### PR TITLE
Miner race fixes

### DIFF
--- a/miner/worker.go
+++ b/miner/worker.go
@@ -161,6 +161,12 @@ func (self *worker) setEtherbase(addr common.Address) {
 	self.coinbase = addr
 }
 
+func (self *worker) setExtra(extra []byte) {
+	self.mu.Lock()
+	defer self.mu.Unlock()
+	self.extra = extra
+}
+
 func (self *worker) pending() (*types.Block, *state.StateDB) {
 	self.currentMu.Lock()
 	defer self.currentMu.Unlock()


### PR DESCRIPTION
This PR fixes two data races in the miner:

 - The first is in the remote agent, where one part of the code constantly recreated the `quit` and `work` channels, whilst another part kept accessing them in a select. For now I sorted it out by removing the variable accesses from the second part and passed the channels as parameters. Possibly a whole rewrite would be welcome on this part as recreating channels concurrently is a very bad juju.
 - The second was in the miner code which directly set the `etherbase` and `extra`-data fields of the worker, even though the worker might have been still alive with a previous run. The following code makes sure the fields are set using accessor methods with proper locking. 