### PR TITLE
balancer: implemented generic load balancer

### DIFF
--- a/balancer/balancer.go
+++ b/balancer/balancer.go
@@ -107,10 +107,10 @@ func (b *Balancer) Push(work Task) {
 func (b *Balancer) balance(work chan Task) {
 	for {
 		select {
-		case task := <-work: // get task
-			b.dispatch(task) // dispatch the tasks
 		case w := <-b.done: // worker is done
 			b.completed(w) // handle worker
+		case task := <-work: // get task
+			b.dispatch(task) // dispatch the tasks
 		}
 	}
 }

--- a/balancer/balancer.go
+++ b/balancer/balancer.go
@@ -1,0 +1,139 @@
+package balancer
+
+import "container/heap"
+
+// Task repsents a single batch of work offered to a worker.
+type Task struct {
+	fn func() error // work function
+	c  chan error   // return channel
+}
+
+// NewTask returns a new task and sets the proper fields.
+func NewTask(fn func() error, c chan error) Task {
+	return Task{
+		fn: fn,
+		c:  c,
+	}
+}
+
+// Worker is a worker that will take one it's assigned tasks
+// and execute it
+type Worker struct {
+	id      int       // worker id
+	tasks   chan Task // tasks to do (buffered)
+	pending int       // count of pending work
+	index   int       // index in the heap
+}
+
+// work will take the oldest task and execute the function and
+// yield the result back in to the return error channel.
+func (w *Worker) work(done chan *Worker) {
+	for {
+		task := <-w.tasks   // get task...
+		task.c <- task.fn() // ...execute the task
+		done <- w           // we're done
+	}
+}
+
+// Pool is a pool of workers and implements containers.Heap
+type Pool []*Worker
+
+func (p Pool) Len() int           { return len(p) }
+func (p Pool) Less(i, j int) bool { return p[i].pending < p[j].pending }
+func (p Pool) Swap(i, j int)      { p[i], p[j] = p[j], p[i] }
+func (p *Pool) Push(x interface{}) {
+	w := x.(*Worker)  // cast the worker
+	w.index = len(*p) // assign the new index
+
+	*p = append(*p, x.(*Worker))
+}
+
+func (p *Pool) Pop() interface{} {
+	old := *p
+	n := len(old)
+	x := old[n-1]
+	*p = old[0 : n-1]
+	return x
+}
+
+// Balancer is responsible for balancing any given tasks
+// to the pool of workers. The workers are managed by the
+// balancer and will try to make sure that the workers are
+// equally balanced in "work to complete".
+type Balancer struct {
+	pool Pool
+	done chan *Worker
+
+	work chan Task
+}
+
+// New returns a new load balancer
+func New(poolSize int) *Balancer {
+	balancer := &Balancer{
+		done: make(chan *Worker),
+		pool: make(Pool, poolSize),
+		work: make(chan Task),
+	}
+
+	operations := make(chan struct{}, poolSize)
+	defer close(operations)
+
+	// fill the pool with the given pool size
+	for i := 0; i < poolSize; i++ {
+		// create new worker
+		balancer.pool[i] = &Worker{id: i, tasks: make(chan Task, 10)}
+		// spawn worker process
+		go func(i int) {
+			operations <- struct{}{}
+			balancer.pool[i].work(balancer.done)
+		}(i)
+	}
+	// spawn own balancer task
+	go balancer.balance(balancer.work)
+
+	// wait for workers to be operations
+	for i := 0; i < poolSize; i++ {
+		<-operations
+	}
+
+	return balancer
+}
+
+// Push pushes the given tasks in to the work channel.
+func (b *Balancer) Push(work Task) {
+	go func() { b.work <- work }()
+}
+
+func (b *Balancer) balance(work chan Task) {
+	for {
+		select {
+		case task := <-work: // get task
+			b.dispatch(task) // dispatch the tasks
+		case w := <-b.done: // worker is done
+			b.completed(w) // handle worker
+		}
+	}
+}
+
+// dispatch dispatches the tasks to the least loaded worker.
+func (b *Balancer) dispatch(task Task) {
+	// Take least loaded worker
+	w := heap.Pop(&b.pool).(*Worker)
+	// send it a task
+	w.tasks <- task
+	// add to its queue
+	w.pending++
+	// put it back in the heap
+	heap.Push(&b.pool, w)
+}
+
+// completed handles the worker and puts it back in the pool
+// based on it's load.
+func (b *Balancer) completed(w *Worker) {
+	// reduce one task
+	w.pending--
+	// remove it from the heap
+	heap.Remove(&b.pool, w.index)
+	// put it back in place
+	heap.Push(&b.pool, w)
+}

--- a/balancer/balancer.go
+++ b/balancer/balancer.go
@@ -105,14 +105,18 @@ func (b *Balancer) Push(work Task) {
 }
 
 func (b *Balancer) balance(work chan Task) {
-	for {
-		select {
-		case w := <-b.done: // worker is done
+	go func() {
+		// worker is done
+		for w := range b.done {
 			b.completed(w) // handle worker
-		case task := <-work: // get task
+		}
+	}()
+	go func() {
+		// get task
+		for task := range work {
 			b.dispatch(task) // dispatch the tasks
 		}
-	}
+	}()
 }
 
 // dispatch dispatches the tasks to the least loaded worker.

--- a/balancer/balancer_test.go
+++ b/balancer/balancer_test.go
@@ -1,0 +1,86 @@
+package balancer
+
+import (
+	"math/big"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/crypto"
+)
+
+func makeTxs(size int, b *testing.B) []types.Transactions {
+	key, _ := crypto.GenerateKey()
+
+	batches := make([]types.Transactions, b.N)
+	for i := 0; i < b.N; i++ {
+		txs := make(types.Transactions, size)
+		for j := range txs {
+			var err error
+			txs[j], err = types.NewTransaction(0, common.Address{}, new(big.Int), new(big.Int), new(big.Int), nil).SignECDSA(key)
+			if err != nil {
+				b.Fatal(err)
+			}
+		}
+		batches[i] = txs
+	}
+	return batches
+}
+
+const benchTxSize = 1024
+
+func BenchmarkTxsRaw(b *testing.B) {
+	batches := makeTxs(benchTxSize, b)
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		txs := batches[i]
+		b.StartTimer()
+
+		for _, tx := range txs {
+			if _, err := tx.From(); err != nil {
+				b.Fatal(err)
+			}
+		}
+	}
+}
+
+func BenchmarkTxsLoadBalancer(b *testing.B) {
+	balancer := New(4)
+	batches := makeTxs(benchTxSize, b)
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		txs := batches[i]
+
+		var (
+			size      = 8
+			batchsize = len(txs) / size
+			ch        = make(chan error, size)
+		)
+
+		for j := 0; j < size; j++ {
+			j := j
+			task := Task{
+				fn: func() error {
+					for _, tx := range txs[j*size : j*size+batchsize] {
+						if _, err := tx.From(); err != nil {
+							return err
+						}
+					}
+					return nil
+				},
+				c: ch,
+			}
+
+			balancer.Push(task)
+		}
+
+		for j := 0; j < size; j++ {
+			if err := <-ch; err != nil {
+				b.Error(err)
+			}
+		}
+		close(ch)
+	}
+}

