### PR TITLE
accounts/keystore, crypto: don't enforce key checks on existing keyfiles

### DIFF
--- a/accounts/keystore/keystore_passphrase.go
+++ b/accounts/keystore/keystore_passphrase.go
@@ -182,10 +182,8 @@ func DecryptKey(keyjson []byte, auth string) (*Key, error) {
 	if err != nil {
 		return nil, err
 	}
-	key, err := crypto.ToECDSA(keyBytes)
-	if err != nil {
-		return nil, err
-	}
+	key := crypto.ToECDSAUnsafe(keyBytes)
+
 	return &Key{
 		Id:         uuid.UUID(keyId),
 		Address:    crypto.PubkeyToAddress(key.PublicKey),

--- a/accounts/keystore/presale.go
+++ b/accounts/keystore/presale.go
@@ -74,10 +74,8 @@ func decryptPreSaleKey(fileContent []byte, password string) (key *Key, err error
 		return nil, err
 	}
 	ethPriv := crypto.Keccak256(plainText)
-	ecKey, err := crypto.ToECDSA(ethPriv)
-	if err != nil {
-		return nil, err
-	}
+	ecKey := crypto.ToECDSAUnsafe(ethPriv)
+
 	key = &Key{
 		Id:         nil,
 		Address:    crypto.PubkeyToAddress(ecKey.PublicKey),

--- a/crypto/crypto.go
+++ b/crypto/crypto.go
@@ -68,9 +68,6 @@ func Keccak512(data ...[]byte) []byte {
 	return d.Sum(nil)
 }
 
-// Deprecated: For backward compatibility as other packages depend on these
-func Sha3Hash(data ...[]byte) common.Hash { return Keccak256Hash(data...) }
-
 // Creates an ethereum address given the bytes and the nonce
 func CreateAddress(b common.Address, nonce uint64) common.Address {
 	data, _ := rlp.EncodeToBytes([]interface{}{b, nonce})
@@ -79,9 +76,24 @@ func CreateAddress(b common.Address, nonce uint64) common.Address {
 
 // ToECDSA creates a private key with the given D value.
 func ToECDSA(d []byte) (*ecdsa.PrivateKey, error) {
+	return toECDSA(d, true)
+}
+
+// ToECDSAUnsafe blidly converts a binary blob to a private key. It should almost
+// never be used unless you are sure the input is valid and want to avoid hitting
+// errors due to bad origin encoding (0 prefixes cut off).
+func ToECDSAUnsafe(d []byte) *ecdsa.PrivateKey {
+	priv, _ := toECDSA(d, false)
+	return priv
+}
+
+// toECDSA creates a private key with the given D value. The strict parameter
+// controls whether the key's length should be enforced at the curve size or
+// it can also accept legacy encodings (0 prefixes).
+func toECDSA(d []byte, strict bool) (*ecdsa.PrivateKey, error) {
 	priv := new(ecdsa.PrivateKey)
 	priv.PublicKey.Curve = S256()
-	if 8*len(d) != priv.Params().BitSize {
+	if strict && 8*len(d) != priv.Params().BitSize {
 		return nil, fmt.Errorf("invalid length, need %d bits", priv.Params().BitSize)
 	}
 	priv.D = new(big.Int).SetBytes(d)
@@ -89,11 +101,12 @@ func ToECDSA(d []byte) (*ecdsa.PrivateKey, error) {
 	return priv, nil
 }
 
-func FromECDSA(prv *ecdsa.PrivateKey) []byte {
-	if prv == nil {
+// FromECDSA exports a private key into a binary dump.
+func FromECDSA(priv *ecdsa.PrivateKey) []byte {
+	if priv == nil {
 		return nil
 	}
-	return math.PaddedBigBytes(prv.D, 32)
+	return math.PaddedBigBytes(priv.D, priv.Params().BitSize/8)
 }
 
 func ToECDSAPub(pub []byte) *ecdsa.PublicKey {
@@ -121,7 +134,6 @@ func HexToECDSA(hexkey string) (*ecdsa.PrivateKey, error) {
 }
 
 // LoadECDSA loads a secp256k1 private key from the given file.
-// The key data is expected to be hex-encoded.
 func LoadECDSA(file string) (*ecdsa.PrivateKey, error) {
 	buf := make([]byte, 64)
 	fd, err := os.Open(file)

--- a/crypto/crypto_test.go
+++ b/crypto/crypto_test.go
@@ -36,7 +36,7 @@ var testPrivHex = "289c2857d4598e37fb9647507e47a309d6133539bf21a8b9cb6df88fd5232
 // These tests are sanity checks.
 // They should ensure that we don't e.g. use Sha3-224 instead of Sha3-256
 // and that the sha3 library uses keccak-f permutation.
-func TestSha3Hash(t *testing.T) {
+func TestKeccak256Hash(t *testing.T) {
 	msg := []byte("abc")
 	exp, _ := hex.DecodeString("4e03657aea45a94fc7d47ba826c8d667c0d1e6e33a64a036ec44f58fa12d6c45")
 	checkhash(t, "Sha3-256-array", func(in []byte) []byte { h := Keccak256Hash(in); return h[:] }, msg, exp)


### PR DESCRIPTION
The https://github.com/ethereum/go-ethereum/pull/14502 PR turned out to be a bit overzealous. It enforced all private keys to be 256 bits. Although it makes sense, apparently there are some very old keyfiles lingering here and there that were encoded badly and thus fail to decode with the size enforcement.

This PR changes the logic so that enforcement is only done when creating new keys, but if a keyfile contains something weird already, it will still accept it.