### PR TITLE
accounts, mobile: make account manager API a bit more uniform

### DIFF
--- a/accounts/account_manager.go
+++ b/accounts/account_manager.go
@@ -113,9 +113,9 @@ func (am *Manager) Accounts() []Account {
 	return am.cache.accounts()
 }
 
-// DeleteAccount deletes the key matched by account if the passphrase is correct.
-// If a contains no filename, the address must match a unique key.
-func (am *Manager) DeleteAccount(a Account, passphrase string) error {
+// Delete deletes the key matched by account if the passphrase is correct.
+// If the account contains no filename, the address must match a unique key.
+func (am *Manager) Delete(a Account, passphrase string) error {
 	// Decrypting the key isn't really necessary, but we do
 	// it anyway to check the password and zero out the key
 	// immediately afterwards.

--- a/accounts/accounts_test.go
+++ b/accounts/accounts_test.go
@@ -53,14 +53,14 @@ func TestManager(t *testing.T) {
 	if err := am.Update(a, "foo", "bar"); err != nil {
 		t.Errorf("Update error: %v", err)
 	}
-	if err := am.DeleteAccount(a, "bar"); err != nil {
-		t.Errorf("DeleteAccount error: %v", err)
+	if err := am.Delete(a, "bar"); err != nil {
+		t.Errorf("Delete error: %v", err)
 	}
 	if common.FileExist(a.File) {
-		t.Errorf("account file %s should be gone after DeleteAccount", a.File)
+		t.Errorf("account file %s should be gone after Delete", a.File)
 	}
 	if am.HasAddress(a.Address) {
-		t.Errorf("HasAccount(%x) should've returned true after DeleteAccount", a.Address)
+		t.Errorf("HasAccount(%x) should've returned true after Delete", a.Address)
 	}
 }
 

--- a/mobile/accounts.go
+++ b/mobile/accounts.go
@@ -103,7 +103,7 @@ func (am *AccountManager) GetAccounts() *Accounts {
 // DeleteAccount deletes the key matched by account if the passphrase is correct.
 // If a contains no filename, the address must match a unique key.
 func (am *AccountManager) DeleteAccount(account *Account, passphrase string) error {
-	return am.manager.DeleteAccount(accounts.Account{
+	return am.manager.Delete(accounts.Account{
 		Address: account.account.Address,
 		File:    account.account.File,
 	}, passphrase)


### PR DESCRIPTION
The account manager in Go mostly has verb-only method names: `Import`, `Export`, `Unlock`, `Update`. The `DeleteAccount` was a bit of a sore sight. This PR removes the `Account` suffix and leaves only `Delete`.