### PR TITLE
core: fix processing regression during receipt import

### DIFF
--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -665,10 +665,11 @@ func SetReceiptsData(config *params.ChainConfig, block *types.Block, receipts ty
 		// The transaction hash can be retrieved from the transaction itself
 		receipts[j].TxHash = transactions[j].Hash()
 
-		tx, _ := transactions[j].AsMessage(signer)
 		// The contract address can be derived from the transaction itself
-		if MessageCreatesContract(tx) {
-			receipts[j].ContractAddress = crypto.CreateAddress(tx.From(), tx.Nonce())
+		if transactions[j].To() == nil {
+			// Deriving the signer is expensive, only do if it's actually needed
+			from, _ := types.Sender(signer, transactions[j])
+			receipts[j].ContractAddress = crypto.CreateAddress(from, transactions[j].Nonce())
 		}
 		// The used gas can be calculated based on previous receipts
 		if j == 0 {

--- a/core/state_transition.go
+++ b/core/state_transition.go
@@ -78,10 +78,6 @@ type Message interface {
 	Data() []byte
 }
 
-func MessageCreatesContract(msg Message) bool {
-	return msg.To() == nil
-}
-
 // IntrinsicGas computes the 'intrinsic gas' for a message
 // with the given data.
 //
@@ -220,7 +216,7 @@ func (self *StateTransition) TransitionDb() (ret []byte, requiredGas, usedGas *b
 	sender := self.from() // err checked in preCheck
 
 	homestead := self.evm.ChainConfig().IsHomestead(self.evm.BlockNumber)
-	contractCreation := MessageCreatesContract(msg)
+	contractCreation := msg.To() == nil
 	// Pay intrinsic gas
 	// TODO convert to uint64
 	intrinsicGas := IntrinsicGas(self.data, contractCreation, homestead)


### PR DESCRIPTION
While implementing EIP155 a regression was made into the fast sync code that caused all transactions' signers to be `ecrecover`-ed, even though we only need it to validate contract deployments. Doing that for heavy blocks however causes significant import resource increases. This PR fixes it by only deriving the sender if it's actually needed.