### PR TITLE
cmd/geth: make console tests more robust

### DIFF
--- a/console/console.go
+++ b/console/console.go
@@ -244,15 +244,13 @@ func (c *Console) AutoCompleteInput(line string, pos int) (string, []string, str
 // console's available modules.
 func (c *Console) Welcome() {
 	// Print some generic Geth metadata
+	fmt.Fprintf(c.printer, "Welcome to the Geth JavaScript console!\n\n")
 	c.jsre.Run(`
-    (function () {
-			console.log("Welcome to the Geth JavaScript console!\n");
-      console.log("instance: " + web3.version.node);
-      console.log("coinbase: " + eth.coinbase);
-      console.log("at block: " + eth.blockNumber + " (" + new Date(1000 * eth.getBlock(eth.blockNumber).timestamp) + ")");
-      console.log(" datadir: " + admin.datadir);
-    })();
-  `)
+		console.log("instance: " + web3.version.node);
+		console.log("coinbase: " + eth.coinbase);
+		console.log("at block: " + eth.blockNumber + " (" + new Date(1000 * eth.getBlock(eth.blockNumber).timestamp) + ")");
+		console.log(" datadir: " + admin.datadir);
+	`)
 	// List all the supported modules for the user to call
 	if apis, err := c.client.SupportedModules(); err == nil {
 		modules := make([]string, 0, len(apis))
@@ -260,9 +258,9 @@ func (c *Console) Welcome() {
 			modules = append(modules, fmt.Sprintf("%s:%s", api, version))
 		}
 		sort.Strings(modules)
-		c.jsre.Run("(function () { console.log(' modules: " + strings.Join(modules, " ") + "'); })();")
+		fmt.Fprintln(c.printer, " modules:", strings.Join(modules, " "))
 	}
-	c.jsre.Run("(function () { console.log(); })();")
+	fmt.Fprintln(c.printer)
 }
 
 // Evaluate executes code and pretty prints the result to the specified output


### PR DESCRIPTION
This PR fixes some regressions introduced by #2535.
Please review: @karalabe 

Included in 1.4.6 milestone because it also fixes a hang in the `geth js` command 
(first commit, see #2651 for details).