### PR TITLE
core/vm: improve error message for invalid opcodes

### DIFF
--- a/core/vm/instructions.go
+++ b/core/vm/instructions.go
@@ -640,7 +640,7 @@ func opDelegateCall(pc *uint64, evm *EVM, contract *Contract, memory *Memory, st
 	// if not homestead return an error. DELEGATECALL is not supported
 	// during pre-homestead.
 	if !evm.ChainConfig().IsHomestead(evm.BlockNumber) {
-		return nil, fmt.Errorf("invalid opcode %x", DELEGATECALL)
+		return nil, fmt.Errorf("invalid opcode 0x%x", int(DELEGATECALL))
 	}
 
 	gas, to, inOffset, inSize, outOffset, outSize := stack.pop().Uint64(), stack.pop(), stack.pop(), stack.pop(), stack.pop(), stack.pop()

--- a/core/vm/interpreter.go
+++ b/core/vm/interpreter.go
@@ -137,7 +137,7 @@ func (evm *Interpreter) Run(contract *Contract, input []byte) (ret []byte, err e
 
 		// if the op is invalid abort the process and return an error
 		if !operation.valid {
-			return nil, fmt.Errorf("invalid opcode %x", op)
+			return nil, fmt.Errorf("invalid opcode 0x%x", int(op))
 		}
 
 		// validate the stack and make sure there enough stack items available


### PR DESCRIPTION
Currently, error messages for invalid opcodes read `invalid opcode <hex encoding of opcode.String()>` which is unreadable (e.g., "invalid opcode 4d697373696e67206f70636f64652030786665"). These changes make the error messages more readable (i.e., `invalid opcode <opcode number in hex>`).