### PR TITLE
core/state, eth: Updated suicides objects when tracing transactions

### DIFF
--- a/eth/api.go
+++ b/eth/api.go
@@ -1876,6 +1876,7 @@ func (api *PrivateDebugAPI) TraceTransaction(txHash common.Hash, logger *vm.LogC
 			if err != nil {
 				return nil, fmt.Errorf("mutation failed: %v", err)
 			}
+			stateDb.DeleteSuicides()
 			continue
 		}
 		// Otherwise trace the transaction and return


### PR DESCRIPTION
Consensus rules dictate that objects can only be removed during the
finalisation of the transaction (i.e. after all calls have finished).
Thus calling a suicided contract twice from the same transaction:
A->B(S)->ret(A)->B(S) results in 2 suicides. Calling the suicided
object twice from two transactions: A->B(S), A->B, results in only one
suicide and a call to an empty object.

Our current debug tracing functionality replays all transaction that
were executed prior to the targetted transaction in order to provide
the user with an accurate trace.

As a side effect to calling StateDB.IntermediateRoot it also deletes any
suicides objects. Our tracing code never calls this function because it
isn't interested in the intermediate root. Becasue of this it caused a
bug in the tracing code where transactions that were send to priviously
deleted objects resulted in two suicides rather than one suicide and a
call to an empty object.

Fixes #2542