### PR TITLE
accounts/usbwallet: fix Ledger usbwallet bug in account list

### DIFF
--- a/accounts/usbwallet/hub.go
+++ b/accounts/usbwallet/hub.go
@@ -168,6 +168,15 @@ func (hub *Hub) refreshWallets() {
 			logger := log.New("url", url)
 			wallet := &wallet{hub: hub, driver: hub.makeDriver(logger), url: &url, info: device, log: logger}
 
+			if wallet.URL().Scheme == "ledger" {
+				wallet.Open("")
+				// Derive the account of the current ledger USB wallet
+				_, err := wallet.Derive(accounts.DefaultLedgerBaseDerivationPath, true)
+				if err != nil {
+					wallet.log.Debug("USB wallet account derivation failed", "err", err)
+				}
+			}
+			
 			events = append(events, accounts.WalletEvent{Wallet: wallet, Kind: accounts.WalletArrived})
 			wallets = append(wallets, wallet)
 			continue


### PR DESCRIPTION
This PR fixes #15128 

- The Ledger devices were not derived when the hub was created. The refreshWallets function created a wallet with an empty account list.
- With this modifications, the usb wallet is derived to get the current ethereum account. 