### PR TITLE
trie: fix delete bug for values contained in fullNode

### DIFF
--- a/trie/trie.go
+++ b/trie/trie.go
@@ -22,7 +22,7 @@ import (
 	"fmt"
 
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/crypto/sha3"
 	"github.com/ethereum/go-ethereum/logger"
 	"github.com/ethereum/go-ethereum/logger/glog"
 )
@@ -30,10 +30,13 @@ import (
 var (
 	// This is the known root hash of an empty trie.
 	emptyRoot = common.HexToHash("56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421")
-
 	// This is the known hash of an empty state trie entry.
-	emptyState = crypto.Keccak256Hash(nil)
+	emptyState common.Hash
 )
+
+func init() {
+	sha3.NewKeccak256().Sum(emptyState[:0])
+}
 
 // Database must be implemented by backing stores for the trie.
 type Database interface {

--- a/trie/trie.go
+++ b/trie/trie.go
@@ -377,6 +377,9 @@ func (t *Trie) delete(n node, prefix, key []byte) (bool, node, error) {
 		// n still contains at least two values and cannot be reduced.
 		return true, n, nil
 
+	case valueNode:
+		return true, nil, nil
+
 	case nil:
 		return false, nil, nil
 


### PR DESCRIPTION
Delete crashed if a fullNode contained a valueNode directly. This bug is
very unlikely to occur with SecureTrie, but can happen with regular
tries. This PR also introduces a randomised test which triggers all
trie operations, which should prevent such bugs in the future.

Credit for finding this bug goes to Github user @rjl493456442.