### PR TITLE
Fix core errors in apply txs

### DIFF
--- a/core/block_processor.go
+++ b/core/block_processor.go
@@ -9,6 +9,7 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/state"
 	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/core/vm"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/event"
 	"github.com/ethereum/go-ethereum/logger"
@@ -72,7 +73,7 @@ func (self *BlockProcessor) ApplyTransaction(coinbase *state.StateObject, stated
 
 	cb := statedb.GetStateObject(coinbase.Address())
 	_, gas, err := ApplyMessage(NewEnv(statedb, self.bc, tx, header), tx, cb)
-	if err != nil && (IsNonceErr(err) || state.IsGasLimitErr(err) || IsInvalidTxErr(err)) {
+	if err != nil && err != vm.OutOfGasError {
 		return nil, nil, err
 	}
 
@@ -118,7 +119,7 @@ func (self *BlockProcessor) ApplyTransactions(coinbase *state.StateObject, state
 		statedb.StartRecord(tx.Hash(), block.Hash(), i)
 
 		receipt, txGas, err := self.ApplyTransaction(coinbase, statedb, header, tx, totalUsedGas, transientProcess)
-		if err != nil && (IsNonceErr(err) || state.IsGasLimitErr(err) || IsInvalidTxErr(err)) {
+		if err != nil && err != vm.OutOfGasError {
 			return nil, err
 		}
 

--- a/core/error.go
+++ b/core/error.go
@@ -30,7 +30,6 @@ func ParentError(hash common.Hash) error {
 
 func IsParentErr(err error) bool {
 	_, ok := err.(*ParentErr)
-
 	return ok
 }
 
@@ -48,7 +47,6 @@ func UncleError(format string, v ...interface{}) error {
 
 func IsUncleErr(err error) bool {
 	_, ok := err.(*UncleErr)
-
 	return ok
 }
 
@@ -67,7 +65,6 @@ func ValidationError(format string, v ...interface{}) *ValidationErr {
 
 func IsValidationErr(err error) bool {
 	_, ok := err.(*ValidationErr)
-
 	return ok
 }
 
@@ -86,7 +83,6 @@ func NonceError(is, exp uint64) *NonceErr {
 
 func IsNonceErr(err error) bool {
 	_, ok := err.(*NonceErr)
-
 	return ok
 }
 
@@ -121,24 +117,6 @@ func InvalidTxError(err error) *InvalidTxErr {
 
 func IsInvalidTxErr(err error) bool {
 	_, ok := err.(*InvalidTxErr)
-
-	return ok
-}
-
-type OutOfGasErr struct {
-	Message string
-}
-
-func OutOfGasError() *OutOfGasErr {
-	return &OutOfGasErr{Message: "Out of gas"}
-}
-func (self *OutOfGasErr) Error() string {
-	return self.Message
-}
-
-func IsOutOfGasErr(err error) bool {
-	_, ok := err.(*OutOfGasErr)
-
 	return ok
 }
 

--- a/core/execution.go
+++ b/core/execution.go
@@ -53,7 +53,7 @@ func (self *Execution) exec(contextAddr *common.Address, code []byte, caller vm.
 	if env.Depth() > int(params.CallCreateDepth.Int64()) {
 		caller.ReturnGas(self.Gas, self.price)
 
-		return nil, vm.DepthError{}
+		return nil, vm.DepthError
 	}
 
 	vsnapshot := env.State().Copy()

--- a/core/state_transition.go
+++ b/core/state_transition.go
@@ -122,7 +122,7 @@ func (self *StateTransition) To() *state.StateObject {
 
 func (self *StateTransition) UseGas(amount *big.Int) error {
 	if self.gas.Cmp(amount) < 0 {
-		return OutOfGasError()
+		return vm.OutOfGasError
 	}
 	self.gas.Sub(self.gas, amount)
 

--- a/core/vm/errors.go
+++ b/core/vm/errors.go
@@ -1,21 +1,14 @@
 package vm
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/ethereum/go-ethereum/params"
 )
 
-type OutOfGasError struct{}
-
-func (self OutOfGasError) Error() string {
-	return "Out Of Gas"
-}
-
-func IsOOGErr(err error) bool {
-	_, ok := err.(OutOfGasError)
-	return ok
-}
+var OutOfGasError = errors.New("Out of gas")
+var DepthError = fmt.Errorf("Max call depth exceeded (%d)", params.CallCreateDepth)
 
 type StackError struct {
 	req, has int
@@ -31,16 +24,5 @@ func (self StackError) Error() string {
 
 func IsStack(err error) bool {
 	_, ok := err.(StackError)
-	return ok
-}
-
-type DepthError struct{}
-
-func (self DepthError) Error() string {
-	return fmt.Sprintf("Max call depth exceeded (%d)", params.CallCreateDepth)
-}
-
-func IsDepthErr(err error) bool {
-	_, ok := err.(DepthError)
 	return ok
 }

--- a/core/vm/vm.go
+++ b/core/vm/vm.go
@@ -116,7 +116,7 @@ func (self *Vm) Run(context *Context, input []byte) (ret []byte, err error) {
 
 			context.UseGas(context.Gas)
 
-			return context.Return(nil), OutOfGasError{}
+			return context.Return(nil), OutOfGasError
 		}
 		// Resize the memory calculated previously
 		mem.Resize(newMemSize.Uint64())
@@ -789,7 +789,7 @@ func (self *Vm) RunPrecompiled(p *PrecompiledAccount, input []byte, context *Con
 
 		return context.Return(ret), nil
 	} else {
-		return nil, OutOfGasError{}
+		return nil, OutOfGasError
 	}
 }
 

--- a/tests/init.go
+++ b/tests/init.go
@@ -20,11 +20,6 @@ var (
 	BlockSkipTests = []string{
 		"SimpleTx3",
 
-		// these panic in block_processor.go:84 , see https://github.com/ethereum/go-ethereum/issues/1384
-		"TRANSCT_rvalue_TooShort",
-		"TRANSCT_rvalue_TooLarge",
-		"TRANSCT_svalue_TooLarge",
-
 		// TODO: check why these fail
 		"BLOCK__RandomByteAtTheEnd",
 		"TRANSCT__RandomByteAtTheEnd",


### PR DESCRIPTION
~~Please merge this first: https://github.com/ethereum/go-ethereum/pull/1385~~

~~This changes the logic in core to propagate all errors except explicitly matched ones, currently only the OutOfGas error. This error had broken type matching due to being defined in two places, so this PR also refactors core errors into its own subpackage so it can be used both in core and in core/vm.~~

OOG error moved to core/vm on @fjl suggestion