### PR TITLE
build: remove hash metadata from cocoapod version

### DIFF
--- a/build/ci.go
+++ b/build/ci.go
@@ -843,7 +843,7 @@ func newPodMetadata(env build.Environment, archive string) podMetadata {
 	return podMetadata{
 		Name:         name,
 		Archive:      archive,
-		Version:      build.VERSION() + "+" + env.Commit[:8],
+		Version:      build.VERSION(),
 		Commit:       env.Commit,
 		Contributors: contribs,
 	}


### PR DESCRIPTION
Originally we used `<version>-<hash>` as the version string for iOS CocoaPods packages. This turned out to be considered a pre-release by cocoapods, which follows the `semver` specification. A previous commit changed our iOS version strings to `<version>+<hash>` which represents build metadata according to the `semver` spec used by CocoaPods. Unfortunately it again turned out that CocoaPods doesn't like it (https://github.com/CocoaPods/CocoaPods/issues/6224), so for now at least this PR just drops all build metainfos and keeps to the plain version number only. Since we ship stable and develop versions as separate packages, there should be no issue with this anyway.