### PR TITLE
core, eth, rpc/api: rpc method to inspect the txpool queue

### DIFF
--- a/eth/api.go
+++ b/eth/api.go
@@ -227,6 +227,39 @@ func NewPublicTxPoolAPI(e *Ethereum) *PublicTxPoolAPI {
 	return &PublicTxPoolAPI{e}
 }
 
+// Content returns the transactions contained within the transaction pool.
+func (s *PublicTxPoolAPI) Content() map[string]map[string]map[string][]*RPCTransaction {
+	content := map[string]map[string]map[string][]*RPCTransaction{
+		"pending": make(map[string]map[string][]*RPCTransaction),
+		"queued":  make(map[string]map[string][]*RPCTransaction),
+	}
+	pending, queue := s.e.TxPool().Content()
+
+	// Flatten the pending transactions
+	for account, batches := range pending {
+		dump := make(map[string][]*RPCTransaction)
+		for nonce, txs := range batches {
+			nonce := fmt.Sprintf("%d", nonce)
+			for _, tx := range txs {
+				dump[nonce] = append(dump[nonce], newRPCPendingTransaction(tx))
+			}
+		}
+		content["pending"][account.Hex()] = dump
+	}
+	// Flatten the queued transactions
+	for account, batches := range queue {
+		dump := make(map[string][]*RPCTransaction)
+		for nonce, txs := range batches {
+			nonce := fmt.Sprintf("%d", nonce)
+			for _, tx := range txs {
+				dump[nonce] = append(dump[nonce], newRPCPendingTransaction(tx))
+			}
+		}
+		content["queued"][account.Hex()] = dump
+	}
+	return content
+}
+
 // Status returns the number of pending and queued transaction in the pool.
 func (s *PublicTxPoolAPI) Status() map[string]*rpc.HexNumber {
 	pending, queue := s.e.TxPool().Stats()
@@ -234,6 +267,47 @@ func (s *PublicTxPoolAPI) Status() map[string]*rpc.HexNumber {
 		"pending": rpc.NewHexNumber(pending),
 		"queued":  rpc.NewHexNumber(queue),
 	}
+}
+
+// Inspect retrieves the content of the transaction pool and flattens it into an
+// easily inspectable list.
+func (s *PublicTxPoolAPI) Inspect() map[string]map[string]map[string][]string {
+	content := map[string]map[string]map[string][]string{
+		"pending": make(map[string]map[string][]string),
+		"queued":  make(map[string]map[string][]string),
+	}
+	pending, queue := s.e.TxPool().Content()
+
+	// Define a formatter to flatten a transaction into a string
+	var format = func(tx *types.Transaction) string {
+		if to := tx.To(); to != nil {
+			return fmt.Sprintf("%s: %v wei + %v × %v gas", tx.To().Hex(), tx.Value(), tx.Gas(), tx.GasPrice())
+		}
+		return fmt.Sprintf("contract creation: %v wei + %v × %v gas", tx.Value(), tx.Gas(), tx.GasPrice())
+	}
+	// Flatten the pending transactions
+	for account, batches := range pending {
+		dump := make(map[string][]string)
+		for nonce, txs := range batches {
+			nonce := fmt.Sprintf("%d", nonce)
+			for _, tx := range txs {
+				dump[nonce] = append(dump[nonce], format(tx))
+			}
+		}
+		content["pending"][account.Hex()] = dump
+	}
+	// Flatten the queued transactions
+	for account, batches := range queue {
+		dump := make(map[string][]string)
+		for nonce, txs := range batches {
+			nonce := fmt.Sprintf("%d", nonce)
+			for _, tx := range txs {
+				dump[nonce] = append(dump[nonce], format(tx))
+			}
+		}
+		content["queued"][account.Hex()] = dump
+	}
+	return content
 }
 
 // PublicAccountAPI provides an API to access accounts managed by this node.

--- a/rpc/javascript.go
+++ b/rpc/javascript.go
@@ -71,8 +71,16 @@ web3._extend({
 	properties:
 	[
 		new web3._extend.Property({
+			name: 'content',
+			getter: 'txpool_content'
+		}),
+		new web3._extend.Property({
+			name: 'inspect',
+			getter: 'txpool_inspect'
+		}),
+		new web3._extend.Property({
 			name: 'status',
-			getter: 'txpool_status'
+			getter: 'txpool_status',
 			outputFormatter: function(status) {
 				status.pending = web3._extend.utils.toDecimal(status.pending);
 				status.queued = web3._extend.utils.toDecimal(status.queued);


### PR DESCRIPTION
This PR adds a new method to the transaction pool rpc namespace, namely `txpool.queue`, which lists all the currently queued (but not executable) transactions in a user friendly way, grouped first by origin account, then by transaction nonce.

The dump look something like:

```js
{
    0x312bbe88e3359a4c216170ef7c9f367fde8f3338: {
      181: ["0xc47aaa860008be6f65b58c6c6e02a84e666efe31: 1061814239999990000 wei + 21000 × 50000000000 gas"]
    },
    0x33228b774dcbddc7158a2fe647453443d8c87e72: {
      104: ["0xc47aaa860008be6f65b58c6c6e02a84e666efe31: 1367364910000000000 wei + 21000 × 50000000000 gas"],
      105: ["0xc47aaa860008be6f65b58c6c6e02a84e666efe31: 1367364910000000000 wei + 21000 × 50000000000 gas"],
      106: ["0xc47aaa860008be6f65b58c6c6e02a84e666efe31: 1367364910000000000 wei + 21000 × 50000000000 gas"],
      107: ["0xc47aaa860008be6f65b58c6c6e02a84e666efe31: 1367364910000000000 wei + 21000 × 50000000000 gas"]
    },
    0x344a8db086faed4efc37131b3a22b0782dad7095: {
      23: ["0xea9a2899d5b13f5cd24d58a910532896e4a8ca5b: 100000000000000000 wei + 30000 × 50000000000 gas"],
      24: ["0xea9a2899d5b13f5cd24d58a910532896e4a8ca5b: 100000000000000000 wei + 300000 × 50000000000 gas"],
      25: ["0xea9a2899d5b13f5cd24d58a910532896e4a8ca5b: 100000000000000000 wei + 300000 × 50000000000 gas"]
    }
}
```

The rational behind introducing this method is mostly for us to be able to manually inspect the contents of the currently queued transactions in order to find anomalies in transaction handling, forwarding and processing.

E.g. there are about [1K pending transactions](https://gist.github.com/karalabe/991d5ea433bbc79f35e5) in the system that are in there from months now, and will never be executed. Although these should get dropped off, they somehow manage to linger, consuming both memory as well as propagation bandwidth. It's a bug we should sort out.