### PR TITLE
cmd/puppeth: remove wrapping loop in single reads

### DIFF
--- a/cmd/puppeth/wizard.go
+++ b/cmd/puppeth/wizard.go
@@ -106,17 +106,15 @@ func (w *wizard) readString() string {
 // readDefaultString reads a single line from stdin, trimming if from spaces. If
 // an empty line is entered, the default value is returned.
 func (w *wizard) readDefaultString(def string) string {
-	for {
-		fmt.Printf("> ")
-		text, err := w.in.ReadString('\n')
-		if err != nil {
-			log.Crit("Failed to read user input", "err", err)
-		}
-		if text = strings.TrimSpace(text); text != "" {
-			return text
-		}
-		return def
+	fmt.Printf("> ")
+	text, err := w.in.ReadString('\n')
+	if err != nil {
+		log.Crit("Failed to read user input", "err", err)
 	}
+	if text = strings.TrimSpace(text); text != "" {
+		return text
+	}
+	return def
 }
 
 // readInt reads a single line from stdin, trimming if from spaces, enforcing it
@@ -207,15 +205,13 @@ func (w *wizard) readDefaultFloat(def float64) float64 {
 // readPassword reads a single line from stdin, trimming it from the trailing new
 // line and returns it. The input will not be echoed.
 func (w *wizard) readPassword() string {
-	for {
-		fmt.Printf("> ")
-		text, err := terminal.ReadPassword(int(syscall.Stdin))
-		if err != nil {
-			log.Crit("Failed to read password", "err", err)
-		}
-		fmt.Println()
-		return string(text)
+	fmt.Printf("> ")
+	text, err := terminal.ReadPassword(int(syscall.Stdin))
+	if err != nil {
+		log.Crit("Failed to read password", "err", err)
 	}
+	fmt.Println()
+	return string(text)
 }
 
 // readAddress reads a single line from stdin, trimming if from spaces and converts


### PR DESCRIPTION
Fix the [cardinal sin of programming](https://twitter.com/NateTheFinch/status/893456847696474112) so that @natefinch doesn't have [to go wtf](https://twitter.com/NateTheFinch/status/893440465034465287).

This PR removes to useless `for` cycles that were accidentally left in, although had no effect at all.