### PR TITLE
eth: remove les server from protocol manager

### DIFF
--- a/eth/backend.go
+++ b/eth/backend.go
@@ -88,7 +88,6 @@ type Ethereum struct {
 
 func (s *Ethereum) AddLesServer(ls LesServer) {
 	s.lesServer = ls
-	s.protocolManager.lesServer = ls
 }
 
 // New creates a new Ethereum object (including the

--- a/eth/handler.go
+++ b/eth/handler.go
@@ -87,8 +87,6 @@ type ProtocolManager struct {
 	quitSync    chan struct{}
 	noMorePeers chan struct{}
 
-	lesServer LesServer
-
 	// wait group is used for graceful shutdowns during downloading
 	// and processing
 	wg sync.WaitGroup


### PR DESCRIPTION
`lesServer` is unused in `eth.ProtocolManager` so it can be removed.