### PR TITLE
internal/ethapi: ask transaction pool for pending nonce

### DIFF
--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -1074,6 +1074,15 @@ func (s *PublicTransactionPoolAPI) GetRawTransactionByBlockHashAndIndex(ctx cont
 
 // GetTransactionCount returns the number of transactions the given address has sent for the given block number
 func (s *PublicTransactionPoolAPI) GetTransactionCount(ctx context.Context, address common.Address, blockNr rpc.BlockNumber) (*hexutil.Uint64, error) {
+	// Ask transaction pool for the nonce which includes pending transactions
+	if blockNr == rpc.PendingBlockNumber {
+		nonce, err := s.b.GetPoolNonce(ctx, address)
+		if err != nil {
+			return nil, err
+		}
+		return (*hexutil.Uint64)(&nonce), nil
+	}
+	// Resolve block number and use its state to ask for the nonce
 	state, _, err := s.b.StateAndHeaderByNumber(ctx, blockNr)
 	if state == nil || err != nil {
 		return nil, err


### PR DESCRIPTION
As described in #2880, for anyone using `abigen` contract bindings to submit concurrent transactions, there is a race condition such that it is possible for two concurrent transactions to be submitted with the same nonce if the first transaction is still pending when the second transaction is submitted.

`transact` in https://github.com/ethereum/go-ethereum/blob/master/accounts/abi/bind/base.go#L176 uses `PendingNonceAt` which invokes the `GetTransactionCount` API method. Currently, `GetTransactionCount` uses `StateAndHeaderByNumber` to get the nonce from the pending state. But, only the miner knows the pending state so if the local node is not a miner, then the state used to get the nonce will not include any pending transactions that the sender has submitted.

This is not a problem for sending transactions using web3 because by default the `SendTransaction` API method in https://github.com/ethereum/go-ethereum/blob/master/internal/ethapi/api.go#L1097 uses `GetPoolNonce` to ask the local node's transaction pool for the pending nonce which will include pending transactions that the sender has submitted.

It seems that `GetTransactionCount` should ask the local node's transaction pool for the nonce if we want the pending nonce to include pending transactions.