### PR TITLE
Old transaction after resend was not removed from pool

### DIFF
--- a/core/transaction_pool.go
+++ b/core/transaction_pool.go
@@ -356,11 +356,12 @@ func (self *TxPool) RemoveTransactions(txs types.Transactions) {
 	self.mu.Lock()
 	defer self.mu.Unlock()
 	for _, tx := range txs {
-		self.removeTx(tx.Hash())
+		self.RemoveTx(tx.Hash())
 	}
 }
 
-func (pool *TxPool) removeTx(hash common.Hash) {
+// RemoveTx removes the transaction with the given hash from the pool.
+func (pool *TxPool) RemoveTx(hash common.Hash) {
 	// delete from pending pool
 	delete(pool.pending, hash)
 	// delete from queue

--- a/core/transaction_pool_test.go
+++ b/core/transaction_pool_test.go
@@ -130,7 +130,7 @@ func TestRemoveTx(t *testing.T) {
 		t.Error("expected txs to be 1, got", len(pool.pending))
 	}
 
-	pool.removeTx(tx.Hash())
+	pool.RemoveTx(tx.Hash())
 
 	if len(pool.queue) > 0 {
 		t.Error("expected queue to be 0, got", len(pool.queue))

--- a/rpc/api/eth_args.go
+++ b/rpc/api/eth_args.go
@@ -888,6 +888,7 @@ type tx struct {
 	Data     string
 	GasLimit string
 	GasPrice string
+	Hash     string
 }
 
 func newTx(t *types.Transaction) *tx {
@@ -906,6 +907,7 @@ func newTx(t *types.Transaction) *tx {
 		Data:     "0x" + common.Bytes2Hex(t.Data()),
 		GasLimit: t.Gas().String(),
 		GasPrice: t.GasPrice().String(),
+		Hash:     t.Hash().Hex(),
 	}
 }
 
@@ -930,6 +932,12 @@ func (tx *tx) UnmarshalJSON(b []byte) (err error) {
 		data             []byte
 		contractCreation = true
 	)
+
+	if val, found := fields["Hash"]; found {
+		if hashVal, ok := val.(string); ok {
+			tx.Hash = hashVal
+		}
+	}
 
 	if val, found := fields["To"]; found {
 		if strVal, ok := val.(string); ok && len(strVal) > 0 {


### PR DESCRIPTION
After [this change](https://github.com/ethereum/go-ethereum/pull/1241/files#diff-5ca161f6ea16137a30ef1967569c8418R966) the transaction hash stored in the transaction pool is of the signed transaction. This causes the `eth.resend` transaction not to remove the pending transaction when it was resend since the removal is on the unsigned transaction returned by `eth.pendingTransactions`.

Part of the signature is a random nonce which makes it impossible to recreate the signed transaction and remove the transaction using the old method. Therefore the transaction Hash was added to `eth.pendingTransactions` and `txPool.RemoveTx` function was exported which accepts this hash and removed the transaction from the pool.