### PR TITLE
core: chain fork fix

### DIFF
--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -47,7 +47,7 @@ import _ "net/http/pprof"
 
 const (
 	ClientIdentifier = "Geth"
-	Version          = "0.9.12"
+	Version          = "0.9.13"
 )
 
 var app = utils.NewApp(Version, "the go-ethereum command line interface")

--- a/core/block_processor.go
+++ b/core/block_processor.go
@@ -21,7 +21,7 @@ import (
 const (
 	// must be bumped when consensus algorithm is changed, this forces the upgradedb
 	// command to be run (forces the blocks to be imported again using the new algorithm)
-	BlockChainVersion = 2
+	BlockChainVersion = 3
 )
 
 var statelogger = logger.NewLogger("BLOCK")

--- a/core/block_processor.go
+++ b/core/block_processor.go
@@ -21,7 +21,7 @@ import (
 const (
 	// must be bumped when consensus algorithm is changed, this forces the upgradedb
 	// command to be run (forces the blocks to be imported again using the new algorithm)
-	BlockChainVersion = 3
+	BlockChainVersion = 2
 )
 
 var statelogger = logger.NewLogger("BLOCK")

--- a/core/chain_manager.go
+++ b/core/chain_manager.go
@@ -496,6 +496,9 @@ func (self *ChainManager) procFutureBlocks() {
 }
 
 func (self *ChainManager) InsertChain(chain types.Blocks) error {
+	self.mu.Lock()
+	defer self.mu.Unlock()
+
 	// A queued approach to delivering events. This is generally faster than direct delivery and requires much less mutex acquiring.
 	var (
 		queue      = make([]interface{}, len(chain))
@@ -543,55 +546,51 @@ func (self *ChainManager) InsertChain(chain types.Blocks) error {
 
 		block.Td = new(big.Int).Set(CalculateTD(block, self.GetBlock(block.ParentHash())))
 
-		self.mu.Lock()
-		{
-			cblock := self.currentBlock
-			// Write block to database. Eventually we'll have to improve on this and throw away blocks that are
-			// not in the canonical chain.
-			self.write(block)
-			// Compare the TD of the last known block in the canonical chain to make sure it's greater.
-			// At this point it's possible that a different chain (fork) becomes the new canonical chain.
-			if block.Td.Cmp(self.td) > 0 {
-				//if block.Header().Number.Cmp(new(big.Int).Add(cblock.Header().Number, common.Big1)) < 0 {
-				if block.Number().Cmp(cblock.Number()) <= 0 {
-					chash := cblock.Hash()
-					hash := block.Hash()
+		cblock := self.currentBlock
+		// Write block to database. Eventually we'll have to improve on this and throw away blocks that are
+		// not in the canonical chain.
+		self.write(block)
+		// Compare the TD of the last known block in the canonical chain to make sure it's greater.
+		// At this point it's possible that a different chain (fork) becomes the new canonical chain.
+		if block.Td.Cmp(self.td) > 0 {
+			//if block.Header().Number.Cmp(new(big.Int).Add(cblock.Header().Number, common.Big1)) < 0 {
+			if block.Number().Cmp(cblock.Number()) <= 0 {
+				chash := cblock.Hash()
+				hash := block.Hash()
 
-					if glog.V(logger.Info) {
-						glog.Infof("Split detected. New head #%v (%x) TD=%v, was #%v (%x) TD=%v\n", block.Header().Number, hash[:4], block.Td, cblock.Header().Number, chash[:4], self.td)
-					}
-					// during split we merge two different chains and create the new canonical chain
-					self.merge(self.getBlockByNumber(block.NumberU64()), block)
-
-					queue[i] = ChainSplitEvent{block, logs}
-					queueEvent.splitCount++
+				if glog.V(logger.Info) {
+					glog.Infof("Split detected. New head #%v (%x) TD=%v, was #%v (%x) TD=%v\n", block.Header().Number, hash[:4], block.Td, cblock.Header().Number, chash[:4], self.td)
 				}
+				// during split we merge two different chains and create the new canonical chain
+				self.merge(self.getBlockByNumber(block.NumberU64()), block)
 
-				self.setTotalDifficulty(block.Td)
-				self.insert(block)
-
-				jsonlogger.LogJson(&logger.EthChainNewHead{
-					BlockHash:     block.Hash().Hex(),
-					BlockNumber:   block.Number(),
-					ChainHeadHash: cblock.Hash().Hex(),
-					BlockPrevHash: block.ParentHash().Hex(),
-				})
-
-				self.setTransState(state.New(block.Root(), self.stateDb))
-				self.txState.SetState(state.New(block.Root(), self.stateDb))
-
-				queue[i] = ChainEvent{block, logs}
-				queueEvent.canonicalCount++
-
-				if glog.V(logger.Debug) {
-					glog.Infof("inserted block #%d (%d TXs %d UNCs) (%x...)\n", block.Number(), len(block.Transactions()), len(block.Uncles()), block.Hash().Bytes()[0:4])
-				}
-			} else {
-				queue[i] = ChainSideEvent{block, logs}
-				queueEvent.sideCount++
+				queue[i] = ChainSplitEvent{block, logs}
+				queueEvent.splitCount++
 			}
+
+			self.setTotalDifficulty(block.Td)
+			self.insert(block)
+
+			jsonlogger.LogJson(&logger.EthChainNewHead{
+				BlockHash:     block.Hash().Hex(),
+				BlockNumber:   block.Number(),
+				ChainHeadHash: cblock.Hash().Hex(),
+				BlockPrevHash: block.ParentHash().Hex(),
+			})
+
+			self.setTransState(state.New(block.Root(), self.stateDb))
+			self.txState.SetState(state.New(block.Root(), self.stateDb))
+
+			queue[i] = ChainEvent{block, logs}
+			queueEvent.canonicalCount++
+
+			if glog.V(logger.Debug) {
+				glog.Infof("inserted block #%d (%d TXs %d UNCs) (%x...)\n", block.Number(), len(block.Transactions()), len(block.Uncles()), block.Hash().Bytes()[0:4])
+			}
+		} else {
+			queue[i] = ChainSideEvent{block, logs}
+			queueEvent.sideCount++
 		}
-		self.mu.Unlock()
 
 		stats.processed++
 

--- a/core/types/block.go
+++ b/core/types/block.go
@@ -351,7 +351,7 @@ func (self *Block) Copy() *Block {
 }
 
 func (self *Block) String() string {
-	return fmt.Sprintf(`Block(#%v): Size: %v TD: %v {
+	str := fmt.Sprintf(`Block(#%v): Size: %v TD: %v {
 MinerHash: %x
 %v
 Transactions:
@@ -360,6 +360,16 @@ Uncles:
 %v
 }
 `, self.Number(), self.Size(), self.Td, self.header.HashNoNonce(), self.header, self.transactions, self.uncles)
+
+	if (self.HeaderHash != common.Hash{}) {
+		str += fmt.Sprintf("\nFake hash = %x", self.HeaderHash)
+	}
+
+	if (self.ParentHeaderHash != common.Hash{}) {
+		str += fmt.Sprintf("\nFake parent hash = %x", self.ParentHeaderHash)
+	}
+
+	return str
 }
 
 func (self *Header) String() string {

--- a/eth/downloader/downloader.go
+++ b/eth/downloader/downloader.go
@@ -436,6 +436,8 @@ func (d *Downloader) process(peer *peer) error {
 		if err != nil && core.IsParentErr(err) {
 			glog.V(logger.Debug).Infoln("Aborting process due to missing parent.")
 
+			// XXX this needs a lot of attention
+			blocks = nil
 			break
 		} else if err != nil {
 			// immediatly unregister the false peer but do not disconnect

--- a/eth/downloader/downloader.go
+++ b/eth/downloader/downloader.go
@@ -472,3 +472,7 @@ func (d *Downloader) isProcessing() bool {
 func (d *Downloader) isBusy() bool {
 	return d.isFetchingHashes() || d.isDownloadingBlocks() || d.isProcessing()
 }
+
+func (d *Downloader) IsBusy() bool {
+	return d.isBusy()
+}

--- a/eth/handler.go
+++ b/eth/handler.go
@@ -163,6 +163,11 @@ func (pm *ProtocolManager) synchronise(peer *peer) {
 	if peer.td.Cmp(pm.chainman.Td()) <= 0 {
 		return
 	}
+	// Check downloader if it's busy so it doesn't show the sync message
+	// for every attempty
+	if pm.downloader.IsBusy() {
+		return
+	}
 
 	glog.V(logger.Info).Infof("Synchronisation attempt using %s TD=%v\n", peer.id, peer.td)
 	// Get the hashes from the peer (synchronously)


### PR DESCRIPTION
This fixes a consensus issue where two different peers give you a different chain.

1. peer A gives canonical block AA
2. peer B gives you canonical uncle AB
3. processed at the same time. AA happens before AB.
4. AB ends up in the canonical chain (i.e. database points to the wrong block)