### PR TITLE
core: allow zero priced transactions from inexistent accounts too

### DIFF
--- a/core/tx_pool.go
+++ b/core/tx_pool.go
@@ -37,15 +37,14 @@ import (
 
 var (
 	// Transaction Pool Errors
-	ErrInvalidSender      = errors.New("Invalid sender")
-	ErrNonce              = errors.New("Nonce too low")
-	ErrCheap              = errors.New("Gas price too low for acceptance")
-	ErrBalance            = errors.New("Insufficient balance")
-	ErrNonExistentAccount = errors.New("Account does not exist or account balance too low")
-	ErrInsufficientFunds  = errors.New("Insufficient funds for gas * price + value")
-	ErrIntrinsicGas       = errors.New("Intrinsic gas too low")
-	ErrGasLimit           = errors.New("Exceeds block gas limit")
-	ErrNegativeValue      = errors.New("Negative value")
+	ErrInvalidSender     = errors.New("Invalid sender")
+	ErrNonce             = errors.New("Nonce too low")
+	ErrCheap             = errors.New("Gas price too low for acceptance")
+	ErrBalance           = errors.New("Insufficient balance")
+	ErrInsufficientFunds = errors.New("Insufficient funds for gas * price + value")
+	ErrIntrinsicGas      = errors.New("Intrinsic gas too low")
+	ErrGasLimit          = errors.New("Exceeds block gas limit")
+	ErrNegativeValue     = errors.New("Negative value")
 )
 
 var (
@@ -287,13 +286,6 @@ func (pool *TxPool) validateTx(tx *types.Transaction) error {
 	if err != nil {
 		return ErrInvalidSender
 	}
-
-	// Make sure the account exist. Non existent accounts
-	// haven't got funds and well therefor never pass.
-	if !currentState.Exist(from) {
-		return ErrNonExistentAccount
-	}
-
 	// Last but not least check for nonce errors
 	if currentState.GetNonce(from) > tx.Nonce() {
 		return ErrNonce

--- a/core/tx_pool_test.go
+++ b/core/tx_pool_test.go
@@ -129,10 +129,6 @@ func TestInvalidTransactions(t *testing.T) {
 	pool, key := setupTxPool()
 
 	tx := transaction(0, big.NewInt(100), key)
-	if err := pool.Add(tx); err != ErrNonExistentAccount {
-		t.Error("expected", ErrNonExistentAccount)
-	}
-
 	from, _ := deriveSender(tx)
 	currentState, _ := pool.currentState()
 	currentState.AddBalance(from, big.NewInt(1))

--- a/light/txpool.go
+++ b/light/txpool.go
@@ -346,19 +346,8 @@ func (pool *TxPool) validateTx(ctx context.Context, tx *types.Transaction) error
 	if from, err = types.Sender(pool.signer, tx); err != nil {
 		return core.ErrInvalidSender
 	}
-
-	// Make sure the account exist. Non existent accounts
-	// haven't got funds and well therefor never pass.
-	currentState := pool.currentState()
-	if h, err := currentState.HasAccount(ctx, from); err == nil {
-		if !h {
-			return core.ErrNonExistentAccount
-		}
-	} else {
-		return err
-	}
-
 	// Last but not least check for nonce errors
+	currentState := pool.currentState()
 	if n, err := currentState.GetNonce(ctx, from); err == nil {
 		if n > tx.Nonce() {
 			return core.ErrNonce


### PR DESCRIPTION
The transaction pool currently may be configured to accept zero gas-priced transactions if configured to do so (may also be via simply initiating one from a local account). However, the transaction validation had a check that verified if the account existed at all. This extra check is not really needed since the balance check below it ensures that there's enough balance anyway (so empty accounts will fail anyway). However the check did drop legitimate transactions from legitimately empty accounts that should still be nonetheless runnable if the gasprice is zero.

This PR drops the notion of account existence check is the transaction pool and rather relies on the balance check to catch this same error.