### PR TITLE
eth/api: rename signAndSendTransaction to sendTransaction

### DIFF
--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -303,10 +303,10 @@ func (s *PrivateAccountAPI) LockAccount(addr common.Address) bool {
 	return s.am.Lock(addr) == nil
 }
 
-// SignAndSendTransaction will create a transaction from the given arguments and
+// SendTransaction will create a transaction from the given arguments and
 // tries to sign it with the key associated with args.To. If the given passwd isn't
 // able to decrypt the key it fails.
-func (s *PrivateAccountAPI) SignAndSendTransaction(ctx context.Context, args SendTxArgs, passwd string) (common.Hash, error) {
+func (s *PrivateAccountAPI) SendTransaction(ctx context.Context, args SendTxArgs, passwd string) (common.Hash, error) {
 	var err error
 	args, err = prepareSendTxArgs(ctx, args, s.b)
 	if err != nil {
@@ -334,6 +334,12 @@ func (s *PrivateAccountAPI) SignAndSendTransaction(ctx context.Context, args Sen
 	}
 
 	return submitTransaction(ctx, s.b, tx, signature)
+}
+
+// SignAndSendTransaction was renamed to SendTransaction. This method is deprecated
+// and will be removed in the future. It primary goal is to give clients time to update.
+func (s *PrivateAccountAPI) SignAndSendTransaction(ctx context.Context, args SendTxArgs, passwd string) (common.Hash, error) {
+	return s.SendTransaction(ctx, args, passwd)
 }
 
 // PublicBlockChainAPI provides an API to access the Ethereum blockchain.

--- a/internal/web3ext/web3ext.go
+++ b/internal/web3ext/web3ext.go
@@ -418,8 +418,8 @@ web3._extend({
 			params: 2
 		}),
 		new web3._extend.Method({
-			name: 'signAndSendTransaction',
-			call: 'personal_signAndSendTransaction',
+			name: 'sendTransaction',
+			call: 'personal_sendTransaction',
 			params: 2,
 			inputFormatter: [web3._extend.formatters.inputTransactionFormatter, null]
 		})


### PR DESCRIPTION
See https://github.com/ethereum/EIPs/issues/113. Will update web3 when it released a new version with this method included.

@frozeman 