### PR TITLE
eth/downloader: throttling tests are time-sensitive, don't run parallel

### DIFF
--- a/eth/downloader/downloader_test.go
+++ b/eth/downloader/downloader_test.go
@@ -720,8 +720,6 @@ func TestThrottling64Full(t *testing.T) { testThrottling(t, 64, FullSync) }
 func TestThrottling64Fast(t *testing.T) { testThrottling(t, 64, FastSync) }
 
 func testThrottling(t *testing.T, protocol int, mode SyncMode) {
-	t.Parallel()
-
 	// Create a long block chain to download and the tester
 	targetBlocks := 8 * blockCacheLimit
 	hashes, headers, blocks, receipts := makeChain(targetBlocks, 0, genesis, nil)
@@ -751,7 +749,7 @@ func testThrottling(t *testing.T, protocol int, mode SyncMode) {
 		}
 		// Wait a bit for sync to throttle itself
 		var cached, frozen int
-		for start := time.Now(); time.Since(start) < time.Second; {
+		for start := time.Now(); time.Since(start) < 3*time.Second; {
 			time.Sleep(25 * time.Millisecond)
 
 			tester.lock.Lock()


### PR DESCRIPTION
The throttling tests are time sensitive, as it's testing whether the downloader stops fetching new things after it accumulated enough in the queues. However, currently all the tests were ran parallel, which placed a huge computing burden on the tester, and hence the timers were completely unreliable for anything. This PR simply marks these tests not to be ran in parallel with others and also increases the time allowance a bit to cater for high CPU load in other package tests.

Edit: I ran these tests 4 times consecutively on all the test servers. It passed consistently, so it seems this was the issue.