### PR TITLE
eth: fix megacheck warnings

### DIFF
--- a/eth/api.go
+++ b/eth/api.go
@@ -465,26 +465,6 @@ func (api *PrivateDebugAPI) traceBlock(block *types.Block, logConfig *vm.LogConf
 	return true, structLogger.StructLogs(), nil
 }
 
-// callmsg is the message type used for call transitions.
-type callmsg struct {
-	addr          common.Address
-	to            *common.Address
-	gas, gasPrice *big.Int
-	value         *big.Int
-	data          []byte
-}
-
-// accessor boilerplate to implement core.Message
-func (m callmsg) From() (common.Address, error)         { return m.addr, nil }
-func (m callmsg) FromFrontier() (common.Address, error) { return m.addr, nil }
-func (m callmsg) Nonce() uint64                         { return 0 }
-func (m callmsg) CheckNonce() bool                      { return false }
-func (m callmsg) To() *common.Address                   { return m.to }
-func (m callmsg) GasPrice() *big.Int                    { return m.gasPrice }
-func (m callmsg) Gas() *big.Int                         { return m.gas }
-func (m callmsg) Value() *big.Int                       { return m.value }
-func (m callmsg) Data() []byte                          { return m.data }
-
 // formatError formats a Go error into either an empty string or the data content
 // of the error itself.
 func formatError(err error) string {

--- a/eth/downloader/downloader_test.go
+++ b/eth/downloader/downloader_test.go
@@ -403,8 +403,7 @@ func (dl *downloadTester) newSlowPeer(id string, version int, hashes []common.Ha
 	dl.lock.Lock()
 	defer dl.lock.Unlock()
 
-	var err error
-	err = dl.downloader.RegisterPeer(id, version, &downloadTesterPeer{dl, id, delay})
+	var err = dl.downloader.RegisterPeer(id, version, &downloadTesterPeer{dl, id, delay})
 	if err == nil {
 		// Assign the owned hashes, headers and blocks to the peer (deep copy)
 		dl.peerHashes[id] = make([]common.Hash, len(hashes))
@@ -1381,7 +1380,7 @@ func testSyncProgress(t *testing.T, protocol int, mode SyncMode) {
 	go func() {
 		defer pending.Done()
 		if err := tester.sync("peer-half", nil, mode); err != nil {
-			t.Fatalf("failed to synchronise blocks: %v", err)
+			panic(fmt.Sprintf("failed to synchronise blocks: %v", err))
 		}
 	}()
 	<-starting
@@ -1398,7 +1397,7 @@ func testSyncProgress(t *testing.T, protocol int, mode SyncMode) {
 	go func() {
 		defer pending.Done()
 		if err := tester.sync("peer-full", nil, mode); err != nil {
-			t.Fatalf("failed to synchronise blocks: %v", err)
+			panic(fmt.Sprintf("failed to synchronise blocks: %v", err))
 		}
 	}()
 	<-starting
@@ -1454,7 +1453,7 @@ func testForkedSyncProgress(t *testing.T, protocol int, mode SyncMode) {
 	go func() {
 		defer pending.Done()
 		if err := tester.sync("fork A", nil, mode); err != nil {
-			t.Fatalf("failed to synchronise blocks: %v", err)
+			panic(fmt.Sprintf("failed to synchronise blocks: %v", err))
 		}
 	}()
 	<-starting
@@ -1474,7 +1473,7 @@ func testForkedSyncProgress(t *testing.T, protocol int, mode SyncMode) {
 	go func() {
 		defer pending.Done()
 		if err := tester.sync("fork B", nil, mode); err != nil {
-			t.Fatalf("failed to synchronise blocks: %v", err)
+			panic(fmt.Sprintf("failed to synchronise blocks: %v", err))
 		}
 	}()
 	<-starting
@@ -1535,7 +1534,7 @@ func testFailedSyncProgress(t *testing.T, protocol int, mode SyncMode) {
 	go func() {
 		defer pending.Done()
 		if err := tester.sync("faulty", nil, mode); err == nil {
-			t.Fatalf("succeeded faulty synchronisation")
+			panic("succeeded faulty synchronisation")
 		}
 	}()
 	<-starting
@@ -1552,7 +1551,7 @@ func testFailedSyncProgress(t *testing.T, protocol int, mode SyncMode) {
 	go func() {
 		defer pending.Done()
 		if err := tester.sync("valid", nil, mode); err != nil {
-			t.Fatalf("failed to synchronise blocks: %v", err)
+			panic(fmt.Sprintf("failed to synchronise blocks: %v", err))
 		}
 	}()
 	<-starting
@@ -1613,7 +1612,7 @@ func testFakedSyncProgress(t *testing.T, protocol int, mode SyncMode) {
 	go func() {
 		defer pending.Done()
 		if err := tester.sync("attack", nil, mode); err == nil {
-			t.Fatalf("succeeded attacker synchronisation")
+			panic("succeeded attacker synchronisation")
 		}
 	}()
 	<-starting
@@ -1630,7 +1629,7 @@ func testFakedSyncProgress(t *testing.T, protocol int, mode SyncMode) {
 	go func() {
 		defer pending.Done()
 		if err := tester.sync("valid", nil, mode); err != nil {
-			t.Fatalf("failed to synchronise blocks: %v", err)
+			panic(fmt.Sprintf("failed to synchronise blocks: %v", err))
 		}
 	}()
 	<-starting

--- a/eth/filters/api.go
+++ b/eth/filters/api.go
@@ -54,7 +54,6 @@ type PublicFilterAPI struct {
 	backend   Backend
 	useMipMap bool
 	mux       *event.TypeMux
-	quit      chan struct{}
 	chainDb   ethdb.Database
 	events    *EventSystem
 	filtersMu sync.Mutex

--- a/eth/filters/filter.go
+++ b/eth/filters/filter.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"math"
 	"math/big"
-	"time"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core"
@@ -41,8 +40,6 @@ type Backend interface {
 type Filter struct {
 	backend   Backend
 	useMipMap bool
-
-	created time.Time
 
 	db         ethdb.Database
 	begin, end int64

--- a/eth/filters/filter_system.go
+++ b/eth/filters/filter_system.go
@@ -74,7 +74,6 @@ type subscription struct {
 // subscription which match the subscription criteria.
 type EventSystem struct {
 	mux       *event.TypeMux
-	sub       *event.TypeMuxSubscription
 	backend   Backend
 	lightMode bool
 	lastHead  *types.Header

--- a/eth/filters/filter_system_test.go
+++ b/eth/filters/filter_system_test.go
@@ -18,6 +18,7 @@ package filters
 
 import (
 	"context"
+	"fmt"
 	"math/big"
 	"reflect"
 	"testing"
@@ -439,15 +440,15 @@ func TestPendingLogsSubscription(t *testing.T) {
 			}
 
 			if len(fetched) != len(tt.expected) {
-				t.Fatalf("invalid number of logs for case %d, want %d log(s), got %d", i, len(tt.expected), len(fetched))
+				panic(fmt.Sprintf("invalid number of logs for case %d, want %d log(s), got %d", i, len(tt.expected), len(fetched)))
 			}
 
 			for l := range fetched {
 				if fetched[l].Removed {
-					t.Errorf("expected log not to be removed for log %d in case %d", l, i)
+					panic(fmt.Sprintf("expected log not to be removed for log %d in case %d", l, i))
 				}
 				if !reflect.DeepEqual(fetched[l], tt.expected[l]) {
-					t.Errorf("invalid log on index %d for case %d", l, i)
+					panic(fmt.Sprintf("invalid log on index %d for case %d", l, i))
 				}
 			}
 		}()

--- a/eth/sync.go
+++ b/eth/sync.go
@@ -138,7 +138,9 @@ func (pm *ProtocolManager) syncer() {
 	defer pm.downloader.Terminate()
 
 	// Wait for different events to fire synchronisation operations
-	forceSync := time.Tick(forceSyncCycle)
+	forceSync := time.NewTicker(forceSyncCycle)
+	defer forceSync.Stop()
+
 	for {
 		select {
 		case <-pm.newPeerCh:
@@ -148,7 +150,7 @@ func (pm *ProtocolManager) syncer() {
 			}
 			go pm.synchronise(pm.peers.BestPeer())
 
-		case <-forceSync:
+		case <-forceSync.C:
 			// Force a sync even if not enough peers are present
 			go pm.synchronise(pm.peers.BestPeer())
 


### PR DESCRIPTION
warnings left:

```
eth\api_backend.go:170:37: event.TypeMux is deprecated: use Feed  (SA1019)
eth\backend.go:72:18: event.TypeMux is deprecated: use Feed  (SA1019)
eth\backend.go:356:32: event.TypeMux is deprecated: use Feed  (SA1019)
eth\config.go:119:6: type configMarshaling is unused (U1000)
eth\downloader\api.go:32:29: event.TypeMux is deprecated: use Feed  (SA1019)
eth\downloader\api.go:41:47: event.TypeMux is deprecated: use Feed  (SA1019)
eth\downloader\downloader.go:99:8: event.TypeMux is deprecated: use Feed  (SA1019)
eth\downloader\downloader.go:204:54: event.TypeMux is deprecated: use Feed  (SA1019)
eth\downloader\downloader_test.go:99:56: event.TypeMux is deprecated: use Feed  (SA1019)
eth\filters\api.go:56:13: event.TypeMux is deprecated: use Feed  (SA1019)
eth\filters\filter.go:34:14: event.TypeMux is deprecated: use Feed  (SA1019)
eth\filters\filter_system.go:76:13: event.TypeMux is deprecated: use Feed  (SA1019)
eth\filters\filter_system.go:90:26: event.TypeMux is deprecated: use Feed  (SA1019)
eth\filters\filter_system_test.go:37:7: event.TypeMux is deprecated: use Feed  (SA1019)
eth\filters\filter_system_test.go:45:35: event.TypeMux is deprecated: use Feed  (SA1019)
eth\filters\filter_system_test.go:76:21: event.TypeMux is deprecated: use Feed  (SA1019)
eth\filters\filter_system_test.go:129:17: event.TypeMux is deprecated: use Feed  (SA1019)
eth\filters\filter_system_test.go:179:17: event.TypeMux is deprecated: use Feed  (SA1019)
eth\filters\filter_system_test.go:224:17: event.TypeMux is deprecated: use Feed  (SA1019)
eth\filters\filter_system_test.go:250:17: event.TypeMux is deprecated: use Feed  (SA1019)
eth\filters\filter_system_test.go:358:17: event.TypeMux is deprecated: use Feed  (SA1019)
eth\filters\filter_test.go:53:17: event.TypeMux is deprecated: use Feed  (SA1019)
eth\filters\filter_test.go:123:17: event.TypeMux is deprecated: use Feed  (SA1019)
eth\handler.go:80:17: event.TypeMux is deprecated: use Feed  (SA1019)
eth\handler.go:97:116: event.TypeMux is deprecated: use Feed  (SA1019)
eth\handler_test.go:471:23: event.TypeMux is deprecated: use Feed  (SA1019)
eth\helper_test.go:54:16: event.TypeMux is deprecated: use Feed  (SA1019)
```

`configMarshaling` seems to be unused due to code-generation.

Initially tried an approach that didn't involve using panic -- it introduced a lot of code, that probably is not that useful.