### PR TITLE
cmd/geth, eth/downloader: collect and report import progress too

### DIFF
--- a/cmd/geth/admin.go
+++ b/cmd/geth/admin.go
@@ -51,7 +51,7 @@ func (js *jsre) adminBindings() {
 	admin.Set("import", js.importChain)
 	admin.Set("export", js.exportChain)
 	admin.Set("verbosity", js.verbosity)
-	admin.Set("progress", js.downloadProgress)
+	admin.Set("progress", js.syncProgress)
 	admin.Set("setSolc", js.setSolc)
 
 	admin.Set("contractInfo", struct{}{})
@@ -324,9 +324,9 @@ func (js *jsre) setHead(call otto.FunctionCall) otto.Value {
 	return otto.UndefinedValue()
 }
 
-func (js *jsre) downloadProgress(call otto.FunctionCall) otto.Value {
-	pending, cached := js.ethereum.Downloader().Stats()
-	v, _ := call.Otto.ToValue(map[string]interface{}{"pending": pending, "cached": cached})
+func (js *jsre) syncProgress(call otto.FunctionCall) otto.Value {
+	pending, cached, importing := js.ethereum.Downloader().Stats()
+	v, _ := call.Otto.ToValue(map[string]interface{}{"pending": pending, "cached": cached, "importing": importing})
 	return v
 }
 

--- a/cmd/geth/admin.go
+++ b/cmd/geth/admin.go
@@ -325,8 +325,13 @@ func (js *jsre) setHead(call otto.FunctionCall) otto.Value {
 }
 
 func (js *jsre) syncProgress(call otto.FunctionCall) otto.Value {
-	pending, cached, importing := js.ethereum.Downloader().Stats()
-	v, _ := call.Otto.ToValue(map[string]interface{}{"pending": pending, "cached": cached, "importing": importing})
+	pending, cached, importing, eta := js.ethereum.Downloader().Stats()
+	v, _ := call.Otto.ToValue(map[string]interface{}{
+		"pending":   pending,
+		"cached":    cached,
+		"importing": importing,
+		"estimate":  eta.String(),
+	})
 	return v
 }
 

--- a/cmd/geth/admin.go
+++ b/cmd/geth/admin.go
@@ -330,7 +330,7 @@ func (js *jsre) syncProgress(call otto.FunctionCall) otto.Value {
 		"pending":   pending,
 		"cached":    cached,
 		"importing": importing,
-		"estimate":  eta.String(),
+		"estimate":  (eta / time.Second * time.Second).String(),
 	})
 	return v
 }


### PR DESCRIPTION
Currently it's difficult to track how the import is progressing because even though `admin.progress()` surfaces the download progress, it does not have any information about the import progress. I have no means to check how much out of those potentially 1024 blocks the importer crunched through.

This PR aims to fix that by surfacing an additional number, the still in-progress block imports. This is done by the downloader maintaining a list of recently taken blocks, and checking how many of those have not yet been imported (i.e. not found in the chain) whenever `Stats()` are requested.

So now we have something more useful to watch:

```javascript
> admin.progress()
{
  cached: 1024,
  importing: 155,
  pending: 17000
}
> admin.progress()
{
  cached: 1024,
  importing: 55,
  pending: 17000
}
I0610 01:16:02.493558   17673 chain_manager.go:686] imported 251 block(s) (0 queued 0 ignored) in 7.980843992s. #536696 [b126eea6 / 066ead6d]
> admin.progress()
{
  cached: 965,
  importing: 897,
  pending: 16035
}
I0610 01:16:10.394021   17673 chain_manager.go:686] imported 256 block(s) (0 queued 0 ignored) in 7.703510153s. #536952 [cc7d28d1 / 806269fd]
> admin.progress()
{
  cached: 1024,
  importing: 725,
  pending: 15976
}
```

There may still be some corner cases.