### PR TITLE
cmd/geth: don't defer a jsre close, it cannot handle it

### DIFF
--- a/cmd/geth/consolecmd.go
+++ b/cmd/geth/consolecmd.go
@@ -147,8 +147,6 @@ func ephemeralConsole(ctx *cli.Context) {
 	if err != nil {
 		utils.Fatalf("Failed to start the JavaScript console: %v", err)
 	}
-	defer console.Stop(false)
-
 	// Evaluate each of the specified JavaScript files
 	for _, file := range ctx.Args() {
 		if err = console.Execute(file); err != nil {
@@ -161,7 +159,7 @@ func ephemeralConsole(ctx *cli.Context) {
 
 	go func() {
 		<-abort
-		os.Exit(0)
+		console.Stop(false)
 	}()
 	console.Stop(true)
 }


### PR DESCRIPTION
Our internal `jsre` object cannot handle double closes (hangs), so we cannot use defer. Instead use a less elegant solution.