### PR TITLE
Set CORS Max-Age to avoid a preflight OPTIONS request for every request.

### DIFF
--- a/rpc/http.go
+++ b/rpc/http.go
@@ -170,6 +170,7 @@ func newCorsHandler(srv *Server, corsString string) http.Handler {
 	c := cors.New(cors.Options{
 		AllowedOrigins: allowedOrigins,
 		AllowedMethods: []string{"POST", "GET"},
+		MaxAge: 3600,
 	})
 	return c.Handler(srv)
 }


### PR DESCRIPTION
Currently each RPC command needs 2 requests. There is an OPTIONS preflight request for each command. This can be reduced by setting Max-Age to 3600 (1 hour).

This speeds up node communication 2x on high latency links.

http://stackoverflow.com/questions/17432982/should-i-expect-options-preflight-with-all-cors-requests