### PR TITLE
eth: don't accept transactions until we sync up with the network

### DIFF
--- a/eth/protocol_test.go
+++ b/eth/protocol_test.go
@@ -97,6 +97,7 @@ func TestRecvTransactions63(t *testing.T) { testRecvTransactions(t, 63) }
 func testRecvTransactions(t *testing.T, protocol int) {
 	txAdded := make(chan []*types.Transaction)
 	pm := newTestProtocolManagerMust(t, false, 0, nil, txAdded)
+	pm.synced = 1 // mark synced to accept transactions
 	p, _ := newTestPeer("peer", protocol, pm, true)
 	defer pm.Stop()
 	defer p.close()

--- a/eth/sync.go
+++ b/eth/sync.go
@@ -174,6 +174,8 @@ func (pm *ProtocolManager) synchronise(peer *peer) {
 	if err := pm.downloader.Synchronise(peer.id, peer.Head(), peer.Td(), mode); err != nil {
 		return
 	}
+	atomic.StoreUint32(&pm.synced, 1) // Mark initial sync done
+
 	// If fast sync was enabled, and we synced up, disable it
 	if atomic.LoadUint32(&pm.fastSync) == 1 {
 		// Disable fast sync if we indeed have something in our chain


### PR DESCRIPTION
When booting the node, we're most probably out of sync. There's no point in gathering and processing transactions at this point in time, as it could take a considerable amount of time to sync up, and shuffling transactions between every block is a wasted resource either way. This PR introduces a mechanism to discard inbound transactions until either the downloader reports a successful sync cycle, or until the fetcher schedules something for us. This should ensure that newly started nodes don't waste time processing transactions against a stale chain.

Further all the accumulates transactions are propagated to all newly joining peers, which additionally puts a large strain on the network and downloader, which needs to play nice with an already saturated connection.

---

Just for the reference, by the time a sync reaches 700K blocks, it accumulates currently about 7K pending transactions and 9K queued ones, each of which requires revalidation after every block and/or import batch.