### PR TITLE
cmd/geth, code, eth/downloader: tune import logs and mem stats

### DIFF
--- a/core/blockchain_test.go
+++ b/core/blockchain_test.go
@@ -436,7 +436,7 @@ func (bproc) ValidateState(block, parent *types.Block, state *state.StateDB, rec
 	return nil
 }
 func (bproc) Process(block *types.Block, statedb *state.StateDB, cfg vm.Config) (types.Receipts, vm.Logs, *big.Int, error) {
-	return nil, nil, nil, nil
+	return nil, nil, new(big.Int), nil
 }
 
 func makeHeaderChainWithDiff(genesis *types.Block, d []int, seed byte) []*types.Header {

--- a/eth/downloader/downloader.go
+++ b/eth/downloader/downloader.go
@@ -952,7 +952,7 @@ func (d *Downloader) fetchNodeData() error {
 
 				// Log a message to the user and return
 				if delivered > 0 {
-					glog.V(logger.Info).Infof("imported %d state entries in %9v: processed %d, pending at least %d", delivered, common.PrettyDuration(time.Since(start)), d.syncStatsStateDone, pending)
+					glog.V(logger.Info).Infof("imported %3d state entries in %9v: processed %d, pending at least %d", delivered, common.PrettyDuration(time.Since(start)), d.syncStatsStateDone, pending)
 				}
 			})
 		}


### PR DESCRIPTION
- Collect memory usage stats during `geth import` and print them on finish.
- Format import logs a bit to make @Arachnid 's OCD happy.
- Add megagas/second stats to import log entries.