### PR TITLE
accounts/keystore: fix cache update and TestUpdatedKeyfileContents fa…

### DIFF
--- a/accounts/keystore/account_cache.go
+++ b/accounts/keystore/account_cache.go
@@ -23,7 +23,6 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
-	"runtime"
 	"sort"
 	"strings"
 	"sync"
@@ -262,7 +261,7 @@ func (fc *fileCache) scanFiles(keyDir string) (set.Interface, set.Interface, set
 		}
 		filesNow.Add(path)
 		// on macOS, we get FS notifications before the actual modTime is updated
-		if modTime.After(prevMtime) || (modTime.Equal(prevMtime) && runtime.GOOS == "darwin") {
+		if modTime.After(prevMtime) || modTime.Equal(prevMtime) {
 			moddedFiles.Add(path)
 		}
 		if modTime.After(newMtime) {

--- a/accounts/keystore/account_cache.go
+++ b/accounts/keystore/account_cache.go
@@ -23,6 +23,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"runtime"
 	"sort"
 	"strings"
 	"sync"
@@ -260,7 +261,8 @@ func (fc *fileCache) scanFiles(keyDir string) (set.Interface, set.Interface, set
 			continue
 		}
 		filesNow.Add(path)
-		if modTime.After(prevMtime) {
+		// on macOS, we get FS notifications before the actual modTime is updated
+		if modTime.After(prevMtime) || (modTime.Equal(prevMtime) && runtime.GOOS == "darwin") {
 			moddedFiles.Add(path)
 		}
 		if modTime.After(newMtime) {


### PR DESCRIPTION
fix cache update and TestUpdatedKeyfileContents failing on macOS.
TestUpdatedKeyfileContents was randomly failing on macOS. Root cause: after writing to a file and closing the file handle, we get the fs notify event, we scan the directory and the modified time of the file is not yet updated (and the scanAccount logic relies on that to update the cache), even after the 500ms delay in watch.go. 
I believe using the EventInfo from notify library in watch.go:93 to avoid scanning directory and relying on modified time of files would be safer (the event contains the Modified / Created / Deleted file path, yet we scan the whole directory and compare modified times)