### PR TITLE
rpc: set CORS Max-Age to reduce preflight OPTIONS requests

### DIFF
--- a/rpc/http.go
+++ b/rpc/http.go
@@ -170,6 +170,7 @@ func newCorsHandler(srv *Server, corsString string) http.Handler {
 	c := cors.New(cors.Options{
 		AllowedOrigins: allowedOrigins,
 		AllowedMethods: []string{"POST", "GET"},
+		MaxAge: 600,
 	})
 	return c.Handler(srv)
 }


### PR DESCRIPTION
https://github.com/ethereum/go-ethereum/issues/3079