### PR TITLE
core: verify state too when deduping existing blocks

### DIFF
--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -792,14 +792,13 @@ func (bc *BlockChain) WriteBlockAndState(block *types.Block, receipts []*types.R
 	if ptd == nil {
 		return NonStatTy, consensus.ErrUnknownAncestor
 	}
+	// If the block is already known, skip it
+	if bc.HasBlockAndState(block.Hash()) {
+		return SideStatTy, nil
+	}
 	// Make sure no inconsistent state is leaked during insertion
 	bc.mu.Lock()
 	defer bc.mu.Unlock()
-
-	if bc.HasBlock(block.Hash(), block.NumberU64()) {
-		log.Trace("Block existed", "hash", block.Hash())
-		return
-	}
 
 	localTd := bc.GetTd(bc.currentBlock.Hash(), bc.currentBlock.NumberU64())
 	externTd := new(big.Int).Add(block.Difficulty(), ptd)


### PR DESCRIPTION
When importing a block, the current code checked if the block is already present in the database and skipped writing it altogether to avoid some db writes. Unfortunately there was a slight difference in what the check verified and what the method actually wrote:

 * The dedup code checked for the presence of the block, **but not** the state.
 * The insertion method inserted the block **and** the state.

This mismatch caused a conflict at fast sync to full sync transition:

 * Fast sync imported all blocks until some pivot point (not yet locked in)
 * Sync failed, restarted with a lower pivot point (it's random)
 * Pivot block is committed, switching to full sync
 * However there are full-but-stateless blocks after the pivot
 * Importer skipped them, never writing the state
 * Subsequent block went boom as the state was missing

The fix is really simple, just verify that both the block as well as the associated state is present before early-exiting from the database writer.

Fixes https://github.com/ethereum/go-ethereum/issues/15204.

Note, this fix resurfaces the "impossible reorg" warning https://github.com/ethereum/go-ethereum/pull/14849 fixed, but a warning is still better than a stuck node. I'll try to find the root cause of the reorg too. Luckily it's reproable via a Rinkeby miner, a fresh chain, and a forced import failure ;P 