### PR TITLE
containers/docker: update base images, add CA certs, build internally on Ubuntu

### DIFF
--- a/containers/docker/develop-alpine/Dockerfile
+++ b/containers/docker/develop-alpine/Dockerfile
@@ -1,7 +1,7 @@
-FROM alpine:3.4
+FROM alpine:3.5
 
 RUN \
-  apk add --update go git make gcc musl-dev && \
+  apk add --update go git make gcc musl-dev ca-certificates && \
   git clone --depth 1 https://github.com/ethereum/go-ethereum && \
   (cd go-ethereum && make geth) && \
   cp go-ethereum/build/bin/geth /geth && \

--- a/containers/docker/develop-ubuntu/Dockerfile
+++ b/containers/docker/develop-ubuntu/Dockerfile
@@ -1,17 +1,15 @@
-FROM ubuntu:wily
-MAINTAINER caktux
+FROM ubuntu:xenial
 
-ENV DEBIAN_FRONTEND noninteractive
-
-RUN apt-get update && \
-    apt-get upgrade -q -y && \
-    apt-get dist-upgrade -q -y && \
-    apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 923F6CA9 && \
-    echo "deb http://ppa.launchpad.net/ethereum/ethereum-dev/ubuntu wily main" | tee -a /etc/apt/sources.list.d/ethereum.list && \
-    apt-get update && \
-    apt-get install -q -y geth
+RUN \
+  apt-get update && apt-get upgrade -q -y && \
+  apt-get install -y --no-install-recommends golang git make gcc libc-dev ca-certificates && \
+  git clone --depth 1 https://github.com/ethereum/go-ethereum && \
+  (cd go-ethereum && make geth) && \
+  cp go-ethereum/build/bin/geth /geth && \
+  apt-get remove -y golang git make gcc libc-dev && apt autoremove -y && apt-get clean && \
+  rm -rf /go-ethereum
 
 EXPOSE 8545
 EXPOSE 30303
 
-ENTRYPOINT ["/usr/bin/geth"]
+ENTRYPOINT ["/geth"]

--- a/containers/docker/master-alpine/Dockerfile
+++ b/containers/docker/master-alpine/Dockerfile
@@ -1,7 +1,7 @@
-FROM alpine:3.4
+FROM alpine:3.5
 
 RUN \
-  apk add --update go git make gcc musl-dev && \
+  apk add --update go git make gcc musl-dev ca-certificates && \
   git clone --depth 1 --branch release/1.5 https://github.com/ethereum/go-ethereum && \
   (cd go-ethereum && make geth) && \
   cp go-ethereum/build/bin/geth /geth && \

--- a/containers/docker/master-ubuntu/Dockerfile
+++ b/containers/docker/master-ubuntu/Dockerfile
@@ -1,17 +1,15 @@
-FROM ubuntu:wily
-MAINTAINER caktux
+FROM ubuntu:xenial
 
-ENV DEBIAN_FRONTEND noninteractive
-
-RUN apt-get update && \
-    apt-get upgrade -q -y && \
-    apt-get dist-upgrade -q -y && \
-    apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 923F6CA9 && \
-    echo "deb http://ppa.launchpad.net/ethereum/ethereum/ubuntu wily main" | tee -a /etc/apt/sources.list.d/ethereum.list && \
-    apt-get update && \
-    apt-get install -q -y geth
+RUN \
+  apt-get update && apt-get upgrade -q -y && \
+  apt-get install -y --no-install-recommends golang git make gcc libc-dev ca-certificates && \
+  git clone --depth 1 --branch release/1.5 https://github.com/ethereum/go-ethereum && \
+  (cd go-ethereum && make geth) && \
+  cp go-ethereum/build/bin/geth /geth && \
+  apt-get remove -y golang git make gcc libc-dev && apt autoremove -y && apt-get clean && \
+  rm -rf /go-ethereum
 
 EXPOSE 8545
 EXPOSE 30303
 
-ENTRYPOINT ["/usr/bin/geth"]
+ENTRYPOINT ["/geth"]


### PR DESCRIPTION
This PR updates our Alpine docker images to use 3.5 instead of the older 3.4. It also adds a permanent package `ca-certificates`, which is needed by Go to do secure HTTP requests (i.e. ethstats reporting). The certificate issue could in theory be worked around by embedding the certs into the Geth binary, but that may get messy so I'd rather just make it available.

The PR also fixes up the Ubuntu images which previously relied on `wily` (unsupported) and also installed Geth from PPAs (which will result in outdated releases as docker hub build before launchpad updated). The new images are based on `xenial` (latest LTS) and also build Geth on docker build, instead of relying on an outside binary,