### PR TITLE
Include metadata with solc compiler outputs

### DIFF
--- a/common/compiler/solidity.go
+++ b/common/compiler/solidity.go
@@ -148,8 +148,10 @@ func runsolc(cmd *exec.Cmd, source string) (map[string]*Contract, error) {
 			return nil, fmt.Errorf("solc: error reading dev doc: %v", err)
 		}
 		var metadata interface{}
-		if err := json.Unmarshal([]byte(info.Metadata), &metadata); err != nil {
-			return nil, fmt.Errorf("solc: error reading metadata: %v", err)
+		if info.Metadata != "" {
+		        if err := json.Unmarshal([]byte(info.Metadata), &metadata); err != nil {
+			      return nil, fmt.Errorf("solc: error reading metadata: %v", err)
+			}
 		}
 		contracts[name] = &Contract{
 			Code: "0x" + info.Bin,

--- a/common/compiler/solidity.go
+++ b/common/compiler/solidity.go
@@ -25,20 +25,20 @@ import (
 	"io/ioutil"
 	"os/exec"
 	"regexp"
+	"strconv"
 	"strings"
+	"sync"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/crypto"
 )
 
 var (
-	versionRegexp = regexp.MustCompile(`[0-9]+\.[0-9]+\.[0-9]+`)
-	solcParams    = []string{
-		"--combined-json", "bin,abi,userdoc,devdoc,metadata",
-		"--add-std",  // include standard lib contracts
-		"--optimize", // code optimizer switched on
-	}
+	versionRegexp = regexp.MustCompile(`([0-9]+)\.([0-9]+)\.([0-9]+)`)
+	spmu          = &sync.Mutex{} // protects access to mutating _solcParams variable (contents are never mutated)
+	_solcParams    = []string{}   // zero-len means uninitialized, protected by spmu
 )
+
 
 type Contract struct {
 	Code string       `json:"code"`
@@ -68,6 +68,58 @@ type solcOutput struct {
 	Version   string
 }
 
+func findSolcParams(solc string) []string {
+	spmu.Lock()
+	defer spmu.Unlock()
+
+	if ( len(_solcParams) != 0 ) {
+		return _solcParams
+	} else {
+		recent, _ := atLeast047(solc) // on err, we default to considering the solidity version recent, see atLeast047
+		var mbmeta string
+		if ( recent ) {
+			mbmeta = ",metadata"
+		} else {
+			mbmeta = ""
+		}
+		_solcParams = []string{
+			"--combined-json", "bin,abi,userdoc,devdoc" + mbmeta,
+			"--add-std",  // include standard lib contracts
+			"--optimize", // code optimizer switched on
+		}
+		return _solcParams
+	}
+}
+
+func atLeast047(solc string) (bool, error) {
+	var (
+		solidity *Solidity
+		major    int
+		minor    int
+		patch    int
+		err      error
+	)
+	solidity, err = SolidityVersion(solc)
+	if ( err != nil ) {
+		return true, err
+	}
+
+	matches := versionRegexp.FindStringSubmatch( solidity.Version )
+	major, err = strconv.Atoi( matches[1] )
+	if ( err != nil ) {
+		return true, err
+	}
+	minor, err = strconv.Atoi( matches[2] )
+	if ( err != nil ) {
+		return true, err
+	}
+	patch, err = strconv.Atoi( matches[3] )
+	if ( err != nil ) {
+		return true, err
+	}
+	return (major > 0 || minor > 4 || patch > 6), nil
+}
+
 // SolidityVersion runs solc and parses its version output.
 func SolidityVersion(solc string) (*Solidity, error) {
 	if solc == "" {
@@ -95,10 +147,11 @@ func CompileSolidityString(solc, source string) (map[string]*Contract, error) {
 	if solc == "" {
 		solc = "solc"
 	}
+	solcParams := findSolcParams(solc)
 	args := append(solcParams, "--")
 	cmd := exec.Command(solc, append(args, "-")...)
 	cmd.Stdin = strings.NewReader(source)
-	return runsolc(cmd, source)
+	return runsolc(cmd, solcParams, source)
 }
 
 // CompileSolidity compiles all given Solidity source files.
@@ -113,12 +166,13 @@ func CompileSolidity(solc string, sourcefiles ...string) (map[string]*Contract, 
 	if solc == "" {
 		solc = "solc"
 	}
+	solcParams := findSolcParams(solc)
 	args := append(solcParams, "--")
 	cmd := exec.Command(solc, append(args, sourcefiles...)...)
-	return runsolc(cmd, source)
+	return runsolc(cmd, solcParams, source)
 }
 
-func runsolc(cmd *exec.Cmd, source string) (map[string]*Contract, error) {
+func runsolc(cmd *exec.Cmd, solcParams []string, source string) (map[string]*Contract, error) {
 	var stderr, stdout bytes.Buffer
 	cmd.Stderr = &stderr
 	cmd.Stdout = &stdout

--- a/common/compiler/solidity.go
+++ b/common/compiler/solidity.go
@@ -54,7 +54,7 @@ type ContractInfo struct {
 	AbiDefinition   interface{} `json:"abiDefinition"`
 	UserDoc         interface{} `json:"userDoc"`
 	DeveloperDoc    interface{} `json:"developerDoc"`
-	Metadata        interface{} `json:"metadata"`
+	Metadata        string      `json:"metadata"`
 }
 
 // Solidity contains information about the solidity compiler.
@@ -201,9 +201,13 @@ func runsolc(cmd *exec.Cmd, solcParams []string, source string) (map[string]*Con
 		if err := json.Unmarshal([]byte(info.Devdoc), &devdoc); err != nil {
 			return nil, fmt.Errorf("solc: error reading dev doc: %v", err)
 		}
-		var metadata interface{}
+		var metadata string
 		if info.Metadata != "" {
-		        if err := json.Unmarshal([]byte(info.Metadata), &metadata); err != nil {
+			jstring, err := json.Marshal( string(info.Metadata) )
+			if ( err != nil ) {
+			      return nil, fmt.Errorf("solc: error coercing metadata to string: %v", err)
+			}
+		        if err := json.Unmarshal(jstring, &metadata); err != nil {
 			      return nil, fmt.Errorf("solc: error reading metadata: %v", err)
 			}
 		}


### PR DESCRIPTION
Recent versions of `solc` now append a [swarm hash of a metadata file](http://solidity.readthedocs.io/en/develop/miscellaneous.html#encoding-of-the-metadata-hash-in-the-bytecode) to generated contract code, in order eventually to permit a kind of "reflection" on deployed contracts, as users become able look-up a file that includes ABI, reference to source and compiler-version to verify the code deployed, etc.

This file is quite detailed, including information not available in any of the other compiler-generated artifact. Clients of `geth` would not in general be able to reconstruct a correctly hashing metadata file from other sources.

This (trivial) PR has `geth` execute `solc` with command-line arguments that provoke metadata generation along with the artifacts already expected.

A serious downside of this PR is that it makes no attempt to remain compatible with older versions of `solc`. Attempts to compile via `geth` using older versions of `solc` will fail.

Swarm hashes have been appended to generated code since Solidity version 0.4.7.