### PR TITLE
core/state, trie: add node iterator, test state/trie sync consistency

### DIFF
--- a/core/state/iterator.go
+++ b/core/state/iterator.go
@@ -1,0 +1,133 @@
+// Copyright 2015 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+package state
+
+import (
+	"bytes"
+	"fmt"
+	"math/big"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/rlp"
+	"github.com/ethereum/go-ethereum/trie"
+)
+
+// NodeIterator is an iterator to traverse the entire state trie post-order,
+// including all of the contract code and contract state tries.
+type NodeIterator struct {
+	state *StateDB // State being iterated
+
+	stateIt *trie.NodeIterator // Primary iterator for the global state trie
+	dataIt  *trie.NodeIterator // Secondary iterator for the data trie of a contract
+	code    []byte             // Source code associated with a contract
+
+	Entry interface{} // Current state entry being iterated (internal representation)
+}
+
+// NewNodeIterator creates an post-order state node iterator.
+func NewNodeIterator(state *StateDB) *NodeIterator {
+	return &NodeIterator{
+		state: state,
+	}
+}
+
+// Next moves the iterator to the next node, returning whether there are any
+// further nodes.
+func (it *NodeIterator) Next() bool {
+	it.step()
+	return it.retrieve()
+}
+
+// step moves the iterator to the next entry of the state trie.
+func (it *NodeIterator) step() {
+	// Abort if we reached the end of the iteration
+	if it.state == nil {
+		return
+	}
+	// Initialize the iterator if we've just started
+	if it.stateIt == nil {
+		it.stateIt = trie.NewNodeIterator(it.state.trie.Trie)
+	}
+	// If we had data nodes previously, we surely have at least state nodes
+	if it.dataIt != nil {
+		if cont := it.dataIt.Next(); !cont {
+			it.dataIt = nil
+		}
+		return
+	}
+	// If we had source code previously, discard that
+	if it.code != nil {
+		it.code = nil
+		return
+	}
+	// Step to the next state trie node, terminating if we're out of nodes
+	if cont := it.stateIt.Next(); !cont {
+		it.state, it.stateIt = nil, nil
+		return
+	}
+	// If the state trie node is an internal entry, leave as is
+	if !it.stateIt.Leaf {
+		return
+	}
+	// Otherwise we've reached an account node, initiate data iteration
+	var account struct {
+		Nonce    uint64
+		Balance  *big.Int
+		Root     common.Hash
+		CodeHash []byte
+	}
+	err := rlp.Decode(bytes.NewReader(it.stateIt.LeafBlob), &account)
+	if err != nil {
+		panic(err)
+	}
+	dataTrie, err := trie.New(account.Root, it.state.db)
+	if err != nil {
+		panic(err)
+	}
+	it.dataIt = trie.NewNodeIterator(dataTrie)
+	if !it.dataIt.Next() {
+		it.dataIt = nil
+	}
+	if bytes.Compare(account.CodeHash, emptyCodeHash) != 0 {
+		it.code, err = it.state.db.Get(account.CodeHash)
+		if err != nil {
+			panic(fmt.Sprintf("code %x: %v", account.CodeHash, err))
+		}
+	}
+}
+
+// retrieve pulls and caches the current state entry the iterator is traversing.
+// The method returns whether there are any more data left for inspection.
+func (it *NodeIterator) retrieve() bool {
+	// Clear out any previously set values
+	it.Entry = nil
+
+	// If the iteration's done, return no available data
+	if it.state == nil {
+		return false
+	}
+	// Otherwise retrieve the current entry
+	switch {
+	case it.dataIt != nil:
+		it.Entry = it.dataIt.Node
+	case it.code != nil:
+		it.Entry = it.code
+	case it.stateIt != nil:
+		it.Entry = it.stateIt.Node
+	}
+	return true
+}

--- a/core/state/sync_test.go
+++ b/core/state/sync_test.go
@@ -18,10 +18,12 @@ package state
 
 import (
 	"bytes"
+	"fmt"
 	"math/big"
 	"testing"
 
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/ethdb"
 	"github.com/ethereum/go-ethereum/trie"
 )
