### PR TITLE
core/state, core, miner: handle missing root error from state.New

### DIFF
--- a/cmd/evm/main.go
+++ b/cmd/evm/main.go
@@ -113,7 +113,7 @@ func run(ctx *cli.Context) {
 	glog.SetV(ctx.GlobalInt(VerbosityFlag.Name))
 
 	db, _ := ethdb.NewMemDatabase()
-	statedb := state.New(common.Hash{}, db)
+	statedb, _ := state.New(common.Hash{}, db)
 	sender := statedb.CreateAccount(common.StringToAddress("sender"))
 	receiver := statedb.CreateAccount(common.StringToAddress("receiver"))
 	receiver.SetCode(common.Hex2Bytes(ctx.GlobalString(CodeFlag.Name)))

--- a/cmd/geth/chaincmd.go
+++ b/cmd/geth/chaincmd.go
@@ -179,7 +179,11 @@ func dump(ctx *cli.Context) {
 			fmt.Println("{}")
 			utils.Fatalf("block not found")
 		} else {
-			state := state.New(block.Root(), chainDb)
+			state, err := state.New(block.Root(), chainDb)
+			if err != nil {
+				utils.Fatalf("could not create new state: %v", err)
+				return
+			}
 			fmt.Printf("%s\n", state.Dump())
 		}
 	}

