### PR TITLE
ethdb, trie: removed RLE compression

### DIFF
--- a/ethdb/database.go
+++ b/ethdb/database.go
@@ -23,7 +23,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/ethereum/go-ethereum/compression/rle"
 	"github.com/ethereum/go-ethereum/logger"
 	"github.com/ethereum/go-ethereum/logger/glog"
 	"github.com/ethereum/go-ethereum/metrics"
@@ -100,12 +99,12 @@ func (self *LDBDatabase) Put(key []byte, value []byte) error {
 		defer self.putTimer.UpdateSince(time.Now())
 	}
 	// Generate the data to write to disk, update the meter and write
-	dat := rle.Compress(value)
+	//value = rle.Compress(value)
 
 	if self.writeMeter != nil {
-		self.writeMeter.Mark(int64(len(dat)))
+		self.writeMeter.Mark(int64(len(value)))
 	}
-	return self.db.Put(key, dat, nil)
+	return self.db.Put(key, value, nil)
 }
 
 // Get returns the given key if it's present.
@@ -126,7 +125,8 @@ func (self *LDBDatabase) Get(key []byte) ([]byte, error) {
 	if self.readMeter != nil {
 		self.readMeter.Mark(int64(len(dat)))
 	}
-	return rle.Decompress(dat)
+	return dat, nil
+	//return rle.Decompress(dat)
 }
 
 // Delete deletes the key from the queue and database

--- a/trie/cache.go
+++ b/trie/cache.go
@@ -17,7 +17,6 @@
 package trie
 
 import (
-	"github.com/ethereum/go-ethereum/compression/rle"
 	"github.com/ethereum/go-ethereum/ethdb"
 	"github.com/ethereum/go-ethereum/logger/glog"
 	"github.com/syndtr/goleveldb/leveldb"
@@ -49,7 +48,8 @@ func (self *Cache) Get(key []byte) []byte {
 
 func (self *Cache) Put(key []byte, data []byte) {
 	// write the data to the ldb batch
-	self.batch.Put(key, rle.Compress(data))
+	//self.batch.Put(key, rle.Compress(data))
+	self.batch.Put(key, data)
 	self.store[string(key)] = data
 }
 


### PR DESCRIPTION
This can only go in just before Frontier because it removes all compression. It will not work with older databases. 