### PR TITLE
Makefile: build ARM v5/v6/v7, drop high API mobile clients

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,11 +3,10 @@
 # don't need to bother with make.
 
 .PHONY: geth geth-cross evm all test travis-test-with-coverage xgo clean
-.PHONY: geth-linux geth-linux-arm geth-linux-386 geth-linux-amd64
+.PHONY: geth-linux geth-linux-arm geth-linux-arm-5 geth-linux-arm-6 geth-linux-arm-7 geth-linux-386 geth-linux-amd64
 .PHONY: geth-darwin geth-darwin-386 geth-darwin-amd64
 .PHONY: geth-windows geth-windows-386 geth-windows-amd64
-.PHONY: geth-android geth-android-16 geth-android-21
-.PHONY: geth-ios geth-ios-5.0 geth-ios-8.1
+.PHONY: geth-android geth-ios
 
 GOBIN = build/bin
 
@@ -24,14 +23,9 @@ geth-cross: geth-linux geth-darwin geth-windows geth-android geth-ios
 	@echo "Full cross compilation done:"
 	@ls -l $(GOBIN)/geth-*
 
-geth-linux: xgo geth-linux-arm geth-linux-386 geth-linux-amd64
+geth-linux: geth-linux-386 geth-linux-amd64 geth-linux-arm
 	@echo "Linux cross compilation done:"
 	@ls -l $(GOBIN)/geth-linux-*
-
-geth-linux-arm: xgo
-	build/env.sh $(GOBIN)/xgo --go=$(GO) --buildmode=$(MODE) --dest=$(GOBIN) --deps=$(CROSSDEPS) --targets=linux/arm -v $(shell build/flags.sh) ./cmd/geth
-	@echo "Linux ARM cross compilation done:"
-	@ls -l $(GOBIN)/geth-linux-* | grep arm
 
 geth-linux-386: xgo
 	build/env.sh $(GOBIN)/xgo --go=$(GO) --buildmode=$(MODE) --dest=$(GOBIN) --deps=$(CROSSDEPS) --targets=linux/386 -v $(shell build/flags.sh) ./cmd/geth
@@ -43,7 +37,26 @@ geth-linux-amd64: xgo
 	@echo "Linux amd64 cross compilation done:"
 	@ls -l $(GOBIN)/geth-linux-* | grep amd64
 
-geth-darwin: xgo geth-darwin-386 geth-darwin-amd64
+geth-linux-arm: geth-linux-arm-5 geth-linux-arm-6 geth-linux-arm-7
+	@echo "Linux ARM cross compilation done:"
+	@ls -l $(GOBIN)/geth-linux-* | grep arm
+
+geth-linux-arm-5: xgo
+	build/env.sh $(GOBIN)/xgo --go=$(GO) --buildmode=$(MODE) --dest=$(GOBIN) --deps=$(CROSSDEPS) --targets=linux/arm-5 -v $(shell build/flags.sh) ./cmd/geth
+	@echo "Linux ARMv5 cross compilation done:"
+	@ls -l $(GOBIN)/geth-linux-* | grep arm-5
+
+geth-linux-arm-6: xgo
+	build/env.sh $(GOBIN)/xgo --go=$(GO) --buildmode=$(MODE) --dest=$(GOBIN) --deps=$(CROSSDEPS) --targets=linux/arm-6 -v $(shell build/flags.sh) ./cmd/geth
+	@echo "Linux ARMv6 cross compilation done:"
+	@ls -l $(GOBIN)/geth-linux-* | grep arm-6
+
+geth-linux-arm-7: xgo
+	build/env.sh $(GOBIN)/xgo --go=$(GO) --buildmode=$(MODE) --dest=$(GOBIN) --deps=$(CROSSDEPS) --targets=linux/arm-7 -v $(shell build/flags.sh) ./cmd/geth
+	@echo "Linux ARMv7 cross compilation done:"
+	@ls -l $(GOBIN)/geth-linux-* | grep arm-7
+
+geth-darwin: geth-darwin-386 geth-darwin-amd64
 	@echo "Darwin cross compilation done:"
 	@ls -l $(GOBIN)/geth-darwin-*
 
