### PR TITLE
rpc/comms: reconnect ipc client after write error

### DIFF
--- a/rpc/comms/ipc.go
+++ b/rpc/comms/ipc.go
@@ -44,12 +44,14 @@ func (self *ipcClient) Close() {
 
 func (self *ipcClient) Send(req interface{}) error {
 	var err error
-	if err = self.coder.WriteResponse(req); err != nil {
-		if _, ok := err.(*net.OpError); ok { // connection lost, retry once
+	if r, ok := req.(*shared.Request); ok {
+		if err = self.coder.WriteResponse(r); err != nil {
 			if err = self.reconnect(); err == nil {
-				err = self.coder.WriteResponse(req)
+				err = self.coder.WriteResponse(r)
 			}
 		}
+
+		return err
 	}
 	return err
 }


### PR DESCRIPTION
In case of a timeout the Unix and Windows ipc implementations returned different errors. The resulted in the console not reconnecting on the Windows platform. This PR will issue a reconnect on all write errors once. This will allow the Windows console to reconnect after a timeout and the console on all platforms to reconnect when the geth service was restarted.