### PR TITLE
params: Updated finalized gascosts for ECMUL/MODEXP

### DIFF
--- a/core/state_transition.go
+++ b/core/state_transition.go
@@ -241,7 +241,7 @@ func (st *StateTransition) TransitionDb() (ret []byte, requiredGas, usedGas *big
 	} else {
 		// Increment the nonce for the next transaction
 		st.state.SetNonce(sender.Address(), st.state.GetNonce(sender.Address())+1)
-		ret, st.gas, vmerr = evm.Call(sender, st.to().Address(), st.data, st.gas, st.value)
+		ret, st.gas, vmerr = evm.Call(sender, *msg.To(), st.data, st.gas, st.value)
 	}
 	if vmerr != nil {
 		log.Debug("VM returned with error", "err", vmerr)

--- a/core/state_transition.go
+++ b/core/state_transition.go
@@ -241,7 +241,7 @@ func (st *StateTransition) TransitionDb() (ret []byte, requiredGas, usedGas *big
 	} else {
 		// Increment the nonce for the next transaction
 		st.state.SetNonce(sender.Address(), st.state.GetNonce(sender.Address())+1)
-		ret, st.gas, vmerr = evm.Call(sender, *msg.To(), st.data, st.gas, st.value)
+		ret, st.gas, vmerr = evm.Call(sender, st.to().Address(), st.data, st.gas, st.value)
 	}
 	if vmerr != nil {
 		log.Debug("VM returned with error", "err", vmerr)

--- a/params/protocol_params.go
+++ b/params/protocol_params.go
@@ -64,9 +64,9 @@ const (
 	Ripemd160PerWordGas     uint64 = 120    // Per-word price for a RIPEMD160 operation
 	IdentityBaseGas         uint64 = 15     // Base price for a data copy operation
 	IdentityPerWordGas      uint64 = 3      // Per-work price for a data copy operation
-	ModExpQuadCoeffDiv      uint64 = 100    // Divisor for the quadratic particle of the big int modular exponentiation
+	ModExpQuadCoeffDiv      uint64 = 20     // Divisor for the quadratic particle of the big int modular exponentiation
 	Bn256AddGas             uint64 = 500    // Gas needed for an elliptic curve addition
-	Bn256ScalarMulGas       uint64 = 2000   // Gas needed for an elliptic curve scalar multiplication
+	Bn256ScalarMulGas       uint64 = 40000  // Gas needed for an elliptic curve scalar multiplication
 	Bn256PairingBaseGas     uint64 = 100000 // Base price for an elliptic curve pairing check
 	Bn256PairingPerPointGas uint64 = 80000  // Per-point price for an elliptic curve pairing check
 )

--- a/tests/block_test.go
+++ b/tests/block_test.go
@@ -32,8 +32,6 @@ func TestBlockchain(t *testing.T) {
 	bt.skipLoad(`^bcTotalDifficultyTest/(lotsOfLeafs|lotsOfBranches|sideChainWithMoreTransactions)`)
 	// Constantinople is not implemented yet.
 	bt.skipLoad(`(?i)(constantinople)`)
-	// Expected failures:
-	bt.fails(`^TransitionTests/bcHomesteadToDao/DaoTransactions(|_UncleExtradata|_EmptyTransactionAndForkBlocksAhead)\.json`, "issue in test")
 
 	// Still failing tests
 	bt.skipLoad(`^bcWalletTest.*_Byzantium$`)

--- a/tests/state_test.go
+++ b/tests/state_test.go
@@ -39,6 +39,13 @@ func TestState(t *testing.T) {
 	st.fails(`^stRevertTest/RevertPrefoundEmptyOOG\.json/EIP158`, "bug in test")
 	st.fails(`^stRevertTest/RevertPrecompiledTouch\.json/Byzantium`, "bug in test")
 	st.fails(`^stRevertTest/RevertPrefoundEmptyOOG\.json/Byzantium`, "bug in test")
+	st.fails( `^stRandom/randomStatetest645\.json/EIP150/.*`, "known bug #15119")
+	st.fails( `^stRandom/randomStatetest645\.json/Frontier/.*`, "known bug #15119")
+	st.fails( `^stRandom/randomStatetest645\.json/Homestead/.*`, "known bug #15119")
+	st.fails( `^stRandom/randomStatetest644\.json/EIP150/.*`, "known bug #15119")
+	st.fails( `^stRandom/randomStatetest644\.json/Frontier/.*`, "known bug #15119")
+	st.fails( `^stRandom/randomStatetest644\.json/Homestead/.*`, "known bug #15119")
+
 
 	st.walk(t, stateTestDir, func(t *testing.T, name string, test *StateTest) {
 		for _, subtest := range test.Subtests() {
@@ -59,7 +66,8 @@ func TestState(t *testing.T) {
 }
 
 // Transactions with gasLimit above this value will not get a VM trace on failure.
-const traceErrorLimit = 400000
+//const traceErrorLimit = 400000
+const traceErrorLimit = 0
 
 func withTrace(t *testing.T, gasLimit uint64, test func(vm.Config) error) {
 	err := test(vm.Config{})


### PR DESCRIPTION
Updated modexp `GQUADDIVISOR` to `20`

* https://github.com/ethereum/EIPs/blob/30055644acd6966806371f24bc9fd9ebd3b56a57/EIPS/bigint_modexp.md

Updated ecmul to `40000`

* https://github.com/ethereum/EIPs/blob/0063de10b489b4eba9ec505dcd573a9c19966326/EIPS/ecopts.md#gas-costs

