### PR TITLE
rpc: Closing Notifier must tear down subscriptions

### DIFF
--- a/rpc/subscription_test.go
+++ b/rpc/subscription_test.go
@@ -72,16 +72,10 @@ func (s *NotificationTestService) SomeSubscription(ctx context.Context, n, val i
 			}
 		}
 
-		select {
-		case <-notifier.Closed():
-			s.mu.Lock()
-			s.unsubscribed = true
-			s.mu.Unlock()
-		case <-subscription.Err():
-			s.mu.Lock()
-			s.unsubscribed = true
-			s.mu.Unlock()
-		}
+		<-subscription.Err()
+		s.mu.Lock()
+		s.unsubscribed = true
+		s.mu.Unlock()
 	}()
 
 	return subscription, nil


### PR DESCRIPTION
* Fixes #15553
* Add a pipeline on the `Notifier`'s `codec` that propagates the `close` to `Subscription`s
* Adjust `subscription_test` accordingly since closing the notifier now implies closing the subscription
  * This should automatically test the initial issue and also makes the tests more determistic by saving a `select`