### PR TITLE
rpc/comms: fix bug attaching the console over http

### DIFF
--- a/rpc/comms/http.go
+++ b/rpc/comms/http.go
@@ -271,13 +271,13 @@ func (self *httpClient) Send(req interface{}) error {
 		reply, _ := ioutil.ReadAll(resp.Body)
 		var rpcSuccessResponse shared.SuccessResponse
 		if err = self.codec.Decode(reply, &rpcSuccessResponse); err == nil {
-			self.lastRes = rpcSuccessResponse.Result
+			self.lastRes = &rpcSuccessResponse
 			self.lastErr = err
 			return nil
 		} else {
 			var rpcErrorResponse shared.ErrorResponse
 			if err = self.codec.Decode(reply, &rpcErrorResponse); err == nil {
-				self.lastRes = rpcErrorResponse.Error
+				self.lastRes = &rpcErrorResponse
 				self.lastErr = err
 				return nil
 			} else {


### PR DESCRIPTION
Attaching the console over rpc:http and attempting to run commands gives 'Invalid response type' messages.

This is because rpc/jeth.go is expecting the response type to be either a pointer to shared.SuccessResponse or shared.ErrorResponse.

This patch fixes rpc/comms/http.go to conform to this interface.