### PR TITLE
Move MakeName to ethutil

### DIFF
--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -18,7 +18,6 @@ import (
 	"github.com/ethereum/go-ethereum/ethutil"
 	"github.com/ethereum/go-ethereum/event"
 	"github.com/ethereum/go-ethereum/logger"
-	"github.com/ethereum/go-ethereum/p2p"
 	"github.com/ethereum/go-ethereum/p2p/nat"
 	"github.com/ethereum/go-ethereum/rpc"
 	"github.com/ethereum/go-ethereum/xeth"
@@ -194,7 +193,7 @@ func GetNodeKey(ctx *cli.Context) (key *ecdsa.PrivateKey) {
 
 func GetEthereum(clientID, version string, ctx *cli.Context) (*eth.Ethereum, error) {
 	return eth.New(&eth.Config{
-		Name:           p2p.MakeName(clientID, version),
+		Name:           ethutil.MakeName(clientID, version),
 		DataDir:        ctx.GlobalString(DataDirFlag.Name),
 		LogFile:        ctx.GlobalString(LogFileFlag.Name),
 		LogLevel:       ctx.GlobalInt(LogLevelFlag.Name),

--- a/ethutil/common.go
+++ b/ethutil/common.go
@@ -13,6 +13,13 @@ import (
 	"github.com/kardianos/osext"
 )
 
+// MakeName creates a node name that follows the ethereum convention
+// for such names. It adds the operation system name and Go runtime version
+// the name.
+func MakeName(name, version string) string {
+	return fmt.Sprintf("%s/v%s/%s/%s", name, version, runtime.GOOS, runtime.Version())
+}
+
 func DefaultAssetPath() string {
 	var assetPath string
 	pwd, _ := os.Getwd()

--- a/p2p/server.go
+++ b/p2p/server.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"fmt"
 	"net"
-	"runtime"
 	"sync"
 	"time"
 
@@ -33,13 +32,6 @@ const (
 var srvlog = logger.NewLogger("P2P Server")
 var srvjslog = logger.NewJsonLogger()
 
-// MakeName creates a node name that follows the ethereum convention
-// for such names. It adds the operation system name and Go runtime version
-// the name.
-func MakeName(name, version string) string {
-	return fmt.Sprintf("%s/v%s/%s/%s", name, version, runtime.GOOS, runtime.Version())
-}
-
 // Server manages all peer connections.
 //
 // The fields of Server are used as configuration parameters.
@@ -54,7 +46,7 @@ type Server struct {
 	MaxPeers int
 
 	// Name sets the node name of this server.
-	// Use MakeName to create a name that follows existing conventions.
+	// Use ethutil.MakeName to create a name that follows existing conventions.
 	Name string
 
 	// Bootstrap nodes are used to establish connectivity


### PR DESCRIPTION
Semantically, belongs with other OS-specific functions and results in cleaner imports.