### PR TITLE
cmd/evm: disable memory/stack output

### DIFF
--- a/cmd/evm/main.go
+++ b/cmd/evm/main.go
@@ -102,6 +102,14 @@ var (
 		Name:  "sender",
 		Usage: "The transaction origin",
 	}
+	DisableMemoryFlag = cli.BoolFlag{
+		Name:  "nomemory",
+		Usage: "disable memory output",
+	}
+	DisableStackFlag = cli.BoolFlag{
+		Name:  "nostack",
+		Usage: "disable stack output",
+	}
 )
 
 func init() {
@@ -123,6 +131,8 @@ func init() {
 		GenesisFlag,
 		MachineFlag,
 		SenderFlag,
+		DisableMemoryFlag,
+		DisableStackFlag,
 	}
 	app.Commands = []cli.Command{
 		compileCommand,

--- a/cmd/evm/runner.go
+++ b/cmd/evm/runner.go
@@ -73,6 +73,10 @@ func runCmd(ctx *cli.Context) error {
 	glogger := log.NewGlogHandler(log.StreamHandler(os.Stderr, log.TerminalFormat(false)))
 	glogger.Verbosity(log.Lvl(ctx.GlobalInt(VerbosityFlag.Name)))
 	log.Root().SetHandler(glogger)
+	logconfig := &vm.LogConfig{
+		DisableMemory: ctx.GlobalBool(DisableMemoryFlag.Name),
+		DisableStack:  ctx.GlobalBool(DisableStackFlag.Name),
+	}
 
 	var (
 		tracer      vm.Tracer
@@ -82,12 +86,12 @@ func runCmd(ctx *cli.Context) error {
 		sender      = common.StringToAddress("sender")
 	)
 	if ctx.GlobalBool(MachineFlag.Name) {
-		tracer = NewJSONLogger(os.Stdout)
+		tracer = NewJSONLogger(logconfig, os.Stdout)
 	} else if ctx.GlobalBool(DebugFlag.Name) {
-		debugLogger = vm.NewStructLogger(nil)
+		debugLogger = vm.NewStructLogger(logconfig)
 		tracer = debugLogger
 	} else {
-		debugLogger = vm.NewStructLogger(nil)
+		debugLogger = vm.NewStructLogger(logconfig)
 	}
 	if ctx.GlobalString(GenesisFlag.Name) != "" {
 		gen := readGenesis(ctx.GlobalString(GenesisFlag.Name))

--- a/core/vm/gen_structlog.go
+++ b/core/vm/gen_structlog.go
@@ -18,12 +18,12 @@ func (s StructLog) MarshalJSON() ([]byte, error) {
 		Gas        math.HexOrDecimal64         `json:"gas"`
 		GasCost    math.HexOrDecimal64         `json:"gasCost"`
 		Memory     hexutil.Bytes               `json:"memory"`
+		MemorySize int                         `json:"memSize"`
 		Stack      []*math.HexOrDecimal256     `json:"stack"`
 		Storage    map[common.Hash]common.Hash `json:"-"`
 		Depth      int                         `json:"depth"`
 		Err        error                       `json:"error"`
 		OpName     string                      `json:"opName"`
-		MemorySize int                         `json:"memSize"`
 	}
 	var enc StructLog
 	enc.Pc = s.Pc
@@ -31,6 +31,7 @@ func (s StructLog) MarshalJSON() ([]byte, error) {
 	enc.Gas = math.HexOrDecimal64(s.Gas)
 	enc.GasCost = math.HexOrDecimal64(s.GasCost)
 	enc.Memory = s.Memory
+	enc.MemorySize = s.MemorySize
 	if s.Stack != nil {
 		enc.Stack = make([]*math.HexOrDecimal256, len(s.Stack))
 		for k, v := range s.Stack {
@@ -41,21 +42,21 @@ func (s StructLog) MarshalJSON() ([]byte, error) {
 	enc.Depth = s.Depth
 	enc.Err = s.Err
 	enc.OpName = s.OpName()
-	enc.MemorySize = s.MemorySize()
 	return json.Marshal(&enc)
 }
 
 func (s *StructLog) UnmarshalJSON(input []byte) error {
 	type StructLog struct {
-		Pc      *uint64                     `json:"pc"`
-		Op      *OpCode                     `json:"op"`
-		Gas     *math.HexOrDecimal64        `json:"gas"`
-		GasCost *math.HexOrDecimal64        `json:"gasCost"`
-		Memory  hexutil.Bytes               `json:"memory"`
-		Stack   []*math.HexOrDecimal256     `json:"stack"`
-		Storage map[common.Hash]common.Hash `json:"-"`
-		Depth   *int                        `json:"depth"`
-		Err     *error                      `json:"error"`
+		Pc         *uint64                     `json:"pc"`
+		Op         *OpCode                     `json:"op"`
+		Gas        *math.HexOrDecimal64        `json:"gas"`
+		GasCost    *math.HexOrDecimal64        `json:"gasCost"`
+		Memory     hexutil.Bytes               `json:"memory"`
+		MemorySize *int                        `json:"memSize"`
+		Stack      []*math.HexOrDecimal256     `json:"stack"`
+		Storage    map[common.Hash]common.Hash `json:"-"`
+		Depth      *int                        `json:"depth"`
+		Err        *error                      `json:"error"`
 	}
 	var dec StructLog
 	if err := json.Unmarshal(input, &dec); err != nil {
@@ -75,6 +76,9 @@ func (s *StructLog) UnmarshalJSON(input []byte) error {
 	}
 	if dec.Memory != nil {
 		s.Memory = dec.Memory
+	}
+	if dec.MemorySize != nil {
+		s.MemorySize = *dec.MemorySize
 	}
 	if dec.Stack != nil {
 		s.Stack = make([]*big.Int, len(dec.Stack))

--- a/core/vm/logger.go
+++ b/core/vm/logger.go
@@ -54,33 +54,29 @@ type LogConfig struct {
 // StructLog is emitted to the EVM each cycle and lists information about the current internal state
 // prior to the execution of the statement.
 type StructLog struct {
-	Pc      uint64                      `json:"pc"`
-	Op      OpCode                      `json:"op"`
-	Gas     uint64                      `json:"gas"`
-	GasCost uint64                      `json:"gasCost"`
-	Memory  []byte                      `json:"memory"`
-	Stack   []*big.Int                  `json:"stack"`
-	Storage map[common.Hash]common.Hash `json:"-"`
-	Depth   int                         `json:"depth"`
-	Err     error                       `json:"error"`
+	Pc         uint64                      `json:"pc"`
+	Op         OpCode                      `json:"op"`
+	Gas        uint64                      `json:"gas"`
+	GasCost    uint64                      `json:"gasCost"`
+	Memory     []byte                      `json:"memory"`
+	MemorySize int                         `json:"memSize"`
+	Stack      []*big.Int                  `json:"stack"`
+	Storage    map[common.Hash]common.Hash `json:"-"`
+	Depth      int                         `json:"depth"`
+	Err        error                       `json:"error"`
 }
 
 // overrides for gencodec
 type structLogMarshaling struct {
-	Stack      []*math.HexOrDecimal256
-	Gas        math.HexOrDecimal64
-	GasCost    math.HexOrDecimal64
-	Memory     hexutil.Bytes
-	OpName     string `json:"opName"`
-	MemorySize int    `json:"memSize"`
+	Stack   []*math.HexOrDecimal256
+	Gas     math.HexOrDecimal64
+	GasCost math.HexOrDecimal64
+	Memory  hexutil.Bytes
+	OpName  string `json:"opName"`
 }
 
 func (s *StructLog) OpName() string {
 	return s.Op.String()
-}
-
-func (s *StructLog) MemorySize() int {
-	return len(s.Memory)
 }
 
 // Tracer is used to collect execution traces from an EVM transaction
@@ -181,7 +177,7 @@ func (l *StructLogger) CaptureState(env *EVM, pc uint64, op OpCode, gas, cost ui
 		}
 	}
 	// create a new snaptshot of the EVM.
-	log := StructLog{pc, op, gas, cost, mem, stck, storage, env.depth, err}
+	log := StructLog{pc, op, gas, cost, mem, memory.Len(), stck, storage, depth, err}
 
 	l.logs = append(l.logs, log)
 	return nil


### PR DESCRIPTION
This  PR adds the flags `--nomemory` and `--nostack` to evm, but allows for having `memSize` even so . 

This is useful in many cases, for example with the jumpdest-attack analysis. With this PR
```
#/home/martin/go/src/github.com/ethereum/go-ethereum/build/bin/evm --statdump --code 6000600060006000600073921e2bb71c7ebda36f39d8d34b336359db186f515af150 --prestate /tmp/tmpsBom4c.json --gas 4700000 --sender 0x457c428117c1b8507111392d50876a9d548a6d36 --nomemory --json  run
... 
{"pc":4149,"op":96,"gas":"0x7b4","gasCost":"0x3","memory":"0x","memSize":524288,"stack":["0x7b","0x80000","0x0"],"depth":2,"error":null,"opName":"PUSH1"}
{"pc":4151,"op":240,"gas":"0x84b1","gasCost":"0x7d00","memory":"0x","memSize":524288,"stack":["0x7b","0x80000","0x0","0x0"],"depth":2,"error":{},"opName":"CREATE"}
{"pc":33,"op":80,"gas":"0x11ed2","gasCost":"0x2","memory":"0x","memSize":0,"stack":["0x0"],"depth":1,"error":null,"opName":"POP"}
{"pc":34,"op":0,"gas":"0x11ed0","gasCost":"0x0","memory":"0x","memSize":0,"stack":[],"depth":1,"error":null,"opName":"STOP"}
evm execution time: 427.988437ms
heap objects:       11804
allocations:        14850856
total allocations:  84145880
GC calls:           16
Gas used:           4626576
```
With full memory output, it basically hogs my machine for three minutes: 
```
...
[],"depth":1,"error":null,"opName":"STOP"}
evm execution time: 3m13.388057499s
heap objects:       9054
allocations:        20433368
total allocations:  7830715848
GC calls:           1067
Gas used:           4626576

{"output":"","gasUsed":"0x469890","time":193388057499}
``` 