### PR TITLE
core/vm/runtime: fix evm command to use --gasprice flag value

### DIFF
--- a/core/vm/runtime/env.go
+++ b/core/vm/runtime/env.go
@@ -37,7 +37,7 @@ func NewEnv(cfg *Config, state *state.StateDB) *vm.EVM {
 		Time:        cfg.Time,
 		Difficulty:  cfg.Difficulty,
 		GasLimit:    new(big.Int).SetUint64(cfg.GasLimit),
-		GasPrice:    new(big.Int),
+		GasPrice:    cfg.GasPrice,
 	}
 
 	return vm.NewEVM(context, cfg.State, cfg.ChainConfig, cfg.EVMConfig)


### PR DESCRIPTION
This is needed when running `emv --price`, otherwise the `GASPRICE` opcode always returns 0.