### PR TITLE
core: reorg logs crashed, add a check for corner cases

### DIFF
--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -1145,13 +1145,16 @@ func (self *BlockChain) reorg(oldBlock, newBlock *types.Block) error {
 		}
 	}
 	// Ensure the user sees large reorgs
-	logFn := log.Debug
-	if len(oldChain) > 63 {
-		logFn = log.Warn
+	if len(oldChain) > 0 && len(newChain) > 0 {
+		logFn := log.Debug
+		if len(oldChain) > 63 {
+			logFn = log.Warn
+		}
+		logFn("Chain split detected", "number", commonBlock.Number(), "hash", commonBlock.Hash(),
+			"drop", len(oldChain), "dropfrom", oldChain[0].Hash(), "add", len(newChain), "addfrom", newChain[0].Hash())
+	} else {
+		log.Error("Impossible reorg, please file an issue", "oldnum", oldBlock.Number(), "oldhash", oldBlock.Hash(), "newnum", newBlock.Number(), "newhash", newBlock.Hash())
 	}
-	logFn("Chain split detected", "number", commonBlock.Number(), "hash", commonBlock.Hash(),
-		"drop", len(oldChain), "dropfrom", oldChain[0].Hash(), "add", len(newChain), "addfrom", newChain[0].Hash())
-
 	var addedTxs types.Transactions
 	// insert blocks. Order does not matter. Last block will be written in ImportChain itself which creates the new head properly
 	for _, block := range newChain {


### PR DESCRIPTION
We've received a report that block insertion crashes while emitting a plain user log (with the new develop logger) https://github.com/ethereum/go-ethereum/issues/3733. This should be impossible to happen, unless we occasionally insert blocks twice. This PR ensures that the original log doesn't crash, as well as emits a warning if the corner case is hit so we may better understand what happens.