### PR TITLE
eth: fix an issue with pulling and inserting blocks twice

### DIFF
--- a/eth/handler.go
+++ b/eth/handler.go
@@ -413,10 +413,12 @@ func (pm *ProtocolManager) handleMsg(p *peer) error {
 
 		pm.fetcher.Enqueue(p.id, request.Block)
 
-		// TODO: Schedule a sync to cover potential gaps (this needs proto update)
+		// Update the peers total difficulty if needed, schedule a download if gapped
 		if request.TD.Cmp(p.Td()) > 0 {
 			p.SetTd(request.TD)
-			go pm.synchronise(p)
+			if request.TD.Cmp(new(big.Int).Add(pm.chainman.Td(), request.Block.Difficulty())) > 0 {
+				go pm.synchronise(p)
+			}
 		}
 
 	case TxMsg:


### PR DESCRIPTION
In a very old release of the downloader we used timers to detect peers having updated chains. Then I killed off the timer since it introduced weird lags and instead added a hack so that whenever we receive a block from a peer, we check if the peers's TD is high enough for a sync. The issue was that checking the peer's TD against ours (inside `synchronize`), happened earlier that we actually imported the new block, so the downloader tried to fetch it too (and succeeded, then the block import got ignored). This PR should properly fix this by checking that there's actually a missing block or if we're up to date (less the block just propagated).