### PR TITLE
cmd/puppeth: support blacklisting malicious IPs on ethstats

### DIFF
--- a/cmd/puppeth/wizard.go
+++ b/cmd/puppeth/wizard.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"math/big"
+	"net"
 	"os"
 	"path/filepath"
 	"sort"
@@ -275,5 +276,28 @@ func (w *wizard) readJSON() string {
 			continue
 		}
 		return string(blob)
+	}
+}
+
+// readIPAddress reads a single line from stdin, trimming if from spaces and
+// converts it to a network IP address.
+func (w *wizard) readIPAddress() net.IP {
+	for {
+		// Read the IP address from the user
+		fmt.Printf("> ")
+		text, err := w.in.ReadString('\n')
+		if err != nil {
+			log.Crit("Failed to read user input", "err", err)
+		}
+		if text = strings.TrimSpace(text); text == "" {
+			return nil
+		}
+		// Make sure it looks ok and return it if so
+		ip := net.ParseIP(text)
+		if ip == nil {
+			log.Error("Invalid IP address, please retry")
+			continue
+		}
+		return ip
 	}
 }


### PR DESCRIPTION
Add support to `puppeth` for blacklisting malicious IP addresses from deployed ethstats servers.