### PR TITLE
Javascript --exec output

### DIFF
--- a/cmd/geth/js.go
+++ b/cmd/geth/js.go
@@ -232,15 +232,10 @@ func (self *jsre) loadAutoCompletion() {
 }
 
 func (self *jsre) batch(statement string) {
-	val, err := self.re.Run(statement)
+	err := self.re.EvalAndPrettyPrint(statement)
 
 	if err != nil {
 		fmt.Printf("error: %v", err)
-	} else if val.IsDefined() && val.IsObject() {
-		obj, _ := self.re.Get("ret_result")
-		fmt.Printf("%v", obj)
-	} else if val.IsDefined() {
-		fmt.Printf("%v", val)
 	}
 
 	if self.atexit != nil {


### PR DESCRIPTION
Geth allows javascript to be passed with the `--exec` argument. Geth will execute the statement and prints `ret_result` as result. This is confusing since on the console web3 will format the response before its printed. This PR prints the output after its processed by web3.

This PR is build on top of #1642 

Closes #1629