### PR TITLE
Fix cross compilation for --alltools

### DIFF
--- a/build/ci.go
+++ b/build/ci.go
@@ -934,6 +934,7 @@ func doXgo(cmdline []string) {
 	args := append(buildFlags(env), flag.Args()...)
 
 	if *alltools {
+		args = args[:len(args)-1]
 		args = append(args, []string{"--dest", GOBIN}...)
 		for _, res := range allToolsArchiveFiles {
 			if strings.HasPrefix(res, GOBIN) {


### PR DESCRIPTION
It appeared that the cross compilation for all tools `--alltools` was broken.