### PR TITLE
Dockerfile: reduce layers from 22 to 14

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,39 +1,36 @@
 FROM ubuntu:14.04.2
 
 ## Environment setup
-ENV HOME /root
 ENV GOPATH /root/go
 ENV PATH /root/go/bin:/usr/local/go/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games
 
-RUN mkdir -p /root/go
 ENV DEBIAN_FRONTEND noninteractive
 
 ## Install base dependencies
-RUN apt-get update && apt-get upgrade -y
-RUN apt-get install -y git mercurial build-essential software-properties-common wget pkg-config libgmp3-dev libreadline6-dev libpcre3-dev libpcre++-dev
+RUN apt-get update && apt-get upgrade -y && \
+    apt-get install -y git mercurial build-essential software-properties-common wget \
+        pkg-config libgmp3-dev libreadline6-dev libpcre3-dev libpcre++-dev
 
 ## Install Qt5.4.1 (not required for CLI)
-# RUN add-apt-repository ppa:beineri/opt-qt541-trusty -y
-# RUN apt-get update -y
-# RUN apt-get install -y qt54quickcontrols qt54webengine mesa-common-dev libglu1-mesa-dev
+# RUN add-apt-repository ppa:beineri/opt-qt541-trusty -y && \
+#     apt-get install -y qt54quickcontrols qt54webengine mesa-common-dev libglu1-mesa-dev
 # ENV PKG_CONFIG_PATH /opt/qt54/lib/pkgconfig
 
-# Install Golang
-RUN wget https://storage.googleapis.com/golang/go1.4.2.linux-amd64.tar.gz
-RUN tar -C /usr/local -xzf go*.tar.gz && go version
+# Install Go
+RUN wget https://storage.googleapis.com/golang/go1.4.2.linux-amd64.tar.gz && \
+    tar -C /usr/local -xzf go*.tar.gz && \
+    go version
 
-# this is a workaround, to make sure that docker's cache is invalidated whenever the git repo changes
+# Workaround, to make sure that docker's cache is invalidated whenever the git repo changes
 ADD https://api.github.com/repos/ethereum/go-ethereum/git/refs/heads/develop file_does_not_exist
 
 ## Fetch and install go-ethereum
-RUN mkdir -p $GOPATH/src/github.com/ethereum/
-RUN git clone https://github.com/ethereum/go-ethereum $GOPATH/src/github.com/ethereum/go-ethereum
-WORKDIR $GOPATH/src/github.com/ethereum/go-ethereum
-RUN git checkout develop
-RUN GOPATH=$GOPATH:$GOPATH/src/github.com/ethereum/go-ethereum/Godeps/_workspace go install -v ./cmd/geth
+RUN mkdir -p $GOPATH/src/github.com/ethereum/                                                             && \
+    git clone https://github.com/ethereum/go-ethereum $GOPATH/src/github.com/ethereum/go-ethereum         && \
+    cd $GOPATH/src/github.com/ethereum/go-ethereum                                                        && \
+    git checkout develop                                                                                  && \
+    GOPATH=$GOPATH:$GOPATH/src/github.com/ethereum/go-ethereum/Godeps/_workspace go install -v ./cmd/geth
 
 ## Run & expose JSON RPC
 ENTRYPOINT ["geth", "-rpc=true", "-rpcport=8545"]
 EXPOSE 8545
-
-

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,28 +8,32 @@ ENV DEBIAN_FRONTEND noninteractive
 
 ## Install base dependencies
 RUN apt-get update && apt-get upgrade -y && \
-    apt-get install -y git mercurial build-essential software-properties-common wget \
-        pkg-config libgmp3-dev libreadline6-dev libpcre3-dev libpcre++-dev --no-install-recommends
+    apt-get install -y build-essential software-properties-common wget pkg-config \
+    	libgmp3-dev unzip --no-install-recommends
 
 ## Install Qt5.4.1 (not required for CLI)
 # RUN add-apt-repository ppa:beineri/opt-qt541-trusty -y && \
 #     apt-get install -y qt54quickcontrols qt54webengine mesa-common-dev libglu1-mesa-dev
 # ENV PKG_CONFIG_PATH /opt/qt54/lib/pkgconfig
 
-# Install Go, dump the race detector
+# Install Go, dump the tarball and race detector
 RUN wget https://storage.googleapis.com/golang/go1.4.2.linux-amd64.tar.gz && \
     tar -C /usr/local -xzf go*.tar.gz                                     && \
-    rm -rf /usr/local/go/pkg/linux_amd64_race                             && \
+    rm -rf go*.tar.gz /usr/local/go/pkg/linux_amd64_race                  && \
     go version
 
 # Workaround, to make sure that docker's cache is invalidated whenever the git repo changes
 ADD https://api.github.com/repos/ethereum/go-ethereum/git/refs/heads/develop file_does_not_exist
 
 ## Fetch and install go-ethereum
-RUN mkdir -p $GOPATH/src/github.com/ethereum/                                                             && \
-    git clone https://github.com/ethereum/go-ethereum $GOPATH/src/github.com/ethereum/go-ethereum         && \
-    cd $GOPATH/src/github.com/ethereum/go-ethereum                                                        && \
-    git checkout develop                                                                                  && \
+RUN mkdir -p $GOPATH/src/github.com/ethereum                                                              && \
+    cd $GOPATH/src/github.com/ethereum                                                                    && \
+    \
+    wget https://github.com/ethereum/go-ethereum/archive/develop.zip                                      && \
+    unzip *.zip && mv go-ethereum-develop go-ethereum                                                     && \
+    rm -f *.zip                                                                                           && \
+    \
+    cd go-ethereum                                                                                        && \
     GOPATH=$GOPATH:$GOPATH/src/github.com/ethereum/go-ethereum/Godeps/_workspace go install -v ./cmd/geth
 
 ## Run & expose JSON RPC

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,8 +8,7 @@ ENV DEBIAN_FRONTEND noninteractive
 
 ## Install base dependencies
 RUN apt-get update && apt-get upgrade -y && \
