### PR TITLE
Use uint64 for block header timestamp

### DIFF
--- a/cmd/evm/main.go
+++ b/cmd/evm/main.go
@@ -106,7 +106,7 @@ type VMEnv struct {
 
 	depth int
 	Gas   *big.Int
-	time  int64
+	time  uint64
 	logs  []vm.StructLog
 }
 
@@ -115,7 +115,7 @@ func NewEnv(state *state.StateDB, transactor common.Address, value *big.Int) *VM
 		state:      state,
 		transactor: &transactor,
 		value:      value,
-		time:       time.Now().Unix(),
+		time:       uint64(time.Now().Unix()),
 	}
 }
 
@@ -123,7 +123,7 @@ func (self *VMEnv) State() *state.StateDB    { return self.state }
 func (self *VMEnv) Origin() common.Address   { return *self.transactor }
 func (self *VMEnv) BlockNumber() *big.Int    { return common.Big0 }
 func (self *VMEnv) Coinbase() common.Address { return *self.transactor }
-func (self *VMEnv) Time() int64              { return self.time }
+func (self *VMEnv) Time() uint64             { return self.time }
 func (self *VMEnv) Difficulty() *big.Int     { return common.Big1 }
 func (self *VMEnv) BlockHash() []byte        { return make([]byte, 32) }
 func (self *VMEnv) Value() *big.Int          { return self.value }

