### PR TITLE
mobile: rename passphrase signing method to avoid Swift rewrite

### DIFF
--- a/mobile/accounts.go
+++ b/mobile/accounts.go
@@ -115,10 +115,10 @@ func (am *AccountManager) Sign(address *Address, hash []byte) (signature []byte,
 	return am.manager.Sign(address.address, hash)
 }
 
-// SignWithPassphrase signs hash if the private key matching the given address
-// can be decrypted with the given passphrase. The produced signature is in the
+// SignPassphrase signs hash if the private key matching the given address can
+// be decrypted with the given passphrase. The produced signature is in the
 // [R || S || V] format where V is 0 or 1.
-func (am *AccountManager) SignWithPassphrase(account *Account, passphrase string, hash []byte) (signature []byte, _ error) {
+func (am *AccountManager) SignPassphrase(account *Account, passphrase string, hash []byte) (signature []byte, _ error) {
 	return am.manager.SignWithPassphrase(account.account, passphrase, hash)
 }
 

--- a/mobile/android_test.go
+++ b/mobile/android_test.go
@@ -69,7 +69,7 @@ public class AndroidTest extends InstrumentationTestCase {
 			Hash txHash = new Hash("0x0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef");
 
 			// Sign a transaction with a single authorization
-			byte[] signature = am.signWithPassphrase(signer, "Signer password", txHash.getBytes());
+			byte[] signature = am.signPassphrase(signer, "Signer password", txHash.getBytes());
 
 			// Sign a transaction with multiple manually cancelled authorizations
 			am.unlock(signer, "Signer password");


### PR DESCRIPTION
Unfuckup Swift 3 rewrites :P