### PR TITLE
core: Simplify bloom9 tests

### DIFF
--- a/core/types/bloom9_test.go
+++ b/core/types/bloom9_test.go
@@ -39,12 +39,12 @@ func TestBloom(t *testing.T) {
 	}
 
 	for _, data := range positive {
-		if !bloom.Test(new(big.Int).SetBytes([]byte(data))) {
+		if !bloom.TestBytes([]byte(data)) {
 			t.Error("expected", data, "to test true")
 		}
 	}
 	for _, data := range negative {
-		if bloom.Test(new(big.Int).SetBytes([]byte(data))) {
+		if bloom.TestBytes([]byte(data)) {
 			t.Error("did not expect", data, "to test true")
 		}
 	}


### PR DESCRIPTION
Bloom9 tests can be simplified with available convenience method `TestByBytes`