### PR TITLE
cmd: fix CLI package deprecation warnings

### DIFF
--- a/cmd/ethtest/main.go
+++ b/cmd/ethtest/main.go
@@ -183,7 +183,7 @@ func runSuite(test, file string) {
 	}
 }
 
-func setupApp(c *cli.Context) {
+func setupApp(c *cli.Context) error {
 	flagTest := c.GlobalString(TestFlag.Name)
 	flagFile := c.GlobalString(FileFlag.Name)
 	continueOnError = c.GlobalBool(ContinueOnErrorFlag.Name)
@@ -196,8 +196,8 @@ func setupApp(c *cli.Context) {
 		if err := runTestWithReader(flagTest, os.Stdin); err != nil {
 			glog.Fatalln(err)
 		}
-
 	}
+	return nil
 }
 
 func main() {

--- a/cmd/evm/main.go
+++ b/cmd/evm/main.go
@@ -104,7 +104,7 @@ func init() {
 	app.Action = run
 }
 
-func run(ctx *cli.Context) {
+func run(ctx *cli.Context) error {
 	glog.SetToStderr(true)
 	glog.SetV(ctx.GlobalInt(VerbosityFlag.Name))
 
@@ -154,6 +154,7 @@ num gc:     %d
 		fmt.Printf(" error: %v", e)
 	}
 	fmt.Println()
+	return nil
 }
 
 func main() {

--- a/cmd/geth/accountcmd.go
+++ b/cmd/geth/accountcmd.go
@@ -167,11 +167,12 @@ nodes.
 	}
 )
 
-func accountList(ctx *cli.Context) {
+func accountList(ctx *cli.Context) error {
 	accman := utils.MakeAccountManager(ctx)
 	for i, acct := range accman.Accounts() {
 		fmt.Printf("Account #%d: {%x} %s\n", i, acct.Address, acct.File)
 	}
+	return nil
 }
 
 // tries unlocking the specified account a few times.
@@ -259,7 +260,7 @@ func ambiguousAddrRecovery(am *accounts.Manager, err *accounts.AmbiguousAddrErro
 }
 
 // accountCreate creates a new account into the keystore defined by the CLI flags.
-func accountCreate(ctx *cli.Context) {
+func accountCreate(ctx *cli.Context) error {
 	accman := utils.MakeAccountManager(ctx)
 	password := getPassPhrase("Your new account is locked with a password. Please give a password. Do not forget this password.", true, 0, utils.MakePasswordList(ctx))
 
@@ -268,11 +269,12 @@ func accountCreate(ctx *cli.Context) {
 		utils.Fatalf("Failed to create account: %v", err)
 	}
 	fmt.Printf("Address: {%x}\n", account.Address)
+	return nil
 }
 
 // accountUpdate transitions an account from a previous format to the current
 // one, also providing the possibility to change the pass-phrase.
-func accountUpdate(ctx *cli.Context) {
+func accountUpdate(ctx *cli.Context) error {
 	if len(ctx.Args()) == 0 {
 		utils.Fatalf("No accounts specified to update")
 	}
@@ -283,9 +285,10 @@ func accountUpdate(ctx *cli.Context) {
 	if err := accman.Update(account, oldPassword, newPassword); err != nil {
 		utils.Fatalf("Could not update the account: %v", err)
 	}
+	return nil
 }
 
-func importWallet(ctx *cli.Context) {
+func importWallet(ctx *cli.Context) error {
 	keyfile := ctx.Args().First()
 	if len(keyfile) == 0 {
 		utils.Fatalf("keyfile must be given as argument")
@@ -303,9 +306,10 @@ func importWallet(ctx *cli.Context) {
 		utils.Fatalf("%v", err)
 	}
 	fmt.Printf("Address: {%x}\n", acct.Address)
+	return nil
 }
 
-func accountImport(ctx *cli.Context) {
+func accountImport(ctx *cli.Context) error {
 	keyfile := ctx.Args().First()
 	if len(keyfile) == 0 {
 		utils.Fatalf("keyfile must be given as argument")
@@ -321,4 +325,5 @@ func accountImport(ctx *cli.Context) {
 		utils.Fatalf("Could not create the account: %v", err)
 	}
 	fmt.Printf("Address: {%x}\n", acct.Address)
+	return nil
 }

--- a/cmd/geth/chaincmd.go
+++ b/cmd/geth/chaincmd.go
@@ -72,7 +72,7 @@ Use "ethereum dump 0" to dump the genesis block.
 	}
 )
 
-func importChain(ctx *cli.Context) {
+func importChain(ctx *cli.Context) error {
 	if len(ctx.Args()) != 1 {
 		utils.Fatalf("This command requires an argument.")
 	}
@@ -84,9 +84,10 @@ func importChain(ctx *cli.Context) {
 		utils.Fatalf("Import error: %v", err)
 	}
 	fmt.Printf("Import done in %v", time.Since(start))
+	return nil
 }
 
-func exportChain(ctx *cli.Context) {
+func exportChain(ctx *cli.Context) error {
 	if len(ctx.Args()) < 1 {
 		utils.Fatalf("This command requires an argument.")
 	}
@@ -114,9 +115,10 @@ func exportChain(ctx *cli.Context) {
 		utils.Fatalf("Export error: %v\n", err)
 	}
 	fmt.Printf("Export done in %v", time.Since(start))
+	return nil
 }
 
-func removeDB(ctx *cli.Context) {
+func removeDB(ctx *cli.Context) error {
 	confirm, err := console.Stdin.PromptConfirm("Remove local database?")
 	if err != nil {
 		utils.Fatalf("%v", err)
@@ -132,9 +134,10 @@ func removeDB(ctx *cli.Context) {
 	} else {
 		fmt.Println("Operation aborted")
 	}
+	return nil
 }
 
-func upgradeDB(ctx *cli.Context) {
+func upgradeDB(ctx *cli.Context) error {
 	glog.Infoln("Upgrading blockchain database")
 
 	chain, chainDb := utils.MakeChain(ctx)
@@ -163,9 +166,10 @@ func upgradeDB(ctx *cli.Context) {
 		os.Remove(exportFile)
 		glog.Infoln("Import finished")
 	}
+	return nil
 }
 
-func dump(ctx *cli.Context) {
+func dump(ctx *cli.Context) error {
 	chain, chainDb := utils.MakeChain(ctx)
 	for _, arg := range ctx.Args() {
 		var block *types.Block
@@ -182,12 +186,12 @@ func dump(ctx *cli.Context) {
 			state, err := state.New(block.Root(), chainDb)
 			if err != nil {
 				utils.Fatalf("could not create new state: %v", err)
-				return
 			}
 			fmt.Printf("%s\n", state.Dump())
 		}
 	}
 	chainDb.Close()
+	return nil
 }
 
 // hashish returns true for strings that look like hashes.

--- a/cmd/geth/consolecmd.go
+++ b/cmd/geth/consolecmd.go
@@ -60,7 +60,7 @@ JavaScript API. See https://github.com/ethereum/go-ethereum/wiki/Javascipt-Conso
 
 // localConsole starts a new geth node, attaching a JavaScript console to it at the
 // same time.
-func localConsole(ctx *cli.Context) {
+func localConsole(ctx *cli.Context) error {
 	// Create and start the node based on the CLI flags
 	node := utils.MakeSystemNode(clientIdentifier, verString, relConfig, makeDefaultExtra(), ctx)
 	startNode(ctx, node)
@@ -86,16 +86,18 @@ func localConsole(ctx *cli.Context) {
 	// If only a short execution was requested, evaluate and return
 	if script := ctx.GlobalString(utils.ExecFlag.Name); script != "" {
 		console.Evaluate(script)
-		return
+		return nil
 	}
 	// Otherwise print the welcome screen and enter interactive mode
 	console.Welcome()
 	console.Interactive()
+
+	return nil
 }
 
 // remoteConsole will connect to a remote geth instance, attaching a JavaScript
 // console to it.
-func remoteConsole(ctx *cli.Context) {
+func remoteConsole(ctx *cli.Context) error {
 	// Attach to a remotely running geth instance and start the JavaScript console
 	client, err := utils.NewRemoteRPCClient(ctx)
 	if err != nil {
@@ -116,17 +118,19 @@ func remoteConsole(ctx *cli.Context) {
 	// If only a short execution was requested, evaluate and return
 	if script := ctx.GlobalString(utils.ExecFlag.Name); script != "" {
 		console.Evaluate(script)
-		return
+		return nil
 	}
 	// Otherwise print the welcome screen and enter interactive mode
 	console.Welcome()
 	console.Interactive()
+
+	return nil
 }
 
 // ephemeralConsole starts a new geth node, attaches an ephemeral JavaScript
 // console to it, and each of the files specified as arguments and tears the
 // everything down.
-func ephemeralConsole(ctx *cli.Context) {
+func ephemeralConsole(ctx *cli.Context) error {
 	// Create and start the node based on the CLI flags
 	node := utils.MakeSystemNode(clientIdentifier, verString, relConfig, makeDefaultExtra(), ctx)
 	startNode(ctx, node)
@@ -164,4 +168,6 @@ func ephemeralConsole(ctx *cli.Context) {
 		os.Exit(0)
 	}()
 	console.Stop(true)
+
+	return nil
 }

--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -271,15 +271,17 @@ func makeDefaultExtra() []byte {
 // geth is the main entry point into the system if no special subcommand is ran.
 // It creates a default node based on the command line arguments and runs it in
 // blocking mode, waiting for it to be shut down.
-func geth(ctx *cli.Context) {
+func geth(ctx *cli.Context) error {
 	node := utils.MakeSystemNode(clientIdentifier, verString, relConfig, makeDefaultExtra(), ctx)
 	startNode(ctx, node)
 	node.Wait()
+
+	return nil
 }
 
 // initGenesis will initialise the given JSON format genesis file and writes it as
 // the zero'd block (i.e. genesis) or will fail hard if it can't succeed.
-func initGenesis(ctx *cli.Context) {
+func initGenesis(ctx *cli.Context) error {
 	genesisPath := ctx.Args().First()
 	if len(genesisPath) == 0 {
 		utils.Fatalf("must supply path to genesis JSON file")
@@ -300,6 +302,7 @@ func initGenesis(ctx *cli.Context) {
 		utils.Fatalf("failed to write genesis block: %v", err)
 	}
 	glog.V(logger.Info).Infof("successfully wrote genesis block and/or chain rule set: %x", block.Hash())
+	return nil
 }
 
 // startNode boots up the system node and all registered protocols, after which
@@ -331,7 +334,7 @@ func startNode(ctx *cli.Context, stack *node.Node) {
 	}
 }
 
-func makedag(ctx *cli.Context) {
+func makedag(ctx *cli.Context) error {
 	args := ctx.Args()
 	wrongArgs := func() {
 		utils.Fatalf(`Usage: geth makedag <block number> <outputdir>`)
@@ -358,13 +361,15 @@ func makedag(ctx *cli.Context) {
 	default:
 		wrongArgs()
 	}
+	return nil
 }
 
-func gpuinfo(ctx *cli.Context) {
+func gpuinfo(ctx *cli.Context) error {
 	eth.PrintOpenCLDevices()
+	return nil
 }
 
-func gpubench(ctx *cli.Context) {
+func gpubench(ctx *cli.Context) error {
 	args := ctx.Args()
 	wrongArgs := func() {
 		utils.Fatalf(`Usage: geth gpubench <gpu number>`)
@@ -381,9 +386,10 @@ func gpubench(ctx *cli.Context) {
 	default:
 		wrongArgs()
 	}
+	return nil
 }
 
-func version(c *cli.Context) {
+func version(c *cli.Context) error {
 	fmt.Println(clientIdentifier)
 	fmt.Println("Version:", verString)
 	fmt.Println("Protocol Versions:", eth.ProtocolVersions)
@@ -392,4 +398,6 @@ func version(c *cli.Context) {
 	fmt.Println("OS:", runtime.GOOS)
 	fmt.Printf("GOPATH=%s\n", os.Getenv("GOPATH"))
 	fmt.Printf("GOROOT=%s\n", runtime.GOROOT())
+
+	return nil
 }

--- a/cmd/geth/monitorcmd.go
+++ b/cmd/geth/monitorcmd.go
@@ -67,7 +67,7 @@ to display multiple metrics simultaneously.
 )
 
 // monitor starts a terminal UI based monitoring tool for the requested metrics.
-func monitor(ctx *cli.Context) {
+func monitor(ctx *cli.Context) error {
 	var (
 		client rpc.Client
 		err    error
@@ -154,6 +154,7 @@ func monitor(ctx *cli.Context) {
 		}
 	}()
 	termui.Loop()
+	return nil
 }
 
 // retrieveMetrics contacts the attached geth node and retrieves the entire set

--- a/cmd/geth/run_test.go
+++ b/cmd/geth/run_test.go
@@ -58,7 +58,10 @@ type testgeth struct {
 func init() {
 	// Run the app if we're the child process for runGeth.
 	if os.Getenv("GETH_TEST_CHILD") != "" {
-		app.RunAndExitOnError()
+		if err := app.Run(os.Args); err != nil {
+			fmt.Fprintln(os.Stderr, err)
+			os.Exit(1)
+		}
 		os.Exit(0)
 	}
 }


### PR DESCRIPTION
This PR fixes two CLI deprecation warnings introduces by upgrading the `cli` package:

 * DEPRECATED Action signature.  Must be `cli.ActionFunc`.  This is an error in the application.  Please contact the distributor of this application if this is not you.  See https://github.com/codegangsta/cli/blob/master/CHANGELOG.md#deprecated-cli-app-action-signature
   * In short, subcommands now need to return an error
 * DEPRECATED cli.App.RunAndExitOnError.  This is an error in the application.  Please contact the distributor of this application if this is not you.  See https://github.com/codegangsta/cli/blob/master/CHANGELOG.md#deprecated-cli-app-runandexitonerror
   * The method is deprecated, exit on error directly.