### PR TITLE
contracts: fix megacheck errors

### DIFF
--- a/contracts/chequebook/cheque.go
+++ b/contracts/chequebook/cheque.go
@@ -376,12 +376,12 @@ func (self *Chequebook) autoDeposit(interval time.Duration) {
 	ticker := time.NewTicker(interval)
 	self.quit = make(chan bool)
 	quit := self.quit
+
 	go func() {
-	FOR:
 		for {
 			select {
 			case <-quit:
-				break FOR
+				return
 			case <-ticker.C:
 				self.lock.Lock()
 				if self.balance.Cmp(self.buffer) < 0 {
@@ -395,7 +395,6 @@ func (self *Chequebook) autoDeposit(interval time.Duration) {
 			}
 		}
 	}()
-	return
 }
 
 // Outbox can issue cheques from a single contract to a single beneficiary.
@@ -436,7 +435,6 @@ type Inbox struct {
 	sender      common.Address              // local peer's address to send cashing tx from
 	signer      *ecdsa.PublicKey            // peer's public key
 	txhash      string                      // tx hash of last cashing tx
-	abigen      bind.ContractBackend        // blockchain API
 	session     *contract.ChequebookSession // abi contract backend with tx opts
 	quit        chan bool                   // when closed causes autocash to stop
 	maxUncashed *big.Int                    // threshold that triggers autocashing
@@ -525,12 +523,12 @@ func (self *Inbox) autoCash(cashInterval time.Duration) {
 	ticker := time.NewTicker(cashInterval)
 	self.quit = make(chan bool)
 	quit := self.quit
+
 	go func() {
-	FOR:
 		for {
 			select {
 			case <-quit:
-				break FOR
+				return
 			case <-ticker.C:
 				self.lock.Lock()
 				if self.cheque != nil && self.cheque.Amount.Cmp(self.cashed) != 0 {
@@ -543,7 +541,6 @@ func (self *Inbox) autoCash(cashInterval time.Duration) {
 			}
 		}
 	}()
-	return
 }
 
 // Receive is called to deposit the latest cheque to the incoming Inbox.

--- a/contracts/chequebook/cheque_test.go
+++ b/contracts/chequebook/cheque_test.go
@@ -170,7 +170,6 @@ func TestVerifyErrors(t *testing.T) {
 		t.Fatalf("expected no error, got %v", err)
 	}
 
-	time.Sleep(5)
 	chbox, err := NewInbox(key1, contr0, addr1, &key0.PublicKey, backend)
 	if err != nil {
 		t.Fatalf("expected no error, got %v", err)

--- a/contracts/chequebook/cheque_test.go
+++ b/contracts/chequebook/cheque_test.go
@@ -193,7 +193,7 @@ func TestVerifyErrors(t *testing.T) {
 	received, err = chbox.Receive(ch1)
 	t.Logf("correct error: %v", err)
 	if err == nil {
-		t.Fatalf("expected receiver error, got none")
+		t.Fatalf("expected receiver error, got none and value %v", received)
 	}
 
 	ch2, err := chbook1.Issue(addr1, amount)
@@ -203,7 +203,7 @@ func TestVerifyErrors(t *testing.T) {
 	received, err = chbox.Receive(ch2)
 	t.Logf("correct error: %v", err)
 	if err == nil {
-		t.Fatalf("expected sender error, got none")
+		t.Fatalf("expected sender error, got none and value %v", received)
 	}
 
 	_, err = chbook1.Issue(addr1, new(big.Int).SetInt64(-1))
@@ -215,7 +215,7 @@ func TestVerifyErrors(t *testing.T) {
 	received, err = chbox.Receive(ch0)
 	t.Logf("correct error: %v", err)
 	if err == nil {
-		t.Fatalf("expected incorrect amount error, got none")
+		t.Fatalf("expected incorrect amount error, got none and value %v", received)
 	}
 
 }


### PR DESCRIPTION
warnings still left:
```
contracts\chequebook\cheque_test.go:173:13: sleeping for 5 nanoseconds is probably a bug. Be explicit if it isn't: time.Sleep(5 * time.Nanosecond) (SA1004)
```

I'm unsure what should happen there. Both, 5ns and 5ms seem wrong.