### PR TITLE
event: concurrently deliver events to each TypeMuxSubscription

### DIFF
--- a/event/event.go
+++ b/event/event.go
@@ -94,7 +94,7 @@ func (mux *TypeMux) Post(ev interface{}) error {
 	subs := mux.subm[rtyp]
 	mux.mutex.RUnlock()
 	for _, sub := range subs {
-		sub.deliver(event)
+		go sub.deliver(event)
 	}
 	return nil
 }


### PR DESCRIPTION
This PR makes that to deliver events to each `TypeMuxSubscription` as concurrent call to avoid to be blocked by previous subscription.