### PR TITLE
trie: add difference iterator

### DIFF
--- a/core/state/iterator.go
+++ b/core/state/iterator.go
@@ -80,7 +80,7 @@ func (it *NodeIterator) step() error {
 	}
 	// If we had data nodes previously, we surely have at least state nodes
 	if it.dataIt != nil {
-		if cont := it.dataIt.Next(); !cont {
+		if cont := it.dataIt.Next(true); !cont {
 			if it.dataIt.Error != nil {
 				return it.dataIt.Error
 			}
@@ -94,7 +94,7 @@ func (it *NodeIterator) step() error {
 		return nil
 	}
 	// Step to the next state trie node, terminating if we're out of nodes
-	if cont := it.stateIt.Next(); !cont {
+	if cont := it.stateIt.Next(true); !cont {
 		if it.stateIt.Error != nil {
 			return it.stateIt.Error
 		}
@@ -120,7 +120,7 @@ func (it *NodeIterator) step() error {
 		return err
 	}
 	it.dataIt = trie.NewNodeIterator(dataTrie)
-	if !it.dataIt.Next() {
+	if !it.dataIt.Next(true) {
 		it.dataIt = nil
 	}
 	if !bytes.Equal(account.CodeHash, emptyCodeHash) {

--- a/core/state/iterator.go
+++ b/core/state/iterator.go
@@ -31,15 +31,14 @@ import (
 type NodeIterator struct {
 	state *StateDB // State being iterated
 
-	stateIt *trie.NodeIterator // Primary iterator for the global state trie
-	dataIt  *trie.NodeIterator // Secondary iterator for the data trie of a contract
+	stateIt trie.NodeIterator // Primary iterator for the global state trie
+	dataIt  trie.NodeIterator // Secondary iterator for the data trie of a contract
 
 	accountHash common.Hash // Hash of the node containing the account
 	codeHash    common.Hash // Hash of the contract source code
 	code        []byte      // Source code associated with a contract
 
 	Hash   common.Hash // Hash of the current entry being iterated (nil if not standalone)
-	Entry  interface{} // Current state entry being iterated (internal representation)
 	Parent common.Hash // Hash of the first full ancestor node (nil if current is the root)
 
 	Error error // Failure set in case of an internal error in the iterator
@@ -81,8 +80,8 @@ func (it *NodeIterator) step() error {
 	// If we had data nodes previously, we surely have at least state nodes
 	if it.dataIt != nil {
 		if cont := it.dataIt.Next(true); !cont {
-			if it.dataIt.Error != nil {
-				return it.dataIt.Error
+			if it.dataIt.Error() != nil {
+				return it.dataIt.Error()
 			}
 			it.dataIt = nil
 		}
@@ -95,14 +94,14 @@ func (it *NodeIterator) step() error {
 	}
 	// Step to the next state trie node, terminating if we're out of nodes
 	if cont := it.stateIt.Next(true); !cont {
-		if it.stateIt.Error != nil {
-			return it.stateIt.Error
+		if it.stateIt.Error() != nil {
+			return it.stateIt.Error()
 		}
 		it.state, it.stateIt = nil, nil
 		return nil
 	}
 	// If the state trie node is an internal entry, leave as is
-	if !it.stateIt.Leaf {
+	if !it.stateIt.Leaf() {
 		return nil
 	}
 	// Otherwise we've reached an account node, initiate data iteration
@@ -112,7 +111,7 @@ func (it *NodeIterator) step() error {
 		Root     common.Hash
 		CodeHash []byte
 	}
-	if err := rlp.Decode(bytes.NewReader(it.stateIt.LeafBlob), &account); err != nil {
+	if err := rlp.Decode(bytes.NewReader(it.stateIt.LeafBlob()), &account); err != nil {
 		return err
 	}
 	dataTrie, err := trie.New(account.Root, it.state.db)
@@ -130,7 +129,7 @@ func (it *NodeIterator) step() error {
 			return fmt.Errorf("code %x: %v", account.CodeHash, err)
 		}
 	}
-	it.accountHash = it.stateIt.Parent
+	it.accountHash = it.stateIt.Parent()
 	return nil
 }
 
@@ -138,7 +137,7 @@ func (it *NodeIterator) step() error {
 // The method returns whether there are any more data left for inspection.
 func (it *NodeIterator) retrieve() bool {
 	// Clear out any previously set values
-	it.Hash, it.Entry = common.Hash{}, nil
+	it.Hash = common.Hash{}
 
 	// If the iteration's done, return no available data
 	if it.state == nil {
@@ -147,14 +146,14 @@ func (it *NodeIterator) retrieve() bool {
 	// Otherwise retrieve the current entry
 	switch {
 	case it.dataIt != nil:
-		it.Hash, it.Entry, it.Parent = it.dataIt.Hash, it.dataIt.Node, it.dataIt.Parent
+		it.Hash, it.Parent = it.dataIt.Hash(), it.dataIt.Parent()
 		if it.Parent == (common.Hash{}) {
 			it.Parent = it.accountHash
 		}
 	case it.code != nil:
-		it.Hash, it.Entry, it.Parent = it.codeHash, it.code, it.accountHash
+		it.Hash, it.Parent = it.codeHash, it.accountHash
 	case it.stateIt != nil:
-		it.Hash, it.Entry, it.Parent = it.stateIt.Hash, it.stateIt.Node, it.stateIt.Parent
+		it.Hash, it.Parent = it.stateIt.Hash(), it.stateIt.Parent()
 	}
 	return true
 }

--- a/trie/iterator_test.go
+++ b/trie/iterator_test.go
@@ -17,6 +17,7 @@
 package trie
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -44,6 +45,7 @@ func TestIterator(t *testing.T) {
 	found := make(map[string]string)
 	it := NewIterator(trie)
 	for it.Next() {
+		fmt.Printf("%s=%s\n", it.Key, it.Value)
 		found[string(it.Key)] = string(it.Value)
 	}
 

--- a/trie/iterator_test.go
+++ b/trie/iterator_test.go
@@ -100,8 +100,8 @@ func TestNodeIteratorCoverage(t *testing.T) {
 	// Gather all the node hashes found by the iterator
 	hashes := make(map[common.Hash]struct{})
 	for it := NewNodeIterator(trie); it.Next(true); {
-		if it.Hash != (common.Hash{}) {
-			hashes[it.Hash] = struct{}{}
+		if it.Hash() != (common.Hash{}) {
+			hashes[it.Hash()] = struct{}{}
 		}
 	}
 	// Cross check the hashes and the database itself

--- a/trie/iterator_test.go
+++ b/trie/iterator_test.go
@@ -153,7 +153,7 @@ func TestDifferenceIterator(t *testing.T) {
 
 	found := make(map[string]string)
 	di, _ := NewDifferenceIterator(NewNodeIterator(triea), NewNodeIterator(trieb))
-	it := FromNodeIterator(di)
+	it := NewIteratorFromNodeIterator(di)
 	for it.Next() {
 		found[string(it.Key)] = string(it.Value)
 	}

--- a/trie/iterator_test.go
+++ b/trie/iterator_test.go
@@ -17,7 +17,6 @@
 package trie
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -45,7 +44,6 @@ func TestIterator(t *testing.T) {
 	found := make(map[string]string)
 	it := NewIterator(trie)
 	for it.Next() {
-		fmt.Printf("%s=%s\n", it.Key, it.Value)
 		found[string(it.Key)] = string(it.Value)
 	}
 

--- a/trie/iterator_test.go
+++ b/trie/iterator_test.go
@@ -101,7 +101,7 @@ func TestNodeIteratorCoverage(t *testing.T) {
 
 	// Gather all the node hashes found by the iterator
 	hashes := make(map[common.Hash]struct{})
-	for it := NewNodeIterator(trie); it.Next(); {
+	for it := NewNodeIterator(trie); it.Next(true); {
 		if it.Hash != (common.Hash{}) {
 			hashes[it.Hash] = struct{}{}
 		}

--- a/trie/secure_trie.go
+++ b/trie/secure_trie.go
@@ -159,7 +159,7 @@ func (t *SecureTrie) Iterator() *Iterator {
 	return t.trie.Iterator()
 }
 
-func (t *SecureTrie) NodeIterator() *NodeIterator {
+func (t *SecureTrie) NodeIterator() NodeIterator {
 	return NewNodeIterator(&t.trie)
 }
 

--- a/trie/sync_test.go
+++ b/trie/sync_test.go
@@ -81,7 +81,7 @@ func checkTrieConsistency(db Database, root common.Hash) error {
 		return nil // // Consider a non existent state consistent
 	}
 	it := NewNodeIterator(trie)
-	for it.Next() {
+	for it.Next(true) {
 	}
 	return it.Error
 }

--- a/trie/sync_test.go
+++ b/trie/sync_test.go
@@ -83,7 +83,7 @@ func checkTrieConsistency(db Database, root common.Hash) error {
 	it := NewNodeIterator(trie)
 	for it.Next(true) {
 	}
-	return it.Error
+	return it.Error()
 }
 
 // Tests that an empty trie is not scheduled for syncing.


### PR DESCRIPTION
This PR implements a differenceIterator, which allows iterating over trie nodes that exist in one trie but not in another. This is a prerequisite for most GC strategies, in order to find obsolete nodes.