### PR TITLE
Change heading to "Go Ethereum"

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-## Ethereum Go
+## Go Ethereum
 
 Official golang implementation of the Ethereum protocol.
 


### PR DESCRIPTION
The repository name as well as the [official website](https://geth.ethereum.org/) refer to this project as "Go Ethereum".