### PR TITLE
[WIP] node: manage HTTP servers in node

### DIFF
--- a/node/api.go
+++ b/node/api.go
@@ -78,10 +78,6 @@ func (api *PrivateAdminAPI) StartRPC(host *string, port *int, cors *string, apis
 	api.node.lock.Lock()
 	defer api.node.lock.Unlock()
 
-	if api.node.httpHandler != nil {
-		return false, fmt.Errorf("HTTP RPC already running on %s", api.node.httpEndpoint)
-	}
-
 	if host == nil {
 		h := DefaultHTTPHost
 		if api.node.config.HTTPHost != "" {
@@ -101,7 +97,7 @@ func (api *PrivateAdminAPI) StartRPC(host *string, port *int, cors *string, apis
 		}
 	}
 
-	modules := api.node.httpWhitelist
+	modules := api.node.config.HTTPModules
 	if apis != nil {
 		modules = nil
 		for _, m := range strings.Split(*apis, ",") {
@@ -120,10 +116,7 @@ func (api *PrivateAdminAPI) StopRPC() (bool, error) {
 	api.node.lock.Lock()
 	defer api.node.lock.Unlock()
 
-	if api.node.httpHandler == nil {
-		return false, fmt.Errorf("HTTP RPC not running")
-	}
-	api.node.stopHTTP()
+	api.node.stopAllHTTP()
 	return true, nil
 }
 
@@ -131,10 +124,6 @@ func (api *PrivateAdminAPI) StopRPC() (bool, error) {
 func (api *PrivateAdminAPI) StartWS(host *string, port *int, allowedOrigins *string, apis *string) (bool, error) {
 	api.node.lock.Lock()
 	defer api.node.lock.Unlock()
-
-	if api.node.wsHandler != nil {
-		return false, fmt.Errorf("WebSocket RPC already running on %s", api.node.wsEndpoint)
-	}
 
 	if host == nil {
 		h := DefaultWSHost
@@ -174,10 +163,8 @@ func (api *PrivateAdminAPI) StopWS() (bool, error) {
 	api.node.lock.Lock()
 	defer api.node.lock.Unlock()
 
-	if api.node.wsHandler == nil {
-		return false, fmt.Errorf("WebSocket RPC not running")
-	}
-	api.node.stopWS()
+	// TODO: stop ws only
+	api.node.stopAllHTTP()
 	return true, nil
 }
 

--- a/node/http.go
+++ b/node/http.go
@@ -1,0 +1,127 @@
+// Copyright 2015 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+package node
+
+import (
+	"fmt"
+	"net"
+	"net/http"
+	"strconv"
+	"strings"
+	"sync"
+
+	"github.com/ethereum/go-ethereum/log"
+	"github.com/rs/cors"
+)
+
+type httpEndpoint struct {
+	fd  net.Listener
+	srv http.Server
+
+	// Multiple handlers can be attached to a single endpoint.
+	mu   sync.Mutex
+	http http.Handler
+	ws   http.Handler
+}
+
+// listenHTTP starts a new HTTP server or returns an existing one.
+// n.lock must be held by the caller.
+func (n *Node) listenHTTP(endpoint string) (*httpEndpoint, error) {
+	_, portstring, err := net.SplitHostPort(endpoint)
+	if err != nil {
+		return nil, fmt.Errorf("invalid endpoint %q", endpoint)
+	}
+	port, err := strconv.Atoi(portstring)
+	if err != nil {
+		return nil, fmt.Errorf("invalid endpoint %q", endpoint)
+	}
+	if port != 0 && n.httpServers[port] != nil {
+		// Use existing server.
+		return n.httpServers[port], nil
+	}
+	fd, err := net.Listen("tcp", endpoint)
+	if err != nil {
+		return nil, err
+	}
+	h := &httpEndpoint{fd: fd}
+	h.srv.Handler = h
+	n.httpServers[fd.Addr().(*net.TCPAddr).Port] = h
+	go h.srv.Serve(fd)
+	return h, nil
+}
+
+func (n *Node) stopAllHTTP() {
+	for _, ep := range n.httpServers {
+		ep.stop()
+	}
+}
+
+func (ep *httpEndpoint) ServeHTTP(resp http.ResponseWriter, req *http.Request) {
+	ep.handler(req).ServeHTTP(resp, req)
+}
+
+func (ep *httpEndpoint) setWS(h http.Handler) {
+	ep.mu.Lock()
+	defer ep.mu.Unlock()
+	ep.ws = h
+}
+
+func (ep *httpEndpoint) setHTTP(h http.Handler) {
+	ep.mu.Lock()
+	defer ep.mu.Unlock()
+	ep.http = h
+}
+
+func (ep *httpEndpoint) stop() error {
+	ep.mu.Lock()
+	defer ep.mu.Unlock()
+	err := ep.fd.Close()
+	// TODO close rpc server too
+	log.Info(fmt.Sprintf("HTTP server closed: http://%s", ep.fd.Addr()))
+	return err
+}
+
+func (ep *httpEndpoint) handler(req *http.Request) http.Handler {
+	ep.mu.Lock()
+	defer ep.mu.Unlock()
+	switch {
+	case ep.ws != nil && req.Method == "GET" && strings.ToLower(req.Header.Get("Upgrade")) == "websocket":
+		return ep.ws
+	case ep.http != nil:
+		return ep.http
+	default:
+		return http.HandlerFunc(defaultHandler)
+	}
+}
+
+func defaultHandler(resp http.ResponseWriter, req *http.Request) {
+	http.Error(resp, "no handler configured on this endpoint, please try again later", http.StatusServiceUnavailable)
+}
+
+func newCorsHandler(corsOrigins []string, h http.Handler) http.Handler {
+	if len(corsOrigins) == 0 {
+		// disable CORS support if user has not specified a custom CORS configuration
+		return h
+	}
+	c := cors.New(cors.Options{
+		AllowedOrigins: corsOrigins,
+		AllowedMethods: []string{"POST", "GET"},
+		MaxAge:         600,
+		AllowedHeaders: []string{"*"},
+	})
+	return c.Handler(h)
+}

--- a/node/node.go
+++ b/node/node.go
@@ -68,14 +68,7 @@ type Node struct {
 	ipcListener net.Listener // IPC RPC listener socket to serve API requests
 	ipcHandler  *rpc.Server  // IPC RPC request handler to process the API requests
 
-	httpEndpoint  string       // HTTP endpoint (interface + port) to listen at (empty = HTTP disabled)
-	httpWhitelist []string     // HTTP RPC modules to allow through this endpoint
-	httpListener  net.Listener // HTTP RPC listener socket to server API requests
-	httpHandler   *rpc.Server  // HTTP RPC request handler to process the API requests
-
-	wsEndpoint string       // Websocket endpoint (interface + port) to listen at (empty = websocket disabled)
-	wsListener net.Listener // Websocket RPC listener socket to server API requests
-	wsHandler  *rpc.Server  // Websocket RPC request handler to process the API requests
+	httpServers map[int]*httpEndpoint // tracks all servers by port.
 
 	stop chan struct{} // Channel to wait for termination notifications
 	lock sync.RWMutex
@@ -119,8 +112,7 @@ func New(conf *Config) (*Node, error) {
 		config:            conf,
 		serviceFuncs:      []ServiceConstructor{},
 		ipcEndpoint:       conf.IPCEndpoint(),
-		httpEndpoint:      conf.HTTPEndpoint(),
-		wsEndpoint:        conf.WSEndpoint(),
+		httpServers:       make(map[int]*httpEndpoint),
 		eventmux:          new(event.TypeMux),
 	}, nil
 }
@@ -270,13 +262,13 @@ func (n *Node) startRPC(services map[reflect.Type]Service) error {
 		n.stopInProc()
 		return err
 	}
-	if err := n.startHTTP(n.httpEndpoint, apis, n.config.HTTPModules, n.config.HTTPCors); err != nil {
+	if err := n.startHTTP(n.config.HTTPEndpoint(), apis, n.config.HTTPModules, n.config.HTTPCors); err != nil {
 		n.stopIPC()
 		n.stopInProc()
 		return err
 	}
-	if err := n.startWS(n.wsEndpoint, apis, n.config.WSModules, n.config.WSOrigins); err != nil {
-		n.stopHTTP()
+	if err := n.startWS(n.config.WSEndpoint(), apis, n.config.WSModules, n.config.WSOrigins); err != nil {
+		n.stopAllHTTP()
 		n.stopIPC()
 		n.stopInProc()
 		return err
@@ -393,36 +385,13 @@ func (n *Node) startHTTP(endpoint string, apis []rpc.API, modules []string, cors
 		}
 	}
 	// All APIs registered, start the HTTP listener
-	var (
-		listener net.Listener
-		err      error
-	)
-	if listener, err = net.Listen("tcp", endpoint); err != nil {
+	ep, err := n.listenHTTP(endpoint)
+	if err != nil {
 		return err
 	}
-	go rpc.NewHTTPServer(cors, handler).Serve(listener)
+	ep.setHTTP(newCorsHandler(cors, handler))
 	log.Info(fmt.Sprintf("HTTP endpoint opened: http://%s", endpoint))
-
-	// All listeners booted successfully
-	n.httpEndpoint = endpoint
-	n.httpListener = listener
-	n.httpHandler = handler
-
 	return nil
-}
-
-// stopHTTP terminates the HTTP RPC endpoint.
-func (n *Node) stopHTTP() {
-	if n.httpListener != nil {
-		n.httpListener.Close()
-		n.httpListener = nil
-
-		log.Info(fmt.Sprintf("HTTP endpoint closed: http://%s", n.httpEndpoint))
-	}
-	if n.httpHandler != nil {
-		n.httpHandler.Stop()
-		n.httpHandler = nil
-	}
 }
 
 // startWS initializes and starts the websocket RPC endpoint.
@@ -447,36 +416,13 @@ func (n *Node) startWS(endpoint string, apis []rpc.API, modules []string, wsOrig
 		}
 	}
 	// All APIs registered, start the HTTP listener
-	var (
-		listener net.Listener
-		err      error
-	)
-	if listener, err = net.Listen("tcp", endpoint); err != nil {
+	ep, err := n.listenHTTP(endpoint)
+	if err != nil {
 		return err
 	}
-	go rpc.NewWSServer(wsOrigins, handler).Serve(listener)
 	log.Info(fmt.Sprintf("WebSocket endpoint opened: ws://%s", endpoint))
-
-	// All listeners booted successfully
-	n.wsEndpoint = endpoint
-	n.wsListener = listener
-	n.wsHandler = handler
-
+	ep.setWS(handler.WebsocketHandler(wsOrigins))
 	return nil
-}
-
-// stopWS terminates the websocket RPC endpoint.
-func (n *Node) stopWS() {
-	if n.wsListener != nil {
-		n.wsListener.Close()
-		n.wsListener = nil
-
-		log.Info(fmt.Sprintf("WebSocket endpoint closed: ws://%s", n.wsEndpoint))
-	}
-	if n.wsHandler != nil {
-		n.wsHandler.Stop()
-		n.wsHandler = nil
-	}
 }
 
 // Stop terminates a running node along with all it's services. In the node was
@@ -491,8 +437,7 @@ func (n *Node) Stop() error {
 	}
 
 	// Terminate the API, services and the p2p server.
-	n.stopWS()
-	n.stopHTTP()
+	n.stopAllHTTP()
 	n.stopIPC()
 	n.rpcAPIs = nil
 	failure := &StopError{
@@ -615,16 +560,6 @@ func (n *Node) AccountManager() *accounts.Manager {
 // IPCEndpoint retrieves the current IPC endpoint used by the protocol stack.
 func (n *Node) IPCEndpoint() string {
 	return n.ipcEndpoint
-}
-
-// HTTPEndpoint retrieves the current HTTP endpoint used by the protocol stack.
-func (n *Node) HTTPEndpoint() string {
-	return n.httpEndpoint
-}
-
-// WSEndpoint retrieves the current WS endpoint used by the protocol stack.
-func (n *Node) WSEndpoint() string {
-	return n.wsEndpoint
 }
 
 // EventMux retrieves the event multiplexer used by all the network services in

--- a/rpc/websocket.go
+++ b/rpc/websocket.go
@@ -45,13 +45,6 @@ func (srv *Server) WebsocketHandler(allowedOrigins []string) http.Handler {
 	}
 }
 
-// NewWSServer creates a new websocket RPC server around an API provider.
-//
-// Deprecated: use Server.WebsocketHandler
-func NewWSServer(allowedOrigins []string, srv *Server) *http.Server {
-	return &http.Server{Handler: srv.WebsocketHandler(allowedOrigins)}
-}
-
 // wsHandshakeValidator returns a handler that verifies the origin during the
 // websocket upgrade process. When a '*' is specified as an allowed origins all
 // connections are accepted.


### PR DESCRIPTION
This removes deprecated ways to create http.Server. WebSocket and
regular HTTP can now be used on the same port:

    geth --rpc --rpcport=8080 --ws --wsport=8080

This facility may be used to attach more stuff (e.g. a web UI) to
existing servers.