### PR TITLE
mobile: fix ropsten chain configs

### DIFF
--- a/mobile/params.go
+++ b/mobile/params.go
@@ -50,7 +50,7 @@ func TestnetChainConfig() *ChainConfig {
 		ChainID:        params.TestNetChainID.Int64(),
 		HomesteadBlock: params.TestNetHomesteadBlock.Int64(),
 		DAOForkBlock:   0,
-		DAOForkSupport: true,
+		DAOForkSupport: false,
 		EIP150Block:    params.TestNetHomesteadGasRepriceBlock.Int64(),
 		EIP150Hash:     Hash{params.TestNetHomesteadGasRepriceHash},
 		EIP155Block:    params.TestNetSpuriousDragon.Int64(),


### PR DESCRIPTION
Our `ChainConfig` use `nil` for the `DaoForkBlock` to signal that there's no notion of DAO for on the testnet. To simplify things mobile side however the block number in `ChainConfig` are `uint64`, defaulting to `0`. This cause the DAO fork to actually be set on the Ropsten testnet on Android. This PR explicitly disables the DAO fork logic.