### PR TITLE
eth/downloader: fix mutex regression causing panics on fail

### DIFF
--- a/eth/downloader/queue.go
+++ b/eth/downloader/queue.go
@@ -1129,12 +1129,13 @@ func (q *queue) deliverNodeData(results []trie.SyncResult, callback func(int, bo
 		if err != nil {
 			q.stateSchedLock.Unlock()
 			callback(i, progressed, err)
+			return
 		}
 		if err = batch.Write(); err != nil {
 			q.stateSchedLock.Unlock()
 			callback(i, progressed, err)
+			return // TODO(karalabe): If a DB write fails (disk full), we ought to cancel the sync
 		}
-
 		// Item processing succeeded, release the lock (temporarily)
 		progressed = progressed || prog
 		q.stateSchedLock.Unlock()


### PR DESCRIPTION
Fixes a double unlock introduced by https://github.com/ethereum/go-ethereum/commit/d3b751e4d94f95f6cc89544852f2d5811e075665. This PR also acts as an immediate fix compared to a more involved solution proposed in https://github.com/ethereum/go-ethereum/pull/3588, which needs further time to evaluate and fully verify.