### PR TITLE
eth: various typos

### DIFF
--- a/eth/api.go
+++ b/eth/api.go
@@ -51,7 +51,7 @@ const defaultGas = uint64(90000)
 
 // blockByNumber is a commonly used helper function which retrieves and returns
 // the block for the given block number, capable of handling two special blocks:
-// rpc.LatestBlockNumber adn rpc.PendingBlockNumber. It returns nil when no block
+// rpc.LatestBlockNumber and rpc.PendingBlockNumber. It returns nil when no block
 // could be found.
 func blockByNumber(m *miner.Miner, bc *core.BlockChain, blockNr rpc.BlockNumber) *types.Block {
 	// Pending block is only known by the miner
@@ -67,7 +67,7 @@ func blockByNumber(m *miner.Miner, bc *core.BlockChain, blockNr rpc.BlockNumber)
 
 // stateAndBlockByNumber is a commonly used helper function which retrieves and
 // returns the state and containing block for the given block number, capable of
-// handling two special states: rpc.LatestBlockNumber adn rpc.PendingBlockNumber.
+// handling two special states: rpc.LatestBlockNumber and rpc.PendingBlockNumber.
 // It returns nil when no block or state could be found.
 func stateAndBlockByNumber(m *miner.Miner, bc *core.BlockChain, blockNr rpc.BlockNumber, chainDb ethdb.Database) (*state.StateDB, *types.Block, error) {
 	// Pending state is only known by the miner
@@ -90,7 +90,7 @@ type PublicEthereumAPI struct {
 	gpo *GasPriceOracle
 }
 
-// NewPublicEthereumAPI creates a new Etheruem protocol API.
+// NewPublicEthereumAPI creates a new Ethereum protocol API.
 func NewPublicEthereumAPI(e *Ethereum) *PublicEthereumAPI {
 	return &PublicEthereumAPI{e, NewGasPriceOracle(e)}
 }
@@ -148,7 +148,7 @@ func (s *PublicEthereumAPI) Hashrate() *rpc.HexNumber {
 	return rpc.NewHexNumber(s.e.Miner().HashRate())
 }
 
-// Syncing returns false in case the node is currently not synching with the network. It can be up to date or has not
+// Syncing returns false in case the node is currently not syncing with the network. It can be up to date or has not
 // yet received the latest block headers from its pears. In case it is synchronizing:
 // - startingBlock: block number this node started to synchronise from
 // - currentBlock:  block number this node is currently importing
@@ -600,7 +600,7 @@ func (s *PublicBlockChainAPI) GetStorageAt(address common.Address, key string, b
 	return state.GetState(address, common.HexToHash(key)).Hex(), nil
 }
 
-// callmsg is the message type used for call transations.
+// callmsg is the message type used for call transactions.
 type callmsg struct {
 	from          *state.StateObject
 	to            *common.Address
@@ -678,7 +678,7 @@ func (s *PublicBlockChainAPI) doCall(args CallArgs, blockNr rpc.BlockNumber) (st
 }
 
 // Call executes the given transaction on the state for the given block number.
-// It doesn't make and changes in the state/blockchain and is usefull to execute and retrieve values.
+// It doesn't make and changes in the state/blockchain and is useful to execute and retrieve values.
 func (s *PublicBlockChainAPI) Call(args CallArgs, blockNr rpc.BlockNumber) (string, error) {
 	result, _, err := s.doCall(args, blockNr)
 	return result, err
@@ -1545,7 +1545,7 @@ func (api *PrivateDebugAPI) SetHead(number uint64) {
 	api.eth.BlockChain().SetHead(number)
 }
 
-// StructLogRes stores a structured log emitted by the evm while replaying a
+// StructLogRes stores a structured log emitted by the EVM while replaying a
 // transaction in debug mode
 type structLogRes struct {
 	Pc      uint64            `json:"pc"`
@@ -1558,7 +1558,7 @@ type structLogRes struct {
 	Storage map[string]string `json:"storage"`
 }
 
-// TransactionExecutionRes groups all structured logs emitted by the evm
+// TransactionExecutionRes groups all structured logs emitted by the EVM
 // while replaying a transaction in debug mode as well as the amount of
 // gas used and the return value
 type TransactionExecutionResult struct {
@@ -1614,7 +1614,7 @@ func (s *PrivateDebugAPI) doReplayTransaction(txHash common.Hash) ([]vm.StructLo
 	return vmenv.StructLogs(), ret, gas, nil
 }
 
-// Executes a transaction and returns the structured logs of the evm
+// Executes a transaction and returns the structured logs of the EVM
 // gathered during the execution
 func (s *PrivateDebugAPI) ReplayTransaction(txHash common.Hash, stackDepth int, memorySize int, storageSize int) (*TransactionExecutionResult, error) {
 
@@ -1690,7 +1690,7 @@ type PublicNetAPI struct {
 	networkVersion int
 }
 
-// NewPublicNetAPI creates a new net api instance.
+// NewPublicNetAPI creates a new net API instance.
 func NewPublicNetAPI(net *p2p.Server, networkVersion int) *PublicNetAPI {
 	return &PublicNetAPI{net, networkVersion}
 }

--- a/eth/downloader/api.go
+++ b/eth/downloader/api.go
@@ -20,7 +20,7 @@ import (
 	"github.com/ethereum/go-ethereum/rpc"
 )
 
-// PublicDownloaderAPI provides an API which gives informatoin about the current synchronisation status.
+// PublicDownloaderAPI provides an API which gives information about the current synchronisation status.
 // It offers only methods that operates on data that can be available to anyone without security risks.
 type PublicDownloaderAPI struct {
 	d *Downloader

--- a/eth/downloader/downloader.go
+++ b/eth/downloader/downloader.go
@@ -197,7 +197,7 @@ func New(stateDb ethdb.Database, mux *event.TypeMux, hasHeader headerCheckFn, ha
 // block where synchronisation started at (may have failed/suspended); the block
 // or header sync is currently at; and the latest known block which the sync targets.
 //
-// In addition, during the state download phase of fast synchonisation the number
+// In addition, during the state download phase of fast synchronisation the number
 // of processed and the total number of known states are also returned. Otherwise
 // these are zero.
 func (d *Downloader) Progress() (uint64, uint64, uint64, uint64, uint64) {
@@ -280,7 +280,7 @@ func (d *Downloader) Synchronise(id string, head common.Hash, td *big.Int, mode 
 // it will use the best peer possible and synchronize if it's TD is higher than our own. If any of the
 // checks fail an error will be returned. This method is synchronous
 func (d *Downloader) synchronise(id string, hash common.Hash, td *big.Int, mode SyncMode) error {
-	// Mock out the synchonisation if testing
+	// Mock out the synchronisation if testing
 	if d.synchroniseMock != nil {
 		return d.synchroniseMock(id, hash)
 	}
@@ -709,7 +709,7 @@ func (d *Downloader) fetchHashes61(p *peer, td *big.Int, from uint64) error {
 				}
 				// If no hashes were retrieved at all, the peer violated it's TD promise that it had a
 				// better chain compared to ours. The only exception is if it's promised blocks were
-				// already imported by other means (e.g. fecher):
+				// already imported by other means (e.g. fetcher):
 				//
 				// R <remote peer>, L <local node>: Both at block 10
 				// R: Mine block 11, and propagate it to L
@@ -1180,7 +1180,7 @@ func (d *Downloader) fetchHeaders(p *peer, td *big.Int, from uint64) error {
 				}
 				// If no headers were retrieved at all, the peer violated it's TD promise that it had a
 				// better chain compared to ours. The only exception is if it's promised blocks were
-				// already imported by other means (e.g. fecher):
+				// already imported by other means (e.g. fetcher):
 				//
 				// R <remote peer>, L <local node>: Both at block 10
 				// R: Mine block 11, and propagate it to L
@@ -1621,7 +1621,7 @@ func (d *Downloader) DeliverBlocks(id string, blocks []*types.Block) (err error)
 	return d.deliver(id, d.blockCh, &blockPack{id, blocks}, blockInMeter, blockDropMeter)
 }
 
-// DeliverHeaders injects a new batch of blck headers received from a remote
+// DeliverHeaders injects a new batch of block headers received from a remote
 // node into the download schedule.
 func (d *Downloader) DeliverHeaders(id string, headers []*types.Header) (err error) {
 	return d.deliver(id, d.headerCh, &headerPack{id, headers}, headerInMeter, headerDropMeter)

--- a/eth/downloader/downloader_test.go
+++ b/eth/downloader/downloader_test.go
@@ -277,7 +277,7 @@ func (dl *downloadTester) insertHeaders(headers []*types.Header, checkFreq int) 
 	dl.lock.Lock()
 	defer dl.lock.Unlock()
 
-	// Do a quick check, as the blockchain.InsertHeaderChain doesn't insert anthing in case of errors
+	// Do a quick check, as the blockchain.InsertHeaderChain doesn't insert anything in case of errors
 	if _, ok := dl.ownHeaders[headers[0].ParentHash]; !ok {
 		return 0, errors.New("unknown parent")
 	}
@@ -958,7 +958,7 @@ func testMultiSynchronisation(t *testing.T, protocol int, mode SyncMode) {
 }
 
 // Tests that synchronisations behave well in multi-version protocol environments
-// and not wreak havok on other nodes in the network.
+// and not wreak havoc on other nodes in the network.
 func TestMultiProtoSynchronisation61(t *testing.T)      { testMultiProtoSync(t, 61, FullSync) }
 func TestMultiProtoSynchronisation62(t *testing.T)      { testMultiProtoSync(t, 62, FullSync) }
 func TestMultiProtoSynchronisation63Full(t *testing.T)  { testMultiProtoSync(t, 63, FullSync) }
@@ -1188,7 +1188,7 @@ func testInvalidHeaderRollback(t *testing.T, protocol int, mode SyncMode) {
 	// Synchronise with the valid peer and make sure sync succeeds. Since the last
 	// rollback should also disable fast syncing for this process, verify that we
 	// did a fresh full sync. Note, we can't assert anything about the receipts
-	// since we won't purge the database of them, hence we can't use asserOwnChain.
+	// since we won't purge the database of them, hence we can't use assertOwnChain.
 	tester.newPeer("valid", protocol, hashes, headers, blocks, receipts)
 	if err := tester.sync("valid", nil, mode); err != nil {
 		t.Fatalf("failed to synchronise blocks: %v", err)

--- a/eth/downloader/queue.go
+++ b/eth/downloader/queue.go
@@ -976,7 +976,7 @@ func (q *queue) DeliverNodeData(id string, data [][]byte, callback func(error, i
 	accepted, errs := 0, make([]error, 0)
 	process := []trie.SyncResult{}
 	for _, blob := range data {
-		// Skip any state trie entires that were not requested
+		// Skip any state trie entries that were not requested
 		hash := common.BytesToHash(crypto.Keccak256(blob))
 		if _, ok := request.Hashes[hash]; !ok {
 			errs = append(errs, fmt.Errorf("non-requested state data %x", hash))

--- a/eth/fetcher/fetcher.go
+++ b/eth/fetcher/fetcher.go
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
 
-// Package fetcher contains the block announcement based synchonisation.
+// Package fetcher contains the block announcement based synchronisation.
 package fetcher
 
 import (
@@ -34,7 +34,7 @@ import (
 const (
 	arriveTimeout = 500 * time.Millisecond // Time allowance before an announced block is explicitly requested
 	gatherSlack   = 100 * time.Millisecond // Interval used to collate almost-expired announces with fetches
-	fetchTimeout  = 5 * time.Second        // Maximum alloted time to return an explicitly requested block
+	fetchTimeout  = 5 * time.Second        // Maximum allotted time to return an explicitly requested block
 	maxUncleDist  = 7                      // Maximum allowed backward distance from the chain head
 	maxQueueDist  = 32                     // Maximum allowed distance from the chain head to queue
 	hashLimit     = 256                    // Maximum number of unique blocks a peer may have announced
@@ -176,7 +176,7 @@ func New(getBlock blockRetrievalFn, validateBlock blockValidatorFn, broadcastBlo
 	}
 }
 
-// Start boots up the announcement based synchoniser, accepting and processing
+// Start boots up the announcement based synchroniser, accepting and processing
 // hash notifications and block fetches until termination requested.
 func (f *Fetcher) Start() {
 	go f.loop()

--- a/eth/filters/api.go
+++ b/eth/filters/api.go
@@ -47,7 +47,7 @@ const (
 	logFilterTy
 )
 
-// PublicFilterAPI offers support to create and manage filters. This will allow externa clients to retrieve various
+// PublicFilterAPI offers support to create and manage filters. This will allow external clients to retrieve various
 // information related to the Ethereum protocol such als blocks, transactions and logs.
 type PublicFilterAPI struct {
 	mux *event.TypeMux

--- a/eth/filters/filter_system_test.go
+++ b/eth/filters/filter_system_test.go
@@ -96,6 +96,6 @@ func TestCallbacks(t *testing.T) {
 	select {
 	case <-pendingLogDone:
 	case <-failTimer.C:
-		t.Error("pending log filter failed to trigger (timout)")
+		t.Error("pending log filter failed to trigger (timeout)")
 	}
 }

--- a/eth/handler.go
+++ b/eth/handler.go
@@ -590,7 +590,7 @@ func (pm *ProtocolManager) handleMsg(p *peer) error {
 		}
 
 	case msg.Code == NewBlockHashesMsg:
-		// Retrieve and deseralize the remote new block hashes notification
+		// Retrieve and deserialize the remote new block hashes notification
 		type announce struct {
 			Hash   common.Hash
 			Number uint64

--- a/eth/handler_test.go
+++ b/eth/handler_test.go
@@ -427,7 +427,7 @@ func testGetNodeData(t *testing.T, protocol int) {
 	acc1Addr := crypto.PubkeyToAddress(acc1Key.PublicKey)
 	acc2Addr := crypto.PubkeyToAddress(acc2Key.PublicKey)
 
-	// Create a chain generator with some simple transactions (blatantly stolen from @fjl/chain_makerts_test)
+	// Create a chain generator with some simple transactions (blatantly stolen from @fjl/chain_markets_test)
 	generator := func(i int, block *core.BlockGen) {
 		switch i {
 		case 0:
@@ -518,7 +518,7 @@ func testGetReceipt(t *testing.T, protocol int) {
 	acc1Addr := crypto.PubkeyToAddress(acc1Key.PublicKey)
 	acc2Addr := crypto.PubkeyToAddress(acc2Key.PublicKey)
 
-	// Create a chain generator with some simple transactions (blatantly stolen from @fjl/chain_makerts_test)
+	// Create a chain generator with some simple transactions (blatantly stolen from @fjl/chain_markets_test)
 	generator := func(i int, block *core.BlockGen) {
 		switch i {
 		case 0:

--- a/eth/metrics.go
+++ b/eth/metrics.go
@@ -72,7 +72,7 @@ type meteredMsgReadWriter struct {
 }
 
 // newMeteredMsgWriter wraps a p2p MsgReadWriter with metering support. If the
-// metrics system is disabled, this fucntion returns the original object.
+// metrics system is disabled, this function returns the original object.
 func newMeteredMsgWriter(rw p2p.MsgReadWriter) p2p.MsgReadWriter {
 	if !metrics.Enabled {
 		return rw


### PR DESCRIPTION
Went through all .go files in eth/ using aspell in ccpp mode.