### PR TITLE
common/hexutil: fix Test{Decode,Unmarshal}Uint64 on 32bit arch

### DIFF
--- a/common/hexutil/hexutil_test.go
+++ b/common/hexutil/hexutil_test.go
@@ -105,7 +105,7 @@ var (
 		{input: `0`, wantErr: ErrMissingPrefix},
 		{input: `0x`, wantErr: ErrEmptyNumber},
 		{input: `0x01`, wantErr: ErrLeadingZero},
-		{input: `0xfffffffffffffffff`, wantErr: ErrUintRange},
+		{input: `0xfffffffffffffffff`, wantErr: ErrUint64Range},
 		{input: `0xx`, wantErr: ErrSyntax},
 		{input: `0x1zz01`, wantErr: ErrSyntax},
 		// valid

--- a/common/hexutil/json_test.go
+++ b/common/hexutil/json_test.go
@@ -202,7 +202,7 @@ var unmarshalUint64Tests = []unmarshalTest{
 	{input: `"0"`, wantErr: ErrMissingPrefix},
 	{input: `"0x"`, wantErr: ErrEmptyNumber},
 	{input: `"0x01"`, wantErr: ErrLeadingZero},
-	{input: `"0xfffffffffffffffff"`, wantErr: ErrUintRange},
+	{input: `"0xfffffffffffffffff"`, wantErr: ErrUint64Range},
 	{input: `"0xx"`, wantErr: ErrSyntax},
 	{input: `"0x1zz01"`, wantErr: ErrSyntax},
 


### PR DESCRIPTION
https://ci.appveyor.com/project/EthereumFoundation/go-ethereum/build/master.1182/job/wf2bw1h0qh67a9ip#L263