### PR TITLE
core/state: fix a bug in touch undo

### DIFF
--- a/core/state/journal.go
+++ b/core/state/journal.go
@@ -73,6 +73,7 @@ type (
 	touchChange struct {
 		account *common.Address
 		prev    bool
+		prevDirty bool
 	}
 )
 
@@ -97,8 +98,10 @@ var ripemd = common.HexToAddress("0000000000000000000000000000000000000003")
 
 func (ch touchChange) undo(s *StateDB) {
 	if !ch.prev && *ch.account != ripemd {
-		delete(s.stateObjects, *ch.account)
-		delete(s.stateObjectsDirty, *ch.account)
+		s.getStateObject(*ch.account).touched = ch.prev
+		if !ch.prevDirty {
+			delete(s.stateObjectsDirty, *ch.account)
+		}
 	}
 }
 

--- a/core/state/state_object.go
+++ b/core/state/state_object.go
@@ -137,8 +137,9 @@ func (self *stateObject) markSuicided() {
 
 func (c *stateObject) touch() {
 	c.db.journal = append(c.db.journal, touchChange{
-		account: &c.address,
-		prev:    c.touched,
+		account:   &c.address,
+		prev:      c.touched,
+		prevDirty: c.onDirty == nil,
 	})
 	if c.onDirty != nil {
 		c.onDirty(c.Address())

--- a/core/state/statedb_test.go
+++ b/core/state/statedb_test.go
@@ -116,7 +116,6 @@ func TestIntermediateLeaks(t *testing.T) {
 }
 
 func TestSnapshotRandom(t *testing.T) {
-	t.Skip("@fjl fix me please")
 	config := &quick.Config{MaxCount: 1000}
 	err := quick.Check((*snapshotTest).run, config)
 	if cerr, ok := err.(*quick.CheckError); ok {


### PR DESCRIPTION
in `touch` operation, only `touched` filed has been changed. Therefore in the related undo function, only `touched` field should be reverted.

In addition, whether remove this obj from dirty map should depend on `prevDirty` flag.

After those modification, a skipped testcase  `TestSnapshotRandom` has passed.