### PR TITLE
core/types: fix test for TransactionsByPriceAndNonce

### DIFF
--- a/core/types/transaction_test.go
+++ b/core/types/transaction_test.go
@@ -147,12 +147,12 @@ func TestTransactionPriceNonceSort(t *testing.T) {
 	txset := NewTransactionsByPriceAndNonce(signer, groups)
 
 	txs := Transactions{}
-	for {
-		if tx := txset.Peek(); tx != nil {
-			txs = append(txs, tx)
-			txset.Shift()
-		}
-		break
+	for tx := txset.Peek(); tx != nil; tx = txset.Peek() {
+		txs = append(txs, tx)
+		txset.Shift()
+	}
+	if len(txs) != 25*25 {
+		t.Errorf("expected %d transactions, found %d", 25*25, len(txs))
 	}
 	for i, txi := range txs {
 		fromi, _ := Sender(signer, txi)


### PR DESCRIPTION
`TestTransactionPriceNonceSort` has a bad loop in it that means the test will pass regardless of the operation of `NewTransactionsByPriceAndNonce`.  This fixes the loop so that it provides all of the transactions and hence a true test of the function.