### PR TITLE
jsre: leave out lines from history possibly containing passwords

### DIFF
--- a/cmd/geth/js.go
+++ b/cmd/geth/js.go
@@ -23,6 +23,7 @@ import (
 	"os"
 	"os/signal"
 	"path/filepath"
+	"regexp"
 	"strings"
 
 	"sort"
@@ -43,6 +44,10 @@ import (
 	"github.com/peterh/liner"
 	"github.com/robertkrimen/otto"
 )
+
+var passwordRegexp = regexp.MustCompile("personal.[nu]")
+
+const passwordRepl = ""
 
 type prompter interface {
 	AppendHistory(string)
@@ -413,12 +418,22 @@ func (self *jsre) interactive() {
 			str += input + "\n"
 			self.setIndent()
 			if indentCount <= 0 {
-				hist := str[:len(str)-1]
-				self.AppendHistory(hist)
+				hist := hidepassword(str[:len(str)-1])
+				if len(hist) > 0 {
+					self.AppendHistory(hist)
+				}
 				self.parseInput(str)
 				str = ""
 			}
 		}
+	}
+}
+
+func hidepassword(input string) string {
+	if passwordRegexp.MatchString(input) {
+		return passwordRepl
+	} else {
+		return input
 	}
 }
 


### PR DESCRIPTION
Currently the js console keeps a history. If you use methods of the `personal` module, and give your password as an argument, it ends up in the history file in cleartext.

The situation is worse, since the js console currently does not even allow interactive password input, so supplying it as argument is the only option. 

Ideally blanking out password arguments should result in history entries like: personal.newAccount(XXXXX), however finding the right argument is very hard, a line could look like this:

```js
personal.unlockAccount(complex(method(arg0, arg1, arg2)), "password"))
```

potentially several calls within complex expression.

Due to lack of a better solution, I blank the entire line if it contains a personal command just to be on the safe side.