### PR TITLE
les, light: add GetCheckpoint request (status.im issue 320)

### DIFF
--- a/les/odr.go
+++ b/les/odr.go
@@ -77,6 +77,7 @@ const (
 	MsgProofsV2
 	MsgHeaderProofs
 	MsgHelperTrieProofs
+	MsgCheckpoint
 )
 
 // Msg encodes a LES message that delivers reply data for a request

--- a/les/odr_requests.go
+++ b/les/odr_requests.go
@@ -545,9 +545,7 @@ func (r *BloomRequest) Validate(db ethdb.Database, msg *Msg) error {
 	return nil
 }
 
-///////////////////////////////////////////////////////////////////////////////////////////
-// status.im request 320
-
+// For status.im request 320
 type CheckpointReq struct {
 	SectionIdx uint64
 }
@@ -597,8 +595,6 @@ func (r *CheckpointRequest) Validate(db ethdb.Database, msg *Msg) error {
 	r.BloomRoot = hashes[2]
 	return nil
 }
-
-///////////////////////////////////////////////////////////////////////////////////////////////
 
 // readTraceDB stores the keys of database reads. We use this to check that received node
 // sets contain only the trie nodes necessary to make proofs pass.

--- a/les/peer.go
+++ b/les/peer.go
@@ -325,6 +325,25 @@ func (p *peer) SendTxs(reqID, cost uint64, txs types.Transactions) error {
 	}
 }
 
+// RequestCheckpoint a checkpoint at the specified section index from a remote node.
+func (p *peer) RequestCheckpoint(reqID, cost uint64, req CheckpointReq) error {
+	p.Log().Debug("Fetching checkpoint", "req", req, "p.version", p.version, "lpv1", lpv1)
+	switch p.version {
+	case lpv1:
+		p.Log().Info("RequestCheckpoint: lpv1 so doing nothing")
+		return nil
+	case lpv2:
+		return sendRequest(p.rw, GetCheckpointMsg, reqID, cost, req)
+	default:
+		panic(nil)
+	}
+}
+
+// SendCheckpoint sends a checkpoint, corresponding to the one requested.
+func (p *peer) SendCheckpoint(reqID, bv uint64, roots [3]common.Hash) error {
+	return sendResponse(p.rw, CheckpointMsg, reqID, bv, roots)
+}
+
 type keyValueEntry struct {
 	Key   string
 	Value rlp.RawValue

--- a/les/peer.go
+++ b/les/peer.go
@@ -325,7 +325,7 @@ func (p *peer) SendTxs(reqID, cost uint64, txs types.Transactions) error {
 	}
 }
 
