### PR TITLE
p2p/discover: evict nonresponsive nodes from DB

### DIFF
--- a/p2p/discover/database.go
+++ b/p2p/discover/database.go
@@ -44,9 +44,10 @@ var (
 	nodeDBVersionKey = []byte("version") // Version of the database to flush if changes
 	nodeDBItemPrefix = []byte("n:")      // Identifier to prefix node entries with
 
-	nodeDBDiscoverRoot = ":discover"
-	nodeDBDiscoverPing = nodeDBDiscoverRoot + ":lastping"
-	nodeDBDiscoverPong = nodeDBDiscoverRoot + ":lastpong"
+	nodeDBDiscoverRoot      = ":discover"
+	nodeDBDiscoverPing      = nodeDBDiscoverRoot + ":lastping"
+	nodeDBDiscoverPong      = nodeDBDiscoverRoot + ":lastpong"
+	nodeDBDiscoverFindFails = nodeDBDiscoverRoot + ":findfail"
 )
 
 // newNodeDB creates a new node database for storing and retrieving infos about
@@ -273,6 +274,16 @@ func (db *nodeDB) lastPong(id NodeID) time.Time {
 // updateLastPong updates the last time a remote node successfully contacted.
 func (db *nodeDB) updateLastPong(id NodeID, instance time.Time) error {
 	return db.storeInt64(makeKey(id, nodeDBDiscoverPong), instance.Unix())
+}
+
+// findFails retrieves the number of findnode failures since bonding.
+func (db *nodeDB) findFails(id NodeID) int {
+	return int(db.fetchInt64(makeKey(id, nodeDBDiscoverFindFails)))
+}
+
+// updateFindFails updates the number of findnode failures since bonding.
+func (db *nodeDB) updateFindFails(id NodeID, fails int) error {
+	return db.storeInt64(makeKey(id, nodeDBDiscoverFindFails), int64(fails))
 }
 
 // querySeeds retrieves a batch of nodes to be used as potential seed servers

--- a/p2p/discover/database_test.go
+++ b/p2p/discover/database_test.go
@@ -93,6 +93,7 @@ func TestNodeDBFetchStore(t *testing.T) {
 		30303,
 	)
 	inst := time.Now()
+	num := 314
 
 	db, _ := newNodeDB("", Version, NodeID{})
 	defer db.close()
@@ -116,6 +117,16 @@ func TestNodeDBFetchStore(t *testing.T) {
 	}
 	if stored := db.lastPong(node.ID); stored.Unix() != inst.Unix() {
 		t.Errorf("pong: value mismatch: have %v, want %v", stored, inst)
+	}
+	// Check fetch/store operations on a node findnode-failure object
+	if stored := db.findFails(node.ID); stored != 0 {
+		t.Errorf("find-node fails: non-existing object: %v", stored)
+	}
+	if err := db.updateFindFails(node.ID, num); err != nil {
+		t.Errorf("find-node fails: failed to update: %v", err)
+	}
+	if stored := db.findFails(node.ID); stored != num {
+		t.Errorf("find-node fails: value mismatch: have %v, want %v", stored, num)
 	}
 	// Check fetch/store operations on an actual node object
 	if stored := db.node(node.ID); stored != nil {

--- a/p2p/discover/table.go
+++ b/p2p/discover/table.go
@@ -229,14 +229,11 @@ func (tab *Table) refresh() {
 		for _, seed := range seeds {
 			glog.V(logger.Debug).Infoln("Seeding network with", seed)
 		}
-		peers := append(tab.nursery, seeds...)
+		nodes := append(tab.nursery, seeds...)
 
-		// Bootstrap the table with a self lookup
-		if len(peers) > 0 {
-			tab.mutex.Lock()
-			tab.add(peers)
-			tab.mutex.Unlock()
-
+		// Bond with all the seed nodes (will pingpong only if failed recently)
+		bonded := tab.bondall(nodes)
+		if len(bonded) > 0 {
 			tab.Lookup(tab.self.ID)
 		}
 		// TODO: the Kademlia paper says that we're supposed to perform

--- a/p2p/discover/table.go
+++ b/p2p/discover/table.go
@@ -229,12 +229,16 @@ func (tab *Table) refresh() {
 		for _, seed := range seeds {
 			glog.V(logger.Debug).Infoln("Seeding network with", seed)
 		}
+		peers := append(tab.nursery, seeds...)
+
 		// Bootstrap the table with a self lookup
-		all := tab.bondall(append(tab.nursery, seeds...))
-		tab.mutex.Lock()
-		tab.add(all)
-		tab.mutex.Unlock()
-		tab.Lookup(tab.self.ID)
+		if len(peers) > 0 {
+			tab.mutex.Lock()
+			tab.add(peers)
+			tab.mutex.Unlock()
+
+			tab.Lookup(tab.self.ID)
+		}
 		// TODO: the Kademlia paper says that we're supposed to perform
 		// random lookups in all buckets further away than our closest neighbor.
 	}

--- a/p2p/discover/table.go
+++ b/p2p/discover/table.go
@@ -142,6 +142,12 @@ func (tab *Table) Lookup(targetID NodeID) []*Node {
 	result := tab.closest(target, bucketSize)
 	tab.mutex.Unlock()
 
+	// If the result set is empty, all nodes were dropped, refresh
+	if len(result.entries) == 0 {
+		tab.refresh()
+		return nil
+	}
+
 	for {
 		// ask the alpha closest nodes that we haven't asked yet
 		for i := 0; i < len(result.entries) && pendingQueries < alpha; i++ {
@@ -158,7 +164,7 @@ func (tab *Table) Lookup(targetID NodeID) []*Node {
 						tab.db.updateFindFails(n.ID, fails)
 						glog.V(logger.Detail).Infof("Bumping failures for %x: %d", n.ID[:8], fails)
 
-						if fails > maxFindnodeFailures {
+						if fails >= maxFindnodeFailures {
 							glog.V(logger.Detail).Infof("Evacuating node %x: %d findnode failures", n.ID[:8], fails)
 							tab.del(n)
 						}
@@ -183,19 +189,41 @@ func (tab *Table) Lookup(targetID NodeID) []*Node {
 	return result.entries
 }
 
-// refresh performs a lookup for a random target to keep buckets full.
+// refresh performs a lookup for a random target to keep buckets full, or seeds
+// the table if it is empty (initial bootstrap or discarded faulty peers).
 func (tab *Table) refresh() {
-	// The Kademlia paper specifies that the bucket refresh should
-	// perform a refresh in the least recently used bucket. We cannot
-	// adhere to this because the findnode target is a 512bit value
-	// (not hash-sized) and it is not easily possible to generate a
-	// sha3 preimage that falls into a chosen bucket.
-	//
-	// We perform a lookup with a random target instead.
-	var target NodeID
-	rand.Read(target[:])
-	result := tab.Lookup(target)
-	if len(result) == 0 {
+	seed := true
+
+	// If the discovery table is empty, seed with previously known nodes
+	tab.mutex.Lock()
+	for _, bucket := range tab.buckets {
+		if len(bucket.entries) > 0 {
+			seed = false
+			break
+		}
+	}
+	tab.mutex.Unlock()
+
+	// If the table is not empty, try to refresh using the live entries
+	if !seed {
+		// The Kademlia paper specifies that the bucket refresh should
+		// perform a refresh in the least recently used bucket. We cannot
+		// adhere to this because the findnode target is a 512bit value
+		// (not hash-sized) and it is not easily possible to generate a
+		// sha3 preimage that falls into a chosen bucket.
+		//
+		// We perform a lookup with a random target instead.
+		var target NodeID
+		rand.Read(target[:])
+
+		result := tab.Lookup(target)
+		if len(result) == 0 {
+			// Lookup failed, seed after all
+			seed = true
+		}
+	}
+
+	if seed {
 		// Pick a batch of previously know seeds to lookup with
 		seeds := tab.db.querySeeds(10)
 		for _, seed := range seeds {

--- a/p2p/discover/table.go
+++ b/p2p/discover/table.go
@@ -26,6 +26,7 @@ const (
 	nBuckets   = hashBits + 1 // Number of buckets
 
 	maxBondingPingPongs = 16
+	maxFindnodeFailures = 5
 )
 
 type Table struct {
@@ -149,7 +150,19 @@ func (tab *Table) Lookup(targetID NodeID) []*Node {
 				asked[n.ID] = true
 				pendingQueries++
 				go func() {
-					r, _ := tab.net.findnode(n.ID, n.addr(), targetID)
+					// Find potential neighbors to bond with
+					r, err := tab.net.findnode(n.ID, n.addr(), targetID)
+					if err != nil {
+						// Bump the failure counter to detect and evacuate non-bonded entries
+						fails := tab.db.findFails(n.ID) + 1
+						tab.db.updateFindFails(n.ID, fails)
+						glog.V(logger.Detail).Infof("Bumping failures for %x: %d", n.ID[:8], fails)
+
+						if fails > maxFindnodeFailures {
+							glog.V(logger.Detail).Infof("Evacuating node %x: %d findnode failures", n.ID[:8], fails)
+							tab.del(n)
+						}
+					}
 					reply <- tab.bondall(r)
 				}()
 			}
@@ -256,8 +269,15 @@ func (tab *Table) bondall(nodes []*Node) (result []*Node) {
 // If pinged is true, the remote node has just pinged us and one half
 // of the process can be skipped.
 func (tab *Table) bond(pinged bool, id NodeID, addr *net.UDPAddr, tcpPort uint16) (*Node, error) {
-	var n *Node
-	if n = tab.db.node(id); n == nil {
+	// Retrieve a previously known node and any recent findnode failures
+	node, fails := tab.db.node(id), 0
+	if node != nil {
+		fails = tab.db.findFails(id)
+	}
+	// If the node is unknown (non-bonded) or failed (remotely unknown), bond from scratch
+	if node == nil || fails > 0 {
+		glog.V(logger.Detail).Infof("Bonding %x: known=%v, fails=%v", id[:8], node != nil, fails)
+
 		tab.bondmu.Lock()
 		w := tab.bonding[id]
 		if w != nil {
@@ -276,18 +296,22 @@ func (tab *Table) bond(pinged bool, id NodeID, addr *net.UDPAddr, tcpPort uint16
 			delete(tab.bonding, id)
 			tab.bondmu.Unlock()
 		}
-		n = w.n
+		node = w.n
 		if w.err != nil {
 			return nil, w.err
 		}
 	}
+	// Bonding succeeded, add to the table and reset previous findnode failures
 	tab.mutex.Lock()
 	defer tab.mutex.Unlock()
-	b := tab.buckets[logdist(tab.self.sha, n.sha)]
-	if !b.bump(n) {
-		tab.pingreplace(n, b)
+
+	b := tab.buckets[logdist(tab.self.sha, node.sha)]
+	if !b.bump(node) {
+		tab.pingreplace(node, b)
 	}
-	return n, nil
+	tab.db.updateFindFails(id, 0)
+
+	return node, nil
 }
 
 func (tab *Table) pingpong(w *bondproc, pinged bool, id NodeID, addr *net.UDPAddr, tcpPort uint16) {
@@ -361,6 +385,21 @@ outer:
 		}
 		if len(bucket.entries) < bucketSize {
 			bucket.entries = append(bucket.entries, n)
+		}
+	}
+}
+
+// del removes an entry from the node table (used to evacuate failed/non-bonded
+// discovery peers).
+func (tab *Table) del(node *Node) {
+	tab.mutex.Lock()
+	defer tab.mutex.Unlock()
+
+	bucket := tab.buckets[logdist(tab.self.sha, node.sha)]
+	for i := range bucket.entries {
+		if bucket.entries[i].ID == node.ID {
+			bucket.entries = append(bucket.entries[:i], bucket.entries[i+1:]...)
+			return
 		}
 	}
 }

--- a/p2p/discover/table.go
+++ b/p2p/discover/table.go
@@ -275,6 +275,7 @@ func (tab *Table) bond(pinged bool, id NodeID, addr *net.UDPAddr, tcpPort uint16
 		fails = tab.db.findFails(id)
 	}
 	// If the node is unknown (non-bonded) or failed (remotely unknown), bond from scratch
+	var result error
 	if node == nil || fails > 0 {
 		glog.V(logger.Detail).Infof("Bonding %x: known=%v, fails=%v", id[:8], node != nil, fails)
 
@@ -296,22 +297,24 @@ func (tab *Table) bond(pinged bool, id NodeID, addr *net.UDPAddr, tcpPort uint16
 			delete(tab.bonding, id)
 			tab.bondmu.Unlock()
 		}
-		node = w.n
-		if w.err != nil {
-			return nil, w.err
+		// Retrieve the bonding results
+		result = w.err
+		if result == nil {
+			node = w.n
 		}
 	}
-	// Bonding succeeded, add to the table and reset previous findnode failures
-	tab.mutex.Lock()
-	defer tab.mutex.Unlock()
+	// Even if bonding temporarily failed, give the node a chance
+	if node != nil {
+		tab.mutex.Lock()
+		defer tab.mutex.Unlock()
 
-	b := tab.buckets[logdist(tab.self.sha, node.sha)]
-	if !b.bump(node) {
-		tab.pingreplace(node, b)
+		b := tab.buckets[logdist(tab.self.sha, node.sha)]
+		if !b.bump(node) {
+			tab.pingreplace(node, b)
+		}
+		tab.db.updateFindFails(id, 0)
 	}
-	tab.db.updateFindFails(id, 0)
-
-	return node, nil
+	return node, result
 }
 
 func (tab *Table) pingpong(w *bondproc, pinged bool, id NodeID, addr *net.UDPAddr, tcpPort uint16) {


### PR DESCRIPTION
This PR patches up an issue with the bootstrap seeding procedure and also fixes a few corner cases and issues that were happening:

---

Previously the bonding procedure short circuited itself if a node-to-be-bonded was in our local node database (the only way to get in there is via a successful bond). However, if the remote side forgotten about us (expiry, manual delete, etc), then all our findnode requests would be dropped and we would just keep trying. To fix this issue:
 * I've introduced a findnode failure counter, that is incremented every time we try to retrieve neighbor peers but the operation fails.
 * If the failures exceed some threshold (5 currently), the discovery peer is evacuated from the node table, as it's assumed to be unbonded.
 * When a bonding is requested, not only database presence is checked, but also previous failures. If there was a recent findnode failure, it's safer to force a rebond/pingpong.
 * Failure counts are reset whenever a node is bonded with (note the special case below).

Special cases:
 * As outlined above, if the fail count of a known node is > 0, it is forcefully pinged (thus it will rebond with us if needed). However, given that it *was* working at a given point, even if ping fails (e.g. the packet is dropped), we still add it to the table. This makes it a bit more robust in the face of network packet loss as it has a chance to still end up as a peer (if it's indeed offline, it will be evacuated by the above proceedure fairly quickly).

---

Another issue is related to network seeding/bootstrapping (i.e. `refresh`-ing the discovery table) which was a one shot operation, run only on boot (and hourly after that, but that's beyond the point here). The issue was that if all boot nodes were down -- and since seeding only happened once -- there was a high chance of not being able to join the network if the first batch of seeds chosen were also offline (highly probably in a dynamic network). The solution to this problem was:
 * Since remote peer lookups ran fairly regularly, I've added a check into it to see if the table became empty per the above evacuation mechanism. If so, a table refresh was forced to try and inject a next batch of seeds.
 * Additionally, the refresh was modified a bit to not inject seed/boot nodes into the table directly, but rather try and bond with them first (if they are known (seed db) and fails == 0, it short circuits and the bonding is assumed done).

With this we are now actually iterating over the entire potential seed database and trying to connect to them, opposed to just hanging and waiting for the hourly refresh tick.

---

PS: With this implementation my UDP firewalled system can connect to 20+ external nodes, opposed to the 2-3 previously without the evacuation and updated seeding procedure. 