### PR TITLE
added net.version

### DIFF
--- a/jsre/pp_js.go
+++ b/jsre/pp_js.go
@@ -116,7 +116,7 @@ var isBigNumber = function (object) {
     var result = typeof BigNumber !== 'undefined' && object instanceof BigNumber;
 
     if (!result) {
-    	if(typeof(object) === "object") {
+    	if (typeof(object) === "object" && object.constructor != null) {
 			result = object.constructor.toString().indexOf("function BigNumber(") == 0;
 		}
     }

--- a/rpc/api/net.go
+++ b/rpc/api/net.go
@@ -32,6 +32,7 @@ var (
 	netMapping = map[string]nethandler{
 		"net_peerCount": (*netApi).PeerCount,
 		"net_listening": (*netApi).IsListening,
+		"net_version": (*netApi).Version,
 	}
 )
 
@@ -91,5 +92,9 @@ func (self *netApi) PeerCount(req *shared.Request) (interface{}, error) {
 
 func (self *netApi) IsListening(req *shared.Request) (interface{}, error) {
 	return self.xeth.IsListening(), nil
+}
+
+func (self *netApi) Version(req *shared.Request) (interface{}, error) {
+	return self.xeth.NetworkVersion(), nil
 }
 

--- a/rpc/api/net_js.go
+++ b/rpc/api/net_js.go
@@ -30,6 +30,10 @@ web3._extend({
 	],
 	properties:
 	[
+		new web3._extend.Property({
+			name: 'version',
+			getter: 'net_version'
+		})
 	]
 });
 `

--- a/rpc/api/txpool_js.go
+++ b/rpc/api/txpool_js.go
@@ -26,8 +26,7 @@ web3._extend({
 	[
 		new web3._extend.Property({
 			name: 'status',
-			getter: 'txpool_status',
-			outputFormatter: function(obj) { return obj; }
+			getter: 'txpool_status'
 		})
 	]
 });


### PR DESCRIPTION
During cleanup the `net.version` method was falsely removed.
This fixes #1434 