### PR TITLE
eth_sendRawTransaction JSON RPC 

### DIFF
--- a/rpc/api.go
+++ b/rpc/api.go
@@ -171,7 +171,7 @@ func (api *EthereumApi) GetRequestReply(req *RpcRequest, reply *interface{}) err
 		*reply = v
 
 	case "eth_sendRawTransaction":
-		args := new(NewSigArgs)
+		args := new(NewDataArgs)
 		if err := json.Unmarshal(req.Params, &args); err != nil {
 			return err
 		}

--- a/rpc/api.go
+++ b/rpc/api.go
@@ -170,6 +170,17 @@ func (api *EthereumApi) GetRequestReply(req *RpcRequest, reply *interface{}) err
 		}
 		*reply = v
 
+	case "eth_pushTx":
+		args := new(NewSigArgs)
+		if err := json.Unmarshal(req.Params, &args); err != nil {
+			return err
+		}
+		v, err := api.xeth().PushTx(args.encodedTx)
+		if err != nil {
+			return err
+		}
+		*reply = v
+
 	case "eth_sendTransaction", "eth_transact":
 		args := new(NewTxArgs)
 		if err := json.Unmarshal(req.Params, &args); err != nil {

--- a/rpc/api.go
+++ b/rpc/api.go
@@ -175,7 +175,7 @@ func (api *EthereumApi) GetRequestReply(req *RpcRequest, reply *interface{}) err
 		if err := json.Unmarshal(req.Params, &args); err != nil {
 			return err
 		}
-		v, err := api.xeth().PushTx(args.encodedTx)
+		v, err := api.xeth().PushTx(args.Data)
 		if err != nil {
 			return err
 		}

--- a/rpc/api.go
+++ b/rpc/api.go
@@ -170,7 +170,7 @@ func (api *EthereumApi) GetRequestReply(req *RpcRequest, reply *interface{}) err
 		}
 		*reply = v
 
