### PR TITLE
eth/downloader: fix premature exit before notifying all part fetchers

### DIFF
--- a/eth/downloader/downloader.go
+++ b/eth/downloader/downloader.go
@@ -1263,8 +1263,10 @@ func (d *Downloader) fetchHeaders(p *peer, td *big.Int, from uint64) error {
 					case ch <- false:
 					case <-d.cancelCh:
 					}
-					return nil
 				}
+			}
+			if !cont {
+				return nil
 			}
 			// Queue not yet full, fetch the next batch
 			from += uint64(len(headers))


### PR DESCRIPTION
The downloader had a bug where it only notifies one sub-fetcher and then exists instead of notifying all of them that header download completed (bug report courtesy of @fjl). The fix is simply to move the exit out of the notification loop and only exit afterwards. My guess is that this is an accidental leftover bug from when we introduced the additional content fetchers.