### PR TITLE
swarm/api: url scheme bzzh for getting hashes of swarm content

### DIFF
--- a/swarm/api/http/server.go
+++ b/swarm/api/http/server.go
@@ -290,12 +290,9 @@ func (s *Server) HandleDelete(w http.ResponseWriter, r *Request) {
 	fmt.Fprint(w, newKey)
 }
 
-// HandleGet handles a GET request to
-// - bzzr://<key> and responds with the raw content stored at the
-//   given storage key
-// - bzzh://<key> and responds with the hash of the content stored
-//   at the given storage key as a text/plain response
-func (s *Server) HandleGet(w http.ResponseWriter, r *Request) {
+// HandleGetRaw handles a GET request to bzzr://<key> and responds with
+// the raw content stored at the given storage key
+func (s *Server) HandleGetRaw(w http.ResponseWriter, r *Request) {
 	key, err := s.api.Resolve(r.uri)
 	if err != nil {
 		s.Error(w, r, fmt.Errorf("error resolving %s: %s", r.uri.Addr, err))
@@ -348,22 +345,15 @@ func (s *Server) HandleGet(w http.ResponseWriter, r *Request) {
 		return
 	}
 
-	switch {
-	case r.uri.Raw():
-		// allow the request to overwrite the content type using a query
-		// parameter
-		contentType := "application/octet-stream"
-		if typ := r.URL.Query().Get("content_type"); typ != "" {
-			contentType = typ
-		}
-		w.Header().Set("Content-Type", contentType)
-
-		http.ServeContent(w, &r.Request, "", time.Now(), reader)
-	case r.uri.Hash():
-		w.Header().Set("Content-Type", "text/plain")
-		w.WriteHeader(http.StatusOK)
-		fmt.Fprint(w, key)
+	// allow the request to overwrite the content type using a query
+	// parameter
+	contentType := "application/octet-stream"
+	if typ := r.URL.Query().Get("content_type"); typ != "" {
+		contentType = typ
 	}
+	w.Header().Set("Content-Type", contentType)
+
+	http.ServeContent(w, &r.Request, "", time.Now(), reader)
 }
 
 // HandleGetFiles handles a GET request to bzz:/<manifest> with an Accept
@@ -626,8 +616,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		s.HandleDelete(w, req)
 
 	case "GET":
-		if uri.Raw() || uri.Hash() {
-			s.HandleGet(w, req)
+		if uri.Raw() {
+			s.HandleGetRaw(w, req)
 			return
 		}
 

--- a/swarm/api/http/server.go
+++ b/swarm/api/http/server.go
@@ -293,7 +293,7 @@ func (s *Server) HandleDelete(w http.ResponseWriter, r *Request) {
 // HandleGet handles a GET request to
 // - bzzr://<key> and responds with the raw content stored at the
 //   given storage key
-// - bzzh://<key> and responds with the hash of the content stored
+// - bzz-hash://<key> and responds with the hash of the content stored
 //   at the given storage key as a text/plain response
 func (s *Server) HandleGet(w http.ResponseWriter, r *Request) {
 	key, err := s.api.Resolve(r.uri)

--- a/swarm/api/http/server.go
+++ b/swarm/api/http/server.go
@@ -290,9 +290,12 @@ func (s *Server) HandleDelete(w http.ResponseWriter, r *Request) {
 	fmt.Fprint(w, newKey)
 }
 
-// HandleGetRaw handles a GET request to bzzr://<key> and responds with
-// the raw content stored at the given storage key
-func (s *Server) HandleGetRaw(w http.ResponseWriter, r *Request) {
+// HandleGet handles a GET request to
+// - bzzr://<key> and responds with the raw content stored at the
+//   given storage key
+// - bzzh://<key> and responds with the hash of the content stored
+//   at the given storage key as a text/plain response
+func (s *Server) HandleGet(w http.ResponseWriter, r *Request) {
 	key, err := s.api.Resolve(r.uri)
 	if err != nil {
 		s.Error(w, r, fmt.Errorf("error resolving %s: %s", r.uri.Addr, err))
@@ -345,15 +348,22 @@ func (s *Server) HandleGetRaw(w http.ResponseWriter, r *Request) {
 		return
 	}
 
-	// allow the request to overwrite the content type using a query
-	// parameter
-	contentType := "application/octet-stream"
-	if typ := r.URL.Query().Get("content_type"); typ != "" {
-		contentType = typ
-	}
-	w.Header().Set("Content-Type", contentType)
+	switch {
+	case r.uri.Raw():
+		// allow the request to overwrite the content type using a query
+		// parameter
+		contentType := "application/octet-stream"
+		if typ := r.URL.Query().Get("content_type"); typ != "" {
+			contentType = typ
+		}
+		w.Header().Set("Content-Type", contentType)
 
-	http.ServeContent(w, &r.Request, "", time.Now(), reader)
+		http.ServeContent(w, &r.Request, "", time.Now(), reader)
+	case r.uri.Hash():
+		w.Header().Set("Content-Type", "text/plain")
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprint(w, key)
+	}
 }
 
 // HandleGetFiles handles a GET request to bzz:/<manifest> with an Accept
@@ -616,8 +626,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		s.HandleDelete(w, req)
 
 	case "GET":
-		if uri.Raw() {
-			s.HandleGetRaw(w, req)
+		if uri.Raw() || uri.Hash() {
+			s.HandleGet(w, req)
 			return
 		}
 

--- a/swarm/api/http/server_test.go
+++ b/swarm/api/http/server_test.go
@@ -33,7 +33,7 @@ import (
 	"github.com/ethereum/go-ethereum/swarm/testutil"
 )
 
-func TestBzzGetPath(t *testing.T) {
+func TestBzzrGetPath(t *testing.T) {
 
 	var err error
 
@@ -104,46 +104,15 @@ func TestBzzGetPath(t *testing.T) {
 		}
 	}
 
-	for k, v := range testrequests {
-		var resp *http.Response
-		var respbody []byte
-
-		url := srv.URL + "/bzzh:/"
-		if k[:] != "" {
-			url += common.ToHex(key[0])[2:] + "/" + k[1:]
-		}
-		resp, err = http.Get(url)
-		if err != nil {
-			t.Fatalf("Request failed: %v", err)
-		}
-		defer resp.Body.Close()
-		respbody, err = ioutil.ReadAll(resp.Body)
-
-		if string(respbody) != key[v].String() {
-			isexpectedfailrequest := false
-
-			for _, r := range expectedfailrequests {
-				if k[:] == r {
-					isexpectedfailrequest = true
-				}
-			}
-			if !isexpectedfailrequest {
-				t.Fatalf("Response body does not match, expected: %v, got %v", key[v], string(respbody))
-			}
-		}
-	}
-
 	nonhashtests := []string{
 		srv.URL + "/bzz:/name",
 		srv.URL + "/bzzi:/nonhash",
 		srv.URL + "/bzzr:/nonhash",
-		srv.URL + "/bzzh:/nonhash",
 	}
 
 	nonhashresponses := []string{
 		"error resolving name: no DNS to resolve name: &#34;name&#34;",
 		"error resolving nonhash: immutable address not a content hash: &#34;nonhash&#34;",
-		"error resolving nonhash: no DNS to resolve name: &#34;nonhash&#34;",
 		"error resolving nonhash: no DNS to resolve name: &#34;nonhash&#34;",
 	}
 

--- a/swarm/api/http/server_test.go
+++ b/swarm/api/http/server_test.go
@@ -33,7 +33,7 @@ import (
 	"github.com/ethereum/go-ethereum/swarm/testutil"
 )
 
-func TestBzzrGetPath(t *testing.T) {
+func TestBzzGetPath(t *testing.T) {
 
 	var err error
 
@@ -104,14 +104,13 @@ func TestBzzrGetPath(t *testing.T) {
 		}
 	}
 
-	// test hash requests
 	for k, v := range testrequests {
 		var resp *http.Response
 		var respbody []byte
 
-		url := srv.URL + "/bzz:/"
+		url := srv.URL + "/bzzh:/"
 		if k[:] != "" {
-			url += common.ToHex(key[0])[2:] + "/" + k[1:] + "?swarm.hash=true"
+			url += common.ToHex(key[0])[2:] + "/" + k[1:]
 		}
 		resp, err = http.Get(url)
 		if err != nil {
@@ -134,23 +133,21 @@ func TestBzzrGetPath(t *testing.T) {
 		}
 	}
 
-	errorTests := []string{
+	nonhashtests := []string{
 		srv.URL + "/bzz:/name",
 		srv.URL + "/bzzi:/nonhash",
 		srv.URL + "/bzzr:/nonhash",
-		srv.URL + "/bzz:/nonhash?swarm.hash=true",
-		srv.URL + "/bzz:/a?swarm.hash=true&list=true",
+		srv.URL + "/bzzh:/nonhash",
 	}
 
-	errorResponses := []string{
+	nonhashresponses := []string{
 		"error resolving name: no DNS to resolve name: &#34;name&#34;",
 		"error resolving nonhash: immutable address not a content hash: &#34;nonhash&#34;",
 		"error resolving nonhash: no DNS to resolve name: &#34;nonhash&#34;",
 		"error resolving nonhash: no DNS to resolve name: &#34;nonhash&#34;",
-		"query parameters list and hash can not be requested at the same time",
 	}
 
-	for i, url := range errorTests {
+	for i, url := range nonhashtests {
 		var resp *http.Response
 		var respbody []byte
 
@@ -164,8 +161,8 @@ func TestBzzrGetPath(t *testing.T) {
 		if err != nil {
 			t.Fatalf("ReadAll failed: %v", err)
 		}
-		if !strings.Contains(string(respbody), errorResponses[i]) {
-			t.Fatalf("Non-Hash response body does not match, expected: %v, got: %v", errorResponses[i], string(respbody))
+		if !strings.Contains(string(respbody), nonhashresponses[i]) {
+			t.Fatalf("Non-Hash response body does not match, expected: %v, got: %v", nonhashresponses[i], string(respbody))
 		}
 	}
 

--- a/swarm/api/http/server_test.go
+++ b/swarm/api/http/server_test.go
@@ -108,7 +108,7 @@ func TestBzzGetPath(t *testing.T) {
 		var resp *http.Response
 		var respbody []byte
 
-		url := srv.URL + "/bzzh:/"
+		url := srv.URL + "/bzz-hash:/"
 		if k[:] != "" {
 			url += common.ToHex(key[0])[2:] + "/" + k[1:]
 		}
@@ -137,7 +137,7 @@ func TestBzzGetPath(t *testing.T) {
 		srv.URL + "/bzz:/name",
 		srv.URL + "/bzzi:/nonhash",
 		srv.URL + "/bzzr:/nonhash",
-		srv.URL + "/bzzh:/nonhash",
+		srv.URL + "/bzz-hash:/nonhash",
 	}
 
 	nonhashresponses := []string{

--- a/swarm/api/http/server_test.go
+++ b/swarm/api/http/server_test.go
@@ -33,7 +33,7 @@ import (
 	"github.com/ethereum/go-ethereum/swarm/testutil"
 )
 
-func TestBzzrGetPath(t *testing.T) {
+func TestBzzGetPath(t *testing.T) {
 
 	var err error
 
@@ -104,15 +104,46 @@ func TestBzzrGetPath(t *testing.T) {
 		}
 	}
 
+	for k, v := range testrequests {
+		var resp *http.Response
+		var respbody []byte
+
+		url := srv.URL + "/bzzh:/"
+		if k[:] != "" {
+			url += common.ToHex(key[0])[2:] + "/" + k[1:]
+		}
+		resp, err = http.Get(url)
+		if err != nil {
+			t.Fatalf("Request failed: %v", err)
+		}
+		defer resp.Body.Close()
+		respbody, err = ioutil.ReadAll(resp.Body)
+
+		if string(respbody) != key[v].String() {
+			isexpectedfailrequest := false
+
+			for _, r := range expectedfailrequests {
+				if k[:] == r {
+					isexpectedfailrequest = true
+				}
+			}
+			if !isexpectedfailrequest {
+				t.Fatalf("Response body does not match, expected: %v, got %v", key[v], string(respbody))
+			}
+		}
+	}
+
 	nonhashtests := []string{
 		srv.URL + "/bzz:/name",
 		srv.URL + "/bzzi:/nonhash",
 		srv.URL + "/bzzr:/nonhash",
+		srv.URL + "/bzzh:/nonhash",
 	}
 
 	nonhashresponses := []string{
 		"error resolving name: no DNS to resolve name: &#34;name&#34;",
 		"error resolving nonhash: immutable address not a content hash: &#34;nonhash&#34;",
+		"error resolving nonhash: no DNS to resolve name: &#34;nonhash&#34;",
 		"error resolving nonhash: no DNS to resolve name: &#34;nonhash&#34;",
 	}
 

--- a/swarm/api/uri.go
+++ b/swarm/api/uri.go
@@ -30,8 +30,6 @@ type URI struct {
 	// * bzzr - raw swarm content
 	// * bzzi - immutable URI of an entry in a swarm manifest
 	//          (address is not resolved)
-	// * bzzh - hash of swarm content
-	//
 	Scheme string
 
 	// Addr is either a hexadecimal storage key or it an address which
@@ -62,7 +60,7 @@ func Parse(rawuri string) (*URI, error) {
 
 	// check the scheme is valid
 	switch uri.Scheme {
-	case "bzz", "bzzi", "bzzr", "bzzh":
+	case "bzz", "bzzi", "bzzr":
 	default:
 		return nil, fmt.Errorf("unknown scheme %q", u.Scheme)
 	}
@@ -91,10 +89,6 @@ func (u *URI) Raw() bool {
 
 func (u *URI) Immutable() bool {
 	return u.Scheme == "bzzi"
-}
-
-func (u *URI) Hash() bool {
-	return u.Scheme == "bzzh"
 }
 
 func (u *URI) String() string {

--- a/swarm/api/uri.go
+++ b/swarm/api/uri.go
@@ -30,6 +30,8 @@ type URI struct {
 	// * bzzr - raw swarm content
 	// * bzzi - immutable URI of an entry in a swarm manifest
 	//          (address is not resolved)
+	// * bzzh - hash of swarm content
+	//
 	Scheme string
 
 	// Addr is either a hexadecimal storage key or it an address which
@@ -60,7 +62,7 @@ func Parse(rawuri string) (*URI, error) {
 
 	// check the scheme is valid
 	switch uri.Scheme {
-	case "bzz", "bzzi", "bzzr":
+	case "bzz", "bzzi", "bzzr", "bzzh":
 	default:
 		return nil, fmt.Errorf("unknown scheme %q", u.Scheme)
 	}
@@ -89,6 +91,10 @@ func (u *URI) Raw() bool {
 
 func (u *URI) Immutable() bool {
 	return u.Scheme == "bzzi"
+}
+
+func (u *URI) Hash() bool {
+	return u.Scheme == "bzzh"
 }
 
 func (u *URI) String() string {

--- a/swarm/api/uri.go
+++ b/swarm/api/uri.go
@@ -30,7 +30,7 @@ type URI struct {
 	// * bzzr - raw swarm content
 	// * bzzi - immutable URI of an entry in a swarm manifest
 	//          (address is not resolved)
-	// * bzzh - hash of swarm content
+	// * bzz-hash - hash of swarm content
 	//
 	Scheme string
 
@@ -52,7 +52,7 @@ type URI struct {
 // * <scheme>://<addr>
 // * <scheme>://<addr>/<path>
 //
-// with scheme one of bzz, bzzr, bzzi or bzzh
+// with scheme one of bzz, bzzr, bzzi or bzz-hash
 func Parse(rawuri string) (*URI, error) {
 	u, err := url.Parse(rawuri)
 	if err != nil {
@@ -62,7 +62,7 @@ func Parse(rawuri string) (*URI, error) {
 
 	// check the scheme is valid
 	switch uri.Scheme {
-	case "bzz", "bzzi", "bzzr", "bzzh":
+	case "bzz", "bzzi", "bzzr", "bzz-hash":
 	default:
 		return nil, fmt.Errorf("unknown scheme %q", u.Scheme)
 	}
@@ -94,7 +94,7 @@ func (u *URI) Immutable() bool {
 }
 
 func (u *URI) Hash() bool {
-	return u.Scheme == "bzzh"
+	return u.Scheme == "bzz-hash"
 }
 
 func (u *URI) String() string {

--- a/swarm/api/uri.go
+++ b/swarm/api/uri.go
@@ -52,7 +52,7 @@ type URI struct {
 // * <scheme>://<addr>
 // * <scheme>://<addr>/<path>
 //
-// with scheme one of bzz, bzzr or bzzi
+// with scheme one of bzz, bzzr, bzzi or bzzh
 func Parse(rawuri string) (*URI, error) {
 	u, err := url.Parse(rawuri)
 	if err != nil {

--- a/swarm/api/uri_test.go
+++ b/swarm/api/uri_test.go
@@ -28,7 +28,6 @@ func TestParseURI(t *testing.T) {
 		expectErr       bool
 		expectRaw       bool
 		expectImmutable bool
-		expectHash      bool
 	}
 	tests := []test{
 		{
@@ -96,16 +95,6 @@ func TestParseURI(t *testing.T) {
 			uri:       "bzz://abc123/path/to/entry",
 			expectURI: &URI{Scheme: "bzz", Addr: "abc123", Path: "path/to/entry"},
 		},
-		{
-			uri:        "bzzh:",
-			expectURI:  &URI{Scheme: "bzzh"},
-			expectHash: true,
-		},
-		{
-			uri:        "bzzh:/",
-			expectURI:  &URI{Scheme: "bzzh"},
-			expectHash: true,
-		},
 	}
 	for _, x := range tests {
 		actual, err := Parse(x.uri)
@@ -126,9 +115,6 @@ func TestParseURI(t *testing.T) {
 		}
 		if actual.Immutable() != x.expectImmutable {
 			t.Fatalf("expected %s immutable to be %t, got %t", x.uri, x.expectImmutable, actual.Immutable())
-		}
-		if actual.Hash() != x.expectHash {
-			t.Fatalf("expected %s hash to be %t, got %t", x.uri, x.expectHash, actual.Hash())
 		}
 	}
 }

--- a/swarm/api/uri_test.go
+++ b/swarm/api/uri_test.go
@@ -97,13 +97,13 @@ func TestParseURI(t *testing.T) {
 			expectURI: &URI{Scheme: "bzz", Addr: "abc123", Path: "path/to/entry"},
 		},
 		{
-			uri:        "bzzh:",
-			expectURI:  &URI{Scheme: "bzzh"},
+			uri:        "bzz-hash:",
+			expectURI:  &URI{Scheme: "bzz-hash"},
 			expectHash: true,
 		},
 		{
-			uri:        "bzzh:/",
-			expectURI:  &URI{Scheme: "bzzh"},
+			uri:        "bzz-hash:/",
+			expectURI:  &URI{Scheme: "bzz-hash"},
 			expectHash: true,
 		},
 	}

--- a/swarm/api/uri_test.go
+++ b/swarm/api/uri_test.go
@@ -28,6 +28,7 @@ func TestParseURI(t *testing.T) {
 		expectErr       bool
 		expectRaw       bool
 		expectImmutable bool
+		expectHash      bool
 	}
 	tests := []test{
 		{
@@ -95,6 +96,16 @@ func TestParseURI(t *testing.T) {
 			uri:       "bzz://abc123/path/to/entry",
 			expectURI: &URI{Scheme: "bzz", Addr: "abc123", Path: "path/to/entry"},
 		},
+		{
+			uri:        "bzzh:",
+			expectURI:  &URI{Scheme: "bzzh"},
+			expectHash: true,
+		},
+		{
+			uri:        "bzzh:/",
+			expectURI:  &URI{Scheme: "bzzh"},
+			expectHash: true,
+		},
 	}
 	for _, x := range tests {
 		actual, err := Parse(x.uri)
@@ -115,6 +126,9 @@ func TestParseURI(t *testing.T) {
 		}
 		if actual.Immutable() != x.expectImmutable {
 			t.Fatalf("expected %s immutable to be %t, got %t", x.uri, x.expectImmutable, actual.Immutable())
+		}
+		if actual.Hash() != x.expectHash {
+			t.Fatalf("expected %s hash to be %t, got %t", x.uri, x.expectHash, actual.Hash())
 		}
 	}
 }


### PR DESCRIPTION
This PR implements bzzh scheme as described in issue ethereum#15238.

More discussion on this subject is on a related PR https://github.com/ethersphere/go-ethereum/pull/141.