### PR TITLE
cmd: separate BootnodesV5Flag from BootnodesFlag

### DIFF
--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -89,6 +89,7 @@ func init() {
 		utils.UnlockedAccountFlag,
 		utils.PasswordFileFlag,
 		utils.BootnodesFlag,
+		utils.BootnodesV5Flag,
 		utils.DataDirFlag,
 		utils.KeyStoreDirFlag,
 		utils.EthashCacheDirFlag,

--- a/cmd/geth/usage.go
+++ b/cmd/geth/usage.go
@@ -127,6 +127,7 @@ var AppHelpFlagGroups = []flagGroup{
 		Name: "NETWORKING",
 		Flags: []cli.Flag{
 			utils.BootnodesFlag,
+			utils.BootnodesV5Flag,
 			utils.ListenPortFlag,
 			utils.MaxPeersFlag,
 			utils.MaxPendingPeersFlag,

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -365,6 +365,11 @@ var (
 		Usage: "Comma separated enode URLs for P2P discovery bootstrap",
 		Value: "",
 	}
+	BootnodesV5Flag = cli.StringFlag{
+		Name:  "v5bootnodes",
+		Usage: "Comma separated enode URLs for experimental RLPx V5 (Topic Discovery) bootstrap",
+		Value: "",
+	}
 	NodeKeyFileFlag = cli.StringFlag{
 		Name:  "nodekey",
 		Usage: "P2P node key file",
@@ -561,8 +566,8 @@ func MakeBootstrapNodes(ctx *cli.Context) []*discover.Node {
 // flags, reverting to pre-configured ones if none have been specified.
 func MakeBootstrapNodesV5(ctx *cli.Context) []*discv5.Node {
 	urls := params.DiscoveryV5Bootnodes
-	if ctx.GlobalIsSet(BootnodesFlag.Name) {
-		urls = strings.Split(ctx.GlobalString(BootnodesFlag.Name), ",")
+	if ctx.GlobalIsSet(BootnodesV5Flag.Name) {
+		urls = strings.Split(ctx.GlobalString(BootnodesV5Flag.Name), ",")
 	}
 
 	bootnodes := make([]*discv5.Node, 0, len(urls))


### PR DESCRIPTION
Currently, the bootstrap nodes specified in the flag `BootnodesFlag` are used both for v4 and v5 discovery. This patch goes to separate the setting of bootstrap nodes for v5 as another flag `BootnodesV5Flag`.

This is my first PR to go-ethereum. Please let me know if this change is appropriate or not. Thanks.