### PR TITLE
docker: don't remove executables in Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ ADD . /go-ethereum
 RUN \
   apk add --update git go make gcc musl-dev linux-headers && \
   (cd go-ethereum && make geth)                           && \
-  cp go-ethereum/build/bin/geth /usr/local/bin/           && \
+  cp go-ethereum/build/bin/* /usr/local/bin/              && \
   apk del git go make gcc musl-dev linux-headers          && \
   rm -rf /go-ethereum && rm -rf /var/cache/apk/*
 


### PR DESCRIPTION
Let's keep all executables in the Docker image (objectives).