### PR TITLE
core, core/vm, cmd/evm: remove redundant balance check

### DIFF
--- a/cmd/evm/main.go
+++ b/cmd/evm/main.go
@@ -217,8 +217,8 @@ func (self *VMEnv) AddLog(log *vm.Log) {
 func (self *VMEnv) CanTransfer(from common.Address, balance *big.Int) bool {
 	return self.state.GetBalance(from).Cmp(balance) >= 0
 }
-func (self *VMEnv) Transfer(from, to vm.Account, amount *big.Int) error {
-	return core.Transfer(from, to, amount)
+func (self *VMEnv) Transfer(from, to vm.Account, amount *big.Int) {
+	core.Transfer(from, to, amount)
 }
 
 func (self *VMEnv) Call(caller vm.ContractRef, addr common.Address, data []byte, gas, price, value *big.Int) ([]byte, error) {

--- a/core/execution.go
+++ b/core/execution.go
@@ -17,7 +17,6 @@
 package core
 
 import (
-	"errors"
 	"math/big"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -108,13 +107,7 @@ func exec(env vm.Environment, caller vm.ContractRef, address, codeAddr *common.A
 }
 
 // generic transfer method
-func Transfer(from, to vm.Account, amount *big.Int) error {
-	if from.Balance().Cmp(amount) < 0 {
-		return errors.New("Insufficient balance in account")
-	}
-
+func Transfer(from, to vm.Account, amount *big.Int) {
 	from.SubBalance(amount)
 	to.AddBalance(amount)
-
-	return nil
 }

--- a/core/vm/environment.go
+++ b/core/vm/environment.go
@@ -51,7 +51,7 @@ type Environment interface {
 	// Determines whether it's possible to transact
 	CanTransfer(from common.Address, balance *big.Int) bool
 	// Transfers amount from one account to the other
-	Transfer(from, to Account, amount *big.Int) error
+	Transfer(from, to Account, amount *big.Int)
 	// Adds a LOG to the state
 	AddLog(*Log)
 	// Adds a structured log to the env

--- a/core/vm/jit_test.go
+++ b/core/vm/jit_test.go
@@ -152,9 +152,7 @@ func (self *Env) SetDepth(i int) { self.depth = i }
 func (self *Env) CanTransfer(from common.Address, balance *big.Int) bool {
 	return true
 }
-func (self *Env) Transfer(from, to Account, amount *big.Int) error {
-	return nil
-}
+func (self *Env) Transfer(from, to Account, amount *big.Int) {}
 func (self *Env) Call(caller ContractRef, addr common.Address, data []byte, gas, price, value *big.Int) ([]byte, error) {
 	return nil, nil
 }

--- a/core/vm_env.go
+++ b/core/vm_env.go
@@ -81,8 +81,8 @@ func (self *VMEnv) SetSnapshot(copy vm.Database) {
 	self.state.Set(copy.(*state.StateDB))
 }
 
-func (self *VMEnv) Transfer(from, to vm.Account, amount *big.Int) error {
-	return Transfer(from, to, amount)
+func (self *VMEnv) Transfer(from, to vm.Account, amount *big.Int) {
+	Transfer(from, to, amount)
 }
 
 func (self *VMEnv) Call(me vm.ContractRef, addr common.Address, data []byte, gas, price, value *big.Int) ([]byte, error) {

--- a/tests/util.go
+++ b/tests/util.go
@@ -209,11 +209,11 @@ func (self *Env) SetSnapshot(copy vm.Database) {
 	self.state.Set(copy.(*state.StateDB))
 }
 
-func (self *Env) Transfer(from, to vm.Account, amount *big.Int) error {
+func (self *Env) Transfer(from, to vm.Account, amount *big.Int) {
 	if self.skipTransfer {
-		return nil
+		return
 	}
-	return core.Transfer(from, to, amount)
+	core.Transfer(from, to, amount)
 }
 
 func (self *Env) Call(caller vm.ContractRef, addr common.Address, data []byte, gas, price, value *big.Int) ([]byte, error) {


### PR DESCRIPTION
Following recent core refactorings, this check is redundant because ```Transfer``` is only called in one place, before which the new ```CanTransfer``` function is called.

This is verified by consensus tests, which proves that this check is never hit. These tests verify attempts to send Ether with insufficient account balance:
```
NotEnoughCashContractCreation
TransactionToItselfNotEnoughFounds
callWithHighValue
```
There is also a couple of random fuzzing tests covering this.