### PR TITLE
core: cache fresh headers and tds to avoid db trashing

### DIFF
--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -368,7 +368,7 @@ func (bc *BlockChain) ResetWithGenesisBlock(genesis *types.Block) {
 	defer bc.mu.Unlock()
 
 	// Prepare the genesis block and reinitialise the chain
-	if err := WriteTd(bc.chainDb, genesis.Hash(), genesis.Difficulty()); err != nil {
+	if err := bc.hc.WriteTd(genesis.Hash(), genesis.Difficulty()); err != nil {
 		glog.Fatalf("failed to write genesis block TD: %v", err)
 	}
 	if err := WriteBlock(bc.chainDb, genesis); err != nil {
@@ -788,7 +788,7 @@ func (self *BlockChain) WriteBlock(block *types.Block) (status WriteStatus, err 
 		status = SideStatTy
 	}
 	// Irrelevant of the canonical status, write the block itself to the database
-	if err := WriteTd(self.chainDb, block.Hash(), externTd); err != nil {
+	if err := self.hc.WriteTd(block.Hash(), externTd); err != nil {
 		glog.Fatalf("failed to write block total difficulty: %v", err)
 	}
 	if err := WriteBlock(self.chainDb, block); err != nil {


### PR DESCRIPTION
The header chain PR had a slight unfortunate side effect that nobody really realized: moving the mutex locking out of the `writeHeader` method, it actually encapsulated the parent check too inside the critical section. The parent check entailed going down to the database and checking whether the parent's TD exists. This single aspect resulted in a 30% performance hit for fast sync because writing out receipts couldn't commence either as the chain was locked and waiting for database reads.

This PR does a few performance fixes:

 * Whenever we write out a TD to the database, we also immediately insert it into the local `tdCache`. This ensures that inserting consecutive headers will not need to wait for database accesses all the time.
 * Similarly whenever we write a header, we also immediately cache it. This doesn't have too big of a performance impact as the header insertion code is smarter than this and does parent checks outside within the batch, not one by one. However it does probably save a few database reads between batches and also when inserting receipts for fresh headers.
 * The `writeHeader` method did an awful lot of header hashing, 4 times the header being inserted and a few times other headers, for which we already knew the hash anyway. I've updated the code to limit the amount of computations we waste on hashing.
 * Lastly I've also cached the hash of the head header into the HeaderChain. This is again useful when adding new headers on top, as we always need the hash of the previous one, and there's no need to recalculate it when we've just inserted it and know perfectly well what it is.

This PR manages to bring the fast sync performance back to the 10 minute mark, where it originally was before the header chain split.

