### PR TITLE
containers/docker: use shallow clone of single branch

### DIFF
--- a/containers/docker/develop-alpine/Dockerfile
+++ b/containers/docker/develop-alpine/Dockerfile
@@ -1,11 +1,11 @@
 FROM alpine:3.4
 
 RUN \
-  apk add --update go git make gcc musl-dev         && \
+  apk add --update go git make gcc musl-dev && \
   git clone --depth 1 --branch develop https://github.com/ethereum/go-ethereum && \
-  (cd go-ethereum && make geth)                     && \
-  cp go-ethereum/build/bin/geth /geth               && \
-  apk del go git make gcc musl-dev                  && \
+  (cd go-ethereum && make geth) && \
+  cp go-ethereum/build/bin/geth /geth && \
+  apk del go git make gcc musl-dev && \
   rm -rf /go-ethereum && rm -rf /var/cache/apk/*
 
 EXPOSE 8545

--- a/containers/docker/develop-alpine/Dockerfile
+++ b/containers/docker/develop-alpine/Dockerfile
@@ -2,8 +2,7 @@ FROM alpine:3.4
 
 RUN \
   apk add --update go git make gcc musl-dev         && \
-  git clone https://github.com/ethereum/go-ethereum && \
-  (cd go-ethereum && git checkout develop)          && \
+  git clone --depth 1 --branch develop https://github.com/ethereum/go-ethereum && \
   (cd go-ethereum && make geth)                     && \
   cp go-ethereum/build/bin/geth /geth               && \
   apk del go git make gcc musl-dev                  && \

--- a/containers/docker/master-alpine/Dockerfile
+++ b/containers/docker/master-alpine/Dockerfile
@@ -2,7 +2,7 @@ FROM alpine:3.4
 
 RUN \
   apk add --update go git make gcc musl-dev         && \
-  git clone https://github.com/ethereum/go-ethereum && \
+  git clone --depth 1 https://github.com/ethereum/go-ethereum && \
   (cd go-ethereum && make geth)                     && \
   cp go-ethereum/build/bin/geth /geth               && \
   apk del go git make gcc musl-dev                  && \

--- a/containers/docker/master-alpine/Dockerfile
+++ b/containers/docker/master-alpine/Dockerfile
@@ -1,11 +1,11 @@
 FROM alpine:3.4
 
 RUN \
-  apk add --update go git make gcc musl-dev         && \
+  apk add --update go git make gcc musl-dev && \
   git clone --depth 1 https://github.com/ethereum/go-ethereum && \
-  (cd go-ethereum && make geth)                     && \
-  cp go-ethereum/build/bin/geth /geth               && \
-  apk del go git make gcc musl-dev                  && \
+  (cd go-ethereum && make geth) && \
+  cp go-ethereum/build/bin/geth /geth && \
+  apk del go git make gcc musl-dev && \
   rm -rf /go-ethereum && rm -rf /var/cache/apk/*
 
 EXPOSE 8545


### PR DESCRIPTION
For the the Alpine development container, add `--depth 1 --branch develop` to reduce its build time and bandwidth usage.

According to the documentation [1] this also implies `--single-branch`, stack overflow [2] seems to be a bit misleading there.

For the master branch container, only add `--depth 1`. There, `--branch` is not required as it is the default.

To make review simpler, I separated whitespace and functional changes and added a separate whitespace only commit. Advantage of putting `&& \` at the end of the line is that it requires to edit less lines of code on future edits and thus makes diffs easier to read.

References:
[1] https://git-scm.com/docs/git-clone
[2] http://stackoverflow.com/a/9920956