### PR TITLE
eth/downloader: fix test to it doesn't time out on a slow machine

### DIFF
--- a/eth/downloader/downloader_test.go
+++ b/eth/downloader/downloader_test.go
@@ -382,7 +382,7 @@ func TestRepeatingHashAttack(t *testing.T) {
 
 	// Make sure that syncing returns and does so with a failure
 	select {
-	case <-time.After(100 * time.Millisecond):
+	case <-time.After(time.Second):
 		t.Fatalf("synchronisation blocked")
 	case err := <-errc:
 		if err == nil {


### PR DESCRIPTION
I'm using a timeout to detect if the downloader blocked after an attack or not. On a slow/overloaded machine however this might be triggered anyway. I've increased it from 100ms to 1s. As this should only block so much in case of a failure, it doesn't slow down testing in the general case.