### PR TITLE
common, core, eth/downloader: adjust import log formatting

### DIFF
--- a/common/format.go
+++ b/common/format.go
@@ -1,0 +1,40 @@
+// Copyright 2016 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+package common
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+	"time"
+)
+
+// PrettyDuration is a pretty printed version of a time.Duration value that cuts
+// the unnecessary precision off from the formatted textual representation.
+type PrettyDuration time.Duration
+
+var prettyDurationRe = regexp.MustCompile("\\.[0-9]+")
+
+// String implements the Stringer interface, allowing pretty printing of duration
+// values rounded to three decimals.
+func (d PrettyDuration) String() string {
+	label := fmt.Sprintf("%v", time.Duration(d))
+	if match := prettyDurationRe.FindString(label); len(match) > 4 {
+		label = strings.Replace(label, match, match[:4], 1)
+	}
+	return label
+}

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -769,8 +769,12 @@ func (self *BlockChain) InsertReceiptChain(blockChain types.Blocks, receiptChain
 
 	// Report some public statistics so the user has a clue what's going on
 	first, last := blockChain[0], blockChain[len(blockChain)-1]
-	glog.V(logger.Info).Infof("imported %d receipt(s) (%d ignored) in %v. #%d [%x… / %x…]", stats.processed, stats.ignored,
-		time.Since(start), last.Number(), first.Hash().Bytes()[:4], last.Hash().Bytes()[:4])
+
+	ignored := ""
+	if stats.ignored > 0 {
+		ignored = fmt.Sprintf(" (%d ignored)", stats.ignored)
+	}
+	glog.V(logger.Info).Infof("imported %d receipts%s in %9v. #%d [%x… / %x…]", stats.processed, ignored, common.PrettyDuration(time.Since(start)), last.Number(), first.Hash().Bytes()[:4], last.Hash().Bytes()[:4])
 
 	return 0, nil
 }
