### PR TITLE
vm: Replace some SstoreClearGas with SstoreResetGas

### DIFF
--- a/core/vm/jit.go
+++ b/core/vm/jit.go
@@ -421,7 +421,7 @@ func jitCalculateGasAndSize(env Environment, contract *Contract, instr instructi
 
 			g = params.SstoreClearGas
 		} else {
-			g = params.SstoreClearGas
+			g = params.SstoreResetGas
 		}
 		gas.Set(g)
 	case SUICIDE:

--- a/core/vm/vm.go
+++ b/core/vm/vm.go
@@ -306,7 +306,7 @@ func calculateGasAndSize(env Environment, contract *Contract, caller ContractRef
 			g = params.SstoreClearGas
 		} else {
 			// non 0 => non 0 (or 0 => 0)
-			g = params.SstoreClearGas
+			g = params.SstoreResetGas
 		}
 		gas.Set(g)
 	case SUICIDE:


### PR DESCRIPTION
According to the yellow paper, when the zeroness of a storage content does not change, the fee should be `Greset` rather than `Gclear`.  These constants have the same value in the code.