### PR TITLE
node, p2p: move network config out of Server

### DIFF
--- a/node/node.go
+++ b/node/node.go
@@ -49,7 +49,7 @@ type Node struct {
 	datadir  string         // Path to the currently used data directory
 	eventmux *event.TypeMux // Event multiplexer used between the services of a stack
 
-	serverConfig *p2p.Server // Configuration of the underlying P2P networking layer
+	serverConfig p2p.Config
 	server       *p2p.Server // Currently running P2P networking layer
 
 	serviceFuncs []ServiceConstructor     // Service constructors (in dependency order)
@@ -97,7 +97,7 @@ func New(conf *Config) (*Node, error) {
 	}
 	return &Node{
 		datadir: conf.DataDir,
-		serverConfig: &p2p.Server{
+		serverConfig: p2p.Config{
 			PrivateKey:      conf.NodeKey(),
 			Name:            conf.Name,
 			Discovery:       !conf.NoDiscovery,
@@ -151,9 +151,7 @@ func (n *Node) Start() error {
 		return ErrNodeRunning
 	}
 	// Otherwise copy and specialize the P2P configuration
-	running := new(p2p.Server)
-	*running = *n.serverConfig
-
+	running := &p2p.Server{Config: n.serverConfig}
 	services := make(map[reflect.Type]Service)
 	for _, constructor := range n.serviceFuncs {
 		// Create a new context for the particular service

--- a/p2p/dial_test.go
+++ b/p2p/dial_test.go
@@ -478,7 +478,8 @@ func TestDialResolve(t *testing.T) {
 	}
 
 	// Now run the task, it should resolve the ID once.
-	srv := &Server{ntab: table, Dialer: &net.Dialer{Deadline: time.Now().Add(-5 * time.Minute)}}
+	config := Config{Dialer: &net.Dialer{Deadline: time.Now().Add(-5 * time.Minute)}}
+	srv := &Server{ntab: table, Config: config}
 	tasks[0].Do(srv)
 	if !reflect.DeepEqual(table.resolveCalls, []discover.NodeID{dest.ID}) {
 		t.Fatalf("wrong resolve calls, got %v", table.resolveCalls)

--- a/p2p/server.go
+++ b/p2p/server.go
@@ -54,12 +54,8 @@ var errServerStopped = errors.New("server stopped")
 
 var srvjslog = logger.NewJsonLogger()
 
-// Server manages all peer connections.
-//
-// The fields of Server are used as configuration parameters.
-// You should set them before starting the Server. Fields may not be
-// modified while the server is running.
-type Server struct {
+// Config holds Server options.
+type Config struct {
 	// This field must be set to a valid secp256k1 private key.
 	PrivateKey *ecdsa.PrivateKey
 
@@ -120,6 +116,12 @@ type Server struct {
 
 	// If NoDial is true, the server will not dial any peers.
 	NoDial bool
+}
+
+// Server manages all peer connections.
+type Server struct {
+	// Config fields may not be modified while the server is running.
+	Config
 
 	// Hooks for testing. These are useful because we can inhibit
 	// the whole protocol stack.


### PR DESCRIPTION
This silences a go vet message about copying p2p.Server in package node.