### PR TITLE
rlp: fix string size check in Split

### DIFF
--- a/rlp/raw.go
+++ b/rlp/raw.go
@@ -98,7 +98,7 @@ func readKind(buf []byte) (k Kind, tagsize, contentsize uint64, err error) {
 		tagsize = 1
 		contentsize = uint64(b - 0x80)
 		// Reject strings that should've been single bytes.
-		if contentsize == 1 && buf[1] < 128 {
+		if contentsize == 1 && len(buf) > 1 && buf[1] < 128 {
 			return 0, 0, 0, ErrCanonSize
 		}
 	case b < 0xC0:

--- a/rlp/raw_test.go
+++ b/rlp/raw_test.go
@@ -96,6 +96,7 @@ func TestSplit(t *testing.T) {
 		{input: "F90055", err: ErrCanonSize, rest: "F90055"},
 		{input: "FA0002FFFF", err: ErrCanonSize, rest: "FA0002FFFF"},
 
+		{input: "81", err: ErrValueTooLarge, rest: "81"},
 		{input: "8501010101", err: ErrValueTooLarge, rest: "8501010101"},
 		{input: "C60607080902", err: ErrValueTooLarge, rest: "C60607080902"},
 


### PR DESCRIPTION
Found by @guidovranken.