### PR TITLE
swarm/storage: remove panic on invalid chunk

### DIFF
--- a/swarm/storage/dbstore.go
+++ b/swarm/storage/dbstore.go
@@ -399,7 +399,7 @@ func (s *DbStore) Get(key Key) (chunk *Chunk, err error) {
 		hash := hasher.Sum(nil)
 		if !bytes.Equal(hash, key) {
 			s.delete(index.Idx, getIndexKey(key))
-			panic("Invalid Chunk in Database. Please repair with command: 'swarm cleandb'")
+			log.Warn("Invalid Chunk in Database. Please repair with command: 'swarm cleandb'")
 		}
 
 		chunk = &Chunk{


### PR DESCRIPTION
This panic is causing a lot of headaches to users and is entirely not needed. Whenever an invalid chunk is encountered, the bad entry is cleared from the DB and the chunk in question is re-requested.
The panic was inserted for debugging purposes and somehow found its way into master.

The PR removes the panic in favour of a log.Warn message