### PR TITLE
eth: add personal_importRawKey

### DIFF
--- a/accounts/account_manager.go
+++ b/accounts/account_manager.go
@@ -284,7 +284,12 @@ func (am *Manager) Import(keyJSON []byte, passphrase, newPassphrase string) (Acc
 
 // ImportECDSA stores the given key into the key directory, encrypting it with the passphrase.
 func (am *Manager) ImportECDSA(priv *ecdsa.PrivateKey, passphrase string) (Account, error) {
-	return am.importKey(newKeyFromECDSA(priv), passphrase)
+	key := newKeyFromECDSA(priv)
+	if am.cache.hasAddress(key.Address) {
+		return Account{}, fmt.Errorf("account already exists")
+	}
+
+	return am.importKey(key, passphrase)
 }
 
 func (am *Manager) importKey(key *Key, passphrase string) (Account, error) {

--- a/eth/api.go
+++ b/eth/api.go
@@ -18,6 +18,7 @@ package eth
 
 import (
 	"bytes"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -437,6 +438,16 @@ func (s *PrivateAccountAPI) NewAccount(password string) (common.Address, error) 
 		return acc.Address, nil
 	}
 	return common.Address{}, err
+}
+
+func (s *PrivateAccountAPI) ImportRawKey(privkey string, password string) (common.Address, error) {
+	hexkey, err := hex.DecodeString(privkey)
+	if err != nil {
+		return common.Address{}, err
+	}
+
+	acc, err := s.am.ImportECDSA(crypto.ToECDSA(hexkey), password)
+	return acc.Address, err
 }
 
 // UnlockAccount will unlock the account associated with the given address with

--- a/internal/web3ext/web3ext.go
+++ b/internal/web3ext/web3ext.go
@@ -18,12 +18,13 @@
 package web3ext
 
 var Modules = map[string]string{
-	"txpool": TxPool_JS,
-	"admin":  Admin_JS,
-	"eth":    Eth_JS,
-	"miner":  Miner_JS,
-	"debug":  Debug_JS,
-	"net":    Net_JS,
+	"txpool":   TxPool_JS,
+	"admin":    Admin_JS,
+	"personal": Personal_JS,
+	"eth":      Eth_JS,
+	"miner":    Miner_JS,
+	"debug":    Debug_JS,
+	"net":      Net_JS,
 }
 
 const TxPool_JS = `
@@ -170,6 +171,20 @@ web3._extend({
 		new web3._extend.Property({
 			name: 'datadir',
 			getter: 'admin_datadir'
+		})
+	]
+});
+`
+
+const Personal_JS = `
+web3._extend({
+	property: 'personal',
+	methods:
+	[
+		new web3._extend.Method({
+			name: 'importRawKey',
+			call: 'personal_importRawKey',
+			params: 2
 		})
 	]
 });


### PR DESCRIPTION
Enables runtime creation of accounts from existing private keys.

This is often useful for use cases where keys are stored and generated outside of geth and used in geth only temporarily to do operations.

Right now a file operation is required to import pre-existing keys, or geth has to be shut down and `geth import` has to be used which is not practical.