### PR TITLE
Added blockchain DB versioning support, closes #650

### DIFF
--- a/core/block_processor.go
+++ b/core/block_processor.go
@@ -18,6 +18,12 @@ import (
 	"gopkg.in/fatih/set.v0"
 )
 
+const (
+	// must be bumped when consensus algorithm is changed, this forces the upgradedb
+	// command to be run (forces the blocks to be imported again using the new algorithm)
+	BlockChainVersion = 1
+)
+
 var statelogger = logger.NewLogger("BLOCK")
 
 type BlockProcessor struct {

--- a/core/chain_manager.go
+++ b/core/chain_manager.go
@@ -284,11 +284,14 @@ func (self *ChainManager) Export(w io.Writer) error {
 	defer self.mu.RUnlock()
 	glog.V(logger.Info).Infof("exporting %v blocks...\n", self.currentBlock.Header().Number)
 
-	for block := self.currentBlock; block != nil; block = self.GetBlock(block.Header().ParentHash) {
-		if err := block.EncodeRLP(w); err != nil {
+	last := self.currentBlock.NumberU64()
+
+	for nr := uint64(0); nr <= last; nr++ {
+		if err := self.GetBlockByNumber(nr).EncodeRLP(w); err != nil {
 			return err
 		}
 	}
+
 	return nil
 }
 


### PR DESCRIPTION
Stores a blockchain version in the blockchain DB and checks if the version in the database matches a hard coded version number. This hard coded number is the consensus algorithm version number. If the algorithm is changed the number should be bumped. If these number differ the user is forced to run a new introduced `upgradedb` command. This command:

1. exports the current blockchain to `datadir/blockchain_${currentversion}_${timestamp}.chain`
2. removes the current blockchain db
3. imports the exported file using the new algorithm
4. if successful removes the file

It also holds 3 bugfixes for:
1. nilpointer exception caused by the blockprocesser not set on import
2. the export commands exports the latest block first, this causes the import command to drop blocks since it points to unknown parents
3. the databases uses in memory buffering and flushes on particular criteria. When these criteria are not met changes are not persisted. This caused "missing" blocks on import when the program doesn't do an explicit flush.
