### PR TITLE
crypto: expose key decryption method to parse a string direclty

### DIFF
--- a/crypto/key_store_passphrase_test.go
+++ b/crypto/key_store_passphrase_test.go
@@ -1,0 +1,51 @@
+// Copyright 2016 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+package crypto
+
+import (
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+)
+
+// Tests that a json key file can be decrypted and encrypted in multiple rounds.
+func TestKeyEncryptDecrypt(t *testing.T) {
+	address := common.HexToAddress("f626acac23772cbe04dd578bee681b06bdefb9fa")
+	keyjson := []byte("{\"address\":\"f626acac23772cbe04dd578bee681b06bdefb9fa\",\"crypto\":{\"cipher\":\"aes-128-ctr\",\"ciphertext\":\"1bcf0ab9b14459795ce59f63e63255ffd84dc38d31614a5a78e37144d7e4a17f\",\"cipherparams\":{\"iv\":\"df4c7e225ee2d81adef522013e3fbe24\"},\"kdf\":\"scrypt\",\"kdfparams\":{\"dklen\":32,\"n\":262144,\"p\":1,\"r\":8,\"salt\":\"2909a99dd2bfa7079a4b40991773b1083f8512c0c55b9b63402ab0e3dc8db8b3\"},\"mac\":\"4ecf6a4ad92ae2c016cb7c44abade74799480c3303eb024661270dfefdbc7510\"},\"id\":\"b4718210-9a30-4883-b8a6-dbdd08bd0ceb\",\"version\":3}")
+	password := ""
+
+	// Do a few rounds of decryption and encryption
+	for i := 0; i < 3; i++ {
+		// Try a bad password first
+		if _, err := DecryptKey(keyjson, password+"bad"); err == nil {
+			t.Error("test %d: json key decrypted with bad password", i)
+		}
+		// Decrypt with the correct password
+		key, err := DecryptKey(keyjson, password)
+		if err != nil {
+			t.Errorf("test %d: json key failed to decrypt: %v", i, err)
+		}
+		if key.Address != address {
+			t.Errorf("test %d: key address mismatch: have %x, want %x", i, key.Address, address)
+		}
+		// Recrypt with a new password and start over
+		password += "new data appended"
+		if keyjson, err = EncryptKey(key, password, LightScryptN, LightScryptP); err != nil {
+			t.Errorf("test %d: failed to recrypt key %v", err)
+		}
+	}
+}

--- a/crypto/key_store_plain.go
+++ b/crypto/key_store_plain.go
@@ -62,18 +62,16 @@ func GenerateNewKeyDefault(ks KeyStore, rand io.Reader, auth string) (key *Key, 
 	return key, err
 }
 
-func (ks keyStorePlain) GetKey(keyAddr common.Address, auth string) (key *Key, err error) {
-	key = new(Key)
-	err = getKey(ks.keysDirPath, keyAddr, key)
-	return
-}
-
-func getKey(keysDirPath string, keyAddr common.Address, content interface{}) (err error) {
-	fileContent, err := getKeyFile(keysDirPath, keyAddr)
+func (ks keyStorePlain) GetKey(keyAddr common.Address, auth string) (*Key, error) {
+	keyjson, err := getKeyFile(ks.keysDirPath, keyAddr)
 	if err != nil {
-		return
+		return nil, err
 	}
-	return json.Unmarshal(fileContent, content)
+	key := new(Key)
+	if err := json.Unmarshal(keyjson, key); err != nil {
+		return nil, err
+	}
+	return key, nil
 }
 
 func (ks keyStorePlain) GetKeyAddresses() (addresses []common.Address, err error) {


### PR DESCRIPTION
Currently our keystore is extremely locked down functionality wise, which make it very very brittle to use. The main limitation is that key parsing and decryption is hidden away as private internals, and wrapped around with methods that only operate on flat files, and even those files need to be named very explicitly.

The issue this causes is that given a key with an unknown file name, it's impossible to import it into the current keystore, because I simply cannot request the store to parse a string content, without needing to flush it out into a file first. But flushing to a file is not enough, as the file name needs to conform to the store spec, notable to contain the address. But to get the address, I need to interpret the contents. And the circle closes up.

This PR splits this unfortunate API design up a bit, adding an extra API endpoint that can simply parse and decrypt a key given its contents, without it needing to be in the store already. This allows geth specific keys to be imported from external sources, something not possible currently.

---

Two follow up commits add:

 - Key file content validation to ensure noone tampered with it (i.e. it really contains the said key)
 - Expose a key encryption API that flattens a key into a json string, without dumping it to disk too

---

Edit: It also works around an issue where key decryption did three disk reads to pull in the key instead of reusing the key content data after the first read.