### PR TITLE
core/bloombits: handle non 8-bit boundary section matches

### DIFF
--- a/core/bloombits/matcher.go
+++ b/core/bloombits/matcher.go
@@ -192,10 +192,12 @@ func (m *Matcher) Start(ctx context.Context, begin, end uint64, results chan uin
 				}
 				// Iterate over all the blocks in the section and return the matching ones
 				for i := first; i <= last; i++ {
-					// Skip the entire byte if no matches are found inside
+					// Skip the entire byte if no matches are found inside (and we're processing an entire byte!)
 					next := res.bitset[(i-sectionStart)/8]
 					if next == 0 {
-						i += 7
+						if i%8 == 0 {
+							i += 7
+						}
 						continue
 					}
 					// Some bit it set, do the actual submatching

--- a/eth/filters/filter.go
+++ b/eth/filters/filter.go
@@ -158,6 +158,7 @@ func (f *Filter) indexedLogs(ctx context.Context, end uint64) ([]*types.Log, err
 				return logs, err
 			}
 			f.begin = int64(number) + 1
+
 			// Retrieve the suggested block and pull any truly matching logs
 			header, err := f.backend.HeaderByNumber(ctx, rpc.BlockNumber(number))
 			if header == nil || err != nil {


### PR DESCRIPTION
In our bloombits matcher, we maintain matched blocks via a `[]byte` bitset. After filtering the blocks and generating the final bitset, we iterate over the block interval and check whether they match according to the bitset.

Since the bitset contains bytes, if a bitset element is zero, we can skip ahead 8 blocks, since none of them will match. **This has a subtlety that we got wrong.** If we start filtering from a block number that's not a multiple of 8, then we **can't** skip ahead 8 blocks when finding a zero bitset element, only `8 - number % 8` elements, since skipping 8 would overlap with the next byte in the bitset.

This PR fixes it by only skipping 8 blocks if we're at a bitset byte boundary, otherwise just increment blocks 1-by-1 until we do reach a byte boundary.

Fixes https://github.com/ethereum/go-ethereum/issues/15309.