### PR TITLE
rpc: set CORS Max-Age to reduce preflight OPTIONS requests

### DIFF
--- a/rpc/http.go
+++ b/rpc/http.go
@@ -170,6 +170,7 @@ func newCorsHandler(srv *Server, corsString string) http.Handler {
 	c := cors.New(cors.Options{
 		AllowedOrigins: allowedOrigins,
 		AllowedMethods: []string{"POST", "GET"},
+		MaxAge: 3600,
 	})
 	return c.Handler(srv)
 }


### PR DESCRIPTION
Currently every RPC command is 2 requests. First the OPTIONS pre-flight and then the actual request. By setting CORS Max-Age to 1 hour the number of requests can be cut in half. For high latency connections to the node, this has significant performance improvements.

http://stackoverflow.com/questions/17432982/should-i-expect-options-preflight-with-all-cors-requests