### PR TITLE
cmd/geth: fix the import error message

### DIFF
--- a/cmd/geth/accountcmd.go
+++ b/cmd/geth/accountcmd.go
@@ -316,7 +316,7 @@ func accountImport(ctx *cli.Context) error {
 	}
 	key, err := crypto.LoadECDSA(keyfile)
 	if err != nil {
-		utils.Fatalf("keyfile must be given as argument")
+		utils.Fatalf("Failed to load the private key: %v", err)
 	}
 	accman := utils.MakeAccountManager(ctx)
 	passphrase := getPassPhrase("Your new account is locked with a password. Please give a password. Do not forget this password.", true, 0, utils.MakePasswordList(ctx))


### PR DESCRIPTION
A small fix for the issue [#2503](https://github.com/ethereum/go-ethereum/issues/2503). The error message when `LoadECDSA()` failed was incorrect. 