### PR TITLE
cmd/evm, core/vm/runtime: add more support for prestate configs

### DIFF
--- a/cmd/evm/runner.go
+++ b/cmd/evm/runner.go
@@ -88,6 +88,7 @@ func runCmd(ctx *cli.Context) error {
 		genTimestamp uint64
 		genGasLimit uint64
 		genDifficulty *big.Int
+		genNumber   uint64
 		sender      = common.StringToAddress("sender")
 		receiver    = common.StringToAddress("receiver")
 	)
@@ -105,6 +106,7 @@ func runCmd(ctx *cli.Context) error {
 		genDifficulty = gen.Difficulty
 		genGasLimit = gen.GasLimit
 		genTimestamp = gen.Timestamp
+		genNumber = gen.Number
 		_, statedb = gen.ToBlock()
 		chainConfig = gen.Config
 	} else {
@@ -167,6 +169,7 @@ func runCmd(ctx *cli.Context) error {
 		Time:     new(big.Int).SetUint64(genTimestamp),
 		Coinbase: genCoinbase,
 		Difficulty: genDifficulty,
+		BlockNumber: new(big.Int).SetUint64(genNumber),
 		State:    statedb,
 		GasLimit: genGasLimit,
 		GasPrice: utils.GlobalBig(ctx, PriceFlag.Name),

--- a/core/vm/runtime/env.go
+++ b/core/vm/runtime/env.go
@@ -19,7 +19,6 @@ package runtime
 import (
 	"math/big"
 
-	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core"
 	"github.com/ethereum/go-ethereum/core/vm"
 )
@@ -28,7 +27,7 @@ func NewEnv(cfg *Config) *vm.EVM {
 	context := vm.Context{
 		CanTransfer: core.CanTransfer,
 		Transfer:    core.Transfer,
-		GetHash:     func(uint64) common.Hash { return common.Hash{} },
+		GetHash:     cfg.GetHashFn,
 
 		Origin:      cfg.Origin,
 		Coinbase:    cfg.Coinbase,

--- a/core/vm/runtime/runtime.go
+++ b/core/vm/runtime/runtime.go
@@ -40,6 +40,7 @@ type Config struct {
 	Time        *big.Int
 	GasLimit    uint64
 	GasPrice    *big.Int
+	TxGasLimit  uint64
 	Value       *big.Int
 	DisableJit  bool // "disable" so it's enabled by default
 	Debug       bool
@@ -95,6 +96,8 @@ func setDefaults(cfg *Config) {
 // the given code. It enabled the JIT by default and make sure that it's restored
 // to it's original state afterwards.
 func Execute(code, input []byte, cfg *Config) ([]byte, *state.StateDB, error) {
+	// TODO: remove Execute()?
+	// only used in runtime_example_test.go
 	if cfg == nil {
 		cfg = new(Config)
 	}
@@ -144,7 +147,7 @@ func Create(input []byte, cfg *Config) ([]byte, common.Address, uint64, error) {
 	code, address, leftOverGas, err := vmenv.Create(
 		sender,
 		input,
-		cfg.GasLimit,
+		cfg.TxGasLimit,
 		cfg.Value,
 	)
 	return code, address, leftOverGas, err
@@ -166,7 +169,7 @@ func Call(address common.Address, input []byte, cfg *Config) ([]byte, uint64, er
 		sender,
 		address,
 		input,
-		cfg.GasLimit,
+		cfg.TxGasLimit,
 		cfg.Value,
 	)
 


### PR DESCRIPTION
Work-in-progress. Probably breaks the evm command if not given a prestate (todo: fallback to defaults when not given a `--prestate`).