### PR TITLE
cmd/geth, miner, params: special extradata for DAO fork start

### DIFF
--- a/cmd/geth/dao_test.go
+++ b/cmd/geth/dao_test.go
@@ -1,0 +1,306 @@
+// Copyright 2016 The go-ethereum Authors
+// This file is part of go-ethereum.
+//
+// go-ethereum is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// go-ethereum is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with go-ethereum. If not, see <http://www.gnu.org/licenses/>.
+
+package main
+
+import (
+	"io/ioutil"
+	"math/big"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core"
+	"github.com/ethereum/go-ethereum/ethdb"
+	"github.com/ethereum/go-ethereum/params"
+)
+
+var daoNoForkGenesis = `{
+	"alloc"      : {},
+	"coinbase"   : "0x0000000000000000000000000000000000000000",
+	"difficulty" : "0x20000",
+	"extraData"  : "",
+	"gasLimit"   : "0x2fefd8",
+	"nonce"      : "0x0000000000000042",
+	"mixhash"    : "0x0000000000000000000000000000000000000000000000000000000000000000",
+	"parentHash" : "0x0000000000000000000000000000000000000000000000000000000000000000",
+	"timestamp"  : "0x00"
+}`
+var daoNoForkGenesisHash = common.HexToHash("5e1fc79cb4ffa4739177b5408045cd5d51c6cf766133f23f7cd72ee1f8d790e0")
+
+var daoProForkGenesis = `{
+	"alloc"      : {},
+	"coinbase"   : "0x0000000000000000000000000000000000000000",
+	"difficulty" : "0x20000",
+	"extraData"  : "",
+	"gasLimit"   : "0x2fefd8",
+	"nonce"      : "0x0000000000000043",
+	"mixhash"    : "0x0000000000000000000000000000000000000000000000000000000000000000",
+	"parentHash" : "0x0000000000000000000000000000000000000000000000000000000000000000",
+	"timestamp"  : "0x00",
+	"config"     : {
+		"daoForkBlock": 314
+	}
+}`
+var daoProForkGenesisHash = common.HexToHash("c80f3c1c3d81ae6d8ea59edf35d3e4b723e4c8684ec71fdb6d4715e3f8add237")
+var daoProForkBlock = big.NewInt(314)
+
+// Tests that creating a new node to with or without the DAO fork flag will correctly
+// set the genesis block but with DAO support explicitly set or unset in the chain
+// config in the database.
+func TestDAOSupportMainnet(t *testing.T) {
+	testDAOForkBlockNewChain(t, false, "", true, params.MainNetDAOForkBlock)
+}
+func TestDAOSupportTestnet(t *testing.T) {
+	testDAOForkBlockNewChain(t, true, "", true, params.TestNetDAOForkBlock)
+}
+func TestDAOSupportPrivnet(t *testing.T) {
+	testDAOForkBlockNewChain(t, false, daoProForkGenesis, false, daoProForkBlock)
+}
+func TestDAONoSupportMainnet(t *testing.T) {
+	testDAOForkBlockNewChain(t, false, "", false, nil)
+}
+func TestDAONoSupportTestnet(t *testing.T) {
+	testDAOForkBlockNewChain(t, true, "", false, nil)
+}
+func TestDAONoSupportPrivnet(t *testing.T) {
+	testDAOForkBlockNewChain(t, false, daoNoForkGenesis, false, nil)
+}
+
+func testDAOForkBlockNewChain(t *testing.T, testnet bool, genesis string, fork bool, expect *big.Int) {
+	// Create a temporary data directory to use and inspect later
+	datadir := tmpdir(t)
+	defer os.RemoveAll(datadir)
+
+	// Start a Geth instance with the requested flags set and immediately terminate
+	if genesis != "" {
+		json := filepath.Join(datadir, "genesis.json")
+		if err := ioutil.WriteFile(json, []byte(genesis), 0600); err != nil {
+			t.Fatalf("failed to write genesis file: %v", err)
+		}
+		runGeth(t, "--datadir", datadir, "init", json).cmd.Wait()
+	}
+	execDAOGeth(t, datadir, testnet, fork, false)
+
+	// Retrieve the DAO config flag from the database
+	path := filepath.Join(datadir, "chaindata")
+	if testnet {
+		path = filepath.Join(datadir, "testnet", "chaindata")
+	}
+	db, err := ethdb.NewLDBDatabase(path, 0, 0)
+	if err != nil {
+		t.Fatalf("failed to open test database: %v", err)
+	}
+	defer db.Close()
+
+	genesisHash := common.HexToHash("0xd4e56740f876aef8c010b86a40d5f56745a118d0906a34e69aec8c0db1cb8fa3")
+	if testnet {
+		genesisHash = common.HexToHash("0x0cd786a2425d16f152c658316c423e6ce1181e15c3295826d7c9904cba9ce303")
+	} else if genesis == daoNoForkGenesis {
+		genesisHash = daoNoForkGenesisHash
+	} else if genesis == daoProForkGenesis {
+		genesisHash = daoProForkGenesisHash
+	}
+	config, err := core.GetChainConfig(db, genesisHash)
+	if err != nil {
+		t.Fatalf("failed to retrieve chain config: %v", err)
+	}
+	// Validate the DAO hard-fork block number against the expected value
+	if config.DAOForkBlock == nil {
+		if expect != nil {
+			t.Fatalf("dao hard-fork block mismatch: have nil, want %v", expect)
+		}
+	} else if config.DAOForkBlock.Cmp(expect) != 0 {
+		t.Fatalf("dao hard-fork block mismatch: have %v, want %v", config.DAOForkBlock, expect)
+	}
+}
+
+// Tests that starting up an already existing node with various DAO fork override
+// flags correctly changes the chain configs in the database.
+func TestDAODefaultMainnet(t *testing.T) {
+	testDAOForkBlockOldChain(t, false, "", false, false, false, false, nil)
+}
+func TestDAOStartSupportMainnet(t *testing.T) {
+	testDAOForkBlockOldChain(t, false, "", false, true, false, false, params.MainNetDAOForkBlock)
+}
+func TestDAOContinueExplicitSupportMainnet(t *testing.T) {
+	testDAOForkBlockOldChain(t, false, "", true, true, false, false, params.MainNetDAOForkBlock)
+}
+func TestDAOContinueImplicitSupportMainnet(t *testing.T) {
+	testDAOForkBlockOldChain(t, false, "", true, false, false, false, params.MainNetDAOForkBlock)
+}
+func TestDAOSwitchSupportMainnet(t *testing.T) {
+	testDAOForkBlockOldChain(t, false, "", false, true, true, false, params.MainNetDAOForkBlock)
+}
+func TestDAOStartOpposeMainnet(t *testing.T) {
+	testDAOForkBlockOldChain(t, false, "", false, false, false, true, nil)
+}
+func TestDAOContinueExplicitOpposeMainnet(t *testing.T) {
+	testDAOForkBlockOldChain(t, false, "", false, false, true, true, nil)
+}
+func TestDAOContinueImplicitOpposeMainnet(t *testing.T) {
+	testDAOForkBlockOldChain(t, false, "", false, false, true, false, nil)
+}
+func TestDAOSwitchOpposeMainnet(t *testing.T) {
+	testDAOForkBlockOldChain(t, false, "", true, false, false, true, nil)
+}
+func TestDAODefaultTestnet(t *testing.T) {
+	testDAOForkBlockOldChain(t, true, "", false, false, false, false, nil)
+}
+func TestDAOStartSupportTestnet(t *testing.T) {
+	testDAOForkBlockOldChain(t, true, "", false, true, false, false, params.TestNetDAOForkBlock)
+}
+func TestDAOContinueExplicitSupportTestnet(t *testing.T) {
+	testDAOForkBlockOldChain(t, true, "", true, true, false, false, params.TestNetDAOForkBlock)
+}
+func TestDAOContinueImplicitSupportTestnet(t *testing.T) {
+	testDAOForkBlockOldChain(t, true, "", true, false, false, false, params.TestNetDAOForkBlock)
+}
+func TestDAOSwitchSupportTestnet(t *testing.T) {
+	testDAOForkBlockOldChain(t, true, "", false, true, true, false, params.TestNetDAOForkBlock)
+}
+func TestDAOStartOpposeTestnet(t *testing.T) {
+	testDAOForkBlockOldChain(t, true, "", false, false, false, true, nil)
+}
+func TestDAOContinueExplicitOpposeTestnet(t *testing.T) {
+	testDAOForkBlockOldChain(t, true, "", false, false, true, true, nil)
+}
+func TestDAOContinueImplicitOpposeTestnet(t *testing.T) {
+	testDAOForkBlockOldChain(t, true, "", false, false, true, false, nil)
+}
+func TestDAOSwitchOpposeTestnet(t *testing.T) {
+	testDAOForkBlockOldChain(t, true, "", true, false, false, true, nil)
+}
+func TestDAODefaultPrivnet(t *testing.T) {
+	testDAOForkBlockOldChain(t, false, daoNoForkGenesis, false, false, false, false, nil)
+}
+func TestDAOStartSupportConPrivnet(t *testing.T) {
+	testDAOForkBlockOldChain(t, false, daoNoForkGenesis, false, true, false, false, params.MainNetDAOForkBlock)
+}
+func TestDAOContinueExplicitSupportConPrivnet(t *testing.T) {
+	testDAOForkBlockOldChain(t, false, daoNoForkGenesis, true, true, false, false, params.MainNetDAOForkBlock)
+}
+func TestDAOContinueImplicitSupportConPrivnet(t *testing.T) {
+	testDAOForkBlockOldChain(t, false, daoNoForkGenesis, true, false, false, false, params.MainNetDAOForkBlock)
+}
+func TestDAOSwitchSupportConPrivnet(t *testing.T) {
+	testDAOForkBlockOldChain(t, false, daoNoForkGenesis, false, true, true, false, params.MainNetDAOForkBlock)
+}
+func TestDAOStartOpposeConPrivnet(t *testing.T) {
+	testDAOForkBlockOldChain(t, false, daoNoForkGenesis, false, false, false, true, nil)
+}
+func TestDAOContinueExplicitOpposeConPrivnet(t *testing.T) {
+	testDAOForkBlockOldChain(t, false, daoNoForkGenesis, false, false, true, true, nil)
+}
+func TestDAOContinueImplicitOpposeConPrivnet(t *testing.T) {
+	testDAOForkBlockOldChain(t, false, daoNoForkGenesis, false, false, true, false, nil)
+}
+func TestDAOSwitchOpposeConPrivnet(t *testing.T) {
+	testDAOForkBlockOldChain(t, false, daoNoForkGenesis, true, false, false, true, nil)
+}
+func TestDAODefaultProPrivnet(t *testing.T) {
+	testDAOForkBlockOldChain(t, false, daoProForkGenesis, false, false, false, false, daoProForkBlock)
+}
+func TestDAOStartSupportProPrivnet(t *testing.T) {
+	testDAOForkBlockOldChain(t, false, daoProForkGenesis, false, true, false, false, daoProForkBlock)
+}
+func TestDAOContinueExplicitSupportProPrivnet(t *testing.T) {
+	testDAOForkBlockOldChain(t, false, daoProForkGenesis, true, true, false, false, daoProForkBlock)
+}
+func TestDAOContinueImplicitSupportProPrivnet(t *testing.T) {
+	testDAOForkBlockOldChain(t, false, daoProForkGenesis, true, false, false, false, daoProForkBlock)
+}
+func TestDAOSwitchSupportProPrivnet(t *testing.T) {
+	testDAOForkBlockOldChain(t, false, daoProForkGenesis, false, true, true, false, params.MainNetDAOForkBlock)
+}
+func TestDAOStartOpposeProPrivnet(t *testing.T) {
+	testDAOForkBlockOldChain(t, false, daoProForkGenesis, false, false, false, true, nil)
+}
+func TestDAOContinueExplicitOpposeProPrivnet(t *testing.T) {
+	testDAOForkBlockOldChain(t, false, daoProForkGenesis, false, false, true, true, nil)
+}
+func TestDAOContinueImplicitOpposeProPrivnet(t *testing.T) {
+	testDAOForkBlockOldChain(t, false, daoProForkGenesis, false, false, true, false, nil)
+}
+func TestDAOSwitchOpposeProPrivnet(t *testing.T) {
+	testDAOForkBlockOldChain(t, false, daoProForkGenesis, true, false, false, true, nil)
+}
+
+func testDAOForkBlockOldChain(t *testing.T, testnet bool, genesis string, oldSupport, newSupport, oldOppose, newOppose bool, expect *big.Int) {
+	// Create a temporary data directory to use and inspect later
+	datadir := tmpdir(t)
+	defer os.RemoveAll(datadir)
+
+	// Cycle two Geth instances, possibly changing fork support in between
+	if genesis != "" {
+		json := filepath.Join(datadir, "genesis.json")
+		if err := ioutil.WriteFile(json, []byte(genesis), 0600); err != nil {
+			t.Fatalf("failed to write genesis file: %v", err)
+		}
+		runGeth(t, "--datadir", datadir, "init", json).cmd.Wait()
+	}
+	execDAOGeth(t, datadir, testnet, oldSupport, oldOppose)
+	execDAOGeth(t, datadir, testnet, newSupport, newOppose)
+
+	// Retrieve the DAO config flag from the database
+	path := filepath.Join(datadir, "chaindata")
+	if testnet {
+		path = filepath.Join(datadir, "testnet", "chaindata")
+	}
+	db, err := ethdb.NewLDBDatabase(path, 0, 0)
+	if err != nil {
+		t.Fatalf("failed to open test database: %v", err)
+	}
+	defer db.Close()
+
+	genesisHash := common.HexToHash("0xd4e56740f876aef8c010b86a40d5f56745a118d0906a34e69aec8c0db1cb8fa3")
+	if testnet {
+		genesisHash = common.HexToHash("0x0cd786a2425d16f152c658316c423e6ce1181e15c3295826d7c9904cba9ce303")
+	} else if genesis == daoNoForkGenesis {
+		genesisHash = daoNoForkGenesisHash
+	} else if genesis == daoProForkGenesis {
+		genesisHash = daoProForkGenesisHash
+	}
+	config, err := core.GetChainConfig(db, genesisHash)
+	if err != nil {
+		t.Fatalf("failed to retrieve chain config: %v", err)
+	}
+	// Validate the DAO hard-fork block number against the expected value
+	if config.DAOForkBlock == nil {
+		if expect != nil {
+			t.Fatalf("dao hard-fork block mismatch: have nil, want %v", expect)
+		}
+	} else if config.DAOForkBlock.Cmp(expect) != 0 {
+		t.Fatalf("dao hard-fork block mismatch: have %v, want %v", config.DAOForkBlock, expect)
+	}
+}
+
+// execDAOGeth starts a Geth instance with some DAO forks set and terminates.
+func execDAOGeth(t *testing.T, datadir string, testnet bool, supportFork bool, opposeFork bool) {
+	args := []string{"--port", "0", "--maxpeers", "0", "--nodiscover", "--nat", "none", "--ipcdisable", "--datadir", datadir}
+	if testnet {
+		args = append(args, "--testnet")
+	}
+	if supportFork {
+		args = append(args, "--support-dao-fork")
+	}
+	if opposeFork {
+		args = append(args, "--oppose-dao-fork")
+	}
+	geth := runGeth(t, append(args, []string{"--exec", "2+2", "console"}...)...)
+	geth.cmd.Wait()
+}

