### PR TITLE
light: fix memory expansion bug (same as fix for core/state)

### DIFF
--- a/light/state.go
+++ b/light/state.go
@@ -261,7 +261,9 @@ func (self *LightState) Copy() *LightState {
 	state := NewLightState(common.Hash{}, self.odr)
 	state.trie = self.trie
 	for k, stateObject := range self.stateObjects {
-		state.stateObjects[k] = stateObject.Copy()
+		if stateObject.dirty {
+			state.stateObjects[k] = stateObject.Copy()
+		}
 	}
 
 	return state

--- a/light/state_object.go
+++ b/light/state_object.go
@@ -186,7 +186,7 @@ func (self *StateObject) Copy() *StateObject {
 	stateObject.codeHash = common.CopyBytes(self.codeHash)
 	stateObject.nonce = self.nonce
 	stateObject.trie = self.trie
-	stateObject.code = common.CopyBytes(self.code)
+	stateObject.code = self.code
 	stateObject.storage = self.storage.Copy()
 	stateObject.remove = self.remove
 	stateObject.dirty = self.dirty


### PR DESCRIPTION
same fix as https://github.com/ethereum/go-ethereum/pull/3007 for package `light`