### PR TITLE
eth: optimise initial transaction sync

### DIFF
--- a/core/types/transaction.go
+++ b/core/types/transaction.go
@@ -448,8 +448,8 @@ func (s *TxByPrice) Pop() interface{} {
 // transactions in a profit-maximising sorted order, while supporting removing
 // entire batches of transactions for non-executable accounts.
 type TransactionsByPriceAndNonce struct {
-	txs   map[common.Address]Transactions // Per account nonce-sorted list of transactions
-	heads TxByPrice                       // Next transaction for each unique account (price heap)
+	txs   map[common.Address][]*Transaction // Per account nonce-sorted list of transactions
+	heads TxByPrice                         // Next transaction for each unique account (price heap)
 }
 
 // NewTransactionsByPriceAndNonce creates a transaction set that can retrieve
@@ -457,7 +457,7 @@ type TransactionsByPriceAndNonce struct {
 //
 // Note, the input map is reowned so the caller should not interact any more with
 // if after providng it to the constructor.
-func NewTransactionsByPriceAndNonce(txs map[common.Address]Transactions) *TransactionsByPriceAndNonce {
+func NewTransactionsByPriceAndNonce(txs map[common.Address][]*Transaction) *TransactionsByPriceAndNonce {
 	// Initialize a price based heap with the head transactions
 	heads := make(TxByPrice, 0, len(txs))
 	for acc, accTxs := range txs {

--- a/core/types/transaction_test.go
+++ b/core/types/transaction_test.go
@@ -128,7 +128,7 @@ func TestTransactionPriceNonceSort(t *testing.T) {
 		keys[i], _ = crypto.GenerateKey()
 	}
 	// Generate a batch of transactions with overlapping values, but shifted nonces
-	groups := map[common.Address]Transactions{}
+	groups := make(map[common.Address][]*Transaction)
 	for start, key := range keys {
 		addr := crypto.PubkeyToAddress(key.PublicKey)
 		for i := 0; i < 25; i++ {

--- a/eth/api_backend.go
+++ b/eth/api_backend.go
@@ -126,8 +126,8 @@ func (b *EthApiBackend) GetPoolTransactions() types.Transactions {
 	defer b.eth.txMu.Unlock()
 
 	var txs types.Transactions
-	for _, batch := range b.eth.txPool.Pending() {
-		txs = append(txs, batch...)
+	for _, tx := range b.eth.txPool.PendingTransactions() {
+		txs = append(txs, tx)
 	}
 	return txs
 }

--- a/eth/helper_test.go
+++ b/eth/helper_test.go
@@ -23,7 +23,6 @@ import (
 	"crypto/ecdsa"
 	"crypto/rand"
 	"math/big"
-	"sort"
 	"sync"
 	"testing"
 
@@ -103,19 +102,15 @@ func (p *testTxPool) AddBatch(txs []*types.Transaction) {
 }
 
 // Pending returns all the transactions known to the pool
-func (p *testTxPool) Pending() map[common.Address]types.Transactions {
+func (p *testTxPool) PendingTransactions() map[common.Hash]*types.Transaction {
 	p.lock.RLock()
 	defer p.lock.RUnlock()
 
-	batches := make(map[common.Address]types.Transactions)
+	pending := make(map[common.Hash]*types.Transaction)
 	for _, tx := range p.pool {
-		from, _ := tx.From()
-		batches[from] = append(batches[from], tx)
+		pending[tx.Hash()] = tx
 	}
-	for _, batch := range batches {
-		sort.Sort(types.TxByNonce(batch))
-	}
-	return batches
+	return pending
 }
 
 // newTestTransaction create a new dummy transaction.

--- a/eth/protocol.go
+++ b/eth/protocol.go
@@ -100,9 +100,9 @@ type txPool interface {
 	// AddBatch should add the given transactions to the pool.
 	AddBatch([]*types.Transaction)
 
-	// Pending should return pending transactions.
-	// The slice should be modifiable by the caller.
-	Pending() map[common.Address]types.Transactions
+	// PendingTransactions should return all processable transactions.
+	// The map should be modifiable by the caller.
+	PendingTransactions() map[common.Hash]*types.Transaction
 }
 
 // statusData is the network packet for the status message.

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -236,7 +236,7 @@ func (self *worker) update() {
 				self.currentMu.Lock()
 
 				acc, _ := ev.Tx.From()
-				txs := map[common.Address]types.Transactions{acc: types.Transactions{ev.Tx}}
+				txs := map[common.Address][]*types.Transaction{acc: types.Transactions{ev.Tx}}
 				txset := types.NewTransactionsByPriceAndNonce(txs)
 
 				self.current.commitTransactions(self.mux, txset, self.gasPrice, self.chain)
@@ -495,7 +495,7 @@ func (self *worker) commitNewWork() {
 	if self.config.DAOForkSupport && self.config.DAOForkBlock != nil && self.config.DAOForkBlock.Cmp(header.Number) == 0 {
 		core.ApplyDAOHardFork(work.state)
 	}
-	txs := types.NewTransactionsByPriceAndNonce(self.eth.TxPool().Pending())
+	txs := types.NewTransactionsByPriceAndNonce(self.eth.TxPool().PendingTransactionsByAccount())
 	work.commitTransactions(self.mux, txs, self.gasPrice, self.chain)
 
 	self.eth.TxPool().RemoveBatch(work.lowGasTxs)


### PR DESCRIPTION
When a connection starts up, all current transactions are sent in both
directions. We can mimise the amount of transactions sent by tracking
which txs where sent by the remote side and excluding those from the
ongoing sync. Transactions to send are picked randomly, ensuring that
most transactions are only sent once.

Fixes #1262