### PR TITLE
les: fixed transaction sending deadlock

### DIFF
--- a/les/txrelay.go
+++ b/les/txrelay.go
@@ -110,7 +110,6 @@ func (self *LesTxRelay) send(txs types.Transactions, count int) {
 	for p, list := range sendTo {
 		cost := p.GetRequestCost(SendTxMsg, len(list))
 		go func(p *peer, list types.Transactions, cost uint64) {
-			p.fcServer.SendRequest(0, cost)
 			p.SendTxs(cost, list)
 		}(p, list, cost)
 	}


### PR DESCRIPTION
This PR fixes https://github.com/ethereum/go-ethereum/issues/3562 by removing a single line that was left there by accident (just didn't cause any trouble until request assignments were introduced).