### PR TITLE
build: Retrieve git commit hash from the enviroment 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,13 @@ FROM golang:1.9-alpine as builder
 
 RUN apk add --no-cache make gcc musl-dev linux-headers
 
+ARG GIT_COMMIT
+ENV GIT_COMMIT ${GIT_COMMIT}
+ARG GIT_BRANCH
+ENV GIT_BRANCH ${GIT_BRANCH}
+ARG GIT_TAG
+ENV GIT_TAG ${GIT_TAG}
+
 ADD . /go-ethereum
 RUN cd /go-ethereum && make geth
 

--- a/Makefile
+++ b/Makefile
@@ -34,6 +34,13 @@ ios:
 	@echo "Done building."
 	@echo "Import \"$(GOBIN)/Geth.framework\" to use the library."
 
+docker:
+	docker build \
+		--build-arg GIT_COMMIT=$(shell git rev-parse HEAD) \
+		--build-arg GIT_BRANCH=$(shell git rev-parse --abbrev-ref HEAD) \
+		--build-arg GIT_TAG=$(shell git tag -l --points-at HEAD) \
+		-t ethereum:$(shell git rev-parse --short HEAD) .
+
 test: all
 	build/env.sh go run build/ci.go test
 

--- a/internal/build/env.go
+++ b/internal/build/env.go
@@ -74,6 +74,13 @@ func Env() Environment {
 			IsPullRequest: os.Getenv("APPVEYOR_PULL_REQUEST_NUMBER") != "",
 			IsCronJob:     os.Getenv("APPVEYOR_SCHEDULED_BUILD") == "True",
 		}
+	case os.Getenv("GIT_COMMIT") != "":
+		return Environment{
+			Name:   "docker",
+			Commit: os.Getenv("GIT_COMMIT"),
+			Branch: os.Getenv("GIT_BRANCH"),
+			Tag:    os.Getenv("GIT_TAG"),
+		}
 	default:
 		return LocalEnv()
 	}


### PR DESCRIPTION
When building with docker the git command are not available. This PR uses the docker env to pass the version info. A Makefile command was added to build the docker container.

Fixes #15346