### PR TITLE
eth, rpc: add eth_minGasPrice to enable lower bounds on UIs

### DIFF
--- a/eth/api.go
+++ b/eth/api.go
@@ -98,6 +98,11 @@ func NewPublicEthereumAPI(e *Ethereum) *PublicEthereumAPI {
 	return &PublicEthereumAPI{e, NewGasPriceOracle(e)}
 }
 
+// MinGasPrice returns te currently configured minimum gas price.
+func (s *PublicEthereumAPI) MinGasPrice() *big.Int {
+	return s.gpo.MinimumPrice()
+}
+
 // GasPrice returns a suggestion for a gas price.
 func (s *PublicEthereumAPI) GasPrice() *big.Int {
 	return s.gpo.SuggestPrice()

--- a/eth/gasprice.go
+++ b/eth/gasprice.go
@@ -194,6 +194,12 @@ func (self *GasPriceOracle) lowestPrice(block *types.Block) *big.Int {
 	return minPrice
 }
 
+// MinimumPrice returns the configured minimum price that the oracle will ever
+// return. This can be used as a bottom limit on UIs for fee selection sliders.
+func (self *GasPriceOracle) MinimumPrice() *big.Int {
+	return new(big.Int).Set(self.minPrice)
+}
+
 // SuggestPrice returns the recommended gas price.
 func (self *GasPriceOracle) SuggestPrice() *big.Int {
 	self.init()

--- a/rpc/javascript.go
+++ b/rpc/javascript.go
@@ -251,6 +251,11 @@ web3._extend({
 		new web3._extend.Property({
 			name: 'pendingTransactions',
 			getter: 'eth_pendingTransactions'
+		}),
+		new web3._extend.Property({
+			name: 'minGasPrice',
+			getter: 'eth_minGasPrice',
+			outputFormatter: web3._extend.formatters.outputBigNumberFormatter
 		})
 	]
 });


### PR DESCRIPTION
This PR exposes the minimum configured gas price to allow properly setting lower bounds on UIs (notably Mist in the current case), since the existing `gasPrice` API endpoint is the suggested price.

@alexvandesande @frozeman PTAL