### PR TITLE
Build a lightweight docker image

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@
 */**/*dapps*
 Godeps/_workspace/pkg
 Godeps/_workspace/bin
+.idea
 
 #*
 .#*

--- a/docker/Dockerfile-alpine
+++ b/docker/Dockerfile-alpine
@@ -1,0 +1,27 @@
+FROM jeanblanchard/alpine-glibc
+MAINTAINER Jim Alateras <jima@comware.com.au>
+
+ENV APP_HOME /app
+ENV APP_USER ethereum
+ENV APP_GROUP ethereum
+ENV PATH $APP_HOME:$PATH
+ENV ETHEREUM_BIN=https://github.com/ethereum/go-ethereum/releases/download/v1.3.5/geth-Linux64-20160303152500-1.3.5-34b622a.tar.bz2
+
+RUN \
+  addgroup -S $APP_USER && \
+  adduser -S -s /bin/bash -G $APP_GROUP $APP_USER
+
+RUN \
+  apk add --update bash wget && \
+  mkdir -p $APP_HOME && \
+  cd $APP_HOME && \
+  wget -qO- --no-check-certificate $ETHEREUM_BIN | tar xvjf - && \
+  chown -R $APP_USER:$APP_GROUP $APP_HOME && \
+  rm -rf /var/cache/apk/* /tmp/* /var/tmp/*
+
+EXPOSE 8545
+EXPOSE 30303
+
+USER $APP_USER
+WORKDIR $APP_HOME
+CMD ["./geth"]

--- a/docker/Dockerfile-alpine
+++ b/docker/Dockerfile-alpine
@@ -17,6 +17,7 @@ RUN \
   cd $APP_HOME && \
   wget -qO- --no-check-certificate $ETHEREUM_BIN | tar xvjf - && \
   chown -R $APP_USER:$APP_GROUP $APP_HOME && \
+  apk del --purge wget  && \
   rm -rf /var/cache/apk/* /tmp/* /var/tmp/*
 
 EXPOSE 8545


### PR DESCRIPTION
Add a `dockerfile` that builds an image from an `alpine glibc` base. This produces a 42MB image compared to a 362MB image.

```
jalateras/geth               latest              8a3638d6ad6f        10 minutes ago      42.43 MB
etherium/geth                latest              896c12289096        4 hours ago         362.6 MB
```