### PR TITLE
node: Make IPC endpoint more generic

### DIFF
--- a/cmd/geth/consolecmd_test.go
+++ b/cmd/geth/consolecmd_test.go
@@ -59,6 +59,7 @@ Welcome to the Geth JavaScript console!
 
 instance: Geth/v{{gethver}}/{{goos}}/{{gover}}
 coinbase: {{.Etherbase}}
+ network: mainnet
 at block: 0 ({{niltime}})
  datadir: {{.Datadir}}
  modules:{{range apis}} {{.}}:1.0{{end}}
@@ -153,6 +154,7 @@ Welcome to the Geth JavaScript console!
 
 instance: Geth/v{{gethver}}/{{goos}}/{{gover}}
 coinbase: {{etherbase}}
+ network: mainnet
 at block: 0 ({{niltime}}){{if ipc}}
  datadir: {{datadir}}{{end}}
  modules:{{range apis}} {{.}}:1.0{{end}}

--- a/cmd/gethrpctest/main.go
+++ b/cmd/gethrpctest/main.go
@@ -95,7 +95,7 @@ func main() {
 func MakeSystemNode(keydir string, privkey string, test *tests.BlockTest) (*node.Node, error) {
 	// Create a networkless protocol stack
 	stack, err := node.New(&node.Config{
-		IPCPath:     node.DefaultIPCEndpoint(),
+		IPCPath:     []string{node.DefaultIPCEndpoint()},
 		HTTPHost:    common.DefaultHTTPHost,
 		HTTPPort:    common.DefaultHTTPPort,
 		HTTPModules: []string{"admin", "db", "eth", "debug", "miner", "net", "shh", "txpool", "personal", "web3"},

--- a/cmd/utils/client.go
+++ b/cmd/utils/client.go
@@ -18,6 +18,7 @@ package utils
 
 import (
 	"fmt"
+	"runtime"
 	"strings"
 
 	"github.com/codegangsta/cli"
@@ -40,6 +41,11 @@ func NewRemoteRPCClient(ctx *cli.Context) (rpc.Client, error) {
 // endpoint. It must start with either `ipc:` or `rpc:` (HTTP).
 func NewRemoteRPCClientFromString(endpoint string) (rpc.Client, error) {
 	if strings.HasPrefix(endpoint, "ipc:") {
+		if runtime.GOOS == "windows" && !strings.HasPrefix(endpoint, `ipc:\\.\pipe\`) {
+			// user supplied named pipe name, e.g: attach "namedpipename" instead
+			// of "attach ipc:\\.\pipe\namedpipename".
+			endpoint = `ipc:\\.\pipe\` + endpoint[4:]
+		}
 		return rpc.NewIPCClient(endpoint[4:])
 	}
 	if strings.HasPrefix(endpoint, "rpc:") {

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -271,8 +271,8 @@ var (
 	}
 	IPCPathFlag = DirectoryFlag{
 		Name:  "ipcpath",
-		Usage: "Filename for IPC socket/pipe within the datadir (explicit paths escape it)",
-		Value: DirectoryString{common.DefaultIPCSocket},
+		Usage: "IPC endpoint location (explicit paths escape it)",
+		Value: DirectoryString{common.DefaultIPCEndpoint()},
 	}
 	WSEnabledFlag = cli.BoolFlag{
 		Name:  "ws",
@@ -418,13 +418,27 @@ func MakeKeyStoreDir(datadir string, ctx *cli.Context) string {
 	return filepath.Join(datadir, "keystore")
 }
 
-// MakeIPCPath creates an IPC path configuration from the set command line flags,
-// returning an empty string if IPC was explicitly disabled, or the set path.
-func MakeIPCPath(ctx *cli.Context) string {
+// MakeIPCPaths creates an IPC path configuration from the set command line flags,
+// returning an empty slice if IPC was explicitly disabled, or the paths to open
+// the IPC endpoint(s).
+func MakeIPCPaths(ctx *cli.Context) []string {
 	if ctx.GlobalBool(IPCDisabledFlag.Name) {
-		return ""
+		return []string{}
 	}
-	return ctx.GlobalString(IPCPathFlag.Name)
+
+	// user overruled default location
+	if ctx.GlobalIsSet(IPCPathFlag.Name) {
+		return []string{ctx.GlobalString(IPCPathFlag.Name)}
+	}
+
+	// return the old geth specific path and new more general default path.
+	// This is a temporary situation, the old path will be removed after a couple
+	// of weeks. This gives clients time to update and users the ability to use
+	// the latest geth version with default IPC setting as they are used to.
+	if runtime.GOOS == "windows" {
+		return []string{`\\.\pipe\geth.ipc`, ctx.GlobalString(IPCPathFlag.Name)}
+	}
+	return []string{"geth.ipc", ctx.GlobalString(IPCPathFlag.Name)}
 }
 
 // MakeNodeKey creates a node key from set command line flags, either loading it
@@ -664,7 +678,7 @@ func MakeSystemNode(name, version string, relconf release.Config, extra []byte, 
 		NAT:             MakeNAT(ctx),
 		MaxPeers:        ctx.GlobalInt(MaxPeersFlag.Name),
 		MaxPendingPeers: ctx.GlobalInt(MaxPendingPeersFlag.Name),
-		IPCPath:         MakeIPCPath(ctx),
+		IPCPath:         MakeIPCPaths(ctx),
 		HTTPHost:        MakeHTTPRpcHost(ctx),
 		HTTPPort:        ctx.GlobalInt(RPCPortFlag.Name),
 		HTTPCors:        ctx.GlobalString(RPCCORSDomainFlag.Name),

--- a/console/console.go
+++ b/console/console.go
@@ -247,8 +247,17 @@ func (c *Console) Welcome() {
 	// Print some generic Geth metadata
 	fmt.Fprintf(c.printer, "Welcome to the Geth JavaScript console!\n\n")
 	c.jsre.Run(`
+		var _network = 'private';
+		switch (eth.getBlock(0).hash.toLowerCase()) {
+		case '0xd4e56740f876aef8c010b86a40d5f56745a118d0906a34e69aec8c0db1cb8fa3':
+			_network = 'mainnet'; break
+		case '0x0cd786a2425d16f152c658316c423e6ce1181e15c3295826d7c9904cba9ce303':
+			_network = 'testnet'; break
+		}
+
 		console.log("instance: " + web3.version.node);
 		console.log("coinbase: " + eth.coinbase);
+		console.log(" network: " + _network);
 		console.log("at block: " + eth.blockNumber + " (" + new Date(1000 * eth.getBlock(eth.blockNumber).timestamp) + ")");
 		console.log(" datadir: " + admin.datadir);
 	`)

--- a/node/config_test.go
+++ b/node/config_test.go
@@ -85,7 +85,7 @@ func TestIPCPathResolution(t *testing.T) {
 	for i, test := range tests {
 		// Only run when platform/test match
 		if (runtime.GOOS == "windows") == test.Windows {
-			if endpoint := (&Config{DataDir: test.DataDir, IPCPath: test.IPCPath}).IPCEndpoint(); endpoint != test.Endpoint {
+			if endpoint := (&Config{DataDir: test.DataDir, IPCPath: []string{test.IPCPath}}).IPCEndpoints()[0]; endpoint != test.Endpoint {
 				t.Errorf("test %d: IPC endpoint mismatch: have %s, want %s", i, endpoint, test.Endpoint)
 			}
 		}


### PR DESCRIPTION
The current version of geth uses `geth.ipc` as IPC endpoint which makes it not very suitable for other clients to use. Also since version 1.4 geth places the IPC endpoint on Linux and OSX in the datadir where geth 1.3 would place it by default in the datadir of the mainnet. This causes the endpoint location to change when geth is started with the testnet flag.

This PR introduces a new name and location for the endpoint. The name has been changed from `geth.ipc` to `ipc.sock` on OSX and Linux. On Windows from `\\.\pipe\geth.ipc` to `\\.\pipe\ethereum`.

The default location for the unix socket endpoints are:
- on OSX `$HOME/Library/Ethereum/ipc.sock`.
- on Linux, if `$ENV{XDG_RUNTIME_DIR}` is defined/not empty and the "ethereum" subdirectory can be created the unix socket listener is created on `$XDG_RUNTIME_DIR/ethereum/ipc.sock`. Otherwise the listener is created in `$HOME/.ethereum/ipc.sock`.

Users can always overrule the default ipc endpoint with the `--ipcpath` flag.

This means regardless of the datadir the default IPC endpoint is always opened in a standardized location where clients can look for it. To give clients time to update geth will temporary open 2 IPC endpoints, the old location and the new location. This makes geth backwards compatible. The old endpoint will be removed in a future version.

Since geth opens the IPC endpoint in a default location regardless of the network the console prints the network as banner.
```
instance: Geth/v1.5.0-unstable-62eafe41/linux/go1.6.2
coinbase: 0x391694e7e0b0cce554cb130d723a9d27458f9298
at block: 1611447 (Mon, 30 May 2016 11:48:51 CEST)
 network: mainnet
 datadir: /home/bas/.ethereum
```