### PR TITLE
console: fix windows console colors

### DIFF
--- a/console/console.go
+++ b/console/console.go
@@ -30,6 +30,7 @@ import (
 	"github.com/ethereum/go-ethereum/internal/jsre"
 	"github.com/ethereum/go-ethereum/internal/web3ext"
 	"github.com/ethereum/go-ethereum/rpc"
+	"github.com/mattn/go-colorable"
 	"github.com/peterh/liner"
 	"github.com/robertkrimen/otto"
 )
@@ -80,7 +81,7 @@ func New(config Config) (*Console, error) {
 		config.Prompt = DefaultPrompt
 	}
 	if config.Printer == nil {
-		config.Printer = os.Stdout
+		config.Printer = colorable.NewColorableStdout()
 	}
 	// Initialize the console and return
 	console := &Console{


### PR DESCRIPTION
The [github.com/fatih/color](https://github.com/fatih/color) we use to colorize the console output added Windows support in a weird way, colorizing for Linux and then converting the colors on the fly to Windows before writing it to stdout. However since the console PR rewrote stdin/stdout handling, the color package never got around to actually transform it's Linux colors to Windows, breaking for Windows users. This PR essentially does this missing step of wrapping the output stream with a linux->windows color converter manually by the console.

Fixes https://github.com/ethereum/go-ethereum/issues/2668.