### PR TITLE
swarm/api: check for zero length manifest error

### DIFF
--- a/swarm/api/manifest.go
+++ b/swarm/api/manifest.go
@@ -62,6 +62,11 @@ func readManifest(manifestReader storage.LazySectionReader, hash storage.Key, dp
 
 	// TODO check size for oversized manifests
 	size, err := manifestReader.Size(quitC)
+	if err != nil { // size == 0
+		// can't determine size means we don't have the root chunk
+		err = fmt.Errorf("Manifest not Found")
+		return
+	}
 	manifestData := make([]byte, size)
 	read, err := manifestReader.Read(manifestData)
 	if int64(read) < size {


### PR DESCRIPTION
This fixes the "Unexpected end of JSON input" error message described here: https://github.com/ethereum/go-ethereum/issues/3307

Essentially, when the manifest size cannot be determined (because the root chunk cannot be retrieved), the size is reported as zero and an error is returned.
The code did not check the error and just proceeded with a zero-length manifest. This caused an error later on during JSON unmarshalling. 

This PR checks the error value returned when checking the manifest size.