### PR TITLE
cmd/puppeth: reserve "yournode" as a non-allowed ethstats user

### DIFF
--- a/cmd/puppeth/module_ethstats.go
+++ b/cmd/puppeth/module_ethstats.go
@@ -42,7 +42,7 @@ RUN \
 WORKDIR /eth-netstats
 EXPOSE 3000
 
-RUN echo 'module.exports = {trusted: [{{.Trusted}}], banned: [{{.Banned}}]};' > lib/utils/config.js
+RUN echo 'module.exports = {trusted: [{{.Trusted}}], banned: [{{.Banned}}], reserved: ["yournode"]};' > lib/utils/config.js
 
 CMD ["npm", "start"]
 `


### PR DESCRIPTION
The Rinkeby dashboard contains the connectivity commands on how users can connect to a Puppeth based network. Among others, it also features the ethstats login info `yournode:password@host`. Unfortunately a lot of users don't realize that they are supposed to *change* `yournode` to something meaningful.

Since it's annoying to see a flickering `yournode` on ethstats (due to 10 people all reporting under the same ID), this PR explicitly disallows users from using `yournode` to log in to ethstats.