### PR TITLE
eth/fetcher: ignore block notification if already under fetching process

### DIFF
--- a/eth/fetcher/fetcher.go
+++ b/eth/fetcher/fetcher.go
@@ -338,7 +338,13 @@ func (f *Fetcher) loop() {
 			if _, ok := f.fetching[notification.hash]; ok {
 				break
 			}
+			if _, ok := f.fetched[notification.hash]; ok {
+				break
+			}
 			if _, ok := f.completing[notification.hash]; ok {
+				break
+			}
+			if _, ok := f.queued[notification.hash]; ok {
 				break
 			}
 			f.announces[notification.origin] = count


### PR DESCRIPTION
This PR is to avoid to handle duplicate block hash notification.