### PR TITLE
properly expose debug.getBlockFromFile api method

### DIFF
--- a/internal/web3ext/web3ext.go
+++ b/internal/web3ext/web3ext.go
@@ -208,8 +208,8 @@ web3._extend({
 			params: 1
 		}),
 		new web3._extend.Method({
-			name: 'traceBlockByFile',
-			call: 'debug_traceBlockByFile',
+			name: 'traceBlockFromFile',
+			call: 'debug_traceBlockFromFile',
 			params: 1
 		}),
 		new web3._extend.Method({


### PR DESCRIPTION
As stated in the [documentation](https://github.com/ethereum/go-ethereum/wiki/Management-APIs#debug_traceblockfromfile) and in the [api](https://github.com/ethereum/go-ethereum/blob/9e5f03b6c487175cc5aa1224e5e12fd573f483a7/eth/api.go#L385), this method should be called getBlockFromFile and not getBlockByFile. Previously this would result in a 'The method ... does not exist/is not available' error.