### PR TITLE
Improve export command 

### DIFF
--- a/cmd/geth/chaincmd.go
+++ b/cmd/geth/chaincmd.go
@@ -76,16 +76,20 @@ func exportChain(ctx *cli.Context) {
 	start := time.Now()
 
 	var err error
+	fp := ctx.Args().First()
 	if len(ctx.Args()) < 3 {
-		err = utils.ExportChain(chain, ctx.Args().First())
+		err = utils.ExportChain(chain, fp)
 	} else {
 		// This can be improved to allow for numbers larger than 9223372036854775807
 		first, ferr := strconv.ParseInt(ctx.Args().Get(1), 10, 64)
 		last, lerr := strconv.ParseInt(ctx.Args().Get(2), 10, 64)
 		if ferr != nil || lerr != nil {
-			utils.Fatalf("Export error in parsing parameters\n")
+			utils.Fatalf("Export error in parsing parameters: block number not an integer\n")
 		}
-		err = utils.ExportAppendChain(chain, ctx.Args().First(), uint64(first), uint64(last))
+		if first < 0 || last < 0 {
+			utils.Fatalf("Export error: block number must be greater than 0\n")
+		}
+		err = utils.ExportAppendChain(chain, fp, uint64(first), uint64(last))
 	}
 
 	if err != nil {

--- a/cmd/geth/chaincmd.go
+++ b/cmd/geth/chaincmd.go
@@ -69,7 +69,7 @@ func importChain(ctx *cli.Context) {
 }
 
 func exportChain(ctx *cli.Context) {
-	if len(ctx.Args()) != 1 {
+	if len(ctx.Args()) < 1 {
 		utils.Fatalf("This command requires an argument.")
 	}
 	chain, _, _, _ := utils.MakeChain(ctx)

--- a/cmd/utils/cmd.go
+++ b/cmd/utils/cmd.go
@@ -268,3 +268,18 @@ func ExportChain(chainmgr *core.ChainManager, fn string) error {
 	glog.Infoln("Exported blockchain to", fn)
 	return nil
 }
+
+func ExportAppendChain(chainmgr *core.ChainManager, fn string, first uint64, last uint64) error {
+	glog.Infoln("Exporting blockchain to", fn)
+	// TODO verify mode perms
+	fh, err := os.OpenFile(fn, os.O_CREATE|os.O_APPEND|os.O_WRONLY, os.ModePerm)
+	if err != nil {
+		return err
+	}
+	defer fh.Close()
+	if err := chainmgr.ExportN(fh, first, last); err != nil {
+		return err
+	}
+	glog.Infoln("Exported blockchain to", fn)
+	return nil
+}

--- a/core/chain_manager.go
+++ b/core/chain_manager.go
@@ -341,13 +341,25 @@ func (bc *ChainManager) ResetWithGenesisBlock(gb *types.Block) {
 
 // Export writes the active chain to the given writer.
 func (self *ChainManager) Export(w io.Writer) error {
+	if err := self.ExportN(w, uint64(1), self.currentBlock.NumberU64()); err != nil {
+		return err
+	}
+	return nil
+}
+
+// ExportN writes a subset of the active chain to the given writer.
+func (self *ChainManager) ExportN(w io.Writer, first uint64, last uint64) error {
 	self.mu.RLock()
 	defer self.mu.RUnlock()
 	glog.V(logger.Info).Infof("exporting %v blocks...\n", self.currentBlock.Header().Number)
 
-	last := self.currentBlock.NumberU64()
+	if first > last {
+		return fmt.Errorf("export failed: first (%d) is greater than last (%d)", first, last)
+	}
 
-	for nr := uint64(1); nr <= last; nr++ {
+	glog.V(logger.Info).Infof("exporting %d blocks...\n", last-first)
+
+	for nr := first; nr <= last; nr++ {
 		block := self.GetBlockByNumber(nr)
 		if block == nil {
 			return fmt.Errorf("export failed on #%d: not found", nr)

--- a/core/chain_manager.go
+++ b/core/chain_manager.go
@@ -351,13 +351,12 @@ func (self *ChainManager) Export(w io.Writer) error {
 func (self *ChainManager) ExportN(w io.Writer, first uint64, last uint64) error {
 	self.mu.RLock()
 	defer self.mu.RUnlock()
-	glog.V(logger.Info).Infof("exporting %v blocks...\n", self.currentBlock.Header().Number)
 
 	if first > last {
 		return fmt.Errorf("export failed: first (%d) is greater than last (%d)", first, last)
 	}
 
-	glog.V(logger.Info).Infof("exporting %d blocks...\n", last-first)
+	glog.V(logger.Info).Infof("exporting %d blocks...\n", last-first+1)
 
 	for nr := first; nr <= last; nr++ {
 		block := self.GetBlockByNumber(nr)

--- a/core/chain_manager.go
+++ b/core/chain_manager.go
@@ -341,7 +341,7 @@ func (bc *ChainManager) ResetWithGenesisBlock(gb *types.Block) {
 
 // Export writes the active chain to the given writer.
 func (self *ChainManager) Export(w io.Writer) error {
-	if err := self.ExportN(w, uint64(1), self.currentBlock.NumberU64()); err != nil {
+	if err := self.ExportN(w, uint64(0), self.currentBlock.NumberU64()); err != nil {
 		return err
 	}
 	return nil


### PR DESCRIPTION
This PR allow the user to export a subset of the chain instead of the entire thing by specifying the start and last blocks as extra parameters. In this mode, the file is appended to rather than truncated. This is useful for partially backing up the chain over time, i.e. at each epoch:

```
geth export /tmp/path/to/file 0 29999 # exporting 30000 blocks...
geth export /tmp/path/to/file 30000 59999 # exporting 30000 blocks...
# /tmp/path/to/file will contain blocks 0-59999.
```

or analysis/debugging:

```
geth export /tmp/potential/forking/block 123456 123456 // exporting 1 blocks...
```