@@ -947,7 +951,7 @@ func (self *BlockChain) InsertChain(chain types.Blocks) (int, error) {
 		switch status {
 		case CanonStatTy:
 			if glog.V(logger.Debug) {
-				glog.Infof("[%v] inserted block #%d (%d TXs %v G %d UNCs) (%x...). Took %v\n", time.Now().UnixNano(), block.Number(), len(block.Transactions()), block.GasUsed(), len(block.Uncles()), block.Hash().Bytes()[0:4], time.Since(bstart))
+				glog.Infof("inserted block #%d [%x…] in %9v: %3d txs %7v gas %d uncles.", block.Number(), block.Hash().Bytes()[0:4], common.PrettyDuration(time.Since(bstart)), len(block.Transactions()), block.GasUsed(), len(block.Uncles()))
 			}
 			events = append(events, ChainEvent{block, block.Hash(), logs})
 
@@ -965,7 +969,7 @@ func (self *BlockChain) InsertChain(chain types.Blocks) (int, error) {
 			}
 		case SideStatTy:
 			if glog.V(logger.Detail) {
-				glog.Infof("inserted forked block #%d (TD=%v) (%d TXs %d UNCs) (%x...). Took %v\n", block.Number(), block.Difficulty(), len(block.Transactions()), len(block.Uncles()), block.Hash().Bytes()[0:4], time.Since(bstart))
+				glog.Infof("inserted forked block #%d [%x…] (TD=%v) in %9v: %3d txs %d uncles.", block.Number(), block.Hash().Bytes()[0:4], block.Difficulty(), common.PrettyDuration(time.Since(bstart)), len(block.Transactions()), len(block.Uncles()))
 			}
 			events = append(events, ChainSideEvent{block, logs})
 
@@ -991,24 +995,27 @@ type insertStats struct {
 	startTime                  time.Time
 }
 
-const (
-	statsReportLimit     = 1024
-	statsReportTimeLimit = 8 * time.Second
-)
+// statsReportLimit is the time limit during import after which we always print
+// out progress. This avoids the user wondering what's going on.
+const statsReportLimit = 8 * time.Second
 
 // report prints statistics if some number of blocks have been processed
 // or more than a few seconds have passed since the last message.
 func (st *insertStats) report(chain []*types.Block, index int) {
-	limit := statsReportLimit
-	if index == len(chain)-1 {
-		limit = 0 // Always print a message for the last block.
-	}
-	now := time.Now()
-	duration := now.Sub(st.startTime)
-	if duration > statsReportTimeLimit || st.queued > limit || st.processed > limit || st.ignored > limit {
+	var (
+		now     = time.Now()
+		elapsed = now.Sub(st.startTime)
+	)
+	if index == len(chain)-1 || elapsed >= statsReportLimit {
 		start, end := chain[st.lastIndex], chain[index]
 		txcount := countTransactions(chain[st.lastIndex : index+1])
-		glog.Infof("imported %d block(s) (%d queued %d ignored) including %d txs in %v. #%v [%x / %x]\n", st.processed, st.queued, st.ignored, txcount, duration, end.Number(), start.Hash().Bytes()[:4], end.Hash().Bytes()[:4])
+
+		extra := ""
+		if st.queued > 0 || st.ignored > 0 {
+			extra = fmt.Sprintf(" (%d queued %d ignored)", st.queued, st.ignored)
+		}
+		glog.Infof("imported %d blocks%s, %5d txs in %9v. #%v [%x… / %x…]\n", st.processed, extra, txcount, common.PrettyDuration(elapsed), end.Number(), start.Hash().Bytes()[:4], end.Hash().Bytes()[:4])
+
 		*st = insertStats{startTime: now, lastIndex: index}
 	}
 }

--- a/core/headerchain.go
+++ b/core/headerchain.go
@@ -18,6 +18,7 @@ package core
 
 import (
 	crand "crypto/rand"
+	"fmt"
 	"math"
 	"math/big"
 	mrand "math/rand"
@@ -321,8 +322,12 @@ func (hc *HeaderChain) InsertHeaderChain(chain []*types.Header, checkFreq int, w
 	}
 	// Report some public statistics so the user has a clue what's going on
 	first, last := chain[0], chain[len(chain)-1]
-	glog.V(logger.Info).Infof("imported %d header(s) (%d ignored) in %v. #%v [%x… / %x…]", stats.processed, stats.ignored,
-		time.Since(start), last.Number, first.Hash().Bytes()[:4], last.Hash().Bytes()[:4])
+
+	ignored := ""
+	if stats.ignored > 0 {
+		ignored = fmt.Sprintf(" (%d ignored)", stats.ignored)
+	}
+	glog.V(logger.Info).Infof("imported %d headers%s in %9v. #%v [%x… / %x…]", stats.processed, ignored, common.PrettyDuration(time.Since(start)), last.Number, first.Hash().Bytes()[:4], last.Hash().Bytes()[:4])
 
 	return 0, nil
 }

--- a/eth/downloader/downloader.go
+++ b/eth/downloader/downloader.go
@@ -952,7 +952,7 @@ func (d *Downloader) fetchNodeData() error {
 
 				// Log a message to the user and return
 				if delivered > 0 {
-					glog.V(logger.Info).Infof("imported %d state entries in %v: processed %d, pending at least %d", delivered, time.Since(start), d.syncStatsStateDone, pending)
+					glog.V(logger.Info).Infof("imported %d state entries in %9v: processed %d, pending at least %d", delivered, common.PrettyDuration(time.Since(start)), d.syncStatsStateDone, pending)
 				}
 			})
 		}


### PR DESCRIPTION
This PR adjust the `import xxx` log lines a bit:

 * Introduces a `common.PrettyDuration` type that serializes with 3 decimal precision, not the crazy 9 version of the stock Go.
 * Transaction counts are expanded to 5 digits to cater for aligned import logs during syncs.
 * Time values are expanded to 9 characters to again cater for aligned import logs during syncs.
 * Omit the `(x queued, y ignored)` part if `x == 0` and `y == 0`

```
I1018 11:49:16.549363 core/blockchain.go:1019] imported 2500 blocks,     0 txs in 752.680ms. #42500 [6e131297 / 441b03be]
I1018 11:49:17.277554 core/blockchain.go:1019] imported 2500 blocks,     0 txs in 719.161ms. #45000 [b54dd325 / a1aeb171]
I1018 11:49:18.308139 core/blockchain.go:1019] imported 2500 blocks,   609 txs in    1.019s. #47500 [abcf870c / 335ebf4f]
I1018 11:49:19.691668 core/blockchain.go:1019] imported 2500 blocks,  1262 txs in    1.370s. #50000 [4ee96561 / 0e30a7c0]
I1018 11:49:21.250418 core/blockchain.go:1019] imported 2500 blocks,  1029 txs in    1.545s. #52500 [3ed2e0a5 / 70c5aff2]
I1018 11:49:23.237391 core/blockchain.go:1019] imported 2500 blocks,  1486 txs in    1.973s. #55000 [d2d19417 / 6be8b24d]
I1018 11:49:24.709930 core/blockchain.go:1019] imported 2500 blocks,  1080 txs in    1.459s. #57500 [06400191 / 3c08ed7d]
I1018 11:49:25.641679 core/blockchain.go:1019] imported 2500 blocks,   458 txs in 921.811ms. #60000 [0d930d57 / f3d66025]
```

The debug block processing logs have also been modified a bit:

 * Drop the superfluous unix timestamp values from them (the log already contains the time)
 * Reordered fields a bit to allow nicer alignment.
 * Set fixed widths for more fields to align tem properly.

```
I1018 12:05:14.939011 core/blockchain.go:955] inserted block #208205 [f236cd2b…] in 455.703µs:   0 txs       0 gas 0 uncles.
I1018 12:05:14.942094 core/blockchain.go:955] inserted block #208206 [ae169902…] in   3.009ms:   4 txs   84000 gas 1 uncles.
I1018 12:05:14.947574 core/blockchain.go:955] inserted block #208207 [64328527…] in   5.288ms:   7 txs  147000 gas 0 uncles.
I1018 12:05:15.025687 core/blockchain.go:955] inserted block #208208 [cd315370…] in  77.798ms: 127 txs 2667000 gas 0 uncles.
I1018 12:05:15.028066 core/blockchain.go:955] inserted block #208209 [847f7ee2…] in 656.259µs:   0 txs       0 gas 0 uncles.
I1018 12:05:15.030271 core/blockchain.go:955] inserted block #208210 [cd9a37b9…] in   2.152ms:   4 txs   84000 gas 1 uncles.
I1018 12:05:15.030710 core/blockchain.go:955] inserted block #208211 [38d9131e…] in 325.855µs:   0 txs       0 gas 0 uncles.
```

In addition, the PR drops part of a previously added feature which printed an import log after every `1025` blocks (yes, 1025 :P). The reason why this is not needed is because we import in batches of 2048 anyway, so those are always printed and the 8sec print timeout still in place should be enough to show progress. (Removing it also results in cleaner logs when import batches are not multiples of 1025 ( :P ), like during import from a dumped chain).