### PR TITLE
cmd/faucet: fix removal of Twitter zlib compression

### DIFF
--- a/cmd/faucet/faucet.go
+++ b/cmd/faucet/faucet.go
@@ -21,7 +21,6 @@ package main
 
 import (
 	"bytes"
-	"compress/zlib"
 	"context"
 	"encoding/json"
 	"errors"
@@ -698,11 +697,7 @@ func authTwitter(url string) (string, string, common.Address, error) {
 	}
 	defer res.Body.Close()
 
-	reader, err := zlib.NewReader(res.Body)
-	if err != nil {
-		return "", "", common.Address{}, err
-	}
-	body, err := ioutil.ReadAll(reader)
+	body, err := ioutil.ReadAll(res.Body)
 	if err != nil {
 		return "", "", common.Address{}, err
 	}


### PR DESCRIPTION
Fixes https://github.com/ethereum/go-ethereum/issues/15645 and https://github.com/ethereum/go-ethereum/issues/15635.

Twitter in their latest update reworked their HTTP compression, properly doing it now (previously they used some forced zlib compression, even if the client didn't ask for it). This PR updates the faucet to drop the forced zlib decompression too.