### PR TITLE
add Solidity compiler to Dockerfile

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -15,6 +15,10 @@ RUN add-apt-repository ppa:ethereum/ethereum-dev
 RUN apt-get update
 RUN apt-get install -q -y geth
 
+# Install Solidity compiler
+RUN apt-get install solc -y
+
+
 EXPOSE 8545
 EXPOSE 30303
 


### PR DESCRIPTION
Many users of the ethereum-docker are working with the tutorial available [here](https://www.ethereum.org/greeter).
Therefore the Solidity-compiler is needed. I request to include it to the Dockerfile.