### PR TITLE
core: split the db blocks into components, move TD out top level

### DIFF
--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -528,17 +528,16 @@ func blockRecovery(ctx *cli.Context) {
 
 	var block *types.Block
 	if arg[0] == '#' {
-		block = core.GetBlockByNumber(blockDb, common.String2Big(arg[1:]).Uint64())
+		block = core.GetBlock(blockDb, core.GetCanonicalHash(blockDb, common.String2Big(arg[1:]).Uint64()))
 	} else {
-		block = core.GetBlockByHash(blockDb, common.HexToHash(arg))
+		block = core.GetBlock(blockDb, common.HexToHash(arg))
 	}
 
 	if block == nil {
 		glog.Fatalln("block not found. Recovery failed")
 	}
 
-	err = core.WriteHead(blockDb, block)
-	if err != nil {
+	if err = core.WriteHeadBlockHash(blockDb, block.Hash()); err != nil {
 		glog.Fatalln("block write err", err)
 	}
 	glog.Infof("Recovery succesful. New HEAD %x\n", block.Hash())

--- a/core/chain_makers.go
+++ b/core/chain_makers.go
@@ -158,7 +158,6 @@ func GenerateChain(parent *types.Block, db common.Database, n int, gen func(int,
 	for i := 0; i < n; i++ {
 		header := makeHeader(parent, statedb)
 		block := genblock(i, header)
-		block.Td = CalcTD(block, parent)
 		blocks[i] = block
 		parent = block
 	}

--- a/core/chain_manager_test.go
+++ b/core/chain_manager_test.go
@@ -388,7 +388,10 @@ func makeChainWithDiff(genesis *types.Block, d []int, seed byte) []*types.Block 
 func chm(genesis *types.Block, db common.Database) *ChainManager {
 	var eventMux event.TypeMux
 	bc := &ChainManager{chainDb: db, genesisBlock: genesis, eventMux: &eventMux, pow: FakePow{}}
-	bc.cache, _ = lru.New(100)
+	bc.headerCache, _ = lru.New(100)
+	bc.bodyCache, _ = lru.New(100)
+	bc.bodyRLPCache, _ = lru.New(100)
+	bc.blockCache, _ = lru.New(100)
 	bc.futureBlocks, _ = lru.New(100)
 	bc.processor = bproc{}
 	bc.ResetWithGenesisBlock(genesis)

--- a/core/chain_manager_test.go
+++ b/core/chain_manager_test.go
@@ -77,6 +77,7 @@ func testFork(t *testing.T, bman *BlockProcessor, i, N int, f func(td1, td2 *big
 	bi1 := bman.bc.GetBlockByNumber(uint64(i)).Hash()
 	bi2 := bman2.bc.GetBlockByNumber(uint64(i)).Hash()
 	if bi1 != bi2 {
+		fmt.Printf("%+v\n%+v\n\n", bi1, bi2)
 		t.Fatal("chains do not have the same hash at height", i)
 	}
 	bman2.bc.SetProcessor(bman2)
@@ -110,7 +111,6 @@ func printChain(bc *ChainManager) {
 
 // process blocks against a chain
 func testChain(chainB types.Blocks, bman *BlockProcessor) (*big.Int, error) {
-	td := new(big.Int)
 	for _, block := range chainB {
 		_, _, err := bman.bc.processor.Process(block)
 		if err != nil {
@@ -119,17 +119,12 @@ func testChain(chainB types.Blocks, bman *BlockProcessor) (*big.Int, error) {
 			}
 			return nil, err
 		}
-		parent := bman.bc.GetBlock(block.ParentHash())
-		block.Td = CalcTD(block, parent)
-		td = block.Td
-
 		bman.bc.mu.Lock()
-		{
-			WriteBlock(bman.bc.chainDb, block)
-		}
+		WriteTd(bman.bc.chainDb, block.Hash(), new(big.Int).Add(block.Difficulty(), bman.bc.GetTd(block.ParentHash())))
+		WriteBlock(bman.bc.chainDb, block)
 		bman.bc.mu.Unlock()
 	}
-	return td, nil
+	return bman.bc.GetTd(chainB[len(chainB)-1].Hash()), nil
 }
 
 func loadChain(fn string, t *testing.T) (types.Blocks, error) {
@@ -391,6 +386,7 @@ func chm(genesis *types.Block, db common.Database) *ChainManager {
 	bc.headerCache, _ = lru.New(100)
 	bc.bodyCache, _ = lru.New(100)
 	bc.bodyRLPCache, _ = lru.New(100)
+	bc.tdCache, _ = lru.New(100)
 	bc.blockCache, _ = lru.New(100)
 	bc.futureBlocks, _ = lru.New(100)
 	bc.processor = bproc{}

--- a/core/genesis.go
+++ b/core/genesis.go
@@ -86,7 +86,7 @@ func WriteGenesisBlock(chainDb common.Database, reader io.Reader) (*types.Block,
 
 	if block := GetBlockByHash(chainDb, block.Hash()); block != nil {
 		glog.V(logger.Info).Infoln("Genesis block already in chain. Writing canonical number")
-		err := WriteCanonNumber(chainDb, block)
+		err := WriteCanonNumber(chainDb, block.Hash(), block.NumberU64())
 		if err != nil {
 			return nil, err
 		}

--- a/core/types/block.go
+++ b/core/types/block.go
@@ -117,6 +117,13 @@ func rlpHash(x interface{}) (h common.Hash) {
 	return h
 }
 
+// Body is a simple (mutable, non-safe) data container for storing and moving
+// a block's data contents (transactions and uncles) together.
+type Body struct {
+	Transactions []*Transaction
+	Uncles       []*Header
+}
+
 type Block struct {
 	header       *Header
 	uncles       []*Header
@@ -129,10 +136,17 @@ type Block struct {
 
 	// Td is used by package core to store the total difficulty
 	// of the chain up to and including the block.
-	Td *big.Int
+	td *big.Int
 
 	// ReceivedAt is used by package eth to track block propagation time.
 	ReceivedAt time.Time
+}
+
+// DeprecatedTd is an old relic for extracting the TD of a block. It is in the
+// code solely to facilitate upgrading the database from the old format to the
+// new, after which it should be deleted. Do not use!
+func (b *Block) DeprecatedTd() *big.Int {
+	return b.td
 }
 
 // [deprecated by eth/63]
@@ -170,7 +184,7 @@ var (
 // are ignored and set to values derived from the given txs, uncles
 // and receipts.
 func NewBlock(header *Header, txs []*Transaction, uncles []*Header, receipts []*Receipt) *Block {
-	b := &Block{header: copyHeader(header), Td: new(big.Int)}
+	b := &Block{header: copyHeader(header), td: new(big.Int)}
 
 	// TODO: panic if len(txs) != len(receipts)
 	if len(txs) == 0 {
@@ -276,18 +290,8 @@ func (b *StorageBlock) DecodeRLP(s *rlp.Stream) error {
 	if err := s.Decode(&sb); err != nil {
 		return err
 	}
-	b.header, b.uncles, b.transactions, b.Td = sb.Header, sb.Uncles, sb.Txs, sb.TD
+	b.header, b.uncles, b.transactions, b.td = sb.Header, sb.Uncles, sb.Txs, sb.TD
 	return nil
-}
-
-// [deprecated by eth/63]
-func (b *StorageBlock) EncodeRLP(w io.Writer) error {
-	return rlp.Encode(w, storageblock{
-		Header: b.header,
-		Txs:    b.transactions,
-		Uncles: b.uncles,
-		TD:     b.Td,
-	})
 }
 
 // TODO: copies
@@ -360,7 +364,6 @@ func (b *Block) WithMiningResult(nonce uint64, mixDigest common.Hash) *Block {
 		transactions: b.transactions,
 		receipts:     b.receipts,
 		uncles:       b.uncles,
-		Td:           b.Td,
 	}
 }
 
@@ -390,7 +393,7 @@ func (b *Block) Hash() common.Hash {
 }
 
 func (b *Block) String() string {
-	str := fmt.Sprintf(`Block(#%v): Size: %v TD: %v {
+	str := fmt.Sprintf(`Block(#%v): Size: %v {
 MinerHash: %x
 %v
 Transactions:
@@ -398,7 +401,7 @@ Transactions:
 Uncles:
 %v
 }
-`, b.Number(), b.Size(), b.Td, b.header.HashNoNonce(), b.header, b.transactions, b.uncles)
+`, b.Number(), b.Size(), b.header.HashNoNonce(), b.header, b.transactions, b.uncles)
 	return str
 }
 

--- a/core/types/block.go
+++ b/core/types/block.go
@@ -135,6 +135,7 @@ type Block struct {
 	ReceivedAt time.Time
 }
 
+// [deprecated by eth/63]
 // StorageBlock defines the RLP encoding of a Block stored in the
 // state database. The StorageBlock encoding contains fields that
 // would otherwise need to be recomputed.
@@ -147,6 +148,7 @@ type extblock struct {
 	Uncles []*Header
 }
 
+// [deprecated by eth/63]
 // "storage" block encoding. used for database.
 type storageblock struct {
 	Header *Header
@@ -268,6 +270,7 @@ func (b *Block) EncodeRLP(w io.Writer) error {
 	})
 }
 
+// [deprecated by eth/63]
 func (b *StorageBlock) DecodeRLP(s *rlp.Stream) error {
 	var sb storageblock
 	if err := s.Decode(&sb); err != nil {
@@ -277,6 +280,7 @@ func (b *StorageBlock) DecodeRLP(s *rlp.Stream) error {
 	return nil
 }
 
+// [deprecated by eth/63]
 func (b *StorageBlock) EncodeRLP(w io.Writer) error {
 	return rlp.Encode(w, storageblock{
 		Header: b.header,

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -18,6 +18,7 @@
 package eth
 
 import (
+	"bytes"
 	"crypto/ecdsa"
 	"encoding/json"
 	"fmt"
@@ -269,11 +270,7 @@ func New(config *Config) (*Ethereum, error) {
 		newdb = func(path string) (common.Database, error) { return ethdb.NewLDBDatabase(path, config.DatabaseCache) }
 	}
 
-	// attempt to merge database together, upgrading from an old version
-	if err := mergeDatabases(config.DataDir, newdb); err != nil {
-		return nil, err
-	}
-
+	// Open the chain database and perform any upgrades needed
 	chainDb, err := newdb(filepath.Join(config.DataDir, "chaindata"))
 	if err != nil {
 		return nil, fmt.Errorf("blockchain db err: %v", err)
@@ -281,6 +278,10 @@ func New(config *Config) (*Ethereum, error) {
 	if db, ok := chainDb.(*ethdb.LDBDatabase); ok {
 		db.Meter("eth/db/chaindata/")
 	}
+	if err := upgradeChainDatabase(chainDb); err != nil {
+		return nil, err
+	}
+
 	dappDb, err := newdb(filepath.Join(config.DataDir, "dapp"))
 	if err != nil {
 		return nil, fmt.Errorf("dapp db err: %v", err)
@@ -721,74 +722,55 @@ func saveBlockchainVersion(db common.Database, bcVersion int) {
 	}
 }
 
-// mergeDatabases when required merge old database layout to one single database
-func mergeDatabases(datadir string, newdb func(path string) (common.Database, error)) error {
-	// Check if already upgraded
-	data := filepath.Join(datadir, "chaindata")
-	if _, err := os.Stat(data); !os.IsNotExist(err) {
+// upgradeChainDatabase ensures that the chain database stores block split into
+// separate header and body entries.
+func upgradeChainDatabase(db common.Database) error {
+	// Short circuit if the head block is stored already as separate header and body
+	data, err := db.Get([]byte("LastBlock"))
+	if err != nil {
 		return nil
 	}
-	// make sure it's not just a clean path
-	chainPath := filepath.Join(datadir, "blockchain")
-	if _, err := os.Stat(chainPath); os.IsNotExist(err) {
+	head := common.BytesToHash(data)
+
+	if block := core.GetBlockByHashOld(db, head); block == nil {
 		return nil
 	}
-	glog.Infoln("Database upgrade required. Upgrading...")
+	// At least some of the database is still the old format, upgrade (skip the head block!)
+	glog.V(logger.Info).Info("Old database detected, upgrading...")
 
-	database, err := newdb(data)
-	if err != nil {
-		return fmt.Errorf("creating data db err: %v", err)
-	}
-	defer database.Close()
+	if db, ok := db.(*ethdb.LDBDatabase); ok {
+		blockPrefix := []byte("block-hash-")
+		for it := db.NewIterator(); it.Next(); {
+			// Skip anything other than a combined block
+			if !bytes.HasPrefix(it.Key(), blockPrefix) {
+				continue
+			}
+			// Skip the head block (merge last to signal upgrade completion)
+			if bytes.HasSuffix(it.Key(), head.Bytes()) {
+				continue
+			}
+			// Load the block, split and serialize (order!)
+			block := core.GetBlockByHashOld(db, common.BytesToHash(bytes.TrimPrefix(it.Key(), blockPrefix)))
 
-	// Migrate blocks
-	chainDb, err := newdb(chainPath)
-	if err != nil {
-		return fmt.Errorf("state db err: %v", err)
-	}
-	defer chainDb.Close()
-
-	if chain, ok := chainDb.(*ethdb.LDBDatabase); ok {
-		glog.Infoln("Merging blockchain database...")
-		it := chain.NewIterator()
-		for it.Next() {
-			database.Put(it.Key(), it.Value())
+			if err := core.WriteBody(db, block); err != nil {
+				return err
+			}
+			if err := core.WriteHeader(db, block.Header()); err != nil {
+				return err
+			}
+			if err := db.Delete(it.Key()); err != nil {
+				return err
+			}
 		}
-		it.Release()
-	}
+		// Lastly, upgrade the head block, disabling the upgrade mechanism
+		current := core.GetBlockByHashOld(db, head)
 
-	// Migrate state
-	stateDb, err := newdb(filepath.Join(datadir, "state"))
-	if err != nil {
-		return fmt.Errorf("state db err: %v", err)
-	}
-	defer stateDb.Close()
-
-	if state, ok := stateDb.(*ethdb.LDBDatabase); ok {
-		glog.Infoln("Merging state database...")
-		it := state.NewIterator()
-		for it.Next() {
-			database.Put(it.Key(), it.Value())
+		if err := core.WriteBody(db, current); err != nil {
+			return err
 		}
-		it.Release()
-	}
-
-	// Migrate transaction / receipts
-	extraDb, err := newdb(filepath.Join(datadir, "extra"))
-	if err != nil {
-		return fmt.Errorf("state db err: %v", err)
-	}
-	defer extraDb.Close()
-
-	if extra, ok := extraDb.(*ethdb.LDBDatabase); ok {
-		glog.Infoln("Merging transaction database...")
-
-		it := extra.NewIterator()
-		for it.Next() {
-			database.Put(it.Key(), it.Value())
+		if err := core.WriteHeader(db, current.Header()); err != nil {
+			return err
 		}
-		it.Release()
 	}
-
 	return nil
 }

--- a/eth/peer.go
+++ b/eth/peer.go
@@ -28,6 +28,7 @@ import (
 	"github.com/ethereum/go-ethereum/logger"
 	"github.com/ethereum/go-ethereum/logger/glog"
 	"github.com/ethereum/go-ethereum/p2p"
+	"github.com/ethereum/go-ethereum/rlp"
 	"gopkg.in/fatih/set.v0"
 )
 
@@ -186,8 +187,8 @@ func (p *peer) SendBlockBodies(bodies []*blockBody) error {
 
 // SendBlockBodiesRLP sends a batch of block contents to the remote peer from
 // an already RLP encoded format.
-func (p *peer) SendBlockBodiesRLP(bodies []*blockBodyRLP) error {
-	return p2p.Send(p.rw, BlockBodiesMsg, blockBodiesRLPData(bodies))
+func (p *peer) SendBlockBodiesRLP(bodies []rlp.RawValue) error {
+	return p2p.Send(p.rw, BlockBodiesMsg, bodies)
 }
 
 // SendNodeData sends a batch of arbitrary internal data, corresponding to the

--- a/eth/peer.go
+++ b/eth/peer.go
@@ -184,6 +184,12 @@ func (p *peer) SendBlockBodies(bodies []*blockBody) error {
 	return p2p.Send(p.rw, BlockBodiesMsg, blockBodiesData(bodies))
 }
 
+// SendBlockBodiesRLP sends a batch of block contents to the remote peer from
+// an already RLP encoded format.
+func (p *peer) SendBlockBodiesRLP(bodies []*blockBodyRLP) error {
+	return p2p.Send(p.rw, BlockBodiesMsg, blockBodiesRLPData(bodies))
+}
+
 // SendNodeData sends a batch of arbitrary internal data, corresponding to the
 // hashes requested.
 func (p *peer) SendNodeData(data [][]byte) error {

--- a/eth/protocol.go
+++ b/eth/protocol.go
@@ -213,22 +213,6 @@ type blockBody struct {
 // blockBodiesData is the network packet for block content distribution.
 type blockBodiesData []*blockBody
 
-// blockBodyRLP represents the RLP encoded data content of a single block.
-type blockBodyRLP []byte
-
-// EncodeRLP is a specialized encoder for a block body to pass the already
-// encoded body RLPs from the database on, without double encoding.
-func (b *blockBodyRLP) EncodeRLP(w io.Writer) error {
-	if _, err := w.Write([]byte(*b)); err != nil {
-		return err
-	}
-	return nil
-}
-
-// blockBodiesRLPData is the network packet for block content distribution
-// based on original RLP formatting (i.e. skip the db-decode/proto-encode).
-type blockBodiesRLPData []*blockBodyRLP
-
 // nodeDataData is the network response packet for a node data retrieval.
 type nodeDataData []struct {
 	Value []byte

--- a/eth/protocol.go
+++ b/eth/protocol.go
@@ -213,6 +213,22 @@ type blockBody struct {
 // blockBodiesData is the network packet for block content distribution.
 type blockBodiesData []*blockBody
 
+// blockBodyRLP represents the RLP encoded data content of a single block.
+type blockBodyRLP []byte
+
+// EncodeRLP is a specialized encoder for a block body to pass the already
+// encoded body RLPs from the database on, without double encoding.
+func (b *blockBodyRLP) EncodeRLP(w io.Writer) error {
+	if _, err := w.Write([]byte(*b)); err != nil {
+		return err
+	}
+	return nil
+}
+
+// blockBodiesRLPData is the network packet for block content distribution
+// based on original RLP formatting (i.e. skip the db-decode/proto-encode).
+type blockBodiesRLPData []*blockBodyRLP
+
 // nodeDataData is the network response packet for a node data retrieval.
 type nodeDataData []struct {
 	Value []byte

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -283,7 +283,7 @@ func (self *worker) wait() {
 					continue
 				}
 
-				stat, err := self.chain.WriteBlock(block, false)
+				stat, err := self.chain.WriteBlock(block)
 				if err != nil {
 					glog.V(logger.Error).Infoln("error writing block to chain", err)
 					continue
@@ -533,14 +533,12 @@ func (self *worker) commitNewWork() {
 
 	// create the new block whose nonce will be mined.
 	work.Block = types.NewBlock(header, work.txs, uncles, work.receipts)
-	work.Block.Td = new(big.Int).Set(core.CalcTD(work.Block, self.chain.GetBlock(work.Block.ParentHash())))
 
 	// We only care about logging if we're actually mining.
 	if atomic.LoadInt32(&self.mining) == 1 {
 		glog.V(logger.Info).Infof("commit new work on block %v with %d txs & %d uncles. Took %v\n", work.Block.Number(), work.tcount, len(uncles), time.Since(tstart))
 		self.logLocalMinedBlocks(work, previous)
 	}
-
 	self.push(work)
 }
 

--- a/rpc/api/parsing.go
+++ b/rpc/api/parsing.go
@@ -281,7 +281,7 @@ func (b *BlockRes) MarshalJSON() ([]byte, error) {
 	}
 }
 
-func NewBlockRes(block *types.Block, fullTx bool) *BlockRes {
+func NewBlockRes(block *types.Block, td *big.Int, fullTx bool) *BlockRes {
 	if block == nil {
 		return nil
 	}
@@ -299,7 +299,7 @@ func NewBlockRes(block *types.Block, fullTx bool) *BlockRes {
 	res.ReceiptRoot = newHexData(block.ReceiptHash())
 	res.Miner = newHexData(block.Coinbase())
 	res.Difficulty = newHexNum(block.Difficulty())
-	res.TotalDifficulty = newHexNum(block.Td)
+	res.TotalDifficulty = newHexNum(td)
 	res.Size = newHexNum(block.Size().Int64())
 	res.ExtraData = newHexData(block.Extra())
 	res.GasLimit = newHexNum(block.GasLimit())

--- a/tests/block_test_util.go
+++ b/tests/block_test_util.go
@@ -440,9 +440,8 @@ func convertBlockTest(in *btJSON) (out *BlockTest, err error) {
 func mustConvertGenesis(testGenesis btHeader) *types.Block {
 	hdr := mustConvertHeader(testGenesis)
 	hdr.Number = big.NewInt(0)
-	b := types.NewBlockWithHeader(hdr)
-	b.Td = new(big.Int)
-	return b
+
+	return types.NewBlockWithHeader(hdr)
 }
 
 func mustConvertHeader(in btHeader) *types.Header {

--- a/xeth/xeth.go
+++ b/xeth/xeth.go
@@ -355,6 +355,10 @@ func (self *XEth) EthBlockByNumber(num int64) *types.Block {
 	return self.getBlockByHeight(num)
 }
 
+func (self *XEth) Td(hash common.Hash) *big.Int {
+	return self.backend.ChainManager().GetTd(hash)
+}
+
 func (self *XEth) CurrentBlock() *types.Block {
 	return self.backend.ChainManager().CurrentBlock()
 }


### PR DESCRIPTION
This PR features the following:
 - [x] Split the block storage into separate headers and bodies (need pure header mode of operation).
 - [x] Support retrieving the raw RLP header/body data (during query, no need to parse and re-flatten).
 - [x] Refactor eth to use direct header/body accesses instead of entire block reads from the database.
 - [x] Factor out the TD from the blocks and assign top level database entries (prep header only mode).
 - [x] Drop direct database "by number" gets (don't duplicate chain manager logic (also has cache)).
 - [x] Tests for all primitive (header, body, td, block) data storage and retrieval operations.
 - [x] Tests for metadata (canonical number, head header, head block) data storage and retrieval.