### PR TITLE
core/state: return the starting nonce for non-existent accs (testnet)

### DIFF
--- a/core/state/statedb.go
+++ b/core/state/statedb.go
@@ -127,7 +127,7 @@ func (self *StateDB) GetNonce(addr common.Address) uint64 {
 		return stateObject.nonce
 	}
 
-	return 0
+	return StartingNonce
 }
 
 func (self *StateDB) GetCode(addr common.Address) []byte {


### PR DESCRIPTION
On the testnet, if requesting the current nonce (`statedb.GetNonce`) of a non existent account (i.e. one that hasn't even received any funds), the current code returns zero. It should return 2^20 instead (i.e. `StartingNonce`). Without this, the API also returns zero for such accounts.

Note, this isn't actually an issue in everyday use because a non existent account does not have any funds to operate with, but the moment a new account is created into the statedb, the correct testnet nonce is actually set (https://github.com/ethereum/go-ethereum/blob/master/core/state/statedb.go#L271), so the first valid tx attempt will go through just fine.