### PR TITLE
p2p: Reduce ping-noise by 1 order of magnitude

### DIFF
--- a/p2p/peer.go
+++ b/p2p/peer.go
@@ -190,7 +190,7 @@ loop:
 }
 
 func (p *Peer) pingLoop() {
-	ping := time.NewTicker(pingInterval)
+	ping := time.NewTimer(pingInterval)
 	defer p.wg.Done()
 	defer ping.Stop()
 	for {
@@ -200,6 +200,7 @@ func (p *Peer) pingLoop() {
 				p.protoErr <- err
 				return
 			}
+			ping.Reset(pingInterval)
 		case <-p.closed:
 			return
 		}


### PR DESCRIPTION

I noticed there was an awful lot of ping-pong going on between peers. There is a pingLoop, which uses a Ticker. 


https://golang.org/pkg/time/#NewTicker:

>  It adjusts the intervals or drops ticks to make up for slow receivers.

I changed it to use a `Timer` instead, and reset manually after firing.
Here are some logs taken with high verbosity, the first three instances where I just ran the unmodified code. 

	#LOG=detailed_log.txt;head $LOG -n1;tail -n1 $LOG ; grep ">> PING" $LOG  | wc -l
	TRACE[09-01|09:46:36|accounts/keystore/watch.go:74] Started watching keystore folder         path=/home/martin/.ethereum/keystore
	TRACE[09-01|09:55:32|p2p/discover/table.go:280]              Bumping findnode failure counter         id=fcad9f6d3faf89a0 failcount=1
	10516

10516 pings in 9 minutes: 19,5 pings/s


	#LOG=detailed_log2.txt;head $LOG -n1;tail -n1 $LOG ; grep ">> PING" $LOG  | wc -l
	TRACE[09-01|10:07:03|accounts/keystore/watch.go:74] Started watching keystore folder         path=/home/martin/.ethereum/keystore
	DEBUG[09-01|10:25:30|p2p/discover/udp.go:509]                UDP read error                           err="read udp [::]:30303: use of closed network connection"
	20021

20021 pings in 18 minutes: 18.5 pings/s

	#LOG=detailed_log3.txt;head $LOG -n1;tail -n1 $LOG ; grep ">> PING" $LOG  | wc -l
	TRACE[09-01|10:44:22|accounts/keystore/watch.go:74] Started watching keystore folder         path=/home/martin/.ethereum/keystore
	TRACE[09-01|10:57:59|p2p/discover/table.go:280]              Bumping findnode failure counter         id=2bbc88036adbfc43 failcount=1
	14103

14103 pings in 13 minutes: 18 pings/s

With the fix: 

	#LOG=detailed_log_pingfix.txt;head $LOG -n1;tail -n1 $LOG ; grep ">> PING" $LOG  | wc -l
	TRACE[09-01|11:00:59|accounts/keystore/watch.go:74] Started watching keystore folder         path=/home/martin/.ethereum/keystore
	DEBUG[09-01|11:10:04|p2p/discover/udp.go:509]                UDP read error                           err="read udp [::]:30303: use of closed network connection"
	836

836 pings in 9 minutes: 1.5 ping/s

1.5 pings/s should correspond to num_peers/15s, so the measurements indicates that we have 23 peers, which seems roughly correct. 

Using a Timer over Ticker seems to be a lot better, though I cannot fully account for _why_ that it behaves so (since Ticker _should_ be more bursty, but not necessarily more active over time, but that may depend on how long window it uses to decide on when to tick next)