### PR TITLE
cmd/utils: fix jspath flag typo

### DIFF
--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -338,7 +338,7 @@ var (
 	// ATM the url is left to the user and deployment to
 	JSpathFlag = cli.StringFlag{
 		Name:  "jspath",
-		Usage: "JavaSript root path for `loadScript` and document root for `admin.httpGet`",
+		Usage: "JavaScript root path for `loadScript` and document root for `admin.httpGet`",
 		Value: ".",
 	}
 	SolcPathFlag = cli.StringFlag{


### PR DESCRIPTION
fixed typo in jspath usage description: "JavaSript" -> "JavaScript"