### PR TITLE
Added Vagrantfile so that developers can spin up a VM to build geth

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,5 @@ cmd/mist/assets/ext/ethereum.js/
 profile.tmp
 profile.cov
 
+# vagrant
+.vagrant

--- a/containers/vagrant/Vagrantfile
+++ b/containers/vagrant/Vagrantfile
@@ -1,0 +1,29 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+Vagrant.configure(2) do |config|
+  config.vm.box = "ubuntu/trusty64"
+
+  config.vm.provider "virtualbox" do |vb|
+    vb.memory = "2048"
+  end
+
+  config.vm.synced_folder "../../", "/home/vagrant/go/src/github.com/ethereum/go-ethereum"
+  config.vm.synced_folder ".", "/vagrant", disabled: true
+
+  config.vm.provision "shell", inline: <<-SHELL
+    sudo apt-get install software-properties-common
+    sudo add-apt-repository -y ppa:ethereum/ethereum
+    sudo add-apt-repository -y ppa:ethereum/ethereum-dev
+    sudo apt-get update
+
+    sudo apt-get install -y build-essential golang git-all
+
+    GOPATH=/home/vagrant/go go get github.com/tools/godep
+
+    sudo chown -R vagrant:vagrant ~vagrant/go
+
+    echo "export GOPATH=/home/vagrant/go" >> ~vagrant/.bashrc
+    echo "export PATH=\\\$PATH:\\\$GOPATH/bin:/usr/local/go/bin" >> ~vagrant/.bashrc
+  SHELL
+end


### PR DESCRIPTION
Added a Vagrantfile so that developers can spin up a VM to build geth.

Steps would be:
- Fork https://github.com/ethereum/go-ethereum
- ```cd <wherever-you-want-it>```
- ```git clone https://github.com/<user>/go-ethereum.git```
- ```cd go-ethereum```
- ```vagrant up```
- ```vagrant ssh```
- ```cd ~vagrant/go/src/github.com/ethereum/go-ethereum```
- ```make geth```

Runs ubuntu/trust64 and requires virtualbox and 2GB of RAM.