### PR TITLE
p2p: enable EIP-8 handshake sending

### DIFF
--- a/p2p/rlpx.go
+++ b/p2p/rlpx.go
@@ -31,7 +31,6 @@ import (
 	"io"
 	mrand "math/rand"
 	"net"
-	"os"
 	"sync"
 	"time"
 
@@ -262,8 +261,6 @@ func (h *encHandshake) staticSharedSecret(prv *ecdsa.PrivateKey) ([]byte, error)
 	return ecies.ImportECDSA(prv).GenerateShared(h.remotePub, sskLen, sskLen)
 }
 
-var configSendEIP = os.Getenv("RLPX_EIP8") != ""
-
 // initiatorEncHandshake negotiates a session token on conn.
 // it should be called on the dialing side of the connection.
 //
@@ -274,12 +271,7 @@ func initiatorEncHandshake(conn io.ReadWriter, prv *ecdsa.PrivateKey, remoteID d
 	if err != nil {
 		return s, err
 	}
-	var authPacket []byte
-	if configSendEIP {
-		authPacket, err = sealEIP8(authMsg, h)
-	} else {
-		authPacket, err = authMsg.sealPlain(h)
-	}
+	authPacket, err := sealEIP8(authMsg, h)
 	if err != nil {
 		return s, err
 	}


### PR DESCRIPTION
With the Ethereum Homestead fork is now behind us, we can
assume that everyone runs an EIP-8 capable client.