### PR TITLE
core: homestead chain configuration & artificial gas floor target mining flag

### DIFF
--- a/accounts/abi/bind/backends/simulated.go
+++ b/accounts/abi/bind/backends/simulated.go
@@ -27,11 +27,10 @@ import (
 	"github.com/ethereum/go-ethereum/core/vm"
 	"github.com/ethereum/go-ethereum/ethdb"
 	"github.com/ethereum/go-ethereum/event"
-	"github.com/ethereum/go-ethereum/params"
 )
 
 // Default chain configuration which sets homestead phase at block 0 (i.e. no frontier)
-var chainConfig = &core.ChainConfig{HomesteadBlock: params.MainNetHomesteadBlock}
+var chainConfig = &core.ChainConfig{HomesteadBlock: big.NewInt(0)}
 
 // This nil assignment ensures compile time that SimulatedBackend implements bind.ContractBackend.
 var _ bind.ContractBackend = (*SimulatedBackend)(nil)

--- a/cmd/ethtest/main.go
+++ b/cmd/ethtest/main.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/codegangsta/cli"
 	"github.com/ethereum/go-ethereum/logger/glog"
+	"github.com/ethereum/go-ethereum/params"
 	"github.com/ethereum/go-ethereum/tests"
 )
 
@@ -73,9 +74,9 @@ func runTestWithReader(test string, r io.Reader) error {
 	var err error
 	switch strings.ToLower(test) {
 	case "bk", "block", "blocktest", "blockchaintest", "blocktests", "blockchaintests":
-		err = tests.RunBlockTestWithReader(r, skipTests)
+		err = tests.RunBlockTestWithReader(params.MainNetHomesteadBlock, r, skipTests)
 	case "st", "state", "statetest", "statetests":
-		err = tests.RunStateTestWithReader(r, skipTests)
+		err = tests.RunStateTestWithReader(tests.RuleSet{params.MainNetHomesteadBlock}, r, skipTests)
 	case "tx", "transactiontest", "transactiontests":
 		err = tests.RunTransactionTestsWithReader(r, skipTests)
 	case "vm", "vmtest", "vmtests":

--- a/cmd/geth/js_test.go
+++ b/cmd/geth/js_test.go
@@ -106,6 +106,7 @@ func testREPL(t *testing.T, config func(*eth.Config)) (string, *testjethre, *nod
 	core.WriteGenesisBlockForTesting(db, core.GenesisAccount{common.HexToAddress(testAddress), common.String2Big(testBalance)})
 
 	ethConf := &eth.Config{
+		ChainConfig:      &core.ChainConfig{HomesteadBlock: new(big.Int)},
 		TestGenesisState: db,
 		AccountManager:   accman,
 		DocRoot:          "/",

--- a/cmd/geth/usage.go
+++ b/cmd/geth/usage.go
@@ -121,6 +121,7 @@ var AppHelpFlagGroups = []flagGroup{
 		Flags: []cli.Flag{
 			utils.MiningEnabledFlag,
 			utils.MinerThreadsFlag,
+			utils.TargetGasLimitFlag,
 			utils.MiningGPUFlag,
 			utils.AutoDAGFlag,
 			utils.EtherbaseFlag,

--- a/common/debug.go
+++ b/common/debug.go
@@ -21,8 +21,10 @@ import (
 	"os"
 	"runtime"
 	"runtime/debug"
+	"strings"
 )
 
+// Report gives off a warning requesting the user to submit an issue to the github tracker.
 func Report(extra ...interface{}) {
 	fmt.Fprintln(os.Stderr, "You've encountered a sought after, hard to reproduce bug. Please report this to the developers <3 https://github.com/ethereum/go-ethereum/issues")
 	fmt.Fprintln(os.Stderr, extra...)
@@ -33,4 +35,18 @@ func Report(extra ...interface{}) {
 	debug.PrintStack()
 
 	fmt.Fprintln(os.Stderr, "#### BUG! PLEASE REPORT ####")
+}
+
+// PrintDepricationWarning prinst the given string in a box using fmt.Println.
+func PrintDepricationWarning(str string) {
+	line := strings.Repeat("#", len(str)+4)
+	emptyLine := strings.Repeat(" ", len(str))
+	fmt.Printf(`
+%s
+# %s #
+# %s #
+# %s #
+%s
+
+`, line, emptyLine, str, emptyLine, line)
 }

--- a/core/bench_test.go
+++ b/core/bench_test.go
@@ -168,7 +168,7 @@ func benchInsertChain(b *testing.B, disk bool, gen func(int, *BlockGen)) {
 	// Time the insertion of the new chain.
 	// State and blocks are stored in the same DB.
 	evmux := new(event.TypeMux)
-	chainman, _ := NewBlockChain(db, FakePow{}, evmux)
+	chainman, _ := NewBlockChain(db, &ChainConfig{HomesteadBlock: new(big.Int)}, FakePow{}, evmux)
 	defer chainman.Stop()
 	b.ReportAllocs()
 	b.ResetTimer()

--- a/core/block_validator.go
+++ b/core/block_validator.go
@@ -41,15 +41,17 @@ var (
 //
 // BlockValidator implements Validator.
 type BlockValidator struct {
-	bc  *BlockChain // Canonical block chain
-	Pow pow.PoW     // Proof of work used for validating
+	config *ChainConfig // Chain configuration options
+	bc     *BlockChain  // Canonical block chain
+	Pow    pow.PoW      // Proof of work used for validating
 }
 
 // NewBlockValidator returns a new block validator which is safe for re-use
-func NewBlockValidator(blockchain *BlockChain, pow pow.PoW) *BlockValidator {
+func NewBlockValidator(config *ChainConfig, blockchain *BlockChain, pow pow.PoW) *BlockValidator {
 	validator := &BlockValidator{
-		Pow: pow,
-		bc:  blockchain,
+		config: config,
+		Pow:    pow,
+		bc:     blockchain,
 	}
 	return validator
 }
@@ -80,7 +82,7 @@ func (v *BlockValidator) ValidateBlock(block *types.Block) error {
 
 	header := block.Header()
 	// validate the block header
-	if err := ValidateHeader(v.Pow, header, parent.Header(), false, false); err != nil {
+	if err := ValidateHeader(v.config, v.Pow, header, parent.Header(), false, false); err != nil {
 		return err
 	}
 	// verify the uncles are correctly rewarded
@@ -175,7 +177,7 @@ func (v *BlockValidator) VerifyUncles(block, parent *types.Block) error {
 			return UncleError("uncle[%d](%x)'s parent is not ancestor (%x)", i, hash[:4], uncle.ParentHash[0:4])
 		}
 
-		if err := ValidateHeader(v.Pow, uncle, ancestors[uncle.ParentHash].Header(), true, true); err != nil {
+		if err := ValidateHeader(v.config, v.Pow, uncle, ancestors[uncle.ParentHash].Header(), true, true); err != nil {
 			return ValidationError(fmt.Sprintf("uncle[%d](%x) header invalid: %v", i, hash[:4], err))
 		}
 	}
@@ -195,13 +197,13 @@ func (v *BlockValidator) ValidateHeader(header, parent *types.Header, checkPow b
 	if v.bc.HasHeader(header.Hash()) {
 		return nil
 	}
-	return ValidateHeader(v.Pow, header, parent, checkPow, false)
+	return ValidateHeader(v.config, v.Pow, header, parent, checkPow, false)
 }
 
 // Validates a header. Returns an error if the header is invalid.
 //
 // See YP section 4.3.4. "Block Header Validity"
-func ValidateHeader(pow pow.PoW, header *types.Header, parent *types.Header, checkPow, uncle bool) error {
+func ValidateHeader(config *ChainConfig, pow pow.PoW, header *types.Header, parent *types.Header, checkPow, uncle bool) error {
 	if big.NewInt(int64(len(header.Extra))).Cmp(params.MaximumExtraDataSize) == 1 {
 		return fmt.Errorf("Header extra data too long (%d)", len(header.Extra))
 	}
@@ -219,7 +221,7 @@ func ValidateHeader(pow pow.PoW, header *types.Header, parent *types.Header, che
 		return BlockEqualTSErr
 	}
 
-	expd := CalcDifficulty(header.Time.Uint64(), parent.Time.Uint64(), parent.Number, parent.Difficulty)
+	expd := CalcDifficulty(config, header.Time.Uint64(), parent.Time.Uint64(), parent.Number, parent.Difficulty)
 	if expd.Cmp(header.Difficulty) != 0 {
 		return fmt.Errorf("Difficulty check failed for header %v, %v", header.Difficulty, expd)
 	}
@@ -251,8 +253,8 @@ func ValidateHeader(pow pow.PoW, header *types.Header, parent *types.Header, che
 // CalcDifficulty is the difficulty adjustment algorithm. It returns
 // the difficulty that a new block should have when created at time
 // given the parent block's time and difficulty.
-func CalcDifficulty(time, parentTime uint64, parentNumber, parentDiff *big.Int) *big.Int {
-	if params.IsHomestead(new(big.Int).Add(parentNumber, common.Big1)) {
+func CalcDifficulty(config *ChainConfig, time, parentTime uint64, parentNumber, parentDiff *big.Int) *big.Int {
+	if config.IsHomestead(new(big.Int).Add(parentNumber, common.Big1)) {
 		return calcDifficultyHomestead(time, parentTime, parentNumber, parentDiff)
 	} else {
 		return calcDifficultyFrontier(time, parentTime, parentNumber, parentDiff)
@@ -363,11 +365,11 @@ func CalcGasLimit(parent *types.Block) *big.Int {
 	gl = gl.Add(gl, contrib)
 	gl.Set(common.BigMax(gl, params.MinGasLimit))
 
-	// however, if we're now below the target (GenesisGasLimit) we increase the
+	// however, if we're now below the target (TargetGasLimit) we increase the
 	// limit as much as we can (parentGasLimit / 1024 -1)
-	if gl.Cmp(params.GenesisGasLimit) < 0 {
+	if gl.Cmp(params.TargetGasLimit) < 0 {
 		gl.Add(parent.GasLimit(), decay)
-		gl.Set(common.BigMin(gl, params.GenesisGasLimit))
+		gl.Set(common.BigMin(gl, params.TargetGasLimit))
 	}
 	return gl
 }

--- a/core/block_validator_test.go
+++ b/core/block_validator_test.go
@@ -27,15 +27,20 @@ import (
 	"github.com/ethereum/go-ethereum/core/vm"
 	"github.com/ethereum/go-ethereum/ethdb"
 	"github.com/ethereum/go-ethereum/event"
+	"github.com/ethereum/go-ethereum/params"
 	"github.com/ethereum/go-ethereum/pow/ezp"
 )
+
+func testChainConfig() *ChainConfig {
+	return &ChainConfig{HomesteadBlock: params.MainNetHomesteadBlock}
+}
 
 func proc() (Validator, *BlockChain) {
 	db, _ := ethdb.NewMemDatabase()
 	var mux event.TypeMux
 
 	WriteTestNetGenesisBlock(db)
-	blockchain, err := NewBlockChain(db, thePow(), &mux)
+	blockchain, err := NewBlockChain(db, testChainConfig(), thePow(), &mux)
 	if err != nil {
 		fmt.Println(err)
 	}
@@ -49,13 +54,14 @@ func TestNumber(t *testing.T) {
 	statedb, _ := state.New(chain.Genesis().Root(), chain.chainDb)
 	header := makeHeader(chain.Genesis(), statedb)
 	header.Number = big.NewInt(3)
-	err := ValidateHeader(pow, header, chain.Genesis().Header(), false, false)
+	cfg := testChainConfig()
+	err := ValidateHeader(cfg, pow, header, chain.Genesis().Header(), false, false)
 	if err != BlockNumberErr {
 		t.Errorf("expected block number error, got %q", err)
 	}
 
 	header = makeHeader(chain.Genesis(), statedb)
-	err = ValidateHeader(pow, header, chain.Genesis().Header(), false, false)
+	err = ValidateHeader(cfg, pow, header, chain.Genesis().Header(), false, false)
 	if err == BlockNumberErr {
 		t.Errorf("didn't expect block number error")
 	}

--- a/core/block_validator_test.go
+++ b/core/block_validator_test.go
@@ -27,12 +27,11 @@ import (
 	"github.com/ethereum/go-ethereum/core/vm"
 	"github.com/ethereum/go-ethereum/ethdb"
 	"github.com/ethereum/go-ethereum/event"
-	"github.com/ethereum/go-ethereum/params"
 	"github.com/ethereum/go-ethereum/pow/ezp"
 )
 
 func testChainConfig() *ChainConfig {
-	return &ChainConfig{HomesteadBlock: params.MainNetHomesteadBlock}
+	return &ChainConfig{HomesteadBlock: big.NewInt(0)}
 }
 
 func proc() (Validator, *BlockChain) {

--- a/core/blockchain_test.go
+++ b/core/blockchain_test.go
@@ -1025,23 +1025,21 @@ func TestReorgSideEvent(t *testing.T) {
 	evmux := &event.TypeMux{}
 	blockchain, _ := NewBlockChain(db, testChainConfig(), FakePow{}, evmux)
 
-	chain, _ := GenerateChain(genesis, db, 3, func(i int, gen *BlockGen) {
-		if i == 2 {
-			gen.OffsetTime(9)
-		}
-	})
+	chain, _ := GenerateChain(genesis, db, 3, func(i int, gen *BlockGen) {})
 	if _, err := blockchain.InsertChain(chain); err != nil {
 		t.Fatalf("failed to insert chain: %v", err)
 	}
 
 	replacementBlocks, _ := GenerateChain(genesis, db, 4, func(i int, gen *BlockGen) {
 		tx, err := types.NewContractCreation(gen.TxNonce(addr1), new(big.Int), big.NewInt(1000000), new(big.Int), nil).SignECDSA(key1)
+		if i == 2 {
+			gen.OffsetTime(-1)
+		}
 		if err != nil {
 			t.Fatalf("failed to create tx: %v", err)
 		}
 		gen.AddTx(tx)
 	})
-
 	subs := evmux.Subscribe(ChainSideEvent{})
 	if _, err := blockchain.InsertChain(replacementBlocks); err != nil {
 		t.Fatalf("failed to insert chain: %v", err)

--- a/core/blockchain_test.go
+++ b/core/blockchain_test.go
@@ -53,7 +53,7 @@ func thePow() pow.PoW {
 func theBlockChain(db ethdb.Database, t *testing.T) *BlockChain {
 	var eventMux event.TypeMux
 	WriteTestNetGenesisBlock(db)
-	blockchain, err := NewBlockChain(db, thePow(), &eventMux)
+	blockchain, err := NewBlockChain(db, testChainConfig(), thePow(), &eventMux)
 	if err != nil {
 		t.Error("failed creating blockchain:", err)
 		t.FailNow()
@@ -141,7 +141,7 @@ func testBlockChainImport(chain types.Blocks, blockchain *BlockChain) error {
 		if err != nil {
 			return err
 		}
-		receipts, _, usedGas, err := blockchain.Processor().Process(block, statedb, nil)
+		receipts, _, usedGas, err := blockchain.Processor().Process(block, statedb, vm.Config{})
 		if err != nil {
 			reportBlock(block, err)
 			return err
@@ -435,7 +435,7 @@ func (bproc) ValidateHeader(*types.Header, *types.Header, bool) error { return n
 func (bproc) ValidateState(block, parent *types.Block, state *state.StateDB, receipts types.Receipts, usedGas *big.Int) error {
 	return nil
 }
-func (bproc) Process(block *types.Block, statedb *state.StateDB, cfg *vm.Config) (types.Receipts, vm.Logs, *big.Int, error) {
+func (bproc) Process(block *types.Block, statedb *state.StateDB, cfg vm.Config) (types.Receipts, vm.Logs, *big.Int, error) {
 	return nil, nil, nil, nil
 }
 
@@ -473,13 +473,14 @@ func makeBlockChainWithDiff(genesis *types.Block, d []int, seed byte) []*types.B
 func chm(genesis *types.Block, db ethdb.Database) *BlockChain {
 	var eventMux event.TypeMux
 	bc := &BlockChain{
-		chainDb: db,
+		chainDb:      db,
 		genesisBlock: genesis,
-		eventMux: &eventMux,
-		pow: FakePow{},
+		eventMux:     &eventMux,
+		pow:          FakePow{},
+		config:       testChainConfig(),
 	}
 	valFn := func() HeaderValidator { return bc.Validator() }
-	bc.hc, _ = NewHeaderChain(db, valFn, bc.getProcInterrupt)
+	bc.hc, _ = NewHeaderChain(db, testChainConfig(), valFn, bc.getProcInterrupt)
 	bc.bodyCache, _ = lru.New(100)
 	bc.bodyRLPCache, _ = lru.New(100)
 	bc.blockCache, _ = lru.New(100)
@@ -613,7 +614,7 @@ func testReorgBadHashes(t *testing.T, full bool) {
 		defer func() { delete(BadHashes, headers[3].Hash()) }()
 	}
 	// Create a new chain manager and check it rolled back the state
-	ncm, err := NewBlockChain(db, FakePow{}, new(event.TypeMux))
+	ncm, err := NewBlockChain(db, testChainConfig(), FakePow{}, new(event.TypeMux))
 	if err != nil {
 		t.Fatalf("failed to create new chain manager: %v", err)
 	}
@@ -667,7 +668,7 @@ func testInsertNonceError(t *testing.T, full bool) {
 			failHash = headers[failAt].Hash()
 
 			blockchain.pow = failPow{failNum}
-			blockchain.validator = NewBlockValidator(blockchain, failPow{failNum})
+			blockchain.validator = NewBlockValidator(testChainConfig(), blockchain, failPow{failNum})
 
 			failRes, err = blockchain.InsertHeaderChain(headers, 1)
 		}
@@ -733,7 +734,7 @@ func TestFastVsFullChains(t *testing.T) {
 	archiveDb, _ := ethdb.NewMemDatabase()
 	WriteGenesisBlockForTesting(archiveDb, GenesisAccount{address, funds})
 
-	archive, _ := NewBlockChain(archiveDb, FakePow{}, new(event.TypeMux))
+	archive, _ := NewBlockChain(archiveDb, testChainConfig(), FakePow{}, new(event.TypeMux))
 
 	if n, err := archive.InsertChain(blocks); err != nil {
 		t.Fatalf("failed to process block %d: %v", n, err)
@@ -741,7 +742,7 @@ func TestFastVsFullChains(t *testing.T) {
 	// Fast import the chain as a non-archive node to test
 	fastDb, _ := ethdb.NewMemDatabase()
 	WriteGenesisBlockForTesting(fastDb, GenesisAccount{address, funds})
-	fast, _ := NewBlockChain(fastDb, FakePow{}, new(event.TypeMux))
+	fast, _ := NewBlockChain(fastDb, testChainConfig(), FakePow{}, new(event.TypeMux))
 
 	headers := make([]*types.Header, len(blocks))
 	for i, block := range blocks {
@@ -817,7 +818,7 @@ func TestLightVsFastVsFullChainHeads(t *testing.T) {
 	archiveDb, _ := ethdb.NewMemDatabase()
 	WriteGenesisBlockForTesting(archiveDb, GenesisAccount{address, funds})
 
-	archive, _ := NewBlockChain(archiveDb, FakePow{}, new(event.TypeMux))
+	archive, _ := NewBlockChain(archiveDb, testChainConfig(), FakePow{}, new(event.TypeMux))
 
 	if n, err := archive.InsertChain(blocks); err != nil {
 		t.Fatalf("failed to process block %d: %v", n, err)
@@ -829,7 +830,7 @@ func TestLightVsFastVsFullChainHeads(t *testing.T) {
 	// Import the chain as a non-archive node and ensure all pointers are updated
 	fastDb, _ := ethdb.NewMemDatabase()
 	WriteGenesisBlockForTesting(fastDb, GenesisAccount{address, funds})
-	fast, _ := NewBlockChain(fastDb, FakePow{}, new(event.TypeMux))
+	fast, _ := NewBlockChain(fastDb, testChainConfig(), FakePow{}, new(event.TypeMux))
 
 	headers := make([]*types.Header, len(blocks))
 	for i, block := range blocks {
@@ -848,7 +849,7 @@ func TestLightVsFastVsFullChainHeads(t *testing.T) {
 	// Import the chain as a light node and ensure all pointers are updated
 	lightDb, _ := ethdb.NewMemDatabase()
 	WriteGenesisBlockForTesting(lightDb, GenesisAccount{address, funds})
-	light, _ := NewBlockChain(lightDb, FakePow{}, new(event.TypeMux))
+	light, _ := NewBlockChain(lightDb, testChainConfig(), FakePow{}, new(event.TypeMux))
 
 	if n, err := light.InsertHeaderChain(headers, 1); err != nil {
 		t.Fatalf("failed to insert header %d: %v", n, err)
@@ -913,7 +914,7 @@ func TestChainTxReorgs(t *testing.T) {
 	})
 	// Import the chain. This runs all block validation rules.
 	evmux := &event.TypeMux{}
-	blockchain, _ := NewBlockChain(db, FakePow{}, evmux)
+	blockchain, _ := NewBlockChain(db, testChainConfig(), FakePow{}, evmux)
 	if i, err := blockchain.InsertChain(chain); err != nil {
 		t.Fatalf("failed to insert original chain[%d]: %v", i, err)
 	}
@@ -986,7 +987,7 @@ func TestLogReorgs(t *testing.T) {
 	)
 
 	evmux := &event.TypeMux{}
-	blockchain, _ := NewBlockChain(db, FakePow{}, evmux)
+	blockchain, _ := NewBlockChain(db, testChainConfig(), FakePow{}, evmux)
 
 	subs := evmux.Subscribe(RemovedLogsEvent{})
 	chain, _ := GenerateChain(genesis, db, 2, func(i int, gen *BlockGen) {
@@ -1022,7 +1023,7 @@ func TestReorgSideEvent(t *testing.T) {
 	)
 
 	evmux := &event.TypeMux{}
-	blockchain, _ := NewBlockChain(db, FakePow{}, evmux)
+	blockchain, _ := NewBlockChain(db, testChainConfig(), FakePow{}, evmux)
 
 	chain, _ := GenerateChain(genesis, db, 3, func(i int, gen *BlockGen) {
 		if i == 2 {

--- a/core/chain_makers.go
+++ b/core/chain_makers.go
@@ -26,7 +26,6 @@ import (
 	"github.com/ethereum/go-ethereum/core/vm"
 	"github.com/ethereum/go-ethereum/ethdb"
 	"github.com/ethereum/go-ethereum/event"
-	"github.com/ethereum/go-ethereum/params"
 	"github.com/ethereum/go-ethereum/pow"
 )
 
@@ -35,16 +34,8 @@ import (
  */
 
 // MakeChainConfig returns a new ChainConfig with the ethereum default chain settings.
-func MakeChainConfig(testnet bool) *ChainConfig {
-	homesteadBlock := params.MainNetHomesteadBlock
-	// set a different default homestead block for the testnet
-	if testnet {
-		homesteadBlock = params.TestNetHomesteadBlock
-	}
-
-	return &ChainConfig{
-		HomesteadBlock: homesteadBlock,
-	}
+func MakeChainConfig() *ChainConfig {
+	return &ChainConfig{HomesteadBlock: big.NewInt(0)}
 }
 
 // FakePow is a non-validating proof of work implementation.
@@ -110,7 +101,7 @@ func (b *BlockGen) AddTx(tx *types.Transaction) {
 		b.SetCoinbase(common.Address{})
 	}
 	b.statedb.StartRecord(tx.Hash(), common.Hash{}, len(b.txs))
-	receipt, _, _, err := ApplyTransaction(MakeChainConfig(true), nil, b.gasPool, b.statedb, b.header, tx, b.header.GasUsed, vm.Config{})
+	receipt, _, _, err := ApplyTransaction(MakeChainConfig(), nil, b.gasPool, b.statedb, b.header, tx, b.header.GasUsed, vm.Config{})
 	if err != nil {
 		panic(err)
 	}
@@ -167,7 +158,7 @@ func (b *BlockGen) OffsetTime(seconds int64) {
 	if b.header.Time.Cmp(b.parent.Header().Time) <= 0 {
 		panic("block time out of range")
 	}
-	b.header.Difficulty = CalcDifficulty(MakeChainConfig(true), b.header.Time.Uint64(), b.parent.Time().Uint64(), b.parent.Number(), b.parent.Difficulty())
+	b.header.Difficulty = CalcDifficulty(MakeChainConfig(), b.header.Time.Uint64(), b.parent.Time().Uint64(), b.parent.Number(), b.parent.Difficulty())
 }
 
 // GenerateChain creates a chain of n blocks. The first block's
@@ -222,7 +213,7 @@ func makeHeader(parent *types.Block, state *state.StateDB) *types.Header {
 		Root:       state.IntermediateRoot(),
 		ParentHash: parent.Hash(),
 		Coinbase:   parent.Coinbase(),
-		Difficulty: CalcDifficulty(MakeChainConfig(true), time.Uint64(), new(big.Int).Sub(time, big.NewInt(10)).Uint64(), parent.Number(), parent.Difficulty()),
+		Difficulty: CalcDifficulty(MakeChainConfig(), time.Uint64(), new(big.Int).Sub(time, big.NewInt(10)).Uint64(), parent.Number(), parent.Difficulty()),
 		GasLimit:   CalcGasLimit(parent),
 		GasUsed:    new(big.Int),
 		Number:     new(big.Int).Add(parent.Number(), common.Big1),
@@ -241,7 +232,7 @@ func newCanonical(n int, full bool) (ethdb.Database, *BlockChain, error) {
 	// Initialize a fresh chain with only a genesis block
 	genesis, _ := WriteTestNetGenesisBlock(db)
 
-	blockchain, _ := NewBlockChain(db, MakeChainConfig(false), FakePow{}, evmux)
+	blockchain, _ := NewBlockChain(db, MakeChainConfig(), FakePow{}, evmux)
 	// Create and inject the requested chain
 	if n == 0 {
 		return db, blockchain, nil

--- a/core/chain_makers.go
+++ b/core/chain_makers.go
@@ -23,10 +23,29 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/state"
 	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/core/vm"
 	"github.com/ethereum/go-ethereum/ethdb"
 	"github.com/ethereum/go-ethereum/event"
+	"github.com/ethereum/go-ethereum/params"
 	"github.com/ethereum/go-ethereum/pow"
 )
+
+/*
+ * TODO: move this to another package.
+ */
+
+// MakeChainConfig returns a new ChainConfig with the ethereum default chain settings.
+func MakeChainConfig(testnet bool) *ChainConfig {
+	homesteadBlock := params.MainNetHomesteadBlock
+	// set a different default homestead block for the testnet
+	if testnet {
+		homesteadBlock = params.TestNetHomesteadBlock
+	}
+
+	return &ChainConfig{
+		HomesteadBlock: homesteadBlock,
+	}
+}
 
 // FakePow is a non-validating proof of work implementation.
 // It returns true from Verify for any block.
@@ -91,7 +110,7 @@ func (b *BlockGen) AddTx(tx *types.Transaction) {
 		b.SetCoinbase(common.Address{})
 	}
 	b.statedb.StartRecord(tx.Hash(), common.Hash{}, len(b.txs))
-	receipt, _, _, err := ApplyTransaction(nil, b.gasPool, b.statedb, b.header, tx, b.header.GasUsed, nil)
+	receipt, _, _, err := ApplyTransaction(MakeChainConfig(true), nil, b.gasPool, b.statedb, b.header, tx, b.header.GasUsed, vm.Config{})
 	if err != nil {
 		panic(err)
 	}
@@ -148,7 +167,7 @@ func (b *BlockGen) OffsetTime(seconds int64) {
 	if b.header.Time.Cmp(b.parent.Header().Time) <= 0 {
 		panic("block time out of range")
 	}
-	b.header.Difficulty = CalcDifficulty(b.header.Time.Uint64(), b.parent.Time().Uint64(), b.parent.Number(), b.parent.Difficulty())
+	b.header.Difficulty = CalcDifficulty(MakeChainConfig(true), b.header.Time.Uint64(), b.parent.Time().Uint64(), b.parent.Number(), b.parent.Difficulty())
 }
 
 // GenerateChain creates a chain of n blocks. The first block's
@@ -203,7 +222,7 @@ func makeHeader(parent *types.Block, state *state.StateDB) *types.Header {
 		Root:       state.IntermediateRoot(),
 		ParentHash: parent.Hash(),
 		Coinbase:   parent.Coinbase(),
-		Difficulty: CalcDifficulty(time.Uint64(), new(big.Int).Sub(time, big.NewInt(10)).Uint64(), parent.Number(), parent.Difficulty()),
+		Difficulty: CalcDifficulty(MakeChainConfig(true), time.Uint64(), new(big.Int).Sub(time, big.NewInt(10)).Uint64(), parent.Number(), parent.Difficulty()),
 		GasLimit:   CalcGasLimit(parent),
 		GasUsed:    new(big.Int),
 		Number:     new(big.Int).Add(parent.Number(), common.Big1),
@@ -222,7 +241,7 @@ func newCanonical(n int, full bool) (ethdb.Database, *BlockChain, error) {
 	// Initialize a fresh chain with only a genesis block
 	genesis, _ := WriteTestNetGenesisBlock(db)
 
-	blockchain, _ := NewBlockChain(db, FakePow{}, evmux)
+	blockchain, _ := NewBlockChain(db, MakeChainConfig(false), FakePow{}, evmux)
 	// Create and inject the requested chain
 	if n == 0 {
 		return db, blockchain, nil

--- a/core/chain_makers_test.go
+++ b/core/chain_makers_test.go
@@ -77,7 +77,7 @@ func ExampleGenerateChain() {
 
 	// Import the chain. This runs all block validation rules.
 	evmux := &event.TypeMux{}
-	blockchain, _ := NewBlockChain(db, MakeChainConfig(true), FakePow{}, evmux)
+	blockchain, _ := NewBlockChain(db, MakeChainConfig(), FakePow{}, evmux)
 	if i, err := blockchain.InsertChain(chain); err != nil {
 		fmt.Printf("insert error (block %d): %v\n", i, err)
 		return

--- a/core/chain_makers_test.go
+++ b/core/chain_makers_test.go
@@ -77,7 +77,7 @@ func ExampleGenerateChain() {
 
 	// Import the chain. This runs all block validation rules.
 	evmux := &event.TypeMux{}
-	blockchain, _ := NewBlockChain(db, FakePow{}, evmux)
+	blockchain, _ := NewBlockChain(db, MakeChainConfig(true), FakePow{}, evmux)
 	if i, err := blockchain.InsertChain(chain); err != nil {
 		fmt.Printf("insert error (block %d): %v\n", i, err)
 		return

--- a/core/config.go
+++ b/core/config.go
@@ -1,0 +1,46 @@
+// Copyright 2016 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+package core
+
+import (
+	"errors"
+	"math/big"
+
+	"github.com/ethereum/go-ethereum/core/vm"
+)
+
+var ChainConfigNotFoundErr = errors.New("ChainConfig not found") // general config not found error
+
+// ChainConfig is the core config which determines the blockchain settings.
+//
+// ChainConfig is stored in the database on a per block basis. This means
+// that any network, identified by its genesis block, can have its own
+// set of configuration options.
+type ChainConfig struct {
+	HomesteadBlock *big.Int // homestead switch block
+
+	VmConfig vm.Config `json:"-"`
+}
+
+// IsHomestead returns whether num is either equal to the homestead block or greater.
+func (c *ChainConfig) IsHomestead(num *big.Int) bool {
+	if num == nil {
+		return false
+	}
+
+	return num.Cmp(c.HomesteadBlock) >= 0
+}

--- a/core/database_util.go
+++ b/core/database_util.go
@@ -19,6 +19,7 @@ package core
 import (
 	"bytes"
 	"encoding/binary"
+	"encoding/json"
 	"fmt"
 	"math/big"
 
@@ -50,6 +51,8 @@ var (
 	MIPMapLevels = []uint64{1000000, 500000, 100000, 50000, 1000}
 
 	blockHashPrefix = []byte("block-hash-") // [deprecated by the header/block split, remove eventually]
+
+	configPrefix = []byte("ethereum-config-") // config prefix for the db
 )
 
 // GetCanonicalHash retrieves a hash assigned to a canonical block number.
@@ -526,4 +529,35 @@ func GetBlockChainVersion(db ethdb.Database) int {
 func WriteBlockChainVersion(db ethdb.Database, vsn int) {
 	enc, _ := rlp.EncodeToBytes(uint(vsn))
 	db.Put([]byte("BlockchainVersion"), enc)
+}
+
+// WriteChainConfig writes the chain config settings to the database.
+func WriteChainConfig(db ethdb.Database, hash common.Hash, cfg *ChainConfig) error {
+	// short circuit and ignore if nil config. GetChainConfig
+	// will return a default.
+	if cfg == nil {
+		return nil
+	}
+
+	jsonChainConfig, err := json.Marshal(cfg)
+	if err != nil {
+		return err
+	}
+
+	return db.Put(append(configPrefix, hash[:]...), jsonChainConfig)
+}
+
+// GetChainConfig will fetch the network settings based on the given hash.
+func GetChainConfig(db ethdb.Database, hash common.Hash) (*ChainConfig, error) {
+	jsonChainConfig, _ := db.Get(append(configPrefix, hash[:]...))
+	if len(jsonChainConfig) == 0 {
+		return nil, ChainConfigNotFoundErr
+	}
+
+	var config ChainConfig
+	if err := json.Unmarshal(jsonChainConfig, &config); err != nil {
+		return nil, err
+	}
+
+	return &config, nil
 }

--- a/core/execution.go
+++ b/core/execution.go
@@ -126,7 +126,7 @@ func exec(env vm.Environment, caller vm.ContractRef, address, codeAddr *common.A
 	// When an error was returned by the EVM or when setting the creation code
 	// above we revert to the snapshot and consume any gas remaining. Additionally
 	// when we're in homestead this also counts for code storage gas errors.
-	if err != nil && (params.IsHomestead(env.BlockNumber()) || err != vm.CodeStoreOutOfGasError) {
+	if err != nil && (env.RuleSet().IsHomestead(env.BlockNumber()) || err != vm.CodeStoreOutOfGasError) {
 		contract.UseGas(contract.Gas)
 
 		env.SetSnapshot(snapshotPreTransfer)

--- a/core/genesis.go
+++ b/core/genesis.go
@@ -43,15 +43,16 @@ func WriteGenesisBlock(chainDb ethdb.Database, reader io.Reader) (*types.Block, 
 	}
 
 	var genesis struct {
-		Nonce      string
-		Timestamp  string
-		ParentHash string
-		ExtraData  string
-		GasLimit   string
-		Difficulty string
-		Mixhash    string
-		Coinbase   string
-		Alloc      map[string]struct {
+		ChainConfig *ChainConfig
+		Nonce       string
+		Timestamp   string
+		ParentHash  string
+		ExtraData   string
+		GasLimit    string
+		Difficulty  string
+		Mixhash     string
+		Coinbase    string
+		Alloc       map[string]struct {
 			Code    string
 			Storage map[string]string
 			Balance string
@@ -114,6 +115,10 @@ func WriteGenesisBlock(chainDb ethdb.Database, reader io.Reader) (*types.Block, 
 	if err := WriteHeadBlockHash(chainDb, block.Hash()); err != nil {
 		return nil, err
 	}
+	if err := WriteChainConfig(chainDb, block.Hash(), genesis.ChainConfig); err != nil {
+		return nil, err
+	}
+
 	return block, nil
 }
 

--- a/core/state_transition.go
+++ b/core/state_transition.go
@@ -104,8 +104,9 @@ func IntrinsicGas(data []byte, contractCreation, homestead bool) *big.Int {
 	return igas
 }
 
-func ApplyMessage(env vm.Environment, msg Message, gp *GasPool) ([]byte, *big.Int, error) {
-	var st = StateTransition{
+// NewStateTransition initialises and returns a new state transition object.
+func NewStateTransition(env vm.Environment, msg Message, gp *GasPool) *StateTransition {
+	return &StateTransition{
 		gp:         gp,
 		env:        env,
 		msg:        msg,
@@ -116,7 +117,20 @@ func ApplyMessage(env vm.Environment, msg Message, gp *GasPool) ([]byte, *big.In
 		data:       msg.Data(),
 		state:      env.Db(),
 	}
-	return st.transitionDb()
+}
+
+// ApplyMessage computes the new state by applying the given message
+// against the old state within the environment.
+//
+// ApplyMessage returns the bytes returned by any EVM execution (if it took place),
+// the gas used (which includes gas refunds) and an error if it failed. An error always
+// indicates a core error meaning that the message would always fail for that particular
+// state and would never be accepted within a block.
+func ApplyMessage(env vm.Environment, msg Message, gp *GasPool) ([]byte, *big.Int, error) {
+	st := NewStateTransition(env, msg, gp)
+
+	ret, _, gasUsed, err := st.TransitionDb()
+	return ret, gasUsed, err
 }
 
 func (self *StateTransition) from() (vm.Account, error) {
@@ -209,7 +223,8 @@ func (self *StateTransition) preCheck() (err error) {
 	return nil
 }
 
-func (self *StateTransition) transitionDb() (ret []byte, usedGas *big.Int, err error) {
+// TransitionDb will move the state by applying the message against the given environment.
+func (self *StateTransition) TransitionDb() (ret []byte, requiredGas, usedGas *big.Int, err error) {
 	if err = self.preCheck(); err != nil {
 		return
 	}
@@ -220,7 +235,7 @@ func (self *StateTransition) transitionDb() (ret []byte, usedGas *big.Int, err e
 	contractCreation := MessageCreatesContract(msg)
 	// Pay intrinsic gas
 	if err = self.useGas(IntrinsicGas(self.data, contractCreation, homestead)); err != nil {
-		return nil, nil, InvalidTxError(err)
+		return nil, nil, nil, InvalidTxError(err)
 	}
 
 	vmenv := self.env
@@ -245,7 +260,7 @@ func (self *StateTransition) transitionDb() (ret []byte, usedGas *big.Int, err e
 	}
 
 	if err != nil && IsValueTransferErr(err) {
-		return nil, nil, InvalidTxError(err)
+		return nil, nil, nil, InvalidTxError(err)
 	}
 
 	// We aren't interested in errors here. Errors returned by the VM are non-consensus errors and therefor shouldn't bubble up
@@ -253,10 +268,12 @@ func (self *StateTransition) transitionDb() (ret []byte, usedGas *big.Int, err e
 		err = nil
 	}
 
+	requiredGas = new(big.Int).Set(self.gasUsed())
+
 	self.refundGas()
 	self.state.AddBalance(self.env.Coinbase(), new(big.Int).Mul(self.gasUsed(), self.gasPrice))
 
-	return ret, self.gasUsed(), err
+	return ret, requiredGas, self.gasUsed(), err
 }
 
 func (self *StateTransition) refundGas() {

--- a/core/state_transition.go
+++ b/core/state_transition.go
@@ -124,7 +124,7 @@ func (self *StateTransition) from() (vm.Account, error) {
 		f   common.Address
 		err error
 	)
-	if params.IsHomestead(self.env.BlockNumber()) {
+	if self.env.RuleSet().IsHomestead(self.env.BlockNumber()) {
 		f, err = self.msg.From()
 	} else {
 		f, err = self.msg.FromFrontier()
@@ -216,7 +216,7 @@ func (self *StateTransition) transitionDb() (ret []byte, usedGas *big.Int, err e
 	msg := self.msg
 	sender, _ := self.from() // err checked in preCheck
 
-	homestead := params.IsHomestead(self.env.BlockNumber())
+	homestead := self.env.RuleSet().IsHomestead(self.env.BlockNumber())
 	contractCreation := MessageCreatesContract(msg)
 	// Pay intrinsic gas
 	if err = self.useGas(IntrinsicGas(self.data, contractCreation, homestead)); err != nil {

--- a/core/tx_pool_test.go
+++ b/core/tx_pool_test.go
@@ -40,7 +40,7 @@ func setupTxPool() (*TxPool, *ecdsa.PrivateKey) {
 
 	var m event.TypeMux
 	key, _ := crypto.GenerateKey()
-	newPool := NewTxPool(&m, func() (*state.StateDB, error) { return statedb, nil }, func() *big.Int { return big.NewInt(1000000) })
+	newPool := NewTxPool(testChainConfig(), &m, func() (*state.StateDB, error) { return statedb, nil }, func() *big.Int { return big.NewInt(1000000) })
 	newPool.resetState()
 	return newPool, key
 }

--- a/core/types.go
+++ b/core/types.go
@@ -61,7 +61,7 @@ type HeaderValidator interface {
 // of gas used in the process and return an error if any of the internal rules
 // failed.
 type Processor interface {
-	Process(block *types.Block, statedb *state.StateDB, cfg *vm.Config) (types.Receipts, vm.Logs, *big.Int, error)
+	Process(block *types.Block, statedb *state.StateDB, cfg vm.Config) (types.Receipts, vm.Logs, *big.Int, error)
 }
 
 // Backend is an interface defining the basic functionality for an operable node

--- a/core/vm/environment.go
+++ b/core/vm/environment.go
@@ -22,9 +22,17 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 )
 
+// RuleSet is an interface that defines the current rule set during the
+// execution of the EVM instructions (e.g. whether it's homestead)
+type RuleSet interface {
+	IsHomestead(*big.Int) bool
+}
+
 // Environment is an EVM requirement and helper which allows access to outside
 // information such as states.
 type Environment interface {
+	// The current ruleset
+	RuleSet() RuleSet
 	// The state database
 	Db() Database
 	// Creates a restorable snapshot
@@ -53,10 +61,10 @@ type Environment interface {
 	AddLog(*Log)
 	// Type of the VM
 	Vm() Vm
-	// Current calling depth
+	// Get the curret calling depth
 	Depth() int
+	// Set the current calling depth
 	SetDepth(i int)
-
 	// Call another contract
 	Call(me ContractRef, addr common.Address, data []byte, gas, price, value *big.Int) ([]byte, error)
 	// Take another's contract code and execute within our own context

--- a/core/vm/instructions.go
+++ b/core/vm/instructions.go
@@ -520,7 +520,7 @@ func opCreate(instr instruction, pc *uint64, env Environment, contract *Contract
 	// homestead we must check for CodeStoreOutOfGasError (homestead only
 	// rule) and treat as an error, if the ruleset is frontier we must
 	// ignore this error and pretend the operation was successful.
-	if params.IsHomestead(env.BlockNumber()) && suberr == CodeStoreOutOfGasError {
+	if env.RuleSet().IsHomestead(env.BlockNumber()) && suberr == CodeStoreOutOfGasError {
 		stack.push(new(big.Int))
 	} else if suberr != nil && suberr != CodeStoreOutOfGasError {
 		stack.push(new(big.Int))

--- a/core/vm/jit.go
+++ b/core/vm/jit.go
@@ -30,27 +30,24 @@ import (
 	"github.com/hashicorp/golang-lru"
 )
 
+// progStatus is the type for the JIT program status.
 type progStatus int32
 
 const (
-	progUnknown progStatus = iota
-	progCompile
-	progReady
-	progError
+	progUnknown progStatus = iota // unknown status
+	progCompile                   // compile status
+	progReady                     // ready for use status
+	progError                     // error status (usually caused during compilation)
 
-	defaultJitMaxCache int = 64
+	defaultJitMaxCache int = 64 // maximum amount of jit cached programs
 )
 
-var (
-	EnableJit   bool // Enables the JIT VM
-	ForceJit    bool // Force the JIT, skip byte VM
-	MaxProgSize int  // Max cache size for JIT Programs
-)
+var MaxProgSize int // Max cache size for JIT programs
 
-var programs *lru.Cache
+var programs *lru.Cache // lru cache for the JIT programs.
 
 func init() {
-	programs, _ = lru.New(defaultJitMaxCache)
+	SetJITCacheSize(defaultJitMaxCache)
 }
 
 // SetJITCacheSize recreates the program cache with the max given size. Setting
@@ -322,7 +319,7 @@ func runProgram(program *Program, pcstart uint64, mem *Memory, stack *stack, env
 		}()
 	}
 
-	homestead := params.IsHomestead(env.BlockNumber())
+	homestead := env.RuleSet().IsHomestead(env.BlockNumber())
 	for pc < uint64(len(program.instructions)) {
 		instrCount++
 

--- a/core/vm/jit_test.go
+++ b/core/vm/jit_test.go
@@ -84,7 +84,7 @@ func TestCompiling(t *testing.T) {
 func TestResetInput(t *testing.T) {
 	var sender account
 
-	env := NewEnv()
+	env := NewEnv(false, true)
 	contract := NewContract(sender, sender, big.NewInt(100), big.NewInt(10000), big.NewInt(0))
 	contract.CodeAddr = &common.Address{}
 
@@ -143,10 +143,7 @@ func runVmBench(test vmBench, b *testing.B) {
 	if test.precompile && !test.forcejit {
 		NewProgram(test.code)
 	}
-	env := NewEnv()
-
-	EnableJit = !test.nojit
-	ForceJit = test.forcejit
+	env := NewEnv(test.nojit, test.forcejit)
 
 	b.ResetTimer()
 
@@ -168,12 +165,16 @@ type Env struct {
 	evm      *EVM
 }
 
-func NewEnv() *Env {
+func NewEnv(noJit, forceJit bool) *Env {
 	env := &Env{gasLimit: big.NewInt(10000), depth: 0}
-	env.evm = New(env, nil)
+	env.evm = New(env, Config{
+		EnableJit: !noJit,
+		ForceJit:  forceJit,
+	})
 	return env
 }
 
+func (self *Env) RuleSet() RuleSet       { return ruleSet{new(big.Int)} }
 func (self *Env) Vm() Vm                 { return self.evm }
 func (self *Env) Origin() common.Address { return common.Address{} }
 func (self *Env) BlockNumber() *big.Int  { return big.NewInt(0) }

--- a/core/vm/jump_table.go
+++ b/core/vm/jump_table.go
@@ -1,10 +1,6 @@
 package vm
 
-import (
-	"math/big"
-
-	"github.com/ethereum/go-ethereum/params"
-)
+import "math/big"
 
 type jumpPtr struct {
 	fn    instrFn
@@ -13,12 +9,12 @@ type jumpPtr struct {
 
 type vmJumpTable [256]jumpPtr
 
-func newJumpTable(blockNumber *big.Int) vmJumpTable {
+func newJumpTable(ruleset RuleSet, blockNumber *big.Int) vmJumpTable {
 	var jumpTable vmJumpTable
 
 	// when initialising a new VM execution we must first check the homestead
 	// changes.
-	if params.IsHomestead(blockNumber) {
+	if ruleset.IsHomestead(blockNumber) {
 		jumpTable[DELEGATECALL] = jumpPtr{opDelegateCall, true}
 	}
 

--- a/core/vm/jump_table_test.go
+++ b/core/vm/jump_table_test.go
@@ -3,20 +3,16 @@ package vm
 import (
 	"math/big"
 	"testing"
-
-	"github.com/ethereum/go-ethereum/params"
 )
 
 func TestInit(t *testing.T) {
-	params.HomesteadBlock = big.NewInt(1)
-
-	jumpTable := newJumpTable(big.NewInt(0))
+	jumpTable := newJumpTable(ruleSet{big.NewInt(1)}, big.NewInt(0))
 	if jumpTable[DELEGATECALL].valid {
 		t.Error("Expected DELEGATECALL not to be present")
 	}
 
 	for _, n := range []int64{1, 2, 100} {
-		jumpTable := newJumpTable(big.NewInt(n))
+		jumpTable := newJumpTable(ruleSet{big.NewInt(1)}, big.NewInt(n))
 		if !jumpTable[DELEGATECALL].valid {
 			t.Error("Expected DELEGATECALL to be present for block", n)
 		}

--- a/core/vm/logger.go
+++ b/core/vm/logger.go
@@ -89,7 +89,7 @@ func newLogger(cfg LogConfig, env Environment) *Logger {
 // captureState logs a new structured log message and pushes it out to the environment
 //
 // captureState also tracks SSTORE ops to track dirty values.
-func (l *Logger) captureState(pc uint64, op OpCode, gas, cost *big.Int, memory *Memory, stack *stack, contract *Contract, err error) {
+func (l *Logger) captureState(pc uint64, op OpCode, gas, cost *big.Int, memory *Memory, stack *stack, contract *Contract, depth int, err error) {
 	// short circuit if no log collector is present
 	if l.cfg.Collector == nil {
 		return

--- a/core/vm/logger_test.go
+++ b/core/vm/logger_test.go
@@ -47,7 +47,7 @@ type dummyEnv struct {
 
 func newDummyEnv(ref *dummyContractRef) *dummyEnv {
 	return &dummyEnv{
-		Env: NewEnv(),
+		Env: NewEnv(true, false),
 		ref: ref,
 	}
 }
@@ -58,7 +58,7 @@ func (d dummyEnv) AddStructLog(StructLog) {}
 
 func TestStoreCapture(t *testing.T) {
 	var (
-		env      = NewEnv()
+		env      = NewEnv(true, false)
 		logger   = newLogger(LogConfig{Collector: env}, env)
 		mem      = NewMemory()
 		stack    = newstack()
@@ -69,7 +69,7 @@ func TestStoreCapture(t *testing.T) {
 
 	var index common.Hash
 
-	logger.captureState(0, SSTORE, new(big.Int), new(big.Int), mem, stack, contract, nil)
+	logger.captureState(0, SSTORE, new(big.Int), new(big.Int), mem, stack, contract, 0, nil)
 	if len(logger.changedValues[contract.Address()]) == 0 {
 		t.Fatalf("expected exactly 1 changed value on address %x, got %d", contract.Address(), len(logger.changedValues[contract.Address()]))
 	}
@@ -91,13 +91,13 @@ func TestStorageCapture(t *testing.T) {
 		stack    = newstack()
 	)
 
-	logger.captureState(0, STOP, new(big.Int), new(big.Int), mem, stack, contract, nil)
+	logger.captureState(0, STOP, new(big.Int), new(big.Int), mem, stack, contract, 0, nil)
 	if ref.calledForEach {
 		t.Error("didn't expect for each to be called")
 	}
 
 	logger = newLogger(LogConfig{Collector: env, FullStorage: true}, env)
-	logger.captureState(0, STOP, new(big.Int), new(big.Int), mem, stack, contract, nil)
+	logger.captureState(0, STOP, new(big.Int), new(big.Int), mem, stack, contract, 0, nil)
 	if !ref.calledForEach {
 		t.Error("expected for each to be called")
 	}

--- a/core/vm/runtime/env.go
+++ b/core/vm/runtime/env.go
@@ -27,8 +27,9 @@ import (
 
 // Env is a basic runtime environment required for running the EVM.
 type Env struct {
-	depth int
-	state *state.StateDB
+	ruleSet vm.RuleSet
+	depth   int
+	state   *state.StateDB
 
 	origin   common.Address
 	coinbase common.Address
@@ -48,6 +49,7 @@ type Env struct {
 // NewEnv returns a new vm.Environment
 func NewEnv(cfg *Config, state *state.StateDB) vm.Environment {
 	env := &Env{
+		ruleSet:    cfg.RuleSet,
 		state:      state,
 		origin:     cfg.Origin,
 		coinbase:   cfg.Coinbase,
@@ -56,7 +58,7 @@ func NewEnv(cfg *Config, state *state.StateDB) vm.Environment {
 		difficulty: cfg.Difficulty,
 		gasLimit:   cfg.GasLimit,
 	}
-	env.evm = vm.New(env, &vm.Config{
+	env.evm = vm.New(env, vm.Config{
 		Debug:     cfg.Debug,
 		EnableJit: !cfg.DisableJit,
 		ForceJit:  !cfg.DisableJit,
@@ -77,6 +79,7 @@ func (self *Env) AddStructLog(log vm.StructLog) {
 	self.logs = append(self.logs, log)
 }
 
+func (self *Env) RuleSet() vm.RuleSet      { return self.ruleSet }
 func (self *Env) Vm() vm.Vm                { return self.evm }
 func (self *Env) Origin() common.Address   { return self.origin }
 func (self *Env) BlockNumber() *big.Int    { return self.number }

--- a/core/vm/runtime/runtime.go
+++ b/core/vm/runtime/runtime.go
@@ -22,13 +22,20 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/state"
+	"github.com/ethereum/go-ethereum/core/vm"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/ethdb"
 )
 
+// The default, always homestead, rule set for the vm env
+type ruleSet struct{}
+
+func (ruleSet) IsHomestead(*big.Int) bool { return true }
+
 // Config is a basic type specifying certain configuration flags for running
 // the EVM.
 type Config struct {
+	RuleSet     vm.RuleSet
 	Difficulty  *big.Int
 	Origin      common.Address
 	Coinbase    common.Address
@@ -46,6 +53,10 @@ type Config struct {
 
 // sets defaults on the config
 func setDefaults(cfg *Config) {
+	if cfg.RuleSet == nil {
+		cfg.RuleSet = ruleSet{}
+	}
+
 	if cfg.Difficulty == nil {
 		cfg.Difficulty = new(big.Int)
 	}

--- a/core/vm/util_test.go
+++ b/core/vm/util_test.go
@@ -1,0 +1,9 @@
+package vm
+
+import "math/big"
+
+type ruleSet struct {
+	hs *big.Int
+}
+
+func (r ruleSet) IsHomestead(n *big.Int) bool { return n.Cmp(r.hs) >= 0 }

--- a/core/vm/vm_jit_fake.go
+++ b/core/vm/vm_jit_fake.go
@@ -22,5 +22,5 @@ import "fmt"
 
 func NewJitVm(env Environment) VirtualMachine {
 	fmt.Printf("Warning! EVM JIT not enabled.\n")
-	return New(env, nil)
+	return New(env, Config{})
 }

--- a/eth/api.go
+++ b/eth/api.go
@@ -674,11 +674,11 @@ func (s *PublicBlockChainAPI) doCall(args CallArgs, blockNr rpc.BlockNumber) (st
 	vmenv := core.NewEnv(stateDb, s.config, s.bc, msg, block.Header(), s.config.VmConfig)
 	gp := new(core.GasPool).AddGas(common.MaxBig)
 
-	res, gas, err := core.ApplyMessage(vmenv, msg, gp)
+	res, requiredGas, _, err := core.NewStateTransition(vmenv, msg, gp).TransitionDb()
 	if len(res) == 0 { // backwards compatibility
-		return "0x", gas, err
+		return "0x", requiredGas, err
 	}
-	return common.ToHex(res), gas, err
+	return common.ToHex(res), requiredGas, err
 }
 
 // Call executes the given transaction on the state for the given block number.

--- a/eth/api.go
+++ b/eth/api.go
@@ -456,6 +456,7 @@ func (s *PrivateAccountAPI) LockAccount(addr common.Address) bool {
 // PublicBlockChainAPI provides an API to access the Ethereum blockchain.
 // It offers only methods that operate on public data that is freely available to anyone.
 type PublicBlockChainAPI struct {
+	config   *core.ChainConfig
 	bc       *core.BlockChain
 	chainDb  ethdb.Database
 	eventMux *event.TypeMux
@@ -464,8 +465,8 @@ type PublicBlockChainAPI struct {
 }
 
 // NewPublicBlockChainAPI creates a new Etheruem blockchain API.
-func NewPublicBlockChainAPI(bc *core.BlockChain, m *miner.Miner, chainDb ethdb.Database, eventMux *event.TypeMux, am *accounts.Manager) *PublicBlockChainAPI {
-	return &PublicBlockChainAPI{bc: bc, miner: m, chainDb: chainDb, eventMux: eventMux, am: am}
+func NewPublicBlockChainAPI(config *core.ChainConfig, bc *core.BlockChain, m *miner.Miner, chainDb ethdb.Database, eventMux *event.TypeMux, am *accounts.Manager) *PublicBlockChainAPI {
+	return &PublicBlockChainAPI{config: config, bc: bc, miner: m, chainDb: chainDb, eventMux: eventMux, am: am}
 }
 
 // BlockNumber returns the block number of the chain head.
@@ -670,7 +671,7 @@ func (s *PublicBlockChainAPI) doCall(args CallArgs, blockNr rpc.BlockNumber) (st
 	}
 
 	// Execute the call and return
-	vmenv := core.NewEnv(stateDb, s.bc, msg, block.Header(), nil)
+	vmenv := core.NewEnv(stateDb, s.config, s.bc, msg, block.Header(), s.config.VmConfig)
 	gp := new(core.GasPool).AddGas(common.MaxBig)
 
 	res, gas, err := core.ApplyMessage(vmenv, msg, gp)
@@ -1501,13 +1502,14 @@ func (api *PublicDebugAPI) SeedHash(number uint64) (string, error) {
 // PrivateDebugAPI is the collection of Etheruem APIs exposed over the private
 // debugging endpoint.
 type PrivateDebugAPI struct {
-	eth *Ethereum
+	config *core.ChainConfig
+	eth    *Ethereum
 }
 
 // NewPrivateDebugAPI creates a new API definition for the private debug methods
 // of the Ethereum service.
-func NewPrivateDebugAPI(eth *Ethereum) *PrivateDebugAPI {
-	return &PrivateDebugAPI{eth: eth}
+func NewPrivateDebugAPI(config *core.ChainConfig, eth *Ethereum) *PrivateDebugAPI {
+	return &PrivateDebugAPI{config: config, eth: eth}
 }
 
 // BlockTraceResults is the returned value when replaying a block to check for
@@ -1601,7 +1603,7 @@ func (api *PrivateDebugAPI) traceBlock(block *types.Block, config vm.Config) (bo
 	config.Debug = true // make sure debug is set.
 	config.Logger.Collector = collector
 
-	if err := core.ValidateHeader(blockchain.AuxValidator(), block.Header(), blockchain.GetHeader(block.ParentHash()), true, false); err != nil {
+	if err := core.ValidateHeader(api.config, blockchain.AuxValidator(), block.Header(), blockchain.GetHeader(block.ParentHash()), true, false); err != nil {
 		return false, collector.traces, err
 	}
 	statedb, err := state.New(blockchain.GetBlock(block.ParentHash()).Root(), api.eth.ChainDb())
@@ -1609,7 +1611,7 @@ func (api *PrivateDebugAPI) traceBlock(block *types.Block, config vm.Config) (bo
 		return false, collector.traces, err
 	}
 
-	receipts, _, usedGas, err := processor.Process(block, statedb, &config)
+	receipts, _, usedGas, err := processor.Process(block, statedb, config)
 	if err != nil {
 		return false, collector.traces, err
 	}
@@ -1731,7 +1733,7 @@ func (s *PrivateDebugAPI) TraceTransaction(txHash common.Hash, logger vm.LogConf
 		data:     tx.Data(),
 	}
 
-	vmenv := core.NewEnv(stateDb, s.eth.BlockChain(), msg, block.Header(), &vm.Config{
+	vmenv := core.NewEnv(stateDb, s.config, s.eth.BlockChain(), msg, block.Header(), vm.Config{
 		Debug:  true,
 		Logger: logger,
 	})
@@ -1788,7 +1790,9 @@ func (s *PublicBlockChainAPI) TraceCall(args CallArgs, blockNr rpc.BlockNumber) 
 	}
 
 	// Execute the call and return
-	vmenv := core.NewEnv(stateDb, s.bc, msg, block.Header(), nil)
+	vmenv := core.NewEnv(stateDb, s.config, s.bc, msg, block.Header(), vm.Config{
+		Debug: true,
+	})
 	gp := new(core.GasPool).AddGas(common.MaxBig)
 
 	ret, gas, err := core.ApplyMessage(vmenv, msg, gp)

--- a/eth/handler.go
+++ b/eth/handler.go
@@ -86,7 +86,7 @@ type ProtocolManager struct {
 
 // NewProtocolManager returns a new ethereum sub protocol manager. The Ethereum sub protocol manages peers capable
 // with the ethereum network.
-func NewProtocolManager(fastSync bool, networkId int, mux *event.TypeMux, txpool txPool, pow pow.PoW, blockchain *core.BlockChain, chaindb ethdb.Database) (*ProtocolManager, error) {
+func NewProtocolManager(config *core.ChainConfig, fastSync bool, networkId int, mux *event.TypeMux, txpool txPool, pow pow.PoW, blockchain *core.BlockChain, chaindb ethdb.Database) (*ProtocolManager, error) {
 	// Figure out whether to allow fast sync or not
 	if fastSync && blockchain.CurrentBlock().NumberU64() > 0 {
 		glog.V(logger.Info).Infof("blockchain not empty, fast sync disabled")
@@ -144,7 +144,7 @@ func NewProtocolManager(fastSync bool, networkId int, mux *event.TypeMux, txpool
 		manager.removePeer)
 
 	validator := func(block *types.Block, parent *types.Block) error {
-		return core.ValidateHeader(pow, block.Header(), parent.Header(), true, false)
+		return core.ValidateHeader(config, pow, block.Header(), parent.Header(), true, false)
 	}
 	heighter := func() uint64 {
 		return blockchain.CurrentBlock().NumberU64()

--- a/eth/helper_test.go
+++ b/eth/helper_test.go
@@ -17,7 +17,6 @@ import (
 	"github.com/ethereum/go-ethereum/event"
 	"github.com/ethereum/go-ethereum/p2p"
 	"github.com/ethereum/go-ethereum/p2p/discover"
-	"github.com/ethereum/go-ethereum/params"
 )
 
 var (
@@ -35,7 +34,7 @@ func newTestProtocolManager(fastSync bool, blocks int, generator func(int, *core
 		pow           = new(core.FakePow)
 		db, _         = ethdb.NewMemDatabase()
 		genesis       = core.WriteGenesisBlockForTesting(db, core.GenesisAccount{testBankAddress, testBankFunds})
-		chainConfig   = &core.ChainConfig{HomesteadBlock: params.MainNetHomesteadBlock}
+		chainConfig   = &core.ChainConfig{HomesteadBlock: big.NewInt(0)} // homestead set to 0 because of chain maker
 		blockchain, _ = core.NewBlockChain(db, chainConfig, pow, evmux)
 	)
 	chain, _ := core.GenerateChain(genesis, db, blocks, generator)

--- a/eth/helper_test.go
+++ b/eth/helper_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/ethereum/go-ethereum/event"
 	"github.com/ethereum/go-ethereum/p2p"
 	"github.com/ethereum/go-ethereum/p2p/discover"
+	"github.com/ethereum/go-ethereum/params"
 )
 
 var (
@@ -34,13 +35,15 @@ func newTestProtocolManager(fastSync bool, blocks int, generator func(int, *core
 		pow           = new(core.FakePow)
 		db, _         = ethdb.NewMemDatabase()
 		genesis       = core.WriteGenesisBlockForTesting(db, core.GenesisAccount{testBankAddress, testBankFunds})
-		blockchain, _ = core.NewBlockChain(db, pow, evmux)
+		chainConfig   = &core.ChainConfig{HomesteadBlock: params.MainNetHomesteadBlock}
+		blockchain, _ = core.NewBlockChain(db, chainConfig, pow, evmux)
 	)
 	chain, _ := core.GenerateChain(genesis, db, blocks, generator)
 	if _, err := blockchain.InsertChain(chain); err != nil {
 		panic(err)
 	}
-	pm, err := NewProtocolManager(fastSync, NetworkId, evmux, &testTxPool{added: newtx}, pow, blockchain, db)
+
+	pm, err := NewProtocolManager(chainConfig, fastSync, NetworkId, evmux, &testTxPool{added: newtx}, pow, blockchain, db)
 	if err != nil {
 		return nil, err
 	}

--- a/miner/miner.go
+++ b/miner/miner.go
@@ -51,8 +51,8 @@ type Miner struct {
 	shouldStart int32 // should start indicates whether we should start after sync
 }
 
-func New(eth core.Backend, mux *event.TypeMux, pow pow.PoW) *Miner {
-	miner := &Miner{eth: eth, mux: mux, pow: pow, worker: newWorker(common.Address{}, eth), canStart: 1}
+func New(eth core.Backend, config *core.ChainConfig, mux *event.TypeMux, pow pow.PoW) *Miner {
+	miner := &Miner{eth: eth, mux: mux, pow: pow, worker: newWorker(config, common.Address{}, eth), canStart: 1}
 	go miner.update()
 
 	return miner

--- a/params/protocol_params.go
+++ b/params/protocol_params.go
@@ -40,8 +40,9 @@ var (
 	EcrecoverGas           = big.NewInt(3000)   //
 	Sha256WordGas          = big.NewInt(12)     //
 
-	MinGasLimit     = big.NewInt(5000)    // Minimum the gas limit may ever be.
-	GenesisGasLimit = big.NewInt(4712388) // Gas limit of the Genesis block.
+	MinGasLimit     = big.NewInt(5000)                  // Minimum the gas limit may ever be.
+	GenesisGasLimit = big.NewInt(4712388)               // Gas limit of the Genesis block.
+	TargetGasLimit  = new(big.Int).Set(GenesisGasLimit) // The artificial target
 
 	Sha3Gas              = big.NewInt(30)     // Once per SHA3 operation.
 	Sha256Gas            = big.NewInt(60)     //

--- a/params/util.go
+++ b/params/util.go
@@ -19,15 +19,6 @@ package params
 import "math/big"
 
 var (
-	TestNetHomesteadBlock = big.NewInt(494000)    // testnet homestead block
-	MainNetHomesteadBlock = big.NewInt(1150000)   // mainnet homestead block
-	HomesteadBlock        = MainNetHomesteadBlock // homestead block used to check against
+	TestNetHomesteadBlock = big.NewInt(494000)  // testnet homestead block
+	MainNetHomesteadBlock = big.NewInt(1150000) // mainnet homestead block
 )
-
-func IsHomestead(blockNumber *big.Int) bool {
-	// for unit tests TODO: flip to true after homestead is live
-	if blockNumber == nil {
-		return false
-	}
-	return blockNumber.Cmp(HomesteadBlock) >= 0
-}

--- a/tests/block_test.go
+++ b/tests/block_test.go
@@ -20,77 +20,66 @@ import (
 	"math/big"
 	"path/filepath"
 	"testing"
-
-	"github.com/ethereum/go-ethereum/params"
 )
 
 func TestBcValidBlockTests(t *testing.T) {
-	params.HomesteadBlock = big.NewInt(1000000)
-	err := RunBlockTest(filepath.Join(blockTestDir, "bcValidBlockTest.json"), BlockSkipTests)
+	err := RunBlockTest(big.NewInt(1000000), filepath.Join(blockTestDir, "bcValidBlockTest.json"), BlockSkipTests)
 	if err != nil {
 		t.Fatal(err)
 	}
 }
 
 func TestBcUncleHeaderValidityTests(t *testing.T) {
-	params.HomesteadBlock = big.NewInt(1000000)
-	err := RunBlockTest(filepath.Join(blockTestDir, "bcUncleHeaderValiditiy.json"), BlockSkipTests)
+	err := RunBlockTest(big.NewInt(1000000), filepath.Join(blockTestDir, "bcUncleHeaderValiditiy.json"), BlockSkipTests)
 	if err != nil {
 		t.Fatal(err)
 	}
 }
 
 func TestBcUncleTests(t *testing.T) {
-	params.HomesteadBlock = big.NewInt(1000000)
-	err := RunBlockTest(filepath.Join(blockTestDir, "bcUncleTest.json"), BlockSkipTests)
+	err := RunBlockTest(big.NewInt(1000000), filepath.Join(blockTestDir, "bcUncleTest.json"), BlockSkipTests)
 	if err != nil {
 		t.Fatal(err)
 	}
 }
 
 func TestBcForkUncleTests(t *testing.T) {
-	params.HomesteadBlock = big.NewInt(1000000)
-	err := RunBlockTest(filepath.Join(blockTestDir, "bcForkUncle.json"), BlockSkipTests)
+	err := RunBlockTest(big.NewInt(1000000), filepath.Join(blockTestDir, "bcForkUncle.json"), BlockSkipTests)
 	if err != nil {
 		t.Fatal(err)
 	}
 }
 
 func TestBcInvalidHeaderTests(t *testing.T) {
-	params.HomesteadBlock = big.NewInt(1000000)
-	err := RunBlockTest(filepath.Join(blockTestDir, "bcInvalidHeaderTest.json"), BlockSkipTests)
+	err := RunBlockTest(big.NewInt(1000000), filepath.Join(blockTestDir, "bcInvalidHeaderTest.json"), BlockSkipTests)
 	if err != nil {
 		t.Fatal(err)
 	}
 }
 
 func TestBcInvalidRLPTests(t *testing.T) {
-	params.HomesteadBlock = big.NewInt(1000000)
-	err := RunBlockTest(filepath.Join(blockTestDir, "bcInvalidRLPTest.json"), BlockSkipTests)
+	err := RunBlockTest(big.NewInt(1000000), filepath.Join(blockTestDir, "bcInvalidRLPTest.json"), BlockSkipTests)
 	if err != nil {
 		t.Fatal(err)
 	}
 }
 
 func TestBcRPCAPITests(t *testing.T) {
-	params.HomesteadBlock = big.NewInt(1000000)
-	err := RunBlockTest(filepath.Join(blockTestDir, "bcRPC_API_Test.json"), BlockSkipTests)
+	err := RunBlockTest(big.NewInt(1000000), filepath.Join(blockTestDir, "bcRPC_API_Test.json"), BlockSkipTests)
 	if err != nil {
 		t.Fatal(err)
 	}
 }
 
 func TestBcForkBlockTests(t *testing.T) {
-	params.HomesteadBlock = big.NewInt(1000000)
-	err := RunBlockTest(filepath.Join(blockTestDir, "bcForkBlockTest.json"), BlockSkipTests)
+	err := RunBlockTest(big.NewInt(1000000), filepath.Join(blockTestDir, "bcForkBlockTest.json"), BlockSkipTests)
 	if err != nil {
 		t.Fatal(err)
 	}
 }
 
 func TestBcForkStress(t *testing.T) {
-	params.HomesteadBlock = big.NewInt(1000000)
-	err := RunBlockTest(filepath.Join(blockTestDir, "bcForkStressTest.json"), BlockSkipTests)
+	err := RunBlockTest(big.NewInt(1000000), filepath.Join(blockTestDir, "bcForkStressTest.json"), BlockSkipTests)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -100,24 +89,21 @@ func TestBcTotalDifficulty(t *testing.T) {
 	// skip because these will fail due to selfish mining fix
 	t.Skip()
 
-	params.HomesteadBlock = big.NewInt(1000000)
-	err := RunBlockTest(filepath.Join(blockTestDir, "bcTotalDifficultyTest.json"), BlockSkipTests)
+	err := RunBlockTest(big.NewInt(1000000), filepath.Join(blockTestDir, "bcTotalDifficultyTest.json"), BlockSkipTests)
 	if err != nil {
 		t.Fatal(err)
 	}
 }
 
 func TestBcWallet(t *testing.T) {
-	params.HomesteadBlock = big.NewInt(1000000)
-	err := RunBlockTest(filepath.Join(blockTestDir, "bcWalletTest.json"), BlockSkipTests)
+	err := RunBlockTest(big.NewInt(1000000), filepath.Join(blockTestDir, "bcWalletTest.json"), BlockSkipTests)
 	if err != nil {
 		t.Fatal(err)
 	}
 }
 
 func TestBcGasPricer(t *testing.T) {
-	params.HomesteadBlock = big.NewInt(1000000)
-	err := RunBlockTest(filepath.Join(blockTestDir, "bcGasPricerTest.json"), BlockSkipTests)
+	err := RunBlockTest(big.NewInt(1000000), filepath.Join(blockTestDir, "bcGasPricerTest.json"), BlockSkipTests)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -125,8 +111,7 @@ func TestBcGasPricer(t *testing.T) {
 
 // TODO: iterate over files once we got more than a few
 func TestBcRandom(t *testing.T) {
-	params.HomesteadBlock = big.NewInt(1000000)
-	err := RunBlockTest(filepath.Join(blockTestDir, "RandomTests/bl201507071825GO.json"), BlockSkipTests)
+	err := RunBlockTest(big.NewInt(1000000), filepath.Join(blockTestDir, "RandomTests/bl201507071825GO.json"), BlockSkipTests)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -136,16 +121,14 @@ func TestBcMultiChain(t *testing.T) {
 	// skip due to selfish mining
 	t.Skip()
 
-	params.HomesteadBlock = big.NewInt(1000000)
-	err := RunBlockTest(filepath.Join(blockTestDir, "bcMultiChainTest.json"), BlockSkipTests)
+	err := RunBlockTest(big.NewInt(1000000), filepath.Join(blockTestDir, "bcMultiChainTest.json"), BlockSkipTests)
 	if err != nil {
 		t.Fatal(err)
 	}
 }
 
 func TestBcState(t *testing.T) {
-	params.HomesteadBlock = big.NewInt(1000000)
-	err := RunBlockTest(filepath.Join(blockTestDir, "bcStateTest.json"), BlockSkipTests)
+	err := RunBlockTest(big.NewInt(1000000), filepath.Join(blockTestDir, "bcStateTest.json"), BlockSkipTests)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -153,88 +136,77 @@ func TestBcState(t *testing.T) {
 
 // Homestead tests
 func TestHomesteadBcValidBlockTests(t *testing.T) {
-	params.HomesteadBlock = big.NewInt(0)
-	err := RunBlockTest(filepath.Join(blockTestDir, "Homestead", "bcValidBlockTest.json"), BlockSkipTests)
+	err := RunBlockTest(big.NewInt(0), filepath.Join(blockTestDir, "Homestead", "bcValidBlockTest.json"), BlockSkipTests)
 	if err != nil {
 		t.Fatal(err)
 	}
 }
 
 func TestHomesteadBcUncleHeaderValidityTests(t *testing.T) {
-	params.HomesteadBlock = big.NewInt(0)
-	err := RunBlockTest(filepath.Join(blockTestDir, "Homestead", "bcUncleHeaderValiditiy.json"), BlockSkipTests)
+	err := RunBlockTest(big.NewInt(0), filepath.Join(blockTestDir, "Homestead", "bcUncleHeaderValiditiy.json"), BlockSkipTests)
 	if err != nil {
 		t.Fatal(err)
 	}
 }
 
 func TestHomesteadBcUncleTests(t *testing.T) {
-	params.HomesteadBlock = big.NewInt(0)
-	err := RunBlockTest(filepath.Join(blockTestDir, "Homestead", "bcUncleTest.json"), BlockSkipTests)
+	err := RunBlockTest(big.NewInt(0), filepath.Join(blockTestDir, "Homestead", "bcUncleTest.json"), BlockSkipTests)
 	if err != nil {
 		t.Fatal(err)
 	}
 }
 
 func TestHomesteadBcInvalidHeaderTests(t *testing.T) {
-	params.HomesteadBlock = big.NewInt(0)
-	err := RunBlockTest(filepath.Join(blockTestDir, "Homestead", "bcInvalidHeaderTest.json"), BlockSkipTests)
+	err := RunBlockTest(big.NewInt(0), filepath.Join(blockTestDir, "Homestead", "bcInvalidHeaderTest.json"), BlockSkipTests)
 	if err != nil {
 		t.Fatal(err)
 	}
 }
 
 func TestHomesteadBcRPCAPITests(t *testing.T) {
-	params.HomesteadBlock = big.NewInt(0)
-	err := RunBlockTest(filepath.Join(blockTestDir, "Homestead", "bcRPC_API_Test.json"), BlockSkipTests)
+	err := RunBlockTest(big.NewInt(0), filepath.Join(blockTestDir, "Homestead", "bcRPC_API_Test.json"), BlockSkipTests)
 	if err != nil {
 		t.Fatal(err)
 	}
 }
 
 func TestHomesteadBcForkStress(t *testing.T) {
-	params.HomesteadBlock = big.NewInt(0)
-	err := RunBlockTest(filepath.Join(blockTestDir, "Homestead", "bcForkStressTest.json"), BlockSkipTests)
+	err := RunBlockTest(big.NewInt(0), filepath.Join(blockTestDir, "Homestead", "bcForkStressTest.json"), BlockSkipTests)
 	if err != nil {
 		t.Fatal(err)
 	}
 }
 
 func TestHomesteadBcTotalDifficulty(t *testing.T) {
-	params.HomesteadBlock = big.NewInt(0)
-	err := RunBlockTest(filepath.Join(blockTestDir, "Homestead", "bcTotalDifficultyTest.json"), BlockSkipTests)
+	err := RunBlockTest(big.NewInt(0), filepath.Join(blockTestDir, "Homestead", "bcTotalDifficultyTest.json"), BlockSkipTests)
 	if err != nil {
 		t.Fatal(err)
 	}
 }
 
 func TestHomesteadBcWallet(t *testing.T) {
-	params.HomesteadBlock = big.NewInt(0)
-	err := RunBlockTest(filepath.Join(blockTestDir, "Homestead", "bcWalletTest.json"), BlockSkipTests)
+	err := RunBlockTest(big.NewInt(0), filepath.Join(blockTestDir, "Homestead", "bcWalletTest.json"), BlockSkipTests)
 	if err != nil {
 		t.Fatal(err)
 	}
 }
 
 func TestHomesteadBcGasPricer(t *testing.T) {
-	params.HomesteadBlock = big.NewInt(0)
-	err := RunBlockTest(filepath.Join(blockTestDir, "Homestead", "bcGasPricerTest.json"), BlockSkipTests)
+	err := RunBlockTest(big.NewInt(0), filepath.Join(blockTestDir, "Homestead", "bcGasPricerTest.json"), BlockSkipTests)
 	if err != nil {
 		t.Fatal(err)
 	}
 }
 
 func TestHomesteadBcMultiChain(t *testing.T) {
-	params.HomesteadBlock = big.NewInt(0)
-	err := RunBlockTest(filepath.Join(blockTestDir, "Homestead", "bcMultiChainTest.json"), BlockSkipTests)
+	err := RunBlockTest(big.NewInt(0), filepath.Join(blockTestDir, "Homestead", "bcMultiChainTest.json"), BlockSkipTests)
 	if err != nil {
 		t.Fatal(err)
 	}
 }
 
 func TestHomesteadBcState(t *testing.T) {
-	params.HomesteadBlock = big.NewInt(0)
-	err := RunBlockTest(filepath.Join(blockTestDir, "Homestead", "bcStateTest.json"), BlockSkipTests)
+	err := RunBlockTest(big.NewInt(0), filepath.Join(blockTestDir, "Homestead", "bcStateTest.json"), BlockSkipTests)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/tests/state_test.go
+++ b/tests/state_test.go
@@ -21,17 +21,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
-
-	"github.com/ethereum/go-ethereum/core/vm"
-	"github.com/ethereum/go-ethereum/params"
 )
-
-func init() {
-	if os.Getenv("JITVM") == "true" {
-		vm.ForceJit = true
-		vm.EnableJit = true
-	}
-}
 
 func BenchmarkStateCall1024(b *testing.B) {
 	fn := filepath.Join(stateTestDir, "stCallCreateCallCodeTest.json")
@@ -41,188 +31,228 @@ func BenchmarkStateCall1024(b *testing.B) {
 }
 
 func TestStateSystemOperations(t *testing.T) {
-	params.HomesteadBlock = big.NewInt(1000000)
+	ruleSet := RuleSet{
+		HomesteadBlock: big.NewInt(1000000),
+	}
 
 	fn := filepath.Join(stateTestDir, "stSystemOperationsTest.json")
-	if err := RunStateTest(fn, StateSkipTests); err != nil {
+	if err := RunStateTest(ruleSet, fn, StateSkipTests); err != nil {
 		t.Error(err)
 	}
 }
 
 func TestStateExample(t *testing.T) {
-	params.HomesteadBlock = big.NewInt(1000000)
+	ruleSet := RuleSet{
+		HomesteadBlock: big.NewInt(1000000),
+	}
 
 	fn := filepath.Join(stateTestDir, "stExample.json")
-	if err := RunStateTest(fn, StateSkipTests); err != nil {
+	if err := RunStateTest(ruleSet, fn, StateSkipTests); err != nil {
 		t.Error(err)
 	}
 }
 
 func TestStatePreCompiledContracts(t *testing.T) {
-	params.HomesteadBlock = big.NewInt(1000000)
+	ruleSet := RuleSet{
+		HomesteadBlock: big.NewInt(1000000),
+	}
 
 	fn := filepath.Join(stateTestDir, "stPreCompiledContracts.json")
-	if err := RunStateTest(fn, StateSkipTests); err != nil {
+	if err := RunStateTest(ruleSet, fn, StateSkipTests); err != nil {
 		t.Error(err)
 	}
 }
 
 func TestStateRecursiveCreate(t *testing.T) {
-	params.HomesteadBlock = big.NewInt(1000000)
+	ruleSet := RuleSet{
+		HomesteadBlock: big.NewInt(1000000),
+	}
 
 	fn := filepath.Join(stateTestDir, "stRecursiveCreate.json")
-	if err := RunStateTest(fn, StateSkipTests); err != nil {
+	if err := RunStateTest(ruleSet, fn, StateSkipTests); err != nil {
 		t.Error(err)
 	}
 }
 
 func TestStateSpecial(t *testing.T) {
-	params.HomesteadBlock = big.NewInt(1000000)
+	ruleSet := RuleSet{
+		HomesteadBlock: big.NewInt(1000000),
+	}
 
 	fn := filepath.Join(stateTestDir, "stSpecialTest.json")
-	if err := RunStateTest(fn, StateSkipTests); err != nil {
+	if err := RunStateTest(ruleSet, fn, StateSkipTests); err != nil {
 		t.Error(err)
 	}
 }
 
 func TestStateRefund(t *testing.T) {
-	params.HomesteadBlock = big.NewInt(1000000)
+	ruleSet := RuleSet{
+		HomesteadBlock: big.NewInt(1000000),
+	}
 
 	fn := filepath.Join(stateTestDir, "stRefundTest.json")
-	if err := RunStateTest(fn, StateSkipTests); err != nil {
+	if err := RunStateTest(ruleSet, fn, StateSkipTests); err != nil {
 		t.Error(err)
 	}
 }
 
 func TestStateBlockHash(t *testing.T) {
-	params.HomesteadBlock = big.NewInt(1000000)
+	ruleSet := RuleSet{
+		HomesteadBlock: big.NewInt(1000000),
+	}
 
 	fn := filepath.Join(stateTestDir, "stBlockHashTest.json")
-	if err := RunStateTest(fn, StateSkipTests); err != nil {
+	if err := RunStateTest(ruleSet, fn, StateSkipTests); err != nil {
 		t.Error(err)
 	}
 }
 
 func TestStateInitCode(t *testing.T) {
-	params.HomesteadBlock = big.NewInt(1000000)
+	ruleSet := RuleSet{
+		HomesteadBlock: big.NewInt(1000000),
+	}
 
 	fn := filepath.Join(stateTestDir, "stInitCodeTest.json")
-	if err := RunStateTest(fn, StateSkipTests); err != nil {
+	if err := RunStateTest(ruleSet, fn, StateSkipTests); err != nil {
 		t.Error(err)
 	}
 }
 
 func TestStateLog(t *testing.T) {
-	params.HomesteadBlock = big.NewInt(1000000)
+	ruleSet := RuleSet{
+		HomesteadBlock: big.NewInt(1000000),
+	}
 
 	fn := filepath.Join(stateTestDir, "stLogTests.json")
-	if err := RunStateTest(fn, StateSkipTests); err != nil {
+	if err := RunStateTest(ruleSet, fn, StateSkipTests); err != nil {
 		t.Error(err)
 	}
 }
 
 func TestStateTransaction(t *testing.T) {
-	params.HomesteadBlock = big.NewInt(1000000)
+	ruleSet := RuleSet{
+		HomesteadBlock: big.NewInt(1000000),
+	}
 
 	fn := filepath.Join(stateTestDir, "stTransactionTest.json")
-	if err := RunStateTest(fn, StateSkipTests); err != nil {
+	if err := RunStateTest(ruleSet, fn, StateSkipTests); err != nil {
 		t.Error(err)
 	}
 }
 
 func TestStateTransition(t *testing.T) {
-	params.HomesteadBlock = big.NewInt(1000000)
+	ruleSet := RuleSet{
+		HomesteadBlock: big.NewInt(1000000),
+	}
 
 	fn := filepath.Join(stateTestDir, "stTransitionTest.json")
-	if err := RunStateTest(fn, StateSkipTests); err != nil {
+	if err := RunStateTest(ruleSet, fn, StateSkipTests); err != nil {
 		t.Error(err)
 	}
 }
 
 func TestCallCreateCallCode(t *testing.T) {
-	params.HomesteadBlock = big.NewInt(1000000)
+	ruleSet := RuleSet{
+		HomesteadBlock: big.NewInt(1000000),
+	}
 
 	fn := filepath.Join(stateTestDir, "stCallCreateCallCodeTest.json")
-	if err := RunStateTest(fn, StateSkipTests); err != nil {
+	if err := RunStateTest(ruleSet, fn, StateSkipTests); err != nil {
 		t.Error(err)
 	}
 }
 
 func TestCallCodes(t *testing.T) {
-	params.HomesteadBlock = big.NewInt(1000000)
+	ruleSet := RuleSet{
+		HomesteadBlock: big.NewInt(1000000),
+	}
 
 	fn := filepath.Join(stateTestDir, "stCallCodes.json")
-	if err := RunStateTest(fn, StateSkipTests); err != nil {
+	if err := RunStateTest(ruleSet, fn, StateSkipTests); err != nil {
 		t.Error(err)
 	}
 }
 
 func TestDelegateCall(t *testing.T) {
-	params.HomesteadBlock = big.NewInt(1000000)
+	ruleSet := RuleSet{
+		HomesteadBlock: big.NewInt(1000000),
+	}
 
 	fn := filepath.Join(stateTestDir, "stDelegatecallTest.json")
-	if err := RunStateTest(fn, StateSkipTests); err != nil {
+	if err := RunStateTest(ruleSet, fn, StateSkipTests); err != nil {
 		t.Error(err)
 	}
 }
 
 func TestMemory(t *testing.T) {
-	params.HomesteadBlock = big.NewInt(1000000)
+	ruleSet := RuleSet{
+		HomesteadBlock: big.NewInt(1000000),
+	}
 
 	fn := filepath.Join(stateTestDir, "stMemoryTest.json")
-	if err := RunStateTest(fn, StateSkipTests); err != nil {
+	if err := RunStateTest(ruleSet, fn, StateSkipTests); err != nil {
 		t.Error(err)
 	}
 }
 
 func TestMemoryStress(t *testing.T) {
-	params.HomesteadBlock = big.NewInt(1000000)
+	ruleSet := RuleSet{
+		HomesteadBlock: big.NewInt(1000000),
+	}
 
 	if os.Getenv("TEST_VM_COMPLEX") == "" {
 		t.Skip()
 	}
 	fn := filepath.Join(stateTestDir, "stMemoryStressTest.json")
-	if err := RunStateTest(fn, StateSkipTests); err != nil {
+	if err := RunStateTest(ruleSet, fn, StateSkipTests); err != nil {
 		t.Error(err)
 	}
 }
 
 func TestQuadraticComplexity(t *testing.T) {
-	params.HomesteadBlock = big.NewInt(1000000)
+	ruleSet := RuleSet{
+		HomesteadBlock: big.NewInt(1000000),
+	}
 
 	if os.Getenv("TEST_VM_COMPLEX") == "" {
 		t.Skip()
 	}
 	fn := filepath.Join(stateTestDir, "stQuadraticComplexityTest.json")
-	if err := RunStateTest(fn, StateSkipTests); err != nil {
+	if err := RunStateTest(ruleSet, fn, StateSkipTests); err != nil {
 		t.Error(err)
 	}
 }
 
 func TestSolidity(t *testing.T) {
-	params.HomesteadBlock = big.NewInt(1000000)
+	ruleSet := RuleSet{
+		HomesteadBlock: big.NewInt(1000000),
+	}
 
 	fn := filepath.Join(stateTestDir, "stSolidityTest.json")
-	if err := RunStateTest(fn, StateSkipTests); err != nil {
+	if err := RunStateTest(ruleSet, fn, StateSkipTests); err != nil {
 		t.Error(err)
 	}
 }
 
 func TestWallet(t *testing.T) {
-	params.HomesteadBlock = big.NewInt(1000000)
+	ruleSet := RuleSet{
+		HomesteadBlock: big.NewInt(1000000),
+	}
 
 	fn := filepath.Join(stateTestDir, "stWalletTest.json")
-	if err := RunStateTest(fn, StateSkipTests); err != nil {
+	if err := RunStateTest(ruleSet, fn, StateSkipTests); err != nil {
 		t.Error(err)
 	}
 }
 
 func TestStateTestsRandom(t *testing.T) {
-	params.HomesteadBlock = big.NewInt(1000000)
+	ruleSet := RuleSet{
+		HomesteadBlock: big.NewInt(1000000),
+	}
 
 	fns, _ := filepath.Glob("./files/StateTests/RandomTests/*")
 	for _, fn := range fns {
-		if err := RunStateTest(fn, StateSkipTests); err != nil {
+		if err := RunStateTest(ruleSet, fn, StateSkipTests); err != nil {
 			t.Error(err)
 		}
 	}
@@ -230,151 +260,172 @@ func TestStateTestsRandom(t *testing.T) {
 
 // homestead tests
 func TestHomesteadStateSystemOperations(t *testing.T) {
-	params.HomesteadBlock = big.NewInt(0)
+	ruleSet := RuleSet{
+		HomesteadBlock: new(big.Int),
+	}
 
 	fn := filepath.Join(stateTestDir, "Homestead", "stSystemOperationsTest.json")
-	if err := RunStateTest(fn, StateSkipTests); err != nil {
+	if err := RunStateTest(ruleSet, fn, StateSkipTests); err != nil {
 		t.Error(err)
 	}
 }
 
 func TestHomesteadStatePreCompiledContracts(t *testing.T) {
-	params.HomesteadBlock = big.NewInt(0)
+	ruleSet := RuleSet{
+		HomesteadBlock: new(big.Int),
+	}
 
 	fn := filepath.Join(stateTestDir, "Homestead", "stPreCompiledContracts.json")
-	if err := RunStateTest(fn, StateSkipTests); err != nil {
+	if err := RunStateTest(ruleSet, fn, StateSkipTests); err != nil {
 		t.Error(err)
 	}
 }
 
 func TestHomesteadStateRecursiveCreate(t *testing.T) {
-	params.HomesteadBlock = big.NewInt(0)
-
-	fn := filepath.Join(stateTestDir, "Homestead", "stRecursiveCreate.json")
-	if err := RunStateTest(fn, StateSkipTests); err != nil {
-		t.Error(err)
+	ruleSet := RuleSet{
+		HomesteadBlock: new(big.Int),
 	}
-}
-
-func TestHomesteadStateSpecial(t *testing.T) {
-	params.HomesteadBlock = big.NewInt(0)
 
 	fn := filepath.Join(stateTestDir, "Homestead", "stSpecialTest.json")
-	if err := RunStateTest(fn, StateSkipTests); err != nil {
+	if err := RunStateTest(ruleSet, fn, StateSkipTests); err != nil {
 		t.Error(err)
 	}
 }
 
 func TestHomesteadStateRefund(t *testing.T) {
-	params.HomesteadBlock = big.NewInt(0)
+	ruleSet := RuleSet{
+		HomesteadBlock: new(big.Int),
+	}
 
 	fn := filepath.Join(stateTestDir, "Homestead", "stRefundTest.json")
-	if err := RunStateTest(fn, StateSkipTests); err != nil {
+	if err := RunStateTest(ruleSet, fn, StateSkipTests); err != nil {
 		t.Error(err)
 	}
 }
 
 func TestHomesteadStateInitCode(t *testing.T) {
-	params.HomesteadBlock = big.NewInt(0)
+	ruleSet := RuleSet{
+		HomesteadBlock: new(big.Int),
+	}
 
 	fn := filepath.Join(stateTestDir, "Homestead", "stInitCodeTest.json")
-	if err := RunStateTest(fn, StateSkipTests); err != nil {
+	if err := RunStateTest(ruleSet, fn, StateSkipTests); err != nil {
 		t.Error(err)
 	}
 }
 
 func TestHomesteadStateLog(t *testing.T) {
-	params.HomesteadBlock = big.NewInt(0)
+	ruleSet := RuleSet{
+		HomesteadBlock: new(big.Int),
+	}
 
 	fn := filepath.Join(stateTestDir, "Homestead", "stLogTests.json")
-	if err := RunStateTest(fn, StateSkipTests); err != nil {
+	if err := RunStateTest(ruleSet, fn, StateSkipTests); err != nil {
 		t.Error(err)
 	}
 }
 
 func TestHomesteadStateTransaction(t *testing.T) {
-	params.HomesteadBlock = big.NewInt(0)
+	ruleSet := RuleSet{
+		HomesteadBlock: new(big.Int),
+	}
 
 	fn := filepath.Join(stateTestDir, "Homestead", "stTransactionTest.json")
-	if err := RunStateTest(fn, StateSkipTests); err != nil {
+	if err := RunStateTest(ruleSet, fn, StateSkipTests); err != nil {
 		t.Error(err)
 	}
 }
 
 func TestHomesteadCallCreateCallCode(t *testing.T) {
-	params.HomesteadBlock = big.NewInt(0)
+	ruleSet := RuleSet{
+		HomesteadBlock: new(big.Int),
+	}
 
 	fn := filepath.Join(stateTestDir, "Homestead", "stCallCreateCallCodeTest.json")
-	if err := RunStateTest(fn, StateSkipTests); err != nil {
+	if err := RunStateTest(ruleSet, fn, StateSkipTests); err != nil {
 		t.Error(err)
 	}
 }
 
 func TestHomesteadCallCodes(t *testing.T) {
-	params.HomesteadBlock = big.NewInt(0)
+	ruleSet := RuleSet{
+		HomesteadBlock: new(big.Int),
+	}
 
 	fn := filepath.Join(stateTestDir, "Homestead", "stCallCodes.json")
-	if err := RunStateTest(fn, StateSkipTests); err != nil {
+	if err := RunStateTest(ruleSet, fn, StateSkipTests); err != nil {
 		t.Error(err)
 	}
 }
 
 func TestHomesteadMemory(t *testing.T) {
-	params.HomesteadBlock = big.NewInt(0)
+	ruleSet := RuleSet{
+		HomesteadBlock: new(big.Int),
+	}
 
 	fn := filepath.Join(stateTestDir, "Homestead", "stMemoryTest.json")
-	if err := RunStateTest(fn, StateSkipTests); err != nil {
+	if err := RunStateTest(ruleSet, fn, StateSkipTests); err != nil {
 		t.Error(err)
 	}
 }
 
 func TestHomesteadMemoryStress(t *testing.T) {
-	params.HomesteadBlock = big.NewInt(0)
+	ruleSet := RuleSet{
+		HomesteadBlock: new(big.Int),
+	}
 
 	if os.Getenv("TEST_VM_COMPLEX") == "" {
 		t.Skip()
 	}
 	fn := filepath.Join(stateTestDir, "Homestead", "stMemoryStressTest.json")
-	if err := RunStateTest(fn, StateSkipTests); err != nil {
+	if err := RunStateTest(ruleSet, fn, StateSkipTests); err != nil {
 		t.Error(err)
 	}
 }
 
 func TestHomesteadQuadraticComplexity(t *testing.T) {
-	params.HomesteadBlock = big.NewInt(0)
+	ruleSet := RuleSet{
+		HomesteadBlock: new(big.Int),
+	}
 
 	if os.Getenv("TEST_VM_COMPLEX") == "" {
 		t.Skip()
 	}
 	fn := filepath.Join(stateTestDir, "Homestead", "stQuadraticComplexityTest.json")
-	if err := RunStateTest(fn, StateSkipTests); err != nil {
+	if err := RunStateTest(ruleSet, fn, StateSkipTests); err != nil {
 		t.Error(err)
 	}
 }
 
 func TestHomesteadWallet(t *testing.T) {
-	params.HomesteadBlock = big.NewInt(0)
+	ruleSet := RuleSet{
+		HomesteadBlock: new(big.Int),
+	}
 
 	fn := filepath.Join(stateTestDir, "Homestead", "stWalletTest.json")
-	if err := RunStateTest(fn, StateSkipTests); err != nil {
+	if err := RunStateTest(ruleSet, fn, StateSkipTests); err != nil {
 		t.Error(err)
 	}
 }
 
 func TestHomesteadDelegateCodes(t *testing.T) {
-	params.HomesteadBlock = big.NewInt(0)
+	ruleSet := RuleSet{
+		HomesteadBlock: new(big.Int),
+	}
 
 	fn := filepath.Join(stateTestDir, "Homestead", "stCallDelegateCodes.json")
-	if err := RunStateTest(fn, StateSkipTests); err != nil {
+	if err := RunStateTest(ruleSet, fn, StateSkipTests); err != nil {
 		t.Error(err)
 	}
 }
 
 func TestHomesteadDelegateCodesCallCode(t *testing.T) {
-	params.HomesteadBlock = big.NewInt(0)
+	ruleSet := RuleSet{
+		HomesteadBlock: new(big.Int),
+	}
 
 	fn := filepath.Join(stateTestDir, "Homestead", "stCallDelegateCodesCallCode.json")
-	if err := RunStateTest(fn, StateSkipTests); err != nil {
+	if err := RunStateTest(ruleSet, fn, StateSkipTests); err != nil {
 		t.Error(err)
 	}
 }

--- a/tests/transaction_test_util.go
+++ b/tests/transaction_test_util.go
@@ -21,10 +21,10 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"math/big"
 	"runtime"
 
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/logger/glog"
 	"github.com/ethereum/go-ethereum/params"
@@ -91,8 +91,6 @@ func RunTransactionTests(file string, skipTests []string) error {
 }
 
 func runTransactionTests(tests map[string]TransactionTest, skipTests []string) error {
-	params.HomesteadBlock = big.NewInt(900000)
-
 	skipTest := make(map[string]bool, len(skipTests))
 	for _, name := range skipTests {
 		skipTest[name] = true
@@ -166,7 +164,8 @@ func verifyTxFields(txTest TransactionTest, decodedTx *types.Transaction) (err e
 		decodedSender common.Address
 	)
 
-	if params.IsHomestead(common.String2Big(txTest.Blocknumber)) {
+	chainConfig := &core.ChainConfig{HomesteadBlock: params.MainNetHomesteadBlock}
+	if chainConfig.IsHomestead(common.String2Big(txTest.Blocknumber)) {
 		decodedSender, err = decodedTx.From()
 	} else {
 		decodedSender, err = decodedTx.FromFrontier()

--- a/tests/vm_test_util.go
+++ b/tests/vm_test_util.go
@@ -29,6 +29,7 @@ import (
 	"github.com/ethereum/go-ethereum/core/vm"
 	"github.com/ethereum/go-ethereum/ethdb"
 	"github.com/ethereum/go-ethereum/logger/glog"
+	"github.com/ethereum/go-ethereum/params"
 )
 
 func RunVmTestWithReader(r io.Reader, skipTests []string) error {
@@ -67,11 +68,6 @@ func BenchVmTest(p string, conf bconf, b *testing.B) error {
 		return fmt.Errorf("test not found: %s", conf.name)
 	}
 
-	pJit := vm.EnableJit
-	vm.EnableJit = conf.jit
-	pForceJit := vm.ForceJit
-	vm.ForceJit = conf.precomp
-
 	env := make(map[string]string)
 	env["currentCoinbase"] = test.Env.CurrentCoinbase
 	env["currentDifficulty"] = test.Env.CurrentDifficulty
@@ -98,9 +94,6 @@ func BenchVmTest(p string, conf bconf, b *testing.B) error {
 	for i := 0; i < b.N; i++ {
 		benchVmTest(test, env, b)
 	}
-
-	vm.EnableJit = pJit
-	vm.ForceJit = pForceJit
 
 	return nil
 }
@@ -248,7 +241,7 @@ func RunVm(state *state.StateDB, env, exec map[string]string) ([]byte, vm.Logs, 
 
 	caller := state.GetOrNewStateObject(from)
 
-	vmenv := NewEnvFromMap(state, env, exec)
+	vmenv := NewEnvFromMap(RuleSet{params.MainNetHomesteadBlock}, state, env, exec)
 	vmenv.vmTest = true
 	vmenv.skipTransfer = true
 	vmenv.initial = true


### PR DESCRIPTION
This PR adds functionality to have configurable chains. At the moment the only part that is configurable is the `homestead` param. When a genesis file is loaded using the **deprecated** `--genesis` flag you can add an additional `config` block to the genesis block with the `homesteadBlock` param. The configurations are written on a per genesis block base, which means that each chain, that is identified by it's genesis block, can have its own set of configuration options (as more will be added over time).

This PR deprecates the generic `--genesis` flag and instead adds an additional sub-command: `init /path/to/genesisfile` (`--genesis` will be removed completely in +1 release). This means that the `--genesis` flag can no longer be grouped together with other flags and is now added as a standalone utility function. The `init` command is a destructive action (semi) and shouldn't be able to be accidentally invoked together with other flags.

This PR also adds a new CLI flag: `--targetgaslimit` which allows miners to set the artificial gas floor which is currently set to (and defaults to) `4712388` (i.e. the Homestead default). 

An example json genesis file would like like:

```json
{
                "config":
                                "homesteadBlock": "10"
                },
		"nonce": "0",
		"difficulty": "0x20000",
		"mixhash": "0x00000000000000000000000000000000000000647572616c65787365646c6578",
		"coinbase": "0x0000000000000000000000000000000000000000",
		"timestamp": "0x00",
		"parentHash": "0x0000000000000000000000000000000000000000000000000000000000000000",
		"extraData": "0x",
		"gasLimit": "0x2FEFD8",
		"alloc": {}
	}
```