### PR TITLE
swarm/api: Fix adding paths which exist as manifests

### DIFF
--- a/swarm/api/manifest.go
+++ b/swarm/api/manifest.go
@@ -237,12 +237,12 @@ func (self *manifestTrie) addEntry(entry *manifestTrieEntry, quitC chan bool) {
 	}
 
 	b := byte(entry.Path[0])
-	if (self.entries[b] == nil) || (self.entries[b].Path == entry.Path) {
+	oldentry := self.entries[b]
+	if (oldentry == nil) || (oldentry.Path == entry.Path && oldentry.ContentType != ManifestType) {
 		self.entries[b] = entry
 		return
 	}
 
-	oldentry := self.entries[b]
 	cpl := 0
 	for (len(entry.Path) > cpl) && (len(oldentry.Path) > cpl) && (entry.Path[cpl] == oldentry.Path[cpl]) {
 		cpl++


### PR DESCRIPTION
Without this change, adding `a` to a manifest which already contains `ab` and `ac` would return a manifest just containing `a` (rather than a manifest containing all three).