### PR TITLE
Improved console error handling

### DIFF
--- a/rpc/jeth.go
+++ b/rpc/jeth.go
@@ -44,11 +44,12 @@ func NewJeth(ethApi shared.EthereumApi, re *jsre.JSRE, client comms.EthereumClie
 }
 
 func (self *Jeth) err(call otto.FunctionCall, code int, msg string, id interface{}) (response otto.Value) {
-	errObj := fmt.Sprintf("{\"message\": \"%s\", \"code\": %d}", msg, code)
-	retResponse := fmt.Sprintf("ret_response = JSON.parse('{\"jsonrpc\": \"%s\", \"id\": %v, \"error\": %s}');", shared.JsonRpcVersion, id, errObj)
+	m := shared.NewRpcErrorResponse(id, shared.JsonRpcVersion, code, fmt.Errorf(msg))
+	errObj, _ := json.Marshal(m.Error)
+	errRes, _ := json.Marshal(m)
 
-	call.Otto.Run("ret_error = " + errObj)
-	res, _ := call.Otto.Run(retResponse)
+	call.Otto.Run("ret_error = " + string(errObj))
+	res, _ := call.Otto.Run("ret_response = " + string(errRes))
 
 	return res
 }

--- a/rpc/shared/types.go
+++ b/rpc/shared/types.go
@@ -74,11 +74,9 @@ type ErrorObject struct {
 }
 
 // Create RPC error response, this allows for custom error codes
-func NewRpcErrorResponse(id interface{}, jsonrpcver string, errCode int, err error) *interface{} {
-	var response interface{}
-
+func NewRpcErrorResponse(id interface{}, jsonrpcver string, errCode int, err error) *ErrorResponse {
 	jsonerr := &ErrorObject{errCode, err.Error()}
-	response = ErrorResponse{Jsonrpc: jsonrpcver, Id: id, Error: jsonerr}
+	response := ErrorResponse{Jsonrpc: jsonrpcver, Id: id, Error: jsonerr}
 
 	glog.V(logger.Detail).Infof("Generated error response: %s", response)
 	return &response


### PR DESCRIPTION
This PR changes the `JSON.parse` for the go json package when serializing error responses in the console. The `JSON.parse` method expects input to be escaped which is not always the case. The json package can make the correct conversion when needed. This will fixed issues when the error message contains newline characters.