### PR TITLE
eth, internal, les: don't allow nils as non-error values

### DIFF
--- a/les/api_backend.go
+++ b/les/api_backend.go
@@ -59,7 +59,6 @@ func (b *LesApiBackend) HeaderByNumber(ctx context.Context, blockNr rpc.BlockNum
 	if blockNr == rpc.LatestBlockNumber || blockNr == rpc.PendingBlockNumber {
 		return b.eth.blockchain.CurrentHeader(), nil
 	}
-
 	return b.eth.blockchain.GetHeaderByNumberOdr(ctx, uint64(blockNr))
 }
 
@@ -73,7 +72,7 @@ func (b *LesApiBackend) BlockByNumber(ctx context.Context, blockNr rpc.BlockNumb
 
 func (b *LesApiBackend) StateAndHeaderByNumber(ctx context.Context, blockNr rpc.BlockNumber) (*state.StateDB, *types.Header, error) {
 	header, err := b.HeaderByNumber(ctx, blockNr)
-	if header == nil || err != nil {
+	if err != nil {
 		return nil, nil, err
 	}
 	return light.NewState(ctx, header, b.eth.odr), header, nil

--- a/les/api_backend.go
+++ b/les/api_backend.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"math/big"
 
+	ethereum "github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/accounts"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/math"
@@ -74,6 +75,9 @@ func (b *LesApiBackend) StateAndHeaderByNumber(ctx context.Context, blockNr rpc.
 	header, err := b.HeaderByNumber(ctx, blockNr)
 	if err != nil {
 		return nil, nil, err
+	}
+	if header == nil {
+		return nil, nil, ethereum.NotFound
 	}
 	return light.NewState(ctx, header, b.eth.odr), header, nil
 }


### PR DESCRIPTION
Fixes https://github.com/ethereum/go-ethereum/issues/3483

This PR does two things:

 * It fixes an issue with header/block lookups on the `eth` API, where retrieving something that did not exist didn't result in an error message, rather a success + a `nil` being returned instread. This caused weird API responses to be sent back.
 * Secondly it removes all the weird `result == nil` checks that some parts of our API code did, which was actually masking instead of solving the lack of the error message above, causing this issue to bubble up to the user instead of failing inside geth (and arguably crashing it, but we would have notived the problem nonetheless).