### PR TITLE
cmd/rlpdump: allow hex input to have leading '0x'

### DIFF
--- a/cmd/rlpdump/main.go
+++ b/cmd/rlpdump/main.go
@@ -51,7 +51,7 @@ func main() {
 	var r io.Reader
 	switch {
 	case *hexMode != "":
-		data, err := hex.DecodeString(*hexMode)
+		data, err := hex.DecodeString(strings.TrimPrefix(*hexMode, "0x"))
 		if err != nil {
 			die(err)
 		}


### PR DESCRIPTION
`rlpdump` fails with a hex input prefixed with `0x`, for example:

    $ rlpdump --hex 0x00
    encoding/hex: invalid byte: U+0078 'x'

This patch allows hex strings to be prefixed with '0x':

    $ rlpdump --hex 0x00
    00

Existing functionality is unchanged.
