### PR TITLE
whisper: sym encryption message padding includes salt

### DIFF
--- a/whisper/whisperv6/message.go
+++ b/whisper/whisperv6/message.go
@@ -123,6 +123,8 @@ func (msg *sentMessage) appendPadding(params *MessageParams) error {
 	rawSize := len(params.Payload) + 1
 	if params.Src != nil {
 		rawSize += signatureLength
+	} else {
+		rawSize += AESNonceLength
 	}
 	odd := rawSize % padSizeLimit
 

--- a/whisper/whisperv6/message.go
+++ b/whisper/whisperv6/message.go
@@ -123,7 +123,9 @@ func (msg *sentMessage) appendPadding(params *MessageParams) error {
 	rawSize := len(params.Payload) + 1
 	if params.Src != nil {
 		rawSize += signatureLength
-	} else {
+	}
+
+	if params.KeySym != nil {
 		rawSize += AESNonceLength
 	}
 	odd := rawSize % padSizeLimit

--- a/whisper/whisperv6/message_test.go
+++ b/whisper/whisperv6/message_test.go
@@ -440,3 +440,35 @@ func TestPaddingAppendedToSymMessages(t *testing.T) {
 		t.Errorf("Invalid size %d != 512", len(msg.Raw))
 	}
 }
+
+func TestPaddingAppendedToSymMessagesWithSignature(t *testing.T) {
+	params := &MessageParams{
+		Payload: make([]byte, 246),
+		KeySym:  make([]byte, aesKeyLength),
+	}
+
+	pSrc, err := crypto.GenerateKey()
+
+	if err != nil {
+		t.Fatalf("Error creating the signature key %v", err)
+		return
+	}
+	params.Src = pSrc
+
+	// Simulate a message with a payload just under 256 so that
+	// payload + flag + aesnonce > 256. Check that the result
+	// is padded on the next 256 boundary.
+	msg := sentMessage{}
+	msg.Raw = make([]byte, len(params.Payload)+1+AESNonceLength+signatureLength)
+
+	err = msg.appendPadding(params)
+
+	if err != nil {
+		t.Fatalf("Error appending padding to message %v", err)
+		return
+	}
+
+	if len(msg.Raw) != 512 {
+		t.Errorf("Invalid size %d != 512", len(msg.Raw))
+	}
+}

--- a/whisper/whisperv6/message_test.go
+++ b/whisper/whisperv6/message_test.go
@@ -416,3 +416,27 @@ func TestPadding(t *testing.T) {
 		singlePaddingTest(t, n)
 	}
 }
+
+func TestPaddingAppendedToSymMessages(t *testing.T) {
+	params := &MessageParams{
+		Payload: make([]byte, 246),
+		KeySym:  make([]byte, aesKeyLength),
+	}
+
+	// Simulate a message with a payload just under 256 so that
+	// payload + flag + aesnonce > 256. Check that the result
+	// is padded on the next 256 boundary.
+	msg := sentMessage{}
+	msg.Raw = make([]byte, len(params.Payload)+1+AESNonceLength)
+
+	err := msg.appendPadding(params)
+
+	if err != nil {
+		t.Fatalf("Error appending padding to message %v", err)
+		return
+	}
+
+	if len(msg.Raw) != 512 {
+		t.Errorf("Invalid size %d != 512", len(msg.Raw))
+	}
+}


### PR DESCRIPTION
Now that the AES salt has been moved to the payload, padding must be adjusted to hide it, lest an attacker guesses that the packet uses symmetric encryption.