### PR TITLE
Add blocktests as go tests

### DIFF
--- a/tests/block_test.go
+++ b/tests/block_test.go
@@ -1,0 +1,78 @@
+package tests
+
+// TODO: figure out how to move this file to tests package and get imports working there
+import (
+	//	"os"
+	"path"
+
+	// TODO: refactor to avoid depending on CLI stuff
+	"github.com/ethereum/go-ethereum/accounts"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/eth"
+	"github.com/ethereum/go-ethereum/ethdb"
+	"testing"
+)
+
+// TODO: refactor test setup & execution to better align with vm and tx tests
+// TODO: refactor to avoid duplication with cmd/geth/blocktest.go
+func TestBcValidBlockTests(t *testing.T) {
+	//dir, _ := os.Getwd()
+	//t.Logf("CWD: ", dir)
+	runBlockTestsInFile("files/BlockTests/bcValidBlockTest.json", t)
+}
+
+func runBlockTestsInFile(filepath string, t *testing.T) {
+	bt, err := LoadBlockTests(filepath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, test := range bt {
+		runBlockTest(test, t)
+	}
+}
+
+func runBlockTest(test *BlockTest, t *testing.T) {
+	cfg := testEthConfig()
+	ethereum, err := eth.New(cfg)
+	if err != nil {
+		t.Fatalf("%v", err)
+	}
+
+	err = ethereum.Start()
+	if err != nil {
+		t.Fatalf("%v", err)
+	}
+
+	// import the genesis block
+	ethereum.ResetWithGenesisBlock(test.Genesis)
+
+	// import pre accounts
+	statedb, err := test.InsertPreState(ethereum.StateDb())
+	if err != nil {
+		t.Fatalf("InsertPreState: %v", err)
+	}
+
+	// insert the test blocks, which will execute all transactions
+	if err := test.InsertBlocks(ethereum.ChainManager()); err != nil {
+		t.Fatalf("Block Test load error: %v %T", err, err)
+	}
+	t.Log("chain loaded")
+
+	if err := test.ValidatePostState(statedb); err != nil {
+		t.Fatal("post state validation failed: %v", err)
+	}
+	t.Log("Block Test post state validated.")
+}
+
+func testEthConfig() *eth.Config {
+	ks := crypto.NewKeyStorePassphrase(path.Join(common.DefaultDataDir(), "keys"))
+
+	return &eth.Config{
+		DataDir:        common.DefaultDataDir(),
+		LogLevel:       5,
+		Etherbase:      "primary",
+		AccountManager: accounts.NewManager(ks),
+		NewDB:          func(path string) (common.Database, error) { return ethdb.NewMemDatabase() },
+	}
+}

--- a/tests/block_test_util.go
+++ b/tests/block_test_util.go
@@ -238,10 +238,10 @@ func mustConvertBytes(in string) []byte {
 	if in == "0x" {
 		return []byte{}
 	}
-	h := nibbleFix(strings.TrimPrefix(in, "0x"))
+	h := unfuckFuckedHex(strings.TrimPrefix(in, "0x"))
 	out, err := hex.DecodeString(h)
 	if err != nil {
-		panic(fmt.Errorf("invalid hex: %q", h))
+		panic(fmt.Errorf("invalid hex: %q: ", h, err))
 	}
 	return out
 }
@@ -255,7 +255,7 @@ func mustConvertHash(in string) common.Hash {
 }
 
 func mustConvertAddress(in string) common.Address {
-	out, err := hex.DecodeString(nibbleFix(strings.TrimPrefix(in, "0x")))
+	out, err := hex.DecodeString(strings.TrimPrefix(in, "0x"))
 	if err != nil {
 		panic(fmt.Errorf("invalid hex: %q", in))
 	}
@@ -318,6 +318,7 @@ func findLine(data []byte, offset int64) (line int) {
 	return
 }
 
+// Nothing to see here, please move along...
 func prepInt(base int, s string) string {
 	if base == 16 {
 		if strings.HasPrefix(s, "0x") {
@@ -329,6 +330,11 @@ func prepInt(base int, s string) string {
 		s = nibbleFix(s)
 	}
 	return s
+}
+
+// don't ask
+func unfuckFuckedHex(almostHex string) string {
+	return nibbleFix(strings.Replace(almostHex, "v", "", -1))
 }
 
 func nibbleFix(s string) string {

--- a/tests/blocktest.go
+++ b/tests/blocktest.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core"
 	"github.com/ethereum/go-ethereum/core/state"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/rlp"
@@ -73,8 +74,8 @@ type btBlock struct {
 
 type BlockTest struct {
 	Genesis *types.Block
-	Blocks  []*types.Block
 
+	json        *btJSON
 	preAccounts map[string]btAccount
 }
 
@@ -88,7 +89,7 @@ func LoadBlockTests(file string) (map[string]*BlockTest, error) {
 	for name, in := range bt {
 		var err error
 		if out[name], err = convertTest(in); err != nil {
-			return nil, fmt.Errorf("bad test %q: %v", err)
+			return out, fmt.Errorf("bad test %q: %v", name, err)
 		}
 	}
 	return out, nil
@@ -124,6 +125,15 @@ func (t *BlockTest) InsertPreState(db common.Database) (*state.StateDB, error) {
 	return statedb, nil
 }
 
+// InsertBlocks loads the test's blocks into the given chain.
+func (t *BlockTest) InsertBlocks(chain *core.ChainManager) error {
+	blocks, err := t.convertBlocks()
+	if err != nil {
+		return err
+	}
+	return chain.InsertChain(blocks)
+}
+
 func (t *BlockTest) ValidatePostState(statedb *state.StateDB) error {
 	for addrString, acct := range t.preAccounts {
 		// XXX: is is worth it checking for errors here?
@@ -149,6 +159,21 @@ func (t *BlockTest) ValidatePostState(statedb *state.StateDB) error {
 	return nil
 }
 
+func (t *BlockTest) convertBlocks() (blocks []*types.Block, err error) {
+	// the conversion handles errors by catching panics.
+	// you might consider this ugly, but the alternative (passing errors)
+	// would be much harder to read.
+	defer func() {
+		if recovered := recover(); recovered != nil {
+			buf := make([]byte, 64<<10)
+			buf = buf[:runtime.Stack(buf, false)]
+			err = fmt.Errorf("%v\n%s", recovered, buf)
+		}
+	}()
+	blocks = mustConvertBlocks(t.json.Blocks)
+	return blocks, nil
+}
+
 func convertTest(in *btJSON) (out *BlockTest, err error) {
 	// the conversion handles errors by catching panics.
 	// you might consider this ugly, but the alternative (passing errors)
@@ -160,9 +185,8 @@ func convertTest(in *btJSON) (out *BlockTest, err error) {
 			err = fmt.Errorf("%v\n%s", recovered, buf)
 		}
 	}()
-	out = &BlockTest{preAccounts: in.Pre}
+	out = &BlockTest{preAccounts: in.Pre, json: in}
 	out.Genesis = mustConvertGenesis(in.GenesisBlockHeader)
-	out.Blocks = mustConvertBlocks(in.Blocks)
 	return out, err
 }
 
@@ -187,13 +211,13 @@ func mustConvertHeader(in btHeader) *types.Header {
 		UncleHash:   mustConvertHash(in.UncleHash),
 		ParentHash:  mustConvertHash(in.ParentHash),
 		Extra:       mustConvertBytes(in.ExtraData),
-		GasUsed:     mustConvertBigInt(in.GasUsed),
-		GasLimit:    mustConvertBigInt(in.GasLimit),
-		Difficulty:  mustConvertBigInt(in.Difficulty),
-		Time:        mustConvertUint(in.Timestamp),
+		GasUsed:     mustConvertBigInt(in.GasUsed, 10),
+		GasLimit:    mustConvertBigInt(in.GasLimit, 10),
+		Difficulty:  mustConvertBigInt(in.Difficulty, 10),
+		Time:        mustConvertUint(in.Timestamp, 10),
 	}
 	// XXX cheats? :-)
-	header.SetNonce(common.BytesToHash(mustConvertBytes(in.Nonce)).Big().Uint64())
+	header.SetNonce(mustConvertUint(in.Nonce, 16))
 	return header
 }
 
@@ -203,7 +227,7 @@ func mustConvertBlocks(testBlocks []btBlock) []*types.Block {
 		var b types.Block
 		r := bytes.NewReader(mustConvertBytes(inb.Rlp))
 		if err := rlp.Decode(r, &b); err != nil {
-			panic(fmt.Errorf("invalid block %d: %q", i, inb.Rlp))
+			panic(fmt.Errorf("invalid block %d: %q\nerror: %v", i, inb.Rlp, err))
 		}
 		out = append(out, &b)
 	}
@@ -214,7 +238,7 @@ func mustConvertBytes(in string) []byte {
 	if in == "0x" {
 		return []byte{}
 	}
-	h := strings.TrimPrefix(unfuckCPPHexInts(in), "0x")
+	h := nibbleFix(strings.TrimPrefix(in, "0x"))
 	out, err := hex.DecodeString(h)
 	if err != nil {
 		panic(fmt.Errorf("invalid hex: %q", h))
@@ -231,7 +255,7 @@ func mustConvertHash(in string) common.Hash {
 }
 
 func mustConvertAddress(in string) common.Address {
-	out, err := hex.DecodeString(strings.TrimPrefix(in, "0x"))
+	out, err := hex.DecodeString(nibbleFix(strings.TrimPrefix(in, "0x")))
 	if err != nil {
 		panic(fmt.Errorf("invalid hex: %q", in))
 	}
@@ -246,16 +270,18 @@ func mustConvertBloom(in string) types.Bloom {
 	return types.BytesToBloom(out)
 }
 
-func mustConvertBigInt(in string) *big.Int {
-	out, ok := new(big.Int).SetString(unfuckCPPHexInts(in), 0)
+func mustConvertBigInt(in string, base int) *big.Int {
+	in = prepInt(base, in)
+	out, ok := new(big.Int).SetString(in, base)
 	if !ok {
 		panic(fmt.Errorf("invalid integer: %q", in))
 	}
 	return out
 }
 
-func mustConvertUint(in string) uint64 {
-	out, err := strconv.ParseUint(unfuckCPPHexInts(in), 0, 64)
+func mustConvertUint(in string, base int) uint64 {
+	in = prepInt(base, in)
+	out, err := strconv.ParseUint(in, base, 64)
 	if err != nil {
 		panic(fmt.Errorf("invalid integer: %q", in))
 	}
@@ -292,12 +318,22 @@ func findLine(data []byte, offset int64) (line int) {
 	return
 }
 
-func unfuckCPPHexInts(s string) string {
-	if s == "0x" { // no respect for the empty value :(
-		return "0x00"
+func prepInt(base int, s string) string {
+	if base == 16 {
+		if strings.HasPrefix(s, "0x") {
+			s = s[2:]
+		}
+		if len(s) == 0 {
+			s = "00"
+		}
+		s = nibbleFix(s)
 	}
-	if (len(s) % 2) != 0 { // motherfucking nibbles
-		return "0x0" + s[2:]
+	return s
+}
+
+func nibbleFix(s string) string {
+	if len(s)%2 != 0 {
+		s = "0" + s
 	}
 	return s
 }

--- a/tests/transaction_test_util.go
+++ b/tests/transaction_test_util.go
@@ -127,15 +127,15 @@ func convertTestTypes(txTest TransactionTest) (sender, to common.Address,
 	txInputData = mustConvertBytes(txTest.Transaction.Data)
 	rlpBytes = mustConvertBytes(txTest.Rlp)
 
-	gasLimit = mustConvertBigInt(txTest.Transaction.GasLimit)
-	gasPrice = mustConvertBigInt(txTest.Transaction.GasPrice)
-	value = mustConvertBigInt(txTest.Transaction.Value)
+	gasLimit = mustConvertBigInt(txTest.Transaction.GasLimit, 16)
+	gasPrice = mustConvertBigInt(txTest.Transaction.GasPrice, 16)
+	value = mustConvertBigInt(txTest.Transaction.Value, 16)
 
 	r = common.Bytes2Big(mustConvertBytes(txTest.Transaction.R))
 	s = common.Bytes2Big(mustConvertBytes(txTest.Transaction.S))
 
-	nonce = mustConvertUint(txTest.Transaction.Nonce)
-	v = mustConvertUint(txTest.Transaction.V)
+	nonce = mustConvertUint(txTest.Transaction.Nonce, 16)
+	v = mustConvertUint(txTest.Transaction.V, 16)
 
 	return sender, to, txInputData, rlpBytes, gasLimit, gasPrice, value, r, s, nonce, v, nil
 }

--- a/tests/transaction_test_util.go
+++ b/tests/transaction_test_util.go
@@ -2,8 +2,8 @@ package tests
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
-	"math/big"
 	"runtime"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -49,70 +49,44 @@ func RunTransactionTests(file string, notWorking map[string]bool) error {
 }
 
 func runTest(txTest TransactionTest) (err error) {
-	expectedSender, expectedTo, expectedData, rlpBytes, expectedGasLimit, expectedGasPrice, expectedValue, expectedR, expectedS, expectedNonce, expectedV, err := convertTestTypes(txTest)
+	tx := new(types.Transaction)
+	err = rlp.DecodeBytes(mustConvertBytes(txTest.Rlp), tx)
 
 	if err != nil {
-		if txTest.Sender == "" { // tx is invalid and this is expected (test OK)
+		if txTest.Sender == "" {
+			// RLP decoding failed and this is expected (test OK)
 			return nil
 		} else {
-			return err // tx is invalid and this is NOT expected (test FAIL)
-		}
-	}
-	tx := new(types.Transaction)
-	rlp.DecodeBytes(rlpBytes, tx)
-	//fmt.Println("HURR tx: %v", tx)
-	sender, err := tx.From()
-	if err != nil {
-		return err
-	}
-
-	if expectedSender != sender {
-		return fmt.Errorf("Sender mismatch: %v %v", expectedSender, sender)
-	}
-	if !bytes.Equal(expectedData, tx.Payload) {
-		return fmt.Errorf("Tx input data mismatch: %#v %#v", expectedData, tx.Payload)
-	}
-	if expectedGasLimit.Cmp(tx.GasLimit) != 0 {
-		return fmt.Errorf("GasLimit mismatch: %v %v", expectedGasLimit, tx.GasLimit)
-	}
-	if expectedGasPrice.Cmp(tx.Price) != 0 {
-		return fmt.Errorf("GasPrice mismatch: %v %v", expectedGasPrice, tx.Price)
-	}
-	if expectedNonce != tx.AccountNonce {
-		return fmt.Errorf("Nonce mismatch: %v %v", expectedNonce, tx.AccountNonce)
-	}
-	if expectedR.Cmp(tx.R) != 0 {
-		return fmt.Errorf("R mismatch: %v %v", expectedR, tx.R)
-	}
-	if expectedS.Cmp(tx.S) != 0 {
-		return fmt.Errorf("S mismatch: %v %v", expectedS, tx.S)
-	}
-	if expectedV != uint64(tx.V) {
-		return fmt.Errorf("V mismatch: %v %v", expectedV, uint64(tx.V))
-	}
-	if tx.Recipient == nil {
-		if expectedTo != common.BytesToAddress([]byte{}) { // "empty" or "zero" address
-			return fmt.Errorf("To mismatch when recipient is nil (contract creation): %v", expectedTo)
-		}
-	} else {
-		if expectedTo != *tx.Recipient {
-			return fmt.Errorf("To mismatch: %v %v", expectedTo, *tx.Recipient)
+			// RLP decoding failed but is expected to succeed (test FAIL)
+			return errors.New("RLP decoding failed when expected to succeed")
 		}
 	}
 
-	if expectedValue.Cmp(tx.Amount) != 0 {
-		return fmt.Errorf("Value mismatch: %v %v", expectedValue, tx.Amount)
+	validationError := verifyTxFields(txTest, tx)
+	if txTest.Sender == "" {
+		if validationError != nil {
+			// RLP decoding works but validation should fail (test OK)
+			return nil
+		} else {
+			// RLP decoding works but validation should fail (test FAIL)
+			// (this should not be possible but added here for completeness)
+			return errors.New("Field validations succeeded but should fail")
+		}
 	}
 
-	return nil
+	if txTest.Sender != "" {
+		if validationError == nil {
+			// RLP decoding works and validations pass (test OK)
+			return nil
+		} else {
+			// RLP decoding works and validations pass (test FAIL)
+			return errors.New("Field validations failed after RLP decoding")
+		}
+	}
+	return errors.New("Should not happen: verify RLP decoding and field validation")
 }
 
-func convertTestTypes(txTest TransactionTest) (sender, to common.Address,
-	txInputData, rlpBytes []byte,
-	gasLimit, gasPrice, value, r, s *big.Int,
-	nonce, v uint64,
-	err error) {
-
+func verifyTxFields(txTest TransactionTest, decodedTx *types.Transaction) (err error) {
 	defer func() {
 		if recovered := recover(); recovered != nil {
 			buf := make([]byte, 64<<10)
@@ -121,21 +95,66 @@ func convertTestTypes(txTest TransactionTest) (sender, to common.Address,
 		}
 	}()
 
-	sender = mustConvertAddress(txTest.Sender)
-	to = mustConvertAddress(txTest.Transaction.To)
+	decodedSender, err := decodedTx.From()
+	if err != nil {
+		return err
+	}
 
-	txInputData = mustConvertBytes(txTest.Transaction.Data)
-	rlpBytes = mustConvertBytes(txTest.Rlp)
+	expectedSender := mustConvertAddress(txTest.Sender)
+	if expectedSender != decodedSender {
+		return fmt.Errorf("Sender mismatch: %v %v", expectedSender, decodedSender)
+	}
 
-	gasLimit = mustConvertBigInt(txTest.Transaction.GasLimit, 16)
-	gasPrice = mustConvertBigInt(txTest.Transaction.GasPrice, 16)
-	value = mustConvertBigInt(txTest.Transaction.Value, 16)
+	expectedData := mustConvertBytes(txTest.Transaction.Data)
+	if !bytes.Equal(expectedData, decodedTx.Payload) {
+		return fmt.Errorf("Tx input data mismatch: %#v %#v", expectedData, decodedTx.Payload)
+	}
 
-	r = common.Bytes2Big(mustConvertBytes(txTest.Transaction.R))
-	s = common.Bytes2Big(mustConvertBytes(txTest.Transaction.S))
+	expectedGasLimit := mustConvertBigInt(txTest.Transaction.GasLimit, 16)
+	if expectedGasLimit.Cmp(decodedTx.GasLimit) != 0 {
+		return fmt.Errorf("GasLimit mismatch: %v %v", expectedGasLimit, decodedTx.GasLimit)
+	}
 
-	nonce = mustConvertUint(txTest.Transaction.Nonce, 16)
-	v = mustConvertUint(txTest.Transaction.V, 16)
+	expectedGasPrice := mustConvertBigInt(txTest.Transaction.GasPrice, 16)
+	if expectedGasPrice.Cmp(decodedTx.Price) != 0 {
+		return fmt.Errorf("GasPrice mismatch: %v %v", expectedGasPrice, decodedTx.Price)
+	}
 
-	return sender, to, txInputData, rlpBytes, gasLimit, gasPrice, value, r, s, nonce, v, nil
+	expectedNonce := mustConvertUint(txTest.Transaction.Nonce, 16)
+	if expectedNonce != decodedTx.AccountNonce {
+		return fmt.Errorf("Nonce mismatch: %v %v", expectedNonce, decodedTx.AccountNonce)
+	}
+
+	expectedR := common.Bytes2Big(mustConvertBytes(txTest.Transaction.R))
+	if expectedR.Cmp(decodedTx.R) != 0 {
+		return fmt.Errorf("R mismatch: %v %v", expectedR, decodedTx.R)
+	}
+
+	expectedS := common.Bytes2Big(mustConvertBytes(txTest.Transaction.S))
+	if expectedS.Cmp(decodedTx.S) != 0 {
+		return fmt.Errorf("S mismatch: %v %v", expectedS, decodedTx.S)
+	}
+
+	expectedV := mustConvertUint(txTest.Transaction.V, 16)
+	if expectedV != uint64(decodedTx.V) {
+		return fmt.Errorf("V mismatch: %v %v", expectedV, uint64(decodedTx.V))
+	}
+
+	expectedTo := mustConvertAddress(txTest.Transaction.To)
+	if decodedTx.Recipient == nil {
+		if expectedTo != common.BytesToAddress([]byte{}) { // "empty" or "zero" address
+			return fmt.Errorf("To mismatch when recipient is nil (contract creation): %v", expectedTo)
+		}
+	} else {
+		if expectedTo != *decodedTx.Recipient {
+			return fmt.Errorf("To mismatch: %v %v", expectedTo, *decodedTx.Recipient)
+		}
+	}
+
+	expectedValue := mustConvertBigInt(txTest.Transaction.Value, 16)
+	if expectedValue.Cmp(decodedTx.Amount) != 0 {
+		return fmt.Errorf("Value mismatch: %v %v", expectedValue, decodedTx.Amount)
+	}
+
+	return nil
 }


### PR DESCRIPTION
* Merge of Felix's fixes to geth blocktest cmd and HEX encodings
* Add fixes to parsing and converting of fields in tx tests
* Correct logic in tx tests; validation of fields and correct
  logic for when RLP decoding works/fails and when this is
  expected or not
* Rename files for consistency
* Add block tests wrapper to run block tests with go test