### PR TITLE
core: differentiate receipt concensus and storage decoding

### DIFF
--- a/core/block_processor.go
+++ b/core/block_processor.go
@@ -112,7 +112,7 @@ func (self *BlockProcessor) ApplyTransaction(gp GasPool, statedb *state.StateDB,
 	}
 
 	logs := statedb.GetLogs(tx.Hash())
-	receipt.SetLogs(logs)
+	receipt.Logs = logs
 	receipt.Bloom = types.CreateBloom(types.Receipts{receipt})
 
 	glog.V(logger.Debug).Infoln(receipt)
@@ -362,7 +362,7 @@ func (sm *BlockProcessor) GetLogs(block *types.Block) (logs state.Logs, err erro
 	receipts := GetBlockReceipts(sm.chainDb, block.Hash())
 	// coalesce logs
 	for _, receipt := range receipts {
-		logs = append(logs, receipt.Logs()...)
+		logs = append(logs, receipt.Logs...)
 	}
 	return logs, nil
 }

--- a/core/block_processor_test.go
+++ b/core/block_processor_test.go
@@ -69,7 +69,7 @@ func TestPutReceipt(t *testing.T) {
 	hash[0] = 2
 
 	receipt := new(types.Receipt)
-	receipt.SetLogs(state.Logs{&state.Log{
+	receipt.Logs = state.Logs{&state.Log{
 		Address:   addr,
 		Topics:    []common.Hash{hash},
 		Data:      []byte("hi"),
@@ -78,7 +78,7 @@ func TestPutReceipt(t *testing.T) {
 		TxIndex:   0,
 		BlockHash: hash,
 		Index:     0,
-	}})
+	}}
 
 	PutReceipts(db, types.Receipts{receipt})
 	receipt = GetReceipt(db, common.Hash{})

--- a/core/chain_makers.go
+++ b/core/chain_makers.go
@@ -98,7 +98,7 @@ func (b *BlockGen) AddTx(tx *types.Transaction) {
 	b.header.GasUsed.Add(b.header.GasUsed, gas)
 	receipt := types.NewReceipt(b.statedb.Root().Bytes(), b.header.GasUsed)
 	logs := b.statedb.GetLogs(tx.Hash())
-	receipt.SetLogs(logs)
+	receipt.Logs = logs
 	receipt.Bloom = types.CreateBloom(types.Receipts{receipt})
 	b.txs = append(b.txs, tx)
 	b.receipts = append(b.receipts, receipt)

--- a/core/state/log.go
+++ b/core/state/log.go
@@ -40,27 +40,30 @@ func NewLog(address common.Address, topics []common.Hash, data []byte, number ui
 	return &Log{Address: address, Topics: topics, Data: data, Number: number}
 }
 
-func (self *Log) EncodeRLP(w io.Writer) error {
-	return rlp.Encode(w, []interface{}{self.Address, self.Topics, self.Data})
+func (l *Log) EncodeRLP(w io.Writer) error {
+	return rlp.Encode(w, []interface{}{l.Address, l.Topics, l.Data})
 }
 
-func (self *Log) String() string {
-	return fmt.Sprintf(`log: %x %x %x %x %d %x %d`, self.Address, self.Topics, self.Data, self.TxHash, self.TxIndex, self.BlockHash, self.Index)
+func (l *Log) DecodeRLP(s *rlp.Stream) error {
+	var log struct {
+		Address common.Address
+		Topics  []common.Hash
+		Data    []byte
+	}
+	if err := s.Decode(&log); err != nil {
+		return err
+	}
+	l.Address, l.Topics, l.Data = log.Address, log.Topics, log.Data
+	return nil
+}
+
+func (l *Log) String() string {
+	return fmt.Sprintf(`log: %x %x %x %x %d %x %d`, l.Address, l.Topics, l.Data, l.TxHash, l.TxIndex, l.BlockHash, l.Index)
 }
 
 type Logs []*Log
 
+// LogForStorage is a wrapper around a Log that flattens and parses the entire
+// content of a log, opposed to only the consensus fields originally (by hiding
+// the rlp interface methods).
 type LogForStorage Log
-
-func (self *LogForStorage) EncodeRLP(w io.Writer) error {
-	return rlp.Encode(w, []interface{}{
-		self.Address,
-		self.Topics,
-		self.Data,
-		self.Number,
-		self.TxHash,
-		self.TxIndex,
-		self.BlockHash,
-		self.Index,
-	})
-}

--- a/core/transaction_util.go
+++ b/core/transaction_util.go
@@ -150,11 +150,14 @@ func GetBlockReceipts(db ethdb.Database, hash common.Hash) types.Receipts {
 	if len(data) == 0 {
 		return nil
 	}
-
-	var receipts types.Receipts
-	err := rlp.DecodeBytes(data, &receipts)
-	if err != nil {
-		glog.V(logger.Core).Infoln("GetReceiptse err", err)
+	rs := []*types.ReceiptForStorage{}
+	if err := rlp.DecodeBytes(data, &rs); err != nil {
+		glog.V(logger.Error).Infof("invalid receipt array RLP for hash %x: %v", hash, err)
+		return nil
+	}
+	receipts := make(types.Receipts, len(rs))
+	for i, receipt := range rs {
+		receipts[i] = (*types.Receipt)(receipt)
 	}
 	return receipts
 }

--- a/core/types/bloom9.go
+++ b/core/types/bloom9.go
@@ -31,7 +31,7 @@ type bytesBacked interface {
 func CreateBloom(receipts Receipts) Bloom {
 	bin := new(big.Int)
 	for _, receipt := range receipts {
-		bin.Or(bin, LogsBloom(receipt.logs))
+		bin.Or(bin, LogsBloom(receipt.Logs))
 	}
 
 	return BytesToBloom(bin.Bytes())

--- a/core/types/receipt.go
+++ b/core/types/receipt.go
@@ -17,7 +17,6 @@
 package types
 
 import (
-	"bytes"
 	"fmt"
 	"io"
 	"math/big"
@@ -27,89 +26,116 @@ import (
 	"github.com/ethereum/go-ethereum/rlp"
 )
 
+// Receipt represents the results of a transaction.
 type Receipt struct {
+	// Consensus fields
 	PostState         []byte
 	CumulativeGasUsed *big.Int
 	Bloom             Bloom
-	TxHash            common.Hash
-	ContractAddress   common.Address
-	logs              state.Logs
-	GasUsed           *big.Int
+	Logs              state.Logs
+
+	// Implementation fields
+	TxHash          common.Hash
+	ContractAddress common.Address
+	GasUsed         *big.Int
 }
 
+// NewReceipt creates a barebone transaction receipt, copying the init fields.
 func NewReceipt(root []byte, cumalativeGasUsed *big.Int) *Receipt {
 	return &Receipt{PostState: common.CopyBytes(root), CumulativeGasUsed: new(big.Int).Set(cumalativeGasUsed)}
 }
 
-func (self *Receipt) SetLogs(logs state.Logs) {
-	self.logs = logs
+// EncodeRLP implements rlp.Encoder, and flattens the consensus fields of a receipt
+// into an RLP stream.
+func (r *Receipt) EncodeRLP(w io.Writer) error {
+	return rlp.Encode(w, []interface{}{r.PostState, r.CumulativeGasUsed, r.Bloom, r.Logs})
 }
 
-func (self *Receipt) Logs() state.Logs {
-	return self.logs
+// DecodeRLP implements rlp.Decoder, and loads the consensus fields of a receipt
+// from an RLP stream.
+func (r *Receipt) DecodeRLP(s *rlp.Stream) error {
+	var receipt struct {
+		PostState         []byte
+		CumulativeGasUsed *big.Int
+		Bloom             Bloom
+		Logs              state.Logs
+	}
+	if err := s.Decode(&receipt); err != nil {
+		return err
+	}
+	r.PostState, r.CumulativeGasUsed, r.Bloom, r.Logs = receipt.PostState, receipt.CumulativeGasUsed, receipt.Bloom, receipt.Logs
+	return nil
 }
 
-func (self *Receipt) EncodeRLP(w io.Writer) error {
-	return rlp.Encode(w, []interface{}{self.PostState, self.CumulativeGasUsed, self.Bloom, self.logs})
+// RlpEncode implements common.RlpEncode required for SHA derivation.
+func (r *Receipt) RlpEncode() []byte {
+	bytes, err := rlp.EncodeToBytes(r)
+	if err != nil {
+		panic(err)
+	}
+	return bytes
 }
 
-func (self *Receipt) DecodeRLP(s *rlp.Stream) error {
-	var r struct {
+// String implements the Stringer interface.
+func (r *Receipt) String() string {
+	return fmt.Sprintf("receipt{med=%x cgas=%v bloom=%x logs=%v}", r.PostState, r.CumulativeGasUsed, r.Bloom, r.Logs)
+}
+
+// ReceiptForStorage is a wrapper around a Receipt that flattens and parses the
+// entire content of a receipt, opposed to only the consensus fields originally.
+type ReceiptForStorage Receipt
+
+// EncodeRLP implements rlp.Encoder, and flattens all content fields of a receipt
+// into an RLP stream.
+func (r *ReceiptForStorage) EncodeRLP(w io.Writer) error {
+	logs := make([]*state.LogForStorage, len(r.Logs))
+	for i, log := range r.Logs {
+		logs[i] = (*state.LogForStorage)(log)
+	}
+	return rlp.Encode(w, []interface{}{r.PostState, r.CumulativeGasUsed, r.Bloom, r.TxHash, r.ContractAddress, logs, r.GasUsed})
+}
+
+// DecodeRLP implements rlp.Decoder, and loads the consensus fields of a receipt
+// from an RLP stream.
+func (r *ReceiptForStorage) DecodeRLP(s *rlp.Stream) error {
+	var receipt struct {
 		PostState         []byte
 		CumulativeGasUsed *big.Int
 		Bloom             Bloom
 		TxHash            common.Hash
 		ContractAddress   common.Address
-		Logs              state.Logs
+		Logs              []*state.LogForStorage
 		GasUsed           *big.Int
 	}
-	if err := s.Decode(&r); err != nil {
+	if err := s.Decode(&receipt); err != nil {
 		return err
 	}
-	self.PostState, self.CumulativeGasUsed, self.Bloom, self.TxHash, self.ContractAddress, self.logs, self.GasUsed = r.PostState, r.CumulativeGasUsed, r.Bloom, r.TxHash, r.ContractAddress, r.Logs, r.GasUsed
+	// Assign the consensus fields
+	r.PostState, r.CumulativeGasUsed, r.Bloom = receipt.PostState, receipt.CumulativeGasUsed, receipt.Bloom
+	r.Logs = make(state.Logs, len(receipt.Logs))
+	for i, log := range receipt.Logs {
+		r.Logs[i] = (*state.Log)(log)
+	}
+	// Assign the implementation fields
+	r.TxHash, r.ContractAddress, r.GasUsed = receipt.TxHash, receipt.ContractAddress, receipt.GasUsed
 
 	return nil
 }
 
-type ReceiptForStorage Receipt
-
-func (self *ReceiptForStorage) EncodeRLP(w io.Writer) error {
-	storageLogs := make([]*state.LogForStorage, len(self.logs))
-	for i, log := range self.logs {
-		storageLogs[i] = (*state.LogForStorage)(log)
-	}
-	return rlp.Encode(w, []interface{}{self.PostState, self.CumulativeGasUsed, self.Bloom, self.TxHash, self.ContractAddress, storageLogs, self.GasUsed})
-}
-
-func (self *Receipt) RlpEncode() []byte {
-	bytes, err := rlp.EncodeToBytes(self)
-	if err != nil {
-		fmt.Println("TMP -- RECEIPT ENCODE ERROR", err)
-	}
-	return bytes
-}
-
-func (self *Receipt) Cmp(other *Receipt) bool {
-	if bytes.Compare(self.PostState, other.PostState) != 0 {
-		return false
-	}
-
-	return true
-}
-
-func (self *Receipt) String() string {
-	return fmt.Sprintf("receipt{med=%x cgas=%v bloom=%x logs=%v}", self.PostState, self.CumulativeGasUsed, self.Bloom, self.logs)
-}
-
+// Receipts is a wrapper around a Receipt array to implement types.DerivableList.
 type Receipts []*Receipt
 
-func (self Receipts) RlpEncode() []byte {
-	bytes, err := rlp.EncodeToBytes(self)
+// RlpEncode implements common.RlpEncode required for SHA derivation.
+func (r Receipts) RlpEncode() []byte {
+	bytes, err := rlp.EncodeToBytes(r)
 	if err != nil {
-		fmt.Println("TMP -- RECEIPTS ENCODE ERROR", err)
+		panic(err)
 	}
 	return bytes
 }
 
-func (self Receipts) Len() int            { return len(self) }
-func (self Receipts) GetRlp(i int) []byte { return common.Rlp(self[i]) }
+// Len returns the number of receipts in this list.
+func (r Receipts) Len() int { return len(r) }
+
+// GetRlp returns the RLP encoding of one receipt from the list.
+func (r Receipts) GetRlp(i int) []byte { return common.Rlp(r[i]) }

--- a/rpc/api/parsing.go
+++ b/rpc/api/parsing.go
@@ -453,8 +453,8 @@ func NewReceiptRes(rec *types.Receipt) *ReceiptRes {
 		v.ContractAddress = newHexData(rec.ContractAddress)
 	}
 
-	logs := make([]interface{}, len(rec.Logs()))
-	for i, log := range rec.Logs() {
+	logs := make([]interface{}, len(rec.Logs))
+	for i, log := range rec.Logs {
 		logs[i] = NewLogRes(log)
 	}
 	v.Logs = &logs


### PR DESCRIPTION
This PR contains the necessary modifications to make Receipts and Logs transferable over the network. Previously the decoders always expected a full storage version, which obviously won't happen over the network, so we need to explicitly decode database contents as storage receipts/logs, and leave the plain receipts/logs to decode as only the consensus fields.