### PR TITLE
RPC cleanup

### DIFF
--- a/cmd/ethereum/flags.go
+++ b/cmd/ethereum/flags.go
@@ -96,7 +96,7 @@ func Init() {
 	flag.StringVar(&NatType, "nat", "", "NAT support (UPNP|PMP) (none)")
 	flag.StringVar(&PMPGateway, "pmp", "", "Gateway IP for PMP")
 	flag.IntVar(&MaxPeer, "maxpeer", 30, "maximum desired peers")
-	flag.IntVar(&RpcPort, "rpcport", 8080, "port to start json-rpc server on")
+	flag.IntVar(&RpcPort, "rpcport", 8545, "port to start json-rpc server on")
 	flag.IntVar(&WsPort, "wsport", 40404, "port to start websocket rpc server on")
 	flag.BoolVar(&StartRpc, "rpc", false, "start rpc server")
 	flag.BoolVar(&StartWebSockets, "ws", false, "start websocket server")

--- a/cmd/mist/flags.go
+++ b/cmd/mist/flags.go
@@ -111,7 +111,7 @@ func Init() {
 	flag.StringVar(&OutboundPort, "port", "30303", "listening port")
 	flag.BoolVar(&UseUPnP, "upnp", true, "enable UPnP support")
 	flag.IntVar(&MaxPeer, "maxpeer", 30, "maximum desired peers")
-	flag.IntVar(&RpcPort, "rpcport", 8080, "port to start json-rpc server on")
+	flag.IntVar(&RpcPort, "rpcport", 8545, "port to start json-rpc server on")
 	flag.IntVar(&WsPort, "wsport", 40404, "port to start websocket rpc server on")
 	flag.BoolVar(&StartRpc, "rpc", true, "start rpc server")
 	flag.BoolVar(&StartWebSockets, "ws", false, "start websocket server")


### PR DESCRIPTION
This is primality fixes to the recent RPC merge including:

* Update "Sending payload" message from Info to DebugDetail
* Adjust signature of WebSocket service to use XEth instead of Ethereum object (same at HTTP)