### PR TITLE
all: fix go vet warnings

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -109,6 +109,7 @@ test: all
 	build/env.sh go test ./...
 
 travis-test-with-coverage: all
+	build/env.sh go vet ./...
 	build/env.sh build/test-global-coverage.sh
 
 xgo:

--- a/accounts/abi/numbers_test.go
+++ b/accounts/abi/numbers_test.go
@@ -30,17 +30,17 @@ func TestNumberTypes(t *testing.T) {
 
 	unsigned := U256(big.NewInt(1))
 	if !bytes.Equal(unsigned, ubytes) {
-		t.Error("expected %x got %x", ubytes, unsigned)
+		t.Errorf("expected %x got %x", ubytes, unsigned)
 	}
 
 	signed := S256(big.NewInt(1))
 	if !bytes.Equal(signed, ubytes) {
-		t.Error("expected %x got %x", ubytes, unsigned)
+		t.Errorf("expected %x got %x", ubytes, unsigned)
 	}
 
 	signed = S256(big.NewInt(-1))
 	if !bytes.Equal(signed, sbytesmin) {
-		t.Error("expected %x got %x", ubytes, unsigned)
+		t.Errorf("expected %x got %x", ubytes, unsigned)
 	}
 }
 
@@ -75,10 +75,10 @@ func TestPackNumber(t *testing.T) {
 
 func TestSigned(t *testing.T) {
 	if isSigned(reflect.ValueOf(uint(10))) {
-		t.Error()
+		t.Error("signed")
 	}
 
 	if !isSigned(reflect.ValueOf(int(10))) {
-		t.Error()
+		t.Error("not signed")
 	}
 }

--- a/cmd/bootnode/main.go
+++ b/cmd/bootnode/main.go
@@ -79,7 +79,7 @@ func main() {
 func writeKey(target string) {
 	key, err := crypto.GenerateKey()
 	if err != nil {
-		log.Fatal("could not generate key: %v", err)
+		log.Fatalf("could not generate key: %v", err)
 	}
 	b := crypto.FromECDSA(key)
 	if target == "-" {

--- a/cmd/ethtest/main.go
+++ b/cmd/ethtest/main.go
@@ -76,7 +76,8 @@ func runTestWithReader(test string, r io.Reader) error {
 	case "bk", "block", "blocktest", "blockchaintest", "blocktests", "blockchaintests":
 		err = tests.RunBlockTestWithReader(params.MainNetHomesteadBlock, r, skipTests)
 	case "st", "state", "statetest", "statetests":
-		err = tests.RunStateTestWithReader(tests.RuleSet{params.MainNetHomesteadBlock}, r, skipTests)
+		rs := tests.RuleSet{HomesteadBlock: params.MainNetHomesteadBlock}
+		err = tests.RunStateTestWithReader(rs, r, skipTests)
 	case "tx", "transactiontest", "transactiontests":
 		err = tests.RunTransactionTestsWithReader(r, skipTests)
 	case "vm", "vmtest", "vmtests":

--- a/cmd/geth/js_test.go
+++ b/cmd/geth/js_test.go
@@ -89,7 +89,10 @@ func testREPL(t *testing.T, config func(*eth.Config)) (string, *testjethre, *nod
 	// Initialize and register the Ethereum protocol
 	accman := accounts.NewPlaintextManager(filepath.Join(tmp, "keystore"))
 	db, _ := ethdb.NewMemDatabase()
-	core.WriteGenesisBlockForTesting(db, core.GenesisAccount{common.HexToAddress(testAddress), common.String2Big(testBalance)})
+	core.WriteGenesisBlockForTesting(db, core.GenesisAccount{
+		Address: common.HexToAddress(testAddress),
+		Balance: common.String2Big(testBalance),
+	})
 	ethConf := &eth.Config{
 		ChainConfig:      &core.ChainConfig{HomesteadBlock: new(big.Int)},
 		TestGenesisState: db,

--- a/cmd/utils/jeth.go
+++ b/cmd/utils/jeth.go
@@ -131,13 +131,11 @@ func (self *Jeth) NewAccount(call otto.FunctionCall) (response otto.Value) {
 		return otto.FalseValue()
 	}
 
-	if ret, err := call.Otto.Call("jeth.newAccount", nil, passwd); err == nil {
+	ret, err := call.Otto.Call("jeth.newAccount", nil, passwd)
+	if err == nil {
 		return ret
-	} else {
-		fmt.Printf("%v\n", err)
-		return otto.FalseValue()
 	}
-
+	fmt.Println(err)
 	return otto.FalseValue()
 }
 
@@ -233,7 +231,6 @@ func (self *Jeth) Send(call otto.FunctionCall) (response otto.Value) {
 func throwJSExeception(msg interface{}) otto.Value {
 	p, _ := otto.ToValue(msg)
 	panic(p)
-	return p
 }
 
 // Sleep will halt the console for arg[0] seconds.

--- a/common/compiler/solidity_test.go
+++ b/common/compiler/solidity_test.go
@@ -57,7 +57,7 @@ func TestCompiler(t *testing.T) {
 	}
 
 	if len(contracts) != 1 {
-		t.Errorf("one contract expected, got\n%s", len(contracts))
+		t.Errorf("one contract expected, got %d", len(contracts))
 	}
 
 	if contracts["test"].Code != code {

--- a/common/math/dist_test.go
+++ b/common/math/dist_test.go
@@ -35,7 +35,7 @@ func TestSum(t *testing.T) {
 	summer := summer{numbers: []*big.Int{big.NewInt(1), big.NewInt(2), big.NewInt(3)}}
 	sum := Sum(summer)
 	if sum.Cmp(big.NewInt(6)) != 0 {
-		t.Errorf("not 6", sum)
+		t.Errorf("got sum = %d, want 6", sum)
 	}
 }
 

--- a/common/path.go
+++ b/common/path.go
@@ -34,7 +34,7 @@ func MakeName(name, version string) string {
 
 func ExpandHomePath(p string) (path string) {
 	path = p
-	sep := fmt.Sprintf("%s", os.PathSeparator)
+	sep := string(os.PathSeparator)
 
 	// Check in case of paths like "/something/~/something/"
 	if len(p) > 1 && p[:1+len(sep)] == "~"+sep {

--- a/core/asm.go
+++ b/core/asm.go
@@ -61,6 +61,4 @@ func Disassemble(script []byte) (asm []string) {
 
 		pc.Add(pc, common.Big1)
 	}
-
-	return asm
 }

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -678,7 +678,7 @@ func (self *BlockChain) InsertReceiptChain(blockChain types.Blocks, receiptChain
 				}
 			}
 			// Write all the data out into the database
-			if err := WriteBody(self.chainDb, block.Hash(), &types.Body{block.Transactions(), block.Uncles()}); err != nil {
+			if err := WriteBody(self.chainDb, block.Hash(), block.Body()); err != nil {
 				errs[index] = fmt.Errorf("failed to write block body: %v", err)
 				atomic.AddInt32(&failed, 1)
 				glog.Fatal(errs[index])

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -993,7 +993,7 @@ func (self *BlockChain) reorg(oldBlock, newBlock *types.Block) error {
 	// first reduce whoever is higher bound
 	if oldBlock.NumberU64() > newBlock.NumberU64() {
 		// reduce old chain
-		for oldBlock = oldBlock; oldBlock != nil && oldBlock.NumberU64() != newBlock.NumberU64(); oldBlock = self.GetBlock(oldBlock.ParentHash()) {
+		for ; oldBlock != nil && oldBlock.NumberU64() != newBlock.NumberU64(); oldBlock = self.GetBlock(oldBlock.ParentHash()) {
 			oldChain = append(oldChain, oldBlock)
 			deletedTxs = append(deletedTxs, oldBlock.Transactions()...)
 
@@ -1001,7 +1001,7 @@ func (self *BlockChain) reorg(oldBlock, newBlock *types.Block) error {
 		}
 	} else {
 		// reduce new chain and append new chain blocks for inserting later on
-		for newBlock = newBlock; newBlock != nil && newBlock.NumberU64() != oldBlock.NumberU64(); newBlock = self.GetBlock(newBlock.ParentHash()) {
+		for ; newBlock != nil && newBlock.NumberU64() != oldBlock.NumberU64(); newBlock = self.GetBlock(newBlock.ParentHash()) {
 			newChain = append(newChain, newBlock)
 		}
 	}

--- a/core/database_util.go
+++ b/core/database_util.go
@@ -318,7 +318,7 @@ func WriteTd(db ethdb.Database, hash common.Hash, td *big.Int) error {
 // WriteBlock serializes a block into the database, header and body separately.
 func WriteBlock(db ethdb.Database, block *types.Block) error {
 	// Store the body first to retain database consistency
-	if err := WriteBody(db, block.Hash(), &types.Body{block.Transactions(), block.Uncles()}); err != nil {
+	if err := WriteBody(db, block.Hash(), block.Body()); err != nil {
 		return err
 	}
 	// Store the header too, signaling full block ownership

--- a/core/database_util_test.go
+++ b/core/database_util_test.go
@@ -196,7 +196,7 @@ func TestBlockStorage(t *testing.T) {
 	if entry := GetBody(db, block.Hash()); entry == nil {
 		t.Fatalf("Stored body not found")
 	} else if types.DeriveSha(types.Transactions(entry.Transactions)) != types.DeriveSha(block.Transactions()) || types.CalcUncleHash(entry.Uncles) != types.CalcUncleHash(block.Uncles()) {
-		t.Fatalf("Retrieved body mismatch: have %v, want %v", entry, &types.Body{block.Transactions(), block.Uncles()})
+		t.Fatalf("Retrieved body mismatch: have %v, want %v", entry, block.Body())
 	}
 	// Delete the block and verify the execution
 	DeleteBlock(db, block.Hash())
@@ -230,7 +230,7 @@ func TestPartialBlockStorage(t *testing.T) {
 	DeleteHeader(db, block.Hash())
 
 	// Store a body and check that it's not recognized as a block
-	if err := WriteBody(db, block.Hash(), &types.Body{block.Transactions(), block.Uncles()}); err != nil {
+	if err := WriteBody(db, block.Hash(), block.Body()); err != nil {
 		t.Fatalf("Failed to write body into database: %v", err)
 	}
 	if entry := GetBlock(db, block.Hash()); entry != nil {
@@ -242,7 +242,7 @@ func TestPartialBlockStorage(t *testing.T) {
 	if err := WriteHeader(db, block.Header()); err != nil {
 		t.Fatalf("Failed to write header into database: %v", err)
 	}
-	if err := WriteBody(db, block.Hash(), &types.Body{block.Transactions(), block.Uncles()}); err != nil {
+	if err := WriteBody(db, block.Hash(), block.Body()); err != nil {
 		t.Fatalf("Failed to write body into database: %v", err)
 	}
 	if entry := GetBlock(db, block.Hash()); entry == nil {

--- a/core/state/dump.go
+++ b/core/state/dump.go
@@ -46,11 +46,19 @@ func (self *StateDB) RawDump() World {
 	it := self.trie.Iterator()
 	for it.Next() {
 		addr := self.trie.GetKey(it.Key)
-		stateObject, _ := DecodeObject(common.BytesToAddress(addr), self.db, it.Value)
+		stateObject, err := DecodeObject(common.BytesToAddress(addr), self.db, it.Value)
+		if err != nil {
+			panic(err)
+		}
 
-		account := Account{Balance: stateObject.balance.String(), Nonce: stateObject.nonce, Root: common.Bytes2Hex(stateObject.Root()), CodeHash: common.Bytes2Hex(stateObject.codeHash), Code: common.Bytes2Hex(stateObject.Code())}
-		account.Storage = make(map[string]string)
-
+		account := Account{
+			Balance:  stateObject.balance.String(),
+			Nonce:    stateObject.nonce,
+			Root:     common.Bytes2Hex(stateObject.Root()),
+			CodeHash: common.Bytes2Hex(stateObject.codeHash),
+			Code:     common.Bytes2Hex(stateObject.Code()),
+			Storage:  make(map[string]string),
+		}
 		storageIt := stateObject.trie.Iterator()
 		for storageIt.Next() {
 			account.Storage[common.Bytes2Hex(self.trie.GetKey(storageIt.Key))] = common.Bytes2Hex(storageIt.Value)

--- a/core/state/state_object.go
+++ b/core/state/state_object.go
@@ -287,7 +287,7 @@ func DecodeObject(address common.Address, db trie.Database, data []byte) (*State
 	}
 	if !bytes.Equal(ext.CodeHash, emptyCodeHash) {
 		if obj.code, err = db.Get(ext.CodeHash); err != nil {
-			return nil, fmt.Errorf("can't find code for hash %x: %v", ext.CodeHash, err)
+			return nil, fmt.Errorf("can't get code for hash %x: %v", ext.CodeHash, err)
 		}
 	}
 	obj.nonce = ext.Nonce

--- a/core/state/state_test.go
+++ b/core/state/state_test.go
@@ -36,7 +36,6 @@ var _ = checker.Suite(&StateSuite{})
 var toAddr = common.BytesToAddress
 
 func (s *StateSuite) TestDump(c *checker.C) {
-	return
 	// generate a few entries
 	obj1 := s.state.GetOrNewStateObject(toAddr([]byte{0x01}))
 	obj1.AddBalance(big.NewInt(22))
@@ -48,24 +47,35 @@ func (s *StateSuite) TestDump(c *checker.C) {
 	// write some of them to the trie
 	s.state.UpdateStateObject(obj1)
 	s.state.UpdateStateObject(obj2)
+	s.state.Commit()
 
 	// check that dump contains the state objects that are in trie
 	got := string(s.state.Dump())
 	want := `{
-    "root": "6e277ae8357d013e50f74eedb66a991f6922f93ae03714de58b3d0c5e9eee53f",
+    "root": "71edff0130dd2385947095001c73d9e28d862fc286fca2b922ca6f6f3cddfdd2",
     "accounts": {
-        "1468288056310c82aa4c01a7e12a10f8111a0560e72b700555479031b86c357d": {
+        "0000000000000000000000000000000000000001": {
             "balance": "22",
             "nonce": 0,
             "root": "56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421",
             "codeHash": "c5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
+            "code": "",
             "storage": {}
         },
-        "a17eacbc25cda025e81db9c5c62868822c73ce097cee2a63e33a2e41268358a1": {
+        "0000000000000000000000000000000000000002": {
+            "balance": "44",
+            "nonce": 0,
+            "root": "56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421",
+            "codeHash": "c5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
+            "code": "",
+            "storage": {}
+        },
+        "0000000000000000000000000000000000000102": {
             "balance": "0",
             "nonce": 0,
             "root": "56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421",
             "codeHash": "87874902497a5bb968da31a2998d8f22e949d1ef6214bcdedd8bae24cca4b9e3",
+            "code": "03030303030303",
             "storage": {}
         }
     }

--- a/core/state/sync_test.go
+++ b/core/state/sync_test.go
@@ -145,7 +145,7 @@ func testIterativeStateSync(t *testing.T, batch int) {
 			if err != nil {
 				t.Fatalf("failed to retrieve node data for %x: %v", hash, err)
 			}
-			results[i] = trie.SyncResult{hash, data}
+			results[i] = trie.SyncResult{Hash: hash, Data: data}
 		}
 		if index, err := sched.Process(results); err != nil {
 			t.Fatalf("failed to process result #%d: %v", index, err)
@@ -175,7 +175,7 @@ func TestIterativeDelayedStateSync(t *testing.T) {
 			if err != nil {
 				t.Fatalf("failed to retrieve node data for %x: %v", hash, err)
 			}
-			results[i] = trie.SyncResult{hash, data}
+			results[i] = trie.SyncResult{Hash: hash, Data: data}
 		}
 		if index, err := sched.Process(results); err != nil {
 			t.Fatalf("failed to process result #%d: %v", index, err)
@@ -212,7 +212,7 @@ func testIterativeRandomStateSync(t *testing.T, batch int) {
 			if err != nil {
 				t.Fatalf("failed to retrieve node data for %x: %v", hash, err)
 			}
-			results = append(results, trie.SyncResult{hash, data})
+			results = append(results, trie.SyncResult{Hash: hash, Data: data})
 		}
 		// Feed the retrieved results back and queue new tasks
 		if index, err := sched.Process(results); err != nil {
@@ -251,7 +251,7 @@ func TestIterativeRandomDelayedStateSync(t *testing.T) {
 			if err != nil {
 				t.Fatalf("failed to retrieve node data for %x: %v", hash, err)
 			}
-			results = append(results, trie.SyncResult{hash, data})
+			results = append(results, trie.SyncResult{Hash: hash, Data: data})
 
 			if len(results) >= cap(results) {
 				break
@@ -289,7 +289,7 @@ func TestIncompleteStateSync(t *testing.T) {
 			if err != nil {
 				t.Fatalf("failed to retrieve node data for %x: %v", hash, err)
 			}
-			results[i] = trie.SyncResult{hash, data}
+			results[i] = trie.SyncResult{Hash: hash, Data: data}
 		}
 		// Process each of the state nodes
 		if index, err := sched.Process(results); err != nil {

--- a/core/types/block.go
+++ b/core/types/block.go
@@ -330,6 +330,9 @@ func (b *Block) Extra() []byte            { return common.CopyBytes(b.header.Ext
 
 func (b *Block) Header() *Header { return CopyHeader(b.header) }
 
+// Body returns the non-header content of the block.
+func (b *Block) Body() *Body { return &Body{b.transactions, b.uncles} }
+
 func (b *Block) HashNoNonce() common.Hash {
 	return b.header.HashNoNonce()
 }

--- a/core/vm/asm.go
+++ b/core/vm/asm.go
@@ -58,6 +58,4 @@ func Disassemble(script []byte) (asm []string) {
 
 		pc.Add(pc, common.Big1)
 	}
-
-	return
 }

--- a/core/vm/jit_util_test.go
+++ b/core/vm/jit_util_test.go
@@ -77,7 +77,7 @@ func TestParser(t *testing.T) {
 				t.Fatal("empty output")
 			}
 			if output[0] != test.output {
-				t.Error("%v failed: expected %v but got %v", test.base+OpCode(i), output[0])
+				t.Errorf("%v failed: expected %v but got %v", test.base+OpCode(i), test.output, output[0])
 			}
 		}
 	}

--- a/crypto/crypto.go
+++ b/crypto/crypto.go
@@ -107,7 +107,7 @@ func ToECDSAPub(pub []byte) *ecdsa.PublicKey {
 		return nil
 	}
 	x, y := elliptic.Unmarshal(secp256k1.S256(), pub)
-	return &ecdsa.PublicKey{secp256k1.S256(), x, y}
+	return &ecdsa.PublicKey{Curve: secp256k1.S256(), X: x, Y: y}
 }
 
 func FromECDSAPub(pub *ecdsa.PublicKey) []byte {
@@ -189,7 +189,7 @@ func SigToPub(hash, sig []byte) (*ecdsa.PublicKey, error) {
 	}
 
 	x, y := elliptic.Unmarshal(secp256k1.S256(), s)
-	return &ecdsa.PublicKey{secp256k1.S256(), x, y}, nil
+	return &ecdsa.PublicKey{Curve: secp256k1.S256(), X: x, Y: y}, nil
 }
 
 func Sign(hash []byte, prv *ecdsa.PrivateKey) (sig []byte, err error) {

--- a/crypto/ecies/ecies.go
+++ b/crypto/ecies/ecies.go
@@ -60,7 +60,7 @@ type PublicKey struct {
 
 // Export an ECIES public key as an ECDSA public key.
 func (pub *PublicKey) ExportECDSA() *ecdsa.PublicKey {
-	return &ecdsa.PublicKey{pub.Curve, pub.X, pub.Y}
+	return &ecdsa.PublicKey{Curve: pub.Curve, X: pub.X, Y: pub.Y}
 }
 
 // Import an ECDSA public key as an ECIES public key.
@@ -83,7 +83,7 @@ type PrivateKey struct {
 func (prv *PrivateKey) ExportECDSA() *ecdsa.PrivateKey {
 	pub := &prv.PublicKey
 	pubECDSA := pub.ExportECDSA()
-	return &ecdsa.PrivateKey{*pubECDSA, prv.D}
+	return &ecdsa.PrivateKey{PublicKey: *pubECDSA, D: prv.D}
 }
 
 // Import an ECDSA private key as an ECIES private key.

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -557,7 +557,7 @@ func upgradeChainDatabase(db ethdb.Database) error {
 			if err := core.WriteTd(db, block.Hash(), block.DeprecatedTd()); err != nil {
 				return err
 			}
-			if err := core.WriteBody(db, block.Hash(), &types.Body{block.Transactions(), block.Uncles()}); err != nil {
+			if err := core.WriteBody(db, block.Hash(), block.Body()); err != nil {
 				return err
 			}
 			if err := core.WriteHeader(db, block.Header()); err != nil {
@@ -573,7 +573,7 @@ func upgradeChainDatabase(db ethdb.Database) error {
 		if err := core.WriteTd(db, current.Hash(), current.DeprecatedTd()); err != nil {
 			return err
 		}
-		if err := core.WriteBody(db, current.Hash(), &types.Body{current.Transactions(), current.Uncles()}); err != nil {
+		if err := core.WriteBody(db, current.Hash(), current.Body()); err != nil {
 			return err
 		}
 		if err := core.WriteHeader(db, current.Header()); err != nil {

--- a/eth/downloader/downloader.go
+++ b/eth/downloader/downloader.go
@@ -892,8 +892,7 @@ func (d *Downloader) fetchBlocks61(from uint64) error {
 					// case, the internal state of the downloader and the queue is very wrong so
 					// better hard crash and note the error instead of silently accumulating into
 					// a much bigger issue.
-					panic(fmt.Sprintf("%v: fetch assignment failed, hard panic", peer))
-					d.queue.CancelBlocks(request) // noop for now
+					panic(fmt.Sprintf("%v: fetch assignment failed", peer))
 				}
 			}
 			// Make sure that we have peers available for fetching. If all peers have been tried
@@ -1525,8 +1524,7 @@ func (d *Downloader) fetchParts(errCancel error, deliveryCh chan dataPack, deliv
 					// case, the internal state of the downloader and the queue is very wrong so
 					// better hard crash and note the error instead of silently accumulating into
 					// a much bigger issue.
-					panic(fmt.Sprintf("%v: %s fetch assignment failed, hard panic", peer, strings.ToLower(kind)))
-					cancel(request) // noop for now
+					panic(fmt.Sprintf("%v: %s fetch assignment failed", peer, strings.ToLower(kind)))
 				}
 				running = true
 			}

--- a/eth/downloader/queue.go
+++ b/eth/downloader/queue.go
@@ -983,7 +983,7 @@ func (q *queue) DeliverNodeData(id string, data [][]byte, callback func(error, i
 			continue
 		}
 		// Inject the next state trie item into the processing queue
-		process = append(process, trie.SyncResult{hash, blob})
+		process = append(process, trie.SyncResult{Hash: hash, Data: blob})
 		accepted++
 
 		delete(request.Hashes, hash)

--- a/eth/filters/api.go
+++ b/eth/filters/api.go
@@ -331,7 +331,7 @@ func (args *NewFilterArgs) UnmarshalJSON(data []byte) error {
 					if decAddr, err := hex.DecodeString(strAddr); err == nil {
 						addresses = append(addresses, common.BytesToAddress(decAddr))
 					} else {
-						fmt.Errorf("invalid address given")
+						return fmt.Errorf("invalid address given")
 					}
 				} else {
 					return fmt.Errorf("invalid address on index %d", i)
@@ -344,10 +344,10 @@ func (args *NewFilterArgs) UnmarshalJSON(data []byte) error {
 			if decAddr, err := hex.DecodeString(singleAddr); err == nil {
 				addresses = append(addresses, common.BytesToAddress(decAddr))
 			} else {
-				fmt.Errorf("invalid address given")
+				return fmt.Errorf("invalid address given")
 			}
 		} else {
-			errors.New("invalid address(es) given")
+			return errors.New("invalid address(es) given")
 		}
 		args.Addresses = addresses
 	}
@@ -394,7 +394,7 @@ func (args *NewFilterArgs) UnmarshalJSON(data []byte) error {
 								parsedTopics[i] = []common.Hash{t}
 							}
 						} else {
-							fmt.Errorf("topic[%d][%d] not a string", i, j)
+							return fmt.Errorf("topic[%d][%d] not a string", i, j)
 						}
 					}
 				} else {

--- a/eth/filters/filter_system_test.go
+++ b/eth/filters/filter_system_test.go
@@ -76,8 +76,8 @@ func TestCallbacks(t *testing.T) {
 	mux.Post(core.ChainEvent{})
 	mux.Post(core.TxPreEvent{})
 	mux.Post(vm.Logs{&vm.Log{}})
-	mux.Post(core.RemovedLogsEvent{vm.Logs{&vm.Log{}}})
-	mux.Post(core.PendingLogsEvent{vm.Logs{&vm.Log{}}})
+	mux.Post(core.RemovedLogsEvent{Logs: vm.Logs{&vm.Log{}}})
+	mux.Post(core.PendingLogsEvent{Logs: vm.Logs{&vm.Log{}}})
 
 	const dura = 5 * time.Second
 	failTimer := time.NewTimer(dura)

--- a/eth/filters/filter_test.go
+++ b/eth/filters/filter_test.go
@@ -56,7 +56,7 @@ func BenchmarkMipmaps(b *testing.B) {
 	)
 	defer db.Close()
 
-	genesis := core.WriteGenesisBlockForTesting(db, core.GenesisAccount{addr1, big.NewInt(1000000)})
+	genesis := core.WriteGenesisBlockForTesting(db, core.GenesisAccount{Address: addr1, Balance: big.NewInt(1000000)})
 	chain, receipts := core.GenerateChain(genesis, db, 100010, func(i int, gen *core.BlockGen) {
 		var receipts types.Receipts
 		switch i {
@@ -132,7 +132,7 @@ func TestFilters(t *testing.T) {
 	)
 	defer db.Close()
 
-	genesis := core.WriteGenesisBlockForTesting(db, core.GenesisAccount{addr, big.NewInt(1000000)})
+	genesis := core.WriteGenesisBlockForTesting(db, core.GenesisAccount{Address: addr, Balance: big.NewInt(1000000)})
 	chain, receipts := core.GenerateChain(genesis, db, 1000, func(i int, gen *core.BlockGen) {
 		var receipts types.Receipts
 		switch i {

--- a/eth/handler.go
+++ b/eth/handler.go
@@ -245,7 +245,6 @@ func (pm *ProtocolManager) handle(p *peer) error {
 			return err
 		}
 	}
-	return nil
 }
 
 // handleMsg is invoked whenever an inbound message is received from a remote

--- a/eth/handler_test.go
+++ b/eth/handler_test.go
@@ -17,7 +17,6 @@
 package eth
 
 import (
-	"fmt"
 	"math/big"
 	"math/rand"
 	"testing"
@@ -448,12 +447,12 @@ func testGetNodeData(t *testing.T, protocol int) {
 		switch i {
 		case 0:
 			// In block 1, the test bank sends account #1 some ether.
-			tx, _ := types.NewTransaction(block.TxNonce(testBankAddress), acc1Addr, big.NewInt(10000), params.TxGas, nil, nil).SignECDSA(testBankKey)
+			tx, _ := types.NewTransaction(block.TxNonce(testBank.Address), acc1Addr, big.NewInt(10000), params.TxGas, nil, nil).SignECDSA(testBankKey)
 			block.AddTx(tx)
 		case 1:
 			// In block 2, the test bank sends some more ether to account #1.
 			// acc1Addr passes it on to account #2.
-			tx1, _ := types.NewTransaction(block.TxNonce(testBankAddress), acc1Addr, big.NewInt(1000), params.TxGas, nil, nil).SignECDSA(testBankKey)
+			tx1, _ := types.NewTransaction(block.TxNonce(testBank.Address), acc1Addr, big.NewInt(1000), params.TxGas, nil, nil).SignECDSA(testBankKey)
 			tx2, _ := types.NewTransaction(block.TxNonce(acc1Addr), acc2Addr, big.NewInt(1000), params.TxGas, nil, nil).SignECDSA(acc1Key)
 			block.AddTx(tx1)
 			block.AddTx(tx2)
@@ -498,14 +497,14 @@ func testGetNodeData(t *testing.T, protocol int) {
 	// Verify that all hashes correspond to the requested data, and reconstruct a state tree
 	for i, want := range hashes {
 		if hash := crypto.Keccak256Hash(data[i]); hash != want {
-			fmt.Errorf("data hash mismatch: have %x, want %x", hash, want)
+			t.Errorf("data hash mismatch: have %x, want %x", hash, want)
 		}
 	}
 	statedb, _ := ethdb.NewMemDatabase()
 	for i := 0; i < len(data); i++ {
 		statedb.Put(hashes[i].Bytes(), data[i])
 	}
-	accounts := []common.Address{testBankAddress, acc1Addr, acc2Addr}
+	accounts := []common.Address{testBank.Address, acc1Addr, acc2Addr}
 	for i := uint64(0); i <= pm.blockchain.CurrentBlock().NumberU64(); i++ {
 		trie, _ := state.New(pm.blockchain.GetBlockByNumber(i).Root(), statedb)
 
@@ -539,12 +538,12 @@ func testGetReceipt(t *testing.T, protocol int) {
 		switch i {
 		case 0:
 			// In block 1, the test bank sends account #1 some ether.
-			tx, _ := types.NewTransaction(block.TxNonce(testBankAddress), acc1Addr, big.NewInt(10000), params.TxGas, nil, nil).SignECDSA(testBankKey)
+			tx, _ := types.NewTransaction(block.TxNonce(testBank.Address), acc1Addr, big.NewInt(10000), params.TxGas, nil, nil).SignECDSA(testBankKey)
 			block.AddTx(tx)
 		case 1:
 			// In block 2, the test bank sends some more ether to account #1.
 			// acc1Addr passes it on to account #2.
-			tx1, _ := types.NewTransaction(block.TxNonce(testBankAddress), acc1Addr, big.NewInt(1000), params.TxGas, nil, nil).SignECDSA(testBankKey)
+			tx1, _ := types.NewTransaction(block.TxNonce(testBank.Address), acc1Addr, big.NewInt(1000), params.TxGas, nil, nil).SignECDSA(testBankKey)
 			tx2, _ := types.NewTransaction(block.TxNonce(acc1Addr), acc2Addr, big.NewInt(1000), params.TxGas, nil, nil).SignECDSA(acc1Key)
 			block.AddTx(tx1)
 			block.AddTx(tx2)

--- a/eth/helper_test.go
+++ b/eth/helper_test.go
@@ -37,9 +37,11 @@ import (
 )
 
 var (
-	testBankKey, _  = crypto.HexToECDSA("b71c71a67e1177ad4e901695e1b4b9ee17ae16c6668d313eac2f96dbcda3f291")
-	testBankAddress = crypto.PubkeyToAddress(testBankKey.PublicKey)
-	testBankFunds   = big.NewInt(1000000)
+	testBankKey, _ = crypto.HexToECDSA("b71c71a67e1177ad4e901695e1b4b9ee17ae16c6668d313eac2f96dbcda3f291")
+	testBank       = core.GenesisAccount{
+		Address: crypto.PubkeyToAddress(testBankKey.PublicKey),
+		Balance: big.NewInt(1000000),
+	}
 )
 
 // newTestProtocolManager creates a new protocol manager for testing purposes,
@@ -50,7 +52,7 @@ func newTestProtocolManager(fastSync bool, blocks int, generator func(int, *core
 		evmux         = new(event.TypeMux)
 		pow           = new(core.FakePow)
 		db, _         = ethdb.NewMemDatabase()
-		genesis       = core.WriteGenesisBlockForTesting(db, core.GenesisAccount{testBankAddress, testBankFunds})
+		genesis       = core.WriteGenesisBlockForTesting(db, testBank)
 		chainConfig   = &core.ChainConfig{HomesteadBlock: big.NewInt(0)} // homestead set to 0 because of chain maker
 		blockchain, _ = core.NewBlockChain(db, chainConfig, pow, evmux)
 	)

--- a/eth/protocol_test.go
+++ b/eth/protocol_test.go
@@ -78,7 +78,7 @@ func testStatusMsgErrors(t *testing.T, protocol int) {
 		select {
 		case err := <-errc:
 			if err == nil {
-				t.Errorf("test %d: protocol returned nil error, want %q", test.wantError)
+				t.Errorf("test %d: protocol returned nil error, want %q", i, test.wantError)
 			} else if err.Error() != test.wantError.Error() {
 				t.Errorf("test %d: wrong error: got %q, want %q", i, err, test.wantError)
 			}

--- a/generators/defaults.go
+++ b/generators/defaults.go
@@ -28,7 +28,7 @@ import (
 	"strings"
 )
 
-func fatal(str string, v ...interface{}) {
+func fatalf(str string, v ...interface{}) {
 	fmt.Fprintf(os.Stderr, str, v...)
 	os.Exit(1)
 }
@@ -40,12 +40,12 @@ type setting struct {
 
 func main() {
 	if len(os.Args) < 3 {
-		fatal("usage %s <input> <output>\n", os.Args[0])
+		fatalf("usage %s <input> <output>\n", os.Args[0])
 	}
 
 	content, err := ioutil.ReadFile(os.Args[1])
 	if err != nil {
-		fatal("error reading file %v\n", err)
+		fatalf("error reading file %v\n", err)
 	}
 
 	m := make(map[string]setting)
@@ -54,7 +54,7 @@ func main() {
 	filepath := filepath.Join(os.Getenv("GOPATH"), "src", "github.com", "ethereum", "go-ethereum", "params", os.Args[2])
 	output, err := os.OpenFile(filepath, os.O_RDWR|os.O_CREATE, 0666)
 	if err != nil {
-		fatal("error opening file for writing %v\n", err)
+		fatalf("error opening file for writing %v\n", err)
 	}
 
 	output.WriteString(`// DO NOT EDIT!!!
@@ -76,6 +76,6 @@ var (
 
 	cmd := exec.Command("gofmt", "-w", filepath)
 	if err := cmd.Run(); err != nil {
-		fatal("gofmt failed: %v\n", err)
+		fatalf("gofmt failed: %v\n", err)
 	}
 }

--- a/logger/glog/glog.go
+++ b/logger/glog/glog.go
@@ -698,7 +698,7 @@ func (l *loggingT) printDepth(s severity, depth int, args ...interface{}) {
 	l.output(s, buf, file, line, false)
 }
 
-func (l *loggingT) printf(s severity, format string, args ...interface{}) {
+func (l *loggingT) printfmt(s severity, format string, args ...interface{}) {
 	buf, file, line := l.header(s, 0)
 	fmt.Fprintf(buf, format, args...)
 	if buf.Bytes()[buf.Len()-1] != '\n' {
@@ -1088,7 +1088,7 @@ func (v Verbose) Infoln(args ...interface{}) {
 // See the documentation of V for usage.
 func (v Verbose) Infof(format string, args ...interface{}) {
 	if v {
-		logging.printf(infoLog, format, args...)
+		logging.printfmt(infoLog, format, args...)
 	}
 }
 
@@ -1107,13 +1107,13 @@ func InfoDepth(depth int, args ...interface{}) {
 // Infoln logs to the INFO log.
 // Arguments are handled in the manner of fmt.Println; a newline is appended if missing.
 func Infoln(args ...interface{}) {
-	logging.println(infoLog, args...)
+	logging.print(infoLog, args...)
 }
 
 // Infof logs to the INFO log.
 // Arguments are handled in the manner of fmt.Printf; a newline is appended if missing.
 func Infof(format string, args ...interface{}) {
-	logging.printf(infoLog, format, args...)
+	logging.printfmt(infoLog, format, args...)
 }
 
 // Warning logs to the WARNING and INFO logs.
@@ -1137,7 +1137,7 @@ func Warningln(args ...interface{}) {
 // Warningf logs to the WARNING and INFO logs.
 // Arguments are handled in the manner of fmt.Printf; a newline is appended if missing.
 func Warningf(format string, args ...interface{}) {
-	logging.printf(warningLog, format, args...)
+	logging.printfmt(warningLog, format, args...)
 }
 
 // Error logs to the ERROR, WARNING, and INFO logs.
@@ -1161,7 +1161,7 @@ func Errorln(args ...interface{}) {
 // Errorf logs to the ERROR, WARNING, and INFO logs.
 // Arguments are handled in the manner of fmt.Printf; a newline is appended if missing.
 func Errorf(format string, args ...interface{}) {
-	logging.printf(errorLog, format, args...)
+	logging.printfmt(errorLog, format, args...)
 }
 
 // Fatal logs to the FATAL, ERROR, WARNING, and INFO logs,
@@ -1188,7 +1188,7 @@ func Fatalln(args ...interface{}) {
 // including a stack trace of all running goroutines, then calls os.Exit(255).
 // Arguments are handled in the manner of fmt.Printf; a newline is appended if missing.
 func Fatalf(format string, args ...interface{}) {
-	logging.printf(fatalLog, format, args...)
+	logging.printfmt(fatalLog, format, args...)
 }
 
 // fatalNoStacks is non-zero if we are to exit without dumping goroutine stacks.
@@ -1219,5 +1219,5 @@ func Exitln(args ...interface{}) {
 // Arguments are handled in the manner of fmt.Printf; a newline is appended if missing.
 func Exitf(format string, args ...interface{}) {
 	atomic.StoreUint32(&fatalNoStacks, 1)
-	logging.printf(fatalLog, format, args...)
+	logging.printfmt(fatalLog, format, args...)
 }

--- a/logger/glog/glog_test.go
+++ b/logger/glog/glog_test.go
@@ -300,7 +300,7 @@ func TestCompileModulePattern(t *testing.T) {
 	for _, test := range patternTests {
 		re, err := compileModulePattern(test.input)
 		if err != nil {
-			t.Fatalf("%s: %v", err)
+			t.Fatalf("%s: %v", test.input, err)
 		}
 		if re.String() != test.want {
 			t.Errorf("mismatch for %q: got %q, want %q", test.input, re.String(), test.want)

--- a/metrics/disk_linux.go
+++ b/metrics/disk_linux.go
@@ -68,5 +68,4 @@ func ReadDiskStats(stats *DiskStats) error {
 			stats.WriteBytes = value
 		}
 	}
-	return nil
 }

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -279,7 +279,7 @@ func (self *worker) wait() {
 					glog.V(logger.Error).Infoln("mining err", err)
 					continue
 				}
-				go self.mux.Post(core.NewMinedBlockEvent{block})
+				go self.mux.Post(core.NewMinedBlockEvent{Block: block})
 			} else {
 				work.state.Commit()
 				parent := self.chain.GetBlock(block.ParentHash())
@@ -322,11 +322,11 @@ func (self *worker) wait() {
 
 				// broadcast before waiting for validation
 				go func(block *types.Block, logs vm.Logs, receipts []*types.Receipt) {
-					self.mux.Post(core.NewMinedBlockEvent{block})
-					self.mux.Post(core.ChainEvent{block, block.Hash(), logs})
+					self.mux.Post(core.NewMinedBlockEvent{Block: block})
+					self.mux.Post(core.ChainEvent{Block: block, Hash: block.Hash(), Logs: logs})
 
 					if stat == core.CanonStatTy {
-						self.mux.Post(core.ChainHeadEvent{block})
+						self.mux.Post(core.ChainHeadEvent{Block: block})
 						self.mux.Post(logs)
 					}
 					if err := core.WriteBlockReceipts(self.chainDb, block.Hash(), receipts); err != nil {
@@ -411,7 +411,7 @@ func (w *worker) setGasPrice(p *big.Int) {
 	const pct = int64(90)
 	w.gasPrice = gasprice(p, pct)
 
-	w.mux.Post(core.GasPriceChanged{w.gasPrice})
+	w.mux.Post(core.GasPriceChanged{Price: w.gasPrice})
 }
 
 func (self *worker) isBlockLocallyMined(current *Work, deepBlockNum uint64) bool {

--- a/p2p/discover/udp_test.go
+++ b/p2p/discover/udp_test.go
@@ -128,7 +128,7 @@ func newUDPTest(t *testing.T) *udpTest {
 func (test *udpTest) packetIn(wantError error, ptype byte, data packet) error {
 	enc, err := encodePacket(test.remotekey, ptype, data)
 	if err != nil {
-		return test.errorf("packet (%d) encode error: %v", err)
+		return test.errorf("packet (%d) encode error: %v", ptype, err)
 	}
 	test.sent = append(test.sent, enc)
 	if err = test.udp.handlePacket(test.remoteaddr, enc); err != wantError {

--- a/p2p/message_test.go
+++ b/p2p/message_test.go
@@ -58,7 +58,7 @@ loop:
 			if err := SendItems(rw1, 1); err == nil {
 				t.Error("EncodeMsg returned nil error")
 			} else if err != ErrPipeClosed {
-				t.Error("EncodeMsg returned wrong error: got %v, want %v", err, ErrPipeClosed)
+				t.Errorf("EncodeMsg returned wrong error: got %v, want %v", err, ErrPipeClosed)
 			}
 			close(done)
 		}()

--- a/p2p/nat/natupnp.go
+++ b/p2p/nat/natupnp.go
@@ -107,9 +107,9 @@ func discoverUPnP() Interface {
 	go discover(found, internetgateway1.URN_WANConnectionDevice_1, func(dev *goupnp.RootDevice, sc goupnp.ServiceClient) *upnp {
 		switch sc.Service.ServiceType {
 		case internetgateway1.URN_WANIPConnection_1:
-			return &upnp{dev, "IGDv1-IP1", &internetgateway1.WANIPConnection1{sc}}
+			return &upnp{dev, "IGDv1-IP1", &internetgateway1.WANIPConnection1{ServiceClient: sc}}
 		case internetgateway1.URN_WANPPPConnection_1:
-			return &upnp{dev, "IGDv1-PPP1", &internetgateway1.WANPPPConnection1{sc}}
+			return &upnp{dev, "IGDv1-PPP1", &internetgateway1.WANPPPConnection1{ServiceClient: sc}}
 		}
 		return nil
 	})
@@ -117,11 +117,11 @@ func discoverUPnP() Interface {
 	go discover(found, internetgateway2.URN_WANConnectionDevice_2, func(dev *goupnp.RootDevice, sc goupnp.ServiceClient) *upnp {
 		switch sc.Service.ServiceType {
 		case internetgateway2.URN_WANIPConnection_1:
-			return &upnp{dev, "IGDv2-IP1", &internetgateway2.WANIPConnection1{sc}}
+			return &upnp{dev, "IGDv2-IP1", &internetgateway2.WANIPConnection1{ServiceClient: sc}}
 		case internetgateway2.URN_WANIPConnection_2:
-			return &upnp{dev, "IGDv2-IP2", &internetgateway2.WANIPConnection2{sc}}
+			return &upnp{dev, "IGDv2-IP2", &internetgateway2.WANIPConnection2{ServiceClient: sc}}
 		case internetgateway2.URN_WANPPPConnection_1:
-			return &upnp{dev, "IGDv2-PPP1", &internetgateway2.WANPPPConnection1{sc}}
+			return &upnp{dev, "IGDv2-PPP1", &internetgateway2.WANPPPConnection1{ServiceClient: sc}}
 		}
 		return nil
 	})

--- a/p2p/server_test.go
+++ b/p2p/server_test.go
@@ -123,7 +123,7 @@ func TestServerDial(t *testing.T) {
 	// run a one-shot TCP server to handle the connection.
 	listener, err := net.Listen("tcp", "127.0.0.1:0")
 	if err != nil {
-		t.Fatalf("could not setup listener: %v")
+		t.Fatalf("could not setup listener: %v", err)
 	}
 	defer listener.Close()
 	accepted := make(chan net.Conn)

--- a/pow/ezp/pow.go
+++ b/pow/ezp/pow.go
@@ -91,8 +91,6 @@ empty:
 			time.Sleep(20 * time.Microsecond)
 		}
 	}
-
-	return 0, nil
 }
 
 func (pow *EasyPow) Verify(block pow.Block) bool {

--- a/rlp/encode.go
+++ b/rlp/encode.go
@@ -300,7 +300,6 @@ func (r *encReader) Read(b []byte) (n int, err error) {
 		}
 		r.piece = nil
 	}
-	panic("not reached")
 }
 
 // next returns the next piece of data to be read.
@@ -650,5 +649,4 @@ func intsize(i uint64) (size int) {
 			return size
 		}
 	}
-	panic("not reached")
 }

--- a/rlp/raw_test.go
+++ b/rlp/raw_test.go
@@ -61,13 +61,13 @@ func TestCountValues(t *testing.T) {
 
 func TestSplitTypes(t *testing.T) {
 	if _, _, err := SplitString(unhex("C100")); err != ErrExpectedString {
-		t.Error("SplitString returned %q, want %q", err, ErrExpectedString)
+		t.Errorf("SplitString returned %q, want %q", err, ErrExpectedString)
 	}
 	if _, _, err := SplitList(unhex("01")); err != ErrExpectedList {
-		t.Error("SplitString returned %q, want %q", err, ErrExpectedList)
+		t.Errorf("SplitString returned %q, want %q", err, ErrExpectedList)
 	}
 	if _, _, err := SplitList(unhex("81FF")); err != ErrExpectedList {
-		t.Error("SplitString returned %q, want %q", err, ErrExpectedList)
+		t.Errorf("SplitString returned %q, want %q", err, ErrExpectedList)
 	}
 }
 

--- a/rpc/ipc_unix.go
+++ b/rpc/ipc_unix.go
@@ -41,5 +41,5 @@ func ipcListen(endpoint string) (net.Listener, error) {
 
 // newIPCConnection will connect to a Unix socket on the given endpoint.
 func newIPCConnection(endpoint string) (net.Conn, error) {
-	return net.DialUnix("unix", nil, &net.UnixAddr{endpoint, "unix"})
+	return net.DialUnix("unix", nil, &net.UnixAddr{Name: endpoint, Net: "unix"})
 }

--- a/rpc/json_test.go
+++ b/rpc/json_test.go
@@ -75,7 +75,7 @@ func TestJSONRequestParsing(t *testing.T) {
 			t.Fatalf("%v", e)
 		}
 		if id != 1234 {
-			t.Fatalf("Expected id 1234 but got %s", id)
+			t.Fatalf("Expected id 1234 but got %d", id)
 		}
 	} else {
 		t.Fatalf("invalid request, expected *json.RawMesage got %T", requests[0].id)

--- a/tests/block_test_util.go
+++ b/tests/block_test_util.go
@@ -491,7 +491,7 @@ func mustConvertBytes(in string) []byte {
 	h := unfuckFuckedHex(strings.TrimPrefix(in, "0x"))
 	out, err := hex.DecodeString(h)
 	if err != nil {
-		panic(fmt.Errorf("invalid hex: %q: ", h, err))
+		panic(fmt.Errorf("invalid hex: %q", h))
 	}
 	return out
 }

--- a/tests/init.go
+++ b/tests/init.go
@@ -67,7 +67,7 @@ func init() {
 func readJson(reader io.Reader, value interface{}) error {
 	data, err := ioutil.ReadAll(reader)
 	if err != nil {
-		return fmt.Errorf("Error reading JSON file", err.Error())
+		return fmt.Errorf("error reading JSON file: %v", err)
 	}
 	if err = json.Unmarshal(data, &value); err != nil {
 		if syntaxerr, ok := err.(*json.SyntaxError); ok {

--- a/trie/proof_test.go
+++ b/trie/proof_test.go
@@ -124,7 +124,7 @@ func BenchmarkVerifyProof(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		im := i % len(keys)
 		if _, err := VerifyProof(root, []byte(keys[im]), proofs[im]); err != nil {
-			b.Fatalf("key %x: error", keys[im], err)
+			b.Fatalf("key %x: %v", keys[im], err)
 		}
 	}
 }

--- a/trie/trie_test.go
+++ b/trie/trie_test.go
@@ -65,7 +65,7 @@ func TestMissingRoot(t *testing.T) {
 		t.Error("New returned non-nil trie for invalid root")
 	}
 	if _, ok := err.(*MissingNodeError); !ok {
-		t.Error("New returned wrong error: %v", err)
+		t.Errorf("New returned wrong error: %v", err)
 	}
 }
 

--- a/whisper/message_test.go
+++ b/whisper/message_test.go
@@ -108,7 +108,7 @@ func TestMessageAnonymousEncryptDecrypt(t *testing.T) {
 		t.Fatalf("failed to open encrypted message: %v", err)
 	}
 	if !bytes.Equal(out.Payload, payload) {
-		t.Error("payload mismatch: have 0x%x, want 0x%x", out.Payload, payload)
+		t.Errorf("payload mismatch: have 0x%x, want 0x%x", out.Payload, payload)
 	}
 }
 
@@ -144,7 +144,7 @@ func TestMessageFullCrypto(t *testing.T) {
 		t.Fatalf("failed to open encrypted message: %v", err)
 	}
 	if !bytes.Equal(out.Payload, payload) {
-		t.Error("payload mismatch: have 0x%x, want 0x%x", out.Payload, payload)
+		t.Errorf("payload mismatch: have 0x%x, want 0x%x", out.Payload, payload)
 	}
 
 	pubKey := out.Recover()


### PR DESCRIPTION
This PR fixes all current `go vet` warnings.
`go vet ./...` is now enabled on Travis CI.