### PR TITLE
consensus/clique: cache block signatures for fast checks

### DIFF
--- a/consensus/clique/snapshot.go
+++ b/consensus/clique/snapshot.go
@@ -24,6 +24,7 @@ import (
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/ethdb"
 	"github.com/ethereum/go-ethereum/params"
+	lru "github.com/hashicorp/golang-lru"
 )
 
 // Vote represents a single vote that an authorized signer made to modify the
@@ -44,7 +45,8 @@ type Tally struct {
 
 // Snapshot is the state of the authorization voting at a given point in time.
 type Snapshot struct {
-	config *params.CliqueConfig // Consensus engine parameters to fine tune behavior
+	config   *params.CliqueConfig // Consensus engine parameters to fine tune behavior
+	sigcache *lru.ARCCache        // Cache of recent block signatures to speed up ecrecover
 
 	Number  uint64                      `json:"number"`  // Block number where the snapshot was created
 	Hash    common.Hash                 `json:"hash"`    // Block hash where the snapshot was created
@@ -57,14 +59,15 @@ type Snapshot struct {
 // newSnapshot create a new snapshot with the specified startup parameters. This
 // method does not initialize the set of recent signers, so only ever use if for
 // the genesis block.
-func newSnapshot(config *params.CliqueConfig, number uint64, hash common.Hash, signers []common.Address) *Snapshot {
+func newSnapshot(config *params.CliqueConfig, sigcache *lru.ARCCache, number uint64, hash common.Hash, signers []common.Address) *Snapshot {
 	snap := &Snapshot{
-		config:  config,
-		Number:  number,
-		Hash:    hash,
-		Signers: make(map[common.Address]struct{}),
-		Recents: make(map[uint64]common.Address),
-		Tally:   make(map[common.Address]Tally),
+		config:   config,
+		sigcache: sigcache,
+		Number:   number,
+		Hash:     hash,
+		Signers:  make(map[common.Address]struct{}),
+		Recents:  make(map[uint64]common.Address),
+		Tally:    make(map[common.Address]Tally),
 	}
 	for _, signer := range signers {
 		snap.Signers[signer] = struct{}{}
@@ -73,7 +76,7 @@ func newSnapshot(config *params.CliqueConfig, number uint64, hash common.Hash, s
 }
 
 // loadSnapshot loads an existing snapshot from the database.
-func loadSnapshot(config *params.CliqueConfig, db ethdb.Database, hash common.Hash) (*Snapshot, error) {
+func loadSnapshot(config *params.CliqueConfig, sigcache *lru.ARCCache, db ethdb.Database, hash common.Hash) (*Snapshot, error) {
 	blob, err := db.Get(append([]byte("clique-"), hash[:]...))
 	if err != nil {
 		return nil, err
@@ -83,6 +86,7 @@ func loadSnapshot(config *params.CliqueConfig, db ethdb.Database, hash common.Ha
 		return nil, err
 	}
 	snap.config = config
+	snap.sigcache = sigcache
 
 	return snap, nil
 }
@@ -99,13 +103,14 @@ func (s *Snapshot) store(db ethdb.Database) error {
 // copy creates a deep copy of the snapshot, though not the individual votes.
 func (s *Snapshot) copy() *Snapshot {
 	cpy := &Snapshot{
-		config:  s.config,
-		Number:  s.Number,
-		Hash:    s.Hash,
-		Signers: make(map[common.Address]struct{}),
-		Recents: make(map[uint64]common.Address),
-		Votes:   make([]*Vote, len(s.Votes)),
-		Tally:   make(map[common.Address]Tally),
+		config:   s.config,
+		sigcache: s.sigcache,
+		Number:   s.Number,
+		Hash:     s.Hash,
+		Signers:  make(map[common.Address]struct{}),
+		Recents:  make(map[uint64]common.Address),
+		Votes:    make([]*Vote, len(s.Votes)),
+		Tally:    make(map[common.Address]Tally),
 	}
 	for signer := range s.Signers {
 		cpy.Signers[signer] = struct{}{}
@@ -190,7 +195,7 @@ func (s *Snapshot) apply(headers []*types.Header) (*Snapshot, error) {
 			delete(snap.Recents, number-limit)
 		}
 		// Resolve the authorization key and check against signers
-		signer, err := ecrecover(header)
+		signer, err := ecrecover(header, s.sigcache)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
Generating the signer of a `clique` block is non negligible as it entails an `ecrecover` operation. As such, it's useful to cache the recently seen block's signers to avoid paying this cost, especially when importing large batches where concurrent processing means recovering the same signer multiple times concurrently.

The original code had a cache for the signatures, but it seems it was never finished as it was left unused. This PR adds the missing piece of actually caching recovered addresses and attempting to pick the signer out from the cache before doing a heavy ecrecover.

The end result on a Nexus 5X:

```
E/GoLog: INFO [05-29|18:56:45] Imported new block headers   count=192 elapsed=1.206s   number=192  hash=8c570c…ba360c ignored=0
E/GoLog: INFO [05-29|18:56:46] Imported new block headers   count=192 elapsed=1.151s   number=384  hash=6d95fa…a59e49 ignored=0
E/GoLog: INFO [05-29|18:56:54] Imported new block headers   count=1344 elapsed=8.154s  number=1728 hash=7eff72…2707a2 ignored=0
E/GoLog: INFO [05-29|18:57:07] Imported new block headers   count=2048 elapsed=12.361s number=3776 hash=60862f…3bf36d ignored=0
E/GoLog: INFO [05-29|18:57:10] Imported new block headers   count=448  elapsed=2.879s  number=4224 hash=c591be…e85d53 ignored=0
E/GoLog: INFO [05-29|18:57:22] Imported new block headers   count=2048 elapsed=12.411s number=6272 hash=4d5b3a…8df378 ignored=0
```

old vs. new

```
E/GoLog: INFO [05-29|19:02:02] Imported new block headers   count=192 elapsed=632.786ms  number=192   hash=8c570c…ba360c ignored=0
E/GoLog: INFO [05-29|19:02:02] Imported new block headers   count=192 elapsed=656.589ms  number=384   hash=6d95fa…a59e49 ignored=0
E/GoLog: INFO [05-29|19:02:05] Imported new block headers   count=768 elapsed=2.519s     number=1152  hash=9d3964…5b5a49 ignored=0
E/GoLog: INFO [05-29|19:02:08] Imported new block headers   count=960 elapsed=3.219s     number=2112  hash=cc3a9a…11d37c ignored=0
E/GoLog: INFO [05-29|19:02:16] Imported new block headers   count=2048 elapsed=7.433s    number=4160  hash=9104d6…600671 ignored=0
E/GoLog: INFO [05-29|19:02:23] Imported new block headers   count=2048 elapsed=7.049s    number=6208  hash=b55e40…482572 ignored=0
E/GoLog: INFO [05-29|19:02:28] Imported new block headers   count=1280 elapsed=4.402s    number=7488  hash=add5a8…599711 ignored=0
E/GoLog: INFO [05-29|19:02:35] Imported new block headers   count=2048 elapsed=7.016s    number=9536  hash=f21589…d35ebc ignored=0
```

On a Zenbook Pro, a light sync from 0 to head takes about 3:20 vs 2:05 with this change.

This one's for you @ligi (I was annoyed that Walleth syncs too much :P).