### PR TITLE
travis: adapt build script to new travis VM settings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -147,7 +147,7 @@ matrix:
         - go run build/ci.go archive -type tar -signer OSX_SIGNING_KEY -upload gethstore/builds
 
         # Build the iOS framework and upload it to CocoaPods and Azure
-        - gem uninstall cocoapods -a
+        - gem uninstall cocoapods -a -x
         - gem install cocoapods
 
         - mv ~/.cocoapods/repos/master ~/.cocoapods/repos/master.bak


### PR DESCRIPTION
Travis updated their build images last week. This apparently broke out cocoapods builder as now it waits for user conformation to remove old pod executables https://travis-ci.org/ethereum/go-ethereum/jobs/229660005#L296, timing out after 10 minutes.

This PR adds a `gem-x` flag that tells it to automatically remove unused executables too without requiring user confirmation. I'm unsure if this is enough of there will be further surprises, but we have to get past this error first. 