### PR TITLE
build: fix xgo argument order when building from make

### DIFF
--- a/build/ci.go
+++ b/build/ci.go
@@ -930,9 +930,9 @@ func doXgo(cmdline []string) {
 
 	// If all tools building is requested, build everything the builder wants
 	args := append(buildFlags(env), flag.Args()...)
-	args = append(args, []string{"--dest", GOBIN}...)
 
 	if *alltools {
+		args = append(args, []string{"--dest", GOBIN}...)
 		for _, res := range allToolsArchiveFiles {
 			if strings.HasPrefix(res, GOBIN) {
 				// Binary tool found, cross build it explicitly
@@ -945,6 +945,9 @@ func doXgo(cmdline []string) {
 		return
 	}
 	// Otherwise xxecute the explicit cross compilation
+	path := args[len(args)-1]
+	args = append(args[:len(args)-1], []string{"--dest", GOBIN, path}...)
+
 	xgo := xgoTool(args)
 	build.MustRun(xgo)
 }


### PR DESCRIPTION
The mips xgo refactor moved setting gobin inside ci.go by appending it to the end of the xgo args. Unfortunately this broke the xgo calls from the makefile since those have the import path to build as the last element, and that needs to remain the last one.

This PR fixes it by cutting the import path off the argument list, appending gobin then, and appending back to the very and the user provided import path.