### PR TITLE
cmd/geth: added 'geth bug' command

### DIFF
--- a/cmd/geth/bugcmd.go
+++ b/cmd/geth/bugcmd.go
@@ -1,0 +1,100 @@
+// Copyright 2017 The go-ethereum Authors
+// This file is part of go-ethereum.
+//
+// go-ethereum is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// go-ethereum is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with go-ethereum. If not, see <http://www.gnu.org/licenses/>.
+
+package main
+
+import (
+	"bytes"
+	"html/template"
+	"net/url"
+	"os/exec"
+	"runtime"
+
+	"github.com/ethereum/go-ethereum/params"
+
+	cli "gopkg.in/urfave/cli.v1"
+)
+
+var bugCommand = cli.Command{
+	Action:    reportBug,
+	Name:      "bug",
+	Usage:     "opens a window to report a bug on the geth repo",
+	ArgsUsage: " ",
+	Category:  "MISCELLANEOUS COMMANDS",
+}
+
+// reportBug reports a bug by opening a new URL to the go-ethereum GH issue
+// tracker and setting default values as the issue body.
+func reportBug(ctx *cli.Context) error {
+	// compile the bug report template or crash
+	t := template.Must(template.New("bug-report").Parse(bugTemplate))
+
+	// assemble the info for the bug template
+	uname, err := uname()
+	if err != nil {
+		return err
+	}
+
+	info := struct {
+		Version, GoVersion, OS, Uname string
+	}{Version: params.Version, GoVersion: runtime.Version(), OS: runtime.GOOS, Uname: uname}
+
+	// execute template and write contents to buff
+	var buff bytes.Buffer
+	if err := t.Execute(&buff, info); err != nil {
+		return err
+	}
+
+	// open a new GH issue
+	return exec.Command("open", "https://github.com/ethereum/go-ethereum/issues/new?body="+url.QueryEscape(buff.String())).Start()
+}
+
+const bugTemplate = `Please answer these questions before submitting your issue. Thanks!
+
+#### What did you do?
+
+#### What did you expect to see?
+
+#### What did you see instead?
+
+#### System details
+
+Version: {{.Version}}
+
+Go Version: {{.GoVersion}}
+OS: {{.OS}}
+uname -a: {{.Uname}}
+`
+
+// uname returns machine hardware, os release, name and version.
+func uname() (string, error) {
+	// figure out the uname of the system (e.g. uname, systeminfo)
+	var (
+		err   error
+		uname []byte
+		cmd   = [2]string{"uname", "-a"}
+	)
+
+	if runtime.GOOS == "windows" {
+		cmd = [2]string{"systeminfo"}
+	}
+
+	uname, err = exec.Command(cmd[0], cmd[1]).Output()
+	if err != nil {
+		return "", err
+	}
+	return string(uname), err
+}

--- a/cmd/geth/bugcmd.go
+++ b/cmd/geth/bugcmd.go
@@ -40,6 +40,8 @@ var bugCommand = cli.Command{
 	Category:  "MISCELLANEOUS COMMANDS",
 }
 
+const issueUrl = "https://github.com/ethereum/go-ethereum/issues/new"
+
 // reportBug reports a bug by opening a new URL to the go-ethereum GH issue
 // tracker and setting default values as the issue body.
 func reportBug(ctx *cli.Context) error {
@@ -53,7 +55,10 @@ func reportBug(ctx *cli.Context) error {
 	printOSDetails(&buff)
 
 	// open a new GH issue
-	browser.Open("https://github.com/ethereum/go-ethereum/issues/new?body=" + url.QueryEscape(buff.String()))
+	if !browser.Open(issueUrl + "?body=" + url.QueryEscape(buff.String())) {
+		fmt.Println("Please file a new issue at", issueUrl, "using this template:\n")
+		fmt.Println(buff.String())
+	}
 	return nil
 }
 

--- a/cmd/geth/bugcmd.go
+++ b/cmd/geth/bugcmd.go
@@ -56,8 +56,7 @@ func reportBug(ctx *cli.Context) error {
 
 	// open a new GH issue
 	if !browser.Open(issueUrl + "?body=" + url.QueryEscape(buff.String())) {
-		fmt.Println("Please file a new issue at", issueUrl, "using this template:\n")
-		fmt.Println(buff.String())
+		fmt.Printf("Please file a new issue at %s using this template:\n%s", issueUrl, buff.String())
 	}
 	return nil
 }

--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -81,6 +81,7 @@ func init() {
 		// See misccmd.go:
 		makedagCommand,
 		versionCommand,
+		bugCommand,
 		licenseCommand,
 	}
 

--- a/cmd/internal/browser/browser.go
+++ b/cmd/internal/browser/browser.go
@@ -1,0 +1,46 @@
+// Copyright 2016 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package browser provides utilities for interacting with users' browsers.
+package browser
+
+import (
+	"os"
+	"os/exec"
+	"runtime"
+)
+
+// Commands returns a list of possible commands to use to open a url.
+func Commands() [][]string {
+	var cmds [][]string
+	if exe := os.Getenv("BROWSER"); exe != "" {
+		cmds = append(cmds, []string{exe})
+	}
+	switch runtime.GOOS {
+	case "darwin":
+		cmds = append(cmds, []string{"/usr/bin/open"})
+	case "windows":
+		cmds = append(cmds, []string{"cmd", "/c", "start"})
+	default:
+		cmds = append(cmds, []string{"xdg-open"})
+	}
+	cmds = append(cmds,
+		[]string{"chrome"},
+		[]string{"google-chrome"},
+		[]string{"chromium"},
+		[]string{"firefox"},
+	)
+	return cmds
+}
+
+// Open tries to open url in a browser and reports whether it succeeded.
+func Open(url string) bool {
+	for _, args := range Commands() {
+		cmd := exec.Command(args[0], append(args[1:], url)...)
+		if cmd.Start() == nil {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
Added `bug` command to` geth`, which will open a browser window
with an issue template and some additional system information.

**Preview:**

```
$ geth bug
```

![unspecified-1](https://cloud.githubusercontent.com/assets/6264126/23075616/787af86c-f53d-11e6-9280-62efe14c75bf.png)

Please feel free to suggest additional template information.