### PR TITLE
travis: build to all supported linux architectures

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,7 @@ matrix:
     # This builder does the Ubuntu PPA and Linux Azure uploads
     - os: linux
       dist: trusty
+      sudo: required
       go: 1.7
       env:
         - ubuntu-ppa
@@ -27,16 +28,30 @@ matrix:
       addons:
         apt:
           packages:
-            - gcc-multilib
             - devscripts
             - debhelper
             - dput
+            - gcc-multilib
       script:
+        # Build for the primary platforms that Trusty can manage
         - go run build/ci.go debsrc -signer "Felix Lange (Geth CI Testing Key) <fjl@twurst.com>" -upload ppa:lp-fjl/geth-ci-testing
         - go run build/ci.go install
         - go run build/ci.go archive -type tar -signer LINUX_SIGNING_KEY -upload gethstore/builds
         - go run build/ci.go install -arch 386
         - go run build/ci.go archive -arch 386 -type tar -signer LINUX_SIGNING_KEY -upload gethstore/builds
+
+        # Switch over GCC to cross compilation (breaks 386, hence why do it here only)
+        - sudo -E apt-get -yq --no-install-suggests --no-install-recommends --force-yes install gcc-arm-linux-gnueabi libc6-dev-armel-cross gcc-arm-linux-gnueabihf libc6-dev-armhf-cross gcc-aarch64-linux-gnu libc6-dev-arm64-cross
+        - sudo ln -s /usr/include/asm-generic /usr/include/asm
+
+        - GOARM=5 CC=arm-linux-gnueabi-gcc go run build/ci.go install -arch arm
+        - GOARM=5 go run build/ci.go archive -arch arm -type tar -signer LINUX_SIGNING_KEY -upload gethstore/builds
+        - GOARM=6 CC=arm-linux-gnueabi-gcc go run build/ci.go install -arch arm
+        - GOARM=6 go run build/ci.go archive -arch arm -type tar -signer LINUX_SIGNING_KEY -upload gethstore/builds
+        - GOARM=7 CC=arm-linux-gnueabihf-gcc go run build/ci.go install -arch arm
+        - GOARM=7 go run build/ci.go archive -arch arm -type tar -signer LINUX_SIGNING_KEY -upload gethstore/builds
+        - CC=aarch64-linux-gnu-gcc go run build/ci.go install -arch arm64
+        - go run build/ci.go archive -arch arm64 -type tar -signer LINUX_SIGNING_KEY -upload gethstore/builds
 
     # This builder does the OSX Azure uploads
     - os: osx

--- a/build/ci.go
+++ b/build/ci.go
@@ -158,6 +158,13 @@ func doInstall(cmdline []string) {
 		build.MustRun(goinstall)
 		return
 	}
+	// If we are cross compiling to ARMv5 ARMv6 or ARMv7, clean any prvious builds
+	if *arch == "arm" {
+		os.RemoveAll(filepath.Join(runtime.GOROOT(), "pkg", runtime.GOOS+"_arm"))
+		for _, path := range filepath.SplitList(build.GOPATH()) {
+			os.RemoveAll(filepath.Join(path, "pkg", runtime.GOOS+"_arm"))
+		}
+	}
 	// Seems we are cross compiling, work around forbidden GOBIN
 	goinstall := goToolArch(*arch, "install", buildFlags(env)...)
 	goinstall.Args = append(goinstall.Args, "-v")
@@ -318,6 +325,9 @@ func doArchive(cmdline []string) {
 
 func archiveBasename(arch string, env build.Environment) string {
 	platform := runtime.GOOS + "-" + arch
+	if arch == "arm" {
+		platform += os.Getenv("GOARM")
+	}
 	archive := platform + "-" + build.VERSION()
 	if isUnstableBuild(env) {
 		archive += "-unstable"


### PR DESCRIPTION
This PR enables building geth (and tools) to additional supported Linux architectures (atmv5, armv6 armv7, arm64).

MIPS64 and MIPS64LE needs a virtualized builder as travis only runs on top of Trusty and we need GCC 5+ for MIPS64, which Trusty does not have.