### PR TITLE
p2p/nat: Delete the udp port mapping before adding

### DIFF
--- a/p2p/nat/natupnp.go
+++ b/p2p/nat/natupnp.go
@@ -62,6 +62,7 @@ func (n *upnp) AddMapping(protocol string, extport, intport int, desc string, li
 	}
 	protocol = strings.ToUpper(protocol)
 	lifetimeS := uint32(lifetime / time.Second)
+	n.DeleteMapping(protocol, extport, intport)
 	return n.client.AddPortMapping("", uint16(extport), protocol, uint16(intport), ip.String(), true, desc, lifetimeS)
 }
 


### PR DESCRIPTION
Fixes #1024 where the ask is to delete the port mapping before adding.