### PR TITLE
common: EIP55-compliant Address.Hex()

### DIFF
--- a/cmd/geth/accountcmd_test.go
+++ b/cmd/geth/accountcmd_test.go
@@ -146,7 +146,7 @@ Passphrase: {{.InputLine "foobar"}}
 
 	wantMessages := []string{
 		"Unlocked account",
-		"=0xf466859ead1932d743d622cb74fc058882e8648a",
+		"=0xf466859eAD1932D743d622CB74FC058882E8648A",
 	}
 	for _, m := range wantMessages {
 		if !strings.Contains(geth.StderrText(), m) {
@@ -191,8 +191,8 @@ Passphrase: {{.InputLine "foobar"}}
 
 	wantMessages := []string{
 		"Unlocked account",
-		"=0x7ef5a6135f1fd6a02593eedc869c6d41d934aef8",
-		"=0x289d485d9771714cce91d3393d764e1311907acc",
+		"=0x7EF5A6135f1FD6a02593eEdC869c6D41D934aef8",
+		"=0x289d485D9771714CCe91D3393D764E1311907ACc",
 	}
 	for _, m := range wantMessages {
 		if !strings.Contains(geth.StderrText(), m) {
@@ -211,8 +211,8 @@ func TestUnlockFlagPasswordFile(t *testing.T) {
 
 	wantMessages := []string{
 		"Unlocked account",
-		"=0x7ef5a6135f1fd6a02593eedc869c6d41d934aef8",
-		"=0x289d485d9771714cce91d3393d764e1311907acc",
+		"=0x7EF5A6135f1FD6a02593eEdC869c6D41D934aef8",
+		"=0x289d485D9771714CCe91D3393D764E1311907ACc",
 	}
 	for _, m := range wantMessages {
 		if !strings.Contains(geth.StderrText(), m) {
@@ -261,7 +261,7 @@ In order to avoid this warning, you need to remove the following duplicate key f
 
 	wantMessages := []string{
 		"Unlocked account",
-		"=0xf466859ead1932d743d622cb74fc058882e8648a",
+		"=0xf466859eAD1932D743d622CB74FC058882E8648A",
 	}
 	for _, m := range wantMessages {
 		if !strings.Contains(geth.StderrText(), m) {

--- a/common/types_test.go
+++ b/common/types_test.go
@@ -94,3 +94,34 @@ func TestAddressUnmarshalJSON(t *testing.T) {
 		}
 	}
 }
+
+func TestAddressHexChecksum(t *testing.T) {
+	var tests = []struct {
+		Input  string
+		Output string
+	}{
+		// Test cases from https://github.com/ethereum/EIPs/blob/master/EIPS/eip-55.md#specification
+		{"0x5aaeb6053f3e94c9b9a09f33669435e7ef1beaed", "0x5aAeb6053F3E94C9b9A09f33669435E7Ef1BeAed"},
+		{"0xfb6916095ca1df60bb79ce92ce3ea74c37c5d359", "0xfB6916095ca1df60bB79Ce92cE3Ea74c37c5d359"},
+		{"0xdbf03b407c01e7cd3cbea99509d93f8dddc8c6fb", "0xdbF03B407c01E7cD3CBea99509d93f8DDDC8C6FB"},
+		{"0xd1220a0cf47c7b9be7a2e6ba89f429762e7b9adb", "0xD1220A0cf47c7B9Be7A2E6BA89F429762e7b9aDb"},
+		// Ensure that non-standard length input values are handled correctly
+		{"0xa", "0x000000000000000000000000000000000000000A"},
+		{"0x0a", "0x000000000000000000000000000000000000000A"},
+		{"0x00a", "0x000000000000000000000000000000000000000A"},
+		{"0x000000000000000000000000000000000000000a", "0x000000000000000000000000000000000000000A"},
+	}
+	for i, test := range tests {
+		output := HexToAddress(test.Input).Hex()
+		if output != test.Output {
+			t.Errorf("test #%d: failed to match when it should (%s != %s)", i, output, test.Output)
+		}
+	}
+}
+
+func BenchmarkAddressHex(b *testing.B) {
+	testAddr := HexToAddress("0x5aaeb6053f3e94c9b9a09f33669435e7ef1beaed")
+	for n := 0; n < b.N; n++ {
+		testAddr.Hex()
+	}
+}


### PR DESCRIPTION
This patch updates the `Address` type in `common/types.go` so that the `Hex()` function provides an EIP55-compliant output string.

The implementation meets the specification as laid out in https://github.com/ethereum/EIPs/blob/master/EIPS/eip-55.md#specification and includes tests that confirm this.

The implementation is pretty lightweight; on my laptop the benchmark gives 1100ns/op, with the majority of that value due to the Keccak hash.

As per a suggestion from @Arachnid I carried out a quick search of the codebase to see if there were any areas that this function was used repeatedly.  The only place that stands out is `NewKeyForDirectICAP()` in `accounts/keystore/key.go`, which is a recursive function.  If the additional overhead is a concern then this function could be rewriten to avoid use of `Hex()` entirely.

This patch also includes changes to a tests that use the output of `Hex()` in its success criteria in `cmd/geth/accountcmd_test.go`