### PR TITLE
ethclient: add NetworkID function

### DIFF
--- a/ethclient/ethclient.go
+++ b/ethclient/ethclient.go
@@ -258,6 +258,19 @@ func (ec *Client) SubscribeNewHead(ctx context.Context, ch chan<- *types.Header)
 
 // State Access
 
+// NetworkID returns the network ID (also known as the chain ID) for this chain.
+func (ec *Client) NetworkID(ctx context.Context) (version *big.Int, err error) {
+	version = big.NewInt(0)
+
+	var ver string
+	if err = ec.c.CallContext(ctx, &ver, "net_version"); err != nil {
+		return version, err
+	}
+
+	version.SetString(ver, 10)
+	return
+}
+
 // BalanceAt returns the wei balance of the given account.
 // The block number can be nil, in which case the balance is taken from the latest known block.
 func (ec *Client) BalanceAt(ctx context.Context, account common.Address, blockNumber *big.Int) (*big.Int, error) {

--- a/ethclient/ethclient.go
+++ b/ethclient/ethclient.go
@@ -20,7 +20,6 @@ package ethclient
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"math/big"
 

--- a/ethclient/ethclient.go
+++ b/ethclient/ethclient.go
@@ -266,9 +266,8 @@ func (ec *Client) NetworkID(ctx context.Context) (*big.Int, error) {
 	if err := ec.c.CallContext(ctx, &ver, "net_version"); err != nil {
 		return nil, err
 	}
-	_, succeeded := version.SetString(ver, 10)
-	if !succeeded {
-		return nil, errors.New("failed to convert net_version result to a network ID number")
+	if _, ok := version.SetString(ver, 10); !ok {
+		return nil, fmt.Errorf("invalid net_version result %q", ver)
 	}
 	return version, nil
 }


### PR DESCRIPTION
There is currently no simple way to obtain the network ID from a Client.  This adds a NetworkID() function that wraps the net_version JSON-RPC call and returns the network ID in a suitable format.