### PR TITLE
cmd/abigen: parse contract name as abi identifier

### DIFF
--- a/cmd/abigen/main.go
+++ b/cmd/abigen/main.go
@@ -94,7 +94,9 @@ func main() {
 			abi, _ := json.Marshal(contract.Info.AbiDefinition) // Flatten the compiler parse
 			abis = append(abis, string(abi))
 			bins = append(bins, contract.Code)
-			types = append(types, name)
+
+			nameParts := strings.Split(name, ":")
+			types = append(types, nameParts[len(nameParts)-1])
 		}
 	} else {
 		// Otherwise load up the ABI, optional bytecode and type name from the parameters


### PR DESCRIPTION
abigen uses solc to generate metadata that it uses to generate go source. In recent versions of solc this output has changed.

Old:
```
{"contracts":{"Test":{"abi":"[]","bin":"6060604052346000575b60098060156000396000f360606040525b600056","devdoc":"{\"methods\":{}}","userdoc":"{\"methods\":{}}"}},"version":"0.4.5+commit.b318366e.Darwin.appleclang"}
```

New:
```
{"contracts":{"/Users/bas/Development/solidity/test.sol:Test":{"abi":"[]","bin":"60606040523415600b57fe5b5b60338060196000396000f30060606040525bfe00a165627a7a723058206f9044412a2f9a29f53b93219d1c72e0ab78781f0df0747245addce67b218c5b0029","devdoc":"{\"methods\":{}}","userdoc":"{\"methods\":{}}"}},"version":"0.4.10-develop.2017.2.6+commit.3cbdafcf.Darwin.appleclang"}
```

In the latest version of solc the contract identifier contains the full filename and contract identifier. This PR will parse the contract name.

Fixes: #3646