### PR TITLE
mobile: fixed FilterLogs

### DIFF
--- a/mobile/ethclient.go
+++ b/mobile/ethclient.go
@@ -198,7 +198,7 @@ func (ec *EthereumClient) FilterLogs(ctx *Context, query *FilterQuery) (logs *Lo
 	}
 	// Temp hack due to vm.Logs being []*vm.Log
 	res := make([]*types.Log, len(rawLogs))
-	for i, _ := range rawLogs {
+	for i := range rawLogs {
 		res[i] = &rawLogs[i]
 	}
 	return &Logs{res}, nil

--- a/mobile/ethclient.go
+++ b/mobile/ethclient.go
@@ -198,8 +198,8 @@ func (ec *EthereumClient) FilterLogs(ctx *Context, query *FilterQuery) (logs *Lo
 	}
 	// Temp hack due to vm.Logs being []*vm.Log
 	res := make([]*types.Log, len(rawLogs))
-	for i, log := range rawLogs {
-		res[i] = &log
+	for i, _ := range rawLogs {
+		res[i] = &rawLogs[i]
 	}
 	return &Logs{res}, nil
 }


### PR DESCRIPTION
It used to write a pointer to a local variable,
that led to fill a result array with the latest log