### PR TITLE
build, internal/build: misc improvements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,9 +45,7 @@ matrix:
         - azure-osx
       script:
         - go run build/ci.go install
-        - go run build/ci.go archive -type zip -signer OSX_SIGNING_KEY -upload gethstore/builds
-        - go run build/ci.go install -arch 386
-        - go run build/ci.go archive -arch 386 -type zip -signer OSX_SIGNING_KEY -upload gethstore/builds
+        - go run build/ci.go archive -type tar -signer OSX_SIGNING_KEY -upload gethstore/builds
 
 install:
   - go get golang.org/x/tools/cmd/cover

--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ test: all
 	build/env.sh go run build/ci.go test
 
 clean:
-	rm -fr build/_workspace/pkg/ Godeps/_workspace/pkg $(GOBIN)/*
+	rm -fr build/_workspace/pkg/ $(GOBIN)/*
 
 # Cross Compilation Targets (xgo)
 

--- a/build/ci.go
+++ b/build/ci.go
@@ -296,18 +296,20 @@ func doArchive(cmdline []string) {
 		log.Fatal("unknown archive type: ", atype)
 	}
 
-	env := build.Env()
+	var (
+		env      = build.Env()
+		base     = archiveBasename(*arch, env)
+		geth     = "geth-" + base + ext
+		alltools = "geth-alltools-" + base + ext
+	)
 	maybeSkipArchive(env)
-
-	base := archiveBasename(*arch, env)
-	if err := build.WriteArchive("geth-"+base, ext, gethArchiveFiles); err != nil {
+	if err := build.WriteArchive(geth, gethArchiveFiles); err != nil {
 		log.Fatal(err)
 	}
-	if err := build.WriteArchive("geth-alltools-"+base, ext, allToolsArchiveFiles); err != nil {
+	if err := build.WriteArchive(alltools, allToolsArchiveFiles); err != nil {
 		log.Fatal(err)
 	}
-
-	for _, archive := range []string{"geth-" + base + ext, "geth-alltools-" + base + ext} {
+	for _, archive := range []string{geth, alltools} {
 		if err := archiveUpload(archive, *upload, *signer); err != nil {
 			log.Fatal(err)
 		}
@@ -315,7 +317,6 @@ func doArchive(cmdline []string) {
 }
 
 func archiveBasename(arch string, env build.Environment) string {
-	// date := time.Now().UTC().Format("200601021504")
 	platform := runtime.GOOS + "-" + arch
 	archive := platform + "-" + build.VERSION()
 	if env.Commit != "" {

--- a/build/ci.go
+++ b/build/ci.go
@@ -319,6 +319,9 @@ func doArchive(cmdline []string) {
 func archiveBasename(arch string, env build.Environment) string {
 	platform := runtime.GOOS + "-" + arch
 	archive := platform + "-" + build.VERSION()
+	if isUnstableBuild(env) {
+		archive += "-unstable"
+	}
 	if env.Commit != "" {
 		archive += "-" + env.Commit[:8]
 	}

--- a/build/env.sh
+++ b/build/env.sh
@@ -19,7 +19,6 @@ if [ ! -L "$ethdir/go-ethereum" ]; then
 fi
 
 # Set up the environment to use the workspace.
-# Also add Godeps workspace so we build using canned dependencies.
 GOPATH="$workspace"
 export GOPATH
 

--- a/build/update-license.go
+++ b/build/update-license.go
@@ -45,7 +45,7 @@ var (
 	// paths with any of these prefixes will be skipped
 	skipPrefixes = []string{
 		// boring stuff
-		"Godeps/", "tests/files/", "build/",
+		"vendor/", "tests/files/", "build/",
 		// don't relicense vendored sources
 		"crypto/sha3/", "crypto/ecies/", "logger/glog/",
 		"crypto/secp256k1/curve.go",


### PR DESCRIPTION
This PR makes small adjustments to automated builds:

* darwin/386 builds don't make sense because macOS only runs on 64 bit machines.
* darwin builds should be distributed as tar.gz archives
* some scripts still referred to the godep workspace
* zip archives were not compressed. Adding compression shrinks the geth-only archive
  from ~20MB to ~6MB.