### PR TITLE
miner, rpc: added submit hashrate for remote agents

### DIFF
--- a/miner/miner.go
+++ b/miner/miner.go
@@ -139,8 +139,15 @@ func (self *Miner) Mining() bool {
 	return atomic.LoadInt32(&self.mining) > 0
 }
 
-func (self *Miner) HashRate() int64 {
-	return self.pow.GetHashrate()
+func (self *Miner) HashRate() (tot int64) {
+	tot += self.pow.GetHashrate()
+	// do we care this might race? is it worth we're rewriting some
+	// aspects of the worker/locking up agents so we can get an accurate
+	// hashrate?
+	for _, agent := range self.worker.agents {
+		tot += agent.GetHashRate()
+	}
+	return
 }
 
 func (self *Miner) SetExtra(extra []byte) {

--- a/miner/remote_agent.go
+++ b/miner/remote_agent.go
@@ -27,6 +27,11 @@ import (
 	"github.com/ethereum/go-ethereum/logger/glog"
 )
 
+type hashrate struct {
+	ping time.Time
+	rate uint64
+}
+
 type RemoteAgent struct {
 	mu sync.Mutex
 
@@ -36,12 +41,22 @@ type RemoteAgent struct {
 
 	currentWork *Work
 	work        map[common.Hash]*Work
+
+	hashrateMu sync.RWMutex
+	hashrate   map[common.Hash]hashrate
 }
 
 func NewRemoteAgent() *RemoteAgent {
-	agent := &RemoteAgent{work: make(map[common.Hash]*Work)}
+	agent := &RemoteAgent{work: make(map[common.Hash]*Work), hashrate: make(map[common.Hash]hashrate)}
 
 	return agent
+}
+
+func (a *RemoteAgent) SubmitHashrate(id common.Hash, rate uint64) {
+	a.hashrateMu.Lock()
+	defer a.hashrateMu.Unlock()
+
+	a.hashrate[id] = hashrate{time.Now(), rate}
 }
 
 func (a *RemoteAgent) Work() chan<- *Work {
@@ -63,7 +78,17 @@ func (a *RemoteAgent) Stop() {
 	close(a.workCh)
 }
 
-func (a *RemoteAgent) GetHashRate() int64 { return 0 }
+// GetHashRate returns the accumulated hashrate of all identifier combined
+func (a *RemoteAgent) GetHashRate() (tot int64) {
+	a.hashrateMu.RLock()
+	defer a.hashrateMu.RUnlock()
+
+	// this could overflow
+	for _, hashrate := range a.hashrate {
+		tot += int64(hashrate.rate)
+	}
+	return
+}
 
 func (a *RemoteAgent) GetWork() [3]string {
 	a.mu.Lock()
@@ -131,6 +156,14 @@ out:
 				}
 			}
 			a.mu.Unlock()
+
+			a.hashrateMu.Lock()
+			for id, hashrate := range a.hashrate {
+				if time.Since(hashrate.ping) > 10*time.Second {
+					delete(a.hashrate, id)
+				}
+			}
+			a.hashrateMu.Unlock()
 		}
 	}
 }

--- a/rpc/api/eth.go
+++ b/rpc/api/eth.go
@@ -92,6 +92,7 @@ var (
 		"eth_hashrate":                            (*ethApi).Hashrate,
 		"eth_getWork":                             (*ethApi).GetWork,
 		"eth_submitWork":                          (*ethApi).SubmitWork,
+		"eth_submitHashrate":                      (*ethApi).SubmitHashrate,
 		"eth_resend":                              (*ethApi).Resend,
 		"eth_pendingTransactions":                 (*ethApi).PendingTransactions,
 		"eth_getTransactionReceipt":               (*ethApi).GetTransactionReceipt,
@@ -571,6 +572,15 @@ func (self *ethApi) SubmitWork(req *shared.Request) (interface{}, error) {
 		return nil, shared.NewDecodeParamError(err.Error())
 	}
 	return self.xeth.RemoteMining().SubmitWork(args.Nonce, common.HexToHash(args.Digest), common.HexToHash(args.Header)), nil
+}
+
+func (self *ethApi) SubmitHashrate(req *shared.Request) (interface{}, error) {
+	args := new(SubmitHashRateArgs)
+	if err := self.codec.Decode(req.Params, &args); err != nil {
+		return nil, shared.NewDecodeParamError(err.Error())
+	}
+	self.xeth.RemoteMining().SubmitHashrate(common.HexToHash(args.Id), args.Rate)
+	return nil, nil
 }
 
 func (self *ethApi) Resend(req *shared.Request) (interface{}, error) {

--- a/rpc/api/eth_args.go
+++ b/rpc/api/eth_args.go
@@ -169,6 +169,37 @@ func (args *GetTxCountArgs) UnmarshalJSON(b []byte) (err error) {
 	return nil
 }
 
+type SubmitHashRateArgs struct {
+	Id   string
+	Rate uint64
+}
+
+func (args *SubmitHashRateArgs) UnmarshalJSON(b []byte) (err error) {
+	var obj []interface{}
+	if err := json.Unmarshal(b, &obj); err != nil {
+		return shared.NewDecodeParamError(err.Error())
+	}
+
+	if len(obj) < 2 {
+		return shared.NewInsufficientParamsError(len(obj), 2)
+	}
+
+	arg0, ok := obj[0].(string)
+	if !ok {
+		return shared.NewInvalidTypeError("hash", "not a string")
+	}
+	args.Id = arg0
+
+	arg1, ok := obj[1].(string)
+	if !ok {
+		return shared.NewInvalidTypeError("rate", "not a string")
+	}
+
+	args.Rate = common.String2Big(arg1).Uint64()
+
+	return nil
+}
+
 type HashArgs struct {
 	Hash string
 }


### PR DESCRIPTION
This will allow you to query `eth_hashrate` to get a hash rate from any `ethminer` given that `ethminer` has implemented the `eth_submitHashrate` method.