### PR TITLE
cmd: fix megacheck warnings

### DIFF
--- a/cmd/evm/disasm.go
+++ b/cmd/evm/disasm.go
@@ -46,8 +46,5 @@ func disasmCmd(ctx *cli.Context) error {
 
 	code := strings.TrimSpace(string(in[:]))
 	fmt.Printf("%v\n", code)
-	if err = asm.PrintDisassembled(code); err != nil {
-		return err
-	}
-	return nil
+	return asm.PrintDisassembled(code)
 }

--- a/cmd/faucet/faucet.go
+++ b/cmd/faucet/faucet.go
@@ -471,7 +471,7 @@ func (f *faucet) apiHandler(conn *websocket.Conn) {
 
 		// Send an error if too frequent funding, othewise a success
 		if !fund {
-			websocket.JSON.Send(conn, map[string]string{"error": fmt.Sprintf("%s left until next allowance", common.PrettyDuration(timeout.Sub(time.Now())))})
+			websocket.JSON.Send(conn, map[string]string{"error": fmt.Sprintf("%s left until next allowance", common.PrettyDuration(time.Until(timeout)))})
 			continue
 		}
 		websocket.JSON.Send(conn, map[string]string{"success": fmt.Sprintf("Funding request accepted for %s into %s", gist.Owner.Login, address.Hex())})

--- a/cmd/faucet/faucet.go
+++ b/cmd/faucet/faucet.go
@@ -471,7 +471,7 @@ func (f *faucet) apiHandler(conn *websocket.Conn) {
 
 		// Send an error if too frequent funding, othewise a success
 		if !fund {
-			websocket.JSON.Send(conn, map[string]string{"error": fmt.Sprintf("%s left until next allowance", common.PrettyDuration(time.Until(timeout)))})
+			websocket.JSON.Send(conn, map[string]string{"error": fmt.Sprintf("%s left until next allowance", common.PrettyDuration(timeout.Sub(time.Now())))})
 			continue
 		}
 		websocket.JSON.Send(conn, map[string]string{"success": fmt.Sprintf("Funding request accepted for %s into %s", gist.Owner.Login, address.Hex())})

--- a/cmd/puppeth/ssh.go
+++ b/cmd/puppeth/ssh.go
@@ -122,7 +122,7 @@ func dial(server string, pubkey []byte) (*sshClient, error) {
 			}
 		}
 		// If a public key exists for this SSH server, check that it matches
-		if bytes.Compare(pubkey, key.Marshal()) == 0 {
+		if bytes.Equal(pubkey, key.Marshal()) {
 			return nil
 		}
 		// We have a mismatch, forbid connecting

--- a/cmd/puppeth/wizard.go
+++ b/cmd/puppeth/wizard.go
@@ -160,6 +160,29 @@ func (w *wizard) readDefaultInt(def int) int {
 	}
 }
 
+/*
+// readFloat reads a single line from stdin, trimming if from spaces, enforcing it
+// to parse into a float.
+func (w *wizard) readFloat() float64 {
+	for {
+		fmt.Printf("> ")
+		text, err := w.in.ReadString('\n')
+		if err != nil {
+			log.Crit("Failed to read user input", "err", err)
+		}
+		if text = strings.TrimSpace(text); text == "" {
+			continue
+		}
+		val, err := strconv.ParseFloat(strings.TrimSpace(text), 64)
+		if err != nil {
+			log.Error("Invalid input, expected float", "err", err)
+			continue
+		}
+		return val
+	}
+}
+*/
+
 // readDefaultFloat reads a single line from stdin, trimming if from spaces, enforcing
 // it to parse into a float. If an empty line is entered, the default value is returned.
 func (w *wizard) readDefaultFloat(def float64) float64 {

--- a/cmd/puppeth/wizard.go
+++ b/cmd/puppeth/wizard.go
@@ -160,27 +160,6 @@ func (w *wizard) readDefaultInt(def int) int {
 	}
 }
 
-// readFloat reads a single line from stdin, trimming if from spaces, enforcing it
-// to parse into a float.
-func (w *wizard) readFloat() float64 {
-	for {
-		fmt.Printf("> ")
-		text, err := w.in.ReadString('\n')
-		if err != nil {
-			log.Crit("Failed to read user input", "err", err)
-		}
-		if text = strings.TrimSpace(text); text == "" {
-			continue
-		}
-		val, err := strconv.ParseFloat(strings.TrimSpace(text), 64)
-		if err != nil {
-			log.Error("Invalid input, expected float", "err", err)
-			continue
-		}
-		return val
-	}
-}
-
 // readDefaultFloat reads a single line from stdin, trimming if from spaces, enforcing
 // it to parse into a float. If an empty line is entered, the default value is returned.
 func (w *wizard) readDefaultFloat(def float64) float64 {

--- a/cmd/puppeth/wizard_network.go
+++ b/cmd/puppeth/wizard_network.go
@@ -71,22 +71,20 @@ func (w *wizard) makeServer() string {
 	fmt.Println()
 	fmt.Println("Please enter remote server's address:")
 
-	for {
-		// Read and fial the server to ensure docker is present
-		input := w.readString()
+	// Read and fial the server to ensure docker is present
+	input := w.readString()
 
-		client, err := dial(input, nil)
-		if err != nil {
-			log.Error("Server not ready for puppeth", "err", err)
-			return ""
-		}
-		// All checks passed, start tracking the server
-		w.servers[input] = client
-		w.conf.Servers[input] = client.pubkey
-		w.conf.flush()
-
-		return input
+	client, err := dial(input, nil)
+	if err != nil {
+		log.Error("Server not ready for puppeth", "err", err)
+		return ""
 	}
+	// All checks passed, start tracking the server
+	w.servers[input] = client
+	w.conf.Servers[input] = client.pubkey
+	w.conf.flush()
+
+	return input
 }
 
 // selectServer lists the user all the currnetly known servers to choose from,


### PR DESCRIPTION
megacheck warnings left:

```
cmd\utils\flags.go:1106:63: event.TypeMux is deprecated: use Feed  (SA1019)
```