### PR TITLE
accounts/abi/bind: surface raw wrappers to access low level ops

### DIFF
--- a/accounts/abi/bind/base.go
+++ b/accounts/abi/bind/base.go
@@ -108,8 +108,7 @@ func (c *BoundContract) Call(opts *CallOpts, result interface{}, method string, 
 	return c.abi.Unpack(result, method, output)
 }
 
-// Transact invokes the (paid) contract method with params as input values and
-// value as the fund transfer to the contract.
+// Transact invokes the (paid) contract method with params as input values.
 func (c *BoundContract) Transact(opts *TransactOpts, method string, params ...interface{}) (*types.Transaction, error) {
 	// Otherwise pack up the parameters and invoke the contract
 	input, err := c.abi.Pack(method, params...)
@@ -117,6 +116,12 @@ func (c *BoundContract) Transact(opts *TransactOpts, method string, params ...in
 		return nil, err
 	}
 	return c.transact(opts, &c.address, input)
+}
+
+// Transfer initiates a plain transaction to move funds to the contract, calling
+// its default method if one is available.
+func (c *BoundContract) Transfer(opts *TransactOpts) (*types.Transaction, error) {
+	return c.transact(opts, &c.address, nil)
 }
 
 // transact executes an actual transaction invocation, first deriving any missing

--- a/accounts/abi/bind/template.go
+++ b/accounts/abi/bind/template.go
@@ -110,6 +110,21 @@ package {{.Package}}
 	  TransactOpts bind.TransactOpts    // Transaction auth options to use throughout this session
 	}
 
+	// {{.Type}}Raw is an auto generated low-level Go binding around an Ethereum contract.
+	type {{.Type}}Raw struct {
+	  Contract *{{.Type}} // Generic contract binding to access the raw methods on
+	}
+
+	// {{.Type}}CallerRaw is an auto generated low-level read-only Go binding around an Ethereum contract.
+	type {{.Type}}CallerRaw struct {
+		Contract *{{.Type}}Caller // Generic read-only contract binding to access the raw methods on
+	}
+
+	// {{.Type}}TransactorRaw is an auto generated low-level write-only Go binding around an Ethereum contract.
+	type {{.Type}}TransactorRaw struct {
+		Contract *{{.Type}}Transactor // Generic write-only contract binding to access the raw methods on
+	}
+
 	// New{{.Type}} creates a new instance of {{.Type}}, bound to a specific deployed contract.
 	func New{{.Type}}(address common.Address, backend bind.ContractBackend) (*{{.Type}}, error) {
 	  contract, err := bind{{.Type}}(address, backend.(bind.ContractCaller), backend.(bind.ContractTransactor))
@@ -144,6 +159,44 @@ package {{.Package}}
 	    return nil, err
 	  }
 	  return bind.NewBoundContract(address, parsed, caller, transactor), nil
+	}
+
+	// Call invokes the (constant) contract method with params as input values and
+	// sets the output to result. The result type might be a single field for simple
+	// returns, a slice of interfaces for anonymous returns and a struct for named
+	// returns.
+	func (_{{$contract.Type}} *{{$contract.Type}}Raw) Call(opts *bind.CallOpts, result interface{}, method string, params ...interface{}) error {
+		return _{{$contract.Type}}.Contract.{{$contract.Type}}Caller.contract.Call(opts, result, method, params...)
+	}
+
+	// Transfer initiates a plain transaction to move funds to the contract, calling
+	// its default method if one is available.
+	func (_{{$contract.Type}} *{{$contract.Type}}Raw) Transfer(opts *bind.TransactOpts) (*types.Transaction, error) {
+		return _{{$contract.Type}}.Contract.{{$contract.Type}}Transactor.contract.Transfer(opts)
+	}
+
+	// Transact invokes the (paid) contract method with params as input values.
+	func (_{{$contract.Type}} *{{$contract.Type}}Raw) Transact(opts *bind.TransactOpts, method string, params ...interface{}) (*types.Transaction, error) {
+		return _{{$contract.Type}}.Contract.{{$contract.Type}}Transactor.contract.Transact(opts, method, params...)
+	}
+
+	// Call invokes the (constant) contract method with params as input values and
+	// sets the output to result. The result type might be a single field for simple
+	// returns, a slice of interfaces for anonymous returns and a struct for named
+	// returns.
+	func (_{{$contract.Type}} *{{$contract.Type}}CallerRaw) Call(opts *bind.CallOpts, result interface{}, method string, params ...interface{}) error {
+		return _{{$contract.Type}}.Contract.contract.Call(opts, result, method, params...)
+	}
+
+	// Transfer initiates a plain transaction to move funds to the contract, calling
+	// its default method if one is available.
+	func (_{{$contract.Type}} *{{$contract.Type}}TransactorRaw) Transfer(opts *bind.TransactOpts) (*types.Transaction, error) {
+		return _{{$contract.Type}}.Contract.contract.Transfer(opts)
+	}
+
+	// Transact invokes the (paid) contract method with params as input values.
+	func (_{{$contract.Type}} *{{$contract.Type}}TransactorRaw) Transact(opts *bind.TransactOpts, method string, params ...interface{}) (*types.Transaction, error) {
+		return _{{$contract.Type}}.Contract.contract.Transact(opts, method, params...)
 	}
 
 	{{range .Calls}}


### PR DESCRIPTION
This PR introduces three new types to generated contracts `XyzRaw`, `XyzCallerRaw` and `XyzTransactorRaw`; with the aim of surfacing the low level generic `Call`, `Transact` and most importantly **default fund transfer** methods.

Usage is: `XyzRaw{myXyzInstance}.Transfer(opts)`.