### PR TITLE
rpc: remove NotifierContextKey

### DIFF
--- a/eth/api.go
+++ b/eth/api.go
@@ -603,7 +603,7 @@ type NewBlocksArgs struct {
 // NewBlocks triggers a new block event each time a block is appended to the chain. It accepts an argument which allows
 // the caller to specify whether the output should contain transactions and in what format.
 func (s *PublicBlockChainAPI) NewBlocks(ctx context.Context, args NewBlocksArgs) (rpc.Subscription, error) {
-	notifier, supported := ctx.Value(rpc.NotifierContextKey).(rpc.Notifier)
+	notifier, supported := rpc.NotifierFromContext(ctx)
 	if !supported {
 		return nil, rpc.ErrNotificationsUnsupported
 	}
@@ -1345,7 +1345,7 @@ func (s *PublicTransactionPoolAPI) PendingTransactions() []*RPCTransaction {
 // NewPendingTransaction creates a subscription that is triggered each time a transaction enters the transaction pool
 // and is send from one of the transactions this nodes manages.
 func (s *PublicTransactionPoolAPI) NewPendingTransactions(ctx context.Context) (rpc.Subscription, error) {
-	notifier, supported := ctx.Value(rpc.NotifierContextKey).(rpc.Notifier)
+	notifier, supported := rpc.NotifierFromContext(ctx)
 	if !supported {
 		return nil, rpc.ErrNotificationsUnsupported
 	}

--- a/eth/downloader/api.go
+++ b/eth/downloader/api.go
@@ -85,7 +85,7 @@ type SyncingResult struct {
 
 // Syncing provides information when this nodes starts synchronising with the Ethereum network and when it's finished.
 func (api *PublicDownloaderAPI) Syncing(ctx context.Context) (rpc.Subscription, error) {
-	notifier, supported := ctx.Value(rpc.NotifierContextKey).(rpc.Notifier)
+	notifier, supported := rpc.NotifierFromContext(ctx)
 	if !supported {
 		return nil, rpc.ErrNotificationsUnsupported
 	}

--- a/eth/filters/api.go
+++ b/eth/filters/api.go
@@ -234,7 +234,7 @@ func (s *PublicFilterAPI) newLogFilter(earliest, latest int64, addresses []commo
 }
 
 func (s *PublicFilterAPI) Logs(ctx context.Context, args NewFilterArgs) (rpc.Subscription, error) {
-	notifier, supported := ctx.Value(rpc.NotifierContextKey).(rpc.Notifier)
+	notifier, supported := rpc.NotifierFromContext(ctx)
 	if !supported {
 		return nil, rpc.ErrNotificationsUnsupported
 	}

--- a/rpc/notification.go
+++ b/rpc/notification.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/ethereum/go-ethereum/logger"
 	"github.com/ethereum/go-ethereum/logger/glog"
+	"golang.org/x/net/context"
 )
 
 var (
@@ -60,6 +61,14 @@ type Notifier interface {
 	NewSubscription(UnsubscribeCallback) (Subscription, error)
 	// Cancel subscription
 	Unsubscribe(id string) error
+}
+
+type notifierKey struct{}
+
+// NotifierFromContext returns the Notifier value stored in ctx, if any.
+func NotifierFromContext(ctx context.Context) (Notifier, bool) {
+	n, ok := ctx.Value(notifierKey{}).(Notifier)
+	return n, ok
 }
 
 // Subscription defines the interface for objects that can notify subscribers

--- a/rpc/notification_test.go
+++ b/rpc/notification_test.go
@@ -36,7 +36,7 @@ func (s *NotificationTestService) Unsubscribe(subid string) {
 }
 
 func (s *NotificationTestService) SomeSubscription(ctx context.Context, n, val int) (Subscription, error) {
-	notifier, supported := ctx.Value(NotifierContextKey).(Notifier)
+	notifier, supported := NotifierFromContext(ctx)
 	if !supported {
 		return nil, ErrNotificationsUnsupported
 	}


### PR DESCRIPTION
Context keys must have a unique type in order to prevent
any unintented clashes. The code used int(1) as key.
Fix it by implementing the pattern recommended by package context.

@bas-vk please review