### PR TITLE
build: unify vendor skipping, always run go vet

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ matrix:
         - sudo chmod 666 /dev/fuse
         - sudo chown root:$USER /etc/fuse.conf
         - go run build/ci.go install
-        - go run build/ci.go test -coverage -vet -misspell
+        - go run build/ci.go test -coverage -misspell
 
     - os: osx
       go: 1.8
@@ -34,7 +34,7 @@ matrix:
         - brew install caskroom/cask/brew-cask
         - brew cask install osxfuse
         - go run build/ci.go install
-        - go run build/ci.go test -coverage -vet -misspell
+        - go run build/ci.go test -coverage -misspell
 
     # This builder does the Ubuntu PPA and Linux Azure uploads
     - os: linux

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,8 +12,10 @@ matrix:
         - sudo modprobe fuse
         - sudo chmod 666 /dev/fuse
         - sudo chown root:$USER /etc/fuse.conf
+        - go run build/ci.go install
+        - go run build/ci.go test -coverage
 
-    # These are the latest Go versions, only run go vet and misspell on these
+    # These are the latest Go versions.
     - os: linux
       dist: trusty
       sudo: required

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -36,4 +36,4 @@ after_build:
 
 test_script:
   - set CGO_ENABLED=1
-  - go run build\ci.go test -vet -coverage
+  - go run build\ci.go test -coverage

--- a/build/ci.go
+++ b/build/ci.go
@@ -24,7 +24,7 @@ Usage: go run ci.go <command> <command flags/arguments>
 Available commands are:
 
    install    [ -arch architecture ] [ packages... ]                                           -- builds packages and executables
-   test       [ -coverage ] [ -vet ] [ -misspell ] [ packages... ]                             -- runs the tests
+   test       [ -coverage ] [ -misspell ] [ packages... ]                                      -- runs the tests
    archive    [ -arch architecture ] [ -type zip|tar ] [ -signer key-envvar ] [ -upload dest ] -- archives build artefacts
    importkeys                                                                                  -- imports signing keys from env
    debsrc     [ -signer key-id ] [ -upload dest ]                                              -- creates a debian source package
@@ -262,7 +262,6 @@ func goToolArch(arch string, subcmd string, args ...string) *exec.Cmd {
 
 func doTest(cmdline []string) {
 	var (
-		vet      = flag.Bool("vet", false, "Whether to run go vet")
 		misspell = flag.Bool("misspell", false, "Whether to run the spell checker")
 		coverage = flag.Bool("coverage", false, "Whether to record code coverage")
 	)
@@ -275,9 +274,7 @@ func doTest(cmdline []string) {
 	packages = build.ExpandPackagesNoVendor(packages)
 
 	// Run analysis tools before the tests.
-	if *vet {
-		build.MustRun(goTool("vet", packages...))
-	}
+	build.MustRun(goTool("vet", packages...))
 	if *misspell {
 		spellcheck(packages)
 	}

--- a/log/handler.go
+++ b/log/handler.go
@@ -106,9 +106,14 @@ func CallerFileHandler(h Handler) Handler {
 // the context with key "fn".
 func CallerFuncHandler(h Handler) Handler {
 	return FuncHandler(func(r *Record) error {
-		r.Ctx = append(r.Ctx, "fn", fmt.Sprintf("%+n", r.Call))
+		r.Ctx = append(r.Ctx, "fn", formatCall("%+n", r.Call))
 		return h.Log(r)
 	})
+}
+
+// This function is here to please go vet on Go < 1.8.
+func formatCall(format string, c stack.Call) string {
+	return fmt.Sprintf(format, c)
 }
 
 // CallerStackHandler returns a Handler that adds a stack trace to the context


### PR DESCRIPTION
This fixes a regression in #3690 where 'make geth' built everything instead of just geth.