### PR TITLE
cmd: Increase lightservers on network

### DIFF
--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -173,7 +173,7 @@ var (
 	LightServFlag = cli.IntFlag{
 		Name:  "lightserv",
 		Usage: "Maximum percentage of time allowed for serving LES requests (0-90)",
-		Value: 0,
+		Value: 25,
 	}
 	LightPeersFlag = cli.IntFlag{
 		Name:  "lightpeers",


### PR DESCRIPTION
Longer term solution to issue #15454.
By allowing geth default behavior to serve light clients, 
we'll improve the overall network capacity.
