### PR TITLE
user agent messages were dumped in some cases

### DIFF
--- a/rpc/comms/ipc.go
+++ b/rpc/comms/ipc.go
@@ -42,16 +42,12 @@ func (self *ipcClient) Close() {
 	self.coder.Close()
 }
 
-func (self *ipcClient) Send(req interface{}) error {
+func (self *ipcClient) Send(msg interface{}) error {
 	var err error
-	if r, ok := req.(*shared.Request); ok {
-		if err = self.coder.WriteResponse(r); err != nil {
-			if err = self.reconnect(); err == nil {
-				err = self.coder.WriteResponse(r)
-			}
+	if err = self.coder.WriteResponse(msg); err != nil {
+		if err = self.reconnect(); err == nil {
+			err = self.coder.WriteResponse(msg)
 		}
-
-		return err
 	}
 	return err
 }

--- a/rpc/jeth.go
+++ b/rpc/jeth.go
@@ -40,16 +40,6 @@ type Jeth struct {
 }
 
 func NewJeth(ethApi shared.EthereumApi, re *jsre.JSRE, client comms.EthereumClient, fe xeth.Frontend) *Jeth {
-	// enable the jeth as the user agent
-	req := shared.Request{
-		Id:      0,
-		Method:  useragent.EnableUserAgentMethod,
-		Jsonrpc: shared.JsonRpcVersion,
-		Params:  []byte("[]"),
-	}
-	client.Send(&req)
-	client.Recv()
-
 	return &Jeth{ethApi, re, client, fe}
 }
 


### PR DESCRIPTION
Due to a missing commit the console didn't handle user agents reponses in the correct way. This causes the console to block until a timeout occurs. This PR will send the user agent response to geth and doesn't block the console.

This fixes #1700