### PR TITLE
Remove unused solc references and improve node RPC config

### DIFF
--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -140,7 +140,6 @@ func init() {
 		utils.MetricsEnabledFlag,
 		utils.FakePoWFlag,
 		utils.NoCompactionFlag,
-		utils.SolcPathFlag,
 		utils.GpoBlocksFlag,
 		utils.GpoPercentileFlag,
 		utils.ExtraDataFlag,

--- a/cmd/geth/usage.go
+++ b/cmd/geth/usage.go
@@ -174,12 +174,6 @@ var AppHelpFlagGroups = []flagGroup{
 			utils.WhisperEnabledFlag,
 		},
 	},
-	{
-		Name: "MISCELLANEOUS",
-		Flags: []cli.Flag{
-			utils.SolcPathFlag,
-		},
-	},
 }
 
 func init() {

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -523,9 +523,17 @@ func setNAT(ctx *cli.Context, cfg *p2p.Config) {
 	}
 }
 
-// makeRPCModules splits input separated by a comma and trims excessive white
-// space from the substrings.
-func makeRPCModules(input string) []string {
+// splitAndTrim splits input separated by a comma
+// and trims excessive white space from the substrings.
+func splitAndTrim(input string) []string {
+	result := strings.Split(input, ",")
+	for i, r := range result {
+		result[i] = strings.TrimSpace(r)
+	}
+	return result
+}
+
+func makeRPCCORS(input string) []string {
 	result := strings.Split(input, ",")
 	for i, r := range result {
 		result[i] = strings.TrimSpace(r)
@@ -547,10 +555,10 @@ func setHTTP(ctx *cli.Context, cfg *node.Config) {
 		cfg.HTTPPort = ctx.GlobalInt(RPCPortFlag.Name)
 	}
 	if ctx.GlobalIsSet(RPCCORSDomainFlag.Name) {
-		cfg.HTTPCors = ctx.GlobalString(RPCCORSDomainFlag.Name)
+		cfg.HTTPCors = splitAndTrim(ctx.GlobalString(RPCCORSDomainFlag.Name))
 	}
 	if ctx.GlobalIsSet(RPCApiFlag.Name) {
-		cfg.HTTPModules = makeRPCModules(ctx.GlobalString(RPCApiFlag.Name))
+		cfg.HTTPModules = splitAndTrim(ctx.GlobalString(RPCApiFlag.Name))
 	}
 }
 
@@ -571,7 +579,7 @@ func setWS(ctx *cli.Context, cfg *node.Config) {
 		cfg.WSOrigins = ctx.GlobalString(WSAllowedOriginsFlag.Name)
 	}
 	if ctx.GlobalIsSet(WSApiFlag.Name) {
-		cfg.WSModules = makeRPCModules(ctx.GlobalString(WSApiFlag.Name))
+		cfg.WSModules = splitAndTrim(ctx.GlobalString(WSApiFlag.Name))
 	}
 }
 

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -533,14 +533,6 @@ func splitAndTrim(input string) []string {
 	return result
 }
 
-func makeRPCCORS(input string) []string {
-	result := strings.Split(input, ",")
-	for i, r := range result {
-		result[i] = strings.TrimSpace(r)
-	}
-	return result
-}
-
 // setHTTP creates the HTTP RPC listener interface string from the set
 // command line flags, returning empty if the HTTP endpoint is disabled.
 func setHTTP(ctx *cli.Context, cfg *node.Config) {
@@ -576,7 +568,7 @@ func setWS(ctx *cli.Context, cfg *node.Config) {
 		cfg.WSPort = ctx.GlobalInt(WSPortFlag.Name)
 	}
 	if ctx.GlobalIsSet(WSAllowedOriginsFlag.Name) {
-		cfg.WSOrigins = ctx.GlobalString(WSAllowedOriginsFlag.Name)
+		cfg.WSOrigins = splitAndTrim(ctx.GlobalString(WSAllowedOriginsFlag.Name))
 	}
 	if ctx.GlobalIsSet(WSApiFlag.Name) {
 		cfg.WSModules = splitAndTrim(ctx.GlobalString(WSApiFlag.Name))

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -392,11 +392,6 @@ var (
 		Usage: "JavaScript root path for `loadScript`",
 		Value: ".",
 	}
-	SolcPathFlag = cli.StringFlag{
-		Name:  "solc",
-		Usage: "Solidity compiler command to be used",
-		Value: "solc",
-	}
 
 	// Gas price oracle settings
 	GpoBlocksFlag = cli.IntFlag{
@@ -827,10 +822,6 @@ func SetEthConfig(ctx *cli.Context, stack *node.Node, cfg *eth.Config) {
 	}
 	if ctx.GlobalIsSet(GasPriceFlag.Name) {
 		cfg.GasPrice = GlobalBig(ctx, GasPriceFlag.Name)
-	}
-
-	if ctx.GlobalIsSet(SolcPathFlag.Name) {
-		cfg.SolcPath = ctx.GlobalString(SolcPathFlag.Name)
 	}
 	if ctx.GlobalIsSet(VMEnableDebugFlag.Name) {
 		// TODO(fjl): force-enable this in --dev mode

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -79,7 +79,6 @@ type Ethereum struct {
 	Mining       bool
 	MinerThreads int
 	etherbase    common.Address
-	solcPath     string
 
 	netVersionId  int
 	netRPCService *ethapi.PublicNetAPI
@@ -122,7 +121,6 @@ func New(ctx *node.ServiceContext, config *Config) (*Ethereum, error) {
 		netVersionId:   config.NetworkId,
 		etherbase:      config.Etherbase,
 		MinerThreads:   config.MinerThreads,
-		solcPath:       config.SolcPath,
 	}
 
 	if err := addMipmapBloomBins(chainDb); err != nil {
@@ -236,7 +234,7 @@ func CreateConsensusEngine(ctx *node.ServiceContext, config *Config, chainConfig
 // APIs returns the collection of RPC services the ethereum package offers.
 // NOTE, some of these services probably need to be moved to somewhere else.
 func (s *Ethereum) APIs() []rpc.API {
-	apis := ethapi.GetAPIs(s.ApiBackend, s.solcPath)
+	apis := ethapi.GetAPIs(s.ApiBackend)
 
 	// Append any APIs exposed explicitly by the consensus engine
 	apis = append(apis, s.engine.APIs(s.BlockChain())...)

--- a/eth/config.go
+++ b/eth/config.go
@@ -105,7 +105,6 @@ type Config struct {
 	EnablePreimageRecording bool
 
 	// Miscellaneous options
-	SolcPath  string
 	DocRoot   string `toml:"-"`
 	PowFake   bool   `toml:"-"`
 	PowTest   bool   `toml:"-"`

--- a/eth/gen_config.go
+++ b/eth/gen_config.go
@@ -35,7 +35,6 @@ func (c Config) MarshalTOML() (interface{}, error) {
 		EthashDatasetsOnDisk    int
 		GPO                     gasprice.Config
 		EnablePreimageRecording bool
-		SolcPath                string
 		DocRoot                 string `toml:"-"`
 		PowFake                 bool   `toml:"-"`
 		PowTest                 bool   `toml:"-"`
@@ -63,7 +62,6 @@ func (c Config) MarshalTOML() (interface{}, error) {
 	enc.EthashDatasetsOnDisk = c.EthashDatasetsOnDisk
 	enc.GPO = c.GPO
 	enc.EnablePreimageRecording = c.EnablePreimageRecording
-	enc.SolcPath = c.SolcPath
 	enc.DocRoot = c.DocRoot
 	enc.PowFake = c.PowFake
 	enc.PowTest = c.PowTest
@@ -94,7 +92,6 @@ func (c *Config) UnmarshalTOML(unmarshal func(interface{}) error) error {
 		EthashDatasetsOnDisk    *int
 		GPO                     *gasprice.Config
 		EnablePreimageRecording *bool
-		SolcPath                *string
 		DocRoot                 *string `toml:"-"`
 		PowFake                 *bool   `toml:"-"`
 		PowTest                 *bool   `toml:"-"`
@@ -166,9 +163,6 @@ func (c *Config) UnmarshalTOML(unmarshal func(interface{}) error) error {
 	}
 	if dec.EnablePreimageRecording != nil {
 		c.EnablePreimageRecording = *dec.EnablePreimageRecording
-	}
-	if dec.SolcPath != nil {
-		c.SolcPath = *dec.SolcPath
 	}
 	if dec.DocRoot != nil {
 		c.DocRoot = *dec.DocRoot

--- a/internal/ethapi/backend.go
+++ b/internal/ethapi/backend.go
@@ -72,7 +72,7 @@ type State interface {
 	GetNonce(ctx context.Context, addr common.Address) (uint64, error)
 }
 
-func GetAPIs(apiBackend Backend, solcPath string) []rpc.API {
+func GetAPIs(apiBackend Backend) []rpc.API {
 	return []rpc.API{
 		{
 			Namespace: "eth",

--- a/internal/web3ext/web3ext.go
+++ b/internal/web3ext/web3ext.go
@@ -144,11 +144,6 @@ web3._extend({
 			params: 2
 		}),
 		new web3._extend.Method({
-			name: 'setSolc',
-			call: 'admin_setSolc',
-			params: 1
-		}),
-		new web3._extend.Method({
 			name: 'startRPC',
 			call: 'admin_startRPC',
 			params: 4,

--- a/les/backend.go
+++ b/les/backend.go
@@ -23,7 +23,6 @@ import (
 
 	"github.com/ethereum/go-ethereum/accounts"
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/common/compiler"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/consensus"
 	"github.com/ethereum/go-ethereum/core"
@@ -61,8 +60,6 @@ type LightEthereum struct {
 	eventMux       *event.TypeMux
 	engine         consensus.Engine
 	accountManager *accounts.Manager
-	solcPath       string
-	solc           *compiler.Solidity
 
 	netVersionId  int
 	netRPCService *ethapi.PublicNetAPI
@@ -91,7 +88,6 @@ func New(ctx *node.ServiceContext, config *eth.Config) (*LightEthereum, error) {
 		engine:         eth.CreateConsensusEngine(ctx, config, chainConfig, chainDb),
 		shutdownChan:   make(chan bool),
 		netVersionId:   config.NetworkId,
-		solcPath:       config.SolcPath,
 	}
 	if eth.blockchain, err = light.NewLightChain(odr, eth.chainConfig, eth.engine, eth.eventMux); err != nil {
 		return nil, err
@@ -145,7 +141,7 @@ func (s *LightDummyAPI) Mining() bool {
 // APIs returns the collection of RPC services the ethereum package offers.
 // NOTE, some of these services probably need to be moved to somewhere else.
 func (s *LightEthereum) APIs() []rpc.API {
-	return append(ethapi.GetAPIs(s.ApiBackend, s.solcPath), []rpc.API{
+	return append(ethapi.GetAPIs(s.ApiBackend), []rpc.API{
 		{
 			Namespace: "eth",
 			Version:   "1.0",

--- a/node/api.go
+++ b/node/api.go
@@ -146,8 +146,13 @@ func (api *PrivateAdminAPI) StartWS(host *string, port *int, allowedOrigins *str
 	if port == nil {
 		port = &api.node.config.WSPort
 	}
-	if allowedOrigins == nil {
-		allowedOrigins = &api.node.config.WSOrigins
+
+	origins := api.node.config.WSOrigins
+	if allowedOrigins != nil {
+		origins = nil
+		for _, origin := range strings.Split(*allowedOrigins, ",") {
+			origins = append(origins, strings.TrimSpace(origin))
+		}
 	}
 
 	modules := api.node.config.WSModules
@@ -158,7 +163,7 @@ func (api *PrivateAdminAPI) StartWS(host *string, port *int, allowedOrigins *str
 		}
 	}
 
-	if err := api.node.startWS(fmt.Sprintf("%s:%d", *host, *port), api.node.rpcAPIs, modules, *allowedOrigins); err != nil {
+	if err := api.node.startWS(fmt.Sprintf("%s:%d", *host, *port), api.node.rpcAPIs, modules, origins); err != nil {
 		return false, err
 	}
 	return true, nil

--- a/node/api.go
+++ b/node/api.go
@@ -92,8 +92,13 @@ func (api *PrivateAdminAPI) StartRPC(host *string, port *int, cors *string, apis
 	if port == nil {
 		port = &api.node.config.HTTPPort
 	}
-	if cors == nil {
-		cors = &api.node.config.HTTPCors
+
+	allowedOrigins := api.node.config.HTTPCors
+	if cors != nil {
+		allowedOrigins = nil
+		for _, origin := range strings.Split(*cors, ",") {
+			allowedOrigins = append(allowedOrigins, strings.TrimSpace(origin))
+		}
 	}
 
 	modules := api.node.httpWhitelist
@@ -104,7 +109,7 @@ func (api *PrivateAdminAPI) StartRPC(host *string, port *int, cors *string, apis
 		}
 	}
 
-	if err := api.node.startHTTP(fmt.Sprintf("%s:%d", *host, *port), api.node.rpcAPIs, modules, *cors); err != nil {
+	if err := api.node.startHTTP(fmt.Sprintf("%s:%d", *host, *port), api.node.rpcAPIs, modules, allowedOrigins); err != nil {
 		return false, err
 	}
 	return true, nil

--- a/node/config.go
+++ b/node/config.go
@@ -100,7 +100,7 @@ type Config struct {
 	// HTTPCors is the Cross-Origin Resource Sharing header to send to requesting
 	// clients. Please be aware that CORS is a browser enforced security, it's fully
 	// useless for custom HTTP clients.
-	HTTPCors string `toml:",omitempty"`
+	HTTPCors []string `toml:",omitempty"`
 
 	// HTTPModules is a list of API modules to expose via the HTTP RPC interface.
 	// If the module list is empty, all RPC API endpoints designated public will be

--- a/node/config.go
+++ b/node/config.go
@@ -119,7 +119,7 @@ type Config struct {
 	// WSOrigins is the list of domain to accept websocket requests from. Please be
 	// aware that the server can only act upon the HTTP request the client sends and
 	// cannot verify the validity of the request header.
-	WSOrigins string `toml:",omitempty"`
+	WSOrigins []string `toml:",omitempty"`
 
 	// WSModules is a list of API modules to expose via the websocket RPC interface.
 	// If the module list is empty, all RPC API endpoints designated public will be

--- a/node/node.go
+++ b/node/node.go
@@ -426,7 +426,7 @@ func (n *Node) stopHTTP() {
 }
 
 // startWS initializes and starts the websocket RPC endpoint.
-func (n *Node) startWS(endpoint string, apis []rpc.API, modules []string, wsOrigins string) error {
+func (n *Node) startWS(endpoint string, apis []rpc.API, modules []string, wsOrigins []string) error {
 	// Short circuit if the WS endpoint isn't being exposed
 	if endpoint == "" {
 		return nil

--- a/node/node.go
+++ b/node/node.go
@@ -372,7 +372,7 @@ func (n *Node) stopIPC() {
 }
 
 // startHTTP initializes and starts the HTTP RPC endpoint.
-func (n *Node) startHTTP(endpoint string, apis []rpc.API, modules []string, cors string) error {
+func (n *Node) startHTTP(endpoint string, apis []rpc.API, modules []string, cors []string) error {
 	// Short circuit if the HTTP endpoint isn't being exposed
 	if endpoint == "" {
 		return nil

--- a/rpc/client_test.go
+++ b/rpc/client_test.go
@@ -394,7 +394,7 @@ func TestClientReconnect(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		go http.Serve(l, srv.WebsocketHandler("*"))
+		go http.Serve(l, srv.WebsocketHandler([]string{"*"}))
 		return srv, l
 	}
 
@@ -466,7 +466,7 @@ func httpTestClient(srv *Server, transport string, fl *flakeyListener) (*Client,
 	var hs *httptest.Server
 	switch transport {
 	case "ws":
-		hs = httptest.NewUnstartedServer(srv.WebsocketHandler("*"))
+		hs = httptest.NewUnstartedServer(srv.WebsocketHandler([]string{"*"}))
 	case "http":
 		hs = httptest.NewUnstartedServer(srv)
 	default:

--- a/rpc/http.go
+++ b/rpc/http.go
@@ -25,7 +25,6 @@ import (
 	"io/ioutil"
 	"net"
 	"net/http"
-	"strings"
 	"sync"
 	"time"
 
@@ -140,8 +139,8 @@ func (t *httpReadWriteNopCloser) Close() error {
 // NewHTTPServer creates a new HTTP RPC server around an API provider.
 //
 // Deprecated: Server implements http.Handler
-func NewHTTPServer(corsString string, srv *Server) *http.Server {
-	return &http.Server{Handler: newCorsHandler(srv, corsString)}
+func NewHTTPServer(cors []string, srv *Server) *http.Server {
+	return &http.Server{Handler: newCorsHandler(srv, cors)}
 }
 
 // ServeHTTP serves JSON-RPC requests over HTTP.
@@ -162,11 +161,7 @@ func (srv *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	srv.ServeSingleRequest(codec, OptionMethodInvocation)
 }
 
-func newCorsHandler(srv *Server, corsString string) http.Handler {
-	var allowedOrigins []string
-	for _, domain := range strings.Split(corsString, ",") {
-		allowedOrigins = append(allowedOrigins, strings.TrimSpace(domain))
-	}
+func newCorsHandler(srv *Server, allowedOrigins []string) http.Handler {
 	c := cors.New(cors.Options{
 		AllowedOrigins: allowedOrigins,
 		AllowedMethods: []string{"POST", "GET"},

--- a/rpc/websocket.go
+++ b/rpc/websocket.go
@@ -36,9 +36,9 @@ import (
 //
 // allowedOrigins should be a comma-separated list of allowed origin URLs.
 // To allow connections with any origin, pass "*".
-func (srv *Server) WebsocketHandler(allowedOrigins string) http.Handler {
+func (srv *Server) WebsocketHandler(allowedOrigins []string) http.Handler {
 	return websocket.Server{
-		Handshake: wsHandshakeValidator(strings.Split(allowedOrigins, ",")),
+		Handshake: wsHandshakeValidator(allowedOrigins),
 		Handler: func(conn *websocket.Conn) {
 			srv.ServeCodec(NewJSONCodec(conn), OptionMethodInvocation|OptionSubscriptions)
 		},
@@ -48,7 +48,7 @@ func (srv *Server) WebsocketHandler(allowedOrigins string) http.Handler {
 // NewWSServer creates a new websocket RPC server around an API provider.
 //
 // Deprecated: use Server.WebsocketHandler
-func NewWSServer(allowedOrigins string, srv *Server) *http.Server {
+func NewWSServer(allowedOrigins []string, srv *Server) *http.Server {
 	return &http.Server{Handler: srv.WebsocketHandler(allowedOrigins)}
 }
 


### PR DESCRIPTION
Currently http cors and websocket origins are a comma separated string in the config object. These are replaced with string arrays that are more expressive in case of a config file.