### PR TITLE
eth, eth/downloader: don't forward the DAO challenge header

### DIFF
--- a/eth/downloader/downloader.go
+++ b/eth/downloader/downloader.go
@@ -541,7 +541,7 @@ func (d *Downloader) fetchHeight(p *peer) (*types.Header, error) {
 // In the rare scenario when we ended up on a long reorganisation (i.e. none of
 // the head links match), we do a binary search to find the common ancestor.
 func (d *Downloader) findAncestor(p *peer, height uint64) (uint64, error) {
-	glog.V(logger.Debug).Infof("%v: looking for common ancestor", p)
+	glog.V(logger.Debug).Infof("%v: looking for common ancestor (remote height %d)", p, height)
 
 	// Figure out the valid ancestor range to prevent rewrite attacks
 	floor, ceil := int64(-1), d.headHeader().Number.Uint64()

--- a/eth/handler.go
+++ b/eth/handler.go
@@ -440,6 +440,7 @@ func (pm *ProtocolManager) handleMsg(p *peer) error {
 					return err
 				}
 				glog.V(logger.Debug).Infof("%v: verified to be on the same side of the DAO fork", p)
+				return nil
 			}
 			// Irrelevant of the fork checks, send the header to the fetcher just in case
 			headers = pm.fetcher.FilterHeaders(headers, time.Now())


### PR DESCRIPTION
When a new peer joins, it might happen that it has the best chain and we immediately try to sync with it. The first header retrieval to that effect is a `height` retrieval. However, in the mean time we are also doing the DAO challenge. The challenge code did **not** digest its header response, causing it to propagate down into the downloader, satisfying the height lookup. This caused the remote height to be set to block 1920000. Further when commencing the ancestor lookup, the first reply was the answer to the height query. This messed up the downloader causing failures, drops and ignored blocks.

This PR simply aborts processing the header it it's the DAO challenge response instead of propagating it down to the downloader unexpectedly.