### PR TITLE
Discovery bonding protocol

### DIFF
--- a/eth/backend.go
+++ b/eth/backend.go
@@ -32,8 +32,8 @@ var (
 	defaultBootNodes = []*discover.Node{
 		// ETH/DEV cmd/bootnode
 		discover.MustParseNode("enode://09fbeec0d047e9a37e63f60f8618aa9df0e49271f3fadb2c070dc09e2099b95827b63a8b837c6fd01d0802d457dd83e3bd48bd3e6509f8209ed90dabbc30e3d3@52.16.188.185:30303"),
-		// ETH/DEV cpp-ethereum (poc-8.ethdev.com)
-		discover.MustParseNode("enode://4a44599974518ea5b0f14c31c4463692ac0329cb84851f3435e6d1b18ee4eae4aa495f846a0fa1219bd58035671881d44423876e57db2abd57254d0197da0ebe@5.1.83.226:30303"),
+		// ETH/DEV cpp-ethereum (poc-9.ethdev.com)
+		discover.MustParseNode("enode://487611428e6c99a11a9795a6abe7b529e81315ca6aad66e2a2fc76e3adf263faba0d35466c2f8f68d561dbefa8878d4df5f1f2ddb1fbeab7f42ffb8cd328bd4a@5.1.83.226:30303"),
 	}
 )
 

