### PR TITLE
SWARM: prevents stack depth attack in checkbook.sol

### DIFF
--- a/swarm/services/chequebook/contract/chequebook.sol
+++ b/swarm/services/chequebook/contract/chequebook.sol
@@ -27,9 +27,11 @@ contract chequebook is mortal {
         if(owner != ecrecover(hash, sig_v, sig_r, sig_s)) return;
         // Attempt sending the difference between the cumulative amount on the cheque
         // and the cumulative amount on the last cashed cheque to beneficiary.
-        if (beneficiary.send(amount - sent[beneficiary])) {
-            // Upon success, update the cumulative amount.
-            sent[beneficiary] = amount;
+        if (amount - sent[beneficiary] >= this.balance) {
+            if (beneficiary.send(amount - sent[beneficiary])) {
+                // Upon success, update the cumulative amount.
+                sent[beneficiary] = amount;
+            }
         } else {
             // Upon failure, punish owner for writing a bounced cheque.
             // owner.sendToDebtorsPrison();


### PR DESCRIPTION
Prevents stack depth attack in checkbook.sol

A malicious actor could cause a send to fail and the contract continues assumes the account wrote a bad check.

This is the same functionality as https://github.com/ethereum/go-ethereum/pull/2683
I Could not rebase :-/