### PR TITLE
ethapi: bugfix for contract creation gas estimate

### DIFF
--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -579,6 +579,11 @@ func (s *PublicBlockChainAPI) Call(ctx context.Context, args CallArgs, blockNr r
 
 // EstimateGas returns an estimate of the amount of gas needed to execute the given transaction.
 func (s *PublicBlockChainAPI) EstimateGas(ctx context.Context, args CallArgs) (*hexutil.Big, error) {
+	if args.To == nil { // contract creation, doCall returns immediately the used gas.
+		_, gas, err := s.doCall(ctx, args, rpc.PendingBlockNumber, vm.Config{})
+		return (*hexutil.Big)(gas), err
+	}
+
 	// Binary search the gas requirement, as it may be higher than the amount used
 	var lo, hi uint64
 	if (*big.Int)(&args.Gas).BitLen() > 0 {


### PR DESCRIPTION
`estimate_gas` does a binary search to estimate the necessary amount of gas. For contract creation this estimate is off (too low). Since it is possible to calculate the amount of necessary gas precisely for contract create transactions this PR will check if the arguments represent a contract creation. And if so returns the necessary gas immediately.

Fixes: #3653 

(Will add a test in the hive rpc test suite).