-    apt-get install -y build-essential software-properties-common wget pkg-config \
-    	libgmp3-dev unzip --no-install-recommends
+    apt-get install -y build-essential ca-certificates pkg-config libgmp3-dev wget unzip --no-install-recommends
 
 ## Install Qt5.4.1 (not required for CLI)
 # RUN add-apt-repository ppa:beineri/opt-qt541-trusty -y && \
@@ -34,7 +33,8 @@ RUN mkdir -p $GOPATH/src/github.com/ethereum                                    
     rm -f *.zip                                                                                           && \
     \
     cd go-ethereum                                                                                        && \
-    GOPATH=$GOPATH:$GOPATH/src/github.com/ethereum/go-ethereum/Godeps/_workspace go install -v ./cmd/geth
+    GOPATH=$GOPATH:$GOPATH/src/github.com/ethereum/go-ethereum/Godeps/_workspace go install -v ./cmd/geth && \
+    rm -rf $GOPATH/pkg $GOPATH/src/github.com/ethereum/go-ethereum/Godeps/_workspace/pkg
 
 ## Run & expose JSON RPC
 ENTRYPOINT ["geth", "-rpc=true", "-rpcport=8545"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,16 +9,17 @@ ENV DEBIAN_FRONTEND noninteractive
 ## Install base dependencies
 RUN apt-get update && apt-get upgrade -y && \
     apt-get install -y git mercurial build-essential software-properties-common wget \
-        pkg-config libgmp3-dev libreadline6-dev libpcre3-dev libpcre++-dev
+        pkg-config libgmp3-dev libreadline6-dev libpcre3-dev libpcre++-dev --no-install-recommends
 
 ## Install Qt5.4.1 (not required for CLI)
 # RUN add-apt-repository ppa:beineri/opt-qt541-trusty -y && \
 #     apt-get install -y qt54quickcontrols qt54webengine mesa-common-dev libglu1-mesa-dev
 # ENV PKG_CONFIG_PATH /opt/qt54/lib/pkgconfig
 
-# Install Go
+# Install Go, dump the race detector
 RUN wget https://storage.googleapis.com/golang/go1.4.2.linux-amd64.tar.gz && \
-    tar -C /usr/local -xzf go*.tar.gz && \
+    tar -C /usr/local -xzf go*.tar.gz                                     && \
+    rm -rf /usr/local/go/pkg/linux_amd64_race                             && \
     go version
 
 # Workaround, to make sure that docker's cache is invalidated whenever the git repo changes


### PR DESCRIPTION
I went through the Dockerfile and found a lot of operations that could be done in a single build step, as well as a few that were unnecessary. Merging and cleaning these reduced the docker image layers from 22 to 14, which is IMHO a significant amount, especially when downloading from the docker hub.

There are probably a few more things that could be optimized to reduce the total size of the downloaded image (e.g. dumping the Go race detector). I'll look into these when time allows :)

```
> docker images --tree
└─511136ea3c5a Virtual Size: 0 B
  └─f3c84ac3a053 Virtual Size: 188.1 MB
    └─a1a958a24818 Virtual Size: 188.3 MB
      └─9fec74352904 Virtual Size: 188.3 MB
        └─d0955f21bf24 Virtual Size: 188.3 MB Tags: ubuntu:14.04.2
          ├─1ba1e49bee3d Virtual Size: 188.3 MB
          │ └─98f2b9eb0afb Virtual Size: 188.3 MB
          │   └─5533aa79733b Virtual Size: 188.3 MB
          │     └─51e8b2978bc6 Virtual Size: 515.3 MB
          │       └─0cf26d7851e1 Virtual Size: 807.1 MB
          │         └─b654e5daebda Virtual Size: 807.1 MB
          │           └─b3ddd82c1a0e Virtual Size: 1.158 GB
          │             └─ae218b86f582 Virtual Size: 1.158 GB
          │               └─9f4d93f64161 Virtual Size: 1.158 GB Tags: my-client-go:latest
          ├─f3896a2e775b Virtual Size: 188.3 MB
          │ └─4ba4dac83fea Virtual Size: 188.3 MB
          │   └─97f770c6a08a Virtual Size: 188.3 MB
          │     └─d5459349b258 Virtual Size: 188.3 MB
          │       └─3acd0bb93508 Virtual Size: 188.3 MB
          │         └─a94164fbb142 Virtual Size: 237 MB
          │           └─3b0d61a0fbd2 Virtual Size: 519 MB
          │             └─0a63526ab08d Virtual Size: 581.4 MB
          │               └─811e4735624e Virtual Size: 810.8 MB
          │                 └─3e573791bd56 Virtual Size: 810.8 MB
          │                   └─387003fa84a6 Virtual Size: 810.8 MB
          │                     └─3127181c6802 Virtual Size: 1.116 GB
          │                       └─8cc5952bc39a Virtual Size: 1.116 GB
          │                         └─f8e70a768af1 Virtual Size: 1.117 GB
          │                           └─93f4a0ce5c32 Virtual Size: 1.162 GB
          │                             └─931cd0599465 Virtual Size: 1.162 GB
          │                               └─80e8a8deec12 Virtual Size: 1.162 GB Tags: ethereum/client-go:latest
```