### PR TITLE
p2p/discover, p2p/discv5: use flexible comparison for IPs

### DIFF
--- a/p2p/discover/udp_test.go
+++ b/p2p/discover/udp_test.go
@@ -374,7 +374,7 @@ func TestUDP_successfulPing(t *testing.T) {
 		if n.ID != rid {
 			t.Errorf("node has wrong ID: got %v, want %v", n.ID, rid)
 		}
-		if !bytes.Equal(n.IP, test.remoteaddr.IP) {
+		if !n.IP.Equal(test.remoteaddr.IP) {
 			t.Errorf("node has wrong IP: got %v, want: %v", n.IP, test.remoteaddr.IP)
 		}
 		if int(n.UDP) != test.remoteaddr.Port {

--- a/p2p/discv5/net.go
+++ b/p2p/discv5/net.go
@@ -759,7 +759,7 @@ func (net *Network) internNodeFromNeighbours(sender *net.UDPAddr, rn rpcNode) (n
 		}
 		return n, err
 	}
-	if !bytes.Equal(n.IP, rn.IP) || n.UDP != rn.UDP || n.TCP != rn.TCP {
+	if !n.IP.Equal(rn.IP) || n.UDP != rn.UDP || n.TCP != rn.TCP {
 		err = fmt.Errorf("metadata mismatch: got %v, want %v", rn, n)
 	}
 	return n, err

--- a/p2p/discv5/node.go
+++ b/p2p/discv5/node.go
@@ -17,7 +17,6 @@
 package discv5
 
 import (
-	"bytes"
 	"crypto/ecdsa"
 	"crypto/elliptic"
 	"encoding/hex"
@@ -81,7 +80,7 @@ func (n *Node) addrEqual(a *net.UDPAddr) bool {
 	if ipv4 := a.IP.To4(); ipv4 != nil {
 		ip = ipv4
 	}
-	return n.UDP == uint16(a.Port) && bytes.Equal(n.IP, ip)
+	return n.UDP == uint16(a.Port) && n.IP.Equal(ip)
 }
 
 // Incomplete returns true for nodes with no IP address.

--- a/p2p/discv5/udp.go
+++ b/p2p/discv5/udp.go
@@ -196,7 +196,7 @@ func makeEndpoint(addr *net.UDPAddr, tcpPort uint16) rpcEndpoint {
 }
 
 func (e1 rpcEndpoint) equal(e2 rpcEndpoint) bool {
-	return e1.UDP == e2.UDP && e1.TCP == e2.TCP && bytes.Equal(e1.IP, e2.IP)
+	return e1.UDP == e2.UDP && e1.TCP == e2.TCP && e1.IP.Equal(e2.IP)
 }
 
 func nodeFromRPC(sender *net.UDPAddr, rn rpcNode) (*Node, error) {


### PR DESCRIPTION
The v5 discovery protocol used `bytes.Equal` to compare to `net.IP` variables. That will often produce bad results because Go may store an IPv4 both as a `[4]byte` as well as a zero prefixed `[16]byte`

https://golang.org/pkg/net/#IP :

> An IP is a single IP address, a slice of bytes. Functions in this package accept either 4-byte (IPv4) or 16-byte (IPv6) slices as input.
>
> Note that in this documentation, referring to an IP address as an IPv4 address or an IPv6 address is a semantic property of the address, not just the length of the byte slice: **a 16-byte slice can still be an IPv4 address.**

This PR changes IP comparisons from `bytes.Equal` to the proper `net.IP.Equal` invocation. Please make sure I didn't do anything wrong (e.g that I didn't introduce a possibility for a nil panic)