### PR TITLE
build: avoid -X separator warning with Go >= 1.5

### DIFF
--- a/build/ldflags.sh
+++ b/build/ldflags.sh
@@ -7,7 +7,12 @@ if [ ! -f "build/env.sh" ]; then
     exit 2
 fi
 
+# Since Go 1.5, the separator char for link time assignments
+# is '=' and using ' ' prints a warning. However, Go < 1.5 does
+# not support using '='.
+sep=$(go version | awk '{ if ($3 >= "go1.5" || index($3, "devel")) print "="; else print " "; }' -)
+
 # set gitCommit when running from a Git checkout.
 if [ -f ".git/HEAD" ]; then
-    echo "-ldflags '-X main.gitCommit $(git rev-parse HEAD)'"
+    echo "-ldflags '-X main.gitCommit$sep$(git rev-parse HEAD)'"
 fi


### PR DESCRIPTION
Supersedes #1733.