### PR TITLE
Provide a public accessor for ChainConfig

### DIFF
--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -1213,3 +1213,6 @@ func (self *BlockChain) GetBlockHashesFromHash(hash common.Hash, max uint64) []c
 func (self *BlockChain) GetHeaderByNumber(number uint64) *types.Header {
 	return self.hc.GetHeaderByNumber(number)
 }
+
+// Config retrieves the blockchain's chain configuration.
+func (self *BlockChain) Config() *ChainConfig { return self.config }


### PR DESCRIPTION
This is necessary for external users of the go-ethereum code who want to, for instance, build a custom node that plays back transactions, as core.ApplyTransaction requires a ChainConfig as a parameter.