### PR TITLE
core/vm: Make MaxCodesize non-retroactive 

### DIFF
--- a/core/vm/evm.go
+++ b/core/vm/evm.go
@@ -336,7 +336,7 @@ func (evm *EVM) Create(caller ContractRef, code []byte, gas uint64, value *big.I
 
 	ret, err = run(evm, snapshot, contract, nil)
 	// check whether the max code size has been exceeded
-	maxCodeSizeExceeded := len(ret) > params.MaxCodeSize
+	maxCodeSizeExceeded := evm.ChainConfig().IsEIP158(evm.BlockNumber) && len(ret) > params.MaxCodeSize
 	// if the contract creation ran successfully and no errors were returned
 	// calculate the gas required to store the code. If the code could not
 	// be stored due to not enough gas set an error and let it be handled

--- a/tests/state_test.go
+++ b/tests/state_test.go
@@ -35,8 +35,6 @@ func TestState(t *testing.T) {
 	st.skipLoad(`^stTransactionTest/OverflowGasRequire\.json`) // gasLimit > 256 bits
 	st.skipLoad(`^stTransactionTest/zeroSigTransa[^/]*\.json`) // EIP-86 is not supported yet
 	// Expected failures:
-	st.fails(`^stCodeSizeLimit/codesizeOOGInvalidSize\.json/(Frontier|Homestead|EIP150)`,
-		"code size limit implementation is not conditional on fork")
 	st.fails(`^stRevertTest/RevertPrecompiledTouch\.json/EIP158`, "bug in test")
 	st.fails(`^stRevertTest/RevertPrefoundEmptyOOG\.json/EIP158`, "bug in test")
 	st.fails(`^stRevertTest/RevertPrecompiledTouch\.json/Byzantium`, "bug in test")


### PR DESCRIPTION
Make max_codesize only applicable post Spurious Dragon, EIPs 158/155/161/170
Ref: https://github.com/ethereum/EIPs/blob/master/EIPS/eip-170.md 

This PR fixes the issue with Geth having implemented EIP 170 retro-actively. Although that is not an issue in itself, it causes problems since it causes false positives on the tests, both hive-tests and fuzz-tests, and often comes up for investigation.

Reducing FP is important, so we can spend our time better, even if it's not a true consensus issue. 

With the PR (plus the individual_statetests-branch): 

```
#build/bin/evm --nomemory statetest  ~/tmp/go_metro_statetest_fail/fail_1.json | jq
unsupported fork "Constantinople"
[
  {
    "name": "randomStatetest",
    "pass": true,
    "fork": "EIP150"
  },
  {
    "name": "randomStatetest",
    "pass": true,
    "fork": "EIP158"
  },
  {
    "name": "randomStatetest",
    "pass": true,
    "fork": "Frontier"
  },
  {
    "name": "randomStatetest",
    "pass": true,
    "fork": "Homestead"
  },
  {
    "name": "randomStatetest",
    "pass": true,
    "fork": "Byzantium"
  },
  {
    "name": "randomStatetest",
    "pass": false,
    "fork": "Constantinople",
    "error": "unsupported fork \"Constantinople\""
  }
]
```
Without the PR, it fails on Homestead

```json
[
  {
    "name": "randomStatetest",
    "pass": true,
    "fork": "Byzantium"
  },
  {
    "name": "randomStatetest",
    "pass": false,
    "fork": "Constantinople",
    "error": "unsupported fork \"Constantinople\""
  },
  {
    "name": "randomStatetest",
    "pass": true,
    "fork": "EIP150"
  },
  {
    "name": "randomStatetest",
    "pass": true,
    "fork": "EIP158"
  },
  {
    "name": "randomStatetest",
    "pass": false,
    "fork": "Frontier",
    "error": "post state root mismatch: got a11c1ea6f69731af08ca32f0127f6c21c69172b060466b1604893a79c9b6774a, want 4e80c13b8ef691f6cde8f12802e3eaf996b3e69a9a774ea211e483aea4d5e0b6"
  },
  {
    "name": "randomStatetest",
    "pass": true,
    "fork": "Homestead"
  }
]
``` 