### PR TITLE
Account management improvements

### DIFF
--- a/accounts/account_manager.go
+++ b/accounts/account_manager.go
@@ -26,7 +26,7 @@ This abstracts part of a user's interaction with an account she controls.
 It's not an abstraction of core Ethereum accounts data type / logic -
 for that see the core processing code of blocks / txs.
 
-Currently this is pretty much a passthrough to the KeyStore2 interface,
+Currently this is pretty much a passthrough to the KeyStore interface,
 and accounts persistence is derived from stored keys' addresses
 
 */
@@ -54,7 +54,7 @@ type Account struct {
 }
 
 type Manager struct {
-	keyStore crypto.KeyStore2
+	keyStore crypto.KeyStore
 	unlocked map[common.Address]*unlocked
 	mutex    sync.RWMutex
 }
@@ -64,7 +64,7 @@ type unlocked struct {
 	abort chan struct{}
 }
 
-func NewManager(keyStore crypto.KeyStore2) *Manager {
+func NewManager(keyStore crypto.KeyStore) *Manager {
 	return &Manager{
 		keyStore: keyStore,
 		unlocked: make(map[common.Address]*unlocked),

--- a/accounts/account_manager.go
+++ b/accounts/account_manager.go
@@ -81,19 +81,6 @@ func (am *Manager) HasAccount(addr common.Address) bool {
 	return false
 }
 
-func (am *Manager) Primary() (addr common.Address, err error) {
-	addrs, err := am.keyStore.GetKeyAddresses()
-	if os.IsNotExist(err) {
-		return common.Address{}, ErrNoKeys
-	} else if err != nil {
-		return common.Address{}, err
-	}
-	if len(addrs) == 0 {
-		return common.Address{}, ErrNoKeys
-	}
-	return addrs[0], nil
-}
-
 func (am *Manager) DeleteAccount(address common.Address, auth string) error {
 	return am.keyStore.DeleteKey(address, auth)
 }

--- a/accounts/accounts_test.go
+++ b/accounts/accounts_test.go
@@ -18,7 +18,7 @@ func TestSign(t *testing.T) {
 	pass := "" // not used but required by API
 	a1, err := am.NewAccount(pass)
 	toSign := randentropy.GetEntropyCSPRNG(32)
-	am.Unlock(a1.Address, "")
+	am.Unlock(a1.Address, "", 0)
 
 	_, err = am.Sign(a1, toSign)
 	if err != nil {
@@ -58,6 +58,47 @@ func TestTimedUnlock(t *testing.T) {
 	if err != ErrLocked {
 		t.Fatal("Signing should've failed with ErrLocked timeout expired, got ", err)
 	}
+
+}
+
+func TestOverrideUnlock(t *testing.T) {
+	dir, ks := tmpKeyStore(t, crypto.NewKeyStorePassphrase)
+	defer os.RemoveAll(dir)
+
+	am := NewManager(ks)
+	pass := "foo"
+	a1, err := am.NewAccount(pass)
+	toSign := randentropy.GetEntropyCSPRNG(32)
+
+	// Unlock indefinitely
+	if err = am.Unlock(a1.Address, pass); err != nil {
+		t.Fatal(err)
+	}
+
+	// Signing without passphrase works because account is temp unlocked
+	_, err = am.Sign(a1, toSign)
+	if err != nil {
+		t.Fatal("Signing shouldn't return an error after unlocking, got ", err)
+	}
+
+	// reset unlock to a shorter period, invalidates the previous unlock
+	if err = am.TimedUnlock(a1.Address, pass, 100*time.Millisecond); err != nil {
+		t.Fatal(err)
+	}
+
+	// Signing without passphrase still works because account is temp unlocked
+	_, err = am.Sign(a1, toSign)
+	if err != nil {
+		t.Fatal("Signing shouldn't return an error after unlocking, got ", err)
+	}
+
+	// Signing fails again after automatic locking
+	time.Sleep(150 * time.Millisecond)
+	_, err = am.Sign(a1, toSign)
+	if err != ErrLocked {
+		t.Fatal("Signing should've failed with ErrLocked timeout expired, got ", err)
+	}
+
 }
 
 func tmpKeyStore(t *testing.T, new func(string) crypto.KeyStore2) (string, crypto.KeyStore2) {

--- a/accounts/accounts_test.go
+++ b/accounts/accounts_test.go
@@ -18,7 +18,7 @@ func TestSign(t *testing.T) {
 	pass := "" // not used but required by API
 	a1, err := am.NewAccount(pass)
 	toSign := randentropy.GetEntropyCSPRNG(32)
-	am.Unlock(a1.Address, "", 0)
+	am.Unlock(a1.Address, "")
 
 	_, err = am.Sign(a1, toSign)
 	if err != nil {

--- a/accounts/accounts_test.go
+++ b/accounts/accounts_test.go
@@ -98,10 +98,11 @@ func TestOverrideUnlock(t *testing.T) {
 	if err != ErrLocked {
 		t.Fatal("Signing should've failed with ErrLocked timeout expired, got ", err)
 	}
-
 }
 
-func tmpKeyStore(t *testing.T, new func(string) crypto.KeyStore2) (string, crypto.KeyStore2) {
+//
+
+func tmpKeyStore(t *testing.T, new func(string) crypto.KeyStore) (string, crypto.KeyStore) {
 	d, err := ioutil.TempDir("", "eth-keystore-test")
 	if err != nil {
 		t.Fatal(err)

--- a/cmd/geth/js_test.go
+++ b/cmd/geth/js_test.go
@@ -140,7 +140,7 @@ func TestAccounts(t *testing.T) {
 	defer os.RemoveAll(tmp)
 
 	checkEvalJSON(t, repl, `eth.accounts`, `["`+testAddress+`"]`)
-	checkEvalJSON(t, repl, `eth.coinbase`, `"`+testAddress+`"`)
+	checkEvalJSON(t, repl, `eth.coinbase`, `"`+common.Address{}.Hex()+`"`)
 
 	val, err := repl.re.Run(`personal.newAccount("password")`)
 	if err != nil {

--- a/cmd/geth/js_test.go
+++ b/cmd/geth/js_test.go
@@ -9,7 +9,6 @@ import (
 	"runtime"
 	"strconv"
 	"testing"
-	"time"
 
 	"github.com/ethereum/go-ethereum/accounts"
 	"github.com/ethereum/go-ethereum/common"
@@ -128,6 +127,7 @@ func TestNodeInfo(t *testing.T) {
 	}
 	defer ethereum.Stop()
 	defer os.RemoveAll(tmp)
+
 	want := `{"DiscPort":0,"IP":"0.0.0.0","ListenAddr":"","Name":"test","NodeID":"4cb2fc32924e94277bf94b5e4c983beedb2eabd5a0bc941db32202735c6625d020ca14a5963d1738af43b6ac0a711d61b1a06de931a499fe2aa0b1a132a902b5","NodeUrl":"enode://4cb2fc32924e94277bf94b5e4c983beedb2eabd5a0bc941db32202735c6625d020ca14a5963d1738af43b6ac0a711d61b1a06de931a499fe2aa0b1a132a902b5@0.0.0.0:0","TCPPort":0,"Td":"131072"}`
 	checkEvalJSON(t, repl, `admin.nodeInfo`, want)
 }

--- a/cmd/geth/js_test.go
+++ b/cmd/geth/js_test.go
@@ -9,6 +9,7 @@ import (
 	"runtime"
 	"strconv"
 	"testing"
+	"time"
 
 	"github.com/ethereum/go-ethereum/accounts"
 	"github.com/ethereum/go-ethereum/common"
@@ -20,8 +21,8 @@ import (
 	"github.com/ethereum/go-ethereum/core/state"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/eth"
-	"github.com/ethereum/go-ethereum/rpc/comms"
 	"github.com/ethereum/go-ethereum/rpc/codec"
+	"github.com/ethereum/go-ethereum/rpc/comms"
 )
 
 const (
@@ -141,7 +142,6 @@ func TestAccounts(t *testing.T) {
 
 	checkEvalJSON(t, repl, `eth.accounts`, `["`+testAddress+`"]`)
 	checkEvalJSON(t, repl, `eth.coinbase`, `null`)
-
 	val, err := repl.re.Run(`personal.newAccount("password")`)
 	if err != nil {
 		t.Errorf("expected no error, got %v", err)
@@ -151,7 +151,7 @@ func TestAccounts(t *testing.T) {
 		t.Errorf("address not hex: %q", addr)
 	}
 
-	// checkEvalJSON(t, repl, `eth.accounts`, `["`+testAddress+`", "`+addr+`"]`)
+	checkEvalJSON(t, repl, `eth.accounts`, `["`+testAddress+`","`+addr+`"]`)
 }
 
 func TestBlockChain(t *testing.T) {

--- a/cmd/geth/js_test.go
+++ b/cmd/geth/js_test.go
@@ -140,7 +140,7 @@ func TestAccounts(t *testing.T) {
 	defer os.RemoveAll(tmp)
 
 	checkEvalJSON(t, repl, `eth.accounts`, `["`+testAddress+`"]`)
-	checkEvalJSON(t, repl, `eth.coinbase`, `"`+common.Address{}.Hex()+`"`)
+	checkEvalJSON(t, repl, `eth.coinbase`, `null`)
 
 	val, err := repl.re.Run(`personal.newAccount("password")`)
 	if err != nil {
@@ -151,9 +151,7 @@ func TestAccounts(t *testing.T) {
 		t.Errorf("address not hex: %q", addr)
 	}
 
-	// skip until order fixed #824
 	// checkEvalJSON(t, repl, `eth.accounts`, `["`+testAddress+`", "`+addr+`"]`)
-	// checkEvalJSON(t, repl, `eth.coinbase`, `"`+testAddress+`"`)
 }
 
 func TestBlockChain(t *testing.T) {

--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -497,7 +497,7 @@ func startEth(ctx *cli.Context, eth *eth.Ethereum) {
 	for i, account := range accounts {
 		if len(account) > 0 {
 			if account == "primary" {
-				utils.Fatalf("the 'primary' keyword is deprecated. You can use indexes, but the indexes are not permanent, they can change if you add external keys, export your keys or copy your keystore to another node.")
+				utils.Fatalf("the 'primary' keyword is deprecated. You can use integer indexes, but the indexes are not permanent, they can change if you add external keys, export your keys or copy your keystore to another node.")
 			}
 			unlockAccount(ctx, am, account, i)
 		}
@@ -526,10 +526,8 @@ func accountList(ctx *cli.Context) {
 	if err != nil {
 		utils.Fatalf("Could not list accounts: %v", err)
 	}
-	name := "Primary"
 	for i, acct := range accts {
-		fmt.Printf("%s #%d: %x\n", name, i, acct)
-		name = "Account"
+		fmt.Printf("Account #%d: %x\n", i, acct)
 	}
 }
 

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -133,7 +133,7 @@ var (
 
 	UnlockedAccountFlag = cli.StringFlag{
 		Name:  "unlock",
-		Usage: "Unlock the account given until this program exits (prompts for password). '--unlock primary' unlocks the primary account",
+		Usage: "Unlock the account given until this program exits (prompts for password). '--unlock n' unlocks the n-th account in order or creation.",
 		Value: "",
 	}
 	PasswordFileFlag = cli.StringFlag{

--- a/crypto/crypto.go
+++ b/crypto/crypto.go
@@ -209,7 +209,7 @@ func ImportBlockTestKey(privKeyBytes []byte) error {
 }
 
 // creates a Key and stores that in the given KeyStore by decrypting a presale key JSON
-func ImportPreSaleKey(keyStore KeyStore2, keyJSON []byte, password string) (*Key, error) {
+func ImportPreSaleKey(keyStore KeyStore, keyJSON []byte, password string) (*Key, error) {
 	key, err := decryptPreSaleKey(keyJSON, password)
 	if err != nil {
 		return nil, err

--- a/crypto/key_store_plain.go
+++ b/crypto/key_store_plain.go
@@ -31,18 +31,15 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
-	"sort"
-	"syscall"
 	"time"
 
 	"github.com/ethereum/go-ethereum/common"
 )
 
-// TODO: rename to KeyStore when replacing existing KeyStore
-type KeyStore2 interface {
+type KeyStore interface {
 	// create new key using io.Reader entropy source and optionally using auth string
 	GenerateNewKey(io.Reader, string) (*Key, error)
-	GetKey(common.Address, string) (*Key, error) // key from addr and auth string
+	GetKey(common.Address, string) (*Key, error) // get key from addr and auth string
 	GetKeyAddresses() ([]common.Address, error)  // get all addresses
 	StoreKey(*Key, string) error                 // store key optionally using auth string
 	DeleteKey(common.Address, string) error      // delete key by addr and auth string
@@ -52,7 +49,7 @@ type keyStorePlain struct {
 	keysDirPath string
 }
 
-func NewKeyStorePlain(path string) KeyStore2 {
+func NewKeyStorePlain(path string) KeyStore {
 	return &keyStorePlain{path}
 }
 
@@ -60,7 +57,7 @@ func (ks keyStorePlain) GenerateNewKey(rand io.Reader, auth string) (key *Key, e
 	return GenerateNewKeyDefault(ks, rand, auth)
 }
 
-func GenerateNewKeyDefault(ks KeyStore2, rand io.Reader, auth string) (key *Key, err error) {
+func GenerateNewKeyDefault(ks KeyStore, rand io.Reader, auth string) (key *Key, err error) {
 	defer func() {
 		if r := recover(); r != nil {
 			err = fmt.Errorf("GenerateNewKey error: %v", r)
@@ -72,81 +69,111 @@ func GenerateNewKeyDefault(ks KeyStore2, rand io.Reader, auth string) (key *Key,
 }
 
 func (ks keyStorePlain) GetKey(keyAddr common.Address, auth string) (key *Key, err error) {
-	fileContent, err := GetKeyFile(ks.keysDirPath, keyAddr)
-	if err != nil {
-		return nil, err
-	}
-
 	key = new(Key)
-	err = json.Unmarshal(fileContent, key)
-	return key, err
+	err = getKey(ks.keysDirPath, keyAddr, key)
+	return
+}
+
+func getKey(keysDirPath string, keyAddr common.Address, content interface{}) (err error) {
+	fileContent, err := getKeyFile(keysDirPath, keyAddr)
+	if err != nil {
+		return
+	}
+	return json.Unmarshal(fileContent, content)
 }
 
 func (ks keyStorePlain) GetKeyAddresses() (addresses []common.Address, err error) {
-	return GetKeyAddresses(ks.keysDirPath)
+	return getKeyAddresses(ks.keysDirPath)
 }
 
 func (ks keyStorePlain) StoreKey(key *Key, auth string) (err error) {
 	keyJSON, err := json.Marshal(key)
 	if err != nil {
-		return err
+		return
 	}
-	err = WriteKeyFile(key.Address, ks.keysDirPath, keyJSON)
-	return err
+	err = writeKeyFile(key.Address, ks.keysDirPath, keyJSON)
+	return
 }
 
 func (ks keyStorePlain) DeleteKey(keyAddr common.Address, auth string) (err error) {
-	keyDirPath := filepath.Join(ks.keysDirPath, keyAddr.Hex())
-	err = os.RemoveAll(keyDirPath)
-	return err
+	return deleteKey(ks.keysDirPath, keyAddr)
 }
 
-func GetKeyFile(keysDirPath string, keyAddr common.Address) (fileContent []byte, err error) {
-	fileName := hex.EncodeToString(keyAddr[:])
-	return ioutil.ReadFile(filepath.Join(keysDirPath, fileName, fileName))
+func deleteKey(keysDirPath string, keyAddr common.Address) (err error) {
+	var keyFilePath string
+	keyFilePath, err = getKeyFilePath(keysDirPath, keyAddr)
+	if err == nil {
+		err = os.Remove(keyFilePath)
+	}
+	return
 }
 
-func WriteKeyFile(addr common.Address, keysDirPath string, content []byte) (err error) {
-	addrHex := hex.EncodeToString(addr[:])
-	keyDirPath := filepath.Join(keysDirPath, addrHex)
-	keyFilePath := filepath.Join(keyDirPath, addrHex)
-	err = os.MkdirAll(keyDirPath, 0700) // read, write and dir search for user
+func getKeyFilePath(keysDirPath string, keyAddr common.Address) (keyFilePath string, err error) {
+	addrHex := hex.EncodeToString(keyAddr[:])
+	matches, err := filepath.Glob(filepath.Join(keysDirPath, fmt.Sprintf("*--%s", addrHex)))
+	if len(matches) > 0 {
+		if err == nil {
+			keyFilePath = matches[len(matches)-1]
+		}
+		return
+	}
+	keyFilePath = filepath.Join(keysDirPath, addrHex, addrHex)
+	_, err = os.Stat(keyFilePath)
+	return
+}
+
+func getKeyFile(keysDirPath string, keyAddr common.Address) (fileContent []byte, err error) {
+	var keyFilePath string
+	keyFilePath, err = getKeyFilePath(keysDirPath, keyAddr)
+	if err == nil {
+		fileContent, err = ioutil.ReadFile(keyFilePath)
+	}
+	return
+}
+
+func writeKeyFile(addr common.Address, keysDirPath string, content []byte) (err error) {
+	filename := keyFileName(addr)
+	// read, write and dir search for user
+	err = os.MkdirAll(keysDirPath, 0700)
 	if err != nil {
 		return err
 	}
-	return ioutil.WriteFile(keyFilePath, content, 0600) // read, write for user
+	// read, write for user
+	return ioutil.WriteFile(filepath.Join(keysDirPath, filename), content, 0600)
 }
 
-func GetKeyAddresses(keysDirPath string) (addresses []common.Address, err error) {
+// keyFilePath implements the naming convention for keyfiles:
+// UTC--<created_at UTC ISO8601>-<address hex>
+func keyFileName(keyAddr common.Address) string {
+	ts := time.Now().UTC()
+	return fmt.Sprintf("UTC--%s--%s", toISO8601(ts), hex.EncodeToString(keyAddr[:]))
+}
+
+func toISO8601(t time.Time) string {
+	var tz string
+	name, offset := t.Zone()
+	if name == "UTC" {
+		tz = "Z"
+	} else {
+		tz = fmt.Sprintf("%03d00", offset/3600)
+	}
+	return fmt.Sprintf("%04d-%02d-%02dT%02d:%02d:%02d.%09d%s", t.Year(), t.Month(), t.Day(), t.Hour(), t.Minute(), t.Second(), t.Nanosecond(), tz)
+}
+
+func getKeyAddresses(keysDirPath string) (addresses []common.Address, err error) {
 	fileInfos, err := ioutil.ReadDir(keysDirPath)
 	if err != nil {
 		return nil, err
 	}
-	var kfis keyFileInfos
 	for _, fileInfo := range fileInfos {
-		stat := fileInfo.Sys().(*syscall.Stat_t)
-		ctime := time.Unix(int64(stat.Ctimespec.Sec), int64(stat.Ctimespec.Nsec))
-		kfis = append(kfis, keyFileInfo{fileInfo.Name(), ctime})
-	}
-	sort.Sort(kfis)
-	for _, kfi := range kfis {
-		address, err := hex.DecodeString(kfi.name)
-		if err != nil {
-			continue
+		filename := fileInfo.Name()
+		if len(filename) >= 40 {
+			addr := filename[len(filename)-40 : len(filename)]
+			address, err := hex.DecodeString(addr)
+			if err == nil {
+				addresses = append(addresses, common.BytesToAddress(address))
+			}
 		}
-		addresses = append(addresses, common.BytesToAddress(address))
 	}
 	return addresses, err
-}
-
-type keyFileInfo struct {
-	name  string
-	ctime time.Time
-}
-type keyFileInfos []keyFileInfo
-
-func (a keyFileInfos) Len() int      { return len(a) }
-func (a keyFileInfos) Swap(i, j int) { a[i], a[j] = a[j], a[i] }
-func (a keyFileInfos) Less(i, j int) bool {
-	return a[i].ctime.Before(a[j].ctime)
 }

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -464,10 +464,9 @@ func (s *Ethereum) StartMining(threads int) error {
 func (s *Ethereum) Etherbase() (eb common.Address, err error) {
 	eb = s.etherbase
 	if (eb == common.Address{}) {
-		err = fmt.Errorf("no accounts found")
-		return eb, err
+		err = fmt.Errorf("etherbase address must be explicitly specified")
 	}
-	return eb, nil
+	return
 }
 
 func (s *Ethereum) StopMining()         { s.miner.Stop() }

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -464,15 +464,8 @@ func (s *Ethereum) StartMining(threads int) error {
 func (s *Ethereum) Etherbase() (eb common.Address, err error) {
 	eb = s.etherbase
 	if (eb == common.Address{}) {
-		primary, err := s.accountManager.Primary()
-		if err != nil {
-			return eb, err
-		}
-		if (primary == common.Address{}) {
-			err = fmt.Errorf("no accounts found")
-			return eb, err
-		}
-		eb = primary
+		err = fmt.Errorf("no accounts found")
+		return eb, err
 	}
 	return eb, nil
 }

--- a/xeth/xeth.go
+++ b/xeth/xeth.go
@@ -477,7 +477,10 @@ func (self *XEth) IsListening() bool {
 }
 
 func (self *XEth) Coinbase() string {
-	eb, _ := self.backend.Etherbase()
+	eb, err := self.backend.Etherbase()
+	if err != nil {
+		return "0x0"
+	}
 	return eb.Hex()
 }
 


### PR DESCRIPTION
* [x]  Permanently unlock account in console.  closes https://github.com/ethereum/go-ethereum/issues/1257
* [x] primary option as depracated. closes https://github.com/ethereum/go-ethereum/issues/1265
* [x] Unlock to support indexes and addresses `--unlock 1`. closes #1242 
* [x] ~~geth account export https://github.com/ethereum/go-ethereum/issues/1054~~ = `cp` 
* [x] support multiple passwords for multiple unlock . see https://github.com/ethereum/go-ethereum/issues/1258,  #1045
* [x] stick to file creation order on local directory. no way new account can change the order. closes #807 
* [x] etherbase does not default to anything, it must be explicitly given.
* [x] account update: migrate or change password
