### PR TITLE
accounts/keystore: Improved error message

### DIFF
--- a/accounts/keystore/presale.go
+++ b/accounts/keystore/presale.go
@@ -58,6 +58,9 @@ func decryptPreSaleKey(fileContent []byte, password string) (key *Key, err error
 	if err != nil {
 		return nil, errors.New("invalid hex in encSeed")
 	}
+	if len(encSeedBytes) < 16 {
+		return nil, errors.New("invalid encSeed, too short")
+	}
 	iv := encSeedBytes[:16]
 	cipherText := encSeedBytes[16:]
 	/*


### PR DESCRIPTION
* Fix for #15668

now looks like:

```sh
➜  go-ethereum git:(15668) build/bin/geth wallet import /tmp/bla.json                
Passphrase: 
Fatal: invalid encSeed, too short
```