### PR TITLE
whisper: fix megacheck warnings

### DIFF
--- a/whisper/mailserver/mailserver.go
+++ b/whisper/mailserver/mailserver.go
@@ -104,7 +104,7 @@ func (s *WMailServer) Archive(env *whisper.Envelope) {
 
 func (s *WMailServer) DeliverMail(peer *whisper.Peer, request *whisper.Envelope) {
 	if peer == nil {
-		log.Error(fmt.Sprint("Whisper peer is nil"))
+		log.Error("Whisper peer is nil")
 		return
 	}
 

--- a/whisper/mailserver/server_test.go
+++ b/whisper/mailserver/server_test.go
@@ -168,7 +168,7 @@ func singleRequest(t *testing.T, server *WMailServer, env *whisper.Envelope, p *
 	src[0]++
 	ok, lower, upper, topic = server.validateRequest(src, request)
 	if ok {
-		t.Fatalf("request validation false positive, seed: %d.", seed)
+		t.Fatalf("request validation false positive, seed: %d (lower: %d, upper: %d).", seed, lower, upper)
 	}
 }
 

--- a/whisper/whisperv2/api.go
+++ b/whisper/whisperv2/api.go
@@ -377,15 +377,6 @@ func (w *whisperFilter) retrieve() (messages []WhisperMessage) {
 	return
 }
 
-// activity returns the last time instance when client requests were executed on
-// the filter.
-func (w *whisperFilter) activity() time.Time {
-	w.lock.RLock()
-	defer w.lock.RUnlock()
-
-	return w.update
-}
-
 // newWhisperFilter creates a new serialized, poll based whisper topic filter.
 func newWhisperFilter(id hexutil.Uint, ref *Whisper) *whisperFilter {
 	return &whisperFilter{

--- a/whisper/whisperv2/whisper.go
+++ b/whisper/whisperv2/whisper.go
@@ -173,7 +173,7 @@ func (self *Whisper) Send(envelope *Envelope) error {
 // Start implements node.Service, starting the background data propagation thread
 // of the Whisper protocol.
 func (self *Whisper) Start(*p2p.Server) error {
-	log.Info(fmt.Sprint("Whisper started"))
+	log.Info("Whisper started")
 	go self.update()
 	return nil
 }
@@ -182,7 +182,7 @@ func (self *Whisper) Start(*p2p.Server) error {
 // of the Whisper protocol.
 func (self *Whisper) Stop() error {
 	close(self.quit)
-	log.Info(fmt.Sprint("Whisper stopped"))
+	log.Info("Whisper stopped")
 	return nil
 }
 

--- a/whisper/whisperv5/gen_criteria_json.go
+++ b/whisper/whisperv5/gen_criteria_json.go
@@ -8,6 +8,8 @@ import (
 	"github.com/ethereum/go-ethereum/common/hexutil"
 )
 
+var _ = (*criteriaOverride)(nil)
+
 func (c Criteria) MarshalJSON() ([]byte, error) {
 	type Criteria struct {
 		SymKeyID     string        `json:"symKeyID"`

--- a/whisper/whisperv5/gen_message_json.go
+++ b/whisper/whisperv5/gen_message_json.go
@@ -8,6 +8,8 @@ import (
 	"github.com/ethereum/go-ethereum/common/hexutil"
 )
 
+var _ = (*messageOverride)(nil)
+
 func (m Message) MarshalJSON() ([]byte, error) {
 	type Message struct {
 		Sig       hexutil.Bytes `json:"sig,omitempty"`

--- a/whisper/whisperv5/gen_newmessage_json.go
+++ b/whisper/whisperv5/gen_newmessage_json.go
@@ -8,6 +8,8 @@ import (
 	"github.com/ethereum/go-ethereum/common/hexutil"
 )
 
+var _ = (*newMessageOverride)(nil)
+
 func (n NewMessage) MarshalJSON() ([]byte, error) {
 	type NewMessage struct {
 		SymKeyID   string        `json:"symKeyID"`

--- a/whisper/whisperv5/message_test.go
+++ b/whisper/whisperv5/message_test.go
@@ -25,11 +25,6 @@ import (
 	"github.com/ethereum/go-ethereum/rlp"
 )
 
-func copyFromBuf(dst []byte, src []byte, beg int) int {
-	copy(dst, src[beg:])
-	return beg + len(dst)
-}
-
 func generateMessageParams() (*MessageParams, error) {
 	// set all the parameters except p.Dst and p.Padding
 
@@ -158,7 +153,7 @@ func TestMessageWrap(t *testing.T) {
 	params.TTL = 1000000
 	params.WorkTime = 1
 	params.PoW = 10000000.0
-	env, err = msg2.Wrap(params)
+	_, err = msg2.Wrap(params)
 	if err == nil {
 		t.Fatalf("unexpectedly reached the PoW target with seed %d.", seed)
 	}

--- a/whisper/whisperv5/whisper_test.go
+++ b/whisper/whisperv5/whisper_test.go
@@ -424,7 +424,7 @@ func TestWhisperSymKeyManagement(t *testing.T) {
 
 	randomKey = make([]byte, aesKeyLength+1)
 	mrand.Read(randomKey)
-	id1, err = w.AddSymKeyDirect(randomKey)
+	_, err = w.AddSymKeyDirect(randomKey)
 	if err == nil {
 		t.Fatalf("added the key with wrong size, seed %d.", seed)
 	}
@@ -541,6 +541,9 @@ func TestCustomization(t *testing.T) {
 	const smallPoW = 0.00001
 
 	f, err := generateFilter(t, true)
+	if err != nil {
+		t.Fatalf("failed generateMessageParams with seed %d: %s.", seed, err)
+	}
 	params, err := generateMessageParams()
 	if err != nil {
 		t.Fatalf("failed generateMessageParams with seed %d: %s.", seed, err)
@@ -607,6 +610,9 @@ func TestCustomization(t *testing.T) {
 
 	// check w.messages()
 	id, err := w.Subscribe(f)
+	if err != nil {
+		t.Fatalf("failed subscribe with seed %d: %s.", seed, err)
+	}
 	time.Sleep(5 * time.Millisecond)
 	mail := f.Retrieve()
 	if len(mail) > 0 {


### PR DESCRIPTION
warnings left:

```
whisper\whisperv5\api.go:232:6: type newMessageOverride is unused (U1000)
whisper\whisperv5\api.go:328:6: type criteriaOverride is unused (U1000)
whisper\whisperv5\api.go:446:6: type messageOverride is unused (U1000)
whisper\whisperv5\filter_test.go:39:6: func InitDebugTest is unused (U1000)
```

The `api` things seem to because of code-generation.

The `InitDebugTest` could be made useful via a flag, so you can run `go test -debug ./whisper/...` or `go test -v ./whisper/...` and it would automatically use the correct `Init` func. Thoughts?