### PR TITLE
cmd,eth,les,internal: remove natspec support

### DIFF
--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -106,7 +106,6 @@ func init() {
 		utils.AutoDAGFlag,
 		utils.TargetGasLimitFlag,
 		utils.NATFlag,
-		utils.NatspecEnabledFlag,
 		utils.NoDiscoverFlag,
 		utils.DiscoveryV5Flag,
 		utils.NetrestrictFlag,

--- a/cmd/geth/usage.go
+++ b/cmd/geth/usage.go
@@ -169,7 +169,6 @@ var AppHelpFlagGroups = []flagGroup{
 		Name: "EXPERIMENTAL",
 		Flags: []cli.Flag{
 			utils.WhisperEnabledFlag,
-			utils.NatspecEnabledFlag,
 		},
 	},
 	{

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -130,10 +130,6 @@ var (
 		Name:  "identity",
 		Usage: "Custom node name",
 	}
-	NatspecEnabledFlag = cli.BoolFlag{
-		Name:  "natspec",
-		Usage: "Enable NatSpec confirmation notice",
-	}
 	DocRootFlag = DirectoryFlag{
 		Name:  "docroot",
 		Usage: "Document Root for HTTPClient file scheme",
@@ -730,7 +726,6 @@ func RegisterEthService(ctx *cli.Context, stack *node.Node, extra []byte) {
 		NetworkId:               ctx.GlobalInt(NetworkIdFlag.Name),
 		MinerThreads:            ctx.GlobalInt(MinerThreadsFlag.Name),
 		ExtraData:               MakeMinerExtra(extra, ctx),
-		NatSpec:                 ctx.GlobalBool(NatspecEnabledFlag.Name),
 		DocRoot:                 ctx.GlobalString(DocRootFlag.Name),
 		GasPrice:                common.String2Big(ctx.GlobalString(GasPriceFlag.Name)),
 		GpoMinGasPrice:          common.String2Big(ctx.GlobalString(GpoMinGasPriceFlag.Name)),

--- a/common/compiler/solidity_test.go
+++ b/common/compiler/solidity_test.go
@@ -36,7 +36,7 @@ contract test {
    }
 }
 `
-	testInfo = `{"source":"\ncontract test {\n   /// @notice Will multiply ` + "`a`" + ` by 7.\n   function multiply(uint a) returns(uint d) {\n       return a * 7;\n   }\n}\n","language":"Solidity","languageVersion":"0.1.1","compilerVersion":"0.1.1","compilerOptions":"--binary file --json-abi file --natspec-user file --natspec-dev file --add-std 1","abiDefinition":[{"constant":false,"inputs":[{"name":"a","type":"uint256"}],"name":"multiply","outputs":[{"name":"d","type":"uint256"}],"type":"function"}],"userDoc":{"methods":{"multiply(uint256)":{"notice":"Will multiply ` + "`a`" + ` by 7."}}},"developerDoc":{"methods":{}}}`
+	testInfo = `{"source":"\ncontract test {\n   /// @notice Will multiply ` + "`a`" + ` by 7.\n   function multiply(uint a) returns(uint d) {\n       return a * 7;\n   }\n}\n","language":"Solidity","languageVersion":"0.1.1","compilerVersion":"0.1.1","compilerOptions":"--binary file --json-abi file --add-std 1","abiDefinition":[{"constant":false,"inputs":[{"name":"a","type":"uint256"}],"name":"multiply","outputs":[{"name":"d","type":"uint256"}],"type":"function"}],"userDoc":{"methods":{"multiply(uint256)":{"notice":"Will multiply ` + "`a`" + ` by 7."}}},"developerDoc":{"methods":{}}}`
 )
 
 func skipWithoutSolc(t *testing.T) {
@@ -99,7 +99,7 @@ func TestSaveInfo(t *testing.T) {
 	if string(got) != testInfo {
 		t.Errorf("incorrect info.json extracted, expected:\n%s\ngot\n%s", testInfo, string(got))
 	}
-	wantHash := common.HexToHash("0x9f3803735e7f16120c5a140ab3f02121fd3533a9655c69b33a10e78752cc49b0")
+	wantHash := common.HexToHash("0x22450a77f0c3ff7a395948d07bc1456881226a1b6325f4189cb5f1254a824080")
 	if cinfohash != wantHash {
 		t.Errorf("content hash for info is incorrect. expected %v, got %v", wantHash.Hex(), cinfohash.Hex())
 	}

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -77,7 +77,6 @@ type Config struct {
 	DatabaseCache      int
 	DatabaseHandles    int
 
-	NatSpec   bool
 	DocRoot   string
 	AutoDAG   bool
 	PowFake   bool
@@ -140,7 +139,6 @@ type Ethereum struct {
 	etherbase    common.Address
 	solcPath     string
 
-	NatSpec       bool
 	netVersionId  int
 	netRPCService *ethapi.PublicNetAPI
 }
@@ -174,7 +172,6 @@ func New(ctx *node.ServiceContext, config *Config) (*Ethereum, error) {
 		shutdownChan:   make(chan bool),
 		stopDbUpgrade:  stopDbUpgrade,
 		netVersionId:   config.NetworkId,
-		NatSpec:        config.NatSpec,
 		etherbase:      config.Etherbase,
 		MinerThreads:   config.MinerThreads,
 		AutoDAG:        config.AutoDAG,

--- a/internal/web3ext/web3ext.go
+++ b/internal/web3ext/web3ext.go
@@ -409,12 +409,6 @@ web3._extend({
 			inputFormatter: [web3._extend.formatters.inputTransactionFormatter, web3._extend.utils.fromDecimal, web3._extend.utils.fromDecimal]
 		}),
 		new web3._extend.Method({
-			name: 'getNatSpec',
-			call: 'eth_getNatSpec',
-			params: 1,
-			inputFormatter: [web3._extend.formatters.inputTransactionFormatter]
-		}),
-		new web3._extend.Method({
 			name: 'signTransaction',
 			call: 'eth_signTransaction',
 			params: 1,

--- a/les/backend.go
+++ b/les/backend.go
@@ -66,7 +66,6 @@ type LightEthereum struct {
 	solcPath       string
 	solc           *compiler.Solidity
 
-	NatSpec       bool
 	netVersionId  int
 	netRPCService *ethapi.PublicNetAPI
 }
@@ -95,7 +94,6 @@ func New(ctx *node.ServiceContext, config *eth.Config) (*LightEthereum, error) {
 		pow:            pow,
 		shutdownChan:   make(chan bool),
 		netVersionId:   config.NetworkId,
-		NatSpec:        config.NatSpec,
 		solcPath:       config.SolcPath,
 	}
 

--- a/swarm/api/http/roundtripper.go
+++ b/swarm/api/http/roundtripper.go
@@ -44,9 +44,7 @@ If Host is left empty, localhost is assumed.
 
 Using a public gateway, the above few lines gives you the leanest
 bzz-scheme aware read-only http client. You really only ever need this
-if you need go-native swarm access to bzz addresses, e.g.,
-github.com/ethereum/go-ethereum/common/natspec
-
+if you need go-native swarm access to bzz addresses.
 */
 
 type RoundTripper struct {


### PR DESCRIPTION
Currently natspec isn't implemented but can be enabled through an experimental command line flag.
This PR remove all natspec references.