### PR TITLE
swarm/api: improve FUSE build constraints, logging and APIs

### DIFF
--- a/internal/web3ext/web3ext.go
+++ b/internal/web3ext/web3ext.go
@@ -29,9 +29,7 @@ var Modules = map[string]string{
 	"shh":        Shh_JS,
 	"swarmfs":    SWARMFS_JS,
 	"txpool":     TxPool_JS,
-
 }
-
 
 const Chequebook_JS = `
 web3._extend({
@@ -491,28 +489,25 @@ web3._extend({
 `
 const SWARMFS_JS = `
 web3._extend({
-  property: 'swarmfs',
-  methods:
-  [
-    new web3._extend.Method({
-      name: 'mount',
-      call: 'swarmfs_mount',
-      params: 2,
-      inputFormatter: [null,null]
-    }),
-    new web3._extend.Method({
-      name: 'unmount',
-      call: 'swarmfs_unmount',
-      params: 1,
-      inputFormatter: [null]
-    }),
-    new web3._extend.Method({
-      name: 'listmounts',
-      call: 'swarmfs_listmounts',
-      params: 0,
-      inputFormatter: []
-    })
-  ]
+	property: 'swarmfs',
+	methods:
+	[
+		new web3._extend.Method({
+			name: 'mount',
+			call: 'swarmfs_mount',
+			params: 2
+		}),
+		new web3._extend.Method({
+			name: 'unmount',
+			call: 'swarmfs_unmount',
+			params: 1
+		}),
+		new web3._extend.Method({
+			name: 'listmounts',
+			call: 'swarmfs_listmounts',
+			params: 0
+		})
+	]
 });
 `
 

--- a/swarm/api/fuse.go
+++ b/swarm/api/fuse.go
@@ -14,7 +14,9 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
 
-// +build !windows
+// +build linux darwin freebsd
+
+// Data structures used for Fuse filesystem, serving directories and serving files to Fuse driver.
 
 package api
 
@@ -29,7 +31,6 @@ import (
 	"golang.org/x/net/context"
 )
 
-// Data structures used for Fuse filesystem, serving directories and serving files to Fuse driver
 type FS struct {
 	root *Dir
 }

--- a/swarm/api/fuse.go
+++ b/swarm/api/fuse.go
@@ -29,9 +29,6 @@ import (
 	"golang.org/x/net/context"
 )
 
