### PR TITLE
core: write individual transactions and receipts too on fast sync

### DIFF
--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -980,6 +980,18 @@ func (self *BlockChain) InsertReceiptChain(blockChain types.Blocks, receiptChain
 				glog.Fatal(errs[index])
 				return
 			}
+			if err := WriteTransactions(self.chainDb, block); err != nil {
+				errs[index] = fmt.Errorf("failed to write individual transactions: %v", err)
+				atomic.AddInt32(&failed, 1)
+				glog.Fatal(errs[index])
+				return
+			}
+			if err := WriteReceipts(self.chainDb, receipts); err != nil {
+				errs[index] = fmt.Errorf("failed to write individual receipts: %v", err)
+				atomic.AddInt32(&failed, 1)
+				glog.Fatal(errs[index])
+				return
+			}
 			atomic.AddInt32(&stats.processed, 1)
 		}
 	}


### PR DESCRIPTION
The fast sync previously didn't write out individual transactions and receipts used by the RPC API, so even though they were there in the database, they weren't retrievable from the RPC. This fix is simply an addition to dump not just the block-grouped transactions and receipts, but rather individual ones too during fast sync receipt processing.

```js
> web3.eth.getTransaction('0x8842346511606ea1faf6138de1dca307f0c6ee0ccc9992f6aacb5fd0d398cfaa')
{
  blockHash: "0x2b7dc663ff78a86ea765346e7da2592b72c528237d96c8e97167779234f45023",
  blockNumber: 614313,
  from: "0xa0cb41b219b4169e6495e09676c80e9dafb69523",
  gas: 129244,
  gasPrice: 50000000000,
  hash: "0x8842346511606ea1faf6138de1dca307f0c6ee0ccc9992f6aacb5fd0d398cfaa",
  input: "0x",
  nonce: 7,
  to: "0x2d7a9d8d3c88836aec94162c0cf017f10073284e",
  transactionIndex: 0,
  value: 420000000000000000000
}
```

```js
> web3.eth.getTransactionReceipt('0x8842346511606ea1faf6138de1dca307f0c6ee0ccc9992f6aacb5fd0d398cfaa')
{
  blockHash: "0x2b7dc663ff78a86ea765346e7da2592b72c528237d96c8e97167779234f45023",
  blockNumber: 614313,
  contractAddress: null,
  cumulativeGasUsed: 29244,
  gasUsed: 29244,
  logs: [{
      address: "0x2d7a9d8d3c88836aec94162c0cf017f10073284e",
      blockHash: "0x2b7dc663ff78a86ea765346e7da2592b72c528237d96c8e97167779234f45023",
      blockNumber: 614313,
      data: "0x000000000000000000000000a0cb41b219b4169e6495e09676c80e9dafb69523000000000000000000000000000000000000000000000016c4abbebea0100000",
      logIndex: 0,
      topics: ["0xe1fffcc4923d04b559f4d29a8bfc6cda04eb5b0d3c460751c2402c5c5cc9109c"],
      transactionHash: "0x8842346511606ea1faf6138de1dca307f0c6ee0ccc9992f6aacb5fd0d398cfaa",
      transactionIndex: 0
  }],
  transactionHash: "0x8842346511606ea1faf6138de1dca307f0c6ee0ccc9992f6aacb5fd0d398cfaa",
  transactionIndex: 0
}
```