### PR TITLE
accounts/abi: handle the "constant" modifier for functions

### DIFF
--- a/accounts/abi/abi.go
+++ b/accounts/abi/abi.go
@@ -268,12 +268,12 @@ func set(dst, src reflect.Value, output Argument) error {
 
 func (abi *ABI) UnmarshalJSON(data []byte) error {
 	var fields []struct {
-		Type    string
-		Name    string
-		Const   bool
-		Indexed bool
-		Inputs  []Argument
-		Outputs []Argument
+		Type     string
+		Name     string
+		Constant bool
+		Indexed  bool
+		Inputs   []Argument
+		Outputs  []Argument
 	}
 
 	if err := json.Unmarshal(data, &fields); err != nil {
@@ -288,7 +288,7 @@ func (abi *ABI) UnmarshalJSON(data []byte) error {
 		case "function", "":
 			abi.Methods[field.Name] = Method{
 				Name:    field.Name,
-				Const:   field.Const,
+				Const:   field.Constant,
 				Inputs:  field.Inputs,
 				Outputs: field.Outputs,
 			}

--- a/accounts/abi/method.go
+++ b/accounts/abi/method.go
@@ -67,8 +67,11 @@ func (m Method) String() string {
 		}
 		outputs[i] += output.Type.String()
 	}
-
-	return fmt.Sprintf("function %v(%v) returns(%v)", m.Name, strings.Join(inputs, ", "), strings.Join(outputs, ", "))
+	constant := ""
+	if m.Const {
+		constant = "constant "
+	}
+	return fmt.Sprintf("function %v(%v) %sreturns(%v)", m.Name, strings.Join(inputs, ", "), constant, strings.Join(outputs, ", "))
 }
 
 func (m Method) Id() []byte {


### PR DESCRIPTION
The ABI field for a constant function is `constant`, which the JSON parser filed to unmarshal since the struct field was named `Const`. This PR renames the field and also adds it to `Stringer`.