### PR TITLE
cmd/utils, core, params: fork all teh things for dev mode

### DIFF
--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -861,6 +861,8 @@ func MakeChainConfigFromDb(ctx *cli.Context, db ethdb.Database) *params.ChainCon
 	if defaults {
 		if ctx.GlobalBool(TestNetFlag.Name) {
 			config = params.TestnetChainConfig
+		} else if ctx.GlobalBool(DevModeFlag.Name) {
+			config = params.AllProtocolChanges
 		} else {
 			// Homestead fork
 			config.HomesteadBlock = params.MainNetHomesteadBlock

--- a/core/genesis.go
+++ b/core/genesis.go
@@ -64,6 +64,9 @@ func WriteGenesisBlock(chainDb ethdb.Database, reader io.Reader) (*types.Block, 
 	if err := json.Unmarshal(contents, &genesis); err != nil {
 		return nil, err
 	}
+	if genesis.ChainConfig == nil {
+		genesis.ChainConfig = params.AllProtocolChanges
+	}
 
 	// creating with empty hash always works
 	statedb, _ := state.New(common.Hash{}, chainDb)

--- a/params/config.go
+++ b/params/config.go
@@ -47,6 +47,16 @@ var TestnetChainConfig = &ChainConfig{
 	EIP158Block:    big.NewInt(10),
 }
 
+// AllProtocolChanges contains every protocol change (EIPs)
+// introduced and accepted by the Ethereum core developers.
+//
+// This configuration is intentionally not using keyed fields.
+// This configuration must *always* have all forks enabled, which
+// means that all fields must be set at all times. This forces
+// anyone adding flags to the config to also have to set these
+// fields.
+var AllProtocolChanges = &ChainConfig{big.NewInt(1337), big.NewInt(0), nil, false, big.NewInt(0), common.Hash{}, big.NewInt(0), big.NewInt(0)}
+
 // ChainConfig is the core config which determines the blockchain settings.
 //
 // ChainConfig is stored in the database on a per block basis. This means


### PR DESCRIPTION
Initially we wanted to set a "all forks included" for anything that didn't have a chain configuration during the initialisation process. Unfortunately it's far more complicated than just changing some code as most of the initialisation functions are shared between flags and commands.

This PR sets all forks to be included for the `--dev` flag and nothing else. In a follow-up PR we will be rewriting most of the geth commands including the `init` commands.