### PR TITLE
Updated RPC sign test

### DIFF
--- a/rpc/args_test.go
+++ b/rpc/args_test.go
@@ -2519,6 +2519,14 @@ func TestSigArgs(t *testing.T) {
 	if err := json.Unmarshal([]byte(input), &args); err != nil {
 		t.Error(err)
 	}
+
+	if expected.From != args.From {
+		t.Errorf("From should be %v but is %v", expected.From, args.From)
+	}
+
+	if expected.Data != args.Data {
+		t.Errorf("Data should be %v but is %v", expected.Data, args.Data)
+	}
 }
 
 func TestSigArgsEmptyData(t *testing.T) {


### PR DESCRIPTION
Test was originally not comparing the values, only instantiating them.