### PR TITLE
core/state: always commit in batches, just finish if not needed later

### DIFF
--- a/core/state/statedb.go
+++ b/core/state/statedb.go
@@ -353,7 +353,8 @@ func (s *StateDB) IntermediateRoot() common.Hash {
 
 // Commit commits all state changes to the database.
 func (s *StateDB) Commit() (root common.Hash, err error) {
-	return s.commit(s.db)
+	root, batch := s.CommitBatch()
+	return root, batch.Write()
 }
 
 // CommitBatch commits all state changes to a write batch but does not


### PR DESCRIPTION
This PR fixes a regression where we would commit state db updates individually instead of in a batch. This is something very undesirable since it thrashes the database. It's not noticeable while the db is small as all kinds of caches hide it (leveldb write cache, OS disk cache) but the moment the cache runs out, the disk is hammered badly. On an SSD this might be less of an issue as it's fairly fast, but a HDD could be hit severely.

Short benchmark (import 0-100K mainnet blocks, 314MB database):

```
Non-batch: Import done in 2m23.500380569s [ZenBook Pro UX501]
Batched:   Import done in 2m11.478333924s [ZenBook Pro UX501]
```

Long benchmark (import 0-500K mainnet blocks, 2.4GB database):

```
Non-batch: Import done in 22m7.245370159s  [ZenBook Pro UX501]
Batched:   Import done in 21m28.698197823s [ZenBook Pro UX501]

Non-batch: Import done in 1h10m3.840878786s [HP Pavilion DV7T]
Batched:   Import done in 1h9m4.500817057s [HP Pavilion DV7T]
```

Full benchmark (import 0-842K mainnet blocks, 5.8GB database):

```
Non-batch: Import done in 3h37m11.527456458s [HP Pavilion DV7T]
Batched:   Import done in 3h26m36.777224524s [HP Pavilion DV7T]
```