### PR TITLE
p2p/discover: NTP sanity check clock drift in case of expirations

### DIFF
--- a/p2p/discover/ntp.go
+++ b/p2p/discover/ntp.go
@@ -1,0 +1,99 @@
+// Copyright 2016 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+// Contains the NTP time drift detection via the SNTP protocol:
+//   https://tools.ietf.org/html/rfc4330
+
+package discover
+
+import (
+	"net"
+	"sort"
+	"time"
+)
+
+// ntpPool is the NTP server to query for the current time
+const ntpPool = "pool.ntp.org"
+
+// durationSlice attaches the methods of sort.Interface to []time.Duration,
+// sorting in increasing order.
+type durationSlice []time.Duration
+
+func (s durationSlice) Len() int           { return len(s) }
+func (s durationSlice) Less(i, j int) bool { return s[i] < s[j] }
+func (s durationSlice) Swap(i, j int)      { s[i], s[j] = s[j], s[i] }
+
+// sntpDrift does a naive time resolution against an NTP server and returns the
+// measured drift. This method uses the simple version of NTP. It's not precise
+// but should be fine for these purposes.
+//
+// Note, it executes two extra measurements compared to the number of requested
+// ones to be able to discard the two extremes as outliers.
+func sntpDrift(measurements int) (time.Duration, error) {
+	// Resolve the address of the NTP server
+	addr, err := net.ResolveUDPAddr("udp", ntpPool+":123")
+	if err != nil {
+		return 0, err
+	}
+	// Construct the time request (empty package with only 2 fields set):
+	//   Bits 3-5: Protocol version, 3
+	//   Bits 6-8: Mode of operation, client, 3
+	request := make([]byte, 48)
+	request[0] = 3<<3 | 3
+
+	// Execute each of the measurements
+	drifts := []time.Duration{}
+	for i := 0; i < measurements+2; i++ {
+		// Dial the NTP server and send the time retrieval request
+		conn, err := net.DialUDP("udp", nil, addr)
+		if err != nil {
+			return 0, err
+		}
+		defer conn.Close()
+
+		sent := time.Now()
+		if _, err = conn.Write(request); err != nil {
+			return 0, err
+		}
+		// Retrieve the reply and calculate the elapsed time
+		conn.SetDeadline(time.Now().Add(5 * time.Second))
+
+		reply := make([]byte, 48)
+		if _, err = conn.Read(reply); err != nil {
+			return 0, err
+		}
+		elapsed := time.Since(sent)
+
+		// Reconstruct the time from the reply data
+		sec := uint64(reply[43]) | uint64(reply[42])<<8 | uint64(reply[41])<<16 | uint64(reply[40])<<24
+		frac := uint64(reply[47]) | uint64(reply[46])<<8 | uint64(reply[45])<<16 | uint64(reply[44])<<24
+
+		nanosec := sec*1e9 + (frac*1e9)>>32
+
+		t := time.Date(1900, 1, 1, 0, 0, 0, 0, time.UTC).Add(time.Duration(nanosec)).Local()
+
+		// Calculate the drift based on an assumed answer time of RRT/2
+		drifts = append(drifts, sent.Sub(t)+elapsed/2)
+	}
+	// Calculate average drif (drop two extremities to avoid outliers)
+	sort.Sort(durationSlice(drifts))
+
+	drift := time.Duration(0)
+	for i := 1; i < len(drifts)-1; i++ {
+		drift += drifts[i]
+	}
+	return drift / time.Duration(measurements), nil
+}


### PR DESCRIPTION
**Please discuss this PR, don't simply review. I'd like to know your opinions + how to do this properly if we go down this path. The current code is a POC, not necessarily ready for merge.**

This is a short term solution to the time sync problem. It connects to the official `ntp.org` servers and polls them 3 times to measure the current time drift. If it's larger than 10 seconds, it displays a warning to the user. No time modification is done, just a warning message.

Longer term we need a more sophisticated solution, but that's not so trivial due to potentially introducing replay attacks on the discovery protocol allowing bad peers to try and divert traffic from good ones.

In sync:

```
I0215 20:31:25.704154 cmd/geth/main.go:522] measured time drift: 13.443277ms
```

Clock in the past:

```
I0215 20:29:07.088299 cmd/geth/main.go:522] measured time drift: 1m10.177685159s


Warning: Your machine's clock seems to be set incorrectly.
Measured time drift from atomic servers is 1m10.177685159s.
Please enable automatic clock synchronization.
```

Clock in the future:

```
I0215 20:31:35.889457 cmd/geth/main.go:522] measured time drift: -44.518441216s


Warning: Your machine's clock seems to be set incorrectly.
Measured time drift from atomic servers is -44.518441216s.
Please enable automatic clock synchronization.
```