### PR TITLE
p2p/discv5: print out self node for v5 discovery.

### DIFF
--- a/p2p/discv5/udp.go
+++ b/p2p/discv5/udp.go
@@ -247,6 +247,7 @@ func ListenUDP(priv *ecdsa.PrivateKey, laddr string, natm nat.Interface, nodeDBP
 		return nil, err
 	}
 	transport.net = net
+	log.Info("UDP listener up", "self", net.tab.self)
 	go transport.readLoop()
 	return net, nil
 }


### PR DESCRIPTION
To keep same behavior as default discovery protocol, and also it's convenient for the user.