-// RequestCheckpoint a checkpoint at the specified section index from a remote node.
+// RequestCheckpoint requests a checkpoint at the specified section index from a remote node.
 func (p *peer) RequestCheckpoint(reqID, cost uint64, req CheckpointReq) error {
 	p.Log().Debug("Fetching checkpoint", "req", req, "p.version", p.version, "lpv1", lpv1)
 	switch p.version {

--- a/les/protocol.go
+++ b/les/protocol.go
@@ -46,7 +46,7 @@ var (
 )
 
 // Number of implemented message corresponding to different protocol versions.
-var ProtocolLengths = map[uint]uint64{lpv1: 15, lpv2: 22}
+var ProtocolLengths = map[uint]uint64{lpv1: 15, lpv2: 24}
 
 const (
 	NetworkId          = 1
@@ -79,6 +79,8 @@ const (
 	SendTxV2Msg            = 0x13
 	GetTxStatusMsg         = 0x14
 	TxStatusMsg            = 0x15
+	GetCheckpointMsg       = 0x16
+	CheckpointMsg          = 0x17
 )
 
 type errCode int

--- a/les/sync.go
+++ b/les/sync.go
@@ -95,6 +95,11 @@ func updateCheckpointFromPeer(pm *ProtocolManager, peer *peer, ctx context.Conte
 	var peerHeadBlockNum = hbl.Number
 	log.Debug("updateCheckpointFromPeer", "peerHeadBlockNum", peerHeadBlockNum)
 
+	if peerHeadBlockNum+1 < light.ChtFrequency {
+		log.Info("Peer has no fully processed blocks, nothing to do")
+		return
+	}
+
 	var sectionIdx uint64 = ((peerHeadBlockNum + 1) / light.ChtFrequency) - 1
 	log.Debug("Retrieving checkpoint with: ", "sectionIdx", sectionIdx)
 

--- a/les/sync.go
+++ b/les/sync.go
@@ -96,7 +96,7 @@ func updateCheckpointFromPeer(pm *ProtocolManager, peer *peer, ctx context.Conte
 	log.Debug("updateCheckpointFromPeer", "peerHeadBlockNum", peerHeadBlockNum)
 
 	if peerHeadBlockNum+1 < light.ChtFrequency {
-		log.Info("Peer has no fully processed sections, so no checkpoint to download")
+		log.Info("Peer has no fully processed sections; so no checkpoint to download")
 		return
 	}
 

--- a/les/sync.go
+++ b/les/sync.go
@@ -81,19 +81,19 @@ func (pm *ProtocolManager) synchronise(peer *peer) {
 
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
 	defer cancel()
-	updateChtFromPeer(pm, peer, ctx)
+	updateCheckpointFromPeer(pm, peer, ctx)
 	pm.blockchain.(*light.LightChain).SyncCht(ctx)
 	pm.downloader.Synchronise(peer.id, peer.Head(), peer.Td(), downloader.LightSync)
 }
 
-// Status.im issue 320: Use GetHeaderProofs to download the latest CHT from a peer.
-func updateChtFromPeer(pm *ProtocolManager, peer *peer, ctx context.Context) {
-	log.Info("Downloading latest CHT root from peer", "peer.headBlockInfo", peer.headBlockInfo())
+// Status.im issue 320: Use GetCheckpoint to download the latest checkpoint from a peer.
+func updateCheckpointFromPeer(pm *ProtocolManager, peer *peer, ctx context.Context) {
+	log.Info("Downloading latest checkpoint from peer", "peer.headBlockInfo", peer.headBlockInfo())
 
 	// Formula from lightchain.go:SyncCht: num := cht.Number*ChtFrequency – 1
 	var hbl = peer.headBlockInfo()
 	var peerHeadBlockNum = hbl.Number
-	log.Debug("UpdateChtFromPeer", "peerHeadBlockNum", peerHeadBlockNum)
+	log.Debug("updateCheckpointFromPeer", "peerHeadBlockNum", peerHeadBlockNum)
 
 	var sectionIdx uint64 = ((peerHeadBlockNum + 1) / light.ChtFrequency) - 1
 	log.Debug("Retrieving checkpoint with: ", "sectionIdx", sectionIdx)

--- a/les/sync.go
+++ b/les/sync.go
@@ -96,7 +96,7 @@ func updateCheckpointFromPeer(pm *ProtocolManager, peer *peer, ctx context.Conte
 	log.Debug("updateCheckpointFromPeer", "peerHeadBlockNum", peerHeadBlockNum)
 
 	if peerHeadBlockNum+1 < light.ChtFrequency {
-		log.Info("Peer has no fully processed blocks, nothing to do")
+		log.Info("Peer has no fully processed sections, so no checkpoint to download")
 		return
 	}
 

--- a/les/sync.go
+++ b/les/sync.go
@@ -98,7 +98,7 @@ func updateChtFromPeer(pm *ProtocolManager, peer *peer, ctx context.Context) {
 	var sectionIdx uint64 = ((peerHeadBlockNum + 1) / light.ChtFrequency) - 1
 	log.Debug("Retrieving checkpoint with: ", "sectionIdx", sectionIdx)
 
-	req := &light.CheckpointRequest{SectionIdx: uint64(sectionIdx)}
+	req := &light.CheckpointRequest{SectionIdx: sectionIdx}
 	pm.odr.Retrieve(ctx, req)
 	log.Info("Retrieved checkpoint from peer: ",
 		"SectionHead=", common.ToHex(req.SectionHead.Bytes()),

--- a/light/lightchain.go
+++ b/light/lightchain.go
@@ -91,6 +91,7 @@ func NewLightChain(odr OdrBackend, config *params.ChainConfig, engine consensus.
 	if err != nil {
 		return nil, err
 	}
+
 	bc.genesisBlock, _ = bc.GetBlockByNumber(NoOdr, 0)
 	if bc.genesisBlock == nil {
 		return nil, core.ErrNoGenesis
@@ -111,6 +112,13 @@ func NewLightChain(odr OdrBackend, config *params.ChainConfig, engine consensus.
 		}
 	}
 	return bc, nil
+}
+
+func (self *LightChain) AddTrustedCheckpoint(name string, sectionIdx uint64,
+	sectionHead common.Hash,
+	chtRoot common.Hash, bloomTrieRoot common.Hash) {
+	cp := trustedCheckpoint{name, sectionIdx, sectionHead, chtRoot, bloomTrieRoot}
+	self.addTrustedCheckpoint(cp)
 }
 
 // addTrustedCheckpoint adds a trusted checkpoint to the blockchain

--- a/light/odr.go
+++ b/light/odr.go
@@ -169,3 +169,16 @@ func (req *BloomRequest) StoreResult(db ethdb.Database) {
 		core.WriteBloomBits(db, req.BitIdx, sectionIdx, sectionHead, req.BloomBits[i])
 	}
 }
+
+// CheckpointRequest is the ODR request type for retrieving a CHT+BloomRoot checkpoint
+type CheckpointRequest struct {
+	OdrRequest
+	SectionIdx  uint64
+	SectionHead common.Hash
+	ChtRoot     common.Hash
+	BloomRoot   common.Hash
+}
+
+// StoreResult stores the retrieved data in local database
+func (req *CheckpointRequest) StoreResult(db ethdb.Database) {
+}


### PR DESCRIPTION
Fixes status-im/status-go#320: "Devise how to update CHT automatically" 

It supersedes PR status-im/status-go#476 , the status.im team asked that to be ported to upstream.

Add a GetCheckpoint request/response pair to LES, to allow client to retrieve an up-to-date checkpoint from peer before synching.
A new function, updateCheckpointFromPeer, is called from ProtocolManager.synchronise to download the highest available checkpoint. As a sanity check, a much older block is then downloaded and verified.
Tested and works fine (using a private network).