### PR TITLE
Fix downloader vulnerabilities

### DIFF
--- a/eth/downloader/downloader.go
+++ b/eth/downloader/downloader.go
@@ -2,7 +2,6 @@ package downloader
 
 import (
 	"errors"
-	"fmt"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -398,8 +397,7 @@ out:
 				// and all failed throw an error
 				if d.queue.InFlight() == 0 {
 					d.queue.Reset()
-
-					return fmt.Errorf("%v peers available = %d. total peers = %d. hashes needed = %d", errPeersUnavailable, len(idlePeers), d.peers.Len(), d.queue.Pending())
+					return errPeersUnavailable
 				}
 
 			} else if d.queue.InFlight() == 0 {

--- a/eth/downloader/downloader.go
+++ b/eth/downloader/downloader.go
@@ -27,7 +27,7 @@ var (
 	errLowTd               = errors.New("peer's TD is too low")
 	ErrBusy                = errors.New("busy")
 	errUnknownPeer         = errors.New("peer's unknown or unhealthy")
-	errBadPeer             = errors.New("action from bad peer ignored")
+	ErrBadPeer             = errors.New("action from bad peer ignored")
 	errNoPeers             = errors.New("no peers to keep download active")
 	ErrPendingQueue        = errors.New("pending items in queue")
 	ErrTimeout             = errors.New("timeout")
@@ -266,9 +266,11 @@ out:
 					break
 				}
 			}
-			d.queue.Insert(hashPack.hashes)
-
-			if !done {
+			// Insert all the new hashes, but only continue if got something useful
+			inserts := d.queue.Insert(hashPack.hashes)
+			if inserts == 0 && !done {
+				return ErrBadPeer
+			} else if !done {
 				activePeer.getHashes(hash)
 				continue
 			}

--- a/eth/downloader/downloader.go
+++ b/eth/downloader/downloader.go
@@ -268,8 +268,12 @@ out:
 			// Insert all the new hashes, but only continue if got something useful
 			inserts := d.queue.Insert(hashPack.hashes)
 			if inserts == 0 && !done {
+				glog.V(logger.Debug).Infof("Peer (%s) responded with stale hashes\n", activePeer.id)
+				d.queue.Reset()
+
 				return ErrBadPeer
-			} else if !done {
+			}
+			if !done {
 				activePeer.getHashes(hash)
 				continue
 			}

--- a/eth/downloader/queue.go
+++ b/eth/downloader/queue.go
@@ -123,13 +123,13 @@ func (q *queue) Has(hash common.Hash) bool {
 }
 
 // Insert adds a set of hashes for the download queue for scheduling, returning
-// the number of new hashes encountered.
-func (q *queue) Insert(hashes []common.Hash) int {
+// the new hashes encountered.
+func (q *queue) Insert(hashes []common.Hash) []common.Hash {
 	q.lock.Lock()
 	defer q.lock.Unlock()
 
 	// Insert all the hashes prioritized in the arrival order
-	inserts := 0
+	inserts := make([]common.Hash, 0, len(hashes))
 	for _, hash := range hashes {
 		// Skip anything we already have
 		if old, ok := q.hashPool[hash]; ok {
@@ -137,7 +137,9 @@ func (q *queue) Insert(hashes []common.Hash) int {
 			continue
 		}
 		// Update the counters and insert the hash
-		q.hashCounter, inserts = q.hashCounter+1, inserts+1
+		q.hashCounter = q.hashCounter + 1
+		inserts = append(inserts, hash)
+
 		q.hashPool[hash] = q.hashCounter
 		q.hashQueue.Push(hash, float32(q.hashCounter)) // Highest gets schedules first
 	}

--- a/eth/sync.go
+++ b/eth/sync.go
@@ -101,7 +101,7 @@ func (pm *ProtocolManager) synchronise(peer *peer) {
 	case downloader.ErrBusy:
 		glog.V(logger.Debug).Infof("Synchronisation already in progress")
 
-	case downloader.ErrTimeout, downloader.ErrBadPeer, downloader.ErrInvalidChain:
+	case downloader.ErrTimeout, downloader.ErrBadPeer, downloader.ErrInvalidChain, downloader.ErrCrossCheckFailed:
 		glog.V(logger.Debug).Infof("Removing peer %v: %v", peer.id, err)
 		pm.removePeer(peer)
 

--- a/eth/sync.go
+++ b/eth/sync.go
@@ -101,11 +101,13 @@ func (pm *ProtocolManager) synchronise(peer *peer) {
 	case downloader.ErrBusy:
 		glog.V(logger.Debug).Infof("Synchronisation already in progress")
 
-	case downloader.ErrTimeout:
-		glog.V(logger.Debug).Infof("Removing peer %v due to sync timeout", peer.id)
+	case downloader.ErrTimeout, downloader.ErrBadPeer:
+		glog.V(logger.Debug).Infof("Removing peer %v: %v", peer.id, err)
 		pm.removePeer(peer)
+
 	case downloader.ErrPendingQueue:
 		glog.V(logger.Debug).Infoln("Synchronisation aborted:", err)
+
 	default:
 		glog.V(logger.Warn).Infof("Synchronisation failed: %v", err)
 	}

--- a/eth/sync.go
+++ b/eth/sync.go
@@ -101,7 +101,7 @@ func (pm *ProtocolManager) synchronise(peer *peer) {
 	case downloader.ErrBusy:
 		glog.V(logger.Debug).Infof("Synchronisation already in progress")
 
-	case downloader.ErrTimeout, downloader.ErrBadPeer:
+	case downloader.ErrTimeout, downloader.ErrBadPeer, downloader.ErrInvalidChain:
 		glog.V(logger.Debug).Infof("Removing peer %v: %v", peer.id, err)
 		pm.removePeer(peer)
 


### PR DESCRIPTION
This patch adds test for two possible attack types: repeating good hashes indefinitely without actually providing the final link to be able to connect to our own chain; and providing some forged hash inside the chain leading to an unknown block.

The latter was handled correctly by the downloader, but the former actually resulted in an infinite loop, blocking the downloader forever. I've added a check to verify the number of new hashes received from a peer, and if that number is 0 (and we haven't reached our chain yet), then it means the hash is invalid and should be cancelled.

Edit 1: Added an additional fix to circumvent a possible attack where a peer reorders completely valid hashes, and because of that they are prioritized out of order and cannot be downloaded (due to the throttled/cache). But kept getting retried indefinitely.

Edit 2: Added a fix to handle madeup hashes, where a selected peer keeps generating random junk hashes indefinitely. Previously this would lock up the node as it had to wait for a known hash to be able to do anything useful. With the fix, from every 512 block of hashes, one of them is cross checked that the origin actually has it. If not, the entire chain is dropped as invalid.

Edit 3: Added one last fix to handle madeup block chains (generating random blocks and sending correct hashes for them). Now every cross check also verifies if the checked block's parent is actually known to us (was already in the previous hash dump). Maybe there's still an attack surface is all parents are set to the same block?)