### PR TITLE
internal/ethapi/tracer: Fix the getBalance method for the ability to use it in debug_traceTransaction

### DIFF
--- a/internal/ethapi/tracer.go
+++ b/internal/ethapi/tracer.go
@@ -130,8 +130,8 @@ type dbWrapper struct {
 }
 
 // getBalance retrieves an account's balance
-func (dw *dbWrapper) getBalance(addr common.Address) *big.Int {
-	return dw.db.GetBalance(addr)
+func (dw *dbWrapper) getBalance(addr []byte) *big.Int {
+	return dw.db.GetBalance(common.BytesToAddress(addr))
 }
 
 // getNonce retrieves an account's nonce


### PR DESCRIPTION
When JavaScript-based tracking is not possible to use db.getBalance, as it expects a common.Address - in js there is no this structure.

https://github.com/ethereum/go-ethereum/issues/3382