### PR TITLE
core/vm, rpc/api: added debug_replayTransaction RPC call

### DIFF
--- a/core/vm/common.go
+++ b/core/vm/common.go
@@ -28,6 +28,8 @@ import (
 // Global Debug flag indicating Debug VM (full logging)
 var Debug bool
 
+var GenerateStructLogs bool = false
+
 // Type is the VM type accepted by **NewVm**
 type Type byte
 

--- a/core/vm/vm.go
+++ b/core/vm/vm.go
@@ -367,7 +367,7 @@ func (self *Vm) RunPrecompiled(p *PrecompiledAccount, input []byte, contract *Co
 // log emits a log event to the environment for each opcode encountered. This is not to be confused with the
 // LOG* opcode.
 func (self *Vm) log(pc uint64, op OpCode, gas, cost *big.Int, memory *Memory, stack *stack, contract *Contract, err error) {
-	if Debug {
+	if Debug || GenerateStructLogs {
 		mem := make([]byte, len(memory.Data()))
 		copy(mem, memory.Data())
 

--- a/rpc/javascript.go
+++ b/rpc/javascript.go
@@ -399,6 +399,11 @@ web3._extend({
 			call: 'debug_writeMemProfile',
 			params: 1
 		}),
+		new web3._extend.Method({
+			name: 'replayTransaction',
+			call: 'debug_replayTransaction',
+			params: 4
+		})
 	],
 	properties:
 	[


### PR DESCRIPTION
This is the successor of PR https://github.com/ethereum/go-ethereum/pull/2133

This pull request introduces a new RPC call "debug_replayTransaction". When called with a given tx hash it will re-run the transaction and returns the log of the evm (stuct log). The tx is re-run against the blockchain state at the height of the block prior to the one the tx was mined.

The call will only process mined transactions.

This functionality can be used for blockchain explorers to extract information on contract internal value transfers as well as developers in order to debug their contracts.