### PR TITLE
cmd/geth: added copyright and license information

### DIFF
--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -143,6 +143,11 @@ This is a destructive action and changes the network in which you will be
 participating.
 `,
 		},
+		{
+			Action: license,
+			Name:   "license",
+			Usage:  "displays geth's license information",
+		},
 	}
 
 	app.Flags = []cli.Flag{
@@ -405,6 +410,24 @@ func version(c *cli.Context) error {
 	fmt.Println("OS:", runtime.GOOS)
 	fmt.Printf("GOPATH=%s\n", os.Getenv("GOPATH"))
 	fmt.Printf("GOROOT=%s\n", runtime.GOROOT())
+
+	return nil
+}
+
+func license(c *cli.Context) error {
+	fmt.Println(`Geth is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+Geth is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with geth. If not, see <http://www.gnu.org/licenses/>.
+`)
 
 	return nil
 }

--- a/cmd/geth/usage.go
+++ b/cmd/geth/usage.go
@@ -30,6 +30,8 @@ import (
 var AppHelpTemplate = `NAME:
    {{.App.Name}} - {{.App.Usage}}
 
+   Copyright 2013-2016 The go-ethereum Authors
+
 USAGE:
    {{.App.HelpName}} [options]{{if .App.Commands}} command [command options]{{end}} {{if .App.ArgsUsage}}{{.App.ArgsUsage}}{{else}}[arguments...]{{end}}
    {{if .App.Version}}


### PR DESCRIPTION
As per GNU GPL requirement I've added the copyright and the license
information as a subcommand as well as a copyright notice when
displaying the help command.