### PR TITLE
jsre: fix #1876, sleep too short on a slow test server

### DIFF
--- a/jsre/jsre_test.go
+++ b/jsre/jsre_test.go
@@ -85,7 +85,7 @@ func TestNatto(t *testing.T) {
 	if err != nil {
 		t.Errorf("expected no error, got %v", err)
 	}
-	time.Sleep(time.Millisecond * 10)
+	time.Sleep(100 * time.Millisecond)
 	val, err := jsre.Run("msg")
 	if err != nil {
 		t.Errorf("expected no error, got %v", err)


### PR DESCRIPTION
This PR fixes an issue in the Natto tests that was checking if the JavaScript `setTimeout` method works correctly. Very rarely this test was failing, my guess being that the 10ms sleep waiting for the timeout to occur (and the related code to run) is too small for a low performance test server running other tests too concurrently. The "proper way" to test this would be to insert a hook into Natto, but raising the timeout a bit higher should also ensure that we rule out test machine hiccups.