### PR TITLE
core/vm, eth: Add support for javascript trace functions

### DIFF
--- a/core/vm/jit_test.go
+++ b/core/vm/jit_test.go
@@ -85,7 +85,7 @@ func TestCompiling(t *testing.T) {
 func TestResetInput(t *testing.T) {
 	var sender account
 
-	env := NewEnv(false, true)
+	env := NewEnv(&Config{EnableJit: true, ForceJit: true})
 	contract := NewContract(sender, sender, big.NewInt(100), big.NewInt(10000), big.NewInt(0))
 	contract.CodeAddr = &common.Address{}
 
@@ -144,7 +144,7 @@ func runVmBench(test vmBench, b *testing.B) {
 	if test.precompile && !test.forcejit {
 		NewProgram(test.code)
 	}
-	env := NewEnv(test.nojit, test.forcejit)
+	env := NewEnv(&Config{EnableJit: !test.nojit, ForceJit: test.forcejit})
 
 	b.ResetTimer()
 
@@ -166,12 +166,9 @@ type Env struct {
 	evm      *EVM
 }
 
-func NewEnv(noJit, forceJit bool) *Env {
+func NewEnv(config *Config) *Env {
 	env := &Env{gasLimit: big.NewInt(10000), depth: 0}
-	env.evm = New(env, Config{
-		EnableJit: !noJit,
-		ForceJit:  forceJit,
-	})
+	env.evm = New(env, *config)
 	return env
 }
 

--- a/core/vm/logger_test.go
+++ b/core/vm/logger_test.go
@@ -47,7 +47,7 @@ type dummyEnv struct {
 
 func newDummyEnv(ref *dummyContractRef) *dummyEnv {
 	return &dummyEnv{
-		Env: NewEnv(true, false),
+		Env: NewEnv(&Config{EnableJit: false, ForceJit: false}),
 		ref: ref,
 	}
 }
@@ -57,7 +57,7 @@ func (d dummyEnv) GetAccount(common.Address) Account {
 
 func TestStoreCapture(t *testing.T) {
 	var (
-		env      = NewEnv(true, false)
+		env      = NewEnv(&Config{EnableJit: false, ForceJit: false})
 		logger   = NewStructLogger(nil)
 		mem      = NewMemory()
 		stack    = newstack()

--- a/internal/ethapi/tracer.go
+++ b/internal/ethapi/tracer.go
@@ -1,0 +1,300 @@
+// Copyright 2016 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+package ethapi
+
+import (
+	"errors"
+	"fmt"
+	"math/big"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/vm"
+	"github.com/robertkrimen/otto"
+)
+
+// fakeBig is used to provide an interface to Javascript for 'big.NewInt'
+type fakeBig struct{}
+
+// NewInt creates a new big.Int with the specified int64 value.
+func (fb *fakeBig) NewInt(x int64) *big.Int {
+	return big.NewInt(x)
+}
+
+// OpCodeWrapper provides a JavaScript-friendly wrapper around OpCode, to convince Otto to treat it
+// as an object, instead of a number.
+type opCodeWrapper struct {
+	op vm.OpCode
+}
+
+// toNumber returns the ID of this opcode as an integer
+func (ocw *opCodeWrapper) toNumber() int {
+	return int(ocw.op)
+}
+
+// toString returns the string representation of the opcode
+func (ocw *opCodeWrapper) toString() string {
+	return ocw.op.String()
+}
+
+// isPush returns true if the op is a Push
+func (ocw *opCodeWrapper) isPush() bool {
+	return ocw.op.IsPush()
+}
+
+// toValue returns an otto.Value for the opCodeWrapper
+func (ocw *opCodeWrapper) toValue(vm *otto.Otto) otto.Value {
+	value, _ := vm.ToValue(ocw)
+	obj := value.Object()
+	obj.Set("toNumber", ocw.toNumber)
+	obj.Set("toString", ocw.toString)
+	obj.Set("isPush", ocw.isPush)
+	return value
+}
+
+// memoryWrapper provides a JS wrapper around vm.Memory
+type memoryWrapper struct {
+	memory *vm.Memory
+}
+
+// slice returns the requested range of memory as a byte slice
+func (mw *memoryWrapper) slice(begin, end int64) []byte {
+	return mw.memory.Get(begin, end-begin)
+}
+
+// getUint returns the 32 bytes at the specified address interpreted
+// as an unsigned integer
+func (mw *memoryWrapper) getUint(addr int64) *big.Int {
+	ret := big.NewInt(0)
+	ret.SetBytes(mw.memory.GetPtr(addr, 32))
+	return ret
+}
+
+// toValue returns an otto.Value for the memoryWrapper
+func (mw *memoryWrapper) toValue(vm *otto.Otto) otto.Value {
+	value, _ := vm.ToValue(mw)
+	obj := value.Object()
+	obj.Set("slice", mw.slice)
+	obj.Set("getUint", mw.getUint)
+	return value
+}
+
+// stackWrapper provides a JS wrapper around vm.Stack
+type stackWrapper struct {
+	stack *vm.Stack
+}
+
+// peek returns the nth-from-the-top element of the stack.
+func (sw *stackWrapper) peek(idx int) *big.Int {
+	return sw.stack.Data()[len(sw.stack.Data())-idx-1]
+}
+
+// length returns the length of the stack
+func (sw *stackWrapper) length() int {
+	return len(sw.stack.Data())
+}
+
+// toValue returns an otto.Value for the stackWrapper
+func (sw *stackWrapper) toValue(vm *otto.Otto) otto.Value {
+	value, _ := vm.ToValue(sw)
+	obj := value.Object()
+	obj.Set("peek", sw.peek)
+	obj.Set("length", sw.length)
+	return value
+}
+
+// dbWrapper provides a JS wrapper around vm.Database
+type dbWrapper struct {
+	db vm.Database
+}
+
+// getBalance retrieves an account's balance
+func (dw *dbWrapper) getBalance(addr common.Address) *big.Int {
+	return dw.db.GetBalance(addr)
+}
+
+// getNonce retrieves an account's nonce
+func (dw *dbWrapper) getNonce(addr common.Address) uint64 {
+	return dw.db.GetNonce(addr)
+}
+
+// getCode retrieves an account's code
+func (dw *dbWrapper) getCode(addr common.Address) []byte {
+	return dw.db.GetCode(addr)
+}
+
+// getState retrieves an account's state data for the given hash
+func (dw *dbWrapper) getState(addr common.Address, hash common.Hash) common.Hash {
+	return dw.db.GetState(addr, hash)
+}
+
+// exists returns true iff the account exists
+func (dw *dbWrapper) exists(addr common.Address) bool {
+	return dw.db.Exist(addr)
+}
+
+// toValue returns an otto.Value for the dbWrapper
+func (dw *dbWrapper) toValue(vm *otto.Otto) otto.Value {
+	value, _ := vm.ToValue(dw)
+	obj := value.Object()
+	obj.Set("getBalance", dw.getBalance)
+	obj.Set("getNonce", dw.getNonce)
+	obj.Set("getCode", dw.getCode)
+	obj.Set("getState", dw.getState)
+	obj.Set("exists", dw.exists)
+	return value
+}
+
+// JavascriptTracer provides an implementation of Tracer that evaluates a
+// Javascript function for each VM execution step.
+type JavascriptTracer struct {
+	vm          *otto.Otto             // Javascript VM instance
+	traceobj    *otto.Object           // User-supplied object to call
+	log         map[string]interface{} // (Reusable) map for the `log` arg to `step`
+	logvalue    otto.Value             // JS view of `log`
+	opcode      *opCodeWrapper         // Wrapper around the opcode
+	opcodevalue otto.Value             // JS view of 'opcode'
+	memory      *memoryWrapper         // Wrapper around the VM memory
+	memvalue    otto.Value             // JS view of `memory`
+	stack       *stackWrapper          // Wrapper around the VM stack
+	stackvalue  otto.Value             // JS view of `stack`
+	db          *dbWrapper             // Wrapper around the VM environment
+	dbvalue     otto.Value             // JS view of `db`
+	err         error                  // Error, if one has occurred
+}
+
+// NewJavascriptTracer instantiates a new JavascriptTracer instance.
+// code specifies a Javascript snippet, which must evaluate to an expression
+// returning an object with 'step' and 'result' functions.
+func NewJavascriptTracer(code string) (*JavascriptTracer, error) {
+	vm := otto.New()
+	vm.Interrupt = make(chan func(), 1)
+
+	// Set up builtins for this environment
+	vm.Set("big", &fakeBig{})
+
+	jstracer, err := vm.Object("(" + code + ")")
+	if err != nil {
+		return nil, err
+	}
+
+	// Check the required functions exist
+	step, err := jstracer.Get("step")
+	if err != nil {
+		return nil, err
+	}
+	if !step.IsFunction() {
+		return nil, fmt.Errorf("Trace object must expose a function step()")
+	}
+
+	result, err := jstracer.Get("result")
+	if err != nil {
+		return nil, err
+	}
+	if !result.IsFunction() {
+		return nil, fmt.Errorf("Trace object must expose a function result()")
+	}
+
+	// Create the persistent log object
+	log := make(map[string]interface{})
+	logvalue, _ := vm.ToValue(log)
+
+	// Create persistent wrappers for memory and stack
+	opcode := &opCodeWrapper{}
+	mem := &memoryWrapper{}
+	stack := &stackWrapper{}
+	db := &dbWrapper{}
+
+	return &JavascriptTracer{
+		vm:          vm,
+		traceobj:    jstracer,
+		log:         log,
+		logvalue:    logvalue,
+		opcode:      opcode,
+		opcodevalue: opcode.toValue(vm),
+		memory:      mem,
+		memvalue:    mem.toValue(vm),
+		stack:       stack,
+		stackvalue:  stack.toValue(vm),
+		db:          db,
+		dbvalue:     db.toValue(vm),
+		err:         nil,
+	}, nil
+}
+
+// Stop terminates execution of any JavaScript
+func (jst *JavascriptTracer) Stop(err error) {
+	jst.vm.Interrupt <- func() {
+		panic(err)
+	}
+}
+
+// callSafely executes a method on a JS object, catching any panics and
+// returning them as error objects.
+func (jst *JavascriptTracer) callSafely(method string, argumentList ...interface{}) (ret interface{}, err error) {
+	defer func() {
+		if caught := recover(); caught != nil {
+			switch caught := caught.(type) {
+			case error:
+				err = caught
+			case string:
+				err = errors.New(caught)
+			case fmt.Stringer:
+				err = errors.New(caught.String())
+			default:
+				panic(caught)
+			}
+		}
+	}()
+
+	value, err := jst.traceobj.Call(method, argumentList...)
+	ret, _ = value.Export()
+	return ret, err
+}
+
+// CaptureState implements the Tracer interface to trace a single step of VM execution
+func (jst *JavascriptTracer) CaptureState(env vm.Environment, pc uint64, op vm.OpCode, gas, cost *big.Int, memory *vm.Memory, stack *vm.Stack, contract *vm.Contract, depth int, err error) {
+	if jst.err == nil {
+		jst.opcode.op = op
+		jst.memory.memory = memory
+		jst.stack.stack = stack
+		jst.db.db = env.Db()
+
+		jst.log["pc"] = pc
+		jst.log["op"] = jst.opcodevalue
+		jst.log["gas"] = gas.Int64()
+		jst.log["gasPrice"] = cost.Int64()
+		jst.log["memory"] = jst.memvalue
+		jst.log["stack"] = jst.stackvalue
+		jst.log["depth"] = depth
+		jst.log["account"] = contract.Address()
+		jst.log["err"] = err
+
+		_, err := jst.callSafely("step", jst.logvalue, jst.dbvalue)
+		if err != nil {
+			jst.err = err
+		}
+	}
+}
+
+// GetResult calls the Javascript 'result' function and returns its value, or any accumulated error
+func (jst *JavascriptTracer) GetResult() (result interface{}, err error) {
+	if jst.err != nil {
+		return nil, jst.err
+	}
+
+	return jst.callSafely("result")
+}

--- a/internal/ethapi/tracer_test.go
+++ b/internal/ethapi/tracer_test.go
@@ -1,0 +1,186 @@
+// Copyright 2016 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+package ethapi
+
+import (
+	"errors"
+	"math/big"
+	"testing"
+	"time"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/vm"
+	"github.com/ethereum/go-ethereum/crypto"
+)
+
+type ruleSet struct{}
+
+func (self *ruleSet) IsHomestead(*big.Int) bool { return true }
+
+type Env struct {
+	gasLimit *big.Int
+	depth    int
+	evm      *vm.EVM
+}
+
+func NewEnv(config *vm.Config) *Env {
+	env := &Env{gasLimit: big.NewInt(10000), depth: 0}
+	env.evm = vm.New(env, *config)
+	return env
+}
+
+func (self *Env) RuleSet() vm.RuleSet    { return &ruleSet{} }
+func (self *Env) Vm() vm.Vm              { return self.evm }
+func (self *Env) Origin() common.Address { return common.Address{} }
+func (self *Env) BlockNumber() *big.Int  { return big.NewInt(0) }
+
+//func (self *Env) PrevHash() []byte      { return self.parent }
+func (self *Env) Coinbase() common.Address  { return common.Address{} }
+func (self *Env) MakeSnapshot() vm.Database { return nil }
+func (self *Env) SetSnapshot(vm.Database)   {}
+func (self *Env) Time() *big.Int            { return big.NewInt(time.Now().Unix()) }
+func (self *Env) Difficulty() *big.Int      { return big.NewInt(0) }
+func (self *Env) Db() vm.Database           { return nil }
+func (self *Env) GasLimit() *big.Int        { return self.gasLimit }
+func (self *Env) VmType() vm.Type           { return vm.StdVmTy }
+func (self *Env) GetHash(n uint64) common.Hash {
+	return common.BytesToHash(crypto.Keccak256([]byte(big.NewInt(int64(n)).String())))
+}
+func (self *Env) AddLog(log *vm.Log) {
+}
+func (self *Env) Depth() int     { return self.depth }
+func (self *Env) SetDepth(i int) { self.depth = i }
+func (self *Env) CanTransfer(from common.Address, balance *big.Int) bool {
+	return true
+}
+func (self *Env) Transfer(from, to vm.Account, amount *big.Int) {}
+func (self *Env) Call(caller vm.ContractRef, addr common.Address, data []byte, gas, price, value *big.Int) ([]byte, error) {
+	return nil, nil
+}
+func (self *Env) CallCode(caller vm.ContractRef, addr common.Address, data []byte, gas, price, value *big.Int) ([]byte, error) {
+	return nil, nil
+}
+func (self *Env) Create(caller vm.ContractRef, data []byte, gas, price, value *big.Int) ([]byte, common.Address, error) {
+	return nil, common.Address{}, nil
+}
+func (self *Env) DelegateCall(me vm.ContractRef, addr common.Address, data []byte, gas, price *big.Int) ([]byte, error) {
+	return nil, nil
+}
+
+type account struct{}
+
+func (account) SubBalance(amount *big.Int)                          {}
+func (account) AddBalance(amount *big.Int)                          {}
+func (account) SetAddress(common.Address)                           {}
+func (account) Value() *big.Int                                     { return nil }
+func (account) SetBalance(*big.Int)                                 {}
+func (account) SetNonce(uint64)                                     {}
+func (account) Balance() *big.Int                                   { return nil }
+func (account) Address() common.Address                             { return common.Address{} }
+func (account) ReturnGas(*big.Int, *big.Int)                        {}
+func (account) SetCode([]byte)                                      {}
+func (account) ForEachStorage(cb func(key, value common.Hash) bool) {}
+
+func runTrace(tracer *JavascriptTracer) (interface{}, error) {
+	env := NewEnv(&vm.Config{Debug: true, Tracer: tracer})
+
+	contract := vm.NewContract(account{}, account{}, big.NewInt(0), env.GasLimit(), big.NewInt(1))
+	contract.Code = []byte{byte(vm.PUSH1), 0x1, byte(vm.PUSH1), 0x1, 0x0}
+
+	_, err := env.Vm().Run(contract, []byte{})
+	if err != nil {
+		return nil, err
+	}
+
+	return tracer.GetResult()
+}
+
+func TestTracing(t *testing.T) {
+	tracer, err := NewJavascriptTracer("{count: 0, step: function() { this.count += 1; }, result: function() { return this.count; }}")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ret, err := runTrace(tracer)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	value, ok := ret.(float64)
+	if !ok {
+		t.Errorf("Expected return value to be float64, was %T", ret)
+	}
+	if value != 3 {
+		t.Errorf("Expected return value to be 3, got %v", value)
+	}
+}
+
+func TestStack(t *testing.T) {
+	tracer, err := NewJavascriptTracer("{depths: [], step: function(log) { this.depths.push(log.stack.length()); }, result: function() { return this.depths; }}")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ret, err := runTrace(tracer)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	value, ok := ret.([]int)
+	if !ok {
+		t.Errorf("Expected return value to be []int, was %T", ret)
+	}
+	if len(value) != 3 || value[0] != 0 || value[1] != 1 || value[2] != 2 {
+		t.Errorf("Expected return value to be [0 1 2], got %v", value)
+	}
+}
+
+func TestHalt(t *testing.T) {
+	timeout := errors.New("stahp")
+	tracer, err := NewJavascriptTracer("{step: function() { while(1); }, result: function() { return null; }}")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	go func() {
+		time.Sleep(1 * time.Second)
+		tracer.Stop(timeout)
+	}()
+
+	if _, err = runTrace(tracer); err != timeout {
+		t.Errorf("Expected timeout error, got %v", err)
+	}
+}
+
+func TestHaltBetweenSteps(t *testing.T) {
+	tracer, err := NewJavascriptTracer("{step: function() {}, result: function() { return null; }}")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	env := NewEnv(&vm.Config{Debug: true, Tracer: tracer})
+	contract := vm.NewContract(&account{}, &account{}, big.NewInt(0), big.NewInt(0), big.NewInt(0))
+
+	tracer.CaptureState(env, 0, 0, big.NewInt(0), big.NewInt(0), nil, nil, contract, 0, nil)
+	timeout := errors.New("stahp")
+	tracer.Stop(timeout)
+	tracer.CaptureState(env, 0, 0, big.NewInt(0), big.NewInt(0), nil, nil, contract, 0, nil)
+
+	if _, err := tracer.GetResult(); err != timeout {
+		t.Errorf("Expected timeout error, got %v", err)
+	}
+}

--- a/internal/web3ext/web3ext.go
+++ b/internal/web3ext/web3ext.go
@@ -284,7 +284,8 @@ web3._extend({
 		new web3._extend.Method({
 			name: 'traceTransaction',
 			call: 'debug_traceTransaction',
-			params: 1
+			params: 2,
+			inputFormatter: [null, null]
 		})
 	],
 	properties: []


### PR DESCRIPTION
This patch allows specifying 'tracer' in the second argument to `debug.traceTransaction`, which specifies a Javascript expression. This expression is expected to evaluate to an object with 'step' and 'result' properties. Callers may also specify 'timeout', a text expression specifying a maximum execution time for the trace function. Example:

        debug.traceTransaction(txhash, {tracer: "{steps: 0, step: function(log, db) { this.steps += 1 }, result: function() { return this.steps; }}", timeout: "1s"})

'step' is a function that takes two arguments, `log` and `db`, and is called for each step of the EVM, or when an error occurs, as the specified transaction is traced.

`log` has the following fields:

 - `pc`: Number, the current program counter
 - `op`: Object, an OpCode object representing the current opcode
 - `gas`: Number, the amount of gas remaining
 - `gasPrice`: Number, the cost in wei of each unit of gas
 - `memory`: Object, a structure representing the contract's memory space
 - `stack`: array[big.Int], the EVM execution stack
 - `depth`: The execution depth
 - `account`: The address of the account executing the current operation
 - `err`: If an error occured, information about the error

If `err` is non-null, all other fields should be ignored.

`log.op` has the following methods:

 - `isPush()` - returns true iff the opcode is a PUSHn
 - `toString()` - returns the string representation of the opcode
 - `toNumber()` - returns the opcode's number

`log.memory` has the following methods:

 - `slice(start, stop)` - returns the specified segment of memory as a byte slice
 - `length()` - returns the length of the memory

`db` has the following methods:

 - `getBalance(address)` - returns a `big.Int` with the specified account's balance
 - `getNonce(address)` - returns a Number with the specified account's nonce
 - `getCode(address)` - returns a byte slice with the code for the specified account
 - `getState(address, hash)` - returns the state value for the specified account and the specified hash
 - `exists(address)` - returns true if the specified address exists

The second function, 'result', takes no arguments, and is expected to return a JSON-serializable value to return to the RPC caller.

If the step function throws an exception or executes an illegal operation at any point, it will not be called on any further VM steps, and the error will be returned to the caller.

Note that several values are Golang big.Int objects, not JavaScript numbers or JS bigints. As such, they have the same interface as described in the godocs. Their default serialization to JSON is as a Javascript number; to serialize large numbers accurately call `.String()` on them. For convenience, `big.NewInt(x)` is provided, and will convert a uint to a Go BigInt.

Usage example, returns the stack at each CALL opcode only:

    debug.traceTransaction(txhash, {tracer: "{data: [], step: function(log) { if(log.op.String() == "CALL") this.data.Add(log.stack); }, result: function() { return this.data; }}"})