### PR TITLE
check tx sender is valid

### DIFF
--- a/core/transaction_pool.go
+++ b/core/transaction_pool.go
@@ -65,6 +65,11 @@ func (pool *TxPool) ValidateTransaction(tx *types.Transaction) error {
 		return fmt.Errorf("tx.v != (28 || 27) => %v", v)
 	}
 
+	senderAddr := tx.From()
+	if senderAddr == nil || len(senderAddr) != 20 {
+		return fmt.Errorf("invalid sender")
+	}
+
 	/* XXX this kind of validation needs to happen elsewhere in the gui when sending txs.
 	   Other clients should do their own validation. Value transfer could throw error
 	   but doesn't necessarily invalidate the tx. Gas can still be payed for and miner


### PR DESCRIPTION
This PR fixes a bug submitted to the bounty.

Without the patch, I can crash the go clients with invalid tx rlp.

Submission text:

Malformed tx rlp crashes the client because ValidateTransaction wasn't checking for valid 'From' result. The check was commented out and incomplete (only checked for nil, not length; ie length could be 0)

To replicate:

```
go get github.com/ebuchman/go-ethereum
cd $GOPATH/src/github.com/ebuchman/go-ethereum
git checkout tamper
cd cmd/ethereum
go get -d
go install
```

Now run a node with `ethereum  --datadir ~/.eth2 --mine`

And an attacker with `ethereum --datadir ~/.eth1 --tamper --port 30403`

The honest node should crash. Sometimes the attacker crashes first, so just try again a few times.

The fix is here: https://github.com/ebuchman/go-ethereum/commit/b765e2d19c9154dcaa38e6043f96f709a7e75796

and coming as a PR

:D