### PR TITLE
cmd/puppeth: fix key reuse during faucet deploys

### DIFF
--- a/cmd/puppeth/wizard_faucet.go
+++ b/cmd/puppeth/wizard_faucet.go
@@ -165,8 +165,7 @@ func (w *wizard) deployFaucet() {
 	}
 	// Load up the credential needed to release funds
 	if infos.node.keyJSON != "" {
-		var key keystore.Key
-		if err := json.Unmarshal([]byte(infos.node.keyJSON), &key); err != nil {
+		if key, err := keystore.DecryptKey([]byte(infos.node.keyJSON), infos.node.keyPass); err != nil {
 			infos.node.keyJSON, infos.node.keyPass = "", ""
 		} else {
 			fmt.Println()


### PR DESCRIPTION
A few releases ago we've changed how we validate account keys. That broke puppeth's key reuse code and was fixed for deploying signers and bootnodes, but we never redeployed the faucet since the breakage. This PR adds the same fix we did for the nodes (https://github.com/ethereum/go-ethereum/pull/14553) into the faucet too.