### PR TITLE
Adds support for extended headers in CORS requests.

### DIFF
--- a/rpc/http.go
+++ b/rpc/http.go
@@ -171,6 +171,7 @@ func newCorsHandler(srv *Server, corsString string) http.Handler {
 		AllowedOrigins: allowedOrigins,
 		AllowedMethods: []string{"POST", "GET"},
 		MaxAge:         600,
+		AllowedHeaders: []string{"*"},
 	})
 	return c.Handler(srv)
 }

--- a/swarm/api/http/server.go
+++ b/swarm/api/http/server.go
@@ -82,6 +82,7 @@ func StartHttpServer(api *api.Api, server *Server) {
 		AllowedOrigins: allowedOrigins,
 		AllowedMethods: []string{"POST", "GET", "DELETE", "PATCH", "PUT"},
 		MaxAge:         600,
+		AllowedHeaders: []string{"*"},
 	})
 	hdlr := c.Handler(serveMux)
 


### PR DESCRIPTION
Fixes #3762.  Details about parameter: https://github.com/rs/cors/blob/a62a804a8a009876ca59105f7899938a1349f4b3/cors.go#L50-L54

Re-opening of #3763 