### PR TITLE
Fix issues with software license links

### DIFF
--- a/index.html
+++ b/index.html
@@ -36,8 +36,8 @@ backing layer.
 
 <p>
 Ethereum may also be run in a private environment, such as for use within a corporate network,
-without any cost. All core source is licensed under the <a href="https://github.com/ethereum/go-ethereum/tree/master/COPYING.md">LGPL</a>
-and all frontend code is licensed under <a href="https://github.com/ethereum/go-ethereum/tree/master/COPYING.LESSER.md">GPL</a>.
+without any cost. All core source is licensed under the <a href="https://github.com/ethereum/go-ethereum/tree/master/COPYING">LGPL</a>
+and all frontend code is licensed under <a href="https://github.com/ethereum/go-ethereum/tree/master/COPYING.LESSER">GPL</a>.
 </p>
 
 <p>

--- a/index.html
+++ b/index.html
@@ -36,8 +36,8 @@ backing layer.
 
 <p>
 Ethereum may also be run in a private environment, such as for use within a corporate network,
-without any cost. All core source is licensed under the <a href="https://github.com/ethereum/go-ethereum/tree/master/COPYING">LGPL</a>
-and all frontend code is licensed under <a href="https://github.com/ethereum/go-ethereum/tree/master/COPYING.LESSER">GPL</a>.
+without any cost. All core source is licensed under the <a href="https://github.com/ethereum/go-ethereum/tree/master/COPYING.LESSER">LGPL</a>
+and all frontend code is licensed under <a href="https://github.com/ethereum/go-ethereum/tree/master/COPYING">GPL</a>.
 </p>
 
 <p>


### PR DESCRIPTION
The GPL and LGPL links seem to be broken and the LGPL link points to the GPL license document and vice-versa. This PR fixes both issues.