### PR TITLE
eth/downloader: fix header download limiting

### DIFF
--- a/eth/downloader/downloader.go
+++ b/eth/downloader/downloader.go
@@ -1249,7 +1249,7 @@ func (d *Downloader) fetchHeaders(p *peer, td *big.Int, from uint64) error {
 				}
 			}
 			// Notify the content fetchers of new headers, but stop if queue is full
-			cont := d.queue.PendingBlocks() < maxQueuedHeaders || d.queue.PendingReceipts() < maxQueuedHeaders
+			cont := d.queue.PendingBlocks() < maxQueuedHeaders && d.queue.PendingReceipts() < maxQueuedHeaders
 			for _, ch := range []chan bool{d.bodyWakeCh, d.receiptWakeCh, d.stateWakeCh} {
 				if cont {
 					// We still have headers to fetch, send continuation wake signal (potential)


### PR DESCRIPTION
Fixes #2201 (OOM during sync).
With this fix mem usage is ~650MB for me.
Still way too much, but at least it doesn't explode anymore.