### PR TITLE
Implement journalling for state objects

### DIFF
--- a/accounts/abi/bind/backends/simulated.go
+++ b/accounts/abi/bind/backends/simulated.go
@@ -172,8 +172,9 @@ func (b *SimulatedBackend) CallContract(ctx context.Context, call ethereum.CallM
 func (b *SimulatedBackend) PendingCallContract(ctx context.Context, call ethereum.CallMsg) ([]byte, error) {
 	b.mu.Lock()
 	defer b.mu.Unlock()
+	defer b.pendingState.RevertToSnapshot(b.pendingState.Snapshot())
 
-	rval, _, err := b.callContract(ctx, call, b.pendingBlock, b.pendingState.Copy())
+	rval, _, err := b.callContract(ctx, call, b.pendingBlock, b.pendingState)
 	return rval, err
 }
 
@@ -197,8 +198,9 @@ func (b *SimulatedBackend) SuggestGasPrice(ctx context.Context) (*big.Int, error
 func (b *SimulatedBackend) EstimateGas(ctx context.Context, call ethereum.CallMsg) (*big.Int, error) {
 	b.mu.Lock()
 	defer b.mu.Unlock()
+	defer b.pendingState.RevertToSnapshot(b.pendingState.Snapshot())
 
-	_, gas, err := b.callContract(ctx, call, b.pendingBlock, b.pendingState.Copy())
+	_, gas, err := b.callContract(ctx, call, b.pendingBlock, b.pendingState)
 	return gas, err
 }
 

--- a/cmd/evm/main.go
+++ b/cmd/evm/main.go
@@ -227,22 +227,22 @@ type ruleSet struct{}
 
 func (ruleSet) IsHomestead(*big.Int) bool { return true }
 
-func (self *VMEnv) RuleSet() vm.RuleSet        { return ruleSet{} }
-func (self *VMEnv) Vm() vm.Vm                  { return self.evm }
-func (self *VMEnv) Db() vm.Database            { return self.state }
-func (self *VMEnv) MakeSnapshot() vm.Database  { return self.state.Copy() }
-func (self *VMEnv) SetSnapshot(db vm.Database) { self.state.Set(db.(*state.StateDB)) }
-func (self *VMEnv) Origin() common.Address     { return *self.transactor }
-func (self *VMEnv) BlockNumber() *big.Int      { return common.Big0 }
-func (self *VMEnv) Coinbase() common.Address   { return *self.transactor }
-func (self *VMEnv) Time() *big.Int             { return self.time }
-func (self *VMEnv) Difficulty() *big.Int       { return common.Big1 }
-func (self *VMEnv) BlockHash() []byte          { return make([]byte, 32) }
-func (self *VMEnv) Value() *big.Int            { return self.value }
-func (self *VMEnv) GasLimit() *big.Int         { return big.NewInt(1000000000) }
-func (self *VMEnv) VmType() vm.Type            { return vm.StdVmTy }
-func (self *VMEnv) Depth() int                 { return 0 }
-func (self *VMEnv) SetDepth(i int)             { self.depth = i }
+func (self *VMEnv) RuleSet() vm.RuleSet       { return ruleSet{} }
+func (self *VMEnv) Vm() vm.Vm                 { return self.evm }
+func (self *VMEnv) Db() vm.Database           { return self.state }
+func (self *VMEnv) SnapshotDatabase() int     { return self.state.Snapshot() }
+func (self *VMEnv) RevertToSnapshot(snap int) { self.state.RevertToSnapshot(snap) }
+func (self *VMEnv) Origin() common.Address    { return *self.transactor }
+func (self *VMEnv) BlockNumber() *big.Int     { return common.Big0 }
+func (self *VMEnv) Coinbase() common.Address  { return *self.transactor }
+func (self *VMEnv) Time() *big.Int            { return self.time }
+func (self *VMEnv) Difficulty() *big.Int      { return common.Big1 }
+func (self *VMEnv) BlockHash() []byte         { return make([]byte, 32) }
+func (self *VMEnv) Value() *big.Int           { return self.value }
+func (self *VMEnv) GasLimit() *big.Int        { return big.NewInt(1000000000) }
+func (self *VMEnv) VmType() vm.Type           { return vm.StdVmTy }
+func (self *VMEnv) Depth() int                { return 0 }
+func (self *VMEnv) SetDepth(i int)            { self.depth = i }
 func (self *VMEnv) GetHash(n uint64) common.Hash {
 	if self.block.Number().Cmp(big.NewInt(int64(n))) == 0 {
 		return self.block.Hash()

--- a/core/execution.go
+++ b/core/execution.go
@@ -85,7 +85,7 @@ func exec(env vm.Environment, caller vm.ContractRef, address, codeAddr *common.A
 		createAccount = true
 	}
 
-	snapshotPreTransfer := env.MakeSnapshot()
+	snapshotPreTransfer := env.SnapshotDatabase()
 	var (
 		from = env.Db().GetAccount(caller.Address())
 		to   vm.Account
@@ -129,7 +129,7 @@ func exec(env vm.Environment, caller vm.ContractRef, address, codeAddr *common.A
 	if err != nil && (env.RuleSet().IsHomestead(env.BlockNumber()) || err != vm.CodeStoreOutOfGasError) {
 		contract.UseGas(contract.Gas)
 
-		env.SetSnapshot(snapshotPreTransfer)
+		env.RevertToSnapshot(snapshotPreTransfer)
 	}
 
 	return ret, addr, err
@@ -144,7 +144,7 @@ func execDelegateCall(env vm.Environment, caller vm.ContractRef, originAddr, toA
 		return nil, common.Address{}, vm.DepthError
 	}
 
-	snapshot := env.MakeSnapshot()
+	snapshot := env.SnapshotDatabase()
 
 	var to vm.Account
 	if !env.Db().Exist(*toAddr) {
@@ -162,7 +162,7 @@ func execDelegateCall(env vm.Environment, caller vm.ContractRef, originAddr, toA
 	if err != nil {
 		contract.UseGas(contract.Gas)
 
-		env.SetSnapshot(snapshot)
+		env.RevertToSnapshot(snapshot)
 	}
 
 	return ret, addr, err

--- a/core/state/dump.go
+++ b/core/state/dump.go
@@ -52,7 +52,7 @@ func (self *StateDB) RawDump() Dump {
 			panic(err)
 		}
 
-		obj := NewObject(common.BytesToAddress(addr), data, nil)
+		obj := newObject(nil, common.BytesToAddress(addr), data, nil)
 		account := DumpAccount{
 			Balance:  data.Balance.String(),
 			Nonce:    data.Nonce,

--- a/core/state/journal.go
+++ b/core/state/journal.go
@@ -1,0 +1,98 @@
+// Copyright 2016 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+package state
+
+import (
+	"math/big"
+
+	"github.com/ethereum/go-ethereum/common"
+)
+
+type journalEntry interface {
+	undo(*StateDB)
+}
+
+type journal []journalEntry
+
+type (
+	// Changes to the account trie.
+	createAccountChange struct {
+		account *common.Address
+	}
+	deleteAccountChange struct {
+		account *common.Address
+	}
+
+	// Changes to individual accounts.
+	balanceChange struct {
+		account *common.Address
+		prev    *big.Int
+	}
+	nonceChange struct {
+		account *common.Address
+		prev    uint64
+	}
+	storageChange struct {
+		account       *common.Address
+		key, prevalue common.Hash
+	}
+	codeChange struct {
+		account            *common.Address
+		prevcode, prevhash []byte
+	}
+
+	// Changes to other state values.
+	refundChange struct {
+		prev *big.Int
+	}
+	addLogChange struct {
+		txhash common.Hash
+	}
+)
+
+func (ch deleteAccountChange) undo(s *StateDB) {
+	s.createStateObject(*ch.account)
+}
+
+func (ch createAccountChange) undo(s *StateDB) {
+	s.delete(*ch.account)
+}
+
+func (ch balanceChange) undo(s *StateDB) {
+	s.GetOrNewStateObject(*ch.account).setBalance(ch.prev)
+}
+
+func (ch nonceChange) undo(s *StateDB) {
+	s.GetOrNewStateObject(*ch.account).setNonce(ch.prev)
+}
+
+func (ch codeChange) undo(s *StateDB) {
+	s.GetOrNewStateObject(*ch.account).setCode(common.BytesToHash(ch.prevhash), ch.prevcode)
+}
+
+func (ch storageChange) undo(s *StateDB) {
+	s.GetOrNewStateObject(*ch.account).setState(ch.key, ch.prevalue)
+}
+
+func (ch refundChange) undo(s *StateDB) {
+	s.refund = ch.prev
+}
+
+func (ch addLogChange) undo(s *StateDB) {
+	logs := s.logs[ch.txhash]
+	s.logs[ch.txhash] = logs[:len(logs)-1]
+}

--- a/core/state/journal.go
+++ b/core/state/journal.go
@@ -34,7 +34,7 @@ type (
 		account *common.Address
 	}
 	deleteAccountChange struct {
-		account *common.Address
+		object *StateObject
 	}
 
 	// Changes to individual accounts.
@@ -65,7 +65,8 @@ type (
 )
 
 func (ch deleteAccountChange) undo(s *StateDB) {
-	s.createStateObject(*ch.account)
+	ch.object.remove = false
+	s.SetStateObject(ch.object)
 }
 
 func (ch createAccountChange) undo(s *StateDB) {

--- a/core/state/managed_state.go
+++ b/core/state/managed_state.go
@@ -39,7 +39,7 @@ type ManagedState struct {
 // ManagedState returns a new managed state with the statedb as it's backing layer
 func ManageState(statedb *StateDB) *ManagedState {
 	return &ManagedState{
-		StateDB:  statedb,
+		StateDB:  statedb.Copy(),
 		accounts: make(map[common.Address]*account),
 	}
 }

--- a/core/state/managed_state.go
+++ b/core/state/managed_state.go
@@ -39,7 +39,7 @@ type ManagedState struct {
 // ManagedState returns a new managed state with the statedb as it's backing layer
 func ManageState(statedb *StateDB) *ManagedState {
 	return &ManagedState{
-		StateDB:  statedb.Copy(),
+		StateDB:  statedb,
 		accounts: make(map[common.Address]*account),
 	}
 }

--- a/core/state/managed_state_test.go
+++ b/core/state/managed_state_test.go
@@ -29,11 +29,8 @@ func create() (*ManagedState, *account) {
 	db, _ := ethdb.NewMemDatabase()
 	statedb, _ := New(common.Hash{}, db)
 	ms := ManageState(statedb)
-	so := &StateObject{address: addr}
-	so.SetNonce(100)
-	ms.StateDB.stateObjects[addr] = so
-	ms.accounts[addr] = newAccount(so)
-
+	ms.StateDB.SetNonce(addr, 100)
+	ms.accounts[addr] = newAccount(ms.StateDB.GetStateObject(addr))
 	return ms, ms.accounts[addr]
 }
 

--- a/core/state/state_object.go
+++ b/core/state/state_object.go
@@ -260,16 +260,16 @@ func (self *StateObject) setBalance(amount *big.Int) {
 // Return the gas back to the origin. Used by the Virtual machine or Closures
 func (c *StateObject) ReturnGas(gas, price *big.Int) {}
 
-func (self *StateObject) Copy(db trie.Database, onDirty func(addr common.Address)) *StateObject {
-	// stateObject := NewObject(self.address, self.data, onDirty)
-	// stateObject.trie = self.trie
-	// stateObject.code = self.code
-	// stateObject.dirtyStorage = self.dirtyStorage.Copy()
-	// stateObject.cachedStorage = self.dirtyStorage.Copy()
-	// stateObject.remove = self.remove
-	// stateObject.dirtyCode = self.dirtyCode
-	// stateObject.deleted = self.deleted
-	return self
+func (self *StateObject) deepCopy(db *StateDB, onDirty func(addr common.Address)) *StateObject {
+	stateObject := newObject(db, self.address, self.data, onDirty)
+	stateObject.trie = self.trie
+	stateObject.code = self.code
+	stateObject.dirtyStorage = self.dirtyStorage.Copy()
+	stateObject.cachedStorage = self.dirtyStorage.Copy()
+	stateObject.remove = self.remove
+	stateObject.dirtyCode = self.dirtyCode
+	stateObject.deleted = self.deleted
+	return stateObject
 }
 
 //

--- a/core/state/state_object.go
+++ b/core/state/state_object.go
@@ -66,6 +66,7 @@ func (self Storage) Copy() Storage {
 type StateObject struct {
 	address common.Address // Ethereum address of this account
 	data    Account
+	db      *StateDB
 
 	// DB error.
 	// State objects are used by the consensus core and VM which are
@@ -99,15 +100,15 @@ type Account struct {
 	CodeHash []byte
 }
 
-// NewObject creates a state object.
-func NewObject(address common.Address, data Account, onDirty func(addr common.Address)) *StateObject {
+// newObject creates a state object.
+func newObject(db *StateDB, address common.Address, data Account, onDirty func(addr common.Address)) *StateObject {
 	if data.Balance == nil {
 		data.Balance = new(big.Int)
 	}
 	if data.CodeHash == nil {
 		data.CodeHash = emptyCodeHash
 	}
-	return &StateObject{address: address, data: data, cachedStorage: make(Storage), dirtyStorage: make(Storage), onDirty: onDirty}
+	return &StateObject{db: db, address: address, data: data, cachedStorage: make(Storage), dirtyStorage: make(Storage), onDirty: onDirty}
 }
 
 // EncodeRLP implements rlp.Encoder.
@@ -122,7 +123,7 @@ func (self *StateObject) setError(err error) {
 	}
 }
 
-func (self *StateObject) MarkForDeletion() {
+func (self *StateObject) markForDeletion() {
 	self.remove = true
 	if self.onDirty != nil {
 		self.onDirty(self.Address())
@@ -163,7 +164,16 @@ func (self *StateObject) GetState(db trie.Database, key common.Hash) common.Hash
 }
 
 // SetState updates a value in account storage.
-func (self *StateObject) SetState(key, value common.Hash) {
+func (self *StateObject) SetState(db trie.Database, key, value common.Hash) {
+	self.db.journal = append(self.db.journal, storageChange{
+		account:  &self.address,
+		key:      key,
+		prevalue: self.GetState(db, key),
+	})
+	self.setState(key, value)
+}
+
+func (self *StateObject) setState(key, value common.Hash) {
 	self.cachedStorage[key] = value
 	self.dirtyStorage[key] = value
 
@@ -189,7 +199,7 @@ func (self *StateObject) updateTrie(db trie.Database) {
 }
 
 // UpdateRoot sets the trie root to the current root hash of
-func (self *StateObject) UpdateRoot(db trie.Database) {
+func (self *StateObject) updateRoot(db trie.Database) {
 	self.updateTrie(db)
 	self.data.Root = self.trie.Hash()
 }
@@ -232,6 +242,14 @@ func (c *StateObject) SubBalance(amount *big.Int) {
 }
 
 func (self *StateObject) SetBalance(amount *big.Int) {
+	self.db.journal = append(self.db.journal, balanceChange{
+		account: &self.address,
+		prev:    new(big.Int).Set(self.data.Balance),
+	})
+	self.setBalance(amount)
+}
+
+func (self *StateObject) setBalance(amount *big.Int) {
 	self.data.Balance = amount
 	if self.onDirty != nil {
 		self.onDirty(self.Address())
@@ -243,15 +261,15 @@ func (self *StateObject) SetBalance(amount *big.Int) {
 func (c *StateObject) ReturnGas(gas, price *big.Int) {}
 
 func (self *StateObject) Copy(db trie.Database, onDirty func(addr common.Address)) *StateObject {
-	stateObject := NewObject(self.address, self.data, onDirty)
-	stateObject.trie = self.trie
-	stateObject.code = self.code
-	stateObject.dirtyStorage = self.dirtyStorage.Copy()
-	stateObject.cachedStorage = self.dirtyStorage.Copy()
-	stateObject.remove = self.remove
-	stateObject.dirtyCode = self.dirtyCode
-	stateObject.deleted = self.deleted
-	return stateObject
+	// stateObject := NewObject(self.address, self.data, onDirty)
+	// stateObject.trie = self.trie
+	// stateObject.code = self.code
+	// stateObject.dirtyStorage = self.dirtyStorage.Copy()
+	// stateObject.cachedStorage = self.dirtyStorage.Copy()
+	// stateObject.remove = self.remove
+	// stateObject.dirtyCode = self.dirtyCode
+	// stateObject.deleted = self.deleted
+	return self
 }
 
 //
@@ -280,6 +298,16 @@ func (self *StateObject) Code(db trie.Database) []byte {
 }
 
 func (self *StateObject) SetCode(codeHash common.Hash, code []byte) {
+	prevcode := self.Code(self.db.db)
+	self.db.journal = append(self.db.journal, codeChange{
+		account:  &self.address,
+		prevhash: self.CodeHash(),
+		prevcode: prevcode,
+	})
+	self.setCode(codeHash, code)
+}
+
+func (self *StateObject) setCode(codeHash common.Hash, code []byte) {
 	self.code = code
 	self.data.CodeHash = codeHash[:]
 	self.dirtyCode = true
@@ -290,6 +318,14 @@ func (self *StateObject) SetCode(codeHash common.Hash, code []byte) {
 }
 
 func (self *StateObject) SetNonce(nonce uint64) {
+	self.db.journal = append(self.db.journal, nonceChange{
+		account: &self.address,
+		prev:    self.data.Nonce,
+	})
+	self.setNonce(nonce)
+}
+
+func (self *StateObject) setNonce(nonce uint64) {
 	self.data.Nonce = nonce
 	if self.onDirty != nil {
 		self.onDirty(self.Address())

--- a/core/state/statedb.go
+++ b/core/state/statedb.go
@@ -421,9 +421,9 @@ func (self *StateDB) createStateObject(addr common.Address) *StateObject {
 	// Create a new one
 	newSo := self.newStateObject(addr)
 
-	// If it existed set the balance to the new account. This also creates a journal entry.
+	// If it existed set the balance to the new account.
 	if so != nil {
-		newSo.SetBalance(so.data.Balance)
+		newSo.setBalance(so.data.Balance)
 	} else {
 		self.journal = append(self.journal, createAccountChange{account: &addr})
 	}

--- a/core/state/statedb.go
+++ b/core/state/statedb.go
@@ -192,6 +192,7 @@ func (self *StateDB) Logs() vm.Logs {
 }
 
 func (self *StateDB) AddRefund(gas *big.Int) {
+	self.journal = append(self.journal, refundChange{prev: new(big.Int).Set(self.refund)})
 	self.refund.Add(self.refund, gas)
 }
 
@@ -452,7 +453,7 @@ func (self *StateDB) Copy() *StateDB {
 	}
 	// Copy the dirty states and logs
 	for addr, _ := range self.stateObjectsDirty {
-		state.stateObjects[addr] = self.stateObjects[addr].Copy(self.db, state.MarkStateObjectDirty)
+		state.stateObjects[addr] = self.stateObjects[addr].deepCopy(state, state.MarkStateObjectDirty)
 		state.stateObjectsDirty[addr] = struct{}{}
 	}
 	for hash, logs := range self.logs {

--- a/core/state/statedb.go
+++ b/core/state/statedb.go
@@ -40,7 +40,7 @@ var StartingNonce uint64
 const (
 	// Number of past tries to keep. The arbitrarily chosen value here
 	// is max uncle depth + 1.
-	maxJournalLength = 8
+	maxTrieCacheLength = 8
 
 	// Number of codehash->size associations to keep.
 	codeSizeCacheSize = 100000
@@ -154,7 +154,7 @@ func (self *StateDB) pushTrie(t *trie.SecureTrie) {
 	self.lock.Lock()
 	defer self.lock.Unlock()
 
-	if len(self.pastTries) >= maxJournalLength {
+	if len(self.pastTries) >= maxTrieCacheLength {
 		copy(self.pastTries, self.pastTries[1:])
 		self.pastTries[len(self.pastTries)-1] = t
 	} else {

--- a/core/state/statedb_test.go
+++ b/core/state/statedb_test.go
@@ -21,7 +21,6 @@ import (
 	"testing"
 
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/ethdb"
 )
 
@@ -34,16 +33,16 @@ func TestUpdateLeaks(t *testing.T) {
 
 	// Update it with some accounts
 	for i := byte(0); i < 255; i++ {
-		obj := state.GetOrNewStateObject(common.BytesToAddress([]byte{i}))
-		obj.AddBalance(big.NewInt(int64(11 * i)))
-		obj.SetNonce(uint64(42 * i))
+		addr := common.BytesToAddress([]byte{i})
+		state.AddBalance(addr, big.NewInt(int64(11*i)))
+		state.SetNonce(addr, uint64(42*i))
 		if i%2 == 0 {
-			obj.SetState(common.BytesToHash([]byte{i, i, i}), common.BytesToHash([]byte{i, i, i, i}))
+			state.SetState(addr, common.BytesToHash([]byte{i, i, i}), common.BytesToHash([]byte{i, i, i, i}))
 		}
 		if i%3 == 0 {
-			obj.SetCode(crypto.Keccak256Hash([]byte{i, i, i, i, i}), []byte{i, i, i, i, i})
+			state.SetCode(addr, []byte{i, i, i, i, i})
 		}
-		state.UpdateStateObject(obj)
+		state.IntermediateRoot()
 	}
 	// Ensure that no data was leaked into the database
 	for _, key := range db.Keys() {
@@ -54,68 +53,68 @@ func TestUpdateLeaks(t *testing.T) {
 
 // Tests that no intermediate state of an object is stored into the database,
 // only the one right before the commit.
-func TestIntermediateLeaks(t *testing.T) {
-	// Create two state databases, one transitioning to the final state, the other final from the beginning
-	transDb, _ := ethdb.NewMemDatabase()
-	finalDb, _ := ethdb.NewMemDatabase()
-	transState, _ := New(common.Hash{}, transDb)
-	finalState, _ := New(common.Hash{}, finalDb)
-
-	// Update the states with some objects
-	for i := byte(0); i < 255; i++ {
-		// Create a new state object with some data into the transition database
-		obj := transState.GetOrNewStateObject(common.BytesToAddress([]byte{i}))
-		obj.SetBalance(big.NewInt(int64(11 * i)))
-		obj.SetNonce(uint64(42 * i))
-		if i%2 == 0 {
-			obj.SetState(common.BytesToHash([]byte{i, i, i, 0}), common.BytesToHash([]byte{i, i, i, i, 0}))
-		}
-		if i%3 == 0 {
-			obj.SetCode(crypto.Keccak256Hash([]byte{i, i, i, i, i, 0}), []byte{i, i, i, i, i, 0})
-		}
-		transState.UpdateStateObject(obj)
-
-		// Overwrite all the data with new values in the transition database
-		obj.SetBalance(big.NewInt(int64(11*i + 1)))
-		obj.SetNonce(uint64(42*i + 1))
-		if i%2 == 0 {
-			obj.SetState(common.BytesToHash([]byte{i, i, i, 0}), common.Hash{})
-			obj.SetState(common.BytesToHash([]byte{i, i, i, 1}), common.BytesToHash([]byte{i, i, i, i, 1}))
-		}
-		if i%3 == 0 {
-			obj.SetCode(crypto.Keccak256Hash([]byte{i, i, i, i, i, 1}), []byte{i, i, i, i, i, 1})
-		}
-		transState.UpdateStateObject(obj)
-
-		// Create the final state object directly in the final database
-		obj = finalState.GetOrNewStateObject(common.BytesToAddress([]byte{i}))
-		obj.SetBalance(big.NewInt(int64(11*i + 1)))
-		obj.SetNonce(uint64(42*i + 1))
-		if i%2 == 0 {
-			obj.SetState(common.BytesToHash([]byte{i, i, i, 1}), common.BytesToHash([]byte{i, i, i, i, 1}))
-		}
-		if i%3 == 0 {
-			obj.SetCode(crypto.Keccak256Hash([]byte{i, i, i, i, i, 1}), []byte{i, i, i, i, i, 1})
-		}
-		finalState.UpdateStateObject(obj)
-	}
-	if _, err := transState.Commit(); err != nil {
-		t.Fatalf("failed to commit transition state: %v", err)
-	}
-	if _, err := finalState.Commit(); err != nil {
-		t.Fatalf("failed to commit final state: %v", err)
-	}
-	// Cross check the databases to ensure they are the same
-	for _, key := range finalDb.Keys() {
-		if _, err := transDb.Get(key); err != nil {
-			val, _ := finalDb.Get(key)
-			t.Errorf("entry missing from the transition database: %x -> %x", key, val)
-		}
-	}
-	for _, key := range transDb.Keys() {
-		if _, err := finalDb.Get(key); err != nil {
-			val, _ := transDb.Get(key)
-			t.Errorf("extra entry in the transition database: %x -> %x", key, val)
-		}
-	}
-}
+// func TestIntermediateLeaks(t *testing.T) {
+// 	// Create two state databases, one transitioning to the final state, the other final from the beginning
+// 	transDb, _ := ethdb.NewMemDatabase()
+// 	finalDb, _ := ethdb.NewMemDatabase()
+// 	transState, _ := New(common.Hash{}, transDb)
+// 	finalState, _ := New(common.Hash{}, finalDb)
+//
+// 	// Update the states with some objects
+// 	for i := byte(0); i < 255; i++ {
+// 		// Create a new state object with some data into the transition database
+// 		obj := transState.GetOrNewStateObject(common.BytesToAddress([]byte{i}))
+// 		obj.SetBalance(big.NewInt(int64(11 * i)))
+// 		obj.SetNonce(uint64(42 * i))
+// 		if i%2 == 0 {
+// 			obj.SetState(common.BytesToHash([]byte{i, i, i, 0}), common.BytesToHash([]byte{i, i, i, i, 0}))
+// 		}
+// 		if i%3 == 0 {
+// 			obj.SetCode(crypto.Keccak256Hash([]byte{i, i, i, i, i, 0}), []byte{i, i, i, i, i, 0})
+// 		}
+// 		transState.UpdateStateObject(obj)
+//
+// 		// Overwrite all the data with new values in the transition database
+// 		obj.SetBalance(big.NewInt(int64(11*i + 1)))
+// 		obj.SetNonce(uint64(42*i + 1))
+// 		if i%2 == 0 {
+// 			obj.SetState(common.BytesToHash([]byte{i, i, i, 0}), common.Hash{})
+// 			obj.SetState(common.BytesToHash([]byte{i, i, i, 1}), common.BytesToHash([]byte{i, i, i, i, 1}))
+// 		}
+// 		if i%3 == 0 {
+// 			obj.SetCode(crypto.Keccak256Hash([]byte{i, i, i, i, i, 1}), []byte{i, i, i, i, i, 1})
+// 		}
+// 		transState.UpdateStateObject(obj)
+//
+// 		// Create the final state object directly in the final database
+// 		obj = finalState.GetOrNewStateObject(common.BytesToAddress([]byte{i}))
+// 		obj.SetBalance(big.NewInt(int64(11*i + 1)))
+// 		obj.SetNonce(uint64(42*i + 1))
+// 		if i%2 == 0 {
+// 			obj.SetState(common.BytesToHash([]byte{i, i, i, 1}), common.BytesToHash([]byte{i, i, i, i, 1}))
+// 		}
+// 		if i%3 == 0 {
+// 			obj.SetCode(crypto.Keccak256Hash([]byte{i, i, i, i, i, 1}), []byte{i, i, i, i, i, 1})
+// 		}
+// 		finalState.UpdateStateObject(obj)
+// 	}
+// 	if _, err := transState.Commit(); err != nil {
+// 		t.Fatalf("failed to commit transition state: %v", err)
+// 	}
+// 	if _, err := finalState.Commit(); err != nil {
+// 		t.Fatalf("failed to commit final state: %v", err)
+// 	}
+// 	// Cross check the databases to ensure they are the same
+// 	for _, key := range finalDb.Keys() {
+// 		if _, err := transDb.Get(key); err != nil {
+// 			val, _ := finalDb.Get(key)
+// 			t.Errorf("entry missing from the transition database: %x -> %x", key, val)
+// 		}
+// 	}
+// 	for _, key := range transDb.Keys() {
+// 		if _, err := finalDb.Get(key); err != nil {
+// 			val, _ := transDb.Get(key)
+// 			t.Errorf("extra entry in the transition database: %x -> %x", key, val)
+// 		}
+// 	}
+// }

--- a/core/vm/environment.go
+++ b/core/vm/environment.go
@@ -36,9 +36,9 @@ type Environment interface {
 	// The state database
 	Db() Database
 	// Creates a restorable snapshot
-	MakeSnapshot() Database
+	SnapshotDatabase() int
 	// Set database to previous snapshot
-	SetSnapshot(Database)
+	RevertToSnapshot(int)
 	// Address of the original invoker (first occurrence of the VM invoker)
 	Origin() common.Address
 	// The block number this VM is invoked on

--- a/core/vm/jit_test.go
+++ b/core/vm/jit_test.go
@@ -179,8 +179,8 @@ func (self *Env) BlockNumber() *big.Int  { return big.NewInt(0) }
 
 //func (self *Env) PrevHash() []byte      { return self.parent }
 func (self *Env) Coinbase() common.Address { return common.Address{} }
-func (self *Env) MakeSnapshot() Database   { return nil }
-func (self *Env) SetSnapshot(Database)     {}
+func (self *Env) SnapshotDatabase() int    { return 0 }
+func (self *Env) RevertToSnapshot(int)     {}
 func (self *Env) Time() *big.Int           { return big.NewInt(time.Now().Unix()) }
 func (self *Env) Difficulty() *big.Int     { return big.NewInt(0) }
 func (self *Env) Db() Database             { return nil }

--- a/core/vm/runtime/env.go
+++ b/core/vm/runtime/env.go
@@ -86,11 +86,11 @@ func (self *Env) SetDepth(i int) { self.depth = i }
 func (self *Env) CanTransfer(from common.Address, balance *big.Int) bool {
 	return self.state.GetBalance(from).Cmp(balance) >= 0
 }
-func (self *Env) MakeSnapshot() vm.Database {
-	return self.state.Copy()
+func (self *Env) SnapshotDatabase() int {
+	return self.state.Snapshot()
 }
-func (self *Env) SetSnapshot(copy vm.Database) {
-	self.state.Set(copy.(*state.StateDB))
+func (self *Env) RevertToSnapshot(snapshot int) {
+	self.state.RevertToSnapshot(snapshot)
 }
 
 func (self *Env) Transfer(from, to vm.Account, amount *big.Int) {

--- a/core/vm_env.go
+++ b/core/vm_env.go
@@ -89,12 +89,12 @@ func (self *VMEnv) CanTransfer(from common.Address, balance *big.Int) bool {
 	return self.state.GetBalance(from).Cmp(balance) >= 0
 }
 
-func (self *VMEnv) MakeSnapshot() vm.Database {
-	return self.state.Copy()
+func (self *VMEnv) SnapshotDatabase() int {
+	return self.state.Snapshot()
 }
 
-func (self *VMEnv) SetSnapshot(copy vm.Database) {
-	self.state.Set(copy.(*state.StateDB))
+func (self *VMEnv) RevertToSnapshot(snapshot int) {
+	self.state.RevertToSnapshot(snapshot)
 }
 
 func (self *VMEnv) Transfer(from, to vm.Account, amount *big.Int) {

--- a/eth/api_backend.go
+++ b/eth/api_backend.go
@@ -98,12 +98,12 @@ func (b *EthApiBackend) GetTd(blockHash common.Hash) *big.Int {
 }
 
 func (b *EthApiBackend) GetVMEnv(ctx context.Context, msg core.Message, state ethapi.State, header *types.Header) (vm.Environment, func() error, error) {
-	stateDb := state.(EthApiState).state.Copy()
+	statedb := state.(EthApiState).state
 	addr, _ := msg.From()
-	from := stateDb.GetOrNewStateObject(addr)
+	from := statedb.GetOrNewStateObject(addr)
 	from.SetBalance(common.MaxBig)
 	vmError := func() error { return nil }
-	return core.NewEnv(stateDb, b.eth.chainConfig, b.eth.blockchain, msg, header, b.eth.chainConfig.VmConfig), vmError, nil
+	return core.NewEnv(statedb, b.eth.chainConfig, b.eth.blockchain, msg, header, b.eth.chainConfig.VmConfig), vmError, nil
 }
 
 func (b *EthApiBackend) SendTx(ctx context.Context, signedTx *types.Transaction) error {

--- a/internal/ethapi/tracer_test.go
+++ b/internal/ethapi/tracer_test.go
@@ -50,14 +50,14 @@ func (self *Env) Origin() common.Address { return common.Address{} }
 func (self *Env) BlockNumber() *big.Int  { return big.NewInt(0) }
 
 //func (self *Env) PrevHash() []byte      { return self.parent }
-func (self *Env) Coinbase() common.Address  { return common.Address{} }
-func (self *Env) MakeSnapshot() vm.Database { return nil }
-func (self *Env) SetSnapshot(vm.Database)   {}
-func (self *Env) Time() *big.Int            { return big.NewInt(time.Now().Unix()) }
-func (self *Env) Difficulty() *big.Int      { return big.NewInt(0) }
-func (self *Env) Db() vm.Database           { return nil }
-func (self *Env) GasLimit() *big.Int        { return self.gasLimit }
-func (self *Env) VmType() vm.Type           { return vm.StdVmTy }
+func (self *Env) Coinbase() common.Address { return common.Address{} }
+func (self *Env) SnapshotDatabase() int    { return 0 }
+func (self *Env) RevertToSnapshot(int)     {}
+func (self *Env) Time() *big.Int           { return big.NewInt(time.Now().Unix()) }
+func (self *Env) Difficulty() *big.Int     { return big.NewInt(0) }
+func (self *Env) Db() vm.Database          { return nil }
+func (self *Env) GasLimit() *big.Int       { return self.gasLimit }
+func (self *Env) VmType() vm.Type          { return vm.StdVmTy }
 func (self *Env) GetHash(n uint64) common.Hash {
 	return common.BytesToHash(crypto.Keccak256([]byte(big.NewInt(int64(n)).String())))
 }

--- a/light/state_test.go
+++ b/light/state_test.go
@@ -23,7 +23,6 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/state"
-	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/ethdb"
 	"github.com/ethereum/go-ethereum/trie"
 	"golang.org/x/net/context"
@@ -54,16 +53,13 @@ func makeTestState() (common.Hash, ethdb.Database) {
 	sdb, _ := ethdb.NewMemDatabase()
 	st, _ := state.New(common.Hash{}, sdb)
 	for i := byte(0); i < 100; i++ {
-		so := st.GetOrNewStateObject(common.Address{i})
+		addr := common.Address{i}
 		for j := byte(0); j < 100; j++ {
-			val := common.Hash{i, j}
-			so.SetState(common.Hash{j}, val)
-			so.SetNonce(100)
+			st.SetState(addr, common.Hash{j}, common.Hash{i, j})
 		}
-		so.AddBalance(big.NewInt(int64(i)))
-		so.SetCode(crypto.Keccak256Hash([]byte{i, i, i}), []byte{i, i, i})
-		so.UpdateRoot(sdb)
-		st.UpdateStateObject(so)
+		st.SetNonce(addr, 100)
+		st.AddBalance(addr, big.NewInt(int64(i)))
+		st.SetCode(addr, []byte{i, i, i})
 	}
 	root, _ := st.Commit()
 	return root, sdb

--- a/tests/files/StateTests/stInitCodeTest.json
+++ b/tests/files/StateTests/stInitCodeTest.json
@@ -1104,5 +1104,67 @@
             "to" : "",
             "value" : "0x01"
         }
+    },
+    "OutOfGasPrefundedContractCreation" : {
+        "env" : {
+            "currentCoinbase" : "2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
+            "currentDifficulty" : "0x02b8feb0",
+            "currentGasLimit" : "0x05f5e100",
+            "currentNumber" : "0x00",
+            "currentTimestamp" : "0x01",
+            "previousHash" : "5e20a0453cecd065ea59c37ac63e079ee08998b6045136a8ce6635c7912ec0b6"
+        },
+        "logs" : [
+        ],
+        "out" : "0x",
+        "post" : {
+            "2adc25665018aa1fe0e6bc666dac8fc2697ff9ba" : {
+                "balance" : "0x0278d0",
+                "code" : "0x",
+                "nonce" : "0x00",
+                "storage" : {
+                }
+            },
+            "a94f5374fce5edbc8e2a8697c15331677e6ebf0b" : {
+                "balance" : "0x0cc970",
+                "code" : "0x",
+                "nonce" : "0x01",
+                "storage" : {
+                }
+            },
+            "6295ee1b4f6dd65047762f924ecd367c17eabf8f" : {
+                "balance" : "0x1",
+                "code" : "0x",
+                "nonce" : "0x00",
+                "storage" : {
+                }
+            }
+        },
+        "postStateRoot" : "cbc258a15bcc22ec1c8d9e63b82159dd1caf8f3527d8215bdd9168e39d0c89e2",
+        "pre" : {
+            "a94f5374fce5edbc8e2a8697c15331677e6ebf0b" : {
+                "balance" : "0x0f4240",
+                "code" : "0x",
+                "nonce" : "0x00",
+                "storage" : {
+                }
+            },
+            "6295ee1b4f6dd65047762f924ecd367c17eabf8f" : {
+                "balance" : "0x1",
+                "code" : "0x",
+                "nonce" : "0x00",
+                "storage" : {
+                }
+            }
+        },
+        "transaction" : {
+            "data" : "0x600a80600c6000396000f200600160008035811a8100",
+            "gasLimit" : "0xd2f0",
+            "gasPrice" : "0x03",
+            "nonce" : "0x00",
+            "secretKey" : "45a915e4d060149eb4365960e6a7a45f334393093061116b197e3240065ff2d8",
+            "to" : "",
+            "value" : "0x01"
+        }
     }
 }

--- a/tests/state_test_util.go
+++ b/tests/state_test_util.go
@@ -95,14 +95,7 @@ func BenchStateTest(ruleSet RuleSet, p string, conf bconf, b *testing.B) error {
 func benchStateTest(ruleSet RuleSet, test VmTest, env map[string]string, b *testing.B) {
 	b.StopTimer()
 	db, _ := ethdb.NewMemDatabase()
-	statedb, _ := state.New(common.Hash{}, db)
-	for addr, account := range test.Pre {
-		obj := StateObjectFromAccount(db, addr, account, statedb.MarkStateObjectDirty)
-		statedb.SetStateObject(obj)
-		for a, v := range account.Storage {
-			obj.SetState(common.HexToHash(a), common.HexToHash(v))
-		}
-	}
+	statedb := makePreState(db, test.Pre)
 	b.StartTimer()
 
 	RunState(ruleSet, statedb, env, test.Exec)
@@ -134,14 +127,7 @@ func runStateTests(ruleSet RuleSet, tests map[string]VmTest, skipTests []string)
 
 func runStateTest(ruleSet RuleSet, test VmTest) error {
 	db, _ := ethdb.NewMemDatabase()
-	statedb, _ := state.New(common.Hash{}, db)
-	for addr, account := range test.Pre {
-		obj := StateObjectFromAccount(db, addr, account, statedb.MarkStateObjectDirty)
-		statedb.SetStateObject(obj)
-		for a, v := range account.Storage {
-			obj.SetState(common.HexToHash(a), common.HexToHash(v))
-		}
-	}
+	statedb := makePreState(db, test.Pre)
 
 	// XXX Yeah, yeah...
 	env := make(map[string]string)
@@ -227,7 +213,7 @@ func RunState(ruleSet RuleSet, statedb *state.StateDB, env, tx map[string]string
 	}
 	// Set pre compiled contracts
 	vm.Precompiled = vm.PrecompiledContracts()
-	snapshot := statedb.Copy()
+	snapshot := statedb.Snapshot()
 	gaspool := new(core.GasPool).AddGas(common.Big(env["currentGasLimit"]))
 
 	key, _ := hex.DecodeString(tx["secretKey"])
@@ -237,7 +223,7 @@ func RunState(ruleSet RuleSet, statedb *state.StateDB, env, tx map[string]string
 	vmenv.origin = addr
 	ret, _, err := core.ApplyMessage(vmenv, message, gaspool)
 	if core.IsNonceErr(err) || core.IsInvalidTxErr(err) || core.IsGasLimitErr(err) {
-		statedb.Set(snapshot)
+		statedb.RevertToSnapshot(snapshot)
 	}
 	statedb.Commit()
 

--- a/tests/vm_test_util.go
+++ b/tests/vm_test_util.go
@@ -101,14 +101,7 @@ func BenchVmTest(p string, conf bconf, b *testing.B) error {
 func benchVmTest(test VmTest, env map[string]string, b *testing.B) {
 	b.StopTimer()
 	db, _ := ethdb.NewMemDatabase()
-	statedb, _ := state.New(common.Hash{}, db)
-	for addr, account := range test.Pre {
-		obj := StateObjectFromAccount(db, addr, account, statedb.MarkStateObjectDirty)
-		statedb.SetStateObject(obj)
-		for a, v := range account.Storage {
-			obj.SetState(common.HexToHash(a), common.HexToHash(v))
-		}
-	}
+	statedb := makePreState(db, test.Pre)
 	b.StartTimer()
 
 	RunVm(statedb, env, test.Exec)
@@ -152,14 +145,7 @@ func runVmTests(tests map[string]VmTest, skipTests []string) error {
 
 func runVmTest(test VmTest) error {
 	db, _ := ethdb.NewMemDatabase()
-	statedb, _ := state.New(common.Hash{}, db)
-	for addr, account := range test.Pre {
-		obj := StateObjectFromAccount(db, addr, account, statedb.MarkStateObjectDirty)
-		statedb.SetStateObject(obj)
-		for a, v := range account.Storage {
-			obj.SetState(common.HexToHash(a), common.HexToHash(v))
-		}
-	}
+	statedb := makePreState(db, test.Pre)
 
 	// XXX Yeah, yeah...
 	env := make(map[string]string)


### PR DESCRIPTION
This PR implements a write journal that records all changes to state objects, and uses it to rewind state changes in the event of a rollback. This enables us to avoid the need to copy entire state objects when a call is made.