### PR TITLE
mobile: accept nil for chainid as homestead signing

### DIFF
--- a/mobile/accounts.go
+++ b/mobile/accounts.go
@@ -115,6 +115,9 @@ func (ks *KeyStore) SignHash(address *Address, hash []byte) (signature []byte, _
 
 // SignTx signs the given transaction with the requested account.
 func (ks *KeyStore) SignTx(account *Account, tx *Transaction, chainID *BigInt) (*Transaction, error) {
+	if chainID == nil { // Null passed from mobile app
+		chainID = new(BigInt)
+	}
 	signed, err := ks.keystore.SignTx(account.account, tx.tx, chainID.bigint)
 	if err != nil {
 		return nil, err
@@ -132,6 +135,9 @@ func (ks *KeyStore) SignHashPassphrase(account *Account, passphrase string, hash
 // SignTxPassphrase signs the transaction if the private key matching the
 // given address can be decrypted with the given passphrase.
 func (ks *KeyStore) SignTxPassphrase(account *Account, passphrase string, tx *Transaction, chainID *BigInt) (*Transaction, error) {
+	if chainID == nil { // Null passed from mobile app
+		chainID = new(BigInt)
+	}
 	signed, err := ks.keystore.SignTxWithPassphrase(account.account, passphrase, tx.tx, chainID.bigint)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
The signing logic in our keystore defines that a `nil` chain id results in the homestead signer being invoked, while a valid chain id results in the EIP155 signer. On mobile side however it's not possible to pass in `nil`, so it's currently impossible to invoke the homestead signer and not the EIP155 signer. This PR adds a check into the wrappers so that a `nil` `*mobile.BigInt` is properly converted to a `nil` `*big.Int`.

**Please note: gomobile currently cannot pass `null` objects from mobile to Go. I've opened a CL to address it: https://go-review.googlesource.com/#/c/43253/. This PR is useless until that is merged.**