### PR TITLE
Revised for compatibility w/MSYS2/MINGW64 w/o MSYS=winsymlinks

### DIFF
--- a/build/env.sh
+++ b/build/env.sh
@@ -2,14 +2,20 @@
 
 set -e
 
-if [ ! -f "build/env.sh" ]; then
+root="$PWD"
+
+if [ ! -f "$root/build/env.sh" ]; then
     echo "$0 must be run from the root of the repository."
     exit 2
 fi
 
+# Create build/bin if it doesn't exist yet.
+if [ ! -L "$root/build/bin" ]; then
+    mkdir -p "$root/build/bin"
+fi
+
 # Create fake Go workspace if it doesn't exist yet.
-workspace="$PWD/../_go_build/_workspace"
-root="$PWD"
+workspace="$root/../_go_build/_workspace"
 ethdir="$workspace/src/github.com/ethereum"
 if [ ! -L "$ethdir/go-ethereum" ]; then
     mkdir -p "$ethdir"

--- a/build/env.sh
+++ b/build/env.sh
@@ -10,14 +10,14 @@ if [ ! -f "$root/build/env.sh" ]; then
 fi
 
 # Create build/bin if it doesn't exist yet.
-if [ ! -a "$root/build/bin" ]; then
+if [ ! -e "$root/build/bin" ]; then
     mkdir -p "$root/build/bin"
 fi
 
 # Create fake Go workspace if it doesn't exist yet.
 workspace="$root/../_go_build/_workspace"
 ethdir="$workspace/src/github.com/ethereum"
-if [ ! -a "$ethdir/go-ethereum" ]; then
+if [ ! -e "$ethdir/go-ethereum" ]; then
     mkdir -p "$ethdir"
     cd "$ethdir"
     ln -s "$root" go-ethereum

--- a/build/env.sh
+++ b/build/env.sh
@@ -8,13 +8,13 @@ if [ ! -f "build/env.sh" ]; then
 fi
 
 # Create fake Go workspace if it doesn't exist yet.
-workspace="$PWD/build/_workspace"
+workspace="$PWD/../_go_build/_workspace"
 root="$PWD"
 ethdir="$workspace/src/github.com/ethereum"
 if [ ! -L "$ethdir/go-ethereum" ]; then
     mkdir -p "$ethdir"
     cd "$ethdir"
-    ln -s ../../../../../. go-ethereum
+    ln -s "$root" go-ethereum
     cd "$root"
 fi
 

--- a/build/env.sh
+++ b/build/env.sh
@@ -10,14 +10,14 @@ if [ ! -f "$root/build/env.sh" ]; then
 fi
 
 # Create build/bin if it doesn't exist yet.
-if [ ! -L "$root/build/bin" ]; then
+if [ ! -a "$root/build/bin" ]; then
     mkdir -p "$root/build/bin"
 fi
 
 # Create fake Go workspace if it doesn't exist yet.
 workspace="$root/../_go_build/_workspace"
 ethdir="$workspace/src/github.com/ethereum"
-if [ ! -L "$ethdir/go-ethereum" ]; then
+if [ ! -a "$ethdir/go-ethereum" ]; then
     mkdir -p "$ethdir"
     cd "$ethdir"
     ln -s "$root" go-ethereum


### PR DESCRIPTION
Please see: https://sourceforge.net/p/msys2/tickets/41/

When the following is NOT enabled (when the line has NOT been uncommented) symlinks are unavailable in MSYS2 shell for WIN32 compatibility.

rem To activate windows native symlinks uncomment next line
rem set MSYS=winsymlinks:nativestrict

which results in the following error due to the nested recursive symlinks within go-ethereum/build/ when _workspace/ was being created there:

```
JasonCoombs@Kauri_Forest MINGW64 ~/go-ethereum/build/_workspace/src/github.com/ethereum
$ ln -s "/home/JasonCoombs/go-ethereum" go-ethereum
ln: failed to create symbolic link ‘go-ethereum’ -> ‘/home/JasonCoombs/go-ethereum’: File name too long
```

The solution, for compatibility with MSYS2/MINGW64 in its default WIN32 mode of operation, is to set up fake Go workspace outside of $root

Beware, MINGW64! FlashGordonW64 is coming to git you. Flash! Ah ahhhhh! The savior of the universe! @ForestMade #SuperHero64