### PR TITLE
core, miner: add PendingStateEvent to track non-log updates.

### DIFF
--- a/core/events.go
+++ b/core/events.go
@@ -35,6 +35,9 @@ type PendingLogsEvent struct {
 	Logs vm.Logs
 }
 
+// PendingStateEvent is posted pre mining and notifies of pending state changes.
+type PendingStateEvent struct{}
+
 // NewBlockEvent is posted when a block has been imported.
 type NewBlockEvent struct{ Block *types.Block }
 

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -649,8 +649,15 @@ func (env *Work) commitTransactions(mux *event.TypeMux, transactions types.Trans
 			coalescedLogs = append(coalescedLogs, logs...)
 		}
 	}
-	if len(coalescedLogs) > 0 {
-		go mux.Post(core.PendingLogsEvent{Logs: coalescedLogs})
+	if len(coalescedLogs) > 0 || env.tcount > 0 {
+		go func(logs vm.Logs, tcount int) {
+			if len(logs) > 0 {
+				mux.Post(core.PendingLogsEvent{Logs: logs})
+			}
+			if tcount > 0 {
+				mux.Post(core.PendingStateEvent{})
+			}
+		}(coalescedLogs, env.tcount)
 	}
 }
 


### PR DESCRIPTION
We've introduced a while ago the `PendingLogsEvent`, which can be used to monitor specific contracts for live events, but often it's useful to be able to detect state changes that do not fire logs explicitly (among others these are value transfers, non-log-ed transactions, etc). This PR adds a new `PendingStateEvent` event which is fired whenever some transactions are accepted by the miner, modifying the currently pending state.