### PR TITLE
rpc: increased log level in case RPC request could not be read

### DIFF
--- a/rpc/errors.go
+++ b/rpc/errors.go
@@ -18,6 +18,11 @@ package rpc
 
 import "fmt"
 
+var (
+	// ErrConnectionClosed is thrown when the connection is closed
+	ErrConnectionClosed = new(connectionClosedError)
+)
+
 // request is for an unknown service
 type methodNotFoundError struct {
 	service string
@@ -94,4 +99,16 @@ func (e *shutdownError) Code() int {
 
 func (e *shutdownError) Error() string {
 	return "server is shutting down"
+}
+
+// connectionClosedError is thrown when the connection is closed
+type connectionClosedError struct {
+}
+
+func (e *connectionClosedError) Code() int {
+	return 0
+}
+
+func (e *connectionClosedError) Error() string {
+	return "connection closed"
 }

--- a/rpc/json.go
+++ b/rpc/json.go
@@ -119,6 +119,9 @@ func (c *jsonCodec) ReadRequestHeaders() ([]rpcRequest, bool, RPCError) {
 
 	var incomingMsg json.RawMessage
 	if err := c.d.Decode(&incomingMsg); err != nil {
+		if err == io.EOF {
+			return nil, false, ErrConnectionClosed
+		}
 		return nil, false, &invalidRequestError{err.Error()}
 	}
 

--- a/rpc/server.go
+++ b/rpc/server.go
@@ -185,8 +185,10 @@ func (s *Server) serveRequest(codec ServerCodec, singleShot bool, options CodecO
 	for atomic.LoadInt32(&s.run) == 1 {
 		reqs, batch, err := s.readRequest(codec)
 		if err != nil {
-			glog.V(logger.Debug).Infof("%v\n", err)
-			codec.Write(codec.CreateErrorResponse(nil, err))
+			if err != ErrConnectionClosed {
+				glog.V(logger.Error).Infof("%v\n", err)
+				codec.Write(codec.CreateErrorResponse(nil, err))
+			}
 			return nil
 		}
 


### PR DESCRIPTION
This PR increases the log level in the RPC server when the next RPC request could not be read. This helps with trouble shooting (primarily mist related) connectivity issues.