### PR TITLE
swarm: Add 'swarm ls' to list manifest directory trees

### DIFF
--- a/cmd/swarm/list.go
+++ b/cmd/swarm/list.go
@@ -1,0 +1,58 @@
+// Copyright 2016 The go-ethereum Authors
+// This file is part of go-ethereum.
+//
+// go-ethereum is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// go-ethereum is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with go-ethereum. If not, see <http://www.gnu.org/licenses/>.
+
+package main
+
+import (
+	"fmt"
+	"os"
+	"strings"
+	"text/tabwriter"
+
+	"github.com/ethereum/go-ethereum/cmd/utils"
+	swarm "github.com/ethereum/go-ethereum/swarm/api/client"
+	"gopkg.in/urfave/cli.v1"
+)
+
+func list(ctx *cli.Context) {
+	args := ctx.Args()
+
+	if len(args) < 1 {
+		utils.Fatalf("Please supply a manifest reference as the first argument")
+	} else if len(args) > 2 {
+		utils.Fatalf("Too many arguments - usage 'swarm ls manifest [prefix]'")
+	}
+	manifest := args[0]
+
+	var prefix string
+	if len(args) == 2 {
+		prefix = args[1]
+	}
+
+	bzzapi := strings.TrimRight(ctx.GlobalString(SwarmApiFlag.Name), "/")
+	client := swarm.NewClient(bzzapi)
+	entries, err := client.ManifestFileList(manifest, prefix)
+	if err != nil {
+		utils.Fatalf("Failed to generate file and directory list: %s", err)
+	}
+
+	w := tabwriter.NewWriter(os.Stdout, 1, 2, 2, ' ', 0)
+	defer w.Flush()
+	fmt.Fprintln(w, "HASH\tCONTENT TYPE\tPATH")
+	for _, entry := range entries {
+		fmt.Fprintf(w, "%s\t%s\t%s\n", entry.Hash, entry.ContentType, entry.Path)
+	}
+}

