### PR TITLE
fix block time issue

### DIFF
--- a/miner/worker.go
+++ b/miner/worker.go
@@ -434,7 +434,7 @@ func (self *worker) commitNewWork() {
 	tstart := time.Now()
 	parent := self.chain.CurrentBlock()
 	tstamp := tstart.Unix()
-	if parent.Time().Cmp(new(big.Int).SetInt64(tstamp)) != 1 {
+	if parent.Time().Cmp(new(big.Int).SetInt64(tstamp)) != -1 {
 		tstamp = parent.Time().Int64() + 1
 	}
 	// this will ensure we're not going off too far in the future


### PR DESCRIPTION
currently, under normal circumstances, you always set the timestamp to previous.Time() + 1.