### PR TITLE
cmd/evm: added --create flag indicating the exec code is to be created

### DIFF
--- a/cmd/evm/main.go
+++ b/cmd/evm/main.go
@@ -84,11 +84,16 @@ var (
 		Name:  "verbosity",
 		Usage: "sets the verbosity level",
 	}
+	CreateFlag = cli.BoolFlag{
+		Name:  "create",
+		Usage: "indicates the action should be create rather than call",
+	}
 )
 
 func init() {
 	app = utils.NewApp("0.2", "the evm command line interface")
 	app.Flags = []cli.Flag{
+		CreateFlag,
 		DebugFlag,
 		VerbosityFlag,
 		ForceJitFlag,
@@ -111,8 +116,6 @@ func run(ctx *cli.Context) error {
 	db, _ := ethdb.NewMemDatabase()
 	statedb, _ := state.New(common.Hash{}, db)
 	sender := statedb.CreateAccount(common.StringToAddress("sender"))
-	receiver := statedb.CreateAccount(common.StringToAddress("receiver"))
-	receiver.SetCode(common.Hex2Bytes(ctx.GlobalString(CodeFlag.Name)))
 
 	vmenv := NewEnv(statedb, common.StringToAddress("evmuser"), common.Big(ctx.GlobalString(ValueFlag.Name)), vm.Config{
 		Debug:     ctx.GlobalBool(DebugFlag.Name),
@@ -121,17 +124,37 @@ func run(ctx *cli.Context) error {
 	})
 
 	tstart := time.Now()
-	ret, e := vmenv.Call(
-		sender,
-		receiver.Address(),
-		common.Hex2Bytes(ctx.GlobalString(InputFlag.Name)),
-		common.Big(ctx.GlobalString(GasFlag.Name)),
-		common.Big(ctx.GlobalString(PriceFlag.Name)),
-		common.Big(ctx.GlobalString(ValueFlag.Name)),
+
+	var (
+		ret []byte
+		err error
 	)
+
+	if ctx.GlobalBool(CreateFlag.Name) {
+		input := append(common.Hex2Bytes(ctx.GlobalString(CodeFlag.Name)), common.Hex2Bytes(ctx.GlobalString(InputFlag.Name))...)
+		ret, _, err = vmenv.Create(
+			sender,
+			input,
+			common.Big(ctx.GlobalString(GasFlag.Name)),
+			common.Big(ctx.GlobalString(PriceFlag.Name)),
+			common.Big(ctx.GlobalString(ValueFlag.Name)),
+		)
+	} else {
+		receiver := statedb.CreateAccount(common.StringToAddress("receiver"))
+		receiver.SetCode(common.Hex2Bytes(ctx.GlobalString(CodeFlag.Name)))
+		ret, err = vmenv.Call(
+			sender,
+			receiver.Address(),
+			common.Hex2Bytes(ctx.GlobalString(InputFlag.Name)),
+			common.Big(ctx.GlobalString(GasFlag.Name)),
+			common.Big(ctx.GlobalString(PriceFlag.Name)),
+			common.Big(ctx.GlobalString(ValueFlag.Name)),
+		)
+	}
 	vmdone := time.Since(tstart)
 
 	if ctx.GlobalBool(DumpFlag.Name) {
+		statedb.Commit()
 		fmt.Println(string(statedb.Dump()))
 	}
 	vm.StdErrFormat(vmenv.StructLogs())
@@ -150,8 +173,8 @@ num gc:     %d
 	}
 
 	fmt.Printf("OUT: 0x%x", ret)
-	if e != nil {
-		fmt.Printf(" error: %v", e)
+	if err != nil {
+		fmt.Printf(" error: %v", err)
 	}
 	fmt.Println()
 	return nil


### PR DESCRIPTION
This fixes an issue if you wanted to test out code deployment rather
than running a piece of code with an argument. This solves it by adding
a --create flag that indicates the Create function should be used rather
than the Call function.

This also adds a statedb.commit call so that the proper state can be
dumped when requested using the --dump flag.