### PR TITLE
internal, accounts, eth: utilize vm failed flag to help gas estimation

### DIFF
--- a/eth/api.go
+++ b/eth/api.go
@@ -523,8 +523,7 @@ func (api *PrivateDebugAPI) TraceTransaction(ctx context.Context, txHash common.
 
 	// Run the transaction with tracing enabled.
 	vmenv := vm.NewEVM(context, statedb, api.config, vm.Config{Debug: true, Tracer: tracer})
-	// TODO utilize failed flag
-	ret, gas, _, err := core.ApplyMessage(vmenv, msg, new(core.GasPool).AddGas(tx.Gas()))
+	ret, gas, failed, err := core.ApplyMessage(vmenv, msg, new(core.GasPool).AddGas(tx.Gas()))
 	if err != nil {
 		return nil, fmt.Errorf("tracing failed: %v", err)
 	}
@@ -532,6 +531,7 @@ func (api *PrivateDebugAPI) TraceTransaction(ctx context.Context, txHash common.
 	case *vm.StructLogger:
 		return &ethapi.ExecutionResult{
 			Gas:         gas,
+			Failed:      failed,
 			ReturnValue: fmt.Sprintf("%x", ret),
 			StructLogs:  ethapi.FormatLogs(tracer.StructLogs()),
 		}, nil


### PR DESCRIPTION
Motivation for this PR:

Now the gas is estimated through the gas is consumed all. But this method does not apply to all scenes. e.g. in the frontier contract deploys can fail without consuming all gas due to have not enough gas to store contract code. And in metropolish will have a revert opcode that can also revert without using all gas.

So a failed flag returned by vm is useful to detect whether an error occurred during the execution of the transaction. It can help to estimate gas accurately.

Besides, I raise the lower limit of the gas estimate to 21000, since the minimum gas cost is 21000.

Though there is another situation we can not handle it. If the call itself has a logical problem, no matter how much gas assigned, it always failed.