### PR TITLE
xeth: added a transact mu

### DIFF
--- a/xeth/xeth.go
+++ b/xeth/xeth.go
@@ -89,8 +89,7 @@ type XEth struct {
 	messagesMu sync.RWMutex
 	messages   map[int]*whisperFilter
 
-	// regmut   sync.Mutex
-	// register map[string][]*interface{} // TODO improve return type
+	transactMu sync.Mutex
 
 	agent *miner.RemoteAgent
 
@@ -952,8 +951,9 @@ func (self *XEth) Transact(fromStr, toStr, nonceStr, valueStr, gasStr, gasPriceS
 		}
 	*/
 
-	// TODO: align default values to have the same type, e.g. not depend on
-	// common.Value conversions later on
+	self.transactMu.Lock()
+	defer self.transactMu.Unlock()
+
 	var nonce uint64
 	if len(nonceStr) != 0 {
 		nonce = common.Big(nonceStr).Uint64()


### PR DESCRIPTION
Added a transact mutex. The transact mutex will fix an issue where
transactions were created with the same nonce resulting in some
transactions being dropped. This happened when two concurrent calls
would call the `Transact` method (which is OK) which would both call
`GetNonce`. While the managed is thread safe it does not help us in this
case.


Closes #1662 