### PR TITLE
cmd/utils: lower the min accepted gas price for relay and GPO

### DIFF
--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -181,7 +181,7 @@ var (
 	GasPriceFlag = cli.StringFlag{
 		Name:  "gasprice",
 		Usage: "Minimal gas price to accept for mining a transactions",
-		Value: new(big.Int).Mul(big.NewInt(50), common.Shannon).String(),
+		Value: new(big.Int).Mul(big.NewInt(20), common.Shannon).String(),
 	}
 	ExtraDataFlag = cli.StringFlag{
 		Name:  "extradata",
@@ -350,7 +350,7 @@ var (
 	GpoMinGasPriceFlag = cli.StringFlag{
 		Name:  "gpomin",
 		Usage: "Minimum suggested gas price",
-		Value: new(big.Int).Mul(big.NewInt(50), common.Shannon).String(),
+		Value: new(big.Int).Mul(big.NewInt(20), common.Shannon).String(),
 	}
 	GpoMaxGasPriceFlag = cli.StringFlag{
 		Name:  "gpomax",


### PR DESCRIPTION
This PR lowers the minimum accepted gas price to 20 shannon and lowers the GPO min to 20 shannon.