### PR TITLE
cmd/geth: use text/templates in the tester, not html

### DIFF
--- a/cmd/geth/run_test.go
+++ b/cmd/geth/run_test.go
@@ -20,7 +20,6 @@ import (
 	"bufio"
 	"bytes"
 	"fmt"
-	"html/template"
 	"io"
 	"io/ioutil"
 	"os"
@@ -28,6 +27,7 @@ import (
 	"regexp"
 	"sync"
 	"testing"
+	"text/template"
 	"time"
 )
 


### PR DESCRIPTION
Beyond trivial PR: the geth integration tester used the wrong templating package (`html/template` instead of `text/template`), causing failures when the output contained characters special to HTML (e.g. the `>` console prompt).

PTAL @fjl 