### PR TITLE
node: Rename TrusterNodes

### DIFF
--- a/node/config.go
+++ b/node/config.go
@@ -316,8 +316,8 @@ func (c *Config) StaticNodes() []*discover.Node {
 	return c.parsePersistentNodes(c.resolvePath(datadirStaticNodes))
 }
 
-// TrusterNodes returns a list of node enode URLs configured as trusted nodes.
-func (c *Config) TrusterNodes() []*discover.Node {
+// TrustedNodes returns a list of node enode URLs configured as trusted nodes.
+func (c *Config) TrustedNodes() []*discover.Node {
 	return c.parsePersistentNodes(c.resolvePath(datadirTrustedNodes))
 }
 

--- a/node/node.go
+++ b/node/node.go
@@ -160,7 +160,7 @@ func (n *Node) Start() error {
 		n.serverConfig.StaticNodes = n.config.StaticNodes()
 	}
 	if n.serverConfig.TrustedNodes == nil {
-		n.serverConfig.TrustedNodes = n.config.TrusterNodes()
+		n.serverConfig.TrustedNodes = n.config.TrustedNodes()
 	}
 	if n.serverConfig.NodeDatabase == "" {
 		n.serverConfig.NodeDatabase = n.config.NodeDB()


### PR DESCRIPTION
I'm pretty sure that TrusterNodes() is a typo and that it should be TrustedNodes() to follow in the naming convention of StaticNodes()