### PR TITLE
makefile: fix evm ld flags, pass them to xgo too

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,29 +15,30 @@ geth-cross: geth-linux geth-darwin geth-windows geth-android
 	@ls -l $(GOBIN)/geth-*
 
 geth-linux: xgo
-	build/env.sh $(GOBIN)/xgo --dest=$(GOBIN) --deps=https://gmplib.org/download/gmp/gmp-6.0.0a.tar.bz2 --targets=linux/* -v ./cmd/geth
+	build/env.sh $(GOBIN)/xgo --dest=$(GOBIN) --deps=https://gmplib.org/download/gmp/gmp-6.0.0a.tar.bz2 --targets=linux/* -v $(shell build/flags.sh) ./cmd/geth
 	@echo "Linux cross compilation done:"
 	@ls -l $(GOBIN)/geth-linux-*
 
 geth-darwin: xgo
-	build/env.sh $(GOBIN)/xgo --dest=$(GOBIN) --deps=https://gmplib.org/download/gmp/gmp-6.0.0a.tar.bz2 --targets=darwin/* -v ./cmd/geth
+	build/env.sh $(GOBIN)/xgo --dest=$(GOBIN) --deps=https://gmplib.org/download/gmp/gmp-6.0.0a.tar.bz2 --targets=darwin/* -v $(shell build/flags.sh) ./cmd/geth
 	@echo "Darwin cross compilation done:"
 	@ls -l $(GOBIN)/geth-darwin-*
 
 geth-windows: xgo
-	build/env.sh $(GOBIN)/xgo --dest=$(GOBIN) --deps=https://gmplib.org/download/gmp/gmp-6.0.0a.tar.bz2 --targets=windows/* -v ./cmd/geth
+	build/env.sh $(GOBIN)/xgo --dest=$(GOBIN) --deps=https://gmplib.org/download/gmp/gmp-6.0.0a.tar.bz2 --targets=windows/* -v $(shell build/flags.sh) ./cmd/geth
 	@echo "Windows cross compilation done:"
 	@ls -l $(GOBIN)/geth-windows-*
 
 geth-android: xgo
-	build/env.sh $(GOBIN)/xgo --dest=$(GOBIN) --deps=https://gmplib.org/download/gmp/gmp-6.0.0a.tar.bz2 --targets=android-16/*,android-21/* -v ./cmd/geth
+	build/env.sh $(GOBIN)/xgo --dest=$(GOBIN) --deps=https://gmplib.org/download/gmp/gmp-6.0.0a.tar.bz2 --targets=android-16/*,android-21/* -v $(shell build/flags.sh) ./cmd/geth
 	@echo "Android cross compilation done:"
 	@ls -l $(GOBIN)/geth-android-*
 
 evm:
-	build/env.sh $(GOROOT)/bin/go install -v $(shell build/ldflags.sh) ./cmd/evm
+	build/env.sh $(GOROOT)/bin/go install -v $(shell build/flags.sh) ./cmd/evm
 	@echo "Done building."
 	@echo "Run \"$(GOBIN)/evm to start the evm."
+
 mist:
 	build/env.sh go install -v $(shell build/flags.sh) ./cmd/mist
 	@echo "Done building."

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 # with Go source code. If you know what GOPATH is then you probably
 # don't need to bother with make.
 
-.PHONY: geth evm mist all test travis-test-with-coverage clean
+.PHONY: geth geth-cross geth-linux geth-darwin geth-windows geth-android evm all test travis-test-with-coverage xgo clean
 GOBIN = build/bin
 
 geth:
@@ -38,11 +38,6 @@ evm:
 	build/env.sh $(GOROOT)/bin/go install -v $(shell build/flags.sh) ./cmd/evm
 	@echo "Done building."
 	@echo "Run \"$(GOBIN)/evm to start the evm."
-
-mist:
-	build/env.sh go install -v $(shell build/flags.sh) ./cmd/mist
-	@echo "Done building."
-	@echo "Run \"$(GOBIN)/mist --asset_path=cmd/mist/assets\" to launch mist."
 
 all:
 	build/env.sh go install -v $(shell build/flags.sh) ./...


### PR DESCRIPTION
This PR fixes a minor regression in `evm` compilation where the `ldflags.sh` was renamed to `flags.sh`, but the evm rule never updated. In addition, `xgo` was extended to support processing build tags and linker flags, so these were also passed to it now, finally injecting the git commit hash into the cross builds too.

There's also a second commit to cleanup the mist leftovers from the makefile, and also to update the phony targets with the cross builds.