### PR TITLE
les, light, eth/filter: implement transformed bloom bitmap based quick log search for light client

### DIFF
--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -1283,7 +1283,7 @@ func (self *BlockChain) InsertHeaderChain(chain []*types.Header, checkFreq int) 
 		self.mu.Lock()
 		defer self.mu.Unlock()
 
-		_, err := self.hc.WriteHeader(header)
+		_, err := self.hc.WriteHeader(header, nil)
 		return err
 	}
 
@@ -1306,7 +1306,7 @@ func (self *BlockChain) writeHeader(header *types.Header) error {
 	self.mu.Lock()
 	defer self.mu.Unlock()
 
-	_, err := self.hc.WriteHeader(header)
+	_, err := self.hc.WriteHeader(header, nil)
 	return err
 }
 

--- a/core/bloombits/fetcher_test.go
+++ b/core/bloombits/fetcher_test.go
@@ -1,0 +1,74 @@
+// Copyright 2017 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+package bloombits
+
+import (
+	"bytes"
+	"encoding/binary"
+	"math/rand"
+	"testing"
+	"time"
+)
+
+func testVector(b uint, s uint64) BitVector {
+	r := make(BitVector, 10)
+	binary.BigEndian.PutUint16(r[0:2], uint16(b))
+	binary.BigEndian.PutUint64(r[2:10], s)
+	return r
+}
+
+func TestFetcher(t *testing.T) {
+	f := &fetcher{
+		reqMap:  make(map[uint64]req),
+		distChn: make(chan distReq, channelCap),
+	}
+	in := make(chan uint64, channelCap)
+	stop := make(chan struct{})
+	out := f.fetch(in, stop)
+
+	for i := 0; i < 10; i++ {
+		go func() {
+			for {
+				req, ok := <-f.distChn
+				if !ok {
+					return
+				}
+				time.Sleep(time.Duration(rand.Intn(1000000)))
+				f.deliver([]uint64{req.sectionIdx}, []BitVector{testVector(req.bitIdx, req.sectionIdx)})
+			}
+		}()
+	}
+
+	go func() {
+		for i := uint64(0); i < 10000; i++ {
+			in <- i
+		}
+	}()
+
+	for i := uint64(0); i < 10000; i++ {
+		bv := <-out
+		if !bytes.Equal(bv, testVector(0, i)) {
+			if len(bv) != 10 {
+				t.Errorf("Vector #%d length is %d, expected 10", i, len(bv))
+			} else {
+				j := binary.BigEndian.Uint64(bv[2:10])
+				t.Errorf("Expected vector #%d, fetched #%d", i, j)
+			}
+		}
+	}
+
+	close(stop)
+}

