### PR TITLE
Invalid named pipe name

### DIFF
--- a/cmd/console/main.go
+++ b/cmd/console/main.go
@@ -52,7 +52,6 @@ func init() {
 
 	app.Action = run
 	app.Flags = []cli.Flag{
-		utils.IPCDisabledFlag,
 		utils.IPCPathFlag,
 		utils.VerbosityFlag,
 		utils.JSpathFlag,

--- a/cmd/console/main.go
+++ b/cmd/console/main.go
@@ -93,7 +93,7 @@ func main() {
 
 func run(ctx *cli.Context) {
 	jspath := ctx.GlobalString(utils.JSpathFlag.Name)
-	ipcpath := ctx.GlobalString(utils.IPCPathFlag.Name)
+	ipcpath := utils.IpcSocketPath(ctx)
 
 	repl := newJSRE(jspath, ipcpath)
 	repl.welcome(ipcpath)

--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -308,7 +308,7 @@ func console(ctx *cli.Context) {
 		ethereum,
 		ctx.String(utils.JSpathFlag.Name),
 		ctx.GlobalString(utils.RPCCORSDomainFlag.Name),
-		filepath.Join(ctx.GlobalString(utils.DataDirFlag.Name), "geth.ipc"),
+		utils.IpcSocketPath(ctx),
 		true,
 		nil,
 	)
@@ -330,7 +330,7 @@ func execJSFiles(ctx *cli.Context) {
 		ethereum,
 		ctx.String(utils.JSpathFlag.Name),
 		ctx.GlobalString(utils.RPCCORSDomainFlag.Name),
-		ctx.GlobalString(utils.IPCPathFlag.Name),
+		utils.IpcSocketPath(ctx),
 		false,
 		nil,
 	)

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -385,9 +385,29 @@ func MakeAccountManager(ctx *cli.Context) *accounts.Manager {
 	return accounts.NewManager(ks)
 }
 
+func IpcSocketPath(ctx *cli.Context) (ipcpath string) {
+
+	if common.IsWindows() {
+		ipcpath = common.DefaultIpcPath()
+		if ipcpath != ctx.GlobalString(IPCPathFlag.Name) {
+			ipcpath = ctx.GlobalString(IPCPathFlag.Name)
+		}
+	} else {
+		ipcpath = common.DefaultIpcPath()
+		if ctx.GlobalString(IPCPathFlag.Name) != common.DefaultIpcPath() {
+			ipcpath = ctx.GlobalString(IPCPathFlag.Name)
+		} else if ctx.GlobalString(DataDirFlag.Name) != "" &&
+		ctx.GlobalString(DataDirFlag.Name) != common.DefaultDataDir() {
+			ipcpath = filepath.Join(ctx.GlobalString(DataDirFlag.Name), "geth.ipc")
+		}
+	}
+
+	return
+}
+
 func StartIPC(eth *eth.Ethereum, ctx *cli.Context) error {
 	config := comms.IpcConfig{
-		Endpoint: filepath.Join(ctx.GlobalString(DataDirFlag.Name), "geth.ipc"),
+		Endpoint: IpcSocketPath(ctx),
 	}
 
 	xeth := xeth.New(eth, nil)

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -386,7 +386,6 @@ func MakeAccountManager(ctx *cli.Context) *accounts.Manager {
 }
 
 func IpcSocketPath(ctx *cli.Context) (ipcpath string) {
-
 	if common.IsWindows() {
 		ipcpath = common.DefaultIpcPath()
 		if ipcpath != ctx.GlobalString(IPCPathFlag.Name) {

--- a/common/path.go
+++ b/common/path.go
@@ -95,6 +95,9 @@ func DefaultDataDir() string {
 }
 
 func DefaultIpcPath() string {
+	if runtime.GOOS == "windows" {
+		return `\\.\pipe\geth.ipc`
+	}
 	return filepath.Join(DefaultDataDir(), "geth.ipc")
 }
 


### PR DESCRIPTION
A Windows specific bug was introduced in PR #1245 which causes geth not to start since it uses an invalid name for a named pipe. This PR fixes that issue.