### PR TITLE
eth: Support for transaction tracing with user supplied JS callbacks

### DIFF
--- a/internal/web3ext/web3ext.go
+++ b/internal/web3ext/web3ext.go
@@ -279,7 +279,8 @@ web3._extend({
 		new web3._extend.Method({
 			name: 'traceTransaction',
 			call: 'debug_traceTransaction',
-			params: 1
+			params: 2,
+			inputFormatter: [null, null]
 		})
 	],
 	properties: []


### PR DESCRIPTION
This patch adds an optional second argument to `debug.traceTransaction`, which specifies a Javascript expression. This expression is expected to evaluate to an object with 'step' and 'result' properties.

'step' is a function that takes one argument, a log object, and is called for each step of the EVM as the 
specified transaction is traced. The argument is a wrapped instance of [this Go struct](https://github.com/ethereum/go-ethereum/blob/290e851f57f5d27a1d5f0f7ad784c836e017c337/core/vm/logger.go#L54), and has all the same properties accessible to Javascript.

'result' takes no arguments, and is expected to return a JSON-serializable value to return to the RPC caller.

If the step function throws an exception or executes an illegal operation at any point, it will not be called on any further VM steps, and the error will be returned to the caller.

Note that the 'Gas', 'GasCost' and 'Stack' fields of the log struct are Golang big.Int objects, _not_ JavaScript numbers or JS bigints. As such, they have the same interface as described in [the GoDocs](https://golang.org/pkg/math/big/). Their default serialization to JSON is as a Javascript number; to serialize large numbers accurately call `.String()` on them. For convenience, `big.NewInt(x)` is provided, and will convert a uint to a Go BigInt.

Likewise, the `Op` field is represented as a byte, and can be cast to an integer with `parseInt(log.Op)`.

Usage example, returns the stack at each CALL opcode only:

`debug.traceTransaction(txhash, "{data: [], step: function(log) { if(parseInt(log.Op) == 0xf1) this.data.Add(log.Stack); }, result: function() { return this.data; }}")`