### PR TITLE
independent flag for json structured logging

### DIFF
--- a/blockpool/test/logger.go
+++ b/blockpool/test/logger.go
@@ -21,8 +21,7 @@ func TestFunc(t *testing.T) {
 */
 func LogInit() {
 	once.Do(func() {
-		var logsys = logger.NewStdLogSystem(os.Stdout, log.LstdFlags, logger.LogLevel(logger.WarnLevel))
-		logger.AddLogSystem(logsys)
+		logger.NewStdLogSystem(os.Stdout, log.LstdFlags, logger.LogLevel(logger.DebugDetailLevel))
 	})
 }
 
@@ -41,11 +40,8 @@ func Testlog(t *testing.T) testLogger {
 	return l
 }
 
-func (testLogger) GetLogLevel() logger.LogLevel { return logger.DebugLevel }
-func (testLogger) SetLogLevel(logger.LogLevel)  {}
-
-func (l testLogger) LogPrint(level logger.LogLevel, msg string) {
-	l.t.Logf("%s", msg)
+func (l testLogger) LogPrint(msg logger.LogMsg) {
+	l.t.Log(msg.String())
 }
 
 func (testLogger) Detach() {
@@ -68,12 +64,10 @@ func Benchlog(b *testing.B) benchLogger {
 	return l
 }
 
-func (benchLogger) GetLogLevel() logger.LogLevel { return logger.Silence }
-
-func (benchLogger) SetLogLevel(logger.LogLevel) {}
-func (l benchLogger) LogPrint(level logger.LogLevel, msg string) {
-	l.b.Logf("%s", msg)
+func (l benchLogger) LogPrint(msg logger.LogMsg) {
+	l.b.Log(msg.String())
 }
+
 func (benchLogger) Detach() {
 	logger.Flush()
 	logger.Reset()

--- a/cmd/ethereum/main.go
+++ b/cmd/ethereum/main.go
@@ -135,7 +135,7 @@ The Ethereum JavaScript VM exposes a node admin interface as well as the DAPP Ja
 		utils.JSpathFlag,
 		utils.ListenPortFlag,
 		utils.LogFileFlag,
-		utils.LogFormatFlag,
+		utils.LogJSONFlag,
 		utils.LogLevelFlag,
 		utils.MaxPeersFlag,
 		utils.MinerThreadsFlag,

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -117,10 +117,10 @@ var (
 		Usage: "0-5 (silent, error, warn, info, debug, debug detail)",
 		Value: int(logger.InfoLevel),
 	}
-	LogFormatFlag = cli.StringFlag{
-		Name:  "logformat",
-		Usage: `"std" or "raw"`,
-		Value: "std",
+	LogJSONFlag = cli.StringFlag{
+		Name:  "logjson",
+		Usage: "Send json structured log output to a file or '-' for standard output (default: no json output)",
+		Value: "",
 	}
 	VMDebugFlag = cli.BoolFlag{
 		Name:  "vmdebug",
@@ -213,7 +213,7 @@ func MakeEthConfig(clientID, version string, ctx *cli.Context) *eth.Config {
 		NetworkId:       ctx.GlobalInt(NetworkIdFlag.Name),
 		LogFile:         ctx.GlobalString(LogFileFlag.Name),
 		LogLevel:        ctx.GlobalInt(LogLevelFlag.Name),
-		LogFormat:       ctx.GlobalString(LogFormatFlag.Name),
+		LogJSON:         ctx.GlobalString(LogJSONFlag.Name),
 		MinerThreads:    ctx.GlobalInt(MinerThreadsFlag.Name),
 		AccountManager:  GetAccountManager(ctx),
 		VmDebug:         ctx.GlobalBool(VMDebugFlag.Name),

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -42,11 +42,11 @@ type Config struct {
 	ProtocolVersion int
 	NetworkId       int
 
-	DataDir   string
-	LogFile   string
-	LogLevel  int
-	LogFormat string
-	VmDebug   bool
+	DataDir  string
+	LogFile  string
+	LogLevel int
+	LogJSON  string
+	VmDebug  bool
 
 	MaxPeers int
 	Port     string
@@ -136,7 +136,7 @@ type Ethereum struct {
 	blockSub event.Subscription
 	miner    *miner.Miner
 
-	logger logger.LogSystem
+	// logger logger.LogSystem
 
 	Mining          bool
 	DataDir         string
@@ -147,7 +147,10 @@ type Ethereum struct {
 
 func New(config *Config) (*Ethereum, error) {
 	// Boostrap database
-	servlogsystem := logger.New(config.DataDir, config.LogFile, config.LogLevel, config.LogFormat)
+	logger.New(config.DataDir, config.LogFile, config.LogLevel)
+	if len(config.LogJSON) > 0 {
+		logger.NewJSONsystem(config.DataDir, config.LogJSON)
+	}
 
 	newdb := config.NewDB
 	if newdb == nil {
@@ -174,12 +177,12 @@ func New(config *Config) (*Ethereum, error) {
 	servlogger.Infof("Protocol Version: %v, Network Id: %v", config.ProtocolVersion, config.NetworkId)
 
 	eth := &Ethereum{
-		shutdownChan:   make(chan bool),
-		blockDb:        blockDb,
-		stateDb:        stateDb,
-		extraDb:        extraDb,
-		eventMux:       &event.TypeMux{},
-		logger:         servlogsystem,
+		shutdownChan: make(chan bool),
+		blockDb:      blockDb,
+		stateDb:      stateDb,
+		extraDb:      extraDb,
+		eventMux:     &event.TypeMux{},
+		// logger:         servlogsystem,
 		accountManager: config.AccountManager,
 		DataDir:        config.DataDir,
 		version:        config.Name, // TODO should separate from Name
@@ -303,7 +306,7 @@ func (s *Ethereum) StartMining() error {
 func (s *Ethereum) StopMining()    { s.miner.Stop() }
 func (s *Ethereum) IsMining() bool { return s.miner.Mining() }
 
-func (s *Ethereum) Logger() logger.LogSystem             { return s.logger }
+// func (s *Ethereum) Logger() logger.LogSystem             { return s.logger }
 func (s *Ethereum) Name() string                         { return s.net.Name }
 func (s *Ethereum) AccountManager() *accounts.Manager    { return s.accountManager }
 func (s *Ethereum) ChainManager() *core.ChainManager     { return s.chainManager }

--- a/logger/log.go
+++ b/logger/log.go
@@ -18,7 +18,7 @@ func openLogFile(datadir string, filename string) *os.File {
 	return file
 }
 
-func New(datadir string, logFile string, logLevel int, logFormat string) LogSystem {
+func New(datadir string, logFile string, logLevel int) LogSystem {
 	var writer io.Writer
 	if logFile == "" {
 		writer = os.Stdout
@@ -27,14 +27,22 @@ func New(datadir string, logFile string, logLevel int, logFormat string) LogSyst
 	}
 
 	var sys LogSystem
-	switch logFormat {
-	case "raw":
-		sys = NewRawLogSystem(writer, 0, LogLevel(logLevel))
-	case "json":
-		sys = NewJsonLogSystem(writer, 0, LogLevel(logLevel))
-	default:
-		sys = NewStdLogSystem(writer, log.LstdFlags, LogLevel(logLevel))
+	sys = NewStdLogSystem(writer, log.LstdFlags, LogLevel(logLevel))
+	AddLogSystem(sys)
+
+	return sys
+}
+
+func NewJSONsystem(datadir string, logFile string) LogSystem {
+	var writer io.Writer
+	if logFile == "-" {
+		writer = os.Stdout
+	} else {
+		writer = openLogFile(datadir, logFile)
 	}
+
+	var sys LogSystem
+	sys = NewJsonLogSystem(writer)
 	AddLogSystem(sys)
 
 	return sys

--- a/logger/loggers.go
+++ b/logger/loggers.go
@@ -28,7 +28,6 @@ const (
 	InfoLevel
 	DebugLevel
 	DebugDetailLevel
-	JsonLevel = 1000
 )
 
 // A Logger prints messages prefixed by a given tag. It provides named
@@ -43,11 +42,11 @@ func NewLogger(tag string) *Logger {
 }
 
 func (logger *Logger) Sendln(level LogLevel, v ...interface{}) {
-	logMessageC <- message{level, logger.tag + fmt.Sprintln(v...)}
+	logMessageC <- stdMsg{level, logger.tag + fmt.Sprintln(v...)}
 }
 
 func (logger *Logger) Sendf(level LogLevel, format string, v ...interface{}) {
-	logMessageC <- message{level, logger.tag + fmt.Sprintf(format, v...)}
+	logMessageC <- stdMsg{level, logger.tag + fmt.Sprintf(format, v...)}
 }
 
 // Errorln writes a message with ErrorLevel.
@@ -129,6 +128,6 @@ func (logger *JsonLogger) LogJson(v JsonLog) {
 	}
 
 	jsontxt, _ := json.Marshal(obj)
-	logMessageC <- message{JsonLevel, string(jsontxt)}
+	logMessageC <- (jsonMsg(jsontxt))
 
 }

--- a/logger/loggers_test.go
+++ b/logger/loggers_test.go
@@ -15,9 +15,11 @@ type TestLogSystem struct {
 	level  LogLevel
 }
 
-func (ls *TestLogSystem) LogPrint(level LogLevel, msg string) {
+func (ls *TestLogSystem) LogPrint(msg LogMsg) {
 	ls.mutex.Lock()
-	ls.output += msg
+	if ls.level >= msg.Level() {
+		ls.output += msg.String()
+	}
 	ls.mutex.Unlock()
 }
 
@@ -47,9 +49,9 @@ type blockedLogSystem struct {
 	unblock chan struct{}
 }
 
-func (ls blockedLogSystem) LogPrint(level LogLevel, msg string) {
+func (ls blockedLogSystem) LogPrint(msg LogMsg) {
 	<-ls.unblock
-	ls.LogSystem.LogPrint(level, msg)
+	ls.LogSystem.LogPrint(msg)
 }
 
 func TestLoggerFlush(t *testing.T) {

--- a/logger/logsystem.go
+++ b/logger/logsystem.go
@@ -9,9 +9,7 @@ import (
 // LogSystem is implemented by log output devices.
 // All methods can be called concurrently from multiple goroutines.
 type LogSystem interface {
-	GetLogLevel() LogLevel
-	SetLogLevel(i LogLevel)
-	LogPrint(LogLevel, string)
+	LogPrint(LogMsg)
 }
 
 // NewStdLogSystem creates a LogSystem that prints to the given writer.
@@ -26,8 +24,13 @@ type stdLogSystem struct {
 	level  uint32
 }
 
-func (t *stdLogSystem) LogPrint(level LogLevel, msg string) {
-	t.logger.Print(msg)
+func (t *stdLogSystem) LogPrint(msg LogMsg) {
+	stdmsg, ok := msg.(stdMsg)
+	if ok {
+		if t.GetLogLevel() >= stdmsg.Level() {
+			t.logger.Print(stdmsg.String())
+		}
+	}
 }
 
 func (t *stdLogSystem) SetLogLevel(i LogLevel) {
@@ -38,50 +41,20 @@ func (t *stdLogSystem) GetLogLevel() LogLevel {
 	return LogLevel(atomic.LoadUint32(&t.level))
 }
 
-// NewRawLogSystem creates a LogSystem that prints to the given writer without
-// adding extra information. Suitable for preformatted output
-func NewRawLogSystem(writer io.Writer, flags int, level LogLevel) LogSystem {
+// NewJSONLogSystem creates a LogSystem that prints to the given writer without
+// adding extra information irrespective of loglevel only if message is JSON type
+func NewJsonLogSystem(writer io.Writer) LogSystem {
 	logger := log.New(writer, "", 0)
-	return &rawLogSystem{logger, uint32(level)}
-}
-
-type rawLogSystem struct {
-	logger *log.Logger
-	level  uint32
-}
-
-func (t *rawLogSystem) LogPrint(level LogLevel, msg string) {
-	t.logger.Print(msg)
-}
-
-func (t *rawLogSystem) SetLogLevel(i LogLevel) {
-	atomic.StoreUint32(&t.level, uint32(i))
-}
-
-func (t *rawLogSystem) GetLogLevel() LogLevel {
-	return LogLevel(atomic.LoadUint32(&t.level))
-}
-
-// NewRawLogSystem creates a LogSystem that prints to the given writer without
-// adding extra information. Suitable for preformatted output
-func NewJsonLogSystem(writer io.Writer, flags int, level LogLevel) LogSystem {
-	logger := log.New(writer, "", 0)
-	return &jsonLogSystem{logger, uint32(level)}
+	return &jsonLogSystem{logger}
 }
 
 type jsonLogSystem struct {
 	logger *log.Logger
-	level  uint32
 }
 
-func (t *jsonLogSystem) LogPrint(level LogLevel, msg string) {
-	t.logger.Print(msg)
-}
-
-func (t *jsonLogSystem) SetLogLevel(i LogLevel) {
-	atomic.StoreUint32(&t.level, uint32(i))
-}
-
-func (t *jsonLogSystem) GetLogLevel() LogLevel {
-	return LogLevel(atomic.LoadUint32(&t.level))
+func (t *jsonLogSystem) LogPrint(msg LogMsg) {
+	jsonmsg, ok := msg.(jsonMsg)
+	if ok {
+		t.logger.Print(jsonmsg.String())
+	}
 }


### PR DESCRIPTION
re https://github.com/ethereum/go-ethereum/issues/538
- logjson flag remove logformat flag
- passed to eth Config
- logsystem not a field of Ethereum
- LogSystem does not need to expose GetLogLevel/SetLogLevel
- message struct just implements more generic LogMsg interface
- LogMsg is a fmt.Stringer with Level()
- jsonMsg ([]byte) implements LogMsg
- remove "raw" systems
- move level logic inside StdLogSystem
- logsystems only print their kind of msg: jsonLogSystem prints jsonMsg, StdLogSystem prints stdMsg