### PR TITLE
eth/downloader: handle timeouts more gracefully

### DIFF
--- a/eth/downloader/downloader.go
+++ b/eth/downloader/downloader.go
@@ -460,6 +460,7 @@ out:
 				// 3) Amount and availability.
 				if peer := d.peers.Peer(pid); peer != nil {
 					peer.Demote()
+					glog.V(logger.Detail).Infof("%s: block delivery timeout", peer)
 				}
 			}
 			// After removing bad peers make sure we actually have sufficient peer left to keep downloading

--- a/eth/downloader/peer.go
+++ b/eth/downloader/peer.go
@@ -87,6 +87,9 @@ func (p *peer) SetIdle() {
 	scale := 2.0
 	if time.Since(p.started) > blockSoftTTL {
 		scale = 0.5
+		if time.Since(p.started) > blockHardTTL {
+			scale = 1 / float64(MaxBlockFetch) // reduces capacity to 1
+		}
 	}
 	for {
 		// Calculate the new download bandwidth allowance


### PR DESCRIPTION
There's an interesting phenomenon happening in the downlaoder caused by the massive blocks currently in the chain:

If we request a batch of blocks, and the request times out, two things can happen:
 * The request still delivers soon-ish, the downloader will consider it out of bounds (i.e. not pending), dump it and will continue to fetch from the peer correctly.
 * However, if the sync stops and restarts in between the timeout and actual delivery, the downloader will *still* consider it out of bounds, even though there is actually a *new* request already in flight. If will hence drop the one in flight, and issue a new one. But then the one in flight arrives, which is out of bounds now since the late delivery killed it's request, so it kills the again newly created request, etc. In essence  there will be 2 concurrent fetches in flight always, each killing the previous one's request, neither ever completing.

This fix differentiates between:
 * Out of bound request: we got something but didn't wait for anything. This is a previous timeout, set the node to idle and just request again.
 * Stale request: we got something *compeltely* different than we expected. This **may** (note, not must) mean there is already a new request in flight. We will fuck up that request anyway since there's no knowing if it's a malicious node or not, but **don't** set the node to idle. If it was really a timeout it will reset when the original request comes in. If it wasn't a timeout, well, then we don't need the node feeding us junk, so it's disabled for this sync cycle.