### PR TITLE
eth: revert tracer preimage recording

### DIFF
--- a/eth/api_tracer.go
+++ b/eth/api_tracer.go
@@ -667,14 +667,11 @@ func (api *PrivateDebugAPI) traceTx(ctx context.Context, message core.Message, v
 		tracer = vm.NewStructLogger(config.LogConfig)
 	}
 	// Run the transaction with tracing enabled.
-	vmenv := vm.NewEVM(vmctx, statedb, api.config, vm.Config{Debug: true, Tracer: tracer, EnablePreimageRecording: true})
+	vmenv := vm.NewEVM(vmctx, statedb, api.config, vm.Config{Debug: true, Tracer: tracer})
 
 	ret, gas, failed, err := core.ApplyMessage(vmenv, message, new(core.GasPool).AddGas(message.Gas()))
 	if err != nil {
 		return nil, fmt.Errorf("tracing failed: %v", err)
-	}
-	if err := core.WritePreimages(api.eth.ChainDb(), vmctx.BlockNumber.Uint64(), statedb.Preimages()); err != nil {
-		return nil, fmt.Errorf("can't write preimage: %v", err)
 	}
 	// Depending on the tracer type, format and return the output
 	switch tracer := tracer.(type) {


### PR DESCRIPTION
This reverts commits 85a1eda59e (#15792) and c495bca4ad (#15787)
because they introduce database writes during tracing.