### PR TITLE
crypto/bn256: fix generator on G1

### DIFF
--- a/crypto/bn256/curve.go
+++ b/crypto/bn256/curve.go
@@ -20,7 +20,7 @@ var curveB = new(big.Int).SetInt64(3)
 // curveGen is the generator of G₁.
 var curveGen = &curvePoint{
 	new(big.Int).SetInt64(1),
-	new(big.Int).SetInt64(-2),
+	new(big.Int).SetInt64(2),
 	new(big.Int).SetInt64(1),
 	new(big.Int).SetInt64(1),
 }


### PR DESCRIPTION
Generator in the current lib uses -2 as the y point when doing ScalarBaseMult, this makes it so that points/signatures generated from libs like py_ecc don't match/validate as pretty much all other libs (including libsnark) have (1, 2) as the standard generator.

This does not affect consensus as the generator is never used in the VM, points are always explicitly defined and there is not ScalarBaseMult op - it only makes it so that doing "import github.com/ethereum/go-ethereum/crypto/bn256" doesn't generate bad points in userland tools.