### PR TITLE
eth/downloader: fix deliveries to check for sync cancels

### DIFF
--- a/eth/downloader/downloader.go
+++ b/eth/downloader/downloader.go
@@ -86,10 +86,6 @@ func New(hasBlock hashCheckFn, getBlock getBlockFn) *Downloader {
 		hashCh:    make(chan hashPack, 1),
 		blockCh:   make(chan blockPack, 1),
 	}
-	// Set the initial downloader state as canceled (sanity check)
-	downloader.cancelCh = make(chan struct{})
-	close(downloader.cancelCh)
-
 	return downloader
 }
 

--- a/eth/downloader/downloader.go
+++ b/eth/downloader/downloader.go
@@ -65,6 +65,7 @@ type Downloader struct {
 
 	// Status
 	synchronising int32
+	notified      int32
 
 	// Channels
 	newPeerCh chan *peer
@@ -128,6 +129,10 @@ func (d *Downloader) Synchronise(id string, hash common.Hash) error {
 	}
 	defer atomic.StoreInt32(&d.synchronising, 0)
 
+	// Post a user notification of the sync (only once per session)
+	if atomic.CompareAndSwapInt32(&d.notified, 0, 1) {
+		glog.V(logger.Info).Infoln("Block synchronisation started")
+	}
 	// Create cancel channel for aborting mid-flight
 	d.cancelLock.Lock()
 	d.cancelCh = make(chan struct{})


### PR DESCRIPTION
I've modifier the two delivery functions (`DeliverHashes` and `DeliverBlocks`) to check for canceled sync operations too, and not just block on trying to deliver the datasets. This required adding a lock around the cancel channel since it's recreated at every sync call.

This way if a delivery is caught post cancel but before the syncer actually manages to terminate, it should properly pick up the cancel and not block the caller goroutine.

There is still *one* instance where a goroutine may be blocked, and that is if the sync legitimately terminates but a delivery gets caught (there's no cancel then), but that probably means that the peer delivered something it shouldn't have, so just screw it and let it wait for the next sync cycle.