### PR TITLE
rpc: move web3.js extensions to internal/web3ext

### DIFF
--- a/cmd/geth/js.go
+++ b/cmd/geth/js.go
@@ -32,6 +32,7 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/registrar"
 	"github.com/ethereum/go-ethereum/eth"
+	"github.com/ethereum/go-ethereum/internal/web3ext"
 	re "github.com/ethereum/go-ethereum/jsre"
 	"github.com/ethereum/go-ethereum/node"
 	"github.com/ethereum/go-ethereum/rpc"
@@ -202,7 +203,7 @@ func (js *jsre) apiBindings() error {
 			continue // manually mapped or ignore
 		}
 
-		if jsFile, ok := rpc.WEB3Extensions[apiName]; ok {
+		if jsFile, ok := web3ext.Modules[apiName]; ok {
 			if err = js.re.Compile(fmt.Sprintf("%s.js", apiName), jsFile); err == nil {
 				shortcuts += fmt.Sprintf("var %s = web3.%s; ", apiName, apiName)
 			} else {

--- a/internal/web3ext/web3ext.go
+++ b/internal/web3ext/web3ext.go
@@ -14,19 +14,17 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
 
-package rpc
+// package web3ext contains geth specific web3.js extensions.
+package web3ext
 
-var (
-	// Holds geth specific RPC extends which can be used to extend web3
-	WEB3Extensions = map[string]string{
-		"txpool": TxPool_JS,
-		"admin":  Admin_JS,
-		"eth":    Eth_JS,
-		"miner":  Miner_JS,
-		"debug":  Debug_JS,
-		"net":    Net_JS,
-	}
-)
+var Modules = map[string]string{
+	"txpool": TxPool_JS,
+	"admin":  Admin_JS,
+	"eth":    Eth_JS,
+	"miner":  Miner_JS,
+	"debug":  Debug_JS,
+	"net":    Net_JS,
+}
 
 const TxPool_JS = `
 web3._extend({


### PR DESCRIPTION
The main reason for the move is that the string constants were displayed by godoc.

@bas-vk or @karalabe please review.