### PR TITLE
Faster imports

### DIFF
--- a/cmd/geth/chaincmd.go
+++ b/cmd/geth/chaincmd.go
@@ -122,7 +122,7 @@ func initGenesis(ctx *cli.Context) error {
 }
 
 func importChain(ctx *cli.Context) error {
-	if len(ctx.Args()) != 1 {
+	if len(ctx.Args()) < 1 {
 		utils.Fatalf("This command requires an argument.")
 	}
 	stack := makeFullNode(ctx)
@@ -146,9 +146,19 @@ func importChain(ctx *cli.Context) error {
 	}()
 	// Import the chain
 	start := time.Now()
-	if err := utils.ImportChain(chain, ctx.Args().First()); err != nil {
-		utils.Fatalf("Import error: %v", err)
+
+	if len(ctx.Args()) == 1 {
+		if err := utils.ImportChain(chain, ctx.Args().First()); err != nil {
+			utils.Fatalf("Import error: %v", err)
+		}
+	} else {
+		for _, arg := range ctx.Args() {
+			if err := utils.ImportChain(chain, arg); err != nil {
+				log.Error("Import error", "err", err)
+			}
+		}
 	}
+
 	fmt.Printf("Import done in %v.\n\n", time.Since(start))
 
 	// Output pre-compaction stats mostly to see the import trashing
@@ -170,6 +180,10 @@ func importChain(ctx *cli.Context) error {
 	fmt.Printf("System memory: %.3f MB current, %.3f MB peak\n", float64(mem.Sys)/1024/1024, float64(atomic.LoadUint64(&peakMemSys))/1024/1024)
 	fmt.Printf("Allocations:   %.3f million\n", float64(mem.Mallocs)/1000000)
 	fmt.Printf("GC pause:      %v\n\n", time.Duration(mem.PauseTotalNs))
+
+	if ctx.GlobalIsSet(utils.NoCompactionFlag.Name) {
+		return nil
+	}
 
 	// Compact the entire database to more accurately measure disk io and print the stats
 	start = time.Now()

--- a/cmd/geth/chaincmd.go
+++ b/cmd/geth/chaincmd.go
@@ -157,7 +157,7 @@ func importChain(ctx *cli.Context) error {
 	} else {
 		for _, arg := range ctx.Args() {
 			if err := utils.ImportChain(chain, arg); err != nil {
-				log.Error("Import error", "file",arg, "err", err)
+				log.Error("Import error", "file", arg, "err", err)
 			}
 		}
 	}

--- a/cmd/geth/chaincmd.go
+++ b/cmd/geth/chaincmd.go
@@ -54,10 +54,13 @@ participating.
 		Action:    importChain,
 		Name:      "import",
 		Usage:     "Import a blockchain file",
-		ArgsUsage: "<filename>",
+		ArgsUsage: "<filename> (<filename 2> ... <filename N>) ",
 		Category:  "BLOCKCHAIN COMMANDS",
 		Description: `
-TODO: Please write this
+The import command imports blocks from an RLP-encoded form. The form can be one file 
+with several RLP-encoded blocks, or several files can be used. 
+If only one file is used, import error will result in failure. If several files are used, 
+processing will proceed even if an individual RLP-file import failure occurs.   
 `,
 	}
 	exportCommand = cli.Command{

--- a/cmd/geth/chaincmd.go
+++ b/cmd/geth/chaincmd.go
@@ -157,7 +157,7 @@ func importChain(ctx *cli.Context) error {
 	} else {
 		for _, arg := range ctx.Args() {
 			if err := utils.ImportChain(chain, arg); err != nil {
-				log.Error("Import error", "err", err)
+				log.Error("Import error", "file",arg, "err", err)
 			}
 		}
 	}

--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -140,6 +140,7 @@ func init() {
 		utils.EthStatsURLFlag,
 		utils.MetricsEnabledFlag,
 		utils.FakePoWFlag,
+		utils.NoCompactionFlag,
 		utils.SolcPathFlag,
 		utils.GpoMinGasPriceFlag,
 		utils.GpoMaxGasPriceFlag,

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -244,7 +244,10 @@ var (
 		Name:  "fakepow",
 		Usage: "Disables proof-of-work verification",
 	}
-
+	NoCompactionFlag = cli.BoolFlag{
+		Name:  "nocompaction",
+		Usage: "Disables db compaction after import",
+	}
 	// RPC settings
 	RPCEnabledFlag = cli.BoolFlag{
 		Name:  "rpc",


### PR DESCRIPTION
This PR is kind of specific for Hive-testing. 
It does two things: 

* During `import` it takes several arguments, each one an RLP-encoded file of block(s). If import of such a file fails, the error is printed, but the next file is resumed. In hive-testing, 'bad' blocks are expected, and we want to import the next block when one block fails. This PR saves us from having to restart `geth` between each file. 
* It adds the flag `nocompaction`, which skips database compaction after import. In hive-testing, we commonly import only one or a handful of blocks, and compacting after importing one block takes 500-700 milliseconds. On 8000+ tests, that's quite a lot of time. 

Hive results (only with a few hundred tests) are below. This is the 'execution time', which is not the same as total time since tests are executed in paralell. for For total time, without this PR , it took 15 minutes, with the PR it took 8 minutes. But that also counts the time for docker to build the image, and other unrelated things. 

```
#python count_time.py artefacts/go-ethereum\:master.json 
Opening artefacts/go-ethereum:master.json
go-ethereum:master
258 tests (236 successes) in 4323.673476 seconds
[/data/workspace/hive]
#python count_time.py artefacts/20170308_105605-go-ethereum\:master.json 
Opening artefacts/20170308_105605-go-ethereum:master.json
go-ethereum:master
258 tests (236 successes) in 3096.796486 seconds

```

So it seems to shave off 25% for hive-tests, at least, with no difference in test-results. 
