### PR TITLE
core, eth: added json tag field for proper unmarshalling

### DIFF
--- a/core/genesis.go
+++ b/core/genesis.go
@@ -43,7 +43,7 @@ func WriteGenesisBlock(chainDb ethdb.Database, reader io.Reader) (*types.Block, 
 	}
 
 	var genesis struct {
-		ChainConfig *ChainConfig
+		ChainConfig *ChainConfig `json:"config"`
 		Nonce       string
 		Timestamp   string
 		ParentHash  string


### PR DESCRIPTION
According to our own instructions the genesis config attribute should be
`"config"`. The genesis definition in the go code, however, has a field
called `ChainConfig`. This field now has a `json:"config"` struct tag so
that the json is properly unmarshalled.

This fixes #2482