### PR TITLE
cmd/utils, node: make datadir reusable for bzzd

### DIFF
--- a/cmd/geth/consolecmd.go
+++ b/cmd/geth/consolecmd.go
@@ -107,7 +107,7 @@ func remoteConsole(ctx *cli.Context) error {
 		utils.Fatalf("Unable to attach to remote geth: %v", err)
 	}
 	config := console.Config{
-		DataDir: utils.MustMakeDataDir(ctx),
+		DataDir: utils.MakeDataDir(ctx),
 		DocRoot: ctx.GlobalString(utils.JSpathFlag.Name),
 		Client:  client,
 		Preload: utils.MakeConsolePreloads(ctx),
@@ -135,7 +135,7 @@ func remoteConsole(ctx *cli.Context) error {
 // for "geth attach" and "geth monitor" with no argument.
 func dialRPC(endpoint string) (*rpc.Client, error) {
 	if endpoint == "" {
-		endpoint = node.DefaultIPCEndpoint()
+		endpoint = node.DefaultIPCEndpoint(clientIdentifier)
 	} else if strings.HasPrefix(endpoint, "rpc:") || strings.HasPrefix(endpoint, "ipc:") {
 		// Backwards compatibility with geth < 1.5 which required
 		// these prefixes.

--- a/cmd/geth/dao_test.go
+++ b/cmd/geth/dao_test.go
@@ -195,9 +195,9 @@ func testDAOForkBlockNewChain(t *testing.T, testnet bool, genesis string, votes 
 		geth.cmd.Wait()
 	}
 	// Retrieve the DAO config flag from the database
-	path := filepath.Join(datadir, "chaindata")
+	path := filepath.Join(datadir, "geth", "chaindata")
 	if testnet && genesis == "" {
-		path = filepath.Join(datadir, "testnet", "chaindata")
+		path = filepath.Join(datadir, "testnet", "geth", "chaindata")
 	}
 	db, err := ethdb.NewLDBDatabase(path, 0, 0)
 	if err != nil {

--- a/cmd/geth/monitorcmd.go
+++ b/cmd/geth/monitorcmd.go
@@ -35,7 +35,7 @@ import (
 var (
 	monitorCommandAttachFlag = cli.StringFlag{
 		Name:  "attach",
-		Value: node.DefaultIPCEndpoint(),
+		Value: node.DefaultIPCEndpoint(clientIdentifier),
 		Usage: "API endpoint to attach to",
 	}
 	monitorCommandRowsFlag = cli.IntFlag{

--- a/cmd/gethrpctest/main.go
+++ b/cmd/gethrpctest/main.go
@@ -23,7 +23,6 @@ import (
 	"os"
 	"os/signal"
 
-	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/eth"
@@ -89,11 +88,11 @@ func MakeSystemNode(privkey string, test *tests.BlockTest) (*node.Node, error) {
 	stack, err := node.New(&node.Config{
 		UseLightweightKDF: true,
 		IPCPath:           node.DefaultIPCEndpoint(""),
-		HTTPHost:          common.DefaultHTTPHost,
-		HTTPPort:          common.DefaultHTTPPort,
+		HTTPHost:          node.DefaultHTTPHost,
+		HTTPPort:          node.DefaultHTTPPort,
 		HTTPModules:       []string{"admin", "db", "eth", "debug", "miner", "net", "shh", "txpool", "personal", "web3"},
-		WSHost:            common.DefaultWSHost,
-		WSPort:            common.DefaultWSPort,
+		WSHost:            node.DefaultWSHost,
+		WSPort:            node.DefaultWSPort,
 		WSModules:         []string{"admin", "db", "eth", "debug", "miner", "net", "shh", "txpool", "personal", "web3"},
 		NoDiscovery:       true,
 	})

--- a/cmd/gethrpctest/main.go
+++ b/cmd/gethrpctest/main.go
@@ -88,7 +88,7 @@ func MakeSystemNode(privkey string, test *tests.BlockTest) (*node.Node, error) {
 	// Create a networkless protocol stack
 	stack, err := node.New(&node.Config{
 		UseLightweightKDF: true,
-		IPCPath:           node.DefaultIPCEndpoint(),
+		IPCPath:           node.DefaultIPCEndpoint(""),
 		HTTPHost:          common.DefaultHTTPHost,
 		HTTPPort:          common.DefaultHTTPPort,
 		HTTPModules:       []string{"admin", "db", "eth", "debug", "miner", "net", "shh", "txpool", "personal", "web3"},

--- a/cmd/utils/customflags.go
+++ b/cmd/utils/customflags.go
@@ -137,9 +137,19 @@ func (self *DirectoryFlag) Set(value string) {
 // Note, it has limitations, e.g. ~someuser/tmp will not be expanded
 func expandPath(p string) string {
 	if strings.HasPrefix(p, "~/") || strings.HasPrefix(p, "~\\") {
-		if user, err := user.Current(); err == nil {
-			p = user.HomeDir + p[1:]
+		if home := homeDir(); home != "" {
+			p = home + p[1:]
 		}
 	}
 	return path.Clean(os.ExpandEnv(p))
+}
+
+func homeDir() string {
+	if home := os.Getenv("HOME"); home != "" {
+		return home
+	}
+	if usr, err := user.Current(); err == nil {
+		return usr.HomeDir
+	}
+	return ""
 }

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -105,7 +105,7 @@ var (
 	DataDirFlag = DirectoryFlag{
 		Name:  "datadir",
 		Usage: "Data directory for the databases and keystore",
-		Value: DirectoryString{common.DefaultDataDir()},
+		Value: DirectoryString{node.DefaultDataDir()},
 	}
 	KeyStoreDirFlag = DirectoryFlag{
 		Name:  "keystore",
@@ -139,7 +139,7 @@ var (
 	DocRootFlag = DirectoryFlag{
 		Name:  "docroot",
 		Usage: "Document Root for HTTPClient file scheme",
-		Value: DirectoryString{common.HomeDir()},
+		Value: DirectoryString{homeDir()},
 	}
 	CacheFlag = cli.IntFlag{
 		Name:  "cache",
@@ -245,12 +245,12 @@ var (
 	RPCListenAddrFlag = cli.StringFlag{
 		Name:  "rpcaddr",
 		Usage: "HTTP-RPC server listening interface",
-		Value: common.DefaultHTTPHost,
+		Value: node.DefaultHTTPHost,
 	}
 	RPCPortFlag = cli.IntFlag{
 		Name:  "rpcport",
 		Usage: "HTTP-RPC server listening port",
-		Value: common.DefaultHTTPPort,
+		Value: node.DefaultHTTPPort,
 	}
 	RPCCORSDomainFlag = cli.StringFlag{
 		Name:  "rpccorsdomain",
@@ -268,13 +268,13 @@ var (
 	}
 	IPCApiFlag = cli.StringFlag{
 		Name:  "ipcapi",
-		Usage: "API's offered over the IPC-RPC interface",
+		Usage: "APIs offered over the IPC-RPC interface",
 		Value: rpc.DefaultIPCApis,
 	}
 	IPCPathFlag = DirectoryFlag{
 		Name:  "ipcpath",
 		Usage: "Filename for IPC socket/pipe within the datadir (explicit paths escape it)",
-		Value: DirectoryString{common.DefaultIPCSocket},
+		Value: DirectoryString{"geth.ipc"},
 	}
 	WSEnabledFlag = cli.BoolFlag{
 		Name:  "ws",
@@ -283,12 +283,12 @@ var (
 	WSListenAddrFlag = cli.StringFlag{
 		Name:  "wsaddr",
 		Usage: "WS-RPC server listening interface",
-		Value: common.DefaultWSHost,
+		Value: node.DefaultWSHost,
 	}
 	WSPortFlag = cli.IntFlag{
 		Name:  "wsport",
 		Usage: "WS-RPC server listening port",
-		Value: common.DefaultWSPort,
+		Value: node.DefaultWSPort,
 	}
 	WSApiFlag = cli.StringFlag{
 		Name:  "wsapi",

--- a/common/path.go
+++ b/common/path.go
@@ -19,10 +19,8 @@ package common
 import (
 	"fmt"
 	"os"
-	"os/user"
 	"path/filepath"
 	"runtime"
-	"strings"
 )
 
 // MakeName creates a node name that follows the ethereum convention
@@ -30,21 +28,6 @@ import (
 // the name.
 func MakeName(name, version string) string {
 	return fmt.Sprintf("%s/v%s/%s/%s", name, version, runtime.GOOS, runtime.Version())
-}
-
-func ExpandHomePath(p string) (path string) {
-	path = p
-	sep := string(os.PathSeparator)
-
-	// Check in case of paths like "/something/~/something/"
-	if len(p) > 1 && p[:1+len(sep)] == "~"+sep {
-		usr, _ := user.Current()
-		dir := usr.HomeDir
-
-		path = strings.Replace(p, "~", dir, 1)
-	}
-
-	return
 }
 
 func FileExist(filePath string) bool {
@@ -61,14 +44,4 @@ func AbsolutePath(Datadir string, filename string) string {
 		return filename
 	}
 	return filepath.Join(Datadir, filename)
-}
-
-func HomeDir() string {
-	if home := os.Getenv("HOME"); home != "" {
-		return home
-	}
-	if usr, err := user.Current(); err == nil {
-		return usr.HomeDir
-	}
-	return ""
 }

--- a/ethdb/database.go
+++ b/ethdb/database.go
@@ -98,6 +98,11 @@ func NewLDBDatabase(file string, cache int, handles int) (*LDBDatabase, error) {
 	}, nil
 }
 
+// Path returns the path to the database directory.
+func (db *LDBDatabase) Path() string {
+	return db.fn
+}
+
 // Put puts the given key / value to the queue
 func (self *LDBDatabase) Put(key []byte, value []byte) error {
 	// Measure the database put latency, if requested

--- a/node/api.go
+++ b/node/api.go
@@ -84,7 +84,7 @@ func (api *PrivateAdminAPI) StartRPC(host *string, port *rpc.HexNumber, cors *st
 	}
 
 	if host == nil {
-		h := common.DefaultHTTPHost
+		h := DefaultHTTPHost
 		if api.node.config.HTTPHost != "" {
 			h = api.node.config.HTTPHost
 		}
@@ -133,7 +133,7 @@ func (api *PrivateAdminAPI) StartWS(host *string, port *rpc.HexNumber, allowedOr
 	}
 
 	if host == nil {
-		h := common.DefaultWSHost
+		h := DefaultWSHost
 		if api.node.config.WSHost != "" {
 			h = api.node.config.WSHost
 		}

--- a/node/api.go
+++ b/node/api.go
@@ -85,16 +85,16 @@ func (api *PrivateAdminAPI) StartRPC(host *string, port *rpc.HexNumber, cors *st
 
 	if host == nil {
 		h := common.DefaultHTTPHost
-		if api.node.httpHost != "" {
-			h = api.node.httpHost
+		if api.node.config.HTTPHost != "" {
+			h = api.node.config.HTTPHost
 		}
 		host = &h
 	}
 	if port == nil {
-		port = rpc.NewHexNumber(api.node.httpPort)
+		port = rpc.NewHexNumber(api.node.config.HTTPPort)
 	}
 	if cors == nil {
-		cors = &api.node.httpCors
+		cors = &api.node.config.HTTPCors
 	}
 
 	modules := api.node.httpWhitelist
@@ -134,19 +134,19 @@ func (api *PrivateAdminAPI) StartWS(host *string, port *rpc.HexNumber, allowedOr
 
 	if host == nil {
 		h := common.DefaultWSHost
-		if api.node.wsHost != "" {
-			h = api.node.wsHost
+		if api.node.config.WSHost != "" {
+			h = api.node.config.WSHost
 		}
 		host = &h
 	}
 	if port == nil {
-		port = rpc.NewHexNumber(api.node.wsPort)
+		port = rpc.NewHexNumber(api.node.config.WSPort)
 	}
 	if allowedOrigins == nil {
-		allowedOrigins = &api.node.wsOrigins
+		allowedOrigins = &api.node.config.WSOrigins
 	}
 
-	modules := api.node.wsWhitelist
+	modules := api.node.config.WSModules
 	if apis != nil {
 		modules = nil
 		for _, m := range strings.Split(*apis, ",") {

--- a/node/config.go
+++ b/node/config.go
@@ -201,7 +201,7 @@ func DefaultIPCEndpoint(clientIdentifier string) string {
 			panic("empty executable name")
 		}
 	}
-	config := &Config{DataDir: common.DefaultDataDir(), IPCPath: clientIdentifier + ".ipc"}
+	config := &Config{DataDir: DefaultDataDir(), IPCPath: clientIdentifier + ".ipc"}
 	return config.IPCEndpoint()
 }
 
@@ -216,7 +216,7 @@ func (c *Config) HTTPEndpoint() string {
 
 // DefaultHTTPEndpoint returns the HTTP endpoint used by default.
 func DefaultHTTPEndpoint() string {
-	config := &Config{HTTPHost: common.DefaultHTTPHost, HTTPPort: common.DefaultHTTPPort}
+	config := &Config{HTTPHost: DefaultHTTPHost, HTTPPort: DefaultHTTPPort}
 	return config.HTTPEndpoint()
 }
 
@@ -231,7 +231,7 @@ func (c *Config) WSEndpoint() string {
 
 // DefaultWSEndpoint returns the websocket endpoint used by default.
 func DefaultWSEndpoint() string {
-	config := &Config{WSHost: common.DefaultWSHost, WSPort: common.DefaultWSPort}
+	config := &Config{WSHost: DefaultWSHost, WSPort: DefaultWSPort}
 	return config.WSEndpoint()
 }
 

--- a/node/config.go
+++ b/node/config.go
@@ -18,7 +18,6 @@ package node
 
 import (
 	"crypto/ecdsa"
-	"encoding/json"
 	"fmt"
 	"io/ioutil"
 	"net"
@@ -48,6 +47,18 @@ var (
 // P2P network layer of a protocol stack. These values can be further extended by
 // all registered services.
 type Config struct {
+	// Name sets the instance name of the node. It must not contain the / character and is
+	// used in the devp2p node identifier. The instance name of geth is "geth". If no
+	// value is specified, the basename of the current executable is used.
+	Name string
+
+	// UserIdent, if set, is used as an additional component in the devp2p node identifier.
+	UserIdent string
+
+	// Version should be set to the version number of the program. It is used
+	// in the devp2p node identifier.
+	Version string
+
 	// DataDir is the file system folder the node should use for any data storage
 	// requirements. The configured data directory will not be directly shared with
 	// registered services, instead those can use utility methods to create/access
@@ -79,10 +90,6 @@ type Config struct {
 	// is configured, the preset one is loaded from the data dir, generating it if
 	// needed.
 	PrivateKey *ecdsa.PrivateKey
-
-	// Name sets the node name of this server. Use common.MakeName to create a name
-	// that follows existing conventions.
-	Name string
 
 	// NoDiscovery specifies whether the peer discovery mechanism should be started
 	// or not. Disabling is usually useful for protocol debugging (manual topology).
@@ -178,9 +185,23 @@ func (c *Config) IPCEndpoint() string {
 	return c.IPCPath
 }
 
+// NodeDB returns the path to the discovery node database.
+func (c *Config) NodeDB() string {
+	if c.DataDir == "" {
+		return "" // ephemeral
+	}
+	return c.resolvePath("nodes")
+}
+
 // DefaultIPCEndpoint returns the IPC path used by default.
-func DefaultIPCEndpoint() string {
-	config := &Config{DataDir: common.DefaultDataDir(), IPCPath: common.DefaultIPCSocket}
+func DefaultIPCEndpoint(clientIdentifier string) string {
+	if clientIdentifier == "" {
+		clientIdentifier = strings.TrimSuffix(filepath.Base(os.Args[0]), ".exe")
+		if clientIdentifier == "" {
+			panic("empty executable name")
+		}
+	}
+	config := &Config{DataDir: common.DefaultDataDir(), IPCPath: clientIdentifier + ".ipc"}
 	return config.IPCEndpoint()
 }
 
@@ -214,15 +235,76 @@ func DefaultWSEndpoint() string {
 	return config.WSEndpoint()
 }
 
+// NodeName returns the devp2p node identifier.
+func (c *Config) NodeName() string {
+	name := c.name()
+	// Backwards compatibility: previous versions used title-cased "Geth", keep that.
+	if name == "geth" || name == "geth-testnet" {
+		name = "Geth"
+	}
+	if c.UserIdent != "" {
+		name += "/" + c.UserIdent
+	}
+	if c.Version != "" {
+		name += "/v" + c.Version
+	}
+	name += "/" + runtime.GOOS
+	name += "/" + runtime.Version()
+	return name
+}
+
+func (c *Config) name() string {
+	if c.Name == "" {
+		progname := strings.TrimSuffix(filepath.Base(os.Args[0]), ".exe")
+		if progname == "" {
+			panic("empty executable name, set Config.Name")
+		}
+		return progname
+	}
+	return c.Name
+}
+
+// These resources are resolved differently for the "geth" and "geth-testnet" instances.
+var isOldGethResource = map[string]bool{
+	"chaindata":          true,
+	"nodes":              true,
+	"nodekey":            true,
+	"static-nodes.json":  true,
+	"trusted-nodes.json": true,
+}
+
+// resolvePath resolves path in the instance directory.
+func (c *Config) resolvePath(path string) string {
+	if filepath.IsAbs(path) {
+		return path
+	}
+	if c.DataDir == "" {
+		return ""
+	}
+	// Backwards-compatibility: ensure that data directory files created
+	// by geth 1.4 are used if they exist.
+	if c.name() == "geth" && isOldGethResource[path] {
+		oldpath := ""
+		if c.Name == "geth" {
+			oldpath = filepath.Join(c.DataDir, path)
+		}
+		if oldpath != "" && common.FileExist(oldpath) {
+			// TODO: print warning
+			return oldpath
+		}
+	}
+	return filepath.Join(c.DataDir, c.name(), path)
+}
+
 // NodeKey retrieves the currently configured private key of the node, checking
 // first any manually set key, falling back to the one found in the configured
 // data folder. If no key can be found, a new one is generated.
 func (c *Config) NodeKey() *ecdsa.PrivateKey {
-	// Use any specifically configured key
+	// Use any specifically configured key.
 	if c.PrivateKey != nil {
 		return c.PrivateKey
 	}
-	// Generate ephemeral key if no datadir is being used
+	// Generate ephemeral key if no datadir is being used.
 	if c.DataDir == "" {
 		key, err := crypto.GenerateKey()
 		if err != nil {
@@ -230,16 +312,22 @@ func (c *Config) NodeKey() *ecdsa.PrivateKey {
 		}
 		return key
 	}
-	// Fall back to persistent key from the data directory
-	keyfile := filepath.Join(c.DataDir, datadirPrivateKey)
+
+	keyfile := c.resolvePath(datadirPrivateKey)
 	if key, err := crypto.LoadECDSA(keyfile); err == nil {
 		return key
 	}
-	// No persistent key found, generate and store a new one
+	// No persistent key found, generate and store a new one.
 	key, err := crypto.GenerateKey()
 	if err != nil {
 		glog.Fatalf("Failed to generate node key: %v", err)
 	}
+	instanceDir := filepath.Join(c.DataDir, c.name())
+	if err := os.MkdirAll(instanceDir, 0700); err != nil {
+		glog.V(logger.Error).Infof("Failed to persist node key: %v", err)
+		return key
+	}
+	keyfile = filepath.Join(instanceDir, datadirPrivateKey)
 	if err := crypto.SaveECDSA(keyfile, key); err != nil {
 		glog.V(logger.Error).Infof("Failed to persist node key: %v", err)
 	}
@@ -248,12 +336,12 @@ func (c *Config) NodeKey() *ecdsa.PrivateKey {
 
 // StaticNodes returns a list of node enode URLs configured as static nodes.
 func (c *Config) StaticNodes() []*discover.Node {
-	return c.parsePersistentNodes(datadirStaticNodes)
+	return c.parsePersistentNodes(c.resolvePath(datadirStaticNodes))
 }
 
 // TrusterNodes returns a list of node enode URLs configured as trusted nodes.
 func (c *Config) TrusterNodes() []*discover.Node {
-	return c.parsePersistentNodes(datadirTrustedNodes)
+	return c.parsePersistentNodes(c.resolvePath(datadirTrustedNodes))
 }
 
 // parsePersistentNodes parses a list of discovery node URLs loaded from a .json
@@ -267,15 +355,10 @@ func (c *Config) parsePersistentNodes(file string) []*discover.Node {
 	if _, err := os.Stat(path); err != nil {
 		return nil
 	}
-	// Load the nodes from the config file
-	blob, err := ioutil.ReadFile(path)
-	if err != nil {
-		glog.V(logger.Error).Infof("Failed to access nodes: %v", err)
-		return nil
-	}
-	nodelist := []string{}
-	if err := json.Unmarshal(blob, &nodelist); err != nil {
-		glog.V(logger.Error).Infof("Failed to load nodes: %v", err)
+	// Load the nodes from the config file.
+	var nodelist []string
+	if err := common.LoadJSON(path, &nodelist); err != nil {
+		glog.V(logger.Error).Infof("Can't load node file %s: %v", path, err)
 		return nil
 	}
 	// Interpret the list as a discovery node array

--- a/node/config_test.go
+++ b/node/config_test.go
@@ -96,57 +96,55 @@ func TestIPCPathResolution(t *testing.T) {
 // ephemeral.
 func TestNodeKeyPersistency(t *testing.T) {
 	// Create a temporary folder and make sure no key is present
-	dir, err := ioutil.TempDir("", "")
+	dir, err := ioutil.TempDir("", "node-test")
 	if err != nil {
 		t.Fatalf("failed to create temporary data directory: %v", err)
 	}
 	defer os.RemoveAll(dir)
 
-	if _, err := os.Stat(filepath.Join(dir, datadirPrivateKey)); err == nil {
-		t.Fatalf("non-created node key already exists")
-	}
+	keyfile := filepath.Join(dir, "unit-test", datadirPrivateKey)
+
 	// Configure a node with a preset key and ensure it's not persisted
 	key, err := crypto.GenerateKey()
 	if err != nil {
 		t.Fatalf("failed to generate one-shot node key: %v", err)
 	}
-	if _, err := New(&Config{DataDir: dir, PrivateKey: key}); err != nil {
-		t.Fatalf("failed to create empty stack: %v", err)
-	}
-	if _, err := os.Stat(filepath.Join(dir, datadirPrivateKey)); err == nil {
+	config := &Config{Name: "unit-test", DataDir: dir, PrivateKey: key}
+	config.NodeKey()
+	if _, err := os.Stat(filepath.Join(keyfile)); err == nil {
 		t.Fatalf("one-shot node key persisted to data directory")
 	}
+
 	// Configure a node with no preset key and ensure it is persisted this time
-	if _, err := New(&Config{DataDir: dir}); err != nil {
-		t.Fatalf("failed to create newly keyed stack: %v", err)
-	}
-	if _, err := os.Stat(filepath.Join(dir, datadirPrivateKey)); err != nil {
+	config = &Config{Name: "unit-test", DataDir: dir}
+	config.NodeKey()
+	if _, err := os.Stat(keyfile); err != nil {
 		t.Fatalf("node key not persisted to data directory: %v", err)
 	}
-	key, err = crypto.LoadECDSA(filepath.Join(dir, datadirPrivateKey))
+	key, err = crypto.LoadECDSA(keyfile)
 	if err != nil {
 		t.Fatalf("failed to load freshly persisted node key: %v", err)
 	}
-	blob1, err := ioutil.ReadFile(filepath.Join(dir, datadirPrivateKey))
+	blob1, err := ioutil.ReadFile(keyfile)
 	if err != nil {
 		t.Fatalf("failed to read freshly persisted node key: %v", err)
 	}
+
 	// Configure a new node and ensure the previously persisted key is loaded
-	if _, err := New(&Config{DataDir: dir}); err != nil {
-		t.Fatalf("failed to create previously keyed stack: %v", err)
-	}
-	blob2, err := ioutil.ReadFile(filepath.Join(dir, datadirPrivateKey))
+	config = &Config{Name: "unit-test", DataDir: dir}
+	config.NodeKey()
+	blob2, err := ioutil.ReadFile(filepath.Join(keyfile))
 	if err != nil {
 		t.Fatalf("failed to read previously persisted node key: %v", err)
 	}
 	if bytes.Compare(blob1, blob2) != 0 {
 		t.Fatalf("persisted node key mismatch: have %x, want %x", blob2, blob1)
 	}
+
 	// Configure ephemeral node and ensure no key is dumped locally
-	if _, err := New(&Config{DataDir: ""}); err != nil {
-		t.Fatalf("failed to create ephemeral stack: %v", err)
-	}
-	if _, err := os.Stat(filepath.Join(".", datadirPrivateKey)); err == nil {
+	config = &Config{Name: "unit-test", DataDir: ""}
+	config.NodeKey()
+	if _, err := os.Stat(filepath.Join(".", "unit-test", datadirPrivateKey)); err == nil {
 		t.Fatalf("ephemeral node key persisted to disk")
 	}
 }

--- a/node/defaults.go
+++ b/node/defaults.go
@@ -14,9 +14,11 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
 
-package common
+package node
 
 import (
+	"os"
+	"os/user"
 	"path/filepath"
 	"runtime"
 )
@@ -33,7 +35,7 @@ const (
 // persistence requirements.
 func DefaultDataDir() string {
 	// Try to place the data folder in the user's home dir
-	home := HomeDir()
+	home := homeDir()
 	if home != "" {
 		if runtime.GOOS == "darwin" {
 			return filepath.Join(home, "Library", "Ethereum")
@@ -44,5 +46,15 @@ func DefaultDataDir() string {
 		}
 	}
 	// As we cannot guess a stable location, return empty and handle later
+	return ""
+}
+
+func homeDir() string {
+	if home := os.Getenv("HOME"); home != "" {
+		return home
+	}
+	if usr, err := user.Current(); err == nil {
+		return usr.HomeDir
+	}
 	return ""
 }

--- a/node/doc.go
+++ b/node/doc.go
@@ -1,0 +1,90 @@
+// Copyright 2016 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+/*
+Package node sets up multi-protocol Ethereum nodes.
+
+In the model exposed by this package, a node is a collection of services which use shared
+resources to provide RPC APIs. Services can also offer devp2p protocols, which are wired
+up to the devp2p network when the node instance is started.
+
+
+Resources Managed By Node
+
+All file-system resources used by a node instance are located in a directory called the
+data directory. The location of each resource can be overridden through additional node
+configuration. The data directory is optional. If it is not set and the location of a
+resource is otherwise unspecified, package node will create the resource in memory.
+
+To access to the devp2p network, Node configures and starts p2p.Server. Each host on the
+devp2p network has a unique identifier, the node key. The Node instance persists this key
+across restarts. Node also loads static and trusted node lists and ensures that knowledge
+about other hosts is persisted.
+
+JSON-RPC servers which run HTTP, WebSocket or IPC can be started on a Node. RPC modules
+offered by registered services will be offered on those endpoints. Users can restrict any
+endpoint to a subset of RPC modules. Node itself offers the "debug", "admin" and "web3"
+modules.
+
+Service implementations can open LevelDB databases through the service context. Package
+node chooses the file system location of each database. If the node is configured to run
+without a data directory, databases are opened in memory instead.
+
+Node also creates the shared store of encrypted Ethereum account keys. Services can access
+the account manager through the service context.
+
+
+Sharing Data Directory Among Instances
+
+Multiple node instances can share a single data directory if they have distinct instance
+names (set through the Name config option). Sharing behaviour depends on the type of
+resource.
+
+devp2p-related resources (node key, static/trusted node lists, known hosts database) are
+stored in a directory with the same name as the instance. Thus, multiple node instances
+using the same data directory will store this information in different subdirectories of
+the data directory.
+
+LevelDB databases are also stored within the instance subdirectory. If multiple node
+instances use the same data directory, openening the databases with identical names will
+create one database for each instance.
+
+The account key store is shared among all node instances using the same data directory
+unless its location is changed through the KeyStoreDir configuration option.
+
+
+Data Directory Sharing Example
+
+In this exanple, two node instances named A and B are started with the same data
+directory. Mode instance A opens the database "db", node instance B opens the databases
+"db" and "db-2". The following files will be created in the data directory:
+
+   data-directory/
+        A/
+            nodekey            -- devp2p node key of instance A
+            nodes/             -- devp2p discovery knowledge database of instance A
+            db/                -- LevelDB content for "db"
+        A.ipc                  -- JSON-RPC UNIX domain socket endpoint of instance A
+        B/
+            nodekey            -- devp2p node key of node B
+            nodes/             -- devp2p discovery knowledge database of instance B
+            static-nodes.json  -- devp2p static node list of instance B
+            db/                -- LevelDB content for "db"
+            db-2/              -- LevelDB content for "db-2"
+        B.ipc                  -- JSON-RPC UNIX domain socket endpoint of instance A
+        keystore/              -- account key store, used by both instances
+*/
+package node

--- a/node/service_test.go
+++ b/node/service_test.go
@@ -38,18 +38,18 @@ func TestContextDatabases(t *testing.T) {
 		t.Fatalf("non-created database already exists")
 	}
 	// Request the opening/creation of a database and ensure it persists to disk
-	ctx := &ServiceContext{datadir: dir}
+	ctx := &ServiceContext{config: &Config{Name: "unit-test", DataDir: dir}}
 	db, err := ctx.OpenDatabase("persistent", 0, 0)
 	if err != nil {
 		t.Fatalf("failed to open persistent database: %v", err)
 	}
 	db.Close()
 
-	if _, err := os.Stat(filepath.Join(dir, "persistent")); err != nil {
+	if _, err := os.Stat(filepath.Join(dir, "unit-test", "persistent")); err != nil {
 		t.Fatalf("persistent database doesn't exists: %v", err)
 	}
 	// Request th opening/creation of an ephemeral database and ensure it's not persisted
-	ctx = &ServiceContext{datadir: ""}
+	ctx = &ServiceContext{config: &Config{DataDir: ""}}
 	db, err = ctx.OpenDatabase("ephemeral", 0, 0)
 	if err != nil {
 		t.Fatalf("failed to open ephemeral database: %v", err)

--- a/p2p/nat/nat.go
+++ b/p2p/nat/nat.go
@@ -197,11 +197,7 @@ type autodisc struct {
 
 func startautodisc(what string, doit func() Interface) Interface {
 	// TODO: monitor network configuration and rerun doit when it changes.
-	ad := &autodisc{what: what, doit: doit}
-	// Start the auto discovery as early as possible so it is already
-	// in progress when the rest of the stack calls the methods.
-	go ad.wait()
-	return ad
+	return &autodisc{what: what, doit: doit}
 }
 
 func (n *autodisc) AddMapping(protocol string, extport, intport int, name string, lifetime time.Duration) error {


### PR DESCRIPTION
This PR changes the layout for new data directories so they can be shared among geth and other programs such as bzzd.

```text
data-directory/
  bzzd/
    nodekey            -- devp2p node key used by bzzd
    nodes/             -- devp2p discovery knowledge database used by bzzd
    bzz-442332../      -- LevelDB content
  bzzd.ipc             -- JSON-RPC UNIX domain socket endpoint of bzzd 
  geth/
    nodekey            -- devp2p node key used by geth
    nodes/             -- devp2p discovery knowledge database used by geth
    static-nodes.json  -- devp2p static node list used by geth
    chaindata/         -- LevelDB content
  geth.ipc             -- JSON-RPC UNIX domain socket endpoint of geth
  keystore/            -- account key store, used by both geth and bzzd
```

Existing geth data directories are used as-is. A migration command that moves geth-related files to the "geth/" subdirectory will be added later.

This change also unifies path resolving in cmd/geth. All paths are now resolved through package node. Many commands that previously only looked at the --datadir flag now work correctly in combination with --testnet. Example:

```text
 >> ./build/bin/geth --datadir=foo --testnet removedb
/Users/fjl/foo/testnet/geth/chaindata
Remove this database? [y/N] y
Removing...
Removed in 1.958119ms
```
