### PR TITLE
build: fix remote path for archive uploads

### DIFF
--- a/build/ci.go
+++ b/build/ci.go
@@ -359,11 +359,11 @@ func archiveUpload(archive string, blobstore string, signer string) error {
 			Token:     os.Getenv("AZURE_BLOBSTORE_TOKEN"),
 			Container: strings.SplitN(blobstore, "/", 2)[1],
 		}
-		if err := build.AzureBlobstoreUpload(archive, archive, auth); err != nil {
+		if err := build.AzureBlobstoreUpload(archive, filepath.Base(archive), auth); err != nil {
 			return err
 		}
 		if signer != "" {
-			if err := build.AzureBlobstoreUpload(archive+".asc", archive+".asc", auth); err != nil {
+			if err := build.AzureBlobstoreUpload(archive+".asc", filepath.Base(archive+".asc"), auth); err != nil {
 				return err
 			}
 		}

--- a/internal/build/azure.go
+++ b/internal/build/azure.go
@@ -16,6 +16,7 @@
 package build
 
 import (
+	"fmt"
 	"os"
 
 	"github.com/Azure/azure-sdk-for-go/storage"
@@ -36,6 +37,11 @@ type AzureBlobstoreConfig struct {
 //
 // See: https://msdn.microsoft.com/en-us/library/azure/dd179451.aspx#Anchor_3
 func AzureBlobstoreUpload(path string, name string, config AzureBlobstoreConfig) error {
+	if *DryRunFlag {
+		fmt.Printf("would upload %q to %s/%s/%s\n", path, config.Account, config.Container, name)
+		return nil
+	}
+
 	// Create an authenticated client against the Azure cloud
 	rawClient, err := storage.NewBasicClient(config.Account, config.Token)
 	if err != nil {


### PR DESCRIPTION
archiveUpload did not handle absolute paths correctly. Fix it by using
the basename and ensure that uploads can be tested using -n.