### PR TITLE
core/vm: add limit option to LogConfig

### DIFF
--- a/core/vm/errors.go
+++ b/core/vm/errors.go
@@ -26,3 +26,4 @@ import (
 var OutOfGasError = errors.New("Out of gas")
 var CodeStoreOutOfGasError = errors.New("Contract creation code storage out of gas")
 var DepthError = fmt.Errorf("Max call depth exceeded (%d)", params.CallCreateDepth)
+var TraceLimitReachedError = errors.New("The number of logs reached the specified limit")

--- a/core/vm/vm.go
+++ b/core/vm/vm.go
@@ -183,7 +183,10 @@ func (evm *EVM) Run(contract *Contract, input []byte) (ret []byte, err error) {
 		mem.Resize(newMemSize.Uint64())
 		// Add a log message
 		if evm.cfg.Debug {
-			evm.cfg.Tracer.CaptureState(evm.env, pc, op, contract.Gas, cost, mem, stack, contract, evm.env.Depth(), nil)
+			err = evm.cfg.Tracer.CaptureState(evm.env, pc, op, contract.Gas, cost, mem, stack, contract, evm.env.Depth(), nil)
+			if err != nil {
+				return nil, err
+			}
 		}
 
 		if opPtr := evm.jumpTable[op]; opPtr.valid {

--- a/internal/ethapi/tracer.go
+++ b/internal/ethapi/tracer.go
@@ -278,7 +278,7 @@ func wrapError(context string, err error) error {
 }
 
 // CaptureState implements the Tracer interface to trace a single step of VM execution
-func (jst *JavascriptTracer) CaptureState(env vm.Environment, pc uint64, op vm.OpCode, gas, cost *big.Int, memory *vm.Memory, stack *vm.Stack, contract *vm.Contract, depth int, err error) {
+func (jst *JavascriptTracer) CaptureState(env vm.Environment, pc uint64, op vm.OpCode, gas, cost *big.Int, memory *vm.Memory, stack *vm.Stack, contract *vm.Contract, depth int, err error) error {
 	if jst.err == nil {
 		jst.memory.memory = memory
 		jst.stack.stack = stack
@@ -301,6 +301,7 @@ func (jst *JavascriptTracer) CaptureState(env vm.Environment, pc uint64, op vm.O
 			jst.err = wrapError("step", err)
 		}
 	}
+	return nil
 }
 
 // GetResult calls the Javascript 'result' function and returns its value, or any accumulated error


### PR DESCRIPTION
This pull-request adds `limit` option to `debug.traceTransaction()`.

```
debug.traceTransaction(tx, {limit: 2})
```

shows at most the first two steps in `structLogs`.

This is supposed to be useful on transactions with a huge number of repetitions.  `traceTransaction()` on [one of recent transactions](https://live.ether.camp/transaction/88a7fe25b04a0e5c245e102d0a5d17300cf7d840fd4d09328d88c35b200550fa) caused oom death.

Maybe this option is interesting for the online blockchain browsers.
