### PR TITLE
build: finally settle on empty iOS ObjC package prefixes

### DIFF
--- a/build/ci.go
+++ b/build/ci.go
@@ -792,7 +792,7 @@ func doXCodeFramework(cmdline []string) {
 	// Build the iOS XCode framework
 	build.MustRun(goTool("get", "golang.org/x/mobile/cmd/gomobile"))
 	build.MustRun(gomobileTool("init"))
-	bind := gomobileTool("bind", "--target", "ios", "--tags", "ios", "--prefix", "i", "-v", "github.com/ethereum/go-ethereum/mobile")
+	bind := gomobileTool("bind", "--target", "ios", "--tags", "ios", "-v", "github.com/ethereum/go-ethereum/mobile")
 
 	if *local {
 		// If we're building locally, use the build folder and stop afterwards


### PR DESCRIPTION
This was something we wanted to do for a long time but depended on a few upstream patches for gomobile (notably https://go-review.googlesource.com/#/c/33954/ and https://go-review.googlesource.com/#/c/34643/ ). This PR finally drops all package prefixes on iOS, letting us write code using only `Geth` as type and function prefixes instead of the `GoGeth` or `iGeth` in a later iteration.