### PR TITLE
swarm/api: Make api.NewManifest synchronous

### DIFF
--- a/cmd/swarm/run_test.go
+++ b/cmd/swarm/run_test.go
@@ -161,6 +161,7 @@ func newTestNode(t *testing.T, dir string) *testNode {
 	conf := &node.Config{
 		DataDir: dir,
 		IPCPath: "bzzd.ipc",
+		NoUSB:   true,
 	}
 	n, err := node.New(conf)
 	if err != nil {

--- a/cmd/swarm/upload_test.go
+++ b/cmd/swarm/upload_test.go
@@ -27,8 +27,6 @@ import (
 // TestCLISwarmUp tests that running 'swarm up' makes the resulting file
 // available from all nodes via the HTTP API
 func TestCLISwarmUp(t *testing.T) {
-	t.Skip("flaky test")
-
 	// start 3 node cluster
 	t.Log("starting 3 node cluster")
 	cluster := newTestCluster(t, 3)

--- a/swarm/api/manifest.go
+++ b/swarm/api/manifest.go
@@ -63,7 +63,7 @@ func (a *Api) NewManifest() (storage.Key, error) {
 	if err != nil {
 		return nil, err
 	}
-	return a.Store(bytes.NewReader(data), int64(len(data)), nil)
+	return a.Store(bytes.NewReader(data), int64(len(data)), &sync.WaitGroup{})
 }
 
 // ManifestWriter is used to add and remove entries from an underlying manifest


### PR DESCRIPTION
Previously, `NewManifest` was asynchronous so subsequent code which tried to use the returned manifest could error as the manifest was not yet persisted.

I have also re-enabled the `TestCLISwarmUp` test which was previously failing intermittently due to this bug.