### PR TITLE
accounts/abi: refactored ABI package

### DIFF
--- a/accounts/abi/abi.go
+++ b/accounts/abi/abi.go
@@ -316,6 +316,8 @@ func set(dst, src reflect.Value, output Argument) error {
 			return fmt.Errorf("abi: cannot unmarshal src (len=%d) in to dst (len=%d)", output.Type.SliceSize, dst.Len())
 		}
 		reflect.Copy(dst, src)
+	case dstType.Kind() == reflect.Interface:
+		dst.Set(src)
 	default:
 		return fmt.Errorf("abi: cannot unmarshal %v in to %v", src.Type(), dst.Type())
 	}

--- a/accounts/abi/abi.go
+++ b/accounts/abi/abi.go
@@ -48,42 +48,6 @@ func JSON(reader io.Reader) (ABI, error) {
 	return abi, nil
 }
 
-// tests, tests whether the given input would result in a successful
-// call. Checks argument list count and matches input to `input`.
-func (abi ABI) pack(method Method, args ...interface{}) ([]byte, error) {
-	// variable input is the output appended at the end of packed
-	// output. This is used for strings and bytes types input.
-	var variableInput []byte
-
-	var ret []byte
-	for i, a := range args {
-		input := method.Inputs[i]
-		// pack the input
-		packed, err := input.Type.pack(a)
-		if err != nil {
-			return nil, fmt.Errorf("`%s` %v", method.Name, err)
-		}
-
-		// check for a slice type (string, bytes, slice)
-		if input.Type.T == StringTy || input.Type.T == BytesTy || input.Type.IsSlice {
-			// calculate the offset
-			offset := len(method.Inputs)*32 + len(variableInput)
-			// set the offset
-			ret = append(ret, packNum(reflect.ValueOf(offset), UintTy)...)
-			// Append the packed output to the variable input. The variable input
-			// will be appended at the end of the input.
-			variableInput = append(variableInput, packed...)
-		} else {
-			// append the packed value to the input
-			ret = append(ret, packed...)
-		}
-	}
-	// append the variable input at the end of the packed input
-	ret = append(ret, variableInput...)
-
-	return ret, nil
-}
-
 // Pack the given method name to conform the ABI. Method call's data
 // will consist of method_id, args0, arg1, ... argN. Method id consists
 // of 4 bytes and arguments are all 32 bytes.
@@ -102,11 +66,7 @@ func (abi ABI) Pack(name string, args ...interface{}) ([]byte, error) {
 		}
 		method = m
 	}
-	// Make sure arguments match up and pack them
-	if len(args) != len(method.Inputs) {
-		return nil, fmt.Errorf("argument count mismatch: %d for %d", len(args), len(method.Inputs))
-	}
-	arguments, err := abi.pack(method, args...)
+	arguments, err := method.pack(method, args...)
 	if err != nil {
 		return nil, err
 	}
