### PR TITLE
core, core/types: regenerate JSON marshaling, add "hash" to headers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,10 +44,10 @@ clean:
 # You need to put $GOBIN (or $GOPATH/bin) in your PATH to use 'go generate'.
 
 devtools:
-	go get -u golang.org/x/tools/cmd/stringer
-	go get -u github.com/jteeuwen/go-bindata/go-bindata
-	go get -u github.com/fjl/gencodec
-	go install ./cmd/abigen
+	env GOBIN= go get -u golang.org/x/tools/cmd/stringer
+	env GOBIN= go get -u github.com/jteeuwen/go-bindata/go-bindata
+	env GOBIN= go get -u github.com/fjl/gencodec
+	env GOBIN= go install ./cmd/abigen
 
 # Cross Compilation Targets (xgo)
 

--- a/core/gen_genesis.go
+++ b/core/gen_genesis.go
@@ -14,19 +14,19 @@ import (
 )
 
 func (g Genesis) MarshalJSON() ([]byte, error) {
-	type GenesisJSON struct {
-		Config     *params.ChainConfig                         `json:"config" optional:"true"`
-		Nonce      math.HexOrDecimal64                         `json:"nonce" optional:"true"`
-		Timestamp  math.HexOrDecimal64                         `json:"timestamp" optional:"true"`
-		ParentHash common.Hash                                 `json:"parentHash" optional:"true"`
-		ExtraData  hexutil.Bytes                               `json:"extraData" optional:"true"`
-		GasLimit   math.HexOrDecimal64                         `json:"gasLimit"`
-		Difficulty *math.HexOrDecimal256                       `json:"difficulty"`
-		Mixhash    common.Hash                                 `json:"mixHash" optional:"true"`
-		Coinbase   common.Address                              `json:"coinbase" optional:"true"`
-		Alloc      map[common.UnprefixedAddress]GenesisAccount `json:"alloc"`
+	type Genesis struct {
+		Config     *params.ChainConfig                         `json:"config"`
+		Nonce      math.HexOrDecimal64                         `json:"nonce"`
+		Timestamp  math.HexOrDecimal64                         `json:"timestamp"`
+		ParentHash common.Hash                                 `json:"parentHash"`
+		ExtraData  hexutil.Bytes                               `json:"extraData"`
+		GasLimit   math.HexOrDecimal64                         `json:"gasLimit"   gencodec:"required"`
+		Difficulty *math.HexOrDecimal256                       `json:"difficulty" gencodec:"required"`
+		Mixhash    common.Hash                                 `json:"mixHash"`
+		Coinbase   common.Address                              `json:"coinbase"`
+		Alloc      map[common.UnprefixedAddress]GenesisAccount `json:"alloc"      gencodec:"required"`
 	}
-	var enc GenesisJSON
+	var enc Genesis
 	enc.Config = g.Config
 	enc.Nonce = math.HexOrDecimal64(g.Nonce)
 	enc.Timestamp = math.HexOrDecimal64(g.Timestamp)
@@ -46,59 +46,57 @@ func (g Genesis) MarshalJSON() ([]byte, error) {
 }
 
 func (g *Genesis) UnmarshalJSON(input []byte) error {
-	type GenesisJSON struct {
-		Config     *params.ChainConfig                         `json:"config" optional:"true"`
-		Nonce      *math.HexOrDecimal64                        `json:"nonce" optional:"true"`
-		Timestamp  *math.HexOrDecimal64                        `json:"timestamp" optional:"true"`
-		ParentHash *common.Hash                                `json:"parentHash" optional:"true"`
-		ExtraData  hexutil.Bytes                               `json:"extraData" optional:"true"`
-		GasLimit   *math.HexOrDecimal64                        `json:"gasLimit"`
-		Difficulty *math.HexOrDecimal256                       `json:"difficulty"`
-		Mixhash    *common.Hash                                `json:"mixHash" optional:"true"`
-		Coinbase   *common.Address                             `json:"coinbase" optional:"true"`
-		Alloc      map[common.UnprefixedAddress]GenesisAccount `json:"alloc"`
+	type Genesis struct {
+		Config     *params.ChainConfig                         `json:"config"`
+		Nonce      *math.HexOrDecimal64                        `json:"nonce"`
+		Timestamp  *math.HexOrDecimal64                        `json:"timestamp"`
+		ParentHash *common.Hash                                `json:"parentHash"`
+		ExtraData  hexutil.Bytes                               `json:"extraData"`
+		GasLimit   *math.HexOrDecimal64                        `json:"gasLimit"   gencodec:"required"`
+		Difficulty *math.HexOrDecimal256                       `json:"difficulty" gencodec:"required"`
+		Mixhash    *common.Hash                                `json:"mixHash"`
+		Coinbase   *common.Address                             `json:"coinbase"`
+		Alloc      map[common.UnprefixedAddress]GenesisAccount `json:"alloc"      gencodec:"required"`
 	}
-	var dec GenesisJSON
+	var dec Genesis
 	if err := json.Unmarshal(input, &dec); err != nil {
 		return err
 	}
-	var x Genesis
 	if dec.Config != nil {
-		x.Config = dec.Config
+		g.Config = dec.Config
 	}
 	if dec.Nonce != nil {
-		x.Nonce = uint64(*dec.Nonce)
+		g.Nonce = uint64(*dec.Nonce)
 	}
 	if dec.Timestamp != nil {
-		x.Timestamp = uint64(*dec.Timestamp)
+		g.Timestamp = uint64(*dec.Timestamp)
 	}
 	if dec.ParentHash != nil {
-		x.ParentHash = *dec.ParentHash
+		g.ParentHash = *dec.ParentHash
 	}
 	if dec.ExtraData != nil {
-		x.ExtraData = dec.ExtraData
+		g.ExtraData = dec.ExtraData
 	}
 	if dec.GasLimit == nil {
 		return errors.New("missing required field 'gasLimit' for Genesis")
 	}
-	x.GasLimit = uint64(*dec.GasLimit)
+	g.GasLimit = uint64(*dec.GasLimit)
 	if dec.Difficulty == nil {
 		return errors.New("missing required field 'difficulty' for Genesis")
 	}
-	x.Difficulty = (*big.Int)(dec.Difficulty)
+	g.Difficulty = (*big.Int)(dec.Difficulty)
 	if dec.Mixhash != nil {
-		x.Mixhash = *dec.Mixhash
+		g.Mixhash = *dec.Mixhash
 	}
 	if dec.Coinbase != nil {
-		x.Coinbase = *dec.Coinbase
+		g.Coinbase = *dec.Coinbase
 	}
 	if dec.Alloc == nil {
 		return errors.New("missing required field 'alloc' for Genesis")
 	}
-	x.Alloc = make(GenesisAlloc, len(dec.Alloc))
+	g.Alloc = make(GenesisAlloc, len(dec.Alloc))
 	for k, v := range dec.Alloc {
-		x.Alloc[common.Address(k)] = v
+		g.Alloc[common.Address(k)] = v
 	}
-	*g = x
 	return nil
 }

--- a/core/gen_genesis_account.go
+++ b/core/gen_genesis_account.go
@@ -13,13 +13,13 @@ import (
 )
 
 func (g GenesisAccount) MarshalJSON() ([]byte, error) {
-	type GenesisAccountJSON struct {
-		Code    hexutil.Bytes               `json:"code,omitempty" optional:"true"`
-		Storage map[common.Hash]common.Hash `json:"storage,omitempty" optional:"true"`
-		Balance *math.HexOrDecimal256       `json:"balance"`
-		Nonce   math.HexOrDecimal64         `json:"nonce,omitempty" optional:"true"`
+	type GenesisAccount struct {
+		Code    hexutil.Bytes               `json:"code,omitempty"`
+		Storage map[common.Hash]common.Hash `json:"storage,omitempty"`
+		Balance *math.HexOrDecimal256       `json:"balance" gencodec:"required"`
+		Nonce   math.HexOrDecimal64         `json:"nonce,omitempty"`
 	}
-	var enc GenesisAccountJSON
+	var enc GenesisAccount
 	enc.Code = g.Code
 	enc.Storage = g.Storage
 	enc.Balance = (*math.HexOrDecimal256)(g.Balance)
@@ -28,30 +28,28 @@ func (g GenesisAccount) MarshalJSON() ([]byte, error) {
 }
 
 func (g *GenesisAccount) UnmarshalJSON(input []byte) error {
-	type GenesisAccountJSON struct {
-		Code    hexutil.Bytes               `json:"code,omitempty" optional:"true"`
-		Storage map[common.Hash]common.Hash `json:"storage,omitempty" optional:"true"`
-		Balance *math.HexOrDecimal256       `json:"balance"`
-		Nonce   *math.HexOrDecimal64        `json:"nonce,omitempty" optional:"true"`
+	type GenesisAccount struct {
+		Code    hexutil.Bytes               `json:"code,omitempty"`
+		Storage map[common.Hash]common.Hash `json:"storage,omitempty"`
+		Balance *math.HexOrDecimal256       `json:"balance" gencodec:"required"`
+		Nonce   *math.HexOrDecimal64        `json:"nonce,omitempty"`
 	}
-	var dec GenesisAccountJSON
+	var dec GenesisAccount
 	if err := json.Unmarshal(input, &dec); err != nil {
 		return err
 	}
-	var x GenesisAccount
 	if dec.Code != nil {
-		x.Code = dec.Code
+		g.Code = dec.Code
 	}
 	if dec.Storage != nil {
-		x.Storage = dec.Storage
+		g.Storage = dec.Storage
 	}
 	if dec.Balance == nil {
 		return errors.New("missing required field 'balance' for GenesisAccount")
 	}
-	x.Balance = (*big.Int)(dec.Balance)
+	g.Balance = (*big.Int)(dec.Balance)
 	if dec.Nonce != nil {
-		x.Nonce = uint64(*dec.Nonce)
+		g.Nonce = uint64(*dec.Nonce)
 	}
-	*g = x
 	return nil
 }

--- a/core/genesis.go
+++ b/core/genesis.go
@@ -41,16 +41,16 @@ var errGenesisNoConfig = errors.New("genesis has no chain configuration")
 // Genesis specifies the header fields, state of a genesis block. It also defines hard
 // fork switch-over blocks through the chain configuration.
 type Genesis struct {
-	Config     *params.ChainConfig `json:"config" optional:"true"`
-	Nonce      uint64              `json:"nonce" optional:"true"`
-	Timestamp  uint64              `json:"timestamp" optional:"true"`
-	ParentHash common.Hash         `json:"parentHash" optional:"true"`
-	ExtraData  []byte              `json:"extraData" optional:"true"`
-	GasLimit   uint64              `json:"gasLimit"`
-	Difficulty *big.Int            `json:"difficulty"`
-	Mixhash    common.Hash         `json:"mixHash" optional:"true"`
-	Coinbase   common.Address      `json:"coinbase" optional:"true"`
-	Alloc      GenesisAlloc        `json:"alloc"`
+	Config     *params.ChainConfig `json:"config"`
+	Nonce      uint64              `json:"nonce"`
+	Timestamp  uint64              `json:"timestamp"`
+	ParentHash common.Hash         `json:"parentHash"`
+	ExtraData  []byte              `json:"extraData"`
+	GasLimit   uint64              `json:"gasLimit"   gencodec:"required"`
+	Difficulty *big.Int            `json:"difficulty" gencodec:"required"`
+	Mixhash    common.Hash         `json:"mixHash"`
+	Coinbase   common.Address      `json:"coinbase"`
+	Alloc      GenesisAlloc        `json:"alloc"      gencodec:"required"`
 }
 
 // GenesisAlloc specifies the initial state that is part of the genesis block.
@@ -58,10 +58,10 @@ type GenesisAlloc map[common.Address]GenesisAccount
 
 // GenesisAccount is an account in the state of the genesis block.
 type GenesisAccount struct {
-	Code    []byte                      `json:"code,omitempty" optional:"true"`
-	Storage map[common.Hash]common.Hash `json:"storage,omitempty" optional:"true"`
-	Balance *big.Int                    `json:"balance"`
-	Nonce   uint64                      `json:"nonce,omitempty" optional:"true"`
+	Code    []byte                      `json:"code,omitempty"`
+	Storage map[common.Hash]common.Hash `json:"storage,omitempty"`
+	Balance *big.Int                    `json:"balance" gencodec:"required"`
+	Nonce   uint64                      `json:"nonce,omitempty"`
 }
 
 // field type overrides for gencodec

--- a/core/types/block.go
+++ b/core/types/block.go
@@ -68,21 +68,21 @@ func (n *BlockNonce) UnmarshalText(input []byte) error {
 
 // Header represents a block header in the Ethereum blockchain.
 type Header struct {
-	ParentHash  common.Hash    `json:"parentHash"`
-	UncleHash   common.Hash    `json:"sha3Uncles"`
-	Coinbase    common.Address `json:"miner"`
-	Root        common.Hash    `json:"stateRoot"`
-	TxHash      common.Hash    `json:"transactionsRoot"`
-	ReceiptHash common.Hash    `json:"receiptsRoot"`
-	Bloom       Bloom          `json:"logsBloom"`
-	Difficulty  *big.Int       `json:"difficulty"`
-	Number      *big.Int       `json:"number"`
-	GasLimit    *big.Int       `json:"gasLimit"`
-	GasUsed     *big.Int       `json:"gasUsed"`
-	Time        *big.Int       `json:"timestamp"`
-	Extra       []byte         `json:"extraData"`
-	MixDigest   common.Hash    `json:"mixHash"`
-	Nonce       BlockNonce     `json:"nonce"`
+	ParentHash  common.Hash    `json:"parentHash"       gencodec:"required"`
+	UncleHash   common.Hash    `json:"sha3Uncles"       gencodec:"required"`
+	Coinbase    common.Address `json:"miner"            gencodec:"required"`
+	Root        common.Hash    `json:"stateRoot"        gencodec:"required"`
+	TxHash      common.Hash    `json:"transactionsRoot" gencodec:"required"`
+	ReceiptHash common.Hash    `json:"receiptsRoot"     gencodec:"required"`
+	Bloom       Bloom          `json:"logsBloom"        gencodec:"required"`
+	Difficulty  *big.Int       `json:"difficulty"       gencodec:"required"`
+	Number      *big.Int       `json:"number"           gencodec:"required"`
+	GasLimit    *big.Int       `json:"gasLimit"         gencodec:"required"`
+	GasUsed     *big.Int       `json:"gasUsed"          gencodec:"required"`
+	Time        *big.Int       `json:"timestamp"        gencodec:"required"`
+	Extra       []byte         `json:"extraData"        gencodec:"required"`
+	MixDigest   common.Hash    `json:"mixHash"          gencodec:"required"`
+	Nonce       BlockNonce     `json:"nonce"            gencodec:"required"`
 }
 
 // field type overrides for gencodec

--- a/core/types/block.go
+++ b/core/types/block.go
@@ -93,6 +93,7 @@ type headerMarshaling struct {
 	GasUsed    *hexutil.Big
 	Time       *hexutil.Big
 	Extra      hexutil.Bytes
+	Hash       common.Hash `json:"hash"` // adds call to Hash() in MarshalJSON
 }
 
 // Hash returns the block hash of the header, which is simply the keccak256 hash of its

--- a/core/types/gen_header_json.go
+++ b/core/types/gen_header_json.go
@@ -12,24 +12,24 @@ import (
 )
 
 func (h Header) MarshalJSON() ([]byte, error) {
-	type HeaderJSON struct {
-		ParentHash  common.Hash    `json:"parentHash"`
-		UncleHash   common.Hash    `json:"sha3Uncles"`
-		Coinbase    common.Address `json:"miner"`
-		Root        common.Hash    `json:"stateRoot"`
-		TxHash      common.Hash    `json:"transactionsRoot"`
-		ReceiptHash common.Hash    `json:"receiptsRoot"`
-		Bloom       Bloom          `json:"logsBloom"`
-		Difficulty  *hexutil.Big   `json:"difficulty"`
-		Number      *hexutil.Big   `json:"number"`
-		GasLimit    *hexutil.Big   `json:"gasLimit"`
-		GasUsed     *hexutil.Big   `json:"gasUsed"`
-		Time        *hexutil.Big   `json:"timestamp"`
-		Extra       hexutil.Bytes  `json:"extraData"`
-		MixDigest   common.Hash    `json:"mixHash"`
-		Nonce       BlockNonce     `json:"nonce"`
+	type Header struct {
+		ParentHash  common.Hash    `json:"parentHash"       gencodec:"required"`
+		UncleHash   common.Hash    `json:"sha3Uncles"       gencodec:"required"`
+		Coinbase    common.Address `json:"miner"            gencodec:"required"`
+		Root        common.Hash    `json:"stateRoot"        gencodec:"required"`
+		TxHash      common.Hash    `json:"transactionsRoot" gencodec:"required"`
+		ReceiptHash common.Hash    `json:"receiptsRoot"     gencodec:"required"`
+		Bloom       Bloom          `json:"logsBloom"        gencodec:"required"`
+		Difficulty  *hexutil.Big   `json:"difficulty"       gencodec:"required"`
+		Number      *hexutil.Big   `json:"number"           gencodec:"required"`
+		GasLimit    *hexutil.Big   `json:"gasLimit"         gencodec:"required"`
+		GasUsed     *hexutil.Big   `json:"gasUsed"          gencodec:"required"`
+		Time        *hexutil.Big   `json:"timestamp"        gencodec:"required"`
+		Extra       hexutil.Bytes  `json:"extraData"        gencodec:"required"`
+		MixDigest   common.Hash    `json:"mixHash"          gencodec:"required"`
+		Nonce       BlockNonce     `json:"nonce"            gencodec:"required"`
 	}
-	var enc HeaderJSON
+	var enc Header
 	enc.ParentHash = h.ParentHash
 	enc.UncleHash = h.UncleHash
 	enc.Coinbase = h.Coinbase
@@ -49,88 +49,86 @@ func (h Header) MarshalJSON() ([]byte, error) {
 }
 
 func (h *Header) UnmarshalJSON(input []byte) error {
-	type HeaderJSON struct {
-		ParentHash  *common.Hash    `json:"parentHash"`
-		UncleHash   *common.Hash    `json:"sha3Uncles"`
-		Coinbase    *common.Address `json:"miner"`
-		Root        *common.Hash    `json:"stateRoot"`
-		TxHash      *common.Hash    `json:"transactionsRoot"`
-		ReceiptHash *common.Hash    `json:"receiptsRoot"`
-		Bloom       *Bloom          `json:"logsBloom"`
-		Difficulty  *hexutil.Big    `json:"difficulty"`
-		Number      *hexutil.Big    `json:"number"`
-		GasLimit    *hexutil.Big    `json:"gasLimit"`
-		GasUsed     *hexutil.Big    `json:"gasUsed"`
-		Time        *hexutil.Big    `json:"timestamp"`
-		Extra       hexutil.Bytes   `json:"extraData"`
-		MixDigest   *common.Hash    `json:"mixHash"`
-		Nonce       *BlockNonce     `json:"nonce"`
+	type Header struct {
+		ParentHash  *common.Hash    `json:"parentHash"       gencodec:"required"`
+		UncleHash   *common.Hash    `json:"sha3Uncles"       gencodec:"required"`
+		Coinbase    *common.Address `json:"miner"            gencodec:"required"`
+		Root        *common.Hash    `json:"stateRoot"        gencodec:"required"`
+		TxHash      *common.Hash    `json:"transactionsRoot" gencodec:"required"`
+		ReceiptHash *common.Hash    `json:"receiptsRoot"     gencodec:"required"`
+		Bloom       *Bloom          `json:"logsBloom"        gencodec:"required"`
+		Difficulty  *hexutil.Big    `json:"difficulty"       gencodec:"required"`
+		Number      *hexutil.Big    `json:"number"           gencodec:"required"`
+		GasLimit    *hexutil.Big    `json:"gasLimit"         gencodec:"required"`
+		GasUsed     *hexutil.Big    `json:"gasUsed"          gencodec:"required"`
+		Time        *hexutil.Big    `json:"timestamp"        gencodec:"required"`
+		Extra       hexutil.Bytes   `json:"extraData"        gencodec:"required"`
+		MixDigest   *common.Hash    `json:"mixHash"          gencodec:"required"`
+		Nonce       *BlockNonce     `json:"nonce"            gencodec:"required"`
 	}
-	var dec HeaderJSON
+	var dec Header
 	if err := json.Unmarshal(input, &dec); err != nil {
 		return err
 	}
-	var x Header
 	if dec.ParentHash == nil {
 		return errors.New("missing required field 'parentHash' for Header")
 	}
-	x.ParentHash = *dec.ParentHash
+	h.ParentHash = *dec.ParentHash
 	if dec.UncleHash == nil {
 		return errors.New("missing required field 'sha3Uncles' for Header")
 	}
-	x.UncleHash = *dec.UncleHash
+	h.UncleHash = *dec.UncleHash
 	if dec.Coinbase == nil {
 		return errors.New("missing required field 'miner' for Header")
 	}
-	x.Coinbase = *dec.Coinbase
+	h.Coinbase = *dec.Coinbase
 	if dec.Root == nil {
 		return errors.New("missing required field 'stateRoot' for Header")
 	}
-	x.Root = *dec.Root
+	h.Root = *dec.Root
 	if dec.TxHash == nil {
 		return errors.New("missing required field 'transactionsRoot' for Header")
 	}
-	x.TxHash = *dec.TxHash
+	h.TxHash = *dec.TxHash
 	if dec.ReceiptHash == nil {
 		return errors.New("missing required field 'receiptsRoot' for Header")
 	}
-	x.ReceiptHash = *dec.ReceiptHash
+	h.ReceiptHash = *dec.ReceiptHash
 	if dec.Bloom == nil {
 		return errors.New("missing required field 'logsBloom' for Header")
 	}
-	x.Bloom = *dec.Bloom
+	h.Bloom = *dec.Bloom
 	if dec.Difficulty == nil {
 		return errors.New("missing required field 'difficulty' for Header")
 	}
-	x.Difficulty = (*big.Int)(dec.Difficulty)
+	h.Difficulty = (*big.Int)(dec.Difficulty)
 	if dec.Number == nil {
 		return errors.New("missing required field 'number' for Header")
 	}
-	x.Number = (*big.Int)(dec.Number)
+	h.Number = (*big.Int)(dec.Number)
 	if dec.GasLimit == nil {
 		return errors.New("missing required field 'gasLimit' for Header")
 	}
-	x.GasLimit = (*big.Int)(dec.GasLimit)
+	h.GasLimit = (*big.Int)(dec.GasLimit)
 	if dec.GasUsed == nil {
 		return errors.New("missing required field 'gasUsed' for Header")
 	}
-	x.GasUsed = (*big.Int)(dec.GasUsed)
+	h.GasUsed = (*big.Int)(dec.GasUsed)
 	if dec.Time == nil {
 		return errors.New("missing required field 'timestamp' for Header")
 	}
-	x.Time = (*big.Int)(dec.Time)
+	h.Time = (*big.Int)(dec.Time)
 	if dec.Extra == nil {
 		return errors.New("missing required field 'extraData' for Header")
 	}
-	x.Extra = dec.Extra
+	h.Extra = dec.Extra
 	if dec.MixDigest == nil {
 		return errors.New("missing required field 'mixHash' for Header")
 	}
-	x.MixDigest = *dec.MixDigest
+	h.MixDigest = *dec.MixDigest
 	if dec.Nonce == nil {
 		return errors.New("missing required field 'nonce' for Header")
 	}
-	x.Nonce = *dec.Nonce
-	*h = x
+	h.Nonce = *dec.Nonce
 	return nil
 }

--- a/core/types/gen_header_json.go
+++ b/core/types/gen_header_json.go
@@ -28,6 +28,7 @@ func (h Header) MarshalJSON() ([]byte, error) {
 		Extra       hexutil.Bytes  `json:"extraData"        gencodec:"required"`
 		MixDigest   common.Hash    `json:"mixHash"          gencodec:"required"`
 		Nonce       BlockNonce     `json:"nonce"            gencodec:"required"`
+		Hash        common.Hash    `json:"hash"`
 	}
 	var enc Header
 	enc.ParentHash = h.ParentHash
@@ -45,6 +46,7 @@ func (h Header) MarshalJSON() ([]byte, error) {
 	enc.Extra = h.Extra
 	enc.MixDigest = h.MixDigest
 	enc.Nonce = h.Nonce
+	enc.Hash = h.Hash()
 	return json.Marshal(&enc)
 }
 

--- a/core/types/gen_log_json.go
+++ b/core/types/gen_log_json.go
@@ -11,18 +11,18 @@ import (
 )
 
 func (l Log) MarshalJSON() ([]byte, error) {
-	type LogJSON struct {
-		Address     common.Address `json:"address"`
-		Topics      []common.Hash  `json:"topics"`
-		Data        hexutil.Bytes  `json:"data"`
-		BlockNumber hexutil.Uint64 `json:"blockNumber" optional:"yes"`
-		TxHash      common.Hash    `json:"transactionHash"`
-		TxIndex     hexutil.Uint   `json:"transactionIndex"`
-		BlockHash   common.Hash    `json:"blockHash" optional:"yes"`
-		Index       hexutil.Uint   `json:"logIndex"`
-		Removed     bool           `json:"removed" optional:"yes"`
+	type Log struct {
+		Address     common.Address `json:"address" gencodec:"required"`
+		Topics      []common.Hash  `json:"topics" gencodec:"required"`
+		Data        hexutil.Bytes  `json:"data" gencodec:"required"`
+		BlockNumber hexutil.Uint64 `json:"blockNumber"`
+		TxHash      common.Hash    `json:"transactionHash" gencodec:"required"`
+		TxIndex     hexutil.Uint   `json:"transactionIndex" gencodec:"required"`
+		BlockHash   common.Hash    `json:"blockHash"`
+		Index       hexutil.Uint   `json:"logIndex" gencodec:"required"`
+		Removed     bool           `json:"removed"`
 	}
-	var enc LogJSON
+	var enc Log
 	enc.Address = l.Address
 	enc.Topics = l.Topics
 	enc.Data = l.Data
@@ -36,55 +36,53 @@ func (l Log) MarshalJSON() ([]byte, error) {
 }
 
 func (l *Log) UnmarshalJSON(input []byte) error {
-	type LogJSON struct {
-		Address     *common.Address `json:"address"`
-		Topics      []common.Hash   `json:"topics"`
-		Data        hexutil.Bytes   `json:"data"`
-		BlockNumber *hexutil.Uint64 `json:"blockNumber" optional:"yes"`
-		TxHash      *common.Hash    `json:"transactionHash"`
-		TxIndex     *hexutil.Uint   `json:"transactionIndex"`
-		BlockHash   *common.Hash    `json:"blockHash" optional:"yes"`
-		Index       *hexutil.Uint   `json:"logIndex"`
-		Removed     *bool           `json:"removed" optional:"yes"`
+	type Log struct {
+		Address     *common.Address `json:"address" gencodec:"required"`
+		Topics      []common.Hash   `json:"topics" gencodec:"required"`
+		Data        hexutil.Bytes   `json:"data" gencodec:"required"`
+		BlockNumber *hexutil.Uint64 `json:"blockNumber"`
+		TxHash      *common.Hash    `json:"transactionHash" gencodec:"required"`
+		TxIndex     *hexutil.Uint   `json:"transactionIndex" gencodec:"required"`
+		BlockHash   *common.Hash    `json:"blockHash"`
+		Index       *hexutil.Uint   `json:"logIndex" gencodec:"required"`
+		Removed     *bool           `json:"removed"`
 	}
-	var dec LogJSON
+	var dec Log
 	if err := json.Unmarshal(input, &dec); err != nil {
 		return err
 	}
-	var x Log
 	if dec.Address == nil {
 		return errors.New("missing required field 'address' for Log")
 	}
-	x.Address = *dec.Address
+	l.Address = *dec.Address
 	if dec.Topics == nil {
 		return errors.New("missing required field 'topics' for Log")
 	}
-	x.Topics = dec.Topics
+	l.Topics = dec.Topics
 	if dec.Data == nil {
 		return errors.New("missing required field 'data' for Log")
 	}
-	x.Data = dec.Data
+	l.Data = dec.Data
 	if dec.BlockNumber != nil {
-		x.BlockNumber = uint64(*dec.BlockNumber)
+		l.BlockNumber = uint64(*dec.BlockNumber)
 	}
 	if dec.TxHash == nil {
 		return errors.New("missing required field 'transactionHash' for Log")
 	}
-	x.TxHash = *dec.TxHash
+	l.TxHash = *dec.TxHash
 	if dec.TxIndex == nil {
 		return errors.New("missing required field 'transactionIndex' for Log")
 	}
-	x.TxIndex = uint(*dec.TxIndex)
+	l.TxIndex = uint(*dec.TxIndex)
 	if dec.BlockHash != nil {
-		x.BlockHash = *dec.BlockHash
+		l.BlockHash = *dec.BlockHash
 	}
 	if dec.Index == nil {
 		return errors.New("missing required field 'logIndex' for Log")
 	}
-	x.Index = uint(*dec.Index)
+	l.Index = uint(*dec.Index)
 	if dec.Removed != nil {
-		x.Removed = *dec.Removed
+		l.Removed = *dec.Removed
 	}
-	*l = x
 	return nil
 }

--- a/core/types/gen_receipt_json.go
+++ b/core/types/gen_receipt_json.go
@@ -12,16 +12,16 @@ import (
 )
 
 func (r Receipt) MarshalJSON() ([]byte, error) {
-	type ReceiptJSON struct {
-		PostState         hexutil.Bytes  `json:"root"`
-		CumulativeGasUsed *hexutil.Big   `json:"cumulativeGasUsed"`
-		Bloom             Bloom          `json:"logsBloom"`
-		Logs              []*Log         `json:"logs"`
-		TxHash            common.Hash    `json:"transactionHash"`
-		ContractAddress   common.Address `json:"contractAddress" optional:"true"`
-		GasUsed           *hexutil.Big   `json:"gasUsed"`
+	type Receipt struct {
+		PostState         hexutil.Bytes  `json:"root"              gencodec:"required"`
+		CumulativeGasUsed *hexutil.Big   `json:"cumulativeGasUsed" gencodec:"required"`
+		Bloom             Bloom          `json:"logsBloom"         gencodec:"required"`
+		Logs              []*Log         `json:"logs"              gencodec:"required"`
+		TxHash            common.Hash    `json:"transactionHash" gencodec:"required"`
+		ContractAddress   common.Address `json:"contractAddress"`
+		GasUsed           *hexutil.Big   `json:"gasUsed" gencodec:"required"`
 	}
-	var enc ReceiptJSON
+	var enc Receipt
 	enc.PostState = r.PostState
 	enc.CumulativeGasUsed = (*hexutil.Big)(r.CumulativeGasUsed)
 	enc.Bloom = r.Bloom
@@ -33,47 +33,45 @@ func (r Receipt) MarshalJSON() ([]byte, error) {
 }
 
 func (r *Receipt) UnmarshalJSON(input []byte) error {
-	type ReceiptJSON struct {
-		PostState         hexutil.Bytes   `json:"root"`
-		CumulativeGasUsed *hexutil.Big    `json:"cumulativeGasUsed"`
-		Bloom             *Bloom          `json:"logsBloom"`
-		Logs              []*Log          `json:"logs"`
-		TxHash            *common.Hash    `json:"transactionHash"`
-		ContractAddress   *common.Address `json:"contractAddress" optional:"true"`
-		GasUsed           *hexutil.Big    `json:"gasUsed"`
+	type Receipt struct {
+		PostState         hexutil.Bytes   `json:"root"              gencodec:"required"`
+		CumulativeGasUsed *hexutil.Big    `json:"cumulativeGasUsed" gencodec:"required"`
+		Bloom             *Bloom          `json:"logsBloom"         gencodec:"required"`
+		Logs              []*Log          `json:"logs"              gencodec:"required"`
+		TxHash            *common.Hash    `json:"transactionHash" gencodec:"required"`
+		ContractAddress   *common.Address `json:"contractAddress"`
+		GasUsed           *hexutil.Big    `json:"gasUsed" gencodec:"required"`
 	}
-	var dec ReceiptJSON
+	var dec Receipt
 	if err := json.Unmarshal(input, &dec); err != nil {
 		return err
 	}
-	var x Receipt
 	if dec.PostState == nil {
 		return errors.New("missing required field 'root' for Receipt")
 	}
-	x.PostState = dec.PostState
+	r.PostState = dec.PostState
 	if dec.CumulativeGasUsed == nil {
 		return errors.New("missing required field 'cumulativeGasUsed' for Receipt")
 	}
-	x.CumulativeGasUsed = (*big.Int)(dec.CumulativeGasUsed)
+	r.CumulativeGasUsed = (*big.Int)(dec.CumulativeGasUsed)
 	if dec.Bloom == nil {
 		return errors.New("missing required field 'logsBloom' for Receipt")
 	}
-	x.Bloom = *dec.Bloom
+	r.Bloom = *dec.Bloom
 	if dec.Logs == nil {
 		return errors.New("missing required field 'logs' for Receipt")
 	}
-	x.Logs = dec.Logs
+	r.Logs = dec.Logs
 	if dec.TxHash == nil {
 		return errors.New("missing required field 'transactionHash' for Receipt")
 	}
-	x.TxHash = *dec.TxHash
+	r.TxHash = *dec.TxHash
 	if dec.ContractAddress != nil {
-		x.ContractAddress = *dec.ContractAddress
+		r.ContractAddress = *dec.ContractAddress
 	}
 	if dec.GasUsed == nil {
 		return errors.New("missing required field 'gasUsed' for Receipt")
 	}
-	x.GasUsed = (*big.Int)(dec.GasUsed)
-	*r = x
+	r.GasUsed = (*big.Int)(dec.GasUsed)
 	return nil
 }

--- a/core/types/gen_tx_json.go
+++ b/core/types/gen_tx_json.go
@@ -12,19 +12,19 @@ import (
 )
 
 func (t txdata) MarshalJSON() ([]byte, error) {
-	type txdataJSON struct {
-		AccountNonce hexutil.Uint64  `json:"nonce"`
-		Price        *hexutil.Big    `json:"gasPrice"`
-		GasLimit     *hexutil.Big    `json:"gas"`
-		Recipient    *common.Address `json:"to" optional:"yes" rlp:"nil"`
-		Amount       *hexutil.Big    `json:"value"`
-		Payload      hexutil.Bytes   `json:"input"`
-		V            *hexutil.Big    `json:"v"`
-		R            *hexutil.Big    `json:"r"`
-		S            *hexutil.Big    `json:"s"`
-		Hash         *common.Hash    `json:"hash" optional:"yes" rlp:"-"`
+	type txdata struct {
+		AccountNonce hexutil.Uint64  `json:"nonce"    gencodec:"required"`
+		Price        *hexutil.Big    `json:"gasPrice" gencodec:"required"`
+		GasLimit     *hexutil.Big    `json:"gas"      gencodec:"required"`
+		Recipient    *common.Address `json:"to"       rlp:"nil"`
+		Amount       *hexutil.Big    `json:"value"    gencodec:"required"`
+		Payload      hexutil.Bytes   `json:"input"    gencodec:"required"`
+		V            *hexutil.Big    `json:"v" gencodec:"required"`
+		R            *hexutil.Big    `json:"r" gencodec:"required"`
+		S            *hexutil.Big    `json:"s" gencodec:"required"`
+		Hash         *common.Hash    `json:"hash" rlp:"-"`
 	}
-	var enc txdataJSON
+	var enc txdata
 	enc.AccountNonce = hexutil.Uint64(t.AccountNonce)
 	enc.Price = (*hexutil.Big)(t.Price)
 	enc.GasLimit = (*hexutil.Big)(t.GasLimit)
@@ -39,61 +39,59 @@ func (t txdata) MarshalJSON() ([]byte, error) {
 }
 
 func (t *txdata) UnmarshalJSON(input []byte) error {
-	type txdataJSON struct {
-		AccountNonce *hexutil.Uint64 `json:"nonce"`
-		Price        *hexutil.Big    `json:"gasPrice"`
-		GasLimit     *hexutil.Big    `json:"gas"`
-		Recipient    *common.Address `json:"to" optional:"yes" rlp:"nil"`
-		Amount       *hexutil.Big    `json:"value"`
-		Payload      hexutil.Bytes   `json:"input"`
-		V            *hexutil.Big    `json:"v"`
-		R            *hexutil.Big    `json:"r"`
-		S            *hexutil.Big    `json:"s"`
-		Hash         *common.Hash    `json:"hash" optional:"yes" rlp:"-"`
+	type txdata struct {
+		AccountNonce *hexutil.Uint64 `json:"nonce"    gencodec:"required"`
+		Price        *hexutil.Big    `json:"gasPrice" gencodec:"required"`
+		GasLimit     *hexutil.Big    `json:"gas"      gencodec:"required"`
+		Recipient    *common.Address `json:"to"       rlp:"nil"`
+		Amount       *hexutil.Big    `json:"value"    gencodec:"required"`
+		Payload      hexutil.Bytes   `json:"input"    gencodec:"required"`
+		V            *hexutil.Big    `json:"v" gencodec:"required"`
+		R            *hexutil.Big    `json:"r" gencodec:"required"`
+		S            *hexutil.Big    `json:"s" gencodec:"required"`
+		Hash         *common.Hash    `json:"hash" rlp:"-"`
 	}
-	var dec txdataJSON
+	var dec txdata
 	if err := json.Unmarshal(input, &dec); err != nil {
 		return err
 	}
-	var x txdata
 	if dec.AccountNonce == nil {
 		return errors.New("missing required field 'nonce' for txdata")
 	}
-	x.AccountNonce = uint64(*dec.AccountNonce)
+	t.AccountNonce = uint64(*dec.AccountNonce)
 	if dec.Price == nil {
 		return errors.New("missing required field 'gasPrice' for txdata")
 	}
-	x.Price = (*big.Int)(dec.Price)
+	t.Price = (*big.Int)(dec.Price)
 	if dec.GasLimit == nil {
 		return errors.New("missing required field 'gas' for txdata")
 	}
-	x.GasLimit = (*big.Int)(dec.GasLimit)
+	t.GasLimit = (*big.Int)(dec.GasLimit)
 	if dec.Recipient != nil {
-		x.Recipient = dec.Recipient
+		t.Recipient = dec.Recipient
 	}
 	if dec.Amount == nil {
 		return errors.New("missing required field 'value' for txdata")
 	}
-	x.Amount = (*big.Int)(dec.Amount)
+	t.Amount = (*big.Int)(dec.Amount)
 	if dec.Payload == nil {
 		return errors.New("missing required field 'input' for txdata")
 	}
-	x.Payload = dec.Payload
+	t.Payload = dec.Payload
 	if dec.V == nil {
 		return errors.New("missing required field 'v' for txdata")
 	}
-	x.V = (*big.Int)(dec.V)
+	t.V = (*big.Int)(dec.V)
 	if dec.R == nil {
 		return errors.New("missing required field 'r' for txdata")
 	}
-	x.R = (*big.Int)(dec.R)
+	t.R = (*big.Int)(dec.R)
 	if dec.S == nil {
 		return errors.New("missing required field 's' for txdata")
 	}
-	x.S = (*big.Int)(dec.S)
+	t.S = (*big.Int)(dec.S)
 	if dec.Hash != nil {
-		x.Hash = dec.Hash
+		t.Hash = dec.Hash
 	}
-	*t = x
 	return nil
 }

--- a/core/types/log.go
+++ b/core/types/log.go
@@ -32,28 +32,28 @@ import (
 type Log struct {
 	// Consensus fields:
 	// address of the contract that generated the event
-	Address common.Address `json:"address"`
+	Address common.Address `json:"address" gencodec:"required"`
 	// list of topics provided by the contract.
-	Topics []common.Hash `json:"topics"`
+	Topics []common.Hash `json:"topics" gencodec:"required"`
 	// supplied by the contract, usually ABI-encoded
-	Data []byte `json:"data"`
+	Data []byte `json:"data" gencodec:"required"`
 
 	// Derived fields. These fields are filled in by the node
 	// but not secured by consensus.
 	// block in which the transaction was included
-	BlockNumber uint64 `json:"blockNumber" optional:"yes"`
+	BlockNumber uint64 `json:"blockNumber"`
 	// hash of the transaction
-	TxHash common.Hash `json:"transactionHash"`
+	TxHash common.Hash `json:"transactionHash" gencodec:"required"`
 	// index of the transaction in the block
-	TxIndex uint `json:"transactionIndex"`
+	TxIndex uint `json:"transactionIndex" gencodec:"required"`
 	// hash of the block in which the transaction was included
-	BlockHash common.Hash `json:"blockHash" optional:"yes"`
+	BlockHash common.Hash `json:"blockHash"`
 	// index of the log in the receipt
-	Index uint `json:"logIndex"`
+	Index uint `json:"logIndex" gencodec:"required"`
 
 	// The Removed field is true if this log was reverted due to a chain reorganisation.
 	// You must pay attention to this field if you receive logs through a filter query.
-	Removed bool `json:"removed" optional:"yes"`
+	Removed bool `json:"removed"`
 }
 
 type logMarshaling struct {

--- a/core/types/receipt.go
+++ b/core/types/receipt.go
@@ -31,15 +31,15 @@ import (
 // Receipt represents the results of a transaction.
 type Receipt struct {
 	// Consensus fields
-	PostState         []byte   `json:"root"`
-	CumulativeGasUsed *big.Int `json:"cumulativeGasUsed"`
-	Bloom             Bloom    `json:"logsBloom"`
-	Logs              []*Log   `json:"logs"`
+	PostState         []byte   `json:"root"              gencodec:"required"`
+	CumulativeGasUsed *big.Int `json:"cumulativeGasUsed" gencodec:"required"`
+	Bloom             Bloom    `json:"logsBloom"         gencodec:"required"`
+	Logs              []*Log   `json:"logs"              gencodec:"required"`
 
 	// Implementation fields (don't reorder!)
-	TxHash          common.Hash    `json:"transactionHash"`
-	ContractAddress common.Address `json:"contractAddress" optional:"true"`
-	GasUsed         *big.Int       `json:"gasUsed"`
+	TxHash          common.Hash    `json:"transactionHash" gencodec:"required"`
+	ContractAddress common.Address `json:"contractAddress"`
+	GasUsed         *big.Int       `json:"gasUsed" gencodec:"required"`
 }
 
 type receiptMarshaling struct {

--- a/core/types/transaction.go
+++ b/core/types/transaction.go
@@ -55,20 +55,20 @@ type Transaction struct {
 }
 
 type txdata struct {
-	AccountNonce uint64          `json:"nonce"`
-	Price        *big.Int        `json:"gasPrice"`
-	GasLimit     *big.Int        `json:"gas"`
-	Recipient    *common.Address `json:"to" optional:"yes" rlp:"nil"` // nil means contract creation
-	Amount       *big.Int        `json:"value"`
-	Payload      []byte          `json:"input"`
+	AccountNonce uint64          `json:"nonce"    gencodec:"required"`
+	Price        *big.Int        `json:"gasPrice" gencodec:"required"`
+	GasLimit     *big.Int        `json:"gas"      gencodec:"required"`
+	Recipient    *common.Address `json:"to"       rlp:"nil"` // nil means contract creation
+	Amount       *big.Int        `json:"value"    gencodec:"required"`
+	Payload      []byte          `json:"input"    gencodec:"required"`
 
 	// Signature values
-	V *big.Int `json:"v"`
-	R *big.Int `json:"r"`
-	S *big.Int `json:"s"`
+	V *big.Int `json:"v" gencodec:"required"`
+	R *big.Int `json:"r" gencodec:"required"`
+	S *big.Int `json:"s" gencodec:"required"`
 
 	// This is only used when marshaling to JSON.
-	Hash *common.Hash `json:"hash" optional:"yes" rlp:"-"`
+	Hash *common.Hash `json:"hash" rlp:"-"`
 }
 
 type txdataMarshaling struct {


### PR DESCRIPTION
This PR uses `gencodec:"required"` instead of `optional:"true"`, following an upstream change in gencodec. It also adds the hash to marshaled headers. 

Fixes #13858.