### PR TITLE
eth/downloader: raise pending state limit that prevented concurrency

### DIFF
--- a/eth/downloader/downloader.go
+++ b/eth/downloader/downloader.go
@@ -59,7 +59,6 @@ var (
 
 	maxQueuedHashes   = 256 * 1024 // [eth/61] Maximum number of hashes to queue for import (DOS protection)
 	maxQueuedHeaders  = 256 * 1024 // [eth/62] Maximum number of headers to queue for import (DOS protection)
-	maxQueuedStates   = 256 * 1024 // [eth/63] Maximum number of state requests to queue (DOS protection)
 	maxResultsProcess = 256        // Number of download results to import at once into the chain
 
 	fsHeaderCheckFrequency = 100  // Verification frequency of the downloaded headers during fast sync

--- a/eth/downloader/queue.go
+++ b/eth/downloader/queue.go
@@ -39,7 +39,8 @@ import (
 )
 
 var (
-	blockCacheLimit = 1024 // Maximum number of blocks to cache before throttling the download
+	blockCacheLimit   = 1024 // Maximum number of blocks to cache before throttling the download
+	maxInFlightStates = 4096 // Maximum number of state downloads to allow concurrently
 )
 
 var (
@@ -464,7 +465,7 @@ func (q *queue) ReserveNodeData(p *peer, count int) *fetchRequest {
 	q.lock.Lock()
 	defer q.lock.Unlock()
 
-	return q.reserveHashes(p, count, q.stateTaskQueue, generator, q.statePendPool, count)
+	return q.reserveHashes(p, count, q.stateTaskQueue, generator, q.statePendPool, maxInFlightStates)
 }
 
 // reserveHashes reserves a set of hashes for the given peer, skipping previously


### PR DESCRIPTION
Well, this was a stupid bug :P 

Although the fast sync state download had this beautiful concurrency built it to pull from as many sources as possible, we also placed an upper limit on the number of concurrent requests allowed to be in flight at any given time. This is needed so that the state trie is not fully expanded breadth first (as we're downloading from the root towards the leaves) - consuming all the available memory - but rather is guided depth first to write out sub-trees before expanding too many siblings.

The problem was, that due to some refactor or by plain accident, I specified for this concurrency limit the same value as the number of state entries we want to download from a single peer. Hence, there was **never** any download tasks for the second peer, as the first always managed to reserve all of them. In essence, this tiny error managed to completely disable concurrent state downloads, serializing it though a single peer.

This fix simply bumps the state download concurrency a single node's allowance to a global 4K. State download now finishes in approximately 2.5 minutes for the entire frontier network :P