### PR TITLE
eth: don't block sync goroutines that short circuit

### DIFF
--- a/eth/downloader/downloader.go
+++ b/eth/downloader/downloader.go
@@ -248,10 +248,11 @@ func (d *Downloader) UnregisterPeer(id string) error {
 
 // Synchronise tries to sync up our local block chain with a remote peer, both
 // adding various sanity checks as well as wrapping it with various log entries.
-func (d *Downloader) Synchronise(id string, head common.Hash, td *big.Int, mode SyncMode) {
+func (d *Downloader) Synchronise(id string, head common.Hash, td *big.Int, mode SyncMode) error {
 	glog.V(logger.Detail).Infof("Attempting synchronisation: %v, head [%x…], TD %v", id, head[:4], td)
 
-	switch err := d.synchronise(id, head, td, mode); err {
+	err := d.synchronise(id, head, td, mode)
+	switch err {
 	case nil:
 		glog.V(logger.Detail).Infof("Synchronisation completed")
 
@@ -268,6 +269,7 @@ func (d *Downloader) Synchronise(id string, head common.Hash, td *big.Int, mode 
 	default:
 		glog.V(logger.Warn).Infof("Synchronisation failed: %v", err)
 	}
+	return err
 }
 
 // synchronise will select the peer and use it for synchronising. If an empty string is given


### PR DESCRIPTION
This is a very simple fix to release goroutines blocked in `eth.synchronise`.

After a `downloader.Synchronise` call returns, there may still be pending import operation (e.g. block processing), so after fast sync, we need to wait for all of these background ops to finish before we can check if fast sync needs to be disabled or not. However, the current code actually blocked all those goroutines too which never synced, but were turned away due to a previous one already running. This lead to many goroutines spinning, just waiting for the main sync to finish. This PR modified the downloader so that a sync result is returned, based on which the code in `eth` can wither loop waiting or flat out return as being turned away.

A second completely independent and until now hidden bug was fixed, which with a non-negligible probability lead to a fast sync to fail and/or drop the origin peer. The cause was that a block insertion into the local chain always force-set the head header and head fast-block to the block being inserted. This is required so that a previous fast/light sync doesn't leave head headers pointing to old/stale side-chains. However, we always reset the heads, even if they were **on the correct** chain. This opened up a race condition where the downloader pulled some headers, inserted them and then they went missing (because it started inserting blocks, which rewound the head header). This in turn caused the downloader to believe there's an ongoing attack and to abort sync / drop the peer.