### PR TITLE
swarm: trouble loading manifest entries whose key ends in a slash '/'…

### DIFF
--- a/swarm/api/manifest.go
+++ b/swarm/api/manifest.go
@@ -333,7 +333,7 @@ func RegularSlashes(path string) (res string) {
 }
 
 func (self *manifestTrie) getEntry(spath string) (entry *manifestTrieEntry, fullpath string) {
-	path := RegularSlashes(spath)
+	path := RegularSlashes(spath) + "/"
 	var pos int
 	quitC := make(chan bool)
 	entry, pos = self.findPrefixOf(path, quitC)


### PR DESCRIPTION
fixes #3467 

after this fix i am getting 
 "root chunk not found for 0000000000000000000000000000000000000000000000000000000000000000"
instead of the usual "manifest for the entry 'js' not found" 