### PR TITLE
core, miner: write miner receipts

### DIFF
--- a/core/block_processor.go
+++ b/core/block_processor.go
@@ -349,11 +349,9 @@ func (sm *BlockProcessor) GetBlockReceipts(bhash common.Hash) types.Receipts {
 // the depricated way by re-processing the block.
 func (sm *BlockProcessor) GetLogs(block *types.Block) (logs state.Logs, err error) {
 	receipts := GetBlockReceipts(sm.chainDb, block.Hash())
-	if len(receipts) > 0 {
-		// coalesce logs
-		for _, receipt := range receipts {
-			logs = append(logs, receipt.Logs()...)
-		}
+	// coalesce logs
+	for _, receipt := range receipts {
+		logs = append(logs, receipt.Logs()...)
 	}
 	return logs, nil
 }

--- a/core/chain_manager.go
+++ b/core/chain_manager.go
@@ -647,7 +647,9 @@ func (self *ChainManager) InsertChain(chain types.Blocks) (int, error) {
 			queue[i] = ChainSplitEvent{block, logs}
 			queueEvent.splitCount++
 		}
-		PutBlockReceipts(self.chainDb, block, receipts)
+		if err := PutBlockReceipts(self.chainDb, block, receipts); err != nil {
+			glog.V(logger.Warn).Infoln("error writing block receipts:", err)
+		}
 
 		stats.processed++
 	}

--- a/core/filter.go
+++ b/core/filter.go
@@ -22,6 +22,8 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/state"
 	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/logger"
+	"github.com/ethereum/go-ethereum/logger/glog"
 )
 
 type AccountChange struct {
@@ -111,7 +113,7 @@ done:
 			// Get the logs of the block
 			unfiltered, err := self.eth.BlockProcessor().GetLogs(block)
 			if err != nil {
-				chainlogger.Warnln("err: filter get logs ", err)
+				glog.V(logger.Warn).Infoln("err: filter get logs ", err)
 
 				break
 			}


### PR DESCRIPTION
This PR solves an issue that as a miner `block-receipts` are not generated. Block receipts are required for fetching past logs