### PR TITLE
core,eth,internal: Added `debug_getBadBlocks()` method

### DIFF
--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -1257,12 +1257,14 @@ func (bc *BlockChain) BadBlocks() ([]BadBlockArgs, error) {
 	headers := make([]BadBlockArgs, 0, bc.badBlocks.Len())
 	for _, hash := range bc.badBlocks.Keys() {
 		if hdr, exist := bc.badBlocks.Peek(hash); exist {
-			headers = append(headers, BadBlockArgs{hdr.(*types.Header).Hash(), hdr.(*types.Header)})
+			header := hdr.(*types.Header)
+			headers = append(headers, BadBlockArgs{header.Hash(), header})
 		}
 	}
 	return headers, nil
 }
-// Adds a 'bad lock' to the LRU
+
+// addBadBlock adds a bad block to the bad-block LRU cache
 func (bc *BlockChain) addBadBlock(block *types.Block) {
 	bc.badBlocks.Add(block.Header().Hash(), block.Header())
 }

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -60,6 +60,7 @@ const (
 	// must be bumped when consensus algorithm is changed, this forces the upgradedb
 	// command to be run (forces the blocks to be imported again using the new algorithm)
 	BlockChainVersion = 3
+	badBlockLimit     = 10
 )
 
 // BlockChain represents the canonical chain given a database with a genesis
@@ -108,6 +109,8 @@ type BlockChain struct {
 	processor Processor // block processor interface
 	validator Validator // block and state validator interface
 	vmConfig  vm.Config
+
+	badBlocks *lru.Cache // Bad block cache
 }
 
 // NewBlockChain returns a fully initialised block chain using information
@@ -118,6 +121,7 @@ func NewBlockChain(chainDb ethdb.Database, config *params.ChainConfig, pow pow.P
 	bodyRLPCache, _ := lru.New(bodyCacheLimit)
 	blockCache, _ := lru.New(blockCacheLimit)
 	futureBlocks, _ := lru.New(maxFutureBlocks)
+	badBlocks,_ := lru.New(badBlockLimit)
 
 	bc := &BlockChain{
 		config:       config,
@@ -130,6 +134,7 @@ func NewBlockChain(chainDb ethdb.Database, config *params.ChainConfig, pow pow.P
 		futureBlocks: futureBlocks,
 		pow:          pow,
 		vmConfig:     vmConfig,
+		badBlocks:    badBlocks,
 	}
 	bc.SetValidator(NewBlockValidator(config, bc, pow))
 	bc.SetProcessor(NewStateProcessor(config, bc))
@@ -893,7 +898,6 @@ func (self *BlockChain) InsertChain(chain types.Blocks) (int, error) {
 			glog.V(logger.Debug).Infoln("Premature abort during block chain processing")
 			break
 		}
-
 		bstart := time.Now()
 		// Wait for block i's nonce to be verified before processing
 		// its state transition.
@@ -1241,9 +1245,28 @@ func (self *BlockChain) update() {
 		}
 	}
 }
