### PR TITLE
core/vm: Ignore EnableJit ChainConfig setting

### DIFF
--- a/core/vm/vm.go
+++ b/core/vm/vm.go
@@ -78,7 +78,9 @@ func (evm *EVM) Run(contract *Contract, input []byte) (ret []byte, err error) {
 		codehash = crypto.Keccak256Hash(contract.Code)
 	}
 	var program *Program
-	if evm.cfg.EnableJit {
+	if false {
+		// JIT disabled due to JIT not being Homestead gas reprice ready.
+
 		// If the JIT is enabled check the status of the JIT program,
 		// if it doesn't exist compile a new program in a separate
 		// goroutine or wait for compilation to finish if the JIT is


### PR DESCRIPTION
As JIT does not currently calculate the correct gas costs due to the reprice fork, ignore any attempt to use it.

Replacement for  #3165. Thanks @obscuren!