### PR TITLE
rpc: format filter ID according to spec for quantities

### DIFF
--- a/rpc/utils.go
+++ b/rpc/utils.go
@@ -24,6 +24,7 @@ import (
 	"math/big"
 	"math/rand"
 	"reflect"
+	"strings"
 	"sync"
 	"time"
 	"unicode"
@@ -250,5 +251,13 @@ func NewID() ID {
 			val >>= 8
 		}
 	}
-	return ID("0x" + hex.EncodeToString(id))
+
+	rpcId := hex.EncodeToString(id)
+	// rpc ID's are RPC quantities, no leading zero's and 0 is 0x0
+	rpcId = strings.TrimLeft(rpcId, "0")
+	if rpcId == "" {
+		rpcId = "0"
+	}
+
+	return ID("0x" + rpcId)
 }

--- a/rpc/utils_test.go
+++ b/rpc/utils_test.go
@@ -1,0 +1,43 @@
+// Copyright 2016 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+package rpc
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestNewID(t *testing.T) {
+	hexchars := "0123456789ABCDEFabcdef"
+	for i := 0; i < 100; i++ {
+		id := string(NewID())
+		if !strings.HasPrefix(id, "0x") {
+			t.Fatalf("invalid ID prefix, want '0x...', got %s", id)
+		}
+
+		id = id[2:]
+		if len(id) == 0 || len(id) > 32 {
+			t.Fatalf("invalid ID length, want len(id) > 0 && len(id) <= 32), got %d", len(id))
+		}
+
+		for i := 0; i < len(id); i++ {
+			if strings.IndexByte(hexchars, id[i]) == -1 {
+				t.Fatalf("unexpected byte, want any valid hex char, got %c", id[i])
+			}
+		}
+	}
+}


### PR DESCRIPTION
As reported in https://github.com/ethereum/go-ethereum/issues/2966 the returned identifier for a new filter doesn't follow the specifications for the quantity type as described in the JSON-RPC spec.

