### PR TITLE
cmd, core, eth: support for the olympic network

### DIFF
--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -280,6 +280,7 @@ JavaScript API. See https://github.com/ethereum/go-ethereum/wiki/Javascipt-Conso
 		utils.BootnodesFlag,
 		utils.DataDirFlag,
 		utils.BlockchainVersionFlag,
+		utils.OlympicFlag,
 		utils.CacheFlag,
 		utils.JSpathFlag,
 		utils.ListenPortFlag,
@@ -346,6 +347,9 @@ func main() {
 
 func run(ctx *cli.Context) {
 	utils.CheckLegalese(ctx.GlobalString(utils.DataDirFlag.Name))
+	if ctx.GlobalBool(utils.OlympicFlag.Name) {
+		utils.InitOlympic()
+	}
 
 	cfg := utils.MakeEthConfig(ClientIdentifier, nodeNameVersion, ctx)
 	ethereum, err := eth.New(cfg)

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -131,6 +131,10 @@ var (
 		Usage: "Megabytes of memory allocated to internal caching",
 		Value: 0,
 	}
+	OlympicFlag = cli.BoolFlag{
+		Name:  "olympic",
+		Usage: "Use olympic style protocol",
+	}
 
 	// miner settings
 	MinerThreadsFlag = cli.IntFlag{
@@ -402,6 +406,7 @@ func MakeEthConfig(clientID, version string, ctx *cli.Context) *eth.Config {
 		MaxPeers:                ctx.GlobalInt(MaxPeersFlag.Name),
 		MaxPendingPeers:         ctx.GlobalInt(MaxPendingPeersFlag.Name),
 		Port:                    ctx.GlobalString(ListenPortFlag.Name),
+		Olympic:                 ctx.GlobalBool(OlympicFlag.Name),
 		NAT:                     MakeNAT(ctx),
 		NatSpec:                 ctx.GlobalBool(NatspecEnabledFlag.Name),
 		Discovery:               !ctx.GlobalBool(NoDiscoverFlag.Name),
@@ -443,6 +448,13 @@ func MakeChain(ctx *cli.Context) (chain *core.ChainManager, blockDB, stateDB, ex
 	}
 	if extraDB, err = ethdb.NewLDBDatabase(filepath.Join(datadir, "extra"), cache); err != nil {
 		Fatalf("Could not open database: %v", err)
+	}
+	if ctx.GlobalBool(OlympicFlag.Name) {
+		InitOlympic()
+		_, err := core.WriteTestNetGenesisBlock(stateDB, blockDB, 42)
+		if err != nil {
+			glog.Fatalln(err)
+		}
 	}
 
 	eventMux := new(event.TypeMux)

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -78,6 +78,7 @@ type Config struct {
 	GenesisNonce int
 	GenesisFile  string
 	GenesisBlock *types.Block // used by block tests
+	Olympic      bool
 
 	BlockChainVersion  int
 	SkipBcVersionCheck bool // e.g. blockchain export
@@ -300,6 +301,14 @@ func New(config *Config) (*Ethereum, error) {
 			return nil, err
 		}
 		glog.V(logger.Info).Infof("Successfully wrote genesis block. New genesis hash = %x\n", block.Hash())
+	}
+
+	if config.Olympic {
+		_, err := core.WriteTestNetGenesisBlock(stateDb, blockDb, 42)
+		if err != nil {
+			return nil, err
+		}
+		glog.V(logger.Error).Infoln("Starting Olympic network")
 	}
 
 	// This is for testing only.


### PR DESCRIPTION
Added a `--olympic` flag which initialiser the olympic protocol settings