### PR TITLE
travis: switch to cocoapods 1.2.0 stable

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -158,7 +158,7 @@ matrix:
 
         # Build the iOS framework and upload it to CocoaPods and Azure
         - gem uninstall cocoapods -a
-        - gem install cocoapods --pre
+        - gem install cocoapods
 
         - mv ~/.cocoapods/repos/master ~/.cocoapods/repos/master.bak
         - sed -i '.bak' 's/repo.join/!repo.join/g' $(dirname `gem which cocoapods`)/cocoapods/sources_manager.rb


### PR DESCRIPTION
Previously we used the pre-release branch of cocoapods to pull in some changes we needed. Since then the stable was released, and the new pre-release broke https://github.com/CocoaPods/CocoaPods/issues/6538.

Since the stable is enough for out purposes currently, this PR switches to that.