### PR TITLE
build: limit test concurrency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,6 @@ matrix:
   include:
     - os: linux
       dist: trusty
-      go: 1.4.2
-    - os: linux
-      dist: trusty
       go: 1.5.4
     - os: linux
       dist: trusty

--- a/build/ci.go
+++ b/build/ci.go
@@ -227,6 +227,9 @@ func doTest(cmdline []string) {
 
 	// Run the actual tests.
 	gotest := goTool("test")
+	// Test a single package at a time. CI builders are slow
+	// and some tests run into timeouts under load.
+	gotest.Args = append(gotest.Args, "-p", "1")
 	if *coverage {
 		gotest.Args = append(gotest.Args, "-covermode=atomic", "-cover")
 	}


### PR DESCRIPTION
TravisCI and AppVeyor run the tests in very slow VMs.
Some of our tests can't cope with that. Running less tests
in parallel should make them somewhat less flakey.