### PR TITLE
build: add bootnode to Ubuntu PPAs too

### DIFF
--- a/build/ci.go
+++ b/build/ci.go
@@ -84,6 +84,10 @@ var (
 			Description: "Ethereum CLI client.",
 		},
 		{
+			Name:        "bootnode",
+			Description: "Ethereum bootnode.",
+		},
+		{
 			Name:        "rlpdump",
 			Description: "Developer utility tool that prints RLP structures.",
 		},


### PR DESCRIPTION
Fixes https://github.com/ethereum/go-ethereum/issues/3703, properly now.