### PR TITLE
core,tests: Fix #15119, don't create account in state_transition

### DIFF
--- a/core/state_transition.go
+++ b/core/state_transition.go
@@ -150,9 +150,6 @@ func (st *StateTransition) to() vm.AccountRef {
 	}
 
 	reference := vm.AccountRef(*to)
-	if !st.state.Exist(*to) {
-		st.state.CreateAccount(*to)
-	}
 	return reference
 }
 

--- a/tests/state_test.go
+++ b/tests/state_test.go
@@ -39,12 +39,6 @@ func TestState(t *testing.T) {
 	st.fails(`^stRevertTest/RevertPrefoundEmptyOOG\.json/EIP158`, "bug in test")
 	st.fails(`^stRevertTest/RevertPrecompiledTouch\.json/Byzantium`, "bug in test")
 	st.fails(`^stRevertTest/RevertPrefoundEmptyOOG\.json/Byzantium`, "bug in test")
-	st.fails( `^stRandom/randomStatetest645\.json/EIP150/.*`, "known bug #15119")
-	st.fails( `^stRandom/randomStatetest645\.json/Frontier/.*`, "known bug #15119")
-	st.fails( `^stRandom/randomStatetest645\.json/Homestead/.*`, "known bug #15119")
-	st.fails( `^stRandom/randomStatetest644\.json/EIP150/.*`, "known bug #15119")
-	st.fails( `^stRandom/randomStatetest644\.json/Frontier/.*`, "known bug #15119")
-	st.fails( `^stRandom/randomStatetest644\.json/Homestead/.*`, "known bug #15119")
 
 
 	st.walk(t, stateTestDir, func(t *testing.T, name string, test *StateTest) {
@@ -76,7 +70,7 @@ func withTrace(t *testing.T, gasLimit uint64, test func(vm.Config) error) {
 	}
 	t.Error(err)
 	if gasLimit > traceErrorLimit {
-		t.Log("gas limit too high for EVM trace")
+		//t.Log("gas limit too high for EVM trace")
 		return
 	}
 	tracer := vm.NewStructLogger(nil)


### PR DESCRIPTION
This PR fixes #15119, and makes a few more failing tests pass. WIthout this patch, in pre-spurious dragon: 

* A precompile which does not exist
* And is called, 
* But the call is reverted (OOG), 
* Would be created in the trie

This is not a cause for concern at this point, but is an error. This is because to to-account is created early in the state transition, before the reversion-snapshot is taken. 

Before we merge this PR, we should really, _really_ think about possiblle consequences of this change. 