### PR TITLE
eth: make the peer-set thread safe

### DIFF
--- a/eth/peer.go
+++ b/eth/peer.go
@@ -243,18 +243,6 @@ func (ps *peerSet) TxLackingPeers(hash common.Hash) []*peer {
 	return list
 }
 
-// AllPeers retrieves a flat list of all the peers within the set.
-func (ps *peerSet) AllPeers() []*peer {
-	ps.lock.RLock()
-	defer ps.lock.RUnlock()
-
-	list := make([]*peer, 0, len(ps.peers))
-	for _, p := range ps.peers {
-		list = append(list, p)
-	}
-	return list
-}
-
 // BestPeer retrieves the known peer with the currently highest total difficulty.
 func (ps *peerSet) BestPeer() *peer {
 	ps.lock.RLock()


### PR DESCRIPTION
I've separated the peer-set into its own struct, with an embedded lock and also the required helper methods moved into it (finding peers with missing blocks/txns, best peer, etc).

I've also added some further logging, among others 2 error level logs in case a peer is added/removed twice. This should help discover data races or some weird usage scenarios leading to corrupted peer sets and inherently those pesky "unhealthy" peer messages.

Also, until now during transaction and block broadcast, the peer map mutex was write locked, meaning that while a broadcast was pending, everything else had to wait. I've reworked this to a) use read only locks, b) release as soon as the list of needed peers is assembled, no need to wait for the send to complete.