### PR TITLE
Makefile, cmd/geth: support building Android archives

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@
 .PHONY: geth-linux-arm geth-linux-arm-5 geth-linux-arm-6 geth-linux-arm-7 geth-linux-arm64
 .PHONY: geth-darwin geth-darwin-386 geth-darwin-amd64
 .PHONY: geth-windows geth-windows-386 geth-windows-amd64
-.PHONY: geth-android geth-ios geth-ios-sim
+.PHONY: geth-android geth-ios
 
 GOBIN = build/bin
 GO ?= latest
@@ -19,88 +19,83 @@ geth:
 
 geth-cross: geth-linux geth-darwin geth-windows geth-android geth-ios
 	@echo "Full cross compilation done:"
-	@ls -l $(GOBIN)/geth-*
+	@ls -ld $(GOBIN)/geth-*
 
 geth-linux: geth-linux-386 geth-linux-amd64 geth-linux-arm
 	@echo "Linux cross compilation done:"
-	@ls -l $(GOBIN)/geth-linux-*
+	@ls -ld $(GOBIN)/geth-linux-*
 
 geth-linux-386: xgo
 	build/env.sh $(GOBIN)/xgo --go=$(GO) --dest=$(GOBIN) --targets=linux/386 -v $(shell build/flags.sh) ./cmd/geth
 	@echo "Linux 386 cross compilation done:"
-	@ls -l $(GOBIN)/geth-linux-* | grep 386
+	@ls -ld $(GOBIN)/geth-linux-* | grep 386
 
 geth-linux-amd64: xgo
 	build/env.sh $(GOBIN)/xgo --go=$(GO) --dest=$(GOBIN) --targets=linux/amd64 -v $(shell build/flags.sh) ./cmd/geth
 	@echo "Linux amd64 cross compilation done:"
-	@ls -l $(GOBIN)/geth-linux-* | grep amd64
+	@ls -ld $(GOBIN)/geth-linux-* | grep amd64
 
 geth-linux-arm: geth-linux-arm-5 geth-linux-arm-6 geth-linux-arm-7 geth-linux-arm64
 	@echo "Linux ARM cross compilation done:"
-	@ls -l $(GOBIN)/geth-linux-* | grep arm
+	@ls -ld $(GOBIN)/geth-linux-* | grep arm
 
 geth-linux-arm-5: xgo
 	build/env.sh $(GOBIN)/xgo --go=$(GO) --dest=$(GOBIN) --targets=linux/arm-5 -v $(shell build/flags.sh) ./cmd/geth
 	@echo "Linux ARMv5 cross compilation done:"
-	@ls -l $(GOBIN)/geth-linux-* | grep arm-5
+	@ls -ld $(GOBIN)/geth-linux-* | grep arm-5
 
 geth-linux-arm-6: xgo
 	build/env.sh $(GOBIN)/xgo --go=$(GO) --dest=$(GOBIN) --targets=linux/arm-6 -v $(shell build/flags.sh) ./cmd/geth
 	@echo "Linux ARMv6 cross compilation done:"
-	@ls -l $(GOBIN)/geth-linux-* | grep arm-6
+	@ls -ld $(GOBIN)/geth-linux-* | grep arm-6
 
 geth-linux-arm-7: xgo
 	build/env.sh $(GOBIN)/xgo --go=$(GO) --dest=$(GOBIN) --targets=linux/arm-7 -v $(shell build/flags.sh) ./cmd/geth
 	@echo "Linux ARMv7 cross compilation done:"
-	@ls -l $(GOBIN)/geth-linux-* | grep arm-7
+	@ls -ld $(GOBIN)/geth-linux-* | grep arm-7
 
 geth-linux-arm64: xgo
 	build/env.sh $(GOBIN)/xgo --go=$(GO) --dest=$(GOBIN) --targets=linux/arm64 -v $(shell build/flags.sh) ./cmd/geth
 	@echo "Linux ARM64 cross compilation done:"
-	@ls -l $(GOBIN)/geth-linux-* | grep arm64
+	@ls -ld $(GOBIN)/geth-linux-* | grep arm64
 
 geth-darwin: geth-darwin-386 geth-darwin-amd64
 	@echo "Darwin cross compilation done:"
-	@ls -l $(GOBIN)/geth-darwin-*
+	@ls -ld $(GOBIN)/geth-darwin-*
 
 geth-darwin-386: xgo
 	build/env.sh $(GOBIN)/xgo --go=$(GO) --dest=$(GOBIN) --targets=darwin/386 -v $(shell build/flags.sh) ./cmd/geth
 	@echo "Darwin 386 cross compilation done:"
-	@ls -l $(GOBIN)/geth-darwin-* | grep 386
+	@ls -ld $(GOBIN)/geth-darwin-* | grep 386
 
 geth-darwin-amd64: xgo
 	build/env.sh $(GOBIN)/xgo --go=$(GO) --dest=$(GOBIN) --targets=darwin/amd64 -v $(shell build/flags.sh) ./cmd/geth
 	@echo "Darwin amd64 cross compilation done:"
