### PR TITLE
swarm/api: bug fix exact match for manifest

### DIFF
--- a/swarm/api/manifest.go
+++ b/swarm/api/manifest.go
@@ -436,6 +436,16 @@ func (self *manifestTrie) findPrefixOf(path string, quitC chan bool) (entry *man
 	if len(path) <= epl {
 		if entry.Path[:len(path)] == path {
 			if entry.ContentType == ManifestType {
+				err := self.loadSubTrie(entry, quitC)
+				if err == nil && entry.subtrie != nil {
+					subentries := entry.subtrie.entries
+					for i := 0; i < len(subentries); i++ {
+						sub := subentries[i]
+						if sub != nil && sub.Path == "" {
+							return sub, len(path)
+						}
+					}
+				}
 				entry.Status = http.StatusMultipleChoices
 			}
 			pos = len(path)

--- a/swarm/api/manifest_test.go
+++ b/swarm/api/manifest_test.go
@@ -21,6 +21,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"net/http"
 	"strings"
 	"testing"
 
@@ -39,17 +40,17 @@ func manifest(paths ...string) (manifestReader storage.LazySectionReader) {
 	}
 }
 
-func testGetEntry(t *testing.T, path, match string, paths ...string) *manifestTrie {
+func testGetEntry(t *testing.T, path, match string, multiple bool, paths ...string) *manifestTrie {
 	quitC := make(chan bool)
 	trie, err := readManifest(manifest(paths...), nil, nil, quitC)
 	if err != nil {
 		t.Errorf("unexpected error making manifest: %v", err)
 	}
-	checkEntry(t, path, match, trie)
+	checkEntry(t, path, match, multiple, trie)
 	return trie
 }
 
-func checkEntry(t *testing.T, path, match string, trie *manifestTrie) {
+func checkEntry(t *testing.T, path, match string, multiple bool, trie *manifestTrie) {
 	entry, fullpath := trie.getEntry(path)
 	if match == "-" && entry != nil {
 		t.Errorf("expected no match for '%s', got '%s'", path, fullpath)
@@ -60,32 +61,55 @@ func checkEntry(t *testing.T, path, match string, trie *manifestTrie) {
 	} else if fullpath != match {
 		t.Errorf("incorrect entry retrieved for '%s'. expected path '%v', got '%s'", path, match, fullpath)
 	}
+
+	if multiple && entry.Status != http.StatusMultipleChoices {
+		t.Errorf("Expected %d Multiple Choices Status for path %s, match %s, got %d", http.StatusMultipleChoices, path, match, entry.Status)
+	} else if !multiple && entry != nil && entry.Status == http.StatusMultipleChoices {
+		t.Errorf("Were not expecting %d Multiple Choices Status for path %s, match %s, but got it", http.StatusMultipleChoices, path, match)
+	}
 }
 
 func TestGetEntry(t *testing.T) {
 	// file system manifest always contains regularized paths
-	testGetEntry(t, "a", "a", "a")
-	testGetEntry(t, "b", "-", "a")
-	testGetEntry(t, "/a//", "a", "a")
+	testGetEntry(t, "a", "a", false, "a")
+	testGetEntry(t, "b", "-", false, "a")
+	testGetEntry(t, "/a//", "a", false, "a")
 	// fallback
-	testGetEntry(t, "/a", "", "")
-	testGetEntry(t, "/a/b", "a/b", "a/b")
+	testGetEntry(t, "/a", "", false, "")
+	testGetEntry(t, "/a/b", "a/b", false, "a/b")
 	// longest/deepest math
-	testGetEntry(t, "read", "read", "readme.md", "readit.md")
-	testGetEntry(t, "rf", "-", "readme.md", "readit.md")
-	testGetEntry(t, "readme", "readme", "readme.md")
-	testGetEntry(t, "readme", "-", "readit.md")
-	testGetEntry(t, "readme.md", "readme.md", "readme.md")
-	testGetEntry(t, "readme.md", "-", "readit.md")
-	testGetEntry(t, "readmeAmd", "-", "readit.md")
-	testGetEntry(t, "readme.mdffff", "-", "readme.md")
-	testGetEntry(t, "ab", "ab", "ab/cefg", "ab/cedh", "ab/kkkkkk")
-	testGetEntry(t, "ab/ce", "ab/ce", "ab/cefg", "ab/cedh", "ab/ceuuuuuuuuuu")
-	testGetEntry(t, "abc", "abc", "abcd", "abczzzzef", "abc/def", "abc/e/g")
-	testGetEntry(t, "a/b", "a/b", "a", "a/bc", "a/ba", "a/b/c")
-	testGetEntry(t, "a/b", "a/b", "a", "a/b", "a/bb", "a/b/c")
-	testGetEntry(t, "//a//b//", "a/b", "a", "a/b", "a/bb", "a/b/c")
+	testGetEntry(t, "read", "read", true, "readme.md", "readit.md")
+	testGetEntry(t, "rf", "-", false, "readme.md", "readit.md")
+	testGetEntry(t, "readme", "readme", false, "readme.md")
+	testGetEntry(t, "readme", "-", false, "readit.md")
+	testGetEntry(t, "readme.md", "readme.md", false, "readme.md")
+	testGetEntry(t, "readme.md", "-", false, "readit.md")
+	testGetEntry(t, "readmeAmd", "-", false, "readit.md")
+	testGetEntry(t, "readme.mdffff", "-", false, "readme.md")
+	testGetEntry(t, "ab", "ab", true, "ab/cefg", "ab/cedh", "ab/kkkkkk")
+	testGetEntry(t, "ab/ce", "ab/ce", true, "ab/cefg", "ab/cedh", "ab/ceuuuuuuuuuu")
+	testGetEntry(t, "abc", "abc", true, "abcd", "abczzzzef", "abc/def", "abc/e/g")
+	testGetEntry(t, "a/b", "a/b", true, "a", "a/bc", "a/ba", "a/b/c")
+	testGetEntry(t, "a/b", "a/b", false, "a", "a/b", "a/bb", "a/b/c")
+	testGetEntry(t, "//a//b//", "a/b", false, "a", "a/b", "a/bb", "a/b/c")
 }
+
+func TestExactMatch(t *testing.T) {
+	quitC := make(chan bool)
+	mf := manifest("shouldBeExactMatch.css", "shouldBeExactMatch.css.map")
+	trie, err := readManifest(mf, nil, nil, quitC)
+	if err != nil {
+		t.Errorf("unexpected error making manifest: %v", err)
+	}
+	entry, _ := trie.getEntry("shouldBeExactMatch.css")
+	if entry.Path != "" {
+		t.Errorf("Expected entry to match %s, got: %s", "shouldBeExactMatch.css", entry.Path)
+	}
+	if entry.Status == http.StatusMultipleChoices {
+		t.Errorf("Got status %d, which is unexepcted", http.StatusMultipleChoices)
+	}
+}
+
 func TestDeleteEntry(t *testing.T) {
 
 }
@@ -108,15 +132,15 @@ func TestAddFileWithManifestPath(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	checkEntry(t, "ab", "ab", trie)
-	checkEntry(t, "ac", "ac", trie)
+	checkEntry(t, "ab", "ab", false, trie)
+	checkEntry(t, "ac", "ac", false, trie)
 
 	// now add path "a" and check we can still get "ab" and "ac"
 	entry := &manifestTrieEntry{}
 	entry.Path = "a"
 	entry.Hash = "a"
 	trie.addEntry(entry, nil)
-	checkEntry(t, "ab", "ab", trie)
-	checkEntry(t, "ac", "ac", trie)
-	checkEntry(t, "a", "a", trie)
+	checkEntry(t, "ab", "ab", false, trie)
+	checkEntry(t, "ac", "ac", false, trie)
+	checkEntry(t, "a", "a", false, trie)
 }


### PR DESCRIPTION
This PR fixes a bug where a request for `/styles.css`  would fail with status code 300 if the request resolves to a manifest and the manifest contains the exact match (empty path in sub-manifest) and more entries, for example `styles.css.map`