--- a/core/block_validator.go
+++ b/core/block_validator.go
@@ -175,7 +175,7 @@ func (v *BlockValidator) VerifyUncles(block, parent *types.Block) error {
 			return UncleError("uncle[%d](%x)'s parent is not ancestor (%x)", i, hash[:4], uncle.ParentHash[0:4])
 		}
 
-		if err := ValidateHeader(v.Pow, uncle, ancestors[uncle.ParentHash].Header(), true, true); err != nil {
+		if err := ValidateHeader(v.Pow, uncle, ancestors[uncle.ParentHash].Header(), false, true); err != nil {
 			return ValidationError(fmt.Sprintf("uncle[%d](%x) header invalid: %v", i, hash[:4], err))
 		}
 	}

--- a/core/block_work.go
+++ b/core/block_work.go
@@ -13,7 +13,7 @@ type nonceResult struct {
 	valid bool
 }
 
-func balanceBlockWork(b *balancer.Balancer, blocks []*types.Block, checker pow.PoW) (chan nonceResult, chan struct{}) {
+func balanceBlockWork(b *balancer.Balancer, blocks []*types.Block, checker pow.PoW) chan nonceResult {
 	const workSize = 64
 
 	var (
@@ -36,16 +36,14 @@ func balanceBlockWork(b *balancer.Balancer, blocks []*types.Block, checker pow.P
 		b.Push(task)
 	}
 
-	donech := make(chan struct{})
 	// we aren't at all interested in the errors
 	// since we handle errors ourself.
 	go func() {
-		<-donech // wait for parent proc to finish
 		for i := 0; i < cap(errch); i++ {
 			<-errch
 		}
 		close(errch)
 	}()
 
-	return nonceResults, donech
+	return nonceResults
 }

--- a/core/block_work.go
+++ b/core/block_work.go
@@ -2,6 +2,7 @@ package core
 
 import (
 	"math"
+	"runtime"
 
 	"github.com/ethereum/go-ethereum/balancer"
 	"github.com/ethereum/go-ethereum/core/types"
@@ -18,7 +19,7 @@ func balanceTxWork(b *balancer.Balancer, txs types.Transactions) {
 		return
 	}
 
-	workSize := len(txs) / 4
+	workSize := len(txs) / runtime.GOMAXPROCS(0)
 
 	errch := make(chan error, int(math.Ceil(float64(len(txs))/float64(workSize)))) // error channel (buffered)
 	for i := 0; i < len(txs); i += workSize {
@@ -48,7 +49,7 @@ func balanceTxWork(b *balancer.Balancer, txs types.Transactions) {
 }
 
 func balanceBlockWork(b *balancer.Balancer, blocks []*types.Block, checker pow.PoW) chan nonceResult {
-	workSize := len(blocks) / 4
+	workSize := len(blocks) / runtime.GOMAXPROCS(0)
 
 	var (
 		nonceResults = make(chan nonceResult, len(blocks))                                      // the nonce result channel (buffered)

--- a/core/block_work.go
+++ b/core/block_work.go
@@ -1,0 +1,51 @@
+package core
+
+import (
+	"math"
+
+	"github.com/ethereum/go-ethereum/balancer"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/pow"
+)
+
+type nonceResult struct {
+	index int
+	valid bool
+}
+
+func balanceBlockWork(b *balancer.Balancer, blocks []*types.Block, checker pow.PoW) (chan nonceResult, chan struct{}) {
+	const workSize = 64
+
+	var (
+		nonceResults = make(chan nonceResult, len(blocks))                                      // the nonce result channel (buffered)
+		errch        = make(chan error, int(math.Ceil(float64(len(blocks))/float64(workSize)))) // error channel (buffered)
+	)
+	for i := 0; i < len(blocks); i += workSize {
+		max := int(math.Min(float64(i+workSize), float64(len(blocks)))) // get max size...
+		batch := blocks[i:max]                                          // ...and create batch
+
+		batchNo := i // batch number for task
+		// create new tasks
+		task := balancer.NewTask(func() error {
+			for i := 0; i < max-batchNo; i++ {
+				nonceResults <- nonceResult{batchNo + i, checker.Verify(batch[i])}
+			}
+			return nil
+		}, errch)
+
+		b.Push(task)
+	}
+
+	donech := make(chan struct{})
+	// we aren't at all interested in the errors
+	// since we handle errors ourself.
+	go func() {
+		<-donech // wait for parent proc to finish
+		for i := 0; i < cap(errch); i++ {
+			<-errch
+		}
+		close(errch)
+	}()
+
+	return nonceResults, donech
+}

--- a/core/block_work.go
+++ b/core/block_work.go
@@ -13,8 +13,42 @@ type nonceResult struct {
 	valid bool
 }
 
+func balanceTxWork(b *balancer.Balancer, txs types.Transactions) {
+	if len(txs) == 0 {
+		return
+	}
+
+	workSize := len(txs) / 4
+
+	errch := make(chan error, int(math.Ceil(float64(len(txs))/float64(workSize)))) // error channel (buffered)
+	for i := 0; i < len(txs); i += workSize {
+		max := int(math.Min(float64(i+workSize), float64(len(txs)))) // get max size...
+		batch := txs[i:max]                                          // ...and create batch
+
+		batchNo := i // batch number for task
+		// create new tasks
+		task := balancer.NewTask(func() error {
+			for i := 0; i < max-batchNo; i++ {
+				batch[i].FromFrontier()
+			}
+			return nil
+		}, errch)
+
+		b.Push(task)
+	}
+
+	// we aren't at all interested in the errors
+	// since we handle errors ourself.
+	go func() {
+		for i := 0; i < cap(errch); i++ {
+			<-errch
+		}
+		close(errch)
+	}()
+}
+
 func balanceBlockWork(b *balancer.Balancer, blocks []*types.Block, checker pow.PoW) chan nonceResult {
-	const workSize = 64
+	workSize := len(blocks) / 4
 
 	var (
 		nonceResults = make(chan nonceResult, len(blocks))                                      // the nonce result channel (buffered)

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -139,7 +139,7 @@ func NewBlockChain(chainDb ethdb.Database, pow pow.PoW, mux *event.TypeMux) (*Bl
 		blockCache:   blockCache,
 		futureBlocks: futureBlocks,
 		pow:          pow,
-		balancer:     balancer.New(runtime.GOMAXPROCS(0)),
+		balancer:     balancer.B,
 	}
 	// Seed a fast but crypto originating random generator
 	seed, err := crand.Int(crand.Reader, big.NewInt(math.MaxInt64))
@@ -1122,17 +1122,9 @@ func (self *BlockChain) InsertChain(chain types.Blocks) (int, error) {
 		tstart        = time.Now()
 
 		nonceChecked = make([]bool, len(chain))
-		txs          types.Transactions
 	)
-	for _, block := range chain {
-		txs = append(txs, block.Transactions()...)
-	}
-	balanceTxWork(self.balancer, txs)
-
 	// Start the parallel nonce verifier.
-	//nonceAbort, nonceResults := verifyNoncesFromBlocks(self.pow, chain)
-	//defer close(nonceAbort)
-	nonceResults := balanceBlockWork(self.balancer, chain, self.pow) // ...balance out work
+	nonceResults := BalanceBlockWork(self.balancer, chain, self.pow)
 
 	txcount := 0
 	for i, block := range chain {

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -1122,7 +1122,12 @@ func (self *BlockChain) InsertChain(chain types.Blocks) (int, error) {
 		tstart        = time.Now()
 
 		nonceChecked = make([]bool, len(chain))
+		txs          types.Transactions
 	)
+	for _, block := range chain {
+		txs = append(txs, block.Transactions()...)
+	}
+	balanceTxWork(self.balancer, txs)
 
 	// Start the parallel nonce verifier.
 	//nonceAbort, nonceResults := verifyNoncesFromBlocks(self.pow, chain)

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -1127,8 +1127,7 @@ func (self *BlockChain) InsertChain(chain types.Blocks) (int, error) {
 	// Start the parallel nonce verifier.
 	//nonceAbort, nonceResults := verifyNoncesFromBlocks(self.pow, chain)
 	//defer close(nonceAbort)
-	nonceResults, donech := balanceBlockWork(self.balancer, chain, self.pow) // ...balance out work
-	defer close(donech)
+	nonceResults := balanceBlockWork(self.balancer, chain, self.pow) // ...balance out work
 
 	txcount := 0
 	for i, block := range chain {

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -139,7 +139,7 @@ func NewBlockChain(chainDb ethdb.Database, pow pow.PoW, mux *event.TypeMux) (*Bl
 		blockCache:   blockCache,
 		futureBlocks: futureBlocks,
 		pow:          pow,
-		balancer:     balancer.New(runtime.NumCPU()),
+		balancer:     balancer.New(runtime.GOMAXPROCS(0)),
 	}
 	// Seed a fast but crypto originating random generator
 	seed, err := crand.Int(crand.Reader, big.NewInt(math.MaxInt64))


### PR DESCRIPTION
Balancer is a generic approach to load balancing given any type of
tasks. Tasks are packages that do 1. perform an expensive tasks and
2. yield a good/bad result (i.e. an error).

When tasks are given to the balancer the balancer will selects one of the
least loaded workers and passes on the work and adds it to its work
queue.

The load balancer can be used in all sorts of places and should
generally help with optimisations in places where parallel processing is
useful. The following tasks could be paralellised:

* The transaction pool's validation process whenever it's given a bunch
  of transactions.
* Block & uncle pow verification
* Transaction sender public key derivation

Some benchmarking results using `1024` transactions:

```
$ go test -run=- -bench . -benchtime 3s

PASS
BenchmarkTxsRaw-4         	      20	 206045816 ns/op
BenchmarkTxsLoadBalancer-4	     200	  28098305 ns/op
ok  	github.com/ethereum/go-ethereum/balancer	52.242s
```