### PR TITLE
Add block hash saving for non canon blocks

### DIFF
--- a/cmd/geth/blocktest.go
+++ b/cmd/geth/blocktest.go
@@ -113,7 +113,6 @@ func runOneBlockTest(ctx *cli.Context, test *tests.BlockTest) (*eth.Ethereum, er
 		return ethereum, fmt.Errorf("Block Test load error: %v", err)
 	}
 
-	fmt.Println("chain loaded")
 	if err := test.ValidatePostState(statedb); err != nil {
 		return ethereum, fmt.Errorf("post state validation failed: %v", err)
 	}

--- a/core/chain_manager.go
+++ b/core/chain_manager.go
@@ -52,10 +52,7 @@ func CalculateTD(block, parent *types.Block) *big.Int {
 	if parent == nil {
 		return block.Difficulty()
 	}
-
-	td := new(big.Int).Add(parent.Td, block.Header().Difficulty)
-
-	return td
+	return new(big.Int).Add(parent.Td, block.Difficulty())
 }
 
 func CalcGasLimit(parent *types.Block) *big.Int {

--- a/core/chain_manager.go
+++ b/core/chain_manager.go
@@ -74,10 +74,10 @@ type ChainManager struct {
 	processor    types.BlockProcessor
 	eventMux     *event.TypeMux
 	genesisBlock *types.Block
-	// Last known total difficulty
-	mu   sync.RWMutex
-	tsmu sync.RWMutex
+	mu           sync.RWMutex
+	tsmu         sync.RWMutex
 
+	// Last known total difficulty
 	td              *big.Int
 	currentBlock    *types.Block
 	lastBlockHash   common.Hash
@@ -458,26 +458,6 @@ func (bc *ChainManager) setTotalDifficulty(td *big.Int) {
 	bc.td = td
 }
 
-func (self *ChainManager) CalcTotalDiff(block *types.Block) (*big.Int, error) {
-	parent := self.GetBlock(block.Header().ParentHash)
-	if parent == nil {
-		return nil, fmt.Errorf("Unable to calculate total diff without known parent %x", block.Header().ParentHash)
-	}
-
-	parentTd := parent.Td
-
-	uncleDiff := new(big.Int)
-	for _, uncle := range block.Uncles() {
-		uncleDiff = uncleDiff.Add(uncleDiff, uncle.Difficulty)
-	}
-
-	td := new(big.Int)
-	td = td.Add(parentTd, uncleDiff)
-	td = td.Add(td, block.Header().Difficulty)
-
-	return td, nil
-}
-
 func (bc *ChainManager) Stop() {
 	close(bc.quit)
 
@@ -534,7 +514,7 @@ func (self *ChainManager) InsertChain(chain types.Blocks) (int, error) {
 			}
 
 			block.Td = new(big.Int)
-			// Do not penelise on future block. We'll need a block queue eventually that will queue
+			// Do not penalize on future block. We'll need a block queue eventually that will queue
 			// future block for future use
 			if err == BlockFutureErr {
 				block.SetQueued(true)

--- a/core/chain_manager_test.go
+++ b/core/chain_manager_test.go
@@ -86,7 +86,7 @@ func testChain(chainB types.Blocks, bman *BlockProcessor) (*big.Int, error) {
 
 		bman.bc.mu.Lock()
 		{
-			bman.bc.write(block)
+			bman.bc.writeBlock(block)
 		}
 		bman.bc.mu.Unlock()
 	}
@@ -342,7 +342,7 @@ func TestGetAncestors(t *testing.T) {
 	}
 
 	for _, block := range chain {
-		chainMan.write(block)
+		chainMan.writeBlock(block)
 	}
 
 	ancestors := chainMan.GetAncestors(chain[len(chain)-1], 4)


### PR DESCRIPTION
* Ensure block hash is stored with the block number as key even if
  a block is non-canonical (not a new tip of the chain), this is
  required by the new chain forking code in the edge cases tested
  by BlockTests/bcUncleTest.json
* Rename and split up related DB / cache storage functions to make
  them easier to read.
* Move if statement's simple statement to it's own line to get
  distinct stacktrace line number in case we get future bugs here.