### PR TITLE
Fix error when reporting numer of txs in imported blocks

### DIFF
--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -1073,7 +1073,7 @@ func (st *insertStats) report(chain []*types.Block, index int) {
 		}
 		log.Info("Imported new chain segment", context...)
 
-		*st = insertStats{startTime: now, lastIndex: index}
+		*st = insertStats{startTime: now, lastIndex: index + 1}
 	}
 }
 


### PR DESCRIPTION
Fixes an off-by-one when the block import counts blocks