### PR TITLE
Enable vendoring supported by Go 1.6 while still using Godep

### DIFF
--- a/vendor
+++ b/vendor
@@ -1,0 +1,1 @@
+Godeps/_workspace/src


### PR DESCRIPTION
A symlink just does the trick while still relying on Godep to handle the
vendored code. Now you can compile geth with just:

	$ go build ./cmd/geth