### PR TITLE
Dockerfile: support alltools image beside plain Geth

### DIFF
--- a/Dockerfile.alltools
+++ b/Dockerfile.alltools
@@ -4,13 +4,12 @@ FROM golang:1.9-alpine as builder
 RUN apk add --no-cache make gcc musl-dev linux-headers
 
 ADD . /go-ethereum
-RUN cd /go-ethereum && make geth
+RUN cd /go-ethereum && make all
 
-# Pull Geth into a second stage deploy alpine container
+# Pull all binaries into a second stage deploy alpine container
 FROM alpine:latest
 
 RUN apk add --no-cache ca-certificates
-COPY --from=builder /go-ethereum/build/bin/geth /usr/local/bin/
+COPY --from=builder /go-ethereum/build/bin/* /usr/local/bin/
 
 EXPOSE 8545 8546 30303 30303/udp 30304/udp
-ENTRYPOINT ["geth"]


### PR DESCRIPTION
This PR adds a second Dockerfile to our repo to build all the available Ethereum tools, not just `geth`.

The reason we add it as a separate dockerfile - instead of having our primary file build everything - is because although it's useful, alltools totals up to a 221MB docker image, whereas most users will only ever want geth, weighing 36.2MB.