### PR TITLE
eth/63 non-archive fast synchronisation

### DIFF
--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -283,6 +283,7 @@ JavaScript API. See https://github.com/ethereum/go-ethereum/wiki/Javascipt-Conso
 		utils.DataDirFlag,
 		utils.BlockchainVersionFlag,
 		utils.OlympicFlag,
+		utils.EthModeFlag,
 		utils.EthVersionFlag,
 		utils.CacheFlag,
 		utils.JSpathFlag,

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -27,6 +27,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"strconv"
+	"strings"
 
 	"github.com/codegangsta/cli"
 	"github.com/ethereum/ethash"
@@ -138,9 +139,14 @@ var (
 		Name:  "olympic",
 		Usage: "Use olympic style protocol",
 	}
+	EthModeFlag = cli.StringFlag{
+		Name:  "mode",
+		Value: "archive",
+		Usage: "Client mode of operation (archive, full, light)",
+	}
 	EthVersionFlag = cli.IntFlag{
 		Name:  "eth",
-		Value: 62,
+		Value: 63,
 		Usage: "Highest eth protocol to advertise (temporary, dev option)",
 	}
 
@@ -409,12 +415,25 @@ func MakeEthConfig(clientID, version string, ctx *cli.Context) *eth.Config {
 	if err != nil {
 		glog.V(logger.Error).Infoln("WARNING: No etherbase set and no accounts found as default")
 	}
-
+	// Resolve the mode of opeation from the string flag
+	var clientMode eth.Mode
+	switch strings.ToLower(ctx.GlobalString(EthModeFlag.Name)) {
+	case "archive":
+		clientMode = eth.ArchiveMode
+	case "full":
+		clientMode = eth.FullMode
+	case "light":
+		clientMode = eth.LightMode
+	default:
+		glog.Fatalf("Unknown node type requested: %s", ctx.GlobalString(EthModeFlag.Name))
+	}
+	// Assemble the entire eth configuration and return
 	return &eth.Config{
 		Name:                    common.MakeName(clientID, version),
 		DataDir:                 ctx.GlobalString(DataDirFlag.Name),
 		GenesisNonce:            ctx.GlobalInt(GenesisNonceFlag.Name),
 		GenesisFile:             ctx.GlobalString(GenesisFileFlag.Name),
+		Mode:                    clientMode,
 		BlockChainVersion:       ctx.GlobalInt(BlockchainVersionFlag.Name),
 		DatabaseCache:           ctx.GlobalInt(CacheFlag.Name),
 		SkipBcVersionCheck:      false,

--- a/core/chain_manager.go
+++ b/core/chain_manager.go
@@ -48,6 +48,8 @@ var (
 )
 
 const (
+	headerCacheLimit    = 256
+	bodyCacheLimit      = 256
 	blockCacheLimit     = 256
 	maxFutureBlocks     = 256
 	maxTimeFutureBlocks = 30
@@ -71,7 +73,10 @@ type ChainManager struct {
 	lastBlockHash   common.Hash
 	currentGasLimit *big.Int
 
-	cache        *lru.Cache // cache is the LRU caching
+	headerCache  *lru.Cache // Cache for the most recent block headers
+	bodyCache    *lru.Cache // Cache for the most recent block bodies
+	bodyRLPCache *lru.Cache // Cache for the most recent block bodies in RLP encoded format
+	blockCache   *lru.Cache // Cache for the most recent entire blocks
 	futureBlocks *lru.Cache // future blocks are blocks added for later processing
 
 	quit    chan struct{}
@@ -84,13 +89,22 @@ type ChainManager struct {
 }
 
 func NewChainManager(chainDb common.Database, pow pow.PoW, mux *event.TypeMux) (*ChainManager, error) {
-	cache, _ := lru.New(blockCacheLimit)
+	headerCache, _ := lru.New(headerCacheLimit)
+	bodyCache, _ := lru.New(bodyCacheLimit)
+	bodyRLPCache, _ := lru.New(bodyCacheLimit)
+	blockCache, _ := lru.New(blockCacheLimit)
+	futureBlocks, _ := lru.New(maxFutureBlocks)
+
 	bc := &ChainManager{
-		chainDb:  chainDb,
-		eventMux: mux,
-		quit:     make(chan struct{}),
-		cache:    cache,
-		pow:      pow,
+		chainDb:      chainDb,
+		eventMux:     mux,
+		quit:         make(chan struct{}),
+		headerCache:  headerCache,
+		bodyCache:    bodyCache,
+		bodyRLPCache: bodyRLPCache,
+		blockCache:   blockCache,
+		futureBlocks: futureBlocks,
+		pow:          pow,
 	}
 
 	bc.genesisBlock = bc.GetBlockByNumber(0)
@@ -105,11 +119,9 @@ func NewChainManager(chainDb common.Database, pow pow.PoW, mux *event.TypeMux) (
 		}
 		glog.V(logger.Info).Infoln("WARNING: Wrote default ethereum genesis block")
 	}
-
 	if err := bc.setLastState(); err != nil {
 		return nil, err
 	}
-
 	// Check the current state of the block hashes and make sure that we do not have any of the bad blocks in our chain
 	for hash, _ := range BadHashes {
 		if block := bc.GetBlock(hash); block != nil {
@@ -123,14 +135,8 @@ func NewChainManager(chainDb common.Database, pow pow.PoW, mux *event.TypeMux) (
 			glog.V(logger.Error).Infoln("Chain reorg was successfull. Resuming normal operation")
 		}
 	}
-
 	// Take ownership of this particular state
-
-	bc.futureBlocks, _ = lru.New(maxFutureBlocks)
-	bc.makeCache()
-
 	go bc.update()
-
 	return bc, nil
 }
 
@@ -139,13 +145,15 @@ func (bc *ChainManager) SetHead(head *types.Block) {
 	defer bc.mu.Unlock()
 
 	for block := bc.currentBlock; block != nil && block.Hash() != head.Hash(); block = bc.GetBlock(block.ParentHash()) {
-		bc.removeBlock(block)
+		DeleteBlock(bc.chainDb, block.Hash())
 	}
+	bc.headerCache.Purge()
+	bc.bodyCache.Purge()
+	bc.bodyRLPCache.Purge()
+	bc.blockCache.Purge()
+	bc.futureBlocks.Purge()
 
-	bc.cache, _ = lru.New(blockCacheLimit)
 	bc.currentBlock = head
-	bc.makeCache()
-
 	bc.setTotalDifficulty(head.Td)
 	bc.insert(head)
 	bc.setLastState()
@@ -199,11 +207,9 @@ func (bc *ChainManager) recover() bool {
 	if len(data) != 0 {
 		block := bc.GetBlock(common.BytesToHash(data))
 		if block != nil {
-			err := bc.chainDb.Put([]byte("LastBlock"), block.Hash().Bytes())
-			if err != nil {
-				glog.Fatalln("db write err:", err)
+			if err := WriteHead(bc.chainDb, block); err != nil {
+				glog.Fatalf("failed to write database head: %v", err)
 			}
-
 			bc.currentBlock = block
 			bc.lastBlockHash = block.Hash()
 			return true
@@ -213,14 +219,14 @@ func (bc *ChainManager) recover() bool {
 }
 
 func (bc *ChainManager) setLastState() error {
-	data, _ := bc.chainDb.Get([]byte("LastBlock"))
-	if len(data) != 0 {
-		block := bc.GetBlock(common.BytesToHash(data))
+	head := GetHeadHash(bc.chainDb)
+	if head != (common.Hash{}) {
+		block := bc.GetBlock(head)
 		if block != nil {
 			bc.currentBlock = block
 			bc.lastBlockHash = block.Hash()
 		} else {
-			glog.Infof("LastBlock (%x) not found. Recovering...\n", data)
+			glog.Infof("LastBlock (%x) not found. Recovering...\n", head)
 			if bc.recover() {
 				glog.Infof("Recover successful")
 			} else {
@@ -240,63 +246,37 @@ func (bc *ChainManager) setLastState() error {
 	return nil
 }
 
-func (bc *ChainManager) makeCache() {
-	bc.cache, _ = lru.New(blockCacheLimit)
-	// load in last `blockCacheLimit` - 1 blocks. Last block is the current.
-	bc.cache.Add(bc.genesisBlock.Hash(), bc.genesisBlock)
-	for _, block := range bc.GetBlocksFromHash(bc.currentBlock.Hash(), blockCacheLimit) {
-		bc.cache.Add(block.Hash(), block)
-	}
-}
-
+// Reset purges the entire blockchain, restoring it to its genesis state.
 func (bc *ChainManager) Reset() {
+	bc.ResetWithGenesisBlock(bc.genesisBlock)
+}
+
+// ResetWithGenesisBlock purges the entire blockchain, restoring it to the
+// specified genesis state.
+func (bc *ChainManager) ResetWithGenesisBlock(genesis *types.Block) {
 	bc.mu.Lock()
 	defer bc.mu.Unlock()
 
+	// Dump the entire block chain and purge the caches
 	for block := bc.currentBlock; block != nil; block = bc.GetBlock(block.ParentHash()) {
-		bc.removeBlock(block)
+		DeleteBlock(bc.chainDb, block.Hash())
 	}
+	bc.headerCache.Purge()
+	bc.bodyCache.Purge()
+	bc.bodyRLPCache.Purge()
+	bc.blockCache.Purge()
+	bc.futureBlocks.Purge()
 
-	bc.cache, _ = lru.New(blockCacheLimit)
+	// Prepare the genesis block and reinitialize the chain
+	bc.genesisBlock = genesis
+	bc.genesisBlock.Td = genesis.Difficulty()
 
-	// Prepare the genesis block
-	err := WriteBlock(bc.chainDb, bc.genesisBlock)
-	if err != nil {
-		glog.Fatalln("db err:", err)
+	if err := WriteBlock(bc.chainDb, bc.genesisBlock); err != nil {
+		glog.Fatalf("failed to write genesis block: %v", err)
 	}
-
 	bc.insert(bc.genesisBlock)
 	bc.currentBlock = bc.genesisBlock
-	bc.makeCache()
-
-	bc.setTotalDifficulty(common.Big("0"))
-}
-
-func (bc *ChainManager) removeBlock(block *types.Block) {
-	bc.chainDb.Delete(append(blockHashPre, block.Hash().Bytes()...))
-}
-
-func (bc *ChainManager) ResetWithGenesisBlock(gb *types.Block) {
-	bc.mu.Lock()
-	defer bc.mu.Unlock()
-
-	for block := bc.currentBlock; block != nil; block = bc.GetBlock(block.ParentHash()) {
-		bc.removeBlock(block)
-	}
-
-	// Prepare the genesis block
-	gb.Td = gb.Difficulty()
-	bc.genesisBlock = gb
-
-	err := WriteBlock(bc.chainDb, bc.genesisBlock)
-	if err != nil {
-		glog.Fatalln("db err:", err)
-	}
-
-	bc.insert(bc.genesisBlock)
-	bc.currentBlock = bc.genesisBlock
-	bc.makeCache()
-	bc.td = gb.Difficulty()
+	bc.setTotalDifficulty(genesis.Difficulty())
 }
 
 // Export writes the active chain to the given writer.
@@ -359,56 +339,130 @@ func (bc *ChainManager) Genesis() *types.Block {
 	return bc.genesisBlock
 }
 
-// Block fetching methods
+// HasHeader checks if a block header is present in the database or not, caching
+// it if present.
+func (bc *ChainManager) HasHeader(hash common.Hash) bool {
+	return bc.GetHeader(hash) != nil
+}
+
+// GetHeader retrieves a block header from the database by hash, caching it if
+// found.
+func (self *ChainManager) GetHeader(hash common.Hash) *types.Header {
+	// Short circuit if the header's already in the cache, retrieve otherwise
+	if header, ok := self.headerCache.Get(hash); ok {
+		return header.(*types.Header)
+	}
+	header := GetHeaderByHash(self.chainDb, hash)
+	if header == nil {
+		return nil
+	}
+	// Cache the found header for next time and return
+	self.headerCache.Add(header.Hash(), header)
+	return header
+}
+
+// GetHeaderByNumber retrieves a block header from the database by number,
+// caching it (associated with its hash) if found.
+func (self *ChainManager) GetHeaderByNumber(number uint64) *types.Header {
+	hash := GetHashByNumber(self.chainDb, number)
+	if hash == (common.Hash{}) {
+		return nil
+	}
+	return self.GetHeader(hash)
+}
+
+// GetBody retrieves a block body (transactions, uncles and total difficulty)
+// from the database by hash, caching it if found. The resion for the peculiar
+// pointer-to-slice return type is to differentiate between empty and inexistent
+// bodies.
+func (self *ChainManager) GetBody(hash common.Hash) (*[]*types.Transaction, *[]*types.Header) {
+	// Short circuit if the body's already in the cache, retrieve otherwise
+	if cached, ok := self.bodyCache.Get(hash); ok {
+		body := cached.(*storageBody)
+		return &body.Transactions, &body.Uncles
+	}
+	transactions, uncles, td := GetBodyByHash(self.chainDb, hash)
+	if td == nil {
+		return nil, nil
+	}
+	// Cache the found body for next time and return
+	self.bodyCache.Add(hash, &storageBody{
+		Transactions: transactions,
+		Uncles:       uncles,
+	})
+	return &transactions, &uncles
+}
+
+// GetBodyRLP retrieves a block body in RLP encoding from the database by hash,
+// caching it if found.
+func (self *ChainManager) GetBodyRLP(hash common.Hash) []byte {
+	// Short circuit if the body's already in the cache, retrieve otherwise
+	if cached, ok := self.bodyRLPCache.Get(hash); ok {
+		return cached.([]byte)
+	}
+	body, td := GetBodyRLPByHash(self.chainDb, hash)
+	if td == nil {
+		return nil
+	}
+	// Cache the found body for next time and return
+	self.bodyRLPCache.Add(hash, body)
+	return body
+}
+
+// HasBlock checks if a block is fully present in the database or not, caching
+// it if present.
 func (bc *ChainManager) HasBlock(hash common.Hash) bool {
 	return bc.GetBlock(hash) != nil
 }
 
-func (self *ChainManager) GetBlockHashesFromHash(hash common.Hash, max uint64) (chain []common.Hash) {
-	block := self.GetBlock(hash)
-	if block == nil {
-		return
-	}
-	// XXX Could be optimised by using a different database which only holds hashes (i.e., linked list)
-	for i := uint64(0); i < max; i++ {
-		block = self.GetBlock(block.ParentHash())
-		if block == nil {
-			break
-		}
-
-		chain = append(chain, block.Hash())
-		if block.Number().Cmp(common.Big0) <= 0 {
-			break
-		}
-	}
-
-	return
-}
-
+// GetBlock retrieves a block from the database by hash, caching it if found.
 func (self *ChainManager) GetBlock(hash common.Hash) *types.Block {
-	if block, ok := self.cache.Get(hash); ok {
+	// Short circuit if the block's already in the cache, retrieve otherwise
+	if block, ok := self.blockCache.Get(hash); ok {
 		return block.(*types.Block)
 	}
-
 	block := GetBlockByHash(self.chainDb, hash)
 	if block == nil {
 		return nil
 	}
-
-	// Add the block to the cache
-	self.cache.Add(hash, (*types.Block)(block))
-
-	return (*types.Block)(block)
+	// Cache the found block for next time and return
+	self.blockCache.Add(block.Hash(), block)
+	return block
 }
 
-func (self *ChainManager) GetBlockByNumber(num uint64) *types.Block {
-	self.mu.RLock()
-	defer self.mu.RUnlock()
-
-	return self.getBlockByNumber(num)
-
+// GetBlockByNumber retrieves a block from the database by number, caching it
+// (associated with its hash) if found.
+func (self *ChainManager) GetBlockByNumber(number uint64) *types.Block {
+	hash := GetHashByNumber(self.chainDb, number)
+	if hash == (common.Hash{}) {
+		return nil
+	}
+	return self.GetBlock(hash)
 }
 
+// GetBlockHashesFromHash retrieves a number of block hashes starting at a given
+// hash, fetching towards the genesis block.
+func (self *ChainManager) GetBlockHashesFromHash(hash common.Hash, max uint64) []common.Hash {
+	// Get the origin header from which to fetch
+	header := self.GetHeader(hash)
+	if header == nil {
+		return nil
+	}
+	// Iterate the headers until enough is collected or the genesis reached
+	chain := make([]common.Hash, 0, max)
+	for i := uint64(0); i < max; i++ {
+		if header = self.GetHeader(header.ParentHash); header == nil {
+			break
+		}
+		chain = append(chain, header.Hash())
+		if header.Number.Cmp(common.Big0) <= 0 {
+			break
+		}
+	}
+	return chain
+}
+
+// [deprecated by eth/62]
 // GetBlocksFromHash returns the block corresponding to hash and up to n-1 ancestors.
 func (self *ChainManager) GetBlocksFromHash(hash common.Hash, n int) (blocks []*types.Block) {
 	for i := 0; i < n; i++ {
@@ -420,11 +474,6 @@ func (self *ChainManager) GetBlocksFromHash(hash common.Hash, n int) (blocks []*
 		hash = block.ParentHash()
 	}
 	return
-}
-
-// non blocking version
-func (self *ChainManager) getBlockByNumber(num uint64) *types.Block {
-	return GetBlockByNumber(self.chainDb, num)
 }
 
 func (self *ChainManager) GetUnclesInChain(block *types.Block, length int) (uncles []*types.Header) {

--- a/core/chain_manager.go
+++ b/core/chain_manager.go
@@ -361,12 +361,7 @@ func (bc *ChainManager) Genesis() *types.Block {
 
 // Block fetching methods
 func (bc *ChainManager) HasBlock(hash common.Hash) bool {
-	if bc.cache.Contains(hash) {
-		return true
-	}
-
-	data, _ := bc.chainDb.Get(append(blockHashPre, hash[:]...))
-	return len(data) != 0
+	return bc.GetBlock(hash) != nil
 }
 
 func (self *ChainManager) GetBlockHashesFromHash(hash common.Hash, max uint64) (chain []common.Hash) {

--- a/core/chain_manager_test.go
+++ b/core/chain_manager_test.go
@@ -388,7 +388,10 @@ func makeChainWithDiff(genesis *types.Block, d []int, seed byte) []*types.Block 
 func chm(genesis *types.Block, db common.Database) *ChainManager {
 	var eventMux event.TypeMux
 	bc := &ChainManager{chainDb: db, genesisBlock: genesis, eventMux: &eventMux, pow: FakePow{}}
-	bc.cache, _ = lru.New(100)
+	bc.headerCache, _ = lru.New(100)
+	bc.bodyCache, _ = lru.New(100)
+	bc.bodyRLPCache, _ = lru.New(100)
+	bc.blockCache, _ = lru.New(100)
 	bc.futureBlocks, _ = lru.New(100)
 	bc.processor = bproc{}
 	bc.ResetWithGenesisBlock(genesis)

--- a/core/chain_util.go
+++ b/core/chain_util.go
@@ -19,7 +19,6 @@ package core
 import (
 	"bytes"
 	"math/big"
-	"time"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
@@ -30,9 +29,12 @@ import (
 )
 
 var (
-	blockHashPre  = []byte("block-hash-")
+	headerHashPre = []byte("header-hash-")
+	bodyHashPre   = []byte("body-hash-")
 	blockNumPre   = []byte("block-num-")
 	ExpDiffPeriod = big.NewInt(100000)
+
+	blockHashPre = []byte("block-hash-") // [deprecated by eth/63]
 )
 
 // CalcDifficulty is the difficulty adjustment algorithm. It returns
@@ -112,27 +114,91 @@ func CalcGasLimit(parent *types.Block) *big.Int {
 	return gl
 }
 
-// GetBlockByHash returns the block corresponding to the hash or nil if not found
-func GetBlockByHash(db common.Database, hash common.Hash) *types.Block {
-	data, _ := db.Get(append(blockHashPre, hash[:]...))
+// storageBody is the block body encoding used for the database.
+type storageBody struct {
+	Transactions []*types.Transaction
+	Uncles       []*types.Header
+}
+
+// GetHeaderRLPByHash retrieves a block header in its raw RLP database encoding,
+// or nil if the header's not found.
+func GetHeaderRLPByHash(db common.Database, hash common.Hash) []byte {
+	data, _ := db.Get(append(headerHashPre, hash[:]...))
+	return data
+}
+
+// GetHeaderByHash retrieves the block header corresponding to the hash, nil if
+// none found.
+func GetHeaderByHash(db common.Database, hash common.Hash) *types.Header {
+	data := GetHeaderRLPByHash(db, hash)
 	if len(data) == 0 {
 		return nil
 	}
-	var block types.StorageBlock
-	if err := rlp.Decode(bytes.NewReader(data), &block); err != nil {
-		glog.V(logger.Error).Infof("invalid block RLP for hash %x: %v", hash, err)
+	header := new(types.Header)
+	if err := rlp.Decode(bytes.NewReader(data), header); err != nil {
+		glog.V(logger.Error).Infof("invalid block header RLP for hash %x: %v", hash, err)
 		return nil
 	}
-	return (*types.Block)(&block)
+	return header
 }
 
-// GetBlockByHash returns the canonical block by number or nil if not found
+// GetBodyRLPByHash retrieves the block body (transactions and uncles) in RLP
+// encoding, and the associated total difficulty.
+func GetBodyRLPByHash(db common.Database, hash common.Hash) ([]byte, *big.Int) {
+	combo, _ := db.Get(append(bodyHashPre, hash[:]...))
+	if len(combo) == 0 {
+		return nil, nil
+	}
+	buffer := bytes.NewBuffer(combo)
+
+	td := new(big.Int)
+	if err := rlp.Decode(buffer, td); err != nil {
+		glog.V(logger.Error).Infof("invalid block td RLP for hash %x: %v", hash, err)
+		return nil, nil
+	}
+	return buffer.Bytes(), td
+}
+
+// GetBodyByHash retrieves the block body (transactons, uncles, total difficulty)
+// corresponding to the hash, nils if none found.
+func GetBodyByHash(db common.Database, hash common.Hash) ([]*types.Transaction, []*types.Header, *big.Int) {
+	data, td := GetBodyRLPByHash(db, hash)
+	if len(data) == 0 || td == nil {
+		return nil, nil, nil
+	}
+	body := new(storageBody)
+	if err := rlp.Decode(bytes.NewReader(data), body); err != nil {
+		glog.V(logger.Error).Infof("invalid block body RLP for hash %x: %v", hash, err)
+		return nil, nil, nil
+	}
+	return body.Transactions, body.Uncles, td
+}
+
+// GetBlockByHash retrieves an entire block corresponding to the hash, assembling
+// it back from the stored header and body.
+func GetBlockByHash(db common.Database, hash common.Hash) *types.Block {
+	// Retrieve the block header and body contents
+	header := GetHeaderByHash(db, hash)
+	if header == nil {
+		return nil
+	}
+	transactions, uncles, td := GetBodyByHash(db, hash)
+	if td == nil {
+		return nil
+	}
+	// Reassemble the block and return
+	block := types.NewBlockWithHeader(header).WithBody(transactions, uncles)
+	block.Td = td
+
+	return block
+}
+
+// GetBlockByNumber returns the canonical block by number or nil if not found.
 func GetBlockByNumber(db common.Database, number uint64) *types.Block {
 	key, _ := db.Get(append(blockNumPre, big.NewInt(int64(number)).Bytes()...))
 	if len(key) == 0 {
 		return nil
 	}
-
 	return GetBlockByHash(db, common.BytesToHash(key))
 }
 
@@ -159,21 +225,67 @@ func WriteHead(db common.Database, block *types.Block) error {
 	return nil
 }
 
-// WriteBlock writes a block to the database
-func WriteBlock(db common.Database, block *types.Block) error {
-	tstart := time.Now()
-
-	enc, _ := rlp.EncodeToBytes((*types.StorageBlock)(block))
-	key := append(blockHashPre, block.Hash().Bytes()...)
-	err := db.Put(key, enc)
+// WriteHeader serializes a block header into the database.
+func WriteHeader(db common.Database, header *types.Header) error {
+	data, err := rlp.EncodeToBytes(header)
 	if err != nil {
-		glog.Fatal("db write fail:", err)
 		return err
 	}
-
-	if glog.V(logger.Debug) {
-		glog.Infof("wrote block #%v %s. Took %v\n", block.Number(), common.PP(block.Hash().Bytes()), time.Since(tstart))
+	key := append(headerHashPre, header.Hash().Bytes()...)
+	if err := db.Put(key, data); err != nil {
+		glog.Fatalf("failed to store header into database: %v", err)
+		return err
 	}
-
+	glog.V(logger.Debug).Infof("stored header #%v [%x…]", header.Number, header.Hash().Bytes()[:4])
 	return nil
+}
+
+// WriteBody serializes the body of a block into the database.
+func WriteBody(db common.Database, block *types.Block) error {
+	body, err := rlp.EncodeToBytes(&storageBody{block.Transactions(), block.Uncles()})
+	if err != nil {
+		return err
+	}
+	td, err := rlp.EncodeToBytes(block.Td)
+	if err != nil {
+		return err
+	}
+	key := append(bodyHashPre, block.Hash().Bytes()...)
+	if err := db.Put(key, append(td, body...)); err != nil {
+		glog.Fatalf("failed to store block body into database: %v", err)
+		return err
+	}
+	glog.V(logger.Debug).Infof("stored block body #%v [%x…]", block.Number, block.Hash().Bytes()[:4])
+	return nil
+}
+
+// WriteBlock serializes a block into the database, header and body separately.
+func WriteBlock(db common.Database, block *types.Block) error {
+	// Store the body first to retain database consistency
+	if err := WriteBody(db, block); err != nil {
+		return err
+	}
+	// Store the header too, signaling full block ownership
+	if err := WriteHeader(db, block.Header()); err != nil {
+		return err
+	}
+	return nil
+}
+
+// [deprecated by eth/63]
+// GetBlockByHashOld returns the old combined block corresponding to the hash
+// or nil if not found. This method is only used by the upgrade mechanism to
+// access the old combined block representation. It will be dropped after the
+// network transitions to eth/63.
+func GetBlockByHashOld(db common.Database, hash common.Hash) *types.Block {
+	data, _ := db.Get(append(blockHashPre, hash[:]...))
+	if len(data) == 0 {
+		return nil
+	}
+	var block types.StorageBlock
+	if err := rlp.Decode(bytes.NewReader(data), &block); err != nil {
+		glog.V(logger.Error).Infof("invalid block RLP for hash %x: %v", hash, err)
+		return nil
+	}
+	return (*types.Block)(&block)
 }

--- a/core/genesis.go
+++ b/core/genesis.go
@@ -86,7 +86,7 @@ func WriteGenesisBlock(chainDb common.Database, reader io.Reader) (*types.Block,
 
 	if block := GetBlockByHash(chainDb, block.Hash()); block != nil {
 		glog.V(logger.Info).Infoln("Genesis block already in chain. Writing canonical number")
-		err := WriteCanonNumber(chainDb, block)
+		err := WriteCanonNumber(chainDb, block.Hash(), block.NumberU64())
 		if err != nil {
 			return nil, err
 		}

--- a/core/types/block.go
+++ b/core/types/block.go
@@ -135,6 +135,7 @@ type Block struct {
 	ReceivedAt time.Time
 }
 
+// [deprecated by eth/63]
 // StorageBlock defines the RLP encoding of a Block stored in the
 // state database. The StorageBlock encoding contains fields that
 // would otherwise need to be recomputed.
@@ -147,6 +148,7 @@ type extblock struct {
 	Uncles []*Header
 }
 
+// [deprecated by eth/63]
 // "storage" block encoding. used for database.
 type storageblock struct {
 	Header *Header
@@ -268,6 +270,7 @@ func (b *Block) EncodeRLP(w io.Writer) error {
 	})
 }
 
+// [deprecated by eth/63]
 func (b *StorageBlock) DecodeRLP(s *rlp.Stream) error {
 	var sb storageblock
 	if err := s.Decode(&sb); err != nil {
@@ -277,6 +280,7 @@ func (b *StorageBlock) DecodeRLP(s *rlp.Stream) error {
 	return nil
 }
 
+// [deprecated by eth/63]
 func (b *StorageBlock) EncodeRLP(w io.Writer) error {
 	return rlp.Encode(w, storageblock{
 		Header: b.header,

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -18,6 +18,7 @@
 package eth
 
 import (
+	"bytes"
 	"crypto/ecdsa"
 	"encoding/json"
 	"fmt"
@@ -267,11 +268,7 @@ func New(config *Config) (*Ethereum, error) {
 		newdb = func(path string) (common.Database, error) { return ethdb.NewLDBDatabase(path, config.DatabaseCache) }
 	}
 
-	// attempt to merge database together, upgrading from an old version
-	if err := mergeDatabases(config.DataDir, newdb); err != nil {
-		return nil, err
-	}
-
+	// Open the chain database and perform any upgrades needed
 	chainDb, err := newdb(filepath.Join(config.DataDir, "chaindata"))
 	if err != nil {
 		return nil, fmt.Errorf("blockchain db err: %v", err)
@@ -279,6 +276,10 @@ func New(config *Config) (*Ethereum, error) {
 	if db, ok := chainDb.(*ethdb.LDBDatabase); ok {
 		db.Meter("eth/db/chaindata/")
 	}
+	if err := upgradeChainDatabase(chainDb); err != nil {
+		return nil, err
+	}
+
 	dappDb, err := newdb(filepath.Join(config.DataDir, "dapp"))
 	if err != nil {
 		return nil, fmt.Errorf("dapp db err: %v", err)
@@ -718,74 +719,55 @@ func saveBlockchainVersion(db common.Database, bcVersion int) {
 	}
 }
 
-// mergeDatabases when required merge old database layout to one single database
-func mergeDatabases(datadir string, newdb func(path string) (common.Database, error)) error {
-	// Check if already upgraded
-	data := filepath.Join(datadir, "chaindata")
-	if _, err := os.Stat(data); !os.IsNotExist(err) {
+// upgradeChainDatabase ensures that the chain database stores block split into
+// separate header and body entries.
+func upgradeChainDatabase(db common.Database) error {
+	// Short circuit if the head block is stored already as separate header and body
+	data, err := db.Get([]byte("LastBlock"))
+	if err != nil {
 		return nil
 	}
-	// make sure it's not just a clean path
-	chainPath := filepath.Join(datadir, "blockchain")
-	if _, err := os.Stat(chainPath); os.IsNotExist(err) {
+	head := common.BytesToHash(data)
+
+	if block := core.GetBlockByHashOld(db, head); block == nil {
 		return nil
 	}
-	glog.Infoln("Database upgrade required. Upgrading...")
+	// At least some of the database is still the old format, upgrade (skip the head block!)
+	glog.V(logger.Info).Info("Old database detected, upgrading...")
 
-	database, err := newdb(data)
-	if err != nil {
-		return fmt.Errorf("creating data db err: %v", err)
-	}
-	defer database.Close()
+	if db, ok := db.(*ethdb.LDBDatabase); ok {
+		blockPrefix := []byte("block-hash-")
+		for it := db.NewIterator(); it.Next(); {
+			// Skip anything other than a combined block
+			if !bytes.HasPrefix(it.Key(), blockPrefix) {
+				continue
+			}
+			// Skip the head block (merge last to signal upgrade completion)
+			if bytes.HasSuffix(it.Key(), head.Bytes()) {
+				continue
+			}
+			// Load the block, split and serialize (order!)
+			block := core.GetBlockByHashOld(db, common.BytesToHash(bytes.TrimPrefix(it.Key(), blockPrefix)))
 
-	// Migrate blocks
-	chainDb, err := newdb(chainPath)
-	if err != nil {
-		return fmt.Errorf("state db err: %v", err)
-	}
-	defer chainDb.Close()
-
-	if chain, ok := chainDb.(*ethdb.LDBDatabase); ok {
-		glog.Infoln("Merging blockchain database...")
-		it := chain.NewIterator()
-		for it.Next() {
-			database.Put(it.Key(), it.Value())
+			if err := core.WriteBody(db, block); err != nil {
+				return err
+			}
+			if err := core.WriteHeader(db, block.Header()); err != nil {
+				return err
+			}
+			if err := db.Delete(it.Key()); err != nil {
+				return err
+			}
 		}
-		it.Release()
-	}
+		// Lastly, upgrade the head block, disabling the upgrade mechanism
+		current := core.GetBlockByHashOld(db, head)
 
-	// Migrate state
-	stateDb, err := newdb(filepath.Join(datadir, "state"))
-	if err != nil {
-		return fmt.Errorf("state db err: %v", err)
-	}
-	defer stateDb.Close()
-
-	if state, ok := stateDb.(*ethdb.LDBDatabase); ok {
-		glog.Infoln("Merging state database...")
-		it := state.NewIterator()
-		for it.Next() {
-			database.Put(it.Key(), it.Value())
+		if err := core.WriteBody(db, current); err != nil {
+			return err
 		}
-		it.Release()
-	}
-
-	// Migrate transaction / receipts
-	extraDb, err := newdb(filepath.Join(datadir, "extra"))
-	if err != nil {
-		return fmt.Errorf("state db err: %v", err)
-	}
-	defer extraDb.Close()
-
-	if extra, ok := extraDb.(*ethdb.LDBDatabase); ok {
-		glog.Infoln("Merging transaction database...")
-
-		it := extra.NewIterator()
-		for it.Next() {
-			database.Put(it.Key(), it.Value())
+		if err := core.WriteHeader(db, current.Header()); err != nil {
+			return err
 		}
-		it.Release()
 	}
-
 	return nil
 }

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -80,6 +80,7 @@ type Config struct {
 	GenesisFile  string
 	GenesisBlock *types.Block // used by block tests
 	Olympic      bool
+	Mode         Mode
 
 	BlockChainVersion  int
 	SkipBcVersionCheck bool // e.g. blockchain export
@@ -374,8 +375,10 @@ func New(config *Config) (*Ethereum, error) {
 
 	eth.blockProcessor = core.NewBlockProcessor(chainDb, eth.pow, eth.chainManager, eth.EventMux())
 	eth.chainManager.SetProcessor(eth.blockProcessor)
-	eth.protocolManager = NewProtocolManager(config.NetworkId, eth.eventMux, eth.txPool, eth.pow, eth.chainManager, chainDb)
-
+	eth.protocolManager, err = NewProtocolManager(config.Mode, config.NetworkId, eth.eventMux, eth.txPool, eth.pow, eth.chainManager, chainDb)
+	if err != nil {
+		return nil, err
+	}
 	eth.miner = miner.New(eth, eth.EventMux(), eth.pow)
 	eth.miner.SetGasPrice(config.GasPrice)
 	eth.miner.SetExtra(config.ExtraData)

--- a/eth/handler_test.go
+++ b/eth/handler_test.go
@@ -17,12 +17,42 @@ import (
 	"github.com/ethereum/go-ethereum/params"
 )
 
+// Tests that protocol versions and modes of operations are matched up properly.
+func TestProtocolCompatibility(t *testing.T) {
+	// Define the compatibility chart
+	tests := []struct {
+		version    uint
+		mode       Mode
+		compatible bool
+	}{
+		{61, ArchiveMode, true}, {62, ArchiveMode, true}, {63, ArchiveMode, true}, {64, ArchiveMode, true},
+		{61, FullMode, false}, {62, FullMode, false}, {63, FullMode, true}, {64, FullMode, true},
+		{61, LightMode, false}, {62, LightMode, false}, {63, LightMode, false}, {64, LightMode, true},
+	}
+	// Make sure anything we screw up is restored
+	backup := ProtocolVersions
+	defer func() { ProtocolVersions = backup }()
+
+	// Try all available compatibility configs and check for errors
+	for i, tt := range tests {
+		ProtocolVersions = []uint{tt.version}
+
+		pm, err := newTestProtocolManager(tt.mode, 0, nil, nil)
+		if pm != nil {
+			defer pm.Stop()
+		}
+		if (err == nil && !tt.compatible) || (err != nil && tt.compatible) {
+			t.Errorf("test %d: compatibility mismatch: have error %v, want compatibility %v", i, err, tt.compatible)
+		}
+	}
+}
+
 // Tests that hashes can be retrieved from a remote chain by hashes in reverse
 // order.
 func TestGetBlockHashes61(t *testing.T) { testGetBlockHashes(t, 61) }
 
 func testGetBlockHashes(t *testing.T, protocol int) {
-	pm := newTestProtocolManager(downloader.MaxHashFetch+15, nil, nil)
+	pm := newTestProtocolManagerMust(t, ArchiveMode, downloader.MaxHashFetch+15, nil, nil)
 	peer, _ := newTestPeer("peer", protocol, pm, true)
 	defer peer.close()
 
@@ -65,7 +95,7 @@ func testGetBlockHashes(t *testing.T, protocol int) {
 func TestGetBlockHashesFromNumber61(t *testing.T) { testGetBlockHashesFromNumber(t, 61) }
 
 func testGetBlockHashesFromNumber(t *testing.T, protocol int) {
-	pm := newTestProtocolManager(downloader.MaxHashFetch+15, nil, nil)
+	pm := newTestProtocolManagerMust(t, ArchiveMode, downloader.MaxHashFetch+15, nil, nil)
 	peer, _ := newTestPeer("peer", protocol, pm, true)
 	defer peer.close()
 
@@ -105,7 +135,7 @@ func testGetBlockHashesFromNumber(t *testing.T, protocol int) {
 func TestGetBlocks61(t *testing.T) { testGetBlocks(t, 61) }
 
 func testGetBlocks(t *testing.T, protocol int) {
-	pm := newTestProtocolManager(downloader.MaxHashFetch+15, nil, nil)
+	pm := newTestProtocolManagerMust(t, ArchiveMode, downloader.MaxHashFetch+15, nil, nil)
 	peer, _ := newTestPeer("peer", protocol, pm, true)
 	defer peer.close()
 
@@ -177,7 +207,7 @@ func TestGetBlockHeaders63(t *testing.T) { testGetBlockHeaders(t, 63) }
 func TestGetBlockHeaders64(t *testing.T) { testGetBlockHeaders(t, 64) }
 
 func testGetBlockHeaders(t *testing.T, protocol int) {
-	pm := newTestProtocolManager(downloader.MaxHashFetch+15, nil, nil)
+	pm := newTestProtocolManagerMust(t, ArchiveMode, downloader.MaxHashFetch+15, nil, nil)
 	peer, _ := newTestPeer("peer", protocol, pm, true)
 	defer peer.close()
 
@@ -303,7 +333,7 @@ func TestGetBlockBodies63(t *testing.T) { testGetBlockBodies(t, 63) }
 func TestGetBlockBodies64(t *testing.T) { testGetBlockBodies(t, 64) }
 
 func testGetBlockBodies(t *testing.T, protocol int) {
-	pm := newTestProtocolManager(downloader.MaxBlockFetch+15, nil, nil)
+	pm := newTestProtocolManagerMust(t, ArchiveMode, downloader.MaxBlockFetch+15, nil, nil)
 	peer, _ := newTestPeer("peer", protocol, pm, true)
 	defer peer.close()
 
@@ -410,7 +440,7 @@ func testGetNodeData(t *testing.T, protocol int) {
 		}
 	}
 	// Assemble the test environment
-	pm := newTestProtocolManager(4, generator, nil)
+	pm := newTestProtocolManagerMust(t, ArchiveMode, 4, generator, nil)
 	peer, _ := newTestPeer("peer", protocol, pm, true)
 	defer peer.close()
 
@@ -499,7 +529,7 @@ func testGetReceipt(t *testing.T, protocol int) {
 		}
 	}
 	// Assemble the test environment
-	pm := newTestProtocolManager(4, generator, nil)
+	pm := newTestProtocolManagerMust(t, ArchiveMode, 4, generator, nil)
 	peer, _ := newTestPeer("peer", protocol, pm, true)
 	defer peer.close()
 

--- a/eth/helper_test.go
+++ b/eth/helper_test.go
@@ -28,7 +28,7 @@ var (
 // newTestProtocolManager creates a new protocol manager for testing purposes,
 // with the given number of blocks already known, and potential notification
 // channels for different events.
-func newTestProtocolManager(blocks int, generator func(int, *core.BlockGen), newtx chan<- []*types.Transaction) *ProtocolManager {
+func newTestProtocolManager(mode Mode, blocks int, generator func(int, *core.BlockGen), newtx chan<- []*types.Transaction) (*ProtocolManager, error) {
 	var (
 		evmux       = new(event.TypeMux)
 		pow         = new(core.FakePow)
@@ -41,8 +41,23 @@ func newTestProtocolManager(blocks int, generator func(int, *core.BlockGen), new
 	if _, err := chainman.InsertChain(core.GenerateChain(genesis, db, blocks, generator)); err != nil {
 		panic(err)
 	}
-	pm := NewProtocolManager(NetworkId, evmux, &testTxPool{added: newtx}, pow, chainman, db)
+	pm, err := NewProtocolManager(mode, NetworkId, evmux, &testTxPool{added: newtx}, pow, chainman, db)
+	if err != nil {
+		return nil, err
+	}
 	pm.Start()
+	return pm, nil
+}
+
+// newTestProtocolManagerMust creates a new protocol manager for testing purposes,
+// with the given number of blocks already known, and potential notification
+// channels for different events. In case of an error, the constructor force-
+// fails the test.
+func newTestProtocolManagerMust(t *testing.T, mode Mode, blocks int, generator func(int, *core.BlockGen), newtx chan<- []*types.Transaction) *ProtocolManager {
+	pm, err := newTestProtocolManager(mode, blocks, generator, newtx)
+	if err != nil {
+		t.Fatalf("Failed to create protocol manager: %v", err)
+	}
 	return pm
 }
 

--- a/eth/peer.go
+++ b/eth/peer.go
@@ -184,6 +184,12 @@ func (p *peer) SendBlockBodies(bodies []*blockBody) error {
 	return p2p.Send(p.rw, BlockBodiesMsg, blockBodiesData(bodies))
 }
 
+// SendBlockBodiesRLP sends a batch of block contents to the remote peer from
+// an already RLP encoded format.
+func (p *peer) SendBlockBodiesRLP(bodies []*blockBodyRLP) error {
+	return p2p.Send(p.rw, BlockBodiesMsg, blockBodiesRLPData(bodies))
+}
+
 // SendNodeData sends a batch of arbitrary internal data, corresponding to the
 // hashes requested.
 func (p *peer) SendNodeData(data [][]byte) error {

--- a/eth/protocol.go
+++ b/eth/protocol.go
@@ -26,6 +26,15 @@ import (
 	"github.com/ethereum/go-ethereum/rlp"
 )
 
+// Mode represents the mode of operation of the eth client.
+type Mode int
+
+const (
+	ArchiveMode Mode = iota // Maintain the entire blockchain history
+	FullMode                // Maintain only a recent view of the blockchain
+	LightMode               // Don't maintain any history, rather fetch on demand
+)
+
 // Constants to match up protocol versions and messages
 const (
 	eth61 = 61
@@ -33,6 +42,14 @@ const (
 	eth63 = 63
 	eth64 = 64
 )
+
+// minimumProtocolVersion is the minimum version of the protocol eth must run to
+// support the desired mode of operation.
+var minimumProtocolVersion = map[Mode]uint{
+	ArchiveMode: eth61,
+	FullMode:    eth63,
+	LightMode:   eth64,
+}
 
 // Supported versions of the eth protocol (first is primary).
 var ProtocolVersions = []uint{eth64, eth63, eth62, eth61}

--- a/eth/protocol.go
+++ b/eth/protocol.go
@@ -213,6 +213,22 @@ type blockBody struct {
 // blockBodiesData is the network packet for block content distribution.
 type blockBodiesData []*blockBody
 
+// blockBodyRLP represents the RLP encoded data content of a single block.
+type blockBodyRLP []byte
+
+// EncodeRLP is a specialized encoder for a block body to pass the already
+// encoded body RLPs from the database on, without double encoding.
+func (b *blockBodyRLP) EncodeRLP(w io.Writer) error {
+	if _, err := w.Write([]byte(*b)); err != nil {
+		return err
+	}
+	return nil
+}
+
+// blockBodiesRLPData is the network packet for block content distribution
+// based on original RLP formatting (i.e. skip the db-decode/proto-encode).
+type blockBodiesRLPData []*blockBodyRLP
+
 // nodeDataData is the network response packet for a node data retrieval.
 type nodeDataData []struct {
 	Value []byte

--- a/eth/protocol_test.go
+++ b/eth/protocol_test.go
@@ -44,7 +44,7 @@ func TestStatusMsgErrors63(t *testing.T) { testStatusMsgErrors(t, 63) }
 func TestStatusMsgErrors64(t *testing.T) { testStatusMsgErrors(t, 64) }
 
 func testStatusMsgErrors(t *testing.T, protocol int) {
-	pm := newTestProtocolManager(0, nil, nil)
+	pm := newTestProtocolManagerMust(t, ArchiveMode, 0, nil, nil)
 	td, currentBlock, genesis := pm.chainman.Status()
 	defer pm.Stop()
 
@@ -99,7 +99,7 @@ func TestRecvTransactions64(t *testing.T) { testRecvTransactions(t, 64) }
 
 func testRecvTransactions(t *testing.T, protocol int) {
 	txAdded := make(chan []*types.Transaction)
-	pm := newTestProtocolManager(0, nil, txAdded)
+	pm := newTestProtocolManagerMust(t, ArchiveMode, 0, nil, txAdded)
 	p, _ := newTestPeer("peer", protocol, pm, true)
 	defer pm.Stop()
 	defer p.close()
@@ -127,7 +127,7 @@ func TestSendTransactions63(t *testing.T) { testSendTransactions(t, 63) }
 func TestSendTransactions64(t *testing.T) { testSendTransactions(t, 64) }
 
 func testSendTransactions(t *testing.T, protocol int) {
-	pm := newTestProtocolManager(0, nil, nil)
+	pm := newTestProtocolManagerMust(t, ArchiveMode, 0, nil, nil)
 	defer pm.Stop()
 
 	// Fill the pool with big transactions.


### PR DESCRIPTION
*This PR is broken up into a separate core refactor https://github.com/ethereum/go-ethereum/pull/1767 and the current eth/63 protocol update. As such, this PR will be paused until the other is finalized.*

Background reading for this PR: [database schema update for the fast sync algorithm](https://gist.github.com/karalabe/852b097284e80452c72d).

This PR features the following:
 - [x] Split the block storage into separate headers and bodies (need pure header mode of operation).
 - [x] Support retrieving the raw RLP header/body data (during query, no need to parse and re-flatten).
 - [x] Refactor eth to use direct header/body accesses instead of entire block reads from the database.
 - [x] Support setting client mode (`--mode=archive` v61+, `--mode=full` v63+, or `--mode=light` v64+).
 - [ ] Upgrade ancestor lookup to support header only mode of operation (non-archive clients).
 - [ ] Implement concurrent header retrieval and header-chain reassembly strategy.
 - [ ] Support direct state database download, possibly from concurrent peers.