### PR TITLE
eth: fixed double close of channel. Fixes #2555

### DIFF
--- a/event/event.go
+++ b/event/event.go
@@ -66,6 +66,9 @@ func (mux *TypeMux) Subscribe(types ...interface{}) Subscription {
 	mux.mutex.Lock()
 	defer mux.mutex.Unlock()
 	if mux.stopped {
+		// set the status to closed so that calling Unsubscribe after this
+		// call will short curuit
+		sub.closed = true
 		close(sub.postC)
 	} else {
 		if mux.subm == nil {

--- a/event/event_test.go
+++ b/event/event_test.go
@@ -25,6 +25,14 @@ import (
 
 type testEvent int
 
+func TestSubCloseUnsub(t *testing.T) {
+	// the point of this test is **not** to panic
+	var mux TypeMux
+	mux.Stop()
+	sub := mux.Subscribe(int(0))
+	sub.Unsubscribe()
+}
+
 func TestSub(t *testing.T) {
 	mux := new(TypeMux)
 	defer mux.Stop()


### PR DESCRIPTION
Removed a pointless and dangerous `defer` which could otherwise cause a
crash due to closing of an already closed channel. The `listenLoop`
method couldn't exit on it's own unless the subscribed events channel
where to be closed. If the channel were to be closed and exit the
function it would `Unsubscribe` again, causing a panic.
