### PR TITLE
eth/downloader: adaptive quality of service tuning

### DIFF
--- a/eth/downloader/peer.go
+++ b/eth/downloader/peer.go
@@ -23,6 +23,8 @@ import (
 	"errors"
 	"fmt"
 	"math"
+	"sort"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -31,8 +33,8 @@ import (
 )
 
 const (
-	maxLackingHashes = 4096 // Maximum number of entries allowed on the list or lacking items
-	throughputImpact = 0.1  // The impact a single measurement has on a peer's final throughput value.
+	maxLackingHashes  = 4096 // Maximum number of entries allowed on the list or lacking items
+	measurementImpact = 0.1  // The impact a single measurement has on a peer's final throughput value.
 )
 
 // Hash and block fetchers belonging to eth/61 and below
@@ -67,6 +69,8 @@ type peer struct {
 	blockThroughput   float64 // Number of blocks (bodies) measured to be retrievable per second
 	receiptThroughput float64 // Number of receipts measured to be retrievable per second
 	stateThroughput   float64 // Number of node data pieces measured to be retrievable per second
+
+	rtt time.Duration // Request round trip time to track responsiveness (QoS)
 
 	headerStarted  time.Time // Time instance when the last header fetch was started
 	blockStarted   time.Time // Time instance when the last block (body) fetch was started
@@ -290,44 +294,47 @@ func (p *peer) setIdle(started time.Time, delivered int, throughput *float64, id
 		return
 	}
 	// Otherwise update the throughput with a new measurement
-	measured := float64(delivered) / (float64(time.Since(started)+1) / float64(time.Second)) // +1 (ns) to ensure non-zero divisor
-	*throughput = (1-throughputImpact)*(*throughput) + throughputImpact*measured
+	elapsed := time.Since(started) + 1 // +1 (ns) to ensure non-zero divisor
+	measured := float64(delivered) / (float64(elapsed) / float64(time.Second))
+
+	*throughput = (1-measurementImpact)*(*throughput) + measurementImpact*measured
+	p.rtt = time.Duration((1-measurementImpact)*float64(p.rtt) + measurementImpact*float64(elapsed))
 }
 
 // HeaderCapacity retrieves the peers header download allowance based on its
 // previously discovered throughput.
-func (p *peer) HeaderCapacity() int {
+func (p *peer) HeaderCapacity(targetRTT time.Duration) int {
 	p.lock.RLock()
 	defer p.lock.RUnlock()
 
-	return int(math.Max(1, math.Min(p.headerThroughput*float64(headerTargetRTT)/float64(time.Second), float64(MaxHeaderFetch))))
+	return int(math.Min(1+math.Max(1, p.headerThroughput*float64(targetRTT)/float64(time.Second)), float64(MaxHeaderFetch)))
 }
 
 // BlockCapacity retrieves the peers block download allowance based on its
 // previously discovered throughput.
-func (p *peer) BlockCapacity() int {
+func (p *peer) BlockCapacity(targetRTT time.Duration) int {
 	p.lock.RLock()
 	defer p.lock.RUnlock()
 
-	return int(math.Max(1, math.Min(p.blockThroughput*float64(blockTargetRTT)/float64(time.Second), float64(MaxBlockFetch))))
+	return int(math.Min(1+math.Max(1, p.blockThroughput*float64(targetRTT)/float64(time.Second)), float64(MaxBlockFetch)))
 }
 
 // ReceiptCapacity retrieves the peers receipt download allowance based on its
 // previously discovered throughput.
-func (p *peer) ReceiptCapacity() int {
+func (p *peer) ReceiptCapacity(targetRTT time.Duration) int {
 	p.lock.RLock()
 	defer p.lock.RUnlock()
 
-	return int(math.Max(1, math.Min(p.receiptThroughput*float64(receiptTargetRTT)/float64(time.Second), float64(MaxReceiptFetch))))
+	return int(math.Min(1+math.Max(1, p.receiptThroughput*float64(targetRTT)/float64(time.Second)), float64(MaxReceiptFetch)))
 }
 
 // NodeDataCapacity retrieves the peers state download allowance based on its
 // previously discovered throughput.
-func (p *peer) NodeDataCapacity() int {
+func (p *peer) NodeDataCapacity(targetRTT time.Duration) int {
 	p.lock.RLock()
 	defer p.lock.RUnlock()
 
-	return int(math.Max(1, math.Min(p.stateThroughput*float64(stateTargetRTT)/float64(time.Second), float64(MaxStateFetch))))
+	return int(math.Min(1+math.Max(1, p.stateThroughput*float64(targetRTT)/float64(time.Second)), float64(MaxStateFetch)))
 }
 
 // MarkLacking appends a new entity to the set of items (blocks, receipts, states)
@@ -361,13 +368,14 @@ func (p *peer) String() string {
 	p.lock.RLock()
 	defer p.lock.RUnlock()
 
-	return fmt.Sprintf("Peer %s [%s]", p.id,
-		fmt.Sprintf("headers %3.2f/s, ", p.headerThroughput)+
-			fmt.Sprintf("blocks %3.2f/s, ", p.blockThroughput)+
-			fmt.Sprintf("receipts %3.2f/s, ", p.receiptThroughput)+
-			fmt.Sprintf("states %3.2f/s, ", p.stateThroughput)+
-			fmt.Sprintf("lacking %4d", len(p.lacking)),
-	)
+	return fmt.Sprintf("Peer %s [%s]", p.id, strings.Join([]string{
+		fmt.Sprintf("hs %3.2f/s", p.headerThroughput),
+		fmt.Sprintf("bs %3.2f/s", p.blockThroughput),
+		fmt.Sprintf("rs %3.2f/s", p.receiptThroughput),
+		fmt.Sprintf("ss %3.2f/s", p.stateThroughput),
+		fmt.Sprintf("miss %4d", len(p.lacking)),
+		fmt.Sprintf("rtt %v", p.rtt),
+	}, ", "))
 }
 
 // peerSet represents the collection of active peer participating in the chain
@@ -402,6 +410,10 @@ func (ps *peerSet) Reset() {
 // average of all existing peers, to give it a realistic chance of being used
 // for data retrievals.
 func (ps *peerSet) Register(p *peer) error {
+	// Retrieve the current median RTT as a sane default
+	p.rtt = ps.medianRTT()
+
+	// Register the new peer with some meaningful defaults
 	ps.lock.Lock()
 	defer ps.lock.Unlock()
 
@@ -563,4 +575,35 @@ func (ps *peerSet) idlePeers(minProtocol, maxProtocol int, idleCheck func(*peer)
 		}
 	}
 	return idle, total
+}
+
+// medianRTT returns the median RTT of te peerset, considering only the tuning
+// peers if there are more peers available.
+func (ps *peerSet) medianRTT() time.Duration {
+	// Gather all the currnetly measured round trip times
+	ps.lock.RLock()
+	defer ps.lock.RUnlock()
+
+	rtts := make([]float64, 0, len(ps.peers))
+	for _, p := range ps.peers {
+		p.lock.RLock()
+		rtts = append(rtts, float64(p.rtt))
+		p.lock.RUnlock()
+	}
+	sort.Float64s(rtts)
+
+	median := rttMaxEstimate
+	if qosTuningPeers <= len(rtts) {
+		median = time.Duration(rtts[qosTuningPeers/2]) // Median of our tuning peers
+	} else if len(rtts) > 0 {
+		median = time.Duration(rtts[len(rtts)/2]) // Median of our connected peers (maintain even like this some baseline qos)
+	}
+	// Restrict the RTT into some QoS defaults, irrelevant of true RTT
+	if median < rttMinEstimate {
+		median = rttMinEstimate
+	}
+	if median > rttMaxEstimate {
+		median = rttMaxEstimate
+	}
+	return median
 }


### PR DESCRIPTION
Currently Geth is tuned for low latency, high bandwidth network scenarios, which the sync mechanism enforces by dropping peers who do not reply fast enough to data queries. The rationale was that by honing in on faster peers (i.e. geographically closer to us), we can achieve much faster sync times.

Even though we are aggressive in peer selection, the downloader tries to be smart about the queries it issues by estimating the throughput of all connected peers and requesting data in proportion with the time it should take the peer to respond, attempting to stabilize both the network (by not assigning huge tasks that would time out) as well as the data stream (by having all peers respond with the same RTT).

This algorithm can ensure that independent of what quality peers we have, we will have a stable download stream... **as long as we have enough bandwidth to cover all our peers as well as a negligible latency compared to the employed timeouts**. However if I have low bandwidth myself, packet RTTs increase proportionally do the download tasks, which can easily hit the timeout thresholds, causing peers to be dropped. Even worse, if I have a high latency connection (EDGE, satellite), the timeouts will almost immediately drop all peers, making sync impossible.

The fundamental flaw is that our current codebase has fixed values as the target RTT in which peers are expected to respond to queries (1-1.5 seconds) and request TTLs after which peers are dropped (3-4 seconds); but for low bandwidth or high latency connections, these are just too low to work out. Simply raising these would allow users with bad connectivity to sync, but would at the same time slow down sync for good connectivity users to the speed of their weakest peer, which would be a bottleneck for the entire algorithm. Instead, this PR attempts to dynamically adapt the target RTT and request TTL values in such a way that we can still hone in on good peers, but do that based on our active peer set and not a blind baseline expected performance.

*Note, hard RTT and TTL values were needed prior to concurrent headers because the master peer which we used to pull headers from was already a bottleneck and we couldn't afford to stall sync with arbitrary performance. With concurrent headers, even if the master peer is slow-ish we can still sync fast, so we can me much more lax with regard to RTT and TTL.*

### Tuning peers

To dynamically adapt the RTT and TTL values, we need to make various measurements on our peers' performance and aggregate them into these thresholds. However if we have a lot of peers (e.g. 10, 25, 100), some of them will be high quality peers, and some will be low quality ones. Aggregating all of them would result in too lax RTT/TTL values, delaying sync due to unnecessary bottlenecks.

Instead of adapting to all connected peers, we would like to hone in on our true performance, and keep only peers that are reasonably close performance wise. To do this, we will tune the parameters based only on our best N peers. Those upwards from N will be required some threshold of performance from our best peers, or else be dropped during sync. This algorithm ensures that although we adapt our RTT/TTL values to our peers and network connectivity, we still saturate our own connection and not introduce bottlenecks. If a better peer joins, it will automatically result in tighter thresholds, whereas if a top peer drops off, the threshold will be automatically relaxed.

The PR chosses `N = 5`. The rationale is that by default geth has `--maxpeers=25`, however only half of that is reserved for outbound connections, so with a NATed/firewalled system, peer count is capped at around 12. With `N == 5` we retain enough peers to do meaningful tuning, but also leave enough slots for bad peers to die off and leave room for better ones. Lastly, it's important to mention that the [BitTorrent protocol](http://www.bittorrent.org/beps/bep_0003.html) also uses 4 (stable) + 1 (optimistic) peers for downloading data at any given time, as higher values cause suboptimal TCP congestion control. Although BitTorrent furthers this logic by choking the remaining peers, it's a complexity we need to decide whether to introduce or not (@fjl suggested we do, maybe in a followup PR we can do an N-tuning M-optimistic K-spare peers split).

### RTT vs. TTL

As discussed, sync performance depends on tuning two parameters of the downloader: the target round trip time (RTT) that ensures we have a stable stream of data to process; and the request time to live (TTL) which ensures some baseline quality of peers. Thinking about it though, the two values are somewhat related: if we can sustain a stable RTT over multiple peers, then we can set TTL to be a constant multiple `c` of this RTT value. As long as RTT doesn't fibrillate, `TTL = c * RTT` is a good filter to weed out under performing peers.

Fibrillation however can be an issue, especially during the beginning of sync. If we have only a couple peers (e.g. 2) that we tuned the RTT to, and suddenly experience a surge in connections (e.g. 4 new ones), then limited bandwidth availability would cause actual round trip times to grow proportionally to the additional download requests (not giving an opportunity for our estimated RTT (and hence related TTL) to adapt fast enough). Hitting the TTL limit would result in both new as well as potentially old, perfectly good peers being dropped. Reducing peer count would drive down the RTT, and reconnecting peers would fibrillate it back up.

The moral of the story is, that `TTL = c * RTT` only makes sense, if the estimated RTT is relatively stable and approximates the true RTT closely enough. As we cannot guarantee RTT stability during peer joins, we introduce a *confidence* factor into our estimation. The more peers join (proportionally to our existing ones), the less confident we can be in our estimated RTT value; and the less confident we are, the higher TTL threshold needs to be allowed to cater for splitting our bandwidth among more peers.

Aggregating the above rational, we can set `TTL = c * RTT / conf`, where `conf ∈ (0, 1]`. If we assume a stable RTT (i.e. `conf == 1`), we can pick a meaningful number for the `c` scaling factor. It's really arbitrary, but `c = 3` gives enough wiggle room for occasional hiccups but is not lax enough to hinder performance too much. As for the confidence multiplier, the only idea we can use is that limited bandwidth is split between peers, so more peers **could (not would)** result in proportionally larger RTTs. Whenever a peer joins, we reduce `conf` proportionally to cater for bandwidth splits: `conf = conf * (1 - 1/(peers+1)) = conf * peers / (peers + 1)`.

E.g. if we had a stable RTT (`conf == 1`) with 2 peers, adding new peers would:

 * +1 peer => `conf = 1 * 2 / 3 = 2/3`
 * +1 peer => `conf = 2/3 * 3 / 4 = 2/4`
 * +1 peer => `conf = 2/4 * 4 / 5 = 2/5`

Per the above, the confidence factor correctly follows the number of joining peers, even when processed one by one (+1+1+1 results in the expected value that +3 would produce). Note, we'll cap the minimum of the confidence factor to `0.1` to prevent too wild TTL values. The confidence factor is increased towards `1` after every RTT.

### Adaptive RTT

Based on the above discussion, if we can estimate a reasonable target round-trip time and can keep it relatively up to date with peers' capacities but at the same time stable as peers join/leave and requests come/go, we can derive a good enough TTL value. The remaining challenge is how to select a good RTT to target for requests. The requirements are that it should be high enough to allow a meaningful batch of data to be retrieved, but low enough so that import can progress without stuttering too much.

We will start out with the maximum allowed RTT value if we have no connections (PR sets it to 20s). This ensures that irrelevant of our local connectivity, we can do some meaningful communication. 

Further, for each peer we will maintain a **very rough** RTT value (initially these are maxed too), which we'll update whenever the said peer responds to one of our data requests (weighed update). Note, this RTT will vary a ton based on our network saturation, the peers network saturation, latencies, congestion, etc. This is fine, it's just meant as a means to compare the performance of different peers at the current workload (whatever that might be).

Using these constantly changing RTT values, every once in a while (more on this later) we select the N best peers to tune with (as mentioned above, 5 currently) and updated our target RTT to the median performance of these best peers (again, weighed update to smooth hiccups). With the target RTT updated, we can calculate a fresh TTL value too.

### Converging towards the optimum

Adaptive algorithms have a tendency to converge to some stable state, which may or may not be the optimal solution (depends on the exact scenario). In our case if we have a single peer, two stable scenarios could be: a) download 256 headers in 2 seconds; and b) download 128 headers in 1 second. Both are perfectly valid in the long run, but as block processing is a streaming operation, and there are a lot of steps to go through, it is usually more advisable to prefer shorter cycles over longer ones. To this extent, we need to force the algorithm out of sub-optimal stable points.

One such scenario is the selection of a stable, but larger RTT (e.g. 5 sec vs. 2 sec). Having a larger than essential RTT means that streaming the blockchain is more bursty and less flowing; but it also means that we could end up keeping weaker peers that ould have been weeded out by the small RTT. As long as the smaller RTT is equally stable, performance wise it will always be preferable. To prevent locking in to a higher than needed RTT, whenever we fetch some data, we will not use our estimated best RTT, but rather only 90% of it. If the smaller RTT was a bad guess (e.g. our latency is the culprit), we'll just estimate the original RTT the next time too and remain unchanged. However if our guessed RTT turns out to be valid, we just shaved off a bit of your sync time. Repeating this will converge on the minimum RTT that is stable for our actual workload.

The second interesting scenario is during throughput estimation. The downloader tries to (did this since forever) estimate how many blocks, receipts, states, etc a peer can give us in a given amount of time, and use that to scale the size of data retrievals to the target RTT. This works well in low latency environments (e.g. 10 blocks 1 sec => 20 blocks 2 secs), but it performs poorly if latency comes into play (e.g. with a 250ms latency, 10 blocks 1 sec => 20 blocks 1.5sec). In high latency environments, the algorithm will constantly under-estimate the true throughput and retrieve less, wasting time because of the latency, not because of actual throughput. To solve this, the PR makes a very subtle change to the calculation of download task sizes. Instead of using `RTT / throughput`, we will actually request `+1` data item than what the correct estimate is. If the limiting factor was bandwidth, we'll get back the original throughput and be done with it. If however the limiting factor was latency, we'll get the same RTT, but at a much higher throughput.
