### PR TITLE
jsre: hotfix web3 for the console eth.syncing formatting

### DIFF
--- a/jsre/ethereum_js.go
+++ b/jsre/ethereum_js.go
@@ -3911,7 +3911,12 @@ var outputSyncingFormatter = function(result) {
     result.startingBlock = utils.toDecimal(result.startingBlock);
     result.currentBlock = utils.toDecimal(result.currentBlock);
     result.highestBlock = utils.toDecimal(result.highestBlock);
-
+    if (result.knownStates !== undefined) {
+      result.knownStates = utils.toDecimal(result.knownStates);
+    }
+    if (result.pulledStates !== undefined) {
+      result.pulledStates = utils.toDecimal(result.pulledStates);
+    }
     return result;
 };
 


### PR DESCRIPTION
Web3 currently doesn't know about the state progress fields of eth_syncing. This causes console formatting issues. This PR hotfixes web3 included in Geth so that we can do our release and I'll open a PR to the upstream repo as well.