### PR TITLE
core, light, miner, trie: add direct cache for state values

### DIFF
--- a/cmd/geth/chaincmd.go
+++ b/cmd/geth/chaincmd.go
@@ -134,8 +134,11 @@ func importChain(ctx *cli.Context) error {
 		utils.Fatalf("Failed to read database stats: %v", err)
 	}
 	fmt.Println(stats)
-	fmt.Printf("Trie cache misses:  %d\n", trie.CacheMisses())
-	fmt.Printf("Trie cache unloads: %d\n\n", trie.CacheUnloads())
+	fmt.Printf("Trie cache misses:   %d\n", trie.CacheMisses())
+	fmt.Printf("Trie cache unloads:  %d\n", trie.CacheUnloads())
+	fmt.Printf("Direct cache reads:  %d\n", trie.DirectCacheReads())
+	fmt.Printf("Direct cache writes: %d\n", trie.DirectCacheWrites())
+	fmt.Printf("Direct cache misses: %d\n\n", trie.DirectCacheMisses())
 
 	// Print the memory statistics used by the importing
 	mem := new(runtime.MemStats)
@@ -324,7 +327,7 @@ func buildCache(ctx *cli.Context) error {
 		}
 
 		i += 1
-		if i % 10000 == 0 {
+		if i%10000 == 0 {
 			fmt.Printf("Processed %d accounts, at %v\n", i, common.ToHex(iter.Key))
 		}
 	}

--- a/cmd/geth/chaincmd.go
+++ b/cmd/geth/chaincmd.go
@@ -134,11 +134,13 @@ func importChain(ctx *cli.Context) error {
 		utils.Fatalf("Failed to read database stats: %v", err)
 	}
 	fmt.Println(stats)
