### PR TITLE
cmd/geth: add JS preload parameter

### DIFF
--- a/cmd/geth/js.go
+++ b/cmd/geth/js.go
@@ -27,6 +27,7 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/codegangsta/cli"
 	"github.com/ethereum/go-ethereum/cmd/utils"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/registrar"
@@ -331,6 +332,23 @@ func (self *jsre) UnlockAccount(addr []byte) bool {
 	}
 }
 
+// preloadJSFiles loads JS files that the user has specified with ctx.PreLoadJSFlag into
+// the JSRE. If not all files could be loaded it will return an error describing the error.
+func (self *jsre) preloadJSFiles(ctx *cli.Context) error {
+	if ctx.GlobalString(utils.PreLoadJSFlag.Name) != "" {
+		assetPath := ctx.GlobalString(utils.JSpathFlag.Name)
+		jsFiles := strings.Split(ctx.GlobalString(utils.PreLoadJSFlag.Name), ",")
+		for _, file := range jsFiles {
+			filename := common.AbsolutePath(assetPath, strings.TrimSpace(file))
+			if err := self.re.Exec(filename); err != nil {
+				return fmt.Errorf("%s: %v", file, err)
+			}
+		}
+	}
+	return nil
+}
+
+// exec executes the JS file with the given filename and stops the JSRE
 func (self *jsre) exec(filename string) error {
 	if err := self.re.Exec(filename); err != nil {
 		self.re.Stop(false)

--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -331,6 +331,7 @@ JavaScript API. See https://github.com/ethereum/go-ethereum/wiki/Javascipt-Conso
 		utils.IPCApiFlag,
 		utils.IPCPathFlag,
 		utils.ExecFlag,
+		utils.PreLoadJSFlag,
 		utils.WhisperEnabledFlag,
 		utils.DevModeFlag,
 		utils.TestNetFlag,
@@ -427,6 +428,13 @@ func attach(ctx *cli.Context) {
 		true,
 	)
 
+	// preload user defined JS files into the console
+	err = repl.preloadJSFiles(ctx)
+	if err != nil {
+		utils.Fatalf("unable to preload JS file %v", err)
+	}
+
+	// in case the exec flag holds a JS statement execute it and return
 	if ctx.GlobalString(utils.ExecFlag.Name) != "" {
 		repl.batch(ctx.GlobalString(utils.ExecFlag.Name))
 	} else {
@@ -477,6 +485,13 @@ func console(ctx *cli.Context) {
 		ctx.GlobalString(utils.RPCCORSDomainFlag.Name),
 		client, true)
 
+	// preload user defined JS files into the console
+	err = repl.preloadJSFiles(ctx)
+	if err != nil {
+		utils.Fatalf("unable to preload JS file %v", err)
+	}
+
+	// in case the exec flag holds a JS statement execute it and return
 	if script := ctx.GlobalString(utils.ExecFlag.Name); script != "" {
 		repl.batch(script)
 	} else {

--- a/cmd/geth/usage.go
+++ b/cmd/geth/usage.go
@@ -101,6 +101,7 @@ var AppHelpFlagGroups = []flagGroup{
 			utils.RPCCORSDomainFlag,
 			utils.JSpathFlag,
 			utils.ExecFlag,
+			utils.PreLoadJSFlag,
 		},
 	},
 	{

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -296,6 +296,10 @@ var (
 		Name:  "exec",
 		Usage: "Execute JavaScript statement (only in combination with console/attach)",
 	}
+	PreLoadJSFlag = cli.StringFlag{
+		Name:  "preload",
+		Usage: "Comma separated list of JavaScript files to preload into the console",
+	}
 
 	// Network Settings
 	MaxPeersFlag = cli.IntFlag{


### PR DESCRIPTION
This PR adds the ability to preload JS files into the console. This is convenient for situations where the user would like to load javascript files into the console. For example to setup contract objects for existing contracts.

Example usage:

```
geth --preload "/tmp/file.js,/tmp/file2.js" console
```

Or together with js path:

```
geth --jspath "/tmp" --preload "file.js,/tmp/file2.js" attach
```