### PR TITLE
node: Remove redundant filepath.Join in parsePersistentNodes.

### DIFF
--- a/node/config.go
+++ b/node/config.go
@@ -365,12 +365,11 @@ func (c *Config) TrusterNodes() []*discover.Node {
 
 // parsePersistentNodes parses a list of discovery node URLs loaded from a .json
 // file from within the data directory.
-func (c *Config) parsePersistentNodes(file string) []*discover.Node {
+func (c *Config) parsePersistentNodes(path string) []*discover.Node {
 	// Short circuit if no node config is present
 	if c.DataDir == "" {
 		return nil
 	}
-	path := filepath.Join(c.DataDir, file)
 	if _, err := os.Stat(path); err != nil {
 		return nil
 	}


### PR DESCRIPTION
```go
// StaticNodes returns a list of node enode URLs configured as static nodes.
func (c *Config) StaticNodes() []*discover.Node {
    return c.parsePersistentNodes(c.resolvePath(datadirStaticNodes))
}

// TrusterNodes returns a list of node enode URLs configured as trusted nodes.
func (c *Config) TrusterNodes() []*discover.Node {
	return c.parsePersistentNodes(c.resolvePath(datadirTrustedNodes))
}
```

Already use c.resolvePath to get full file path. Don't need join in parsePersistentNodes function.