### PR TITLE
containers/docker: use docker volumes

### DIFF
--- a/containers/docker/develop-alpine/Dockerfile
+++ b/containers/docker/develop-alpine/Dockerfile
@@ -7,9 +7,12 @@ RUN \
   (cd go-ethereum && make geth)                     && \
   cp go-ethereum/build/bin/geth /geth               && \
   apk del go git make gcc musl-dev                  && \
-  rm -rf /go-ethereum && rm -rf /var/cache/apk/*
+  rm -rf /go-ethereum && rm -rf /var/cache/apk/*    && \
+  mkdir /datadir
 
 EXPOSE 8545
 EXPOSE 30303
 
-ENTRYPOINT ["/geth"]
+VOLUME /datadir
+
+ENTRYPOINT ["/geth", "--datadir=/datadir"]

--- a/containers/docker/develop-ubuntu/Dockerfile
+++ b/containers/docker/develop-ubuntu/Dockerfile
@@ -9,9 +9,10 @@ RUN apt-get update && \
     apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 923F6CA9 && \
     echo "deb http://ppa.launchpad.net/ethereum/ethereum-dev/ubuntu wily main" | tee -a /etc/apt/sources.list.d/ethereum.list && \
     apt-get update && \
-    apt-get install -q -y geth
+    apt-get install -q -y geth && \
+    mkdir /datadir
 
 EXPOSE 8545
 EXPOSE 30303
 
-ENTRYPOINT ["/usr/bin/geth"]
+ENTRYPOINT ["/usr/bin/geth", "--datadir=/datadir"]

--- a/containers/docker/master-alpine/Dockerfile
+++ b/containers/docker/master-alpine/Dockerfile
@@ -6,9 +6,12 @@ RUN \
   (cd go-ethereum && make geth)                     && \
   cp go-ethereum/build/bin/geth /geth               && \
   apk del go git make gcc musl-dev                  && \
-  rm -rf /go-ethereum && rm -rf /var/cache/apk/*
+  rm -rf /go-ethereum && rm -rf /var/cache/apk/*    && \
+  mkdir /datadir
 
 EXPOSE 8545
 EXPOSE 30303
 
-ENTRYPOINT ["/geth"]
+VOLUME /datadir
+
+ENTRYPOINT ["/geth", "--datadir=/datadir"]

--- a/containers/docker/master-ubuntu/Dockerfile
+++ b/containers/docker/master-ubuntu/Dockerfile
@@ -9,9 +9,12 @@ RUN apt-get update && \
     apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 923F6CA9 && \
     echo "deb http://ppa.launchpad.net/ethereum/ethereum/ubuntu wily main" | tee -a /etc/apt/sources.list.d/ethereum.list && \
     apt-get update && \
-    apt-get install -q -y geth
+    apt-get install -q -y geth && \
+    mkdir /datadir
 
 EXPOSE 8545
 EXPOSE 30303
 
-ENTRYPOINT ["/usr/bin/geth"]
+VOLUME /datadir
+
+ENTRYPOINT ["/usr/bin/geth", "--datadir=/datadir"]


### PR DESCRIPTION
This PR is meant for discussion only.

Is there a special reasoning why blockchain data is not persistent between container restarts?

It should be possible to define a docker volume and set the `--datadir` parameter to the path of that volume by default.

That way, there would be an option to not store the data inside the container where it will be lost on next container restart, but on the host's filesystem instead.

Storing blockchain data on the host filesystem would be optional. If no volume is defined when using `docker run`, behavior should be as before.

Example usage would be:

```
docker run --volume /path/to/datadir/on/host:/datadir ethereum/client-go
```

The change should be backward compatible, or does this break any functionality?

Documentation would need to be updated accordingly.