### PR TITLE
[WIP] cmd/evm: prestate config and json trace fixes

### DIFF
--- a/cmd/evm/json_logger.go
+++ b/cmd/evm/json_logger.go
@@ -40,7 +40,7 @@ func (l *JSONLogger) CaptureState(env *vm.EVM, pc uint64, op vm.OpCode, gas, cos
 	log := vm.StructLog{
 		Pc:         pc,
 		Op:         op,
-		Gas:        gas + cost,
+		Gas:        gas,
 		GasCost:    cost,
 		MemorySize: memory.Len(),
 		Storage:    nil,

--- a/cmd/evm/main.go
+++ b/cmd/evm/main.go
@@ -102,6 +102,10 @@ var (
 		Name:  "sender",
 		Usage: "The transaction origin",
 	}
+	ReceiverFlag = cli.StringFlag{
+		Name:  "receiver",
+		Usage: "The transaction receiver (execution context)",
+	}
 	DisableMemoryFlag = cli.BoolFlag{
 		Name:  "nomemory",
 		Usage: "disable memory output",
@@ -131,6 +135,7 @@ func init() {
 		GenesisFlag,
 		MachineFlag,
 		SenderFlag,
+		ReceiverFlag,
 		DisableMemoryFlag,
 		DisableStackFlag,
 	}

--- a/cmd/evm/runner.go
+++ b/cmd/evm/runner.go
@@ -84,6 +84,7 @@ func runCmd(ctx *cli.Context) error {
 		statedb     *state.StateDB
 		chainConfig *params.ChainConfig
 		sender      = common.StringToAddress("sender")
+		receiver    = common.StringToAddress("receiver")
 	)
 	if ctx.GlobalBool(MachineFlag.Name) {
 		tracer = NewJSONLogger(logconfig, os.Stdout)
@@ -104,46 +105,52 @@ func runCmd(ctx *cli.Context) error {
 	if ctx.GlobalString(SenderFlag.Name) != "" {
 		sender = common.HexToAddress(ctx.GlobalString(SenderFlag.Name))
 	}
-
 	statedb.CreateAccount(sender)
+
+	if ctx.GlobalString(ReceiverFlag.Name) != "" {
+		receiver = common.HexToAddress(ctx.GlobalString(ReceiverFlag.Name))
+	}
 
 	var (
 		code []byte
 		ret  []byte
 		err  error
 	)
-	if fn := ctx.Args().First(); len(fn) > 0 {
-		src, err := ioutil.ReadFile(fn)
-		if err != nil {
-			return err
-		}
+	if statedb.GetCodeSize(receiver) == 0 {
+		if fn := ctx.Args().First(); len(fn) > 0 {
+			src, err := ioutil.ReadFile(fn)
+			if err != nil {
+				return err
+			}
 
-		bin, err := compiler.Compile(fn, src, false)
-		if err != nil {
-			return err
-		}
-		code = common.Hex2Bytes(bin)
-	} else if ctx.GlobalString(CodeFlag.Name) != "" {
-		code = common.Hex2Bytes(ctx.GlobalString(CodeFlag.Name))
-	} else {
-		var hexcode []byte
-		if ctx.GlobalString(CodeFileFlag.Name) != "" {
-			var err error
-			hexcode, err = ioutil.ReadFile(ctx.GlobalString(CodeFileFlag.Name))
+			bin, err := compiler.Compile(fn, src, false)
 			if err != nil {
-				fmt.Printf("Could not load code from file: %v\n", err)
-				os.Exit(1)
+				return err
 			}
+			code = common.Hex2Bytes(bin)
+		} else if ctx.GlobalString(CodeFlag.Name) != "" {
+			code = common.Hex2Bytes(ctx.GlobalString(CodeFlag.Name))
 		} else {
-			var err error
-			hexcode, err = ioutil.ReadAll(os.Stdin)
-			if err != nil {
-				fmt.Printf("Could not load code from stdin: %v\n", err)
-				os.Exit(1)
+			var hexcode []byte
+			if ctx.GlobalString(CodeFileFlag.Name) != "" {
+				var err error
+				hexcode, err = ioutil.ReadFile(ctx.GlobalString(CodeFileFlag.Name))
+				if err != nil {
+					fmt.Printf("Could not load code from file: %v\n", err)
+					os.Exit(1)
+				}
+			} else {
+				var err error
+				hexcode, err = ioutil.ReadAll(os.Stdin)
+				if err != nil {
+					fmt.Printf("Could not load code from stdin: %v\n", err)
+					os.Exit(1)
+				}
 			}
+			code = common.Hex2Bytes(string(bytes.TrimRight(hexcode, "\n")))
 		}
-		code = common.Hex2Bytes(string(bytes.TrimRight(hexcode, "\n")))
 	}
+
 	initialGas := ctx.GlobalUint64(GasFlag.Name)
 	runtimeConfig := runtime.Config{
 		Origin:   sender,
@@ -180,9 +187,9 @@ func runCmd(ctx *cli.Context) error {
 		input := append(code, common.Hex2Bytes(ctx.GlobalString(InputFlag.Name))...)
 		ret, _, leftOverGas, err = runtime.Create(input, &runtimeConfig)
 	} else {
-		receiver := common.StringToAddress("receiver")
-		statedb.SetCode(receiver, code)
-
+		if statedb.GetCodeSize(receiver) == 0 {
+			statedb.SetCode(receiver, code)
+		}
 		ret, leftOverGas, err = runtime.Call(receiver, common.Hex2Bytes(ctx.GlobalString(InputFlag.Name)), &runtimeConfig)
 	}
 	execTime := time.Since(tstart)

--- a/cmd/evm/runner.go
+++ b/cmd/evm/runner.go
@@ -24,6 +24,7 @@ import (
 	"os"
 	"runtime/pprof"
 	"time"
+	"math/big"
 
 	goruntime "runtime"
 
@@ -83,6 +84,10 @@ func runCmd(ctx *cli.Context) error {
 		debugLogger *vm.StructLogger
 		statedb     *state.StateDB
 		chainConfig *params.ChainConfig
+		genCoinbase common.Address
+		genTimestamp uint64
+		genGasLimit uint64
+		genDifficulty *big.Int
 		sender      = common.StringToAddress("sender")
 		receiver    = common.StringToAddress("receiver")
 	)
@@ -98,6 +103,14 @@ func runCmd(ctx *cli.Context) error {
 		gen := readGenesis(ctx.GlobalString(GenesisFlag.Name))
 		_, statedb = gen.ToBlock()
 		chainConfig = gen.Config
+		genCoinbase = gen.Coinbase
+		genDifficulty = gen.Difficulty
+		genGasLimit = gen.GasLimit
+		genTimestamp = gen.Timestamp
+		fmt.Println("runner.go gen.Difficulty:", gen.Difficulty)
+		fmt.Println("runner.go gen.Coinbase:", gen.Coinbase)
+		fmt.Println("runner.go gen.Timestamp:", gen.Timestamp)
+		fmt.Println("runner.go chainConfig:", chainConfig)
 	} else {
 		db, _ := ethdb.NewMemDatabase()
 		statedb, _ = state.New(common.Hash{}, state.NewDatabase(db))
@@ -105,7 +118,8 @@ func runCmd(ctx *cli.Context) error {
 	if ctx.GlobalString(SenderFlag.Name) != "" {
 		sender = common.HexToAddress(ctx.GlobalString(SenderFlag.Name))
 	}
-	statedb.CreateAccount(sender)
+	// createAccount overwrites the nonce in the prestate. should only be used if no prestate provided
+	// statedb.CreateAccount(sender)
 
 	if ctx.GlobalString(ReceiverFlag.Name) != "" {
 		receiver = common.HexToAddress(ctx.GlobalString(ReceiverFlag.Name))
@@ -154,9 +168,13 @@ func runCmd(ctx *cli.Context) error {
 	initialGas := ctx.GlobalUint64(GasFlag.Name)
 	runtimeConfig := runtime.Config{
 		Origin:   sender,
+		Time:			new(big.Int).SetUint64(genTimestamp),
+		Coinbase: genCoinbase,
+		Difficulty: genDifficulty,
 		State:    statedb,
-		GasLimit: initialGas,
+		GasLimit: genGasLimit,
 		GasPrice: utils.GlobalBig(ctx, PriceFlag.Name),
+		TxGasLimit: initialGas,
 		Value:    utils.GlobalBig(ctx, ValueFlag.Name),
 		EVMConfig: vm.Config{
 			Tracer:             tracer,
@@ -183,15 +201,30 @@ func runCmd(ctx *cli.Context) error {
 	}
 	tstart := time.Now()
 	var leftOverGas uint64
+	
+	// sender prepays the gas fee
+	mgval := new(big.Int).Mul(new(big.Int).SetUint64(initialGas), runtimeConfig.GasPrice)
+	statedb.SubBalance(sender, mgval)
+
 	if ctx.GlobalBool(CreateFlag.Name) {
 		input := append(code, common.Hex2Bytes(ctx.GlobalString(InputFlag.Name))...)
+		intrinsicGas := core.IntrinsicGas(input, ctx.GlobalBool(CreateFlag.Name), true)
+		initialGas -= intrinsicGas.Uint64()
+		runtimeConfig.TxGasLimit = initialGas
 		ret, _, leftOverGas, err = runtime.Create(input, &runtimeConfig)
 	} else {
 		if statedb.GetCodeSize(receiver) == 0 {
 			statedb.SetCode(receiver, code)
 		}
+		intrinsicGas := core.IntrinsicGas(common.Hex2Bytes(ctx.GlobalString(InputFlag.Name)), false, true)
+		initialGas -= intrinsicGas.Uint64()
+		runtimeConfig.TxGasLimit = initialGas
 		ret, leftOverGas, err = runtime.Call(receiver, common.Hex2Bytes(ctx.GlobalString(InputFlag.Name)), &runtimeConfig)
 	}
+
+	remainingEther := new(big.Int).Mul(new(big.Int).SetUint64(leftOverGas), runtimeConfig.GasPrice)
+	statedb.AddBalance(sender, remainingEther)
+	
 	execTime := time.Since(tstart)
 
 	if ctx.GlobalBool(DumpFlag.Name) {

--- a/core/vm/runtime/env.go
+++ b/core/vm/runtime/env.go
@@ -19,7 +19,6 @@ package runtime
 import (
 	"math/big"
 
-	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core"
 	"github.com/ethereum/go-ethereum/core/state"
 	"github.com/ethereum/go-ethereum/core/vm"
@@ -29,8 +28,7 @@ func NewEnv(cfg *Config, state *state.StateDB) *vm.EVM {
 	context := vm.Context{
 		CanTransfer: core.CanTransfer,
 		Transfer:    core.Transfer,
-		GetHash:     func(uint64) common.Hash { return common.Hash{} },
-
+		GetHash:     cfg.GetHashFn,
 		Origin:      cfg.Origin,
 		Coinbase:    cfg.Coinbase,
 		BlockNumber: cfg.BlockNumber,

--- a/core/vm/runtime/runtime.go
+++ b/core/vm/runtime/runtime.go
@@ -40,6 +40,7 @@ type Config struct {
 	Time        *big.Int
 	GasLimit    uint64
 	GasPrice    *big.Int
+	TxGasLimit  uint64
 	Value       *big.Int
 	DisableJit  bool // "disable" so it's enabled by default
 	Debug       bool
@@ -79,7 +80,7 @@ func setDefaults(cfg *Config) {
 		cfg.Value = new(big.Int)
 	}
 	if cfg.BlockNumber == nil {
-		cfg.BlockNumber = new(big.Int)
+		cfg.BlockNumber = big.NewInt(1)
 	}
 	if cfg.GetHashFn == nil {
 		cfg.GetHashFn = func(n uint64) common.Hash {
@@ -144,7 +145,7 @@ func Create(input []byte, cfg *Config) ([]byte, common.Address, uint64, error) {
 	code, address, leftOverGas, err := vmenv.Create(
 		sender,
 		input,
-		cfg.GasLimit,
+		cfg.TxGasLimit,
 		cfg.Value,
 	)
 	return code, address, leftOverGas, err
@@ -166,7 +167,7 @@ func Call(address common.Address, input []byte, cfg *Config) ([]byte, uint64, er
 		sender,
 		address,
 		input,
-		cfg.GasLimit,
+		cfg.TxGasLimit,
 		cfg.Value,
 	)
 


### PR DESCRIPTION
This is only half-done [WIP do not merge]. The evm command is probably broken if certain arguments aren't passed in (no default fallbacks yet).

This PR includes https://github.com/ethereum/go-ethereum/pull/14873.

Some of these changes add more support for configs given in a prestate (https://github.com/ethereum/go-ethereum/pull/14476). Others, like charging for intrinsic gas, are to reproduce the results of state tests. Those changes are mostly copy/pasted from [state_test_util.go](https://github.com/ethereum/go-ethereum/blob/225de7ca0a9e861696a5a43b666090b574c4c769/tests/state_test_util.go#L169-L203) and [state_transition.go](https://github.com/ethereum/go-ethereum/blob/225de7ca0a9e861696a5a43b666090b574c4c769/core/state_transition.go).

Additionally there are changes to the json tracing. These are done to converge with the EVM traces that pyethereum produces, where it makes sense. For instance, a `stackCopy` variable was added to fix cases where the trace would print a mutated stack (the stack _after_ the operation was applied), rather than printing the stack _before_ the operation was applied.