### PR TITLE
swarm/storage: call size before seek-from-end

### DIFF
--- a/swarm/storage/chunker.go
+++ b/swarm/storage/chunker.go
@@ -483,8 +483,11 @@ func (s *LazyChunkReader) Seek(offset int64, whence int) (int64, error) {
 	case 1:
 		offset += s.off
 	case 2:
-		if s.chunk == nil {
-			return 0, fmt.Errorf("seek from the end requires rootchunk for size. call Size first")
+		if s.chunk == nil { //seek from the end requires rootchunk for size. call Size first
+			_, err := s.Size(nil)
+			if err != nil {
+				return 0, fmt.Errorf("can't get size: %v", err)
+			}
 		}
 		offset += s.chunk.Size
 	}


### PR DESCRIPTION
In order to seek from the end of a file, we need to know its size. 

Instead of returning the error "seek from the end requires rootchunk for size. call Size first", this PR changes the Seek function to do just that -- to call Size first.

This relates to (but does not completely solve) the "seeker can't seek" errors described here: https://github.com/ethereum/go-ethereum/issues/3307

It should be noted here that the swarm http server does actually call size first, only it does not check the returned value for errors. That will be fixed in a different PR.