### PR TITLE
miner: set tx index logs

### DIFF
--- a/miner/worker.go
+++ b/miner/worker.go
@@ -561,6 +561,7 @@ func (env *Work) commitTransactions(mux *event.TypeMux, txs *types.TransactionsB
 	gp := new(core.GasPool).AddGas(env.header.GasLimit)
 
 	var coalescedLogs vm.Logs
+
 	for {
 		// Retrieve the next transaction and abort if all done
 		tx := txs.Peek()
@@ -582,7 +583,7 @@ func (env *Work) commitTransactions(mux *event.TypeMux, txs *types.TransactionsB
 			continue
 		}
 		// Start executing the transaction
-		env.state.StartRecord(tx.Hash(), common.Hash{}, 0)
+		env.state.StartRecord(tx.Hash(), common.Hash{}, env.tcount)
 
 		err, logs := env.commitTransaction(tx, bc, gp)
 		switch {


### PR DESCRIPTION
The miner creates a new state record for each transaction. One of the parameters for these records is the transaction index. Currently this index is hard coded to zero and causes all logs to have a transaction index of 0. This PR corrects this.