### PR TITLE
build: fix missing .exe executable names on cross builds

### DIFF
--- a/build/ci.go
+++ b/build/ci.go
@@ -182,7 +182,7 @@ func doInstall(cmdline []string) {
 				if name == "main" {
 					gobuild := goToolArch(*arch, "build", buildFlags(env)...)
 					gobuild.Args = append(gobuild.Args, "-v")
-					gobuild.Args = append(gobuild.Args, []string{"-o", filepath.Join(GOBIN, cmd.Name())}...)
+					gobuild.Args = append(gobuild.Args, []string{"-o", executablePath(cmd.Name())}...)
 					gobuild.Args = append(gobuild.Args, "."+string(filepath.Separator)+filepath.Join("cmd", cmd.Name()))
 					build.MustRun(gobuild)
 					break


### PR DESCRIPTION
When cross building individual binaries, we need to explicitly name the output file. On Windows we did that without appending the `.exe` extension, causing archival commands to fail since they do need the `.exe` to zip the files up.