### PR TITLE
Fix AccountManager test not cleaning up test accounts

### DIFF
--- a/accounts/account_manager.go
+++ b/accounts/account_manager.go
@@ -76,6 +76,10 @@ func (am AccountManager) NewAccount(auth string) (*Account, error) {
 	return ua, err
 }
 
+func (am AccountManager) DeleteAccount(address []byte, auth string) error {
+	return am.keyStore.DeleteKey(address, auth)
+}
+
 // set of accounts == set of keys in given key store
 // TODO: do we need persistence of accounts as well?
 func (am *AccountManager) Accounts() ([]Account, error) {

--- a/accounts/accounts_test.go
+++ b/accounts/accounts_test.go
@@ -8,13 +8,31 @@ import (
 )
 
 func TestAccountManager(t *testing.T) {
-	ks := crypto.NewKeyStorePlain(crypto.DefaultDataDir())
+
+	// Get AccountManager
+	ks := crypto.NewKeyStorePlain(crypto.DefaultDataDir() + "/testaccounts")
 	am := NewAccountManager(ks)
+
+	// Create a new account
 	pass := "" // not used but required by API
 	a1, err := am.NewAccount(pass)
+
+	// Sign junk
 	toSign := randentropy.GetEntropyCSPRNG(32)
 	_, err = am.Sign(a1, pass, toSign)
 	if err != nil {
 		t.Fatal(err)
+	}
+
+	// Cleanup
+	accounts, err := am.Accounts()
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, account := range accounts {
+		err := am.DeleteAccount(account.Address, pass)
+		if err != nil {
+			t.Fatal(err)
+		}
 	}
 }

--- a/crypto/key_store_plain.go
+++ b/crypto/key_store_plain.go
@@ -126,8 +126,11 @@ func GetKeyAddresses(keysDirPath string) (addresses [][]byte, err error) {
 	}
 	addresses = make([][]byte, len(fileInfos))
 	for i, fileInfo := range fileInfos {
-		addresses[i] = make([]byte, 40)
-		addresses[i] = []byte(fileInfo.Name())
+		address, err := hex.DecodeString(fileInfo.Name())
+		if err != nil {
+			continue
+		}
+		addresses[i] = address
 	}
 	return addresses, err
 }


### PR DESCRIPTION
there was definitely a bug where the AccountManager wasn't reading accounts correctly because it wasn't decoding the hex address.
