### PR TITLE
core: transaction nonce recovery

### DIFF
--- a/core/transaction_pool.go
+++ b/core/transaction_pool.go
@@ -121,8 +121,8 @@ func (pool *TxPool) resetState() {
 		if addr, err := tx.From(); err == nil {
 			// Set the nonce. Transaction nonce can never be lower
 			// than the state nonce; validatePool took care of that.
-			if pool.pendingState.GetNonce(addr) < tx.Nonce() {
-				pool.pendingState.SetNonce(addr, tx.Nonce())
+			if pool.pendingState.GetNonce(addr) <= tx.Nonce() {
+				pool.pendingState.SetNonce(addr, tx.Nonce()+1)
 			}
 		}
 	}


### PR DESCRIPTION
When the transaction state recovery kicked in it assigned the last
(incorrect) nonce to the pending state which caused transactions with
the same nonce to occur.

Added test for nonce recovery

Fixes #1662