### PR TITLE
p2p: more concurrency fixups

### DIFF
--- a/p2p/discover/node.go
+++ b/p2p/discover/node.go
@@ -14,8 +14,6 @@ import (
 	"strconv"
 	"strings"
 	"sync"
-	"sync/atomic"
-	"time"
 
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/crypto/secp256k1"
@@ -31,9 +29,6 @@ type Node struct {
 
 	DiscPort int // UDP listening port for discovery protocol
 	TCPPort  int // TCP listening port for RLPx
-
-	// this must be set/read using atomic load and store.
-	activeStamp int64
 }
 
 func newNode(id NodeID, addr *net.UDPAddr) *Node {
@@ -48,16 +43,6 @@ func newNode(id NodeID, addr *net.UDPAddr) *Node {
 func (n *Node) isValid() bool {
 	// TODO: don't accept localhost, LAN addresses from internet hosts
 	return !n.IP.IsMulticast() && !n.IP.IsUnspecified() && n.TCPPort != 0 && n.DiscPort != 0
-}
-
-func (n *Node) bumpActive() {
-	stamp := time.Now().Unix()
-	atomic.StoreInt64(&n.activeStamp, stamp)
-}
-
-func (n *Node) active() time.Time {
-	stamp := atomic.LoadInt64(&n.activeStamp)
-	return time.Unix(stamp, 0)
 }
 
 func (n *Node) addr() *net.UDPAddr {

--- a/p2p/discover/table.go
+++ b/p2p/discover/table.go
@@ -326,7 +326,6 @@ outer:
 func (b *bucket) bump(n *Node) bool {
 	for i := range b.entries {
 		if b.entries[i].ID == n.ID {
-			n.bumpActive()
 			// move it to the front
 			copy(b.entries[1:], b.entries[:i])
 			b.entries[0] = n

--- a/p2p/discover/udp.go
+++ b/p2p/discover/udp.go
@@ -267,11 +267,12 @@ func (t *udp) loop() {
 	defer timeout.Stop()
 
 	rearmTimeout := func() {
-		if len(pending) == 0 || nextDeadline == pending[0].deadline {
+		now := time.Now()
+		if len(pending) == 0 || now.Before(nextDeadline) {
 			return
 		}
 		nextDeadline = pending[0].deadline
-		timeout.Reset(nextDeadline.Sub(time.Now()))
+		timeout.Reset(nextDeadline.Sub(now))
 	}
 
 	for {

--- a/p2p/handshake.go
+++ b/p2p/handshake.go
@@ -115,7 +115,7 @@ func setupOutboundConn(fd net.Conn, prv *ecdsa.PrivateKey, our *protoHandshake, 
 	// returning the handshake read error. If the remote side
 	// disconnects us early with a valid reason, we should return it
 	// as the error so it can be tracked elsewhere.
-	werr := make(chan error)
+	werr := make(chan error, 1)
 	go func() { werr <- Send(rw, handshakeMsg, our) }()
 	rhs, err := readProtocolHandshake(rw, secrets.RemoteID, our)
 	if err != nil {

--- a/p2p/server.go
+++ b/p2p/server.go
@@ -260,9 +260,11 @@ func (srv *Server) Stop() {
 	// No new peers can be added at this point because dialLoop and
 	// listenLoop are down. It is safe to call peerWG.Wait because
 	// peerWG.Add is not called outside of those loops.
+	srv.lock.Lock()
 	for _, peer := range srv.peers {
 		peer.Disconnect(DiscQuitting)
 	}
+	srv.lock.Unlock()
 	srv.peerWG.Wait()
 }
 


### PR DESCRIPTION
These commits are meant to fix #703 and other (unreported) concurrency issues. 

The changes in `p2p/discover` also help with 32bit Windows builds. I found them 
while testing on that platform.