### PR TITLE
trie: merkle proofs

### DIFF
--- a/trie/fullnode.go
+++ b/trie/fullnode.go
@@ -16,6 +16,9 @@
 
 package trie
 
+// FullNode represents the main node type for a radix tree.
+// The first 16 children are branches for each possible next letter in the key.
+// The final slot is for a terminating node (a ValueNode), whose key ends at the FullNode.
 type FullNode struct {
 	trie  *Trie
 	nodes [17]Node

--- a/trie/hashnode.go
+++ b/trie/hashnode.go
@@ -18,6 +18,10 @@ package trie
 
 import "github.com/ethereum/go-ethereum/common"
 
+// HashNode represents a node that is too big to be a ShortNode.
+// The actual node of interest (probably a FullNode) is rlp encoded and hashed,
+// yielding the key of the HashNode. The key can be used to fetch the actual
+// node from the database
 type HashNode struct {
 	key   []byte
 	trie  *Trie

--- a/trie/node.go
+++ b/trie/node.go
@@ -25,7 +25,7 @@ type Node interface {
 	Copy(*Trie) Node // All nodes, for now, return them self
 	Dirty() bool
 	fstring(string) string
-	Hash() interface{}
+	Hash() interface{} // only really a hash if size(node) > 32
 	RlpData() interface{}
 	setDirty(dirty bool)
 }

--- a/trie/proof.go
+++ b/trie/proof.go
@@ -1,0 +1,182 @@
+package trie
+
+import (
+	"bytes"
+
+	"github.com/ethereum/go-ethereum/common"
+	//	"github.com/ethereum/go-ethereum/rlp"
+)
+
+/*
+A merkle proof for the trie consists of the RLP data for all nodes
+on the path from the root to the node of interest
+*/
+
+type TrieProof struct {
+	Key        []byte
+	Value      []byte
+	InnerNodes []ProofNode // ShortNode or FullNode
+	RootHash   []byte
+}
+
+func (proof *TrieProof) RlpData() interface{} {
+	return []interface{}{proof.Key, proof.Value, proof.InnerNodes, proof.RootHash}
+}
+
+// Prove a byte array is in the trie
+func (trie *Trie) Prove(key []byte) *TrieProof {
+	if trie == nil {
+		return nil
+	}
+	k := CompactHexDecode(key) // nibbles
+
+	rootHash := trie.Hash()
+	proof := &TrieProof{
+		Key:      key,
+		RootHash: rootHash,
+	}
+	// recursively appends nodes on the path from root to k to proof.InnerNodes
+	if exists := trie.constructProof(trie.root, k, proof); !exists {
+		return nil
+	}
+	return proof
+}
+
+// Verify the proof actually proves the given key byte-array is in the trie
+func (proof *TrieProof) Verify(key, value, rootHash []byte) bool {
+	if !bytes.Equal(key, proof.Key) {
+		return false
+	}
+	if !bytes.Equal(value, proof.Value) {
+		return false
+	}
+	if !bytes.Equal(rootHash, proof.RootHash) {
+		return false
+	}
+	// build up proof nodes into proper nodes in a dumy trie
+	trie := New(nil, nil)
+	nextNode := Node(NewValueNode(trie, value))
+	for _, proofNode := range proof.InnerNodes {
+		nextNode = linkProofNodes(trie, proofNode, nextNode)
+		if nextNode == nil {
+			return false
+		}
+	}
+	trie.root = nextNode
+	finalHash := trie.Hash()
+	return bytes.Equal(proof.RootHash, finalHash)
+}
+
+//--------------------------------------------------------------------------------
+
+// Proof node contains some rlp encoded data that can be decoded into a Node
+type ProofNode struct {
+	Key   []byte   // bytes
+	Nodes [][]byte `rlp:"nil"` // empty (ShortNode) or FullNode
+}
+
+func (proof ProofNode) RlpData() interface{} {
+	var t []interface{}
+	if proof.Nodes != nil {
+		t = make([]interface{}, 17)
+		for i, n := range proof.Nodes {
+			t[i] = n
+		}
+	}
+	return []interface{}{proof.Key, t}
+}
+
+// Create ShortNodefrom or FullNode. FullNode's should only have 17 entries in byte array
+func (proof ProofNode) TrieNode(trie *Trie) Node {
+	if len(proof.Nodes) == 0 {
+		return &ShortNode{trie: trie, key: proof.Key}
+	} else {
+		fullNode := NewFullNode(trie)
+		if len(proof.Nodes) != len(fullNode.nodes) {
+			return nil
+		}
+		for i, hash := range proof.Nodes {
+			fullNode.nodes[i] = trie.mknode(common.NewValueFromBytes(hash))
+		}
+		return fullNode
+	}
+}
+
+// Create proof node from full node by rlp encoding all children
+func FullNodeToProof(node *FullNode, key byte) ProofNode {
+	proofNode := ProofNode{Key: []byte{key}, Nodes: make([][]byte, 17)}
+	for i, n := range node.nodes {
+		if n == nil || i == int(key) { // don't store the node for the branch we're proving
+			proofNode.Nodes[i] = common.Encode("")
+		} else {
+			proofNode.Nodes[i] = common.Encode(n)
+		}
+	}
+	return proofNode
+}
+
+func ShortNodeToProof(node *ShortNode) ProofNode {
+	return ProofNode{Key: node.key, Nodes: nil}
+}
+
+//--------------------------------------------------------------------------------
+
+// key should be nibbles
+func (trie *Trie) constructProof(node Node, key []byte, proof *TrieProof) (exists bool) {
+	if node == nil {
+		return false
+	}
+	switch n := node.(type) {
+	case *ValueNode:
+		// NOTE: we should have made sure the key matches by now
+		// getting here == much success, very proof
+		proof.Value = n.Val()
+	case *HashNode:
+		// resolve the hash node and call constructProof
+		if exists := trie.constructProof(trie.trans(n), key, proof); !exists {
+			return false
+		}
+	case *ShortNode:
+		// chew off some key, constructProof on the value
+		if !bytes.HasPrefix(key, n.Key()) {
+			return false
+		}
+		k := key[len(n.Key()):]
+		if exists := trie.constructProof(n.Value(), k, proof); !exists {
+			return false
+		}
+		proof.InnerNodes = append(proof.InnerNodes, ShortNodeToProof(n))
+	case *FullNode:
+		// pick the right branch and carry on
+		if exists := trie.constructProof(n.branch(key[0]), key[1:], proof); !exists {
+			return false
+		}
+		proof.InnerNodes = append(proof.InnerNodes, FullNodeToProof(n, key[0]))
+	default:
+		panic("unknown node type")
+	}
+	return true
+}
+
+// fill in the nodes as we climb up the tree.
+//returns nil if full node has an empty key or too many branches
+func linkProofNodes(trie *Trie, proofNode ProofNode, node Node) Node {
+	nextNode := proofNode.TrieNode(trie)
+	if nextNode == nil {
+		return nil
+	}
+	switch nextNode := nextNode.(type) {
+	case *ShortNode:
+		nextNode.value = node
+		return nextNode
+	case *FullNode:
+		if len(proofNode.Key) == 0 {
+			return nil
+		}
+		nextNode.nodes[proofNode.Key[0]] = node
+		return nextNode
+	default:
+		panic("invalid proof node")
+	}
+	return nil
+}

--- a/trie/shortnode.go
+++ b/trie/shortnode.go
@@ -18,9 +18,12 @@ package trie
 
 import "github.com/ethereum/go-ethereum/common"
 
+// ShortNode holds the nibble key for a ValueNode, HashNode, or FullNode.
+// Note a ShortNode should never hold another ShortNode, as they can just
+// be combined into one ShortNode
 type ShortNode struct {
 	trie  *Trie
-	key   []byte
+	key   []byte // hex-prefixed bytes
 	value Node
 	dirty bool
 }
@@ -30,7 +33,6 @@ func NewShortNode(t *Trie, key []byte, value Node) *ShortNode {
 }
 func (self *ShortNode) Value() Node {
 	self.value = self.trie.trans(self.value)
-
 	return self.value
 }
 func (self *ShortNode) Dirty() bool { return self.dirty }
@@ -48,6 +50,7 @@ func (self *ShortNode) Hash() interface{} {
 	return self.trie.store(self)
 }
 
+// returns nibbles
 func (self *ShortNode) Key() []byte {
 	return CompactDecode(self.key)
 }

--- a/trie/trie.go
+++ b/trie/trie.go
@@ -358,6 +358,7 @@ func (self *Trie) mknode(value *common.Value) Node {
 	return NewValueNode(self, value.Bytes())
 }
 
+// resolve HashNodes by fetching from the db
 func (self *Trie) trans(node Node) Node {
 	switch node := node.(type) {
 	case *HashNode:

--- a/trie/trie.go
+++ b/trie/trie.go
@@ -239,7 +239,7 @@ func (self *Trie) get(node Node, key []byte) Node {
 		k := node.Key()
 		cnode := node.Value()
 
-		if len(key) >= len(k) && bytes.Equal(k, key[:len(k)]) {
+		if len(key) >= len(k) && bytes.HasPrefix(key, k) {
 			return self.get(cnode, key[len(k):])
 		}
 
@@ -373,7 +373,7 @@ func (self *Trie) store(node Node) interface{} {
 	data := common.Encode(node)
 	if len(data) >= 32 {
 		key := crypto.Sha3(data)
-		if node.Dirty() {
+		if node.Dirty() && self.cache != nil {
 			//fmt.Println("save", node)
 			//fmt.Println()
 			self.cache.Put(key, data)

--- a/trie/valuenode.go
+++ b/trie/valuenode.go
@@ -18,6 +18,8 @@ package trie
 
 import "github.com/ethereum/go-ethereum/common"
 
+// ValueNode represents a leaf node, a terminal point in the tree.
+// It is implied that if you found the ValueNode, then you know its key
 type ValueNode struct {
 	trie  *Trie
 	data  []byte


### PR DESCRIPTION
Here's a first take at merkle proofs for the trie.

The basic idea is to fetch and store all the ShortNodes and FullNodes along the path to a given value. We don't store the ShortNode's value or the relevant branch of the FullNode, as they will be overwritten during verification. Both nodes are represented by a common ProofNode type, which holds a key and a slice of byte-slices. If the slice is nil, it's a ShortNode. RLP handles the rest. 

I also added lots of comments. 

I included a test for bad proofs, whereby I just mutate a byte in the rlp encoded proof before decoding back to a proof struct. Note I had to be careful with mutating bytes `128` and `32` because of apparent indeterminacy in rlp (ie. you can mutate those bytes and everything will still be fine)
 