### PR TITLE
common, all: polish a lot of hex handling code

### DIFF
--- a/cmd/geth/js_test.go
+++ b/cmd/geth/js_test.go
@@ -396,7 +396,7 @@ multiply7 = Multiply7.at(contractaddress);
 	if sol != nil && solcVersion != sol.Version() {
 		modContractInfo := versionRE.ReplaceAll(contractInfo, []byte(`"compilerVersion":"`+sol.Version()+`"`))
 		fmt.Printf("modified contractinfo:\n%s\n", modContractInfo)
-		contentHash = `"` + common.ToHex(crypto.Keccak256([]byte(modContractInfo))) + `"`
+		contentHash = `"` + common.BytesToHex(crypto.Keccak256([]byte(modContractInfo))) + `"`
 	}
 	if checkEvalJSON(t, repl, `filename = "/tmp/info.json"`, `"/tmp/info.json"`) != nil {
 		return

--- a/common/bytes_test.go
+++ b/common/bytes_test.go
@@ -83,16 +83,51 @@ func (s *BytesSuite) TestCopyBytes(c *checker.C) {
 }
 
 func (s *BytesSuite) TestIsHex(c *checker.C) {
-	data1 := "a9e67e"
-	exp1 := false
-	res1 := IsHex(data1)
-	c.Assert(res1, checker.DeepEquals, exp1)
+	tests := []struct {
+		data string
+		hex  bool
+	}{
+		// Ensure minimum length requirements pass
+		{"", false},
+		{"0", false},
+		{"00", false},
+		{"0x", false},
+		{"0x0", false},
+		{"0x00", true},
 
-	data2 := "0xa9e67e00"
-	exp2 := true
-	res2 := IsHex(data2)
-	c.Assert(res2, checker.DeepEquals, exp2)
+		// Ensure prefix is enforced
+		{"1234", false},
+		{"abcdef", false},
+		{"0_1234", false},
+		{"0_abcdef", false},
+		{"0x1234", true},
+		{"0xabcdef", true},
 
+		// Ensure even number of digits
+		{"0x333", false},
+		{"0x4444", true},
+		{"0x55555", false},
+		{"0x666666", true},
+
+		// Ensure bad digits are caught
+		{"0xhi", false},
+		{"0xhelloworld", false},
+		{"0x0x00", false},
+
+		// Ensure both lower as well as upper case are accepted
+		{"0X1234", true},
+		{"0Xabcdef", true},
+		{"0xaCcDeF", true},
+		{"0XaCcDeF", true},
+
+		// Random tests from previous suite
+		{"a9e67e", false},
+		{"0xa9e67e00", true},
+	}
+
+	for _, tt := range tests {
+		c.Assert(IsHex(tt.data), checker.DeepEquals, tt.hex)
+	}
 }
 
 func (s *BytesSuite) TestParseDataString(c *checker.C) {

--- a/common/natspec/natspec.go
+++ b/common/natspec/natspec.go
@@ -111,11 +111,12 @@ func FetchDocsForContract(contractAddress string, xeth *xeth.XEth, client *httpc
 	codehex := xeth.CodeAt(contractAddress)
 	codeb := xeth.CodeAtBytes(contractAddress)
 
-	if codehex == "0x" {
+	if codehex == "0x" || codehex == "0X" {
 		err = fmt.Errorf("contract (%v) not found", contractAddress)
 		return
 	}
 	codehash := common.BytesToHash(crypto.Keccak256(codeb))
+
 	// set up nameresolver with natspecreg + urlhint contract addresses
 	reg := registrar.New(xeth)
 

--- a/common/path.go
+++ b/common/path.go
@@ -56,11 +56,11 @@ func FileExist(filePath string) bool {
 	return true
 }
 
-func AbsolutePath(Datadir string, filename string) string {
+func AbsolutePath(datadir string, filename string) string {
 	if filepath.IsAbs(filename) {
 		return filename
 	}
-	return filepath.Join(Datadir, filename)
+	return filepath.Join(datadir, filename)
 }
 
 func HomeDir() string {

--- a/common/registrar/ethreg/api.go
+++ b/common/registrar/ethreg/api.go
@@ -183,7 +183,7 @@ func (be *registryAPIBackend) Call(fromStr, toStr, valueStr, gasStr, gasPriceStr
 	gp := new(core.GasPool).AddGas(common.MaxBig)
 	res, gas, err := core.ApplyMessage(vmenv, msg, gp)
 
-	return common.ToHex(res), gas.String(), err
+	return common.NumberToHex(res), gas.String(), err
 }
 
 // StorageAt returns the data stores in the state for the given address and location.
@@ -199,7 +199,7 @@ func (be *registryAPIBackend) StorageAt(addr string, storageAddr string) string 
 // Transact forms a transaction from the given arguments and submits it to the
 // transactio pool for execution.
 func (be *registryAPIBackend) Transact(fromStr, toStr, nonceStr, valueStr, gasStr, gasPriceStr, codeStr string) (string, error) {
-	if len(toStr) > 0 && toStr != "0x" && !common.IsHexAddress(toStr) {
+	if len(toStr) > 0 && toStr != "0x" && toStr != "0X" && !common.IsHexAddress(toStr) {
 		return "", errors.New("invalid address")
 	}
 

--- a/common/registrar/registrar.go
+++ b/common/registrar/registrar.go
@@ -18,6 +18,7 @@ package registrar
 
 import (
 	"encoding/binary"
+	"encoding/hex"
 	"fmt"
 	"math/big"
 	"regexp"
@@ -68,7 +69,7 @@ const (
 )
 
 func abiSignature(s string) string {
-	return common.ToHex(crypto.Keccak256([]byte(s))[:4])
+	return common.BytesToHex(crypto.Keccak256([]byte(s))[:4])
 }
 
 var (
@@ -282,8 +283,8 @@ func (self *Registrar) SetHashToHash(address common.Address, codehash, dochash c
 	if err != nil {
 		return
 	}
-	codehex := common.Bytes2Hex(codehash[:])
-	dochex := common.Bytes2Hex(dochash[:])
+	codehex := hex.EncodeToString(codehash[:])
+	dochex := hex.EncodeToString(dochash[:])
 
 	data := registerContentHashAbi + codehex + dochex
 	glog.V(logger.Detail).Infof("SetHashToHash data: %s sent  to %v\n", data, HashRegAddr)
@@ -305,7 +306,7 @@ func (self *Registrar) SetUrlToHash(address common.Address, hash common.Hash, ur
 		return "", fmt.Errorf("UrlHint address is not set")
 	}
 
-	hashHex := common.Bytes2Hex(hash[:])
+	hashHex := hex.EncodeToString(hash[:])
 	var urlHex string
 	urlb := []byte(url)
 	var cnt byte
@@ -315,15 +316,15 @@ func (self *Registrar) SetUrlToHash(address common.Address, hash common.Hash, ur
 		if n > 32 {
 			n = 32
 		}
-		urlHex = common.Bytes2Hex(urlb[:n])
+		urlHex = hex.EncodeToString(urlb[:n])
 		urlb = urlb[n:]
 		n = len(urlb)
 		bcnt := make([]byte, 32)
 		bcnt[31] = cnt
 		data := registerUrlAbi +
 			hashHex +
-			common.Bytes2Hex(bcnt) +
-			common.Bytes2Hex(common.Hex2BytesFixed(urlHex, 32))
+			hex.EncodeToString(bcnt) +
+			hex.EncodeToString(common.Hex2BytesFixed(urlHex, 32))
 		txh, err = self.backend.Transact(
 			address.Hex(),
 			UrlHintAddr,
@@ -420,7 +421,7 @@ func storageFixedArray(addr, idx []byte) []byte {
 }
 
 func storageAddress(addr []byte) string {
-	return common.ToHex(addr)
+	return common.BytesToHex(addr)
 }
 
 func encodeAddress(address common.Address) string {
@@ -428,7 +429,7 @@ func encodeAddress(address common.Address) string {
 }
 
 func encodeName(name string, index uint8) (string, string) {
-	extra := common.Bytes2Hex([]byte(name))
+	extra := hex.EncodeToString([]byte(name))
 	if len(name) > 32 {
 		return fmt.Sprintf("%064x", index), extra
 	}

--- a/common/registrar/registrar_test.go
+++ b/common/registrar/registrar_test.go
@@ -52,7 +52,7 @@ func (self *testBackend) initUrlHint() {
 	mapaddr := storageMapping(storageIdx2Addr(1), hash[:])
 
 	key := storageAddress(storageFixedArray(mapaddr, storageIdx2Addr(0)))
-	self.contracts[UrlHintAddr[2:]][key] = common.ToHex([]byte(url))
+	self.contracts[UrlHintAddr[2:]][key] = common.NumberToHex([]byte(url))
 	key = storageAddress(storageFixedArray(mapaddr, storageIdx2Addr(1)))
 	self.contracts[UrlHintAddr[2:]][key] = "0x0"
 }

--- a/common/types.go
+++ b/common/types.go
@@ -50,7 +50,7 @@ func HexToHash(s string) Hash    { return BytesToHash(FromHex(s)) }
 func (h Hash) Str() string   { return string(h[:]) }
 func (h Hash) Bytes() []byte { return h[:] }
 func (h Hash) Big() *big.Int { return Bytes2Big(h[:]) }
-func (h Hash) Hex() string   { return "0x" + Bytes2Hex(h[:]) }
+func (h Hash) Hex() string   { return BytesToHex(h[:]) }
 
 // UnmarshalJSON parses a hash in its hex from to a hash.
 func (h *Hash) UnmarshalJSON(input []byte) error {
@@ -110,7 +110,8 @@ func BigToAddress(b *big.Int) Address  { return BytesToAddress(b.Bytes()) }
 func HexToAddress(s string) Address    { return BytesToAddress(FromHex(s)) }
 
 // IsHexAddress verifies whether a string can represent a valid hex-encoded
-// Ethereum address or not.
+// Ethereum address or not. The accepted format is a 40 hex-character string,
+// optionally prefixed by 0x or 0X.
 func IsHexAddress(s string) bool {
 	if len(s) == 2+2*AddressLength && IsHex(s) {
 		return true
@@ -126,7 +127,7 @@ func (a Address) Str() string   { return string(a[:]) }
 func (a Address) Bytes() []byte { return a[:] }
 func (a Address) Big() *big.Int { return Bytes2Big(a[:]) }
 func (a Address) Hash() Hash    { return BytesToHash(a[:]) }
-func (a Address) Hex() string   { return "0x" + Bytes2Hex(a[:]) }
+func (a Address) Hex() string   { return BytesToHex(a[:]) }
 
 // Sets the address to the value of b. If b is larger than len(a) it will panic
 func (a *Address) SetBytes(b []byte) {
@@ -182,8 +183,7 @@ func (a *Address) UnmarshalJSON(data []byte) error {
 // 	hex(value[:4])...(hex[len(value)-4:])
 func PP(value []byte) string {
 	if len(value) <= 8 {
-		return Bytes2Hex(value)
+		return hex.EncodeToString(value)
 	}
-
 	return fmt.Sprintf("%x...%x", value[:4], value[len(value)-4])
 }

--- a/common/types_test.go
+++ b/common/types_test.go
@@ -29,3 +29,38 @@ func TestBytesConversion(t *testing.T) {
 		t.Errorf("expected %x got %x", exp, hash)
 	}
 }
+
+// Tests whether addresses are correctly matched against allowed form and data
+// content.
+func TestIsHexAddress(t *testing.T) {
+	tests := []struct {
+		address string
+		valid   bool
+	}{
+		{"", false},                                             // Empty, without optional 0x prefix
+		{"0x", false},                                           // Empty, with optional 0x prefix
+		{"00", false},                                           // Too short, without optional 0x prefix
+		{"0x00", false},                                         // Too short, with optional 0x prefix
+		{"00000000000000000000000000000000000000", false},       // Too short (even), without optional 0x prefix
+		{"0x00000000000000000000000000000000000000", false},     // Too short (even), with optional 0x prefix
+		{"000000000000000000000000000000000000000", false},      // Too short (odd), without optional 0x prefix
+		{"0x000000000000000000000000000000000000000", false},    // Too short (odd), with optional 0x prefix
+		{"0000000000000000000000000000000000000000", true},      // Valid, without optional 0x prefix
+		{"0x0000000000000000000000000000000000000000", true},    // Valid, with optional 0x prefix
+		{"0x00000000000000000000000000000000000000", false},     // Length / prefix combo invalidity
+		{"00x0000000000000000000000000000000000000", false},     // Invalid content, without optional 0x prefix
+		{"0x0x00000000000000000000000000000000000000", false},   // Invalid content, with optional 0x prefix
+		{"abcdefghijklmnopqrstuvwxyz0123456789xxxx", false},     // Invalid content, without optional 0x prefix
+		{"0xabcdefghijklmnopqrstuvwxyz0123456789xxxx", false},   // Invalid content, with optional 0x prefix
+		{"00000000000000000000000000000000000000000", false},    // Too long (odd), without optional 0x prefix
+		{"0x00000000000000000000000000000000000000000", false},  // Too long (odd), with optional 0x prefix
+		{"000000000000000000000000000000000000000000", false},   // Too long (even), without optional 0x prefix
+		{"0x000000000000000000000000000000000000000000", false}, // Too long (even), with optional 0x prefix
+	}
+
+	for i, tt := range tests {
+		if valid := IsHexAddress(tt.address); valid != tt.valid {
+			t.Errorf("test %d: address validity mismatch: have %v, want %v", i, valid, tt.valid)
+		}
+	}
+}

--- a/core/bad_block.go
+++ b/core/bad_block.go
@@ -18,11 +18,11 @@ package core
 
 import (
 	"bytes"
+	"encoding/hex"
 	"encoding/json"
 	"io/ioutil"
 	"net/http"
 
-	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/logger"
 	"github.com/ethereum/go-ethereum/logger/glog"
@@ -43,7 +43,7 @@ func ReportBlock(block *types.Block, err error) {
 
 	blockRlp, _ := rlp.EncodeToBytes(block)
 	data := map[string]interface{}{
-		"block":     common.Bytes2Hex(blockRlp),
+		"block":     hex.EncodeToString(blockRlp),
 		"errortype": err.Error(),
 		"hints": map[string]interface{}{
 			"receipts": "NYI",

--- a/core/state/dump.go
+++ b/core/state/dump.go
@@ -17,6 +17,7 @@
 package state
 
 import (
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 
@@ -39,7 +40,7 @@ type World struct {
 
 func (self *StateDB) RawDump() World {
 	world := World{
-		Root:     common.Bytes2Hex(self.trie.Root()),
+		Root:     hex.EncodeToString(self.trie.Root()),
 		Accounts: make(map[string]Account),
 	}
 
@@ -48,14 +49,14 @@ func (self *StateDB) RawDump() World {
 		addr := self.trie.GetKey(it.Key)
 		stateObject, _ := DecodeObject(common.BytesToAddress(addr), self.db, it.Value)
 
-		account := Account{Balance: stateObject.balance.String(), Nonce: stateObject.nonce, Root: common.Bytes2Hex(stateObject.Root()), CodeHash: common.Bytes2Hex(stateObject.codeHash), Code: common.Bytes2Hex(stateObject.Code())}
+		account := Account{Balance: stateObject.balance.String(), Nonce: stateObject.nonce, Root: hex.EncodeToString(stateObject.Root()), CodeHash: hex.EncodeToString(stateObject.codeHash), Code: hex.EncodeToString(stateObject.Code())}
 		account.Storage = make(map[string]string)
 
 		storageIt := stateObject.trie.Iterator()
 		for storageIt.Next() {
-			account.Storage[common.Bytes2Hex(self.trie.GetKey(storageIt.Key))] = common.Bytes2Hex(storageIt.Value)
+			account.Storage[hex.EncodeToString(self.trie.GetKey(storageIt.Key))] = hex.EncodeToString(storageIt.Value)
 		}
-		world.Accounts[common.Bytes2Hex(addr)] = account
+		world.Accounts[hex.EncodeToString(addr)] = account
 	}
 	return world
 }

--- a/core/tx_pool.go
+++ b/core/tx_pool.go
@@ -17,6 +17,7 @@
 package core
 
 import (
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"math/big"
@@ -288,14 +289,14 @@ func (self *TxPool) add(tx *types.Transaction) error {
 	if glog.V(logger.Debug) {
 		var toname string
 		if to := tx.To(); to != nil {
-			toname = common.Bytes2Hex(to[:4])
+			toname = hex.EncodeToString(to[:4])
 		} else {
 			toname = "[NEW_CONTRACT]"
 		}
 		// we can ignore the error here because From is
 		// verified in ValidateTransaction.
 		f, _ := tx.From()
-		from := common.Bytes2Hex(f[:4])
+		from := hex.EncodeToString(f[:4])
 		glog.Infof("(t) %x => %s (%v) %x\n", from, toname, tx.Value, hash)
 	}
 

--- a/eth/api.go
+++ b/eth/api.go
@@ -582,11 +582,7 @@ func (s *PublicBlockChainAPI) GetCode(address common.Address, blockNr rpc.BlockN
 	if state == nil || err != nil {
 		return "", err
 	}
-	res := state.GetCode(address)
-	if len(res) == 0 { // backwards compatibility
-		return "0x", nil
-	}
-	return common.ToHex(res), nil
+	return common.BytesToHex(state.GetCode(address)), nil
 }
 
 // GetStorageAt returns the storage from the state at the given address, key and
@@ -671,10 +667,7 @@ func (s *PublicBlockChainAPI) doCall(args CallArgs, blockNr rpc.BlockNumber) (st
 	gp := new(core.GasPool).AddGas(common.MaxBig)
 
 	res, gas, err := core.ApplyMessage(vmenv, msg, gp)
-	if len(res) == 0 { // backwards compatibility
-		return "0x", gas, err
-	}
-	return common.ToHex(res), gas, err
+	return common.BytesToHex(res), gas, err
 }
 
 // Call executes the given transaction on the state for the given block number.
@@ -1102,7 +1095,7 @@ func (s *PublicTransactionPoolAPI) SendRawTransaction(encodedTx string) (string,
 // be unlocked.
 func (s *PublicTransactionPoolAPI) Sign(address common.Address, data string) (string, error) {
 	signature, error := s.am.Sign(accounts.Account{Address: address}, common.HexToHash(data).Bytes())
-	return common.ToHex(signature), error
+	return common.BytesToHex(signature), error
 }
 
 type SignTransactionArgs struct {
@@ -1194,7 +1187,7 @@ func newTx(t *types.Transaction) *Tx {
 		From:     from,
 		Value:    rpc.NewHexNumber(t.Value()),
 		Nonce:    rpc.NewHexNumber(t.Nonce()),
-		Data:     "0x" + common.Bytes2Hex(t.Data()),
+		Data:     common.BytesToHex(t.Data()),
 		GasLimit: rpc.NewHexNumber(t.Gas()),
 		GasPrice: rpc.NewHexNumber(t.GasPrice()),
 		Hash:     t.Hash(),
@@ -1241,7 +1234,7 @@ func (s *PublicTransactionPoolAPI) SignTransaction(args *SignTransactionArgs) (*
 		return nil, err
 	}
 
-	return &SignTransactionResult{"0x" + common.Bytes2Hex(data), newTx(tx)}, nil
+	return &SignTransactionResult{common.BytesToHex(data), newTx(tx)}, nil
 }
 
 // PendingTransactions returns the transactions that are in the transaction pool and have a from address that is one of

--- a/eth/filters/api.go
+++ b/eth/filters/api.go
@@ -573,7 +573,7 @@ func newFilterId() (string, error) {
 	if n != 16 {
 		return "", errors.New("Unable to generate filter id")
 	}
-	return "0x" + hex.EncodeToString(subid[:]), nil
+	return common.BytesToHex(subid[:]), nil
 }
 
 // toRPCLogs is a helper that will convert a vm.Logs array to an structure which

--- a/logger/log.go
+++ b/logger/log.go
@@ -21,12 +21,14 @@ import (
 	"io"
 	"log"
 	"os"
-
-	"github.com/ethereum/go-ethereum/common"
+	"path/filepath"
 )
 
 func openLogFile(datadir string, filename string) *os.File {
-	path := common.AbsolutePath(datadir, filename)
+	path := filename
+	if !filepath.IsAbs(path) {
+		path = filepath.Join(datadir, filename)
+	}
 	file, err := os.OpenFile(path, os.O_RDWR|os.O_CREATE|os.O_APPEND, 0666)
 	if err != nil {
 		panic(fmt.Sprintf("error opening log file '%s': %v", filename, err))

--- a/node/api.go
+++ b/node/api.go
@@ -269,5 +269,5 @@ func (s *PublicWeb3API) ClientVersion() string {
 // Sha3 applies the ethereum sha3 implementation on the input.
 // It assumes the input is hex encoded.
 func (s *PublicWeb3API) Sha3(input string) string {
-	return common.ToHex(crypto.Keccak256(common.FromHex(input)))
+	return common.BytesToHex(crypto.Keccak256(common.FromHex(input)))
 }

--- a/rpc/types.go
+++ b/rpc/types.go
@@ -24,6 +24,7 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/event"
 	"gopkg.in/fatih/set.v0"
 )
@@ -220,11 +221,7 @@ func (h *HexNumber) UnmarshalJSON(input []byte) error {
 // MarshalJSON serialize the hex number instance to a hex representation.
 func (h *HexNumber) MarshalJSON() ([]byte, error) {
 	if h != nil {
-		hn := (*big.Int)(h)
-		if hn.BitLen() == 0 {
-			return []byte(`"0x0"`), nil
-		}
-		return []byte(fmt.Sprintf(`"0x%x"`, hn)), nil
+		return []byte(`"` + common.NumberToHex((*big.Int)(h).Bytes()) + `"`), nil
 	}
 	return nil, nil
 }

--- a/rpc/utils.go
+++ b/rpc/utils.go
@@ -18,7 +18,6 @@ package rpc
 
 import (
 	"crypto/rand"
-	"encoding/hex"
 	"errors"
 	"fmt"
 	"math/big"
@@ -26,6 +25,7 @@ import (
 	"unicode"
 	"unicode/utf8"
 
+	"github.com/ethereum/go-ethereum/common"
 	"golang.org/x/net/context"
 )
 
@@ -211,7 +211,7 @@ func newSubscriptionId() (string, error) {
 	if n != 16 {
 		return "", errors.New("Unable to generate subscription id")
 	}
-	return "0x" + hex.EncodeToString(subid[:]), nil
+	return common.BytesToHex(subid[:]), nil
 }
 
 // SupportedModules returns the collection of API's that the RPC server offers

--- a/tests/block_test_util.go
+++ b/tests/block_test_util.go
@@ -437,7 +437,7 @@ func (test *BlockTest) ValidateImportedHeaders(cm *core.BlockChain, validBlocks 
 	// all blocks have been processed by ChainManager, as they may not
 	// be part of the longest chain until last block is imported.
 	for b := cm.CurrentBlock(); b != nil && b.NumberU64() != 0; b = cm.GetBlock(b.Header().ParentHash) {
-		bHash := common.Bytes2Hex(b.Hash().Bytes()) // hex without 0x prefix
+		bHash := hex.EncodeToString(b.Hash().Bytes()) // hex without 0x prefix
 		if err := validateHeader(bmap[bHash].BlockHeader, b.Header()); err != nil {
 			return fmt.Errorf("Imported block header validation failed: %v", err)
 		}

--- a/whisper/api.go
+++ b/whisper/api.go
@@ -74,7 +74,7 @@ func (s *PublicWhisperAPI) NewIdentity() (string, error) {
 	}
 
 	identity := s.w.NewIdentity()
-	return common.ToHex(crypto.FromECDSAPub(&identity.PublicKey)), nil
+	return common.BytesToHex(crypto.FromECDSAPub(&identity.PublicKey)), nil
 }
 
 type NewFilterArgs struct {
@@ -403,11 +403,11 @@ func NewWhisperMessage(message *Message) WhisperMessage {
 	return WhisperMessage{
 		ref: message,
 
-		Payload: common.ToHex(message.Payload),
-		From:    common.ToHex(crypto.FromECDSAPub(message.Recover())),
-		To:      common.ToHex(crypto.FromECDSAPub(message.To)),
+		Payload: common.BytesToHex(message.Payload),
+		From:    common.BytesToHex(crypto.FromECDSAPub(message.Recover())),
+		To:      common.BytesToHex(crypto.FromECDSAPub(message.To)),
 		Sent:    message.Sent.Unix(),
 		TTL:     int64(message.TTL / time.Second),
-		Hash:    common.ToHex(message.Hash.Bytes()),
+		Hash:    common.BytesToHex(message.Hash.Bytes()),
 	}
 }


### PR DESCRIPTION
This PR polishes our internal APIs a bit, notably makes the `common.IsHex` check a lot stricter by actually checking individual characters too, not just a general form (length, prefix) of a string for hex validation.

This is needed because we have a few other methods (e.g. `common.IsHexAddress`) that relied on `IsHex` to seemingly validate the string contents, but in reality the validation never happened. This isn't a problem in our current code base, but it could be a failure ready to happen, especially if you build on top of the go-ethereum code.

I've also added a ton of tests that all fail on the previous version, accepting invalid hex strings.