### PR TITLE
eth/downloader: separate state sync from queue

### DIFF
--- a/core/state/sync.go
+++ b/core/state/sync.go
@@ -59,10 +59,16 @@ func (s *StateSync) Missing(max int) []common.Hash {
 }
 
 // Process injects a batch of retrieved trie nodes data, returning if something
-// was committed to the database and also the index of an entry if processing of
+// was committed to the memcache and also the index of an entry if processing of
 // it failed.
-func (s *StateSync) Process(list []trie.SyncResult, dbw trie.DatabaseWriter) (bool, int, error) {
-	return (*trie.TrieSync)(s).Process(list, dbw)
+func (s *StateSync) Process(list []trie.SyncResult) (bool, int, error) {
+	return (*trie.TrieSync)(s).Process(list)
+}
+
+// Commit flushes the data stored in the internal memcache out to persistent
+// storage, returning th enumber of items written and any occurred error.
+func (s *StateSync) Commit(dbw trie.DatabaseWriter) (int, error) {
+	return (*trie.TrieSync)(s).Commit(dbw)
 }
 
 // Pending returns the number of state entries currently pending for download.

--- a/core/state/sync_test.go
+++ b/core/state/sync_test.go
@@ -138,8 +138,11 @@ func testIterativeStateSync(t *testing.T, batch int) {
 			}
 			results[i] = trie.SyncResult{Hash: hash, Data: data}
 		}
-		if _, index, err := sched.Process(results, dstDb); err != nil {
+		if _, index, err := sched.Process(results); err != nil {
 			t.Fatalf("failed to process result #%d: %v", index, err)
+		}
+		if index, err := sched.Commit(dstDb); err != nil {
+			t.Fatalf("failed to commit data #%d: %v", index, err)
 		}
 		queue = append(queue[:0], sched.Missing(batch)...)
 	}
@@ -168,8 +171,11 @@ func TestIterativeDelayedStateSync(t *testing.T) {
 			}
 			results[i] = trie.SyncResult{Hash: hash, Data: data}
 		}
-		if _, index, err := sched.Process(results, dstDb); err != nil {
+		if _, index, err := sched.Process(results); err != nil {
 			t.Fatalf("failed to process result #%d: %v", index, err)
+		}
+		if index, err := sched.Commit(dstDb); err != nil {
+			t.Fatalf("failed to commit data #%d: %v", index, err)
 		}
 		queue = append(queue[len(results):], sched.Missing(0)...)
 	}
@@ -206,8 +212,11 @@ func testIterativeRandomStateSync(t *testing.T, batch int) {
 			results = append(results, trie.SyncResult{Hash: hash, Data: data})
 		}
 		// Feed the retrieved results back and queue new tasks
