### PR TITLE
cmd/gethrpctest: add missing chain configuration config field

### DIFF
--- a/cmd/gethrpctest/main.go
+++ b/cmd/gethrpctest/main.go
@@ -26,11 +26,13 @@ import (
 
 	"github.com/ethereum/go-ethereum/accounts"
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/eth"
 	"github.com/ethereum/go-ethereum/ethdb"
 	"github.com/ethereum/go-ethereum/logger/glog"
 	"github.com/ethereum/go-ethereum/node"
+	"github.com/ethereum/go-ethereum/params"
 	"github.com/ethereum/go-ethereum/tests"
 	"github.com/ethereum/go-ethereum/whisper"
 )
@@ -129,6 +131,7 @@ func MakeSystemNode(keydir string, privkey string, test *tests.BlockTest) (*node
 	ethConf := &eth.Config{
 		TestGenesisState: db,
 		TestGenesisBlock: test.Genesis,
+		ChainConfig:      &core.ChainConfig{HomesteadBlock: params.MainNetHomesteadBlock},
 		AccountManager:   accman,
 	}
 	if err := stack.Register(func(ctx *node.ServiceContext) (node.Service, error) { return eth.New(ctx, ethConf) }); err != nil {

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -19,6 +19,7 @@ package eth
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"math/big"
 	"os"
@@ -243,6 +244,9 @@ func New(ctx *node.ServiceContext, config *Config) (*Ethereum, error) {
 		glog.V(logger.Info).Infoln("WARNING: Wrote default ethereum genesis block")
 	}
 
+	if config.ChainConfig == nil {
+		return nil, errors.New("missing chain config")
+	}
 	eth.chainConfig = config.ChainConfig
 	eth.chainConfig.VmConfig = vm.Config{
 		EnableJit: config.EnableJit,


### PR DESCRIPTION
This PR fixes a tiny regression caused by the chain config PR where the RPC test command wasn't updated to include the default config and caused a panic in `eth`.

 - Fix `gethrpctest` to set the homestead block to the default main net one.
 - Fix `eth` to gracefully fail if no config is provided vs. the current hard panic.

@obscuren please review.