### PR TITLE
whisper: deflake Test*MessageExpiration

### DIFF
--- a/whisper/whisper.go
+++ b/whisper/whisper.go
@@ -255,7 +255,7 @@ func (self *Whisper) add(envelope *Envelope) error {
 	defer self.poolMu.Unlock()
 
 	// short circuit when a received envelope has already expired
-	if envelope.Expiry <= uint32(time.Now().Unix()) {
+	if envelope.Expiry < uint32(time.Now().Unix()) {
 		return nil
 	}
 
@@ -278,7 +278,6 @@ func (self *Whisper) add(envelope *Envelope) error {
 		go self.postEvent(envelope)
 	}
 	glog.V(logger.Detail).Infof("cached whisper envelope %x\n", envelope)
-
 	return nil
 }
 

--- a/whisper/whisper_test.go
+++ b/whisper/whisper_test.go
@@ -179,9 +179,7 @@ func TestMessageExpiration(t *testing.T) {
 	node := startTestCluster(1)[0]
 
 	message := NewMessage([]byte("expiring message"))
-	envelope, err := message.Wrap(DefaultPoW, Options{
-		TTL: time.Second,
-	})
+	envelope, err := message.Wrap(DefaultPoW, Options{TTL: time.Second})
 	if err != nil {
 		t.Fatalf("failed to wrap message: %v", err)
 	}
@@ -197,17 +195,17 @@ func TestMessageExpiration(t *testing.T) {
 		t.Fatalf("message not found in cache")
 	}
 	// Wait for expiration and check cache again
-	time.Sleep(time.Second)     // wait for expiration
-	time.Sleep(expirationCycle) // wait for cleanup cycle
+	time.Sleep(time.Second)         // wait for expiration
+	time.Sleep(2 * expirationCycle) // wait for cleanup cycle
 
 	node.poolMu.RLock()
 	_, found = node.messages[envelope.Hash()]
 	node.poolMu.RUnlock()
-
 	if found {
 		t.Fatalf("message not expired from cache")
 	}
 
+	// Check that adding an expired envelope doesn't do anything.
 	node.add(envelope)
 	node.poolMu.RLock()
 	_, found = node.messages[envelope.Hash()]
@@ -215,5 +213,4 @@ func TestMessageExpiration(t *testing.T) {
 	if found {
 		t.Fatalf("message was added to cache")
 	}
-
 }


### PR DESCRIPTION
These tests have become a common annoyance on CI. Fix them by allowing
messages with expiration == now into the cache and delaying the check
for expired message handling slightly.

@karalabe please review