### PR TITLE
Ignore round and curly brackets in strings for indentation level

### DIFF
--- a/console/console_test.go
+++ b/console/console_test.go
@@ -294,3 +294,49 @@ func TestPrettyError(t *testing.T) {
 		t.Fatalf("pretty error mismatch: have %s, want %s", output, want)
 	}
 }
+
+// Tests that tests if the number of indents for JS input is calculated correct.
+func TestIndenting(t *testing.T) {
+	testCases := []struct {
+		input               string
+		expectedIndentCount int
+	}{
+		{`var a = 1;`, 0},
+		{`"some string"`, 0},
+		{`"some string with (parentesis`, 0},
+		{`"some string with newline
+		("`, 0},
+		{`function v(a,b) {}`, 0},
+		{`function f(a,b) { var str = "asd("; };`, 0},
+		{`function f(a) {`, 1},
+		{`function f(a, function(b) {`, 2},
+		{`function f(a, function(b) {
+		     var str = "a)}";
+		  });`, 0},
+		{`function f(a,b) {
+		   var str = "a{b(" + a, ", " + b;
+		   }`, 0},
+		{`var str = "\"{"`, 0},
+		{`var str = "'("`, 0},
+		{`var str = "\\{"`, 0},
+		{`var str = "\\\\{"`, 0},
+		{`var str = 'a"{`, 0},
+		{`var obj = {`, 1},
+		{`var obj = { {a:1`, 2},
+		{`var obj = { {a:1}`, 1},
+		{`var obj = { {a:1}, b:2}`, 0},
+		{`var obj = {}`, 0},
+		{`var obj = {
+			a: 1, b: 2
+		}`, 0},
+		{`var test = }`, -1},
+		{`var str = "a\""; var obj = {`, 1},
+	}
+
+	for i, tt := range testCases {
+		counted := countIndents(tt.input)
+		if counted != tt.expectedIndentCount {
+			t.Errorf("test %d: invalid indenting: have %d, want %d", i, counted, tt.expectedIndentCount)
+		}
+	}
+}


### PR DESCRIPTION
This PR will count the number of open round and curly brackets to determine the indentation level.
It ignores brackets that are part of a string.

fixes: #2443

@karalabe PTAL