### PR TITLE
Differentiate between 0 and unspecified gas/gasprice

### DIFF
--- a/rpc/api.go
+++ b/rpc/api.go
@@ -626,9 +626,9 @@ func (api *EthereumApi) doCall(params json.RawMessage) (string, string, error) {
 
 	var gasprice string
 	if args.GasPrice == nil {
-		gas = ""
+		gasprice = ""
 	} else {
-		gas = args.GasPrice.String()
+		gasprice = args.GasPrice.String()
 	}
 
 	return api.xethAtStateNum(args.BlockNumber).Call(args.From, args.To, args.Value.String(), gas, gasprice, args.Data)

--- a/rpc/api.go
+++ b/rpc/api.go
@@ -182,7 +182,21 @@ func (api *EthereumApi) GetRequestReply(req *RpcRequest, reply *interface{}) err
 			nonce = args.Nonce.String()
 		}
 
-		v, err := api.xeth().Transact(args.From, args.To, nonce, args.Value.String(), args.Gas.String(), args.GasPrice.String(), args.Data)
+		var gas string
+		if args.Gas == nil {
+			gas = ""
+		} else {
+			gas = args.Gas.String()
+		}
+
+		var gasprice string
+		if args.GasPrice == nil {
+			gas = ""
+		} else {
+			gas = args.GasPrice.String()
+		}
+
+		v, err := api.xeth().Transact(args.From, args.To, nonce, args.Value.String(), gas, gasprice, args.Data)
 		if err != nil {
 			return err
 		}
@@ -603,5 +617,19 @@ func (api *EthereumApi) doCall(params json.RawMessage) (string, string, error) {
 		return "", "", err
 	}
 
-	return api.xethAtStateNum(args.BlockNumber).Call(args.From, args.To, args.Value.String(), args.Gas.String(), args.GasPrice.String(), args.Data)
+	var gas string
+	if args.Gas == nil {
+		gas = ""
+	} else {
+		gas = args.Gas.String()
+	}
+
+	var gasprice string
+	if args.GasPrice == nil {
+		gas = ""
+	} else {
+		gas = args.GasPrice.String()
+	}
+
+	return api.xethAtStateNum(args.BlockNumber).Call(args.From, args.To, args.Value.String(), gas, gasprice, args.Data)
 }

--- a/rpc/api.go
+++ b/rpc/api.go
@@ -191,9 +191,9 @@ func (api *EthereumApi) GetRequestReply(req *RpcRequest, reply *interface{}) err
 
 		var gasprice string
 		if args.GasPrice == nil {
-			gas = ""
+			gasprice = ""
 		} else {
-			gas = args.GasPrice.String()
+			gasprice = args.GasPrice.String()
 		}
 
 		v, err := api.xeth().Transact(args.From, args.To, nonce, args.Value.String(), gas, gasprice, args.Data)

