### PR TITLE
make registrar available in console

### DIFF
--- a/cmd/geth/js.go
+++ b/cmd/geth/js.go
@@ -141,7 +141,7 @@ var net = web3.net;
 		utils.Fatalf("Error setting namespaces: %v", err)
 	}
 
-	js.re.Eval(globalRegistrar + "registrar = new GlobalRegistrar(\"" + globalRegistrarAddr + "\");")
+	js.re.Eval(globalRegistrar + "registrar = GlobalRegistrar.at(\"" + globalRegistrarAddr + "\");")
 }
 
 var ds, _ = docserver.New("/")


### PR DESCRIPTION
Due to a syntax change in web3 the registrar contract wasn't available in the console.
fixes #1068