### PR TITLE
eth: fix debug.storageRangeAt return value

### DIFF
--- a/eth/api.go
+++ b/eth/api.go
@@ -615,14 +615,18 @@ func (api *PrivateDebugAPI) StorageRangeAt(ctx context.Context, blockHash common
 	if st == nil {
 		return StorageRangeResult{}, fmt.Errorf("account %x doesn't exist", contractAddress)
 	}
-	return storageRangeAt(st, keyStart, maxResult), nil
+	return storageRangeAt(st, keyStart, maxResult)
 }
 
-func storageRangeAt(st state.Trie, start []byte, maxResult int) StorageRangeResult {
+func storageRangeAt(st state.Trie, start []byte, maxResult int) (StorageRangeResult, error) {
 	it := trie.NewIterator(st.NodeIterator(start))
 	result := StorageRangeResult{Storage: storageMap{}}
 	for i := 0; i < maxResult && it.Next(); i++ {
-		e := storageEntry{Value: common.BytesToHash(it.Value)}
+		_, content, _, err := rlp.Split(it.Value)
+		if err != nil {
+			return StorageRangeResult{}, err
+		}
+		e := storageEntry{Value: common.BytesToHash(content)}
 		if preimage := st.GetKey(it.Key); preimage != nil {
 			preimage := common.BytesToHash(preimage)
 			e.Key = &preimage
@@ -634,5 +638,5 @@ func storageRangeAt(st state.Trie, start []byte, maxResult int) StorageRangeResu
 		next := common.BytesToHash(it.Key)
 		result.NextKey = &next
 	}
-	return result
+	return result, nil
 }

--- a/eth/api_test.go
+++ b/eth/api_test.go
@@ -79,7 +79,10 @@ func TestStorageRangeAt(t *testing.T) {
 		},
 	}
 	for _, test := range tests {
-		result := storageRangeAt(state.StorageTrie(addr), test.start, test.limit)
+		result, err := storageRangeAt(state.StorageTrie(addr), test.start, test.limit)
+		if err != nil {
+			t.Error(err)
+		}
 		if !reflect.DeepEqual(result, test.want) {
 			t.Fatalf("wrong result for range 0x%x.., limit %d:\ngot %s\nwant %s",
 				test.start, test.limit, dumper.Sdump(result), dumper.Sdump(&test.want))


### PR DESCRIPTION
This PR Fixes #15196  

- debug.storageRangeAt uses the rlp.Split function to return the content of the RLP values.
- Modify the test function in the case Split returns an error.

To test this PR I deployed on Rinkeby this contract:
```
contract test {
    uint v = 128;
}
```
The modification can be checked with this call:
```
> debug.storageRangeAt("0xd1a9569e5b5a482db6ac6c2a9fc9eddc58f49be1b8c4bff7c638239993708ceb", 0, "0xb9f998b90b2bfe93f0f34a2db45c3f70938d4fb7", "0x", 1)
```
It should return 0x80 instead of 0x8180 before.