### PR TITLE
cmd/utils: geth attach didn't respect the --ipcpath flag

### DIFF
--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -138,7 +138,7 @@ See https://github.com/ethereum/go-ethereum/wiki/Javascipt-Console
 			Description: `
 		The Geth console is an interactive shell for the JavaScript runtime environment
 		which exposes a node admin interface as well as the Ðapp JavaScript API.
-		See https://github.com/ethereum/go-ethereum/wiki/Javascipt-Console.
+		See https://github.com/ethereum/go-ethereum/wiki/JavaScript-Console.
 		This command allows to open a console on a running geth node.
 		`,
 		},

--- a/cmd/utils/client.go
+++ b/cmd/utils/client.go
@@ -21,7 +21,6 @@ import (
 	"strings"
 
 	"github.com/codegangsta/cli"
-	"github.com/ethereum/go-ethereum/node"
 	"github.com/ethereum/go-ethereum/rpc"
 )
 
@@ -33,7 +32,7 @@ func NewRemoteRPCClient(ctx *cli.Context) (rpc.Client, error) {
 		return NewRemoteRPCClientFromString(endpoint)
 	}
 	// use IPC by default
-	return rpc.NewIPCClient(node.DefaultIPCEndpoint())
+	return rpc.NewIPCClient(MakeIPCPath(ctx))
 }
 
 // NewRemoteRPCClientFromString returns a RPC client which connects to the given


### PR DESCRIPTION
With the refactoring of how the node initializes and starts geth attach is not respecting the `--ipcpath` flag anymore.

@karalabe PTAL