### PR TITLE
core: transaction queue

### DIFF
--- a/common/natspec/natspec_e2e_test.go
+++ b/common/natspec/natspec_e2e_test.go
@@ -220,7 +220,7 @@ func (self *testFrontend) applyTxs() {
 	block := self.ethereum.ChainManager().NewBlock(cb)
 	coinbase := self.stateDb.GetStateObject(cb)
 	coinbase.SetGasPool(big.NewInt(10000000))
-	txs := self.ethereum.TxPool().GetTransactions()
+	txs := self.ethereum.TxPool().GetQueuedTransactions()
 
 	for i := 0; i < len(txs); i++ {
 		for _, tx := range txs {

--- a/core/block_processor.go
+++ b/core/block_processor.go
@@ -258,7 +258,7 @@ func (sm *BlockProcessor) processWithParent(block, parent *types.Block) (logs st
 	state.Sync()
 
 	// Remove transactions from the pool
-	sm.txpool.RemoveSet(block.Transactions())
+	sm.txpool.RemoveTransactions(block.Transactions())
 
 	// This puts transactions in a extra db for rpc
 	for i, tx := range block.Transactions() {

--- a/core/chain_makers.go
+++ b/core/chain_makers.go
@@ -108,7 +108,9 @@ func makeChain(bman *BlockProcessor, parent *types.Block, max int, db common.Dat
 // Create a new chain manager starting from given block
 // Effectively a fork factory
 func newChainManager(block *types.Block, eventMux *event.TypeMux, db common.Database) *ChainManager {
-	bc := &ChainManager{blockDb: db, stateDb: db, genesisBlock: GenesisBlock(db), eventMux: eventMux}
+	genesis := GenesisBlock(db)
+	bc := &ChainManager{blockDb: db, stateDb: db, genesisBlock: genesis, eventMux: eventMux}
+	bc.txState = state.ManageState(state.New(genesis.Root(), db))
 	bc.futureBlocks = NewBlockCache(1000)
 	if block == nil {
 		bc.Reset()

--- a/core/chain_manager.go
+++ b/core/chain_manager.go
@@ -576,7 +576,7 @@ func (self *ChainManager) InsertChain(chain types.Blocks) error {
 				})
 
 				self.setTransState(state.New(block.Root(), self.stateDb))
-				self.setTxState(state.New(block.Root(), self.stateDb))
+				self.txState.SetState(state.New(block.Root(), self.stateDb))
 
 				queue[i] = ChainEvent{block, logs}
 				queueEvent.canonicalCount++

--- a/core/error.go
+++ b/core/error.go
@@ -81,7 +81,7 @@ func (err *NonceErr) Error() string {
 }
 
 func NonceError(is, exp uint64) *NonceErr {
-	return &NonceErr{Message: fmt.Sprintf("Transaction w/ invalid nonce (%d / %d)", is, exp), Is: is, Exp: exp}
+	return &NonceErr{Message: fmt.Sprintf("Transaction w/ invalid nonce. tx=%d  state=%d)", is, exp), Is: is, Exp: exp}
 }
 
 func IsNonceErr(err error) bool {

--- a/core/transaction_pool.go
+++ b/core/transaction_pool.go
@@ -229,8 +229,10 @@ func (self *TxPool) queueTx(tx *types.Transaction) {
 func (pool *TxPool) addTx(tx *types.Transaction) {
 	if _, ok := pool.txs[tx.Hash()]; !ok {
 		pool.txs[tx.Hash()] = tx
-		// Notify the subscribers
-		pool.eventMux.Post(TxPreEvent{tx})
+		// Notify the subscribers. This event is posted in a goroutine
+		// because it's possible that somewhere during the post "Remove transaction"
+		// gets called which will then wait for the global tx pool lock and deadlock.
+		go pool.eventMux.Post(TxPreEvent{tx})
 	}
 }
 

--- a/core/transaction_pool.go
+++ b/core/transaction_pool.go
@@ -201,6 +201,18 @@ func (self *TxPool) GetTransactions() (txs types.Transactions) {
 	return
 }
 
+func (self *TxPool) GetQueuedTransactions() types.Transactions {
+	self.mu.RLock()
+	defer self.mu.RUnlock()
+
+	var txs types.Transactions
+	for _, ts := range self.queue {
+		txs = append(txs, ts...)
+	}
+
+	return txs
+}
+
 func (self *TxPool) RemoveTransactions(txs types.Transactions) {
 	self.mu.Lock()
 	defer self.mu.Unlock()

--- a/core/transaction_pool_test.go
+++ b/core/transaction_pool_test.go
@@ -67,7 +67,7 @@ func TestTransactionQueue(t *testing.T) {
 	tx.SignECDSA(key)
 	from, _ := tx.From()
 	pool.currentState().AddBalance(from, big.NewInt(1))
-	pool.addTx(tx)
+	pool.queueTx(tx)
 
 	pool.checkQueue()
 	if len(pool.txs) != 1 {
@@ -79,7 +79,7 @@ func TestTransactionQueue(t *testing.T) {
 	from, _ = tx.From()
 	pool.currentState().SetNonce(from, 10)
 	tx.SetNonce(1)
-	pool.addTx(tx)
+	pool.queueTx(tx)
 	pool.checkQueue()
 	if _, ok := pool.txs[tx.Hash()]; ok {
 		t.Error("expected transaction to be in tx pool")
@@ -96,9 +96,9 @@ func TestTransactionQueue(t *testing.T) {
 	tx1.SignECDSA(key)
 	tx2.SignECDSA(key)
 	tx3.SignECDSA(key)
-	pool.addTx(tx1)
-	pool.addTx(tx2)
-	pool.addTx(tx3)
+	pool.queueTx(tx1)
+	pool.queueTx(tx2)
+	pool.queueTx(tx3)
 	from, _ = tx1.From()
 	pool.checkQueue()
 
@@ -106,7 +106,7 @@ func TestTransactionQueue(t *testing.T) {
 		t.Error("expected tx pool to be 1 =")
 	}
 
-	if len(pool.queue[from]) != 2 {
+	if len(pool.queue[from]) != 3 {
 		t.Error("expected transaction queue to be empty. is", len(pool.queue[from]))
 	}
 }

--- a/core/transaction_pool_test.go
+++ b/core/transaction_pool_test.go
@@ -56,7 +56,57 @@ func TestInvalidTransactions(t *testing.T) {
 	tx.SignECDSA(key)
 
 	err = pool.Add(tx)
-	if err != ErrImpossibleNonce {
-		t.Error("expected", ErrImpossibleNonce)
+	if err != ErrNonce {
+		t.Error("expected", ErrNonce)
+	}
+}
+
+func TestTransactionQueue(t *testing.T) {
+	pool, key := setupTxPool()
+	tx := transaction()
+	tx.SignECDSA(key)
+	from, _ := tx.From()
+	pool.currentState().AddBalance(from, big.NewInt(1))
+	pool.addTx(tx)
+
+	pool.checkQueue()
+	if len(pool.txs) != 1 {
+		t.Error("expected valid txs to be 1 is", len(pool.txs))
+	}
+
+	tx = transaction()
+	tx.SignECDSA(key)
+	from, _ = tx.From()
+	pool.currentState().SetNonce(from, 10)
+	tx.SetNonce(1)
+	pool.addTx(tx)
+	pool.checkQueue()
+	if _, ok := pool.txs[tx.Hash()]; ok {
+		t.Error("expected transaction to be in tx pool")
+	}
+
+	if len(pool.queue[from]) != 0 {
+		t.Error("expected transaction queue to be empty. is", len(pool.queue[from]))
+	}
+
+	pool, key = setupTxPool()
+	tx1, tx2, tx3 := transaction(), transaction(), transaction()
+	tx2.SetNonce(10)
+	tx3.SetNonce(11)
+	tx1.SignECDSA(key)
+	tx2.SignECDSA(key)
+	tx3.SignECDSA(key)
+	pool.addTx(tx1)
+	pool.addTx(tx2)
+	pool.addTx(tx3)
+	from, _ = tx1.From()
+	pool.checkQueue()
+
+	if len(pool.txs) != 1 {
+		t.Error("expected tx pool to be 1 =")
+	}
+
+	if len(pool.queue[from]) != 2 {
+		t.Error("expected transaction queue to be empty. is", len(pool.queue[from]))
 	}
 }

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -379,7 +379,7 @@ func (s *Ethereum) Start() error {
 	}
 
 	// Start services
-	s.txPool.Start()
+	go s.txPool.Start()
 
 	if s.whisper != nil {
 		s.whisper.Start()

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -3,7 +3,6 @@ package eth
 import (
 	"crypto/ecdsa"
 	"fmt"
-	"math"
 	"path"
 	"strings"
 
@@ -136,11 +135,10 @@ type Ethereum struct {
 	protocolManager *ProtocolManager
 	downloader      *downloader.Downloader
 
-	net           *p2p.Server
-	eventMux      *event.TypeMux
-	txSub         event.Subscription
-	minedBlockSub event.Subscription
-	miner         *miner.Miner
+	net      *p2p.Server
+	eventMux *event.TypeMux
+	txSub    event.Subscription
+	miner    *miner.Miner
 
 	// logger logger.LogSystem
 
@@ -222,7 +220,7 @@ func New(config *Config) (*Ethereum, error) {
 	eth.whisper = whisper.New()
 	eth.shhVersionId = int(eth.whisper.Version())
 	eth.miner = miner.New(eth, eth.pow, config.MinerThreads)
-	eth.protocolManager = NewProtocolManager(config.ProtocolVersion, config.NetworkId, eth.txPool, eth.chainManager, eth.downloader)
+	eth.protocolManager = NewProtocolManager(config.ProtocolVersion, config.NetworkId, eth.eventMux, eth.txPool, eth.chainManager, eth.downloader)
 
 	netprv, err := config.nodeKey()
 	if err != nil {
@@ -380,6 +378,7 @@ func (s *Ethereum) Start() error {
 
 	// Start services
 	go s.txPool.Start()
+	s.protocolManager.Start()
 
 	if s.whisper != nil {
 		s.whisper.Start()
@@ -388,10 +387,6 @@ func (s *Ethereum) Start() error {
 	// broadcast transactions
 	s.txSub = s.eventMux.Subscribe(core.TxPreEvent{})
 	go s.txBroadcastLoop()
-
-	// broadcast mined blocks
-	s.minedBlockSub = s.eventMux.Subscribe(core.NewMinedBlockEvent{})
-	go s.minedBroadcastLoop()
 
 	glog.V(logger.Info).Infoln("Server started")
 	return nil
@@ -422,9 +417,9 @@ func (s *Ethereum) Stop() {
 	defer s.stateDb.Close()
 	defer s.extraDb.Close()
 
-	s.txSub.Unsubscribe()         // quits txBroadcastLoop
-	s.minedBlockSub.Unsubscribe() // quits blockBroadcastLoop
+	s.txSub.Unsubscribe() // quits txBroadcastLoop
 
+	s.protocolManager.Stop()
 	s.txPool.Stop()
 	s.eventMux.Stop()
 	if s.whisper != nil {
@@ -440,13 +435,10 @@ func (s *Ethereum) WaitForShutdown() {
 	<-s.shutdownChan
 }
 
-// now tx broadcasting is taken out of txPool
-// handled here via subscription, efficiency?
 func (self *Ethereum) txBroadcastLoop() {
 	// automatically stops if unsubscribe
 	for obj := range self.txSub.Chan() {
 		event := obj.(core.TxPreEvent)
-		self.net.BroadcastLimited("eth", TxMsg, math.Sqrt, []*types.Transaction{event.Tx})
 		self.syncAccounts(event.Tx)
 	}
 }
@@ -461,16 +453,6 @@ func (self *Ethereum) syncAccounts(tx *types.Transaction) {
 	if self.accountManager.HasAccount(from.Bytes()) {
 		if self.chainManager.TxState().GetNonce(from) < tx.Nonce() {
 			self.chainManager.TxState().SetNonce(from, tx.Nonce())
-		}
-	}
-}
-
-func (self *Ethereum) minedBroadcastLoop() {
-	// automatically stops if unsubscribe
-	for obj := range self.minedBlockSub.Chan() {
-		switch ev := obj.(type) {
-		case core.NewMinedBlockEvent:
-			self.protocolManager.BroadcastBlock(ev.Block.Hash(), ev.Block)
 		}
 	}
 }

--- a/eth/peer.go
+++ b/eth/peer.go
@@ -86,6 +86,12 @@ func (p *peer) sendNewBlock(block *types.Block) error {
 	return p2p.Send(p.rw, NewBlockMsg, []interface{}{block, block.Td})
 }
 
+func (p *peer) sendTransaction(tx *types.Transaction) error {
+	p.txHashes.Add(tx.Hash())
+
+	return p2p.Send(p.rw, TxMsg, []*types.Transaction{tx})
+}
+
 func (p *peer) requestHashes(from common.Hash) error {
 	glog.V(logger.Debug).Infof("[%s] fetching hashes (%d) %x...\n", p.id, maxHashes, from[:4])
 	return p2p.Send(p.rw, GetBlockHashesMsg, getBlockHashesMsgData{from, maxHashes})

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -290,8 +290,8 @@ func (self *worker) commitNewWork() {
 			// ignore the transactor so no nonce errors will be thrown for this account
 			// next time the worker is run, they'll be picked up again.
 			ignoredTransactors.Add(from)
-			//glog.V(logger.Debug).Infof("Gas limit reached for block. %d TXs included in this block\n", i)
-			//break gasLimit
+
+			glog.V(logger.Detail).Infof("Gas limit reached for (%x) in this block. Continue to try smaller txs\n", from[:4])
 		default:
 			tcount++
 		}

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -258,7 +258,7 @@ func (self *worker) commitNewWork() {
 		tcount             = 0
 		ignoredTransactors = set.New()
 	)
-	//gasLimit:
+
 	for _, tx := range transactions {
 		// We can skip err. It has already been validated in the tx pool
 		from, _ := tx.From()
@@ -296,7 +296,6 @@ func (self *worker) commitNewWork() {
 			tcount++
 		}
 	}
-	//self.eth.TxPool().InvalidateSet(remove)
 
 	var (
 		uncles    []*types.Header

--- a/xeth/xeth.go
+++ b/xeth/xeth.go
@@ -682,9 +682,11 @@ func (self *XEth) Transact(fromStr, toStr, valueStr, gasStr, gasPriceStr, codeSt
 
 	if contractCreation {
 		addr := core.AddressFromMessage(tx)
-		glog.V(logger.Info).Infof("Contract addr %x\n", addr)
+		glog.V(logger.Info).Infof("Tx(%x) created: %x\n", tx.Hash(), addr)
 
 		return core.AddressFromMessage(tx).Hex(), nil
+	} else {
+		glog.V(logger.Info).Infof("Tx(%x) to: %x\n", tx.Hash(), tx.To())
 	}
 	return tx.Hash().Hex(), nil
 }


### PR DESCRIPTION
- [x] Transaction queue
- [x] Improve transaction propagation

##### Transaction queue

As transactions come in they should first be placed in a queue and be checked for nonce gaps. Transactions will stay in the queue until they have have been checked. If they match up, move them out of the queue on to main transaction slice which indicates they are ready for processing.

##### Transaction propagation

Similar to block propagation where incoming transaction their hashes are being stored per peer. When propagating transactions to peers we take the peers which haven't given us the transaction (yet) and `sqrt(peer)` to determine the amount of peers we send to. We then take a random set and propagate.