### PR TITLE
core: fix a formatting loop in BadHashError

### DIFF
--- a/core/error.go
+++ b/core/error.go
@@ -181,7 +181,7 @@ func IsValueTransferErr(e error) bool {
 type BadHashError common.Hash
 
 func (h BadHashError) Error() string {
-	return fmt.Sprintf("Found known bad hash in chain %x", h)
+	return fmt.Sprintf("Found known bad hash in chain %x", h[:])
 }
 
 func IsBadHashError(err error) bool {


### PR DESCRIPTION
Formatting oneself results in an infinite loop in the `fmt` package ([repro](http://play.golang.org/p/BuPEqTkzjq)).