-	fmt.Printf("Trie cache misses:   %d\n", trie.CacheMisses())
-	fmt.Printf("Trie cache unloads:  %d\n", trie.CacheUnloads())
-	fmt.Printf("Direct cache reads:  %d\n", trie.DirectCacheReads())
-	fmt.Printf("Direct cache writes: %d\n", trie.DirectCacheWrites())
-	fmt.Printf("Direct cache misses: %d\n\n", trie.DirectCacheMisses())
+	fmt.Printf("Trie cache misses:            %d\n", trie.CacheMisses())
+	fmt.Printf("Trie cache unloads:           %d\n", trie.CacheUnloads())
+	fmt.Printf("Direct memory cache hits:     %d\n", trie.DirectCacheMemcacheHits())
+	fmt.Printf("Direct memory cache misses:   %d\n", trie.DirectCacheMemcacheMisses())
+	fmt.Printf("Direct database cache reads:  %d\n", trie.DirectCacheReads())
+	fmt.Printf("Direct database cache writes: %d\n", trie.DirectCacheWrites())
+	fmt.Printf("Direct database cache misses: %d\n\n", trie.DirectCacheMisses())
 
 	// Print the memory statistics used by the importing
 	mem := new(runtime.MemStats)

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -553,7 +553,7 @@ func (self *BlockChain) GetBlockByNumber(number uint64) *types.Block {
 
 // IsCanonChainBlock checks whether the given block is in the current canonical chain.
 func (self *BlockChain) IsCanonChainBlock(number uint64, hash common.Hash) bool {
-	return number < uint64(self.currentBlock.Number().Int64()) && GetCanonicalHash(self.chainDb, number) == hash
+	return GetCanonicalHash(self.chainDb, number) == hash
 }
 
 // [deprecated by eth/62]
@@ -937,6 +937,7 @@ func (self *BlockChain) InsertChain(chain types.Blocks) (int, error) {
 			self.reportBlock(block, nil, err)
 			return i, err
 		}
+		self.stateCache.SetBlockContext(block.Hash(), block.NumberU64(), self)
 		// Process block using the parent state as reference point.
 		receipts, logs, usedGas, err := self.processor.Process(block, self.stateCache, vm.Config{})
 		if err != nil {

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -275,7 +275,7 @@ func (self *BlockChain) FastSyncCommitHead(hash common.Hash) error {
 	if block == nil {
 		return fmt.Errorf("non existent block [%x…]", hash[:4])
 	}
-	if _, err := trie.NewSecure(block.Root(), self.chainDb, 0); err != nil {
+	if _, err := trie.New(block.Root(), self.chainDb, 0); err != nil {
 		return err
 	}
 	// If all checks out, manually set the head block
@@ -549,6 +549,11 @@ func (self *BlockChain) GetBlockByNumber(number uint64) *types.Block {
 		return nil
 	}
 	return self.GetBlock(hash, number)
+}
+
+// IsCanonChainBlock checks whether the given block is in the current canonical chain.
+func (self *BlockChain) IsCanonChainBlock(number uint64, hash common.Hash) bool {
+	return number < uint64(self.currentBlock.Number().Int64()) && GetCanonicalHash(self.chainDb, number) == hash
 }
 
 // [deprecated by eth/62]

--- a/core/chain_makers.go
+++ b/core/chain_makers.go
@@ -107,7 +107,7 @@ func (b *BlockGen) AddTx(tx *types.Transaction) {
 	if b.gasPool == nil {
 		b.SetCoinbase(common.Address{})
 	}
-	b.statedb.StartRecord(tx.Hash(), common.Hash{}, len(b.txs))
+	b.statedb.SetTxContext(common.Hash{}, b.header.Number.Uint64(), tx.Hash(), len(b.txs), nil)
 	receipt, _, _, err := ApplyTransaction(b.config, nil, b.gasPool, b.statedb, b.header, tx, b.header.GasUsed, vm.Config{})
 	if err != nil {
 		panic(err)

--- a/core/chain_makers.go
+++ b/core/chain_makers.go
@@ -107,7 +107,7 @@ func (b *BlockGen) AddTx(tx *types.Transaction) {
 	if b.gasPool == nil {
 		b.SetCoinbase(common.Address{})
 	}
-	b.statedb.SetTxContext(common.Hash{}, b.header.Number.Uint64(), tx.Hash(), len(b.txs), nil)
+	b.statedb.SetTxContext(tx.Hash(), len(b.txs))
 	receipt, _, _, err := ApplyTransaction(b.config, nil, b.gasPool, b.statedb, b.header, tx, b.header.GasUsed, vm.Config{})
 	if err != nil {
 		panic(err)

--- a/core/state/dump.go
+++ b/core/state/dump.go
@@ -44,9 +44,9 @@ func (self *StateDB) RawDump() Dump {
 		Accounts: make(map[string]DumpAccount),
 	}
 
-	it := self.trie.Iterator()
+	it := self.storage.Iterator()
 	for it.Next() {
-		addr := self.trie.GetKey(it.Key)
+		addr := self.storage.GetKey(it.Key)
 		var data Account
 		if err := rlp.DecodeBytes(it.Value, &data); err != nil {
 			panic(err)
@@ -61,9 +61,9 @@ func (self *StateDB) RawDump() Dump {
 			Code:     common.Bytes2Hex(obj.Code(self.db)),
 			Storage:  make(map[string]string),
 		}
-		storageIt := obj.getTrie(self.db).Iterator()
+		storageIt := obj.getStorage(self.db).Iterator()
 		for storageIt.Next() {
-			account.Storage[common.Bytes2Hex(self.trie.GetKey(storageIt.Key))] = common.Bytes2Hex(storageIt.Value)
+			account.Storage[common.Bytes2Hex(self.storage.GetKey(storageIt.Key))] = common.Bytes2Hex(storageIt.Value)
 		}
 		dump.Accounts[common.Bytes2Hex(addr)] = account
 	}

--- a/core/state/iterator.go
+++ b/core/state/iterator.go
@@ -76,7 +76,7 @@ func (it *NodeIterator) step() error {
 	}
 	// Initialize the iterator if we've just started
 	if it.stateIt == nil {
-		it.stateIt = it.state.trie.NodeIterator()
+		it.stateIt = trie.NewNodeIterator(it.state.trie)
 	}
 	// If we had data nodes previously, we surely have at least state nodes
 	if it.dataIt != nil {
@@ -115,7 +115,7 @@ func (it *NodeIterator) step() error {
 	if err := rlp.Decode(bytes.NewReader(it.stateIt.LeafBlob), &account); err != nil {
 		return err
 	}
-	dataTrie, err := trie.New(account.Root, it.state.db)
+	dataTrie, err := trie.New(account.Root, it.state.db, 0)
 	if err != nil {
 		return err
 	}

--- a/core/state/iterator_test.go
+++ b/core/state/iterator_test.go
@@ -47,7 +47,7 @@ func TestNodeIteratorCoverage(t *testing.T) {
 		}
 	}
 	for _, key := range db.(*ethdb.MemDatabase).Keys() {
-		if bytes.HasPrefix(key, []byte("secure-key-")) {
+		if bytes.HasPrefix(key, []byte("secure-key-")) || bytes.HasPrefix(key, CachePrefix) {
 			continue
 		}
 		if _, ok := hashes[common.BytesToHash(key)]; !ok {

--- a/core/state/iterator_test.go
+++ b/core/state/iterator_test.go
@@ -47,7 +47,7 @@ func TestNodeIteratorCoverage(t *testing.T) {
 		}
 	}
 	for _, key := range db.(*ethdb.MemDatabase).Keys() {
-		if bytes.HasPrefix(key, []byte("secure-key-")) || bytes.HasPrefix(key, CachePrefix) {
+		if bytes.HasPrefix(key, []byte("secure-key-")) || bytes.HasPrefix(key, DirectCachePrefix) {
 			continue
 		}
 		if _, ok := hashes[common.BytesToHash(key)]; !ok {

--- a/core/state/sync.go
+++ b/core/state/sync.go
@@ -32,10 +32,11 @@ import (
 type StateSync trie.TrieSync
 
 // NewStateSync create a new state trie download scheduler.
-func NewStateSync(root common.Hash, database ethdb.Database) *StateSync {
+func NewStateSync(number uint64, hash common.Hash, root common.Hash, database ethdb.Database) *StateSync {
 	var syncer *trie.TrieSync
 
-	callback := func(leaf []byte, parent common.Hash) error {
+	callback := func(keys [][]byte, leaf []byte, parent common.Hash) error {
+		// Try to decode any leaf nodes as accounts
 		var obj struct {
 			Nonce    uint64
 			Balance  *big.Int
@@ -45,12 +46,19 @@ func NewStateSync(root common.Hash, database ethdb.Database) *StateSync {
 		if err := rlp.Decode(bytes.NewReader(leaf), &obj); err != nil {
 			return err
 		}
-		syncer.AddSubTrie(obj.Root, 64, parent, nil)
+		// Populate the direct account caches in the database
+		for _, key := range keys {
+			if err := trie.WriteDirectCache(CachePrefix, key, leaf, number, hash, database); err != nil {
+				return err
+			}
+		}
+		// Schedule downloading all the dependencies of the account
+		syncer.AddSubTrie(obj.Root, 64, parent, nil, nil)
 		syncer.AddRawEntry(common.BytesToHash(obj.CodeHash), 64, parent)
 
 		return nil
 	}
-	syncer = trie.NewTrieSync(root, database, callback)
+	syncer = trie.NewTrieSync(root, database, callback, CachePrefix)
 	return (*StateSync)(syncer)
 }
 

--- a/core/state/sync_test.go
+++ b/core/state/sync_test.go
@@ -47,8 +47,8 @@ func makeTestState() (ethdb.Database, common.Hash, []*testAccount) {
 		obj := state.GetOrNewStateObject(common.BytesToAddress([]byte{i}))
 		acc := &testAccount{address: common.BytesToAddress([]byte{i})}
 
-		obj.AddBalance(big.NewInt(int64(11 * i)))
-		acc.balance = big.NewInt(int64(11 * i))
+		obj.AddBalance(big.NewInt(11 * int64(i)))
+		acc.balance = big.NewInt(11 * int64(i))
 
 		obj.SetNonce(uint64(42 * i))
 		acc.nonce = uint64(42 * i)
@@ -110,7 +110,7 @@ func checkStateConsistency(db ethdb.Database, root common.Hash) error {
 func TestEmptyStateSync(t *testing.T) {
 	empty := common.HexToHash("56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421")
 	db, _ := ethdb.NewMemDatabase()
-	if req := NewStateSync(empty, db).Missing(1); len(req) != 0 {
+	if req := NewStateSync(0, common.Hash{}, empty, db).Missing(1); len(req) != 0 {
 		t.Errorf("content requested for empty state: %v", req)
 	}
 }
@@ -126,7 +126,7 @@ func testIterativeStateSync(t *testing.T, batch int) {
 
 	// Create a destination state and sync with the scheduler
 	dstDb, _ := ethdb.NewMemDatabase()
-	sched := NewStateSync(srcRoot, dstDb)
+	sched := NewStateSync(0, common.Hash{}, srcRoot, dstDb)
 
 	queue := append([]common.Hash{}, sched.Missing(batch)...)
 	for len(queue) > 0 {
@@ -155,7 +155,7 @@ func TestIterativeDelayedStateSync(t *testing.T) {
 
 	// Create a destination state and sync with the scheduler
 	dstDb, _ := ethdb.NewMemDatabase()
-	sched := NewStateSync(srcRoot, dstDb)
+	sched := NewStateSync(0, common.Hash{}, srcRoot, dstDb)
 
 	queue := append([]common.Hash{}, sched.Missing(0)...)
 	for len(queue) > 0 {
@@ -189,7 +189,7 @@ func testIterativeRandomStateSync(t *testing.T, batch int) {
 
 	// Create a destination state and sync with the scheduler
 	dstDb, _ := ethdb.NewMemDatabase()
-	sched := NewStateSync(srcRoot, dstDb)
+	sched := NewStateSync(0, common.Hash{}, srcRoot, dstDb)
 
 	queue := make(map[common.Hash]struct{})
 	for _, hash := range sched.Missing(batch) {
@@ -226,7 +226,7 @@ func TestIterativeRandomDelayedStateSync(t *testing.T) {
 
 	// Create a destination state and sync with the scheduler
 	dstDb, _ := ethdb.NewMemDatabase()
-	sched := NewStateSync(srcRoot, dstDb)
+	sched := NewStateSync(0, common.Hash{}, srcRoot, dstDb)
 
 	queue := make(map[common.Hash]struct{})
 	for _, hash := range sched.Missing(0) {
@@ -268,7 +268,7 @@ func TestIncompleteStateSync(t *testing.T) {
 
 	// Create a destination state and sync with the scheduler
 	dstDb, _ := ethdb.NewMemDatabase()
-	sched := NewStateSync(srcRoot, dstDb)
+	sched := NewStateSync(0, common.Hash{}, srcRoot, dstDb)
 
 	added := []common.Hash{}
 	queue := append([]common.Hash{}, sched.Missing(1)...)

--- a/core/state_processor.go
+++ b/core/state_processor.go
@@ -72,8 +72,7 @@ func (p *StateProcessor) Process(block *types.Block, statedb *state.StateDB, cfg
 	}
 	// Iterate over and process the individual transactions
 	for i, tx := range block.Transactions() {
-		//fmt.Println("tx:", i)
-		statedb.StartRecord(tx.Hash(), block.Hash(), i)
+		statedb.SetTxContext(block.Hash(), block.NumberU64(), tx.Hash(), i, p.bc)
 		receipt, logs, _, err := ApplyTransaction(p.config, p.bc, gp, statedb, header, tx, totalUsedGas, cfg)
 		if err != nil {
 			return nil, nil, nil, err

--- a/core/state_processor.go
+++ b/core/state_processor.go
@@ -72,7 +72,7 @@ func (p *StateProcessor) Process(block *types.Block, statedb *state.StateDB, cfg
 	}
 	// Iterate over and process the individual transactions
 	for i, tx := range block.Transactions() {
-		statedb.SetTxContext(block.Hash(), block.NumberU64(), tx.Hash(), i, p.bc)
+		statedb.SetTxContext(tx.Hash(), i)
 		receipt, logs, _, err := ApplyTransaction(p.config, p.bc, gp, statedb, header, tx, totalUsedGas, cfg)
 		if err != nil {
 			return nil, nil, nil, err

--- a/core/types/derive_sha.go
+++ b/core/types/derive_sha.go
@@ -31,7 +31,7 @@ type DerivableList interface {
 
 func DeriveSha(list DerivableList) common.Hash {
 	keybuf := new(bytes.Buffer)
-	trie := new(trie.Trie)
+	trie, _ := trie.New(common.Hash{}, nil, 0)
 	for i := 0; i < list.Len(); i++ {
 		keybuf.Reset()
 		rlp.Encode(keybuf, uint(i))

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -255,6 +255,10 @@ func New(ctx *node.ServiceContext, config *Config) (*Ethereum, error) {
 	gpo := gasprice.NewGasPriceOracle(eth.blockchain, chainDb, eth.eventMux, gpoParams)
 	eth.ApiBackend = &EthApiBackend{eth, gpo}
 
+	if err := populateDirectCache(chainDb, eth.blockchain); err != nil {
+		return nil, err
+	}
+
 	return eth, nil
 }
 

--- a/eth/db_upgrade.go
+++ b/eth/db_upgrade.go
@@ -371,7 +371,7 @@ func populateDirectCache(db ethdb.Database, bc *core.BlockChain) error {
 		if err != nil {
 			return err
 		}
-		dc := trie.NewDirectCache(tr, db, state.DirectCachePrefix, blockNum, blockHash, bc, false)
+		dc := trie.NewDirectCache(tr, db, nil, state.DirectCachePrefix, blockNum, blockHash, bc, false)
 		go func() {
 			for core.GetBlockNumber(db, core.GetHeadBlockHash(db)) < blockNum+8 {
 				time.Sleep(10 * time.Second)

--- a/eth/db_upgrade.go
+++ b/eth/db_upgrade.go
@@ -26,11 +26,13 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core"
+	"github.com/ethereum/go-ethereum/core/state"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/ethdb"
 	"github.com/ethereum/go-ethereum/logger"
 	"github.com/ethereum/go-ethereum/logger/glog"
 	"github.com/ethereum/go-ethereum/rlp"
+	"github.com/ethereum/go-ethereum/trie"
 )
 
 var useSequentialKeys = []byte("dbUpgrade_20160530sequentialKeys")
@@ -352,5 +354,38 @@ func addMipmapBloomBins(db ethdb.Database) (err error) {
 		core.WriteMipmapBloom(db, i, core.GetBlockReceipts(db, hash, i))
 	}
 	glog.V(logger.Info).Infoln("upgrade completed in", time.Since(tstart))
+	return nil
+}
+
+func populateDirectCache(db ethdb.Database, bc *core.BlockChain) error {
+	blockHash, status := trie.GetMigrationState(state.DirectCachePrefix, db)
+	if status == trie.NotStarted {
+		blockHash = core.GetHeadBlockHash(db)
+		status = trie.Running
+		trie.SetMigrationState(state.DirectCachePrefix, blockHash, status, db)
+	}
+	blockNum := core.GetBlockNumber(db, blockHash)
+
+	if status == trie.Running {
+		tr, err := trie.New(core.GetBlock(db, blockHash, blockNum).Root(), db, 0)
+		if err != nil {
+			return err
+		}
+		dc := trie.NewDirectCache(tr, db, state.DirectCachePrefix, blockNum, blockHash, bc, false)
+		go func() {
+			for core.GetBlockNumber(db, core.GetHeadBlockHash(db)) < blockNum+8 {
+				time.Sleep(10 * time.Second)
+			}
+			glog.Infof("Beginning direct cache upgrade at block %v", blockNum)
+
+			start := time.Now()
+			if err := dc.Populate(); err != nil {
+				glog.Errorf("Direct cache upgrade failed: %v", err)
+			} else {
+				glog.Infof("Direct cache upgrade finished in %v", time.Since(start))
+			}
+			trie.SetMigrationState(state.DirectCachePrefix, blockHash, trie.Complete, db)
+		}()
+	}
 	return nil
 }

--- a/eth/downloader/downloader_test.go
+++ b/eth/downloader/downloader_test.go
@@ -294,7 +294,7 @@ func (dl *downloadTester) headFastBlock() *types.Block {
 func (dl *downloadTester) commitHeadBlock(hash common.Hash) error {
 	// For now only check that the state trie is correct
 	if block := dl.getBlock(hash); block != nil {
-		_, err := trie.NewSecure(block.Root(), dl.stateDb, 0)
+		_, err := trie.New(block.Root(), dl.stateDb, 0)
 		return err
 	}
 	return fmt.Errorf("non existent block: %x", hash[:4])

--- a/eth/downloader/queue.go
+++ b/eth/downloader/queue.go
@@ -399,7 +399,7 @@ func (q *queue) Schedule(headers []*types.Header, from uint64) []*types.Header {
 			}
 
 			q.stateSchedLock.Lock()
-			q.stateScheduler = state.NewStateSync(header.Root, q.stateDatabase)
+			q.stateScheduler = state.NewStateSync(header.Number.Uint64(), header.Hash(), header.Root, q.stateDatabase)
 			q.stateSchedLock.Unlock()
 		}
 		inserts = append(inserts, header)
@@ -1152,6 +1152,6 @@ func (q *queue) Prepare(offset uint64, mode SyncMode, pivot uint64, head *types.
 
 	// If long running fast sync, also start up a head stateretrieval immediately
 	if mode == FastSync && pivot > 0 {
-		q.stateScheduler = state.NewStateSync(head.Root, q.stateDatabase)
+		q.stateScheduler = state.NewStateSync(head.Number.Uint64(), head.Hash(), head.Root, q.stateDatabase)
 	}
 }

--- a/les/handler.go
+++ b/les/handler.go
@@ -637,7 +637,7 @@ func (pm *ProtocolManager) handleMsg(p *peer) error {
 		for _, req := range req.Reqs {
 			// Retrieve the requested state entry, stopping if enough was found
 			if header := core.GetHeader(pm.chainDb, req.BHash, core.GetBlockNumber(pm.chainDb, req.BHash)); header != nil {
-				if trie, _ := trie.New(header.Root, pm.chainDb); trie != nil {
+				if trie, _ := trie.New(header.Root, pm.chainDb, 0); trie != nil {
 					sdata := trie.Get(req.AccKey)
 					var acc state.Account
 					if err := rlp.DecodeBytes(sdata, &acc); err == nil {
@@ -764,13 +764,13 @@ func (pm *ProtocolManager) handleMsg(p *peer) error {
 			}
 			// Retrieve the requested state entry, stopping if enough was found
 			if header := core.GetHeader(pm.chainDb, req.BHash, core.GetBlockNumber(pm.chainDb, req.BHash)); header != nil {
-				if tr, _ := trie.New(header.Root, pm.chainDb); tr != nil {
+				if tr, _ := trie.New(header.Root, pm.chainDb, 0); tr != nil {
 					if len(req.AccKey) > 0 {
 						sdata := tr.Get(req.AccKey)
 						tr = nil
 						var acc state.Account
 						if err := rlp.DecodeBytes(sdata, &acc); err == nil {
-							tr, _ = trie.New(acc.Root, pm.chainDb)
+							tr, _ = trie.New(acc.Root, pm.chainDb, 0)
 						}
 					}
 					if tr != nil {
@@ -832,7 +832,7 @@ func (pm *ProtocolManager) handleMsg(p *peer) error {
 
 			if header := pm.blockchain.GetHeaderByNumber(req.BlockNum); header != nil {
 				if root := getChtRoot(pm.chainDb, req.ChtNum); root != (common.Hash{}) {
-					if tr, _ := trie.New(root, pm.chainDb); tr != nil {
+					if tr, _ := trie.New(root, pm.chainDb, 0); tr != nil {
 						var encNumber [8]byte
 						binary.BigEndian.PutUint64(encNumber[:], req.BlockNum)
 						proof := tr.Prove(encNumber[:])

--- a/les/handler_test.go
+++ b/les/handler_test.go
@@ -316,7 +316,7 @@ func testGetProofs(t *testing.T, protocol int) {
 	for i := uint64(0); i <= bc.CurrentBlock().NumberU64(); i++ {
 		header := bc.GetHeaderByNumber(i)
 		root := header.Root
-		trie, _ := trie.New(root, db)
+		trie, _ := trie.New(root, db, 0)
 
 		for _, acc := range accounts {
 			req := ProofReq{

--- a/les/server.go
+++ b/les/server.go
@@ -362,13 +362,13 @@ func makeCht(db ethdb.Database) bool {
 	var t *trie.Trie
 	if lastChtNum > 0 {
 		var err error
-		t, err = trie.New(getChtRoot(db, lastChtNum), db)
+		t, err = trie.New(getChtRoot(db, lastChtNum), db, 0)
 		if err != nil {
 			lastChtNum = 0
 		}
 	}
 	if lastChtNum == 0 {
-		t, _ = trie.New(common.Hash{}, db)
+		t, _ = trie.New(common.Hash{}, db, 0)
 	}
 
 	for num := lastChtNum * light.ChtFrequency; num < (lastChtNum+1)*light.ChtFrequency; num++ {

--- a/light/odr_test.go
+++ b/light/odr_test.go
@@ -73,7 +73,7 @@ func (odr *testOdr) Retrieve(ctx context.Context, req OdrRequest) error {
 	case *ReceiptsRequest:
 		req.Receipts = core.GetBlockReceipts(odr.sdb, req.Hash, core.GetBlockNumber(odr.sdb, req.Hash))
 	case *TrieRequest:
-		t, _ := trie.New(req.Id.Root, odr.sdb)
+		t, _ := trie.New(req.Id.Root, odr.sdb, 0)
 		req.Proof = t.Prove(req.Key)
 	case *CodeRequest:
 		req.Data, _ = odr.sdb.Get(req.Hash[:])

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -617,7 +617,7 @@ func (env *Work) commitTransactions(mux *event.TypeMux, txs *types.TransactionsB
 			continue
 		}
 		// Start executing the transaction
-		env.state.StartRecord(tx.Hash(), common.Hash{}, env.tcount)
+		env.state.SetTxContext(common.Hash{}, env.header.Number.Uint64(), tx.Hash(), env.tcount, bc)
 
 		err, logs := env.commitTransaction(tx, bc, gp)
 		switch {

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -617,7 +617,7 @@ func (env *Work) commitTransactions(mux *event.TypeMux, txs *types.TransactionsB
 			continue
 		}
 		// Start executing the transaction
-		env.state.SetTxContext(common.Hash{}, env.header.Number.Uint64(), tx.Hash(), env.tcount, bc)
+		env.state.SetTxContext(tx.Hash(), env.tcount)
 
 		err, logs := env.commitTransaction(tx, bc, gp)
 		switch {

--- a/trie/directcache.go
+++ b/trie/directcache.go
@@ -1,0 +1,180 @@
+// Copyright 2016 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+package trie
+
+import (
+	"time"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/logger"
+	"github.com/ethereum/go-ethereum/logger/glog"
+	"github.com/ethereum/go-ethereum/metrics"
+	"github.com/ethereum/go-ethereum/rlp"
+)
+
+var directCacheWrites = metrics.NewCounter("directcache/writes")
+var directCacheHitTimer = metrics.NewTimer("directcache/timer/hits")
+var directCacheMissTimer = metrics.NewTimer("directcache/timer/misses")
+
+type cachedValue struct {
+	Value     []byte
+	BlockNum  uint64
+	BlockHash common.Hash
+}
+
+// CacheValidator can check whether a certain block is in the current canonical chain.
+type CacheValidator interface {
+	IsCanonChainBlock(uint64, common.Hash) bool
+}
+
+type DirectCache struct {
+	data      PersistentMap
+	db        Database
+	keyPrefix []byte
+	blockNum  uint64
+	blockHash common.Hash
+	validator CacheValidator
+	complete  bool
+	dirty     map[string]bool
+}
+
+type NullCacheValidator struct {}
+
+func (cv *NullCacheValidator) IsCanonChainBlock(num uint64, hash common.Hash) bool {
+	return false
+}
+
+func NewDirectCache(pm PersistentMap, db Database, keyPrefix []byte, validator CacheValidator, complete bool) *DirectCache {
+	return &DirectCache{
+		data: pm,
+		db: db,
+		keyPrefix: keyPrefix,
+		validator: validator,
+		complete: complete,
+		dirty: make(map[string]bool),
+	}
+}
+
+func (dc *DirectCache) Iterator() *Iterator {
+	// Todo: If complete is true, implement an iterator over the DB instead.
+	return dc.data.Iterator()
+}
+
+func (dc *DirectCache) makeKey(key []byte) []byte {
+	return append(dc.keyPrefix, key...)
+}
+
+func (dc *DirectCache) Get(key []byte) []byte {
+	res, err := dc.TryGet(key)
+	if err != nil && glog.V(logger.Error) {
+		glog.Errorf("Unhandled error: %v", err)
+	}
+	return res
+}
+
+func (dc *DirectCache) TryGet(key []byte) ([]byte, error) {
+	start := time.Now()
+
+	dirty := dc.dirty[string(key)]
+
+	// Use the underlying object for dirty keys
+	if !dirty {
+		cacheKey := dc.makeKey(key)
+		if cached, ok := dc.getCached(cacheKey); ok {
+			directCacheHitTimer.UpdateSince(start)
+			return cached, nil
+		}
+	}
+
+	value, err := dc.data.TryGet(key)
+	if err != nil {
+		return value, err
+	}
+
+	if !dc.dirty[string(key)] {
+		// Flag the key as dirty so it gets written at commit time
+		dc.dirty[string(key)] = true
+	}
+
+	// Don't count fetches of dirty data as cache misses
+	if !dirty {
+		directCacheMissTimer.UpdateSince(start)
+	}
+
+	return value, nil
+}
+
+func (dc *DirectCache) getCached(key []byte) ([]byte, bool) {
+	enc, _ := dc.db.Get(key)
+	if len(enc) == 0 {
+		return nil, dc.complete
+	}
+
+	var data cachedValue
+	if err := rlp.DecodeBytes(enc, &data); err != nil && glog.V(logger.Error) {
+		glog.Errorf("Can't decode cached object at %x: %v", key, err)
+		return nil, false
+	}
+
+	canonical := dc.validator.IsCanonChainBlock(data.BlockNum, data.BlockHash)
+	return data.Value, canonical
+}
+
+func (dc *DirectCache) Update(key, value []byte) {
+	if err := dc.TryUpdate(key, value); err != nil && glog.V(logger.Error) {
+		glog.Errorf("Unhandled error: %v", err)
+	}
+}
+
+func (dc *DirectCache) TryUpdate(key, value []byte) error {
+	dc.dirty[string(key)] = true
+	return dc.data.TryUpdate(key, value)
+}
+
+func (dc *DirectCache) Delete(key []byte) {
+	if err := dc.TryDelete(key); err != nil && glog.V(logger.Error) {
+		glog.Errorf("Unhandled error: %v", err)
+	}
+}
+
+func (dc *DirectCache) TryDelete(key []byte) error {
+	dc.dirty[string(key)] = true
+	return dc.data.TryDelete(key)
+}
+
+func (dc *DirectCache) CommitTo(dbw DatabaseWriter) (root common.Hash, err error) {
+	directCacheWrites.Inc(int64(len(dc.dirty)))
+	for k, _ := range dc.dirty {
+		v, err := dc.data.TryGet([]byte(k))
+		if err, ok := err.(*MissingNodeError); err != nil && !ok {
+			return common.Hash{}, err
+		}
+		if err := dc.putCache(dbw, []byte(k), v); err != nil {
+			return common.Hash{}, err
+		}
+	}
+	dc.dirty = make(map[string]bool)
+	return dc.data.CommitTo(dbw)
+}
+
+func (dc *DirectCache) putCache(dbw DatabaseWriter, key, value []byte) error {
+	enc, _ := rlp.EncodeToBytes(cachedValue{value, dc.blockNum, dc.blockHash})
+	if err := dbw.Put(append(dc.keyPrefix, key...), enc); err != nil {
+		return err
+	}
+	return nil
+}

--- a/trie/directcache.go
+++ b/trie/directcache.go
@@ -30,6 +30,27 @@ var directCacheWrites = metrics.NewCounter("directcache/writes")
 var directCacheHitTimer = metrics.NewTimer("directcache/timer/hits")
 var directCacheMissTimer = metrics.NewTimer("directcache/timer/misses")
 
+// DirectCacheReads retrieves a global counter measuring the number of direct
+// cache reads from the disk since process startup. This isn't useful for anything
+// apart from trie debugging purposes.
+func DirectCacheReads() int64 {
+	return directCacheHitTimer.Count() + directCacheMissTimer.Count()
+}
+
+// DirectCacheWrites retrieves a global counter measuring the number of direct
+// cache writes from the disk since process startup. This isn't useful for anything
+// apart from trie debugging purposes.
+func DirectCacheWrites() int64 {
+	return directCacheWrites.Count()
+}
+
+// DirectCacheMisses retrieves a global counter measuring the number of direct
+// cache writes from the disk since process startup. This isn't useful for anything
+// apart from trie debugging purposes.
+func DirectCacheMisses() int64 {
+	return directCacheMissTimer.Count()
+}
+
 type cachedValue struct {
 	Value     []byte
 	BlockNum  uint64
@@ -52,7 +73,7 @@ type DirectCache struct {
 	dirty     map[string]bool
 }
 
-type NullCacheValidator struct {}
+type NullCacheValidator struct{}
 
 func (cv *NullCacheValidator) IsCanonChainBlock(num uint64, hash common.Hash) bool {
 	return false
@@ -60,12 +81,12 @@ func (cv *NullCacheValidator) IsCanonChainBlock(num uint64, hash common.Hash) bo
 
 func NewDirectCache(pm PersistentMap, db Database, keyPrefix []byte, validator CacheValidator, complete bool) *DirectCache {
 	return &DirectCache{
-		data: pm,
-		db: db,
+		data:      pm,
+		db:        db,
 		keyPrefix: keyPrefix,
 		validator: validator,
-		complete: complete,
-		dirty: make(map[string]bool),
+		complete:  complete,
+		dirty:     make(map[string]bool),
 	}
 }
 
@@ -157,7 +178,6 @@ func (dc *DirectCache) TryDelete(key []byte) error {
 }
 
 func (dc *DirectCache) CommitTo(dbw DatabaseWriter) (root common.Hash, err error) {
-	directCacheWrites.Inc(int64(len(dc.dirty)))
 	for k, _ := range dc.dirty {
 		v, err := dc.data.TryGet([]byte(k))
 		if err, ok := err.(*MissingNodeError); err != nil && !ok {
@@ -172,9 +192,26 @@ func (dc *DirectCache) CommitTo(dbw DatabaseWriter) (root common.Hash, err error
 }
 
 func (dc *DirectCache) putCache(dbw DatabaseWriter, key, value []byte) error {
-	enc, _ := rlp.EncodeToBytes(cachedValue{value, dc.blockNum, dc.blockHash})
-	if err := dbw.Put(append(dc.keyPrefix, key...), enc); err != nil {
-		return err
-	}
-	return nil
+	return WriteDirectCache(dc.keyPrefix, key, value, dc.blockNum, dc.blockHash, dbw)
+}
+
+// WriteDirectCache places a value node directly into the database along with
+// block metadata to validate its relevancy.
+//
+// The method is meant to be used by code that circumvents the state database
+// and its integrated cache, namely during fast sync and database upgrades.
+func WriteDirectCache(prefix, key, value []byte, number uint64, hash common.Hash, dbw DatabaseWriter) error {
+	directCacheWrites.Inc(1)
+	enc, _ := rlp.EncodeToBytes(cachedValue{value, number, hash})
+	return dbw.Put(append(prefix, key...), enc)
+}
+
+// GetDirectCache retrieves a value node directly from the database along with
+// block metadata to validate its relevancy.
+//
+// The method is meant to be used by code that circumvents the state database
+// and its integrated cache, namely during fast sync and database upgrades.
+func GetDirectCache(prefix, key []byte, db Database) ([]byte, error) {
+	defer func(start time.Time) { directCacheHitTimer.UpdateSince(start) }(time.Now())
+	return db.Get(append(prefix, key...))
 }

--- a/trie/iterator.go
+++ b/trie/iterator.go
@@ -82,7 +82,7 @@ type nodeIteratorState struct {
 
 // NodeIterator is an iterator to traverse the trie post-order.
 type NodeIterator struct {
-	trie  *Trie                // Trie being iterated
+	trie  *Trie          // Trie being iterated
 	stack []*nodeIteratorState // Hierarchy of trie nodes persisting the iteration state
 
 	Hash     common.Hash // Hash of the current node being iterated (nil if not standalone)

--- a/trie/iterator.go
+++ b/trie/iterator.go
@@ -74,20 +74,22 @@ func (it *Iterator) makeKey() []byte {
 // nodeIteratorState represents the iteration state at one particular node of the
 // trie, which can be resumed at a later invocation.
 type nodeIteratorState struct {
-	hash   common.Hash // Hash of the node being iterated (nil if not standalone)
-	node   node        // Trie node being iterated
-	parent common.Hash // Hash of the first full ancestor node (nil if current is the root)
-	child  int         // Child to be processed next
+	hash    common.Hash // Hash of the node being iterated (nil if not standalone)
+	node    node        // Trie node being iterated
+	parent  common.Hash // Hash of the first full ancestor node (nil if current is the root)
+	nibbles []byte      // Key nibbles leading up to this node for key reconstruction
+	child   int         // Child to be processed next
 }
 
 // NodeIterator is an iterator to traverse the trie post-order.
 type NodeIterator struct {
-	trie  *Trie          // Trie being iterated
+	trie  *Trie                // Trie being iterated
 	stack []*nodeIteratorState // Hierarchy of trie nodes persisting the iteration state
 
 	Hash     common.Hash // Hash of the current node being iterated (nil if not standalone)
 	Node     node        // Current node being iterated (internal representation)
 	Parent   common.Hash // Hash of the first full ancestor node (nil if current is the root)
+	Nibbles  []byte      // Key nibbles leading up to this node for key reconstruction
 	Leaf     bool        // Flag whether the current node is a value (data) node
 	LeafBlob []byte      // Data blob contained within a leaf (otherwise nil)
 
@@ -155,11 +157,16 @@ func (it *NodeIterator) step() error {
 			}
 			for parent.child++; parent.child < len(node.Children); parent.child++ {
 				if current := node.Children[parent.child]; current != nil {
+					nibbles := parent.nibbles
+					if parent.child < 16 {
+						nibbles = append(nibbles, byte(parent.child))
+					}
 					it.stack = append(it.stack, &nodeIteratorState{
-						hash:   common.BytesToHash(node.flags.hash),
-						node:   current,
-						parent: ancestor,
-						child:  -1,
+						hash:    common.BytesToHash(node.flags.hash),
+						node:    current,
+						parent:  ancestor,
+						nibbles: nibbles,
+						child:   -1,
 					})
 					break
 				}
@@ -171,10 +178,11 @@ func (it *NodeIterator) step() error {
 			}
 			parent.child++
 			it.stack = append(it.stack, &nodeIteratorState{
-				hash:   common.BytesToHash(node.flags.hash),
-				node:   node.Val,
-				parent: ancestor,
-				child:  -1,
+				hash:    common.BytesToHash(node.flags.hash),
+				node:    node.Val,
+				parent:  ancestor,
+				nibbles: append(parent.nibbles, node.Key...),
+				child:   -1,
 			})
 		} else if hash, ok := parent.node.(hashNode); ok {
 			// Hash node, resolve the hash child from the database, then the node itself
@@ -188,10 +196,11 @@ func (it *NodeIterator) step() error {
 				return err
 			}
 			it.stack = append(it.stack, &nodeIteratorState{
-				hash:   common.BytesToHash(hash),
-				node:   node,
-				parent: ancestor,
-				child:  -1,
+				hash:    common.BytesToHash(hash),
+				node:    node,
+				parent:  ancestor,
+				nibbles: parent.nibbles,
+				child:   -1,
 			})
 		} else {
 			break
@@ -207,7 +216,7 @@ func (it *NodeIterator) step() error {
 // The method returns whether there are any more data left for inspection.
 func (it *NodeIterator) retrieve() bool {
 	// Clear out any previously set values
-	it.Hash, it.Node, it.Parent, it.Leaf, it.LeafBlob = common.Hash{}, nil, common.Hash{}, false, nil
+	it.Hash, it.Node, it.Parent, it.Nibbles, it.Leaf, it.LeafBlob = common.Hash{}, nil, common.Hash{}, nil, false, nil
 
 	// If the iteration's done, return no available data
 	if it.trie == nil {
@@ -216,7 +225,7 @@ func (it *NodeIterator) retrieve() bool {
 	// Otherwise retrieve the current node and resolve leaf accessors
 	state := it.stack[len(it.stack)-1]
 
-	it.Hash, it.Node, it.Parent = state.hash, state.node, state.parent
+	it.Hash, it.Node, it.Parent, it.Nibbles = state.hash, state.node, state.parent, state.nibbles
 	if value, ok := it.Node.(valueNode); ok {
 		it.Leaf, it.LeafBlob = true, []byte(value)
 	}

--- a/trie/proof_test.go
+++ b/trie/proof_test.go
@@ -50,7 +50,7 @@ func TestProof(t *testing.T) {
 }
 
 func TestOneElementProof(t *testing.T) {
-	trie := new(Trie)
+	trie, _ := New(common.Hash{}, nil, 0)
 	updateString(trie, "k", "v")
 	proof := trie.Prove([]byte("k"))
 	if proof == nil {
@@ -130,7 +130,7 @@ func BenchmarkVerifyProof(b *testing.B) {
 }
 
 func randomTrie(n int) (*Trie, map[string]*kv) {
-	trie := new(Trie)
+	trie, _ := New(common.Hash{}, nil, 0)
 	vals := make(map[string]*kv)
 	for i := byte(0); i < 100; i++ {
 		value := &kv{common.LeftPadBytes([]byte{i}, 32), []byte{i}, false}

--- a/trie/secure_trie.go
+++ b/trie/secure_trie.go
@@ -26,6 +26,17 @@ var secureKeyPrefix = []byte("secure-key-")
 
 const secureKeyLength = 11 + 32 // Length of the above prefix + 32byte hash
 
+type PersistentMap interface {
+	Iterator() *Iterator
+	Get(key []byte) []byte
+	TryGet(key []byte) ([]byte, error)
+	Update(key, value []byte)
+	TryUpdate(key, value []byte) error
+	Delete(key []byte)
+	TryDelete(key []byte) error
+	CommitTo(db DatabaseWriter) (root common.Hash, err error)
+}
+
 // SecureTrie wraps a trie with key hashing. In a secure trie, all
 // access operations hash the key using keccak256. This prevents
 // calling code from creating long chains of nodes that
@@ -37,75 +48,65 @@ const secureKeyLength = 11 + 32 // Length of the above prefix + 32byte hash
 //
 // SecureTrie is not safe for concurrent use.
 type SecureTrie struct {
-	trie             Trie
+	data             PersistentMap
+	db               Database
 	hashKeyBuf       [secureKeyLength]byte
 	secKeyBuf        [200]byte
 	secKeyCache      map[string][]byte
 	secKeyCacheOwner *SecureTrie // Pointer to self, replace the key cache on mismatch
 }
 
-// NewSecure creates a trie with an existing root node from db.
-//
-// If root is the zero hash or the sha3 hash of an empty string, the
-// trie is initially empty. Otherwise, New will panic if db is nil
-// and returns MissingNodeError if the root node cannot be found.
-//
-// Accessing the trie loads nodes from db on demand.
-// Loaded nodes are kept around until their 'cache generation' expires.
-// A new cache generation is created by each call to Commit.
-// cachelimit sets the number of past cache generations to keep.
-func NewSecure(root common.Hash, db Database, cachelimit uint16) (*SecureTrie, error) {
+// NewSecure creates a secure persistent map from an existing map.
+func NewSecure(pm PersistentMap, db Database) *SecureTrie {
+	if pm == nil {
+		panic("NewSecure called with nil persistent map")
+	}
 	if db == nil {
 		panic("NewSecure called with nil database")
 	}
-	trie, err := New(root, db)
-	if err != nil {
-		return nil, err
-	}
-	trie.SetCacheLimit(cachelimit)
-	return &SecureTrie{trie: *trie}, nil
+	return &SecureTrie{data: pm, db: db}
 }
 
-// Get returns the value for key stored in the trie.
+// Get returns the value for key stored in the map.
 // The value bytes must not be modified by the caller.
 func (t *SecureTrie) Get(key []byte) []byte {
 	res, err := t.TryGet(key)
 	if err != nil && glog.V(logger.Error) {
-		glog.Errorf("Unhandled trie error: %v", err)
+		glog.Errorf("Unhandled persistent map error: %v", err)
 	}
 	return res
 }
 
-// TryGet returns the value for key stored in the trie.
+// TryGet returns the value for key stored in the map.
 // The value bytes must not be modified by the caller.
 // If a node was not found in the database, a MissingNodeError is returned.
 func (t *SecureTrie) TryGet(key []byte) ([]byte, error) {
-	return t.trie.TryGet(t.hashKey(key))
+	return t.data.TryGet(t.hashKey(key))
 }
 
-// Update associates key with value in the trie. Subsequent calls to
+// Update associates key with value in the map. Subsequent calls to
 // Get will return value. If value has length zero, any existing value
-// is deleted from the trie and calls to Get will return nil.
+// is deleted from the map and calls to Get will return nil.
 //
 // The value bytes must not be modified by the caller while they are
-// stored in the trie.
+// stored in the map.
 func (t *SecureTrie) Update(key, value []byte) {
 	if err := t.TryUpdate(key, value); err != nil && glog.V(logger.Error) {
-		glog.Errorf("Unhandled trie error: %v", err)
+		glog.Errorf("Unhandled persistent map error: %v", err)
 	}
 }
 
-// TryUpdate associates key with value in the trie. Subsequent calls to
+// TryUpdate associates key with value in the map. Subsequent calls to
 // Get will return value. If value has length zero, any existing value
-// is deleted from the trie and calls to Get will return nil.
+// is deleted from the map and calls to Get will return nil.
 //
 // The value bytes must not be modified by the caller while they are
-// stored in the trie.
+// stored in the map.
 //
 // If a node was not found in the database, a MissingNodeError is returned.
 func (t *SecureTrie) TryUpdate(key, value []byte) error {
 	hk := t.hashKey(key)
-	err := t.trie.TryUpdate(hk, value)
+	err := t.data.TryUpdate(hk, value)
 	if err != nil {
 		return err
 	}
@@ -113,19 +114,19 @@ func (t *SecureTrie) TryUpdate(key, value []byte) error {
 	return nil
 }
 
-// Delete removes any existing value for key from the trie.
+// Delete removes any existing value for key from the map.
 func (t *SecureTrie) Delete(key []byte) {
 	if err := t.TryDelete(key); err != nil && glog.V(logger.Error) {
-		glog.Errorf("Unhandled trie error: %v", err)
+		glog.Errorf("Unhandled persistent map error: %v", err)
 	}
 }
 
-// TryDelete removes any existing value for key from the trie.
+// TryDelete removes any existing value for key from the map.
 // If a node was not found in the database, a MissingNodeError is returned.
 func (t *SecureTrie) TryDelete(key []byte) error {
 	hk := t.hashKey(key)
 	delete(t.getSecKeyCache(), string(hk))
-	return t.trie.TryDelete(hk)
+	return t.data.TryDelete(hk)
 }
 
 // GetKey returns the sha3 preimage of a hashed key that was
@@ -134,51 +135,37 @@ func (t *SecureTrie) GetKey(shaKey []byte) []byte {
 	if key, ok := t.getSecKeyCache()[string(shaKey)]; ok {
 		return key
 	}
-	key, _ := t.trie.db.Get(t.secKey(shaKey))
+	key, _ := t.db.Get(t.secKey(shaKey))
 	return key
 }
 
-// Commit writes all nodes and the secure hash pre-images to the trie's database.
-// Nodes are stored with their sha3 hash as the key.
-//
-// Committing flushes nodes from memory. Subsequent Get calls will load nodes
-// from the database.
-func (t *SecureTrie) Commit() (root common.Hash, err error) {
-	return t.CommitTo(t.trie.db)
-}
-
-func (t *SecureTrie) Hash() common.Hash {
-	return t.trie.Hash()
-}
-
-func (t *SecureTrie) Root() []byte {
-	return t.trie.Root()
-}
-
 func (t *SecureTrie) Iterator() *Iterator {
-	return t.trie.Iterator()
-}
-
-func (t *SecureTrie) NodeIterator() *NodeIterator {
-	return NewNodeIterator(&t.trie)
+	return t.data.Iterator()
 }
 
 // CommitTo writes all nodes and the secure hash pre-images to the given database.
 // Nodes are stored with their sha3 hash as the key.
 //
 // Committing flushes nodes from memory. Subsequent Get calls will load nodes from
-// the trie's database. Calling code must ensure that the changes made to db are
-// written back to the trie's attached database before using the trie.
+// the database. Calling code must ensure that the changes made to db are
+// written back to the attached database before using the map.
 func (t *SecureTrie) CommitTo(db DatabaseWriter) (root common.Hash, err error) {
+	if err := t.CommitPreimages(); err != nil {
+		return common.Hash{}, err
+	}
+	return t.data.CommitTo(db)
+}
+
+func (t *SecureTrie) CommitPreimages() error {
 	if len(t.getSecKeyCache()) > 0 {
 		for hk, key := range t.secKeyCache {
-			if err := db.Put(t.secKey([]byte(hk)), key); err != nil {
-				return common.Hash{}, err
+			if err := t.db.Put(t.secKey([]byte(hk)), key); err != nil {
+				return err
 			}
 		}
 		t.secKeyCache = make(map[string][]byte)
 	}
-	return t.trie.CommitTo(db)
+	return nil
 }
 
 // secKey returns the database key for the preimage of key, as an ephemeral buffer.
@@ -203,7 +190,7 @@ func (t *SecureTrie) hashKey(key []byte) []byte {
 }
 
 // getSecKeyCache returns the current secure key cache, creating a new one if
-// ownership changed (i.e. the current secure trie is a copy of another owning
+// ownership changed (i.e. the current secure map is a copy of another owning
 // the actual cache).
 func (t *SecureTrie) getSecKeyCache() map[string][]byte {
 	if t != t.secKeyCacheOwner {

--- a/trie/sync.go
+++ b/trie/sync.go
@@ -36,10 +36,39 @@ type request struct {
 	raw  bool        // Whether this is a raw entry (code) or a trie node
 
 	parents []*request // Parent state nodes referencing this entry (notify all upon completion)
+	nibbles [][]byte   // Trie path nibbles that accumulate up to the key at the leaf (paired with parents)
 	depth   int        // Depth level within the trie the node is located to prioritise DFS
 	deps    int        // Number of dependencies before allowed to commit this node
 
 	callback TrieSyncLeafCallback // Callback to invoke if a leaf node it reached on this branch
+	dcPrefix []byte               // Database prefix to use for leaf direct caching
+}
+
+// keys traverses the request ancestry tree, reconstructing the key paths leading
+// to the current request through the nibbles represented by each node.
+func (r *request) keys(suffix []byte) [][]byte {
+	keys := r.paths(suffix)
+	for i := 0; i < len(keys); i++ {
+		keys[i] = compactHexEncode(keys[i])
+	}
+	return keys
+}
+
+// paths traverses the request ancestry tree, reconstructing the key paths leading
+// to the current request through the nibbles represented by each node.
+func (r *request) paths(suffix []byte) [][]byte {
+	// A root level request just returns the trailing suffix
+	if len(r.parents) == 0 {
+		return [][]byte{suffix}
+	}
+	// Otherwise collect all the ancestor paths, and append the current one
+	var keys [][]byte
+	for i, parent := range r.parents {
+		for _, key := range parent.paths(r.nibbles[i]) {
+			keys = append(keys, append(key, suffix...))
+		}
+	}
+	return keys
 }
 
 // SyncResult is a simple list to return missing nodes along with their request
@@ -52,7 +81,7 @@ type SyncResult struct {
 // TrieSyncLeafCallback is a callback type invoked when a trie sync reaches a
 // leaf node. It's used by state syncing to check if the leaf node requires some
 // further data syncing.
-type TrieSyncLeafCallback func(leaf []byte, parent common.Hash) error
+type TrieSyncLeafCallback func(keys [][]byte, leaf []byte, parent common.Hash) error
 
 // TrieSync is the main state trie synchronisation scheduler, which provides yet
 // unknown trie hashes to retrieve, accepts node data associated with said hashes
@@ -64,18 +93,18 @@ type TrieSync struct {
 }
 
 // NewTrieSync creates a new trie data download scheduler.
-func NewTrieSync(root common.Hash, database ethdb.Database, callback TrieSyncLeafCallback) *TrieSync {
+func NewTrieSync(root common.Hash, database ethdb.Database, callback TrieSyncLeafCallback, dcPrefix []byte) *TrieSync {
 	ts := &TrieSync{
 		database: database,
 		requests: make(map[common.Hash]*request),
 		queue:    prque.New(),
 	}
-	ts.AddSubTrie(root, 0, common.Hash{}, callback)
+	ts.AddSubTrie(root, 0, common.Hash{}, callback, dcPrefix)
 	return ts
 }
 
 // AddSubTrie registers a new trie to the sync code, rooted at the designated parent.
-func (s *TrieSync) AddSubTrie(root common.Hash, depth int, parent common.Hash, callback TrieSyncLeafCallback) {
+func (s *TrieSync) AddSubTrie(root common.Hash, depth int, parent common.Hash, callback TrieSyncLeafCallback, dcPrefix []byte) {
 	// Short circuit if the trie is empty or already known
 	if root == emptyRoot {
 		return
@@ -90,6 +119,7 @@ func (s *TrieSync) AddSubTrie(root common.Hash, depth int, parent common.Hash, c
 		hash:     root,
 		depth:    depth,
 		callback: callback,
+		dcPrefix: dcPrefix,
 	}
 	// If this sub-trie has a designated parent, link them together
 	if parent != (common.Hash{}) {
@@ -198,6 +228,7 @@ func (s *TrieSync) schedule(req *request) {
 	// If we're already requesting this node, add a new reference and stop
 	if old, ok := s.requests[req.hash]; ok {
 		old.parents = append(old.parents, req.parents...)
+		old.nibbles = append(old.nibbles, req.nibbles...)
 		return
 	}
 	// Schedule the request for future retrieval
@@ -210,6 +241,7 @@ func (s *TrieSync) schedule(req *request) {
 func (s *TrieSync) children(req *request, object node) ([]*request, error) {
 	// Gather all the children of the node, irrelevant whether known or not
 	type child struct {
+		path  []byte
 		node  node
 		depth int
 	}
@@ -218,13 +250,19 @@ func (s *TrieSync) children(req *request, object node) ([]*request, error) {
 	switch node := (object).(type) {
 	case *shortNode:
 		children = []child{{
+			path:  node.Key,
 			node:  node.Val,
 			depth: req.depth + len(node.Key),
 		}}
 	case *fullNode:
 		for i := 0; i < 17; i++ {
 			if node.Children[i] != nil {
+				var path []byte
+				if i < 16 {
+					path = []byte{byte(i)}
+				}
 				children = append(children, child{
+					path:  path,
 					node:  node.Children[i],
 					depth: req.depth + 1,
 				})
@@ -239,7 +277,7 @@ func (s *TrieSync) children(req *request, object node) ([]*request, error) {
 		// Notify any external watcher of a new key/value node
 		if req.callback != nil {
 			if node, ok := (child.node).(valueNode); ok {
-				if err := req.callback(node, req.hash); err != nil {
+				if err := req.callback(req.keys(child.path), node, req.hash); err != nil {
 					return nil, err
 				}
 			}
@@ -249,14 +287,40 @@ func (s *TrieSync) children(req *request, object node) ([]*request, error) {
 			// Try to resolve the node from the local database
 			blob, _ := s.database.Get(node)
 			if local, err := decodeNode(node[:], blob, 0); local != nil && err == nil {
+				// Local node found, iterate and invoke the leaf callback for all subleaves
+				if req.callback != nil && req.dcPrefix != nil {
+					trie, _ := New(common.BytesToHash(node[:]), s.database, 0)
+					unknown := false
+
+					it := NewNodeIterator(trie)
+					for it.Next() {
+						if it.Leaf {
+							// If this branch was already visited, abort iteration
+							keys := req.keys(append(child.path, it.Nibbles...))
+							if !unknown {
+								if val, err := GetDirectCache(req.dcPrefix, keys[0], s.database); val != nil && err == nil {
+									break
+								}
+								// Branch is unknown, mark as so to avoid repeated db lookups
+								unknown = true
+							}
+							// Otherwise write out all accounts ending in this leaf
+							if err := req.callback(keys, nil, req.hash); err != nil {
+								return nil, err
+							}
+						}
+					}
+				}
 				continue
 			}
 			// Locally unknown node, schedule for retrieval
 			requests = append(requests, &request{
 				hash:     common.BytesToHash(node),
 				parents:  []*request{req},
+				nibbles:  [][]byte{child.path},
 				depth:    child.depth,
 				callback: req.callback,
+				dcPrefix: req.dcPrefix,
 			})
 		}
 	}

--- a/trie/sync.go
+++ b/trie/sync.go
@@ -298,7 +298,7 @@ func (s *TrieSync) children(req *request, object node) ([]*request, error) {
 							// If this branch was already visited, abort iteration
 							keys := req.keys(append(child.path, it.Nibbles...))
 							if !unknown {
-								if val, err := GetDirectCache(req.dcPrefix, keys[0], s.database); val != nil && err == nil {
+								if HasDirectCache(req.dcPrefix, keys[0], s.database) {
 									break
 								}
 								// Branch is unknown, mark as so to avoid repeated db lookups

--- a/trie/sync_test.go
+++ b/trie/sync_test.go
@@ -28,7 +28,7 @@ import (
 func makeTestTrie() (ethdb.Database, *Trie, map[string][]byte) {
 	// Create an empty trie
 	db, _ := ethdb.NewMemDatabase()
-	trie, _ := New(common.Hash{}, db)
+	trie, _ := New(common.Hash{}, db, 0)
 
 	// Fill it with some arbitrary data
 	content := make(map[string][]byte)
@@ -59,7 +59,7 @@ func makeTestTrie() (ethdb.Database, *Trie, map[string][]byte) {
 // content map.
 func checkTrieContents(t *testing.T, db Database, root []byte, content map[string][]byte) {
 	// Check root availability and trie contents
-	trie, err := New(common.BytesToHash(root), db)
+	trie, err := New(common.BytesToHash(root), db, 0)
 	if err != nil {
 		t.Fatalf("failed to create trie at %x: %v", root, err)
 	}
@@ -76,7 +76,7 @@ func checkTrieContents(t *testing.T, db Database, root []byte, content map[strin
 // checkTrieConsistency checks that all nodes in a trie are indeed present.
 func checkTrieConsistency(db Database, root common.Hash) error {
 	// Create and iterate a trie rooted in a subnode
-	trie, err := New(root, db)
+	trie, err := New(root, db, 0)
 	if err != nil {
 		return nil // // Consider a non existent state consistent
 	}
@@ -88,8 +88,8 @@ func checkTrieConsistency(db Database, root common.Hash) error {
 
 // Tests that an empty trie is not scheduled for syncing.
 func TestEmptyTrieSync(t *testing.T) {
-	emptyA, _ := New(common.Hash{}, nil)
-	emptyB, _ := New(emptyRoot, nil)
+	emptyA, _ := New(common.Hash{}, nil, 0)
+	emptyB, _ := New(emptyRoot, nil, 0)
 
 	for i, trie := range []*Trie{emptyA, emptyB} {
 		db, _ := ethdb.NewMemDatabase()

--- a/trie/sync_test.go
+++ b/trie/sync_test.go
@@ -55,6 +55,28 @@ func makeTestTrie() (ethdb.Database, *Trie, map[string][]byte) {
 	return db, trie, content
 }
 
+// makeRepetitiveTestTrie creates a test trie to test node-wise reconstruction,
+// where all values are the same, forcing large parts of the trie to share nodes.
+func makeRepetitiveTestTrie() (ethdb.Database, *Trie, map[string][]byte) {
+	// Create an empty trie
+	db, _ := ethdb.NewMemDatabase()
+	trie, _ := New(common.Hash{}, db, 0)
+
+	// Fill it with some arbitrary data
+	content := make(map[string][]byte)
+	for i := byte(0); i < 255; i++ {
+		for j := byte(0); j < 255; j++ {
+			key, val := common.LeftPadBytes([]byte{j, i}, 32), common.LeftPadBytes(nil, 32)
+			content[string(key)] = val
+			trie.Update(key, val)
+		}
+	}
+	trie.Commit()
+
+	// Return the generated trie
+	return db, trie, content
+}
+
 // checkTrieContents cross references a reconstructed trie with an expected data
 // content map.
 func checkTrieContents(t *testing.T, db Database, root []byte, content map[string][]byte) {
@@ -93,7 +115,7 @@ func TestEmptyTrieSync(t *testing.T) {
 
 	for i, trie := range []*Trie{emptyA, emptyB} {
 		db, _ := ethdb.NewMemDatabase()
-		if req := NewTrieSync(common.BytesToHash(trie.Root()), db, nil).Missing(1); len(req) != 0 {
+		if req := NewTrieSync(common.BytesToHash(trie.Root()), db, nil, nil).Missing(1); len(req) != 0 {
 			t.Errorf("test %d: content requested for empty trie: %v", i, req)
 		}
 	}
@@ -110,7 +132,7 @@ func testIterativeTrieSync(t *testing.T, batch int) {
 
 	// Create a destination trie and sync with the scheduler
 	dstDb, _ := ethdb.NewMemDatabase()
-	sched := NewTrieSync(common.BytesToHash(srcTrie.Root()), dstDb, nil)
+	sched := NewTrieSync(common.BytesToHash(srcTrie.Root()), dstDb, nil, nil)
 
 	queue := append([]common.Hash{}, sched.Missing(batch)...)
 	for len(queue) > 0 {
@@ -139,7 +161,7 @@ func TestIterativeDelayedTrieSync(t *testing.T) {
 
 	// Create a destination trie and sync with the scheduler
 	dstDb, _ := ethdb.NewMemDatabase()
-	sched := NewTrieSync(common.BytesToHash(srcTrie.Root()), dstDb, nil)
+	sched := NewTrieSync(common.BytesToHash(srcTrie.Root()), dstDb, nil, nil)
 
 	queue := append([]common.Hash{}, sched.Missing(10000)...)
 	for len(queue) > 0 {
@@ -173,7 +195,7 @@ func testIterativeRandomTrieSync(t *testing.T, batch int) {
 
 	// Create a destination trie and sync with the scheduler
 	dstDb, _ := ethdb.NewMemDatabase()
-	sched := NewTrieSync(common.BytesToHash(srcTrie.Root()), dstDb, nil)
+	sched := NewTrieSync(common.BytesToHash(srcTrie.Root()), dstDb, nil, nil)
 
 	queue := make(map[common.Hash]struct{})
 	for _, hash := range sched.Missing(batch) {
@@ -210,7 +232,7 @@ func TestIterativeRandomDelayedTrieSync(t *testing.T) {
 
 	// Create a destination trie and sync with the scheduler
 	dstDb, _ := ethdb.NewMemDatabase()
-	sched := NewTrieSync(common.BytesToHash(srcTrie.Root()), dstDb, nil)
+	sched := NewTrieSync(common.BytesToHash(srcTrie.Root()), dstDb, nil, nil)
 
 	queue := make(map[common.Hash]struct{})
 	for _, hash := range sched.Missing(10000) {
@@ -253,7 +275,7 @@ func TestDuplicateAvoidanceTrieSync(t *testing.T) {
 
 	// Create a destination trie and sync with the scheduler
 	dstDb, _ := ethdb.NewMemDatabase()
-	sched := NewTrieSync(common.BytesToHash(srcTrie.Root()), dstDb, nil)
+	sched := NewTrieSync(common.BytesToHash(srcTrie.Root()), dstDb, nil, nil)
 
 	queue := append([]common.Hash{}, sched.Missing(0)...)
 	requested := make(map[common.Hash]struct{})
@@ -289,7 +311,7 @@ func TestIncompleteTrieSync(t *testing.T) {
 
 	// Create a destination trie and sync with the scheduler
 	dstDb, _ := ethdb.NewMemDatabase()
-	sched := NewTrieSync(common.BytesToHash(srcTrie.Root()), dstDb, nil)
+	sched := NewTrieSync(common.BytesToHash(srcTrie.Root()), dstDb, nil, nil)
 
 	added := []common.Hash{}
 	queue := append([]common.Hash{}, sched.Missing(1)...)
@@ -329,5 +351,51 @@ func TestIncompleteTrieSync(t *testing.T) {
 			t.Fatalf("trie inconsistency not caught, missing: %x", key)
 		}
 		dstDb.Put(key, value)
+	}
+}
+
+// Tests that if a leaf callback is specified, all leaf nodes are invoked with
+// it, even if sync short circuits with existing local nodes.
+func TestAllLeafCallbackTrieSync(t *testing.T) {
+	// Create a random trie to copy
+	srcDb, srcTrie, srcData := makeRepetitiveTestTrie()
+
+	// Create a callback to accumulate all keys for later verification
+	leaves, count := make(map[string]struct{}), 0
+	callback := func(keys [][]byte, leaf []byte, parent common.Hash) error {
+		for _, key := range keys {
+			leaves[string(key)] = struct{}{}
+			count++
+		}
+		return nil
+	}
+	// Create a destination trie and sync with the scheduler
+	dstDb, _ := ethdb.NewMemDatabase()
+	sched := NewTrieSync(common.BytesToHash(srcTrie.Root()), dstDb, callback, []byte("leaf:"))
+
+	queue := append([]common.Hash{}, sched.Missing(1)...)
+	for len(queue) > 0 {
+		results := make([]SyncResult, len(queue))
+		for i, hash := range queue {
+			data, err := srcDb.Get(hash.Bytes())
+			if err != nil {
+				t.Fatalf("failed to retrieve node data for %x: %v", hash, err)
+			}
+			results[i] = SyncResult{hash, data}
+		}
+		if _, index, err := sched.Process(results); err != nil {
+			t.Fatalf("failed to process result #%d: %v", index, err)
+		}
+		queue = append(queue[:0], sched.Missing(1)...)
+	}
+	// Cross check that the two tries are in sync
+	checkTrieContents(t, dstDb, srcTrie.Root(), srcData)
+
+	// Ensure the leaf callback was invoked for all leaves, including cached ones
+	if len(leaves) != len(srcData) {
+		t.Errorf("Leaf callback count mismatch: have %v, want %v", len(leaves), len(srcData))
+	}
+	if len(leaves) != count {
+		t.Errorf("Duplicate leaf callbacks: have %v, want %v", count, len(leaves))
 	}
 }

--- a/trie/trie.go
+++ b/trie/trie.go
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
 
-// Package trie implements Merkle Patricia Tries.
+// Package trie implements Merkle Patricia tries.
 package trie
 
 import (
@@ -73,11 +73,11 @@ type DatabaseWriter interface {
 	Put(key, value []byte) error
 }
 
-// Trie is a Merkle Patricia Trie.
+// trie is a Merkle Patricia trie.
 // The zero value is an empty trie with no database.
 // Use New to create a trie that sits on top of a database.
 //
-// Trie is not safe for concurrent use.
+// trie is not safe for concurrent use.
 type Trie struct {
 	root         node
 	db           Database
@@ -88,12 +88,6 @@ type Trie struct {
 	// new nodes are tagged with the current generation and unloaded
 	// when their generation is older than than cachegen-cachelimit.
 	cachegen, cachelimit uint16
-}
-
-// SetCacheLimit sets the number of 'cache generations' to keep.
-// A cache generations is created by a call to Commit.
-func (t *Trie) SetCacheLimit(l uint16) {
-	t.cachelimit = l
 }
 
 // newFlag returns the cache flag value for a newly created node.
@@ -107,11 +101,14 @@ func (t *Trie) newFlag() nodeFlag {
 // trie is initially empty and does not require a database. Otherwise,
 // New will panic if db is nil and returns a MissingNodeError if root does
 // not exist in the database. Accessing the trie loads nodes from db on demand.
-func New(root common.Hash, db Database) (*Trie, error) {
-	trie := &Trie{db: db, originalRoot: root}
+//
+// cacheLimit is the number of 'cache generations' to keep.
+// A cache generations is created by a call to Commit.
+func New(root common.Hash, db Database, cacheLimit uint16) (*Trie, error) {
+	trie := &Trie{db: db, originalRoot: root, cachelimit: cacheLimit}
 	if (root != common.Hash{}) && root != emptyRoot {
 		if db == nil {
-			panic("trie.New: cannot use existing root without a database")
+			panic("Trie.New: cannot use existing root without a database")
 		}
 		rootnode, err := trie.resolveHash(root[:], nil, nil)
 		if err != nil {

--- a/trie/trie_test.go
+++ b/trie/trie_test.go
@@ -40,7 +40,7 @@ func init() {
 // Used for testing
 func newEmpty() *Trie {
 	db, _ := ethdb.NewMemDatabase()
-	trie, _ := New(common.Hash{}, db)
+	trie, _ := New(common.Hash{}, db, 0)
 	return trie
 }
 
@@ -63,7 +63,7 @@ func TestNull(t *testing.T) {
 
 func TestMissingRoot(t *testing.T) {
 	db, _ := ethdb.NewMemDatabase()
-	trie, err := New(common.HexToHash("0beec7b5ea3f0fdbc95d0dd47f3c5bc275da8a33"), db)
+	trie, err := New(common.HexToHash("0beec7b5ea3f0fdbc95d0dd47f3c5bc275da8a33"), db, 0)
 	if trie != nil {
 		t.Error("New returned non-nil trie for invalid root")
 	}
@@ -74,36 +74,36 @@ func TestMissingRoot(t *testing.T) {
 
 func TestMissingNode(t *testing.T) {
 	db, _ := ethdb.NewMemDatabase()
-	trie, _ := New(common.Hash{}, db)
+	trie, _ := New(common.Hash{}, db, 0)
 	updateString(trie, "120000", "qwerqwerqwerqwerqwerqwerqwerqwer")
 	updateString(trie, "123456", "asdfasdfasdfasdfasdfasdfasdfasdf")
 	root, _ := trie.Commit()
 
-	trie, _ = New(root, db)
+	trie, _ = New(root, db, 0)
 	_, err := trie.TryGet([]byte("120000"))
 	if err != nil {
 		t.Errorf("Unexpected error: %v", err)
 	}
 
-	trie, _ = New(root, db)
+	trie, _ = New(root, db, 0)
 	_, err = trie.TryGet([]byte("120099"))
 	if err != nil {
 		t.Errorf("Unexpected error: %v", err)
 	}
 
-	trie, _ = New(root, db)
+	trie, _ = New(root, db, 0)
 	_, err = trie.TryGet([]byte("123456"))
 	if err != nil {
 		t.Errorf("Unexpected error: %v", err)
 	}
 
-	trie, _ = New(root, db)
+	trie, _ = New(root, db, 0)
 	err = trie.TryUpdate([]byte("120099"), []byte("zxcvzxcvzxcvzxcvzxcvzxcvzxcvzxcv"))
 	if err != nil {
 		t.Errorf("Unexpected error: %v", err)
 	}
 
-	trie, _ = New(root, db)
+	trie, _ = New(root, db, 0)
 	err = trie.TryDelete([]byte("123456"))
 	if err != nil {
 		t.Errorf("Unexpected error: %v", err)
@@ -111,31 +111,31 @@ func TestMissingNode(t *testing.T) {
 
 	db.Delete(common.FromHex("e1d943cc8f061a0c0b98162830b970395ac9315654824bf21b73b891365262f9"))
 
-	trie, _ = New(root, db)
+	trie, _ = New(root, db, 0)
 	_, err = trie.TryGet([]byte("120000"))
 	if _, ok := err.(*MissingNodeError); !ok {
 		t.Errorf("Wrong error: %v", err)
 	}
 
-	trie, _ = New(root, db)
+	trie, _ = New(root, db, 0)
 	_, err = trie.TryGet([]byte("120099"))
 	if _, ok := err.(*MissingNodeError); !ok {
 		t.Errorf("Wrong error: %v", err)
 	}
 
-	trie, _ = New(root, db)
+	trie, _ = New(root, db, 0)
 	_, err = trie.TryGet([]byte("123456"))
 	if err != nil {
 		t.Errorf("Unexpected error: %v", err)
 	}
 
-	trie, _ = New(root, db)
+	trie, _ = New(root, db, 0)
 	err = trie.TryUpdate([]byte("120099"), []byte("zxcv"))
 	if _, ok := err.(*MissingNodeError); !ok {
 		t.Errorf("Wrong error: %v", err)
 	}
 
-	trie, _ = New(root, db)
+	trie, _ = New(root, db, 0)
 	err = trie.TryDelete([]byte("123456"))
 	if _, ok := err.(*MissingNodeError); !ok {
 		t.Errorf("Wrong error: %v", err)
@@ -263,7 +263,7 @@ func TestReplication(t *testing.T) {
 	}
 
 	// create a new trie on top of the database and check that lookups work.
-	trie2, err := New(exp, trie.db)
+	trie2, err := New(exp, trie.db, 0)
 	if err != nil {
 		t.Fatalf("can't recreate trie at %x: %v", exp, err)
 	}
@@ -332,8 +332,7 @@ func TestCacheUnload(t *testing.T) {
 	// The branch containing it is loaded from DB exactly two times:
 	// in the 0th and 6th iteration.
 	db := &countingDB{Database: trie.db, gets: make(map[string]int)}
-	trie, _ = New(root, db)
-	trie.SetCacheLimit(5)
+	trie, _ = New(root, db, 5)
 	for i := 0; i < 12; i++ {
 		getString(trie, key1)
 		trie.Commit()
@@ -417,7 +416,7 @@ func randRead(r *rand.Rand, b []byte) {
 
 func runRandTest(rt randTest) bool {
 	db, _ := ethdb.NewMemDatabase()
-	tr, _ := New(common.Hash{}, db)
+	tr, _ := New(common.Hash{}, db, 0)
 	values := make(map[string]string) // tracks content of the trie
 
 	for _, step := range rt {
@@ -446,13 +445,13 @@ func runRandTest(rt randTest) bool {
 			if err != nil {
 				panic(err)
 			}
-			newtr, err := New(hash, db)
+			newtr, err := New(hash, db, 0)
 			if err != nil {
 				panic(err)
 			}
 			tr = newtr
 		case opItercheckhash:
-			checktr, _ := New(common.Hash{}, nil)
+			checktr, _ := New(common.Hash{}, nil, 0)
 			it := tr.Iterator()
 			for it.Next() {
 				checktr.Update(it.Key, it.Value)
@@ -520,10 +519,10 @@ func BenchmarkHashLE(b *testing.B)   { benchHash(b, binary.LittleEndian) }
 const benchElemCount = 20000
 
 func benchGet(b *testing.B, commit bool) {
-	trie := new(Trie)
+	trie, _ := New(common.Hash{}, nil, 0)
 	if commit {
 		_, tmpdb := tempDB()
-		trie, _ = New(common.Hash{}, tmpdb)
+		trie, _ = New(common.Hash{}, tmpdb, 0)
 	}
 	k := make([]byte, 32)
 	for i := 0; i < benchElemCount; i++ {


### PR DESCRIPTION
**Supersedes https://github.com/ethereum/go-ethereum/pull/3188 with rebased and squashed commits.**

This PR implements a 'direct cache' in leveldb, which maps from account hash to (account, block number, block hash). This disk cache is on the order of 5-10x quicker to look up than the trie, and permits quick efficient lookups of values in the current state. Reorgs are handled by comparing the stored block hash to the canonical hash for the specified block number; if they match, it falls back to looking up data in the trie.