### PR TITLE
core/genesis: add support for setting nonce in 'alloc'

### DIFF
--- a/core/genesis.go
+++ b/core/genesis.go
@@ -57,6 +57,7 @@ func WriteGenesisBlock(chainDb ethdb.Database, reader io.Reader) (*types.Block, 
 			Code    string
 			Storage map[string]string
 			Balance string
+			Nonce   string
 		}
 	}
 
@@ -70,6 +71,7 @@ func WriteGenesisBlock(chainDb ethdb.Database, reader io.Reader) (*types.Block, 
 		address := common.HexToAddress(addr)
 		statedb.AddBalance(address, common.String2Big(account.Balance))
 		statedb.SetCode(address, common.Hex2Bytes(account.Code))
+		statedb.SetNonce(address, common.String2Big(account.Nonce).Uint64())
 		for key, value := range account.Storage {
 			statedb.SetState(address, common.HexToHash(key), common.HexToHash(value))
 		}


### PR DESCRIPTION
This is to be able to set `pre`-state when performing blockchain tests through Hive, we need to be able to set the nonce. 