### PR TITLE
getTransactionReceipt RPC support

### DIFF
--- a/core/transaction_util.go
+++ b/core/transaction_util.go
@@ -55,6 +55,21 @@ func PutReceipts(db common.Database, receipts types.Receipts) error {
 }
 
 // GetReceipt returns a receipt by hash
+func GetFullReceipt(db common.Database, txHash common.Hash) *types.ReceiptForStorage {
+	data, _ := db.Get(append(receiptsPre, txHash[:]...))
+	if len(data) == 0 {
+		return nil
+	}
+
+	var receipt types.ReceiptForStorage
+	err := rlp.DecodeBytes(data, &receipt)
+	if err != nil {
+		glog.V(logger.Error).Infoln("GetReceipt err:", err)
+	}
+	return &receipt
+}
+
+// GetReceipt returns a receipt by hash
 func GetReceipt(db common.Database, txHash common.Hash) *types.Receipt {
 	data, _ := db.Get(append(receiptsPre, txHash[:]...))
 	if len(data) == 0 {

--- a/core/transaction_util.go
+++ b/core/transaction_util.go
@@ -55,21 +55,6 @@ func PutReceipts(db common.Database, receipts types.Receipts) error {
 }
 
 // GetReceipt returns a receipt by hash
-func GetFullReceipt(db common.Database, txHash common.Hash) *types.ReceiptForStorage {
-	data, _ := db.Get(append(receiptsPre, txHash[:]...))
-	if len(data) == 0 {
-		return nil
-	}
-
-	var receipt types.ReceiptForStorage
-	err := rlp.DecodeBytes(data, &receipt)
-	if err != nil {
-		glog.V(logger.Error).Infoln("GetReceipt err:", err)
-	}
-	return &receipt
-}
-
-// GetReceipt returns a receipt by hash
 func GetReceipt(db common.Database, txHash common.Hash) *types.Receipt {
 	data, _ := db.Get(append(receiptsPre, txHash[:]...))
 	if len(data) == 0 {

--- a/rpc/api/eth.go
+++ b/rpc/api/eth.go
@@ -605,13 +605,18 @@ func (self *ethApi) GetTransactionReceipt(req *shared.Request) (interface{}, err
 	}
 
 	txhash := common.BytesToHash(common.FromHex(args.Hash))
+	tx, bhash, bnum, txi := self.xeth.EthTransactionByHash(args.Hash)
 	rec := self.xeth.GetTxReceipt(txhash)
 	// We could have an error of "not found". Should disambiguate
 	// if err != nil {
 	// 	return err, nil
 	// }
-	if rec != nil {
+	if rec != nil && tx != nil {
 		v := NewReceiptRes(rec)
+		v.BlockHash = newHexData(bhash)
+		v.BlockNumber = newHexNum(bnum)
+		v.GasUsed = newHexNum(tx.Gas().Bytes())
+		v.TransactionIndex = newHexNum(txi)
 		return v, nil
 	}
 

--- a/rpc/api/eth.go
+++ b/rpc/api/eth.go
@@ -604,7 +604,8 @@ func (self *ethApi) GetTransactionReceipt(req *shared.Request) (interface{}, err
 		return nil, shared.NewDecodeParamError(err.Error())
 	}
 
-	rec, _ := self.xeth.GetTxReceipt(common.StringToHash(args.Hash))
+	v := common.BytesToHash(common.FromHex(args.Hash))
+	rec := self.xeth.GetTxReceipt(v)
 	// We could have an error of "not found". Should disambiguate
 	// if err != nil {
 	// 	return err, nil

--- a/rpc/api/eth.go
+++ b/rpc/api/eth.go
@@ -604,8 +604,8 @@ func (self *ethApi) GetTransactionReceipt(req *shared.Request) (interface{}, err
 		return nil, shared.NewDecodeParamError(err.Error())
 	}
 
-	v := common.BytesToHash(common.FromHex(args.Hash))
-	rec := self.xeth.GetTxReceipt(v)
+	txhash := common.BytesToHash(common.FromHex(args.Hash))
+	rec := self.xeth.GetTxReceipt(txhash)
 	// We could have an error of "not found". Should disambiguate
 	// if err != nil {
 	// 	return err, nil

--- a/rpc/api/eth.go
+++ b/rpc/api/eth.go
@@ -77,6 +77,7 @@ var (
 		"eth_submitWork":                          (*ethApi).SubmitWork,
 		"eth_resend":                              (*ethApi).Resend,
 		"eth_pendingTransactions":                 (*ethApi).PendingTransactions,
+		"eth_getTransactionReceipt":               (*ethApi).GetTransactionReceipt,
 	}
 )
 
@@ -595,4 +596,23 @@ func (self *ethApi) PendingTransactions(req *shared.Request) (interface{}, error
 	}
 
 	return ltxs, nil
+}
+
+func (self *ethApi) GetTransactionReceipt(req *shared.Request) (interface{}, error) {
+	args := new(HashArgs)
+	if err := self.codec.Decode(req.Params, &args); err != nil {
+		return nil, shared.NewDecodeParamError(err.Error())
+	}
+
+	rec, _ := self.xeth.GetTxReceipt(common.StringToHash(args.Hash))
+	// We could have an error of "not found". Should disambiguate
+	// if err != nil {
+	// 	return err, nil
+	// }
+	if rec != nil {
+		v := NewReceiptRes(rec)
+		return v, nil
+	}
+
+	return nil, nil
 }

--- a/rpc/api/parsing.go
+++ b/rpc/api/parsing.go
@@ -413,7 +413,7 @@ type ReceiptRes struct {
 	Logs              *[]interface{} `json:logs`
 }
 
-func NewReceiptRes(rec *types.ReceiptForStorage) *ReceiptRes {
+func NewReceiptRes(rec *types.Receipt) *ReceiptRes {
 	if rec == nil {
 		return nil
 	}

--- a/rpc/api/parsing.go
+++ b/rpc/api/parsing.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"bytes"
 	"encoding/binary"
 	"encoding/hex"
 	"encoding/json"
@@ -419,11 +420,18 @@ func NewReceiptRes(rec *types.Receipt) *ReceiptRes {
 	}
 
 	var v = new(ReceiptRes)
-	// TODO fill out rest of object
-	// ContractAddress is all 0 when not a creation tx
-	v.ContractAddress = newHexData(rec.ContractAddress)
-	v.CumulativeGasUsed = newHexNum(rec.CumulativeGasUsed)
 	v.TransactionHash = newHexData(rec.TxHash)
+	// v.TransactionIndex = newHexNum(input) // transaction
+	// v.BlockNumber = newHexNum(input)			//		transaction
+	// v.BlockHash = newHexData(input)				//transaction
+	v.CumulativeGasUsed = newHexNum(rec.CumulativeGasUsed)
+	// v.GasUsed = newHexNum(input)        // CumulativeGasUsed (blocknum-1)
+	// If the ContractAddress is 20 0x0 bytes, assume it is not a contract creation
+	if bytes.Compare(rec.ContractAddress.Bytes(), bytes.Repeat([]byte{0}, 20)) != 0 {
+		v.ContractAddress = newHexData(rec.ContractAddress)
+	}
+	// v.Logs = rec.Logs()
+
 	return v
 }
 

--- a/rpc/api/parsing.go
+++ b/rpc/api/parsing.go
@@ -413,15 +413,17 @@ type ReceiptRes struct {
 	Logs              *[]interface{} `json:logs`
 }
 
-func NewReceiptRes(rec *types.Receipt) *ReceiptRes {
+func NewReceiptRes(rec *types.ReceiptForStorage) *ReceiptRes {
 	if rec == nil {
 		return nil
 	}
 
 	var v = new(ReceiptRes)
 	// TODO fill out rest of object
+	// ContractAddress is all 0 when not a creation tx
+	v.ContractAddress = newHexData(rec.ContractAddress)
 	v.CumulativeGasUsed = newHexNum(rec.CumulativeGasUsed)
-
+	v.TransactionHash = newHexData(rec.TxHash)
 	return v
 }
 

--- a/rpc/api/parsing.go
+++ b/rpc/api/parsing.go
@@ -421,11 +421,11 @@ func NewReceiptRes(rec *types.Receipt) *ReceiptRes {
 
 	var v = new(ReceiptRes)
 	v.TransactionHash = newHexData(rec.TxHash)
-	// v.TransactionIndex = newHexNum(input) // transaction
-	// v.BlockNumber = newHexNum(input)			//		transaction
-	// v.BlockHash = newHexData(input)				//transaction
+	// v.TransactionIndex = newHexNum(input)
+	// v.BlockNumber = newHexNum(input)
+	// v.BlockHash = newHexData(input)
 	v.CumulativeGasUsed = newHexNum(rec.CumulativeGasUsed)
-	// v.GasUsed = newHexNum(input)        // CumulativeGasUsed (blocknum-1)
+	// v.GasUsed = newHexNum(input)
 	// If the ContractAddress is 20 0x0 bytes, assume it is not a contract creation
 	if bytes.Compare(rec.ContractAddress.Bytes(), bytes.Repeat([]byte{0}, 20)) != 0 {
 		v.ContractAddress = newHexData(rec.ContractAddress)

--- a/rpc/api/parsing.go
+++ b/rpc/api/parsing.go
@@ -402,6 +402,29 @@ func NewUncleRes(h *types.Header) *UncleRes {
 // 	WorkProved string `json:"workProved"`
 // }
 
+type ReceiptRes struct {
+	TransactionHash   *hexdata       `json:transactionHash`
+	TransactionIndex  *hexnum        `json:transactionIndex`
+	BlockNumber       *hexnum        `json:blockNumber`
+	BlockHash         *hexdata       `json:blockHash`
+	CumulativeGasUsed *hexnum        `json:cumulativeGasUsed`
+	GasUsed           *hexnum        `json:gasUsed`
+	ContractAddress   *hexdata       `json:contractAddress`
+	Logs              *[]interface{} `json:logs`
+}
+
+func NewReceiptRes(rec *types.Receipt) *ReceiptRes {
+	if rec == nil {
+		return nil
+	}
+
+	var v = new(ReceiptRes)
+	// TODO fill out rest of object
+	v.CumulativeGasUsed = newHexNum(rec.CumulativeGasUsed)
+
+	return v
+}
+
 func numString(raw interface{}) (*big.Int, error) {
 	var number *big.Int
 	// Parse as integer

--- a/rpc/api/utils.go
+++ b/rpc/api/utils.go
@@ -86,6 +86,7 @@ var (
 			"submitWork",
 			"pendingTransactions",
 			"resend",
+			"getTransactionReceipt",
 		},
 		"miner": []string{
 			"hashrate",

--- a/xeth/xeth.go
+++ b/xeth/xeth.go
@@ -368,8 +368,8 @@ func (self *XEth) GetBlockReceipts(bhash common.Hash) types.Receipts {
 	return self.backend.BlockProcessor().GetBlockReceipts(bhash)
 }
 
-func (self *XEth) GetTxReceipt(txhash common.Hash) *types.Receipt {
-	return core.GetReceipt(self.backend.ExtraDb(), txhash)
+func (self *XEth) GetTxReceipt(txhash common.Hash) *types.ReceiptForStorage {
+	return core.GetFullReceipt(self.backend.ExtraDb(), txhash)
 }
 
 func (self *XEth) GasLimit() *big.Int {

--- a/xeth/xeth.go
+++ b/xeth/xeth.go
@@ -368,8 +368,8 @@ func (self *XEth) GetBlockReceipts(bhash common.Hash) types.Receipts {
 	return self.backend.BlockProcessor().GetBlockReceipts(bhash)
 }
 
-func (self *XEth) GetTxReceipt(txhash common.Hash) *types.ReceiptForStorage {
-	return core.GetFullReceipt(self.backend.ExtraDb(), txhash)
+func (self *XEth) GetTxReceipt(txhash common.Hash) *types.Receipt {
+	return core.GetReceipt(self.backend.ExtraDb(), txhash)
 }
 
 func (self *XEth) GasLimit() *big.Int {

--- a/xeth/xeth.go
+++ b/xeth/xeth.go
@@ -966,7 +966,6 @@ func (self *XEth) Transact(fromStr, toStr, nonceStr, valueStr, gasStr, gasPriceS
 	if contractCreation {
 		addr := crypto.CreateAddress(from, nonce)
 		glog.V(logger.Info).Infof("Tx(%x) created: %x\n", tx.Hash(), addr)
-		return addr.Hex(), nil
 	} else {
 		glog.V(logger.Info).Infof("Tx(%x) to: %x\n", tx.Hash(), tx.To())
 	}


### PR DESCRIPTION
#1042 #1306 

* [x] XEth.EthTransactionByHash seems to be not returning the block hash for a transaction as expected.
* [x] Full receipt fields not available 
* [x] Fill fields with parent and sibling context
  - Logs are not currently set
