### PR TITLE
core/blockchain: Change iterator in procFutureBlocks

### DIFF
--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -592,7 +592,7 @@ func (bc *BlockChain) Stop() {
 func (self *BlockChain) procFutureBlocks() {
 	blocks := make([]*types.Block, 0, self.futureBlocks.Len())
 	for _, hash := range self.futureBlocks.Keys() {
-		if block, exist := self.futureBlocks.Get(hash); exist {
+		if block, exist := self.futureBlocks.Peek(hash); exist {
 			blocks = append(blocks, block.(*types.Block))
 		}
 	}


### PR DESCRIPTION
to use `lru.Peek` instead of `Get`

See  [`Get`](https://github.com/hashicorp/golang-lru/blob/master/simplelru/lru.go#L73) versus 
[`Peek`](https://github.com/hashicorp/golang-lru/blob/master/simplelru/lru.go#L90) : 

> Returns the key value (or undefined if not found) without updating the "recently used"-ness of the key.

Without this change, we're reordering the `recentness` stochastically when processing future blocks. 