### PR TITLE
accounts/abi: Provide DoNotSend flag in TransactOpts

### DIFF
--- a/accounts/abi/bind/base.go
+++ b/accounts/abi/bind/base.go
@@ -52,7 +52,8 @@ type TransactOpts struct {
 	GasPrice *big.Int // Gas price to use for the transaction execution (nil = gas price oracle)
 	GasLimit *big.Int // Gas limit to set for the transaction execution (nil = estimate + 10%)
 
-	Context context.Context // Network context to support cancellation and timeouts (nil = no timeout)
+	Context   context.Context // Network context to support cancellation and timeouts (nil = no timeout)
+	DoNotSend bool            // Do not send the transaction; used for dry runs and offline transaction generation
 }
 
 // BoundContract is the base wrapper object that reflects a contract on the
@@ -219,8 +220,10 @@ func (c *BoundContract) transact(opts *TransactOpts, contract *common.Address, i
 	if err != nil {
 		return nil, err
 	}
-	if err := c.transactor.SendTransaction(ensureContext(opts.Context), signedTx); err != nil {
-		return nil, err
+	if !opts.DoNotSend {
+		if err := c.transactor.SendTransaction(ensureContext(opts.Context), signedTx); err != nil {
+			return nil, err
+		}
 	}
 	return signedTx, nil
 }


### PR DESCRIPTION
At current there is no way to create but not send a transaction whose code has been generated with `abigen`.  This patch adds a `DoNotSend` flag to `TransactOpts` to provide this feature.

Adding this feature allows for such transactions to be created offline (e.g. on an airgapped PC) and broadcast to the network at a later date and/or from a separate computer.