### PR TITLE
ethclient: Changed TransactionByHash to only pass one argument to eth_getTransactionByHash

### DIFF
--- a/ethclient/ethclient.go
+++ b/ethclient/ethclient.go
@@ -145,7 +145,7 @@ func (ec *Client) HeaderByNumber(ctx context.Context, number *big.Int) (*types.H
 // TransactionByHash returns the transaction with the given hash.
 func (ec *Client) TransactionByHash(ctx context.Context, hash common.Hash) (*types.Transaction, error) {
 	var tx *types.Transaction
-	err := ec.c.CallContext(ctx, &tx, "eth_getTransactionByHash", hash, false)
+	err := ec.c.CallContext(ctx, &tx, "eth_getTransactionByHash", hash)
 	if err == nil {
 		if _, r, _ := tx.SignatureValues(); r == nil {
 			return nil, fmt.Errorf("server returned transaction without signature")


### PR DESCRIPTION
Fixes #3203