### PR TITLE
rlp: boolean support

### DIFF
--- a/rlp/decode_test.go
+++ b/rlp/decode_test.go
@@ -19,6 +19,7 @@ package rlp
 import (
 	"bytes"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"io"
 	"math/big"
@@ -115,6 +116,9 @@ func TestStreamErrors(t *testing.T) {
 		{"8133", calls{"Uint"}, nil, ErrCanonSize},
 		{"817F", calls{"Uint"}, nil, ErrCanonSize},
 		{"8180", calls{"Uint"}, nil, nil},
+
+		// Non-valid boolean
+		{"02", calls{"Bool"}, nil, errors.New("rlp: invalid boolean value: 2")},
 
 		// Size tags must use the smallest possible encoding.
 		// Leading zero bytes in the size tag are also rejected.
@@ -315,6 +319,11 @@ var (
 )
 
 var decodeTests = []decodeTest{
+	// booleans
+	{input: "01", ptr: new(bool), value: true},
+	{input: "80", ptr: new(bool), value: false},
+	{input: "02", ptr: new(bool), error: "rlp: invalid boolean value: 2"},
+
 	// integers
 	{input: "05", ptr: new(uint32), value: uint32(5)},
 	{input: "80", ptr: new(uint32), value: uint32(0)},

--- a/rlp/encode.go
+++ b/rlp/encode.go
@@ -361,6 +361,8 @@ func makeWriter(typ reflect.Type) (writer, error) {
 		return writeBigIntNoPtr, nil
 	case isUint(kind):
 		return writeUint, nil
+	case kind == reflect.Bool:
+		return writeBool, nil
 	case kind == reflect.String:
 		return writeString, nil
 	case kind == reflect.Slice && isByte(typ.Elem()):
@@ -394,6 +396,15 @@ func writeUint(val reflect.Value, w *encbuf) error {
 		s := putint(w.sizebuf[1:], i)
 		w.sizebuf[0] = 0x80 + byte(s)
 		w.str = append(w.str, w.sizebuf[:s+1]...)
+	}
+	return nil
+}
+
+func writeBool(val reflect.Value, w *encbuf) error {
+	if val.Bool() {
+		w.str = append(w.str, 0x01)
+	} else {
+		w.str = append(w.str, 0x80)
 	}
 	return nil
 }

--- a/rlp/encode_test.go
+++ b/rlp/encode_test.go
@@ -71,6 +71,10 @@ type encTest struct {
 }
 
 var encTests = []encTest{
+	// booleans
+	{val: true, output: "01"},
+	{val: false, output: "80"},
+
 	// integers
 	{val: uint32(0), output: "80"},
 	{val: uint32(127), output: "7F"},


### PR DESCRIPTION
As the new eth protocol uses boolean values too (encoded as 0/1 integers), it would be nice to be able to work with these straight as booleans instead of having to interpret numbers as bools (it would require checking against invalid (2+) values whenever working with inbound bools, which is a pain to do in calling code).