### PR TITLE
eth/downloader: fix active peer shadowing, polish func names

### DIFF
--- a/eth/downloader/downloader_test.go
+++ b/eth/downloader/downloader_test.go
@@ -76,7 +76,7 @@ func (dl *downloadTester) getBlock(hash common.Hash) *types.Block {
 }
 
 func (dl *downloadTester) getHashes(hash common.Hash) error {
-	dl.downloader.AddHashes(dl.activePeerId, dl.hashes)
+	dl.downloader.DeliverHashes(dl.activePeerId, dl.hashes)
 	return nil
 }
 
@@ -87,7 +87,7 @@ func (dl *downloadTester) getBlocks(id string) func([]common.Hash) error {
 			blocks[i] = dl.blocks[hash]
 		}
 
-		go dl.downloader.DeliverChunk(id, blocks)
+		go dl.downloader.DeliverBlocks(id, blocks)
 
 		return nil
 	}
@@ -188,12 +188,12 @@ func TestInactiveDownloader(t *testing.T) {
 	blocks := createBlocksFromHashSet(createHashSet(hashes))
 	tester := newTester(t, hashes, nil)
 
-	err := tester.downloader.AddHashes("bad peer 001", hashes)
+	err := tester.downloader.DeliverHashes("bad peer 001", hashes)
 	if err != errNoSyncActive {
 		t.Error("expected no sync error, got", err)
 	}
 
-	err = tester.downloader.DeliverChunk("bad peer 001", blocks)
+	err = tester.downloader.DeliverBlocks("bad peer 001", blocks)
 	if err != errNoSyncActive {
 		t.Error("expected no sync error, got", err)
 	}

--- a/eth/handler.go
+++ b/eth/handler.go
@@ -224,7 +224,7 @@ func (self *ProtocolManager) handleMsg(p *peer) error {
 		if err := msgStream.Decode(&hashes); err != nil {
 			break
 		}
-		err := self.downloader.AddHashes(p.id, hashes)
+		err := self.downloader.DeliverHashes(p.id, hashes)
 		if err != nil {
 			glog.V(logger.Debug).Infoln(err)
 		}
@@ -264,7 +264,7 @@ func (self *ProtocolManager) handleMsg(p *peer) error {
 			glog.V(logger.Detail).Infoln("Decode error", err)
 			blocks = nil
 		}
-		self.downloader.DeliverChunk(p.id, blocks)
+		self.downloader.DeliverBlocks(p.id, blocks)
 
 	case NewBlockMsg:
 		var request newBlockMsgData


### PR DESCRIPTION
I've dropped the activePeer from the downloader since only the fetchHashes used it anyway, so no reason to pollute the larger scope.

Also I've renames AddHashes and DeliverChunks to DeliverHashes and DeliverBlocks to make them more uniform.