### PR TITLE
core/types: make consensus types immutable

### DIFF
--- a/core/bench_test.go
+++ b/core/bench_test.go
@@ -1,0 +1,149 @@
+package core
+
+import (
+	"crypto/ecdsa"
+	"io/ioutil"
+	"math/big"
+	"os"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/ethdb"
+	"github.com/ethereum/go-ethereum/event"
+	"github.com/ethereum/go-ethereum/params"
+)
+
+func BenchmarkInsertChain_empty_memdb(b *testing.B) {
+	benchInsertChain(b, false, nil)
+}
+func BenchmarkInsertChain_empty_diskdb(b *testing.B) {
+	benchInsertChain(b, true, nil)
+}
+func BenchmarkInsertChain_valueTx_memdb(b *testing.B) {
+	benchInsertChain(b, false, genValueTx(0))
+}
+func BenchmarkInsertChain_valueTx_diskdb(b *testing.B) {
+	benchInsertChain(b, true, genValueTx(0))
+}
+func BenchmarkInsertChain_valueTx_100kB_memdb(b *testing.B) {
+	benchInsertChain(b, false, genValueTx(100*1024))
+}
+func BenchmarkInsertChain_valueTx_100kB_diskdb(b *testing.B) {
+	benchInsertChain(b, true, genValueTx(100*1024))
+}
+func BenchmarkInsertChain_uncles_memdb(b *testing.B) {
+	benchInsertChain(b, false, genUncles)
+}
+func BenchmarkInsertChain_uncles_diskdb(b *testing.B) {
+	benchInsertChain(b, true, genUncles)
+}
+func BenchmarkInsertChain_ring200_memdb(b *testing.B) {
+	benchInsertChain(b, false, genTxRing(200))
+}
+func BenchmarkInsertChain_ring200_diskdb(b *testing.B) {
+	benchInsertChain(b, true, genTxRing(200))
+}
+func BenchmarkInsertChain_ring1000_memdb(b *testing.B) {
+	benchInsertChain(b, false, genTxRing(1000))
+}
+func BenchmarkInsertChain_ring1000_diskdb(b *testing.B) {
+	benchInsertChain(b, true, genTxRing(1000))
+}
+
+var (
+	// This is the content of the genesis block used by the benchmarks.
+	benchRootKey, _ = crypto.HexToECDSA("b71c71a67e1177ad4e901695e1b4b9ee17ae16c6668d313eac2f96dbcda3f291")
+	benchRootAddr   = crypto.PubkeyToAddress(benchRootKey.PublicKey)
+	benchRootFunds  = common.BigPow(2, 100)
+)
+
+// genValueTx returns a block generator that includes a single
+// value-transfer transaction with n bytes of extra data in each
+// block.
+func genValueTx(nbytes int) func(int, *BlockGen) {
+	return func(i int, gen *BlockGen) {
+		toaddr := common.Address{}
+		data := make([]byte, nbytes)
+		gas := IntrinsicGas(data)
+		tx, _ := types.NewTransaction(gen.TxNonce(benchRootAddr), toaddr, big.NewInt(1), gas, nil, data).SignECDSA(benchRootKey)
+		gen.AddTx(tx)
+	}
+}
+
+// genTxRing returns a block generator that sends ether in a ring
+// among n accounts. This is creates n entries in the state database
+// and fills the blocks with many small transactions.
+func genTxRing(naccounts int) func(int, *BlockGen) {
+	keys := make([]*ecdsa.PrivateKey, naccounts)
+	keys[0] = benchRootKey
+	for i := 1; i < naccounts; i++ {
+		keys[i], _ = crypto.GenerateKey()
+	}
+
+	from := 0
+	return func(i int, gen *BlockGen) {
+		gas := CalcGasLimit(gen.PrevBlock(i - 1))
+		for {
+			gas.Sub(gas, params.TxGas)
+			if gas.Cmp(params.TxGas) < 0 {
+				break
+			}
+			to := (from + 1) % naccounts
+			fromaddr := crypto.PubkeyToAddress(keys[from].PublicKey)
+			toaddr := crypto.PubkeyToAddress(keys[to].PublicKey)
+			tx, _ := types.NewTransaction(gen.TxNonce(fromaddr), toaddr, benchRootFunds, params.TxGas, nil, nil).SignECDSA(keys[from])
+			gen.AddTx(tx)
+			from = to
+		}
+	}
+}
+
+// genUncles generates blocks with two uncle headers.
+func genUncles(i int, gen *BlockGen) {
+	if i >= 6 {
+		b2 := gen.PrevBlock(i - 6).Header()
+		b2.Extra = []byte("foo")
+		gen.AddUncle(b2)
+		b3 := gen.PrevBlock(i - 6).Header()
+		b3.Extra = []byte("bar")
+		gen.AddUncle(b3)
+	}
+}
+
+func benchInsertChain(b *testing.B, disk bool, gen func(int, *BlockGen)) {
+	// Create the database in memory or in a temporary directory.
+	var db common.Database
+	if !disk {
+		db, _ = ethdb.NewMemDatabase()
+	} else {
+		dir, err := ioutil.TempDir("", "eth-core-bench")
+		if err != nil {
+			b.Fatalf("cannot create temporary directory: %v", err)
+		}
+		defer os.RemoveAll(dir)
+		db, err = ethdb.NewLDBDatabase(dir)
+		if err != nil {
+			b.Fatalf("cannot create temporary database: %v", err)
+		}
+		defer db.Close()
+	}
+
+	// Generate a chain of b.N blocks using the supplied block
+	// generator function.
+	genesis := GenesisBlockForTesting(db, benchRootAddr, benchRootFunds)
+	chain := GenerateChain(genesis, db, b.N, gen)
+
+	// Time the insertion of the new chain.
+	// State and blocks are stored in the same DB.
+	evmux := new(event.TypeMux)
+	chainman, _ := NewChainManager(genesis, db, db, FakePow{}, evmux)
+	chainman.SetProcessor(NewBlockProcessor(db, db, FakePow{}, chainman, evmux))
+	defer chainman.Stop()
+	b.ReportAllocs()
+	b.ResetTimer()
+	if i, err := chainman.InsertChain(chain); err != nil {
+		b.Fatalf("insert error (block %d): %v\n", i, err)
+	}
+}

