### PR TITLE
cmd/swarm: Support using Mainnet for resolving ENS names

### DIFF
--- a/contracts/ens/ens.go
+++ b/contracts/ens/ens.go
@@ -29,6 +29,11 @@ import (
 	"github.com/ethereum/go-ethereum/crypto"
 )
 
+var (
+	MainNetAddress = common.HexToAddress("0x314159265dD8dbb310642f98f50C066173C1259b")
+	TestNetAddress = common.HexToAddress("0x112234455c3a32fd11230c42e7bccd4a84e02010")
+)
+
 // swarm domain name registry and resolver
 type ENS struct {
 	*contract.ENSSession

--- a/swarm/api/config.go
+++ b/swarm/api/config.go
@@ -25,6 +25,7 @@ import (
 	"path/filepath"
 
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/contracts/ens"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/swarm/network"
 	"github.com/ethereum/go-ethereum/swarm/services/swap"
@@ -34,10 +35,6 @@ import (
 const (
 	DefaultHTTPListenAddr = "127.0.0.1"
 	DefaultHTTPPort       = "8500"
-)
-
-var (
-	ensRootAddress = common.HexToAddress("0x112234455c3a32fd11230c42e7bccd4a84e02010")
 )
 
 // separate bzz directories
@@ -84,7 +81,7 @@ func NewConfig(path string, contract common.Address, prvKey *ecdsa.PrivateKey, n
 		Swap:          swap.DefaultSwapParams(contract, prvKey),
 		PublicKey:     pubkeyhex,
 		BzzKey:        keyhex,
-		EnsRoot:       ensRootAddress,
+		EnsRoot:       ens.TestNetAddress,
 		NetworkId:     networkId,
 	}
 	data, err = ioutil.ReadFile(confpath)
@@ -129,7 +126,7 @@ func NewConfig(path string, contract common.Address, prvKey *ecdsa.PrivateKey, n
 	self.Swap.SetKey(prvKey)
 
 	if (self.EnsRoot == common.Address{}) {
-		self.EnsRoot = ensRootAddress
+		self.EnsRoot = ens.TestNetAddress
 	}
 
 	return

--- a/swarm/swarm.go
+++ b/swarm/swarm.go
@@ -76,7 +76,7 @@ func (self *Swarm) API() *SwarmAPI {
 
 // creates a new swarm service instance
 // implements node.Service
-func NewSwarm(ctx *node.ServiceContext, backend chequebook.Backend, config *api.Config, swapEnabled, syncEnabled bool, cors string) (self *Swarm, err error) {
+func NewSwarm(ctx *node.ServiceContext, backend chequebook.Backend, ensClient *ethclient.Client, config *api.Config, swapEnabled, syncEnabled bool, cors string) (self *Swarm, err error) {
 	if bytes.Equal(common.FromHex(config.PublicKey), storage.ZeroKey) {
 		return nil, fmt.Errorf("empty public key")
 	}
@@ -136,10 +136,10 @@ func NewSwarm(ctx *node.ServiceContext, backend chequebook.Backend, config *api.
 	// set up high level api
 	transactOpts := bind.NewKeyedTransactor(self.privateKey)
 
-	if backend == (*ethclient.Client)(nil) {
-		log.Warn("No ENS, please specify non-empty --ethapi to use domain name resolution")
+	if ensClient == nil {
+		log.Warn("No ENS, please specify non-empty --ens-api to use domain name resolution")
 	} else {
-		self.dns, err = ens.NewENS(transactOpts, config.EnsRoot, self.backend)
+		self.dns, err = ens.NewENS(transactOpts, config.EnsRoot, ensClient)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
This deprecates `--ethapi` in favour of `--ens-api` and `--swap-api` and adds auto-detection of the mainnet and testnet ENS contract addresses.

Closes #14636.

Ref #14386 (does not close as we still want to support per-tld ENS APIs).

/cc @zelig @homotopycolimit 