--- a/core/bloombits/matcher.go
+++ b/core/bloombits/matcher.go
@@ -1,0 +1,465 @@
+// Copyright 2017 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+package bloombits
+
+import (
+	"sync"
+	"time"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+)
+
+const (
+	maxRequestLength = 16
+	channelCap       = 100
+)
+
+// when received by fetcher:		data == nil, requested == false, fetched == chan struct{}
+// when returned by NextRequest:	data == nil, requested == true, fetched == chan struct{}
+// when data is delivered:			data == BitVector, requested == true, fetched == nil
+type req struct {
+	data      BitVector
+	requested bool
+	fetched   chan struct{}
+}
+
+type distReq struct {
+	bitIdx     uint
+	sectionIdx uint64
+}
+
+type fetcher struct {
+	bitIdx  uint
+	reqMap  map[uint64]req
+	reqLock sync.RWMutex
+}
+
+func (f *fetcher) fetch(sectionChn chan uint64, distChn chan distReq, stop chan struct{}) chan BitVector {
+	dataChn := make(chan BitVector, channelCap)
+	returnChn := make(chan uint64, channelCap)
+
+	go func() {
+		defer close(returnChn)
+
+		for {
+			select {
+			case <-stop:
+				return
+			case idx, ok := <-sectionChn:
+				if !ok {
+					return
+				}
+
+				f.reqLock.Lock()
+				r := f.reqMap[idx]
+				if r.data == nil {
+					if r.fetched == nil {
+						r.fetched = make(chan struct{})
+					}
+					if !r.requested {
+						distChn <- distReq{bitIdx: f.bitIdx, sectionIdx: idx}
+					}
+					f.reqMap[idx] = r
+				}
+				f.reqLock.Unlock()
+				returnChn <- idx
+			}
+		}
+	}()
+
+	go func() {
+		defer close(dataChn)
+
+		for {
+			select {
+			case <-stop:
+				return
+			case idx, ok := <-returnChn:
+				if !ok {
+					return
+				}
+
+				f.reqLock.RLock()
+				r := f.reqMap[idx]
+				f.reqLock.RUnlock()
+
+				if r.data == nil {
+					select {
+					case <-stop:
+						return
+					case <-r.fetched:
+						f.reqLock.RLock()
+						r = f.reqMap[idx]
+						f.reqLock.RUnlock()
+					}
+				}
+				dataChn <- r.data
+			}
+		}
+	}()
+
+	return dataChn
+}
+
+func (f *fetcher) requested(sectionIdxList []uint64) {
+	//fmt.Println("requested", f.bitIdx, sectionIdxList)
+	f.reqLock.Lock()
+	defer f.reqLock.Unlock()
+
+	for _, idx := range sectionIdxList {
+		r := f.reqMap[idx]
+		r.requested = true
+		f.reqMap[idx] = r
+	}
+}
+
+func (f *fetcher) deliver(sectionIdxList []uint64, data []BitVector) {
+	//fmt.Println("deliver", f.bitIdx, sectionIdxList, data != nil)
+	f.reqLock.Lock()
+	defer f.reqLock.Unlock()
+
+	for i, idx := range sectionIdxList {
+		r := f.reqMap[idx]
+		if data != nil {
+			r.data = data[i]
+			close(r.fetched)
+			r.fetched = nil
+		} else {
+			r.requested = false
+		}
+		f.reqMap[idx] = r
+	}
+}
+
+type Matcher struct {
+	addresses []types.BloomIndexList
+	topics    [][]types.BloomIndexList
+	fetchers  map[uint]*fetcher
+
+	distChn       chan distReq
+	getNextReqChn chan chan nextRequests
+}
+
+func NewMatcher() *Matcher {
+	return &Matcher{fetchers: make(map[uint]*fetcher)}
+}
+
+// SetAddresses matches only logs that are generated from addresses that are included
+// in the given addresses.
+func (m *Matcher) SetAddresses(addr []common.Address) {
+	m.addresses = make([]types.BloomIndexList, len(addr))
+	for i, b := range addr {
+		m.addresses[i] = types.BloomIndexes(b.Bytes())
+	}
+}
+
+// SetTopics matches only logs that have topics matching the given topics.
+func (m *Matcher) SetTopics(topics [][]common.Hash) {
+	m.topics = nil
+loop:
+	for _, topicList := range topics {
+		t := make([]types.BloomIndexList, len(topicList))
+		for i, b := range topicList {
+			if (b == common.Hash{}) {
+				continue loop
+			}
+			t[i] = types.BloomIndexes(b.Bytes())
+		}
+		m.topics = append(m.topics, t)
+	}
+}
+
+func (m *Matcher) match(sectionChn chan uint64, stop chan struct{}) (chan uint64, chan BitVector) {
+	subIdx := m.topics
+	if len(m.addresses) > 0 {
+		subIdx = append([][]types.BloomIndexList{m.addresses}, subIdx...)
+	}
+	//fmt.Println("idx", subIdx)
+	m.distChn = make(chan distReq, channelCap)
+	m.getNextReqChn = make(chan chan nextRequests) // should be a blocking channel
+	go m.distributeRequests(stop)
+
+	s := sectionChn
+	var bv chan BitVector
+	for _, idx := range subIdx {
+		s, bv = m.subMatch(s, bv, idx, stop)
+	}
+	return s, bv
+}
+
+func (m *Matcher) getOrNewFetcher(idx uint) *fetcher {
+	if f, ok := m.fetchers[idx]; ok {
+		return f
+	}
+	f := &fetcher{
+		bitIdx: idx,
+		reqMap: make(map[uint64]req),
+	}
+	m.fetchers[idx] = f
+	return f
+}
+
+// andVector == nil
+func (m *Matcher) subMatch(sectionChn chan uint64, andVectorChn chan BitVector, idxs []types.BloomIndexList, stop chan struct{}) (chan uint64, chan BitVector) {
+	// set up fetchers
+	fetchIdx := make([][3]chan uint64, len(idxs))
+	fetchData := make([][3]chan BitVector, len(idxs))
+	for i, idx := range idxs {
+		for j, ii := range idx {
+			fetchIdx[i][j] = make(chan uint64, channelCap)
+			fetchData[i][j] = m.getOrNewFetcher(ii).fetch(fetchIdx[i][j], m.distChn, stop)
+		}
+	}
+
+	processChn := make(chan uint64, channelCap)
+	resIdxChn := make(chan uint64, channelCap)
+	resDataChn := make(chan BitVector, channelCap)
+
+	// goroutine for starting retrievals
+	go func() {
+		for {
+			select {
+			case <-stop:
+				return
+			case s, ok := <-sectionChn:
+				if !ok {
+					close(processChn)
+					for _, ff := range fetchIdx {
+						for _, f := range ff {
+							close(f)
+						}
+					}
+					return
+				}
+
+				processChn <- s
+				for _, ff := range fetchIdx {
+					for _, f := range ff {
+						f <- s
+					}
+				}
+			}
+		}
+	}()
+
+	// goroutine for processing retrieved data
+	go func() {
+		for {
+			select {
+			case <-stop:
+				return
+			case s, ok := <-processChn:
+				if !ok {
+					close(resIdxChn)
+					close(resDataChn)
+					return
+				}
+
+				var orVector BitVector
+				for _, ff := range fetchData {
+					var andVector BitVector
+					for _, f := range ff {
+						data := <-f
+						if andVector == nil {
+							andVector = bvCopy(data)
+						} else {
+							bvAnd(andVector, data)
+						}
+					}
+					if orVector == nil {
+						orVector = andVector
+					} else {
+						bvOr(orVector, andVector)
+					}
+				}
+
+				if orVector == nil {
+					orVector = bvZero()
+				}
+				if andVectorChn != nil {
+					bvAnd(orVector, <-andVectorChn)
+				}
+				if bvIsNonZero(orVector) {
+					resIdxChn <- s
+					resDataChn <- orVector
+				}
+			}
+		}
+	}()
+
+	return resIdxChn, resDataChn
+}
+
+func (m *Matcher) GetMatches(start, end uint64, stop chan struct{}) chan uint64 {
+	sectionChn := make(chan uint64, channelCap)
+	resultsChn := make(chan uint64, channelCap)
+
+	s, bv := m.match(sectionChn, stop)
+
+	startSection := start / SectionSize
+	endSection := end / SectionSize
+
+	go func() {
+		defer close(sectionChn)
+
+		for i := startSection; i <= endSection; i++ {
+			select {
+			case sectionChn <- i:
+			case <-stop:
+				return
+			}
+		}
+	}()
+
+	go func() {
+		defer close(resultsChn)
+
+		for {
+			select {
+			case idx, ok := <-s:
+				if !ok {
+					return
+				}
+				match := <-bv //nil check
+				sectionStart := idx * SectionSize
+				s := sectionStart
+				if start > s {
+					s = start
+				}
+				e := sectionStart + SectionSize - 1
+				if end < e {
+					e = end
+				}
+				for i := s; i <= e; i++ {
+					b := match[(i-sectionStart)/8]
+					bit := 7 - i%8
+					if b != 0 {
+						if b&(1<<bit) != 0 {
+							resultsChn <- i
+						}
+					} else {
+						i += bit
+					}
+				}
+
+			case <-stop:
+				return
+			}
+		}
+	}()
+
+	return resultsChn
+}
+
+type nextRequests struct {
+	bitIdx         uint
+	sectionIdxList []uint64
+}
+
+func (m *Matcher) distributeRequests(stop chan struct{}) {
+	reqCnt := 0
+	reqs := make(map[uint][]uint64)
+	storeReq := func(r distReq) {
+		queue := reqs[r.bitIdx]
+		i := 0
+		for i < len(queue) && r.sectionIdx > queue[i] {
+			i++
+		}
+		reqs[r.bitIdx] = append(append(queue[:i], r.sectionIdx), queue[i:]...)
+		reqCnt++
+	}
+
+	storeReqs := func(r distReq) {
+		storeReq(r)
+		timeout := time.After(time.Microsecond)
+		for {
+			select {
+			case <-timeout:
+				return
+			case r := <-m.distChn:
+				storeReq(r)
+			}
+		}
+	}
+
+	for {
+		if reqCnt == 0 {
+			select {
+			case r := <-m.distChn:
+				storeReqs(r)
+			case <-stop:
+				return
+			}
+		} else {
+			select {
+			case r := <-m.distChn:
+				storeReqs(r)
+			case <-stop:
+				return
+			case c := <-m.getNextReqChn:
+				var (
+					found       bool
+					bestBit     uint
+					bestSection uint64
+				)
+
+				for bitIdx, queue := range reqs {
+					if len(queue) > 0 && (!found || queue[0] < bestSection) {
+						found = true
+						bestBit = bitIdx
+						bestSection = queue[0]
+					}
+				}
+				if !found {
+					panic(nil)
+				}
+
+				bestQueue := reqs[bestBit]
+				cnt := len(bestQueue)
+				if cnt > maxRequestLength {
+					cnt = maxRequestLength
+				}
+				res := nextRequests{bestBit, bestQueue[:cnt]}
+				reqs[bestBit] = bestQueue[cnt:]
+				reqCnt -= cnt
+
+				c <- res
+			}
+		}
+	}
+}
+
+func (m *Matcher) NextRequest(stop chan struct{}) (bitIdx uint, sectionIdxList []uint64) {
+	c := make(chan nextRequests)
+	select {
+	case m.getNextReqChn <- c:
+		r := <-c
+		//fmt.Println("request", r.bitIdx, r.sectionIdxList)
+		m.fetchers[r.bitIdx].requested(r.sectionIdxList)
+		return r.bitIdx, r.sectionIdxList
+	case <-stop:
+		return 0, nil
+	}
+}
+
+// It is possible to deliver data even after GetMatches has been stopped. Once a vector has been
+// requested, the next call to GetMatches will keep waiting for delivery.
+// If retrieval has been cancelled, call Deliver with data == nil. In this case the next call to
+// GetMatches will re-request it.
+func (m *Matcher) Deliver(bitIdx uint, sectionIdxList []uint64, data []BitVector) {
+	m.fetchers[bitIdx].deliver(sectionIdxList, data)
+}

