### PR TITLE
core: fix #1848, block receipts db entry for the genesis too

### DIFF
--- a/core/genesis.go
+++ b/core/genesis.go
@@ -100,6 +100,9 @@ func WriteGenesisBlock(chainDb ethdb.Database, reader io.Reader) (*types.Block, 
 	if err := WriteBlock(chainDb, block); err != nil {
 		return nil, err
 	}
+	if err := PutBlockReceipts(chainDb, block, nil); err != nil {
+		return nil, err
+	}
 	if err := WriteCanonicalHash(chainDb, block.Hash(), block.NumberU64()); err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This PR simply ensures that the genesis block also contains a valid block receipts database entry. Note, this is really a cosmetics thing that is used only in the tests so that there is no special case for when a block is the genesis or not. In no real world scenario should a node really look up the receipts of the genesis block, so there's no real need for a database upgrade to patch it. Imho.

EDIT: Although I didn't add a test for this, the updated GetReceipts test in the eth package will catch this issue, but it requires a few more fixes so I don't want to do unrelated commits here.