### PR TITLE
tests: cleanup tester blockchain after test run

### DIFF
--- a/tests/block_test_util.go
+++ b/tests/block_test_util.go
@@ -177,6 +177,7 @@ func runBlockTest(homesteadBlock, daoForkBlock, gasPriceFork *big.Int, test *Blo
 	if err != nil {
 		return err
 	}
+	defer chain.Stop()
 
 	//vm.Debug = true
 	validBlocks, err := test.TryBlocksInsert(chain)


### PR DESCRIPTION
The block tests didn't call `blockchain.Stop()` after running the tests, causing a goroutine leak while testing.