### PR TITLE
cmd/geth Autocompletion bugfix which let the console crash

### DIFF
--- a/cmd/geth/js.go
+++ b/cmd/geth/js.go
@@ -121,7 +121,7 @@ func keywordCompleter(line string) []string {
 }
 
 func apiWordCompleter(line string, pos int) (head string, completions []string, tail string) {
-	if len(line) == 0 {
+	if len(line) == 0 || pos == 0 {
 		return "", nil, ""
 	}
 


### PR DESCRIPTION
This PR fixed a crash when the user presses tab on a non empty line when the cursor is at the beginning of the line.

Fixes: #1768