### PR TITLE
import/export accounts

### DIFF
--- a/accounts/account_manager.go
+++ b/accounts/account_manager.go
@@ -239,3 +239,15 @@ func (am *Manager) Import(path string, keyAuth string) (Account, error) {
 	}
 	return Account{Address: key.Address}, nil
 }
+
+func (am *Manager) ImportPreSaleKey(keyJSON []byte, password string) (acc Account, err error) {
+	var key *crypto.Key
+	key, err = crypto.ImportPreSaleKey(am.keyStore, keyJSON, password)
+	if err != nil {
+		return
+	}
+	if err = am.keyStore.StoreKey(key, password); err != nil {
+		return
+	}
+	return Account{Address: key.Address}, nil
+}

--- a/accounts/account_manager.go
+++ b/accounts/account_manager.go
@@ -36,9 +36,8 @@ import (
 	"bytes"
 	"crypto/ecdsa"
 	crand "crypto/rand"
-	"os"
-
 	"errors"
+	"os"
 	"sync"
 	"time"
 
@@ -101,17 +100,6 @@ func (am *Manager) firstAddr() ([]byte, error) {
 	return addrs[0], nil
 }
 
-func (am *Manager) getKey(addr []byte, keyAuth string) (*crypto.Key, error) {
-	if len(addr) == 0 {
-		var err error
-		addr, err = am.firstAddr()
-		if err != nil {
-			return nil, err
-		}
-	}
-	return am.keyStore.GetKey(addr, keyAuth)
-}
-
 func (am *Manager) DeleteAccount(address []byte, auth string) error {
 	return am.keyStore.DeleteKey(address, auth)
 }
@@ -130,7 +118,7 @@ func (am *Manager) Sign(a Account, toSign []byte) (signature []byte, err error) 
 // TimedUnlock unlocks the account with the given address.
 // When timeout has passed, the account will be locked again.
 func (am *Manager) TimedUnlock(addr []byte, keyAuth string, timeout time.Duration) error {
-	key, err := am.getKey(addr, keyAuth)
+	key, err := am.keyStore.GetKey(addr, keyAuth)
 	if err != nil {
 		return err
 	}
@@ -143,7 +131,7 @@ func (am *Manager) TimedUnlock(addr []byte, keyAuth string, timeout time.Duratio
 // stays unlocked until the program exits or until a TimedUnlock
 // timeout (started after the call to Unlock) expires.
 func (am *Manager) Unlock(addr []byte, keyAuth string) error {
-	key, err := am.getKey(addr, keyAuth)
+	key, err := am.keyStore.GetKey(addr, keyAuth)
 	if err != nil {
 		return err
 	}

--- a/accounts/account_manager.go
+++ b/accounts/account_manager.go
@@ -101,6 +101,17 @@ func (am *Manager) firstAddr() ([]byte, error) {
 	return addrs[0], nil
 }
 
+func (am *Manager) getKey(addr []byte, keyAuth string) (*crypto.Key, error) {
+	if len(addr) == 0 {
+		var err error
+		addr, err = am.firstAddr()
+		if err != nil {
+			return nil, err
+		}
+	}
+	return am.keyStore.GetKey(addr, keyAuth)
+}
+
 func (am *Manager) DeleteAccount(address []byte, auth string) error {
 	return am.keyStore.DeleteKey(address, auth)
 }
@@ -119,7 +130,7 @@ func (am *Manager) Sign(a Account, toSign []byte) (signature []byte, err error) 
 // TimedUnlock unlocks the account with the given address.
 // When timeout has passed, the account will be locked again.
 func (am *Manager) TimedUnlock(addr []byte, keyAuth string, timeout time.Duration) error {
-	key, err := am.keyStore.GetKey(addr, keyAuth)
+	key, err := am.getKey(addr, keyAuth)
 	if err != nil {
 		return err
 	}
@@ -132,7 +143,7 @@ func (am *Manager) TimedUnlock(addr []byte, keyAuth string, timeout time.Duratio
 // stays unlocked until the program exits or until a TimedUnlock
 // timeout (started after the call to Unlock) expires.
 func (am *Manager) Unlock(addr []byte, keyAuth string) error {
-	key, err := am.keyStore.GetKey(addr, keyAuth)
+	key, err := am.getKey(addr, keyAuth)
 	if err != nil {
 		return err
 	}

--- a/accounts/account_manager.go
+++ b/accounts/account_manager.go
@@ -208,6 +208,8 @@ func zeroKey(k *ecdsa.PrivateKey) {
 	}
 }
 
+// USE WITH CAUTION = this will save an unencrypted private key on disk
+// no cli or js interface
 func (am *Manager) Export(path string, addr []byte, keyAuth string) error {
 	key, err := am.keyStore.GetKey(addr, keyAuth)
 	if err != nil {

--- a/accounts/account_manager.go
+++ b/accounts/account_manager.go
@@ -208,3 +208,23 @@ func zeroKey(k *ecdsa.PrivateKey) {
 		b[i] = 0
 	}
 }
+
+func (am *Manager) Export(path string, addr []byte, keyAuth string) error {
+	key, err := am.keyStore.GetKey(addr, keyAuth)
+	if err != nil {
+		return err
+	}
+	return crypto.SaveECDSA(path, key.PrivateKey)
+}
+
+func (am *Manager) Import(path string, keyAuth string) (Account, error) {
+	privateKeyECDSA, err := crypto.LoadECDSA(path)
+	if err != nil {
+		return Account{}, err
+	}
+	key := crypto.NewKeyFromECDSA(privateKeyECDSA)
+	if err = am.keyStore.StoreKey(key, keyAuth); err != nil {
+		return Account{}, err
+	}
+	return Account{Address: key.Address}, nil
+}

--- a/blockpool/status_test.go
+++ b/blockpool/status_test.go
@@ -1,7 +1,7 @@
 package blockpool
 
 import (
-	// "fmt"
+	"fmt"
 	"testing"
 	"time"
 
@@ -45,17 +45,15 @@ func getStatusValues(s *Status) []int {
 func checkStatus(t *testing.T, bp *BlockPool, syncing bool, expected []int) (err error) {
 	s := bp.Status()
 	if s.Syncing != syncing {
-		t.Errorf("status for Syncing incorrect. expected %v, got %v", syncing, s.Syncing)
+		err = fmt.Errorf("status for Syncing incorrect. expected %v, got %v", syncing, s.Syncing)
+		return
 	}
 	got := getStatusValues(s)
 	for i, v := range expected {
-		if i == 0 || i == 7 {
-			continue //hack
-		}
 		err = test.CheckInt(statusFields[i], got[i], v, t)
 		// fmt.Printf("%v: %v (%v)\n", statusFields[i], got[i], v)
 		if err != nil {
-			return err
+			return
 		}
 	}
 	return
@@ -63,6 +61,25 @@ func checkStatus(t *testing.T, bp *BlockPool, syncing bool, expected []int) (err
 
 func TestBlockPoolStatus(t *testing.T) {
 	test.LogInit()
+	var err error
+	n := 3
+	for n > 0 {
+		n--
+		err = testBlockPoolStatus(t)
+		if err != nil {
+			t.Log(err)
+			continue
+		} else {
+			return
+		}
+	}
+	if err != nil {
+		t.Errorf("no pass out of 3: %v", err)
+	}
+}
+
+func testBlockPoolStatus(t *testing.T) (err error) {
+
 	_, blockPool, blockPoolTester := newTestBlockPool(t)
 	blockPoolTester.blockChain[0] = nil
 	blockPoolTester.initRefBlockChain(12)
@@ -70,6 +87,7 @@ func TestBlockPoolStatus(t *testing.T) {
 	delete(blockPoolTester.refBlockChain, 6)
 
 	blockPool.Start()
+	defer blockPool.Stop()
 	blockPoolTester.tds = make(map[int]int)
 	blockPoolTester.tds[9] = 1
 	blockPoolTester.tds[11] = 3
@@ -79,73 +97,67 @@ func TestBlockPoolStatus(t *testing.T) {
 	peer2 := blockPoolTester.newPeer("peer2", 2, 6)
 	peer3 := blockPoolTester.newPeer("peer3", 3, 11)
 	peer4 := blockPoolTester.newPeer("peer4", 1, 9)
-	// peer1 := blockPoolTester.newPeer("peer1", 1, 9)
-	// peer2 := blockPoolTester.newPeer("peer2", 2, 6)
-	// peer3 := blockPoolTester.newPeer("peer3", 3, 11)
-	// peer4 := blockPoolTester.newPeer("peer4", 1, 9)
 	peer2.blocksRequestsMap = peer1.blocksRequestsMap
 
 	var expected []int
-	var err error
 	expected = []int{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}
-	err = checkStatus(t, blockPool, false, expected)
+	err = checkStatus(nil, blockPool, false, expected)
 	if err != nil {
 		return
 	}
 
 	peer1.AddPeer()
 	expected = []int{0, 0, 0, 0, 0, 1, 0, 0, 1, 1, 0, 1, 0}
-	err = checkStatus(t, blockPool, true, expected)
+	err = checkStatus(nil, blockPool, true, expected)
 	if err != nil {
 		return
 	}
 
 	peer1.serveBlocks(8, 9)
-	expected = []int{0, 0, 1, 1, 0, 1, 0, 0, 1, 1, 1, 1, 0}
-	// err = checkStatus(t, blockPool, true, expected)
+	expected = []int{1, 0, 1, 1, 0, 1, 0, 0, 1, 1, 1, 1, 0}
+	err = checkStatus(nil, blockPool, true, expected)
 	if err != nil {
 		return
 	}
 
 	peer1.serveBlockHashes(9, 8, 7, 3, 2)
 	expected = []int{6, 5, 1, 1, 0, 1, 0, 0, 1, 1, 1, 1, 0}
-	// expected = []int{5, 5, 1, 1, 0, 1, 0, 0, 1, 1, 1, 1, 0}
-	err = checkStatus(t, blockPool, true, expected)
+	err = checkStatus(nil, blockPool, true, expected)
 	if err != nil {
 		return
 	}
 
 	peer1.serveBlocks(3, 7, 8)
 	expected = []int{6, 5, 3, 3, 0, 1, 0, 0, 1, 1, 1, 1, 0}
-	err = checkStatus(t, blockPool, true, expected)
+	err = checkStatus(nil, blockPool, true, expected)
 	if err != nil {
 		return
 	}
 
 	peer1.serveBlocks(2, 3)
 	expected = []int{6, 5, 4, 4, 0, 1, 0, 0, 1, 1, 1, 1, 0}
-	err = checkStatus(t, blockPool, true, expected)
+	err = checkStatus(nil, blockPool, true, expected)
 	if err != nil {
 		return
 	}
 
 	peer4.AddPeer()
 	expected = []int{6, 5, 4, 4, 0, 2, 0, 0, 2, 2, 1, 1, 0}
-	err = checkStatus(t, blockPool, true, expected)
+	err = checkStatus(nil, blockPool, true, expected)
 	if err != nil {
 		return
 	}
 
 	peer4.sendBlockHashes(12, 11)
 	expected = []int{6, 5, 4, 4, 0, 2, 0, 0, 2, 2, 1, 1, 0}
-	err = checkStatus(t, blockPool, true, expected)
+	err = checkStatus(nil, blockPool, true, expected)
 	if err != nil {
 		return
 	}
 
 	peer2.AddPeer()
 	expected = []int{6, 5, 4, 4, 0, 3, 0, 0, 3, 3, 1, 2, 0}
-	err = checkStatus(t, blockPool, true, expected)
+	err = checkStatus(nil, blockPool, true, expected)
 	if err != nil {
 		return
 	}
@@ -153,76 +165,76 @@ func TestBlockPoolStatus(t *testing.T) {
 	peer2.serveBlocks(5, 6)
 	peer2.serveBlockHashes(6, 5, 4, 3, 2)
 	expected = []int{10, 8, 5, 5, 0, 3, 1, 0, 3, 3, 2, 2, 0}
-	err = checkStatus(t, blockPool, true, expected)
+	err = checkStatus(nil, blockPool, true, expected)
 	if err != nil {
 		return
 	}
 
 	peer2.serveBlocks(2, 3, 4)
 	expected = []int{10, 8, 6, 6, 0, 3, 1, 0, 3, 3, 2, 2, 0}
-	err = checkStatus(t, blockPool, true, expected)
+	err = checkStatus(nil, blockPool, true, expected)
 	if err != nil {
 		return
 	}
 
 	blockPool.RemovePeer("peer2")
 	expected = []int{10, 8, 6, 6, 0, 3, 1, 0, 3, 2, 2, 2, 0}
-	err = checkStatus(t, blockPool, true, expected)
+	err = checkStatus(nil, blockPool, true, expected)
 	if err != nil {
 		return
 	}
 
 	peer1.serveBlockHashes(2, 1, 0)
 	expected = []int{11, 9, 6, 6, 0, 3, 1, 0, 3, 2, 2, 2, 0}
-	err = checkStatus(t, blockPool, true, expected)
+	err = checkStatus(nil, blockPool, true, expected)
 	if err != nil {
 		return
 	}
 
 	peer1.serveBlocks(1, 2)
 	expected = []int{11, 9, 7, 7, 0, 3, 1, 0, 3, 2, 2, 2, 0}
-	err = checkStatus(t, blockPool, true, expected)
+	err = checkStatus(nil, blockPool, true, expected)
 	if err != nil {
 		return
 	}
 
 	peer1.serveBlocks(4, 5)
 	expected = []int{11, 9, 8, 8, 0, 3, 1, 0, 3, 2, 2, 2, 0}
-	err = checkStatus(t, blockPool, true, expected)
+	err = checkStatus(nil, blockPool, true, expected)
 	if err != nil {
 		return
 	}
 
 	peer3.AddPeer()
 	expected = []int{11, 9, 8, 8, 0, 4, 1, 0, 4, 3, 2, 3, 0}
-	err = checkStatus(t, blockPool, true, expected)
+	err = checkStatus(nil, blockPool, true, expected)
 	if err != nil {
 		return
 	}
 
 	peer3.serveBlocks(10, 11)
 	expected = []int{12, 9, 9, 9, 0, 4, 1, 0, 4, 3, 3, 3, 0}
-	err = checkStatus(t, blockPool, true, expected)
+	err = checkStatus(nil, blockPool, true, expected)
 	if err != nil {
 		return
 	}
 
 	peer3.serveBlockHashes(11, 10, 9)
 	expected = []int{14, 11, 9, 9, 0, 4, 1, 0, 4, 3, 3, 3, 0}
-	err = checkStatus(t, blockPool, true, expected)
+	err = checkStatus(nil, blockPool, true, expected)
 	if err != nil {
 		return
 	}
 
 	peer4.sendBlocks(11, 12)
 	expected = []int{14, 11, 9, 9, 0, 4, 1, 0, 4, 3, 4, 3, 1}
-	err = checkStatus(t, blockPool, true, expected)
+	err = checkStatus(nil, blockPool, true, expected)
 	if err != nil {
 		return
 	}
 	peer3.serveBlocks(9, 10)
 	expected = []int{14, 11, 10, 10, 0, 4, 1, 0, 4, 3, 4, 3, 1}
-	err = checkStatus(t, blockPool, true, expected)
+	err = checkStatus(nil, blockPool, true, expected)
 	if err != nil {
 		return
 	}
@@ -231,10 +243,9 @@ func TestBlockPoolStatus(t *testing.T) {
 	blockPool.Wait(waitTimeout)
 	time.Sleep(200 * time.Millisecond)
 	expected = []int{14, 3, 11, 3, 8, 4, 1, 8, 4, 3, 4, 3, 1}
-	err = checkStatus(t, blockPool, false, expected)
+	err = checkStatus(nil, blockPool, false, expected)
 	if err != nil {
 		return
 	}
-
-	blockPool.Stop()
+	return nil
 }

--- a/blockpool/test/util.go
+++ b/blockpool/test/util.go
@@ -10,16 +10,20 @@ import (
 
 func CheckInt(name string, got int, expected int, t *testing.T) (err error) {
 	if got != expected {
-		t.Errorf("status for %v incorrect. expected %v, got %v", name, expected, got)
-		err = fmt.Errorf("")
+		err = fmt.Errorf("status for %v incorrect. expected %v, got %v", name, expected, got)
+		if t != nil {
+			t.Error(err)
+		}
 	}
 	return
 }
 
 func CheckDuration(name string, got time.Duration, expected time.Duration, t *testing.T) (err error) {
 	if got != expected {
-		t.Errorf("status for %v incorrect. expected %v, got %v", name, expected, got)
-		err = fmt.Errorf("")
+		err = fmt.Errorf("status for %v incorrect. expected %v, got %v", name, expected, got)
+		if t != nil {
+			t.Error(err)
+		}
 	}
 	return
 }

--- a/cmd/ethereum/js.go
+++ b/cmd/ethereum/js.go
@@ -102,7 +102,7 @@ func (js *jsre) apiBindings() {
 	jethObj := t.Object()
 	jethObj.Set("send", jeth.Send)
 
-	err := js.re.Compile("bignum.js", re.BigNumber_JS)
+	err := js.re.Compile("bignumber.js", re.BigNumber_JS)
 	if err != nil {
 		utils.Fatalf("Error loading bignumber.js: %v", err)
 	}

--- a/cmd/ethereum/js.go
+++ b/cmd/ethereum/js.go
@@ -67,14 +67,14 @@ type jsre struct {
 	prompter
 }
 
-func newJSRE(ethereum *eth.Ethereum, libPath string) *jsre {
+func newJSRE(ethereum *eth.Ethereum, libPath string, interactive bool) *jsre {
 	js := &jsre{ethereum: ethereum, ps1: "> "}
 	js.xeth = xeth.New(ethereum, js)
 	js.re = re.New(libPath)
 	js.apiBindings()
 	js.adminBindings()
 
-	if !liner.TerminalSupported() {
+	if !liner.TerminalSupported() || !interactive {
 		js.prompter = dumbterm{bufio.NewReader(os.Stdin)}
 	} else {
 		lr := liner.NewLiner()

--- a/cmd/ethereum/js_test.go
+++ b/cmd/ethereum/js_test.go
@@ -47,7 +47,7 @@ func testJEthRE(t *testing.T) (repl *jsre, ethereum *eth.Ethereum, err error) {
 		return
 	}
 	assetPath := path.Join(os.Getenv("GOPATH"), "src", "github.com", "ethereum", "go-ethereum", "cmd", "mist", "assets", "ext")
-	repl = newJSRE(ethereum, assetPath)
+	repl = newJSRE(ethereum, assetPath, false)
 	return
 }
 

--- a/cmd/ethereum/js_test.go
+++ b/cmd/ethereum/js_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"io/ioutil"
 	"os"
 	"path"
 	"testing"
@@ -9,7 +10,6 @@ import (
 	"github.com/robertkrimen/otto"
 
 	"github.com/ethereum/go-ethereum/accounts"
-	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/eth"
 )
@@ -30,8 +30,8 @@ func testJEthRE(t *testing.T) (repl *jsre, ethereum *eth.Ethereum, err error) {
 	}
 	// FIXME: this does not work ATM
 	ks := crypto.NewKeyStorePlain("/tmp/eth/keys")
-	common.WriteFile("/tmp/eth/keys/e273f01c99144c438695e10f24926dc1f9fbf62d/e273f01c99144c438695e10f24926dc1f9fbf62d",
-		[]byte(`{"Id":"RhRXD+fNRKS4jx+7ZfEsNA==","Address":"4nPwHJkUTEOGleEPJJJtwfn79i0=","PrivateKey":"h4ACVpe74uIvi5Cg/2tX/Yrm2xdr3J7QoMbMtNX2CNc="}`))
+	ioutil.WriteFile("/tmp/eth/keys/e273f01c99144c438695e10f24926dc1f9fbf62d/e273f01c99144c438695e10f24926dc1f9fbf62d",
+		[]byte(`{"Id":"RhRXD+fNRKS4jx+7ZfEsNA==","Address":"4nPwHJkUTEOGleEPJJJtwfn79i0=","PrivateKey":"h4ACVpe74uIvi5Cg/2tX/Yrm2xdr3J7QoMbMtNX2CNc="}`), os.ModePerm)
 
 	port++
 	ethereum, err = eth.New(&eth.Config{

--- a/cmd/ethereum/main.go
+++ b/cmd/ethereum/main.go
@@ -246,7 +246,7 @@ func console(ctx *cli.Context) {
 	}
 
 	startEth(ctx, ethereum)
-	repl := newJSRE(ethereum, ctx.String(utils.JSpathFlag.Name))
+	repl := newJSRE(ethereum, ctx.String(utils.JSpathFlag.Name), true)
 	repl.interactive()
 
 	ethereum.Stop()
@@ -261,7 +261,7 @@ func execJSFiles(ctx *cli.Context) {
 	}
 
 	startEth(ctx, ethereum)
-	repl := newJSRE(ethereum, ctx.String(utils.JSpathFlag.Name))
+	repl := newJSRE(ethereum, ctx.String(utils.JSpathFlag.Name), false)
 	for _, file := range ctx.Args() {
 		repl.exec(file)
 	}

--- a/cmd/ethereum/main.go
+++ b/cmd/ethereum/main.go
@@ -355,10 +355,11 @@ func getPassPhrase(ctx *cli.Context, desc string, confirmation bool) (passphrase
 			passphrase = auth
 
 		} else {
-			var err error
-			if passphrase, err = common.ReadAllFile(passfile); err != nil {
+			passbytes, err := ioutil.ReadFile(passfile)
+			if err != nil {
 				utils.Fatalf("Unable to read password file '%s': %v", passfile, err)
 			}
+			passphrase = string(passbytes)
 		}
 	}
 	return

--- a/cmd/ethereum/main.go
+++ b/cmd/ethereum/main.go
@@ -295,7 +295,11 @@ func unlockAccount(ctx *cli.Context, am *accounts.Manager, account string) (pass
 		// Load startup keys. XXX we are going to need a different format
 		// Attempt to unlock the account
 		passphrase = getPassPhrase(ctx, "", false)
-		err = am.Unlock(common.FromHex(account), passphrase)
+		accbytes := common.FromHex(account)
+		if len(accbytes) == 0 {
+			utils.Fatalf("Invalid account address '%s'", account)
+		}
+		err = am.Unlock(accbytes, passphrase)
 		if err != nil {
 			utils.Fatalf("Unlock account failed '%v'", err)
 		}

--- a/cmd/ethereum/main.go
+++ b/cmd/ethereum/main.go
@@ -294,7 +294,7 @@ func unlockAccount(ctx *cli.Context, am *accounts.Manager, account string) (pass
 		var err error
 		// Load startup keys. XXX we are going to need a different format
 		// Attempt to unlock the account
-		passphrase := getPassPhrase(ctx, "", false)
+		passphrase = getPassPhrase(ctx, "", false)
 		err = am.Unlock(common.FromHex(account), passphrase)
 		if err != nil {
 			utils.Fatalf("Unlock account failed '%v'", err)
@@ -310,7 +310,11 @@ func startEth(ctx *cli.Context, eth *eth.Ethereum) {
 	account := ctx.GlobalString(utils.UnlockedAccountFlag.Name)
 	if len(account) > 0 {
 		if account == "coinbase" {
-			account = ""
+			accbytes, err := am.Coinbase()
+			if err != nil {
+				utils.Fatalf("no coinbase account: %v", err)
+			}
+			account = common.ToHex(accbytes)
 		}
 		unlockAccount(ctx, am, account)
 	}
@@ -420,6 +424,7 @@ func accountExport(ctx *cli.Context) {
 	}
 	am := utils.GetAccountManager(ctx)
 	auth := unlockAccount(ctx, am, account)
+
 	err := am.Export(keyfile, common.FromHex(account), auth)
 	if err != nil {
 		utils.Fatalf("Account export failed: %v", err)

--- a/cmd/ethereum/main.go
+++ b/cmd/ethereum/main.go
@@ -134,7 +134,7 @@ Exports the given account's private key into keyfile using the canonical EC form
 The account needs to be unlocked, if it is not the user is prompted for a passphrase to unlock it.
 For non-interactive use, the password can be specified with the --unlock flag:
 
-    ethereum --unlock <passwrdfile> account export <address> <keyfile>
+    ethereum --password <passwrdfile> account export <address> <keyfile>
 
 Note:
 Since you can directly copy your encrypted accounts to another ethereum instance, this import/export mechanism is not needed when you transfer an account between nodes.
@@ -305,6 +305,9 @@ func startEth(ctx *cli.Context, eth *eth.Ethereum) {
 
 	account := ctx.GlobalString(utils.UnlockedAccountFlag.Name)
 	if len(account) > 0 {
+		if account == "coinbase" {
+			account = ""
+		}
 		unlockAccount(ctx, am, account)
 	}
 	// Start auxiliary services if enabled.

--- a/cmd/ethereum/main.go
+++ b/cmd/ethereum/main.go
@@ -83,9 +83,6 @@ The output of this command is supposed to be machine-readable.
 					Action: accountList,
 					Name:   "list",
 					Usage:  "print account addresses",
-					Description: `
-
-`,
 				},
 				{
 					Action: accountCreate,
@@ -111,12 +108,14 @@ For non-interactive use the passphrase can be specified with the --password flag
 
     ethereum account import <keyfile>
 
-Imports a private key from <keyfile> and creates a new account with the address derived from the key.
-The keyfile is assumed to contain an unencrypted private key in canonical EC format.
+Imports a private key from <keyfile> and creates a new account with the address
+derived from the key.
+The keyfile is assumed to contain an unencrypted private key in canonical EC
+format.
 
 The account is saved in encrypted format, you are prompted for a passphrase.
 You must remember this passphrase to unlock your account in future.
-For non-interactive use the passphrase can be specified with the --password flag:
+For non-interactive use the passphrase can be specified with the -password flag:
 
     ethereum --password <passwordfile> account import <keyfile>
 
@@ -130,14 +129,18 @@ For non-interactive use the passphrase can be specified with the --password flag
 
     ethereum account export <address> <keyfile>
 
-Exports the given account's private key into keyfile using the canonical EC format.
-The account needs to be unlocked, if it is not the user is prompted for a passphrase to unlock it.
-For non-interactive use, the password can be specified with the --unlock flag:
+Exports the given account's private key into keyfile using the canonical EC
+format.
+The account needs to be unlocked, if it is not the user is prompted for a
+passphrase to unlock it.
+For non-interactive use, the passphrase can be specified with the --unlock flag:
 
     ethereum --password <passwrdfile> account export <address> <keyfile>
 
 Note:
-Since you can directly copy your encrypted accounts to another ethereum instance, this import/export mechanism is not needed when you transfer an account between nodes.
+As you can directly copy your encrypted accounts to another ethereum instance,
+this import/export mechanism is not needed when you transfer an account between
+nodes.
 					`,
 				},
 			},
@@ -156,16 +159,18 @@ Use "ethereum dump 0" to dump the genesis block.
 			Name:   "console",
 			Usage:  `Ethereum Console: interactive JavaScript environment`,
 			Description: `
-Console is an interactive shell for the Ethereum JavaScript runtime environment which exposes a node admin interface as well as the DAPP JavaScript API.
+Console is an interactive shell for the Ethereum JavaScript runtime environment
+which exposes a node admin interface as well as the DAPP JavaScript API.
 See https://github.com/ethereum/go-ethereum/wiki/Frontier-Console
 `,
 		},
 		{
 			Action: execJSFiles,
 			Name:   "js",
-			Usage:  `executes the given JavaScript files in the Ethereum Frontier JavaScript VM`,
+			Usage:  `executes the given JavaScript files in the Ethereum JavaScript VM`,
 			Description: `
-The Ethereum JavaScript VM exposes a node admin interface as well as the DAPP JavaScript API. See https://github.com/ethereum/go-ethereum/wiki/Frontier-Console
+The Ethereum JavaScript VM exposes a node admin interface as well as the DAPP
+JavaScript API. See https://github.com/ethereum/go-ethereum/wiki/Javascipt-Console
 `,
 		},
 		{

--- a/cmd/mist/bindings.go
+++ b/cmd/mist/bindings.go
@@ -22,13 +22,14 @@ package main
 
 import (
 	"encoding/json"
+	"io/ioutil"
 	"os"
 	"strconv"
 
 	"github.com/ethereum/go-ethereum/cmd/utils"
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/core/state"
+	"github.com/ethereum/go-ethereum/core/types"
 )
 
 type plugin struct {
@@ -46,14 +47,14 @@ func (self *Gui) AddPlugin(pluginPath string) {
 	self.plugins[pluginPath] = plugin{Name: pluginPath, Path: pluginPath}
 
 	json, _ := json.MarshalIndent(self.plugins, "", "    ")
-	common.WriteFile(self.eth.DataDir+"/plugins.json", json)
+	ioutil.WriteFile(self.eth.DataDir+"/plugins.json", json, os.ModePerm)
 }
 
 func (self *Gui) RemovePlugin(pluginPath string) {
 	delete(self.plugins, pluginPath)
 
 	json, _ := json.MarshalIndent(self.plugins, "", "    ")
-	common.WriteFile(self.eth.DataDir+"/plugins.json", json)
+	ioutil.WriteFile(self.eth.DataDir+"/plugins.json", json, os.ModePerm)
 }
 
 func (self *Gui) DumpState(hash, path string) {

--- a/cmd/mist/gui.go
+++ b/cmd/mist/gui.go
@@ -25,6 +25,7 @@ import "C"
 import (
 	"encoding/json"
 	"fmt"
+	"io/ioutil"
 	"math/big"
 	"path"
 	"runtime"
@@ -91,8 +92,8 @@ func NewWindow(ethereum *eth.Ethereum) *Gui {
 		plugins:       make(map[string]plugin),
 		serviceEvents: make(chan ServEv, 1),
 	}
-	data, _ := common.ReadAllFile(path.Join(ethereum.DataDir, "plugins.json"))
-	json.Unmarshal([]byte(data), &gui.plugins)
+	data, _ := ioutil.ReadFile(path.Join(ethereum.DataDir, "plugins.json"))
+	json.Unmarshal(data, &gui.plugins)
 
 	return gui
 }

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -104,7 +104,13 @@ var (
 	}
 	UnlockedAccountFlag = cli.StringFlag{
 		Name:  "unlock",
-		Usage: "Unlock a given account untill this programs exits (address:password)",
+		Usage: "unlock the account given until this program exits (prompts for password).",
+		Value: "",
+	}
+	PasswordFileFlag = cli.StringFlag{
+		Name:  "password",
+		Usage: "Password used when saving a new account and unlocking an existing account. If you create a new account make sure you remember this password.",
+		Value: "",
 	}
 
 	// logging and debug settings

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -97,14 +97,9 @@ var (
 		Usage: "Enable mining",
 	}
 
-	// key settings
-	UnencryptedKeysFlag = cli.BoolFlag{
-		Name:  "unencrypted-keys",
-		Usage: "disable private key disk encryption (for testing)",
-	}
 	UnlockedAccountFlag = cli.StringFlag{
 		Name:  "unlock",
-		Usage: "unlock the account given until this program exits (prompts for password).",
+		Usage: "unlock the account given until this program exits (prompts for password). '--unlock coinbase' unlocks the primary (coinbase) account",
 		Value: "",
 	}
 	PasswordFileFlag = cli.StringFlag{
@@ -249,12 +244,7 @@ func GetChain(ctx *cli.Context) (*core.ChainManager, common.Database, common.Dat
 
 func GetAccountManager(ctx *cli.Context) *accounts.Manager {
 	dataDir := ctx.GlobalString(DataDirFlag.Name)
-	var ks crypto.KeyStore2
-	if ctx.GlobalBool(UnencryptedKeysFlag.Name) {
-		ks = crypto.NewKeyStorePlain(path.Join(dataDir, "plainkeys"))
-	} else {
-		ks = crypto.NewKeyStorePassphrase(path.Join(dataDir, "keys"))
-	}
+	ks := crypto.NewKeyStorePassphrase(path.Join(dataDir, "keys"))
 	return accounts.NewManager(ks)
 }
 

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -109,7 +109,7 @@ var (
 	}
 	PasswordFileFlag = cli.StringFlag{
 		Name:  "password",
-		Usage: "Password used when saving a new account and unlocking an existing account. If you create a new account make sure you remember this password.",
+		Usage: "Path to password file for (un)locking an existing account.",
 		Value: "",
 	}
 

--- a/common/path.go
+++ b/common/path.go
@@ -2,7 +2,6 @@ package common
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/user"
 	"path"
@@ -41,35 +40,6 @@ func FileExist(filePath string) bool {
 	}
 
 	return true
-}
-
-func ReadAllFile(filePath string) (string, error) {
-	file, err := os.Open(filePath)
-	if err != nil {
-		return "", err
-	}
-
-	data, err := ioutil.ReadAll(file)
-	if err != nil {
-		return "", err
-	}
-
-	return string(data), nil
-}
-
-func WriteFile(filePath string, content []byte) error {
-	fh, err := os.OpenFile(filePath, os.O_TRUNC|os.O_RDWR|os.O_CREATE, os.ModePerm)
-	if err != nil {
-		return err
-	}
-	defer fh.Close()
-
-	_, err = fh.Write(content)
-	if err != nil {
-		return err
-	}
-
-	return nil
 }
 
 func AbsolutePath(Datadir string, filename string) string {

--- a/common/path_test.go
+++ b/common/path_test.go
@@ -2,55 +2,10 @@ package common
 
 import (
 	"os"
-	"testing"
+	// "testing"
 
 	checker "gopkg.in/check.v1"
 )
-
-func TestGoodFile(t *testing.T) {
-	goodpath := "~/goethereumtest.pass"
-	path := ExpandHomePath(goodpath)
-	contentstring := "3.14159265358979323846"
-
-	err := WriteFile(path, []byte(contentstring))
-	if err != nil {
-		t.Error("Could not write file")
-	}
-
-	if !FileExist(path) {
-		t.Error("File not found at", path)
-	}
-
-	v, err := ReadAllFile(path)
-	if err != nil {
-		t.Error("Could not read file", path)
-	}
-	if v != contentstring {
-		t.Error("Expected", contentstring, "Got", v)
-	}
-
-}
-
-func TestBadFile(t *testing.T) {
-	badpath := "/this/path/should/not/exist/goethereumtest.fail"
-	path := ExpandHomePath(badpath)
-	contentstring := "3.14159265358979323846"
-
-	err := WriteFile(path, []byte(contentstring))
-	if err == nil {
-		t.Error("Wrote file, but should not be able to", path)
-	}
-
-	if FileExist(path) {
-		t.Error("Found file, but should not be able to", path)
-	}
-
-	v, err := ReadAllFile(path)
-	if err == nil {
-		t.Error("Read file, but should not be able to", v)
-	}
-
-}
 
 type CommonSuite struct{}
 

--- a/crypto/crypto.go
+++ b/crypto/crypto.go
@@ -139,6 +139,11 @@ func LoadECDSA(file string) (*ecdsa.PrivateKey, error) {
 	return ToECDSA(buf), nil
 }
 
+// SaveECDSA saves a secp256k1 private key from the given file.
+func SaveECDSA(file string, key *ecdsa.PrivateKey) error {
+	return common.WriteFile(file, FromECDSA(key))
+}
+
 func GenerateKey() (*ecdsa.PrivateKey, error) {
 	return ecdsa.GenerateKey(S256(), rand.Reader)
 }

--- a/crypto/crypto.go
+++ b/crypto/crypto.go
@@ -9,6 +9,7 @@ import (
 	"crypto/sha256"
 	"fmt"
 	"io"
+	"io/ioutil"
 	"os"
 
 	"encoding/hex"
@@ -139,9 +140,10 @@ func LoadECDSA(file string) (*ecdsa.PrivateKey, error) {
 	return ToECDSA(buf), nil
 }
 
-// SaveECDSA saves a secp256k1 private key from the given file.
+// SaveECDSA saves a secp256k1 private key to the given file with restrictive
+// permissions
 func SaveECDSA(file string, key *ecdsa.PrivateKey) error {
-	return common.WriteFile(file, FromECDSA(key))
+	return ioutil.WriteFile(file, FromECDSA(key), 0600)
 }
 
 func GenerateKey() (*ecdsa.PrivateKey, error) {

--- a/crypto/key.go
+++ b/crypto/key.go
@@ -85,6 +85,16 @@ func (k *Key) UnmarshalJSON(j []byte) (err error) {
 	return err
 }
 
+func NewKeyFromECDSA(privateKeyECDSA *ecdsa.PrivateKey) *Key {
+	id := uuid.NewRandom()
+	key := &Key{
+		Id:         id,
+		Address:    PubkeyToAddress(privateKeyECDSA.PublicKey),
+		PrivateKey: privateKeyECDSA,
+	}
+	return key
+}
+
 func NewKey(rand io.Reader) *Key {
 	randBytes := make([]byte, 64)
 	_, err := rand.Read(randBytes)
@@ -97,11 +107,5 @@ func NewKey(rand io.Reader) *Key {
 		panic("key generation: ecdsa.GenerateKey failed: " + err.Error())
 	}
 
-	id := uuid.NewRandom()
-	key := &Key{
-		Id:         id,
-		Address:    PubkeyToAddress(privateKeyECDSA.PublicKey),
-		PrivateKey: privateKeyECDSA,
-	}
-	return key
+	return NewKeyFromECDSA(privateKeyECDSA)
 }

--- a/jsre/jsre_test.go
+++ b/jsre/jsre_test.go
@@ -2,9 +2,9 @@ package jsre
 
 import (
 	"github.com/robertkrimen/otto"
+	"io/ioutil"
+	"os"
 	"testing"
-
-	"github.com/ethereum/go-ethereum/common"
 )
 
 type testNativeObjectBinding struct {
@@ -26,7 +26,7 @@ func (no *testNativeObjectBinding) TestMethod(call otto.FunctionCall) otto.Value
 func TestExec(t *testing.T) {
 	jsre := New("/tmp")
 
-	common.WriteFile("/tmp/test.js", []byte(`msg = "testMsg"`))
+	ioutil.WriteFile("/tmp/test.js", []byte(`msg = "testMsg"`), os.ModePerm)
 	err := jsre.Exec("test.js")
 	if err != nil {
 		t.Errorf("expected no error, got %v", err)
@@ -64,7 +64,7 @@ func TestBind(t *testing.T) {
 func TestLoadScript(t *testing.T) {
 	jsre := New("/tmp")
 
-	common.WriteFile("/tmp/test.js", []byte(`msg = "testMsg"`))
+	ioutil.WriteFile("/tmp/test.js", []byte(`msg = "testMsg"`), os.ModePerm)
 	_, err := jsre.Run(`loadScript("test.js")`)
 	if err != nil {
 		t.Errorf("expected no error, got %v", err)


### PR DESCRIPTION
#541 
https://github.com/ethereum/go-ethereum/wiki/Managing-your-accounts
- cli: add passwordfile flag
- cli: change unlock flag only takes account
- cli: with unlock you are prompted for password or use passfile with password flag
- cli: unlockAccount used in normal client start (run) and accountExport
- cli: getPassword used in accountCreate and accountImport
- accounts: Manager.Import, Manager.Export
- crypto: SaveECDSA (to complement LoadECDSA) to save to file
- crypto: NewKeyFromECDSA added (used in accountImport and New = generated constructor)