### PR TITLE
core/vm, rpc/api, xeth: added eth_debugTransaction RPC call

### DIFF
--- a/core/vm/common.go
+++ b/core/vm/common.go
@@ -28,6 +28,9 @@ import (
 // Global Debug flag indicating Debug VM (full logging)
 var Debug bool
 
+// Global Debug flag indicating to generate structured logs of the evm execution (full logging)
+var GenerateStructLogs bool = false
+
 // Type is the VM type accepted by **NewVm**
 type Type byte
 

--- a/core/vm/vm.go
+++ b/core/vm/vm.go
@@ -367,7 +367,7 @@ func (self *Vm) RunPrecompiled(p *PrecompiledAccount, input []byte, contract *Co
 // log emits a log event to the environment for each opcode encountered. This is not to be confused with the
 // LOG* opcode.
 func (self *Vm) log(pc uint64, op OpCode, gas, cost *big.Int, memory *Memory, stack *stack, contract *Contract, err error) {
-	if Debug {
+	if Debug || GenerateStructLogs {
 		mem := make([]byte, len(memory.Data()))
 		copy(mem, memory.Data())
 

--- a/rpc/api/eth_args.go
+++ b/rpc/api/eth_args.go
@@ -1102,3 +1102,50 @@ func (args *ResendArgs) UnmarshalJSON(b []byte) (err error) {
 
 	return nil
 }
+
+type DebugTransactionArgs struct {
+	TxHash     string
+	StackDepth int
+	MemorySize int
+}
+
+func (args *DebugTransactionArgs) UnmarshalJSON(b []byte) (err error) {
+	var obj []interface{}
+
+	if err := json.Unmarshal(b, &obj); err != nil {
+		return shared.NewDecodeParamError(err.Error())
+	}
+
+	if len(obj) < 1 {
+		return shared.NewInsufficientParamsError(len(obj), 1)
+	}
+
+	argstr, ok := obj[0].(string)
+	if !ok {
+		return shared.NewInvalidTypeError("txHash", "not a string")
+	}
+	args.TxHash = argstr
+
+	if len(obj) > 1 && obj[1] != nil {
+		if stackDepthVal, ok := obj[1].(float64); ok {
+			args.StackDepth = int(stackDepthVal)
+		} else {
+			return shared.NewInvalidTypeError("stackDepth", "invalid number")
+		}
+	} else {
+		args.StackDepth = -1
+	}
+
+	if len(obj) > 2 && obj[2] != nil {
+
+		if memorySizeVal, ok := obj[2].(float64); ok {
+			args.MemorySize = int(memorySizeVal)
+		} else {
+			return shared.NewInvalidTypeError("memorySize", "invalid number")
+		}
+	} else {
+		args.MemorySize = -1
+	}
+
+	return nil
+}

--- a/rpc/api/eth_js.go
+++ b/rpc/api/eth_js.go
@@ -53,6 +53,11 @@ web3._extend({
 			call: 'eth_submitTransaction',
 			params: 1,
 			inputFormatter: [web3._extend.formatters.inputTransactionFormatter]
+		}),
+		new web3._extend.Method({
+			name: 'debugTransaction',
+			call: 'eth_debugTransaction',
+			params: 3
 		})
 	],
 	properties:

--- a/rpc/api/parsing.go
+++ b/rpc/api/parsing.go
@@ -462,6 +462,23 @@ func NewReceiptRes(rec *types.Receipt) *ReceiptRes {
 	return v
 }
 
+type StructLogRes struct {
+	Pc      uint64            `json:"Pc"`
+	Op      string            `json:"Op"`
+	Gas     *big.Int          `json:Gas`
+	GasCost *big.Int          `json:GasCost`
+	Error   error             `json:Error`
+	Stack   []string          `json:"Stack"`
+	Memory  map[string]string `json:Memory`
+	Storage map[string]string `json:Storage`
+}
+
+type TransactionExecutionRes struct {
+	Gas         *big.Int       `json:Gas`
+	ReturnValue string         `json:ReturnValue`
+	StructLogs  []StructLogRes `json:StructLogs`
+}
+
 func numString(raw interface{}) (*big.Int, error) {
 	var number *big.Int
 	// Parse as integer


### PR DESCRIPTION
This pull request introduces a new RPC call "eth_debugTransaction". When called with a given tx hash it will re-run the transaction and returns the log of the evm (stuct log). The tx is re-run against the blockchain state at the height of the block prior to the one the tx was mined.

The call will only process mined transactions.

This functionality can be used for blockchain explorers to extract information on contract internal value transfers as well as developers in order to debug their contracts.

Had to create a new pull request, for the previous discussion see: https://github.com/ethereum/go-ethereum/pull/2131