### PR TITLE
cmd, eth: drop the blockchain version from cli/eth configs

### DIFF
--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -133,7 +133,6 @@ participating.
 		utils.BootnodesFlag,
 		utils.DataDirFlag,
 		utils.KeyStoreDirFlag,
-		utils.BlockchainVersionFlag,
 		utils.OlympicFlag,
 		utils.FastSyncFlag,
 		utils.CacheFlag,

--- a/cmd/geth/usage.go
+++ b/cmd/geth/usage.go
@@ -74,7 +74,6 @@ var AppHelpFlagGroups = []flagGroup{
 			utils.FastSyncFlag,
 			utils.LightKDFFlag,
 			utils.CacheFlag,
-			utils.BlockchainVersionFlag,
 		},
 	},
 	{

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -146,11 +146,6 @@ var (
 		Usage: "Megabytes of memory allocated to internal caching (min 16MB / database forced)",
 		Value: 128,
 	}
-	BlockchainVersionFlag = cli.IntFlag{
-		Name:  "blockchainversion",
-		Usage: "Blockchain version (integer)",
-		Value: core.BlockChainVersion,
-	}
 	FastSyncFlag = cli.BoolFlag{
 		Name:  "fast",
 		Usage: "Enable fast syncing through state downloads",
@@ -681,7 +676,6 @@ func RegisterEthService(ctx *cli.Context, stack *node.Node, extra []byte) {
 		Etherbase:               MakeEtherbase(stack.AccountManager(), ctx),
 		ChainConfig:             MustMakeChainConfig(ctx),
 		FastSync:                ctx.GlobalBool(FastSyncFlag.Name),
-		BlockChainVersion:       ctx.GlobalInt(BlockchainVersionFlag.Name),
 		DatabaseCache:           ctx.GlobalInt(CacheFlag.Name),
 		DatabaseHandles:         MakeDatabaseHandles(),
 		NetworkId:               ctx.GlobalInt(NetworkIdFlag.Name),

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -70,7 +70,6 @@ type Config struct {
 	Genesis   string // Genesis JSON to seed the chain database with
 	FastSync  bool   // Enables the state download based fast synchronisation algorithm
 
-	BlockChainVersion  int
 	SkipBcVersionCheck bool // e.g. blockchain export
 	DatabaseCache      int
 	DatabaseHandles    int
@@ -180,10 +179,10 @@ func New(ctx *node.ServiceContext, config *Config) (*Ethereum, error) {
 
 	if !config.SkipBcVersionCheck {
 		bcVersion := core.GetBlockChainVersion(chainDb)
-		if bcVersion != config.BlockChainVersion && bcVersion != 0 {
-			return nil, fmt.Errorf("Blockchain DB version mismatch (%d / %d). Run geth upgradedb.\n", bcVersion, config.BlockChainVersion)
+		if bcVersion != core.BlockChainVersion && bcVersion != 0 {
+			return nil, fmt.Errorf("Blockchain DB version mismatch (%d / %d). Run geth upgradedb.\n", bcVersion, core.BlockChainVersion)
 		}
-		core.WriteBlockChainVersion(chainDb, config.BlockChainVersion)
+		core.WriteBlockChainVersion(chainDb, core.BlockChainVersion)
 	}
 
 	// load the genesis block or write a new one if no genesis


### PR DESCRIPTION
Currently `eth` takes as a config parameter the blockchain version. This doesn't make much sense, since the entire `eth` and `core` are version specific. There's no possibility to use anything different. This PR removes this configurability from the CLI flags and `eth.Config`, instead using the `core.BlockChainVersion` constant.