### PR TITLE
prefix dapp key/value entries in extradb

### DIFF
--- a/xeth/xeth.go
+++ b/xeth/xeth.go
@@ -28,6 +28,7 @@ var (
 	filterTickerTime = 5 * time.Minute
 	defaultGasPrice  = big.NewInt(10000000000000) //150000000000
 	defaultGas       = big.NewInt(90000)          //500000
+	dappStorePre     = []byte("dapp-")
 )
 
 // byte will be inferred
@@ -410,13 +411,15 @@ func (self *XEth) SetSolc(solcPath string) (*compiler.Solidity, error) {
 	return self.Solc()
 }
 
+// store DApp value in extra database
 func (self *XEth) DbPut(key, val []byte) bool {
-	self.backend.ExtraDb().Put(key, val)
+	self.backend.ExtraDb().Put(append(dappStorePre, key...), val)
 	return true
 }
 
+// retrieve DApp value from extra database
 func (self *XEth) DbGet(key []byte) ([]byte, error) {
-	val, err := self.backend.ExtraDb().Get(key)
+	val, err := self.backend.ExtraDb().Get(append(dappStorePre, key...))
 	return val, err
 }
 


### PR DESCRIPTION
To prevent DApps overwrite receipts and transactions entries in the extradb key value pairs are prefixed. This fixes #1053. In the future these functions will be removed.

Note, DApps will not find already stored entries since these are not yet prefixed.