### PR TITLE
containers/docker: remove debug symbols from alpine docker images

### DIFF
--- a/containers/docker/develop-alpine/Dockerfile
+++ b/containers/docker/develop-alpine/Dockerfile
@@ -1,12 +1,13 @@
 FROM alpine:3.4
 
 RUN \
-  apk add --update go git make gcc musl-dev         && \
+  apk add --update go git make gcc musl-dev binutils && \
   git clone https://github.com/ethereum/go-ethereum && \
   (cd go-ethereum && git checkout develop)          && \
   (cd go-ethereum && make geth)                     && \
   cp go-ethereum/build/bin/geth /geth               && \
-  apk del go git make gcc musl-dev                  && \
+  strip /geth                                       && \
+  apk del go git make gcc musl-dev binutils         && \
   rm -rf /go-ethereum && rm -rf /var/cache/apk/*
 
 EXPOSE 8545

--- a/containers/docker/master-alpine/Dockerfile
+++ b/containers/docker/master-alpine/Dockerfile
@@ -1,11 +1,12 @@
 FROM alpine:3.4
 
 RUN \
-  apk add --update go git make gcc musl-dev         && \
+  apk add --update go git make gcc musl-dev binutils && \
   git clone https://github.com/ethereum/go-ethereum && \
   (cd go-ethereum && make geth)                     && \
   cp go-ethereum/build/bin/geth /geth               && \
-  apk del go git make gcc musl-dev                  && \
+  strip /geth                                       && \
+  apk del go git make gcc musl-dev binutils         && \
   rm -rf /go-ethereum && rm -rf /var/cache/apk/*
 
 EXPOSE 8545


### PR DESCRIPTION
Am I right to assume that one of the main intentions of the Alpine docker image is small container size, compared to the Ubuntu image?

This PR further reduces Docker Alpine container image size by removing debug symbols from the `geth` go binary.

On my machine, container size is reduced from `34.15 MB` down to `25.42 MB` for the `develop-alpine` Dockerfile.

Without these symbols, crash logs may be harder to read, but I think it is worth the tradeoff.

The commit breaks indentation of the `&& \` characters to make the diff more easily readable. I propose to fix whitespace in front of `&& \` in a separate whitespace changes only commit or to remove the whitespace altogether, as is already done in the Ubuntu Dockerfiles.

I'd also like to add some hints to the existence of the `ethereum/client-go:alpine` docker tag on the [running in Docker](https://github.com/ethereum/go-ethereum/wiki/Running-in-Docker) wiki page, later.

To speed up the `git clone` operation during `docker build`, I'd like to add `--depth=1 --branch=develop` in a separate PR.