### PR TITLE
rpc/comms: fix #1795, ensure IPC path exists before binding

### DIFF
--- a/rpc/comms/ipc_unix.go
+++ b/rpc/comms/ipc_unix.go
@@ -21,6 +21,7 @@ package comms
 import (
 	"net"
 	"os"
+	"path/filepath"
 
 	"github.com/ethereum/go-ethereum/logger"
 	"github.com/ethereum/go-ethereum/logger/glog"
@@ -69,7 +70,11 @@ func (self *ipcClient) reconnect() error {
 }
 
 func startIpc(cfg IpcConfig, codec codec.Codec, initializer func(conn net.Conn) (shared.EthereumApi, error)) error {
-	os.Remove(cfg.Endpoint) // in case it still exists from a previous run
+	// Ensure the IPC path exists and remove any previous leftover
+	if err := os.MkdirAll(filepath.Dir(cfg.Endpoint), 0751); err != nil {
+		return err
+	}
+	os.Remove(cfg.Endpoint)
 
 	l, err := net.ListenUnix("unix", &net.UnixAddr{Name: cfg.Endpoint, Net: "unix"})
 	if err != nil {


### PR DESCRIPTION
This PR fixes an issue where geth crashed if the IPC endpoint directory didn't exist. E.g. `geth --ipcpath=/tmp/a/b/c/d/e`.