### PR TITLE
console: fix instance name printed incorrect on start

### DIFF
--- a/cmd/geth/js.go
+++ b/cmd/geth/js.go
@@ -245,7 +245,7 @@ func (self *jsre) batch(statement string) {
 func (self *jsre) welcome() {
 	self.re.Run(`
     (function () {
-      console.log('instance: ' + web3.version.client);
+      console.log('instance: ' + web3.version.node);
       console.log(' datadir: ' + admin.datadir);
       console.log("coinbase: " + eth.coinbase);
       var ts = 1000 * eth.getBlock(eth.blockNumber).timestamp;


### PR DESCRIPTION
Probably after a web3 upgrade the instance name isn't printed in the welcome message due to a call to a non existing property. This PR corrects this.



