### PR TITLE
core: fix an RLP encoding data race due to deep struct copy

### DIFF
--- a/core/types/block.go
+++ b/core/types/block.go
@@ -257,7 +257,7 @@ func (b *Block) DecodeRLP(s *rlp.Stream) error {
 	return nil
 }
 
-func (b Block) EncodeRLP(w io.Writer) error {
+func (b *Block) EncodeRLP(w io.Writer) error {
 	return rlp.Encode(w, extblock{
 		Header: b.header,
 		Txs:    b.transactions,
@@ -274,7 +274,7 @@ func (b *StorageBlock) DecodeRLP(s *rlp.Stream) error {
 	return nil
 }
 
-func (b StorageBlock) EncodeRLP(w io.Writer) error {
+func (b *StorageBlock) EncodeRLP(w io.Writer) error {
 	return rlp.Encode(w, storageblock{
 		Header: b.header,
 		Txs:    b.transactions,


### PR DESCRIPTION
See last three data races from https://gist.github.com/tcoulter/04b5afe44585dfcf245d