### PR TITLE
core: Add BadHashErr and test for BadHashes handling

### DIFF
--- a/core/chain_manager.go
+++ b/core/chain_manager.go
@@ -642,7 +642,7 @@ func (self *ChainManager) InsertChain(chain types.Blocks) (int, error) {
 		}
 
 		if BadHashes[block.Hash()] {
-			err := fmt.Errorf("Found known bad hash in chain %x", block.Hash())
+			err := BadHashError(block.Hash())
 			blockErr(block, err)
 			return i, err
 		}

--- a/core/error.go
+++ b/core/error.go
@@ -177,3 +177,14 @@ func IsValueTransferErr(e error) bool {
 	_, ok := e.(*ValueTransferError)
 	return ok
 }
+
+type BadHashError common.Hash
+
+func (h BadHashError) Error() string {
+	return fmt.Sprintf("Found known bad hash in chain %x", h)
+}
+
+func IsBadHashError(err error) bool {
+	_, ok := err.(BadHashError)
+	return ok
+}


### PR DESCRIPTION
Please see the commented out test code that causes chain_manager to panic here: https://github.com/ethereum/go-ethereum/blob/master/core/chain_manager.go#L119

Would be great if this could be tested. Can this panic be recovered in tests somehow? Or perhaps changed to return an error?