### PR TITLE
swarm/fuse: Return amount of data written if the file exists

### DIFF
--- a/swarm/fuse/fuse_file.go
+++ b/swarm/fuse/fuse_file.go
@@ -134,7 +134,7 @@ func (sf *SwarmFile) Write(ctx context.Context, req *fuse.WriteRequest, resp *fu
 		if err != nil {
 			return err
 		}
-		resp.Size = int(sf.fileSize)
+		resp.Size = len(req.Data)
 	} else {
 		log.Warn("Invalid write request size(%v) : off(%v)", sf.fileSize, req.Offset)
 		return errInvalidOffset


### PR DESCRIPTION
If the file already existed, the WriteResponse.Size was being set
as the length of the entire file, not just the amount that was
written to the existing file.

Fixes #15216