--- a/core/bloombits/utils.go
+++ b/core/bloombits/utils.go
@@ -1,0 +1,165 @@
+// Copyright 2017 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+package bloombits
+
+import (
+	"github.com/ethereum/go-ethereum/core/types"
+)
+
+const SectionSize = 4096
+
+type (
+	BitVector  []byte
+	CompVector []byte
+)
+
+func bvAnd(a, b BitVector) {
+	for i, bb := range b {
+		a[i] &= bb
+	}
+}
+
+func bvOr(a, b BitVector) {
+	for i, bb := range b {
+		a[i] |= bb
+	}
+}
+
+func bvZero() BitVector {
+	return make(BitVector, SectionSize/8)
+}
+
+func bvCopy(a BitVector) BitVector {
+	c := make(BitVector, SectionSize/8)
+	copy(c, a)
+	return c
+}
+
+func bvIsNonZero(a BitVector) bool {
+	for _, b := range a {
+		if b != 0 {
+			return true
+		}
+	}
+	return false
+}
+
+func CompressBloomBits(bits BitVector) CompVector {
+	if len(bits) != SectionSize/8 {
+		panic(nil)
+	}
+	c := compressBits(bits)
+	if len(c) >= SectionSize/8 {
+		// make a copy so that output is always detached from input
+		return CompVector(bvCopy(bits))
+	}
+	return CompVector(c)
+}
+
+func compressBits(bits []byte) []byte {
+	l := len(bits)
+	b := make([]byte, l/8)
+	c := make([]byte, l)
+	cl := 0
+	for i, v := range bits {
+		if v != 0 {
+			c[cl] = v
+			cl++
+			b[i/8] |= 1 << byte(7-i%8)
+		}
+	}
+	if cl == 0 {
+		return nil
+	}
+	if l > 8 {
+		b = compressBits(b)
+	}
+	return append(b, c[0:cl]...)
+}
+
+func DecompressBloomBits(bits CompVector) BitVector {
+	if len(bits) == SectionSize/8 {
+		// make a copy so that output is always detached from input
+		return bvCopy(BitVector(bits))
+	}
+	dc, ofs := decompressBits(bits, SectionSize/8)
+	if ofs != len(bits) {
+		panic(nil)
+	}
+	return dc
+}
+
+func decompressBits(bits []byte, targetLen int) ([]byte, int) {
+	lb := len(bits)
+	dc := make([]byte, targetLen)
+	if lb == 0 {
+		return dc, 0
+	}
+
+	l := targetLen / 8
+	var (
+		b   []byte
+		ofs int
+	)
+	if l == 1 {
+		b = bits[0:1]
+		ofs = 1
+	} else {
+		b, ofs = decompressBits(bits, l)
+	}
+	for i, _ := range dc {
+		if b[i/8]&(1<<byte(7-i%8)) != 0 {
+			if ofs == lb {
+				panic(nil)
+			}
+			dc[i] = bits[ofs]
+			ofs++
+		}
+	}
+	return dc, ofs
+}
+
+const BloomLength = 2048
+
+type BloomBitsCreator struct {
+	blooms [BloomLength][SectionSize / 8]byte
+	bitIdx uint
+}
+
+func (b *BloomBitsCreator) AddHeaderBloom(bloom types.Bloom) {
+	if b.bitIdx >= SectionSize {
+		panic("too many header blooms added")
+	}
+
+	byteIdx := b.bitIdx / 8
+	bitMask := byte(1) << byte(7-b.bitIdx%8)
+	for bloomBitIdx, _ := range b.blooms {
+		bloomByteIdx := BloomLength/8 - 1 - bloomBitIdx/8
+		bloomBitMask := byte(1) << byte(bloomBitIdx%8)
+		if (bloom[bloomByteIdx] & bloomBitMask) != 0 {
+			b.blooms[bloomBitIdx][byteIdx] |= bitMask
+		}
+	}
+	b.bitIdx++
+}
+
+func (b *BloomBitsCreator) GetBitVector(idx uint) BitVector {
+	if b.bitIdx != SectionSize {
+		panic("not enough header blooms added")
+	}
+
+	return BitVector(b.blooms[idx][:])
+}