@@ -126,18 +86,21 @@ func toGoSlice(i int, t Argument, output []byte) (interface{}, error) {
 	if index+32 > len(output) {
 		return nil, fmt.Errorf("abi: cannot marshal in to go slice: insufficient size output %d require %d", len(output), index+32)
 	}
+	elem := t.Type.Elem
 
 	// first we need to create a slice of the type
 	var refSlice reflect.Value
-	switch t.Type.T {
+	switch elem.T {
 	case IntTy, UintTy, BoolTy: // int, uint, bool can all be of type big int.
 		refSlice = reflect.ValueOf([]*big.Int(nil))
 	case AddressTy: // address must be of slice Address
 		refSlice = reflect.ValueOf([]common.Address(nil))
 	case HashTy: // hash must be of slice hash
 		refSlice = reflect.ValueOf([]common.Hash(nil))
+	case FixedBytesTy:
+		refSlice = reflect.ValueOf([]byte(nil))
 	default: // no other types are supported
-		return nil, fmt.Errorf("abi: unsupported slice type %v", t.Type.T)
+		return nil, fmt.Errorf("abi: unsupported slice type %v", elem.T)
 	}
 	// get the offset which determines the start of this array ...
 	offset := int(common.BytesToBig(output[index : index+32]).Uint64())
@@ -164,7 +127,7 @@ func toGoSlice(i int, t Argument, output []byte) (interface{}, error) {
 		)
 
 		// set inter to the correct type (cast)
-		switch t.Type.T {
+		switch elem.T {
 		case IntTy, UintTy:
 			inter = common.BytesToBig(returnOutput)
 		case BoolTy:
@@ -186,7 +149,7 @@ func toGoSlice(i int, t Argument, output []byte) (interface{}, error) {
 // argument in T.
 func toGoType(i int, t Argument, output []byte) (interface{}, error) {
 	// we need to treat slices differently
-	if t.Type.IsSlice {
+	if (t.Type.IsSlice || t.Type.IsArray) && t.Type.T != BytesTy && t.Type.T != StringTy && t.Type.T != FixedBytesTy {
 		return toGoSlice(i, t, output)
 	}
 
@@ -328,8 +291,8 @@ func set(dst, src reflect.Value, output Argument) error {
 			return fmt.Errorf("abi: cannot unmarshal %v in to array of elem %v", src.Type(), dstType.Elem())
 		}
 
-		if dst.Len() < output.Type.Size {
-			return fmt.Errorf("abi: cannot unmarshal src (len=%d) in to dst (len=%d)", output.Type.Size, dst.Len())
+		if dst.Len() < output.Type.SliceSize {
+			return fmt.Errorf("abi: cannot unmarshal src (len=%d) in to dst (len=%d)", output.Type.SliceSize, dst.Len())
 		}
 		reflect.Copy(dst, src)
 	default:

--- a/accounts/abi/abi.go
+++ b/accounts/abi/abi.go
@@ -197,13 +197,13 @@ func toGoType(i int, t Argument, output []byte) (interface{}, error) {
 		case reflect.Uint64:
 			return uint64(bigNum.Uint64()), nil
 		case reflect.Int8:
-			return uint8(bigNum.Int64()), nil
+			return int8(bigNum.Int64()), nil
 		case reflect.Int16:
-			return uint16(bigNum.Int64()), nil
+			return int16(bigNum.Int64()), nil
 		case reflect.Int32:
-			return uint32(bigNum.Int64()), nil
+			return int32(bigNum.Int64()), nil
 		case reflect.Int64:
-			return uint64(bigNum.Int64()), nil
+			return int64(bigNum.Int64()), nil
 		case reflect.Ptr:
 			return bigNum, nil
 		}

--- a/accounts/abi/abi.go
+++ b/accounts/abi/abi.go
@@ -180,12 +180,33 @@ func toGoType(i int, t Argument, output []byte) (interface{}, error) {
 		returnOutput = output[index : index+32]
 	}
 
-	// cast bytes to abi return type
+	// convert the bytes to whatever is specified by the ABI.
 	switch t.Type.T {
-	case IntTy:
-		return common.BytesToBig(returnOutput), nil
-	case UintTy:
-		return common.BytesToBig(returnOutput), nil
+	case IntTy, UintTy:
+		bigNum := common.BytesToBig(returnOutput)
+
+		// If the type is a integer convert to the integer type
+		// specified by the ABI.
+		switch t.Type.Kind {
+		case reflect.Uint8:
+			return uint8(bigNum.Uint64()), nil
+		case reflect.Uint16:
+			return uint16(bigNum.Uint64()), nil
+		case reflect.Uint32:
+			return uint32(bigNum.Uint64()), nil
+		case reflect.Uint64:
+			return uint64(bigNum.Uint64()), nil
+		case reflect.Int8:
+			return uint8(bigNum.Int64()), nil
+		case reflect.Int16:
+			return uint16(bigNum.Int64()), nil
+		case reflect.Int32:
+			return uint32(bigNum.Int64()), nil
+		case reflect.Int64:
+			return uint64(bigNum.Int64()), nil
+		case reflect.Ptr:
+			return bigNum, nil
+		}
 	case BoolTy:
 		return common.BytesToBig(returnOutput).Uint64() > 0, nil
 	case AddressTy:

--- a/accounts/abi/abi_test.go
+++ b/accounts/abi/abi_test.go
@@ -161,6 +161,13 @@ func TestSimpleMethodUnpack(t *testing.T) {
 			"hash",
 			nil,
 		},
+		{
+			`[ { "type": "bytes32" } ]`,
+			pad([]byte{1}, 32, false),
+			pad([]byte{1}, 32, false),
+			"interface",
+			nil,
+		},
 	} {
 		abiDefinition := fmt.Sprintf(`[{ "name" : "method", "outputs": %s}]`, test.def)
 		abi, err := JSON(strings.NewReader(abiDefinition))
@@ -203,6 +210,8 @@ func TestSimpleMethodUnpack(t *testing.T) {
 			var v common.Hash
 			err = abi.Unpack(&v, "method", test.marshalledOutput)
 			outvar = v
+		case "interface":
+			err = abi.Unpack(&outvar, "method", test.marshalledOutput)
 		default:
 			t.Errorf("unsupported type '%v' please add it to the switch statement in this test", test.outVar)
 			continue

--- a/accounts/abi/error.go
+++ b/accounts/abi/error.go
@@ -33,7 +33,7 @@ func formatSliceString(kind reflect.Kind, sliceSize int) string {
 // sliceTypeCheck checks that the given slice can by assigned to the reflection
 // type in t.
 func sliceTypeCheck(t Type, val reflect.Value) error {
-	if !(val.Kind() == reflect.Slice || val.Kind() == reflect.Array) {
+	if val.Kind() != reflect.Slice && val.Kind() != reflect.Array {
 		return typeErr(formatSliceString(t.Kind, t.SliceSize), val.Type())
 	}
 	if t.IsArray && val.Len() != t.SliceSize {
@@ -48,14 +48,13 @@ func sliceTypeCheck(t Type, val reflect.Value) error {
 		return sliceTypeCheck(*t.Elem, val.Index(0))
 	}
 
-	elemKind := val.Type().Elem().Kind()
-	if elemKind != t.Elem.Kind {
+	if elemKind := val.Type().Elem().Kind(); elemKind != t.Elem.Kind {
 		return typeErr(formatSliceString(t.Elem.Kind, t.SliceSize), val.Type())
 	}
 	return nil
 }
 
-// typeCheck checks that thet given reflection val can be assigned to the reflection
+// typeCheck checks that the given reflection value can be assigned to the reflection
 // type in t.
 func typeCheck(t Type, value reflect.Value) error {
 	if t.IsSlice || t.IsArray {

--- a/accounts/abi/error.go
+++ b/accounts/abi/error.go
@@ -1,0 +1,80 @@
+// Copyright 2016 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+package abi
+
+import (
+	"fmt"
+	"reflect"
+)
+
+// formatSliceString formats the reflection kind with the given slice size
+// and returns a formatted string representation.
+func formatSliceString(kind reflect.Kind, sliceSize int) string {
+	if sliceSize == -1 {
+		return fmt.Sprintf("[]%v", kind)
+	}
+	return fmt.Sprintf("[%d]%v", sliceSize, kind)
+}
+
+// sliceTypeCheck checks that the given slice can by assigned to the reflection
+// type in t.
+func sliceTypeCheck(t Type, val reflect.Value) error {
+	if !(val.Kind() == reflect.Slice || val.Kind() == reflect.Array) {
+		return typeErr(formatSliceString(t.Kind, t.SliceSize), val.Type())
+	}
+	if t.IsArray && val.Len() != t.SliceSize {
+		return typeErr(formatSliceString(t.Elem.Kind, t.SliceSize), formatSliceString(val.Type().Elem().Kind(), val.Len()))
+	}
+
+	if t.Elem.IsSlice {
+		if val.Len() > 0 {
+			return sliceTypeCheck(*t.Elem, val.Index(0))
+		}
+	} else if t.Elem.IsArray {
+		return sliceTypeCheck(*t.Elem, val.Index(0))
+	}
+
+	elemKind := val.Type().Elem().Kind()
+	if elemKind != t.Elem.Kind {
+		return typeErr(formatSliceString(t.Elem.Kind, t.SliceSize), val.Type())
+	}
+	return nil
+}
+
+// typeCheck checks that thet given reflection val can be assigned to the reflection
+// type in t.
+func typeCheck(t Type, value reflect.Value) error {
+	if t.IsSlice || t.IsArray {
+		return sliceTypeCheck(t, value)
+	}
+
+	// Check base type validity. Element types will be checked later on.
+	if t.Kind != value.Kind() {
+		return typeErr(t.Kind, value.Kind())
+	}
+	return nil
+}
+
+// varErr returns a formatted error.
+func varErr(expected, got reflect.Kind) error {
+	return typeErr(expected, got)
+}
+
+// typeErr returns a formatted type casting error.
+func typeErr(expected, got interface{}) error {
+	return fmt.Errorf("abi: cannot use %v as type %v as argument", got, expected)
+}

--- a/accounts/abi/method.go
+++ b/accounts/abi/method.go
@@ -58,7 +58,7 @@ func (m Method) pack(method Method, args ...interface{}) ([]byte, error) {
 		}
 
 		// check for a slice type (string, bytes, slice)
-		if input.Type.T == StringTy || input.Type.T == BytesTy || input.Type.IsSlice || input.Type.IsArray {
+		if input.Type.requiresLengthPrefix() {
 			// calculate the offset
 			offset := len(method.Inputs)*32 + len(variableInput)
 			// set the offset

--- a/accounts/abi/method.go
+++ b/accounts/abi/method.go
@@ -18,6 +18,7 @@ package abi
 
 import (
 	"fmt"
+	"reflect"
 	"strings"
 
 	"github.com/ethereum/go-ethereum/crypto"
@@ -36,6 +37,44 @@ type Method struct {
 	Const   bool
 	Inputs  []Argument
 	Outputs []Argument
+}
+
+func (m Method) pack(method Method, args ...interface{}) ([]byte, error) {
+	// Make sure arguments match up and pack them
+	if len(args) != len(method.Inputs) {
+		return nil, fmt.Errorf("argument count mismatch: %d for %d", len(args), len(method.Inputs))
+	}
+	// variable input is the output appended at the end of packed
+	// output. This is used for strings and bytes types input.
+	var variableInput []byte
+
+	var ret []byte
+	for i, a := range args {
+		input := method.Inputs[i]
+		// pack the input
+		packed, err := input.Type.pack(reflect.ValueOf(a))
+		if err != nil {
+			return nil, fmt.Errorf("`%s` %v", method.Name, err)
+		}
+
+		// check for a slice type (string, bytes, slice)
+		if input.Type.T == StringTy || input.Type.T == BytesTy || input.Type.IsSlice || input.Type.IsArray {
+			// calculate the offset
+			offset := len(method.Inputs)*32 + len(variableInput)
+			// set the offset
+			ret = append(ret, packNum(reflect.ValueOf(offset), UintTy)...)
+			// Append the packed output to the variable input. The variable input
+			// will be appended at the end of the input.
+			variableInput = append(variableInput, packed...)
+		} else {
+			// append the packed value to the input
+			ret = append(ret, packed...)
+		}
+	}
+	// append the variable input at the end of the packed input
+	ret = append(ret, variableInput...)
+
+	return ret, nil
 }
 
 // Sig returns the methods string signature according to the ABI spec.

--- a/accounts/abi/numbers.go
+++ b/accounts/abi/numbers.go
@@ -24,8 +24,8 @@ import (
 )
 
 var (
-	big_t     = reflect.TypeOf(&big.Int{})
-	ubig_t    = reflect.TypeOf(&big.Int{})
+	big_t     = reflect.TypeOf(big.Int{})
+	ubig_t    = reflect.TypeOf(big.Int{})
 	byte_t    = reflect.TypeOf(byte(0))
 	byte_ts   = reflect.TypeOf([]byte(nil))
 	uint_t    = reflect.TypeOf(uint(0))

--- a/accounts/abi/packing.go
+++ b/accounts/abi/packing.go
@@ -1,0 +1,65 @@
+// Copyright 2016 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+package abi
+
+import (
+	"reflect"
+
+	"github.com/ethereum/go-ethereum/common"
+)
+
+// packBytesSlice packs the given bytes as [L, V] as the canonical representation
+// bytes slice
+func packBytesSlice(bytes []byte, l int) []byte {
+	len := packNum(reflect.ValueOf(l), UintTy)
+	return append(len, common.RightPadBytes(bytes, (l+31)/32*32)...)
+}
+
+// packElement packs the given reflect value according to the abi specification in
+// t.
+func packElement(t Type, reflectValue reflect.Value) []byte {
+	switch t.T {
+	case IntTy, UintTy:
+		return packNum(reflectValue, t.T)
+	case StringTy:
+		return packBytesSlice([]byte(reflectValue.String()), reflectValue.Len())
+	case AddressTy:
+		if reflectValue.Kind() == reflect.Array {
+			reflectValue = mustArrayToByteSlice(reflectValue)
+		}
+
+		return common.LeftPadBytes(reflectValue.Bytes(), 32)
+	case BoolTy:
+		if reflectValue.Bool() {
+			return common.LeftPadBytes(common.Big1.Bytes(), 32)
+		} else {
+			return common.LeftPadBytes(common.Big0.Bytes(), 32)
+		}
+	case BytesTy:
+		if reflectValue.Kind() == reflect.Array {
+			reflectValue = mustArrayToByteSlice(reflectValue)
+		}
+		return packBytesSlice(reflectValue.Bytes(), reflectValue.Len())
+	case FixedBytesTy:
+		if reflectValue.Kind() == reflect.Array {
+			reflectValue = mustArrayToByteSlice(reflectValue)
+		}
+
+		return common.LeftPadBytes(reflectValue.Bytes(), 32)
+	}
+	panic("abi: fatal error")
+}

--- a/accounts/abi/packing.go
+++ b/accounts/abi/packing.go
@@ -59,7 +59,7 @@ func packElement(t Type, reflectValue reflect.Value) []byte {
 			reflectValue = mustArrayToByteSlice(reflectValue)
 		}
 
-		return common.LeftPadBytes(reflectValue.Bytes(), 32)
+		return common.RightPadBytes(reflectValue.Bytes(), 32)
 	}
 	panic("abi: fatal error")
 }

--- a/accounts/abi/reflect.go
+++ b/accounts/abi/reflect.go
@@ -1,0 +1,64 @@
+// Copyright 2016 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+package abi
+
+import "reflect"
+
+// indirect recursively dereferences the value until it either gets the value
+// or finds a big.Int
+func indirect(v reflect.Value) reflect.Value {
+	if v.Kind() == reflect.Ptr && v.Elem().Type() != big_t {
+		return indirect(v.Elem())
+	}
+	return v
+}
+
+// reflectIntKind returns the reflect using the given size and
+// unsignedness.
+func reflectIntKind(unsigned bool, size int) reflect.Kind {
+	switch size {
+	case 8:
+		if unsigned {
+			return reflect.Uint8
+		}
+		return reflect.Int8
+	case 16:
+		if unsigned {
+			return reflect.Uint16
+		}
+		return reflect.Int16
+	case 32:
+		if unsigned {
+			return reflect.Uint32
+		}
+		return reflect.Int32
+	case 64:
+		if unsigned {
+			return reflect.Uint64
+		}
+		return reflect.Int64
+	}
+	return reflect.Ptr
+}
+
+// mustArrayToBytesSlice creates a new byte slice with the exact same size as value
+// and copies the bytes in value to the new slice.
+func mustArrayToByteSlice(value reflect.Value) reflect.Value {
+	slice := reflect.MakeSlice(reflect.TypeOf([]byte{}), value.Len(), value.Len())
+	reflect.Copy(slice, value)
+	return slice
+}

--- a/accounts/abi/type.go
+++ b/accounts/abi/type.go
@@ -89,6 +89,7 @@ func NewType(t string) (typ Type, err error) {
 			return Type{}, err
 		}
 		typ.Elem = &sliceType
+		typ.stringKind = sliceType.stringKind + t[len(res[1]):]
 		return typ, nil
 	}
 
@@ -110,6 +111,7 @@ func NewType(t string) (typ Type, err error) {
 		varSize = 256
 		t += "256"
 	}
+	typ.stringKind = t
 
 	switch varType {
 	case "int":
@@ -149,7 +151,6 @@ func NewType(t string) (typ Type, err error) {
 	default:
 		return Type{}, fmt.Errorf("unsupported arg type: %s", t)
 	}
-	typ.stringKind = t
 
 	return
 }
@@ -180,4 +181,10 @@ func (t Type) pack(v reflect.Value) ([]byte, error) {
 	}
 
 	return packElement(t, v), nil
+}
+
+// requireLengthPrefix returns whether the type requires any sort of length
+// prefixing.
+func (t Type) requiresLengthPrefix() bool {
+	return t.T != FixedBytesTy && (t.T == StringTy || t.T == BytesTy || t.IsSlice || t.IsArray)
 }

--- a/accounts/abi/type.go
+++ b/accounts/abi/type.go
@@ -21,8 +21,6 @@ import (
 	"reflect"
 	"regexp"
 	"strconv"
-
-	"github.com/ethereum/go-ethereum/common"
 )
 
 const (
@@ -40,52 +38,58 @@ const (
 
 // Type is the reflection of the supported argument type
 type Type struct {
-	IsSlice   bool
-	SliceSize int
+	IsSlice, IsArray bool
+	SliceSize        int
 
-	Kind       reflect.Kind
-	Type       reflect.Type
-	Size       int
-	T          byte   // Our own type checking
+	Elem *Type
+
+	Kind reflect.Kind
+	Type reflect.Type
+	Size int
+	T    byte // Our own type checking
+
 	stringKind string // holds the unparsed string for deriving signatures
 }
 
 var (
+	// fullTypeRegex parses the abi types
+	//
+	// Types can be in the format of:
+	//
+	// 	Input  = Type [ "[" [ Number ] "]" ] Name .
+	// 	Type   = [ "u" ] "int" [ Number ] .
+	//
+	// Examples:
+	//
+	//      string     int       uint       real
+	//      string32   int8      uint8      uint[]
+	//      address    int256    uint256    real[2]
 	fullTypeRegex = regexp.MustCompile("([a-zA-Z0-9]+)(\\[([0-9]*)?\\])?")
-	typeRegex     = regexp.MustCompile("([a-zA-Z]+)([0-9]*)?")
+	// typeRegex parses the abi sub types
+	typeRegex = regexp.MustCompile("([a-zA-Z]+)([0-9]*)?")
 )
 
-// NewType returns a fully parsed Type given by the input string or an error if it  can't be parsed.
-//
-// Strings can be in the format of:
-//
-// 	Input  = Type [ "[" [ Number ] "]" ] Name .
-// 	Type   = [ "u" ] "int" [ Number ] .
-//
-// Examples:
-//
-//      string     int       uint       real
-//      string32   int8      uint8      uint[]
-//      address    int256    uint256    real[2]
+// NewType creates a new reflection type of abi type given in t.
 func NewType(t string) (typ Type, err error) {
-	// 1. full string 2. type 3. (opt.) is slice 4. (opt.) size
-	// parse the full representation of the abi-type definition; including:
-	// * full string
-	// * type
-	// 	* is slice
-	//	* slice size
 	res := fullTypeRegex.FindAllStringSubmatch(t, -1)[0]
-
 	// check if type is slice and parse type.
 	switch {
 	case res[3] != "":
 		// err is ignored. Already checked for number through the regexp
 		typ.SliceSize, _ = strconv.Atoi(res[3])
-		typ.IsSlice = true
+		typ.IsArray = true
 	case res[2] != "":
 		typ.IsSlice, typ.SliceSize = true, -1
 	case res[0] == "":
 		return Type{}, fmt.Errorf("abi: type parse error: %s", t)
+	}
+	if typ.IsArray || typ.IsSlice {
+		sliceType, err := NewType(res[1])
+		if err != nil {
+			return Type{}, err
+		}
+		typ.Elem = &sliceType
+		return typ, nil
 	}
 
 	// parse the type and size of the abi-type.
@@ -109,21 +113,20 @@ func NewType(t string) (typ Type, err error) {
 
 	switch varType {
 	case "int":
-		typ.Kind = reflect.Int
+		typ.Kind = reflectIntKind(false, varSize)
 		typ.Type = big_t
 		typ.Size = varSize
 		typ.T = IntTy
 	case "uint":
-		typ.Kind = reflect.Uint
+		typ.Kind = reflectIntKind(true, varSize)
 		typ.Type = ubig_t
 		typ.Size = varSize
 		typ.T = UintTy
 	case "bool":
 		typ.Kind = reflect.Bool
 		typ.T = BoolTy
-	case "real": // TODO
-		typ.Kind = reflect.Invalid
 	case "address":
+		typ.Kind = reflect.Array
 		typ.Type = address_t
 		typ.Size = 20
 		typ.T = AddressTy
@@ -131,22 +134,17 @@ func NewType(t string) (typ Type, err error) {
 		typ.Kind = reflect.String
 		typ.Size = -1
 		typ.T = StringTy
-		if varSize > 0 {
-			typ.Size = 32
-		}
-	case "hash":
-		typ.Kind = reflect.Array
-		typ.Size = 32
-		typ.Type = hash_t
-		typ.T = HashTy
 	case "bytes":
-		typ.Kind = reflect.Array
-		typ.Type = byte_ts
-		typ.Size = varSize
+		sliceType, _ := NewType("uint8")
+		typ.Elem = &sliceType
 		if varSize == 0 {
+			typ.IsSlice = true
 			typ.T = BytesTy
+			typ.SliceSize = -1
 		} else {
+			typ.IsArray = true
 			typ.T = FixedBytesTy
+			typ.SliceSize = varSize
 		}
 	default:
 		return Type{}, fmt.Errorf("unsupported arg type: %s", t)
@@ -156,98 +154,30 @@ func NewType(t string) (typ Type, err error) {
 	return
 }
 
+// String implements Stringer
 func (t Type) String() (out string) {
 	return t.stringKind
 }
 
-// packBytesSlice packs the given bytes as [L, V] as the canonical representation
-// bytes slice
-func packBytesSlice(bytes []byte, l int) []byte {
-	len := packNum(reflect.ValueOf(l), UintTy)
-	return append(len, common.RightPadBytes(bytes, (l+31)/32*32)...)
-}
+func (t Type) pack(v reflect.Value) ([]byte, error) {
+	// dereference pointer first if it's a pointer
+	v = indirect(v)
 
-// Test the given input parameter `v` and checks if it matches certain
-// criteria
-// * Big integers are checks for ptr types and if the given value is
-//   assignable
-// * Integer are checked for size
-// * Strings, addresses and bytes are checks for type and size
-func (t Type) pack(v interface{}) ([]byte, error) {
-	value := reflect.ValueOf(v)
-	switch kind := value.Kind(); kind {
-	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
-		// check input is unsigned
-		if t.Type != ubig_t {
-			return nil, fmt.Errorf("abi: type mismatch: %s for %T", t.Type, v)
-		}
+	if err := typeCheck(t, v); err != nil {
+		return nil, err
+	}
 
-		// no implicit type casting
-		if int(value.Type().Size()*8) != t.Size {
-			return nil, fmt.Errorf("abi: cannot use type %T as type uint%d", v, t.Size)
-		}
-
-		return packNum(value, t.T), nil
-	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
-		if t.Type != ubig_t {
-			return nil, fmt.Errorf("type mismatch: %s for %T", t.Type, v)
-		}
-
-		// no implicit type casting
-		if int(value.Type().Size()*8) != t.Size {
-			return nil, fmt.Errorf("abi: cannot use type %T as type uint%d", v, t.Size)
-		}
-		return packNum(value, t.T), nil
-	case reflect.Ptr:
-		// If the value is a ptr do a assign check (only used by
-		// big.Int for now)
-		if t.Type == ubig_t && value.Type() != ubig_t {
-			return nil, fmt.Errorf("type mismatch: %s for %T", t.Type, v)
-		}
-		return packNum(value, t.T), nil
-	case reflect.String:
-		if t.Size > -1 && value.Len() > t.Size {
-			return nil, fmt.Errorf("%v out of bound. %d for %d", value.Kind(), value.Len(), t.Size)
-		}
-
-		return packBytesSlice([]byte(value.String()), value.Len()), nil
-	case reflect.Slice:
-		// Byte slice is a special case, it gets treated as a single value
-		if t.T == BytesTy {
-			return packBytesSlice(value.Bytes(), value.Len()), nil
-		}
-
-		if t.SliceSize > -1 && value.Len() > t.SliceSize {
-			return nil, fmt.Errorf("%v out of bound. %d for %d", value.Kind(), value.Len(), t.Size)
-		}
-
-		// Signed / Unsigned check
-		if value.Type() == big_t && (t.T != IntTy && isSigned(value)) || (t.T == UintTy && isSigned(value)) {
-			return nil, fmt.Errorf("slice of incompatible types.")
-		}
-
+	if (t.IsSlice || t.IsArray) && t.T != BytesTy && t.T != FixedBytesTy {
 		var packed []byte
-		for i := 0; i < value.Len(); i++ {
-			val, err := t.pack(value.Index(i).Interface())
+		for i := 0; i < v.Len(); i++ {
+			val, err := t.Elem.pack(v.Index(i))
 			if err != nil {
 				return nil, err
 			}
 			packed = append(packed, val...)
 		}
-		return packBytesSlice(packed, value.Len()), nil
-	case reflect.Bool:
-		if value.Bool() {
-			return common.LeftPadBytes(common.Big1.Bytes(), 32), nil
-		} else {
-			return common.LeftPadBytes(common.Big0.Bytes(), 32), nil
-		}
-	case reflect.Array:
-		if v, ok := value.Interface().(common.Address); ok {
-			return common.LeftPadBytes(v[:], 32), nil
-		} else if v, ok := value.Interface().(common.Hash); ok {
-			return v[:], nil
-		}
+		return packBytesSlice(packed, v.Len()), nil
 	}
 
-	return nil, fmt.Errorf("ABI: bad input given %v", value.Kind())
+	return packElement(t, v), nil
 }


### PR DESCRIPTION
Refactored the abi package parsing and type handling. Relying mostly on
package reflect as opposed to most of our own type reflection. Our own
type reflection is still used however for cases such as Bytes and
FixedBytes (abi: bytes•).

This also inclused several fixes for slice handling of arbitrary and
fixed size for all supported types.

This also further removes implicit type casting such as assigning,
for example `[2]T{} = []T{1}` will fail, however `[2]T{} == []T{1, 2}`
(notice assigning *slice* to fixed size *array*). Assigning arrays to
slices will always succeed if they are of the same element type.

Incidentally also fixes #2379 

| Reviewers |
|---|
| @zelig |
| @karalabe |
| @fjl |