### PR TITLE
cmd/puppeth: fix improper key validation for remotes

### DIFF
--- a/cmd/puppeth/module_node.go
+++ b/cmd/puppeth/module_node.go
@@ -135,7 +135,7 @@ func deployNode(client *sshClient, network string, bootv4, bootv5 []string, conf
 	}
 	defer client.Run("rm -rf " + workdir)
 
-	// Build and deploy the bootnode service
+	// Build and deploy the boot or seal node service
 	return nil, client.Stream(fmt.Sprintf("cd %s && docker-compose -p %s up -d --build", workdir, network))
 }
 

--- a/cmd/puppeth/wizard_node.go
+++ b/cmd/puppeth/wizard_node.go
@@ -109,8 +109,7 @@ func (w *wizard) deployNode(boot bool) {
 		} else if w.conf.genesis.Config.Clique != nil {
 			// If a previous signer was already set, offer to reuse it
 			if infos.keyJSON != "" {
-				var key keystore.Key
-				if err := json.Unmarshal([]byte(infos.keyJSON), &key); err != nil {
+				if key, err := keystore.DecryptKey([]byte(infos.keyJSON), infos.keyPass); err != nil {
 					infos.keyJSON, infos.keyPass = "", ""
 				} else {
 					fmt.Println()


### PR DESCRIPTION
This PR fixes a bug surfaced by the ECDSA key length check introduced a few days ago. Puppeth contained a small bug where it validated a keyfile's contents by trying to unmarshal it into accounts.Key. However that represents a plain key, not an encrypted one. This PR swaps out the validation to the proper decryption method.

Interestingly the reason this worked until now is because we didn't use the key for anything, just checked if it unmarshals.