### PR TITLE
internal/debug: also rename debug_startTrace to debug_startGoTrace

### DIFF
--- a/cmd/utils/cmd.go
+++ b/cmd/utils/cmd.go
@@ -73,15 +73,13 @@ func StartNode(stack *node.Node) {
 		<-sigc
 		glog.V(logger.Info).Infoln("Got interrupt, shutting down...")
 		go stack.Stop()
-		logger.Flush()
 		for i := 10; i > 0; i-- {
 			<-sigc
 			if i > 1 {
-				glog.V(logger.Info).Infoln("Already shutting down, please be patient.")
-				glog.V(logger.Info).Infoln("Interrupt", i-1, "more times to induce panic.")
+				glog.V(logger.Info).Infof("Already shutting down, interrupt %d more times for panic.", i-1)
 			}
 		}
-		glog.V(logger.Error).Infof("Force quitting: this might not end so well.")
+		debug.Exit() // ensure trace and CPU profile data is flushed.
 		debug.LoudPanic("boom")
 	}()
 }

--- a/internal/debug/api.go
+++ b/internal/debug/api.go
@@ -51,7 +51,7 @@ type HandlerT struct {
 	traceFile string
 }
 
-// Verbosity sets the glog verbosity floor.
+// Verbosity sets the glog verbosity ceiling.
 // The verbosity of individual packages and source files
 // can be raised using Vmodule.
 func (*HandlerT) Verbosity(level int) {
@@ -134,11 +134,11 @@ func (h *HandlerT) StopCPUProfile() error {
 // GoTrace turns on tracing for nsec seconds and writes
 // trace data to file.
 func (h *HandlerT) GoTrace(file string, nsec uint) error {
-	if err := h.StartTrace(file); err != nil {
+	if err := h.StartGoTrace(file); err != nil {
 		return err
 	}
 	time.Sleep(time.Duration(nsec) * time.Second)
-	h.StopTrace()
+	h.StopGoTrace()
 	return nil
 }
 

--- a/internal/debug/flags.go
+++ b/internal/debug/flags.go
@@ -89,7 +89,7 @@ func Setup(ctx *cli.Context) error {
 	runtime.MemProfileRate = ctx.GlobalInt(memprofilerateFlag.Name)
 	Handler.SetBlockProfileRate(ctx.GlobalInt(blockprofilerateFlag.Name))
 	if traceFile := ctx.GlobalString(traceFlag.Name); traceFile != "" {
-		if err := Handler.StartTrace(traceFile); err != nil {
+		if err := Handler.StartGoTrace(traceFile); err != nil {
 			return err
 		}
 	}
@@ -114,5 +114,5 @@ func Setup(ctx *cli.Context) error {
 // respective file.
 func Exit() {
 	Handler.StopCPUProfile()
-	Handler.StopTrace()
+	Handler.StopGoTrace()
 }

--- a/internal/debug/trace.go
+++ b/internal/debug/trace.go
@@ -27,8 +27,8 @@ import (
 	"github.com/ethereum/go-ethereum/logger/glog"
 )
 
-// StartTrace turns on tracing, writing to the given file.
-func (h *HandlerT) StartTrace(file string) error {
+// StartGoTrace turns on tracing, writing to the given file.
+func (h *HandlerT) StartGoTrace(file string) error {
 	h.mu.Lock()
 	defer h.mu.Unlock()
 	if h.traceW != nil {
@@ -49,7 +49,7 @@ func (h *HandlerT) StartTrace(file string) error {
 }
 
 // StopTrace stops an ongoing trace.
-func (h *HandlerT) StopTrace() error {
+func (h *HandlerT) StopGoTrace() error {
 	h.mu.Lock()
 	defer h.mu.Unlock()
 	trace.Stop()

--- a/internal/debug/trace_fallback.go
+++ b/internal/debug/trace_fallback.go
@@ -22,10 +22,10 @@ package debug
 
 import "errors"
 
-func (*HandlerT) StartTrace(string) error {
+func (*HandlerT) StartGoTrace(string) error {
 	return errors.New("tracing is not supported on Go < 1.5")
 }
 
-func (*HandlerT) StopTrace() error {
+func (*HandlerT) StopGoTrace() error {
 	return errors.New("tracing is not supported on Go < 1.5")
 }

--- a/internal/web3ext/web3ext.go
+++ b/internal/web3ext/web3ext.go
@@ -371,13 +371,13 @@ web3._extend({
 			params: 2
 		}),
 		new web3._extend.Method({
-			name: 'startTrace',
-			call: 'debug_startTrace',
+			name: 'startGoTrace',
+			call: 'debug_startGoTrace',
 			params: 1
 		}),
 		new web3._extend.Method({
-			name: 'stopTrace',
-			call: 'debug_stopTrace',
+			name: 'stopGoTrace',
+			call: 'debug_stopGoTrace',
 			params: 0
 		}),
 		new web3._extend.Method({


### PR DESCRIPTION
This was missing from the previous change.
Please review: @obscuren 

The second commit fixes the case where you are profiling/tracing and geth has
problems exiting. Before the change the profile data would not be flushed, leading
to an incomplete profile/trace that cannot be loaded.

```text
I0506 11:18:40.371954 internal/debug/trace.go:47] trace started, writing to foo.trace
I0506 11:18:40.372069 cmd/geth/main.go:285] error setting canonical miner information: extra exceeds 32
I0506 11:18:40.372168 ethdb/database.go:82] Alloted 128MB cache and 1024 file handles to /Users/fjl/Library/Ethereum/chaindata
I0506 11:18:40.435718 ethdb/database.go:169] closed db:/Users/fjl/Library/Ethereum/chaindata
I0506 11:18:40.436747 ethdb/database.go:82] Alloted 128MB cache and 1024 file handles to /Users/fjl/Library/Ethereum/chaindata
I0506 11:18:40.519955 ethdb/database.go:82] Alloted 16MB cache and 16 file handles to /Users/fjl/Library/Ethereum/dapp
I0506 11:18:40.528108 eth/backend.go:170] Protocol Versions: [63 62 61], Network Id: 1
I0506 11:18:40.528189 eth/backend.go:199] Blockchain DB Version: 3
I0506 11:18:40.529153 core/blockchain.go:206] Last header: #781728 [3ba28a65…] TD=4974093610624855033
I0506 11:18:40.529168 core/blockchain.go:207] Last block: #781728 [3ba28a65…] TD=4974093610624855033
I0506 11:18:40.529175 core/blockchain.go:208] Fast block: #781728 [3ba28a65…] TD=4974093610624855033
I0506 11:18:40.530337 p2p/server.go:311] Starting Server
I0506 11:18:42.484962 p2p/discover/udp.go:217] Listening, enode://fe556af88ae0d207972412fd1dc0af356f68f5b0af0a69b5cc17e54c12962988f18034671120c1a0623549f76391f7633183addd97da8c897f073aae0678b44d@[::]:30303
I0506 11:18:42.485276 p2p/server.go:554] Listening on [::]:30303
I0506 11:18:42.486454 node/node.go:298] IPC endpoint opened: /Users/fjl/Library/Ethereum/geth.ipc
I0506 11:18:43.778727 cmd/utils/cmd.go:74] Got interrupt, shutting down...
I0506 11:18:44.282575 cmd/utils/cmd.go:79] Already shutting down, interrupt 9 more times for panic.
I0506 11:18:44.618657 cmd/utils/cmd.go:79] Already shutting down, interrupt 8 more times for panic.
I0506 11:18:44.938678 cmd/utils/cmd.go:79] Already shutting down, interrupt 7 more times for panic.
I0506 11:18:45.266776 cmd/utils/cmd.go:79] Already shutting down, interrupt 6 more times for panic.
I0506 11:18:45.586708 cmd/utils/cmd.go:79] Already shutting down, interrupt 5 more times for panic.
I0506 11:18:45.906556 cmd/utils/cmd.go:79] Already shutting down, interrupt 4 more times for panic.
I0506 11:18:46.242527 cmd/utils/cmd.go:79] Already shutting down, interrupt 3 more times for panic.
I0506 11:18:46.858766 cmd/utils/cmd.go:79] Already shutting down, interrupt 2 more times for panic.
I0506 11:18:47.522659 cmd/utils/cmd.go:79] Already shutting down, interrupt 1 more times for panic.
I0506 11:18:48.260290 internal/debug/trace.go:59] done writing trace to foo.trace
panic: boom

goroutine 105 [running]:
panic(0x4735b40, 0xc8203e94a0)
	/usr/local/Cellar/go/HEAD/libexec/src/runtime/panic.go:500 +0x18c
github.com/ethereum/go-ethereum/internal/debug.LoudPanic(0x4735b40, 0xc8203e94a0)
	/Users/fjl/develop/eth/src/github.com/ethereum/go-ethereum/build/_workspace/src/github.com/ethereum/go-ethereum/internal/debug/loudpanic.go:26 +0x44
...
```