### PR TITLE
rpc: HTTP origin case insensitive

### DIFF
--- a/rpc/websocket.go
+++ b/rpc/websocket.go
@@ -61,22 +61,22 @@ func wsHandshakeValidator(allowedOrigins []string) func(*websocket.Config, *http
 			allowAllOrigins = true
 		}
 		if origin != "" {
-			origins.Add(origin)
+			origins.Add(strings.ToLower(origin))
 		}
 	}
 
-	// allow localhost if no allowedOrigins are specified
+	// allow localhost if no allowedOrigins are specified.
 	if len(origins.List()) == 0 {
 		origins.Add("http://localhost")
 		if hostname, err := os.Hostname(); err == nil {
-			origins.Add("http://" + hostname)
+			origins.Add("http://" + strings.ToLower(hostname))
 		}
 	}
 
 	glog.V(logger.Debug).Infof("Allowed origin(s) for WS RPC interface %v\n", origins.List())
 
 	f := func(cfg *websocket.Config, req *http.Request) error {
-		origin := req.Header.Get("Origin")
+		origin := strings.ToLower(req.Header.Get("Origin"))
 		if allowAllOrigins || origins.Has(origin) {
 			return nil
 		}


### PR DESCRIPTION
The HTTP Origin header is defined as case insensitive in the spec. The current RPC package does a case sensitive compare. Since the websocket library transforms the send Origin header to lower case this causes problems on platforms with an upper case in the hostname. This PR make the comparison case insensitive.

(http interface is not affected since this uses the cors package which does already does a case insensitive compare)

PTAL: @karalabe