### PR TITLE
Makefile: for non-gophers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,8 @@ mist
 cmd/mist/mist
 deploy/osx/Mist.app
 deploy/osx/Mist\ Installer.dmg
+
+# used by the Makefile
+/build/_workspace/
+/build/bin/
+

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,22 @@
+# This Makefile is meant to be used by people that do not usually work
+# with Go source code. If you know what GOPATH is then you probably
+# don't need to bother with make.
+#
+# Note that there is no way to run the tests or do anything other than
+# building the binaries. This is by design.
+
+.PHONY: geth mist clean
+GOBIN = build/bin
+
+geth:
+	build/env.sh go install -v github.com/ethereum/go-ethereum/cmd/geth
+	@echo "Done building."
+	@echo "Run \"$(GOBIN)/geth\" to launch geth."
+
+mist:
+	build/env.sh go install -v github.com/ethereum/go-ethereum/cmd/mist
+	@echo "Done building."
+	@echo "Run \"$(GOBIN)/mist --asset_path=cmd/mist/assets\" to launch mist."
+
+clean:
+	rm -fr build/_workspace/pkg/ $(GOBIN)/*

--- a/build/env.sh
+++ b/build/env.sh
@@ -1,0 +1,28 @@
+#!/bin/sh
+
+set -e
+
+if [ ! -f "build/env.sh" ]; then
+    echo "$0 must be run from the root of the repository."
+    exit 2
+fi
+
+# Create fake Go workspace if it doesn't exist yet.
+workspace="$PWD/build/_workspace"
+root="$PWD"
+ethdir="$workspace/src/github.com/ethereum"
+if [ ! -L "$ethdir/go-ethereum" ]; then
+    mkdir -p "$ethdir"
+    cd "$ethdir"
+    ln -s ../../../../../. go-ethereum
+    cd "$root"
+fi
+
+# Set up the environment to use the workspace.
+# Also add Godeps workspace so we build using canned dependencies.
+GOPATH="$ethdir/go-ethereum/Godeps/_workspace:$workspace"
+GOBIN="$PWD/build/bin"
+export GOPATH GOBIN
+
+# Launch the arguments with the configured environment.
+exec $@


### PR DESCRIPTION
Many people need or want to build go-ethereum from the git repository,
mostly to stay up to date with recent changes. We cannot expect that
people without Go experience grok the Go workspace concept.

With the Makefile, building from github requires only
three steps (provided that a Go toolchain is installed):

    - git clone https://github.com/ethereum/go-ethereum
    - ... install C libraries (libgmp, etc.) ...
    - make

## How it works

This adds a fake Go workspace tree (in `build/_workspace`) with a symlink pointing back to the root of the repo. All go commands executed by the `Makefile` run with this GOPATH and the Godeps directory configured in the environment.