### PR TITLE
cmd: properly initialize Olympic for all subcommands

### DIFF
--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -340,6 +340,7 @@ JavaScript API. See https://github.com/ethereum/go-ethereum/wiki/Javascipt-Conso
 	}
 	app.Before = func(ctx *cli.Context) error {
 		utils.SetupLogger(ctx)
+		utils.SetupNetwork(ctx)
 		utils.SetupVM(ctx)
 		utils.SetupEth(ctx)
 		if ctx.GlobalBool(utils.PProfEanbledFlag.Name) {
@@ -391,9 +392,6 @@ func makeDefaultExtra() []byte {
 
 func run(ctx *cli.Context) {
 	utils.CheckLegalese(utils.MustDataDir(ctx))
-	if ctx.GlobalBool(utils.OlympicFlag.Name) {
-		utils.InitOlympic()
-	}
 
 	cfg := utils.MakeEthConfig(ClientIdentifier, nodeNameVersion, ctx)
 	cfg.ExtraData = makeExtra(ctx)

--- a/cmd/utils/cmd.go
+++ b/cmd/utils/cmd.go
@@ -21,8 +21,6 @@ import (
 	"bufio"
 	"fmt"
 	"io"
-	"math"
-	"math/big"
 	"os"
 	"os/signal"
 	"regexp"
@@ -34,7 +32,6 @@ import (
 	"github.com/ethereum/go-ethereum/eth"
 	"github.com/ethereum/go-ethereum/logger"
 	"github.com/ethereum/go-ethereum/logger/glog"
-	"github.com/ethereum/go-ethereum/params"
 	"github.com/ethereum/go-ethereum/rlp"
 	"github.com/peterh/liner"
 )
@@ -144,16 +141,6 @@ func StartEthereum(ethereum *eth.Ethereum) {
 		glog.V(logger.Error).Infof("Force quitting: this might not end so well.")
 		panic("boom")
 	}()
-}
-
-func InitOlympic() {
-	params.DurationLimit = big.NewInt(8)
-	params.GenesisGasLimit = big.NewInt(3141592)
-	params.MinGasLimit = big.NewInt(125000)
-	params.MaximumExtraDataSize = big.NewInt(1024)
-	NetworkIdFlag.Value = 0
-	core.BlockReward = big.NewInt(1.5e+18)
-	core.ExpDiffPeriod = big.NewInt(math.MaxInt64)
 }
 
 func FormatTransactionData(data string) []byte {


### PR DESCRIPTION
This PR runs the network detection and configuration functionality for all geth subcommands, fixing https://github.com/ethereum/go-ethereum/issues/1884 which was caused by the Olympic parameters not set for `geth console` (and possible others).