### PR TITLE
mobile: use EIP155 signer for determining sender

### DIFF
--- a/mobile/types.go
+++ b/mobile/types.go
@@ -264,8 +264,11 @@ func (tx *Transaction) GetHash() *Hash    { return &Hash{tx.tx.Hash()} }
 func (tx *Transaction) GetSigHash() *Hash { return &Hash{tx.tx.SigHash(types.HomesteadSigner{})} }
 func (tx *Transaction) GetCost() *BigInt  { return &BigInt{tx.tx.Cost()} }
 
-func (tx *Transaction) GetFrom() (address *Address, _ error) {
-	from, err := types.Sender(types.HomesteadSigner{}, tx.tx)
+func (tx *Transaction) GetFrom(chainID *BigInt) (address *Address, _ error) {
+	if chainID == nil { // Null passed from mobile app
+		chainID = new(BigInt)
+	}
+	from, err := types.Sender(types.NewEIP155Signer(chainID.bigint), tx.tx)
 	return &Address{from}, err
 }
 


### PR DESCRIPTION
Currently the mobile package uses the homestead signer for deriving the sender address. This PR replaces the homestead signer with the eip155 signer and expects the client to pass the chain id.

Fixes #14599

@karalabe since this is a package for mobile I'm not sure if anything special is required. I also added a unittest but am not sure if this can cause problems?