### PR TITLE
containers/docker: make ubuntu images standalone

### DIFF
--- a/containers/docker/develop-alpine/Dockerfile
+++ b/containers/docker/develop-alpine/Dockerfile
@@ -9,6 +9,7 @@ RUN \
   rm -rf /go-ethereum && rm -rf /var/cache/apk/*
 
 EXPOSE 8545
+EXPOSE 8546
 EXPOSE 30303
 
 ENTRYPOINT ["/geth"]

--- a/containers/docker/develop-ubuntu/Dockerfile
+++ b/containers/docker/develop-ubuntu/Dockerfile
@@ -1,17 +1,14 @@
-FROM ubuntu:wily
-MAINTAINER caktux
+FROM ubuntu:xenial
 
-ENV DEBIAN_FRONTEND noninteractive
-
-RUN apt-get update && \
-    apt-get upgrade -q -y && \
-    apt-get dist-upgrade -q -y && \
-    apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 923F6CA9 && \
-    echo "deb http://ppa.launchpad.net/ethereum/ethereum-dev/ubuntu wily main" | tee -a /etc/apt/sources.list.d/ethereum.list && \
-    apt-get update && \
-    apt-get install -q -y geth
+RUN \
+  apt-get update && apt-get install -y golang git make gcc build-essential ca-certificates --no-install-recommends && \
+  git clone --depth 1 --branch develop https://github.com/ethereum/go-ethereum && \
+  (cd go-ethereum && make geth) && cp go-ethereum/build/bin/geth /geth && \
+  apt-get remove -y golang git make gcc build-essential ca-certificates && apt-get clean && \
+  apt-get autoremove -y && rm -rf /go-ethereum && rm -rf /var/cache/apt/*
 
 EXPOSE 8545
+EXPOSE 8546
 EXPOSE 30303
 
-ENTRYPOINT ["/usr/bin/geth"]
+ENTRYPOINT ["/geth"]

--- a/containers/docker/master-alpine/Dockerfile
+++ b/containers/docker/master-alpine/Dockerfile
@@ -9,6 +9,7 @@ RUN \
   rm -rf /go-ethereum && rm -rf /var/cache/apk/*
 
 EXPOSE 8545
+EXPOSE 8546
 EXPOSE 30303
 
 ENTRYPOINT ["/geth"]

--- a/containers/docker/master-ubuntu/Dockerfile
+++ b/containers/docker/master-ubuntu/Dockerfile
@@ -1,17 +1,14 @@
-FROM ubuntu:wily
-MAINTAINER caktux
+FROM ubuntu:xenial
 
-ENV DEBIAN_FRONTEND noninteractive
-
-RUN apt-get update && \
-    apt-get upgrade -q -y && \
-    apt-get dist-upgrade -q -y && \
-    apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 923F6CA9 && \
-    echo "deb http://ppa.launchpad.net/ethereum/ethereum/ubuntu wily main" | tee -a /etc/apt/sources.list.d/ethereum.list && \
-    apt-get update && \
-    apt-get install -q -y geth
+RUN \
+  apt-get update && apt-get install -y golang git make gcc build-essential ca-certificates --no-install-recommends && \
+  git clone --depth 1 https://github.com/ethereum/go-ethereum && \
+  (cd go-ethereum && make geth) && cp go-ethereum/build/bin/geth /geth && \
+  apt-get remove -y golang git make gcc build-essential ca-certificates && apt-get clean && \
+  apt-get autoremove -y && rm -rf /go-ethereum && rm -rf /var/cache/apt/*
 
 EXPOSE 8545
+EXPOSE 8546
 EXPOSE 30303
 
-ENTRYPOINT ["/usr/bin/geth"]
+ENTRYPOINT ["/geth"]


### PR DESCRIPTION
The Ubuntu docker images relied on PPAs being updated before they are built, which obviously was impossible (docker hub autobuilds on push), resulting in our Ubuntu images always being out of date. This PR ensures that we build Geth inside Ubuntu images too and not depend on some external service.