### PR TITLE
core/state: fixes #3791

### DIFF
--- a/core/state/managed_state_test.go
+++ b/core/state/managed_state_test.go
@@ -29,6 +29,7 @@ func create() (*ManagedState, *account) {
 	db, _ := ethdb.NewMemDatabase()
 	statedb, _ := New(common.Hash{}, db)
 	ms := ManageState(statedb)
+	ms.StateDB.createObject(addr)
 	ms.StateDB.SetNonce(addr, 100)
 	ms.accounts[addr] = newAccount(ms.StateDB.getStateObject(addr))
 	return ms, ms.accounts[addr]
@@ -116,6 +117,7 @@ func TestSetNonce(t *testing.T) {
 	}
 
 	addr[0] = 1
+	ms.StateDB.createObject(addr)
 	ms.StateDB.SetNonce(addr, 1)
 
 	if ms.GetNonce(addr) != 1 {

--- a/core/state/state_object.go
+++ b/core/state/state_object.go
@@ -136,9 +136,11 @@ func (self *stateObject) markSuicided() {
 }
 
 func (c *stateObject) touch() {
+	prevDirty := c.onDirty == nil
 	c.db.journal = append(c.db.journal, touchChange{
-		account: &c.address,
-		prev:    c.touched,
+		account:   &c.address,
+		prev:      c.touched,
+		prevDirty: prevDirty,
 	})
 	if c.onDirty != nil {
 		c.onDirty(c.Address())

--- a/core/state/state_test.go
+++ b/core/state/state_test.go
@@ -113,6 +113,7 @@ func (s *StateSuite) TestSnapshot(c *checker.C) {
 	data1 := common.BytesToHash([]byte{42})
 	data2 := common.BytesToHash([]byte{43})
 
+	s.state.createObject(stateobjaddr)
 	// set initial state object value
 	s.state.SetState(stateobjaddr, storageaddr, data1)
 	// get snapshot of current state
@@ -143,6 +144,8 @@ func TestSnapshot2(t *testing.T) {
 
 	stateobjaddr0 := toAddr([]byte("so0"))
 	stateobjaddr1 := toAddr([]byte("so1"))
+	state.createObject(stateobjaddr0)
+	state.createObject(stateobjaddr1)
 	var storageaddr common.Hash
 
 	data0 := common.BytesToHash([]byte{17})

--- a/core/state/statedb.go
+++ b/core/state/statedb.go
@@ -397,7 +397,7 @@ func (self *StateDB) deleteStateObject(stateObject *stateObject) {
 func (self *StateDB) getStateObject(addr common.Address) (stateObject *stateObject) {
 	// Prefer 'live' objects.
 	if obj := self.stateObjects[addr]; obj != nil {
-		if obj.deleted {
+		if obj.suicided {
 			return nil
 		}
 		return obj

--- a/core/state/statedb.go
+++ b/core/state/statedb.go
@@ -310,7 +310,7 @@ func (self *StateDB) HasSuicided(addr common.Address) bool {
 
 // AddBalance adds amount to the account associated with addr
 func (self *StateDB) AddBalance(addr common.Address, amount *big.Int) {
-	stateObject := self.GetOrNewStateObject(addr)
+	stateObject := self.getStateObject(addr)
 	if stateObject != nil {
 		stateObject.AddBalance(amount)
 	}
@@ -318,35 +318,35 @@ func (self *StateDB) AddBalance(addr common.Address, amount *big.Int) {
 
 // SubBalance subtracts amount from the account associated with addr
 func (self *StateDB) SubBalance(addr common.Address, amount *big.Int) {
-	stateObject := self.GetOrNewStateObject(addr)
+	stateObject := self.getStateObject(addr)
 	if stateObject != nil {
 		stateObject.SubBalance(amount)
 	}
 }
 
 func (self *StateDB) SetBalance(addr common.Address, amount *big.Int) {
-	stateObject := self.GetOrNewStateObject(addr)
+	stateObject := self.getStateObject(addr)
 	if stateObject != nil {
 		stateObject.SetBalance(amount)
 	}
 }
 
 func (self *StateDB) SetNonce(addr common.Address, nonce uint64) {
-	stateObject := self.GetOrNewStateObject(addr)
+	stateObject := self.getStateObject(addr)
 	if stateObject != nil {
 		stateObject.SetNonce(nonce)
 	}
 }
 
 func (self *StateDB) SetCode(addr common.Address, code []byte) {
-	stateObject := self.GetOrNewStateObject(addr)
+	stateObject := self.getStateObject(addr)
 	if stateObject != nil {
 		stateObject.SetCode(crypto.Keccak256Hash(code), code)
 	}
 }
 
 func (self *StateDB) SetState(addr common.Address, key common.Hash, value common.Hash) {
-	stateObject := self.GetOrNewStateObject(addr)
+	stateObject := self.getStateObject(addr)
 	if stateObject != nil {
 		stateObject.SetState(self.db, key, value)
 	}

--- a/core/state/statedb.go
+++ b/core/state/statedb.go
@@ -366,6 +366,7 @@ func (self *StateDB) Suicide(addr common.Address) bool {
 		account:     &addr,
 		prev:        stateObject.suicided,
 		prevbalance: new(big.Int).Set(stateObject.Balance()),
+		prevObj:     stateObject,
 	})
 	stateObject.markSuicided()
 	stateObject.data.Balance = new(big.Int)

--- a/core/state/statedb_test.go
+++ b/core/state/statedb_test.go
@@ -116,7 +116,7 @@ func TestIntermediateLeaks(t *testing.T) {
 }
 
 func TestSnapshotRandom(t *testing.T) {
-	t.Skip("@fjl fix me please")
+	//t.Skip("@fjl fix me please")
 	config := &quick.Config{MaxCount: 1000}
 	err := quick.Check((*snapshotTest).run, config)
 	if cerr, ok := err.(*quick.CheckError); ok {


### PR DESCRIPTION
In this pull request:

1. skip set operation if a obj is suicided, which help to prevent duplicate `Create` operation been generated.

2. use suicided to mark whether a obj is available

3. modify suicide and touch journal definition and related undo function

4. modify related testcase