### PR TITLE
cmd/bootnode: stop after generating/writing nodekey

### DIFF
--- a/cmd/bootnode/main.go
+++ b/cmd/bootnode/main.go
@@ -68,6 +68,7 @@ func main() {
 		if err = crypto.SaveECDSA(*genKey, nodeKey); err != nil {
 			utils.Fatalf("%v", err)
 		}
+		return
 	case *nodeKeyFile == "" && *nodeKeyHex == "":
 		utils.Fatalf("Use -nodekey or -nodekeyhex to specify a private key")
 	case *nodeKeyFile != "" && *nodeKeyHex != "":


### PR DESCRIPTION
When bootnode is started with the `genkey` flag it will generate and write a new key to a file and start the bootnode. Expected behaviour is to write the key and stop. The bootnode can than be started with the `nodekey` flag pointing to the keyfile.

Fixes #14371