### PR TITLE
core/state, trie: add direct cache for state values

### DIFF
--- a/cmd/geth/chaincmd.go
+++ b/cmd/geth/chaincmd.go
@@ -33,6 +33,7 @@ import (
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/ethdb"
 	"github.com/ethereum/go-ethereum/logger/glog"
+	"github.com/ethereum/go-ethereum/rlp"
 	"github.com/ethereum/go-ethereum/trie"
 	"github.com/syndtr/goleveldb/leveldb/util"
 	"gopkg.in/urfave/cli.v1"
@@ -268,6 +269,49 @@ func dump(ctx *cli.Context) error {
 		}
 	}
 	chainDb.Close()
+	return nil
+}
+
+var accountCacheKeyPrefix = []byte("accounthashcache:")
+
+type cachedAccount struct {
+	state.Account
+	BlockNum  uint64
+	BlockHash common.Hash
+}
+
+func buildCache(ctx *cli.Context) error {
+	stack := makeFullNode(ctx)
+	chain, chainDb := utils.MakeChain(ctx, stack)
+	defer chainDb.Close()
+
+	num, _ := strconv.Atoi(ctx.Args()[0])
+	blockNum := uint64(num)
+	block := chain.GetBlockByNumber(blockNum)
+	blockHash := block.Hash()
+	t, err := trie.New(block.Root(), chainDb, 0)
+	if err != nil {
+		utils.Fatalf("Could not open trie: %v", err)
+	}
+	st := trie.NewSecure(t, chainDb)
+	iter := st.Iterator()
+	i := 0
+	for iter.Next() {
+		var data state.Account
+		if err := rlp.DecodeBytes(iter.Value, &data); err != nil {
+			utils.Fatalf("can't decode object at %x: %v", iter.Key[:], err)
+		}
+
+		enc, _ := rlp.EncodeToBytes(cachedAccount{data, blockNum, blockHash})
+		if err := chainDb.Put(append(accountCacheKeyPrefix, iter.Key[:]...), enc); err != nil {
+			utils.Fatalf("Could not write to DB: %v", err)
+		}
+
+		i += 1
+		if i % 10000 == 0 {
+			fmt.Printf("Processed %d accounts, at %v\n", i, common.ToHex(iter.Key))
+		}
+	}
 	return nil
 }
 

--- a/cmd/geth/chaincmd.go
+++ b/cmd/geth/chaincmd.go
@@ -118,8 +118,11 @@ func importChain(ctx *cli.Context) error {
 		utils.Fatalf("Failed to read database stats: %v", err)
 	}
 	fmt.Println(stats)
-	fmt.Printf("Trie cache misses:  %d\n", trie.CacheMisses())
-	fmt.Printf("Trie cache unloads: %d\n\n", trie.CacheUnloads())
+	fmt.Printf("Trie cache misses:   %d\n", trie.CacheMisses())
+	fmt.Printf("Trie cache unloads:  %d\n", trie.CacheUnloads())
+	fmt.Printf("Direct cache reads:  %d\n", trie.DirectCacheReads())
+	fmt.Printf("Direct cache writes: %d\n", trie.DirectCacheWrites())
+	fmt.Printf("Direct cache misses: %d\n\n", trie.DirectCacheMisses())
 
 	// Print the memory statistics used by the importing
 	mem := new(runtime.MemStats)
@@ -308,7 +311,7 @@ func buildCache(ctx *cli.Context) error {
 		}
 
 		i += 1
-		if i % 10000 == 0 {
+		if i%10000 == 0 {
 			fmt.Printf("Processed %d accounts, at %v\n", i, common.ToHex(iter.Key))
 		}
 	}

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -545,6 +545,11 @@ func (self *BlockChain) GetBlockByNumber(number uint64) *types.Block {
 	return self.GetBlock(hash, number)
 }
 
