### PR TITLE
core/vm: resolve circular dependency to debug vm storage

### DIFF
--- a/core/vm/contract.go
+++ b/core/vm/contract.go
@@ -27,6 +27,7 @@ type ContractRef interface {
 	ReturnGas(*big.Int, *big.Int)
 	Address() common.Address
 	SetCode([]byte)
+	EachStorage(cb func(key, value []byte))
 }
 
 // Contract represents an ethereum contract in the state database. It contains
@@ -123,4 +124,10 @@ func (self *Contract) SetCode(code []byte) {
 func (self *Contract) SetCallCode(addr *common.Address, code []byte) {
 	self.Code = code
 	self.CodeAddr = addr
+}
+
+// EachStorage iterates the contract's storage and calls a method for every key
+// value pair.
+func (self *Contract) EachStorage(cb func(key, value []byte)) {
+	self.caller.EachStorage(cb)
 }

--- a/core/vm/environment.go
+++ b/core/vm/environment.go
@@ -121,4 +121,5 @@ type Account interface {
 	Address() common.Address
 	ReturnGas(*big.Int, *big.Int)
 	SetCode([]byte)
+	EachStorage(cb func(key, value []byte))
 }

--- a/core/vm/jit_test.go
+++ b/core/vm/jit_test.go
@@ -125,14 +125,15 @@ type vmBench struct {
 
 type account struct{}
 
-func (account) SubBalance(amount *big.Int)   {}
-func (account) AddBalance(amount *big.Int)   {}
-func (account) SetBalance(*big.Int)          {}
-func (account) SetNonce(uint64)              {}
-func (account) Balance() *big.Int            { return nil }
-func (account) Address() common.Address      { return common.Address{} }
-func (account) ReturnGas(*big.Int, *big.Int) {}
-func (account) SetCode([]byte)               {}
+func (account) SubBalance(amount *big.Int)             {}
+func (account) AddBalance(amount *big.Int)             {}
+func (account) SetBalance(*big.Int)                    {}
+func (account) SetNonce(uint64)                        {}
+func (account) Balance() *big.Int                      { return nil }
+func (account) Address() common.Address                { return common.Address{} }
+func (account) ReturnGas(*big.Int, *big.Int)           {}
+func (account) SetCode([]byte)                         {}
+func (account) EachStorage(cb func(key, value []byte)) {}
 
 func runVmBench(test vmBench, b *testing.B) {
 	var sender account

--- a/core/vm/vm.go
+++ b/core/vm/vm.go
@@ -376,12 +376,9 @@ func (self *Vm) log(pc uint64, op OpCode, gas, cost *big.Int, memory *Memory, st
 			stck[i] = new(big.Int).Set(item)
 		}
 		storage := make(map[common.Hash][]byte)
-		/*
-			object := contract.self.(*state.StateObject)
-			object.EachStorage(func(k, v []byte) {
-				storage[common.BytesToHash(k)] = v
-			})
-		*/
+		contract.self.EachStorage(func(k, v []byte) {
+			storage[common.BytesToHash(k)] = v
+		})
 		self.env.AddStructLog(StructLog{pc, op, new(big.Int).Set(gas), cost, mem, stck, storage, err})
 	}
 }


### PR DESCRIPTION
A while ago the VM's debug functionality used a direct cast from a `vm.Contract` to a `state.StateObject` to access the data storage for debugging purposes. This I guess introduced a circular dependency a while back and was disabled. Unfortunately this also meant that all storage entries are now missing from stack traces, making it impossible to debug anything related to persistency. This PR exposes the `EachStorage` method of the `StateObject` through the used interfaces to allow iterating over the persistent storage and display it.