### PR TITLE
crypto: "Crypto" -> "crypto" in web3 key format

### DIFF
--- a/crypto/key.go
+++ b/crypto/key.go
@@ -50,17 +50,17 @@ type plainKeyJSON struct {
 }
 
 type encryptedKeyJSONV3 struct {
-	Address string `json:"address"`
-	Crypto  cryptoJSON
-	Id      string `json:"id"`
-	Version int    `json:"version"`
+	Address string     `json:"address"`
+	Crypto  cryptoJSON `json:"crypto"`
+	Id      string     `json:"id"`
+	Version int        `json:"version"`
 }
 
 type encryptedKeyJSONV1 struct {
-	Address string `json:"address"`
-	Crypto  cryptoJSON
-	Id      string `json:"id"`
-	Version string `json:"version"`
+	Address string     `json:"address"`
+	Crypto  cryptoJSON `json:"crypto"`
+	Id      string     `json:"id"`
+	Version string     `json:"version"`
 }
 
 type cryptoJSON struct {


### PR DESCRIPTION
This fixes an issue where geth created keys that are not compatible with other
implementations of the Web3 Secret Storage specification.
I verified (using `eth.sign`) that existing keys continue to work.