### PR TITLE
p2p: throttle all discovery lookups

### DIFF
--- a/p2p/server.go
+++ b/p2p/server.go
@@ -115,6 +115,7 @@ type Server struct {
 	ntab         discoverTable
 	listener     net.Listener
 	ourHandshake *protoHandshake
+	lastLookup   time.Time
 
 	// These are for Peers, PeerCount (and nothing else).
 	peerOp     chan peerOpFunc


### PR DESCRIPTION
Lookup calls would spin out of control when network connectivity was
lost. The throttling that was in place only took effect when the table
returned zero results, which doesn't happen very often.

The new throttling should not have a negative impact when the host is
online. Lookups against the network take some time and dials for all
results must complete or hit the cache before a new one is started. This
usually takes longer than four seconds, leaving online lookups
unaffected.

Fixes #1296