### PR TITLE
Rewrite templates for (sub)commands help section

### DIFF
--- a/cmd/geth/consolecmd.go
+++ b/cmd/geth/consolecmd.go
@@ -30,9 +30,7 @@ import (
 
 var (
 	consoleFlags = []cli.Flag{utils.JSpathFlag, utils.ExecFlag, utils.PreloadJSFlag}
-)
 
-var (
 	consoleCommand = cli.Command{
 		Action:   utils.MigrateFlags(localConsole),
 		Name:     "console",

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -56,6 +56,19 @@ import (
 	"gopkg.in/urfave/cli.v1"
 )
 
+var (
+	CommandHelpTemplate = `{{.cmd.Name}}{{if .cmd.Subcommands}} command{{end}}{{if .cmd.Flags}} [command options]{{end}} [arguments...]
+{{if .cmd.Description}}{{.cmd.Description}}
+{{end}}{{if .cmd.Subcommands}}
+SUBCOMMANDS:
+	{{range .cmd.Subcommands}}{{.cmd.Name}}{{with .cmd.ShortName}}, {{.cmd}}{{end}}{{ "\t" }}{{.cmd.Usage}}
+	{{end}}{{end}}{{if .categorizedFlags}}
+{{range $idx, $categorized := .categorizedFlags}}{{$categorized.Name}} OPTIONS:
+{{range $categorized.Flags}}{{"\t"}}{{.}}
+{{end}}
+{{end}}{{end}}`
+)
+
 func init() {
 	cli.AppHelpTemplate = `{{.Name}} {{if .Flags}}[global options] {{end}}command{{if .Flags}} [command options]{{end}} [arguments...]
 
@@ -70,16 +83,7 @@ GLOBAL OPTIONS:
    {{end}}{{end}}
 `
 
-	cli.CommandHelpTemplate = `{{.Name}}{{if .Subcommands}} command{{end}}{{if .Flags}} [command options]{{end}} [arguments...]
-{{if .Description}}{{.Description}}
-{{end}}{{if .Subcommands}}
-SUBCOMMANDS:
-	{{range .Subcommands}}{{.Name}}{{with .ShortName}}, {{.}}{{end}}{{ "\t" }}{{.Usage}}
-	{{end}}{{end}}{{if .Flags}}
-OPTIONS:
-	{{range .Flags}}{{.}}
-	{{end}}{{end}}
-`
+	cli.CommandHelpTemplate = CommandHelpTemplate
 }
 
 // NewApp creates an app with sane defaults.


### PR DESCRIPTION
With the new command line flag structure the help section of the command and subcommands wasn't pretty. This PR rewrites the help template that it prints a pretty overview of available flags for a particular command/subcommand.

It also adds a run command. When we drop support for the old style flags it becomes impossible to run geth without a command because that would require global flags. In a similar way just running git without commands doesn't not work. The run command replaces the default action and runs geth in a headless mode.