### PR TITLE
Document tx.To() in case of contract creation txs

### DIFF
--- a/core/types/transaction.go
+++ b/core/types/transaction.go
@@ -233,8 +233,8 @@ func (tx *Transaction) Value() *big.Int    { return new(big.Int).Set(tx.data.Amo
 func (tx *Transaction) Nonce() uint64      { return tx.data.AccountNonce }
 func (tx *Transaction) CheckNonce() bool   { return true }
 
-// Get the recipient address of this transaction.
-// It returns nil if the transaction is a contract creation transaction.
+// To returns the recipient address of the transaction.
+// It returns nil if the transaction is a contract creation.
 func (tx *Transaction) To() *common.Address {
 	if tx.data.Recipient == nil {
 		return nil

--- a/core/types/transaction.go
+++ b/core/types/transaction.go
@@ -233,6 +233,8 @@ func (tx *Transaction) Value() *big.Int    { return new(big.Int).Set(tx.data.Amo
 func (tx *Transaction) Nonce() uint64      { return tx.data.AccountNonce }
 func (tx *Transaction) CheckNonce() bool   { return true }
 
+// Get the recipient address of this transaction.
+// It returns nil if the transaction is a contract creation transaction.
 func (tx *Transaction) To() *common.Address {
 	if tx.data.Recipient == nil {
 		return nil


### PR DESCRIPTION
`transaction.To()` returns nil when the transaction is a contract creation transaction but did not document this behavior.

Solved #3331