-		if _, index, err := sched.Process(results, dstDb); err != nil {
+		if _, index, err := sched.Process(results); err != nil {
 			t.Fatalf("failed to process result #%d: %v", index, err)
+		}
+		if index, err := sched.Commit(dstDb); err != nil {
+			t.Fatalf("failed to commit data #%d: %v", index, err)
 		}
 		queue = make(map[common.Hash]struct{})
 		for _, hash := range sched.Missing(batch) {
@@ -249,8 +258,11 @@ func TestIterativeRandomDelayedStateSync(t *testing.T) {
 			}
 		}
 		// Feed the retrieved results back and queue new tasks
-		if _, index, err := sched.Process(results, dstDb); err != nil {
+		if _, index, err := sched.Process(results); err != nil {
 			t.Fatalf("failed to process result #%d: %v", index, err)
+		}
+		if index, err := sched.Commit(dstDb); err != nil {
+			t.Fatalf("failed to commit data #%d: %v", index, err)
 		}
 		for _, hash := range sched.Missing(0) {
 			queue[hash] = struct{}{}
@@ -283,8 +295,11 @@ func TestIncompleteStateSync(t *testing.T) {
 			results[i] = trie.SyncResult{Hash: hash, Data: data}
 		}
 		// Process each of the state nodes
-		if _, index, err := sched.Process(results, dstDb); err != nil {
+		if _, index, err := sched.Process(results); err != nil {
 			t.Fatalf("failed to process result #%d: %v", index, err)
+		}
+		if index, err := sched.Commit(dstDb); err != nil {
+			t.Fatalf("failed to commit data #%d: %v", index, err)
 		}
 		for _, result := range results {
 			added = append(added, result.Hash)

--- a/eth/downloader/downloader.go
+++ b/eth/downloader/downloader.go
@@ -450,7 +450,7 @@ func (d *Downloader) syncWithPeer(p *peer, hash common.Hash, td *big.Int) (err e
 	}
 	if d.mode == FastSync {
 		fetchers = append(fetchers, func() error { return d.processFastSyncContent(latest) })
-	} else {
+	} else if d.mode == FullSync {
 		fetchers = append(fetchers, d.processFullSyncContent)
 	}
 	err = d.spawnSync(fetchers)

--- a/eth/downloader/downloader.go
+++ b/eth/downloader/downloader.go
@@ -1293,8 +1293,7 @@ func (d *Downloader) processHeaders(origin uint64, td *big.Int) error {
 	}
 }
 
-// processBlocks takes fetch results from the queue and tries to import them
-// into the chain.
+// processFullSyncContent takes fetch results from the queue and imports them into the chain.
 func (d *Downloader) processFullSyncContent() error {
 	for {
 		results := d.queue.WaitResults()
@@ -1339,6 +1338,8 @@ func (d *Downloader) importBlockResults(results []*fetchResult) error {
 	return nil
 }
 
+// processFastSyncContent takes fetch results from the queue and writes them to the
+// database. It also controls the synchronisation of state nodes of the pivot block.
 func (d *Downloader) processFastSyncContent(latest *types.Header) error {
 	// Start syncing state of the reported head block.
 	// This should get us most of the state of the pivot block.

--- a/eth/downloader/downloader.go
+++ b/eth/downloader/downloader.go
@@ -233,8 +233,8 @@ func (d *Downloader) Progress() ethereum.SyncProgress {
 		StartingBlock: d.syncStatsChainOrigin,
 		CurrentBlock:  current,
 		HighestBlock:  d.syncStatsChainHeight,
-		PulledStates:  d.syncStatsState.done,
-		KnownStates:   d.syncStatsState.done + d.syncStatsState.pending,
+		PulledStates:  d.syncStatsState.processed,
+		KnownStates:   d.syncStatsState.processed + d.syncStatsState.pending,
 	}
 }
 

--- a/eth/downloader/downloader.go
+++ b/eth/downloader/downloader.go
@@ -428,7 +428,7 @@ func (d *Downloader) syncWithPeer(p *peer, hash common.Hash, td *big.Int) (err e
 			pivot = d.fsPivotLock.Number.Uint64()
 		}
 		// If the point is below the origin, move origin back to ensure state download
-		if pivot <= origin {
+		if pivot < origin {
 			if pivot > 0 {
 				origin = pivot - 1
 			} else {
@@ -442,18 +442,28 @@ func (d *Downloader) syncWithPeer(p *peer, hash common.Hash, td *big.Int) (err e
 		d.syncInitHook(origin, height)
 	}
 
-	return d.spawnSync(origin+1,
-		func() error { return d.fetchHeaders(p, origin+1) },    // Headers are always retrieved
-		func() error { return d.fetchBodies(origin + 1) },      // Bodies are retrieved during normal and fast sync
-		func() error { return d.fetchReceipts(origin + 1) },    // Receipts are retrieved during fast sync
-		func() error { return d.processHeaders(origin+1, td) }, // Headers are always retrieved
-		func() error { return d.processContent(latest) },
-	)
+	fetchers := []func() error{
+		func() error { return d.fetchHeaders(p, origin+1) }, // Headers are always retrieved
+		func() error { return d.fetchBodies(origin + 1) },   // Bodies are retrieved during normal and fast sync
+		func() error { return d.fetchReceipts(origin + 1) }, // Receipts are retrieved during fast sync
+		func() error { return d.processHeaders(origin+1, td) },
+	}
+	if d.mode == FastSync {
+		fetchers = append(fetchers, func() error { return d.processFastSyncContent(latest) })
+	} else {
+		fetchers = append(fetchers, d.processFullSyncContent)
+	}
+	err = d.spawnSync(fetchers)
+	if err != nil && d.mode == FastSync && d.fsPivotLock != nil {
+		// If sync failed in the critical section, bump the fail counter.
+		atomic.AddUint32(&d.fsPivotFails, 1)
+	}
+	return err
 }
 
 // spawnSync runs d.process and all given fetcher functions to completion in
 // separate goroutines, returning the first error that appears.
-func (d *Downloader) spawnSync(origin uint64, fetchers ...func() error) error {
+func (d *Downloader) spawnSync(fetchers []func() error) error {
 	var wg sync.WaitGroup
 	errc := make(chan error, len(fetchers))
 	wg.Add(len(fetchers))
@@ -477,11 +487,6 @@ func (d *Downloader) spawnSync(origin uint64, fetchers ...func() error) error {
 	d.queue.Close()
 	d.Cancel()
 	wg.Wait()
-
-	// If sync failed in the critical section, bump the fail counter
-	if err != nil && d.mode == FastSync && d.fsPivotLock != nil {
-		atomic.AddUint32(&d.fsPivotFails, 1)
-	}
 	return err
 }
 
@@ -1288,103 +1293,150 @@ func (d *Downloader) processHeaders(origin uint64, td *big.Int) error {
 	}
 }
 
-// processContent takes fetch results from the queue and tries to import them
-// into the chain. The type of import operation will depend on the result contents.
-func (d *Downloader) processContent(head *types.Header) error {
-	var stateSync *stateSync
-	if d.mode == FastSync {
-		// Start syncing state of the reported head block.
-		// This should get us most of the state of the pivot block.
-		stateSync = d.syncState(head.Root)
-		defer stateSync.Cancel()
-		go func() {
-			if err := stateSync.wait(); err != nil {
-				d.queue.Close() // wake up WaitResults
-			}
-		}()
-	}
-
-	pivot := d.queue.FastSyncPivot()
+// processBlocks takes fetch results from the queue and tries to import them
+// into the chain.
+func (d *Downloader) processFullSyncContent() error {
 	for {
 		results := d.queue.WaitResults()
 		if len(results) == 0 {
-			if stateSync != nil {
-				return stateSync.Cancel()
-			}
 			return nil
 		}
 		if d.chainInsertHook != nil {
 			d.chainInsertHook(results)
 		}
-		// Actually import the blocks
-		first, last := results[0].Header, results[len(results)-1].Header
-		log.Debug("Inserting downloaded chain", "items", len(results),
-			"firstnum", first.Number, "firsthash", first.Hash(),
-			"lastnum", last.Number, "lasthash", last.Hash(),
-		)
-		for len(results) != 0 {
-			// Check for any termination requests
-			select {
-			case <-d.quitCh:
-				return errCancelContentProcessing
-			default:
-			}
-			if stateSync != nil {
-				if _, err := stateSync.checkDone(); err != nil {
-					return err
-				}
-			}
-			// Retrieve the a batch of results to import
-			var (
-				blocks   = make([]*types.Block, 0, maxResultsProcess)
-				receipts = make([]types.Receipts, 0, maxResultsProcess)
-			)
-			items := int(math.Min(float64(len(results)), float64(maxResultsProcess)))
-			for _, result := range results[:items] {
-				switch {
-				case d.mode == FullSync:
-					blocks = append(blocks, types.NewBlockWithHeader(result.Header).WithBody(result.Transactions, result.Uncles))
-				case d.mode == FastSync:
-					blocks = append(blocks, types.NewBlockWithHeader(result.Header).WithBody(result.Transactions, result.Uncles))
-					if result.Header.Number.Uint64() <= pivot {
-						receipts = append(receipts, result.Receipts)
-					}
-				}
-			}
-			// Try to process the results, aborting if there's an error
-			var (
-				err   error
-				index int
-			)
-			switch {
-			case len(receipts) > 0:
-				index, err = d.insertReceipts(blocks, receipts)
-				if err == nil && blocks[len(blocks)-1].NumberU64() == pivot {
-					index = len(blocks) - 1
-					stateSync.Cancel()
-					err = d.commitPivotBlock(blocks[len(blocks)-1])
-				}
-			default:
-				index, err = d.insertBlocks(blocks)
-			}
-			if err != nil {
-				log.Debug("Downloaded item processing failed", "number", results[index].Header.Number, "hash", results[index].Header.Hash(), "err", err)
-				return errInvalidChain
-			}
-			// Shift the results to the next batch
-			results = results[items:]
+		if err := d.importBlockResults(results); err != nil {
+			return err
 		}
 	}
 }
 
-func (d *Downloader) commitPivotBlock(block *types.Block) error {
+func (d *Downloader) importBlockResults(results []*fetchResult) error {
+	for len(results) != 0 {
+		// Check for any termination requests. This makes clean shutdown faster.
+		select {
+		case <-d.quitCh:
+			return errCancelContentProcessing
+		default:
+		}
+		// Retrieve the a batch of results to import
+		items := int(math.Min(float64(len(results)), float64(maxResultsProcess)))
+		first, last := results[0].Header, results[items-1].Header
+		log.Debug("Inserting downloaded chain", "items", len(results),
+			"firstnum", first.Number, "firsthash", first.Hash(),
+			"lastnum", last.Number, "lasthash", last.Hash(),
+		)
+		blocks := make([]*types.Block, items)
+		for i, result := range results[:items] {
+			blocks[i] = types.NewBlockWithHeader(result.Header).WithBody(result.Transactions, result.Uncles)
+		}
+		if index, err := d.insertBlocks(blocks); err != nil {
+			log.Debug("Downloaded item processing failed", "number", results[index].Header.Number, "hash", results[index].Header.Hash(), "err", err)
+			return errInvalidChain
+		}
+		// Shift the results to the next batch
+		results = results[items:]
+	}
+	return nil
+}
+
+func (d *Downloader) processFastSyncContent(latest *types.Header) error {
+	// Start syncing state of the reported head block.
+	// This should get us most of the state of the pivot block.
+	stateSync := d.syncState(latest.Root)
+	defer stateSync.Cancel()
+	go func() {
+		if err := stateSync.Wait(); err != nil {
+			d.queue.Close() // wake up WaitResults
+		}
+	}()
+
+	pivot := d.queue.FastSyncPivot()
+	for {
+		results := d.queue.WaitResults()
+		if len(results) == 0 {
+			return stateSync.Cancel()
+		}
+		if d.chainInsertHook != nil {
+			d.chainInsertHook(results)
+		}
+		P, beforeP, afterP := splitAroundPivot(pivot, results)
+		if err := d.commitFastSyncData(beforeP, stateSync); err != nil {
+			return err
+		}
+		if P != nil {
+			stateSync.Cancel()
+			if err := d.commitPivotBlock(P); err != nil {
+				return err
+			}
+		}
+		if err := d.importBlockResults(afterP); err != nil {
+			return err
+		}
+	}
+}
+
+func splitAroundPivot(pivot uint64, results []*fetchResult) (p *fetchResult, before, after []*fetchResult) {
+	for _, result := range results {
+		num := result.Header.Number.Uint64()
+		switch {
+		case num < pivot:
+			before = append(before, result)
+		case num == pivot:
+			p = result
+		default:
+			after = append(after, result)
+		}
+	}
+	return p, before, after
+}
+
+func (d *Downloader) commitFastSyncData(results []*fetchResult, stateSync *stateSync) error {
+	for len(results) != 0 {
+		// Check for any termination requests.
+		select {
+		case <-d.quitCh:
+			return errCancelContentProcessing
+		case <-stateSync.done:
+			if err := stateSync.Wait(); err != nil {
+				return err
+			}
+		default:
+		}
+		// Retrieve the a batch of results to import
+		items := int(math.Min(float64(len(results)), float64(maxResultsProcess)))
+		first, last := results[0].Header, results[items-1].Header
+		log.Debug("Inserting fast-sync blocks", "items", len(results),
+			"firstnum", first.Number, "firsthash", first.Hash(),
+			"lastnumn", last.Number, "lasthash", last.Hash(),
+		)
+		blocks := make([]*types.Block, items)
+		receipts := make([]types.Receipts, items)
+		for i, result := range results[:items] {
+			blocks[i] = types.NewBlockWithHeader(result.Header).WithBody(result.Transactions, result.Uncles)
+			receipts[i] = result.Receipts
+		}
+		if index, err := d.insertReceipts(blocks, receipts); err != nil {
+			log.Debug("Downloaded item processing failed", "number", results[index].Header.Number, "hash", results[index].Header.Hash(), "err", err)
+			return errInvalidChain
+		}
+		// Shift the results to the next batch
+		results = results[items:]
+	}
+	return nil
+}
+
+func (d *Downloader) commitPivotBlock(result *fetchResult) error {
+	b := types.NewBlockWithHeader(result.Header).WithBody(result.Transactions, result.Uncles)
 	// Sync the pivot block state. This should complete reasonably quickly because
 	// we've already synced up to the reported head block state earlier.
-	if err := d.syncState(block.Root()).wait(); err != nil {
+	if err := d.syncState(b.Root()).Wait(); err != nil {
 		return err
 	}
-	log.Debug("Committing block as new head", "number", block.Number(), "hash", block.Hash())
-	return d.commitHeadBlock(block.Hash())
+	log.Debug("Committing fast sync pivot as new head", "number", b.Number(), "hash", b.Hash())
+	if _, err := d.insertReceipts([]*types.Block{b}, []types.Receipts{result.Receipts}); err != nil {
+		return err
+	}
+	return d.commitHeadBlock(b.Hash())
 }
 
 // DeliverHeaders injects a new batch of block headers received from a remote

--- a/eth/downloader/metrics.go
+++ b/eth/downloader/metrics.go
@@ -38,8 +38,6 @@ var (
 	receiptDropMeter    = metrics.NewMeter("eth/downloader/receipts/drop")
 	receiptTimeoutMeter = metrics.NewMeter("eth/downloader/receipts/timeout")
 
-	stateInMeter      = metrics.NewMeter("eth/downloader/states/in")
-	stateReqTimer     = metrics.NewTimer("eth/downloader/states/req")
-	stateDropMeter    = metrics.NewMeter("eth/downloader/states/drop")
-	stateTimeoutMeter = metrics.NewMeter("eth/downloader/states/timeout")
+	stateInMeter   = metrics.NewMeter("eth/downloader/states/in")
+	stateDropMeter = metrics.NewMeter("eth/downloader/states/drop")
 )

--- a/eth/downloader/peer.go
+++ b/eth/downloader/peer.go
@@ -30,6 +30,7 @@ import (
 	"time"
 
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/event"
 	"github.com/ethereum/go-ethereum/log"
 )
 
@@ -195,7 +196,7 @@ func (p *peer) FetchReceipts(request *fetchRequest) error {
 }
 
 // FetchNodeData sends a node state data retrieval request to the remote peer.
-func (p *peer) FetchNodeData(request *fetchRequest) error {
+func (p *peer) FetchNodeData(hashes []common.Hash) error {
 	// Sanity check the protocol version
 	if p.version < 63 {
 		panic(fmt.Sprintf("node data fetch [eth/63+] requested on eth/%d", p.version))
@@ -205,14 +206,7 @@ func (p *peer) FetchNodeData(request *fetchRequest) error {
 		return errAlreadyFetching
 	}
 	p.stateStarted = time.Now()
-
-	// Convert the hash set to a retrievable slice
-	hashes := make([]common.Hash, 0, len(request.Hashes))
-	for hash := range request.Hashes {
-		hashes = append(hashes, hash)
-	}
 	go p.getNodeData(hashes)
-
 	return nil
 }
 
@@ -343,8 +337,9 @@ func (p *peer) Lacks(hash common.Hash) bool {
 // peerSet represents the collection of active peer participating in the chain
 // download procedure.
 type peerSet struct {
-	peers map[string]*peer
-	lock  sync.RWMutex
+	peers       map[string]*peer
+	newPeerFeed event.Feed
+	lock        sync.RWMutex
 }
 
 // newPeerSet creates a new peer set top track the active download sources.
@@ -352,6 +347,10 @@ func newPeerSet() *peerSet {
 	return &peerSet{
 		peers: make(map[string]*peer),
 	}
+}
+
+func (ps *peerSet) SubscribeNewPeers(ch chan<- *peer) event.Subscription {
+	return ps.newPeerFeed.Subscribe(ch)
 }
 
 // Reset iterates over the current peer set, and resets each of the known peers
@@ -377,9 +376,8 @@ func (ps *peerSet) Register(p *peer) error {
 
 	// Register the new peer with some meaningful defaults
 	ps.lock.Lock()
-	defer ps.lock.Unlock()
-
 	if _, ok := ps.peers[p.id]; ok {
+		ps.lock.Unlock()
 		return errAlreadyRegistered
 	}
 	if len(ps.peers) > 0 {
@@ -399,6 +397,9 @@ func (ps *peerSet) Register(p *peer) error {
 		p.stateThroughput /= float64(len(ps.peers))
 	}
 	ps.peers[p.id] = p
+	ps.lock.Unlock()
+
+	ps.newPeerFeed.Send(p)
 	return nil
 }
 

--- a/eth/downloader/queue.go
+++ b/eth/downloader/queue.go
@@ -377,25 +377,15 @@ func (q *queue) countProcessableItems() int {
 		if result == nil || result.Pending > 0 {
 			return i
 		}
-		// Special handling for the fast-sync pivot block:
-		if q.mode == FastSync {
-			bnum := result.Header.Number.Uint64()
-			if bnum == q.fastSyncPivot {
-				// Stop before processing the pivot block to ensure that
-				// resultCache has space for fsHeaderForceVerify items. Not
-				// doing this could leave us unable to download the required
-				// amount of headers.
-				for j := 0; j < fsHeaderForceVerify; j++ {
-					if i+j+1 >= len(q.resultCache) || q.resultCache[i+j+1] == nil {
-						return i
-					}
+		// Stop before processing the pivot block to ensure that
+		// resultCache has space for fsHeaderForceVerify items. Not
+		// doing this could leave us unable to download the required
+		// amount of headers.
+		if q.mode == FastSync && result.Header.Number.Uint64() == q.fastSyncPivot {
+			for j := 0; j < fsHeaderForceVerify; j++ {
+				if i+j+1 >= len(q.resultCache) || q.resultCache[i+j+1] == nil {
+					return i
 				}
-			}
-			// If we're just the after fast sync pivot, stop as well
-			// because the following batch needs different insertion.
-			// This simplifies handling the switchover in d.processContent.
-			if bnum == q.fastSyncPivot+1 && i > 0 {
-				return i
 			}
 		}
 	}

--- a/eth/downloader/queue.go
+++ b/eth/downloader/queue.go
@@ -26,12 +26,8 @@ import (
 	"time"
 
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/core/state"
 	"github.com/ethereum/go-ethereum/core/types"
-	"github.com/ethereum/go-ethereum/crypto"
-	"github.com/ethereum/go-ethereum/ethdb"
 	"github.com/ethereum/go-ethereum/log"
-	"github.com/ethereum/go-ethereum/trie"
 	"github.com/rcrowley/go-metrics"
 	"gopkg.in/karalabe/cookiejar.v2/collections/prque"
 )
@@ -94,15 +90,6 @@ type queue struct {
 	receiptPendPool  map[string]*fetchRequest      // [eth/63] Currently pending receipt retrieval operations
 	receiptDonePool  map[common.Hash]struct{}      // [eth/63] Set of the completed receipt fetches
 
-	stateTaskIndex int                      // [eth/63] Counter indexing the added hashes to ensure prioritised retrieval order
-	stateTaskPool  map[common.Hash]int      // [eth/63] Pending node data retrieval tasks, mapping to their priority
-	stateTaskQueue *prque.Prque             // [eth/63] Priority queue of the hashes to fetch the node data for
-	statePendPool  map[string]*fetchRequest // [eth/63] Currently pending node data retrieval operations
-
-	stateDatabase  ethdb.Database   // [eth/63] Trie database to populate during state reassembly
-	stateScheduler *state.StateSync // [eth/63] State trie synchronisation scheduler and integrator
-	stateWriters   int              // [eth/63] Number of running state DB writer goroutines
-
 	resultCache  []*fetchResult // Downloaded but not yet delivered fetch results
 	resultOffset uint64         // Offset of the first cached fetch result in the block chain
 
@@ -112,7 +99,7 @@ type queue struct {
 }
 
 // newQueue creates a new download queue for scheduling block retrieval.
-func newQueue(stateDb ethdb.Database) *queue {
+func newQueue() *queue {
 	lock := new(sync.Mutex)
 	return &queue{
 		headerPendPool:   make(map[string]*fetchRequest),
@@ -125,10 +112,6 @@ func newQueue(stateDb ethdb.Database) *queue {
 		receiptTaskQueue: prque.New(),
 		receiptPendPool:  make(map[string]*fetchRequest),
 		receiptDonePool:  make(map[common.Hash]struct{}),
-		stateTaskPool:    make(map[common.Hash]int),
-		stateTaskQueue:   prque.New(),
-		statePendPool:    make(map[string]*fetchRequest),
-		stateDatabase:    stateDb,
 		resultCache:      make([]*fetchResult, blockCacheLimit),
 		active:           sync.NewCond(lock),
 		lock:             lock,
@@ -157,12 +140,6 @@ func (q *queue) Reset() {
 	q.receiptTaskQueue.Reset()
 	q.receiptPendPool = make(map[string]*fetchRequest)
 	q.receiptDonePool = make(map[common.Hash]struct{})
-
-	q.stateTaskIndex = 0
-	q.stateTaskPool = make(map[common.Hash]int)
-	q.stateTaskQueue.Reset()
-	q.statePendPool = make(map[string]*fetchRequest)
-	q.stateScheduler = nil
 
 	q.resultCache = make([]*fetchResult, blockCacheLimit)
 	q.resultOffset = 0
@@ -201,28 +178,6 @@ func (q *queue) PendingReceipts() int {
 	return q.receiptTaskQueue.Size()
 }
 
-// PendingNodeData retrieves the number of node data entries pending for retrieval.
-func (q *queue) PendingNodeData() int {
-	q.lock.Lock()
-	defer q.lock.Unlock()
-
-	return q.pendingNodeDataLocked()
-}
-
-// pendingNodeDataLocked retrieves the number of node data entries pending for retrieval.
-// The caller must hold q.lock.
-func (q *queue) pendingNodeDataLocked() int {
-	var n int
-	if q.stateScheduler != nil {
-		n = q.stateScheduler.Pending()
-	}
-	// Ensure that PendingNodeData doesn't return 0 until all state is written.
-	if q.stateWriters > 0 {
-		n++
-	}
-	return n
-}
-
 // InFlightHeaders retrieves whether there are header fetch requests currently
 // in flight.
 func (q *queue) InFlightHeaders() bool {
@@ -250,28 +205,15 @@ func (q *queue) InFlightReceipts() bool {
 	return len(q.receiptPendPool) > 0
 }
 
-// InFlightNodeData retrieves whether there are node data entry fetch requests
-// currently in flight.
-func (q *queue) InFlightNodeData() bool {
-	q.lock.Lock()
-	defer q.lock.Unlock()
-
-	return len(q.statePendPool)+q.stateWriters > 0
-}
-
-// Idle returns if the queue is fully idle or has some data still inside. This
-// method is used by the tester to detect termination events.
+// Idle returns if the queue is fully idle or has some data still inside.
 func (q *queue) Idle() bool {
 	q.lock.Lock()
 	defer q.lock.Unlock()
 
-	queued := q.blockTaskQueue.Size() + q.receiptTaskQueue.Size() + q.stateTaskQueue.Size()
-	pending := len(q.blockPendPool) + len(q.receiptPendPool) + len(q.statePendPool)
+	queued := q.blockTaskQueue.Size() + q.receiptTaskQueue.Size()
+	pending := len(q.blockPendPool) + len(q.receiptPendPool)
 	cached := len(q.blockDonePool) + len(q.receiptDonePool)
 
-	if q.stateScheduler != nil {
-		queued += q.stateScheduler.Pending()
-	}
 	return (queued + pending + cached) == 0
 }
 
@@ -389,19 +331,6 @@ func (q *queue) Schedule(headers []*types.Header, from uint64) []*types.Header {
 			q.receiptTaskPool[hash] = header
 			q.receiptTaskQueue.Push(header, -float32(header.Number.Uint64()))
 		}
-		if q.mode == FastSync && header.Number.Uint64() == q.fastSyncPivot {
-			// Pivoting point of the fast sync, switch the state retrieval to this
-			log.Debug("Switching state downloads to new block", "number", header.Number, "hash", hash)
-
-			q.stateTaskIndex = 0
-			q.stateTaskPool = make(map[common.Hash]int)
-			q.stateTaskQueue.Reset()
-			for _, req := range q.statePendPool {
-				req.Hashes = make(map[common.Hash]int) // Make sure executing requests fail, but don't disappear
-			}
-
-			q.stateScheduler = state.NewStateSync(header.Root, q.stateDatabase)
-		}
 		inserts = append(inserts, header)
 		q.headerHead = hash
 		from++
@@ -452,25 +381,19 @@ func (q *queue) countProcessableItems() int {
 		if q.mode == FastSync {
 			bnum := result.Header.Number.Uint64()
 			if bnum == q.fastSyncPivot {
-				// If the state of the pivot block is not
-				// available yet, we cannot proceed and return 0.
-				//
 				// Stop before processing the pivot block to ensure that
 				// resultCache has space for fsHeaderForceVerify items. Not
 				// doing this could leave us unable to download the required
 				// amount of headers.
-				if i > 0 || len(q.stateTaskPool) > 0 || q.pendingNodeDataLocked() > 0 {
-					return i
-				}
 				for j := 0; j < fsHeaderForceVerify; j++ {
 					if i+j+1 >= len(q.resultCache) || q.resultCache[i+j+1] == nil {
 						return i
 					}
 				}
 			}
-			// If we're just the fast sync pivot, stop as well
+			// If we're just the after fast sync pivot, stop as well
 			// because the following batch needs different insertion.
-			// This simplifies handling the switchover in d.process.
+			// This simplifies handling the switchover in d.processContent.
 			if bnum == q.fastSyncPivot+1 && i > 0 {
 				return i
 			}
@@ -517,25 +440,6 @@ func (q *queue) ReserveHeaders(p *peer, count int) *fetchRequest {
 	}
 	q.headerPendPool[p.id] = request
 	return request
-}
-
-// ReserveNodeData reserves a set of node data hashes for the given peer, skipping
-// any previously failed download.
-func (q *queue) ReserveNodeData(p *peer, count int) *fetchRequest {
-	// Create a task generator to fetch status-fetch tasks if all schedules ones are done
-	generator := func(max int) {
-		if q.stateScheduler != nil {
-			for _, hash := range q.stateScheduler.Missing(max) {
-				q.stateTaskPool[hash] = q.stateTaskIndex
-				q.stateTaskQueue.Push(hash, -float32(q.stateTaskIndex))
-				q.stateTaskIndex++
-			}
-		}
-	}
-	q.lock.Lock()
-	defer q.lock.Unlock()
-
-	return q.reserveHashes(p, count, q.stateTaskQueue, generator, q.statePendPool, maxInFlightStates)
 }
 
 // reserveHashes reserves a set of hashes for the given peer, skipping previously
@@ -722,12 +626,6 @@ func (q *queue) CancelReceipts(request *fetchRequest) {
 	q.cancel(request, q.receiptTaskQueue, q.receiptPendPool)
 }
 
-// CancelNodeData aborts a node state data fetch request, returning all pending
-// hashes to the task queue.
-func (q *queue) CancelNodeData(request *fetchRequest) {
-	q.cancel(request, q.stateTaskQueue, q.statePendPool)
-}
-
 // Cancel aborts a fetch request, returning all pending hashes to the task queue.
 func (q *queue) cancel(request *fetchRequest, taskQueue *prque.Prque, pendPool map[string]*fetchRequest) {
 	q.lock.Lock()
@@ -764,12 +662,6 @@ func (q *queue) Revoke(peerId string) {
 		}
 		delete(q.receiptPendPool, peerId)
 	}
-	if request, ok := q.statePendPool[peerId]; ok {
-		for hash, index := range request.Hashes {
-			q.stateTaskQueue.Push(hash, float32(index))
-		}
-		delete(q.statePendPool, peerId)
-	}
 }
 
 // ExpireHeaders checks for in flight requests that exceeded a timeout allowance,
@@ -797,15 +689,6 @@ func (q *queue) ExpireReceipts(timeout time.Duration) map[string]int {
 	defer q.lock.Unlock()
 
 	return q.expire(timeout, q.receiptPendPool, q.receiptTaskQueue, receiptTimeoutMeter)
-}
-
-// ExpireNodeData checks for in flight node data requests that exceeded a timeout
-// allowance, canceling them and returning the responsible peers for penalisation.
-func (q *queue) ExpireNodeData(timeout time.Duration) map[string]int {
-	q.lock.Lock()
-	defer q.lock.Unlock()
-
-	return q.expire(timeout, q.statePendPool, q.stateTaskQueue, stateTimeoutMeter)
 }
 
 // expire is the generic check that move expired tasks from a pending pool back
@@ -1044,84 +927,6 @@ func (q *queue) deliver(id string, taskPool map[common.Hash]*types.Header, taskQ
 	}
 }
 
-// DeliverNodeData injects a node state data retrieval response into the queue.
-// The method returns the number of node state accepted from the delivery.
-func (q *queue) DeliverNodeData(id string, data [][]byte, callback func(int, bool, error)) (int, error) {
-	q.lock.Lock()
-	defer q.lock.Unlock()
-
-	// Short circuit if the data was never requested
-	request := q.statePendPool[id]
-	if request == nil {
-		return 0, errNoFetchesPending
-	}
-	stateReqTimer.UpdateSince(request.Time)
-	delete(q.statePendPool, id)
-
-	// If no data was retrieved, mark their hashes as unavailable for the origin peer
-	if len(data) == 0 {
-		for hash := range request.Hashes {
-			request.Peer.MarkLacking(hash)
-		}
-	}
-	// Iterate over the downloaded data and verify each of them
-	errs := make([]error, 0)
-	process := []trie.SyncResult{}
-	for _, blob := range data {
-		// Skip any state trie entries that were not requested
-		hash := common.BytesToHash(crypto.Keccak256(blob))
-		if _, ok := request.Hashes[hash]; !ok {
-			errs = append(errs, fmt.Errorf("non-requested state data %x", hash))
-			continue
-		}
-		// Inject the next state trie item into the processing queue
-		process = append(process, trie.SyncResult{Hash: hash, Data: blob})
-		delete(request.Hashes, hash)
-		delete(q.stateTaskPool, hash)
-	}
-	// Return all failed or missing fetches to the queue
-	for hash, index := range request.Hashes {
-		q.stateTaskQueue.Push(hash, float32(index))
-	}
-	if q.stateScheduler == nil {
-		return 0, errNoFetchesPending
-	}
-
-	// Run valid nodes through the trie download scheduler. It writes completed nodes to a
-	// batch, which is committed asynchronously. This may lead to over-fetches because the
-	// scheduler treats everything as written after Process has returned, but it's
-	// unlikely to be an issue in practice.
-	batch := q.stateDatabase.NewBatch()
-	progressed, nproc, procerr := q.stateScheduler.Process(process, batch)
-	q.stateWriters += 1
-	go func() {
-		if procerr == nil {
-			nproc = len(process)
-			procerr = batch.Write()
-		}
-		// Return processing errors through the callback so the sync gets canceled. The
-		// number of writers is decremented prior to the call so PendingNodeData will
-		// return zero when the callback runs.
-		q.lock.Lock()
-		q.stateWriters -= 1
-		q.lock.Unlock()
-		callback(nproc, progressed, procerr)
-		// Wake up WaitResults after the state has been written because it might be
-		// waiting for completion of the pivot block's state download.
-		q.active.Signal()
-	}()
-
-	// If none of the data items were good, it's a stale delivery
-	switch {
-	case len(errs) == 0:
-		return len(process), nil
-	case len(errs) == len(request.Hashes):
-		return len(process), errStaleDelivery
-	default:
-		return len(process), fmt.Errorf("multiple failures: %v", errs)
-	}
-}
-
 // Prepare configures the result cache to allow accepting and caching inbound
 // fetch results.
 func (q *queue) Prepare(offset uint64, mode SyncMode, pivot uint64, head *types.Header) {
@@ -1134,9 +939,4 @@ func (q *queue) Prepare(offset uint64, mode SyncMode, pivot uint64, head *types.
 	}
 	q.fastSyncPivot = pivot
 	q.mode = mode
-
-	// If long running fast sync, also start up a head stateretrieval immediately
-	if mode == FastSync && pivot > 0 {
-		q.stateScheduler = state.NewStateSync(head.Root, q.stateDatabase)
-	}
 }

--- a/eth/downloader/statesync.go
+++ b/eth/downloader/statesync.go
@@ -309,8 +309,8 @@ func (s *stateSync) process(req *stateReq) (nproc int, err error) {
 	// Put unfulfilled tasks back.
 	for hash, task := range req.tasks {
 		if len(req.response) > 0 || req.timedOut() {
-			// Ensure that the item will be retried if the response contained some data or
-			// timed out.
+			// Ensure that the item will be retried because it may have been excluded due
+			// to a protocol limit.
 			delete(task.triedPeers, req.peer.id)
 		}
 		if npeers := s.d.peers.Len(); len(task.triedPeers) >= npeers {

--- a/eth/downloader/statesync.go
+++ b/eth/downloader/statesync.go
@@ -294,8 +294,8 @@ func (s *stateSync) process(req *stateReq) (nproc int, err error) {
 			return 0, fmt.Errorf("invalid state node %s: %v", hash.TerminalString(), err)
 		} else if err == nil {
 			nproc++
-			delete(req.tasks, hash)
 		}
+		delete(req.tasks, hash)
 	}
 	if err := batch.Write(); err != nil {
 		return 0, err

--- a/eth/downloader/statesync.go
+++ b/eth/downloader/statesync.go
@@ -182,25 +182,16 @@ func newStateSync(d *Downloader, root common.Hash) *stateSync {
 	}
 }
 
-// wait blocks until the sync is done or canceled.
-func (s *stateSync) wait() error {
+// Wait blocks until the sync is done or canceled.
+func (s *stateSync) Wait() error {
 	<-s.done
 	return s.err
 }
 
-// wait blocks until the sync is done or canceled.
-func (s *stateSync) checkDone() (bool, error) {
-	select {
-	case <-s.done:
-		return true, s.err
-	default:
-		return false, nil
-	}
-}
-
+// Cancel cancels the sync and waits until it has shut down.
 func (s *stateSync) Cancel() error {
 	s.cancelOnce.Do(func() { close(s.cancel) })
-	return s.wait()
+	return s.Wait()
 }
 
 func (s *stateSync) run() {

--- a/eth/downloader/statesync.go
+++ b/eth/downloader/statesync.go
@@ -1,0 +1,331 @@
+// Copyright 2017 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+package downloader
+
+import (
+	"fmt"
+	"hash"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/state"
+	"github.com/ethereum/go-ethereum/crypto/sha3"
+	"github.com/ethereum/go-ethereum/ethdb"
+	"github.com/ethereum/go-ethereum/log"
+	"github.com/ethereum/go-ethereum/trie"
+)
+
+type stateReq struct {
+	items    []common.Hash
+	tasks    map[common.Hash]*stateTask
+	timeout  time.Duration
+	timer    *time.Timer // fires when timeout has elapsed
+	peer     *peer       // the peer that we're requesting from
+	response [][]byte    // the response. this is nil for timed-out requests.
+}
+
+type stateSyncStats struct {
+	done    uint64 // number of entries pulled
+	pending uint64 // number of pending entries
+}
+
+// syncPivotState starts downloading state with the given root hash.
+func (d *Downloader) syncState(root common.Hash) *stateSync {
+	s := newStateSync(d, root)
+	select {
+	case d.stateSyncStart <- s:
+	case <-d.cancelCh:
+		s.err = errCancelStateFetch
+		close(s.done)
+	}
+	return s
+}
+
+// stateFetcher manages the active state sync and accepts requests
+// on its behalf.
+func (d *Downloader) stateFetcher() {
+	for {
+		select {
+		case s := <-d.stateSyncStart:
+			for next := s; next != nil; {
+				next = d.runStateSync(next)
+			}
+		case <-d.stateCh:
+			// Ignore state responses while no sync is running.
+		case <-d.quitCh:
+			return
+		}
+	}
+}
+
+// runStateSync runs s until it completes or another stateSync is requested.
+func (d *Downloader) runStateSync(s *stateSync) *stateSync {
+	var (
+		activeReqs    = make(map[string]*stateReq)
+		finishedReqs  []*stateReq
+		timeout       = make(chan *stateReq)
+		cancelTimeout = make(chan struct{})
+	)
+	// Cancel active request timers on exit.
+	// The cancelTimeout channel prevents leaking of timer goroutines
+	// in the unlikely case where a timer is fired just before canceling it.
+	defer func() {
+		for _, req := range activeReqs {
+			req.timer.Stop()
+		}
+		close(cancelTimeout)
+	}()
+	// Run the state sync.
+	go s.run()
+	defer s.Cancel()
+
+	for {
+		// Enable sending of the first buffered element if there is one.
+		var deliverReq *stateReq
+		var deliverReqCh chan *stateReq
+		if len(finishedReqs) > 0 {
+			deliverReq = finishedReqs[0]
+			deliverReqCh = s.deliver
+		}
+
+		select {
+		// The stateSync lifecycle:
+		case next := <-d.stateSyncStart:
+			return next
+		case <-s.done:
+			return nil
+
+		// Send the next finished request to the current sync:
+		case deliverReqCh <- deliverReq:
+			finishedReqs = finishedReqs[1:]
+
+		// Handle incoming state packs:
+		case pack := <-d.stateCh:
+			req := activeReqs[pack.PeerId()]
+			if req == nil {
+				log.Debug("Unrequested node data", "peer", pack.PeerId(), "len", pack.Items())
+				continue
+			}
+			delete(activeReqs, pack.PeerId())
+			req.timer.Stop()
+			req.response = pack.(*statePack).states
+			finishedReqs = append(finishedReqs, req)
+
+		// Handle timed-out requests:
+		case req := <-timeout:
+			if activeReqs[req.peer.id] != req {
+				continue // ignore old timeout
+			}
+			finishedReqs = append(finishedReqs, req)
+			delete(activeReqs, req.peer.id)
+
+		// Track outgoing state requests:
+		case req := <-d.trackStateReq:
+			activeReqs[req.peer.id] = req
+			req.timer = time.AfterFunc(req.timeout, func() {
+				select {
+				case timeout <- req:
+				case <-cancelTimeout:
+				}
+			})
+		}
+	}
+}
+
+// stateSync schedules requests for downloading a particular state root.
+type stateSync struct {
+	d              *Downloader
+	sched          *state.StateSync
+	keccak         hash.Hash
+	tasksAvailable map[common.Hash]*stateTask
+
+	deliver    chan *stateReq
+	cancel     chan struct{}
+	cancelOnce sync.Once
+	done       chan struct{}
+	err        error // set after done is closed
+}
+
+type stateTask struct {
+	triedPeers map[string]struct{}
+}
+
+func newStateSync(d *Downloader, root common.Hash) *stateSync {
+	return &stateSync{
+		d:              d,
+		sched:          state.NewStateSync(root, d.stateDB),
+		keccak:         sha3.NewKeccak256(),
+		tasksAvailable: make(map[common.Hash]*stateTask),
+		deliver:        make(chan *stateReq),
+		cancel:         make(chan struct{}),
+		done:           make(chan struct{}, 1),
+	}
+}
+
+// wait blocks until the sync is done or canceled.
+func (s *stateSync) wait() error {
+	<-s.done
+	return s.err
+}
+
+// wait blocks until the sync is done or canceled.
+func (s *stateSync) checkDone() (bool, error) {
+	select {
+	case <-s.done:
+		return true, s.err
+	default:
+		return false, nil
+	}
+}
+
+func (s *stateSync) Cancel() error {
+	s.cancelOnce.Do(func() { close(s.cancel) })
+	return s.wait()
+}
+
+func (s *stateSync) run() {
+	s.err = s.loop()
+	close(s.done)
+}
+
+func (s *stateSync) loop() error {
+	newPeer := make(chan *peer, 200)
+	peerSub := s.d.peers.SubscribeNewPeers(newPeer)
+	defer peerSub.Unsubscribe()
+
+	for s.sched.Pending() > 0 {
+		if err := s.assignTasks(); err != nil {
+			return err
+		}
+
+		select {
+		case <-newPeer:
+			// assign new tasks
+		case <-s.cancel:
+			return errCancelStateFetch
+		case req := <-s.deliver:
+			// response or timeout
+			req.peer.SetNodeDataIdle(len(req.response))
+			procStart := time.Now()
+			n, err := s.process(req)
+			if err != nil {
+				log.Warn("Node data write error", "err", err)
+				return err
+			}
+			if len(req.items) == 1 && req.response == nil {
+				log.Warn("Node data timeout, dropping peer", "peer", req.peer.id)
+				s.d.dropPeer(req.peer.id)
+			}
+			s.updateStats(n, time.Since(procStart))
+		}
+	}
+	return nil
+}
+
+func (s *stateSync) sendReq(req *stateReq) {
+	req.peer.log.Trace("Requesting new batch of data", "type", "state", "count", len(req.items))
+	select {
+	case s.d.trackStateReq <- req:
+		req.peer.FetchNodeData(req.items)
+	case <-s.cancel:
+	}
+}
+
+func (s *stateSync) assignTasks() error {
+	peers, _ := s.d.peers.NodeDataIdlePeers()
+	for _, p := range peers {
+		cap := p.NodeDataCapacity(s.d.requestRTT())
+		req := &stateReq{peer: p, timeout: s.d.requestTTL()}
+		if err := s.popTasks(cap, req); err != nil {
+			return err
+		}
+		if len(req.items) > 0 {
+			s.sendReq(req)
+		}
+	}
+	return nil
+}
+
+func (s *stateSync) popTasks(n int, req *stateReq) error {
+	// Refill available tasks from the scheduler.
+	if len(s.tasksAvailable) < n {
+		new := s.sched.Missing(n - len(s.tasksAvailable))
+		for _, hash := range new {
+			s.tasksAvailable[hash] = &stateTask{make(map[string]struct{})}
+		}
+	}
+	// Find tasks that haven't been tried with the request's peer.
+	req.items = make([]common.Hash, 0, n)
+	req.tasks = make(map[common.Hash]*stateTask, n)
+	for hash, t := range s.tasksAvailable {
+		if len(req.items) == n {
+			break
+		}
+		if _, ok := t.triedPeers[req.peer.id]; ok {
+			continue
+		}
+		t.triedPeers[req.peer.id] = struct{}{}
+		req.items = append(req.items, hash)
+		req.tasks[hash] = t
+		delete(s.tasksAvailable, hash)
+	}
+	return nil
+}
+
+func (s *stateSync) process(req *stateReq) (nproc int, err error) {
+	batch := s.d.stateDB.NewBatch()
+	for _, blob := range req.response {
+		if hash, ok := s.processNodeData(blob, batch); ok {
+			nproc++
+			delete(req.tasks, hash)
+		}
+	}
+	if err := batch.Write(); err != nil {
+		return 0, err
+	}
+	if nproc > 0 && atomic.LoadUint32(&s.d.fsPivotFails) > 1 {
+		log.Trace("Fast-sync progressed, resetting fail counter", "previous", atomic.LoadUint32(&s.d.fsPivotFails))
+		atomic.StoreUint32(&s.d.fsPivotFails, 1) // Don't ever reset to 0, as that will unlock the pivot block
+	}
+	// Put unfulfilled tasks back.
+	for hash, task := range req.tasks {
+		if npeers := s.d.peers.Len(); len(task.triedPeers) >= npeers {
+			return nproc, fmt.Errorf("state node %s failed with all peers (%d tries, %d peers)", hash.TerminalString(), len(task.triedPeers), npeers)
+		}
+		s.tasksAvailable[hash] = task
+	}
+	return nproc, nil
+}
+
+func (s *stateSync) processNodeData(blob []byte, batch ethdb.Batch) (common.Hash, bool) {
+	res := trie.SyncResult{Data: blob}
+	s.keccak.Reset()
+	s.keccak.Write(blob)
+	s.keccak.Sum(res.Hash[:0])
+	_, _, err := s.sched.Process([]trie.SyncResult{res}, batch)
+	return res.Hash, err == nil
+}
+
+func (s *stateSync) updateStats(processed int, duration time.Duration) {
+	s.d.syncStatsLock.Lock()
+	defer s.d.syncStatsLock.Unlock()
+	s.d.syncStatsState.pending = uint64(s.sched.Pending())
+	s.d.syncStatsState.done += uint64(processed)
+	log.Info("Imported new state entries", "count", processed, "elapsed", common.PrettyDuration(duration), "processed", s.d.syncStatsState.done, "pending", s.d.syncStatsState.pending, "retry", len(s.tasksAvailable))
+}

--- a/eth/downloader/statesync.go
+++ b/eth/downloader/statesync.go
@@ -115,7 +115,7 @@ func (d *Downloader) runStateSync(s *stateSync) *stateSync {
 
 		// Send the next finished request to the current sync:
 		case deliverReqCh <- deliverReq:
-			finishedReqs = finishedReqs[1:]
+			finishedReqs = append(finishedReqs[:0], finishedReqs[1:]...)
 
 		// Handle incoming state packs:
 		case pack := <-d.stateCh:

--- a/eth/downloader/statesync.go
+++ b/eth/downloader/statesync.go
@@ -85,10 +85,12 @@ func (d *Downloader) runStateSync(s *stateSync) *stateSync {
 		finishedReqs []*stateReq
 		timeout      = make(chan *stateReq)
 	)
-	// Cancel active request timers on exit.
 	defer func() {
+		// Cancel active request timers on exit. Also set peers to idle so they're
+		// available for the next sync.
 		for _, req := range activeReqs {
 			req.timer.Stop()
+			req.peer.SetNodeDataIdle(0)
 		}
 	}()
 	// Run the state sync.

--- a/eth/downloader/statesync.go
+++ b/eth/downloader/statesync.go
@@ -54,7 +54,7 @@ func (d *Downloader) syncState(root common.Hash) *stateSync {
 	s := newStateSync(d, root)
 	select {
 	case d.stateSyncStart <- s:
-	case <-d.cancelCh:
+	case <-d.quitCh:
 		s.err = errCancelStateFetch
 		close(s.done)
 	}

--- a/eth/downloader/statesync.go
+++ b/eth/downloader/statesync.go
@@ -291,7 +291,7 @@ func (s *stateSync) process(req *stateReq) (nproc int, err error) {
 	for _, blob := range req.response {
 		hash, err := s.processNodeData(blob, batch)
 		if err != nil && err != trie.ErrNotRequested {
-			return 0, fmt.Errorf("invalid state node %s: %v", err)
+			return 0, fmt.Errorf("invalid state node %s: %v", hash.TerminalString(), err)
 		} else if err == nil {
 			nproc++
 			delete(req.tasks, hash)

--- a/eth/downloader/statesync.go
+++ b/eth/downloader/statesync.go
@@ -31,9 +31,6 @@ import (
 	"github.com/ethereum/go-ethereum/trie"
 )
 
-// If a single state node is tried more than this many times, sync fails.
-const maxStateNodeRetries = 50
-
 type stateReq struct {
 	items    []common.Hash
 	tasks    map[common.Hash]*stateTask
@@ -315,12 +312,9 @@ func (s *stateSync) process(req *stateReq) (nproc int, err error) {
 			// to a protocol limit.
 			delete(task.triedPeers, req.peer.id)
 		}
-		// Check retry limits.
+		// Check retry limit.
 		if len(task.triedPeers) >= npeers {
 			return nproc, fmt.Errorf("state node %s failed with all peers (%d tries, %d peers)", hash.TerminalString(), len(task.triedPeers), npeers)
-		}
-		if task.numTries > maxStateNodeRetries && task.numTries >= npeers {
-			return nproc, fmt.Errorf("download of state node %s failed %d times", hash.TerminalString(), task.numTries)
 		}
 		s.tasksAvailable[hash] = task
 	}

--- a/trie/sync.go
+++ b/trie/sync.go
@@ -52,6 +52,21 @@ type SyncResult struct {
 	Data []byte      // Data content of the retrieved node
 }
 
+// SyncMemCache is an in-memory cache of successfully downloaded but not yet
+// persisted data items.
+type SyncMemCache struct {
+	cache map[common.Hash][]byte // In-memory memcache of recently ocmpleted items
+	order []common.Hash          // Order of completion to prevent out-of-order data loss
+}
+
+// newSyncMemCache allocates a new memory-cache for not-yet persisted trie nodes.
+func newSyncMemCache() *SyncMemCache {
+	return &SyncMemCache{
+		cache: make(map[common.Hash][]byte),
+		order: make([]common.Hash, 0, 256),
+	}
+}
+
 // TrieSyncLeafCallback is a callback type invoked when a trie sync reaches a
 // leaf node. It's used by state syncing to check if the leaf node requires some
 // further data syncing.
@@ -61,7 +76,8 @@ type TrieSyncLeafCallback func(leaf []byte, parent common.Hash) error
 // unknown trie hashes to retrieve, accepts node data associated with said hashes
 // and reconstructs the trie step by step until all is done.
 type TrieSync struct {
-	database DatabaseReader
+	database DatabaseReader           // Persistent database to check for existing entries
+	memcache *SyncMemCache            // Memory cache to avoid frequest database writes
 	requests map[common.Hash]*request // Pending requests pertaining to a key hash
 	queue    *prque.Prque             // Priority queue with the pending requests
 }
@@ -70,6 +86,7 @@ type TrieSync struct {
 func NewTrieSync(root common.Hash, database DatabaseReader, callback TrieSyncLeafCallback) *TrieSync {
 	ts := &TrieSync{
 		database: database,
+		memcache: newSyncMemCache(),
 		requests: make(map[common.Hash]*request),
 		queue:    prque.New(),
 	}
@@ -81,6 +98,9 @@ func NewTrieSync(root common.Hash, database DatabaseReader, callback TrieSyncLea
 func (s *TrieSync) AddSubTrie(root common.Hash, depth int, parent common.Hash, callback TrieSyncLeafCallback) {
 	// Short circuit if the trie is empty or already known
 	if root == emptyRoot {
+		return
+	}
+	if _, ok := s.memcache.cache[root]; ok {
 		return
 	}
 	key := root.Bytes()
@@ -113,6 +133,9 @@ func (s *TrieSync) AddSubTrie(root common.Hash, depth int, parent common.Hash, c
 func (s *TrieSync) AddRawEntry(hash common.Hash, depth int, parent common.Hash) {
 	// Short circuit if the entry is empty or already known
 	if hash == emptyState {
+		return
+	}
+	if _, ok := s.memcache.cache[hash]; ok {
 		return
 	}
 	if blob, _ := s.database.Get(hash.Bytes()); blob != nil {
@@ -148,7 +171,7 @@ func (s *TrieSync) Missing(max int) []common.Hash {
 // Process injects a batch of retrieved trie nodes data, returning if something
 // was committed to the database and also the index of an entry if processing of
 // it failed.
-func (s *TrieSync) Process(results []SyncResult, dbw DatabaseWriter) (bool, int, error) {
+func (s *TrieSync) Process(results []SyncResult) (bool, int, error) {
 	committed := false
 
 	for i, item := range results {
@@ -163,7 +186,7 @@ func (s *TrieSync) Process(results []SyncResult, dbw DatabaseWriter) (bool, int,
 		// If the item is a raw entry request, commit directly
 		if request.raw {
 			request.data = item.Data
-			s.commit(request, dbw)
+			s.commit(request)
 			committed = true
 			continue
 		}
@@ -180,7 +203,7 @@ func (s *TrieSync) Process(results []SyncResult, dbw DatabaseWriter) (bool, int,
 			return committed, i, err
 		}
 		if len(requests) == 0 && request.deps == 0 {
-			s.commit(request, dbw)
+			s.commit(request)
 			committed = true
 			continue
 		}
@@ -190,6 +213,22 @@ func (s *TrieSync) Process(results []SyncResult, dbw DatabaseWriter) (bool, int,
 		}
 	}
 	return committed, 0, nil
+}
+
+// Commit flushes the data stored in the internal memcache out to persistent
+// storage, returning th enumber of items written and any occurred error.
+func (s *TrieSync) Commit(dbw DatabaseWriter) (int, error) {
+	// Dump the memcache into a database dbw
+	for i, key := range s.memcache.order {
+		if err := dbw.Put(key[:], s.memcache.cache[key]); err != nil {
+			return i, err
+		}
+	}
+	written := len(s.memcache.order)
+
+	// Drop the memcache data and return
+	s.memcache = newSyncMemCache()
+	return written, nil
 }
 
 // Pending returns the number of state entries currently pending for download.
@@ -253,13 +292,17 @@ func (s *TrieSync) children(req *request, object node) ([]*request, error) {
 		// If the child references another node, resolve or schedule
 		if node, ok := (child.node).(hashNode); ok {
 			// Try to resolve the node from the local database
+			hash := common.BytesToHash(node)
+			if _, ok := s.memcache.cache[hash]; ok {
+				continue
+			}
 			blob, _ := s.database.Get(node)
 			if local, err := decodeNode(node[:], blob, 0); local != nil && err == nil {
 				continue
 			}
 			// Locally unknown node, schedule for retrieval
 			requests = append(requests, &request{
-				hash:     common.BytesToHash(node),
+				hash:     hash,
 				parents:  []*request{req},
 				depth:    child.depth,
 				callback: req.callback,
@@ -269,21 +312,21 @@ func (s *TrieSync) children(req *request, object node) ([]*request, error) {
 	return requests, nil
 }
 
-// commit finalizes a retrieval request and stores it into the database. If any
+// commit finalizes a retrieval request and stores it into the memcache. If any
 // of the referencing parent requests complete due to this commit, they are also
 // committed themselves.
-func (s *TrieSync) commit(req *request, dbw DatabaseWriter) (err error) {
-	// Write the node content to disk
-	if err := dbw.Put(req.hash[:], req.data); err != nil {
-		return err
-	}
+func (s *TrieSync) commit(req *request) (err error) {
+	// Write the node content to the memcache
+	s.memcache.cache[req.hash] = req.data
+	s.memcache.order = append(s.memcache.order, req.hash)
+
 	delete(s.requests, req.hash)
 
 	// Check all parents for completion
 	for _, parent := range req.parents {
 		parent.deps--
 		if parent.deps == 0 {
-			if err := s.commit(parent, dbw); err != nil {
+			if err := s.commit(parent); err != nil {
 				return err
 			}
 		}

--- a/trie/sync.go
+++ b/trie/sync.go
@@ -28,6 +28,10 @@ import (
 // node it did not request.
 var ErrNotRequested = errors.New("not requested")
 
+// ErrAlreadyProcessed is returned by the trie sync when it's requested to process a
+// node it already processed previously.
+var ErrAlreadyProcessed = errors.New("already processed")
+
 // request represents a scheduled or already in-flight state retrieval request.
 type request struct {
 	hash common.Hash // Hash of the node data content to retrieve
@@ -152,6 +156,9 @@ func (s *TrieSync) Process(results []SyncResult, dbw DatabaseWriter) (bool, int,
 		request := s.requests[item.Hash]
 		if request == nil {
 			return committed, i, ErrNotRequested
+		}
+		if request.data != nil {
+			return committed, i, ErrAlreadyProcessed
 		}
 		// If the item is a raw entry request, commit directly
 		if request.raw {

--- a/trie/sync_test.go
+++ b/trie/sync_test.go
@@ -122,8 +122,11 @@ func testIterativeTrieSync(t *testing.T, batch int) {
 			}
 			results[i] = SyncResult{hash, data}
 		}
-		if _, index, err := sched.Process(results, dstDb); err != nil {
+		if _, index, err := sched.Process(results); err != nil {
 			t.Fatalf("failed to process result #%d: %v", index, err)
+		}
+		if index, err := sched.Commit(dstDb); err != nil {
+			t.Fatalf("failed to commit data #%d: %v", index, err)
 		}
 		queue = append(queue[:0], sched.Missing(batch)...)
 	}
@@ -152,8 +155,11 @@ func TestIterativeDelayedTrieSync(t *testing.T) {
 			}
 			results[i] = SyncResult{hash, data}
 		}
-		if _, index, err := sched.Process(results, dstDb); err != nil {
+		if _, index, err := sched.Process(results); err != nil {
 			t.Fatalf("failed to process result #%d: %v", index, err)
+		}
+		if index, err := sched.Commit(dstDb); err != nil {
+			t.Fatalf("failed to commit data #%d: %v", index, err)
 		}
 		queue = append(queue[len(results):], sched.Missing(10000)...)
 	}
@@ -190,8 +196,11 @@ func testIterativeRandomTrieSync(t *testing.T, batch int) {
 			results = append(results, SyncResult{hash, data})
 		}
 		// Feed the retrieved results back and queue new tasks
-		if _, index, err := sched.Process(results, dstDb); err != nil {
+		if _, index, err := sched.Process(results); err != nil {
 			t.Fatalf("failed to process result #%d: %v", index, err)
+		}
+		if index, err := sched.Commit(dstDb); err != nil {
+			t.Fatalf("failed to commit data #%d: %v", index, err)
 		}
 		queue = make(map[common.Hash]struct{})
 		for _, hash := range sched.Missing(batch) {
@@ -231,8 +240,11 @@ func TestIterativeRandomDelayedTrieSync(t *testing.T) {
 			}
 		}
 		// Feed the retrieved results back and queue new tasks
-		if _, index, err := sched.Process(results, dstDb); err != nil {
+		if _, index, err := sched.Process(results); err != nil {
 			t.Fatalf("failed to process result #%d: %v", index, err)
+		}
+		if index, err := sched.Commit(dstDb); err != nil {
+			t.Fatalf("failed to commit data #%d: %v", index, err)
 		}
 		for _, result := range results {
 			delete(queue, result.Hash)
@@ -272,8 +284,11 @@ func TestDuplicateAvoidanceTrieSync(t *testing.T) {
 
 			results[i] = SyncResult{hash, data}
 		}
-		if _, index, err := sched.Process(results, dstDb); err != nil {
+		if _, index, err := sched.Process(results); err != nil {
 			t.Fatalf("failed to process result #%d: %v", index, err)
+		}
+		if index, err := sched.Commit(dstDb); err != nil {
+			t.Fatalf("failed to commit data #%d: %v", index, err)
 		}
 		queue = append(queue[:0], sched.Missing(0)...)
 	}
@@ -304,8 +319,11 @@ func TestIncompleteTrieSync(t *testing.T) {
 			results[i] = SyncResult{hash, data}
 		}
 		// Process each of the trie nodes
-		if _, index, err := sched.Process(results, dstDb); err != nil {
+		if _, index, err := sched.Process(results); err != nil {
 			t.Fatalf("failed to process result #%d: %v", index, err)
+		}
+		if index, err := sched.Commit(dstDb); err != nil {
+			t.Fatalf("failed to commit data #%d: %v", index, err)
 		}
 		for _, result := range results {
 			added = append(added, result.Hash)


### PR DESCRIPTION
Scheduling of state node downloads hogged the downloader queue lock when
new requests were scheduled. This caused timeouts for other requests.
With this change, state sync is fully independent of all other downloads
and doesn't involve the queue at all.

State sync is started and checked on in processContent. This is slightly
awkward because processContent doesn't have a select loop. Instead, the
queue is closed by an auxiliary goroutine when state sync fails. We
tried several alternatives to this but settled on the current approach
because it's the least amount of change overall.

Handling of the pivot block has changed slightly: the queue previously
prevented import of pivot block receipts before the state of the pivot
block was available. In this commit, the receipt will be imported before
the state. This causes an annoyance where the pivot block is committed
as fast block head even when state downloads fail. Stay tuned for more
updates in this area ;)