+// IsCanonChainBlock checks whether the given block is in the current canonical chain.
+func (self *BlockChain) IsCanonChainBlock(number uint64, hash common.Hash) bool {
+	return number < uint64(self.currentBlock.Number().Int64()) && GetCanonicalHash(self.chainDb, number) == hash
+}
+
 // [deprecated by eth/62]
 // GetBlocksFromHash returns the block corresponding to hash and up to n-1 ancestors.
 func (self *BlockChain) GetBlocksFromHash(hash common.Hash, n int) (blocks []*types.Block) {

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -269,7 +269,7 @@ func (self *BlockChain) FastSyncCommitHead(hash common.Hash) error {
 	if block == nil {
 		return fmt.Errorf("non existent block [%x…]", hash[:4])
 	}
-	if _, err := trie.NewSecure(block.Root(), self.chainDb, 0); err != nil {
+	if _, err := trie.New(block.Root(), self.chainDb, 0); err != nil {
 		return err
 	}
 	// If all checks out, manually set the head block

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -922,6 +922,7 @@ func (self *BlockChain) InsertChain(chain types.Blocks) (int, error) {
 			reportBlock(block, err)
 			return i, err
 		}
+		self.stateCache.SetBlockContext(block.Hash(), block.NumberU64(), self)
 		// Process block using the parent state as reference point.
 		receipts, logs, usedGas, err := self.processor.Process(block, self.stateCache, self.config.VmConfig)
 		if err != nil {

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -547,7 +547,7 @@ func (self *BlockChain) GetBlockByNumber(number uint64) *types.Block {
 
 // IsCanonChainBlock checks whether the given block is in the current canonical chain.
 func (self *BlockChain) IsCanonChainBlock(number uint64, hash common.Hash) bool {
-	return number < uint64(self.currentBlock.Number().Int64()) && GetCanonicalHash(self.chainDb, number) == hash
+	return GetCanonicalHash(self.chainDb, number) == hash
 }
 
 // [deprecated by eth/62]

--- a/core/chain_makers.go
+++ b/core/chain_makers.go
@@ -105,7 +105,7 @@ func (b *BlockGen) AddTx(tx *types.Transaction) {
 	if b.gasPool == nil {
 		b.SetCoinbase(common.Address{})
 	}
-	b.statedb.SetTxContext(common.Hash{}, b.header.Number.Uint64(), tx.Hash(), len(b.txs), nil)
+	b.statedb.SetTxContext(tx.Hash(), len(b.txs))
 	receipt, _, _, err := ApplyTransaction(MakeChainConfig(), nil, b.gasPool, b.statedb, b.header, tx, b.header.GasUsed, vm.Config{})
 	if err != nil {
 		panic(err)

--- a/core/chain_makers.go
+++ b/core/chain_makers.go
@@ -105,7 +105,7 @@ func (b *BlockGen) AddTx(tx *types.Transaction) {
 	if b.gasPool == nil {
 		b.SetCoinbase(common.Address{})
 	}
-	b.statedb.StartRecord(tx.Hash(), common.Hash{}, len(b.txs))
+	b.statedb.SetTxContext(common.Hash{}, b.header.Number.Uint64(), tx.Hash(), len(b.txs), nil)
 	receipt, _, _, err := ApplyTransaction(MakeChainConfig(), nil, b.gasPool, b.statedb, b.header, tx, b.header.GasUsed, vm.Config{})
 	if err != nil {
 		panic(err)

--- a/core/state/dump.go
+++ b/core/state/dump.go
@@ -44,9 +44,9 @@ func (self *StateDB) RawDump() Dump {
 		Accounts: make(map[string]DumpAccount),
 	}
 
-	it := self.trie.Iterator()
+	it := self.storage.Iterator()
 	for it.Next() {
-		addr := self.trie.GetKey(it.Key)
+		addr := self.storage.GetKey(it.Key)
 		var data Account
 		if err := rlp.DecodeBytes(it.Value, &data); err != nil {
 			panic(err)
@@ -61,9 +61,9 @@ func (self *StateDB) RawDump() Dump {
 			Code:     common.Bytes2Hex(obj.Code(self.db)),
 			Storage:  make(map[string]string),
 		}
-		storageIt := obj.getTrie(self.db).Iterator()
+		storageIt := obj.getStorage(self.db).Iterator()
 		for storageIt.Next() {
-			account.Storage[common.Bytes2Hex(self.trie.GetKey(storageIt.Key))] = common.Bytes2Hex(storageIt.Value)
+			account.Storage[common.Bytes2Hex(self.storage.GetKey(storageIt.Key))] = common.Bytes2Hex(storageIt.Value)
 		}
 		dump.Accounts[common.Bytes2Hex(addr)] = account
 	}

--- a/core/state/iterator.go
+++ b/core/state/iterator.go
@@ -115,11 +115,11 @@ func (it *NodeIterator) step() error {
 	if err := rlp.Decode(bytes.NewReader(it.stateIt.LeafBlob), &account); err != nil {
 		return err
 	}
-	dataTrie, err := trie.New(account.Root, it.state.db)
+	dataTrie, err := trie.New(account.Root, it.state.db, 0)
 	if err != nil {
 		return err
 	}
-	it.dataIt = trie.NewNodeIterator(dataTrie)
+	it.dataIt = dataTrie.NodeIterator()
 	if !it.dataIt.Next() {
 		it.dataIt = nil
 	}

--- a/core/state/iterator.go
+++ b/core/state/iterator.go
@@ -76,7 +76,7 @@ func (it *NodeIterator) step() error {
 	}
 	// Initialize the iterator if we've just started
 	if it.stateIt == nil {
-		it.stateIt = it.state.trie.NodeIterator()
+		it.stateIt = trie.NewNodeIterator(it.state.trie)
 	}
 	// If we had data nodes previously, we surely have at least state nodes
 	if it.dataIt != nil {
@@ -119,7 +119,7 @@ func (it *NodeIterator) step() error {
 	if err != nil {
 		return err
 	}
-	it.dataIt = dataTrie.NodeIterator()
+	it.dataIt = trie.NewNodeIterator(dataTrie)
 	if !it.dataIt.Next() {
 		it.dataIt = nil
 	}

--- a/core/state/iterator_test.go
+++ b/core/state/iterator_test.go
@@ -47,7 +47,7 @@ func TestNodeIteratorCoverage(t *testing.T) {
 		}
 	}
 	for _, key := range db.(*ethdb.MemDatabase).Keys() {
-		if bytes.HasPrefix(key, []byte("secure-key-")) {
+		if bytes.HasPrefix(key, []byte("secure-key-")) || bytes.HasPrefix(key, CachePrefix) {
 			continue
 		}
 		if _, ok := hashes[common.BytesToHash(key)]; !ok {

--- a/core/state/iterator_test.go
+++ b/core/state/iterator_test.go
@@ -47,7 +47,7 @@ func TestNodeIteratorCoverage(t *testing.T) {
 		}
 	}
 	for _, key := range db.(*ethdb.MemDatabase).Keys() {
-		if bytes.HasPrefix(key, []byte("secure-key-")) || bytes.HasPrefix(key, CachePrefix) {
+		if bytes.HasPrefix(key, []byte("secure-key-")) || bytes.HasPrefix(key, DirectCachePrefix) {
 			continue
 		}
 		if _, ok := hashes[common.BytesToHash(key)]; !ok {

--- a/core/state/state_object.go
+++ b/core/state/state_object.go
@@ -137,11 +137,12 @@ func (self *StateObject) markSuicided() {
 func (c *StateObject) getTrie(db trie.Database) *trie.SecureTrie {
 	if c.trie == nil {
 		var err error
-		c.trie, err = trie.NewSecure(c.data.Root, db, 0)
+		t, err := trie.New(c.data.Root, db, 0)
 		if err != nil {
-			c.trie, _ = trie.NewSecure(common.Hash{}, db, 0)
+			t, _ = trie.New(common.Hash{}, nil, 0)
 			c.setError(fmt.Errorf("can't create storage trie: %v", err))
 		}
+		c.trie = trie.NewSecure(t, db)
 	}
 	return c.trie
 }

--- a/core/state/state_object.go
+++ b/core/state/state_object.go
@@ -76,7 +76,7 @@ type StateObject struct {
 	dbErr error
 
 	// Write caches.
-	trie *trie.SimpleTrie // storage trie, which becomes non-nil on first access
+	trie *trie.Trie // storage trie, which becomes non-nil on first access
 	storage *trie.SecureTrie // Interface to storage
 	code Code             // contract bytecode, which gets set when code is loaded
 

--- a/core/state/statedb.go
+++ b/core/state/statedb.go
@@ -191,7 +191,7 @@ func (self *StateDB) SetTxContext(blockHash common.Hash, blockNum uint64, txHash
 	if validator == nil {
 		validator = &trie.NullCacheValidator{}
 	}
-	storage := trie.NewDirectCache(self.trie, self.db, CachePrefix, &trie.NullCacheValidator{}, true)
+	storage := trie.NewDirectCache(self.trie, self.db, CachePrefix, validator, true)
 	self.storage = trie.NewSecure(storage, self.db)
 }
 

--- a/core/state/statedb.go
+++ b/core/state/statedb.go
@@ -191,7 +191,7 @@ func (self *StateDB) SetTxContext(blockHash common.Hash, blockNum uint64, txHash
 	if validator == nil {
 		validator = &trie.NullCacheValidator{}
 	}
-	storage := trie.NewDirectCache(self.trie, self.db, CachePrefix, validator, true)
+	storage := trie.NewDirectCache(self.trie, self.db, CachePrefix, &trie.NullCacheValidator{}, true)
 	self.storage = trie.NewSecure(storage, self.db)
 }
 

--- a/core/state/statedb.go
+++ b/core/state/statedb.go
@@ -188,7 +188,7 @@ func (self *StateDB) SetBlockContext(blockHash common.Hash, blockNum uint64, val
 	if validator == nil {
 		validator = &trie.NullCacheValidator{}
 	}
-	storage := trie.NewDirectCache(self.trie, self.db, CachePrefix, validator, true)
+	storage := trie.NewDirectCache(self.trie, self.db, CachePrefix, blockNum, blockHash, validator, true)
 	self.storage = trie.NewSecure(storage, self.db)
 }
 

--- a/core/state/statedb.go
+++ b/core/state/statedb.go
@@ -107,7 +107,7 @@ func New(root common.Hash, db ethdb.Database) (*StateDB, error) {
 		refund:            new(big.Int),
 		logs:              make(map[common.Hash]vm.Logs),
 	}
-	ret.SetTxContext(common.Hash{}, 0, common.Hash{}, 0, nil)
+	ret.SetBlockContext(common.Hash{}, 0, nil)
 	return ret, nil
 }
 
@@ -130,7 +130,7 @@ func (self *StateDB) New(root common.Hash) (*StateDB, error) {
 		refund:            new(big.Int),
 		logs:              make(map[common.Hash]vm.Logs),
 	}
-	ret.SetTxContext(common.Hash{}, 0, common.Hash{}, 0, nil)
+	ret.SetBlockContext(common.Hash{}, 0, nil)
 	return ret, nil
 }
 
@@ -153,8 +153,8 @@ func (self *StateDB) Reset(root common.Hash) error {
 	self.logs = make(map[common.Hash]vm.Logs)
 	self.logSize = 0
 	self.clearJournalAndRefund()
-	self.SetTxContext(common.Hash{}, 0, common.Hash{}, 0, nil)
-
+	self.SetBlockContext(common.Hash{}, 0, nil)
+	self.SetTxContext(common.Hash{}, 0)
 
 	return nil
 }
@@ -183,16 +183,18 @@ func (self *StateDB) pushTrie(t *trie.Trie) {
 	}
 }
 
-func (self *StateDB) SetTxContext(blockHash common.Hash, blockNum uint64, txHash common.Hash, txIndex int, validator trie.CacheValidator) {
+func (self *StateDB) SetBlockContext(blockHash common.Hash, blockNum uint64, validator trie.CacheValidator) {
 	self.bhash = blockHash
-	self.thash = txHash
-	self.txIndex = txIndex
-
 	if validator == nil {
 		validator = &trie.NullCacheValidator{}
 	}
 	storage := trie.NewDirectCache(self.trie, self.db, CachePrefix, validator, true)
 	self.storage = trie.NewSecure(storage, self.db)
+}
+
+func (self *StateDB) SetTxContext(txHash common.Hash, txIndex int) {
+	self.thash = txHash
+	self.txIndex = txIndex
 }
 
 func (self *StateDB) AddLog(log *vm.Log) {

--- a/core/state/statedb.go
+++ b/core/state/statedb.go
@@ -62,9 +62,9 @@ type revision struct {
 // * Accounts
 type StateDB struct {
 	db            ethdb.Database
-	trie          *trie.SimpleTrie
+	trie          *trie.Trie
 	storage       *trie.SecureTrie
-	pastTries     []*trie.SimpleTrie
+	pastTries     []*trie.Trie
 	codeSizeCache *lru.Cache
 
 	// This map holds 'live' objects, which will get modified while processing a state transition.
@@ -155,7 +155,7 @@ func (self *StateDB) Reset(root common.Hash) error {
 
 // openTrie creates a trie. It uses an existing trie if one is available
 // from the journal if available.
-func (self *StateDB) openTrie(root common.Hash) (*trie.SimpleTrie, error) {
+func (self *StateDB) openTrie(root common.Hash) (*trie.Trie, error) {
 	for i := len(self.pastTries) - 1; i >= 0; i-- {
 		if self.pastTries[i].Hash() == root {
 			tr := *self.pastTries[i]
@@ -165,7 +165,7 @@ func (self *StateDB) openTrie(root common.Hash) (*trie.SimpleTrie, error) {
 	return trie.New(root, self.db, MaxTrieCacheGen)
 }
 
-func (self *StateDB) pushTrie(t *trie.SimpleTrie) {
+func (self *StateDB) pushTrie(t *trie.Trie) {
 	self.lock.Lock()
 	defer self.lock.Unlock()
 

--- a/core/state/statedb.go
+++ b/core/state/statedb.go
@@ -42,7 +42,6 @@ var StartingNonce uint64
 var MaxTrieCacheGen = uint16(120)
 
 var DirectCachePrefix = []byte("accounthashcache:")
-var DirectStateCacheCompleteKey = []byte("directstatecache:complete")
 
 const (
 	// Number of past tries to keep. This value is chosen such that
@@ -193,12 +192,12 @@ func (self *StateDB) SetBlockContext(blockHash common.Hash, blockNum uint64, val
 
 	// Check if cache population has completed
 	if !self.cacheComplete {
-		if value, err := self.db.Get(DirectStateCacheCompleteKey); err == nil && value != nil {
+		if _, status := trie.GetMigrationState(DirectCachePrefix, self.db); status == trie.Complete {
 			self.cacheComplete = true
 		}
 	}
 
-	storage := trie.NewDirectCache(self.trie, self.db, DirectCachePrefix, blockNum, blockHash, validator, true)
+	storage := trie.NewDirectCache(self.trie, self.db, DirectCachePrefix, blockNum, blockHash, validator, self.cacheComplete)
 	self.storage = trie.NewSecure(storage, self.db)
 }
 

--- a/core/state/sync.go
+++ b/core/state/sync.go
@@ -53,12 +53,12 @@ func NewStateSync(number uint64, hash common.Hash, root common.Hash, database et
 			}
 		}
 		// Schedule downloading all the dependencies of the account
-		syncer.AddSubTrie(obj.Root, 64, parent, nil)
+		syncer.AddSubTrie(obj.Root, 64, parent, nil, nil)
 		syncer.AddRawEntry(common.BytesToHash(obj.CodeHash), 64, parent)
 
 		return nil
 	}
-	syncer = trie.NewTrieSync(root, database, callback)
+	syncer = trie.NewTrieSync(root, database, callback, CachePrefix)
 	return (*StateSync)(syncer)
 }
 

--- a/core/state/sync_test.go
+++ b/core/state/sync_test.go
@@ -47,8 +47,8 @@ func makeTestState() (ethdb.Database, common.Hash, []*testAccount) {
 		obj := state.GetOrNewStateObject(common.BytesToAddress([]byte{i}))
 		acc := &testAccount{address: common.BytesToAddress([]byte{i})}
 
-		obj.AddBalance(big.NewInt(int64(11 * i)))
-		acc.balance = big.NewInt(int64(11 * i))
+		obj.AddBalance(big.NewInt(11 * int64(i)))
+		acc.balance = big.NewInt(11 * int64(i))
 
 		obj.SetNonce(uint64(42 * i))
 		acc.nonce = uint64(42 * i)
@@ -110,7 +110,7 @@ func checkStateConsistency(db ethdb.Database, root common.Hash) error {
 func TestEmptyStateSync(t *testing.T) {
 	empty := common.HexToHash("56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421")
 	db, _ := ethdb.NewMemDatabase()
-	if req := NewStateSync(empty, db).Missing(1); len(req) != 0 {
+	if req := NewStateSync(0, common.Hash{}, empty, db).Missing(1); len(req) != 0 {
 		t.Errorf("content requested for empty state: %v", req)
 	}
 }
@@ -126,7 +126,7 @@ func testIterativeStateSync(t *testing.T, batch int) {
 
 	// Create a destination state and sync with the scheduler
 	dstDb, _ := ethdb.NewMemDatabase()
-	sched := NewStateSync(srcRoot, dstDb)
+	sched := NewStateSync(0, common.Hash{}, srcRoot, dstDb)
 
 	queue := append([]common.Hash{}, sched.Missing(batch)...)
 	for len(queue) > 0 {
@@ -155,7 +155,7 @@ func TestIterativeDelayedStateSync(t *testing.T) {
 
 	// Create a destination state and sync with the scheduler
 	dstDb, _ := ethdb.NewMemDatabase()
-	sched := NewStateSync(srcRoot, dstDb)
+	sched := NewStateSync(0, common.Hash{}, srcRoot, dstDb)
 
 	queue := append([]common.Hash{}, sched.Missing(0)...)
 	for len(queue) > 0 {
@@ -189,7 +189,7 @@ func testIterativeRandomStateSync(t *testing.T, batch int) {
 
 	// Create a destination state and sync with the scheduler
 	dstDb, _ := ethdb.NewMemDatabase()
-	sched := NewStateSync(srcRoot, dstDb)
+	sched := NewStateSync(0, common.Hash{}, srcRoot, dstDb)
 
 	queue := make(map[common.Hash]struct{})
 	for _, hash := range sched.Missing(batch) {
@@ -226,7 +226,7 @@ func TestIterativeRandomDelayedStateSync(t *testing.T) {
 
 	// Create a destination state and sync with the scheduler
 	dstDb, _ := ethdb.NewMemDatabase()
-	sched := NewStateSync(srcRoot, dstDb)
+	sched := NewStateSync(0, common.Hash{}, srcRoot, dstDb)
 
 	queue := make(map[common.Hash]struct{})
 	for _, hash := range sched.Missing(0) {
@@ -268,7 +268,7 @@ func TestIncompleteStateSync(t *testing.T) {
 
 	// Create a destination state and sync with the scheduler
 	dstDb, _ := ethdb.NewMemDatabase()
-	sched := NewStateSync(srcRoot, dstDb)
+	sched := NewStateSync(0, common.Hash{}, srcRoot, dstDb)
 
 	added := []common.Hash{}
 	queue := append([]common.Hash{}, sched.Missing(1)...)

--- a/core/state_processor.go
+++ b/core/state_processor.go
@@ -71,7 +71,7 @@ func (p *StateProcessor) Process(block *types.Block, statedb *state.StateDB, cfg
 	}
 	// Iterate over and process the individual transactions
 	for i, tx := range block.Transactions() {
-		statedb.StartRecord(tx.Hash(), block.Hash(), i)
+		statedb.SetTxContext(block.Hash(), block.NumberU64(), tx.Hash(), i, p.bc)
 		receipt, logs, _, err := ApplyTransaction(p.config, p.bc, gp, statedb, header, tx, totalUsedGas, cfg)
 		if err != nil {
 			return nil, nil, totalUsedGas, err

--- a/core/state_processor.go
+++ b/core/state_processor.go
@@ -71,7 +71,7 @@ func (p *StateProcessor) Process(block *types.Block, statedb *state.StateDB, cfg
 	}
 	// Iterate over and process the individual transactions
 	for i, tx := range block.Transactions() {
-		statedb.SetTxContext(block.Hash(), block.NumberU64(), tx.Hash(), i, p.bc)
+		statedb.SetTxContext(tx.Hash(), i)
 		receipt, logs, _, err := ApplyTransaction(p.config, p.bc, gp, statedb, header, tx, totalUsedGas, cfg)
 		if err != nil {
 			return nil, nil, totalUsedGas, err

--- a/core/types/derive_sha.go
+++ b/core/types/derive_sha.go
@@ -31,7 +31,7 @@ type DerivableList interface {
 
 func DeriveSha(list DerivableList) common.Hash {
 	keybuf := new(bytes.Buffer)
-	trie := new(trie.Trie)
+	trie, _ := trie.New(common.Hash{}, nil, 0)
 	for i := 0; i < list.Len(); i++ {
 		keybuf.Reset()
 		rlp.Encode(keybuf, uint(i))

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -235,6 +235,10 @@ func New(ctx *node.ServiceContext, config *Config) (*Ethereum, error) {
 	gpo := gasprice.NewGasPriceOracle(eth.blockchain, chainDb, eth.eventMux, gpoParams)
 	eth.apiBackend = &EthApiBackend{eth, gpo}
 
+	if err := populateDirectCache(chainDb, eth.blockchain); err != nil {
+		return nil, err
+	}
+
 	return eth, nil
 }
 

--- a/eth/db_upgrade.go
+++ b/eth/db_upgrade.go
@@ -354,3 +354,10 @@ func addMipmapBloomBins(db ethdb.Database) (err error) {
 	glog.V(logger.Info).Infoln("upgrade completed in", time.Since(tstart))
 	return nil
 }
+
+//struct upgradeState 
+
+func populateDirectCache(db ethdb.Database, blockchain *core.BlockChain) error {
+
+	return nil
+}

--- a/eth/db_upgrade.go
+++ b/eth/db_upgrade.go
@@ -355,9 +355,6 @@ func addMipmapBloomBins(db ethdb.Database) (err error) {
 	return nil
 }
 
-//struct upgradeState 
-
 func populateDirectCache(db ethdb.Database, blockchain *core.BlockChain) error {
-
 	return nil
 }

--- a/eth/downloader/downloader_test.go
+++ b/eth/downloader/downloader_test.go
@@ -286,7 +286,7 @@ func (dl *downloadTester) headFastBlock() *types.Block {
 func (dl *downloadTester) commitHeadBlock(hash common.Hash) error {
 	// For now only check that the state trie is correct
 	if block := dl.getBlock(hash); block != nil {
-		_, err := trie.NewSecure(block.Root(), dl.stateDb, 0)
+		_, err := trie.New(block.Root(), dl.stateDb, 0)
 		return err
 	}
 	return fmt.Errorf("non existent block: %x", hash[:4])

--- a/eth/downloader/queue.go
+++ b/eth/downloader/queue.go
@@ -390,7 +390,7 @@ func (q *queue) Schedule(headers []*types.Header, from uint64) []*types.Header {
 		if q.mode == FastSync && header.Number.Uint64() == q.fastSyncPivot {
 			// Pivoting point of the fast sync, retrieve the state tries
 			q.stateSchedLock.Lock()
-			q.stateScheduler = state.NewStateSync(header.Root, q.stateDatabase)
+			q.stateScheduler = state.NewStateSync(header.Number.Uint64(), header.Hash(), header.Root, q.stateDatabase)
 			q.stateSchedLock.Unlock()
 		}
 		inserts = append(inserts, header)
@@ -1141,6 +1141,6 @@ func (q *queue) Prepare(offset uint64, mode SyncMode, pivot uint64, head *types.
 
 	// If long running fast sync, also start up a head stateretrieval immediately
 	if mode == FastSync && pivot > 0 {
-		q.stateScheduler = state.NewStateSync(head.Root, q.stateDatabase)
+		q.stateScheduler = state.NewStateSync(head.Number.Uint64(), head.Hash(), head.Root, q.stateDatabase)
 	}
 }

--- a/light/state_test.go
+++ b/light/state_test.go
@@ -40,7 +40,7 @@ func (odr *testOdr) Database() ethdb.Database {
 func (odr *testOdr) Retrieve(ctx context.Context, req OdrRequest) error {
 	switch req := req.(type) {
 	case *TrieRequest:
-		t, _ := trie.New(req.root, odr.sdb)
+		t, _ := trie.New(req.root, odr.sdb, 0)
 		req.proof = t.Prove(req.key)
 	case *NodeDataRequest:
 		req.data, _ = odr.sdb.Get(req.hash[:])

--- a/light/trie.go
+++ b/light/trie.go
@@ -74,15 +74,26 @@ func (t *LightTrie) do(ctx context.Context, fallbackKey []byte, fn func() error)
 	return err
 }
 
+func (t *LightTrie) getTrie() (ret *trie.SecureTrie, err error) {
+	if t.trie == nil {
+		var tr trie.Trie
+		tr, err = trie.New(t.originalRoot, t.db, 0)
+		if err != nil {
+			return nil, err
+		}
+		t.trie = trie.NewSecure(tr, t.db)
+	}
+	return t.trie, nil
+}
+
 // Get returns the value for key stored in the trie.
 // The value bytes must not be modified by the caller.
 func (t *LightTrie) Get(ctx context.Context, key []byte) (res []byte, err error) {
 	err = t.do(ctx, key, func() (err error) {
-		if t.trie == nil {
-			t.trie, err = trie.NewSecure(t.originalRoot, t.db, 0)
-		}
+		var tr *trie.SecureTrie
+		tr, err = t.getTrie()
 		if err == nil {
-			res, err = t.trie.TryGet(key)
+			res, err = tr.TryGet(key)
 		}
 		return
 	})
@@ -97,11 +108,10 @@ func (t *LightTrie) Get(ctx context.Context, key []byte) (res []byte, err error)
 // stored in the trie.
 func (t *LightTrie) Update(ctx context.Context, key, value []byte) (err error) {
 	err = t.do(ctx, key, func() (err error) {
-		if t.trie == nil {
-			t.trie, err = trie.NewSecure(t.originalRoot, t.db, 0)
-		}
+		var tr *trie.SecureTrie
+		tr, err = t.getTrie()
 		if err == nil {
-			err = t.trie.TryUpdate(key, value)
+			err = tr.TryUpdate(key, value)
 		}
 		return
 	})
@@ -111,11 +121,10 @@ func (t *LightTrie) Update(ctx context.Context, key, value []byte) (err error) {
 // Delete removes any existing value for key from the trie.
 func (t *LightTrie) Delete(ctx context.Context, key []byte) (err error) {
 	err = t.do(ctx, key, func() (err error) {
-		if t.trie == nil {
-			t.trie, err = trie.NewSecure(t.originalRoot, t.db, 0)
-		}
+		var tr *trie.SecureTrie
+		tr, err = t.getTrie()
 		if err == nil {
-			err = t.trie.TryDelete(key)
+			err = tr.TryDelete(key)
 		}
 		return
 	})

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -66,6 +66,15 @@ func NewTimer(name string) metrics.Timer {
 	return metrics.GetOrRegisterTimer(name, metrics.DefaultRegistry)
 }
 
+// NewCounter create a new metrics Counter, either a real one of a NOP stub depending
+// on the metrics flag.
+func NewCounter(name string) metrics.Counter {
+	if !Enabled {
+		return new(metrics.NilCounter)
+	}
+	return metrics.GetOrRegisterCounter(name, metrics.DefaultRegistry)
+}
+
 // CollectProcessMetrics periodically collects various metrics about the running
 // process.
 func CollectProcessMetrics(refresh time.Duration) {

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -583,7 +583,7 @@ func (env *Work) commitTransactions(mux *event.TypeMux, txs *types.TransactionsB
 			continue
 		}
 		// Start executing the transaction
-		env.state.SetTxContext(common.Hash{}, env.header.Number.Uint64(), tx.Hash(), env.tcount, bc)
+		env.state.SetTxContext(tx.Hash(), env.tcount)
 
 		err, logs := env.commitTransaction(tx, bc, gp)
 		switch {

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -583,7 +583,7 @@ func (env *Work) commitTransactions(mux *event.TypeMux, txs *types.TransactionsB
 			continue
 		}
 		// Start executing the transaction
-		env.state.StartRecord(tx.Hash(), common.Hash{}, env.tcount)
+		env.state.SetTxContext(common.Hash{}, env.header.Number.Uint64(), tx.Hash(), env.tcount, bc)
 
 		err, logs := env.commitTransaction(tx, bc, gp)
 		switch {

--- a/trie/directcache.go
+++ b/trie/directcache.go
@@ -52,7 +52,7 @@ type DirectCache struct {
 	dirty     map[string]bool
 }
 
-type NullCacheValidator struct {}
+type NullCacheValidator struct{}
 
 func (cv *NullCacheValidator) IsCanonChainBlock(num uint64, hash common.Hash) bool {
 	return false
@@ -60,12 +60,12 @@ func (cv *NullCacheValidator) IsCanonChainBlock(num uint64, hash common.Hash) bo
 
 func NewDirectCache(pm PersistentMap, db Database, keyPrefix []byte, validator CacheValidator, complete bool) *DirectCache {
 	return &DirectCache{
-		data: pm,
-		db: db,
+		data:      pm,
+		db:        db,
 		keyPrefix: keyPrefix,
 		validator: validator,
-		complete: complete,
-		dirty: make(map[string]bool),
+		complete:  complete,
+		dirty:     make(map[string]bool),
 	}
 }
 
@@ -172,9 +172,10 @@ func (dc *DirectCache) CommitTo(dbw DatabaseWriter) (root common.Hash, err error
 }
 
 func (dc *DirectCache) putCache(dbw DatabaseWriter, key, value []byte) error {
-	enc, _ := rlp.EncodeToBytes(cachedValue{value, dc.blockNum, dc.blockHash})
-	if err := dbw.Put(append(dc.keyPrefix, key...), enc); err != nil {
-		return err
-	}
-	return nil
+	return WriteDirectCache(dc.keyPrefix, key, value, dc.blockNum, dc.blockHash, dbw)
+}
+
+func WriteDirectCache(prefix, key, value []byte, number uint64, hash common.Hash, dbw DatabaseWriter) error {
+	enc, _ := rlp.EncodeToBytes(cachedValue{value, number, hash})
+	return dbw.Put(append(prefix, key...), enc)
 }

--- a/trie/directcache.go
+++ b/trie/directcache.go
@@ -1,0 +1,179 @@
+// Copyright 2016 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+package trie
+
+import (
+	"time"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/logger"
+	"github.com/ethereum/go-ethereum/logger/glog"
+	"github.com/ethereum/go-ethereum/metrics"
+	"github.com/ethereum/go-ethereum/rlp"
+)
+
+var directCacheWrites = metrics.NewCounter("directcache/writes")
+var directCacheHitTimer = metrics.NewTimer("directcache/timer/hits")
+var directCacheMissTimer = metrics.NewTimer("directcache/timer/misses")
+
+type cachedValue struct {
+	Value     []byte
+	BlockNum  uint64
+	BlockHash common.Hash
+}
+
+// CacheValidator can check whether a certain block is in the current canonical chain.
+type CacheValidator interface {
+	IsCanonChainBlock(uint64, common.Hash) bool
+}
+
+type DirectCache struct {
+	storage   Storage
+	db        Database
+	keyPrefix []byte
+	blockNum  uint64
+	blockHash common.Hash
+	validator CacheValidator
+	complete  bool
+	dirty     map[string]bool
+}
+
+func NewDirectCache(s Storage, db Database, keyPrefix []byte, blockNum uint64, blockHash common.Hash, validator CacheValidator, complete bool) *DirectCache {
+	return &DirectCache{
+		storage: s,
+		db: db,
+		keyPrefix: keyPrefix,
+		blockNum: blockNum,
+		blockHash: blockHash,
+		validator: validator,
+		complete: complete,
+		dirty: make(map[string]bool),
+	}
+}
+
+func (dc *DirectCache) Iterator() *Iterator {
+	// Todo: If complete is true, implement an iterator over the DB instead.
+	return dc.storage.Iterator()
+}
+
+func (dc *DirectCache) NodeIterator() *NodeIterator {
+	return dc.storage.NodeIterator()
+}
+
+func (dc *DirectCache) makeKey(key []byte) []byte {
+	return append(dc.keyPrefix, key...)
+}
+
+func (dc *DirectCache) Get(key []byte) []byte {
+	res, err := dc.TryGet(key)
+	if err != nil && glog.V(logger.Error) {
+		glog.Errorf("Unhandled error: %v", err)
+	}
+	return res
+}
+
+func (dc *DirectCache) TryGet(key []byte) ([]byte, error) {
+	start := time.Now()
+
+	// Use the underlying object for dirty keys
+	if !dc.dirty[string(key)] {
+		cacheKey := dc.makeKey(key)
+		if cached, ok := dc.getCached(cacheKey); ok {
+			directCacheHitTimer.UpdateSince(start)
+			return cached, nil
+		}
+	}
+
+	value, err := dc.storage.TryGet(key)
+	if err != nil {
+		return value, err
+	}
+
+	// If the cache isn't comprehensive, update it
+	if !dc.complete && !dc.dirty[string(key)] {
+		if err := dc.putCache(dc.db, key, value); err != nil && glog.V(logger.Error) {
+			glog.Errorf("Error updating cache: %v", err)
+		}
+	}
+
+	directCacheMissTimer.UpdateSince(start)
+	return value, nil
+}
+
+func (dc *DirectCache) getCached(key []byte) ([]byte, bool) {
+	enc, _ := dc.db.Get(key)
+	if len(enc) == 0 {
+		return nil, dc.complete
+	}
+
+	var data cachedValue
+	if err := rlp.DecodeBytes(enc, &data); err != nil && glog.V(logger.Error) {
+		glog.Errorf("Can't decode cached object at %x: %v", key, err)
+		return nil, false
+	}
+
+	return data.Value, dc.validator.IsCanonChainBlock(data.BlockNum, data.BlockHash)
+}
+
+func (dc *DirectCache) putCache(dbw DatabaseWriter, key, value []byte) error {
+	enc, _ := rlp.EncodeToBytes(cachedValue{value, dc.blockNum, dc.blockHash})
+	if err := dbw.Put(append(dc.keyPrefix, key...), enc); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (dc *DirectCache) Update(key, value []byte) {
+	if err := dc.TryUpdate(key, value); err != nil && glog.V(logger.Error) {
+		glog.Errorf("Unhandled error: %v", err)
+	}
+}
+
+func (dc *DirectCache) TryUpdate(key, value []byte) error {
+	dc.dirty[string(key)] = true
+	return dc.storage.TryUpdate(key, value)
+}
+
+func (dc *DirectCache) Delete(key []byte) {
+	if err := dc.TryDelete(key); err != nil && glog.V(logger.Error) {
+		glog.Errorf("Unhandled error: %v", err)
+	}
+}
+
+func (dc *DirectCache) TryDelete(key []byte) error {
+	dc.dirty[string(key)] = true
+	return dc.storage.TryDelete(key)
+}
+
+func (dc *DirectCache) Commit() (root common.Hash, err error) {
+	return dc.CommitTo(dc.db)
+}
+
+func (dc *DirectCache) CommitTo(dbw DatabaseWriter) (root common.Hash, err error) {
+	directCacheWrites.Inc(int64(len(dc.dirty)))
+	for k, _ := range dc.dirty {
+		v, err := dc.storage.TryGet([]byte(k))
+		if err, ok := err.(*MissingNodeError); err != nil && !ok {
+			return common.Hash{}, err
+		}
+		if err := dc.putCache(dbw, []byte(k), v); err != nil {
+			return common.Hash{}, err
+		}
+	}
+	dc.dirty = make(map[string]bool)
+	return dc.storage.CommitTo(dbw)
+}

--- a/trie/directcache.go
+++ b/trie/directcache.go
@@ -70,10 +70,6 @@ func (dc *DirectCache) Iterator() *Iterator {
 	return dc.storage.Iterator()
 }
 
-func (dc *DirectCache) NodeIterator() *NodeIterator {
-	return dc.storage.NodeIterator()
-}
-
 func (dc *DirectCache) makeKey(key []byte) []byte {
 	return append(dc.keyPrefix, key...)
 }

--- a/trie/directcache.go
+++ b/trie/directcache.go
@@ -52,13 +52,17 @@ type DirectCache struct {
 	dirty     map[string]bool
 }
 
-func NewDirectCache(s Storage, db Database, keyPrefix []byte, blockNum uint64, blockHash common.Hash, validator CacheValidator, complete bool) *DirectCache {
+type NullCacheValidator struct {}
+
+func (cv *NullCacheValidator) IsCanonChainBlock(num uint64, hash common.Hash) bool {
+	return false
+}
+
+func NewDirectCache(s Storage, db Database, keyPrefix []byte, validator CacheValidator, complete bool) *DirectCache {
 	return &DirectCache{
 		storage: s,
 		db: db,
 		keyPrefix: keyPrefix,
-		blockNum: blockNum,
-		blockHash: blockHash,
 		validator: validator,
 		complete: complete,
 		dirty: make(map[string]bool),
@@ -83,6 +87,7 @@ func (dc *DirectCache) Get(key []byte) []byte {
 }
 
 func (dc *DirectCache) TryGet(key []byte) ([]byte, error) {
+	return dc.storage.TryGet(key)
 	start := time.Now()
 
 	// Use the underlying object for dirty keys

--- a/trie/directcache.go
+++ b/trie/directcache.go
@@ -159,10 +159,6 @@ func (dc *DirectCache) TryDelete(key []byte) error {
 	return dc.data.TryDelete(key)
 }
 
-func (dc *DirectCache) Commit() (root common.Hash, err error) {
-	return dc.CommitTo(dc.db)
-}
-
 func (dc *DirectCache) CommitTo(dbw DatabaseWriter) (root common.Hash, err error) {
 	directCacheWrites.Inc(int64(len(dc.dirty)))
 	for k, _ := range dc.dirty {

--- a/trie/directcache.go
+++ b/trie/directcache.go
@@ -79,11 +79,13 @@ func (cv *NullCacheValidator) IsCanonChainBlock(num uint64, hash common.Hash) bo
 	return false
 }
 
-func NewDirectCache(pm PersistentMap, db Database, keyPrefix []byte, validator CacheValidator, complete bool) *DirectCache {
+func NewDirectCache(pm PersistentMap, db Database, keyPrefix []byte, blockNum uint64, blockHash common.Hash, validator CacheValidator, complete bool) *DirectCache {
 	return &DirectCache{
 		data:      pm,
 		db:        db,
 		keyPrefix: keyPrefix,
+		blockNum:  blockNum,
+		blockHash: blockHash,
 		validator: validator,
 		complete:  complete,
 		dirty:     make(map[string]bool),
@@ -151,7 +153,7 @@ func (dc *DirectCache) getCached(key []byte) ([]byte, bool) {
 		return nil, false
 	}
 
-	canonical := dc.validator.IsCanonChainBlock(data.BlockNum, data.BlockHash)
+	canonical := dc.blockNum > 0 && data.BlockNum < dc.blockNum && dc.validator.IsCanonChainBlock(data.BlockNum, data.BlockHash)
 	return data.Value, canonical
 }
 

--- a/trie/iterator.go
+++ b/trie/iterator.go
@@ -20,7 +20,7 @@ import "github.com/ethereum/go-ethereum/common"
 
 // Iterator is a key-value trie iterator that traverses a Trie.
 type Iterator struct {
-	trie   *SimpleTrie
+	trie   *Trie
 	nodeIt *NodeIterator
 	keyBuf []byte
 
@@ -29,7 +29,7 @@ type Iterator struct {
 }
 
 // NewIterator creates a new key-value iterator.
-func NewIterator(trie *SimpleTrie) *Iterator {
+func NewIterator(trie *Trie) *Iterator {
 	return &Iterator{
 		trie:   trie,
 		nodeIt: NewNodeIterator(trie),
@@ -82,7 +82,7 @@ type nodeIteratorState struct {
 
 // NodeIterator is an iterator to traverse the trie post-order.
 type NodeIterator struct {
-	trie  *SimpleTrie          // Trie being iterated
+	trie  *Trie          // Trie being iterated
 	stack []*nodeIteratorState // Hierarchy of trie nodes persisting the iteration state
 
 	Hash     common.Hash // Hash of the current node being iterated (nil if not standalone)
@@ -95,7 +95,7 @@ type NodeIterator struct {
 }
 
 // NewNodeIterator creates an post-order trie iterator.
-func NewNodeIterator(trie *SimpleTrie) *NodeIterator {
+func NewNodeIterator(trie *Trie) *NodeIterator {
 	if trie.Hash() == emptyState {
 		return new(NodeIterator)
 	}

--- a/trie/iterator.go
+++ b/trie/iterator.go
@@ -20,7 +20,7 @@ import "github.com/ethereum/go-ethereum/common"
 
 // Iterator is a key-value trie iterator that traverses a Trie.
 type Iterator struct {
-	trie   *Trie
+	trie   *SimpleTrie
 	nodeIt *NodeIterator
 	keyBuf []byte
 
@@ -29,7 +29,7 @@ type Iterator struct {
 }
 
 // NewIterator creates a new key-value iterator.
-func NewIterator(trie *Trie) *Iterator {
+func NewIterator(trie *SimpleTrie) *Iterator {
 	return &Iterator{
 		trie:   trie,
 		nodeIt: NewNodeIterator(trie),
@@ -82,7 +82,7 @@ type nodeIteratorState struct {
 
 // NodeIterator is an iterator to traverse the trie post-order.
 type NodeIterator struct {
-	trie  *Trie                // Trie being iterated
+	trie  *SimpleTrie          // Trie being iterated
 	stack []*nodeIteratorState // Hierarchy of trie nodes persisting the iteration state
 
 	Hash     common.Hash // Hash of the current node being iterated (nil if not standalone)
@@ -95,7 +95,7 @@ type NodeIterator struct {
 }
 
 // NewNodeIterator creates an post-order trie iterator.
-func NewNodeIterator(trie *Trie) *NodeIterator {
+func NewNodeIterator(trie *SimpleTrie) *NodeIterator {
 	if trie.Hash() == emptyState {
 		return new(NodeIterator)
 	}

--- a/trie/iterator.go
+++ b/trie/iterator.go
@@ -74,20 +74,22 @@ func (it *Iterator) makeKey() []byte {
 // nodeIteratorState represents the iteration state at one particular node of the
 // trie, which can be resumed at a later invocation.
 type nodeIteratorState struct {
-	hash   common.Hash // Hash of the node being iterated (nil if not standalone)
-	node   node        // Trie node being iterated
-	parent common.Hash // Hash of the first full ancestor node (nil if current is the root)
-	child  int         // Child to be processed next
+	hash    common.Hash // Hash of the node being iterated (nil if not standalone)
+	node    node        // Trie node being iterated
+	parent  common.Hash // Hash of the first full ancestor node (nil if current is the root)
+	nibbles []byte      // Key nibbles leading up to this node for key reconstruction
+	child   int         // Child to be processed next
 }
 
 // NodeIterator is an iterator to traverse the trie post-order.
 type NodeIterator struct {
-	trie  *Trie          // Trie being iterated
+	trie  *Trie                // Trie being iterated
 	stack []*nodeIteratorState // Hierarchy of trie nodes persisting the iteration state
 
 	Hash     common.Hash // Hash of the current node being iterated (nil if not standalone)
 	Node     node        // Current node being iterated (internal representation)
 	Parent   common.Hash // Hash of the first full ancestor node (nil if current is the root)
+	Nibbles  []byte      // Key nibbles leading up to this node for key reconstruction
 	Leaf     bool        // Flag whether the current node is a value (data) node
 	LeafBlob []byte      // Data blob contained within a leaf (otherwise nil)
 
@@ -155,11 +157,16 @@ func (it *NodeIterator) step() error {
 			}
 			for parent.child++; parent.child < len(node.Children); parent.child++ {
 				if current := node.Children[parent.child]; current != nil {
+					nibbles := parent.nibbles
+					if parent.child < 16 {
+						nibbles = append(nibbles, byte(parent.child))
+					}
 					it.stack = append(it.stack, &nodeIteratorState{
-						hash:   common.BytesToHash(node.flags.hash),
-						node:   current,
-						parent: ancestor,
-						child:  -1,
+						hash:    common.BytesToHash(node.flags.hash),
+						node:    current,
+						parent:  ancestor,
+						nibbles: nibbles,
+						child:   -1,
 					})
 					break
 				}
@@ -171,10 +178,11 @@ func (it *NodeIterator) step() error {
 			}
 			parent.child++
 			it.stack = append(it.stack, &nodeIteratorState{
-				hash:   common.BytesToHash(node.flags.hash),
-				node:   node.Val,
-				parent: ancestor,
-				child:  -1,
+				hash:    common.BytesToHash(node.flags.hash),
+				node:    node.Val,
+				parent:  ancestor,
+				nibbles: append(parent.nibbles, node.Key...),
+				child:   -1,
 			})
 		} else if hash, ok := parent.node.(hashNode); ok {
 			// Hash node, resolve the hash child from the database, then the node itself
@@ -188,10 +196,11 @@ func (it *NodeIterator) step() error {
 				return err
 			}
 			it.stack = append(it.stack, &nodeIteratorState{
-				hash:   common.BytesToHash(hash),
-				node:   node,
-				parent: ancestor,
-				child:  -1,
+				hash:    common.BytesToHash(hash),
+				node:    node,
+				parent:  ancestor,
+				nibbles: parent.nibbles,
+				child:   -1,
 			})
 		} else {
 			break
@@ -207,7 +216,7 @@ func (it *NodeIterator) step() error {
 // The method returns whether there are any more data left for inspection.
 func (it *NodeIterator) retrieve() bool {
 	// Clear out any previously set values
-	it.Hash, it.Node, it.Parent, it.Leaf, it.LeafBlob = common.Hash{}, nil, common.Hash{}, false, nil
+	it.Hash, it.Node, it.Parent, it.Nibbles, it.Leaf, it.LeafBlob = common.Hash{}, nil, common.Hash{}, nil, false, nil
 
 	// If the iteration's done, return no available data
 	if it.trie == nil {
@@ -216,7 +225,7 @@ func (it *NodeIterator) retrieve() bool {
 	// Otherwise retrieve the current node and resolve leaf accessors
 	state := it.stack[len(it.stack)-1]
 
-	it.Hash, it.Node, it.Parent = state.hash, state.node, state.parent
+	it.Hash, it.Node, it.Parent, it.Nibbles = state.hash, state.node, state.parent, state.nibbles
 	if value, ok := it.Node.(valueNode); ok {
 		it.Leaf, it.LeafBlob = true, []byte(value)
 	}

--- a/trie/proof.go
+++ b/trie/proof.go
@@ -37,7 +37,7 @@ import (
 // contains all nodes of the longest existing prefix of the key
 // (at least the root node), ending with the node that proves the
 // absence of the key.
-func (t *Trie) Prove(key []byte) []rlp.RawValue {
+func (t *SimpleTrie) Prove(key []byte) []rlp.RawValue {
 	// Collect all nodes on the path to key.
 	key = compactHexDecode(key)
 	nodes := []node{}

--- a/trie/proof.go
+++ b/trie/proof.go
@@ -37,7 +37,7 @@ import (
 // contains all nodes of the longest existing prefix of the key
 // (at least the root node), ending with the node that proves the
 // absence of the key.
-func (t *SimpleTrie) Prove(key []byte) []rlp.RawValue {
+func (t *Trie) Prove(key []byte) []rlp.RawValue {
 	// Collect all nodes on the path to key.
 	key = compactHexDecode(key)
 	nodes := []node{}

--- a/trie/proof_test.go
+++ b/trie/proof_test.go
@@ -50,7 +50,7 @@ func TestProof(t *testing.T) {
 }
 
 func TestOneElementProof(t *testing.T) {
-	trie := new(Trie)
+	trie, _ := New(common.Hash{}, nil, 0)
 	updateString(trie, "k", "v")
 	proof := trie.Prove([]byte("k"))
 	if proof == nil {
@@ -129,8 +129,8 @@ func BenchmarkVerifyProof(b *testing.B) {
 	}
 }
 
-func randomTrie(n int) (*Trie, map[string]*kv) {
-	trie := new(Trie)
+func randomTrie(n int) (*SimpleTrie, map[string]*kv) {
+	trie, _ := New(common.Hash{}, nil, 0)
 	vals := make(map[string]*kv)
 	for i := byte(0); i < 100; i++ {
 		value := &kv{common.LeftPadBytes([]byte{i}, 32), []byte{i}, false}

--- a/trie/proof_test.go
+++ b/trie/proof_test.go
@@ -129,7 +129,7 @@ func BenchmarkVerifyProof(b *testing.B) {
 	}
 }
 
-func randomTrie(n int) (*SimpleTrie, map[string]*kv) {
+func randomTrie(n int) (*Trie, map[string]*kv) {
 	trie, _ := New(common.Hash{}, nil, 0)
 	vals := make(map[string]*kv)
 	for i := byte(0); i < 100; i++ {

--- a/trie/secure_trie.go
+++ b/trie/secure_trie.go
@@ -34,7 +34,6 @@ type PersistentMap interface {
 	TryUpdate(key, value []byte) error
 	Delete(key []byte)
 	TryDelete(key []byte) error
-	Commit() (root common.Hash, err error)
 	CommitTo(db DatabaseWriter) (root common.Hash, err error)
 }
 
@@ -138,18 +137,6 @@ func (t *SecureTrie) GetKey(shaKey []byte) []byte {
 	}
 	key, _ := t.db.Get(t.secKey(shaKey))
 	return key
-}
-
-// Commit writes all nodes and the secure hash pre-images to the database.
-// Nodes are stored with their sha3 hash as the key.
-//
-// Committing flushes nodes from memory. Subsequent Get calls will load nodes
-// from the database.
-func (t *SecureTrie) Commit() (root common.Hash, err error) {
-	if err := t.CommitPreimages(); err != nil {
-		return common.Hash{}, err
-	}
-	return t.data.Commit()
 }
 
 func (t *SecureTrie) Iterator() *Iterator {

--- a/trie/secure_trie.go
+++ b/trie/secure_trie.go
@@ -26,6 +26,18 @@ var secureKeyPrefix = []byte("secure-key-")
 
 const secureKeyLength = 11 + 32 // Length of the above prefix + 32byte hash
 
+type PersistentMap interface {
+	Iterator() *Iterator
+	Get(key []byte) []byte
+	TryGet(key []byte) ([]byte, error)
+	Update(key, value []byte)
+	TryUpdate(key, value []byte) error
+	Delete(key []byte)
+	TryDelete(key []byte) error
+	Commit() (root common.Hash, err error)
+	CommitTo(db DatabaseWriter) (root common.Hash, err error)
+}
+
 // SecureTrie wraps a trie with key hashing. In a secure trie, all
 // access operations hash the key using keccak256. This prevents
 // calling code from creating long chains of nodes that
@@ -37,7 +49,7 @@ const secureKeyLength = 11 + 32 // Length of the above prefix + 32byte hash
 //
 // SecureTrie is not safe for concurrent use.
 type SecureTrie struct {
-	storage          Storage
+	data             PersistentMap
 	db               Database
 	hashKeyBuf       [secureKeyLength]byte
 	secKeyBuf        [200]byte
@@ -45,57 +57,57 @@ type SecureTrie struct {
 	secKeyCacheOwner *SecureTrie // Pointer to self, replace the key cache on mismatch
 }
 
-// NewSecure creates a secure Storage from an existing Storage.
-func NewSecure(s Storage, db Database) *SecureTrie {
-	if s == nil {
-		panic("NewSecure called with nil storage")
+// NewSecure creates a secure persistent map from an existing map.
+func NewSecure(pm PersistentMap, db Database) *SecureTrie {
+	if pm == nil {
+		panic("NewSecure called with nil persistent map")
 	}
 	if db == nil {
 		panic("NewSecure called with nil database")
 	}
-	return &SecureTrie{storage: s, db: db}
+	return &SecureTrie{data: pm, db: db}
 }
 
-// Get returns the value for key stored in the storage.
+// Get returns the value for key stored in the map.
 // The value bytes must not be modified by the caller.
 func (t *SecureTrie) Get(key []byte) []byte {
 	res, err := t.TryGet(key)
 	if err != nil && glog.V(logger.Error) {
-		glog.Errorf("Unhandled storage error: %v", err)
+		glog.Errorf("Unhandled persistent map error: %v", err)
 	}
 	return res
 }
 
-// TryGet returns the value for key stored in the storage.
+// TryGet returns the value for key stored in the map.
 // The value bytes must not be modified by the caller.
 // If a node was not found in the database, a MissingNodeError is returned.
 func (t *SecureTrie) TryGet(key []byte) ([]byte, error) {
-	return t.storage.TryGet(t.hashKey(key))
+	return t.data.TryGet(t.hashKey(key))
 }
 
-// Update associates key with value in the storage. Subsequent calls to
+// Update associates key with value in the map. Subsequent calls to
 // Get will return value. If value has length zero, any existing value
-// is deleted from the storage and calls to Get will return nil.
+// is deleted from the map and calls to Get will return nil.
 //
 // The value bytes must not be modified by the caller while they are
-// stored in the storage.
+// stored in the map.
 func (t *SecureTrie) Update(key, value []byte) {
 	if err := t.TryUpdate(key, value); err != nil && glog.V(logger.Error) {
-		glog.Errorf("Unhandled storage error: %v", err)
+		glog.Errorf("Unhandled persistent map error: %v", err)
 	}
 }
 
-// TryUpdate associates key with value in the storage. Subsequent calls to
+// TryUpdate associates key with value in the map. Subsequent calls to
 // Get will return value. If value has length zero, any existing value
-// is deleted from the storage and calls to Get will return nil.
+// is deleted from the map and calls to Get will return nil.
 //
 // The value bytes must not be modified by the caller while they are
-// stored in the storage.
+// stored in the map.
 //
 // If a node was not found in the database, a MissingNodeError is returned.
 func (t *SecureTrie) TryUpdate(key, value []byte) error {
 	hk := t.hashKey(key)
-	err := t.storage.TryUpdate(hk, value)
+	err := t.data.TryUpdate(hk, value)
 	if err != nil {
 		return err
 	}
@@ -103,19 +115,19 @@ func (t *SecureTrie) TryUpdate(key, value []byte) error {
 	return nil
 }
 
-// Delete removes any existing value for key from the storage.
+// Delete removes any existing value for key from the map.
 func (t *SecureTrie) Delete(key []byte) {
 	if err := t.TryDelete(key); err != nil && glog.V(logger.Error) {
-		glog.Errorf("Unhandled storage error: %v", err)
+		glog.Errorf("Unhandled persistent map error: %v", err)
 	}
 }
 
-// TryDelete removes any existing value for key from the storage.
+// TryDelete removes any existing value for key from the map.
 // If a node was not found in the database, a MissingNodeError is returned.
 func (t *SecureTrie) TryDelete(key []byte) error {
 	hk := t.hashKey(key)
 	delete(t.getSecKeyCache(), string(hk))
-	return t.storage.TryDelete(hk)
+	return t.data.TryDelete(hk)
 }
 
 // GetKey returns the sha3 preimage of a hashed key that was
@@ -137,11 +149,11 @@ func (t *SecureTrie) Commit() (root common.Hash, err error) {
 	if err := t.CommitPreimages(); err != nil {
 		return common.Hash{}, err
 	}
-	return t.storage.Commit()
+	return t.data.Commit()
 }
 
 func (t *SecureTrie) Iterator() *Iterator {
-	return t.storage.Iterator()
+	return t.data.Iterator()
 }
 
 // CommitTo writes all nodes and the secure hash pre-images to the given database.
@@ -149,12 +161,12 @@ func (t *SecureTrie) Iterator() *Iterator {
 //
 // Committing flushes nodes from memory. Subsequent Get calls will load nodes from
 // the database. Calling code must ensure that the changes made to db are
-// written back to the attached database before using the storage.
+// written back to the attached database before using the map.
 func (t *SecureTrie) CommitTo(db DatabaseWriter) (root common.Hash, err error) {
 	if err := t.CommitPreimages(); err != nil {
 		return common.Hash{}, err
 	}
-	return t.storage.CommitTo(db)
+	return t.data.CommitTo(db)
 }
 
 func (t *SecureTrie) CommitPreimages() error {
@@ -191,7 +203,7 @@ func (t *SecureTrie) hashKey(key []byte) []byte {
 }
 
 // getSecKeyCache returns the current secure key cache, creating a new one if
-// ownership changed (i.e. the current secure storage is a copy of another owning
+// ownership changed (i.e. the current secure map is a copy of another owning
 // the actual cache).
 func (t *SecureTrie) getSecKeyCache() map[string][]byte {
 	if t != t.secKeyCacheOwner {

--- a/trie/secure_trie_test.go
+++ b/trie/secure_trie_test.go
@@ -27,7 +27,7 @@ import (
 	"github.com/ethereum/go-ethereum/ethdb"
 )
 
-func newEmptySecure() (*SimpleTrie, *SecureTrie) {
+func newEmptySecure() (*Trie, *SecureTrie) {
 	db, _ := ethdb.NewMemDatabase()
 	tr, _ := New(common.Hash{}, db, 0)
 	st := NewSecure(tr, db)

--- a/trie/secure_trie_test.go
+++ b/trie/secure_trie_test.go
@@ -27,11 +27,11 @@ import (
 	"github.com/ethereum/go-ethereum/ethdb"
 )
 
-func newEmptySecure() *SecureTrie {
+func newEmptySecure() (*SimpleTrie, *SecureTrie) {
 	db, _ := ethdb.NewMemDatabase()
 	tr, _ := New(common.Hash{}, db, 0)
 	st := NewSecure(tr, db)
-	return st
+	return tr, st
 }
 
 // makeTestSecureTrie creates a large enough secure trie for testing.
@@ -67,7 +67,7 @@ func makeTestSecureTrie() (ethdb.Database, *SecureTrie, map[string][]byte) {
 }
 
 func TestSecureDelete(t *testing.T) {
-	trie := newEmptySecure()
+	trie, st := newEmptySecure()
 	vals := []struct{ k, v string }{
 		{"do", "verb"},
 		{"ether", "wookiedoo"},
@@ -80,9 +80,9 @@ func TestSecureDelete(t *testing.T) {
 	}
 	for _, val := range vals {
 		if val.v != "" {
-			trie.Update([]byte(val.k), []byte(val.v))
+			st.Update([]byte(val.k), []byte(val.v))
 		} else {
-			trie.Delete([]byte(val.k))
+			st.Delete([]byte(val.k))
 		}
 	}
 	hash := trie.Hash()
@@ -93,17 +93,17 @@ func TestSecureDelete(t *testing.T) {
 }
 
 func TestSecureGetKey(t *testing.T) {
-	trie := newEmptySecure()
-	trie.Update([]byte("foo"), []byte("bar"))
+	_, st := newEmptySecure()
+	st.Update([]byte("foo"), []byte("bar"))
 
 	key := []byte("foo")
 	value := []byte("bar")
 	seckey := crypto.Keccak256(key)
 
-	if !bytes.Equal(trie.Get(key), value) {
+	if !bytes.Equal(st.Get(key), value) {
 		t.Errorf("Get did not return bar")
 	}
-	if k := trie.GetKey(seckey); !bytes.Equal(k, key) {
+	if k := st.GetKey(seckey); !bytes.Equal(k, key) {
 		t.Errorf("GetKey returned %q, want %q", k, key)
 	}
 }

--- a/trie/secure_trie_test.go
+++ b/trie/secure_trie_test.go
@@ -60,7 +60,7 @@ func makeTestSecureTrie() (ethdb.Database, *SecureTrie, map[string][]byte) {
 			trie.Update(key, val)
 		}
 	}
-	trie.Commit()
+	trie.CommitTo(db)
 
 	// Return the generated trie
 	return db, trie, content
@@ -110,7 +110,7 @@ func TestSecureGetKey(t *testing.T) {
 
 func TestSecureTrieConcurrency(t *testing.T) {
 	// Create an initial trie and copy if for concurrent access
-	_, trie, _ := makeTestSecureTrie()
+	db, trie, _ := makeTestSecureTrie()
 
 	threads := runtime.NumCPU()
 	tries := make([]*SecureTrie, threads)
@@ -139,7 +139,7 @@ func TestSecureTrieConcurrency(t *testing.T) {
 					tries[index].Update(key, val)
 				}
 			}
-			tries[index].Commit()
+			tries[index].CommitTo(db)
 		}(i)
 	}
 	// Wait for all threads to finish

--- a/trie/secure_trie_test.go
+++ b/trie/secure_trie_test.go
@@ -29,15 +29,17 @@ import (
 
 func newEmptySecure() *SecureTrie {
 	db, _ := ethdb.NewMemDatabase()
-	trie, _ := NewSecure(common.Hash{}, db, 0)
-	return trie
+	tr, _ := New(common.Hash{}, db, 0)
+	st := NewSecure(tr, db)
+	return st
 }
 
 // makeTestSecureTrie creates a large enough secure trie for testing.
 func makeTestSecureTrie() (ethdb.Database, *SecureTrie, map[string][]byte) {
 	// Create an empty trie
 	db, _ := ethdb.NewMemDatabase()
-	trie, _ := NewSecure(common.Hash{}, db, 0)
+	tr, _ := New(common.Hash{}, db, 0)
+	trie := NewSecure(tr, db)
 
 	// Fill it with some arbitrary data
 	content := make(map[string][]byte)

--- a/trie/sync.go
+++ b/trie/sync.go
@@ -292,7 +292,7 @@ func (s *TrieSync) children(req *request, object node) ([]*request, error) {
 							// If this branch was already visited, abort iteration
 							keys := req.keys(append(child.path, it.Nibbles...))
 							if !unknown {
-								if val, err := GetDirectCache(req.dcPrefix, keys[0], s.database); val != nil && err == nil {
+								if HasDirectCache(req.dcPrefix, keys[0], s.database) {
 									break
 								}
 								// Branch is unknown, mark as so to avoid repeated db lookups

--- a/trie/sync_test.go
+++ b/trie/sync_test.go
@@ -25,7 +25,7 @@ import (
 )
 
 // makeTestTrie create a sample test trie to test node-wise reconstruction.
-func makeTestTrie() (ethdb.Database, *SimpleTrie, map[string][]byte) {
+func makeTestTrie() (ethdb.Database, *Trie, map[string][]byte) {
 	// Create an empty trie
 	db, _ := ethdb.NewMemDatabase()
 	trie, _ := New(common.Hash{}, db, 0)
@@ -91,7 +91,7 @@ func TestEmptyTrieSync(t *testing.T) {
 	emptyA, _ := New(common.Hash{}, nil, 0)
 	emptyB, _ := New(emptyRoot, nil, 0)
 
-	for i, trie := range []*SimpleTrie{emptyA, emptyB} {
+	for i, trie := range []*Trie{emptyA, emptyB} {
 		db, _ := ethdb.NewMemDatabase()
 		if req := NewTrieSync(common.BytesToHash(trie.Root()), db, nil).Missing(1); len(req) != 0 {
 			t.Errorf("test %d: content requested for empty trie: %v", i, req)

--- a/trie/sync_test.go
+++ b/trie/sync_test.go
@@ -115,7 +115,7 @@ func TestEmptyTrieSync(t *testing.T) {
 
 	for i, trie := range []*Trie{emptyA, emptyB} {
 		db, _ := ethdb.NewMemDatabase()
-		if req := NewTrieSync(common.BytesToHash(trie.Root()), db, nil).Missing(1); len(req) != 0 {
+		if req := NewTrieSync(common.BytesToHash(trie.Root()), db, nil, nil).Missing(1); len(req) != 0 {
 			t.Errorf("test %d: content requested for empty trie: %v", i, req)
 		}
 	}
@@ -132,7 +132,7 @@ func testIterativeTrieSync(t *testing.T, batch int) {
 
 	// Create a destination trie and sync with the scheduler
 	dstDb, _ := ethdb.NewMemDatabase()
-	sched := NewTrieSync(common.BytesToHash(srcTrie.Root()), dstDb, nil)
+	sched := NewTrieSync(common.BytesToHash(srcTrie.Root()), dstDb, nil, nil)
 
 	queue := append([]common.Hash{}, sched.Missing(batch)...)
 	for len(queue) > 0 {
@@ -161,7 +161,7 @@ func TestIterativeDelayedTrieSync(t *testing.T) {
 
 	// Create a destination trie and sync with the scheduler
 	dstDb, _ := ethdb.NewMemDatabase()
-	sched := NewTrieSync(common.BytesToHash(srcTrie.Root()), dstDb, nil)
+	sched := NewTrieSync(common.BytesToHash(srcTrie.Root()), dstDb, nil, nil)
 
 	queue := append([]common.Hash{}, sched.Missing(10000)...)
 	for len(queue) > 0 {
@@ -195,7 +195,7 @@ func testIterativeRandomTrieSync(t *testing.T, batch int) {
 
 	// Create a destination trie and sync with the scheduler
 	dstDb, _ := ethdb.NewMemDatabase()
-	sched := NewTrieSync(common.BytesToHash(srcTrie.Root()), dstDb, nil)
+	sched := NewTrieSync(common.BytesToHash(srcTrie.Root()), dstDb, nil, nil)
 
 	queue := make(map[common.Hash]struct{})
 	for _, hash := range sched.Missing(batch) {
@@ -232,7 +232,7 @@ func TestIterativeRandomDelayedTrieSync(t *testing.T) {
 
 	// Create a destination trie and sync with the scheduler
 	dstDb, _ := ethdb.NewMemDatabase()
-	sched := NewTrieSync(common.BytesToHash(srcTrie.Root()), dstDb, nil)
+	sched := NewTrieSync(common.BytesToHash(srcTrie.Root()), dstDb, nil, nil)
 
 	queue := make(map[common.Hash]struct{})
 	for _, hash := range sched.Missing(10000) {
@@ -275,7 +275,7 @@ func TestDuplicateAvoidanceTrieSync(t *testing.T) {
 
 	// Create a destination trie and sync with the scheduler
 	dstDb, _ := ethdb.NewMemDatabase()
-	sched := NewTrieSync(common.BytesToHash(srcTrie.Root()), dstDb, nil)
+	sched := NewTrieSync(common.BytesToHash(srcTrie.Root()), dstDb, nil, nil)
 
 	queue := append([]common.Hash{}, sched.Missing(0)...)
 	requested := make(map[common.Hash]struct{})
@@ -311,7 +311,7 @@ func TestIncompleteTrieSync(t *testing.T) {
 
 	// Create a destination trie and sync with the scheduler
 	dstDb, _ := ethdb.NewMemDatabase()
-	sched := NewTrieSync(common.BytesToHash(srcTrie.Root()), dstDb, nil)
+	sched := NewTrieSync(common.BytesToHash(srcTrie.Root()), dstDb, nil, nil)
 
 	added := []common.Hash{}
 	queue := append([]common.Hash{}, sched.Missing(1)...)
@@ -371,7 +371,7 @@ func TestAllLeafCallbackTrieSync(t *testing.T) {
 	}
 	// Create a destination trie and sync with the scheduler
 	dstDb, _ := ethdb.NewMemDatabase()
-	sched := NewTrieSync(common.BytesToHash(srcTrie.Root()), dstDb, callback)
+	sched := NewTrieSync(common.BytesToHash(srcTrie.Root()), dstDb, callback, []byte("leaf:"))
 
 	queue := append([]common.Hash{}, sched.Missing(1)...)
 	for len(queue) > 0 {

--- a/trie/sync_test.go
+++ b/trie/sync_test.go
@@ -25,10 +25,10 @@ import (
 )
 
 // makeTestTrie create a sample test trie to test node-wise reconstruction.
-func makeTestTrie() (ethdb.Database, *Trie, map[string][]byte) {
+func makeTestTrie() (ethdb.Database, *SimpleTrie, map[string][]byte) {
 	// Create an empty trie
 	db, _ := ethdb.NewMemDatabase()
-	trie, _ := New(common.Hash{}, db)
+	trie, _ := New(common.Hash{}, db, 0)
 
 	// Fill it with some arbitrary data
 	content := make(map[string][]byte)
@@ -59,7 +59,7 @@ func makeTestTrie() (ethdb.Database, *Trie, map[string][]byte) {
 // content map.
 func checkTrieContents(t *testing.T, db Database, root []byte, content map[string][]byte) {
 	// Check root availability and trie contents
-	trie, err := New(common.BytesToHash(root), db)
+	trie, err := New(common.BytesToHash(root), db, 0)
 	if err != nil {
 		t.Fatalf("failed to create trie at %x: %v", root, err)
 	}
@@ -76,7 +76,7 @@ func checkTrieContents(t *testing.T, db Database, root []byte, content map[strin
 // checkTrieConsistency checks that all nodes in a trie are indeed present.
 func checkTrieConsistency(db Database, root common.Hash) error {
 	// Create and iterate a trie rooted in a subnode
-	trie, err := New(root, db)
+	trie, err := New(root, db, 0)
 	if err != nil {
 		return nil // // Consider a non existent state consistent
 	}
@@ -88,10 +88,10 @@ func checkTrieConsistency(db Database, root common.Hash) error {
 
 // Tests that an empty trie is not scheduled for syncing.
 func TestEmptyTrieSync(t *testing.T) {
-	emptyA, _ := New(common.Hash{}, nil)
-	emptyB, _ := New(emptyRoot, nil)
+	emptyA, _ := New(common.Hash{}, nil, 0)
+	emptyB, _ := New(emptyRoot, nil, 0)
 
-	for i, trie := range []*Trie{emptyA, emptyB} {
+	for i, trie := range []*SimpleTrie{emptyA, emptyB} {
 		db, _ := ethdb.NewMemDatabase()
 		if req := NewTrieSync(common.BytesToHash(trie.Root()), db, nil).Missing(1); len(req) != 0 {
 			t.Errorf("test %d: content requested for empty trie: %v", i, req)

--- a/trie/sync_test.go
+++ b/trie/sync_test.go
@@ -55,6 +55,28 @@ func makeTestTrie() (ethdb.Database, *Trie, map[string][]byte) {
 	return db, trie, content
 }
 
+// makeRepetitiveTestTrie creates a test trie to test node-wise reconstruction,
+// where all values are the same, forcing large parts of the trie to share nodes.
+func makeRepetitiveTestTrie() (ethdb.Database, *Trie, map[string][]byte) {
+	// Create an empty trie
+	db, _ := ethdb.NewMemDatabase()
+	trie, _ := New(common.Hash{}, db, 0)
+
+	// Fill it with some arbitrary data
+	content := make(map[string][]byte)
+	for i := byte(0); i < 255; i++ {
+		for j := byte(0); j < 255; j++ {
+			key, val := common.LeftPadBytes([]byte{j, i}, 32), common.LeftPadBytes(nil, 32)
+			content[string(key)] = val
+			trie.Update(key, val)
+		}
+	}
+	trie.Commit()
+
+	// Return the generated trie
+	return db, trie, content
+}
+
 // checkTrieContents cross references a reconstructed trie with an expected data
 // content map.
 func checkTrieContents(t *testing.T, db Database, root []byte, content map[string][]byte) {
@@ -329,5 +351,51 @@ func TestIncompleteTrieSync(t *testing.T) {
 			t.Fatalf("trie inconsistency not caught, missing: %x", key)
 		}
 		dstDb.Put(key, value)
+	}
+}
+
+// Tests that if a leaf callback is specified, all leaf nodes are invoked with
+// it, even if sync short circuits with existing local nodes.
+func TestAllLeafCallbackTrieSync(t *testing.T) {
+	// Create a random trie to copy
+	srcDb, srcTrie, srcData := makeRepetitiveTestTrie()
+
+	// Create a callback to accumulate all keys for later verification
+	leaves, count := make(map[string]struct{}), 0
+	callback := func(keys [][]byte, leaf []byte, parent common.Hash) error {
+		for _, key := range keys {
+			leaves[string(key)] = struct{}{}
+			count++
+		}
+		return nil
+	}
+	// Create a destination trie and sync with the scheduler
+	dstDb, _ := ethdb.NewMemDatabase()
+	sched := NewTrieSync(common.BytesToHash(srcTrie.Root()), dstDb, callback)
+
+	queue := append([]common.Hash{}, sched.Missing(1)...)
+	for len(queue) > 0 {
+		results := make([]SyncResult, len(queue))
+		for i, hash := range queue {
+			data, err := srcDb.Get(hash.Bytes())
+			if err != nil {
+				t.Fatalf("failed to retrieve node data for %x: %v", hash, err)
+			}
+			results[i] = SyncResult{hash, data}
+		}
+		if index, err := sched.Process(results); err != nil {
+			t.Fatalf("failed to process result #%d: %v", index, err)
+		}
+		queue = append(queue[:0], sched.Missing(1)...)
+	}
+	// Cross check that the two tries are in sync
+	checkTrieContents(t, dstDb, srcTrie.Root(), srcData)
+
+	// Ensure the leaf callback was invoked for all leaves, including cached ones
+	if len(leaves) != len(srcData) {
+		t.Errorf("Leaf callback count mismatch: have %v, want %v", len(leaves), len(srcData))
+	}
+	if len(leaves) != count {
+		t.Errorf("Duplicate leaf callbacks: have %v, want %v", count, len(leaves))
 	}
 }

--- a/trie/trie.go
+++ b/trie/trie.go
@@ -78,7 +78,7 @@ type DatabaseWriter interface {
 // Use New to create a trie that sits on top of a database.
 //
 // trie is not safe for concurrent use.
-type Trie interface {
+type Storage interface {
 	Iterator() *Iterator
 	NodeIterator() *NodeIterator
 	Get(key []byte) []byte
@@ -87,8 +87,6 @@ type Trie interface {
 	TryUpdate(key, value []byte) error
 	Delete(key []byte)
 	TryDelete(key []byte) error
-	Root() []byte
-	Hash() common.Hash
 	Commit() (root common.Hash, err error)
 	CommitTo(db DatabaseWriter) (root common.Hash, err error)
 }

--- a/trie/trie.go
+++ b/trie/trie.go
@@ -78,18 +78,6 @@ type DatabaseWriter interface {
 // Use New to create a trie that sits on top of a database.
 //
 // trie is not safe for concurrent use.
-type Storage interface {
-	Iterator() *Iterator
-	Get(key []byte) []byte
-	TryGet(key []byte) ([]byte, error)
-	Update(key, value []byte)
-	TryUpdate(key, value []byte) error
-	Delete(key []byte)
-	TryDelete(key []byte) error
-	Commit() (root common.Hash, err error)
-	CommitTo(db DatabaseWriter) (root common.Hash, err error)
-}
-
 type Trie struct {
 	root         node
 	db           Database

--- a/trie/trie_test.go
+++ b/trie/trie_test.go
@@ -583,14 +583,14 @@ func tempDB() (string, Database) {
 	return dir, db
 }
 
-func getString(trie Trie, k string) []byte {
+func getString(trie *Trie, k string) []byte {
 	return trie.Get([]byte(k))
 }
 
-func updateString(trie Trie, k, v string) {
+func updateString(trie *Trie, k, v string) {
 	trie.Update([]byte(k), []byte(v))
 }
 
-func deleteString(trie Trie, k string) {
+func deleteString(trie *Trie, k string) {
 	trie.Delete([]byte(k))
 }

--- a/trie/trie_test.go
+++ b/trie/trie_test.go
@@ -38,14 +38,14 @@ func init() {
 }
 
 // Used for testing
-func newEmpty() *SimpleTrie {
+func newEmpty() *Trie {
 	db, _ := ethdb.NewMemDatabase()
 	trie, _ := New(common.Hash{}, db, 0)
 	return trie
 }
 
 func TestEmptyTrie(t *testing.T) {
-	var trie SimpleTrie
+	var trie Trie
 	res := trie.Hash()
 	exp := emptyRoot
 	if res != common.Hash(exp) {
@@ -54,7 +54,7 @@ func TestEmptyTrie(t *testing.T) {
 }
 
 func TestNull(t *testing.T) {
-	var trie SimpleTrie
+	var trie Trie
 	key := make([]byte, 32)
 	value := common.FromHex("0x823140710bf13990e4500136726d8b55")
 	trie.Update(key, value)
@@ -547,7 +547,7 @@ func benchGet(b *testing.B, commit bool) {
 	}
 }
 
-func benchUpdate(b *testing.B, e binary.ByteOrder) *SimpleTrie {
+func benchUpdate(b *testing.B, e binary.ByteOrder) *Trie {
 	trie := newEmpty()
 	k := make([]byte, 32)
 	for i := 0; i < b.N; i++ {


### PR DESCRIPTION
This PR implements a 'direct cache' in leveldb, which maps from account hash to `(account, block number, block hash)`. This disk cache is on the order of 5-10x quicker to look up than the trie, and permits quick efficient lookups of values in the current state. Reorgs are handled by comparing the stored block hash to the canonical hash for the specified block number; if they match, it falls back to looking up data in the trie.
