### PR TITLE
accounts: fix two races in the account manager

### DIFF
--- a/accounts/keystore/file_cache.go
+++ b/accounts/keystore/file_cache.go
@@ -1,0 +1,102 @@
+// Copyright 2017 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+package keystore
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/ethereum/go-ethereum/log"
+	set "gopkg.in/fatih/set.v0"
+)
+
+// fileCache is a cache of files seen during scan of keystore.
+type fileCache struct {
+	all     *set.SetNonTS // Set of all files from the keystore folder
+	lastMod time.Time     // Last time instance when a file was modified
+	mu      sync.RWMutex
+}
+
+// scan performs a new scan on the given directory, compares against the already
+// cached filenames, and returns file sets: creates, deletes, updates.
+func (fc *fileCache) scan(keyDir string) (set.Interface, set.Interface, set.Interface, error) {
+	t0 := time.Now()
+
+	// List all the failes from the keystore folder
+	files, err := ioutil.ReadDir(keyDir)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	t1 := time.Now()
+
+	fc.mu.Lock()
+	defer fc.mu.Unlock()
+
+	// Iterate all the files and gather their metadata
+	all := set.NewNonTS()
+	mods := set.NewNonTS()
+
+	var newLastMod time.Time
+	for _, fi := range files {
+		// Skip any non-key files from the folder
+		path := filepath.Join(keyDir, fi.Name())
+		if skipKeyFile(fi) {
+			log.Trace("Ignoring file on account scan", "path", path)
+			continue
+		}
+		// Gather the set of all and fresly modified files
+		all.Add(path)
+
+		modified := fi.ModTime()
+		if modified.After(fc.lastMod) {
+			mods.Add(path)
+		}
+		if modified.After(newLastMod) {
+			newLastMod = modified
+		}
+	}
+	t2 := time.Now()
+
+	// Update the tracked files and return the three sets
+	deletes := set.Difference(fc.all, all)   // Deletes = previous - current
+	creates := set.Difference(all, fc.all)   // Creates = current - previous
+	updates := set.Difference(mods, creates) // Updates = modified - creates
+
+	fc.all, fc.lastMod = all, newLastMod
+	t3 := time.Now()
+
+	// Report on the scanning stats and return
+	log.Debug("FS scan times", "list", t1.Sub(t0), "set", t2.Sub(t1), "diff", t3.Sub(t2))
+	return creates, deletes, updates, nil
+}
+
+// skipKeyFile ignores editor backups, hidden files and folders/symlinks.
+func skipKeyFile(fi os.FileInfo) bool {
+	// Skip editor backups and UNIX-style hidden files.
+	if strings.HasSuffix(fi.Name(), "~") || strings.HasPrefix(fi.Name(), ".") {
+		return true
+	}
+	// Skip misc special files, directories (yes, symlinks too).
+	if fi.IsDir() || fi.Mode()&os.ModeType != 0 {
+		return true
+	}
+	return false
+}

--- a/accounts/manager.go
+++ b/accounts/manager.go
@@ -41,17 +41,17 @@ type Manager struct {
 // NewManager creates a generic account manager to sign transaction via various
 // supported backends.
 func NewManager(backends ...Backend) *Manager {
+	// Retrieve the initial list of wallets from the backends and sort by URL
+	var wallets []Wallet
+	for _, backend := range backends {
+		wallets = merge(wallets, backend.Wallets()...)
+	}
 	// Subscribe to wallet notifications from all backends
 	updates := make(chan WalletEvent, 4*len(backends))
 
 	subs := make([]event.Subscription, len(backends))
 	for i, backend := range backends {
 		subs[i] = backend.Subscribe(updates)
-	}
-	// Retrieve the initial list of wallets from the backends and sort by URL
-	var wallets []Wallet
-	for _, backend := range backends {
-		wallets = merge(wallets, backend.Wallets()...)
 	}
 	// Assemble the account manager and return
 	am := &Manager{


### PR DESCRIPTION
The first commit in the PR fixes an init/run data race in the `account.Manager`: Listing the wallets from a backend has the side effect that a filesystem scan will be run and anything new will fire a wallet event. The wallet event is forwarded to anyone subscribed.

The issue was that the `account.Manager` first subscribed to wallet events, then did an account listing, and only afterwards fired up the goroutine to consume the subscriptions. If the keystore contained more than 8 accounts, the wallet listing actually fired 8+ events, overflowing the manager's subscription and blocking. But since the manager itself is firing the events internally from the listing, it cannot consume them, locking itself up.

The issue is simple enough to correct, do the initial scan of the wallets first, and only afterwards subscribe to events. Note, this **might** in rare cases cause an account not to be detected (if it's created after the manager lists the accounts and before it gets to the subscriptions). But that should be picked up at the next fs scan some seconds later, so it's not **that** bad.

---

The second commit moves the `keystore.fileCache` to its own file to keep the `account_cache.go` file a bit shorter and cleaner. Apart from minor polishes the commit also fixes a data race in the directory scanning: currently the scan itself can run concurrently, and only saving the results is done in sync. This is not correct, because "gathering" the results depends already on the previous state (notably the modification time). Two concurrent scans results in the same files being gathered as new, the first obtaining the lock reports them as new, the second reports them as modified. The result is that all accounts get added, deleted and readded to the keystore account cache for every concurrent scan. 

The solution here is to just make the folder metadata scan lock the entire file cache. The lock is held for 50ms anyway, so it's not a heavy congestion, and can make the code cleaner and simpler to reason about.