### PR TITLE
miner: fix megacheck warnings

### DIFF
--- a/miner/remote_agent.go
+++ b/miner/remote_agent.go
@@ -169,7 +169,8 @@ func (a *RemoteAgent) SubmitWork(nonce types.BlockNonce, mixDigest, hash common.
 // RemoteAgent.Start() constantly recreates these channels, so the loop code cannot
 // assume data stability in these member fields.
 func (a *RemoteAgent) loop(workCh chan *Work, quitCh chan struct{}) {
-	ticker := time.Tick(5 * time.Second)
+	ticker := time.NewTicker(5 * time.Second)
+	defer ticker.Stop()
 
 	for {
 		select {
@@ -179,7 +180,7 @@ func (a *RemoteAgent) loop(workCh chan *Work, quitCh chan struct{}) {
 			a.mu.Lock()
 			a.currentWork = work
 			a.mu.Unlock()
-		case <-ticker:
+		case <-ticker.C:
 			// cleanup
 			a.mu.Lock()
 			for hash, work := range a.work {


### PR DESCRIPTION
warnings left:

```
miner\miner.go:47:7: event.TypeMux is deprecated: use Feed  (SA1019)
miner\miner.go:60:56: event.TypeMux is deprecated: use Feed  (SA1019)
miner\worker.go:90:10: event.TypeMux is deprecated: use Feed  (SA1019)
miner\worker.go:120:112: event.TypeMux is deprecated: use Feed  (SA1019)
miner\worker.go:490:42: event.TypeMux is deprecated: use Feed  (SA1019)
```