### PR TITLE
whisper/whisper2: fix Go 1.10 vet issues on type mismatches

### DIFF
--- a/whisper/whisperv2/whisper.go
+++ b/whisper/whisperv2/whisper.go
@@ -262,7 +262,7 @@ func (self *Whisper) add(envelope *Envelope) error {
 	// Insert the message into the tracked pool
 	hash := envelope.Hash()
 	if _, ok := self.messages[hash]; ok {
-		log.Trace(fmt.Sprintf("whisper envelope already cached: %x\n", envelope))
+		log.Trace(fmt.Sprintf("whisper envelope already cached: %x\n", hash))
 		return nil
 	}
 	self.messages[hash] = envelope
@@ -277,7 +277,7 @@ func (self *Whisper) add(envelope *Envelope) error {
 		// Notify the local node of a message arrival
 		go self.postEvent(envelope)
 	}
-	log.Trace(fmt.Sprintf("cached whisper envelope %x\n", envelope))
+	log.Trace(fmt.Sprintf("cached whisper envelope %x\n", hash))
 	return nil
 }
 


### PR DESCRIPTION
There are two `fmt.Sprintf` type errors in whisper, where the requested formatting type is hex `%x`, but the input is a `whisper.Envelope`. This PR fixes it by actually printing what the dev intended (the hash on the envelope).

Btw, the `fmt.Sprintf` is useless in the log (was an automatic refactor), but since whisper2 is deprecated already, this PR is just meant to fix the type issue (which results in a compilation error on Go 1.10), but doesn't attempt to further clean up the old code.