### PR TITLE
cmd/utils, eth, les: bubble --fakepow flag into eth/les too

### DIFF
--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -749,6 +749,7 @@ func RegisterEthService(ctx *cli.Context, stack *node.Node, extra []byte) {
 		GpobaseCorrectionFactor: ctx.GlobalInt(GpobaseCorrectionFactorFlag.Name),
 		SolcPath:                ctx.GlobalString(SolcPathFlag.Name),
 		AutoDAG:                 ctx.GlobalBool(AutoDAGFlag.Name) || ctx.GlobalBool(MiningEnabledFlag.Name),
+		PowFake:                 ctx.GlobalBool(FakePoWFlag.Name),
 	}
 
 	// Override any default configs in dev mode or the test net

--- a/les/backend.go
+++ b/les/backend.go
@@ -22,7 +22,6 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/ethereum/ethash"
 	"github.com/ethereum/go-ethereum/accounts"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/compiler"
@@ -42,6 +41,7 @@ import (
 	"github.com/ethereum/go-ethereum/node"
 	"github.com/ethereum/go-ethereum/p2p"
 	"github.com/ethereum/go-ethereum/params"
+	"github.com/ethereum/go-ethereum/pow"
 	rpc "github.com/ethereum/go-ethereum/rpc"
 )
 
@@ -61,13 +61,12 @@ type LightEthereum struct {
 	ApiBackend *LesApiBackend
 
 	eventMux       *event.TypeMux
-	pow            *ethash.Ethash
+	pow            pow.PoW
 	accountManager *accounts.Manager
 	solcPath       string
 	solc           *compiler.Solidity
 
 	NatSpec       bool
-	PowTest       bool
 	netVersionId  int
 	netRPCService *ethapi.PublicNetAPI
 }
@@ -97,7 +96,6 @@ func New(ctx *node.ServiceContext, config *eth.Config) (*LightEthereum, error) {
 		shutdownChan:   make(chan bool),
 		netVersionId:   config.NetworkId,
 		NatSpec:        config.NatSpec,
-		PowTest:        config.PowTest,
 		solcPath:       config.SolcPath,
 	}
 


### PR DESCRIPTION
A while ago we've introduced the `--fakepow` flag, which disabled proof-of-work checks when importing chains from exported dumps. This was nice as it allowed faster benchmarking and testing without waiting for PoW validations, which in these scenarios weren't needed anyway.

This PR takes this a step further by also bubbling up the `--fakepow` flag into the `eth` and `les` packages, allowing the same PoW disabling during live syncs too. This of course is still a debugging/development/benchmark feature, but it may be useful when testing live syncs without having a multi-gb chain dump lying around, for example when running a pre-release live test sync on a VM.