### PR TITLE
makefile: built in cross compilation targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,30 @@ geth:
 	@echo "Done building."
 	@echo "Run \"$(GOBIN)/geth\" to launch geth."
 
+geth-cross: geth-linux geth-darwin geth-windows geth-android
+	@echo "Full cross compilation done:"
+	@ls -l $(GOBIN)/geth-*
+
+geth-linux: xgo
+	build/env.sh $(GOBIN)/xgo --dest=$(GOBIN) --deps=https://gmplib.org/download/gmp/gmp-6.0.0a.tar.bz2 --targets=linux/* -v ./cmd/geth
+	@echo "Linux cross compilation done:"
+	@ls -l $(GOBIN)/geth-linux-*
+
+geth-darwin: xgo
+	build/env.sh $(GOBIN)/xgo --dest=$(GOBIN) --deps=https://gmplib.org/download/gmp/gmp-6.0.0a.tar.bz2 --targets=darwin/* -v ./cmd/geth
+	@echo "Darwin cross compilation done:"
+	@ls -l $(GOBIN)/geth-darwin-*
+
+geth-windows: xgo
+	build/env.sh $(GOBIN)/xgo --dest=$(GOBIN) --deps=https://gmplib.org/download/gmp/gmp-6.0.0a.tar.bz2 --targets=windows/* -v ./cmd/geth
+	@echo "Windows cross compilation done:"
+	@ls -l $(GOBIN)/geth-windows-*
+
+geth-android: xgo
+	build/env.sh $(GOBIN)/xgo --dest=$(GOBIN) --deps=https://gmplib.org/download/gmp/gmp-6.0.0a.tar.bz2 --targets=android-16/*,android-21/* -v ./cmd/geth
+	@echo "Android cross compilation done:"
+	@ls -l $(GOBIN)/geth-android-*
+
 evm:
 	build/env.sh $(GOROOT)/bin/go install -v $(shell build/ldflags.sh) ./cmd/evm
 	@echo "Done building."
@@ -27,6 +51,9 @@ test: all
 
 travis-test-with-coverage: all
 	build/env.sh build/test-global-coverage.sh
+
+xgo:
+	build/env.sh go get github.com/karalabe/xgo
 
 clean:
 	rm -fr build/_workspace/pkg/ Godeps/_workspace/pkg $(GOBIN)/*


### PR DESCRIPTION
:sparkles: 

```
$ make geth-cross
[...]
Full cross compilation done:
-rwxr-xr-x 1 root root 23280432 Sep 21 21:33 build/bin/geth-android-16-arm
-rwxr-xr-x 1 root root 23280432 Sep 21 21:34 build/bin/geth-android-21-arm
-rwxr-xr-x 1 root root 14427264 Sep 21 21:31 build/bin/geth-darwin-386
-rwxr-xr-x 1 root root 17435156 Sep 21 21:30 build/bin/geth-darwin-amd64
-rwxr-xr-x 1 root root 21158117 Sep 21 21:28 build/bin/geth-linux-386
-rwxr-xr-x 1 root root 25118808 Sep 21 21:28 build/bin/geth-linux-amd64
-rwxr-xr-x 1 root root 20637198 Sep 21 21:29 build/bin/geth-linux-arm
-rwxr-xr-x 1 root root 16405858 Sep 21 21:32 build/bin/geth-windows-386.exe
-rwxr-xr-x 1 root root 19479325 Sep 21 21:31 build/bin/geth-windows-amd64.exe
```

```
real   7m12.292s
user   0m0.840s
sys    0m0.692s
```
