### PR TITLE
agent/miner Prevent the CpuAgent to be started multiple times

### DIFF
--- a/miner/agent.go
+++ b/miner/agent.go
@@ -61,10 +61,10 @@ func (self *CpuAgent) Stop() {
 }
 
 func (self *CpuAgent) Start() {
-	defer self.mu.Unlock()
 	self.mu.Lock()
-
-	if atomic.LoadInt32(&self.isMining) == 1 {
+	defer self.mu.Unlock()
+	
+	if !atomic.CompareAndSwapInt32(&self.isMining, 0, 1) {
 		return // agent already started
 	}
 
@@ -74,8 +74,6 @@ func (self *CpuAgent) Start() {
 	self.workCh = make(chan *Work, 1)
 
 	go self.update()
-
-	atomic.StoreInt32(&self.isMining, 1)
 }
 
 func (self *CpuAgent) update() {


### PR DESCRIPTION
A `CpuAgent` instance can be [started](https://github.com/ethereum/go-ethereum/blob/master/miner/worker.go#L182) multiple times. This causes multiple go-routines running the update loop on the same instances. When the agent is stopped the work channel is [closed](https://github.com/ethereum/go-ethereum/blob/master/miner/agent.go#L101). When another go-routine tries to [read](https://github.com/ethereum/go-ethereum/blob/master/miner/agent.go#L76) from this channel in the update loop it can read a nil pointer instead of a task. This can cause a nil pointer exception later on.

This PR adds a check to determine if the agent is already started. This causes only a single update loop for each `CpuAgent`.

This fixes #1757 