### PR TITLE
eth/downloader: match capabilities when querying idle peers

### DIFF
--- a/eth/downloader/downloader.go
+++ b/eth/downloader/downloader.go
@@ -816,7 +816,7 @@ func (d *Downloader) fetchBlocks61(from uint64) error {
 			}
 			// Send a download request to all idle peers, until throttled
 			throttled := false
-			for _, peer := range d.peers.IdlePeers() {
+			for _, peer := range d.peers.IdlePeers(eth61) {
 				// Short circuit if throttling activated
 				if d.queue.Throttle() {
 					throttled = true
@@ -1255,7 +1255,7 @@ func (d *Downloader) fetchBodies(from uint64) error {
 			}
 			// Send a download request to all idle peers, until throttled
 			queuedEmptyBlocks, throttled := false, false
-			for _, peer := range d.peers.IdlePeers() {
+			for _, peer := range d.peers.IdlePeers(eth62) {
 				// Short circuit if throttling activated
 				if d.queue.Throttle() {
 					throttled = true

--- a/eth/downloader/peer.go
+++ b/eth/downloader/peer.go
@@ -312,14 +312,16 @@ func (ps *peerSet) AllPeers() []*peer {
 
 // IdlePeers retrieves a flat list of all the currently idle peers within the
 // active peer set, ordered by their reputation.
-func (ps *peerSet) IdlePeers() []*peer {
+func (ps *peerSet) IdlePeers(version int) []*peer {
 	ps.lock.RLock()
 	defer ps.lock.RUnlock()
 
 	list := make([]*peer, 0, len(ps.peers))
 	for _, p := range ps.peers {
-		if atomic.LoadInt32(&p.idle) == 0 {
-			list = append(list, p)
+		if (version == eth61 && p.version == eth61) || (version >= eth62 && p.version >= eth62) {
+			if atomic.LoadInt32(&p.idle) == 0 {
+				list = append(list, p)
+			}
 		}
 	}
 	for i := 0; i < len(list); i++ {


### PR DESCRIPTION
This PR fixes a capability matching issue in the downloader. Although we correctly stored the eth protocol version for each of our peers and correctly selected the sync packages to use depending on the protocol currently being synced with, when retrieving idle peers to assign new tasks to I returned all available peers and forgot to check that they can indeed talk the protocol being synced on. Fixing this simply entailed in separating eth/61 peers from eth/62+ peers. This will still exhibit a similar issue when going up to eth/63, but idle peer retrieval was rewritten in eth/63 so that will be sorted out in a different way.