### PR TITLE
Improved error handling for NewTransactionFromBytes

### DIFF
--- a/core/types/transaction.go
+++ b/core/types/transaction.go
@@ -97,15 +97,6 @@ func NewTransaction(nonce uint64, to common.Address, amount, gasLimit, gasPrice 
 	return &Transaction{data: d}
 }
 
-func NewTransactionFromBytes(data []byte) *Transaction {
-	// TODO: remove this function if possible. callers would
-	// much better off decoding into transaction directly.
-	// it's not that hard.
-	tx := new(Transaction)
-	rlp.DecodeBytes(data, tx)
-	return tx
-}
-
 func (tx *Transaction) EncodeRLP(w io.Writer) error {
 	return rlp.Encode(w, &tx.data)
 }


### PR DESCRIPTION
In case an invalid RLP encoded transaction is passed to `types.NewTransactionFromBytes` nil is returned. Due to a lack of checking this can cause a nil pointer later.

- [x] improved error handling for NewTransactionFromBytes
- [x] add unittest for NewTransactionFromBytes
- [ ] verify this with develop when gas limit is raised

Closes #1518.