### PR TITLE
cmd/geth: expand admin.progress() to something meaningful

### DIFF
--- a/cmd/geth/admin.go
+++ b/cmd/geth/admin.go
@@ -262,8 +262,8 @@ func (js *jsre) setHead(call otto.FunctionCall) otto.Value {
 }
 
 func (js *jsre) downloadProgress(call otto.FunctionCall) otto.Value {
-	current, max := js.ethereum.Downloader().Stats()
-	v, _ := call.Otto.ToValue(fmt.Sprintf("%d/%d", current, max))
+	pending, cached := js.ethereum.Downloader().Stats()
+	v, _ := call.Otto.ToValue(map[string]interface{}{"pending": pending, "cached": cached})
 	return v
 }
 


### PR DESCRIPTION
Previously:

```
> admin.progress()
'389121/1024'
```

With this PR:

```
> admin.progress()
{
  pending: 152208,
  cached: 1024
}
```

Also enabling:
```
> admin.progress().pending
149264
> admin.progress().cached
1024
```