### PR TITLE
Mobile : manage FilterQuery enabling contract events subscription

### DIFF
--- a/mobile/common.go
+++ b/mobile/common.go
@@ -89,6 +89,18 @@ func (h *Hash) GetHex() string {
 // Hashes represents a slice of hashes.
 type Hashes struct{ hashes []common.Hash }
 
+// NewHashes creates a slice of uninitialized Hashes.
+func NewHashes(size int) *Hashes {
+	return &Hashes{
+		hashes: make([]common.Hash, size),
+	}
+}
+
+// NewHashesEmpty creates an empty slice of Hashes values.
+func NewHashesEmpty() *Hashes {
+	return NewHashes(0)
+}
+
 // Size returns the number of hashes in the slice.
 func (h *Hashes) Size() int {
 	return len(h.hashes)
@@ -100,6 +112,20 @@ func (h *Hashes) Get(index int) (hash *Hash, _ error) {
 		return nil, errors.New("index out of bounds")
 	}
 	return &Hash{h.hashes[index]}, nil
+}
+
+// Set sets the Hash at the given index in the slice.
+func (h *Hashes) Set(index int, hash *Hash) error {
+	if index < 0 || index >= len(h.hashes) {
+		return errors.New("index out of bounds")
+	}
+	h.hashes[index] = hash.hash
+	return nil
+}
+
+// Append adds a new Hash element to the end of the slice.
+func (h *Hashes) Append(hash *Hash) {
+	h.hashes = append(h.hashes, hash.hash)
 }
 
 // Address represents the 20 byte address of an Ethereum account.
@@ -164,6 +190,18 @@ func (a *Address) GetHex() string {
 // Addresses represents a slice of addresses.
 type Addresses struct{ addresses []common.Address }
 
+// NewAddresses creates a slice of uninitialized addresses.
+func NewAddresses(size int) *Addresses {
+	return &Addresses{
+		addresses: make([]common.Address, size),
+	}
+}
+
+// NewAddressesEmpty creates an empty slice of Addresses values.
+func NewAddressesEmpty() *Addresses {
+	return NewAddresses(0)
+}
+
 // Size returns the number of addresses in the slice.
 func (a *Addresses) Size() int {
 	return len(a.addresses)
@@ -184,4 +222,9 @@ func (a *Addresses) Set(index int, address *Address) error {
 	}
 	a.addresses[index] = address.address
 	return nil
+}
+
+// Append adds a new address element to the end of the slice.
+func (a *Addresses) Append(address *Address) {
+	a.addresses = append(a.addresses, address.address)
 }

--- a/mobile/ethereum.go
+++ b/mobile/ethereum.go
@@ -123,3 +123,8 @@ func (fq *FilterQuery) GetFromBlock() *BigInt    { return &BigInt{fq.query.FromB
 func (fq *FilterQuery) GetToBlock() *BigInt      { return &BigInt{fq.query.ToBlock} }
 func (fq *FilterQuery) GetAddresses() *Addresses { return &Addresses{fq.query.Addresses} }
 func (fq *FilterQuery) GetTopics() *Topics       { return &Topics{fq.query.Topics} }
+
+func (fq *FilterQuery) SetFromBlock(fromBlock *BigInt)    { fq.query.FromBlock = fromBlock.bigint }
+func (fq *FilterQuery) SetToBlock(toBlock *BigInt)        { fq.query.ToBlock = toBlock.bigint }
+func (fq *FilterQuery) SetAddresses(addresses *Addresses) { fq.query.Addresses = addresses.addresses }
+func (fq *FilterQuery) SetTopics(topics *Topics)          { fq.query.Topics = topics.topics }

--- a/mobile/ethereum.go
+++ b/mobile/ethereum.go
@@ -87,6 +87,18 @@ func (p *SyncProgress) GetKnownStates() int64   { return int64(p.progress.KnownS
 // Topics is a set of topic lists to filter events with.
 type Topics struct{ topics [][]common.Hash }
 
+// NewTopics creates a slice of uninitialized Topics.
+func NewTopics(size int) *Topics {
+	return &Topics{
+		topics: make([][]common.Hash, size),
+	}
+}
+
+// NewTopicsEmpty creates an empty slice of Topics values.
+func NewTopicsEmpty() *Topics {
+	return NewTopics(0)
+}
+
 // Size returns the number of topic lists inside the set
 func (t *Topics) Size() int {
 	return len(t.topics)
@@ -107,6 +119,11 @@ func (t *Topics) Set(index int, topics *Hashes) error {
 	}
 	t.topics[index] = topics.hashes
 	return nil
+}
+
+// Append adds a new topic list to the end of the slice.
+func (t *Topics) Append(topics *Hashes) {
+	t.topics = append(t.topics, topics.hashes)
 }
 
 // FilterQuery contains options for contact log filtering.


### PR DESCRIPTION
I'm building a wrapper of go-ethereum android archive called [EthDroid](https://github.com/sqli-nantes/ethereum-android/tree/geth_1.6). 
I noticed that with the newly exposed mobile interface, we cannot customize FilterQueries to fit with contract events detection. 
My fork adds methods to create customized FilterQueries thanks to : 

- FilterQuery.SetFromBlock
- FilterQuery.SetToBlock
- FilterQuery.SetAddresse
- FilterQuery.SetTopics
************
- Addresses.NewAddresses
- Addresses.NewAddressesEmpty
- Addresses.Append
************
- Topics.NewTopics
- Topics.NewTopicsEmpty
- Topics.Append
************
- Hashes.NewHashes
- Hashes.NewHashesEmpty
- Hashes.Set
- Hashes.Append
