### PR TITLE
cmd, common, console, eth, release: drop redundant "full"s

### DIFF
--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -328,7 +328,7 @@ func startNode(ctx *cli.Context, stack *node.Node) {
 	}
 	// Start auxiliary services if enabled
 	if ctx.GlobalBool(utils.MiningEnabledFlag.Name) {
-		var ethereum *eth.FullNodeService
+		var ethereum *eth.Ethereum
 		if err := stack.Service(&ethereum); err != nil {
 			utils.Fatalf("ethereum service not running: %v", err)
 		}

--- a/cmd/gethrpctest/main.go
+++ b/cmd/gethrpctest/main.go
@@ -146,7 +146,7 @@ func MakeSystemNode(keydir string, privkey string, test *tests.BlockTest) (*node
 // RunTest executes the specified test against an already pre-configured protocol
 // stack to ensure basic checks pass before running RPC tests.
 func RunTest(stack *node.Node, test *tests.BlockTest) error {
-	var ethereum *eth.FullNodeService
+	var ethereum *eth.Ethereum
 	stack.Service(&ethereum)
 	blockchain := ethereum.BlockChain()
 

--- a/common/natspec/natspec_e2e_test.go
+++ b/common/natspec/natspec_e2e_test.go
@@ -99,7 +99,7 @@ const (
 
 type testFrontend struct {
 	t           *testing.T
-	ethereum    *eth.FullNodeService
+	ethereum    *eth.Ethereum
 	xeth        *xe.XEth
 	wait        chan *big.Int
 	lastConfirm string
@@ -123,7 +123,7 @@ func (self *testFrontend) ConfirmTransaction(tx string) bool {
 	return true
 }
 
-func testEth(t *testing.T) (ethereum *eth.FullNodeService, err error) {
+func testEth(t *testing.T) (ethereum *eth.Ethereum, err error) {
 
 	tmp, err := ioutil.TempDir("", "natspec-test")
 	if err != nil {

--- a/console/console_test.go
+++ b/console/console_test.go
@@ -76,7 +76,7 @@ func (p *hookedPrompter) SetWordCompleter(completer WordCompleter) {}
 type tester struct {
 	workspace string
 	stack     *node.Node
-	ethereum  *eth.FullNodeService
+	ethereum  *eth.Ethereum
 	console   *Console
 	input     *hookedPrompter
 	output    *bytes.Buffer
@@ -134,7 +134,7 @@ func newTester(t *testing.T, confOverride func(*eth.Config)) *tester {
 		t.Fatalf("failed to create JavaScript console: %v", err)
 	}
 	// Create the final tester and return
-	var ethereum *eth.FullNodeService
+	var ethereum *eth.Ethereum
 	stack.Service(&ethereum)
 
 	return &tester{

--- a/eth/api.go
+++ b/eth/api.go
@@ -40,41 +40,41 @@ import (
 	"github.com/ethereum/go-ethereum/rpc"
 )
 
-// PublicFullEthereumAPI provides an API to access Ethereum full node-related
+// PublicEthereumAPI provides an API to access Ethereum full node-related
 // information.
-type PublicFullEthereumAPI struct {
-	e *FullNodeService
+type PublicEthereumAPI struct {
+	e *Ethereum
 }
 
-// NewPublicFullEthereumAPI creates a new Etheruem protocol API for full nodes.
-func NewPublicFullEthereumAPI(e *FullNodeService) *PublicFullEthereumAPI {
-	return &PublicFullEthereumAPI{e}
+// NewPublicEthereumAPI creates a new Etheruem protocol API for full nodes.
+func NewPublicEthereumAPI(e *Ethereum) *PublicEthereumAPI {
+	return &PublicEthereumAPI{e}
 }
 
 // Etherbase is the address that mining rewards will be send to
-func (s *PublicFullEthereumAPI) Etherbase() (common.Address, error) {
+func (s *PublicEthereumAPI) Etherbase() (common.Address, error) {
 	return s.e.Etherbase()
 }
 
 // Coinbase is the address that mining rewards will be send to (alias for Etherbase)
-func (s *PublicFullEthereumAPI) Coinbase() (common.Address, error) {
+func (s *PublicEthereumAPI) Coinbase() (common.Address, error) {
 	return s.Etherbase()
 }
 
 // Hashrate returns the POW hashrate
-func (s *PublicFullEthereumAPI) Hashrate() *rpc.HexNumber {
+func (s *PublicEthereumAPI) Hashrate() *rpc.HexNumber {
 	return rpc.NewHexNumber(s.e.Miner().HashRate())
 }
 
 // PublicMinerAPI provides an API to control the miner.
 // It offers only methods that operate on data that pose no security risk when it is publicly accessible.
 type PublicMinerAPI struct {
-	e     *FullNodeService
+	e     *Ethereum
 	agent *miner.RemoteAgent
 }
 
 // NewPublicMinerAPI create a new PublicMinerAPI instance.
-func NewPublicMinerAPI(e *FullNodeService) *PublicMinerAPI {
+func NewPublicMinerAPI(e *Ethereum) *PublicMinerAPI {
 	agent := miner.NewRemoteAgent()
 	e.Miner().Register(agent)
 
@@ -120,11 +120,11 @@ func (s *PublicMinerAPI) SubmitHashrate(hashrate rpc.HexNumber, id common.Hash) 
 // PrivateMinerAPI provides private RPC methods to control the miner.
 // These methods can be abused by external users and must be considered insecure for use by untrusted users.
 type PrivateMinerAPI struct {
-	e *FullNodeService
+	e *Ethereum
 }
 
 // NewPrivateMinerAPI create a new RPC service which controls the miner of this node.
-func NewPrivateMinerAPI(e *FullNodeService) *PrivateMinerAPI {
+func NewPrivateMinerAPI(e *Ethereum) *PrivateMinerAPI {
 	return &PrivateMinerAPI{e: e}
 }
 
@@ -191,20 +191,20 @@ func (s *PrivateMinerAPI) MakeDAG(blockNr rpc.BlockNumber) (bool, error) {
 	return true, nil
 }
 
-// PrivateFullAdminAPI is the collection of Etheruem full node-related APIs
+// PrivateAdminAPI is the collection of Etheruem full node-related APIs
 // exposed over the private admin endpoint.
-type PrivateFullAdminAPI struct {
-	eth *FullNodeService
+type PrivateAdminAPI struct {
+	eth *Ethereum
 }
 
 // NewPrivateAdminAPI creates a new API definition for the full node private
 // admin methods of the Ethereum service.
-func NewPrivateFullAdminAPI(eth *FullNodeService) *PrivateFullAdminAPI {
-	return &PrivateFullAdminAPI{eth: eth}
+func NewPrivateAdminAPI(eth *Ethereum) *PrivateAdminAPI {
+	return &PrivateAdminAPI{eth: eth}
 }
 
 // ExportChain exports the current blockchain into a local file.
-func (api *PrivateFullAdminAPI) ExportChain(file string) (bool, error) {
+func (api *PrivateAdminAPI) ExportChain(file string) (bool, error) {
 	// Make sure we can create the file to export into
 	out, err := os.OpenFile(file, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, os.ModePerm)
 	if err != nil {
@@ -230,7 +230,7 @@ func hasAllBlocks(chain *core.BlockChain, bs []*types.Block) bool {
 }
 
 // ImportChain imports a blockchain from a local file.
-func (api *PrivateFullAdminAPI) ImportChain(file string) (bool, error) {
+func (api *PrivateAdminAPI) ImportChain(file string) (bool, error) {
 	// Make sure the can access the file to import
 	in, err := os.Open(file)
 	if err != nil {
@@ -271,20 +271,20 @@ func (api *PrivateFullAdminAPI) ImportChain(file string) (bool, error) {
 	return true, nil
 }
 
-// PublicFullDebugAPI is the collection of Etheruem full node APIs exposed
+// PublicDebugAPI is the collection of Etheruem full node APIs exposed
 // over the public debugging endpoint.
-type PublicFullDebugAPI struct {
-	eth *FullNodeService
+type PublicDebugAPI struct {
+	eth *Ethereum
 }
 
-// NewPublicFullDebugAPI creates a new API definition for the full node-
+// NewPublicDebugAPI creates a new API definition for the full node-
 // related public debug methods of the Ethereum service.
-func NewPublicFullDebugAPI(eth *FullNodeService) *PublicFullDebugAPI {
-	return &PublicFullDebugAPI{eth: eth}
+func NewPublicDebugAPI(eth *Ethereum) *PublicDebugAPI {
+	return &PublicDebugAPI{eth: eth}
 }
 
 // DumpBlock retrieves the entire state of the database at a given block.
-func (api *PublicFullDebugAPI) DumpBlock(number uint64) (state.World, error) {
+func (api *PublicDebugAPI) DumpBlock(number uint64) (state.World, error) {
 	block := api.eth.BlockChain().GetBlockByNumber(number)
 	if block == nil {
 		return state.World{}, fmt.Errorf("block #%d not found", number)
@@ -296,17 +296,17 @@ func (api *PublicFullDebugAPI) DumpBlock(number uint64) (state.World, error) {
 	return stateDb.RawDump(), nil
 }
 
-// PrivateFullDebugAPI is the collection of Etheruem full node APIs exposed over
+// PrivateDebugAPI is the collection of Etheruem full node APIs exposed over
 // the private debugging endpoint.
-type PrivateFullDebugAPI struct {
+type PrivateDebugAPI struct {
 	config *core.ChainConfig
-	eth    *FullNodeService
+	eth    *Ethereum
 }
 
-// NewPrivateFullDebugAPI creates a new API definition for the full node-related
+// NewPrivateDebugAPI creates a new API definition for the full node-related
 // private debug methods of the Ethereum service.
-func NewPrivateFullDebugAPI(config *core.ChainConfig, eth *FullNodeService) *PrivateFullDebugAPI {
-	return &PrivateFullDebugAPI{config: config, eth: eth}
+func NewPrivateDebugAPI(config *core.ChainConfig, eth *Ethereum) *PrivateDebugAPI {
+	return &PrivateDebugAPI{config: config, eth: eth}
 }
 
 // BlockTraceResult is the returned value when replaying a block to check for
@@ -319,7 +319,7 @@ type BlockTraceResult struct {
 
 // TraceBlock processes the given block's RLP but does not import the block in to
 // the chain.
-func (api *PrivateFullDebugAPI) TraceBlock(blockRlp []byte, config *vm.Config) BlockTraceResult {
+func (api *PrivateDebugAPI) TraceBlock(blockRlp []byte, config *vm.Config) BlockTraceResult {
 	var block types.Block
 	err := rlp.Decode(bytes.NewReader(blockRlp), &block)
 	if err != nil {
@@ -336,7 +336,7 @@ func (api *PrivateFullDebugAPI) TraceBlock(blockRlp []byte, config *vm.Config) B
 
 // TraceBlockFromFile loads the block's RLP from the given file name and attempts to
 // process it but does not import the block in to the chain.
-func (api *PrivateFullDebugAPI) TraceBlockFromFile(file string, config *vm.Config) BlockTraceResult {
+func (api *PrivateDebugAPI) TraceBlockFromFile(file string, config *vm.Config) BlockTraceResult {
 	blockRlp, err := ioutil.ReadFile(file)
 	if err != nil {
 		return BlockTraceResult{Error: fmt.Sprintf("could not read file: %v", err)}
@@ -345,7 +345,7 @@ func (api *PrivateFullDebugAPI) TraceBlockFromFile(file string, config *vm.Confi
 }
 
 // TraceBlockByNumber processes the block by canonical block number.
-func (api *PrivateFullDebugAPI) TraceBlockByNumber(number uint64, config *vm.Config) BlockTraceResult {
+func (api *PrivateDebugAPI) TraceBlockByNumber(number uint64, config *vm.Config) BlockTraceResult {
 	// Fetch the block that we aim to reprocess
 	block := api.eth.BlockChain().GetBlockByNumber(number)
 	if block == nil {
@@ -361,7 +361,7 @@ func (api *PrivateFullDebugAPI) TraceBlockByNumber(number uint64, config *vm.Con
 }
 
 // TraceBlockByHash processes the block by hash.
-func (api *PrivateFullDebugAPI) TraceBlockByHash(hash common.Hash, config *vm.Config) BlockTraceResult {
+func (api *PrivateDebugAPI) TraceBlockByHash(hash common.Hash, config *vm.Config) BlockTraceResult {
 	// Fetch the block that we aim to reprocess
 	block := api.eth.BlockChain().GetBlockByHash(hash)
 	if block == nil {
@@ -389,7 +389,7 @@ func (t *TraceCollector) AddStructLog(slog vm.StructLog) {
 }
 
 // traceBlock processes the given block but does not save the state.
-func (api *PrivateFullDebugAPI) traceBlock(block *types.Block, config *vm.Config) (bool, []vm.StructLog, error) {
+func (api *PrivateDebugAPI) traceBlock(block *types.Block, config *vm.Config) (bool, []vm.StructLog, error) {
 	// Validate and reprocess the block
 	var (
 		blockchain = api.eth.BlockChain()
@@ -452,7 +452,7 @@ func formatError(err error) string {
 
 // TraceTransaction returns the structured logs created during the execution of EVM
 // and returns them as a JSON object.
-func (api *PrivateFullDebugAPI) TraceTransaction(txHash common.Hash, logger *vm.LogConfig) (*ethapi.ExecutionResult, error) {
+func (api *PrivateDebugAPI) TraceTransaction(txHash common.Hash, logger *vm.LogConfig) (*ethapi.ExecutionResult, error) {
 	if logger == nil {
 		logger = new(vm.LogConfig)
 	}

--- a/eth/api_backend.go
+++ b/eth/api_backend.go
@@ -36,7 +36,7 @@ import (
 
 // EthApiBackend implements ethapi.Backend for full nodes
 type EthApiBackend struct {
-	eth *FullNodeService
+	eth *Ethereum
 	gpo *gasprice.GasPriceOracle
 }
 

--- a/eth/bind.go
+++ b/eth/bind.go
@@ -42,7 +42,7 @@ type ContractBackend struct {
 
 // NewContractBackend creates a new native contract backend using an existing
 // Etheruem object.
-func NewContractBackend(eth *FullNodeService) *ContractBackend {
+func NewContractBackend(eth *Ethereum) *ContractBackend {
 	return &ContractBackend{
 		eapi:  ethapi.NewPublicEthereumAPI(eth.apiBackend, nil, nil),
 		bcapi: ethapi.NewPublicBlockChainAPI(eth.apiBackend),

--- a/eth/cpu_mining.go
+++ b/eth/cpu_mining.go
@@ -28,7 +28,7 @@ import (
 
 const disabledInfo = "Set GO_OPENCL and re-build to enable."
 
-func (s *FullNodeService) StartMining(threads int, gpus string) error {
+func (s *Ethereum) StartMining(threads int, gpus string) error {
 	eb, err := s.Etherbase()
 	if err != nil {
 		err = fmt.Errorf("Cannot start mining without etherbase address: %v", err)

--- a/eth/gpu_mining.go
+++ b/eth/gpu_mining.go
@@ -33,7 +33,7 @@ import (
 	"github.com/ethereum/go-ethereum/miner"
 )
 
-func (s *FullNodeService) StartMining(threads int, gpus string) error {
+func (s *Ethereum) StartMining(threads int, gpus string) error {
 	eb, err := s.Etherbase()
 	if err != nil {
 		err = fmt.Errorf("Cannot start mining without etherbase address: %v", err)

--- a/release/release.go
+++ b/release/release.go
@@ -58,7 +58,7 @@ type ReleaseService struct {
 // releases and notify the user of such.
 func NewReleaseService(ctx *node.ServiceContext, config Config) (node.Service, error) {
 	// Retrieve the Ethereum service dependency to access the blockchain
-	var ethereum *eth.FullNodeService
+	var ethereum *eth.Ethereum
 	if err := ctx.Service(&ethereum); err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
The full/light node API split PR renamed many of the `eth` package's types to include "Full". Since by definition the `eth` package is "full" and the `light` package is "light", there is no need for a redundant naming, which also breaks APIs quite heavily.

This PR renames `eth.FullNodeService` back to `eth.Ethereum` and various `eth.FullXXXAPIs` to back simply `eth.XXXAPIs`.

*Edit: I'm open to debate on these, but these name revert proposals avoid both breaking existing APIs as well as avoids introducing API stuttering (e.g. `light.LightNode`).*