### PR TITLE
Throw exception in a manner that matches behavior of nodes

### DIFF
--- a/rpc/api/miner.go
+++ b/rpc/api/miner.go
@@ -126,6 +126,10 @@ func (self *minerApi) SetExtra(req *shared.Request) (interface{}, error) {
 		return nil, err
 	}
 
+	if common.IsHex(args.Data) {
+		args.Data = string(common.FromHex(args.Data)) //convert the byte array back to a string
+	}
+
 	if uint64(len(args.Data)) > params.MaximumExtraDataSize.Uint64() {
 		return false, fmt.Errorf("extra datasize can be no longer than %v bytes", params.MaximumExtraDataSize)
 	}

--- a/rpc/api/miner.go
+++ b/rpc/api/miner.go
@@ -126,7 +126,7 @@ func (self *minerApi) SetExtra(req *shared.Request) (interface{}, error) {
 		return nil, err
 	}
 
-	if uint64(len(args.Data)) > params.MaximumExtraDataSize.Uint64()*2 {
+	if uint64(len(args.Data)) > params.MaximumExtraDataSize.Uint64() {
 		return false, fmt.Errorf("extra datasize can be no longer than %v bytes", params.MaximumExtraDataSize)
 	}
 


### PR DESCRIPTION
Currently geth will allow the user to set an extra data field via miner.setExtra that is larger than the limit that nodes accept by a factor of two. By deleting the ```*2``` this matches the behaviorof go-ethereum, cpp-ethereum, and pyethereum. This prevents geth from allowing the user to set an extra data field that is larger than possible (thereby causing the user to mine blocks that are invalid). 

See behavior of go-ethereum here: https://github.com/ethereum/go-ethereum/blob/80e5f507130a926ea62dde07c2b98d6f8a0ba3e2/core/block_processor.go#L378

See behavior of cpp-ethereum here: https://github.com/ethereum/cpp-ethereum/blob/09e5dbfa06055498ddeaa4dcbd30a36a7dcc4462/libethcore/Ethash.cpp#L99

See behavior of pyethereum here: https://github.com/ethereum/pyethereum/blob/develop/ethereum/blocks.py#L532

See behavior of ethereumJ here: https://github.com/ethereum/ethereumj/blob/27107e3bfedc5d6eabdd391749f84eb3e151adca/ethereumj-core/src/main/java/org/ethereum/core/BlockchainImpl.java#L429