### PR TITLE
miner: register newly created remote agent in the API

### DIFF
--- a/miner/api.go
+++ b/miner/api.go
@@ -33,7 +33,10 @@ type PublicMinerAPI struct {
 
 // NewPublicMinerAPI create a new PublicMinerAPI instance.
 func NewPublicMinerAPI(miner *Miner) *PublicMinerAPI {
-	return &PublicMinerAPI{miner, NewRemoteAgent()}
+	agent := NewRemoteAgent()
+	miner.Register(agent)
+
+	return &PublicMinerAPI{miner, agent}
 }
 
 // Mining returns an indication if this node is currently mining.


### PR DESCRIPTION
When creating the remote miner agent, it wasn't registered with the miner itself, so the RPC was talking to a dangling agent.