### PR TITLE
Frontier/sec 29

### DIFF
--- a/core/types/block.go
+++ b/core/types/block.go
@@ -148,22 +148,19 @@ func NewBlockWithHeader(header *Header) *Block {
 	return &Block{header: header}
 }
 
-func (self *Block) Validate() error {
+func (self *Block) ValidateFields() error {
 	if self.header == nil {
 		return fmt.Errorf("header is nil")
 	}
-	// check *big.Int fields
-	if self.header.Difficulty == nil {
-		return fmt.Errorf("Difficulty undefined")
+	for i, transaction := range self.transactions {
+		if transaction == nil {
+			return fmt.Errorf("transaction %d is nil", i)
+		}
 	}
-	if self.header.GasLimit == nil {
-		return fmt.Errorf("GasLimit undefined")
-	}
-	if self.header.GasUsed == nil {
-		return fmt.Errorf("GasUsed undefined")
-	}
-	if self.header.Number == nil {
-		return fmt.Errorf("Number undefined")
+	for i, uncle := range self.uncles {
+		if uncle == nil {
+			return fmt.Errorf("uncle %d is nil", i)
+		}
 	}
 	return nil
 }
@@ -253,10 +250,10 @@ func (self *Block) AddReceipt(receipt *Receipt) {
 }
 
 func (self *Block) RlpData() interface{} {
-	return []interface{}{self.header, self.transactions, self.uncles}
-}
+	// 	return []interface{}{self.header, self.transactions, self.uncles}
+	// }
 
-func (self *Block) RlpDataForStorage() interface{} {
+	// func (self *Block) RlpDataForStorage() interface{} {
 	return []interface{}{self.header, self.transactions, self.uncles, self.Td /* TODO receipts */}
 }
 

--- a/core/types/block.go
+++ b/core/types/block.go
@@ -148,6 +148,26 @@ func NewBlockWithHeader(header *Header) *Block {
 	return &Block{header: header}
 }
 
+func (self *Block) Validate() error {
+	if self.header == nil {
+		return fmt.Errorf("header is nil")
+	}
+	// check *big.Int fields
+	if self.header.Difficulty == nil {
+		return fmt.Errorf("Difficulty undefined")
+	}
+	if self.header.GasLimit == nil {
+		return fmt.Errorf("GasLimit undefined")
+	}
+	if self.header.GasUsed == nil {
+		return fmt.Errorf("GasUsed undefined")
+	}
+	if self.header.Number == nil {
+		return fmt.Errorf("Number undefined")
+	}
+	return nil
+}
+
 func (self *Block) DecodeRLP(s *rlp.Stream) error {
 	var eb extblock
 	if err := s.Decode(&eb); err != nil {

--- a/core/types/block.go
+++ b/core/types/block.go
@@ -250,10 +250,10 @@ func (self *Block) AddReceipt(receipt *Receipt) {
 }
 
 func (self *Block) RlpData() interface{} {
-	// 	return []interface{}{self.header, self.transactions, self.uncles}
-	// }
+	return []interface{}{self.header, self.transactions, self.uncles}
+}
 
-	// func (self *Block) RlpDataForStorage() interface{} {
+func (self *Block) RlpDataForStorage() interface{} {
 	return []interface{}{self.header, self.transactions, self.uncles, self.Td /* TODO receipts */}
 }
 

--- a/eth/protocol.go
+++ b/eth/protocol.go
@@ -185,7 +185,10 @@ func (self *ethProtocol) handle() error {
 		if err := msg.Decode(&txs); err != nil {
 			return self.protoError(ErrDecode, "msg %v: %v", msg, err)
 		}
-		for _, tx := range txs {
+		for i, tx := range txs {
+			if tx == nil {
+				return self.protoError(ErrDecode, "transaction %d is nil", i)
+			}
 			jsonlogger.LogJson(&logger.EthTxReceived{
 				TxHash:   tx.Hash().Hex(),
 				RemoteId: self.peer.ID().String(),

--- a/eth/protocol.go
+++ b/eth/protocol.go
@@ -268,6 +268,9 @@ func (self *ethProtocol) handle() error {
 					return self.protoError(ErrDecode, "msg %v: %v", msg, err)
 				}
 			}
+			if err := block.ValidateFields(); err != nil {
+				return self.protoError(ErrDecode, "block validation %v: %v", msg, err)
+			}
 			self.blockPool.AddBlock(&block, self.id)
 		}
 
@@ -276,7 +279,7 @@ func (self *ethProtocol) handle() error {
 		if err := msg.Decode(&request); err != nil {
 			return self.protoError(ErrDecode, "%v: %v", msg, err)
 		}
-		if err := request.Block.Validate(); err != nil {
+		if err := request.Block.ValidateFields(); err != nil {
 			return self.protoError(ErrDecode, "block validation %v: %v", msg, err)
 		}
 		hash := request.Block.Hash()

--- a/eth/protocol.go
+++ b/eth/protocol.go
@@ -105,7 +105,7 @@ type getBlockHashesMsgData struct {
 type statusMsgData struct {
 	ProtocolVersion uint32
 	NetworkId       uint32
-	TD              big.Int
+	TD              *big.Int
 	CurrentBlock    common.Hash
 	GenesisBlock    common.Hash
 }
@@ -344,7 +344,7 @@ func (self *ethProtocol) handleStatus() error {
 		return self.protoError(ErrProtocolVersionMismatch, "%d (!= %d)", status.ProtocolVersion, self.protocolVersion)
 	}
 
-	_, suspended := self.blockPool.AddPeer(&status.TD, status.CurrentBlock, self.id, self.requestBlockHashes, self.requestBlocks, self.protoErrorDisconnect)
+	_, suspended := self.blockPool.AddPeer(status.TD, status.CurrentBlock, self.id, self.requestBlockHashes, self.requestBlocks, self.protoErrorDisconnect)
 	if suspended {
 		return self.protoError(ErrSuspendedPeer, "")
 	}
@@ -375,7 +375,7 @@ func (self *ethProtocol) sendStatus() error {
 	return p2p.Send(self.rw, StatusMsg, &statusMsgData{
 		ProtocolVersion: uint32(self.protocolVersion),
 		NetworkId:       uint32(self.networkId),
-		TD:              *td,
+		TD:              td,
 		CurrentBlock:    currentBlock,
 		GenesisBlock:    genesisBlock,
 	})

--- a/eth/protocol_test.go
+++ b/eth/protocol_test.go
@@ -173,7 +173,7 @@ func (self *ethProtocolTester) handshake(t *testing.T, mock bool) {
 	err := p2p.ExpectMsg(self, StatusMsg, &statusMsgData{
 		ProtocolVersion: ProtocolVersion,
 		NetworkId:       NetworkId,
-		TD:              *td,
+		TD:              td,
 		CurrentBlock:    currentBlock,
 		GenesisBlock:    genesis,
 	})
@@ -181,7 +181,7 @@ func (self *ethProtocolTester) handshake(t *testing.T, mock bool) {
 		t.Fatalf("incorrect outgoing status: %v", err)
 	}
 	if mock {
-		go p2p.Send(self, StatusMsg, &statusMsgData{ProtocolVersion, NetworkId, *td, currentBlock, genesis})
+		go p2p.Send(self, StatusMsg, &statusMsgData{ProtocolVersion, NetworkId, td, currentBlock, genesis})
 	}
 }
 
@@ -201,15 +201,15 @@ func TestStatusMsgErrors(t *testing.T) {
 			wantErrorCode: ErrNoStatusMsg,
 		},
 		{
-			code: StatusMsg, data: statusMsgData{10, NetworkId, *td, currentBlock, genesis},
+			code: StatusMsg, data: statusMsgData{10, NetworkId, td, currentBlock, genesis},
 			wantErrorCode: ErrProtocolVersionMismatch,
 		},
 		{
-			code: StatusMsg, data: statusMsgData{ProtocolVersion, 999, *td, currentBlock, genesis},
+			code: StatusMsg, data: statusMsgData{ProtocolVersion, 999, td, currentBlock, genesis},
 			wantErrorCode: ErrNetworkIdMismatch,
 		},
 		{
-			code: StatusMsg, data: statusMsgData{ProtocolVersion, NetworkId, *td, currentBlock, common.Hash{3}},
+			code: StatusMsg, data: statusMsgData{ProtocolVersion, NetworkId, td, currentBlock, common.Hash{3}},
 			wantErrorCode: ErrGenesisBlockMismatch,
 		},
 	}


### PR DESCRIPTION
I confirm #506 
Simply because by sending empty payload new block massages you can take down the client, this was a massive vulnarability. 
I am adding message data validations and tests.

- [x] NewBlockMsg
- [x] StatusMsg
- [x] BlocksMsg
- [x] BlockHashesMsg
- [x] TxMsg