### PR TITLE
core/types: rename txdata.gasLimit -> txdata.gas for json marshalling

### DIFF
--- a/core/types/gen_tx_json.go
+++ b/core/types/gen_tx_json.go
@@ -15,7 +15,7 @@ func (t txdata) MarshalJSON() ([]byte, error) {
 	type txdataJSON struct {
 		AccountNonce hexutil.Uint64  `json:"nonce"`
 		Price        *hexutil.Big    `json:"gasPrice"`
-		GasLimit     *hexutil.Big    `json:"gasLimit"`
+		GasLimit     *hexutil.Big    `json:"gas"`
 		Recipient    *common.Address `json:"to" optional:"yes" rlp:"nil"`
 		Amount       *hexutil.Big    `json:"value"`
 		Payload      hexutil.Bytes   `json:"input"`
@@ -42,7 +42,7 @@ func (t *txdata) UnmarshalJSON(input []byte) error {
 	type txdataJSON struct {
 		AccountNonce *hexutil.Uint64 `json:"nonce"`
 		Price        *hexutil.Big    `json:"gasPrice"`
-		GasLimit     *hexutil.Big    `json:"gasLimit"`
+		GasLimit     *hexutil.Big    `json:"gas"`
 		Recipient    *common.Address `json:"to" optional:"yes" rlp:"nil"`
 		Amount       *hexutil.Big    `json:"value"`
 		Payload      hexutil.Bytes   `json:"input"`
@@ -65,7 +65,7 @@ func (t *txdata) UnmarshalJSON(input []byte) error {
 	}
 	x.Price = (*big.Int)(dec.Price)
 	if dec.GasLimit == nil {
-		return errors.New("missing required field 'gasLimit' for txdata")
+		return errors.New("missing required field 'gas' for txdata")
 	}
 	x.GasLimit = (*big.Int)(dec.GasLimit)
 	if dec.Recipient != nil {

--- a/core/types/transaction.go
+++ b/core/types/transaction.go
@@ -57,7 +57,7 @@ type Transaction struct {
 type txdata struct {
 	AccountNonce uint64          `json:"nonce"`
 	Price        *big.Int        `json:"gasPrice"`
-	GasLimit     *big.Int        `json:"gasLimit"`
+	GasLimit     *big.Int        `json:"gas"`
 	Recipient    *common.Address `json:"to" optional:"yes" rlp:"nil"` // nil means contract creation
 	Amount       *big.Int        `json:"value"`
 	Payload      []byte          `json:"input"`


### PR DESCRIPTION
As as described in the json rpc spec the transaction gas limit should be stored under the `gas` key in json messages. Currently it uses `GasLimit` as it's called internally.