### PR TITLE
node: improve error handling for web3_sha3 RPC method

### DIFF
--- a/node/api.go
+++ b/node/api.go
@@ -21,7 +21,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/p2p"
 	"github.com/ethereum/go-ethereum/p2p/discover"
@@ -331,6 +331,6 @@ func (s *PublicWeb3API) ClientVersion() string {
 
 // Sha3 applies the ethereum sha3 implementation on the input.
 // It assumes the input is hex encoded.
-func (s *PublicWeb3API) Sha3(input string) string {
-	return common.ToHex(crypto.Keccak256(common.FromHex(input)))
+func (s *PublicWeb3API) Sha3(input hexutil.Bytes) hexutil.Bytes {
+	return crypto.Keccak256(input)
 }


### PR DESCRIPTION
Currently this RPC method accepts a string as it initially was documented within the RPC spec. This is confusing since the implementation expects input to be hex encoded. If the input isn't valid hex `FromHex` returns an empty sting and the response is the hash of the empty string.

This PR used the new `hexutil.Bytes` that validates if the input is valid hex when the request is parsed.
The spec is also updated to explicitly specify that input must be hex encoded.

Fixes #3314