### PR TITLE
p2p/discover: fix pending replies iteration

### DIFF
--- a/p2p/discover/udp.go
+++ b/p2p/discover/udp.go
@@ -253,7 +253,8 @@ func (t *udp) loop() {
 
 		case reply := <-t.replies:
 			// run matching callbacks, remove if they return false.
-			for i, p := range pending {
+			for i := 0; i < len(pending); i++ {
+				p := pending[i]
 				if reply.from == p.from && reply.ptype == p.ptype && p.callback(reply.data) {
 					p.errc <- nil
 					copy(pending[i:], pending[i+1:])


### PR DESCRIPTION
This should fix #314.

Range expressions capture the length of the slice once before the first
iteration. A range expression cannot be used here since the loop
modifies the slice variable (including length changes).