### PR TITLE
console: add admin.sleep and admin.sleepBlocks

### DIFF
--- a/cmd/geth/js.go
+++ b/cmd/geth/js.go
@@ -348,6 +348,15 @@ func (js *jsre) apiBindings(f xeth.Frontend) error {
 		persObj.Set("newAccount", jeth.NewAccount)
 	}
 
+	// The admin.sleep and admin.sleepBlocks are offered by the console and not by the RPC layer.
+	// Bind these if the admin module is available.
+	if a, err := js.re.Get("admin"); err == nil {
+		if adminObj := a.Object(); adminObj != nil {
+			adminObj.Set("sleepBlocks", jeth.SleepBlocks)
+			adminObj.Set("sleep", jeth.Sleep)
+		}
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
The `admin.sleep` and `admin.sleepBlocks` where part of the old RPC API and not migrated in https://github.com/ethereum/go-ethereum/pull/2072. This is a good thing since these methods are not something the RPC layer should offer.

The problem is that when https://github.com/ethereum/go-ethereum/pull/2113 is merged these methods will not be available. This PR will add both methods as part of the console. It can be merged before https://github.com/ethereum/go-ethereum/pull/2113.