### PR TITLE
core/vm: skip some statedblookup during gascalc for call

### DIFF
--- a/core/vm/gas_table.go
+++ b/core/vm/gas_table.go
@@ -324,7 +324,7 @@ func gasCall(gt params.GasTable, evm *EVM, contract *Contract, stack *Stack, mem
 		eip158         = evm.ChainConfig().IsEIP158(evm.BlockNumber)
 	)
 	if eip158 {
-		if evm.StateDB.Empty(address) && transfersValue {
+		if transfersValue && evm.StateDB.Empty(address)  {
 			gas += params.CallNewAccountGas
 		}
 	} else if !evm.StateDB.Exist(address) {


### PR DESCRIPTION
This is a minor PR which in some cases can prevent from having to load account from disk during gas calulation for `CALL`. 