### PR TITLE
accounts/abi: fix singleUnpack for mobile

### DIFF
--- a/accounts/abi/event.go
+++ b/accounts/abi/event.go
@@ -133,15 +133,14 @@ func (e Event) singleUnpack(v interface{}, output []byte) error {
 
 	// if we reach this part, there is only one output member from the contract event.
 	// for mobile, the result type is always a slice.
-	var firstValue reflect.Value
-	if reflect.Slice == value.Kind() {
-		// take the first element
-		firstValue = value.Index(0).Elem()
-	} else {
-		firstValue = value
+	if reflect.Slice == value.Kind() && value.Len() >= 1 {
+		//check if it's not a byte slice
+		if reflect.TypeOf([]byte{}) != value.Type() {
+			value = value.Index(0).Elem()
+		}
 	}
 
-	if err := set(firstValue, reflect.ValueOf(marshalledValue), e.Inputs[0]); err != nil {
+	if err := set(value, reflect.ValueOf(marshalledValue), e.Inputs[0]); err != nil {
 		return err
 	}
 	return nil

--- a/accounts/abi/event.go
+++ b/accounts/abi/event.go
@@ -130,7 +130,18 @@ func (e Event) singleUnpack(v interface{}, output []byte) error {
 	if err != nil {
 		return err
 	}
-	if err := set(value, reflect.ValueOf(marshalledValue), e.Inputs[0]); err != nil {
+
+	// if we reach this part, there is only one output member from the contract event.
+	// for mobile, the result type is always a slice.
+	var firstValue reflect.Value
+	if reflect.Slice == value.Kind() {
+		// take the first element
+		firstValue = value.Index(0).Elem()
+	} else {
+		firstValue = value
+	}
+
+	if err := set(firstValue, reflect.ValueOf(marshalledValue), e.Inputs[0]); err != nil {
 		return err
 	}
 	return nil

--- a/accounts/abi/method.go
+++ b/accounts/abi/method.go
@@ -150,7 +150,18 @@ func (method Method) singleUnpack(v interface{}, output []byte) error {
 	if err != nil {
 		return err
 	}
-	if err := set(value, reflect.ValueOf(marshalledValue), method.Outputs[0]); err != nil {
+
+	// if we reach this part, there is only one output member from the contract method.
+	// for mobile, the result type is always a slice.
+	var firstValue reflect.Value
+	if reflect.Slice == value.Kind() {
+		// take the first element
+		firstValue = value.Index(0).Elem()
+	} else {
+		firstValue = value
+	}
+
+	if err := set(firstValue, reflect.ValueOf(marshalledValue), method.Outputs[0]); err != nil {
 		return err
 	}
 	return nil

--- a/accounts/abi/method.go
+++ b/accounts/abi/method.go
@@ -153,15 +153,14 @@ func (method Method) singleUnpack(v interface{}, output []byte) error {
 
 	// if we reach this part, there is only one output member from the contract method.
 	// for mobile, the result type is always a slice.
-	var firstValue reflect.Value
-	if reflect.Slice == value.Kind() {
-		// take the first element
-		firstValue = value.Index(0).Elem()
-	} else {
-		firstValue = value
+	if reflect.Slice == value.Kind() && value.Len() >= 1 {
+		//check if it's not a byte slice
+		if reflect.TypeOf([]byte{}) != value.Type() {
+			value = value.Index(0).Elem()
+		}
 	}
 
-	if err := set(firstValue, reflect.ValueOf(marshalledValue), method.Outputs[0]); err != nil {
+	if err := set(value, reflect.ValueOf(marshalledValue), method.Outputs[0]); err != nil {
 		return err
 	}
 	return nil


### PR DESCRIPTION
until now calling a contract function with a single result failed
this commit fixes #15387 #14832

for example :
```java
boundContract = Geth.bindContract(contractAddress, ABI, mEthereumClient);

Address userAddress = Geth.newAddressFromHex("0x2cA4c0Dbb6FFD3812a2d5c6d440487Dfcd088f5B");

Interface result = Geth.newInterface();
result.setDefaultBigInt();
Interfaces results = Geth.newInterfaces(1);
results.set(0, result);

Interface in = Geth.newInterface();
in.setAddress(userAddress);
Interfaces params = Geth.newInterfaces(1);
params.set(0, in);

CallOpts opts = Geth.newCallOpts();
opts.setContext(mContext);

boundContract.call(opts, results, "balanceOf", params);
```
will result with the error :
```
 abi: cannot unmarshal *big.Int in to []interface {}
```