### PR TITLE
tests: print stateroot in evm/statetest

### DIFF
--- a/cmd/evm/staterunner.go
+++ b/cmd/evm/staterunner.go
@@ -94,7 +94,8 @@ func stateTestCmd(ctx *cli.Context) error {
 		for _, st := range test.Subtests() {
 			// Run the test and aggregate the result
 			result := &StatetestResult{Name: key, Fork: st.Fork, Pass: true}
-			if state, err := test.Run(st, cfg); err != nil {
+			state, err := test.Run(st, cfg)
+			if err != nil {
 				// Test failed, mark as so and dump any state to aid debugging
 				result.Pass, result.Error = false, err.Error()
 				if ctx.GlobalBool(DumpFlag.Name) && state != nil {
@@ -102,6 +103,11 @@ func stateTestCmd(ctx *cli.Context) error {
 					result.State = &dump
 				}
 			}
+			// print state root for evmlab tracing (already committed above, so no need to delete objects again
+			if ctx.GlobalBool(MachineFlag.Name) && state != nil {
+				fmt.Fprintf(os.Stderr, "{\"stateRoot\": \"%x\"}\n", state.IntermediateRoot(false))
+			}
+
 			results = append(results, *result)
 
 			// Print any structured logs collected


### PR DESCRIPTION
This is a trivial PR to print out stateroot when doing the `statetest` via `evm`. It's used by the statetest fuzzer. 