### PR TITLE
Blockpool not conforming with the spec

### DIFF
--- a/core/chain_manager.go
+++ b/core/chain_manager.go
@@ -238,13 +238,11 @@ func (self *ChainManager) GetBlockHashesFromHash(hash []byte, max uint64) (chain
 
 	// XXX Could be optimised by using a different database which only holds hashes (i.e., linked list)
 	for i := uint64(0); i < max; i++ {
+		block = self.GetBlock(block.Header().ParentHash)
 		chain = append(chain, block.Hash())
-
 		if block.Header().Number.Cmp(ethutil.Big0) <= 0 {
 			break
 		}
-
-		block = self.GetBlock(block.Header().ParentHash)
 	}
 
 	return

--- a/eth/error.go
+++ b/eth/error.go
@@ -16,6 +16,7 @@ const (
 	ErrInvalidBlock
 	ErrInvalidPoW
 	ErrUnrequestedBlock
+	ErrInsufficientChainInfo
 )
 
 var errorToString = map[int]string{
@@ -30,6 +31,7 @@ var errorToString = map[int]string{
 	ErrInvalidBlock:            "Invalid block",
 	ErrInvalidPoW:              "Invalid PoW",
 	ErrUnrequestedBlock:        "Unrequested block",
+	ErrInsufficientChainInfo:   "Insufficient chain info",
 }
 
 type protocolError struct {

--- a/eth/protocol.go
+++ b/eth/protocol.go
@@ -211,16 +211,6 @@ func (self *ethProtocol) handle() error {
 		// uses AddPeer followed by AddHashes, AddBlock only if peer is the best peer
 		// (or selected as new best peer)
 		if self.blockPool.AddPeer(request.TD, hash, self.id, self.requestBlockHashes, self.requestBlocks, self.protoErrorDisconnect) {
-			called := true
-			iter := func() ([]byte, bool) {
-				if called {
-					called = false
-					return hash, true
-				} else {
-					return nil, false
-				}
-			}
-			self.blockPool.AddBlockHashes(iter, self.id)
 			self.blockPool.AddBlock(request.Block, self.id)
 		}
 

--- a/eth/test/tests/02.sh
+++ b/eth/test/tests/02.sh
@@ -12,8 +12,8 @@ EOF
 
 peer 11 01
 peer 12 02
-P13ID=$PID
+P12ID=$PID
 test_node $NAME "" -loglevel 5 $JSFILE
-sleep 0.5
-kill $P13ID
+sleep 0.3
+kill $P12ID
 

--- a/eth/test/tests/03.sh
+++ b/eth/test/tests/03.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
 
-TIMEOUT=35
+TIMEOUT=12
 
 cat >> $JSFILE <<EOF
 eth.addPeer("localhost:30311");
-sleep(30000);
+sleep(10000);
 eth.export("$CHAIN_TEST");
 EOF
 

--- a/eth/test/tests/common.sh
+++ b/eth/test/tests/common.sh
@@ -3,14 +3,14 @@
 # launched by run.sh
 function test_node {
   rm -rf $DIR/$1
-  ARGS="-datadir $DIR/$1 -debug debug -seed=false -shh=false -id test$1"
+  ARGS="-datadir $DIR/$1 -debug debug -seed=false -shh=false -id test$1 -port 303$1"
   if [ "" != "$2" ]; then
     chain="chains/$2.chain"
     echo "import chain $chain"
     $ETH $ARGS -loglevel 3 -chain $chain | grep CLI |grep import
   fi
-  echo "starting test node $1 with extra args ${@:3}"
-  $ETH $ARGS -port 303$1 ${@:3} &
+  echo "starting test node $1 with args $ARGS ${@:3}"
+  $ETH $ARGS  ${@:3} &
   PID=$!
   PIDS="$PIDS $PID"
 }


### PR DESCRIPTION
According to the spec the response to getBlockHashes(hash, amount) is max amount hashes starting from the PARENT of hash. I assumed that it was starting from hash, which allows very easy linking of chain sections. 
Fixing this requires a much more complicated logic, hackier code (100 (10%) lines more), slower operation. 
