### PR TITLE
accounts/abi/bind: fix multi-value anonymous unmarshalling

### DIFF
--- a/accounts/abi/abi_test.go
+++ b/accounts/abi/abi_test.go
@@ -305,10 +305,10 @@ func TestUnpackSetInterfaceSlice(t *testing.T) {
 		t.Fatal(err)
 	}
 	if *var1 != 1 {
-		t.Errorf("expected var1 to be 1, got", *var1)
+		t.Error("expected var1 to be 1, got", *var1)
 	}
 	if *var2 != 2 {
-		t.Errorf("expected var2 to be 2, got", *var2)
+		t.Error("expected var2 to be 2, got", *var2)
 	}
 
 	out = []interface{}{var1}

--- a/accounts/abi/bind/template.go
+++ b/accounts/abi/bind/template.go
@@ -211,7 +211,7 @@ package {{.Package}}
 				{{range $i, $_ := .Normalized.Outputs}}ret{{$i}} = new({{bindtype .Type}})
 				{{end}}
 			){{end}}
-			out := {{if .Structured}}ret{{else}}{{if eq (len .Normalized.Outputs) 1}}ret0{{else}}[]interface{}{
+			out := {{if .Structured}}ret{{else}}{{if eq (len .Normalized.Outputs) 1}}ret0{{else}}&[]interface{}{
 				{{range $i, $_ := .Normalized.Outputs}}ret{{$i}},
 				{{end}}
 			}{{end}}{{end}}


### PR DESCRIPTION
This PR is a follow up to https://github.com/ethereum/go-ethereum/pull/2551, updating abigen too to use the correct unpack invocation.