### PR TITLE
p2p: throttle peers to prevent hammering

### DIFF
--- a/p2p/peer_error.go
+++ b/p2p/peer_error.go
@@ -73,7 +73,6 @@ const (
 	DiscSelf
 	DiscReadTimeout
 	DiscSubprotocolError
-	DiscThrottled
 )
 
 var discReasonToString = [...]string{
@@ -90,7 +89,6 @@ var discReasonToString = [...]string{
 	DiscSelf:                "Connected to self",
 	DiscReadTimeout:         "Read timeout",
 	DiscSubprotocolError:    "Subprotocol error",
-	DiscThrottled:           "Node throttled",
 }
 
 func (d DiscReason) String() string {

--- a/p2p/peer_error.go
+++ b/p2p/peer_error.go
@@ -73,7 +73,7 @@ const (
 	DiscSelf
 	DiscReadTimeout
 	DiscSubprotocolError
-	DiscFailureCooldown
+	DiscThrottled
 )
 
 var discReasonToString = [...]string{
@@ -90,7 +90,7 @@ var discReasonToString = [...]string{
 	DiscSelf:                "Connected to self",
 	DiscReadTimeout:         "Read timeout",
 	DiscSubprotocolError:    "Subprotocol error",
-	DiscFailureCooldown:     "Failure cooldown",
+	DiscThrottled:           "Node throttled",
 }
 
 func (d DiscReason) String() string {

--- a/p2p/peer_error.go
+++ b/p2p/peer_error.go
@@ -73,6 +73,7 @@ const (
 	DiscSelf
 	DiscReadTimeout
 	DiscSubprotocolError
+	DiscFailureCooldown
 )
 
 var discReasonToString = [...]string{
@@ -89,6 +90,7 @@ var discReasonToString = [...]string{
 	DiscSelf:                "Connected to self",
 	DiscReadTimeout:         "Read timeout",
 	DiscSubprotocolError:    "Subprotocol error",
+	DiscFailureCooldown:     "Failure cooldown",
 }
 
 func (d DiscReason) String() string {

--- a/p2p/server.go
+++ b/p2p/server.go
@@ -616,7 +616,7 @@ func (srv *Server) checkPeer(id discover.NodeID) (bool, DiscReason) {
 	case id == srv.ntab.Self().ID:
 		return false, DiscSelf
 	case srv.throttle[id]:
-		return false, DiscThrottled
+		return false, DiscUselessPeer
 	default:
 		return true, 0
 	}

--- a/p2p/server_test.go
+++ b/p2p/server_test.go
@@ -80,7 +80,7 @@ func TestServerDial(t *testing.T) {
 	// run a one-shot TCP server to handle the connection.
 	listener, err := net.Listen("tcp", "127.0.0.1:0")
 	if err != nil {
-		t.Fatalf("could not setup listener: %v")
+		t.Fatalf("could not setup listener: %v", err)
 	}
 	defer listener.Close()
 	accepted := make(chan net.Conn)
@@ -496,6 +496,116 @@ func TestServerMaxPendingAccepts(t *testing.T) {
 		case <-time.After(time.Second):
 			t.Fatalf("peer %d: handshake timeout", i)
 		}
+	}
+}
+
+// Tests that a failed dial will temporarily throttle a peer.
+func TestServerOutboundThrottling(t *testing.T) {
+	defer testlog(t).detach()
+
+	// Start a simple test server
+	server := startTestServer(t, nil)
+	defer server.Stop()
+
+	// Request a failing dial from the server and check throttling
+	node := &discover.Node{
+		ID:  discover.PubkeyID(&newkey().PublicKey),
+		IP:  []byte{127, 0, 0, 1},
+		TCP: 65535,
+	}
+	server.staticDial <- node
+
+	time.Sleep(100 * time.Millisecond)
+	if throttle := server.throttle[node.ID]; !throttle {
+		t.Fatalf("throttling mismatch: have %v, want %v", throttle, true)
+	}
+	// Open a one shot TCP server to listen for valid dialing
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("failed to setup listener: %v", err)
+	}
+	defer listener.Close()
+
+	connected := make(chan net.Conn)
+	go func() {
+		conn, err := listener.Accept()
+		if err == nil {
+			conn.Close()
+			connected <- conn
+		}
+	}()
+	time.Sleep(100 * time.Millisecond)
+
+	// Request a re-dial from the server, make sure this also fails
+	addr := listener.Addr().(*net.TCPAddr)
+	node.IP, node.TCP = addr.IP, uint16(addr.Port)
+	server.staticDial <- node
+
+	select {
+	case peer := <-connected:
+		t.Fatalf("throttled peer connected: %v", peer)
+
+	case <-time.After(100 * time.Millisecond):
+		// Ok, peer not accepted
+	}
+}
+
+// Tests that a failed peer will get temporarily throttled.
+func TestServerInboundThrottling(t *testing.T) {
+	defer testlog(t).detach()
+
+	// Start a test server and a peer sink for synchronization
+	started := make(chan *Peer)
+	server := &Server{
+		ListenAddr:  "127.0.0.1:0",
+		PrivateKey:  newkey(),
+		MaxPeers:    10,
+		NoDial:      true,
+		newPeerHook: func(p *Peer) { started <- p },
+	}
+	if err := server.Start(); err != nil {
+		t.Fatal("failed to start test server: %v", err)
+	}
+	defer server.Stop()
+
+	// Create a new peer identity to check throttling with
+	dialer := &net.Dialer{Deadline: time.Now().Add(3 * time.Second)}
+	key := newkey()
+
+	// Connect with a new peer, run the handshake and disconnect
+	connection, err := dialer.Dial("tcp", server.ListenAddr)
+	if err != nil {
+		t.Fatalf("failed to dial server: %v", err)
+	}
+	shake := &protoHandshake{Version: baseProtocolVersion, ID: discover.PubkeyID(&key.PublicKey)}
+	if _, err = setupConn(connection, key, shake, server.Self(), false, server.trustedNodes); err != nil {
+		t.Fatalf("failed to run handshake: %v", err)
+	}
+	<-started
+	connection.Close()
+	server.peerWG.Wait()
+
+	// Check that throttling has been enabled
+	if throttle := server.throttle[shake.ID]; !throttle {
+		t.Fatalf("throttling mismatch: have %v, want %v", throttle, true)
+	}
+	// Try to reconnect with the same peer, run the handshake and verify throttling
+	connection, err = dialer.Dial("tcp", server.ListenAddr)
+	if err != nil {
+		t.Fatalf("failed to re-dial server: %v", err)
+	}
+	defer connection.Close()
+
+	shake = &protoHandshake{Version: baseProtocolVersion, ID: discover.PubkeyID(&key.PublicKey)}
+	if _, err = setupConn(connection, key, shake, server.Self(), false, server.trustedNodes); err != nil {
+		t.Fatalf("failed to re-run handshake: %v", err)
+	}
+	select {
+	case peer := <-started:
+		t.Fatalf("throttled peer accepted: %v", peer)
+
+	case <-time.After(100 * time.Millisecond):
+		// Ok, peer not accepted
 	}
 }
 


### PR DESCRIPTION
Maintain a list of recent failures to prevent constant redialing (i.e. have a cooldown of 30 seconds before reattempting a previously failed/dropped/disconnected peer).