### PR TITLE
cmd/geth: print version on geth start

### DIFF
--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -299,7 +299,6 @@ func makeDefaultExtra() []byte {
 // It creates a default node based on the command line arguments and runs it in
 // blocking mode, waiting for it to be shut down.
 func geth(ctx *cli.Context) {
-	glog.V(logger.Info).Infof("instance: Geth/%s/%s/%s\n", verString, runtime.Version(), runtime.GOOS)
 	node := utils.MakeSystemNode(clientIdentifier, verString, relConfig, makeDefaultExtra(), ctx)
 	startNode(ctx, node)
 	node.Wait()
@@ -435,6 +434,8 @@ func execScripts(ctx *cli.Context) {
 // it unlocks any requested accounts, and starts the RPC/IPC interfaces and the
 // miner.
 func startNode(ctx *cli.Context, stack *node.Node) {
+	// Report geth version
+	glog.V(logger.Info).Infof("instance: Geth/%s/%s/%s\n", verString, runtime.Version(), runtime.GOOS)
 	// Start up the node itself
 	utils.StartNode(stack)
 

--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -299,7 +299,7 @@ func makeDefaultExtra() []byte {
 // It creates a default node based on the command line arguments and runs it in
 // blocking mode, waiting for it to be shut down.
 func geth(ctx *cli.Context) {
-	fmt.Printf("instance: Geth/%s/%s/%s\n", verString, runtime.Version(), runtime.GOOS)
+	glog.V(logger.Info).Infof("instance: Geth/%s/%s/%s\n", verString, runtime.Version(), runtime.GOOS)
 	node := utils.MakeSystemNode(clientIdentifier, verString, relConfig, makeDefaultExtra(), ctx)
 	startNode(ctx, node)
 	node.Wait()

--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -299,6 +299,7 @@ func makeDefaultExtra() []byte {
 // It creates a default node based on the command line arguments and runs it in
 // blocking mode, waiting for it to be shut down.
 func geth(ctx *cli.Context) {
+	fmt.Printf("instance: Geth/%s/%s/%s\n", verString, runtime.Version(), runtime.GOOS)
 	node := utils.MakeSystemNode(clientIdentifier, verString, relConfig, makeDefaultExtra(), ctx)
 	startNode(ctx, node)
 	node.Wait()


### PR DESCRIPTION
For feature request #2609 - print version on geth start to help development / debugging when using different geth instances.