### PR TITLE
core/vm: fix typos in jump_table.go

### DIFF
--- a/core/vm/jump_table.go
+++ b/core/vm/jump_table.go
@@ -42,12 +42,12 @@ type operation struct {
 	// memorySize returns the memory size required for the operation
 	memorySize memorySizeFunc
 
-	halts   bool // indicates whether the operation shoult halt further execution
+	halts   bool // indicates whether the operation should halt further execution
 	jumps   bool // indicates whether the program counter should not increment
 	writes  bool // determines whether this a state modifying operation
 	valid   bool // indication whether the retrieved operation is valid and known
 	reverts bool // determines whether the operation reverts state (implicitly halts)
-	returns bool // determines whether the opertions sets the return data content
+	returns bool // determines whether the operations sets the return data content
 }
 
 var (


### PR DESCRIPTION
Fix typos in jump_table.go