### PR TITLE
core, eth: replace reorganiz with reorganis

### DIFF
--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -775,7 +775,7 @@ func (self *BlockChain) WriteBlock(block *types.Block) (status WriteStatus, err 
 	// Second clause in the if statement reduces the vulnerability to selfish mining.
 	// Please refer to http://www.cs.cornell.edu/~ie53/publications/btcProcFC.pdf
 	if externTd.Cmp(localTd) > 0 || (externTd.Cmp(localTd) == 0 && mrand.Float64() < 0.5) {
-		// Reorganize the chain if the parent is not the head block
+		// Reorganise the chain if the parent is not the head block
 		if block.ParentHash() != self.currentBlock.Hash() {
 			if err := self.reorg(self.currentBlock, block); err != nil {
 				return NonStatTy, err

--- a/core/blockchain_test.go
+++ b/core/blockchain_test.go
@@ -168,7 +168,7 @@ func testHeaderChainImport(chain []*types.Header, blockchain *BlockChain) error 
 		if err := blockchain.Validator().ValidateHeader(header, blockchain.GetHeader(header.ParentHash), false); err != nil {
 			return err
 		}
-		// Manually insert the header into the database, but don't reorganize (allows subsequent testing)
+		// Manually insert the header into the database, but don't reorganise (allows subsequent testing)
 		blockchain.mu.Lock()
 		WriteTd(blockchain.chainDb, header.Hash(), new(big.Int).Add(header.Difficulty, blockchain.GetTd(header.ParentHash)))
 		WriteHeader(blockchain.chainDb, header)
@@ -491,7 +491,7 @@ func chm(genesis *types.Block, db ethdb.Database) *BlockChain {
 	return bc
 }
 
-// Tests that reorganizing a long difficult chain after a short easy one
+// Tests that reorganising a long difficult chain after a short easy one
 // overwrites the canonical numbers and links in the database.
 func TestReorgLongHeaders(t *testing.T) { testReorgLong(t, false) }
 func TestReorgLongBlocks(t *testing.T)  { testReorgLong(t, true) }
@@ -500,7 +500,7 @@ func testReorgLong(t *testing.T, full bool) {
 	testReorg(t, []int{1, 2, 4}, []int{1, 2, 3, 4}, 10, full)
 }
 
-// Tests that reorganizing a short difficult chain after a long easy one
+// Tests that reorganising a short difficult chain after a long easy one
 // overwrites the canonical numbers and links in the database.
 func TestReorgShortHeaders(t *testing.T) { testReorgShort(t, false) }
 func TestReorgShortBlocks(t *testing.T)  { testReorgShort(t, true) }
@@ -858,7 +858,7 @@ func TestLightVsFastVsFullChainHeads(t *testing.T) {
 	assert(t, "light", light, height/2, 0, 0)
 }
 
-// Tests that chain reorganizations handle transaction removals and reinsertions.
+// Tests that chain reorganisations handle transaction removals and reinsertions.
 func TestChainTxReorgs(t *testing.T) {
 	params.MinGasLimit = big.NewInt(125000)      // Minimum the gas limit may ever be.
 	params.GenesisGasLimit = big.NewInt(3141592) // Gas limit of the Genesis block.

--- a/core/tx_pool_test.go
+++ b/core/tx_pool_test.go
@@ -366,7 +366,7 @@ func TestTransactionPostponing(t *testing.T) {
 	if len(pool.queue[account]) != 0 {
 		t.Errorf("queued transaction mismatch: have %d, want %d", len(pool.queue), 0)
 	}
-	// Reduce the balance of the account, and check that transactions are reorganized
+	// Reduce the balance of the account, and check that transactions are reorganised
 	state.AddBalance(account, big.NewInt(-750))
 	pool.resetState()
 

--- a/eth/downloader/downloader.go
+++ b/eth/downloader/downloader.go
@@ -534,7 +534,7 @@ func (d *Downloader) fetchHeight61(p *peer) (uint64, error) {
 // findAncestor61 tries to locate the common ancestor block of the local chain and
 // a remote peers blockchain. In the general case when our node was in sync and
 // on the correct chain, checking the top N blocks should already get us a match.
-// In the rare scenario when we ended up on a long reorganization (i.e. none of
+// In the rare scenario when we ended up on a long reorganisation (i.e. none of
 // the head blocks match), we do a binary search to find the common ancestor.
 func (d *Downloader) findAncestor61(p *peer) (uint64, error) {
 	glog.V(logger.Debug).Infof("%v: looking for common ancestor", p)
@@ -960,7 +960,7 @@ func (d *Downloader) fetchHeight(p *peer) (uint64, error) {
 // findAncestor tries to locate the common ancestor link of the local chain and
 // a remote peers blockchain. In the general case when our node was in sync and
 // on the correct chain, checking the top N links should already get us a match.
-// In the rare scenario when we ended up on a long reorganization (i.e. none of
+// In the rare scenario when we ended up on a long reorganisation (i.e. none of
 // the head links match), we do a binary search to find the common ancestor.
 func (d *Downloader) findAncestor(p *peer) (uint64, error) {
 	glog.V(logger.Debug).Infof("%v: looking for common ancestor", p)


### PR DESCRIPTION
Rational: "reorganiz" is more common than "reorganis" in core

grep -r reorganiz core | wc -l
       6
grep -r reorganis core | wc -l
       4

"reorganization" also appears twice in eth/downloader/downloader.go, but "reorganis" appears nowhere but in core