### PR TITLE
build: add CI scripts for windows

### DIFF
--- a/build/win-ci-compile.bat
+++ b/build/win-ci-compile.bat
@@ -1,0 +1,26 @@
+@echo off
+if not exist .\build\win-ci-compile.bat (
+   echo This script must be run from the root of the repository.
+   exit /b
+)
+if not defined GOPATH (
+   echo GOPATH is not set.
+   exit /b
+)
+
+set GOPATH=%GOPATH%;%cd%\Godeps\_workspace
+set GOBIN=%cd%\build\bin
+
+rem set gitCommit when running from a Git checkout.
+set goLinkFlags=""
+if exist ".git\HEAD" (
+   where /q git
+   if not errorlevel 1 (
+      for /f %%h in ('git rev-parse HEAD') do (
+          set goLinkFlags="-X main.gitCommit=%%h"
+      )
+   )
+)
+
+@echo on
+go install -v -ldflags %goLinkFlags% ./...

--- a/build/win-ci-test.bat
+++ b/build/win-ci-test.bat
@@ -1,0 +1,15 @@
+@echo off
+if not exist .\build\win-ci-test.bat (
+   echo This script must be run from the root of the repository.
+   exit /b
+)
+if not defined GOPATH (
+   echo GOPATH is not set.
+   exit /b
+)
+
+set GOPATH=%GOPATH%;%cd%\Godeps\_workspace
+set GOBIN=%cd%\build\bin
+
+@echo on
+go test ./...


### PR DESCRIPTION
This implements the scripts mentioned in https://github.com/ethereum/go-ethereum/pull/2512#issuecomment-217050056. The idea is to run these from
the build steps on buildbot. We can then make changes to the build process through
the script.

@caktux Do these look meaningful to you?