### PR TITLE
swarm/storage: binary merkle tree with inclusion proof 

### DIFF
--- a/swarm/storage/binarymerkle.go
+++ b/swarm/storage/binarymerkle.go
@@ -345,8 +345,7 @@ func (d *state) Reset() {
 	d.btree = BTree{count: 0, root: nil, rootHash: nil}
 }
 
-// Write absorbs more data into the hash's state. It produces an error
-// if more data is written to the ShakeHash after writing
+// Write absorbs more data into the hash's state.
 func (d *state) Write(p []byte) (written int, err error) {
 	tree, r, count, err1 := BuildBMT(hashFunc, p, 32)
 	d.btree = *tree
@@ -357,10 +356,6 @@ func (d *state) Write(p []byte) (written int, err error) {
 	}
 
 	return count, err
-}
-
-func (d *state) Get(p []byte) (written int) {
-	return 3
 }
 
 // Sum return the root hash of the BMT

--- a/swarm/storage/binarymerkle.go
+++ b/swarm/storage/binarymerkle.go
@@ -1,0 +1,315 @@
+package storage
+
+// provides a binary merkle tree implementation.
+
+import (
+	"bytes"
+	_ "crypto/sha256"
+	"encoding/binary"
+	"fmt"
+
+	"github.com/ethereum/go-ethereum/crypto/sha3"
+)
+
+var hashFunc Hasher = sha3.NewKeccak256 //default hasher
+
+// A merkle tree for a user that stores the entire tree
+// Specifically this tree is left a leaning balanced binary tree
+// Where each node holds the hash of its leaves
+// And the rootHash is the root node hashed with the count
+// This tree is immutable
+type BTree struct {
+	count    uint64
+	root     *node
+	rootHash []byte
+	//hashFunc Hasher
+}
+
+type node struct {
+	label    []byte
+	children [2]*node // if all nil, leaf node
+
+	// Representation invariants:
+	// if children[0] is nil, children[1] is nil
+	// if both children non nil:
+	//      label is hash of (children[0].label + children[1].label)
+	// if leaf: label is arbitrary data
+	// else if children[1] is nil, label=hash(children[0].label)
+}
+
+func (t BTree) Count() uint64 {
+	return t.count
+}
+
+// The hash/root of an empty BTree does not matter
+func (t BTree) Root() []byte {
+	return t.rootHash
+}
+
+// All trees should pass , unless they are invalid, which should only happen
+// if incorrectly built or modified.
+// Checks the rep invariants
+func (t BTree) Validate() error {
+	count, height, error := t.root.validate()
+	if error != nil {
+		return error
+	}
+	if count != t.count {
+		return fmt.Errorf("Incorrect count. Was %d, should be %d", t.count, count)
+	}
+	if height != GetHeight(count) {
+		return fmt.Errorf("Incorrect height. Was %d, should be %d", height, GetHeight(count))
+	}
+
+	rootLabel := make([]byte, 0)
+	if height > 0 {
+		rootLabel = t.root.label
+	}
+	h := rootHash(count, rootLabel)
+	if !bytes.Equal(t.rootHash, h) {
+		return fmt.Errorf("Incorrect rootHash")
+	}
+	return nil
+}
+
+// Checks the rep invariants
+func (t *node) validate() (count uint64, height int, err error) {
+	if t == nil {
+		return 0, 0, nil
+	}
+	if t.children[0] == nil {
+		if t.children[1] != nil {
+			return 0, 0, fmt.Errorf("Invalid Node: Node missing first child, but has second")
+		}
+		// Leaf node
+		return 1, 1, nil
+	}
+
+	// Not a leaf node
+	count, height, err = t.children[0].validate()
+	if err != nil {
+		return
+	}
+	if t.children[1] != nil {
+		count2, height2, err2 := t.children[1].validate()
+		count += count2
+		if err2 != nil {
+			return count, height, err2
+		}
+		if height2 != height {
+			return count, height, fmt.Errorf("Invalid Node: height mismatch between children")
+		}
+	}
+	h := makeHash(t.children[0], t.children[1])
+	if !bytes.Equal(h, t.label) {
+		return 0, 0, fmt.Errorf("Invalid Node: Node hash mismatch")
+	}
+
+	height++
+	return
+}
+
+func rootHash(count uint64, data []byte) []byte {
+	h := hashFunc()
+	h.Reset()
+	h.Write(data)
+	binary.Write(h, binary.LittleEndian, count)
+	return h.Sum(make([]byte, 0))
+}
+
+func makeHash(left, right *node) []byte {
+	h := hashFunc()
+	h.Reset()
+	if left != nil {
+		h.Write(left.label)
+		if right != nil {
+			h.Write(right.label)
+		}
+	}
+	return h.Sum(make([]byte, 0))
+}
+
+// Returns the height of the tree containing count leaf nodes.
+// This the number of nodes (including the final leaf) from the root to
+// any leaf.
+func GetHeight(count uint64) int {
+	if count == 0 {
+		return 0
+	}
+	height := 0
+	for count > (1 << uint(height)) {
+		height++
+	}
+	return height + 1
+}
+
+// Build Binary Merkle Tree over data segments of segmentsize len with a specific hash func
+// Return
+// BMT - The BMT Representation of the data
+// ROOT - BMT Root
+// Count - Numers of leafs at the BMT
+// error - if exist validation(-1) count(-2) ok(0)
+func BuildBMT(h Hasher, data []byte, segmentsize int) (bmt *BTree, roor *Root, count int, errorcode int) {
+	blocks := splitData(data, segmentsize)
+	hashFunc = h
+	leafcount := len(blocks)
+	tree := Build(blocks)
+	err := tree.Validate()
+	if err != nil {
+		return nil, nil, 0, -1
+	}
+	if tree.Count() != uint64(leafcount) {
+		return nil, nil, 0, -2
+	}
+
+	return tree, &Root{uint64(leafcount), tree.Root()}, leafcount, 0
+	//r := Root{uint64(count), tree.Root()}
+
+}
+
+// Build a tree
+func Build(data [][]byte) *BTree {
+	count := uint64(len(data))
+	height := GetHeight(count)
+	node, leftOverData := buildNode(data, height)
+	if len(leftOverData) != 0 {
+		panic("Build failed to consume all data")
+	}
+	rootLabel := make([]byte, 0)
+	if height > 0 {
+		rootLabel = node.label
+	}
+	hash := rootHash(count, rootLabel)
+	t := BTree{count, node, hash}
+	return &t
+}
+
+// returns a node and the left over data not used by it
+func buildNode(data [][]byte, height int) (*node, [][]byte) {
+	if height == 0 || len(data) == 0 {
+		return nil, data
+	}
+	if height == 1 {
+		// leaf
+		return &node{label: data[0]}, data[1:]
+	}
+	n0, data := buildNode(data, height-1)
+	n1, data := buildNode(data, height-1)
+
+	hash := makeHash(n0, n1)
+	return &node{label: hash, children: [2]*node{n0, n1}}, data
+}
+
+func splitData(data []byte, size int) [][]byte {
+	/* Splits data into an array of slices of len(size) */
+	count := len(data) / size
+	blocks := make([][]byte, 0, count)
+	for i := 0; i < count; i++ {
+		block := data[i*size : (i+1)*size]
+		blocks = append(blocks, block)
+	}
+	if len(data)%size != 0 {
+		blocks = append(blocks, data[len(blocks)*size:])
+	}
+	return blocks
+}
+
+// Return a [][]byte needed to prove the inclusion of the item at the passed index
+// The payload of the item at index is the first value in the proof
+func (t *BTree) InclusionProof(index int) [][]byte {
+	if uint64(index) >= t.count {
+		panic("Invalid index: too large")
+	}
+	if index < 0 {
+		panic("Invalid index: negative")
+	}
+	h := GetHeight(t.count)
+	fmt.Println(h)
+	return proveNode(h, t.root, index)
+}
+
+func proveNode(height int, n *node, index int) [][]byte {
+	if height == 1 {
+		if index != 0 {
+			panic("Invalid index: non 0 for final node")
+		}
+		return [][]byte{n.label}
+	}
+	childIndex := index >> uint(height-2)
+	nextIndex := index & (^(1 << uint(height-2)))
+	b := proveNode(height-1, n.children[childIndex], nextIndex)
+	otherChildIndex := (childIndex + 1) % 2
+	if n.children[otherChildIndex] != nil {
+		b = append(b, n.children[otherChildIndex].label)
+	}
+	return b
+}
+
+// The Root of a merkle tree for a client that does not store the tree
+type Root struct {
+	Count uint64
+	Base  []byte
+}
+
+// Proves the inclusion of an element at the given index with the value thats the first entry in proof
+func (r *Root) CheckProof(h Hasher, proof [][]byte, index int) bool {
+	hashFunc = h
+	t_height := GetHeight(r.Count)
+	root, ok := checkNode(t_height, proof, uint64(index), r.Count)
+	base := rootHash(r.Count, root)
+	return ok && bytes.Equal(r.Base, base)
+}
+
+func checkNode(height int, proof [][]byte, index, count uint64) ([]byte, bool) {
+	if len(proof) == 0 {
+		fmt.Println("Empty")
+		return nil, false
+	}
+	if count <= index {
+		fmt.Println("bad count", count, index)
+		return nil, false
+	}
+
+	if height == 1 {
+		if index != 0 || len(proof) != 1 {
+			fmt.Println("BAD", index, proof)
+			return nil, false
+		}
+		return proof[0], true
+	}
+
+	childIndex := index >> uint(height-2)
+	mask := uint64(^(1 << uint(height-2)))
+	nextIndex := index & mask
+
+	var data []byte
+	var ok bool
+
+	h := hashFunc()
+	h.Reset()
+	//	h:=hashFunc.New()
+	var nextCount uint64
+	last := len(proof) - 1
+	if childIndex == 1 {
+		nextCount = count & mask
+		h.Write(proof[last])
+		data, ok = checkNode(height-1, proof[:last], nextIndex, nextCount)
+		h.Write(data)
+	} else {
+		nextCount = count
+		if count > ^mask {
+			nextCount = ^mask
+		}
+		if count == nextCount {
+			data, ok = checkNode(height-1, proof, nextIndex, nextCount)
+			h.Write(data)
+		} else {
+			data, ok = checkNode(height-1, proof[:last], nextIndex, nextCount)
+			h.Write(data)
+			h.Write(proof[last])
+		}
+	}
+
+	hash := h.Sum(make([]byte, 0))
+	return hash, ok
+}

