### PR TITLE
Fix various data races in eth and core

### DIFF
--- a/core/chain_manager.go
+++ b/core/chain_manager.go
@@ -379,8 +379,11 @@ func (self *ChainManager) ExportN(w io.Writer, first uint64, last uint64) error 
 func (bc *ChainManager) insert(block *types.Block) {
 	key := append(blockNumPre, block.Number().Bytes()...)
 	bc.blockDb.Put(key, block.Hash().Bytes())
-
 	bc.blockDb.Put([]byte("LastBlock"), block.Hash().Bytes())
+
+	bc.mu.Lock()
+	defer bc.mu.Unlock()
+
 	bc.currentBlock = block
 	bc.lastBlockHash = block.Hash()
 }

--- a/eth/handler.go
+++ b/eth/handler.go
@@ -356,7 +356,7 @@ func (pm *ProtocolManager) importBlock(p *peer, block *types.Block, td *big.Int)
 	p.blockHashes.Add(hash)
 	p.SetHead(hash)
 	if td != nil {
-		p.td = td
+		p.SetTd(td)
 	}
 	// Log the block's arrival
 	_, chainHead, _ := pm.chainman.Status()
@@ -369,7 +369,7 @@ func (pm *ProtocolManager) importBlock(p *peer, block *types.Block, td *big.Int)
 	})
 	// If the block's already known or its difficulty is lower than ours, drop
 	if pm.chainman.HasBlock(hash) {
-		p.td = pm.chainman.GetBlock(hash).Td // update the peer's TD to the real value
+		p.SetTd(pm.chainman.GetBlock(hash).Td) // update the peer's TD to the real value
 		return nil
 	}
 	if td != nil && pm.chainman.Td().Cmp(td) > 0 && new(big.Int).Add(block.Number(), big.NewInt(7)).Cmp(pm.chainman.CurrentBlock().Number()) < 0 {

--- a/eth/handler.go
+++ b/eth/handler.go
@@ -157,7 +157,7 @@ func (pm *ProtocolManager) handle(p *peer) error {
 	}
 	defer pm.removePeer(p.id)
 
-	if err := pm.downloader.RegisterPeer(p.id, p.recentHash, p.requestHashes, p.requestBlocks); err != nil {
+	if err := pm.downloader.RegisterPeer(p.id, p.Head(), p.requestHashes, p.requestBlocks); err != nil {
 		return err
 	}
 	// propagate existing transactions. new transactions appearing
@@ -303,7 +303,7 @@ func (self *ProtocolManager) handleMsg(p *peer) error {
 		// Mark the hashes as present at the remote node
 		for _, hash := range hashes {
 			p.blockHashes.Add(hash)
-			p.recentHash = hash
+			p.SetHead(hash)
 		}
 		// Schedule all the unknown hashes for retrieval
 		unknown := make([]common.Hash, 0, len(hashes))
@@ -354,7 +354,7 @@ func (pm *ProtocolManager) importBlock(p *peer, block *types.Block, td *big.Int)
 
 	// Mark the block as present at the remote node (don't duplicate already held data)
 	p.blockHashes.Add(hash)
-	p.recentHash = hash
+	p.SetHead(hash)
 	if td != nil {
 		p.td = td
 	}

--- a/eth/sync.go
+++ b/eth/sync.go
@@ -214,14 +214,15 @@ func (pm *ProtocolManager) synchronise(peer *peer) {
 	// FIXME if we have the hash in our chain and the TD of the peer is
 	// much higher than ours, something is wrong with us or the peer.
 	// Check if the hash is on our own chain
-	if pm.chainman.HasBlock(peer.recentHash) {
+	head := peer.Head()
+	if pm.chainman.HasBlock(head) {
 		glog.V(logger.Debug).Infoln("Synchronisation canceled: head already known")
 		return
 	}
 	// Get the hashes from the peer (synchronously)
-	glog.V(logger.Detail).Infof("Attempting synchronisation: %v, 0x%x", peer.id, peer.recentHash)
+	glog.V(logger.Detail).Infof("Attempting synchronisation: %v, 0x%x", peer.id, head)
 
-	err := pm.downloader.Synchronise(peer.id, peer.recentHash)
+	err := pm.downloader.Synchronise(peer.id, head)
 	switch err {
 	case nil:
 		glog.V(logger.Detail).Infof("Synchronisation completed")

--- a/eth/sync.go
+++ b/eth/sync.go
@@ -208,7 +208,7 @@ func (pm *ProtocolManager) synchronise(peer *peer) {
 		return
 	}
 	// Make sure the peer's TD is higher than our own. If not drop.
-	if peer.td.Cmp(pm.chainman.Td()) <= 0 {
+	if peer.Td().Cmp(pm.chainman.Td()) <= 0 {
 		return
 	}
 	// FIXME if we have the hash in our chain and the TD of the peer is

--- a/p2p/rlpx.go
+++ b/p2p/rlpx.go
@@ -102,6 +102,7 @@ func (t *rlpx) doProtoHandshake(our *protoHandshake) (their *protoHandshake, err
 	werr := make(chan error, 1)
 	go func() { werr <- Send(t.rw, handshakeMsg, our) }()
 	if their, err = readProtocolHandshake(t.rw, our); err != nil {
+		<-werr // make sure the write terminates too
 		return nil, err
 	}
 	if err := <-werr; err != nil {


### PR DESCRIPTION
There is one mode data race in the RLPx protocol during session closing. Don't know if @fjl already addressed it in his PR or if I should add it here.