### PR TITLE
crypto/secp256k1: add C compiler flags for pkgsrc

### DIFF
--- a/crypto/secp256k1/secp256.go
+++ b/crypto/secp256k1/secp256.go
@@ -20,11 +20,11 @@ package secp256k1
 
 /*
 #cgo CFLAGS: -I./libsecp256k1
-#cgo darwin CFLAGS: -I/usr/local/include
+#cgo darwin CFLAGS: -I/usr/local/include -I/opt/pkg/include
 #cgo freebsd CFLAGS: -I/usr/local/include
 #cgo linux,arm CFLAGS: -I/usr/local/arm/include
 #cgo LDFLAGS: -lgmp
-#cgo darwin LDFLAGS: -L/usr/local/lib
+#cgo darwin LDFLAGS: -L/usr/local/lib -L/opt/pkg/lib
 #cgo freebsd LDFLAGS: -L/usr/local/lib
 #cgo linux,arm LDFLAGS: -L/usr/local/arm/lib
 #define USE_NUM_GMP


### PR DESCRIPTION
[pkgsrc](http://pkgsrc.org/) is a cross-platform package manager that also supports OS X.