### PR TITLE
eth, eth/downloader: fix processing interrupt caused by temp cancel

### DIFF
--- a/eth/downloader/downloader_test.go
+++ b/eth/downloader/downloader_test.go
@@ -749,22 +749,21 @@ func TestHashAttackerDropping(t *testing.T) {
 		result error
 		drop   bool
 	}{
-		{nil, false},                  // Sync succeeded, all is well
-		{errBusy, false},              // Sync is already in progress, no problem
-		{errUnknownPeer, false},       // Peer is unknown, was already dropped, don't double drop
-		{errBadPeer, true},            // Peer was deemed bad for some reason, drop it
-		{errStallingPeer, true},       // Peer was detected to be stalling, drop it
-		{errBannedHead, true},         // Peer's head hash is a known bad hash, drop it
-		{errNoPeers, false},           // No peers to download from, soft race, no issue
-		{errPendingQueue, false},      // There are blocks still cached, wait to exhaust, no issue
-		{errTimeout, true},            // No hashes received in due time, drop the peer
-		{errEmptyHashSet, true},       // No hashes were returned as a response, drop as it's a dead end
-		{errPeersUnavailable, true},   // Nobody had the advertised blocks, drop the advertiser
-		{errInvalidChain, true},       // Hash chain was detected as invalid, definitely drop
-		{errCrossCheckFailed, true},   // Hash-origin failed to pass a block cross check, drop
-		{errCancelHashFetch, false},   // Synchronisation was canceled, origin may be innocent, don't drop
-		{errCancelBlockFetch, false},  // Synchronisation was canceled, origin may be innocent, don't drop
-		{errCancelChainImport, false}, // Synchronisation was canceled, origin may be innocent, don't drop
+		{nil, false},                 // Sync succeeded, all is well
+		{errBusy, false},             // Sync is already in progress, no problem
+		{errUnknownPeer, false},      // Peer is unknown, was already dropped, don't double drop
+		{errBadPeer, true},           // Peer was deemed bad for some reason, drop it
+		{errStallingPeer, true},      // Peer was detected to be stalling, drop it
+		{errBannedHead, true},        // Peer's head hash is a known bad hash, drop it
+		{errNoPeers, false},          // No peers to download from, soft race, no issue
+		{errPendingQueue, false},     // There are blocks still cached, wait to exhaust, no issue
+		{errTimeout, true},           // No hashes received in due time, drop the peer
+		{errEmptyHashSet, true},      // No hashes were returned as a response, drop as it's a dead end
+		{errPeersUnavailable, true},  // Nobody had the advertised blocks, drop the advertiser
+		{errInvalidChain, true},      // Hash chain was detected as invalid, definitely drop
+		{errCrossCheckFailed, true},  // Hash-origin failed to pass a block cross check, drop
+		{errCancelHashFetch, false},  // Synchronisation was canceled, origin may be innocent, don't drop
+		{errCancelBlockFetch, false}, // Synchronisation was canceled, origin may be innocent, don't drop
 	}
 	// Run the tests and check disconnection status
 	tester := newTester()

--- a/eth/downloader/downloader_test.go
+++ b/eth/downloader/downloader_test.go
@@ -247,7 +247,7 @@ func TestCancel(t *testing.T) {
 	tester.newPeer("peer", hashes, blocks)
 
 	// Make sure canceling works with a pristine downloader
-	tester.downloader.Cancel()
+	tester.downloader.cancel()
 	hashCount, blockCount := tester.downloader.queue.Size()
 	if hashCount > 0 || blockCount > 0 {
 		t.Errorf("block or hash count mismatch: %d hashes, %d blocks, want 0", hashCount, blockCount)
@@ -256,7 +256,7 @@ func TestCancel(t *testing.T) {
 	if err := tester.sync("peer"); err != nil {
 		t.Fatalf("failed to synchronise blocks: %v", err)
 	}
-	tester.downloader.Cancel()
+	tester.downloader.cancel()
 	hashCount, blockCount = tester.downloader.queue.Size()
 	if hashCount > 0 || blockCount > 0 {
 		t.Errorf("block or hash count mismatch: %d hashes, %d blocks, want 0", hashCount, blockCount)

--- a/eth/downloader/downloader_test.go
+++ b/eth/downloader/downloader_test.go
@@ -359,7 +359,7 @@ func TestSlowSynchronisation(t *testing.T) {
 	// Create a batch of blocks, with a slow and a full speed peer
 	targetCycles := 2
 	targetBlocks := targetCycles*blockCacheLimit - 15
-	targetIODelay := 500 * time.Millisecond
+	targetIODelay := time.Second
 
 	hashes := createHashes(targetBlocks, knownHash)
 	blocks := createBlocksFromHashes(hashes)

--- a/eth/sync.go
+++ b/eth/sync.go
@@ -251,7 +251,7 @@ func (pm *ProtocolManager) fetcher() {
 // downloading hashes and blocks as well as retrieving cached ones.
 func (pm *ProtocolManager) syncer() {
 	// Abort any pending syncs if we terminate
-	defer pm.downloader.Cancel()
+	defer pm.downloader.Terminate()
 
 	forceSync := time.Tick(forceSyncCycle)
 	for {


### PR DESCRIPTION
The downloader's block processor previously took into account sync-cancellation via the cancel channel: the rationale was that if we need to forcefully abort a sync, the processor itself should stop too. Unfortunately, there is a nasty side effect / logical race condition when a processing is aborted due to a cancellation, and no new one is ever spawned, leading to a lockup:

 * We start importing a batch of very heavy blocks, the first 256 out of an entire 1024 cache
 * The downloader starts fetching to refill the cache, but fails and aborts the entire sync
 * However, the processor is inserting very heavy blocks, so it doesn't notice the cancel
 * A new sync is started, and the cache is filled with fresh blocks
 * Even though blocks arrive, no new processor is started since the previous is still running
 * The previous finishes its heavy import, notices the cancelled op and terminates (no restart check)
 * Since the cache is already full, no new processor is started in place of the old
 * Deadlock

The fix is actually threefold:
 * First up, ignore sync cancellations: if the cached blocks are junk, import will abort anyway, no need to prematurely cancel. If they are not junk, then let the processor finish in peace, even if the origin sync failed.
 * Secondly though, we still need a capability to terminate if the node is shutting down. Introduce a separate shutdown flag (modified only once throughout the lifetime of the downloader) to signal termination.
 * Thirdly, instead of relying on ambiguous error returns for deciding if processor reentry is needed or not, always check reentry unless hard exit is requested.