### PR TITLE
eth: cancel DAO challenge on peer drop (annoying log)

### DIFF
--- a/eth/handler.go
+++ b/eth/handler.go
@@ -295,6 +295,13 @@ func (pm *ProtocolManager) handle(p *peer) error {
 			glog.V(logger.Warn).Infof("%v: timed out DAO fork-check, dropping", p)
 			pm.removePeer(p.id)
 		})
+		// Make sure it's cleaned up if the peer dies off
+		defer func() {
+			if p.forkDrop != nil {
+				p.forkDrop.Stop()
+				p.forkDrop = nil
+			}
+		}()
 	}
 	// main loop. handle incoming messages.
 	for {


### PR DESCRIPTION
When peers are disconnected for some reason other than the DAO challenge (either locally or remotely), but the challenge is still running, after the 15 sec timeout a log will appear warning of a disconnect (of the already disconnected peer). Although it's fully harmless, it's annoying. This PR makes sure the challenge timer is aborted when the peer drops.