### PR TITLE
multi stage build / make target arg

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,18 @@
-FROM alpine:3.5
+FROM alpine:3.5 as builder
 
 ADD . /go-ethereum
+ARG MAKE_TARGET=geth
 RUN \
   apk add --update git go make gcc musl-dev linux-headers && \
-  (cd go-ethereum && make geth)                           && \
-  cp go-ethereum/build/bin/geth /usr/local/bin/           && \
-  apk del git go make gcc musl-dev linux-headers          && \
-  rm -rf /go-ethereum && rm -rf /var/cache/apk/*
+  (cd go-ethereum && make $MAKE_TARGET)                   && \
+  echo "Dockerfile builder stage finished."
+#  cp go-ethereum/build/bin/geth /usr/local/bin/           && \
+#  apk del git go make gcc musl-dev linux-headers         && \
+#  rm -rf /go-ethereum && rm -rf /var/cache/apk/*
+
+FROM alpine:3.5
+
+COPY --from=builder /go-ethereum/build/bin/* /usr/local/bin/
 
 EXPOSE 8545
 EXPOSE 30303


### PR DESCRIPTION
Two things in this PR:

1. Multi-staged build (I think all CI/CD tools support it by now);
2. Optional build ARG to "make all".

I believe images should have all tools (geth, bootnode etc.) as documented, or at least we could have two tags for each release, like "ethereum/client-go:v1.6.7" and "ethereum/client-go:v1.6.7-all".

Multi-staged build can get much faster with a pre-made builder image with tools already installed.
