### PR TITLE
cmd/geth, eth: accept transactions on CPU mining

### DIFF
--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -301,7 +301,7 @@ func startNode(ctx *cli.Context, stack *node.Node) {
 				th.SetThreads(threads)
 			}
 		}
-		if err := ethereum.StartMining(); err != nil {
+		if err := ethereum.StartMining(true); err != nil {
 			utils.Fatalf("Failed to start mining: %v", err)
 		}
 	}

--- a/eth/api.go
+++ b/eth/api.go
@@ -103,7 +103,7 @@ func (api *PublicMinerAPI) SubmitWork(nonce types.BlockNonce, solution, digest c
 // result[2], 32 bytes hex encoded boundary condition ("target"), 2^256/difficulty
 func (api *PublicMinerAPI) GetWork() ([3]string, error) {
 	if !api.e.IsMining() {
-		if err := api.e.StartMining(); err != nil {
+		if err := api.e.StartMining(false); err != nil {
 			return [3]string{}, err
 		}
 	}
@@ -153,7 +153,7 @@ func (api *PrivateMinerAPI) Start(threads *int) error {
 	}
 	// Start the miner and return
 	if !api.e.IsMining() {
-		return api.e.StartMining()
+		return api.e.StartMining(true)
 	}
 	return nil
 }

--- a/eth/protocol_test.go
+++ b/eth/protocol_test.go
@@ -94,7 +94,7 @@ func TestRecvTransactions63(t *testing.T) { testRecvTransactions(t, 63) }
 func testRecvTransactions(t *testing.T, protocol int) {
 	txAdded := make(chan []*types.Transaction)
 	pm := newTestProtocolManagerMust(t, false, 0, nil, txAdded)
-	pm.synced = 1 // mark synced to accept transactions
+	pm.acceptTxs = 1 // mark synced to accept transactions
 	p, _ := newTestPeer("peer", protocol, pm, true)
 	defer pm.Stop()
 	defer p.close()

--- a/eth/sync.go
+++ b/eth/sync.go
@@ -188,7 +188,7 @@ func (pm *ProtocolManager) synchronise(peer *peer) {
 	if err := pm.downloader.Synchronise(peer.id, pHead, pTd, mode); err != nil {
 		return
 	}
-	atomic.StoreUint32(&pm.synced, 1) // Mark initial sync done
+	atomic.StoreUint32(&pm.acceptTxs, 1) // Mark initial sync done
 	if head := pm.blockchain.CurrentBlock(); head.NumberU64() > 0 {
 		// We've completed a sync cycle, notify all peers of new state. This path is
 		// essential in star-topology networks where a gateway node needs to notify


### PR DESCRIPTION
Way back we had an issue with transactions during sync, where a node freshly joining the network accumulated a ton of old transactions (who knows from where), trying to execute them against every imported block, causing a significant sync slowdown. We've addressed the issue by introducing a "syncing" state into `eth`, which was tracking whether we managed to sync the network for the first time or not yet, rejecting all transactions until either the downloader finished a sync cycle, or the network propagated us a new block.

This had an unforseen side effect, where private networks running a single miner got stuck. Since the singleton miner was the one minting all new blocks, it itself never completed a sync cycle, and was never propagated a new block. As a consequence, the miner always thought itself as not synced, so kept rejecting transactions, causing the network to never actually incorporate new transactions into the blockchain. The suggested workaround was to run at least 2 miners (yuck).

The complexity in fixing this issue properly is that it's not obvious when "sync" is complete if there are no blocks arriving (maybe we don't have internet, maybe we're the miner, maybe there's no miner). Reenabling transaction processing prematurely can have a huge performance hit on average nodes, so we don't want to do that. The other non trivial choice is to simply enable transaction processing on mining. Unfortunately this also isn't that obvious, since a node with an attached ethminer would instantly start tx processing, even if it has an empty chain.

The idea behind this PR is that we will instantly enable transaction processing on CPU mining, but retaing the old behavior of only enabling after the initial sync for normal nodes or remote miners. The rationale is that noone will ever CPU mine on mainnet, so we don't degrade performance for anyone there. On the other hand in private networks where users might CPU mine, sync performance ins't **that** essential vs. a non functioning network, so it's a viable workaround while a nicer solution is done via a txpool and/or miner rewrite. Even in private networks only miners are affected, which probably won't just pop on and off, rather them being stably run by their operators, so negative effects are non important.