### PR TITLE
p2p: snappy encoding for devp2p (version bump to 5)

### DIFF
--- a/p2p/peer.go
+++ b/p2p/peer.go
@@ -31,9 +31,11 @@ import (
 )
 
 const (
-	baseProtocolVersion    = 4
+	baseProtocolVersion    = 5
 	baseProtocolLength     = uint64(16)
 	baseProtocolMaxMsgSize = 2 * 1024
+
+	snappyProtocolVersion = 5
 
 	pingInterval = 15 * time.Second
 )


### PR DESCRIPTION
**Implements https://github.com/ethereum/EIPs/pull/706.**

This PR bumps the version number of the devp2p protocol to v5 and implements (mandatory) Snappy compression for the message payload fields. The results are staggering:

Rinkeby fast sync without compression:

```js
{
  InboundTraffic: {
    Avg01Min: "80.09M (1.33M/s)",
    Avg05Min: "945.18M (3.15M/s)",
    Avg15Min: "1.95G (2.17M/s)",
    Overall: "2.51G (4.09M/s)"
  },
  OutboundTraffic: {
    Avg01Min: "1.46M (24.29K/s)",
    Avg05Min: "15.19M (50.63K/s)",
    Avg15Min: "35.02M (38.91K/s)",
    Overall: "55.89M (90.87K/s)"
  }
```

Rinkeby fast sync with Snappy encoding:

```js
{
  InboundTraffic: {
    Avg01Min: "41.58M (693.07K/s)",
    Avg05Min: "191.29M (637.63K/s)",
    Avg15Min: "344.51M (382.79K/s)",
    Overall: "463.65M (785.86K/s)"
  },
  OutboundTraffic: {
    Avg01Min: "2.64M (43.96K/s)",
    Avg05Min: "19.86M (66.20K/s)",
    Avg15Min: "34.65M (38.50K/s)",
    Overall: "46.21M (121.93K/s)"
  }
}
```

Mainnet fast sync without compression:

```js
{
  InboundTraffic: {
    Avg01Min: "60.29M (1.00M/s)",
    Avg05Min: "2.25G (7.51M/s)",
    Avg15Min: "7.59G (8.43M/s)",
    Overall: "33.59G (6.58M/s)"
  },
  OutboundTraffic: {
    Avg01Min: "590.21K (9.84K/s)",
    Avg05Min: "9.27M (30.90K/s)",
    Avg15Min: "46.54M (51.72K/s)",
    Overall: "1.01G (197.11K/s)"
  }
}
```

Mainnet fast sync with Snappy encoding:

```js
{
  InboundTraffic: {
    Avg01Min: "36.79M (613.15K/s)",
    Avg05Min: "309.53M (1.03M/s)",
    Avg15Min: "2.45G (2.72M/s)",
    Overall: "13.46G (3.94M/s)"
  },
  OutboundTraffic: {
    Avg01Min: "16.63M (277.12K/s)",
    Avg05Min: "82.10M (273.66K/s)",
    Avg15Min: "206.05M (228.94K/s)",
    Overall: "1.01G (294.07K/s)"
  }
}
```
