### PR TITLE
eth/filters: added notifications for out of bound log events

### DIFF
--- a/eth/filters/filter.go
+++ b/eth/filters/filter.go
@@ -39,7 +39,7 @@ type Filter struct {
 
 	BlockCallback       func(*types.Block, vm.Logs)
 	TransactionCallback func(*types.Transaction)
-	LogsCallback        func(vm.Logs)
+	LogCallback         func(*vm.Log, bool)
 }
 
 // Create a new filter which uses a bloom filter on blocks to figure out whether a particular block

--- a/eth/filters/filter_system.go
+++ b/eth/filters/filter_system.go
@@ -46,6 +46,7 @@ func NewFilterSystem(mux *event.TypeMux) *FilterSystem {
 	}
 	fs.sub = mux.Subscribe(
 		//core.PendingBlockEvent{},
+		core.RemovedLogEvent{},
 		core.ChainEvent{},
 		core.TxPreEvent{},
 		vm.Logs(nil),
@@ -96,7 +97,7 @@ func (fs *FilterSystem) filterLoop() {
 		case core.ChainEvent:
 			fs.filterMu.RLock()
 			for id, filter := range fs.filters {
-				if filter.BlockCallback != nil && fs.created[id].Before(event.Time) {
+				if filter.BlockCallback != nil && !fs.created[id].After(event.Time) {
 					filter.BlockCallback(ev.Block, ev.Logs)
 				}
 			}
@@ -105,7 +106,7 @@ func (fs *FilterSystem) filterLoop() {
 		case core.TxPreEvent:
 			fs.filterMu.RLock()
 			for id, filter := range fs.filters {
-				if filter.TransactionCallback != nil && fs.created[id].Before(event.Time) {
+				if filter.TransactionCallback != nil && !fs.created[id].After(event.Time) {
 					filter.TransactionCallback(ev.Tx)
 				}
 			}
@@ -114,10 +115,20 @@ func (fs *FilterSystem) filterLoop() {
 		case vm.Logs:
 			fs.filterMu.RLock()
 			for id, filter := range fs.filters {
-				if filter.LogsCallback != nil && fs.created[id].Before(event.Time) {
-					msgs := filter.FilterLogs(ev)
-					if len(msgs) > 0 {
-						filter.LogsCallback(msgs)
+				if filter.LogCallback != nil && !fs.created[id].After(event.Time) {
+					for _, log := range filter.FilterLogs(ev) {
+						filter.LogCallback(log, false)
+					}
+				}
+			}
+			fs.filterMu.RUnlock()
+
+		case core.RemovedLogEvent:
+			fs.filterMu.RLock()
+			for id, filter := range fs.filters {
+				if filter.LogCallback != nil && !fs.created[id].After(event.Time) {
+					for _, removedLog := range ev.Logs {
+						filter.LogCallback(removedLog, true)
 					}
 				}
 			}

--- a/eth/filters/filter_system_test.go
+++ b/eth/filters/filter_system_test.go
@@ -1,0 +1,87 @@
+package filters
+
+import (
+	"testing"
+	"time"
+
+	"github.com/ethereum/go-ethereum/core"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/core/vm"
+	"github.com/ethereum/go-ethereum/event"
+)
+
+func TestCallbacks(t *testing.T) {
+	var (
+		mux            event.TypeMux
+		fs             = NewFilterSystem(&mux)
+		blockDone      = make(chan struct{})
+		txDone         = make(chan struct{})
+		logDone        = make(chan struct{})
+		removedLogDone = make(chan struct{})
+	)
+
+	blockFilter := &Filter{
+		BlockCallback: func(*types.Block, vm.Logs) {
+			close(blockDone)
+		},
+	}
+	txFilter := &Filter{
+		TransactionCallback: func(*types.Transaction) {
+			close(txDone)
+		},
+	}
+	logFilter := &Filter{
+		LogCallback: func(l *vm.Log, oob bool) {
+			if !oob {
+				close(logDone)
+			}
+		},
+	}
+
+	removedLogFilter := &Filter{
+		LogCallback: func(l *vm.Log, oob bool) {
+			if oob {
+				close(removedLogDone)
+			}
+		},
+	}
+
+	fs.Add(blockFilter)
+	fs.Add(txFilter)
+	fs.Add(logFilter)
+	fs.Add(removedLogFilter)
+
+	mux.Post(core.ChainEvent{})
+	mux.Post(core.TxPreEvent{})
+	mux.Post(core.RemovedLogEvent{vm.Logs{&vm.Log{}}})
+	mux.Post(vm.Logs{&vm.Log{}})
+
+	const dura = 5 * time.Second
+	failTimer := time.NewTimer(dura)
+	select {
+	case <-blockDone:
+	case <-failTimer.C:
+		t.Error("block filter failed to trigger (timeout)")
+	}
+
+	failTimer.Reset(dura)
+	select {
+	case <-txDone:
+	case <-failTimer.C:
+		t.Error("transaction filter failed to trigger (timeout)")
+	}
+
+	failTimer.Reset(dura)
+	select {
+	case <-logDone:
+	case <-failTimer.C:
+		t.Error("log filter failed to trigger (timeout)")
+	}
+
+	failTimer.Reset(dura)
+	select {
+	case <-removedLogDone:
+	case <-failTimer.C:
+		t.Error("removed log filter failed to trigger (timeout)")
+	}
+}


### PR DESCRIPTION
Out of Bound log events are events that were removed due to a fork. When
logs are received the filtering mechanism should check for the `removed`
field on the json structure.

```js
{
    // regular log information
    removed: true
}
```