### PR TITLE
Infinite loop in filters

### DIFF
--- a/rpc/api/args_test.go
+++ b/rpc/api/args_test.go
@@ -1394,13 +1394,10 @@ func TestBlockFilterArgsDefaults(t *testing.T) {
 }
 
 func TestBlockFilterArgsWords(t *testing.T) {
-	input := `[{
-  "fromBlock": "latest",
-  "toBlock": "pending"
-  }]`
+	input := `[{"fromBlock": "latest", "toBlock": "latest"}]`
 	expected := new(BlockFilterArgs)
 	expected.Earliest = -1
-	expected.Latest = -2
+	expected.Latest = -1
 
 	args := new(BlockFilterArgs)
 	if err := json.Unmarshal([]byte(input), &args); err != nil {
@@ -1411,8 +1408,9 @@ func TestBlockFilterArgsWords(t *testing.T) {
 		t.Errorf("Earliest shoud be %#v but is %#v", expected.Earliest, args.Earliest)
 	}
 
-	if expected.Latest != args.Latest {
-		t.Errorf("Latest shoud be %#v but is %#v", expected.Latest, args.Latest)
+	input = `[{"toBlock": "pending"}]`
+	if err := json.Unmarshal([]byte(input), &args); err == nil {
+		t.Errorf("Pending isn't currently supported and should raise an unsupported error")
 	}
 }
 

--- a/rpc/api/eth_args.go
+++ b/rpc/api/eth_args.go
@@ -714,6 +714,13 @@ func (args *BlockFilterArgs) UnmarshalJSON(b []byte) (err error) {
 			return err
 		}
 	}
+
+	if num == -2 {
+		return fmt.Errorf("\"pending\" is unsupported")
+	} else if num < -2 {
+		return fmt.Errorf("Invalid to block number")
+	}
+
 	args.Latest = num
 
 	if obj[0].Limit == nil {


### PR DESCRIPTION
During the creation of a filter the user has the option to specify "pending". This is internally translated to `-2`. In `Filter.Find` this number is casted to an uint64 which causes it to overflow and causes a (practically) infinite loop.

Currently "pending" isn't supported. This PR returns an unsupported error when the users tries to create a filter with "pending".