+// SendTxArgs represents the arguments to sumbit a new transaction into the transaction pool.
+type BadBlockArgs struct {
+	Hash     common.Hash  `json:"hash"`
+	Header   *types.Header `json:"header"`
+}
+// BadBlocks returns a list of the last 'bad blocks' that the client has seen on the network
+func (bc *BlockChain) BadBlocks() ([] BadBlockArgs, error) {
+	headers := make([]BadBlockArgs, 0, bc.badBlocks.Len())
+	for _, hash := range bc.badBlocks.Keys() {
+		if hdr, exist := bc.badBlocks.Peek(hash); exist {
+			headers = append(headers, BadBlockArgs{ hdr.(*types.Header).Hash(), hdr.(*types.Header)})
+		}
+	}
+	return headers, nil
+}
+func (bc *BlockChain) addBadBlock(block *types.Block){
+	bc.badBlocks.Add(block.Header().Hash(), block.Header())
+}
 
 // reportBlock logs a bad block error.
 func (bc *BlockChain) reportBlock(block *types.Block, receipts types.Receipts, err error) {
+	bc.addBadBlock(block)
 	if glog.V(logger.Error) {
 		var receiptString string
 		for _, receipt := range receipts {

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -121,7 +121,7 @@ func NewBlockChain(chainDb ethdb.Database, config *params.ChainConfig, pow pow.P
 	bodyRLPCache, _ := lru.New(bodyCacheLimit)
 	blockCache, _ := lru.New(blockCacheLimit)
 	futureBlocks, _ := lru.New(maxFutureBlocks)
-	badBlocks,_ := lru.New(badBlockLimit)
+	badBlocks, _ := lru.New(badBlockLimit)
 
 	bc := &BlockChain{
 		config:       config,
@@ -1245,22 +1245,25 @@ func (self *BlockChain) update() {
 		}
 	}
 }
-// SendTxArgs represents the arguments to sumbit a new transaction into the transaction pool.
+
+// BadBlockArgs represents the entries in the list returned when bad blocks are queried.
 type BadBlockArgs struct {
-	Hash     common.Hash  `json:"hash"`
-	Header   *types.Header `json:"header"`
+	Hash   common.Hash   `json:"hash"`
+	Header *types.Header `json:"header"`
 }
+
 // BadBlocks returns a list of the last 'bad blocks' that the client has seen on the network
-func (bc *BlockChain) BadBlocks() ([] BadBlockArgs, error) {
+func (bc *BlockChain) BadBlocks() ([]BadBlockArgs, error) {
 	headers := make([]BadBlockArgs, 0, bc.badBlocks.Len())
 	for _, hash := range bc.badBlocks.Keys() {
 		if hdr, exist := bc.badBlocks.Peek(hash); exist {
-			headers = append(headers, BadBlockArgs{ hdr.(*types.Header).Hash(), hdr.(*types.Header)})
+			headers = append(headers, BadBlockArgs{hdr.(*types.Header).Hash(), hdr.(*types.Header)})
 		}
 	}
 	return headers, nil
 }
-func (bc *BlockChain) addBadBlock(block *types.Block){
+// Adds a 'bad lock' to the LRU
+func (bc *BlockChain) addBadBlock(block *types.Block) {
 	bc.badBlocks.Add(block.Header().Hash(), block.Header())
 }
 

--- a/core/blockchain_test.go
+++ b/core/blockchain_test.go
@@ -485,6 +485,7 @@ func chm(genesis *types.Block, db ethdb.Database) *BlockChain {
 	bc.bodyRLPCache, _ = lru.New(100)
 	bc.blockCache, _ = lru.New(100)
 	bc.futureBlocks, _ = lru.New(100)
+	bc.badBlocks, _ = lru.New(10)
 	bc.SetValidator(bproc{})
 	bc.SetProcessor(bproc{})
 	bc.ResetWithGenesisBlock(genesis)

--- a/eth/api.go
+++ b/eth/api.go
@@ -567,9 +567,8 @@ func (api *PrivateDebugAPI) Preimage(ctx context.Context, hash common.Hash) (hex
 	return db.Get(hash.Bytes())
 }
 
-
 // GetBadBLocks returns a list of the last 'bad blocks' that the client has seen on the network
 // and returns them as a JSON list of block-hashes
-func (api *PrivateDebugAPI) GetBadBlocks(ctx context.Context) ([] core.BadBlockArgs, error) {
+func (api *PrivateDebugAPI) GetBadBlocks(ctx context.Context) ([]core.BadBlockArgs, error) {
 	return api.eth.BlockChain().BadBlocks()
 }

--- a/eth/api.go
+++ b/eth/api.go
@@ -566,3 +566,10 @@ func (api *PrivateDebugAPI) Preimage(ctx context.Context, hash common.Hash) (hex
 	db := core.PreimageTable(api.eth.ChainDb())
 	return db.Get(hash.Bytes())
 }
+
+
+// GetBadBLocks returns a list of the last 'bad blocks' that the client has seen on the network
+// and returns them as a JSON list of block-hashes
+func (api *PrivateDebugAPI) GetBadBlocks(ctx context.Context) ([] core.BadBlockArgs, error) {
+	return api.eth.BlockChain().BadBlocks()
+}

--- a/internal/web3ext/web3ext.go
+++ b/internal/web3ext/web3ext.go
@@ -294,7 +294,12 @@ web3._extend({
 			call: 'debug_preimage',
 			params: 1,
 			inputFormatter: [null]
-		})
+		}),
+		new web3._extend.Method({
+			name: 'getBadBlocks',
+			call: 'debug_getBadBlocks',
+			params: 0,
+		}),
 	],
 	properties: []
 });


### PR DESCRIPTION
When bad blocks are discovered, these are stored within geth.
An RPC-endpoint makes them availablewithin the `debug`
namespace. This feature makes it easier to discover network forks.

Example output: 
```javascript
> debug.getBadBlocks()
[{
    hash: "0xf29000250e8c61b192ee15ad71802cc2d76d1e73db06bd166b79b0918d9024b7",
    header: {
      difficulty: "0x62a132d85e60",
      extraData: "0x4477617266506f6f6c",
      gasLimit: "0x3d5eb1",
      gasUsed: "0x0",
      logsBloom: "0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
      miner: "0x2a65aca4d5fc5b5c859090a6c34d164135398226",
      mixHash: "0x1a082b9b670d4d5cc822a56196e341393477d3b9b2979181323bddbe1b886b4b",
      nonce: "0xda611ab00c7dab10",
      number: "0x2e9a95",
      parentHash: "0x051f6e8c0d456cac879e6707b8507f22cd970be8b5bb5901778acad3bec27007",
      receiptsRoot: "0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421",
      sha3Uncles: "0x01f86b8b6264aed8800b73405ef5d57319a8b268f0b23c11037fc42d7dd260d4",
      stateRoot: "0x2f35c2feb45f16a4f7a00719ee44683103cdb291d58311d938c6a8b622f34c51",
      timestamp: "0x58871d5b",
      transactionsRoot: "0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421"
    }
}, {
    hash: "0xba1a9029ba293fe207667cd2e01882ef18d2a8037918803855313ca15ed22da1",
    header: {
      difficulty: "0x62a142d85e60",
      extraData: "0x61736961312e65746865726d696e652e6f7267",
      gasLimit: "0x3d6e07",
      gasUsed: "0xcbb4f",
      logsBloom: "0x0000000000000000000000000000000000000000004000000000000000002000000000000020000000000004000000010000100000002000000000080000000000000000004000008000000c000000080000000000000000000000000000000001000200001200000000000000000000004080200000000000000010000100000040000100000000000000000008000000000000000000002000000000000000000200000000000100000000000000100000000001000020000000000000000000000002000000000000002000000000000000000000001000920000008000200000000000000000000000000000000400000000000000000000000000000020",
      miner: "0xea674fdde714fd979de3edf0f56aa9716b898ec8",
      mixHash: "0xec517cdda407d8b26b48d46ecf0ea0c1884e2017b355f373991208754e5d3176",
      nonce: "0x7e0fa9600d34bb9d",
      number: "0x2e9a96",
      parentHash: "0xf29000250e8c61b192ee15ad71802cc2d76d1e73db06bd166b79b0918d9024b7",
      receiptsRoot: "0xc601cb85c158f2cc9a2a66ad6e23c14aea23ebe46837fb882ecb3acf8f958280",
      sha3Uncles: "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
      stateRoot: "0xf1f377c6cbaf53cce72b05e9fb3392b784eceb35737aa83033bfe1d4551f83bb",
      timestamp: "0x58871d6a",
      transactionsRoot: "0x0d1ef5239269e1462b6a3ced7d74e9d61b8af4e67db00da8084e608beffc1781"
    }
}]
```