--- a/cmd/swarm/main.go
+++ b/cmd/swarm/main.go
@@ -148,6 +148,15 @@ The output of this command is supposed to be machine-readable.
 `,
 		},
 		{
+			Action:    list,
+			Name:      "ls",
+			Usage:     "list files and directories contained in a manifest",
+			ArgsUsage: " <manifest> [<prefix>]",
+			Description: `
+Lists files and directories contained in a manifest.
+`,
+		},
+		{
 			Action:    hash,
 			Name:      "hash",
 			Usage:     "print the swarm hash of a file or directory",

--- a/cmd/swarm/upload.go
+++ b/cmd/swarm/upload.go
@@ -68,7 +68,7 @@ func upload(ctx *cli.Context) {
 	if err != nil {
 		utils.Fatalf("Upload failed: %v", err)
 	}
-	mroot := swarm.Manifest{[]swarm.ManifestEntry{entry}}
+	mroot := swarm.Manifest{Entries: []swarm.ManifestEntry{entry}}
 	if !wantManifest {
 		// Print the manifest. This is the only output to stdout.
 		mrootJSON, _ := json.MarshalIndent(mroot, "", "  ")

--- a/cmd/swarm/upload.go
+++ b/cmd/swarm/upload.go
@@ -18,21 +18,15 @@
 package main
 
 import (
-	"bytes"
 	"encoding/json"
 	"fmt"
-	"io"
-	"io/ioutil"
-	"mime"
-	"net/http"
 	"os"
 	"os/user"
 	"path"
-	"path/filepath"
 	"strings"
 
 	"github.com/ethereum/go-ethereum/cmd/utils"
-	"github.com/ethereum/go-ethereum/log"
+	swarm "github.com/ethereum/go-ethereum/swarm/api/client"
 	"gopkg.in/urfave/cli.v1"
 )
 
@@ -50,7 +44,7 @@ func upload(ctx *cli.Context) {
 
 	var (
 		file   = args[0]
-		client = &client{api: bzzapi}
+		client = swarm.NewClient(bzzapi)
 	)
 	fi, err := os.Stat(expandPath(file))
 	if err != nil {
@@ -63,25 +57,25 @@ func upload(ctx *cli.Context) {
 		if !wantManifest {
 			utils.Fatalf("Manifest is required for directory uploads")
 		}
-		mhash, err := client.uploadDirectory(file, defaultPath)
+		mhash, err := client.UploadDirectory(file, defaultPath)
 		if err != nil {
 			utils.Fatalf("Failed to upload directory: %v", err)
 		}
 		fmt.Println(mhash)
 		return
 	}
-	entry, err := client.uploadFile(file, fi)
+	entry, err := client.UploadFile(file, fi)
 	if err != nil {
 		utils.Fatalf("Upload failed: %v", err)
 	}
-	mroot := manifest{[]manifestEntry{entry}}
+	mroot := swarm.Manifest{[]swarm.ManifestEntry{entry}}
 	if !wantManifest {
 		// Print the manifest. This is the only output to stdout.
 		mrootJSON, _ := json.MarshalIndent(mroot, "", "  ")
 		fmt.Println(string(mrootJSON))
 		return
 	}
-	hash, err := client.uploadManifest(mroot)
+	hash, err := client.UploadManifest(mroot)
 	if err != nil {
 		utils.Fatalf("Manifest upload failed: %v", err)
 	}
@@ -110,149 +104,4 @@ func homeDir() string {
 		return usr.HomeDir
 	}
 	return ""
-}
-
-// client wraps interaction with the swarm HTTP gateway.
-type client struct {
-	api string
-}
-
-// manifest is the JSON representation of a swarm manifest.
-type manifestEntry struct {
-	Hash        string `json:"hash,omitempty"`
-	ContentType string `json:"contentType,omitempty"`
-	Path        string `json:"path,omitempty"`
-}
-
-// manifest is the JSON representation of a swarm manifest.
-type manifest struct {
-	Entries []manifestEntry `json:"entries,omitempty"`
-}
-
-func (c *client) uploadDirectory(dir string, defaultPath string) (string, error) {
-	mhash, err := c.postRaw("application/json", 2, ioutil.NopCloser(bytes.NewReader([]byte("{}"))))
-	if err != nil {
-		return "", fmt.Errorf("failed to upload empty manifest")
-	}
-	if len(defaultPath) > 0 {
-		fi, err := os.Stat(defaultPath)
-		if err != nil {
-			return "", err
-		}
-		mhash, err = c.uploadToManifest(mhash, "", defaultPath, fi)
-		if err != nil {
-			return "", err
-		}
-	}
-	prefix := filepath.ToSlash(filepath.Clean(dir)) + "/"
-	err = filepath.Walk(dir, func(path string, fi os.FileInfo, err error) error {
-		if err != nil || fi.IsDir() {
-			return err
-		}
-		if !strings.HasPrefix(path, dir) {
-			return fmt.Errorf("path %s outside directory %s", path, dir)
-		}
-		uripath := strings.TrimPrefix(filepath.ToSlash(filepath.Clean(path)), prefix)
-		mhash, err = c.uploadToManifest(mhash, uripath, path, fi)
-		return err
-	})
-	return mhash, err
-}
-
-func (c *client) uploadFile(file string, fi os.FileInfo) (manifestEntry, error) {
-	hash, err := c.uploadFileContent(file, fi)
-	m := manifestEntry{
-		Hash:        hash,
-		ContentType: mime.TypeByExtension(filepath.Ext(fi.Name())),
-	}
-	return m, err
-}
-
-func (c *client) uploadFileContent(file string, fi os.FileInfo) (string, error) {
-	fd, err := os.Open(file)
-	if err != nil {
-		return "", err
-	}
-	defer fd.Close()
-	log.Info("Uploading swarm content", "file", file, "bytes", fi.Size())
-	return c.postRaw("application/octet-stream", fi.Size(), fd)
-}
-
-func (c *client) uploadManifest(m manifest) (string, error) {
-	jsm, err := json.Marshal(m)
-	if err != nil {
-		panic(err)
-	}
-	log.Info("Uploading swarm manifest")
-	return c.postRaw("application/json", int64(len(jsm)), ioutil.NopCloser(bytes.NewReader(jsm)))
-}
-
-func (c *client) uploadToManifest(mhash string, path string, fpath string, fi os.FileInfo) (string, error) {
-	fd, err := os.Open(fpath)
-	if err != nil {
-		return "", err
-	}
-	defer fd.Close()
-	log.Info("Uploading swarm content and path", "file", fpath, "bytes", fi.Size(), "path", path)
-	req, err := http.NewRequest("PUT", c.api+"/bzz:/"+mhash+"/"+path, fd)
-	if err != nil {
-		return "", err
-	}
-	req.Header.Set("content-type", mime.TypeByExtension(filepath.Ext(fi.Name())))
-	req.ContentLength = fi.Size()
-	resp, err := http.DefaultClient.Do(req)
-	if err != nil {
-		return "", err
-	}
-	defer resp.Body.Close()
-	if resp.StatusCode >= 400 {
-		return "", fmt.Errorf("bad status: %s", resp.Status)
-	}
-	content, err := ioutil.ReadAll(resp.Body)
-	return string(content), err
-}
-
-func (c *client) postRaw(mimetype string, size int64, body io.ReadCloser) (string, error) {
-	req, err := http.NewRequest("POST", c.api+"/bzzr:/", body)
-	if err != nil {
-		return "", err
-	}
-	req.Header.Set("content-type", mimetype)
-	req.ContentLength = size
-	resp, err := http.DefaultClient.Do(req)
-	if err != nil {
-		return "", err
-	}
-	defer resp.Body.Close()
-	if resp.StatusCode >= 400 {
-		return "", fmt.Errorf("bad status: %s", resp.Status)
-	}
-	content, err := ioutil.ReadAll(resp.Body)
-	return string(content), err
-}
-
-func (c *client) downloadManifest(mhash string) (manifest, error) {
-
-	mroot := manifest{}
-	req, err := http.NewRequest("GET", c.api+"/bzzr:/"+mhash, nil)
-	if err != nil {
-		return mroot, err
-	}
-	resp, err := http.DefaultClient.Do(req)
-	if err != nil {
-		return mroot, err
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode >= 400 {
-		return mroot, fmt.Errorf("bad status: %s", resp.Status)
-
-	}
-	content, err := ioutil.ReadAll(resp.Body)
-
-	err = json.Unmarshal(content, &mroot)
-	if err != nil {
-		return mroot, fmt.Errorf("Manifest %v is malformed: %v", mhash, err)
-	}
-	return mroot, err
 }

--- a/swarm/api/client/client.go
+++ b/swarm/api/client/client.go
@@ -1,0 +1,188 @@
+// Copyright 2016 The go-ethereum Authors
+// This file is part of go-ethereum.
+//
+// go-ethereum is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// go-ethereum is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with go-ethereum. If not, see <http://www.gnu.org/licenses/>.
+
+package client
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"mime"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/ethereum/go-ethereum/log"
+)
+
+var (
+	DefaultGateway = "http://localhost:8500"
+	DefaultClient  = NewClient(DefaultGateway)
+)
+
+// Manifest represents a swarm manifest.
+type Manifest struct {
+	Entries []ManifestEntry `json:"entries,omitempty"`
+}
+
+// ManifestEntry represents an entry in a swarm manifest.
+type ManifestEntry struct {
+	Hash        string `json:"hash,omitempty"`
+	ContentType string `json:"contentType,omitempty"`
+	Path        string `json:"path,omitempty"`
+}
+
+func NewClient(gateway string) *Client {
+	return &Client{
+		Gateway: gateway,
+	}
+}
+
+// Client wraps interaction with a swarm HTTP gateway.
+type Client struct {
+	Gateway string
+}
+
+func (c *Client) UploadDirectory(dir string, defaultPath string) (string, error) {
+	mhash, err := c.postRaw("application/json", 2, ioutil.NopCloser(bytes.NewReader([]byte("{}"))))
+	if err != nil {
+		return "", fmt.Errorf("failed to upload empty manifest")
+	}
+	if len(defaultPath) > 0 {
+		fi, err := os.Stat(defaultPath)
+		if err != nil {
+			return "", err
+		}
+		mhash, err = c.uploadToManifest(mhash, "", defaultPath, fi)
+		if err != nil {
+			return "", err
+		}
+	}
+	prefix := filepath.ToSlash(filepath.Clean(dir)) + "/"
+	err = filepath.Walk(dir, func(path string, fi os.FileInfo, err error) error {
+		if err != nil || fi.IsDir() {
+			return err
+		}
+		if !strings.HasPrefix(path, dir) {
+			return fmt.Errorf("path %s outside directory %s", path, dir)
+		}
+		uripath := strings.TrimPrefix(filepath.ToSlash(filepath.Clean(path)), prefix)
+		mhash, err = c.uploadToManifest(mhash, uripath, path, fi)
+		return err
+	})
+	return mhash, err
+}
+
+func (c *Client) UploadFile(file string, fi os.FileInfo) (ManifestEntry, error) {
+	hash, err := c.uploadFileContent(file, fi)
+	m := ManifestEntry{
+		Hash:        hash,
+		ContentType: mime.TypeByExtension(filepath.Ext(fi.Name())),
+	}
+	return m, err
+}
+
+func (c *Client) uploadFileContent(file string, fi os.FileInfo) (string, error) {
+	fd, err := os.Open(file)
+	if err != nil {
+		return "", err
+	}
+	defer fd.Close()
+	log.Info("Uploading swarm content", "file", file, "bytes", fi.Size())
+	return c.postRaw("application/octet-stream", fi.Size(), fd)
+}
+
+func (c *Client) UploadManifest(m Manifest) (string, error) {
+	jsm, err := json.Marshal(m)
+	if err != nil {
+		panic(err)
+	}
+	log.Info("Uploading swarm manifest")
+	return c.postRaw("application/json", int64(len(jsm)), ioutil.NopCloser(bytes.NewReader(jsm)))
+}
+
+func (c *Client) uploadToManifest(mhash string, path string, fpath string, fi os.FileInfo) (string, error) {
+	fd, err := os.Open(fpath)
+	if err != nil {
+		return "", err
+	}
+	defer fd.Close()
+	log.Info("Uploading swarm content and path", "file", fpath, "bytes", fi.Size(), "path", path)
+	req, err := http.NewRequest("PUT", c.Gateway+"/bzz:/"+mhash+"/"+path, fd)
+	if err != nil {
+		return "", err
+	}
+	req.Header.Set("content-type", mime.TypeByExtension(filepath.Ext(fi.Name())))
+	req.ContentLength = fi.Size()
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode >= 400 {
+		return "", fmt.Errorf("bad status: %s", resp.Status)
+	}
+	content, err := ioutil.ReadAll(resp.Body)
+	return string(content), err
+}
+
+func (c *Client) postRaw(mimetype string, size int64, body io.ReadCloser) (string, error) {
+	req, err := http.NewRequest("POST", c.Gateway+"/bzzr:/", body)
+	if err != nil {
+		return "", err
+	}
+	req.Header.Set("content-type", mimetype)
+	req.ContentLength = size
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode >= 400 {
+		return "", fmt.Errorf("bad status: %s", resp.Status)
+	}
+	content, err := ioutil.ReadAll(resp.Body)
+	return string(content), err
+}
+
+func (c *Client) DownloadManifest(mhash string) (Manifest, error) {
+
+	mroot := Manifest{}
+	req, err := http.NewRequest("GET", c.Gateway+"/bzzr:/"+mhash, nil)
+	if err != nil {
+		return mroot, err
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return mroot, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode >= 400 {
+		return mroot, fmt.Errorf("bad status: %s", resp.Status)
+
+	}
+	content, err := ioutil.ReadAll(resp.Body)
+
+	err = json.Unmarshal(content, &mroot)
+	if err != nil {
+		return mroot, fmt.Errorf("Manifest %v is malformed: %v", mhash, err)
+	}
+	return mroot, err
+}

--- a/swarm/api/client/client_test.go
+++ b/swarm/api/client/client_test.go
@@ -1,0 +1,105 @@
+// Copyright 2016 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+package client
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"reflect"
+	"sort"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/swarm/testutil"
+)
+
+func TestClientManifestFileList(t *testing.T) {
+	srv := testutil.NewTestSwarmServer(t)
+	defer srv.Close()
+
+	dir, err := ioutil.TempDir("", "swarm-client-test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	files := []string{
+		"file1.txt",
+		"file2.txt",
+		"dir1/file3.txt",
+		"dir1/file4.txt",
+		"dir2/file5.txt",
+		"dir2/dir3/file6.txt",
+		"dir2/dir4/file7.txt",
+		"dir2/dir4/file8.txt",
+	}
+	for _, file := range files {
+		path := filepath.Join(dir, file)
+		if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+			t.Fatalf("error creating dir for %s: %s", path, err)
+		}
+		if err := ioutil.WriteFile(path, []byte("data"), 0644); err != nil {
+			t.Fatalf("error writing file %s: %s", path, err)
+		}
+	}
+
+	client := NewClient(srv.URL)
+
+	hash, err := client.UploadDirectory(dir, "")
+	if err != nil {
+		t.Fatalf("error uploading directory: %s", err)
+	}
+
+	ls := func(prefix string) []string {
+		entries, err := client.ManifestFileList(hash, prefix)
+		if err != nil {
+			t.Fatal(err)
+		}
+		paths := make([]string, len(entries))
+		for i, entry := range entries {
+			paths[i] = entry.Path
+		}
+		sort.Strings(paths)
+		return paths
+	}
+
+	tests := map[string][]string{
+		"":                    []string{"dir1/", "dir2/", "file1.txt", "file2.txt"},
+		"file":                []string{"file1.txt", "file2.txt"},
+		"file1":               []string{"file1.txt"},
+		"file2.txt":           []string{"file2.txt"},
+		"file12":              []string{},
+		"dir":                 []string{"dir1/", "dir2/"},
+		"dir1":                []string{"dir1/"},
+		"dir1/":               []string{"dir1/file3.txt", "dir1/file4.txt"},
+		"dir1/file":           []string{"dir1/file3.txt", "dir1/file4.txt"},
+		"dir1/file3.txt":      []string{"dir1/file3.txt"},
+		"dir1/file34":         []string{},
+		"dir2/":               []string{"dir2/dir3/", "dir2/dir4/", "dir2/file5.txt"},
+		"dir2/file":           []string{"dir2/file5.txt"},
+		"dir2/dir":            []string{"dir2/dir3/", "dir2/dir4/"},
+		"dir2/dir3/":          []string{"dir2/dir3/file6.txt"},
+		"dir2/dir4/":          []string{"dir2/dir4/file7.txt", "dir2/dir4/file8.txt"},
+		"dir2/dir4/file":      []string{"dir2/dir4/file7.txt", "dir2/dir4/file8.txt"},
+		"dir2/dir4/file7.txt": []string{"dir2/dir4/file7.txt"},
+		"dir2/dir4/file78":    []string{},
+	}
+	for prefix, expected := range tests {
+		actual := ls(prefix)
+		if !reflect.DeepEqual(actual, expected) {
+			t.Fatalf("expected prefix %q to return paths %v, got %v", prefix, expected, actual)
+		}
+	}
+}

--- a/swarm/api/http/server_test.go
+++ b/swarm/api/http/server_test.go
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
 
-package http
+package http_test
 
 import (
 	"bytes"
@@ -22,18 +22,15 @@ import (
 	"net/http"
 	"sync"
 	"testing"
-	"time"
 
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/swarm/api"
 	"github.com/ethereum/go-ethereum/swarm/storage"
+	"github.com/ethereum/go-ethereum/swarm/testutil"
 )
 
 func TestBzzrGetPath(t *testing.T) {
 
 	var err error
-
-	maxproxyattempts := 3
 
 	testmanifest := []string{
 		`{"entries":[{"path":"a/","hash":"674af7073604ebfc0282a4ab21e5ef1a3c22913866879ebc0816f8a89896b2ed","contentType":"application/bzz-manifest+json","status":0}]}`,
@@ -54,61 +51,30 @@ func TestBzzrGetPath(t *testing.T) {
 
 	key := [3]storage.Key{}
 
-	dir, _ := ioutil.TempDir("", "bzz-storage-test")
-
-	storeparams := &storage.StoreParams{
-		ChunkDbPath:   dir,
-		DbCapacity:    5000000,
-		CacheCapacity: 5000,
-		Radius:        0,
-	}
-
-	localStore, err := storage.NewLocalStore(storage.MakeHashFunc("SHA3"), storeparams)
-	if err != nil {
-		t.Fatal(err)
-	}
-	chunker := storage.NewTreeChunker(storage.NewChunkerParams())
-	dpa := &storage.DPA{
-		Chunker:    chunker,
-		ChunkStore: localStore,
-	}
-	dpa.Start()
-	defer dpa.Stop()
+	srv := testutil.NewTestSwarmServer(t)
+	defer srv.Close()
 
 	wg := &sync.WaitGroup{}
 
 	for i, mf := range testmanifest {
 		reader[i] = bytes.NewReader([]byte(mf))
-		key[i], err = dpa.Store(reader[i], int64(len(mf)), wg, nil)
+		key[i], err = srv.Dpa.Store(reader[i], int64(len(mf)), wg, nil)
 		if err != nil {
 			t.Fatal(err)
 		}
 		wg.Wait()
 	}
 
-	a := api.NewApi(dpa, nil)
-
-	/// \todo iterate port numbers up if fail
-	StartHttpServer(a, &Server{Addr: "127.0.0.1:8504", CorsString: ""})
-	// how to wait for ListenAndServe to have initialized? This is pretty cruuuude
-	// if we fix it we don't need maxproxyattempts anymore either
-	time.Sleep(1000 * time.Millisecond)
-	for i := 0; i <= maxproxyattempts; i++ {
-		_, err := http.Get("http://127.0.0.1:8504/bzzr:/" + common.ToHex(key[0])[2:] + "/a")
-		if i == maxproxyattempts {
-			t.Fatalf("Failed to connect to proxy after %v attempts: %v", i, err)
-		} else if err != nil {
-			time.Sleep(100 * time.Millisecond)
-			continue
-		}
-		break
+	_, err = http.Get(srv.URL + "/bzzr:/" + common.ToHex(key[0])[2:] + "/a")
+	if err != nil {
+		t.Fatalf("Failed to connect to proxy: %v", err)
 	}
 
 	for k, v := range testrequests {
 		var resp *http.Response
 		var respbody []byte
 
-		url := "http://127.0.0.1:8504/bzzr:/"
+		url := srv.URL + "/bzzr:/"
 		if k[:] != "" {
 			url += common.ToHex(key[0])[2:] + "/" + k[1:] + "?content_type=text/plain"
 		}

--- a/swarm/swarm.go
+++ b/swarm/swarm.go
@@ -191,7 +191,10 @@ func (self *Swarm) Start(net *p2p.Server) error {
 	// start swarm http proxy server
 	if self.config.Port != "" {
 		addr := ":" + self.config.Port
-		go httpapi.StartHttpServer(self.api, &httpapi.Server{Addr: addr, CorsString: self.corsString})
+		go httpapi.StartHttpServer(self.api, &httpapi.ServerConfig{
+			Addr:       addr,
+			CorsString: self.corsString,
+		})
 	}
 
 	log.Debug(fmt.Sprintf("Swarm http proxy started on port: %v", self.config.Port))

--- a/swarm/testutil/http.go
+++ b/swarm/testutil/http.go
@@ -1,0 +1,56 @@
+package testutil
+
+import (
+	"io/ioutil"
+	"net/http/httptest"
+	"os"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/swarm/api"
+	httpapi "github.com/ethereum/go-ethereum/swarm/api/http"
+	"github.com/ethereum/go-ethereum/swarm/storage"
+)
+
+func NewTestSwarmServer(t *testing.T) *TestSwarmServer {
+	dir, err := ioutil.TempDir("", "swarm-storage-test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	storeparams := &storage.StoreParams{
+		ChunkDbPath:   dir,
+		DbCapacity:    5000000,
+		CacheCapacity: 5000,
+		Radius:        0,
+	}
+	localStore, err := storage.NewLocalStore(storage.MakeHashFunc("SHA3"), storeparams)
+	if err != nil {
+		os.RemoveAll(dir)
+		t.Fatal(err)
+	}
+	chunker := storage.NewTreeChunker(storage.NewChunkerParams())
+	dpa := &storage.DPA{
+		Chunker:    chunker,
+		ChunkStore: localStore,
+	}
+	dpa.Start()
+	a := api.NewApi(dpa, nil)
+	srv := httptest.NewServer(httpapi.NewServer(a))
+	return &TestSwarmServer{
+		Server: srv,
+		Dpa:    dpa,
+		dir:    dir,
+	}
+}
+
+type TestSwarmServer struct {
+	*httptest.Server
+
+	Dpa *storage.DPA
+	dir string
+}
+
+func (t *TestSwarmServer) Close() {
+	t.Server.Close()
+	t.Dpa.Stop()
+	os.RemoveAll(t.dir)
+}


### PR DESCRIPTION
This adds a `swarm ls` command which lists files and directories stored in a manifest.

Rather than listing all files, it uses "directory prefixes" in case there are a lot of files in a manifest but you just want to traverse it.

This also includes some refactoring to the tests and the introduction of a `swarm/api/client` package to make things easier to test.

Examples:

---

1. with the contents of the `swarm` directory of this repository uploaded with manifest hash `47203951b3451bcb73f2a3764142e9b2987c855764a08dc3bdd11b1e798b3b04`:

```
$ swarm ls 47203951b3451bcb73f2a3764142e9b2987c855764a08dc3bdd11b1e798b3b04
HASH                                                              CONTENT TYPE  PATH
                                                                  DIR           api/
                                                                  DIR           network/
                                                                  DIR           services/
                                                                  DIR           storage/
