### PR TITLE
Fix two issues with Swarm's chequebook contract

### DIFF
--- a/contracts/chequebook/contract/chequebook.sol
+++ b/contracts/chequebook/contract/chequebook.sol
@@ -27,10 +27,11 @@ contract chequebook is mortal {
         if(owner != ecrecover(hash, sig_v, sig_r, sig_s)) return;
         // Attempt sending the difference between the cumulative amount on the cheque
         // and the cumulative amount on the last cashed cheque to beneficiary.
-        if (amount - sent[beneficiary] >= this.balance) {
+        uint256 diff = amount - sent[beneficiary];
+        if (diff <= this.balance) {
 	    // update the cumulative amount before sending
             sent[beneficiary] = amount;
-            if (!beneficiary.send(amount - sent[beneficiary])) {
+            if (!beneficiary.send(diff)) {
                 // Upon failure to execute send, revert everything
                 throw;
             }


### PR DESCRIPTION
This patch fixes the following issues:

* The contract executes `send()` when it does not have enough balance.
* The contract always sends a total amount of zero.