### PR TITLE
ethdb, cmd/geth, eth: guerilla state pruning

### DIFF
--- a/cmd/geth/chaincmd.go
+++ b/cmd/geth/chaincmd.go
@@ -177,7 +177,9 @@ func pruneDB(ctx *cli.Context) {
 		iter := chain.NewIterator()
 		for iter.Next() {
 			key := iter.Key()
-			if len(key) == 32 {
+
+			has, _ := chain.LDB().Has(append(key, 0x01), nil)
+			if len(key) == 32 && !has {
 				chain.Delete(key)
 			}
 		}

--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -95,6 +95,7 @@ func init() {
 		monitorCommand,
 		accountCommand,
 		walletCommand,
+		pruningCommand,
 		{
 			Action: makedag,
 			Name:   "makedag",

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -841,6 +841,20 @@ func MakeChainDatabase(ctx *cli.Context) ethdb.Database {
 	return chainDb
 }
 
+func MustOpenDatabase(ctx *cli.Context, name string) ethdb.Database {
+	var (
+		datadir = MustMakeDataDir(ctx)
+		cache   = ctx.GlobalInt(CacheFlag.Name)
+		handles = MakeDatabaseHandles()
+	)
+
+	db, err := ethdb.NewLDBDatabase(filepath.Join(datadir, name), cache, handles)
+	if err != nil {
+		Fatalf("Could not open database '%s': %v", name, err)
+	}
+	return db
+}
+
 // MakeChain creates a chain manager from set command line flags.
 func MakeChain(ctx *cli.Context) (chain *core.BlockChain, chainDb ethdb.Database) {
 	var err error

--- a/ethdb/database.go
+++ b/ethdb/database.go
@@ -295,6 +295,11 @@ func (b *ldbBatch) Put(key, value []byte) error {
 	return nil
 }
 
+func (b *ldbBatch) Delete(key []byte) error {
+	b.b.Delete(key)
+	return nil
+}
+
 func (b *ldbBatch) Write() error {
 	return b.db.Write(b.b, nil)
 }

--- a/ethdb/interface.go
+++ b/ethdb/interface.go
@@ -26,5 +26,6 @@ type Database interface {
 
 type Batch interface {
 	Put(key, value []byte) error
+	Delete(key []byte) error
 	Write() error
 }


### PR DESCRIPTION
This is by no means production ready code. This PR is up for debate and demonstrate and introduces an intermediate state pruning process.

This PR takes the following approach on pruning:
1. Take the state of the last 256 blocks
2. Copy them to another database
3. Remove all state data from database
4. Copy state data from step (2)

~~After running this you'll still, with a legacy, full state database, end up 12GB of data. I'm not sure where the exact bulk of the data is coming from and is most definitely worth investigating.~~

This PR does not contain any automated pruning process. Pruning is fully optionally and must be initiated manually using the `prune` sub command (i.e. `geth prune`). 
