### PR TITLE
Proof-of-concept test with maintaining a local map of nonces

### DIFF
--- a/eth/backend.go
+++ b/eth/backend.go
@@ -170,7 +170,7 @@ func New(ctx *node.ServiceContext, config *Config) (*Ethereum, error) {
 	eth.miner.SetGasPrice(config.GasPrice)
 	eth.miner.SetExtra(makeExtraData(config.ExtraData))
 
-	eth.ApiBackend = &EthApiBackend{eth, nil}
+	eth.ApiBackend = &EthApiBackend{eth, nil, make(map[common.Address] uint64)}
 	gpoParams := config.GPO
 	if gpoParams.Default == nil {
 		gpoParams.Default = config.GasPrice

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -330,7 +330,6 @@ func (s *PrivateAccountAPI) SendTransaction(ctx context.Context, args SendTxArgs
 	}
 	// Assemble the transaction and sign with the wallet
 	tx := args.toTransaction()
-
 	var chainID *big.Int
 	if config := s.b.ChainConfig(); config.IsEIP155(s.b.CurrentBlock().Number()) {
 		chainID = config.ChainId
@@ -1183,6 +1182,8 @@ func (s *PublicTransactionPoolAPI) SendTransaction(ctx context.Context, args Sen
 	}
 	// Assemble the transaction and sign with the wallet
 	tx := args.toTransaction()
+
+	log.Info("Assembled transaction", "fullhash", tx.Hash().Hex(), "nonce", tx.Nonce())
 
 	var chainID *big.Int
 	if config := s.b.ChainConfig(); config.IsEIP155(s.b.CurrentBlock().Number()) {


### PR DESCRIPTION
This is a proof-of-concept fix for https://github.com/ethereum/go-ethereum/issues/14375 . It uses a map for maintaining local nonces inside the backend. 
When a tx is submitted without explicit nonce, the implementation checks if the `nonce` returned from the transaction-pool is higher than the `localNonce`. If so, it uses that, otherwise returns the local and increases it. 

More context in the bug. 
__OBS__ This is not production code, just demoes one way to to solve the particular issue of nonce-clashes. There may be other bad consequences of this PR, so perhaps best if some better go-coder than me take it from here. 