### PR TITLE
README.md: Fixed typo.

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ As a developer, sooner rather than later you'll want to start interacting with G
 network via your own programs and not manually through the console. To aid this, Geth has built in
 support for a JSON-RPC based APIs ([standard APIs](https://github.com/ethereum/wiki/wiki/JSON-RPC) and
 [Geth specific APIs](https://github.com/ethereum/go-ethereum/wiki/Management-APIs)). These can be
-exposed via HTTP, WebSockets and IPC (unix sockets on unix based platroms, and named pipes on Windows).
+exposed via HTTP, WebSockets and IPC (unix sockets on unix based platforms, and named pipes on Windows).
 
 The IPC interface is enabled by default and exposes all the APIs supported by Geth, whereas the HTTP
 and WS interfaces need to manually be enabled and only expose a subset of APIs due to security reasons.


### PR DESCRIPTION
Not sure which package to mark this as (required, according to the contribution guidelines), as it is in the main README.md, and not in a Go package.