### PR TITLE
accounts/keystore: change modtime for test case files to be bigger than 1sec.

### DIFF
--- a/accounts/keystore/account_cache_test.go
+++ b/accounts/keystore/account_cache_test.go
@@ -349,6 +349,7 @@ func TestUpdatedKeyfileContents(t *testing.T) {
 		return
 	}
 
+	// needed so that modTime of `file` is different to its current value after forceCopyFile
 	time.Sleep(1000 * time.Millisecond)
 
 	// Now replace file contents
@@ -364,6 +365,7 @@ func TestUpdatedKeyfileContents(t *testing.T) {
 		return
 	}
 
+	// needed so that modTime of `file` is different to its current value after forceCopyFile
 	time.Sleep(1000 * time.Millisecond)
 
 	// Now replace file contents again
@@ -379,6 +381,7 @@ func TestUpdatedKeyfileContents(t *testing.T) {
 		return
 	}
 
+	// needed so that modTime of `file` is different to its current value after ioutil.WriteFile
 	time.Sleep(1000 * time.Millisecond)
 
 	// Now replace file contents with crap

--- a/accounts/keystore/account_cache_test.go
+++ b/accounts/keystore/account_cache_test.go
@@ -59,7 +59,7 @@ func TestWatchNewFile(t *testing.T) {
 
 	// Ensure the watcher is started before adding any files.
 	ks.Accounts()
-	time.Sleep(200 * time.Millisecond)
+	time.Sleep(1000 * time.Millisecond)
 
 	// Move in the files.
 	wantAccounts := make([]accounts.Account, len(cachetestAccounts))
@@ -349,6 +349,8 @@ func TestUpdatedKeyfileContents(t *testing.T) {
 		return
 	}
 
+	time.Sleep(1000 * time.Millisecond)
+
 	// Now replace file contents
 	if err := forceCopyFile(file, cachetestAccounts[1].URL.Path); err != nil {
 		t.Fatal(err)
@@ -362,6 +364,8 @@ func TestUpdatedKeyfileContents(t *testing.T) {
 		return
 	}
 
+	time.Sleep(1000 * time.Millisecond)
+
 	// Now replace file contents again
 	if err := forceCopyFile(file, cachetestAccounts[2].URL.Path); err != nil {
 		t.Fatal(err)
@@ -374,6 +378,9 @@ func TestUpdatedKeyfileContents(t *testing.T) {
 		t.Error(err)
 		return
 	}
+
+	time.Sleep(1000 * time.Millisecond)
+
 	// Now replace file contents with crap
 	if err := ioutil.WriteFile(file, []byte("foo"), 0644); err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
On OSX Sierra `FileInfo.ModTime` always returns `nsec=0`, which breaks the algorithm at `fileCache.scanFiles`. A simple fix is to make sure that changes to keystore files in tests do not happen within the same second.