### PR TITLE
fix to allow import of testnet blocks

### DIFF
--- a/cmd/geth/chaincmd.go
+++ b/cmd/geth/chaincmd.go
@@ -76,6 +76,9 @@ func importChain(ctx *cli.Context) error {
 	if len(ctx.Args()) != 1 {
 		utils.Fatalf("This command requires an argument.")
 	}
+	if ctx.GlobalBool(utils.TestNetFlag.Name) {
+		state.StartingNonce = 1048576 // (2**20)
+	}
 	chain, chainDb := utils.MakeChain(ctx)
 	start := time.Now()
 	err := utils.ImportChain(chain, ctx.Args().First())

--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -33,6 +33,7 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/console"
 	"github.com/ethereum/go-ethereum/core"
+	"github.com/ethereum/go-ethereum/core/state"
 	"github.com/ethereum/go-ethereum/eth"
 	"github.com/ethereum/go-ethereum/ethdb"
 	"github.com/ethereum/go-ethereum/internal/debug"
@@ -259,6 +260,10 @@ func initGenesis(ctx *cli.Context) error {
 	genesisPath := ctx.Args().First()
 	if len(genesisPath) == 0 {
 		utils.Fatalf("must supply path to genesis JSON file")
+	}
+
+	if ctx.GlobalBool(utils.TestNetFlag.Name) {
+		state.StartingNonce = 1048576 // (2**20)
 	}
 
 	chainDb, err := ethdb.NewLDBDatabase(filepath.Join(utils.MustMakeDataDir(ctx), "chaindata"), 0, 0)


### PR DESCRIPTION
As described in https://github.com/ethereum/go-ethereum/issues/2905 import of testnet blocks fails because `init` and `import` commands don't set the transaction "StartingNonce" for testnet.
In the fix I simply set the "StartingNonce" in the init and import commands functions in the same way it's done for a node start (in `MakeSystemNode`), if testnet flag is detected.

After this fix the behavior of import is this: import skips the first block so it expects the user to first load a genesis block (if blocks are from testnet or from custom blockchain, for default net it's not required). Maybe this could be changed in the future to not require the user to manually load the testnet genesis.