### PR TITLE
should use bytes.Equal(fileContents, finfo.contents) instead

### DIFF
--- a/swarm/fuse/swarmfs_test.go
+++ b/swarm/fuse/swarmfs_test.go
@@ -140,7 +140,7 @@ func compareGeneratedFileWithFileInMount(t *testing.T, files map[string]fileInfo
 		if err != nil {
 			t.Fatalf("Could not readfile %v : %v", fname, err)
 		}
-		if bytes.Compare(fileContents, finfo.contents) != 0 {
+		if !bytes.Equal(fileContents, finfo.contents) {
 			t.Fatalf("File %v contents mismatch: %v , %v", fname, fileContents, finfo.contents)
 
 		}


### PR DESCRIPTION
should use bytes.Equal(fileContents, finfo.contents) instead