### PR TITLE
cmd/geth: use plain keystore for JS tests

### DIFF
--- a/cmd/geth/js_test.go
+++ b/cmd/geth/js_test.go
@@ -68,7 +68,7 @@ func testJEthRE(t *testing.T) (string, *testjethre, *eth.Ethereum) {
 	// set up mock genesis with balance on the testAddress
 	core.GenesisData = []byte(testGenesis)
 
-	ks := crypto.NewKeyStorePassphrase(filepath.Join(tmp, "keystore"))
+	ks := crypto.NewKeyStorePlain(filepath.Join(tmp, "keystore"))
 	am := accounts.NewManager(ks)
 	ethereum, err := eth.New(&eth.Config{
 		DataDir:        tmp,


### PR DESCRIPTION
This reduces the time it takes to run the tests back to 3 seconds.