### PR TITLE
crypto, crypto/secp256k1: use libsecp256k1 for scalar multiplication

### DIFF
--- a/crypto/crypto.go
+++ b/crypto/crypto.go
@@ -43,14 +43,6 @@ import (
 	"golang.org/x/crypto/ripemd160"
 )
 
-var secp256k1n *big.Int
-
-func init() {
-	// specify the params for the s256 curve
-	ecies.AddParamsForCurve(S256(), ecies.ECIES_AES128_SHA256)
-	secp256k1n = common.String2Big("0xfffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364141")
-}
-
 func Sha3(data ...[]byte) []byte {
 	d := sha3.NewKeccak256()
 	for _, b := range data {
@@ -99,9 +91,9 @@ func ToECDSA(prv []byte) *ecdsa.PrivateKey {
 	}
 
 	priv := new(ecdsa.PrivateKey)
-	priv.PublicKey.Curve = S256()
+	priv.PublicKey.Curve = secp256k1.S256()
 	priv.D = common.BigD(prv)
-	priv.PublicKey.X, priv.PublicKey.Y = S256().ScalarBaseMult(prv)
+	priv.PublicKey.X, priv.PublicKey.Y = secp256k1.S256().ScalarBaseMult(prv)
 	return priv
 }
 
@@ -116,15 +108,15 @@ func ToECDSAPub(pub []byte) *ecdsa.PublicKey {
 	if len(pub) == 0 {
 		return nil
 	}
-	x, y := elliptic.Unmarshal(S256(), pub)
-	return &ecdsa.PublicKey{S256(), x, y}
+	x, y := elliptic.Unmarshal(secp256k1.S256(), pub)
+	return &ecdsa.PublicKey{secp256k1.S256(), x, y}
 }
 
 func FromECDSAPub(pub *ecdsa.PublicKey) []byte {
 	if pub == nil || pub.X == nil || pub.Y == nil {
 		return nil
 	}
-	return elliptic.Marshal(S256(), pub.X, pub.Y)
+	return elliptic.Marshal(secp256k1.S256(), pub.X, pub.Y)
 }
 
 // HexToECDSA parses a secp256k1 private key.
@@ -168,7 +160,7 @@ func SaveECDSA(file string, key *ecdsa.PrivateKey) error {
 }
 
 func GenerateKey() (*ecdsa.PrivateKey, error) {
-	return ecdsa.GenerateKey(S256(), rand.Reader)
+	return ecdsa.GenerateKey(secp256k1.S256(), rand.Reader)
 }
 
 func ValidateSignatureValues(v byte, r, s *big.Int) bool {
@@ -176,7 +168,7 @@ func ValidateSignatureValues(v byte, r, s *big.Int) bool {
 		return false
 	}
 	vint := uint32(v)
-	if r.Cmp(secp256k1n) < 0 && s.Cmp(secp256k1n) < 0 && (vint == 27 || vint == 28) {
+	if r.Cmp(secp256k1.N) < 0 && s.Cmp(secp256k1.N) < 0 && (vint == 27 || vint == 28) {
 		return true
 	} else {
 		return false
@@ -189,8 +181,8 @@ func SigToPub(hash, sig []byte) (*ecdsa.PublicKey, error) {
 		return nil, err
 	}
 
-	x, y := elliptic.Unmarshal(S256(), s)
-	return &ecdsa.PublicKey{S256(), x, y}, nil
+	x, y := elliptic.Unmarshal(secp256k1.S256(), s)
+	return &ecdsa.PublicKey{secp256k1.S256(), x, y}, nil
 }
 
 func Sign(hash []byte, prv *ecdsa.PrivateKey) (sig []byte, err error) {

--- a/crypto/crypto_test.go
+++ b/crypto/crypto_test.go
@@ -181,7 +181,7 @@ func TestValidateSignatureValues(t *testing.T) {
 	minusOne := big.NewInt(-1)
 	one := common.Big1
 	zero := common.Big0
-	secp256k1nMinus1 := new(big.Int).Sub(secp256k1n, common.Big1)
+	secp256k1nMinus1 := new(big.Int).Sub(secp256k1.N, common.Big1)
 
 	// correct v,r,s
 	check(true, 27, one, one)
@@ -208,9 +208,9 @@ func TestValidateSignatureValues(t *testing.T) {
 	// correct sig with max r,s
 	check(true, 27, secp256k1nMinus1, secp256k1nMinus1)
 	// correct v, combinations of incorrect r,s at upper limit
-	check(false, 27, secp256k1n, secp256k1nMinus1)
-	check(false, 27, secp256k1nMinus1, secp256k1n)
-	check(false, 27, secp256k1n, secp256k1n)
+	check(false, 27, secp256k1.N, secp256k1nMinus1)
+	check(false, 27, secp256k1nMinus1, secp256k1.N)
+	check(false, 27, secp256k1.N, secp256k1.N)
 
 	// current callers ensures r,s cannot be negative, but let's test for that too
 	// as crypto package could be used stand-alone

--- a/crypto/ecies/asn1.go
+++ b/crypto/ecies/asn1.go
@@ -41,6 +41,8 @@ import (
 	"fmt"
 	"hash"
 	"math/big"
+
+	"github.com/ethereum/go-ethereum/crypto/secp256k1"
 )
 
 var (
@@ -81,6 +83,7 @@ func doScheme(base, v []int) asn1.ObjectIdentifier {
 type secgNamedCurve asn1.ObjectIdentifier
 
 var (
+	secgNamedCurveS256 = secgNamedCurve{1, 3, 132, 0, 10}
 	secgNamedCurveP256 = secgNamedCurve{1, 2, 840, 10045, 3, 1, 7}
 	secgNamedCurveP384 = secgNamedCurve{1, 3, 132, 0, 34}
 	secgNamedCurveP521 = secgNamedCurve{1, 3, 132, 0, 35}
@@ -116,6 +119,8 @@ func (curve secgNamedCurve) Equal(curve2 secgNamedCurve) bool {
 
 func namedCurveFromOID(curve secgNamedCurve) elliptic.Curve {
 	switch {
+	case curve.Equal(secgNamedCurveS256):
+		return secp256k1.S256()
 	case curve.Equal(secgNamedCurveP256):
 		return elliptic.P256()
 	case curve.Equal(secgNamedCurveP384):
@@ -134,6 +139,8 @@ func oidFromNamedCurve(curve elliptic.Curve) (secgNamedCurve, bool) {
 		return secgNamedCurveP384, true
 	case elliptic.P521():
 		return secgNamedCurveP521, true
+	case secp256k1.S256():
+		return secgNamedCurveS256, true
 	}
 
 	return nil, false

--- a/crypto/ecies/ecies.go
+++ b/crypto/ecies/ecies.go
@@ -125,6 +125,7 @@ func (prv *PrivateKey) GenerateShared(pub *PublicKey, skLen, macLen int) (sk []b
 	if skLen+macLen > MaxSharedKeyLength(pub) {
 		return nil, ErrSharedKeyTooBig
 	}
+
 	x, _ := pub.Curve.ScalarMult(pub.X, pub.Y, prv.D.Bytes())
 	if x == nil {
 		return nil, ErrSharedKeyIsPointAtInfinity

--- a/crypto/ecies/params.go
+++ b/crypto/ecies/params.go
@@ -41,13 +41,12 @@ import (
 	"crypto/sha512"
 	"fmt"
 	"hash"
+
+	"github.com/ethereum/go-ethereum/crypto/secp256k1"
 )
 
-// The default curve for this package is the NIST P256 curve, which
-// provides security equivalent to AES-128.
-var DefaultCurve = elliptic.P256()
-
 var (
+	DefaultCurve                  = secp256k1.S256()
 	ErrUnsupportedECDHAlgorithm   = fmt.Errorf("ecies: unsupported ECDH algorithm")
 	ErrUnsupportedECIESParameters = fmt.Errorf("ecies: unsupported ECIES parameters")
 )
@@ -101,9 +100,10 @@ var (
 )
 
 var paramsFromCurve = map[elliptic.Curve]*ECIESParams{
-	elliptic.P256(): ECIES_AES128_SHA256,
-	elliptic.P384(): ECIES_AES256_SHA384,
-	elliptic.P521(): ECIES_AES256_SHA512,
+	secp256k1.S256(): ECIES_AES128_SHA256,
+	elliptic.P256():  ECIES_AES128_SHA256,
+	elliptic.P384():  ECIES_AES256_SHA384,
+	elliptic.P521():  ECIES_AES256_SHA512,
 }
 
 func AddParamsForCurve(curve elliptic.Curve, params *ECIESParams) {

--- a/crypto/key.go
+++ b/crypto/key.go
@@ -25,6 +25,7 @@ import (
 	"strings"
 
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/crypto/secp256k1"
 	"github.com/pborman/uuid"
 )
 
@@ -137,7 +138,7 @@ func NewKey(rand io.Reader) *Key {
 		panic("key generation: could not read from random source: " + err.Error())
 	}
 	reader := bytes.NewReader(randBytes)
-	privateKeyECDSA, err := ecdsa.GenerateKey(S256(), reader)
+	privateKeyECDSA, err := ecdsa.GenerateKey(secp256k1.S256(), reader)
 	if err != nil {
 		panic("key generation: ecdsa.GenerateKey failed: " + err.Error())
 	}
@@ -155,7 +156,7 @@ func NewKeyForDirectICAP(rand io.Reader) *Key {
 		panic("key generation: could not read from random source: " + err.Error())
 	}
 	reader := bytes.NewReader(randBytes)
-	privateKeyECDSA, err := ecdsa.GenerateKey(S256(), reader)
+	privateKeyECDSA, err := ecdsa.GenerateKey(secp256k1.S256(), reader)
 	if err != nil {
 		panic("key generation: ecdsa.GenerateKey failed: " + err.Error())
 	}

--- a/crypto/secp256k1/curve_test.go
+++ b/crypto/secp256k1/curve_test.go
@@ -1,0 +1,39 @@
+// Copyright 2015 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+package secp256k1
+
+import (
+	"bytes"
+	"encoding/hex"
+	"math/big"
+	"testing"
+)
+
+func TestReadBits(t *testing.T) {
+	check := func(input string) {
+		want, _ := hex.DecodeString(input)
+		int, _ := new(big.Int).SetString(input, 16)
+		buf := make([]byte, len(want))
+		readBits(buf, int)
+		if !bytes.Equal(buf, want) {
+			t.Errorf("have: %x\nwant: %x", buf, want)
+		}
+	}
+	check("000000000000000000000000000000000000000000000000000000FEFCF3F8F0")
+	check("0000000000012345000000000000000000000000000000000000FEFCF3F8F0")
+	check("18F8F8F1000111000110011100222004330052300000000000000000FEFCF3F8F0")
+}

--- a/crypto/secp256k1/pubkey_scalar_mul.h
+++ b/crypto/secp256k1/pubkey_scalar_mul.h
@@ -1,0 +1,56 @@
+// Copyright 2015 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+/** Multiply point by scalar in constant time.
+ *  Returns: 1: multiplication was successful
+ *           0: scalar was invalid (zero or overflow)
+ *  Args:    ctx:      pointer to a context object (cannot be NULL)
+ *  Out:     point:    the multiplied point (usually secret)
+ *  In:      point:    pointer to a 64-byte bytepublic point,
+                       encoded as two 256bit big-endian numbers.
+ *           scalar:   a 32-byte scalar with which to multiply the point
+ */
+int secp256k1_pubkey_scalar_mul(const secp256k1_context* ctx, unsigned char *point, const unsigned char *scalar) {
+    int ret = 0;
+    int overflow = 0;
+    secp256k1_fe feX, feY;
+    secp256k1_gej res;
+    secp256k1_ge ge;
+    secp256k1_scalar s;
+    ARG_CHECK(point != NULL);
+    ARG_CHECK(scalar != NULL);
+    (void)ctx;
+
+    secp256k1_fe_set_b32(&feX, point);
+    secp256k1_fe_set_b32(&feY, point+32);
+    secp256k1_ge_set_xy(&ge, &feX, &feY);
+    secp256k1_scalar_set_b32(&s, scalar, &overflow);
+    if (overflow || secp256k1_scalar_is_zero(&s)) {
+        ret = 0;
+    } else {
+        secp256k1_ecmult_const(&res, &ge, &s);
+        secp256k1_ge_set_gej(&ge, &res);
+        /* Note: can't use secp256k1_pubkey_save here because it is not constant time. */
+        secp256k1_fe_normalize(&ge.x);
+        secp256k1_fe_normalize(&ge.y);
+        secp256k1_fe_get_b32(point, &ge.x);
+        secp256k1_fe_get_b32(point+32, &ge.y);
+        ret = 1;
+    }
+    secp256k1_scalar_clear(&s);
+    return ret;
+}
+

--- a/crypto/secp256k1/secp256.go
+++ b/crypto/secp256k1/secp256.go
@@ -96,7 +96,7 @@ func GenerateKeyPair() ([]byte, []byte) {
 
 	var output_len C.size_t
 
-	C.secp256k1_ec_pubkey_serialize( // always returns 1
+	_ = C.secp256k1_ec_pubkey_serialize( // always returns 1
 		context,
 		pubkey65_ptr,
 		&output_len,
@@ -163,7 +163,7 @@ func Sign(msg []byte, seckey []byte) ([]byte, error) {
 	sig_serialized_ptr := (*C.uchar)(unsafe.Pointer(&sig_serialized[0]))
 	var recid C.int
 
-	C.secp256k1_ecdsa_recoverable_signature_serialize_compact(
+	_ = C.secp256k1_ecdsa_recoverable_signature_serialize_compact(
 		context,
 		sig_serialized_ptr, // 64 byte compact signature
 		&recid,

--- a/crypto/secp256k1/secp256.go
+++ b/crypto/secp256k1/secp256.go
@@ -20,6 +20,7 @@ package secp256k1
 
 /*
 #cgo CFLAGS: -I./libsecp256k1
+#cgo CFLAGS: -I./libsecp256k1/src/
 #cgo darwin CFLAGS: -I/usr/local/include
 #cgo freebsd CFLAGS: -I/usr/local/include
 #cgo linux,arm CFLAGS: -I/usr/local/arm/include
@@ -35,6 +36,7 @@ package secp256k1
 #define NDEBUG
 #include "./libsecp256k1/src/secp256k1.c"
 #include "./libsecp256k1/src/modules/recovery/main_impl.h"
+#include "pubkey_scalar_mul.h"
 
 typedef void (*callbackFunc) (const char* msg, void* data);
 extern void secp256k1GoPanicIllegal(const char* msg, void* data);
@@ -44,6 +46,7 @@ import "C"
 
 import (
 	"errors"
+	"math/big"
 	"unsafe"
 
 	"github.com/ethereum/go-ethereum/crypto/randentropy"
@@ -56,13 +59,16 @@ import (
    > store private keys in buffer and shuffle (deters persistance on swap disc)
    > byte permutation (changing)
    > xor with chaning random block (to deter scanning memory for 0x63) (stream cipher?)
-   > on disk: store keys in wallets
 */
 
 // holds ptr to secp256k1_context_struct (see secp256k1/include/secp256k1.h)
-var context *C.secp256k1_context
+var (
+	context *C.secp256k1_context
+	N       *big.Int
+)
 
 func init() {
+	N, _ = new(big.Int).SetString("fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364141", 16)
 	// around 20 ms on a modern CPU.
 	context = C.secp256k1_context_create(3) // SECP256K1_START_SIGN | SECP256K1_START_VERIFY
 	C.secp256k1_context_set_illegal_callback(context, C.callbackFunc(C.secp256k1GoPanicIllegal), nil)
@@ -78,7 +84,6 @@ var (
 func GenerateKeyPair() ([]byte, []byte) {
 	var seckey []byte = randentropy.GetEntropyCSPRNG(32)
 	var seckey_ptr *C.uchar = (*C.uchar)(unsafe.Pointer(&seckey[0]))
-
 	var pubkey64 []byte = make([]byte, 64) // secp256k1_pubkey
 	var pubkey65 []byte = make([]byte, 65) // 65 byte uncompressed pubkey
 	pubkey64_ptr := (*C.secp256k1_pubkey)(unsafe.Pointer(&pubkey64[0]))
@@ -96,7 +101,7 @@ func GenerateKeyPair() ([]byte, []byte) {
 
 	var output_len C.size_t
 
-	_ = C.secp256k1_ec_pubkey_serialize( // always returns 1
+	C.secp256k1_ec_pubkey_serialize( // always returns 1
 		context,
 		pubkey65_ptr,
 		&output_len,
@@ -163,7 +168,7 @@ func Sign(msg []byte, seckey []byte) ([]byte, error) {
 	sig_serialized_ptr := (*C.uchar)(unsafe.Pointer(&sig_serialized[0]))
 	var recid C.int
 
-	_ = C.secp256k1_ecdsa_recoverable_signature_serialize_compact(
+	C.secp256k1_ecdsa_recoverable_signature_serialize_compact(
 		context,
 		sig_serialized_ptr, // 64 byte compact signature
 		&recid,
@@ -253,4 +258,17 @@ func checkSignature(sig []byte) error {
 		return ErrInvalidRecoveryID
 	}
 	return nil
+}
+
+// reads num into buf as big-endian bytes.
+func readBits(buf []byte, num *big.Int) {
+	const wordLen = int(unsafe.Sizeof(big.Word(0)))
+	i := len(buf)
+	for _, d := range num.Bits() {
+		for j := 0; j < wordLen && i > 0; j++ {
+			i--
+			buf[i] = byte(d)
+			d >>= 8
+		}
+	}
 }

--- a/crypto/secp256k1/secp256_test.go
+++ b/crypto/secp256k1/secp256_test.go
@@ -24,7 +24,7 @@ import (
 	"github.com/ethereum/go-ethereum/crypto/randentropy"
 )
 
-const TestCount = 10000
+const TestCount = 1000
 
 func TestPrivkeyGenerate(t *testing.T) {
 	_, seckey := GenerateKeyPair()

--- a/crypto/secp256k1/secp256_test.go
+++ b/crypto/secp256k1/secp256_test.go
@@ -86,10 +86,7 @@ func TestSignAndRecover(t *testing.T) {
 func TestRandomMessagesWithSameKey(t *testing.T) {
 	pubkey, seckey := GenerateKeyPair()
 	keys := func() ([]byte, []byte) {
-		// Sign function zeroes the privkey so we need a new one in each call
-		newkey := make([]byte, len(seckey))
-		copy(newkey, seckey)
-		return pubkey, newkey
+		return pubkey, seckey
 	}
 	signAndRecoverWithRandomMessages(t, keys)
 }
@@ -209,30 +206,32 @@ func compactSigCheck(t *testing.T, sig []byte) {
 	}
 }
 
-// godep go test -v -run=XXX -bench=BenchmarkSignRandomInputEachRound
+// godep go test -v -run=XXX -bench=BenchmarkSign
 // add -benchtime=10s to benchmark longer for more accurate average
-func BenchmarkSignRandomInputEachRound(b *testing.B) {
+
+// to avoid compiler optimizing the benchmarked function call
+var err error
+
+func BenchmarkSign(b *testing.B) {
 	for i := 0; i < b.N; i++ {
-		b.StopTimer()
 		_, seckey := GenerateKeyPair()
 		msg := randentropy.GetEntropyCSPRNG(32)
 		b.StartTimer()
-		if _, err := Sign(msg, seckey); err != nil {
-			b.Fatal(err)
-		}
+		_, e := Sign(msg, seckey)
+		err = e
+		b.StopTimer()
 	}
 }
 
-//godep go test -v -run=XXX -bench=BenchmarkRecoverRandomInputEachRound
-func BenchmarkRecoverRandomInputEachRound(b *testing.B) {
+//godep go test -v -run=XXX -bench=BenchmarkECRec
+func BenchmarkRecover(b *testing.B) {
 	for i := 0; i < b.N; i++ {
-		b.StopTimer()
 		_, seckey := GenerateKeyPair()
 		msg := randentropy.GetEntropyCSPRNG(32)
 		sig, _ := Sign(msg, seckey)
 		b.StartTimer()
-		if _, err := RecoverPubkey(msg, sig); err != nil {
-			b.Fatal(err)
-		}
+		_, e := RecoverPubkey(msg, sig)
+		err = e
+		b.StopTimer()
 	}
 }

--- a/p2p/discover/node.go
+++ b/p2p/discover/node.go
@@ -210,7 +210,7 @@ func PubkeyID(pub *ecdsa.PublicKey) NodeID {
 // Pubkey returns the public key represented by the node ID.
 // It returns an error if the ID is not a point on the curve.
 func (id NodeID) Pubkey() (*ecdsa.PublicKey, error) {
-	p := &ecdsa.PublicKey{Curve: crypto.S256(), X: new(big.Int), Y: new(big.Int)}
+	p := &ecdsa.PublicKey{Curve: secp256k1.S256(), X: new(big.Int), Y: new(big.Int)}
 	half := len(id) / 2
 	p.X.SetBytes(id[:half])
 	p.Y.SetBytes(id[half:])

--- a/p2p/rlpx.go
+++ b/p2p/rlpx.go
@@ -277,7 +277,7 @@ func newInitiatorHandshake(remoteID discover.NodeID) (*encHandshake, error) {
 		return nil, err
 	}
 	// generate random keypair to use for signing
-	randpriv, err := ecies.GenerateKey(rand.Reader, crypto.S256(), nil)
+	randpriv, err := ecies.GenerateKey(rand.Reader, secp256k1.S256(), nil)
 	if err != nil {
 		return nil, err
 	}
@@ -376,7 +376,7 @@ func decodeAuthMsg(prv *ecdsa.PrivateKey, token []byte, auth []byte) (*encHandsh
 	var err error
 	h := new(encHandshake)
 	// generate random keypair for session
-	h.randomPrivKey, err = ecies.GenerateKey(rand.Reader, crypto.S256(), nil)
+	h.randomPrivKey, err = ecies.GenerateKey(rand.Reader, secp256k1.S256(), nil)
 	if err != nil {
 		return nil, err
 	}

--- a/p2p/rlpx_test.go
+++ b/p2p/rlpx_test.go
@@ -93,6 +93,7 @@ func testEncHandshake(token []byte) error {
 	go func() {
 		r := result{side: "initiator"}
 		defer func() { output <- r }()
+		defer fd0.Close()
 
 		dest := &discover.Node{ID: discover.PubkeyID(&prv1.PublicKey)}
 		r.id, r.err = c0.doEncHandshake(prv0, dest)
@@ -107,6 +108,7 @@ func testEncHandshake(token []byte) error {
 	go func() {
 		r := result{side: "receiver"}
 		defer func() { output <- r }()
+		defer fd1.Close()
 
 		r.id, r.err = c1.doEncHandshake(prv1, nil)
 		if r.err != nil {

--- a/whisper/message_test.go
+++ b/whisper/message_test.go
@@ -23,6 +23,7 @@ import (
 	"time"
 
 	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/crypto/secp256k1"
 )
 
 // Tests whether a message can be wrapped without any identity or encryption.
@@ -72,8 +73,8 @@ func TestMessageCleartextSignRecover(t *testing.T) {
 	if pubKey == nil {
 		t.Fatalf("failed to recover public key")
 	}
-	p1 := elliptic.Marshal(crypto.S256(), key.PublicKey.X, key.PublicKey.Y)
-	p2 := elliptic.Marshal(crypto.S256(), pubKey.X, pubKey.Y)
+	p1 := elliptic.Marshal(secp256k1.S256(), key.PublicKey.X, key.PublicKey.Y)
+	p2 := elliptic.Marshal(secp256k1.S256(), pubKey.X, pubKey.Y)
 	if !bytes.Equal(p1, p2) {
 		t.Fatalf("public key mismatch: have 0x%x, want 0x%x", p2, p1)
 	}
@@ -150,8 +151,8 @@ func TestMessageFullCrypto(t *testing.T) {
 	if pubKey == nil {
 		t.Fatalf("failed to recover public key")
 	}
-	p1 := elliptic.Marshal(crypto.S256(), fromKey.PublicKey.X, fromKey.PublicKey.Y)
-	p2 := elliptic.Marshal(crypto.S256(), pubKey.X, pubKey.Y)
+	p1 := elliptic.Marshal(secp256k1.S256(), fromKey.PublicKey.X, fromKey.PublicKey.Y)
+	p2 := elliptic.Marshal(secp256k1.S256(), pubKey.X, pubKey.Y)
 	if !bytes.Equal(p1, p2) {
 		t.Fatalf("public key mismatch: have 0x%x, want 0x%x", p2, p1)
 	}


### PR DESCRIPTION
~~**Depends on https://github.com/ethereum/go-ethereum/pull/1853 - please review & merge it first.**~~

NOTE: package `crypto/ecies` needs some refactoring love - this patch is not ideal as package `ecies` is a bit messy. Discussed with @fjl and we have several ideas around how to refactor it. Would prefer to make that refactoring in a separate PR so it's easier to review separated from this change.

- [x] Add libsecp256k1 Scalar Multiplication API based on it's ECDH API and use this in the curve interface function `ScalarMult` for this curve.
- [x] Add benchmark of Scalar Multiplication (lib + Go wrapping code)
- [x] Add shared secret test with static values to catch errors when integrating.
- [x] Move Go secp256k1 curve to crypto/secp256k1 so it can be used in crypto/ecies package (needed to run tests with the correct curve - currently tests are run with another curve - P256)
- [x] Fix RLPx test setup to avoid hanging in case of errors returned from crypto libs
- [x] Some boilerplate added to squeeze this curve into current ECIES impl.

Speedup:
```
benchmark                     old ns/op     new ns/op     delta
BenchmarkGenSharedKeyS256     6523809       165052        -97.47%
```
