### PR TITLE
Remove personal.deleteAccount from RPC interface

### DIFF
--- a/rpc/api/personal.go
+++ b/rpc/api/personal.go
@@ -36,7 +36,6 @@ var (
 	personalMapping = map[string]personalhandler{
 		"personal_listAccounts":  (*personalApi).ListAccounts,
 		"personal_newAccount":    (*personalApi).NewAccount,
-		"personal_deleteAccount": (*personalApi).DeleteAccount,
 		"personal_unlockAccount": (*personalApi).UnlockAccount,
 	}
 )
@@ -103,21 +102,6 @@ func (self *personalApi) NewAccount(req *shared.Request) (interface{}, error) {
 	am := self.ethereum.AccountManager()
 	acc, err := am.NewAccount(args.Passphrase)
 	return acc.Address.Hex(), err
-}
-
-func (self *personalApi) DeleteAccount(req *shared.Request) (interface{}, error) {
-	args := new(DeleteAccountArgs)
-	if err := self.codec.Decode(req.Params, &args); err != nil {
-		return nil, shared.NewDecodeParamError(err.Error())
-	}
-
-	addr := common.HexToAddress(args.Address)
-	am := self.ethereum.AccountManager()
-	if err := am.DeleteAccount(addr, args.Passphrase); err == nil {
-		return true, nil
-	} else {
-		return false, err
-	}
 }
 
 func (self *personalApi) UnlockAccount(req *shared.Request) (interface{}, error) {

--- a/rpc/api/personal_args.go
+++ b/rpc/api/personal_args.go
@@ -44,36 +44,6 @@ func (args *NewAccountArgs) UnmarshalJSON(b []byte) (err error) {
 	return shared.NewInvalidTypeError("passhrase", "not a string")
 }
 
-type DeleteAccountArgs struct {
-	Address    string
-	Passphrase string
-}
-
-func (args *DeleteAccountArgs) UnmarshalJSON(b []byte) (err error) {
-	var obj []interface{}
-	if err := json.Unmarshal(b, &obj); err != nil {
-		return shared.NewDecodeParamError(err.Error())
-	}
-
-	if len(obj) < 2 {
-		return shared.NewInsufficientParamsError(len(obj), 2)
-	}
-
-	if addr, ok := obj[0].(string); ok {
-		args.Address = addr
-	} else {
-		return shared.NewInvalidTypeError("address", "not a string")
-	}
-
-	if passhrase, ok := obj[1].(string); ok {
-		args.Passphrase = passhrase
-	} else {
-		return shared.NewInvalidTypeError("passhrase", "not a string")
-	}
-
-	return nil
-}
-
 type UnlockAccountArgs struct {
 	Address    string
 	Passphrase string

--- a/rpc/api/utils.go
+++ b/rpc/api/utils.go
@@ -118,7 +118,6 @@ var (
 		"personal": []string{
 			"listAccounts",
 			"newAccount",
-			"deleteAccount",
 			"unlockAccount",
 		},
 		"shh": []string{


### PR DESCRIPTION
This function should not be offered over the RPC interface.
This PR removes all references to this function.