### PR TITLE
params,consensus/ethash,miner: move parameter maxUncles from ethash to params

### DIFF
--- a/consensus/ethash/consensus.go
+++ b/consensus/ethash/consensus.go
@@ -37,7 +37,6 @@ import (
 // Ethash proof-of-work protocol constants.
 var (
 	blockReward *big.Int = big.NewInt(5e+18) // Block reward in wei for successfully mining a block
-	maxUncles            = 2                 // Maximum number of uncles allowed in a single block
 )
 
 // Various error messages to mark blocks invalid. These should be private to
@@ -172,7 +171,7 @@ func (ethash *Ethash) VerifyUncles(chain consensus.ChainReader, block *types.Blo
 		return nil
 	}
 	// Verify that there are at most 2 uncles included in this block
-	if len(block.Uncles()) > maxUncles {
+	if len(block.Uncles()) > params.MaxUncles {
 		return errTooManyUncles
 	}
 	// Gather the set of past uncles and ancestors

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -452,7 +452,7 @@ func (self *worker) commitNewWork() {
 		badUncles []common.Hash
 	)
 	for hash, uncle := range self.possibleUncles {
-		if len(uncles) == 2 {
+		if len(uncles) == params.MaxUncles {
 			break
 		}
 		if err := self.commitUncle(work, uncle.Header()); err != nil {

--- a/params/protocol_params.go
+++ b/params/protocol_params.go
@@ -60,6 +60,7 @@ const (
 	MemoryGas        uint64 = 3     // Times the address of the (highest referenced byte in memory + 1). NOTE: referencing happens on read, write and in instructions such as RETURN and CALL.
 	TxDataNonZeroGas uint64 = 68    // Per byte of data attached to a transaction that is not equal to zero. NOTE: Not payable on data of calls between transactions.
 
+	MaxUncles   = 2 // Maximum number of uncles allowed in a single block
 	MaxCodeSize = 24576
 )
 


### PR DESCRIPTION
move parameter maxUncles from ethash to params,to avoid magic number