### PR TITLE
core: leave contract addr in receipt empty when deployment fails

### DIFF
--- a/core/state_processor.go
+++ b/core/state_processor.go
@@ -97,7 +97,7 @@ func ApplyTransaction(config *params.ChainConfig, bc *BlockChain, gp *GasPool, s
 		return nil, nil, nil, err
 	}
 
-	_, gas, err := ApplyMessage(NewEnv(statedb, config, bc, msg, header, cfg), msg, gp)
+	ret, gas, err := ApplyMessage(NewEnv(statedb, config, bc, msg, header, cfg), msg, gp)
 	if err != nil {
 		return nil, nil, nil, err
 	}
@@ -107,7 +107,9 @@ func ApplyTransaction(config *params.ChainConfig, bc *BlockChain, gp *GasPool, s
 	receipt := types.NewReceipt(statedb.IntermediateRoot(config.IsEIP158(header.Number)).Bytes(), usedGas)
 	receipt.TxHash = tx.Hash()
 	receipt.GasUsed = new(big.Int).Set(gas)
-	if MessageCreatesContract(msg) {
+
+	// ret is only not nil when the contract is deployed successful.
+	if MessageCreatesContract(msg) && ret != nil {
 		receipt.ContractAddress = crypto.CreateAddress(msg.From(), tx.Nonce())
 	}
 

--- a/core/state_transition.go
+++ b/core/state_transition.go
@@ -235,6 +235,8 @@ func (self *StateTransition) TransitionDb() (ret []byte, requiredGas, usedGas *b
 		if err != nil {
 			ret = nil
 			glog.V(logger.Core).Infoln("VM create err:", err)
+		} else if ret == nil { // contract deployed without code
+			ret = []byte{}
 		}
 	} else {
 		// Increment the nonce for the next transaction


### PR DESCRIPTION
VM execution errors are not returned in `core.ApplyMessage` since these errors are no "real" errors. When a contract deploy transaction fails (e.g. runs out of gas) the receipt still holds the contract address since it will only check if an error was returned.

This PR will check that the VM returns contract code before setting the contract address in the receipt. This only happens when the contract was deployed successful.