### PR TITLE
abi: make toGoType public

### DIFF
--- a/accounts/abi/abi.go
+++ b/accounts/abi/abi.go
@@ -110,7 +110,7 @@ func (abi ABI) Unpack(v interface{}, name string, output []byte) error {
 		// names
 		case reflect.Struct:
 			for i := 0; i < len(method.Outputs); i++ {
-				marshalledValue, err := toGoType(i, method.Outputs[i], output)
+				marshalledValue, err := ToGoType(i, method.Outputs[i], output)
 				if err != nil {
 					return err
 				}
@@ -138,7 +138,7 @@ func (abi ABI) Unpack(v interface{}, name string, output []byte) error {
 				}
 
 				for i := 0; i < len(method.Outputs); i++ {
-					marshalledValue, err := toGoType(i, method.Outputs[i], output)
+					marshalledValue, err := ToGoType(i, method.Outputs[i], output)
 					if err != nil {
 						return err
 					}
@@ -154,7 +154,7 @@ func (abi ABI) Unpack(v interface{}, name string, output []byte) error {
 			// values to the new interface slice.
 			z := reflect.MakeSlice(typ, 0, len(method.Outputs))
 			for i := 0; i < len(method.Outputs); i++ {
-				marshalledValue, err := toGoType(i, method.Outputs[i], output)
+				marshalledValue, err := ToGoType(i, method.Outputs[i], output)
 				if err != nil {
 					return err
 				}
@@ -166,7 +166,7 @@ func (abi ABI) Unpack(v interface{}, name string, output []byte) error {
 		}
 
 	} else {
-		marshalledValue, err := toGoType(0, method.Outputs[0], output)
+		marshalledValue, err := ToGoType(0, method.Outputs[0], output)
 		if err != nil {
 			return err
 		}

--- a/accounts/abi/unpack.go
+++ b/accounts/abi/unpack.go
@@ -25,7 +25,7 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 )
 
-// toGoSliceType parses the input and casts it to the proper slice defined by the ABI
+// toGoSlice parses the input and casts it to the proper slice defined by the ABI
 // argument in T.
 func toGoSlice(i int, t Argument, output []byte) (interface{}, error) {
 	index := i * 32
@@ -181,9 +181,9 @@ func readBool(word []byte) (bool, error) {
 
 }
 
-// toGoType parses the input and casts it to the proper type defined by the ABI
-// argument in T.
-func toGoType(i int, t Argument, output []byte) (interface{}, error) {
+// ToGoType parses the i-th input and casts it to the proper type defined by the ABI
+// argument `t`. `output` is the whole ABI-encoded data.
+func ToGoType(i int, t Argument, output []byte) (interface{}, error) {
 	// we need to treat slices differently
 	if (t.Type.IsSlice || t.Type.IsArray) && t.Type.T != BytesTy && t.Type.T != StringTy && t.Type.T != FixedBytesTy && t.Type.T != FunctionTy {
 		return toGoSlice(i, t, output)


### PR DESCRIPTION
toGoType is a usefull function which could be used in external libraries,
eg to parse the Log.Data. Hence it's good to make it public.