### PR TITLE
cmd/geth: fix extra trailing newline in license command

### DIFF
--- a/cmd/geth/misccmd.go
+++ b/cmd/geth/misccmd.go
@@ -134,7 +134,6 @@ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
-along with geth. If not, see <http://www.gnu.org/licenses/>.
-`)
+along with geth. If not, see <http://www.gnu.org/licenses/>.`)
 	return nil
 }


### PR DESCRIPTION
The `geth license` command currently prints the license, and adds two newlines at the end. This gets flagged (i.e. compile error) on Go 1.10 since `fmt.Println` already prints a new line, so no need to double it.

Although we could change the code to retain the current functionality, I don't think there's a particular need to print an empty line after the license, so I've just removed the extra newline character.