### PR TITLE
internal/build: fix git tag env variable for AppVeyor

### DIFF
--- a/internal/build/env.go
+++ b/internal/build/env.go
@@ -65,7 +65,7 @@ func Env() Environment {
 			Repo:          os.Getenv("APPVEYOR_REPO_NAME"),
 			Commit:        os.Getenv("APPVEYOR_REPO_COMMIT"),
 			Branch:        os.Getenv("APPVEYOR_REPO_BRANCH"),
-			Tag:           os.Getenv("APPVEYOR_REPO_TAG"),
+			Tag:           os.Getenv("APPVEYOR_REPO_TAG_NAME"),
 			Buildnum:      os.Getenv("APPVEYOR_BUILD_NUMBER"),
 			IsPullRequest: os.Getenv("APPVEYOR_PULL_REQUEST_NUMBER") != "",
 		}


### PR DESCRIPTION
This fixes archive generation for tag builds. See https://ci.appveyor.com/project/tgerring/go-ethereum/build/release/1.4.724#L153