### PR TITLE
EVM fuzzing

### DIFF
--- a/core/vm/runtime/fuzz.go
+++ b/core/vm/runtime/fuzz.go
@@ -1,0 +1,20 @@
+// +build gofuzz
+
+package runtime
+
+// Fuzz is the basic entry point for the go-fuzz tool
+//
+// This returns 1 for valid parsable/runable code, 0
+// for invalid opcode.
+func Fuzz(input []byte) int {
+	_, _, err := Execute(input, input, &Config{
+		GasLimit: 3000000,
+	})
+
+	// invalid opcode
+	if err != nil && len(err.Error()) > 6 && string(err.Error()[:7]) == "invalid" {
+		return 0
+	}
+
+	return 1
+}


### PR DESCRIPTION
**`	core/vm, crypto: support for go-fuzz `**

Adds support for the [`go-fuzz`](https://github.com/dvyukov/go-fuzz) tool, allowing fuzzing to be done on the EVM.

```sh
# Get go build
go get github.com/dvyukov/go-fuzz/go-fuzz
go get github.com/dvyukov/go-fuzz/go-fuzz-build

# Build the fuzzing env. This generates a “runtime.zip” file in the current directory.
go-fuzz-build -tags nocgo github.com/ethereum/go-ethereum/core/vm/runtime
# Run the fuzzer. The work dir preferable in a persistent directory that doesn’t get wiped. This contains the corpus.
go-fuzz -bin=./runtime.zip -workdir=$HOME/evm-fuzz
```
