### PR TITLE
eth: send but not announce block to peers if propagate is true

### DIFF
--- a/eth/handler.go
+++ b/eth/handler.go
@@ -688,6 +688,7 @@ func (pm *ProtocolManager) BroadcastBlock(block *types.Block, propagate bool) {
 			peer.SendNewBlock(block, td)
 		}
 		log.Trace("Propagated block", "hash", hash, "recipients", len(transfer), "duration", common.PrettyDuration(time.Since(block.ReceivedAt)))
+		return
 	}
 	// Otherwise if the block is indeed in out own chain, announce it
 	if pm.blockchain.HasBlock(hash) {


### PR DESCRIPTION
According the function definition, BroadcastBlock() will either propagate or announce a block, so we should add `return`