--- a/cmd/geth/genesis_test.go
+++ b/cmd/geth/genesis_test.go
@@ -1,0 +1,105 @@
+// Copyright 2016 The go-ethereum Authors
+// This file is part of go-ethereum.
+//
+// go-ethereum is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// go-ethereum is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with go-ethereum. If not, see <http://www.gnu.org/licenses/>.
+
+package main
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+var customGenesisTests = []struct {
+	genesis string
+	query   string
+	result  string
+}{
+	// Plain genesis file without anything extra
+	{
+		genesis: `{
+			"alloc"      : {},
+			"coinbase"   : "0x0000000000000000000000000000000000000000",
+			"difficulty" : "0x20000",
+			"extraData"  : "",
+			"gasLimit"   : "0x2fefd8",
+			"nonce"      : "0x0000000000000042",
+			"mixhash"    : "0x0000000000000000000000000000000000000000000000000000000000000000",
+			"parentHash" : "0x0000000000000000000000000000000000000000000000000000000000000000",
+			"timestamp"  : "0x00"
+		}`,
+		query:  "eth.getBlock(0).nonce",
+		result: "0x0000000000000042",
+	},
+	// Genesis file with an empty chain configuration (ensure missing fields work)
+	{
+		genesis: `{
+			"alloc"      : {},
+			"coinbase"   : "0x0000000000000000000000000000000000000000",
+			"difficulty" : "0x20000",
+			"extraData"  : "",
+			"gasLimit"   : "0x2fefd8",
+			"nonce"      : "0x0000000000000042",
+			"mixhash"    : "0x0000000000000000000000000000000000000000000000000000000000000000",
+			"parentHash" : "0x0000000000000000000000000000000000000000000000000000000000000000",
+			"timestamp"  : "0x00",
+			"config"     : {}
+		}`,
+		query:  "eth.getBlock(0).nonce",
+		result: "0x0000000000000042",
+	},
+	// Genesis file with specific chain configurations
+	{
+		genesis: `{
+			"alloc"      : {},
+			"coinbase"   : "0x0000000000000000000000000000000000000000",
+			"difficulty" : "0x20000",
+			"extraData"  : "",
+			"gasLimit"   : "0x2fefd8",
+			"nonce"      : "0x0000000000000042",
+			"mixhash"    : "0x0000000000000000000000000000000000000000000000000000000000000000",
+			"parentHash" : "0x0000000000000000000000000000000000000000000000000000000000000000",
+			"timestamp"  : "0x00",
+			"config"     : {
+				"homesteadBlock" : 314,
+			},
+		}`,
+		query:  "eth.getBlock(0).nonce",
+		result: "0x0000000000000042",
+	},
+}
+
+// Tests that initializing Geth with a custom genesis block and chain definitions
+// work properly.
+func TestCustomGenesis(t *testing.T) {
+	for i, tt := range customGenesisTests {
+		// Create a temporary data directory to use and inspect later
+		datadir := tmpdir(t)
+		defer os.RemoveAll(datadir)
+
+		// Initialize the data directory with the custom genesis block
+		json := filepath.Join(datadir, "genesis.json")
+		if err := ioutil.WriteFile(json, []byte(tt.genesis), 0600); err != nil {
+			t.Fatalf("test %d: failed to write genesis file: %v", i, err)
+		}
+		runGeth(t, "--datadir", datadir, "init", json).cmd.Wait()
+
+		// Query the custom genesis block
+		geth := runGeth(t, "--datadir", datadir, "--maxpeers", "0", "--nodiscover", "--nat", "none", "--ipcdisable", "--exec", tt.query, "console")
+		geth.expectRegexp(tt.result)
+		geth.expectExit()
+	}
+}

