### PR TITLE
core, eth, node, rpc: port the admin and debug API

### DIFF
--- a/cmd/gethrpctest/main.go
+++ b/cmd/gethrpctest/main.go
@@ -214,7 +214,7 @@ func StartIPC(stack *node.Node) error {
 	server := rpc.NewServer()
 
 	// register package API's this node provides
-	offered := stack.RPCAPIs()
+	offered := stack.APIs()
 	for _, api := range offered {
 		server.RegisterName(api.Namespace, api.Service)
 		glog.V(logger.Debug).Infof("Register %T@%s for IPC service\n", api.Service, api.Namespace)

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -798,7 +798,7 @@ func StartIPC(stack *node.Node, ctx *cli.Context) error {
 		server := rpc.NewServer()
 
 		// register package API's this node provides
-		offered := stack.RPCAPIs()
+		offered := stack.APIs()
 		for _, api := range offered {
 			server.RegisterName(api.Namespace, api.Service)
 			glog.V(logger.Debug).Infof("Register %T under namespace '%s' for IPC service\n", api.Service, api.Namespace)

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -295,6 +295,19 @@ func (s *Ethereum) APIs() []rpc.API {
 			Version:   "1.0",
 			Service:   filters.NewPublicFilterAPI(s.ChainDb(), s.EventMux()),
 			Public:    true,
+		}, {
+			Namespace: "admin",
+			Version:   "1.0",
+			Service:   NewPrivateAdminAPI(s),
+		}, {
+			Namespace: "debug",
+			Version:   "1.0",
+			Service:   NewPublicDebugAPI(s),
+			Public:    true,
+		}, {
+			Namespace: "debug",
+			Version:   "1.0",
+			Service:   NewPrivateDebugAPI(s),
 		},
 	}
 }

--- a/node/api.go
+++ b/node/api.go
@@ -1,0 +1,244 @@
+// Copyright 2015 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+package node
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/ethereum/go-ethereum/logger/glog"
+	"github.com/ethereum/go-ethereum/p2p"
+	"github.com/ethereum/go-ethereum/p2p/discover"
+	"github.com/ethereum/go-ethereum/rpc/comms"
+	"github.com/rcrowley/go-metrics"
+)
+
+// PrivateAdminAPI is the collection of administrative API methods exposed only
+// over a secure RPC channel.
+type PrivateAdminAPI struct {
+	node *Node // Node interfaced by this API
+}
+
+// NewPrivateAdminAPI creates a new API definition for the private admin methods
+// of the node itself.
+func NewPrivateAdminAPI(node *Node) *PrivateAdminAPI {
+	return &PrivateAdminAPI{node: node}
+}
+
+// AddPeer requests connecting to a remote node, and also maintaining the new
+// connection at all times, even reconnecting if it is lost.
+func (api *PrivateAdminAPI) AddPeer(url string) (bool, error) {
+	// Make sure the server is running, fail otherwise
+	server := api.node.Server()
+	if server == nil {
+		return false, ErrNodeStopped
+	}
+	// Try to add the url as a static peer and return
+	node, err := discover.ParseNode(url)
+	if err != nil {
+		return false, fmt.Errorf("invalid enode: %v", err)
+	}
+	server.AddPeer(node)
+	return true, nil
+}
+
+// StartRPC starts the HTTP RPC API server.
+func (api *PrivateAdminAPI) StartRPC(address string, port int, cors string, apis string) (bool, error) {
+	/*// Parse the list of API modules to make available
+	apis, err := api.ParseApiString(apis, codec.JSON, xeth.New(api.node, nil), api.node)
+	if err != nil {
+		return false, err
+	}
+	// Configure and start the HTTP RPC server
+	config := comms.HttpConfig{
+		ListenAddress: address,
+		ListenPort:    port,
+		CorsDomain:    cors,
+	}
+	if err := comms.StartHttp(config, self.codec, api.Merge(apis...)); err != nil {
+		return false, err
+	}
+	return true, nil*/
+	return false, fmt.Errorf("needs new RPC implementation to resolve circular dependency")
+}
+
+// StopRPC terminates an already running HTTP RPC API endpoint.
+func (api *PrivateAdminAPI) StopRPC() {
+	comms.StopHttp()
+}
+
+// PublicAdminAPI is the collection of administrative API methods exposed over
+// both secure and unsecure RPC channels.
+type PublicAdminAPI struct {
+	node *Node // Node interfaced by this API
+}
+
+// NewPublicAdminAPI creates a new API definition for the public admin methods
+// of the node itself.
+func NewPublicAdminAPI(node *Node) *PublicAdminAPI {
+	return &PublicAdminAPI{node: node}
+}
+
+// Peers retrieves all the information we know about each individual peer at the
+// protocol granularity.
+func (api *PublicAdminAPI) Peers() ([]*p2p.PeerInfo, error) {
+	server := api.node.Server()
+	if server == nil {
+		return nil, ErrNodeStopped
+	}
+	return server.PeersInfo(), nil
+}
+
+// NodeInfo retrieves all the information we know about the host node at the
+// protocol granularity.
+func (api *PublicAdminAPI) NodeInfo() (*p2p.NodeInfo, error) {
+	server := api.node.Server()
+	if server == nil {
+		return nil, ErrNodeStopped
+	}
+	return server.NodeInfo(), nil
+}
+
+// Datadir retrieves the current data directory the node is using.
+func (api *PublicAdminAPI) Datadir() string {
+	return api.node.DataDir()
+}
+
+// PrivateDebugAPI is the collection of debugging related API methods exposed
+// only over a secure RPC channel.
+type PrivateDebugAPI struct {
+	node *Node // Node interfaced by this API
+}
+
+// NewPrivateDebugAPI creates a new API definition for the private debug methods
+// of the node itself.
+func NewPrivateDebugAPI(node *Node) *PrivateDebugAPI {
+	return &PrivateDebugAPI{node: node}
+}
+
+// Verbosity updates the node's logging verbosity. Note, due to the lack of fine
+// grained contextual loggers, this will update the verbosity level for the entire
+// process, not just this node instance.
+func (api *PrivateDebugAPI) Verbosity(level int) {
+	glog.SetV(level)
+}
+
+// PublicDebugAPI is the collection of debugging related API methods exposed over
+// both secure and unsecure RPC channels.
+type PublicDebugAPI struct {
+	node *Node // Node interfaced by this API
+}
+
+// NewPublicDebugAPI creates a new API definition for the public debug methods
+// of the node itself.
+func NewPublicDebugAPI(node *Node) *PublicDebugAPI {
+	return &PublicDebugAPI{node: node}
+}
+
+// Metrics retrieves all the known system metric collected by the node.
+func (api *PublicDebugAPI) Metrics(raw bool) (map[string]interface{}, error) {
+	// Create a rate formatter
+	units := []string{"", "K", "M", "G", "T", "E", "P"}
+	round := func(value float64, prec int) string {
+		unit := 0
+		for value >= 1000 {
+			unit, value, prec = unit+1, value/1000, 2
+		}
+		return fmt.Sprintf(fmt.Sprintf("%%.%df%s", prec, units[unit]), value)
+	}
+	format := func(total float64, rate float64) string {
+		return fmt.Sprintf("%s (%s/s)", round(total, 0), round(rate, 2))
+	}
+	// Iterate over all the metrics, and just dump for now
+	counters := make(map[string]interface{})
+	metrics.DefaultRegistry.Each(func(name string, metric interface{}) {
+		// Create or retrieve the counter hierarchy for this metric
+		root, parts := counters, strings.Split(name, "/")
+		for _, part := range parts[:len(parts)-1] {
+			if _, ok := root[part]; !ok {
+				root[part] = make(map[string]interface{})
+			}
+			root = root[part].(map[string]interface{})
+		}
+		name = parts[len(parts)-1]
+
+		// Fill the counter with the metric details, formatting if requested
+		if raw {
+			switch metric := metric.(type) {
+			case metrics.Meter:
+				root[name] = map[string]interface{}{
+					"AvgRate01Min": metric.Rate1(),
+					"AvgRate05Min": metric.Rate5(),
+					"AvgRate15Min": metric.Rate15(),
+					"MeanRate":     metric.RateMean(),
+					"Overall":      float64(metric.Count()),
+				}
+
+			case metrics.Timer:
+				root[name] = map[string]interface{}{
+					"AvgRate01Min": metric.Rate1(),
+					"AvgRate05Min": metric.Rate5(),
+					"AvgRate15Min": metric.Rate15(),
+					"MeanRate":     metric.RateMean(),
+					"Overall":      float64(metric.Count()),
+					"Percentiles": map[string]interface{}{
+						"5":  metric.Percentile(0.05),
+						"20": metric.Percentile(0.2),
+						"50": metric.Percentile(0.5),
+						"80": metric.Percentile(0.8),
+						"95": metric.Percentile(0.95),
+					},
+				}
+
+			default:
+				root[name] = "Unknown metric type"
+			}
+		} else {
+			switch metric := metric.(type) {
+			case metrics.Meter:
+				root[name] = map[string]interface{}{
+					"Avg01Min": format(metric.Rate1()*60, metric.Rate1()),
+					"Avg05Min": format(metric.Rate5()*300, metric.Rate5()),
+					"Avg15Min": format(metric.Rate15()*900, metric.Rate15()),
+					"Overall":  format(float64(metric.Count()), metric.RateMean()),
+				}
+
+			case metrics.Timer:
+				root[name] = map[string]interface{}{
+					"Avg01Min": format(metric.Rate1()*60, metric.Rate1()),
+					"Avg05Min": format(metric.Rate5()*300, metric.Rate5()),
+					"Avg15Min": format(metric.Rate15()*900, metric.Rate15()),
+					"Overall":  format(float64(metric.Count()), metric.RateMean()),
+					"Maximum":  time.Duration(metric.Max()).String(),
+					"Minimum":  time.Duration(metric.Min()).String(),
+					"Percentiles": map[string]interface{}{
+						"5":  time.Duration(metric.Percentile(0.05)).String(),
+						"20": time.Duration(metric.Percentile(0.2)).String(),
+						"50": time.Duration(metric.Percentile(0.5)).String(),
+						"80": time.Duration(metric.Percentile(0.8)).String(),
+						"95": time.Duration(metric.Percentile(0.95)).String(),
+					},
+				}
+
+			default:
+				root[name] = "Unknown metric type"
+			}
+		}
+	})
+	return counters, nil
+}

--- a/node/node.go
+++ b/node/node.go
@@ -266,9 +266,33 @@ func (n *Node) EventMux() *event.TypeMux {
 	return n.eventmux
 }
 
-// RPCAPIs returns the collection of RPC descriptor this node offers
-func (n *Node) RPCAPIs() []rpc.API {
-	var apis []rpc.API
+// APIs returns the collection of RPC descriptor this node offers. This method
+// is just a quick placeholder passthrough for the RPC update, which in the next
+// step will be fully integrated into the node itself.
+func (n *Node) APIs() []rpc.API {
+	// Define all the APIs owned by the node itself
+	apis := []rpc.API{
+		{
+			Namespace: "admin",
+			Version:   "1.0",
+			Service:   NewPrivateAdminAPI(n),
+		}, {
+			Namespace: "admin",
+			Version:   "1.0",
+			Service:   NewPublicAdminAPI(n),
+			Public:    true,
+		}, {
+			Namespace: "debug",
+			Version:   "1.0",
+			Service:   NewPrivateDebugAPI(n),
+		}, {
+			Namespace: "debug",
+			Version:   "1.0",
+			Service:   NewPublicDebugAPI(n),
+			Public:    true,
+		},
+	}
+	// Inject all the APIs owned by various services
 	for _, api := range n.services {
 		apis = append(apis, api.APIs()...)
 	}

--- a/rpc/api/debug_js.go
+++ b/rpc/api/debug_js.go
@@ -25,37 +25,37 @@ web3._extend({
 			name: 'printBlock',
 			call: 'debug_printBlock',
 			params: 1,
-			inputFormatter: [web3._extend.formatters.inputBlockNumberFormatter]
+			inputFormatter: [null]
 		}),
 		new web3._extend.Method({
 			name: 'getBlockRlp',
 			call: 'debug_getBlockRlp',
 			params: 1,
-			inputFormatter: [web3._extend.formatters.inputBlockNumberFormatter]
+			inputFormatter: [null]
 		}),
 		new web3._extend.Method({
 			name: 'setHead',
 			call: 'debug_setHead',
 			params: 1,
-			inputFormatter: [web3._extend.formatters.inputBlockNumberFormatter]
+			inputFormatter: [null]
 		}),
 		new web3._extend.Method({
 			name: 'processBlock',
 			call: 'debug_processBlock',
 			params: 1,
-			inputFormatter: [web3._extend.formatters.inputBlockNumberFormatter]
+			inputFormatter: [null]
 		}),
 		new web3._extend.Method({
 			name: 'seedHash',
 			call: 'debug_seedHash',
 			params: 1,
-			inputFormatter: [web3._extend.formatters.inputBlockNumberFormatter]
+			inputFormatter: [null]
 		}),
 		new web3._extend.Method({
 			name: 'dumpBlock',
 			call: 'debug_dumpBlock',
 			params: 1,
-			inputFormatter: [web3._extend.formatters.inputBlockNumberFormatter]
+			inputFormatter: [null]
 		}),
 		new web3._extend.Method({
 			name: 'metrics',


### PR DESCRIPTION
This PR ports the base admin commands:

 * admin_addPeer
 * admin_peers
 * admin_nodeInfo
 * admin_exportChain
 * admin_importChain
 * admin_verbosity
 * admin_setSolc
 * admin_datadir
 * admin_startRPC
 * admin_stopRPC

and also all of the debug commands. The remaining admin commands are either natspec, registrar, or the http/sleep methods are a bit questionable, so we should discuss those.

Additionally, I tried to verify all the commands so that they work, the only one I've implemented but is commented out is the StartRPC, because it introduces a circular dependency. We'd need to upgrade the HttpRpc too to use the new decoupled implementation before that code can be included in the `node` package.