### PR TITLE
cmd/evm: adds ability to run individual state test file

### DIFF
--- a/cmd/evm/main.go
+++ b/cmd/evm/main.go
@@ -143,6 +143,7 @@ func init() {
 		compileCommand,
 		disasmCommand,
 		runCommand,
+		stateTestCommand,
 	}
 }
 

--- a/cmd/evm/staterunner.go
+++ b/cmd/evm/staterunner.go
@@ -1,0 +1,109 @@
+// Copyright 2017 The go-ethereum Authors
+// This file is part of go-ethereum.
+//
+// go-ethereum is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// go-ethereum is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with go-ethereum. If not, see <http://www.gnu.org/licenses/>.
+
+package main
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"os"
+
+	"github.com/ethereum/go-ethereum/core/vm"
+	"github.com/ethereum/go-ethereum/log"
+	"github.com/ethereum/go-ethereum/tests"
+
+	cli "gopkg.in/urfave/cli.v1"
+)
+
+var stateTestCommand = cli.Command{
+	Action:    stateTestCmd,
+	Name:      "statetest",
+	Usage:     "executes the given state tests",
+	ArgsUsage: "<file>",
+}
+
+func stateTestCmd(ctx *cli.Context) error {
+	glogger := log.NewGlogHandler(log.StreamHandler(os.Stderr, log.TerminalFormat(false)))
+	glogger.Verbosity(log.Lvl(ctx.GlobalInt(VerbosityFlag.Name)))
+	log.Root().SetHandler(glogger)
+	logconfig := &vm.LogConfig{
+		DisableMemory: ctx.GlobalBool(DisableMemoryFlag.Name),
+		DisableStack:  ctx.GlobalBool(DisableStackFlag.Name),
+	}
+	var (
+		tracer      vm.Tracer
+		debugLogger *vm.StructLogger
+		//		statedb     *state.StateDB
+		//		chainConfig *params.ChainConfig
+	)
+	if ctx.GlobalBool(MachineFlag.Name) {
+		tracer = NewJSONLogger(logconfig, os.Stdout)
+	} else if ctx.GlobalBool(DebugFlag.Name) {
+		debugLogger = vm.NewStructLogger(logconfig)
+		tracer = debugLogger
+	} else {
+		debugLogger = vm.NewStructLogger(logconfig)
+	}
+
+	if len(ctx.Args().First()) == 0 {
+		return errors.New("filename required")
+	}
+
+	fn := ctx.Args().First()
+	src, err := ioutil.ReadFile(fn)
+	if err != nil {
+		return err
+	}
+
+	var tests map[string]tests.StateTest
+
+	if err = json.Unmarshal(src, &tests); err != nil {
+		return err
+	}
+	cfg := vm.Config{
+		Tracer: tracer,
+		Debug:  ctx.GlobalBool(DebugFlag.Name) || ctx.GlobalBool(MachineFlag.Name),
+	}
+
+	for _, test := range tests {
+		for _, st := range test.Subtests() {
+			fmt.Printf("Test %v\n", st)
+			fmt.Printf("====================\n")
+
+			if err = test.Run(st, cfg); err != nil {
+				fmt.Printf("FAIL : %v\n", err)
+			} else {
+				fmt.Printf("PASS\n")
+			}
+			if ctx.GlobalBool(DebugFlag.Name) {
+				if debugLogger != nil {
+					fmt.Fprintln(os.Stderr, "#### TRACE ####")
+					vm.WriteTrace(os.Stderr, debugLogger.StructLogs())
+				}
+			}
+
+			fmt.Printf("====================\n")
+		}
+
+	}
+
+	if err != nil {
+		return err
+	}
+	return nil
+}

