### PR TITLE
core: Fix VM error logging

### DIFF
--- a/core/state_transition.go
+++ b/core/state_transition.go
@@ -243,7 +243,7 @@ func (st *StateTransition) TransitionDb() (ret []byte, requiredGas, usedGas *big
 		ret, st.gas, vmerr = evm.Call(sender, st.to().Address(), st.data, st.gas, st.value)
 	}
 	if vmerr != nil {
-		log.Debug("VM returned with error", "err", err)
+		log.Debug("VM returned with error", "err", vmerr)
 		// The only possible consensus-error would be if there wasn't
 		// sufficient balance to make the transfer happen. The first
 		// balance transfer may never fail.


### PR DESCRIPTION
Before:

```
DEBUG[06-03|22:56:51] VM returned with error   err=nil
```

After:

```
DEBUG[06-03|22:57:32] VM returned with error   err="invalid jump destination (PUSH1) 0"
```