### PR TITLE
Negative numbers not properly converted in ABI encoding

### DIFF
--- a/accounts/abi/numbers.go
+++ b/accounts/abi/numbers.go
@@ -96,7 +96,7 @@ func packNum(value reflect.Value, to byte) []byte {
 			return S2S256(int64(value.Uint()))
 		}
 	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
-		if to == UintTy {
+		if to == IntTy {
 			return U2U256(uint64(value.Int()))
 		} else {
 			return S2S256(value.Int())


### PR DESCRIPTION
When converting a negative number e.g., -2, the resulting ABI
encoding should look as follows:

fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe

However, since the check of the type is for an uint instead of an int,
it results in the following ABI encoding:

0101010101010101010101010101010101010101010101010101010101010102