### PR TITLE
cmd/geth: truly randomize console test RPC endpoints

### DIFF
--- a/cmd/geth/consolecmd_test.go
+++ b/cmd/geth/consolecmd_test.go
@@ -17,7 +17,8 @@
 package main
 
 import (
-	"math/rand"
+	"crypto/rand"
+	"math/big"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -73,7 +74,7 @@ func TestIPCAttachWelcome(t *testing.T) {
 	coinbase := "0x8605cdbbdb6d264aa742e77020dcbc58fcdce182"
 	var ipc string
 	if runtime.GOOS == "windows" {
-		ipc = `\\.\pipe\geth` + strconv.Itoa(rand.Int())
+		ipc = `\\.\pipe\geth` + strconv.Itoa(trulyRandInt(100000, 999999))
 	} else {
 		ws := tmpdir(t)
 		defer os.RemoveAll(ws)
@@ -94,7 +95,7 @@ func TestIPCAttachWelcome(t *testing.T) {
 
 func TestHTTPAttachWelcome(t *testing.T) {
 	coinbase := "0x8605cdbbdb6d264aa742e77020dcbc58fcdce182"
-	port := strconv.Itoa(rand.Intn(65535-1024) + 1024) // Yeah, sometimes this will fail, sorry :P
+	port := strconv.Itoa(trulyRandInt(1024, 65536)) // Yeah, sometimes this will fail, sorry :P
 	geth := runGeth(t,
 		"--port", "0", "--maxpeers", "0", "--nodiscover", "--nat", "none",
 		"--etherbase", coinbase, "--rpc", "--rpcport", port)
@@ -108,7 +109,7 @@ func TestHTTPAttachWelcome(t *testing.T) {
 
 func TestWSAttachWelcome(t *testing.T) {
 	coinbase := "0x8605cdbbdb6d264aa742e77020dcbc58fcdce182"
-	port := strconv.Itoa(rand.Intn(65535-1024) + 1024) // Yeah, sometimes this will fail, sorry :P
+	port := strconv.Itoa(trulyRandInt(1024, 65536)) // Yeah, sometimes this will fail, sorry :P
 
 	geth := runGeth(t,
 		"--port", "0", "--maxpeers", "0", "--nodiscover", "--nat", "none",
@@ -159,4 +160,11 @@ at block: 0 ({{niltime}}){{if ipc}}
 > {{.InputLine "exit" }}
 `)
 	attach.expectExit()
+}
+
+// trulyRandInt generates a crypto random integer used by the console tests to
+// not clash network ports with other tests running cocurrently.
+func trulyRandInt(lo, hi int) int {
+	num, _ := rand.Int(rand.Reader, big.NewInt(int64(hi-lo)))
+	return int(num.Int64()) + lo
 }


### PR DESCRIPTION
Currently it seems that the OSX build and CI servers have some stale tests stuck in the background, hogging a few RPC ports. Although our console tests randomly select RPC ports to open, we don't seed the randomizer in our test suites, causing the same ports to be selected for multiple runs. This results in the new tests clashing with leftovers (and could also cause concurrent test suite runs clashing with each other):

 * https://builds.ethereum.org/builders/OSX%20Go%20pull%20requests/builds/3685/steps/go-test/logs/stdio
 * https://builds.ethereum.org/builders/OSX%20Go%20pull%20requests/builds/3684/steps/go-test/logs/stdio

Further this same issue causes the build server to fail the test and hence no homebrew packages:

 * https://builds.ethereum.org/builders/OSX%20Go%20master%20branch/builds/99/steps/go-test/logs/stdio

To solve this annoyance, this PR uses truly random numbers for RPC and IPC endpoints, ensuring no clash even if multiple test suits run concurrently or of there's some leftover junk. It uses `crypto/rand` to avoid seeding the random generator with a different seed for each test (deterministic random number during tests are good).