### PR TITLE
ethdb: return copied value when invoke Get for mdb

### DIFF
--- a/ethdb/database_test.go
+++ b/ethdb/database_test.go
@@ -95,6 +95,21 @@ func testPutGet(db ethdb.Database, t *testing.T) {
 	}
 
 	for _, v := range test_values {
+		orig, err := db.Get([]byte(v))
+		if err != nil {
+			t.Fatalf("get failed: %v", err)
+		}
+		orig[0] = byte(0xff)
+		data, err := db.Get([]byte(v))
+		if err != nil {
+			t.Fatalf("get failed: %v", err)
+		}
+		if !bytes.Equal(data, []byte("?")) {
+			t.Fatalf("get returned wrong result, got %q expected ?", string(data))
+		}
+	}
+
+	for _, v := range test_values {
 		err := db.Delete([]byte(v))
 		if err != nil {
 			t.Fatalf("delete %q failed: %v", v, err)

--- a/ethdb/memory_database.go
+++ b/ethdb/memory_database.go
@@ -50,7 +50,7 @@ func (db *MemDatabase) Get(key []byte) ([]byte, error) {
 	defer db.lock.RUnlock()
 
 	if entry, ok := db.db[string(key)]; ok {
-		return entry, nil
+		return common.CopyBytes(entry), nil
 	}
 	return nil, errors.New("not found")
 }


### PR DESCRIPTION
In this PR:

A value copy is returned when invoke Get function. Because if only a reference value is returned, the content of the value changes, will affect the corresponding content in the database