### PR TITLE
[WIP, Don't Review] travis, appveyor: upgrade to Go 1.10beta1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,6 @@ matrix:
         - go run build/ci.go install
         - go run build/ci.go test -coverage
 
-    # These are the latest Go versions.
     - os: linux
       dist: trusty
       sudo: required
@@ -37,8 +36,20 @@ matrix:
         - go run build/ci.go install
         - go run build/ci.go test -coverage
 
+    # These are the latest Go versions.
+    - os: linux
+      dist: trusty
+      sudo: required
+      go: 1.10beta1
+      script:
+        - sudo modprobe fuse
+        - sudo chmod 666 /dev/fuse
+        - sudo chown root:$USER /etc/fuse.conf
+        - go run build/ci.go install
+        - go run build/ci.go test -coverage
+
     - os: osx
-      go: 1.9.x
+      go: 1.10beta1
       script:
         - brew update
         - brew install caskroom/cask/brew-cask
@@ -49,7 +60,7 @@ matrix:
     # This builder only tests code linters on latest version of Go
     - os: linux
       dist: trusty
-      go: 1.9.x
+      go: 1.10beta1
       env:
         - lint
       git:
@@ -61,7 +72,7 @@ matrix:
     - os: linux
       dist: trusty
       sudo: required
-      go: 1.9.x
+      go: 1.10beta1
       env:
         - ubuntu-ppa
         - azure-linux
@@ -101,7 +112,7 @@ matrix:
       dist: trusty
       services:
         - docker
-      go: 1.9.x
+      go: 1.10beta1
       env:
         - azure-linux-mips
       git:
@@ -145,7 +156,7 @@ matrix:
       git:
         submodules: false # avoid cloning ethereum/tests
       before_install:
-        - curl https://storage.googleapis.com/golang/go1.9.2.linux-amd64.tar.gz | tar -xz
+        - curl https://storage.googleapis.com/golang/go1.10beta1.linux-amd64.tar.gz | tar -xz
         - export PATH=`pwd`/go/bin:$PATH
         - export GOROOT=`pwd`/go
         - export GOPATH=$HOME/go
@@ -162,7 +173,7 @@ matrix:
 
     # This builder does the OSX Azure, iOS CocoaPods and iOS Azure uploads
     - os: osx
-      go: 1.9.x
+      go: 1.10beta1
       env:
         - azure-osx
         - azure-ios
@@ -190,7 +201,7 @@ matrix:
     - os: linux
       dist: trusty
       sudo: required
-      go: 1.9.x
+      go: 1.10beta1
       env:
         - azure-purge
       git:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -23,8 +23,8 @@ environment:
 install:
   - git submodule update --init
   - rmdir C:\go /s /q
-  - appveyor DownloadFile https://storage.googleapis.com/golang/go1.9.2.windows-%GETH_ARCH%.zip
-  - 7z x go1.9.2.windows-%GETH_ARCH%.zip -y -oC:\ > NUL
+  - appveyor DownloadFile https://storage.googleapis.com/golang/go1.10beta1.windows-%GETH_ARCH%.zip
+  - 7z x go1.10beta1.windows-%GETH_ARCH%.zip -y -oC:\ > NUL
   - go version
   - gcc --version
 

--- a/vendor/github.com/rjeczalik/notify/watcher_fsevents_cgo.go
+++ b/vendor/github.com/rjeczalik/notify/watcher_fsevents_cgo.go
@@ -26,6 +26,7 @@ import "C"
 import (
 	"errors"
 	"os"
+	"runtime"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -63,6 +64,10 @@ var (
 func init() {
 	wg.Add(1)
 	go func() {
+		// There is exactly one run loop per thread. Lock this goroutine to its
+		// thread to ensure that it's not rescheduled on a different thread while
+		// setting up the run loop.
+		runtime.LockOSThread()
 		runloop = C.CFRunLoopGetCurrent()
 		C.CFRunLoopAddSource(runloop, source, C.kCFRunLoopDefaultMode)
 		C.CFRunLoopRun()

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -286,10 +286,10 @@
 			"revisionTime": "2016-11-28T21:05:44Z"
 		},
 		{
-			"checksumSHA1": "tnQdt7bxmueZFl0EPrW9YrWiqGg=",
+			"checksumSHA1": "lhq+IT6eusmK2Ortmhen0qT3wJM=",
 			"path": "github.com/rjeczalik/notify",
-			"revision": "e1801ee34d54c4bf45126ef51fe9750b4e42bee8",
-			"revisionTime": "2017-12-10T15:45:11Z"
+			"revision": "b76ef5c8085eae5170c0b1e3abbd94e41e086bfb",
+			"revisionTime": "2018-01-03T10:29:26Z"
 		},
 		{
 			"checksumSHA1": "5uqO4ITTDMklKi3uNaE/D9LQ5nM=",


### PR DESCRIPTION
**DO NOT MERGE**

This is a WIP progress PR mostly to have our code tested against the upcoming Go release. Go 1.10 does a couple more invasive changes which might cause gofmt or the linters to signal new stuff, so it's better to catch in time. Also there's a build error on current master with 32 bit versions of Go, so this PR should help test that for upstream verifications.

Trophies: https://github.com/ethereum/go-ethereum/pull/15781, https://github.com/ethereum/go-ethereum/pull/15782, https://github.com/ethereum/go-ethereum/pull/15783, https://github.com/ethereum/go-ethereum/pull/15784, https://github.com/ethereum/go-ethereum/pull/15785, https://github.com/rjeczalik/notify/issues/139.