### PR TITLE
core, xeth: chain reorg move missing transactions to transaction pool

### DIFF
--- a/cmd/geth/js_test.go
+++ b/cmd/geth/js_test.go
@@ -92,7 +92,7 @@ func testREPL(t *testing.T, config func(*eth.Config)) (string, *testjethre, *eth
 
 	db, _ := ethdb.NewMemDatabase()
 
-	core.WriteGenesisBlockForTesting(db, common.HexToAddress(testAddress), common.String2Big(testBalance))
+	core.WriteGenesisBlockForTesting(db, core.GenesisAccount{common.HexToAddress(testAddress), common.String2Big(testBalance)})
 	ks := crypto.NewKeyStorePlain(filepath.Join(tmp, "keystore"))
 	am := accounts.NewManager(ks)
 	conf := &eth.Config{

--- a/common/natspec/natspec_e2e_test.go
+++ b/common/natspec/natspec_e2e_test.go
@@ -134,7 +134,7 @@ func testEth(t *testing.T) (ethereum *eth.Ethereum, err error) {
 
 	db, _ := ethdb.NewMemDatabase()
 	// set up mock genesis with balance on the testAddress
-	core.WriteGenesisBlockForTesting(db, common.HexToAddress(testAddress), common.String2Big(testBalance))
+	core.WriteGenesisBlockForTesting(db, core.GenesisAccount{common.HexToAddress(testAddress), common.String2Big(testBalance)})
 
 	// only use minimalistic stack with no networking
 	ethereum, err = eth.New(&eth.Config{

--- a/core/bench_test.go
+++ b/core/bench_test.go
@@ -162,7 +162,7 @@ func benchInsertChain(b *testing.B, disk bool, gen func(int, *BlockGen)) {
 
 	// Generate a chain of b.N blocks using the supplied block
 	// generator function.
-	genesis := WriteGenesisBlockForTesting(db, benchRootAddr, benchRootFunds)
+	genesis := WriteGenesisBlockForTesting(db, GenesisAccount{benchRootAddr, benchRootFunds})
 	chain := GenerateChain(genesis, db, b.N, gen)
 
 	// Time the insertion of the new chain.

--- a/core/chain_makers_test.go
+++ b/core/chain_makers_test.go
@@ -42,7 +42,7 @@ func ExampleGenerateChain() {
 	)
 
 	// Ensure that key1 has some funds in the genesis block.
-	genesis := WriteGenesisBlockForTesting(db, addr1, big.NewInt(1000000))
+	genesis := WriteGenesisBlockForTesting(db, GenesisAccount{addr1, big.NewInt(1000000)})
 
 	// This call generates a chain of 5 blocks. The function runs for
 	// each block and adds different features to gen based on the

--- a/core/events.go
+++ b/core/events.go
@@ -36,6 +36,9 @@ type NewBlockEvent struct{ Block *types.Block }
 // NewMinedBlockEvent is posted when a block has been imported.
 type NewMinedBlockEvent struct{ Block *types.Block }
 
+// RemovedTransactionEvent is posted when a reorg happens
+type RemovedTransactionEvent struct{ Txs types.Transactions }
+
 // ChainSplit is posted when a new head is detected
 type ChainSplitEvent struct {
 	Block *types.Block

--- a/core/genesis.go
+++ b/core/genesis.go
@@ -125,15 +125,27 @@ func GenesisBlockForTesting(db ethdb.Database, addr common.Address, balance *big
 	return block
 }
 
-func WriteGenesisBlockForTesting(db ethdb.Database, addr common.Address, balance *big.Int) *types.Block {
+type GenesisAccount struct {
+	Address common.Address
+	Balance *big.Int
+}
+
+func WriteGenesisBlockForTesting(db ethdb.Database, accounts ...GenesisAccount) *types.Block {
+	accountJson := "{"
+	for i, account := range accounts {
+		if i != 0 {
+			accountJson += ","
+		}
+		accountJson += fmt.Sprintf(`"0x%x":{"balance":"0x%x"}`, account.Address, account.Balance.Bytes())
+	}
+	accountJson += "}"
+
 	testGenesis := fmt.Sprintf(`{
 	"nonce":"0x%x",
 	"gasLimit":"0x%x",
 	"difficulty":"0x%x",
-	"alloc": {
-		"0x%x":{"balance":"0x%x"}
-	}
-}`, types.EncodeNonce(0), params.GenesisGasLimit.Bytes(), params.GenesisDifficulty.Bytes(), addr, balance.Bytes())
+	"alloc": %s
+}`, types.EncodeNonce(0), params.GenesisGasLimit.Bytes(), params.GenesisDifficulty.Bytes(), accountJson)
 	block, _ := WriteGenesisBlock(db, strings.NewReader(testGenesis))
 	return block
 }

--- a/core/transaction_pool_test.go
+++ b/core/transaction_pool_test.go
@@ -238,3 +238,15 @@ func TestNonceRecovery(t *testing.T) {
 		t.Errorf("expected nonce to be %d, got %d", n+1, fn)
 	}
 }
+
+func TestRemovedTxEvent(t *testing.T) {
+	pool, key := setupTxPool()
+	tx := transaction(0, big.NewInt(1000000), key)
+	from, _ := tx.From()
+	pool.currentState().AddBalance(from, big.NewInt(1000000000000))
+	pool.eventMux.Post(RemovedTransactionEvent{types.Transactions{tx}})
+	pool.eventMux.Post(ChainHeadEvent{nil})
+	if len(pool.pending) != 1 {
+		t.Error("expected 1 pending tx, got", len(pool.pending))
+	}
+}

--- a/core/transaction_util.go
+++ b/core/transaction_util.go
@@ -77,6 +77,22 @@ func PutTransactions(db ethdb.Database, block *types.Block, txs types.Transactio
 	}
 }
 
+func DeleteTransaction(db ethdb.Database, txHash common.Hash) {
+	db.Delete(txHash[:])
+}
+
+func GetTransaction(db ethdb.Database, txhash common.Hash) *types.Transaction {
+	data, _ := db.Get(txhash[:])
+	if len(data) != 0 {
+		var tx types.Transaction
+		if err := rlp.DecodeBytes(data, &tx); err != nil {
+			return nil
+		}
+		return &tx
+	}
+	return nil
+}
+
 // PutReceipts stores the receipts in the current database
 func PutReceipts(db ethdb.Database, receipts types.Receipts) error {
 	batch := new(leveldb.Batch)
@@ -105,6 +121,11 @@ func PutReceipts(db ethdb.Database, receipts types.Receipts) error {
 	}
 
 	return nil
+}
+
+// Delete a receipts from the database
+func DeleteReceipt(db ethdb.Database, txHash common.Hash) {
+	db.Delete(append(receiptsPre, txHash[:]...))
 }
 
 // GetReceipt returns a receipt by hash

--- a/core/types/transaction.go
+++ b/core/types/transaction.go
@@ -272,12 +272,34 @@ func (tx *Transaction) String() string {
 // Transaction slice type for basic sorting.
 type Transactions []*Transaction
 
-func (s Transactions) Len() int      { return len(s) }
+// Len returns the length of s
+func (s Transactions) Len() int { return len(s) }
+
+// Swap swaps the i'th and the j'th element in s
 func (s Transactions) Swap(i, j int) { s[i], s[j] = s[j], s[i] }
 
+// GetRlp implements Rlpable and returns the i'th element of s in rlp
 func (s Transactions) GetRlp(i int) []byte {
 	enc, _ := rlp.EncodeToBytes(s[i])
 	return enc
+}
+
+// Returns a new set t which is the difference between a to b
+func TxDifference(a, b Transactions) (keep Transactions) {
+	keep = make(Transactions, 0, len(a))
+
+	remove := make(map[common.Hash]struct{})
+	for _, tx := range b {
+		remove[tx.Hash()] = struct{}{}
+	}
+
+	for _, tx := range a {
+		if _, ok := remove[tx.Hash()]; !ok {
+			keep = append(keep, tx)
+		}
+	}
+
+	return keep
 }
 
 type TxByNonce struct{ Transactions }

--- a/eth/helper_test.go
+++ b/eth/helper_test.go
@@ -33,7 +33,7 @@ func newTestProtocolManager(blocks int, generator func(int, *core.BlockGen), new
 		evmux       = new(event.TypeMux)
 		pow         = new(core.FakePow)
 		db, _       = ethdb.NewMemDatabase()
-		genesis     = core.WriteGenesisBlockForTesting(db, testBankAddress, testBankFunds)
+		genesis     = core.WriteGenesisBlockForTesting(db, core.GenesisAccount{testBankAddress, testBankFunds})
 		chainman, _ = core.NewChainManager(db, pow, evmux)
 		blockproc   = core.NewBlockProcessor(db, pow, chainman, evmux)
 	)


### PR DESCRIPTION
This PR addresses functionality to the `ChainManager` so that missing transaction that may occur during chain forks get inserted back in to the `TransactionPool`. It calculated the difference between old and new chain and picks out transactions that never ended up in the new chain.

**NOTE: For reference, this PR seen quite some iterations. The following text is OLD**

***

Added an new transaction type used by the transaction pool `poolTx`.
This struct hold information about the transaction state:

* amount of post tries
* added timestamp
* last post timestamp

Whenever a transaction is being submitted by the user the transaction is
flagged as owned. When an owned transaction sits in the pool for too
long (39 seconds) it will be posted again.

A future PR could check the amount of post tries and will post back a
failure event. An failure event could potentially be posted back to a
frontend connected to the `geth` instance and deletes from the pool. A
frontend could ask the user for a higher gas price or some other action.

***

This PR also adds back any potential missing transactions during chain reorganisations and adds functionality to `types.Transactions` to split of `Difference`s between two slices of `Transaction`s. 

Closes #1668 