### PR TITLE
Nodeinfo format Genesis and Header

### DIFF
--- a/eth/handler.go
+++ b/eth/handler.go
@@ -750,10 +750,10 @@ func (self *ProtocolManager) txBroadcastLoop() {
 // EthNodeInfo represents a short summary of the Ethereum sub-protocol metadata known
 // about the host peer.
 type EthNodeInfo struct {
-	Network    int      `json:"network"`    // Ethereum network ID (0=Olympic, 1=Frontier, 2=Morden)
-	Difficulty *big.Int `json:"difficulty"` // Total difficulty of the host's blockchain
-	Genesis    string   `json:"genesis"`    // SHA3 hash of the host's genesis block
-	Head       string   `json:"head"`       // SHA3 hash of the host's best owned block
+	Network    int         `json:"network"`    // Ethereum network ID (0=Olympic, 1=Frontier, 2=Morden)
+	Difficulty *big.Int    `json:"difficulty"` // Total difficulty of the host's blockchain
+	Genesis    common.Hash `json:"genesis"`    // SHA3 hash of the host's genesis block
+	Head       common.Hash `json:"head"`       // SHA3 hash of the host's best owned block
 }
 
 // NodeInfo retrieves some protocol metadata about the running host node.
@@ -761,7 +761,7 @@ func (self *ProtocolManager) NodeInfo() *EthNodeInfo {
 	return &EthNodeInfo{
 		Network:    self.networkId,
 		Difficulty: self.blockchain.GetTd(self.blockchain.CurrentBlock().Hash()),
-		Genesis:    fmt.Sprintf("%x", self.blockchain.Genesis().Hash()),
-		Head:       fmt.Sprintf("%x", self.blockchain.CurrentBlock().Hash()),
+		Genesis:    self.blockchain.Genesis().Hash(),
+		Head:       self.blockchain.CurrentBlock().Hash(),
 	}
 }


### PR DESCRIPTION
The eth protocol genesis and header fields are formatted and exposed as strings without the the '0x' prefix. This is against the convention that hashes are hex encoded and prefixed with 0x in the RPC layer and causes statements as `web3.eth.getBlock(web3.admin.nodeInfo.protocols.eth.head)` to fail. This PR returns both hashes as `common.Hash` which will be serialized correct by the RPC layer.

Before:
```
> web3.admin.nodeInfo.protocols.eth
{
  genesis: "fd4af92a79c7fc2fd8bf0d342f2e832e1d4f485c85b9152d2039e03bc604fdca",
  head: "f37001cff285aad22166281e5f2f053b393f5cf6a0def7538a3262b2fa5612ee",
}
```

after:
```
> web3.admin.nodeInfo.protocols.eth
{
  genesis: "0xfd4af92a79c7fc2fd8bf0d342f2e832e1d4f485c85b9152d2039e03bc604fdca",
  head: "0xf37001cff285aad22166281e5f2f053b393f5cf6a0def7538a3262b2fa5612ee",
}

```