### PR TITLE
fix N being overwritten by BigInt.Div functionality

### DIFF
--- a/dagger.go
+++ b/dagger.go
@@ -115,7 +115,7 @@ func Sum(sha hash.Hash) []byte {
 
 func (dag *Dagger) Eval(N *big.Int) *big.Int {
   pow := BigPow(2, 26)
-  dag.xn = N.Div(N, pow)
+  dag.xn = pow.Div(N, pow)
 
   sha := sha3.NewKeccak224()
   sha.Reset()


### PR DESCRIPTION
Div modifies the object that calls it as well as returns the result. N was being overwritten with the div result and eventually (quickly) went to zero.

I'm not super savvy to go, so there may be a more canonical way to do this, like e.g. calling dag.xn.Div, which didn't work for me. In this case, though, pow is not used again in the function and seemed safe to overwrite.
