### PR TITLE
cmd/utils: removed DAO oppose / support message

### DIFF
--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -800,23 +800,6 @@ func MustMakeChainConfigFromDb(ctx *cli.Context, db ethdb.Database) *core.ChainC
 	case ctx.GlobalBool(OpposeDAOFork.Name):
 		config.DAOForkSupport = false
 	}
-	// Temporarilly display a proper message so the user knows which fork its on
-	if !ctx.GlobalBool(TestNetFlag.Name) && (genesis == nil || genesis.Hash() == common.HexToHash("0xd4e56740f876aef8c010b86a40d5f56745a118d0906a34e69aec8c0db1cb8fa3")) {
-		choice := "SUPPORT"
-		if !config.DAOForkSupport {
-			choice = "OPPOSE"
-		}
-		current := fmt.Sprintf("Geth is currently configured to %s the DAO hard-fork!", choice)
-		howtoswap := fmt.Sprintf("You can change your choice prior to block #%v with --support-dao-fork or --oppose-dao-fork.", config.DAOForkBlock)
-		howtosync := fmt.Sprintf("After the hard-fork block #%v passed, changing chains requires a resync from scratch!", config.DAOForkBlock)
-		separator := strings.Repeat("-", len(howtoswap))
-
-		glog.V(logger.Warn).Info(separator)
-		glog.V(logger.Warn).Info(current)
-		glog.V(logger.Warn).Info(howtoswap)
-		glog.V(logger.Warn).Info(howtosync)
-		glog.V(logger.Warn).Info(separator)
-	}
 	return config
 }
 


### PR DESCRIPTION
This removes the DAO message; e.g.

```
I0821 23:54:26.165227 cmd/utils/flags.go:814] ------------------------------------------------------------------------------------------------
I0821 23:54:26.165246 cmd/utils/flags.go:815] Geth is currently configured to OPPOSE the DAO hard-fork!
I0821 23:54:26.165254 cmd/utils/flags.go:816] You can change your choice prior to block #1920000 with --support-dao-fork or --oppose-dao-fork.
I0821 23:54:26.165260 cmd/utils/flags.go:817] After the hard-fork block #1920000 passed, changing chains requires a resync from scratch!
I0821 23:54:26.165267 cmd/utils/flags.go:818] ------------------------------------------------------------------------------------------------
```

This does **not** remove the `--oppose-dao-fork` / `--support-dao-fork` flags.