### PR TITLE
docker: update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,13 @@
-FROM alpine:3.5
+FROM alpine:3.6
 
 ADD . /go-ethereum
 RUN \
-  apk add --update git go make gcc musl-dev linux-headers && \
-  (cd go-ethereum && make geth)                           && \
-  cp go-ethereum/build/bin/geth /usr/local/bin/           && \
-  apk del git go make gcc musl-dev linux-headers          && \
-  rm -rf /go-ethereum && rm -rf /var/cache/apk/*
+  apk add --no-cache git go make gcc musl-dev linux-headers && \
+  (cd go-ethereum && make geth)                             && \
+  cp go-ethereum/build/bin/geth /usr/local/bin/             && \
+  apk del git go make gcc musl-dev linux-headers            && \
+  rm -rf /go-ethereum
 
-EXPOSE 8545
-EXPOSE 30303
-EXPOSE 30303/udp
+EXPOSE 8545 30303 30303/udp
 
 ENTRYPOINT ["geth"]


### PR DESCRIPTION
 - update to alpine:3.6
 - don't download index, no need to remove it
 - expose as a single layer