### PR TITLE
core: fixed head write on block insertion

### DIFF
--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -297,6 +297,9 @@ func (bc *BlockChain) insert(block *types.Block) {
 	if err := WriteCanonicalHash(bc.chainDb, block.Hash(), block.NumberU64()); err != nil {
 		glog.Fatalf("failed to insert block number: %v", err)
 	}
+	if err := WriteHeadBlockHash(bc.chainDb, block.Hash()); err != nil {
+		glog.Fatalf("failed to insert block number: %v", err)
+	}
 	bc.currentBlock = block
 }
 

--- a/core/blockchain_test.go
+++ b/core/blockchain_test.go
@@ -153,6 +153,19 @@ func insertChain(done chan bool, blockchain *BlockChain, chain types.Blocks, t *
 	done <- true
 }
 
+func TestLastBlock(t *testing.T) {
+	db, err := ethdb.NewMemDatabase()
+	if err != nil {
+		t.Fatal("Failed to create db:", err)
+	}
+	bchain := theBlockChain(db, t)
+	block := makeChain(bchain.CurrentBlock(), 1, db, 0)[0]
+	bchain.insert(block)
+	if block.Hash() != GetHeadBlockHash(db) {
+		t.Errorf("Write/Get HeadBlockHash failed")
+	}
+}
+
 func TestExtendCanonical(t *testing.T) {
 	CanonicalLength := 5
 	db, err := ethdb.NewMemDatabase()


### PR DESCRIPTION
Due to a rebase this probably got overlooked / ignored. This fixes the
issue of a block insertion never writing the last block.