### PR TITLE
eth: Added GPO to suggest default gas prices

### DIFF
--- a/eth/api.go
+++ b/eth/api.go
@@ -47,10 +47,7 @@ import (
 	"gopkg.in/fatih/set.v0"
 )
 
-const (
-	defaultGasPrice = uint64(10000000000000)
-	defaultGas      = uint64(90000)
-)
+const defaultGas = uint64(90000)
 
 // blockByNumber is a commonly used helper function which retrieves and returns
 // the block for the given block number, capable of handling two special blocks:
@@ -762,6 +759,7 @@ func newRPCTransaction(b *types.Block, txHash common.Hash) (*RPCTransaction, err
 type PublicTransactionPoolAPI struct {
 	eventMux *event.TypeMux
 	chainDb  ethdb.Database
+	gpo      *GasPriceOracle
 	bc       *core.BlockChain
 	miner    *miner.Miner
 	am       *accounts.Manager
@@ -770,14 +768,15 @@ type PublicTransactionPoolAPI struct {
 }
 
 // NewPublicTransactionPoolAPI creates a new RPC service with methods specific for the transaction pool.
-func NewPublicTransactionPoolAPI(txPool *core.TxPool, m *miner.Miner, chainDb ethdb.Database, eventMux *event.TypeMux, bc *core.BlockChain, am *accounts.Manager) *PublicTransactionPoolAPI {
+func NewPublicTransactionPoolAPI(e *Ethereum) *PublicTransactionPoolAPI {
 	return &PublicTransactionPoolAPI{
-		eventMux: eventMux,
-		chainDb:  chainDb,
-		bc:       bc,
-		am:       am,
-		txPool:   txPool,
-		miner:    m,
+		eventMux: e.EventMux(),
+		gpo:      NewGasPriceOracle(e),
+		chainDb:  e.ChainDb(),
+		bc:       e.BlockChain(),
+		am:       e.AccountManager(),
+		txPool:   e.TxPool(),
+		miner:    e.Miner(),
 	}
 }
 
@@ -970,7 +969,7 @@ func (s *PublicTransactionPoolAPI) SendTransaction(args SendTxArgs) (common.Hash
 		args.Gas = rpc.NewHexNumber(defaultGas)
 	}
 	if args.GasPrice == nil {
-		args.GasPrice = rpc.NewHexNumber(defaultGasPrice)
+		args.GasPrice = rpc.NewHexNumber(s.gpo.SuggestPrice())
 	}
 	if args.Value == nil {
 		args.Value = rpc.NewHexNumber(0)
@@ -1111,7 +1110,7 @@ func (tx *Tx) UnmarshalJSON(b []byte) (err error) {
 		tx.GasLimit = rpc.NewHexNumber(0)
 	}
 	if tx.GasPrice == nil {
-		tx.GasPrice = rpc.NewHexNumber(defaultGasPrice)
+		tx.GasPrice = rpc.NewHexNumber(int64(50000000000))
 	}
 
 	if contractCreation {
@@ -1154,7 +1153,7 @@ func (s *PublicTransactionPoolAPI) SignTransaction(args *SignTransactionArgs) (*
 		args.Gas = rpc.NewHexNumber(defaultGas)
 	}
 	if args.GasPrice == nil {
-		args.GasPrice = rpc.NewHexNumber(defaultGasPrice)
+		args.GasPrice = rpc.NewHexNumber(s.gpo.SuggestPrice())
 	}
 	if args.Value == nil {
 		args.Value = rpc.NewHexNumber(0)

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -269,7 +269,7 @@ func (s *Ethereum) APIs() []rpc.API {
 		}, {
 			Namespace: "eth",
 			Version:   "1.0",
-			Service:   NewPublicTransactionPoolAPI(s.TxPool(), s.Miner(), s.ChainDb(), s.EventMux(), s.BlockChain(), s.AccountManager()),
+			Service:   NewPublicTransactionPoolAPI(s),
 			Public:    true,
 		}, {
 			Namespace: "eth",


### PR DESCRIPTION
This PR fixes a regression of the RPC where the default gas price that
was being used for transaction wasn't properly using the GPO. This PR
adds the GPO back to suggest gas prices rather than the hardcoded
default of 10000000000000.

Closes #2194