### PR TITLE
discovery: allow bootstrap URLs to have a resolvable hostname.

### DIFF
--- a/p2p/discover/node.go
+++ b/p2p/discover/node.go
@@ -171,13 +171,15 @@ func parseComplete(rawurl string) (*Node, error) {
 	if id, err = HexID(u.User.String()); err != nil {
 		return nil, fmt.Errorf("invalid node ID (%v)", err)
 	}
-	// Parse the IP address.
+	// Parse the host.
 	host, port, err := net.SplitHostPort(u.Host)
 	if err != nil {
 		return nil, fmt.Errorf("invalid host: %v", err)
 	}
-	if ip = net.ParseIP(host); ip == nil {
-		return nil, errors.New("invalid IP address")
+	if addrs, err := net.LookupIP(host); err == nil {
+		ip = addrs[0] // Take first address
+	} else {
+		return nil, errors.New("could not resolve host")
 	}
 	// Ensure the IP is 4 bytes long for IPv4 addresses.
 	if ipv4 := ip.To4(); ipv4 != nil {

--- a/p2p/discover/node_test.go
+++ b/p2p/discover/node_test.go
@@ -68,7 +68,7 @@ var parseNodeTests = []struct {
 	// Complete nodes with IP address.
 	{
 		rawurl:    "enode://1dd9d65c4552b5eb43d5ad55a2ee3f56c6cbc1c64a5c8d659f51fcd51bace24351232b8d7821617d2b29b54b81cdefb9b3e9c37d7fd5f63270bcc9e1a6f6a439@hostname:3",
-		wantError: `invalid IP address`,
+		wantError: `could not resolve host`,
 	},
 	{
 		rawurl:    "enode://1dd9d65c4552b5eb43d5ad55a2ee3f56c6cbc1c64a5c8d659f51fcd51bace24351232b8d7821617d2b29b54b81cdefb9b3e9c37d7fd5f63270bcc9e1a6f6a439@127.0.0.1:foo",

--- a/p2p/discv5/node.go
+++ b/p2p/discv5/node.go
@@ -179,13 +179,15 @@ func parseComplete(rawurl string) (*Node, error) {
 	if id, err = HexID(u.User.String()); err != nil {
 		return nil, fmt.Errorf("invalid node ID (%v)", err)
 	}
-	// Parse the IP address.
+	// Parse the host.
 	host, port, err := net.SplitHostPort(u.Host)
 	if err != nil {
 		return nil, fmt.Errorf("invalid host: %v", err)
 	}
-	if ip = net.ParseIP(host); ip == nil {
-		return nil, errors.New("invalid IP address")
+	if addrs, err := net.LookupIP(host); err == nil {
+		ip = addrs[0] // Take first address
+	} else {
+		return nil, errors.New("could not resolve host")
 	}
 	// Ensure the IP is 4 bytes long for IPv4 addresses.
 	if ipv4 := ip.To4(); ipv4 != nil {

--- a/p2p/discv5/node_test.go
+++ b/p2p/discv5/node_test.go
@@ -68,7 +68,7 @@ var parseNodeTests = []struct {
 	// Complete nodes with IP address.
 	{
 		rawurl:    "enode://1dd9d65c4552b5eb43d5ad55a2ee3f56c6cbc1c64a5c8d659f51fcd51bace24351232b8d7821617d2b29b54b81cdefb9b3e9c37d7fd5f63270bcc9e1a6f6a439@hostname:3",
-		wantError: `invalid IP address`,
+		wantError: `could not resolve host`,
 	},
 	{
 		rawurl:    "enode://1dd9d65c4552b5eb43d5ad55a2ee3f56c6cbc1c64a5c8d659f51fcd51bace24351232b8d7821617d2b29b54b81cdefb9b3e9c37d7fd5f63270bcc9e1a6f6a439@127.0.0.1:foo",


### PR DESCRIPTION
Hi, I'm not sure why, but bootstrap URLs seems to take great effort to not allow for hostnames in the URLs, which can be a bit annoying for private instances.

Would you consider allowing this? The changes are not intrusives, and especially do not change behavior one bit when litteral IP addresses are used.

Maybe test could be updated to try one resolvable and one unresolvable hostname, but I do not have working examples...

Thanks