### PR TITLE
les: allow LES connection to other servers

### DIFF
--- a/les/peer.go
+++ b/les/peer.go
@@ -391,9 +391,10 @@ func (p *peer) Handshake(td *big.Int, head common.Hash, headNum uint64, genesis 
 		return errResp(ErrProtocolVersionMismatch, "%d (!= %d)", rVersion, p.version)
 	}
 	if server != nil {
-		if recv.get("serveStateSince", nil) == nil {
+		// until we have a proper peer connectivity API, allow LES connection to other servers
+		/*if recv.get("serveStateSince", nil) == nil {
 			return errResp(ErrUselessPeer, "wanted client, got server")
-		}
+		}*/
 		p.fcClient = flowcontrol.NewClientNode(server.fcManager, server.defParams)
 	} else {
 		if recv.get("serveChainSince", nil) != nil {


### PR DESCRIPTION
Unfortunately at the moment we have to either run LES protocol with every LES capable peer (even if it is useless) or drop them. So until we have a proper peer connectivity API which allows connecting through ETH but not through LES, allow LES connection to other servers.

This is a fix for https://github.com/ethereum/go-ethereum/issues/13877
