### PR TITLE
Add all cmd executables to the docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,13 +4,13 @@ FROM golang:1.9-alpine as builder
 RUN apk add --no-cache make gcc musl-dev linux-headers
 
 ADD . /go-ethereum
-RUN cd /go-ethereum && make geth
+RUN cd /go-ethereum && make all
 
 # Pull Geth into a second stage deploy alpine container
 FROM alpine:latest
 
 RUN apk add --no-cache ca-certificates
-COPY --from=builder /go-ethereum/build/bin/geth /usr/local/bin/
+COPY --from=builder /go-ethereum/build/bin/* /usr/local/bin/
 
 EXPOSE 8545 8546 30303 30303/udp
 ENTRYPOINT ["geth"]


### PR DESCRIPTION
Fixes #15352:
```
$ docker run --rm --entrypoint='ls' courajs/client-go -l /usr/local/bin
total 208068
-rwxr-xr-x    1 root     root       8622688 Oct 21 22:33 abigen
-rwxr-xr-x    1 root     root      21040232 Oct 21 22:33 bootnode
-rwxr-xr-x    1 root     root      20676400 Oct 21 22:33 evm
-rwxr-xr-x    1 root     root      19292400 Oct 21 22:34 examples
-rwxr-xr-x    1 root     root      27282288 Oct 21 22:33 faucet
-rwxr-xr-x    1 root     root      31428968 Oct 21 22:33 geth
-rwxr-xr-x    1 root     root      19210848 Oct 21 22:33 p2psim
-rwxr-xr-x    1 root     root      14028096 Oct 21 22:33 puppeth
-rwxr-xr-x    1 root     root       2894412 Oct 21 22:33 rlpdump
-rwxr-xr-x    1 root     root      26453960 Oct 21 22:33 swarm
-rwxr-xr-x    1 root     root      22109400 Oct 21 22:33 wnode
```