### PR TITLE
core/blockchain: Made logging of reorgs more structured

### DIFF
--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -1082,8 +1082,6 @@ func (self *BlockChain) reorg(oldBlock, newBlock *types.Block) error {
 		newChain    types.Blocks
 		oldChain    types.Blocks
 		commonBlock *types.Block
-		oldStart    = oldBlock
-		newStart    = newBlock
 		deletedTxs  types.Transactions
 		deletedLogs []*types.Log
 		// collectLogs collects the logs that were generated during the
@@ -1124,7 +1122,6 @@ func (self *BlockChain) reorg(oldBlock, newBlock *types.Block) error {
 		return fmt.Errorf("Invalid new chain")
 	}
 
-	numSplit := newBlock.Number()
 	for {
 		if oldBlock.Hash() == newBlock.Hash() {
 			commonBlock = oldBlock
@@ -1145,9 +1142,24 @@ func (self *BlockChain) reorg(oldBlock, newBlock *types.Block) error {
 		}
 	}
 
-	if glog.V(logger.Debug) {
+	oldLen := len(oldChain)
+
+	if glog.V(logger.Debug)  || oldLen > 63 {
 		commonHash := commonBlock.Hash()
-		glog.Infof("Chain split detected @ %x. Reorganising chain from #%v %x to %x", commonHash[:4], numSplit, oldStart.Hash().Bytes()[:4], newStart.Hash().Bytes()[:4])
+		commonNumber := commonBlock.Number()
+		newLen := len(newChain)
+
+		newLast   := newChain[0]
+		newFirst  := newChain[newLen-1]
+		oldLast   := oldChain[0]
+		oldFirst  := oldChain[oldLen-1]
+		glog.Infof("Chain split detected after #%v [%x…]. Reorganising chain (-%v +%v blocks) from #%v-#%v [%x/%x] in favour of #%v-#%v [%x/%x]", 
+				commonNumber, commonHash[:4], 
+				oldLen, newLen,
+				oldFirst.Number(),oldLast.Number(),
+				oldFirst.Hash().Bytes()[:4] ,oldLast.Hash().Bytes()[:4], 
+				newFirst.Number(),newLast.Number(),
+				newFirst.Hash().Bytes()[:4], newLast.Hash().Bytes()[:4])
 	}
 
 	var addedTxs types.Transactions

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -1144,22 +1144,22 @@ func (self *BlockChain) reorg(oldBlock, newBlock *types.Block) error {
 
 	oldLen := len(oldChain)
 
-	if glog.V(logger.Debug)  || oldLen > 63 {
+	if glog.V(logger.Debug) || oldLen > 63 {
 		commonHash := commonBlock.Hash()
 		commonNumber := commonBlock.Number()
 		newLen := len(newChain)
 
-		newLast   := newChain[0]
-		newFirst  := newChain[newLen-1]
-		oldLast   := oldChain[0]
-		oldFirst  := oldChain[oldLen-1]
-		glog.Infof("Chain split detected after #%v [%x…]. Reorganising chain (-%v +%v blocks) from #%v-#%v [%x/%x] in favour of #%v-#%v [%x/%x]", 
-				commonNumber, commonHash[:4], 
-				oldLen, newLen,
-				oldFirst.Number(),oldLast.Number(),
-				oldFirst.Hash().Bytes()[:4] ,oldLast.Hash().Bytes()[:4], 
-				newFirst.Number(),newLast.Number(),
-				newFirst.Hash().Bytes()[:4], newLast.Hash().Bytes()[:4])
+		newLast := newChain[0]
+		newFirst := newChain[newLen-1]
+		oldLast := oldChain[0]
+		oldFirst := oldChain[oldLen-1]
+		glog.Infof("Chain split detected after #%v [%x…]. Reorganising chain (-%v +%v blocks) from #%v-#%v [%x/%x] in favour of #%v-#%v [%x/%x]",
+			commonNumber, commonHash[:4],
+			oldLen, newLen,
+			oldFirst.Number(), oldLast.Number(),
+			oldFirst.Hash().Bytes()[:4], oldLast.Hash().Bytes()[:4],
+			newFirst.Number(), newLast.Number(),
+			newFirst.Hash().Bytes()[:4], newLast.Hash().Bytes()[:4])
 	}
 
 	var addedTxs types.Transactions

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -1142,19 +1142,14 @@ func (self *BlockChain) reorg(oldBlock, newBlock *types.Block) error {
 		}
 	}
 
-	oldLen := len(oldChain)
-
-	if glog.V(logger.Debug) || oldLen > 63 {
-		commonHash := commonBlock.Hash()
-		commonNumber := commonBlock.Number()
+	if oldLen := len(oldChain); oldLen > 63 || glog.V(logger.Debug) {
 		newLen := len(newChain)
-
 		newLast := newChain[0]
 		newFirst := newChain[newLen-1]
 		oldLast := oldChain[0]
 		oldFirst := oldChain[oldLen-1]
-		glog.Infof("Chain split detected after #%v [%x…]. Reorganising chain (-%v +%v blocks) from #%v-#%v [%x/%x] in favour of #%v-#%v [%x/%x]",
-			commonNumber, commonHash[:4],
+		glog.Infof("Chain split detected after #%v [%x…]. Reorganising chain (-%v +%v blocks), rejecting #%v-#%v [%x…/%x…] in favour of #%v-#%v [%x…/%x…]",
+			commonBlock.Number(), commonBlock.Hash().Bytes()[:4],
 			oldLen, newLen,
 			oldFirst.Number(), oldLast.Number(),
 			oldFirst.Hash().Bytes()[:4], oldLast.Hash().Bytes()[:4],


### PR DESCRIPTION
 also always log if reorg is > 63 blocks long

Example output (from `go test -v`) : 
```
core/blockchain.go:1162] Chain split detected after #0 [086da144…]. Reorganising chain (-3 +3 blocks) from #1/#3 [9103ba61/319428f2] in favour of #1/#3 [fafbcfea/34fcacdd]
```