### PR TITLE
accounts: increase re-lock timeout to account for slow CI servers

### DIFF
--- a/accounts/accounts_test.go
+++ b/accounts/accounts_test.go
@@ -68,7 +68,7 @@ func TestTimedUnlock(t *testing.T) {
 	}
 
 	// Signing fails again after automatic locking
-	time.Sleep(150 * time.Millisecond)
+	time.Sleep(350 * time.Millisecond)
 	_, err = am.Sign(a1, testSigData)
 	if err != ErrLocked {
 		t.Fatal("Signing should've failed with ErrLocked timeout expired, got ", err)


### PR DESCRIPTION
Hopefully fixes https://github.com/ethereum/go-ethereum/issues/2023

My guess is that the CI server is way too busy when running the batch of tests, and the 50ms time between an account re-lock and the testing of the re-lock is occasionally too small during heavy testing. This PR increases that time gap to 250ms. If it still times out, we might consider a deeper issue.