### PR TITLE
Mobile ci fixes

### DIFF
--- a/build/ci.go
+++ b/build/ci.go
@@ -796,7 +796,7 @@ func doXCodeFramework(cmdline []string) {
 	}
 	// Prepare and upload a PodSpec to CocoaPods
 	if *deploy != "" {
-		meta := newPodMetadata(env)
+		meta := newPodMetadata(env, archive)
 		build.Render("build/pod.podspec", meta.Name+".podspec", 0755, meta)
 		build.MustRunCommand("pod", *deploy, "push", meta.Name+".podspec", "--allow-warnings", "--verbose")
 	}
@@ -806,6 +806,7 @@ type podMetadata struct {
 	Name         string
 	Version      string
 	Commit       string
+	Archive      string
 	Contributors []podContributor
 }
 
@@ -814,7 +815,7 @@ type podContributor struct {
 	Email string
 }
 
-func newPodMetadata(env build.Environment) podMetadata {
+func newPodMetadata(env build.Environment, archive string) podMetadata {
 	// Collect the list of authors from the repo root
 	contribs := []podContributor{}
 	if authors, err := os.Open("AUTHORS"); err == nil {
@@ -841,7 +842,8 @@ func newPodMetadata(env build.Environment) podMetadata {
 	}
 	return podMetadata{
 		Name:         name,
-		Version:      archiveVersion(env),
+		Archive:      archive,
+		Version:      build.VERSION() + "+" + env.Commit[:8],
 		Commit:       env.Commit,
 		Contributors: contribs,
 	}

--- a/build/ci.go
+++ b/build/ci.go
@@ -744,7 +744,7 @@ func newMavenMetadata(env build.Environment) mavenMetadata {
 				continue
 			}
 			// Split the author and insert as a contributor
-			re := regexp.MustCompile("([^<]+) <(.+>)")
+			re := regexp.MustCompile("([^<]+) <(.+)>")
 			parts := re.FindStringSubmatch(line)
 			if len(parts) == 3 {
 				contribs = append(contribs, mavenContributor{Name: parts[1], Email: parts[2]})
@@ -829,7 +829,7 @@ func newPodMetadata(env build.Environment, archive string) podMetadata {
 				continue
 			}
 			// Split the author and insert as a contributor
-			re := regexp.MustCompile("([^<]+) <(.+>)")
+			re := regexp.MustCompile("([^<]+) <(.+)>")
 			parts := re.FindStringSubmatch(line)
 			if len(parts) == 3 {
 				contribs = append(contribs, podContributor{Name: parts[1], Email: parts[2]})

--- a/build/pod.podspec
+++ b/build/pod.podspec
@@ -14,9 +14,9 @@ Pod::Spec.new do |spec|
 	spec.ios.vendored_frameworks = 'Frameworks/Geth.framework'
 
 	spec.prepare_command = <<-CMD
-    curl https://gethstore.blob.core.windows.net/builds/geth-ios-all-{{.Version}}.tar.gz | tar -xvz
+    curl https://gethstore.blob.core.windows.net/builds/{{.Archive}}.tar.gz | tar -xvz
     mkdir Frameworks
-    mv geth-ios-all-{{.Version}}/Geth.framework Frameworks
-    rm -rf geth-ios-all-{{.Version}}
+    mv {{.Archive}}/Geth.framework Frameworks
+    rm -rf {{.Archive}}
   CMD
 end


### PR DESCRIPTION
This PR fixes two issues:

- On Maven and CocoaPods, the bundle metadata files contained invalid email addresses for the authors as the regex accidentally added a trailing `>` character.
- CocoaPods interprets the current `-<hash>` version number extention (e.g. in `1.5.2-c8695209`) as a pre-release (correctly according to the semver spec) and requires build metadata to be specified via `+<hash>` instead (e.g. `1.5.2+c8695209`).  This PR fixes this, which should allow proper dependency versioning and upgrade strategies.
  - As an extension to this fix, we also drop `-unstable` tags from CocoaPod versions (since that would cause the same issues as the hash) and instead simply rely on users either depending on `Geth` for stable releases and `GethDevelop` for develop releases, which is much more flexible and explicit anyway.