### PR TITLE
cmd/geth: fix startup with empty database

### DIFF
--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -359,6 +359,12 @@ JavaScript API. See https://github.com/ethereum/go-ethereum/wiki/Javascipt-Conso
 		go metrics.CollectProcessMetrics(3 * time.Second)
 
 		utils.SetupNetwork(ctx)
+
+		// Deprecation warning.
+		if ctx.GlobalIsSet(utils.GenesisFileFlag.Name) {
+			common.PrintDepricationWarning("--genesis is deprecated. Switch to use 'geth init /path/to/file'")
+		}
+
 		return nil
 	}
 

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -772,23 +772,22 @@ func MustMakeChainConfig(ctx *cli.Context) *core.ChainConfig {
 	)
 	defer db.Close()
 
-	chainConfig, err := core.GetChainConfig(db, genesis.Hash())
-	if err != nil {
-		if err != core.ChainConfigNotFoundErr {
+	if genesis != nil {
+		// Exsting genesis block, use stored config if available.
+		storedConfig, err := core.GetChainConfig(db, genesis.Hash())
+		if err == nil {
+			return storedConfig
+		} else if err != core.ChainConfigNotFoundErr {
 			Fatalf("Could not make chain configuration: %v", err)
 		}
-		var homesteadBlockNo *big.Int
-		if ctx.GlobalBool(TestNetFlag.Name) {
-			homesteadBlockNo = params.TestNetHomesteadBlock
-		} else {
-			homesteadBlockNo = params.MainNetHomesteadBlock
-		}
-
-		chainConfig = &core.ChainConfig{
-			HomesteadBlock: homesteadBlockNo,
-		}
 	}
-	return chainConfig
+	var homesteadBlockNo *big.Int
+	if ctx.GlobalBool(TestNetFlag.Name) {
+		homesteadBlockNo = params.TestNetHomesteadBlock
+	} else {
+		homesteadBlockNo = params.MainNetHomesteadBlock
+	}
+	return &core.ChainConfig{HomesteadBlock: homesteadBlockNo}
 }
 
 // MakeChainDatabase open an LevelDB using the flags passed to the client and will hard crash if it fails.

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -169,10 +169,6 @@ func New(ctx *node.ServiceContext, config *Config) (*Ethereum, error) {
 
 	// Load up any custom genesis block if requested
 	if len(config.Genesis) > 0 {
-		// Using println instead of glog to make sure it **always** displays regardless of
-		// verbosity settings.
-		common.PrintDepricationWarning("--genesis is deprecated. Switch to use 'geth init /path/to/file'")
-
 		block, err := core.WriteGenesisBlock(chainDb, strings.NewReader(config.Genesis))
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
Fixes #2408 

Fun fact: both issues caused unit test failures in #2284 because cmd/geth startup
is now tested there.