### PR TITLE
swarm: add config file

### DIFF
--- a/cmd/swarm/config.go
+++ b/cmd/swarm/config.go
@@ -1,0 +1,321 @@
+// Copyright 2017 The go-ethereum Authors
+// This file is part of go-ethereum.
+//
+// go-ethereum is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// go-ethereum is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with go-ethereum. If not, see <http://www.gnu.org/licenses/>.
+
+package main
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"reflect"
+	"strconv"
+	"unicode"
+
+	cli "gopkg.in/urfave/cli.v1"
+
+	"github.com/ethereum/go-ethereum/cmd/utils"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/log"
+	"github.com/ethereum/go-ethereum/node"
+	"github.com/naoina/toml"
+
+	bzzapi "github.com/ethereum/go-ethereum/swarm/api"
+)
+
+var (
+	//flag definition for the dumpconfig command
+	DumpConfigCommand = cli.Command{
+		Action:      utils.MigrateFlags(dumpConfig),
+		Name:        "dumpconfig",
+		Usage:       "Show configuration values",
+		ArgsUsage:   "",
+		Flags:       app.Flags,
+		Category:    "MISCELLANEOUS COMMANDS",
+		Description: `The dumpconfig command shows configuration values.`,
+	}
+
+	//flag definition for the config file command
+	SwarmTomlConfigPathFlag = cli.StringFlag{
+		Name:  "config",
+		Usage: "TOML configuration file",
+	}
+)
+
+//constants for environment variables
+const (
+	SWARM_ENV_CHEQUEBOOK_ADDR = "SWARM_CHEQUEBOOK_ADDR"
+	SWARM_ENV_ACCOUNT         = "SWARM_ACCOUNT"
+	SWARM_ENV_LISTEN_ADDR     = "SWARM_LISTEN_ADDR"
+	SWARM_ENV_PORT            = "SWARM_PORT"
+	SWARM_ENV_NETWORK_ID      = "SWARM_NETWORK_ID"
+	SWARM_ENV_SWAP_ENABLE     = "SWARM_SWAP_ENABLE"
+	SWARM_ENV_SWAP_API        = "SWARM_SWAP_API"
+	SWARM_ENV_SYNC_ENABLE     = "SWARM_SYNC_ENABLE"
+	SWARM_ENV_ENS_API         = "SWARM_ENS_API"
+	SWARM_ENV_ENS_ADDR        = "SWARM_ENS_ADDR"
+	SWARM_ENV_CORS            = "SWARM_CORS"
+	SWARM_ENV_BOOTNODES       = "SWARM_BOOTNODES"
+	GETH_ENV_DATADIR          = "GETH_DATADIR"
+)
+
+// These settings ensure that TOML keys use the same names as Go struct fields.
+var tomlSettings = toml.Config{
+	NormFieldName: func(rt reflect.Type, key string) string {
+		return key
+	},
+	FieldToKey: func(rt reflect.Type, field string) string {
+		return field
+	},
+	MissingField: func(rt reflect.Type, field string) error {
+		link := ""
+		if unicode.IsUpper(rune(rt.Name()[0])) && rt.PkgPath() != "main" {
+			link = fmt.Sprintf(", check github.com/ethereum/go-ethereum/swarm/api/config.go for available fields")
+		}
+		return fmt.Errorf("field '%s' is not defined in %s%s", field, rt.String(), link)
+	},
+}
+
+//before booting the swarm node, build the configuration
+func buildConfig(ctx *cli.Context) (config *bzzapi.Config, err error) {
+	//check for deprecated flags
+	checkDeprecated(ctx)
+	//start by creating a default config
+	config = bzzapi.NewDefaultConfig()
+	//first load settings from config file (if provided)
+	config, err = configFileOverride(config, ctx)
+	//override settings provided by environment variables
+	config = envVarsOverride(config)
+	//override settings provided by command line
+	config = cmdLineOverride(config, ctx)
+
+	return
+}
+
+//finally, after the configuration build phase is finished, initialize
+func initSwarmNode(config *bzzapi.Config, stack *node.Node, ctx *cli.Context) {
+	//at this point, all vars should be set in the Config
+	//get the account for the provided swarm account
+	prvkey := getAccount(config.BzzAccount, ctx, stack)
+	//set the resolved config path (geth --datadir)
+	config.Path = stack.InstanceDir()
+	//finally, initialize the configuration
+	config.Init(prvkey)
+	//configuration phase completed here
+	log.Debug("Starting Swarm with the following parameters:")
+	//after having created the config, print it to screen
+	log.Debug(printConfig(config))
+}
+
+//override the current config with whatever is in the config file, if a config file has been provided
+func configFileOverride(config *bzzapi.Config, ctx *cli.Context) (*bzzapi.Config, error) {
+	var err error
+
+	//only do something if the -config flag has been set
+	if ctx.GlobalIsSet(SwarmTomlConfigPathFlag.Name) {
+		var filepath string
+		if filepath = ctx.GlobalString(SwarmTomlConfigPathFlag.Name); filepath == "" {
+			utils.Fatalf("Config file flag provided with invalid file path")
+		}
+		f, err := os.Open(filepath)
+		if err != nil {
+			return nil, err
+		}
+		defer f.Close()
+
+		//decode the TOML file into a Config struct
+		//note that we are decoding into the existing defaultConfig;
+		//if an entry is not present in the file, the default entry is kept
+		err = tomlSettings.NewDecoder(f).Decode(&config)
+		// Add file name to errors that have a line number.
+		if _, ok := err.(*toml.LineError); ok {
+			err = errors.New(filepath + ", " + err.Error())
+		}
+	}
+	return config, err
+}
+
+//override the current config with whatever is provided through the command line
+//most values are not allowed a zero value (empty string), if not otherwise noted
+func cmdLineOverride(currentConfig *bzzapi.Config, ctx *cli.Context) *bzzapi.Config {
+
+	if keyid := ctx.GlobalString(SwarmAccountFlag.Name); keyid != "" {
+		currentConfig.BzzAccount = keyid
+	}
+
+	if chbookaddr := ctx.GlobalString(ChequebookAddrFlag.Name); chbookaddr != "" {
+		currentConfig.Contract = common.HexToAddress(chbookaddr)
+	}
+
+	if networkid := ctx.GlobalString(SwarmNetworkIdFlag.Name); networkid != "" {
+		if id, _ := strconv.Atoi(networkid); id != 0 {
+			currentConfig.NetworkId = uint64(id)
+		}
+	}
+
+	if ctx.GlobalIsSet(utils.DataDirFlag.Name) {
+		if datadir := ctx.GlobalString(utils.DataDirFlag.Name); datadir != "" {
+			currentConfig.Path = datadir
+		}
+	}
+
+	bzzport := ctx.GlobalString(SwarmPortFlag.Name)
+	if len(bzzport) > 0 {
+		currentConfig.Port = bzzport
+	}
+
+	if bzzaddr := ctx.GlobalString(SwarmListenAddrFlag.Name); bzzaddr != "" {
+		currentConfig.ListenAddr = bzzaddr
+	}
+
+	if ctx.GlobalIsSet(SwarmSwapEnabledFlag.Name) {
+		currentConfig.SwapEnabled = true
+	}
+
+	if ctx.GlobalIsSet(SwarmSyncEnabledFlag.Name) {
+		currentConfig.SyncEnabled = true
+	}
+
+	currentConfig.SwapApi = ctx.GlobalString(SwarmSwapAPIFlag.Name)
+	if currentConfig.SwapEnabled && currentConfig.SwapApi == "" {
+		utils.Fatalf(SWARM_ERR_SWAP_SET_NO_API)
+	}
+
+	//EnsApi can be set to "", so can't check for empty string, as it is allowed!
+	if ctx.GlobalIsSet(EnsAPIFlag.Name) {
+		currentConfig.EnsApi = ctx.GlobalString(EnsAPIFlag.Name)
+	}
+
+	if ensaddr := ctx.GlobalString(EnsAddrFlag.Name); ensaddr != "" {
+		currentConfig.EnsRoot = common.HexToAddress(ensaddr)
+	}
+
+	if cors := ctx.GlobalString(CorsStringFlag.Name); cors != "" {
+		currentConfig.Cors = cors
+	}
+
+	if ctx.GlobalIsSet(utils.BootnodesFlag.Name) {
+		currentConfig.BootNodes = ctx.GlobalString(utils.BootnodesFlag.Name)
+	}
+
+	return currentConfig
+
+}
+
+//override the current config with whatver is provided in environment variables
+//most values are not allowed a zero value (empty string), if not otherwise noted
+func envVarsOverride(currentConfig *bzzapi.Config) (config *bzzapi.Config) {
+
+	if keyid := os.Getenv(SWARM_ENV_ACCOUNT); keyid != "" {
+		currentConfig.BzzAccount = keyid
+	}
+
+	if chbookaddr := os.Getenv(SWARM_ENV_CHEQUEBOOK_ADDR); chbookaddr != "" {
+		currentConfig.Contract = common.HexToAddress(chbookaddr)
+	}
+
+	if networkid := os.Getenv(SWARM_ENV_NETWORK_ID); networkid != "" {
+		if id, _ := strconv.Atoi(networkid); id != 0 {
+			currentConfig.NetworkId = uint64(id)
+		}
+	}
+
+	if datadir := os.Getenv(GETH_ENV_DATADIR); datadir != "" {
+		currentConfig.Path = datadir
+	}
+
+	bzzport := os.Getenv(SWARM_ENV_PORT)
+	if len(bzzport) > 0 {
+		currentConfig.Port = bzzport
+	}
+
+	if bzzaddr := os.Getenv(SWARM_ENV_LISTEN_ADDR); bzzaddr != "" {
+		currentConfig.ListenAddr = bzzaddr
+	}
+
+	if swapenable := os.Getenv(SWARM_ENV_SWAP_ENABLE); swapenable != "" {
+		if swap, err := strconv.ParseBool(swapenable); err != nil {
+			currentConfig.SwapEnabled = swap
+		}
+	}
+
+	if syncenable := os.Getenv(SWARM_ENV_SYNC_ENABLE); syncenable != "" {
+		if sync, err := strconv.ParseBool(syncenable); err != nil {
+			currentConfig.SyncEnabled = sync
+		}
+	}
+
+	if swapapi := os.Getenv(SWARM_ENV_SWAP_API); swapapi != "" {
+		currentConfig.SwapApi = swapapi
+	}
+
+	if currentConfig.SwapEnabled && currentConfig.SwapApi == "" {
+		utils.Fatalf(SWARM_ERR_SWAP_SET_NO_API)
+	}
+
+	//EnsApi can be set to "", so can't check for empty string, as it is allowed
+	if ensapi, exists := os.LookupEnv(SWARM_ENV_ENS_API); exists == true {
+		currentConfig.EnsApi = ensapi
+	}
+
+	if ensaddr := os.Getenv(SWARM_ENV_ENS_ADDR); ensaddr != "" {
+		currentConfig.EnsRoot = common.HexToAddress(ensaddr)
+	}
+
+	if cors := os.Getenv(SWARM_ENV_CORS); cors != "" {
+		currentConfig.Cors = cors
+	}
+
+	if bootnodes := os.Getenv(SWARM_ENV_BOOTNODES); bootnodes != "" {
+		currentConfig.BootNodes = bootnodes
+	}
+
+	return currentConfig
+}
+
+// dumpConfig is the dumpconfig command.
+// writes a default config to STDOUT
+func dumpConfig(ctx *cli.Context) error {
+	cfg, err := buildConfig(ctx)
+	if err != nil {
+		utils.Fatalf(fmt.Sprintf("Uh oh - dumpconfig triggered an error %v", err))
+	}
+	comment := ""
+	out, err := tomlSettings.Marshal(&cfg)
+	if err != nil {
+		return err
+	}
+	io.WriteString(os.Stdout, comment)
+	os.Stdout.Write(out)
+	return nil
+}
+
+//deprecated flags checked here
+func checkDeprecated(ctx *cli.Context) {
+	// exit if the deprecated --ethapi flag is set
+	if ctx.GlobalString(DeprecatedEthAPIFlag.Name) != "" {
+		utils.Fatalf("--ethapi is no longer a valid command line flag, please use --ens-api and/or --swap-api.")
+	}
+}
+
+//print a Config as string
+func printConfig(config *bzzapi.Config) string {
+	out, err := tomlSettings.Marshal(&config)
+	if err != nil {
+		return (fmt.Sprintf("Something is not right with the configuration: %v", err))
+	}
+	return string(out)
+}

