### PR TITLE
cmd/puppeth: limit cotnainers to 10MB logs

### DIFF
--- a/cmd/puppeth/module_dashboard.go
+++ b/cmd/puppeth/module_dashboard.go
@@ -425,6 +425,11 @@ services:
       - "{{.Port}}:80"{{else}}
     environment:
       - VIRTUAL_HOST={{.VHost}}{{end}}
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "1m"
+        max-file: "10"
     restart: always
 `
 

--- a/cmd/puppeth/module_ethstats.go
+++ b/cmd/puppeth/module_ethstats.go
@@ -60,6 +60,11 @@ services:
     environment:
       - WS_SECRET={{.Secret}}{{if .VHost}}
       - VIRTUAL_HOST={{.VHost}}{{end}}
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "1m"
+        max-file: "10"
     restart: always
 `
 

--- a/cmd/puppeth/module_faucet.go
+++ b/cmd/puppeth/module_faucet.go
@@ -82,6 +82,11 @@ services:
       - CAPTCHA_SECRET={{.CaptchaSecret}}{{if .VHost}}
       - VIRTUAL_HOST={{.VHost}}
       - VIRTUAL_PORT=8080{{end}}
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "1m"
+        max-file: "10"
     restart: always
 `
 

--- a/cmd/puppeth/module_nginx.go
+++ b/cmd/puppeth/module_nginx.go
@@ -43,6 +43,11 @@ services:
       - "{{.Port}}:80"
     volumes:
       - /var/run/docker.sock:/tmp/docker.sock:ro
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "1m"
+        max-file: "10"
     restart: always
 `
 

--- a/cmd/puppeth/module_node.go
+++ b/cmd/puppeth/module_node.go
@@ -68,6 +68,11 @@ services:
       - MINER_NAME={{.Etherbase}}
       - GAS_TARGET={{.GasTarget}}
       - GAS_PRICE={{.GasPrice}}
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "1m"
+        max-file: "10"
     restart: always
 `
 


### PR DESCRIPTION
Puppeth currently starts all containers with unlimited log capacity. This might not be the best idea for ethstats, since malicious users might do a lot of "bad" stuff that produces warnings, creating a huge log file which chokes docker eventually.

This PR adds a 10 file log limit, each 1MB max to all the deployed containers to avoid weird things happening.