### PR TITLE
cmd/ethereum: add a flag to switch to unencrytped keystore

### DIFF
--- a/cmd/ethereum/main.go
+++ b/cmd/ethereum/main.go
@@ -127,6 +127,7 @@ runtime will execute the file and exit.
 		utils.RPCEnabledFlag,
 		utils.RPCListenAddrFlag,
 		utils.RPCPortFlag,
+		utils.UnencryptedKeysFlag,
 		utils.VMDebugFlag,
 		//utils.VMTypeFlag,
 	}
@@ -213,20 +214,24 @@ func accountList(ctx *cli.Context) {
 
 func accountCreate(ctx *cli.Context) {
 	am := utils.GetAccountManager(ctx)
-	fmt.Println("The new account will be encrypted with a passphrase.")
-	fmt.Println("Please enter a passphrase now.")
-	auth, err := readPassword("Passphrase: ", true)
-	if err != nil {
-		utils.Fatalf("%v", err)
+	passphrase := ""
+	if !ctx.GlobalBool(utils.UnencryptedKeysFlag.Name) {
+		fmt.Println("The new account will be encrypted with a passphrase.")
+		fmt.Println("Please enter a passphrase now.")
+		auth, err := readPassword("Passphrase: ", true)
+		if err != nil {
+			utils.Fatalf("%v", err)
+		}
+		confirm, err := readPassword("Repeat Passphrase: ", false)
+		if err != nil {
+			utils.Fatalf("%v", err)
+		}
+		if auth != confirm {
+			utils.Fatalf("Passphrases did not match.")
+		}
+		passphrase = auth
 	}
-	confirm, err := readPassword("Repeat Passphrase: ", false)
-	if err != nil {
-		utils.Fatalf("%v", err)
-	}
-	if auth != confirm {
-		utils.Fatalf("Passphrases did not match.")
-	}
-	acct, err := am.NewAccount(auth)
+	acct, err := am.NewAccount(passphrase)
 	if err != nil {
 		utils.Fatalf("Could not create the account: %v", err)
 	}

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -95,6 +95,10 @@ var (
 		Name:  "mine",
 		Usage: "Enable mining",
 	}
+	UnencryptedKeysFlag = cli.BoolFlag{
+		Name:  "unencrypted-keys",
+		Usage: "disable private key disk encryption (for testing)",
+	}
 
 	LogFileFlag = cli.StringFlag{
 		Name:  "logfile",
@@ -220,7 +224,12 @@ func GetChain(ctx *cli.Context) (*core.ChainManager, ethutil.Database, ethutil.D
 
 func GetAccountManager(ctx *cli.Context) *accounts.Manager {
 	dataDir := ctx.GlobalString(DataDirFlag.Name)
-	ks := crypto.NewKeyStorePassphrase(path.Join(dataDir, "keys"))
+	var ks crypto.KeyStore2
+	if ctx.GlobalBool(UnencryptedKeysFlag.Name) {
+		ks = crypto.NewKeyStorePlain(path.Join(dataDir, "plainkeys"))
+	} else {
+		ks = crypto.NewKeyStorePassphrase(path.Join(dataDir, "keys"))
+	}
 	return accounts.NewManager(ks)
 }
 


### PR DESCRIPTION
This is mostly for automated tests. The tests can use the following
commands to start the node:

    ethereum --unencrypted-keys account new
    ...
    ethereum --unencrypted-keys