### PR TITLE
accounts: release the mutex during signing

### DIFF
--- a/accounts/account_manager.go
+++ b/accounts/account_manager.go
@@ -78,8 +78,8 @@ func (am *Manager) DeleteAccount(address common.Address, auth string) error {
 
 func (am *Manager) Sign(a Account, toSign []byte) (signature []byte, err error) {
 	am.mutex.RLock()
-	defer am.mutex.RUnlock()
 	unlockedKey, found := am.unlocked[a.Address]
+	am.mutex.RUnlock()
 	if !found {
 		return nil, ErrLocked
 	}


### PR DESCRIPTION
The account manager holds the mutex for the entirety of the signing procedure, whereas it is only needed to fetch the key itself with which to sign. Since the signing can be quite an expensive operation, there's no need to keep the lock in the mean time.