### PR TITLE
p2p/nat: request timeouts for UPnP discovery

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -31,7 +31,7 @@
 		},
 		{
 			"ImportPath": "github.com/huin/goupnp",
-			"Rev": "c57ae84388ab59076fd547f1abeab71c2edb0a21"
+			"Rev": "5cff77a69fb22f5f1774c4451ea2aab63d4d2f20"
 		},
 		{
 			"ImportPath": "github.com/jackpal/go-nat-pmp",

--- a/Godeps/_workspace/src/github.com/huin/goupnp/goupnp.go
+++ b/Godeps/_workspace/src/github.com/huin/goupnp/goupnp.go
@@ -19,7 +19,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
-
+	"time"
 	"golang.org/x/net/html/charset"
 
 	"github.com/huin/goupnp/httpu"
@@ -64,7 +64,6 @@ func DiscoverDevices(searchTarget string) ([]MaybeRootDevice, error) {
 		maybe := &results[i]
 		loc, err := response.Location()
 		if err != nil {
-
 			maybe.Err = ContextError{"unexpected bad location from search", err}
 			continue
 		}
@@ -93,7 +92,11 @@ func DiscoverDevices(searchTarget string) ([]MaybeRootDevice, error) {
 }
 
 func requestXml(url string, defaultSpace string, doc interface{}) error {
-	resp, err := http.Get(url)
+	timeout := time.Duration(3 * time.Second)
+	client := http.Client{
+		Timeout: timeout,
+	}
+	resp, err := client.Get(url)
 	if err != nil {
 		return err
 	}

--- a/p2p/nat/natupnp.go
+++ b/p2p/nat/natupnp.go
@@ -12,6 +12,8 @@ import (
 	"github.com/huin/goupnp/dcps/internetgateway2"
 )
 
+const soapRequestTimeout = 3 * time.Second
+
 type upnp struct {
 	dev     *goupnp.RootDevice
 	service string
@@ -131,6 +133,7 @@ func discover(out chan<- *upnp, target string, matcher func(*goupnp.RootDevice, 
 			}
 			// check for a matching IGD service
 			sc := goupnp.ServiceClient{service.NewSOAPClient(), devs[i].Root, service}
+			sc.SOAPClient.HTTPClient.Timeout = soapRequestTimeout
 			upnp := matcher(devs[i].Root, sc)
 			if upnp == nil {
 				return


### PR DESCRIPTION
The UPnP discovery was missing HTTP request timeouts, causing shutdown to hang in some cases.