### PR TITLE
minor: fix typo

### DIFF
--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -343,7 +343,7 @@ var (
 	// ATM the url is left to the user and deployment to
 	JSpathFlag = cli.StringFlag{
 		Name:  "jspath",
-		Usage: "JavaSript root path for `loadScript` and document root for `admin.httpGet`",
+		Usage: "JavaScript root path for `loadScript` and document root for `admin.httpGet`",
 		Value: ".",
 	}
 	SolcPathFlag = cli.StringFlag{


### PR DESCRIPTION
fixed typo in jspath usage description: "JavaSript" -> "JavaScript"