### PR TITLE
travis: only run go vet and misspell on latest Go

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,11 +14,20 @@ matrix:
     - os: linux
       dist: trusty
       go: 1.7.5
+
+    # These are the latest Go versions, only run go vet and misspell on these
     - os: linux
       dist: trusty
       go: 1.8
+      script:
+        - go run build/ci.go install
+        - go run build/ci.go test -coverage -vet -misspell
+
     - os: osx
       go: 1.8
+      script:
+        - go run build/ci.go install
+        - go run build/ci.go test -coverage -vet -misspell
 
     # This builder does the Ubuntu PPA and Linux Azure uploads
     - os: linux
@@ -138,7 +147,7 @@ install:
   - go get golang.org/x/tools/cmd/cover
 script:
   - go run build/ci.go install
-  - go run build/ci.go test -coverage -vet -misspell
+  - go run build/ci.go test -coverage
 
 notifications:
   webhooks:


### PR DESCRIPTION
Go vet is gradually being made smarter. This means that higher versions will catch more errors and hit less corner cases. As such, there's no point to run go vet for any jobs other than for the latest Go version.

Also `go vet` prior to Go 1.8. hits a format string corner case used in our new logger.