### PR TITLE
ethclient: fix TransactionByHash()'s pending return value.

### DIFF
--- a/ethclient/ethclient.go
+++ b/ethclient/ethclient.go
@@ -167,11 +167,11 @@ func (ec *Client) TransactionByHash(ctx context.Context, hash common.Hash) (tx *
 	} else if _, r, _ := tx.RawSignatureValues(); r == nil {
 		return nil, false, fmt.Errorf("server returned transaction without signature")
 	}
-	var block struct{ BlockHash *common.Hash }
+	var block struct{ BlockNumber *string }
 	if err := json.Unmarshal(raw, &block); err != nil {
 		return nil, false, err
 	}
-	return tx, block.BlockHash == nil, nil
+	return tx, block.BlockNumber == nil, nil
 }
 
 // TransactionCount returns the total number of transactions in the given block.


### PR DESCRIPTION
As per #14661 TransactionByHash() always returns false for pending.
This uses blockNumber rather than blockHash to ensure that it returns
the correct value for pending and will not suffer side-effects if
eth_getTransactionByHash is fixed in future.