### PR TITLE
core: use blocks and avoid deep reorgs in txpool

### DIFF
--- a/core/tx_pool_test.go
+++ b/core/tx_pool_test.go
@@ -50,22 +50,22 @@ type testBlockChain struct {
 	chainHeadFeed *event.Feed
 }
 
-func (bc *testBlockChain) CurrentHeader() *types.Header {
-	return &types.Header{
+func (bc *testBlockChain) CurrentBlock() *types.Block {
+	return types.NewBlock(&types.Header{
 		GasLimit: bc.gasLimit,
-	}
-}
-
-func (bc *testBlockChain) SubscribeChainHeadEvent(ch chan<- ChainHeadEvent) event.Subscription {
-	return bc.chainHeadFeed.Subscribe(ch)
+	}, nil, nil, nil)
 }
 
 func (bc *testBlockChain) GetBlock(hash common.Hash, number uint64) *types.Block {
-	return types.NewBlock(bc.CurrentHeader(), nil, nil, nil)
+	return bc.CurrentBlock()
 }
 
 func (bc *testBlockChain) StateAt(common.Hash) (*state.StateDB, error) {
 	return bc.statedb, nil
+}
+
+func (bc *testBlockChain) SubscribeChainHeadEvent(ch chan<- ChainHeadEvent) event.Subscription {
+	return bc.chainHeadFeed.Subscribe(ch)
 }
 
 func transaction(nonce uint64, gaslimit *big.Int, key *ecdsa.PrivateKey) *types.Transaction {


### PR DESCRIPTION
This PR fixes two bugs in the reorg code of the transaction pool. Both only appear during initial fast sync:

 * The pool was using `blockchain.CurrentHeader` to retrieve the current head, to make it eventually more useful for the light client and allow reusing the transaction pool there. Unfortunately this had the side effect that during fast sync, the head header doesn't have state associated, so the pool was displaying an ugly red ERROR log that state is missing. This PR fixes it by using `blockchain.CurrentBlock` instead of headers.
 * The second bug was that starting up Geth for a fast sync, the "old" block tracked by the transaction pool is block number 0, whilst the next full "new" block will be the head of the chain. This would lead to the pool doing a reorg of the size of the entire chain to gather the transaction diff. This PR addresses it by placing a 64 depth reorg limit, above which it will refuse to pull transactions in from past blocks.