### PR TITLE
Convert direct references to the BlockChain implementation to interfaces to facilitate reuse

### DIFF
--- a/core/state_processor.go
+++ b/core/state_processor.go
@@ -17,10 +17,10 @@ var (
 )
 
 type StateProcessor struct {
-	bc *BlockChain
+	bc blockGetter
 }
 
-func NewStateProcessor(bc *BlockChain) *StateProcessor {
+func NewStateProcessor(bc blockGetter) *StateProcessor {
 	return &StateProcessor{bc}
 }
 
@@ -60,7 +60,7 @@ func (p *StateProcessor) Process(block *types.Block, statedb *state.StateDB) (ty
 //
 // ApplyTransactions returns the generated receipts and vm logs during the
 // execution of the state transition phase.
-func ApplyTransaction(bc *BlockChain, gp *GasPool, statedb *state.StateDB, header *types.Header, tx *types.Transaction, usedGas *big.Int) (*types.Receipt, vm.Logs, *big.Int, error) {
+func ApplyTransaction(bc blockGetter, gp *GasPool, statedb *state.StateDB, header *types.Header, tx *types.Transaction, usedGas *big.Int) (*types.Receipt, vm.Logs, *big.Int, error) {
 	_, gas, err := ApplyMessage(NewEnv(statedb, bc, tx, header), tx, gp)
 	if err != nil {
 		return nil, nil, nil, err

--- a/core/vm_env.go
+++ b/core/vm_env.go
@@ -25,10 +25,14 @@ import (
 	"github.com/ethereum/go-ethereum/core/vm"
 )
 
+type blockGetter interface {
+	GetBlock(common.Hash) *types.Block
+}
+
 // GetHashFn returns a function for which the VM env can query block hashes through
 // up to the limit defined by the Yellow Paper and uses the given block chain
 // to query for information.
-func GetHashFn(ref common.Hash, chain *BlockChain) func(n uint64) common.Hash {
+func GetHashFn(ref common.Hash, chain blockGetter) func(n uint64) common.Hash {
 	return func(n uint64) common.Hash {
 		for block := chain.GetBlock(ref); block != nil; block = chain.GetBlock(block.ParentHash()) {
 			if block.NumberU64() == n {
@@ -45,7 +49,7 @@ type VMEnv struct {
 	header *types.Header
 	msg    Message
 	depth  int
-	chain  *BlockChain
+	chain  blockGetter
 	typ    vm.Type
 
 	getHashFn func(uint64) common.Hash
@@ -53,7 +57,7 @@ type VMEnv struct {
 	logs []vm.StructLog
 }
 
-func NewEnv(state *state.StateDB, chain *BlockChain, msg Message, header *types.Header) *VMEnv {
+func NewEnv(state *state.StateDB, chain blockGetter, msg Message, header *types.Header) *VMEnv {
 	return &VMEnv{
 		chain:     chain,
 		state:     state,

--- a/eth/handler.go
+++ b/eth/handler.go
@@ -60,7 +60,7 @@ type ProtocolManager struct {
 
 	fastSync   bool
 	txpool     txPool
-	blockchain *core.BlockChain
+	blockchain blockChain
 	chaindb    ethdb.Database
 
 	downloader *downloader.Downloader
@@ -86,7 +86,7 @@ type ProtocolManager struct {
 
 // NewProtocolManager returns a new ethereum sub protocol manager. The Ethereum sub protocol manages peers capable
 // with the ethereum network.
-func NewProtocolManager(fastSync bool, networkId int, mux *event.TypeMux, txpool txPool, pow pow.PoW, blockchain *core.BlockChain, chaindb ethdb.Database) (*ProtocolManager, error) {
+func NewProtocolManager(fastSync bool, networkId int, mux *event.TypeMux, txpool txPool, pow pow.PoW, blockchain blockChain, chaindb ethdb.Database) (*ProtocolManager, error) {
 	// Figure out whether to allow fast sync or not
 	if fastSync && blockchain.CurrentBlock().NumberU64() > 0 {
 		glog.V(logger.Info).Infof("blockchain not empty, fast sync disabled")

--- a/eth/protocol.go
+++ b/eth/protocol.go
@@ -123,6 +123,30 @@ type chainManager interface {
 	Status() (td *big.Int, currentBlock common.Hash, genesisBlock common.Hash)
 }
 
+// proxy interface to core.BlockChain
+type blockChain interface {
+	Status() (td *big.Int, currentBlock common.Hash, genesisBlock common.Hash)
+	Genesis() *types.Block
+	CurrentHeader() *types.Header
+	CurrentBlock() *types.Block
+	CurrentFastBlock() *types.Block
+	HasHeader(hash common.Hash) bool
+	HasBlock(hash common.Hash) bool
+	HasBlockAndState(hash common.Hash) bool
+	GetHeader(hash common.Hash) *types.Header
+	GetHeaderByNumber(number uint64) *types.Header
+	GetBlock(hash common.Hash) *types.Block
+	GetBlockByNumber(number uint64) *types.Block
+	GetBlockHashesFromHash(hash common.Hash, max uint64) []common.Hash
+	GetBodyRLP(hash common.Hash) rlp.RawValue
+	FastSyncCommitHead(hash common.Hash) error
+	GetTd(hash common.Hash) *big.Int
+	InsertHeaderChain(chain []*types.Header, checkFreq int) (int, error)
+	InsertChain(chain types.Blocks) (int, error)
+	InsertReceiptChain(blockChain types.Blocks, receiptChain []types.Receipts) (int, error)
+	Rollback(chain []common.Hash)
+}
+
 // statusData is the network packet for the status message.
 type statusData struct {
 	ProtocolVersion uint32


### PR DESCRIPTION
A lot of what's in core can be reused fairly easily as a library. The ProtocolManager can stand on its own as well as the VM code and state processing. However those structs tend to have direct references the the BlockChain struct making it impossible to tease them apart.

This pull request introduces a couple interfaces for people who would want to reuse some of those pieces without bringing the full BlockChain implementation. It also makes validation usable directly by allowing direct calling to VerifyUncles, staying consistent with ValidateHeader.