### PR TITLE
pow: fix Search with ethash test mode

### DIFF
--- a/pow/ethash_algo.go
+++ b/pow/ethash_algo.go
@@ -349,12 +349,12 @@ func hashimotoLight(size uint64, cache []uint32, hash []byte, nonce uint64) ([]b
 // hashimotoFull aggregates data from the full dataset (using the full in-memory
 // dataset) in order to produce our final value for a particular header hash and
 // nonce.
-func hashimotoFull(size uint64, dataset []uint32, hash []byte, nonce uint64) ([]byte, []byte) {
+func hashimotoFull(dataset []uint32, hash []byte, nonce uint64) ([]byte, []byte) {
 	lookup := func(index uint32) []uint32 {
 		offset := index * hashWords
 		return dataset[offset : offset+hashWords]
 	}
-	return hashimoto(hash, nonce, size, lookup)
+	return hashimoto(hash, nonce, uint64(len(dataset))*4, lookup)
 }
 
 // datasetSizes is a lookup table for the ethash dataset size for the first 2048

--- a/pow/ethash_algo_test.go
+++ b/pow/ethash_algo_test.go
@@ -660,7 +660,7 @@ func TestHashimoto(t *testing.T) {
 	if !bytes.Equal(result, wantResult) {
 		t.Errorf("light hashimoto result mismatch: have %x, want %x", result, wantResult)
 	}
-	digest, result = hashimotoFull(32*1024, dataset, hash, nonce)
+	digest, result = hashimotoFull(dataset, hash, nonce)
 	if !bytes.Equal(digest, wantDigest) {
 		t.Errorf("full hashimoto digest mismatch: have %x, want %x", digest, wantDigest)
 	}
@@ -713,6 +713,17 @@ func TestConcurrentDiskCacheGeneration(t *testing.T) {
 	pend.Wait()
 }
 
+func TestTestMode(t *testing.T) {
+	head := &types.Header{Difficulty: big.NewInt(100)}
+	ethash := NewTestEthash()
+	nonce, mix := ethash.Search(types.NewBlockWithHeader(head), nil)
+	head.Nonce = types.EncodeNonce(nonce)
+	copy(head.MixDigest[:], mix)
+	if err := ethash.Verify(types.NewBlockWithHeader(head)); err != nil {
+		t.Error("unexpected Verify error:", err)
+	}
+}
+
 // Benchmarks the cache generation performance.
 func BenchmarkCacheGeneration(b *testing.B) {
 	for i := 0; i < b.N; i++ {
@@ -758,6 +769,6 @@ func BenchmarkHashimotoFullSmall(b *testing.B) {
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		hashimotoFull(32*65536, dataset, hash, 0)
+		hashimotoFull(dataset, hash, 0)
 	}
 }


### PR DESCRIPTION
The cache/dataset methods crashed with a nil pointer error if
cachesinmem/dagsinmem were zero. Fix it by skipping the eviction logic
if there are no caches/datasets.

Search always used the regular dataset size regardless of test mode. Fix
it by removing the redundant size parameter of hashimotoFull.

Fixes #3784