### PR TITLE
Premature miner update loop break

### DIFF
--- a/miner/miner.go
+++ b/miner/miner.go
@@ -62,11 +62,12 @@ func (self *Miner) update() {
 			if shouldStart {
 				self.Start(self.coinbase, self.threads)
 			}
+
+            // unsubscribe. we're only interested in this event once
+            events.Unsubscribe()
+            // stop immediately and ignore all further pending events
+            break
 		}
-		// unsubscribe. we're only interested in this event once
-		events.Unsubscribe()
-		// stop immediately and ignore all further pending events
-		break
 	}
 }
 

--- a/miner/miner.go
+++ b/miner/miner.go
@@ -63,10 +63,10 @@ func (self *Miner) update() {
 				self.Start(self.coinbase, self.threads)
 			}
 
-            // unsubscribe. we're only interested in this event once
-            events.Unsubscribe()
-            // stop immediately and ignore all further pending events
-            break
+			// unsubscribe. we're only interested in this event once
+			events.Unsubscribe()
+			// stop immediately and ignore all further pending events
+			break
 		}
 	}
 }


### PR DESCRIPTION
I believe this is caused by breaking from the miner update loop too soon. It breaks when a StartEvent is received and never wait for a Done or Failed event. As a result the canStart indicator is never set to 1 and the miner nevers starts.

This fixes #1065 
