### PR TITLE
Makefile, cmd/geth: assemble ios xcode frameworks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,12 +7,9 @@
 .PHONY: geth-linux-arm geth-linux-arm-5 geth-linux-arm-6 geth-linux-arm-7 geth-linux-arm64
 .PHONY: geth-darwin geth-darwin-386 geth-darwin-amd64
 .PHONY: geth-windows geth-windows-386 geth-windows-amd64
-.PHONY: geth-android
-.PHONY: geth-ios geth-ios-arm-7 geth-ios-arm64
+.PHONY: geth-android geth-ios geth-ios-sim
 
 GOBIN = build/bin
-
-MODE ?= default
 GO ?= latest
 
 geth:
@@ -29,12 +26,12 @@ geth-linux: geth-linux-386 geth-linux-amd64 geth-linux-arm
 	@ls -l $(GOBIN)/geth-linux-*
 
 geth-linux-386: xgo
-	build/env.sh $(GOBIN)/xgo --go=$(GO) --buildmode=$(MODE) --dest=$(GOBIN) --targets=linux/386 -v $(shell build/flags.sh) ./cmd/geth
+	build/env.sh $(GOBIN)/xgo --go=$(GO) --dest=$(GOBIN) --targets=linux/386 -v $(shell build/flags.sh) ./cmd/geth
 	@echo "Linux 386 cross compilation done:"
 	@ls -l $(GOBIN)/geth-linux-* | grep 386
 
 geth-linux-amd64: xgo
-	build/env.sh $(GOBIN)/xgo --go=$(GO) --buildmode=$(MODE) --dest=$(GOBIN) --targets=linux/amd64 -v $(shell build/flags.sh) ./cmd/geth
+	build/env.sh $(GOBIN)/xgo --go=$(GO) --dest=$(GOBIN) --targets=linux/amd64 -v $(shell build/flags.sh) ./cmd/geth
 	@echo "Linux amd64 cross compilation done:"
 	@ls -l $(GOBIN)/geth-linux-* | grep amd64
 
@@ -43,22 +40,22 @@ geth-linux-arm: geth-linux-arm-5 geth-linux-arm-6 geth-linux-arm-7 geth-linux-ar
 	@ls -l $(GOBIN)/geth-linux-* | grep arm
 
 geth-linux-arm-5: xgo
-	build/env.sh $(GOBIN)/xgo --go=$(GO) --buildmode=$(MODE) --dest=$(GOBIN) --targets=linux/arm-5 -v $(shell build/flags.sh) ./cmd/geth
+	build/env.sh $(GOBIN)/xgo --go=$(GO) --dest=$(GOBIN) --targets=linux/arm-5 -v $(shell build/flags.sh) ./cmd/geth
 	@echo "Linux ARMv5 cross compilation done:"
 	@ls -l $(GOBIN)/geth-linux-* | grep arm-5
 
 geth-linux-arm-6: xgo
-	build/env.sh $(GOBIN)/xgo --go=$(GO) --buildmode=$(MODE) --dest=$(GOBIN) --targets=linux/arm-6 -v $(shell build/flags.sh) ./cmd/geth
+	build/env.sh $(GOBIN)/xgo --go=$(GO) --dest=$(GOBIN) --targets=linux/arm-6 -v $(shell build/flags.sh) ./cmd/geth
 	@echo "Linux ARMv6 cross compilation done:"
 	@ls -l $(GOBIN)/geth-linux-* | grep arm-6
 
 geth-linux-arm-7: xgo
-	build/env.sh $(GOBIN)/xgo --go=$(GO) --buildmode=$(MODE) --dest=$(GOBIN) --targets=linux/arm-7 -v $(shell build/flags.sh) ./cmd/geth
+	build/env.sh $(GOBIN)/xgo --go=$(GO) --dest=$(GOBIN) --targets=linux/arm-7 -v $(shell build/flags.sh) ./cmd/geth
 	@echo "Linux ARMv7 cross compilation done:"
 	@ls -l $(GOBIN)/geth-linux-* | grep arm-7
 
 geth-linux-arm64: xgo
