### PR TITLE
Enforce 256 bit keys on raw import, support raw mobile imports

### DIFF
--- a/accounts/keystore/key.go
+++ b/accounts/keystore/key.go
@@ -124,14 +124,13 @@ func (k *Key) UnmarshalJSON(j []byte) (err error) {
 	if err != nil {
 		return err
 	}
-
-	privkey, err := hex.DecodeString(keyJSON.PrivateKey)
+	privkey, err := crypto.HexToECDSA(keyJSON.PrivateKey)
 	if err != nil {
 		return err
 	}
 
 	k.Address = common.BytesToAddress(addr)
-	k.PrivateKey = crypto.ToECDSA(privkey)
+	k.PrivateKey = privkey
 
 	return nil
 }

--- a/accounts/keystore/keystore.go
+++ b/accounts/keystore/keystore.go
@@ -450,7 +450,6 @@ func (ks *KeyStore) ImportECDSA(priv *ecdsa.PrivateKey, passphrase string) (acco
 	if ks.cache.hasAddress(key.Address) {
 		return accounts.Account{}, fmt.Errorf("account already exists")
 	}
-
 	return ks.importKey(key, passphrase)
 }
 

--- a/accounts/keystore/keystore_passphrase.go
+++ b/accounts/keystore/keystore_passphrase.go
@@ -182,7 +182,10 @@ func DecryptKey(keyjson []byte, auth string) (*Key, error) {
 	if err != nil {
 		return nil, err
 	}
-	key := crypto.ToECDSA(keyBytes)
+	key, err := crypto.ToECDSA(keyBytes)
+	if err != nil {
+		return nil, err
+	}
 	return &Key{
 		Id:         uuid.UUID(keyId),
 		Address:    crypto.PubkeyToAddress(key.PublicKey),

--- a/accounts/keystore/keystore_passphrase_test.go
+++ b/accounts/keystore/keystore_passphrase_test.go
@@ -46,7 +46,7 @@ func TestKeyEncryptDecrypt(t *testing.T) {
 		// Decrypt with the correct password
 		key, err := DecryptKey(keyjson, password)
 		if err != nil {
-			t.Errorf("test %d: json key failed to decrypt: %v", i, err)
+			t.Fatalf("test %d: json key failed to decrypt: %v", i, err)
 		}
 		if key.Address != address {
 			t.Errorf("test %d: key address mismatch: have %x, want %x", i, key.Address, address)

--- a/accounts/keystore/presale.go
+++ b/accounts/keystore/presale.go
@@ -74,7 +74,10 @@ func decryptPreSaleKey(fileContent []byte, password string) (key *Key, err error
 		return nil, err
 	}
 	ethPriv := crypto.Keccak256(plainText)
-	ecKey := crypto.ToECDSA(ethPriv)
+	ecKey, err := crypto.ToECDSA(ethPriv)
+	if err != nil {
+		return nil, err
+	}
 	key = &Key{
 		Id:         nil,
 		Address:    crypto.PubkeyToAddress(ecKey.PublicKey),

--- a/core/types/transaction_test.go
+++ b/core/types/transaction_test.go
@@ -79,7 +79,7 @@ func decodeTx(data []byte) (*Transaction, error) {
 }
 
 func defaultTestKey() (*ecdsa.PrivateKey, common.Address) {
-	key := crypto.ToECDSA(common.Hex2Bytes("45a915e4d060149eb4365960e6a7a45f334393093061116b197e3240065ff2d8"))
+	key, _ := crypto.HexToECDSA("45a915e4d060149eb4365960e6a7a45f334393093061116b197e3240065ff2d8")
 	addr := crypto.PubkeyToAddress(key.PublicKey)
 	return key, addr
 }

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -19,7 +19,6 @@ package ethapi
 import (
 	"bytes"
 	"context"
-	"encoding/hex"
 	"errors"
 	"fmt"
 	"math/big"
@@ -283,12 +282,11 @@ func fetchKeystore(am *accounts.Manager) *keystore.KeyStore {
 // ImportRawKey stores the given hex encoded ECDSA key into the key directory,
 // encrypting it with the passphrase.
 func (s *PrivateAccountAPI) ImportRawKey(privkey string, password string) (common.Address, error) {
-	hexkey, err := hex.DecodeString(privkey)
+	key, err := crypto.HexToECDSA(privkey)
 	if err != nil {
 		return common.Address{}, err
 	}
-
-	acc, err := fetchKeystore(s.am).ImportECDSA(crypto.ToECDSA(hexkey), password)
+	acc, err := fetchKeystore(s.am).ImportECDSA(key, password)
 	return acc.Address, err
 }
 

--- a/mobile/accounts.go
+++ b/mobile/accounts.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/ethereum/go-ethereum/accounts"
 	"github.com/ethereum/go-ethereum/accounts/keystore"
+	"github.com/ethereum/go-ethereum/crypto"
 )
 
 const (
@@ -176,6 +177,11 @@ func (ks *KeyStore) NewAccount(passphrase string) (*Account, error) {
 	return &Account{account}, nil
 }
 
+// UpdateAccount changes the passphrase of an existing account.
+func (ks *KeyStore) UpdateAccount(account *Account, passphrase, newPassphrase string) error {
+	return ks.keystore.Update(account.account, passphrase, newPassphrase)
+}
+
 // ExportKey exports as a JSON key, encrypted with newPassphrase.
 func (ks *KeyStore) ExportKey(account *Account, passphrase, newPassphrase string) (key []byte, _ error) {
 	return ks.keystore.Export(account.account, passphrase, newPassphrase)
@@ -190,9 +196,17 @@ func (ks *KeyStore) ImportKey(keyJSON []byte, passphrase, newPassphrase string) 
 	return &Account{acc}, nil
 }
 
-// UpdateAccount changes the passphrase of an existing account.
-func (ks *KeyStore) UpdateAccount(account *Account, passphrase, newPassphrase string) error {
-	return ks.keystore.Update(account.account, passphrase, newPassphrase)
+// ImportECDSAKey stores the given encrypted JSON key into the key directory.
+func (ks *KeyStore) ImportECDSAKey(key []byte, passphrase string) (account *Account, _ error) {
+	privkey, err := crypto.ToECDSA(key)
+	if err != nil {
+		return nil, err
+	}
+	acc, err := ks.keystore.ImportECDSA(privkey, passphrase)
+	if err != nil {
+		return nil, err
+	}
+	return &Account{acc}, nil
 }
 
 // ImportPreSaleKey decrypts the given Ethereum presale wallet and stores

--- a/swarm/api/config_test.go
+++ b/swarm/api/config_test.go
@@ -96,7 +96,10 @@ func TestConfigWriteRead(t *testing.T) {
 	}
 	defer os.RemoveAll(tmp)
 
-	prvkey := crypto.ToECDSA(common.Hex2Bytes(hexprvkey))
+	prvkey, err := crypto.HexToECDSA(hexprvkey)
+	if err != nil {
+		t.Fatalf("failed to load private key: %v", err)
+	}
 	orig, err := NewConfig(tmp, common.Address{}, prvkey, 323)
 	if err != nil {
 		t.Fatalf("expected no error, got %v", err)

--- a/tests/util.go
+++ b/tests/util.go
@@ -18,7 +18,6 @@ package tests
 
 import (
 	"bytes"
-	"encoding/hex"
 	"fmt"
 	"math/big"
 	"os"
@@ -161,8 +160,8 @@ func NewEVMEnvironment(vmTest bool, chainConfig *params.ChainConfig, statedb *st
 
 	origin := common.HexToAddress(tx["caller"])
 	if len(tx["secretKey"]) > 0 {
-		key, _ := hex.DecodeString(tx["secretKey"])
-		origin = crypto.PubkeyToAddress(crypto.ToECDSA(key).PublicKey)
+		key, _ := crypto.HexToECDSA(tx["secretKey"])
+		origin = crypto.PubkeyToAddress(key.PublicKey)
 	}
 
 	var to *common.Address


### PR DESCRIPTION
Fixes https://github.com/ethereum/go-ethereum/issues/14481

The first commit changes our crypto API a bit so importing raw ECDSA keys are enforced to be 32 bytes in size not only for hex strings, but for raw byte slices too. The second commit surfaces importing raw keys into the mobile keystore (hence why it was important to enforce the correct bytes, to prevent users importing hex strings accidentally).