### PR TITLE
core/state: cleanup & optimisations

### DIFF
--- a/common/types.go
+++ b/common/types.go
@@ -62,6 +62,10 @@ func (h Hash) Generate(rand *rand.Rand, size int) reflect.Value {
 	return reflect.ValueOf(h)
 }
 
+func EmptyHash(h Hash) bool {
+	return h == Hash{}
+}
+
 /////////// Address
 func BytesToAddress(b []byte) Address {
 	var a Address

--- a/core/block_processor.go
+++ b/core/block_processor.go
@@ -249,15 +249,13 @@ func (sm *BlockProcessor) processWithParent(block, parent *types.Block) (logs st
 	// Sync the current block's state to the database
 	state.Sync()
 
-	go func() {
-		// This puts transactions in a extra db for rpc
-		for i, tx := range block.Transactions() {
-			putTx(sm.extraDb, tx, block, uint64(i))
-		}
+	// This puts transactions in a extra db for rpc
+	for i, tx := range block.Transactions() {
+		putTx(sm.extraDb, tx, block, uint64(i))
+	}
 
-		// store the receipts
-		putReceipts(sm.extraDb, block.Hash(), receipts)
-	}()
+	// store the receipts
+	putReceipts(sm.extraDb, block.Hash(), receipts)
 
 	return state.Logs(), nil
 }

--- a/core/block_processor.go
+++ b/core/block_processor.go
@@ -185,7 +185,7 @@ func (sm *BlockProcessor) processWithParent(block, parent *types.Block) (logs st
 	state := state.New(parent.Root(), sm.db)
 
 	// Block validation
-	if err = sm.ValidateHeader(block.Header(), parent.Header(), false); err != nil {
+	if err = ValidateHeader(sm.Pow, block.Header(), parent.Header(), false); err != nil {
 		return
 	}
 
@@ -260,67 +260,6 @@ func (sm *BlockProcessor) processWithParent(block, parent *types.Block) (logs st
 	return state.Logs(), nil
 }
 
-// See YP section 4.3.4. "Block Header Validity"
-// Validates a block. Returns an error if the block is invalid.
-func (sm *BlockProcessor) ValidateHeader(block, parent *types.Header, checkPow bool) error {
-	if big.NewInt(int64(len(block.Extra))).Cmp(params.MaximumExtraDataSize) == 1 {
-		return fmt.Errorf("Block extra data too long (%d)", len(block.Extra))
-	}
-
-	expd := CalcDifficulty(block, parent)
-	if expd.Cmp(block.Difficulty) != 0 {
-		return fmt.Errorf("Difficulty check failed for block %v, %v", block.Difficulty, expd)
-	}
-
-	a := new(big.Int).Sub(block.GasLimit, parent.GasLimit)
-	a.Abs(a)
-	b := new(big.Int).Div(parent.GasLimit, params.GasLimitBoundDivisor)
-	if !(a.Cmp(b) < 0) || (block.GasLimit.Cmp(params.MinGasLimit) == -1) {
-		return fmt.Errorf("GasLimit check failed for block %v (%v > %v)", block.GasLimit, a, b)
-	}
-
-	if int64(block.Time) > time.Now().Unix() {
-		return BlockFutureErr
-	}
-
-	if new(big.Int).Sub(block.Number, parent.Number).Cmp(big.NewInt(1)) != 0 {
-		return BlockNumberErr
-	}
-
-	if block.Time <= parent.Time {
-		return BlockEqualTSErr //ValidationError("Block timestamp equal or less than previous block (%v - %v)", block.Time, parent.Time)
-	}
-
-	if checkPow {
-		// Verify the nonce of the block. Return an error if it's not valid
-		if !sm.Pow.Verify(types.NewBlockWithHeader(block)) {
-			return ValidationError("Block's nonce is invalid (= %x)", block.Nonce)
-		}
-	}
-
-	return nil
-}
-
-func AccumulateRewards(statedb *state.StateDB, block *types.Block) {
-	reward := new(big.Int).Set(BlockReward)
-
-	for _, uncle := range block.Uncles() {
-		num := new(big.Int).Add(big.NewInt(8), uncle.Number)
-		num.Sub(num, block.Number())
-
-		r := new(big.Int)
-		r.Mul(BlockReward, num)
-		r.Div(r, big.NewInt(8))
-
-		statedb.AddBalance(uncle.Coinbase, r)
-
-		reward.Add(reward, new(big.Int).Div(BlockReward, big.NewInt(32)))
-	}
-
-	// Get the account associated with the coinbase
-	statedb.AddBalance(block.Header().Coinbase, reward)
-}
-
 func (sm *BlockProcessor) VerifyUncles(statedb *state.StateDB, block, parent *types.Block) error {
 	ancestors := set.New()
 	uncles := set.New()
@@ -358,7 +297,7 @@ func (sm *BlockProcessor) VerifyUncles(statedb *state.StateDB, block, parent *ty
 			return UncleError("uncle[%d](%x)'s parent is not ancestor (%x)", i, hash[:4], uncle.ParentHash[0:4])
 		}
 
-		if err := sm.ValidateHeader(uncle, ancestorHeaders[uncle.ParentHash], true); err != nil {
+		if err := ValidateHeader(sm.Pow, uncle, ancestorHeaders[uncle.ParentHash], true); err != nil {
 			return ValidationError(fmt.Sprintf("uncle[%d](%x) header invalid: %v", i, hash[:4], err))
 		}
 	}
@@ -393,6 +332,67 @@ func (sm *BlockProcessor) GetLogs(block *types.Block) (logs state.Logs, err erro
 	sm.TransitionState(state, parent, block, true)
 
 	return state.Logs(), nil
+}
+
+// See YP section 4.3.4. "Block Header Validity"
+// Validates a block. Returns an error if the block is invalid.
+func ValidateHeader(pow pow.PoW, block, parent *types.Header, checkPow bool) error {
+	if big.NewInt(int64(len(block.Extra))).Cmp(params.MaximumExtraDataSize) == 1 {
+		return fmt.Errorf("Block extra data too long (%d)", len(block.Extra))
+	}
+
+	expd := CalcDifficulty(block, parent)
+	if expd.Cmp(block.Difficulty) != 0 {
+		return fmt.Errorf("Difficulty check failed for block %v, %v", block.Difficulty, expd)
+	}
+
+	a := new(big.Int).Sub(block.GasLimit, parent.GasLimit)
+	a.Abs(a)
+	b := new(big.Int).Div(parent.GasLimit, params.GasLimitBoundDivisor)
+	if !(a.Cmp(b) < 0) || (block.GasLimit.Cmp(params.MinGasLimit) == -1) {
+		return fmt.Errorf("GasLimit check failed for block %v (%v > %v)", block.GasLimit, a, b)
+	}
+
+	if int64(block.Time) > time.Now().Unix() {
+		return BlockFutureErr
+	}
+
+	if new(big.Int).Sub(block.Number, parent.Number).Cmp(big.NewInt(1)) != 0 {
+		return BlockNumberErr
+	}
+
+	if block.Time <= parent.Time {
+		return BlockEqualTSErr //ValidationError("Block timestamp equal or less than previous block (%v - %v)", block.Time, parent.Time)
+	}
+
+	if checkPow {
+		// Verify the nonce of the block. Return an error if it's not valid
+		if !pow.Verify(types.NewBlockWithHeader(block)) {
+			return ValidationError("Block's nonce is invalid (= %x)", block.Nonce)
+		}
+	}
+
+	return nil
+}
+
+func AccumulateRewards(statedb *state.StateDB, block *types.Block) {
+	reward := new(big.Int).Set(BlockReward)
+
+	for _, uncle := range block.Uncles() {
+		num := new(big.Int).Add(big.NewInt(8), uncle.Number)
+		num.Sub(num, block.Number())
+
+		r := new(big.Int)
+		r.Mul(BlockReward, num)
+		r.Div(r, big.NewInt(8))
+
+		statedb.AddBalance(uncle.Coinbase, r)
+
+		reward.Add(reward, new(big.Int).Div(BlockReward, big.NewInt(32)))
+	}
+
+	// Get the account associated with the coinbase
+	statedb.AddBalance(block.Header().Coinbase, reward)
 }
 
 func getBlockReceipts(db common.Database, bhash common.Hash) (receipts types.Receipts, err error) {

--- a/core/block_processor_test.go
+++ b/core/block_processor_test.go
@@ -26,18 +26,20 @@ func proc() (*BlockProcessor, *ChainManager) {
 }
 
 func TestNumber(t *testing.T) {
-	bp, chain := proc()
+	_, chain := proc()
 	block1 := chain.NewBlock(common.Address{})
 	block1.Header().Number = big.NewInt(3)
 	block1.Header().Time--
 
-	err := bp.ValidateHeader(block1.Header(), chain.Genesis().Header(), false)
+	pow := ezp.New()
+
+	err := ValidateHeader(pow, block1.Header(), chain.Genesis().Header(), false)
 	if err != BlockNumberErr {
 		t.Errorf("expected block number error %v", err)
 	}
 
 	block1 = chain.NewBlock(common.Address{})
-	err = bp.ValidateHeader(block1.Header(), chain.Genesis().Header(), false)
+	err = ValidateHeader(pow, block1.Header(), chain.Genesis().Header(), false)
 	if err == BlockNumberErr {
 		t.Errorf("didn't expect block number error")
 	}

--- a/core/state/dump.go
+++ b/core/state/dump.go
@@ -34,7 +34,7 @@ func (self *StateDB) RawDump() World {
 		account := Account{Balance: stateObject.balance.String(), Nonce: stateObject.nonce, Root: common.Bytes2Hex(stateObject.Root()), CodeHash: common.Bytes2Hex(stateObject.codeHash)}
 		account.Storage = make(map[string]string)
 
-		storageIt := stateObject.State.trie.Iterator()
+		storageIt := stateObject.trie.Iterator()
 		for storageIt.Next() {
 			account.Storage[common.Bytes2Hex(self.trie.GetKey(storageIt.Key))] = common.Bytes2Hex(storageIt.Value)
 		}
@@ -54,8 +54,8 @@ func (self *StateDB) Dump() []byte {
 
 // Debug stuff
 func (self *StateObject) CreateOutputForDiff() {
-	fmt.Printf("%x %x %x %x\n", self.Address(), self.State.Root(), self.balance.Bytes(), self.nonce)
-	it := self.State.trie.Iterator()
+	fmt.Printf("%x %x %x %x\n", self.Address(), self.Root(), self.balance.Bytes(), self.nonce)
+	it := self.trie.Iterator()
 	for it.Next() {
 		fmt.Printf("%x %x\n", it.Key, it.Value)
 	}

--- a/core/state/state_object.go
+++ b/core/state/state_object.go
@@ -128,8 +128,10 @@ func (self *StateObject) MarkForDeletion() {
 	}
 }
 
-func (c *StateObject) getAddr(addr common.Hash) (ret common.Hash) {
-	return common.BytesToHash(common.NewValueFromBytes([]byte(c.State.trie.Get(addr[:]))).Bytes())
+func (c *StateObject) getAddr(addr common.Hash) common.Hash {
+	var ret []byte
+	rlp.DecodeBytes(c.State.trie.Get(addr[:]), &ret)
+	return common.BytesToHash(ret)
 }
 
 func (c *StateObject) setAddr(addr []byte, value common.Hash) {

--- a/core/state/state_test.go
+++ b/core/state/state_test.go
@@ -70,37 +70,34 @@ func TestNull(t *testing.T) {
 	address := common.HexToAddress("0x823140710bf13990e4500136726d8b55")
 	state.CreateAccount(address)
 	//value := common.FromHex("0x823140710bf13990e4500136726d8b55")
-	value := make([]byte, 16)
+	var value common.Hash
 	state.SetState(address, common.Hash{}, value)
 	state.Update()
 	state.Sync()
 	value = state.GetState(address, common.Hash{})
+	if !common.EmptyHash(value) {
+		t.Errorf("expected empty hash. got %x", value)
+	}
 }
 
 func (s *StateSuite) TestSnapshot(c *checker.C) {
 	stateobjaddr := toAddr([]byte("aa"))
-	storageaddr := common.Big("0")
-	data1 := common.NewValue(42)
-	data2 := common.NewValue(43)
+	var storageaddr common.Hash
+	data1 := common.BytesToHash([]byte{42})
+	data2 := common.BytesToHash([]byte{43})
 
-	// get state object
-	stateObject := s.state.GetOrNewStateObject(stateobjaddr)
 	// set inital state object value
-	stateObject.SetStorage(storageaddr, data1)
+	s.state.SetState(stateobjaddr, storageaddr, data1)
 	// get snapshot of current state
 	snapshot := s.state.Copy()
 
-	// get state object. is this strictly necessary?
-	stateObject = s.state.GetStateObject(stateobjaddr)
 	// set new state object value
-	stateObject.SetStorage(storageaddr, data2)
+	s.state.SetState(stateobjaddr, storageaddr, data2)
 	// restore snapshot
 	s.state.Set(snapshot)
 
-	// get state object
-	stateObject = s.state.GetStateObject(stateobjaddr)
 	// get state storage value
-	res := stateObject.GetStorage(storageaddr)
+	res := s.state.GetState(stateobjaddr, storageaddr)
 
 	c.Assert(data1, checker.DeepEquals, res)
 }

--- a/core/state/statedb.go
+++ b/core/state/statedb.go
@@ -296,10 +296,6 @@ func (s *StateDB) Reset() {
 
 	// Reset all nested states
 	for _, stateObject := range s.stateObjects {
-		if stateObject.State == nil {
-			continue
-		}
-
 		stateObject.Reset()
 	}
 
@@ -310,11 +306,7 @@ func (s *StateDB) Reset() {
 func (s *StateDB) Sync() {
 	// Sync all nested states
 	for _, stateObject := range s.stateObjects {
-		if stateObject.State == nil {
-			continue
-		}
-
-		stateObject.State.Sync()
+		stateObject.trie.Commit()
 	}
 
 	s.trie.Commit()
@@ -339,7 +331,7 @@ func (self *StateDB) Update() {
 			if stateObject.remove {
 				self.DeleteStateObject(stateObject)
 			} else {
-				stateObject.Sync()
+				stateObject.Update()
 
 				self.UpdateStateObject(stateObject)
 			}

--- a/core/state/statedb.go
+++ b/core/state/statedb.go
@@ -103,13 +103,13 @@ func (self *StateDB) GetCode(addr common.Address) []byte {
 	return nil
 }
 
-func (self *StateDB) GetState(a common.Address, b common.Hash) []byte {
+func (self *StateDB) GetState(a common.Address, b common.Hash) common.Hash {
 	stateObject := self.GetStateObject(a)
 	if stateObject != nil {
-		return stateObject.GetState(b).Bytes()
+		return stateObject.GetState(b)
 	}
 
-	return nil
+	return common.Hash{}
 }
 
 func (self *StateDB) IsDeleted(addr common.Address) bool {
@@ -145,10 +145,10 @@ func (self *StateDB) SetCode(addr common.Address, code []byte) {
 	}
 }
 
-func (self *StateDB) SetState(addr common.Address, key common.Hash, value interface{}) {
+func (self *StateDB) SetState(addr common.Address, key common.Hash, value common.Hash) {
 	stateObject := self.GetOrNewStateObject(addr)
 	if stateObject != nil {
-		stateObject.SetState(key, common.NewValue(value))
+		stateObject.SetState(key, value)
 	}
 }
 

--- a/core/state/statedb.go
+++ b/core/state/statedb.go
@@ -259,7 +259,7 @@ func (s *StateDB) Cmp(other *StateDB) bool {
 
 func (self *StateDB) Copy() *StateDB {
 	state := New(common.Hash{}, self.db)
-	state.trie = self.trie.Copy()
+	state.trie = self.trie
 	for k, stateObject := range self.stateObjects {
 		state.stateObjects[k] = stateObject.Copy()
 	}

--- a/core/state_transition.go
+++ b/core/state_transition.go
@@ -241,11 +241,9 @@ func (self *StateTransition) refundGas() {
 	sender.AddBalance(remaining)
 
 	uhalf := new(big.Int).Div(self.gasUsed(), common.Big2)
-	for addr, ref := range self.state.Refunds() {
-		refund := common.BigMin(uhalf, ref)
-		self.gas.Add(self.gas, refund)
-		self.state.AddBalance(common.StringToAddress(addr), refund.Mul(refund, self.msg.GasPrice()))
-	}
+	refund := common.BigMin(uhalf, self.state.Refunds())
+	self.gas.Add(self.gas, refund)
+	self.state.AddBalance(sender.Address(), refund.Mul(refund, self.msg.GasPrice()))
 
 	coinbase.RefundGas(self.gas, self.msg.GasPrice())
 }

--- a/core/vm/context.go
+++ b/core/vm/context.go
@@ -26,16 +26,25 @@ type Context struct {
 	Args []byte
 }
 
+var dests destinations
+
+func init() {
+	dests = make(destinations)
+}
+
 // Create a new context for the given data items.
 func NewContext(caller ContextRef, object ContextRef, value, gas, price *big.Int) *Context {
 	c := &Context{caller: caller, self: object, Args: nil}
 
-	if parent, ok := caller.(*Context); ok {
-		// Reuse JUMPDEST analysis from parent context if available.
-		c.jumpdests = parent.jumpdests
-	} else {
-		c.jumpdests = make(destinations)
-	}
+	/*
+		if parent, ok := caller.(*Context); ok {
+			// Reuse JUMPDEST analysis from parent context if available.
+			c.jumpdests = parent.jumpdests
+		} else {
+			c.jumpdests = make(destinations)
+		}
+	*/
+	c.jumpdests = dests
 
 	// Gas should be a pointer so it can safely be reduced through the run
 	// This pointer will be off the state transition

--- a/core/vm/context.go
+++ b/core/vm/context.go
@@ -26,25 +26,16 @@ type Context struct {
 	Args []byte
 }
 
-var dests destinations
-
-func init() {
-	dests = make(destinations)
-}
-
 // Create a new context for the given data items.
 func NewContext(caller ContextRef, object ContextRef, value, gas, price *big.Int) *Context {
 	c := &Context{caller: caller, self: object, Args: nil}
 
-	/*
-		if parent, ok := caller.(*Context); ok {
-			// Reuse JUMPDEST analysis from parent context if available.
-			c.jumpdests = parent.jumpdests
-		} else {
-			c.jumpdests = make(destinations)
-		}
-	*/
-	c.jumpdests = dests
+	if parent, ok := caller.(*Context); ok {
+		// Reuse JUMPDEST analysis from parent context if available.
+		c.jumpdests = parent.jumpdests
+	} else {
+		c.jumpdests = make(destinations)
+	}
 
 	// Gas should be a pointer so it can safely be reduced through the run
 	// This pointer will be off the state transition

--- a/core/vm/vm.go
+++ b/core/vm/vm.go
@@ -686,6 +686,11 @@ func (self *Vm) calculateGasAndSize(context *Context, caller ContextRef, op OpCo
 		var g *big.Int
 		y, x := stack.data[stack.len()-2], stack.data[stack.len()-1]
 		val := statedb.GetState(context.Address(), common.BigToHash(x))
+
+		// This checks for 3 scenario's and calculates gas accordingly
+		// 1. From a zero-value address to a non-zero value         (NEW VALUE)
+		// 2. From a non-zero value address to a zero-value address (DELETE)
+		// 3. From a nen-zero to a non-zero                         (CHANGE)
 		if common.EmptyHash(val) && !common.EmptyHash(common.BigToHash(y)) {
 			// 0 => non 0
 			g = params.SstoreSetGas
@@ -697,13 +702,6 @@ func (self *Vm) calculateGasAndSize(context *Context, caller ContextRef, op OpCo
 			// non 0 => non 0 (or 0 => 0)
 			g = params.SstoreClearGas
 		}
-
-		/*
-			if len(val) == 0 && len(y.Bytes()) > 0 {
-			} else if len(val) > 0 && len(y.Bytes()) == 0 {
-			} else {
-			}
-		*/
 		gas.Set(g)
 	case SUICIDE:
 		if !statedb.IsDeleted(context.Address()) {

--- a/core/vm/vm.go
+++ b/core/vm/vm.go
@@ -690,7 +690,7 @@ func (self *Vm) calculateGasAndSize(context *Context, caller ContextRef, op OpCo
 			// 0 => non 0
 			g = params.SstoreSetGas
 		} else if len(val) > 0 && len(y.Bytes()) == 0 {
-			statedb.Refund(self.env.Origin(), params.SstoreRefundGas)
+			statedb.Refund(params.SstoreRefundGas)
 
 			g = params.SstoreClearGas
 		} else {
@@ -700,7 +700,7 @@ func (self *Vm) calculateGasAndSize(context *Context, caller ContextRef, op OpCo
 		gas.Set(g)
 	case SUICIDE:
 		if !statedb.IsDeleted(context.Address()) {
-			statedb.Refund(self.env.Origin(), params.SuicideRefundGas)
+			statedb.Refund(params.SuicideRefundGas)
 		}
 	case MLOAD:
 		newMemSize = calcMemSize(stack.peek(), u256(32))

--- a/tests/block_test_util.go
+++ b/tests/block_test_util.go
@@ -124,7 +124,7 @@ func (t *BlockTest) InsertPreState(ethereum *eth.Ethereum) (*state.StateDB, erro
 		obj.SetBalance(balance)
 		obj.SetNonce(nonce)
 		for k, v := range acct.Storage {
-			statedb.SetState(common.HexToAddress(addrString), common.HexToHash(k), common.FromHex(v))
+			statedb.SetState(common.HexToAddress(addrString), common.HexToHash(k), common.HexToHash(v))
 		}
 	}
 	// sync objects to trie

--- a/tests/vm/gh_test.go
+++ b/tests/vm/gh_test.go
@@ -97,7 +97,7 @@ func RunVmTest(p string, t *testing.T) {
 			obj := StateObjectFromAccount(db, addr, account)
 			statedb.SetStateObject(obj)
 			for a, v := range account.Storage {
-				obj.SetState(common.HexToHash(a), common.NewValue(helper.FromHex(v)))
+				obj.SetState(common.HexToHash(a), common.HexToHash(v))
 			}
 		}
 
@@ -168,11 +168,11 @@ func RunVmTest(p string, t *testing.T) {
 			}
 
 			for addr, value := range account.Storage {
-				v := obj.GetState(common.HexToHash(addr)).Bytes()
-				vexp := helper.FromHex(value)
+				v := obj.GetState(common.HexToHash(addr))
+				vexp := common.HexToHash(value)
 
-				if bytes.Compare(v, vexp) != 0 {
-					t.Errorf("%s's : (%x: %s) storage failed. Expected %x, got %x (%v %v)\n", name, obj.Address().Bytes()[0:4], addr, vexp, v, common.BigD(vexp), common.BigD(v))
+				if v != vexp {
+					t.Errorf("%s's : (%x: %s) storage failed. Expected %x, got %x (%v %v)\n", name, obj.Address().Bytes()[0:4], addr, vexp, v, vexp.Big(), v.Big())
 				}
 			}
 		}

--- a/xeth/types.go
+++ b/xeth/types.go
@@ -22,7 +22,7 @@ func NewObject(state *state.StateObject) *Object {
 	return &Object{state}
 }
 
-func (self *Object) StorageString(str string) *common.Value {
+func (self *Object) StorageString(str string) []byte {
 	if common.IsHex(str) {
 		return self.storage(common.Hex2Bytes(str[2:]))
 	} else {
@@ -30,12 +30,12 @@ func (self *Object) StorageString(str string) *common.Value {
 	}
 }
 
-func (self *Object) StorageValue(addr *common.Value) *common.Value {
+func (self *Object) StorageValue(addr *common.Value) []byte {
 	return self.storage(addr.Bytes())
 }
 
-func (self *Object) storage(addr []byte) *common.Value {
-	return self.StateObject.GetStorage(common.BigD(addr))
+func (self *Object) storage(addr []byte) []byte {
+	return self.StateObject.GetState(common.BytesToHash(addr)).Bytes()
 }
 
 func (self *Object) Storage() (storage map[string]string) {

--- a/xeth/xeth.go
+++ b/xeth/xeth.go
@@ -488,7 +488,7 @@ func (self *XEth) NumberToHuman(balance string) string {
 }
 
 func (self *XEth) StorageAt(addr, storageAddr string) string {
-	return common.ToHex(self.State().state.GetState(common.HexToAddress(addr), common.HexToHash(storageAddr)))
+	return self.State().state.GetState(common.HexToAddress(addr), common.HexToHash(storageAddr)).Hex()
 }
 
 func (self *XEth) BalanceAt(addr string) string {


### PR DESCRIPTION
This PR optimises the following

* `StateObject`s no longer have an embedded state but rather access the trie directly
* `StateObject`s and `StateDB` no longer copy tries around for snapshotting but rather use the same 
* Removed `common.Value` as storage caching value but rather use `common.Hash`
* Reworked **refund** model
* Removed full validation from `TxPool` during `validatePool`. Instead only nonces are checked