### PR TITLE
internal/ethapi: fix all signatures input being the same when message is not hex

### DIFF
--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -292,9 +292,12 @@ func (s *PrivateAccountAPI) SendTransaction(ctx context.Context, args SendTxArgs
 // safely used to calculate a signature from. The hash is calulcated with:
 // keccak256("\x19Ethereum Signed Message:\n"${message length}${message}).
 func signHash(message string) []byte {
-	data := common.FromHex(message)
 	// Give context to the signed message. This prevents an adversery to sign a tx.
 	// It has no cryptographic purpose.
+	data := common.FromHex(message)
+	if len(data) == 0 {
+		data = []byte(message)
+	}
 	msg := fmt.Sprintf("\x19Ethereum Signed Message:\n%d%s", len(data), data)
 	// Always hash, this prevents choosen plaintext attacks that can extract key information
 	return crypto.Keccak256([]byte(msg))


### PR DESCRIPTION
In https://github.com/ethereum/go-ethereum/pull/2940 `personal_sign` and `personal_ecRecover` were introduced and now arbitrary strings can be sent as the argument instead of the keccak256 hash, as `eth_sign` worked before.

The problem is that when `common.FromHex(s)` is called with a non-hex string as a parameter, the function will return an empty byte array. With the current implementation of `signHash` this causes `data` to be empty, and therefore the payload that is signed to always be the same (`"\x19Ethereum Signed Message:\n0"`) for every non-hex message. 

This is quite bad because every signature from a given key will match if it is not hex (it always signs the same payload). This change will produce breaking changes to all non-hex signatures created since it was introduced (v1.5.2)

I decided to solve the problem inside the problematic function to keep it contained, but maybe just making `common.FromHex(s)` return the input string bytes if it fails to decode a hex string would be better, but I'm not sure of the side effects given it is used in lots of different parts.