### PR TITLE
whisper: remove Version from the envelope (v6)

### DIFF
--- a/whisper/whisperv6/benchmarks_test.go
+++ b/whisper/whisperv6/benchmarks_test.go
@@ -17,14 +17,16 @@
 package whisperv6
 
 import (
+	"crypto/sha256"
 	"testing"
 
 	"github.com/ethereum/go-ethereum/crypto"
+	"golang.org/x/crypto/pbkdf2"
 )
 
 func BenchmarkDeriveKeyMaterial(b *testing.B) {
 	for i := 0; i < b.N; i++ {
-		deriveKeyMaterial([]byte("test"), 0)
+		pbkdf2.Key([]byte("test"), nil, 65356, aesKeyLength, sha256.New)
 	}
 }
 

--- a/whisper/whisperv6/message.go
+++ b/whisper/whisperv6/message.go
@@ -70,9 +70,8 @@ type ReceivedMessage struct {
 	Dst   *ecdsa.PublicKey // Message recipient (identity used to decode the message)
 	Topic TopicType
 
-	SymKeyHash      common.Hash // The Keccak256Hash of the key, associated with the Topic
-	EnvelopeHash    common.Hash // Message envelope hash to act as a unique id
-	EnvelopeVersion uint64
+	SymKeyHash   common.Hash // The Keccak256Hash of the key, associated with the Topic
+	EnvelopeHash common.Hash // Message envelope hash to act as a unique id
 }
 
 func isMessageSigned(flags byte) bool {

--- a/whisper/whisperv6/whisper_test.go
+++ b/whisper/whisperv6/whisper_test.go
@@ -19,11 +19,13 @@ package whisperv6
 import (
 	"bytes"
 	"crypto/ecdsa"
+	"crypto/sha256"
 	mrand "math/rand"
 	"testing"
 	"time"
 
 	"github.com/ethereum/go-ethereum/common"
+	"golang.org/x/crypto/pbkdf2"
 )
 
 func TestWhisperBasic(t *testing.T) {
@@ -79,14 +81,7 @@ func TestWhisperBasic(t *testing.T) {
 	}
 
 	var derived []byte
-	ver := uint64(0xDEADBEEF)
-	if _, err := deriveKeyMaterial(peerID, ver); err != unknownVersionError(ver) {
-		t.Fatalf("failed deriveKeyMaterial with param = %v: %s.", peerID, err)
-	}
-	derived, err = deriveKeyMaterial(peerID, 0)
-	if err != nil {
-		t.Fatalf("failed second deriveKeyMaterial with param = %v: %s.", peerID, err)
-	}
+	derived = pbkdf2.Key([]byte(peerID), nil, 65356, aesKeyLength, sha256.New)
 	if !validateSymmetricKey(derived) {
 		t.Fatalf("failed validateSymmetricKey with param = %v.", derived)
 	}


### PR DESCRIPTION
The v6 packet format no longer use the version field, this PR removes it.