### PR TITLE
core/state, trie: don't leak database writes before commit

### DIFF
--- a/core/state/statedb_test.go
+++ b/core/state/statedb_test.go
@@ -1,0 +1,52 @@
+// Copyright 2015 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+package state
+
+import (
+	"math/big"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/ethdb"
+)
+
+// Tests that updating a state trie does not leak any database writes prior to
+// actually committing the state.
+func TestUpdateLeaks(t *testing.T) {
+	// Create an empty state database
+	db, _ := ethdb.NewMemDatabase()
+	state, _ := New(common.Hash{}, db)
+
+	// Update it with some accounts
+	for i := byte(0); i < 255; i++ {
+		obj := state.GetOrNewStateObject(common.BytesToAddress([]byte{i}))
+		obj.AddBalance(big.NewInt(int64(11 * i)))
+		obj.SetNonce(uint64(42 * i))
+		if i%2 == 0 {
+			obj.SetState(common.BytesToHash([]byte{i, i, i}), common.BytesToHash([]byte{i, i, i, i}))
+		}
+		if i%3 == 0 {
+			obj.SetCode([]byte{i, i, i, i, i})
+		}
+		state.UpdateStateObject(obj)
+	}
+	// Ensure that no data was leaked into the database
+	for _, key := range db.Keys() {
+		value, _ := db.Get(key)
+		t.Errorf("State leaked into database: %x -> %x", key, value)
+	}
+}

--- a/ethdb/memory_database.go
+++ b/ethdb/memory_database.go
@@ -107,7 +107,7 @@ func (b *memBatch) Put(key, value []byte) error {
 	b.lock.Lock()
 	defer b.lock.Unlock()
 
-	b.writes = append(b.writes, kv{key, common.CopyBytes(value)})
+	b.writes = append(b.writes, kv{common.CopyBytes(key), common.CopyBytes(value)})
 	return nil
 }
 

--- a/trie/secure_trie.go
+++ b/trie/secure_trie.go
@@ -109,7 +109,7 @@ func (t *SecureTrie) TryUpdate(key, value []byte) error {
 	if err != nil {
 		return err
 	}
-	t.secKeyCache[string(hk)] = key
+	t.secKeyCache[string(hk)] = common.CopyBytes(key)
 	return nil
 }
 
@@ -123,7 +123,9 @@ func (t *SecureTrie) Delete(key []byte) {
 // TryDelete removes any existing value for key from the trie.
 // If a node was not found in the database, a MissingNodeError is returned.
 func (t *SecureTrie) TryDelete(key []byte) error {
-	return t.Trie.TryDelete(t.hashKey(key))
+	hk := t.hashKey(key)
+	delete(t.secKeyCache, string(hk))
+	return t.Trie.TryDelete(hk)
 }
 
 // GetKey returns the sha3 preimage of a hashed key that was


### PR DESCRIPTION
Currently both the state db and the secure trie are leaking database writes: although they were designed to cache all updates until commit, some updates still reach the database before a commit. The problem with this is that if such a key is updated multiple times, then the database will be hit with the same write multiple times. Also in certain situations the data should never even end up in the database, but it does since an intermediate state leaks it there. This makes it impossible for the state pruning to clean it up, since it cannot find these leaked entries that never should be in the database.

One of the leaks is writing a contract data whenever we update the account: if a block contains 10 transactions to a contract, we will actually write out the contract's code 10 times. Further, if a contract is created and deleted in the same block, the code will end up in the database, whereas it should not as it's only a block-internal intermediate state.

The second leak is in the secure trie, which writes the secure pre-image of a key to the database whenever the key is updated, leading to the same scenarios as above. 

The fix to both of the above scenarios was to only write them to the database during commit. For contracts this could be done easily, dropping intermediate contract code from ending up in the database. For secure tries the fix was to cache the secure entries and store them during commit. This probably still could lead to ephemeral secure hashes ending up in the database (I'll investigate and fix in a follow up PR if that's the case), but at least we only write each key once, and not once per update.

Running the old vs. new code on 100K blocks:

```
Old: Import done in 2m8.448078245s
New: Import done in 2m6.465299777s
```

Update: for 250K blocks:

```
Old: Import done in 7m45.191423932s
New: Import done in 7m33.420245411s
```

Although the difference is not *that* big, we should note that the first 100K blocks are relatively low traffic. It would probably be much more visible on higher blocks.

---

A second commit fixes a memdb bug where we didn't copy the keys of a memdb batch when saving it for later storage and the buffer area was reused externally (i.e. when iterating over a map of entries to insert).