### PR TITLE
cmd: add makecache cmd, use caches during import cmd

### DIFF
--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -157,6 +157,7 @@ func init() {
 		attachCommand,
 		javascriptCommand,
 		// See misccmd.go:
+		makecacheCommand,
 		makedagCommand,
 		versionCommand,
 		bugCommand,

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -1093,7 +1093,10 @@ func MakeChain(ctx *cli.Context, stack *node.Node) (chain *core.BlockChain, chai
 
 	engine := ethash.NewFaker()
 	if !ctx.GlobalBool(FakePoWFlag.Name) {
-		engine = ethash.New("", 1, 0, "", 1, 0)
+		engine = ethash.New(
+			stack.ResolvePath(eth.DefaultConfig.EthashCacheDir), eth.DefaultConfig.EthashCachesInMem, eth.DefaultConfig.EthashCachesOnDisk,
+			stack.ResolvePath(eth.DefaultConfig.EthashDatasetDir), eth.DefaultConfig.EthashDatasetsInMem, eth.DefaultConfig.EthashDatasetsOnDisk,
+		)
 	}
 	config, _, err := core.SetupGenesisBlock(chainDb, MakeGenesis(ctx))
 	if err != nil {


### PR DESCRIPTION
This PR adds a `geth makecache` subcommand to allow pre-generating ethash verification caches too (not only DAGs) for the hive test harness. The PR also fixes the `geth import` subcommand so that disk based verification caches are used opposed to always generating on startup (it saves about 1 second / startup).

~~Jury is still out on how beneficial this is for hive, running the consensus tests now.~~

15681 hive tests ran in 1h55m54.523518164s on my laptop. The original code without this change (and associated hive update) runs in 2h54m15.19209476s.