### PR TITLE
core, eth: drop database block splitting upgrader

### DIFF
--- a/core/database_util.go
+++ b/core/database_util.go
@@ -539,24 +539,6 @@ func DeleteReceipt(db ethdb.Database, hash common.Hash) {
 	db.Delete(append(receiptsPrefix, hash.Bytes()...))
 }
 
-// [deprecated by the header/block split, remove eventually]
-// GetBlockByHashOld returns the old combined block corresponding to the hash
-// or nil if not found. This method is only used by the upgrade mechanism to
-// access the old combined block representation. It will be dropped after the
-// network transitions to eth/63.
-func GetBlockByHashOld(db ethdb.Database, hash common.Hash) *types.Block {
-	data, _ := db.Get(append(oldBlockHashPrefix, hash[:]...))
-	if len(data) == 0 {
-		return nil
-	}
-	var block types.StorageBlock
-	if err := rlp.Decode(bytes.NewReader(data), &block); err != nil {
-		log.Error(fmt.Sprintf("invalid block RLP for hash %x: %v", hash, err))
-		return nil
-	}
-	return (*types.Block)(&block)
-}
-
 // returns a formatted MIP mapped key by adding prefix, canonical number and level
 //
 // ex. fn(98, 1000) = (prefix || 1000 || 0)

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -176,9 +176,6 @@ func New(ctx *node.ServiceContext, config *Config) (*Ethereum, error) {
 		solcPath:       config.SolcPath,
 	}
 
-	if err := upgradeChainDatabase(chainDb); err != nil {
-		return nil, err
-	}
 	if err := addMipmapBloomBins(chainDb); err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
The block split was done in [Geth v1.2.1](https://github.com/ethereum/go-ethereum/commit/2b339cbbd8bb475d2195d54a71dcced700003430)