--- a/core/chain_makers.go
+++ b/core/chain_makers.go
@@ -155,7 +155,7 @@ func makeHeader(parent *types.Block, state *state.StateDB) *types.Header {
 		Root:       state.Root(),
 		ParentHash: parent.Hash(),
 		Coinbase:   parent.Coinbase(),
-		Difficulty: CalcDifficulty(time, parent.Time(), parent.Difficulty()),
+		Difficulty: CalcDifficulty(int64(time), int64(parent.Time()), parent.Difficulty()),
 		GasLimit:   CalcGasLimit(parent),
 		GasUsed:    new(big.Int),
 		Number:     new(big.Int).Add(parent.Number(), common.Big1),

--- a/core/chain_manager.go
+++ b/core/chain_manager.go
@@ -658,7 +658,7 @@ func (self *ChainManager) InsertChain(chain types.Blocks) (int, error) {
 				// Allow up to MaxFuture second in the future blocks. If this limit
 				// is exceeded the chain is discarded and processed at a later time
 				// if given.
-				if max := time.Now().Unix() + maxTimeFutureBlocks; block.Time() > max {
+				if max := time.Now().Unix() + maxTimeFutureBlocks; int64(block.Time()) > max {
 					return i, fmt.Errorf("%v: BlockFutureErr, %v > %v", BlockFutureErr, block.Time(), max)
 				}
 

--- a/core/types/block.go
+++ b/core/types/block.go
@@ -290,7 +290,7 @@ func (b *Block) MixDigest() common.Hash   { return b.header.MixDigest }
 func (b *Block) Nonce() uint64            { return binary.BigEndian.Uint64(b.header.Nonce[:]) }
 func (b *Block) Bloom() Bloom             { return b.header.Bloom }
 func (b *Block) Coinbase() common.Address { return b.header.Coinbase }
-func (b *Block) Time() int64              { return int64(b.header.Time) }
+func (b *Block) Time() uint64             { return b.header.Time }
 func (b *Block) Root() common.Hash        { return b.header.Root }
 func (b *Block) ParentHash() common.Hash  { return b.header.ParentHash }
 func (b *Block) TxHash() common.Hash      { return b.header.TxHash }

--- a/core/types/block_test.go
+++ b/core/types/block_test.go
@@ -31,7 +31,7 @@ func TestBlockEncoding(t *testing.T) {
 	check("Root", block.Root(), common.HexToHash("ef1552a40b7165c3cd773806b9e0c165b75356e0314bf0706f279c729f51e017"))
 	check("Hash", block.Hash(), common.HexToHash("0a5843ac1cb04865017cb35a57b50b07084e5fcee39b5acadade33149f4fff9e"))
 	check("Nonce", block.Nonce(), uint64(0xa13a5a8c8f2bb1c4))
-	check("Time", block.Time(), int64(1426516743))
+	check("Time", block.Time(), uint64(1426516743))
 	check("Size", block.Size(), common.StorageSize(len(blockEnc)))
 
 	tx1 := NewTransaction(0, common.HexToAddress("095e7baea6a6c7c4c2dfeb977efac326af552d87"), big.NewInt(10), big.NewInt(50000), big.NewInt(10), nil)

--- a/core/vm/environment.go
+++ b/core/vm/environment.go
@@ -17,7 +17,7 @@ type Environment interface {
 	BlockNumber() *big.Int
 	GetHash(n uint64) common.Hash
 	Coinbase() common.Address
-	Time() int64
+	Time() uint64
 	Difficulty() *big.Int
 	GasLimit() *big.Int
 	Transfer(from, to Account, amount *big.Int) error

--- a/core/vm/vm.go
+++ b/core/vm/vm.go
@@ -444,7 +444,7 @@ func (self *Vm) Run(context *Context, input []byte) (ret []byte, err error) {
 		case TIMESTAMP:
 			time := self.env.Time()
 
-			stack.push(big.NewInt(time))
+			stack.push(new(big.Int).SetUint64(time))
 
 		case NUMBER:
 			number := self.env.BlockNumber()

--- a/core/vm_env.go
+++ b/core/vm_env.go
@@ -33,7 +33,7 @@ func NewEnv(state *state.StateDB, chain *ChainManager, msg Message, header *type
 func (self *VMEnv) Origin() common.Address   { f, _ := self.msg.From(); return f }
 func (self *VMEnv) BlockNumber() *big.Int    { return self.header.Number }
 func (self *VMEnv) Coinbase() common.Address { return self.header.Coinbase }
-func (self *VMEnv) Time() int64              { return int64(self.header.Time) }
+func (self *VMEnv) Time() uint64             { return self.header.Time }
 func (self *VMEnv) Difficulty() *big.Int     { return self.header.Difficulty }
 func (self *VMEnv) GasLimit() *big.Int       { return self.header.GasLimit }
 func (self *VMEnv) Value() *big.Int          { return self.msg.Value() }

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -368,8 +368,8 @@ func (self *worker) commitNewWork() {
 	tstart := time.Now()
 	parent := self.chain.CurrentBlock()
 	tstamp := tstart.Unix()
-	if tstamp <= parent.Time() {
-		tstamp = parent.Time() + 1
+	if tstamp <= int64(parent.Time()) {
+		tstamp = int64(parent.Time()) + 1
 	}
 	// this will ensure we're not going off too far in the future
 	if now := time.Now().Unix(); tstamp > now+4 {
@@ -382,7 +382,7 @@ func (self *worker) commitNewWork() {
 	header := &types.Header{
 		ParentHash: parent.Hash(),
 		Number:     num.Add(num, common.Big1),
-		Difficulty: core.CalcDifficulty(tstamp, parent.Time(), parent.Difficulty()),
+		Difficulty: core.CalcDifficulty(int64(tstamp), int64(parent.Time()), parent.Difficulty()),
 		GasLimit:   core.CalcGasLimit(parent),
 		GasUsed:    new(big.Int),
 		Coinbase:   self.coinbase,

--- a/tests/util.go
+++ b/tests/util.go
@@ -120,7 +120,7 @@ type Env struct {
 	coinbase common.Address
 
 	number     *big.Int
-	time       int64
+	time       uint64
 	difficulty *big.Int
 	gasLimit   *big.Int
 
@@ -150,7 +150,7 @@ func NewEnvFromMap(state *state.StateDB, envValues map[string]string, exeValues 
 	//env.parent = common.Hex2Bytes(envValues["previousHash"])
 	env.coinbase = common.HexToAddress(envValues["currentCoinbase"])
 	env.number = common.Big(envValues["currentNumber"])
-	env.time = common.Big(envValues["currentTimestamp"]).Int64()
+	env.time = common.Big(envValues["currentTimestamp"]).Uint64()
 	env.difficulty = common.Big(envValues["currentDifficulty"])
 	env.gasLimit = common.Big(envValues["currentGasLimit"])
 	env.Gas = new(big.Int)
@@ -163,7 +163,7 @@ func (self *Env) BlockNumber() *big.Int  { return self.number }
 
 //func (self *Env) PrevHash() []byte      { return self.parent }
 func (self *Env) Coinbase() common.Address { return self.coinbase }
-func (self *Env) Time() int64              { return self.time }
+func (self *Env) Time() uint64             { return self.time }
 func (self *Env) Difficulty() *big.Int     { return self.difficulty }
 func (self *Env) State() *state.StateDB    { return self.state }
 func (self *Env) GasLimit() *big.Int       { return self.gasLimit }

--- a/xeth/types.go
+++ b/xeth/types.go
@@ -60,7 +60,7 @@ type Block struct {
 	Hash         string       `json:"hash"`
 	Transactions *common.List `json:"transactions"`
 	Uncles       *common.List `json:"uncles"`
-	Time         int64        `json:"time"`
+	Time         uint64       `json:"time"`
 	Coinbase     string       `json:"coinbase"`
 	Name         string       `json:"name"`
 	GasLimit     string       `json:"gasLimit"`


### PR DESCRIPTION
This also moves the timestamp checks to before the difficulty check, as that check converts timestamps to int64 before calculating diff.

Note that the core block struct is not modified - it has always used uint64 for unix time field.