### PR TITLE
cmd/evm: fix gas in json trace on OOG steps

### DIFF
--- a/cmd/evm/json_logger.go
+++ b/cmd/evm/json_logger.go
@@ -37,10 +37,13 @@ func NewJSONLogger(cfg *vm.LogConfig, writer io.Writer) *JSONLogger {
 
 // CaptureState outputs state information on the logger.
 func (l *JSONLogger) CaptureState(env *vm.EVM, pc uint64, op vm.OpCode, gas, cost uint64, memory *vm.Memory, stack *vm.Stack, contract *vm.Contract, depth int, err error) error {
+	if err == nil {
+		gas += cost
+	}
 	log := vm.StructLog{
 		Pc:         pc,
 		Op:         op,
-		Gas:        gas + cost,
+		Gas:        gas,
 		GasCost:    cost,
 		MemorySize: memory.Len(),
 		Storage:    nil,


### PR DESCRIPTION
Because the json trace adds the cost of a step to the remaining gas in the printed log, the reported gas is incorrect on steps that OOG..

Before fix:
```
{"pc":62,"op":135,"gas":"0xb61be","gasCost":"0x3","memory":"0x0000000000000000000000000000000000000000000000000000000000000001","memSize":32,"stack":["0xcc8c7a84d4f2872441499fa72b48bd45b03923ab","0x0","0x1","0x0","0x0","0x20","0x0","0x0"],"depth":1,"error":null,"opName":"DUP8"}
{"pc":63,"op":96,"gas":"0xb61bb","gasCost":"0x3","memory":"0x0000000000000000000000000000000000000000000000000000000000000001","memSize":32,"stack":["0xcc8c7a84d4f2872441499fa72b48bd45b03923ab","0x0","0x1","0x0","0x0","0x20","0x0","0x0","0xcc8c7a84d4f2872441499fa72b48bd45b03923ab"],"depth":1,"error":null,"opName":"PUSH1"}
{"pc":65,"op":241,"gas":"0xb61b8","gasCost":"0x2c2","memory":"0x0000000000000000000000000000000000000000000000000000000000000001","memSize":32,"stack":["0xcc8c7a84d4f2872441499fa72b48bd45b03923ab","0x0","0x1","0x0","0x0","0x20","0x0","0x0","0xcc8c7a84d4f2872441499fa72b48bd45b03923ab","0x6"],"depth":1,"error":null,"opName":"CALL"}
{"pc":0,"op":96,"gas":"0x6","gasCost":"0x3","memory":"0x","memSize":0,"stack":[],"depth":2,"error":null,"opName":"PUSH1"}
{"pc":2,"op":53,"gas":"0x3","gasCost":"0x3","memory":"0x","memSize":0,"stack":["0x0"],"depth":2,"error":null,"opName":"CALLDATALOAD"}
{"pc":3,"op":255,"gas":"0x1388","gasCost":"0x1388","memory":"0x","memSize":0,"stack":["0x1"],"depth":2,"error":{},"opName":"SELFDESTRUCT"}
{"pc":66,"op":80,"gas":"0xb5ef6","gasCost":"0x2","memory":"0x0000000000000000000000000000000000000000000000000000000000000001","memSize":32,"stack":["0xcc8c7a84d4f2872441499fa72b48bd45b03923ab","0x0","0x1","0x0"],"depth":1,"error":null,"opName":"POP"}
```
In the trace above, on the SELFDESTRUCT step the gas is reported as 0x1388 (5000), but it should be zero.

After fix:
```
{"pc":62,"op":135,"gas":"0xb61be","gasCost":"0x3","memory":"0x0000000000000000000000000000000000000000000000000000000000000001","memSize":32,"stack":["0xcc8c7a84d4f2872441499fa72b48bd45b03923ab","0x0","0x1","0x0","0x0","0x20","0x0","0x0"],"depth":1,"error":null,"opName":"DUP8"}
{"pc":63,"op":96,"gas":"0xb61bb","gasCost":"0x3","memory":"0x0000000000000000000000000000000000000000000000000000000000000001","memSize":32,"stack":["0xcc8c7a84d4f2872441499fa72b48bd45b03923ab","0x0","0x1","0x0","0x0","0x20","0x0","0x0","0xcc8c7a84d4f2872441499fa72b48bd45b03923ab"],"depth":1,"error":null,"opName":"PUSH1"}
{"pc":65,"op":241,"gas":"0xb61b8","gasCost":"0x2c2","memory":"0x0000000000000000000000000000000000000000000000000000000000000001","memSize":32,"stack":["0xcc8c7a84d4f2872441499fa72b48bd45b03923ab","0x0","0x1","0x0","0x0","0x20","0x0","0x0","0xcc8c7a84d4f2872441499fa72b48bd45b03923ab","0x6"],"depth":1,"error":null,"opName":"CALL"}
{"pc":0,"op":96,"gas":"0x6","gasCost":"0x3","memory":"0x","memSize":0,"stack":[],"depth":2,"error":null,"opName":"PUSH1"}
{"pc":2,"op":53,"gas":"0x3","gasCost":"0x3","memory":"0x","memSize":0,"stack":["0x0"],"depth":2,"error":null,"opName":"CALLDATALOAD"}
{"pc":3,"op":255,"gas":"0x0","gasCost":"0x1388","memory":"0x","memSize":0,"stack":["0x1"],"depth":2,"error":{},"opName":"SELFDESTRUCT"}
{"pc":66,"op":80,"gas":"0xb5ef6","gasCost":"0x2","memory":"0x0000000000000000000000000000000000000000000000000000000000000001","memSize":32,"stack":["0xcc8c7a84d4f2872441499fa72b48bd45b03923ab","0x0","0x1","0x0"],"depth":1,"error":null,"opName":"POP"}
```