### PR TITLE
core: bump timeout test to avoid flakyness on overloaded ci

### DIFF
--- a/core/tx_pool_test.go
+++ b/core/tx_pool_test.go
@@ -750,14 +750,14 @@ func TestTransactionQueueTimeLimitingNoLocals(t *testing.T) { testTransactionQue
 func testTransactionQueueTimeLimiting(t *testing.T, nolocals bool) {
 	// Reduce the eviction interval to a testable amount
 	defer func(old time.Duration) { evictionInterval = old }(evictionInterval)
-	evictionInterval = 250 * time.Millisecond
+	evictionInterval = time.Second
 
 	// Create the pool to test the non-expiration enforcement
 	db, _ := ethdb.NewMemDatabase()
 	statedb, _ := state.New(common.Hash{}, state.NewDatabase(db))
 
 	config := testTxPoolConfig
-	config.Lifetime = 250 * time.Millisecond
+	config.Lifetime = time.Second
 	config.NoLocals = nolocals
 
 	pool := NewTxPool(config, params.TestChainConfig, new(event.TypeMux), func() (*state.StateDB, error) { return statedb, nil }, func() *big.Int { return big.NewInt(1000000) })


### PR DESCRIPTION
There's a test in the txpool suite that checks for proper transaction eviction based on lifetime expiration. The test previously used a 250ms expiration times, which is apparently way too low during heavy CI runs. This PR bumps the tested time to 1 second to ensure overloaded CI can still meaningfully cope with it.