--- a/rpc/args.go
+++ b/rpc/args.go
@@ -261,22 +261,22 @@ func (args *NewTxArgs) UnmarshalJSON(b []byte) (err error) {
 	args.Value = num
 
 	num = nil
-	if ext.Gas == nil {
-		num = big.NewInt(0)
-	} else {
+	if ext.Gas != nil {
 		if num, err = numString(ext.Gas); err != nil {
 			return err
 		}
+	} else {
+		num = nil
 	}
 	args.Gas = num
 
 	num = nil
-	if ext.GasPrice == nil {
-		num = big.NewInt(0)
-	} else {
+	if ext.GasPrice != nil {
 		if num, err = numString(ext.GasPrice); err != nil {
 			return err
 		}
+	} else {
+		num = nil
 	}
 	args.GasPrice = num
 
@@ -346,21 +346,21 @@ func (args *CallArgs) UnmarshalJSON(b []byte) (err error) {
 	}
 	args.Value = num
 
-	if ext.Gas == nil {
-		num = big.NewInt(0)
-	} else {
+	if ext.Gas != nil {
 		if num, err = numString(ext.Gas); err != nil {
 			return err
 		}
+	} else {
+		num = nil
 	}
 	args.Gas = num
 
-	if ext.GasPrice == nil {
-		num = big.NewInt(0)
-	} else {
+	if ext.GasPrice != nil {
 		if num, err = numString(ext.GasPrice); err != nil {
 			return err
 		}
+	} else {
+		num = nil
 	}
 	args.GasPrice = num
 

--- a/rpc/args_test.go
+++ b/rpc/args_test.go
@@ -573,14 +573,15 @@ func TestNewTxArgsGasMissing(t *testing.T) {
   "data": "0xd46e8dd67c5d32be8d46e8dd67c5d32be8058bb8eb970870f072445675058bb8eb970870f072445675"
   }]`
 	expected := new(NewTxArgs)
-	expected.Gas = big.NewInt(0)
+	expected.Gas = nil
 
 	args := new(NewTxArgs)
 	if err := json.Unmarshal([]byte(input), &args); err != nil {
 		t.Error(err)
 	}
 
-	if bytes.Compare(expected.Gas.Bytes(), args.Gas.Bytes()) != 0 {
+	if args.Gas != expected.Gas {
+		// if bytes.Compare(expected.Gas.Bytes(), args.Gas.Bytes()) != 0 {
 		t.Errorf("Gas shoud be %v but is %v", expected.Gas, args.Gas)
 	}
 }
@@ -594,14 +595,15 @@ func TestNewTxArgsBlockGaspriceMissing(t *testing.T) {
   "data": "0xd46e8dd67c5d32be8d46e8dd67c5d32be8058bb8eb970870f072445675058bb8eb970870f072445675"
   }]`
 	expected := new(NewTxArgs)
-	expected.GasPrice = big.NewInt(0)
+	expected.GasPrice = nil
 
 	args := new(NewTxArgs)
 	if err := json.Unmarshal([]byte(input), &args); err != nil {
 		t.Error(err)
 	}
 
-	if bytes.Compare(expected.GasPrice.Bytes(), args.GasPrice.Bytes()) != 0 {
+	if args.GasPrice != expected.GasPrice {
+		// if bytes.Compare(expected.GasPrice.Bytes(), args.GasPrice.Bytes()) != 0 {
 		t.Errorf("GasPrice shoud be %v but is %v", expected.GasPrice, args.GasPrice)
 	}
 
@@ -829,9 +831,10 @@ func TestCallArgsGasMissing(t *testing.T) {
 	}
 
 	expected := new(CallArgs)
-	expected.Gas = big.NewInt(0)
+	expected.Gas = nil
 
-	if bytes.Compare(expected.Gas.Bytes(), args.Gas.Bytes()) != 0 {
+	if args.Gas != expected.Gas {
+		// if bytes.Compare(expected.Gas.Bytes(), args.Gas.Bytes()) != 0 {
 		t.Errorf("Gas shoud be %v but is %v", expected.Gas, args.Gas)
 	}
 
@@ -852,9 +855,10 @@ func TestCallArgsBlockGaspriceMissing(t *testing.T) {
 	}
 
 	expected := new(CallArgs)
-	expected.GasPrice = big.NewInt(0)
+	expected.GasPrice = nil
 
-	if bytes.Compare(expected.GasPrice.Bytes(), args.GasPrice.Bytes()) != 0 {
+	if args.GasPrice != expected.GasPrice {
+		// if bytes.Compare(expected.GasPrice.Bytes(), args.GasPrice.Bytes()) != 0 {
 		t.Errorf("GasPrice shoud be %v but is %v", expected.GasPrice, args.GasPrice)
 	}
 }

--- a/xeth/xeth.go
+++ b/xeth/xeth.go
@@ -885,11 +885,28 @@ func (self *XEth) Transact(fromStr, toStr, nonceStr, valueStr, gasStr, gasPriceS
 		from             = common.HexToAddress(fromStr)
 		to               = common.HexToAddress(toStr)
 		value            = common.Big(valueStr)
-		gas              = common.Big(gasStr)
-		price            = common.Big(gasPriceStr)
+		gas              *big.Int
+		price            *big.Int
 		data             []byte
 		contractCreation bool
 	)
+
+	if len(gasStr) == 0 {
+		gas = DefaultGas()
+	} else {
+		gas = common.Big(gasStr)
+	}
+
+	if len(gasPriceStr) == 0 {
+		price = DefaultGasPrice()
+	} else {
+		price = common.Big(gasPriceStr)
+	}
+
+	data = common.FromHex(codeStr)
+	if len(toStr) == 0 {
+		contractCreation = true
+	}
 
 	// 2015-05-18 Is this still needed?
 	// TODO if no_private_key then
@@ -916,18 +933,6 @@ func (self *XEth) Transact(fromStr, toStr, nonceStr, valueStr, gasStr, gasPriceS
 
 	// TODO: align default values to have the same type, e.g. not depend on
 	// common.Value conversions later on
-	if gas.Cmp(big.NewInt(0)) == 0 {
-		gas = DefaultGas()
-	}
-
-	if price.Cmp(big.NewInt(0)) == 0 {
-		price = DefaultGasPrice()
-	}
-
-	data = common.FromHex(codeStr)
-	if len(toStr) == 0 {
-		contractCreation = true
-	}
 
 	var tx *types.Transaction
 	if contractCreation {


### PR DESCRIPTION
Closes #1145 

Admittedly, there is probably a better way of handling this, but to do it correctly, we need to take a hard look at XEth, giving it a proper interface for consumable API, especially in light of IPC and Go 1.5 libraries.