### PR TITLE
replaced path with platform aware filepath module

### DIFF
--- a/cmd/geth/js.go
+++ b/cmd/geth/js.go
@@ -22,8 +22,9 @@ import (
 	"fmt"
 	"math/big"
 	"os"
-	"path"
 	"strings"
+
+	"path/filepath"
 
 	"github.com/ethereum/go-ethereum/cmd/utils"
 	"github.com/ethereum/go-ethereum/common/docserver"
@@ -209,7 +210,7 @@ func (self *jsre) interactive() {
 }
 
 func (self *jsre) withHistory(op func(*os.File)) {
-	hist, err := os.OpenFile(path.Join(self.ethereum.DataDir, "history"), os.O_RDWR|os.O_CREATE, os.ModePerm)
+	hist, err := os.OpenFile(filepath.Join(self.ethereum.DataDir, "history"), os.O_RDWR|os.O_CREATE, os.ModePerm)
 	if err != nil {
 		fmt.Printf("unable to open history file: %v\n", err)
 		return

--- a/cmd/geth/js.go
+++ b/cmd/geth/js.go
@@ -22,9 +22,8 @@ import (
 	"fmt"
 	"math/big"
 	"os"
-	"strings"
-
 	"path/filepath"
+	"strings"
 
 	"github.com/ethereum/go-ethereum/cmd/utils"
 	"github.com/ethereum/go-ethereum/common/docserver"

--- a/cmd/geth/js_test.go
+++ b/cmd/geth/js_test.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
-	"path"
 	"path/filepath"
 	"regexp"
 	"runtime"
@@ -96,7 +95,7 @@ func testJEthRE(t *testing.T) (string, *testjethre, *eth.Ethereum) {
 		t.Fatal(err)
 	}
 
-	assetPath := path.Join(os.Getenv("GOPATH"), "src", "github.com", "ethereum", "go-ethereum", "cmd", "mist", "assets", "ext")
+	assetPath := filepath.Join(os.Getenv("GOPATH"), "src", "github.com", "ethereum", "go-ethereum", "cmd", "mist", "assets", "ext")
 	ds, err := docserver.New("/")
 	if err != nil {
 		t.Errorf("Error creating DocServer: %v", err)
@@ -361,7 +360,7 @@ func checkEvalJSON(t *testing.T, re *testjethre, expr, want string) error {
 	}
 	if err != nil {
 		_, file, line, _ := runtime.Caller(1)
-		file = path.Base(file)
+		file = filepath.Base(file)
 		fmt.Printf("\t%s:%d: %v\n", file, line, err)
 		t.Fail()
 	}

--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -26,7 +26,6 @@ import (
 	"io"
 	"io/ioutil"
 	"os"
-	"path"
 	"path/filepath"
 	"runtime"
 	"strconv"
@@ -565,7 +564,7 @@ func upgradeDb(ctx *cli.Context) {
 	}
 
 	filename := fmt.Sprintf("blockchain_%d_%s.chain", bcVersion, time.Now().Format("2006-01-02_15:04:05"))
-	exportFile := path.Join(ctx.GlobalString(utils.DataDirFlag.Name), filename)
+	exportFile := filepath.Join(ctx.GlobalString(utils.DataDirFlag.Name), filename)
 
 	err = utils.ExportChain(ethereum.ChainManager(), exportFile)
 	if err != nil {
@@ -576,7 +575,7 @@ func upgradeDb(ctx *cli.Context) {
 	ethereum.StateDb().Close()
 	ethereum.ExtraDb().Close()
 
-	os.RemoveAll(path.Join(ctx.GlobalString(utils.DataDirFlag.Name), "blockchain"))
+	os.RemoveAll(filepath.Join(ctx.GlobalString(utils.DataDirFlag.Name), "blockchain"))
 
 	ethereum, err = eth.New(cfg)
 	if err != nil {

--- a/cmd/mist/gui.go
+++ b/cmd/mist/gui.go
@@ -27,11 +27,10 @@ import (
 	"fmt"
 	"io/ioutil"
 	"math/big"
+	"path/filepath"
 	"runtime"
 	"sort"
 	"time"
-
-	"path/filepath"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core"

--- a/cmd/mist/gui.go
+++ b/cmd/mist/gui.go
@@ -27,10 +27,11 @@ import (
 	"fmt"
 	"io/ioutil"
 	"math/big"
-	"path"
 	"runtime"
 	"sort"
 	"time"
+
+	"path/filepath"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core"
@@ -79,7 +80,7 @@ type Gui struct {
 
 // Create GUI, but doesn't start it
 func NewWindow(ethereum *eth.Ethereum) *Gui {
-	db, err := ethdb.NewLDBDatabase(path.Join(ethereum.DataDir, "tx_database"))
+	db, err := ethdb.NewLDBDatabase(filepath.Join(ethereum.DataDir, "tx_database"))
 	if err != nil {
 		panic(err)
 	}
@@ -92,7 +93,7 @@ func NewWindow(ethereum *eth.Ethereum) *Gui {
 		plugins:       make(map[string]plugin),
 		serviceEvents: make(chan ServEv, 1),
 	}
-	data, _ := ioutil.ReadFile(path.Join(ethereum.DataDir, "plugins.json"))
+	data, _ := ioutil.ReadFile(filepath.Join(ethereum.DataDir, "plugins.json"))
 	json.Unmarshal(data, &gui.plugins)
 
 	return gui

--- a/cmd/mist/html_container.go
+++ b/cmd/mist/html_container.go
@@ -26,7 +26,6 @@ import (
 	"io/ioutil"
 	"net/url"
 	"os"
-	"path"
 	"path/filepath"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -80,7 +79,7 @@ func (app *HtmlApplication) RootFolder() string {
 	if err != nil {
 		return ""
 	}
-	return path.Dir(common.WindonizePath(folder.RequestURI()))
+	return filepath.Dir(common.WindonizePath(folder.RequestURI()))
 }
 func (app *HtmlApplication) RecursiveFolders() []os.FileInfo {
 	files, _ := ioutil.ReadDir(app.RootFolder())

--- a/cmd/mist/ui_lib.go
+++ b/cmd/mist/ui_lib.go
@@ -22,7 +22,6 @@ package main
 
 import (
 	"io/ioutil"
-
 	"path/filepath"
 
 	"github.com/ethereum/go-ethereum/common"

--- a/cmd/mist/ui_lib.go
+++ b/cmd/mist/ui_lib.go
@@ -22,7 +22,8 @@ package main
 
 import (
 	"io/ioutil"
-	"path"
+
+	"path/filepath"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
@@ -110,7 +111,7 @@ func (ui *UiLib) ConnectToPeer(nodeURL string) {
 }
 
 func (ui *UiLib) AssetPath(p string) string {
-	return path.Join(ui.assetPath, p)
+	return filepath.Join(ui.assetPath, p)
 }
 
 func (self *UiLib) Transact(params map[string]interface{}) (string, error) {
@@ -218,7 +219,7 @@ func (self *UiLib) Messages(id int) *common.List {
 }
 
 func (self *UiLib) ReadFile(p string) string {
-	content, err := ioutil.ReadFile(self.AssetPath(path.Join("ext", p)))
+	content, err := ioutil.ReadFile(self.AssetPath(filepath.Join("ext", p)))
 	if err != nil {
 		guilogger.Infoln("error reading file", p, ":", err)
 	}

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -7,9 +7,8 @@ import (
 	"math/big"
 	"net/http"
 	"os"
-	"runtime"
-
 	"path/filepath"
+	"runtime"
 
 	"github.com/codegangsta/cli"
 	"github.com/ethereum/ethash"

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -7,8 +7,9 @@ import (
 	"math/big"
 	"net/http"
 	"os"
-	"path"
 	"runtime"
+
+	"path/filepath"
 
 	"github.com/codegangsta/cli"
 	"github.com/ethereum/ethash"
@@ -55,7 +56,7 @@ OPTIONS:
 // NewApp creates an app with sane defaults.
 func NewApp(version, usage string) *cli.App {
 	app := cli.NewApp()
-	app.Name = path.Base(os.Args[0])
+	app.Name = filepath.Base(os.Args[0])
 	app.Author = ""
 	//app.Authors = nil
 	app.Email = ""
@@ -319,17 +320,17 @@ func MakeEthConfig(clientID, version string, ctx *cli.Context) *eth.Config {
 func GetChain(ctx *cli.Context) (*core.ChainManager, common.Database, common.Database) {
 	dataDir := ctx.GlobalString(DataDirFlag.Name)
 
-	blockDb, err := ethdb.NewLDBDatabase(path.Join(dataDir, "blockchain"))
+	blockDb, err := ethdb.NewLDBDatabase(filepath.Join(dataDir, "blockchain"))
 	if err != nil {
 		Fatalf("Could not open database: %v", err)
 	}
 
-	stateDb, err := ethdb.NewLDBDatabase(path.Join(dataDir, "state"))
+	stateDb, err := ethdb.NewLDBDatabase(filepath.Join(dataDir, "state"))
 	if err != nil {
 		Fatalf("Could not open database: %v", err)
 	}
 
-	extraDb, err := ethdb.NewLDBDatabase(path.Join(dataDir, "extra"))
+	extraDb, err := ethdb.NewLDBDatabase(filepath.Join(dataDir, "extra"))
 	if err != nil {
 		Fatalf("Could not open database: %v", err)
 	}
@@ -346,7 +347,7 @@ func GetChain(ctx *cli.Context) (*core.ChainManager, common.Database, common.Dat
 
 func GetAccountManager(ctx *cli.Context) *accounts.Manager {
 	dataDir := ctx.GlobalString(DataDirFlag.Name)
-	ks := crypto.NewKeyStorePassphrase(path.Join(dataDir, "keys"))
+	ks := crypto.NewKeyStorePassphrase(filepath.Join(dataDir, "keys"))
 	return accounts.NewManager(ks)
 }
 

--- a/common/compiler/solidity.go
+++ b/common/compiler/solidity.go
@@ -7,7 +7,6 @@ import (
 	"io/ioutil"
 	"os"
 	"os/exec"
-	"path"
 	"path/filepath"
 	"regexp"
 	"strings"
@@ -130,10 +129,10 @@ func (sol *Solidity) Compile(source string) (contract *Contract, err error) {
 	_, file := filepath.Split(matches[0])
 	base := strings.Split(file, ".")[0]
 
-	codeFile := path.Join(wd, base+".binary")
-	abiDefinitionFile := path.Join(wd, base+".abi")
-	userDocFile := path.Join(wd, base+".docuser")
-	developerDocFile := path.Join(wd, base+".docdev")
+	codeFile := filepath.Join(wd, base+".binary")
+	abiDefinitionFile := filepath.Join(wd, base+".abi")
+	userDocFile := filepath.Join(wd, base+".docuser")
+	developerDocFile := filepath.Join(wd, base+".docdev")
 
 	code, err := ioutil.ReadFile(codeFile)
 	if err != nil {

--- a/common/path.go
+++ b/common/path.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"os"
 	"os/user"
-	"path"
 	"path/filepath"
 	"runtime"
 	"strings"
@@ -44,22 +43,22 @@ func FileExist(filePath string) bool {
 }
 
 func AbsolutePath(Datadir string, filename string) string {
-	if path.IsAbs(filename) {
+	if filepath.IsAbs(filename) {
 		return filename
 	}
-	return path.Join(Datadir, filename)
+	return filepath.Join(Datadir, filename)
 }
 
 func DefaultAssetPath() string {
 	var assetPath string
 	pwd, _ := os.Getwd()
-	srcdir := path.Join(os.Getenv("GOPATH"), "src", "github.com", "ethereum", "go-ethereum", "cmd", "mist")
+	srcdir := filepath.Join(os.Getenv("GOPATH"), "src", "github.com", "ethereum", "go-ethereum", "cmd", "mist")
 
 	// If the current working directory is the go-ethereum dir
 	// assume a debug build and use the source directory as
 	// asset directory.
 	if pwd == srcdir {
-		assetPath = path.Join(pwd, "assets")
+		assetPath = filepath.Join(pwd, "assets")
 	} else {
 		switch runtime.GOOS {
 		case "darwin":
@@ -67,9 +66,9 @@ func DefaultAssetPath() string {
 			exedir, _ := osext.ExecutableFolder()
 			assetPath = filepath.Join(exedir, "..", "Resources")
 		case "linux":
-			assetPath = path.Join("usr", "share", "mist")
+			assetPath = filepath.Join("usr", "share", "mist")
 		case "windows":
-			assetPath = path.Join(".", "assets")
+			assetPath = filepath.Join(".", "assets")
 		default:
 			assetPath = "."
 		}
@@ -78,7 +77,7 @@ func DefaultAssetPath() string {
 	// Check if the assetPath exists. If not, try the source directory
 	// This happens when binary is run from outside cmd/mist directory
 	if _, err := os.Stat(assetPath); os.IsNotExist(err) {
-		assetPath = path.Join(srcdir, "assets")
+		assetPath = filepath.Join(srcdir, "assets")
 	}
 
 	return assetPath
@@ -87,11 +86,11 @@ func DefaultAssetPath() string {
 func DefaultDataDir() string {
 	usr, _ := user.Current()
 	if runtime.GOOS == "darwin" {
-		return path.Join(usr.HomeDir, "Library", "Ethereum")
+		return filepath.Join(usr.HomeDir, "Library", "Ethereum")
 	} else if runtime.GOOS == "windows" {
-		return path.Join(usr.HomeDir, "AppData", "Roaming", "Ethereum")
+		return filepath.Join(usr.HomeDir, "AppData", "Roaming", "Ethereum")
 	} else {
-		return path.Join(usr.HomeDir, ".ethereum")
+		return filepath.Join(usr.HomeDir, ".ethereum")
 	}
 }
 

--- a/core/chain_manager_test.go
+++ b/core/chain_manager_test.go
@@ -4,11 +4,10 @@ import (
 	"fmt"
 	"math/big"
 	"os"
+	"path/filepath"
 	"runtime"
 	"strconv"
 	"testing"
-
-	"path/filepath"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/state"

--- a/core/chain_manager_test.go
+++ b/core/chain_manager_test.go
@@ -4,10 +4,11 @@ import (
 	"fmt"
 	"math/big"
 	"os"
-	"path"
 	"runtime"
 	"strconv"
 	"testing"
+
+	"path/filepath"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/state"
@@ -94,7 +95,7 @@ func testChain(chainB types.Blocks, bman *BlockProcessor) (*big.Int, error) {
 }
 
 func loadChain(fn string, t *testing.T) (types.Blocks, error) {
-	fh, err := os.OpenFile(path.Join(os.Getenv("GOPATH"), "src", "github.com", "ethereum", "go-ethereum", "_data", fn), os.O_RDONLY, os.ModePerm)
+	fh, err := os.OpenFile(filepath.Join(os.Getenv("GOPATH"), "src", "github.com", "ethereum", "go-ethereum", "_data", fn), os.O_RDONLY, os.ModePerm)
 	if err != nil {
 		return nil, err
 	}

--- a/crypto/key_store_passphrase.go
+++ b/crypto/key_store_passphrase.go
@@ -72,7 +72,7 @@ import (
 	"errors"
 	"io"
 	"os"
-	"path"
+	"path/filepath"
 
 	"code.google.com/p/go-uuid/uuid"
 	"github.com/ethereum/go-ethereum/crypto/randentropy"
@@ -163,7 +163,7 @@ func (ks keyStorePassphrase) DeleteKey(keyAddr []byte, auth string) (err error) 
 		return err
 	}
 
-	keyDirPath := path.Join(ks.keysDirPath, hex.EncodeToString(keyAddr))
+	keyDirPath := filepath.Join(ks.keysDirPath, hex.EncodeToString(keyAddr))
 	return os.RemoveAll(keyDirPath)
 }
 

--- a/crypto/key_store_plain.go
+++ b/crypto/key_store_plain.go
@@ -30,7 +30,7 @@ import (
 	"io"
 	"io/ioutil"
 	"os"
-	"path"
+	"path/filepath"
 )
 
 // TODO: rename to KeyStore when replacing existing KeyStore
@@ -91,20 +91,20 @@ func (ks keyStorePlain) StoreKey(key *Key, auth string) (err error) {
 }
 
 func (ks keyStorePlain) DeleteKey(keyAddr []byte, auth string) (err error) {
-	keyDirPath := path.Join(ks.keysDirPath, hex.EncodeToString(keyAddr))
+	keyDirPath := filepath.Join(ks.keysDirPath, hex.EncodeToString(keyAddr))
 	err = os.RemoveAll(keyDirPath)
 	return err
 }
 
 func GetKeyFile(keysDirPath string, keyAddr []byte) (fileContent []byte, err error) {
 	fileName := hex.EncodeToString(keyAddr)
-	return ioutil.ReadFile(path.Join(keysDirPath, fileName, fileName))
+	return ioutil.ReadFile(filepath.Join(keysDirPath, fileName, fileName))
 }
 
 func WriteKeyFile(addr []byte, keysDirPath string, content []byte) (err error) {
 	addrHex := hex.EncodeToString(addr)
-	keyDirPath := path.Join(keysDirPath, addrHex)
-	keyFilePath := path.Join(keyDirPath, addrHex)
+	keyDirPath := filepath.Join(keysDirPath, addrHex)
+	keyFilePath := filepath.Join(keyDirPath, addrHex)
 	err = os.MkdirAll(keyDirPath, 0700) // read, write and dir search for user
 	if err != nil {
 		return err

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -7,7 +7,6 @@ import (
 	"io/ioutil"
 	"math/big"
 	"os"
-	"path"
 	"path/filepath"
 	"strings"
 	"time"
@@ -145,7 +144,7 @@ func (cfg *Config) nodeKey() (*ecdsa.PrivateKey, error) {
 		return cfg.NodeKey, nil
 	}
 	// use persistent key if present
-	keyfile := path.Join(cfg.DataDir, "nodekey")
+	keyfile := filepath.Join(cfg.DataDir, "nodekey")
 	key, err := crypto.LoadECDSA(keyfile)
 	if err == nil {
 		return key, nil
@@ -214,25 +213,25 @@ func New(config *Config) (*Ethereum, error) {
 	if newdb == nil {
 		newdb = func(path string) (common.Database, error) { return ethdb.NewLDBDatabase(path) }
 	}
-	blockDb, err := newdb(path.Join(config.DataDir, "blockchain"))
+	blockDb, err := newdb(filepath.Join(config.DataDir, "blockchain"))
 	if err != nil {
 		return nil, fmt.Errorf("blockchain db err: %v", err)
 	}
-	stateDb, err := newdb(path.Join(config.DataDir, "state"))
+	stateDb, err := newdb(filepath.Join(config.DataDir, "state"))
 	if err != nil {
 		return nil, fmt.Errorf("state db err: %v", err)
 	}
-	extraDb, err := newdb(path.Join(config.DataDir, "extra"))
+	extraDb, err := newdb(filepath.Join(config.DataDir, "extra"))
 	if err != nil {
 		return nil, fmt.Errorf("extra db err: %v", err)
 	}
-	nodeDb := path.Join(config.DataDir, "nodes")
+	nodeDb := filepath.Join(config.DataDir, "nodes")
 
 	// Perform database sanity checks
 	d, _ := blockDb.Get([]byte("ProtocolVersion"))
 	protov := int(common.NewValue(d).Uint())
 	if protov != config.ProtocolVersion && protov != 0 {
-		path := path.Join(config.DataDir, "blockchain")
+		path := filepath.Join(config.DataDir, "blockchain")
 		return nil, fmt.Errorf("Database version mismatch. Protocol(%d / %d). `rm -rf %s`", protov, config.ProtocolVersion, path)
 	}
 	saveProtocolVersion(blockDb, config.ProtocolVersion)

--- a/ethdb/database_test.go
+++ b/ethdb/database_test.go
@@ -2,13 +2,14 @@ package ethdb
 
 import (
 	"os"
-	"path"
+
+	"path/filepath"
 
 	"github.com/ethereum/go-ethereum/common"
 )
 
 func newDb() *LDBDatabase {
-	file := path.Join("/", "tmp", "ldbtesttmpfile")
+	file := filepath.Join("/", "tmp", "ldbtesttmpfile")
 	if common.FileExist(file) {
 		os.RemoveAll(file)
 	}

--- a/ethdb/database_test.go
+++ b/ethdb/database_test.go
@@ -2,7 +2,6 @@ package ethdb
 
 import (
 	"os"
-
 	"path/filepath"
 
 	"github.com/ethereum/go-ethereum/common"

--- a/generators/defaults.go
+++ b/generators/defaults.go
@@ -8,7 +8,7 @@ import (
 	"io/ioutil"
 	"os"
 	"os/exec"
-	"path"
+	"path/filepath"
 	"strings"
 )
 
@@ -35,7 +35,7 @@ func main() {
 	m := make(map[string]setting)
 	json.Unmarshal(content, &m)
 
-	filepath := path.Join(os.Getenv("GOPATH"), "src", "github.com", "ethereum", "go-ethereum", "params", os.Args[2])
+	filepath := filepath.Join(os.Getenv("GOPATH"), "src", "github.com", "ethereum", "go-ethereum", "params", os.Args[2])
 	output, err := os.OpenFile(filepath, os.O_RDWR|os.O_CREATE, os.ModePerm /*0777*/)
 	if err != nil {
 		fatal("error opening file for writing %v\n", err)

--- a/p2p/discover/udp_test.go
+++ b/p2p/discover/udp_test.go
@@ -9,6 +9,7 @@ import (
 	logpkg "log"
 	"net"
 	"os"
+	"path/filepath"
 	"reflect"
 	"runtime"
 	"sync"
@@ -17,7 +18,6 @@ import (
 
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/logger"
-    "path/filepath"
 )
 
 func init() {

--- a/p2p/discover/udp_test.go
+++ b/p2p/discover/udp_test.go
@@ -9,7 +9,6 @@ import (
 	logpkg "log"
 	"net"
 	"os"
-	"path"
 	"reflect"
 	"runtime"
 	"sync"
@@ -18,6 +17,7 @@ import (
 
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/logger"
+    "path/filepath"
 )
 
 func init() {
@@ -88,7 +88,7 @@ func (test *udpTest) waitPacketOut(validate interface{}) error {
 func (test *udpTest) errorf(format string, args ...interface{}) error {
 	_, file, line, ok := runtime.Caller(2) // errorf + waitPacketOut
 	if ok {
-		file = path.Base(file)
+		file = filepath.Base(file)
 	} else {
 		file = "???"
 		line = 1

--- a/tests/block_test.go
+++ b/tests/block_test.go
@@ -1,7 +1,7 @@
 package tests
 
 import (
-	"path"
+	"path/filepath"
 	"testing"
 
 	"github.com/ethereum/go-ethereum/accounts"
@@ -99,7 +99,7 @@ func runBlockTest(name string, test *BlockTest, t *testing.T) {
 }
 
 func testEthConfig() *eth.Config {
-	ks := crypto.NewKeyStorePassphrase(path.Join(common.DefaultDataDir(), "keys"))
+	ks := crypto.NewKeyStorePassphrase(filepath.Join(common.DefaultDataDir(), "keys"))
 
 	return &eth.Config{
 		DataDir:        common.DefaultDataDir(),

--- a/update-license.go
+++ b/update-license.go
@@ -26,13 +26,13 @@ import (
 	"io/ioutil"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"regexp"
 	"runtime"
 	"sort"
 	"strings"
 	"sync"
 	"text/template"
-    "path/filepath"
 )
 
 var (

--- a/update-license.go
+++ b/update-license.go
@@ -26,13 +26,13 @@ import (
 	"io/ioutil"
 	"os"
 	"os/exec"
-	"path"
 	"regexp"
 	"runtime"
 	"sort"
 	"strings"
 	"sync"
 	"text/template"
+    "path/filepath"
 )
 
 var (
@@ -144,7 +144,7 @@ func getFiles(out chan<- string) {
 				return
 			}
 		}
-		ext := path.Ext(line)
+		ext := filepath.Ext(line)
 		for _, wantExt := range extensions {
 			if ext == wantExt {
 				goto send


### PR DESCRIPTION
The path module isn't platform aware. It will always use a forward slash which will cause in some cases problems on Windows, most notable path.Join. Therefore most path.function calls are replace with the filepath counterpart which is platform aware.

This fixes #928.