### PR TITLE
common/hexutil: fix EncodeBig, Big.MarshalJSON

### DIFF
--- a/common/hexutil/hexutil.go
+++ b/common/hexutil/hexutil.go
@@ -169,12 +169,7 @@ func EncodeBig(bigint *big.Int) string {
 	if nbits == 0 {
 		return "0x0"
 	}
-	enc := make([]byte, 2, (nbits/8)*2+2)
-	copy(enc, "0x")
-	for i := len(bigint.Bits()) - 1; i >= 0; i-- {
-		enc = strconv.AppendUint(enc, uint64(bigint.Bits()[i]), 16)
-	}
-	return string(enc)
+	return fmt.Sprintf("0x%x", bigint)
 }
 
 func has0xPrefix(input string) bool {

--- a/common/hexutil/hexutil_test.go
+++ b/common/hexutil/hexutil_test.go
@@ -46,6 +46,7 @@ var (
 		{referenceBig("1"), "0x1"},
 		{referenceBig("ff"), "0xff"},
 		{referenceBig("112233445566778899aabbccddeeff"), "0x112233445566778899aabbccddeeff"},
+		{referenceBig("80a7f2c1bcc396c00"), "0x80a7f2c1bcc396c00"},
 	}
 
 	encodeUint64Tests = []marshalTest{

--- a/common/hexutil/json.go
+++ b/common/hexutil/json.go
@@ -109,13 +109,8 @@ func (b *Big) MarshalJSON() ([]byte, error) {
 	if nbits == 0 {
 		return jsonZero, nil
 	}
-	enc := make([]byte, 3, (nbits/8)*2+4)
-	copy(enc, `"0x`)
-	for i := len(bigint.Bits()) - 1; i >= 0; i-- {
-		enc = strconv.AppendUint(enc, uint64(bigint.Bits()[i]), 16)
-	}
-	enc = append(enc, '"')
-	return enc, nil
+	enc := fmt.Sprintf(`"0x%x"`, bigint)
+	return []byte(enc), nil
 }
 
 // UnmarshalJSON implements json.Unmarshaler.


### PR DESCRIPTION
The code was too clever and failed to include zeros on a big.Word boundary.