### PR TITLE
build: Fix devel golang detection

### DIFF
--- a/build/ci.go
+++ b/build/ci.go
@@ -175,7 +175,7 @@ func doInstall(cmdline []string) {
 
 	// Check Go version. People regularly open issues about compilation
 	// failure with outdated Go. This should save them the trouble.
-	if runtime.Version() < "go1.7" && !strings.HasPrefix(runtime.Version(), "devel") {
+	if runtime.Version() < "go1.7" && !strings.Contains(runtime.Version(), "devel") {
 		log.Println("You have Go version", runtime.Version())
 		log.Println("go-ethereum requires at least Go version 1.7 and cannot")
 		log.Println("be compiled with an earlier version. Please upgrade your Go installation.")


### PR DESCRIPTION
Fixes the following error when golang-tip is installed on Ubuntu:
```
$ make geth
build/env.sh go run build/ci.go install ./cmd/geth
ci.go:179: You have Go version debian devel snapshot +201703281907.4b50c81~ppa1~ubuntu16.10.1
ci.go:180: go-ethereum requires at least Go version 1.7 and cannot
ci.go:181: be compiled with an earlier version. Please upgrade your Go installation.
exit status 1
Makefile:15: recipe for target 'geth' failed
make: *** [geth] Error 1
```