### PR TITLE
fix panic on bad tx sender

### DIFF
--- a/chain/transaction_pool.go
+++ b/chain/transaction_pool.go
@@ -116,7 +116,11 @@ func (pool *TxPool) ValidateTransaction(tx *types.Transaction) error {
 
 	// Get the sender
 	//sender := pool.Ethereum.BlockManager().procState.GetAccount(tx.Sender())
-	sender := pool.Ethereum.BlockManager().CurrentState().GetAccount(tx.Sender())
+	senderAddr := tx.Sender()
+	if senderAddr == nil {
+		return fmt.Errorf("Invalid sender")
+	}
+	sender := pool.Ethereum.BlockManager().CurrentState().GetAccount(senderAddr)
 
 	totAmount := new(big.Int).Set(tx.Value)
 	// Make sure there's enough in the sender's account. Having insufficient

--- a/chain/types/transaction.go
+++ b/chain/types/transaction.go
@@ -116,7 +116,7 @@ func (tx *Transaction) Sender() []byte {
 
 	// Validate the returned key.
 	// Return nil if public key isn't in full format
-	if len(pubkey) != 0 && pubkey[0] != 4 {
+	if len(pubkey) == 0 || pubkey[0] != 4 {
 		return nil
 	}
 


### PR DESCRIPTION
Transaction pool would panic on processing a tx with a bad sig.

I can push an example branch with a script showing the panic but it required exporting a `BadSig` function from `chain/types/transaction.go` for convenience (of course, an attacker could just hand craft the rlp tx bytes himself to trigger this). I suppose I should add a `transaction_pool_test.go` with a bunch of handcrafted malicious txs. Here's the fix in the meantime. Have I missed something, or was there no signature check up to now?

Note the panic was on the `GetAccount`, which ultimately triggered https://github.com/ethereum/go-ethereum/blob/develop/trie/trie.go#L299
