### PR TITLE
rpc: fix megacheck warnings

### DIFF
--- a/rpc/ipc_windows.go
+++ b/rpc/ipc_windows.go
@@ -39,7 +39,7 @@ func ipcListen(endpoint string) (net.Listener, error) {
 func newIPCConnection(ctx context.Context, endpoint string) (net.Conn, error) {
 	timeout := defaultPipeDialTimeout
 	if deadline, ok := ctx.Deadline(); ok {
-		timeout = time.Until(deadline)
+		timeout = deadline.Sub(time.Now())
 		if timeout < 0 {
 			timeout = 0
 		}

--- a/rpc/ipc_windows.go
+++ b/rpc/ipc_windows.go
@@ -39,7 +39,7 @@ func ipcListen(endpoint string) (net.Listener, error) {
 func newIPCConnection(ctx context.Context, endpoint string) (net.Conn, error) {
 	timeout := defaultPipeDialTimeout
 	if deadline, ok := ctx.Deadline(); ok {
-		timeout = deadline.Sub(time.Now())
+		timeout = time.Until(deadline)
 		if timeout < 0 {
 			timeout = 0
 		}

--- a/rpc/subscription.go
+++ b/rpc/subscription.go
@@ -53,7 +53,6 @@ type notifierKey struct{}
 type Notifier struct {
 	codec    ServerCodec
 	subMu    sync.RWMutex // guards active and inactive maps
-	stopped  bool
 	active   map[ID]*Subscription
 	inactive map[ID]*Subscription
 }

--- a/rpc/types.go
+++ b/rpc/types.go
@@ -48,7 +48,6 @@ type callback struct {
 // service represents a registered object
 type service struct {
 	name          string        // name for service
-	rcvr          reflect.Value // receiver of methods for the service
 	typ           reflect.Type  // receiver type
 	callbacks     callbacks     // registered handlers
 	subscriptions subscriptions // available subscriptions/notifications
@@ -58,23 +57,19 @@ type service struct {
 type serverRequest struct {
 	id            interface{}
 	svcname       string
-	rcvr          reflect.Value
 	callb         *callback
 	args          []reflect.Value
 	isUnsubscribe bool
 	err           Error
 }
 
-type serviceRegistry map[string]*service       // collection of services
-type callbacks map[string]*callback            // collection of RPC callbacks
-type subscriptions map[string]*callback        // collection of subscription callbacks
-type subscriptionRegistry map[string]*callback // collection of subscription callbacks
+type serviceRegistry map[string]*service // collection of services
+type callbacks map[string]*callback      // collection of RPC callbacks
+type subscriptions map[string]*callback  // collection of subscription callbacks
 
 // Server represents a RPC server
 type Server struct {
-	services       serviceRegistry
-	muSubcriptions sync.Mutex // protects subscriptions
-	subscriptions  subscriptionRegistry
+	services serviceRegistry
 
 	run      int32
 	codecsMu sync.Mutex

--- a/rpc/utils.go
+++ b/rpc/utils.go
@@ -119,21 +119,6 @@ func isHexNum(t reflect.Type) bool {
 	return t == bigIntType
 }
 
-var blockNumberType = reflect.TypeOf((*BlockNumber)(nil)).Elem()
-
-// Indication if the given block is a BlockNumber
-func isBlockNumber(t reflect.Type) bool {
-	if t == nil {
-		return false
-	}
-
-	for t.Kind() == reflect.Ptr {
-		t = t.Elem()
-	}
-
-	return t == blockNumberType
-}
-
 // suitableCallbacks iterates over the methods of the given type. It will determine if a method satisfies the criteria
 // for a RPC callback or a subscription callback and adds it to the collection of callbacks or subscriptions. See server
 // documentation for a summary of these criteria.

--- a/rpc/utils.go
+++ b/rpc/utils.go
@@ -195,18 +195,12 @@ METHODS:
 		}
 
 		switch mtype.NumOut() {
-		case 0, 1:
-			break
-		case 2:
-			if h.errPos == -1 { // method must one return value and 1 error
+		case 0, 1, 2:
+			if mtype.NumOut() == 2 && h.errPos == -1 { // method must one return value and 1 error
 				continue METHODS
 			}
-			break
-		default:
-			continue METHODS
+			callbacks[mname] = &h
 		}
-
-		callbacks[mname] = &h
 	}
 
 	return callbacks, subscriptions


### PR DESCRIPTION
warnings left:

```
rpc\utils.go:199:4: ineffective break statement. Did you mean to break out of the outer loop? (SA4011)
rpc\utils.go:204:4: ineffective break statement. Did you mean to break out of the outer loop? (SA4011)
rpc\utils.go:204:4: redundant break statement (S1023)
```

I'm unsure what to do about the break statements.