### PR TITLE
cmd: add a `--fakepow` flag to help benchmarking database changes

### DIFF
--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -205,6 +205,7 @@ JavaScript API. See https://github.com/ethereum/go-ethereum/wiki/Javascipt-Conso
 		utils.NetworkIdFlag,
 		utils.RPCCORSDomainFlag,
 		utils.MetricsEnabledFlag,
+		utils.FakePoWFlag,
 		utils.SolcPathFlag,
 		utils.GpoMinGasPriceFlag,
 		utils.GpoMaxGasPriceFlag,

--- a/cmd/geth/usage.go
+++ b/cmd/geth/usage.go
@@ -150,8 +150,11 @@ var AppHelpFlagGroups = []flagGroup{
 		},
 	},
 	{
-		Name:  "LOGGING AND DEBUGGING",
-		Flags: append([]cli.Flag{utils.MetricsEnabledFlag}, debug.Flags...),
+		Name: "LOGGING AND DEBUGGING",
+		Flags: append([]cli.Flag{
+			utils.MetricsEnabledFlag,
+			utils.FakePoWFlag,
+		}, debug.Flags...),
 	},
 	{
 		Name: "EXPERIMENTAL",


### PR DESCRIPTION
This is a tiny utility PR to add a `--fakepow` flag to Geth. This allows testing and evaluating various non POW related optimizations by themselves (e.g. database opts) without having to constantly wait for the costly POWs to also run.

Note, this of course will skew results a bit since with POW out of the picture, the remainder of the system is under a much bigger strain and performance bottlenecks get emphasized a lot more, but I think it's still a useful tool to test if something does or does not make a dent on performance.