### PR TITLE
Argument parsing can lead to panic in rpc channel

### DIFF
--- a/rpc/api/eth_args.go
+++ b/rpc/api/eth_args.go
@@ -626,7 +626,12 @@ func (args *GetBlockByHashArgs) UnmarshalJSON(b []byte) (err error) {
 
 	args.IncludeTxs = obj[1].(bool)
 
-	return nil
+	if inclTx, ok := obj[1].(bool); ok {
+		args.IncludeTxs = inclTx
+		return nil
+	}
+
+	return shared.NewInvalidTypeError("includeTxs", "not a bool")
 }
 
 type GetBlockByNumberArgs struct {
@@ -648,9 +653,12 @@ func (args *GetBlockByNumberArgs) UnmarshalJSON(b []byte) (err error) {
 		return err
 	}
 
-	args.IncludeTxs = obj[1].(bool)
+	if inclTx, ok := obj[1].(bool); ok {
+		args.IncludeTxs = inclTx
+		return nil
+	}
 
-	return nil
+	return shared.NewInvalidTypeError("includeTxs", "not a bool")
 }
 
 type BlockFilterArgs struct {


### PR DESCRIPTION
The second argument in `eth_getBlockByHash` and `eth_getBlockByNumber` is converted to a boolean with a type assertion. When second argument is not a boolean this will lead to a panic. The http channel recovers from this panic and closes the connection. The IPC won't recover and crashes the node.

This PR adds a type check to the conversion which prevents the panic. And it adds recover support in the IPC channel.