### PR TITLE
cmd, common, node, rpc: move IPC into the node itself

### DIFF
--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -502,12 +502,7 @@ func startNode(ctx *cli.Context, stack *node.Node) {
 			unlockAccount(ctx, accman, trimmed, i, passwords)
 		}
 	}
-	// Start auxiliary services if enabled.
-	if !ctx.GlobalBool(utils.IPCDisabledFlag.Name) {
-		if err := utils.StartIPC(stack, ctx); err != nil {
-			utils.Fatalf("Failed to start IPC: %v", err)
-		}
-	}
+	// Start auxiliary services if enabled
 	if ctx.GlobalBool(utils.RPCEnabledFlag.Name) {
 		if err := utils.StartRPC(stack, ctx); err != nil {
 			utils.Fatalf("Failed to start RPC: %v", err)

--- a/cmd/geth/monitorcmd.go
+++ b/cmd/geth/monitorcmd.go
@@ -28,7 +28,7 @@ import (
 
 	"github.com/codegangsta/cli"
 	"github.com/ethereum/go-ethereum/cmd/utils"
-	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/node"
 	"github.com/ethereum/go-ethereum/rpc"
 	"github.com/gizak/termui"
 )
@@ -36,7 +36,7 @@ import (
 var (
 	monitorCommandAttachFlag = cli.StringFlag{
 		Name:  "attach",
-		Value: "ipc:" + common.DefaultIpcPath(),
+		Value: "ipc:" + node.DefaultIpcEndpoint(),
 		Usage: "API endpoint to attach to",
 	}
 	monitorCommandRowsFlag = cli.IntFlag{

--- a/cmd/utils/client.go
+++ b/cmd/utils/client.go
@@ -150,10 +150,8 @@ func NewRemoteRPCClient(ctx *cli.Context) (rpc.Client, error) {
 		endpoint := ctx.Args().First()
 		return NewRemoteRPCClientFromString(endpoint)
 	}
-
 	// use IPC by default
-	endpoint := IPCSocketPath(ctx)
-	return rpc.NewIPCClient(endpoint)
+	return rpc.NewIPCClient(node.DefaultIpcEndpoint())
 }
 
 // NewRemoteRPCClientFromString returns a RPC client which connects to the given

--- a/common/path.go
+++ b/common/path.go
@@ -89,9 +89,8 @@ func DefaultDataDir() string {
 	return ""
 }
 
-func DefaultIpcPath() string {
-	if runtime.GOOS == "windows" {
-		return `\\.\pipe\geth.ipc`
-	}
-	return filepath.Join(DefaultDataDir(), "geth.ipc")
+// DefaultIpcSocket returns the relative name of the default IPC socket. The path
+// resolution is done by a node with other contextual infos.
+func DefaultIpcSocket() string {
+	return "geth.ipc"
 }

--- a/node/node_example_test.go
+++ b/node/node_example_test.go
@@ -31,6 +31,7 @@ import (
 //
 // The following methods are needed to implement a node.Service:
 //  - Protocols() []p2p.Protocol - devp2p protocols the service can communicate on
+//  - APIs() []rpc.API           - api methods the service wants to expose on rpc channels
 //  - Start() error              - method invoked when the node is ready to start the service
 //  - Stop() error               - method invoked when the node terminates the service
 type SampleService struct{}

--- a/node/service_test.go
+++ b/node/service_test.go
@@ -63,7 +63,7 @@ func TestContextDatabases(t *testing.T) {
 
 // Tests that already constructed services can be retrieves by later ones.
 func TestContextServices(t *testing.T) {
-	stack, err := New(testNodeConfig)
+	stack, err := New(testNodeConfig())
 	if err != nil {
 		t.Fatalf("failed to create protocol stack: %v", err)
 	}

--- a/node/utils_test.go
+++ b/node/utils_test.go
@@ -52,6 +52,7 @@ func NewNoopServiceD(*ServiceContext) (Service, error) { return new(NoopServiceD
 // methods can be instrumented both return value as well as event hook wise.
 type InstrumentedService struct {
 	protocols []p2p.Protocol
+	apis      []rpc.API
 	start     error
 	stop      error
 
@@ -70,7 +71,7 @@ func (s *InstrumentedService) Protocols() []p2p.Protocol {
 }
 
 func (s *InstrumentedService) APIs() []rpc.API {
-	return nil
+	return s.apis
 }
 
 func (s *InstrumentedService) Start(server *p2p.Server) error {
@@ -120,4 +121,15 @@ func InstrumentedServiceMakerB(base ServiceConstructor) ServiceConstructor {
 
 func InstrumentedServiceMakerC(base ServiceConstructor) ServiceConstructor {
 	return InstrumentingWrapperMaker(base, reflect.TypeOf(InstrumentedServiceC{}))
+}
+
+// OneMethodApi is a single-method API handler to be returned by test services.
+type OneMethodApi struct {
+	fun func()
+}
+
+func (api *OneMethodApi) TheOneMethod() {
+	if api.fun != nil {
+		api.fun()
+	}
 }

--- a/rpc/json.go
+++ b/rpc/json.go
@@ -41,7 +41,7 @@ type JSONRequest struct {
 	Method  string          `json:"method"`
 	Version string          `json:"jsonrpc"`
 	Id      *int64          `json:"id,omitempty"`
-	Payload json.RawMessage `json:"params"`
+	Payload json.RawMessage `json:"params,omitempty"`
 }
 
 // JSON-RPC response


### PR DESCRIPTION
**Edit: the HTTP and WebSocket API endpoints are currently implemented as singletons. Because of this, it will take a much larger effort to move them into the node. Hence this PR will only do the IPC part, and I'll leave the HTTP to a follow up PR with a more constrained scope.**

This PR supersedes https://github.com/ethereum/go-ethereum/pull/2031. The goal is to have the RPC managed fully by the node, configurable by some config parameters. This is particularly needed because currently the RPC API internals are spilled all over the node-client code (e.g. [etherapis](https://github.com/gophergala2016/etherapis/blob/master/etherapis/geth/geth.go#L95)).

 - [x] Move the IPC RPC endpoint fully into the `node`
 - ~~[ ] Move the HTTP RPC endpoint fully into the `node`~~
 - ~~[ ] Move the WS RPC endpoint fully into the `node`~~