### PR TITLE
eth/downloader: return invalid chain (peer drop) on import fails

### DIFF
--- a/eth/downloader/downloader.go
+++ b/eth/downloader/downloader.go
@@ -1859,7 +1859,7 @@ func (d *Downloader) processContent() error {
 			}
 			if err != nil {
 				glog.V(logger.Debug).Infof("Result #%d [%x…] processing failed: %v", results[index].Header.Number, results[index].Header.Hash().Bytes()[:4], err)
-				return err
+				return errInvalidChain
 			}
 			// Shift the results to the next batch
 			results = results[items:]


### PR DESCRIPTION
If block processing fails in the downloader, it is currently bubbling up that particular error up to the very top of the sync cycle. However, the sync cycle only handles downloader specific errors correctly with regards to peer drops, it doesn't know about other errors. This causes block import failures to be silently discarded as "some random unimportant error", whereas it's very important: the origin peer tried to feed us something bad that we couldn't handle.

In our current network this doesn't really happen, because there isn't a heavy bad chin present. With the DAO hard-fork on the other hand, depending on which side of the fork you're on, there will be a heavy "other" chain, the members of which we'd like to drop.

This PR changes the bubbled up error from the random error type returned from blockchain to the downloader specific `errInvalidChain`, signalling that the chain being processed is very bad and its originator peer should be dropped.

*Chalk one up for `hive`.* 