### PR TITLE
types: bugfix invalid V derivation on tx json unmarshal

### DIFF
--- a/core/types/transaction.go
+++ b/core/types/transaction.go
@@ -198,7 +198,8 @@ func (tx *Transaction) UnmarshalJSON(input []byte) error {
 
 	var V byte
 	if isProtectedV((*big.Int)(dec.V)) {
-		V = byte((new(big.Int).Sub((*big.Int)(dec.V), deriveChainId((*big.Int)(dec.V))).Uint64()) - 35)
+		chainId := deriveChainId((*big.Int)(dec.V)).Uint64()
+		V = byte(dec.V.ToInt().Uint64() - 35 - 2*chainId)
 	} else {
 		V = byte(((*big.Int)(dec.V)).Uint64() - 27)
 	}

--- a/core/types/transaction_signing.go
+++ b/core/types/transaction_signing.go
@@ -160,7 +160,7 @@ func (s EIP155Signer) PublicKey(tx *Transaction) ([]byte, error) {
 // needs to be in the [R || S || V] format where V is 0 or 1.
 func (s EIP155Signer) WithSignature(tx *Transaction, sig []byte) (*Transaction, error) {
 	if len(sig) != 65 {
-		panic(fmt.Sprintf("wrong size for snature: got %d, want 65", len(sig)))
+		panic(fmt.Sprintf("wrong size for signature: got %d, want 65", len(sig)))
 	}
 
 	cpy := &Transaction{data: tx.data}


### PR DESCRIPTION
`Transaction#UnmarshalJSON` currently only subtracts the chainId once instead of 2 times as described in EIP-155. This causes a check if r,s,v values are valid to fail.