@@ -57,7 +70,7 @@ geth-darwin-amd64: xgo
 	@echo "Darwin amd64 cross compilation done:"
 	@ls -l $(GOBIN)/geth-darwin-* | grep amd64
 
-geth-windows: xgo geth-windows-386 geth-windows-amd64
+geth-windows: geth-windows-386 geth-windows-amd64
 	@echo "Windows cross compilation done:"
 	@ls -l $(GOBIN)/geth-windows-*
 
@@ -71,33 +84,15 @@ geth-windows-amd64: xgo
 	@echo "Windows amd64 cross compilation done:"
 	@ls -l $(GOBIN)/geth-windows-* | grep amd64
 
-geth-android: xgo geth-android-16 geth-android-21
+geth-android: xgo
+	build/env.sh $(GOBIN)/xgo --go=$(GO) --buildmode=$(MODE) --dest=$(GOBIN) --deps=$(CROSSDEPS) --targets=android/* -v $(shell build/flags.sh) ./cmd/geth
 	@echo "Android cross compilation done:"
 	@ls -l $(GOBIN)/geth-android-*
 
-geth-android-16: xgo
-	build/env.sh $(GOBIN)/xgo --go=$(GO) --buildmode=$(MODE) --dest=$(GOBIN) --deps=$(CROSSDEPS) --targets=android-16/* -v $(shell build/flags.sh) ./cmd/geth
-	@echo "Android 16 cross compilation done:"
-	@ls -l $(GOBIN)/geth-android-16-*
-
-geth-android-21: xgo
-	build/env.sh $(GOBIN)/xgo --go=$(GO) --buildmode=$(MODE) --dest=$(GOBIN) --deps=$(CROSSDEPS) --targets=android-21/* -v $(shell build/flags.sh) ./cmd/geth
-	@echo "Android 21 cross compilation done:"
-	@ls -l $(GOBIN)/geth-android-21-*
-
-geth-ios: xgo geth-ios-5.0 geth-ios-8.1
+geth-ios: xgo
+	build/env.sh $(GOBIN)/xgo --go=$(GO) --buildmode=$(MODE) --dest=$(GOBIN) --deps=$(CROSSDEPS) --depsargs=--disable-assembly --targets=ios/* -v $(shell build/flags.sh) ./cmd/geth
 	@echo "iOS cross compilation done:"
 	@ls -l $(GOBIN)/geth-ios-*
-
-geth-ios-5.0:
-	build/env.sh $(GOBIN)/xgo --go=$(GO) --buildmode=$(MODE) --dest=$(GOBIN) --deps=$(CROSSDEPS) --depsargs=--disable-assembly --targets=ios-5.0/* -v $(shell build/flags.sh) ./cmd/geth
-	@echo "iOS 5.0 cross compilation done:"
-	@ls -l $(GOBIN)/geth-ios-5.0-*
-
-geth-ios-8.1:
-	build/env.sh $(GOBIN)/xgo --go=$(GO) --buildmode=$(MODE) --dest=$(GOBIN) --deps=$(CROSSDEPS) --depsargs=--disable-assembly --targets=ios-8.1/* -v $(shell build/flags.sh) ./cmd/geth
-	@echo "iOS 8.1 cross compilation done:"
-	@ls -l $(GOBIN)/geth-ios-8.1-*
 
 evm:
 	build/env.sh $(GOROOT)/bin/go install -v $(shell build/flags.sh) ./cmd/evm


### PR DESCRIPTION
This PR builds upon the latest xgo updates which enabled building Linux binaries for later versions of ARM than v5 previously. Currently this allows building geth for `ARMv5`, `ARMv6` and `ARMv7`, the first two being `armel` architectures and the latter one being `armhf`. The two are incompatible, hence the need to actually support for sub-architectures.

I've also dropped building iOS 8.1 and Android 21, as we are already building for lower API versions (5.0 and 16 respectively), which should run fine on later devices. If we get to actually deploying to live devices we might reconsider these, but until then this should put less of a burden on build servers and have the same results anyway.