### PR TITLE
internal/ethapi: add personal_sign method

### DIFF
--- a/accounts/abi/bind/auth.go
+++ b/accounts/abi/bind/auth.go
@@ -52,7 +52,7 @@ func NewKeyedTransactor(key *ecdsa.PrivateKey) *TransactOpts {
 			if address != keyAddr {
 				return nil, errors.New("not authorized to sign this account")
 			}
-			signature, err := crypto.Sign(tx.SigHash().Bytes(), key)
+			signature, err := crypto.SignEthereum(tx.SigHash().Bytes(), key)
 			if err != nil {
 				return nil, err
 			}

--- a/common/bytes.go
+++ b/common/bytes.go
@@ -37,7 +37,7 @@ func ToHex(b []byte) string {
 
 func FromHex(s string) []byte {
 	if len(s) > 1 {
-		if s[0:2] == "0x" {
+		if s[0:2] == "0x" || s[0:2] == "0X" {
 			s = s[2:]
 		}
 		if len(s)%2 == 1 {

--- a/common/registrar/ethreg/api.go
+++ b/common/registrar/ethreg/api.go
@@ -257,7 +257,7 @@ func (be *registryAPIBackend) Transact(fromStr, toStr, nonceStr, valueStr, gasSt
 		tx = types.NewTransaction(nonce, to, value, gas, price, data)
 	}
 
-	signature, err := be.am.Sign(from, tx.SigHash().Bytes())
+	signature, err := be.am.SignEthereum(from, tx.SigHash().Bytes())
 	if err != nil {
 		return "", err
 	}

--- a/console/bridge.go
+++ b/console/bridge.go
@@ -131,19 +131,19 @@ func (b *bridge) UnlockAccount(call otto.FunctionCall) (response otto.Value) {
 // jeth.sign) with it to actually execute the RPC call.
 func (b *bridge) Sign(call otto.FunctionCall) (response otto.Value) {
 	var (
-		hash    = call.Argument(0)
+		message = call.Argument(0)
 		account = call.Argument(1)
 		passwd  = call.Argument(2)
 	)
 
-	if !hash.IsString() {
-		throwJSException("first argument must be the hash to sign")
+	if !message.IsString() {
+		throwJSException("first argument must be the message to sign")
 	}
 	if !account.IsString() {
 		throwJSException("second argument must be the account to sign with")
 	}
 
-	// if the password is not given or null ask the user, otherwise ensure it's a string
+	// if the password is not given or null ask the user and ensure password is a string
 	if passwd.IsUndefined() || passwd.IsNull() {
 		fmt.Fprintf(b.printer, "Give password for account %s\n", account)
 		if input, err := b.prompter.PromptPassword("Passphrase: "); err != nil {
@@ -157,7 +157,7 @@ func (b *bridge) Sign(call otto.FunctionCall) (response otto.Value) {
 	}
 
 	// Send the request to the backend and return
-	val, err := call.Otto.Call("jeth.sign", nil, hash, account, passwd)
+	val, err := call.Otto.Call("jeth.sign", nil, message, account, passwd)
 	if err != nil {
 		throwJSException(err.Error())
 	}

--- a/console/bridge.go
+++ b/console/bridge.go
@@ -126,6 +126,44 @@ func (b *bridge) UnlockAccount(call otto.FunctionCall) (response otto.Value) {
 	return val
 }
 
+// Sign is a wrapper around the personal.sign RPC method that uses a non-echoing password
+// prompt to aquire the passphrase and executes the original RPC method (saved in
+// jeth.sign) with it to actually execute the RPC call.
+func (b *bridge) Sign(call otto.FunctionCall) (response otto.Value) {
+	var (
+		hash    = call.Argument(0)
+		account = call.Argument(1)
+		passwd  = call.Argument(2)
+	)
+
+	if !hash.IsString() {
+		throwJSException("first argument must be the hash to sign")
+	}
+	if !account.IsString() {
+		throwJSException("second argument must be the account to sign with")
+	}
+
+	// if the password is not given or null ask the user, otherwise ensure it's a string
+	if passwd.IsUndefined() || passwd.IsNull() {
+		fmt.Fprintf(b.printer, "Give password for account %s\n", account)
+		if input, err := b.prompter.PromptPassword("Passphrase: "); err != nil {
+			throwJSException(err.Error())
+		} else {
+			passwd, _ = otto.ToValue(input)
+		}
+	}
+	if !passwd.IsString() {
+		throwJSException("third argument must be the password to unlock the account")
+	}
+
+	// Send the request to the backend and return
+	val, err := call.Otto.Call("jeth.sign", nil, hash, account, passwd)
+	if err != nil {
+		throwJSException(err.Error())
+	}
+	return val
+}
+
 // Sleep will block the console for the specified number of seconds.
 func (b *bridge) Sleep(call otto.FunctionCall) (response otto.Value) {
 	if call.Argument(0).IsNumber() {

--- a/console/console.go
+++ b/console/console.go
@@ -156,10 +156,9 @@ func (c *Console) init(preload []string) error {
 		if err != nil {
 			return err
 		}
-		// Override the unlockAccount and newAccount methods since these require user interaction.
-		// Assign the jeth.unlockAccount and jeth.newAccount in the Console the original web3 callbacks.
-		// These will be called by the jeth.* methods after they got the password from the user and send
-		// the original web3 request to the backend.
+		// Override the unlockAccount, newAccount and sign methods since these require user interaction.
+		// Assign these method in the Console the original web3 callbacks. These will be called by the jeth.*
+		// methods after they got the password from the user and send the original web3 request to the backend.
 		if obj := personal.Object(); obj != nil { // make sure the personal api is enabled over the interface
 			if _, err = c.jsre.Run(`jeth.unlockAccount = personal.unlockAccount;`); err != nil {
 				return fmt.Errorf("personal.unlockAccount: %v", err)
@@ -167,8 +166,12 @@ func (c *Console) init(preload []string) error {
 			if _, err = c.jsre.Run(`jeth.newAccount = personal.newAccount;`); err != nil {
 				return fmt.Errorf("personal.newAccount: %v", err)
 			}
+			if _, err = c.jsre.Run(`jeth.sign = personal.sign;`); err != nil {
+				return fmt.Errorf("personal.sign: %v", err)
+			}
 			obj.Set("unlockAccount", bridge.UnlockAccount)
 			obj.Set("newAccount", bridge.NewAccount)
+			obj.Set("sign", bridge.Sign)
 		}
 	}
 	// The admin.sleep and admin.sleepBlocks are offered by the console and not by the RPC layer.

--- a/core/types/block_test.go
+++ b/core/types/block_test.go
@@ -51,7 +51,7 @@ func TestBlockEncoding(t *testing.T) {
 	check("Size", block.Size(), common.StorageSize(len(blockEnc)))
 
 	tx1 := NewTransaction(0, common.HexToAddress("095e7baea6a6c7c4c2dfeb977efac326af552d87"), big.NewInt(10), big.NewInt(50000), big.NewInt(10), nil)
-	tx1, _ = tx1.WithSignature(common.Hex2Bytes("9bea4c4daac7c7c52e093e6a4c35dbbcf8856f1af7b059ba20253e70848d094f8a8fae537ce25ed8cb5af9adac3f141af69bd515bd2ba031522df09b97dd72b100"))
+	tx1, _ = tx1.WithSignature(common.Hex2Bytes("9bea4c4daac7c7c52e093e6a4c35dbbcf8856f1af7b059ba20253e70848d094f8a8fae537ce25ed8cb5af9adac3f141af69bd515bd2ba031522df09b97dd72b11b"))
 	check("len(Transactions)", len(block.Transactions()), 1)
 	check("Transactions[0].Hash", block.Transactions()[0].Hash(), tx1.Hash())
 

--- a/core/types/transaction.go
+++ b/core/types/transaction.go
@@ -244,6 +244,8 @@ func (tx *Transaction) publicKey(homestead bool) ([]byte, error) {
 	return pub, nil
 }
 
+// WithSignature returns a new transaction with the given signature.
+// This signature needs to be formatted as described in the yellow paper (v+27).
 func (tx *Transaction) WithSignature(sig []byte) (*Transaction, error) {
 	if len(sig) != 65 {
 		panic(fmt.Sprintf("wrong size for signature: got %d, want 65", len(sig)))
@@ -251,13 +253,13 @@ func (tx *Transaction) WithSignature(sig []byte) (*Transaction, error) {
 	cpy := &Transaction{data: tx.data}
 	cpy.data.R = new(big.Int).SetBytes(sig[:32])
 	cpy.data.S = new(big.Int).SetBytes(sig[32:64])
-	cpy.data.V = sig[64] + 27
+	cpy.data.V = sig[64]
 	return cpy, nil
 }
 
 func (tx *Transaction) SignECDSA(prv *ecdsa.PrivateKey) (*Transaction, error) {
 	h := tx.SigHash()
-	sig, err := crypto.Sign(h[:], prv)
+	sig, err := crypto.SignEthereum(h[:], prv)
 	if err != nil {
 		return nil, err
 	}

--- a/core/types/transaction_test.go
+++ b/core/types/transaction_test.go
@@ -46,7 +46,7 @@ var (
 		big.NewInt(1),
 		common.FromHex("5544"),
 	).WithSignature(
-		common.Hex2Bytes("98ff921201554726367d2be8c804a7ff89ccf285ebc57dff8ae4c44b9c19ac4a8887321be575c8095f789dd4c743dfe42c1820f9231f98a962b210e3ac2452a301"),
+		common.Hex2Bytes("98ff921201554726367d2be8c804a7ff89ccf285ebc57dff8ae4c44b9c19ac4a8887321be575c8095f789dd4c743dfe42c1820f9231f98a962b210e3ac2452a31c"),
 	)
 )
 

--- a/crypto/crypto.go
+++ b/crypto/crypto.go
@@ -78,12 +78,12 @@ func Ripemd160(data []byte) []byte {
 	return ripemd.Sum(nil)
 }
 
-// Ecrecover returns the public key for the private key that was used
-// to calculate the signature.
+// Ecrecover returns the public key for the private key that was used to
+// calculate the signature.
 //
 // Note: secp256k1 expects the recover id to be either 0, 1. Ethereum
 // signatures have a recover id with an offset of 27. Callers must take
-// this into account and if "recovering" an Ethereum signature adjust.
+// this into account and if "recovering" from an Ethereum signature adjust.
 func Ecrecover(hash, sig []byte) ([]byte, error) {
 	return secp256k1.RecoverPubkey(hash, sig)
 }
@@ -221,8 +221,8 @@ func Sign(data []byte, prv *ecdsa.PrivateKey) (sig []byte, err error) {
 // SignEthereum calculates an Ethereum ECDSA signature.
 // This function is susceptible to choosen plaintext attacks that can leak
 // information about the private key that is used for signing. Callers must
-// be aware that the given hash cannot be choosen by an adversery. Common
-// solution is to hash any input before calculating the signature.
+// be aware that the given hash cannot be freely choosen by an adversery.
+// Common solution is to hash the message before calculating the signature.
 func SignEthereum(data []byte, prv *ecdsa.PrivateKey) ([]byte, error) {
 	sig, err := Sign(data, prv)
 	if err != nil {

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -298,6 +298,16 @@ func (s *PrivateAccountAPI) SendTransaction(ctx context.Context, args SendTxArgs
 	return submitTransaction(ctx, s.b, tx, signature)
 }
 
+// Sign decrypts the private key associated with the given address with the given password.
+// If the key was successful decrypted the given hash is signed and the signature is returned.
+func (s *PrivateAccountAPI) Sign(ctx context.Context, hash common.Hash, addr common.Address, passwd string) (string, error) {
+	signature, err := s.b.AccountManager().SignWithPassphrase(addr, passwd, hash.Bytes())
+	if err != nil {
+		return "0x", err
+	}
+	return "0x" + hex.EncodeToString(signature), nil
+}
+
 // SignAndSendTransaction was renamed to SendTransaction. This method is deprecated
 // and will be removed in the future. It primary goal is to give clients time to update.
 func (s *PrivateAccountAPI) SignAndSendTransaction(ctx context.Context, args SendTxArgs, passwd string) (common.Hash, error) {

--- a/internal/web3ext/web3ext.go
+++ b/internal/web3ext/web3ext.go
@@ -434,6 +434,11 @@ web3._extend({
 			call: 'personal_sign',
 			params: 3,
 			inputFormatter: [null, web3._extend.formatters.inputAddressFormatter, null]
+		}),
+		new web3._extend.Method({
+			name: 'recover',
+			call: 'personal_recover',
+			params: 2
 		})
 	]
 })

--- a/internal/web3ext/web3ext.go
+++ b/internal/web3ext/web3ext.go
@@ -428,6 +428,12 @@ web3._extend({
 			call: 'personal_sendTransaction',
 			params: 2,
 			inputFormatter: [web3._extend.formatters.inputTransactionFormatter, null]
+		}),
+		new web3._extend.Method({
+			name: 'sign',
+			call: 'personal_sign',
+			params: 3,
+			inputFormatter: [null, web3._extend.formatters.inputAddressFormatter, null]
 		})
 	]
 });

--- a/internal/web3ext/web3ext.go
+++ b/internal/web3ext/web3ext.go
@@ -436,8 +436,8 @@ web3._extend({
 			inputFormatter: [null, web3._extend.formatters.inputAddressFormatter, null]
 		}),
 		new web3._extend.Method({
-			name: 'recover',
-			call: 'personal_recover',
+			name: 'ecRecover',
+			call: 'personal_ecRecover',
 			params: 2
 		})
 	]

--- a/internal/web3ext/web3ext.go
+++ b/internal/web3ext/web3ext.go
@@ -436,7 +436,7 @@ web3._extend({
 			inputFormatter: [null, web3._extend.formatters.inputAddressFormatter, null]
 		})
 	]
-});
+})
 `
 
 const RPC_JS = `


### PR DESCRIPTION
This PR includes several things:

1. the behavior of `eth_sign` is changed. It now accepts an arbitrary message, hashes it and calculates the signature of the hash (breaks backwards compatability!).
2. add `personal_sign`, same semantics as `eth_sign` but also accepts a password. The private key used to sign the hash is temporary unlocked in the scope of the request.
3. add `personal_recover`, returns the address for the account that created the signature.

`personal_recover(message, signature)`
`personal_sign(hash, address [, password])`

@alexvandesande 