### PR TITLE
Implement OS sensitive dataDirs

### DIFF
--- a/accounts/accounts_test.go
+++ b/accounts/accounts_test.go
@@ -5,10 +5,11 @@ import (
 
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/crypto/randentropy"
+	"github.com/ethereum/go-ethereum/ethutil"
 )
 
 func TestAccountManager(t *testing.T) {
-	ks := crypto.NewKeyStorePlain(crypto.DefaultDataDir())
+	ks := crypto.NewKeyStorePlain(ethutil.DefaultDataDir())
 	am := NewAccountManager(ks)
 	pass := "" // not used but required by API
 	a1, err := am.NewAccount(pass)

--- a/cmd/ethereum/flags.go
+++ b/cmd/ethereum/flags.go
@@ -26,10 +26,10 @@ import (
 	"fmt"
 	"log"
 	"os"
-	"os/user"
 	"path"
 
 	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/ethutil"
 	"github.com/ethereum/go-ethereum/logger"
 	"github.com/ethereum/go-ethereum/p2p/nat"
 	"github.com/ethereum/go-ethereum/vm"
@@ -79,12 +79,7 @@ var (
 	InputFile      string
 )
 
-func defaultDataDir() string {
-	usr, _ := user.Current()
-	return path.Join(usr.HomeDir, ".ethereum")
-}
-
-var defaultConfigFile = path.Join(defaultDataDir(), "conf.ini")
+var defaultConfigFile = path.Join(ethutil.DefaultDataDir(), "conf.ini")
 
 func Init() {
 	// TODO: move common flag processing to cmd/util
@@ -107,7 +102,7 @@ func Init() {
 	flag.StringVar(&SecretFile, "import", "", "imports the file given (hex or mnemonic formats)")
 	flag.StringVar(&ExportDir, "export", "", "exports the session keyring to files in the directory given")
 	flag.StringVar(&LogFile, "logfile", "", "log file (defaults to standard output)")
-	flag.StringVar(&Datadir, "datadir", defaultDataDir(), "specifies the datadir to use")
+	flag.StringVar(&Datadir, "datadir", ethutil.DefaultDataDir(), "specifies the datadir to use")
 	flag.StringVar(&ConfigFile, "conf", defaultConfigFile, "config file")
 	flag.StringVar(&DebugFile, "debug", "", "debug file (no debugging if not set)")
 	flag.IntVar(&LogLevel, "loglevel", int(logger.InfoLevel), "loglevel: 0-5: silent,error,warn,info,debug,debug detail)")

--- a/cmd/mist/flags.go
+++ b/cmd/mist/flags.go
@@ -26,13 +26,13 @@ import (
 	"fmt"
 	"log"
 	"os"
-	"os/user"
 	"path"
 	"path/filepath"
 	"runtime"
 
 	"bitbucket.org/kardianos/osext"
 	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/ethutil"
 	"github.com/ethereum/go-ethereum/logger"
 	"github.com/ethereum/go-ethereum/p2p/nat"
 	"github.com/ethereum/go-ethereum/vm"
@@ -94,12 +94,8 @@ func defaultAssetPath() string {
 	}
 	return assetPath
 }
-func defaultDataDir() string {
-	usr, _ := user.Current()
-	return path.Join(usr.HomeDir, ".ethereum")
-}
 
-var defaultConfigFile = path.Join(defaultDataDir(), "conf.ini")
+var defaultConfigFile = path.Join(ethutil.DefaultDataDir(), "conf.ini")
 
 func Init() {
 	// TODO: move common flag processing to cmd/utils
@@ -121,7 +117,7 @@ func Init() {
 	flag.StringVar(&SecretFile, "import", "", "imports the file given (hex or mnemonic formats)")
 	flag.StringVar(&ExportDir, "export", "", "exports the session keyring to files in the directory given")
 	flag.StringVar(&LogFile, "logfile", "", "log file (defaults to standard output)")
-	flag.StringVar(&Datadir, "datadir", defaultDataDir(), "specifies the datadir to use")
+	flag.StringVar(&Datadir, "datadir", ethutil.DefaultDataDir(), "specifies the datadir to use")
 	flag.StringVar(&ConfigFile, "conf", defaultConfigFile, "config file")
 	flag.StringVar(&DebugFile, "debug", "", "debug file (no debugging if not set)")
 	flag.IntVar(&LogLevel, "loglevel", int(logger.InfoLevel), "loglevel: 0-5: silent,error,warn,info,debug,debug detail)")

--- a/crypto/key_store_plain.go
+++ b/crypto/key_store_plain.go
@@ -30,7 +30,6 @@ import (
 	"io"
 	"io/ioutil"
 	"os"
-	"os/user"
 	"path"
 )
 
@@ -46,12 +45,6 @@ type KeyStore2 interface {
 
 type keyStorePlain struct {
 	keysDirPath string
-}
-
-// TODO: copied from cmd/ethereum/flags.go
-func DefaultDataDir() string {
-	usr, _ := user.Current()
-	return path.Join(usr.HomeDir, ".ethereum")
 }
 
 func NewKeyStorePlain(path string) KeyStore2 {

--- a/crypto/key_store_test.go
+++ b/crypto/key_store_test.go
@@ -2,12 +2,13 @@ package crypto
 
 import (
 	"github.com/ethereum/go-ethereum/crypto/randentropy"
+	"github.com/ethereum/go-ethereum/ethutil"
 	"reflect"
 	"testing"
 )
 
 func TestKeyStorePlain(t *testing.T) {
-	ks := NewKeyStorePlain(DefaultDataDir())
+	ks := NewKeyStorePlain(ethutil.DefaultDataDir())
 	pass := "" // not used but required by API
 	k1, err := ks.GenerateNewKey(randentropy.Reader, pass)
 	if err != nil {
@@ -35,7 +36,7 @@ func TestKeyStorePlain(t *testing.T) {
 }
 
 func TestKeyStorePassphrase(t *testing.T) {
-	ks := NewKeyStorePassphrase(DefaultDataDir())
+	ks := NewKeyStorePassphrase(ethutil.DefaultDataDir())
 	pass := "foo"
 	k1, err := ks.GenerateNewKey(randentropy.Reader, pass)
 	if err != nil {
@@ -61,7 +62,7 @@ func TestKeyStorePassphrase(t *testing.T) {
 }
 
 func TestKeyStorePassphraseDecryptionFail(t *testing.T) {
-	ks := NewKeyStorePassphrase(DefaultDataDir())
+	ks := NewKeyStorePassphrase(ethutil.DefaultDataDir())
 	pass := "foo"
 	k1, err := ks.GenerateNewKey(randentropy.Reader, pass)
 	if err != nil {
@@ -89,7 +90,7 @@ func TestImportPreSaleKey(t *testing.T) {
 	// python pyethsaletool.py genwallet
 	// with password "foo"
 	fileContent := "{\"encseed\": \"26d87f5f2bf9835f9a47eefae571bc09f9107bb13d54ff12a4ec095d01f83897494cf34f7bed2ed34126ecba9db7b62de56c9d7cd136520a0427bfb11b8954ba7ac39b90d4650d3448e31185affcd74226a68f1e94b1108e6e0a4a91cdd83eba\", \"ethaddr\": \"d4584b5f6229b7be90727b0fc8c6b91bb427821f\", \"email\": \"gustav.simonsson@gmail.com\", \"btcaddr\": \"1EVknXyFC68kKNLkh6YnKzW41svSRoaAcx\"}"
-	ks := NewKeyStorePassphrase(DefaultDataDir())
+	ks := NewKeyStorePassphrase(ethutil.DefaultDataDir())
 	pass := "foo"
 	_, err := ImportPreSaleKey(ks, []byte(fileContent), pass)
 	if err != nil {

--- a/ethutil/common.go
+++ b/ethutil/common.go
@@ -3,10 +3,22 @@ package ethutil
 import (
 	"fmt"
 	"math/big"
+	"os/user"
+	"path"
 	"runtime"
 	"time"
 )
 
+func DefaultDataDir() string {
+	usr, _ := user.Current()
+	if runtime.GOOS == "darwin" {
+		return path.Join(usr.HomeDir, "Library/Ethereum")
+	} else if runtime.GOOS == "windows" {
+		return path.Join(usr.HomeDir, "AppData/Roaming/Ethereum")
+	} else {
+		return path.Join(usr.HomeDir, ".ethereum")
+	}
+}
 func IsWindows() bool {
 	return runtime.GOOS == "windows"
 }


### PR DESCRIPTION
Refactors defaultDataDir to be OS sensitive and DRY. 

It will use the following paths.
- "Library directory" (`~/Library/Ethereum`) as defined in the [OS X Documentation](https://developer.apple.com/library/mac/documentation/General/Conceptual/MOSXAppProgrammingGuide/AppRuntime/AppRuntime.html) on OS X 
- The roaming [App Data](http://windows.microsoft.com/en-us/windows-8/what-appdata-folder) (`~/AppData/Roaming/Ethereum`) folder on Windows. 
- Unix path will be unchanged and still be `~/.ethereum`

I have not bothered with migration to keep the code simple. Potentially we might want to add a migration script that actually moves the old path to the new but since we are still pre-release I doubt it matters much.
