### PR TITLE
vendor: update HID library for glibc < v2.17 build

### DIFF
--- a/vendor/github.com/karalabe/hid/LICENSE.md
+++ b/vendor/github.com/karalabe/hid/LICENSE.md
@@ -1,8 +1,8 @@
 The components of `hid` are licensed as such:
 
  * `hidapi` is released under the [3-clause BSD](https://github.com/signal11/hidapi/blob/master/LICENSE-bsd.txt) license.
- * `libusb` is released under the [GNU GPL 2.1](https://github.com/libusb/libusb/blob/master/COPYING)license.
+ * `libusb` is released under the [GNU LGPL 2.1](https://github.com/libusb/libusb/blob/master/COPYING)license.
  * `go.hid` is released under the [2-clause BSD](https://github.com/GeertJohan/go.hid/blob/master/LICENSE) license.
  * `gowchar` is released under the [3-clause BSD](https://github.com/orofarne/gowchar/blob/master/LICENSE) license.
 
-Given the above, `hid` is licensed under GNU GPL 2.1 or later on Linux and 3-clause BSD on other platforms.
+Given the above, `hid` is licensed under GNU LGPL 2.1 or later on Linux and 3-clause BSD on other platforms.

--- a/vendor/github.com/karalabe/hid/README.md
+++ b/vendor/github.com/karalabe/hid/README.md
@@ -1,7 +1,13 @@
+[![Travis][travisimg]][travisurl]
+[![AppVeyor][appveyorimg]][appveyorurl]
 [![GoDoc][docimg]][docurl]
 
-[docimg]: https://godoc.org/github.com/karalabe/hid?status.svg
-[docurl]: https://godoc.org/github.com/karalabe/hid
+[travisimg]:   https://travis-ci.org/karalabe/hid.svg?branch=master
+[travisurl]:   https://travis-ci.org/karalabe/hid
+[appveyorimg]: https://ci.appveyor.com/api/projects/status/plroy54odykb0ch3/branch/master?svg=true
+[appveyorurl]: https://ci.appveyor.com/project/karalabe/hid
+[docimg]:      https://godoc.org/github.com/karalabe/hid?status.svg
+[docurl]:      https://godoc.org/github.com/karalabe/hid
 
 # Gopher Interface Devices (USB HID)
 
@@ -34,8 +40,8 @@ such, `gowchar` was also vendored in inline (copyright headers and origins prese
 The components of `hid` are licensed as such:
 
  * `hidapi` is released under the [3-clause BSD](https://github.com/signal11/hidapi/blob/master/LICENSE-bsd.txt) license.
- * `libusb` is released under the [GNU GPL 2.1](https://github.com/libusb/libusb/blob/master/COPYING)license.
+ * `libusb` is released under the [GNU LGPL 2.1](https://github.com/libusb/libusb/blob/master/COPYING)license.
  * `go.hid` is released under the [2-clause BSD](https://github.com/GeertJohan/go.hid/blob/master/LICENSE) license.
  * `gowchar` is released under the [3-clause BSD](https://github.com/orofarne/gowchar/blob/master/LICENSE) license.
 
-Given the above, `hid` is licensed under GNU GPL 2.1 or later on Linux and 3-clause BSD on other platforms.
+Given the above, `hid` is licensed under GNU LGPL 2.1 or later on Linux and 3-clause BSD on other platforms.

--- a/vendor/github.com/karalabe/hid/appveyor.yml
+++ b/vendor/github.com/karalabe/hid/appveyor.yml
@@ -1,0 +1,31 @@
+os: Visual Studio 2015
+
+# Clone directly into GOPATH.
+clone_folder: C:\gopath\src\github.com\karalabe\hid
+clone_depth: 1
+version: "{branch}.{build}"
+environment:
+  global:
+    GOPATH: C:\gopath
+    CC: gcc.exe
+  matrix:
+    - GOARCH: amd64
+      MSYS2_ARCH: x86_64
+      MSYS2_BITS: 64
+      MSYSTEM: MINGW64
+      PATH: C:\msys64\mingw64\bin\;%PATH%
+    - GOARCH: 386
+      MSYS2_ARCH: i686
+      MSYS2_BITS: 32
+      MSYSTEM: MINGW32
+      PATH: C:\msys64\mingw32\bin\;%PATH%
+
+install:
+  - rmdir C:\go /s /q
+  - appveyor DownloadFile https://storage.googleapis.com/golang/go1.8.windows-%GOARCH%.zip
+  - 7z x go1.8.windows-%GOARCH%.zip -y -oC:\ > NUL
+  - go version
+  - gcc --version
+
+build_script:
+  - go install ./...

--- a/vendor/github.com/karalabe/hid/hid_disabled.go
+++ b/vendor/github.com/karalabe/hid/hid_disabled.go
@@ -4,9 +4,7 @@
 // This file is released under the 3-clause BSD license. Note however that Linux
 // support depends on libusb, released under GNU GPL 2.1 or later.
 
-// +build !linux
-// +build !darwin ios
-// +build !windows
+// +build !linux,!darwin,!windows ios !cgo
 
 package hid
 

--- a/vendor/github.com/karalabe/hid/hid_enabled.go
+++ b/vendor/github.com/karalabe/hid/hid_enabled.go
@@ -4,8 +4,7 @@
 // This file is released under the 3-clause BSD license. Note however that Linux
 // support depends on libusb, released under GNU GPL 2.1 or later.
 
-// +build !ios
-// +build linux darwin windows
+// +build linux,cgo darwin,!ios,cgo windows,cgo
 
 package hid
 
@@ -13,6 +12,7 @@ package hid
 #cgo CFLAGS: -I./hidapi/hidapi
 
 #cgo linux CFLAGS: -I./libusb/libusb -DDEFAULT_VISIBILITY="" -DOS_LINUX -D_GNU_SOURCE -DPOLL_NFDS_TYPE=int
+#cgo linux,!android LDFLAGS: -lrt
 #cgo darwin CFLAGS: -DOS_DARWIN
 #cgo darwin LDFLAGS: -framework CoreFoundation -framework IOKit
 #cgo windows CFLAGS: -DOS_WINDOWS

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -125,10 +125,10 @@
 			"revisionTime": "2016-06-03T03:41:37Z"
 		},
 		{
-			"checksumSHA1": "HKy8oSpuboe02Uqq+43zbIzD/AY=",
+			"checksumSHA1": "sGdhjz2N/DpfiZrMnHSzl2H/YX8=",
 			"path": "github.com/karalabe/hid",
-			"revision": "40280bf4f6fc762010efeb066cbff7490d467f03",
-			"revisionTime": "2017-02-17T09:52:56Z",
+			"revision": "875879887cf0560a993b57e04615944e1dd02a73",
+			"revisionTime": "2017-02-27T10:57:12Z",
 			"tree": true
 		},
 		{


### PR DESCRIPTION
Some people complained that using older Linux distributions, building Geth fails. This PR pulls in an update for the USB HID library to link against `rt` as a fallback if the required symbols cannot be found in `glibc`.