### PR TITLE
core: gracefully handle missing homestead block config

### DIFF
--- a/cmd/geth/genesis_test.go
+++ b/cmd/geth/genesis_test.go
@@ -1,0 +1,105 @@
+// Copyright 2016 The go-ethereum Authors
+// This file is part of go-ethereum.
+//
+// go-ethereum is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// go-ethereum is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with go-ethereum. If not, see <http://www.gnu.org/licenses/>.
+
+package main
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+var customGenesisTests = []struct {
+	genesis string
+	query   string
+	result  string
+}{
+	// Plain genesis file without anything extra
+	{
+		genesis: `{
+			"alloc"      : {},
+			"coinbase"   : "0x0000000000000000000000000000000000000000",
+			"difficulty" : "0x20000",
+			"extraData"  : "",
+			"gasLimit"   : "0x2fefd8",
+			"nonce"      : "0x0000000000000042",
+			"mixhash"    : "0x0000000000000000000000000000000000000000000000000000000000000000",
+			"parentHash" : "0x0000000000000000000000000000000000000000000000000000000000000000",
+			"timestamp"  : "0x00"
+		}`,
+		query:  "eth.getBlock(0).nonce",
+		result: "0x0000000000000042",
+	},
+	// Genesis file with an empty chain configuration (ensure missing fields work)
+	{
+		genesis: `{
+			"alloc"      : {},
+			"coinbase"   : "0x0000000000000000000000000000000000000000",
+			"difficulty" : "0x20000",
+			"extraData"  : "",
+			"gasLimit"   : "0x2fefd8",
+			"nonce"      : "0x0000000000000042",
+			"mixhash"    : "0x0000000000000000000000000000000000000000000000000000000000000000",
+			"parentHash" : "0x0000000000000000000000000000000000000000000000000000000000000000",
+			"timestamp"  : "0x00",
+			"config"     : {}
+		}`,
+		query:  "eth.getBlock(0).nonce",
+		result: "0x0000000000000042",
+	},
+	// Genesis file with specific chain configurations
+	{
+		genesis: `{
+			"alloc"      : {},
+			"coinbase"   : "0x0000000000000000000000000000000000000000",
+			"difficulty" : "0x20000",
+			"extraData"  : "",
+			"gasLimit"   : "0x2fefd8",
+			"nonce"      : "0x0000000000000042",
+			"mixhash"    : "0x0000000000000000000000000000000000000000000000000000000000000000",
+			"parentHash" : "0x0000000000000000000000000000000000000000000000000000000000000000",
+			"timestamp"  : "0x00",
+			"config"     : {
+				"homesteadBlock" : 314,
+			},
+		}`,
+		query:  "eth.getBlock(0).nonce",
+		result: "0x0000000000000042",
+	},
+}
+
+// Tests that initializing Geth with a custom genesis block and chain definitions
+// work properly.
+func TestCustomGenesis(t *testing.T) {
+	for i, tt := range customGenesisTests {
+		// Create a temporary data directory to use and inspect later
+		datadir := tmpdir(t)
+		defer os.RemoveAll(datadir)
+
+		// Initialize the data directory with the custom genesis block
+		json := filepath.Join(datadir, "genesis.json")
+		if err := ioutil.WriteFile(json, []byte(tt.genesis), 0600); err != nil {
+			t.Fatalf("test %d: failed to write genesis file: %v", i, err)
+		}
+		runGeth(t, "--datadir", datadir, "init", json).cmd.Wait()
+
+		// Query the custom genesis block
+		geth := runGeth(t, "--datadir", datadir, "--maxpeers", "0", "--nodiscover", "--nat", "none", "--ipcdisable", "--exec", tt.query, "console")
+		geth.expectRegexp(tt.result)
+		geth.expectExit()
+	}
+}

--- a/core/config.go
+++ b/core/config.go
@@ -38,7 +38,7 @@ type ChainConfig struct {
 
 // IsHomestead returns whether num is either equal to the homestead block or greater.
 func (c *ChainConfig) IsHomestead(num *big.Int) bool {
-	if num == nil {
+	if c.HomesteadBlock == nil || num == nil {
 		return false
 	}
 


### PR DESCRIPTION
Our nodes didn't handle an interesting corner case until now: **having** a chain configuration (in the genesis.json), but **not having** a `homesteadBlock` set in it (i.e. `{..., "config": {}}`). Since our configs until now only featured the homestead block number, either it (block number) was present or the entire config section was missing (resulting the the defaults being used).

With the DAO fork being worked on and requiring an additional config section, it becomes entirely possible to have the DAO fork number set, but the homestead number not set. This PR ensures that it the homestead block number is missing, it's assumed not forked.

*Note, there's almost no end user use case to set the DAO hard fork in a private network (so skipping the entire config section or only setting the homestead block is still entirely workable), but it is needed to properly test it n automated ways so better to fix it up properly now.*