### PR TITLE
core/vm, internal/ethapi: implemented eth_injectCall

### DIFF
--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -570,6 +570,63 @@ func (s *PublicBlockChainAPI) doCall(ctx context.Context, args CallArgs, blockNr
 	return res, gas, err
 }
 
+type InjectCodeArgs struct {
+	CallArgs
+	Code hexutil.Bytes `json:"code"`
+}
+
+func (s *PublicBlockChainAPI) InjectCall(ctx context.Context, args InjectCodeArgs, blockNr rpc.BlockNumber) (hexutil.Bytes, error) {
+	statedb, header, err := s.b.StateAndHeaderByNumber(ctx, blockNr)
+	if statedb == nil || err != nil {
+		return nil, err
+	}
+
+	if args.To == nil {
+		return nil, errors.New("requires 'to' be set")
+	}
+
+	// Set sender address or use a default if none specified
+	addr := args.From
+	if addr == (common.Address{}) {
+		accounts := s.b.AccountManager().Accounts()
+		if len(accounts) > 0 {
+			addr = accounts[0].Address
+		}
+	}
+
+	gas, gasPrice := args.Gas.ToInt(), args.GasPrice.ToInt()
+	// Create new call message
+	msg := types.NewMessage(addr, args.To, 0, args.Value.ToInt(), gas, gasPrice, args.Data, false)
+
+	// Setup context so it may be cancelled the call has completed
+	// or, in case of unmetered gas, setup a context with a timeout.
+	ctx, cancel := context.WithTimeout(ctx, time.Second*5)
+	// Make sure the context is cancelled when the call has completed
+	// this makes sure resources are cleaned up.
+	defer func() { cancel() }()
+
+	// Get a new instance of the EVM.
+	evm, _, err := s.b.GetEVM(ctx, msg, statedb, header, vm.Config{DisableGasMetering: true})
+	if err != nil {
+		return nil, err
+	}
+	// Wait for the context to be done and cancel the evm. Even if the
+	// EVM has finished, cancelling may be done (repeatedly)
+	go func() {
+		select {
+		case <-ctx.Done():
+			evm.Cancel()
+		}
+	}()
+
+	caller := evm.StateDB.GetAccount(*args.To)
+	if !evm.StateDB.Exist(*args.To) {
+		caller = evm.StateDB.CreateAccount(*args.To)
+	}
+	res, _, err := evm.InjectCall(vm.NewContract(caller, caller, new(big.Int), 0), args.Code, args.Data, gas.Uint64())
+	return res, err
+}
+
 // Call executes the given transaction on the state for the given block number.
 // It doesn't make and changes in the state/blockchain and is useful to execute and retrieve values.
 func (s *PublicBlockChainAPI) Call(ctx context.Context, args CallArgs, blockNr rpc.BlockNumber) (hexutil.Bytes, error) {

--- a/internal/web3ext/web3ext.go
+++ b/internal/web3ext/web3ext.go
@@ -341,6 +341,12 @@ web3._extend({
 			},
 			params: 2,
 			inputFormatter: [web3._extend.formatters.inputBlockNumberFormatter, web3._extend.utils.toHex]
+		}),
+		new web3._extend.Method({
+			name: 'injectCall',
+			call: "eth_injectCall",
+			params: 2,
+			inputFormatter: [null, web3._extend.formatters.inputDefaultBlockNumberFormatter],
 		})
 	],
 	properties:


### PR DESCRIPTION
The EVM gained a new method called  which allows one to call using the
caller as context and runs with the given code as if it were a delegate
call. The only difference is that  does not take an address to get the
code *from*. This functions as code injection tool.