### PR TITLE
build: use single CocoaPods package, pre-release dev builds

### DIFF
--- a/build/ci.go
+++ b/build/ci.go
@@ -826,13 +826,12 @@ func doXCodeFramework(cmdline []string) {
 	// Prepare and upload a PodSpec to CocoaPods
 	if *deploy != "" {
 		meta := newPodMetadata(env, archive)
-		build.Render("build/pod.podspec", meta.Name+".podspec", 0755, meta)
-		build.MustRunCommand("pod", *deploy, "push", meta.Name+".podspec", "--allow-warnings", "--verbose")
+		build.Render("build/pod.podspec", "Geth.podspec", 0755, meta)
+		build.MustRunCommand("pod", *deploy, "push", "Geth.podspec", "--allow-warnings", "--verbose")
 	}
 }
 
 type podMetadata struct {
-	Name         string
 	Version      string
 	Commit       string
 	Archive      string
@@ -865,14 +864,13 @@ func newPodMetadata(env build.Environment, archive string) podMetadata {
 			}
 		}
 	}
-	name := "Geth"
+	version := build.VERSION()
 	if isUnstableBuild(env) {
-		name += "Develop"
+		version += "-unstable." + env.Buildnum
 	}
 	return podMetadata{
-		Name:         name,
 		Archive:      archive,
-		Version:      build.VERSION(),
+		Version:      version,
 		Commit:       env.Commit,
 		Contributors: contribs,
 	}

--- a/build/pod.podspec
+++ b/build/pod.podspec
@@ -1,5 +1,5 @@
 Pod::Spec.new do |spec|
-  spec.name         = '{{.Name}}'
+  spec.name         = 'Geth'
   spec.version      = '{{.Version}}'
   spec.license      = { :type => 'GNU Lesser General Public License, Version 3.0' }
   spec.homepage     = 'https://github.com/ethereum/go-ethereum'


### PR DESCRIPTION
Apparently CocoaPods doesn't allow overwriting a previously released package, neither support meta informations appended, so that pretty much excludes a clean separation of `Geth` and `GethDevelop`. The only viable alternative is to use pre-release tags (i.e. `1.5.3-something`), which makes having a separate develop package superfluous.

This PR begins to tag all unstable builds with `-unstable.buildnum` and uses the `Geth` package globally for both stable and unstable builds. CocoaPods should in theory ensure that stable and pre-releases don't update between each other, and having a single package will probably be cleaner anyway.

As always with CocoaPods, I provide 0 guarantees that this works :P 