### PR TITLE
ErrInvalidPubKey; machine-readable account list output

### DIFF
--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -527,11 +527,24 @@ func startNode(ctx *cli.Context, stack *node.Node) {
 func accountList(ctx *cli.Context) {
 	accman := utils.MakeAccountManager(ctx)
 	accts, err := accman.Accounts()
+	arg := ctx.Args().First()
 	if err != nil {
 		utils.Fatalf("Could not list accounts: %v", err)
 	}
-	for i, acct := range accts {
-		fmt.Printf("Account #%d: %x\n", i, acct)
+	if arg != "" {
+		// arg is an integer for the key we want to print
+		i, err := strconv.Atoi(arg)
+		if err != nil {
+			utils.Fatalf("Must specify a valid integer argument: %v", err)
+		}
+		if i+1 > len(accts) {
+			utils.Fatalf("Cannot get key %d; there are only %d keys, and counting starts at 0", i, len(accts))
+		}
+		fmt.Printf("%x\n", accts[i].Address)
+	} else {
+		for i, acct := range accts {
+			fmt.Printf("Account #%d: %x\n", i, acct)
+		}
 	}
 }
 

--- a/core/types/transaction.go
+++ b/core/types/transaction.go
@@ -31,7 +31,10 @@ import (
 	"github.com/ethereum/go-ethereum/rlp"
 )
 
-var ErrInvalidSig = errors.New("invalid v, r, s values")
+var (
+	ErrInvalidSig    = errors.New("invalid v, r, s values")
+	ErrInvalidPubKey = errors.New("invalid public key")
+)
 
 type Transaction struct {
 	data txdata
@@ -200,7 +203,7 @@ func (tx *Transaction) publicKey() ([]byte, error) {
 		return nil, err
 	}
 	if len(pub) == 0 || pub[0] != 4 {
-		return nil, errors.New("invalid public key")
+		return nil, ErrInvalidPubKey
 	}
 	return pub, nil
 }


### PR DESCRIPTION
Just a few very simple things:

1) `geth account list <N>` for machine readable output of account `<N>`

2) use an ErrInvalidPubKey variable in pubkey recovery
