### PR TITLE
p2p/nat: fix #2291, NAT discovery did't abort on failure

### DIFF
--- a/p2p/nat/natupnp.go
+++ b/p2p/nat/natupnp.go
@@ -139,6 +139,7 @@ func discoverUPnP() Interface {
 func discover(out chan<- *upnp, target string, matcher func(*goupnp.RootDevice, goupnp.ServiceClient) *upnp) {
 	devs, err := goupnp.DiscoverDevices(target)
 	if err != nil {
+		out <- nil
 		return
 	}
 	found := false


### PR DESCRIPTION
This PR fixes a hang in NAT discovery where if the UPnP procedure failed, the discovery goroutine simply returned without notifying the parent of the abortion. This caused the parent to indefinitely hang.