### PR TITLE
core/vm: Panic if JIT is invoked

### DIFF
--- a/core/vm/vm.go
+++ b/core/vm/vm.go
@@ -88,6 +88,10 @@ func (evm *EVM) Run(contract *Contract, input []byte) (ret []byte, err error) {
 			return RunProgram(GetProgram(codehash), evm.env, contract, input)
 		case progUnknown:
 			if evm.cfg.ForceJit {
+				// JIT support has fallen off; gas calculations are no longer in consensus
+				// with the network.
+				panic("JIT not supported in this release")
+
 				// Create and compile program
 				program = NewProgram(contract.Code)
 				perr := CompileProgram(program)


### PR DESCRIPTION
Hi folks,

First off, thanks for all the hard work these past few weeks! I know things must have been difficult.

Support for JIT appears to have been dropped in 1.4.16, and as of the hard-fork release JIT produces results that are no longer consensus-compatible. Specifically, the gas cost calculations do not use the gas table, and even prior to hard-fork activation we were seeing consistent issues with the JIT cost estimation when invoking CALL.

I have no insight as to whether this is a temporary or longer-term state of affairs for JIT, but in the meantime it seems prudent to catch anyone who manages to invoke JIT either through the command line or a custom entry point into go-ethereum.