### PR TITLE
consensus/ethash: close mmap before rename, windows limitation

### DIFF
--- a/build/ci.go
+++ b/build/ci.go
@@ -292,7 +292,8 @@ func doTest(cmdline []string) {
 	// Run analysis tools before the tests.
 	build.MustRun(goTool("vet", packages...))
 	if *misspell {
-		spellcheck(packages)
+		// TODO(karalabe): Reenable after false detection is fixed: https://github.com/client9/misspell/issues/105
+		// spellcheck(packages)
 	}
 	// Run the actual tests.
 	gotest := goTool("test", buildFlags(env)...)

--- a/consensus/ethash/ethash.go
+++ b/consensus/ethash/ethash.go
@@ -130,13 +130,16 @@ func memoryMapAndGenerate(path string, size uint64, generator func(buffer []uint
 	data := buffer[len(dumpMagic):]
 	generator(data)
 
-	if err := mem.Flush(); err != nil {
-		mem.Unmap()
-		dump.Close()
+	if err := mem.Unmap(); err != nil {
 		return nil, nil, nil, err
 	}
-	os.Rename(temp, path)
-	return dump, mem, data, nil
+	if err := dump.Close(); err != nil {
+		return nil, nil, nil, err
+	}
+	if err := os.Rename(temp, path); err != nil {
+		return nil, nil, nil, err
+	}
+	return memoryMap(path)
 }
 
 // cache wraps an ethash cache with some metadata to allow easier concurrent use.

--- a/eth/config.go
+++ b/eth/config.go
@@ -34,6 +34,7 @@ import (
 // DefaultConfig contains default settings for use on the Ethereum main net.
 var DefaultConfig = Config{
 	SyncMode:             downloader.FastSync,
+	EthashCacheDir:       "ethash",
 	EthashCachesInMem:    2,
 	EthashCachesOnDisk:   3,
 	EthashDatasetsInMem:  1,


### PR DESCRIPTION
Our current ethash memory mapped caches generated the cache in a temp file, then renamed it into its final location. Unfortunately this is forbidden under Windows, as it's not capable of renaming open files opposed to unix systems. The PR changes the logic so that instead of flush/rename, we now do a close/rename/open cycle. It is more costly but I didn't want to add Windows specific logic so low level as ethash.

It also works around https://github.com/ethereum/go-ethereum/issues/3815 . The underlying issue there is that the `mmap-go` library calls flush on the memory map handle, not the file handle. This is an upstream bug, also spotted by someone else (https://github.com/edsrzf/mmap-go/pull/14). However since we close the generated cache down before rename, we don't care that the `Flush` method doesn't work as the OS will flush it on close anyway. 