### PR TITLE
issue template: add remark about general questions

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,3 +1,9 @@
+Hi there,
+
+please note that this is an issue tracker reserved for bug reports and feature requests.
+
+For general questions please use the gitter channel or the Ethereum stack exchange at https://ethereum.stackexchange.com.
+
 #### System information
 
 Geth version: `geth version`


### PR DESCRIPTION
There are frequently issues created that aren't bug reports nor feature requests. This PR adds a remark to the issue template telling issue creators that for these type of questions other places are more suitable.

@karalabe pling