### PR TITLE
eth/downloader: fix a potential issue against future refactors

### DIFF
--- a/eth/downloader/downloader.go
+++ b/eth/downloader/downloader.go
@@ -1491,6 +1491,10 @@ func (d *Downloader) qosTuner() {
 func (d *Downloader) qosReduceConfidence() {
 	// If we have a single peer, confidence is always 1
 	peers := uint64(d.peers.Len())
+	if peers == 0 {
+		// Ensure peer connectivity races don't catch us off guard
+		return
+	}
 	if peers == 1 {
 		atomic.StoreUint64(&d.rttConfidence, 1000000)
 		return


### PR DESCRIPTION
The `qosReduceConfidence` method in the downloader is sensitive to the number of peers being zero, potentially doing division by zero. This **cannot** happen in the current code as this method is only ever called after adding a new peer, and every peer has its own thread, so dropping the peer cannot happen while it is being added. Nevertheless it's saner to fix this as a future refactor might not retain this invariant.