--- a/cmd/evm/staterunner.go
+++ b/cmd/evm/staterunner.go
@@ -23,6 +23,7 @@ import (
 	"io/ioutil"
 	"os"
 
+	"github.com/ethereum/go-ethereum/core/state"
 	"github.com/ethereum/go-ethereum/core/vm"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/tests"
@@ -38,84 +39,81 @@ var stateTestCommand = cli.Command{
 }
 
 type StatetestResult struct {
-	Name  string `json:"name"`
-	Pass  bool   `json:"pass"`
-	Fork  string `json:"fork"`
-	Error string `json:"error,omitempty"`
+	Name  string      `json:"name"`
+	Pass  bool        `json:"pass"`
+	Fork  string      `json:"fork"`
+	Error string      `json:"error,omitempty"`
+	State *state.Dump `json:"state,omitempty"`
 }
 
 func stateTestCmd(ctx *cli.Context) error {
+	if len(ctx.Args().First()) == 0 {
+		return errors.New("path-to-test argument required")
+	}
+	// Configure the go-ethereum logger
 	glogger := log.NewGlogHandler(log.StreamHandler(os.Stderr, log.TerminalFormat(false)))
 	glogger.Verbosity(log.Lvl(ctx.GlobalInt(VerbosityFlag.Name)))
 	log.Root().SetHandler(glogger)
-	logconfig := &vm.LogConfig{
+
+	// Configure the EVM logger
+	config := &vm.LogConfig{
 		DisableMemory: ctx.GlobalBool(DisableMemoryFlag.Name),
 		DisableStack:  ctx.GlobalBool(DisableStackFlag.Name),
 	}
 	var (
-		tracer      vm.Tracer
-		debugLogger *vm.StructLogger
-		//		statedb     *state.StateDB
-		//		chainConfig *params.ChainConfig
+		tracer   vm.Tracer
+		debugger *vm.StructLogger
 	)
-	if ctx.GlobalBool(MachineFlag.Name) {
-		tracer = NewJSONLogger(logconfig, os.Stderr)
-	} else if ctx.GlobalBool(DebugFlag.Name) {
-		debugLogger = vm.NewStructLogger(logconfig)
-		tracer = debugLogger
-	} else {
-		debugLogger = vm.NewStructLogger(logconfig)
-	}
+	switch {
+	case ctx.GlobalBool(MachineFlag.Name):
+		tracer = NewJSONLogger(config, os.Stderr)
 
-	if len(ctx.Args().First()) == 0 {
-		return errors.New("filename required")
-	}
+	case ctx.GlobalBool(DebugFlag.Name):
+		debugger = vm.NewStructLogger(config)
+		tracer = debugger
 
-	fn := ctx.Args().First()
-	src, err := ioutil.ReadFile(fn)
+	default:
+		debugger = vm.NewStructLogger(config)
+	}
+	// Load the test content from the input file
+	src, err := ioutil.ReadFile(ctx.Args().First())
 	if err != nil {
 		return err
 	}
-
 	var tests map[string]tests.StateTest
-
 	if err = json.Unmarshal(src, &tests); err != nil {
 		return err
 	}
-
-	var results = make([]StatetestResult, 0, len(tests))
-
+	// Iterate over all the tests, run them and aggregate the results
 	cfg := vm.Config{
 		Tracer: tracer,
 		Debug:  ctx.GlobalBool(DebugFlag.Name) || ctx.GlobalBool(MachineFlag.Name),
 	}
-
+	results := make([]StatetestResult, 0, len(tests))
 	for key, test := range tests {
 		for _, st := range test.Subtests() {
-			result := &StatetestResult{
-				Name: key,
-				Fork: st.Fork,
-				Pass: true,
-			}
-
-			if err = test.Run(st, cfg); err != nil {
-				result.Error = err.Error()
-				result.Pass = false
+			// Run the test and aggregate the result
+			result := &StatetestResult{Name: key, Fork: st.Fork, Pass: true}
+			if state, err := test.Run(st, cfg); err != nil {
+				// Test failed, mark as so and dump any state to aid debugging
+				result.Pass, result.Error = false, err.Error()
+				if ctx.GlobalBool(DumpFlag.Name) && state != nil {
+					dump := state.RawDump()
+					result.State = &dump
+				}
 			}
 			results = append(results, *result)
 
+			// Print any structured logs collected
 			if ctx.GlobalBool(DebugFlag.Name) {
-				if debugLogger != nil {
+				if debugger != nil {
 					fmt.Fprintln(os.Stderr, "#### TRACE ####")
-					vm.WriteTrace(os.Stderr, debugLogger.StructLogs())
+					vm.WriteTrace(os.Stderr, debugger.StructLogs())
 				}
 			}
 		}
 	}
-	json.NewEncoder(os.Stdout).Encode(results)
-
-	if err != nil {
-		return err
-	}
+	out, _ := json.MarshalIndent(results, "", "  ")
+	fmt.Println(string(out))
 	return nil
 }

--- a/tests/state_test.go
+++ b/tests/state_test.go
@@ -50,7 +50,8 @@ func TestState(t *testing.T) {
 					t.Skip("constantinople not supported yet")
 				}
 				withTrace(t, test.gasLimit(subtest), func(vmconfig vm.Config) error {
-					return st.checkFailure(t, name, test.Run(subtest, vmconfig))
+					_, err := test.Run(subtest, vmconfig)
+					return st.checkFailure(t, name, err)
 				})
 			})
 		}


### PR DESCRIPTION
This PR adds ability to run a given general state test, as requested by @winsvega . 

~~Note This is WIP so far, I expect to have to modify it a bit to suit the needs by the test team.~~ 

Examples: 
```
#build/bin/evm  statetest  /home/martin/go/src/github.com/ethereum/go-ethereum/tests/testdata/GeneralStateTests/stCreateTest/CREATE_EmptyContract.json
Test {EIP158 0}
====================
PASS
====================
Test {Frontier 0}
====================
PASS
====================
Test {Homestead 0}
====================
PASS
====================
Test {Byzantium 0}
====================
PASS
====================
Test {Constantinople 0}
====================
FAIL : unsupported fork "Constantinople"
====================
Test {EIP150 0}
====================
PASS
====================
```
Most common flags can be used, e..g `--json` and `--debug`
```
#build/bin/evm  --json statetest  /home/martin/go/src/github.com/ethereum/go-ethereum/tests/testdata/GeneralStateTests/stCreateTest/CREATE_EmptyContract.json | head -n30
Test {Byzantium 0}
====================
{"pc":0,"op":90,"gas":"0x8d5b8","gasCost":"0x2","memory":"0x","memSize":0,"stack":[],"depth":1,"error":null,"opName":"GAS"}
{"pc":1,"op":96,"gas":"0x8d5b6","gasCost":"0x3","memory":"0x","memSize":0,"stack":["0x8d5b6"],"depth":1,"error":null,"opName":"PUSH1"}
{"pc":3,"op":85,"gas":"0x8d5b3","gasCost":"0x4e20","memory":"0x","memSize":0,"stack":["0x8d5b6","0x0"],"depth":1,"error":null,"opName":"SSTORE"}
{"pc":4,"op":96,"gas":"0x88793","gasCost":"0x3","memory":"0x","memSize":0,"stack":[],"depth":1,"error":null,"opName":"PUSH1"}
{"pc":6,"op":96,"gas":"0x88790","gasCost":"0x3","memory":"0x","memSize":0,"stack":["0x20"],"depth":1,"error":null,"opName":"PUSH1"}
{"pc":8,"op":96,"gas":"0x8878d","gasCost":"0x3","memory":"0x","memSize":0,"stack":["0x20","0x0"],"depth":1,"error":null,"opName":"PUSH1"}
{"pc":10,"op":240,"gas":"0x8878a","gasCost":"0x7d03","memory":"0x0000000000000000000000000000000000000000000000000000000000000000","memSize":32,"stack":["0x20","0x0","0x0"],"depth":1,"error":null,"opName":"CREATE"}
{"pc":0,"op":0,"gas":"0x7ea5d","gasCost":"0x0","memory":"0x","memSize":0,"stack":[],"depth":2,"error":null,"opName":"STOP"}
{"pc":11,"op":96,"gas":"0x80a87","gasCost":"0x3","memory":"0x0000000000000000000000000000000000000000000000000000000000000000","memSize":32,"stack":["0xf1ecf98489fa9ed60a664fc4998db699cfa39d40"],"depth":1,"error":null,"opName":"PUSH1"}
{"pc":13,"op":85,"gas":"0x80a84","gasCost":"0x4e20","memory":"0x0000000000000000000000000000000000000000000000000000000000000000","memSize":32,"stack":["0xf1ecf98489fa9ed60a664fc4998db699cfa39d40","0x1"],"depth":1,"error":null,"opName":"SSTORE"}
{"pc":14,"op":90,"gas":"0x7bc64","gasCost":"0x2","memory":"0x0000000000000000000000000000000000000000000000000000000000000000","memSize":32,"stack":[],"depth":1,"error":null,"opName":"GAS"}
{"pc":15,"op":96,"gas":"0x7bc62","gasCost":"0x3","memory":"0x0000000000000000000000000000000000000000000000000000000000000000","memSize":32,"stack":["0x7bc62"],"depth":1,"error":null,"opName":"PUSH1"}
{"pc":17,"op":85,"gas":"0x7bc5f","gasCost":"0x4e20","memory":"0x0000000000000000000000000000000000000000000000000000000000000000","memSize":32,"stack":["0x7bc62","0x64"],"depth":1,"error":null,"opName":"SSTORE"}
{"pc":18,"op":0,"gas":"0x76e3f","gasCost":"0x0","memory":"0x0000000000000000000000000000000000000000000000000000000000000000","memSize":32,"stack":[],"depth":1,"error":null,"opName":"STOP"}
PASS
====================
Test {Constantinople 0}
====================
FAIL : unsupported fork "Constantinople"
====================
Test {EIP150 0}

```

And without json, but with `--debug`:
```
#build/bin/evm  --debug statetest  /home/martin/go/src/github.com/ethereum/go-ethereum/tests/testdata/GeneralStateTests/stCreateTest/CREATE_EmptyContract.json
Test {Homestead 0}
====================
PASS
#### TRACE ####
GAS             pc=00000000 gas=578998 cost=2

PUSH1           pc=00000001 gas=578995 cost=3
Stack:
00000000  000000000000000000000000000000000000000000000000000000000008d5b6

SSTORE          pc=00000003 gas=558995 cost=20000
Stack:
00000000  0000000000000000000000000000000000000000000000000000000000000000
00000001  000000000000000000000000000000000000000000000000000000000008d5b6
Storage:
0000000000000000000000000000000000000000000000000000000000000000: 000000000000000000000000000000000000000000000000000000000008d5b6

PUSH1           pc=00000004 gas=558992 cost=3
Storage:
0000000000000000000000000000000000000000000000000000000000000000: 000000000000000000000000000000000000000000000000000000000008d5b6

PUSH1           pc=00000006 gas=558989 cost=3
Stack:
00000000  0000000000000000000000000000000000000000000000000000000000000020
Storage:
0000000000000000000000000000000000000000000000000000000000000000: 000000000000000000000000000000000000000000000000000000000008d5b6
```

