### PR TITLE
eth: gracefully error if database cannot be opened

### DIFF
--- a/eth/backend.go
+++ b/eth/backend.go
@@ -200,10 +200,13 @@ func makeExtraData(extra []byte) []byte {
 // CreateDB creates the chain database.
 func CreateDB(ctx *node.ServiceContext, config *Config, name string) (ethdb.Database, error) {
 	db, err := ctx.OpenDatabase(name, config.DatabaseCache, config.DatabaseHandles)
+	if err != nil {
+		return nil, err
+	}
 	if db, ok := db.(*ethdb.LDBDatabase); ok {
 		db.Meter("eth/db/chaindata/")
 	}
-	return db, err
+	return db, nil
 }
 
 // CreateConsensusEngine creates the required type of consensus engine instance for an Ethereum service

--- a/node/service.go
+++ b/node/service.go
@@ -43,7 +43,11 @@ func (ctx *ServiceContext) OpenDatabase(name string, cache int, handles int) (et
 	if ctx.config.DataDir == "" {
 		return ethdb.NewMemDatabase()
 	}
-	return ethdb.NewLDBDatabase(ctx.config.resolvePath(name), cache, handles)
+	db, err := ethdb.NewLDBDatabase(ctx.config.resolvePath(name), cache, handles)
+	if err != nil {
+		return nil, err
+	}
+	return db, nil
 }
 
 // ResolvePath resolves a user path into the data directory if that was relative


### PR DESCRIPTION
This PR fixes a regression in the database opening where a open failure (e.g. already open) coupled with metrics being enabled caused geth to panic (instead of cleanly exit). The cause was an error handling going missing in https://github.com/ethereum/go-ethereum/commit/84d11c19fd246e245906ca7e498a67f6e0c55e1e#diff-e42690942282286ede9e53bbe7b0c248L250.

