### PR TITLE
eth,internal: add eth_chainId method to PublicEthereumApi JSONRPC

### DIFF
--- a/eth/api.go
+++ b/eth/api.go
@@ -71,6 +71,11 @@ func (api *PublicEthereumAPI) Hashrate() hexutil.Uint64 {
 	return hexutil.Uint64(api.e.Miner().HashRate())
 }
 
+// ChainId is the EIP-155 replay-protection chain id for the current ethereum chain config.
+func (api *PublicEthereumAPI) ChainId() *big.Int {
+	return api.e.chainConfig.ChainId
+}
+
 // PublicMinerAPI provides an API to control the miner.
 // It offers only methods that operate on data that pose no security risk when it is publicly accessible.
 type PublicMinerAPI struct {

--- a/eth/api.go
+++ b/eth/api.go
@@ -72,8 +72,12 @@ func (api *PublicEthereumAPI) Hashrate() hexutil.Uint64 {
 }
 
 // ChainId is the EIP-155 replay-protection chain id for the current ethereum chain config.
-func (api *PublicEthereumAPI) ChainId() *big.Int {
-	return api.e.chainConfig.ChainId
+func (api *PublicEthereumAPI) ChainId() hexutil.Uint {
+	chainID := new(big.Int)
+	if config := api.e.chainConfig; config.IsEIP155(api.e.blockchain.CurrentBlock().Number()) {
+		chainID = config.ChainId
+	}
+	return hexutil.Uint(chainID)
 }
 
 // PublicMinerAPI provides an API to control the miner.

--- a/internal/web3ext/web3ext.go
+++ b/internal/web3ext/web3ext.go
@@ -361,6 +361,11 @@ web3._extend({
 	methods:
 	[
 		new web3._extend.Method({
+			name: 'chainId',
+			call: 'eth_chainId',
+			params: 0
+		}),
+		new web3._extend.Method({
 			name: 'sign',
 			call: 'eth_sign',
 			params: 2,


### PR DESCRIPTION
I'm stealing @sorpaas words from [his congruent Parity client PR](https://github.com/paritytech/parity/pull/6329):
> Currently although we can use net_version RPC call to get the
current network ID, there's no RPC for querying the chain ID. This
makes it impossible to determine the current actual blockchain using
the RPC. An ETH/ETC client can accidentally connect to an ETC/ETH RPC
endpoint without knowing it unless it tries to sign a transaction or
it fetch a transaction that is known to have signed with a chain
ID. This has since caused trouble for application developers, such as
MetaMask, to add multi-chain support. 

Recently merged the same endpoint to ETC's go-ethereum: https://github.com/ethereumproject/go-ethereum/pull/336