### PR TITLE
accounts/keystore: prevent key-loading in `geth account new`

### DIFF
--- a/accounts/keystore/keystore.go
+++ b/accounts/keystore/keystore.go
@@ -75,10 +75,19 @@ type unlocked struct {
 	abort chan struct{}
 }
 
-// NewKeyStore creates a keystore for the given directory.
-func NewKeyStore(keydir string, scryptN, scryptP int) *KeyStore {
+// NewUninitializedKeyStore creates a keystore for the given directory, but does not load the existing keys
+func NewUninitializedKeyStore(keydir string, scryptN, scryptP int) *KeyStore {
 	keydir, _ = filepath.Abs(keydir)
 	ks := &KeyStore{storage: &keyStorePassphrase{keydir, scryptN, scryptP}}
+	// Initialize the set of unlocked keys and the account cache
+	ks.unlocked = make(map[common.Address]*unlocked)
+	ks.cache, ks.changes = newAccountCache(keydir)
+	return ks
+}
+
+// NewKeyStore creates a keystore for the given directory.
+func NewKeyStore(keydir string, scryptN, scryptP int) *KeyStore {
+	ks := NewUninitializedKeyStore(keydir, scryptN, scryptP)
 	ks.init(keydir)
 	return ks
 }
@@ -88,18 +97,18 @@ func NewKeyStore(keydir string, scryptN, scryptP int) *KeyStore {
 func NewPlaintextKeyStore(keydir string) *KeyStore {
 	keydir, _ = filepath.Abs(keydir)
 	ks := &KeyStore{storage: &keyStorePlain{keydir}}
+	// Initialize the set of unlocked keys and the account cache
+	ks.unlocked = make(map[common.Address]*unlocked)
+	ks.cache, ks.changes = newAccountCache(keydir)
 	ks.init(keydir)
 	return ks
 }
 
+// init initalizes the keystore by loading the accounts
 func (ks *KeyStore) init(keydir string) {
 	// Lock the mutex since the account cache might call back with events
 	ks.mu.Lock()
 	defer ks.mu.Unlock()
-
-	// Initialize the set of unlocked keys and the account cache
-	ks.unlocked = make(map[common.Address]*unlocked)
-	ks.cache, ks.changes = newAccountCache(keydir)
 
 	// TODO: In order for this finalizer to work, there must be no references
 	// to ks. addressCache doesn't keep a reference but unlocked keys do,

--- a/accounts/keystore/keystore.go
+++ b/accounts/keystore/keystore.go
@@ -412,12 +412,22 @@ func (ks *KeyStore) expire(addr common.Address, u *unlocked, timeout time.Durati
 	}
 }
 
-// NewAccount generates a new key and stores it into the key directory,
+// CreateNewAccount generates a new key and stores it into the key directory,
 // encrypting it with the passphrase.
-func (ks *KeyStore) NewAccount(passphrase string) (accounts.Account, error) {
+func (ks *KeyStore) CreateNewAccount(passphrase string) (accounts.Account, error) {
 	_, account, err := storeNewKey(ks.storage, crand.Reader, passphrase)
 	if err != nil {
 		return accounts.Account{}, err
+	}
+	return account, nil
+}
+
+// NewAccount generates a new key and stores it into the key directory,
+// encrypting it with the passphrase, and adds it to the cache
+func (ks *KeyStore) NewAccount(passphrase string) (accounts.Account, error) {
+	account, err := ks.CreateNewAccount(passphrase)
+	if err != nil {
+		return account, err
 	}
 	// Add the account to the cache immediately rather
 	// than waiting for file system notifications to pick it up.

--- a/cmd/geth/accountcmd.go
+++ b/cmd/geth/accountcmd.go
@@ -26,6 +26,7 @@ import (
 	"github.com/ethereum/go-ethereum/console"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/log"
+	"github.com/ethereum/go-ethereum/node"
 	"gopkg.in/urfave/cli.v1"
 )
 
@@ -292,17 +293,10 @@ func ambiguousAddrRecovery(ks *keystore.KeyStore, err *keystore.AmbiguousAddrErr
 // accountCreate creates a new account into the keystore defined by the CLI flags.
 func accountCreate(ctx *cli.Context) error {
 	cfg := createConfig(ctx)
-	scryptN := keystore.StandardScryptN
-	scryptP := keystore.StandardScryptP
+	ks, _, err := node.MakeKeystoreBackend(&cfg.Node, false)
 
-	if cfg.Node.UseLightweightKDF {
-		scryptN = keystore.LightScryptN
-		scryptP = keystore.LightScryptP
-	}
 	password := getPassPhrase("Your new account is locked with a password. Please give a password. Do not forget this password.", true, 0, utils.MakePasswordList(ctx))
-	ks := keystore.NewUninitializedKeyStore(cfg.Node.KeyStoreDir, scryptN, scryptP)
-
-	account, err := ks.NewAccount(password)
+	account, err := ks.CreateNewAccount(password)
 	if err != nil {
 		utils.Fatalf("Failed to create account: %v", err)
 	}

--- a/cmd/geth/config.go
+++ b/cmd/geth/config.go
@@ -109,7 +109,7 @@ func defaultNodeConfig() node.Config {
 	return cfg
 }
 
-func makeConfigNode(ctx *cli.Context) (*node.Node, gethConfig) {
+func createConfig(ctx *cli.Context) gethConfig {
 	// Load defaults.
 	cfg := gethConfig{
 		Eth:       eth.DefaultConfig,
@@ -124,9 +124,13 @@ func makeConfigNode(ctx *cli.Context) (*node.Node, gethConfig) {
 			utils.Fatalf("%v", err)
 		}
 	}
-
 	// Apply flags.
 	utils.SetNodeConfig(ctx, &cfg.Node)
+	return cfg
+}
+
+func makeConfigNode(ctx *cli.Context) (*node.Node, gethConfig) {
+	cfg := createConfig(ctx)
 	stack, err := node.New(&cfg.Node)
 	if err != nil {
 		utils.Fatalf("Failed to create the protocol stack: %v", err)


### PR DESCRIPTION
The changes introduced in https://github.com/ethereum/go-ethereum/pull/15171 made an initial scan of the filesystem performed upon startup. This had an adverse effect in the case where geth was not actually intended to run in normal 'daemon'-mode, but was only meant for brief `geth account new`. 

This PR makes the `geth account new` _not_ configure a complete full node, but instead initalize a keystore directly. When doing so, it can avoind to load all existing files from the keystore directory. 

Fixes https://github.com/ethereum/go-ethereum/issues/15511. 

On commit `88b1db728826efd499ea407579f41e8b683d6b53` (with 55k accounts):

```
#time yes | build/bin/geth --datadir ~/tmp/account_gen account  new
Your new account is locked with a password. Please give a password. Do not forget this password.
!! Unsupported terminal, password will be echoed.
Passphrase: 
Repeat passphrase: 
Address: {b3d522cbff4c47cfeee5252e29729b52ada68b3a}

real	0m46.971s
user	0m49.480s
sys	0m1.524s

```

With this PR: 

``` 
#time yes | build/bin/geth --datadir ~/tmp/account_gen account  new
Your new account is locked with a password. Please give a password. Do not forget this password.
!! Unsupported terminal, password will be echoed.
Passphrase: 
Repeat passphrase: 
Address: {a9486ada158b8dc2e2008dbbc20351f81f7af95f}

real	0m0.743s
user	0m0.712s
sys	0m0.040s

```