### PR TITLE
bugfix as a result of PR 671

### DIFF
--- a/cmd/utils/customflags.go
+++ b/cmd/utils/customflags.go
@@ -18,11 +18,11 @@ type DirectoryString struct {
 	Value string
 }
 
-func (self DirectoryString) String() string {
+func (self *DirectoryString) String() string {
 	return self.Value
 }
 
-func (self DirectoryString) Set(value string) error {
+func (self *DirectoryString) Set(value string) error {
 	self.Value = expandPath(value)
 	return nil
 }
@@ -72,9 +72,8 @@ func (self DirectoryFlag) Apply(set *flag.FlagSet) {
 	}
 
 	eachName(self.Name, func(name string) {
-		set.Var(self.Value, self.Name, "a: "+self.Usage)
+		set.Var(&self.Value, self.Name, self.Usage)
 	})
-
 }
 
 func prefixFor(name string) (prefix string) {


### PR DESCRIPTION
The passed datadir argument was set on a copy of the Flag object and therefore lost after the method call. Changed method signature to pointer receiver.
