### PR TITLE
p2p: fix a close race in the dial test

### DIFF
--- a/p2p/server_test.go
+++ b/p2p/server_test.go
@@ -117,7 +117,6 @@ func TestServerDial(t *testing.T) {
 			t.Error("accept error:", err)
 			return
 		}
-		conn.Close()
 		accepted <- conn
 	}()
 
@@ -134,6 +133,8 @@ func TestServerDial(t *testing.T) {
 
 	select {
 	case conn := <-accepted:
+		defer conn.Close()
+
 		select {
 		case peer := <-connected:
 			if peer.ID() != remid {


### PR DESCRIPTION
The tester connection was immediately disconnected after dialing, so in certain cases the peers was removed before the tester got around to check it's presence.

```
> godep go test -cpu=2 ./...
--- FAIL: TestServerDial-2 (0.02s)
        server_test.go:151: Peers mismatch: got [], want [Peer 639e9663239800d0 127.0.0.1:54603]
```