### PR TITLE
internal/build: use 'git tag --points-at' to get the current tag

### DIFF
--- a/internal/build/env.go
+++ b/internal/build/env.go
@@ -20,6 +20,7 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	"strings"
 )
 
 var (
@@ -89,9 +90,13 @@ func LocalEnv() Environment {
 		}
 	}
 	if env.Tag == "" {
-		env.Tag = RunGit("for-each-ref", "--points-at=HEAD", "--count=1", "--format=%(refname:short)", "refs/tags")
+		env.Tag = firstLine(RunGit("tag", "-l", "--points-at", "HEAD"))
 	}
 	return env
+}
+
+func firstLine(s string) string {
+	return strings.Split(s, "\n")[0]
 }
 
 func applyEnvFlags(env Environment) Environment {


### PR DESCRIPTION
This should restore support for building with git 1.x.
`git tag -l --points-at` was [added in git 1.7.10](https://github.com/git/git/blob/master/Documentation/RelNotes/1.7.10.txt#L128) (roughly 5 years ago), whereas 
`git for-each-ref --points-at` is a newer feature supported [since 2.7.0](https://github.com/git/git/blob/master/Documentation/RelNotes/2.7.0.txt#L100) (1 year ago).