### PR TITLE
eth: implement the NewBlockHashes protocol proposal

### DIFF
--- a/eth/handler.go
+++ b/eth/handler.go
@@ -362,7 +362,7 @@ func (pm *ProtocolManager) importBlock(p *peer, block *types.Block, td *big.Int)
 	_, chainHead, _ := pm.chainman.Status()
 	jsonlogger.LogJson(&logger.EthChainReceivedNewBlock{
 		BlockHash:     hash.Hex(),
-		BlockNumber:   block.Number(), // this surely must be zero
+		BlockNumber:   block.Number(),
 		ChainHeadHash: chainHead.Hex(),
 		BlockPrevHash: block.ParentHash().Hex(),
 		RemoteId:      p.ID().String(),

--- a/eth/peer.go
+++ b/eth/peer.go
@@ -88,6 +88,10 @@ func (p *peer) sendBlocks(blocks []*types.Block) error {
 	return p2p.Send(p.rw, BlocksMsg, blocks)
 }
 
+func (p *peer) sendNewBlockHashes(hashes []common.Hash) error {
+	return p2p.Send(p.rw, NewBlockHashesMsg, hashes)
+}
+
 func (p *peer) sendNewBlock(block *types.Block) error {
 	p.blockHashes.Add(block.Hash())
 

--- a/eth/peer.go
+++ b/eth/peer.go
@@ -89,6 +89,9 @@ func (p *peer) sendBlocks(blocks []*types.Block) error {
 }
 
 func (p *peer) sendNewBlockHashes(hashes []common.Hash) error {
+	for _, hash := range hashes {
+		p.blockHashes.Add(hash)
+	}
 	return p2p.Send(p.rw, NewBlockHashesMsg, hashes)
 }
 

--- a/eth/protocol.go
+++ b/eth/protocol.go
@@ -17,7 +17,7 @@ const (
 // eth protocol message codes
 const (
 	StatusMsg = iota
-	GetTxMsg  // unused
+	NewBlockHashesMsg
 	TxMsg
 	GetBlockHashesMsg
 	BlockHashesMsg


### PR DESCRIPTION
This is a work in progress. It implements the protocol spec for the NewBlockHashes as defined here: https://github.com/ethereum/wiki/wiki/Proposal:-NewBlockHashes, but it is still missing a few essential features:

 - [x] If multiple peers send us the hash notification, fetch from only one
 - [x] Introduce a timer to check if somebody is trying to screw us with non-existent hashes
 - [x] Don't start up a separate goroutine for every hash notification
 - [x] Separate explicit fetches from downloader fetches