### PR TITLE
contracts/chequebook: fix race in test

### DIFF
--- a/contracts/chequebook/cheque_test.go
+++ b/contracts/chequebook/cheque_test.go
@@ -232,8 +232,8 @@ func TestDeposit(t *testing.T) {
 	balance := new(big.Int).SetUint64(42)
 	chbook.Deposit(balance)
 	backend.Commit()
-	if chbook.balance.Cmp(balance) != 0 {
-		t.Fatalf("expected balance %v, got %v", balance, chbook.balance)
+	if chbook.Balance().Cmp(balance) != 0 {
+		t.Fatalf("expected balance %v, got %v", balance, chbook.Balance())
 	}
 
 	amount := common.Big1
@@ -243,8 +243,8 @@ func TestDeposit(t *testing.T) {
 	}
 	backend.Commit()
 	exp := new(big.Int).SetUint64(41)
-	if chbook.balance.Cmp(exp) != 0 {
-		t.Fatalf("expected balance %v, got %v", exp, chbook.balance)
+	if chbook.Balance().Cmp(exp) != 0 {
+		t.Fatalf("expected balance %v, got %v", exp, chbook.Balance())
 	}
 
 	// autodeposit on each issue
@@ -259,8 +259,8 @@ func TestDeposit(t *testing.T) {
 		t.Fatalf("expected no error, got %v", err)
 	}
 	backend.Commit()
-	if chbook.balance.Cmp(balance) != 0 {
-		t.Fatalf("expected balance %v, got %v", balance, chbook.balance)
+	if chbook.Balance().Cmp(balance) != 0 {
+		t.Fatalf("expected balance %v, got %v", balance, chbook.Balance())
 	}
 
 	// autodeposit off
@@ -277,11 +277,11 @@ func TestDeposit(t *testing.T) {
 	backend.Commit()
 
 	exp = new(big.Int).SetUint64(40)
-	if chbook.balance.Cmp(exp) != 0 {
-		t.Fatalf("expected balance %v, got %v", exp, chbook.balance)
+	if chbook.Balance().Cmp(exp) != 0 {
+		t.Fatalf("expected balance %v, got %v", exp, chbook.Balance())
 	}
 
-	// autodeposit every 10ms if new cheque issued
+	// autodeposit every 30ms if new cheque issued
 	interval := 30 * time.Millisecond
 	chbook.AutoDeposit(interval, common.Big1, balance)
 	_, err = chbook.Issue(addr1, amount)
@@ -296,14 +296,14 @@ func TestDeposit(t *testing.T) {
 	backend.Commit()
 
 	exp = new(big.Int).SetUint64(38)
-	if chbook.balance.Cmp(exp) != 0 {
-		t.Fatalf("expected balance %v, got %v", exp, chbook.balance)
+	if chbook.Balance().Cmp(exp) != 0 {
+		t.Fatalf("expected balance %v, got %v", exp, chbook.Balance())
 	}
 
 	time.Sleep(3 * interval)
 	backend.Commit()
-	if chbook.balance.Cmp(balance) != 0 {
-		t.Fatalf("expected balance %v, got %v", balance, chbook.balance)
+	if chbook.Balance().Cmp(balance) != 0 {
+		t.Fatalf("expected balance %v, got %v", balance, chbook.Balance())
 	}
 
 	exp = new(big.Int).SetUint64(40)
@@ -319,8 +319,8 @@ func TestDeposit(t *testing.T) {
 	}
 	time.Sleep(3 * interval)
 	backend.Commit()
-	if chbook.balance.Cmp(exp) != 0 {
-		t.Fatalf("expected balance %v, got %v", exp, chbook.balance)
+	if chbook.Balance().Cmp(exp) != 0 {
+		t.Fatalf("expected balance %v, got %v", exp, chbook.Balance())
 	}
 
 	_, err = chbook.Issue(addr1, amount)
@@ -330,8 +330,8 @@ func TestDeposit(t *testing.T) {
 	time.Sleep(1 * interval)
 	backend.Commit()
 
-	if chbook.balance.Cmp(balance) != 0 {
-		t.Fatalf("expected balance %v, got %v", balance, chbook.balance)
+	if chbook.Balance().Cmp(balance) != 0 {
+		t.Fatalf("expected balance %v, got %v", balance, chbook.Balance())
 	}
 
 	chbook.AutoDeposit(1*interval, common.Big0, balance)
@@ -352,8 +352,8 @@ func TestDeposit(t *testing.T) {
 	backend.Commit()
 
 	exp = new(big.Int).SetUint64(39)
-	if chbook.balance.Cmp(exp) != 0 {
-		t.Fatalf("expected balance %v, got %v", exp, chbook.balance)
+	if chbook.Balance().Cmp(exp) != 0 {
+		t.Fatalf("expected balance %v, got %v", exp, chbook.Balance())
 	}
 
 }


### PR DESCRIPTION
Fixes #14934  

Fixes the data race issue in the TestDeposit : 
The TestDeposit was reading the chequebook balance without lock.
The balance readings is now made through the Deposit() function with a lock.