### PR TITLE
typo: ci.go must be run from root of repo

### DIFF
--- a/build/ci.go
+++ b/build/ci.go
@@ -19,7 +19,7 @@
 /*
 The ci command is called from Continuous Integration scripts.
 
-Usage: go run ci.go <command> <command flags/arguments>
+Usage: go run build/ci.go <command> <command flags/arguments>
 
 Available commands are:
 


### PR DESCRIPTION
ran into the error on [L140](https://github.com/ethereum/go-ethereum/blob/0f7fbb85d6e939510a3e3bb6493a9a332ddfd8e8/build/ci.go#L140)