### PR TITLE
eth: disable eth/61 to prepare for more elaborate fork sync algos

### DIFF
--- a/eth/protocol.go
+++ b/eth/protocol.go
@@ -37,10 +37,10 @@ const (
 var ProtocolName = "eth"
 
 // Supported versions of the eth protocol (first is primary).
-var ProtocolVersions = []uint{eth63, eth62, eth61}
+var ProtocolVersions = []uint{eth63, eth62}
 
 // Number of implemented message corresponding to different protocol versions.
-var ProtocolLengths = []uint64{17, 8, 9}
+var ProtocolLengths = []uint64{17, 8}
 
 const (
 	NetworkId          = 1


### PR DESCRIPTION
This PR disables the `eth/61` protocol to support any fork logic depending on header contents (v61 operates on hashes, not headers). The actual implementation will be removed in Geth 1.5 only to prevent doing any last minute invasive changes.