### PR TITLE
core: Filter on addresses should work as an OR not an AND.

### DIFF
--- a/core/filter.go
+++ b/core/filter.go
@@ -131,12 +131,12 @@ done:
 
 func includes(addresses []common.Address, a common.Address) bool {
 	for _, addr := range addresses {
-		if addr != a {
-			return false
+		if addr == a {
+			return true
 		}
 	}
 
-	return true
+	return false
 }
 
 func (self *Filter) FilterLogs(logs state.Logs) state.Logs {


### PR DESCRIPTION
Right now filters check if all submitted addresses match and only filter if this is true, it should work if any of the addresses match.