--- a/core/database_util.go
+++ b/core/database_util.go
@@ -26,6 +26,7 @@ import (
 	"sync"
 
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/bloombits"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/ethdb"
 	"github.com/ethereum/go-ethereum/logger"
@@ -71,6 +72,9 @@ var (
 
 	preimageCounter    = metrics.NewCounter("db/preimage/total")
 	preimageHitCounter = metrics.NewCounter("db/preimage/hits")
+
+	bloomBitsPrefix   = []byte("bloomBits-")
+	bloomBitsAvailKey = []byte("bloomBitsAvailable")
 )
 
 // encodeBlockNumber encodes a block number as big endian uint64
@@ -698,4 +702,53 @@ func FindCommonAncestor(db ethdb.Database, a, b *types.Header) *types.Header {
 		}
 	}
 	return a
+}
+
+func GetBloomBits(db ethdb.Database, bitIdx, sectionIdx uint64) (bloombits.CompVector, error) {
+	var encKey [10]byte
+	binary.BigEndian.PutUint16(encKey[0:2], uint16(bitIdx))
+	binary.BigEndian.PutUint64(encKey[2:10], sectionIdx)
+	key := append(bloomBitsPrefix, encKey[:]...)
+	bloomBits, err := db.Get(key)
+	return bloombits.CompVector(bloomBits), err
+}
+
+func StoreBloomBits(db ethdb.Database, bitIdx, sectionIdx uint64, bloomBits bloombits.CompVector) {
+	var encKey [10]byte
+	binary.BigEndian.PutUint16(encKey[0:2], uint16(bitIdx))
+	binary.BigEndian.PutUint64(encKey[2:10], sectionIdx)
+	key := append(bloomBitsPrefix, encKey[:]...)
+	db.Put(key, bloomBits)
+}
+
+func GetBloomBitsAvailable(db ethdb.Database) uint64 {
+	data, _ := db.Get(bloomBitsAvailKey)
+	if len(data) == 8 {
+		return binary.BigEndian.Uint64(data[:])
+	}
+	return 0
+}
+
+func StoreBloomBitsAvailable(db ethdb.Database, cnt uint64) {
+	var data [8]byte
+	binary.BigEndian.PutUint64(data[:], cnt)
+	db.Put(bloomBitsAvailKey, data[:])
+}
+
+func MakeBloomBitsSection(db ethdb.Database, sectionIdx uint64) error {
+	bc := &bloombits.BloomBitsCreator{}
+	for i := sectionIdx * bloombits.SectionSize; i < (sectionIdx+1)*bloombits.SectionSize; i++ {
+		hash := GetCanonicalHash(db, i)
+		header := GetHeader(db, hash, i)
+		if header == nil {
+			glog.V(logger.Error).Infof("Error creating bloomBits section #%d: header #%d not found", sectionIdx, i)
+			return errors.New("Header not found")
+		}
+		bc.AddHeaderBloom(header.Bloom)
+	}
+
+	for i := 0; i < bloombits.BloomLength; i++ {
+		StoreBloomBits(db, uint64(i), sectionIdx, bloombits.CompressBloomBits(bc.GetBitVector(uint(i))))
+	}
+	return nil
 }

