### PR TITLE
consensus/ethash, eth: don't mine if 0 threads are set

### DIFF
--- a/consensus/ethash/sealer.go
+++ b/consensus/ethash/sealer.go
@@ -61,6 +61,9 @@ func (ethash *Ethash) Seal(chain consensus.ChainReader, block *types.Block, stop
 	if threads == 0 {
 		threads = runtime.NumCPU()
 	}
+	if threads < 0 {
+		threads = 0 // Allows disabling local mining without extra logic around local/remote
+	}
 	var pend sync.WaitGroup
 	for i := 0; i < threads; i++ {
 		pend.Add(1)

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -240,8 +240,10 @@ func CreateConsensusEngine(ctx *node.ServiceContext, config *Config, chainConfig
 		log.Warn("Ethash used in shared mode")
 		return ethash.NewShared()
 	default:
-		return ethash.New(ctx.ResolvePath(config.EthashCacheDir), config.EthashCachesInMem, config.EthashCachesOnDisk,
+		engine := ethash.New(ctx.ResolvePath(config.EthashCacheDir), config.EthashCachesInMem, config.EthashCachesOnDisk,
 			config.EthashDatasetDir, config.EthashDatasetsInMem, config.EthashDatasetsOnDisk)
+		engine.SetThreads(-1) // Disable CPU mining
+		return engine
 	}
 }
 


### PR DESCRIPTION
The current ethash implementation started mining on all CPU cores if 0 threads was specified. This turned out to hit a design convolution in the API/miner where `GetWork` actually started the miner, causing ethash to start CPU mining.

The underlying issue is that the API and the miner too is oblivious to local CPU miners or remote attached miners, both pathways calling the same `eth.StartMiner` and `miner.Start` methods. The proper solution would be to rewrite the miner so it has a clear notion of local and remote mining and the eth API so that it doesn't call the same method, rather explicitly starts local or remote mining.

Unfortunately that's a big work, so this PR just works around the issue by interpreting a `< 0` miner thread count as "don't CPU mine", and after creating the `ethash` instance in `eth`, we explicitly set the thread count to `-1`. This ensures that remote work requests don't trigger CPU mining, only if the user explicitly instructs geth to do so via `miner.Start()`.