### PR TITLE
miner: bugfix where blockhash in receipts and logs is left empty

### DIFF
--- a/miner/worker.go
+++ b/miner/worker.go
@@ -302,6 +302,17 @@ func (self *worker) wait() {
 					glog.V(logger.Error).Infoln("error writing block to chain", err)
 					continue
 				}
+
+				// update block hash since it is now available and not when the receipt/log of individual transactions were created
+				for _, r := range work.receipts {
+					for _, l := range r.Logs {
+						l.BlockHash = block.Hash()
+					}
+				}
+				for _, log := range work.state.Logs() {
+					log.BlockHash = block.Hash()
+				}
+
 				// check if canon block and write transactions
 				if stat == core.CanonStatTy {
 					// This puts transactions in a extra db for rpc


### PR DESCRIPTION
When the transactions are processed in the miner for the pending block the block hash isn't yet known. As a result the generated receipts and logs don't yet contain the block hash. This PR will update the block hash when the block has been mined.

This fixes #1971.