### PR TITLE
ipc socket always uses default path

### DIFF
--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -308,7 +308,7 @@ func console(ctx *cli.Context) {
 		ethereum,
 		ctx.String(utils.JSpathFlag.Name),
 		ctx.GlobalString(utils.RPCCORSDomainFlag.Name),
-		ctx.GlobalString(utils.IPCPathFlag.Name),
+		filepath.Join(ctx.GlobalString(utils.DataDirFlag.Name), "geth.ipc"),
 		true,
 		nil,
 	)

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -387,7 +387,7 @@ func MakeAccountManager(ctx *cli.Context) *accounts.Manager {
 
 func StartIPC(eth *eth.Ethereum, ctx *cli.Context) error {
 	config := comms.IpcConfig{
-		Endpoint: ctx.GlobalString(IPCPathFlag.Name),
+		Endpoint: filepath.Join(ctx.GlobalString(DataDirFlag.Name), "geth.ipc"),
 	}
 
 	xeth := xeth.New(eth, nil)


### PR DESCRIPTION
In case a user specifies a custom datadir the ipc socket was always created in ${defaultdatadir}. When this directory doesn't exist geth stops with an error.

Closes https://github.com/ethereum/go-ethereum/issues/1246