### PR TITLE
Add path expansion support for command line arguments, closes 567

### DIFF
--- a/cmd/utils/customflags.go
+++ b/cmd/utils/customflags.go
@@ -1,115 +1,118 @@
 package utils
+
 import (
-    "path/filepath"
-    "os"
-    "strings"
-    "os/user"
-    "github.com/codegangsta/cli"
-    "flag"
-    "fmt"
+	"flag"
+	"fmt"
+	"os"
+	"os/user"
+	"path/filepath"
+	"strings"
+
+	"github.com/codegangsta/cli"
 )
 
 // Custom type which is registered in the flags library which cli uses for
 // argument parsing. This allows us to expand Value to an absolute path when
 // the argument is parsed
 type DirectoryString struct {
-    Value string
+	Value string
 }
 
 func (self DirectoryString) String() string {
-    return self.Value
+	return self.Value
 }
 
 func (self DirectoryString) Set(value string) error {
-    self.Value = expandPath(value)
-    return nil
+	self.Value = expandPath(value)
+	return nil
 }
 
 // Custom cli.Flag type which expand the received string to an absolute path.
 // e.g. ~/.ethereum -> /home/username/.ethereum
 type DirectoryFlag struct {
-    cli.GenericFlag
-    Name   string
-    Value  DirectoryString
-    Usage  string
-    EnvVar string
+	cli.GenericFlag
+	Name   string
+	Value  DirectoryString
+	Usage  string
+	EnvVar string
 }
 
 func (self DirectoryFlag) String() string {
-    var fmtString string
-    fmtString = "%s %v\t%v"
+	var fmtString string
+	fmtString = "%s %v\t%v"
 
-    if len(self.Value.Value) > 0 {
-        fmtString = "%s \"%v\"\t%v"
-    } else {
-        fmtString = "%s %v\t%v"
-    }
+	if len(self.Value.Value) > 0 {
+		fmtString = "%s \"%v\"\t%v"
+	} else {
+		fmtString = "%s %v\t%v"
+	}
 
-    return withEnvHint(self.EnvVar, fmt.Sprintf(fmtString, prefixedNames(self.Name), self.Value.Value, self.Usage))
+	return withEnvHint(self.EnvVar, fmt.Sprintf(fmtString, prefixedNames(self.Name), self.Value.Value, self.Usage))
 }
 
 func eachName(longName string, fn func(string)) {
-    parts := strings.Split(longName, ",")
-    for _, name := range parts {
-        name = strings.Trim(name, " ")
-        fn(name)
-    }
+	parts := strings.Split(longName, ",")
+	for _, name := range parts {
+		name = strings.Trim(name, " ")
+		fn(name)
+	}
 }
+
 // called by cli library, grabs variable from environment (if in env)
 // and adds variable to flag set for parsing.
 func (self DirectoryFlag) Apply(set *flag.FlagSet) {
-    if self.EnvVar != "" {
-        for _, envVar := range strings.Split(self.EnvVar, ",") {
-            envVar = strings.TrimSpace(envVar)
-            if envVal := os.Getenv(envVar); envVal != "" {
-                self.Value.Value = envVal
-                break
-            }
-        }
-    }
+	if self.EnvVar != "" {
+		for _, envVar := range strings.Split(self.EnvVar, ",") {
+			envVar = strings.TrimSpace(envVar)
+			if envVal := os.Getenv(envVar); envVal != "" {
+				self.Value.Value = envVal
+				break
+			}
+		}
+	}
 
-    eachName(self.Name, func(name string) {
-        set.Var(self.Value, self.Name, "a: " + self.Usage)
-    })
+	eachName(self.Name, func(name string) {
+		set.Var(self.Value, self.Name, "a: "+self.Usage)
+	})
 
 }
 
 func prefixFor(name string) (prefix string) {
-    if len(name) == 1 {
-        prefix = "-"
-    } else {
-        prefix = "--"
-    }
+	if len(name) == 1 {
+		prefix = "-"
+	} else {
+		prefix = "--"
+	}
 
-    return
+	return
 }
 
 func prefixedNames(fullName string) (prefixed string) {
-    parts := strings.Split(fullName, ",")
-    for i, name := range parts {
-        name = strings.Trim(name, " ")
-        prefixed += prefixFor(name) + name
-        if i < len(parts)-1 {
-            prefixed += ", "
-        }
-    }
-    return
+	parts := strings.Split(fullName, ",")
+	for i, name := range parts {
+		name = strings.Trim(name, " ")
+		prefixed += prefixFor(name) + name
+		if i < len(parts)-1 {
+			prefixed += ", "
+		}
+	}
+	return
 }
 
 func withEnvHint(envVar, str string) string {
-    envText := ""
-    if envVar != "" {
-        envText = fmt.Sprintf(" [$%s]", strings.Join(strings.Split(envVar, ","), ", $"))
-    }
-    return str + envText
+	envText := ""
+	if envVar != "" {
+		envText = fmt.Sprintf(" [$%s]", strings.Join(strings.Split(envVar, ","), ", $"))
+	}
+	return str + envText
 }
 
 func (self DirectoryFlag) getName() string {
-    return self.Name
+	return self.Name
 }
 
 func (self *DirectoryFlag) Set(value string) {
-    self.Value.Value = value
+	self.Value.Value = value
 }
 
 // Expands a file path
