### PR TITLE
miner: moved state sync

### DIFF
--- a/miner/worker.go
+++ b/miner/worker.go
@@ -263,6 +263,7 @@ func (self *worker) wait() {
 			}
 			block := result.Block
 
+			self.current.state.Sync()
 			if self.fullValidation {
 				if _, err := self.chain.InsertChain(types.Blocks{block}); err != nil {
 					glog.V(logger.Error).Infoln("mining err", err)
@@ -489,7 +490,6 @@ func (self *worker) commitNewWork() {
 		// commit state root after all state transitions.
 		core.AccumulateRewards(self.current.state, header, uncles)
 		current.state.SyncObjects()
-		self.current.state.Sync()
 		header.Root = current.state.Root()
 	}
 


### PR DESCRIPTION
Moved the state sync so it only syncs the state when the block mining yield a possitive result