### PR TITLE
p2p: always allow dynamic dials if network not disabled

### DIFF
--- a/p2p/server.go
+++ b/p2p/server.go
@@ -337,7 +337,7 @@ func (srv *Server) Start() (err error) {
 		srv.ntab = ntab
 	}
 
-	dynPeers := srv.MaxPeers / 2
+	dynPeers := (srv.MaxPeers + 1) / 2
 	if !srv.Discovery {
 		dynPeers = 0
 	}


### PR DESCRIPTION
This PR fixes a small subtlety in the p2p code which split the available connection pool into two equal halves, one for outbound connections and the other for inbound. The issue was that the code set `MaxPeers / 2` as the number of allowed outbound dials, which results in 0 if the MaxPeers is set to 1 (realistic scenario for very limited devices, at least for now). However, if the process cannot accept inbound connections (firewalled, NATed, etc), then the node will never be able to connect. By using the *ceiling* of `MaxPeers / 2` opposed to the current *floor* we ensure that if only 1 single peer is allowed, that can be either an inbound or also an outbound connection.