--- a/core/block_processor.go
+++ b/core/block_processor.go
@@ -207,7 +207,10 @@ func (sm *BlockProcessor) Process(block *types.Block) (logs vm.Logs, receipts ty
 
 func (sm *BlockProcessor) processWithParent(block, parent *types.Block) (logs vm.Logs, receipts types.Receipts, err error) {
 	// Create a new state based on the parent's root (e.g., create copy)
-	state := state.New(parent.Root(), sm.chainDb)
+	state, err := state.New(parent.Root(), sm.chainDb)
+	if err != nil {
+		return nil, nil, err
+	}
 	header := block.Header()
 	uncles := block.Uncles()
 	txs := block.Transactions()

--- a/core/block_processor_test.go
+++ b/core/block_processor_test.go
@@ -46,7 +46,7 @@ func TestNumber(t *testing.T) {
 	pow := ezp.New()
 	_, chain := proc()
 
-	statedb := state.New(chain.Genesis().Root(), chain.chainDb)
+	statedb, _ := state.New(chain.Genesis().Root(), chain.chainDb)
 	header := makeHeader(chain.Genesis(), statedb)
 	header.Number = big.NewInt(3)
 	err := ValidateHeader(pow, header, chain.Genesis().Header(), false, false)

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -199,7 +199,7 @@ func (self *BlockChain) SetProcessor(proc types.BlockProcessor) {
 	self.processor = proc
 }
 
-func (self *BlockChain) State() *state.StateDB {
+func (self *BlockChain) State() (*state.StateDB, error) {
 	return state.New(self.CurrentBlock().Root(), self.chainDb)
 }
 

--- a/core/chain_makers.go
+++ b/core/chain_makers.go
@@ -156,7 +156,10 @@ func (b *BlockGen) OffsetTime(seconds int64) {
 // values. Inserting them into BlockChain requires use of FakePow or
 // a similar non-validating proof of work implementation.
 func GenerateChain(parent *types.Block, db ethdb.Database, n int, gen func(int, *BlockGen)) []*types.Block {
-	statedb := state.New(parent.Root(), db)
+	statedb, err := state.New(parent.Root(), db)
+	if err != nil {
+		panic(err)
+	}
 	blocks := make(types.Blocks, n)
 	genblock := func(i int, h *types.Header) *types.Block {
 		b := &BlockGen{parent: parent, i: i, chain: blocks, header: h, statedb: statedb}

--- a/core/chain_makers_test.go
+++ b/core/chain_makers_test.go
@@ -84,7 +84,7 @@ func ExampleGenerateChain() {
 		return
 	}
 
-	state := chainman.State()
+	state, _ := chainman.State()
 	fmt.Printf("last block: #%d\n", chainman.CurrentBlock().Number())
 	fmt.Println("balance of addr1:", state.GetBalance(addr1))
 	fmt.Println("balance of addr2:", state.GetBalance(addr2))

--- a/core/genesis.go
+++ b/core/genesis.go
@@ -60,7 +60,8 @@ func WriteGenesisBlock(chainDb ethdb.Database, reader io.Reader) (*types.Block, 
 		return nil, err
 	}
 
-	statedb := state.New(common.Hash{}, chainDb)
+	// creating with empty hash always works
+	statedb, _ := state.New(common.Hash{}, chainDb)
 	for addr, account := range genesis.Alloc {
 		address := common.HexToAddress(addr)
 		statedb.AddBalance(address, common.String2Big(account.Balance))
@@ -115,9 +116,9 @@ func WriteGenesisBlock(chainDb ethdb.Database, reader io.Reader) (*types.Block, 
 }
 
 // GenesisBlockForTesting creates a block in which addr has the given wei balance.
-// The state trie of the block is written to db.
+// The state trie of the block is written to db. the passed db needs to contain a state root
 func GenesisBlockForTesting(db ethdb.Database, addr common.Address, balance *big.Int) *types.Block {
-	statedb := state.New(common.Hash{}, db)
+	statedb, _ := state.New(common.Hash{}, db)
 	obj := statedb.GetOrNewStateObject(addr)
 	obj.SetBalance(balance)
 	root, err := statedb.Commit()

--- a/core/state/managed_state_test.go
+++ b/core/state/managed_state_test.go
@@ -27,7 +27,7 @@ var addr = common.BytesToAddress([]byte("test"))
 
 func create() (*ManagedState, *account) {
 	db, _ := ethdb.NewMemDatabase()
-	statedb := New(common.Hash{}, db)
+	statedb, _ := New(common.Hash{}, db)
 	ms := ManageState(statedb)
 	so := &StateObject{address: addr, nonce: 100}
 	ms.StateDB.stateObjects[addr.Str()] = so

--- a/core/state/state_test.go
+++ b/core/state/state_test.go
@@ -77,12 +77,12 @@ func (s *StateSuite) TestDump(c *checker.C) {
 
 func (s *StateSuite) SetUpTest(c *checker.C) {
 	db, _ := ethdb.NewMemDatabase()
-	s.state = New(common.Hash{}, db)
+	s.state, _ = New(common.Hash{}, db)
 }
 
 func TestNull(t *testing.T) {
 	db, _ := ethdb.NewMemDatabase()
-	state := New(common.Hash{}, db)
+	state, _ := New(common.Hash{}, db)
 
 	address := common.HexToAddress("0x823140710bf13990e4500136726d8b55")
 	state.CreateAccount(address)
@@ -122,7 +122,7 @@ func (s *StateSuite) TestSnapshot(c *checker.C) {
 // printing/logging in tests (-check.vv does not work)
 func TestSnapshot2(t *testing.T) {
 	db, _ := ethdb.NewMemDatabase()
-	state := New(common.Hash{}, db)
+	state, _ := New(common.Hash{}, db)
 
 	stateobjaddr0 := toAddr([]byte("so0"))
 	stateobjaddr1 := toAddr([]byte("so1"))

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -389,7 +389,8 @@ func New(config *Config) (*Ethereum, error) {
 
 		return nil, err
 	}
-	eth.txPool = core.NewTxPool(eth.EventMux(), eth.blockchain.State, eth.blockchain.GasLimit)
+	newPool := core.NewTxPool(eth.EventMux(), eth.blockchain.State, eth.blockchain.GasLimit)
+	eth.txPool = newPool
 
 	eth.blockProcessor = core.NewBlockProcessor(chainDb, eth.pow, eth.blockchain, eth.EventMux())
 	eth.blockchain.SetProcessor(eth.blockProcessor)

--- a/eth/handler_test.go
+++ b/eth/handler_test.go
@@ -443,10 +443,11 @@ func testGetNodeData(t *testing.T, protocol int) {
 	}
 	accounts := []common.Address{testBankAddress, acc1Addr, acc2Addr}
 	for i := uint64(0); i <= pm.blockchain.CurrentBlock().NumberU64(); i++ {
-		trie := state.New(pm.blockchain.GetBlockByNumber(i).Root(), statedb)
+		trie, _ := state.New(pm.blockchain.GetBlockByNumber(i).Root(), statedb)
 
 		for j, acc := range accounts {
-			bw := pm.blockchain.State().GetBalance(acc)
+			state, _ := pm.blockchain.State()
+			bw := state.GetBalance(acc)
 			bh := trie.GetBalance(acc)
 
 			if (bw != nil && bh == nil) || (bw == nil && bh != nil) {

--- a/eth/helper_test.go
+++ b/eth/helper_test.go
@@ -38,7 +38,8 @@ func newTestProtocolManager(blocks int, generator func(int, *core.BlockGen), new
 		blockproc     = core.NewBlockProcessor(db, pow, blockchain, evmux)
 	)
 	blockchain.SetProcessor(blockproc)
-	if _, err := blockchain.InsertChain(core.GenerateChain(genesis, db, blocks, generator)); err != nil {
+	chain := core.GenerateChain(genesis, db, blocks, generator)
+	if _, err := blockchain.InsertChain(chain); err != nil {
 		panic(err)
 	}
 	pm := NewProtocolManager(NetworkId, evmux, &testTxPool{added: newtx}, pow, blockchain, db)

--- a/rpc/api/debug.go
+++ b/rpc/api/debug.go
@@ -119,9 +119,9 @@ func (self *debugApi) DumpBlock(req *shared.Request) (interface{}, error) {
 		return nil, fmt.Errorf("block #%d not found", args.BlockNumber)
 	}
 
-	stateDb := state.New(block.Root(), self.ethereum.ChainDb())
-	if stateDb == nil {
-		return nil, nil
+	stateDb, err := state.New(block.Root(), self.ethereum.ChainDb())
+	if err != nil {
+		return nil, err
 	}
 
 	return stateDb.RawDump(), nil

--- a/tests/state_test_util.go
+++ b/tests/state_test_util.go
@@ -103,7 +103,7 @@ func BenchStateTest(p string, conf bconf, b *testing.B) error {
 func benchStateTest(test VmTest, env map[string]string, b *testing.B) {
 	b.StopTimer()
 	db, _ := ethdb.NewMemDatabase()
-	statedb := state.New(common.Hash{}, db)
+	statedb, _ := state.New(common.Hash{}, db)
 	for addr, account := range test.Pre {
 		obj := StateObjectFromAccount(db, addr, account)
 		statedb.SetStateObject(obj)
@@ -142,7 +142,7 @@ func runStateTests(tests map[string]VmTest, skipTests []string) error {
 
 func runStateTest(test VmTest) error {
 	db, _ := ethdb.NewMemDatabase()
-	statedb := state.New(common.Hash{}, db)
+	statedb, _ := state.New(common.Hash{}, db)
 	for addr, account := range test.Pre {
 		obj := StateObjectFromAccount(db, addr, account)
 		statedb.SetStateObject(obj)

--- a/tests/vm_test_util.go
+++ b/tests/vm_test_util.go
@@ -108,7 +108,7 @@ func BenchVmTest(p string, conf bconf, b *testing.B) error {
 func benchVmTest(test VmTest, env map[string]string, b *testing.B) {
 	b.StopTimer()
 	db, _ := ethdb.NewMemDatabase()
-	statedb := state.New(common.Hash{}, db)
+	statedb, _ := state.New(common.Hash{}, db)
 	for addr, account := range test.Pre {
 		obj := StateObjectFromAccount(db, addr, account)
 		statedb.SetStateObject(obj)
@@ -159,7 +159,7 @@ func runVmTests(tests map[string]VmTest, skipTests []string) error {
 
 func runVmTest(test VmTest) error {
 	db, _ := ethdb.NewMemDatabase()
-	statedb := state.New(common.Hash{}, db)
+	statedb, _ := state.New(common.Hash{}, db)
 	for addr, account := range test.Pre {
 		obj := StateObjectFromAccount(db, addr, account)
 		statedb.SetStateObject(obj)


### PR DESCRIPTION
This turned into
![qdvd216](https://cloud.githubusercontent.com/assets/293096/10311922/25e3c238-6c49-11e5-8fb0-fbb1d50cb37e.gif)

After a lot of discussion and feedback from @fjl this should now be ready for review again:
- [x] Bubble up error from state.New if missing state root
- [x] If this error is hit in miner, short-circuit `commitNewWork`
- [x] In tx pool, delay init of pendingState until new block or tx arrives.