### PR TITLE
p2p/discover: Stop iterating after match found for incoming msg

### DIFF
--- a/p2p/discover/udp.go
+++ b/p2p/discover/udp.go
@@ -385,7 +385,7 @@ func (t *udp) loop() {
 
 		case r := <-t.gotreply:
 			var matched bool
-			for el := plist.Front(); el != nil; el = el.Next() {
+			for el := plist.Front(); !matched && el != nil; el = el.Next() {
 				p := el.Value.(*pending)
 				if p.from == r.from && p.ptype == r.ptype {
 					matched = true


### PR DESCRIPTION
When the p2p layer receives a message, it searches through the `plist` to see if it's a reply to something it was waiting for. When doing so, it iterates through the entire list every time. 

This PR changes that so that it exits the iteration once a match has been found. 