### PR TITLE
Hive-test fixes

### DIFF
--- a/common/math/big.go
+++ b/common/math/big.go
@@ -27,8 +27,8 @@ var (
 	tt256     = BigPow(2, 256)
 	tt256m1   = new(big.Int).Sub(tt256, big.NewInt(1))
 	MaxBig256 = new(big.Int).Set(tt256m1)
-	tt63      = BigPow(2,63)
-	TT63m1    = new(big.Int).Sub(tt63,big.NewInt(1))
+	tt63      = BigPow(2, 63)
+	MaxBig63  = new(big.Int).Sub(tt63, big.NewInt(1))
 )
 
 const (

--- a/common/math/big.go
+++ b/common/math/big.go
@@ -27,6 +27,8 @@ var (
 	tt256     = BigPow(2, 256)
 	tt256m1   = new(big.Int).Sub(tt256, big.NewInt(1))
 	MaxBig256 = new(big.Int).Set(tt256m1)
+	tt63      = BigPow(2,63)
+	TT63m1    = new(big.Int).Sub(tt63,big.NewInt(1))
 )
 
 const (

--- a/consensus/ethash/consensus.go
+++ b/consensus/ethash/consensus.go
@@ -244,12 +244,12 @@ func (ethash *Ethash) verifyHeader(chain consensus.ChainReader, header, parent *
 		return fmt.Errorf("invalid difficulty: have %v, want %v", header.Difficulty, expected)
 	}
 	// Verify that the gas limit is < 2^63-1
-	if header.GasLimit.Cmp(math.TT63m1) > 0{
-		return fmt.Errorf("invalid gasLimit: have %v, max %v", header.GasLimit, math.TT63m1)	
+	if header.GasLimit.Cmp(math.MaxBig63) > 0 {
+		return fmt.Errorf("invalid gasLimit: have %v, max %v", header.GasLimit, math.MaxBig63)
 	}
 	// Verify that the gasUsed is <= gasLimit
-	if header.GasUsed.Cmp(header.GasLimit) > 0{
-		return fmt.Errorf("invalid gasUsed: have %v, gasLimit %v", header.GasUsed, header.GasLimit)			
+	if header.GasUsed.Cmp(header.GasLimit) > 0 {
+		return fmt.Errorf("invalid gasUsed: have %v, gasLimit %v", header.GasUsed, header.GasLimit)
 	}
 
 	// Verify that the gas limit remains within allowed bounds

--- a/consensus/ethash/consensus.go
+++ b/consensus/ethash/consensus.go
@@ -243,7 +243,7 @@ func (ethash *Ethash) verifyHeader(chain consensus.ChainReader, header, parent *
 	if expected.Cmp(header.Difficulty) != 0 {
 		return fmt.Errorf("invalid difficulty: have %v, want %v", header.Difficulty, expected)
 	}
-	// Verify that the gas limit is < 2^63-1
+	// Verify that the gas limit is <= 2^63-1
 	if header.GasLimit.Cmp(math.MaxBig63) > 0 {
 		return fmt.Errorf("invalid gasLimit: have %v, max %v", header.GasLimit, math.MaxBig63)
 	}

--- a/consensus/ethash/consensus.go
+++ b/consensus/ethash/consensus.go
@@ -243,9 +243,13 @@ func (ethash *Ethash) verifyHeader(chain consensus.ChainReader, header, parent *
 	if expected.Cmp(header.Difficulty) != 0 {
 		return fmt.Errorf("invalid difficulty: have %v, want %v", header.Difficulty, expected)
 	}
-	// Verify that the gas limit is < 2^63
+	// Verify that the gas limit is < 2^63-1
 	if header.GasLimit.Cmp(math.TT63m1) > 0{
 		return fmt.Errorf("invalid gasLimit: have %v, max %v", header.GasLimit, math.TT63m1)	
+	}
+	// Verify that the gasUsed is <= gasLimit
+	if header.GasUsed.Cmp(header.GasLimit) > 0{
+		return fmt.Errorf("invalid gasUsed: have %v, gasLimit %v", header.GasUsed, header.GasLimit)			
 	}
 
 	// Verify that the gas limit remains within allowed bounds

--- a/consensus/ethash/consensus.go
+++ b/consensus/ethash/consensus.go
@@ -243,6 +243,11 @@ func (ethash *Ethash) verifyHeader(chain consensus.ChainReader, header, parent *
 	if expected.Cmp(header.Difficulty) != 0 {
 		return fmt.Errorf("invalid difficulty: have %v, want %v", header.Difficulty, expected)
 	}
+	// Verify that the gas limit is < 2^63
+	if header.GasLimit.Cmp(math.TT63m1) > 0{
+		return fmt.Errorf("invalid gasLimit: have %v, max %v", header.GasLimit, math.TT63m1)	
+	}
+
 	// Verify that the gas limit remains within allowed bounds
 	diff := new(big.Int).Set(parent.GasLimit)
 	diff = diff.Sub(diff, header.GasLimit)


### PR DESCRIPTION
This fixes a couple of issues which show up on hive testing. 

* Checking gasLimit below `2^63-1`
* Checking `gasUsed < gasLimit`. This is already implicitly done for canon blocks, but need to be explicitly checked for uncles. 