### PR TITLE
trie: fix regression that linked all downloaded nodes together

### DIFF
--- a/trie/sync.go
+++ b/trie/sync.go
@@ -213,11 +213,13 @@ func (s *TrieSync) children(req *request) ([]*request, error) {
 
 	switch node := (*req.object).(type) {
 	case *shortNode:
+		node = node.copy() // Prevents linking all downloaded nodes together.
 		children = []child{{
 			node:  &node.Val,
 			depth: req.depth + len(node.Key),
 		}}
 	case *fullNode:
+		node = node.copy()
 		for i := 0; i < 17; i++ {
 			if node.Children[i] != nil {
 				children = append(children, child{


### PR DESCRIPTION
The trie sync code links subtries using pointers into node structs.
Since commit 40cdcf1183 nodes are no longer copied when unpacking from
an interface value, causing all nodes to get linked up as the sync
progresses. Fix it by breaking the pointer chain with an explicit copy.