### PR TITLE
core/vm: Panic if JIT is invoked

### DIFF
--- a/core/vm/vm.go
+++ b/core/vm/vm.go
@@ -79,6 +79,10 @@ func (evm *EVM) Run(contract *Contract, input []byte) (ret []byte, err error) {
 	}
 	var program *Program
 	if evm.cfg.EnableJit {
+		// JIT support has fallen off; gas calculations are no longer in consensus
+		// with the network.
+		panic("JIT not supported in this release")
+
 		// If the JIT is enabled check the status of the JIT program,
 		// if it doesn't exist compile a new program in a separate
 		// goroutine or wait for compilation to finish if the JIT is


### PR DESCRIPTION
(This is a resubmit of a previous attempt with a commit message that did not meet repository guidelines)

Hi folks,

First off, thanks for all the hard work these past few weeks! I know things must have been difficult.

Support for JIT appears to have been dropped in 1.4.16, and as of the hard-fork release JIT produces results that are no longer consensus-compatible. Specifically, the gas cost calculations do not use the gas table, and even prior to hard-fork activation we were seeing consistent issues with the JIT cost estimation when invoking CALL.

I have no insight as to whether this is a temporary or longer-term state of affairs for JIT, but in the meantime it seems prudent to catch anyone who manages to invoke JIT either through the command line or a custom entry point into go-ethereum.