### PR TITLE
Strip extraneous carriage return from end of entered password

### DIFF
--- a/cmd/utils/cmd.go
+++ b/cmd/utils/cmd.go
@@ -91,6 +91,7 @@ func PromptPassword(prompt string, warnTerm bool) (string, error) {
 	}
 	fmt.Print(prompt)
 	input, err := bufio.NewReader(os.Stdin).ReadString('\n')
+	input = strings.TrimRight(input, "\n")
 	fmt.Println()
 	return input, err
 }


### PR DESCRIPTION
Current users of the Mist wallet on OS X are [unable to import their presale wallets](https://github.com/ethereum/mist/issues/182). This is due to the fallback terminal password input mechanism failing to strip off the carriage return at the end of the input. I confirmed that this is a bug within geth itself.

This PR fixes this issue.