### PR TITLE
settable etherbase

### DIFF
--- a/accounts/account_manager.go
+++ b/accounts/account_manager.go
@@ -81,13 +81,7 @@ func (am *Manager) HasAccount(addr []byte) bool {
 	return false
 }
 
-// Coinbase returns the account address that mining rewards are sent to.
-func (am *Manager) Coinbase() (addr []byte, err error) {
-	// TODO: persist coinbase address on disk
-	return am.firstAddr()
-}
-
-func (am *Manager) firstAddr() ([]byte, error) {
+func (am *Manager) Primary() (addr []byte, err error) {
 	addrs, err := am.keyStore.GetKeyAddresses()
 	if os.IsNotExist(err) {
 		return nil, ErrNoKeys

--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -221,6 +221,7 @@ JavaScript API. See https://github.com/ethereum/go-ethereum/wiki/Javascipt-Conso
 		utils.LogJSONFlag,
 		utils.LogLevelFlag,
 		utils.MaxPeersFlag,
+		utils.EtherbaseFlag,
 		utils.MinerThreadsFlag,
 		utils.MiningEnabledFlag,
 		utils.NATFlag,
@@ -322,10 +323,10 @@ func startEth(ctx *cli.Context, eth *eth.Ethereum) {
 
 	account := ctx.GlobalString(utils.UnlockedAccountFlag.Name)
 	if len(account) > 0 {
-		if account == "coinbase" {
-			accbytes, err := am.Coinbase()
+		if account == "primary" {
+			accbytes, err := am.Primary()
 			if err != nil {
-				utils.Fatalf("no coinbase account: %v", err)
+				utils.Fatalf("no primary account: %v", err)
 			}
 			account = common.ToHex(accbytes)
 		}
@@ -468,7 +469,6 @@ func dump(ctx *cli.Context) {
 		} else {
 			statedb := state.New(block.Root(), stateDb)
 			fmt.Printf("%s\n", statedb.Dump())
-			// fmt.Println(block)
 		}
 	}
 }

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -96,10 +96,15 @@ var (
 		Name:  "mine",
 		Usage: "Enable mining",
 	}
+	EtherbaseFlag = cli.StringFlag{
+		Name:  "Etherbase",
+		Usage: "public address for block mining rewards. By default the address of your primary account is used",
+		Value: "primary",
+	}
 
 	UnlockedAccountFlag = cli.StringFlag{
 		Name:  "unlock",
-		Usage: "unlock the account given until this program exits (prompts for password). '--unlock coinbase' unlocks the primary (coinbase) account",
+		Usage: "unlock the account given until this program exits (prompts for password). '--unlock primary' unlocks the primary account",
 		Value: "",
 	}
 	PasswordFileFlag = cli.StringFlag{
@@ -215,6 +220,7 @@ func MakeEthConfig(clientID, version string, ctx *cli.Context) *eth.Config {
 		LogFile:         ctx.GlobalString(LogFileFlag.Name),
 		LogLevel:        ctx.GlobalInt(LogLevelFlag.Name),
 		LogJSON:         ctx.GlobalString(LogJSONFlag.Name),
+		Etherbase:       ctx.GlobalString(EtherbaseFlag.Name),
 		MinerThreads:    ctx.GlobalInt(MinerThreadsFlag.Name),
 		AccountManager:  GetAccountManager(ctx),
 		VmDebug:         ctx.GlobalBool(VMDebugFlag.Name),

--- a/xeth/xeth.go
+++ b/xeth/xeth.go
@@ -250,8 +250,8 @@ func (self *XEth) IsListening() bool {
 }
 
 func (self *XEth) Coinbase() string {
-	cb, _ := self.backend.AccountManager().Coinbase()
-	return common.ToHex(cb)
+	eb, _ := self.backend.Etherbase()
+	return eb.Hex()
 }
 
 func (self *XEth) NumberToHuman(balance string) string {


### PR DESCRIPTION
- etherbase flag for block reward destination
- coinbase => etherbase
- CLI- eth Config -> eth, xeth -> RPC / Miner
- use primary instead of coinbase as the unlock magic wildcard
- accounts: firstAddr/Coinbase -> Primary

cont'd from #550 #541 
https://github.com/ethereum/go-ethereum/wiki/Managing-your-accounts
system testing: https://github.com/ethereum/system-testing/pull/61