### PR TITLE
added batch mode to console

### DIFF
--- a/cmd/console/js.go
+++ b/cmd/console/js.go
@@ -332,11 +332,13 @@ func (self *jsre) welcome(ipcpath string) {
 
 func (self *jsre) batch(args cli.Args) {
 	statement := strings.Join(args, " ")
-
 	val, err := self.re.Run(statement)
 
 	if err != nil {
 		fmt.Printf("error: %v", err)
+	} else if val.IsDefined() && val.IsObject() {
+		obj, _ := self.re.Get("ret_result")
+		fmt.Printf("%v", obj)
 	} else if val.IsDefined() {
 		fmt.Printf("%v", val)
 	}
@@ -346,7 +348,6 @@ func (self *jsre) batch(args cli.Args) {
 	}
 
 	self.re.Stop(false)
-	
 }
 
 func (self *jsre) interactive(ipcpath string) {

--- a/cmd/console/js.go
+++ b/cmd/console/js.go
@@ -30,6 +30,7 @@ import (
 
 	"sort"
 
+	"github.com/codegangsta/cli"
 	"github.com/ethereum/go-ethereum/cmd/utils"
 	"github.com/ethereum/go-ethereum/common/docserver"
 	re "github.com/ethereum/go-ethereum/jsre"
@@ -329,7 +330,28 @@ func (self *jsre) welcome(ipcpath string) {
 	}
 }
 
-func (self *jsre) interactive() {
+func (self *jsre) batch(args cli.Args) {
+	statement := strings.Join(args, " ")
+
+	val, err := self.re.Run(statement)
+
+	if err != nil {
+		fmt.Printf("error: %v", err)
+	} else if val.IsDefined() {
+		fmt.Printf("%v", val)
+	}
+
+	if self.atexit != nil {
+		self.atexit()
+	}
+
+	self.re.Stop(false)
+	
+}
+
+func (self *jsre) interactive(ipcpath string) {
+	self.welcome(ipcpath)
+
 	// Read input lines.
 	prompt := make(chan string)
 	inputln := make(chan string)

--- a/cmd/console/main.go
+++ b/cmd/console/main.go
@@ -40,7 +40,7 @@ const (
 var (
 	gitCommit       string // set via linker flag
 	nodeNameVersion string
-	app             = utils.NewApp(Version, "the ether console")
+	app             = utils.NewApp(Version, "the geth console")
 )
 
 func init() {
@@ -93,8 +93,11 @@ func main() {
 func run(ctx *cli.Context) {
 	jspath := ctx.GlobalString(utils.JSpathFlag.Name)
 	ipcpath := utils.IpcSocketPath(ctx)
-
 	repl := newJSRE(jspath, ipcpath)
-	repl.welcome(ipcpath)
-	repl.interactive()
+
+	if ctx.Args().Present() {
+		repl.batch(ctx.Args())
+	} else {
+		repl.interactive(ipcpath)
+	}
 }


### PR DESCRIPTION
This PR will allow allows for an argument to be passed on the console which is executed in the javascript runtime. Any results are printed to stdout without formatting. When an object is returned it is printed in json format. This closes #1253.

```
± |console-batch ✗| → ./build/bin/console 'eth.blockNumber'
607008
```
Or execute a script:
```
± |console-batch ✗| → ./build/bin/console 'loadScript("/home/bas/Temp/checkbalances.js")'
eth.accounts[0]: 0x185b6a2c66239ac4787fc078c8b3676dab4856c8 	balance: 0.71902075186783521 ether
eth.accounts[1]: 0x30301c4f6212c94e3d9ae794f786f84baa323085 	balance: 151.577699905644506003 ether
eth.accounts[2]: 0x5d664d9561c8fd8cb5c7663af370cafd77d95295 	balance: 0 ether
eth.accounts[3]: 0x5f3f3622e1348d598e3ac0d71d4fb71e63cfa6e6 	balance: 7.34294755e-10 ether
eth.accounts[4]: 0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b 	balance: 29.905767527535963712 ether
eth.accounts[5]: 0xb343e919eefdfcd73a784d8af61d84f08dbd217d 	balance: 0.01 ether
eth.accounts[6]: 0xe065fe0ca3dd79b8ad664d954693df29892116fb 	balance: 0 ether
true
```
Object parsing.
```
± |console-batch ✗| → ./build/bin/console 'eth.getBlock(eth.blockNumber)' | jq ".transactions"
[
  "0x47bc27248c6c89de38a0391b52d25ab5be78a7a60125ad9a8ce460bd0c71f4c9",
  "0xabad2e7cd78df35b72ecc095aa6e65fea3f5d493019775f43cb0badc8fce411e",
  "0x7387f4c0a5dcda4f8d8d31d65219eb56022a29fd623980afaac0f47d64fa9723"
]


