### PR TITLE
eth: add subscription for logs

### DIFF
--- a/eth/filters/filter_system.go
+++ b/eth/filters/filter_system.go
@@ -164,7 +164,7 @@ func (fs *FilterSystem) filterLoop() {
 			fs.filterMu.RLock()
 			for _, filter := range fs.logFilters {
 				if filter.LogCallback != nil && !filter.created.After(event.Time) {
-					for _, removedLog := range ev.Logs {
+					for _, removedLog := range filter.FilterLogs(ev.Logs) {
 						filter.LogCallback(removedLog, true)
 					}
 				}

--- a/rpc/server.go
+++ b/rpc/server.go
@@ -193,14 +193,14 @@ func (s *Server) Stop() {
 	}
 }
 
-// sendNotification will create a notification from the given event by serializing member fields of the event.
-// It will then send the notification to the client, when it fails the codec is closed. When the event has multiple
-// fields an array of values is returned.
+// sendNotification will send a notification to the client when the given event
+// is not nil. It will close the codec when the subscription could not be send.
 func sendNotification(codec ServerCodec, subid string, event interface{}) {
-	notification := codec.CreateNotification(subid, event)
-
-	if err := codec.Write(notification); err != nil {
-		codec.Close()
+	if event != nil {
+		notification := codec.CreateNotification(subid, event)
+		if err := codec.Write(notification); err != nil {
+			codec.Close()
+		}
 	}
 }
 

--- a/rpc/types.go
+++ b/rpc/types.go
@@ -136,9 +136,9 @@ func defaultSubscriptionOutputFormatter(data interface{}) interface{} {
 
 // Subscription is used by the server to send notifications to the client
 type Subscription struct {
-	sub    event.Subscription
-	match  SubscriptionMatcher
-	format SubscriptionOutputFormat
+	sub    event.Subscription       // event generator
+	match  SubscriptionMatcher      // allows for event filtering
+	format SubscriptionOutputFormat // allows for event output formatting (e.g. add custom fields)
 }
 
 // NewSubscription create a new RPC subscription
@@ -146,13 +146,15 @@ func NewSubscription(sub event.Subscription) Subscription {
 	return Subscription{sub, nil, defaultSubscriptionOutputFormatter}
 }
 
-// NewSubscriptionWithOutputFormat create a new RPC subscription which a custom notification output format
+// NewSubscriptionWithOutputFormat creates a new RPC subscription which a custom notification output format.
+// If formatter returns nil the event is discarded.
 func NewSubscriptionWithOutputFormat(sub event.Subscription, formatter SubscriptionOutputFormat) Subscription {
 	return Subscription{sub, nil, formatter}
 }
 
 // NewSubscriptionFiltered will create a new subscription. For each raised event the given matcher is
-// called. If it returns true the event is send as notification to the client, otherwise it is ignored.
+// called. If it returns true the event is send to the client, otherwise it is discarded. This can be
+// used in situations where custom filtering is necessary.
 func NewSubscriptionFiltered(sub event.Subscription, match SubscriptionMatcher) Subscription {
 	return Subscription{sub, match, defaultSubscriptionOutputFormatter}
 }


### PR DESCRIPTION
This PR adds a new subscription for new logs. It accepts an address or an array of addresses and an array of topics. It will push all logs that match the criteria as long as the subscription is active. This will remove the need for polling for new logs.

```
{
  "jsonrpc": "2.0",
  "method": "eth_subscription",
  "params": {
    "result":
      {
        "address": "0x6f1bd0796d89d0da01feb7096e7d8e032e412641",
        "blockHash": "0xf172e38607df6d89b30447611d22fbb620fbb5fececdb82f321e3fc9a3deb805",
        "blockNumber": "0x7f",
        "data": "0x000000000000000000000000079bd9292ae3f362de496bb706994bb13f0f66be00000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000001",
        "logIndex": "0x0",
        "topics": [
          "0x9114b3496933c87d362645cbea777906bf9e6e07ae912f5b285de3e2a8da0b66"
        ],
        "transactionHash": "0xbad9e94db1d58fe425b21804f462a5eca64525c29b762fb62cd23bf0aa35e681",
        "transactionIndex": "0x0",
        "removed": false
      }
    ,
    "subscription": "0xe2ca44a3cbab1572ba0d78f567a1910a"
  }
}
```