### PR TITLE
core: fix contract is always false even when tx is contract creaction.

### DIFF
--- a/core/types/transaction.go
+++ b/core/types/transaction.go
@@ -300,7 +300,7 @@ func (tx *Transaction) String() string {
 	Hex:      %x
 `,
 		tx.Hash(),
-		len(tx.data.Recipient) == 0,
+		tx.data.Recipient == nil,
 		from,
 		to,
 		tx.data.AccountNonce,


### PR DESCRIPTION
len(tx.data.Recipient) will always return 20, because type of Receipt is [20]byte.