@@ -118,16 +121,13 @@ func (self *DirectoryFlag) Set(value string) {
 // 3. cleans the path, e.g. /a/b/../c -> /a/c
 // Note, it has limitations, e.g. ~someuser/tmp will not be expanded
 func expandPath(p string) string {
-    if strings.HasPrefix(p, "~/") || strings.HasPrefix(p, "~\\") {
-        if user, err := user.Current(); err == nil {
-            if err == nil {
-                p = strings.Replace(p, "~", user.HomeDir, 1)
-            }
-        }
-    }
+	if strings.HasPrefix(p, "~/") || strings.HasPrefix(p, "~\\") {
+		if user, err := user.Current(); err == nil {
+			if err == nil {
+				p = strings.Replace(p, "~", user.HomeDir, 1)
+			}
+		}
+	}
 
-    return filepath.Clean(os.ExpandEnv(p))
+	return filepath.Clean(os.ExpandEnv(p))
 }
-
-
-

--- a/cmd/utils/customflags.go
+++ b/cmd/utils/customflags.go
@@ -1,0 +1,133 @@
+package utils
+import (
+    "path/filepath"
+    "os"
+    "strings"
+    "os/user"
+    "github.com/codegangsta/cli"
+    "flag"
+    "fmt"
+)
+
+// Custom type which is registered in the flags library which cli uses for
+// argument parsing. This allows us to expand Value to an absolute path when
+// the argument is parsed
+type DirectoryString struct {
+    Value string
+}
+
+func (self DirectoryString) String() string {
+    return self.Value
+}
+
+func (self DirectoryString) Set(value string) error {
+    self.Value = expandPath(value)
+    return nil
+}
+
+// Custom cli.Flag type which expand the received string to an absolute path.
+// e.g. ~/.ethereum -> /home/username/.ethereum
+type DirectoryFlag struct {
+    cli.GenericFlag
+    Name   string
+    Value  DirectoryString
+    Usage  string
+    EnvVar string
+}
+
+func (self DirectoryFlag) String() string {
+    var fmtString string
+    fmtString = "%s %v\t%v"
+
+    if len(self.Value.Value) > 0 {
+        fmtString = "%s \"%v\"\t%v"
+    } else {
+        fmtString = "%s %v\t%v"
+    }
+
+    return withEnvHint(self.EnvVar, fmt.Sprintf(fmtString, prefixedNames(self.Name), self.Value.Value, self.Usage))
+}
+
+func eachName(longName string, fn func(string)) {
+    parts := strings.Split(longName, ",")
+    for _, name := range parts {
+        name = strings.Trim(name, " ")
+        fn(name)
+    }
+}
+// called by cli library, grabs variable from environment (if in env)
+// and adds variable to flag set for parsing.
+func (self DirectoryFlag) Apply(set *flag.FlagSet) {
+    if self.EnvVar != "" {
+        for _, envVar := range strings.Split(self.EnvVar, ",") {
+            envVar = strings.TrimSpace(envVar)
+            if envVal := os.Getenv(envVar); envVal != "" {
+                self.Value.Value = envVal
+                break
+            }
+        }
+    }
+
+    eachName(self.Name, func(name string) {
+        set.Var(self.Value, self.Name, "a: " + self.Usage)
+    })
+
+}
+
+func prefixFor(name string) (prefix string) {
+    if len(name) == 1 {
+        prefix = "-"
+    } else {
+        prefix = "--"
+    }
+
+    return
+}
+
+func prefixedNames(fullName string) (prefixed string) {
+    parts := strings.Split(fullName, ",")
+    for i, name := range parts {
+        name = strings.Trim(name, " ")
+        prefixed += prefixFor(name) + name
+        if i < len(parts)-1 {
+            prefixed += ", "
+        }
+    }
+    return
+}
+
+func withEnvHint(envVar, str string) string {
+    envText := ""
+    if envVar != "" {
+        envText = fmt.Sprintf(" [$%s]", strings.Join(strings.Split(envVar, ","), ", $"))
+    }
+    return str + envText
+}
+
+func (self DirectoryFlag) getName() string {
+    return self.Name
+}
+
+func (self *DirectoryFlag) Set(value string) {
+    self.Value.Value = value
+}
+
+// Expands a file path
+// 1. replace tilde with users home dir
+// 2. expands embedded environment variables
+// 3. cleans the path, e.g. /a/b/../c -> /a/c
+// Note, it has limitations, e.g. ~someuser/tmp will not be expanded
+func expandPath(p string) string {
+    if strings.HasPrefix(p, "~/") || strings.HasPrefix(p, "~\\") {
+        if user, err := user.Current(); err == nil {
+            if err == nil {
+                p = strings.Replace(p, "~", user.HomeDir, 1)
+            }
+        }
+    }
+
+    return filepath.Clean(os.ExpandEnv(p))
+}
+
+
+

--- a/cmd/utils/customflags_test.go
+++ b/cmd/utils/customflags_test.go
@@ -1,28 +1,28 @@
 package utils
 
 import (
-    "testing"
-    "os"
-    "os/user"
+	"os"
+	"os/user"
+	"testing"
 )
 
 func TestPathExpansion(t *testing.T) {
 
-    user, _ := user.Current()
+	user, _ := user.Current()
 
-    tests := map[string]string {
-        "/home/someuser/tmp": "/home/someuser/tmp",
-        "~/tmp": user.HomeDir + "/tmp",
-        "$DDDXXX/a/b": "/tmp/a/b",
-        "/a/b/": "/a/b",
-    }
+	tests := map[string]string{
+		"/home/someuser/tmp": "/home/someuser/tmp",
+		"~/tmp":              user.HomeDir + "/tmp",
+		"$DDDXXX/a/b":        "/tmp/a/b",
+		"/a/b/":              "/a/b",
+	}
 
-    os.Setenv("DDDXXX", "/tmp")
+	os.Setenv("DDDXXX", "/tmp")
 
-    for test, expected := range tests {
-        got := expandPath(test)
-        if got != expected {
-            t.Errorf("test %s, got %s, expected %s\n", test, got, expected)
-        }
-    }
+	for test, expected := range tests {
+		got := expandPath(test)
+		if got != expected {
+			t.Errorf("test %s, got %s, expected %s\n", test, got, expected)
+		}
+	}
 }

--- a/cmd/utils/customflags_test.go
+++ b/cmd/utils/customflags_test.go
@@ -1,0 +1,28 @@
+package utils
+
+import (
+    "testing"
+    "os"
+    "os/user"
+)
+
+func TestPathExpansion(t *testing.T) {
+
+    user, _ := user.Current()
+
+    tests := map[string]string {
+        "/home/someuser/tmp": "/home/someuser/tmp",
+        "~/tmp": user.HomeDir + "/tmp",
+        "$DDDXXX/a/b": "/tmp/a/b",
+        "/a/b/": "/a/b",
+    }
+
+    os.Setenv("DDDXXX", "/tmp")
+
+    for test, expected := range tests {
+        got := expandPath(test)
+        if got != expected {
+            t.Errorf("test %s, got %s, expected %s\n", test, got, expected)
+        }
+    }
+}

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -68,10 +68,10 @@ func NewApp(version, usage string) *cli.App {
 
 var (
 	// General settings
-	DataDirFlag = cli.StringFlag{
-		Name:  "datadir",
+	DataDirFlag = DirectoryFlag{
+		Name: "datadir",
 		Usage: "Data directory to be used",
-		Value: common.DefaultDataDir(),
+		Value: DirectoryString{common.DefaultDataDir()},
 	}
 	ProtocolVersionFlag = cli.IntFlag{
 		Name:  "protocolversion",

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -69,7 +69,7 @@ func NewApp(version, usage string) *cli.App {
 var (
 	// General settings
 	DataDirFlag = DirectoryFlag{
-		Name: "datadir",
+		Name:  "datadir",
 		Usage: "Data directory to be used",
 		Value: DirectoryString{common.DefaultDataDir()},
 	}


### PR DESCRIPTION
Introduced new flag type for directories which geth now uses for datadir argument. During commandline argument parsing the datadir value is expanded in case it still contains a tilde or environment variable which the shell did not expand.
fixes #567 = #639 / 1