### PR TITLE
travis, appveyor: update to Go 1.8.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ matrix:
     - os: linux
       dist: trusty
       sudo: required
-      go: 1.8
+      go: 1.8.1
       script:
         - sudo -E apt-get -yq --no-install-suggests --no-install-recommends --force-yes install fuse
         - sudo modprobe fuse
@@ -29,7 +29,7 @@ matrix:
         - go run build/ci.go test -coverage -misspell
 
     - os: osx
-      go: 1.8
+      go: 1.8.1
       sudo: required
       script:
         - brew update
@@ -42,7 +42,7 @@ matrix:
     - os: linux
       dist: trusty
       sudo: required
-      go: 1.8
+      go: 1.8.1
       env:
         - ubuntu-ppa
         - azure-linux
@@ -71,9 +71,8 @@ matrix:
         - GOARM=6 go run build/ci.go archive -arch arm -type tar -signer LINUX_SIGNING_KEY -upload gethstore/builds
         - GOARM=7 CC=arm-linux-gnueabihf-gcc go run build/ci.go install -arch arm
         - GOARM=7 go run build/ci.go archive -arch arm -type tar -signer LINUX_SIGNING_KEY -upload gethstore/builds
-        # ARM64 linux builds are broken in Go 1.8 (https://github.com/golang/go/issues/19137), reenable in Go 1.8.1
-        # - CC=aarch64-linux-gnu-gcc go run build/ci.go install -arch arm64
-        # - go run build/ci.go archive -arch arm64 -type tar -signer LINUX_SIGNING_KEY -upload gethstore/builds
+        - CC=aarch64-linux-gnu-gcc go run build/ci.go install -arch arm64
+        - go run build/ci.go archive -arch arm64 -type tar -signer LINUX_SIGNING_KEY -upload gethstore/builds
 
     # This builder does the Linux Azure MIPS xgo uploads
     - os: linux
@@ -81,7 +80,7 @@ matrix:
       sudo: required
       services:
         - docker
-      go: 1.8
+      go: 1.8.1
       env:
         - azure-linux-mips
       script:
@@ -100,24 +99,6 @@ matrix:
         - go run build/ci.go xgo --alltools -- --targets=linux/mips64le --ldflags '-extldflags "-static"' -v
         - for bin in build/bin/*-linux-mips64le; do mv -f "${bin}" "${bin/-linux-mips64le/}"; done
         - go run build/ci.go archive -arch mips64le -type tar -signer LINUX_SIGNING_KEY -upload gethstore/builds
-
-    # This builder is a temporary fallback for building ARM64 while Go 1.8 is fixed
-    - os: linux
-      dist: trusty
-      sudo: required
-      go: 1.7.5
-      env:
-        - azure-linux-arm64-fallback
-      addons:
-        apt:
-          packages:
-            - gcc-multilib
-      script:
-        - sudo -E apt-get -yq --no-install-suggests --no-install-recommends --force-yes install gcc-aarch64-linux-gnu libc6-dev-arm64-cross
-        - sudo ln -s /usr/include/asm-generic /usr/include/asm
-
-        - CC=aarch64-linux-gnu-gcc go run build/ci.go install -arch arm64
-        - go run build/ci.go archive -arch arm64 -type tar -signer LINUX_SIGNING_KEY -upload gethstore/builds
 
     # This builder does the Android Maven and Azure uploads
     - os: linux
@@ -139,7 +120,7 @@ matrix:
         - azure-android
         - maven-android
       before_install:
-        - curl https://storage.googleapis.com/golang/go1.8.linux-amd64.tar.gz | tar -xz
+        - curl https://storage.googleapis.com/golang/go1.8.1.linux-amd64.tar.gz | tar -xz
         - export PATH=`pwd`/go/bin:$PATH
         - export GOROOT=`pwd`/go
         - export GOPATH=$HOME/go
@@ -156,7 +137,7 @@ matrix:
 
     # This builder does the OSX Azure, iOS CocoaPods and iOS Azure uploads
     - os: osx
-      go: 1.8
+      go: 1.8.1
       env:
         - azure-osx
         - azure-ios
@@ -182,7 +163,7 @@ matrix:
     - os: linux
       dist: trusty
       sudo: required
-      go: 1.8
+      go: 1.8.1
       env:
         - azure-purge
       script:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -22,8 +22,8 @@ environment:
 
 install:
   - rmdir C:\go /s /q
-  - appveyor DownloadFile https://storage.googleapis.com/golang/go1.8.windows-%GETH_ARCH%.zip
-  - 7z x go1.8.windows-%GETH_ARCH%.zip -y -oC:\ > NUL
+  - appveyor DownloadFile https://storage.googleapis.com/golang/go1.8.1.windows-%GETH_ARCH%.zip
+  - 7z x go1.8.1.windows-%GETH_ARCH%.zip -y -oC:\ > NUL
   - go version
   - gcc --version
 


### PR DESCRIPTION
Updates our CI build jobs to Go 1.8.1 and finally removes the hacky 1.7.5 fallback for arm64.