### PR TITLE
cmd/evm: add `--receiver` flag

### DIFF
--- a/cmd/evm/main.go
+++ b/cmd/evm/main.go
@@ -53,7 +53,7 @@ var (
 	}
 	CodeFileFlag = cli.StringFlag{
 		Name:  "codefile",
-		Usage: "file containing EVM code",
+		Usage: "File containing EVM code. If '-' is specified, code is read from stdin ",
 	}
 	GasFlag = cli.Uint64Flag{
 		Name:  "gas",

--- a/cmd/evm/main.go
+++ b/cmd/evm/main.go
@@ -102,6 +102,10 @@ var (
 		Name:  "sender",
 		Usage: "The transaction origin",
 	}
+	ReceiverFlag = cli.StringFlag{
+		Name:  "receiver",
+		Usage: "The transaction receiver (execution context)",
+	}
 	DisableMemoryFlag = cli.BoolFlag{
 		Name:  "nomemory",
 		Usage: "disable memory output",
@@ -131,6 +135,7 @@ func init() {
 		GenesisFlag,
 		MachineFlag,
 		SenderFlag,
+		ReceiverFlag,
 		DisableMemoryFlag,
 		DisableStackFlag,
 	}

--- a/cmd/evm/runner.go
+++ b/cmd/evm/runner.go
@@ -84,6 +84,7 @@ func runCmd(ctx *cli.Context) error {
 		statedb     *state.StateDB
 		chainConfig *params.ChainConfig
 		sender      = common.StringToAddress("sender")
+		receiver    = common.StringToAddress("receiver")
 	)
 	if ctx.GlobalBool(MachineFlag.Name) {
 		tracer = NewJSONLogger(logconfig, os.Stdout)
@@ -104,46 +105,52 @@ func runCmd(ctx *cli.Context) error {
 	if ctx.GlobalString(SenderFlag.Name) != "" {
 		sender = common.HexToAddress(ctx.GlobalString(SenderFlag.Name))
 	}
-
 	statedb.CreateAccount(sender)
+
+	if ctx.GlobalString(ReceiverFlag.Name) != "" {
+		receiver = common.HexToAddress(ctx.GlobalString(ReceiverFlag.Name))
+	}
 
 	var (
 		code []byte
 		ret  []byte
 		err  error
 	)
-	if fn := ctx.Args().First(); len(fn) > 0 {
-		src, err := ioutil.ReadFile(fn)
-		if err != nil {
-			return err
-		}
+	if statedb.GetCodeSize(receiver) == 0 {
+		if fn := ctx.Args().First(); len(fn) > 0 {
+			src, err := ioutil.ReadFile(fn)
+			if err != nil {
+				return err
+			}
 
-		bin, err := compiler.Compile(fn, src, false)
-		if err != nil {
-			return err
-		}
-		code = common.Hex2Bytes(bin)
-	} else if ctx.GlobalString(CodeFlag.Name) != "" {
-		code = common.Hex2Bytes(ctx.GlobalString(CodeFlag.Name))
-	} else {
-		var hexcode []byte
-		if ctx.GlobalString(CodeFileFlag.Name) != "" {
-			var err error
-			hexcode, err = ioutil.ReadFile(ctx.GlobalString(CodeFileFlag.Name))
+			bin, err := compiler.Compile(fn, src, false)
 			if err != nil {
-				fmt.Printf("Could not load code from file: %v\n", err)
-				os.Exit(1)
+				return err
 			}
+			code = common.Hex2Bytes(bin)
+		} else if ctx.GlobalString(CodeFlag.Name) != "" {
+			code = common.Hex2Bytes(ctx.GlobalString(CodeFlag.Name))
 		} else {
-			var err error
-			hexcode, err = ioutil.ReadAll(os.Stdin)
-			if err != nil {
-				fmt.Printf("Could not load code from stdin: %v\n", err)
-				os.Exit(1)
+			var hexcode []byte
+			if ctx.GlobalString(CodeFileFlag.Name) != "" {
+				var err error
+				hexcode, err = ioutil.ReadFile(ctx.GlobalString(CodeFileFlag.Name))
+				if err != nil {
+					fmt.Printf("Could not load code from file: %v\n", err)
+					os.Exit(1)
+				}
+			} else {
+				var err error
+				hexcode, err = ioutil.ReadAll(os.Stdin)
+				if err != nil {
+					fmt.Printf("Could not load code from stdin: %v\n", err)
+					os.Exit(1)
+				}
 			}
+			code = common.Hex2Bytes(string(bytes.TrimRight(hexcode, "\n")))
 		}
-		code = common.Hex2Bytes(string(bytes.TrimRight(hexcode, "\n")))
 	}
+
 	initialGas := ctx.GlobalUint64(GasFlag.Name)
 	runtimeConfig := runtime.Config{
 		Origin:   sender,
@@ -180,9 +187,9 @@ func runCmd(ctx *cli.Context) error {
 		input := append(code, common.Hex2Bytes(ctx.GlobalString(InputFlag.Name))...)
 		ret, _, leftOverGas, err = runtime.Create(input, &runtimeConfig)
 	} else {
-		receiver := common.StringToAddress("receiver")
-		statedb.SetCode(receiver, code)
-
+		if statedb.GetCodeSize(receiver) == 0 {
+			statedb.SetCode(receiver, code)
+		}
 		ret, leftOverGas, err = runtime.Call(receiver, common.Hex2Bytes(ctx.GlobalString(InputFlag.Name)), &runtimeConfig)
 	}
 	execTime := time.Since(tstart)


### PR DESCRIPTION
This PR adds `--receiver` to the `evm`. 
Example of executing the code `ADDRESS; ORIGIN`:

```
#build/bin/evm --code "3032" --json --receiver "0x000000001337" --sender "0xcafebabe" run  
{"pc":0,"op":48,"gas":"0x2540be400","gasCost":"0x2","memory":"0x","memSize":0,"stack":[],"depth":1,"error":null,"opName":"ADDRESS"}
{"pc":1,"op":50,"gas":"0x2540be3fe","gasCost":"0x2","memory":"0x","memSize":0,"stack":["0x1337"],"depth":1,"error":null,"opName":"ORIGIN"}
{"pc":2,"op":0,"gas":"0x2540be3fc","gasCost":"0x0","memory":"0x","memSize":0,"stack":["0x1337","0xcafebabe"],"depth":1,"error":null,"opName":"STOP"}
```

~~This PR implements `receiver` in such way, that is the `receiver` account is present in the prestate (genesis), it ignores the `--code` parameter (or variations thereof, such as reading from stdin, or reading `--codefile`). If the `receiver` is not defined in the prestate, it reads the code as usual.~~ 

If any CLI option such as `--codefile`, `--code` or easm-file (`evm run easm.file`) is supplied, it overrides the code in state. However, it only tries to read code from `stdin` if the code in state is empty.