### PR TITLE
accounts/keystore: Ignore initial trigger of rescan-event

### DIFF
--- a/accounts/keystore/watch.go
+++ b/accounts/keystore/watch.go
@@ -81,10 +81,14 @@ func (w *watcher) loop() {
 	// When an event occurs, the reload call is delayed a bit so that
 	// multiple events arriving quickly only cause a single reload.
 	var (
-		debounce         = time.NewTimer(0)
 		debounceDuration = 500 * time.Millisecond
 		rescanTriggered  = false
+		debounce         = time.NewTimer(0)
 	)
+	// Ignore initial trigger
+	if !debounce.Stop() {
+		<-debounce.C
+	}
 	defer debounce.Stop()
 	for {
 		select {


### PR DESCRIPTION
We're not doing the initial scan from the `watch`, which is there to react to fs events. Thus we can ignore the initial trigger, which is just a side-effect of being unable to create an unitialized timer. 