### PR TITLE
swarm: trouble loading manifest entries whose key ends in a slash '/'…

### DIFF
--- a/swarm/api/manifest.go
+++ b/swarm/api/manifest.go
@@ -333,7 +333,7 @@ func RegularSlashes(path string) (res string) {
 }
 
 func (self *manifestTrie) getEntry(spath string) (entry *manifestTrieEntry, fullpath string) {
-	path := RegularSlashes(spath)
+	path := RegularSlashes(spath) + "/"
 	var pos int
 	quitC := make(chan bool)
 	entry, pos = self.findPrefixOf(path, quitC)


### PR DESCRIPTION
After this fix the code is entering the right function... but even after a night of sync i get "root chunk not found for 0000000000000000000000000000000000000000000000000000000000000000" if i do a "http://localhost:8500/bzzr:/81a7cbc7fa2467e3a4efd0c9f590f5c4c1abaf396e50bb3bd0ca7e4aba7f22de/js/?content_type=text/plain"... 
Instead i should get "Manifest entry for ' ' not found"  :-) Need to check though