### PR TITLE
core/state: revert metro suicide map addition

### DIFF
--- a/core/state/journal.go
+++ b/core/state/journal.go
@@ -91,11 +91,6 @@ func (ch suicideChange) undo(s *StateDB) {
 	if obj != nil {
 		obj.suicided = ch.prev
 		obj.setBalance(ch.prevbalance)
-		// if the object wasn't suicided before, remove
-		// it from the list of destructed objects as well.
-		if !obj.suicided {
-			delete(s.stateObjectsDestructed, *ch.account)
-		}
 	}
 }
 

--- a/core/state_processor.go
+++ b/core/state_processor.go
@@ -106,7 +106,7 @@ func ApplyTransaction(config *params.ChainConfig, bc *BlockChain, author *common
 	// Update the state with pending changes
 	var root []byte
 	if config.IsMetropolis(header.Number) {
-		statedb.Finalise()
+		statedb.Finalise(true)
 	} else {
 		root = statedb.IntermediateRoot(config.IsEIP158(header.Number)).Bytes()
 	}

--- a/tests/block_test.go
+++ b/tests/block_test.go
@@ -37,7 +37,6 @@ func TestBlockchain(t *testing.T) {
 
 	// Still failing tests
 	bt.skipLoad(`^bcWalletTest.*_Byzantium$`)
-	bt.skipLoad(`^bcStateTests/suicideCoinbase.json.*_Byzantium$`)
 
 	bt.walk(t, blockTestDir, func(t *testing.T, name string, test *BlockTest) {
 		if err := bt.checkFailure(t, name, test.Run()); err != nil {


### PR DESCRIPTION
This PR reverts some special suicide handling added for Metropolis to use the exact same logic as EIP158 did. I really don't see the reason for this existing in the first place (also this makes us pass the suicide tests).