### PR TITLE
p2p: prevent writes at shutdown time

### DIFF
--- a/p2p/peer_test.go
+++ b/p2p/peer_test.go
@@ -121,7 +121,7 @@ func TestPeerDisconnect(t *testing.T) {
 	}
 	select {
 	case reason := <-disc:
-		if reason != DiscQuitting {
+		if reason != DiscRequested {
 			t.Errorf("run returned wrong reason: got %v, want %v", reason, DiscRequested)
 		}
 	case <-time.After(500 * time.Millisecond):


### PR DESCRIPTION
This PR fixes a bug in package p2p that allowed network writes to start after disconnect was requested
(e.g. through `Server.Stop`). It may or may not help with #1233.