### PR TITLE
rpc/api: fix #1972 api regression (nil eth panic) in attach

### DIFF
--- a/rpc/api/admin.go
+++ b/rpc/api/admin.go
@@ -32,7 +32,6 @@ import (
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/eth"
 	"github.com/ethereum/go-ethereum/logger/glog"
-	"github.com/ethereum/go-ethereum/p2p"
 	"github.com/ethereum/go-ethereum/rlp"
 	"github.com/ethereum/go-ethereum/rpc/codec"
 	"github.com/ethereum/go-ethereum/rpc/comms"
@@ -81,17 +80,15 @@ type adminhandler func(*adminApi, *shared.Request) (interface{}, error)
 // admin api provider
 type adminApi struct {
 	xeth     *xeth.XEth
-	network  *p2p.Server
 	ethereum *eth.Ethereum
 	codec    codec.Codec
 	coder    codec.ApiCoder
 }
 
 // create a new admin api instance
-func NewAdminApi(xeth *xeth.XEth, network *p2p.Server, ethereum *eth.Ethereum, codec codec.Codec) *adminApi {
+func NewAdminApi(xeth *xeth.XEth, ethereum *eth.Ethereum, codec codec.Codec) *adminApi {
 	return &adminApi{
 		xeth:     xeth,
-		network:  network,
 		ethereum: ethereum,
 		codec:    codec,
 		coder:    codec.New(nil),
@@ -140,11 +137,11 @@ func (self *adminApi) AddPeer(req *shared.Request) (interface{}, error) {
 }
 
 func (self *adminApi) Peers(req *shared.Request) (interface{}, error) {
-	return self.network.PeersInfo(), nil
+	return self.ethereum.Network().PeersInfo(), nil
 }
 
 func (self *adminApi) NodeInfo(req *shared.Request) (interface{}, error) {
-	return self.network.NodeInfo(), nil
+	return self.ethereum.Network().NodeInfo(), nil
 }
 
 func (self *adminApi) DataDir(req *shared.Request) (interface{}, error) {

--- a/rpc/api/utils.go
+++ b/rpc/api/utils.go
@@ -165,7 +165,7 @@ func ParseApiString(apistr string, codec codec.Codec, xeth *xeth.XEth, eth *eth.
 	for i, name := range names {
 		switch strings.ToLower(strings.TrimSpace(name)) {
 		case shared.AdminApiName:
-			apis[i] = NewAdminApi(xeth, eth.Network(), eth, codec)
+			apis[i] = NewAdminApi(xeth, eth, codec)
 		case shared.DebugApiName:
 			apis[i] = NewDebugApi(xeth, eth, codec)
 		case shared.DbApiName:


### PR DESCRIPTION
The peer info polish PR https://github.com/ethereum/go-ethereum/pull/1934 introduced a small regression during console attachment by calling a method on the local eth object (which does not exist) resulting in a nil panic. This was an unfortunate oversight that the object is nil during attach. This PR fixes that by moving the network accessing code back into the internals of the admin RPI API. This will be sorted out in a nicer way in the custom protocol stack PR, so it should be fine for now as a hotfix.