### PR TITLE
core/vm: fixed jit error & added inline docs

### DIFF
--- a/cmd/evm/main.go
+++ b/cmd/evm/main.go
@@ -102,7 +102,7 @@ func init() {
 func run(ctx *cli.Context) {
 	vm.Debug = ctx.GlobalBool(DebugFlag.Name)
 	vm.ForceJit = ctx.GlobalBool(ForceJitFlag.Name)
-	vm.DisableJit = ctx.GlobalBool(DisableJitFlag.Name)
+	vm.EnableJit = !ctx.GlobalBool(DisableJitFlag.Name)
 
 	glog.SetToStderr(true)
 

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -452,7 +452,7 @@ func SetupLogger(ctx *cli.Context) {
 
 // SetupVM configured the VM package's global settings
 func SetupVM(ctx *cli.Context) {
-	vm.DisableJit = !ctx.GlobalBool(VMEnableJitFlag.Name)
+	vm.EnableJit = ctx.GlobalBool(VMEnableJitFlag.Name)
 	vm.ForceJit = ctx.GlobalBool(VMForceJitFlag.Name)
 	vm.SetJITCacheSize(ctx.GlobalInt(VMJitCacheFlag.Name))
 }

--- a/core/block_processor.go
+++ b/core/block_processor.go
@@ -354,18 +354,8 @@ func (sm *BlockProcessor) GetLogs(block *types.Block) (logs state.Logs, err erro
 		for _, receipt := range receipts {
 			logs = append(logs, receipt.Logs()...)
 		}
-		return
 	}
-
-	// TODO: remove backward compatibility
-	var (
-		parent = sm.bc.GetBlock(block.ParentHash())
-		state  = state.New(parent.Root(), sm.chainDb)
-	)
-
-	sm.TransitionState(state, parent, block, true)
-
-	return state.Logs(), nil
+	return logs, nil
 }
 
 // See YP section 4.3.4. "Block Header Validity"

--- a/core/vm/instructions.go
+++ b/core/vm/instructions.go
@@ -341,19 +341,19 @@ func opCoinbase(instr instruction, env Environment, context *Context, memory *Me
 }
 
 func opTimestamp(instr instruction, env Environment, context *Context, memory *Memory, stack *stack) {
-	stack.push(new(big.Int).SetUint64(env.Time()))
+	stack.push(U256(new(big.Int).SetUint64(env.Time())))
 }
 
 func opNumber(instr instruction, env Environment, context *Context, memory *Memory, stack *stack) {
-	stack.push(U256(env.BlockNumber()))
+	stack.push(U256(new(big.Int).Set(env.BlockNumber())))
 }
 
 func opDifficulty(instr instruction, env Environment, context *Context, memory *Memory, stack *stack) {
-	stack.push(new(big.Int).Set(env.Difficulty()))
+	stack.push(U256(new(big.Int).Set(env.Difficulty())))
 }
 
 func opGasLimit(instr instruction, env Environment, context *Context, memory *Memory, stack *stack) {
-	stack.push(new(big.Int).Set(env.GasLimit()))
+	stack.push(U256(new(big.Int).Set(env.GasLimit())))
 }
 
 func opPop(instr instruction, env Environment, context *Context, memory *Memory, stack *stack) {
@@ -415,15 +415,12 @@ func opSstore(instr instruction, env Environment, context *Context, memory *Memo
 	env.State().SetState(context.Address(), loc, common.BigToHash(val))
 }
 
-func opJump(instr instruction, env Environment, context *Context, memory *Memory, stack *stack) {
-}
-func opJumpi(instr instruction, env Environment, context *Context, memory *Memory, stack *stack) {
-}
-func opJumpdest(instr instruction, env Environment, context *Context, memory *Memory, stack *stack) {
-}
+func opJump(instr instruction, env Environment, context *Context, memory *Memory, stack *stack)     {}
+func opJumpi(instr instruction, env Environment, context *Context, memory *Memory, stack *stack)    {}
+func opJumpdest(instr instruction, env Environment, context *Context, memory *Memory, stack *stack) {}
 
 func opPc(instr instruction, env Environment, context *Context, memory *Memory, stack *stack) {
-	stack.push(instr.data)
+	stack.push(new(big.Int).Set(instr.data))
 }
 
 func opMsize(instr instruction, env Environment, context *Context, memory *Memory, stack *stack) {

--- a/core/vm/jit.go
+++ b/core/vm/jit.go
@@ -83,6 +83,7 @@ type Program struct {
 	code []byte
 }
 
+// NewProgram returns a new JIT program
 func NewProgram(code []byte) *Program {
 	program := &Program{
 		Id:           crypto.Sha3Hash(code),
@@ -113,6 +114,7 @@ func (p *Program) addInstr(op OpCode, pc uint64, fn instrFn, data *big.Int) {
 	p.mapping[pc] = len(p.instructions) - 1
 }
 
+// CompileProgram compiles the given program and return an error when it fails
 func CompileProgram(program *Program) (err error) {
 	if progStatus(atomic.LoadInt32(&program.status)) == progCompile {
 		return nil
@@ -272,6 +274,8 @@ func CompileProgram(program *Program) (err error) {
 	return nil
 }
 
+// RunProgram runs the program given the enviroment and context and returns an
+// error if the execution failed (non-consensus)
 func RunProgram(program *Program, env Environment, context *Context, input []byte) ([]byte, error) {
 	return runProgram(program, 0, NewMemory(), newstack(), env, context, input)
 }
@@ -351,6 +355,8 @@ func runProgram(program *Program, pcstart uint64, mem *Memory, stack *stack, env
 
 		pc++
 	}
+
+	context.Input = nil
 
 	return context.Return(nil), nil
 }

--- a/core/vm/jit_test.go
+++ b/core/vm/jit_test.go
@@ -46,7 +46,7 @@ func runVmBench(test vmBench, b *testing.B) {
 	}
 	env := NewEnv()
 
-	DisableJit = test.nojit
+	EnableJit = !test.nojit
 	ForceJit = test.forcejit
 
 	b.ResetTimer()

--- a/core/vm/settings.go
+++ b/core/vm/settings.go
@@ -17,9 +17,9 @@
 package vm
 
 var (
-	DisableJit  bool = true // Disable the JIT VM
-	ForceJit    bool        // Force the JIT, skip byte VM
-	MaxProgSize int         // Max cache size for JIT Programs
+	EnableJit   bool // Enables the JIT VM
+	ForceJit    bool // Force the JIT, skip byte VM
+	MaxProgSize int  // Max cache size for JIT Programs
 )
 
 const defaultJitMaxCache int = 64

--- a/core/vm/vm.go
+++ b/core/vm/vm.go
@@ -64,7 +64,7 @@ func (self *Vm) Run(context *Context, input []byte) (ret []byte, err error) {
 		codehash = crypto.Sha3Hash(context.Code) // codehash is used when doing jump dest caching
 		program  *Program
 	)
-	if !DisableJit {
+	if EnableJit {
 		// Fetch program status.
 		// * If ready run using JIT
 		// * If unknown, compile in a seperate goroutine

--- a/tests/state_test.go
+++ b/tests/state_test.go
@@ -27,14 +27,13 @@ import (
 func init() {
 	if os.Getenv("JITVM") == "true" {
 		vm.ForceJit = true
-	} else {
-		vm.DisableJit = true
+		vm.EnableJit = true
 	}
 }
 
 func BenchmarkStateCall1024(b *testing.B) {
 	fn := filepath.Join(stateTestDir, "stCallCreateCallCodeTest.json")
-	if err := BenchVmTest(fn, bconf{"Call1024BalanceTooLow", true, false}, b); err != nil {
+	if err := BenchVmTest(fn, bconf{"Call1024BalanceTooLow", true, os.Getenv("JITVM") == "true"}, b); err != nil {
 		b.Error(err)
 	}
 }

--- a/tests/state_test_util.go
+++ b/tests/state_test_util.go
@@ -71,8 +71,8 @@ func BenchStateTest(p string, conf bconf, b *testing.B) error {
 		return fmt.Errorf("test not found: %s", conf.name)
 	}
 
-	pNoJit := vm.DisableJit
-	vm.DisableJit = conf.nojit
+	pJit := vm.EnableJit
+	vm.EnableJit = conf.jit
 	pForceJit := vm.ForceJit
 	vm.ForceJit = conf.precomp
 
@@ -94,7 +94,7 @@ func BenchStateTest(p string, conf bconf, b *testing.B) error {
 		benchStateTest(test, env, b)
 	}
 
-	vm.DisableJit = pNoJit
+	vm.EnableJit = pJit
 	vm.ForceJit = pForceJit
 
 	return nil

--- a/tests/vm_test.go
+++ b/tests/vm_test.go
@@ -17,20 +17,21 @@
 package tests
 
 import (
+	"os"
 	"path/filepath"
 	"testing"
 )
 
 func BenchmarkVmAckermann32Tests(b *testing.B) {
 	fn := filepath.Join(vmTestDir, "vmPerformanceTest.json")
-	if err := BenchVmTest(fn, bconf{"ackermann32", true, false}, b); err != nil {
+	if err := BenchVmTest(fn, bconf{"ackermann32", true, os.Getenv("JITVM") == "true"}, b); err != nil {
 		b.Error(err)
 	}
 }
 
 func BenchmarkVmFibonacci16Tests(b *testing.B) {
 	fn := filepath.Join(vmTestDir, "vmPerformanceTest.json")
-	if err := BenchVmTest(fn, bconf{"fibonacci16", true, false}, b); err != nil {
+	if err := BenchVmTest(fn, bconf{"fibonacci16", true, os.Getenv("JITVM") == "true"}, b); err != nil {
 		b.Error(err)
 	}
 }

--- a/tests/vm_test_util.go
+++ b/tests/vm_test_util.go
@@ -52,7 +52,7 @@ func RunVmTestWithReader(r io.Reader, skipTests []string) error {
 type bconf struct {
 	name    string
 	precomp bool
-	nojit   bool
+	jit     bool
 }
 
 func BenchVmTest(p string, conf bconf, b *testing.B) error {
@@ -67,8 +67,8 @@ func BenchVmTest(p string, conf bconf, b *testing.B) error {
 		return fmt.Errorf("test not found: %s", conf.name)
 	}
 
-	pNoJit := vm.DisableJit
-	vm.DisableJit = conf.nojit
+	pJit := vm.EnableJit
+	vm.EnableJit = conf.jit
 	pForceJit := vm.ForceJit
 	vm.ForceJit = conf.precomp
 
@@ -99,7 +99,7 @@ func BenchVmTest(p string, conf bconf, b *testing.B) error {
 		benchVmTest(test, env, b)
 	}
 
-	vm.DisableJit = pNoJit
+	vm.EnableJit = pJit
 	vm.ForceJit = pForceJit
 
 	return nil


### PR DESCRIPTION
`opNumber` did not create a new big int which could lead to the block's
number being modified.

Closes #1633 