### PR TITLE
p2p: fix value of DiscSubprotocolError

### DIFF
--- a/p2p/peer_error.go
+++ b/p2p/peer_error.go
@@ -66,7 +66,7 @@ const (
 	DiscUnexpectedIdentity
 	DiscSelf
 	DiscReadTimeout
-	DiscSubprotocolError
+	DiscSubprotocolError = 0x10
 )
 
 var discReasonToString = [...]string{


### PR DESCRIPTION
We had the wrong value (12) since forever.