### PR TITLE
cmd/evm, core/vm, internal/ethapi: Show error when exiting

### DIFF
--- a/cmd/evm/json_logger.go
+++ b/cmd/evm/json_logger.go
@@ -57,11 +57,12 @@ func (l *JSONLogger) CaptureState(env *vm.EVM, pc uint64, op vm.OpCode, gas, cos
 }
 
 // CaptureEnd is triggered at end of execution.
-func (l *JSONLogger) CaptureEnd(output []byte, gasUsed uint64, t time.Duration) error {
+func (l *JSONLogger) CaptureEnd(output []byte, gasUsed uint64, t time.Duration, err error) error {
 	type endLog struct {
 		Output  string              `json:"output"`
 		GasUsed math.HexOrDecimal64 `json:"gasUsed"`
 		Time    time.Duration       `json:"time"`
+		Err     string              `json:"error"`
 	}
-	return l.encoder.Encode(endLog{common.Bytes2Hex(output), math.HexOrDecimal64(gasUsed), t})
+	return l.encoder.Encode(endLog{common.Bytes2Hex(output), math.HexOrDecimal64(gasUsed), t, err.Error()})
 }

--- a/cmd/evm/json_logger.go
+++ b/cmd/evm/json_logger.go
@@ -62,7 +62,10 @@ func (l *JSONLogger) CaptureEnd(output []byte, gasUsed uint64, t time.Duration, 
 		Output  string              `json:"output"`
 		GasUsed math.HexOrDecimal64 `json:"gasUsed"`
 		Time    time.Duration       `json:"time"`
-		Err     string              `json:"error"`
+		Err     string              `json:"error,omitempty"`
 	}
-	return l.encoder.Encode(endLog{common.Bytes2Hex(output), math.HexOrDecimal64(gasUsed), t, err.Error()})
+	if err != nil {
+		return l.encoder.Encode(endLog{common.Bytes2Hex(output), math.HexOrDecimal64(gasUsed), t, err.Error()})
+	}
+	return l.encoder.Encode(endLog{common.Bytes2Hex(output), math.HexOrDecimal64(gasUsed), t, ""})
 }

--- a/cmd/evm/runner.go
+++ b/cmd/evm/runner.go
@@ -234,13 +234,13 @@ Gas used:           %d
 `, execTime, mem.HeapObjects, mem.Alloc, mem.TotalAlloc, mem.NumGC, initialGas-leftOverGas)
 	}
 	if tracer != nil {
-		tracer.CaptureEnd(ret, initialGas-leftOverGas, execTime)
+		tracer.CaptureEnd(ret, initialGas-leftOverGas, execTime, err)
 	} else {
 		fmt.Printf("0x%x\n", ret)
+		if err != nil {
+			fmt.Printf(" error: %v\n", err)
+		}
 	}
 
-	if err != nil {
-		fmt.Printf(" error: %v\n", err)
-	}
 	return nil
 }

--- a/core/vm/logger.go
+++ b/core/vm/logger.go
@@ -86,7 +86,7 @@ func (s *StructLog) OpName() string {
 // if you need to retain them beyond the current call.
 type Tracer interface {
 	CaptureState(env *EVM, pc uint64, op OpCode, gas, cost uint64, memory *Memory, stack *Stack, contract *Contract, depth int, err error) error
-	CaptureEnd(output []byte, gasUsed uint64, t time.Duration) error
+	CaptureEnd(output []byte, gasUsed uint64, t time.Duration, err error) error
 }
 
 // StructLogger is an EVM state logger and implements Tracer.
@@ -183,8 +183,11 @@ func (l *StructLogger) CaptureState(env *EVM, pc uint64, op OpCode, gas, cost ui
 	return nil
 }
 
-func (l *StructLogger) CaptureEnd(output []byte, gasUsed uint64, t time.Duration) error {
+func (l *StructLogger) CaptureEnd(output []byte, gasUsed uint64, t time.Duration, err error) error {
 	fmt.Printf("0x%x", output)
+	if err != nil {
+		fmt.Printf(" error: %v\n", err)
+	}
 	return nil
 }
 

--- a/internal/ethapi/tracer.go
+++ b/internal/ethapi/tracer.go
@@ -346,7 +346,7 @@ func (jst *JavascriptTracer) CaptureState(env *vm.EVM, pc uint64, op vm.OpCode, 
 }
 
 // CaptureEnd is called after the call finishes
-func (jst *JavascriptTracer) CaptureEnd(output []byte, gasUsed uint64, t time.Duration) error {
+func (jst *JavascriptTracer) CaptureEnd(output []byte, gasUsed uint64, t time.Duration, err error) error {
 	//TODO! @Arachnid please figure out of there's anything we can use this method for
 	return nil
 }


### PR DESCRIPTION
The `evm` can be configured to capture internal state as json output, by implementing the `tracer` interface. The tracer interface was called upon execution end, but any error which caused the execution to end was not provided. 

This PR adds the `error` to the interface, and adds it to the json output for the `evm`. 

Before fix (shown in non-json output): 

```json
...
{"pc":175,"op":244,"gas":"0x5cf94ee8","gasCost":"0x5bf94f10","memory":"0x","memSize":0,"stack":["0x34b58fe4b8140fac218b4a113b14ae3a64","0xa42fd9979a285bfbd6df9dd70d656097f0ac","0x30a3fa37ed70cd8d2e997844f260","0x948b055b3481fce44a4f2a8418787649af282a45b1363ccf","0xfa980b9a0fb4847a111d9b010c16212ed4e17c8506a6800e231ffb","0x2f3ac96c308e2872d95bf3b4053135ed71b62d91987cb7b41375","0x34b58fe4b8140fac218b4a113b14ae3a64","0x6d220c","0x8a72ea","0x99af83","0x455233","0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b","0x3df3fac5"],"depth":1,"error":{},"opName":"DELEGATECALL"}
{"output":"","gasUsed":"0xffffff","time":2813174}
 error: out of gas
```
After fix:

```json
...
{"pc":175,"op":244,"gas":"0x5cf94ee8","gasCost":"0x5bf94f10","memory":"0x","memSize":0,"stack":["0x34b58fe4b8140fac218b4a113b14ae3a64","0xa42fd9979a285bfbd6df9dd70d656097f0ac","0x30a3fa37ed70cd8d2e997844f260","0x948b055b3481fce44a4f2a8418787649af282a45b1363ccf","0xfa980b9a0fb4847a111d9b010c16212ed4e17c8506a6800e231ffb","0x2f3ac96c308e2872d95bf3b4053135ed71b62d91987cb7b41375","0x34b58fe4b8140fac218b4a113b14ae3a64","0x6d220c","0x8a72ea","0x99af83","0x455233","0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b","0x3df3fac5"],"depth":1,"error":{},"opName":"DELEGATECALL"}
{"output":"","gasUsed":"0xffffff","time":580475,"error":"out of gas"}
``` 