### PR TITLE
crypto/secp256k1: use libsecp256k1 endomorphism

### DIFF
--- a/crypto/secp256k1/secp256.go
+++ b/crypto/secp256k1/secp256.go
@@ -25,6 +25,7 @@ package secp256k1
 #define USE_FIELD_INV_BUILTIN
 #define USE_SCALAR_8X32
 #define USE_SCALAR_INV_BUILTIN
+#define USE_ENDOMORPHISM
 #define NDEBUG
 #include "./libsecp256k1/src/secp256k1.c"
 #include "./libsecp256k1/src/modules/recovery/main_impl.h"


### PR DESCRIPTION
```
benchmark              old ns/op     new ns/op     delta
BenchmarkRecover-2     208484        170297        -18.32%
```

Endomorphism is disabled by default in libsecp256k1 [1], the reason appears to be concerns that it may be covered by patents [2]. The patents in question appears to be owned by Certicom [3][4].

If this implementation is indeed covered by patents, most likely it would be fine for open-source libraries to make use of it. Moreover, as the code is already in place, it's easy to disable in the event of agitated patent holders.

1. https://github.com/bitcoin-core/secp256k1#implementation-details
2. https://bitcointalk.org/index.php?topic=1740973.0
3. https://www.google.com/patents/US20020044649
4. https://en.wikipedia.org/wiki/ECC_patents
