### PR TITLE
abi: cannot unmarshal []*big.Int in to []uint32

### DIFF
--- a/accounts/abi/type.go
+++ b/accounts/abi/type.go
@@ -90,7 +90,11 @@ func NewType(t string) (typ Type, err error) {
 		}
 		typ.Elem = &sliceType
 		typ.stringKind = sliceType.stringKind + t[len(res[1]):]
-		return typ, nil
+		//Altough we know that this is an array, we cannot return as we don't
+		//know the type of the element, however, if it is still an array, then don't determine the type
+		if typ.Elem.IsArray {
+			return typ, nil
+		}
 	}
 
 	// parse the type and size of the abi-type.


### PR DESCRIPTION
On solidity contract I have "uint32 []" type, when abigen creates Go bindings - they are also "[]uint32" type on Go side. Even though it looks like it should work - the actual type of the data coming from the chain is of type " []*big.Int".

When executing contract function from Go side - getting unmarshal error:
abi: cannot unmarshal []*big.Int in to []uint32

The fix is to create array with the correct type

This fixed the issue reported in: https://github.com/ethereum/go-ethereum/issues/2802