### PR TITLE
eth, miner: fetch pending block/state in on go (data race)

### DIFF
--- a/eth/api.go
+++ b/eth/api.go
@@ -56,7 +56,8 @@ const defaultGas = uint64(90000)
 func blockByNumber(m *miner.Miner, bc *core.BlockChain, blockNr rpc.BlockNumber) *types.Block {
 	// Pending block is only known by the miner
 	if blockNr == rpc.PendingBlockNumber {
-		return m.PendingBlock()
+		block, _ := m.Pending()
+		return block
 	}
 	// Otherwise resolve and return the block
 	if blockNr == rpc.LatestBlockNumber {
@@ -72,7 +73,8 @@ func blockByNumber(m *miner.Miner, bc *core.BlockChain, blockNr rpc.BlockNumber)
 func stateAndBlockByNumber(m *miner.Miner, bc *core.BlockChain, blockNr rpc.BlockNumber, chainDb ethdb.Database) (*state.StateDB, *types.Block, error) {
 	// Pending state is only known by the miner
 	if blockNr == rpc.PendingBlockNumber {
-		return m.PendingState(), m.PendingBlock(), nil
+		block, state := m.Pending()
+		return state, block, nil
 	}
 	// Otherwise resolve the block number and return its state
 	block := blockByNumber(m, bc, blockNr)

--- a/miner/miner.go
+++ b/miner/miner.go
@@ -164,12 +164,9 @@ func (self *Miner) SetExtra(extra []byte) error {
 	return nil
 }
 
-func (self *Miner) PendingState() *state.StateDB {
-	return self.worker.pendingState()
-}
-
-func (self *Miner) PendingBlock() *types.Block {
-	return self.worker.pendingBlock()
+// Pending returns the currently pending block and associated state.
+func (self *Miner) Pending() (*types.Block, *state.StateDB) {
+	return self.worker.pending()
 }
 
 func (self *Miner) SetEtherbase(addr common.Address) {

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -152,13 +152,7 @@ func (self *worker) setEtherbase(addr common.Address) {
 	self.coinbase = addr
 }
 
-func (self *worker) pendingState() *state.StateDB {
-	self.currentMu.Lock()
-	defer self.currentMu.Unlock()
-	return self.current.state
-}
-
-func (self *worker) pendingBlock() *types.Block {
+func (self *worker) pending() (*types.Block, *state.StateDB) {
 	self.currentMu.Lock()
 	defer self.currentMu.Unlock()
 
@@ -168,9 +162,9 @@ func (self *worker) pendingBlock() *types.Block {
 			self.current.txs,
 			nil,
 			self.current.receipts,
-		)
+		), self.current.state
 	}
-	return self.current.Block
+	return self.current.Block, self.current.state
 }
 
 func (self *worker) start() {


### PR DESCRIPTION
The miner had two utility methods to retrieve the currently pending stats: `PendingState` and `PendingBlock`. Since certain methods require both of these (e.g. gas estimation), calling them individually introduces a data race whereby the block/state may go out of sync in between calls.

This PR merges the two calls into one, ensuring that retrieving them both are protected by the same mutex.