### PR TITLE
RPC address inside Docker container set

### DIFF
--- a/docker/supervisord.conf
+++ b/docker/supervisord.conf
@@ -4,7 +4,7 @@ nodaemon=false
 [program:geth]
 priority=30
 directory=/
-command=geth --rpc
+command=geth --rpc --rpcaddr 0.0.0.0
 user=root
 autostart=true
 autorestart=true


### PR DESCRIPTION
Without this, API is not accessible from outside of Docker container.