### PR TITLE
whisper: fix datarace in expiration test

### DIFF
--- a/whisper/whisper_test.go
+++ b/whisper/whisper_test.go
@@ -189,13 +189,22 @@ func TestMessageExpiration(t *testing.T) {
 		t.Fatalf("failed to inject message: %v", err)
 	}
 	// Check that the message is inside the cache
-	if _, ok := node.messages[envelope.Hash()]; !ok {
+	node.poolMu.RLock()
+	_, found := node.messages[envelope.Hash()]
+	node.poolMu.RUnlock()
+
+	if !found {
 		t.Fatalf("message not found in cache")
 	}
 	// Wait for expiration and check cache again
 	time.Sleep(time.Second)     // wait for expiration
 	time.Sleep(expirationCycle) // wait for cleanup cycle
-	if _, ok := node.messages[envelope.Hash()]; ok {
+
+	node.poolMu.RLock()
+	_, found = node.messages[envelope.Hash()]
+	node.poolMu.RUnlock()
+
+	if found {
 		t.Fatalf("message not expired from cache")
 	}
 }


### PR DESCRIPTION
```
==================
WARNING: DATA RACE
Write by goroutine 11:
  runtime.mapdelete()
      /opt/google/go/src/runtime/hashmap.go:511 +0x0
  github.com/ethereum/go-ethereum/whisper.(*Whisper).expire.func1()
      /work/src/github.com/ethereum/go-ethereum/whisper/whisper.go:337 +0xa2
  gopkg.in/fatih/set%2ev0.(*set).Each()
      /work/src/github.com/ethereum/go-ethereum/Godeps/_workspace/src/gopkg.in/fatih/set.v0/set_nots.go:149 +0xc2
  github.com/ethereum/go-ethereum/whisper.(*Whisper).expire()
      /work/src/github.com/ethereum/go-ethereum/whisper/whisper.go:339 +0x211
  github.com/ethereum/go-ethereum/whisper.(*Whisper).update()
      /work/src/github.com/ethereum/go-ethereum/whisper/whisper.go:315 +0xf9

Previous read by goroutine 9:
  runtime.mapaccess2()
      /opt/google/go/src/runtime/hashmap.go:320 +0x0
  github.com/ethereum/go-ethereum/whisper.TestMessageExpiration()
      /work/src/github.com/ethereum/go-ethereum/whisper/whisper_test.go:192 +0x42b
  testing.tRunner()
      /opt/google/go/src/testing/testing.go:456 +0xdc

Goroutine 11 (running) created at:
  github.com/ethereum/go-ethereum/whisper.(*Whisper).Start()
      /work/src/github.com/ethereum/go-ethereum/whisper/whisper.go:161 +0x134
  github.com/ethereum/go-ethereum/whisper.startTestCluster()
      /work/src/github.com/ethereum/go-ethereum/whisper/whisper_test.go:36 +0x2c5
  github.com/ethereum/go-ethereum/whisper.TestMessageExpiration()
      /work/src/github.com/ethereum/go-ethereum/whisper/whisper_test.go:179 +0x4e
  testing.tRunner()
      /opt/google/go/src/testing/testing.go:456 +0xdc

Goroutine 9 (running) created at:
  testing.RunTests()
      /opt/google/go/src/testing/testing.go:561 +0xaa3
  testing.(*M).Run()
      /opt/google/go/src/testing/testing.go:494 +0xe4
  main.main()
      github.com/ethereum/go-ethereum/whisper/_test/_testmain.go:102 +0x20f
==================
```