### PR TITLE
consensus/clique: fix overflow on recent signer check around genesis

### DIFF
--- a/consensus/clique/clique.go
+++ b/consensus/clique/clique.go
@@ -599,7 +599,7 @@ func (c *Clique) Seal(chain consensus.ChainReader, block *types.Block, stop <-ch
 	for seen, recent := range snap.Recents {
 		if recent == signer {
 			// Signer is among recents, only wait if the current block doens't shift it out
-			if limit := uint64(len(snap.Signers)/2 + 1); seen > number-limit {
+			if limit := uint64(len(snap.Signers)/2 + 1); number < limit || seen > number-limit {
 				log.Info("Signed recently, must wait for others")
 				<-stop
 				return nil, nil


### PR DESCRIPTION
Fixes https://github.com/ethereum/go-ethereum/issues/14408.

In the `clique` miner, the logic that figured out whether a signer is allowed to sign or not compared the last known block made by the local miner to the `current block - signer threshold` (half of the signers + 1). If the last block was below, we're allowed to sign.

The `current block - signer threshold` however was running on unsigned ints, so if the threshold was for example 2, and the block number 1, the `number - limit` got `maxuint64`, allowing the signer to actually sign the block. Such a block is rejected at remote nodes, but nonetheless was injected into the local miner's chain, causing a later signing failure when it did notice it (too late, already in the chain).

This PR simply adds a second check so that if a signer is among the recent ones, and we have less blocks that the threshold, then always wait for others to sign.