### PR TITLE
core: deadlock in chainmanager after posting RemovedTransactionEvent

### DIFF
--- a/core/chain_manager.go
+++ b/core/chain_manager.go
@@ -804,7 +804,9 @@ func (self *ChainManager) reorg(oldBlock, newBlock *types.Block) error {
 		DeleteReceipt(self.chainDb, tx.Hash())
 		DeleteTransaction(self.chainDb, tx.Hash())
 	}
-	self.eventMux.Post(RemovedTransactionEvent{diff})
+	// Must be posted in a goroutine because of the transaction pool trying
+	// to acquire the chain manager lock
+	go self.eventMux.Post(RemovedTransactionEvent{diff})
 
 	return nil
 }


### PR DESCRIPTION
This PR solves an issue with the chain manager posting a
`RemovedTransactionEvent`, the tx pool will try to
acquire the chainmanager lock which has previously been locked prior to
posting `RemovedTransactionEvent`. This results in a deadlock in the
core.