### PR TITLE
core: make genesis incompatibility error more explicit

### DIFF
--- a/core/genesis.go
+++ b/core/genesis.go
@@ -86,7 +86,7 @@ type GenesisMismatchError struct {
 }
 
 func (e *GenesisMismatchError) Error() string {
-	return fmt.Sprintf("wrong genesis block in database (have %x, new %x)", e.Stored[:8], e.New[:8])
+	return fmt.Sprintf("database already contains an incompatible genesis block (have %x, new %x)", e.Stored[:8], e.New[:8])
 }
 
 // SetupGenesisBlock writes or updates the genesis block in db.


### PR DESCRIPTION
Fixes https://github.com/ethereum/go-ethereum/issues/14352 (and a lot reports about the same thing from gitter).

Previously users were allowed to reinit an already inited chain, overwriting the genesis block (and nothing else). This was deemed dangerous potentially leading to data loss, so starting from Geth 1.6.0 we rejected such attempts with an error message `wrong genesis block in database (have ..., want ...)`. Unfortunately this error message isn't very useful for an end user, as it doesn't really say how to fix the problem.

This PR changes the error message to make it more use friendly by explicitly stating that there's already a genesis block inside the database, and that is not compatible with the one you try to reinit with.