### PR TITLE
eth/downloader: fix #2841 spikes by block fetches

### DIFF
--- a/eth/downloader/downloader.go
+++ b/eth/downloader/downloader.go
@@ -412,6 +412,14 @@ func (d *Downloader) syncWithPeer(p *peer, hash common.Hash, td *big.Int) (err e
 		)
 
 	case p.version >= 62:
+		// essentially double check the peer-reported height. If its
+		// block at that height turns out to already be in our chain,
+		// stop search and ignore the alleged higher total difficulty
+		if d.hasBlockAndState(p.head) {
+			glog.Infof("%v: advertised a head already in our chain. Ignoring reported higher total difficulty", p)
+			return nil
+		}
+
 		// Look up the sync boundaries: the common ancestor and the target block
 		latest, err := d.fetchHeight(p)
 		if err != nil {


### PR DESCRIPTION
**Ignore a reportedly higher total difficulty when a peer's best block is already present in local chain.**

This patch fixes issues

• #2721 **geth memory leak, 'ignore' message burst** and
• #2841 **Traffic and CPU spikes by useless block fetches** 

and may address

• #2843 **Disk I/O hammering**

**It makes robust against inaccurately reported height or total difficulty coming from peers.**


#### Identified Problem

1. The issue was in the search for the latest common ancestor in a presumed split. The current geth 1.4.x relies on the peer to send a correct block height together with its total difficulty. The search for the latest common ancestor starts at the height that the peer reported as his highest, looking backwards. 

2. To that end, often 192 block headers are being requested from the peer backwards from its reported height. Presumably when the height and/or total difficulty were reported wrongly, the block at the reported height is then accepted by the local client as latest common ancestor with the peer – because it is the latest matching of the blocks that the peer was asked about, in the case that all blocks match the local chain. Which should never occur, but frequently does. 

3. Blocks after the reported height are not checked. This often goes wrong and results into waste of resources. If the _real_ latest common ancestor came _after_ the height reported by the peer, this is not detected. Likewise if the chains were in fact identical. In both cases the block at the height originally reported by the peer as best remains the official latest common ancestor in the eyes of the local client.

4. This results in all headers and bodies of all blocks being fetched beginning from that reported height forward to the actual height the peer could deliver headers for. Whatever wrong height the peer would report, block headers and bodies would be refetched from that height on, resulting in some cases into thousands of blocks being frequently refetched, as seen in #2841, only to be discarded once examined.

5. Due to the internal architecture of geth, the blocks were immediately pow-checked, creating CPU load, and likely the I/O pressure described in issue #2843 before being found to already be in the local chain, and discarded.


#### Source 

The height from which the backwards search starts is capped (ceil()) by the peers reported height at https://github.com/ethereum/go-ethereum/blob/master/eth/downloader/downloader.go#L1054

That height is being passed to findAncestor(), after coming from fetchHeight(), here https://github.com/ethereum/go-ethereum/blob/master/eth/downloader/downloader.go#L422


#### Fix 

This patch by @fjl fixes the issue but may need more thorough investigation. 

**For this fix, the block at the reported block height is compared to the local chain first. If they match, the conclusion about differing total difficulty must be assumed wrong and based on wrong reporting from the peer.**

However, we did not check whether our own total difficulty was wrong or the reported data parsed badly. We did not check whether it is always only Parity creating the problem. Yet the algorithm should be able to cope with wrong height or total difficulty claims at any rate.


#### Status

First tests show that this patch fixes the resulting bandwidth and cpu load, making a marked difference, with no observed downside. We are making further tests.


#### Patch for any 1.4.x version

Independently of this PR being improved the fix can be applied to any geth `1.4.x` release and `develop`:

[block-fetch-patch.txt](https://github.com/ethereum/go-ethereum/files/375825/block-fetch-patch.txt) (extension `txt` for github file type limitations.)

Download and apply with `git apply block-fetch-patch.txt`.