### PR TITLE
Fix issue with geth account new

### DIFF
--- a/accounts/keystore/keystore_passphrase.go
+++ b/accounts/keystore/keystore_passphrase.go
@@ -91,21 +91,10 @@ func (ks keyStorePassphrase) GetKey(addr common.Address, filename, auth string) 
 	return key, nil
 }
 
-func StoreKey(dir, auth string, scryptN, scryptP int) (error, common.Address) {
-	key, err := newKey(crand.Reader)
-	if err != nil {
-		return err, common.Address{}
-	}
-	keyjson, err := EncryptKey(key, auth, scryptN, scryptP)
-	if err != nil {
-		return err, common.Address{}
-	}
-	fullpath := filepath.Join(dir, keyFileName(key.Address))
-	err = writeKeyFile(fullpath, keyjson)
-	if err != nil {
-		return err, common.Address{}
-	}
-	return nil, key.Address
+// StoreKey generates a key, encrypts with 'auth' and stores in the given directory
+func StoreKey(dir, auth string, scryptN, scryptP int) (common.Address, error) {
+	_, a, err := storeNewKey(&keyStorePassphrase{dir, scryptN, scryptP}, crand.Reader, auth)
+	return a.Address, err
 }
 
 func (ks keyStorePassphrase) StoreKey(filename string, key *Key, auth string) error {

--- a/cmd/geth/accountcmd.go
+++ b/cmd/geth/accountcmd.go
@@ -291,7 +291,7 @@ func ambiguousAddrRecovery(ks *keystore.KeyStore, err *keystore.AmbiguousAddrErr
 
 // accountCreate creates a new account into the keystore defined by the CLI flags.
 func accountCreate(ctx *cli.Context) error {
-	cfg := gethConfig{}
+	cfg := gethConfig{Node: defaultNodeConfig()}
 	// Load config file.
 	if file := ctx.GlobalString(configFileFlag.Name); file != "" {
 		if err := loadConfig(file, &cfg); err != nil {

--- a/cmd/geth/accountcmd.go
+++ b/cmd/geth/accountcmd.go
@@ -302,7 +302,7 @@ func accountCreate(ctx *cli.Context) error {
 	scryptN, scryptP, keydir, err := cfg.Node.AccountConfig()
 
 	if err != nil {
-		utils.Fatalf("Failed to create account: %v", err)
+		utils.Fatalf("Failed to read configuration: %v", err)
 	}
 
 	password := getPassPhrase("Your new account is locked with a password. Please give a password. Do not forget this password.", true, 0, utils.MakePasswordList(ctx))

--- a/cmd/geth/accountcmd.go
+++ b/cmd/geth/accountcmd.go
@@ -26,7 +26,6 @@ import (
 	"github.com/ethereum/go-ethereum/console"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/log"
-	"github.com/ethereum/go-ethereum/node"
 	"gopkg.in/urfave/cli.v1"
 )
 
@@ -292,7 +291,6 @@ func ambiguousAddrRecovery(ks *keystore.KeyStore, err *keystore.AmbiguousAddrErr
 
 // accountCreate creates a new account into the keystore defined by the CLI flags.
 func accountCreate(ctx *cli.Context) error {
-
 	cfg := gethConfig{}
 	// Load config file.
 	if file := ctx.GlobalString(configFileFlag.Name); file != "" {
@@ -301,7 +299,7 @@ func accountCreate(ctx *cli.Context) error {
 		}
 	}
 	utils.SetNodeConfig(ctx, &cfg.Node)
-	scryptN, scryptP, keydir, err := node.ResolveAccountConfig(&cfg.Node)
+	scryptN, scryptP, keydir, err := cfg.Node.AccountConfig()
 
 	if err != nil {
 		utils.Fatalf("Failed to create account: %v", err)
@@ -309,7 +307,7 @@ func accountCreate(ctx *cli.Context) error {
 
 	password := getPassPhrase("Your new account is locked with a password. Please give a password. Do not forget this password.", true, 0, utils.MakePasswordList(ctx))
 
-	err, address := keystore.StoreKey(keydir, password, scryptN, scryptP)
+	address, err := keystore.StoreKey(keydir, password, scryptN, scryptP)
 
 	if err != nil {
 		utils.Fatalf("Failed to create account: %v", err)

--- a/node/config.go
+++ b/node/config.go
@@ -359,6 +359,36 @@ func (c *Config) parsePersistentNodes(path string) []*discover.Node {
 	}
 	return nodes
 }
+// ResolveAccountConfig determines the settings for scrypt and keydirectory
+func ResolveAccountConfig(conf *Config) (int, int, string, error) {
+	scryptN := keystore.StandardScryptN
+	scryptP := keystore.StandardScryptP
+	if conf.UseLightweightKDF {
+		scryptN = keystore.LightScryptN
+		scryptP = keystore.LightScryptP
+	}
+
+	var (
+		keydir string
+		err    error
+	)
+	switch {
+	case filepath.IsAbs(conf.KeyStoreDir):
+		keydir = conf.KeyStoreDir
+	case conf.DataDir != "":
+		if conf.KeyStoreDir == "" {
+			keydir = filepath.Join(conf.DataDir, datadirDefaultKeyStore)
+		} else {
+			keydir, err = filepath.Abs(conf.KeyStoreDir)
+		}
+	case conf.KeyStoreDir != "":
+		keydir, err = filepath.Abs(conf.KeyStoreDir)
+	default:
+		// There is no datadir.
+		keydir, err = ioutil.TempDir("", "go-ethereum-keystore")
+	}
+	return scryptN, scryptP, keydir, err
+}
 
 func makeAccountManager(conf *Config) (*accounts.Manager, string, error) {
 	scryptN := keystore.StandardScryptN


### PR DESCRIPTION
This PR makes `geth account new` operate directly on a keystore file, instead of using a complete keystore.

The first commit should only involve the `geth account new` command, whereas the second commit removes some code which is also used in other circumstances. As far as I could tell, it should be the same functionality, but the `ephemeral` string has been removed. 