--- a/p2p/discover/table.go
+++ b/p2p/discover/table.go
@@ -328,7 +328,7 @@ func (b *bucket) bump(n *Node) bool {
 		if b.entries[i].ID == n.ID {
 			n.bumpActive()
 			// move it to the front
-			copy(b.entries[1:], b.entries[:i+1])
+			copy(b.entries[1:], b.entries[:i])
 			b.entries[0] = n
 			return true
 		}

--- a/p2p/discover/table.go
+++ b/p2p/discover/table.go
@@ -14,9 +14,10 @@ import (
 )
 
 const (
-	alpha      = 3              // Kademlia concurrency factor
-	bucketSize = 16             // Kademlia bucket size
-	nBuckets   = nodeIDBits + 1 // Number of buckets
+	alpha               = 3              // Kademlia concurrency factor
+	bucketSize          = 16             // Kademlia bucket size
+	nBuckets            = nodeIDBits + 1 // Number of buckets
+	maxBondingPingPongs = 10
 )
 
 type Table struct {
@@ -24,27 +25,50 @@ type Table struct {
 	buckets [nBuckets]*bucket // index of known nodes by distance
 	nursery []*Node           // bootstrap nodes
 
+	bondmu    sync.Mutex
+	bonding   map[NodeID]*bondproc
+	bondslots chan struct{} // limits total number of active bonding processes
+
 	net  transport
 	self *Node // metadata of the local node
+	db   *nodeDB
+}
+
+type bondproc struct {
+	err  error
+	n    *Node
+	done chan struct{}
 }
 
 // transport is implemented by the UDP transport.
 // it is an interface so we can test without opening lots of UDP
 // sockets and without generating a private key.
 type transport interface {
-	ping(*Node) error
-	findnode(e *Node, target NodeID) ([]*Node, error)
+	ping(NodeID, *net.UDPAddr) error
+	waitping(NodeID) error
+	findnode(toid NodeID, addr *net.UDPAddr, target NodeID) ([]*Node, error)
 	close()
 }
 
 // bucket contains nodes, ordered by their last activity.
+// the entry that was most recently active is the last element
+// in entries.
 type bucket struct {
 	lastLookup time.Time
 	entries    []*Node
 }
 
 func newTable(t transport, ourID NodeID, ourAddr *net.UDPAddr) *Table {
-	tab := &Table{net: t, self: newNode(ourID, ourAddr)}
+	tab := &Table{
+		net:       t,
+		db:        new(nodeDB),
+		self:      newNode(ourID, ourAddr),
+		bonding:   make(map[NodeID]*bondproc),
+		bondslots: make(chan struct{}, maxBondingPingPongs),
+	}
+	for i := 0; i < cap(tab.bondslots); i++ {
+		tab.bondslots <- struct{}{}
+	}
 	for i := range tab.buckets {
 		tab.buckets[i] = new(bucket)
 	}
@@ -107,8 +131,8 @@ func (tab *Table) Lookup(target NodeID) []*Node {
 				asked[n.ID] = true
 				pendingQueries++
 				go func() {
-					result, _ := tab.net.findnode(n, target)
-					reply <- result
+					r, _ := tab.net.findnode(n.ID, n.addr(), target)
+					reply <- tab.bondall(r)
 				}()
 			}
 		}
@@ -116,13 +140,11 @@ func (tab *Table) Lookup(target NodeID) []*Node {
 			// we have asked all closest nodes, stop the search
 			break
 		}
-
 		// wait for the next reply
 		for _, n := range <-reply {
-			cn := n
-			if !seen[n.ID] {
+			if n != nil && !seen[n.ID] {
 				seen[n.ID] = true
-				result.push(cn, bucketSize)
+				result.push(n, bucketSize)
 			}
 		}
 		pendingQueries--
@@ -145,8 +167,9 @@ func (tab *Table) refresh() {
 	result := tab.Lookup(randomID(tab.self.ID, ld))
 	if len(result) == 0 {
 		// bootstrap the table with a self lookup
+		all := tab.bondall(tab.nursery)
 		tab.mutex.Lock()
-		tab.add(tab.nursery)
+		tab.add(all)
 		tab.mutex.Unlock()
 		tab.Lookup(tab.self.ID)
 		// TODO: the Kademlia paper says that we're supposed to perform
@@ -176,45 +199,105 @@ func (tab *Table) len() (n int) {
 	return n
 }
 
-// bumpOrAdd updates the activity timestamp for the given node and
-// attempts to insert the node into a bucket. The returned Node might
-// not be part of the table. The caller must hold tab.mutex.
-func (tab *Table) bumpOrAdd(node NodeID, from *net.UDPAddr) (n *Node) {
-	b := tab.buckets[logdist(tab.self.ID, node)]
-	if n = b.bump(node); n == nil {
-		n = newNode(node, from)
-		if len(b.entries) == bucketSize {
-			tab.pingReplace(n, b)
-		} else {
-			b.entries = append(b.entries, n)
+// bondall bonds with all given nodes concurrently and returns
+// those nodes for which bonding has probably succeeded.
+func (tab *Table) bondall(nodes []*Node) (result []*Node) {
+	rc := make(chan *Node, len(nodes))
+	for i := range nodes {
+		go func(n *Node) {
+			nn, _ := tab.bond(false, n.ID, n.addr(), uint16(n.TCPPort))
+			rc <- nn
+		}(nodes[i])
+	}
+	for _ = range nodes {
+		if n := <-rc; n != nil {
+			result = append(result, n)
 		}
 	}
-	return n
+	return result
 }
 
-func (tab *Table) pingReplace(n *Node, b *bucket) {
-	old := b.entries[bucketSize-1]
-	go func() {
-		if err := tab.net.ping(old); err == nil {
-			// it responded, we don't need to replace it.
+// bond ensures the local node has a bond with the given remote node.
+// It also attempts to insert the node into the table if bonding succeeds.
+// The caller must not hold tab.mutex.
+//
+// A bond is must be established before sending findnode requests.
+// Both sides must have completed a ping/pong exchange for a bond to
+// exist. The total number of active bonding processes is limited in
+// order to restrain network use.
+//
+// bond is meant to operate idempotently in that bonding with a remote
+// node which still remembers a previously established bond will work.
+// The remote node will simply not send a ping back, causing waitping
+// to time out.
+//
+// If pinged is true, the remote node has just pinged us and one half
+// of the process can be skipped.
+func (tab *Table) bond(pinged bool, id NodeID, addr *net.UDPAddr, tcpPort uint16) (*Node, error) {
+	var n *Node
+	if n = tab.db.get(id); n == nil {
+		tab.bondmu.Lock()
+		w := tab.bonding[id]
+		if w != nil {
+			// Wait for an existing bonding process to complete.
+			tab.bondmu.Unlock()
+			<-w.done
+		} else {
+			// Register a new bonding process.
+			w = &bondproc{done: make(chan struct{})}
+			tab.bonding[id] = w
+			tab.bondmu.Unlock()
+			// Do the ping/pong. The result goes into w.
+			tab.pingpong(w, pinged, id, addr, tcpPort)
+			// Unregister the process after it's done.
+			tab.bondmu.Lock()
+			delete(tab.bonding, id)
+			tab.bondmu.Unlock()
+		}
+		n = w.n
+		if w.err != nil {
+			return nil, w.err
+		}
+	}
+	tab.mutex.Lock()
+	defer tab.mutex.Unlock()
+	if b := tab.buckets[logdist(tab.self.ID, n.ID)]; !b.bump(n) {
+		tab.pingreplace(n, b)
+	}
+	return n, nil
+}
+
+func (tab *Table) pingpong(w *bondproc, pinged bool, id NodeID, addr *net.UDPAddr, tcpPort uint16) {
+	<-tab.bondslots
+	defer func() { tab.bondslots <- struct{}{} }()
+	if w.err = tab.net.ping(id, addr); w.err != nil {
+		close(w.done)
+		return
+	}
+	if !pinged {
+		// Give the remote node a chance to ping us before we start
+		// sending findnode requests. If they still remember us,
+		// waitping will simply time out.
+		tab.net.waitping(id)
+	}
+	w.n = tab.db.add(id, addr, tcpPort)
+	close(w.done)
+}
+
+func (tab *Table) pingreplace(new *Node, b *bucket) {
+	if len(b.entries) == bucketSize {
+		oldest := b.entries[bucketSize-1]
+		if err := tab.net.ping(oldest.ID, oldest.addr()); err == nil {
+			// The node responded, we don't need to replace it.
 			return
 		}
-		// it didn't respond, replace the node if it is still the oldest node.
-		tab.mutex.Lock()
-		if len(b.entries) > 0 && b.entries[len(b.entries)-1] == old {
-			// slide down other entries and put the new one in front.
-			// TODO: insert in correct position to keep the order
-			copy(b.entries[1:], b.entries)
-			b.entries[0] = n
-		}
-		tab.mutex.Unlock()
-	}()
-}
-
-// bump updates the activity timestamp for the given node.
-// The caller must hold tab.mutex.
-func (tab *Table) bump(node NodeID) {
-	tab.buckets[logdist(tab.self.ID, node)].bump(node)
+	} else {
+		// Add a slot at the end so the last entry doesn't
+		// fall off when adding the new node.
+		b.entries = append(b.entries, nil)
+	}
+	copy(b.entries[1:], b.entries)
+	b.entries[0] = new
 }
 
 // add puts the entries into the table if their corresponding
@@ -240,17 +323,17 @@ outer:
 	}
 }
 
-func (b *bucket) bump(id NodeID) *Node {
-	for i, n := range b.entries {
-		if n.ID == id {
-			n.active = time.Now()
+func (b *bucket) bump(n *Node) bool {
+	for i := range b.entries {
+		if b.entries[i].ID == n.ID {
+			n.bumpActive()
 			// move it to the front
 			copy(b.entries[1:], b.entries[:i+1])
 			b.entries[0] = n
-			return n
+			return true
 		}
 	}
-	return nil
+	return false
 }
 
 // nodesByDistance is a list of nodes, ordered by

--- a/p2p/discover/udp.go
+++ b/p2p/discover/udp.go
@@ -20,12 +20,14 @@ const Version = 3
 
 // Errors
 var (
-	errPacketTooSmall = errors.New("too small")
-	errBadHash        = errors.New("bad hash")
-	errExpired        = errors.New("expired")
-	errBadVersion     = errors.New("version mismatch")
-	errTimeout        = errors.New("RPC timeout")
-	errClosed         = errors.New("socket closed")
+	errPacketTooSmall   = errors.New("too small")
+	errBadHash          = errors.New("bad hash")
+	errExpired          = errors.New("expired")
+	errBadVersion       = errors.New("version mismatch")
+	errUnsolicitedReply = errors.New("unsolicited reply")
+	errUnknownNode      = errors.New("unknown node")
+	errTimeout          = errors.New("RPC timeout")
+	errClosed           = errors.New("socket closed")
 )
 
 // Timeouts
@@ -80,14 +82,27 @@ type rpcNode struct {
 	ID   NodeID
 }
 
+type packet interface {
+	handle(t *udp, from *net.UDPAddr, fromID NodeID, mac []byte) error
+}
+
+type conn interface {
+	ReadFromUDP(b []byte) (n int, addr *net.UDPAddr, err error)
+	WriteToUDP(b []byte, addr *net.UDPAddr) (n int, err error)
+	Close() error
+	LocalAddr() net.Addr
+}
+
 // udp implements the RPC protocol.
 type udp struct {
-	conn       *net.UDPConn
-	priv       *ecdsa.PrivateKey
+	conn conn
+	priv *ecdsa.PrivateKey
+
 	addpending chan *pending
-	replies    chan reply
-	closing    chan struct{}
-	nat        nat.Interface
+	gotreply   chan reply
+
+	closing chan struct{}
+	nat     nat.Interface
 
 	*Table
 }
@@ -124,6 +139,9 @@ type reply struct {
 	from  NodeID
 	ptype byte
 	data  interface{}
+	// loop indicates whether there was
+	// a matching request by sending on this channel.
+	matched chan<- bool
 }
 
 // ListenUDP returns a new table that listens for UDP packets on laddr.
@@ -136,15 +154,20 @@ func ListenUDP(priv *ecdsa.PrivateKey, laddr string, natm nat.Interface) (*Table
 	if err != nil {
 		return nil, err
 	}
+	tab, _ := newUDP(priv, conn, natm)
+	log.Infoln("Listening,", tab.self)
+	return tab, nil
+}
+
+func newUDP(priv *ecdsa.PrivateKey, c conn, natm nat.Interface) (*Table, *udp) {
 	udp := &udp{
-		conn:       conn,
+		conn:       c,
 		priv:       priv,
 		closing:    make(chan struct{}),
+		gotreply:   make(chan reply),
 		addpending: make(chan *pending),
-		replies:    make(chan reply),
 	}
-
-	realaddr := conn.LocalAddr().(*net.UDPAddr)
+	realaddr := c.LocalAddr().(*net.UDPAddr)
 	if natm != nil {
 		if !realaddr.IP.IsLoopback() {
 			go nat.Map(natm, udp.closing, "udp", realaddr.Port, realaddr.Port, "ethereum discovery")
@@ -155,11 +178,9 @@ func ListenUDP(priv *ecdsa.PrivateKey, laddr string, natm nat.Interface) (*Table
 		}
 	}
 	udp.Table = newTable(udp, PubkeyID(&priv.PublicKey), realaddr)
-
 	go udp.loop()
 	go udp.readLoop()
-	log.Infoln("Listening, ", udp.self)
-	return udp.Table, nil
+	return udp.Table, udp
 }
 
 func (t *udp) close() {
@@ -169,10 +190,10 @@ func (t *udp) close() {
 }
 
 // ping sends a ping message to the given node and waits for a reply.
-func (t *udp) ping(e *Node) error {
+func (t *udp) ping(toid NodeID, toaddr *net.UDPAddr) error {
 	// TODO: maybe check for ReplyTo field in callback to measure RTT
-	errc := t.pending(e.ID, pongPacket, func(interface{}) bool { return true })
-	t.send(e, pingPacket, ping{
+	errc := t.pending(toid, pongPacket, func(interface{}) bool { return true })
+	t.send(toaddr, pingPacket, ping{
 		Version:    Version,
 		IP:         t.self.IP.String(),
 		Port:       uint16(t.self.TCPPort),
@@ -181,12 +202,16 @@ func (t *udp) ping(e *Node) error {
 	return <-errc
 }
 
+func (t *udp) waitping(from NodeID) error {
+	return <-t.pending(from, pingPacket, func(interface{}) bool { return true })
+}
+
 // findnode sends a findnode request to the given node and waits until
 // the node has sent up to k neighbors.
-func (t *udp) findnode(to *Node, target NodeID) ([]*Node, error) {
+func (t *udp) findnode(toid NodeID, toaddr *net.UDPAddr, target NodeID) ([]*Node, error) {
 	nodes := make([]*Node, 0, bucketSize)
 	nreceived := 0
-	errc := t.pending(to.ID, neighborsPacket, func(r interface{}) bool {
+	errc := t.pending(toid, neighborsPacket, func(r interface{}) bool {
 		reply := r.(*neighbors)
 		for _, n := range reply.Nodes {
 			nreceived++
@@ -196,8 +221,7 @@ func (t *udp) findnode(to *Node, target NodeID) ([]*Node, error) {
 		}
 		return nreceived >= bucketSize
 	})
-
-	t.send(to, findnodePacket, findnode{
+	t.send(toaddr, findnodePacket, findnode{
 		Target:     target,
 		Expiration: uint64(time.Now().Add(expiration).Unix()),
 	})
@@ -217,6 +241,17 @@ func (t *udp) pending(id NodeID, ptype byte, callback func(interface{}) bool) <-
 		ch <- errClosed
 	}
 	return ch
+}
+
+func (t *udp) handleReply(from NodeID, ptype byte, req packet) bool {
+	matched := make(chan bool)
+	select {
+	case t.gotreply <- reply{from, ptype, req, matched}:
+		// loop will handle it
+		return <-matched
+	case <-t.closing:
+		return false
+	}
 }
 
 // loop runs in its own goroutin. it keeps track of
@@ -249,6 +284,7 @@ func (t *udp) loop() {
 			for _, p := range pending {
 				p.errc <- errClosed
 			}
+			pending = nil
 			return
 
 		case p := <-t.addpending:
@@ -256,18 +292,21 @@ func (t *udp) loop() {
 			pending = append(pending, p)
 			rearmTimeout()
 
-		case reply := <-t.replies:
-			// run matching callbacks, remove if they return false.
+		case r := <-t.gotreply:
+			var matched bool
 			for i := 0; i < len(pending); i++ {
-				p := pending[i]
-				if reply.from == p.from && reply.ptype == p.ptype && p.callback(reply.data) {
-					p.errc <- nil
-					copy(pending[i:], pending[i+1:])
-					pending = pending[:len(pending)-1]
-					i--
+				if p := pending[i]; p.from == r.from && p.ptype == r.ptype {
+					matched = true
+					if p.callback(r.data) {
+						// callback indicates the request is done, remove it.
+						p.errc <- nil
+						copy(pending[i:], pending[i+1:])
+						pending = pending[:len(pending)-1]
+						i--
+					}
 				}
 			}
-			rearmTimeout()
+			r.matched <- matched
 
 		case now := <-timeout.C:
 			// notify and remove callbacks whose deadline is in the past.
@@ -292,33 +331,38 @@ const (
 
 var headSpace = make([]byte, headSize)
 
-func (t *udp) send(to *Node, ptype byte, req interface{}) error {
-	b := new(bytes.Buffer)
-	b.Write(headSpace)
-	b.WriteByte(ptype)
-	if err := rlp.Encode(b, req); err != nil {
-		log.Errorln("error encoding packet:", err)
-		return err
-	}
-
-	packet := b.Bytes()
-	sig, err := crypto.Sign(crypto.Sha3(packet[headSize:]), t.priv)
+func (t *udp) send(toaddr *net.UDPAddr, ptype byte, req interface{}) error {
+	packet, err := encodePacket(t.priv, ptype, req)
 	if err != nil {
-		log.Errorln("could not sign packet:", err)
 		return err
 	}
-	copy(packet[macSize:], sig)
-	// add the hash to the front. Note: this doesn't protect the
-	// packet in any way. Our public key will be part of this hash in
-	// the future.
-	copy(packet, crypto.Sha3(packet[macSize:]))
-
-	toaddr := &net.UDPAddr{IP: to.IP, Port: to.DiscPort}
 	log.DebugDetailf(">>> %v %T %v\n", toaddr, req, req)
 	if _, err = t.conn.WriteToUDP(packet, toaddr); err != nil {
 		log.DebugDetailln("UDP send failed:", err)
 	}
 	return err
+}
+
+func encodePacket(priv *ecdsa.PrivateKey, ptype byte, req interface{}) ([]byte, error) {
+	b := new(bytes.Buffer)
+	b.Write(headSpace)
+	b.WriteByte(ptype)
+	if err := rlp.Encode(b, req); err != nil {
+		log.Errorln("error encoding packet:", err)
+		return nil, err
+	}
+	packet := b.Bytes()
+	sig, err := crypto.Sign(crypto.Sha3(packet[headSize:]), priv)
+	if err != nil {
+		log.Errorln("could not sign packet:", err)
+		return nil, err
+	}
+	copy(packet[macSize:], sig)
+	// add the hash to the front. Note: this doesn't protect the
+	// packet in any way. Our public key will be part of this hash in
+	// The future.
+	copy(packet, crypto.Sha3(packet[macSize:]))
+	return packet, nil
 }
 
 // readLoop runs in its own goroutine. it handles incoming UDP packets.
@@ -330,29 +374,34 @@ func (t *udp) readLoop() {
 		if err != nil {
 			return
 		}
-		if err := t.packetIn(from, buf[:nbytes]); err != nil {
+		packet, fromID, hash, err := decodePacket(buf[:nbytes])
+		if err != nil {
 			log.Debugf("Bad packet from %v: %v\n", from, err)
+			continue
 		}
+		log.DebugDetailf("<<< %v %T %v\n", from, packet, packet)
+		go func() {
+			if err := packet.handle(t, from, fromID, hash); err != nil {
+				log.Debugf("error handling %T from %v: %v", packet, from, err)
+			}
+		}()
 	}
 }
 
-func (t *udp) packetIn(from *net.UDPAddr, buf []byte) error {
+func decodePacket(buf []byte) (packet, NodeID, []byte, error) {
 	if len(buf) < headSize+1 {
-		return errPacketTooSmall
+		return nil, NodeID{}, nil, errPacketTooSmall
 	}
 	hash, sig, sigdata := buf[:macSize], buf[macSize:headSize], buf[headSize:]
 	shouldhash := crypto.Sha3(buf[macSize:])
 	if !bytes.Equal(hash, shouldhash) {
-		return errBadHash
+		return nil, NodeID{}, nil, errBadHash
 	}
 	fromID, err := recoverNodeID(crypto.Sha3(buf[headSize:]), sig)
 	if err != nil {
-		return err
+		return nil, NodeID{}, hash, err
 	}
-
-	var req interface {
-		handle(t *udp, from *net.UDPAddr, fromID NodeID, mac []byte) error
-	}
+	var req packet
 	switch ptype := sigdata[0]; ptype {
 	case pingPacket:
 		req = new(ping)
@@ -363,13 +412,10 @@ func (t *udp) packetIn(from *net.UDPAddr, buf []byte) error {
 	case neighborsPacket:
 		req = new(neighbors)
 	default:
-		return fmt.Errorf("unknown type: %d", ptype)
+		return nil, fromID, hash, fmt.Errorf("unknown type: %d", ptype)
 	}
-	if err := rlp.Decode(bytes.NewReader(sigdata[1:]), req); err != nil {
-		return err
-	}
-	log.DebugDetailf("<<< %v %T %v\n", from, req, req)
-	return req.handle(t, from, fromID, hash)
+	err = rlp.Decode(bytes.NewReader(sigdata[1:]), req)
+	return req, fromID, hash, err
 }
 
 func (req *ping) handle(t *udp, from *net.UDPAddr, fromID NodeID, mac []byte) error {
@@ -379,18 +425,14 @@ func (req *ping) handle(t *udp, from *net.UDPAddr, fromID NodeID, mac []byte) er
 	if req.Version != Version {
 		return errBadVersion
 	}
-	t.mutex.Lock()
-	// Note: we're ignoring the provided IP address right now
-	n := t.bumpOrAdd(fromID, from)
-	if req.Port != 0 {
-		n.TCPPort = int(req.Port)
-	}
-	t.mutex.Unlock()
-
-	t.send(n, pongPacket, pong{
+	t.send(from, pongPacket, pong{
 		ReplyTok:   mac,
 		Expiration: uint64(time.Now().Add(expiration).Unix()),
 	})
+	if !t.handleReply(fromID, pingPacket, req) {
+		// Note: we're ignoring the provided IP address right now
+		t.bond(true, fromID, from, req.Port)
+	}
 	return nil
 }
 
@@ -398,11 +440,9 @@ func (req *pong) handle(t *udp, from *net.UDPAddr, fromID NodeID, mac []byte) er
 	if expired(req.Expiration) {
 		return errExpired
 	}
-	t.mutex.Lock()
-	t.bump(fromID)
-	t.mutex.Unlock()
-
-	t.replies <- reply{fromID, pongPacket, req}
+	if !t.handleReply(fromID, pongPacket, req) {
+		return errUnsolicitedReply
+	}
 	return nil
 }
 
@@ -410,12 +450,21 @@ func (req *findnode) handle(t *udp, from *net.UDPAddr, fromID NodeID, mac []byte
 	if expired(req.Expiration) {
 		return errExpired
 	}
+	if t.db.get(fromID) == nil {
+		// No bond exists, we don't process the packet. This prevents
+		// an attack vector where the discovery protocol could be used
+		// to amplify traffic in a DDOS attack. A malicious actor
+		// would send a findnode request with the IP address and UDP
+		// port of the target as the source address. The recipient of
+		// the findnode packet would then send a neighbors packet
+		// (which is a much bigger packet than findnode) to the victim.
+		return errUnknownNode
+	}
 	t.mutex.Lock()
-	e := t.bumpOrAdd(fromID, from)
 	closest := t.closest(req.Target, bucketSize).entries
 	t.mutex.Unlock()
 
-	t.send(e, neighborsPacket, neighbors{
+	t.send(from, neighborsPacket, neighbors{
 		Nodes:      closest,
 		Expiration: uint64(time.Now().Add(expiration).Unix()),
 	})
@@ -426,12 +475,9 @@ func (req *neighbors) handle(t *udp, from *net.UDPAddr, fromID NodeID, mac []byt
 	if expired(req.Expiration) {
 		return errExpired
 	}
-	t.mutex.Lock()
-	t.bump(fromID)
-	t.add(req.Nodes)
-	t.mutex.Unlock()
-
-	t.replies <- reply{fromID, neighborsPacket, req}
+	if !t.handleReply(fromID, neighborsPacket, req) {
+		return errUnsolicitedReply
+	}
 	return nil
 }
 


### PR DESCRIPTION
The discovery protocol now requires a ping/pong exchange before any other requests can be sent.
This is a protective measure to prevent amplification/DDOS attacks which was suggested by security auditors.

cpp-ethereum implements this already and we won't have network interop until this is implemented on our side.