-	case "eth_pushTx":
+	case "eth_sendRawTransaction":
 		args := new(NewSigArgs)
 		if err := json.Unmarshal(req.Params, &args); err != nil {
 			return err

--- a/rpc/api/eth.go
+++ b/rpc/api/eth.go
@@ -255,13 +255,7 @@ func (self *ethApi) PushTx(req *shared.Request) (interface{}, error) {
 		return nil, shared.NewDecodeParamError(err.Error())
 	}
 
-	// nonce may be nil ("guess" mode)
-	var nonce string
-	if args.Nonce != nil {
-		nonce = args.Nonce.String()
-	}
-
-	v, err := self.xeth.PushTx(args.encodedTx)
+	v, err := self.xeth.PushTx(args.Data)
 	if err != nil {
 		return nil, err
 	}

--- a/rpc/api/eth.go
+++ b/rpc/api/eth.go
@@ -46,6 +46,7 @@ var (
 		"eth_getData":                           (*ethApi).GetData,
 		"eth_getCode":                           (*ethApi).GetData,
 		"eth_sign":                              (*ethApi).Sign,
+		"eth_pushTx":                            (*ethApi).PushTx,
 		"eth_sendTransaction":                   (*ethApi).SendTransaction,
 		"eth_transact":                          (*ethApi).SendTransaction,
 		"eth_estimateGas":                       (*ethApi).EstimateGas,
@@ -241,6 +242,26 @@ func (self *ethApi) Sign(req *shared.Request) (interface{}, error) {
 		return nil, shared.NewDecodeParamError(err.Error())
 	}
 	v, err := self.xeth.Sign(args.From, args.Data, false)
+	if err != nil {
+		return nil, err
+	}
+	return v, nil
+}
+
+
+func (self *ethApi) PushTx(req *shared.Request) (interface{}, error) {
+	args := new(NewTxArgs)
+	if err := self.codec.Decode(req.Params, &args); err != nil {
+		return nil, shared.NewDecodeParamError(err.Error())
+	}
+
+	// nonce may be nil ("guess" mode)
+	var nonce string
+	if args.Nonce != nil {
+		nonce = args.Nonce.String()
+	}
+
+	v, err := self.xeth.PushTx(args.encodedTx)
 	if err != nil {
 		return nil, err
 	}

--- a/rpc/api/eth.go
+++ b/rpc/api/eth.go
@@ -46,7 +46,7 @@ var (
 		"eth_getData":                           (*ethApi).GetData,
 		"eth_getCode":                           (*ethApi).GetData,
 		"eth_sign":                              (*ethApi).Sign,
-		"eth_pushTx":                            (*ethApi).PushTx,
+		"eth_sendRawTransaction":                (*ethApi).PushTx,
 		"eth_sendTransaction":                   (*ethApi).SendTransaction,
 		"eth_transact":                          (*ethApi).SendTransaction,
 		"eth_estimateGas":                       (*ethApi).EstimateGas,

--- a/rpc/api/eth.go
+++ b/rpc/api/eth.go
@@ -250,7 +250,7 @@ func (self *ethApi) Sign(req *shared.Request) (interface{}, error) {
 
 
 func (self *ethApi) PushTx(req *shared.Request) (interface{}, error) {
-	args := new(NewTxArgs)
+	args := new(NewSigArgs)
 	if err := self.codec.Decode(req.Params, &args); err != nil {
 		return nil, shared.NewDecodeParamError(err.Error())
 	}

--- a/rpc/api/eth.go
+++ b/rpc/api/eth.go
@@ -250,7 +250,7 @@ func (self *ethApi) Sign(req *shared.Request) (interface{}, error) {
 
 
 func (self *ethApi) PushTx(req *shared.Request) (interface{}, error) {
-	args := new(NewSigArgs)
+	args := new(NewDataArgs)
 	if err := self.codec.Decode(req.Params, &args); err != nil {
 		return nil, shared.NewDecodeParamError(err.Error())
 	}

--- a/rpc/api/eth_args.go
+++ b/rpc/api/eth_args.go
@@ -226,6 +226,35 @@ func (args *GetDataArgs) UnmarshalJSON(b []byte) (err error) {
 	return nil
 }
 
+type NewDataArgs struct {
+    Data string
+}
+
+func (args *NewDataArgs) UnmarshalJSON(b []byte) (err error) {
+    var obj []interface{}
+
+    if err := json.Unmarshal(b, &obj); err != nil {
+        return shared.NewDecodeParamError(err.Error())
+    }
+
+    // Check for sufficient params
+    if len(obj) < 1 {
+        return shared.NewInsufficientParamsError(len(obj), 1)
+    }
+
+    data, ok := obj[0].(string)
+    if !ok {
+        return shared.NewInvalidTypeError("data", "not a string")
+    }
+    args.Data = data
+
+    if len(args.Data) == 0 {
+        return shared.NewValidationError("data", "is required")
+    }
+
+    return nil
+}
+
 type NewSigArgs struct {
 	From string
 	Data string

--- a/rpc/api/utils.go
+++ b/rpc/api/utils.go
@@ -51,6 +51,7 @@ var (
 			"getData",
 			"getCode",
 			"sign",
+			"pushTx",
 			"sendTransaction",
 			"transact",
 			"estimateGas",

--- a/rpc/api/utils.go
+++ b/rpc/api/utils.go
@@ -51,7 +51,7 @@ var (
 			"getData",
 			"getCode",
 			"sign",
-			"pushTx",
+			"eth_sendRawTransaction",
 			"sendTransaction",
 			"transact",
 			"estimateGas",

--- a/rpc/api/utils.go
+++ b/rpc/api/utils.go
@@ -51,7 +51,7 @@ var (
 			"getData",
 			"getCode",
 			"sign",
-			"eth_sendRawTransaction",
+			"sendRawTransaction",
 			"sendTransaction",
 			"transact",
 			"estimateGas",

--- a/rpc/args.go
+++ b/rpc/args.go
@@ -154,6 +154,35 @@ func (args *GetBlockByNumberArgs) UnmarshalJSON(b []byte) (err error) {
 	return nil
 }
 
+type NewDataArgs struct {
+    Data string
+}
+
+func (args *NewDataArgs) UnmarshalJSON(b []byte) (err error) {
+    var obj []interface{}
+
+    if err := json.Unmarshal(b, &obj); err != nil {
+        return NewDecodeParamError(err.Error())
+    }
+
+    // Check for sufficient params
+    if len(obj) < 1 {
+        return NewInsufficientParamsError(len(obj), 1)
+    }
+
+    data, ok := obj[0].(string)
+    if !ok {
+        return NewInvalidTypeError("data", "not a string")
+    }
+    args.Data = data
+
+    if len(args.Data) == 0 {
+        return NewValidationError("data", "is required")
+    }
+
+    return nil
+}
+
 type NewTxArgs struct {
 	From     string
 	To       string

--- a/xeth/xeth.go
+++ b/xeth/xeth.go
@@ -787,9 +787,6 @@ func (self *XEth) FromNumber(str string) string {
 
 func (self *XEth) PushTx(encodedTx string) (string, error) {
 	tx := types.NewTransactionFromBytes(common.FromHex(encodedTx))
-
-	glog.V(logger.Info).Infof("Tx(%x) gas: %x\n", tx.Hash(), tx.Gas())
-
 	err := self.backend.TxPool().Add(tx)
 	if err != nil {
 		return "", err
@@ -968,7 +965,7 @@ func (self *XEth) Transact(fromStr, toStr, nonceStr, valueStr, gasStr, gasPriceS
 
 		return core.AddressFromMessage(tx).Hex(), nil
 	} else {
-		glog.V(logger.Info).Infof("YEYEYE!! Tx(%x) to: %x\n, gas: %x", tx.Hash(), tx.To(), tx.Gas())
+		glog.V(logger.Info).Infof("Tx(%x) to: %x\n", tx.Hash(), tx.To())
 	}
 	return tx.Hash().Hex(), nil
 }

--- a/xeth/xeth.go
+++ b/xeth/xeth.go
@@ -787,6 +787,9 @@ func (self *XEth) FromNumber(str string) string {
 
 func (self *XEth) PushTx(encodedTx string) (string, error) {
 	tx := types.NewTransactionFromBytes(common.FromHex(encodedTx))
+
+	glog.V(logger.Info).Infof("Tx(%x) gas: %x\n", tx.Hash(), tx.Gas())
+
 	err := self.backend.TxPool().Add(tx)
 	if err != nil {
 		return "", err
@@ -965,7 +968,7 @@ func (self *XEth) Transact(fromStr, toStr, nonceStr, valueStr, gasStr, gasPriceS
 
 		return core.AddressFromMessage(tx).Hex(), nil
 	} else {
-		glog.V(logger.Info).Infof("Tx(%x) to: %x\n", tx.Hash(), tx.To())
+		glog.V(logger.Info).Infof("YEYEYE!! Tx(%x) to: %x\n, gas: %x", tx.Hash(), tx.To(), tx.Gas())
 	}
 	return tx.Hash().Hex(), nil
 }

--- a/xeth/xeth.go
+++ b/xeth/xeth.go
@@ -794,8 +794,12 @@ func (self *XEth) PushTx(encodedTx string) (string, error) {
 
 	if tx.To() == nil {
 		addr := core.AddressFromMessage(tx)
+		glog.V(logger.Info).Infof("Tx(%x) created: %x\n", tx.Hash(), addr)
 		return addr.Hex(), nil
+	} else {
+		glog.V(logger.Info).Infof("Tx(%x) to: %x\n", tx.Hash(), tx.To())
 	}
+
 	return tx.Hash().Hex(), nil
 }
 


### PR DESCRIPTION
I'm still testing this, but this should allow signed transactions to be sent to JSON RPC. It uses the pushTx method, which I believe is the right approach for sending signed transaction packets to the chain. Thoughts?

Closes #1071