### PR TITLE
trie: make fullnode children hash calculation concurrently

### DIFF
--- a/trie/secure_trie.go
+++ b/trie/secure_trie.go
@@ -199,10 +199,10 @@ func (t *SecureTrie) secKey(key []byte) []byte {
 // invalid on the next call to hashKey or secKey.
 func (t *SecureTrie) hashKey(key []byte) []byte {
 	h := newHasher(0, 0)
-	h.sha.Reset()
-	h.sha.Write(key)
-	buf := h.sha.Sum(t.hashKeyBuf[:0])
-	returnHasherToPool(h)
+	calculator := h.newCalculator()
+	calculator.sha.Write(key)
+	buf := calculator.sha.Sum(t.hashKeyBuf[:0])
+	h.returnCalculator(calculator)
 	return buf
 }
 

--- a/trie/trie.go
+++ b/trie/trie.go
@@ -501,6 +501,5 @@ func (t *Trie) hashRoot(db DatabaseWriter) (node, node, error) {
 		return hashNode(emptyRoot.Bytes()), nil, nil
 	}
 	h := newHasher(t.cachegen, t.cachelimit)
-	defer returnHasherToPool(h)
 	return h.hash(t.root, db, true)
 }


### PR DESCRIPTION
Motivation:

For fullnode in trie, the children hash calculation was serial before. However, the hash calculation between any child nodes does not affect each other. So i make this concurrently.

Performance:

I run the `BenchmarkHashBE` and `BenchmarkHashLE` on my server machine(8cores 3.7GHZ) for performance checking.

for parallel：

```
BenchmarkHash-8   	 1000000	      1868 ns/op	    1513 B/op	      18 allocs/op
```

for serial:

```
BenchmarkHash-8   	  500000	      3919 ns/op	    1428 B/op	      15 allocs/op
```

Performance doubled when hash large tree.