### PR TITLE
eth_sendTransaction, error not reported

### DIFF
--- a/eth/api.go
+++ b/eth/api.go
@@ -999,7 +999,7 @@ func (s *PublicTransactionPoolAPI) SendTransaction(args SendTxArgs) (common.Hash
 
 	s.txPool.SetLocal(signedTx)
 	if err := s.txPool.Add(signedTx); err != nil {
-		return common.Hash{}, nil
+		return common.Hash{}, err
 	}
 
 	if contractCreation {


### PR DESCRIPTION
When a transaction could not be added to the pool the raised error was not returned.
This PR will fix #2180.