### PR TITLE
core/state: track all accounts in canon state

### DIFF
--- a/accounts/abi/bind/backends/simulated.go
+++ b/accounts/abi/bind/backends/simulated.go
@@ -135,11 +135,8 @@ func (b *SimulatedBackend) StorageAt(ctx context.Context, contract common.Addres
 		return nil, errBlockNumberUnsupported
 	}
 	statedb, _ := b.blockchain.State()
-	if obj := statedb.GetStateObject(contract); obj != nil {
-		val := obj.GetState(key)
-		return val[:], nil
-	}
-	return nil, nil
+	val := statedb.GetState(contract, key)
+	return val[:], nil
 }
 
 // TransactionReceipt returns the receipt of a transaction.

--- a/core/state/dump.go
+++ b/core/state/dump.go
@@ -50,15 +50,15 @@ func (self *StateDB) RawDump() World {
 		if err != nil {
 			panic(err)
 		}
-
 		account := Account{
-			Balance:  stateObject.balance.String(),
-			Nonce:    stateObject.nonce,
-			Root:     common.Bytes2Hex(stateObject.Root()),
-			CodeHash: common.Bytes2Hex(stateObject.codeHash),
-			Code:     common.Bytes2Hex(stateObject.Code()),
+			Balance:  stateObject.Balance().String(),
+			Nonce:    stateObject.Nonce(),
+			Root:     common.Bytes2Hex(stateObject.data.Root[:]),
+			CodeHash: common.Bytes2Hex(stateObject.CodeHash()),
+			Code:     common.Bytes2Hex(stateObject.Code(self.db)),
 			Storage:  make(map[string]string),
 		}
+		stateObject.initTrie(self.db)
 		storageIt := stateObject.trie.Iterator()
 		for storageIt.Next() {
 			account.Storage[common.Bytes2Hex(self.trie.GetKey(storageIt.Key))] = common.Bytes2Hex(storageIt.Value)
@@ -75,13 +75,4 @@ func (self *StateDB) Dump() []byte {
 	}
 
 	return json
-}
-
-// Debug stuff
-func (self *StateObject) CreateOutputForDiff() {
-	fmt.Printf("%x %x %x %x\n", self.Address(), self.Root(), self.balance.Bytes(), self.nonce)
-	it := self.trie.Iterator()
-	for it.Next() {
-		fmt.Printf("%x %x\n", it.Key, it.Value)
-	}
 }

--- a/core/state/dump.go
+++ b/core/state/dump.go
@@ -23,7 +23,7 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 )
 
