### PR TITLE
eth: update default gas price when not mining too

### DIFF
--- a/eth/api.go
+++ b/eth/api.go
@@ -154,7 +154,11 @@ func (api *PrivateMinerAPI) Start(threads *int) error {
 	// Start the miner and return
 	if !api.e.IsMining() {
 		// Propagate the initial price point to the transaction pool
-		api.e.txPool.SetGasPrice(api.e.gasPrice)
+		api.e.lock.RLock()
+		price := api.e.gasPrice
+		api.e.lock.RUnlock()
+
+		api.e.txPool.SetGasPrice(price)
 		return api.e.StartMining(true)
 	}
 	return nil
@@ -182,6 +186,10 @@ func (api *PrivateMinerAPI) SetExtra(extra string) (bool, error) {
 
 // SetGasPrice sets the minimum accepted gas price for the miner.
 func (api *PrivateMinerAPI) SetGasPrice(gasPrice hexutil.Big) bool {
+	api.e.lock.Lock()
+	api.e.gasPrice = (*big.Int)(&gasPrice)
+	api.e.lock.Unlock()
+
 	api.e.txPool.SetGasPrice((*big.Int)(&gasPrice))
 	return true
 }


### PR DESCRIPTION
This fixes a minor regression when calling `miner.setGasPrice`. Currently this invocation sets the gas price directly on the tx pool, but does not update the default value inside `eth.Ethereum`. If the miner is started later, during startup it will set the new gas price to whatever was in eth, possibly overriding our manual `setGasPrice` value.

This PR fixes it by not only updating the gas price on the tx pool when set via the API, but also the "default" one stored inside the Ethereum object.

It also add a lock around the gas price value (since it's settable now) and also `etherbase` (which was racey until now, alas it's probably almost never updated, so no real danger).