### PR TITLE
console, cli, api fixes

### DIFF
--- a/cmd/utils/cmd.go
+++ b/cmd/utils/cmd.go
@@ -40,7 +40,9 @@ const (
 	importBatchSize = 2500
 )
 
-var interruptCallbacks = []func(os.Signal){}
+var (
+	interruptCallbacks = []func(os.Signal){}
+)
 
 func openLogFile(Datadir string, filename string) *os.File {
 	path := common.AbsolutePath(Datadir, filename)

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -183,6 +183,10 @@ var (
 		Usage: "Sets the minimal gasprice when mining transactions",
 		Value: new(big.Int).Mul(big.NewInt(50), common.Shannon).String(),
 	}
+	ExtraDataFlag = cli.StringFlag{
+		Name:  "extradata",
+		Usage: "Extra data for the miner",
+	}
 
 	UnlockedAccountFlag = cli.StringFlag{
 		Name:  "unlock",
@@ -345,7 +349,7 @@ var (
 	// ATM the url is left to the user and deployment to
 	JSpathFlag = cli.StringFlag{
 		Name:  "jspath",
-		Usage: "JS library path to be used with console and js subcommands",
+		Usage: "JS root path for loadScript and document root for admin.httpGet",
 		Value: ".",
 	}
 	SolcPathFlag = cli.StringFlag{
@@ -612,7 +616,7 @@ func StartIPC(eth *eth.Ethereum, ctx *cli.Context) error {
 		xeth := xeth.New(eth, fe)
 		codec := codec.JSON
 
-		apis, err := api.ParseApiString(ctx.GlobalString(IPCApiFlag.Name), codec, xeth, eth)
+		apis, err := api.ParseApiString(ctx.GlobalString(IPCApiFlag.Name), codec, xeth, eth, ctx.GlobalString(JSpathFlag.Name))
 		if err != nil {
 			return nil, err
 		}
@@ -633,7 +637,7 @@ func StartRPC(eth *eth.Ethereum, ctx *cli.Context) error {
 	xeth := xeth.New(eth, nil)
 	codec := codec.JSON
 
-	apis, err := api.ParseApiString(ctx.GlobalString(RpcApiFlag.Name), codec, xeth, eth)
+	apis, err := api.ParseApiString(ctx.GlobalString(RpcApiFlag.Name), codec, xeth, eth, ctx.GlobalString(JSpathFlag.Name))
 	if err != nil {
 		return err
 	}

--- a/common/docserver/docserver.go
+++ b/common/docserver/docserver.go
@@ -95,12 +95,18 @@ func (self *DocServer) Get(uri, path string) (content []byte, err error) {
 			resp.Body.Close()
 		}
 	}()
+
 	if err != nil {
 		return
 	}
+
 	content, err = ioutil.ReadAll(resp.Body)
 	if err != nil {
 		return
+	}
+
+	if resp.StatusCode/100 != 2 {
+		return content, fmt.Errorf("HTTP error: %s", resp.Status)
 	}
 
 	if path != "" {

--- a/common/registrar/registrar_test.go
+++ b/common/registrar/registrar_test.go
@@ -36,29 +36,31 @@ var (
 )
 
 func NewTestBackend() *testBackend {
-	HashRegAddr = common.BigToAddress(common.Big0).Hex() //[2:]
-	UrlHintAddr = common.BigToAddress(common.Big1).Hex() //[2:]
 	self := &testBackend{}
 	self.contracts = make(map[string](map[string]string))
+	return self
+}
 
+func (self *testBackend) initHashReg() {
 	self.contracts[HashRegAddr[2:]] = make(map[string]string)
 	key := storageAddress(storageMapping(storageIdx2Addr(1), codehash[:]))
 	self.contracts[HashRegAddr[2:]][key] = hash.Hex()
+}
 
+func (self *testBackend) initUrlHint() {
 	self.contracts[UrlHintAddr[2:]] = make(map[string]string)
 	mapaddr := storageMapping(storageIdx2Addr(1), hash[:])
 
-	key = storageAddress(storageFixedArray(mapaddr, storageIdx2Addr(0)))
+	key := storageAddress(storageFixedArray(mapaddr, storageIdx2Addr(0)))
 	self.contracts[UrlHintAddr[2:]][key] = common.ToHex([]byte(url))
 	key = storageAddress(storageFixedArray(mapaddr, storageIdx2Addr(1)))
 	self.contracts[UrlHintAddr[2:]][key] = "0x0"
-	return self
 }
 
 func (self *testBackend) StorageAt(ca, sa string) (res string) {
 	c := self.contracts[ca]
 	if c == nil {
-		return
+		return "0x0"
 	}
 	res = c[sa]
 	return
@@ -84,9 +86,31 @@ func TestSetGlobalRegistrar(t *testing.T) {
 func TestHashToHash(t *testing.T) {
 	b := NewTestBackend()
 	res := New(b)
-	// res.SetHashReg()
 
+	HashRegAddr = "0x0"
 	got, err := res.HashToHash(codehash)
+	if err == nil {
+		t.Errorf("expected error")
+	} else {
+		exp := "HashReg address is not set"
+		if err.Error() != exp {
+			t.Errorf("incorrect error, expected '%v', got '%v'", exp, err.Error())
+		}
+	}
+
+	HashRegAddr = common.BigToAddress(common.Big1).Hex() //[2:]
+	got, err = res.HashToHash(codehash)
+	if err == nil {
+		t.Errorf("expected error")
+	} else {
+		exp := "HashToHash: content hash not found for '" + codehash.Hex() + "'"
+		if err.Error() != exp {
+			t.Errorf("incorrect error, expected '%v', got '%v'", exp, err.Error())
+		}
+	}
+
+	b.initHashReg()
+	got, err = res.HashToHash(codehash)
 	if err != nil {
 		t.Errorf("expected no error, got %v", err)
 	} else {
@@ -99,11 +123,33 @@ func TestHashToHash(t *testing.T) {
 func TestHashToUrl(t *testing.T) {
 	b := NewTestBackend()
 	res := New(b)
-	// res.SetUrlHint()
 
+	UrlHintAddr = "0x0"
 	got, err := res.HashToUrl(hash)
+	if err == nil {
+		t.Errorf("expected error")
+	} else {
+		exp := "UrlHint address is not set"
+		if err.Error() != exp {
+			t.Errorf("incorrect error, expected '%v', got '%v'", exp, err.Error())
+		}
+	}
+
+	UrlHintAddr = common.BigToAddress(common.Big2).Hex() //[2:]
+	got, err = res.HashToUrl(hash)
+	if err == nil {
+		t.Errorf("expected error")
+	} else {
+		exp := "HashToUrl: URL hint not found for '" + hash.Hex() + "'"
+		if err.Error() != exp {
+			t.Errorf("incorrect error, expected '%v', got '%v'", exp, err.Error())
+		}
+	}
+
+	b.initUrlHint()
+	got, err = res.HashToUrl(hash)
 	if err != nil {
-		t.Errorf("expected 	 error, got %v", err)
+		t.Errorf("expected no error, got %v", err)
 	} else {
 		if got != url {
 			t.Errorf("incorrect result, expected '%v', got '%s'", url, got)

--- a/crypto/crypto.go
+++ b/crypto/crypto.go
@@ -261,6 +261,9 @@ func decryptPreSaleKey(fileContent []byte, password string) (key *Key, err error
 	passBytes := []byte(password)
 	derivedKey := pbkdf2.Key(passBytes, passBytes, 2000, 16, sha256.New)
 	plainText, err := aesCBCDecrypt(derivedKey, cipherText, iv)
+	if err != nil {
+		return nil, err
+	}
 	ethPriv := Sha3(plainText)
 	ecKey := ToECDSA(ethPriv)
 	key = &Key{
@@ -271,7 +274,7 @@ func decryptPreSaleKey(fileContent []byte, password string) (key *Key, err error
 	derivedAddr := hex.EncodeToString(key.Address.Bytes()) // needed because .Hex() gives leading "0x"
 	expectedAddr := preSaleKeyStruct.EthAddr
 	if derivedAddr != expectedAddr {
-		err = errors.New(fmt.Sprintf("decrypted addr not equal to expected addr ", derivedAddr, expectedAddr))
+		err = fmt.Errorf("decrypted addr '%s' not equal to expected addr '%s'", derivedAddr, expectedAddr)
 	}
 	return key, err
 }

--- a/rpc/api/admin.go
+++ b/rpc/api/admin.go
@@ -84,17 +84,19 @@ type adminApi struct {
 	ethereum *eth.Ethereum
 	codec    codec.Codec
 	coder    codec.ApiCoder
+	docRoot  string
 	ds       *docserver.DocServer
 }
 
 // create a new admin api instance
-func NewAdminApi(xeth *xeth.XEth, ethereum *eth.Ethereum, codec codec.Codec) *adminApi {
+func NewAdminApi(xeth *xeth.XEth, ethereum *eth.Ethereum, codec codec.Codec, docRoot string) *adminApi {
 	return &adminApi{
 		xeth:     xeth,
 		ethereum: ethereum,
 		codec:    codec,
 		coder:    codec.New(nil),
-		ds:       docserver.New("/"),
+		docRoot:  docRoot,
+		ds:       docserver.New(docRoot),
 	}
 }
 
@@ -256,7 +258,7 @@ func (self *adminApi) StartRPC(req *shared.Request) (interface{}, error) {
 		CorsDomain:    args.CorsDomain,
 	}
 
-	apis, err := ParseApiString(args.Apis, self.codec, self.xeth, self.ethereum)
+	apis, err := ParseApiString(args.Apis, self.codec, self.xeth, self.ethereum, self.docRoot)
 	if err != nil {
 		return false, err
 	}

--- a/rpc/api/api_test.go
+++ b/rpc/api/api_test.go
@@ -30,7 +30,7 @@ import (
 )
 
 func TestParseApiString(t *testing.T) {
-	apis, err := ParseApiString("", codec.JSON, nil, nil)
+	apis, err := ParseApiString("", codec.JSON, nil, nil, "")
 	if err == nil {
 		t.Errorf("Expected an err from parsing empty API string but got nil")
 	}
@@ -39,7 +39,7 @@ func TestParseApiString(t *testing.T) {
 		t.Errorf("Expected 0 apis from empty API string")
 	}
 
-	apis, err = ParseApiString("eth", codec.JSON, nil, nil)
+	apis, err = ParseApiString("eth", codec.JSON, nil, nil, "")
 	if err != nil {
 		t.Errorf("Expected nil err from parsing empty API string but got %v", err)
 	}
@@ -48,7 +48,7 @@ func TestParseApiString(t *testing.T) {
 		t.Errorf("Expected 1 apis but got %d - %v", apis, apis)
 	}
 
-	apis, err = ParseApiString("eth,eth", codec.JSON, nil, nil)
+	apis, err = ParseApiString("eth,eth", codec.JSON, nil, nil, "")
 	if err != nil {
 		t.Errorf("Expected nil err from parsing empty API string but got \"%v\"", err)
 	}
@@ -57,7 +57,7 @@ func TestParseApiString(t *testing.T) {
 		t.Errorf("Expected 2 apis but got %d - %v", apis, apis)
 	}
 
-	apis, err = ParseApiString("eth,invalid", codec.JSON, nil, nil)
+	apis, err = ParseApiString("eth,invalid", codec.JSON, nil, nil, "")
 	if err == nil {
 		t.Errorf("Expected an err but got no err")
 	}

--- a/rpc/api/personal.go
+++ b/rpc/api/personal.go
@@ -98,9 +98,22 @@ func (self *personalApi) NewAccount(req *shared.Request) (interface{}, error) {
 	if err := self.codec.Decode(req.Params, &args); err != nil {
 		return nil, shared.NewDecodeParamError(err.Error())
 	}
-
+	var passwd string
+	if args.Passphrase == nil {
+		fe := self.xeth.Frontend()
+		if fe == nil {
+			return false, fmt.Errorf("unable to create account: unable to interact with user")
+		}
+		var ok bool
+		passwd, ok = fe.AskPassword()
+		if !ok {
+			return false, fmt.Errorf("unable to create account: no password given")
+		}
+	} else {
+		passwd = *args.Passphrase
+	}
 	am := self.ethereum.AccountManager()
-	acc, err := am.NewAccount(args.Passphrase)
+	acc, err := am.NewAccount(passwd)
 	return acc.Address.Hex(), err
 }
 

--- a/rpc/api/personal_args.go
+++ b/rpc/api/personal_args.go
@@ -23,7 +23,7 @@ import (
 )
 
 type NewAccountArgs struct {
-	Passphrase string
+	Passphrase *string
 }
 
 func (args *NewAccountArgs) UnmarshalJSON(b []byte) (err error) {
@@ -32,16 +32,15 @@ func (args *NewAccountArgs) UnmarshalJSON(b []byte) (err error) {
 		return shared.NewDecodeParamError(err.Error())
 	}
 
-	if len(obj) < 1 {
-		return shared.NewInsufficientParamsError(len(obj), 1)
+	if len(obj) >= 1 && obj[0] != nil {
+		if passphrasestr, ok := obj[0].(string); ok {
+			args.Passphrase = &passphrasestr
+		} else {
+			return shared.NewInvalidTypeError("passphrase", "not a string")
+		}
 	}
 
-	if passhrase, ok := obj[0].(string); ok {
-		args.Passphrase = passhrase
-		return nil
-	}
-
-	return shared.NewInvalidTypeError("passhrase", "not a string")
+	return nil
 }
 
 type UnlockAccountArgs struct {

--- a/rpc/api/utils.go
+++ b/rpc/api/utils.go
@@ -33,14 +33,21 @@ var (
 		"admin": []string{
 			"addPeer",
 			"datadir",
+			"enableUserAgent",
 			"exportChain",
 			"getContractInfo",
+			"httpGet",
 			"importChain",
 			"nodeInfo",
 			"peers",
 			"register",
 			"registerUrl",
+			"saveInfo",
+			"setGlobalRegistrar",
+			"setHashReg",
+			"setUrlHint",
 			"setSolc",
+			"sleep",
 			"sleepBlocks",
 			"startNatSpec",
 			"startRPC",
@@ -146,7 +153,7 @@ var (
 )
 
 // Parse a comma separated API string to individual api's
-func ParseApiString(apistr string, codec codec.Codec, xeth *xeth.XEth, eth *eth.Ethereum) ([]shared.EthereumApi, error) {
+func ParseApiString(apistr string, codec codec.Codec, xeth *xeth.XEth, eth *eth.Ethereum, docRoot string) ([]shared.EthereumApi, error) {
 	if len(strings.TrimSpace(apistr)) == 0 {
 		return nil, fmt.Errorf("Empty apistr provided")
 	}
@@ -157,7 +164,7 @@ func ParseApiString(apistr string, codec codec.Codec, xeth *xeth.XEth, eth *eth.
 	for i, name := range names {
 		switch strings.ToLower(strings.TrimSpace(name)) {
 		case shared.AdminApiName:
-			apis[i] = NewAdminApi(xeth, eth, codec)
+			apis[i] = NewAdminApi(xeth, eth, codec, docRoot)
 		case shared.DebugApiName:
 			apis[i] = NewDebugApi(xeth, eth, codec)
 		case shared.DbApiName:

--- a/rpc/jeth.go
+++ b/rpc/jeth.go
@@ -158,11 +158,11 @@ func (self *Jeth) askPassword(id interface{}, jsonrpc string, args []interface{}
 	if len(args) >= 1 {
 		if account, ok := args[0].(string); ok {
 			fmt.Printf("Unlock account %s\n", account)
-			passwd, err = utils.PromptPassword("Passphrase: ", true)
 		} else {
 			return false
 		}
 	}
+	passwd, err = utils.PromptPassword("Passphrase: ", true)
 
 	if err = self.client.Send(shared.NewRpcResponse(id, jsonrpc, passwd, err)); err != nil {
 		glog.V(logger.Info).Infof("Unable to send user agent ask password response - %v\n", err)

--- a/rpc/useragent/remote_frontend.go
+++ b/rpc/useragent/remote_frontend.go
@@ -49,6 +49,31 @@ func (fe *RemoteFrontend) Enable() {
 	fe.enabled = true
 }
 
+func (fe *RemoteFrontend) AskPassword() (string, bool) {
+	if !fe.enabled {
+		return "", false
+	}
+
+	err := fe.send(AskPasswordMethod)
+	if err != nil {
+		glog.V(logger.Error).Infof("Unable to send password request to agent - %v\n", err)
+		return "", false
+	}
+
+	passwdRes, err := fe.recv()
+	if err != nil {
+		glog.V(logger.Error).Infof("Unable to recv password response from agent - %v\n", err)
+		return "", false
+	}
+
+	if passwd, ok := passwdRes.Result.(string); ok {
+		return passwd, true
+	}
+
+	return "", false
+
+}
+
 // UnlockAccount asks the user agent for the user password and tries to unlock the account.
 // It will try 3 attempts before giving up.
 func (fe *RemoteFrontend) UnlockAccount(address []byte) bool {

--- a/xeth/frontend.go
+++ b/xeth/frontend.go
@@ -19,6 +19,9 @@ package xeth
 // Frontend should be implemented by users of XEth. Its methods are
 // called whenever XEth makes a decision that requires user input.
 type Frontend interface {
+	// AskPassword is called when a new account is created or updated
+	AskPassword() (string, bool)
+
 	// UnlockAccount is called when a transaction needs to be signed
 	// but the key corresponding to the transaction's sender is
 	// locked.
@@ -40,5 +43,6 @@ type Frontend interface {
 // transactions but cannot not unlock any keys.
 type dummyFrontend struct{}
 
+func (dummyFrontend) AskPassword() (string, bool)    { return "", false }
 func (dummyFrontend) UnlockAccount([]byte) bool      { return false }
 func (dummyFrontend) ConfirmTransaction(string) bool { return true }


### PR DESCRIPTION
This PR addresses several minor bugs, regressions, inconsistencies relating to geth UI including console, cli, rpc api
* [x] console: bash history behaviour: lines with leading space are ommitted from history. fixes #1697
* [x] console: exit processed even with whitespace around
* [x] console: all whitespace lines (not only empty ones) are ignored
* [x] registrar: methods now return proper error if reg addresses are not set + tests. fixes #1457
* [x] registrar: fix major regression: deploy registrars, register HashsReg and UrlHint in GlobalRegistrar. set all 3 contract addresses in code
* [x] rpc/console: fix major [unreported] regression. Now all comms accept interactive password for personal.newAccount() 
* [x] rpc/console: fix regression with docRoot / admin API (natspec example on wiki)
* [x] cli/accounts: unlock multiple accounts (with inline passwdfile). fixes #1785 
* [x] crypto (CLI): catch AES decryption error on presale wallet import + fix error msg format. fixes #1580
* [x]  CLI: improve error message when starting a second instance of geth. fixes #1564 
* [x] common/natspec: fix end to end test 
* [x] common/docserver: catch http errors from response 


