### PR TITLE
cmd/geth, internal/web3ext, rpc: surface rpc module, fix shh, fix miner

### DIFF
--- a/cmd/geth/js.go
+++ b/cmd/geth/js.go
@@ -199,7 +199,7 @@ func (js *jsre) apiBindings() error {
 	// load only supported API's in javascript runtime
 	shortcuts := "var eth = web3.eth; var personal = web3.personal; "
 	for _, apiName := range apiNames {
-		if apiName == "web3" || apiName == "rpc" {
+		if apiName == "web3" {
 			continue // manually mapped or ignore
 		}
 

--- a/internal/web3ext/web3ext.go
+++ b/internal/web3ext/web3ext.go
@@ -18,43 +18,16 @@
 package web3ext
 
 var Modules = map[string]string{
-	"txpool":   TxPool_JS,
 	"admin":    Admin_JS,
-	"personal": Personal_JS,
+	"debug":    Debug_JS,
 	"eth":      Eth_JS,
 	"miner":    Miner_JS,
-	"debug":    Debug_JS,
 	"net":      Net_JS,
+	"personal": Personal_JS,
+	"rpc":      RPC_JS,
+	"shh":      Shh_JS,
+	"txpool":   TxPool_JS,
 }
-
-const TxPool_JS = `
-web3._extend({
-	property: 'txpool',
-	methods:
-	[
-	],
-	properties:
-	[
-		new web3._extend.Property({
-			name: 'content',
-			getter: 'txpool_content'
-		}),
-		new web3._extend.Property({
-			name: 'inspect',
-			getter: 'txpool_inspect'
-		}),
-		new web3._extend.Property({
-			name: 'status',
-			getter: 'txpool_status',
-			outputFormatter: function(status) {
-				status.pending = web3._extend.utils.toDecimal(status.pending);
-				status.queued = web3._extend.utils.toDecimal(status.queued);
-				return status;
-			}
-		})
-	]
-});
-`
 
 const Admin_JS = `
 web3._extend({
@@ -171,88 +144,6 @@ web3._extend({
 		new web3._extend.Property({
 			name: 'datadir',
 			getter: 'admin_datadir'
-		})
-	]
-});
-`
-
-const Personal_JS = `
-web3._extend({
-	property: 'personal',
-	methods:
-	[
-		new web3._extend.Method({
-			name: 'importRawKey',
-			call: 'personal_importRawKey',
-			params: 2
-		})
-	]
-});
-`
-
-const Eth_JS = `
-web3._extend({
-	property: 'eth',
-	methods:
-	[
-		new web3._extend.Method({
-			name: 'sign',
-			call: 'eth_sign',
-			params: 2,
-			inputFormatter: [web3._extend.formatters.inputAddressFormatter, null]
-		}),
-		new web3._extend.Method({
-			name: 'resend',
-			call: 'eth_resend',
-			params: 3,
-			inputFormatter: [web3._extend.formatters.inputTransactionFormatter, web3._extend.utils.fromDecimal, web3._extend.utils.fromDecimal]
-		}),
-		new web3._extend.Method({
-			name: 'getNatSpec',
-			call: 'eth_getNatSpec',
-			params: 1,
-			inputFormatter: [web3._extend.formatters.inputTransactionFormatter]
-		}),
-		new web3._extend.Method({
-			name: 'signTransaction',
-			call: 'eth_signTransaction',
-			params: 1,
-			inputFormatter: [web3._extend.formatters.inputTransactionFormatter]
-		}),
-		new web3._extend.Method({
-			name: 'submitTransaction',
-			call: 'eth_submitTransaction',
-			params: 1,
-			inputFormatter: [web3._extend.formatters.inputTransactionFormatter]
-		})
-	],
-	properties:
-	[
-		new web3._extend.Property({
-			name: 'pendingTransactions',
-			getter: 'eth_pendingTransactions',
-			outputFormatter: function(txs) {
-				var formatted = [];
-				for (var i = 0; i < txs.length; i++) {
-					formatted.push(web3._extend.formatters.outputTransactionFormatter(txs[i]));
-					formatted[i].blockHash = null;
-				}
-				return formatted;
-			}
-		})
-	]
-});
-`
-
-const Net_JS = `
-web3._extend({
-	property: 'net',
-	methods: [],
-	properties:
-	[
-		new web3._extend.Property({
-			name: 'version',
-			getter: 'net_version'
 		})
 	]
 });
@@ -410,6 +301,60 @@ web3._extend({
 });
 `
 
+const Eth_JS = `
+web3._extend({
+	property: 'eth',
+	methods:
+	[
+		new web3._extend.Method({
+			name: 'sign',
+			call: 'eth_sign',
+			params: 2,
+			inputFormatter: [web3._extend.formatters.inputAddressFormatter, null]
+		}),
+		new web3._extend.Method({
+			name: 'resend',
+			call: 'eth_resend',
+			params: 3,
+			inputFormatter: [web3._extend.formatters.inputTransactionFormatter, web3._extend.utils.fromDecimal, web3._extend.utils.fromDecimal]
+		}),
+		new web3._extend.Method({
+			name: 'getNatSpec',
+			call: 'eth_getNatSpec',
+			params: 1,
+			inputFormatter: [web3._extend.formatters.inputTransactionFormatter]
+		}),
+		new web3._extend.Method({
+			name: 'signTransaction',
+			call: 'eth_signTransaction',
+			params: 1,
+			inputFormatter: [web3._extend.formatters.inputTransactionFormatter]
+		}),
+		new web3._extend.Method({
+			name: 'submitTransaction',
+			call: 'eth_submitTransaction',
+			params: 1,
+			inputFormatter: [web3._extend.formatters.inputTransactionFormatter]
+		})
+	],
+	properties:
+	[
+		new web3._extend.Property({
+			name: 'pendingTransactions',
+			getter: 'eth_pendingTransactions',
+			outputFormatter: function(txs) {
+				var formatted = [];
+				for (var i = 0; i < txs.length; i++) {
+					formatted.push(web3._extend.formatters.outputTransactionFormatter(txs[i]));
+					formatted[i].blockHash = null;
+				}
+				return formatted;
+			}
+		})
+	]
+});
+`
+
 const Miner_JS = `
 web3._extend({
 	property: 'miner',
@@ -440,7 +385,7 @@ web3._extend({
 			name: 'setGasPrice',
 			call: 'miner_setGasPrice',
 			params: 1,
-			inputFormatter: [web3._extend.utils.fromDecial]
+			inputFormatter: [web3._extend.utils.fromDecimal]
 		}),
 		new web3._extend.Method({
 			name: 'startAutoDAG',
@@ -463,6 +408,48 @@ web3._extend({
 });
 `
 
+const Net_JS = `
+web3._extend({
+	property: 'net',
+	methods: [],
+	properties:
+	[
+		new web3._extend.Property({
+			name: 'version',
+			getter: 'net_version'
+		})
+	]
+});
+`
+
+const Personal_JS = `
+web3._extend({
+	property: 'personal',
+	methods:
+	[
+		new web3._extend.Method({
+			name: 'importRawKey',
+			call: 'personal_importRawKey',
+			params: 2
+		})
+	]
+});
+`
+
+const RPC_JS = `
+web3._extend({
+	property: 'rpc',
+	methods: [],
+	properties:
+	[
+		new web3._extend.Property({
+			name: 'modules',
+			getter: 'rpc_modules'
+		})
+	]
+});
+`
+
 const Shh_JS = `
 web3._extend({
 	property: 'shh',
@@ -471,7 +458,35 @@ web3._extend({
 	[
 		new web3._extend.Property({
 			name: 'version',
-			getter: 'shh_version'
+			getter: 'shh_version',
+			outputFormatter: web3._extend.utils.toDecimal
+		})
+	]
+});
+`
+
+const TxPool_JS = `
+web3._extend({
+	property: 'txpool',
+	methods: [],
+	properties:
+	[
+		new web3._extend.Property({
+			name: 'content',
+			getter: 'txpool_content'
+		}),
+		new web3._extend.Property({
+			name: 'inspect',
+			getter: 'txpool_inspect'
+		}),
+		new web3._extend.Property({
+			name: 'status',
+			getter: 'txpool_status',
+			outputFormatter: function(status) {
+				status.pending = web3._extend.utils.toDecimal(status.pending);
+				status.queued = web3._extend.utils.toDecimal(status.queued);
+				return status;
+			}
 		})
 	]
 });

--- a/rpc/server.go
+++ b/rpc/server.go
@@ -34,7 +34,8 @@ const (
 
 	notificationBufferSize = 10000 // max buffered notifications before codec is closed
 
-	DefaultIPCApis  = "admin,eth,debug,miner,net,shh,txpool,personal,web3"
+	MetadataApi     = "rpc"
+	DefaultIPCApis  = "admin,debug,eth,miner,net,personal,shh,txpool,web3"
 	DefaultHTTPApis = "eth,net,web3"
 )
 
@@ -61,7 +62,7 @@ func NewServer() *Server {
 	// register a default service which will provide meta information about the RPC service such as the services and
 	// methods it offers.
 	rpcService := &RPCService{server}
-	server.RegisterName("rpc", rpcService)
+	server.RegisterName(MetadataApi, rpcService)
 
 	return server
 }

--- a/rpc/utils.go
+++ b/rpc/utils.go
@@ -234,7 +234,7 @@ func SupportedModules(client Client) (map[string]string, error) {
 	req := JSONRequest{
 		Id:      []byte("1"),
 		Version: "2.0",
-		Method:  "rpc_modules",
+		Method:  MetadataApi + "_modules",
 	}
 	if err := client.Send(req); err != nil {
 		return nil, err


### PR DESCRIPTION
This is a trivial PR that however contains quite a few fixes:

 * The RPC layer provided a hidden `rpc` module that was advertised by the console, but wasn't actually callable. Since that metadata endpoint could provide valuable later on, this PR surfaces it to the console too within the `rpc` namespace.
 * Although we had customized method endpoints and wrappers for `shh_version`, it was forgotten to be added to the list of web3 extensions, loosing it. This PR adds it back in, also fixing its output formatter which was hex previously. To prevent such issues in the future, the PR also sorted the contents of `web3ext.go`, which was probably the cause for losing a module in the first place.
 * `miner.setGasPrice` had a typo in the input formatter, essentially making that endpoint non functional.

PTAL @bas-vk 