### PR TITLE
containers/docker/master-alpine: drop gmp dependency

### DIFF
--- a/containers/docker/master-alpine/Dockerfile
+++ b/containers/docker/master-alpine/Dockerfile
@@ -1,11 +1,11 @@
 FROM alpine:3.3
 
 RUN \
-  apk add --update go git make gcc musl-dev gmp-dev gmp && \
-  git clone https://github.com/ethereum/go-ethereum     && \
-  (cd go-ethereum && make geth)                         && \
-  cp go-ethereum/build/bin/geth /geth                   && \
-  apk del go git make gcc musl-dev gmp-dev              && \
+  apk add --update go git make gcc musl-dev         && \
+  git clone https://github.com/ethereum/go-ethereum && \
+  (cd go-ethereum && make geth)                     && \
+  cp go-ethereum/build/bin/geth /geth               && \
+  apk del go git make gcc musl-dev                  && \
   rm -rf /go-ethereum && rm -rf /var/cache/apk/*
 
 EXPOSE 8545


### PR DESCRIPTION
Drop `gmp` dependency on master docker images.