### PR TITLE
miner crash due to blockchain db close

### DIFF
--- a/miner/worker.go
+++ b/miner/worker.go
@@ -288,6 +288,10 @@ func (self *worker) makeCurrent() {
 	current.ownedAccounts = accountAddressesSet(accounts)
 
 	parent := self.chain.GetBlock(current.block.ParentHash())
+	if parent == nil {
+		// in case geth quits the blockchain db can be closed and this returns nil
+		return
+	}
 	current.coinbase.SetGasPool(core.CalcGasLimit(parent))
 
 	self.current = current


### PR DESCRIPTION
The miner update loop runs in the background and waits for incoming events to update its local state. Some command (e.g. export, upgradedb) won't start a complete Ethereum instance but simply initiates the actions it needs. This causes a race condition in the miner which access the blockchain db through the ChainManager on particular events. When the blockchain database is closed nil is returned. The miner will then panics on a nill ptr dereference. With this patch the miner checks if it has received a block before using it.

This fixes #1103 