### PR TITLE
eth: fix #2076, where end of hash query was interpreted number query

### DIFF
--- a/eth/handler.go
+++ b/eth/handler.go
@@ -372,6 +372,8 @@ func (pm *ProtocolManager) handleMsg(p *peer) error {
 		if err := msg.Decode(&query); err != nil {
 			return errResp(ErrDecode, "%v: %v", msg, err)
 		}
+		hashMode := query.Origin.Hash != (common.Hash{})
+
 		// Gather headers until the fetch or network limits is reached
 		var (
 			bytes   common.StorageSize
@@ -381,7 +383,7 @@ func (pm *ProtocolManager) handleMsg(p *peer) error {
 		for !unknown && len(headers) < int(query.Amount) && bytes < softResponseLimit && len(headers) < downloader.MaxHeaderFetch {
 			// Retrieve the next header satisfying the query
 			var origin *types.Header
-			if query.Origin.Hash != (common.Hash{}) {
+			if hashMode {
 				origin = pm.blockchain.GetHeader(query.Origin.Hash)
 			} else {
 				origin = pm.blockchain.GetHeaderByNumber(query.Origin.Number)


### PR DESCRIPTION
When collecting headers for a remote query, we used the query object itself as the iterator to step over the header chain either hash or number based (depending on the query). However, when doing a reverse hash based iteration, after retrieving the genesis block too, the next hash to retrieve was the parent of the genesis, the `nil` hash. However, the code assumed that a `nil` hash means number based iteration, so it pulled in the number of the query (unset = `0`) and duplicated the genesis header in the response. This PR fixes it by caching whether the original query origin was hash or number, and uses that cached flag opposed to checking in each step.