--- a/cmd/geth/genesis_test.go
+++ b/cmd/geth/genesis_test.go
@@ -75,6 +75,7 @@ var customGenesisTests = []struct {
 			"timestamp"  : "0x00",
 			"config"     : {
 				"homesteadBlock" : 314,
+				"daoForkBlock"   : 141
 			},
 		}`,
 		query:  "eth.getBlock(0).nonce",

--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -150,7 +150,6 @@ participating.
 		utils.IdentityFlag,
 		utils.UnlockedAccountFlag,
 		utils.PasswordFileFlag,
-		utils.GenesisFileFlag,
 		utils.BootnodesFlag,
 		utils.DataDirFlag,
 		utils.KeyStoreDirFlag,
@@ -165,6 +164,8 @@ participating.
 		utils.MaxPendingPeersFlag,
 		utils.EtherbaseFlag,
 		utils.GasPriceFlag,
+		utils.SupportDAOFork,
+		utils.OpposeDAOFork,
 		utils.MinerThreadsFlag,
 		utils.MiningEnabledFlag,
 		utils.MiningGPUFlag,
@@ -225,12 +226,6 @@ participating.
 		eth.EnableBadBlockReporting = true
 
 		utils.SetupNetwork(ctx)
-
-		// Deprecation warning.
-		if ctx.GlobalIsSet(utils.GenesisFileFlag.Name) {
-			common.PrintDepricationWarning("--genesis is deprecated. Switch to use 'geth init /path/to/file'")
-		}
-
 		return nil
 	}
 

--- a/cmd/geth/usage.go
+++ b/cmd/geth/usage.go
@@ -68,7 +68,6 @@ var AppHelpFlagGroups = []flagGroup{
 			utils.OlympicFlag,
 			utils.TestNetFlag,
 			utils.DevModeFlag,
-			utils.GenesisFileFlag,
 			utils.IdentityFlag,
 			utils.FastSyncFlag,
 			utils.LightKDFFlag,

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -126,10 +126,6 @@ var (
 		Name:  "dev",
 		Usage: "Developer mode: pre-configured private network with several debugging flags",
 	}
-	GenesisFileFlag = cli.StringFlag{
-		Name:  "genesis",
-		Usage: "Insert/overwrite the genesis block (JSON format)",
-	}
 	IdentityFlag = cli.StringFlag{
 		Name:  "identity",
 		Usage: "Custom node name",
@@ -160,6 +156,15 @@ var (
 	LightKDFFlag = cli.BoolFlag{
 		Name:  "lightkdf",
 		Usage: "Reduce key-derivation RAM & CPU usage at some expense of KDF strength",
+	}
+	// Fork settings
+	SupportDAOFork = cli.BoolFlag{
+		Name:  "support-dao-fork",
+		Usage: "Updates the chain rules to support the DAO hard-fork",
+	}
+	OpposeDAOFork = cli.BoolFlag{
+		Name:  "oppose-dao-fork",
+		Usage: "Updates the chain rules to oppose the DAO hard-fork",
 	}
 	// Miner settings
 	// TODO: refactor CPU vs GPU mining flags
@@ -534,20 +539,6 @@ func MakeWSRpcHost(ctx *cli.Context) string {
 	return ctx.GlobalString(WSListenAddrFlag.Name)
 }
 
-// MakeGenesisBlock loads up a genesis block from an input file specified in the
-// command line, or returns the empty string if none set.
-func MakeGenesisBlock(ctx *cli.Context) string {
-	genesis := ctx.GlobalString(GenesisFileFlag.Name)
-	if genesis == "" {
-		return ""
-	}
-	data, err := ioutil.ReadFile(genesis)
-	if err != nil {
-		Fatalf("Failed to load custom genesis file: %v", err)
-	}
-	return string(data)
-}
-
 // MakeDatabaseHandles raises out the number of allowed file handles per process
 // for Geth and returns half of the allowance to assign to the database.
 func MakeDatabaseHandles() int {
@@ -689,7 +680,6 @@ func MakeSystemNode(name, version string, relconf release.Config, extra []byte, 
 
 	ethConf := &eth.Config{
 		ChainConfig:             MustMakeChainConfig(ctx),
-		Genesis:                 MakeGenesisBlock(ctx),
 		FastSync:                ctx.GlobalBool(FastSyncFlag.Name),
 		BlockChainVersion:       ctx.GlobalInt(BlockchainVersionFlag.Name),
 		DatabaseCache:           ctx.GlobalInt(CacheFlag.Name),
@@ -722,17 +712,13 @@ func MakeSystemNode(name, version string, relconf release.Config, extra []byte, 
 		if !ctx.GlobalIsSet(NetworkIdFlag.Name) {
 			ethConf.NetworkId = 1
 		}
-		if !ctx.GlobalIsSet(GenesisFileFlag.Name) {
-			ethConf.Genesis = core.OlympicGenesisBlock()
-		}
+		ethConf.Genesis = core.OlympicGenesisBlock()
 
 	case ctx.GlobalBool(TestNetFlag.Name):
 		if !ctx.GlobalIsSet(NetworkIdFlag.Name) {
 			ethConf.NetworkId = 2
 		}
-		if !ctx.GlobalIsSet(GenesisFileFlag.Name) {
-			ethConf.Genesis = core.TestNetGenesisBlock()
-		}
+		ethConf.Genesis = core.TestNetGenesisBlock()
 		state.StartingNonce = 1048576 // (2**20)
 
 	case ctx.GlobalBool(DevModeFlag.Name):
@@ -747,9 +733,7 @@ func MakeSystemNode(name, version string, relconf release.Config, extra []byte, 
 			stackConf.ListenAddr = ":0"
 		}
 		// Override the Ethereum protocol configs
-		if !ctx.GlobalIsSet(GenesisFileFlag.Name) {
-			ethConf.Genesis = core.OlympicGenesisBlock()
-		}
+		ethConf.Genesis = core.OlympicGenesisBlock()
 		if !ctx.GlobalIsSet(GasPriceFlag.Name) {
 			ethConf.GasPrice = new(big.Int)
 		}
@@ -813,24 +797,44 @@ func MustMakeChainConfig(ctx *cli.Context) *core.ChainConfig {
 
 // MustMakeChainConfigFromDb reads the chain configuration from the given database.
 func MustMakeChainConfigFromDb(ctx *cli.Context, db ethdb.Database) *core.ChainConfig {
-	genesis := core.GetBlock(db, core.GetCanonicalHash(db, 0), 0)
-
-	if genesis != nil {
-		// Existing genesis block, use stored config if available.
+	// If the chain is already initialized, use any existing chain configs
+	if genesis := core.GetBlock(db, core.GetCanonicalHash(db, 0), 0); genesis != nil {
 		storedConfig, err := core.GetChainConfig(db, genesis.Hash())
 		if err == nil {
+			// Force override any existing configs if explicitly requested
+			switch {
+			case storedConfig.DAOForkBlock == nil && ctx.GlobalBool(SupportDAOFork.Name) && ctx.GlobalBool(TestNetFlag.Name):
+				storedConfig.DAOForkBlock = params.TestNetDAOForkBlock
+			case storedConfig.DAOForkBlock == nil && ctx.GlobalBool(SupportDAOFork.Name):
+				storedConfig.DAOForkBlock = params.MainNetDAOForkBlock
+			case ctx.GlobalBool(OpposeDAOFork.Name):
+				storedConfig.DAOForkBlock = nil
+			}
 			return storedConfig
 		} else if err != core.ChainConfigNotFoundErr {
 			Fatalf("Could not make chain configuration: %v", err)
 		}
 	}
-	var homesteadBlockNo *big.Int
+	// If the chain is uninitialized nor no configs are present, create one
+	var homesteadBlock *big.Int
 	if ctx.GlobalBool(TestNetFlag.Name) {
-		homesteadBlockNo = params.TestNetHomesteadBlock
+		homesteadBlock = params.TestNetHomesteadBlock
 	} else {
-		homesteadBlockNo = params.MainNetHomesteadBlock
+		homesteadBlock = params.MainNetHomesteadBlock
 	}
-	return &core.ChainConfig{HomesteadBlock: homesteadBlockNo}
+	var daoForkBlock *big.Int
+	switch {
+	case ctx.GlobalBool(SupportDAOFork.Name) && ctx.GlobalBool(TestNetFlag.Name):
+		daoForkBlock = params.TestNetDAOForkBlock
+	case ctx.GlobalBool(SupportDAOFork.Name):
+		daoForkBlock = params.MainNetDAOForkBlock
+	case ctx.GlobalBool(OpposeDAOFork.Name):
+		daoForkBlock = nil
+	}
+	return &core.ChainConfig{
+		HomesteadBlock: homesteadBlock,
+		DAOForkBlock:   daoForkBlock,
+	}
 }
 
 // MakeChainDatabase open an LevelDB using the flags passed to the client and will hard crash if it fails.

--- a/core/config.go
+++ b/core/config.go
@@ -31,7 +31,8 @@ var ChainConfigNotFoundErr = errors.New("ChainConfig not found") // general conf
 // that any network, identified by its genesis block, can have its own
 // set of configuration options.
 type ChainConfig struct {
-	HomesteadBlock *big.Int // homestead switch block
+	HomesteadBlock *big.Int `json:"homesteadBlock"` // homestead switch block (0 = already homestead)
+	DAOForkBlock   *big.Int `json:"daoForkBlock"`   // TheDAO hard-fork block (nil = no fork)
 
 	VmConfig vm.Config `json:"-"`
 }
@@ -41,6 +42,5 @@ func (c *ChainConfig) IsHomestead(num *big.Int) bool {
 	if num == nil {
 		return false
 	}
-
 	return num.Cmp(c.HomesteadBlock) >= 0
 }

--- a/core/config.go
+++ b/core/config.go
@@ -39,7 +39,7 @@ type ChainConfig struct {
 
 // IsHomestead returns whether num is either equal to the homestead block or greater.
 func (c *ChainConfig) IsHomestead(num *big.Int) bool {
-	if num == nil {
+	if c.HomesteadBlock == nil || num == nil {
 		return false
 	}
 	return num.Cmp(c.HomesteadBlock) >= 0

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -205,6 +205,8 @@ func New(ctx *node.ServiceContext, config *Config) (*Ethereum, error) {
 	if config.ChainConfig == nil {
 		return nil, errors.New("missing chain config")
 	}
+	core.WriteChainConfig(chainDb, genesis.Hash(), config.ChainConfig)
+
 	eth.chainConfig = config.ChainConfig
 	eth.chainConfig.VmConfig = vm.Config{
 		EnableJit: config.EnableJit,

--- a/params/util.go
+++ b/params/util.go
@@ -16,11 +16,18 @@
 
 package params
 
-import "math/big"
+import (
+	"math/big"
+
+	"github.com/ethereum/go-ethereum/common"
+)
 
 var (
-	TestNetHomesteadBlock = big.NewInt(494000)  // testnet homestead block
-	MainNetHomesteadBlock = big.NewInt(1150000) // mainnet homestead block
-	TestNetDAOForkBlock   = big.NewInt(8888888) // testnet dao hard-fork block
-	MainNetDAOForkBlock   = big.NewInt(9999999) // mainnet dao hard-fork block
+	TestNetHomesteadBlock = big.NewInt(494000)  // Testnet homestead block
+	MainNetHomesteadBlock = big.NewInt(1150000) // Mainnet homestead block
+
+	TestNetDAOForkBlock = big.NewInt(8888888)                            // Testnet dao hard-fork block
+	MainNetDAOForkBlock = big.NewInt(9999999)                            // Mainnet dao hard-fork block
+	DAOForkBlockExtra   = common.FromHex("0x64616f2d686172642d666f726b") // Block extradata to signel the fork with ("dao-hard-fork")
+	DAOForkExtraRange   = big.NewInt(10)                                 // Number of blocks to override the extradata (prevent no-fork attacks)
 )

--- a/params/util.go
+++ b/params/util.go
@@ -21,4 +21,6 @@ import "math/big"
 var (
 	TestNetHomesteadBlock = big.NewInt(494000)  // testnet homestead block
 	MainNetHomesteadBlock = big.NewInt(1150000) // mainnet homestead block
+	TestNetDAOForkBlock   = big.NewInt(8888888) // testnet dao hard-fork block
+	MainNetDAOForkBlock   = big.NewInt(9999999) // mainnet dao hard-fork block
 )


### PR DESCRIPTION
Prerequisite PRs, merge these first to get rid of duplicate commits:

 - [ ] *core: gracefully handle missing homestead block config* #2790
 - [ ] *cmd, core, eth, params: implement flags to control dao fork blocks* #2788

---

This PR modifies the miner so that if the DAO hard-fork is enabled, the fork block and `10` consecutive blocks all have `0x64616f2d686172642d666f726b` (hex for `dao-hard-fork`) as their extra-data.

This is important to allow header-only mode clients (fast sync algo, light client) to verify whether a header is indeed on the correct chain and not get duped into syncing a live alternative fork. It also helps full nodes to split the network between two forks and avoid cross network noise.

Consecutive blocks are needed to prevent any malicious miner from minting a non-forked block with the fork extra-data. Unless almost all non-forking miners are malicious, there will be a non-forking block in the first `10` that does not have the fork extra-data set, separating that chain from the forked chain.

---

This PR does not contain unit tests as out miner module wasn't written with unit tests in mind and I'd like to avoid a too invasive rewrite in such a critical time. However, this feature **is** covered by [`hive` end to end tests](https://github.com/karalabe/hive/tree/master/simulators/dao-hard-fork/extradata) with full mining.