### PR TITLE
Allow unlocking multiple accounts

### DIFF
--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -368,9 +368,16 @@ func unlockAccount(ctx *cli.Context, am *accounts.Manager, account string) (pass
 	if len(account) == 0 {
 		utils.Fatalf("Invalid account address '%s'", account)
 	}
-	// Attempt to unlock the account
-	passphrase = getPassPhrase(ctx, "Unlocking account "+account, false)
-	err = am.Unlock(common.HexToAddress(account), passphrase)
+	// Attempt to unlock the account 3 times
+	attempts := 3
+	for tries := 0; tries < attempts; tries++ {
+		msg := fmt.Sprintf("Unlocking account %s...%s | Attempt %d/%d", account[:8], account[len(account)-6:], tries+1, attempts)
+		passphrase = getPassPhrase(ctx, msg, false)
+		err = am.Unlock(common.HexToAddress(account), passphrase)
+		if err == nil {
+			break
+		}
+	}
 	if err != nil {
 		utils.Fatalf("Unlock account failed '%v'", err)
 	}

--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -364,11 +364,12 @@ func execJSFiles(ctx *cli.Context) {
 func unlockAccount(ctx *cli.Context, am *accounts.Manager, account string) (passphrase string) {
 	var err error
 	// Load startup keys. XXX we are going to need a different format
-	// Attempt to unlock the account
-	passphrase = getPassPhrase(ctx, "", false)
+
 	if len(account) == 0 {
 		utils.Fatalf("Invalid account address '%s'", account)
 	}
+	// Attempt to unlock the account
+	passphrase = getPassPhrase(ctx, "Unlocking account "+account, false)
 	err = am.Unlock(common.HexToAddress(account), passphrase)
 	if err != nil {
 		utils.Fatalf("Unlock account failed '%v'", err)
@@ -384,15 +385,18 @@ func startEth(ctx *cli.Context, eth *eth.Ethereum) {
 	am := eth.AccountManager()
 
 	account := ctx.GlobalString(utils.UnlockedAccountFlag.Name)
-	if len(account) > 0 {
-		if account == "primary" {
-			primaryAcc, err := am.Primary()
-			if err != nil {
-				utils.Fatalf("no primary account: %v", err)
+	accounts := strings.Split(account, " ")
+	for _, account := range accounts {
+		if len(account) > 0 {
+			if account == "primary" {
+				primaryAcc, err := am.Primary()
+				if err != nil {
+					utils.Fatalf("no primary account: %v", err)
+				}
+				account = primaryAcc.Hex()
 			}
-			account = primaryAcc.Hex()
+			unlockAccount(ctx, am, account)
 		}
-		unlockAccount(ctx, am, account)
 	}
 	// Start auxiliary services if enabled.
 	if ctx.GlobalBool(utils.RPCEnabledFlag.Name) {


### PR DESCRIPTION
Separate accounts with spaces when using `--unlock`. Closes #1045 

Seeking comment on whether an unsuccessful password should exit fatally as it currently does or be handled more gracefully and if so, how?