### PR TITLE
timer bugfix when clearInterval was called from within the callback

### DIFF
--- a/jsre/jsre.go
+++ b/jsre/jsre.go
@@ -154,7 +154,9 @@ loop:
 			if err != nil {
 				fmt.Println("js error:", err, arguments)
 			}
-			if timer.interval {
+		
+			_, inreg := registry[timer] // when clearInterval is called from within the callback don't reset it
+			if timer.interval && inreg {
 				timer.timer.Reset(timer.duration)
 			} else {
 				delete(registry, timer)


### PR DESCRIPTION
This fixes #1083

When a new timer event is created with `setInterval` from the javascript console the go code creates a `time.Timer` instance which will fire repetitively after each interval. When the `clearInterval` method is called to stop the timer from within the callback the timer is restarted after the callback is finished. This overrides the `clearInterval`.

This PR will check if the timer was unregistered in the `cleanInterval` and will not restart the timer.