### PR TITLE
internal/ethapi: return empty arrays instead of null

### DIFF
--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -191,7 +191,7 @@ func NewPublicAccountAPI(am *accounts.Manager) *PublicAccountAPI {
 
 // Accounts returns the collection of accounts this node manages
 func (s *PublicAccountAPI) Accounts() []common.Address {
-	var addresses []common.Address
+	addresses := make([]common.Address, 0)
 	for _, wallet := range s.am.Wallets() {
 		for _, account := range wallet.Accounts() {
 			addresses = append(addresses, account.Address)
@@ -218,7 +218,7 @@ func NewPrivateAccountAPI(b Backend) *PrivateAccountAPI {
 
 // ListAccounts will return a list of addresses for accounts this node manages.
 func (s *PrivateAccountAPI) ListAccounts() []common.Address {
-	var addresses []common.Address
+	addresses := make([]common.Address, 0)
 	for _, wallet := range s.am.Wallets() {
 		for _, account := range wallet.Accounts() {
 			addresses = append(addresses, account.Address)
@@ -237,7 +237,7 @@ type rawWallet struct {
 
 // ListWallets will return a list of wallets this node manages.
 func (s *PrivateAccountAPI) ListWallets() []rawWallet {
-	var wallets []rawWallet
+	wallets := make([]rawWallet, 0)
 	for _, wallet := range s.am.Wallets() {
 		wallets = append(wallets, rawWallet{
 			URL:      wallet.URL().String(),

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -191,7 +191,7 @@ func NewPublicAccountAPI(am *accounts.Manager) *PublicAccountAPI {
 
 // Accounts returns the collection of accounts this node manages
 func (s *PublicAccountAPI) Accounts() []common.Address {
-	addresses := make([]common.Address, 0)
+	addresses := make([]common.Address, 0) // return [] instead of nil if empty
 	for _, wallet := range s.am.Wallets() {
 		for _, account := range wallet.Accounts() {
 			addresses = append(addresses, account.Address)
@@ -218,7 +218,7 @@ func NewPrivateAccountAPI(b Backend) *PrivateAccountAPI {
 
 // ListAccounts will return a list of addresses for accounts this node manages.
 func (s *PrivateAccountAPI) ListAccounts() []common.Address {
-	addresses := make([]common.Address, 0)
+	addresses := make([]common.Address, 0) // return [] instead of nil if empty
 	for _, wallet := range s.am.Wallets() {
 		for _, account := range wallet.Accounts() {
 			addresses = append(addresses, account.Address)
@@ -237,7 +237,7 @@ type rawWallet struct {
 
 // ListWallets will return a list of wallets this node manages.
 func (s *PrivateAccountAPI) ListWallets() []rawWallet {
-	wallets := make([]rawWallet, 0)
+	wallets := make([]rawWallet, 0) // return [] instead of nil if empty
 	for _, wallet := range s.am.Wallets() {
 		wallets = append(wallets, rawWallet{
 			URL:      wallet.URL().String(),


### PR DESCRIPTION
Currently `eth_accounts`, `personal_listAccounts` and `personal_listWallets` return `null` instead of an empty array when there are no accounts/wallets. Convention in these situations is to return an empty array.

Fixes #14365