### PR TITLE
cmd/puppeth: use dumb textual IP filtering

### DIFF
--- a/cmd/puppeth/wizard.go
+++ b/cmd/puppeth/wizard.go
@@ -302,8 +302,10 @@ func (w *wizard) readJSON() string {
 }
 
 // readIPAddress reads a single line from stdin, trimming if from spaces and
-// converts it to a network IP address.
-func (w *wizard) readIPAddress() net.IP {
+// returning it if it's convertible to an IP address. The reason for keeping
+// the user input format instead of returning a Go net.IP is to match with
+// weird formats used by ethstats, which compares IPs textually, not by value.
+func (w *wizard) readIPAddress() string {
 	for {
 		// Read the IP address from the user
 		fmt.Printf("> ")
@@ -312,14 +314,13 @@ func (w *wizard) readIPAddress() net.IP {
 			log.Crit("Failed to read user input", "err", err)
 		}
 		if text = strings.TrimSpace(text); text == "" {
-			return nil
+			return ""
 		}
 		// Make sure it looks ok and return it if so
-		ip := net.ParseIP(text)
-		if ip == nil {
+		if ip := net.ParseIP(text); ip == nil {
 			log.Error("Invalid IP address, please retry")
 			continue
 		}
-		return ip
+		return text
 	}
 }


### PR DESCRIPTION
Puppeth until now supported blacklisting ethstats peers via their IP addresses by maintaining a slice of Go `net.IP` addresses and flattening it into a string list for the docker config.

Unfortunately ethstats uses plain string comparison for IP banning, and Go uses a different IP formatting scheme than nodejs (IPv6 addresses in Go get shortened if they contain `:0:0:0:0` ending to `::`). As such, parsing the user input into `net.IP` and later converting to string will mismatch the comparison. This PR dumbs down the blacklist to use `[]string` instead of `[]net.IP`.

Alongside the change, the PR also introduces a bit finer blacklist manipulation support so that Puppeth admins don't have to reconstruct the blacklist every single time they want to add/remove an entry to/from it.