### PR TITLE
core: don't process blocks if they're already present in the database

### DIFF
--- a/common/db.go
+++ b/common/db.go
@@ -20,6 +20,7 @@ package common
 type Database interface {
 	Put(key []byte, value []byte) error
 	Get(key []byte) ([]byte, error)
+	Has(key []byte) bool
 	Delete(key []byte) error
 	Close()
 	Flush() error

--- a/core/chain_manager.go
+++ b/core/chain_manager.go
@@ -364,9 +364,7 @@ func (bc *ChainManager) HasBlock(hash common.Hash) bool {
 	if bc.cache.Contains(hash) {
 		return true
 	}
-
-	data, _ := bc.chainDb.Get(append(blockHashPre, hash[:]...))
-	return len(data) != 0
+	return bc.chainDb.Has(append(blockHashPre, hash[:]...))
 }
 
 func (self *ChainManager) GetBlockHashesFromHash(hash common.Hash, max uint64) (chain []common.Hash) {
@@ -559,6 +557,10 @@ func (self *ChainManager) InsertChain(chain types.Blocks) (int, error) {
 		if atomic.LoadInt32(&self.procInterrupt) == 1 {
 			glog.V(logger.Debug).Infoln("Premature abort during chain processing")
 			break
+		}
+		if self.HasBlock(block.Hash()) {
+			stats.ignored++
+			continue
 		}
 
 		bstart := time.Now()

--- a/ethdb/database.go
+++ b/ethdb/database.go
@@ -138,6 +138,11 @@ func (self *LDBDatabase) Delete(key []byte) error {
 	return self.db.Delete(key, nil)
 }
 
+func (self *LDBDatabase) Has(key []byte) bool {
+	b, _ := self.db.Has(key, nil)
+	return b
+}
+
 func (self *LDBDatabase) NewIterator() iterator.Iterator {
 	return self.db.NewIterator(nil, nil)
 }

--- a/ethdb/memory_database.go
+++ b/ethdb/memory_database.go
@@ -57,6 +57,11 @@ func (db *MemDatabase) GetKeys() []*common.Key {
 }
 */
 
+func (db *MemDatabase) Has(key []byte) bool {
+	_, ok := db.db[string(key)]
+	return ok
+}
+
 func (db *MemDatabase) Delete(key []byte) error {
 	delete(db.db, string(key))
 


### PR DESCRIPTION
Blocks usually arrive multiple times as they are from different peers.
`ChainManager` imported them each time.