### PR TITLE
ethclient: bugfix retrieving logs

### DIFF
--- a/ethclient/ethclient.go
+++ b/ethclient/ethclient.go
@@ -269,7 +269,7 @@ func (ec *Client) NonceAt(ctx context.Context, account common.Address, blockNumb
 // FilterLogs executes a filter query.
 func (ec *Client) FilterLogs(ctx context.Context, q ethereum.FilterQuery) ([]vm.Log, error) {
 	var result []vm.Log
-	err := ec.c.CallContext(ctx, &result, "eth_getFilterLogs", toFilterArg(q))
+	err := ec.c.CallContext(ctx, &result, "eth_getLogs", toFilterArg(q))
 	return result, err
 }
 
@@ -281,7 +281,7 @@ func (ec *Client) SubscribeFilterLogs(ctx context.Context, q ethereum.FilterQuer
 func toFilterArg(q ethereum.FilterQuery) interface{} {
 	arg := map[string]interface{}{
 		"fromBlock": toBlockNumArg(q.FromBlock),
-		"endBlock":  toBlockNumArg(q.ToBlock),
+		"toBlock":   toBlockNumArg(q.ToBlock),
 		"addresses": q.Addresses,
 		"topics":    q.Topics,
 	}


### PR DESCRIPTION
This PR fixes 2 issues:

1. Ethclient used `eth_getFilterLogs` that [accepts](https://github.com/ethereum/wiki/wiki/JSON-RPC#eth_getfilterlogs) a filter identifier. In this case ethclient should use `eth_Logs` which [accepts](https://github.com/ethereum/wiki/wiki/JSON-RPC#eth_getlogs) criteria.
2. ethclient used `endBlock` instead of `toBlock`.


Fixes https://github.com/ethereum/go-ethereum/issues/3001