### PR TITLE
eth/filters: ignore logs that don't match filter criteria on chain reorg

### DIFF
--- a/eth/filters/filter_system.go
+++ b/eth/filters/filter_system.go
@@ -164,7 +164,7 @@ func (fs *FilterSystem) filterLoop() {
 			fs.filterMu.RLock()
 			for _, filter := range fs.logFilters {
 				if filter.LogCallback != nil && !filter.created.After(event.Time) {
-					for _, removedLog := range ev.Logs {
+					for _, removedLog := range filter.FilterLogs(ev.Logs) {
 						filter.LogCallback(removedLog, true)
 					}
 				}


### PR DESCRIPTION
In case of a chain reorganisation reverted logs are send back to the client with a `removed: true` indication. Currently all logs are send back to the client, even logs that don't match the filter criteria. This PR will only send back reverted logs that actually match the filter criteria.

PTAL: @obscuren, @frozeman