### PR TITLE
eth, trie: removed key prefixing from state entries & merge db fix

### DIFF
--- a/trie/cache.go
+++ b/trie/cache.go
@@ -38,8 +38,6 @@ func NewCache(backend Backend) *Cache {
 }
 
 func (self *Cache) Get(key []byte) []byte {
-	key = append(StatePre, key...)
-
 	data := self.store[string(key)]
 	if data == nil {
 		data, _ = self.backend.Get(key)
@@ -49,8 +47,6 @@ func (self *Cache) Get(key []byte) []byte {
 }
 
 func (self *Cache) Put(key []byte, data []byte) {
-	key = append(StatePre, key...)
-
 	self.batch.Put(key, data)
 	self.store[string(key)] = data
 }

--- a/trie/trie.go
+++ b/trie/trie.go
@@ -27,8 +27,6 @@ import (
 	"github.com/ethereum/go-ethereum/crypto"
 )
 
-var StatePre = []byte("state-")
-
 func ParanoiaCheck(t1 *Trie, backend Backend) (bool, *Trie) {
 	t2 := New(nil, backend)
 


### PR DESCRIPTION
Fixed database merge strategy to use the correct database. Due to a copy
paste fail when doing type evaluation the same database was being
iterated (chain), all others were ignored.

Removed state prefixing because {H(code): code} is stored in the same
database as the rest of the state.