### PR TITLE
core, core/types, miner: fix transaction nonce-price combo sort

### DIFF
--- a/core/transaction_pool.go
+++ b/core/transaction_pool.go
@@ -376,7 +376,7 @@ func (self *TxPool) GetQueuedTransactions() types.Transactions {
 			ret = append(ret, tx)
 		}
 	}
-	sort.Sort(types.TxByNonce{ret})
+	sort.Sort(types.TxByNonce(ret))
 	return ret
 }
 

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -19,7 +19,6 @@ package miner
 import (
 	"fmt"
 	"math/big"
-	"sort"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -496,12 +495,12 @@ func (self *worker) commitNewWork() {
 
 	/* //approach 1
 	transactions := self.eth.TxPool().GetTransactions()
-	sort.Sort(types.TxByNonce{transactions})
+	sort.Sort(types.TxByNonce(transactions))
 	*/
 
 	//approach 2
 	transactions := self.eth.TxPool().GetTransactions()
-	sort.Sort(types.TxByPriceAndNonce{transactions})
+	types.SortByPriceAndNonce(transactions)
 
 	/* // approach 3
 	// commit transactions for this run.
@@ -525,8 +524,8 @@ func (self *worker) commitNewWork() {
 			multiTxOwner = append(multiTxOwner, txs...)
 		}
 	}
-	sort.Sort(types.TxByPrice{singleTxOwner})
-	sort.Sort(types.TxByNonce{multiTxOwner})
+	sort.Sort(types.TxByPrice(singleTxOwner))
+	sort.Sort(types.TxByNonce(multiTxOwner))
 	transactions := append(singleTxOwner, multiTxOwner...)
 	*/
 


### PR DESCRIPTION
This PR closes #2139 

Content wise it mainly discards the types.TxByPriceAndNonce, as that algo wasn't defining a total order over the elements, which messed up the ordering. The new algo fist sorts by nonces per account, and then uses a heap to merge in the best paying transactions, but only always considering the top available ones, not all.

Testing the nonce ordering is obvious, but the gas price is not so much. For every transaction in the sorted list the test finds the position of the previous- and next-nonce transaction from the same account (in between which two the selected transaction can move freely), and ensures that in that specific interval, the selected transaction is priced correctly.

---

A minor polish that this PR also includes is changing `types.TxByPrice` and `types.TxByNonce` from **containing** a struct to **aliasing** a struct. This needs us to manually implement the `sort.Len` and `sort.Swap` methods for these, but using an embedded struct really messes up the heap interface implementation, so this way is far cleaner (also it's the recommended way).