### PR TITLE
whisper: fix message payload

### DIFF
--- a/whisper/api.go
+++ b/whisper/api.go
@@ -178,6 +178,9 @@ func (s *PublicWhisperAPI) Post(args PostArgs) (bool, error) {
 
 	// construct whisper message with transmission options
 	message := NewMessage(common.FromHex(args.Payload))
+	if len(message.Payload) == 0 && len(args.Payload) > 0 {
+		message.Payload = []byte(args.Payload)
+	}
 	options := Options{
 		To:     crypto.ToECDSAPub(common.FromHex(args.To)),
 		TTL:    time.Duration(args.TTL) * time.Second,

--- a/whisper/whisper.go
+++ b/whisper/whisper.go
@@ -302,10 +302,11 @@ func (self *Whisper) open(envelope *Envelope) *Message {
 	// Iterate over the keys and try to decrypt the message
 	for _, key := range self.keys {
 		message, err := envelope.Open(key)
-		if err == nil {
+		switch err {
+		case nil:
 			message.To = &key.PublicKey
 			return message
-		} else if err == ecies.ErrInvalidPublicKey {
+		case ecies.ErrInvalidPublicKey:
 			return message
 		}
 	}


### PR DESCRIPTION
i. Error handling on parsing the incoming messages did not take care of all possible cases, and did not allow returning a non-encrypted messages after erroring-out on an attempted decryption.

ii. The API was not passing message payloads to the backend. As the payloads were missing, the decryption functions returned unexpected errors, that resulted in missing messages.