### PR TITLE
 mobile, ethclient, core/types: enable filtering on pending/latest logs

### DIFF
--- a/core/types/gen_log_json.go
+++ b/core/types/gen_log_json.go
@@ -10,6 +10,8 @@ import (
 	"github.com/ethereum/go-ethereum/common/hexutil"
 )
 
+var _ = (*logMarshaling)(nil)
+
 func (l Log) MarshalJSON() ([]byte, error) {
 	type Log struct {
 		Address     common.Address `json:"address" gencodec:"required"`
@@ -17,9 +19,9 @@ func (l Log) MarshalJSON() ([]byte, error) {
 		Data        hexutil.Bytes  `json:"data" gencodec:"required"`
 		BlockNumber hexutil.Uint64 `json:"blockNumber"`
 		TxHash      common.Hash    `json:"transactionHash" gencodec:"required"`
-		TxIndex     hexutil.Uint   `json:"transactionIndex" gencodec:"required"`
+		TxIndex     hexutil.Uint   `json:"transactionIndex"`
 		BlockHash   common.Hash    `json:"blockHash"`
-		Index       hexutil.Uint   `json:"logIndex" gencodec:"required"`
+		Index       hexutil.Uint   `json:"logIndex"`
 		Removed     bool           `json:"removed"`
 	}
 	var enc Log
@@ -42,9 +44,9 @@ func (l *Log) UnmarshalJSON(input []byte) error {
 		Data        hexutil.Bytes   `json:"data" gencodec:"required"`
 		BlockNumber *hexutil.Uint64 `json:"blockNumber"`
 		TxHash      *common.Hash    `json:"transactionHash" gencodec:"required"`
-		TxIndex     *hexutil.Uint   `json:"transactionIndex" gencodec:"required"`
+		TxIndex     *hexutil.Uint   `json:"transactionIndex"`
 		BlockHash   *common.Hash    `json:"blockHash"`
-		Index       *hexutil.Uint   `json:"logIndex" gencodec:"required"`
+		Index       *hexutil.Uint   `json:"logIndex"`
 		Removed     *bool           `json:"removed"`
 	}
 	var dec Log
@@ -70,17 +72,15 @@ func (l *Log) UnmarshalJSON(input []byte) error {
 		return errors.New("missing required field 'transactionHash' for Log")
 	}
 	l.TxHash = *dec.TxHash
-	if dec.TxIndex == nil {
-		return errors.New("missing required field 'transactionIndex' for Log")
+	if dec.TxIndex != nil {
+		l.TxIndex = uint(*dec.TxIndex)
 	}
-	l.TxIndex = uint(*dec.TxIndex)
 	if dec.BlockHash != nil {
 		l.BlockHash = *dec.BlockHash
 	}
-	if dec.Index == nil {
-		return errors.New("missing required field 'logIndex' for Log")
+	if dec.Index != nil {
+		l.Index = uint(*dec.Index)
 	}
-	l.Index = uint(*dec.Index)
 	if dec.Removed != nil {
 		l.Removed = *dec.Removed
 	}

--- a/core/types/log.go
+++ b/core/types/log.go
@@ -45,11 +45,11 @@ type Log struct {
 	// hash of the transaction
 	TxHash common.Hash `json:"transactionHash" gencodec:"required"`
 	// index of the transaction in the block
-	TxIndex uint `json:"transactionIndex" gencodec:"required"`
+	TxIndex uint `json:"transactionIndex"`
 	// hash of the block in which the transaction was included
 	BlockHash common.Hash `json:"blockHash"`
 	// index of the log in the receipt
-	Index uint `json:"logIndex" gencodec:"required"`
+	Index uint `json:"logIndex"`
 
 	// The Removed field is true if this log was reverted due to a chain reorganisation.
 	// You must pay attention to this field if you receive logs through a filter query.

--- a/ethclient/ethclient.go
+++ b/ethclient/ethclient.go
@@ -257,6 +257,14 @@ func toBlockNumArg(number *big.Int) string {
 	if number == nil {
 		return "latest"
 	}
+	switch number.Int64() {
+	case rpc.PendingBlockNumber.Int64():
+		return "pending"
+	case rpc.LatestBlockNumber.Int64():
+		return "latest"
+	case rpc.EarliestBlockNumber.Int64():
+		return "earliest"
+	}
 	return hexutil.EncodeBig(number)
 }
 

--- a/ethclient/ethclient.go
+++ b/ethclient/ethclient.go
@@ -257,12 +257,11 @@ func toBlockNumArg(number *big.Int) string {
 	if number == nil {
 		return "latest"
 	}
-	switch number.Int64() {
-	case rpc.PendingBlockNumber.Int64():
+	if number.Cmp(big.NewInt(rpc.PendingBlockNumber.Int64())) == 0 {
 		return "pending"
-	case rpc.LatestBlockNumber.Int64():
+	} else if number.Cmp(big.NewInt(rpc.LatestBlockNumber.Int64())) == 0 {
 		return "latest"
-	case rpc.EarliestBlockNumber.Int64():
+	} else if number.Cmp(big.NewInt(rpc.EarliestBlockNumber.Int64())) == 0 {
 		return "earliest"
 	}
 	return hexutil.EncodeBig(number)

--- a/mobile/ethclient.go
+++ b/mobile/ethclient.go
@@ -23,6 +23,15 @@ import (
 
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/ethclient"
+	"github.com/ethereum/go-ethereum/rpc"
+)
+
+const (
+	PendingBlockNumber = int(rpc.PendingBlockNumber)
+
+	LatestBlockNumber = int(rpc.LatestBlockNumber)
+
+	EarliestBlockNumber = int(rpc.EarliestBlockNumber)
 )
 
 // EthereumClient provides access to the Ethereum APIs.


### PR DESCRIPTION
**Problem:**

currently in Mobile clients, there is no possibility to filter logs on Ethereum special blocks ('latest'/'pending'/'earliest'), when using either `EthereumClient.filterLogs` or `EthereumClient.subscribeFilterLogs`.
This should be done using the `setFrom/ToBlock` methods of `FilterQuery`, but input is `BigInt`, and there's no provided way to specify this special arguments.

There are already predefined consts at [types.go](https://github.com/ethereum/go-ethereum/blob/e063d538b80d2edfc3c2b374aaee4e38e2145170/rpc/types.go#L122), but in mobile the're not in use, and when marshlling block number to Json string at [`ethclient.toBlockNumArg`](https://github.com/ethereum/go-ethereum/blob/d78ad226c26c84635c60fad233de9e6e438a5599/ethclient/ethclient.go#L256), there is no logic to marshall those special blocks. (thus, trying to put manually this consts number, results with an error of: `go.Universe$proxyerror: Invalid params: Invalid block number: invalid digit found in string.`)

**Solution**
expose those consts at Mobile level, so it can be use as input to 'block number' parameters, and marshal those consts value to the special blocks for json.
as pending logs might contains empty transaction index and index, relax the gencodec 'required' parameter so generated json parser will allow empty values. 
