### PR TITLE
common/hexutil: implement TextMarshaler, TextUnmarshaler

### DIFF
--- a/common/hexutil/hexutil.go
+++ b/common/hexutil/hexutil.go
@@ -49,6 +49,7 @@ var (
 	ErrOddLength     = errors.New("hex string has odd length")
 	ErrUint64Range   = errors.New("hex number does not fit into 64 bits")
 	ErrUintRange     = fmt.Errorf("hex number does not fit into %d bits", uintBits)
+	ErrBig256Range   = errors.New("hex number does not fit into 256 bits")
 )
 
 // Decode decodes a hex string with 0x prefix.
@@ -126,10 +127,14 @@ func init() {
 }
 
 // DecodeBig decodes a hex string with 0x prefix as a quantity.
+// Numbers larger than 256 bits are not accepted.
 func DecodeBig(input string) (*big.Int, error) {
 	raw, err := checkNumber(input)
 	if err != nil {
 		return nil, err
+	}
+	if len(raw) > 64 {
+		return nil, ErrBig256Range
 	}
 	words := make([]big.Word, len(raw)/bigWordNibbles+1)
 	end := len(raw)

--- a/common/hexutil/hexutil.go
+++ b/common/hexutil/hexutil.go
@@ -178,7 +178,7 @@ func EncodeBig(bigint *big.Int) string {
 	if nbits == 0 {
 		return "0x0"
 	}
-	return fmt.Sprintf("0x%x", bigint)
+	return fmt.Sprintf("%#x", bigint)
 }
 
 func has0xPrefix(input string) bool {

--- a/common/hexutil/hexutil.go
+++ b/common/hexutil/hexutil.go
@@ -60,7 +60,11 @@ func Decode(input string) ([]byte, error) {
 	if !has0xPrefix(input) {
 		return nil, ErrMissingPrefix
 	}
-	return hex.DecodeString(input[2:])
+	b, err := hex.DecodeString(input[2:])
+	if err != nil {
+		err = mapError(err)
+	}
+	return b, err
 }
 
 // MustDecode decodes a hex string with 0x prefix. It panics for invalid input.

--- a/common/hexutil/hexutil_test.go
+++ b/common/hexutil/hexutil_test.go
@@ -47,6 +47,7 @@ var (
 		{referenceBig("ff"), "0xff"},
 		{referenceBig("112233445566778899aabbccddeeff"), "0x112233445566778899aabbccddeeff"},
 		{referenceBig("80a7f2c1bcc396c00"), "0x80a7f2c1bcc396c00"},
+		{referenceBig("-80a7f2c1bcc396c00"), "-0x80a7f2c1bcc396c00"},
 	}
 
 	encodeUint64Tests = []marshalTest{

--- a/common/hexutil/hexutil_test.go
+++ b/common/hexutil/hexutil_test.go
@@ -18,7 +18,6 @@ package hexutil
 
 import (
 	"bytes"
-	"encoding/hex"
 	"math/big"
 	"testing"
 )
@@ -60,10 +59,10 @@ var (
 		// invalid
 		{input: ``, wantErr: ErrEmptyString},
 		{input: `0`, wantErr: ErrMissingPrefix},
-		{input: `0x0`, wantErr: hex.ErrLength},
-		{input: `0x023`, wantErr: hex.ErrLength},
-		{input: `0xxx`, wantErr: hex.InvalidByteError('x')},
-		{input: `0x01zz01`, wantErr: hex.InvalidByteError('z')},
+		{input: `0x0`, wantErr: ErrOddLength},
+		{input: `0x023`, wantErr: ErrOddLength},
+		{input: `0xxx`, wantErr: ErrSyntax},
+		{input: `0x01zz01`, wantErr: ErrSyntax},
 		// valid
 		{input: `0x`, want: []byte{}},
 		{input: `0X`, want: []byte{}},

--- a/common/hexutil/hexutil_test.go
+++ b/common/hexutil/hexutil_test.go
@@ -28,9 +28,10 @@ type marshalTest struct {
 }
 
 type unmarshalTest struct {
-	input   string
-	want    interface{}
-	wantErr error
+	input        string
+	want         interface{}
+	wantErr      error // if set, decoding must fail on any platform
+	wantErr32bit error // if set, decoding must fail on 32bit platforms (used for Uint tests)
 }
 
 var (
@@ -53,6 +54,13 @@ var (
 		{uint64(1), "0x1"},
 		{uint64(0xff), "0xff"},
 		{uint64(0x1122334455667788), "0x1122334455667788"},
+	}
+
+	encodeUintTests = []marshalTest{
+		{uint(0), "0x0"},
+		{uint(1), "0x1"},
+		{uint(0xff), "0xff"},
+		{uint(0x11223344), "0x11223344"},
 	}
 
 	decodeBytesTests = []unmarshalTest{

--- a/common/hexutil/hexutil_test.go
+++ b/common/hexutil/hexutil_test.go
@@ -83,6 +83,10 @@ var (
 		{input: `0x01`, wantErr: ErrLeadingZero},
 		{input: `0xx`, wantErr: ErrSyntax},
 		{input: `0x1zz01`, wantErr: ErrSyntax},
+		{
+			input:   `0x10000000000000000000000000000000000000000000000000000000000000000`,
+			wantErr: ErrBig256Range,
+		},
 		// valid
 		{input: `0x0`, want: big.NewInt(0)},
 		{input: `0x2`, want: big.NewInt(0x2)},
@@ -98,6 +102,10 @@ var (
 		{
 			input: `0xffffffffffffffffffffffffffffffffffff`,
 			want:  referenceBig("ffffffffffffffffffffffffffffffffffff"),
+		},
+		{
+			input: `0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff`,
+			want:  referenceBig("ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"),
 		},
 	}
 

--- a/common/hexutil/json.go
+++ b/common/hexutil/json.go
@@ -25,9 +25,8 @@ import (
 )
 
 var (
-	textZero          = []byte(`0x0`)
-	errNonString      = errors.New("cannot unmarshal non-string as hex data")
-	errNegativeBigInt = errors.New("hexutil.Big: can't marshal negative integer")
+	textZero     = []byte(`0x0`)
+	errNonString = errors.New("cannot unmarshal non-string as hex data")
 )
 
 // Bytes marshals/unmarshals as a JSON string with 0x prefix.
@@ -101,18 +100,7 @@ type Big big.Int
 
 // MarshalText implements encoding.TextMarshaler
 func (b Big) MarshalText() ([]byte, error) {
-	bigint := (big.Int)(b)
-	if bigint.Sign() == -1 {
-		return nil, errNegativeBigInt
-	}
-	nbits := bigint.BitLen()
-	if nbits == 0 {
-		return textZero, nil
-	}
-	enc := make([]byte, 2, nbits/4+2)
-	copy(enc, "0x")
-	enc = bigint.Append(enc, 16)
-	return enc, nil
+	return []byte(EncodeBig((*big.Int)(&b))), nil
 }
 
 // UnmarshalJSON implements json.Unmarshaler.

--- a/common/hexutil/json.go
+++ b/common/hexutil/json.go
@@ -91,9 +91,12 @@ func UnmarshalJSON(typname string, input, out []byte) error {
 	return nil
 }
 
-// Big marshals/unmarshals as a JSON string with 0x prefix. The zero value marshals as
-// "0x0". Negative integers are not supported at this time. Attempting to marshal them
-// will return an error.
+// Big marshals/unmarshals as a JSON string with 0x prefix.
+// The zero value marshals as "0x0".
+//
+// Negative integers are not supported at this time. Attempting to marshal them will
+// return an error. Values larger than 256bits are rejected by Unmarshal but will be
+// marshaled without error.
 type Big big.Int
 
 // MarshalJSON implements json.Marshaler.
@@ -118,6 +121,9 @@ func (b *Big) UnmarshalJSON(input []byte) error {
 	raw, err := checkNumberJSON(input)
 	if err != nil {
 		return err
+	}
+	if len(raw) > 64 {
+		return ErrBig256Range
 	}
 	words := make([]big.Word, len(raw)/bigWordNibbles+1)
 	end := len(raw)

--- a/common/hexutil/json_example_test.go
+++ b/common/hexutil/json_example_test.go
@@ -1,0 +1,45 @@
+// Copyright 2017 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+package hexutil_test
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/ethereum/go-ethereum/common/hexutil"
+)
+
+type MyType [5]byte
+
+func (v *MyType) UnmarshalText(input []byte) error {
+	return hexutil.UnmarshalFixedText("MyType", input, v[:])
+}
+
+func (v MyType) String() string {
+	return hexutil.Bytes(v[:]).String()
+}
+
+func ExampleUnmarshalFixedText() {
+	var v1, v2 MyType
+	fmt.Println("v1 error:", json.Unmarshal([]byte(`"0x01"`), &v1))
+	fmt.Println("v2 error:", json.Unmarshal([]byte(`"0x0101010101"`), &v2))
+	fmt.Println("v2:", v2)
+	// Output:
+	// v1 error: hex string has length 2, want 10 for MyType
+	// v2 error: <nil>
+	// v2: 0x0101010101
+}

--- a/common/hexutil/json_test.go
+++ b/common/hexutil/json_test.go
@@ -130,6 +130,10 @@ var unmarshalBigTests = []unmarshalTest{
 	{input: `"0x01"`, wantErr: ErrLeadingZero},
 	{input: `"0xx"`, wantErr: ErrSyntax},
 	{input: `"0x1zz01"`, wantErr: ErrSyntax},
+	{
+		input:   `"0x10000000000000000000000000000000000000000000000000000000000000000"`,
+		wantErr: ErrBig256Range,
+	},
 
 	// valid encoding
 	{input: `""`, want: big.NewInt(0)},
@@ -147,6 +151,10 @@ var unmarshalBigTests = []unmarshalTest{
 	{
 		input: `"0xffffffffffffffffffffffffffffffffffff"`,
 		want:  referenceBig("ffffffffffffffffffffffffffffffffffff"),
+	},
+	{
+		input: `"0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"`,
+		want:  referenceBig("ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"),
 	},
 }
 

--- a/common/types.go
+++ b/common/types.go
@@ -71,14 +71,14 @@ func (h Hash) Format(s fmt.State, c rune) {
 	fmt.Fprintf(s, "%"+string(c), h[:])
 }
 
-// UnmarshalJSON parses a hash in its hex from to a hash.
-func (h *Hash) UnmarshalJSON(input []byte) error {
-	return hexutil.UnmarshalJSON("Hash", input, h[:])
+// UnmarshalText parses a hash in hex syntax.
+func (h *Hash) UnmarshalText(input []byte) error {
+	return hexutil.UnmarshalFixedText("Hash", input, h[:])
 }
 
-// Serialize given hash to JSON
-func (h Hash) MarshalJSON() ([]byte, error) {
-	return hexutil.Bytes(h[:]).MarshalJSON()
+// MarshalText returns the hex representation of h.
+func (h Hash) MarshalText() ([]byte, error) {
+	return hexutil.Bytes(h[:]).MarshalText()
 }
 
 // Sets the hash to the value of b. If b is larger than len(h) it will panic
@@ -171,14 +171,14 @@ func (a *Address) Set(other Address) {
 	}
 }
 
-// Serialize given address to JSON
-func (a Address) MarshalJSON() ([]byte, error) {
-	return hexutil.Bytes(a[:]).MarshalJSON()
+// MarshalText returns the hex representation of a.
+func (a Address) MarshalText() ([]byte, error) {
+	return hexutil.Bytes(a[:]).MarshalText()
 }
 
-// Parse address from raw json data
-func (a *Address) UnmarshalJSON(input []byte) error {
-	return hexutil.UnmarshalJSON("Address", input, a[:])
+// UnmarshalText parses a hash in hex syntax.
+func (a *Address) UnmarshalText(input []byte) error {
+	return hexutil.UnmarshalFixedText("Address", input, a[:])
 }
 
 // PP Pretty Prints a byte slice in the following format:

--- a/common/types_test.go
+++ b/common/types_test.go
@@ -17,6 +17,7 @@
 package common
 
 import (
+	"encoding/json"
 	"math/big"
 	"strings"
 	"testing"
@@ -37,7 +38,6 @@ func TestBytesConversion(t *testing.T) {
 }
 
 func TestHashJsonValidation(t *testing.T) {
-	var h Hash
 	var tests = []struct {
 		Prefix string
 		Size   int
@@ -52,7 +52,8 @@ func TestHashJsonValidation(t *testing.T) {
 	}
 	for _, test := range tests {
 		input := `"` + test.Prefix + strings.Repeat("0", test.Size) + `"`
-		err := h.UnmarshalJSON([]byte(input))
+		var v Hash
+		err := json.Unmarshal([]byte(input), &v)
 		if err == nil {
 			if test.Error != "" {
 				t.Errorf("%s: error mismatch: have nil, want %q", input, test.Error)
@@ -66,7 +67,6 @@ func TestHashJsonValidation(t *testing.T) {
 }
 
 func TestAddressUnmarshalJSON(t *testing.T) {
-	var a Address
 	var tests = []struct {
 		Input     string
 		ShouldErr bool
@@ -81,7 +81,8 @@ func TestAddressUnmarshalJSON(t *testing.T) {
 		{`"0x0000000000000000000000000000000000000010"`, false, big.NewInt(16)},
 	}
 	for i, test := range tests {
-		err := a.UnmarshalJSON([]byte(test.Input))
+		var v Address
+		err := json.Unmarshal([]byte(test.Input), &v)
 		if err != nil && !test.ShouldErr {
 			t.Errorf("test #%d: unexpected error: %v", i, err)
 		}
@@ -89,8 +90,8 @@ func TestAddressUnmarshalJSON(t *testing.T) {
 			if test.ShouldErr {
 				t.Errorf("test #%d: expected error, got none", i)
 			}
-			if a.Big().Cmp(test.Output) != 0 {
-				t.Errorf("test #%d: address mismatch: have %v, want %v", i, a.Big(), test.Output)
+			if v.Big().Cmp(test.Output) != 0 {
+				t.Errorf("test #%d: address mismatch: have %v, want %v", i, v.Big(), test.Output)
 			}
 		}
 	}

--- a/core/types/block.go
+++ b/core/types/block.go
@@ -62,14 +62,14 @@ func (n BlockNonce) Uint64() uint64 {
 	return binary.BigEndian.Uint64(n[:])
 }
 
-// MarshalJSON implements json.Marshaler
-func (n BlockNonce) MarshalJSON() ([]byte, error) {
-	return hexutil.Bytes(n[:]).MarshalJSON()
+// MarshalText encodes n as a hex string with 0x prefix.
+func (n BlockNonce) MarshalText() ([]byte, error) {
+	return hexutil.Bytes(n[:]).MarshalText()
 }
 
-// UnmarshalJSON implements json.Unmarshaler
-func (n *BlockNonce) UnmarshalJSON(input []byte) error {
-	return hexutil.UnmarshalJSON("BlockNonce", input, n[:])
+// UnmarshalText implements encoding.TextUnmarshaler.
+func (n *BlockNonce) UnmarshalText(input []byte) error {
+	return hexutil.UnmarshalFixedText("BlockNonce", input, n[:])
 }
 
 // Header represents a block header in the Ethereum blockchain.

--- a/core/types/bloom9.go
+++ b/core/types/bloom9.go
@@ -75,14 +75,14 @@ func (b Bloom) TestBytes(test []byte) bool {
 
 }
 
-// MarshalJSON encodes b as a hex string with 0x prefix.
-func (b Bloom) MarshalJSON() ([]byte, error) {
-	return hexutil.Bytes(b[:]).MarshalJSON()
+// MarshalText encodes b as a hex string with 0x prefix.
+func (b Bloom) MarshalText() ([]byte, error) {
+	return hexutil.Bytes(b[:]).MarshalText()
 }
 
-// UnmarshalJSON b as a hex string with 0x prefix.
-func (b *Bloom) UnmarshalJSON(input []byte) error {
-	return hexutil.UnmarshalJSON("Bloom", input, b[:])
+// UnmarshalText b as a hex string with 0x prefix.
+func (b *Bloom) UnmarshalText(input []byte) error {
+	return hexutil.UnmarshalFixedText("Bloom", input, b[:])
 }
 
 func CreateBloom(receipts Receipts) Bloom {


### PR DESCRIPTION
This PR makes the wrapper types more generally applicable.
encoding.TextMarshaler is supported by most codec implementations (e.g.
for yaml).

The tests now ensure that package json actually recognizes the custom
marshaler implementation irrespective of how it is implemented.

The Uint type has new tests, too. These are tricky because uint size
depends on the CPU word size. Turns out that there was one incorrect
case where decoding returned ErrUint64Range instead of ErrUintRange