27d7a6d01d1f6a6e143f368a815352205c4b9b5bf4c3efa51f04bfc2d675f971                swarm.go
                                                                  DIR           testutil/
```

```
$ swarm ls 47203951b3451bcb73f2a3764142e9b2987c855764a08dc3bdd11b1e798b3b04 services/
HASH  CONTENT TYPE  PATH
      DIR           services/swap/
```

```
$ swarm ls 47203951b3451bcb73f2a3764142e9b2987c855764a08dc3bdd11b1e798b3b04 services/swap/
HASH                                                              CONTENT TYPE  PATH
8cdf723c59f002addc37ec1f6873403ab9532117f37aa385412c8c89bd0a0c28                services/swap/swap.go
                                                                  DIR           services/swap/swap/
```

---

2. listing files in the public `theswarm.eth` manifest:

```
$ swarm --bzzapi "http://swarm-gateways.net" ls theswarm.eth
HASH                                                              CONTENT TYPE               PATH
                                                                  DIR                        .git/
3f765acb4c6a9645d27fa54532926297955da67fb8a088026d413be7f6125e25  text/plain; charset=utf-8  README.md
                                                                  DIR                        Swarm_files/
                                                                  DIR                        ethersphere/
                                                                  DIR                        images/
7b7eb0f53ef673191338c4c6ecd8997a8016397cd1c3f2774dc238840c9e5f0f  text/html; charset=utf-8   index.html
                                                                  DIR                        talks/
7b7eb0f53ef673191338c4c6ecd8997a8016397cd1c3f2774dc238840c9e5f0f  text/html; charset=utf-8   /
```

```
$ swarm --bzzapi "http://swarm-gateways.net" ls theswarm.eth images/
HASH                                                              CONTENT TYPE  PATH
736f17d25c07a0a1074b838e90bde4f9cfaeeb940e3ef545ca355eecb96630e5  image/png     images/swarm-01.png
ffc0988c581f0fcbb658f66b5ea636e63abf746ecb717931862b8e6cca3e746d  image/png     images/swarm-02.png
a17efc88ece60835374b91680af4f7de2042dab54c0f638eb7bfc2f53691585c  image/png     images/swarm-03.png
b645405800c2f2716c92e606eb217d566257754e484c55f19194f5c9badc43a6  image/png     images/swarm-04.png
```

---

Ref #3540 (does not close it as I haven't added a `--json` flag).

/cc @zelig 