### PR TITLE
cmd/geth: removed multiline support

### DIFF
--- a/cmd/geth/js.go
+++ b/cmd/geth/js.go
@@ -119,7 +119,6 @@ func newLightweightJSRE(docRoot string, client rpc.Client, datadir string, inter
 		lr.SetCtrlCAborts(true)
 		lr.SetWordCompleter(makeCompleter(js))
 		lr.SetTabCompletionStyle(liner.TabPrints)
-		lr.SetMultiLineMode(true)
 		js.prompter = lr
 		js.atexit = func() {
 			js.withHistory(datadir, func(hist *os.File) { hist.Truncate(0); lr.WriteHistory(hist) })


### PR DESCRIPTION
When attempting to paste very long lines of text the REPL goes
completely fubar, never completing the paste. Removing the multiline
support "fixes" this.

Long lines of text are usually pasted when deploying contracts and as it
stands right now makes creating new contracts from the REPL impossible.