### PR TITLE
travis: run CI builds against multiple Go versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,12 @@
 language: go
 go:
   - 1.4.2
+  - 1.5.4
+  - 1.6.2
 install:
   # - go get code.google.com/p/go.tools/cmd/goimports
   # - go get github.com/golang/lint/golint
-  # - go get golang.org/x/tools/cmd/vet 
+  # - go get golang.org/x/tools/cmd/vet
   - go get golang.org/x/tools/cmd/cover
 before_script:
   # - gofmt -l -w .
@@ -24,6 +26,6 @@ notifications:
   webhooks:
     urls:
       - https://webhooks.gitter.im/e/e09ccdce1048c5e03445
-    on_success: change 
+    on_success: change
     on_failure: always
-    on_start: false 
+    on_start: false


### PR DESCRIPTION
As discussed, we need to support various Go releases. Although currently we don't do anything too fancy, we need to prepare for the dependency revamp where different Go versions could cause much more interesting issues. This PR modifies the Travis build config to run against Go 1.4.2, 1.5.4 as well as  1.6.2. This should help us find compatibility issues much more quickly.

I.e. Like the build failure that surfaced by the Go 1.6.2 build I just added ;)