### PR TITLE
eth, eth/downloader: better remote head tracking

### DIFF
--- a/eth/sync.go
+++ b/eth/sync.go
@@ -161,10 +161,12 @@ func (pm *ProtocolManager) synchronise(peer *peer) {
 	if peer == nil {
 		return
 	}
-	// Make sure the peer's TD is higher than our own. If not drop.
+	// Make sure the peer's TD is higher than our own
 	currentBlock := pm.blockchain.CurrentBlock()
 	td := pm.blockchain.GetTd(currentBlock.Hash(), currentBlock.NumberU64())
-	if peer.Td().Cmp(td) <= 0 {
+
+	pHead, pTd := peer.Head()
+	if pTd.Cmp(td) <= 0 {
 		return
 	}
 	// Otherwise try to sync with the downloader
@@ -172,7 +174,7 @@ func (pm *ProtocolManager) synchronise(peer *peer) {
 	if atomic.LoadUint32(&pm.fastSync) == 1 {
 		mode = downloader.FastSync
 	}
-	if err := pm.downloader.Synchronise(peer.id, peer.Head(), peer.Td(), mode); err != nil {
+	if err := pm.downloader.Synchronise(peer.id, pHead, pTd, mode); err != nil {
 		return
 	}
 	atomic.StoreUint32(&pm.synced, 1) // Mark initial sync done


### PR DESCRIPTION
Currently the downloader has a bad bug: it caches the known head of a remote peer when it connects and never updates that head (inside the downloader). This means that if after the initial sync cycle a new cycle is initiated against a long connected peer, it will start syncing assuming that ooold head, resulting in a ton of duplicate blocks being pulled, imported and ignored.

The solution is to replace the cached head with a callback (:trollface:) that can fetch the actual current head. This is somewhat complicated by the fact that in the eth protocol handler we were a bit liberal in how we set the current head. The PR also fixes this by only ever updating the head header of a remote peer when receiving a propagated block, but even then only setting it to `propagated block - 1`. This is good for a variety of reasons:

 * Peers only propagate blocks they **think** are valid (header, PoW), but they may turn out to not be. However if the remote peer **thinks** block `N` **might** be valid, then block `N-1` **surely is**. So by setting the head to `N-1` instead of `N`, it is surely a correct hash/difficulty.
 * By tracking `HEAD - 1` instead of the **potentially** real head we have a nice side effect that sync cycles are only spawned if there's a gap of two blocks between our chain and a remote chain. This works around races between propagated/announced blocks and sync cycle startups.
 * Having the head 1 lower than the potentially true one doesn't affect the downloader sync wise, as it will fetch headers until no more are returned, not capped by any field at all.
 * Also having a 1 gap shouldn't affect syncing at all, since propagated blocks will fill it in and the fetcher should also cleanly handle < 7 gaps in the chain.