-type Account struct {
+type DumpAccount struct {
 	Balance  string            `json:"balance"`
 	Nonce    uint64            `json:"nonce"`
 	Root     string            `json:"root"`
@@ -32,15 +32,15 @@ type Account struct {
 	Storage  map[string]string `json:"storage"`
 }
 
-type World struct {
-	Root     string             `json:"root"`
-	Accounts map[string]Account `json:"accounts"`
+type Dump struct {
+	Root     string                 `json:"root"`
+	Accounts map[string]DumpAccount `json:"accounts"`
 }
 
-func (self *StateDB) RawDump() World {
-	world := World{
+func (self *StateDB) RawDump() Dump {
+	dump := Dump{
 		Root:     common.Bytes2Hex(self.trie.Root()),
-		Accounts: make(map[string]Account),
+		Accounts: make(map[string]DumpAccount),
 	}
 
 	it := self.trie.Iterator()
@@ -50,7 +50,7 @@ func (self *StateDB) RawDump() World {
 		if err != nil {
 			panic(err)
 		}
-		account := Account{
+		account := DumpAccount{
 			Balance:  stateObject.Balance().String(),
 			Nonce:    stateObject.Nonce(),
 			Root:     common.Bytes2Hex(stateObject.data.Root[:]),
@@ -63,9 +63,9 @@ func (self *StateDB) RawDump() World {
 		for storageIt.Next() {
 			account.Storage[common.Bytes2Hex(self.trie.GetKey(storageIt.Key))] = common.Bytes2Hex(storageIt.Value)
 		}
-		world.Accounts[common.Bytes2Hex(addr)] = account
+		dump.Accounts[common.Bytes2Hex(addr)] = account
 	}
-	return world
+	return dump
 }
 
 func (self *StateDB) Dump() []byte {

--- a/core/state/managed_state.go
+++ b/core/state/managed_state.go
@@ -127,7 +127,7 @@ func (ms *ManagedState) getAccount(addr common.Address) *account {
 		// Always make sure the state account nonce isn't actually higher
 		// than the tracked one.
 		so := ms.StateDB.GetStateObject(addr)
-		if so != nil && uint64(len(account.nonces))+account.nstart < so.nonce {
+		if so != nil && uint64(len(account.nonces))+account.nstart < so.Nonce() {
 			ms.accounts[addr] = newAccount(so)
 		}
 
@@ -137,5 +137,5 @@ func (ms *ManagedState) getAccount(addr common.Address) *account {
 }
 
 func newAccount(so *StateObject) *account {
-	return &account{so, so.nonce, nil}
+	return &account{so, so.Nonce(), nil}
 }

--- a/core/state/managed_state.go
+++ b/core/state/managed_state.go
@@ -33,14 +33,14 @@ type ManagedState struct {
 
 	mu sync.RWMutex
 
-	accounts map[string]*account
+	accounts map[common.Address]*account
 }
 
 // ManagedState returns a new managed state with the statedb as it's backing layer
 func ManageState(statedb *StateDB) *ManagedState {
 	return &ManagedState{
 		StateDB:  statedb.Copy(),
-		accounts: make(map[string]*account),
+		accounts: make(map[common.Address]*account),
 	}
 }
 
@@ -103,7 +103,7 @@ func (ms *ManagedState) SetNonce(addr common.Address, nonce uint64) {
 	so := ms.GetOrNewStateObject(addr)
 	so.SetNonce(nonce)
 
-	ms.accounts[addr.Str()] = newAccount(so)
+	ms.accounts[addr] = newAccount(so)
 }
 
 // HasAccount returns whether the given address is managed or not
@@ -114,27 +114,26 @@ func (ms *ManagedState) HasAccount(addr common.Address) bool {
 }
 
 func (ms *ManagedState) hasAccount(addr common.Address) bool {
-	_, ok := ms.accounts[addr.Str()]
+	_, ok := ms.accounts[addr]
 	return ok
 }
 
 // populate the managed state
 func (ms *ManagedState) getAccount(addr common.Address) *account {
-	straddr := addr.Str()
-	if account, ok := ms.accounts[straddr]; !ok {
+	if account, ok := ms.accounts[addr]; !ok {
 		so := ms.GetOrNewStateObject(addr)
-		ms.accounts[straddr] = newAccount(so)
+		ms.accounts[addr] = newAccount(so)
 	} else {
 		// Always make sure the state account nonce isn't actually higher
 		// than the tracked one.
 		so := ms.StateDB.GetStateObject(addr)
 		if so != nil && uint64(len(account.nonces))+account.nstart < so.nonce {
-			ms.accounts[straddr] = newAccount(so)
+			ms.accounts[addr] = newAccount(so)
 		}
 
 	}
 
-	return ms.accounts[straddr]
+	return ms.accounts[addr]
 }
 
 func newAccount(so *StateObject) *account {

--- a/core/state/managed_state_test.go
+++ b/core/state/managed_state_test.go
@@ -30,10 +30,10 @@ func create() (*ManagedState, *account) {
 	statedb, _ := New(common.Hash{}, db)
 	ms := ManageState(statedb)
 	so := &StateObject{address: addr, nonce: 100}
-	ms.StateDB.stateObjects[addr.Str()] = so
-	ms.accounts[addr.Str()] = newAccount(so)
+	ms.StateDB.stateObjects[addr] = so
+	ms.accounts[addr] = newAccount(so)
 
-	return ms, ms.accounts[addr.Str()]
+	return ms, ms.accounts[addr]
 }
 
 func TestNewNonce(t *testing.T) {
@@ -92,7 +92,7 @@ func TestRemoteNonceChange(t *testing.T) {
 	account.nonces = append(account.nonces, nn...)
 	nonce := ms.NewNonce(addr)
 
-	ms.StateDB.stateObjects[addr.Str()].nonce = 200
+	ms.StateDB.stateObjects[addr].nonce = 200
 	nonce = ms.NewNonce(addr)
 	if nonce != 200 {
 		t.Error("expected nonce after remote update to be", 201, "got", nonce)
@@ -100,7 +100,7 @@ func TestRemoteNonceChange(t *testing.T) {
 	ms.NewNonce(addr)
 	ms.NewNonce(addr)
 	ms.NewNonce(addr)
-	ms.StateDB.stateObjects[addr.Str()].nonce = 200
+	ms.StateDB.stateObjects[addr].nonce = 200
 	nonce = ms.NewNonce(addr)
 	if nonce != 204 {
 		t.Error("expected nonce after remote update to be", 201, "got", nonce)

--- a/core/state/managed_state_test.go
+++ b/core/state/managed_state_test.go
@@ -29,7 +29,8 @@ func create() (*ManagedState, *account) {
 	db, _ := ethdb.NewMemDatabase()
 	statedb, _ := New(common.Hash{}, db)
 	ms := ManageState(statedb)
-	so := &StateObject{address: addr, nonce: 100}
+	so := &StateObject{address: addr}
+	so.SetNonce(100)
 	ms.StateDB.stateObjects[addr] = so
 	ms.accounts[addr] = newAccount(so)
 
@@ -92,7 +93,7 @@ func TestRemoteNonceChange(t *testing.T) {
 	account.nonces = append(account.nonces, nn...)
 	nonce := ms.NewNonce(addr)
 
-	ms.StateDB.stateObjects[addr].nonce = 200
+	ms.StateDB.stateObjects[addr].data.Nonce = 200
 	nonce = ms.NewNonce(addr)
 	if nonce != 200 {
 		t.Error("expected nonce after remote update to be", 201, "got", nonce)
@@ -100,7 +101,7 @@ func TestRemoteNonceChange(t *testing.T) {
 	ms.NewNonce(addr)
 	ms.NewNonce(addr)
 	ms.NewNonce(addr)
-	ms.StateDB.stateObjects[addr].nonce = 200
+	ms.StateDB.stateObjects[addr].data.Nonce = 200
 	nonce = ms.NewNonce(addr)
 	if nonce != 204 {
 		t.Error("expected nonce after remote update to be", 201, "got", nonce)

--- a/core/state/state_object.go
+++ b/core/state/state_object.go
@@ -94,6 +94,9 @@ type Account struct {
 	Balance  *big.Int
 	Root     common.Hash // merkle root of the storage trie
 	CodeHash []byte
+
+	// TODO(fjl): track code size here to get it into the cache
+	// codeSize int
 }
 
 // NewObject creates a state object.

--- a/core/state/state_test.go
+++ b/core/state/state_test.go
@@ -146,8 +146,8 @@ func TestSnapshot2(t *testing.T) {
 
 	// db, trie are already non-empty values
 	so0 := state.GetStateObject(stateobjaddr0)
-	so0.balance = big.NewInt(42)
-	so0.nonce = 43
+	so0.SetBalance(big.NewInt(42))
+	so0.SetNonce(43)
 	so0.SetCode([]byte{'c', 'a', 'f', 'e'})
 	so0.remove = false
 	so0.deleted = false
@@ -157,8 +157,8 @@ func TestSnapshot2(t *testing.T) {
 
 	// and one with deleted == true
 	so1 := state.GetStateObject(stateobjaddr1)
-	so1.balance = big.NewInt(52)
-	so1.nonce = 53
+	so1.SetBalance(big.NewInt(52))
+	so1.SetNonce(53)
 	so1.SetCode([]byte{'c', 'a', 'f', 'e', '2'})
 	so1.remove = true
 	so1.deleted = true
@@ -174,41 +174,50 @@ func TestSnapshot2(t *testing.T) {
 	state.Set(snapshot)
 
 	so0Restored := state.GetStateObject(stateobjaddr0)
-	so0Restored.GetState(storageaddr)
-	so1Restored := state.GetStateObject(stateobjaddr1)
+	// Update lazily-loaded values before comparing.
+	so0Restored.GetState(db, storageaddr)
+	so0Restored.Code(db)
 	// non-deleted is equal (restored)
 	compareStateObjects(so0Restored, so0, t)
+
 	// deleted should be nil, both before and after restore of state copy
+	so1Restored := state.GetStateObject(stateobjaddr1)
 	if so1Restored != nil {
 		t.Fatalf("deleted object not nil after restoring snapshot")
 	}
 }
 
 func compareStateObjects(so0, so1 *StateObject, t *testing.T) {
-	if so0.address != so1.address {
+	if so0.Address() != so1.Address() {
 		t.Fatalf("Address mismatch: have %v, want %v", so0.address, so1.address)
 	}
-	if so0.balance.Cmp(so1.balance) != 0 {
-		t.Fatalf("Balance mismatch: have %v, want %v", so0.balance, so1.balance)
+	if so0.Balance().Cmp(so1.Balance()) != 0 {
+		t.Fatalf("Balance mismatch: have %v, want %v", so0.Balance(), so1.Balance())
 	}
-	if so0.nonce != so1.nonce {
-		t.Fatalf("Nonce mismatch: have %v, want %v", so0.nonce, so1.nonce)
+	if so0.Nonce() != so1.Nonce() {
+		t.Fatalf("Nonce mismatch: have %v, want %v", so0.Nonce(), so1.Nonce())
 	}
-	if !bytes.Equal(so0.codeHash, so1.codeHash) {
-		t.Fatalf("CodeHash mismatch: have %v, want %v", so0.codeHash, so1.codeHash)
+	if so0.data.Root != so1.data.Root {
+		t.Errorf("Root mismatch: have %x, want %x", so0.data.Root[:], so1.data.Root[:])
+	}
+	if !bytes.Equal(so0.CodeHash(), so1.CodeHash()) {
+		t.Fatalf("CodeHash mismatch: have %v, want %v", so0.CodeHash(), so1.CodeHash())
 	}
 	if !bytes.Equal(so0.code, so1.code) {
 		t.Fatalf("Code mismatch: have %v, want %v", so0.code, so1.code)
 	}
 
+	if len(so1.storage) != len(so0.storage) {
+		t.Errorf("Storage size mismatch: have %d, want %d", len(so1.storage), len(so0.storage))
+	}
 	for k, v := range so1.storage {
 		if so0.storage[k] != v {
-			t.Fatalf("Storage key %s mismatch: have %v, want %v", k, so0.storage[k], v)
+			t.Errorf("Storage key %x mismatch: have %v, want %v", k, so0.storage[k], v)
 		}
 	}
 	for k, v := range so0.storage {
 		if so1.storage[k] != v {
-			t.Fatalf("Storage key %s mismatch: have %v, want none.", k, v)
+			t.Errorf("Storage key %x mismatch: have %v, want none.", k, v)
 		}
 	}
 

--- a/eth/api.go
+++ b/eth/api.go
@@ -288,14 +288,14 @@ func NewPublicDebugAPI(eth *Ethereum) *PublicDebugAPI {
 }
 
 // DumpBlock retrieves the entire state of the database at a given block.
-func (api *PublicDebugAPI) DumpBlock(number uint64) (state.World, error) {
+func (api *PublicDebugAPI) DumpBlock(number uint64) (state.Dump, error) {
 	block := api.eth.BlockChain().GetBlockByNumber(number)
 	if block == nil {
-		return state.World{}, fmt.Errorf("block #%d not found", number)
+		return state.Dump{}, fmt.Errorf("block #%d not found", number)
 	}
 	stateDb, err := state.New(block.Root(), api.eth.ChainDb())
 	if err != nil {
-		return state.World{}, err
+		return state.Dump{}, err
 	}
 	return stateDb.RawDump(), nil
 }

--- a/light/state_test.go
+++ b/light/state_test.go
@@ -62,7 +62,7 @@ func makeTestState() (common.Hash, ethdb.Database) {
 		}
 		so.AddBalance(big.NewInt(int64(i)))
 		so.SetCode([]byte{i, i, i})
-		so.Update()
+		so.UpdateRoot(sdb)
 		st.UpdateStateObject(so)
 	}
 	root, _ := st.Commit()

--- a/tests/state_test_util.go
+++ b/tests/state_test_util.go
@@ -187,7 +187,7 @@ func runStateTest(ruleSet RuleSet, test VmTest) error {
 		}
 
 		for addr, value := range account.Storage {
-			v := obj.GetState(common.HexToHash(addr))
+			v := statedb.GetState(obj.Address(), common.HexToHash(addr))
 			vexp := common.HexToHash(value)
 
 			if v != vexp {

--- a/tests/util.go
+++ b/tests/util.go
@@ -104,15 +104,16 @@ func (self Log) Topics() [][]byte {
 }
 
 func StateObjectFromAccount(db ethdb.Database, addr string, account Account) *state.StateObject {
-	obj := state.NewStateObject(common.HexToAddress(addr), db)
-	obj.SetBalance(common.Big(account.Balance))
-
 	if common.IsHex(account.Code) {
 		account.Code = account.Code[2:]
 	}
-	obj.SetCode(common.Hex2Bytes(account.Code))
-	obj.SetNonce(common.Big(account.Nonce).Uint64())
-
+	code := common.Hex2Bytes(account.Code)
+	obj := state.NewObject(common.HexToAddress(addr), state.Account{
+		Balance:  common.Big(account.Balance),
+		CodeHash: crypto.Keccak256(code),
+		Nonce:    common.Big(account.Nonce).Uint64(),
+	})
+	obj.SetCode(code)
 	return obj
 }
 

--- a/tests/vm_test_util.go
+++ b/tests/vm_test_util.go
@@ -205,11 +205,9 @@ func runVmTest(test VmTest) error {
 		if obj == nil {
 			continue
 		}
-
 		for addr, value := range account.Storage {
-			v := obj.GetState(common.HexToHash(addr))
+			v := statedb.GetState(obj.Address(), common.HexToHash(addr))
 			vexp := common.HexToHash(value)
-
 			if v != vexp {
 				return fmt.Errorf("(%x: %s) storage failed. Expected %x, got %x (%v %v)\n", obj.Address().Bytes()[0:4], addr, vexp, v, vexp.Big(), v.Big())
 			}


### PR DESCRIPTION
This change introduces a global, per-state cache that keeps
account data in the canon state.

TODO

- [ ] fix core.GenerateChain related test failures
- [ ] reuse StateDB across blocks in BlockChain