### PR TITLE
Implement server side packet handling for eth/62 and eth/63

### DIFF
--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -283,6 +283,7 @@ JavaScript API. See https://github.com/ethereum/go-ethereum/wiki/Javascipt-Conso
 		utils.DataDirFlag,
 		utils.BlockchainVersionFlag,
 		utils.OlympicFlag,
+		utils.EthVersionFlag,
 		utils.CacheFlag,
 		utils.JSpathFlag,
 		utils.ListenPortFlag,
@@ -333,6 +334,7 @@ JavaScript API. See https://github.com/ethereum/go-ethereum/wiki/Javascipt-Conso
 	app.Before = func(ctx *cli.Context) error {
 		utils.SetupLogger(ctx)
 		utils.SetupVM(ctx)
+		utils.SetupEth(ctx)
 		if ctx.GlobalBool(utils.PProfEanbledFlag.Name) {
 			utils.StartPProf(ctx)
 		}

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -138,6 +138,11 @@ var (
 		Name:  "olympic",
 		Usage: "Use olympic style protocol",
 	}
+	EthVersionFlag = cli.IntFlag{
+		Name:  "eth",
+		Value: 61,
+		Usage: "Highest eth protocol to advertise (temporary, dev option)",
+	}
 
 	// miner settings
 	MinerThreadsFlag = cli.IntFlag{
@@ -457,6 +462,18 @@ func SetupVM(ctx *cli.Context) {
 	vm.EnableJit = ctx.GlobalBool(VMEnableJitFlag.Name)
 	vm.ForceJit = ctx.GlobalBool(VMForceJitFlag.Name)
 	vm.SetJITCacheSize(ctx.GlobalInt(VMJitCacheFlag.Name))
+}
+
+// SetupEth configures the eth packages global settings
+func SetupEth(ctx *cli.Context) {
+	version := ctx.GlobalInt(EthVersionFlag.Name)
+	for len(eth.ProtocolVersions) > 0 && eth.ProtocolVersions[0] > uint(version) {
+		eth.ProtocolVersions = eth.ProtocolVersions[1:]
+		eth.ProtocolLengths = eth.ProtocolLengths[1:]
+	}
+	if len(eth.ProtocolVersions) == 0 {
+		Fatalf("No valid eth protocols remaining")
+	}
 }
 
 // MakeChain creates a chain manager from set command line flags.

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -373,7 +373,7 @@ func New(config *Config) (*Ethereum, error) {
 
 	eth.blockProcessor = core.NewBlockProcessor(chainDb, eth.pow, eth.chainManager, eth.EventMux())
 	eth.chainManager.SetProcessor(eth.blockProcessor)
-	eth.protocolManager = NewProtocolManager(config.NetworkId, eth.eventMux, eth.txPool, eth.pow, eth.chainManager)
+	eth.protocolManager = NewProtocolManager(config.NetworkId, eth.eventMux, eth.txPool, eth.pow, eth.chainManager, chainDb)
 
 	eth.miner = miner.New(eth, eth.EventMux(), eth.pow)
 	eth.miner.SetGasPrice(config.GasPrice)

--- a/eth/downloader/downloader.go
+++ b/eth/downloader/downloader.go
@@ -39,6 +39,7 @@ import (
 const (
 	eth60 = 60 // Constant to check for old protocol support
 	eth61 = 61 // Constant to check for new protocol support
+	eth62 = 62 // Constant to check for experimental protocol support
 )
 
 var (
@@ -329,7 +330,7 @@ func (d *Downloader) syncWithPeer(p *peer, hash common.Hash, td *big.Int) (err e
 		if err = d.fetchBlocks60(); err != nil {
 			return err
 		}
-	case eth61:
+	case eth61, eth62:
 		// New eth/61, use forward, concurrent hash and block retrieval algorithm
 		number, err := d.findAncestor(p)
 		if err != nil {

--- a/eth/downloader/downloader.go
+++ b/eth/downloader/downloader.go
@@ -39,7 +39,6 @@ import (
 const (
 	eth60 = 60 // Constant to check for old protocol support
 	eth61 = 61 // Constant to check for new protocol support
-	eth62 = 62 // Constant to check for experimental protocol support
 )
 
 var (
@@ -332,7 +331,7 @@ func (d *Downloader) syncWithPeer(p *peer, hash common.Hash, td *big.Int) (err e
 		if err = d.fetchBlocks60(); err != nil {
 			return err
 		}
-	case eth61, eth62:
+	case eth61:
 		// New eth/61, use forward, concurrent hash and block retrieval algorithm
 		number, err := d.findAncestor(p)
 		if err != nil {

--- a/eth/downloader/downloader.go
+++ b/eth/downloader/downloader.go
@@ -47,6 +47,7 @@ var (
 	MaxHashFetch   = 512 // Amount of hashes to be fetched per retrieval request
 	MaxBlockFetch  = 128 // Amount of blocks to be fetched per retrieval request
 	MaxHeaderFetch = 256 // Amount of block headers to be fetched per retrieval request
+	MaxStateFetch  = 384 // Amount of node
 
 	hashTTL         = 5 * time.Second  // Time it takes for a hash request to time out
 	blockSoftTTL    = 3 * time.Second  // Request completion threshold for increasing or decreasing a peer's bandwidth

--- a/eth/downloader/downloader.go
+++ b/eth/downloader/downloader.go
@@ -43,9 +43,10 @@ const (
 )
 
 var (
-	MinHashFetch  = 512 // Minimum amount of hashes to not consider a peer stalling
-	MaxHashFetch  = 512 // Amount of hashes to be fetched per retrieval request
-	MaxBlockFetch = 128 // Amount of blocks to be fetched per retrieval request
+	MinHashFetch   = 512 // Minimum amount of hashes to not consider a peer stalling
+	MaxHashFetch   = 512 // Amount of hashes to be fetched per retrieval request
+	MaxBlockFetch  = 128 // Amount of blocks to be fetched per retrieval request
+	MaxHeaderFetch = 256 // Amount of block headers to be fetched per retrieval request
 
 	hashTTL         = 5 * time.Second  // Time it takes for a hash request to time out
 	blockSoftTTL    = 3 * time.Second  // Request completion threshold for increasing or decreasing a peer's bandwidth

--- a/eth/downloader/downloader.go
+++ b/eth/downloader/downloader.go
@@ -42,11 +42,12 @@ const (
 )
 
 var (
-	MinHashFetch   = 512 // Minimum amount of hashes to not consider a peer stalling
-	MaxHashFetch   = 512 // Amount of hashes to be fetched per retrieval request
-	MaxBlockFetch  = 128 // Amount of blocks to be fetched per retrieval request
-	MaxHeaderFetch = 256 // Amount of block headers to be fetched per retrieval request
-	MaxStateFetch  = 384 // Amount of node
+	MinHashFetch     = 512 // Minimum amount of hashes to not consider a peer stalling
+	MaxHashFetch     = 512 // Amount of hashes to be fetched per retrieval request
+	MaxBlockFetch    = 128 // Amount of blocks to be fetched per retrieval request
+	MaxHeaderFetch   = 256 // Amount of block headers to be fetched per retrieval request
+	MaxStateFetch    = 384 // Amount of node state values to allow fetching per request
+	MaxReceiptsFetch = 384 // Amount of transaction receipts to allow fetching per request
 
 	hashTTL         = 5 * time.Second  // Time it takes for a hash request to time out
 	blockSoftTTL    = 3 * time.Second  // Request completion threshold for increasing or decreasing a peer's bandwidth

--- a/eth/fetcher/fetcher.go
+++ b/eth/fetcher/fetcher.go
@@ -69,8 +69,9 @@ type peerDropFn func(id string)
 // announce is the hash notification of the availability of a new block in the
 // network.
 type announce struct {
-	hash common.Hash // Hash of the block being announced
-	time time.Time   // Timestamp of the announcement
+	hash   common.Hash // Hash of the block being announced
+	number uint64      // Number of the block being announced (0 = unknown | old protocol)
+	time   time.Time   // Timestamp of the announcement
 
 	origin string           // Identifier of the peer originating the notification
 	fetch  blockRequesterFn // Fetcher function to retrieve
@@ -152,9 +153,10 @@ func (f *Fetcher) Stop() {
 
 // Notify announces the fetcher of the potential availability of a new block in
 // the network.
-func (f *Fetcher) Notify(peer string, hash common.Hash, time time.Time, fetcher blockRequesterFn) error {
+func (f *Fetcher) Notify(peer string, hash common.Hash, number uint64, time time.Time, fetcher blockRequesterFn) error {
 	block := &announce{
 		hash:   hash,
+		number: number,
 		time:   time,
 		origin: peer,
 		fetch:  fetcher,

--- a/eth/handler_test.go
+++ b/eth/handler_test.go
@@ -19,9 +19,12 @@ import (
 
 // Tests that hashes can be retrieved from a remote chain by hashes in reverse
 // order.
-func TestGetBlockHashes(t *testing.T) {
+func TestGetBlockHashes60(t *testing.T) { testGetBlockHashes(t, 60) }
+func TestGetBlockHashes61(t *testing.T) { testGetBlockHashes(t, 61) }
+
+func testGetBlockHashes(t *testing.T, protocol int) {
 	pm := newTestProtocolManager(downloader.MaxHashFetch+15, nil, nil)
-	peer, _ := newTestPeer("peer", pm, true)
+	peer, _ := newTestPeer("peer", protocol, pm, true)
 	defer peer.close()
 
 	// Create a batch of tests for various scenarios
@@ -60,9 +63,12 @@ func TestGetBlockHashes(t *testing.T) {
 
 // Tests that hashes can be retrieved from a remote chain by numbers in forward
 // order.
-func TestGetBlockHashesFromNumber(t *testing.T) {
+func TestGetBlockHashesFromNumber60(t *testing.T) { testGetBlockHashesFromNumber(t, 60) }
+func TestGetBlockHashesFromNumber61(t *testing.T) { testGetBlockHashesFromNumber(t, 61) }
+
+func testGetBlockHashesFromNumber(t *testing.T, protocol int) {
 	pm := newTestProtocolManager(downloader.MaxHashFetch+15, nil, nil)
-	peer, _ := newTestPeer("peer", pm, true)
+	peer, _ := newTestPeer("peer", protocol, pm, true)
 	defer peer.close()
 
 	// Create a batch of tests for various scenarios
@@ -98,9 +104,12 @@ func TestGetBlockHashesFromNumber(t *testing.T) {
 }
 
 // Tests that blocks can be retrieved from a remote chain based on their hashes.
-func TestGetBlocks(t *testing.T) {
+func TestGetBlocks60(t *testing.T) { testGetBlocks(t, 60) }
+func TestGetBlocks61(t *testing.T) { testGetBlocks(t, 61) }
+
+func testGetBlocks(t *testing.T, protocol int) {
 	pm := newTestProtocolManager(downloader.MaxHashFetch+15, nil, nil)
-	peer, _ := newTestPeer("peer", pm, true)
+	peer, _ := newTestPeer("peer", protocol, pm, true)
 	defer peer.close()
 
 	// Create a batch of tests for various scenarios
@@ -166,9 +175,9 @@ func TestGetBlocks(t *testing.T) {
 }
 
 // Tests that block headers can be retrieved from a remote chain based on their hashes.
-func TestGetBlockHeaders(t *testing.T) {
+func TestGetBlockHeaders62(t *testing.T) {
 	pm := newTestProtocolManager(downloader.MaxHashFetch+15, nil, nil)
-	peer, _ := newTestPeer("peer", pm, true)
+	peer, _ := newTestPeer("peer", 62, pm, true)
 	defer peer.close()
 
 	// Create a batch of tests for various scenarios
@@ -226,15 +235,15 @@ func TestGetBlockHeaders(t *testing.T) {
 			}
 		}
 		// Send the hash request and verify the response
-		p2p.Send(peer.app, 0x09, hashes)
-		if err := p2p.ExpectMsg(peer.app, 0x0a, headers); err != nil {
+		p2p.Send(peer.app, 0x03, hashes)
+		if err := p2p.ExpectMsg(peer.app, 0x04, headers); err != nil {
 			t.Errorf("test %d: headers mismatch: %v", i, err)
 		}
 	}
 }
 
 // Tests that the node state database can be retrieved based on hashes.
-func TestGetNodeData(t *testing.T) {
+func TestGetNodeData63(t *testing.T) {
 	// Define three accounts to simulate transactions with
 	acc1Key, _ := crypto.HexToECDSA("8a1f9a8f95be41cd7ccb6168179afb4504aefe388d1e14474d32c45c72ce7b7a")
 	acc2Key, _ := crypto.HexToECDSA("49a7b37aa6f6645917e7b807e9d1c00d4fa71f18343b0d4122a4d2df64dd6fee")
@@ -271,7 +280,7 @@ func TestGetNodeData(t *testing.T) {
 	}
 	// Assemble the test environment
 	pm := newTestProtocolManager(4, generator, nil)
-	peer, _ := newTestPeer("peer", pm, true)
+	peer, _ := newTestPeer("peer", 63, pm, true)
 	defer peer.close()
 
 	// Fetch for now the entire state db
@@ -279,12 +288,12 @@ func TestGetNodeData(t *testing.T) {
 	for _, key := range pm.statedb.(*ethdb.MemDatabase).Keys() {
 		hashes = append(hashes, common.BytesToHash(key))
 	}
-	p2p.Send(peer.app, 0x0b, hashes)
+	p2p.Send(peer.app, 0x0d, hashes)
 	msg, err := peer.app.ReadMsg()
 	if err != nil {
 		t.Fatalf("failed to read node data response: %v", err)
 	}
-	if msg.Code != 0x0c {
+	if msg.Code != 0x0e {
 		t.Fatalf("response packet code mismatch: have %x, want %x", msg.Code, 0x0c)
 	}
 	var data [][]byte

--- a/eth/handler_test.go
+++ b/eth/handler_test.go
@@ -1,0 +1,89 @@
+package eth
+
+import (
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/eth/downloader"
+	"github.com/ethereum/go-ethereum/p2p"
+)
+
+// Tests that hashes can be retrieved from a remote chain by hashes in reverse
+// order.
+func TestGetBlockHashes(t *testing.T) {
+	pm := newTestProtocolManager(downloader.MaxHashFetch+15, nil)
+	peer, _ := newTestPeer("peer", pm, true)
+	defer peer.close()
+
+	// Create a batch of tests for various scenarios
+	limit := downloader.MaxHashFetch
+	tests := []struct {
+		origin common.Hash
+		number int
+		result int
+	}{
+		{common.Hash{}, 1, 0},                                 // Make sure non existent hashes don't return results
+		{pm.chainman.Genesis().Hash(), 1, 0},                  // There are no hashes to retrieve up from the genesis
+		{pm.chainman.GetBlockByNumber(5).Hash(), 5, 5},        // All the hashes including the genesis requested
+		{pm.chainman.GetBlockByNumber(5).Hash(), 10, 5},       // More hashes than available till the genesis requested
+		{pm.chainman.GetBlockByNumber(100).Hash(), 10, 10},    // All hashes available from the middle of the chain
+		{pm.chainman.CurrentBlock().Hash(), 10, 10},           // All hashes available from the head of the chain
+		{pm.chainman.CurrentBlock().Hash(), limit, limit},     // Request the maximum allowed hash count
+		{pm.chainman.CurrentBlock().Hash(), limit + 1, limit}, // Request more than the maximum allowed hash count
+	}
+	// Run each of the tests and verify the results against the chain
+	for i, tt := range tests {
+		// Assemble the hash response we would like to receive
+		resp := make([]common.Hash, tt.result)
+		if len(resp) > 0 {
+			from := pm.chainman.GetBlock(tt.origin).NumberU64() - 1
+			for j := 0; j < len(resp); j++ {
+				resp[j] = pm.chainman.GetBlockByNumber(uint64(int(from) - j)).Hash()
+			}
+		}
+		// Send the hash request and verify the response
+		p2p.Send(peer.app, 0x03, getBlockHashesData{tt.origin, uint64(tt.number)})
+		if err := p2p.ExpectMsg(peer.app, 0x04, resp); err != nil {
+			t.Errorf("test %d: block hashes mismatch: %v", i, err)
+		}
+	}
+}
+
+// Tests that hashes can be retrieved from a remote chain by numbers in forward
+// order.
+func TestGetBlockHashesFromNumber(t *testing.T) {
+	pm := newTestProtocolManager(downloader.MaxHashFetch+15, nil)
+	peer, _ := newTestPeer("peer", pm, true)
+	defer peer.close()
+
+	// Create a batch of tests for various scenarios
+	limit := downloader.MaxHashFetch
+	tests := []struct {
+		origin uint64
+		number int
+		result int
+	}{
+		{pm.chainman.CurrentBlock().NumberU64() + 1, 1, 0},     // Out of bounds requests should return empty
+		{pm.chainman.CurrentBlock().NumberU64(), 1, 1},         // Make sure the head hash can be retrieved
+		{pm.chainman.CurrentBlock().NumberU64() - 4, 5, 5},     // All hashes, including the head hash requested
+		{pm.chainman.CurrentBlock().NumberU64() - 4, 10, 5},    // More hashes requested than available till the head
+		{pm.chainman.CurrentBlock().NumberU64() - 100, 10, 10}, // All hashes available from the middle of the chain
+		{0, 10, 10},           // All hashes available from the root of the chain
+		{0, limit, limit},     // Request the maximum allowed hash count
+		{0, limit + 1, limit}, // Request more than the maximum allowed hash count
+		{0, 1, 1},             // Make sure the genesis hash can be retrieved
+	}
+	// Run each of the tests and verify the results against the chain
+	for i, tt := range tests {
+		// Assemble the hash response we would like to receive
+		resp := make([]common.Hash, tt.result)
+		for j := 0; j < len(resp); j++ {
+			resp[j] = pm.chainman.GetBlockByNumber(tt.origin + uint64(j)).Hash()
+		}
+		// Send the hash request and verify the response
+		p2p.Send(peer.app, 0x08, getBlockHashesFromNumberData{tt.origin, uint64(tt.number)})
+		if err := p2p.ExpectMsg(peer.app, 0x04, resp); err != nil {
+			t.Errorf("test %d: block hashes mismatch: %v", i, err)
+		}
+	}
+}

--- a/eth/handler_test.go
+++ b/eth/handler_test.go
@@ -1,17 +1,26 @@
 package eth
 
 import (
+	"fmt"
+	"math/big"
+	"math/rand"
 	"testing"
 
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core"
+	"github.com/ethereum/go-ethereum/core/state"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/eth/downloader"
+	"github.com/ethereum/go-ethereum/ethdb"
 	"github.com/ethereum/go-ethereum/p2p"
+	"github.com/ethereum/go-ethereum/params"
 )
 
 // Tests that hashes can be retrieved from a remote chain by hashes in reverse
 // order.
 func TestGetBlockHashes(t *testing.T) {
-	pm := newTestProtocolManager(downloader.MaxHashFetch+15, nil)
+	pm := newTestProtocolManager(downloader.MaxHashFetch+15, nil, nil)
 	peer, _ := newTestPeer("peer", pm, true)
 	defer peer.close()
 
@@ -52,7 +61,7 @@ func TestGetBlockHashes(t *testing.T) {
 // Tests that hashes can be retrieved from a remote chain by numbers in forward
 // order.
 func TestGetBlockHashesFromNumber(t *testing.T) {
-	pm := newTestProtocolManager(downloader.MaxHashFetch+15, nil)
+	pm := newTestProtocolManager(downloader.MaxHashFetch+15, nil, nil)
 	peer, _ := newTestPeer("peer", pm, true)
 	defer peer.close()
 
@@ -84,6 +93,228 @@ func TestGetBlockHashesFromNumber(t *testing.T) {
 		p2p.Send(peer.app, 0x08, getBlockHashesFromNumberData{tt.origin, uint64(tt.number)})
 		if err := p2p.ExpectMsg(peer.app, 0x04, resp); err != nil {
 			t.Errorf("test %d: block hashes mismatch: %v", i, err)
+		}
+	}
+}
+
+// Tests that blocks can be retrieved from a remote chain based on their hashes.
+func TestGetBlocks(t *testing.T) {
+	pm := newTestProtocolManager(downloader.MaxHashFetch+15, nil, nil)
+	peer, _ := newTestPeer("peer", pm, true)
+	defer peer.close()
+
+	// Create a batch of tests for various scenarios
+	limit := downloader.MaxBlockFetch
+	tests := []struct {
+		random    int           // Number of blocks to fetch randomly from the chain
+		explicit  []common.Hash // Explicitly requested blocks
+		available []bool        // Availability of explicitly requested blocks
+		expected  int           // Total number of existing blocks to expect
+	}{
+		{1, nil, nil, 1},                                                       // A single random block should be retrievable
+		{10, nil, nil, 10},                                                     // Multiple random blocks should be retrievable
+		{limit, nil, nil, limit},                                               // The maximum possible blocks should be retrievable
+		{limit + 1, nil, nil, limit},                                           // No more that the possible block count should be returned
+		{0, []common.Hash{pm.chainman.Genesis().Hash()}, []bool{true}, 1},      // The genesis block should be retrievable
+		{0, []common.Hash{pm.chainman.CurrentBlock().Hash()}, []bool{true}, 1}, // The chains head block should be retrievable
+		{0, []common.Hash{common.Hash{}}, []bool{false}, 0},                    // A non existent block should not be returned
+
+		// Existing and non-existing blocks interleaved should not cause problems
+		{0, []common.Hash{
+			common.Hash{},
+			pm.chainman.GetBlockByNumber(1).Hash(),
+			common.Hash{},
+			pm.chainman.GetBlockByNumber(10).Hash(),
+			common.Hash{},
+			pm.chainman.GetBlockByNumber(100).Hash(),
+			common.Hash{},
+		}, []bool{false, true, false, true, false, true, false}, 3},
+	}
+	// Run each of the tests and verify the results against the chain
+	for i, tt := range tests {
+		// Collect the hashes to request, and the response to expect
+		hashes, seen := []common.Hash{}, make(map[int64]bool)
+		blocks := []*types.Block{}
+
+		for j := 0; j < tt.random; j++ {
+			for {
+				num := rand.Int63n(int64(pm.chainman.CurrentBlock().NumberU64()))
+				if !seen[num] {
+					seen[num] = true
+
+					block := pm.chainman.GetBlockByNumber(uint64(num))
+					hashes = append(hashes, block.Hash())
+					if len(blocks) < tt.expected {
+						blocks = append(blocks, block)
+					}
+					break
+				}
+			}
+		}
+		for j, hash := range tt.explicit {
+			hashes = append(hashes, hash)
+			if tt.available[j] && len(blocks) < tt.expected {
+				blocks = append(blocks, pm.chainman.GetBlock(hash))
+			}
+		}
+		// Send the hash request and verify the response
+		p2p.Send(peer.app, 0x05, hashes)
+		if err := p2p.ExpectMsg(peer.app, 0x06, blocks); err != nil {
+			t.Errorf("test %d: blocks mismatch: %v", i, err)
+		}
+	}
+}
+
+// Tests that block headers can be retrieved from a remote chain based on their hashes.
+func TestGetBlockHeaders(t *testing.T) {
+	pm := newTestProtocolManager(downloader.MaxHashFetch+15, nil, nil)
+	peer, _ := newTestPeer("peer", pm, true)
+	defer peer.close()
+
+	// Create a batch of tests for various scenarios
+	limit := downloader.MaxHeaderFetch
+	tests := []struct {
+		random    int           // Number of blocks to fetch randomly from the chain
+		explicit  []common.Hash // Explicitly requested blocks
+		available []bool        // Availability of explicitly requested blocks
+		expected  int           // Total number of existing blocks to expect
+	}{
+		{1, nil, nil, 1},                                                       // A single random block should be retrievable
+		{10, nil, nil, 10},                                                     // Multiple random blocks should be retrievable
+		{limit, nil, nil, limit},                                               // The maximum possible blocks should be retrievable
+		{limit + 1, nil, nil, limit},                                           // No more that the possible block count should be returned
+		{0, []common.Hash{pm.chainman.Genesis().Hash()}, []bool{true}, 1},      // The genesis block should be retrievable
+		{0, []common.Hash{pm.chainman.CurrentBlock().Hash()}, []bool{true}, 1}, // The chains head block should be retrievable
+		{0, []common.Hash{common.Hash{}}, []bool{false}, 0},                    // A non existent block should not be returned
+
+		// Existing and non-existing blocks interleaved should not cause problems
+		{0, []common.Hash{
+			common.Hash{},
+			pm.chainman.GetBlockByNumber(1).Hash(),
+			common.Hash{},
+			pm.chainman.GetBlockByNumber(10).Hash(),
+			common.Hash{},
+			pm.chainman.GetBlockByNumber(100).Hash(),
+			common.Hash{},
+		}, []bool{false, true, false, true, false, true, false}, 3},
+	}
+	// Run each of the tests and verify the results against the chain
+	for i, tt := range tests {
+		// Collect the hashes to request, and the response to expect
+		hashes, seen := []common.Hash{}, make(map[int64]bool)
+		headers := []*types.Header{}
+
+		for j := 0; j < tt.random; j++ {
+			for {
+				num := rand.Int63n(int64(pm.chainman.CurrentBlock().NumberU64()))
+				if !seen[num] {
+					seen[num] = true
+
+					block := pm.chainman.GetBlockByNumber(uint64(num))
+					hashes = append(hashes, block.Hash())
+					if len(headers) < tt.expected {
+						headers = append(headers, block.Header())
+					}
+					break
+				}
+			}
+		}
+		for j, hash := range tt.explicit {
+			hashes = append(hashes, hash)
+			if tt.available[j] && len(headers) < tt.expected {
+				headers = append(headers, pm.chainman.GetBlock(hash).Header())
+			}
+		}
+		// Send the hash request and verify the response
+		p2p.Send(peer.app, 0x09, hashes)
+		if err := p2p.ExpectMsg(peer.app, 0x0a, headers); err != nil {
+			t.Errorf("test %d: headers mismatch: %v", i, err)
+		}
+	}
+}
+
+// Tests that the node state database can be retrieved based on hashes.
+func TestGetNodeData(t *testing.T) {
+	// Define three accounts to simulate transactions with
+	acc1Key, _ := crypto.HexToECDSA("8a1f9a8f95be41cd7ccb6168179afb4504aefe388d1e14474d32c45c72ce7b7a")
+	acc2Key, _ := crypto.HexToECDSA("49a7b37aa6f6645917e7b807e9d1c00d4fa71f18343b0d4122a4d2df64dd6fee")
+	acc1Addr := crypto.PubkeyToAddress(acc1Key.PublicKey)
+	acc2Addr := crypto.PubkeyToAddress(acc2Key.PublicKey)
+
+	// Create a chain generator with some simple transactions (blatantly stolen from @fjl/chain_makerts_test)
+	generator := func(i int, block *core.BlockGen) {
+		switch i {
+		case 0:
+			// In block 1, the test bank sends account #1 some ether.
+			tx, _ := types.NewTransaction(block.TxNonce(testBankAddress), acc1Addr, big.NewInt(10000), params.TxGas, nil, nil).SignECDSA(testBankKey)
+			block.AddTx(tx)
+		case 1:
+			// In block 2, the test bank sends some more ether to account #1.
+			// acc1Addr passes it on to account #2.
+			tx1, _ := types.NewTransaction(block.TxNonce(testBankAddress), acc1Addr, big.NewInt(1000), params.TxGas, nil, nil).SignECDSA(testBankKey)
+			tx2, _ := types.NewTransaction(block.TxNonce(acc1Addr), acc2Addr, big.NewInt(1000), params.TxGas, nil, nil).SignECDSA(acc1Key)
+			block.AddTx(tx1)
+			block.AddTx(tx2)
+		case 2:
+			// Block 3 is empty but was mined by account #2.
+			block.SetCoinbase(acc2Addr)
+			block.SetExtra([]byte("yeehaw"))
+		case 3:
+			// Block 4 includes blocks 2 and 3 as uncle headers (with modified extra data).
+			b2 := block.PrevBlock(1).Header()
+			b2.Extra = []byte("foo")
+			block.AddUncle(b2)
+			b3 := block.PrevBlock(2).Header()
+			b3.Extra = []byte("foo")
+			block.AddUncle(b3)
+		}
+	}
+	// Assemble the test environment
+	pm := newTestProtocolManager(4, generator, nil)
+	peer, _ := newTestPeer("peer", pm, true)
+	defer peer.close()
+
+	// Fetch for now the entire state db
+	hashes := []common.Hash{}
+	for _, key := range pm.statedb.(*ethdb.MemDatabase).Keys() {
+		hashes = append(hashes, common.BytesToHash(key))
+	}
+	p2p.Send(peer.app, 0x0b, hashes)
+	msg, err := peer.app.ReadMsg()
+	if err != nil {
+		t.Fatalf("failed to read node data response: %v", err)
+	}
+	if msg.Code != 0x0c {
+		t.Fatalf("response packet code mismatch: have %x, want %x", msg.Code, 0x0c)
+	}
+	var data [][]byte
+	if err := msg.Decode(&data); err != nil {
+		t.Fatalf("failed to decode response node data: %v", err)
+	}
+	// Verify that all hashes correspond to the requested data, and reconstruct a state tree
+	for i, want := range hashes {
+		if hash := crypto.Sha3Hash(data[i]); hash != want {
+			fmt.Errorf("data hash mismatch: have %x, want %x", hash, want)
+		}
+	}
+	statedb, _ := ethdb.NewMemDatabase()
+	for i := 0; i < len(data); i++ {
+		statedb.Put(hashes[i].Bytes(), data[i])
+	}
+	accounts := []common.Address{testBankAddress, acc1Addr, acc2Addr}
+	for i := uint64(0); i <= pm.chainman.CurrentBlock().NumberU64(); i++ {
+		trie := state.New(pm.chainman.GetBlockByNumber(i).Root(), statedb)
+
+		for j, acc := range accounts {
+			bw := pm.chainman.State().GetBalance(acc)
+			bh := trie.GetBalance(acc)
+
+			if (bw != nil && bh == nil) || (bw == nil && bh != nil) {
+				t.Errorf("test %d, account %d: balance mismatch: have %v, want %v", i, j, bh, bw)
+			}
+			if bw != nil && bh != nil && bw.Cmp(bw) != 0 {
+				t.Errorf("test %d, account %d: balance mismatch: have %v, want %v", i, j, bh, bw)
+			}
 		}
 	}
 }

--- a/eth/helper_test.go
+++ b/eth/helper_test.go
@@ -1,0 +1,140 @@
+// This file contains some shares testing functionality, common to  multiple
+// different files and modules being tested.
+
+package eth
+
+import (
+	"crypto/rand"
+	"math/big"
+	"sync"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/ethdb"
+	"github.com/ethereum/go-ethereum/event"
+	"github.com/ethereum/go-ethereum/p2p"
+	"github.com/ethereum/go-ethereum/p2p/discover"
+)
+
+// newTestProtocolManager creates a new protocol manager for testing purposes,
+// with the given number of blocks already known, and potential notification
+// channels for different events.
+func newTestProtocolManager(blocks int, newtx chan<- []*types.Transaction) *ProtocolManager {
+	var (
+		emux        = new(event.TypeMux)
+		pow         = new(core.FakePow)
+		db, _       = ethdb.NewMemDatabase()
+		genesis     = core.WriteGenesisBlockForTesting(db, common.Address{}, big.NewInt(0))
+		chainman, _ = core.NewChainManager(db, pow, emux)
+		blockproc   = core.NewBlockProcessor(db, pow, chainman, emux)
+	)
+	chainman.SetProcessor(blockproc)
+	chainman.InsertChain(core.GenerateChain(genesis, db, blocks, nil))
+
+	pm := NewProtocolManager(NetworkId, emux, &testTxPool{added: newtx}, pow, chainman)
+	pm.Start()
+	return pm
+}
+
+// testTxPool is a fake, helper transaction pool for testing purposes
+type testTxPool struct {
+	pool  []*types.Transaction        // Collection of all transactions
+	added chan<- []*types.Transaction // Notification channel for new transactions
+
+	lock sync.RWMutex // Protects the transaction pool
+}
+
+// AddTransactions appends a batch of transactions to the pool, and notifies any
+// listeners if the addition channel is non nil
+func (p *testTxPool) AddTransactions(txs []*types.Transaction) {
+	p.lock.Lock()
+	defer p.lock.Unlock()
+
+	p.pool = append(p.pool, txs...)
+	if p.added != nil {
+		p.added <- txs
+	}
+}
+
+// GetTransactions returns all the transactions known to the pool
+func (p *testTxPool) GetTransactions() types.Transactions {
+	p.lock.RLock()
+	defer p.lock.RUnlock()
+
+	txs := make([]*types.Transaction, len(p.pool))
+	copy(txs, p.pool)
+
+	return txs
+}
+
+// newTestTransaction create a new dummy transaction.
+func newTestTransaction(from *crypto.Key, nonce uint64, datasize int) *types.Transaction {
+	tx := types.NewTransaction(nonce, common.Address{}, big.NewInt(0), big.NewInt(100000), big.NewInt(0), make([]byte, datasize))
+	tx, _ = tx.SignECDSA(from.PrivateKey)
+
+	return tx
+}
+
+// testPeer is a simulated peer to allow testing direct network calls.
+type testPeer struct {
+	net p2p.MsgReadWriter // Network layer reader/writer to simulate remote messaging
+	app *p2p.MsgPipeRW    // Application layer reader/writer to simulate the local side
+	*peer
+}
+
+// newTestPeer creates a new peer registered at the given protocol manager.
+func newTestPeer(name string, pm *ProtocolManager, shake bool) (*testPeer, <-chan error) {
+	// Create a message pipe to communicate through
+	app, net := p2p.MsgPipe()
+
+	// Generate a random id and create the peer
+	var id discover.NodeID
+	rand.Read(id[:])
+
+	peer := pm.newPeer(int(ProtocolVersions[0]), NetworkId, p2p.NewPeer(id, name, nil), net)
+
+	// Start the peer on a new thread
+	errc := make(chan error, 1)
+	go func() {
+		pm.newPeerCh <- peer
+		errc <- pm.handle(peer)
+	}()
+	tp := &testPeer{
+		app:  app,
+		net:  net,
+		peer: peer,
+	}
+	// Execute any implicitly requested handshakes and return
+	if shake {
+		td, head, genesis := pm.chainman.Status()
+		tp.handshake(nil, td, head, genesis)
+	}
+	return tp, errc
+}
+
+// handshake simulates a trivial handshake that expects the same state from the
+// remote side as we are simulating locally.
+func (p *testPeer) handshake(t *testing.T, td *big.Int, head common.Hash, genesis common.Hash) {
+	msg := &statusData{
+		ProtocolVersion: uint32(ProtocolVersions[0]),
+		NetworkId:       uint32(NetworkId),
+		TD:              td,
+		CurrentBlock:    head,
+		GenesisBlock:    genesis,
+	}
+	if err := p2p.ExpectMsg(p.app, StatusMsg, msg); err != nil {
+		t.Fatalf("status recv: %v", err)
+	}
+	if err := p2p.Send(p.app, StatusMsg, msg); err != nil {
+		t.Fatalf("status send: %v", err)
+	}
+}
+
+// close terminates the local side of the peer, notifying the remote protocol
+// manager of termination.
+func (p *testPeer) close() {
+	p.app.Close()
+}

--- a/eth/helper_test.go
+++ b/eth/helper_test.go
@@ -93,7 +93,7 @@ type testPeer struct {
 }
 
 // newTestPeer creates a new peer registered at the given protocol manager.
-func newTestPeer(name string, pm *ProtocolManager, shake bool) (*testPeer, <-chan error) {
+func newTestPeer(name string, version int, pm *ProtocolManager, shake bool) (*testPeer, <-chan error) {
 	// Create a message pipe to communicate through
 	app, net := p2p.MsgPipe()
 
@@ -101,7 +101,7 @@ func newTestPeer(name string, pm *ProtocolManager, shake bool) (*testPeer, <-cha
 	var id discover.NodeID
 	rand.Read(id[:])
 
-	peer := pm.newPeer(int(ProtocolVersions[0]), NetworkId, p2p.NewPeer(id, name, nil), net)
+	peer := pm.newPeer(version, NetworkId, p2p.NewPeer(id, name, nil), net)
 
 	// Start the peer on a new thread
 	errc := make(chan error, 1)
@@ -126,7 +126,7 @@ func newTestPeer(name string, pm *ProtocolManager, shake bool) (*testPeer, <-cha
 // remote side as we are simulating locally.
 func (p *testPeer) handshake(t *testing.T, td *big.Int, head common.Hash, genesis common.Hash) {
 	msg := &statusData{
-		ProtocolVersion: uint32(ProtocolVersions[0]),
+		ProtocolVersion: uint32(p.version),
 		NetworkId:       uint32(NetworkId),
 		TD:              td,
 		CurrentBlock:    head,

--- a/eth/metrics.go
+++ b/eth/metrics.go
@@ -22,44 +22,53 @@ import (
 )
 
 var (
-	propTxnInPacketsMeter    = metrics.NewMeter("eth/prop/txns/in/packets")
-	propTxnInTrafficMeter    = metrics.NewMeter("eth/prop/txns/in/traffic")
-	propTxnOutPacketsMeter   = metrics.NewMeter("eth/prop/txns/out/packets")
-	propTxnOutTrafficMeter   = metrics.NewMeter("eth/prop/txns/out/traffic")
-	propHashInPacketsMeter   = metrics.NewMeter("eth/prop/hashes/in/packets")
-	propHashInTrafficMeter   = metrics.NewMeter("eth/prop/hashes/in/traffic")
-	propHashOutPacketsMeter  = metrics.NewMeter("eth/prop/hashes/out/packets")
-	propHashOutTrafficMeter  = metrics.NewMeter("eth/prop/hashes/out/traffic")
-	propBlockInPacketsMeter  = metrics.NewMeter("eth/prop/blocks/in/packets")
-	propBlockInTrafficMeter  = metrics.NewMeter("eth/prop/blocks/in/traffic")
-	propBlockOutPacketsMeter = metrics.NewMeter("eth/prop/blocks/out/packets")
-	propBlockOutTrafficMeter = metrics.NewMeter("eth/prop/blocks/out/traffic")
-	reqHashInPacketsMeter    = metrics.NewMeter("eth/req/hashes/in/packets")
-	reqHashInTrafficMeter    = metrics.NewMeter("eth/req/hashes/in/traffic")
-	reqHashOutPacketsMeter   = metrics.NewMeter("eth/req/hashes/out/packets")
-	reqHashOutTrafficMeter   = metrics.NewMeter("eth/req/hashes/out/traffic")
-	reqBlockInPacketsMeter   = metrics.NewMeter("eth/req/blocks/in/packets")
-	reqBlockInTrafficMeter   = metrics.NewMeter("eth/req/blocks/in/traffic")
-	reqBlockOutPacketsMeter  = metrics.NewMeter("eth/req/blocks/out/packets")
-	reqBlockOutTrafficMeter  = metrics.NewMeter("eth/req/blocks/out/traffic")
-	reqHeaderInPacketsMeter  = metrics.NewMeter("eth/req/header/in/packets")
-	reqHeaderInTrafficMeter  = metrics.NewMeter("eth/req/header/in/traffic")
-	reqHeaderOutPacketsMeter = metrics.NewMeter("eth/req/header/out/packets")
-	reqHeaderOutTrafficMeter = metrics.NewMeter("eth/req/header/out/traffic")
-	reqStateInPacketsMeter   = metrics.NewMeter("eth/req/state/in/packets")
-	reqStateInTrafficMeter   = metrics.NewMeter("eth/req/state/in/traffic")
-	reqStateOutPacketsMeter  = metrics.NewMeter("eth/req/state/out/packets")
-	reqStateOutTrafficMeter  = metrics.NewMeter("eth/req/state/out/traffic")
-	miscInPacketsMeter       = metrics.NewMeter("eth/misc/in/packets")
-	miscInTrafficMeter       = metrics.NewMeter("eth/misc/in/traffic")
-	miscOutPacketsMeter      = metrics.NewMeter("eth/misc/out/packets")
-	miscOutTrafficMeter      = metrics.NewMeter("eth/misc/out/traffic")
+	propTxnInPacketsMeter     = metrics.NewMeter("eth/prop/txns/in/packets")
+	propTxnInTrafficMeter     = metrics.NewMeter("eth/prop/txns/in/traffic")
+	propTxnOutPacketsMeter    = metrics.NewMeter("eth/prop/txns/out/packets")
+	propTxnOutTrafficMeter    = metrics.NewMeter("eth/prop/txns/out/traffic")
+	propHashInPacketsMeter    = metrics.NewMeter("eth/prop/hashes/in/packets")
+	propHashInTrafficMeter    = metrics.NewMeter("eth/prop/hashes/in/traffic")
+	propHashOutPacketsMeter   = metrics.NewMeter("eth/prop/hashes/out/packets")
+	propHashOutTrafficMeter   = metrics.NewMeter("eth/prop/hashes/out/traffic")
+	propBlockInPacketsMeter   = metrics.NewMeter("eth/prop/blocks/in/packets")
+	propBlockInTrafficMeter   = metrics.NewMeter("eth/prop/blocks/in/traffic")
+	propBlockOutPacketsMeter  = metrics.NewMeter("eth/prop/blocks/out/packets")
+	propBlockOutTrafficMeter  = metrics.NewMeter("eth/prop/blocks/out/traffic")
+	reqHashInPacketsMeter     = metrics.NewMeter("eth/req/hashes/in/packets")
+	reqHashInTrafficMeter     = metrics.NewMeter("eth/req/hashes/in/traffic")
+	reqHashOutPacketsMeter    = metrics.NewMeter("eth/req/hashes/out/packets")
+	reqHashOutTrafficMeter    = metrics.NewMeter("eth/req/hashes/out/traffic")
+	reqBlockInPacketsMeter    = metrics.NewMeter("eth/req/blocks/in/packets")
+	reqBlockInTrafficMeter    = metrics.NewMeter("eth/req/blocks/in/traffic")
+	reqBlockOutPacketsMeter   = metrics.NewMeter("eth/req/blocks/out/packets")
+	reqBlockOutTrafficMeter   = metrics.NewMeter("eth/req/blocks/out/traffic")
+	reqHeaderInPacketsMeter   = metrics.NewMeter("eth/req/header/in/packets")
+	reqHeaderInTrafficMeter   = metrics.NewMeter("eth/req/header/in/traffic")
+	reqHeaderOutPacketsMeter  = metrics.NewMeter("eth/req/header/out/packets")
+	reqHeaderOutTrafficMeter  = metrics.NewMeter("eth/req/header/out/traffic")
+	reqBodyInPacketsMeter     = metrics.NewMeter("eth/req/body/in/packets")
+	reqBodyInTrafficMeter     = metrics.NewMeter("eth/req/body/in/traffic")
+	reqBodyOutPacketsMeter    = metrics.NewMeter("eth/req/body/out/packets")
+	reqBodyOutTrafficMeter    = metrics.NewMeter("eth/req/body/out/traffic")
+	reqStateInPacketsMeter    = metrics.NewMeter("eth/req/state/in/packets")
+	reqStateInTrafficMeter    = metrics.NewMeter("eth/req/state/in/traffic")
+	reqStateOutPacketsMeter   = metrics.NewMeter("eth/req/state/out/packets")
+	reqStateOutTrafficMeter   = metrics.NewMeter("eth/req/state/out/traffic")
+	reqReceiptInPacketsMeter  = metrics.NewMeter("eth/req/receipt/in/packets")
+	reqReceiptInTrafficMeter  = metrics.NewMeter("eth/req/receipt/in/traffic")
+	reqReceiptOutPacketsMeter = metrics.NewMeter("eth/req/receipt/out/packets")
+	reqReceiptOutTrafficMeter = metrics.NewMeter("eth/req/receipt/out/traffic")
+	miscInPacketsMeter        = metrics.NewMeter("eth/misc/in/packets")
+	miscInTrafficMeter        = metrics.NewMeter("eth/misc/in/traffic")
+	miscOutPacketsMeter       = metrics.NewMeter("eth/misc/out/packets")
+	miscOutTrafficMeter       = metrics.NewMeter("eth/misc/out/traffic")
 )
 
 // meteredMsgReadWriter is a wrapper around a p2p.MsgReadWriter, capable of
 // accumulating the above defined metrics based on the data stream contents.
 type meteredMsgReadWriter struct {
-	p2p.MsgReadWriter
+	p2p.MsgReadWriter     // Wrapped message stream to meter
+	version           int // Protocol version to select correct meters
 }
 
 // newMeteredMsgWriter wraps a p2p MsgReadWriter with metering support. If the
@@ -68,7 +77,13 @@ func newMeteredMsgWriter(rw p2p.MsgReadWriter) p2p.MsgReadWriter {
 	if !metrics.Enabled {
 		return rw
 	}
-	return &meteredMsgReadWriter{rw}
+	return &meteredMsgReadWriter{MsgReadWriter: rw}
+}
+
+// Init sets the protocol version used by the stream to know which meters to
+// increment in case of overlapping message ids between protocol versions.
+func (rw *meteredMsgReadWriter) Init(version int) {
+	rw.version = version
 }
 
 func (rw *meteredMsgReadWriter) ReadMsg() (p2p.Msg, error) {
@@ -79,20 +94,27 @@ func (rw *meteredMsgReadWriter) ReadMsg() (p2p.Msg, error) {
 	}
 	// Account for the data traffic
 	packets, traffic := miscInPacketsMeter, miscInTrafficMeter
-	switch msg.Code {
-	case BlockHashesMsg:
+	switch {
+	case (rw.version == eth60 || rw.version == eth61) && msg.Code == BlockHashesMsg:
 		packets, traffic = reqHashInPacketsMeter, reqHashInTrafficMeter
-	case BlocksMsg:
+	case (rw.version == eth60 || rw.version == eth61) && msg.Code == BlocksMsg:
 		packets, traffic = reqBlockInPacketsMeter, reqBlockInTrafficMeter
-	case BlockHeadersMsg:
-		packets, traffic = reqHeaderInPacketsMeter, reqHeaderInTrafficMeter
-	case NodeDataMsg:
+
+	case rw.version == eth62 && msg.Code == BlockHeadersMsg:
+		packets, traffic = reqBlockInPacketsMeter, reqBlockInTrafficMeter
+	case rw.version == eth62 && msg.Code == BlockBodiesMsg:
+		packets, traffic = reqBodyInPacketsMeter, reqBodyInTrafficMeter
+
+	case rw.version == eth63 && msg.Code == NodeDataMsg:
 		packets, traffic = reqStateInPacketsMeter, reqStateInTrafficMeter
-	case NewBlockHashesMsg:
+	case rw.version == eth63 && msg.Code == ReceiptsMsg:
+		packets, traffic = reqReceiptInPacketsMeter, reqReceiptInTrafficMeter
+
+	case msg.Code == NewBlockHashesMsg:
 		packets, traffic = propHashInPacketsMeter, propHashInTrafficMeter
-	case NewBlockMsg:
+	case msg.Code == NewBlockMsg:
 		packets, traffic = propBlockInPacketsMeter, propBlockInTrafficMeter
-	case TxMsg:
+	case msg.Code == TxMsg:
 		packets, traffic = propTxnInPacketsMeter, propTxnInTrafficMeter
 	}
 	packets.Mark(1)
@@ -104,20 +126,27 @@ func (rw *meteredMsgReadWriter) ReadMsg() (p2p.Msg, error) {
 func (rw *meteredMsgReadWriter) WriteMsg(msg p2p.Msg) error {
 	// Account for the data traffic
 	packets, traffic := miscOutPacketsMeter, miscOutTrafficMeter
-	switch msg.Code {
-	case BlockHashesMsg:
+	switch {
+	case (rw.version == eth60 || rw.version == eth61) && msg.Code == BlockHashesMsg:
 		packets, traffic = reqHashOutPacketsMeter, reqHashOutTrafficMeter
-	case BlocksMsg:
+	case (rw.version == eth60 || rw.version == eth61) && msg.Code == BlocksMsg:
 		packets, traffic = reqBlockOutPacketsMeter, reqBlockOutTrafficMeter
-	case BlockHeadersMsg:
+
+	case rw.version == eth62 && msg.Code == BlockHeadersMsg:
 		packets, traffic = reqHeaderOutPacketsMeter, reqHeaderOutTrafficMeter
-	case NodeDataMsg:
+	case rw.version == eth62 && msg.Code == BlockBodiesMsg:
+		packets, traffic = reqBodyOutPacketsMeter, reqBodyOutTrafficMeter
+
+	case rw.version == eth63 && msg.Code == NodeDataMsg:
 		packets, traffic = reqStateOutPacketsMeter, reqStateOutTrafficMeter
-	case NewBlockHashesMsg:
+	case rw.version == eth63 && msg.Code == ReceiptsMsg:
+		packets, traffic = reqReceiptOutPacketsMeter, reqReceiptOutTrafficMeter
+
+	case msg.Code == NewBlockHashesMsg:
 		packets, traffic = propHashOutPacketsMeter, propHashOutTrafficMeter
-	case NewBlockMsg:
+	case msg.Code == NewBlockMsg:
 		packets, traffic = propBlockOutPacketsMeter, propBlockOutTrafficMeter
-	case TxMsg:
+	case msg.Code == TxMsg:
 		packets, traffic = propTxnOutPacketsMeter, propTxnOutTrafficMeter
 	}
 	packets.Mark(1)

--- a/eth/metrics.go
+++ b/eth/metrics.go
@@ -18,6 +18,7 @@ package eth
 
 import (
 	"github.com/ethereum/go-ethereum/metrics"
+	"github.com/ethereum/go-ethereum/p2p"
 )
 
 var (
@@ -41,4 +42,87 @@ var (
 	reqBlockInTrafficMeter   = metrics.NewMeter("eth/req/blocks/in/traffic")
 	reqBlockOutPacketsMeter  = metrics.NewMeter("eth/req/blocks/out/packets")
 	reqBlockOutTrafficMeter  = metrics.NewMeter("eth/req/blocks/out/traffic")
+	reqHeaderInPacketsMeter  = metrics.NewMeter("eth/req/header/in/packets")
+	reqHeaderInTrafficMeter  = metrics.NewMeter("eth/req/header/in/traffic")
+	reqHeaderOutPacketsMeter = metrics.NewMeter("eth/req/header/out/packets")
+	reqHeaderOutTrafficMeter = metrics.NewMeter("eth/req/header/out/traffic")
+	reqStateInPacketsMeter   = metrics.NewMeter("eth/req/state/in/packets")
+	reqStateInTrafficMeter   = metrics.NewMeter("eth/req/state/in/traffic")
+	reqStateOutPacketsMeter  = metrics.NewMeter("eth/req/state/out/packets")
+	reqStateOutTrafficMeter  = metrics.NewMeter("eth/req/state/out/traffic")
+	miscInPacketsMeter       = metrics.NewMeter("eth/misc/in/packets")
+	miscInTrafficMeter       = metrics.NewMeter("eth/misc/in/traffic")
+	miscOutPacketsMeter      = metrics.NewMeter("eth/misc/out/packets")
+	miscOutTrafficMeter      = metrics.NewMeter("eth/misc/out/traffic")
 )
+
+// meteredMsgReadWriter is a wrapper around a p2p.MsgReadWriter, capable of
+// accumulating the above defined metrics based on the data stream contents.
+type meteredMsgReadWriter struct {
+	p2p.MsgReadWriter
+}
+
+// newMeteredMsgWriter wraps a p2p MsgReadWriter with metering support. If the
+// metrics system is disabled, this fucntion returns the original object.
+func newMeteredMsgWriter(rw p2p.MsgReadWriter) p2p.MsgReadWriter {
+	if !metrics.Enabled {
+		return rw
+	}
+	return &meteredMsgReadWriter{rw}
+}
+
+func (rw *meteredMsgReadWriter) ReadMsg() (p2p.Msg, error) {
+	// Read the message and short circuit in case of an error
+	msg, err := rw.MsgReadWriter.ReadMsg()
+	if err != nil {
+		return msg, err
+	}
+	// Account for the data traffic
+	packets, traffic := miscInPacketsMeter, miscInTrafficMeter
+	switch msg.Code {
+	case BlockHashesMsg:
+		packets, traffic = reqHashInPacketsMeter, reqHashInTrafficMeter
+	case BlocksMsg:
+		packets, traffic = reqBlockInPacketsMeter, reqBlockInTrafficMeter
+	case BlockHeadersMsg:
+		packets, traffic = reqHeaderInPacketsMeter, reqHeaderInTrafficMeter
+	case NodeDataMsg:
+		packets, traffic = reqStateInPacketsMeter, reqStateInTrafficMeter
+	case NewBlockHashesMsg:
+		packets, traffic = propHashInPacketsMeter, propHashInTrafficMeter
+	case NewBlockMsg:
+		packets, traffic = propBlockInPacketsMeter, propBlockInTrafficMeter
+	case TxMsg:
+		packets, traffic = propTxnInPacketsMeter, propTxnInTrafficMeter
+	}
+	packets.Mark(1)
+	traffic.Mark(int64(msg.Size))
+
+	return msg, err
+}
+
+func (rw *meteredMsgReadWriter) WriteMsg(msg p2p.Msg) error {
+	// Account for the data traffic
+	packets, traffic := miscOutPacketsMeter, miscOutTrafficMeter
+	switch msg.Code {
+	case BlockHashesMsg:
+		packets, traffic = reqHashOutPacketsMeter, reqHashOutTrafficMeter
+	case BlocksMsg:
+		packets, traffic = reqBlockOutPacketsMeter, reqBlockOutTrafficMeter
+	case BlockHeadersMsg:
+		packets, traffic = reqHeaderOutPacketsMeter, reqHeaderOutTrafficMeter
+	case NodeDataMsg:
+		packets, traffic = reqStateOutPacketsMeter, reqStateOutTrafficMeter
+	case NewBlockHashesMsg:
+		packets, traffic = propHashOutPacketsMeter, propHashOutTrafficMeter
+	case NewBlockMsg:
+		packets, traffic = propBlockOutPacketsMeter, propBlockOutTrafficMeter
+	case TxMsg:
+		packets, traffic = propTxnOutPacketsMeter, propTxnOutTrafficMeter
+	}
+	packets.Mark(1)
+	traffic.Mark(int64(msg.Size))
+
+	// Send the packet to the p2p layer
+	return rw.MsgReadWriter.WriteMsg(msg)
+}

--- a/eth/peer.go
+++ b/eth/peer.go
@@ -165,6 +165,11 @@ func (p *peer) SendBlockHeaders(headers []*types.Header) error {
 	return p2p.Send(p.rw, BlockHeadersMsg, headers)
 }
 
+// SendBlockBodies sends a batch of block contents to the remote peer.
+func (p *peer) SendBlockBodies(bodies []*blockBody) error {
+	return p2p.Send(p.rw, BlockBodiesMsg, blockBodiesData(bodies))
+}
+
 // SendNodeData sends a batch of arbitrary internal data, corresponding to the
 // hashes requested.
 func (p *peer) SendNodeData(data [][]byte) error {

--- a/eth/peer.go
+++ b/eth/peer.go
@@ -171,6 +171,12 @@ func (p *peer) SendNodeData(data [][]byte) error {
 	return p2p.Send(p.rw, NodeDataMsg, data)
 }
 
+// SendReceipts sends a batch of transaction receipts, corresponding to the ones
+// requested.
+func (p *peer) SendReceipts(receipts []*types.Receipt) error {
+	return p2p.Send(p.rw, ReceiptsMsg, receipts)
+}
+
 // RequestHashes fetches a batch of hashes from a peer, starting at from, going
 // towards the genesis block.
 func (p *peer) RequestHashes(from common.Hash) error {
@@ -203,6 +209,12 @@ func (p *peer) RequestHeaders(hashes []common.Hash) error {
 func (p *peer) RequestNodeData(hashes []common.Hash) error {
 	glog.V(logger.Debug).Infof("%v fetching %v state data\n", p, len(hashes))
 	return p2p.Send(p.rw, GetNodeDataMsg, hashes)
+}
+
+// RequestReceipts fetches a batch of transaction receipts from a remote node.
+func (p *peer) RequestReceipts(hashes []common.Hash) error {
+	glog.V(logger.Debug).Infof("%v fetching %v receipts\n", p, len(hashes))
+	return p2p.Send(p.rw, GetReceiptsMsg, hashes)
 }
 
 // Handshake executes the eth protocol handshake, negotiating version number,

--- a/eth/protocol.go
+++ b/eth/protocol.go
@@ -24,10 +24,10 @@ import (
 )
 
 // Supported versions of the eth protocol (first is primary).
-var ProtocolVersions = []uint{61, 60}
+var ProtocolVersions = []uint{62, 61, 60}
 
 // Number of implemented message corresponding to different protocol versions.
-var ProtocolLengths = []uint64{9, 8}
+var ProtocolLengths = []uint64{13, 9, 8}
 
 const (
 	NetworkId          = 1
@@ -36,6 +36,7 @@ const (
 
 // eth protocol message codes
 const (
+	// Protocol messages belonging to eth/60
 	StatusMsg = iota
 	NewBlockHashesMsg
 	TxMsg
@@ -44,7 +45,15 @@ const (
 	GetBlocksMsg
 	BlocksMsg
 	NewBlockMsg
+
+	// Protocol messages belonging to eth/61
 	GetBlockHashesFromNumberMsg
+
+	// Protocol messages belonging to eth/62
+	GetBlockHeadersMsg
+	BlockHeadersMsg
+	GetNodeDataMsg
+	NodeDataMsg
 )
 
 type errCode int
@@ -102,15 +111,14 @@ type statusData struct {
 	GenesisBlock    common.Hash
 }
 
-// getBlockHashesData is the network packet for the hash based block retrieval
-// message.
+// getBlockHashesData is the network packet for the hash based hash retrieval.
 type getBlockHashesData struct {
 	Hash   common.Hash
 	Amount uint64
 }
 
-// getBlockHashesFromNumberData is the network packet for the number based block
-// retrieval message.
+// getBlockHashesFromNumberData is the network packet for the number based hash
+// retrieval.
 type getBlockHashesFromNumberData struct {
 	Number uint64
 	Amount uint64
@@ -120,4 +128,9 @@ type getBlockHashesFromNumberData struct {
 type newBlockData struct {
 	Block *types.Block
 	TD    *big.Int
+}
+
+// nodeDataData is the network response packet for a node data retrieval.
+type nodeDataData []struct {
+	Value []byte
 }

--- a/eth/protocol.go
+++ b/eth/protocol.go
@@ -17,10 +17,13 @@
 package eth
 
 import (
+	"fmt"
+	"io"
 	"math/big"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/rlp"
 )
 
 // Constants to match up protocol versions and messages
@@ -151,6 +154,50 @@ type getBlockHashesData struct {
 type getBlockHashesFromNumberData struct {
 	Number uint64
 	Amount uint64
+}
+
+// getBlockHeadersData represents a block header query.
+type getBlockHeadersData struct {
+	Origin  hashOrNumber // Block from which to retrieve headers
+	Amount  uint64       // Maximum number of headers to retrieve
+	Skip    uint64       // Blocks to skip between consecutive headers
+	Reverse bool         // Query direction (false = rising towards latest, true = falling towards genesis)
+}
+
+// hashOrNumber is a combined field for specifying an origin block.
+type hashOrNumber struct {
+	Hash   common.Hash // Block hash from which to retrieve headers (excludes Number)
+	Number uint64      // Block hash from which to retrieve headers (excludes Hash)
+}
+
+// EncodeRLP is a specialized encoder for hashOrNumber to encode only one of the
+// two contained union fields.
+func (hn *hashOrNumber) EncodeRLP(w io.Writer) error {
+	if hn.Hash == (common.Hash{}) {
+		return rlp.Encode(w, hn.Number)
+	}
+	if hn.Number != 0 {
+		return fmt.Errorf("both origin hash (%x) and number (%d) provided", hn.Hash, hn.Number)
+	}
+	return rlp.Encode(w, hn.Hash)
+}
+
+// DecodeRLP is a specialized decoder for hashOrNumber to decode the contents
+// into either a block hash or a block number.
+func (hn *hashOrNumber) DecodeRLP(s *rlp.Stream) error {
+	_, size, _ := s.Kind()
+	origin, err := s.Raw()
+	if err == nil {
+		switch {
+		case size == 32:
+			err = rlp.DecodeBytes(origin, &hn.Hash)
+		case size <= 8:
+			err = rlp.DecodeBytes(origin, &hn.Number)
+		default:
+			err = fmt.Errorf("invalid input size %d for origin", size)
+		}
+	}
+	return err
 }
 
 // newBlockData is the network packet for the block propagation message.

--- a/eth/protocol.go
+++ b/eth/protocol.go
@@ -29,6 +29,7 @@ const (
 	eth61 = 61
 	eth62 = 62
 	eth63 = 63
+	eth64 = 64
 )
 
 // Supported versions of the eth protocol (first is primary).
@@ -54,10 +55,13 @@ const (
 	BlocksMsg         = 0x06
 	NewBlockMsg       = 0x07
 
-	// Protocol messages belonging to eth/61
+	// Protocol messages belonging to eth/61 (extension of eth/60)
 	GetBlockHashesFromNumberMsg = 0x08
 
-	// Protocol messages belonging to eth/62
+	// Protocol messages belonging to eth/62 (new protocol from scratch)
+	// StatusMsg          = 0x00 (uncomment after eth/61 deprecation)
+	// NewBlockHashesMsg  = 0x01 (uncomment after eth/61 deprecation)
+	// TxMsg              = 0x02 (uncomment after eth/61 deprecation)
 	GetBlockHeadersMsg = 0x03
 	BlockHeadersMsg    = 0x04
 	GetBlockBodiesMsg  = 0x05
@@ -68,6 +72,11 @@ const (
 	NodeDataMsg    = 0x0e
 	GetReceiptsMsg = 0x0f
 	ReceiptsMsg    = 0x10
+
+	// Protocol messages belonging to eth/64
+	GetAcctProofMsg     = 0x11
+	GetStorageDataProof = 0x12
+	Proof               = 0x13
 )
 
 type errCode int
@@ -125,6 +134,12 @@ type statusData struct {
 	GenesisBlock    common.Hash
 }
 
+// newBlockHashesData is the network packet for the block announcements.
+type newBlockHashesData []struct {
+	Hash   common.Hash // Hash of one particular block being announced
+	Number uint64      // Number of one particular block being announced
+}
+
 // getBlockHashesData is the network packet for the hash based hash retrieval.
 type getBlockHashesData struct {
 	Hash   common.Hash
@@ -143,6 +158,15 @@ type newBlockData struct {
 	Block *types.Block
 	TD    *big.Int
 }
+
+// blockBody represents the data content of a single block.
+type blockBody struct {
+	Transactions []*types.Transaction // Transactions contained within a block
+	Uncles       []*types.Header      // Uncles contained within a block
+}
+
+// blockBodiesData is the network packet for block content distribution.
+type blockBodiesData []*blockBody
 
 // nodeDataData is the network response packet for a node data retrieval.
 type nodeDataData []struct {

--- a/eth/protocol.go
+++ b/eth/protocol.go
@@ -23,11 +23,19 @@ import (
 	"github.com/ethereum/go-ethereum/core/types"
 )
 
+// Constants to match up protocol versions and messages
+const (
+	eth60 = 60
+	eth61 = 61
+	eth62 = 62
+	eth63 = 63
+)
+
 // Supported versions of the eth protocol (first is primary).
-var ProtocolVersions = []uint{62, 61, 60}
+var ProtocolVersions = []uint{61, 60}
 
 // Number of implemented message corresponding to different protocol versions.
-var ProtocolLengths = []uint64{13, 9, 8}
+var ProtocolLengths = []uint64{9, 8}
 
 const (
 	NetworkId          = 1
@@ -37,23 +45,29 @@ const (
 // eth protocol message codes
 const (
 	// Protocol messages belonging to eth/60
-	StatusMsg = iota
-	NewBlockHashesMsg
-	TxMsg
-	GetBlockHashesMsg
-	BlockHashesMsg
-	GetBlocksMsg
-	BlocksMsg
-	NewBlockMsg
+	StatusMsg         = 0x00
+	NewBlockHashesMsg = 0x01
+	TxMsg             = 0x02
+	GetBlockHashesMsg = 0x03
+	BlockHashesMsg    = 0x04
+	GetBlocksMsg      = 0x05
+	BlocksMsg         = 0x06
+	NewBlockMsg       = 0x07
 
 	// Protocol messages belonging to eth/61
-	GetBlockHashesFromNumberMsg
+	GetBlockHashesFromNumberMsg = 0x08
 
 	// Protocol messages belonging to eth/62
-	GetBlockHeadersMsg
-	BlockHeadersMsg
-	GetNodeDataMsg
-	NodeDataMsg
+	GetBlockHeadersMsg = 0x03
+	BlockHeadersMsg    = 0x04
+	GetBlockBodiesMsg  = 0x05
+	BlockBodiesMsg     = 0x06
+
+	// Protocol messages belonging to eth/63
+	GetNodeDataMsg = 0x0d
+	NodeDataMsg    = 0x0e
+	GetReceiptsMsg = 0x0f
+	ReceiptsMsg    = 0x10
 )
 
 type errCode int

--- a/eth/protocol.go
+++ b/eth/protocol.go
@@ -36,10 +36,10 @@ const (
 )
 
 // Supported versions of the eth protocol (first is primary).
-var ProtocolVersions = []uint{61, 60}
+var ProtocolVersions = []uint{eth64, eth63, eth62, eth61, eth60}
 
 // Number of implemented message corresponding to different protocol versions.
-var ProtocolLengths = []uint64{9, 8}
+var ProtocolLengths = []uint64{15, 12, 8, 9, 8}
 
 const (
 	NetworkId          = 1
@@ -69,6 +69,7 @@ const (
 	BlockHeadersMsg    = 0x04
 	GetBlockBodiesMsg  = 0x05
 	BlockBodiesMsg     = 0x06
+	// 	NewBlockMsg       = 0x07 (uncomment after eth/61 deprecation)
 
 	// Protocol messages belonging to eth/63
 	GetNodeDataMsg = 0x0d

--- a/eth/protocol_test.go
+++ b/eth/protocol_test.go
@@ -41,6 +41,7 @@ func TestStatusMsgErrors60(t *testing.T) { testStatusMsgErrors(t, 60) }
 func TestStatusMsgErrors61(t *testing.T) { testStatusMsgErrors(t, 61) }
 func TestStatusMsgErrors62(t *testing.T) { testStatusMsgErrors(t, 62) }
 func TestStatusMsgErrors63(t *testing.T) { testStatusMsgErrors(t, 63) }
+func TestStatusMsgErrors64(t *testing.T) { testStatusMsgErrors(t, 64) }
 
 func testStatusMsgErrors(t *testing.T, protocol int) {
 	pm := newTestProtocolManager(0, nil, nil)
@@ -95,6 +96,7 @@ func TestRecvTransactions60(t *testing.T) { testRecvTransactions(t, 60) }
 func TestRecvTransactions61(t *testing.T) { testRecvTransactions(t, 61) }
 func TestRecvTransactions62(t *testing.T) { testRecvTransactions(t, 62) }
 func TestRecvTransactions63(t *testing.T) { testRecvTransactions(t, 63) }
+func TestRecvTransactions64(t *testing.T) { testRecvTransactions(t, 64) }
 
 func testRecvTransactions(t *testing.T, protocol int) {
 	txAdded := make(chan []*types.Transaction)
@@ -124,6 +126,7 @@ func TestSendTransactions60(t *testing.T) { testSendTransactions(t, 60) }
 func TestSendTransactions61(t *testing.T) { testSendTransactions(t, 61) }
 func TestSendTransactions62(t *testing.T) { testSendTransactions(t, 62) }
 func TestSendTransactions63(t *testing.T) { testSendTransactions(t, 63) }
+func TestSendTransactions64(t *testing.T) { testSendTransactions(t, 64) }
 
 func testSendTransactions(t *testing.T, protocol int) {
 	pm := newTestProtocolManager(0, nil, nil)

--- a/eth/protocol_test.go
+++ b/eth/protocol_test.go
@@ -37,7 +37,7 @@ func init() {
 var testAccount = crypto.NewKey(rand.Reader)
 
 func TestStatusMsgErrors(t *testing.T) {
-	pm := newTestProtocolManager(0, nil)
+	pm := newTestProtocolManager(0, nil, nil)
 	td, currentBlock, genesis := pm.chainman.Status()
 	defer pm.Stop()
 
@@ -87,7 +87,7 @@ func TestStatusMsgErrors(t *testing.T) {
 // This test checks that received transactions are added to the local pool.
 func TestRecvTransactions(t *testing.T) {
 	txAdded := make(chan []*types.Transaction)
-	pm := newTestProtocolManager(0, txAdded)
+	pm := newTestProtocolManager(0, nil, txAdded)
 	p, _ := newTestPeer("peer", pm, true)
 	defer pm.Stop()
 	defer p.close()
@@ -110,7 +110,7 @@ func TestRecvTransactions(t *testing.T) {
 
 // This test checks that pending transactions are sent.
 func TestSendTransactions(t *testing.T) {
-	pm := newTestProtocolManager(0, nil)
+	pm := newTestProtocolManager(0, nil, nil)
 	defer pm.Stop()
 
 	// Fill the pool with big transactions.

--- a/ethdb/memory_database.go
+++ b/ethdb/memory_database.go
@@ -49,6 +49,14 @@ func (db *MemDatabase) Get(key []byte) ([]byte, error) {
 	return db.db[string(key)], nil
 }
 
+func (db *MemDatabase) Keys() [][]byte {
+	keys := [][]byte{}
+	for key, _ := range db.db {
+		keys = append(keys, []byte(key))
+	}
+	return keys
+}
+
 /*
 func (db *MemDatabase) GetKeys() []*common.Key {
 	data, _ := db.Get([]byte("KeyRing"))

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -31,8 +31,8 @@ import (
 // MetricsEnabledFlag is the CLI flag name to use to enable metrics collections.
 var MetricsEnabledFlag = "metrics"
 
-// enabled is the flag specifying if metrics are enable or not.
-var enabled = false
+// Enabled is the flag specifying if metrics are enable or not.
+var Enabled = false
 
 // Init enables or disables the metrics system. Since we need this to run before
 // any other code gets to create meters and timers, we'll actually do an ugly hack
@@ -41,7 +41,7 @@ func init() {
 	for _, arg := range os.Args {
 		if strings.TrimLeft(arg, "-") == MetricsEnabledFlag {
 			glog.V(logger.Info).Infof("Enabling metrics collection")
-			enabled = true
+			Enabled = true
 		}
 	}
 }
@@ -49,7 +49,7 @@ func init() {
 // NewMeter create a new metrics Meter, either a real one of a NOP stub depending
 // on the metrics flag.
 func NewMeter(name string) metrics.Meter {
-	if !enabled {
+	if !Enabled {
 		return new(metrics.NilMeter)
 	}
 	return metrics.GetOrRegisterMeter(name, metrics.DefaultRegistry)
@@ -58,7 +58,7 @@ func NewMeter(name string) metrics.Meter {
 // NewTimer create a new metrics Timer, either a real one of a NOP stub depending
 // on the metrics flag.
 func NewTimer(name string) metrics.Timer {
-	if !enabled {
+	if !Enabled {
 		return new(metrics.NilTimer)
 	}
 	return metrics.GetOrRegisterTimer(name, metrics.DefaultRegistry)
@@ -68,7 +68,7 @@ func NewTimer(name string) metrics.Timer {
 // process.
 func CollectProcessMetrics(refresh time.Duration) {
 	// Short circuit if the metrics system is disabled
-	if !enabled {
+	if !Enabled {
 		return
 	}
 	// Create the various data collectors

--- a/p2p/metrics.go
+++ b/p2p/metrics.go
@@ -38,8 +38,14 @@ type meteredConn struct {
 }
 
 // newMeteredConn creates a new metered connection, also bumping the ingress or
-// egress connection meter.
+// egress connection meter. If the metrics system is disabled, this function
+// returns the original object.
 func newMeteredConn(conn net.Conn, ingress bool) net.Conn {
+	// Short circuit if metrics are disabled
+	if !metrics.Enabled {
+		return conn
+	}
+	// Otherwise bump the connection counters and wrap the connection
 	if ingress {
 		ingressConnectMeter.Mark(1)
 	} else {


### PR DESCRIPTION
This PR aims to implement the "server" side of the [eth/62](https://github.com/ethereum/wiki/wiki/Ethereum-Wire-Protocol#proposed-messages-for-new-model-syncing-pv62) and [eth/63](https://github.com/ethereum/wiki/wiki/Ethereum-Wire-Protocol#proposed-messages-for-light-client-pv63) protocols. The goal of v62 is to introduce the necessary network packets for more flexible full node synchronization, whereas v63 aims to set the bases for implementing light clients. All the proposed network packets have been implemented and handled, also supporting switching the between any of the 4 currently supported protocol versions: 60 through 63.

Note, the client side of the protocols (i.e. synchronization, downloader, fetcher, etc), have **not** yet been updated, so enabling protocols above 62 and connecting to the main net would likely result in very undefined behavior.

However, given the scope of this PR, I would like to have a round of reviews and corrections in the current state, and only move forward with implementing the client side and updated/new sync logic after the server side core is deemed to be solid. That should desirable be done in a new PR to keep the merges clean.