### PR TITLE
eth, miner: move remote agent to it own package

### DIFF
--- a/eth/api.go
+++ b/eth/api.go
@@ -36,7 +36,7 @@ import (
 	"github.com/ethereum/go-ethereum/core/vm"
 	"github.com/ethereum/go-ethereum/internal/ethapi"
 	"github.com/ethereum/go-ethereum/log"
-	"github.com/ethereum/go-ethereum/miner"
+	"github.com/ethereum/go-ethereum/miner/remote"
 	"github.com/ethereum/go-ethereum/params"
 	"github.com/ethereum/go-ethereum/rlp"
 	"github.com/ethereum/go-ethereum/rpc"
@@ -75,12 +75,12 @@ func (api *PublicEthereumAPI) Hashrate() hexutil.Uint64 {
 // It offers only methods that operate on data that pose no security risk when it is publicly accessible.
 type PublicMinerAPI struct {
 	e     *Ethereum
-	agent *miner.RemoteAgent
+	agent *remote.RemoteAgent
 }
 
 // NewPublicMinerAPI create a new PublicMinerAPI instance.
 func NewPublicMinerAPI(e *Ethereum) *PublicMinerAPI {
-	agent := miner.NewRemoteAgent(e.BlockChain(), e.Engine())
+	agent := remote.NewRemoteAgent(e.BlockChain(), e.Engine())
 	e.Miner().Register(agent)
 
 	return &PublicMinerAPI{e, agent}

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -81,6 +81,10 @@ type Work struct {
 	createdAt time.Time
 }
 
+func (work Work) GetCreateTime() time.Time {
+	return work.createdAt
+}
+
 type Result struct {
 	Work  *Work
 	Block *types.Block


### PR DESCRIPTION
In this PR, i move the remote agent to it own package since now it will pollutes both `eth` and `miner` package. 