### PR TITLE
eth/downloader: fix a rare test race on the OSX CI

### DIFF
--- a/eth/downloader/downloader_test.go
+++ b/eth/downloader/downloader_test.go
@@ -83,7 +83,13 @@ func newTester() *downloadTester {
 // sync starts synchronizing with a remote peer, blocking until it completes.
 func (dl *downloadTester) sync(id string) error {
 	err := dl.downloader.synchronise(id, dl.peerHashes[id][0])
-	for atomic.LoadInt32(&dl.downloader.processing) == 1 {
+	for {
+		// If the queue is empty and processing stopped, break
+		hashes, blocks := dl.downloader.queue.Size()
+		if hashes+blocks == 0 && atomic.LoadInt32(&dl.downloader.processing) == 0 {
+			break
+		}
+		// Otherwise sleep a bit and retry
 		time.Sleep(time.Millisecond)
 	}
 	return err


### PR DESCRIPTION
This a trivial PR that just fixes a test sync issue. After a successful sync, the tester sometimes too soon (i.e. slow CI server, slow scheduling) assumed that processing was also done as none was running. This PR fixes that the tester only terminates a sync if the pending import queue is also empty.