### PR TITLE
core/vm, cmd/evm: standard vm traces

### DIFF
--- a/cmd/evm/json_logger.go
+++ b/cmd/evm/json_logger.go
@@ -40,7 +40,7 @@ func (l *JSONLogger) CaptureState(env *vm.EVM, pc uint64, op vm.OpCode, gas, cos
 	log := vm.StructLog{
 		Pc:         pc,
 		Op:         op,
-		Gas:        gas + cost,
+		Gas:        gas,
 		GasCost:    cost,
 		MemorySize: memory.Len(),
 		Storage:    nil,


### PR DESCRIPTION
Some standardization (https://github.com/ethereum/tests/issues/249) fixes for EVM traces.