### PR TITLE
Signer pt 1

### DIFF
--- a/accounts/abi/abi.go
+++ b/accounts/abi/abi.go
@@ -20,6 +20,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"bytes"
 )
 
 // The ABI holds information about a contract's context and available
@@ -135,5 +136,16 @@ func (abi *ABI) UnmarshalJSON(data []byte) error {
 		}
 	}
 
+	return nil
+}
+
+// methodById looks up a method by the 4-byte id
+// returns nil if none found
+func (abi *ABI) MethodById(sigdata []byte) *Method {
+	for _, method := range abi.Methods{
+		if bytes.Equal(method.Id(), sigdata) {
+			return &method
+		}
+	}
 	return nil
 }

--- a/accounts/abi/event.go
+++ b/accounts/abi/event.go
@@ -75,7 +75,7 @@ func (e Event) tupleUnpack(v interface{}, output []byte) error {
 			// need to move this up because they read sequentially
 			j += input.Type.Size
 		}
-		marshalledValue, err := toGoType((i+j)*32, input.Type, output)
+		marshalledValue, err := ToGoType((i+j)*32, input.Type, output)
 		if err != nil {
 			return err
 		}
@@ -126,7 +126,7 @@ func (e Event) singleUnpack(v interface{}, output []byte) error {
 
 	value := valueOf.Elem()
 
-	marshalledValue, err := toGoType(0, e.Inputs[0].Type, output)
+	marshalledValue, err := ToGoType(0, e.Inputs[0].Type, output)
 	if err != nil {
 		return err
 	}

--- a/accounts/abi/method.go
+++ b/accounts/abi/method.go
@@ -99,7 +99,7 @@ func (method Method) tupleUnpack(v interface{}, output []byte) error {
 			// need to move this up because they read sequentially
 			j += toUnpack.Type.Size
 		}
-		marshalledValue, err := toGoType((i+j)*32, toUnpack.Type, output)
+		marshalledValue, err := ToGoType((i+j)*32, toUnpack.Type, output)
 		if err != nil {
 			return err
 		}
@@ -146,7 +146,7 @@ func (method Method) singleUnpack(v interface{}, output []byte) error {
 
 	value := valueOf.Elem()
 
-	marshalledValue, err := toGoType(0, method.Outputs[0].Type, output)
+	marshalledValue, err := ToGoType(0, method.Outputs[0].Type, output)
 	if err != nil {
 		return err
 	}

--- a/accounts/abi/unpack.go
+++ b/accounts/abi/unpack.go
@@ -127,7 +127,7 @@ func forEachUnpack(t Type, output []byte, start, size int) (interface{}, error) 
 		if t.Elem.T == ArrayTy && j != 0 {
 			i = start + t.Elem.Size*32*j
 		}
-		inter, err := toGoType(i, *t.Elem, output)
+		inter, err := ToGoType(i, *t.Elem, output)
 		if err != nil {
 			return nil, err
 		}
@@ -139,9 +139,9 @@ func forEachUnpack(t Type, output []byte, start, size int) (interface{}, error) 
 	return refSlice.Interface(), nil
 }
 
-// toGoType parses the output bytes and recursively assigns the value of these bytes
+// ToGoType parses the output bytes and recursively assigns the value of these bytes
 // into a go type with accordance with the ABI spec.
-func toGoType(index int, t Type, output []byte) (interface{}, error) {
+func ToGoType(index int, t Type, output []byte) (interface{}, error) {
 	if index+32 > len(output) {
 		return nil, fmt.Errorf("abi: cannot marshal in to go type: length insufficient %d require %d", len(output), index+32)
 	}

--- a/accounts/usbwallet/hub.go
+++ b/accounts/usbwallet/hub.go
@@ -127,7 +127,7 @@ func (hub *Hub) refreshWallets() {
 		// breaking the Ledger protocol if that is waiting for user confirmation. This
 		// is a bug acknowledged at Ledger, but it won't be fixed on old devices so we
 		// need to prevent concurrent comms ourselves. The more elegant solution would
-		// be to ditch enumeration in favor of hutplug events, but that don't work yet
+		// be to ditch enumeration in favor of hotplug events, but that don't work yet
 		// on Windows so if we need to hack it anyway, this is more elegant for now.
 		hub.commsLock.Lock()
 		if hub.commsPend > 0 { // A confirmation is pending, don't refresh

--- a/accounts/usbwallet/wallet.go
+++ b/accounts/usbwallet/wallet.go
@@ -99,7 +99,7 @@ type wallet struct {
 	//
 	// As such, a hardware wallet needs two locks to function correctly. A state
 	// lock can be used to protect the wallet's software-side internal state, which
-	// must not be held exlusively during hardware communication. A communication
+	// must not be held exclusively during hardware communication. A communication
 	// lock can be used to achieve exclusive access to the device itself, this one
 	// however should allow "skipping" waiting for operations that might want to
 	// use the device, but can live without too (e.g. account self-derivation).

--- a/common/types_test.go
+++ b/common/types_test.go
@@ -18,6 +18,7 @@ package common
 
 import (
 	"encoding/json"
+
 	"math/big"
 	"strings"
 	"testing"
@@ -148,4 +149,47 @@ func BenchmarkAddressHex(b *testing.B) {
 	for n := 0; n < b.N; n++ {
 		testAddr.Hex()
 	}
+}
+
+func TestMixedcaseAccount_Address(t *testing.T) {
+
+	// https://github.com/ethereum/EIPs/blob/master/EIPS/eip-55.md
+	// Note: 0X{checksum_addr} is not valid according to spec above
+
+	var res []struct {
+		A     MixedcaseAddress
+		Valid bool
+	}
+	if err := json.Unmarshal([]byte(`[
+		{"A" : "0xae967917c465db8578ca9024c205720b1a3651A9", "Valid": false},
+		{"A" : "0xAe967917c465db8578ca9024c205720b1a3651A9", "Valid": true},
+		{"A" : "0XAe967917c465db8578ca9024c205720b1a3651A9", "Valid": false},
+		{"A" : "0x1111111111111111111112222222222223333323", "Valid": true}
+		]`), &res); err != nil {
+		t.Fatal(err)
+	}
+
+	for _, r := range res {
+		if got := r.A.ValidChecksum(); got != r.Valid {
+			t.Errorf("Expected checksum %v, got checksum %v, input %v", r.Valid, got, r.A.String())
+		}
+	}
+
+	//These should throw exceptions:
+	var r2 []MixedcaseAddress
+	for _, r := range []string{
+		`["0x11111111111111111111122222222222233333"]`,     // Too short
+		`["0x111111111111111111111222222222222333332"]`,    // Too short
+		`["0x11111111111111111111122222222222233333234"]`,  // Too long
+		`["0x111111111111111111111222222222222333332344"]`, // Too long
+		`["1111111111111111111112222222222223333323"]`,     // Missing 0x
+		`["x1111111111111111111112222222222223333323"]`,    // Missing 0
+		`["0xG111111111111111111112222222222223333323"]`,   //Non-hex
+	} {
+		if err := json.Unmarshal([]byte(r), &r2); err == nil {
+			t.Errorf("Expected failure, input %v", r)
+		}
+
+	}
+
 }

--- a/rpc/client.go
+++ b/rpc/client.go
@@ -33,6 +33,7 @@ import (
 	"time"
 
 	"github.com/ethereum/go-ethereum/log"
+	"os"
 )
 
 var (
@@ -171,11 +172,52 @@ func DialContext(ctx context.Context, rawurl string) (*Client, error) {
 		return DialHTTP(rawurl)
 	case "ws", "wss":
 		return DialWebsocket(ctx, rawurl, "")
+	case "stdio":
+		return DialStdIO(ctx)
 	case "":
 		return DialIPC(ctx, rawurl)
 	default:
 		return nil, fmt.Errorf("no known transport for URL scheme %q", u.Scheme)
 	}
+}
+
+type StdIOConn struct{}
+
+func (io StdIOConn) Read(b []byte) (n int, err error) {
+	return os.Stdin.Read(b)
+}
+
+func (io StdIOConn) Write(b []byte) (n int, err error) {
+	return os.Stdout.Write(b)
+}
+
+func (io StdIOConn) Close() error {
+	return nil
+}
+
+func (io StdIOConn) LocalAddr() net.Addr {
+	return &net.UnixAddr{Name: "stdio", Net: "stdio"}
+}
+
+func (io StdIOConn) RemoteAddr() net.Addr {
+	return &net.UnixAddr{Name: "stdio", Net: "stdio"}
+}
+
+func (io StdIOConn) SetDeadline(t time.Time) error {
+	return &net.OpError{Op: "set", Net: "stdio", Source: nil, Addr: nil, Err: errors.New("deadline not supported")}
+}
+
+func (io StdIOConn) SetReadDeadline(t time.Time) error {
+	return &net.OpError{Op: "set", Net: "stdio", Source: nil, Addr: nil, Err: errors.New("deadline not supported")}
+}
+
+func (io StdIOConn) SetWriteDeadline(t time.Time) error {
+	return &net.OpError{Op: "set", Net: "stdio", Source: nil, Addr: nil, Err: errors.New("deadline not supported")}
+}
+func DialStdIO(ctx context.Context) (*Client, error) {
+	return newClient(ctx, func(_ context.Context) (net.Conn, error) {
+		return StdIOConn{}, nil
+	})
 }
 
 func newClient(initctx context.Context, connectFunc func(context.Context) (net.Conn, error)) (*Client, error) {
@@ -184,7 +226,6 @@ func newClient(initctx context.Context, connectFunc func(context.Context) (net.C
 		return nil, err
 	}
 	_, isHTTP := conn.(*httpConn)
-
 	c := &Client{
 		writeConn:   conn,
 		isHTTP:      isHTTP,
@@ -524,13 +565,13 @@ func (c *Client) dispatch(conn net.Conn) {
 			}
 
 		case err := <-c.readErr:
-			log.Debug(fmt.Sprintf("<-readErr: %v", err))
+			log.Debug("<-readErr", "err", err)
 			c.closeRequestOps(err)
 			conn.Close()
 			reading = false
 
 		case newconn := <-c.reconnected:
-			log.Debug(fmt.Sprintf("<-reconnected: (reading=%t) %v", reading, conn.RemoteAddr()))
+			log.Debug("<-reconnected", "reading", reading, "remote", conn.RemoteAddr())
 			if reading {
 				// Wait for the previous read loop to exit. This is a rare case.
 				conn.Close()
@@ -587,7 +628,7 @@ func (c *Client) closeRequestOps(err error) {
 
 func (c *Client) handleNotification(msg *jsonrpcMessage) {
 	if !strings.HasSuffix(msg.Method, notificationMethodSuffix) {
-		log.Debug(fmt.Sprint("dropping non-subscription message: ", msg))
+		log.Debug("dropping non-subscription message", "msg", msg)
 		return
 	}
 	var subResult struct {
@@ -595,7 +636,7 @@ func (c *Client) handleNotification(msg *jsonrpcMessage) {
 		Result json.RawMessage `json:"result"`
 	}
 	if err := json.Unmarshal(msg.Params, &subResult); err != nil {
-		log.Debug(fmt.Sprint("dropping invalid subscription message: ", msg))
+		log.Debug("dropping invalid subscription message", "msg", msg)
 		return
 	}
 	if c.subs[subResult.ID] != nil {
@@ -606,7 +647,7 @@ func (c *Client) handleNotification(msg *jsonrpcMessage) {
 func (c *Client) handleResponse(msg *jsonrpcMessage) {
 	op := c.respWait[string(msg.ID)]
 	if op == nil {
-		log.Debug(fmt.Sprintf("unsolicited response %v", msg))
+		log.Debug("unsolicited response", "msg", msg)
 		return
 	}
 	delete(c.respWait, string(msg.ID))

--- a/rpc/http.go
+++ b/rpc/http.go
@@ -159,11 +159,16 @@ func (srv *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	// All checks passed, create a codec that reads direct from the request body
 	// untilEOF and writes the response to w and order the server to process a
 	// single request.
+	ctx := context.Background()
+	ctx = context.WithValue(ctx, "remote", r.RemoteAddr)
+	ctx = context.WithValue(ctx, "scheme", r.Proto)
+	ctx = context.WithValue(ctx, "local", r.Host)
+
 	codec := NewJSONCodec(&httpReadWriteNopCloser{r.Body, w})
 	defer codec.Close()
 
 	w.Header().Set("content-type", contentType)
-	srv.ServeSingleRequest(codec, OptionMethodInvocation)
+	srv.ServeSingleRequest(codec, OptionMethodInvocation, ctx)
 }
 
 // validateRequest returns a non-zero response code and error message if the

--- a/rpc/types.go
+++ b/rpc/types.go
@@ -74,6 +74,7 @@ type Server struct {
 	run      int32
 	codecsMu sync.Mutex
 	codecs   *set.Set
+	auditlog *RPCLogger
 }
 
 // rpcRequest represents a raw incoming RPC request


### PR DESCRIPTION
This is the first PR for the signer, containing some preparations for future work.  Note for reviewers: This PR _should_ not affect _any_ existing feature or change any functionality in the way geth works today (so please shout if you believe it does). Contents of this PR: 

* `toGoType` -> `ToGoType`: to enable parsing calldata according to an ABI-specification. 
* Case-preserving address-type. This can (later on) be used instead of `common.Address` in e.g. `to` - field in `sendTransaction`, and will internally remember what the input was, instead of storing _only_ the 20 bytes that make up the address. This will make it possible for geth to forward the data verbatim, and the UI can alert the user about erroneous checksums. Also, the signer API uses this already. 
* Stdio client: a new rpc client which uses stdin/stdout for communication
* Audit log. This is useless in geth, which has credentials over the API, but is used in the signer which does not. 
* Forwarding of certain parameters, e.g. remote ip, so that the API methods can be aware of where the request comes from. If there are better ways of doing this, hints are appreciated. I'd like more values (e.g `Origin`), and don't like to hardcode every possible value into the http server.  