### PR TITLE
travis, appveyor: update builders to Go 1.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -53,6 +53,25 @@ matrix:
         - GOARM=6 go run build/ci.go archive -arch arm -type tar -signer LINUX_SIGNING_KEY -upload gethstore/builds
         - GOARM=7 CC=arm-linux-gnueabihf-gcc go run build/ci.go install -arch arm
         - GOARM=7 go run build/ci.go archive -arch arm -type tar -signer LINUX_SIGNING_KEY -upload gethstore/builds
+        # ARM64 linux builds are broken in Go 1.8 (https://github.com/golang/go/issues/19137), reenable in Go 1.8.1
+        # - CC=aarch64-linux-gnu-gcc go run build/ci.go install -arch arm64
+        # - go run build/ci.go archive -arch arm64 -type tar -signer LINUX_SIGNING_KEY -upload gethstore/builds
+
+    # This builder is a temporary fallback for building ARM64 while Go 1.8 is fixed
+    - os: linux
+      dist: trusty
+      sudo: required
+      go: 1.7.5
+      env:
+        - azure-linux-arm64-fallback
+      addons:
+        apt:
+          packages:
+            - gcc-multilib
+      script:
+        - sudo -E apt-get -yq --no-install-suggests --no-install-recommends --force-yes install gcc-aarch64-linux-gnu libc6-dev-arm64-cross
+        - sudo ln -s /usr/include/asm-generic /usr/include/asm
+
         - CC=aarch64-linux-gnu-gcc go run build/ci.go install -arch arm64
         - go run build/ci.go archive -arch arm64 -type tar -signer LINUX_SIGNING_KEY -upload gethstore/builds
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,15 +13,18 @@ matrix:
       go: 1.6.2
     - os: linux
       dist: trusty
-      go: 1.7.4
+      go: 1.7.5
+    - os: linux
+      dist: trusty
+      go: 1.8
     - os: osx
-      go: 1.7.4
+      go: 1.8
 
     # This builder does the Ubuntu PPA and Linux Azure uploads
     - os: linux
       dist: trusty
       sudo: required
-      go: 1.7.4
+      go: 1.8
       env:
         - ubuntu-ppa
         - azure-linux
@@ -73,10 +76,10 @@ matrix:
         - azure-android
         - maven-android
       before_install:
-        - curl https://storage.googleapis.com/golang/go1.8rc3.linux-amd64.tar.gz | tar -xz
+        - curl https://storage.googleapis.com/golang/go1.8.linux-amd64.tar.gz | tar -xz
         - export PATH=`pwd`/go/bin:$PATH
         - export GOROOT=`pwd`/go
-        - export GOPATH=$HOME/go # Drop post Go 1.8
+        - export GOPATH=$HOME/go
       script:
         # Build the Android archive and upload it to Maven Central and Azure
         - curl https://dl.google.com/android/repository/android-ndk-r13b-linux-x86_64.zip -o android-ndk-r13b.zip
@@ -90,7 +93,7 @@ matrix:
 
     # This builder does the OSX Azure, iOS CocoaPods and iOS Azure uploads
     - os: osx
-      go: 1.7.4
+      go: 1.8
       env:
         - azure-osx
         - azure-ios

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -22,8 +22,8 @@ environment:
 
 install:
   - rmdir C:\go /s /q
-  - appveyor DownloadFile https://storage.googleapis.com/golang/go1.7.4.windows-%GETH_ARCH%.zip
-  - 7z x go1.7.4.windows-%GETH_ARCH%.zip -y -oC:\ > NUL
+  - appveyor DownloadFile https://storage.googleapis.com/golang/go1.8.windows-%GETH_ARCH%.zip
+  - 7z x go1.8.windows-%GETH_ARCH%.zip -y -oC:\ > NUL
   - go version
   - gcc --version
 


### PR DESCRIPTION
**ARM64 blocked by https://github.com/golang/go/issues/19137, fixed by https://go-review.googlesource.com/#/c/37251/, scheduled for Go 1.8.1. That single build was reverted to Go 1.7.5.**