### PR TITLE
cmd/faucet: ignore whitespace in gist content

### DIFF
--- a/cmd/faucet/faucet.go
+++ b/cmd/faucet/faucet.go
@@ -413,8 +413,9 @@ func (f *faucet) apiHandler(conn *websocket.Conn) {
 		// Iterate over all the files and look for Ethereum addresses
 		var address common.Address
 		for _, file := range gist.Files {
-			if len(file.Content) == 2+common.AddressLength*2 {
-				address = common.HexToAddress(file.Content)
+			content := strings.TrimSpace(file.Content)
+			if len(content) == 2+common.AddressLength*2 {
+				address = common.HexToAddress(content)
 			}
 		}
 		if address == (common.Address{}) {


### PR DESCRIPTION
Fixes https://github.com/ethereum/go-ethereum/issues/14821.