### PR TITLE
core/vm: fix overflow in gas calculation formula

### DIFF
--- a/core/vm/gas_table_test.go
+++ b/core/vm/gas_table_test.go
@@ -16,24 +16,20 @@
 
 package vm
 
-import (
-	"math"
-	"testing"
-)
+import "testing"
 
 func TestMemoryGasCost(t *testing.T) {
-	size := uint64(math.MaxUint64 - 64)
-	_, err := memoryGasCost(&Memory{}, size)
+	//size := uint64(math.MaxUint64 - 64)
+	size := uint64(0xffffffffe0)
+	v, err := memoryGasCost(&Memory{}, size)
 	if err != nil {
 		t.Error("didn't expect error:", err)
 	}
-
-	_, err = memoryGasCost(&Memory{}, size+32)
-	if err != nil {
-		t.Error("didn't expect error:", err)
+	if v != 36028899963961341 {
+		t.Errorf("Expected: 36028899963961341, got %d", v)
 	}
 
-	_, err = memoryGasCost(&Memory{}, size+33)
+	_, err = memoryGasCost(&Memory{}, size+1)
 	if err == nil {
 		t.Error("expected error")
 	}


### PR DESCRIPTION
This PR fixes an overflow occurring in the squaring-operation when calculating the square-coefficient of memory expansion. Values > `0xffffffffe1` would make the `square` = `0`. Fortunately, the linear coefficient still resulted in 12.8 billion gas, so it's not a critical issue. 

The PR now instead throws a gas overflow error for memory requirements larger than `0xffffffffe0` which is about 1.1 TB. 