### PR TITLE
common/compiler: support relative path to solc

### DIFF
--- a/common/compiler/solidity.go
+++ b/common/compiler/solidity.go
@@ -149,7 +149,6 @@ func (sol *Solidity) Compile(source string) (map[string]*Contract, error) {
 	compilerOptions := strings.Join(params, " ")
 
 	cmd := exec.Command(sol.solcPath, params...)
-	cmd.Dir = wd
 	cmd.Stdin = strings.NewReader(source)
 	cmd.Stderr = stderr
 


### PR DESCRIPTION
This change adds support for relative path to `solc`.

I noticed being unable to compile solidity code on Windows with #2598. I noticed that the working directory for calling `solc` was changed to the temporary directory where the compilation output is placed. There is no need to change the working directory for calling `solc`. It actually breaks having a relative path to `solc` which can be returned by `exec.LookPath` when we are finding the path to `solc` in https://github.com/ethereum/go-ethereum/blob/develop/common/compiler/solidity.go#L91.

My setup was to have `geth.exe` in the same directory as `solc.exe`. The following function was called `exec.LookPath(solcPath)` with solcPath being `solc`. It would return `.\solc.exe` which broke because of the working directory change.