### PR TITLE
eth/api: fixed GetCompilers when there is no error creating Solc

### DIFF
--- a/eth/api.go
+++ b/eth/api.go
@@ -113,7 +113,7 @@ func (s *PublicEthereumAPI) GasPrice() *big.Int {
 // GetCompilers returns the collection of available smart contract compilers
 func (s *PublicEthereumAPI) GetCompilers() ([]string, error) {
 	solc, err := s.e.Solc()
-	if err != nil && solc != nil {
+	if err == nil && solc != nil {
 		return []string{"Solidity"}, nil
 	}
 


### PR DESCRIPTION
Fixes #2598.