### PR TITLE
cmd/geth, cmd/swarm: Fix to close file handler appropriately

### DIFF
--- a/cmd/geth/chaincmd.go
+++ b/cmd/geth/chaincmd.go
@@ -123,6 +123,7 @@ func initGenesis(ctx *cli.Context) error {
 	if err != nil {
 		utils.Fatalf("failed to read genesis file: %v", err)
 	}
+	defer genesisFile.Close()
 
 	block, err := core.WriteGenesisBlock(chaindb, genesisFile)
 	if err != nil {

--- a/cmd/swarm/hash.go
+++ b/cmd/swarm/hash.go
@@ -36,6 +36,7 @@ func hash(ctx *cli.Context) {
 		fmt.Println("Error opening file " + args[1])
 		os.Exit(1)
 	}
+	defer f.Close()
 
 	stat, _ := f.Stat()
 	chunker := storage.NewTreeChunker(storage.NewChunkerParams())


### PR DESCRIPTION
It must call `Close` after `os.Open`.