### PR TITLE
cmd/geth: leaner blockchain commands

### DIFF
--- a/cmd/geth/blocktestcmd.go
+++ b/cmd/geth/blocktestcmd.go
@@ -12,7 +12,7 @@ import (
 	"github.com/ethereum/go-ethereum/tests"
 )
 
-var blocktestCmd = cli.Command{
+var blocktestCommand = cli.Command{
 	Action: runBlockTest,
 	Name:   "blocktest",
 	Usage:  `loads a block test file`,

--- a/cmd/geth/chaincmd.go
+++ b/cmd/geth/chaincmd.go
@@ -52,7 +52,7 @@ func importChain(ctx *cli.Context) {
 	if len(ctx.Args()) != 1 {
 		utils.Fatalf("This command requires an argument.")
 	}
-	chain, blockDB, stateDB, extraDB := utils.GetChain(ctx)
+	chain, blockDB, stateDB, extraDB := utils.MakeChain(ctx)
 	start := time.Now()
 	if err := utils.ImportChain(chain, ctx.Args().First()); err != nil {
 		utils.Fatalf("Import error: %v\n", err)
@@ -65,7 +65,7 @@ func exportChain(ctx *cli.Context) {
 	if len(ctx.Args()) != 1 {
 		utils.Fatalf("This command requires an argument.")
 	}
-	chain, _, _, _ := utils.GetChain(ctx)
+	chain, _, _, _ := utils.MakeChain(ctx)
 	start := time.Now()
 	if err := utils.ExportChain(chain, ctx.Args().First()); err != nil {
 		utils.Fatalf("Export error: %v\n", err)
@@ -95,7 +95,7 @@ func removeDB(ctx *cli.Context) {
 func upgradeDB(ctx *cli.Context) {
 	glog.Infoln("Upgrading blockchain database")
 
-	chain, blockDB, stateDB, extraDB := utils.GetChain(ctx)
+	chain, blockDB, stateDB, extraDB := utils.MakeChain(ctx)
 	v, _ := blockDB.Get([]byte("BlockchainVersion"))
 	bcVersion := int(common.NewValue(v).Uint())
 	if bcVersion == 0 {
@@ -113,7 +113,7 @@ func upgradeDB(ctx *cli.Context) {
 	os.RemoveAll(filepath.Join(ctx.GlobalString(utils.DataDirFlag.Name), "state"))
 
 	// Import the chain file.
-	chain, blockDB, stateDB, extraDB = utils.GetChain(ctx)
+	chain, blockDB, stateDB, extraDB = utils.MakeChain(ctx)
 	blockDB.Put([]byte("BlockchainVersion"), common.NewValue(core.BlockChainVersion).Bytes())
 	err := utils.ImportChain(chain, exportFile)
 	flushAll(blockDB, stateDB, extraDB)
@@ -126,7 +126,7 @@ func upgradeDB(ctx *cli.Context) {
 }
 
 func dump(ctx *cli.Context) {
-	chain, _, stateDB, _ := utils.GetChain(ctx)
+	chain, _, stateDB, _ := utils.MakeChain(ctx)
 	for _, arg := range ctx.Args() {
 		var block *types.Block
 		if hashish(arg) {

--- a/cmd/geth/chaincmd.go
+++ b/cmd/geth/chaincmd.go
@@ -1,0 +1,159 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"time"
+
+	"github.com/codegangsta/cli"
+	"github.com/ethereum/go-ethereum/cmd/utils"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core"
+	"github.com/ethereum/go-ethereum/core/state"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/logger/glog"
+)
+
+var (
+	importCommand = cli.Command{
+		Action: importChain,
+		Name:   "import",
+		Usage:  `import a blockchain file`,
+	}
+	exportCommand = cli.Command{
+		Action: exportChain,
+		Name:   "export",
+		Usage:  `export blockchain into file`,
+	}
+	upgradedbCommand = cli.Command{
+		Action: upgradeDB,
+		Name:   "upgradedb",
+		Usage:  "upgrade chainblock database",
+	}
+	removedbCommand = cli.Command{
+		Action: removeDB,
+		Name:   "removedb",
+		Usage:  "Remove blockchain and state databases",
+	}
+	dumpCommand = cli.Command{
+		Action: dump,
+		Name:   "dump",
+		Usage:  `dump a specific block from storage`,
+		Description: `
+The arguments are interpreted as block numbers or hashes.
+Use "ethereum dump 0" to dump the genesis block.
+`,
+	}
+)
+
+func importChain(ctx *cli.Context) {
+	if len(ctx.Args()) != 1 {
+		utils.Fatalf("This command requires an argument.")
+	}
+	chain, blockDB, stateDB, extraDB := utils.GetChain(ctx)
+	start := time.Now()
+	if err := utils.ImportChain(chain, ctx.Args().First()); err != nil {
+		utils.Fatalf("Import error: %v\n", err)
+	}
+	flushAll(blockDB, stateDB, extraDB)
+	fmt.Printf("Import done in %v", time.Since(start))
+}
+
+func exportChain(ctx *cli.Context) {
+	if len(ctx.Args()) != 1 {
+		utils.Fatalf("This command requires an argument.")
+	}
+	chain, _, _, _ := utils.GetChain(ctx)
+	start := time.Now()
+	if err := utils.ExportChain(chain, ctx.Args().First()); err != nil {
+		utils.Fatalf("Export error: %v\n", err)
+	}
+	fmt.Printf("Export done in %v", time.Since(start))
+}
+
+func removeDB(ctx *cli.Context) {
+	confirm, err := utils.PromptConfirm("Remove local databases?")
+	if err != nil {
+		utils.Fatalf("%v", err)
+	}
+
+	if confirm {
+		fmt.Println("Removing chain and state databases...")
+		start := time.Now()
+
+		os.RemoveAll(filepath.Join(ctx.GlobalString(utils.DataDirFlag.Name), "blockchain"))
+		os.RemoveAll(filepath.Join(ctx.GlobalString(utils.DataDirFlag.Name), "state"))
+
+		fmt.Printf("Removed in %v\n", time.Since(start))
+	} else {
+		fmt.Println("Operation aborted")
+	}
+}
+
+func upgradeDB(ctx *cli.Context) {
+	glog.Infoln("Upgrading blockchain database")
+
+	chain, blockDB, stateDB, extraDB := utils.GetChain(ctx)
+	v, _ := blockDB.Get([]byte("BlockchainVersion"))
+	bcVersion := int(common.NewValue(v).Uint())
+	if bcVersion == 0 {
+		bcVersion = core.BlockChainVersion
+	}
+
+	// Export the current chain.
+	filename := fmt.Sprintf("blockchain_%d_%s.chain", bcVersion, time.Now().Format("20060102_150405"))
+	exportFile := filepath.Join(ctx.GlobalString(utils.DataDirFlag.Name), filename)
+	if err := utils.ExportChain(chain, exportFile); err != nil {
+		utils.Fatalf("Unable to export chain for reimport %s\n", err)
+	}
+	flushAll(blockDB, stateDB, extraDB)
+	os.RemoveAll(filepath.Join(ctx.GlobalString(utils.DataDirFlag.Name), "blockchain"))
+	os.RemoveAll(filepath.Join(ctx.GlobalString(utils.DataDirFlag.Name), "state"))
+
+	// Import the chain file.
+	chain, blockDB, stateDB, extraDB = utils.GetChain(ctx)
+	blockDB.Put([]byte("BlockchainVersion"), common.NewValue(core.BlockChainVersion).Bytes())
+	err := utils.ImportChain(chain, exportFile)
+	flushAll(blockDB, stateDB, extraDB)
+	if err != nil {
+		utils.Fatalf("Import error %v (a backup is made in %s, use the import command to import it)\n", err, exportFile)
+	} else {
+		os.Remove(exportFile)
+		glog.Infoln("Import finished")
+	}
+}
+
+func dump(ctx *cli.Context) {
+	chain, _, stateDB, _ := utils.GetChain(ctx)
+	for _, arg := range ctx.Args() {
+		var block *types.Block
+		if hashish(arg) {
+			block = chain.GetBlock(common.HexToHash(arg))
+		} else {
+			num, _ := strconv.Atoi(arg)
+			block = chain.GetBlockByNumber(uint64(num))
+		}
+		if block == nil {
+			fmt.Println("{}")
+			utils.Fatalf("block not found")
+		} else {
+			state := state.New(block.Root(), stateDB)
+			fmt.Printf("%s\n", state.Dump())
+		}
+	}
+}
+
+// hashish returns true for strings that look like hashes.
+func hashish(x string) bool {
+	_, err := strconv.Atoi(x)
+	return err != nil
+}
+
+func flushAll(dbs ...common.Database) {
+	for _, db := range dbs {
+		db.Flush()
+		db.Close()
+	}
+}

--- a/cmd/geth/chaincmd.go
+++ b/cmd/geth/chaincmd.go
@@ -55,7 +55,7 @@ func importChain(ctx *cli.Context) {
 	chain, blockDB, stateDB, extraDB := utils.MakeChain(ctx)
 	start := time.Now()
 	err := utils.ImportChain(chain, ctx.Args().First())
-	flushAll(blockDB, stateDB, extraDB)
+	closeAll(blockDB, stateDB, extraDB)
 	if err != nil {
 		utils.Fatalf("Import error: %v", err)
 	}
@@ -109,7 +109,7 @@ func upgradeDB(ctx *cli.Context) {
 	if err := utils.ExportChain(chain, exportFile); err != nil {
 		utils.Fatalf("Unable to export chain for reimport %s", err)
 	}
-	flushAll(blockDB, stateDB, extraDB)
+	closeAll(blockDB, stateDB, extraDB)
 	os.RemoveAll(filepath.Join(ctx.GlobalString(utils.DataDirFlag.Name), "blockchain"))
 	os.RemoveAll(filepath.Join(ctx.GlobalString(utils.DataDirFlag.Name), "state"))
 
@@ -117,7 +117,7 @@ func upgradeDB(ctx *cli.Context) {
 	chain, blockDB, stateDB, extraDB = utils.MakeChain(ctx)
 	blockDB.Put([]byte("BlockchainVersion"), common.NewValue(core.BlockChainVersion).Bytes())
 	err := utils.ImportChain(chain, exportFile)
-	flushAll(blockDB, stateDB, extraDB)
+	closeAll(blockDB, stateDB, extraDB)
 	if err != nil {
 		utils.Fatalf("Import error %v (a backup is made in %s, use the import command to import it)", err, exportFile)
 	} else {
@@ -152,9 +152,8 @@ func hashish(x string) bool {
 	return err != nil
 }
 
-func flushAll(dbs ...common.Database) {
+func closeAll(dbs ...common.Database) {
 	for _, db := range dbs {
-		db.Flush()
 		db.Close()
 	}
 }

--- a/cmd/geth/chaincmd.go
+++ b/cmd/geth/chaincmd.go
@@ -54,10 +54,11 @@ func importChain(ctx *cli.Context) {
 	}
 	chain, blockDB, stateDB, extraDB := utils.MakeChain(ctx)
 	start := time.Now()
-	if err := utils.ImportChain(chain, ctx.Args().First()); err != nil {
-		utils.Fatalf("Import error: %v\n", err)
-	}
+	err := utils.ImportChain(chain, ctx.Args().First())
 	flushAll(blockDB, stateDB, extraDB)
+	if err != nil {
+		utils.Fatalf("Import error: %v", err)
+	}
 	fmt.Printf("Import done in %v", time.Since(start))
 }
 
@@ -106,7 +107,7 @@ func upgradeDB(ctx *cli.Context) {
 	filename := fmt.Sprintf("blockchain_%d_%s.chain", bcVersion, time.Now().Format("20060102_150405"))
 	exportFile := filepath.Join(ctx.GlobalString(utils.DataDirFlag.Name), filename)
 	if err := utils.ExportChain(chain, exportFile); err != nil {
-		utils.Fatalf("Unable to export chain for reimport %s\n", err)
+		utils.Fatalf("Unable to export chain for reimport %s", err)
 	}
 	flushAll(blockDB, stateDB, extraDB)
 	os.RemoveAll(filepath.Join(ctx.GlobalString(utils.DataDirFlag.Name), "blockchain"))
@@ -118,7 +119,7 @@ func upgradeDB(ctx *cli.Context) {
 	err := utils.ImportChain(chain, exportFile)
 	flushAll(blockDB, stateDB, extraDB)
 	if err != nil {
-		utils.Fatalf("Import error %v (a backup is made in %s, use the import command to import it)\n", err, exportFile)
+		utils.Fatalf("Import error %v (a backup is made in %s, use the import command to import it)", err, exportFile)
 	} else {
 		os.Remove(exportFile)
 		glog.Infoln("Import finished")

--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -394,7 +394,7 @@ func startEth(ctx *cli.Context, eth *eth.Ethereum) {
 }
 
 func accountList(ctx *cli.Context) {
-	am := utils.GetAccountManager(ctx)
+	am := utils.MakeAccountManager(ctx)
 	accts, err := am.Accounts()
 	if err != nil {
 		utils.Fatalf("Could not list accounts: %v", err)
@@ -436,7 +436,7 @@ func getPassPhrase(ctx *cli.Context, desc string, confirmation bool) (passphrase
 }
 
 func accountCreate(ctx *cli.Context) {
-	am := utils.GetAccountManager(ctx)
+	am := utils.MakeAccountManager(ctx)
 	passphrase := getPassPhrase(ctx, "Your new account is locked with a password. Please give a password. Do not forget this password.", true)
 	acct, err := am.NewAccount(passphrase)
 	if err != nil {
@@ -455,7 +455,7 @@ func importWallet(ctx *cli.Context) {
 		utils.Fatalf("Could not read wallet file: %v", err)
 	}
 
-	am := utils.GetAccountManager(ctx)
+	am := utils.MakeAccountManager(ctx)
 	passphrase := getPassPhrase(ctx, "", false)
 
 	acct, err := am.ImportPreSaleKey(keyJson, passphrase)
@@ -470,7 +470,7 @@ func accountImport(ctx *cli.Context) {
 	if len(keyfile) == 0 {
 		utils.Fatalf("keyfile must be given as argument")
 	}
-	am := utils.GetAccountManager(ctx)
+	am := utils.MakeAccountManager(ctx)
 	passphrase := getPassPhrase(ctx, "Your new account is locked with a password. Please give a password. Do not forget this password.", true)
 	acct, err := am.Import(keyfile, passphrase)
 	if err != nil {

--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -24,28 +24,23 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
+	_ "net/http/pprof"
 	"os"
 	"path/filepath"
 	"runtime"
 	"strconv"
 	"strings"
-	"time"
 
 	"github.com/codegangsta/cli"
 	"github.com/ethereum/ethash"
 	"github.com/ethereum/go-ethereum/accounts"
 	"github.com/ethereum/go-ethereum/cmd/utils"
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/core"
-	"github.com/ethereum/go-ethereum/core/state"
-	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/eth"
 	"github.com/ethereum/go-ethereum/logger"
-	"github.com/ethereum/go-ethereum/logger/glog"
 	"github.com/mattn/go-colorable"
 	"github.com/mattn/go-isatty"
 )
-import _ "net/http/pprof"
 
 const (
 	ClientIdentifier = "Geth"
@@ -69,7 +64,12 @@ func init() {
 	app.Action = run
 	app.HideVersion = true // we have a command to print the version
 	app.Commands = []cli.Command{
-		blocktestCmd,
+		blocktestCommand,
+		importCommand,
+		exportCommand,
+		upgradedbCommand,
+		removedbCommand,
+		dumpCommand,
 		{
 			Action: makedag,
 			Name:   "makedag",
@@ -195,15 +195,6 @@ nodes.
 			},
 		},
 		{
-			Action: dump,
-			Name:   "dump",
-			Usage:  `dump a specific block from storage`,
-			Description: `
-The arguments are interpreted as block numbers or hashes.
-Use "ethereum dump 0" to dump the genesis block.
-`,
-		},
-		{
 			Action: console,
 			Name:   "console",
 			Usage:  `Geth Console: interactive JavaScript environment`,
@@ -221,26 +212,6 @@ See https://github.com/ethereum/go-ethereum/wiki/Javascipt-Console
 The JavaScript VM exposes a node admin interface as well as the Ðapp
 JavaScript API. See https://github.com/ethereum/go-ethereum/wiki/Javascipt-Console
 `,
-		},
-		{
-			Action: importchain,
-			Name:   "import",
-			Usage:  `import a blockchain file`,
-		},
-		{
-			Action: exportchain,
-			Name:   "export",
-			Usage:  `export blockchain into file`,
-		},
-		{
-			Action: upgradeDb,
-			Name:   "upgradedb",
-			Usage:  "upgrade chainblock database",
-		},
-		{
-			Action: removeDb,
-			Name:   "removedb",
-			Usage:  "Remove blockchain and state databases",
 		},
 	}
 	app.Flags = []cli.Flag{
@@ -508,103 +479,6 @@ func accountImport(ctx *cli.Context) {
 	fmt.Printf("Address: %x\n", acct)
 }
 
-func importchain(ctx *cli.Context) {
-	if len(ctx.Args()) != 1 {
-		utils.Fatalf("This command requires an argument.")
-	}
-	chain, blockDB, stateDB, extraDB := utils.GetChain(ctx)
-	start := time.Now()
-	if err := utils.ImportChain(chain, ctx.Args().First()); err != nil {
-		utils.Fatalf("Import error: %v\n", err)
-	}
-	flushAll(blockDB, stateDB, extraDB)
-	fmt.Printf("Import done in %v", time.Since(start))
-}
-
-func exportchain(ctx *cli.Context) {
-	if len(ctx.Args()) != 1 {
-		utils.Fatalf("This command requires an argument.")
-	}
-	chain, _, _, _ := utils.GetChain(ctx)
-	start := time.Now()
-	if err := utils.ExportChain(chain, ctx.Args().First()); err != nil {
-		utils.Fatalf("Export error: %v\n", err)
-	}
-	fmt.Printf("Export done in %v", time.Since(start))
-}
-
-func removeDb(ctx *cli.Context) {
-	confirm, err := utils.PromptConfirm("Remove local databases?")
-	if err != nil {
-		utils.Fatalf("%v", err)
-	}
-
-	if confirm {
-		fmt.Println("Removing chain and state databases...")
-		start := time.Now()
-
-		os.RemoveAll(filepath.Join(ctx.GlobalString(utils.DataDirFlag.Name), "blockchain"))
-		os.RemoveAll(filepath.Join(ctx.GlobalString(utils.DataDirFlag.Name), "state"))
-
-		fmt.Printf("Removed in %v\n", time.Since(start))
-	} else {
-		fmt.Println("Operation aborted")
-	}
-}
-
-func upgradeDb(ctx *cli.Context) {
-	glog.Infoln("Upgrading blockchain database")
-
-	chain, blockDB, stateDB, extraDB := utils.GetChain(ctx)
-	v, _ := blockDB.Get([]byte("BlockchainVersion"))
-	bcVersion := int(common.NewValue(v).Uint())
-	if bcVersion == 0 {
-		bcVersion = core.BlockChainVersion
-	}
-
-	// Export the current chain.
-	filename := fmt.Sprintf("blockchain_%d_%s.chain", bcVersion, time.Now().Format("20060102_150405"))
-	exportFile := filepath.Join(ctx.GlobalString(utils.DataDirFlag.Name), filename)
-	if err := utils.ExportChain(chain, exportFile); err != nil {
-		utils.Fatalf("Unable to export chain for reimport %s\n", err)
-	}
-	flushAll(blockDB, stateDB, extraDB)
-	os.RemoveAll(filepath.Join(ctx.GlobalString(utils.DataDirFlag.Name), "blockchain"))
-	os.RemoveAll(filepath.Join(ctx.GlobalString(utils.DataDirFlag.Name), "state"))
-
-	// Import the chain file.
-	chain, blockDB, stateDB, extraDB = utils.GetChain(ctx)
-	blockDB.Put([]byte("BlockchainVersion"), common.NewValue(core.BlockChainVersion).Bytes())
-	err := utils.ImportChain(chain, exportFile)
-	flushAll(blockDB, stateDB, extraDB)
-	if err != nil {
-		utils.Fatalf("Import error %v (a backup is made in %s, use the import command to import it)\n", err, exportFile)
-	} else {
-		os.Remove(exportFile)
-		glog.Infoln("Import finished")
-	}
-}
-
-func dump(ctx *cli.Context) {
-	chain, _, stateDB, _ := utils.GetChain(ctx)
-	for _, arg := range ctx.Args() {
-		var block *types.Block
-		if hashish(arg) {
-			block = chain.GetBlock(common.HexToHash(arg))
-		} else {
-			num, _ := strconv.Atoi(arg)
-			block = chain.GetBlockByNumber(uint64(num))
-		}
-		if block == nil {
-			fmt.Println("{}")
-			utils.Fatalf("block not found")
-		} else {
-			state := state.New(block.Root(), stateDB)
-			fmt.Printf("%s\n", state.Dump())
-		}
-	}
-}
-
 func makedag(ctx *cli.Context) {
 	args := ctx.Args()
 	wrongArgs := func() {
@@ -646,17 +520,4 @@ func version(c *cli.Context) {
 	fmt.Println("OS:", runtime.GOOS)
 	fmt.Printf("GOPATH=%s\n", os.Getenv("GOPATH"))
 	fmt.Printf("GOROOT=%s\n", runtime.GOROOT())
-}
-
-// hashish returns true for strings that look like hashes.
-func hashish(x string) bool {
-	_, err := strconv.Atoi(x)
-	return err != nil
-}
-
-func flushAll(dbs ...common.Database) {
-	for _, db := range dbs {
-		db.Flush()
-		db.Close()
-	}
 }

--- a/cmd/mist/main.go
+++ b/cmd/mist/main.go
@@ -86,6 +86,10 @@ func init() {
 		utils.BlockchainVersionFlag,
 		utils.NetworkIdFlag,
 	}
+	app.Before = func(ctx *cli.Context) error {
+		utils.SetupLogger(ctx)
+		return nil
+	}
 }
 
 func main() {

--- a/cmd/utils/cmd.go
+++ b/cmd/utils/cmd.go
@@ -125,10 +125,17 @@ func initDataDir(Datadir string) {
 	}
 }
 
-// Fatalf formats a message to standard output and exits the program.
+// Fatalf formats a message to standard error and exits the program.
+// The message is also printed to standard output if standard error
+// is redirected to a different file.
 func Fatalf(format string, args ...interface{}) {
-	fmt.Fprintf(os.Stderr, "Fatal: "+format+"\n", args...)
-	fmt.Fprintf(os.Stdout, "Fatal: "+format+"\n", args...)
+	w := io.MultiWriter(os.Stdout, os.Stderr)
+	outf, _ := os.Stdout.Stat()
+	errf, _ := os.Stderr.Stat()
+	if outf != nil && errf != nil && os.SameFile(outf, errf) {
+		w = os.Stderr
+	}
+	fmt.Fprintf(w, "Fatal: "+format+"\n", args...)
 	logger.Flush()
 	os.Exit(1)
 }

--- a/cmd/utils/cmd.go
+++ b/cmd/utils/cmd.go
@@ -40,6 +40,10 @@ import (
 	"github.com/peterh/liner"
 )
 
+const (
+	importBatchSize = 2500
+)
+
 var interruptCallbacks = []func(os.Signal){}
 
 // Register interrupt handlers callbacks
@@ -205,8 +209,7 @@ func ImportChain(chain *core.ChainManager, fn string) error {
 	stream := rlp.NewStream(fh, 0)
 
 	// Run actual the import.
-	batchSize := 2500
-	blocks := make(types.Blocks, batchSize)
+	blocks := make(types.Blocks, importBatchSize)
 	n := 0
 	for batch := 0; ; batch++ {
 		// Load a batch of RLP blocks.
@@ -214,7 +217,7 @@ func ImportChain(chain *core.ChainManager, fn string) error {
 			return fmt.Errorf("interrupted")
 		}
 		i := 0
-		for ; i < batchSize; i++ {
+		for ; i < importBatchSize; i++ {
 			var b types.Block
 			if err := stream.Decode(&b); err == io.EOF {
 				break

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -256,7 +256,8 @@ var (
 	}
 )
 
-func GetNAT(ctx *cli.Context) nat.Interface {
+// MakeNAT creates a port mapper from set command line flags.
+func MakeNAT(ctx *cli.Context) nat.Interface {
 	natif, err := nat.Parse(ctx.GlobalString(NATFlag.Name))
 	if err != nil {
 		Fatalf("Option %s: %v", NATFlag.Name, err)
@@ -264,7 +265,8 @@ func GetNAT(ctx *cli.Context) nat.Interface {
 	return natif
 }
 
-func GetNodeKey(ctx *cli.Context) (key *ecdsa.PrivateKey) {
+// MakeNodeKey creates a node key from set command line flags.
+func MakeNodeKey(ctx *cli.Context) (key *ecdsa.PrivateKey) {
 	hex, file := ctx.GlobalString(NodeKeyHexFlag.Name), ctx.GlobalString(NodeKeyFileFlag.Name)
 	var err error
 	switch {
@@ -282,6 +284,7 @@ func GetNodeKey(ctx *cli.Context) (key *ecdsa.PrivateKey) {
 	return key
 }
 
+// MakeEthConfig creates ethereum options from set command line flags.
 func MakeEthConfig(clientID, version string, ctx *cli.Context) *eth.Config {
 	customName := ctx.GlobalString(IdentityFlag.Name)
 	if len(customName) > 0 {
@@ -299,15 +302,15 @@ func MakeEthConfig(clientID, version string, ctx *cli.Context) *eth.Config {
 		LogJSON:            ctx.GlobalString(LogJSONFlag.Name),
 		Etherbase:          ctx.GlobalString(EtherbaseFlag.Name),
 		MinerThreads:       ctx.GlobalInt(MinerThreadsFlag.Name),
-		AccountManager:     GetAccountManager(ctx),
+		AccountManager:     MakeAccountManager(ctx),
 		VmDebug:            ctx.GlobalBool(VMDebugFlag.Name),
 		MaxPeers:           ctx.GlobalInt(MaxPeersFlag.Name),
 		MaxPendingPeers:    ctx.GlobalInt(MaxPendingPeersFlag.Name),
 		Port:               ctx.GlobalString(ListenPortFlag.Name),
-		NAT:                GetNAT(ctx),
+		NAT:                MakeNAT(ctx),
 		NatSpec:            ctx.GlobalBool(NatspecEnabledFlag.Name),
 		Discovery:          !ctx.GlobalBool(NoDiscoverFlag.Name),
-		NodeKey:            GetNodeKey(ctx),
+		NodeKey:            MakeNodeKey(ctx),
 		Shh:                ctx.GlobalBool(WhisperEnabledFlag.Name),
 		Dial:               true,
 		BootNodes:          ctx.GlobalString(BootnodesFlag.Name),
@@ -325,7 +328,8 @@ func SetupLogger(ctx *cli.Context) {
 	glog.SetLogDir(ctx.GlobalString(LogFileFlag.Name))
 }
 
-func GetChain(ctx *cli.Context) (chain *core.ChainManager, blockDB, stateDB, extraDB common.Database) {
+// MakeChain creates a chain manager from set command line flags.
+func MakeChain(ctx *cli.Context) (chain *core.ChainManager, blockDB, stateDB, extraDB common.Database) {
 	dd := ctx.GlobalString(DataDirFlag.Name)
 	var err error
 	if blockDB, err = ethdb.NewLDBDatabase(filepath.Join(dd, "blockchain")); err != nil {
@@ -347,7 +351,8 @@ func GetChain(ctx *cli.Context) (chain *core.ChainManager, blockDB, stateDB, ext
 	return chain, blockDB, stateDB, extraDB
 }
 
-func GetAccountManager(ctx *cli.Context) *accounts.Manager {
+// MakeChain creates an account manager from set command line flags.
+func MakeAccountManager(ctx *cli.Context) *accounts.Manager {
 	dataDir := ctx.GlobalString(DataDirFlag.Name)
 	ks := crypto.NewKeyStorePassphrase(filepath.Join(dataDir, "keystore"))
 	return accounts.NewManager(ks)

--- a/p2p/nat/nat_test.go
+++ b/p2p/nat/nat_test.go
@@ -30,7 +30,7 @@ func TestAutoDiscRace(t *testing.T) {
 	}
 
 	// Check that they all return the correct result within the deadline.
-	deadline := time.After(550 * time.Millisecond)
+	deadline := time.After(2 * time.Second)
 	for i := 0; i < cap(results); i++ {
 		select {
 		case <-deadline:


### PR DESCRIPTION
The blockchain commands don't need the full stack. With this change,
p2p, miner, downloader, etc are no longer created for these blockchain operations.

This PR also adds periodic DB flushing and interrupt handling for `geth import` and `geth upgradedb`.
The flushing should resolve the high memory usage reported in #1119, #1116, #1125.