### PR TITLE
cmd, eth, rpc: fix some RPC issues with pending blocks

### DIFF
--- a/cmd/gethrpctest/main.go
+++ b/cmd/gethrpctest/main.go
@@ -52,6 +52,10 @@ var (
 func main() {
 	flag.Parse()
 
+	// Enable logging errors, we really do want to see those
+	glog.SetV(2)
+	glog.SetToStderr(true)
+
 	// Load the test suite to run the RPC against
 	tests, err := tests.LoadBlockTests(*testFile)
 	if err != nil {

--- a/eth/filters/api.go
+++ b/eth/filters/api.go
@@ -239,13 +239,13 @@ func (args *NewFilterArgs) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	if raw.From == nil {
+	if raw.From == nil || raw.From.Int64() < 0 {
 		args.FromBlock = rpc.LatestBlockNumber
 	} else {
 		args.FromBlock = *raw.From
 	}
 
-	if raw.ToBlock == nil {
+	if raw.ToBlock == nil || raw.ToBlock.Int64() < 0 {
 		args.ToBlock = rpc.LatestBlockNumber
 	} else {
 		args.ToBlock = *raw.ToBlock

--- a/rpc/server.go
+++ b/rpc/server.go
@@ -332,7 +332,6 @@ func (s *Server) handle(ctx context.Context, codec ServerCodec, req *serverReque
 			return res
 		}
 	}
-
 	return codec.CreateResponse(req.id, reply[0].Interface())
 }
 
@@ -344,7 +343,6 @@ func (s *Server) exec(ctx context.Context, codec ServerCodec, req *serverRequest
 	} else {
 		response = s.handle(ctx, codec, req)
 	}
-
 	if err := codec.Write(response); err != nil {
 		glog.V(logger.Error).Infof("%v\n", err)
 		codec.Close()

--- a/rpc/types.go
+++ b/rpc/types.go
@@ -174,12 +174,14 @@ type HexNumber big.Int
 // NewHexNumber creates a new hex number instance which will serialize the given val with `%#x` on marshal.
 func NewHexNumber(val interface{}) *HexNumber {
 	if val == nil {
-		return nil
+		return nil // note, this doesn't catch nil pointers, only passing nil directly!
 	}
 
-	if v, ok := val.(*big.Int); ok && v != nil {
-		hn := new(big.Int).Set(v)
-		return (*HexNumber)(hn)
+	if v, ok := val.(*big.Int); ok {
+		if v != nil {
+			return (*HexNumber)(new(big.Int).Set(v))
+		}
+		return nil
 	}
 
 	rval := reflect.ValueOf(val)
@@ -303,10 +305,9 @@ const (
 )
 
 // UnmarshalJSON parses the given JSON fragement into a BlockNumber. It supports:
-// - "latest" or "earliest" as string arguments
+// - "latest", "earliest" or "pending" as string arguments
 // - the block number
 // Returned errors:
-// - an unsupported error when "pending" is specified (not yet implemented)
 // - an invalid block number error when the given argument isn't a known strings
 // - an out of range error when the given block number is either too little or too large
 func (bn *BlockNumber) UnmarshalJSON(data []byte) error {


### PR DESCRIPTION
This PR mainly fixes an important RPC call, namely getting the account transaction count (`GetTransactionCount`) in the pending block. AFAIK, this is used by web3.js to figure out the account nonce to send the subsequent transaction with.

A few other fixes include:
 * Logging error messages in the RPC tester.
 * Removing a few 0 fields from GetBlocks when the pending block is queried.
 * A minor fix in the API interface{} to hex converter which didn't handle nil's fully properly.