### PR TITLE
Use --prestate flag to pass JSON file to Rinkeby and Testnet

### DIFF
--- a/cmd/evm/main.go
+++ b/cmd/evm/main.go
@@ -90,10 +90,6 @@ var (
 		Name:  "nogasmetering",
 		Usage: "disable gas metering",
 	}
-	GenesisFlag = cli.StringFlag{
-		Name:  "prestate",
-		Usage: "JSON file with prestate (genesis) config",
-	}
 	MachineFlag = cli.BoolFlag{
 		Name:  "json",
 		Usage: "output trace logs in machine readable format (json)",

--- a/cmd/evm/runner.go
+++ b/cmd/evm/runner.go
@@ -48,27 +48,6 @@ var runCommand = cli.Command{
 	Description: `The run command runs arbitrary EVM code.`,
 }
 
-// readGenesis will read the given JSON format genesis file and return
-// the initialized Genesis structure
-func readGenesis(genesisPath string) *core.Genesis {
-	// Make sure we have a valid genesis JSON
-	//genesisPath := ctx.Args().First()
-	if len(genesisPath) == 0 {
-		utils.Fatalf("Must supply path to genesis JSON file")
-	}
-	file, err := os.Open(genesisPath)
-	if err != nil {
-		utils.Fatalf("Failed to read genesis file: %v", err)
-	}
-	defer file.Close()
-
-	genesis := new(core.Genesis)
-	if err := json.NewDecoder(file).Decode(genesis); err != nil {
-		utils.Fatalf("invalid genesis file: %v", err)
-	}
-	return genesis
-}
-
 func runCmd(ctx *cli.Context) error {
 	glogger := log.NewGlogHandler(log.StreamHandler(os.Stderr, log.TerminalFormat(false)))
 	glogger.Verbosity(log.Lvl(ctx.GlobalInt(VerbosityFlag.Name)))
@@ -95,7 +74,7 @@ func runCmd(ctx *cli.Context) error {
 		debugLogger = vm.NewStructLogger(logconfig)
 	}
 	if ctx.GlobalString(GenesisFlag.Name) != "" {
-		gen := readGenesis(ctx.GlobalString(GenesisFlag.Name))
+		gen := utils.ReadGenesis(ctx.GlobalString(GenesisFlag.Name))
 		_, statedb = gen.ToBlock()
 		chainConfig = gen.Config
 	} else {

--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -118,6 +118,7 @@ var (
 		utils.GpoBlocksFlag,
 		utils.GpoPercentileFlag,
 		utils.ExtraDataFlag,
+		utils.GenesisFlag,
 		configFileFlag,
 	}
 


### PR DESCRIPTION
Moved GenesisFlag to utils to use --prestate flag for loading genesis JSON file in Rinkeby and Testnet.