### PR TITLE
core/vm: improve opByte

### DIFF
--- a/common/math/big.go
+++ b/common/math/big.go
@@ -130,10 +130,10 @@ func PaddedBigBytes(bigint *big.Int, n int) []byte {
 	return ret
 }
 
-// LittleEndianByteAt returns the byte at position n,
-// if bigint is considered little-endian.
-// So n==0 gives the least significant byte
-func LittleEndianByteAt(bigint *big.Int, n int) byte {
+// bigEndianByteAt returns the byte at position n,
+// if bigint is considered big-endian.
+// So n==0 returns the least significant byte
+func bigEndianByteAt(bigint *big.Int, n int) byte {
 	words := bigint.Bits()
 	// Check word-bucket the byte will reside in
 	i := n / wordBytes
@@ -147,15 +147,15 @@ func LittleEndianByteAt(bigint *big.Int, n int) byte {
 	return byte(word >> shift)
 }
 
-// BigEndian32ByteAt returns the byte at position n,
-// if bigint is considered big-endian.
-// So n==0 gives the most significant byte
-// WARNING: Only works for bigints in 32-byte range
-func BigEndian32ByteAt(bigint *big.Int, n int) byte {
-	if n > 31 {
+// Byte returns the byte at position n,
+// if bigint is considered little-endian with the supplied padlength.
+// n==0 returns the most significant byte
+// bigint '5', padlength 32, n=31 => 5
+func Byte(bigint *big.Int, padlength, n int) byte {
+	if n >= padlength {
 		return byte(0)
 	}
-	return LittleEndianByteAt(bigint, 31-n)
+	return bigEndianByteAt(bigint, padlength-1-n)
 }
 
 // ReadBits encodes the absolute value of bigint as big-endian bytes. Callers must ensure

--- a/common/math/big.go
+++ b/common/math/big.go
@@ -130,6 +130,34 @@ func PaddedBigBytes(bigint *big.Int, n int) []byte {
 	return ret
 }
 
+// LittleEndianByteAt returns the byte at position n,
+// if bigint is considered little-endian.
+// So n==0 gives the least significant byte
+func LittleEndianByteAt(bigint *big.Int, n int) byte {
+	words := bigint.Bits()
+	// Check word-bucket the byte will reside in
+	i := n / wordBytes
+	if i >= len(words) {
+		return byte(0)
+	}
+	word := words[i]
+	// Offset of the byte
+	shift := 8 * uint(n%wordBytes)
+
+	return byte(word >> shift)
+}
+
+// BigEndian32ByteAt returns the byte at position n,
+// if bigint is considered big-endian.
+// So n==0 gives the most significant byte
+// WARNING: Only works for bigints in 32-byte range
+func BigEndian32ByteAt(bigint *big.Int, n int) byte {
+	if n > 31 {
+		return byte(0)
+	}
+	return LittleEndianByteAt(bigint, 31-n)
+}
+
 // ReadBits encodes the absolute value of bigint as big-endian bytes. Callers must ensure
 // that buf has enough space. If buf is too short the result will be incomplete.
 func ReadBits(bigint *big.Int, buf []byte) {

--- a/common/math/big.go
+++ b/common/math/big.go
@@ -131,7 +131,7 @@ func PaddedBigBytes(bigint *big.Int, n int) []byte {
 }
 
 // bigEndianByteAt returns the byte at position n,
-// if bigint is considered big-endian.
+// in Big-Endian encoding
 // So n==0 returns the least significant byte
 func bigEndianByteAt(bigint *big.Int, n int) byte {
 	words := bigint.Bits()
@@ -148,9 +148,9 @@ func bigEndianByteAt(bigint *big.Int, n int) byte {
 }
 
 // Byte returns the byte at position n,
-// if bigint is considered little-endian with the supplied padlength.
-// n==0 returns the most significant byte
-// bigint '5', padlength 32, n=31 => 5
+// with the supplied padlength in Little-Endian encoding.
+// n==0 returns the MSB
+// Example: bigint '5', padlength 32, n=31 => 5
 func Byte(bigint *big.Int, padlength, n int) byte {
 	if n >= padlength {
 		return byte(0)

--- a/common/math/big_test.go
+++ b/common/math/big_test.go
@@ -141,6 +141,7 @@ func BenchmarkPaddedBigBytesLargePadding(b *testing.B) {
 		PaddedBigBytes(bigint, 200)
 	}
 }
+
 func BenchmarkPaddedBigBytesSmallPadding(b *testing.B) {
 	bigint := MustParseBig256("0x18F8F8F1000111000110011100222004330052300000000000000000FEFCF3CC")
 	for i := 0; i < b.N; i++ {
@@ -154,18 +155,21 @@ func BenchmarkPaddedBigBytesSmallOnePadding(b *testing.B) {
 		PaddedBigBytes(bigint, 32)
 	}
 }
+
 func BenchmarkByteAtBrandNew(b *testing.B) {
 	bigint := MustParseBig256("0x18F8F8F1000111000110011100222004330052300000000000000000FEFCF3CC")
 	for i := 0; i < b.N; i++ {
 		bigEndianByteAt(bigint, 15)
 	}
 }
+
 func BenchmarkByteAt(b *testing.B) {
 	bigint := MustParseBig256("0x18F8F8F1000111000110011100222004330052300000000000000000FEFCF3CC")
 	for i := 0; i < b.N; i++ {
 		bigEndianByteAt(bigint, 15)
 	}
 }
+
 func BenchmarkByteAtOld(b *testing.B) {
 
 	bigint := MustParseBig256("0x18F8F8F1000111000110011100222004330052300000000000000000FEFCF3CC")
@@ -207,21 +211,22 @@ func TestU256(t *testing.T) {
 		}
 	}
 }
-func TestLittleEndianByteAt(t *testing.T) {
 
+func TestBigEndianByteAt(t *testing.T) {
 	tests := []struct {
 		x   string
 		y   int
 		exp byte
 	}{
-		{"0", 0, 0x00},
-		{"1", 1, 0x00},
-		{"0", 1, 0x00},
-		//{"1", 0, 0x01},
+		{"00", 0, 0x00},
+		{"01", 1, 0x00},
+		{"00", 1, 0x00},
+		{"01", 0, 0x01},
 		{"0000000000000000000000000000000000000000000000000000000000102030", 0, 0x30},
 		{"0000000000000000000000000000000000000000000000000000000000102030", 1, 0x20},
 		{"ABCDEF0908070605040302010000000000000000000000000000000000000000", 31, 0xAB},
 		{"ABCDEF0908070605040302010000000000000000000000000000000000000000", 32, 0x00},
+		{"ABCDEF0908070605040302010000000000000000000000000000000000000000", 500, 0x00},
 	}
 	for _, test := range tests {
 		v := new(big.Int).SetBytes(common.Hex2Bytes(test.x))
@@ -232,17 +237,16 @@ func TestLittleEndianByteAt(t *testing.T) {
 
 	}
 }
-func TestBigEndianByteAt(t *testing.T) {
-
+func TestLittleEndianByteAt(t *testing.T) {
 	tests := []struct {
 		x   string
 		y   int
 		exp byte
 	}{
-		{"0", 0, 0x00},
-		{"1", 1, 0x00},
-		{"0", 1, 0x00},
-		{"1", 0, 0x00},
+		{"00", 0, 0x00},
+		{"01", 1, 0x00},
+		{"00", 1, 0x00},
+		{"01", 0, 0x00},
 		{"0000000000000000000000000000000000000000000000000000000000102030", 0, 0x00},
 		{"0000000000000000000000000000000000000000000000000000000000102030", 1, 0x00},
 		{"ABCDEF0908070605040302010000000000000000000000000000000000000000", 31, 0x00},
@@ -266,6 +270,7 @@ func TestBigEndianByteAt(t *testing.T) {
 
 	}
 }
+
 func TestS256(t *testing.T) {
 	tests := []struct{ x, y *big.Int }{
 		{x: big.NewInt(0), y: big.NewInt(0)},

--- a/common/math/big_test.go
+++ b/common/math/big_test.go
@@ -157,13 +157,13 @@ func BenchmarkPaddedBigBytesSmallOnePadding(b *testing.B) {
 func BenchmarkByteAtBrandNew(b *testing.B) {
 	bigint := MustParseBig256("0x18F8F8F1000111000110011100222004330052300000000000000000FEFCF3CC")
 	for i := 0; i < b.N; i++ {
-		BigEndian32ByteAt(bigint, 15)
+		bigEndianByteAt(bigint, 15)
 	}
 }
 func BenchmarkByteAt(b *testing.B) {
 	bigint := MustParseBig256("0x18F8F8F1000111000110011100222004330052300000000000000000FEFCF3CC")
 	for i := 0; i < b.N; i++ {
-		BigEndian32ByteAt(bigint, 15)
+		bigEndianByteAt(bigint, 15)
 	}
 }
 func BenchmarkByteAtOld(b *testing.B) {
@@ -225,7 +225,7 @@ func TestLittleEndianByteAt(t *testing.T) {
 	}
 	for _, test := range tests {
 		v := new(big.Int).SetBytes(common.Hex2Bytes(test.x))
-		actual := LittleEndianByteAt(v, test.y)
+		actual := bigEndianByteAt(v, test.y)
 		if actual != test.exp {
 			t.Fatalf("Expected  [%v] %v:th byte to be %v, was %v.", test.x, test.y, test.exp, actual)
 		}
@@ -254,11 +254,12 @@ func TestBigEndianByteAt(t *testing.T) {
 		{"0000000000000000000000000000000000000000000000000000000000102030", 31, 0x30},
 		{"0000000000000000000000000000000000000000000000000000000000102030", 30, 0x20},
 		{"ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff", 32, 0x0},
-		{"ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff", 0xFFFFFFFF, 0x0},
+		{"ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff", 31, 0xFF},
+		{"ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff", 0xFFFF, 0x0},
 	}
 	for _, test := range tests {
 		v := new(big.Int).SetBytes(common.Hex2Bytes(test.x))
-		actual := BigEndian32ByteAt(v, test.y)
+		actual := Byte(v, 32, test.y)
 		if actual != test.exp {
 			t.Fatalf("Expected  [%v] %v:th byte to be %v, was %v.", test.x, test.y, test.exp, actual)
 		}

--- a/common/math/big_test.go
+++ b/common/math/big_test.go
@@ -21,6 +21,8 @@ import (
 	"encoding/hex"
 	"math/big"
 	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
 )
 
 func TestHexOrDecimal256(t *testing.T) {
@@ -133,8 +135,40 @@ func TestPaddedBigBytes(t *testing.T) {
 	}
 }
 
-func BenchmarkPaddedBigBytes(b *testing.B) {
+func BenchmarkPaddedBigBytesLargePadding(b *testing.B) {
 	bigint := MustParseBig256("123456789123456789123456789123456789")
+	for i := 0; i < b.N; i++ {
+		PaddedBigBytes(bigint, 200)
+	}
+}
+func BenchmarkPaddedBigBytesSmallPadding(b *testing.B) {
+	bigint := MustParseBig256("0x18F8F8F1000111000110011100222004330052300000000000000000FEFCF3CC")
+	for i := 0; i < b.N; i++ {
+		PaddedBigBytes(bigint, 5)
+	}
+}
+
+func BenchmarkPaddedBigBytesSmallOnePadding(b *testing.B) {
+	bigint := MustParseBig256("0x18F8F8F1000111000110011100222004330052300000000000000000FEFCF3CC")
+	for i := 0; i < b.N; i++ {
+		PaddedBigBytes(bigint, 32)
+	}
+}
+func BenchmarkByteAtBrandNew(b *testing.B) {
+	bigint := MustParseBig256("0x18F8F8F1000111000110011100222004330052300000000000000000FEFCF3CC")
+	for i := 0; i < b.N; i++ {
+		BigEndian32ByteAt(bigint, 15)
+	}
+}
+func BenchmarkByteAt(b *testing.B) {
+	bigint := MustParseBig256("0x18F8F8F1000111000110011100222004330052300000000000000000FEFCF3CC")
+	for i := 0; i < b.N; i++ {
+		BigEndian32ByteAt(bigint, 15)
+	}
+}
+func BenchmarkByteAtOld(b *testing.B) {
+
+	bigint := MustParseBig256("0x18F8F8F1000111000110011100222004330052300000000000000000FEFCF3CC")
 	for i := 0; i < b.N; i++ {
 		PaddedBigBytes(bigint, 32)
 	}
@@ -173,7 +207,64 @@ func TestU256(t *testing.T) {
 		}
 	}
 }
+func TestLittleEndianByteAt(t *testing.T) {
 
+	tests := []struct {
+		x   string
+		y   int
+		exp byte
+	}{
+		{"0", 0, 0x00},
+		{"1", 1, 0x00},
+		{"0", 1, 0x00},
+		//{"1", 0, 0x01},
+		{"0000000000000000000000000000000000000000000000000000000000102030", 0, 0x30},
+		{"0000000000000000000000000000000000000000000000000000000000102030", 1, 0x20},
+		{"ABCDEF0908070605040302010000000000000000000000000000000000000000", 31, 0xAB},
+		{"ABCDEF0908070605040302010000000000000000000000000000000000000000", 32, 0x00},
+	}
+	for _, test := range tests {
+		v := new(big.Int).SetBytes(common.Hex2Bytes(test.x))
+		actual := LittleEndianByteAt(v, test.y)
+		if actual != test.exp {
+			t.Fatalf("Expected  [%v] %v:th byte to be %v, was %v.", test.x, test.y, test.exp, actual)
+		}
+
+	}
+}
+func TestBigEndianByteAt(t *testing.T) {
+
+	tests := []struct {
+		x   string
+		y   int
+		exp byte
+	}{
+		{"0", 0, 0x00},
+		{"1", 1, 0x00},
+		{"0", 1, 0x00},
+		{"1", 0, 0x00},
+		{"0000000000000000000000000000000000000000000000000000000000102030", 0, 0x00},
+		{"0000000000000000000000000000000000000000000000000000000000102030", 1, 0x00},
+		{"ABCDEF0908070605040302010000000000000000000000000000000000000000", 31, 0x00},
+		{"ABCDEF0908070605040302010000000000000000000000000000000000000000", 32, 0x00},
+		{"ABCDEF0908070605040302010000000000000000000000000000000000000000", 0, 0xAB},
+		{"ABCDEF0908070605040302010000000000000000000000000000000000000000", 1, 0xCD},
+		{"00CDEF090807060504030201ffffffffffffffffffffffffffffffffffffffff", 0, 0x00},
+		{"00CDEF090807060504030201ffffffffffffffffffffffffffffffffffffffff", 1, 0xCD},
+		{"0000000000000000000000000000000000000000000000000000000000102030", 31, 0x30},
+		{"0000000000000000000000000000000000000000000000000000000000102030", 30, 0x20},
+		{"ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff", 32, 0x0},
+		{"ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff", 0xFFFFFFFF, 0x0},
+	}
+	for _, test := range tests {
+		v := new(big.Int).SetBytes(common.Hex2Bytes(test.x))
+		actual := BigEndian32ByteAt(v, test.y)
+		if actual != test.exp {
+			t.Fatalf("Expected  [%v] %v:th byte to be %v, was %v.", test.x, test.y, test.exp, actual)
+		}
+
+	}
+}
 func TestS256(t *testing.T) {
 	tests := []struct{ x, y *big.Int }{
 		{x: big.NewInt(0), y: big.NewInt(0)},

--- a/core/vm/instructions.go
+++ b/core/vm/instructions.go
@@ -258,8 +258,8 @@ func opXor(pc *uint64, evm *EVM, contract *Contract, memory *Memory, stack *Stac
 func opByte(pc *uint64, evm *EVM, contract *Contract, memory *Memory, stack *Stack) ([]byte, error) {
 	th, val := stack.pop(), stack.peek()
 	if th.Cmp(common.Big32) < 0 {
-		b := math.BigEndian32ByteAt(val, int(th.Int64()))
-		val.SetInt64(int64(b))
+		b := math.Byte(val, 32, int(th.Int64()))
+		val.SetUint64(uint64(b))
 	} else {
 		val.SetUint64(0)
 	}

--- a/core/vm/instructions.go
+++ b/core/vm/instructions.go
@@ -256,15 +256,14 @@ func opXor(pc *uint64, evm *EVM, contract *Contract, memory *Memory, stack *Stac
 }
 
 func opByte(pc *uint64, evm *EVM, contract *Contract, memory *Memory, stack *Stack) ([]byte, error) {
-	th, val := stack.pop(), stack.pop()
-	if th.Cmp(big.NewInt(32)) < 0 {
-		byte := evm.interpreter.intPool.get().SetInt64(int64(math.PaddedBigBytes(val, 32)[th.Int64()]))
-		stack.push(byte)
+	th, val := stack.pop(), stack.peek()
+	if th.Cmp(common.Big32) < 0 {
+		b := math.BigEndian32ByteAt(val, int(th.Int64()))
+		val.SetInt64(int64(b))
 	} else {
-		stack.push(new(big.Int))
+		val.SetUint64(0)
 	}
-
-	evm.interpreter.intPool.put(th, val)
+	evm.interpreter.intPool.put(th)
 	return nil, nil
 }
 func opAddmod(pc *uint64, evm *EVM, contract *Contract, memory *Memory, stack *Stack) ([]byte, error) {

--- a/core/vm/instructions_test.go
+++ b/core/vm/instructions_test.go
@@ -9,7 +9,6 @@ import (
 )
 
 func TestByteOp(t *testing.T) {
-
 	var (
 		env   = NewEVM(Context{}, nil, params.TestChainConfig, Config{EnableJit: false, ForceJit: false})
 		stack = newstack()

--- a/core/vm/instructions_test.go
+++ b/core/vm/instructions_test.go
@@ -1,0 +1,43 @@
+package vm
+
+import (
+	"math/big"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/params"
+)
+
+func TestByteOp(t *testing.T) {
+
+	var (
+		env   = NewEVM(Context{}, nil, params.TestChainConfig, Config{EnableJit: false, ForceJit: false})
+		stack = newstack()
+	)
+	tests := []struct {
+		v        string
+		th       uint64
+		expected *big.Int
+	}{
+		{"ABCDEF0908070605040302010000000000000000000000000000000000000000", 0, big.NewInt(0xAB)},
+		{"ABCDEF0908070605040302010000000000000000000000000000000000000000", 1, big.NewInt(0xCD)},
+		{"00CDEF090807060504030201ffffffffffffffffffffffffffffffffffffffff", 0, big.NewInt(0x00)},
+		{"00CDEF090807060504030201ffffffffffffffffffffffffffffffffffffffff", 1, big.NewInt(0xCD)},
+		{"0000000000000000000000000000000000000000000000000000000000102030", 31, big.NewInt(0x30)},
+		{"0000000000000000000000000000000000000000000000000000000000102030", 30, big.NewInt(0x20)},
+		{"ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff", 32, big.NewInt(0x0)},
+		{"ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff", 0xFFFFFFFFFFFFFFFF, big.NewInt(0x0)},
+	}
+	pc := uint64(0)
+	for _, test := range tests {
+		val := new(big.Int).SetBytes(common.Hex2Bytes(test.v))
+		th := new(big.Int).SetUint64(test.th)
+		stack.push(val)
+		stack.push(th)
+		opByte(&pc, env, nil, nil, stack)
+		actual := stack.pop()
+		if actual.Cmp(test.expected) != 0 {
+			t.Fatalf("Expected  [%v] %v:th byte to be %v, was %v.", test.v, test.th, test.expected, actual)
+		}
+	}
+}


### PR DESCRIPTION
This PR makes the `BYTE` operation much faster, since 
* it does not need to allocate a full bytearray (which is then discarded)
* it does not go through the entire `bigint`, but insted reaches directly into the desired byte. 

