### PR TITLE
build: require Go >= 1.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,14 +5,6 @@ matrix:
   include:
     - os: linux
       dist: trusty
-      go: 1.5.4
-      env:
-        - GO15VENDOREXPERIMENT=1
-    - os: linux
-      dist: trusty
-      go: 1.6.2
-    - os: linux
-      dist: trusty
       go: 1.7.5
 
     # These are the latest Go versions, only run go vet and misspell on these

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ For prerequisites and detailed build instructions please read the
 [Installation Instructions](https://github.com/ethereum/go-ethereum/wiki/Building-Ethereum)
 on the wiki.
 
-Building geth requires both a Go and a C compiler.
+Building geth requires both a Go (version 1.7 or later) and a C compiler.
 You can install them using your favourite package manager.
 Once the dependencies are installed, run
 

--- a/build/ci.go
+++ b/build/ci.go
@@ -162,9 +162,9 @@ func doInstall(cmdline []string) {
 
 	// Check Go version. People regularly open issues about compilation
 	// failure with outdated Go. This should save them the trouble.
-	if runtime.Version() < "go1.4" && !strings.HasPrefix(runtime.Version(), "devel") {
+	if runtime.Version() < "go1.7" && !strings.HasPrefix(runtime.Version(), "devel") {
 		log.Println("You have Go version", runtime.Version())
-		log.Println("go-ethereum requires at least Go version 1.4 and cannot")
+		log.Println("go-ethereum requires at least Go version 1.7 and cannot")
 		log.Println("be compiled with an earlier version. Please upgrade your Go installation.")
 		os.Exit(1)
 	}
@@ -219,16 +219,9 @@ func buildFlags(env build.Environment) (flags []string) {
 		flags = append(flags, "-tags", "opencl")
 	}
 
-	// Since Go 1.5, the separator char for link time assignments
-	// is '=' and using ' ' prints a warning. However, Go < 1.5 does
-	// not support using '='.
-	sep := " "
-	if runtime.Version() > "go1.5" || strings.Contains(runtime.Version(), "devel") {
-		sep = "="
-	}
 	// Set gitCommit constant via link-time assignment.
 	if env.Commit != "" {
-		flags = append(flags, "-ldflags", "-X main.gitCommit"+sep+env.Commit)
+		flags = append(flags, "-ldflags", "-X main.gitCommit="+env.Commit)
 	}
 	return flags
 }
@@ -249,10 +242,7 @@ func goToolArch(arch string, subcmd string, args ...string) *exec.Cmd {
 			cmd.Args = append(cmd.Args, []string{"-ldflags", "-extldflags -Wl,--allow-multiple-definition"}...)
 		}
 	}
-	cmd.Env = []string{
-		"GO15VENDOREXPERIMENT=1",
-		"GOPATH=" + build.GOPATH(),
-	}
+	cmd.Env = []string{"GOPATH=" + build.GOPATH()}
 	if arch == "" || arch == runtime.GOARCH {
 		cmd.Env = append(cmd.Env, "GOBIN="+GOBIN)
 	} else {

--- a/build/ci.go
+++ b/build/ci.go
@@ -215,10 +215,6 @@ func doInstall(cmdline []string) {
 }
 
 func buildFlags(env build.Environment) (flags []string) {
-	if os.Getenv("GO_OPENCL") != "" {
-		flags = append(flags, "-tags", "opencl")
-	}
-
 	// Set gitCommit constant via link-time assignment.
 	if env.Commit != "" {
 		flags = append(flags, "-ldflags", "-X main.gitCommit="+env.Commit)

--- a/build/env.sh
+++ b/build/env.sh
@@ -20,8 +20,7 @@ fi
 
 # Set up the environment to use the workspace.
 GOPATH="$workspace"
-GO15VENDOREXPERIMENT=1
-export GOPATH GO15VENDOREXPERIMENT
+export GOPATH
 
 # Run the command inside the workspace.
 cd "$ethdir/go-ethereum"


### PR DESCRIPTION
We have decided to bump the requirement to Go 1.7 because it enables subtests and allows dropping backward-compatibility code. This is in line with Go's support policy. Go 1.6 and earlier no longer receive security updates.