### PR TITLE
accounts, crypto: fixed file naming for windows

### DIFF
--- a/accounts/account_manager.go
+++ b/accounts/account_manager.go
@@ -228,8 +228,5 @@ func (am *Manager) ImportPreSaleKey(keyJSON []byte, password string) (acc Accoun
 	if err != nil {
 		return
 	}
-	if err = am.keyStore.StoreKey(key, password); err != nil {
-		return
-	}
 	return Account{Address: key.Address}, nil
 }

--- a/crypto/key_store_plain.go
+++ b/crypto/key_store_plain.go
@@ -189,7 +189,7 @@ func toISO8601(t time.Time) string {
 	} else {
 		tz = fmt.Sprintf("%03d00", offset/3600)
 	}
-	return fmt.Sprintf("%04d-%02d-%02dT%02d:%02d:%02d.%09d%s", t.Year(), t.Month(), t.Day(), t.Hour(), t.Minute(), t.Second(), t.Nanosecond(), tz)
+	return fmt.Sprintf("%04d-%02d-%02dT%02d-%02d-%02d.%09d%s", t.Year(), t.Month(), t.Day(), t.Hour(), t.Minute(), t.Second(), t.Nanosecond(), tz)
 }
 
 func getKeyAddresses(keysDirPath string) (addresses []common.Address, err error) {


### PR DESCRIPTION
* : colon => dash - in keyfile name - slight deviation from ISO8601 for WIN FS compatibility (the commit accidentally missing from frozen)
*  fix wallet import key duplicate write