### PR TITLE
eth/downloader: bump the download queue size to prevent starvation

### DIFF
--- a/eth/downloader/downloader_test.go
+++ b/eth/downloader/downloader_test.go
@@ -43,6 +43,11 @@ var (
 	genesis     = core.GenesisBlockForTesting(testdb, testAddress, big.NewInt(1000000000))
 )
 
+// Reduce the block cache limit, otherwise the tests will be very heavy.
+func init() {
+	blockCacheLimit = 1024
+}
+
 // makeChain creates a chain of n blocks starting at and including parent.
 // the returned hash chain is ordered head->parent. In addition, every 3rd block
 // contains a transaction and every 5th an uncle to allow testing correct block

--- a/eth/downloader/queue.go
+++ b/eth/downloader/queue.go
@@ -39,7 +39,7 @@ import (
 )
 
 var (
-	blockCacheLimit   = 1024 // Maximum number of blocks to cache before throttling the download
+	blockCacheLimit   = 8192 // Maximum number of blocks to cache before throttling the download
 	maxInFlightStates = 4096 // Maximum number of state downloads to allow concurrently
 )
 


### PR DESCRIPTION
Bumps the number of data elements than can be queue up for processing. This should significantly reduce sync times when import is fast but there are a few shitty peers, as in those cases slow downloading can proceed even when blocks are being processed. Normally the downloader tunes in on fast peers, but if we have only a few peers, slow ones can still produce anomalies. This way essentially smooths out the anomalies.

Memory usage wise this does bump the cache by a factor of 8, but given that a pruned database is about 1.3GB for 1.03M blocks, one block should be around 1KB, so 8MB buffer should be completely fine.