### PR TITLE
miner: log locally mined blocks after they are 5-deep in the chain

### DIFF
--- a/miner/worker.go
+++ b/miner/worker.go
@@ -40,7 +40,7 @@ type Agent interface {
 
 const miningLogAtDepth = 5
 
-type UInt64RingBuffer struct {
+type uint64RingBuffer struct {
 	ints []uint64 //array of all integers in buffer
 	next int      //where is the next insertion? assert 0 <= next < len(ints)
 }
@@ -61,7 +61,7 @@ type environment struct {
 	lowGasTransactors  *set.Set
 	ownedAccounts      *set.Set
 	lowGasTxs          types.Transactions
-	localMinedBlocks   *UInt64RingBuffer // the most recent block numbers that were mined locally (used to check block inclusion)
+	localMinedBlocks   *uint64RingBuffer // the most recent block numbers that were mined locally (used to check block inclusion)
 }
 
 // env returns a new environment for the current cycle
@@ -217,9 +217,9 @@ out:
 	events.Unsubscribe()
 }
 
-func newLocalMinedBlock(blockNumber uint64, prevMinedBlocks *UInt64RingBuffer) (minedBlocks *UInt64RingBuffer) {
+func newLocalMinedBlock(blockNumber uint64, prevMinedBlocks *uint64RingBuffer) (minedBlocks *uint64RingBuffer) {
 	if prevMinedBlocks == nil {
-		minedBlocks = &UInt64RingBuffer{next: 0, ints: make([]uint64, miningLogAtDepth)}
+		minedBlocks = &uint64RingBuffer{next: 0, ints: make([]uint64, miningLogAtDepth)}
 	} else {
 		minedBlocks = prevMinedBlocks
 	}

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -38,7 +38,7 @@ type Agent interface {
 	GetHashRate() int64
 }
 
-const MINING_LOG_AT_DEPTH = 5
+const miningLogAtDepth = 5
 
 type UInt64RingBuffer struct {
 	ints []uint64 //array of all integers in buffer
@@ -219,7 +219,7 @@ out:
 
 func newLocalMinedBlock(blockNumber uint64, prevMinedBlocks *UInt64RingBuffer) (minedBlocks *UInt64RingBuffer) {
 	if prevMinedBlocks == nil {
-		minedBlocks = &UInt64RingBuffer{next: 0, ints: make([]uint64, MINING_LOG_AT_DEPTH)}
+		minedBlocks = &UInt64RingBuffer{next: 0, ints: make([]uint64, miningLogAtDepth)}
 	} else {
 		minedBlocks = prevMinedBlocks
 	}
@@ -353,9 +353,9 @@ func (self *worker) logLocalMinedBlocks(previous *environment) {
 	if previous != nil && self.current.localMinedBlocks != nil {
 		nextBlockNum := self.current.block.Number().Uint64()
 		for checkBlockNum := previous.block.Number().Uint64(); checkBlockNum < nextBlockNum; checkBlockNum++ {
-			inspectBlockNum := checkBlockNum - MINING_LOG_AT_DEPTH
+			inspectBlockNum := checkBlockNum - miningLogAtDepth
 			if self.isBlockLocallyMined(inspectBlockNum) {
-				glog.V(logger.Info).Infof("🔨 🔗  Mined %d blocks back: block #%v", MINING_LOG_AT_DEPTH, inspectBlockNum)
+				glog.V(logger.Info).Infof("🔨 🔗  Mined %d blocks back: block #%v", miningLogAtDepth, inspectBlockNum)
 			}
 		}
 	}

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -219,7 +219,7 @@ out:
 
 func newLocalMinedBlock(blockNumber uint64, prevMinedBlocks *uint64RingBuffer) (minedBlocks *uint64RingBuffer) {
 	if prevMinedBlocks == nil {
-		minedBlocks = &uint64RingBuffer{next: 0, ints: make([]uint64, miningLogAtDepth)}
+		minedBlocks = &uint64RingBuffer{next: 0, ints: make([]uint64, miningLogAtDepth + 1)}
 	} else {
 		minedBlocks = prevMinedBlocks
 	}

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -248,11 +248,11 @@ func (self *worker) wait() {
 				canonBlock := self.chain.GetBlockByNumber(block.NumberU64())
 				if canonBlock != nil && canonBlock.Hash() != block.Hash() {
 					stale = "stale-"
+				} else {
+					self.current.localMinedBlocks = newLocalMinedBlock(block.Number().Uint64(), self.current.localMinedBlocks)
 				}
 
 				glog.V(logger.Info).Infof("🔨  Mined %sblock #%v (%x)", stale, block.Number(), block.Hash().Bytes()[:4])
-
-				self.current.localMinedBlocks = newLocalMinedBlock(block.Number().Uint64(), self.current.localMinedBlocks)
 
 				jsonlogger.LogJson(&logger.EthMinerNewBlock{
 					BlockHash:     block.Hash().Hex(),


### PR DESCRIPTION
For issue #1047

Please review structure and go idioms.  I'm a go newb!

Local deep mining logs help determine which blocks are unlikely to end up as uncles.

Mechanism:
 * Store the 5 most recent locally mined block numbers
 * On every imported block, check if the 5-deep block num is in that store
 * Also confirm that the block is signed with miner's coinbase
 * If so, write Info log

Why not just check the coinbase? This log is useful if you're running
multiple nodes and want to know if miners farming for *this* node are performing well.