### PR TITLE
accounts: disable file system watcher on windows

### DIFF
--- a/accounts/watch.go
+++ b/accounts/watch.go
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
 
-// +build darwin,!ios freebsd linux,!arm64 netbsd solaris windows
+// +build darwin,!ios freebsd linux,!arm64 netbsd solaris
 
 package accounts
 

--- a/accounts/watch_fallback.go
+++ b/accounts/watch_fallback.go
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
 
-// +build ios linux,arm64 !darwin,!freebsd,!linux,!netbsd,!solaris,!windows
+// +build ios linux,arm64 windows !darwin,!freebsd,!linux,!netbsd,!solaris
 
 // This is the fallback implementation of directory watching.
 // It is used on unsupported platforms.


### PR DESCRIPTION
The watcher is unreliable and causes test failures on Windows.
Disable it until we have a better solution.