### PR TITLE
accounts/abi: Must copy arrays of arrays element wise

### DIFF
--- a/accounts/abi/reflect.go
+++ b/accounts/abi/reflect.go
@@ -81,7 +81,14 @@ func set(dst, src reflect.Value, output Argument) error {
 		if dst.Len() < output.Type.SliceSize {
 			return fmt.Errorf("abi: cannot unmarshal src (len=%d) in to dst (len=%d)", output.Type.SliceSize, dst.Len())
 		}
-		reflect.Copy(dst, src)
+		switch dstType.Elem().Kind() {
+		case reflect.Array:
+			for i := 0; i < dst.Len(); i++ {
+				reflect.Copy(dst.Index(i), src.Index(i))
+			}
+		default:
+			reflect.Copy(dst, src)
+		}
 	case dstType.Kind() == reflect.Interface:
 		dst.Set(src)
 	case dstType.Kind() == reflect.Ptr:


### PR DESCRIPTION
Without this when the output is something like 

```go
struct {
   Codes [500][4]byte
   // ...
```

the reflect code will panic with

```
panic: reflect.Copy: [4]uint8 != []uint8

goroutine 1 [running]:
panic(0x44e6460, 0xc420195020)
	/usr/local/go/src/runtime/panic.go:500 +0x1a1
reflect.typesMustMatch(0x45b83c5, 0xc, 0x48b9ca0, 0x44f0d00, 0x48b9ca0, 0x44de5e0)
	/usr/local/go/src/reflect/value.go:1772 +0x19e
reflect.Copy(0x44f0e80, 0xc4200ff000, 0x191, 0x44d9c20, 0xc420262ba0, 0x97, 0x1)
	/usr/local/go/src/reflect/value.go:1855 +0x116
github.com/ethereum/go-ethereum/accounts/abi.set(0x44f0e80, 0xc4200ff000, 0x191, 0x44d9c20, 0xc420262ba0, 0x97, 0xc420073738, 0x8, 0x100, 0x1f4, ...)
	/Users/jb/src/github.com/ethereum/go-ethereum/accounts/abi/reflect.go:85 +0x781
github.com/ethereum/go-ethereum/accounts/abi.ABI.Unpack(0x0, 0x0, 0x0, 0xc42041ed00, 0x1, 0x4, 0x0, 0x0, 0x0, 0xc42041c600, ...)
	/Users/jb/src/github.com/ethereum/go-ethereum/accounts/abi/abi.go:288 +0x575
github.com/ethereum/go-ethereum/accounts/abi/bind.(*BoundContract).Call(0xc4200a2630, 0xc4203c7680, 0x44d5fc0, 0xc4200ff000, 0x45be438, 0xf, 0x0, 0x0, 0x0, 0xc420073920, ...)
	/Users/jb/src/github.com/ethereum/go-ethereum/accounts/abi/bind/base.go:144 +0x323
...
```

This fixes that by copying element wise when the destination is an array of arrays.