### PR TITLE
Makefile: support building for the MIPS64 platforms

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 # don't need to bother with make.
 
 .PHONY: geth geth-cross evm all test clean
-.PHONY: geth-linux geth-linux-386 geth-linux-amd64
+.PHONY: geth-linux geth-linux-386 geth-linux-amd64 geth-linux-mips64 geth-linux-mips64le
 .PHONY: geth-linux-arm geth-linux-arm-5 geth-linux-arm-6 geth-linux-arm-7 geth-linux-arm64
 .PHONY: geth-darwin geth-darwin-386 geth-darwin-amd64
 .PHONY: geth-windows geth-windows-386 geth-windows-amd64
@@ -37,7 +37,7 @@ geth-cross: geth-linux geth-darwin geth-windows geth-android geth-ios
 	@echo "Full cross compilation done:"
 	@ls -ld $(GOBIN)/geth-*
 
-geth-linux: geth-linux-386 geth-linux-amd64 geth-linux-arm
+geth-linux: geth-linux-386 geth-linux-amd64 geth-linux-arm geth-linux-mips64 geth-linux-mips64le
 	@echo "Linux cross compilation done:"
 	@ls -ld $(GOBIN)/geth-linux-*
 
@@ -74,6 +74,16 @@ geth-linux-arm64:
 	build/env.sh go run build/ci.go xgo --go=$(GO) --dest=$(GOBIN) --targets=linux/arm64 -v ./cmd/geth
 	@echo "Linux ARM64 cross compilation done:"
 	@ls -ld $(GOBIN)/geth-linux-* | grep arm64
+
+geth-linux-mips64:
+	build/env.sh go run build/ci.go xgo --go=$(GO) --dest=$(GOBIN) --targets=linux/mips64 -v ./cmd/geth
+	@echo "Linux MIPS64 cross compilation done:"
+	@ls -ld $(GOBIN)/geth-linux-* | grep mips64
+
+geth-linux-mips64le:
+	build/env.sh go run build/ci.go xgo --go=$(GO) --dest=$(GOBIN) --targets=linux/mips64le -v ./cmd/geth
+	@echo "Linux MIPS64le cross compilation done:"
+	@ls -ld $(GOBIN)/geth-linux-* | grep mips64le
 
 geth-darwin: geth-darwin-386 geth-darwin-amd64
 	@echo "Darwin cross compilation done:"


### PR DESCRIPTION
Adds cross compilation support for MIPS64 and MIPS64le

Merge **blocked** by:

 * [x] Fix ethash to build on big endian systems https://github.com/ethereum/ethash/pull/85.
 * [x] Vendor in the big endian ethash fix https://github.com/ethereum/go-ethereum/pull/2685.
 * [x] Release of Go 1.7 (due by July 31, 2016) for MIPS support in `xgo-latest`.