### PR TITLE
core: fix panic when stat-ing a tx from a queue-only account

### DIFF
--- a/core/tx_pool.go
+++ b/core/tx_pool.go
@@ -838,7 +838,7 @@ func (pool *TxPool) Status(hashes []common.Hash) []TxStatus {
 	for i, hash := range hashes {
 		if tx := pool.all[hash]; tx != nil {
 			from, _ := types.Sender(pool.signer, tx) // already validated
-			if pool.pending[from].txs.items[tx.Nonce()] != nil {
+			if pool.pending[from] != nil && pool.pending[from].txs.items[tx.Nonce()] != nil {
 				status[i] = TxStatusPending
 			} else {
 				status[i] = TxStatusQueued


### PR DESCRIPTION
Fixes https://github.com/ethereum/go-ethereum/issues/15711.

The light client has a functionality to request the txpool status of a transaction (unknown, pending, queued). This operates by looking up the transaction, and if it's known by the pool (contained in `pool.all`), it checks whether it's in `pool.pending[from]` or not.

However, `pool.pending[from]` might be `nil` if the account only has queued transactions, but no pending ones. In that case, the code crashed. This PR fixes is so that if `pool.pending[from]` is `nil`, the transaction is immediately assumed to be queued, and not explicitly checked further.