### PR TITLE
doc: crypto/secp256k1 GMP dependency package name.

### DIFF
--- a/crypto/secp256k1/README.md
+++ b/crypto/secp256k1/README.md
@@ -7,8 +7,11 @@ Implements cryptographic operations for the secp256k1 ECDSA curve used by Bitcoi
 
 Installing
 ===
+
+GMP library headers are required to build. On Debian-based systems, the package is called `libgmp-dev`.
+
 ```
-sudo apt-get install gmp-dev
+sudo apt-get install libgmp-dev
 ```
 
 Now compiles with cgo!


### PR DESCRIPTION
Linux build documentation is mostly geared towards Ubuntu 14.04 (LTS). Appropriate package is called `libgmp-dev` there.

Wiki documentation is OK on this.