### PR TITLE
geth/js: bugfix, geth would not stop after the js subcommand

### DIFF
--- a/cmd/geth/js.go
+++ b/cmd/geth/js.go
@@ -378,15 +378,6 @@ func (self *jsre) UnlockAccount(addr []byte) bool {
 	}
 }
 
-func (self *jsre) exec(filename string) error {
-	if err := self.re.Exec(filename); err != nil {
-		self.re.Stop(false)
-		return fmt.Errorf("Javascript Error: %v", err)
-	}
-	self.re.Stop(true)
-	return nil
-}
-
 func (self *jsre) interactive() {
 	// Read input lines.
 	prompt := make(chan string)

--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -460,7 +460,10 @@ func execScripts(ctx *cli.Context) {
 		client, false, nil)
 
 	for _, file := range ctx.Args() {
-		repl.exec(file)
+		if err := repl.re.Exec(file); err != nil {
+			fmt.Errorf("Javascript Error: %v", err)
+			break
+		}
 	}
 	node.Stop()
 }


### PR DESCRIPTION
This PR fixes #1892 

The problem is that geth will wait until all javascript timers are cleared. When geth starts it loads the web3 library into the javascript runtime. Web3 will install a timer to support its filter functionality. This timer will never be cleared and causes geth to wait indefinitely.

This is actually a nasty problem to solve. If the user supplies the following script:
```
web3.eth.filter('latest').watch(function() {
   ...
});
```
it expects geth to run indefinitely. But when the user doesn't create any watches/filters it expects geth to exit after it executed the script. In both cases there will only be the single polling timer created by web3 and geth is unable to determine if there are actually polling tasks registered.

This PR won't wait for any timers and stops geth when the last javascript file has been executed. Users who would like to run javascript files that run indefinitely will need to create a node.js script.