### PR TITLE
Empty Call response should return 0x instead of 0x00. Closes #739

### DIFF
--- a/rpc/api.go
+++ b/rpc/api.go
@@ -189,7 +189,11 @@ func (api *EthereumApi) GetRequestReply(req *RpcRequest, reply *interface{}) err
 			return err
 		}
 		// TODO unwrap the parent method's ToHex call
-		*reply = newHexData(common.FromHex(v))
+		if v == "0x0" {
+			*reply = newHexData([]byte{})
+		} else {
+			*reply = newHexData(common.FromHex(v))
+		}
 	case "eth_flush":
 		return NewNotImplementedError(req.Method)
 	case "eth_getBlockByHash":


### PR DESCRIPTION
Parent returns a hexstring converted with common.FromHex(), which does not adhere to hexdata spec for empty result. This is a hack to handle this specific case.

A better fix would be to alter XEth to return the bytes instead of a hexified string or to make hexdata a proper type and return that. Currently, it only exists in RPC package.