### PR TITLE
accounts/abi, ethclient: Allow sending transactions from unlocked accounts via RPC

### DIFF
--- a/accounts/abi/bind/backend.go
+++ b/accounts/abi/bind/backend.go
@@ -88,6 +88,8 @@ type ContractTransactor interface {
 	EstimateGas(ctx context.Context, call ethereum.CallMsg) (usedGas *big.Int, err error)
 	// SendTransaction injects the transaction into the pending pool for execution.
 	SendTransaction(ctx context.Context, tx *types.Transaction) error
+	// SendUnsignedTransaction injects an unsigned transaction into the pending pool for execution.
+	SendUnsignedTransaction(ctx context.Context, tx *types.Transaction, sender common.Address) error
 }
 
 // ContractBackend defines the methods needed to work with contracts on a read-write basis.

--- a/eth/bind.go
+++ b/eth/bind.go
@@ -136,3 +136,21 @@ func (b *ContractBackend) SendTransaction(ctx context.Context, tx *types.Transac
 	_, err := b.txapi.SendRawTransaction(ctx, raw)
 	return err
 }
+
+// SendUnsignedTransaction implements bind.ContractTransactor injects an
+// unsigned transaction into the pending pool for execution
+func (b *ContractBackend) SendUnsignedTransaction(ctx context.Context, tx *types.Transaction, sender common.Address) error {
+	// Convert our transaction + sender into internal struct SendTxArgs
+	nonce := tx.Nonce()
+	args := ethapi.SendTxArgs{
+		From:     sender,
+		To:       tx.To(),
+		Gas:      (*hexutil.Big)(tx.Gas()),
+		GasPrice: (*hexutil.Big)(tx.GasPrice()),
+		Value:    (*hexutil.Big)(tx.Value()),
+		Data:     tx.Data(),
+		Nonce:    (*hexutil.Uint64)(&nonce),
+	}
+	_, err := b.txapi.SendTransaction(ctx, args)
+	return err
+}


### PR DESCRIPTION
Currently there doesn't seem to be a way to use ethclient to send transactions using eth_sendTransaction, instead needing to import a key and sign the transaction locally first. This PR adds a new method that sends a transaction using this rpc method if the Signer field of TransactOpts is nil, which seemed to be the least intrusive way to add this functionality.