### PR TITLE
consensus/ethash, cmd/geth: Fix `makedag` epoch

### DIFF
--- a/consensus/ethash/ethash.go
+++ b/consensus/ethash/ethash.go
@@ -308,14 +308,14 @@ func (d *dataset) release() {
 
 // MakeCache generates a new ethash cache and optionally stores it to disk.
 func MakeCache(block uint64, dir string) {
-	c := cache{epoch: block/epochLength + 1}
+	c := cache{epoch: block / epochLength}
 	c.generate(dir, math.MaxInt32, false)
 	c.release()
 }
 
 // MakeDataset generates a new ethash dataset and optionally stores it to disk.
 func MakeDataset(block uint64, dir string) {
-	d := dataset{epoch: block/epochLength + 1}
+	d := dataset{epoch: block / epochLength}
 	d.generate(dir, math.MaxInt32, false)
 	d.release()
 }


### PR DESCRIPTION
`geth makedag <blocknumber> <path>` was creating DAGs for `<blocknumber>/<epoch_length> + 1`, hence it was impossible to create an epoch 0 DAG.