### PR TITLE
eth, p2p, rpc/api: polish protocol info gathering

### DIFF
--- a/eth/backend.go
+++ b/eth/backend.go
@@ -472,62 +472,10 @@ func New(config *Config) (*Ethereum, error) {
 	return eth, nil
 }
 
-type NodeInfo struct {
-	Name       string
-	NodeUrl    string
-	NodeID     string
-	IP         string
-	DiscPort   int // UDP listening port for discovery protocol
-	TCPPort    int // TCP listening port for RLPx
-	Td         string
-	ListenAddr string
-}
-
-func (s *Ethereum) NodeInfo() *NodeInfo {
-	node := s.net.Self()
-
-	return &NodeInfo{
-		Name:       s.Name(),
-		NodeUrl:    node.String(),
-		NodeID:     node.ID.String(),
-		IP:         node.IP.String(),
-		DiscPort:   int(node.UDP),
-		TCPPort:    int(node.TCP),
-		ListenAddr: s.net.ListenAddr,
-		Td:         s.BlockChain().GetTd(s.BlockChain().CurrentBlock().Hash()).String(),
-	}
-}
-
-type PeerInfo struct {
-	ID            string
-	Name          string
-	Caps          string
-	RemoteAddress string
-	LocalAddress  string
-}
-
-func newPeerInfo(peer *p2p.Peer) *PeerInfo {
-	var caps []string
-	for _, cap := range peer.Caps() {
-		caps = append(caps, cap.String())
-	}
-	return &PeerInfo{
-		ID:            peer.ID().String(),
-		Name:          peer.Name(),
-		Caps:          strings.Join(caps, ", "),
-		RemoteAddress: peer.RemoteAddr().String(),
-		LocalAddress:  peer.LocalAddr().String(),
-	}
-}
-
-// PeersInfo returns an array of PeerInfo objects describing connected peers
-func (s *Ethereum) PeersInfo() (peersinfo []*PeerInfo) {
-	for _, peer := range s.net.Peers() {
-		if peer != nil {
-			peersinfo = append(peersinfo, newPeerInfo(peer))
-		}
-	}
-	return
+// Network retrieves the underlying P2P network server. This should eventually
+// be moved out into a protocol independent package, but for now use an accessor.
+func (s *Ethereum) Network() *p2p.Server {
+	return s.net
 }
 
 func (s *Ethereum) ResetWithGenesisBlock(gb *types.Block) {

--- a/eth/helper_test.go
+++ b/eth/helper_test.go
@@ -117,7 +117,7 @@ func newTestPeer(name string, version int, pm *ProtocolManager, shake bool) (*te
 	var id discover.NodeID
 	rand.Read(id[:])
 
-	peer := pm.newPeer(version, NetworkId, p2p.NewPeer(id, name, nil), net)
+	peer := pm.newPeer(version, p2p.NewPeer(id, name, nil), net)
 
 	// Start the peer on a new thread
 	errc := make(chan error, 1)

--- a/eth/protocol.go
+++ b/eth/protocol.go
@@ -33,6 +33,9 @@ const (
 	eth63 = 63
 )
 
+// Official short name of the protocol used during capability negotiation.
+var ProtocolName = "eth"
+
 // Supported versions of the eth protocol (first is primary).
 var ProtocolVersions = []uint{eth63, eth62, eth61}
 

--- a/eth/sync_test.go
+++ b/eth/sync_test.go
@@ -40,8 +40,8 @@ func TestFastSyncDisabling(t *testing.T) {
 	// Sync up the two peers
 	io1, io2 := p2p.MsgPipe()
 
-	go pmFull.handle(pmFull.newPeer(63, NetworkId, p2p.NewPeer(discover.NodeID{}, "empty", nil), io2))
-	go pmEmpty.handle(pmEmpty.newPeer(63, NetworkId, p2p.NewPeer(discover.NodeID{}, "full", nil), io1))
+	go pmFull.handle(pmFull.newPeer(63, p2p.NewPeer(discover.NodeID{}, "empty", nil), io2))
+	go pmEmpty.handle(pmEmpty.newPeer(63, p2p.NewPeer(discover.NodeID{}, "full", nil), io1))
 
 	time.Sleep(250 * time.Millisecond)
 	pmEmpty.synchronise(pmEmpty.peers.BestPeer())

--- a/p2p/protocol.go
+++ b/p2p/protocol.go
@@ -16,7 +16,11 @@
 
 package p2p
 
-import "fmt"
+import (
+	"fmt"
+
+	"github.com/ethereum/go-ethereum/p2p/discover"
+)
 
 // Protocol represents a P2P subprotocol implementation.
 type Protocol struct {
@@ -39,6 +43,15 @@ type Protocol struct {
 	// any protocol-level error (such as an I/O error) that is
 	// encountered.
 	Run func(peer *Peer, rw MsgReadWriter) error
+
+	// NodeInfo is an optional helper method to retrieve protocol specific metadata
+	// about the host node.
+	NodeInfo func() interface{}
+
+	// PeerInfo is an optional helper method to retrieve protocol specific metadata
+	// about a certain peer in the network. If an info retrieval function is set,
+	// but returns nil, it is assumed that the protocol handshake is still running.
+	PeerInfo func(id discover.NodeID) interface{}
 }
 
 func (p Protocol) cap() Cap {

--- a/p2p/server.go
+++ b/p2p/server.go
@@ -689,3 +689,66 @@ func (srv *Server) runPeer(p *Peer) {
 		NumConnections: srv.PeerCount(),
 	})
 }
+
+// NodeInfo represents a short summary of the information known about the host.
+type NodeInfo struct {
+	ID    string `json:"id"`    // Unique node identifier (also the encryption key)
+	Name  string `json:"name"`  // Name of the node, including client type, version, OS, custom data
+	Enode string `json:"enode"` // Enode URL for adding this peer from remote peers
+	IP    string `json:"ip"`    // IP address of the node
+	Ports struct {
+		Discovery int `json:"discovery"` // UDP listening port for discovery protocol
+		Listener  int `json:"listener"`  // TCP listening port for RLPx
+	} `json:"ports"`
+	ListenAddr string                 `json:"listenAddr"`
+	Protocols  map[string]interface{} `json:"protocols"`
+}
+
+// Info gathers and returns a collection of metadata known about the host.
+func (srv *Server) NodeInfo() *NodeInfo {
+	node := srv.Self()
+
+	// Gather and assemble the generic node infos
+	info := &NodeInfo{
+		Name:       srv.Name,
+		Enode:      node.String(),
+		ID:         node.ID.String(),
+		IP:         node.IP.String(),
+		ListenAddr: srv.ListenAddr,
+		Protocols:  make(map[string]interface{}),
+	}
+	info.Ports.Discovery = int(node.UDP)
+	info.Ports.Listener = int(node.TCP)
+
+	// Gather all the running protocol infos (only once per protocol type)
+	for _, proto := range srv.Protocols {
+		if _, ok := info.Protocols[proto.Name]; !ok {
+			nodeInfo := interface{}("unknown")
+			if query := proto.NodeInfo; query != nil {
+				nodeInfo = proto.NodeInfo()
+			}
+			info.Protocols[proto.Name] = nodeInfo
+		}
+	}
+	return info
+}
+
+// PeersInfo returns an array of metadata objects describing connected peers.
+func (srv *Server) PeersInfo() []*PeerInfo {
+	// Gather all the generic and sub-protocol specific infos
+	infos := make([]*PeerInfo, 0, srv.PeerCount())
+	for _, peer := range srv.Peers() {
+		if peer != nil {
+			infos = append(infos, peer.Info())
+		}
+	}
+	// Sort the result array alphabetically by node identifier
+	for i := 0; i < len(infos); i++ {
+		for j := i + 1; j < len(infos); j++ {
+			if infos[i].ID > infos[j].ID {
+				infos[i], infos[j] = infos[j], infos[i]
+			}
+		}
+	}
+	return infos
+}

--- a/rpc/api/admin.go
+++ b/rpc/api/admin.go
@@ -32,6 +32,7 @@ import (
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/eth"
 	"github.com/ethereum/go-ethereum/logger/glog"
+	"github.com/ethereum/go-ethereum/p2p"
 	"github.com/ethereum/go-ethereum/rlp"
 	"github.com/ethereum/go-ethereum/rpc/codec"
 	"github.com/ethereum/go-ethereum/rpc/comms"
@@ -80,15 +81,17 @@ type adminhandler func(*adminApi, *shared.Request) (interface{}, error)
 // admin api provider
 type adminApi struct {
 	xeth     *xeth.XEth
+	network  *p2p.Server
 	ethereum *eth.Ethereum
 	codec    codec.Codec
 	coder    codec.ApiCoder
 }
 
 // create a new admin api instance
-func NewAdminApi(xeth *xeth.XEth, ethereum *eth.Ethereum, codec codec.Codec) *adminApi {
+func NewAdminApi(xeth *xeth.XEth, network *p2p.Server, ethereum *eth.Ethereum, codec codec.Codec) *adminApi {
 	return &adminApi{
 		xeth:     xeth,
+		network:  network,
 		ethereum: ethereum,
 		codec:    codec,
 		coder:    codec.New(nil),
@@ -137,11 +140,11 @@ func (self *adminApi) AddPeer(req *shared.Request) (interface{}, error) {
 }
 
 func (self *adminApi) Peers(req *shared.Request) (interface{}, error) {
-	return self.ethereum.PeersInfo(), nil
+	return self.network.PeersInfo(), nil
 }
 
 func (self *adminApi) NodeInfo(req *shared.Request) (interface{}, error) {
-	return self.ethereum.NodeInfo(), nil
+	return self.network.NodeInfo(), nil
 }
 
 func (self *adminApi) DataDir(req *shared.Request) (interface{}, error) {

--- a/rpc/api/utils.go
+++ b/rpc/api/utils.go
@@ -165,7 +165,7 @@ func ParseApiString(apistr string, codec codec.Codec, xeth *xeth.XEth, eth *eth.
 	for i, name := range names {
 		switch strings.ToLower(strings.TrimSpace(name)) {
 		case shared.AdminApiName:
-			apis[i] = NewAdminApi(xeth, eth, codec)
+			apis[i] = NewAdminApi(xeth, eth.Network(), eth, codec)
 		case shared.DebugApiName:
 			apis[i] = NewDebugApi(xeth, eth, codec)
 		case shared.DbApiName:


### PR DESCRIPTION
The goal of this PR is to polish the protocol information gathering API, notably `admin.nodeInfo` and `admin.peers`. The changes consist of moving most of the generic information gathering into the `p2p` package, as it has access to all the details currently displayed by the admin commands. And also creating two (optional) interface methods into the `p2p.Protocol`, namely `NodeInfo` and `PeerInfo`, that can be implemented by any sub-protocol to allow displaying protocol specific meta-data. This way the whole information gathering is driven by the p2p layer, actually allowing all running sub-protocols to add their meta data contributions.

The new output for the two commands is:

```js
> admin.nodeInfo
{
  enode: "enode://44826a5d6a55f88a18298bca4773fca5749cdc3a5c9f308aa7d810e9b31123f3e7c5fba0b1d70aac5308426f47df2a128a6747040a3815cc7dd7167d03be320d@[::]:30303",
  id: "44826a5d6a55f88a18298bca4773fca5749cdc3a5c9f308aa7d810e9b31123f3e7c5fba0b1d70aac5308426f47df2a128a6747040a3815cc7dd7167d03be320d",
  ip: "::",
  listenAddr: "[::]:30303",
  name: "Geth/v1.3.0-dev/linux/go1.5",
  ports: {
    discovery: 30303,
    listener: 30303
  },
  protocols: {
    eth: {
      difficulty: 2304969791029874700,
      genesis: "d4e56740f876aef8c010b86a40d5f56745a118d0906a34e69aec8c0db1cb8fa3",
      head: "1709367dcd08c915e5fdb09df58838255827dcccd4bab575882c351bd6098a69",
      network: 1
    }
  }
}
```

```js
> admin.peers
[{
    caps: ["eth/61", "eth/62"],
    id: "a979fb575495b8d6db44f750317d0f4622bf4c2aa3365d6af7c284339968eef29b69ad0dce72a4d8db5ebb4968de0e3bec910127f134779fbcb0cb6d3331163c",
    name: "Geth/v1.2.2-465e810c/linux/go1.5.1",
    network: {
      localAddress: "192.168.0.185:42063",
      remoteAddress: "52.16.188.185:30303"
    },
    protocols: {
      eth: {
        difficulty: 2304976310514273500,
        head: "cd9ba09b5c5475709ad929a56af309d519e9412d8c47cf77c27a8a4bc279e96c",
        version: 62
      }
    }
}, {
    caps: ["eth/60", "eth/61"],
    id: "cac48c12180ab0cbcd0c71cb59d1c1474b5f83640c77fcb7a88fd6ee71eb647a8ceef9b6e64971fe027f038b7181cc4faba1fc98f1f571ee9ce1e94a9a725f46",
    name: "Geth/v1.1.3-4813a391/linux/go1.5",
    network: {
      localAddress: "192.168.0.185:33604",
      remoteAddress: "5.9.116.9:30303"
    },
    protocols: {
      eth: "handshake"
    }
}]
```

**Note: the capital casing was changed to lower case notation, to conform with all the other API methods. This was probably a leftover however might cause issues if someone relies on them. Additionally I've also made a few minor tweaks to have some semi-meaningful field ordering (i.e. similar fields should be close to each other, not separated by tons of different things).**