--- a/swarm/storage/binarymerkle.go
+++ b/swarm/storage/binarymerkle.go
@@ -178,6 +178,9 @@ func GetHeight(count uint64) int {
 // Count - Numers of leafs at the BMT
 // error -
 func BuildBMT(h Hasher, data []byte, segmentsize int) (bmt *BTree, roor *Root, count int, err error) {
+	if len(data) == 0 {
+		return nil, nil, 0, errors.New("data length is 0 ")
+	}
 	hashFunc = h
 	leafcount := len(data) / segmentsize
 	if len(data)%segmentsize != 0 {

--- a/swarm/storage/binarymerkle_test.go
+++ b/swarm/storage/binarymerkle_test.go
@@ -3,84 +3,182 @@ package storage
 import (
 	"fmt"
 	"log"
+	"math/rand"
 	"testing"
 	"time"
 
 	"github.com/ethereum/go-ethereum/crypto/sha3"
 )
 
-//will test the hash (hash.Hash) interface
-func TestBuildBMT2(t *testing.T) {
+func TestBuildBMT(t *testing.T) {
+	for n := 0; n <= 4096; n += 1 {
+		fmt.Println("chunksize", n)
+		testBuildBMTprv(n, t)
+	}
+}
 
-	// Grab some data to make the tree out of, and partition
-	data := make([]byte, 4096)
-	tdata := testDataReader(4096)
+func testBuildBMTprv(n int, t *testing.T) {
+
+	data := make([]byte, n)
+	tdata := testDataReader(n)
 	tdata.Read(data)
-	var thashFunc = MakeHashFunc("BMTSHA3")
-	var h = thashFunc()
-	h.Reset()
-	h.Write(data)
-	var key = h.Sum(nil)
 
-	fmt.Println(key)
+	var tree *BTree
+	var r *Root
+	var count int
+	var err1 error
+	start := time.Now()
+	tree, r, count, err1 = BuildBMT(sha3.NewKeccak256, data, true)
+	elapsed := time.Since(start)
+	log.Printf("n=%d took %s", n, elapsed)
 
+	if err1 != nil {
+		fmt.Println(tree, r, count, err1)
+		return
+	}
 	// for i := 0; i < count; i++ {
-	// 	p := tree.InclusionProof(i)
+	// 	p, err := tree.InclusionProof(i)
+	// 	if err != nil {
+	// 		fmt.Println("proof failed ", i, err.Error())
+	// 		continue
+	// 	}
+	// 	ok, err := r.CheckProof(sha3.NewKeccak256, p.proof, i)
 	//
-	// 	fmt.Println(p)
-	//
-	// 	ok := r.CheckProof(sha3.NewKeccak256, p, i)
-	// 	if !ok {
+	// 	if !ok || (err != nil) {
 	// 		t.Errorf("proof %d failed", i)
 	// 	}
 	// }
-	// fmt.Println("done")
-}
 
-func TestBuildBMTStress(t *testing.T) {
-
-	for i := 1; i < 4096; i++ {
-		BuildBMTwithGivenDataLen(i, t)
-	}
-}
-
-func TestBuildBMT(t *testing.T) {
-	BuildBMTwithGivenDataLen(4096, t)
-}
-
-func BuildBMTwithGivenDataLen(datalen int, t *testing.T) {
-
-	// Grab some data to make the tree out of, and partition
-	fmt.Println("dl", datalen)
-	data := make([]byte, datalen)
-	tdata := testDataReader(datalen)
-	tdata.Read(data)
-	fmt.Println(data)
-
-	start := time.Now()
-
-	tree, r, count, err1 := BuildBMT(sha3.NewKeccak256, data, 32)
-
-	elapsed := time.Since(start)
-	log.Printf("Binomial took %s", elapsed)
-
-	if err1 != nil {
-		fmt.Println(err1)
+	offset := rand.Intn(n)
+	length := rand.Intn((n-offset+1)-1) + 1
+	p, err := tree.GetInclusionProofs(offset, length)
+	if err != nil {
+		t.Errorf("proof %d failed %s", offset, err)
 		return
+
 	}
 
-	fmt.Println(tree.Root(), count)
+	ok, err := r.CheckProofs(sha3.NewKeccak256, p)
 
-	for i := 0; i < count; i++ {
-		p := tree.InclusionProof(i)
+	if !ok || (err != nil) {
+		t.Errorf("proof  failed %s", err)
+	} else {
+		fmt.Println("proofs ok for offset", offset, "lenght", length, "chunksize", n)
+	}
 
-		fmt.Println(p)
+	// ok, err := r.CheckProof(sha3.NewKeccak256, p.proof, i)
+	//
+	// if !ok || (err != nil) {
+	// 	t.Errorf("proof %d failed", i)
+	// }
 
-		ok, err := r.CheckProof(sha3.NewKeccak256, p, i)
+	fmt.Println("done")
+}
 
-		if !ok || (err != nil) {
-			t.Errorf("proof %d failed", i)
+func benchmarkBuildBMT(n int, t *testing.B) {
+	//t.ReportAllocs()
+	tdata := testDataReader(n)
+	data := make([]byte, n)
+	tdata.Read(data)
+
+	//reader := bytes.NewReader(data)
+
+	var tree *BTree
+	var r *Root
+	var count int
+	var err1 error
+	//	blocks := splitData(data, 32)
+	t.ReportAllocs()
+	t.ResetTimer()
+	for i := 0; i < t.N; i++ {
+
+		tree, r, count, err1 = BuildBMT(sha3.NewKeccak256, data, false)
+
+		if err1 != nil {
+			fmt.Println(err1, tree, r, count)
+			return
 		}
 	}
-	fmt.Println("done")
+}
+
+func benchmarkSHA3(n int, t *testing.B) {
+
+	data := make([]byte, n)
+	tdata := testDataReader(n)
+	tdata.Read(data)
+	hashFunc = sha3.NewKeccak256
+
+	t.ReportAllocs()
+	t.ResetTimer()
+
+	h := hashFunc()
+	for i := 0; i < t.N; i++ {
+
+		h.Reset()
+		h.Write(data)
+		//binary.Write(h, binary.LittleEndian, count)
+		h.Sum(nil)
+
+	}
+
+}
+
+func BenchmarkBuildBMT_4k(t *testing.B)   { benchmarkBuildBMT(4096, t) }
+func BenchmarkBuildBMT_2k(t *testing.B)   { benchmarkBuildBMT(4096/2, t) }
+func BenchmarkBuildBMT_1k(t *testing.B)   { benchmarkBuildBMT(4096/4, t) }
+func BenchmarkBuildBMT_512b(t *testing.B) { benchmarkBuildBMT(4096/8, t) }
+func BenchmarkBuildBMT_256b(t *testing.B) { benchmarkBuildBMT(4096/16, t) }
+func BenchmarkBuildBMT_128b(t *testing.B) { benchmarkBuildBMT(4096/64, t) }
+
+func BenchmarkBuildSHA3_4k(t *testing.B)   { benchmarkSHA3(4096, t) }
+func BenchmarkBuildSHA3_2k(t *testing.B)   { benchmarkSHA3(4096/2, t) }
+func BenchmarkBuildSHA3_1k(t *testing.B)   { benchmarkSHA3(4096/4, t) }
+func BenchmarkBuildSHA3_512b(t *testing.B) { benchmarkSHA3(4096/8, t) }
+func BenchmarkBuildSHA3_256b(t *testing.B) { benchmarkSHA3(4096/16, t) }
+
+func BenchmarkBuildNagiBinaryMerkle_4k(t *testing.B) {
+	n := 4096
+	data := make([]byte, n)
+	tdata := testDataReader(n)
+	tdata.Read(data)
+	hashFunc = sha3.NewKeccak256
+
+	t.ReportAllocs()
+	t.ResetTimer()
+
+	//h := hashFunc()
+	for i := 0; i < t.N; i++ {
+
+		BinaryMerkle(data, sha3.NewKeccak256)
+
+	}
+
+}
+
+//func BenchmarkBinaryMerkleTree(t *testing.B) { benchmarkBMT(4096, t) }
+
+// This implementation does not take advantage of any paralellisms and uses
+// far more memory than necessary, but it is easy to see that it is correct.
+// It can be used for generating test cases for optimized implementations.
+
+func BinaryMerkle(chunk []byte, hasher Hasher) []byte {
+	hash := hasher()
+	section := 2 * hash.Size()
+	l := len(chunk)
+	if l > section {
+		n := l / section
+		r := l - n*section
+		hash.Write(chunk[0:r])
+		next := hash.Sum(nil)
+		for r < l {
+			hash.Reset()
+			hash.Write(chunk[r : r+section])
+			next = hash.Sum(next)
+			r += section
+		}
+		return BinaryMerkle(next, hasher)
+	} else {
+		hash.Write(chunk)
+		return hash.Sum(nil)
+	}
 }

--- a/swarm/storage/binarymerkle_test.go
+++ b/swarm/storage/binarymerkle_test.go
@@ -41,6 +41,35 @@ func TestGetHeight2(t *testing.T) {
 	}
 }
 
+func TestBuildBMT3(t *testing.T) {
+
+	// Grab some data to make the tree out of, and partition
+	data, err := ioutil.ReadFile("binarymerkle_test.go") // assume testdata exists
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+	var thashFunc = MakeHashFunc("BMTSHA3")
+	var h = thashFunc()
+	h.Reset()
+	h.Write(data)
+	var key = h.Sum(nil)
+
+	fmt.Println(key)
+
+	// for i := 0; i < count; i++ {
+	// 	p := tree.InclusionProof(i)
+	//
+	// 	fmt.Println(p)
+	//
+	// 	ok := r.CheckProof(sha3.NewKeccak256, p, i)
+	// 	if !ok {
+	// 		t.Errorf("proof %d failed", i)
+	// 	}
+	// }
+	// fmt.Println("done")
+}
+
 func TestBuildBMT(t *testing.T) {
 
 	// Grab some data to make the tree out of, and partition
@@ -50,7 +79,7 @@ func TestBuildBMT(t *testing.T) {
 		return
 	}
 
-	tree, r, count, err1 := BuildBMT(sha3.NewKeccak256, data, 32)
+	tree, r, count, err1 := BuildBMT(sha3.NewKeccak256, data, 1)
 
 	switch err1 {
 	case -1:
@@ -61,7 +90,7 @@ func TestBuildBMT(t *testing.T) {
 		t.Errorf("BMT leaf count validation error")
 		return
 	case 0:
-		fmt.Println("Build BMT OK")
+		fmt.Println("Build BMT OK  ", count)
 	}
 
 	fmt.Println(tree.Root())
@@ -76,6 +105,7 @@ func TestBuildBMT(t *testing.T) {
 			t.Errorf("proof %d failed", i)
 		}
 	}
+	fmt.Println("done")
 }
 
 func TestBuildBMT2(t *testing.T) {
@@ -88,7 +118,7 @@ func TestBuildBMT2(t *testing.T) {
 	}
 
 	fmt.Println(len(data))
-	blocks := splitData(data, 32)
+	blocks := splitData(data, 2)
 
 	count := len(blocks)
 

--- a/swarm/storage/binarymerkle_test.go
+++ b/swarm/storage/binarymerkle_test.go
@@ -2,53 +2,17 @@ package storage
 
 import (
 	"fmt"
-	"io/ioutil"
 	"testing"
 
 	"github.com/ethereum/go-ethereum/crypto/sha3"
 )
 
-func TestGetHeight(t *testing.T) {
-	data := [][2]int{
-		{0, 0},
-		{1, 1},
-		{2, 2},
-		{3, 3},
-		{4, 3},
-		{255, 9},
-		{256, 9},
-		{257, 10},
-	}
-	for _, v := range data {
-		h := GetHeight(uint64(v[0]))
-		if !(v[1] == h) {
-			t.Errorf("GetHeight(%d)!=%d (was %d)", v[0], v[1], h)
-		}
-	}
-}
-
-func TestGetHeight2(t *testing.T) {
-	for i := 1; i < 1000; i++ {
-		h := GetHeight(uint64(i))
-		upperBound := 1 << uint(h-1)
-		lowerBound := (1 << uint(h-2)) + 1
-		if i < lowerBound {
-			t.Errorf("GetHeight(%d) too high: %d", i, h)
-		}
-		if i > upperBound {
-			t.Errorf("GetHeight(%d) too low: %d", i, h)
-		}
-	}
-}
-
 func TestBuildBMT3(t *testing.T) {
 
 	// Grab some data to make the tree out of, and partition
-	data, err := ioutil.ReadFile("binarymerkle_test.go") // assume testdata exists
-	if err != nil {
-		fmt.Println(err)
-		return
-	}
+	data := make([]byte, 4096)
+	tdata := testDataReader(4096)
+	tdata.Read(data)
 	var thashFunc = MakeHashFunc("BMTSHA3")
 	var h = thashFunc()
 	h.Reset()
@@ -73,35 +37,28 @@ func TestBuildBMT3(t *testing.T) {
 func TestBuildBMT(t *testing.T) {
 
 	// Grab some data to make the tree out of, and partition
-	data, err := ioutil.ReadFile("binarymerkle_test.go") // assume testdata exists
-	if err != nil {
-		fmt.Println(err)
-		return
-	}
-
+	data := make([]byte, 4096)
+	tdata := testDataReader(4096)
+	tdata.Read(data)
 	tree, r, count, err1 := BuildBMT(sha3.NewKeccak256, data, 1)
 
-	switch err1 {
-	case -1:
-
-		t.Errorf("BMT Validation error")
+	if err1 != nil {
+		fmt.Println(err1)
 		return
-	case -2:
-		t.Errorf("BMT leaf count validation error")
-		return
-	case 0:
-		fmt.Println("Build BMT OK  ", count)
 	}
 
 	fmt.Println(tree.Root())
+
+	//var ok bool
 
 	for i := 0; i < count; i++ {
 		p := tree.InclusionProof(i)
 
 		fmt.Println(p)
 
-		ok := r.CheckProof(sha3.NewKeccak256, p, i)
-		if !ok {
+		ok, err := r.CheckProof(sha3.NewKeccak256, p, i)
+
+		if !ok || (err != nil) {
 			t.Errorf("proof %d failed", i)
 		}
 	}
@@ -110,12 +67,9 @@ func TestBuildBMT(t *testing.T) {
 
 func TestBuildBMT2(t *testing.T) {
 
-	// Grab some data to make the tree out of, and partition
-	data, err := ioutil.ReadFile("binarymerkle_test.go") // assume testdata exists
-	if err != nil {
-		fmt.Println(err)
-		return
-	}
+	data := make([]byte, 4096)
+	tdata := testDataReader(4096)
+	tdata.Read(data)
 
 	fmt.Println(len(data))
 	blocks := splitData(data, 2)
@@ -142,8 +96,8 @@ func TestBuildBMT2(t *testing.T) {
 
 		fmt.Println(p)
 
-		ok := r.CheckProof(sha3.NewKeccak256, p, i)
-		if !ok {
+		ok, err := r.CheckProof(sha3.NewKeccak256, p, i)
+		if !ok || (err != nil) {
 			t.Errorf("proof %d failed", i)
 		}
 	}

--- a/swarm/storage/binarymerkle_test.go
+++ b/swarm/storage/binarymerkle_test.go
@@ -1,0 +1,123 @@
+package storage
+
+import (
+	"fmt"
+	"io/ioutil"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/crypto/sha3"
+)
+
+func TestGetHeight(t *testing.T) {
+	data := [][2]int{
+		{0, 0},
+		{1, 1},
+		{2, 2},
+		{3, 3},
+		{4, 3},
+		{255, 9},
+		{256, 9},
+		{257, 10},
+	}
+	for _, v := range data {
+		h := GetHeight(uint64(v[0]))
+		if !(v[1] == h) {
+			t.Errorf("GetHeight(%d)!=%d (was %d)", v[0], v[1], h)
+		}
+	}
+}
+
+func TestGetHeight2(t *testing.T) {
+	for i := 1; i < 1000; i++ {
+		h := GetHeight(uint64(i))
+		upperBound := 1 << uint(h-1)
+		lowerBound := (1 << uint(h-2)) + 1
+		if i < lowerBound {
+			t.Errorf("GetHeight(%d) too high: %d", i, h)
+		}
+		if i > upperBound {
+			t.Errorf("GetHeight(%d) too low: %d", i, h)
+		}
+	}
+}
+
+func TestBuildBMT(t *testing.T) {
+
+	// Grab some data to make the tree out of, and partition
+	data, err := ioutil.ReadFile("binarymerkle_test.go") // assume testdata exists
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+
+	tree, r, count, err1 := BuildBMT(sha3.NewKeccak256, data, 32)
+
+	switch err1 {
+	case -1:
+
+		t.Errorf("BMT Validation error")
+		return
+	case -2:
+		t.Errorf("BMT leaf count validation error")
+		return
+	case 0:
+		fmt.Println("Build BMT OK")
+	}
+
+	fmt.Println(tree.Root())
+
+	for i := 0; i < count; i++ {
+		p := tree.InclusionProof(i)
+
+		fmt.Println(p)
+
+		ok := r.CheckProof(sha3.NewKeccak256, p, i)
+		if !ok {
+			t.Errorf("proof %d failed", i)
+		}
+	}
+}
+
+func TestBuildBMT2(t *testing.T) {
+
+	// Grab some data to make the tree out of, and partition
+	data, err := ioutil.ReadFile("binarymerkle_test.go") // assume testdata exists
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+
+	fmt.Println(len(data))
+	blocks := splitData(data, 32)
+
+	count := len(blocks)
+
+	//	t.Errorf("GetCount() != %d (was )", count)
+
+	tree := Build(blocks)
+	err1 := tree.Validate()
+	if err1 != nil {
+		t.Errorf("%s", err1)
+	}
+	if tree.Count() != uint64(count) {
+		t.Errorf("GetCount() != %d (was %d)", count, tree.Count())
+	}
+
+	r := Root{uint64(count), tree.Root()}
+
+	fmt.Println(tree.Root())
+
+	for i := 0; i < count; i++ {
+		p := tree.InclusionProof(i)
+
+		fmt.Println(p)
+
+		ok := r.CheckProof(sha3.NewKeccak256, p, i)
+		if !ok {
+			t.Errorf("proof %d failed", i)
+		}
+	}
+	//t.Errorf("proof ok")
+	// TODO: check wrong proofs fail
+
+}

--- a/swarm/storage/chunker.go
+++ b/swarm/storage/chunker.go
@@ -51,7 +51,8 @@ data_{i} := size(subtree_{i}) || key_{j} || key_{j+1} .... || key_{j+n-1}
 */
 
 const (
-	defaultHash = "SHA3" // http://golang.org/pkg/hash/#Hash
+	//defaultHash = "SHA3"
+	defaultHash = "BMTSHA3" // http://golang.org/pkg/hash/#Hash
 	// defaultHash           = "SHA256" // http://golang.org/pkg/hash/#Hash
 	defaultBranches int64 = 128
 	// hashSize     int64 = hasherfunc.New().Size() // hasher knows about its own length in bytes

--- a/swarm/storage/types.go
+++ b/swarm/storage/types.go
@@ -83,6 +83,8 @@ func MakeHashFunc(hash string) Hasher {
 		return crypto.SHA256.New
 	case "SHA3":
 		return sha3.NewKeccak256
+	case "BMTSHA3":
+		return NewBMTSHA3
 	}
 	return nil
 }


### PR DESCRIPTION
binary merle tree with inclusion proof per issue #3451 .
This pr provide a general interface to create a Binary Merkle Tree for a gives leafs size (32 bytes)
-It provide an interface to get a proof on inclusion for a certain segment in the original data.
-It provide an interface to get the BMT root hash.
This BMT Hash should be use as the HASH func for the current swarm Merkle tree(Current is SHA3).
Implement phase 1&2 issue #3451 
