### PR TITLE
cmd/geth: fix console history exclusion

### DIFF
--- a/cmd/geth/js.go
+++ b/cmd/geth/js.go
@@ -42,7 +42,6 @@ import (
 
 var (
 	passwordRegexp = regexp.MustCompile("personal.[nu]")
-	leadingSpace   = regexp.MustCompile("^ ")
 	onlyws         = regexp.MustCompile("^\\s*$")
 	exit           = regexp.MustCompile("^\\s*exit\\s*;*\\s*$")
 )
@@ -361,7 +360,7 @@ func (self *jsre) interactive() {
 			str += input + "\n"
 			self.setIndent()
 			if indentCount <= 0 {
-				if mustLogInHistory(str) {
+				if !excludeFromHistory(str) {
 					utils.Stdin.AppendHistory(str[:len(str)-1])
 				}
 				self.parseInput(str)
@@ -371,10 +370,8 @@ func (self *jsre) interactive() {
 	}
 }
 
-func mustLogInHistory(input string) bool {
-	return len(input) == 0 ||
-		passwordRegexp.MatchString(input) ||
-		!leadingSpace.MatchString(input)
+func excludeFromHistory(input string) bool {
+	return len(input) == 0 || input[0] == ' ' || passwordRegexp.MatchString(input)
 }
 
 func (self *jsre) withHistory(datadir string, op func(*os.File)) {


### PR DESCRIPTION
Calls to 'personal' API should be excluded from console history because
they can be called with an account passphrase as argument. The check for
such calls was inverted and didn't work.