### PR TITLE
cmd/geth, cmd/utils: surface the light KDF flag to the CLI

### DIFF
--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -305,6 +305,7 @@ JavaScript API. See https://github.com/ethereum/go-ethereum/wiki/Javascipt-Conso
 		utils.OlympicFlag,
 		utils.FastSyncFlag,
 		utils.CacheFlag,
+		utils.LightKDFFlag,
 		utils.JSpathFlag,
 		utils.ListenPortFlag,
 		utils.MaxPeersFlag,

--- a/cmd/geth/usage.go
+++ b/cmd/geth/usage.go
@@ -69,6 +69,7 @@ var AppHelpFlagGroups = []flagGroup{
 			utils.GenesisFileFlag,
 			utils.IdentityFlag,
 			utils.FastSyncFlag,
+			utils.LightKDFFlag,
 			utils.CacheFlag,
 			utils.BlockchainVersionFlag,
 		},

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -150,11 +150,11 @@ var (
 	}
 	FastSyncFlag = cli.BoolFlag{
 		Name:  "fast",
-		Usage: "Enables fast syncing through state downloads",
+		Usage: "Enable fast syncing through state downloads",
 	}
 	LightKDFFlag = cli.BoolFlag{
 		Name:  "lightkdf",
-		Usage: "Reduce KDF memory & CPU usage at some expense of KDF strength",
+		Usage: "Reduce key-derivation RAM & CPU usage at some expense of KDF strength",
 	}
 	// Miner settings
 	// TODO: refactor CPU vs GPU mining flags


### PR DESCRIPTION
This PR fixes a minor omission of surfacing the light KDF flag into the CLI.