### PR TITLE
xeth: fix #640, panic converting nil recipient to hex.

### DIFF
--- a/cmd/mist/gui.go
+++ b/cmd/mist/gui.go
@@ -238,13 +238,11 @@ func (gui *Gui) insertTransaction(window string, tx *types.Transaction) {
 		inout = "recv"
 	}
 
-	var (
-		ptx  = xeth.NewTx(tx)
-		send = from.Hex()
-		rec  = tx.To().Hex()
-	)
-	ptx.Sender = send
-	ptx.Address = rec
+	ptx := xeth.NewTx(tx)
+	ptx.Sender = from.Hex()
+	if to := tx.To(); to != nil {
+		ptx.Address = to.Hex()
+	}
 
 	if window == "post" {
 		//gui.getObjectByName("transactionView").Call("addTx", ptx, inout)

--- a/xeth/types.go
+++ b/xeth/types.go
@@ -140,8 +140,11 @@ type Transaction struct {
 
 func NewTx(tx *types.Transaction) *Transaction {
 	hash := tx.Hash().Hex()
-	receiver := tx.To().Hex()
-	if len(receiver) == 0 {
+
+	var receiver string
+	if to := tx.To(); to != nil {
+		receiver = to.Hex()
+	} else {
 		receiver = core.AddressFromMessage(tx).Hex()
 	}
 	sender, _ := tx.From()


### PR DESCRIPTION
Fetching the recipient address from a transaction was changed to return nil
instead of a zero-address, but this code path was not updated, so whenever
a contract was created, a nil panic occured.