### PR TITLE
Fix typo in core/vm/interpreter.go

### DIFF
--- a/core/vm/interpreter.go
+++ b/core/vm/interpreter.go
@@ -92,7 +92,7 @@ func (in *Interpreter) enforceRestrictions(op OpCode, operation operation, stack
 		if in.readOnly {
 			// If the interpreter is operating in readonly mode, make sure no
 			// state-modifying operation is performed. The 3rd stack item
-			// for a call operation is the value. Transfering value from one
+			// for a call operation is the value. Transferring value from one
 			// account to the others means the state is modified and should also
 			// return with an error.
 			if operation.writes || (op == CALL && stack.Back(2).BitLen() > 0) {


### PR DESCRIPTION
Signed-off-by: Ti Zhou <tizhou1986@gmail.com>

Fix typo in core/vm/interpreter.go