### PR TITLE
core/types: rlpHash(b.header) should instead use header.Hash()

### DIFF
--- a/core/types/block.go
+++ b/core/types/block.go
@@ -381,7 +381,7 @@ func (b *Block) Hash() common.Hash {
 	if hash := b.hash.Load(); hash != nil {
 		return hash.(common.Hash)
 	}
-	v := rlpHash(b.header)
+	v := b.header.Hash()
 	b.hash.Store(v)
 	return v
 }


### PR DESCRIPTION
please refer to https://github.com/ethereum/go-ethereum/issues/14586