### PR TITLE
cmd/evm: added debug flag (back)

### DIFF
--- a/cmd/evm/main.go
+++ b/cmd/evm/main.go
@@ -161,7 +161,7 @@ func run(ctx *cli.Context) error {
 			Value:    common.Big(ctx.GlobalString(ValueFlag.Name)),
 			EVMConfig: vm.Config{
 				Tracer:             logger,
-				Debug: ctx.GlobalBool(DebugFlag.Name),
+				Debug:              ctx.GlobalBool(DebugFlag.Name),
 				DisableGasMetering: ctx.GlobalBool(DisableGasMeteringFlag.Name),
 			},
 		})
@@ -177,7 +177,7 @@ func run(ctx *cli.Context) error {
 			Value:    common.Big(ctx.GlobalString(ValueFlag.Name)),
 			EVMConfig: vm.Config{
 				Tracer:             logger,
-				Debug: ctx.GlobalBool(DebugFlag.Name),
+				Debug:              ctx.GlobalBool(DebugFlag.Name),
 				DisableGasMetering: ctx.GlobalBool(DisableGasMeteringFlag.Name),
 			},
 		})

--- a/cmd/evm/main.go
+++ b/cmd/evm/main.go
@@ -161,6 +161,7 @@ func run(ctx *cli.Context) error {
 			Value:    common.Big(ctx.GlobalString(ValueFlag.Name)),
 			EVMConfig: vm.Config{
 				Tracer:             logger,
+				Debug: ctx.GlobalBool(DebugFlag.Name),
 				DisableGasMetering: ctx.GlobalBool(DisableGasMeteringFlag.Name),
 			},
 		})
@@ -176,6 +177,7 @@ func run(ctx *cli.Context) error {
 			Value:    common.Big(ctx.GlobalString(ValueFlag.Name)),
 			EVMConfig: vm.Config{
 				Tracer:             logger,
+				Debug: ctx.GlobalBool(DebugFlag.Name),
 				DisableGasMetering: ctx.GlobalBool(DisableGasMeteringFlag.Name),
 			},
 		})


### PR DESCRIPTION
For some reason, the debug functionality in `evm` did not work. I added back the debug directive. 