### PR TITLE
.dockerignore, internal/build: Read git information directly from file

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,5 @@
 **/.git
+/.git
 !/.git/HEAD
 !/.git/refs/heads
 **/*_test.go

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,6 @@
 **/.git
+!/.git/HEAD
+!/.git/refs/heads
 **/*_test.go
 
 build/_workspace

--- a/internal/build/env.go
+++ b/internal/build/env.go
@@ -82,18 +82,21 @@ func Env() Environment {
 // LocalEnv returns build environment metadata gathered from git.
 func LocalEnv() Environment {
 	env := applyEnvFlags(Environment{Name: "local", Repo: "ethereum/go-ethereum"})
-	if _, err := os.Stat(".git"); err != nil {
+	head := ReadGitFile("HEAD")
+	if splits := strings.Split(head, " "); len(splits) == 2 {
+		head = splits[1]
+	} else {
 		return env
 	}
 	if env.Commit == "" {
-		env.Commit = RunGit("rev-parse", "HEAD")
+		env.Commit = ReadGitFile(head)
 	}
 	if env.Branch == "" {
-		if b := RunGit("rev-parse", "--abbrev-ref", "HEAD"); b != "HEAD" {
-			env.Branch = b
+		if head != "HEAD" {
+			env.Branch = strings.TrimLeft(head, "refs/heads/")
 		}
 	}
-	if env.Tag == "" {
+	if info, err := os.Stat(".git/objects"); err == nil && info.IsDir() && env.Tag == "" {
 		env.Tag = firstLine(RunGit("tag", "-l", "--points-at", "HEAD"))
 	}
 	return env

--- a/internal/build/util.go
+++ b/internal/build/util.go
@@ -25,6 +25,7 @@ import (
 	"log"
 	"os"
 	"os/exec"
+	"path"
 	"path/filepath"
 	"runtime"
 	"strings"
@@ -86,6 +87,15 @@ func RunGit(args ...string) string {
 		log.Fatal(strings.Join(cmd.Args, " "), ": ", err, "\n", stderr.String())
 	}
 	return strings.TrimSpace(stdout.String())
+}
+
+// ReadGitFile returns content of file in .git directory.
+func ReadGitFile(file string) string {
+	content, err := ioutil.ReadFile(path.Join(".git", file))
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(content))
 }
 
 // Render renders the given template file into outputFile.


### PR DESCRIPTION
This commit changes the way of retrieving git commit and branch for build environment from running git command to reading git files directly.

This commit also adds required git files into Docker build context.

fixes: #15346 

