### PR TITLE
eth: fix tracer panic when running without configs + reexec

### DIFF
--- a/eth/api_tracer.go
+++ b/eth/api_tracer.go
@@ -204,7 +204,7 @@ func (api *PrivateDebugAPI) traceChain(ctx context.Context, start, end *types.Bl
 	if err != nil {
 		// If the starting state is missing, allow some number of blocks to be reexecuted
 		reexec := defaultTraceReexec
-		if config.Reexec != nil {
+		if config != nil && config.Reexec != nil {
 			reexec = *config.Reexec
 		}
 		// Find the most recent block that has the state available
@@ -465,7 +465,7 @@ func (api *PrivateDebugAPI) traceBlock(ctx context.Context, block *types.Block, 
 		return nil, fmt.Errorf("parent %x not found", block.ParentHash())
 	}
 	reexec := defaultTraceReexec
-	if config.Reexec != nil {
+	if config != nil && config.Reexec != nil {
 		reexec = *config.Reexec
 	}
 	statedb, err := api.computeStateDB(parent, reexec)
@@ -619,7 +619,7 @@ func (api *PrivateDebugAPI) TraceTransaction(ctx context.Context, hash common.Ha
 		return nil, fmt.Errorf("transaction %x not found", hash)
 	}
 	reexec := defaultTraceReexec
-	if config.Reexec != nil {
+	if config != nil && config.Reexec != nil {
 		reexec = *config.Reexec
 	}
 	msg, vmctx, statedb, err := api.computeTxEnv(blockHash, int(index), reexec)


### PR DESCRIPTION
The fancy tracer PR added a new functionality to reexecute a number of historical blocks for a trace if the state is missing for the requested entity (block, chain, tx). This is 128 by default but can be explicitly set via a tracer config field.

Currently there's a `nil` pointer panic in the old raw tracer because that one does not have a `config` parameter at all, but the tracing code still pokes around `config.Reexec`. This PR fixes it by checking first whether the config parameter itself was set before trying to poke around its fields.