### PR TITLE
core, tests: get_hash fix

### DIFF
--- a/core/vm/environment.go
+++ b/core/vm/environment.go
@@ -39,7 +39,7 @@ type Environment interface {
 	// The block number this VM is invoken on
 	BlockNumber() *big.Int
 	// The n'th hash ago from this block number
-	GetHash(n uint64) common.Hash
+	GetHash(uint64) common.Hash
 	// The handler's address
 	Coinbase() common.Address
 	// The current time (block time)

--- a/core/vm_env.go
+++ b/core/vm_env.go
@@ -59,8 +59,10 @@ func (self *VMEnv) SetDepth(i int)           { self.depth = i }
 func (self *VMEnv) VmType() vm.Type          { return self.typ }
 func (self *VMEnv) SetVmType(t vm.Type)      { self.typ = t }
 func (self *VMEnv) GetHash(n uint64) common.Hash {
-	if block := self.chain.GetBlockByNumber(n); block != nil {
-		return block.Hash()
+	for block := self.chain.GetBlock(self.header.ParentHash); block != nil; block = self.chain.GetBlock(block.ParentHash()) {
+		if block.NumberU64() == n {
+			return block.Hash()
+		}
 	}
 
 	return common.Hash{}

--- a/tests/util.go
+++ b/tests/util.go
@@ -131,8 +131,8 @@ type Env struct {
 	initial      bool
 	Gas          *big.Int
 
-	origin common.Address
-	//parent   common.Hash
+	origin   common.Address
+	parent   common.Hash
 	coinbase common.Address
 
 	number     *big.Int
@@ -163,7 +163,7 @@ func NewEnvFromMap(state *state.StateDB, envValues map[string]string, exeValues 
 	env := NewEnv(state)
 
 	env.origin = common.HexToAddress(exeValues["caller"])
-	//env.parent = common.Hex2Bytes(envValues["previousHash"])
+	env.parent = common.HexToHash(envValues["previousHash"])
 	env.coinbase = common.HexToAddress(envValues["currentCoinbase"])
 	env.number = common.Big(envValues["currentNumber"])
 	env.time = common.Big(envValues["currentTimestamp"])
@@ -174,10 +174,8 @@ func NewEnvFromMap(state *state.StateDB, envValues map[string]string, exeValues 
 	return env
 }
 
-func (self *Env) Origin() common.Address { return self.origin }
-func (self *Env) BlockNumber() *big.Int  { return self.number }
-
-//func (self *Env) PrevHash() []byte      { return self.parent }
+func (self *Env) Origin() common.Address   { return self.origin }
+func (self *Env) BlockNumber() *big.Int    { return self.number }
 func (self *Env) Coinbase() common.Address { return self.coinbase }
 func (self *Env) Time() *big.Int           { return self.time }
 func (self *Env) Difficulty() *big.Int     { return self.difficulty }


### PR DESCRIPTION
Make sure that we're fetching the hash from the current chain and not
the canonical chain.

Closes #1849 