### PR TITLE
core/state, cmd/geth: Streaming json output for  command

### DIFF
--- a/cmd/evm/runner.go
+++ b/cmd/evm/runner.go
@@ -209,7 +209,7 @@ func runCmd(ctx *cli.Context) error {
 	if ctx.GlobalBool(DumpFlag.Name) {
 		statedb.Commit(true)
 		statedb.IntermediateRoot(true)
-		fmt.Println(string(statedb.Dump()))
+		fmt.Println(string(statedb.Dump(false, false)))
 	}
 
 	if memProfilePath := ctx.GlobalString(MemProfileFlag.Name); memProfilePath != "" {

--- a/cmd/evm/runner.go
+++ b/cmd/evm/runner.go
@@ -209,7 +209,7 @@ func runCmd(ctx *cli.Context) error {
 	if ctx.GlobalBool(DumpFlag.Name) {
 		statedb.Commit(true)
 		statedb.IntermediateRoot(true)
-		fmt.Println(string(statedb.Dump(false, false)))
+		fmt.Println(string(statedb.Dump(false, false, true)))
 	}
 
 	if memProfilePath := ctx.GlobalString(MemProfileFlag.Name); memProfilePath != "" {

--- a/cmd/evm/staterunner.go
+++ b/cmd/evm/staterunner.go
@@ -105,7 +105,7 @@ func stateTestCmd(ctx *cli.Context) error {
 				// Test failed, mark as so and dump any state to aid debugging
 				result.Pass, result.Error = false, err.Error()
 				if ctx.GlobalBool(DumpFlag.Name) && state != nil {
-					dump := state.RawDump()
+					dump := state.RawDump(false, false)
 					result.State = &dump
 				}
 			}

--- a/cmd/evm/staterunner.go
+++ b/cmd/evm/staterunner.go
@@ -105,7 +105,7 @@ func stateTestCmd(ctx *cli.Context) error {
 				// Test failed, mark as so and dump any state to aid debugging
 				result.Pass, result.Error = false, err.Error()
 				if ctx.GlobalBool(DumpFlag.Name) && state != nil {
-					dump := state.RawDump(false, false)
+					dump := state.RawDump(false, false, true)
 					result.State = &dump
 				}
 			}

--- a/cmd/geth/chaincmd.go
+++ b/cmd/geth/chaincmd.go
@@ -165,7 +165,7 @@ Remove blockchain and state databases`,
 			utils.IterativeOutputFlag,
 			utils.ExcludeCodeFlag,
 			utils.ExcludeStorageFlag,
-			utils.IncludeMissingPreimagesFlag,
+			utils.IncludeIncompletesFlag,
 		},
 		Category: "BLOCKCHAIN COMMANDS",
 		Description: `
@@ -525,10 +525,10 @@ func dump(ctx *cli.Context) error {
 			if err != nil {
 				utils.Fatalf("could not create new state: %v", err)
 			}
-			excludeCode := ctx.GlobalBool(utils.ExcludeCodeFlag.Name)
-			excludeStorage := ctx.GlobalBool(utils.ExcludeStorageFlag.Name)
-			includeMissing := ctx.GlobalBool(utils.IncludeMissingPreimagesFlag.Name)
-			if ctx.GlobalBool(utils.IterativeOutputFlag.Name) {
+			excludeCode := ctx.Bool(utils.ExcludeCodeFlag.Name)
+			excludeStorage := ctx.Bool(utils.ExcludeStorageFlag.Name)
+			includeMissing := ctx.Bool(utils.IncludeIncompletesFlag.Name)
+			if ctx.Bool(utils.IterativeOutputFlag.Name) {
 				state.IterativeDump(excludeCode, excludeStorage, !includeMissing, json.NewEncoder(os.Stdout))
 			} else {
 				if includeMissing {

--- a/cmd/geth/chaincmd.go
+++ b/cmd/geth/chaincmd.go
@@ -162,6 +162,9 @@ Remove blockchain and state databases`,
 			utils.DataDirFlag,
 			utils.CacheFlag,
 			utils.SyncModeFlag,
+			utils.IterativeOutputFlag,
+			utils.ExcludeCodeFlag,
+			utils.ExcludeStorageFlag,
 		},
 		Category: "BLOCKCHAIN COMMANDS",
 		Description: `
@@ -287,7 +290,7 @@ func importChain(ctx *cli.Context) error {
 	fmt.Printf("Allocations:   %.3f million\n", float64(mem.Mallocs)/1000000)
 	fmt.Printf("GC pause:      %v\n\n", time.Duration(mem.PauseTotalNs))
 
-	if ctx.GlobalIsSet(utils.NoCompactionFlag.Name) {
+	if ctx.GlobalBool(utils.NoCompactionFlag.Name) {
 		return nil
 	}
 
@@ -520,7 +523,13 @@ func dump(ctx *cli.Context) error {
 			if err != nil {
 				utils.Fatalf("could not create new state: %v", err)
 			}
-			fmt.Printf("%s\n", state.Dump())
+			excludeCode := ctx.GlobalBool(utils.ExcludeCodeFlag.Name)
+			excludeStorage := ctx.GlobalBool(utils.ExcludeStorageFlag.Name)
+			if ctx.GlobalBool(utils.IterativeOutputFlag.Name) {
+				state.IterativeDump(excludeCode, excludeStorage, json.NewEncoder(os.Stdout))
+			} else {
+				fmt.Printf("%s\n", state.Dump(excludeCode, excludeStorage))
+			}
 		}
 	}
 	chainDb.Close()

--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -193,6 +193,7 @@ var (
 		utils.IterativeOutputFlag,
 		utils.ExcludeCodeFlag,
 		utils.ExcludeStorageFlag,
+		utils.IncludeMissingPreimagesFlag,
 	}
 )
 

--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -188,6 +188,12 @@ var (
 		utils.MetricsInfluxDBPasswordFlag,
 		utils.MetricsInfluxDBTagsFlag,
 	}
+
+	dumpFlags = []cli.Flag{
+		utils.IterativeOutputFlag,
+		utils.ExcludeCodeFlag,
+		utils.ExcludeStorageFlag,
+	}
 )
 
 func init() {
@@ -231,6 +237,7 @@ func init() {
 	app.Flags = append(app.Flags, debug.Flags...)
 	app.Flags = append(app.Flags, whisperFlags...)
 	app.Flags = append(app.Flags, metricsFlags...)
+	app.Flags = append(app.Flags, dumpFlags...)
 
 	app.Before = func(ctx *cli.Context) error {
 		logdir := ""

--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -188,13 +188,6 @@ var (
 		utils.MetricsInfluxDBPasswordFlag,
 		utils.MetricsInfluxDBTagsFlag,
 	}
-
-	dumpFlags = []cli.Flag{
-		utils.IterativeOutputFlag,
-		utils.ExcludeCodeFlag,
-		utils.ExcludeStorageFlag,
-		utils.IncludeMissingPreimagesFlag,
-	}
 )
 
 func init() {
@@ -238,7 +231,6 @@ func init() {
 	app.Flags = append(app.Flags, debug.Flags...)
 	app.Flags = append(app.Flags, whisperFlags...)
 	app.Flags = append(app.Flags, metricsFlags...)
-	app.Flags = append(app.Flags, dumpFlags...)
 
 	app.Before = func(ctx *cli.Context) error {
 		logdir := ""

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -197,20 +197,20 @@ var (
 		Usage: "List of trusted ULC servers",
 	}
 	IterativeOutputFlag = cli.BoolFlag{
-		Name:  "dump.iterative",
-		Usage: "Print streaming JSON iteratively as json objects, delimited by newlines",
+		Name:  "iterative",
+		Usage: "Print streaming JSON iteratively, delimited by newlines",
 	}
 	ExcludeStorageFlag = cli.BoolFlag{
-		Name:  "dump.nostorage",
-		Usage: "When set, exclude storage entries (saves db lookups)",
+		Name:  "nostorage",
+		Usage: "Exclude storage entries (save db lookups)",
 	}
-	IncludeMissingPreimagesFlag = cli.BoolFlag{
-		Name:  "dump.includeincomplete",
-		Usage: "When set, include also those we do not have address of (missing preimage)",
+	IncludeIncompletesFlag = cli.BoolFlag{
+		Name:  "incompletes",
+		Usage: "Include accounts for which we don't have the address (missing preimage)",
 	}
 	ExcludeCodeFlag = cli.BoolFlag{
-		Name:  "dump.nocode",
-		Usage: "When set, exclude contract code (saves db lookups)",
+		Name:  "nocode",
+		Usage: "Exclude contract code (save db lookups)",
 	}
 	defaultSyncMode = eth.DefaultConfig.SyncMode
 	SyncModeFlag    = TextMarshalerFlag{

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -196,6 +196,18 @@ var (
 		Name:  "ulc.trusted",
 		Usage: "List of trusted ULC servers",
 	}
+	IterativeOutputFlag = cli.BoolFlag{
+		Name:  "dump.iterative",
+		Usage: "Print streaming JSON iteratively as json objects, delimited by newlines",
+	}
+	ExcludeStorageFlag = cli.BoolFlag{
+		Name:  "dump.nostorage",
+		Usage: "When set, exclude storage entries (saves db lookups)",
+	}
+	ExcludeCodeFlag = cli.BoolFlag{
+		Name:  "dump.nocode",
+		Usage: "When set, exclude contract code (saves db lookups)",
+	}
 	defaultSyncMode = eth.DefaultConfig.SyncMode
 	SyncModeFlag    = TextMarshalerFlag{
 		Name:  "syncmode",

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -204,6 +204,10 @@ var (
 		Name:  "dump.nostorage",
 		Usage: "When set, exclude storage entries (saves db lookups)",
 	}
+	IncludeMissingPreimagesFlag = cli.BoolFlag{
+		Name:  "dump.includeincomplete",
+		Usage: "When set, include also those we do not have address of (missing preimage)",
+	}
 	ExcludeCodeFlag = cli.BoolFlag{
 		Name:  "dump.nocode",
 		Usage: "When set, exclude contract code (saves db lookups)",

--- a/core/state/dump.go
+++ b/core/state/dump.go
@@ -33,8 +33,8 @@ type DumpAccount struct {
 	Nonce     uint64                 `json:"nonce"`
 	Root      string                 `json:"root"`
 	CodeHash  string                 `json:"codeHash"`
-	Code      string                 `json:"code"`
-	Storage   map[common.Hash]string `json:"storage"`
+	Code      string                 `json:"code,omitempty"`
+	Storage   map[common.Hash]string `json:"storage,omitempty"`
 	Address   *common.Address        `json:"address,omitempty"` // Address only present in iterative (line-by-line) mode
 	SecureKey hexutil.Bytes          `json:"key,omitempty"`     // If we don't have address, we can output the key
 

--- a/core/state/dump.go
+++ b/core/state/dump.go
@@ -19,9 +19,9 @@ package state
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/ethereum/go-ethereum/common/hexutil"
 
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/rlp"
 	"github.com/ethereum/go-ethereum/trie"

--- a/core/state/dump.go
+++ b/core/state/dump.go
@@ -21,61 +21,128 @@ import (
 	"fmt"
 
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/rlp"
 	"github.com/ethereum/go-ethereum/trie"
 )
 
+// DumpAccount represents an account in the state
 type DumpAccount struct {
-	Balance  string            `json:"balance"`
-	Nonce    uint64            `json:"nonce"`
-	Root     string            `json:"root"`
-	CodeHash string            `json:"codeHash"`
-	Code     string            `json:"code"`
-	Storage  map[string]string `json:"storage"`
-}
-
-type Dump struct {
+	Balance  string                 `json:"balance"`
+	Nonce    uint64                 `json:"nonce"`
 	Root     string                 `json:"root"`
-	Accounts map[string]DumpAccount `json:"accounts"`
+	CodeHash string                 `json:"codeHash"`
+	Code     string                 `json:"code"`
+	Storage  map[common.Hash]string `json:"storage"`
+	Address  *common.Address        `json:"address,omitempty"` // Address only present in iterative (line-by-line) mode
 }
 
-func (self *StateDB) RawDump() Dump {
-	dump := Dump{
-		Root:     fmt.Sprintf("%x", self.trie.Hash()),
-		Accounts: make(map[string]DumpAccount),
-	}
+// Dump represents the full dump in a collected format, as one large map
+type Dump struct {
+	Root     string                         `json:"root"`
+	Accounts map[common.Address]DumpAccount `json:"accounts"`
+}
 
+// iterativeDump is a 'collector'-implementation which dump output line-by-line iteratively
+type iterativeDump json.Encoder
+
+// Collector interface which the state trie calls during iteration
+type collector interface {
+	onRoot(common.Hash)
+	onAccount(common.Address, DumpAccount)
+}
+
+func (self *Dump) onRoot(root common.Hash) {
+	self.Root = fmt.Sprintf("%x", root)
+}
+
+func (self *Dump) onAccount(addr common.Address, account DumpAccount) {
+	self.Accounts[addr] = account
+}
+
+func (self iterativeDump) onAccount(addr common.Address, account DumpAccount) {
+	dumpAccount := &DumpAccount{
+		Balance:  account.Balance,
+		Nonce:    account.Nonce,
+		Root:     account.Root,
+		CodeHash: account.CodeHash,
+		Code:     account.Code,
+		Storage:  account.Storage,
+		Address:  nil,
+	}
+	if addr != (common.Address{}) {
+		dumpAccount.Address = &addr
+	}
+	(*json.Encoder)(&self).Encode(dumpAccount)
+}
+func (self iterativeDump) onRoot(root common.Hash) {
+	(*json.Encoder)(&self).Encode(struct {
+		Root common.Hash `json:"root"`
+	}{root})
+}
+
+func (self *StateDB) dump(c collector, excludeCode, excludeStorage bool) {
+	emptyAddress := (common.Address{})
+	missingPreimages := 0
+	c.onRoot(self.trie.Hash())
 	it := trie.NewIterator(self.trie.NodeIterator(nil))
 	for it.Next() {
-		addr := self.trie.GetKey(it.Key)
+		addr := common.BytesToAddress(self.trie.GetKey(it.Key))
+		if emptyAddress == addr {
+			// We don't have the preimage. All accounts missing preimages
+			// will be 'mapped' and overwrite the same entry, which is quite useless.
+			// Make note and continue
+			missingPreimages++
+			continue
+		}
 		var data Account
 		if err := rlp.DecodeBytes(it.Value, &data); err != nil {
 			panic(err)
 		}
-
-		obj := newObject(nil, common.BytesToAddress(addr), data)
+		obj := newObject(nil, addr, data)
 		account := DumpAccount{
 			Balance:  data.Balance.String(),
 			Nonce:    data.Nonce,
 			Root:     common.Bytes2Hex(data.Root[:]),
 			CodeHash: common.Bytes2Hex(data.CodeHash),
-			Code:     common.Bytes2Hex(obj.Code(self.db)),
-			Storage:  make(map[string]string),
 		}
-		storageIt := trie.NewIterator(obj.getTrie(self.db).NodeIterator(nil))
-		for storageIt.Next() {
-			account.Storage[common.Bytes2Hex(self.trie.GetKey(storageIt.Key))] = common.Bytes2Hex(storageIt.Value)
+		if !excludeCode {
+			account.Code = common.Bytes2Hex(obj.Code(self.db))
 		}
-		dump.Accounts[common.Bytes2Hex(addr)] = account
+		if !excludeStorage {
+			account.Storage = make(map[common.Hash]string)
+			storageIt := trie.NewIterator(obj.getTrie(self.db).NodeIterator(nil))
+			for storageIt.Next() {
+				account.Storage[common.BytesToHash(self.trie.GetKey(storageIt.Key))] = common.Bytes2Hex(storageIt.Value)
+			}
+		}
+		c.onAccount(addr, account)
 	}
-	return dump
+	if missingPreimages > 0 {
+		log.Warn("Dump incomplete due to missing preimages", "missing", missingPreimages)
+	}
 }
 
-func (self *StateDB) Dump() []byte {
-	json, err := json.MarshalIndent(self.RawDump(), "", "    ")
+// RawDump returns the entire state an a single large object
+func (self *StateDB) RawDump(excludeCode, excludeStorage bool) Dump {
+	dump := &Dump{
+		Accounts: make(map[common.Address]DumpAccount),
+	}
+	self.dump(dump, excludeCode, excludeStorage)
+	return *dump
+}
+
+// Dump returns a JSON string representing the entire state as a single json-object
+func (self *StateDB) Dump(excludeCode, excludeStorage bool) []byte {
+	dump := self.RawDump(excludeCode, excludeStorage)
+	json, err := json.MarshalIndent(dump, "", "  ")
 	if err != nil {
 		fmt.Println("dump err", err)
 	}
-
 	return json
+}
+
+// IterativeDump dumps out accounts as json-objects, delimited by linebreaks on stdout
+func (self *StateDB) IterativeDump(excludeCode, excludeStorage bool, output *json.Encoder) {
+	self.dump(iterativeDump(*output), excludeCode, excludeStorage)
 }

--- a/core/state/state_test.go
+++ b/core/state/state_test.go
@@ -52,7 +52,7 @@ func (s *StateSuite) TestDump(c *checker.C) {
 	s.state.Commit(false)
 
 	// check that dump contains the state objects that are in trie
-	got := string(s.state.Dump())
+	got := string(s.state.Dump(false, false))
 	want := `{
     "root": "71edff0130dd2385947095001c73d9e28d862fc286fca2b922ca6f6f3cddfdd2",
     "accounts": {

--- a/core/state/state_test.go
+++ b/core/state/state_test.go
@@ -60,25 +60,20 @@ func (s *StateSuite) TestDump(c *checker.C) {
             "balance": "22",
             "nonce": 0,
             "root": "56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421",
-            "codeHash": "c5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
-            "code": "",
-            "storage": {}
+            "codeHash": "c5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470"
         },
         "0x0000000000000000000000000000000000000002": {
             "balance": "44",
             "nonce": 0,
             "root": "56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421",
-            "codeHash": "c5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
-            "code": "",
-            "storage": {}
+            "codeHash": "c5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470"
         },
         "0x0000000000000000000000000000000000000102": {
             "balance": "0",
             "nonce": 0,
             "root": "56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421",
             "codeHash": "87874902497a5bb968da31a2998d8f22e949d1ef6214bcdedd8bae24cca4b9e3",
-            "code": "03030303030303",
-            "storage": {}
+            "code": "03030303030303"
         }
     }
 }`

--- a/core/state/state_test.go
+++ b/core/state/state_test.go
@@ -52,11 +52,11 @@ func (s *StateSuite) TestDump(c *checker.C) {
 	s.state.Commit(false)
 
 	// check that dump contains the state objects that are in trie
-	got := string(s.state.Dump(false, false))
+	got := string(s.state.Dump(false, false, true))
 	want := `{
     "root": "71edff0130dd2385947095001c73d9e28d862fc286fca2b922ca6f6f3cddfdd2",
     "accounts": {
-        "0000000000000000000000000000000000000001": {
+        "0x0000000000000000000000000000000000000001": {
             "balance": "22",
             "nonce": 0,
             "root": "56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421",
@@ -64,7 +64,7 @@ func (s *StateSuite) TestDump(c *checker.C) {
             "code": "",
             "storage": {}
         },
-        "0000000000000000000000000000000000000002": {
+        "0x0000000000000000000000000000000000000002": {
             "balance": "44",
             "nonce": 0,
             "root": "56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421",
@@ -72,7 +72,7 @@ func (s *StateSuite) TestDump(c *checker.C) {
             "code": "",
             "storage": {}
         },
-        "0000000000000000000000000000000000000102": {
+        "0x0000000000000000000000000000000000000102": {
             "balance": "0",
             "nonce": 0,
             "root": "56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421",

--- a/eth/api.go
+++ b/eth/api.go
@@ -266,7 +266,7 @@ func (api *PublicDebugAPI) DumpBlock(blockNr rpc.BlockNumber) (state.Dump, error
 		// both the pending block as well as the pending state from
 		// the miner and operate on those
 		_, stateDb := api.eth.miner.Pending()
-		return stateDb.RawDump(), nil
+		return stateDb.RawDump(false, false), nil
 	}
 	var block *types.Block
 	if blockNr == rpc.LatestBlockNumber {
@@ -281,7 +281,7 @@ func (api *PublicDebugAPI) DumpBlock(blockNr rpc.BlockNumber) (state.Dump, error
 	if err != nil {
 		return state.Dump{}, err
 	}
-	return stateDb.RawDump(), nil
+	return stateDb.RawDump(false, false), nil
 }
 
 // PrivateDebugAPI is the collection of Ethereum full node APIs exposed over

--- a/eth/api.go
+++ b/eth/api.go
@@ -266,7 +266,7 @@ func (api *PublicDebugAPI) DumpBlock(blockNr rpc.BlockNumber) (state.Dump, error
 		// both the pending block as well as the pending state from
 		// the miner and operate on those
 		_, stateDb := api.eth.miner.Pending()
-		return stateDb.RawDump(false, false), nil
+		return stateDb.RawDump(false, false, true), nil
 	}
 	var block *types.Block
 	if blockNr == rpc.LatestBlockNumber {
@@ -281,7 +281,7 @@ func (api *PublicDebugAPI) DumpBlock(blockNr rpc.BlockNumber) (state.Dump, error
 	if err != nil {
 		return state.Dump{}, err
 	}
-	return stateDb.RawDump(false, false), nil
+	return stateDb.RawDump(false, false, true), nil
 }
 
 // PrivateDebugAPI is the collection of Ethereum full node APIs exposed over


### PR DESCRIPTION
Currently, doing a dump of the entire state results in a ~9G large json file, which is very heavy to process. 

This PR makes it possible to dump out the state in a more machine-friendly manner, whereby the dump output consists of a stream of json-objects, the first line containing the state `root`, and each line afterwards representing an account in the trie. Thus, a consumer of the resulting output does not need to have the full 9 Gb in memory during processing, nor does the `geth` export node.  



### Examples

Existing functionality:
```
build/bin/geth --datadir /tmp/foo  dump  0  | head
WARN [11-13|21:37:49] No etherbase set and no accounts found as default 
INFO [11-13|21:37:49] Allocated cache and file handles         database=/tmp/foo/geth/chaindata cache=128 handles=1024
INFO [11-13|21:37:49] Disk storage enabled for ethash caches   dir=/tmp/foo/geth/ethash count=3
INFO [11-13|21:37:49] Disk storage enabled for ethash DAGs     dir=/home/martin/.ethash count=2
INFO [11-13|21:37:49] Loaded most recent local header          number=0 hash=d4e567…cb8fa3 td=17179869184
INFO [11-13|21:37:49] Loaded most recent local full block      number=0 hash=d4e567…cb8fa3 td=17179869184
INFO [11-13|21:37:49] Loaded most recent local fast block      number=0 hash=d4e567…cb8fa3 td=17179869184
{
    "root": "d7f8974fb5ac78d9ac099b9ad5018bedc2ce0a72dad1827a1709da30580f0544",
    "accounts": {
        "000d836201318ec6899a67540690382780743280": {
            "balance": "200000000000000000000",
            "nonce": 0,
            "root": "56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421",
            "codeHash": "c5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
            "code": "",
            "storage": {}
```
New functionality:
```
build/bin/geth --datadir /tmp/foo --iterative  dump  0  | head
WARN [11-13|21:37:55] No etherbase set and no accounts found as default 
INFO [11-13|21:37:55] Allocated cache and file handles         database=/tmp/foo/geth/chaindata cache=128 handles=1024
INFO [11-13|21:37:55] Disk storage enabled for ethash caches   dir=/tmp/foo/geth/ethash count=3
INFO [11-13|21:37:55] Disk storage enabled for ethash DAGs     dir=/home/martin/.ethash count=2
INFO [11-13|21:37:55] Loaded most recent local header          number=0 hash=d4e567…cb8fa3 td=17179869184
INFO [11-13|21:37:55] Loaded most recent local full block      number=0 hash=d4e567…cb8fa3 td=17179869184
INFO [11-13|21:37:55] Loaded most recent local fast block      number=0 hash=d4e567…cb8fa3 td=17179869184
{"root":"d7f8974fb5ac78d9ac099b9ad5018bedc2ce0a72dad1827a1709da30580f0544"}
{"address":"ae34861d342253194ffc6652dfde51ab44cad3fe","balance":"466215000000000000000","nonce":0,"root":"56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421","codeHash":"c5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470","code":"","storage":{}}
{"address":"e6115b13f9795f7e956502d5074567dab945ce6b","balance":"100000000000000000000000","nonce":0,"root":"56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421","codeHash":"c5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470","code":"","storage":{}}
{"address":"9d069197d1de50045a186f5ec744ac40e8af91c6","balance":"2000000000000000000000","nonce":0,"root":"56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421","codeHash":"c5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470","code":"","storage":{}}
{"address":"1895a0eb4a4372722fcbc5afe6936f289c88a419","balance":"910000000000000000000","nonce":0,"root":"56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421","codeHash":"c5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470","code":"","storage":{}}
{"address":"2d5b42fc59ebda0dfd66ae914bc28c1b0a6ef83a","balance":"206764195000000000000000","nonce":0,"root":"56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421","codeHash":"c5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470","code":"","storage":{}}
{"address":"4a81abe4984c7c6bef63d69820e55743c61f201c","balance":"16011846000000000000000","nonce":0,"root":"56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421","codeHash":"c5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470","code":"","storage":{}}
{"address":"4989e1ab5e7cd00746b3938ef0f0d064a2025ba5","balance":"2000000000000000000000","nonce":0,"root":"56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421","codeHash":"c5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470","code":"","storage":{}}
{"address":"f114ff0d0f24eff896edde5471dea484824a99b3","balance":"13700000000000000000","nonce":0,"root":"56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421","codeHash":"c5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470","code":"","storage":{}}
{"address":"92c13fe0d6ce87fd50e03def9fa6400509bd7073","balance":"40000000000000000000","nonce":0,"root":"56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421","codeHash":"c5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470","code":"","storage":{}}

```