### PR TITLE
core, core/state, trie: enterprise hand-tuned multi-level caching

### DIFF
--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -819,6 +819,7 @@ func (self *BlockChain) InsertChain(chain types.Blocks) (int, error) {
 		tstart        = time.Now()
 
 		nonceChecked = make([]bool, len(chain))
+		statedb      *state.StateDB
 	)
 
 	// Start the parallel nonce verifier.
@@ -885,7 +886,11 @@ func (self *BlockChain) InsertChain(chain types.Blocks) (int, error) {
 
 		// Create a new statedb using the parent block and report an
 		// error if it fails.
-		statedb, err := state.New(self.GetBlock(block.ParentHash()).Root(), self.chainDb)
+		if statedb == nil {
+			statedb, err = state.New(self.GetBlock(block.ParentHash()).Root(), self.chainDb)
+		} else {
+			err = statedb.Reset(chain[i-1].Root())
+		}
 		if err != nil {
 			reportBlock(block, err)
 			return i, err

--- a/core/state/statedb.go
+++ b/core/state/statedb.go
@@ -68,6 +68,28 @@ func New(root common.Hash, db ethdb.Database) (*StateDB, error) {
 	}, nil
 }
 
+// Reset clears out all emphemeral state objects from the state db, but keeps
+// the underlying state trie to avoid reloading data for the next operations.
+func (self *StateDB) Reset(root common.Hash) error {
+	var (
+		err error
+		tr  = self.trie
+	)
+	if self.trie.Hash() != root {
+		if tr, err = trie.NewSecure(root, self.db); err != nil {
+			return err
+		}
+	}
+	*self = StateDB{
+		db:           self.db,
+		trie:         tr,
+		stateObjects: make(map[string]*StateObject),
+		refund:       new(big.Int),
+		logs:         make(map[common.Hash]vm.Logs),
+	}
+	return nil
+}
+
 func (self *StateDB) StartRecord(thash, bhash common.Hash, ti int) {
 	self.thash = thash
 	self.bhash = bhash

--- a/trie/secure_trie.go
+++ b/trie/secure_trie.go
@@ -162,11 +162,11 @@ func (t *SecureTrie) CommitTo(db DatabaseWriter) (root common.Hash, err error) {
 		}
 		t.secKeyCache = make(map[string][]byte)
 	}
-	n, err := t.hashRoot(db)
+	n, clean, err := t.hashRoot(db)
 	if err != nil {
 		return (common.Hash{}), err
 	}
-	t.root = n
+	t.root = clean
 	return common.BytesToHash(n.(hashNode)), nil
 }
 

