### PR TITLE
eth: announce block after sync cycle (star topology)

### DIFF
--- a/eth/sync.go
+++ b/eth/sync.go
@@ -189,7 +189,15 @@ func (pm *ProtocolManager) synchronise(peer *peer) {
 		return
 	}
 	atomic.StoreUint32(&pm.synced, 1) // Mark initial sync done
-
+	if head := pm.blockchain.CurrentBlock(); head.NumberU64() > 0 {
+		// We've completed a sync cycle, notify all peers of new state. This path is
+		// essential in star-topology networks where a gateway node needs to notify
+		// all its out-of-date peers of the availability of a new block. This failure
+		// scenario will most often crop up in private and hackathon networks with
+		// degenerate connectivity, but it should be healthy for the mainnet too to
+		// more reliably update peers or the local TD state.
+		go pm.BroadcastBlock(head, false)
+	}
 	// If fast sync was enabled, and we synced up, disable it
 	if atomic.LoadUint32(&pm.fastSync) == 1 {
 		// Disable fast sync if we indeed have something in our chain


### PR DESCRIPTION
Fixes https://github.com/ethereum/go-ethereum/issues/2995

When completing a sync cycle, notify all peers of new state. This path is essential in star-topology networks where a gateway node needs to notify all its out-of-date peers of the availability of a new block, which it currently does not do.

This failure scenario will most often crop up in private and hackathon networks with degenerate connectivity, but it should be healthy for the mainnet too to more reliably update peers or the local TD state.