### PR TITLE
core, miner: adopted new style errors

### DIFF
--- a/core/block_processor.go
+++ b/core/block_processor.go
@@ -9,7 +9,6 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/state"
 	"github.com/ethereum/go-ethereum/core/types"
-	"github.com/ethereum/go-ethereum/core/vm"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/event"
 	"github.com/ethereum/go-ethereum/logger"
@@ -73,7 +72,7 @@ func (self *BlockProcessor) ApplyTransaction(coinbase *state.StateObject, stated
 
 	cb := statedb.GetStateObject(coinbase.Address())
 	_, gas, err := ApplyMessage(NewEnv(statedb, self.bc, tx, header), tx, cb)
-	if err != nil && err != vm.OutOfGasError {
+	if err != nil {
 		return nil, nil, err
 	}
 
@@ -119,7 +118,7 @@ func (self *BlockProcessor) ApplyTransactions(coinbase *state.StateObject, state
 		statedb.StartRecord(tx.Hash(), block.Hash(), i)
 
 		receipt, txGas, err := self.ApplyTransaction(coinbase, statedb, header, tx, totalUsedGas, transientProcess)
-		if err != nil && err != vm.OutOfGasError {
+		if err != nil {
 			return nil, err
 		}
 

--- a/core/state_transition.go
+++ b/core/state_transition.go
@@ -203,14 +203,21 @@ func (self *StateTransition) transitionState() (ret []byte, usedGas *big.Int, er
 				glog.V(logger.Core).Infoln("Insufficient gas for creating code. Require", dataGas, "and have", self.gas)
 			}
 		}
+		glog.V(logger.Core).Infoln("VM create err:", err)
 	} else {
 		// Increment the nonce for the next transaction
 		self.state.SetNonce(sender.Address(), sender.Nonce()+1)
 		ret, err = vmenv.Call(sender, self.To().Address(), self.data, self.gas, self.gasPrice, self.value)
+		glog.V(logger.Core).Infoln("VM call err:", err)
 	}
 
 	if err != nil && IsValueTransferErr(err) {
 		return nil, nil, InvalidTxError(err)
+	}
+
+	// We aren't interested in errors here. Errors returned by the VM are non-consensus errors and therefor shouldn't bubble up
+	if err != nil {
+		err = nil
 	}
 
 	if vm.Debug {

--- a/core/types/transaction.go
+++ b/core/types/transaction.go
@@ -15,6 +15,8 @@ import (
 	"github.com/ethereum/go-ethereum/rlp"
 )
 
+var ErrInvalidSig = errors.New("invalid v, r, s values")
+
 func IsContractAddr(addr []byte) bool {
 	return len(addr) == 0
 }
@@ -177,7 +179,7 @@ func (tx *Transaction) SignatureValues() (v byte, r *big.Int, s *big.Int) {
 
 func (tx *Transaction) publicKey() ([]byte, error) {
 	if !crypto.ValidateSignatureValues(tx.data.V, tx.data.R, tx.data.S) {
-		return nil, errors.New("invalid v, r, s values")
+		return nil, ErrInvalidSig
 	}
 
 	// encode the signature in uncompressed format

--- a/core/vm/errors.go
+++ b/core/vm/errors.go
@@ -22,7 +22,7 @@ func (self StackError) Error() string {
 	return fmt.Sprintf("stack error! require %v, have %v", self.req, self.has)
 }
 
-func IsStack(err error) bool {
+func IsStackErr(err error) bool {
 	_, ok := err.(StackError)
 	return ok
 }


### PR DESCRIPTION
After the change to how VM errors are checked we created similar errors, but only backward. I've removed the bubble up from `StateTransition` during VM errors so we no longer need to explicitly check for non-consensus issues.