### PR TITLE
metrics: change MetricsEnabledFlag to be const

### DIFF
--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -29,7 +29,7 @@ import (
 )
 
 // MetricsEnabledFlag is the CLI flag name to use to enable metrics collections.
-var MetricsEnabledFlag = "metrics"
+const MetricsEnabledFlag = "metrics"
 
 // Enabled is the flag specifying if metrics are enable or not.
 var Enabled = false


### PR DESCRIPTION
Using an exported global variable is not consider as a good practice, which creates hard time for parallel testing.

https://stackoverflow.com/questions/45711053/what-is-the-best-way-to-synchronize-tests-in-different-packages-which-involve-wi

In essence, MetricsEnabledFlag is a constant to represent a command line parameter.