### PR TITLE
ethapi: GetTransactionReceipt panic fix

### DIFF
--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -1006,6 +1006,9 @@ func (s *PublicTransactionPoolAPI) GetTransactionReceipt(hash common.Hash) (map[
 		return nil, nil
 	}
 	receipt, _, _, _ := core.GetReceipt(s.b.ChainDb(), hash) // Old receipts don't have the lookup data available
+	if receipt == nil {
+		return nil, nil
+	}
 
 	var signer types.Signer = types.FrontierSigner{}
 	if tx.Protected() {

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -1003,11 +1003,11 @@ func (s *PublicTransactionPoolAPI) GetRawTransactionByHash(ctx context.Context, 
 func (s *PublicTransactionPoolAPI) GetTransactionReceipt(hash common.Hash) (map[string]interface{}, error) {
 	tx, blockHash, blockNumber, index := core.GetTransaction(s.b.ChainDb(), hash)
 	if tx == nil {
-		return nil, nil
+		return nil, errors.New("unknown transaction")
 	}
 	receipt, _, _, _ := core.GetReceipt(s.b.ChainDb(), hash) // Old receipts don't have the lookup data available
 	if receipt == nil {
-		return nil, nil
+		return nil, errors.New("unknown receipt")
 	}
 
 	var signer types.Signer = types.FrontierSigner{}


### PR DESCRIPTION
Panic occurs when core.GetReceipt may return nil receipt.

#15408
#14432