### PR TITLE
RPC pub sub

### DIFF
--- a/eth/backend.go
+++ b/eth/backend.go
@@ -310,7 +310,7 @@ func (s *Ethereum) APIs() []rpc.API {
 		}, {
 			Namespace: "eth",
 			Version:   "1.0",
-			Service:   downloader.NewPublicDownloaderAPI(s.Downloader()),
+			Service:   downloader.NewPublicDownloaderAPI(s.Downloader(), s.EventMux()),
 			Public:    true,
 		}, {
 			Namespace: "miner",

--- a/eth/downloader/api.go
+++ b/eth/downloader/api.go
@@ -17,18 +17,55 @@
 package downloader
 
 import (
+	"sync"
+
+	"golang.org/x/net/context"
+
+	"github.com/ethereum/go-ethereum/event"
 	"github.com/ethereum/go-ethereum/rpc"
 )
 
 // PublicDownloaderAPI provides an API which gives information about the current synchronisation status.
 // It offers only methods that operates on data that can be available to anyone without security risks.
 type PublicDownloaderAPI struct {
-	d *Downloader
+	d                   *Downloader
+	mux                 *event.TypeMux
+	muSyncSubscriptions sync.Mutex
+	syncSubscriptions   map[string]rpc.Subscription
 }
 
 // NewPublicDownloaderAPI create a new PublicDownloaderAPI.
-func NewPublicDownloaderAPI(d *Downloader) *PublicDownloaderAPI {
-	return &PublicDownloaderAPI{d}
+func NewPublicDownloaderAPI(d *Downloader, m *event.TypeMux) *PublicDownloaderAPI {
+	api := &PublicDownloaderAPI{d: d, mux: m, syncSubscriptions: make(map[string]rpc.Subscription)}
+
+	go api.run()
+
+	return api
+}
+
+func (api *PublicDownloaderAPI) run() {
+	sub := api.mux.Subscribe(StartEvent{}, DoneEvent{}, FailedEvent{})
+
+	for event := range sub.Chan() {
+		var notification interface{}
+
+		switch event.Data.(type) {
+		case StartEvent:
+			result := &SyncingResult{Syncing: true}
+			result.Status.Origin, result.Status.Current, result.Status.Height, result.Status.Pulled, result.Status.Known = api.d.Progress()
+			notification = result
+		case DoneEvent, FailedEvent:
+			notification = false
+		}
+
+		api.muSyncSubscriptions.Lock()
+		for id, sub := range api.syncSubscriptions {
+			if sub.Notify(notification) == rpc.ErrNotificationNotFound {
+				delete(api.syncSubscriptions, id)
+			}
+		}
+		api.muSyncSubscriptions.Unlock()
+	}
 }
 
 // Progress gives progress indications when the node is synchronising with the Ethereum network.
@@ -47,19 +84,25 @@ type SyncingResult struct {
 }
 
 // Syncing provides information when this nodes starts synchronising with the Ethereum network and when it's finished.
-func (s *PublicDownloaderAPI) Syncing() (rpc.Subscription, error) {
-	sub := s.d.mux.Subscribe(StartEvent{}, DoneEvent{}, FailedEvent{})
-
-	output := func(event interface{}) interface{} {
-		switch event.(type) {
-		case StartEvent:
-			result := &SyncingResult{Syncing: true}
-			result.Status.Origin, result.Status.Current, result.Status.Height, result.Status.Pulled, result.Status.Known = s.d.Progress()
-			return result
-		case DoneEvent, FailedEvent:
-			return false
-		}
-		return nil
+func (api *PublicDownloaderAPI) Syncing(ctx context.Context) (rpc.Subscription, error) {
+	notifier, supported := ctx.Value(rpc.NotifierContextKey).(rpc.Notifier)
+	if !supported {
+		return nil, rpc.ErrNotificationsUnsupported
 	}
-	return rpc.NewSubscriptionWithOutputFormat(sub, output), nil
+
+	subscription, err := notifier.NewSubscription(func(id string) {
+		api.muSyncSubscriptions.Lock()
+		delete(api.syncSubscriptions, id)
+		api.muSyncSubscriptions.Unlock()
+	})
+
+	if err != nil {
+		return nil, err
+	}
+
+	api.muSyncSubscriptions.Lock()
+	api.syncSubscriptions[subscription.ID()] = subscription
+	api.muSyncSubscriptions.Unlock()
+
+	return subscription, nil
 }

--- a/node/node.go
+++ b/node/node.go
@@ -303,7 +303,7 @@ func (n *Node) startIPC(apis []rpc.API) error {
 				glog.V(logger.Error).Infof("IPC accept failed: %v", err)
 				continue
 			}
-			go handler.ServeCodec(rpc.NewJSONCodec(conn))
+			go handler.ServeCodec(rpc.NewJSONCodec(conn), rpc.OptionMethodInvocation | rpc.OptionSubscriptions)
 		}
 	}()
 	// All listeners booted successfully

--- a/rpc/doc.go
+++ b/rpc/doc.go
@@ -68,35 +68,19 @@ The package also supports the publish subscribe pattern through the use of subsc
 A method that is considered eligible for notifications must satisfy the following criteria:
  - object must be exported
  - method must be exported
+ - first method argument type must be context.Context
  - method argument(s) must be exported or builtin types
  - method must return the tuple Subscription, error
 
-
 An example method:
- func (s *BlockChainService) Head() (Subscription, error) {
- 	sub := s.bc.eventMux.Subscribe(ChainHeadEvent{})
-	return v2.NewSubscription(sub), nil
- }
-
-This method will push all raised ChainHeadEvents to subscribed clients. If the client is only
-interested in every N'th block it is possible to add a criteria.
-
- func (s *BlockChainService) HeadFiltered(nth uint64) (Subscription, error) {
- 	sub := s.bc.eventMux.Subscribe(ChainHeadEvent{})
-
-	criteria := func(event interface{}) bool {
-		chainHeadEvent := event.(ChainHeadEvent)
-		if chainHeadEvent.Block.NumberU64() % nth == 0 {
-			return true
-		}
-		return false
-	}
-
-	return v2.NewSubscriptionFiltered(sub, criteria), nil
+ func (s *BlockChainService) NewBlocks(ctx context.Context) (Subscription, error) {
+ 	...
  }
 
 Subscriptions are deleted when:
  - the user sends an unsubscribe request
- - the connection which was used to create the subscription is closed
+ - the connection which was used to create the subscription is closed. This can be initiated
+   by the client and server. The server will close the connection on an write error or when
+   the queue of buffered notifications gets too big.
 */
 package rpc

--- a/rpc/http.go
+++ b/rpc/http.go
@@ -126,7 +126,7 @@ func newJSONHTTPHandler(srv *Server) http.HandlerFunc {
 		// a single request.
 		codec := NewJSONCodec(&httpReadWriteNopCloser{r.Body, w})
 		defer codec.Close()
-		srv.ServeSingleRequest(codec)
+		srv.ServeSingleRequest(codec, OptionMethodInvocation)
 	}
 }
 

--- a/rpc/inproc.go
+++ b/rpc/inproc.go
@@ -39,7 +39,7 @@ func (c *inProcClient) Close() {
 // RPC server.
 func NewInProcRPCClient(handler *Server) Client {
 	p1, p2 := net.Pipe()
-	go handler.ServeCodec(NewJSONCodec(p1))
+	go handler.ServeCodec(NewJSONCodec(p1), OptionMethodInvocation|OptionSubscriptions)
 	return &inProcClient{handler, p2, json.NewEncoder(p2), json.NewDecoder(p2)}
 }
 

--- a/rpc/notification.go
+++ b/rpc/notification.go
@@ -1,0 +1,288 @@
+// Copyright 2016 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+package rpc
+
+import (
+	"errors"
+	"sync"
+	"time"
+
+	"github.com/ethereum/go-ethereum/logger"
+	"github.com/ethereum/go-ethereum/logger/glog"
+)
+
+var (
+	// ErrNotificationsUnsupported is returned when the connection doesn't support notifications
+	ErrNotificationsUnsupported = errors.New("notifications not supported")
+
+	// ErrNotificationNotFound is returned when the notification for the given id is not found
+	ErrNotificationNotFound = errors.New("notification not found")
+
+	// errNotifierStopped is returned when the notifier is stopped (e.g. codec is closed)
+	errNotifierStopped = errors.New("unable to send notification")
+
+	// errNotificationQueueFull is returns when there are too many notifications in the queue
+	errNotificationQueueFull = errors.New("too many pending notifications")
+)
+
+// unsubSignal is a signal that the subscription is unsubscribed. It is used to flush buffered
+// notifications that might be pending in the internal queue.
+var unsubSignal = new(struct{})
+
+// UnsubscribeCallback defines a callback that is called when a subcription ends.
+// It receives the subscription id as argument.
+type UnsubscribeCallback func(id string)
+
+// notification is a helper object that holds event data for a subscription
+type notification struct {
+	sub  *bufferedSubscription // subscription id
+	data interface{}           // event data
+}
+
+// A Notifier type describes the interface for objects that can send create subscriptions
+type Notifier interface {
+	// Create a new subscription. The given callback is called when this subscription
+	// is cancelled (e.g. client send an unsubscribe, connection closed).
+	NewSubscription(UnsubscribeCallback) (Subscription, error)
+	// Cancel subscription
+	Unsubscribe(id string) error
+}
+
+// Subscription defines the interface for objects that can notify subscribers
+type Subscription interface {
+	// Inform client of an event
+	Notify(data interface{}) error
+	// Unique identifier
+	ID() string
+	// Cancel subscription
+	Cancel() error
+}
+
+// bufferedSubscription is a subscription that uses a bufferedNotifier to send
+// notifications to subscribers.
+type bufferedSubscription struct {
+	id               string
+	unsubOnce        sync.Once           // call unsub method once
+	unsub            UnsubscribeCallback // called on Unsubscribed
+	notifier         *bufferedNotifier   // forward notifications to
+	pending          chan interface{}    // closed when active
+	flushed          chan interface{}    // closed when all buffered notifications are send
+	lastNotification time.Time           // last time a notification was send
+}
+
+// ID returns the subscription identifier that the client uses to refer to this instance.
+func (s *bufferedSubscription) ID() string {
+	return s.id
+}
+
+// Cancel informs the notifier that this subscription is cancelled by the API
+func (s *bufferedSubscription) Cancel() error {
+	return s.notifier.Unsubscribe(s.id)
+}
+
+// Notify the subscriber of a particular event.
+func (s *bufferedSubscription) Notify(data interface{}) error {
+	return s.notifier.send(s.id, data)
+}
+
+// bufferedNotifier is a notifier that queues notifications in an internal queue and
+// send them as fast as possible to the client from this queue. It will stop if the
+// queue grows past a given size.
+type bufferedNotifier struct {
+	codec         ServerCodec                      // underlying connection
+	mu            sync.Mutex                       // guard internal state
+	subscriptions map[string]*bufferedSubscription // keep track of subscriptions associated with codec
+	queueSize     int                              // max number of items in queue
+	queue         chan *notification               // notification queue
+	stopped       bool                             // indication if this notifier is ordered to stop
+}
+
+// newBufferedNotifier returns a notifier that queues notifications in an internal queue
+// from which notifications are send as fast as possible to the client. If the queue size
+// limit is reached (client is unable to keep up) it will stop and closes the codec.
+func newBufferedNotifier(codec ServerCodec, size int) *bufferedNotifier {
+	notifier := &bufferedNotifier{
+		codec:         codec,
+		subscriptions: make(map[string]*bufferedSubscription),
+		queue:         make(chan *notification, size),
+		queueSize:     size,
+	}
+
+	go notifier.run()
+
+	return notifier
+}
+
+// NewSubscription creates a new subscription that forwards events to this instance internal
+// queue. The given callback is called when the subscription is unsubscribed/cancelled.
+func (n *bufferedNotifier) NewSubscription(callback UnsubscribeCallback) (Subscription, error) {
+	id, err := newSubscriptionID()
+	if err != nil {
+		return nil, err
+	}
+
+	n.mu.Lock()
+	defer n.mu.Unlock()
+
+	if n.stopped {
+		return nil, errNotifierStopped
+	}
+
+	sub := &bufferedSubscription{
+		id:               id,
+		unsub:            callback,
+		notifier:         n,
+		pending:          make(chan interface{}),
+		flushed:          make(chan interface{}),
+		lastNotification: time.Now(),
+	}
+
+	n.subscriptions[id] = sub
+
+	return sub, nil
+}
+
+// Remove the given subscription. If subscription is not found notificationNotFoundErr is returned.
+func (n *bufferedNotifier) Unsubscribe(subid string) error {
+	n.mu.Lock()
+	sub, found := n.subscriptions[subid]
+	n.mu.Unlock()
+
+	if found {
+		// send the unsubscribe signal, this will cause the notifier not to accept new events
+		// for this subscription and will close the flushed channel after the last (buffered)
+		// notification was send to the client.
+		if err := n.send(subid, unsubSignal); err != nil {
+			return err
+		}
+
+		// wait for confirmation that all (buffered) events are send for this subscription.
+		// this ensures that the unsubscribe method response is not send before all buffered
+		// events for this subscription are send.
+		<-sub.flushed
+
+		return nil
+	}
+
+	return ErrNotificationNotFound
+}
+
+// Send enques the given data for the subscription with public ID on the internal queue. t returns
+// an error when the notifier is stopped or the queue is full. If data is the unsubscribe signal it
+// will remove the subscription with the given id from the subscription collection.
+func (n *bufferedNotifier) send(id string, data interface{}) error {
+	n.mu.Lock()
+	defer n.mu.Unlock()
+
+	if n.stopped {
+		return errNotifierStopped
+	}
+
+	var (
+		subscription *bufferedSubscription
+		found        bool
+	)
+
+	// check if subscription is associated with this connection, it might be cancelled
+	// (subscribe/connection closed)
+	if subscription, found = n.subscriptions[id]; !found {
+		glog.V(logger.Error).Infof("received notification for unknown subscription %s\n", id)
+		return ErrNotificationNotFound
+	}
+
+	// received the unsubscribe signal. Add it to the queue to make sure any pending notifications
+	// for this subscription are send. When the run loop receives this singal it will signal that
+	// all pending subscriptions are flushed and that the confirmation of the unsubscribe can be
+	// send to the user. Remove the subscriptions to make sure new notifications are not accepted.
+	if data == unsubSignal {
+		delete(n.subscriptions, id)
+		if subscription.unsub != nil {
+			subscription.unsubOnce.Do(func() { subscription.unsub(id) })
+		}
+	}
+
+	subscription.lastNotification = time.Now()
+
+	if len(n.queue) >= n.queueSize {
+		glog.V(logger.Warn).Infoln("too many buffered notifications -> close connection")
+		n.codec.Close()
+		return errNotificationQueueFull
+	}
+
+	n.queue <- &notification{subscription, data}
+	return nil
+}
+
+// run reads notifications from the internal queue and sends them to the client. In case of an
+// error, or when the codec is closed it will cancel all active subscriptions and returns.
+func (n *bufferedNotifier) run() {
+	defer func() {
+		n.mu.Lock()
+		defer n.mu.Unlock()
+
+		n.stopped = true
+		close(n.queue)
+
+		// on exit call unsubscribe callback
+		for id, sub := range n.subscriptions {
+			if sub.unsub != nil {
+				sub.unsubOnce.Do(func() { sub.unsub(id) })
+			}
+			close(sub.flushed)
+			delete(n.subscriptions, id)
+		}
+	}()
+
+	for {
+		select {
+		case notification := <-n.queue:
+			// It can happen that an event is raised before the RPC server was able to send the sub
+			// id to the client. Therefore subscriptions are marked as pending until the sub id was
+			// send. The RPC server will activate the subscription by closing the pending chan.
+			<-notification.sub.pending
+
+			if notification.data == unsubSignal {
+				// unsubSignal is the last accepted message for this subscription. Raise the signal
+				// that all buffered notifications are sent by closing the flushed channel. This
+				// indicates that the response for the unsubscribe can be send to the client.
+				close(notification.sub.flushed)
+			} else {
+				msg := n.codec.CreateNotification(notification.sub.id, notification.data)
+				if err := n.codec.Write(msg); err != nil {
+					n.codec.Close()
+					// unable to send notification to client, unsubscribe all subscriptions
+					glog.V(logger.Warn).Infof("unable to send notification - %v\n", err)
+					return
+				}
+			}
+		case <-n.codec.Closed(): // connection was closed
+			glog.V(logger.Debug).Infoln("codec closed, stop subscriptions")
+			return
+		}
+	}
+}
+
+// Marks the subscription as active. This will causes the notifications for this subscription to be
+// forwarded to the client.
+func (n *bufferedNotifier) activate(subid string) {
+	n.mu.Lock()
+	defer n.mu.Unlock()
+
+	if sub, found := n.subscriptions[subid]; found {
+		close(sub.pending)
+	}
+}

--- a/rpc/notification_test.go
+++ b/rpc/notification_test.go
@@ -1,0 +1,119 @@
+// Copyright 2016 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+package rpc
+
+import (
+	"encoding/json"
+	"net"
+	"testing"
+	"time"
+
+	"golang.org/x/net/context"
+)
+
+type NotificationTestService struct{}
+
+var (
+	unsubCallbackCalled = false
+)
+
+func (s *NotificationTestService) Unsubscribe(subid string) {
+	unsubCallbackCalled = true
+}
+
+func (s *NotificationTestService) SomeSubscription(ctx context.Context, n, val int) (Subscription, error) {
+	notifier, supported := ctx.Value(NotifierContextKey).(Notifier)
+	if !supported {
+		return nil, ErrNotificationsUnsupported
+	}
+
+	// by explicitly creating an subscription we make sure that the subscription id is send back to the client
+	// before the first subscription.Notify is called. Otherwise the events might be send before the response
+	// for the eth_subscribe method.
+	subscription, err := notifier.NewSubscription(s.Unsubscribe)
+	if err != nil {
+		return nil, err
+	}
+
+	go func() {
+		for i := 0; i < n; i++ {
+			if err := subscription.Notify(val + i); err != nil {
+				return
+			}
+		}
+	}()
+
+	return subscription, nil
+}
+
+func TestNotifications(t *testing.T) {
+	server := NewServer()
+	service := &NotificationTestService{}
+
+	if err := server.RegisterName("eth", service); err != nil {
+		t.Fatalf("unable to register test service %v", err)
+	}
+
+	clientConn, serverConn := net.Pipe()
+
+	go server.ServeCodec(NewJSONCodec(serverConn), OptionMethodInvocation|OptionSubscriptions)
+
+	out := json.NewEncoder(clientConn)
+	in := json.NewDecoder(clientConn)
+
+	n := 5
+	val := 12345
+	request := map[string]interface{}{
+		"id":      1,
+		"method":  "eth_subscribe",
+		"version": "2.0",
+		"params":  []interface{}{"someSubscription", n, val},
+	}
+
+	// create subscription
+	if err := out.Encode(request); err != nil {
+		t.Fatal(err)
+	}
+
+	var subid string
+	response := JSONSuccessResponse{Result: subid}
+	if err := in.Decode(&response); err != nil {
+		t.Fatal(err)
+	}
+
+	var ok bool
+	if subid, ok = response.Result.(string); !ok {
+		t.Fatalf("expected subscription id, got %T", response.Result)
+	}
+
+	for i := 0; i < n; i++ {
+		var notification jsonNotification
+		if err := in.Decode(&notification); err != nil {
+			t.Fatalf("%v", err)
+		}
+
+		if int(notification.Params.Result.(float64)) != val+i {
+			t.Fatalf("expected %d, got %d", val+i, notification.Params.Result)
+		}
+	}
+
+	clientConn.Close() // causes notification unsubscribe callback to be called
+	time.Sleep(1 * time.Second)
+
+	if !unsubCallbackCalled {
+		t.Error("unsubscribe callback not called after closing connection")
+	}
+}

--- a/rpc/server_test.go
+++ b/rpc/server_test.go
@@ -65,8 +65,12 @@ func (s *Service) InvalidRets3() (string, string, error) {
 	return "", "", nil
 }
 
-func (s *Service) Subscription() (Subscription, error) {
-	return NewSubscription(nil), nil
+func (s *Service) Subscription(ctx context.Context) (Subscription, error) {
+	return nil, nil
+}
+
+func (s *Service) SubsriptionWithArgs(ctx context.Context, a, b int) (Subscription, error) {
+	return nil, nil
 }
 
 func TestServerRegisterName(t *testing.T) {
@@ -90,8 +94,8 @@ func TestServerRegisterName(t *testing.T) {
 		t.Errorf("Expected 4 callbacks for service 'calc', got %d", len(svc.callbacks))
 	}
 
-	if len(svc.subscriptions) != 1 {
-		t.Errorf("Expected 1 subscription for service 'calc', got %d", len(svc.subscriptions))
+	if len(svc.subscriptions) != 2 {
+		t.Errorf("Expected 2 subscriptions for service 'calc', got %d", len(svc.subscriptions))
 	}
 }
 
@@ -229,7 +233,7 @@ func TestServerMethodExecution(t *testing.T) {
 
 	input, _ := json.Marshal(&req)
 	codec := &ServerTestCodec{input: input, closer: make(chan interface{})}
-	go server.ServeCodec(codec)
+	go server.ServeCodec(codec, OptionMethodInvocation)
 
 	<-codec.closer
 
@@ -259,7 +263,7 @@ func TestServerMethodWithCtx(t *testing.T) {
 
 	input, _ := json.Marshal(&req)
 	codec := &ServerTestCodec{input: input, closer: make(chan interface{})}
-	go server.ServeCodec(codec)
+	go server.ServeCodec(codec, OptionMethodInvocation)
 
 	<-codec.closer
 

--- a/rpc/types.go
+++ b/rpc/types.go
@@ -24,7 +24,6 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/ethereum/go-ethereum/event"
 	"gopkg.in/fatih/set.v0"
 )
 
@@ -66,10 +65,10 @@ type serverRequest struct {
 	err           RPCError
 }
 
-type serviceRegistry map[string]*service          // collection of services
-type callbacks map[string]*callback               // collection of RPC callbacks
-type subscriptions map[string]*callback           // collection of subscription callbacks
-type subscriptionRegistry map[string]Subscription // collection of subscriptions
+type serviceRegistry map[string]*service       // collection of services
+type callbacks map[string]*callback            // collection of RPC callbacks
+type subscriptions map[string]*callback        // collection of subscription callbacks
+type subscriptionRegistry map[string]*callback // collection of subscription callbacks
 
 // Server represents a RPC server
 type Server struct {
@@ -121,51 +120,6 @@ type ServerCodec interface {
 	Close()
 	// Closed when underlying connection is closed
 	Closed() <-chan interface{}
-}
-
-// SubscriptionMatcher returns true if the given value matches the criteria specified by the user
-type SubscriptionMatcher func(interface{}) bool
-
-// SubscriptionOutputFormat accepts event data and has the ability to format the data before it is send to the client
-type SubscriptionOutputFormat func(interface{}) interface{}
-
-// defaultSubscriptionOutputFormatter returns data and is used as default output format for notifications
-func defaultSubscriptionOutputFormatter(data interface{}) interface{} {
-	return data
-}
-
-// Subscription is used by the server to send notifications to the client
-type Subscription struct {
-	sub    event.Subscription
-	match  SubscriptionMatcher
-	format SubscriptionOutputFormat
-}
-
-// NewSubscription create a new RPC subscription
-func NewSubscription(sub event.Subscription) Subscription {
-	return Subscription{sub, nil, defaultSubscriptionOutputFormatter}
-}
-
-// NewSubscriptionWithOutputFormat create a new RPC subscription which a custom notification output format
-func NewSubscriptionWithOutputFormat(sub event.Subscription, formatter SubscriptionOutputFormat) Subscription {
-	return Subscription{sub, nil, formatter}
-}
-
-// NewSubscriptionFiltered will create a new subscription. For each raised event the given matcher is
-// called. If it returns true the event is send as notification to the client, otherwise it is ignored.
-func NewSubscriptionFiltered(sub event.Subscription, match SubscriptionMatcher) Subscription {
-	return Subscription{sub, match, defaultSubscriptionOutputFormatter}
-}
-
-// Chan returns the channel where new events will be published. It's up the user to call the matcher to
-// determine if the events are interesting for the client.
-func (s *Subscription) Chan() <-chan *event.Event {
-	return s.sub.Chan()
-}
-
-// Unsubscribe will end the subscription and closes the event channel
-func (s *Subscription) Unsubscribe() {
-	s.sub.Unsubscribe()
 }
 
 // HexNumber serializes a number to hex format using the "%#x" format

--- a/rpc/websocket.go
+++ b/rpc/websocket.go
@@ -93,7 +93,8 @@ func NewWSServer(cors string, handler *Server) *http.Server {
 		Handler: websocket.Server{
 			Handshake: wsHandshakeValidator(strings.Split(cors, ",")),
 			Handler: func(conn *websocket.Conn) {
-				handler.ServeCodec(NewJSONCodec(&wsReaderWriterCloser{conn}))
+				handler.ServeCodec(NewJSONCodec(&wsReaderWriterCloser{conn}),
+					OptionMethodInvocation|OptionSubscriptions)
 			},
 		},
 	}


### PR DESCRIPTION
This PR will add support for pub sub. Main differences with the previous implementation:

- [X] notification generation is moved from the rpc package to the API (more flexible)
- [X] uses `context.Context` to pass a notifier to the api which can be used to send notifications
- [X] creates 1 go-routine per subscription type instead of 1 go-routine per subscription (reduces the use of the event mux)
- [X] buffers notifications and kills the connection when when the number of notifications is >= 10k -> slow clients won't lead to internal queueing
- [X] create wiki page (https://github.com/ethereum/go-ethereum/wiki/RPC-PUB-SUB)

Note, this PR is a first implementation to gain experience and leaves room for improvements. There are a couple of hacks necessary to make this approach work with the current rpc package. It is also more complex than (probably) necessary. Mainly because the current RPC spec has some features (e.g. batch support) which makes compatibility with moving subscriptions to the api harder.

Anyone interested in trying. The most easiest way is to enable the ws interface:
`admin.startWS("localhost", 8546, "*", "eth")`

And send the following request with the echo websocket page http://www.websocket.org/echo.html (connect to ws://localhost:8546).

`{"id": 1, "method": "eth_subscribe", "params": ["newBlocks", {}]}`