### PR TITLE
node: fix megacheck warnings

### DIFF
--- a/node/config.go
+++ b/node/config.go
@@ -35,7 +35,7 @@ import (
 	"github.com/ethereum/go-ethereum/p2p/discover"
 )
 
-var (
+const (
 	datadirPrivateKey      = "nodekey"            // Path within the datadir to the node's private key
 	datadirDefaultKeyStore = "keystore"           // Path within the datadir to the keystore
 	datadirStaticNodes     = "static-nodes.json"  // Path within the datadir to the static node list
@@ -160,7 +160,7 @@ func (c *Config) NodeDB() string {
 	if c.DataDir == "" {
 		return "" // ephemeral
 	}
-	return c.resolvePath("nodes")
+	return c.resolvePath(datadirNodeDatabase)
 }
 
 // DefaultIPCEndpoint returns the IPC path used by default.

--- a/node/utils_test.go
+++ b/node/utils_test.go
@@ -41,12 +41,10 @@ func NewNoopService(*ServiceContext) (Service, error) { return new(NoopService),
 type NoopServiceA struct{ NoopService }
 type NoopServiceB struct{ NoopService }
 type NoopServiceC struct{ NoopService }
-type NoopServiceD struct{ NoopService }
 
 func NewNoopServiceA(*ServiceContext) (Service, error) { return new(NoopServiceA), nil }
 func NewNoopServiceB(*ServiceContext) (Service, error) { return new(NoopServiceB), nil }
 func NewNoopServiceC(*ServiceContext) (Service, error) { return new(NoopServiceC), nil }
-func NewNoopServiceD(*ServiceContext) (Service, error) { return new(NoopServiceD), nil }
 
 // InstrumentedService is an implementation of Service for which all interface
 // methods can be instrumented both return value as well as event hook wise.


### PR DESCRIPTION
warnings left:

```
node\node.go:51:12: event.TypeMux is deprecated: use Feed  (SA1019)
node\node.go:124:26: event.TypeMux is deprecated: use Feed  (SA1019)
node\node.go:403:5: rpc.NewHTTPServer is deprecated: Server implements http.Handler  (SA1019)
node\node.go:457:5: rpc.NewWSServer is deprecated: use Server.WebsocketHandler  (SA1019)
node\node.go:632:28: event.TypeMux is deprecated: use Feed  (SA1019)
node\service.go:35:18: event.TypeMux is deprecated: use Feed  (SA1019)
```