### PR TITLE
cmd/rlpdump: support dumping only the first entity

### DIFF
--- a/cmd/rlpdump/main.go
+++ b/cmd/rlpdump/main.go
@@ -32,6 +32,7 @@ import (
 var (
 	hexMode = flag.String("hex", "", "dump given hex data")
 	noASCII = flag.Bool("noascii", false, "don't print ASCII strings readably")
+	single  = flag.Bool("single", false, "print only the first element, discard the rest")
 )
 
 func init() {
@@ -82,6 +83,9 @@ func main() {
 			break
 		}
 		fmt.Println()
+		if *single {
+			break
+		}
 	}
 }
 


### PR DESCRIPTION
This PR adds a `--single` flag to `rlpdump`, which can be used to stop it from interpreting the entire stream and only print the first whole item it finds. This is useful where we know we have a good rlp message at the beginning, but don't know how long the message is and where something else begins.

Notably etherscan uses rlpdump to extract the miner information from the header extra-data, which works if the extra-data is a single rlp, but fails in clique for example where there might be trailing zero bytes after the rlp and also the signer signature is contained there.