### PR TITLE
eth: added a cancel method for the downloader

### DIFF
--- a/eth/sync.go
+++ b/eth/sync.go
@@ -63,6 +63,9 @@ func (pm *ProtocolManager) processBlocks() error {
 		max := int(math.Min(float64(len(blocks)), float64(blockProcAmount)))
 		_, err := pm.chainman.InsertChain(blocks[:max])
 		if err != nil {
+			// cancel download process
+			pm.downloader.Cancel()
+
 			return err
 		}
 		blocks = blocks[max:]


### PR DESCRIPTION
Added a cancel method to the downloader which gracefully shuts down any
active syncing process (hash fetching or block downloading) and resets
the queue and remove any pending blocks.

Issue with the downloader which would stall because of an active ongoing
process when an invalid block was found.