### PR TITLE
core: print import stats more often

### DIFF
--- a/eth/handler.go
+++ b/eth/handler.go
@@ -288,7 +288,7 @@ func (pm *ProtocolManager) handle(p *peer) error {
 		}
 		// Start a timer to disconnect if the peer doesn't reply in time
 		p.forkDrop = time.AfterFunc(daoChallengeTimeout, func() {
-			glog.V(logger.Warn).Infof("%v: timed out DAO fork-check, dropping", p)
+			glog.V(logger.Debug).Infof("%v: timed out DAO fork-check, dropping", p)
 			pm.removePeer(p.id)
 		})
 		// Make sure it's cleaned up if the peer dies off


### PR DESCRIPTION
If geth is busy importing 2048 heavy blocks it can take a while before
it prints anything. This change ensures that a message gets printed
every 8s.