### PR TITLE
eth: add new RPC method (personal.) SignAndSendTransaction

### DIFF
--- a/accounts/account_manager.go
+++ b/accounts/account_manager.go
@@ -147,9 +147,21 @@ func (am *Manager) Sign(addr common.Address, hash []byte) (signature []byte, err
 	return crypto.Sign(hash, unlockedKey.PrivateKey)
 }
 
+// SignWithPassphrase signs hash if the private key matching the given address can be
+// decrypted with the given passphrase.
+func (am *Manager) SignWithPassphrase(addr common.Address, passphrase string, hash []byte) (signature []byte, err error) {
+	_, key, err := am.getDecryptedKey(Account{Address: addr}, passphrase)
+	if err != nil {
+		return nil, err
+	}
+
+	defer zeroKey(key.PrivateKey)
+	return crypto.Sign(hash, key.PrivateKey)
+}
+
 // Unlock unlocks the given account indefinitely.
-func (am *Manager) Unlock(a Account, keyAuth string) error {
-	return am.TimedUnlock(a, keyAuth, 0)
+func (am *Manager) Unlock(a Account, passphrase string) error {
+	return am.TimedUnlock(a, passphrase, 0)
 }
 
 // Lock removes the private key with the given address from memory.

--- a/accounts/accounts_test.go
+++ b/accounts/accounts_test.go
@@ -81,6 +81,34 @@ func TestSign(t *testing.T) {
 	}
 }
 
+func TestSignWithPassphrase(t *testing.T) {
+	dir, am := tmpManager(t, true)
+	defer os.RemoveAll(dir)
+
+	pass := "passwd"
+	acc, err := am.NewAccount(pass)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if _, unlocked := am.unlocked[acc.Address]; unlocked {
+		t.Fatal("expected account to be locked")
+	}
+
+	_, err = am.SignWithPassphrase(acc.Address, pass, testSigData)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if _, unlocked := am.unlocked[acc.Address]; unlocked {
+		t.Fatal("expected account to be locked")
+	}
+
+	if _, err = am.SignWithPassphrase(acc.Address, "invalid passwd", testSigData); err == nil {
+		t.Fatal("expected SignHash to fail with invalid password")
+	}
+}
+
 func TestTimedUnlock(t *testing.T) {
 	dir, am := tmpManager(t, true)
 	defer os.RemoveAll(dir)

--- a/cmd/geth/js.go
+++ b/cmd/geth/js.go
@@ -41,7 +41,7 @@ import (
 )
 
 var (
-	passwordRegexp = regexp.MustCompile("personal.[nu]")
+	passwordRegexp = regexp.MustCompile("personal.[nus]")
 	onlyws         = regexp.MustCompile("^\\s*$")
 	exit           = regexp.MustCompile("^\\s*exit\\s*;*\\s*$")
 )

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -26,6 +26,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/ethereum/ethash"
@@ -113,6 +114,7 @@ type Ethereum struct {
 
 	// Handlers
 	txPool          *core.TxPool
+	txMu            sync.Mutex
 	blockchain      *core.BlockChain
 	accountManager  *accounts.Manager
 	pow             *ethash.Ethash
@@ -293,7 +295,7 @@ func (s *Ethereum) APIs() []rpc.API {
 		}, {
 			Namespace: "personal",
 			Version:   "1.0",
-			Service:   NewPrivateAccountAPI(s.accountManager),
+			Service:   NewPrivateAccountAPI(s),
 			Public:    false,
 		}, {
 			Namespace: "eth",

--- a/internal/web3ext/web3ext.go
+++ b/internal/web3ext/web3ext.go
@@ -431,6 +431,12 @@ web3._extend({
 			name: 'importRawKey',
 			call: 'personal_importRawKey',
 			params: 2
+		}),
+		new web3._extend.Method({
+			name: 'signAndSendTransaction',
+			call: 'personal_signAndSendTransaction',
+			params: 2,
+			inputFormatter: [web3._extend.formatters.inputTransactionFormatter, null]
 		})
 	]
 });


### PR DESCRIPTION
This PR introduces a new RPC method `PrivateAccountAPI.SignAndSendTransaction` that is exposed in the personal namespace. The method accepts a transaction and password as arguments. This allows external applications to submit a transaction without the need to first unlock an account before submitting a transaction which can give an adversary a small time window to submit a fraudulent transaction or sign data.

It also fixes several style issues in `eth/api.go`.

PTAL @obscuren  @fjl 