### PR TITLE
Makefile, README: remove evm target, add puppeth to table

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,11 @@ geth:
 	@echo "Done building."
 	@echo "Run \"$(GOBIN)/geth\" to launch geth."
 
+puppeth:
+	build/env.sh go run build/ci.go install ./cmd/puppeth
+	@echo "Done building."
+	@echo "Run \"$(GOBIN)/puppeth\" to launch puppeth."
+
 swarm:
 	build/env.sh go run build/ci.go install ./cmd/swarm
 	@echo "Done building."

--- a/Makefile
+++ b/Makefile
@@ -16,21 +16,6 @@ geth:
 	@echo "Done building."
 	@echo "Run \"$(GOBIN)/geth\" to launch geth."
 
-puppeth:
-	build/env.sh go run build/ci.go install ./cmd/puppeth
-	@echo "Done building."
-	@echo "Run \"$(GOBIN)/puppeth\" to launch puppeth."
-
-swarm:
-	build/env.sh go run build/ci.go install ./cmd/swarm
-	@echo "Done building."
-	@echo "Run \"$(GOBIN)/swarm\" to launch swarm."
-
-evm:
-	build/env.sh go run build/ci.go install ./cmd/evm
-	@echo "Done building."
-	@echo "Run \"$(GOBIN)/evm\" to start the evm."
-
 all:
 	build/env.sh go run build/ci.go install
 

--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,11 @@ geth:
 	@echo "Done building."
 	@echo "Run \"$(GOBIN)/geth\" to launch geth."
 
+swarm:
+	build/env.sh go run build/ci.go install ./cmd/swarm
+	@echo "Done building."
+	@echo "Run \"$(GOBIN)/swarm\" to launch swarm."
+
 all:
 	build/env.sh go run build/ci.go install
 

--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ The go-ethereum project comes with several wrappers/executables found in the `cm
 | `gethrpctest` | Developer utility tool to support our [ethereum/rpc-test](https://github.com/ethereum/rpc-tests) test suite which validates baseline conformity to the [Ethereum JSON RPC](https://github.com/ethereum/wiki/wiki/JSON-RPC) specs. Please see the [test suite's readme](https://github.com/ethereum/rpc-tests/blob/master/README.md) for details. |
 | `rlpdump` | Developer utility tool to convert binary RLP ([Recursive Length Prefix](https://github.com/ethereum/wiki/wiki/RLP)) dumps (data encoding used by the Ethereum protocol both network as well as consensus wise) to user friendlier hierarchical representation (e.g. `rlpdump --hex CE0183FFFFFFC4C304050583616263`). |
 | `swarm`    | swarm daemon and tools. This is the entrypoint for the swarm network. `swarm --help` for command line options and subcommands. See https://swarm-guide.readthedocs.io for swarm documentation. |
+| `puppeth`    | a CLI wizard that aids in creating a new Ethereum network. |
 
 ## Running geth
 


### PR DESCRIPTION
Remove evm, swarm from top-level Makefile (consistency with puppeth) and add puppeth to README