### PR TITLE
light: fix megacheck warnings

### DIFF
--- a/light/lightchain.go
+++ b/light/lightchain.go
@@ -52,7 +52,6 @@ type LightChain struct {
 
 	mu      sync.RWMutex
 	chainmu sync.RWMutex
-	procmu  sync.RWMutex
 
 	bodyCache    *lru.Cache // Cache for the most recent block bodies
 	bodyRLPCache *lru.Cache // Cache for the most recent block bodies in RLP encoded format

--- a/light/lightchain_test.go
+++ b/light/lightchain_test.go
@@ -18,7 +18,6 @@ package light
 
 import (
 	"context"
-	"fmt"
 	"math/big"
 	"testing"
 
@@ -98,10 +97,7 @@ func testFork(t *testing.T, LightChain *LightChain, i, n int, comparator func(td
 		t.Errorf("chain content mismatch at %d: have hash %v, want hash %v", i, hash2, hash1)
 	}
 	// Extend the newly created chain
-	var (
-		headerChainB []*types.Header
-	)
-	headerChainB = makeHeaderChain(LightChain2.CurrentHeader(), n, db, forkSeed)
+	headerChainB := makeHeaderChain(LightChain2.CurrentHeader(), n, db, forkSeed)
 	if _, err := LightChain2.InsertHeaderChain(headerChainB, 1); err != nil {
 		t.Fatalf("failed to insert forking chain: %v", err)
 	}
@@ -115,13 +111,6 @@ func testFork(t *testing.T, LightChain *LightChain, i, n int, comparator func(td
 	tdPost = LightChain.GetTdByHash(headerChainB[len(headerChainB)-1].Hash())
 	// Compare the total difficulties of the chains
 	comparator(tdPre, tdPost)
-}
-
-func printChain(bc *LightChain) {
-	for i := bc.CurrentHeader().Number.Uint64(); i > 0; i-- {
-		b := bc.GetHeaderByNumber(uint64(i))
-		fmt.Printf("\t%x %v\n", b.Hash(), b.Difficulty)
-	}
 }
 
 // testHeaderChainImport tries to process a chain of header, writing them into

--- a/light/txpool.go
+++ b/light/txpool.go
@@ -124,12 +124,6 @@ func (pool *TxPool) GetNonce(ctx context.Context, addr common.Address) (uint64, 
 	return nonce, nil
 }
 
-type txBlockData struct {
-	BlockHash  common.Hash
-	BlockIndex uint64
-	Index      uint64
-}
-
 // txStateChanges stores the recent changes between pending/mined states of
 // transactions. True means mined, false means rolled back, no entry means no change
 type txStateChanges map[common.Hash]bool


### PR DESCRIPTION
warnings left:

```
light\lightchain.go:50:16: event.TypeMux is deprecated: use Feed  (SA1019)
light\lightchain.go:72:94: event.TypeMux is deprecated: use Feed  (SA1019)
light\lightchain_test.go:58:89: event.TypeMux is deprecated: use Feed  (SA1019)
light\lightchain_test.go:78:87: event.TypeMux is deprecated: use Feed  (SA1019)
light\lightchain_test.go:342:102: event.TypeMux is deprecated: use Feed  (SA1019)
light\odr_test.go:236:17: event.TypeMux is deprecated: use Feed  (SA1019)
light\trie_test.go:44:97: event.TypeMux is deprecated: use Feed  (SA1019)
light\txpool.go:49:12: event.TypeMux is deprecated: use Feed  (SA1019)
light\txpool.go:81:54: event.TypeMux is deprecated: use Feed  (SA1019)
light\txpool_test.go:85:17: event.TypeMux is deprecated: use Feed  (SA1019)
```