--- a/cmd/swarm/config_test.go
+++ b/cmd/swarm/config_test.go
@@ -1,0 +1,459 @@
+// Copyright 2017 The go-ethereum Authors
+// This file is part of go-ethereum.
+//
+// go-ethereum is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// go-ethereum is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with go-ethereum. If not, see <http://www.gnu.org/licenses/>.
+
+package main
+
+import (
+	"fmt"
+	"io"
+	"io/ioutil"
+	"os"
+	"os/exec"
+	"testing"
+	"time"
+
+	"github.com/ethereum/go-ethereum/rpc"
+	"github.com/ethereum/go-ethereum/swarm"
+	"github.com/ethereum/go-ethereum/swarm/api"
+
+	"github.com/docker/docker/pkg/reexec"
+)
+
+func TestDumpConfig(t *testing.T) {
+	swarm := runSwarm(t, "dumpconfig")
+	defaultConf := api.NewDefaultConfig()
+	out, err := tomlSettings.Marshal(&defaultConf)
+	if err != nil {
+		t.Fatal(err)
+	}
+	swarm.Expect(string(out))
+	swarm.ExpectExit()
+}
+
+func TestFailsSwapEnabledNoSwapApi(t *testing.T) {
+	flags := []string{
+		fmt.Sprintf("--%s", SwarmNetworkIdFlag.Name), "42",
+		fmt.Sprintf("--%s", SwarmPortFlag.Name), "54545",
+		fmt.Sprintf("--%s", SwarmSwapEnabledFlag.Name),
+	}
+
+	swarm := runSwarm(t, flags...)
+	swarm.Expect("Fatal: " + SWARM_ERR_SWAP_SET_NO_API + "\n")
+	swarm.ExpectExit()
+}
+
+func TestFailsNoBzzAccount(t *testing.T) {
+	flags := []string{
+		fmt.Sprintf("--%s", SwarmNetworkIdFlag.Name), "42",
+		fmt.Sprintf("--%s", SwarmPortFlag.Name), "54545",
+	}
+
+	swarm := runSwarm(t, flags...)
+	swarm.Expect("Fatal: " + SWARM_ERR_NO_BZZACCOUNT + "\n")
+	swarm.ExpectExit()
+}
+
+func TestCmdLineOverrides(t *testing.T) {
+	dir, err := ioutil.TempDir("", "bzztest")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(dir)
+
+	conf, account := getTestAccount(t, dir)
+	node := &testNode{Dir: dir}
+
+	// assign ports
+	httpPort, err := assignTCPPort()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	flags := []string{
+		fmt.Sprintf("--%s", SwarmNetworkIdFlag.Name), "42",
+		fmt.Sprintf("--%s", SwarmPortFlag.Name), httpPort,
+		fmt.Sprintf("--%s", SwarmSyncEnabledFlag.Name),
+		fmt.Sprintf("--%s", CorsStringFlag.Name), "*",
+		fmt.Sprintf("--%s", SwarmAccountFlag.Name), account.Address.String(),
+		fmt.Sprintf("--%s", EnsAPIFlag.Name), "",
+		"--datadir", dir,
+		"--ipcpath", conf.IPCPath,
+	}
+	node.Cmd = runSwarm(t, flags...)
+	node.Cmd.InputLine(testPassphrase)
+	defer func() {
+		if t.Failed() {
+			node.Shutdown()
+		}
+	}()
+	// wait for the node to start
+	for start := time.Now(); time.Since(start) < 10*time.Second; time.Sleep(50 * time.Millisecond) {
+		node.Client, err = rpc.Dial(conf.IPCEndpoint())
+		if err == nil {
+			break
+		}
+	}
+	if node.Client == nil {
+		t.Fatal(err)
+	}
+
+	// load info
+	var info swarm.Info
+	if err := node.Client.Call(&info, "bzz_info"); err != nil {
+		t.Fatal(err)
+	}
+
+	if info.Port != httpPort {
+		t.Fatalf("Expected port to be %s, got %s", httpPort, info.Port)
+	}
+
+	if info.NetworkId != 42 {
+		t.Fatalf("Expected network ID to be %d, got %d", 42, info.NetworkId)
+	}
+
+	if info.SyncEnabled != true {
+		t.Fatal("Expected Sync to be enabled, but is false")
+	}
+
+	if info.Cors != "*" {
+		t.Fatalf("Expected Cors flag to be set to %s, got %s", "*", info.Cors)
+	}
+
+	node.Shutdown()
+}
+
+func TestFileOverrides(t *testing.T) {
+
+	// assign ports
+	httpPort, err := assignTCPPort()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	//create a config file
+	//first, create a default conf
+	defaultConf := api.NewDefaultConfig()
+	//change some values in order to test if they have been loaded
+	defaultConf.SyncEnabled = true
+	defaultConf.NetworkId = 54
+	defaultConf.Port = httpPort
+	defaultConf.StoreParams.DbCapacity = 9000000
+	defaultConf.ChunkerParams.Branches = 64
+	defaultConf.HiveParams.CallInterval = 6000000000
+	defaultConf.Swap.Params.Strategy.AutoCashInterval = 600 * time.Second
+	defaultConf.SyncParams.KeyBufferSize = 512
+	//create a TOML string
+	out, err := tomlSettings.Marshal(&defaultConf)
+	if err != nil {
+		t.Fatalf("Error creating TOML file in TestFileOverride: %v", err)
+	}
+	//create file
+	f, err := ioutil.TempFile("", "testconfig.toml")
+	if err != nil {
+		t.Fatalf("Error writing TOML file in TestFileOverride: %v", err)
+	}
+	//write file
+	_, err = f.WriteString(string(out))
+	if err != nil {
+		t.Fatalf("Error writing TOML file in TestFileOverride: %v", err)
+	}
+	f.Sync()
+
+	dir, err := ioutil.TempDir("", "bzztest")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(dir)
+	conf, account := getTestAccount(t, dir)
+	node := &testNode{Dir: dir}
+
+	flags := []string{
+		fmt.Sprintf("--%s", SwarmTomlConfigPathFlag.Name), f.Name(),
+		fmt.Sprintf("--%s", SwarmAccountFlag.Name), account.Address.String(),
+		"--ens-api", "",
+		"--ipcpath", conf.IPCPath,
+		"--datadir", dir,
+	}
+	node.Cmd = runSwarm(t, flags...)
+	node.Cmd.InputLine(testPassphrase)
+	defer func() {
+		if t.Failed() {
+			node.Shutdown()
+		}
+	}()
+	// wait for the node to start
+	for start := time.Now(); time.Since(start) < 10*time.Second; time.Sleep(50 * time.Millisecond) {
+		node.Client, err = rpc.Dial(conf.IPCEndpoint())
+		if err == nil {
+			break
+		}
+	}
+	if node.Client == nil {
+		t.Fatal(err)
+	}
+
+	// load info
+	var info swarm.Info
+	if err := node.Client.Call(&info, "bzz_info"); err != nil {
+		t.Fatal(err)
+	}
+
+	if info.Port != httpPort {
+		t.Fatalf("Expected port to be %s, got %s", httpPort, info.Port)
+	}
+
+	if info.NetworkId != 54 {
+		t.Fatalf("Expected network ID to be %d, got %d", 54, info.NetworkId)
+	}
+
+	if info.SyncEnabled != true {
+		t.Fatal("Expected Sync to be enabled, but is false")
+	}
+
+	if info.StoreParams.DbCapacity != 9000000 {
+		t.Fatalf("Expected network ID to be %d, got %d", 54, info.NetworkId)
+	}
+
+	if info.ChunkerParams.Branches != 64 {
+		t.Fatalf("Expected chunker params branches to be %d, got %d", 64, info.ChunkerParams.Branches)
+	}
+
+	if info.HiveParams.CallInterval != 6000000000 {
+		t.Fatalf("Expected HiveParams CallInterval to be %d, got %d", uint64(6000000000), uint64(info.HiveParams.CallInterval))
+	}
+
+	if info.Swap.Params.Strategy.AutoCashInterval != 600*time.Second {
+		t.Fatalf("Expected SwapParams AutoCashInterval to be %ds, got %d", 600, info.Swap.Params.Strategy.AutoCashInterval)
+	}
+
+	if info.SyncParams.KeyBufferSize != 512 {
+		t.Fatalf("Expected info.SyncParams.KeyBufferSize to be %d, got %d", 512, info.SyncParams.KeyBufferSize)
+	}
+
+	node.Shutdown()
+}
+
+func TestEnvVars(t *testing.T) {
+	// assign ports
+	httpPort, err := assignTCPPort()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	envVars := os.Environ()
+	envVars = append(envVars, fmt.Sprintf("%s=%s", SwarmPortFlag.EnvVar, httpPort))
+	envVars = append(envVars, fmt.Sprintf("%s=%s", SwarmNetworkIdFlag.EnvVar, "999"))
+	envVars = append(envVars, fmt.Sprintf("%s=%s", CorsStringFlag.EnvVar, "*"))
+	envVars = append(envVars, fmt.Sprintf("%s=%s", SwarmSyncEnabledFlag.EnvVar, "true"))
+
+	dir, err := ioutil.TempDir("", "bzztest")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(dir)
+	conf, account := getTestAccount(t, dir)
+	node := &testNode{Dir: dir}
+	flags := []string{
+		fmt.Sprintf("--%s", SwarmAccountFlag.Name), account.Address.String(),
+		"--ens-api", "",
+		"--datadir", dir,
+		"--ipcpath", conf.IPCPath,
+	}
+
+	//node.Cmd = runSwarm(t,flags...)
+	//node.Cmd.cmd.Env = envVars
+	//the above assignment does not work, so we need a custom Cmd here in order to pass envVars:
+	cmd := &exec.Cmd{
+		Path:   reexec.Self(),
+		Args:   append([]string{"swarm-test"}, flags...),
+		Stderr: os.Stderr,
+		Stdout: os.Stdout,
+	}
+	cmd.Env = envVars
+	//stdout, err := cmd.StdoutPipe()
+	//if err != nil {
+	//	t.Fatal(err)
+	//}
+	//stdout = bufio.NewReader(stdout)
+	var stdin io.WriteCloser
+	if stdin, err = cmd.StdinPipe(); err != nil {
+		t.Fatal(err)
+	}
+	if err := cmd.Start(); err != nil {
+		t.Fatal(err)
+	}
+
+	//cmd.InputLine(testPassphrase)
+	io.WriteString(stdin, testPassphrase+"\n")
+	defer func() {
+		if t.Failed() {
+			node.Shutdown()
+			cmd.Process.Kill()
+		}
+	}()
+	// wait for the node to start
+	for start := time.Now(); time.Since(start) < 10*time.Second; time.Sleep(50 * time.Millisecond) {
+		node.Client, err = rpc.Dial(conf.IPCEndpoint())
+		if err == nil {
+			break
+		}
+	}
+
+	if node.Client == nil {
+		t.Fatal(err)
+	}
+
+	// load info
+	var info swarm.Info
+	if err := node.Client.Call(&info, "bzz_info"); err != nil {
+		t.Fatal(err)
+	}
+
+	if info.Port != httpPort {
+		t.Fatalf("Expected port to be %s, got %s", httpPort, info.Port)
+	}
+
+	if info.NetworkId != 999 {
+		t.Fatalf("Expected network ID to be %d, got %d", 999, info.NetworkId)
+	}
+
+	if info.Cors != "*" {
+		t.Fatalf("Expected Cors flag to be set to %s, got %s", "*", info.Cors)
+	}
+
+	if info.SyncEnabled != true {
+		t.Fatal("Expected Sync to be enabled, but is false")
+	}
+
+	node.Shutdown()
+	cmd.Process.Kill()
+}
+
+func TestCmdLineOverridesFile(t *testing.T) {
+
+	// assign ports
+	httpPort, err := assignTCPPort()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	//create a config file
+	//first, create a default conf
+	defaultConf := api.NewDefaultConfig()
+	//change some values in order to test if they have been loaded
+	defaultConf.SyncEnabled = false
+	defaultConf.NetworkId = 54
+	defaultConf.Port = "8588"
+	defaultConf.StoreParams.DbCapacity = 9000000
+	defaultConf.ChunkerParams.Branches = 64
+	defaultConf.HiveParams.CallInterval = 6000000000
+	defaultConf.Swap.Params.Strategy.AutoCashInterval = 600 * time.Second
+	defaultConf.SyncParams.KeyBufferSize = 512
+	//create a TOML file
+	out, err := tomlSettings.Marshal(&defaultConf)
+	if err != nil {
+		t.Fatalf("Error creating TOML file in TestFileOverride: %v", err)
+	}
+	//write file
+	f, err := ioutil.TempFile("", "testconfig.toml")
+	if err != nil {
+		t.Fatalf("Error writing TOML file in TestFileOverride: %v", err)
+	}
+	//write file
+	_, err = f.WriteString(string(out))
+	if err != nil {
+		t.Fatalf("Error writing TOML file in TestFileOverride: %v", err)
+	}
+	f.Sync()
+
+	dir, err := ioutil.TempDir("", "bzztest")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(dir)
+	conf, account := getTestAccount(t, dir)
+	node := &testNode{Dir: dir}
+
+	expectNetworkId := uint64(77)
+
+	flags := []string{
+		fmt.Sprintf("--%s", SwarmNetworkIdFlag.Name), "77",
+		fmt.Sprintf("--%s", SwarmPortFlag.Name), httpPort,
+		fmt.Sprintf("--%s", SwarmSyncEnabledFlag.Name),
+		fmt.Sprintf("--%s", SwarmTomlConfigPathFlag.Name), f.Name(),
+		fmt.Sprintf("--%s", SwarmAccountFlag.Name), account.Address.String(),
+		"--ens-api", "",
+		"--datadir", dir,
+		"--ipcpath", conf.IPCPath,
+	}
+	node.Cmd = runSwarm(t, flags...)
+	node.Cmd.InputLine(testPassphrase)
+	defer func() {
+		if t.Failed() {
+			node.Shutdown()
+		}
+	}()
+	// wait for the node to start
+	for start := time.Now(); time.Since(start) < 10*time.Second; time.Sleep(50 * time.Millisecond) {
+		node.Client, err = rpc.Dial(conf.IPCEndpoint())
+		if err == nil {
+			break
+		}
+	}
+	if node.Client == nil {
+		t.Fatal(err)
+	}
+
+	// load info
+	var info swarm.Info
+	if err := node.Client.Call(&info, "bzz_info"); err != nil {
+		t.Fatal(err)
+	}
+
+	if info.Port != httpPort {
+		t.Fatalf("Expected port to be %s, got %s", httpPort, info.Port)
+	}
+
+	if info.NetworkId != expectNetworkId {
+		t.Fatalf("Expected network ID to be %d, got %d", expectNetworkId, info.NetworkId)
+	}
+
+	if info.SyncEnabled != true {
+		t.Fatal("Expected Sync to be enabled, but is false")
+	}
+
+	if info.StoreParams.DbCapacity != 9000000 {
+		t.Fatalf("Expected network ID to be %d, got %d", 54, info.NetworkId)
+	}
+
+	if info.ChunkerParams.Branches != 64 {
+		t.Fatalf("Expected chunker params branches to be %d, got %d", 64, info.ChunkerParams.Branches)
+	}
+
+	if info.HiveParams.CallInterval != 6000000000 {
+		t.Fatalf("Expected HiveParams CallInterval to be %d, got %d", uint64(6000000000), uint64(info.HiveParams.CallInterval))
+	}
+
+	if info.Swap.Params.Strategy.AutoCashInterval != 600*time.Second {
+		t.Fatalf("Expected SwapParams AutoCashInterval to be %ds, got %d", 600, info.Swap.Params.Strategy.AutoCashInterval)
+	}
+
+	if info.SyncParams.KeyBufferSize != 512 {
+		t.Fatalf("Expected info.SyncParams.KeyBufferSize to be %d, got %d", 512, info.SyncParams.KeyBufferSize)
+	}
+
+	node.Shutdown()
+}

