### PR TITLE
Dockerfile revamp

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+FROM alpine:3.3
+
+ADD . /go-ethereum
+RUN \
+  apk add --update go make gcc musl-dev             && \
+  (cd go-ethereum && make geth)                     && \
+  cp go-ethereum/build/bin/geth /geth               && \
+  apk del go make gcc musl-dev                      && \
+  rm -rf /go-ethereum && rm -rf /var/cache/apk/*
+
+EXPOSE 8545
+EXPOSE 30303
+
+ENTRYPOINT ["/geth"]

--- a/containers/docker/develop-alpine/Dockerfile
+++ b/containers/docker/develop-alpine/Dockerfile
@@ -2,7 +2,7 @@ FROM alpine:3.4
 
 RUN \
   apk add --update go git make gcc musl-dev && \
-  git clone --depth 1 --branch develop https://github.com/ethereum/go-ethereum && \
+  git clone --depth 1 https://github.com/ethereum/go-ethereum && \
   (cd go-ethereum && make geth) && \
   cp go-ethereum/build/bin/geth /geth && \
   apk del go git make gcc musl-dev && \

--- a/containers/docker/master-alpine/Dockerfile
+++ b/containers/docker/master-alpine/Dockerfile
@@ -2,7 +2,7 @@ FROM alpine:3.4
 
 RUN \
   apk add --update go git make gcc musl-dev && \
-  git clone --depth 1 https://github.com/ethereum/go-ethereum && \
+  git clone --depth 1 --branch release/1.5 https://github.com/ethereum/go-ethereum && \
   (cd go-ethereum && make geth) && \
   cp go-ethereum/build/bin/geth /geth && \
   apk del go git make gcc musl-dev && \


### PR DESCRIPTION
This PR fixes existing dockerfiles so they point to the latest release and to the development head again, following the recent changes to our branch structure.

It also creates a new Dockerfile in the root, that builds the currently checked out repository using Alpine as a base.

My suggestion is that we do the following after merging this PR:
 - Deprecate the 'latest', 'latest-alpine', 'develop', and 'develop-alpine' tags on Dockerhub, and announce we will cease pushing new releases to these tags in the near future.
 - Set up automatic configurations for master, each of the release branches, and each of the release tags, to automatically build docker images.
 - Later, deprecate, then delete the old build configurations.
 - Later still, set up 'latest' to track 'master'.