### PR TITLE
travis: Install Android NDK explicitly, removed from gomobile

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -65,10 +65,11 @@ matrix:
 
         # Build the Android archive and upload it to Maven Central and Azure
         - brew update
-        - brew install android-sdk maven gpg
+        - travis_wait 60 brew install android-sdk android-ndk maven gpg
         - alias gpg="gpg2"
 
         - export ANDROID_HOME=/usr/local/opt/android-sdk
+        - export ANDROID_NDK=/usr/local/opt/android-ndk
         - echo "y" | android update sdk --no-ui --filter `android list sdk | grep "SDK Platform Android" | grep -E 'API 15|API 19|API 24' | awk '{print $1}' | cut -d '-' -f 1 | tr '\n' ','`
 
         - go run build/ci.go aar -signer ANDROID_SIGNING_KEY -deploy https://oss.sonatype.org -upload gethstore/builds

--- a/build/ci.go
+++ b/build/ci.go
@@ -700,9 +700,16 @@ func doAndroidArchive(cmdline []string) {
 	flag.CommandLine.Parse(cmdline)
 	env := build.Env()
 
+	// Sanity check that the SDK and NDK are installed and set
+	if os.Getenv("ANDROID_HOME") == "" {
+		log.Fatal("Please ensure ANDROID_HOME points to your Android SDK")
+	}
+	if os.Getenv("ANDROID_NDK") == "" {
+		log.Fatal("Please ensure ANDROID_NDK points to your Android NDK")
+	}
 	// Build the Android archive and Maven resources
 	build.MustRun(goTool("get", "golang.org/x/mobile/cmd/gomobile"))
-	build.MustRun(gomobileTool("init"))
+	build.MustRun(gomobileTool("init", "--ndk", os.Getenv("ANDROID_NDK")))
 	build.MustRun(gomobileTool("bind", "--target", "android", "--javapkg", "org.ethereum", "-v", "github.com/ethereum/go-ethereum/mobile"))
 
 	if *local {


### PR DESCRIPTION
The Android NDK was recently removed from `gomobile`, leading to our Android builds failing. Starting from https://go-review.googlesource.com/#/c/35173/ , `gomobile` requires a locally installed NDK. This PR ensures that travis installs that too before running the build steps.

**Please wait until green. There's no way to test this apart from trial and error.**