### PR TITLE
core/vm: allocate stack to 1024

### DIFF
--- a/core/vm/stack.go
+++ b/core/vm/stack.go
@@ -29,7 +29,7 @@ type Stack struct {
 }
 
 func newstack() *Stack {
-	return &Stack{}
+	return &Stack{data: make([]*big.Int, 0, 1024)}
 }
 
 func (st *Stack) Data() []*big.Int {


### PR DESCRIPTION
Pre allocate the stack to 1024 optimising stack pushing, reducing calls
to `runtime.makeslice` and `runtime.mallocgc`