### PR TITLE
Remove old logger from RPC pkg

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Automated (dev) builds
 * Ubuntu
   [trusty](https://build.ethdev.com/builds/Linux%20Go%20develop%20deb%20i386-trusty/latest/) |
   [utopic](https://build.ethdev.com/builds/Linux%20Go%20develop%20deb%20i386-utopic/latest/)
-* [Windows] Coming soon&trade;
+* [Windows 64-bit](https://build.ethdev.com/builds/Windows%20Go%20develop%20branch/Geth-Win64-latest.7z)
 
 Executables
 ===========

--- a/rpc/api.go
+++ b/rpc/api.go
@@ -63,8 +63,8 @@ func (api *EthereumApi) GetRequestReply(req *RpcRequest, reply *interface{}) err
 	case "eth_mining":
 		*reply = api.xeth().IsMining()
 	case "eth_gasPrice":
-		v := xeth.DefaultGas()
-		*reply = newHexData(v.Bytes())
+		v := xeth.DefaultGasPrice()
+		*reply = newHexNum(v.Bytes())
 	case "eth_accounts":
 		*reply = api.xeth().Accounts()
 	case "eth_blockNumber":

--- a/rpc/api.go
+++ b/rpc/api.go
@@ -489,6 +489,6 @@ func (api *EthereumApi) GetRequestReply(req *RpcRequest, reply *interface{}) err
 		return NewNotImplementedError(req.Method)
 	}
 
-	rpclogger.DebugDetailf("Reply: %T %s", reply, reply)
+	glog.V(logger.Detail).Infof("Reply: %T %s\n", reply, reply)
 	return nil
 }

--- a/rpc/http.go
+++ b/rpc/http.go
@@ -13,7 +13,6 @@ import (
 	"github.com/rs/cors"
 )
 
-var rpclogger = logger.NewLogger("RPC")
 var rpclistener *stoppableTCPListener
 
 const (
@@ -31,7 +30,7 @@ func Start(pipe *xeth.XEth, config RpcConfig) error {
 
 	l, err := newStoppableTCPListener(fmt.Sprintf("%s:%d", config.ListenAddress, config.ListenPort))
 	if err != nil {
-		rpclogger.Errorf("Can't listen on %s:%d: %v", config.ListenAddress, config.ListenPort, err)
+		glog.V(logger.Error).Infof("Can't listen on %s:%d: %v", config.ListenAddress, config.ListenPort, err)
 		return err
 	}
 	rpclistener = l
@@ -136,7 +135,7 @@ func send(writer io.Writer, v interface{}) (n int, err error) {
 	var payload []byte
 	payload, err = json.MarshalIndent(v, "", "\t")
 	if err != nil {
-		rpclogger.Fatalln("Error marshalling JSON", err)
+		glog.V(logger.Error).Infoln("Error marshalling JSON", err)
 		return 0, err
 	}
 	glog.V(logger.Detail).Infof("Sending payload: %s", payload)


### PR DESCRIPTION
* Removes remaining logger package calls, using glog instead
* Updates README with Windows build link