### PR TITLE
cademlia changed to use hash of public key as address/nodeID

### DIFF
--- a/eth/protocol.go
+++ b/eth/protocol.go
@@ -92,7 +92,7 @@ func EthProtocol(txPool txPool, chainManager chainManager, blockPool blockPool) 
 // the main loop that handles incoming messages
 // note RemovePeer in the post-disconnect hook
 func runEthProtocol(txPool txPool, chainManager chainManager, blockPool blockPool, peer *p2p.Peer, rw p2p.MsgReadWriter) (err error) {
-	id := peer.ID()
+	id := peer.PublicKey()
 	self := &ethProtocol{
 		txPool:       txPool,
 		chainManager: chainManager,

--- a/p2p/crypto.go
+++ b/p2p/crypto.go
@@ -1,7 +1,6 @@
 package p2p
 
 import (
-	// "binary"
 	"crypto/ecdsa"
 	"crypto/rand"
 	"fmt"
@@ -37,26 +36,26 @@ func (self hexkey) String() string {
 }
 
 func encHandshake(conn io.ReadWriter, prv *ecdsa.PrivateKey, dial *discover.Node) (
-	remoteID discover.NodeID,
+	remotePublicKey discover.PublicKey,
 	sessionToken []byte,
 	err error,
 ) {
 	if dial == nil {
 		var remotePubkey []byte
 		sessionToken, remotePubkey, err = inboundEncHandshake(conn, prv, nil)
-		copy(remoteID[:], remotePubkey)
+		copy(remotePublicKey[:], remotePubkey)
 	} else {
-		remoteID = dial.ID
-		sessionToken, err = outboundEncHandshake(conn, prv, remoteID[:], nil)
+		remotePublicKey = dial.PublicKey
+		sessionToken, err = outboundEncHandshake(conn, prv, remotePublicKey[:], nil)
 	}
-	return remoteID, sessionToken, err
+	return remotePublicKey, sessionToken, err
 }
 
 // outboundEncHandshake negotiates a session token on conn.
 // it should be called on the dialing side of the connection.
 //
 // privateKey is the local client's private key
-// remotePublicKey is the remote peer's node ID
+// remotePublicKey is the remote peer's node PublicKey
 // sessionToken is the token from a previous session with this node.
 func outboundEncHandshake(conn io.ReadWriter, prvKey *ecdsa.PrivateKey, remotePublicKey []byte, sessionToken []byte) (
 	newSessionToken []byte,

--- a/xeth/types.go
+++ b/xeth/types.go
@@ -214,7 +214,7 @@ func NewPeer(peer *p2p.Peer) *Peer {
 	return &Peer{
 		ref:     peer,
 		Ip:      fmt.Sprintf("%v", peer.RemoteAddr()),
-		Version: fmt.Sprintf("%v", peer.ID()),
+		Version: fmt.Sprintf("%v", peer.PublicKey()),
 		Caps:    fmt.Sprintf("%v", caps),
 	}
 }


### PR DESCRIPTION
- rename NodeID, ID -> PublicKey
- add NodeID as 256 bit hash field to structs
- use NodeID in cademlia calculations and lookup target
- use PublicKey elsewhere
- add exportedd accessors for own and remote PublicKey and NodeID