### PR TITLE
build/ci.go: don't set CC for `go run ci.go`, only inside

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -87,13 +87,13 @@ matrix:
         - sudo -E apt-get -yq --no-install-suggests --no-install-recommends --force-yes install gcc-arm-linux-gnueabi libc6-dev-armel-cross gcc-arm-linux-gnueabihf libc6-dev-armhf-cross gcc-aarch64-linux-gnu libc6-dev-arm64-cross
         - sudo ln -s /usr/include/asm-generic /usr/include/asm
 
-        - GOARM=5 CC=arm-linux-gnueabi-gcc go run build/ci.go install -arch arm
+        - GOARM=5 go run build/ci.go install -arch arm -cc arm-linux-gnueabi-gcc
         - GOARM=5 go run build/ci.go archive -arch arm -type tar -signer LINUX_SIGNING_KEY -upload gethstore/builds
-        - GOARM=6 CC=arm-linux-gnueabi-gcc go run build/ci.go install -arch arm
+        - GOARM=6 go run build/ci.go install -arch arm -cc arm-linux-gnueabi-gcc
         - GOARM=6 go run build/ci.go archive -arch arm -type tar -signer LINUX_SIGNING_KEY -upload gethstore/builds
-        - GOARM=7 CC=arm-linux-gnueabihf-gcc go run build/ci.go install -arch arm
+        - GOARM=7 go run build/ci.go install -arch arm -cc arm-linux-gnueabihf-gcc
         - GOARM=7 go run build/ci.go archive -arch arm -type tar -signer LINUX_SIGNING_KEY -upload gethstore/builds
-        - CC=aarch64-linux-gnu-gcc go run build/ci.go install -arch arm64
+        - go run build/ci.go install -arch arm64 -cc aarch64-linux-gnu-gcc
         - go run build/ci.go archive -arch arm64 -type tar -signer LINUX_SIGNING_KEY -upload gethstore/builds
 
     # This builder does the Linux Azure MIPS xgo uploads

--- a/build/ci.go
+++ b/build/ci.go
@@ -23,7 +23,7 @@ Usage: go run build/ci.go <command> <command flags/arguments>
 
 Available commands are:
 
-   install    [ -arch architecture ] [ packages... ]                                           -- builds packages and executables
+   install    [ -arch architecture ] [ -cc compiler ] [ packages... ]                          -- builds packages and executables
    test       [ -coverage ] [ packages... ]                                                    -- runs the tests
    lint                                                                                        -- runs certain pre-selected linters
    archive    [ -arch architecture ] [ -type zip|tar ] [ -signer key-envvar ] [ -upload dest ] -- archives build artefacts
@@ -173,6 +173,7 @@ func main() {
 func doInstall(cmdline []string) {
 	var (
 		arch = flag.String("arch", "", "Architecture to cross build for")
+		cc   = flag.String("cc", "", "C compiler to cross build with")
 	)
 	flag.CommandLine.Parse(cmdline)
 	env := build.Env()
@@ -207,7 +208,7 @@ func doInstall(cmdline []string) {
 		}
 	}
 	// Seems we are cross compiling, work around forbidden GOBIN
-	goinstall := goToolArch(*arch, "install", buildFlags(env)...)
+	goinstall := goToolArch(*arch, *cc, "install", buildFlags(env)...)
 	goinstall.Args = append(goinstall.Args, "-v")
 	goinstall.Args = append(goinstall.Args, []string{"-buildmode", "archive"}...)
 	goinstall.Args = append(goinstall.Args, packages...)
@@ -221,7 +222,7 @@ func doInstall(cmdline []string) {
 			}
 			for name := range pkgs {
 				if name == "main" {
-					gobuild := goToolArch(*arch, "build", buildFlags(env)...)
+					gobuild := goToolArch(*arch, *cc, "build", buildFlags(env)...)
 					gobuild.Args = append(gobuild.Args, "-v")
 					gobuild.Args = append(gobuild.Args, []string{"-o", executablePath(cmd.Name())}...)
 					gobuild.Args = append(gobuild.Args, "."+string(filepath.Separator)+filepath.Join("cmd", cmd.Name()))
@@ -249,10 +250,10 @@ func buildFlags(env build.Environment) (flags []string) {
 }
 
 func goTool(subcmd string, args ...string) *exec.Cmd {
-	return goToolArch(runtime.GOARCH, subcmd, args...)
+	return goToolArch(runtime.GOARCH, os.Getenv("CC"), subcmd, args...)
 }
 
-func goToolArch(arch string, subcmd string, args ...string) *exec.Cmd {
+func goToolArch(arch string, cc string, subcmd string, args ...string) *exec.Cmd {
 	cmd := build.GoTool(subcmd, args...)
 	if subcmd == "build" || subcmd == "install" || subcmd == "test" {
 		// Go CGO has a Windows linker error prior to 1.8 (https://github.com/golang/go/issues/8756).
@@ -267,6 +268,9 @@ func goToolArch(arch string, subcmd string, args ...string) *exec.Cmd {
 	} else {
 		cmd.Env = append(cmd.Env, "CGO_ENABLED=1")
 		cmd.Env = append(cmd.Env, "GOARCH="+arch)
+	}
+	if cc != "" {
+		cmd.Env = append(cmd.Env, "CC="+cc)
 	}
 	for _, e := range os.Environ() {
 		if strings.HasPrefix(e, "GOPATH=") || strings.HasPrefix(e, "GOBIN=") {


### PR DESCRIPTION
Our `build/ci.go` script + travic config combo was incorrect from a Go tooling standpoint, but worked correctly up to Go 1.9 due to limitations of Go itself. Go 1.10 fixes the limitations, causing our CI script to break.

The issue lies in the way we pass the C compiler for cross compilation to `ci.go`. Currently we just set `CC` before calling `go run build/ci.go`, which will get passed to the inside cross compilation invocation. The issue is that this in reality sets `CC` for the outer `go run` too, not just cross compilation. So in theory if `ci.go` depended on CGO, things would blow up because we try to use some cross compiler to build for the host.

Unfortunately, `ci.go` **does** indeed depend on CGO through some arbitrary dependency path. The reason we never hit this issue is because Go 1.9 and below just looked at `runtime/cgo.a`, saw that it was recent and didn't try to rebuild. Go 1.10 gets a bit smarter, and notices that the C compiler changed, so it **will** try to rebuild `runtime/cgo`, which will result in all kinds of failures when the C compiler is actually a cross compilat for a different platform/architecture (e.g. arm).

This PR fixes the issue by not specifying the C compiler through the outer `CC` env var, rather sets it as a flag to `ci.go install`, which will internally convert it into a `CC` env var before invoking the cross compiling Go step.

More details and discussion on the Go issue tracker: https://github.com/golang/go/issues/23288