### PR TITLE
cmd, node: add --nousb and node.Config.NoUSB to disable hw wallets

### DIFF
--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -88,6 +88,7 @@ func init() {
 		utils.BootnodesFlag,
 		utils.DataDirFlag,
 		utils.KeyStoreDirFlag,
+		utils.NoUSBFlag,
 		utils.EthashCacheDirFlag,
 		utils.EthashCachesInMemoryFlag,
 		utils.EthashCachesOnDiskFlag,

--- a/cmd/geth/usage.go
+++ b/cmd/geth/usage.go
@@ -67,6 +67,7 @@ var AppHelpFlagGroups = []flagGroup{
 			configFileFlag,
 			utils.DataDirFlag,
 			utils.KeyStoreDirFlag,
+			utils.NoUSBFlag,
 			utils.NetworkIdFlag,
 			utils.TestNetFlag,
 			utils.DevModeFlag,

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -115,6 +115,10 @@ var (
 		Name:  "keystore",
 		Usage: "Directory for the keystore (default = inside the datadir)",
 	}
+	NoUSBFlag = cli.BoolFlag{
+		Name:  "nousb",
+		Usage: "Disables monitoring for and managine USB hardware wallets",
+	}
 	EthashCacheDirFlag = DirectoryFlag{
 		Name:  "ethash.cachedir",
 		Usage: "Directory to store the ethash verification caches (default = inside the datadir)",
@@ -728,6 +732,9 @@ func SetNodeConfig(ctx *cli.Context, cfg *node.Config) {
 	}
 	if ctx.GlobalIsSet(LightKDFFlag.Name) {
 		cfg.UseLightweightKDF = ctx.GlobalBool(LightKDFFlag.Name)
+	}
+	if ctx.GlobalIsSet(NoUSBFlag.Name) {
+		cfg.NoUSB = ctx.GlobalBool(NoUSBFlag.Name)
 	}
 }
 

--- a/node/config.go
+++ b/node/config.go
@@ -82,6 +82,9 @@ type Config struct {
 	// scrypt KDF at the expense of security.
 	UseLightweightKDF bool `toml:",omitempty"`
 
+	// NoUSB disables hardware wallet monitoring and connectivity.
+	NoUSB bool `toml:",omitempty"`
+
 	// IPCPath is the requested location to place the IPC endpoint. If the path is
 	// a simple file name, it is placed inside the data directory (or on the root
 	// pipe path on Windows), whereas if it's a resolvable path name (absolute or
@@ -389,10 +392,12 @@ func makeAccountManager(conf *Config) (*accounts.Manager, string, error) {
 	backends := []accounts.Backend{
 		keystore.NewKeyStore(keydir, scryptN, scryptP),
 	}
-	if ledgerhub, err := usbwallet.NewLedgerHub(); err != nil {
-		log.Warn(fmt.Sprintf("Failed to start Ledger hub, disabling: %v", err))
-	} else {
-		backends = append(backends, ledgerhub)
+	if !conf.NoUSB {
+		if ledgerhub, err := usbwallet.NewLedgerHub(); err != nil {
+			log.Warn(fmt.Sprintf("Failed to start Ledger hub, disabling: %v", err))
+		} else {
+			backends = append(backends, ledgerhub)
+		}
 	}
 	return accounts.NewManager(backends...), ephemeral, nil
 }


### PR DESCRIPTION
Fixes https://github.com/ethereum/go-ethereum/issues/14355.

Sometimes it might be desirable to disable USB access. Notably currently we auto discover wallets when they are plugged in, and users running multiple geth instances concurrently face issues that the processes "race" for the wallet.

This PR adds a `NoUSB` config field to `node` and a `--nousb` flag that disables looking for hardware wallets.