### PR TITLE
cmd/geth, cmd/utils: init/removedb on light/full dbs simultaneously

### DIFF
--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -908,22 +908,16 @@ func SetupNetwork(ctx *cli.Context) {
 	params.TargetGasLimit = new(big.Int).SetUint64(ctx.GlobalUint64(TargetGasLimitFlag.Name))
 }
 
-func ChainDbName(ctx *cli.Context) string {
-	if ctx.GlobalBool(LightModeFlag.Name) {
-		return "lightchaindata"
-	} else {
-		return "chaindata"
-	}
-}
-
 // MakeChainDatabase open an LevelDB using the flags passed to the client and will hard crash if it fails.
 func MakeChainDatabase(ctx *cli.Context, stack *node.Node) ethdb.Database {
 	var (
 		cache   = ctx.GlobalInt(CacheFlag.Name)
 		handles = makeDatabaseHandles()
-		name    = ChainDbName(ctx)
 	)
-
+	name := "chaindata"
+	if ctx.GlobalBool(LightModeFlag.Name) {
+		name = "lightchaindata"
+	}
 	chainDb, err := stack.OpenDatabase(name, cache, handles)
 	if err != nil {
 		Fatalf("Could not open database: %v", err)


### PR DESCRIPTION
We've had a lot of confusion over database initialization when people start playing with light nodes as `geth init` actually inits `chaindata`, requiring the user to explicitly specify `geth --light init` to initialize `lightchaindata`.

This is needlessly confusing as there's no point in initializing only the full database or the light database within a directory to a custom genesis. This PR merges the two inits, so that `geth init` initializes both the light and the full database, irrelevant of command line flags specified.

To keep the PR symmetric, `removedb` also removes both (after user confirmation).