### PR TITLE
core, light: remove procInterrupt from HeaderChain, LightChain

### DIFF
--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -139,7 +139,7 @@ func NewBlockChain(chainDb ethdb.Database, config *params.ChainConfig, engine co
 	bc.SetProcessor(NewStateProcessor(config, bc, engine))
 
 	var err error
-	bc.hc, err = NewHeaderChain(chainDb, config, engine, bc.getProcInterrupt)
+	bc.hc, err = NewHeaderChain(chainDb, config, engine)
 	if err != nil {
 		return nil, err
 	}
@@ -166,10 +166,6 @@ func NewBlockChain(chainDb ethdb.Database, config *params.ChainConfig, engine co
 	// Take ownership of this particular state
 	go bc.update()
 	return bc, nil
-}
-
-func (bc *BlockChain) getProcInterrupt() bool {
-	return atomic.LoadInt32(&bc.procInterrupt) == 1
 }
 
 // loadLastState loads the last known chain state from the database. This method

--- a/core/headerchain.go
+++ b/core/headerchain.go
@@ -18,7 +18,6 @@ package core
 
 import (
 	crand "crypto/rand"
-	"errors"
 	"fmt"
 	"math"
 	"math/big"
@@ -58,17 +57,14 @@ type HeaderChain struct {
 	tdCache     *lru.Cache // Cache for the most recent block total difficulties
 	numberCache *lru.Cache // Cache for the most recent block numbers
 
-	procInterrupt func() bool
-
 	rand   *mrand.Rand
 	engine consensus.Engine
 }
 
 // NewHeaderChain creates a new HeaderChain structure.
 //  getValidator should return the parent's validator
-//  procInterrupt points to the parent's interrupt semaphore
 //  wg points to the parent's shutdown wait group
-func NewHeaderChain(chainDb ethdb.Database, config *params.ChainConfig, engine consensus.Engine, procInterrupt func() bool) (*HeaderChain, error) {
+func NewHeaderChain(chainDb ethdb.Database, config *params.ChainConfig, engine consensus.Engine) (*HeaderChain, error) {
 	headerCache, _ := lru.New(headerCacheLimit)
 	tdCache, _ := lru.New(tdCacheLimit)
 	numberCache, _ := lru.New(numberCacheLimit)
@@ -80,14 +76,13 @@ func NewHeaderChain(chainDb ethdb.Database, config *params.ChainConfig, engine c
 	}
 
 	hc := &HeaderChain{
-		config:        config,
-		chainDb:       chainDb,
-		headerCache:   headerCache,
-		tdCache:       tdCache,
-		numberCache:   numberCache,
-		procInterrupt: procInterrupt,
-		rand:          mrand.New(mrand.NewSource(seed.Int64())),
-		engine:        engine,
+		config:      config,
+		chainDb:     chainDb,
+		headerCache: headerCache,
+		tdCache:     tdCache,
+		numberCache: numberCache,
+		rand:        mrand.New(mrand.NewSource(seed.Int64())),
+		engine:      engine,
 	}
 
 	hc.genesisHeader = hc.GetHeaderByNumber(0)
@@ -230,11 +225,6 @@ func (hc *HeaderChain) ValidateHeaderChain(chain []*types.Header, checkFreq int)
 
 	// Iterate over the headers and ensure they all check out
 	for i, header := range chain {
-		// If the chain is terminating, stop processing blocks
-		if hc.procInterrupt() {
-			log.Debug("Premature abort during headers verification")
-			return 0, errors.New("aborted")
-		}
 		// If the header is a banned one, straight out abort
 		if BadHashes[header.Hash()] {
 			return i, ErrBlacklistedHash
@@ -261,11 +251,6 @@ func (hc *HeaderChain) InsertHeaderChain(chain []*types.Header, writeHeader WhCa
 	stats := struct{ processed, ignored int }{}
 	// All headers passed verification, import them into the database
 	for i, header := range chain {
-		// Short circuit insertion if shutting down
-		if hc.procInterrupt() {
-			log.Debug("Premature abort during headers import")
-			return i, errors.New("aborted")
-		}
 		// If the header's already known, skip it, otherwise store
 		if hc.GetHeader(header.Hash(), header.Number.Uint64()) != nil {
 			stats.ignored++


### PR DESCRIPTION
Verifying headers isn't that slow and the tiny benefit of quitting
earlier doesn't justify passing around a callback to wrap an atomic
field.