### PR TITLE
consensus/ethash: fix a timestamp update race

### DIFF
--- a/consensus/ethash/ethash.go
+++ b/consensus/ethash/ethash.go
@@ -467,8 +467,9 @@ func (ethash *Ethash) cache(block uint64) []uint32 {
 			future = &cache{epoch: epoch + 1}
 			ethash.fcache = future
 		}
+		// New current cache, set its initial timestamp
+		current.used = time.Now()
 	}
-	current.used = time.Now()
 	ethash.lock.Unlock()
 
 	// Wait for generation finish, bump the timestamp and finalize the cache
@@ -529,8 +530,9 @@ func (ethash *Ethash) dataset(block uint64) []uint32 {
 			future = &dataset{epoch: epoch + 1}
 			ethash.fdataset = future
 		}
+		// New current dataset, set its initial timestamp
+		current.used = time.Now()
 	}
-	current.used = time.Now()
 	ethash.lock.Unlock()
 
 	// Wait for generation finish, bump the timestamp and finalize the cache


### PR DESCRIPTION
When generating ethash verification caches and mining datasets, we've retrieved the current epoch's struct and bumped its timestamp, generated it (if unavailable) and bumped its timestamp again.

The first bump was racey as it wasn't protected by a lock. In reality however we don't really want to bump the timestamp before generating the data, only for entities newly created. This PR moves the first timestamp "bump" one nesting deeper, so that it's called only for new caches and datasets, which cannot yet have references outside.

The second bump will handle the case for everything else.