--- a/trie/trie_test.go
+++ b/trie/trie_test.go
@@ -295,7 +295,7 @@ func TestReplication(t *testing.T) {
 	for _, val := range vals2 {
 		updateString(trie2, val.k, val.v)
 	}
-	if trie2.Hash() != exp {
+	if hash := trie2.Hash(); hash != exp {
 		t.Errorf("root failure. expected %x got %x", exp, hash)
 	}
 }


### PR DESCRIPTION
#### Enterprise grade hand-tuned multi-level heuristic smart caching :trollface: 

This PR is based on the results of analyzing the trie internals ([dataset](https://gist.github.com/karalabe/92463a14df8ead77ebde83ca809b0922)), plotted on [this chart](https://gist.github.com/karalabe/00ec9106cb7ad2a941a41e2d76d71b4c) (download and open, you can disable individual plot lines by clicking on them in the legend). The data points are averages within a batch of 2500 blocks.

The interesting phenomenon highlighted on the above chart becomes apparent if you turn on `Transactions`, `Hashes` and `Dup Hashes` only. Based on the chart it's mostly clear that the number of unique hashing operations done per block increases linearly with the transactions contained within. However, the number of duplicate hashing operations **increases quadratically**. This can in certain batches of blocks reach over 16000 hashing operations per 800 unique ones.

Looking at `Transactions`, `Stores` and `Dup Stores` highlights that similar to unique hashing, unique storage increases linearly with the number of transactions, but opposed to duplicate hashes, duplicate stores are also linear with the number of transactions. The highest peak being 40-50 duplicate stores per 210-220 unique stores.

#### Cause for the quadratic growth

Investigating the trie implementation (i.e. looking at the code and picking @fjl's brain), it turns out that we construct a single state trie while processing all the transactions in a block, but since each transaction needs an intermediate state root, we also hash the entire trie after every transaction.

The issue is, that during hierarchically hashing the entire intermediate state trie, we operate on a temporary ephemeral data structure, which we then discard. However if the block contains a second transaction, the trie associated with it will share significant portions with the trie loaded by the first transaction, and calculating the intermediate state root will rehash all the nodes added by the first transaction. Following this logic, calculating the state root for a transaction will reprocess all the data that previous transactions included and already processed, leading to quadratic data processing: for `T` transactions, we're doing `O((T*H)^2)` hashes, where `H` is a number of hashes required per one transaction.

##### Avoiding duplicate hashing

To avoid quadratically wasting computing capacity on hashing, we need to cache the computed hashes for every trie node so that it may be reused by subsequent intermediate root hashes in the same block and not recalculated all the time.

To this end this PR adds a `hash` field to the `fullNode` and `shortNode`, which is originally set to nil for new nodes (it's set to the actual hash if loaded from the database). Afterwards during any recursive hashing operation, if a new hash is computed for a node we need to set this `hash` cache field on the original node. As the trie is immutable, modifying already existing nodes is not possible, so the recursive hasher reconstructs the trie with the `hash` field already set on the nodes, recursively replacing old non-cached nodes with new cached ones. After hashing the entire trie, the root itself will be replaced with this new pre-cached version.

The effect of this is that after hashing a trie, all its nodes will have their hashes cached and a new transaction built on top of this will only need to hash the diff of the trie and not its entirety.

##### Avoiding duplicate RLP encoding

The above hashing avoidance does a nice job in preventing recalculating the same hash many times over, but the RLP of the trie node is still calculated twice: once when it's hashed for the first time (needed for the hash) and once when it's actually committed to the database (as we don't have the original we hashed a while ago).

To avoid this reencoding an `rlp` field was also added to full and short nodes, which analogously to hashes, caches the RLP encoded value of the node for later reuse. This value is set for nodes at exactly the same place as the hash is set.

#### Breaking block boundaries

The above optimizations allowed saving a lot of unneeded hashing and rlp encoding operations when processing transactions within a block, but after the state trie was committed to the database, all the cached data was dropped. However a lot of this data is needed actually by the next block, which will just load it up from the database again, repeating all the processing we've already done. It could provide very valuable if we could keep the trie around for a few blocks.

The subtle issue with retaining the trie is that previously we did a single commit per trie, but retaining it for multiple blocks would introduce quadratic database storage similar to the hash issue we've just solved: the commit operation saves the entire trie to the database, without knowing what was already saved, so saving a constantly growing trie would trash the database very heavily.

The solution is yet again a small extension to the full and short nodes of a trie, which signals whether the node is dirty (i.e. not yet written to the database) or not. With the dirty flag being maintained we put a slight more burden on processing a single block, but in exchange allow reusing the trie for subsequent blocks.

*Note, doing this indefinitely would create a huge trie that's not even user/accessed any more, so the cache must be purged after some number of blocks. The current PR creates a clean cache for all batch import operations.*

### Performance

Running the benchmarks from `core` is clear that the most benefit is to heavy blocks:

```
benchmark                                       old ns/op     new ns/op     delta
BenchmarkInsertChain_ring200_memdb-8            169996701     63918841      -62.40%
BenchmarkInsertChain_ring200_diskdb-8           164672946     62274447      -62.18%
BenchmarkInsertChain_ring1000_memdb-8           248371257     70347291      -71.68%
BenchmarkInsertChain_ring1000_diskdb-8          243630098     67859683      -72.15%

benchmark                                       old allocs     new allocs     delta
BenchmarkInsertChain_ring200_memdb-8            746932         383517         -48.65%
BenchmarkInsertChain_ring200_diskdb-8           744374         380127         -48.93%
BenchmarkInsertChain_ring1000_memdb-8           985641         398243         -59.60%
BenchmarkInsertChain_ring1000_diskdb-8          982802         394308         -59.88%
```

```
benchmark                                       old ns/op     new ns/op     delta
BenchmarkInsertChain_empty_memdb-8              122176        123053        +0.72%
BenchmarkInsertChain_empty_diskdb-8             228054        227075        -0.43%
BenchmarkInsertChain_valueTx_memdb-8            228280        227416        -0.38%
BenchmarkInsertChain_valueTx_diskdb-8           359055        337056        -6.13%
BenchmarkInsertChain_valueTx_100kB_memdb-8      913643        933061        +2.13%
BenchmarkInsertChain_valueTx_100kB_diskdb-8     3469567       3367808       -2.93%
BenchmarkInsertChain_uncles_memdb-8             235461        238771        +1.41%
BenchmarkInsertChain_uncles_diskdb-8            363703        340066        -6.50%

benchmark                                       old allocs     new allocs     delta
BenchmarkInsertChain_empty_memdb-8              566            577            +1.94%
BenchmarkInsertChain_empty_diskdb-8             642            641            -0.16%
BenchmarkInsertChain_valueTx_memdb-8            1119           1133           +1.25%
BenchmarkInsertChain_valueTx_diskdb-8           1190           1187           -0.25%
BenchmarkInsertChain_valueTx_100kB_memdb-8      1122           1136           +1.25%
BenchmarkInsertChain_valueTx_100kB_diskdb-8     1315           1314           -0.08%
BenchmarkInsertChain_uncles_memdb-8             1090           1101           +1.01%
BenchmarkInsertChain_uncles_diskdb-8            1162           1161           -0.09%
```

Running live chain imports display some speedups:

| Code | POW | Machine | 0..500K | 500K..1M | 1M..1.5M |
|:---:|:---:|:---:|:---:|:---:|:---:|
| develop | fake | Core2, HDD, 4GB | 24:35 | 4:14:32 | |
| proposal | fake | Core2, HDD, 4GB | 21:45 | 4:05:01 | |
| sorted db | fake | Core2, HDD, 4GB | 24:20 | 1:48:44 | 10:50:30 |
| sorted + this | fake | Core2, HDD, 4GB | 22:40 | 1:42:32 | 8:03:42 |
| | | | | | |
| develop | fake | Core i7, SSD, 12GB | 11:24 | 37:32 | |
| proposal | fake | Core i7, SSD, 12GB | 8:58 | 34:44 | |
| sorted db | fake | Core i7, SSD, 12GB | 11:13 | - | 1:13:35 |
| sorted + this | fake | Core i7, SSD, 12GB | 9:20 | 33:58 | 47:26 |

Looking through the logs it's apparent that we're getting throttled by the database here sadly. Batches of blocks are processed significantly faster than before, but the database cannot keep up with the rate we're pushing data in, so after a few batches, there's a significant pause in import while the database catches up.

All in all the heavier the blocks become, the more benefit this PR will have, but if the blocks are not too saturated, any speedup gained is just killed by longer database pauses.