### PR TITLE
build: Add Travis Job to Lint Go Code #15372

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,7 +38,7 @@ matrix:
         - sudo chmod 666 /dev/fuse
         - sudo chown root:$USER /etc/fuse.conf
         - go run build/ci.go install
-        - go run build/ci.go test -coverage -misspell
+        - go run build/ci.go test -coverage
 
     - os: osx
       go: 1.9.x
@@ -48,7 +48,19 @@ matrix:
         - brew install caskroom/cask/brew-cask
         - brew cask install osxfuse
         - go run build/ci.go install
-        - go run build/ci.go test -coverage -misspell
+        - go run build/ci.go test -coverage
+
+    # This only tests code linters on latest version of Go
+    - os: linux
+      dist: trusty
+      sudo: required
+      go: 1.9.x
+      script:
+        - sudo -E apt-get -yq --no-install-suggests --no-install-recommends --force-yes install fuse
+        - sudo modprobe fuse
+        - sudo chmod 666 /dev/fuse
+        - sudo chown root:$USER /etc/fuse.conf
+        - go run build/ci.go lint
 
     # This builder does the Ubuntu PPA and Linux Azure uploads
     - os: linux

--- a/.travis.yml
+++ b/.travis.yml
@@ -50,11 +50,13 @@ matrix:
         - go run build/ci.go install
         - go run build/ci.go test -coverage
 
-    # This only tests code linters on latest version of Go
+    # This builder only tests code linters on latest version of Go
     - os: linux
       dist: trusty
       sudo: required
       go: 1.9.x
+      env:
+        - lint
       script:
         - sudo -E apt-get -yq --no-install-suggests --no-install-recommends --force-yes install fuse
         - sudo modprobe fuse

--- a/build/ci.go
+++ b/build/ci.go
@@ -24,8 +24,8 @@ Usage: go run ci.go <command> <command flags/arguments>
 Available commands are:
 
    install    [ -arch architecture ] [ packages... ]                                           -- builds packages and executables
-   test       [ -coverage ] [ packages... ]			                                           -- runs the tests
-   lint       													                               -- runs linters
+   test       [ -coverage ] [ packages... ]                                                    -- runs the tests
+   lint                                                                                        -- runs certain pre-selected linters
    archive    [ -arch architecture ] [ -type zip|tar ] [ -signer key-envvar ] [ -upload dest ] -- archives build artefacts
    importkeys                                                                                  -- imports signing keys from env
    debsrc     [ -signer key-id ] [ -upload dest ]                                              -- creates a debian source package
