### PR TITLE
Fix trie deletion bug

### DIFF
--- a/trie/trie.go
+++ b/trie/trie.go
@@ -373,6 +373,9 @@ func (t *Trie) delete(n node, prefix, key []byte) (bool, node, error) {
 	case nil:
 		return false, nil, nil
 
+	case valueNode:
+		return true, nil, nil
+
 	case hashNode:
 		// We've hit a part of the trie that isn't loaded yet. Load
 		// the node and delete from it. This leaves all child nodes on


### PR DESCRIPTION
Here is a test case in the `trie_test.go`

```
func TestDel(t *testing.T) {
    trie := newEmpty()

    vals := []struct{ k, v string }{
        {"do", "verb"},
        {"ether", "wookiedoo"},
        {"horse", "stallion"},
        {"shaman", "horse"},
        {"doge", "coin"},
        {"dog", "puppy"},
        {"somethingveryoddindeedthis is", "myothernodedata"},
    }
    for _, val := range vals {
        updateString(trie, val.k, val.v)
    }
    deleteString(trie, "do")
}

```

A panic occur when the test case executed.

I modified the `trie.go` source code. The cause of this bug is when you try to delete a `valuenode` of the **17th** child of the `fullnode` in the trie, there is an error 