### PR TITLE
Support for import/export hex encoded keys

### DIFF
--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -149,8 +149,7 @@ password to file or expose in any other way.
 Imports an unencrypted private key from <keyfile> and creates a new account.
 Prints the address.
 
-The keyfile is assumed to contain an unencrypted private key in canonical EC
-raw bytes format.
+The keyfile is assumed to contain an unencrypted private key in hexadecimal format.
 
 The account is saved in encrypted format, you are prompted for a passphrase.
 

--- a/common/bytes.go
+++ b/common/bytes.go
@@ -147,18 +147,6 @@ func Hex2Bytes(str string) []byte {
 	return h
 }
 
-func HexBytes2Bytes(d []byte) []byte {
-	r := make([]byte, hex.DecodedLen(len(d)))
-	hex.Decode(r, d)
-	return r
-}
-
-func Bytes2HexBytes(d []byte) []byte {
-	r := make([]byte, hex.EncodedLen(len(d)))
-	hex.Encode(r, d)
-	return r
-}
-
 func StringToByteFunc(str string, cb func(str string) []byte) (ret []byte) {
 	if len(str) > 1 && str[0:2] == "0x" && !strings.Contains(str, "\n") {
 		ret = Hex2Bytes(str[2:])

--- a/common/bytes.go
+++ b/common/bytes.go
@@ -147,6 +147,18 @@ func Hex2Bytes(str string) []byte {
 	return h
 }
 
+func HexBytes2Bytes(d []byte) []byte {
+	r := make([]byte, hex.DecodedLen(len(d)))
+	hex.Decode(r, d)
+	return r
+}
+
+func Bytes2HexBytes(d []byte) []byte {
+	r := make([]byte, hex.EncodedLen(len(d)))
+	hex.Encode(r, d)
+	return r
+}
+
 func StringToByteFunc(str string, cb func(str string) []byte) (ret []byte) {
 	if len(str) > 1 && str[0:2] == "0x" && !strings.Contains(str, "\n") {
 		ret = Hex2Bytes(str[2:])

--- a/crypto/crypto.go
+++ b/crypto/crypto.go
@@ -121,7 +121,7 @@ func HexToECDSA(hexkey string) (*ecdsa.PrivateKey, error) {
 
 // LoadECDSA loads a secp256k1 private key from the given file.
 func LoadECDSA(file string) (*ecdsa.PrivateKey, error) {
-	buf := make([]byte, 32)
+	buf := make([]byte, 64)
 	fd, err := os.Open(file)
 	if err != nil {
 		return nil, err
@@ -130,13 +130,13 @@ func LoadECDSA(file string) (*ecdsa.PrivateKey, error) {
 	if _, err := io.ReadFull(fd, buf); err != nil {
 		return nil, err
 	}
-	return ToECDSA(buf), nil
+	return ToECDSA(common.HexBytes2Bytes(buf)), nil
 }
 
 // SaveECDSA saves a secp256k1 private key to the given file with restrictive
 // permissions
 func SaveECDSA(file string, key *ecdsa.PrivateKey) error {
-	return ioutil.WriteFile(file, FromECDSA(key), 0600)
+	return ioutil.WriteFile(file, common.Bytes2HexBytes(FromECDSA(key)), 0600)
 }
 
 func GenerateKey() (*ecdsa.PrivateKey, error) {

--- a/crypto/crypto.go
+++ b/crypto/crypto.go
@@ -130,13 +130,20 @@ func LoadECDSA(file string) (*ecdsa.PrivateKey, error) {
 	if _, err := io.ReadFull(fd, buf); err != nil {
 		return nil, err
 	}
-	return ToECDSA(common.HexBytes2Bytes(buf)), nil
+
+	key, err := hex.DecodeString(string(buf))
+	if err != nil {
+		return nil, err
+	}
+
+	return ToECDSA(key), nil
 }
 
 // SaveECDSA saves a secp256k1 private key to the given file with restrictive
 // permissions
 func SaveECDSA(file string, key *ecdsa.PrivateKey) error {
-	return ioutil.WriteFile(file, common.Bytes2HexBytes(FromECDSA(key)), 0600)
+	k := hex.EncodeToString(FromECDSA(key))
+	return ioutil.WriteFile(file, []byte(k), 0600)
 }
 
 func GenerateKey() (*ecdsa.PrivateKey, error) {


### PR DESCRIPTION
Key export/import is now compatible with Alethzero.
This closes #635