### PR TITLE
cmd/swarm: enable testnet flag for swarm node

### DIFF
--- a/cmd/swarm/main.go
+++ b/cmd/swarm/main.go
@@ -1,4 +1,4 @@
-// Copyright 2016 The go-ethereum Authors
+// Copyright 2017 The go-ethereum Authors
 // This file is part of go-ethereum.
 //
 // go-ethereum is free software: you can redistribute it and/or modify
@@ -127,7 +127,7 @@ func init() {
 	// Set up the cli app.
 	app.Action = bzzd
 	app.HideVersion = true // we have a command to print the version
-	app.Copyright = "Copyright 2013-2016 The go-ethereum Authors"
+	app.Copyright = "Copyright 2013-2017 The go-ethereum Authors"
 	app.Commands = []cli.Command{
 		{
 			Action:    version,
@@ -163,6 +163,7 @@ Prints the swarm hash of file or directory.
 		utils.DataDirFlag,
 		utils.BootnodesFlag,
 		utils.KeyStoreDirFlag,
+		utils.TestNetFlag,
 		utils.ListenPortFlag,
 		utils.NoDiscoverFlag,
 		utils.DiscoveryV5Flag,


### PR DESCRIPTION
To run a swarm node, a user has to provide `--datadir`, `--keystore` and `--ethapi` flags. I propose to enable the `--testnet` flag similar to geth which should handle the defaults for convenience.

This is work in progress, and I kindly request someone to tag this PR as _in-progress_.