### PR TITLE
tests: fix data race in bad-block-report disabling during tests

### DIFF
--- a/tests/init.go
+++ b/tests/init.go
@@ -56,13 +56,16 @@ var (
 	VmSkipTests    = []string{}
 )
 
+// Disable reporting bad blocks for the tests
+func init() {
+	core.DisableBadBlockReporting = true
+}
+
 func readJson(reader io.Reader, value interface{}) error {
 	data, err := ioutil.ReadAll(reader)
 	if err != nil {
 		return fmt.Errorf("Error reading JSON file", err.Error())
 	}
-
-	core.DisableBadBlockReporting = true
 	if err = json.Unmarshal(data, &value); err != nil {
 		if syntaxerr, ok := err.(*json.SyntaxError); ok {
 			line := findLine(data, syntaxerr.Offset)


### PR DESCRIPTION
```
==================
WARNING: DATA RACE
Write by goroutine 173:
  github.com/ethereum/go-ethereum/tests.readJson()
      /work/src/github.com/ethereum/go-ethereum/tests/init.go:65 +0x254
  github.com/ethereum/go-ethereum/tests.readJsonFile()
      /work/src/github.com/ethereum/go-ethereum/tests/init.go:97 +0x11f
  github.com/ethereum/go-ethereum/tests.RunBlockTest()
      /work/src/github.com/ethereum/go-ethereum/tests/block_test_util.go:128 +0xf1
  github.com/ethereum/go-ethereum/tests.TestBcUncleHeaderValidityTests()
      /work/src/github.com/ethereum/go-ethereum/tests/block_test.go:32 +0x178
  testing.tRunner()
      /opt/google/go/src/testing/testing.go:456 +0xdc

Previous read by goroutine 94:
  github.com/ethereum/go-ethereum/core.ReportBlock()
      /work/src/github.com/ethereum/go-ethereum/core/bad_block.go:38 +0x51

Goroutine 173 (running) created at:
  testing.RunTests()
      /opt/google/go/src/testing/testing.go:561 +0xaa3
  testing.(*M).Run()
      /opt/google/go/src/testing/testing.go:494 +0xe4
  main.main()
      github.com/ethereum/go-ethereum/tests/_test/_testmain.go:162 +0x20f

Goroutine 94 (finished) created at:
  github.com/ethereum/go-ethereum/core.(*BlockChain).InsertChain()
      /work/src/github.com/ethereum/go-ethereum/core/blockchain.go:1094 +0x1ecb
  github.com/ethereum/go-ethereum/tests.(*BlockTest).TryBlocksInsert()
      /work/src/github.com/ethereum/go-ethereum/tests/block_test_util.go:295 +0x441
  github.com/ethereum/go-ethereum/tests.runBlockTest()
      /work/src/github.com/ethereum/go-ethereum/tests/block_test_util.go:195 +0x924
  github.com/ethereum/go-ethereum/tests.runBlockTests()
      /work/src/github.com/ethereum/go-ethereum/tests/block_test_util.go:155 +0x560
  github.com/ethereum/go-ethereum/tests.RunBlockTest()
      /work/src/github.com/ethereum/go-ethereum/tests/block_test_util.go:136 +0x1b3
  github.com/ethereum/go-ethereum/tests.TestBcValidBlockTests()
      /work/src/github.com/ethereum/go-ethereum/tests/block_test.go:25 +0x178
  testing.tRunner()
      /opt/google/go/src/testing/testing.go:456 +0xdc
==================
```