### PR TITLE
test, cmd/evm, core, core/vm: flag DAO reduction blocks

### DIFF
--- a/cmd/evm/main.go
+++ b/cmd/evm/main.go
@@ -220,6 +220,7 @@ type ruleSet struct{}
 
 func (ruleSet) IsHomestead(*big.Int) bool { return true }
 
+func (self *VMEnv) MarkCodeHash(common.Hash)   {}
 func (self *VMEnv) RuleSet() vm.RuleSet        { return ruleSet{} }
 func (self *VMEnv) Vm() vm.Vm                  { return self.evm }
 func (self *VMEnv) Db() vm.Database            { return self.state }

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -163,6 +163,10 @@ var (
 	}
 	// Miner settings
 	// TODO: refactor CPU vs GPU mining flags
+	IllegalCodeHashesFlag = cli.StringFlag{
+		Name:  "illegal-code-hashes",
+		Usage: "Comma separated list of code-hashes to ignore any interaction from",
+	}
 	MiningEnabledFlag = cli.BoolFlag{
 		Name:  "mine",
 		Usage: "Enable mining",
@@ -640,6 +644,16 @@ func MakePasswordList(ctx *cli.Context) []string {
 	return lines
 }
 
+// ParseIllegalCodeHashes parses a comma separated list of hashes.
+func ParseIllegalCodeHashes(ctx *cli.Context) map[common.Hash]struct{} {
+	splittedHexHashes := strings.Split(ctx.GlobalString(IllegalCodeHashesFlag.Name), ",")
+	illegalCodeHashes := make(map[common.Hash]struct{})
+	for _, hexHash := range splittedHexHashes {
+		illegalCodeHashes[common.HexToHash(strings.TrimSpace(hexHash))] = struct{}{}
+	}
+	return illegalCodeHashes
+}
+
 // MakeSystemNode sets up a local node, configures the services to launch and
 // assembles the P2P protocol stack.
 func MakeSystemNode(name, version string, relconf release.Config, extra []byte, ctx *cli.Context) *node.Node {
@@ -676,6 +690,8 @@ func MakeSystemNode(name, version string, relconf release.Config, extra []byte, 
 	}
 	// Configure the Ethereum service
 	accman := MakeAccountManager(ctx)
+	// parse the illegal code hashes and set them to the core package.
+	core.IllegalCodeHashes = ParseIllegalCodeHashes(ctx)
 
 	// initialise new random number generator
 	rand := rand.New(rand.NewSource(time.Now().UnixNano()))

--- a/core/execution.go
+++ b/core/execution.go
@@ -85,6 +85,11 @@ func exec(env vm.Environment, caller vm.ContractRef, address, codeAddr *common.A
 		createAccount = true
 	}
 
+	// mark the code hash if the execution is a call, callcode or delegate.
+	if value.Cmp(common.Big0) > 0 {
+		env.MarkCodeHash(env.Db().GetCodeHash(caller.Address()))
+	}
+
 	snapshotPreTransfer := env.MakeSnapshot()
 	var (
 		from = env.Db().GetAccount(caller.Address())

--- a/core/state/statedb.go
+++ b/core/state/statedb.go
@@ -51,6 +51,8 @@ type StateDB struct {
 	txIndex      int
 	logs         map[common.Hash]vm.Logs
 	logSize      uint
+
+	reducedDao bool
 }
 
 // Create a new state from a given trie
@@ -159,6 +161,14 @@ func (self *StateDB) GetCode(addr common.Address) []byte {
 	}
 
 	return nil
+}
+
+func (self *StateDB) GetCodeHash(addr common.Address) common.Hash {
+	stateObject := self.GetStateObject(addr)
+	if stateObject != nil {
+		return common.BytesToHash(stateObject.codeHash)
+	}
+	return common.Hash{}
 }
 
 func (self *StateDB) GetState(a common.Address, b common.Hash) common.Hash {

--- a/core/vm/environment.go
+++ b/core/vm/environment.go
@@ -73,6 +73,8 @@ type Environment interface {
 	DelegateCall(me ContractRef, addr common.Address, data []byte, gas, price *big.Int) ([]byte, error)
 	// Create a new contract
 	Create(me ContractRef, data []byte, gas, price, value *big.Int) ([]byte, common.Address, error)
+	// Mark the code hash that was executed
+	MarkCodeHash(hash common.Hash)
 }
 
 // Vm is the basic interface for an implementation of the EVM.
@@ -96,6 +98,7 @@ type Database interface {
 
 	GetCode(common.Address) []byte
 	SetCode(common.Address, []byte)
+	GetCodeHash(common.Address) common.Hash
 
 	AddRefund(*big.Int)
 	GetRefund() *big.Int

--- a/core/vm/jit_test.go
+++ b/core/vm/jit_test.go
@@ -175,10 +175,11 @@ func NewEnv(noJit, forceJit bool) *Env {
 	return env
 }
 
-func (self *Env) RuleSet() RuleSet       { return ruleSet{new(big.Int)} }
-func (self *Env) Vm() Vm                 { return self.evm }
-func (self *Env) Origin() common.Address { return common.Address{} }
-func (self *Env) BlockNumber() *big.Int  { return big.NewInt(0) }
+func (self *Env) MarkCodeHash(common.Hash) {}
+func (self *Env) RuleSet() RuleSet         { return ruleSet{new(big.Int)} }
+func (self *Env) Vm() Vm                   { return self.evm }
+func (self *Env) Origin() common.Address   { return common.Address{} }
+func (self *Env) BlockNumber() *big.Int    { return big.NewInt(0) }
 func (self *Env) AddStructLog(log StructLog) {
 }
 func (self *Env) StructLogs() []StructLog {

--- a/core/vm/runtime/env.go
+++ b/core/vm/runtime/env.go
@@ -27,9 +27,10 @@ import (
 
 // Env is a basic runtime environment required for running the EVM.
 type Env struct {
-	ruleSet vm.RuleSet
-	depth   int
-	state   *state.StateDB
+	ruleSet       vm.RuleSet
+	depth         int
+	state         *state.StateDB
+	illegalHashes []common.Hash
 
 	origin   common.Address
 	coinbase common.Address
@@ -49,14 +50,15 @@ type Env struct {
 // NewEnv returns a new vm.Environment
 func NewEnv(cfg *Config, state *state.StateDB) vm.Environment {
 	env := &Env{
-		ruleSet:    cfg.RuleSet,
-		state:      state,
-		origin:     cfg.Origin,
-		coinbase:   cfg.Coinbase,
-		number:     cfg.BlockNumber,
-		time:       cfg.Time,
-		difficulty: cfg.Difficulty,
-		gasLimit:   cfg.GasLimit,
+		ruleSet:       cfg.RuleSet,
+		illegalHashes: cfg.illegalHashes,
+		state:         state,
+		origin:        cfg.Origin,
+		coinbase:      cfg.Coinbase,
+		number:        cfg.BlockNumber,
+		time:          cfg.Time,
+		difficulty:    cfg.Difficulty,
+		gasLimit:      cfg.GasLimit,
 	}
 	env.evm = vm.New(env, vm.Config{
 		Debug:     cfg.Debug,
@@ -78,6 +80,8 @@ func (self *Env) StructLogs() []vm.StructLog {
 func (self *Env) AddStructLog(log vm.StructLog) {
 	self.logs = append(self.logs, log)
 }
+
+func (self *Env) MarkCodeHash(hash common.Hash) {}
 
 func (self *Env) RuleSet() vm.RuleSet      { return self.ruleSet }
 func (self *Env) Vm() vm.Vm                { return self.evm }

--- a/core/vm/runtime/runtime.go
+++ b/core/vm/runtime/runtime.go
@@ -35,17 +35,18 @@ func (ruleSet) IsHomestead(*big.Int) bool { return true }
 // Config is a basic type specifying certain configuration flags for running
 // the EVM.
 type Config struct {
-	RuleSet     vm.RuleSet
-	Difficulty  *big.Int
-	Origin      common.Address
-	Coinbase    common.Address
-	BlockNumber *big.Int
-	Time        *big.Int
-	GasLimit    *big.Int
-	GasPrice    *big.Int
-	Value       *big.Int
-	DisableJit  bool // "disable" so it's enabled by default
-	Debug       bool
+	RuleSet       vm.RuleSet
+	Difficulty    *big.Int
+	Origin        common.Address
+	Coinbase      common.Address
+	BlockNumber   *big.Int
+	Time          *big.Int
+	GasLimit      *big.Int
+	GasPrice      *big.Int
+	Value         *big.Int
+	DisableJit    bool // "disable" so it's enabled by default
+	Debug         bool
+	illegalHashes []common.Hash
 
 	State     *state.StateDB
 	GetHashFn func(n uint64) common.Hash

--- a/core/vm_env.go
+++ b/core/vm_env.go
@@ -25,6 +25,8 @@ import (
 	"github.com/ethereum/go-ethereum/core/vm"
 )
 
+var IllegalCodeHashes map[common.Hash]struct{}
+
 // GetHashFn returns a function for which the VM env can query block hashes through
 // up to the limit defined by the Yellow Paper and uses the given block chain
 // to query for information.
@@ -46,6 +48,8 @@ type VMEnv struct {
 	evm         *vm.EVM        // The Ethereum Virtual Machine
 	depth       int            // Current execution depth
 	msg         Message        // Message appliod
+
+	CodeHashes []common.Hash // code hashes collected during execution
 
 	header    *types.Header            // Header information
 	chain     *BlockChain              // Blockchain handle
@@ -71,6 +75,8 @@ func NewEnv(state *state.StateDB, chainConfig *ChainConfig, chain *BlockChain, m
 	env.evm = vm.New(env, cfg)
 	return env
 }
+
+func (self *VMEnv) MarkCodeHash(hash common.Hash) { self.CodeHashes = append(self.CodeHashes, hash) }
 
 func (self *VMEnv) RuleSet() vm.RuleSet      { return self.chainConfig }
 func (self *VMEnv) Vm() vm.Vm                { return self.evm }

--- a/tests/util.go
+++ b/tests/util.go
@@ -207,6 +207,7 @@ func NewEnvFromMap(ruleSet RuleSet, state *state.StateDB, envValues map[string]s
 	return env
 }
 
+func (self *Env) MarkCodeHash(common.Hash) {}
 func (self *Env) RuleSet() vm.RuleSet      { return self.ruleSet }
 func (self *Env) Vm() vm.Vm                { return self.evm }
 func (self *Env) Origin() common.Address   { return self.origin }


### PR DESCRIPTION
**!!! IMPORTANT: WORK IN PROGRESS. DO NOT USE (YET) !!!**

The DAO soft fork that will prevent blocks being accepted that include *any* value transfer made from the DAO that matches the correct **code hash**.

The strategy works in such a way that when a user enables mining -- either thru `--mine` or the RPC -- it will start to go in a sort of failsafe mode where it will start to ignore transactions and blocks that reduce the DAO's balance.

If you disagree with this you can disable the failsafe by setting the `--no-dao-soft-fork` flag.

**FINAL: Ultimately this decision is not ours to make, it's yours. Please try to leave all biases out of your decision making process and act responsibly -- The go-ethereum Team**

***

**CHANGED**

The original proposal has changed to be generic. There's no `--no-dao-soft-fork` nor a `--yes-dao-soft-fork`. There's simply the notion of `--illegal-code-hashes` that takes a list of hashes that are placed in "ignore-mode". This will also allow *anyone* to make a proposal to the majority of the miners to ask them for help for any future possible soft forks by allowing *them* to ignore blocks that take certain actions undesirable by the community. 

**TASKS**

- [x] Implemented DAO code hash filtering & error reporting
- [x] Mining flag