### PR TITLE
cmd/geth: add missing gas target flag (fixing 0 convergence issue)

### DIFF
--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -312,6 +312,7 @@ JavaScript API. See https://github.com/ethereum/go-ethereum/wiki/Javascipt-Conso
 		utils.MiningEnabledFlag,
 		utils.MiningGPUFlag,
 		utils.AutoDAGFlag,
+		utils.TargetGasLimitFlag,
 		utils.NATFlag,
 		utils.NatspecEnabledFlag,
 		utils.NoDiscoverFlag,

--- a/cmd/geth/usage.go
+++ b/cmd/geth/usage.go
@@ -121,10 +121,10 @@ var AppHelpFlagGroups = []flagGroup{
 		Flags: []cli.Flag{
 			utils.MiningEnabledFlag,
 			utils.MinerThreadsFlag,
-			utils.TargetGasLimitFlag,
 			utils.MiningGPUFlag,
 			utils.AutoDAGFlag,
 			utils.EtherbaseFlag,
+			utils.TargetGasLimitFlag,
 			utils.GasPriceFlag,
 			utils.ExtraDataFlag,
 		},


### PR DESCRIPTION
The `utils.TargetGasLimitFlag` flag was not assigned to the list of flags used by geth. This resulted in its value being `""` whenever retrieved, inherently causing geth to set the gas target to 0 instead of Pau million. This would cause nodes to converge to the MinGasLimit instead of the TargetGasLimit!