### PR TITLE
core: fix nonce verification one more time

### DIFF
--- a/core/blocks.go
+++ b/core/blocks.go
@@ -7,4 +7,5 @@ var BadHashes = map[common.Hash]bool{
 	common.HexToHash("f269c503aed286caaa0d114d6a5320e70abbc2febe37953207e76a2873f2ba79"): true,
 	common.HexToHash("38f5bbbffd74804820ffa4bab0cd540e9de229725afb98c1a7e57936f4a714bc"): true,
 	common.HexToHash("7064455b364775a16afbdecd75370e912c6e2879f202eda85b9beae547fff3ac"): true,
+	common.HexToHash("5b7c80070a6eff35f3eb3181edb023465c776d40af2885571e1bc4689f3a44d8"): true,
 }

--- a/core/chain_manager.go
+++ b/core/chain_manager.go
@@ -551,12 +551,12 @@ func (self *ChainManager) InsertChain(chain types.Blocks) (int, error) {
 		bstart := time.Now()
 		// Wait for block i's nonce to be verified before processing
 		// its state transition.
-		for nonceChecked[i] {
+		for !nonceChecked[i] {
 			r := <-nonceDone
 			nonceChecked[r.i] = true
 			if !r.valid {
-				block := chain[i]
-				return i, ValidationError("Block (#%v / %x) nonce is invalid (= %x)", block.Number(), block.Hash(), block.Nonce)
+				block := chain[r.i]
+				return r.i, &BlockNonceErr{Hash: block.Hash(), Number: block.Number(), Nonce: block.Nonce()}
 			}
 		}
 

--- a/core/error.go
+++ b/core/error.go
@@ -90,6 +90,23 @@ func IsNonceErr(err error) bool {
 	return ok
 }
 
+// BlockNonceErr indicates that a block's nonce is invalid.
+type BlockNonceErr struct {
+	Number *big.Int
+	Hash   common.Hash
+	Nonce  uint64
+}
+
+func (err *BlockNonceErr) Error() string {
+	return fmt.Sprintf("block %d (%v) nonce is invalid (got %d)", err.Number, err.Hash, err.Nonce)
+}
+
+// IsBlockNonceErr returns true for invalid block nonce errors.
+func IsBlockNonceErr(err error) bool {
+	_, ok := err.(*BlockNonceErr)
+	return ok
+}
+
 type InvalidTxErr struct {
 	Message string
 }


### PR DESCRIPTION
The block nonce verification was effectively disabled by a typo (missing `!`).
This time, there is an actual test for it.

The bug was introduced in e7e2cbfc018f5e0. This commit is on the develop branch but has not appeared in any release yet. It was reviewed by two people before inclusion. This bug has lead to a fork on the Olympic test network because some people run nodes with code from the develop branch.