### PR TITLE
assetPath configurable on command line for ethereal GUI

### DIFF
--- a/ethereal/config.go
+++ b/ethereal/config.go
@@ -16,6 +16,7 @@ var UseSeed bool
 var ImportKey string
 var ExportKey bool
 var DataDir string
+var AssetPath string
 
 func Init() {
 	flag.BoolVar(&StartConsole, "c", false, "debug and testing console")
@@ -29,6 +30,7 @@ func Init() {
 	flag.StringVar(&DataDir, "dir", ".ethereal", "ethereum data directory")
 	flag.StringVar(&ImportKey, "import", "", "imports the given private key (hex)")
 	flag.IntVar(&MaxPeer, "x", 5, "maximum desired peers")
+	flag.StringVar(&AssetPath, "asset_path", "", "absolute path to GUI assets directory")
 
 	flag.Parse()
 }

--- a/ethereal/ethereum.go
+++ b/ethereal/ethereum.go
@@ -100,11 +100,11 @@ func main() {
 		os.Exit(0)
 	}
 
-	log.Printf("Starting Ethereum v%s\n", ethutil.Config.Ver)
+	log.Printf("Starting Ethereum GUI v%s\n", ethutil.Config.Ver)
 
 	// Set the max peers
 	ethereum.MaxPeers = MaxPeer
 
 	gui := ethui.New(ethereum)
-	gui.Start()
+	gui.Start(AssetPath)
 }

--- a/ethereal/ui/ui_lib.go
+++ b/ethereal/ui/ui_lib.go
@@ -16,6 +16,14 @@ type UiLib struct {
 	engine    *qml.Engine
 	eth       *eth.Ethereum
 	connected bool
+	assetPath string
+}
+
+func NewUiLib(engine *qml.Engine, eth *eth.Ethereum, assetPath string) *UiLib {
+	if assetPath == "" {
+		assetPath = DefaultAssetPath()
+	}
+	return &UiLib{engine: engine, eth: eth, assetPath: assetPath}
 }
 
 // Opens a QML file (external application)
@@ -45,10 +53,10 @@ func (ui *UiLib) ConnectToPeer(addr string) {
 }
 
 func (ui *UiLib) AssetPath(p string) string {
-	return AssetPath(p)
+	return path.Join(ui.assetPath, p)
 }
 
-func AssetPath(p string) string {
+func DefaultAssetPath() string {
 	var base string
 
 	// If the current working directory is the go-ethereum dir
@@ -72,5 +80,5 @@ func AssetPath(p string) string {
 		}
 	}
 
-	return path.Join(base, p)
+	return base
 }


### PR DESCRIPTION
- solves the problem of non-standard installs
- add AssetPath to config as string var
- introduced UiLib constructor which falls back to defaultAssetPath (earlier behaviour) if no assetPath is set
- defaultAssetPath now internal concern of UiLib
- gui.Start(assetPath) argument passed from ethereal main() as set Init() in config.go
- informative log message if wallet.qml fails to open