--- a/core/types/bloom9.go
+++ b/core/types/bloom9.go
@@ -106,6 +106,19 @@ func LogsBloom(logs []*Log) *big.Int {
 	return bin
 }
 
+type BloomIndexList [3]uint
+
+func BloomIndexes(b []byte) BloomIndexList {
+	b = crypto.Keccak256(b[:])
+
+	var r [3]uint
+	for i, _ := range r {
+		r[i] = (uint(b[i+i+1]) + (uint(b[i+i]) << 8)) & 2047
+	}
+
+	return r
+}
+
 func bloom9(b []byte) *big.Int {
 	b = crypto.Keccak256(b[:])
 

--- a/eth/api_backend.go
+++ b/eth/api_backend.go
@@ -22,6 +22,7 @@ import (
 	"github.com/ethereum/go-ethereum/accounts"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core"
+	"github.com/ethereum/go-ethereum/core/bloombits"
 	"github.com/ethereum/go-ethereum/core/state"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/core/vm"
@@ -197,6 +198,18 @@ func (b *EthApiBackend) EventMux() *event.TypeMux {
 
 func (b *EthApiBackend) AccountManager() *accounts.Manager {
 	return b.eth.AccountManager()
+}
+
+func (b *EthApiBackend) GetBloomBits(ctx context.Context, bitIdx uint64, sectionIdxList []uint64) ([]bloombits.CompVector, error) {
+	results := make([]bloombits.CompVector, len(sectionIdxList))
+	var err error
+	for i, idx := range sectionIdxList {
+		results[i], err = core.GetBloomBits(b.eth.chainDb, bitIdx, idx)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return results, nil
 }
 
 type EthApiState struct {

--- a/eth/filters/filter.go
+++ b/eth/filters/filter.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core"
+	"github.com/ethereum/go-ethereum/core/bloombits"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/ethdb"
 	"github.com/ethereum/go-ethereum/event"
@@ -36,12 +37,13 @@ type Backend interface {
 	EventMux() *event.TypeMux
 	HeaderByNumber(ctx context.Context, blockNr rpc.BlockNumber) (*types.Header, error)
 	GetReceipts(ctx context.Context, blockHash common.Hash) (types.Receipts, error)
+	GetBloomBits(ctx context.Context, bitIdx uint64, sectionIdxList []uint64) ([]bloombits.CompVector, error)
 }
 
 // Filter can be used to retrieve and filter logs.
 type Filter struct {
-	backend   Backend
-	useMipMap bool
+	backend                 Backend
+	useMipMap, useBloomBits bool
 
 	created time.Time
 
@@ -49,6 +51,8 @@ type Filter struct {
 	begin, end int64
 	addresses  []common.Address
 	topics     [][]common.Hash
+
+	matcher *bloombits.Matcher
 }
 
 // New creates a new filter which uses a bloom filter on blocks to figure out whether
@@ -57,9 +61,11 @@ type Filter struct {
 // to light clients.
 func New(backend Backend, useMipMap bool) *Filter {
 	return &Filter{
-		backend:   backend,
-		useMipMap: useMipMap,
-		db:        backend.ChainDb(),
+		backend:      backend,
+		useMipMap:    useMipMap,
+		useBloomBits: !useMipMap,
+		db:           backend.ChainDb(),
+		matcher:      bloombits.NewMatcher(),
 	}
 }
 
@@ -79,11 +85,17 @@ func (f *Filter) SetEndBlock(end int64) {
 // in the given addresses.
 func (f *Filter) SetAddresses(addr []common.Address) {
 	f.addresses = addr
+	if f.useBloomBits {
+		f.matcher.SetAddresses(addr)
+	}
 }
 
 // SetTopics matches only logs that have topics matching the given topics.
 func (f *Filter) SetTopics(topics [][]common.Hash) {
 	f.topics = topics
+	if f.useBloomBits {
+		f.matcher.SetTopics(topics)
+	}
 }
 
 // FindOnce searches the blockchain for matching log entries, returning
@@ -167,7 +179,109 @@ func (f *Filter) mipFind(start, end uint64, depth int) (logs []*types.Log, block
 	return nil, end
 }
 
+func (f *Filter) serveMatcher(ctx context.Context, stop chan struct{}) chan error {
+	errChn := make(chan error)
+	for i := 0; i < 10; i++ {
+		go func(i int) {
+			for {
+				//fmt.Println(i, "NextRequest")
+				b, s := f.matcher.NextRequest(stop)
+				//fmt.Println(i, "NextRequest ret", b, s)
+				if s == nil {
+					return
+				}
+				data, err := f.backend.GetBloomBits(ctx, uint64(b), s)
+				//fmt.Println(i, "GetBloomBits", len(data), err)
+				if err != nil {
+					f.matcher.Deliver(b, s, nil)
+					errChn <- err
+					return
+				}
+				decomp := make([]bloombits.BitVector, len(data))
+				for i, d := range data {
+					decomp[i] = bloombits.DecompressBloomBits(bloombits.CompVector(d))
+				}
+				//fmt.Println(i, "Deliver")
+				f.matcher.Deliver(b, s, decomp)
+				//fmt.Println(i, "Deliver ret")
+			}
+		}(i)
+	}
+
+	return errChn
+}
+
 func (f *Filter) getLogs(ctx context.Context, start, end uint64) (logs []*types.Log, blockNumber uint64, err error) {
+
+	checkBlock := func(i uint64, header *types.Header) (logs []*types.Log, blockNumber uint64, err error) {
+		// Get the logs of the block
+		receipts, err := f.backend.GetReceipts(ctx, header.Hash())
+		if err != nil {
+			return nil, end, err
+		}
+		var unfiltered []*types.Log
+		for _, receipt := range receipts {
+			unfiltered = append(unfiltered, ([]*types.Log)(receipt.Logs)...)
+		}
+		logs = filterLogs(unfiltered, nil, nil, f.addresses, f.topics)
+		if len(logs) > 0 {
+			return logs, i, nil
+		}
+		return nil, i, nil
+	}
+
+	if f.useBloomBits {
+		haveBloomBitsBefore := core.GetBloomBitsAvailable(f.db) * bloombits.SectionSize
+		e := end
+		if haveBloomBitsBefore <= e {
+			e = haveBloomBitsBefore - 1
+		}
+
+		stop := make(chan struct{})
+		defer close(stop)
+		//fmt.Println("GetMatches")
+		matches := f.matcher.GetMatches(start, e, stop)
+		//fmt.Println("GetMatches ret")
+		errChn := f.serveMatcher(ctx, stop)
+
+	loop:
+		for {
+			select {
+			case i, ok := <-matches:
+				if !ok {
+					break loop
+				}
+
+				blockNumber := rpc.BlockNumber(i)
+				header, err := f.backend.HeaderByNumber(ctx, blockNumber)
+				if header == nil || err != nil {
+					return logs, end, err
+				}
+
+				l, b, e := checkBlock(i, header)
+
+				//fmt.Println("match", i, f.bloomFilter(header.Bloom), len(l))
+				/*for i := 0; i < 16; i++ {
+					fmt.Println(header.Bloom[i*16 : i*16+16])
+				}*/
+
+				if l != nil || e != nil {
+					return l, b, e
+				}
+			case err := <-errChn:
+				return logs, end, err
+			case <-ctx.Done():
+				return nil, end, ctx.Err()
+			}
+		}
+
+		if end < haveBloomBitsBefore {
+			return logs, end, nil
+		} else {
+			start = haveBloomBitsBefore
+		}
+	}
+
 	for i := start; i <= end; i++ {
 		blockNumber := rpc.BlockNumber(i)
 		header, err := f.backend.HeaderByNumber(ctx, blockNumber)
@@ -178,18 +292,9 @@ func (f *Filter) getLogs(ctx context.Context, start, end uint64) (logs []*types.
 		// Use bloom filtering to see if this block is interesting given the
 		// current parameters
 		if f.bloomFilter(header.Bloom) {
-			// Get the logs of the block
-			receipts, err := f.backend.GetReceipts(ctx, header.Hash())
-			if err != nil {
-				return nil, end, err
-			}
-			var unfiltered []*types.Log
-			for _, receipt := range receipts {
-				unfiltered = append(unfiltered, ([]*types.Log)(receipt.Logs)...)
-			}
-			logs = filterLogs(unfiltered, nil, nil, f.addresses, f.topics)
-			if len(logs) > 0 {
-				return logs, uint64(blockNumber), nil
+			l, b, e := checkBlock(i, header)
+			if l != nil || e != nil {
+				return l, b, e
 			}
 		}
 	}

--- a/les/api_backend.go
+++ b/les/api_backend.go
@@ -22,6 +22,7 @@ import (
 	"github.com/ethereum/go-ethereum/accounts"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core"
+	"github.com/ethereum/go-ethereum/core/bloombits"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/core/vm"
 	"github.com/ethereum/go-ethereum/eth/downloader"
@@ -152,4 +153,8 @@ func (b *LesApiBackend) EventMux() *event.TypeMux {
 
 func (b *LesApiBackend) AccountManager() *accounts.Manager {
 	return b.eth.accountManager
+}
+
+func (b *LesApiBackend) GetBloomBits(ctx context.Context, bitIdx uint64, sectionIdxList []uint64) ([]bloombits.CompVector, error) {
+	return light.GetBloomBits(ctx, b.eth.odr, bitIdx, sectionIdxList)
 }

--- a/les/flowcontrol/control.go
+++ b/les/flowcontrol/control.go
@@ -130,6 +130,7 @@ func (peer *ServerNode) recalcBLE(time mclock.AbsTime) {
 const safetyMargin = time.Millisecond * 200
 
 func (peer *ServerNode) canSend(maxCost uint64) time.Duration {
+	peer.recalcBLE(mclock.Now())
 	maxCost += uint64(safetyMargin) * peer.params.MinRecharge / uint64(fcTimeConst)
 	if maxCost > peer.params.BufLimit {
 		maxCost = peer.params.BufLimit
@@ -204,13 +205,11 @@ func (peer *ServerNode) SendRequest(reqID, maxCost uint64) {
 		peer.lock.Lock()
 	}
 
-	peer.recalcBLE(mclock.Now())
 	wait := peer.canSend(maxCost)
 	for wait > 0 {
 		peer.lock.Unlock()
 		time.Sleep(wait)
 		peer.lock.Lock()
-		peer.recalcBLE(mclock.Now())
 		wait = peer.canSend(maxCost)
 	}
 	peer.assignedRequest = 0

--- a/les/peer.go
+++ b/les/peer.go
@@ -193,6 +193,11 @@ func (p *peer) SendHeaderProofs(reqID, bv uint64, proofs []ChtResp) error {
 	return sendResponse(p.rw, HeaderProofsMsg, reqID, bv, proofs)
 }
 
+// SendBloomBits sends a batch of bloom proofs, corresponding to the ones requested.
+func (p *peer) SendBloomBits(reqID, bv uint64, proofs []BloomResp) error {
+	return sendResponse(p.rw, BloomBitsMsg, reqID, bv, proofs)
+}
+
 // RequestHeadersByHash fetches a batch of blocks' headers corresponding to the
 // specified header query, based on the hash of an origin block.
 func (p *peer) RequestHeadersByHash(reqID, cost uint64, origin common.Hash, amount int, skip int, reverse bool) error {
@@ -216,7 +221,7 @@ func (p *peer) RequestBodies(reqID, cost uint64, hashes []common.Hash) error {
 
 // RequestCode fetches a batch of arbitrary data from a node's known state
 // data, corresponding to the specified hashes.
-func (p *peer) RequestCode(reqID, cost uint64, reqs []*CodeReq) error {
+func (p *peer) RequestCode(reqID, cost uint64, reqs []CodeReq) error {
 	glog.V(logger.Debug).Infof("%v fetching %v state data", p, len(reqs))
 	return sendRequest(p.rw, GetCodeMsg, reqID, cost, reqs)
 }
@@ -228,15 +233,21 @@ func (p *peer) RequestReceipts(reqID, cost uint64, hashes []common.Hash) error {
 }
 
 // RequestProofs fetches a batch of merkle proofs from a remote node.
-func (p *peer) RequestProofs(reqID, cost uint64, reqs []*ProofReq) error {
+func (p *peer) RequestProofs(reqID, cost uint64, reqs []ProofReq) error {
 	glog.V(logger.Debug).Infof("%v fetching %v proofs", p, len(reqs))
 	return sendRequest(p.rw, GetProofsMsg, reqID, cost, reqs)
 }
 
 // RequestHeaderProofs fetches a batch of header merkle proofs from a remote node.
-func (p *peer) RequestHeaderProofs(reqID, cost uint64, reqs []*ChtReq) error {
+func (p *peer) RequestHeaderProofs(reqID, cost uint64, reqs []ChtReq) error {
 	glog.V(logger.Debug).Infof("%v fetching %v header proofs", p, len(reqs))
 	return sendRequest(p.rw, GetHeaderProofsMsg, reqID, cost, reqs)
+}
+
+// RequestBloomBits fetches a batch of bloom merkle proofs from a remote node.
+func (p *peer) RequestBloomBits(reqID, cost uint64, reqs []BloomReq) error {
+	glog.V(logger.Debug).Infof("%v fetching %v bloom proofs", p, len(reqs))
+	return sendRequest(p.rw, GetBloomBitsMsg, reqID, cost, reqs)
 }
 
 func (p *peer) SendTxs(cost uint64, txs types.Transactions) error {

--- a/les/protocol.go
+++ b/les/protocol.go
@@ -36,7 +36,7 @@ const (
 var ProtocolVersions = []uint{lpv1}
 
 // Number of implemented message corresponding to different protocol versions.
-var ProtocolLengths = []uint64{15}
+var ProtocolLengths = []uint64{17}
 
 const (
 	NetworkId          = 1
@@ -61,6 +61,8 @@ const (
 	SendTxMsg          = 0x0c
 	GetHeaderProofsMsg = 0x0d
 	HeaderProofsMsg    = 0x0e
+	GetBloomBitsMsg    = 0x0f
+	BloomBitsMsg       = 0x10
 )
 
 type errCode int

--- a/les/serverpool.go
+++ b/les/serverpool.go
@@ -333,7 +333,7 @@ func (pool *serverPool) selectPeer(reqID uint64, canSend func(*peer) (bool, time
 func (pool *serverPool) selectPeerWait(reqID uint64, canSend func(*peer) (bool, time.Duration), abort <-chan struct{}) *peer {
 	for {
 		peer, wait, locked := pool.selectPeer(reqID, canSend)
-		if locked {
+		if locked || peer == nil {
 			return peer
 		}
 		select {

--- a/light/odr.go
+++ b/light/odr.go
@@ -138,7 +138,7 @@ func (req *ReceiptsRequest) StoreResult(db ethdb.Database) {
 	core.WriteBlockReceipts(db, req.Hash, req.Number, req.Receipts)
 }
 
-// TrieRequest is the ODR request type for state/storage trie entries
+// ChtRequest is the ODR request type for retrieving old headers from a CHT structure
 type ChtRequest struct {
 	OdrRequest
 	ChtNum, BlockNum uint64
@@ -155,5 +155,21 @@ func (req *ChtRequest) StoreResult(db ethdb.Database) {
 	hash, num := req.Header.Hash(), req.Header.Number.Uint64()
 	core.WriteTd(db, hash, num, req.Td)
 	core.WriteCanonicalHash(db, hash, num)
-	//storeProof(db, req.Proof)
+}
+
+// BloomRequest is the ODR request type for retrieving bloom filters from a CHT structure
+type BloomRequest struct {
+	OdrRequest
+	ChtNum, BitIdx uint64
+	SectionIdxList []uint64
+	ChtRoot        common.Hash
+	BloomBits      [][]byte
+	Proofs         [][]rlp.RawValue
+}
+
+// StoreResult stores the retrieved data in local database
+func (req *BloomRequest) StoreResult(db ethdb.Database) {
+	for i, sectionIdx := range req.SectionIdxList {
+		core.StoreBloomBits(db, req.BitIdx, sectionIdx, req.BloomBits[i])
+	}
 }


### PR DESCRIPTION
This PR optimizes log searching by creating a data structure (BloomBits) that makes it cheaper to retrieve bloom filter data relevant to a specific filter either from the database or through the LES protocol. When searching in a long section of the block history, we are checking three specific bits of each bloom filter per address/topic. In order to do that, currently we read/retrieve a cca. 500 byte block header for each block. The implemented structure optimizes this by a "bitwise 90 degree rotation" of the bloom filters. Blocks are grouped into sections (SectionSize is 4096 blocks at the moment), BloomBits[bitIdx][sectionIdx] is a 4096 bit (512 byte) long bit vector that contains a single bit of each bloom filter from the block range [sectionIdx*SectionSize ... (sectionIdx+1)*SectionSize-1]. (Since bloom filters are usually sparse, a simple data compression makes this structure even more efficient, especially for ODR retrieval.) By reading and binary AND-ing three BloomBits sections, we can filter for an address/topic in 4096 blocks at once ("1" bits in the binary AND result mean bloom matches).
A new request/reply pair is added to LES (GetBloomBits/BloomBits), which retrieve/serve Merkle proofs of BloomBits sections, which are added to the CHT trie. Headers downloaded after the CHT checkpoint are processed by the client, the recent BloomBits (along with the recent headers) are always available in the database.
This search algorithm is currently only used by the light client but it could be considered for full clients too. If the required BloomBits data is available locally, an address search in the entire 3M block history takes only a fraction of a second (around 0.1-0.2s). A second level filter (MIP mapping) could be used with this approach too, but it is not a high priority at the moment because of its high efficiency in its current single-level form. This approach also saves a lot of database writes compared to the current MIP map implementation.

Note: the PR is under heavy development at the moment, hopefully it will be functional again later this week.