### PR TITLE
internal/debug: rename debug_trace to debug_goTrace

### DIFF
--- a/internal/debug/api.go
+++ b/internal/debug/api.go
@@ -131,9 +131,9 @@ func (h *HandlerT) StopCPUProfile() error {
 	return nil
 }
 
-// Trace turns on tracing for nsec seconds and writes
+// GoTrace turns on tracing for nsec seconds and writes
 // trace data to file.
-func (h *HandlerT) Trace(file string, nsec uint) error {
+func (h *HandlerT) GoTrace(file string, nsec uint) error {
 	if err := h.StartTrace(file); err != nil {
 		return err
 	}

--- a/internal/web3ext/web3ext.go
+++ b/internal/web3ext/web3ext.go
@@ -366,8 +366,8 @@ web3._extend({
 			params: 0
 		}),
 		new web3._extend.Method({
-			name: 'trace',
-			call: 'debug_trace',
+			name: 'goTrace',
+			call: 'debug_goTrace',
 			params: 2
 		}),
 		new web3._extend.Method({


### PR DESCRIPTION
Reduces confusion with EVM execution tracing methods.

Please review: @karalabe 