-	build/env.sh $(GOBIN)/xgo --go=$(GO) --buildmode=$(MODE) --dest=$(GOBIN) --targets=linux/arm64 -v $(shell build/flags.sh) ./cmd/geth
+	build/env.sh $(GOBIN)/xgo --go=$(GO) --dest=$(GOBIN) --targets=linux/arm64 -v $(shell build/flags.sh) ./cmd/geth
 	@echo "Linux ARM64 cross compilation done:"
 	@ls -l $(GOBIN)/geth-linux-* | grep arm64
 
@@ -67,12 +64,12 @@ geth-darwin: geth-darwin-386 geth-darwin-amd64
 	@ls -l $(GOBIN)/geth-darwin-*
 
 geth-darwin-386: xgo
-	build/env.sh $(GOBIN)/xgo --go=$(GO) --buildmode=$(MODE) --dest=$(GOBIN) --targets=darwin/386 -v $(shell build/flags.sh) ./cmd/geth
+	build/env.sh $(GOBIN)/xgo --go=$(GO) --dest=$(GOBIN) --targets=darwin/386 -v $(shell build/flags.sh) ./cmd/geth
 	@echo "Darwin 386 cross compilation done:"
 	@ls -l $(GOBIN)/geth-darwin-* | grep 386
 
 geth-darwin-amd64: xgo
-	build/env.sh $(GOBIN)/xgo --go=$(GO) --buildmode=$(MODE) --dest=$(GOBIN) --targets=darwin/amd64 -v $(shell build/flags.sh) ./cmd/geth
+	build/env.sh $(GOBIN)/xgo --go=$(GO) --dest=$(GOBIN) --targets=darwin/amd64 -v $(shell build/flags.sh) ./cmd/geth
 	@echo "Darwin amd64 cross compilation done:"
 	@ls -l $(GOBIN)/geth-darwin-* | grep amd64
 
@@ -81,33 +78,29 @@ geth-windows: geth-windows-386 geth-windows-amd64
 	@ls -l $(GOBIN)/geth-windows-*
 
 geth-windows-386: xgo
-	build/env.sh $(GOBIN)/xgo --go=$(GO) --buildmode=$(MODE) --dest=$(GOBIN) --targets=windows/386 -v $(shell build/flags.sh) ./cmd/geth
+	build/env.sh $(GOBIN)/xgo --go=$(GO) --dest=$(GOBIN) --targets=windows/386 -v $(shell build/flags.sh) ./cmd/geth
 	@echo "Windows 386 cross compilation done:"
 	@ls -l $(GOBIN)/geth-windows-* | grep 386
 
 geth-windows-amd64: xgo
-	build/env.sh $(GOBIN)/xgo --go=$(GO) --buildmode=$(MODE) --dest=$(GOBIN) --targets=windows/amd64 -v $(shell build/flags.sh) ./cmd/geth
+	build/env.sh $(GOBIN)/xgo --go=$(GO) --dest=$(GOBIN) --targets=windows/amd64 -v $(shell build/flags.sh) ./cmd/geth
 	@echo "Windows amd64 cross compilation done:"
 	@ls -l $(GOBIN)/geth-windows-* | grep amd64
 
 geth-android: xgo
