### PR TITLE
miner: immediately include uncles in pending block

### DIFF
--- a/miner/worker.go
+++ b/miner/worker.go
@@ -239,6 +239,8 @@ func (self *worker) update() {
 			self.uncleMu.Lock()
 			self.possibleUncles[ev.Block.Hash()] = ev.Block
 			self.uncleMu.Unlock()
+			// immediately include uncles
+			self.commitNewWork()
 		case core.TxPreEvent:
 			// Apply transaction to the pending state if we're not mining
 			if atomic.LoadInt32(&self.mining) == 0 {


### PR DESCRIPTION
This fixes https://github.com/ethereum/go-ethereum/issues/2902