### PR TITLE
eth package creates new event mux

### DIFF
--- a/eth/backend.go
+++ b/eth/backend.go
@@ -191,7 +191,7 @@ func New(ctx *node.ServiceContext, config *Config) (*Ethereum, error) {
 		shutdownChan:            make(chan bool),
 		chainDb:                 chainDb,
 		dappDb:                  dappDb,
-		eventMux:                &event.TypeMux{},
+		eventMux:                ctx.EventMux,
 		accountManager:          config.AccountManager,
 		etherbase:               config.Etherbase,
 		netVersionId:            config.NetworkId,


### PR DESCRIPTION
`eth.New` creates a new event mux instead of using the global event mux from the node context. This causes events not being posted/received in other parts of the system.

This fixes #2016

