### PR TITLE
cmd/puppeth: fix faucet 502 error due to non-exposed HTTP port

### DIFF
--- a/cmd/puppeth/module_faucet.go
+++ b/cmd/puppeth/module_faucet.go
@@ -39,6 +39,8 @@ ADD genesis.json /genesis.json
 ADD account.json /account.json
 ADD account.pass /account.pass
 
+EXPOSE 8080 30303 30303/udp
+
 ENTRYPOINT [ \
 	"faucet", "--genesis", "/genesis.json", "--network", "{{.NetworkID}}", "--bootnodes", "{{.Bootnodes}}", "--ethstats", "{{.Ethstats}}", "--ethport", "{{.EthPort}}",     \
 	"--faucet.name", "{{.FaucetName}}", "--faucet.amount", "{{.FaucetAmount}}", "--faucet.minutes", "{{.FaucetMinutes}}", "--faucet.tiers", "{{.FaucetTiers}}",             \


### PR DESCRIPTION
When we switched over from puppeth's custom faucet docker image to the official geth-alltools image, the `EXPOSE 8080` went missing, causing the new image not to have nginx access. This fixes it by reopening the port.