### PR TITLE
cmd/swarm: Exit if --ethapi is set

### DIFF
--- a/cmd/swarm/run_test.go
+++ b/cmd/swarm/run_test.go
@@ -194,7 +194,7 @@ func newTestNode(t *testing.T, dir string) *testNode {
 		"--nodiscover",
 		"--datadir", dir,
 		"--ipcpath", conf.IPCPath,
-		"--ethapi", "",
+		"--ens-api", "",
 		"--bzzaccount", account.Address.String(),
 		"--bzznetworkid", "321",
 		"--bzzport", httpPort,

--- a/swarm/dev/scripts/boot-cluster.sh
+++ b/swarm/dev/scripts/boot-cluster.sh
@@ -208,7 +208,7 @@ start_swarm_node() {
     --bootnodes    "${BOOTNODE_URL}"
     --datadir      "${dir}"
     --identity     "${name}"
-    --ethapi       "${GETH_RPC_URL}"
+    --ens-api      "${GETH_RPC_URL}"
     --bzznetworkid "321"
     --bzzaccount   "${address}"
     --password     "${dir}/password"


### PR DESCRIPTION
The previous attempt to use `--ethapi` as a fallback if `--ens-api` is not set does not work because `--ens-api` has a default value, and also setting `--ens-api` to `""` is the suggested way to disable ENS lookups.

/cc @homotopycolimit @zelig 