@@ -57,8 +57,8 @@ import (
 	"runtime"
 	"strings"
 	"time"
-	"github.com/ethereum/go-ethereum/internal/build"
 
+	"github.com/ethereum/go-ethereum/internal/build"
 )
 
 var (
@@ -312,26 +312,19 @@ func doTest(cmdline []string) {
 
 // runs gometalinter on requested packages
 func doLint(cmdline []string) {
-
 	flag.CommandLine.Parse(cmdline)
 
 	packages := []string{"./..."}
-
 	if len(flag.CommandLine.Args()) > 0 {
 		packages = flag.CommandLine.Args()
-		for _, pkg := range packages {
-			packages = append(packages, fmt.Sprintf("%s/...", pkg));
-		}
 	}
-
-
-	//get metalinter and install linters
+	// Get metalinter and install all supported linters
 	build.MustRun(goTool("get", "gopkg.in/alecthomas/gometalinter.v1"))
-	build.MustRunCommand(filepath.Join(GOBIN,"gometalinter.v1"), "--install")
+	build.MustRunCommand(filepath.Join(GOBIN, "gometalinter.v1"), "--install")
 
-	configs := []string{"--vendor", "--disable-all", "--enable=vet", "--enable=deadcode"} // Add additional linters to the slice with "--enable=linter-name"
+	configs := []string{"--vendor", "--disable-all", "--enable=vet"} // Add additional linters to the slice with "--enable=linter-name"
 
-	build.MustRunCommand(filepath.Join(GOBIN,"gometalinter.v1"), append(configs, packages...)...)
+	build.MustRunCommand(filepath.Join(GOBIN, "gometalinter.v1"), append(configs, packages...)...)
 }
 
 // Release Packaging

--- a/build/ci.go
+++ b/build/ci.go
@@ -24,7 +24,8 @@ Usage: go run ci.go <command> <command flags/arguments>
 Available commands are:
 
    install    [ -arch architecture ] [ packages... ]                                           -- builds packages and executables
-   test       [ -coverage ] [ -misspell ] [ packages... ]                                      -- runs the tests
+   test       [ -coverage ] [ packages... ]			                                           -- runs the tests
+   lint       													                               -- runs linters
    archive    [ -arch architecture ] [ -type zip|tar ] [ -signer key-envvar ] [ -upload dest ] -- archives build artefacts
    importkeys                                                                                  -- imports signing keys from env
    debsrc     [ -signer key-id ] [ -upload dest ]                                              -- creates a debian source package
@@ -56,8 +57,8 @@ import (
 	"runtime"
 	"strings"
 	"time"
-
 	"github.com/ethereum/go-ethereum/internal/build"
+
 )
 
 var (
@@ -146,6 +147,8 @@ func main() {
 		doInstall(os.Args[2:])
 	case "test":
 		doTest(os.Args[2:])
+	case "lint":
+		doLint(os.Args[2:])
 	case "archive":
 		doArchive(os.Args[2:])
 	case "debsrc":
@@ -280,7 +283,6 @@ func goToolArch(arch string, subcmd string, args ...string) *exec.Cmd {
 
 func doTest(cmdline []string) {
 	var (
-		misspell = flag.Bool("misspell", false, "Whether to run the spell checker")
 		coverage = flag.Bool("coverage", false, "Whether to record code coverage")
 	)
 	flag.CommandLine.Parse(cmdline)
@@ -294,10 +296,7 @@ func doTest(cmdline []string) {
 
 	// Run analysis tools before the tests.
 	build.MustRun(goTool("vet", packages...))
-	if *misspell {
-		// TODO(karalabe): Reenable after false detection is fixed: https://github.com/client9/misspell/issues/105
-		// spellcheck(packages)
-	}
+
 	// Run the actual tests.
 	gotest := goTool("test", buildFlags(env)...)
 	// Test a single package at a time. CI builders are slow
@@ -306,36 +305,33 @@ func doTest(cmdline []string) {
 	if *coverage {
 		gotest.Args = append(gotest.Args, "-covermode=atomic", "-cover")
 	}
+
 	gotest.Args = append(gotest.Args, packages...)
 	build.MustRun(gotest)
 }
 
-// spellcheck runs the client9/misspell spellchecker package on all Go, Cgo and
-// test files in the requested packages.
-func spellcheck(packages []string) {
-	// Ensure the spellchecker is available
-	build.MustRun(goTool("get", "github.com/client9/misspell/cmd/misspell"))
+// runs gometalinter on requested packages
+func doLint(cmdline []string) {
 
-	// Windows chokes on long argument lists, check packages individually
-	for _, pkg := range packages {
-		// The spell checker doesn't work on packages, gather all .go files for it
-		out, err := goTool("list", "-f", "{{.Dir}}{{range .GoFiles}}\n{{.}}{{end}}{{range .CgoFiles}}\n{{.}}{{end}}{{range .TestGoFiles}}\n{{.}}{{end}}", pkg).CombinedOutput()
-		if err != nil {
-			log.Fatalf("source file listing failed: %v\n%s", err, string(out))
-		}
-		// Retrieve the folder and assemble the source list
-		lines := strings.Split(string(out), "\n")
-		root := lines[0]
+	flag.CommandLine.Parse(cmdline)
 
-		sources := make([]string, 0, len(lines)-1)
-		for _, line := range lines[1:] {
-			if line = strings.TrimSpace(line); line != "" {
-				sources = append(sources, filepath.Join(root, line))
-			}
+	packages := []string{"./..."}
+
+	if len(flag.CommandLine.Args()) > 0 {
+		packages = flag.CommandLine.Args()
+		for _, pkg := range packages {
+			packages = append(packages, fmt.Sprintf("%s/...", pkg));
 		}
-		// Run the spell checker for this particular package
-		build.MustRunCommand(filepath.Join(GOBIN, "misspell"), append([]string{"-error"}, sources...)...)
 	}
+
+
+	//get metalinter and install linters
+	build.MustRun(goTool("get", "gopkg.in/alecthomas/gometalinter.v1"))
+	build.MustRunCommand(filepath.Join(GOBIN,"gometalinter.v1"), "--install")
+
+	configs := []string{"--vendor", "--disable-all", "--enable=vet", "--enable=deadcode"} // Add additional linters to the slice with "--enable=linter-name"
+
+	build.MustRunCommand(filepath.Join(GOBIN,"gometalinter.v1"), append(configs, packages...)...)
 }
 
 // Release Packaging


### PR DESCRIPTION
build: removes misspell from test option, implements generalized linter job system for travis and ci [finishes #15372]

This PR adds a generalized lint job that can be ran on the command line, and extended with additional linters:

```go run build/ci.go lint```

It also removes the misspell option from the test run (it's implementation was problematic and commented out). If this approach is acceptable, we can add misspell as an optional linter in the new [doLint function](https://github.com/ethereum/go-ethereum/compare/master...danmelton:master#diff-75e934896def206c5aeb231d2f5c9cb9R332)

Lastly, there is a [new travis job](https://github.com/ethereum/go-ethereum/compare/master...danmelton:master#diff-354f30a63fb0907d4ad57269548329e3R53) that runs the build/ci.go lint task.