### PR TITLE
Change Logging from Debug to Info

### DIFF
--- a/p2p/discover/udp.go
+++ b/p2p/discover/udp.go
@@ -224,7 +224,7 @@ func ListenUDP(priv *ecdsa.PrivateKey, laddr string, natm nat.Interface, nodeDBP
 	if err != nil {
 		return nil, err
 	}
-	log.Debug("UDP listener up", "self", tab.self)
+	log.Info("UDP listener up", "self", tab.self)
 	return tab, nil
 }
 


### PR DESCRIPTION
There is no indication of the bootnode starting if the verbosity is not explicitly set to. Also there is no way of knowing the bootnode's enode on start.

Changing the log level from `Debug` to `Info` makes bootnode to print the enode address on start:
`INFO [05-17|10:58:49] UDP listener up                          self=enode://61xxx@[::]:30301`