### PR TITLE
eth/downloader: ensure cancel channel is closed post sync

### DIFF
--- a/eth/downloader/downloader.go
+++ b/eth/downloader/downloader.go
@@ -332,6 +332,8 @@ func (d *Downloader) synchronise(id string, hash common.Hash, td *big.Int, mode 
 	d.cancelCh = make(chan struct{})
 	d.cancelLock.Unlock()
 
+	defer d.cancel() // No matter what, we can't leave the cancel channel open
+
 	// Set the requested sync mode, unless it's forbidden
 	d.mode = mode
 	if d.mode == FastSync && d.noFast {


### PR DESCRIPTION
This PR fixes an issue in the downloader that could block up peers after transitioning to the fetcher.

The downloader implemented sync cancellation via a single cancel channel, which was initialized before starting sync and closed when sync completed (either successfully, or failed). However, after introducing this orchestration mechanism, the downloader evolved to make a few meta-queries (e.g. ancestor lookup, height lookup, etc). These queries were made after creating the cancel channel, but before starting the sync itself, so if either of these failed, the downloader bailed out, leaving the cancel channel dangling.

The cancel channel remaining live meant that any peer who was delivering some data packets got blocked in the delivery routine until either the cancel is really closed (never with this failure), or until the delivery is actually read by the downloader. Usually the downloader would start a sync cycle soon after the previous failed and gather any pending leftovers. If however the fetcher got activated after this failure and took over propagation based sync, the downloader will not be invoked again, causing those blocked peers to remain there indefinitely.

This PR addresses the issue by adding a `defer.cancel()` to the downloader right after creating a new cancel channel, which would ensure that no matter on what code path the sync terminates, the cancel channel is properly closed and will not block pending or future arriving packets.

*Note, we still need to retain our existing cancellation paths as they are responsible for aborting the various fetches if either of them fails (after which they wait for each other to finish), so this defer is not a replacement for the graceful cleanup of the goroutines, but rather a catch-all statement for the pre-sync meta-queries and/or other possible error paths.*