--- a/swarm/api/config.go
+++ b/swarm/api/config.go
@@ -18,15 +18,15 @@ package api
 
 import (
 	"crypto/ecdsa"
-	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/contracts/ens"
 	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/log"
+	"github.com/ethereum/go-ethereum/node"
 	"github.com/ethereum/go-ethereum/swarm/network"
 	"github.com/ethereum/go-ethereum/swarm/services/swap"
 	"github.com/ethereum/go-ethereum/swarm/storage"
@@ -46,101 +46,68 @@ type Config struct {
 	*network.HiveParams
 	Swap *swap.SwapParams
 	*network.SyncParams
-	Path       string
-	ListenAddr string
-	Port       string
-	PublicKey  string
-	BzzKey     string
-	EnsRoot    common.Address
-	NetworkId  uint64
+	Contract    common.Address
+	EnsRoot     common.Address
+	EnsApi      string
+	Path        string
+	ListenAddr  string
+	Port        string
+	PublicKey   string
+	BzzKey      string
+	NetworkId   uint64
+	SwapEnabled bool
+	SyncEnabled bool
+	SwapApi     string
+	Cors        string
+	BzzAccount  string
+	BootNodes   string
 }
 
-// config is agnostic to where private key is coming from
-// so managing accounts is outside swarm and left to wrappers
-func NewConfig(path string, contract common.Address, prvKey *ecdsa.PrivateKey, networkId uint64) (self *Config, err error) {
-	address := crypto.PubkeyToAddress(prvKey.PublicKey) // default beneficiary address
-	dirpath := filepath.Join(path, "bzz-"+common.Bytes2Hex(address.Bytes()))
-	err = os.MkdirAll(dirpath, os.ModePerm)
-	if err != nil {
-		return
-	}
-	confpath := filepath.Join(dirpath, "config.json")
-	var data []byte
-	pubkey := crypto.FromECDSAPub(&prvKey.PublicKey)
-	pubkeyhex := common.ToHex(pubkey)
-	keyhex := crypto.Keccak256Hash(pubkey).Hex()
+//create a default config with all parameters to set to defaults
+func NewDefaultConfig() (self *Config) {
 
 	self = &Config{
-		SyncParams:    network.NewSyncParams(dirpath),
-		HiveParams:    network.NewHiveParams(dirpath),
+		StoreParams:   storage.NewDefaultStoreParams(),
 		ChunkerParams: storage.NewChunkerParams(),
-		StoreParams:   storage.NewStoreParams(dirpath),
+		HiveParams:    network.NewDefaultHiveParams(),
+		SyncParams:    network.NewDefaultSyncParams(),
+		Swap:          swap.NewDefaultSwapParams(),
 		ListenAddr:    DefaultHTTPListenAddr,
 		Port:          DefaultHTTPPort,
-		Path:          dirpath,
-		Swap:          swap.DefaultSwapParams(contract, prvKey),
-		PublicKey:     pubkeyhex,
-		BzzKey:        keyhex,
+		Path:          node.DefaultDataDir(),
+		EnsApi:        node.DefaultIPCEndpoint("geth"),
 		EnsRoot:       ens.TestNetAddress,
-		NetworkId:     networkId,
-	}
-	data, err = ioutil.ReadFile(confpath)
-
-	// if not set in function param, then set default for swarm network, will be overwritten by config file if present
-	if networkId == 0 {
-		self.NetworkId = network.NetworkId
-	}
-
-	if err != nil {
-		if !os.IsNotExist(err) {
-			return
-		}
-
-		// file does not exist
-		// write out config file
-		err = self.Save()
-		if err != nil {
-			err = fmt.Errorf("error writing config: %v", err)
-		}
-		return
-	}
-
-	// file exists, deserialise
-	err = json.Unmarshal(data, self)
-	if err != nil {
-		return nil, fmt.Errorf("unable to parse config: %v", err)
-	}
-	// check public key
-	if pubkeyhex != self.PublicKey {
-		return nil, fmt.Errorf("public key does not match the one in the config file %v != %v", pubkeyhex, self.PublicKey)
-	}
-	if keyhex != self.BzzKey {
-		return nil, fmt.Errorf("bzz key does not match the one in the config file %v != %v", keyhex, self.BzzKey)
-	}
-
-	// if set in function param, replace id set from config file
-	if networkId != 0 {
-		self.NetworkId = networkId
-	}
-
-	self.Swap.SetKey(prvKey)
-
-	if (self.EnsRoot == common.Address{}) {
-		self.EnsRoot = ens.TestNetAddress
+		NetworkId:     network.NetworkId,
+		SwapEnabled:   false,
+		SyncEnabled:   true,
+		SwapApi:       "",
+		BootNodes:     "",
 	}
 
 	return
 }
 
-func (self *Config) Save() error {
-	data, err := json.MarshalIndent(self, "", "    ")
+//some config params need to be initialized after the complete
+//config building phase is completed (e.g. due to overriding flags)
+func (self *Config) Init(prvKey *ecdsa.PrivateKey) {
+
+	address := crypto.PubkeyToAddress(prvKey.PublicKey)
+	self.Path = filepath.Join(self.Path, "bzz-"+common.Bytes2Hex(address.Bytes()))
+	err := os.MkdirAll(self.Path, os.ModePerm)
 	if err != nil {
-		return err
+		log.Error(fmt.Sprintf("Error creating root swarm data directory: %v", err))
+		return
 	}
-	err = os.MkdirAll(self.Path, os.ModePerm)
-	if err != nil {
-		return err
-	}
-	confpath := filepath.Join(self.Path, "config.json")
-	return ioutil.WriteFile(confpath, data, os.ModePerm)
+
+	pubkey := crypto.FromECDSAPub(&prvKey.PublicKey)
+	pubkeyhex := common.ToHex(pubkey)
+	keyhex := crypto.Keccak256Hash(pubkey).Hex()
+
+	self.PublicKey = pubkeyhex
+	self.BzzKey = keyhex
+
+	self.Swap.Init(self.Contract, prvKey)
+	self.SyncParams.Init(self.Path)
+	self.HiveParams.Init(self.Path)
+	self.StoreParams.Init(self.Path)
 }

--- a/swarm/api/config_test.go
+++ b/swarm/api/config_test.go
@@ -17,109 +17,53 @@
 package api
 
 import (
-	"io/ioutil"
-	"os"
-	"path/filepath"
-	"strings"
+	"reflect"
 	"testing"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/crypto"
 )
 
-var (
-	hexprvkey     = "65138b2aa745041b372153550584587da326ab440576b2a1191dd95cee30039c"
-	defaultConfig = `{
-    "ChunkDbPath": "` + filepath.Join("TMPDIR", "chunks") + `",
-    "DbCapacity": 5000000,
-    "CacheCapacity": 5000,
-    "Radius": 0,
-    "Branches": 128,
-    "Hash": "SHA3",
-    "CallInterval": 3000000000,
-    "KadDbPath": "` + filepath.Join("TMPDIR", "bzz-peers.json") + `",
-    "MaxProx": 8,
-    "ProxBinSize": 2,
-    "BucketSize": 4,
-    "PurgeInterval": 151200000000000,
-    "InitialRetryInterval": 42000000,
-    "MaxIdleInterval": 42000000000,
-    "ConnRetryExp": 2,
-    "Swap": {
-        "BuyAt": 20000000000,
-        "SellAt": 20000000000,
-        "PayAt": 100,
-        "DropAt": 10000,
-        "AutoCashInterval": 300000000000,
-        "AutoCashThreshold": 50000000000000,
-        "AutoDepositInterval": 300000000000,
-        "AutoDepositThreshold": 50000000000000,
-        "AutoDepositBuffer": 100000000000000,
-        "PublicKey": "0x045f5cfd26692e48d0017d380349bcf50982488bc11b5145f3ddf88b24924299048450542d43527fbe29a5cb32f38d62755393ac002e6bfdd71b8d7ba725ecd7a3",
-        "Contract": "0x0000000000000000000000000000000000000000",
-        "Beneficiary": "0x0d2f62485607cf38d9d795d93682a517661e513e"
-    },
-    "RequestDbPath": "` + filepath.Join("TMPDIR", "requests") + `",
-    "RequestDbBatchSize": 512,
-    "KeyBufferSize": 1024,
-    "SyncBatchSize": 128,
-    "SyncBufferSize": 128,
-    "SyncCacheSize": 1024,
-    "SyncPriorities": [
-        2,
-        1,
-        1,
-        0,
-        0
-    ],
-    "SyncModes": [
-        true,
-        true,
-        true,
-        true,
-        false
-    ],
-    "Path": "TMPDIR",
-    "ListenAddr": "127.0.0.1",
-    "Port": "8500",
-    "PublicKey": "0x045f5cfd26692e48d0017d380349bcf50982488bc11b5145f3ddf88b24924299048450542d43527fbe29a5cb32f38d62755393ac002e6bfdd71b8d7ba725ecd7a3",
-    "BzzKey": "0xe861964402c0b78e2d44098329b8545726f215afa737d803714a4338552fcb81",
-    "EnsRoot": "0x112234455c3a32fd11230c42e7bccd4a84e02010",
-    "NetworkId": 323
-}`
-)
+func TestConfig(t *testing.T) {
 
-func TestConfigWriteRead(t *testing.T) {
-	tmp, err := ioutil.TempDir(os.TempDir(), "bzz-test")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(tmp)
+	var hexprvkey = "65138b2aa745041b372153550584587da326ab440576b2a1191dd95cee30039c"
 
 	prvkey, err := crypto.HexToECDSA(hexprvkey)
 	if err != nil {
 		t.Fatalf("failed to load private key: %v", err)
 	}
-	orig, err := NewConfig(tmp, common.Address{}, prvkey, 323)
-	if err != nil {
-		t.Fatalf("expected no error, got %v", err)
-	}
-	data, err := ioutil.ReadFile(filepath.Join(orig.Path, "config.json"))
-	if err != nil {
-		t.Fatalf("default config file cannot be read: %v", err)
-	}
-	exp := strings.Replace(defaultConfig, "TMPDIR", orig.Path, -1)
-	exp = strings.Replace(exp, "\\", "\\\\", -1)
-	if string(data) != exp {
-		t.Fatalf("default config mismatch:\nexpected: %v\ngot: %v", exp, string(data))
+
+	one := NewDefaultConfig()
+	two := NewDefaultConfig()
+
+	if equal := reflect.DeepEqual(one, two); equal == false {
+		t.Fatal("Two default configs are not equal")
 	}
 
-	conf, err := NewConfig(tmp, common.Address{}, prvkey, 323)
-	if err != nil {
-		t.Fatalf("expected no error, got %v", err)
+	one.Init(prvkey)
+
+	//the init function should set the following fields
+	if one.BzzKey == "" {
+		t.Fatal("Expected BzzKey to be set")
 	}
-	if conf.Swap.Beneficiary.Hex() != orig.Swap.Beneficiary.Hex() {
-		t.Fatalf("expected beneficiary from loaded config %v to match original %v", conf.Swap.Beneficiary.Hex(), orig.Swap.Beneficiary.Hex())
+	if one.PublicKey == "" {
+		t.Fatal("Expected PublicKey to be set")
 	}
 
+	//the Init function should append subdirs to the given path
+	if one.Swap.PayProfile.Beneficiary == (common.Address{}) {
+		t.Fatal("Failed to correctly initialize SwapParams")
+	}
+
+	if one.SyncParams.RequestDbPath == one.Path {
+		t.Fatal("Failed to correctly initialize SyncParams")
+	}
+
+	if one.HiveParams.KadDbPath == one.Path {
+		t.Fatal("Failed to correctly initialize HiveParams")
+	}
+
+	if one.StoreParams.ChunkDbPath == one.Path {
+		t.Fatal("Failed to correctly initialize StoreParams")
+	}
 }

--- a/swarm/network/hive.go
+++ b/swarm/network/hive.go
@@ -70,17 +70,23 @@ type HiveParams struct {
 	*kademlia.KadParams
 }
 
-func NewHiveParams(path string) *HiveParams {
-	kad := kademlia.NewKadParams()
+//create default params
+func NewDefaultHiveParams() *HiveParams {
+	kad := kademlia.NewDefaultKadParams()
 	// kad.BucketSize = bucketSize
 	// kad.MaxProx = maxProx
 	// kad.ProxBinSize = proxBinSize
 
 	return &HiveParams{
 		CallInterval: callInterval,
-		KadDbPath:    filepath.Join(path, "bzz-peers.json"),
 		KadParams:    kad,
 	}
+}
+
+//this can only finally be set after all config options (file, cmd line, env vars)
+//have been evaluated
+func (self *HiveParams) Init(path string) {
+	self.KadDbPath = filepath.Join(path, "bzz-peers.json")
 }
 
 func NewHive(addr common.Hash, params *HiveParams, swapEnabled, syncEnabled bool) *Hive {

--- a/swarm/network/kademlia/kademlia.go
+++ b/swarm/network/kademlia/kademlia.go
@@ -52,7 +52,7 @@ type KadParams struct {
 	ConnRetryExp         int
 }
 
-func NewKadParams() *KadParams {
+func NewDefaultKadParams() *KadParams {
 	return &KadParams{
 		MaxProx:              maxProx,
 		ProxBinSize:          proxBinSize,

--- a/swarm/network/kademlia/kademlia_test.go
+++ b/swarm/network/kademlia/kademlia_test.go
@@ -63,7 +63,7 @@ func TestOn(t *testing.T) {
 	if !ok1 || !ok2 {
 		t.Errorf("oops")
 	}
-	kad := New(addr, NewKadParams())
+	kad := New(addr, NewDefaultKadParams())
 	err := kad.On(&testNode{addr: other}, nil)
 	_ = err
 }
@@ -72,7 +72,7 @@ func TestBootstrap(t *testing.T) {
 
 	test := func(test *bootstrapTest) bool {
 		// for any node kad.le, Target and N
-		params := NewKadParams()
+		params := NewDefaultKadParams()
 		params.MaxProx = test.MaxProx
 		params.BucketSize = test.BucketSize
 		params.ProxBinSize = test.BucketSize
@@ -127,7 +127,7 @@ func TestFindClosest(t *testing.T) {
 
 	test := func(test *FindClosestTest) bool {
 		// for any node kad.le, Target and N
-		params := NewKadParams()
+		params := NewDefaultKadParams()
 		params.MaxProx = 7
 		kad := New(test.Self, params)
 		var err error
@@ -198,7 +198,7 @@ var (
 func TestProxAdjust(t *testing.T) {
 	r := rand.New(rand.NewSource(time.Now().UnixNano()))
 	self := gen(Address{}, r).(Address)
-	params := NewKadParams()
+	params := NewDefaultKadParams()
 	params.MaxProx = 7
 	kad := New(self, params)
 
@@ -232,7 +232,7 @@ func TestSaveLoad(t *testing.T) {
 	r := rand.New(rand.NewSource(time.Now().UnixNano()))
 	addresses := gen([]Address{}, r).([]Address)
 	self := RandomAddress()
-	params := NewKadParams()
+	params := NewDefaultKadParams()
 	params.MaxProx = 7
 	kad := New(self, params)
 

--- a/swarm/network/syncer.go
+++ b/swarm/network/syncer.go
@@ -131,9 +131,8 @@ type SyncParams struct {
 }
 
 // constructor with default values
-func NewSyncParams(bzzdir string) *SyncParams {
+func NewDefaultSyncParams() *SyncParams {
 	return &SyncParams{
-		RequestDbPath:      filepath.Join(bzzdir, "requests"),
 		RequestDbBatchSize: requestDbBatchSize,
 		KeyBufferSize:      keyBufferSize,
 		SyncBufferSize:     syncBufferSize,
@@ -142,6 +141,12 @@ func NewSyncParams(bzzdir string) *SyncParams {
 		SyncPriorities:     []uint{High, Medium, Medium, Low, Low},
 		SyncModes:          []bool{true, true, true, true, false},
 	}
+}
+
+//this can only finally be set after all config options (file, cmd line, env vars)
+//have been evaluated
+func (self *SyncParams) Init(path string) {
+	self.RequestDbPath = filepath.Join(path, "requests")
 }
 
 // syncer is the agent that manages content distribution/storage replication/chunk storeRequest forwarding

--- a/swarm/services/swap/swap.go
+++ b/swarm/services/swap/swap.go
@@ -80,17 +80,10 @@ type PayProfile struct {
 	lock        sync.RWMutex
 }
 
-func DefaultSwapParams(contract common.Address, prvkey *ecdsa.PrivateKey) *SwapParams {
-	pubkey := &prvkey.PublicKey
+//create params with default values
+func NewDefaultSwapParams() *SwapParams {
 	return &SwapParams{
-		PayProfile: &PayProfile{
-			PublicKey:   common.ToHex(crypto.FromECDSAPub(pubkey)),
-			Contract:    contract,
-			Beneficiary: crypto.PubkeyToAddress(*pubkey),
-			privateKey:  prvkey,
-			publicKey:   pubkey,
-			owner:       crypto.PubkeyToAddress(*pubkey),
-		},
+		PayProfile: &PayProfile{},
 		Params: &swap.Params{
 			Profile: &swap.Profile{
 				BuyAt:  buyAt,
@@ -106,6 +99,21 @@ func DefaultSwapParams(contract common.Address, prvkey *ecdsa.PrivateKey) *SwapP
 				AutoDepositBuffer:    autoDepositBuffer,
 			},
 		},
+	}
+}
+
+//this can only finally be set after all config options (file, cmd line, env vars)
+//have been evaluated
+func (self *SwapParams) Init(contract common.Address, prvkey *ecdsa.PrivateKey) {
+	pubkey := &prvkey.PublicKey
+
+	self.PayProfile = &PayProfile{
+		PublicKey:   common.ToHex(crypto.FromECDSAPub(pubkey)),
+		Contract:    contract,
+		Beneficiary: crypto.PubkeyToAddress(*pubkey),
+		privateKey:  prvkey,
+		publicKey:   pubkey,
+		owner:       crypto.PubkeyToAddress(*pubkey),
 	}
 }
 

--- a/swarm/storage/netstore.go
+++ b/swarm/storage/netstore.go
@@ -57,13 +57,19 @@ type StoreParams struct {
 	Radius        int
 }
 
-func NewStoreParams(path string) (self *StoreParams) {
+//create params with default values
+func NewDefaultStoreParams() (self *StoreParams) {
 	return &StoreParams{
-		ChunkDbPath:   filepath.Join(path, "chunks"),
 		DbCapacity:    defaultDbCapacity,
 		CacheCapacity: defaultCacheCapacity,
 		Radius:        defaultRadius,
 	}
+}
+
+//this can only finally be set after all config options (file, cmd line, env vars)
+//have been evaluated
+func (self *StoreParams) Init(path string) {
+	self.ChunkDbPath = filepath.Join(path, "chunks")
 }
 
 // netstore contructor, takes path argument that is used to initialise dbStore,

--- a/swarm/swarm.go
+++ b/swarm/swarm.go
@@ -220,7 +220,7 @@ func (self *Swarm) Start(srv *p2p.Server) error {
 // stops all component services.
 func (self *Swarm) Stop() error {
 	self.dpa.Stop()
-	self.hive.Stop()
+	err := self.hive.Stop()
 	if ch := self.config.Swap.Chequebook(); ch != nil {
 		ch.Stop()
 		ch.Save()
@@ -230,7 +230,7 @@ func (self *Swarm) Stop() error {
 		self.lstore.DbStore.Close()
 	}
 	self.sfs.Stop()
-	return self.config.Save()
+	return err
 }
 
 // implements the node.Service interface
@@ -301,7 +301,6 @@ func (self *Swarm) SetChequebook(ctx context.Context) error {
 		return err
 	}
 	log.Info(fmt.Sprintf("new chequebook set (%v): saving config file, resetting all connections in the hive", self.config.Swap.Contract.Hex()))
-	self.config.Save()
 	self.hive.DropAll()
 	return nil
 }
@@ -314,10 +313,9 @@ func NewLocalSwarm(datadir, port string) (self *Swarm, err error) {
 		return
 	}
 
-	config, err := api.NewConfig(datadir, common.Address{}, prvKey, network.NetworkId)
-	if err != nil {
-		return
-	}
+	config := api.NewDefaultConfig()
+	config.Path = datadir
+	config.Init(prvKey)
 	config.Port = port
 
 	dpa, err := storage.NewLocalDPA(datadir)


### PR DESCRIPTION
This PR adds a TOML configuration option to swarm.
It reuses the TOML configuration structure used in `geth` with swarm customized items.

The PR:

- Adds a `dumpconfig` command to the `swarm` executable which allows printing the (default!) configuration to STDOUT, which then can be redirected to a file in order to customize it
- Adds a `config <file>` option to the `swarm executable` which will allow to load a configuration file in TOML format from the specified location in order to initialize the Swarm node

The override priorities are like follows:
ENVIRONMENT VARIABLES override COMMAND LINE ARGUMENTS override CONFIG FILE override DEFAULT CONFIG.



