### PR TITLE
core: silence txpool reorg warning (annoying on import)

### DIFF
--- a/core/tx_pool.go
+++ b/core/tx_pool.go
@@ -360,7 +360,7 @@ func (pool *TxPool) reset(oldHead, newHead *types.Header) {
 		newNum := newHead.Number.Uint64()
 
 		if depth := uint64(math.Abs(float64(oldNum) - float64(newNum))); depth > 64 {
-			log.Warn("Skipping deep transaction reorg", "depth", depth)
+			log.Debug("Skipping deep transaction reorg", "depth", depth)
 		} else {
 			// Reorg seems shallow enough to pull in all transactions into memory
 			var discarded, included types.Transactions


### PR DESCRIPTION
Whenever the blockchain does a reorg, the transaction pool needs to load up all the transactions that went missing in the process. If the reorg is deeper than 64 blocks, the pool ignored it and warns us. If however we're importing big batches of blocks (full sync, fast sync end, or catching up), we're constantly being "warned", which gets annoying fast.

Since this warning was mostly inserted to detect errors with the new logic (which seems to work correctly), I think we can lower it from WARN to DEBUG. The blockchain will still warn us of large reorgs, so there's no inherent added value here, as long as the txpool works correctly in handling them.