### PR TITLE
admin.StopRPC added to console

### DIFF
--- a/cmd/geth/admin.go
+++ b/cmd/geth/admin.go
@@ -26,6 +26,7 @@ func (js *jsre) adminBindings() {
 	admin := t.Object()
 	admin.Set("suggestPeer", js.suggestPeer)
 	admin.Set("startRPC", js.startRPC)
+	admin.Set("stopRPC", js.stopRPC)
 	admin.Set("nodeInfo", js.nodeInfo)
 	admin.Set("peers", js.peers)
 	admin.Set("newAccount", js.newAccount)
@@ -139,6 +140,13 @@ func (js *jsre) startRPC(call otto.FunctionCall) otto.Value {
 	}
 
 	return otto.TrueValue()
+}
+
+func (js *jsre) stopRPC(call otto.FunctionCall) otto.Value {
+	if rpc.Stop() == nil {
+		return otto.TrueValue()
+	}
+	return otto.FalseValue()
 }
 
 func (js *jsre) suggestPeer(call otto.FunctionCall) otto.Value {

--- a/rpc/http.go
+++ b/rpc/http.go
@@ -45,7 +45,7 @@ func Start(pipe *xeth.XEth, config RpcConfig) error {
 		c := cors.New(opts)
 		handler = NewStoppableHandler(c.Handler(JSONRPC(pipe)), l.stop)
 	} else {
-		handler = JSONRPC(pipe)
+		handler = NewStoppableHandler(JSONRPC(pipe), l.stop)
 	}
 
 	go http.Serve(l, handler)

--- a/rpc/http.go
+++ b/rpc/http.go
@@ -14,7 +14,7 @@ import (
 )
 
 var rpclogger = logger.NewLogger("RPC")
-var rpclistener *StoppableTCPListener
+var rpclistener *stoppableTCPListener
 
 const (
 	jsonrpcver       = "2.0"
@@ -29,7 +29,7 @@ func Start(pipe *xeth.XEth, config RpcConfig) error {
 		return nil // RPC service already running on given host/port
 	}
 
-	l, err := NewStoppableTCPListener(fmt.Sprintf("%s:%d", config.ListenAddress, config.ListenPort))
+	l, err := newStoppableTCPListener(fmt.Sprintf("%s:%d", config.ListenAddress, config.ListenPort))
 	if err != nil {
 		rpclogger.Errorf("Can't listen on %s:%d: %v", config.ListenAddress, config.ListenPort, err)
 		return err
@@ -43,9 +43,9 @@ func Start(pipe *xeth.XEth, config RpcConfig) error {
 		opts.AllowedOrigins = []string{config.CorsDomain}
 
 		c := cors.New(opts)
-		handler = NewStoppableHandler(c.Handler(JSONRPC(pipe)), l.stop)
+		handler = newStoppableHandler(c.Handler(JSONRPC(pipe)), l.stop)
 	} else {
-		handler = NewStoppableHandler(JSONRPC(pipe), l.stop)
+		handler = newStoppableHandler(JSONRPC(pipe), l.stop)
 	}
 
 	go http.Serve(l, handler)


### PR DESCRIPTION
Adds support for stopping the rpc service in the console, this closes #729.

1. When the user issues a stopRPC command the listener is stopped immediately and new connections are not accepted.
2.  Active connections (http keep-alive) follow the go principe and run in their own goroutines. The net package doesn't provide an easy way to interact with these routines. Therefore the ClosableConnection type was added. This is a net.TCPConn but with a specialised Read method. This method tests if the listener was stopped, in that case it returns an io.EOF. If not stopped it cals the TCPConn.Read method.
3. The net package would still call the handler in case of an read error before it stops. Therefore the NewStoppableHandler is added. This wraps the default json/cors handlers and does a check if the listener was stopped. In that case it would return an error indicating that the RPC service is stopped. After that the connection is closed.

Note, it doesn't do a graceful shutdown. This could be added but will stall the console while waiting for idle connections to timeout.