### PR TITLE
core: solve a remote-import/local-mine data race

### DIFF
--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -771,13 +771,12 @@ func (self *BlockChain) WriteBlock(block *types.Block) (status WriteStatus, err 
 	if ptd == nil {
 		return NonStatTy, ParentError(block.ParentHash())
 	}
-
-	localTd := self.GetTd(self.currentBlock.Hash(), self.currentBlock.NumberU64())
-	externTd := new(big.Int).Add(block.Difficulty(), ptd)
-
 	// Make sure no inconsistent state is leaked during insertion
 	self.mu.Lock()
 	defer self.mu.Unlock()
+
+	localTd := self.GetTd(self.currentBlock.Hash(), self.currentBlock.NumberU64())
+	externTd := new(big.Int).Add(block.Difficulty(), ptd)
 
 	// If the total difficulty is higher than our known, add it to the canonical chain
 	// Second clause in the if statement reduces the vulnerability to selfish mining.


### PR DESCRIPTION
The `blockchain.WriteBlock` is a method used by the miner whenever it mints a new block to have it imported into the local chain. This method before acquiring the lock on the blockchain itself however retrieved the current total difficulty, for which it needed the **current block's hash**. Accessing the current block without a lock is a bit no-no, as it may concurrently be modified by a remote import.