### PR TITLE
eth/downloader: fix a throughput estimation data race

### DIFF
--- a/eth/downloader/peer.go
+++ b/eth/downloader/peer.go
@@ -251,8 +251,8 @@ func (p *peer) setIdle(started time.Time, delivered int, throughput *float64, id
 	// Irrelevant of the scaling, make sure the peer ends up idle
 	defer atomic.StoreInt32(idle, 0)
 
-	p.lock.RLock()
-	defer p.lock.RUnlock()
+	p.lock.Lock()
+	defer p.lock.Unlock()
 
 	// If nothing was delivered (hard timeout / unavailable data), reduce throughput to minimum
 	if delivered == 0 {


### PR DESCRIPTION
When the downloader was estimating the throughput of a peer and updating its value, we accidentally only locked the peer's mutex for reading, not writing. Interestingly this data race doesn't get hit by the current code, only surfaced by the concurrent headers.