### PR TITLE
cmd/utils/flags.go: Applying a String len guard for the gitCommit param of the NewApp()

### DIFF
--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -96,7 +96,7 @@ func NewApp(gitCommit, usage string) *cli.App {
 	//app.Authors = nil
 	app.Email = ""
 	app.Version = params.Version
-	if gitCommit != "" && len(gitCommit) >= 8 {
+	if len(gitCommit) >= 8 {
 		app.Version += "-" + gitCommit[:8]
 	}
 	app.Usage = usage

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -96,7 +96,7 @@ func NewApp(gitCommit, usage string) *cli.App {
 	//app.Authors = nil
 	app.Email = ""
 	app.Version = params.Version
-	if gitCommit != "" {
+	if gitCommit != "" && len(gitCommit) >= 8 {
 		app.Version += "-" + gitCommit[:8]
 	}
 	app.Usage = usage


### PR DESCRIPTION
Just a simple guard to match the check-case of [1]. Seems that for some applications, people are trying to sneak in the git-tag (version) of theirs, rather than an actual commit hash. This is only to protect them.

[1] https://github.com/ethereum/go-ethereum/blob/master/params/version.go#L41