@@ -42,7 +44,7 @@ func makeTestState() (ethdb.Database, common.Hash, []*testAccount) {
 
 	// Fill it with some arbitrary data
 	accounts := []*testAccount{}
-	for i := byte(0); i < 255; i++ {
+	for i := byte(0); i < 96; i++ {
 		obj := state.GetOrNewStateObject(common.BytesToAddress([]byte{i}))
 		acc := &testAccount{address: common.BytesToAddress([]byte{i})}
 
@@ -61,6 +63,9 @@ func makeTestState() (ethdb.Database, common.Hash, []*testAccount) {
 	}
 	root, _ := state.Commit()
 
+	// Remove any potentially cached data from the test state creation
+	trie.ClearGlobalCache()
+
 	// Return the generated state
 	return db, root, accounts
 }
@@ -68,9 +73,18 @@ func makeTestState() (ethdb.Database, common.Hash, []*testAccount) {
 // checkStateAccounts cross references a reconstructed state with an expected
 // account array.
 func checkStateAccounts(t *testing.T, db ethdb.Database, root common.Hash, accounts []*testAccount) {
-	state, _ := New(root, db)
-	for i, acc := range accounts {
+	// Remove any potentially cached data from the state synchronisation
+	trie.ClearGlobalCache()
 
+	// Check root availability and state contents
+	state, err := New(root, db)
+	if err != nil {
+		t.Fatalf("failed to create state trie at %x: %v", root, err)
+	}
+	if err := checkStateConsistency(db, root); err != nil {
+		t.Fatalf("inconsistent state trie at %x: %v", root, err)
+	}
+	for i, acc := range accounts {
 		if balance := state.GetBalance(acc.address); balance.Cmp(acc.balance) != 0 {
 			t.Errorf("account %d: balance mismatch: have %v, want %v", i, balance, acc.balance)
 		}
@@ -81,6 +95,31 @@ func checkStateAccounts(t *testing.T, db ethdb.Database, root common.Hash, accou
 			t.Errorf("account %d: code mismatch: have %x, want %x", i, code, acc.code)
 		}
 	}
+}
+
+// checkStateConsistency checks that all nodes in a state trie and indeed present.
+func checkStateConsistency(db ethdb.Database, root common.Hash) (failure error) {
+	// Capture any panics by the iterator
+	defer func() {
+		if r := recover(); r != nil {
+			failure = fmt.Errorf("%v", r)
+		}
+	}()
+	// Remove any potentially cached data from the test state creation or previous checks
+	trie.ClearGlobalCache()
+
+	// Create and iterate a state trie rooted in a sub-node
+	if _, err := db.Get(root.Bytes()); err != nil {
+		return
+	}
+	state, err := New(root, db)
+	if err != nil {
+		return
+	}
+	it := NewNodeIterator(state)
+	for it.Next() {
+	}
+	return nil
 }
 
 // Tests that an empty state is not scheduled for syncing.
@@ -235,4 +274,66 @@ func TestIterativeRandomDelayedStateSync(t *testing.T) {
 	}
 	// Cross check that the two states are in sync
 	checkStateAccounts(t, dstDb, srcRoot, srcAccounts)
+}
+
+// Tests that at any point in time during a sync, only complete sub-tries are in
+// the database.
+func TestIncompleteStateSync(t *testing.T) {
+	// Create a random state to copy
+	srcDb, srcRoot, srcAccounts := makeTestState()
+
+	// Create a destination state and sync with the scheduler
+	dstDb, _ := ethdb.NewMemDatabase()
+	sched := NewStateSync(srcRoot, dstDb)
+
+	added := []common.Hash{}
+	queue := append([]common.Hash{}, sched.Missing(1)...)
+	for len(queue) > 0 {
+		// Fetch a batch of state nodes
+		results := make([]trie.SyncResult, len(queue))
+		for i, hash := range queue {
+			data, err := srcDb.Get(hash.Bytes())
+			if err != nil {
+				t.Fatalf("failed to retrieve node data for %x: %v", hash, err)
+			}
+			results[i] = trie.SyncResult{hash, data}
+		}
+		// Process each of the state nodes
+		if index, err := sched.Process(results); err != nil {
+			t.Fatalf("failed to process result #%d: %v", index, err)
+		}
+		for _, result := range results {
+			added = append(added, result.Hash)
+		}
+		// Check that all known sub-tries in the synced state is complete
+		for _, root := range added {
+			// Skim through the accounts and make sure the root hash is not a code node
+			codeHash := false
+			for _, acc := range srcAccounts {
+				if bytes.Compare(root.Bytes(), crypto.Sha3(acc.code)) == 0 {
+					codeHash = true
+					break
+				}
+			}
+			// If the root is a real trie node, check consistency
+			if !codeHash {
+				if err := checkStateConsistency(dstDb, root); err != nil {
+					t.Fatalf("state inconsistent: %v", err)
+				}
+			}
+		}
+		// Fetch the next batch to retrieve
+		queue = append(queue[:0], sched.Missing(1)...)
+	}
+	// Sanity check that removing any node from the database is detected
+	for _, node := range added[1:] {
+		key := node.Bytes()
+		value, _ := dstDb.Get(key)
+
+		dstDb.Delete(key)
+		if err := checkStateConsistency(dstDb, added[0]); err == nil {
+			t.Fatalf("trie inconsistency not caught, missing: %x", key)
+		}
+		dstDb.Put(key, value)
+	}
 }

--- a/core/state/sync_test.go
+++ b/core/state/sync_test.go
@@ -18,7 +18,6 @@ package state
 
 import (
 	"bytes"
-	"fmt"
 	"math/big"
 	"testing"
 
@@ -97,28 +96,23 @@ func checkStateAccounts(t *testing.T, db ethdb.Database, root common.Hash, accou
 	}
 }
 
-// checkStateConsistency checks that all nodes in a state trie and indeed present.
-func checkStateConsistency(db ethdb.Database, root common.Hash) (failure error) {
-	// Capture any panics by the iterator
-	defer func() {
-		if r := recover(); r != nil {
-			failure = fmt.Errorf("%v", r)
-		}
-	}()
+// checkStateConsistency checks that all nodes in a state trie are indeed present.
+func checkStateConsistency(db ethdb.Database, root common.Hash) error {
 	// Remove any potentially cached data from the test state creation or previous checks
 	trie.ClearGlobalCache()
 
 	// Create and iterate a state trie rooted in a sub-node
 	if _, err := db.Get(root.Bytes()); err != nil {
-		return
+		return nil // Consider a non existent state consistent
 	}
 	state, err := New(root, db)
 	if err != nil {
-		return
+		return err
 	}
-	for it := NewNodeIterator(state); it.Next(); {
+	it := NewNodeIterator(state)
+	for it.Next() {
 	}
-	return nil
+	return it.Error
 }
 
 // Tests that an empty state is not scheduled for syncing.

--- a/core/state/sync_test.go
+++ b/core/state/sync_test.go
@@ -116,8 +116,7 @@ func checkStateConsistency(db ethdb.Database, root common.Hash) (failure error) 
 	if err != nil {
 		return
 	}
-	it := NewNodeIterator(state)
-	for it.Next() {
+	for it := NewNodeIterator(state); it.Next(); {
 	}
 	return nil
 }

--- a/trie/sync_test.go
+++ b/trie/sync_test.go
@@ -96,8 +96,7 @@ func checkTrieConsistency(db Database, root common.Hash) (failure error) {
 	if err != nil {
 		return
 	}
-	it := NewNodeIterator(trie)
-	for it.Next() {
+	for it := NewNodeIterator(trie); it.Next(); {
 	}
 	return nil
 }

--- a/trie/sync_test.go
+++ b/trie/sync_test.go
@@ -18,7 +18,6 @@ package trie
 
 import (
 	"bytes"
-	"fmt"
 	"testing"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -80,25 +79,20 @@ func checkTrieContents(t *testing.T, db Database, root []byte, content map[strin
 	}
 }
 
-// checkTrieConsistency checks that all nodes in a trie and indeed present.
-func checkTrieConsistency(db Database, root common.Hash) (failure error) {
-	// Capture any panics by the iterator
-	defer func() {
-		if r := recover(); r != nil {
-			failure = fmt.Errorf("%v", r)
-		}
-	}()
+// checkTrieConsistency checks that all nodes in a trie are indeed present.
+func checkTrieConsistency(db Database, root common.Hash) error {
 	// Remove any potentially cached data from the test trie creation or previous checks
 	globalCache.Clear()
 
 	// Create and iterate a trie rooted in a subnode
 	trie, err := New(root, db)
 	if err != nil {
-		return
+		return nil // // Consider a non existent state consistent
 	}
-	for it := NewNodeIterator(trie); it.Next(); {
+	it := NewNodeIterator(trie)
+	for it.Next() {
 	}
-	return nil
+	return it.Error
 }
 
 // Tests that an empty trie is not scheduled for syncing.


### PR DESCRIPTION
This PR adds a node iterator into the trie which can traverse the trie itself, returning one node at a time (and crashing hard if something's missing); as well as a node iterator into the state, which can also iterate the contract state data as well as the contract code, essentially walking the entire active trie associated with a root hash.

The aim of the iterator in the first round is to allow testing the consistency of a (state) trie after a sync (such that all nodes are indeed present in the trie). This is done in the sync tests to check the algos, not in the live code.

Later the iterator would probably come in handy for database recovery to ensure that the blocks we reset to (e.g. `setHead`) indeed contains all the necessary state entries and not lead to corruption. Also it could help with implementing a simple copy-swap state pruning algorithm, though that would require extending the iterator with premature stops to allow skipping known branches.