-	build/env.sh $(GOBIN)/xgo --go=$(GO) --buildmode=$(MODE) --dest=$(GOBIN) --targets=android/* -v $(shell build/flags.sh) ./cmd/geth
+	build/env.sh $(GOBIN)/xgo --go=$(GO) --dest=$(GOBIN) --targets=android/* -v $(shell build/flags.sh) ./cmd/geth
 	@echo "Android cross compilation done:"
 	@ls -l $(GOBIN)/geth-android-*
 
-geth-ios: geth-ios-arm-7 geth-ios-arm64
-	@echo "iOS cross compilation done:"
+geth-ios: xgo
+	build/env.sh $(GOBIN)/xgo --go=$(GO) --dest=$(GOBIN) --targets=ios-7.0/* -v $(shell build/flags.sh) ./cmd/geth
+	@echo "iOS framework cross compilation done:"
 	@ls -l $(GOBIN)/geth-ios-*
 
-geth-ios-arm-7: xgo
-	build/env.sh $(GOBIN)/xgo --go=$(GO) --buildmode=$(MODE) --dest=$(GOBIN) --targets=ios/arm-7 -v $(shell build/flags.sh) ./cmd/geth
-	@echo "iOS ARMv7 cross compilation done:"
-	@ls -l $(GOBIN)/geth-ios-* | grep arm-7
-
-geth-ios-arm64: xgo
-	build/env.sh $(GOBIN)/xgo --go=$(GO) --buildmode=$(MODE) --dest=$(GOBIN) --targets=ios-7.0/arm64 -v $(shell build/flags.sh) ./cmd/geth
-	@echo "iOS ARM64 cross compilation done:"
-	@ls -l $(GOBIN)/geth-ios-* | grep arm64
+geth-ios-sim: xgo
+	build/env.sh $(GOBIN)/xgo --go=$(GO) --dest=$(GOBIN) --targets=ios-7.0/amd64 -v $(shell build/flags.sh) ./cmd/geth
+	@echo "iOS framework simulator-only cross compilation done:"
+	@ls -l $(GOBIN)/geth-ios-*
 
 evm:
 	build/env.sh $(GOROOT)/bin/go install -v $(shell build/flags.sh) ./cmd/evm

--- a/cmd/geth/library.c
+++ b/cmd/geth/library.c
@@ -1,0 +1,24 @@
+// Copyright 2015 The go-ethereum Authors
+// This file is part of go-ethereum.
+//
+// go-ethereum is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// go-ethereum is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with go-ethereum. If not, see <http://www.gnu.org/licenses/>.
+
+// Simple wrapper to translate the API exposed methods and types to inthernal
+// Go versions of the same types.
+
+#include "_cgo_export.h"
+
+int run(const char* args) {
+ return doRun((char*)args);
+}

--- a/cmd/geth/library.go
+++ b/cmd/geth/library.go
@@ -1,0 +1,46 @@
+// Copyright 2015 The go-ethereum Authors
+// This file is part of go-ethereum.
+//
+// go-ethereum is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// go-ethereum is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with go-ethereum. If not, see <http://www.gnu.org/licenses/>.
+
+// Contains a simple library definition to allow creating a Geth instance from
+// straight C code.
+
+package main
+
+// #ifdef __cplusplus
+// extern "C" {
+// #endif
+//
+// extern int run(const char*);
+//
+// #ifdef __cplusplus
+// }
+// #endif
+import "C"
+import (
+	"fmt"
+	"os"
+	"strings"
+)
+
+//export doRun
+func doRun(args *C.char) C.int {
+	// This is equivalent to geth.main, just modified to handle the function arg passing
+	if err := app.Run(strings.Split("geth "+C.GoString(args), " ")); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		return -1
+	}
+	return 0
+}

--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -340,6 +340,8 @@ JavaScript API. See https://github.com/ethereum/go-ethereum/wiki/Javascipt-Conso
 		utils.ExtraDataFlag,
 	}
 	app.Before = func(ctx *cli.Context) error {
+		runtime.GOMAXPROCS(runtime.NumCPU())
+
 		utils.SetupLogger(ctx)
 		utils.SetupNetwork(ctx)
 		utils.SetupVM(ctx)
@@ -353,7 +355,6 @@ JavaScript API. See https://github.com/ethereum/go-ethereum/wiki/Javascipt-Conso
 }
 
 func main() {
-	runtime.GOMAXPROCS(runtime.NumCPU())
 	defer logger.Flush()
 	if err := app.Run(os.Args); err != nil {
 		fmt.Fprintln(os.Stderr, err)


### PR DESCRIPTION
*Don't merge just yet, I've still to do a final round of evaluation on an osx machine*

This PR enables calling `geth.run("command line flags")` from other programming languages via C bindings, and also enables the assembly of Xcode frameworks for geth in iOS, containing the libraries for `armv7`, `arm64` and optionally `x86_64` simulator if `xgo` is properly injected with it.