### PR TITLE
core: revert invalid block dedup code

### DIFF
--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -796,11 +796,6 @@ func (bc *BlockChain) WriteBlockAndState(block *types.Block, receipts []*types.R
 	bc.mu.Lock()
 	defer bc.mu.Unlock()
 
-	if bc.HasBlock(block.Hash(), block.NumberU64()) {
-		log.Trace("Block existed", "hash", block.Hash())
-		return
-	}
-
 	localTd := bc.GetTd(bc.currentBlock.Hash(), bc.currentBlock.NumberU64())
 	externTd := new(big.Int).Add(block.Difficulty(), ptd)
 


### PR DESCRIPTION
This PR reverts https://github.com/ethereum/go-ethereum/pull/14849 as it was causing BAD BLOCK errors and client sync deadlocks https://github.com/ethereum/go-ethereum/issues/15204.

The "impossible reorg" warning that will resurface is a false alarm, but it needs a better detection code. False alarm is still better than stuck network.

Superseeds https://github.com/ethereum/go-ethereum/pull/15234 (see for details).