### PR TITLE
Expose the raw client in mobile

### DIFF
--- a/mobile/ethclient.go
+++ b/mobile/ethclient.go
@@ -36,6 +36,11 @@ func NewEthereumClient(rawurl string) (client *EthereumClient, _ error) {
 	return &EthereumClient{rawClient}, err
 }
 
+// Get the raw ethclient.Client
+func (ec *EthereumClient) RawClient() *ethclient.Client {
+	return ec.client
+}
+
 // GetBlockByHash returns the given full block.
 func (ec *EthereumClient) GetBlockByHash(ctx *Context, hash *Hash) (block *Block, _ error) {
 	rawBlock, err := ec.client.BlockByHash(ctx.context, hash.hash)


### PR DESCRIPTION
New to the code base. Not sure if this is the best way to handle is but some of the APIs I'm trying to use (like ENS) expect an ethclient.Client not a mobile.EthereumClient which doesn't implement the correct interface. 

Simple solution is to just expect the raw client unless you guys can point me in a better direction. 