### PR TITLE
mobile: iOS naming and API fixes for generators and Swift

### DIFF
--- a/build/ci.go
+++ b/build/ci.go
@@ -800,7 +800,7 @@ func doXCodeFramework(cmdline []string) {
 	// Build the iOS XCode framework
 	build.MustRun(goTool("get", "golang.org/x/mobile/cmd/gomobile"))
 	build.MustRun(gomobileTool("init"))
-	bind := gomobileTool("bind", "--target", "ios", "--tags", "ios", "--prefix", "GE", "-v", "github.com/ethereum/go-ethereum/mobile")
+	bind := gomobileTool("bind", "--target", "ios", "--tags", "ios", "--prefix", "i", "-v", "github.com/ethereum/go-ethereum/mobile")
 
 	if *local {
 		// If we're building locally, use the build folder and stop afterwards

--- a/mobile/accounts.go
+++ b/mobile/accounts.go
@@ -91,8 +91,8 @@ func NewAccountManager(keydir string, scryptN, scryptP int) *AccountManager {
 }
 
 // HasAddress reports whether a key with the given address is present.
-func (am *AccountManager) HasAddress(addr *Address) bool {
-	return am.manager.HasAddress(addr.address)
+func (am *AccountManager) HasAddress(address *Address) bool {
+	return am.manager.HasAddress(address.address)
 }
 
 // GetAccounts returns all key files present in the directory.
@@ -102,32 +102,32 @@ func (am *AccountManager) GetAccounts() *Accounts {
 
 // DeleteAccount deletes the key matched by account if the passphrase is correct.
 // If a contains no filename, the address must match a unique key.
-func (am *AccountManager) DeleteAccount(a *Account, passphrase string) error {
+func (am *AccountManager) DeleteAccount(account *Account, passphrase string) error {
 	return am.manager.DeleteAccount(accounts.Account{
-		Address: a.account.Address,
-		File:    a.account.File,
+		Address: account.account.Address,
+		File:    account.account.File,
 	}, passphrase)
 }
 
 // Sign signs hash with an unlocked private key matching the given address.
-func (am *AccountManager) Sign(addr *Address, hash []byte) (signature []byte, _ error) {
-	return am.manager.Sign(addr.address, hash)
+func (am *AccountManager) Sign(address *Address, hash []byte) (signature []byte, _ error) {
+	return am.manager.Sign(address.address, hash)
 }
 
 // SignWithPassphrase signs hash if the private key matching the given address can be
 // decrypted with the given passphrase.
-func (am *AccountManager) SignWithPassphrase(addr *Address, passphrase string, hash []byte) (signature []byte, _ error) {
-	return am.manager.SignWithPassphrase(addr.address, passphrase, hash)
+func (am *AccountManager) SignWithPassphrase(address *Address, passphrase string, hash []byte) (signature []byte, _ error) {
+	return am.manager.SignWithPassphrase(address.address, passphrase, hash)
 }
 
 // Unlock unlocks the given account indefinitely.
-func (am *AccountManager) Unlock(a *Account, passphrase string) error {
-	return am.manager.TimedUnlock(a.account, passphrase, 0)
+func (am *AccountManager) Unlock(account *Account, passphrase string) error {
+	return am.manager.TimedUnlock(account.account, passphrase, 0)
 }
 
 // Lock removes the private key with the given address from memory.
-func (am *AccountManager) Lock(addr *Address) error {
-	return am.manager.Lock(addr.address)
+func (am *AccountManager) Lock(address *Address) error {
+	return am.manager.Lock(address.address)
 }
 
 // TimedUnlock unlocks the given account with the passphrase. The account
@@ -152,8 +152,8 @@ func (am *AccountManager) NewAccount(passphrase string) (*Account, error) {
 }
 
 // ExportKey exports as a JSON key, encrypted with newPassphrase.
-func (am *AccountManager) ExportKey(a *Account, passphrase, newPassphrase string) (key []byte, _ error) {
-	return am.manager.Export(a.account, passphrase, newPassphrase)
+func (am *AccountManager) ExportKey(account *Account, passphrase, newPassphrase string) (key []byte, _ error) {
+	return am.manager.Export(account.account, passphrase, newPassphrase)
 }
 
 // ImportKey stores the given encrypted JSON key into the key directory.
@@ -166,8 +166,8 @@ func (am *AccountManager) ImportKey(keyJSON []byte, passphrase, newPassphrase st
 }
 
 // Update changes the passphrase of an existing account.
-func (am *AccountManager) Update(a *Account, passphrase, newPassphrase string) error {
-	return am.manager.Update(a.account, passphrase, newPassphrase)
+func (am *AccountManager) Update(account *Account, passphrase, newPassphrase string) error {
+	return am.manager.Update(account.account, passphrase, newPassphrase)
 }
 
 // ImportPreSaleKey decrypts the given Ethereum presale wallet and stores

--- a/mobile/accounts.go
+++ b/mobile/accounts.go
@@ -56,7 +56,7 @@ func (a *Accounts) Size() int {
 }
 
 // Get returns the account at the given index from the slice.
-func (a *Accounts) Get(index int) (*Account, error) {
+func (a *Accounts) Get(index int) (account *Account, _ error) {
 	if index < 0 || index >= len(a.accounts) {
 		return nil, errors.New("index out of bounds")
 	}
@@ -110,13 +110,13 @@ func (am *AccountManager) DeleteAccount(a *Account, passphrase string) error {
 }
 
 // Sign signs hash with an unlocked private key matching the given address.
-func (am *AccountManager) Sign(addr *Address, hash []byte) ([]byte, error) {
+func (am *AccountManager) Sign(addr *Address, hash []byte) (signature []byte, _ error) {
 	return am.manager.Sign(addr.address, hash)
 }
 
 // SignWithPassphrase signs hash if the private key matching the given address can be
 // decrypted with the given passphrase.
-func (am *AccountManager) SignWithPassphrase(addr *Address, passphrase string, hash []byte) ([]byte, error) {
+func (am *AccountManager) SignWithPassphrase(addr *Address, passphrase string, hash []byte) (signature []byte, _ error) {
 	return am.manager.SignWithPassphrase(addr.address, passphrase, hash)
 }
 
@@ -152,17 +152,17 @@ func (am *AccountManager) NewAccount(passphrase string) (*Account, error) {
 }
 
 // ExportKey exports as a JSON key, encrypted with newPassphrase.
-func (am *AccountManager) ExportKey(a *Account, passphrase, newPassphrase string) ([]byte, error) {
+func (am *AccountManager) ExportKey(a *Account, passphrase, newPassphrase string) (key []byte, _ error) {
 	return am.manager.Export(a.account, passphrase, newPassphrase)
 }
 
 // ImportKey stores the given encrypted JSON key into the key directory.
-func (am *AccountManager) ImportKey(keyJSON []byte, passphrase, newPassphrase string) (*Account, error) {
-	account, err := am.manager.Import(keyJSON, passphrase, newPassphrase)
+func (am *AccountManager) ImportKey(keyJSON []byte, passphrase, newPassphrase string) (account *Account, _ error) {
+	acc, err := am.manager.Import(keyJSON, passphrase, newPassphrase)
 	if err != nil {
 		return nil, err
 	}
-	return &Account{account}, nil
+	return &Account{acc}, nil
 }
 
 // Update changes the passphrase of an existing account.
@@ -172,7 +172,7 @@ func (am *AccountManager) Update(a *Account, passphrase, newPassphrase string) e
 
 // ImportPreSaleKey decrypts the given Ethereum presale wallet and stores
 // a key file in the key directory. The key file is encrypted with the same passphrase.
-func (am *AccountManager) ImportPreSaleKey(keyJSON []byte, passphrase string) (*Account, error) {
+func (am *AccountManager) ImportPreSaleKey(keyJSON []byte, passphrase string) (ccount *Account, _ error) {
 	account, err := am.manager.ImportPreSaleKey(keyJSON, passphrase)
 	if err != nil {
 		return nil, err

--- a/mobile/big.go
+++ b/mobile/big.go
@@ -78,7 +78,7 @@ func (bi *BigInts) Size() int {
 }
 
 // Get returns the bigint at the given index from the slice.
-func (bi *BigInts) Get(index int) (*BigInt, error) {
+func (bi *BigInts) Get(index int) (bigint *BigInt, _ error) {
 	if index < 0 || index >= len(bi.bigints) {
 		return nil, errors.New("index out of bounds")
 	}

--- a/mobile/common.go
+++ b/mobile/common.go
@@ -33,18 +33,18 @@ type Hash struct {
 }
 
 // NewHashFromBytes converts a slice of bytes to a hash value.
-func NewHashFromBytes(hash []byte) (*Hash, error) {
+func NewHashFromBytes(binary []byte) (hash *Hash, _ error) {
 	h := new(Hash)
-	if err := h.SetBytes(hash); err != nil {
+	if err := h.SetBytes(binary); err != nil {
 		return nil, err
 	}
 	return h, nil
 }
 
 // NewHashFromHex converts a hex string to a hash value.
-func NewHashFromHex(hash string) (*Hash, error) {
+func NewHashFromHex(hex string) (hash *Hash, _ error) {
 	h := new(Hash)
-	if err := h.SetHex(hash); err != nil {
+	if err := h.SetHex(hex); err != nil {
 		return nil, err
 	}
 	return h, nil
@@ -95,7 +95,7 @@ func (h *Hashes) Size() int {
 }
 
 // Get returns the hash at the given index from the slice.
-func (h *Hashes) Get(index int) (*Hash, error) {
+func (h *Hashes) Get(index int) (hash *Hash, _ error) {
 	if index < 0 || index >= len(h.hashes) {
 		return nil, errors.New("index out of bounds")
 	}
@@ -108,18 +108,18 @@ type Address struct {
 }
 
 // NewAddressFromBytes converts a slice of bytes to a hash value.
-func NewAddressFromBytes(address []byte) (*Address, error) {
+func NewAddressFromBytes(binary []byte) (address *Address, _ error) {
 	a := new(Address)
-	if err := a.SetBytes(address); err != nil {
+	if err := a.SetBytes(binary); err != nil {
 		return nil, err
 	}
 	return a, nil
 }
 
 // NewAddressFromHex converts a hex string to a address value.
-func NewAddressFromHex(address string) (*Address, error) {
+func NewAddressFromHex(hex string) (address *Address, _ error) {
 	a := new(Address)
-	if err := a.SetHex(address); err != nil {
+	if err := a.SetHex(hex); err != nil {
 		return nil, err
 	}
 	return a, nil
@@ -170,7 +170,7 @@ func (a *Addresses) Size() int {
 }
 
 // Get returns the address at the given index from the slice.
-func (a *Addresses) Get(index int) (*Address, error) {
+func (a *Addresses) Get(index int) (address *Address, _ error) {
 	if index < 0 || index >= len(a.addresses) {
 		return nil, errors.New("index out of bounds")
 	}

--- a/mobile/discover.go
+++ b/mobile/discover.go
@@ -53,7 +53,7 @@ type Enode struct {
 // and UDP discovery port 30301.
 //
 //    enode://<hex node id>@10.3.58.6:30303?discport=30301
-func NewEnode(rawurl string) (*Enode, error) {
+func NewEnode(rawurl string) (enode *Enode, _ error) {
 	node, err := discv5.ParseNode(rawurl)
 	if err != nil {
 		return nil, err
@@ -82,7 +82,7 @@ func (e *Enodes) Size() int {
 }
 
 // Get returns the enode at the given index from the slice.
-func (e *Enodes) Get(index int) (*Enode, error) {
+func (e *Enodes) Get(index int) (enode *Enode, _ error) {
 	if index < 0 || index >= len(e.nodes) {
 		return nil, errors.New("index out of bounds")
 	}

--- a/mobile/doc.go
+++ b/mobile/doc.go
@@ -51,6 +51,10 @@
 // should not be provided to limit the remote code complexity. Arrays should be
 // avoided as much as possible since they complicate bounds checking.
 //
+// If a method has multiple return values (e.g. some return + an error), those
+// are generated as output arguments in ObjC. To avoid weird generated names like
+// ret_0 for them, please always assign names to output variables if tuples.
+//
 // Note, a panic *cannot* cross over language boundaries, instead will result in
 // an undebuggable SEGFAULT in the process. For error handling only ever use error
 // returns, which may be the only or the second return.

--- a/mobile/ethclient.go
+++ b/mobile/ethclient.go
@@ -32,80 +32,80 @@ type EthereumClient struct {
 }
 
 // NewEthereumClient connects a client to the given URL.
-func NewEthereumClient(rawurl string) (*EthereumClient, error) {
-	client, err := ethclient.Dial(rawurl)
-	return &EthereumClient{client}, err
+func NewEthereumClient(rawurl string) (client *EthereumClient, _ error) {
+	rawClient, err := ethclient.Dial(rawurl)
+	return &EthereumClient{rawClient}, err
 }
 
 // GetBlockByHash returns the given full block.
-func (ec *EthereumClient) GetBlockByHash(ctx *Context, hash *Hash) (*Block, error) {
-	block, err := ec.client.BlockByHash(ctx.context, hash.hash)
-	return &Block{block}, err
+func (ec *EthereumClient) GetBlockByHash(ctx *Context, hash *Hash) (block *Block, _ error) {
+	rawBlock, err := ec.client.BlockByHash(ctx.context, hash.hash)
+	return &Block{rawBlock}, err
 }
 
 // GetBlockByNumber returns a block from the current canonical chain. If number is <0, the
 // latest known block is returned.
-func (ec *EthereumClient) GetBlockByNumber(ctx *Context, number int64) (*Block, error) {
+func (ec *EthereumClient) GetBlockByNumber(ctx *Context, number int64) (block *Block, _ error) {
 	if number < 0 {
-		block, err := ec.client.BlockByNumber(ctx.context, nil)
-		return &Block{block}, err
+		rawBlock, err := ec.client.BlockByNumber(ctx.context, nil)
+		return &Block{rawBlock}, err
 	}
-	block, err := ec.client.BlockByNumber(ctx.context, big.NewInt(number))
-	return &Block{block}, err
+	rawBlock, err := ec.client.BlockByNumber(ctx.context, big.NewInt(number))
+	return &Block{rawBlock}, err
 }
 
 // GetHeaderByHash returns the block header with the given hash.
-func (ec *EthereumClient) GetHeaderByHash(ctx *Context, hash *Hash) (*Header, error) {
-	header, err := ec.client.HeaderByHash(ctx.context, hash.hash)
-	return &Header{header}, err
+func (ec *EthereumClient) GetHeaderByHash(ctx *Context, hash *Hash) (header *Header, _ error) {
+	rawHeader, err := ec.client.HeaderByHash(ctx.context, hash.hash)
+	return &Header{rawHeader}, err
 }
 
 // GetHeaderByNumber returns a block header from the current canonical chain. If number is <0,
 // the latest known header is returned.
-func (ec *EthereumClient) GetHeaderByNumber(ctx *Context, number int64) (*Header, error) {
+func (ec *EthereumClient) GetHeaderByNumber(ctx *Context, number int64) (header *Header, _ error) {
 	if number < 0 {
-		header, err := ec.client.HeaderByNumber(ctx.context, nil)
-		return &Header{header}, err
+		rawHeader, err := ec.client.HeaderByNumber(ctx.context, nil)
+		return &Header{rawHeader}, err
 	}
-	header, err := ec.client.HeaderByNumber(ctx.context, big.NewInt(number))
-	return &Header{header}, err
+	rawHeader, err := ec.client.HeaderByNumber(ctx.context, big.NewInt(number))
+	return &Header{rawHeader}, err
 }
 
 // GetTransactionByHash returns the transaction with the given hash.
-func (ec *EthereumClient) GetTransactionByHash(ctx *Context, hash *Hash) (*Transaction, error) {
+func (ec *EthereumClient) GetTransactionByHash(ctx *Context, hash *Hash) (tx *Transaction, _ error) {
 	// TODO(karalabe): handle isPending
-	tx, _, err := ec.client.TransactionByHash(ctx.context, hash.hash)
-	return &Transaction{tx}, err
+	rawTx, _, err := ec.client.TransactionByHash(ctx.context, hash.hash)
+	return &Transaction{rawTx}, err
 }
 
 // GetTransactionCount returns the total number of transactions in the given block.
-func (ec *EthereumClient) GetTransactionCount(ctx *Context, hash *Hash) (int, error) {
-	count, err := ec.client.TransactionCount(ctx.context, hash.hash)
-	return int(count), err
+func (ec *EthereumClient) GetTransactionCount(ctx *Context, hash *Hash) (count int, _ error) {
+	rawCount, err := ec.client.TransactionCount(ctx.context, hash.hash)
+	return int(rawCount), err
 }
 
 // GetTransactionInBlock returns a single transaction at index in the given block.
-func (ec *EthereumClient) GetTransactionInBlock(ctx *Context, hash *Hash, index int) (*Transaction, error) {
-	tx, err := ec.client.TransactionInBlock(ctx.context, hash.hash, uint(index))
-	return &Transaction{tx}, err
+func (ec *EthereumClient) GetTransactionInBlock(ctx *Context, hash *Hash, index int) (tx *Transaction, _ error) {
+	rawTx, err := ec.client.TransactionInBlock(ctx.context, hash.hash, uint(index))
+	return &Transaction{rawTx}, err
 
 }
 
 // GetTransactionReceipt returns the receipt of a transaction by transaction hash.
 // Note that the receipt is not available for pending transactions.
-func (ec *EthereumClient) GetTransactionReceipt(ctx *Context, hash *Hash) (*Receipt, error) {
-	receipt, err := ec.client.TransactionReceipt(ctx.context, hash.hash)
-	return &Receipt{receipt}, err
+func (ec *EthereumClient) GetTransactionReceipt(ctx *Context, hash *Hash) (receipt *Receipt, _ error) {
+	rawReceipt, err := ec.client.TransactionReceipt(ctx.context, hash.hash)
+	return &Receipt{rawReceipt}, err
 }
 
 // SyncProgress retrieves the current progress of the sync algorithm. If there's
 // no sync currently running, it returns nil.
-func (ec *EthereumClient) SyncProgress(ctx *Context) (*SyncProgress, error) {
-	progress, err := ec.client.SyncProgress(ctx.context)
-	if progress == nil {
+func (ec *EthereumClient) SyncProgress(ctx *Context) (progress *SyncProgress, _ error) {
+	rawProgress, err := ec.client.SyncProgress(ctx.context)
+	if rawProgress == nil {
 		return nil, err
 	}
-	return &SyncProgress{*progress}, err
+	return &SyncProgress{*rawProgress}, err
 }
 
 // NewHeadHandler is a client-side subscription callback to invoke on events and
@@ -117,10 +117,10 @@ type NewHeadHandler interface {
 
 // SubscribeNewHead subscribes to notifications about the current blockchain head
 // on the given channel.
-func (ec *EthereumClient) SubscribeNewHead(ctx *Context, handler NewHeadHandler, buffer int) (*Subscription, error) {
+func (ec *EthereumClient) SubscribeNewHead(ctx *Context, handler NewHeadHandler, buffer int) (sub *Subscription, _ error) {
 	// Subscribe to the event internally
 	ch := make(chan *types.Header, buffer)
-	sub, err := ec.client.SubscribeNewHead(ctx.context, ch)
+	rawSub, err := ec.client.SubscribeNewHead(ctx.context, ch)
 	if err != nil {
 		return nil, err
 	}
@@ -131,31 +131,31 @@ func (ec *EthereumClient) SubscribeNewHead(ctx *Context, handler NewHeadHandler,
 			case header := <-ch:
 				handler.OnNewHead(&Header{header})
 
-			case err := <-sub.Err():
+			case err := <-rawSub.Err():
 				handler.OnError(err.Error())
 				return
 			}
 		}
 	}()
-	return &Subscription{sub}, nil
+	return &Subscription{rawSub}, nil
 }
 
 // State Access
 
 // GetBalanceAt returns the wei balance of the given account.
 // The block number can be <0, in which case the balance is taken from the latest known block.
-func (ec *EthereumClient) GetBalanceAt(ctx *Context, account *Address, number int64) (*BigInt, error) {
+func (ec *EthereumClient) GetBalanceAt(ctx *Context, account *Address, number int64) (balance *BigInt, _ error) {
 	if number < 0 {
-		balance, err := ec.client.BalanceAt(ctx.context, account.address, nil)
-		return &BigInt{balance}, err
+		rawBalance, err := ec.client.BalanceAt(ctx.context, account.address, nil)
+		return &BigInt{rawBalance}, err
 	}
-	balance, err := ec.client.BalanceAt(ctx.context, account.address, big.NewInt(number))
-	return &BigInt{balance}, err
+	rawBalance, err := ec.client.BalanceAt(ctx.context, account.address, big.NewInt(number))
+	return &BigInt{rawBalance}, err
 }
 
 // GetStorageAt returns the value of key in the contract storage of the given account.
 // The block number can be <0, in which case the value is taken from the latest known block.
-func (ec *EthereumClient) GetStorageAt(ctx *Context, account *Address, key *Hash, number int64) ([]byte, error) {
+func (ec *EthereumClient) GetStorageAt(ctx *Context, account *Address, key *Hash, number int64) (storage []byte, _ error) {
 	if number < 0 {
 		return ec.client.StorageAt(ctx.context, account.address, key.hash, nil)
 	}
@@ -164,7 +164,7 @@ func (ec *EthereumClient) GetStorageAt(ctx *Context, account *Address, key *Hash
 
 // GetCodeAt returns the contract code of the given account.
 // The block number can be <0, in which case the code is taken from the latest known block.
-func (ec *EthereumClient) GetCodeAt(ctx *Context, account *Address, number int64) ([]byte, error) {
+func (ec *EthereumClient) GetCodeAt(ctx *Context, account *Address, number int64) (code []byte, _ error) {
 	if number < 0 {
 		return ec.client.CodeAt(ctx.context, account.address, nil)
 	}
@@ -173,26 +173,26 @@ func (ec *EthereumClient) GetCodeAt(ctx *Context, account *Address, number int64
 
 // GetNonceAt returns the account nonce of the given account.
 // The block number can be <0, in which case the nonce is taken from the latest known block.
-func (ec *EthereumClient) GetNonceAt(ctx *Context, account *Address, number int64) (int64, error) {
+func (ec *EthereumClient) GetNonceAt(ctx *Context, account *Address, number int64) (nonce int64, _ error) {
 	if number < 0 {
-		nonce, err := ec.client.NonceAt(ctx.context, account.address, nil)
-		return int64(nonce), err
+		rawNonce, err := ec.client.NonceAt(ctx.context, account.address, nil)
+		return int64(rawNonce), err
 	}
-	nonce, err := ec.client.NonceAt(ctx.context, account.address, big.NewInt(number))
-	return int64(nonce), err
+	rawNonce, err := ec.client.NonceAt(ctx.context, account.address, big.NewInt(number))
+	return int64(rawNonce), err
 }
 
 // Filters
 
 // FilterLogs executes a filter query.
-func (ec *EthereumClient) FilterLogs(ctx *Context, query *FilterQuery) (*Logs, error) {
-	logs, err := ec.client.FilterLogs(ctx.context, query.query)
+func (ec *EthereumClient) FilterLogs(ctx *Context, query *FilterQuery) (logs *Logs, _ error) {
+	rawLogs, err := ec.client.FilterLogs(ctx.context, query.query)
 	if err != nil {
 		return nil, err
 	}
 	// Temp hack due to vm.Logs being []*vm.Log
-	res := make(vm.Logs, len(logs))
-	for i, log := range logs {
+	res := make(vm.Logs, len(rawLogs))
+	for i, log := range rawLogs {
 		res[i] = &log
 	}
 	return &Logs{res}, nil
@@ -206,10 +206,10 @@ type FilterLogsHandler interface {
 }
 
 // SubscribeFilterLogs subscribes to the results of a streaming filter query.
-func (ec *EthereumClient) SubscribeFilterLogs(ctx *Context, query *FilterQuery, handler FilterLogsHandler, buffer int) (*Subscription, error) {
+func (ec *EthereumClient) SubscribeFilterLogs(ctx *Context, query *FilterQuery, handler FilterLogsHandler, buffer int) (sub *Subscription, _ error) {
 	// Subscribe to the event internally
 	ch := make(chan vm.Log, buffer)
-	sub, err := ec.client.SubscribeFilterLogs(ctx.context, query.query, ch)
+	rawSub, err := ec.client.SubscribeFilterLogs(ctx.context, query.query, ch)
 	if err != nil {
 		return nil, err
 	}
@@ -220,44 +220,44 @@ func (ec *EthereumClient) SubscribeFilterLogs(ctx *Context, query *FilterQuery, 
 			case log := <-ch:
 				handler.OnFilterLogs(&Log{&log})
 
-			case err := <-sub.Err():
+			case err := <-rawSub.Err():
 				handler.OnError(err.Error())
 				return
 			}
 		}
 	}()
-	return &Subscription{sub}, nil
+	return &Subscription{rawSub}, nil
 }
 
 // Pending State
 
 // GetPendingBalanceAt returns the wei balance of the given account in the pending state.
-func (ec *EthereumClient) GetPendingBalanceAt(ctx *Context, account *Address) (*BigInt, error) {
-	balance, err := ec.client.PendingBalanceAt(ctx.context, account.address)
-	return &BigInt{balance}, err
+func (ec *EthereumClient) GetPendingBalanceAt(ctx *Context, account *Address) (balance *BigInt, _ error) {
+	rawBalance, err := ec.client.PendingBalanceAt(ctx.context, account.address)
+	return &BigInt{rawBalance}, err
 }
 
 // GetPendingStorageAt returns the value of key in the contract storage of the given account in the pending state.
-func (ec *EthereumClient) GetPendingStorageAt(ctx *Context, account *Address, key *Hash) ([]byte, error) {
+func (ec *EthereumClient) GetPendingStorageAt(ctx *Context, account *Address, key *Hash) (storage []byte, _ error) {
 	return ec.client.PendingStorageAt(ctx.context, account.address, key.hash)
 }
 
 // GetPendingCodeAt returns the contract code of the given account in the pending state.
-func (ec *EthereumClient) GetPendingCodeAt(ctx *Context, account *Address) ([]byte, error) {
+func (ec *EthereumClient) GetPendingCodeAt(ctx *Context, account *Address) (code []byte, _ error) {
 	return ec.client.PendingCodeAt(ctx.context, account.address)
 }
 
 // GetPendingNonceAt returns the account nonce of the given account in the pending state.
 // This is the nonce that should be used for the next transaction.
-func (ec *EthereumClient) GetPendingNonceAt(ctx *Context, account *Address) (int64, error) {
-	nonce, err := ec.client.PendingNonceAt(ctx.context, account.address)
-	return int64(nonce), err
+func (ec *EthereumClient) GetPendingNonceAt(ctx *Context, account *Address) (nonce int64, _ error) {
+	rawNonce, err := ec.client.PendingNonceAt(ctx.context, account.address)
+	return int64(rawNonce), err
 }
 
 // GetPendingTransactionCount returns the total number of transactions in the pending state.
-func (ec *EthereumClient) GetPendingTransactionCount(ctx *Context) (int, error) {
-	count, err := ec.client.PendingTransactionCount(ctx.context)
-	return int(count), err
+func (ec *EthereumClient) GetPendingTransactionCount(ctx *Context) (count int, _ error) {
+	rawCount, err := ec.client.PendingTransactionCount(ctx.context)
+	return int(rawCount), err
 }
 
 // Contract Calling
@@ -268,7 +268,7 @@ func (ec *EthereumClient) GetPendingTransactionCount(ctx *Context) (int, error) 
 // blockNumber selects the block height at which the call runs. It can be <0, in which
 // case the code is taken from the latest known block. Note that state from very old
 // blocks might not be available.
-func (ec *EthereumClient) CallContract(ctx *Context, msg *CallMsg, number int64) ([]byte, error) {
+func (ec *EthereumClient) CallContract(ctx *Context, msg *CallMsg, number int64) (output []byte, _ error) {
 	if number < 0 {
 		return ec.client.CallContract(ctx.context, msg.msg, nil)
 	}
@@ -277,24 +277,24 @@ func (ec *EthereumClient) CallContract(ctx *Context, msg *CallMsg, number int64)
 
 // PendingCallContract executes a message call transaction using the EVM.
 // The state seen by the contract call is the pending state.
-func (ec *EthereumClient) PendingCallContract(ctx *Context, msg *CallMsg) ([]byte, error) {
+func (ec *EthereumClient) PendingCallContract(ctx *Context, msg *CallMsg) (output []byte, _ error) {
 	return ec.client.PendingCallContract(ctx.context, msg.msg)
 }
 
 // SuggestGasPrice retrieves the currently suggested gas price to allow a timely
 // execution of a transaction.
-func (ec *EthereumClient) SuggestGasPrice(ctx *Context) (*BigInt, error) {
-	price, err := ec.client.SuggestGasPrice(ctx.context)
-	return &BigInt{price}, err
+func (ec *EthereumClient) SuggestGasPrice(ctx *Context) (price *BigInt, _ error) {
+	rawPrice, err := ec.client.SuggestGasPrice(ctx.context)
+	return &BigInt{rawPrice}, err
 }
 
 // EstimateGas tries to estimate the gas needed to execute a specific transaction based on
 // the current pending state of the backend blockchain. There is no guarantee that this is
 // the true gas limit requirement as other transactions may be added or removed by miners,
 // but it should provide a basis for setting a reasonable default.
-func (ec *EthereumClient) EstimateGas(ctx *Context, msg *CallMsg) (*BigInt, error) {
-	price, err := ec.client.EstimateGas(ctx.context, msg.msg)
-	return &BigInt{price}, err
+func (ec *EthereumClient) EstimateGas(ctx *Context, msg *CallMsg) (gas *BigInt, _ error) {
+	rawGas, err := ec.client.EstimateGas(ctx.context, msg.msg)
+	return &BigInt{rawGas}, err
 }
 
 // SendTransaction injects a signed transaction into the pending pool for execution.

--- a/mobile/ethereum.go
+++ b/mobile/ethereum.go
@@ -93,7 +93,7 @@ func (t *Topics) Size() int {
 }
 
 // Get returns the topic list at the given index from the slice.
-func (t *Topics) Get(index int) (*Hashes, error) {
+func (t *Topics) Get(index int) (hashes *Hashes, _ error) {
 	if index < 0 || index >= len(t.topics) {
 		return nil, errors.New("index out of bounds")
 	}

--- a/mobile/interface.go
+++ b/mobile/interface.go
@@ -131,7 +131,7 @@ func (i *Interfaces) Size() int {
 }
 
 // Get returns the bigint at the given index from the slice.
-func (i *Interfaces) Get(index int) (*Interface, error) {
+func (i *Interfaces) Get(index int) (iface *Interface, _ error) {
 	if index < 0 || index >= len(i.objects) {
 		return nil, errors.New("index out of bounds")
 	}

--- a/mobile/p2p.go
+++ b/mobile/p2p.go
@@ -66,7 +66,7 @@ func (pi *PeerInfos) Size() int {
 }
 
 // Get returns the peer info at the given index from the slice.
-func (pi *PeerInfos) Get(index int) (*PeerInfo, error) {
+func (pi *PeerInfos) Get(index int) (info *PeerInfo, _ error) {
 	if index < 0 || index >= len(pi.infos) {
 		return nil, errors.New("index out of bounds")
 	}

--- a/mobile/primitives.go
+++ b/mobile/primitives.go
@@ -32,7 +32,7 @@ func (s *Strings) Size() int {
 }
 
 // Get returns the string at the given index from the slice.
-func (s *Strings) Get(index int) (string, error) {
+func (s *Strings) Get(index int) (str string, _ error) {
 	if index < 0 || index >= len(s.strs) {
 		return "", errors.New("index out of bounds")
 	}

--- a/mobile/types.go
+++ b/mobile/types.go
@@ -89,7 +89,7 @@ func (h *Headers) Size() int {
 }
 
 // Get returns the header at the given index from the slice.
-func (h *Headers) Get(index int) (*Header, error) {
+func (h *Headers) Get(index int) (header *Header, _ error) {
 	if index < 0 || index >= len(h.headers) {
 		return nil, errors.New("index out of bounds")
 	}
@@ -142,7 +142,7 @@ func (tx *Transaction) GetHash() *Hash    { return &Hash{tx.tx.Hash()} }
 func (tx *Transaction) GetSigHash() *Hash { return &Hash{tx.tx.SigHash(types.HomesteadSigner{})} }
 func (tx *Transaction) GetCost() *BigInt  { return &BigInt{tx.tx.Cost()} }
 
-func (tx *Transaction) GetFrom() (*Address, error) {
+func (tx *Transaction) GetFrom() (address *Address, _ error) {
 	from, err := types.Sender(types.HomesteadSigner{}, tx.tx)
 	return &Address{from}, err
 }
@@ -154,25 +154,25 @@ func (tx *Transaction) GetTo() *Address {
 	return nil
 }
 
-func (tx *Transaction) WithSignature(sig []byte) (*Transaction, error) {
-	t, err := tx.tx.WithSignature(types.HomesteadSigner{}, sig)
-	return &Transaction{t}, err
+func (tx *Transaction) WithSignature(sig []byte) (signedTx *Transaction, _ error) {
+	rawTx, err := tx.tx.WithSignature(types.HomesteadSigner{}, sig)
+	return &Transaction{rawTx}, err
 }
 
 // Transactions represents a slice of transactions.
 type Transactions struct{ txs types.Transactions }
 
 // Size returns the number of transactions in the slice.
-func (t *Transactions) Size() int {
-	return len(t.txs)
+func (txs *Transactions) Size() int {
+	return len(txs.txs)
 }
 
 // Get returns the transaction at the given index from the slice.
-func (t *Transactions) Get(index int) (*Transaction, error) {
-	if index < 0 || index >= len(t.txs) {
+func (txs *Transactions) Get(index int) (tx *Transaction, _ error) {
+	if index < 0 || index >= len(txs.txs) {
 		return nil, errors.New("index out of bounds")
 	}
-	return &Transaction{t.txs[index]}, nil
+	return &Transaction{txs.txs[index]}, nil
 }
 
 // Receipt represents the results of a transaction.

--- a/mobile/vm.go
+++ b/mobile/vm.go
@@ -48,7 +48,7 @@ func (l *Logs) Size() int {
 }
 
 // Get returns the log at the given index from the slice.
-func (l *Logs) Get(index int) (*Log, error) {
+func (l *Logs) Get(index int) (log *Log, _ error) {
 	if index < 0 || index >= len(l.logs) {
 		return nil, errors.New("index out of bounds")
 	}


### PR DESCRIPTION
~~**Update: There's a fresh PR pending on `gomobile` that will enable support for empty prefixes. Let's wait a bit to see it that gets merged in: https://go-review.googlesource.com/#/c/33954/**~~

This PR uses a new namespace prefix for our iOS package that is a bit less ugly from an outside perspective (e.g. `GEGeth -> iGeth`). Unfortunately due to `gomobile` limitations the package name `Geth` cannot be dropped, and there must be a prefix in front of it in addition. The name `Geth` is not changeable as that would break Android, which is again a limitation of `gomobile` (so we can't do `GoEthereum`) :P

Beside the prefixing, this PR contains a batch of refactors that assigns names to all return values (in the case of multiple returns) as those are generated as output arguments in ObjC, which in turn need explicit naming in Swift, so unnamed returns will cause Swift code to fill up with `ret_0`.