### PR TITLE
core/vm: avoid unnecessary stack memory copies during gas calc

### DIFF
--- a/core/vm/gas_table.go
+++ b/core/vm/gas_table.go
@@ -352,7 +352,7 @@ func gasCall(gt params.GasTable, evm *EVM, contract *Contract, stack *Stack, mem
 	// We replace the stack item so that it's available when the opCall instruction is
 	// called. This information is otherwise lost due to the dependency on *current*
 	// available gas.
-	stack.data[stack.len()-1] = new(big.Int).SetUint64(cg)
+	stack.data[stack.len()-1].SetUint64(cg)
 
 	if gas, overflow = math.SafeAdd(gas, cg); overflow {
 		return 0, errGasUintOverflow
@@ -384,7 +384,7 @@ func gasCallCode(gt params.GasTable, evm *EVM, contract *Contract, stack *Stack,
 	// We replace the stack item so that it's available when the opCall instruction is
 	// called. This information is otherwise lost due to the dependency on *current*
 	// available gas.
-	stack.data[stack.len()-1] = new(big.Int).SetUint64(cg)
+	stack.data[stack.len()-1].SetUint64(cg)
 
 	if gas, overflow = math.SafeAdd(gas, cg); overflow {
 		return 0, errGasUintOverflow
@@ -445,7 +445,7 @@ func gasDelegateCall(gt params.GasTable, evm *EVM, contract *Contract, stack *St
 	// (availableGas - gas) * 63 / 64
 	// We replace the stack item so that it's available when the opCall instruction is
 	// called.
-	stack.data[stack.len()-1] = new(big.Int).SetUint64(cg)
+	stack.data[stack.len()-1].SetUint64(cg)
 
 	if gas, overflow = math.SafeAdd(gas, cg); overflow {
 		return 0, errGasUintOverflow
@@ -472,7 +472,7 @@ func gasStaticCall(gt params.GasTable, evm *EVM, contract *Contract, stack *Stac
 	// (availableGas - gas) * 63 / 64
 	// We replace the stack item so that it's available when the opCall instruction is
 	// called.
-	stack.data[stack.len()-1] = new(big.Int).SetUint64(cg)
+	stack.data[stack.len()-1].SetUint64(cg)
 
 	if gas, overflow = math.SafeAdd(gas, cg); overflow {
 		return 0, errGasUintOverflow


### PR DESCRIPTION
This PR removes two batches of unnecessary memory allocations and copies with regard to EVM stack and gas calculation:

 * Whenever a `CALL*` opcode is executed, the gas allowance on the EVM stack is replaced according to the `63/64` fork rule. I don't see a reason to allocate a new `big.Int` for the new stack item. If we're overwriting anyway, we can overwrite the existing content.
 * Due to modifying the stack for `CALL*` opcodes, the EVM tracer currently copied the entire stack for every single opcode. This is insanely wasteful since we're only changing 1 value very rarely, and the tracer copied all values all the time to handle it. The PR contains a very very selective logic for saving the original stack item only if it will actually change. This saves us about 27% of tracing time.