### PR TITLE
contracts/release: do not print error log if les backend has no peers

### DIFF
--- a/contracts/release/release.go
+++ b/contracts/release/release.go
@@ -137,7 +137,7 @@ func (r *ReleaseService) checkVersion() {
 	if err != nil {
 		if err == bind.ErrNoCode {
 			log.Debug("Release oracle not found", "contract", r.config.Oracle)
-		} else {
+		} else if err != les.ErrNoPeers {
 			log.Error("Failed to retrieve current release", "err", err)
 		}
 		return

--- a/light/trie.go
+++ b/light/trie.go
@@ -151,7 +151,7 @@ func (t *odrTrie) do(key []byte, fn func() error) error {
 		}
 		r := &TrieRequest{Id: t.id, Key: key}
 		if err := t.db.backend.Retrieve(t.db.ctx, r); err != nil {
-			return fmt.Errorf("can't fetch trie key %x: %v", key, err)
+			return err
 		}
 	}
 }


### PR DESCRIPTION
Light client always printed this error message at startup but there is no need to report an error in this case, just retry next time.
A light trie error is also changed which is a simple solution for this problem but I believe it is the right one. The retrieval error is the relevant info here, it makes no sense to wrap it just because it happened during a trie node retrieval.