### PR TITLE
Fine tune seeder and p2p peer handling

### DIFF
--- a/cmd/geth/js_test.go
+++ b/cmd/geth/js_test.go
@@ -35,6 +35,7 @@ const (
 
 var (
 	versionRE   = regexp.MustCompile(strconv.Quote(`"compilerVersion":"` + solcVersion + `"`))
+	testNodeKey = crypto.ToECDSA(common.Hex2Bytes("4b50fa71f5c3eeb8fdc452224b2395af2fcc3d125e06c32c82e048c0559db03f"))
 	testGenesis = `{"` + testAddress[2:] + `": {"balance": "` + testBalance + `"}}`
 )
 
@@ -72,6 +73,7 @@ func testJEthRE(t *testing.T) (string, *testjethre, *eth.Ethereum) {
 	ks := crypto.NewKeyStorePlain(filepath.Join(tmp, "keystore"))
 	am := accounts.NewManager(ks)
 	ethereum, err := eth.New(&eth.Config{
+		NodeKey:        testNodeKey,
 		DataDir:        tmp,
 		AccountManager: am,
 		MaxPeers:       0,
@@ -122,7 +124,7 @@ func TestNodeInfo(t *testing.T) {
 	}
 	defer ethereum.Stop()
 	defer os.RemoveAll(tmp)
-	want := `{"DiscPort":0,"IP":"0.0.0.0","ListenAddr":"","Name":"test","NodeID":"00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000","NodeUrl":"enode://00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000@0.0.0.0:0","TCPPort":0,"Td":"0"}`
+	want := `{"DiscPort":0,"IP":"0.0.0.0","ListenAddr":"","Name":"test","NodeID":"4cb2fc32924e94277bf94b5e4c983beedb2eabd5a0bc941db32202735c6625d020ca14a5963d1738af43b6ac0a711d61b1a06de931a499fe2aa0b1a132a902b5","NodeUrl":"enode://4cb2fc32924e94277bf94b5e4c983beedb2eabd5a0bc941db32202735c6625d020ca14a5963d1738af43b6ac0a711d61b1a06de931a499fe2aa0b1a132a902b5@0.0.0.0:0","TCPPort":0,"Td":"131072"}`
 	checkEvalJSON(t, repl, `admin.nodeInfo()`, want)
 }
 

--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -260,6 +260,7 @@ JavaScript API. See https://github.com/ethereum/go-ethereum/wiki/Javascipt-Conso
 		utils.AutoDAGFlag,
 		utils.NATFlag,
 		utils.NatspecEnabledFlag,
+		utils.NoDiscoverFlag,
 		utils.NodeKeyFileFlag,
 		utils.NodeKeyHexFlag,
 		utils.RPCEnabledFlag,

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -235,6 +235,10 @@ var (
 		Usage: "NAT port mapping mechanism (any|none|upnp|pmp|extip:<IP>)",
 		Value: "any",
 	}
+	NoDiscoverFlag = cli.BoolFlag{
+		Name:  "nodiscover",
+		Usage: "Disables the peer discovery mechanism (manual peer addition)",
+	}
 	WhisperEnabledFlag = cli.BoolFlag{
 		Name:  "shh",
 		Usage: "Enable whisper",
@@ -312,6 +316,7 @@ func MakeEthConfig(clientID, version string, ctx *cli.Context) *eth.Config {
 		Port:               ctx.GlobalString(ListenPortFlag.Name),
 		NAT:                GetNAT(ctx),
 		NatSpec:            ctx.GlobalBool(NatspecEnabledFlag.Name),
+		Discovery:          !ctx.GlobalBool(NoDiscoverFlag.Name),
 		NodeKey:            GetNodeKey(ctx),
 		Shh:                ctx.GlobalBool(WhisperEnabledFlag.Name),
 		Dial:               true,
@@ -320,7 +325,6 @@ func MakeEthConfig(clientID, version string, ctx *cli.Context) *eth.Config {
 		SolcPath:           ctx.GlobalString(SolcPathFlag.Name),
 		AutoDAG:            ctx.GlobalBool(AutoDAGFlag.Name) || ctx.GlobalBool(MiningEnabledFlag.Name),
 	}
-
 }
 
 func GetChain(ctx *cli.Context) (*core.ChainManager, common.Database, common.Database) {

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -72,6 +72,7 @@ type Config struct {
 
 	MaxPeers        int
 	MaxPendingPeers int
+	Discovery       bool
 	Port            string
 
 	// Space-separated list of discovery node URLs
@@ -311,6 +312,7 @@ func New(config *Config) (*Ethereum, error) {
 		Name:            config.Name,
 		MaxPeers:        config.MaxPeers,
 		MaxPendingPeers: config.MaxPendingPeers,
+		Discovery:       config.Discovery,
 		Protocols:       protocols,
 		NAT:             config.NAT,
 		NoDial:          !config.Dial,

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -449,14 +449,10 @@ func (s *Ethereum) Start() error {
 		ClientString:    s.net.Name,
 		ProtocolVersion: ProtocolVersion,
 	})
-
-	if s.net.MaxPeers > 0 {
-		err := s.net.Start()
-		if err != nil {
-			return err
-		}
+	err := s.net.Start()
+	if err != nil {
+		return err
 	}
-
 	// periodically flush databases
 	go s.syncDatabases()
 

--- a/p2p/server.go
+++ b/p2p/server.go
@@ -275,9 +275,6 @@ func (srv *Server) Start() (err error) {
 	if srv.PrivateKey == nil {
 		return fmt.Errorf("Server.PrivateKey must be set to a non-nil key")
 	}
-	if srv.MaxPeers <= 0 {
-		return fmt.Errorf("Server.MaxPeers must be > 0")
-	}
 	if srv.newTransport == nil {
 		srv.newTransport = newRLPX
 	}

--- a/p2p/server.go
+++ b/p2p/server.go
@@ -55,6 +55,10 @@ type Server struct {
 	// Zero defaults to preset values.
 	MaxPendingPeers int
 
+	// Discovery specifies whether the peer discovery mechanism should be started
+	// or not. Disabling is usually useful for protocol debugging (manual topology).
+	Discovery bool
+
 	// Name sets the node name of this server.
 	// Use common.MakeName to create a name that follows existing conventions.
 	Name string
@@ -240,6 +244,14 @@ func (srv *Server) Self() *discover.Node {
 	if !srv.running {
 		return &discover.Node{IP: net.ParseIP("0.0.0.0")}
 	}
+	if srv.ntab == nil {
+		addr := srv.listener.Addr().(*net.TCPAddr)
+		return &discover.Node{
+			ID:  discover.PubkeyID(&srv.PrivateKey.PublicKey),
+			IP:  addr.IP,
+			TCP: uint16(addr.Port),
+		}
+	}
 	return srv.ntab.Self()
 }
 
@@ -290,15 +302,22 @@ func (srv *Server) Start() (err error) {
 	srv.peerOpDone = make(chan struct{})
 
 	// node table
-	ntab, err := discover.ListenUDP(srv.PrivateKey, srv.ListenAddr, srv.NAT, srv.NodeDatabase)
-	if err != nil {
-		return err
+	if srv.Discovery {
+		ntab, err := discover.ListenUDP(srv.PrivateKey, srv.ListenAddr, srv.NAT, srv.NodeDatabase)
+		if err != nil {
+			return err
+		}
+		srv.ntab = ntab
 	}
-	srv.ntab = ntab
-	dialer := newDialState(srv.StaticNodes, srv.ntab, srv.MaxPeers/2)
+
+	dynPeers := srv.MaxPeers / 2
+	if !srv.Discovery {
+		dynPeers = 0
+	}
+	dialer := newDialState(srv.StaticNodes, srv.ntab, dynPeers)
 
 	// handshake
-	srv.ourHandshake = &protoHandshake{Version: baseProtocolVersion, Name: srv.Name, ID: ntab.Self().ID}
+	srv.ourHandshake = &protoHandshake{Version: baseProtocolVersion, Name: srv.Name, ID: discover.PubkeyID(&srv.PrivateKey.PublicKey)}
 	for _, p := range srv.Protocols {
 		srv.ourHandshake.Caps = append(srv.ourHandshake.Caps, p.cap())
 	}
@@ -454,7 +473,9 @@ running:
 	}
 
 	// Terminate discovery. If there is a running lookup it will terminate soon.
-	srv.ntab.Close()
+	if srv.ntab != nil {
+		srv.ntab.Close()
+	}
 	// Disconnect all peers.
 	for _, p := range peers {
 		p.Disconnect(DiscQuitting)
@@ -486,7 +507,7 @@ func (srv *Server) encHandshakeChecks(peers map[discover.NodeID]*Peer, c *conn) 
 		return DiscTooManyPeers
 	case peers[c.id] != nil:
 		return DiscAlreadyConnected
-	case c.id == srv.ntab.Self().ID:
+	case c.id == srv.Self().ID:
 		return DiscSelf
 	default:
 		return nil


### PR DESCRIPTION
```
> geth --nodiscover --maxpeers=0 --vmodule=server=6,udp=6 console
I0526 19:06:17.792988   20598 backend.go:256] Protocol Version: 60, Network Id: 0
I0526 19:06:17.793052   20598 backend.go:266] Blockchain DB Version: 2
I0526 19:06:17.795074   20598 chain_manager.go:257] Last block (#447189) 52506c535653b3c3bbc4d004b157e043d4b379d783490b126fc2dd7931159577 TD=933016044569906
I0526 19:06:19.354463   20598 cmd.go:137] Starting Geth/v0.9.24/linux/go1.4.2
I0526 19:06:19.354615   20598 server.go:284] Starting Server
I0526 19:06:19.354727   20598 backend.go:477] Server started
I0526 19:06:19.354797   20598 server.go:521] Listening on [::]:30303
> net
{
  listening: true,
  getListening: [Function],
  peerCount: 0,
  getPeerCount: [Function]
}
> admin.nodeInfo()
{
  Name: 'Geth/v0.9.24/linux/go1.4.2',
  NodeUrl: 'enode://3ece8e6a2e000204d1b0fa999715e57b7c25796a0c861fd6630d4f081bc45a4403df849d63e5753b647975e7f3625be68b6cd8fd6fa0bf95108002ee84f16427@[::]:30303?discport=0',
  NodeID: '3ece8e6a2e000204d1b0fa999715e57b7c25796a0c861fd6630d4f081bc45a4403df849d63e5753b647975e7f3625be68b6cd8fd6fa0bf95108002ee84f16427',
  IP: '::',
  DiscPort: 0,
  TCPPort: 30303,
  Td: '933016044569906',
  ListenAddr: '[::]:30303'
}
> admin.addPeer("enode://a979fb575495b8d6db44f750317d0f4622bf4c2aa3365d6af7c284339968eef29b69ad0dce72a4d8db5ebb4968de0e3bec910127f134779fbcb0cb6d3331163c@52.16.188.185:30303")I0526 19:06:26.415588   20598 server.go:428] <-addstatic: enode://a979fb575495b8d6db44f750317d0f4622bf4c2aa3365d6af7c284339968eef29b69ad0dce72a4d8db5ebb4968de0e3bec910127f134779fbcb0cb6d3331163c@52.16.188.185:30303
I0526 19:06:26.415814   20598 server.go:404] new task: static dial a979fb575495b8d6 52.16.188.185:30303

true
I0526 19:06:26.632432   20598 server.go:448] <-posthandshake: trusted static dial conn a979fb575495b8d6 52.16.188.185:30303
I0526 19:06:26.635710   20598 server.go:454] <-addpeer: trusted static dial conn a979fb575495b8d6 52.16.188.185:30303
I0526 19:06:26.635762   20598 server.go:622] Added Peer a979fb575495b8d6 52.16.188.185:30303
I0526 19:06:26.635835   20598 server.go:438] <-taskdone: static dial a979fb575495b8d6 52.16.188.185:30303
I0526 19:06:26.635871   20598 server.go:404] new task: wait for dial hist expire (29.999959283s)
I0526 19:06:29.355329   20598 downloader.go:159] Block synchronisation started
> net
{
  listening: true,
  getListening: [Function],
  peerCount: 1,
  getPeerCount: [Function]
}
I0526 19:06:32.601349   20598 chain_manager.go:655] imported 1 block(s) (0 queued 0 ignored) in 1.746006357s. #447190 [826f3bfd / 826f3bfd]
```