### PR TITLE
travis, appveyor, build: add source spell checking

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -90,7 +90,7 @@ install:
   - go get golang.org/x/tools/cmd/cover
 script:
   - go run build/ci.go install
-  - go run build/ci.go test -coverage -vet
+  - go run build/ci.go test -coverage -vet -misspell
 
 notifications:
   webhooks:

--- a/accounts/abi/type.go
+++ b/accounts/abi/type.go
@@ -91,7 +91,7 @@ func NewType(t string) (typ Type, err error) {
 		}
 		typ.Elem = &sliceType
 		typ.stringKind = sliceType.stringKind + t[len(res[1]):]
-		// Altough we know that this is an array, we cannot return
+		// Although we know that this is an array, we cannot return
 		// as we don't know the type of the element, however, if it
 		// is still an array, then don't determine the type.
 		if typ.Elem.IsArray || typ.Elem.IsSlice {

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -36,4 +36,4 @@ after_build:
 
 test_script:
   - set CGO_ENABLED=1
-  - go run build\ci.go test -vet -coverage
+  - go run build\ci.go test -vet -coverage -misspell

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -36,4 +36,4 @@ after_build:
 
 test_script:
   - set CGO_ENABLED=1
-  - go run build\ci.go test -vet -coverage -misspell
+  - go run build\ci.go test -vet -coverage


### PR DESCRIPTION
Misspelled stuff in docs is annoying, looks bad and lowers the code quality. However once in the repo, even if a dev notices a typo later, the whole fix-commit-push-pr-review-merge fiasco is too long winded to actually get anyone to fix them. This results in the typos staying in our code for a long time, until someone actually does a spell check run and fixes everything. Then 1 commit later a new typo gets added.

This PR enforces the spell checker on our CI build step, ensuring that everyone corrects his own spelling errors and that they don't end up in the repo, adding tech debt and wasting someone else's time to clean it up later.