### PR TITLE
Strip extraneous carriage return from end of entered password

### DIFF
--- a/cmd/utils/cmd.go
+++ b/cmd/utils/cmd.go
@@ -92,6 +92,7 @@ func PromptPassword(prompt string, warnTerm bool) (string, error) {
 	}
 	fmt.Print(prompt)
 	input, err := bufio.NewReader(os.Stdin).ReadString('\n')
+	input = strings.TrimRight(input, "\r\n")
 	fmt.Println()
 	return input, err
 }


### PR DESCRIPTION
This is a repeat of #2369 but against the `develop` branch.

The fix has been tested to work on OS X, Ubuntu and Windows.