### PR TITLE
accounts: disable filesystem notifications on iOS

### DIFF
--- a/accounts/watch.go
+++ b/accounts/watch.go
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
 
-// +build darwin freebsd linux netbsd solaris windows
+// +build darwin,!ios freebsd linux netbsd solaris windows
 
 package accounts
 

--- a/accounts/watch_fallback.go
+++ b/accounts/watch_fallback.go
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
 
-// +build !darwin,!freebsd,!linux,!netbsd,!solaris,!windows
+// +build ios !darwin,!freebsd,!linux,!netbsd,!solaris,!windows
 
 // This is the fallback implementation of directory watching.
 // It is used on unsupported platforms.


### PR DESCRIPTION
The file notification library on darwin uses [`fsevents`](https://github.com/rjeczalik/notify/blob/master/watcher_fsevents_cgo.go) by default. This is OSX specific and not available on iThingy platforms. This PR adds a build tag when compiling to iOS so that the file notifications use `kqueue` instead of the unavailable one.

@fjl Please check if this makes sense.