### PR TITLE
cmd/geth, cmd/utils, node: rename ws domains to origins

### DIFF
--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -326,7 +326,7 @@ JavaScript API. See https://github.com/ethereum/go-ethereum/wiki/Javascipt-Conso
 		utils.WSListenAddrFlag,
 		utils.WSPortFlag,
 		utils.WSApiFlag,
-		utils.WSAllowedDomainsFlag,
+		utils.WSAllowedOriginsFlag,
 		utils.IPCDisabledFlag,
 		utils.IPCApiFlag,
 		utils.IPCPathFlag,

--- a/cmd/geth/usage.go
+++ b/cmd/geth/usage.go
@@ -94,7 +94,7 @@ var AppHelpFlagGroups = []flagGroup{
 			utils.WSListenAddrFlag,
 			utils.WSPortFlag,
 			utils.WSApiFlag,
-			utils.WSAllowedDomainsFlag,
+			utils.WSAllowedOriginsFlag,
 			utils.IPCDisabledFlag,
 			utils.IPCApiFlag,
 			utils.IPCPathFlag,

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -287,9 +287,9 @@ var (
 		Usage: "API's offered over the WS-RPC interface",
 		Value: rpc.DefaultHTTPApis,
 	}
-	WSAllowedDomainsFlag = cli.StringFlag{
-		Name:  "wsdomains",
-		Usage: "Domains from which to accept websockets requests (can be spoofed)",
+	WSAllowedOriginsFlag = cli.StringFlag{
+		Name:  "wsorigins",
+		Usage: "Origins from which to accept websockets requests (can be spoofed)",
 		Value: "",
 	}
 	ExecFlag = cli.StringFlag{
@@ -655,7 +655,7 @@ func MakeSystemNode(name, version string, extra []byte, ctx *cli.Context) *node.
 		HTTPModules:     strings.Split(ctx.GlobalString(RPCApiFlag.Name), ","),
 		WSHost:          MakeWSRpcHost(ctx),
 		WSPort:          ctx.GlobalInt(WSPortFlag.Name),
-		WSDomains:       ctx.GlobalString(WSAllowedDomainsFlag.Name),
+		WSOrigins:       ctx.GlobalString(WSAllowedOriginsFlag.Name),
 		WSModules:       strings.Split(ctx.GlobalString(WSApiFlag.Name), ","),
 	}
 	// Configure the Ethereum service

--- a/node/config.go
+++ b/node/config.go
@@ -127,10 +127,10 @@ type Config struct {
 	// ephemeral nodes).
 	WSPort int
 
-	// WSDomains is the list of domain to accept websocket requests from. Please be
+	// WSOrigins is the list of origins to accept websocket requests from. Please be
 	// aware that the server can only act upon the HTTP request the client sends and
 	// cannot verify the validity of the request header.
-	WSDomains string
+	WSOrigins string
 
 	// WSModules is a list of API modules to expose via the websocket RPC interface.
 	// If the module list is empty, all RPC API endpoints designated public will be


### PR DESCRIPTION
Our CLI flags currently have a `--wsdomains` flag, meant to set the allowed domains to open websocket requests from. However with websockets there's a subtle different with origin checking: not the domain itself but rather the entire origin (i.e protocol included) is sent back from the browser to the server, so to handle it, the server needs to validate the entire origin, not just the domain part. This PR thus renames `wsdomains` to `wsorigins` to make this subtle distinction much more explicit.