### PR TITLE
mobile: Add GetSign to mobile BigInt

### DIFF
--- a/mobile/big.go
+++ b/mobile/big.go
@@ -62,6 +62,16 @@ func (bi *BigInt) SetInt64(x int64) {
 	bi.bigint.SetInt64(x)
 }
 
+// Sign returns:
+//
+//	-1 if x <  0
+//	 0 if x == 0
+//	+1 if x >  0
+//
+func (bi *BigInt) Sign() int {
+	return bi.bigint.Sign()
+}
+
 // SetString sets the big int to x.
 //
 // The string prefix determines the actual conversion base. A prefix of "0x" or


### PR DESCRIPTION
Currently, the only way of getting the sign of a BigInt from mobile is
coverting to string. This adds a GetSign function to make conversion
faster.