### PR TITLE
les:flowcontrol: fix division by zero for lightserv flag

### DIFF
--- a/les/flowcontrol/manager.go
+++ b/les/flowcontrol/manager.go
@@ -81,10 +81,14 @@ func NewClientManager(rcTarget, maxSimReq, maxRcSum uint64) *ClientManager {
 	cm := &ClientManager{
 		nodes:       make(map[*cmNode]struct{}),
 		resumeQueue: make(chan chan bool),
-		rcRecharge:  rcConst * rcConst / (100*rcConst/rcTarget - rcConst),
+		rcRecharge:  rcConst * rcConst,
 		maxSimReq:   maxSimReq,
 		maxRcSum:    maxRcSum,
 	}
+	if rcTarget < 100 {
+		cm.rcRecharge /= (100*rcConst/rcTarget - rcConst)
+	}
+
 	go cm.queueProc()
 	return cm
 }


### PR DESCRIPTION
Currently geth crashes if the users specifies a value of 100 for the `--lightserv` flag due to a division by zero panic. Another problem occurs if the user specifies > 100, in that case there are no resources allowed for handling light client requests which is probably not what the user meant.

This PR will only do throttling in case the user specified <100. Otherwise it would set the throttle threshold to such a high value that it will effectively never be reached.