### PR TITLE
Fix two additional download vulnerabilities

### DIFF
--- a/eth/downloader/downloader.go
+++ b/eth/downloader/downloader.go
@@ -15,8 +15,10 @@ import (
 )
 
 const (
-	maxHashFetch     = 512              // Amount of hashes to be fetched per chunk
-	maxBlockFetch    = 128              // Amount of blocks to be fetched per chunk
+	MinHashFetch  = 512  // Minimum amount of hashes to not consider a peer stalling
+	MaxHashFetch  = 2048 // Amount of hashes to be fetched per retrieval request
+	MaxBlockFetch = 128  // Amount of blocks to be fetched per retrieval request
+
 	peerCountTimeout = 12 * time.Second // Amount of time it takes for the peer handler to ignore minDesiredPeerCount
 	hashTTL          = 5 * time.Second  // Time it takes for a hash request to time out
 )
@@ -290,7 +292,7 @@ func (d *Downloader) fetchHashes(p *peer, h common.Hash) error {
 			}
 			if !done {
 				// Check that the peer is not stalling the sync
-				if len(inserts) < maxHashFetch {
+				if len(inserts) < MinHashFetch {
 					return ErrStallingPeer
 				}
 				// Try and fetch a random block to verify the hash batch
@@ -451,7 +453,7 @@ out:
 					}
 					// Get a possible chunk. If nil is returned no chunk
 					// could be returned due to no hashes available.
-					request := d.queue.Reserve(peer, maxBlockFetch)
+					request := d.queue.Reserve(peer, MaxBlockFetch)
 					if request == nil {
 						continue
 					}

--- a/eth/downloader/downloader_test.go
+++ b/eth/downloader/downloader_test.go
@@ -135,7 +135,7 @@ func (dl *downloadTester) getBlock(hash common.Hash) *types.Block {
 
 // getHashes retrieves a batch of hashes for reconstructing the chain.
 func (dl *downloadTester) getHashes(head common.Hash) error {
-	limit := maxHashFetch
+	limit := MaxHashFetch
 	if dl.maxHashFetch > 0 {
 		limit = dl.maxHashFetch
 	}

--- a/eth/downloader/queue.go
+++ b/eth/downloader/queue.go
@@ -17,7 +17,7 @@ import (
 )
 
 const (
-	blockCacheLimit = 1024 // Maximum number of blocks to cache before throttling the download
+	blockCacheLimit = 8 * MaxBlockFetch // Maximum number of blocks to cache before throttling the download
 )
 
 // fetchRequest is a currently running block retrieval operation.

--- a/eth/handler.go
+++ b/eth/handler.go
@@ -206,8 +206,8 @@ func (self *ProtocolManager) handleMsg(p *peer) error {
 			return errResp(ErrDecode, "->msg %v: %v", msg, err)
 		}
 
-		if request.Amount > maxHashes {
-			request.Amount = maxHashes
+		if request.Amount > downloader.MaxHashFetch {
+			request.Amount = downloader.MaxHashFetch
 		}
 
 		hashes := self.chainman.GetBlockHashesFromHash(request.Hash, request.Amount)
@@ -254,7 +254,7 @@ func (self *ProtocolManager) handleMsg(p *peer) error {
 			if block != nil {
 				blocks = append(blocks, block)
 			}
-			if i == maxBlocks {
+			if i == downloader.MaxBlockFetch {
 				break
 			}
 		}

--- a/eth/peer.go
+++ b/eth/peer.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/eth/downloader"
 	"github.com/ethereum/go-ethereum/logger"
 	"github.com/ethereum/go-ethereum/logger/glog"
 	"github.com/ethereum/go-ethereum/p2p"
@@ -100,8 +101,8 @@ func (p *peer) sendTransaction(tx *types.Transaction) error {
 }
 
 func (p *peer) requestHashes(from common.Hash) error {
-	glog.V(logger.Debug).Infof("[%s] fetching hashes (%d) %x...\n", p.id, maxHashes, from[:4])
-	return p2p.Send(p.rw, GetBlockHashesMsg, getBlockHashesMsgData{from, maxHashes})
+	glog.V(logger.Debug).Infof("[%s] fetching hashes (%d) %x...\n", p.id, downloader.MaxHashFetch, from[:4])
+	return p2p.Send(p.rw, GetBlockHashesMsg, getBlockHashesMsgData{from, downloader.MaxHashFetch})
 }
 
 func (p *peer) requestBlocks(hashes []common.Hash) error {

--- a/eth/protocol.go
+++ b/eth/protocol.go
@@ -12,8 +12,6 @@ const (
 	NetworkId          = 0
 	ProtocolLength     = uint64(8)
 	ProtocolMaxMsgSize = 10 * 1024 * 1024
-	maxHashes          = 512
-	maxBlocks          = 128
 )
 
 // eth protocol message codes


### PR DESCRIPTION
 * If the peer sending the hash chain doesn't send in 512 batches, it's assumed to be stalling and it is dropped. Although it might be argued it's harsh, without this there's an attack potential to drip hashes one by one and circumvent block cross checks.

 * Until now the cross checker only verified that the block matches the stated hash, and it's parent hash is known. This was corrected to actually verify the parent hash as equal to the next hash in the retrieved hash chain. This prevents malicious peers from forging a block chain pointing to some well known hash (e.g. genesis) to circumvent the cross check.