### PR TITLE
rlp: input limit and other corrections

### DIFF
--- a/cmd/rlpdump/main.go
+++ b/cmd/rlpdump/main.go
@@ -78,7 +78,7 @@ func main() {
 		os.Exit(2)
 	}
 
-	s := rlp.NewStream(r)
+	s := rlp.NewStream(r, 0)
 	for {
 		if err := dump(s, 0); err != nil {
 			if err != io.EOF {

--- a/cmd/utils/cmd.go
+++ b/cmd/utils/cmd.go
@@ -154,7 +154,7 @@ func ImportChain(chainmgr *core.ChainManager, fn string) error {
 	defer fh.Close()
 
 	chainmgr.Reset()
-	stream := rlp.NewStream(fh)
+	stream := rlp.NewStream(fh, 0)
 	var i, n int
 
 	batchSize := 2500

--- a/core/types/transaction.go
+++ b/core/types/transaction.go
@@ -22,7 +22,7 @@ type Transaction struct {
 	AccountNonce uint64
 	Price        *big.Int
 	GasLimit     *big.Int
-	Recipient    *common.Address // nil means contract creation
+	Recipient    *common.Address `rlp:"nil"` // nil means contract creation
 	Amount       *big.Int
 	Payload      []byte
 	V            byte

--- a/eth/protocol.go
+++ b/eth/protocol.go
@@ -210,7 +210,7 @@ func (self *ethProtocol) handle() error {
 		return p2p.Send(self.rw, BlockHashesMsg, hashes)
 
 	case BlockHashesMsg:
-		msgStream := rlp.NewStream(msg.Payload)
+		msgStream := rlp.NewStream(msg.Payload, uint64(msg.Size))
 		if _, err := msgStream.List(); err != nil {
 			return err
 		}
@@ -231,7 +231,7 @@ func (self *ethProtocol) handle() error {
 		self.blockPool.AddBlockHashes(iter, self.id)
 
 	case GetBlocksMsg:
-		msgStream := rlp.NewStream(msg.Payload)
+		msgStream := rlp.NewStream(msg.Payload, uint64(msg.Size))
 		if _, err := msgStream.List(); err != nil {
 			return err
 		}
@@ -259,7 +259,7 @@ func (self *ethProtocol) handle() error {
 		return p2p.Send(self.rw, BlocksMsg, blocks)
 
 	case BlocksMsg:
-		msgStream := rlp.NewStream(msg.Payload)
+		msgStream := rlp.NewStream(msg.Payload, uint64(msg.Size))
 		if _, err := msgStream.List(); err != nil {
 			return err
 		}

--- a/p2p/discover/udp.go
+++ b/p2p/discover/udp.go
@@ -413,7 +413,7 @@ func decodePacket(buf []byte) (packet, NodeID, []byte, error) {
 	default:
 		return nil, fromID, hash, fmt.Errorf("unknown type: %d", ptype)
 	}
-	err = rlp.Decode(bytes.NewReader(sigdata[1:]), req)
+	err = rlp.DecodeBytes(sigdata[1:], req)
 	return req, fromID, hash, err
 }
 

--- a/p2p/message.go
+++ b/p2p/message.go
@@ -32,7 +32,8 @@ type Msg struct {
 //
 // For the decoding rules, please see package rlp.
 func (msg Msg) Decode(val interface{}) error {
-	if err := rlp.Decode(msg.Payload, val); err != nil {
+	s := rlp.NewStream(msg.Payload, uint64(msg.Size))
+	if err := s.Decode(val); err != nil {
 		return newPeerError(errInvalidMsg, "(code %x) (size %d) %v", msg.Code, msg.Size, err)
 	}
 	return nil

--- a/p2p/peer_error.go
+++ b/p2p/peer_error.go
@@ -57,7 +57,7 @@ func (self *peerError) Error() string {
 	return self.message
 }
 
-type DiscReason byte
+type DiscReason uint
 
 const (
 	DiscRequested DiscReason = iota

--- a/rlp/decode.go
+++ b/rlp/decode.go
@@ -58,9 +58,8 @@ type Decoder interface {
 //     }
 //
 // To decode into a slice, the input must be a list and the resulting
-// slice will contain the input elements in order.
-// As a special case, if the slice has a byte-size element type, the input
-// can also be an RLP string.
+// slice will contain the input elements in order. For byte slices,
+// the input must be an RLP string.
 //
 // To decode into a Go string, the input must be an RLP string. The
 // input bytes are taken as-is and will not necessarily be valid UTF-8.
@@ -309,13 +308,6 @@ func decodeListArray(s *Stream, val reflect.Value, elemdec decoder) error {
 }
 
 func decodeByteSlice(s *Stream, val reflect.Value) error {
-	kind, _, err := s.Kind()
-	if err != nil {
-		return err
-	}
-	if kind == List {
-		return decodeListSlice(s, val, decodeUint)
-	}
 	b, err := s.Bytes()
 	if err != nil {
 		return wrapStreamError(err, val.Type())
@@ -351,7 +343,7 @@ func decodeByteArray(s *Stream, val reflect.Value) error {
 			return wrapStreamError(ErrCanonSize, val.Type())
 		}
 	case List:
-		return decodeListArray(s, val, decodeUint)
+		return wrapStreamError(ErrExpectedString, val.Type())
 	}
 	return nil
 }

--- a/rlp/decode.go
+++ b/rlp/decode.go
@@ -751,7 +751,7 @@ func (s *Stream) Kind() (kind Kind, size uint64, err error) {
 		tos = &s.stack[len(s.stack)-1]
 	}
 	if s.kind < 0 {
-		// don't read further if we're at the end of the
+		// Don't read further if we're at the end of the
 		// innermost list.
 		if tos != nil && tos.pos == tos.size {
 			return 0, 0, EOL
@@ -772,7 +772,7 @@ func (s *Stream) Kind() (kind Kind, size uint64, err error) {
 		}
 	} else {
 		// Inside a list, check that the value doesn't overflow the list.
-		if tos.pos+s.size > tos.size {
+		if s.size > tos.size-tos.pos {
 			return 0, 0, ErrElemTooLarge
 		}
 	}

--- a/rlp/decode.go
+++ b/rlp/decode.go
@@ -37,9 +37,9 @@ type Decoder interface {
 // DecodeRLP.
 //
 // To decode into a pointer, Decode will set the pointer to nil if the
-// input has size zero or the input is a single byte with value zero.
-// If the input has nonzero size, Decode will allocate a new value of
-// the type being pointed to.
+// input has size zero. If the input has nonzero size, Decode will
+// parse the input data into a value of the type being pointed to.
+// If the pointer is non-nil, the existing value will reused.
 //
 // To decode into a struct, Decode expects the input to be an RLP
 // list. The decoded elements of the list are assigned to each public
@@ -382,8 +382,8 @@ func makePtrDecoder(typ reflect.Type) (decoder, error) {
 		return nil, err
 	}
 	dec := func(s *Stream, val reflect.Value) (err error) {
-		_, size, err := s.Kind()
-		if err != nil || size == 0 && s.byteval == 0 {
+		kind, size, err := s.Kind()
+		if err != nil || size == 0 && kind != Byte {
 			// rearm s.Kind. This is important because the input
 			// position must advance to the next value even though
 			// we don't read anything.

--- a/rlp/decode_test.go
+++ b/rlp/decode_test.go
@@ -323,56 +323,29 @@ var decodeTests = []decodeTest{
 	// byte slices
 	{input: "01", ptr: new([]byte), value: []byte{1}},
 	{input: "80", ptr: new([]byte), value: []byte{}},
-
 	{input: "8D6162636465666768696A6B6C6D", ptr: new([]byte), value: []byte("abcdefghijklm")},
-	{input: "C0", ptr: new([]byte), value: []byte{}},
-	{input: "C3010203", ptr: new([]byte), value: []byte{1, 2, 3}},
-
-	{
-		input: "8105",
-		ptr:   new([]byte),
-		error: "rlp: non-canonical size information for []uint8",
-	},
-	{
-		input: "C3820102",
-		ptr:   new([]byte),
-		error: "rlp: input string too long for uint8, decoding into ([]uint8)[0]",
-	},
+	{input: "C0", ptr: new([]byte), error: "rlp: expected input string or byte for []uint8"},
+	{input: "8105", ptr: new([]byte), error: "rlp: non-canonical size information for []uint8"},
 
 	// byte arrays
 	{input: "01", ptr: new([5]byte), value: [5]byte{1}},
 	{input: "80", ptr: new([5]byte), value: [5]byte{}},
 	{input: "850102030405", ptr: new([5]byte), value: [5]byte{1, 2, 3, 4, 5}},
-	{input: "C0", ptr: new([5]byte), value: [5]byte{}},
-	{input: "C3010203", ptr: new([5]byte), value: [5]byte{1, 2, 3, 0, 0}},
 
-	{
-		input: "C3820102",
-		ptr:   new([5]byte),
-		error: "rlp: input string too long for uint8, decoding into ([5]uint8)[0]",
-	},
-	{
-		input: "86010203040506",
-		ptr:   new([5]byte),
-		error: "rlp: input string too long for [5]uint8",
-	},
-	{
-		input: "8105",
-		ptr:   new([5]byte),
-		error: "rlp: non-canonical size information for [5]uint8",
-	},
+	// byte array errors
+	{input: "C0", ptr: new([5]byte), error: "rlp: expected input string or byte for [5]uint8"},
+	{input: "C3010203", ptr: new([5]byte), error: "rlp: expected input string or byte for [5]uint8"},
+	{input: "86010203040506", ptr: new([5]byte), error: "rlp: input string too long for [5]uint8"},
+	{input: "8105", ptr: new([5]byte), error: "rlp: non-canonical size information for [5]uint8"},
 
 	// byte array reuse (should be zeroed)
 	{input: "850102030405", ptr: &sharedByteArray, value: [5]byte{1, 2, 3, 4, 5}},
 	{input: "01", ptr: &sharedByteArray, value: [5]byte{1}}, // kind: String
 	{input: "850102030405", ptr: &sharedByteArray, value: [5]byte{1, 2, 3, 4, 5}},
 	{input: "01", ptr: &sharedByteArray, value: [5]byte{1}}, // kind: Byte
-	{input: "C3010203", ptr: &sharedByteArray, value: [5]byte{1, 2, 3, 0, 0}},
-	{input: "C101", ptr: &sharedByteArray, value: [5]byte{1}}, // kind: List
 
 	// zero sized byte arrays
 	{input: "80", ptr: new([0]byte), value: [0]byte{}},
-	{input: "C0", ptr: new([0]byte), value: [0]byte{}},
 	{input: "01", ptr: new([0]byte), error: "rlp: input string too long for [0]uint8"},
 	{input: "8101", ptr: new([0]byte), error: "rlp: input string too long for [0]uint8"},
 

--- a/rlp/decode_test.go
+++ b/rlp/decode_test.go
@@ -112,6 +112,9 @@ func TestStreamErrors(t *testing.T) {
 		{"BFFFFFFFFFFFFFFFFFFF", calls{"Bytes"}, nil, ErrValueTooLarge},
 		{"C801", calls{"List"}, nil, ErrValueTooLarge},
 
+		// Test for list element size check overflow.
+		{"CD04040404FFFFFFFFFFFFFFFFFF0303", calls{"List", "Uint", "Uint", "Uint", "Uint", "List"}, nil, ErrElemTooLarge},
+
 		// Test for input limit overflow. Since we are counting the limit
 		// down toward zero in Stream.remaining, reading too far can overflow
 		// remaining to a large value, effectively disabling the limit.

--- a/rlp/decode_test.go
+++ b/rlp/decode_test.go
@@ -290,11 +290,6 @@ var (
 	)
 )
 
-var (
-	sharedByteArray [5]byte
-	sharedPtr       = new(*uint)
-)
-
 var decodeTests = []decodeTest{
 	// integers
 	{input: "05", ptr: new(uint32), value: uint32(5)},
@@ -315,10 +310,15 @@ var decodeTests = []decodeTest{
 	{input: "F8020004", ptr: new([]uint), error: "rlp: non-canonical size information for []uint"},
 
 	// arrays
-	{input: "C0", ptr: new([5]uint), value: [5]uint{}},
 	{input: "C50102030405", ptr: new([5]uint), value: [5]uint{1, 2, 3, 4, 5}},
+	{input: "C0", ptr: new([5]uint), error: "rlp: input list has too few elements for [5]uint"},
+	{input: "C102", ptr: new([5]uint), error: "rlp: input list has too few elements for [5]uint"},
 	{input: "C6010203040506", ptr: new([5]uint), error: "rlp: input list has too many elements for [5]uint"},
 	{input: "F8020004", ptr: new([5]uint), error: "rlp: non-canonical size information for [5]uint"},
+
+	// zero sized arrays
+	{input: "C0", ptr: new([0]uint), value: [0]uint{}},
+	{input: "C101", ptr: new([0]uint), error: "rlp: input list has too many elements for [0]uint"},
 
 	// byte slices
 	{input: "01", ptr: new([]byte), value: []byte{1}},
@@ -328,21 +328,17 @@ var decodeTests = []decodeTest{
 	{input: "8105", ptr: new([]byte), error: "rlp: non-canonical size information for []uint8"},
 
 	// byte arrays
-	{input: "01", ptr: new([5]byte), value: [5]byte{1}},
-	{input: "80", ptr: new([5]byte), value: [5]byte{}},
+	{input: "02", ptr: new([1]byte), value: [1]byte{2}},
 	{input: "850102030405", ptr: new([5]byte), value: [5]byte{1, 2, 3, 4, 5}},
 
 	// byte array errors
+	{input: "02", ptr: new([5]byte), error: "rlp: input string too short for [5]uint8"},
+	{input: "80", ptr: new([5]byte), error: "rlp: input string too short for [5]uint8"},
+	{input: "820000", ptr: new([5]byte), error: "rlp: input string too short for [5]uint8"},
 	{input: "C0", ptr: new([5]byte), error: "rlp: expected input string or byte for [5]uint8"},
 	{input: "C3010203", ptr: new([5]byte), error: "rlp: expected input string or byte for [5]uint8"},
 	{input: "86010203040506", ptr: new([5]byte), error: "rlp: input string too long for [5]uint8"},
-	{input: "8105", ptr: new([5]byte), error: "rlp: non-canonical size information for [5]uint8"},
-
-	// byte array reuse (should be zeroed)
-	{input: "850102030405", ptr: &sharedByteArray, value: [5]byte{1, 2, 3, 4, 5}},
-	{input: "01", ptr: &sharedByteArray, value: [5]byte{1}}, // kind: String
-	{input: "850102030405", ptr: &sharedByteArray, value: [5]byte{1, 2, 3, 4, 5}},
-	{input: "01", ptr: &sharedByteArray, value: [5]byte{1}}, // kind: Byte
+	{input: "8105", ptr: new([1]byte), error: "rlp: non-canonical size information for [1]uint8"},
 
 	// zero sized byte arrays
 	{input: "80", ptr: new([0]byte), value: [0]byte{}},

--- a/rlp/decode_test.go
+++ b/rlp/decode_test.go
@@ -378,7 +378,7 @@ var decodeTests = []decodeTest{
 	},
 
 	// pointers
-	{input: "00", ptr: new(*uint), value: (*uint)(nil)},
+	{input: "00", ptr: new(*uint), value: uintp(0)},
 	{input: "80", ptr: new(*uint), value: (*uint)(nil)},
 	{input: "C0", ptr: new(*uint), value: (*uint)(nil)},
 	{input: "07", ptr: new(*uint), value: uintp(7)},

--- a/rlp/encode.go
+++ b/rlp/encode.go
@@ -194,7 +194,7 @@ func (w *encbuf) Write(b []byte) (int, error) {
 
 func (w *encbuf) encode(val interface{}) error {
 	rval := reflect.ValueOf(val)
-	ti, err := cachedTypeInfo(rval.Type())
+	ti, err := cachedTypeInfo(rval.Type(), tags{})
 	if err != nil {
 		return err
 	}
@@ -485,7 +485,7 @@ func writeInterface(val reflect.Value, w *encbuf) error {
 		return nil
 	}
 	eval := val.Elem()
-	ti, err := cachedTypeInfo(eval.Type())
+	ti, err := cachedTypeInfo(eval.Type(), tags{})
 	if err != nil {
 		return err
 	}
@@ -493,7 +493,7 @@ func writeInterface(val reflect.Value, w *encbuf) error {
 }
 
 func makeSliceWriter(typ reflect.Type) (writer, error) {
-	etypeinfo, err := cachedTypeInfo1(typ.Elem())
+	etypeinfo, err := cachedTypeInfo1(typ.Elem(), tags{})
 	if err != nil {
 		return nil, err
 	}
@@ -530,7 +530,7 @@ func makeStructWriter(typ reflect.Type) (writer, error) {
 }
 
 func makePtrWriter(typ reflect.Type) (writer, error) {
-	etypeinfo, err := cachedTypeInfo1(typ.Elem())
+	etypeinfo, err := cachedTypeInfo1(typ.Elem(), tags{})
 	if err != nil {
 		return nil, err
 	}

--- a/rlp/typecache.go
+++ b/rlp/typecache.go
@@ -7,7 +7,7 @@ import (
 
 var (
 	typeCacheMutex sync.RWMutex
-	typeCache      = make(map[reflect.Type]*typeinfo)
+	typeCache      = make(map[typekey]*typeinfo)
 )
 
 type typeinfo struct {
@@ -15,13 +15,25 @@ type typeinfo struct {
 	writer
 }
 
+// represents struct tags
+type tags struct {
+	nilOK bool
+}
+
+type typekey struct {
+	reflect.Type
+	// the key must include the struct tags because they
+	// might generate a different decoder.
+	tags
+}
+
 type decoder func(*Stream, reflect.Value) error
 
 type writer func(reflect.Value, *encbuf) error
 
-func cachedTypeInfo(typ reflect.Type) (*typeinfo, error) {
+func cachedTypeInfo(typ reflect.Type, tags tags) (*typeinfo, error) {
 	typeCacheMutex.RLock()
-	info := typeCache[typ]
+	info := typeCache[typekey{typ, tags}]
 	typeCacheMutex.RUnlock()
 	if info != nil {
 		return info, nil
@@ -29,11 +41,12 @@ func cachedTypeInfo(typ reflect.Type) (*typeinfo, error) {
 	// not in the cache, need to generate info for this type.
 	typeCacheMutex.Lock()
 	defer typeCacheMutex.Unlock()
-	return cachedTypeInfo1(typ)
+	return cachedTypeInfo1(typ, tags)
 }
 
-func cachedTypeInfo1(typ reflect.Type) (*typeinfo, error) {
-	info := typeCache[typ]
+func cachedTypeInfo1(typ reflect.Type, tags tags) (*typeinfo, error) {
+	key := typekey{typ, tags}
+	info := typeCache[key]
 	if info != nil {
 		// another goroutine got the write lock first
 		return info, nil
@@ -41,21 +54,27 @@ func cachedTypeInfo1(typ reflect.Type) (*typeinfo, error) {
 	// put a dummmy value into the cache before generating.
 	// if the generator tries to lookup itself, it will get
 	// the dummy value and won't call itself recursively.
-	typeCache[typ] = new(typeinfo)
-	info, err := genTypeInfo(typ)
+	typeCache[key] = new(typeinfo)
+	info, err := genTypeInfo(typ, tags)
 	if err != nil {
 		// remove the dummy value if the generator fails
-		delete(typeCache, typ)
+		delete(typeCache, key)
 		return nil, err
 	}
-	*typeCache[typ] = *info
-	return typeCache[typ], err
+	*typeCache[key] = *info
+	return typeCache[key], err
+}
+
+type field struct {
+	index int
+	info  *typeinfo
 }
 
 func structFields(typ reflect.Type) (fields []field, err error) {
 	for i := 0; i < typ.NumField(); i++ {
 		if f := typ.Field(i); f.PkgPath == "" { // exported
-			info, err := cachedTypeInfo1(f.Type)
+			tags := parseStructTag(f.Tag.Get("rlp"))
+			info, err := cachedTypeInfo1(f.Type, tags)
 			if err != nil {
 				return nil, err
 			}
@@ -65,9 +84,13 @@ func structFields(typ reflect.Type) (fields []field, err error) {
 	return fields, nil
 }
 
-func genTypeInfo(typ reflect.Type) (info *typeinfo, err error) {
+func parseStructTag(tag string) tags {
+	return tags{nilOK: tag == "nil"}
+}
+
+func genTypeInfo(typ reflect.Type, tags tags) (info *typeinfo, err error) {
 	info = new(typeinfo)
-	if info.decoder, err = makeDecoder(typ); err != nil {
+	if info.decoder, err = makeDecoder(typ, tags); err != nil {
 		return nil, err
 	}
 	if info.writer, err = makeWriter(typ); err != nil {

--- a/whisper/envelope.go
+++ b/whisper/envelope.go
@@ -109,16 +109,17 @@ func (self *Envelope) Hash() common.Hash {
 	return self.hash
 }
 
-// rlpenv is an Envelope but is not an rlp.Decoder.
-// It is used for decoding because we need to
-type rlpenv Envelope
-
 // DecodeRLP decodes an Envelope from an RLP data stream.
 func (self *Envelope) DecodeRLP(s *rlp.Stream) error {
 	raw, err := s.Raw()
 	if err != nil {
 		return err
 	}
+	// The decoding of Envelope uses the struct fields but also needs
+	// to compute the hash of the whole RLP-encoded envelope. This
+	// type has the same structure as Envelope but is not an
+	// rlp.Decoder so we can reuse the Envelope struct definition.
+	type rlpenv Envelope
 	if err := rlp.DecodeBytes(raw, (*rlpenv)(self)); err != nil {
 		return err
 	}

--- a/whisper/peer.go
+++ b/whisper/peer.go
@@ -66,7 +66,7 @@ func (self *peer) handshake() error {
 	if packet.Code != statusCode {
 		return fmt.Errorf("peer sent %x before status packet", packet.Code)
 	}
-	s := rlp.NewStream(packet.Payload)
+	s := rlp.NewStream(packet.Payload, uint64(packet.Size))
 	if _, err := s.List(); err != nil {
 		return fmt.Errorf("bad status message: %v", err)
 	}


### PR DESCRIPTION
This is supposed to address #420 and fixes an as-of-yet unreported integer overflow vulnerability in package rlp.

Further changes in this PR will remove the optional struct fields feature, which I now believe is a better fix for #506 than checking for nil pointers all over the codebase. Please do not merge until the `in progress` label is removed.