### PR TITLE
log: fix annoyances

### DIFF
--- a/cmd/bootnode/main.go
+++ b/cmd/bootnode/main.go
@@ -50,7 +50,7 @@ func main() {
 	)
 	flag.Parse()
 
-	glogger := log.NewGlogHandler(log.StreamHandler(os.Stderr, log.TerminalFormat()))
+	glogger := log.NewGlogHandler(log.StreamHandler(os.Stderr, log.TerminalFormat(false)))
 	glogger.Verbosity(log.Lvl(*verbosity))
 	glogger.Vmodule(*vmodule)
 	log.Root().SetHandler(glogger)

--- a/cmd/evm/main.go
+++ b/cmd/evm/main.go
@@ -112,7 +112,7 @@ func init() {
 }
 
 func run(ctx *cli.Context) error {
-	glogger := log.NewGlogHandler(log.StreamHandler(os.Stderr, log.TerminalFormat()))
+	glogger := log.NewGlogHandler(log.StreamHandler(os.Stderr, log.TerminalFormat(false)))
 	glogger.Verbosity(log.Lvl(ctx.GlobalInt(VerbosityFlag.Name)))
 	log.Root().SetHandler(glogger)
 

--- a/cmd/wnode/main.go
+++ b/cmd/wnode/main.go
@@ -152,7 +152,7 @@ func echo() {
 }
 
 func initialize() {
-	log.Root().SetHandler(log.LvlFilterHandler(log.Lvl(*argVerbosity), log.StreamHandler(os.Stderr, log.TerminalFormat())))
+	log.Root().SetHandler(log.LvlFilterHandler(log.Lvl(*argVerbosity), log.StreamHandler(os.Stderr, log.TerminalFormat(false))))
 
 	done = make(chan struct{})
 	var peers []*discover.Node

--- a/eth/protocol_test.go
+++ b/eth/protocol_test.go
@@ -30,7 +30,7 @@ import (
 )
 
 func init() {
-	// log.Root().SetHandler(log.LvlFilterHandler(log.LvlTrace, log.StreamHandler(os.Stderr, log.TerminalFormat())))
+	// log.Root().SetHandler(log.LvlFilterHandler(log.LvlTrace, log.StreamHandler(os.Stderr, log.TerminalFormat(false))))
 }
 
 var testAccount, _ = crypto.HexToECDSA("b71c71a67e1177ad4e901695e1b4b9ee17ae16c6668d313eac2f96dbcda3f291")

--- a/log/format.go
+++ b/log/format.go
@@ -69,22 +69,24 @@ func (f formatFunc) Format(r *Record) []byte {
 //
 //     [May 16 20:58:45] [DBUG] remove route ns=haproxy addr=127.0.0.1:50002
 //
-func TerminalFormat() Format {
+func TerminalFormat(usecolor bool) Format {
 	return FormatFunc(func(r *Record) []byte {
 		var color = 0
-		switch r.Lvl {
-		case LvlCrit:
-			color = 35
-		case LvlError:
-			color = 31
-		case LvlWarn:
-			color = 33
-		case LvlInfo:
-			color = 32
-		case LvlDebug:
-			color = 36
-		case LvlTrace:
-			color = 34
+		if usecolor {
+			switch r.Lvl {
+			case LvlCrit:
+				color = 35
+			case LvlError:
+				color = 31
+			case LvlWarn:
+				color = 33
+			case LvlInfo:
+				color = 32
+			case LvlDebug:
+				color = 36
+			case LvlTrace:
+				color = 34
+			}
 		}
 
 		b := &bytes.Buffer{}

--- a/log/format.go
+++ b/log/format.go
@@ -88,7 +88,7 @@ func TerminalFormat() Format {
 		}
 
 		b := &bytes.Buffer{}
-		lvl := strings.ToUpper(r.Lvl.String())
+		lvl := r.Lvl.AlignedString()
 		if atomic.LoadUint32(&locationEnabled) != 0 {
 			// Log origin printing was requested, format the location path and line number
 			location := fmt.Sprintf("%+v", r.Call)
@@ -107,13 +107,13 @@ func TerminalFormat() Format {
 			if color > 0 {
 				fmt.Fprintf(b, "\x1b[%dm%s\x1b[0m[%s|%s]%s %s ", color, lvl, r.Time.Format(termTimeFormat), location, padding, r.Msg)
 			} else {
-				fmt.Fprintf(b, "[%s] [%s|%s]%s %s ", lvl, r.Time.Format(termTimeFormat), location, padding, r.Msg)
+				fmt.Fprintf(b, "%s[%s|%s]%s %s ", lvl, r.Time.Format(termTimeFormat), location, padding, r.Msg)
 			}
 		} else {
 			if color > 0 {
 				fmt.Fprintf(b, "\x1b[%dm%s\x1b[0m[%s] %s ", color, lvl, r.Time.Format(termTimeFormat), r.Msg)
 			} else {
-				fmt.Fprintf(b, "[%s] [%s] %s ", lvl, r.Time.Format(termTimeFormat), r.Msg)
+				fmt.Fprintf(b, "%s[%s] %s ", lvl, r.Time.Format(termTimeFormat), r.Msg)
 			}
 		}
 		// try to justify the log output for short messages

--- a/log/logger.go
+++ b/log/logger.go
@@ -24,7 +24,27 @@ const (
 	LvlTrace
 )
 
-// Returns the name of a Lvl
+// Aligned returns a 5-character string containing the name of a Lvl.
+func (l Lvl) AlignedString() string {
+	switch l {
+	case LvlTrace:
+		return "TRACE"
+	case LvlDebug:
+		return "DEBUG"
+	case LvlInfo:
+		return "INFO "
+	case LvlWarn:
+		return "WARN "
+	case LvlError:
+		return "ERROR"
+	case LvlCrit:
+		return "CRIT "
+	default:
+		panic("bad level")
+	}
+}
+
+// Strings returns the name of a Lvl.
 func (l Lvl) String() string {
 	switch l {
 	case LvlTrace:

--- a/log/root.go
+++ b/log/root.go
@@ -2,28 +2,16 @@ package log
 
 import (
 	"os"
-
-	"github.com/ethereum/go-ethereum/log/term"
-	"github.com/mattn/go-colorable"
 )
 
 var (
-	root          *logger
+	root          = &logger{[]interface{}{}, new(swapHandler)}
 	StdoutHandler = StreamHandler(os.Stdout, LogfmtFormat())
 	StderrHandler = StreamHandler(os.Stderr, LogfmtFormat())
 )
 
 func init() {
-	if term.IsTty(os.Stdout.Fd()) {
-		StdoutHandler = StreamHandler(colorable.NewColorableStdout(), TerminalFormat())
-	}
-
-	if term.IsTty(os.Stderr.Fd()) {
-		StderrHandler = StreamHandler(colorable.NewColorableStderr(), TerminalFormat())
-	}
-
-	root = &logger{[]interface{}{}, new(swapHandler)}
-	root.SetHandler(LvlFilterHandler(LvlInfo, StdoutHandler))
+	root.SetHandler(DiscardHandler())
 }
 
 // New returns a new logger with the given context.

--- a/mobile/init.go
+++ b/mobile/init.go
@@ -27,7 +27,7 @@ import (
 
 func init() {
 	// Initialize the logger
-	log.Root().SetHandler(log.LvlFilterHandler(log.LvlInfo, log.StreamHandler(os.Stderr, log.TerminalFormat())))
+	log.Root().SetHandler(log.LvlFilterHandler(log.LvlInfo, log.StreamHandler(os.Stderr, log.TerminalFormat(false))))
 
 	// Initialize the goroutine count
 	runtime.GOMAXPROCS(runtime.NumCPU())

--- a/mobile/logger.go
+++ b/mobile/logger.go
@@ -24,5 +24,5 @@ import (
 
 // SetVerbosity sets the global verbosity level (between 0 and 6 - see logger/verbosity.go).
 func SetVerbosity(level int) {
-	log.Root().SetHandler(log.LvlFilterHandler(log.Lvl(level), log.StreamHandler(os.Stderr, log.TerminalFormat())))
+	log.Root().SetHandler(log.LvlFilterHandler(log.Lvl(level), log.StreamHandler(os.Stderr, log.TerminalFormat(false))))
 }

--- a/p2p/server_test.go
+++ b/p2p/server_test.go
@@ -31,7 +31,7 @@ import (
 )
 
 func init() {
-	// log.Root().SetHandler(log.LvlFilterHandler(log.LvlError, log.StreamHandler(os.Stderr, log.TerminalFormat())))
+	// log.Root().SetHandler(log.LvlFilterHandler(log.LvlError, log.StreamHandler(os.Stderr, log.TerminalFormat(false))))
 }
 
 type testTransport struct {

--- a/swarm/network/syncdb_test.go
+++ b/swarm/network/syncdb_test.go
@@ -31,7 +31,7 @@ import (
 )
 
 func init() {
-	log.Root().SetHandler(log.LvlFilterHandler(log.LvlCrit, log.StreamHandler(os.Stderr, log.TerminalFormat())))
+	log.Root().SetHandler(log.LvlFilterHandler(log.LvlCrit, log.StreamHandler(os.Stderr, log.TerminalFormat(false))))
 }
 
 type testSyncDb struct {

--- a/tests/util.go
+++ b/tests/util.go
@@ -41,7 +41,7 @@ var (
 )
 
 func init() {
-	log.Root().SetHandler(log.LvlFilterHandler(log.LvlCrit, log.StreamHandler(os.Stderr, log.TerminalFormat())))
+	log.Root().SetHandler(log.LvlFilterHandler(log.LvlCrit, log.StreamHandler(os.Stderr, log.TerminalFormat(false))))
 	if os.Getenv("JITVM") == "true" {
 		ForceJit = true
 		EnableJit = true


### PR DESCRIPTION
This PR replaces the `EROR` and `DBUG` strings with their full name so I don't have to look at a spelling error all the time. It also removes the default stdout handler because it showed logs while testing. 

Colors are now disabled more aggressively (but still enabled for geth attached to a terminal).