### PR TITLE
rpc: allow dumb empty requests for AWS health checks

### DIFF
--- a/rpc/http.go
+++ b/rpc/http.go
@@ -146,13 +146,17 @@ func NewHTTPServer(cors []string, srv *Server) *http.Server {
 
 // ServeHTTP serves JSON-RPC requests over HTTP.
 func (srv *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	// Permit dumb empty requests for remote health-checks (AWS)
+	if r.Method == "GET" && r.ContentLength == 0 && r.URL.RawQuery == "" {
+		return
+	}
+	// For meaningful requests, validate it's size and content type
 	if r.ContentLength > maxHTTPRequestContentLength {
 		http.Error(w,
 			fmt.Sprintf("content length too large (%d>%d)", r.ContentLength, maxHTTPRequestContentLength),
 			http.StatusRequestEntityTooLarge)
 		return
 	}
-
 	ct := r.Header.Get("content-type")
 	mt, _, err := mime.ParseMediaType(ct)
 	if err != nil || mt != "application/json" {
@@ -161,14 +165,13 @@ func (srv *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			http.StatusUnsupportedMediaType)
 		return
 	}
-
-	w.Header().Set("content-type", "application/json")
-
-	// create a codec that reads direct from the request body until
-	// EOF and writes the response to w and order the server to process
-	// a single request.
+	// All checks passed, create a codec that reads direct from the request body
+	// untilEOF and writes the response to w and order the server to process a
+	// single request.
 	codec := NewJSONCodec(&httpReadWriteNopCloser{r.Body, w})
 	defer codec.Close()
+
+	w.Header().Set("content-type", "application/json")
 	srv.ServeSingleRequest(codec, OptionMethodInvocation)
 }
 


### PR DESCRIPTION
A while back, in https://github.com/ethereum/go-ethereum/pull/15220 we've introduced an extra limitation in our HTTP RPC to reject all requests that do not have `application/json` as the content type. This was needed to prevent the circumvention of CORS checks in certain browsers.

This however meant that dumb, empty HTTP GET requests now return a failure. Whilst this sounds a good idea, it also breaks the AWS load balancer health checks, as those simply issue a GET on load balanced ports and kill the backing services if they don't reply with 200 https://github.com/ethereum/go-ethereum/issues/15490.

This PR makes a special case exception, so that if someone sends an **empty** HTTP GET request to our HTTP RPC endpoint, instead of rejecting it, we just return immediately, causing a 200 code.