### PR TITLE
XEth cleanup

### DIFF
--- a/rpc/api.go
+++ b/rpc/api.go
@@ -60,9 +60,9 @@ func (api *EthereumApi) GetRequestReply(req *RpcRequest, reply *interface{}) err
 		}
 		*reply = common.ToHex(crypto.Sha3(common.FromHex(args.Data)))
 	case "web3_clientVersion":
-		*reply = api.xeth().Backend().Version()
+		*reply = api.xeth().ClientVersion()
 	case "net_version":
-		*reply = string(api.xeth().Backend().ProtocolVersion())
+		*reply = api.xeth().NetworkVersion()
 	case "net_listening":
 		*reply = api.xeth().IsListening()
 	case "net_peerCount":
@@ -84,7 +84,7 @@ func (api *EthereumApi) GetRequestReply(req *RpcRequest, reply *interface{}) err
 	case "eth_accounts":
 		*reply = api.xeth().Accounts()
 	case "eth_blockNumber":
-		v := api.xeth().Backend().ChainManager().CurrentBlock().Number()
+		v := api.xeth().CurrentBlock().Number()
 		*reply = common.ToHex(v.Bytes())
 	case "eth_getBalance":
 		args := new(GetBalanceArgs)

--- a/rpc/api.go
+++ b/rpc/api.go
@@ -49,7 +49,7 @@ func (api *EthereumApi) Close() {
 }
 
 func (api *EthereumApi) GetRequestReply(req *RpcRequest, reply *interface{}) error {
-	// Spec at https://github.com/ethereum/wiki/wiki/Generic-JSON-RPC
+	// Spec at https://github.com/ethereum/wiki/wiki/JSON-RPC
 	rpclogger.Debugf("%s %s", req.Method, req.Params)
 
 	switch req.Method {
@@ -68,6 +68,8 @@ func (api *EthereumApi) GetRequestReply(req *RpcRequest, reply *interface{}) err
 	case "net_peerCount":
 		v := api.xeth().PeerCount()
 		*reply = common.ToHex(big.NewInt(int64(v)).Bytes())
+	case "eth_version":
+		*reply = api.xeth().EthVersion()
 	case "eth_coinbase":
 		// TODO handling of empty coinbase due to lack of accounts
 		res := api.xeth().Coinbase()
@@ -406,6 +408,8 @@ func (api *EthereumApi) GetRequestReply(req *RpcRequest, reply *interface{}) err
 
 		res, _ := api.db.Get([]byte(args.Database + args.Key))
 		*reply = common.ToHex(res)
+	case "shh_version":
+		*reply = api.xeth().WhisperVersion()
 	case "shh_post":
 		args := new(WhisperMessageArgs)
 		if err := json.Unmarshal(req.Params, &args); err != nil {

--- a/whisper/whisper.go
+++ b/whisper/whisper.go
@@ -16,8 +16,9 @@ import (
 )
 
 const (
-	statusMsg    = 0x0
-	envelopesMsg = 0x01
+	statusMsg      = 0x0
+	envelopesMsg   = 0x01
+	whisperVersion = 0x02
 )
 
 type MessageEvent struct {
@@ -56,12 +57,16 @@ func New() *Whisper {
 	// p2p whisper sub protocol handler
 	whisper.protocol = p2p.Protocol{
 		Name:    "shh",
-		Version: 2,
+		Version: uint(whisperVersion),
 		Length:  2,
 		Run:     whisper.msgHandler,
 	}
 
 	return whisper
+}
+
+func (self *Whisper) Version() uint {
+	return self.protocol.Version
 }
 
 func (self *Whisper) Start() {

--- a/xeth/frontend.go
+++ b/xeth/frontend.go
@@ -1,0 +1,32 @@
+package xeth
+
+import (
+	"github.com/ethereum/go-ethereum/core/types"
+)
+
+// Frontend should be implemented by users of XEth. Its methods are
+// called whenever XEth makes a decision that requires user input.
+type Frontend interface {
+	// UnlockAccount is called when a transaction needs to be signed
+	// but the key corresponding to the transaction's sender is
+	// locked.
+	//
+	// It should unlock the account with the given address and return
+	// true if unlocking succeeded.
+	UnlockAccount(address []byte) bool
+
+	// This is called for all transactions inititated through
+	// Transact. It should prompt the user to confirm the transaction
+	// and return true if the transaction was acknowledged.
+	//
+	// ConfirmTransaction is not used for Call transactions
+	// because they cannot change any state.
+	ConfirmTransaction(tx *types.Transaction) bool
+}
+
+// dummyFrontend is a non-interactive frontend that allows all
+// transactions but cannot not unlock any keys.
+type dummyFrontend struct{}
+
+func (dummyFrontend) UnlockAccount([]byte) bool                  { return false }
+func (dummyFrontend) ConfirmTransaction(*types.Transaction) bool { return true }

--- a/xeth/state.go
+++ b/xeth/state.go
@@ -29,7 +29,7 @@ func (self *State) SafeGet(addr string) *Object {
 func (self *State) safeGet(addr string) *state.StateObject {
 	object := self.state.GetStateObject(common.HexToAddress(addr))
 	if object == nil {
-		object = state.NewStateObject(common.HexToAddress(addr), self.xeth.eth.StateDb())
+		object = state.NewStateObject(common.HexToAddress(addr), self.xeth.backend.StateDb())
 	}
 
 	return object

--- a/xeth/xeth.go
+++ b/xeth/xeth.go
@@ -124,10 +124,11 @@ func (self *XEth) AtStateNum(num int64) *XEth {
 	} else {
 		st = self.backend.ChainManager().State()
 	}
-	return self.WithState(st)
+
+	return self.withState(st)
 }
 
-func (self *XEth) WithState(statedb *state.StateDB) *XEth {
+func (self *XEth) withState(statedb *state.StateDB) *XEth {
 	xeth := &XEth{
 		backend: self.backend,
 	}

--- a/xeth/xeth.go
+++ b/xeth/xeth.go
@@ -29,11 +29,11 @@ var (
 )
 
 type XEth struct {
-	backend *eth.Ethereum
+	backend  *eth.Ethereum
+	frontend Frontend
+
 	state   *State
 	whisper *Whisper
-
-	frontend Frontend
 
 	quit          chan struct{}
 	filterManager *filter.FilterManager
@@ -47,7 +47,6 @@ type XEth struct {
 	// regmut   sync.Mutex
 	// register map[string][]*interface{} // TODO improve return type
 
-	// Miner agent
 	agent *miner.RemoteAgent
 }
 
@@ -57,10 +56,10 @@ type XEth struct {
 func New(eth *eth.Ethereum, frontend Frontend) *XEth {
 	xeth := &XEth{
 		backend:       eth,
+		frontend:      frontend,
 		whisper:       NewWhisper(eth.Whisper()),
 		quit:          make(chan struct{}),
 		filterManager: filter.NewFilterManager(eth.EventMux()),
-		frontend:      frontend,
 		logs:          make(map[int]*logFilter),
 		messages:      make(map[int]*whisperFilter),
 		agent:         miner.NewRemoteAgent(),
@@ -71,6 +70,7 @@ func New(eth *eth.Ethereum, frontend Frontend) *XEth {
 		xeth.frontend = dummyFrontend{}
 	}
 	xeth.state = NewState(xeth, xeth.backend.ChainManager().TransState())
+
 	go xeth.start()
 	go xeth.filterManager.Start()
 
@@ -144,6 +144,7 @@ func (self *XEth) WithState(statedb *state.StateDB) *XEth {
 	xeth.state = NewState(xeth, statedb)
 	return xeth
 }
+
 func (self *XEth) State() *State { return self.state }
 
 func (self *XEth) Whisper() *Whisper { return self.whisper }

--- a/xeth/xeth.go
+++ b/xeth/xeth.go
@@ -221,12 +221,20 @@ func (self *XEth) IsMining() bool {
 	return self.backend.IsMining()
 }
 
+func (self *XEth) EthVersion() string {
+	return string(self.backend.EthVersion())
+}
+
 func (self *XEth) NetworkVersion() string {
-	return string(self.backend.ProtocolVersion())
+	return string(self.backend.NetVersion())
+}
+
+func (self *XEth) WhisperVersion() string {
+	return string(self.backend.ShhVersion())
 }
 
 func (self *XEth) ClientVersion() string {
-	return self.backend.Version()
+	return self.backend.ClientVersion()
 }
 
 func (self *XEth) SetMining(shouldmine bool) bool {

--- a/xeth/xeth.go
+++ b/xeth/xeth.go
@@ -28,33 +28,6 @@ var (
 	defaultGas       = big.NewInt(90000)          //500000
 )
 
-// Frontend should be implemented by users of XEth. Its methods are
-// called whenever XEth makes a decision that requires user input.
-type Frontend interface {
-	// UnlockAccount is called when a transaction needs to be signed
-	// but the key corresponding to the transaction's sender is
-	// locked.
-	//
-	// It should unlock the account with the given address and return
-	// true if unlocking succeeded.
-	UnlockAccount(address []byte) bool
-
-	// This is called for all transactions inititated through
-	// Transact. It should prompt the user to confirm the transaction
-	// and return true if the transaction was acknowledged.
-	//
-	// ConfirmTransaction is not used for Call transactions
-	// because they cannot change any state.
-	ConfirmTransaction(tx *types.Transaction) bool
-}
-
-// dummyFrontend is a non-interactive frontend that allows all
-// transactions but cannot not unlock any keys.
-type dummyFrontend struct{}
-
-func (dummyFrontend) UnlockAccount([]byte) bool                  { return false }
-func (dummyFrontend) ConfirmTransaction(*types.Transaction) bool { return true }
-
 type XEth struct {
 	backend *eth.Ethereum
 	state   *State

--- a/xeth/xeth.go
+++ b/xeth/xeth.go
@@ -204,7 +204,7 @@ func (self *XEth) BlockByNumber(num int64) *Block {
 	}
 
 	if num == -1 {
-		return NewBlock(self.backend.ChainManager().CurrentBlock())
+		return NewBlock(self.CurrentBlock())
 	}
 
 	return NewBlock(self.backend.ChainManager().GetBlockByNumber(uint64(num)))
@@ -217,7 +217,7 @@ func (self *XEth) EthBlockByNumber(num int64) *types.Block {
 	}
 
 	if num == -1 {
-		return self.backend.ChainManager().CurrentBlock()
+		return self.CurrentBlock()
 	}
 
 	return self.backend.ChainManager().GetBlockByNumber(uint64(num))
@@ -549,7 +549,7 @@ func (self *XEth) Call(fromStr, toStr, valueStr, gasStr, gasPriceStr, dataStr st
 		msg.gasPrice = defaultGasPrice
 	}
 
-	block := self.backend.ChainManager().CurrentBlock()
+	block := self.CurrentBlock()
 	vmenv := core.NewEnv(statedb, self.backend.ChainManager(), msg, block)
 
 	res, err := vmenv.Call(msg.from, msg.to, msg.data, msg.gas, msg.gasPrice, msg.value)


### PR DESCRIPTION
* Remove Backend interface resulting from import cycle (caused redundant code)
* Don't expose backend outside the package. Prefer discrete functions (cleaner interface)
* Move Frontend to separate file (cleanup)
* DRY BlockHeight into internal function (cleanup)
* Remove redundant internal convenience vars (cleanup)
* rename eth to backend, to balance frontend (cleanup)
* Expose protocol versions to RPC (*_version)