### PR TITLE
logger/glog: improve vmodule

### DIFF
--- a/logger/glog/glog.go
+++ b/logger/glog/glog.go
@@ -138,6 +138,11 @@ func SetV(v int) {
 	logging.verbosity.set(Level(v))
 }
 
+// SetVmodule sets the global verbosity patterns.
+func SetVmodule(pat string) error {
+	return logging.vmodule.Set(pat)
+}
+
 // SetToStderr sets the global output style
 func SetToStderr(toStderr bool) {
 	logging.toStderr = toStderr

--- a/node/api.go
+++ b/node/api.go
@@ -138,6 +138,11 @@ func (api *PrivateDebugAPI) Verbosity(level int) {
 	glog.SetV(level)
 }
 
+// Vmodule updates the node's logging verbosity pattern.
+func (api *PrivateDebugAPI) Vmodule(pattern string) error {
+	return glog.SetVmodule(pattern)
+}
+
 // PublicDebugAPI is the collection of debugging related API methods exposed over
 // both secure and unsecure RPC channels.
 type PublicDebugAPI struct {

--- a/rpc/api/admin.go
+++ b/rpc/api/admin.go
@@ -31,7 +31,6 @@ import (
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/eth"
-	"github.com/ethereum/go-ethereum/logger/glog"
 	"github.com/ethereum/go-ethereum/node"
 	"github.com/ethereum/go-ethereum/p2p/discover"
 	"github.com/ethereum/go-ethereum/rlp"
@@ -55,7 +54,6 @@ var (
 		"admin_nodeInfo":           (*adminApi).NodeInfo,
 		"admin_exportChain":        (*adminApi).ExportChain,
 		"admin_importChain":        (*adminApi).ImportChain,
-		"admin_verbosity":          (*adminApi).Verbosity,
 		"admin_setSolc":            (*adminApi).SetSolc,
 		"admin_datadir":            (*adminApi).DataDir,
 		"admin_startRPC":           (*adminApi).StartRPC,
@@ -222,16 +220,6 @@ func (self *adminApi) ExportChain(req *shared.Request) (interface{}, error) {
 		return false, err
 	}
 
-	return true, nil
-}
-
-func (self *adminApi) Verbosity(req *shared.Request) (interface{}, error) {
-	args := new(VerbosityArgs)
-	if err := self.coder.Decode(req.Params, &args); err != nil {
-		return nil, shared.NewDecodeParamError(err.Error())
-	}
-
-	glog.SetV(args.Level)
 	return true, nil
 }
 

--- a/rpc/api/admin_args.go
+++ b/rpc/api/admin_args.go
@@ -69,28 +69,6 @@ func (args *ImportExportChainArgs) UnmarshalJSON(b []byte) (err error) {
 	return nil
 }
 
-type VerbosityArgs struct {
-	Level int
-}
-
-func (args *VerbosityArgs) UnmarshalJSON(b []byte) (err error) {
-	var obj []interface{}
-	if err := json.Unmarshal(b, &obj); err != nil {
-		return shared.NewDecodeParamError(err.Error())
-	}
-
-	if len(obj) != 1 {
-		return shared.NewDecodeParamError("Expected enode as argument")
-	}
-
-	level, err := numString(obj[0])
-	if err == nil {
-		args.Level = int(level.Int64())
-	}
-
-	return nil
-}
-
 type SetSolcArgs struct {
 	Path string
 }

--- a/rpc/api/admin_js.go
+++ b/rpc/api/admin_js.go
@@ -46,12 +46,6 @@ web3._extend({
 			inputFormatter: [null, null]
 		}),
 		new web3._extend.Method({
-			name: 'verbosity',
-			call: 'admin_verbosity',
-			params: 1,
-			inputFormatter: [web3._extend.utils.fromDecimal]
-		}),
-		new web3._extend.Method({
 			name: 'setSolc',
 			call: 'admin_setSolc',
 			params: 1,

--- a/rpc/api/debug_js.go
+++ b/rpc/api/debug_js.go
@@ -62,7 +62,19 @@ web3._extend({
 			call: 'debug_metrics',
 			params: 1,
 			inputFormatter: [null]
-		})
+		}),
+		new web3._extend.Method({
+			name: 'verbosity',
+			call: 'debug_verbosity',
+			params: 1,
+			inputFormatter: [web3._extend.utils.fromDecimal]
+		}),
+		new web3._extend.Method({
+			name: 'vmodule',
+			call: 'debug_vmodule',
+			params: 1,
+			inputFormatter: [null]
+		}),
 	],
 	properties:
 	[


### PR DESCRIPTION
This change allows setting the verbosity for directory prefixes using the syntax

    --vmodule=eth/*=6

If you want to restrict messages to a particular directory (e.g. p2p), but exclude subdirectories, use

    --vmodule=p2p=6

If you want to see log messages from a particular source file, use

    --vmodule=server.go=6

You can compose these basic patterns. If you want to see all output from peer.go in a package below
eth (eth/peer.go, eth/downloader/peer.go), use

    --vmodule=eth/*/peer.go=6

The output format also changes to display part of the import path and removes the process id.

```text
I0120 14:10:59.731647 ethdb/database.go:71] Alloted 16MB cache to /Users/fjl/Library/Ethereum/chaindata
I0120 14:10:59.763596 ethdb/database.go:71] Alloted 16MB cache to /Users/fjl/Library/Ethereum/dapp
I0120 14:10:59.769989 eth/backend.go:161] Protocol Versions: [63 62 61], Network Id: 1
I0120 14:10:59.770127 eth/backend.go:189] Blockchain DB Version: 3
I0120 14:10:59.770985 core/blockchain.go:210] Last header: #848682 [96865ccd…] TD=5538940244436146641
...
```

Additionally the vmodule patterns can now be set through the debug API without
restarting the node.

```text
$ geth attach
...
> debug.vmodule("p2p=6")
```
