### PR TITLE
Etherbase defaults to first account even if it is created during the session

### DIFF
--- a/cmd/geth/js_test.go
+++ b/cmd/geth/js_test.go
@@ -159,7 +159,7 @@ func TestAccounts(t *testing.T) {
 	defer os.RemoveAll(tmp)
 
 	checkEvalJSON(t, repl, `eth.accounts`, `["`+testAddress+`"]`)
-	checkEvalJSON(t, repl, `eth.coinbase`, `null`)
+	checkEvalJSON(t, repl, `eth.coinbase`, `"`+testAddress+`"`)
 	val, err := repl.re.Run(`personal.newAccount("password")`)
 	if err != nil {
 		t.Errorf("expected no error, got %v", err)
@@ -170,6 +170,7 @@ func TestAccounts(t *testing.T) {
 	}
 
 	checkEvalJSON(t, repl, `eth.accounts`, `["`+testAddress+`","`+addr+`"]`)
+
 }
 
 func TestBlockChain(t *testing.T) {

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -489,7 +489,11 @@ func (s *Ethereum) StartMining(threads int) error {
 func (s *Ethereum) Etherbase() (eb common.Address, err error) {
 	eb = s.etherbase
 	if (eb == common.Address{}) {
-		err = fmt.Errorf("etherbase address must be explicitly specified")
+		addr, e := s.AccountManager().AddressByIndex(0)
+		if e != nil {
+			err = fmt.Errorf("etherbase address must be explicitly specified")
+		}
+		eb = common.HexToAddress(addr)
 	}
 	return
 }


### PR DESCRIPTION
This now works: 

```js
> eth.coinbase
> personal.newAccount("")
'0x6c2b90c64b88385f2889b61f4776ae89feea6fbb'
> eth.coinbase
'0x6c2b90c64b88385f2889b61f4776ae89feea6fbb'
```