### PR TITLE
abi: support for input and output slices & removed support for implicit type conversion

### DIFF
--- a/accounts/abi/abi.go
+++ b/accounts/abi/abi.go
@@ -20,6 +20,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"math/big"
 	"reflect"
 	"strings"
 
@@ -116,11 +117,80 @@ func (abi ABI) Pack(name string, args ...interface{}) ([]byte, error) {
 	return append(method.Id(), arguments...), nil
 }
 
+// toGoSliceType prses the input and casts it to the proper slice defined by the ABI
+// argument in T.
+func toGoSlice(i int, t Argument, output []byte) (interface{}, error) {
+	index := i * 32
+	// The slice must, at very least be large enough for the index+32 which is exactly the size required
+	// for the [offset in output, size of offset].
+	if index+32 > len(output) {
+		return nil, fmt.Errorf("abi: cannot marshal in to go slice: insufficient size output %d require %d", len(output), index+32)
+	}
+
+	// first we need to create a slice of the type
+	var refSlice reflect.Value
+	switch t.Type.T {
+	case IntTy, UintTy, BoolTy: // int, uint, bool can all be of type big int.
+		refSlice = reflect.ValueOf([]*big.Int(nil))
+	case AddressTy: // address must be of slice Address
+		refSlice = reflect.ValueOf([]common.Address(nil))
+	case HashTy: // hash must be of slice hash
+		refSlice = reflect.ValueOf([]common.Hash(nil))
+	default: // no other types are supported
+		return nil, fmt.Errorf("abi: unsupported slice type %v", t.Type.T)
+	}
+	// get the offset which determines the start of this array ...
+	offset := int(common.BytesToBig(output[index : index+32]).Uint64())
+	if offset+32 > len(output) {
+		return nil, fmt.Errorf("abi: cannot marshal in to go slice: offset %d would go over slice boundary (len=%d)", len(output), offset+32)
+	}
+
+	slice := output[offset:]
+	// ... starting with the size of the array in elements ...
+	size := int(common.BytesToBig(slice[:32]).Uint64())
+	slice = slice[32:]
+	// ... and make sure that we've at the very least the amount of bytes
+	// available in the buffer.
+	if size*32 > len(slice) {
+		return nil, fmt.Errorf("abi: cannot marshal in to go slice: insufficient size output %d require %d", len(output), offset+32+size*32)
+	}
+
+	// reslice to match the required size
+	slice = slice[:(size * 32)]
+	for i := 0; i < size; i++ {
+		var (
+			inter        interface{}             // interface type
+			returnOutput = slice[i*32 : i*32+32] // the return output
+		)
+
+		// set inter to the correct type (cast)
+		switch t.Type.T {
+		case IntTy, UintTy:
+			inter = common.BytesToBig(returnOutput)
+		case BoolTy:
+			inter = common.BytesToBig(returnOutput).Uint64() > 0
+		case AddressTy:
+			inter = common.BytesToAddress(returnOutput)
+		case HashTy:
+			inter = common.BytesToHash(returnOutput)
+		}
+		// append the item to our reflect slice
+		refSlice = reflect.Append(refSlice, reflect.ValueOf(inter))
+	}
+
+	// return the interface
+	return refSlice.Interface(), nil
+}
+
 // toGoType parses the input and casts it to the proper type defined by the ABI
 // argument in T.
 func toGoType(i int, t Argument, output []byte) (interface{}, error) {
-	index := i * 32
+	// we need to treat slices differently
+	if t.Type.Kind == reflect.Slice {
+		return toGoSlice(i, t, output)
+	}
 
+	index := i * 32
 	if index+32 > len(output) {
 		return nil, fmt.Errorf("abi: cannot marshal in to go type: length insufficient %d require %d", len(output), index+32)
 	}

--- a/accounts/abi/abi.go
+++ b/accounts/abi/abi.go
@@ -63,9 +63,8 @@ func (abi ABI) pack(method Method, args ...interface{}) ([]byte, error) {
 			return nil, fmt.Errorf("`%s` %v", method.Name, err)
 		}
 
-		// check for a string or bytes input type
-		switch input.Type.T {
-		case StringTy, BytesTy:
+		// check for a slice type (string, bytes, slice)
+		if input.Type.T == StringTy || input.Type.T == BytesTy || input.Type.IsSlice {
 			// calculate the offset
 			offset := len(method.Inputs)*32 + len(variableInput)
 			// set the offset
@@ -73,7 +72,7 @@ func (abi ABI) pack(method Method, args ...interface{}) ([]byte, error) {
 			// Append the packed output to the variable input. The variable input
 			// will be appended at the end of the input.
 			variableInput = append(variableInput, packed...)
-		default:
+		} else {
 			// append the packed value to the input
 			ret = append(ret, packed...)
 		}

--- a/accounts/abi/abi.go
+++ b/accounts/abi/abi.go
@@ -186,7 +186,7 @@ func toGoSlice(i int, t Argument, output []byte) (interface{}, error) {
 // argument in T.
 func toGoType(i int, t Argument, output []byte) (interface{}, error) {
 	// we need to treat slices differently
-	if t.Type.Kind == reflect.Slice {
+	if t.Type.IsSlice {
 		return toGoSlice(i, t, output)
 	}
 

--- a/accounts/abi/abi_test.go
+++ b/accounts/abi/abi_test.go
@@ -59,7 +59,7 @@ func TestType(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	if typ.Kind != reflect.Ptr {
+	if typ.Kind != reflect.Uint {
 		t.Error("expected uint32 to have kind Ptr")
 	}
 
@@ -67,8 +67,8 @@ func TestType(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	if typ.Kind != reflect.Slice {
-		t.Error("expected uint32[] to have type slice")
+	if !typ.IsSlice {
+		t.Error("expected uint32[] to be slice")
 	}
 	if typ.Type != ubig_t {
 		t.Error("expcted uith32[] to have type uint64")
@@ -78,13 +78,13 @@ func TestType(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	if typ.Kind != reflect.Slice {
-		t.Error("expected uint32[2] to have kind slice")
+	if !typ.IsSlice {
+		t.Error("expected uint32[2] to be slice")
 	}
 	if typ.Type != ubig_t {
 		t.Error("expcted uith32[2] to have type uint64")
 	}
-	if typ.Size != 2 {
+	if typ.SliceSize != 2 {
 		t.Error("expected uint32[2] to have a size of 2")
 	}
 }
@@ -149,10 +149,6 @@ func TestTestNumbers(t *testing.T) {
 		t.Errorf("expected send( ptr ) to throw, requires *big.Int instead of *int")
 	}
 
-	if _, err := abi.Pack("send", 1000); err != nil {
-		t.Error("expected send(1000) to cast to big")
-	}
-
 	if _, err := abi.Pack("test", uint32(1000)); err != nil {
 		t.Error(err)
 	}
@@ -204,13 +200,28 @@ func TestTestSlice(t *testing.T) {
 		t.FailNow()
 	}
 
-	slice := make([]byte, 2)
+	slice := make([]uint64, 2)
 	if _, err := abi.Pack("uint64[2]", slice); err != nil {
 		t.Error(err)
 	}
 
 	if _, err := abi.Pack("uint64[]", slice); err != nil {
 		t.Error(err)
+	}
+}
+
+func TestImplicitTypeCasts(t *testing.T) {
+	abi, err := JSON(strings.NewReader(jsondata2))
+	if err != nil {
+		t.Error(err)
+		t.FailNow()
+	}
+
+	slice := make([]uint8, 2)
+	_, err = abi.Pack("uint64[2]", slice)
+	expStr := "`uint64[2]` abi: cannot use type uint8 as type uint64"
+	if err.Error() != expStr {
+		t.Errorf("expected %v, got %v", expStr, err)
 	}
 }
 

--- a/accounts/abi/numbers.go
+++ b/accounts/abi/numbers.go
@@ -117,8 +117,6 @@ func packNum(value reflect.Value, to byte) []byte {
 // checks whether the given reflect value is signed. This also works for slices with a number type
 func isSigned(v reflect.Value) bool {
 	switch v.Type() {
-	case ubig_ts, big_ts, big_t, ubig_t:
-		return true
 	case int_ts, int8_ts, int16_ts, int32_ts, int64_ts, int_t, int8_t, int16_t, int32_t, int64_t:
 		return true
 	}

--- a/accounts/abi/numbers_test.go
+++ b/accounts/abi/numbers_test.go
@@ -81,8 +81,4 @@ func TestSigned(t *testing.T) {
 	if !isSigned(reflect.ValueOf(int(10))) {
 		t.Error()
 	}
-
-	if !isSigned(reflect.ValueOf(big.NewInt(10))) {
-		t.Error()
-	}
 }

--- a/accounts/abi/type.go
+++ b/accounts/abi/type.go
@@ -113,7 +113,6 @@ func NewType(t string) (typ Type, err error) {
 	case "real": // TODO
 		typ.Kind = reflect.Invalid
 	case "address":
-		typ.Kind = reflect.Slice
 		typ.Type = address_t
 		typ.Size = 20
 		typ.T = AddressTy
@@ -125,12 +124,12 @@ func NewType(t string) (typ Type, err error) {
 			typ.Size = 32
 		}
 	case "hash":
-		typ.Kind = reflect.Slice
+		typ.Kind = reflect.Array
 		typ.Size = 32
 		typ.Type = hash_t
 		typ.T = HashTy
 	case "bytes":
-		typ.Kind = reflect.Slice
+		typ.Kind = reflect.Array
 		typ.Type = byte_ts
 		typ.Size = vsize
 		if vsize == 0 {


### PR DESCRIPTION
This PR adds support for slices for all supported types by the Go ABI.

The following solidity functions are now supported and automatically supported by the `abigen` binary:

* `function input(address[] in)`
* `function output() constant returns(address[] a, address[] b)`

The ABI is now also stricter when it comes to input and output acceptance and will attempt to follow the Golang convention. The following implicit conversions are now no longer supported:

| Go type | ABI type |
|---|---|
| `make([]byte, 20)` | `address` |
|`[20]byte` | `address` |
|`[*]byte` | `uint*` |
| `make([]byte, *)` | `uint*` |  

*any (u)int that do not match in size are also no longer supported*