### PR TITLE
cmd/geth, node: surface geth architecture into version

### DIFF
--- a/cmd/geth/consolecmd_test.go
+++ b/cmd/geth/consolecmd_test.go
@@ -45,6 +45,7 @@ func TestConsoleWelcome(t *testing.T) {
 
 	// Gather all the infos the welcome message needs to contain
 	geth.setTemplateFunc("goos", func() string { return runtime.GOOS })
+	geth.setTemplateFunc("goarch", func() string { return runtime.GOARCH })
 	geth.setTemplateFunc("gover", runtime.Version)
 	geth.setTemplateFunc("gethver", func() string { return params.Version })
 	geth.setTemplateFunc("niltime", func() string { return time.Unix(0, 0).Format(time.RFC1123) })
@@ -58,7 +59,7 @@ func TestConsoleWelcome(t *testing.T) {
 	geth.expect(`
 Welcome to the Geth JavaScript console!
 
-instance: Geth/v{{gethver}}/{{goos}}/{{gover}}
+instance: Geth/v{{gethver}}/{{goos}}-{{goarch}}/{{gover}}
 coinbase: {{.Etherbase}}
 at block: 0 ({{niltime}})
  datadir: {{.Datadir}}
@@ -131,6 +132,7 @@ func testAttachWelcome(t *testing.T, geth *testgeth, endpoint string) {
 
 	// Gather all the infos the welcome message needs to contain
 	attach.setTemplateFunc("goos", func() string { return runtime.GOOS })
+	attach.setTemplateFunc("goarch", func() string { return runtime.GOARCH })
 	attach.setTemplateFunc("gover", runtime.Version)
 	attach.setTemplateFunc("gethver", func() string { return params.Version })
 	attach.setTemplateFunc("etherbase", func() string { return geth.Etherbase })
@@ -152,7 +154,7 @@ func testAttachWelcome(t *testing.T, geth *testgeth, endpoint string) {
 	attach.expect(`
 Welcome to the Geth JavaScript console!
 
-instance: Geth/v{{gethver}}/{{goos}}/{{gover}}
+instance: Geth/v{{gethver}}/{{goos}}-{{goarch}}/{{gover}}
 coinbase: {{etherbase}}
 at block: 0 ({{niltime}}){{if ipc}}
  datadir: {{datadir}}{{end}}

--- a/cmd/geth/misccmd.go
+++ b/cmd/geth/misccmd.go
@@ -101,10 +101,11 @@ func version(ctx *cli.Context) error {
 	if gitCommit != "" {
 		fmt.Println("Git Commit:", gitCommit)
 	}
+	fmt.Println("Architecture:", runtime.GOARCH)
 	fmt.Println("Protocol Versions:", eth.ProtocolVersions)
 	fmt.Println("Network Id:", ctx.GlobalInt(utils.NetworkIdFlag.Name))
 	fmt.Println("Go Version:", runtime.Version())
-	fmt.Println("OS:", runtime.GOOS)
+	fmt.Println("Operating System:", runtime.GOOS)
 	fmt.Printf("GOPATH=%s\n", os.Getenv("GOPATH"))
 	fmt.Printf("GOROOT=%s\n", runtime.GOROOT())
 	return nil

--- a/node/config.go
+++ b/node/config.go
@@ -266,7 +266,7 @@ func (c *Config) NodeName() string {
 	if c.Version != "" {
 		name += "/v" + c.Version
 	}
-	name += "/" + runtime.GOOS
+	name += "/" + runtime.GOOS + "-" + runtime.GOARCH
 	name += "/" + runtime.Version()
 	return name
 }

--- a/node/node.go
+++ b/node/node.go
@@ -173,7 +173,7 @@ func (n *Node) Start() error {
 		MaxPendingPeers:  n.config.MaxPendingPeers,
 	}
 	running := &p2p.Server{Config: n.serverConfig}
-	log.Info(fmt.Sprint("instance:", n.serverConfig.Name))
+	log.Info("Starting peer-to-peer node", "instance", n.serverConfig.Name)
 
 	// Otherwise copy and specialize the P2P configuration
 	services := make(map[reflect.Type]Service)


### PR DESCRIPTION
We often receive reports about out of memory issues. Many times this is due to people downloading 32 bit versions of Geth, and then setting very high memory cache limits (1GB+), causing Go to eventually run out of the 2GB address space.

This PR does not mean to solve the underlying issue, just to make it easier to spot by surfacing the build architecture into both `geth version` as well as the node's version string advertised on the network. The latter should help debug library use cases (i.e. based on logs) as well as aid in mapping the network better since we can differentiate between linux/x64, linux/mips and linux/android (similar for ios) versus having all versions just grouped under a single umbrella namespace.