### PR TITLE
Change go-uuid to use the current supported repository.

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -6,9 +6,9 @@
 	],
 	"Deps": [
 		{
-			"ImportPath": "code.google.com/p/go-uuid/uuid",
-			"Comment": "null-12",
-			"Rev": "7dda39b2e7d5e265014674c5af696ba4186679e9"
+		        "ImportPath": "github.com/pborman/uuid",
+		        "Comment": "none",
+		        "Rev": "cccd189d45f7ac3368a0d127efb7f4d08ae0b655"
 		},
 		{
 			"ImportPath": "github.com/codegangsta/cli",

--- a/crypto/crypto.go
+++ b/crypto/crypto.go
@@ -33,12 +33,12 @@ import (
 	"encoding/json"
 	"errors"
 
-	"code.google.com/p/go-uuid/uuid"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/crypto/ecies"
 	"github.com/ethereum/go-ethereum/crypto/secp256k1"
 	"github.com/ethereum/go-ethereum/crypto/sha3"
 	"github.com/ethereum/go-ethereum/rlp"
+	"github.com/pborman/uuid"
 	"golang.org/x/crypto/pbkdf2"
 	"golang.org/x/crypto/ripemd160"
 )

--- a/crypto/key.go
+++ b/crypto/key.go
@@ -23,8 +23,8 @@ import (
 	"encoding/json"
 	"io"
 
-	"code.google.com/p/go-uuid/uuid"
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/pborman/uuid"
 )
 
 const (

--- a/crypto/key_store_passphrase.go
+++ b/crypto/key_store_passphrase.go
@@ -36,9 +36,9 @@ import (
 	"io"
 	"reflect"
 
-	"code.google.com/p/go-uuid/uuid"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/crypto/randentropy"
+	"github.com/pborman/uuid"
 	"golang.org/x/crypto/pbkdf2"
 	"golang.org/x/crypto/scrypt"
 )


### PR DESCRIPTION
code.google.com is going away. Long live uuid, just someplace else.