### PR TITLE
core: transaction pool fixes & resending transactions

### DIFF
--- a/cmd/geth/admin.go
+++ b/cmd/geth/admin.go
@@ -137,10 +137,10 @@ func (js *jsre) resend(call otto.FunctionCall) otto.Value {
 	if tx, ok := v.(*tx); ok {
 		gl, gp := tx.GasLimit, tx.GasPrice
 		if len(call.ArgumentList) > 1 {
-			gl = call.Argument(1).String()
+			gp = call.Argument(1).String()
 		}
 		if len(call.ArgumentList) > 2 {
-			gp = call.Argument(2).String()
+			gl = call.Argument(2).String()
 		}
 
 		ret, err := js.xeth.Transact(tx.From, tx.To, tx.Nonce, tx.Value, gl, gp, tx.Data)

--- a/cmd/mist/bindings.go
+++ b/cmd/mist/bindings.go
@@ -40,7 +40,7 @@ type plugin struct {
 func (gui *Gui) Transact(from, recipient, value, gas, gasPrice, d string) (string, error) {
 	d = common.Bytes2Hex(utils.FormatTransactionData(d))
 
-	return gui.xeth.Transact(from, recipient, value, gas, gasPrice, d)
+	return gui.xeth.Transact(from, recipient, "", value, gas, gasPrice, d)
 }
 
 func (self *Gui) AddPlugin(pluginPath string) {

--- a/cmd/mist/ui_lib.go
+++ b/cmd/mist/ui_lib.go
@@ -119,6 +119,7 @@ func (self *UiLib) Transact(params map[string]interface{}) (string, error) {
 	return self.XEth.Transact(
 		object["from"],
 		object["to"],
+		"",
 		object["value"],
 		object["gas"],
 		object["gasPrice"],

--- a/common/resolver/resolver.go
+++ b/common/resolver/resolver.go
@@ -24,11 +24,11 @@ var HashRegContractAddress string = "0000000000000000000000000000000000000000000
 
 func CreateContracts(xeth *xe.XEth, addr string) {
 	var err error
-	URLHintContractAddress, err = xeth.Transact(addr, "", "100000000000", "1000000", "100000", ContractCodeURLhint)
+	URLHintContractAddress, err = xeth.Transact(addr, "", "", "100000000000", "1000000", "100000", ContractCodeURLhint)
 	if err != nil {
 		panic(err)
 	}
-	HashRegContractAddress, err = xeth.Transact(addr, "", "100000000000", "1000000", "100000", ContractCodeHashReg)
+	HashRegContractAddress, err = xeth.Transact(addr, "", "", "100000000000", "1000000", "100000", ContractCodeHashReg)
 	if err != nil {
 		panic(err)
 	}

--- a/core/transaction_pool.go
+++ b/core/transaction_pool.go
@@ -235,7 +235,7 @@ func (self *TxPool) RemoveTransactions(txs types.Transactions) {
 	defer self.mu.Unlock()
 
 	for _, tx := range txs {
-		delete(self.txs, tx.Hash())
+		self.removeTx(tx.Hash())
 	}
 }
 

--- a/rpc/api.go
+++ b/rpc/api.go
@@ -173,7 +173,13 @@ func (api *EthereumApi) GetRequestReply(req *RpcRequest, reply *interface{}) err
 			return fmt.Errorf("Transaction not confirmed")
 		}
 
-		v, err := api.xeth().Transact(args.From, args.To, args.Value.String(), args.Gas.String(), args.GasPrice.String(), args.Data)
+		// nonce may be nil ("guess" mode)
+		var nonce string
+		if args.Nonce != nil {
+			nonce = args.Nonce.String()
+		}
+
+		v, err := api.xeth().Transact(args.From, args.To, nonce, args.Value.String(), args.Gas.String(), args.GasPrice.String(), args.Data)
 		if err != nil {
 			return err
 		}

--- a/rpc/args.go
+++ b/rpc/args.go
@@ -157,6 +157,7 @@ func (args *GetBlockByNumberArgs) UnmarshalJSON(b []byte) (err error) {
 type NewTxArgs struct {
 	From     string
 	To       string
+	Nonce    *big.Int
 	Value    *big.Int
 	Gas      *big.Int
 	GasPrice *big.Int
@@ -170,6 +171,7 @@ func (args *NewTxArgs) UnmarshalJSON(b []byte) (err error) {
 	var ext struct {
 		From     string
 		To       string
+		Nonce    interface{}
 		Value    interface{}
 		Gas      interface{}
 		GasPrice interface{}
@@ -200,6 +202,14 @@ func (args *NewTxArgs) UnmarshalJSON(b []byte) (err error) {
 	args.Data = ext.Data
 
 	var num *big.Int
+	if ext.Nonce != nil {
+		num, err = numString(ext.Nonce)
+		if err != nil {
+			return err
+		}
+	}
+	args.Nonce = num
+
 	if ext.Value == nil {
 		num = big.NewInt(0)
 	} else {

--- a/xeth/xeth.go
+++ b/xeth/xeth.go
@@ -648,7 +648,7 @@ func (self *XEth) ConfirmTransaction(tx string) bool {
 
 }
 
-func (self *XEth) Transact(fromStr, toStr, valueStr, gasStr, gasPriceStr, codeStr string) (string, error) {
+func (self *XEth) Transact(fromStr, toStr, nonceStr, valueStr, gasStr, gasPriceStr, codeStr string) (string, error) {
 	var (
 		from             = common.HexToAddress(fromStr)
 		to               = common.HexToAddress(toStr)
@@ -704,7 +704,13 @@ func (self *XEth) Transact(fromStr, toStr, valueStr, gasStr, gasPriceStr, codeSt
 	}
 
 	state := self.backend.ChainManager().TxState()
-	nonce := state.NewNonce(from)
+
+	var nonce uint64
+	if len(nonceStr) != 0 {
+		nonce = common.Big(nonceStr).Uint64()
+	} else {
+		nonce = state.NewNonce(from)
+	}
 	tx.SetNonce(nonce)
 
 	if err := self.sign(tx, from, false); err != nil {


### PR DESCRIPTION
This PR implements `resend`ing of transactions with different gas settings.

```javascript
// create transaction
eth.sendTransaction({from: eth.accounts[0], value: "10", gasPrice: 10, data: "0x00aabb"})
// get the pending transaction
var tx = eth.pendingTransactions()[0]
// resend the transaction with a different gas price
eth.resend(tx, 10000000 /*, optional gasLimit */)
```