### PR TITLE
core/vm: copy stack element to prevent overwrites

### DIFF
--- a/core/vm/vm.go
+++ b/core/vm/vm.go
@@ -370,9 +370,11 @@ func (self *Vm) log(pc uint64, op OpCode, gas, cost *big.Int, memory *Memory, st
 	if Debug {
 		mem := make([]byte, len(memory.Data()))
 		copy(mem, memory.Data())
-		stck := make([]*big.Int, len(stack.Data()))
-		copy(stck, stack.Data())
 
+		stck := make([]*big.Int, len(stack.Data()))
+		for i, item := range stack.Data() {
+			stck[i] = new(big.Int).Set(item)
+		}
 		storage := make(map[common.Hash][]byte)
 		/*
 			object := contract.self.(*state.StateObject)
@@ -380,7 +382,6 @@ func (self *Vm) log(pc uint64, op OpCode, gas, cost *big.Int, memory *Memory, st
 				storage[common.BytesToHash(k)] = v
 			})
 		*/
-
 		self.env.AddStructLog(StructLog{pc, op, new(big.Int).Set(gas), cost, mem, stck, storage, err})
 	}
 }


### PR DESCRIPTION
When creating debug logs from the VM execution steps, the stack data were only shallow copied, meaning that subsequent operations actually modified the underlying `big.Int` and changes the logs. This can be seen for example with the `DIV` opcode, where the result of the operation is already seen in the DIV log entry, whereas it should only appear on the next instruction:

```
PC 00000035: CALLDATALOAD GAS: 3141583 COST: 3
STACK = 2
0000: 0000000000000000000000000000000000000000000000000000000000000000
0001: 0000000100000000000000000000000000000000000000000000000000000000
MEM = 0
STORAGE = 0

PC 00000036: DIV GAS: 3141578 COST: 5
STACK = 2
0000: 00000000000000000000000000000000000000000000000000000000c1620375
0001: 0000000100000000000000000000000000000000000000000000000000000000
MEM = 0
STORAGE = 0

PC 00000037: DUP1 GAS: 3141575 COST: 3
STACK = 1
0000: 00000000000000000000000000000000000000000000000000000000c1620375
MEM = 0
STORAGE = 0
```

vs. fixed

```
PC 00000035: CALLDATALOAD GAS: 3141583 COST: 3
STACK = 2
0000: 0000000000000000000000000000000000000000000000000000000000000000
0001: 0000000100000000000000000000000000000000000000000000000000000000
MEM = 0
STORAGE = 0

PC 00000036: DIV GAS: 3141578 COST: 5
STACK = 2
0000: c162037500000000000000000000000000000000000000000000000000000000
0001: 0000000100000000000000000000000000000000000000000000000000000000
MEM = 0
STORAGE = 0

PC 00000037: DUP1 GAS: 3141575 COST: 3
STACK = 1
0000: 00000000000000000000000000000000000000000000000000000000c1620375
MEM = 0
STORAGE = 0
```