### PR TITLE
fix: broken mipmap bloom

### DIFF
--- a/eth/filters/filter.go
+++ b/eth/filters/filter.go
@@ -141,7 +141,7 @@ func (f *Filter) mipFind(start, end uint64, depth int) (logs []*types.Log, block
 		// up where a previous run left off.
 		first := true
 		for _, addr := range f.addresses {
-			if first || bloom.TestBytes(addr[:]) {
+			if first && bloom.TestBytes(addr[:]) {
 				first = false
 				// range check normalised values and make sure that
 				// we're resolving the correct range instead of the


### PR DESCRIPTION
Current "||" logic causes bloom losing efficacy. "&&" should be the correct logic.