### PR TITLE
ethstats: work around weird URL scheme parsing issues

### DIFF
--- a/ethstats/ethstats.go
+++ b/ethstats/ethstats.go
@@ -23,10 +23,10 @@ import (
 	"fmt"
 	"math/big"
 	"net"
-	"net/url"
 	"regexp"
 	"runtime"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -128,7 +128,7 @@ func (s *Service) loop() {
 		path := fmt.Sprintf("%s/api", s.host)
 		urls := []string{path}
 
-		if parsed, err := url.Parse(path); err == nil && !parsed.IsAbs() {
+		if !strings.Contains(path, "://") { // url.Parse and url.IsAbs is unsuitable (https://github.com/golang/go/issues/19779)
 			urls = []string{"wss://" + path, "ws://" + path}
 		}
 		// Establish a websocket connection to the server on any supported URL


### PR DESCRIPTION
The `url` package included in Go handles quite a lot of fancy cases with parsing URLs. This unfortunately means that some URLs don't parse so obviously as one might expect. This is fine for machine generated URLs, but for user input, it can go horribly wrong from time to time.

TL;DR; Revert to the dumb way of checking if a scheme is present in the ethstats connection string.

More infos at https://play.golang.org/p/qbW1wWkcKY and https://github.com/golang/go/issues/19779