-	@ls -l $(GOBIN)/geth-darwin-* | grep amd64
+	@ls -ld $(GOBIN)/geth-darwin-* | grep amd64
 
 geth-windows: geth-windows-386 geth-windows-amd64
 	@echo "Windows cross compilation done:"
-	@ls -l $(GOBIN)/geth-windows-*
+	@ls -ld $(GOBIN)/geth-windows-*
 
 geth-windows-386: xgo
 	build/env.sh $(GOBIN)/xgo --go=$(GO) --dest=$(GOBIN) --targets=windows/386 -v $(shell build/flags.sh) ./cmd/geth
 	@echo "Windows 386 cross compilation done:"
-	@ls -l $(GOBIN)/geth-windows-* | grep 386
+	@ls -ld $(GOBIN)/geth-windows-* | grep 386
 
 geth-windows-amd64: xgo
 	build/env.sh $(GOBIN)/xgo --go=$(GO) --dest=$(GOBIN) --targets=windows/amd64 -v $(shell build/flags.sh) ./cmd/geth
 	@echo "Windows amd64 cross compilation done:"
-	@ls -l $(GOBIN)/geth-windows-* | grep amd64
+	@ls -ld $(GOBIN)/geth-windows-* | grep amd64
 
 geth-android: xgo
-	build/env.sh $(GOBIN)/xgo --go=$(GO) --dest=$(GOBIN) --targets=android/* -v $(shell build/flags.sh) ./cmd/geth
+	build/env.sh $(GOBIN)/xgo --go=$(GO) --dest=$(GOBIN) --targets=android-21/aar -v $(shell build/flags.sh) ./cmd/geth
 	@echo "Android cross compilation done:"
-	@ls -l $(GOBIN)/geth-android-*
+	@ls -ld $(GOBIN)/geth-android-*
 
 geth-ios: xgo
-	build/env.sh $(GOBIN)/xgo --go=$(GO) --dest=$(GOBIN) --targets=ios-7.0/* -v $(shell build/flags.sh) ./cmd/geth
+	build/env.sh $(GOBIN)/xgo --go=$(GO) --dest=$(GOBIN) --targets=ios-7.0/framework -v $(shell build/flags.sh) ./cmd/geth
 	@echo "iOS framework cross compilation done:"
-	@ls -l $(GOBIN)/geth-ios-*
-
-geth-ios-sim: xgo
-	build/env.sh $(GOBIN)/xgo --go=$(GO) --dest=$(GOBIN) --targets=ios-7.0/amd64 -v $(shell build/flags.sh) ./cmd/geth
-	@echo "iOS framework simulator-only cross compilation done:"
-	@ls -l $(GOBIN)/geth-ios-*
+	@ls -ld $(GOBIN)/geth-ios-*
 
 evm:
 	build/env.sh $(GOROOT)/bin/go install -v $(shell build/flags.sh) ./cmd/evm

--- a/cmd/geth/library_android.go
+++ b/cmd/geth/library_android.go
@@ -1,0 +1,56 @@
+// Copyright 2015 The go-ethereum Authors
+// This file is part of go-ethereum.
+//
+// go-ethereum is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// go-ethereum is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with go-ethereum. If not, see <http://www.gnu.org/licenses/>.
+
+// Contains specialized code for running Geth on Android.
+
+package main
+
+// #include <android/log.h>
+// #cgo LDFLAGS: -llog
+import "C"
+import (
+	"bufio"
+	"os"
+)
+
+func init() {
+	// Redirect the standard output and error to logcat
+	oldStdout, oldStderr := os.Stdout, os.Stderr
+
+	outRead, outWrite, _ := os.Pipe()
+	errRead, errWrite, _ := os.Pipe()
+
+	os.Stdout = outWrite
+	os.Stderr = errWrite
+
+	go func() {
+		scanner := bufio.NewScanner(outRead)
+		for scanner.Scan() {
+			line := scanner.Text()
+			C.__android_log_write(C.ANDROID_LOG_INFO, C.CString("Stdout"), C.CString(line))
+			oldStdout.WriteString(line + "\n")
+		}
+	}()
+
+	go func() {
+		scanner := bufio.NewScanner(errRead)
+		for scanner.Scan() {
+			line := scanner.Text()
+			C.__android_log_write(C.ANDROID_LOG_INFO, C.CString("Stderr"), C.CString(line))
+			oldStderr.WriteString(line + "\n")
+		}
+	}()
+}


### PR DESCRIPTION
This PR modifies the Makefile yet again to use the Android .aar enabled xgo to generate importable archives on Android too.

Further it adds a temporary `library_android.go` file that streams the `stdout` and `stderr` streams into the Android `logcat` service. I'm aware that this is a very ugly solution to have it in the `cmd/geth` package, but we need unified log handling first, otherwise I'd need to add a special Android version of a lof of methods all over the code base.

Similarly a missing feature is that we need to unify the number of places we can `os.Exit` and insert flushing all output to the `logcat` before exiting, as the `Exit` will terminate all Go threads as well as all Android threads (i.e. it exists the entire mobile app). This may be something we'd like to consider how best to handle.