### PR TITLE
node: fixes deadlock on Wait()

### DIFF
--- a/node/node.go
+++ b/node/node.go
@@ -536,6 +536,7 @@ func (n *Node) Stop() error {
 func (n *Node) Wait() {
 	n.lock.RLock()
 	if n.server == nil {
+		n.lock.RUnlock()
 		return
 	}
 	stop := n.stop


### PR DESCRIPTION
- if server is nil (which happens if you try restarting just started server i.e. we have a race btw call to `Wait()` and `Restart()`), you end up deadlocking (on read lock)
- the fix is trivial - to unlock before returning
- for us the problem occurred in tests (due to nature of the issue - where you restart newly started server), but the race and deadlock are real, hence the PR