### PR TITLE
fixed printing circular structures

### DIFF
--- a/jsre/pp_js.go
+++ b/jsre/pp_js.go
@@ -2,17 +2,13 @@ package jsre
 
 const pp_js = `
 function pp(object, indent) {
-    var str = "";
-    /*
-    var o = object;
     try {
-	object = JSON.stringify(object)
-	object = JSON.parse(object);
-   } catch(e) {
-	object = o;
-   }
-   */
+        JSON.stringify(object)
+    } catch(e) {
+        return pp(e, indent);
+    }
 
+    var str = "";
     if(object instanceof Array) {
         str += "[";
         for(var i = 0, l = object.length; i < l; i++) {
@@ -24,7 +20,7 @@ function pp(object, indent) {
         }
         str += " ]";
     } else if (object instanceof Error) {
-        str += "\033[31m" + "Error";
+        str += "\033[31m" + "Error:\033[0m " + object.message;
     } else if (isBigNumber(object)) {
         str += "\033[32m'" + object.toString(10) + "'";
     } else if(typeof(object) === "object") {


### PR DESCRIPTION
- fixed printing circular structures. This snippet was crashing command line geth:
```
x = {}
x.a = x
```

- print erros with their message