### PR TITLE
Changes blockchain storage location to AppData Local.

### DIFF
--- a/common/path.go
+++ b/common/path.go
@@ -88,7 +88,7 @@ func DefaultDataDir() string {
 	if runtime.GOOS == "darwin" {
 		return filepath.Join(usr.HomeDir, "Library", "Ethereum")
 	} else if runtime.GOOS == "windows" {
-		return filepath.Join(usr.HomeDir, "AppData", "Roaming", "Ethereum")
+		return filepath.Join(usr.HomeDir, "AppData", "Local", "Ethereum")
 	} else {
 		return filepath.Join(usr.HomeDir, ".ethereum")
 	}


### PR DESCRIPTION
Fixes #2237.

Note: This will likely not be backwards compatible.  A more complete change would be to check at startup for the blockchain in `AppData/Roaming` and if found migrate it to `AppData/Local`.  If nothing is found then just use `AppData/Local`.