--- a/core/block_cache_test.go
+++ b/core/block_cache_test.go
@@ -11,12 +11,12 @@ import (
 func newChain(size int) (chain []*types.Block) {
 	var parentHash common.Hash
 	for i := 0; i < size; i++ {
-		block := types.NewBlock(parentHash, common.Address{}, common.Hash{}, new(big.Int), 0, nil)
-		block.Header().Number = big.NewInt(int64(i))
+		head := &types.Header{ParentHash: parentHash, Number: big.NewInt(int64(i))}
+		block := types.NewBlock(head, nil, nil, nil)
 		chain = append(chain, block)
 		parentHash = block.Hash()
 	}
-	return
+	return chain
 }
 
 func insertChainCache(cache *BlockCache, chain []*types.Block) {

--- a/core/block_processor_test.go
+++ b/core/block_processor_test.go
@@ -26,20 +26,18 @@ func proc() (*BlockProcessor, *ChainManager) {
 }
 
 func TestNumber(t *testing.T) {
-	_, chain := proc()
-	block1 := chain.NewBlock(common.Address{})
-	block1.Header().Number = big.NewInt(3)
-	block1.Header().Time--
-
 	pow := ezp.New()
 
-	err := ValidateHeader(pow, block1.Header(), chain.Genesis().Header(), false)
+	bp, chain := proc()
+	header := makeHeader(chain.Genesis(), 0, bp.db, 0)
+	header.Number = big.NewInt(3)
+	err := ValidateHeader(pow, header, chain.Genesis().Header(), false)
 	if err != BlockNumberErr {
-		t.Errorf("expected block number error %v", err)
+		t.Errorf("expected block number error, got %q", err)
 	}
 
-	block1 = chain.NewBlock(common.Address{})
-	err = ValidateHeader(pow, block1.Header(), chain.Genesis().Header(), false)
+	header = makeHeader(chain.Genesis(), 0, bp.db, 0)
+	err = ValidateHeader(pow, header, chain.Genesis().Header(), false)
 	if err == BlockNumberErr {
 		t.Errorf("didn't expect block number error")
 	}

--- a/core/block_processor_test.go
+++ b/core/block_processor_test.go
@@ -27,16 +27,17 @@ func proc() (*BlockProcessor, *ChainManager) {
 
 func TestNumber(t *testing.T) {
 	pow := ezp.New()
+	_, chain := proc()
 
-	bp, chain := proc()
-	header := makeHeader(chain.Genesis(), 0, bp.db, 0)
+	statedb := state.New(chain.Genesis().Root(), chain.stateDb)
+	header := makeHeader(chain.Genesis(), statedb)
 	header.Number = big.NewInt(3)
 	err := ValidateHeader(pow, header, chain.Genesis().Header(), false)
 	if err != BlockNumberErr {
 		t.Errorf("expected block number error, got %q", err)
 	}
 
-	header = makeHeader(chain.Genesis(), 0, bp.db, 0)
+	header = makeHeader(chain.Genesis(), statedb)
 	err = ValidateHeader(pow, header, chain.Genesis().Header(), false)
 	if err == BlockNumberErr {
 		t.Errorf("didn't expect block number error")

--- a/core/block_processor_test.go
+++ b/core/block_processor_test.go
@@ -32,13 +32,13 @@ func TestNumber(t *testing.T) {
 	statedb := state.New(chain.Genesis().Root(), chain.stateDb)
 	header := makeHeader(chain.Genesis(), statedb)
 	header.Number = big.NewInt(3)
-	err := ValidateHeader(pow, header, chain.Genesis().Header(), false)
+	err := ValidateHeader(pow, header, chain.Genesis(), false)
 	if err != BlockNumberErr {
 		t.Errorf("expected block number error, got %q", err)
 	}
 
 	header = makeHeader(chain.Genesis(), statedb)
-	err = ValidateHeader(pow, header, chain.Genesis().Header(), false)
+	err = ValidateHeader(pow, header, chain.Genesis(), false)
 	if err == BlockNumberErr {
 		t.Errorf("didn't expect block number error")
 	}

--- a/core/chain_makers.go
+++ b/core/chain_makers.go
@@ -1,7 +1,6 @@
 package core
 
 import (
-	"fmt"
 	"math/big"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -11,7 +10,8 @@ import (
 	"github.com/ethereum/go-ethereum/pow"
 )
 
-// So we can generate blocks easily
+// FakePow is a non-validating proof of work implementation.
+// It returns true from Verify for any block.
 type FakePow struct{}
 
 func (f FakePow) Search(block pow.Block, stop <-chan struct{}) (uint64, []byte) {
@@ -23,69 +23,125 @@ func (f FakePow) Turbo(bool)                  {}
 
 // So we can deterministically seed different blockchains
 var (
-	CanonicalSeed = 1
-	ForkSeed      = 2
+	canonicalSeed = 1
+	forkSeed      = 2
 )
 
-// Utility functions for making chains on the fly
-// Exposed for sake of testing from other packages (eg. go-ethash)
-func MakeBlock(bman *BlockProcessor, parent *types.Block, i int, db common.Database, seed int) *types.Block {
-	return types.NewBlock(makeHeader(parent, i, db, seed), nil, nil, nil)
+// BlockGen creates blocks for testing.
+// See GenerateChain for a detailed explanation.
+type BlockGen struct {
+	i       int
+	parent  *types.Block
+	chain   []*types.Block
+	header  *types.Header
+	statedb *state.StateDB
+
+	coinbase *state.StateObject
+	txs      []*types.Transaction
+	receipts []*types.Receipt
+	uncles   []*types.Header
 }
 
-func MakeChain(bman *BlockProcessor, parent *types.Block, max int, db common.Database, seed int) types.Blocks {
-	return makeChain(bman, parent, max, db, seed)
-}
-
-func NewChainMan(block *types.Block, eventMux *event.TypeMux, db common.Database) *ChainManager {
-	return newChainManager(block, eventMux, db)
-}
-
-func NewBlockProc(db common.Database, cman *ChainManager, eventMux *event.TypeMux) *BlockProcessor {
-	return newBlockProcessor(db, cman, eventMux)
-}
-
-func NewCanonical(n int, db common.Database) (*BlockProcessor, error) {
-	return newCanonical(n, db)
-}
-
-// makeHeader creates the header for a new empty block, simulating
-// what miner would do. We seed chains by the first byte of the coinbase.
-func makeHeader(parent *types.Block, i int, db common.Database, seed int) *types.Header {
-	var addr common.Address
-	addr[0], addr[19] = byte(seed), byte(i) // 'random' coinbase
-	time := parent.Time() + 10              // block time is fixed at 10 seconds
-
-	// ensure that the block's coinbase has the block reward in the state.
-	state := state.New(parent.Root(), db)
-	cbase := state.GetOrNewStateObject(addr)
-	cbase.SetGasLimit(CalcGasLimit(parent))
-	cbase.AddBalance(BlockReward)
-	state.Update()
-
-	return &types.Header{
-		Root:       state.Root(),
-		ParentHash: parent.Hash(),
-		Coinbase:   addr,
-		Difficulty: CalcDifficulty(time, parent.Time(), parent.Difficulty()),
-		Number:     new(big.Int).Add(parent.Number(), common.Big1),
-		Time:       uint64(time),
-		GasLimit:   CalcGasLimit(parent),
-	}
-}
-
-// makeChain creates a valid chain of empty blocks.
-func makeChain(bman *BlockProcessor, parent *types.Block, max int, db common.Database, seed int) types.Blocks {
-	bman.bc.currentBlock = parent
-	blocks := make(types.Blocks, max)
-	for i := 0; i < max; i++ {
-		block := types.NewBlock(makeHeader(parent, i, db, seed), nil, nil, nil)
-		// Use ProcessWithParent to verify that we have produced a valid block.
-		_, err := bman.processWithParent(block, parent)
-		if err != nil {
-			fmt.Println("process with parent failed", err)
-			panic(err)
+// SetCoinbase sets the coinbase of the generated block.
+// It can be called at most once.
+func (b *BlockGen) SetCoinbase(addr common.Address) {
+	if b.coinbase != nil {
+		if len(b.txs) > 0 {
+			panic("coinbase must be set before adding transactions")
 		}
+		panic("coinbase can only be set once")
+	}
+	b.header.Coinbase = addr
+	b.coinbase = b.statedb.GetOrNewStateObject(addr)
+	b.coinbase.SetGasLimit(b.header.GasLimit)
+}
+
+// SetExtra sets the extra data field of the generated block.
+func (b *BlockGen) SetExtra(data []byte) {
+	b.header.Extra = data
+}
+
+// AddTx adds a transaction to the generated block. If no coinbase has
+// been set, the block's coinbase is set to the zero address.
+//
+// AddTx panics if the transaction cannot be executed. In addition to
+// the protocol-imposed limitations (gas limit, etc.), there are some
+// further limitations on the content of transactions that can be
+// added. Notably, contract code relying on the BLOCKHASH instruction
+// will panic during execution.
+func (b *BlockGen) AddTx(tx *types.Transaction) {
+	if b.coinbase == nil {
+		b.SetCoinbase(common.Address{})
+	}
+	_, gas, err := ApplyMessage(NewEnv(b.statedb, nil, tx, b.header), tx, b.coinbase)
+	if err != nil {
+		panic(err)
+	}
+	b.statedb.Update()
+	b.header.GasUsed.Add(b.header.GasUsed, gas)
+	receipt := types.NewReceipt(b.statedb.Root().Bytes(), b.header.GasUsed)
+	logs := b.statedb.GetLogs(tx.Hash())
+	receipt.SetLogs(logs)
+	receipt.Bloom = types.CreateBloom(types.Receipts{receipt})
+	b.txs = append(b.txs, tx)
+	b.receipts = append(b.receipts, receipt)
+}
+
+// TxNonce returns the next valid transaction nonce for the
+// account at addr. It panics if the account does not exist.
+func (b *BlockGen) TxNonce(addr common.Address) uint64 {
+	if !b.statedb.HasAccount(addr) {
+		panic("account does not exist")
+	}
+	return b.statedb.GetNonce(addr)
+}
+
+// AddUncle adds an uncle header to the generated block.
+func (b *BlockGen) AddUncle(h *types.Header) {
+	b.uncles = append(b.uncles, h)
+}
+
+// PrevBlock returns a previously generated block by number. It panics if
+// num is greater or equal to the number of the block being generated.
+// For index -1, PrevBlock returns the parent block given to GenerateChain.
+func (b *BlockGen) PrevBlock(index int) *types.Block {
+	if index >= b.i {
+		panic("block index out of range")
+	}
+	if index == -1 {
+		return b.parent
+	}
+	return b.chain[index]
+}
+
+// GenerateChain creates a chain of n blocks. The first block's
+// parent will be the provided parent. db is used to store
+// intermediate states and should contain the parent's state trie.
+//
+// The generator function is called with a new block generator for
+// every block. Any transactions and uncles added to the generator
+// become part of the block. If gen is nil, the blocks will be empty
+// and their coinbase will be the zero address.
+//
+// Blocks created by GenerateChain do not contain valid proof of work
+// values. Inserting them into ChainManager requires use of FakePow or
+// a similar non-validating proof of work implementation.
+func GenerateChain(parent *types.Block, db common.Database, n int, gen func(int, *BlockGen)) []*types.Block {
+	statedb := state.New(parent.Root(), db)
+	blocks := make(types.Blocks, n)
+	genblock := func(i int, h *types.Header) *types.Block {
+		b := &BlockGen{parent: parent, i: i, chain: blocks, header: h, statedb: statedb}
+		if gen != nil {
+			gen(i, b)
+		}
+		AccumulateRewards(statedb, h, b.uncles)
+		statedb.Update()
+		h.Root = statedb.Root()
+		return types.NewBlock(h, b.txs, b.uncles, b.receipts)
+	}
+	for i := 0; i < n; i++ {
+		header := makeHeader(parent, statedb)
+		block := genblock(i, header)
 		block.Td = CalcTD(block, parent)
 		blocks[i] = block
 		parent = block
@@ -93,41 +149,38 @@ func makeChain(bman *BlockProcessor, parent *types.Block, max int, db common.Dat
 	return blocks
 }
 
-// Create a new chain manager starting from given block
-// Effectively a fork factory
-func newChainManager(block *types.Block, eventMux *event.TypeMux, db common.Database) *ChainManager {
-	genesis := GenesisBlock(0, db)
-	bc := &ChainManager{blockDb: db, stateDb: db, genesisBlock: genesis, eventMux: eventMux, pow: FakePow{}}
-	bc.txState = state.ManageState(state.New(genesis.Root(), db))
-	bc.futureBlocks = NewBlockCache(1000)
-	if block == nil {
-		bc.Reset()
-	} else {
-		bc.currentBlock = block
-		bc.td = block.Td
+func makeHeader(parent *types.Block, state *state.StateDB) *types.Header {
+	time := parent.Time() + 10 // block time is fixed at 10 seconds
+	return &types.Header{
+		Root:       state.Root(),
+		ParentHash: parent.Hash(),
+		Coinbase:   parent.Coinbase(),
+		Difficulty: CalcDifficulty(time, parent.Time(), parent.Difficulty()),
+		GasLimit:   CalcGasLimit(parent),
+		GasUsed:    new(big.Int),
+		Number:     new(big.Int).Add(parent.Number(), common.Big1),
+		Time:       uint64(time),
 	}
-	return bc
 }
 
-// block processor with fake pow
-func newBlockProcessor(db common.Database, cman *ChainManager, eventMux *event.TypeMux) *BlockProcessor {
-	chainMan := newChainManager(nil, eventMux, db)
-	bman := NewBlockProcessor(db, db, FakePow{}, chainMan, eventMux)
-	return bman
-}
-
-// Make a new, deterministic canonical chain by running InsertChain
-// on result of makeChain.
+// newCanonical creates a new deterministic canonical chain by running
+// InsertChain on the result of makeChain.
 func newCanonical(n int, db common.Database) (*BlockProcessor, error) {
-	eventMux := &event.TypeMux{}
-
-	bman := newBlockProcessor(db, newChainManager(nil, eventMux, db), eventMux)
+	evmux := &event.TypeMux{}
+	chainman, _ := NewChainManager(GenesisBlock(0, db), db, db, FakePow{}, evmux)
+	bman := NewBlockProcessor(db, db, FakePow{}, chainman, evmux)
 	bman.bc.SetProcessor(bman)
 	parent := bman.bc.CurrentBlock()
 	if n == 0 {
 		return bman, nil
 	}
-	lchain := makeChain(bman, parent, n, db, CanonicalSeed)
+	lchain := makeChain(parent, n, db, canonicalSeed)
 	_, err := bman.bc.InsertChain(lchain)
 	return bman, err
+}
+
+func makeChain(parent *types.Block, n int, db common.Database, seed int) []*types.Block {
+	return GenerateChain(parent, db, n, func(i int, b *BlockGen) {
+		b.SetCoinbase(common.Address{0: byte(seed), 19: byte(i)})
+	})
 }

--- a/core/chain_makers_test.go
+++ b/core/chain_makers_test.go
@@ -1,0 +1,78 @@
+package core
+
+import (
+	"fmt"
+	"math/big"
+
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/ethdb"
+	"github.com/ethereum/go-ethereum/event"
+	"github.com/ethereum/go-ethereum/params"
+)
+
+func ExampleGenerateChain() {
+	var (
+		key1, _ = crypto.HexToECDSA("b71c71a67e1177ad4e901695e1b4b9ee17ae16c6668d313eac2f96dbcda3f291")
+		key2, _ = crypto.HexToECDSA("8a1f9a8f95be41cd7ccb6168179afb4504aefe388d1e14474d32c45c72ce7b7a")
+		key3, _ = crypto.HexToECDSA("49a7b37aa6f6645917e7b807e9d1c00d4fa71f18343b0d4122a4d2df64dd6fee")
+		addr1   = crypto.PubkeyToAddress(key1.PublicKey)
+		addr2   = crypto.PubkeyToAddress(key2.PublicKey)
+		addr3   = crypto.PubkeyToAddress(key3.PublicKey)
+		db, _   = ethdb.NewMemDatabase()
+	)
+
+	// Ensure that key1 has some funds in the genesis block.
+	genesis := GenesisBlockForTesting(db, addr1, big.NewInt(1000000))
+
+	// This call generates a chain of 5 blocks. The function runs for
+	// each block and adds different features to gen based on the
+	// block index.
+	chain := GenerateChain(genesis, db, 5, func(i int, gen *BlockGen) {
+		switch i {
+		case 0:
+			// In block 1, addr1 sends addr2 some ether.
+			tx, _ := types.NewTransaction(gen.TxNonce(addr1), addr2, big.NewInt(10000), params.TxGas, nil, nil).SignECDSA(key1)
+			gen.AddTx(tx)
+		case 1:
+			// In block 2, addr1 sends some more ether to addr2.
+			// addr2 passes it on to addr3.
+			tx1, _ := types.NewTransaction(gen.TxNonce(addr1), addr2, big.NewInt(1000), params.TxGas, nil, nil).SignECDSA(key1)
+			tx2, _ := types.NewTransaction(gen.TxNonce(addr2), addr3, big.NewInt(1000), params.TxGas, nil, nil).SignECDSA(key2)
+			gen.AddTx(tx1)
+			gen.AddTx(tx2)
+		case 2:
+			// Block 3 is empty but was mined by addr3.
+			gen.SetCoinbase(addr3)
+			gen.SetExtra([]byte("yeehaw"))
+		case 3:
+			// Block 4 includes blocks 2 and 3 as uncle headers (with modified extra data).
+			b2 := gen.PrevBlock(1).Header()
+			b2.Extra = []byte("foo")
+			gen.AddUncle(b2)
+			b3 := gen.PrevBlock(2).Header()
+			b3.Extra = []byte("foo")
+			gen.AddUncle(b3)
+		}
+	})
+
+	// Import the chain. This runs all block validation rules.
+	evmux := &event.TypeMux{}
+	chainman, _ := NewChainManager(genesis, db, db, FakePow{}, evmux)
+	chainman.SetProcessor(NewBlockProcessor(db, db, FakePow{}, chainman, evmux))
+	if i, err := chainman.InsertChain(chain); err != nil {
+		fmt.Printf("insert error (block %d): %v\n", i, err)
+		return
+	}
+
+	state := chainman.State()
+	fmt.Printf("last block: #%d\n", chainman.CurrentBlock().Number())
+	fmt.Println("balance of addr1:", state.GetBalance(addr1))
+	fmt.Println("balance of addr2:", state.GetBalance(addr2))
+	fmt.Println("balance of addr3:", state.GetBalance(addr3))
+	// Output:
+	// last block: #5
+	// balance of addr1: 989000
+	// balance of addr2: 10000
+	// balance of addr3: 5906250000000001000
+}

--- a/core/chain_manager.go
+++ b/core/chain_manager.go
@@ -60,7 +60,9 @@ func CalcTD(block, parent *types.Block) *big.Int {
 	if parent == nil {
 		return block.Difficulty()
 	}
-	return new(big.Int).Add(parent.Td, block.Header().Difficulty)
+	d := block.Difficulty()
+	d.Add(d, parent.Td)
+	return d
 }
 
 // CalcGasLimit computes the gas limit of the next block after parent.
@@ -463,26 +465,6 @@ func (self *ChainManager) GetUnclesInChain(block *types.Block, length int) (uncl
 // assumes that the `mu` mutex is held!
 func (bc *ChainManager) setTotalDifficulty(td *big.Int) {
 	bc.td = new(big.Int).Set(td)
-}
-
-func (self *ChainManager) CalcTotalDiff(block *types.Block) (*big.Int, error) {
-	parent := self.GetBlock(block.Header().ParentHash)
-	if parent == nil {
-		return nil, fmt.Errorf("Unable to calculate total diff without known parent %x", block.Header().ParentHash)
-	}
-
-	parentTd := parent.Td
-
-	uncleDiff := new(big.Int)
-	for _, uncle := range block.Uncles() {
-		uncleDiff = uncleDiff.Add(uncleDiff, uncle.Difficulty)
-	}
-
-	td := new(big.Int)
-	td = td.Add(parentTd, uncleDiff)
-	td = td.Add(td, block.Header().Difficulty)
-
-	return td, nil
 }
 
 func (bc *ChainManager) Stop() {

--- a/core/chain_manager.go
+++ b/core/chain_manager.go
@@ -164,7 +164,7 @@ func (bc *ChainManager) SetHead(head *types.Block) {
 	bc.mu.Lock()
 	defer bc.mu.Unlock()
 
-	for block := bc.currentBlock; block != nil && block.Hash() != head.Hash(); block = bc.GetBlock(block.Header().ParentHash) {
+	for block := bc.currentBlock; block != nil && block.Hash() != head.Hash(); block = bc.GetBlock(block.ParentHash()) {
 		bc.removeBlock(block)
 	}
 
@@ -269,7 +269,7 @@ func (bc *ChainManager) Reset() {
 	bc.mu.Lock()
 	defer bc.mu.Unlock()
 
-	for block := bc.currentBlock; block != nil; block = bc.GetBlock(block.Header().ParentHash) {
+	for block := bc.currentBlock; block != nil; block = bc.GetBlock(block.ParentHash()) {
 		bc.removeBlock(block)
 	}
 
@@ -294,7 +294,7 @@ func (bc *ChainManager) ResetWithGenesisBlock(gb *types.Block) {
 	bc.mu.Lock()
 	defer bc.mu.Unlock()
 
-	for block := bc.currentBlock; block != nil; block = bc.GetBlock(block.Header().ParentHash) {
+	for block := bc.currentBlock; block != nil; block = bc.GetBlock(block.ParentHash()) {
 		bc.removeBlock(block)
 	}
 

--- a/core/chain_manager_test.go
+++ b/core/chain_manager_test.go
@@ -67,7 +67,7 @@ func testFork(t *testing.T, bman *BlockProcessor, i, N int, f func(td1, td2 *big
 
 	// extend the fork
 	parent := bman2.bc.CurrentBlock()
-	chainB := makeChain(bman2, parent, N, db, ForkSeed)
+	chainB := makeChain(parent, N, db, forkSeed)
 	_, err = bman2.bc.InsertChain(chainB)
 	if err != nil {
 		t.Fatal("Insert chain error for fork:", err)
@@ -256,7 +256,7 @@ func TestBrokenChain(t *testing.T) {
 	}
 	bman2.bc.SetProcessor(bman2)
 	parent := bman2.bc.CurrentBlock()
-	chainB := makeChain(bman2, parent, 5, db2, ForkSeed)
+	chainB := makeChain(parent, 5, db2, forkSeed)
 	chainB = chainB[1:]
 	_, err = testChain(chainB, bman)
 	if err == nil {
@@ -444,7 +444,7 @@ func TestInsertNonceError(t *testing.T) {
 		genesis := GenesisBlock(0, db)
 		bc := chm(genesis, db)
 		bc.processor = NewBlockProcessor(db, db, bc.pow, bc, bc.eventMux)
-		blocks := makeChain(bc.processor.(*BlockProcessor), bc.currentBlock, i, db, 0)
+		blocks := makeChain(bc.currentBlock, i, db, 0)
 
 		fail := rand.Int() % len(blocks)
 		failblock := blocks[fail]

--- a/core/genesis.go
+++ b/core/genesis.go
@@ -3,6 +3,7 @@ package core
 import (
 	"encoding/json"
 	"fmt"
+	"math/big"
 	"os"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -56,3 +57,20 @@ var GenesisAccounts = []byte(`{
 	"e6716f9544a56c530d868e4bfbacb172315bdead": {"balance": "1606938044258990275541962092341162602522202993782792835301376"},
 	"1a26338f0d905e295fccb71fa9ea849ffa12aaf4": {"balance": "1606938044258990275541962092341162602522202993782792835301376"}
 }`)
+
+// GenesisBlockForTesting creates a block in which addr has the given wei balance.
+// The state trie of the block is written to db.
+func GenesisBlockForTesting(db common.Database, addr common.Address, balance *big.Int) *types.Block {
+	statedb := state.New(common.Hash{}, db)
+	obj := statedb.GetOrNewStateObject(addr)
+	obj.SetBalance(balance)
+	statedb.Update()
+	statedb.Sync()
+	block := types.NewBlock(&types.Header{
+		Difficulty: params.GenesisDifficulty,
+		GasLimit:   params.GenesisGasLimit,
+		Root:       statedb.Root(),
+	}, nil, nil, nil)
+	block.Td = params.GenesisDifficulty
+	return block
+}

--- a/core/state_transition.go
+++ b/core/state_transition.go
@@ -73,16 +73,17 @@ func MessageGasValue(msg Message) *big.Int {
 	return new(big.Int).Mul(msg.Gas(), msg.GasPrice())
 }
 
-func IntrinsicGas(msg Message) *big.Int {
+// IntrinsicGas computes the 'intrisic gas' for a message
+// with the given data.
+func IntrinsicGas(data []byte) *big.Int {
 	igas := new(big.Int).Set(params.TxGas)
-	for _, byt := range msg.Data() {
+	for _, byt := range data {
 		if byt != 0 {
 			igas.Add(igas, params.TxDataNonZeroGas)
 		} else {
 			igas.Add(igas, params.TxDataZeroGas)
 		}
 	}
-
 	return igas
 }
 
@@ -195,7 +196,7 @@ func (self *StateTransition) transitionState() (ret []byte, usedGas *big.Int, er
 	sender, _ := self.From() // err checked in preCheck
 
 	// Pay intrinsic gas
-	if err = self.UseGas(IntrinsicGas(self.msg)); err != nil {
+	if err = self.UseGas(IntrinsicGas(self.msg.Data())); err != nil {
 		return nil, nil, InvalidTxError(err)
 	}
 

--- a/core/state_transition.go
+++ b/core/state_transition.go
@@ -203,14 +203,14 @@ func (self *StateTransition) transitionState() (ret []byte, usedGas *big.Int, er
 	sender, _ := self.From() // err checked in preCheck
 
 	// Pay intrinsic gas
-	if err = self.UseGas(IntrinsicGas(self.msg.Data())); err != nil {
+	if err = self.UseGas(IntrinsicGas(self.data)); err != nil {
 		return nil, nil, InvalidTxError(err)
 	}
 
 	vmenv := self.env
 	var ref vm.ContextRef
 	if MessageCreatesContract(msg) {
-		ret, err, ref = vmenv.Create(sender, self.msg.Data(), self.gas, self.gasPrice, self.value)
+		ret, err, ref = vmenv.Create(sender, self.data, self.gas, self.gasPrice, self.value)
 		if err == nil {
 			dataGas := big.NewInt(int64(len(ret)))
 			dataGas.Mul(dataGas, params.CreateDataGas)
@@ -224,7 +224,7 @@ func (self *StateTransition) transitionState() (ret []byte, usedGas *big.Int, er
 	} else {
 		// Increment the nonce for the next transaction
 		self.state.SetNonce(sender.Address(), sender.Nonce()+1)
-		ret, err = vmenv.Call(sender, self.To().Address(), self.msg.Data(), self.gas, self.gasPrice, self.value)
+		ret, err = vmenv.Call(sender, self.To().Address(), self.data, self.gas, self.gasPrice, self.value)
 	}
 
 	if err != nil && IsValueTransferErr(err) {

--- a/core/state_transition.go
+++ b/core/state_transition.go
@@ -77,12 +77,19 @@ func MessageGasValue(msg Message) *big.Int {
 // with the given data.
 func IntrinsicGas(data []byte) *big.Int {
 	igas := new(big.Int).Set(params.TxGas)
-	for _, byt := range data {
-		if byt != 0 {
-			igas.Add(igas, params.TxDataNonZeroGas)
-		} else {
-			igas.Add(igas, params.TxDataZeroGas)
+	if len(data) > 0 {
+		var nz int64
+		for _, byt := range data {
+			if byt != 0 {
+				nz++
+			}
 		}
+		m := big.NewInt(nz)
+		m.Mul(m, params.TxDataNonZeroGas)
+		igas.Add(igas, m)
+		m.SetInt64(int64(len(data)) - nz)
+		m.Mul(m, params.TxDataZeroGas)
+		igas.Add(igas, m)
 	}
 	return igas
 }

--- a/core/transaction_pool.go
+++ b/core/transaction_pool.go
@@ -180,7 +180,7 @@ func (pool *TxPool) validateTx(tx *types.Transaction) error {
 	}
 
 	// Should supply enough intrinsic gas
-	if tx.Gas().Cmp(IntrinsicGas(tx)) < 0 {
+	if tx.Gas().Cmp(IntrinsicGas(tx.Data())) < 0 {
 		return ErrIntrinsicGas
 	}
 

--- a/core/transaction_pool_test.go
+++ b/core/transaction_pool_test.go
@@ -13,8 +13,9 @@ import (
 	"github.com/ethereum/go-ethereum/event"
 )
 
-func transaction() *types.Transaction {
-	return types.NewTransactionMessage(common.Address{}, big.NewInt(100), big.NewInt(100), big.NewInt(100), nil)
+func transaction(nonce uint64, gaslimit *big.Int, key *ecdsa.PrivateKey) *types.Transaction {
+	tx, _ := types.NewTransaction(nonce, common.Address{}, big.NewInt(100), gaslimit, big.NewInt(1), nil).SignECDSA(key)
+	return tx
 }
 
 func setupTxPool() (*TxPool, *ecdsa.PrivateKey) {
@@ -29,43 +30,34 @@ func setupTxPool() (*TxPool, *ecdsa.PrivateKey) {
 func TestInvalidTransactions(t *testing.T) {
 	pool, key := setupTxPool()
 
-	tx := transaction()
-	tx.SignECDSA(key)
-	err := pool.Add(tx)
-	if err != ErrNonExistentAccount {
+	tx := transaction(0, big.NewInt(100), key)
+	if err := pool.Add(tx); err != ErrNonExistentAccount {
 		t.Error("expected", ErrNonExistentAccount)
 	}
 
 	from, _ := tx.From()
 	pool.currentState().AddBalance(from, big.NewInt(1))
-	err = pool.Add(tx)
-	if err != ErrInsufficientFunds {
+	if err := pool.Add(tx); err != ErrInsufficientFunds {
 		t.Error("expected", ErrInsufficientFunds)
 	}
 
 	balance := new(big.Int).Add(tx.Value(), new(big.Int).Mul(tx.Gas(), tx.GasPrice()))
 	pool.currentState().AddBalance(from, balance)
-	err = pool.Add(tx)
-	if err != ErrIntrinsicGas {
+	if err := pool.Add(tx); err != ErrIntrinsicGas {
 		t.Error("expected", ErrIntrinsicGas, "got", err)
 	}
 
 	pool.currentState().SetNonce(from, 1)
 	pool.currentState().AddBalance(from, big.NewInt(0xffffffffffffff))
-	tx.GasLimit = big.NewInt(100000)
-	tx.Price = big.NewInt(1)
-	tx.SignECDSA(key)
-
-	err = pool.Add(tx)
-	if err != ErrNonce {
+	tx = transaction(0, big.NewInt(100000), key)
+	if err := pool.Add(tx); err != ErrNonce {
 		t.Error("expected", ErrNonce)
 	}
 }
 
 func TestTransactionQueue(t *testing.T) {
 	pool, key := setupTxPool()
-	tx := transaction()
-	tx.SignECDSA(key)
+	tx := transaction(0, big.NewInt(100), key)
 	from, _ := tx.From()
 	pool.currentState().AddBalance(from, big.NewInt(1))
 	pool.queueTx(tx.Hash(), tx)
@@ -75,9 +67,7 @@ func TestTransactionQueue(t *testing.T) {
 		t.Error("expected valid txs to be 1 is", len(pool.pending))
 	}
 
-	tx = transaction()
-	tx.SetNonce(1)
-	tx.SignECDSA(key)
+	tx = transaction(1, big.NewInt(100), key)
 	from, _ = tx.From()
 	pool.currentState().SetNonce(from, 2)
 	pool.queueTx(tx.Hash(), tx)
@@ -91,12 +81,9 @@ func TestTransactionQueue(t *testing.T) {
 	}
 
 	pool, key = setupTxPool()
-	tx1, tx2, tx3 := transaction(), transaction(), transaction()
-	tx2.SetNonce(10)
-	tx3.SetNonce(11)
-	tx1.SignECDSA(key)
-	tx2.SignECDSA(key)
-	tx3.SignECDSA(key)
+	tx1 := transaction(0, big.NewInt(100), key)
+	tx2 := transaction(10, big.NewInt(100), key)
+	tx3 := transaction(11, big.NewInt(100), key)
 	pool.queueTx(tx1.Hash(), tx1)
 	pool.queueTx(tx2.Hash(), tx2)
 	pool.queueTx(tx3.Hash(), tx3)
@@ -114,8 +101,7 @@ func TestTransactionQueue(t *testing.T) {
 
 func TestRemoveTx(t *testing.T) {
 	pool, key := setupTxPool()
-	tx := transaction()
-	tx.SignECDSA(key)
+	tx := transaction(0, big.NewInt(100), key)
 	from, _ := tx.From()
 	pool.currentState().AddBalance(from, big.NewInt(1))
 	pool.queueTx(tx.Hash(), tx)
@@ -142,13 +128,10 @@ func TestRemoveTx(t *testing.T) {
 func TestNegativeValue(t *testing.T) {
 	pool, key := setupTxPool()
 
-	tx := transaction()
-	tx.Value().Set(big.NewInt(-1))
-	tx.SignECDSA(key)
+	tx, _ := types.NewTransaction(0, common.Address{}, big.NewInt(-1), big.NewInt(100), big.NewInt(1), nil).SignECDSA(key)
 	from, _ := tx.From()
 	pool.currentState().AddBalance(from, big.NewInt(1))
-	err := pool.Add(tx)
-	if err != ErrNegativeValue {
+	if err := pool.Add(tx); err != ErrNegativeValue {
 		t.Error("expected", ErrNegativeValue, "got", err)
 	}
 }
@@ -165,20 +148,15 @@ func TestTransactionChainFork(t *testing.T) {
 	}
 	resetState()
 
-	tx := transaction()
-	tx.GasLimit = big.NewInt(100000)
-	tx.SignECDSA(key)
-
-	err := pool.add(tx)
-	if err != nil {
+	tx := transaction(0, big.NewInt(100000), key)
+	if err := pool.add(tx); err != nil {
 		t.Error("didn't expect error", err)
 	}
 	pool.RemoveTransactions([]*types.Transaction{tx})
 
 	// reset the pool's internal state
 	resetState()
-	err = pool.add(tx)
-	if err != nil {
+	if err := pool.add(tx); err != nil {
 		t.Error("didn't expect error", err)
 	}
 }
@@ -195,24 +173,14 @@ func TestTransactionDoubleNonce(t *testing.T) {
 	}
 	resetState()
 
-	tx := transaction()
-	tx.GasLimit = big.NewInt(100000)
-	tx.SignECDSA(key)
-
-	err := pool.add(tx)
-	if err != nil {
+	tx := transaction(0, big.NewInt(100000), key)
+	tx2 := transaction(0, big.NewInt(1000000), key)
+	if err := pool.add(tx); err != nil {
 		t.Error("didn't expect error", err)
 	}
-
-	tx2 := transaction()
-	tx2.GasLimit = big.NewInt(1000000)
-	tx2.SignECDSA(key)
-
-	err = pool.add(tx2)
-	if err != nil {
+	if err := pool.add(tx2); err != nil {
 		t.Error("didn't expect error", err)
 	}
-
 	if len(pool.pending) != 2 {
 		t.Error("expected 2 pending txs. Got", len(pool.pending))
 	}
@@ -222,20 +190,13 @@ func TestMissingNonce(t *testing.T) {
 	pool, key := setupTxPool()
 	addr := crypto.PubkeyToAddress(key.PublicKey)
 	pool.currentState().AddBalance(addr, big.NewInt(100000000000000))
-	tx := transaction()
-	tx.AccountNonce = 1
-	tx.GasLimit = big.NewInt(100000)
-	tx.SignECDSA(key)
-
-	err := pool.add(tx)
-	if err != nil {
+	tx := transaction(1, big.NewInt(100000), key)
+	if err := pool.add(tx); err != nil {
 		t.Error("didn't expect error", err)
 	}
-
 	if len(pool.pending) != 0 {
 		t.Error("expected 0 pending transactions, got", len(pool.pending))
 	}
-
 	if len(pool.queue[addr]) != 1 {
 		t.Error("expected 1 queued transaction, got", len(pool.queue[addr]))
 	}

--- a/core/types/block.go
+++ b/core/types/block.go
@@ -15,71 +15,59 @@ import (
 	"github.com/ethereum/go-ethereum/rlp"
 )
 
+// A BlockNonce is a 64-bit hash which proves (combined with the
+// mix-hash) that a suffcient amount of computation has been carried
+// out on a block.
+type BlockNonce [8]byte
+
+func EncodeNonce(i uint64) BlockNonce {
+	var n BlockNonce
+	binary.BigEndian.PutUint64(n[:], i)
+	return n
+}
+
+func (n BlockNonce) Uint64() uint64 {
+	return binary.BigEndian.Uint64(n[:])
+}
+
 type Header struct {
-	// Hash to the previous block
-	ParentHash common.Hash
-	// Uncles of this block
-	UncleHash common.Hash
-	// The coin base address
-	Coinbase common.Address
-	// Block Trie state
-	Root common.Hash
-	// Tx sha
-	TxHash common.Hash
-	// Receipt sha
-	ReceiptHash common.Hash
-	// Bloom
-	Bloom Bloom
-	// Difficulty for the current block
-	Difficulty *big.Int
-	// The block number
-	Number *big.Int
-	// Gas limit
-	GasLimit *big.Int
-	// Gas used
-	GasUsed *big.Int
-	// Creation time
-	Time uint64
-	// Extra data
-	Extra []byte
-	// Mix digest for quick checking to prevent DOS
-	MixDigest common.Hash
-	// Nonce
-	Nonce [8]byte
+	ParentHash  common.Hash    // Hash to the previous block
+	UncleHash   common.Hash    // Uncles of this block
+	Coinbase    common.Address // The coin base address
+	Root        common.Hash    // Block Trie state
+	TxHash      common.Hash    // Tx sha
+	ReceiptHash common.Hash    // Receipt sha
+	Bloom       Bloom          // Bloom
+	Difficulty  *big.Int       // Difficulty for the current block
+	Number      *big.Int       // The block number
+	GasLimit    *big.Int       // Gas limit
+	GasUsed     *big.Int       // Gas used
+	Time        uint64         // Creation time
+	Extra       []byte         // Extra data
+	MixDigest   common.Hash    // for quick difficulty verification
+	Nonce       BlockNonce
 }
 
-func (self *Header) Hash() common.Hash {
-	return rlpHash(self.rlpData(true))
+func (h *Header) Hash() common.Hash {
+	return rlpHash(h)
 }
 
-func (self *Header) HashNoNonce() common.Hash {
-	return rlpHash(self.rlpData(false))
-}
-
-func (self *Header) rlpData(withNonce bool) []interface{} {
-	fields := []interface{}{
-		self.ParentHash,
-		self.UncleHash,
-		self.Coinbase,
-		self.Root,
-		self.TxHash,
-		self.ReceiptHash,
-		self.Bloom,
-		self.Difficulty,
-		self.Number,
-		self.GasLimit,
-		self.GasUsed,
-		self.Time,
-		self.Extra,
-	}
-	if withNonce {
-		fields = append(fields, self.MixDigest, self.Nonce)
-	}
-	return fields
-}
-
-func (self *Header) RlpData() interface{} {
-	return self.rlpData(true)
+func (h *Header) HashNoNonce() common.Hash {
+	return rlpHash([]interface{}{
+		h.ParentHash,
+		h.UncleHash,
+		h.Coinbase,
+		h.Root,
+		h.TxHash,
+		h.ReceiptHash,
+		h.Bloom,
+		h.Difficulty,
+		h.Number,
+		h.GasLimit,
+		h.GasUsed,
+		h.Time,
+		h.Extra,
+	})
 }
 
 func (h *Header) UnmarshalJSON(data []byte) error {
@@ -112,20 +100,14 @@ func rlpHash(x interface{}) (h common.Hash) {
 }
 
 type Block struct {
-	// Preset Hash for mock (Tests)
-	HeaderHash       common.Hash
-	ParentHeaderHash common.Hash
-	// ^^^^ ignore ^^^^
-
 	header       *Header
 	uncles       []*Header
 	transactions Transactions
-	Td           *big.Int
-	queued       bool // flag for blockpool to skip TD check
+	receipts     Receipts
 
+	Td         *big.Int
+	queued     bool // flag for blockpool to skip TD check
 	ReceivedAt time.Time
-
-	receipts Receipts
 }
 
 // StorageBlock defines the RLP encoding of a Block stored in the
@@ -148,43 +130,90 @@ type storageblock struct {
 	TD     *big.Int
 }
 
-func NewBlock(parentHash common.Hash, coinbase common.Address, root common.Hash, difficulty *big.Int, nonce uint64, extra []byte) *Block {
-	header := &Header{
-		Root:       root,
-		ParentHash: parentHash,
-		Coinbase:   coinbase,
-		Difficulty: difficulty,
-		Time:       uint64(time.Now().Unix()),
-		Extra:      extra,
-		GasUsed:    new(big.Int),
-		GasLimit:   new(big.Int),
-		Number:     new(big.Int),
+var (
+	emptyRootHash  = DeriveSha(Transactions{})
+	emptyUncleHash = CalcUncleHash(nil)
+)
+
+// NewBlock creates a new block. The input data is copied,
+// changes to header and to the field values will not affect the
+// block.
+//
+// The values of TxHash, UncleHash, ReceiptHash and Bloom in header
+// are ignored and set to values derived from the given txs, uncles
+// and receipts.
+func NewBlock(header *Header, txs []*Transaction, uncles []*Header, receipts []*Receipt) *Block {
+	b := &Block{header: copyHeader(header), Td: new(big.Int)}
+
+	// TODO: panic if len(txs) != len(receipts)
+	if len(txs) == 0 {
+		b.header.TxHash = emptyRootHash
+	} else {
+		b.header.TxHash = DeriveSha(Transactions(txs))
+		b.transactions = make(Transactions, len(txs))
+		copy(b.transactions, txs)
 	}
-	header.SetNonce(nonce)
-	block := &Block{header: header}
-	block.Td = new(big.Int)
 
-	return block
+	if len(receipts) == 0 {
+		b.header.ReceiptHash = emptyRootHash
+	} else {
+		b.header.ReceiptHash = DeriveSha(Receipts(receipts))
+		b.header.Bloom = CreateBloom(receipts)
+		b.receipts = make([]*Receipt, len(receipts))
+		copy(b.receipts, receipts)
+	}
+
+	if len(uncles) == 0 {
+		b.header.UncleHash = emptyUncleHash
+	} else {
+		b.header.UncleHash = CalcUncleHash(uncles)
+		b.uncles = make([]*Header, len(uncles))
+		for i := range uncles {
+			b.uncles[i] = copyHeader(uncles[i])
+		}
+	}
+
+	return b
 }
 
-func (self *Header) SetNonce(nonce uint64) {
-	binary.BigEndian.PutUint64(self.Nonce[:], nonce)
-}
-
+// NewBlockWithHeader creates a block with the given header data. The
+// header data is copied, changes to header and to the field values
+// will not affect the block.
 func NewBlockWithHeader(header *Header) *Block {
-	return &Block{header: header}
+	return &Block{header: copyHeader(header)}
 }
 
-func (self *Block) ValidateFields() error {
-	if self.header == nil {
+func copyHeader(h *Header) *Header {
+	cpy := *h
+	if cpy.Difficulty = new(big.Int); h.Difficulty != nil {
+		cpy.Difficulty.Set(h.Difficulty)
+	}
+	if cpy.Number = new(big.Int); h.Number != nil {
+		cpy.Number.Set(h.Number)
+	}
+	if cpy.GasLimit = new(big.Int); h.GasLimit != nil {
+		cpy.GasLimit.Set(h.GasLimit)
+	}
+	if cpy.GasUsed = new(big.Int); h.GasUsed != nil {
+		cpy.GasUsed.Set(h.GasUsed)
+	}
+	if len(h.Extra) > 0 {
+		cpy.Extra = make([]byte, len(h.Extra))
+		copy(cpy.Extra, h.Extra)
+	}
+	return &cpy
+}
+
+func (b *Block) ValidateFields() error {
+	if b.header == nil {
 		return fmt.Errorf("header is nil")
 	}
-	for i, transaction := range self.transactions {
+	for i, transaction := range b.transactions {
 		if transaction == nil {
 			return fmt.Errorf("transaction %d is nil", i)
 		}
 	}
-	for i, uncle := range self.uncles {
+	for i, uncle := range b.uncles {
 		if uncle == nil {
 			return fmt.Errorf("uncle %d is nil", i)
 		}
@@ -192,64 +221,48 @@ func (self *Block) ValidateFields() error {
 	return nil
 }
 
-func (self *Block) DecodeRLP(s *rlp.Stream) error {
+func (b *Block) DecodeRLP(s *rlp.Stream) error {
 	var eb extblock
 	if err := s.Decode(&eb); err != nil {
 		return err
 	}
-	self.header, self.uncles, self.transactions = eb.Header, eb.Uncles, eb.Txs
+	b.header, b.uncles, b.transactions = eb.Header, eb.Uncles, eb.Txs
 	return nil
 }
 
-func (self Block) EncodeRLP(w io.Writer) error {
+func (b Block) EncodeRLP(w io.Writer) error {
 	return rlp.Encode(w, extblock{
-		Header: self.header,
-		Txs:    self.transactions,
-		Uncles: self.uncles,
+		Header: b.header,
+		Txs:    b.transactions,
+		Uncles: b.uncles,
 	})
 }
 
-func (self *StorageBlock) DecodeRLP(s *rlp.Stream) error {
+func (b *StorageBlock) DecodeRLP(s *rlp.Stream) error {
 	var sb storageblock
 	if err := s.Decode(&sb); err != nil {
 		return err
 	}
-	self.header, self.uncles, self.transactions, self.Td = sb.Header, sb.Uncles, sb.Txs, sb.TD
+	b.header, b.uncles, b.transactions, b.Td = sb.Header, sb.Uncles, sb.Txs, sb.TD
 	return nil
 }
 
-func (self StorageBlock) EncodeRLP(w io.Writer) error {
+func (b StorageBlock) EncodeRLP(w io.Writer) error {
 	return rlp.Encode(w, storageblock{
-		Header: self.header,
-		Txs:    self.transactions,
-		Uncles: self.uncles,
-		TD:     self.Td,
+		Header: b.header,
+		Txs:    b.transactions,
+		Uncles: b.uncles,
+		TD:     b.Td,
 	})
 }
 
-func (self *Block) Header() *Header {
-	return self.header
-}
+// TODO: copies
+func (b *Block) Uncles() []*Header          { return b.uncles }
+func (b *Block) Transactions() Transactions { return b.transactions }
+func (b *Block) Receipts() Receipts         { return b.receipts }
 
-func (self *Block) Uncles() []*Header {
-	return self.uncles
-}
-
-func (self *Block) CalculateUnclesHash() common.Hash {
-	return rlpHash(self.uncles)
-}
-
-func (self *Block) SetUncles(uncleHeaders []*Header) {
-	self.uncles = uncleHeaders
-	self.header.UncleHash = rlpHash(uncleHeaders)
-}
-
-func (self *Block) Transactions() Transactions {
-	return self.transactions
-}
-
-func (self *Block) Transaction(hash common.Hash) *Transaction {
-	for _, transaction := range self.transactions {
+func (b *Block) Transaction(hash common.Hash) *Transaction {
+	for _, transaction := range b.transactions {
 		if transaction.Hash() == hash {
 			return transaction
 		}
@@ -257,74 +270,33 @@ func (self *Block) Transaction(hash common.Hash) *Transaction {
 	return nil
 }
 
-func (self *Block) SetTransactions(transactions Transactions) {
-	self.transactions = transactions
-	self.header.TxHash = DeriveSha(transactions)
-}
-func (self *Block) AddTransaction(transaction *Transaction) {
-	self.transactions = append(self.transactions, transaction)
-	self.SetTransactions(self.transactions)
+func (b *Block) Number() *big.Int     { return new(big.Int).Set(b.header.Number) }
+func (b *Block) GasLimit() *big.Int   { return new(big.Int).Set(b.header.GasLimit) }
+func (b *Block) GasUsed() *big.Int    { return new(big.Int).Set(b.header.GasUsed) }
+func (b *Block) Difficulty() *big.Int { return new(big.Int).Set(b.header.Difficulty) }
+
+func (b *Block) NumberU64() uint64        { return b.header.Number.Uint64() }
+func (b *Block) MixDigest() common.Hash   { return b.header.MixDigest }
+func (b *Block) Nonce() uint64            { return binary.BigEndian.Uint64(b.header.Nonce[:]) }
+func (b *Block) Bloom() Bloom             { return b.header.Bloom }
+func (b *Block) Coinbase() common.Address { return b.header.Coinbase }
+func (b *Block) Time() int64              { return int64(b.header.Time) }
+func (b *Block) Root() common.Hash        { return b.header.Root }
+func (b *Block) ParentHash() common.Hash  { return b.header.ParentHash }
+func (b *Block) TxHash() common.Hash      { return b.header.TxHash }
+func (b *Block) ReceiptHash() common.Hash { return b.header.ReceiptHash }
+func (b *Block) UncleHash() common.Hash   { return b.header.UncleHash }
+func (b *Block) Extra() []byte            { return common.CopyBytes(b.header.Extra) }
+
+func (b *Block) Header() *Header { return copyHeader(b.header) }
+
+func (b *Block) HashNoNonce() common.Hash {
+	return b.header.HashNoNonce()
 }
 
-func (self *Block) Receipts() Receipts {
-	return self.receipts
-}
-
-func (self *Block) SetReceipts(receipts Receipts) {
-	self.receipts = receipts
-	self.header.ReceiptHash = DeriveSha(receipts)
-	self.header.Bloom = CreateBloom(receipts)
-}
-func (self *Block) AddReceipt(receipt *Receipt) {
-	self.receipts = append(self.receipts, receipt)
-	self.SetReceipts(self.receipts)
-}
-
-func (self *Block) RlpData() interface{} {
-	return []interface{}{self.header, self.transactions, self.uncles}
-}
-
-func (self *Block) RlpDataForStorage() interface{} {
-	return []interface{}{self.header, self.transactions, self.uncles, self.Td /* TODO receipts */}
-}
-
-// Header accessors (add as you need them)
-func (self *Block) Number() *big.Int       { return self.header.Number }
-func (self *Block) NumberU64() uint64      { return self.header.Number.Uint64() }
-func (self *Block) MixDigest() common.Hash { return self.header.MixDigest }
-func (self *Block) Nonce() uint64 {
-	return binary.BigEndian.Uint64(self.header.Nonce[:])
-}
-func (self *Block) SetNonce(nonce uint64) {
-	self.header.SetNonce(nonce)
-}
-
-func (self *Block) Queued() bool     { return self.queued }
-func (self *Block) SetQueued(q bool) { self.queued = q }
-
-func (self *Block) Bloom() Bloom             { return self.header.Bloom }
-func (self *Block) Coinbase() common.Address { return self.header.Coinbase }
-func (self *Block) Time() int64              { return int64(self.header.Time) }
-func (self *Block) GasLimit() *big.Int       { return self.header.GasLimit }
-func (self *Block) GasUsed() *big.Int        { return self.header.GasUsed }
-func (self *Block) Root() common.Hash        { return self.header.Root }
-func (self *Block) SetRoot(root common.Hash) { self.header.Root = root }
-func (self *Block) GetTransaction(i int) *Transaction {
-	if len(self.transactions) > i {
-		return self.transactions[i]
-	}
-	return nil
-}
-func (self *Block) GetUncle(i int) *Header {
-	if len(self.uncles) > i {
-		return self.uncles[i]
-	}
-	return nil
-}
-
-func (self *Block) Size() common.StorageSize {
+func (b *Block) Size() common.StorageSize {
 	c := writeCounter(0)
-	rlp.Encode(&c, self)
+	rlp.Encode(&c, b)
 	return common.StorageSize(c)
 }
 
@@ -335,48 +307,32 @@ func (c *writeCounter) Write(b []byte) (int, error) {
 	return len(b), nil
 }
 
+func CalcUncleHash(uncles []*Header) common.Hash {
+	return rlpHash(uncles)
+}
+
+// WithMiningResult returns a new block with the data from b
+// where nonce and mix digest are set to the provided values.
+func (b *Block) WithMiningResult(nonce uint64, mixDigest common.Hash) *Block {
+	cpy := *b.header
+	binary.BigEndian.PutUint64(cpy.Nonce[:], nonce)
+	cpy.MixDigest = mixDigest
+	return &Block{
+		header:       &cpy,
+		transactions: b.transactions,
+		receipts:     b.receipts,
+		uncles:       b.uncles,
+		Td:           b.Td,
+	}
+}
+
 // Implement pow.Block
-func (self *Block) Difficulty() *big.Int     { return self.header.Difficulty }
-func (self *Block) HashNoNonce() common.Hash { return self.header.HashNoNonce() }
 
-func (self *Block) Hash() common.Hash {
-	if (self.HeaderHash != common.Hash{}) {
-		return self.HeaderHash
-	} else {
-		return self.header.Hash()
-	}
+func (b *Block) Hash() common.Hash {
+	return b.header.Hash()
 }
 
-func (self *Block) ParentHash() common.Hash {
-	if (self.ParentHeaderHash != common.Hash{}) {
-		return self.ParentHeaderHash
-	} else {
-		return self.header.ParentHash
-	}
-}
-
-func (self *Block) Copy() *Block {
-	block := NewBlock(self.header.ParentHash, self.Coinbase(), self.Root(), new(big.Int), self.Nonce(), self.header.Extra)
-	block.header.Bloom = self.header.Bloom
-	block.header.TxHash = self.header.TxHash
-	block.transactions = self.transactions
-	block.header.UncleHash = self.header.UncleHash
-	block.uncles = self.uncles
-	block.header.GasLimit.Set(self.header.GasLimit)
-	block.header.GasUsed.Set(self.header.GasUsed)
-	block.header.ReceiptHash = self.header.ReceiptHash
-	block.header.Difficulty.Set(self.header.Difficulty)
-	block.header.Number.Set(self.header.Number)
-	block.header.Time = self.header.Time
-	block.header.MixDigest = self.header.MixDigest
-	if self.Td != nil {
-		block.Td.Set(self.Td)
-	}
-
-	return block
-}
-
-func (self *Block) String() string {
+func (b *Block) String() string {
 	str := fmt.Sprintf(`Block(#%v): Size: %v TD: %v {
 MinerHash: %x
 %v
@@ -385,20 +341,11 @@ Transactions:
 Uncles:
 %v
 }
-`, self.Number(), self.Size(), self.Td, self.header.HashNoNonce(), self.header, self.transactions, self.uncles)
-
-	if (self.HeaderHash != common.Hash{}) {
-		str += fmt.Sprintf("\nFake hash = %x", self.HeaderHash)
-	}
-
-	if (self.ParentHeaderHash != common.Hash{}) {
-		str += fmt.Sprintf("\nFake parent hash = %x", self.ParentHeaderHash)
-	}
-
+`, b.Number(), b.Size(), b.Td, b.header.HashNoNonce(), b.header, b.transactions, b.uncles)
 	return str
 }
 
-func (self *Header) String() string {
+func (h *Header) String() string {
 	return fmt.Sprintf(`Header(%x):
 [
 	ParentHash:	    %x
@@ -414,9 +361,9 @@ func (self *Header) String() string {
 	GasUsed:	    %v
 	Time:		    %v
 	Extra:		    %s
-	MixDigest:          %x
+	MixDigest:      %x
 	Nonce:		    %x
-]`, self.Hash(), self.ParentHash, self.UncleHash, self.Coinbase, self.Root, self.TxHash, self.ReceiptHash, self.Bloom, self.Difficulty, self.Number, self.GasLimit, self.GasUsed, self.Time, self.Extra, self.MixDigest, self.Nonce)
+]`, h.Hash(), h.ParentHash, h.UncleHash, h.Coinbase, h.Root, h.TxHash, h.ReceiptHash, h.Bloom, h.Difficulty, h.Number, h.GasLimit, h.GasUsed, h.Time, h.Extra, h.MixDigest, h.Nonce)
 }
 
 type Blocks []*Block
@@ -442,4 +389,4 @@ func (self blockSorter) Swap(i, j int) {
 }
 func (self blockSorter) Less(i, j int) bool { return self.by(self.blocks[i], self.blocks[j]) }
 
-func Number(b1, b2 *Block) bool { return b1.Header().Number.Cmp(b2.Header().Number) < 0 }
+func Number(b1, b2 *Block) bool { return b1.header.Number.Cmp(b2.header.Number) < 0 }

--- a/core/types/block_test.go
+++ b/core/types/block_test.go
@@ -13,7 +13,6 @@ import (
 // from bcValidBlockTest.json, "SimpleTx"
 func TestBlockEncoding(t *testing.T) {
 	blockEnc := common.FromHex("f90260f901f9a083cafc574e1f51ba9dc0568fc617a08ea2429fb384059c972f13b19fa1c8dd55a01dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347948888f1f195afa192cfee860698584c030f4c9db1a0ef1552a40b7165c3cd773806b9e0c165b75356e0314bf0706f279c729f51e017a05fe50b260da6308036625b850b5d6ced6d0a9f814c0688bc91ffb7b7a3a54b67a0bc37d79753ad738a6dac4921e57392f145d8887476de3f783dfa7edae9283e52b90100000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000008302000001832fefd8825208845506eb0780a0bd4472abb6659ebe3ee06ee4d7b72a00a9f4d001caca51342001075469aff49888a13a5a8c8f2bb1c4f861f85f800a82c35094095e7baea6a6c7c4c2dfeb977efac326af552d870a801ba09bea4c4daac7c7c52e093e6a4c35dbbcf8856f1af7b059ba20253e70848d094fa08a8fae537ce25ed8cb5af9adac3f141af69bd515bd2ba031522df09b97dd72b1c0")
-
 	var block Block
 	if err := rlp.DecodeBytes(blockEnc, &block); err != nil {
 		t.Fatal("decode error: ", err)
@@ -35,20 +34,10 @@ func TestBlockEncoding(t *testing.T) {
 	check("Time", block.Time(), int64(1426516743))
 	check("Size", block.Size(), common.StorageSize(len(blockEnc)))
 
-	to := common.HexToAddress("095e7baea6a6c7c4c2dfeb977efac326af552d87")
-	check("Transactions", block.Transactions(), Transactions{
-		{
-			Payload:      []byte{},
-			Amount:       big.NewInt(10),
-			Price:        big.NewInt(10),
-			GasLimit:     big.NewInt(50000),
-			AccountNonce: 0,
-			V:            27,
-			R:            common.String2Big("0x9bea4c4daac7c7c52e093e6a4c35dbbcf8856f1af7b059ba20253e70848d094f"),
-			S:            common.String2Big("0x8a8fae537ce25ed8cb5af9adac3f141af69bd515bd2ba031522df09b97dd72b1"),
-			Recipient:    &to,
-		},
-	})
+	tx1 := NewTransaction(0, common.HexToAddress("095e7baea6a6c7c4c2dfeb977efac326af552d87"), big.NewInt(10), big.NewInt(50000), big.NewInt(10), nil)
+	tx1, _ = tx1.WithSignature(common.Hex2Bytes("9bea4c4daac7c7c52e093e6a4c35dbbcf8856f1af7b059ba20253e70848d094f8a8fae537ce25ed8cb5af9adac3f141af69bd515bd2ba031522df09b97dd72b100"))
+	check("len(Transactions)", len(block.Transactions()), 1)
+	check("Transactions[0].Hash", block.Transactions()[0].Hash(), tx1.Hash())
 
 	ourBlockEnc, err := rlp.EncodeToBytes(&block)
 	if err != nil {

--- a/core/types/transaction.go
+++ b/core/types/transaction.go
@@ -4,6 +4,7 @@ import (
 	"crypto/ecdsa"
 	"errors"
 	"fmt"
+	"io"
 	"math/big"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -18,38 +19,59 @@ func IsContractAddr(addr []byte) bool {
 }
 
 type Transaction struct {
-	AccountNonce uint64
-	Price        *big.Int
-	GasLimit     *big.Int
-	Recipient    *common.Address `rlp:"nil"` // nil means contract creation
-	Amount       *big.Int
-	Payload      []byte
-	V            byte
-	R, S         *big.Int
+	data txdata
 }
 
-func NewContractCreationTx(amount, gasLimit, gasPrice *big.Int, data []byte) *Transaction {
-	return &Transaction{
-		Recipient: nil,
-		Amount:    amount,
-		GasLimit:  gasLimit,
-		Price:     gasPrice,
-		Payload:   data,
-		R:         new(big.Int),
-		S:         new(big.Int),
-	}
+type txdata struct {
+	AccountNonce    uint64
+	Price, GasLimit *big.Int
+	Recipient       *common.Address `rlp:"nil"` // nil means contract creation
+	Amount          *big.Int
+	Payload         []byte
+	V               byte     // signature
+	R, S            *big.Int // signature
 }
 
-func NewTransactionMessage(to common.Address, amount, gasAmount, gasPrice *big.Int, data []byte) *Transaction {
-	return &Transaction{
-		Recipient: &to,
-		Amount:    amount,
-		GasLimit:  gasAmount,
-		Price:     gasPrice,
-		Payload:   data,
-		R:         new(big.Int),
-		S:         new(big.Int),
+func NewContractCreation(nonce uint64, amount, gasLimit, gasPrice *big.Int, data []byte) *Transaction {
+	if len(data) > 0 {
+		data = common.CopyBytes(data)
 	}
+	return &Transaction{data: txdata{
+		AccountNonce: nonce,
+		Recipient:    nil,
+		Amount:       new(big.Int).Set(amount),
+		GasLimit:     new(big.Int).Set(gasLimit),
+		Price:        new(big.Int).Set(gasPrice),
+		Payload:      data,
+		R:            new(big.Int),
+		S:            new(big.Int),
+	}}
+}
+
+func NewTransaction(nonce uint64, to common.Address, amount, gasLimit, gasPrice *big.Int, data []byte) *Transaction {
+	if len(data) > 0 {
+		data = common.CopyBytes(data)
+	}
+	d := txdata{
+		AccountNonce: nonce,
+		Recipient:    &to,
+		Payload:      data,
+		Amount:       new(big.Int),
+		GasLimit:     new(big.Int),
+		Price:        new(big.Int),
+		R:            new(big.Int),
+		S:            new(big.Int),
+	}
+	if amount != nil {
+		d.Amount.Set(amount)
+	}
+	if gasLimit != nil {
+		d.GasLimit.Set(gasLimit)
+	}
+	if gasPrice != nil {
+		d.Price.Set(gasPrice)
+	}
+	return &Transaction{data: d}
 }
 
 func NewTransactionFromBytes(data []byte) *Transaction {
@@ -61,112 +83,110 @@ func NewTransactionFromBytes(data []byte) *Transaction {
 	return tx
 }
 
+func (tx *Transaction) EncodeRLP(w io.Writer) error {
+	return rlp.Encode(w, &tx.data)
+}
+
+func (tx *Transaction) DecodeRLP(s *rlp.Stream) error {
+	return s.Decode(&tx.data)
+}
+
+func (tx *Transaction) Data() []byte       { return common.CopyBytes(tx.data.Payload) }
+func (tx *Transaction) Gas() *big.Int      { return new(big.Int).Set(tx.data.GasLimit) }
+func (tx *Transaction) GasPrice() *big.Int { return new(big.Int).Set(tx.data.Price) }
+func (tx *Transaction) Value() *big.Int    { return new(big.Int).Set(tx.data.Amount) }
+func (tx *Transaction) Nonce() uint64      { return tx.data.AccountNonce }
+
+func (tx *Transaction) To() *common.Address {
+	if tx.data.Recipient == nil {
+		return nil
+	} else {
+		to := *tx.data.Recipient
+		return &to
+	}
+}
+
 func (tx *Transaction) Hash() common.Hash {
-	return rlpHash([]interface{}{
-		tx.AccountNonce, tx.Price, tx.GasLimit, tx.Recipient, tx.Amount, tx.Payload,
+	v := rlpHash([]interface{}{
+		tx.data.AccountNonce,
+		tx.data.Price,
+		tx.data.GasLimit,
+		tx.data.Recipient,
+		tx.data.Amount,
+		tx.data.Payload,
 	})
+	return v
 }
 
-// Size returns the encoded RLP size of tx.
-func (self *Transaction) Size() common.StorageSize {
-	c := writeCounter(0)
-	rlp.Encode(&c, self)
-	return common.StorageSize(c)
+func (tx *Transaction) Size() common.StorageSize {
+	v, _, _ := rlp.EncodeToReader(&tx.data)
+	return common.StorageSize(v)
 }
 
-func (self *Transaction) Data() []byte {
-	return self.Payload
-}
-
-func (self *Transaction) Gas() *big.Int {
-	return self.GasLimit
-}
-
-func (self *Transaction) GasPrice() *big.Int {
-	return self.Price
-}
-
-func (self *Transaction) Value() *big.Int {
-	return self.Amount
-}
-
-func (self *Transaction) Nonce() uint64 {
-	return self.AccountNonce
-}
-
-func (self *Transaction) SetNonce(AccountNonce uint64) {
-	self.AccountNonce = AccountNonce
-}
-
-func (self *Transaction) From() (common.Address, error) {
-	pubkey, err := self.PublicKey()
+func (tx *Transaction) From() (common.Address, error) {
+	pubkey, err := tx.PublicKey()
 	if err != nil {
 		return common.Address{}, err
 	}
-
 	var addr common.Address
 	copy(addr[:], crypto.Sha3(pubkey[1:])[12:])
 	return addr, nil
 }
 
-// To returns the recipient of the transaction.
-// If transaction is a contract creation (with no recipient address)
-// To returns nil.
-func (tx *Transaction) To() *common.Address {
-	return tx.Recipient
+// Cost returns amount + gasprice * gaslimit.
+func (tx *Transaction) Cost() *big.Int {
+	total := new(big.Int).Mul(tx.data.Price, tx.data.GasLimit)
+	total.Add(total, tx.data.Amount)
+	return total
 }
 
-func (tx *Transaction) GetSignatureValues() (v byte, r []byte, s []byte) {
-	v = byte(tx.V)
-	r = common.LeftPadBytes(tx.R.Bytes(), 32)
-	s = common.LeftPadBytes(tx.S.Bytes(), 32)
-	return
+func (tx *Transaction) SignatureValues() (v byte, r *big.Int, s *big.Int) {
+	return tx.data.V, new(big.Int).Set(tx.data.R), new(big.Int).Set(tx.data.S)
 }
 
 func (tx *Transaction) PublicKey() ([]byte, error) {
-	if !crypto.ValidateSignatureValues(tx.V, tx.R, tx.S) {
+	if !crypto.ValidateSignatureValues(tx.data.V, tx.data.R, tx.data.S) {
 		return nil, errors.New("invalid v, r, s values")
 	}
 
-	hash := tx.Hash()
-	v, r, s := tx.GetSignatureValues()
-	sig := append(r, s...)
-	sig = append(sig, v-27)
+	// encode the signature in uncompressed format
+	r, s := tx.data.R.Bytes(), tx.data.S.Bytes()
+	sig := make([]byte, 65)
+	copy(sig[32-len(r):32], r)
+	copy(sig[64-len(s):64], s)
+	sig[64] = tx.data.V - 27
 
-	p, err := crypto.SigToPub(hash[:], sig)
+	// recover the public key from the signature
+	hash := tx.Hash()
+	pub, err := crypto.Ecrecover(hash[:], sig)
 	if err != nil {
 		glog.V(logger.Error).Infof("Could not get pubkey from signature: ", err)
 		return nil, err
 	}
-
-	pubkey := crypto.FromECDSAPub(p)
-	if len(pubkey) == 0 || pubkey[0] != 4 {
+	if len(pub) == 0 || pub[0] != 4 {
 		return nil, errors.New("invalid public key")
 	}
-	return pubkey, nil
+	return pub, nil
 }
 
-func (tx *Transaction) SetSignatureValues(sig []byte) error {
-	tx.R = common.Bytes2Big(sig[:32])
-	tx.S = common.Bytes2Big(sig[32:64])
-	tx.V = sig[64] + 27
-	return nil
+func (tx *Transaction) WithSignature(sig []byte) (*Transaction, error) {
+	if len(sig) != 65 {
+		panic(fmt.Sprintf("wrong size for signature: got %d, want 65", len(sig)))
+	}
+	cpy := &Transaction{data: tx.data}
+	cpy.data.R = new(big.Int).SetBytes(sig[:32])
+	cpy.data.S = new(big.Int).SetBytes(sig[32:64])
+	cpy.data.V = sig[64] + 27
+	return cpy, nil
 }
 
-func (tx *Transaction) SignECDSA(prv *ecdsa.PrivateKey) error {
+func (tx *Transaction) SignECDSA(prv *ecdsa.PrivateKey) (*Transaction, error) {
 	h := tx.Hash()
 	sig, err := crypto.Sign(h[:], prv)
 	if err != nil {
-		return err
+		return nil, err
 	}
-	tx.SetSignatureValues(sig)
-	return nil
-}
-
-// TODO: remove
-func (tx *Transaction) RlpData() interface{} {
-	data := []interface{}{tx.AccountNonce, tx.Price, tx.GasLimit, tx.Recipient, tx.Amount, tx.Payload}
-	return append(data, tx.V, tx.R.Bytes(), tx.S.Bytes())
+	return tx.WithSignature(sig)
 }
 
 func (tx *Transaction) String() string {
@@ -176,12 +196,12 @@ func (tx *Transaction) String() string {
 	} else {
 		from = fmt.Sprintf("%x", f[:])
 	}
-	if t := tx.To(); t == nil {
+	if tx.data.Recipient == nil {
 		to = "[contract creation]"
 	} else {
-		to = fmt.Sprintf("%x", t[:])
+		to = fmt.Sprintf("%x", tx.data.Recipient[:])
 	}
-	enc, _ := rlp.EncodeToBytes(tx)
+	enc, _ := rlp.EncodeToBytes(&tx.data)
 	return fmt.Sprintf(`
 	TX(%x)
 	Contract: %v
@@ -198,35 +218,23 @@ func (tx *Transaction) String() string {
 	Hex:      %x
 `,
 		tx.Hash(),
-		len(tx.Recipient) == 0,
+		len(tx.data.Recipient) == 0,
 		from,
 		to,
-		tx.AccountNonce,
-		tx.Price,
-		tx.GasLimit,
-		tx.Amount,
-		tx.Payload,
-		tx.V,
-		tx.R,
-		tx.S,
+		tx.data.AccountNonce,
+		tx.data.Price,
+		tx.data.GasLimit,
+		tx.data.Amount,
+		tx.data.Payload,
+		tx.data.V,
+		tx.data.R,
+		tx.data.S,
 		enc,
 	)
 }
 
-// Transaction slice type for basic sorting
+// Transaction slice type for basic sorting.
 type Transactions []*Transaction
-
-// TODO: remove
-func (self Transactions) RlpData() interface{} {
-	// Marshal the transactions of this block
-	enc := make([]interface{}, len(self))
-	for i, tx := range self {
-		// Cast it to a string (safe)
-		enc[i] = tx.RlpData()
-	}
-
-	return enc
-}
 
 func (s Transactions) Len() int      { return len(s) }
 func (s Transactions) Swap(i, j int) { s[i], s[j] = s[j], s[i] }
@@ -239,5 +247,5 @@ func (s Transactions) GetRlp(i int) []byte {
 type TxByNonce struct{ Transactions }
 
 func (s TxByNonce) Less(i, j int) bool {
-	return s.Transactions[i].AccountNonce < s.Transactions[j].AccountNonce
+	return s.Transactions[i].data.AccountNonce < s.Transactions[j].data.AccountNonce
 }

--- a/core/types/transaction_test.go
+++ b/core/types/transaction_test.go
@@ -15,40 +15,35 @@ import (
 // at github.com/ethereum/tests.
 
 var (
-	emptyTx = NewTransactionMessage(
+	emptyTx = NewTransaction(
+		0,
 		common.HexToAddress("095e7baea6a6c7c4c2dfeb977efac326af552d87"),
 		big.NewInt(0), big.NewInt(0), big.NewInt(0),
 		nil,
 	)
 
-	rightvrsRecipient = common.HexToAddress("b94f5374fce5edbc8e2a8697c15331677e6ebf0b")
-	rightvrsTx        = &Transaction{
-		Recipient:    &rightvrsRecipient,
-		AccountNonce: 3,
-		Price:        big.NewInt(1),
-		GasLimit:     big.NewInt(2000),
-		Amount:       big.NewInt(10),
-		Payload:      common.FromHex("5544"),
-		V:            28,
-		R:            common.String2Big("0x98ff921201554726367d2be8c804a7ff89ccf285ebc57dff8ae4c44b9c19ac4a"),
-		S:            common.String2Big("0x8887321be575c8095f789dd4c743dfe42c1820f9231f98a962b210e3ac2452a3"),
-	}
+	rightvrsTx, _ = NewTransaction(
+		3,
+		common.HexToAddress("b94f5374fce5edbc8e2a8697c15331677e6ebf0b"),
+		big.NewInt(10),
+		big.NewInt(2000),
+		big.NewInt(1),
+		common.FromHex("5544"),
+	).WithSignature(
+		common.Hex2Bytes("98ff921201554726367d2be8c804a7ff89ccf285ebc57dff8ae4c44b9c19ac4a8887321be575c8095f789dd4c743dfe42c1820f9231f98a962b210e3ac2452a301"),
+	)
 )
 
 func TestTransactionHash(t *testing.T) {
-	// "EmptyTransaction"
 	if emptyTx.Hash() != common.HexToHash("c775b99e7ad12f50d819fcd602390467e28141316969f4b57f0626f74fe3b386") {
 		t.Errorf("empty transaction hash mismatch, got %x", emptyTx.Hash())
 	}
-
-	// "RightVRSTest"
 	if rightvrsTx.Hash() != common.HexToHash("fe7a79529ed5f7c3375d06b26b186a8644e0e16c373d7a12be41c62d6042b77a") {
 		t.Errorf("RightVRS transaction hash mismatch, got %x", rightvrsTx.Hash())
 	}
 }
 
 func TestTransactionEncode(t *testing.T) {
-	// "RightVRSTest"
 	txb, err := rlp.EncodeToBytes(rightvrsTx)
 	if err != nil {
 		t.Fatalf("encode error: %v", err)
@@ -72,19 +67,16 @@ func defaultTestKey() (*ecdsa.PrivateKey, common.Address) {
 
 func TestRecipientEmpty(t *testing.T) {
 	_, addr := defaultTestKey()
-
 	tx, err := decodeTx(common.Hex2Bytes("f8498080808080011ca09b16de9d5bdee2cf56c28d16275a4da68cd30273e2525f3959f5d62557489921a0372ebd8fb3345f7db7b5a86d42e24d36e983e259b0664ceb8c227ec9af572f3d"))
 	if err != nil {
 		t.Error(err)
 		t.FailNow()
 	}
-
 	from, err := tx.From()
 	if err != nil {
 		t.Error(err)
 		t.FailNow()
 	}
-
 	if addr != from {
 		t.Error("derived address doesn't match")
 	}

--- a/core/vm_env.go
+++ b/core/vm_env.go
@@ -10,32 +10,32 @@ import (
 )
 
 type VMEnv struct {
-	state *state.StateDB
-	block *types.Block
-	msg   Message
-	depth int
-	chain *ChainManager
-	typ   vm.Type
+	state  *state.StateDB
+	header *types.Header
+	msg    Message
+	depth  int
+	chain  *ChainManager
+	typ    vm.Type
 	// structured logging
 	logs []vm.StructLog
 }
 
-func NewEnv(state *state.StateDB, chain *ChainManager, msg Message, block *types.Block) *VMEnv {
+func NewEnv(state *state.StateDB, chain *ChainManager, msg Message, header *types.Header) *VMEnv {
 	return &VMEnv{
-		chain: chain,
-		state: state,
-		block: block,
-		msg:   msg,
-		typ:   vm.StdVmTy,
+		chain:  chain,
+		state:  state,
+		header: header,
+		msg:    msg,
+		typ:    vm.StdVmTy,
 	}
 }
 
 func (self *VMEnv) Origin() common.Address   { f, _ := self.msg.From(); return f }
-func (self *VMEnv) BlockNumber() *big.Int    { return self.block.Number() }
-func (self *VMEnv) Coinbase() common.Address { return self.block.Coinbase() }
-func (self *VMEnv) Time() int64              { return self.block.Time() }
-func (self *VMEnv) Difficulty() *big.Int     { return self.block.Difficulty() }
-func (self *VMEnv) GasLimit() *big.Int       { return self.block.GasLimit() }
+func (self *VMEnv) BlockNumber() *big.Int    { return self.header.Number }
+func (self *VMEnv) Coinbase() common.Address { return self.header.Coinbase }
+func (self *VMEnv) Time() int64              { return int64(self.header.Time) }
+func (self *VMEnv) Difficulty() *big.Int     { return self.header.Difficulty }
+func (self *VMEnv) GasLimit() *big.Int       { return self.header.GasLimit }
 func (self *VMEnv) Value() *big.Int          { return self.msg.Value() }
 func (self *VMEnv) State() *state.StateDB    { return self.state }
 func (self *VMEnv) Depth() int               { return self.depth }

--- a/eth/downloader/downloader_test.go
+++ b/eth/downloader/downloader_test.go
@@ -40,7 +40,10 @@ func createHashes(amount int, root common.Hash) (hashes []common.Hash) {
 
 // createBlock assembles a new block at the given chain height.
 func createBlock(i int, parent, hash common.Hash) *types.Block {
-	header := &types.Header{Number: big.NewInt(int64(i))}
+	header := &types.Header{
+		Hash: hash,
+		Number: big.NewInt(int64(i))
+	}
 	block := types.NewBlockWithHeader(header)
 	block.HeaderHash = hash
 	block.ParentHeaderHash = parent

--- a/eth/gasprice.go
+++ b/eth/gasprice.go
@@ -133,20 +133,20 @@ func (self *GasPriceOracle) lowestPrice(block *types.Block) *big.Int {
 		gasUsed = recepits[len(recepits)-1].CumulativeGasUsed
 	}
 
-	if new(big.Int).Mul(gasUsed, big.NewInt(100)).Cmp(new(big.Int).Mul(block.Header().GasLimit,
+	if new(big.Int).Mul(gasUsed, big.NewInt(100)).Cmp(new(big.Int).Mul(block.GasLimit(),
 		big.NewInt(int64(self.eth.GpoFullBlockRatio)))) < 0 {
 		// block is not full, could have posted a tx with MinGasPrice
 		return self.eth.GpoMinGasPrice
 	}
 
-	if len(block.Transactions()) < 1 {
+	txs := block.Transactions()
+	if len(txs) == 0 {
 		return self.eth.GpoMinGasPrice
 	}
-
 	// block is full, find smallest gasPrice
-	minPrice := block.Transactions()[0].GasPrice()
-	for i := 1; i < len(block.Transactions()); i++ {
-		price := block.Transactions()[i].GasPrice()
+	minPrice := txs[0].GasPrice()
+	for i := 1; i < len(txs); i++ {
+		price := txs[i].GasPrice()
 		if price.Cmp(minPrice) < 0 {
 			minPrice = price
 		}

--- a/eth/handler.go
+++ b/eth/handler.go
@@ -93,7 +93,7 @@ func NewProtocolManager(protocolVersion, networkId int, mux *event.TypeMux, txpo
 	manager.downloader = downloader.New(manager.eventMux, manager.chainman.HasBlock, manager.chainman.GetBlock, manager.chainman.InsertChain, manager.removePeer)
 
 	validator := func(block *types.Block, parent *types.Block) error {
-		return core.ValidateHeader(pow, block.Header(), parent.Header(), true)
+		return core.ValidateHeader(pow, block.Header(), parent, true)
 	}
 	heighter := func() uint64 {
 		return manager.chainman.CurrentBlock().NumberU64()

--- a/eth/protocol_test.go
+++ b/eth/protocol_test.go
@@ -234,7 +234,7 @@ func (pool *fakeTxPool) GetTransactions() types.Transactions {
 
 func newtx(from *crypto.Key, nonce uint64, datasize int) *types.Transaction {
 	data := make([]byte, datasize)
-	tx := types.NewTransactionMessage(common.Address{}, big.NewInt(0), big.NewInt(100000), big.NewInt(0), data)
-	tx.SetNonce(nonce)
+	tx := types.NewTransaction(nonce, common.Address{}, big.NewInt(0), big.NewInt(100000), big.NewInt(0), data)
+	tx, _ = tx.SignECDSA(from.PrivateKey)
 	return tx
 }

--- a/miner/agent.go
+++ b/miner/agent.go
@@ -90,15 +90,13 @@ done:
 	}
 }
 
-func (self *CpuAgent) mine(block *types.Block, stop <- chan struct{}) {
+func (self *CpuAgent) mine(block *types.Block, stop <-chan struct{}) {
 	glog.V(logger.Debug).Infof("(re)started agent[%d]. mining...\n", self.index)
 
 	// Mine
 	nonce, mixDigest := self.pow.Search(block, stop)
 	if nonce != 0 {
-		block.SetNonce(nonce)
-		block.Header().MixDigest = common.BytesToHash(mixDigest)
-		self.returnCh <- block
+		self.returnCh <- block.WithMiningResult(nonce, common.BytesToHash(mixDigest))
 	} else {
 		self.returnCh <- nil
 	}

--- a/miner/remote_agent.go
+++ b/miner/remote_agent.go
@@ -81,9 +81,7 @@ func (a *RemoteAgent) SubmitWork(nonce uint64, mixDigest, seedHash common.Hash) 
 
 	// Make sure the external miner was working on the right hash
 	if a.currentWork != nil && a.work != nil {
-		a.currentWork.SetNonce(nonce)
-		a.currentWork.Header().MixDigest = mixDigest
-		a.returnCh <- a.currentWork
+		a.returnCh <- a.currentWork.WithMiningResult(nonce, mixDigest)
 		//a.returnCh <- Work{a.currentWork.Number().Uint64(), nonce, mixDigest.Bytes(), seedHash.Bytes()}
 		return true
 	}

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -49,10 +49,8 @@ type uint64RingBuffer struct {
 // environment is the workers current environment and holds
 // all of the current state information
 type environment struct {
-	totalUsedGas       *big.Int           // total gas usage in the cycle
 	state              *state.StateDB     // apply state changes here
 	coinbase           *state.StateObject // the miner's account
-	block              *types.Block       // the new block
 	ancestors          *set.Set           // ancestor set (used for checking uncle parent validity)
 	family             *set.Set           // family set (used for checking uncle invalidity)
 	uncles             *set.Set           // uncle set
@@ -63,22 +61,12 @@ type environment struct {
 	ownedAccounts      *set.Set
 	lowGasTxs          types.Transactions
 	localMinedBlocks   *uint64RingBuffer // the most recent block numbers that were mined locally (used to check block inclusion)
-}
 
-// env returns a new environment for the current cycle
-func env(block *types.Block, eth core.Backend) *environment {
-	state := state.New(block.Root(), eth.StateDb())
-	env := &environment{
-		totalUsedGas: new(big.Int),
-		state:        state,
-		block:        block,
-		ancestors:    set.New(),
-		family:       set.New(),
-		uncles:       set.New(),
-		coinbase:     state.GetOrNewStateObject(block.Coinbase()),
-	}
+	block *types.Block // the new block
 
-	return env
+	header   *types.Header
+	txs      []*types.Transaction
+	receipts []*types.Receipt
 }
 
 // worker is the main object which takes care of applying messages to the new state
@@ -137,14 +125,20 @@ func newWorker(coinbase common.Address, eth core.Backend) *worker {
 func (self *worker) pendingState() *state.StateDB {
 	self.currentMu.Lock()
 	defer self.currentMu.Unlock()
-
 	return self.current.state
 }
 
 func (self *worker) pendingBlock() *types.Block {
 	self.currentMu.Lock()
 	defer self.currentMu.Unlock()
-
+	if atomic.LoadInt32(&self.mining) == 0 {
+		return types.NewBlock(
+			self.current.header,
+			self.current.txs,
+			nil,
+			self.current.receipts,
+		)
+	}
 	return self.current.block
 }
 
@@ -206,7 +200,7 @@ out:
 				// Apply transaction to the pending state if we're not mining
 				if atomic.LoadInt32(&self.mining) == 0 {
 					self.mu.Lock()
-					self.commitTransactions(types.Transactions{ev.Tx})
+					self.current.commitTransactions(types.Transactions{ev.Tx}, self.gasPrice, self.proc)
 					self.mu.Unlock()
 				}
 			}
@@ -259,8 +253,8 @@ func (self *worker) wait() {
 				jsonlogger.LogJson(&logger.EthMinerNewBlock{
 					BlockHash:     block.Hash().Hex(),
 					BlockNumber:   block.Number(),
-					ChainHeadHash: block.ParentHeaderHash.Hex(),
-					BlockPrevHash: block.ParentHeaderHash.Hex(),
+					ChainHeadHash: block.ParentHash().Hex(),
+					BlockPrevHash: block.ParentHash().Hex(),
 				})
 			} else {
 				self.commitNewWork()
@@ -271,14 +265,12 @@ func (self *worker) wait() {
 
 func (self *worker) push() {
 	if atomic.LoadInt32(&self.mining) == 1 {
-		self.current.block.SetRoot(self.current.state.Root())
-
 		// push new work to agents
 		for _, agent := range self.agents {
 			atomic.AddInt32(&self.atWork, 1)
 
 			if agent.Work() != nil {
-				agent.Work() <- self.current.block.Copy()
+				agent.Work() <- self.current.block
 			} else {
 				common.Report(fmt.Sprintf("%v %T\n", agent, agent))
 			}
@@ -286,22 +278,20 @@ func (self *worker) push() {
 	}
 }
 
-func (self *worker) makeCurrent() {
-	block := self.chain.NewBlock(self.coinbase)
-	parent := self.chain.GetBlock(block.ParentHash())
-	// TMP fix for build server ...
-	if parent == nil {
-		return
+// makeCurrent creates a new environment for the current cycle.
+func (self *worker) makeCurrent(parent *types.Block, header *types.Header) {
+	state := state.New(parent.Root(), self.eth.StateDb())
+	current := &environment{
+		state:     state,
+		ancestors: set.New(),
+		family:    set.New(),
+		uncles:    set.New(),
+		header:    header,
+		coinbase:  state.GetOrNewStateObject(self.coinbase),
 	}
-
-	if block.Time() <= parent.Time() {
-		block.Header().Time = parent.Header().Time + 1
-	}
-	block.Header().Extra = self.extra
 
 	// when 08 is processed ancestors contain 07 (quick block)
-	current := env(block, self.eth)
-	for _, ancestor := range self.chain.GetAncestors(block, 7) {
+	for _, ancestor := range self.chain.GetBlocksFromHash(parent.Hash(), 7) {
 		for _, uncle := range ancestor.Uncles() {
 			current.family.Add(uncle.Hash())
 		}
@@ -309,6 +299,7 @@ func (self *worker) makeCurrent() {
 		current.ancestors.Add(ancestor.Hash())
 	}
 	accounts, _ := self.eth.AccountManager().Accounts()
+
 	// Keep track of transactions which return errors so they can be removed
 	current.remove = set.New()
 	current.tcount = 0
@@ -318,9 +309,6 @@ func (self *worker) makeCurrent() {
 	if self.current != nil {
 		current.localMinedBlocks = self.current.localMinedBlocks
 	}
-
-	current.coinbase.SetGasLimit(core.CalcGasLimit(parent))
-
 	self.current = current
 }
 
@@ -352,13 +340,13 @@ func (self *worker) isBlockLocallyMined(deepBlockNum uint64) bool {
 
 	//Does the block at {deepBlockNum} send earnings to my coinbase?
 	var block = self.chain.GetBlockByNumber(deepBlockNum)
-	return block != nil && block.Header().Coinbase == self.coinbase
+	return block != nil && block.Coinbase() == self.coinbase
 }
 
 func (self *worker) logLocalMinedBlocks(previous *environment) {
 	if previous != nil && self.current.localMinedBlocks != nil {
-		nextBlockNum := self.current.block.Number().Uint64()
-		for checkBlockNum := previous.block.Number().Uint64(); checkBlockNum < nextBlockNum; checkBlockNum++ {
+		nextBlockNum := self.current.block.NumberU64()
+		for checkBlockNum := previous.block.NumberU64(); checkBlockNum < nextBlockNum; checkBlockNum++ {
 			inspectBlockNum := checkBlockNum - miningLogAtDepth
 			if self.isBlockLocallyMined(inspectBlockNum) {
 				glog.V(logger.Info).Infof("🔨 🔗  Mined %d blocks back: block #%v", miningLogAtDepth, inspectBlockNum)
@@ -376,18 +364,35 @@ func (self *worker) commitNewWork() {
 	defer self.currentMu.Unlock()
 
 	tstart := time.Now()
+	parent := self.chain.CurrentBlock()
+	tstamp := tstart.Unix()
+	if tstamp <= parent.Time() {
+		tstamp = parent.Time() + 1
+	}
+	num := parent.Number()
+	header := &types.Header{
+		ParentHash: parent.Hash(),
+		Number:     num.Add(num, common.Big1),
+		Difficulty: core.CalcDifficulty(tstamp, parent.Time(), parent.Difficulty()),
+		GasLimit:   core.CalcGasLimit(parent),
+		GasUsed:    new(big.Int),
+		Coinbase:   self.coinbase,
+		Extra:      self.extra,
+		Time:       uint64(tstamp),
+	}
 
 	previous := self.current
-	self.makeCurrent()
+	self.makeCurrent(parent, header)
 	current := self.current
 
+	// commit transactions for this run.
 	transactions := self.eth.TxPool().GetTransactions()
 	sort.Sort(types.TxByNonce{transactions})
-
-	// commit transactions for this run
-	self.commitTransactions(transactions)
+	current.coinbase.SetGasLimit(header.GasLimit)
+	current.commitTransactions(transactions, self.gasPrice, self.proc)
 	self.eth.TxPool().RemoveTransactions(current.lowGasTxs)
 
+	// compute uncles for the new block.
 	var (
 		uncles    []*types.Header
 		badUncles []common.Hash
@@ -396,88 +401,76 @@ func (self *worker) commitNewWork() {
 		if len(uncles) == 2 {
 			break
 		}
-
 		if err := self.commitUncle(uncle.Header()); err != nil {
 			if glog.V(logger.Ridiculousness) {
 				glog.V(logger.Detail).Infof("Bad uncle found and will be removed (%x)\n", hash[:4])
 				glog.V(logger.Detail).Infoln(uncle)
 			}
-
 			badUncles = append(badUncles, hash)
 		} else {
 			glog.V(logger.Debug).Infof("commiting %x as uncle\n", hash[:4])
 			uncles = append(uncles, uncle.Header())
 		}
 	}
+	for _, hash := range badUncles {
+		delete(self.possibleUncles, hash)
+	}
 
-	// We only care about logging if we're actually mining
+	// commit state root after all state transitions.
+	core.AccumulateRewards(self.current.state, header, uncles)
+	current.state.Update()
+	header.Root = current.state.Root()
+
+	// create the new block whose nonce will be mined.
+	current.block = types.NewBlock(header, current.txs, uncles, current.receipts)
+
+	// We only care about logging if we're actually mining.
 	if atomic.LoadInt32(&self.mining) == 1 {
 		glog.V(logger.Info).Infof("commit new work on block %v with %d txs & %d uncles. Took %v\n", current.block.Number(), current.tcount, len(uncles), time.Since(tstart))
 		self.logLocalMinedBlocks(previous)
 	}
 
-	for _, hash := range badUncles {
-		delete(self.possibleUncles, hash)
-	}
-
-	self.current.block.SetUncles(uncles)
-
-	core.AccumulateRewards(self.current.state, self.current.block)
-
-	self.current.state.Update()
-
 	self.push()
 }
 
-var (
-	inclusionReward = new(big.Int).Div(core.BlockReward, big.NewInt(32))
-	_uncleReward    = new(big.Int).Mul(core.BlockReward, big.NewInt(15))
-	uncleReward     = new(big.Int).Div(_uncleReward, big.NewInt(16))
-)
-
 func (self *worker) commitUncle(uncle *types.Header) error {
-	if self.current.uncles.Has(uncle.Hash()) {
-		// Error not unique
+	hash := uncle.Hash()
+	if self.current.uncles.Has(hash) {
 		return core.UncleError("Uncle not unique")
 	}
-
 	if !self.current.ancestors.Has(uncle.ParentHash) {
 		return core.UncleError(fmt.Sprintf("Uncle's parent unknown (%x)", uncle.ParentHash[0:4]))
 	}
-
-	if self.current.family.Has(uncle.Hash()) {
-		return core.UncleError(fmt.Sprintf("Uncle already in family (%x)", uncle.Hash()))
+	if self.current.family.Has(hash) {
+		return core.UncleError(fmt.Sprintf("Uncle already in family (%x)", hash))
 	}
 	self.current.uncles.Add(uncle.Hash())
-
 	return nil
 }
 
-func (self *worker) commitTransactions(transactions types.Transactions) {
-	current := self.current
-
+func (env *environment) commitTransactions(transactions types.Transactions, gasPrice *big.Int, proc *core.BlockProcessor) {
 	for _, tx := range transactions {
 		// We can skip err. It has already been validated in the tx pool
 		from, _ := tx.From()
 
 		// Check if it falls within margin. Txs from owned accounts are always processed.
-		if tx.GasPrice().Cmp(self.gasPrice) < 0 && !current.ownedAccounts.Has(from) {
+		if tx.GasPrice().Cmp(gasPrice) < 0 && !env.ownedAccounts.Has(from) {
 			// ignore the transaction and transactor. We ignore the transactor
 			// because nonce will fail after ignoring this transaction so there's
 			// no point
-			current.lowGasTransactors.Add(from)
+			env.lowGasTransactors.Add(from)
 
-			glog.V(logger.Info).Infof("transaction(%x) below gas price (tx=%v ask=%v). All sequential txs from this address(%x) will be ignored\n", tx.Hash().Bytes()[:4], common.CurrencyToString(tx.GasPrice()), common.CurrencyToString(self.gasPrice), from[:4])
+			glog.V(logger.Info).Infof("transaction(%x) below gas price (tx=%v ask=%v). All sequential txs from this address(%x) will be ignored\n", tx.Hash().Bytes()[:4], common.CurrencyToString(tx.GasPrice()), common.CurrencyToString(gasPrice), from[:4])
 		}
 
 		// Continue with the next transaction if the transaction sender is included in
 		// the low gas tx set. This will also remove the tx and all sequential transaction
 		// from this transactor
-		if current.lowGasTransactors.Has(from) {
+		if env.lowGasTransactors.Has(from) {
 			// add tx to the low gas set. This will be removed at the end of the run
 			// owned accounts are ignored
-			if !current.ownedAccounts.Has(from) {
-				current.lowGasTxs = append(current.lowGasTxs, tx)
+			if !env.ownedAccounts.Has(from) {
+				env.lowGasTxs = append(env.lowGasTxs, tx)
 			}
 			continue
 		}
@@ -487,46 +480,41 @@ func (self *worker) commitTransactions(transactions types.Transactions) {
 		// the transaction is processed (that could potentially be included in the block) it
 		// will throw a nonce error because the previous transaction hasn't been processed.
 		// Therefor we need to ignore any transaction after the ignored one.
-		if current.ignoredTransactors.Has(from) {
+		if env.ignoredTransactors.Has(from) {
 			continue
 		}
 
-		self.current.state.StartRecord(tx.Hash(), common.Hash{}, 0)
+		env.state.StartRecord(tx.Hash(), common.Hash{}, 0)
 
-		err := self.commitTransaction(tx)
+		err := env.commitTransaction(tx, proc)
 		switch {
 		case core.IsNonceErr(err) || core.IsInvalidTxErr(err):
-			current.remove.Add(tx.Hash())
+			env.remove.Add(tx.Hash())
 
 			if glog.V(logger.Detail) {
 				glog.Infof("TX (%x) failed, will be removed: %v\n", tx.Hash().Bytes()[:4], err)
 			}
 		case state.IsGasLimitErr(err):
-			from, _ := tx.From()
 			// ignore the transactor so no nonce errors will be thrown for this account
 			// next time the worker is run, they'll be picked up again.
-			current.ignoredTransactors.Add(from)
+			env.ignoredTransactors.Add(from)
 
 			glog.V(logger.Detail).Infof("Gas limit reached for (%x) in this block. Continue to try smaller txs\n", from[:4])
 		default:
-			current.tcount++
+			env.tcount++
 		}
 	}
-
-	self.current.block.Header().GasUsed = self.current.totalUsedGas
 }
 
-func (self *worker) commitTransaction(tx *types.Transaction) error {
-	snap := self.current.state.Copy()
-	receipt, _, err := self.proc.ApplyTransaction(self.current.coinbase, self.current.state, self.current.block, tx, self.current.totalUsedGas, true)
+func (env *environment) commitTransaction(tx *types.Transaction, proc *core.BlockProcessor) error {
+	snap := env.state.Copy()
+	receipt, _, err := proc.ApplyTransaction(env.coinbase, env.state, env.header, tx, env.header.GasUsed, true)
 	if err != nil && (core.IsNonceErr(err) || state.IsGasLimitErr(err) || core.IsInvalidTxErr(err)) {
-		self.current.state.Set(snap)
+		env.state.Set(snap)
 		return err
 	}
-
-	self.current.block.AddTransaction(tx)
-	self.current.block.AddReceipt(receipt)
-
+	env.txs = append(env.txs, tx)
+	env.receipts = append(env.receipts, receipt)
 	return nil
 }
 

--- a/rlp/encode.go
+++ b/rlp/encode.go
@@ -29,6 +29,12 @@ type Encoder interface {
 	EncodeRLP(io.Writer) error
 }
 
+// ListSize returns the encoded size of an RLP list with the given
+// content size.
+func ListSize(contentSize uint64) uint64 {
+	return uint64(headsize(contentSize)) + contentSize
+}
+
 // Encode writes the RLP encoding of val to w. Note that Encode may
 // perform many small writes in some cases. Consider making w
 // buffered.

--- a/rlp/encode.go
+++ b/rlp/encode.go
@@ -29,48 +29,6 @@ type Encoder interface {
 	EncodeRLP(io.Writer) error
 }
 
-// Flat wraps a value (which must encode as a list) so
-// it encodes as the list's elements.
-//
-// Example: suppose you have defined a type
-//
-//     type foo struct { A, B uint }
-//
-// Under normal encoding rules,
-//
-//     rlp.Encode(foo{1, 2}) --> 0xC20102
-//
-// This function can help you achieve the following encoding:
-//
-//     rlp.Encode(rlp.Flat(foo{1, 2})) --> 0x0102
-func Flat(val interface{}) Encoder {
-	return flatenc{val}
-}
-
-type flatenc struct{ val interface{} }
-
-func (e flatenc) EncodeRLP(out io.Writer) error {
-	// record current output position
-	var (
-		eb          = out.(*encbuf)
-		prevstrsize = len(eb.str)
-		prevnheads  = len(eb.lheads)
-	)
-	if err := eb.encode(e.val); err != nil {
-		return err
-	}
-	// check that a new list header has appeared
-	if len(eb.lheads) == prevnheads || eb.lheads[prevnheads].offset == prevstrsize-1 {
-		return fmt.Errorf("rlp.Flat: %T did not encode as list", e.val)
-	}
-	// remove the new list header
-	newhead := eb.lheads[prevnheads]
-	copy(eb.lheads[prevnheads:], eb.lheads[prevnheads+1:])
-	eb.lheads = eb.lheads[:len(eb.lheads)-1]
-	eb.lhsize -= headsize(uint64(newhead.size))
-	return nil
-}
-
 // Encode writes the RLP encoding of val to w. Note that Encode may
 // perform many small writes in some cases. Consider making w
 // buffered.

--- a/rlp/encode.go
+++ b/rlp/encode.go
@@ -5,11 +5,8 @@ import (
 	"io"
 	"math/big"
 	"reflect"
+	"sync"
 )
-
-// TODO: put encbufs in a sync.Pool.
-//     Doing that requires zeroing the buffers after use.
-//     encReader will need to drop it's buffer when done.
 
 var (
 	// Common encoded values.
@@ -112,7 +109,9 @@ func Encode(w io.Writer, val interface{}) error {
 		// Avoid copying by writing to the outer encbuf directly.
 		return outer.encode(val)
 	}
-	eb := newencbuf()
+	eb := encbufPool.Get().(*encbuf)
+	eb.reset()
+	defer encbufPool.Put(eb)
 	if err := eb.encode(val); err != nil {
 		return err
 	}
@@ -122,7 +121,9 @@ func Encode(w io.Writer, val interface{}) error {
 // EncodeBytes returns the RLP encoding of val.
 // Please see the documentation of Encode for the encoding rules.
 func EncodeToBytes(val interface{}) ([]byte, error) {
-	eb := newencbuf()
+	eb := encbufPool.Get().(*encbuf)
+	eb.reset()
+	defer encbufPool.Put(eb)
 	if err := eb.encode(val); err != nil {
 		return nil, err
 	}
@@ -135,7 +136,8 @@ func EncodeToBytes(val interface{}) ([]byte, error) {
 //
 // Please see the documentation of Encode for the encoding rules.
 func EncodeToReader(val interface{}) (size int, r io.Reader, err error) {
-	eb := newencbuf()
+	eb := encbufPool.Get().(*encbuf)
+	eb.reset()
 	if err := eb.encode(val); err != nil {
 		return 0, nil, err
 	}
@@ -182,8 +184,19 @@ func puthead(buf []byte, smalltag, largetag byte, size uint64) int {
 	}
 }
 
-func newencbuf() *encbuf {
-	return &encbuf{sizebuf: make([]byte, 9)}
+// encbufs are pooled.
+var encbufPool = sync.Pool{
+	New: func() interface{} { return &encbuf{sizebuf: make([]byte, 9)} },
+}
+
+func (w *encbuf) reset() {
+	w.lhsize = 0
+	if w.str != nil {
+		w.str = w.str[:0]
+	}
+	if w.lheads != nil {
+		w.lheads = w.lheads[:0]
+	}
 }
 
 // encbuf implements io.Writer so it can be passed it into EncodeRLP.
@@ -295,6 +308,8 @@ type encReader struct {
 func (r *encReader) Read(b []byte) (n int, err error) {
 	for {
 		if r.piece = r.next(); r.piece == nil {
+			encbufPool.Put(r.buf)
+			r.buf = nil
 			return n, io.EOF
 		}
 		nn := copy(b[n:], r.piece)
@@ -313,6 +328,9 @@ func (r *encReader) Read(b []byte) (n int, err error) {
 // it returns nil at EOF.
 func (r *encReader) next() []byte {
 	switch {
+	case r.buf == nil:
+		return nil
+
 	case r.piece != nil:
 		// There is still data available for reading.
 		return r.piece

--- a/rlp/encode_test.go
+++ b/rlp/encode_test.go
@@ -189,15 +189,6 @@ var encTests = []encTest{
 	{val: &recstruct{5, nil}, output: "C205C0"},
 	{val: &recstruct{5, &recstruct{4, &recstruct{3, nil}}}, output: "C605C404C203C0"},
 
-	// flat
-	{val: Flat(uint(1)), error: "rlp.Flat: uint did not encode as list"},
-	{val: Flat(simplestruct{A: 3, B: "foo"}), output: "0383666F6F"},
-	{
-		// value generates more list headers after the Flat
-		val:    []interface{}{"foo", []uint{1, 2}, Flat([]uint{3, 4}), []uint{5, 6}, "bar"},
-		output: "D083666F6FC201020304C2050683626172",
-	},
-
 	// nil
 	{val: (*uint)(nil), output: "80"},
 	{val: (*string)(nil), output: "80"},

--- a/rpc/api/eth.go
+++ b/rpc/api/eth.go
@@ -348,14 +348,6 @@ func (self *ethApi) GetBlockByNumber(req *shared.Request) (interface{}, error) {
 
 	block := self.xeth.EthBlockByNumber(args.BlockNumber)
 	br := NewBlockRes(block, args.IncludeTxs)
-	// If request was for "pending", nil nonsensical fields
-	if args.BlockNumber == -2 {
-		br.BlockHash = nil
-		br.BlockNumber = nil
-		br.Miner = nil
-		br.Nonce = nil
-		br.LogsBloom = nil
-	}
 	return br, nil
 }
 

--- a/rpc/api/parsing.go
+++ b/rpc/api/parsing.go
@@ -270,29 +270,31 @@ func NewBlockRes(block *types.Block, fullTx bool) *BlockRes {
 	res.BlockHash = newHexData(block.Hash())
 	res.ParentHash = newHexData(block.ParentHash())
 	res.Nonce = newHexData(block.Nonce())
-	res.Sha3Uncles = newHexData(block.Header().UncleHash)
+	res.Sha3Uncles = newHexData(block.UncleHash())
 	res.LogsBloom = newHexData(block.Bloom())
-	res.TransactionRoot = newHexData(block.Header().TxHash)
+	res.TransactionRoot = newHexData(block.TxHash())
 	res.StateRoot = newHexData(block.Root())
-	res.Miner = newHexData(block.Header().Coinbase)
+	res.Miner = newHexData(block.Coinbase())
 	res.Difficulty = newHexNum(block.Difficulty())
 	res.TotalDifficulty = newHexNum(block.Td)
 	res.Size = newHexNum(block.Size().Int64())
-	res.ExtraData = newHexData(block.Header().Extra)
+	res.ExtraData = newHexData(block.Extra())
 	res.GasLimit = newHexNum(block.GasLimit())
 	res.GasUsed = newHexNum(block.GasUsed())
 	res.UnixTimestamp = newHexNum(block.Time())
 
-	res.Transactions = make([]*TransactionRes, len(block.Transactions()))
-	for i, tx := range block.Transactions() {
+	txs := block.Transactions()
+	res.Transactions = make([]*TransactionRes, len(txs))
+	for i, tx := range txs {
 		res.Transactions[i] = NewTransactionRes(tx)
 		res.Transactions[i].BlockHash = res.BlockHash
 		res.Transactions[i].BlockNumber = res.BlockNumber
 		res.Transactions[i].TxIndex = newHexNum(i)
 	}
 
-	res.Uncles = make([]*UncleRes, len(block.Uncles()))
-	for i, uncle := range block.Uncles() {
+	uncles := block.Uncles()
+	res.Uncles = make([]*UncleRes, len(uncles))
+	for i, uncle := range uncles {
 		res.Uncles[i] = NewUncleRes(uncle)
 	}
 

--- a/tests/block_test_util.go
+++ b/tests/block_test_util.go
@@ -245,7 +245,7 @@ func (t *BlockTest) TryBlocksInsert(chainManager *core.ChainManager) error {
 			if b.BlockHeader == nil {
 				continue // OK - block is supposed to be invalid, continue with next block
 			} else {
-				return fmt.Errorf("Block RLP decoding failed when expected to succeed: ", err)
+				return fmt.Errorf("Block RLP decoding failed when expected to succeed: %v", err)
 			}
 		}
 		// RLP decoding worked, try to insert into chain:
@@ -254,7 +254,7 @@ func (t *BlockTest) TryBlocksInsert(chainManager *core.ChainManager) error {
 			if b.BlockHeader == nil {
 				continue // OK - block is supposed to be invalid, continue with next block
 			} else {
-				return fmt.Errorf("Block insertion into chain failed: ", err)
+				return fmt.Errorf("Block insertion into chain failed: %v", err)
 			}
 		}
 		if b.BlockHeader == nil {
@@ -262,7 +262,7 @@ func (t *BlockTest) TryBlocksInsert(chainManager *core.ChainManager) error {
 		}
 		err = t.validateBlockHeader(b.BlockHeader, cb.Header())
 		if err != nil {
-			return fmt.Errorf("Block header validation failed: ", err)
+			return fmt.Errorf("Block header validation failed: %v", err)
 		}
 	}
 	return nil
@@ -286,7 +286,7 @@ func (s *BlockTest) validateBlockHeader(h *btHeader, h2 *types.Header) error {
 
 	expectedNonce := mustConvertBytes(h.Nonce)
 	if !bytes.Equal(expectedNonce, h2.Nonce[:]) {
-		return fmt.Errorf("Nonce: expected: %v, decoded: %v", expectedNonce, h2.Nonce[:])
+		return fmt.Errorf("Nonce: expected: %v, decoded: %v", expectedNonce, h2.Nonce)
 	}
 
 	expectedNumber := mustConvertBigInt(h.Number, 16)
@@ -423,9 +423,8 @@ func mustConvertHeader(in btHeader) *types.Header {
 		GasLimit:    mustConvertBigInt(in.GasLimit, 16),
 		Difficulty:  mustConvertBigInt(in.Difficulty, 16),
 		Time:        mustConvertUint(in.Timestamp, 16),
+		Nonce:       types.EncodeNonce(mustConvertUint(in.Nonce, 16)),
 	}
-	// XXX cheats? :-)
-	header.SetNonce(mustConvertUint(in.Nonce, 16))
 	return header
 }
 

--- a/tests/transaction_test_util.go
+++ b/tests/transaction_test_util.go
@@ -152,54 +152,53 @@ func verifyTxFields(txTest TransactionTest, decodedTx *types.Transaction) (err e
 	}
 
 	expectedData := mustConvertBytes(txTest.Transaction.Data)
-	if !bytes.Equal(expectedData, decodedTx.Payload) {
-		return fmt.Errorf("Tx input data mismatch: %#v %#v", expectedData, decodedTx.Payload)
+	if !bytes.Equal(expectedData, decodedTx.Data()) {
+		return fmt.Errorf("Tx input data mismatch: %#v %#v", expectedData, decodedTx.Data())
 	}
 
 	expectedGasLimit := mustConvertBigInt(txTest.Transaction.GasLimit, 16)
-	if expectedGasLimit.Cmp(decodedTx.GasLimit) != 0 {
-		return fmt.Errorf("GasLimit mismatch: %v %v", expectedGasLimit, decodedTx.GasLimit)
+	if expectedGasLimit.Cmp(decodedTx.Gas()) != 0 {
+		return fmt.Errorf("GasLimit mismatch: %v %v", expectedGasLimit, decodedTx.Gas())
 	}
 
 	expectedGasPrice := mustConvertBigInt(txTest.Transaction.GasPrice, 16)
-	if expectedGasPrice.Cmp(decodedTx.Price) != 0 {
-		return fmt.Errorf("GasPrice mismatch: %v %v", expectedGasPrice, decodedTx.Price)
+	if expectedGasPrice.Cmp(decodedTx.GasPrice()) != 0 {
+		return fmt.Errorf("GasPrice mismatch: %v %v", expectedGasPrice, decodedTx.GasPrice())
 	}
 
 	expectedNonce := mustConvertUint(txTest.Transaction.Nonce, 16)
-	if expectedNonce != decodedTx.AccountNonce {
-		return fmt.Errorf("Nonce mismatch: %v %v", expectedNonce, decodedTx.AccountNonce)
+	if expectedNonce != decodedTx.Nonce() {
+		return fmt.Errorf("Nonce mismatch: %v %v", expectedNonce, decodedTx.Nonce())
 	}
 
-	expectedR := common.Bytes2Big(mustConvertBytes(txTest.Transaction.R))
-	if expectedR.Cmp(decodedTx.R) != 0 {
-		return fmt.Errorf("R mismatch: %v %v", expectedR, decodedTx.R)
+	v, r, s := decodedTx.SignatureValues()
+	expectedR := mustConvertBigInt(txTest.Transaction.R, 16)
+	if r.Cmp(expectedR) != 0 {
+		return fmt.Errorf("R mismatch: %v %v", expectedR, r)
 	}
-
-	expectedS := common.Bytes2Big(mustConvertBytes(txTest.Transaction.S))
-	if expectedS.Cmp(decodedTx.S) != 0 {
-		return fmt.Errorf("S mismatch: %v %v", expectedS, decodedTx.S)
+	expectedS := mustConvertBigInt(txTest.Transaction.S, 16)
+	if s.Cmp(expectedS) != 0 {
+		return fmt.Errorf("S mismatch: %v %v", expectedS, s)
 	}
-
 	expectedV := mustConvertUint(txTest.Transaction.V, 16)
-	if expectedV != uint64(decodedTx.V) {
-		return fmt.Errorf("V mismatch: %v %v", expectedV, uint64(decodedTx.V))
+	if uint64(v) != expectedV {
+		return fmt.Errorf("V mismatch: %v %v", expectedV, v)
 	}
 
 	expectedTo := mustConvertAddress(txTest.Transaction.To)
-	if decodedTx.Recipient == nil {
+	if decodedTx.To() == nil {
 		if expectedTo != common.BytesToAddress([]byte{}) { // "empty" or "zero" address
 			return fmt.Errorf("To mismatch when recipient is nil (contract creation): %v", expectedTo)
 		}
 	} else {
-		if expectedTo != *decodedTx.Recipient {
-			return fmt.Errorf("To mismatch: %v %v", expectedTo, *decodedTx.Recipient)
+		if expectedTo != *decodedTx.To() {
+			return fmt.Errorf("To mismatch: %v %v", expectedTo, *decodedTx.To())
 		}
 	}
 
 	expectedValue := mustConvertBigInt(txTest.Transaction.Value, 16)
-	if expectedValue.Cmp(decodedTx.Amount) != 0 {
-		return fmt.Errorf("Value mismatch: %v %v", expectedValue, decodedTx.Amount)
+	if expectedValue.Cmp(decodedTx.Value()) != 0 {
+		return fmt.Errorf("Value mismatch: %v %v", expectedValue, decodedTx.Value())
 	}
 
 	return nil

--- a/xeth/xeth.go
+++ b/xeth/xeth.go
@@ -209,8 +209,8 @@ func (self *XEth) AtStateNum(num int64) *XEth {
 // - could be removed in favour of mining on testdag (natspec e2e + networking)
 // + filters
 func (self *XEth) ApplyTestTxs(statedb *state.StateDB, address common.Address, txc uint64) (uint64, *XEth) {
-
-	block := self.backend.ChainManager().NewBlock(address)
+	chain := self.backend.ChainManager()
+	header := chain.CurrentBlock().Header()
 	coinbase := statedb.GetStateObject(address)
 	coinbase.SetGasLimit(big.NewInt(10000000))
 	txs := self.backend.TxPool().GetQueuedTransactions()
@@ -218,7 +218,7 @@ func (self *XEth) ApplyTestTxs(statedb *state.StateDB, address common.Address, t
 	for i := 0; i < len(txs); i++ {
 		for _, tx := range txs {
 			if tx.Nonce() == txc {
-				_, _, err := core.ApplyMessage(core.NewEnv(statedb, self.backend.ChainManager(), tx, block), tx, coinbase)
+				_, _, err := core.ApplyMessage(core.NewEnv(statedb, self.backend.ChainManager(), tx, header), tx, coinbase)
 				if err != nil {
 					panic(err)
 				}
@@ -845,8 +845,8 @@ func (self *XEth) Call(fromStr, toStr, valueStr, gasStr, gasPriceStr, dataStr st
 		msg.gasPrice = self.DefaultGasPrice()
 	}
 
-	block := self.CurrentBlock()
-	vmenv := core.NewEnv(statedb, self.backend.ChainManager(), msg, block)
+	header := self.CurrentBlock().Header()
+	vmenv := core.NewEnv(statedb, self.backend.ChainManager(), msg, header)
 
 	res, gas, err := core.ApplyMessage(vmenv, msg, from)
 	return common.ToHex(res), gas.String(), err

--- a/xeth/xeth.go
+++ b/xeth/xeth.go
@@ -946,51 +946,45 @@ func (self *XEth) Transact(fromStr, toStr, nonceStr, valueStr, gasStr, gasPriceS
 
 	// TODO: align default values to have the same type, e.g. not depend on
 	// common.Value conversions later on
-
-	var tx *types.Transaction
-	if contractCreation {
-		tx = types.NewContractCreationTx(value, gas, price, data)
-	} else {
-		tx = types.NewTransactionMessage(to, value, gas, price, data)
-	}
-
-	state := self.backend.TxPool().State()
-
 	var nonce uint64
 	if len(nonceStr) != 0 {
 		nonce = common.Big(nonceStr).Uint64()
 	} else {
+		state := self.backend.TxPool().State()
 		nonce = state.GetNonce(from)
 	}
-	tx.SetNonce(nonce)
+	var tx *types.Transaction
+	if contractCreation {
+		tx = types.NewContractCreation(nonce, value, gas, price, data)
+	} else {
+		tx = types.NewTransaction(nonce, to, value, gas, price, data)
+	}
 
-	if err := self.sign(tx, from, false); err != nil {
+	signed, err := self.sign(tx, from, false)
+	if err != nil {
 		return "", err
 	}
-	if err := self.backend.TxPool().Add(tx); err != nil {
+	if err = self.backend.TxPool().Add(signed); err != nil {
 		return "", err
 	}
-	//state.SetNonce(from, nonce+1)
 
 	if contractCreation {
 		addr := core.AddressFromMessage(tx)
 		glog.V(logger.Info).Infof("Tx(%x) created: %x\n", tx.Hash(), addr)
-
-		return core.AddressFromMessage(tx).Hex(), nil
+		return addr.Hex(), nil
 	} else {
 		glog.V(logger.Info).Infof("Tx(%x) to: %x\n", tx.Hash(), tx.To())
 	}
 	return tx.Hash().Hex(), nil
 }
 
-func (self *XEth) sign(tx *types.Transaction, from common.Address, didUnlock bool) error {
+func (self *XEth) sign(tx *types.Transaction, from common.Address, didUnlock bool) (*types.Transaction, error) {
 	hash := tx.Hash()
 	sig, err := self.doSign(from, hash, didUnlock)
 	if err != nil {
-		return err
+		return tx, err
 	}
-	tx.SetSignatureValues(sig)
-	return nil
+	return tx.WithSignature(sig)
 }
 
 // callmsg is the message type used for call transations.


### PR DESCRIPTION
This PR will make the core consensus-related types immutable.
The rationale for the change is:

* We have a lot of code that modifies blocks. Code that does so must be
  written very carefully to avoid introducing data races and corrupting internal state.
  We have seen hard to debug issues such as #1037 (Uncle Is Ancestor) but couldn't
  find their cause because it is hard see where offending modifications are performed.
* Code that modifies pointer values (`*big.Int`) taken from blocks must be written very
  carefully to prevent inadvertent corruption of internal state.
* We cannot cache blocks (and their hashes, sizes), transactions (and their hashes, sizes, sender
  addresses) in a reliable way because modification is always possible. This hurts performance.

The PR will address the problem in several steps:

- [x] making modification of block (tx, receipt) data impossible at the cost of reducing performance
- [x] introducing benchmarks that capture the performance impact of those changes
- [x] applying (measurable) optimisations to get the performance back
