### PR TITLE
console, internal/web3ext: remove bzz and ens extensions

### DIFF
--- a/console/console.go
+++ b/console/console.go
@@ -137,9 +137,13 @@ func (c *Console) init(preload []string) error {
 			continue // manually mapped or ignore
 		}
 		if file, ok := web3ext.Modules[api]; ok {
+			// Load our extension for the module.
 			if err = c.jsre.Compile(fmt.Sprintf("%s.js", api), file); err != nil {
 				return fmt.Errorf("%s.js: %v", api, err)
 			}
+			flatten += fmt.Sprintf("var %s = web3.%s; ", api, api)
+		} else if obj, err := c.jsre.Run("web3." + api); err == nil && obj.IsObject() {
+			// Enable web3.js built-in extension if available.
 			flatten += fmt.Sprintf("var %s = web3.%s; ", api, api)
 		}
 	}

--- a/internal/web3ext/web3ext.go
+++ b/internal/web3ext/web3ext.go
@@ -19,10 +19,8 @@ package web3ext
 
 var Modules = map[string]string{
 	"admin":      Admin_JS,
-	"bzz":        Bzz_JS,
 	"chequebook": Chequebook_JS,
 	"debug":      Debug_JS,
-	"ens":        ENS_JS,
 	"eth":        Eth_JS,
 	"miner":      Miner_JS,
 	"net":        Net_JS,
@@ -31,101 +29,6 @@ var Modules = map[string]string{
 	"shh":        Shh_JS,
 	"txpool":     TxPool_JS,
 }
-
-const Bzz_JS = `
-web3._extend({
-	property: 'bzz',
-	methods:
-	[
-		new web3._extend.Method({
-			name: 'syncEnabled',
-			call: 'bzz_syncEnabled',
-			params: 1,
-			inputFormatter: [null]
-		}),
-		new web3._extend.Method({
-			name: 'swapEnabled',
-			call: 'bzz_swapEnabled',
-			params: 1,
-			inputFormatter: [null]
-		}),
-		new web3._extend.Method({
-			name: 'download',
-			call: 'bzz_download',
-			params: 2,
-			inputFormatter: [null, null]
-		}),
-		new web3._extend.Method({
-			name: 'upload',
-			call: 'bzz_upload',
-			params: 2,
-			inputFormatter: [null, null]
-		}),
-		new web3._extend.Method({
-			name: 'resolve',
-			call: 'bzz_resolve',
-			params: 1,
-			inputFormatter: [null]
-		}),
-		new web3._extend.Method({
-			name: 'get',
-			call: 'bzz_get',
-			params: 1,
-			inputFormatter: [null]
-		}),
-		new web3._extend.Method({
-			name: 'put',
-			call: 'bzz_put',
-			params: 2,
-			inputFormatter: [null, null]
-		}),
-		new web3._extend.Method({
-			name: 'modify',
-			call: 'bzz_modify',
-			params: 4,
-			inputFormatter: [null, null, null, null]
-		})
-	],
-	properties:
-	[
-		new web3._extend.Property({
-			name: 'hive',
-			getter: 'bzz_hive'
-		}),
-		new web3._extend.Property({
-			name: 'info',
-			getter: 'bzz_info',
-		}),
-	]
-});
-`
-
-const ENS_JS = `
-web3._extend({
-  property: 'ens',
-  methods:
-  [
-    new web3._extend.Method({
-			name: 'register',
-			call: 'ens_register',
-			params: 1,
-			inputFormatter: [null]
-		}),
-	new web3._extend.Method({
-			name: 'setContentHash',
-			call: 'ens_setContentHash',
-			params: 2,
-			inputFormatter: [null, null]
-		}),
-	new web3._extend.Method({
-			name: 'resolve',
-			call: 'ens_resolve',
-			params: 1,
-			inputFormatter: [null]
-		}),
-	]
-})
-`
 
 const Chequebook_JS = `
 web3._extend({


### PR DESCRIPTION
web3.js includes bzz methods and throws an error when the extension
module is reregistered. The ENS RPC API is deprecated and not exposed by
anything. The difference to #3600 is that `bzz` still works even though the
extension is no longer registered in the Go extension map.

Fixes #3596