### PR TITLE
Issue 777

### DIFF
--- a/rpc/args.go
+++ b/rpc/args.go
@@ -145,12 +145,8 @@ func (args *GetBlockByNumberArgs) UnmarshalJSON(b []byte) (err error) {
 		return NewInsufficientParamsError(len(obj), 2)
 	}
 
-	if v, ok := obj[0].(float64); ok {
-		args.BlockNumber = int64(v)
-	} else if v, ok := obj[0].(string); ok {
-		args.BlockNumber = common.Big(v).Int64()
-	} else {
-		return NewInvalidTypeError("blockNumber", "not a number or string")
+	if err := blockHeight(obj[0], &args.BlockNumber); err != nil {
+		return err
 	}
 
 	args.IncludeTxs = obj[1].(bool)

--- a/rpc/args.go
+++ b/rpc/args.go
@@ -535,11 +535,11 @@ func (args *BlockNumIndexArgs) UnmarshalJSON(b []byte) (err error) {
 		return err
 	}
 
-	arg1, ok := obj[1].(string)
-	if !ok {
-		return NewInvalidTypeError("index", "not a string")
+	var arg1 *big.Int
+	if arg1, err = numString(obj[1]); err != nil {
+		return err
 	}
-	args.Index = common.Big(arg1).Int64()
+	args.Index = arg1.Int64()
 
 	return nil
 }

--- a/rpc/args_test.go
+++ b/rpc/args_test.go
@@ -2184,6 +2184,21 @@ func TestBlockNumArgs(t *testing.T) {
 	}
 }
 
+func TestBlockNumArgsWord(t *testing.T) {
+	input := `["pending"]`
+	expected := new(BlockNumIndexArgs)
+	expected.BlockNumber = -2
+
+	args := new(BlockNumArg)
+	if err := json.Unmarshal([]byte(input), &args); err != nil {
+		t.Error(err)
+	}
+
+	if expected.BlockNumber != args.BlockNumber {
+		t.Errorf("BlockNumber shoud be %#v but is %#v", expected.BlockNumber, args.BlockNumber)
+	}
+}
+
 func TestBlockNumArgsInvalid(t *testing.T) {
 	input := `{}`
 
@@ -2218,6 +2233,26 @@ func TestBlockNumIndexArgs(t *testing.T) {
 	expected := new(BlockNumIndexArgs)
 	expected.BlockNumber = 666
 	expected.Index = 0
+
+	args := new(BlockNumIndexArgs)
+	if err := json.Unmarshal([]byte(input), &args); err != nil {
+		t.Error(err)
+	}
+
+	if expected.BlockNumber != args.BlockNumber {
+		t.Errorf("BlockNumber shoud be %#v but is %#v", expected.BlockNumber, args.BlockNumber)
+	}
+
+	if expected.Index != args.Index {
+		t.Errorf("Index shoud be %#v but is %#v", expected.Index, args.Index)
+	}
+}
+
+func TestBlockNumIndexArgsWord(t *testing.T) {
+	input := `["latest", 67]`
+	expected := new(BlockNumIndexArgs)
+	expected.BlockNumber = -1
+	expected.Index = 67
 
 	args := new(BlockNumIndexArgs)
 	if err := json.Unmarshal([]byte(input), &args); err != nil {

--- a/rpc/args_test.go
+++ b/rpc/args_test.go
@@ -2264,7 +2264,7 @@ func TestBlockNumIndexArgsBlocknumInvalid(t *testing.T) {
 }
 
 func TestBlockNumIndexArgsIndexInvalid(t *testing.T) {
-	input := `["0x29a", 1]`
+	input := `["0x29a", true]`
 
 	args := new(BlockNumIndexArgs)
 	str := ExpectInvalidTypeError(json.Unmarshal([]byte(input), &args))

--- a/rpc/args_test.go
+++ b/rpc/args_test.go
@@ -355,6 +355,25 @@ func TestGetBlockByNumberArgsBlockHex(t *testing.T) {
 		t.Errorf("IncludeTxs should be %v but is %v", expected.IncludeTxs, args.IncludeTxs)
 	}
 }
+func TestGetBlockByNumberArgsWords(t *testing.T) {
+	input := `["earliest", true]`
+	expected := new(GetBlockByNumberArgs)
+	expected.BlockNumber = 0
+	expected.IncludeTxs = true
+
+	args := new(GetBlockByNumberArgs)
+	if err := json.Unmarshal([]byte(input), &args); err != nil {
+		t.Error(err)
+	}
+
+	if args.BlockNumber != expected.BlockNumber {
+		t.Errorf("BlockNumber should be %v but is %v", expected.BlockNumber, args.BlockNumber)
+	}
+
+	if args.IncludeTxs != expected.IncludeTxs {
+		t.Errorf("IncludeTxs should be %v but is %v", expected.IncludeTxs, args.IncludeTxs)
+	}
+}
 
 func TestGetBlockByNumberEmpty(t *testing.T) {
 	input := `[]`


### PR DESCRIPTION
* eth_getBlockByNumber (GetBlockByNumberArgs) will now accept magic words
* Added tests for BlockNumArg and BlockNumIndexArgs demonstrating that magic words are already accepted for eth_getBlockTransactionCountByNumber (BlockNumArg), eth_getTransactionByBlockNumberAndIndex(BlockNumIndexArgs), eth_getUncleByBlockNumberAndIndex (BlockNumIndexArgs)

