### PR TITLE
cmd/geth: fix passing datadir flag to attach subcommand

### DIFF
--- a/cmd/geth/consolecmd.go
+++ b/cmd/geth/consolecmd.go
@@ -17,6 +17,7 @@
 package main
 
 import (
+	"fmt"
 	"os"
 	"os/signal"
 	"strings"
@@ -112,7 +113,11 @@ func localConsole(ctx *cli.Context) error {
 // console to it.
 func remoteConsole(ctx *cli.Context) error {
 	// Attach to a remotely running geth instance and start the JavaScript console
-	client, err := dialRPC(ctx.Args().First())
+	endpoint := ctx.Args().First()
+	if endpoint == "" && ctx.GlobalIsSet(utils.DataDirFlag.Name) {
+		endpoint = fmt.Sprintf("%s/geth.ipc", ctx.GlobalString(utils.DataDirFlag.Name))
+	}
+	client, err := dialRPC(endpoint)
 	if err != nil {
 		utils.Fatalf("Unable to attach to remote geth: %v", err)
 	}


### PR DESCRIPTION
the datadir flag wasn't respected, instead you had to provide an
additional argument, which was unclear from a usage point of view

Signed-off-by: Maximilian Meister <mmeister@suse.de>

I tried the following on a private network:
```
geth --datadir /etc/testnet/miner attach
Fatal: Unable to attach to remote geth: dial unix /root/.ethereum/geth.ipc: connect: no such file or directory
command terminated with exit code 1
```