### PR TITLE
common: Fix HomeDir detection

### DIFF
--- a/common/path.go
+++ b/common/path.go
@@ -63,13 +63,14 @@ func AbsolutePath(Datadir string, filename string) string {
 	return filepath.Join(Datadir, filename)
 }
 
-func HomeDir() (home string) {
-	if usr, err := user.Current(); err == nil {
-		home = usr.HomeDir
-	} else {
-		home = os.Getenv("HOME")
+func HomeDir() string {
+	if home := os.Getenv("HOME"); home != "" {
+		return home
 	}
-	return
+	if usr, err := user.Current(); err == nil {
+		return usr.HomeDir
+	}
+	return ""
 }
 
 func DefaultDataDir() string {


### PR DESCRIPTION
I am working on porting geth to [Ubuntu Core](https://developer.ubuntu.com/en/snappy/https://developer.ubuntu.com/en/snappy/). I am testing geth on a Raspberry PI and for Ubuntu Core the $HOME directory is unique for each application. See [here](https://developer.ubuntu.com/en/snappy/guides/filesystem-layout) for more information of their filesystem layout.

For some reason in Go `usr.HomeDir` returns a different value than `$HOME` in Ubuntu Core.

Adding this at the end of `HomeDir()`
```go
fmt.Printf("at HomeDir, user.HomeDir = %s and $HOME is %s\n", usr.HomeDir, os.Getenv("HOME"))
```

gives the following output

```
at HomeDir, user.HomeDir = /home/ubuntu and $HOME is /home/ubuntu/apps/geth.sideload/IJcODREBYbHO
```

With this commit, I propose giving precedence to the `$HOME` environment variable as is also suggested by the [homedir](https://github.com/mitchellh/go-homedir/blob/master/homedir.go) project.

We could adopt their complicated logic to determine the home directory but that could possibly be deferred for another PR. What are your thoughts guys?