### PR TITLE
accounts/abi: ABI fixes & added types

### DIFF
--- a/accounts/abi/abi.go
+++ b/accounts/abi/abi.go
@@ -36,7 +36,7 @@ import (
 type Method struct {
 	Name   string
 	Const  bool
-	Input  []Argument
+	Inputs []Argument
 	Return Type // not yet implemented
 }
 
@@ -49,9 +49,9 @@ type Method struct {
 // Please note that "int" is substitute for its canonical representation "int256"
 func (m Method) String() (out string) {
 	out += m.Name
-	types := make([]string, len(m.Input))
+	types := make([]string, len(m.Inputs))
 	i := 0
-	for _, input := range m.Input {
+	for _, input := range m.Inputs {
 		types[i] = input.Type.String()
 		i++
 	}
@@ -104,7 +104,7 @@ func (abi ABI) pack(name string, args ...interface{}) ([]byte, error) {
 
 	var ret []byte
 	for i, a := range args {
-		input := method.Input[i]
+		input := method.Inputs[i]
 
 		packed, err := input.Type.pack(a)
 		if err != nil {
@@ -129,8 +129,8 @@ func (abi ABI) Pack(name string, args ...interface{}) ([]byte, error) {
 	}
 
 	// start with argument count match
-	if len(args) != len(method.Input) {
-		return nil, fmt.Errorf("argument count mismatch: %d for %d", len(args), len(method.Input))
+	if len(args) != len(method.Inputs) {
+		return nil, fmt.Errorf("argument count mismatch: %d for %d", len(args), len(method.Inputs))
 	}
 
 	arguments, err := abi.pack(name, args...)

--- a/accounts/abi/type.go
+++ b/accounts/abi/type.go
@@ -43,7 +43,7 @@ type Type struct {
 	stringKind string // holds the unparsed string for deriving signatures
 }
 
-// New type returns a fully parsed Type given by the input string or an error if it  can't be parsed.
+// NewType returns a fully parsed Type given by the input string or an error if it  can't be parsed.
 //
 // Strings can be in the format of:
 //
@@ -130,6 +130,10 @@ func NewType(t string) (typ Type, err error) {
 			if vsize > 0 {
 				typ.Size = 32
 			}
+		case "bytes":
+			typ.Kind = reflect.Slice
+			typ.Type = byte_ts
+			typ.Size = vsize
 		default:
 			return Type{}, fmt.Errorf("unsupported arg type: %s", t)
 		}
@@ -200,7 +204,13 @@ func (t Type) pack(v interface{}) ([]byte, error) {
 		} else {
 			return common.LeftPadBytes(common.Big0.Bytes(), 32), nil
 		}
+	case reflect.Array:
+		if v, ok := value.Interface().(common.Address); ok {
+			return t.pack(v[:])
+		} else if v, ok := value.Interface().(common.Hash); ok {
+			return t.pack(v[:])
+		}
 	}
 
-	panic("unreached")
+	return nil, fmt.Errorf("ABI: bad input given %T", value.Kind())
 }


### PR DESCRIPTION
Changed field `input` to new `inputs`. Addad Hash and Address as input
types.