### PR TITLE
eth: skip transaction handling during fast sync

### DIFF
--- a/eth/sync_test.go
+++ b/eth/sync_test.go
@@ -17,6 +17,7 @@
 package eth
 
 import (
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -29,12 +30,12 @@ import (
 func TestFastSyncDisabling(t *testing.T) {
 	// Create a pristine protocol manager, check that fast sync is left enabled
 	pmEmpty := newTestProtocolManagerMust(t, true, 0, nil, nil)
-	if !pmEmpty.fastSync {
+	if atomic.LoadUint32(&pmEmpty.fastSync) == 0 {
 		t.Fatalf("fast sync disabled on pristine blockchain")
 	}
 	// Create a full protocol manager, check that fast sync gets disabled
 	pmFull := newTestProtocolManagerMust(t, true, 1024, nil, nil)
-	if pmFull.fastSync {
+	if atomic.LoadUint32(&pmFull.fastSync) == 1 {
 		t.Fatalf("fast sync not disabled on non-empty blockchain")
 	}
 	// Sync up the two peers
@@ -47,7 +48,7 @@ func TestFastSyncDisabling(t *testing.T) {
 	pmEmpty.synchronise(pmEmpty.peers.BestPeer())
 
 	// Check that fast sync was disabled
-	if pmEmpty.fastSync {
+	if atomic.LoadUint32(&pmEmpty.fastSync) == 1 {
 		t.Fatalf("fast sync not disabled after successful synchronisation")
 	}
 }


### PR DESCRIPTION
This PR's meant to address a transaction handling issue that became a bit more emphasized with the high transaction count of the DAO. During synchronization, nodes do accept, try to process and propagate good transactions to other nodes. This is desirable to prevent DOS attacks.

However, during initial fast sync all the transactions propagated to a node are essentially useless since it cannot do anything with them, and by the time the node finishes syncing, most will be integrated into the chain either way. However, by keeping them in the active pool, it puts a burden on the node to constantly recheck the cached transactions if they should be dumped or still kept around.

This PR disables accepting new transactions while fast sync is in progress, hence taking quite a computational and networking burden off a node's shoulder.

---

Performance wise with this PR + the concurrent headers a sync from 0 to 1533536 took 24 minutes for me, down from 27 mins a few weeks ago (with less blocks back then). Seems that sync is also a lot more stable, probably due to all that junk transaction traffic not being pushed over network links.

---

PS: The PR does make one slight change in behavior compared to the old code: if a private network is booted up with every node configured to fast sync, then the network will not forward transactions until the first block is mined and fast sync disabled. Given however that nodes should never assume any timing guarantees about transaction incorporation, this should be a fully negligible scenario.