### PR TITLE
core: tx pool skip price validation for "owned" transactions

### DIFF
--- a/core/transaction_pool_test.go
+++ b/core/transaction_pool_test.go
@@ -72,6 +72,17 @@ func TestInvalidTransactions(t *testing.T) {
 	if err := pool.Add(tx); err != ErrNonce {
 		t.Error("expected", ErrNonce)
 	}
+
+	tx = transaction(1, big.NewInt(100000), key)
+	pool.minGasPrice = big.NewInt(1000)
+	if err := pool.Add(tx); err != ErrCheap {
+		t.Error("expected", ErrCheap, "got", err)
+	}
+
+	pool.SetLocal(tx)
+	if err := pool.Add(tx); err != nil {
+		t.Error("expected", nil, "got", err)
+	}
 }
 
 func TestTransactionQueue(t *testing.T) {

--- a/eth/api.go
+++ b/eth/api.go
@@ -926,6 +926,7 @@ func (s *PublicTransactionPoolAPI) SendTransaction(args SendTxArgs) (common.Hash
 		return common.Hash{}, err
 	}
 
+	s.txPool.SetLocal(signedTx)
 	if err := s.txPool.Add(signedTx); err != nil {
 		return common.Hash{}, nil
 	}
@@ -948,6 +949,7 @@ func (s *PublicTransactionPoolAPI) SendRawTransaction(encodedTx string) (string,
 		return "", err
 	}
 
+	s.txPool.SetLocal(tx)
 	if err := s.txPool.Add(tx); err != nil {
 		return "", err
 	}

--- a/xeth/xeth.go
+++ b/xeth/xeth.go
@@ -1044,6 +1044,7 @@ func (self *XEth) Transact(fromStr, toStr, nonceStr, valueStr, gasStr, gasPriceS
 	if err != nil {
 		return "", err
 	}
+	self.EthereumService().TxPool().SetLocal(signed)
 	if err = self.EthereumService().TxPool().Add(signed); err != nil {
 		return "", err
 	}


### PR DESCRIPTION
Add "local" parameter for adding transactions which circumvents gas price checking against local miner minimum
