### PR TITLE
accounts/abi: Implement Parsing for Struct Types

### DIFF
--- a/accounts/abi/type.go
+++ b/accounts/abi/type.go
@@ -24,6 +24,7 @@ import (
 	"strings"
 )
 
+// Type enumerator
 const (
 	IntTy byte = iota
 	UintTy
@@ -37,6 +38,7 @@ const (
 	HashTy
 	FixedPointTy
 	FunctionTy
+	StructTy
 )
 
 // Type is the reflection of the supported argument type
@@ -58,21 +60,96 @@ var (
 
 // NewType creates a new reflection type of abi type given in t.
 func NewType(t string) (typ Type, err error) {
-	// check that array brackets are equal if they exist
-	if strings.Count(t, "[") != strings.Count(t, "]") {
-		return Type{}, fmt.Errorf("invalid arg type in abi")
-	}
-
-	typ.stringKind = t
 
 	// if there are brackets, get ready to go into slice/array mode and
 	// recursively create the type
+	var found bool
+	if typ, found, err = checkForSlices(t); found == true || err != nil {
+		return typ, err
+	}
+
+	typ.stringKind = t
+	// parse the type and size of the abi-type.
+	parsedType := typeRegex.FindAllStringSubmatch(t, -1)[0]
+	// varSize is the size of the variable
+	var varSize int
+	if len(parsedType[3]) > 0 {
+		var err error
+		varSize, err = strconv.Atoi(parsedType[2])
+		if err != nil {
+			return Type{}, fmt.Errorf("abi: error parsing variable size: %v", err)
+		}
+	} else {
+		if parsedType[0] == "uint" || parsedType[0] == "int" {
+			// this should fail because it means that there's something wrong with
+			// the abi type (the compiler should always format it to the size...always)
+			return Type{}, fmt.Errorf("unsupported arg type: %s", t)
+		}
+	}
+	// varType is the parsed abi type
+	switch varType := parsedType[1]; varType {
+	case "int":
+		typ.Kind, typ.Type = reflectIntKindAndType(false, varSize)
+		typ.Size = varSize
+		typ.T = IntTy
+	case "uint":
+		typ.Kind, typ.Type = reflectIntKindAndType(true, varSize)
+		typ.Size = varSize
+		typ.T = UintTy
+	case "bool":
+		typ.Kind = reflect.Bool
+		typ.T = BoolTy
+		typ.Type = reflect.TypeOf(bool(false))
+	case "address":
+		typ.Kind = reflect.Array
+		typ.Type = address_t
+		typ.Size = 20
+		typ.T = AddressTy
+	case "string":
+		typ.Kind = reflect.String
+		typ.Type = reflect.TypeOf("")
+		typ.T = StringTy
+	case "bytes":
+		if varSize == 0 {
+			typ.T = BytesTy
+			typ.Kind = reflect.Slice
+			typ.Type = reflect.SliceOf(reflect.TypeOf(byte(0)))
+		} else {
+			typ.T = FixedBytesTy
+			typ.Kind = reflect.Array
+			typ.Size = varSize
+			typ.Type = reflect.ArrayOf(varSize, reflect.TypeOf(byte(0)))
+		}
+	case "function":
+		typ.Kind = reflect.Array
+		typ.T = FunctionTy
+		typ.Size = 24
+		typ.Type = reflect.ArrayOf(24, reflect.TypeOf(byte(0)))
+	default:
+		return Type{}, fmt.Errorf("unsupported arg type: %s", t)
+	}
+
+	return
+}
+
+// if brackets surround the type, create it recursively, otherwise note that brackets weren't found
+func checkForSlices(t string, structComponents ...unmarshalArg) (typ Type, found bool, err error) {
+	// check that array brackets are equal if they exist
+	if strings.Count(t, "[") != strings.Count(t, "]") {
+		return Type{}, false, fmt.Errorf("invalid arg type in abi")
+	}
+
 	if strings.Count(t, "[") != 0 {
 		i := strings.LastIndex(t, "[")
 		// recursively embed the type
-		embeddedType, err := NewType(t[:i])
+		var embeddedType Type
+		if len(structComponents) > 0 {
+			embeddedType, err = ParseStructType(t, structComponents...)
+		} else {
+			embeddedType, err = NewType(t[:i])
+		}
 		if err != nil {
-			return Type{}, err
+			return Type{}, false, err
 		}
 		// grab the last cell and create a type from there
 		sliced := t[i:]
@@ -93,78 +170,46 @@ func NewType(t string) (typ Type, err error) {
 			typ.Elem = &embeddedType
 			typ.Size, err = strconv.Atoi(intz[0])
 			if err != nil {
-				return Type{}, fmt.Errorf("abi: error parsing variable size: %v", err)
+				return Type{}, false, fmt.Errorf("abi: error parsing variable size: %v", err)
 			}
 			typ.Type = reflect.ArrayOf(typ.Size, embeddedType.Type)
 		} else {
-			return Type{}, fmt.Errorf("invalid formatting of array type")
+			return Type{}, false, fmt.Errorf("invalid formatting of array type")
 		}
-		return typ, err
-	} else {
-		// parse the type and size of the abi-type.
-		parsedType := typeRegex.FindAllStringSubmatch(t, -1)[0]
-		// varSize is the size of the variable
-		var varSize int
-		if len(parsedType[3]) > 0 {
-			var err error
-			varSize, err = strconv.Atoi(parsedType[2])
-			if err != nil {
-				return Type{}, fmt.Errorf("abi: error parsing variable size: %v", err)
-			}
-		} else {
-			if parsedType[0] == "uint" || parsedType[0] == "int" {
-				// this should fail because it means that there's something wrong with
-				// the abi type (the compiler should always format it to the size...always)
-				return Type{}, fmt.Errorf("unsupported arg type: %s", t)
-			}
-		}
-		// varType is the parsed abi type
-		varType := parsedType[1]
-
-		switch varType {
-		case "int":
-			typ.Kind, typ.Type = reflectIntKindAndType(false, varSize)
-			typ.Size = varSize
-			typ.T = IntTy
-		case "uint":
-			typ.Kind, typ.Type = reflectIntKindAndType(true, varSize)
-			typ.Size = varSize
-			typ.T = UintTy
-		case "bool":
-			typ.Kind = reflect.Bool
-			typ.T = BoolTy
-			typ.Type = reflect.TypeOf(bool(false))
-		case "address":
-			typ.Kind = reflect.Array
-			typ.Type = address_t
-			typ.Size = 20
-			typ.T = AddressTy
-		case "string":
-			typ.Kind = reflect.String
-			typ.Type = reflect.TypeOf("")
-			typ.T = StringTy
-		case "bytes":
-			if varSize == 0 {
-				typ.T = BytesTy
-				typ.Kind = reflect.Slice
-				typ.Type = reflect.SliceOf(reflect.TypeOf(byte(0)))
-			} else {
-				typ.T = FixedBytesTy
-				typ.Kind = reflect.Array
-				typ.Size = varSize
-				typ.Type = reflect.ArrayOf(varSize, reflect.TypeOf(byte(0)))
-			}
-		case "function":
-			typ.Kind = reflect.Array
-			typ.T = FunctionTy
-			typ.Size = 24
-			typ.Type = reflect.ArrayOf(24, reflect.TypeOf(byte(0)))
-		default:
-			return Type{}, fmt.Errorf("unsupported arg type: %s", t)
-		}
+		return typ, true, err
 	}
+	return Type{}, false, nil
+}
 
-	return
+func ParseStructType(t string, components ...unmarshalArg) (typ Type, err error) {
+	// if there are brackets, get ready to go into slice/array mode and
+	// recursively create the type
+	var found bool
+	if typ, found, err = checkForSlices(t, components...); found == true || err != nil {
+		return typ, err
+	}
+	typ.stringKind = t
+	typ.T = StructTy
+	typ.Kind = reflect.Struct
+	// create the struct type
+	var fields []reflect.StructField
+	for i, component := range components {
+		// it's a embedded struct type
+		var fieldType Type
+
+		if len(component.Components) > 0 {
+			fieldType, err = ParseStructType(component.Type, component.Components...)
+		} else {
+			fieldType, err = NewType(component.Type)
+		}
+
+		if err != nil {
+			return Type{}, err
+		}
+		fields[i] = reflect.StructField{Name: component.Name, Type: fieldType.Type, Tag: reflect.StructTag(fmt.Sprintf(`json:"%v"`, component.Name))}
+	}
+	typ.Type = reflect.StructOf(fields)
+	return typ, nil
 }
 
 // String implements Stringer

--- a/accounts/abi/type_test.go
+++ b/accounts/abi/type_test.go
@@ -115,15 +115,86 @@ func TestStructParse(t *testing.T) {
 	}{
 		{
 			unmarshalArg{Name: "s", Type: "tuple", Components: []unmarshalArg{unmarshalArg{Name: "a", Type: "uint256"}, unmarshalArg{Name: "b", Type: "uint256[]"}, unmarshalArg{Name: "c", Type: "tuple[]", Components: []unmarshalArg{unmarshalArg{Name: "x", Type: "uint256"}, unmarshalArg{Name: "y", Type: "uint256"}}}}},
-			Type{Kind: reflect.Struct, T: StructTy, Type: reflect.TypeOf(
-				struct {
-					A *big.Int   `json:"a"`
-					B []*big.Int `json:"b"`
-					C []struct {
-						X *big.Int `json:"x"`
-						Y *big.Int `json:"y"`
-					} `json:"c"`
-				}{}), stringKind: "(uint256,uint256[],(uint256,uint256)[])"},
+			Type{
+				Kind:       reflect.Struct,
+				T:          StructTy,
+				stringKind: "(uint256,uint256[],(uint256,uint256)[])",
+				Type: reflect.TypeOf(
+					struct {
+						A *big.Int   `json:"a"`
+						B []*big.Int `json:"b"`
+						C []struct {
+							X *big.Int `json:"x"`
+							Y *big.Int `json:"y"`
+						} `json:"c"`
+					}{},
+				),
+			},
+		},
+		{
+			unmarshalArg{Name: "s", Type: "tuple[]", Components: []unmarshalArg{unmarshalArg{Name: "a", Type: "string"}, unmarshalArg{Name: "b", Type: "bytes32"}, unmarshalArg{Name: "c", Type: "tuple[]", Components: []unmarshalArg{unmarshalArg{Name: "x", Type: "string"}, unmarshalArg{Name: "y", Type: "string"}}}}},
+			Type{
+				Kind:       reflect.Slice,
+				T:          SliceTy,
+				stringKind: "(string,bytes32,(string,string)[])[]",
+				Type: reflect.TypeOf(
+					[]struct {
+						A string   `json:"a"`
+						B [32]byte `json:"b"`
+						C []struct {
+							X string `json:"x"`
+							Y string `json:"y"`
+						} `json:"c"`
+					}{},
+				),
+				Elem: &Type{
+					Kind:       reflect.Struct,
+					T:          StructTy,
+					stringKind: "(string,bytes32,(string,string)[])",
+					Type: reflect.TypeOf(
+						struct {
+							A string   `json:"a"`
+							B [32]byte `json:"b"`
+							C []struct {
+								X string `json:"x"`
+								Y string `json:"y"`
+							} `json:"c"`
+						}{}),
+				},
+			},
+		},
+		{
+			unmarshalArg{Name: "s", Type: "tuple[3]", Components: []unmarshalArg{unmarshalArg{Name: "a", Type: "string"}, unmarshalArg{Name: "b", Type: "bytes32"}, unmarshalArg{Name: "c", Type: "tuple[]", Components: []unmarshalArg{unmarshalArg{Name: "x", Type: "string"}, unmarshalArg{Name: "y", Type: "string"}}}}},
+			Type{
+				Kind:       reflect.Array,
+				T:          ArrayTy,
+				Size:       3,
+				stringKind: "(string,bytes32,(string,string)[])[3]",
+				Type: reflect.TypeOf(
+					[3]struct {
+						A string   `json:"a"`
+						B [32]byte `json:"b"`
+						C []struct {
+							X string `json:"x"`
+							Y string `json:"y"`
+						} `json:"c"`
+					}{},
+				),
+				Elem: &Type{
+					Kind:       reflect.Struct,
+					T:          StructTy,
+					stringKind: "(string,bytes32,(string,string)[])",
+					Type: reflect.TypeOf(
+						struct {
+							A string   `json:"a"`
+							B [32]byte `json:"b"`
+							C []struct {
+								X string `json:"x"`
+								Y string `json:"y"`
+							} `json:"c"`
+						}{}),
+				},
+			},
 		},
 	} {
 		newStruct, err := ParseStructType(test.input.Name, test.input.Components...)

--- a/accounts/abi/type_test.go
+++ b/accounts/abi/type_test.go
@@ -107,6 +107,40 @@ func TestTypeRegexp(t *testing.T) {
 	}
 }
 
+// Sample structs for struct parsing test
+
+type (
+	S struct {
+		A *big.Int
+		B []*big.Int
+		C []struct {
+			X *big.Int
+			Y *big.Int
+		}
+	}
+)
+
+func TestStructParse(t *testing.T) {
+
+	for i, test := range []struct {
+		input          unmarshalArg
+		expectedOutput Type
+	}{
+		{
+			unmarshalArg{Name: "s", Type: "tuple", Components: []unmarshalArg{unmarshalArg{Name: "a", Type: "uint256"}, unmarshalArg{Name: "b", Type: "uint256[]"}, unmarshalArg{Name: "c", Type: "tuple[]", Components: []unmarshalArg{unmarshalArg{Name: "x", Type: "uint256"}, unmarshalArg{Name: "y", Type: "uint256"}}}}},
+			Type{Kind: reflect.Struct, T: StructTy, Type: reflect.TypeOf(S{}), stringKind: "(uint256,uint256[],(uint256,uint256)[])"},
+		},
+	} {
+		newStruct, err := ParseStructType(test.input.Name, test.input.Components...)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !reflect.DeepEqual(newStruct, test.expectedOutput) {
+			t.Errorf("test %v: parsed type mismatch:\nGOT %v\nWANT %v ", i, newStruct, test.expectedOutput)
+		}
+	}
+}
+
 func TestTypeCheck(t *testing.T) {
 	for i, test := range []struct {
 		typ   string

--- a/accounts/abi/type_test.go
+++ b/accounts/abi/type_test.go
@@ -197,7 +197,7 @@ func TestStructParse(t *testing.T) {
 			},
 		},
 	} {
-		newStruct, err := ParseStructType(test.input.Name, test.input.Components...)
+		newStruct, err := ParseStructType(test.input.Type, test.input.Components...)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/accounts/abi/type_test.go
+++ b/accounts/abi/type_test.go
@@ -107,19 +107,6 @@ func TestTypeRegexp(t *testing.T) {
 	}
 }
 
-// Sample structs for struct parsing test
-
-type (
-	S struct {
-		A *big.Int
-		B []*big.Int
-		C []struct {
-			X *big.Int
-			Y *big.Int
-		}
-	}
-)
-
 func TestStructParse(t *testing.T) {
 
 	for i, test := range []struct {
@@ -128,7 +115,15 @@ func TestStructParse(t *testing.T) {
 	}{
 		{
 			unmarshalArg{Name: "s", Type: "tuple", Components: []unmarshalArg{unmarshalArg{Name: "a", Type: "uint256"}, unmarshalArg{Name: "b", Type: "uint256[]"}, unmarshalArg{Name: "c", Type: "tuple[]", Components: []unmarshalArg{unmarshalArg{Name: "x", Type: "uint256"}, unmarshalArg{Name: "y", Type: "uint256"}}}}},
-			Type{Kind: reflect.Struct, T: StructTy, Type: reflect.TypeOf(S{}), stringKind: "(uint256,uint256[],(uint256,uint256)[])"},
+			Type{Kind: reflect.Struct, T: StructTy, Type: reflect.TypeOf(
+				struct {
+					A *big.Int   `json:"a"`
+					B []*big.Int `json:"b"`
+					C []struct {
+						X *big.Int `json:"x"`
+						Y *big.Int `json:"y"`
+					} `json:"c"`
+				}{}), stringKind: "(uint256,uint256[],(uint256,uint256)[])"},
 		},
 	} {
 		newStruct, err := ParseStructType(test.input.Name, test.input.Components...)
@@ -136,7 +131,7 @@ func TestStructParse(t *testing.T) {
 			t.Fatal(err)
 		}
 		if !reflect.DeepEqual(newStruct, test.expectedOutput) {
-			t.Errorf("test %v: parsed type mismatch:\nGOT %v\nWANT %v ", i, newStruct, test.expectedOutput)
+			t.Errorf("test %v: parsed type mismatch:\nGOT %v\nWANT %v ", i, spew.Sdump(typeWithoutStringer(newStruct)), spew.Sdump(typeWithoutStringer(test.expectedOutput)))
 		}
 	}
 }


### PR DESCRIPTION
This PR contains parsing for tuple types (aka Structs) in the ABI. This is a fairly new feature and figured I'd help ya'll get there at the least. This does not contain packing or unpacking. Those will come in a later PR when I have time to work on it. 