### PR TITLE
eth: don't import propagated blocks during fastsync

### DIFF
--- a/eth/handler.go
+++ b/eth/handler.go
@@ -171,6 +171,11 @@ func NewProtocolManager(config *params.ChainConfig, mode downloader.SyncMode, ne
 		return blockchain.CurrentBlock().NumberU64()
 	}
 	inserter := func(blocks types.Blocks) (int, error) {
+		// If fast sync is running, deny importing weird blocks
+		if atomic.LoadUint32(&manager.fastSync) == 1 {
+			log.Warn("Discarded bad propagated block", "number", blocks[0].Number(), "hash", blocks[0].Hash())
+			return 0, nil
+		}
 		atomic.StoreUint32(&manager.acceptTxs, 1) // Mark initial sync done on any fetcher import
 		return manager.blockchain.InsertChain(blocks)
 	}

--- a/eth/sync.go
+++ b/eth/sync.go
@@ -183,6 +183,7 @@ func (pm *ProtocolManager) synchronise(peer *peer) {
 		// The only scenario where this can happen is if the user manually (or via a
 		// bad block) rolled back a fast sync node below the sync point. In this case
 		// however it's safe to reenable fast sync.
+		atomic.StoreUint32(&pm.fastSync, 1)
 		mode = downloader.FastSync
 	}
 	if err := pm.downloader.Synchronise(peer.id, pHead, pTd, mode); err != nil {


### PR DESCRIPTION
Fast sync operates on headers and block contents separately, assembling the final chain at the very end when committing the pivot block. Until that point, importing full blocks is ill advised as it could cause problems with the canonical chain status in the database.

This PR ensures that while fast sync is enabled, propagated blocks are discarded.