### PR TITLE
dockerignore, internal/build: forward correct git folder

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,7 +1,7 @@
 **/.git
-/.git
-!/.git/HEAD
-!/.git/refs/heads
+.git
+!.git/HEAD
+!.git/refs/heads
 **/*_test.go
 
 build/_workspace

--- a/internal/build/env.go
+++ b/internal/build/env.go
@@ -82,14 +82,15 @@ func Env() Environment {
 // LocalEnv returns build environment metadata gathered from git.
 func LocalEnv() Environment {
 	env := applyEnvFlags(Environment{Name: "local", Repo: "ethereum/go-ethereum"})
-	head := ReadGitFile("HEAD")
+
+	head := readGitFile("HEAD")
 	if splits := strings.Split(head, " "); len(splits) == 2 {
 		head = splits[1]
 	} else {
 		return env
 	}
 	if env.Commit == "" {
-		env.Commit = ReadGitFile(head)
+		env.Commit = readGitFile(head)
 	}
 	if env.Branch == "" {
 		if head != "HEAD" {

--- a/internal/build/util.go
+++ b/internal/build/util.go
@@ -89,8 +89,8 @@ func RunGit(args ...string) string {
 	return strings.TrimSpace(stdout.String())
 }
 
-// ReadGitFile returns content of file in .git directory.
-func ReadGitFile(file string) string {
+// readGitFile returns content of file in .git directory.
+func readGitFile(file string) string {
 	content, err := ioutil.ReadFile(path.Join(".git", file))
 	if err != nil {
 		return ""


### PR DESCRIPTION
Fixes an invalid .git folder exception in dockerignore, reduces the visibility of a utility method.

Patches up a previous PR that didn't quite work as expected https://github.com/ethereum/go-ethereum/pull/15458.