### PR TITLE
eth/downloader: dereference discarded statesync request

### DIFF
--- a/eth/downloader/statesync.go
+++ b/eth/downloader/statesync.go
@@ -132,7 +132,10 @@ func (d *Downloader) runStateSync(s *stateSync) *stateSync {
 
 		// Send the next finished request to the current sync:
 		case deliverReqCh <- deliverReq:
-			finished = append(finished[:0], finished[1:]...)
+			// Shift out the first request, but also set the emptied slot to nil for GC
+			copy(finished, finished[1:])
+			finished[len(finished)-1] = nil
+			finished = finished[:len(finished)-1]
 
 		// Handle incoming state packs:
 		case pack := <-d.stateCh:


### PR DESCRIPTION
In the state synchronization structure of the downloader we are maintaining a `finished` slice containing all the currently pending responses (or timeouts) to state requests. Whenever the state processor accepts a pending item, we shift the entire slice to the left.

However, since `finished` is backed by a single array internally, reducing the length by one will still keep the last item in a live (alas currently unreachable) array, and as such will keep a live memory reference to it. This in theory shouldn't matter much as it will soon enough be overwritten, but given our memory problems during sync, I'd rather avoid any such dangling GC references.