### PR TITLE
fix compilation error on 2 fixed size arrays, type Hash and Address

### DIFF
--- a/common/types.go
+++ b/common/types.go
@@ -90,7 +90,7 @@ func (h Hash) MarshalText() ([]byte, error) {
 
 // Sets the hash to the value of b. If b is larger than len(h), 'b' will be cropped (from the left).
 func (h *Hash) SetBytes(b []byte) {
-	if len(b) > len(h) {
+	if len(b) > HashLength {
 		b = b[len(b)-HashLength:]
 	}
 
@@ -200,7 +200,7 @@ func (a Address) Format(s fmt.State, c rune) {
 
 // Sets the address to the value of b. If b is larger than len(a) it will panic
 func (a *Address) SetBytes(b []byte) {
-	if len(b) > len(a) {
+	if len(b) > AddressLength {
 		b = b[len(b)-AddressLength:]
 	}
 	copy(a[AddressLength-len(b):], b)


### PR DESCRIPTION
This fails to compile with Go 1.9.1

Since the the types `Hash` and `Address` are defined as arrays with respective fixed length `HashLength` and `AddressLength`,  the substitution should be fine