### PR TITLE
Comment genesis check

### DIFF
--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -746,10 +746,10 @@ func MakeSystemNode(name, version string, relconf release.Config, extra []byte, 
 		if !ctx.GlobalIsSet(ListenPortFlag.Name) {
 			stackConf.ListenAddr = ":0"
 		}
-		// Override the Ethereum protocol configs
-		if !ctx.GlobalIsSet(GenesisFileFlag.Name) {
-			ethConf.Genesis = core.OlympicGenesisBlock()
-		}
+		//// Override the Ethereum protocol configs
+		//if !ctx.GlobalIsSet(GenesisFileFlag.Name) {
+		//	ethConf.Genesis = core.OlympicGenesisBlock()
+		//}
 		if !ctx.GlobalIsSet(GasPriceFlag.Name) {
 			ethConf.GasPrice = new(big.Int)
 		}


### PR DESCRIPTION
Hi guys, while trying to cope with this [problem](http://ethereum.stackexchange.com/questions/3948/how-to-create-private-network-with-preallocated-amount-of-eth) I did't find the right answer and tried to understand the logic of `--dev` flag, so am not the go programmer, but that looks like a bug.

So, If we specify `--dev` flag, than go client complaining about deprecation, that is totally ok, but:
```
    app.Before = func(ctx *cli.Context) error {
        . . .
        // Deprecation warning.
        if ctx.GlobalIsSet(utils.GenesisFileFlag.Name) {
            common.PrintDepricationWarning("--genesis is deprecated. Switch to use 'geth init /path/to/file'")
        }
        . . . 
    }
```

After that if client don't see the `--genesis` flag it override the genesis settings that was previously set by `geth init genesis.json`
```
    case ctx.GlobalBool(DevModeFlag.Name):
        . . . 
        // Override the Ethereum protocol configs
        if !ctx.GlobalIsSet(GenesisFileFlag.Name) {
            ethConf.Genesis = core.OlympicGenesisBlock()
        }
        . . .
    }
```

I recompiled the project, and all works good for me now, I know that this is not the better solution but it is better than nothing. So, is it a bug or am I missing something? Console output after recompilation:

```
 root@b25ddca5a39e:/tmp/go-ethereum/build/bin# ./geth --datadir /opt/deluge/services/ethnode/ init /opt/deluge/services/ethnode/genesis.json
I0516 16:26:50.479199 ethdb/database.go:82] Alloted 16MB cache and 16 file handles to /opt/deluge/services/ethnode/chaindata
I0516 16:26:50.551565 cmd/geth/main.go:353] successfully wrote genesis block and/or chain rule set: e25cef41beec3e8e911d6b966c7bdf8de5f26a0b06347aecfd34fba46fad5b66

root@b25ddca5a39e:/tmp/go-ethereum/build/bin# ./geth --dev --datadir /opt/deluge/services/ethnode/ console
I0516 16:26:58.721312 ethdb/database.go:82] Alloted 128MB cache and 1024 file handles to /opt/deluge/services/ethnode/chaindata
I0516 16:26:58.748516 ethdb/database.go:169] closed db:/opt/deluge/services/ethnode/chaindata
I0516 16:26:58.751784 ethdb/database.go:82] Alloted 128MB cache and 1024 file handles to /opt/deluge/services/ethnode/chaindata
I0516 16:26:58.853713 eth/backend.go:617] upgrading db log bloom bins
I0516 16:26:58.854109 eth/backend.go:625] upgrade completed in 398.756µs
I0516 16:26:58.854326 ethdb/database.go:82] Alloted 16MB cache and 16 file handles to /opt/deluge/services/ethnode/dapp
I0516 16:26:58.861837 eth/backend.go:170] Protocol Versions: [63 62 61], Network Id: 1
I0516 16:26:58.862019 eth/backend.go:199] Blockchain DB Version: 3
I0516 16:26:58.862082 eth/backend.go:224] ethash used in test mode
I0516 16:26:58.863409 core/blockchain.go:206] Last header: #0 [e25cef41…] TD=131072
I0516 16:26:58.863489 core/blockchain.go:207] Last block: #0 [e25cef41…] TD=131072
I0516 16:26:58.863541 core/blockchain.go:208] Fast block: #0 [e25cef41…] TD=131072
I0516 16:26:58.864566 p2p/server.go:311] Starting Server
I0516 16:27:00.888120 p2p/discover/udp.go:217] Listening, enode://cfd6397ae0c7936aee38e161c4a74d893e5c83184fa6af637375b74d4cd9c154054ef780cad9e66f850792eeadaadd8f1066062352dada6e23e3e768a1e1ebf1@[::]:53606
I0516 16:27:00.889078 whisper/whisper.go:176] Whisper started
I0516 16:27:00.893571 p2p/server.go:554] Listening on [::]:54577
I0516 16:27:00.893978 node/node.go:298] IPC endpoint opened: /opt/deluge/services/ethnode/geth.ipc
instance: Geth/v1.4.4-stable/linux/go1.5.1
coinbase: 0xe7b728f368fce77508e4562ef370d3e902bb79dc
at block: 0 (Thu, 01 Jan 1970 00:00:00 UTC)
 datadir: /opt/deluge/services/ethnode
> eth.getBalance(eth.coinbase)
10000000000000000000
>
```
