### PR TITLE
common: fix #1818, secondary datadir paths to fall back to

### DIFF
--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -390,7 +390,7 @@ func makeDefaultExtra() []byte {
 }
 
 func run(ctx *cli.Context) {
-	utils.CheckLegalese(ctx.GlobalString(utils.DataDirFlag.Name))
+	utils.CheckLegalese(utils.MustDataDir(ctx))
 	if ctx.GlobalBool(utils.OlympicFlag.Name) {
 		utils.InitOlympic()
 	}
@@ -409,7 +409,7 @@ func run(ctx *cli.Context) {
 }
 
 func attach(ctx *cli.Context) {
-	utils.CheckLegalese(ctx.GlobalString(utils.DataDirFlag.Name))
+	utils.CheckLegalese(utils.MustDataDir(ctx))
 
 	var client comms.EthereumClient
 	var err error
@@ -441,7 +441,7 @@ func attach(ctx *cli.Context) {
 }
 
 func console(ctx *cli.Context) {
-	utils.CheckLegalese(ctx.GlobalString(utils.DataDirFlag.Name))
+	utils.CheckLegalese(utils.MustDataDir(ctx))
 
 	cfg := utils.MakeEthConfig(ClientIdentifier, nodeNameVersion, ctx)
 	cfg.ExtraData = makeExtra(ctx)
@@ -475,7 +475,7 @@ func console(ctx *cli.Context) {
 }
 
 func execJSFiles(ctx *cli.Context) {
-	utils.CheckLegalese(ctx.GlobalString(utils.DataDirFlag.Name))
+	utils.CheckLegalese(utils.MustDataDir(ctx))
 
 	cfg := utils.MakeEthConfig(ClientIdentifier, nodeNameVersion, ctx)
 	ethereum, err := eth.New(cfg)
@@ -502,7 +502,7 @@ func execJSFiles(ctx *cli.Context) {
 }
 
 func unlockAccount(ctx *cli.Context, am *accounts.Manager, addr string, i int) (addrHex, auth string) {
-	utils.CheckLegalese(ctx.GlobalString(utils.DataDirFlag.Name))
+	utils.CheckLegalese(utils.MustDataDir(ctx))
 
 	var err error
 	addrHex, err = utils.ParamToAddress(addr, am)
@@ -527,7 +527,7 @@ func unlockAccount(ctx *cli.Context, am *accounts.Manager, addr string, i int) (
 }
 
 func blockRecovery(ctx *cli.Context) {
-	utils.CheckLegalese(ctx.GlobalString(utils.DataDirFlag.Name))
+	utils.CheckLegalese(utils.MustDataDir(ctx))
 
 	arg := ctx.Args().First()
 	if len(ctx.Args()) < 1 && len(arg) > 0 {
@@ -593,7 +593,7 @@ func startEth(ctx *cli.Context, eth *eth.Ethereum) {
 }
 
 func accountList(ctx *cli.Context) {
-	utils.CheckLegalese(ctx.GlobalString(utils.DataDirFlag.Name))
+	utils.CheckLegalese(utils.MustDataDir(ctx))
 
 	am := utils.MakeAccountManager(ctx)
 	accts, err := am.Accounts()
@@ -643,7 +643,7 @@ func getPassPhrase(ctx *cli.Context, desc string, confirmation bool, i int) (pas
 }
 
 func accountCreate(ctx *cli.Context) {
-	utils.CheckLegalese(ctx.GlobalString(utils.DataDirFlag.Name))
+	utils.CheckLegalese(utils.MustDataDir(ctx))
 
 	am := utils.MakeAccountManager(ctx)
 	passphrase := getPassPhrase(ctx, "Your new account is locked with a password. Please give a password. Do not forget this password.", true, 0)
@@ -655,7 +655,7 @@ func accountCreate(ctx *cli.Context) {
 }
 
 func accountUpdate(ctx *cli.Context) {
-	utils.CheckLegalese(ctx.GlobalString(utils.DataDirFlag.Name))
+	utils.CheckLegalese(utils.MustDataDir(ctx))
 
 	am := utils.MakeAccountManager(ctx)
 	arg := ctx.Args().First()
@@ -672,7 +672,7 @@ func accountUpdate(ctx *cli.Context) {
 }
 
 func importWallet(ctx *cli.Context) {
-	utils.CheckLegalese(ctx.GlobalString(utils.DataDirFlag.Name))
+	utils.CheckLegalese(utils.MustDataDir(ctx))
 
 	keyfile := ctx.Args().First()
 	if len(keyfile) == 0 {
@@ -694,7 +694,7 @@ func importWallet(ctx *cli.Context) {
 }
 
 func accountImport(ctx *cli.Context) {
-	utils.CheckLegalese(ctx.GlobalString(utils.DataDirFlag.Name))
+	utils.CheckLegalese(utils.MustDataDir(ctx))
 
 	keyfile := ctx.Args().First()
 	if len(keyfile) == 0 {
@@ -710,7 +710,7 @@ func accountImport(ctx *cli.Context) {
 }
 
 func makedag(ctx *cli.Context) {
-	utils.CheckLegalese(ctx.GlobalString(utils.DataDirFlag.Name))
+	utils.CheckLegalese(utils.MustDataDir(ctx))
 
 	args := ctx.Args()
 	wrongArgs := func() {

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -416,7 +416,7 @@ func MakeEthConfig(clientID, version string, ctx *cli.Context) *eth.Config {
 
 	cfg := &eth.Config{
 		Name:                    common.MakeName(clientID, version),
-		DataDir:                 ctx.GlobalString(DataDirFlag.Name),
+		DataDir:                 MustDataDir(ctx),
 		GenesisNonce:            ctx.GlobalInt(GenesisNonceFlag.Name),
 		GenesisFile:             ctx.GlobalString(GenesisFileFlag.Name),
 		BlockChainVersion:       ctx.GlobalInt(BlockchainVersionFlag.Name),
@@ -509,7 +509,7 @@ func SetupEth(ctx *cli.Context) {
 
 // MakeChain creates a chain manager from set command line flags.
 func MakeChain(ctx *cli.Context) (chain *core.ChainManager, chainDb ethdb.Database) {
-	datadir := ctx.GlobalString(DataDirFlag.Name)
+	datadir := MustDataDir(ctx)
 	cache := ctx.GlobalInt(CacheFlag.Name)
 
 	var err error
@@ -539,9 +539,19 @@ func MakeChain(ctx *cli.Context) (chain *core.ChainManager, chainDb ethdb.Databa
 
 // MakeChain creates an account manager from set command line flags.
 func MakeAccountManager(ctx *cli.Context) *accounts.Manager {
-	dataDir := ctx.GlobalString(DataDirFlag.Name)
+	dataDir := MustDataDir(ctx)
 	ks := crypto.NewKeyStorePassphrase(filepath.Join(dataDir, "keystore"))
 	return accounts.NewManager(ks)
+}
+
+// MustDataDir retrieves the currently requested data directory, terminating if
+// none (or the empty string) is specified.
+func MustDataDir(ctx *cli.Context) string {
+	if path := ctx.GlobalString(DataDirFlag.Name); path != "" {
+		return path
+	}
+	Fatalf("Cannot determine default data directory, please set manually (--datadir)")
+	return ""
 }
 
 func IpcSocketPath(ctx *cli.Context) (ipcpath string) {

--- a/common/path.go
+++ b/common/path.go
@@ -100,14 +100,24 @@ func DefaultAssetPath() string {
 }
 
 func DefaultDataDir() string {
-	usr, _ := user.Current()
-	if runtime.GOOS == "darwin" {
-		return filepath.Join(usr.HomeDir, "Library", "Ethereum")
-	} else if runtime.GOOS == "windows" {
-		return filepath.Join(usr.HomeDir, "AppData", "Roaming", "Ethereum")
+	// Try to place the data folder in the user's home dir
+	var home string
+	if usr, err := user.Current(); err == nil {
+		home = usr.HomeDir
 	} else {
-		return filepath.Join(usr.HomeDir, ".ethereum")
+		home = os.Getenv("HOME")
 	}
+	if home != "" {
+		if runtime.GOOS == "darwin" {
+			return filepath.Join(home, "Library", "Ethereum")
+		} else if runtime.GOOS == "windows" {
+			return filepath.Join(home, "AppData", "Roaming", "Ethereum")
+		} else {
+			return filepath.Join(home, ".ethereum")
+		}
+	}
+	// As we cannot guess a stable location, return empty and handle later
+	return ""
 }
 
 func DefaultIpcPath() string {


### PR DESCRIPTION
This PR fixes an issue in Fedora and Android where the current user cannot be retrieved on certain platforms (Actually, the fix is more generic). If the user cannot be accessed, the default data dir uses a workspace in the current working folder. If that also cannot be retrieved, it defaults to an empty folder, leaving it to the user to sort it out manually via CLI flags (still better than crashing).