### PR TITLE
rpc: be less restrictive on the request id

### DIFF
--- a/cmd/utils/jeth.go
+++ b/cmd/utils/jeth.go
@@ -37,7 +37,7 @@ func NewJeth(re *jsre.JSRE, client rpc.Client) *Jeth {
 	return &Jeth{re, client}
 }
 
-func (self *Jeth) err(call otto.FunctionCall, code int, msg string, id *int64) (response otto.Value) {
+func (self *Jeth) err(call otto.FunctionCall, code int, msg string, id interface{}) (response otto.Value) {
 	m := rpc.JSONErrResponse{
 		Version: "2.0",
 		Id:      id,

--- a/rpc/json_test.go
+++ b/rpc/json_test.go
@@ -51,8 +51,8 @@ func TestJSONRequestParsing(t *testing.T) {
 		t.Fatalf("Expected method 'Add' but got '%s'", requests[0].method)
 	}
 
-	if requests[0].id != 1234 {
-		t.Fatalf("Expected id 1234 but got %d", requests[0].id)
+	if id, ok := requests[0].id.(float64); !ok || id != 1234 {
+		t.Fatalf("Expected id 1234 but got %v", requests[0].id)
 	}
 
 	var arg int

--- a/rpc/server_test.go
+++ b/rpc/server_test.go
@@ -109,7 +109,7 @@ func (c *ServerTestCodec) ReadRequestHeaders() ([]rpcRequest, bool, RPCError) {
 	if c.counter == 1 {
 		var req JSONRequest
 		json.Unmarshal(c.input, &req)
-		return []rpcRequest{rpcRequest{id: *req.Id, isPubSub: false, service: "test", method: req.Method, params: req.Payload}}, false, nil
+		return []rpcRequest{rpcRequest{id: req.Id, isPubSub: false, service: "test", method: req.Method, params: req.Payload}}, false, nil
 	}
 
 	// requests are executes in parallel, wait a bit before returning an error so that the previous request has time to
@@ -172,15 +172,15 @@ func (c *ServerTestCodec) ParseRequestArguments(argTypes []reflect.Type, payload
 	return argValues, nil
 }
 
-func (c *ServerTestCodec) CreateResponse(id int64, reply interface{}) interface{} {
+func (c *ServerTestCodec) CreateResponse(id interface{}, reply interface{}) interface{} {
 	return &JSONSuccessResponse{Version: jsonRPCVersion, Id: id, Result: reply}
 }
 
-func (c *ServerTestCodec) CreateErrorResponse(id *int64, err RPCError) interface{} {
+func (c *ServerTestCodec) CreateErrorResponse(id interface{}, err RPCError) interface{} {
 	return &JSONErrResponse{Version: jsonRPCVersion, Id: id, Error: JSONError{Code: err.Code(), Message: err.Error()}}
 }
 
-func (c *ServerTestCodec) CreateErrorResponseWithInfo(id *int64, err RPCError, info interface{}) interface{} {
+func (c *ServerTestCodec) CreateErrorResponseWithInfo(id interface{}, err RPCError, info interface{}) interface{} {
 	return &JSONErrResponse{Version: jsonRPCVersion, Id: id,
 		Error: JSONError{Code: err.Code(), Message: err.Error(), Data: info}}
 }

--- a/rpc/types.go
+++ b/rpc/types.go
@@ -57,7 +57,7 @@ type service struct {
 
 // serverRequest is an incoming request
 type serverRequest struct {
-	id            int64
+	id            interface{}
 	svcname       string
 	rcvr          reflect.Value
 	callb         *callback
@@ -86,7 +86,7 @@ type Server struct {
 type rpcRequest struct {
 	service  string
 	method   string
-	id       int64
+	id       interface{}
 	isPubSub bool
 	params   interface{}
 }
@@ -108,11 +108,11 @@ type ServerCodec interface {
 	// Parse request argument to the given types
 	ParseRequestArguments([]reflect.Type, interface{}) ([]reflect.Value, RPCError)
 	// Assemble success response
-	CreateResponse(int64, interface{}) interface{}
+	CreateResponse(interface{}, interface{}) interface{}
 	// Assemble error response
-	CreateErrorResponse(*int64, RPCError) interface{}
+	CreateErrorResponse(interface{}, RPCError) interface{}
 	// Assemble error response with extra information about the error through info
-	CreateErrorResponseWithInfo(id *int64, err RPCError, info interface{}) interface{}
+	CreateErrorResponseWithInfo(id interface{}, err RPCError, info interface{}) interface{}
 	// Create notification response
 	CreateNotification(string, interface{}) interface{}
 	// Write msg to client.

--- a/rpc/utils.go
+++ b/rpc/utils.go
@@ -218,7 +218,7 @@ func newSubscriptionId() (string, error) {
 // on which the given client connects.
 func SupportedModules(client Client) (map[string]string, error) {
 	req := JSONRequest{
-		Id:      new(int64),
+		Id:      []byte("1"),
 		Version: "2.0",
 		Method:  "rpc_modules",
 	}


### PR DESCRIPTION
The new RPC implementation only allows integers as request id which is a bit too restricted. This PR complies with the JSON-RPC standard and allows integers, strings and `null` to be used as request id's.

Closes: https://github.com/ethereum/go-ethereum/issues/2270