### PR TITLE
Makefile: individual platforms, configurable Go runtime

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,8 +2,16 @@
 # with Go source code. If you know what GOPATH is then you probably
 # don't need to bother with make.
 
-.PHONY: geth geth-cross geth-linux geth-darwin geth-windows geth-android evm all test travis-test-with-coverage xgo clean
+.PHONY: geth geth-cross evm all test travis-test-with-coverage xgo clean
+.PHONY: geth-linux geth-linux-arm geth-linux-386 geth-linux-amd64
+.PHONY: geth-darwin geth-darwin-386 geth-darwin-amd64
+.PHONY: geth-windows geth-windows-386 geth-windows-amd64
+.PHONY: geth-android geth-android-16 geth-android-21
+
 GOBIN = build/bin
+
+CROSSDEPS = https://gmplib.org/download/gmp/gmp-6.0.0a.tar.bz2
+GO ?= latest
 
 geth:
 	build/env.sh go install -v $(shell build/flags.sh) ./cmd/geth
@@ -14,25 +22,66 @@ geth-cross: geth-linux geth-darwin geth-windows geth-android
 	@echo "Full cross compilation done:"
 	@ls -l $(GOBIN)/geth-*
 
-geth-linux: xgo
-	build/env.sh $(GOBIN)/xgo --dest=$(GOBIN) --deps=https://gmplib.org/download/gmp/gmp-6.0.0a.tar.bz2 --targets=linux/* -v $(shell build/flags.sh) ./cmd/geth
+geth-linux: xgo geth-linux-arm geth-linux-386 geth-linux-amd64
 	@echo "Linux cross compilation done:"
 	@ls -l $(GOBIN)/geth-linux-*
 
-geth-darwin: xgo
-	build/env.sh $(GOBIN)/xgo --dest=$(GOBIN) --deps=https://gmplib.org/download/gmp/gmp-6.0.0a.tar.bz2 --targets=darwin/* -v $(shell build/flags.sh) ./cmd/geth
+geth-linux-arm: xgo
+	build/env.sh $(GOBIN)/xgo --go=$(GO) --dest=$(GOBIN) --deps=$(CROSSDEPS) --targets=linux/arm -v $(shell build/flags.sh) ./cmd/geth
+	@echo "Linux ARM cross compilation done:"
+	@ls -l $(GOBIN)/geth-linux-* | grep arm
+
+geth-linux-386: xgo
+	build/env.sh $(GOBIN)/xgo --go=$(GO) --dest=$(GOBIN) --deps=$(CROSSDEPS) --targets=linux/386 -v $(shell build/flags.sh) ./cmd/geth
+	@echo "Linux 386 cross compilation done:"
+	@ls -l $(GOBIN)/geth-linux-* | grep 386
+
+geth-linux-amd64: xgo
+	build/env.sh $(GOBIN)/xgo --go=$(GO) --dest=$(GOBIN) --deps=$(CROSSDEPS) --targets=linux/amd64 -v $(shell build/flags.sh) ./cmd/geth
+	@echo "Linux amd64 cross compilation done:"
+	@ls -l $(GOBIN)/geth-linux-* | grep amd64
+
+geth-darwin: xgo geth-darwin-386 geth-darwin-amd64
 	@echo "Darwin cross compilation done:"
 	@ls -l $(GOBIN)/geth-darwin-*
 
-geth-windows: xgo
-	build/env.sh $(GOBIN)/xgo --dest=$(GOBIN) --deps=https://gmplib.org/download/gmp/gmp-6.0.0a.tar.bz2 --targets=windows/* -v $(shell build/flags.sh) ./cmd/geth
+geth-darwin-386: xgo
+	build/env.sh $(GOBIN)/xgo --go=$(GO) --dest=$(GOBIN) --deps=$(CROSSDEPS) --targets=darwin/386 -v $(shell build/flags.sh) ./cmd/geth
+	@echo "Darwin 386 cross compilation done:"
+	@ls -l $(GOBIN)/geth-darwin-* | grep 386
+
+geth-darwin-amd64: xgo
+	build/env.sh $(GOBIN)/xgo --go=$(GO) --dest=$(GOBIN) --deps=$(CROSSDEPS) --targets=darwin/amd64 -v $(shell build/flags.sh) ./cmd/geth
+	@echo "Darwin amd64 cross compilation done:"
+	@ls -l $(GOBIN)/geth-darwin-* | grep amd64
+
+geth-windows: xgo geth-windows-386 geth-windows-amd64
 	@echo "Windows cross compilation done:"
 	@ls -l $(GOBIN)/geth-windows-*
 
-geth-android: xgo
-	build/env.sh $(GOBIN)/xgo --dest=$(GOBIN) --deps=https://gmplib.org/download/gmp/gmp-6.0.0a.tar.bz2 --targets=android-16/*,android-21/* -v $(shell build/flags.sh) ./cmd/geth
+geth-windows-386: xgo
+	build/env.sh $(GOBIN)/xgo --go=$(GO) --dest=$(GOBIN) --deps=$(CROSSDEPS) --targets=windows/386 -v $(shell build/flags.sh) ./cmd/geth
+	@echo "Windows 386 cross compilation done:"
+	@ls -l $(GOBIN)/geth-windows-* | grep 386
+
+geth-windows-amd64: xgo
+	build/env.sh $(GOBIN)/xgo --go=$(GO) --dest=$(GOBIN) --deps=$(CROSSDEPS) --targets=windows/amd64 -v $(shell build/flags.sh) ./cmd/geth
+	@echo "Windows amd64 cross compilation done:"
+	@ls -l $(GOBIN)/geth-windows-* | grep amd64
+
+geth-android: xgo geth-android-16 geth-android-21
 	@echo "Android cross compilation done:"
 	@ls -l $(GOBIN)/geth-android-*
+
+geth-android-16: xgo
+	build/env.sh $(GOBIN)/xgo --go=$(GO) --dest=$(GOBIN) --deps=$(CROSSDEPS) --targets=android-16/* -v $(shell build/flags.sh) ./cmd/geth
+	@echo "Android 16 cross compilation done:"
+	@ls -l $(GOBIN)/geth-android-16-*
+
+geth-android-21: xgo
+	build/env.sh $(GOBIN)/xgo --go=$(GO) --dest=$(GOBIN) --deps=$(CROSSDEPS) --targets=android-21/* -v $(shell build/flags.sh) ./cmd/geth
+	@echo "Android 21 cross compilation done:"
+	@ls -l $(GOBIN)/geth-android-21-*
 
 evm:
 	build/env.sh $(GOROOT)/bin/go install -v $(shell build/flags.sh) ./cmd/evm


### PR DESCRIPTION
This PR does two tings:
 - Allows cross compiling to individual platforms: instead of having to build all Linux binaries to get the ARM version, now it's possible to do `make geth-linux-arm`
 - Allows specifying the Go runtime version to build with via the `GO` make variable. Allowed patterns are [those accepted by xgo](https://github.com/karalabe/xgo#go-releases): e.g. `make geth-linux GO=1.5-develop`