### PR TITLE
core, eth/filters, miner, xeth: Optimised log filtering

### DIFF
--- a/core/chain_makers.go
+++ b/core/chain_makers.go
@@ -105,6 +105,10 @@ func (b *BlockGen) AddTx(tx *types.Transaction) {
 	b.receipts = append(b.receipts, receipt)
 }
 
+func (b *BlockGen) AddReceipt(receipt *types.Receipt) {
+	b.receipts = append(b.receipts, receipt)
+}
+
 // TxNonce returns the next valid transaction nonce for the
 // account at addr. It panics if the account does not exist.
 func (b *BlockGen) TxNonce(addr common.Address) uint64 {

--- a/core/chain_makers.go
+++ b/core/chain_makers.go
@@ -105,7 +105,12 @@ func (b *BlockGen) AddTx(tx *types.Transaction) {
 	b.receipts = append(b.receipts, receipt)
 }
 
-func (b *BlockGen) AddReceipt(receipt *types.Receipt) {
+// AddUncheckedReceipts forcefully adds a receipts to the block without a
+// backing transaction.
+//
+// AddUncheckedReceipts will cause consensus failures when used during real
+// chain processing. This is best used in conjuction with raw block insertion.
+func (b *BlockGen) AddUncheckedReceipt(receipt *types.Receipt) {
 	b.receipts = append(b.receipts, receipt)
 }
 

--- a/core/types/bloom9.go
+++ b/core/types/bloom9.go
@@ -17,6 +17,7 @@
 package types
 
 import (
+	"fmt"
 	"math/big"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -26,6 +27,46 @@ import (
 
 type bytesBacked interface {
 	Bytes() []byte
+}
+
+const bloomLength = 256
+
+type Bloom [bloomLength]byte
+
+func BytesToBloom(b []byte) Bloom {
+	var bloom Bloom
+	bloom.SetBytes(b)
+	return bloom
+}
+
+func (b *Bloom) SetBytes(d []byte) {
+	if len(b) < len(d) {
+		panic(fmt.Sprintf("bloom bytes too big %d %d", len(b), len(d)))
+	}
+
+	copy(b[bloomLength-len(d):], d)
+}
+
+func (b *Bloom) Add(d *big.Int) {
+	bin := new(big.Int).SetBytes(b[:])
+	bin.Or(bin, bloom9(d.Bytes()))
+	b.SetBytes(bin.Bytes())
+}
+
+func (b Bloom) Big() *big.Int {
+	return common.Bytes2Big(b[:])
+}
+
+func (b Bloom) Bytes() []byte {
+	return b[:]
+}
+
+func (b Bloom) Test(test *big.Int) bool {
+	return BloomLookup(b, test)
+}
+
+func (b Bloom) TestBytes(test []byte) bool {
+	return b.Test(common.BytesToBig(test))
 }
 
 func CreateBloom(receipts Receipts) Bloom {

--- a/core/types/bloom9_test.go
+++ b/core/types/bloom9_test.go
@@ -16,6 +16,40 @@
 
 package types
 
+import (
+	"math/big"
+	"testing"
+)
+
+func TestBloom(t *testing.T) {
+	positive := []string{
+		"testtest",
+		"test",
+		"hallo",
+		"other",
+	}
+	negative := []string{
+		"tes",
+		"lo",
+	}
+
+	var bloom Bloom
+	for _, data := range positive {
+		bloom.Add(new(big.Int).SetBytes([]byte(data)))
+	}
+
+	for _, data := range positive {
+		if !bloom.Test(new(big.Int).SetBytes([]byte(data))) {
+			t.Error("expected", data, "to test true")
+		}
+	}
+	for _, data := range negative {
+		if bloom.Test(new(big.Int).SetBytes([]byte(data))) {
+			t.Error("did not expect", data, "to test true")
+		}
+	}
+}
+
 /*
 import (
 	"testing"

--- a/core/types/common.go
+++ b/core/types/common.go
@@ -16,41 +16,8 @@
 
 package types
 
-import (
-	"math/big"
-
-	"fmt"
-
-	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/core/vm"
-)
+import "github.com/ethereum/go-ethereum/core/vm"
 
 type BlockProcessor interface {
 	Process(*Block) (vm.Logs, Receipts, error)
-}
-
-const bloomLength = 256
-
-type Bloom [bloomLength]byte
-
-func BytesToBloom(b []byte) Bloom {
-	var bloom Bloom
-	bloom.SetBytes(b)
-	return bloom
-}
-
-func (b *Bloom) SetBytes(d []byte) {
-	if len(b) < len(d) {
-		panic(fmt.Sprintf("bloom bytes too big %d %d", len(b), len(d)))
-	}
-
-	copy(b[bloomLength-len(d):], d)
-}
-
-func (b Bloom) Big() *big.Int {
-	return common.Bytes2Big(b[:])
-}
-
-func (b Bloom) Bytes() []byte {
-	return b[:]
 }

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -47,6 +47,7 @@ import (
 	"github.com/ethereum/go-ethereum/p2p"
 	"github.com/ethereum/go-ethereum/p2p/discover"
 	"github.com/ethereum/go-ethereum/p2p/nat"
+	"github.com/ethereum/go-ethereum/rlp"
 	"github.com/ethereum/go-ethereum/whisper"
 )
 
@@ -286,6 +287,9 @@ func New(config *Config) (*Ethereum, error) {
 		db.Meter("eth/db/chaindata/")
 	}
 	if err := upgradeChainDatabase(chainDb); err != nil {
+		return nil, err
+	}
+	if err := addMipmapBloomBins(chainDb); err != nil {
 		return nil, err
 	}
 
@@ -767,5 +771,47 @@ func upgradeChainDatabase(db ethdb.Database) error {
 			return err
 		}
 	}
+	return nil
+}
+
+func addMipmapBloomBins(db ethdb.Database) (err error) {
+	const mipmapVersion uint = 2
+
+	// check if the version is set. We ignore data for now since there's
+	// only one version so we can easily ignore it for now
+	var data []byte
+	data, _ = db.Get([]byte("setting-mipmap-version"))
+	if len(data) > 0 {
+		var version uint
+		if err := rlp.DecodeBytes(data, &version); err == nil && version == mipmapVersion {
+			return nil
+		}
+	}
+
+	defer func() {
+		if err == nil {
+			var val []byte
+			val, err = rlp.EncodeToBytes(mipmapVersion)
+			if err == nil {
+				err = db.Put([]byte("setting-mipmap-version"), val)
+			}
+			return
+		}
+	}()
+	latestBlock := core.GetBlock(db, core.GetHeadBlockHash(db))
+	if latestBlock == nil { // clean database
+		return
+	}
+
+	tstart := time.Now()
+	glog.V(logger.Info).Infoln("upgrading db log bloom bins")
+	for i := uint64(0); i <= latestBlock.NumberU64(); i++ {
+		hash := core.GetCanonicalHash(db, i)
+		if (hash == common.Hash{}) {
+			return fmt.Errorf("chain db corrupted. Could not find block %d.", i)
+		}
+		core.WriteMipmapBloom(db, i, core.GetBlockReceipts(db, hash))
+	}
+	glog.V(logger.Info).Infoln("upgrade completed in", time.Since(tstart))
 	return nil
 }

--- a/eth/backend_test.go
+++ b/eth/backend_test.go
@@ -1,0 +1,67 @@
+package eth
+
+import (
+	"math/big"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/core/vm"
+	"github.com/ethereum/go-ethereum/ethdb"
+)
+
+func TestMipmapUpgrade(t *testing.T) {
+	db, _ := ethdb.NewMemDatabase()
+	addr := common.BytesToAddress([]byte("jeff"))
+	genesis := core.WriteGenesisBlockForTesting(db)
+
+	chain := core.GenerateChain(genesis, db, 10, func(i int, gen *core.BlockGen) {
+		var receipts types.Receipts
+		switch i {
+		case 1:
+			receipt := types.NewReceipt(nil, new(big.Int))
+			receipt.SetLogs(vm.Logs{&vm.Log{Address: addr}})
+			gen.AddUncheckedReceipt(receipt)
+			receipts = types.Receipts{receipt}
+		case 2:
+			receipt := types.NewReceipt(nil, new(big.Int))
+			receipt.SetLogs(vm.Logs{&vm.Log{Address: addr}})
+			gen.AddUncheckedReceipt(receipt)
+			receipts = types.Receipts{receipt}
+		}
+
+		// store the receipts
+		err := core.PutReceipts(db, receipts)
+		if err != nil {
+			t.Fatal(err)
+		}
+	})
+	for _, block := range chain {
+		core.WriteBlock(db, block)
+		if err := core.WriteCanonicalHash(db, block.Hash(), block.NumberU64()); err != nil {
+			t.Fatalf("failed to insert block number: %v", err)
+		}
+		if err := core.WriteHeadBlockHash(db, block.Hash()); err != nil {
+			t.Fatalf("failed to insert block number: %v", err)
+		}
+		if err := core.PutBlockReceipts(db, block, block.Receipts()); err != nil {
+			t.Fatal("error writing block receipts:", err)
+		}
+	}
+
+	err := addMipmapBloomBins(db)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	bloom := core.GetMipmapBloom(db, 1, core.MIPMapLevels[0])
+	if (bloom == types.Bloom{}) {
+		t.Error("got empty bloom filter")
+	}
+
+	data, _ := db.Get([]byte("setting-mipmap-version"))
+	if len(data) == 0 {
+		t.Error("setting-mipmap-version not written to database")
+	}
+}

--- a/eth/filters/filter.go
+++ b/eth/filters/filter.go
@@ -17,8 +17,6 @@
 package filters
 
 import (
-	"math"
-
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core"
 	"github.com/ethereum/go-ethereum/core/types"
@@ -107,8 +105,6 @@ done:
 			break done
 		case block.NumberU64() < earliestBlockNo:
 			break done
-		case self.max <= len(logs):
-			break done
 		}
 
 		// Use bloom filtering to see if this block is interesting given the
@@ -128,9 +124,7 @@ done:
 		block = core.GetBlock(self.db, block.ParentHash())
 	}
 
-	skip := int(math.Min(float64(len(logs)), float64(self.skip)))
-
-	return logs[skip:]
+	return logs
 }
 
 func includes(addresses []common.Address, a common.Address) bool {

--- a/eth/filters/filter_test.go
+++ b/eth/filters/filter_test.go
@@ -1,0 +1,95 @@
+package filters
+
+import (
+	"math/big"
+	"os"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/core/vm"
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/ethdb"
+)
+
+func makeReceipt(addr common.Address) *types.Receipt {
+	receipt := types.NewReceipt(nil, new(big.Int))
+	receipt.SetLogs(vm.Logs{
+		&vm.Log{Address: addr},
+	})
+	receipt.Bloom = types.CreateBloom(types.Receipts{receipt})
+	return receipt
+}
+
+func BenchmarkMipmaps(b *testing.B) {
+	const dbname = "/tmp/mipmap"
+	var (
+		db, _   = ethdb.NewLDBDatabase(dbname, 16)
+		key1, _ = crypto.HexToECDSA("b71c71a67e1177ad4e901695e1b4b9ee17ae16c6668d313eac2f96dbcda3f291")
+		addr1   = crypto.PubkeyToAddress(key1.PublicKey)
+		addr2   = common.BytesToAddress([]byte("jeff"))
+		addr3   = common.BytesToAddress([]byte("ethereum"))
+		addr4   = common.BytesToAddress([]byte("random addresses please"))
+	)
+	defer func() {
+		db.Close()
+		os.Remove(dbname)
+	}()
+
+	genesis := core.WriteGenesisBlockForTesting(db, core.GenesisAccount{addr1, big.NewInt(1000000)})
+	chain := core.GenerateChain(genesis, db, 100000, func(i int, gen *core.BlockGen) {
+		var receipts types.Receipts
+		switch i {
+		case 2403:
+			receipt := makeReceipt(addr1)
+			receipts = types.Receipts{receipt}
+			gen.AddReceipt(receipt)
+		case 10340:
+			receipt := makeReceipt(addr2)
+			receipts = types.Receipts{receipt}
+			gen.AddReceipt(receipt)
+		case 34:
+			receipt := makeReceipt(addr3)
+			receipts = types.Receipts{receipt}
+			gen.AddReceipt(receipt)
+		case 99999:
+			receipt := makeReceipt(addr4)
+			receipts = types.Receipts{receipt}
+			gen.AddReceipt(receipt)
+
+		}
+
+		// store the receipts
+		err := core.PutReceipts(db, receipts)
+		if err != nil {
+			b.Fatal(err)
+		}
+	})
+	for _, block := range chain {
+		core.WriteBlock(db, block)
+		if err := core.WriteCanonicalHash(db, block.Hash(), block.NumberU64()); err != nil {
+			b.Fatalf("failed to insert block number: %v", err)
+		}
+		if err := core.WriteHeadBlockHash(db, block.Hash()); err != nil {
+			b.Fatalf("failed to insert block number: %v", err)
+		}
+		if err := core.PutBlockReceipts(db, block, block.Receipts()); err != nil {
+			b.Fatal("error writing block receipts:", err)
+		}
+	}
+
+	b.ResetTimer()
+
+	filter := New(db)
+	filter.SetAddress([]common.Address{addr1, addr2, addr3, addr4})
+	filter.SetEarliestBlock(0)
+	filter.SetLatestBlock(-1)
+
+	for i := 0; i < b.N; i++ {
+		logs := filter.Find()
+		if len(logs) != 4 {
+			b.Fatal("expected 4 log, got", len(logs))
+		}
+	}
+}

--- a/eth/filters/filter_test.go
+++ b/eth/filters/filter_test.go
@@ -1,6 +1,7 @@
 package filters
 
 import (
+	"io/ioutil"
 	"math/big"
 	"os"
 	"testing"
@@ -23,40 +24,42 @@ func makeReceipt(addr common.Address) *types.Receipt {
 }
 
 func BenchmarkMipmaps(b *testing.B) {
-	const dbname = "/tmp/mipmap"
+	dir, err := ioutil.TempDir("", "mipmap")
+	if err != nil {
+		b.Fatal(err)
+	}
+	defer os.RemoveAll(dir)
+
 	var (
-		db, _   = ethdb.NewLDBDatabase(dbname, 16)
+		db, _   = ethdb.NewLDBDatabase(dir, 16)
 		key1, _ = crypto.HexToECDSA("b71c71a67e1177ad4e901695e1b4b9ee17ae16c6668d313eac2f96dbcda3f291")
 		addr1   = crypto.PubkeyToAddress(key1.PublicKey)
 		addr2   = common.BytesToAddress([]byte("jeff"))
 		addr3   = common.BytesToAddress([]byte("ethereum"))
 		addr4   = common.BytesToAddress([]byte("random addresses please"))
 	)
-	defer func() {
-		db.Close()
-		os.Remove(dbname)
-	}()
+	defer db.Close()
 
 	genesis := core.WriteGenesisBlockForTesting(db, core.GenesisAccount{addr1, big.NewInt(1000000)})
-	chain := core.GenerateChain(genesis, db, 100000, func(i int, gen *core.BlockGen) {
+	chain := core.GenerateChain(genesis, db, 100010, func(i int, gen *core.BlockGen) {
 		var receipts types.Receipts
 		switch i {
 		case 2403:
 			receipt := makeReceipt(addr1)
 			receipts = types.Receipts{receipt}
-			gen.AddReceipt(receipt)
-		case 10340:
+			gen.AddUncheckedReceipt(receipt)
+		case 1034:
 			receipt := makeReceipt(addr2)
 			receipts = types.Receipts{receipt}
-			gen.AddReceipt(receipt)
+			gen.AddUncheckedReceipt(receipt)
 		case 34:
 			receipt := makeReceipt(addr3)
 			receipts = types.Receipts{receipt}
-			gen.AddReceipt(receipt)
+			gen.AddUncheckedReceipt(receipt)
 		case 99999:
 			receipt := makeReceipt(addr4)
 			receipts = types.Receipts{receipt}
-			gen.AddReceipt(receipt)
+			gen.AddUncheckedReceipt(receipt)
 
 		}
 
@@ -65,6 +68,7 @@ func BenchmarkMipmaps(b *testing.B) {
 		if err != nil {
 			b.Fatal(err)
 		}
+		core.WriteMipmapBloom(db, uint64(i+1), receipts)
 	})
 	for _, block := range chain {
 		core.WriteBlock(db, block)
@@ -82,14 +86,182 @@ func BenchmarkMipmaps(b *testing.B) {
 	b.ResetTimer()
 
 	filter := New(db)
-	filter.SetAddress([]common.Address{addr1, addr2, addr3, addr4})
-	filter.SetEarliestBlock(0)
-	filter.SetLatestBlock(-1)
+	filter.SetAddresses([]common.Address{addr1, addr2, addr3, addr4})
+	filter.SetBeginBlock(0)
+	filter.SetEndBlock(-1)
 
 	for i := 0; i < b.N; i++ {
 		logs := filter.Find()
 		if len(logs) != 4 {
 			b.Fatal("expected 4 log, got", len(logs))
 		}
+	}
+}
+
+func TestFilters(t *testing.T) {
+	dir, err := ioutil.TempDir("", "mipmap")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(dir)
+
+	var (
+		db, _   = ethdb.NewLDBDatabase(dir, 16)
+		key1, _ = crypto.HexToECDSA("b71c71a67e1177ad4e901695e1b4b9ee17ae16c6668d313eac2f96dbcda3f291")
+		addr    = crypto.PubkeyToAddress(key1.PublicKey)
+
+		hash1 = common.BytesToHash([]byte("topic1"))
+		hash2 = common.BytesToHash([]byte("topic2"))
+		hash3 = common.BytesToHash([]byte("topic3"))
+		hash4 = common.BytesToHash([]byte("topic4"))
+	)
+	defer db.Close()
+
+	genesis := core.WriteGenesisBlockForTesting(db, core.GenesisAccount{addr, big.NewInt(1000000)})
+	chain := core.GenerateChain(genesis, db, 1000, func(i int, gen *core.BlockGen) {
+		var receipts types.Receipts
+		switch i {
+		case 1:
+			receipt := types.NewReceipt(nil, new(big.Int))
+			receipt.SetLogs(vm.Logs{
+				&vm.Log{
+					Address: addr,
+					Topics:  []common.Hash{hash1},
+				},
+			})
+			gen.AddUncheckedReceipt(receipt)
+			receipts = types.Receipts{receipt}
+		case 2:
+			receipt := types.NewReceipt(nil, new(big.Int))
+			receipt.SetLogs(vm.Logs{
+				&vm.Log{
+					Address: addr,
+					Topics:  []common.Hash{hash2},
+				},
+			})
+			gen.AddUncheckedReceipt(receipt)
+			receipts = types.Receipts{receipt}
+		case 998:
+			receipt := types.NewReceipt(nil, new(big.Int))
+			receipt.SetLogs(vm.Logs{
+				&vm.Log{
+					Address: addr,
+					Topics:  []common.Hash{hash3},
+				},
+			})
+			gen.AddUncheckedReceipt(receipt)
+			receipts = types.Receipts{receipt}
+		case 999:
+			receipt := types.NewReceipt(nil, new(big.Int))
+			receipt.SetLogs(vm.Logs{
+				&vm.Log{
+					Address: addr,
+					Topics:  []common.Hash{hash4},
+				},
+			})
+			gen.AddUncheckedReceipt(receipt)
+			receipts = types.Receipts{receipt}
+		}
+
+		// store the receipts
+		err := core.PutReceipts(db, receipts)
+		if err != nil {
+			t.Fatal(err)
+		}
+		// i is used as block number for the writes but since the i
+		// starts at 0 and block 0 (genesis) is already present increment
+		// by one
+		core.WriteMipmapBloom(db, uint64(i+1), receipts)
+	})
+	for _, block := range chain {
+		core.WriteBlock(db, block)
+		if err := core.WriteCanonicalHash(db, block.Hash(), block.NumberU64()); err != nil {
+			t.Fatalf("failed to insert block number: %v", err)
+		}
+		if err := core.WriteHeadBlockHash(db, block.Hash()); err != nil {
+			t.Fatalf("failed to insert block number: %v", err)
+		}
+		if err := core.PutBlockReceipts(db, block, block.Receipts()); err != nil {
+			t.Fatal("error writing block receipts:", err)
+		}
+	}
+
+	filter := New(db)
+	filter.SetAddresses([]common.Address{addr})
+	filter.SetTopics([][]common.Hash{[]common.Hash{hash1, hash2, hash3, hash4}})
+	filter.SetBeginBlock(0)
+	filter.SetEndBlock(-1)
+
+	logs := filter.Find()
+	if len(logs) != 4 {
+		t.Error("expected 4 log, got", len(logs))
+	}
+
+	filter = New(db)
+	filter.SetAddresses([]common.Address{addr})
+	filter.SetTopics([][]common.Hash{[]common.Hash{hash3}})
+	filter.SetBeginBlock(900)
+	filter.SetEndBlock(999)
+	logs = filter.Find()
+	if len(logs) != 1 {
+		t.Error("expected 1 log, got", len(logs))
+	}
+	if len(logs) > 0 && logs[0].Topics[0] != hash3 {
+		t.Errorf("expected log[0].Topics[0] to be %x, got %x", hash3, logs[0].Topics[0])
+	}
+
+	filter = New(db)
+	filter.SetAddresses([]common.Address{addr})
+	filter.SetTopics([][]common.Hash{[]common.Hash{hash3}})
+	filter.SetBeginBlock(990)
+	filter.SetEndBlock(-1)
+	logs = filter.Find()
+	if len(logs) != 1 {
+		t.Error("expected 1 log, got", len(logs))
+	}
+	if len(logs) > 0 && logs[0].Topics[0] != hash3 {
+		t.Errorf("expected log[0].Topics[0] to be %x, got %x", hash3, logs[0].Topics[0])
+	}
+
+	filter = New(db)
+	filter.SetTopics([][]common.Hash{[]common.Hash{hash1, hash2}})
+	filter.SetBeginBlock(1)
+	filter.SetEndBlock(10)
+
+	logs = filter.Find()
+	if len(logs) != 2 {
+		t.Error("expected 2 log, got", len(logs))
+	}
+
+	failHash := common.BytesToHash([]byte("fail"))
+	filter = New(db)
+	filter.SetTopics([][]common.Hash{[]common.Hash{failHash}})
+	filter.SetBeginBlock(0)
+	filter.SetEndBlock(-1)
+
+	logs = filter.Find()
+	if len(logs) != 0 {
+		t.Error("expected 0 log, got", len(logs))
+	}
+
+	failAddr := common.BytesToAddress([]byte("failmenow"))
+	filter = New(db)
+	filter.SetAddresses([]common.Address{failAddr})
+	filter.SetBeginBlock(0)
+	filter.SetEndBlock(-1)
+
+	logs = filter.Find()
+	if len(logs) != 0 {
+		t.Error("expected 0 log, got", len(logs))
+	}
+
+	filter = New(db)
+	filter.SetTopics([][]common.Hash{[]common.Hash{failHash}, []common.Hash{hash1}})
+	filter.SetBeginBlock(0)
+	filter.SetEndBlock(-1)
+
+	logs = filter.Find()
+	if len(logs) != 0 {
+		t.Error("expected 0 log, got", len(logs))
 	}
 }

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -301,6 +301,8 @@ func (self *worker) wait() {
 					core.PutTransactions(self.chainDb, block, block.Transactions())
 					// store the receipts
 					core.PutReceipts(self.chainDb, work.receipts)
+					// Write map map bloom filters
+					core.WriteMipmapBloom(self.chainDb, block.NumberU64(), work.receipts)
 				}
 
 				// broadcast before waiting for validation

--- a/xeth/xeth.go
+++ b/xeth/xeth.go
@@ -543,11 +543,9 @@ func (self *XEth) NewLogFilter(earliest, latest int64, skip, max int, address []
 	id := self.filterManager.Add(filter)
 	self.logQueue[id] = &logQueue{timeout: time.Now()}
 
-	filter.SetEarliestBlock(earliest)
-	filter.SetLatestBlock(latest)
-	filter.SetSkip(skip)
-	filter.SetMax(max)
-	filter.SetAddress(cAddress(address))
+	filter.SetBeginBlock(earliest)
+	filter.SetEndBlock(latest)
+	filter.SetAddresses(cAddress(address))
 	filter.SetTopics(cTopics(topics))
 	filter.LogsCallback = func(logs vm.Logs) {
 		self.logMu.Lock()
@@ -652,11 +650,9 @@ func (self *XEth) Logs(id int) vm.Logs {
 
 func (self *XEth) AllLogs(earliest, latest int64, skip, max int, address []string, topics [][]string) vm.Logs {
 	filter := filters.New(self.backend.ChainDb())
-	filter.SetEarliestBlock(earliest)
-	filter.SetLatestBlock(latest)
-	filter.SetSkip(skip)
-	filter.SetMax(max)
-	filter.SetAddress(cAddress(address))
+	filter.SetBeginBlock(earliest)
+	filter.SetEndBlock(latest)
+	filter.SetAddresses(cAddress(address))
 	filter.SetTopics(cTopics(topics))
 
 	return filter.Find()


### PR DESCRIPTION
Log filtering is now using a MIPmap like approach where addresses of
logs are added to a mapped bloom bin. The current levels for the MIP are
in ranges of 1.000.000, 500.000, 100.000, 50.000, 1.000. Logs are
therefor filtered in batches of 1.000.

Closes #1895