-
-
-
 // Data structures used for Fuse filesystem, serving directories and serving files to Fuse driver
 type FS struct {
 	root *Dir
@@ -54,7 +51,6 @@ type File struct {
 	fileSize uint64
 	reader   storage.LazySectionReader
 }
-
 
 // Functions which satisfy the Fuse File System requests
 func (filesystem *FS) Root() (fs.Node, error) {
@@ -104,13 +100,11 @@ func (d *Dir) ReadDirAll(ctx context.Context) ([]fuse.Dirent, error) {
 }
 
 func (file *File) Attr(ctx context.Context, a *fuse.Attr) error {
-
 	a.Inode = file.inode
 	//TODO: need to get permission as argument
 	a.Mode = 0500
 	a.Uid = uint32(os.Getuid())
 	a.Gid = uint32(os.Getegid())
-
 
 	reader := file.swarmApi.Retrieve(file.key)
 	quitC := make(chan bool)
@@ -135,5 +129,4 @@ func (file *File) Read(ctx context.Context, req *fuse.ReadRequest, resp *fuse.Re
 	}
 	resp.Data = buf[:n]
 	return err
-
 }

--- a/swarm/api/swarmfs.go
+++ b/swarm/api/swarmfs.go
@@ -17,24 +17,21 @@
 package api
 
 import (
-	"time"
 	"sync"
+	"time"
 )
 
 const (
 	Swarmfs_Version = "0.1"
-	mountTimeout   = time.Second * 5
-	maxFuseMounts  = 5
+	mountTimeout    = time.Second * 5
+	maxFuseMounts   = 5
 )
-
 
 type SwarmFS struct {
 	swarmApi     *Api
 	activeMounts map[string]*MountInfo
 	activeLock   *sync.RWMutex
 }
-
-
 
 func NewSwarmFS(api *Api) *SwarmFS {
 	swarmfs := &SwarmFS{
@@ -44,5 +41,3 @@ func NewSwarmFS(api *Api) *SwarmFS {
 	}
 	return swarmfs
 }
-
-

--- a/swarm/api/swarmfs_fallback.go
+++ b/swarm/api/swarmfs_fallback.go
@@ -28,19 +28,21 @@ func isFUSEUnsupportedError(err error) bool {
 	return err == errNoFUSE
 }
 
-// Dummy struct and functions to satsfy windows build
-type MountInfo struct{}
-
-func (self *SwarmFS) Mount(mhash, mountpoint string) error {
-	return errNoFUSE
+type MountInfo struct {
+	MountPoint   string
+	ManifestHash string
 }
 
-func (self *SwarmFS) Unmount(mountpoint string) error {
-	return errNoFUSE
+func (self *SwarmFS) Mount(mhash, mountpoint string) (*MountInfo, error) {
+	return nil, errNoFUSE
 }
 
-func (self *SwarmFS) Listmounts() (string, error) {
-	return "", errNoFUSE
+func (self *SwarmFS) Unmount(mountpoint string) (bool, error) {
+	return false, errNoFUSE
+}
+
+func (self *SwarmFS) Listmounts() ([]*MountInfo, error) {
+	return nil, errNoFUSE
 }
 
 func (self *SwarmFS) Stop() error {

--- a/swarm/api/swarmfs_fallback.go
+++ b/swarm/api/swarmfs_fallback.go
@@ -14,35 +14,35 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
 
-// +build windows
+// +build !linux,!darwin,!freebsd
 
 package api
 
 import (
-	"github.com/ethereum/go-ethereum/log"
+	"errors"
 )
 
-// Dummy struct and functions to satsfy windows build
-type MountInfo struct {
+var errNoFUSE = errors.New("FUSE is not supported on this platform")
+
+func isFUSEUnsupportedError(err error) bool {
+	return err == errNoFUSE
 }
 
+// Dummy struct and functions to satsfy windows build
+type MountInfo struct{}
 
 func (self *SwarmFS) Mount(mhash, mountpoint string) error {
-	log.Info("Platform not supported")
-	return nil
+	return errNoFUSE
 }
 
 func (self *SwarmFS) Unmount(mountpoint string) error {
-	log.Info("Platform not supported")
-	return nil
+	return errNoFUSE
 }
 
 func (self *SwarmFS) Listmounts() (string, error) {
-	log.Info("Platform not supported")
-	return "",nil
+	return "", errNoFUSE
 }
 
 func (self *SwarmFS) Stop() error {
-	log.Info("Platform not supported")
 	return nil
 }

--- a/swarm/api/swarmfs_unix.go
+++ b/swarm/api/swarmfs_unix.go
@@ -19,6 +19,7 @@
 package api
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -38,6 +39,12 @@ var (
 	inodeLock sync.RWMutex
 )
 
+var (
+	errEmptyMountPoint = errors.New("need non-empty mount point")
+	errMaxMountCount   = errors.New("max FUSE mount count reached")
+	errMountTimeout    = errors.New("mount timeout")
+)
+
 func isFUSEUnsupportedError(err error) bool {
 	if perr, ok := err.(*os.PathError); ok {
 		return perr.Op == "open" && perr.Path == "/dev/fuse"
@@ -45,51 +52,48 @@ func isFUSEUnsupportedError(err error) bool {
 	return err == fuse.ErrOSXFUSENotFound
 }
 
-// information about every active mount
+// MountInfo contains information about every active mount
 type MountInfo struct {
-	mountPoint     string
-	manifestHash   string
+	MountPoint     string
+	ManifestHash   string
 	resolvedKey    storage.Key
 	rootDir        *Dir
 	fuseConnection *fuse.Conn
 }
 
+// newInode creates a new inode number.
 // Inode numbers need to be unique, they are used for caching inside fuse
-func NewInode() uint64 {
+func newInode() uint64 {
 	inodeLock.Lock()
 	defer inodeLock.Unlock()
 	inode += 1
 	return inode
 }
 
-func (self *SwarmFS) Mount(mhash, mountpoint string) (string, error) {
+func (self *SwarmFS) Mount(mhash, mountpoint string) (*MountInfo, error) {
+	if mountpoint == "" {
+		return nil, errEmptyMountPoint
+	}
+	cleanedMountPoint, err := filepath.Abs(filepath.Clean(mountpoint))
+	if err != nil {
+		return nil, err
+	}
+
 	self.activeLock.Lock()
 	defer self.activeLock.Unlock()
 
 	noOfActiveMounts := len(self.activeMounts)
 	if noOfActiveMounts >= maxFuseMounts {
-		err := fmt.Errorf("Max mount count reached. Cannot mount %s ", mountpoint)
-		log.Warn(err.Error())
-		return err.Error(), err
-	}
-
-	cleanedMountPoint, err := filepath.Abs(filepath.Clean(mountpoint))
-	if err != nil {
-		return err.Error(), err
+		return nil, errMaxMountCount
 	}
 
 	if _, ok := self.activeMounts[cleanedMountPoint]; ok {
-		err := fmt.Errorf("Mountpoint %s already mounted.", cleanedMountPoint)
-		log.Warn(err.Error())
-		return err.Error(), err
+		return nil, fmt.Errorf("%s is already mounted", cleanedMountPoint)
 	}
 
-	log.Info(fmt.Sprintf("Attempting to mount %s ", cleanedMountPoint))
 	key, _, path, err := self.swarmApi.parseAndResolve(mhash, true)
 	if err != nil {
-		errStr := fmt.Sprintf("Could not resolve %s : %v", mhash, err)
-		log.Warn(errStr)
-		return errStr, err
+		return nil, fmt.Errorf("can't resolve %q: %v", mhash, err)
 	}
 
 	if len(path) > 0 {
@@ -99,15 +103,13 @@ func (self *SwarmFS) Mount(mhash, mountpoint string) (string, error) {
 	quitC := make(chan bool)
 	trie, err := loadManifest(self.swarmApi.dpa, key, quitC)
 	if err != nil {
-		errStr := fmt.Sprintf("fs.Download: loadManifestTrie error: %v", err)
-		log.Warn(errStr)
-		return errStr, err
+		return nil, fmt.Errorf("can't load manifest %v: %v", key.String(), err)
 	}
 
 	dirTree := map[string]*Dir{}
 
 	rootDir := &Dir{
-		inode:       NewInode(),
+		inode:       newInode(),
 		name:        "root",
 		directories: nil,
 		files:       nil,
@@ -130,7 +132,7 @@ func (self *SwarmFS) Mount(mhash, mountpoint string) (string, error) {
 
 				if _, ok := dirTree[dirUntilNow]; !ok {
 					dirTree[dirUntilNow] = &Dir{
-						inode:       NewInode(),
+						inode:       newInode(),
 						name:        thisDir,
 						path:        dirUntilNow,
 						directories: nil,
@@ -146,7 +148,7 @@ func (self *SwarmFS) Mount(mhash, mountpoint string) (string, error) {
 			}
 		}
 		thisFile := &File{
-			inode:    NewInode(),
+			inode:    newInode(),
 			name:     filename,
 			path:     fullpath,
 			key:      key,
@@ -158,107 +160,84 @@ func (self *SwarmFS) Mount(mhash, mountpoint string) (string, error) {
 	fconn, err := fuse.Mount(cleanedMountPoint, fuse.FSName("swarmfs"), fuse.VolumeName(mhash))
 	if err != nil {
 		fuse.Unmount(cleanedMountPoint)
-		errStr := fmt.Sprintf("Mounting %s encountered error: %v", cleanedMountPoint, err)
-		log.Warn(errStr)
-		return errStr, err
+		log.Warn("Error mounting swarm manifest", "mountpoint", cleanedMountPoint, "err", err)
+		return nil, err
 	}
 
 	mounterr := make(chan error, 1)
 	go func() {
-		log.Info(fmt.Sprintf("Serving %s at %s", mhash, cleanedMountPoint))
 		filesys := &FS{root: rootDir}
 		if err := fs.Serve(fconn, filesys); err != nil {
-			log.Warn(fmt.Sprintf("Could not Serve FS error: %v", err))
+			mounterr <- err
 		}
 	}()
 
 	// Check if the mount process has an error to report.
 	select {
-
 	case <-time.After(mountTimeout):
-		err := fmt.Errorf("Mounting %s timed out.", cleanedMountPoint)
-		log.Warn(err.Error())
-		return err.Error(), err
+		fuse.Unmount(cleanedMountPoint)
+		return nil, errMountTimeout
 
 	case err := <-mounterr:
-		errStr := fmt.Sprintf("Mounting %s encountered error: %v", cleanedMountPoint, err)
-		log.Warn(errStr)
-		return errStr, err
+		log.Warn("Error serving swarm FUSE FS", "mountpoint", cleanedMountPoint, "err", err)
+		return nil, err
 
 	case <-fconn.Ready:
-		log.Debug(fmt.Sprintf("Mounting connection succeeded for : %v", cleanedMountPoint))
+		log.Info("Now serving swarm FUSE FS", "manifest", mhash, "mountpoint", cleanedMountPoint)
 	}
 
-	//Assemble and Store the mount information for future use
-	mountInformation := &MountInfo{
-		mountPoint:     cleanedMountPoint,
-		manifestHash:   mhash,
+	// Assemble and Store the mount information for future use
+	mi := &MountInfo{
+		MountPoint:     cleanedMountPoint,
+		ManifestHash:   mhash,
 		resolvedKey:    key,
 		rootDir:        rootDir,
 		fuseConnection: fconn,
 	}
-	self.activeMounts[cleanedMountPoint] = mountInformation
-
-	succString := fmt.Sprintf("Mounting successful for %s", cleanedMountPoint)
-	log.Info(succString)
-
-	return succString, nil
+	self.activeMounts[cleanedMountPoint] = mi
+	return mi, nil
 }
 
-func (self *SwarmFS) Unmount(mountpoint string) (string, error) {
+func (self *SwarmFS) Unmount(mountpoint string) (bool, error) {
 	self.activeLock.Lock()
 	defer self.activeLock.Unlock()
 
 	cleanedMountPoint, err := filepath.Abs(filepath.Clean(mountpoint))
 	if err != nil {
-		return err.Error(), err
+		return false, err
 	}
 
-	// Get the mount information based on the mountpoint argument
 	mountInfo := self.activeMounts[cleanedMountPoint]
-
-	if mountInfo == nil || mountInfo.mountPoint != cleanedMountPoint {
-		err := fmt.Errorf("Could not find mount information for %s ", cleanedMountPoint)
-		log.Warn(err.Error())
-		return err.Error(), err
+	if mountInfo == nil || mountInfo.MountPoint != cleanedMountPoint {
+		return false, fmt.Errorf("%s is not mounted", cleanedMountPoint)
 	}
-
 	err = fuse.Unmount(cleanedMountPoint)
 	if err != nil {
-		//TODO: try forceful unmount if normal unmount fails
-		errStr := fmt.Sprintf("UnMount error: %v", err)
-		log.Warn(errStr)
-		return errStr, err
+		// TODO(jmozah): try forceful unmount if normal unmount fails
+		return false, err
 	}
 
+	// remove the mount information from the active map
 	mountInfo.fuseConnection.Close()
-
-	//remove the mount information from the active map
 	delete(self.activeMounts, cleanedMountPoint)
-
-	succString := fmt.Sprintf("UnMounting %v succeeded", cleanedMountPoint)
-	log.Info(succString)
-	return succString, nil
+	return true, nil
 }
 
-func (self *SwarmFS) Listmounts() (string, error) {
+func (self *SwarmFS) Listmounts() []*MountInfo {
 	self.activeLock.RLock()
 	defer self.activeLock.RUnlock()
 
-	var rows []string
-	for mp := range self.activeMounts {
-		mountInfo := self.activeMounts[mp]
-		rows = append(rows, fmt.Sprintf("Swarm Root: %s, Mount Point: %s ", mountInfo.manifestHash, mountInfo.mountPoint))
+	rows := make([]*MountInfo, 0, len(self.activeMounts))
+	for _, mi := range self.activeMounts {
+		rows = append(rows, mi)
 	}
-
-	return strings.Join(rows, "\n"), nil
+	return rows
 }
 
 func (self *SwarmFS) Stop() bool {
 	for mp := range self.activeMounts {
 		mountInfo := self.activeMounts[mp]
-		self.Unmount(mountInfo.mountPoint)
+		self.Unmount(mountInfo.MountPoint)
 	}
-
 	return true
 }


### PR DESCRIPTION
This PR:

* fixes the build on BSD and other 'exotic' platforms.
* cleans up excessive log messages in FUSE code.
* ensures that swarmfs methods in the console cannot be invoked with the 
   wrong number of arguments.