### PR TITLE
cmd/geth: fix recover command crash if no param is supplied

### DIFF
--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -542,10 +542,10 @@ func unlockAccount(ctx *cli.Context, am *accounts.Manager, addr string, i int, i
 func blockRecovery(ctx *cli.Context) {
 	utils.CheckLegalese(utils.MustDataDir(ctx))
 
-	arg := ctx.Args().First()
-	if len(ctx.Args()) < 1 && len(arg) > 0 {
+	if len(ctx.Args()) < 1 {
 		glog.Fatal("recover requires block number or hash")
 	}
+	arg := ctx.Args().First()
 
 	cfg := utils.MakeEthConfig(ClientIdentifier, nodeNameVersion, ctx)
 	utils.CheckLegalese(cfg.DataDir)


### PR DESCRIPTION
If no arguments are supplied to `geth recover`, if will panic because the if that checks against this got a bit convoluted and never entered (one of the operands in the condition was always false by definition).

This fixes the issue reported in https://github.com/ethereum/go-ethereum/issues/1962#issuecomment-153889585