### PR TITLE
Remove old natspec Admin_JS stubs

### DIFF
--- a/internal/web3ext/web3ext.go
+++ b/internal/web3ext/web3ext.go
@@ -111,21 +111,6 @@ web3._extend({
 			params: 3
 		}),
 		new web3._extend.Method({
-			name: 'startNatSpec',
-			call: 'admin_startNatSpec',
-			params: 0
-		}),
-		new web3._extend.Method({
-			name: 'stopNatSpec',
-			call: 'admin_stopNatSpec',
-			params: 0
-		}),
-		new web3._extend.Method({
-			name: 'getContractInfo',
-			call: 'admin_getContractInfo',
-			params: 1
-		}),
-		new web3._extend.Method({
 			name: 'httpGet',
 			call: 'admin_httpGet',
 			params: 2


### PR DESCRIPTION
This stops them from showing up in the admin object on the javascript console.
Corresponding natspec functions no longer built since 1.3.6?