### PR TITLE
blockpool stability fixes:

### DIFF
--- a/blockpool/blockpool_test.go
+++ b/blockpool/blockpool_test.go
@@ -3,19 +3,12 @@ package blockpool
 import (
 	"testing"
 	"time"
-
-	"github.com/ethereum/go-ethereum/blockpool/test"
 )
-
-func init() {
-	test.LogInit()
-}
 
 // using the mock framework in blockpool_util_test
 // we test various scenarios here
 
 func TestPeerWithKnownBlock(t *testing.T) {
-	test.LogInit()
 	_, blockPool, blockPoolTester := newTestBlockPool(t)
 	blockPoolTester.refBlockChain[0] = nil
 	blockPoolTester.blockChain[0] = nil
@@ -31,7 +24,6 @@ func TestPeerWithKnownBlock(t *testing.T) {
 }
 
 func TestPeerWithKnownParentBlock(t *testing.T) {
-	test.LogInit()
 	_, blockPool, blockPoolTester := newTestBlockPool(t)
 	blockPoolTester.initRefBlockChain(1)
 	blockPoolTester.blockChain[0] = nil
@@ -50,7 +42,6 @@ func TestPeerWithKnownParentBlock(t *testing.T) {
 }
 
 func TestSimpleChain(t *testing.T) {
-	test.LogInit()
 	_, blockPool, blockPoolTester := newTestBlockPool(t)
 	blockPoolTester.blockChain[0] = nil
 	blockPoolTester.initRefBlockChain(2)
@@ -70,7 +61,6 @@ func TestSimpleChain(t *testing.T) {
 }
 
 func TestChainConnectingWithParentHash(t *testing.T) {
-	test.LogInit()
 	_, blockPool, blockPoolTester := newTestBlockPool(t)
 	blockPoolTester.blockChain[0] = nil
 	blockPoolTester.initRefBlockChain(3)
@@ -90,7 +80,6 @@ func TestChainConnectingWithParentHash(t *testing.T) {
 }
 
 func TestMultiSectionChain(t *testing.T) {
-	test.LogInit()
 	_, blockPool, blockPoolTester := newTestBlockPool(t)
 	blockPoolTester.blockChain[0] = nil
 	blockPoolTester.initRefBlockChain(5)
@@ -113,7 +102,6 @@ func TestMultiSectionChain(t *testing.T) {
 }
 
 func TestNewBlocksOnPartialChain(t *testing.T) {
-	test.LogInit()
 	_, blockPool, blockPoolTester := newTestBlockPool(t)
 	blockPoolTester.blockChain[0] = nil
 	blockPoolTester.initRefBlockChain(7)
@@ -146,7 +134,6 @@ func TestNewBlocksOnPartialChain(t *testing.T) {
 }
 
 func TestPeerSwitchUp(t *testing.T) {
-	test.LogInit()
 	_, blockPool, blockPoolTester := newTestBlockPool(t)
 	blockPoolTester.blockChain[0] = nil
 	blockPoolTester.initRefBlockChain(7)
@@ -174,7 +161,6 @@ func TestPeerSwitchUp(t *testing.T) {
 }
 
 func TestPeerSwitchDownOverlapSectionWithoutRootBlock(t *testing.T) {
-	test.LogInit()
 	_, blockPool, blockPoolTester := newTestBlockPool(t)
 	blockPoolTester.blockChain[0] = nil
 	blockPoolTester.initRefBlockChain(6)
@@ -200,7 +186,6 @@ func TestPeerSwitchDownOverlapSectionWithoutRootBlock(t *testing.T) {
 }
 
 func TestPeerSwitchDownOverlapSectionWithRootBlock(t *testing.T) {
-	test.LogInit()
 	_, blockPool, blockPoolTester := newTestBlockPool(t)
 	blockPoolTester.blockChain[0] = nil
 	blockPoolTester.initRefBlockChain(6)
@@ -227,7 +212,6 @@ func TestPeerSwitchDownOverlapSectionWithRootBlock(t *testing.T) {
 }
 
 func TestPeerSwitchDownDisjointSection(t *testing.T) {
-	test.LogInit()
 	_, blockPool, blockPoolTester := newTestBlockPool(t)
 	blockPoolTester.blockChain[0] = nil
 	blockPoolTester.initRefBlockChain(3)
@@ -254,7 +238,6 @@ func TestPeerSwitchDownDisjointSection(t *testing.T) {
 }
 
 func TestPeerSwitchBack(t *testing.T) {
-	test.LogInit()
 	_, blockPool, blockPoolTester := newTestBlockPool(t)
 	blockPoolTester.blockChain[0] = nil
 	blockPoolTester.initRefBlockChain(8)
@@ -270,7 +253,7 @@ func TestPeerSwitchBack(t *testing.T) {
 	go peer2.serveBlockHashes(6, 5, 4)
 	peer2.serveBlocks(4, 5)                  // section partially complete
 	peer1.AddPeer()                          // peer1 is promoted as best peer
-	go peer1.serveBlocks(10, 11)             //
+	peer1.serveBlocks(10, 11)                //
 	peer1.serveBlockHashes(11, 10)           // only gives useless results
 	blockPool.RemovePeer("peer1")            // peer1 disconnects
 	go peer2.serveBlockHashes(4, 3, 2, 1, 0) // tests that asking for hashes from 4 is remembered
@@ -284,7 +267,6 @@ func TestPeerSwitchBack(t *testing.T) {
 }
 
 func TestForkSimple(t *testing.T) {
-	test.LogInit()
 	_, blockPool, blockPoolTester := newTestBlockPool(t)
 	blockPoolTester.blockChain[0] = nil
 	blockPoolTester.initRefBlockChain(9)
@@ -320,7 +302,6 @@ func TestForkSimple(t *testing.T) {
 }
 
 func TestForkSwitchBackByNewBlocks(t *testing.T) {
-	test.LogInit()
 	_, blockPool, blockPoolTester := newTestBlockPool(t)
 	blockPoolTester.blockChain[0] = nil
 	blockPoolTester.initRefBlockChain(11)
@@ -351,8 +332,8 @@ func TestForkSwitchBackByNewBlocks(t *testing.T) {
 	go peer1.serveBlockHashes(11, 10, 9)
 	go peer1.serveBlocks(9, 10)
 	// time.Sleep(1 * time.Second)
-	go peer1.serveBlocks(3, 7)      // tests that block requests on earlier fork are remembered
-	go peer1.serveBlockHashes(2, 1) // tests that hash request from root of connecting chain section (added by demoted peer) is remembered
+	go peer1.serveBlocks(3, 7)         // tests that block requests on earlier fork are remembered
+	go peer1.serveBlockHashes(2, 1, 0) // tests that hash request from root of connecting chain section (added by demoted peer) is remembered
 	peer1.serveBlocks(0, 1)
 
 	blockPool.Wait(waitTimeout)
@@ -367,7 +348,6 @@ func TestForkSwitchBackByNewBlocks(t *testing.T) {
 }
 
 func TestForkSwitchBackByPeerSwitchBack(t *testing.T) {
-	test.LogInit()
 	_, blockPool, blockPoolTester := newTestBlockPool(t)
 	blockPoolTester.blockChain[0] = nil
 	blockPoolTester.initRefBlockChain(9)
@@ -411,7 +391,6 @@ func TestForkSwitchBackByPeerSwitchBack(t *testing.T) {
 }
 
 func TestForkCompleteSectionSwitchBackByPeerSwitchBack(t *testing.T) {
-	test.LogInit()
 	_, blockPool, blockPoolTester := newTestBlockPool(t)
 	blockPoolTester.blockChain[0] = nil
 	blockPoolTester.initRefBlockChain(9)
@@ -429,16 +408,17 @@ func TestForkCompleteSectionSwitchBackByPeerSwitchBack(t *testing.T) {
 	peer1.AddPeer()
 	go peer1.serveBlocks(8, 9)
 	go peer1.serveBlockHashes(9, 8, 7)
-	peer1.serveBlocks(3, 7, 8)               // make sure this section is complete
-	time.Sleep(1 * time.Second)              //
-	go peer1.serveBlockHashes(7, 3, 2)       // block 3/7 is section boundary
+	peer1.serveBlocks(3, 7, 8) // make sure this section is complete
+	// time.Sleep(2 * time.Second)              //
+	peer1.serveBlockHashes(7, 3, 2)          // block 3/7 is section boundary
 	peer1.serveBlocks(2, 3)                  // partially complete sections block 2 missing
 	peer2.AddPeer()                          //
 	go peer2.serveBlocks(5, 6)               //
 	go peer2.serveBlockHashes(6, 5, 4, 3, 2) // peer2 forks on block 3
+	time.Sleep(100 * time.Millisecond)       //
 	peer2.serveBlocks(2, 3, 4, 5)            // block 2 still missing.
 	blockPool.RemovePeer("peer2")            // peer2 disconnects, peer1 is promoted again as best peer
-	go peer1.serveBlockHashes(2, 1, 0)       //
+	go peer1.serveBlockHashes(2, 1)          //
 	peer1.serveBlocks(0, 1, 2)
 
 	blockPool.Wait(waitTimeout)

--- a/blockpool/config_test.go
+++ b/blockpool/config_test.go
@@ -17,6 +17,7 @@ func TestBlockPoolConfig(t *testing.T) {
 	test.CheckInt("BlockBatchSize", c.BlockBatchSize, blockBatchSize, t)
 	test.CheckInt("BlocksRequestRepetition", c.BlocksRequestRepetition, blocksRequestRepetition, t)
 	test.CheckInt("BlocksRequestMaxIdleRounds", c.BlocksRequestMaxIdleRounds, blocksRequestMaxIdleRounds, t)
+	test.CheckInt("NodeCacheSize", c.NodeCacheSize, nodeCacheSize, t)
 	test.CheckDuration("BlockHashesRequestInterval", c.BlockHashesRequestInterval, blockHashesRequestInterval, t)
 	test.CheckDuration("BlocksRequestInterval", c.BlocksRequestInterval, blocksRequestInterval, t)
 	test.CheckDuration("BlockHashesTimeout", c.BlockHashesTimeout, blockHashesTimeout, t)
@@ -29,7 +30,7 @@ func TestBlockPoolConfig(t *testing.T) {
 func TestBlockPoolOverrideConfig(t *testing.T) {
 	test.LogInit()
 	blockPool := &BlockPool{Config: &Config{}, chainEvents: &event.TypeMux{}}
-	c := &Config{128, 32, 1, 0, 300 * time.Millisecond, 100 * time.Millisecond, 90 * time.Second, 0, 30 * time.Second, 30 * time.Second, 4 * time.Second}
+	c := &Config{128, 32, 1, 0, 500, 300 * time.Millisecond, 100 * time.Millisecond, 90 * time.Second, 0, 30 * time.Second, 30 * time.Second, 4 * time.Second}
 
 	blockPool.Config = c
 	blockPool.Start()
@@ -37,6 +38,7 @@ func TestBlockPoolOverrideConfig(t *testing.T) {
 	test.CheckInt("BlockBatchSize", c.BlockBatchSize, 32, t)
 	test.CheckInt("BlocksRequestRepetition", c.BlocksRequestRepetition, blocksRequestRepetition, t)
 	test.CheckInt("BlocksRequestMaxIdleRounds", c.BlocksRequestMaxIdleRounds, blocksRequestMaxIdleRounds, t)
+	test.CheckInt("NodeCacheSize", c.NodeCacheSize, 500, t)
 	test.CheckDuration("BlockHashesRequestInterval", c.BlockHashesRequestInterval, 300*time.Millisecond, t)
 	test.CheckDuration("BlocksRequestInterval", c.BlocksRequestInterval, 100*time.Millisecond, t)
 	test.CheckDuration("BlockHashesTimeout", c.BlockHashesTimeout, 90*time.Second, t)

--- a/blockpool/peers_test.go
+++ b/blockpool/peers_test.go
@@ -1,23 +1,30 @@
 package blockpool
 
 import (
+	"flag"
 	"math/big"
 	"testing"
 	"time"
 
-	"github.com/ethereum/go-ethereum/blockpool/test"
-	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core"
 	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/logger"
+	"github.com/ethereum/go-ethereum/logger/glog"
+)
+
+var (
+	_ = flag.Set("alsologtostderr", "true")
+	// _ = flag.Set("log_dir", ".")
+	_ = flag.Set("v", "5")
 )
 
 // the actual tests
 func TestAddPeer(t *testing.T) {
-	test.LogInit()
+	glog.V(logger.Error).Infoln("logging...")
 	hashPool, blockPool, blockPoolTester := newTestBlockPool(t)
-	peer0 := blockPoolTester.newPeer("peer0", 1, 1)
-	peer1 := blockPoolTester.newPeer("peer1", 2, 2)
-	peer2 := blockPoolTester.newPeer("peer2", 3, 3)
+	peer0 := blockPoolTester.newPeer("peer0", 2, 2)
+	peer1 := blockPoolTester.newPeer("peer1", 4, 4)
+	peer2 := blockPoolTester.newPeer("peer2", 6, 6)
 	var bestpeer *peer
 
 	blockPool.Start()
@@ -25,127 +32,149 @@ func TestAddPeer(t *testing.T) {
 	// pool
 	best := peer0.AddPeer()
 	if !best {
-		t.Errorf("peer0 (TD=1) not accepted as best")
+		t.Errorf("peer0 (TD=2) not accepted as best")
+		return
 	}
 	if blockPool.peers.best.id != "peer0" {
-		t.Errorf("peer0 (TD=1) not set as best")
+		t.Errorf("peer0 (TD=2) not set as best")
+		return
 	}
+	peer0.serveBlocks(1, 2)
 
 	best = peer2.AddPeer()
 	if !best {
-		t.Errorf("peer2 (TD=3) not accepted as best")
+		t.Errorf("peer2 (TD=6) not accepted as best")
+		return
 	}
 	if blockPool.peers.best.id != "peer2" {
-		t.Errorf("peer2 (TD=3) not set as best")
+		t.Errorf("peer2 (TD=6) not set as best")
+		return
 	}
-	peer2.waitBlocksRequests(3)
+	peer2.serveBlocks(5, 6)
 
 	best = peer1.AddPeer()
 	if best {
-		t.Errorf("peer1 (TD=2) accepted as best")
+		t.Errorf("peer1 (TD=4) accepted as best")
+		return
 	}
 	if blockPool.peers.best.id != "peer2" {
-		t.Errorf("peer2 (TD=3) not set any more as best")
+		t.Errorf("peer2 (TD=6) not set any more as best")
+		return
 	}
-	if blockPool.peers.best.td.Cmp(big.NewInt(int64(3))) != 0 {
-		t.Errorf("peer1 TD not set")
+	if blockPool.peers.best.td.Cmp(big.NewInt(int64(6))) != 0 {
+		t.Errorf("peer2 TD=6 not set")
+		return
 	}
 
-	peer2.td = 4
-	peer2.currentBlock = 4
+	peer2.td = 8
+	peer2.currentBlock = 8
 	best = peer2.AddPeer()
 	if !best {
-		t.Errorf("peer2 (TD=4) not accepted as best")
+		t.Errorf("peer2 (TD=8) not accepted as best")
+		return
 	}
 	if blockPool.peers.best.id != "peer2" {
-		t.Errorf("peer2 (TD=4) not set as best")
+		t.Errorf("peer2 (TD=8) not set as best")
+		return
 	}
-	if blockPool.peers.best.td.Cmp(big.NewInt(int64(4))) != 0 {
-		t.Errorf("peer2 TD not updated")
+	if blockPool.peers.best.td.Cmp(big.NewInt(int64(8))) != 0 {
+		t.Errorf("peer2 TD = 8 not updated")
+		return
 	}
-	peer2.waitBlocksRequests(4)
 
-	peer1.td = 3
-	peer1.currentBlock = 3
+	peer1.td = 6
+	peer1.currentBlock = 6
 	best = peer1.AddPeer()
 	if best {
-		t.Errorf("peer1 (TD=3) should not be set as best")
+		t.Errorf("peer1 (TD=6) should not be set as best")
+		return
 	}
 	if blockPool.peers.best.id == "peer1" {
-		t.Errorf("peer1 (TD=3) should not be set as best")
+		t.Errorf("peer1 (TD=6) should not be set as best")
+		return
 	}
 	bestpeer, best = blockPool.peers.getPeer("peer1")
-	if bestpeer.td.Cmp(big.NewInt(int64(3))) != 0 {
-		t.Errorf("peer1 TD should be updated")
+	if bestpeer.td.Cmp(big.NewInt(int64(6))) != 0 {
+		t.Errorf("peer1 TD=6 should be updated")
+		return
 	}
 
 	blockPool.RemovePeer("peer2")
 	bestpeer, best = blockPool.peers.getPeer("peer2")
 	if bestpeer != nil {
 		t.Errorf("peer2 not removed")
+		return
 	}
 
 	if blockPool.peers.best.id != "peer1" {
-		t.Errorf("existing peer1 (TD=3) should be set as best peer")
+		t.Errorf("existing peer1 (TD=6) should be set as best peer")
+		return
 	}
-	peer1.waitBlocksRequests(3)
 
 	blockPool.RemovePeer("peer1")
 	bestpeer, best = blockPool.peers.getPeer("peer1")
 	if bestpeer != nil {
 		t.Errorf("peer1 not removed")
+		return
 	}
 
 	if blockPool.peers.best.id != "peer0" {
-		t.Errorf("existing peer0 (TD=1) should be set as best peer")
+		t.Errorf("existing peer0 (TD=2) should be set as best peer")
+		return
 	}
-	peer0.waitBlocksRequests(1)
 
 	blockPool.RemovePeer("peer0")
 	bestpeer, best = blockPool.peers.getPeer("peer0")
 	if bestpeer != nil {
-		t.Errorf("peer1 not removed")
+		t.Errorf("peer0 not removed")
+		return
 	}
 
 	// adding back earlier peer ok
-	peer0.currentBlock = 3
+	peer0.currentBlock = 5
+	peer0.td = 5
 	best = peer0.AddPeer()
 	if !best {
-		t.Errorf("peer0 (TD=1) should be set as best")
+		t.Errorf("peer0 (TD=5) should be set as best")
+		return
 	}
 
 	if blockPool.peers.best.id != "peer0" {
-		t.Errorf("peer0 (TD=1) should be set as best")
+		t.Errorf("peer0 (TD=5) should be set as best")
+		return
 	}
-	peer0.waitBlocksRequests(3)
+	peer0.serveBlocks(4, 5)
 
-	hash := hashPool.IndexesToHashes([]int{0})[0]
-	newblock := &types.Block{Td: common.Big3, HeaderHash: hash}
+	hash := hashPool.IndexesToHashes([]int{6})[0]
+	newblock := &types.Block{Td: big.NewInt(int64(6)), HeaderHash: hash}
 	blockPool.chainEvents.Post(core.ChainHeadEvent{newblock})
 	time.Sleep(100 * time.Millisecond)
 	if blockPool.peers.best != nil {
 		t.Errorf("no peer should be ahead of self")
+		return
 	}
 	best = peer1.AddPeer()
 	if blockPool.peers.best != nil {
-		t.Errorf("still no peer should be ahead of self")
+		t.Errorf("after peer1 (TD=6) still no peer should be ahead of self")
+		return
 	}
 
 	best = peer2.AddPeer()
 	if !best {
-		t.Errorf("peer2 (TD=4) not accepted as best")
+		t.Errorf("peer2 (TD=8) not accepted as best")
+		return
 	}
 
 	blockPool.RemovePeer("peer2")
 	if blockPool.peers.best != nil {
 		t.Errorf("no peer should be ahead of self")
+		return
 	}
 
 	blockPool.Stop()
 }
 
 func TestPeerPromotionByTdOnBlock(t *testing.T) {
-	test.LogInit()
 	_, blockPool, blockPoolTester := newTestBlockPool(t)
 	blockPoolTester.blockChain[0] = nil
 	blockPoolTester.initRefBlockChain(4)

--- a/blockpool/status_test.go
+++ b/blockpool/status_test.go
@@ -51,7 +51,6 @@ func checkStatus(t *testing.T, bp *BlockPool, syncing bool, expected []int) (err
 	got := getStatusValues(s)
 	for i, v := range expected {
 		err = test.CheckInt(statusFields[i], got[i], v, t)
-		// fmt.Printf("%v: %v (%v)\n", statusFields[i], got[i], v)
 		if err != nil {
 			return
 		}
@@ -60,9 +59,6 @@ func checkStatus(t *testing.T, bp *BlockPool, syncing bool, expected []int) (err
 }
 
 func TestBlockPoolStatus(t *testing.T) {
-	t.Skip() // :FIXME:
-
-	test.LogInit()
 	var err error
 	n := 3
 	for n > 0 {
@@ -86,19 +82,17 @@ func testBlockPoolStatus(t *testing.T) (err error) {
 	blockPoolTester.blockChain[0] = nil
 	blockPoolTester.initRefBlockChain(12)
 	blockPoolTester.refBlockChain[3] = []int{4, 7}
-	delete(blockPoolTester.refBlockChain, 6)
+	blockPoolTester.refBlockChain[5] = []int{10}
+	blockPoolTester.refBlockChain[6] = []int{11}
+	blockPoolTester.refBlockChain[9] = []int{6}
+	delete(blockPoolTester.refBlockChain, 10)
 
 	blockPool.Start()
 
-	blockPoolTester.tds = make(map[int]int)
-	blockPoolTester.tds[9] = 1
-	blockPoolTester.tds[11] = 3
-	blockPoolTester.tds[6] = 2
-
-	peer1 := blockPoolTester.newPeer("peer1", 1, 9)
-	peer2 := blockPoolTester.newPeer("peer2", 2, 6)
-	peer3 := blockPoolTester.newPeer("peer3", 3, 11)
-	peer4 := blockPoolTester.newPeer("peer4", 1, 9)
+	peer1 := blockPoolTester.newPeer("peer1", 9, 9)
+	peer2 := blockPoolTester.newPeer("peer2", 10, 10)
+	peer3 := blockPoolTester.newPeer("peer3", 11, 11)
+	peer4 := blockPoolTester.newPeer("peer4", 9, 9)
 	peer2.blocksRequestsMap = peer1.blocksRequestsMap
 
 	var expected []int
@@ -124,119 +118,112 @@ func testBlockPoolStatus(t *testing.T) (err error) {
 	}
 
 	peer1.serveBlockHashes(9, 8, 7, 3, 2)
-	expected = []int{6, 5, 1, 1, 0, 1, 0, 0, 1, 1, 1, 1, 0}
+	expected = []int{5, 5, 1, 1, 0, 1, 0, 0, 1, 1, 1, 1, 0}
 	err = checkStatus(nil, blockPool, true, expected)
 	if err != nil {
 		return
 	}
 
 	peer1.serveBlocks(3, 7, 8)
-	expected = []int{6, 5, 3, 3, 0, 1, 0, 0, 1, 1, 1, 1, 0}
+	expected = []int{5, 5, 3, 3, 0, 1, 0, 0, 1, 1, 1, 1, 0}
 	err = checkStatus(nil, blockPool, true, expected)
 	if err != nil {
 		return
 	}
 
 	peer1.serveBlocks(2, 3)
-	expected = []int{6, 5, 4, 4, 0, 1, 0, 0, 1, 1, 1, 1, 0}
+	expected = []int{5, 5, 4, 4, 0, 1, 0, 0, 1, 1, 1, 1, 0}
 	err = checkStatus(nil, blockPool, true, expected)
 	if err != nil {
 		return
 	}
 
 	peer4.AddPeer()
-	expected = []int{6, 5, 4, 4, 0, 2, 0, 0, 2, 2, 1, 1, 0}
-	err = checkStatus(nil, blockPool, true, expected)
-	if err != nil {
-		return
-	}
-
-	peer4.sendBlockHashes(12, 11)
-	expected = []int{6, 5, 4, 4, 0, 2, 0, 0, 2, 2, 1, 1, 0}
+	expected = []int{5, 5, 4, 4, 0, 2, 0, 0, 2, 2, 1, 1, 0}
 	err = checkStatus(nil, blockPool, true, expected)
 	if err != nil {
 		return
 	}
 
 	peer2.AddPeer()
-	expected = []int{6, 5, 4, 4, 0, 3, 0, 0, 3, 3, 1, 2, 0}
+	expected = []int{5, 5, 4, 4, 0, 3, 0, 0, 3, 3, 1, 2, 0}
 	err = checkStatus(nil, blockPool, true, expected)
 	if err != nil {
 		return
 	}
 
-	peer2.serveBlocks(5, 6)
-	peer2.serveBlockHashes(6, 5, 4, 3, 2)
-	expected = []int{10, 8, 5, 5, 0, 3, 1, 0, 3, 3, 2, 2, 0}
+	peer2.serveBlocks(5, 10)
+	peer2.serveBlockHashes(10, 5, 4, 3, 2)
+	expected = []int{8, 8, 5, 5, 0, 3, 1, 0, 3, 3, 2, 2, 0}
 	err = checkStatus(nil, blockPool, true, expected)
 	if err != nil {
 		return
 	}
 
 	peer2.serveBlocks(2, 3, 4)
-	expected = []int{10, 8, 6, 6, 0, 3, 1, 0, 3, 3, 2, 2, 0}
+	expected = []int{8, 8, 6, 6, 0, 3, 1, 0, 3, 3, 2, 2, 0}
 	err = checkStatus(nil, blockPool, true, expected)
 	if err != nil {
 		return
 	}
 
 	blockPool.RemovePeer("peer2")
-	expected = []int{10, 8, 6, 6, 0, 3, 1, 0, 3, 2, 2, 2, 0}
+	expected = []int{8, 8, 6, 6, 0, 3, 1, 0, 3, 2, 2, 2, 0}
 	err = checkStatus(nil, blockPool, true, expected)
 	if err != nil {
 		return
 	}
 
 	peer1.serveBlockHashes(2, 1, 0)
-	expected = []int{11, 9, 6, 6, 0, 3, 1, 0, 3, 2, 2, 2, 0}
+	expected = []int{9, 9, 6, 6, 0, 3, 1, 0, 3, 2, 2, 2, 0}
 	err = checkStatus(nil, blockPool, true, expected)
 	if err != nil {
 		return
 	}
 
 	peer1.serveBlocks(1, 2)
-	expected = []int{11, 9, 7, 7, 0, 3, 1, 0, 3, 2, 2, 2, 0}
+	expected = []int{9, 9, 7, 7, 0, 3, 1, 0, 3, 2, 2, 2, 0}
 	err = checkStatus(nil, blockPool, true, expected)
 	if err != nil {
 		return
 	}
 
 	peer1.serveBlocks(4, 5)
-	expected = []int{11, 9, 8, 8, 0, 3, 1, 0, 3, 2, 2, 2, 0}
+	expected = []int{9, 9, 8, 8, 0, 3, 1, 0, 3, 2, 2, 2, 0}
 	err = checkStatus(nil, blockPool, true, expected)
 	if err != nil {
 		return
 	}
 
 	peer3.AddPeer()
-	expected = []int{11, 9, 8, 8, 0, 4, 1, 0, 4, 3, 2, 3, 0}
+	expected = []int{9, 9, 8, 8, 0, 4, 1, 0, 4, 3, 2, 3, 0}
 	err = checkStatus(nil, blockPool, true, expected)
 	if err != nil {
 		return
 	}
 
-	peer3.serveBlocks(10, 11)
-	expected = []int{12, 9, 9, 9, 0, 4, 1, 0, 4, 3, 3, 3, 0}
+	peer3.serveBlocks(6, 11)
+	expected = []int{10, 9, 9, 9, 0, 4, 1, 0, 4, 3, 3, 3, 0}
 	err = checkStatus(nil, blockPool, true, expected)
 	if err != nil {
 		return
 	}
 
-	peer3.serveBlockHashes(11, 10, 9)
-	expected = []int{14, 11, 9, 9, 0, 4, 1, 0, 4, 3, 3, 3, 0}
+	peer3.serveBlockHashes(11, 6, 9)
+	expected = []int{11, 11, 9, 9, 0, 4, 1, 0, 4, 3, 3, 3, 0}
 	err = checkStatus(nil, blockPool, true, expected)
 	if err != nil {
 		return
 	}
 
 	peer4.sendBlocks(11, 12)
-	expected = []int{14, 11, 9, 9, 0, 4, 1, 0, 4, 3, 4, 3, 1}
+	expected = []int{11, 11, 9, 9, 0, 4, 1, 0, 4, 3, 4, 3, 0}
 	err = checkStatus(nil, blockPool, true, expected)
 	if err != nil {
 		return
 	}
-	peer3.serveBlocks(9, 10)
-	expected = []int{14, 11, 10, 10, 0, 4, 1, 0, 4, 3, 4, 3, 1}
+	peer3.serveBlocks(9, 6)
+	expected = []int{11, 11, 10, 10, 0, 4, 1, 0, 4, 3, 4, 3, 0}
 	err = checkStatus(nil, blockPool, true, expected)
 	if err != nil {
 		return
@@ -245,10 +232,11 @@ func testBlockPoolStatus(t *testing.T) (err error) {
 	peer3.serveBlocks(0, 1)
 	blockPool.Wait(waitTimeout)
 	time.Sleep(200 * time.Millisecond)
+
+	expected = []int{11, 3, 11, 3, 8, 4, 1, 8, 4, 3, 4, 3, 0}
+	err = checkStatus(nil, blockPool, false, expected)
 	blockPool.Stop()
 
-	expected = []int{14, 3, 11, 3, 8, 4, 1, 8, 4, 3, 4, 3, 1}
-	err = checkStatus(nil, blockPool, false, expected)
 	if err != nil {
 		return
 	}

--- a/core/chain_manager.go
+++ b/core/chain_manager.go
@@ -470,6 +470,7 @@ func (self *ChainManager) InsertChain(chain types.Blocks) error {
 			}
 
 			if IsParentErr(err) && self.futureBlocks.Has(block.ParentHash()) {
+				block.SetQueued(true)
 				self.futureBlocks.Push(block)
 				stats.queued++
 				continue

--- a/errs/errors.go
+++ b/errs/errors.go
@@ -69,7 +69,7 @@ func (self *Errors) New(code int, format string, params ...interface{}) *Error {
 
 func (self Error) Error() (message string) {
 	if len(message) == 0 {
-		self.message = fmt.Sprintf("[%s] %s", self.Package, self.Name)
+		self.message = fmt.Sprintf("[%s] ERROR: %s", self.Package, self.Name)
 		if self.format != "" {
 			self.message += ": " + fmt.Sprintf(self.format, self.params...)
 		}
@@ -81,14 +81,7 @@ func (self Error) Log(v glog.Verbose) {
 	if v {
 		v.Infoln(self)
 	}
-	//log.Sendln(self.level, self)
 }
-
-/*
-func (self Error) Log(log *logger.Logger) {
-	log.Sendln(self.level, self)
-}
-*/
 
 /*
 err.Fatal() is true if err's severity level is 0 or 1 (logger.ErrorLevel or logger.Silence)

--- a/errs/errors_test.go
+++ b/errs/errors_test.go
@@ -28,7 +28,7 @@ func testErrors() *Errors {
 func TestErrorMessage(t *testing.T) {
 	err := testErrors().New(0, "zero detail %v", "available")
 	message := fmt.Sprintf("%v", err)
-	exp := "[TEST] zero: zero detail available"
+	exp := "[TEST] ERROR: zero: zero detail available"
 	if message != exp {
 		t.Errorf("error message incorrect. expected %v, got %v", exp, message)
 	}

--- a/eth/protocol.go
+++ b/eth/protocol.go
@@ -299,7 +299,7 @@ func (self *ethProtocol) handle() error {
 		// to simplify backend interface adding a new block
 		// uses AddPeer followed by AddBlock only if peer is the best peer
 		// (or selected as new best peer)
-		if best, _ := self.blockPool.AddPeer(request.TD, hash, self.id, self.requestBlockHashes, self.requestBlocks, self.protoErrorDisconnect); best {
+		if _, suspended := self.blockPool.AddPeer(request.TD, hash, self.id, self.requestBlockHashes, self.requestBlocks, self.protoErrorDisconnect); !suspended {
 			self.blockPool.AddBlock(request.Block, self.id)
 		}
 
@@ -384,11 +384,9 @@ func (self *ethProtocol) sendStatus() error {
 }
 
 func (self *ethProtocol) protoErrorDisconnect(err *errs.Error) {
-	//err.Log(self.peer.Logger)
 	err.Log(glog.V(logger.Info))
-	/*
-		if err.Fatal() {
-			self.peer.Disconnect(p2p.DiscSubprotocolError)
-		}
-	*/
+	if err.Fatal() {
+		self.peer.Disconnect(p2p.DiscSubprotocolError)
+	}
+
 }

--- a/logger/glog/README
+++ b/logger/glog/README
@@ -19,20 +19,20 @@ The comment from glog.go introduces the ideas:
 	Error, Fatal, plus formatting variants such as Infof. It
 	also provides V-style logging controlled by the -v and
 	-vmodule=file=2 flags.
-	
+
 	Basic examples:
-	
+
 		glog.Info("Prepare to repel boarders")
-	
+
 		glog.Fatalf("Initialization failed: %s", err)
-	
+
 	See the documentation for the V function for an explanation
 	of these examples:
-	
+
 		if glog.V(2) {
 			glog.Info("Starting transaction...")
 		}
-	
+
 		glog.V(2).Infoln("Processed", nItems, "elements")
 
 


### PR DESCRIPTION
- follow up locks and fix them
- chainManager: call SetQueued for parentErr future blocks, uncomment TD checks, unskip test
- make ErrIncorrectTD non-fatal to be forgiving to genuine mistaken nodes (temp) but demote them to guard against stuck best peers.
- add purging to bounded nodeCache (config nodeCacheSize)
- use nodeCache when creating blockpool entries and let non-best peers add blocks (performance boost)
- minor error in addError
- reduce idleBestPeerTimeout to 1 minute
- correct status counts and unskip status passing status test
- glogified logging