### PR TITLE
Fix warning on go 1.5

### DIFF
--- a/build/ldflags.sh
+++ b/build/ldflags.sh
@@ -9,5 +9,5 @@ fi
 
 # set gitCommit when running from a Git checkout.
 if [ -f ".git/HEAD" ]; then
-    echo "-ldflags '-X main.gitCommit $(git rev-parse HEAD)'"
+    echo "-ldflags '-X main.gitCommit=$(git rev-parse HEAD)'"
 fi


### PR DESCRIPTION
link: warning: option -X main.gitCommit 6ec13e7e2bab1ebdb580819a48629055bbbb5fb3 may not work in future releases; use -X main.gitCommit=6ec13e7e2bab1ebdb580819a48629055bbbb5fb3