### PR TITLE
go-ethereum/dashboard: update assets.go

### DIFF
--- a/dashboard/assets.go
+++ b/dashboard/assets.go
@@ -14,7 +14,6 @@ import (
 	"strings"
 	"time"
 )
-
 type asset struct {
 	bytes []byte
 	info  os.FileInfo
@@ -46,8 +45,7 @@ func (fi bindataFileInfo) Sys() interface{} {
 	return nil
 }
 
-//nolint:misspell
-var _publicBundleJs = []byte(`!function(modules) {
+var _publicBundleJs = []byte((((((((((`!function(modules) {
     function __webpack_require__(moduleId) {
         if (installedModules[moduleId]) return installedModules[moduleId].exports;
         var module = installedModules[moduleId] = {
@@ -741,10 +739,10 @@ var _publicBundleJs = []byte(`!function(modules) {
                                 renderedClasses = sheetsManagerTheme.sheet.classes;
                             }
                             classes = classesProp ? (0, _extends3.default)({}, renderedClasses, (0, _keys2.default)(classesProp).reduce(function(accumulator, key) {
-                                return "production" !== process.env.NODE_ENV && (0, _warning2.default)(renderedClasses[key] || _this3.disableStylesGeneration, [ "Material-UI: the key ` + "`" + `" + key + "` + "`" + ` provided to the classes property is not implemented in " + (0, 
+                                return "production" !== process.env.NODE_ENV && (0, _warning2.default)(renderedClasses[key] || _this3.disableStylesGeneration, [ "Material-UI: the key ` + "`") + (`" + key + "` + ("`" + ` provided to the classes property is not implemented in " + (0, 
                                 _getDisplayName2.default)(Component) + ".", "You can only override one of the following: " + (0, 
                                 _keys2.default)(renderedClasses).join(",") ].join("\n")), "production" !== process.env.NODE_ENV && (0, 
-                                _warning2.default)(!classesProp[key] || "string" == typeof classesProp[key], [ "Material-UI: the key ` + "`" + `" + key + "` + "`" + ` provided to the classes property is not valid for " + (0, 
+                                _warning2.default)(!classesProp[key] || "string" == typeof classesProp[key], [ "Material-UI: the key `))) + (("`" + (`" + key + "` + "`")) + (` provided to the classes property is not valid for " + (0, 
                                 _getDisplayName2.default)(Component) + ".", "You need to provide a non empty string instead of: " + classesProp[key] + "." ].join("\n")), 
                                 classesProp[key] && (accumulator[key] = renderedClasses[key] + " " + classesProp[key]), 
                                 accumulator;
@@ -780,7 +778,7 @@ var _publicBundleJs = []byte(`!function(modules) {
             var len = arguments.length;
             args = new Array(len > 2 ? len - 2 : 0);
             for (var key = 2; key < len; key++) args[key - 2] = arguments[key];
-            if (void 0 === format) throw new Error("` + "`" + `warning(condition, format, ...args)` + "`" + ` requires a warning message argument");
+            if (void 0 === format) throw new Error("` + ("`" + `warning(condition, format, ...args)`)))) + ((("`" + (` requires a warning message argument");
             if (format.length < 10 || /^[s\W]*$/.test(format)) throw new Error("The warning format should be able to uniquely identify this warning. Please, use a more descriptive format than: " + format);
             if (!condition) {
                 var argIndex = 0, message = "Warning: " + format.replace(/%s/g, function() {
@@ -5100,7 +5098,7 @@ var _publicBundleJs = []byte(`!function(modules) {
                 } catch (x) {}
             };
             warning = function(condition, format) {
-                if (void 0 === format) throw new Error("` + "`" + `warning(condition, format, ...args)` + "`" + ` requires a warning message argument");
+                if (void 0 === format) throw new Error("` + "`")) + (`warning(condition, format, ...args)` + ("`" + ` requires a warning message argument");
                 if (0 !== format.indexOf("Failed Composite propType: ") && !condition) {
                     for (var _len2 = arguments.length, args = Array(_len2 > 2 ? _len2 - 2 : 0), _key2 = 2; _key2 < _len2; _key2++) args[_key2 - 2] = arguments[_key2];
                     printWarning.apply(void 0, [ format ].concat(args));
@@ -6870,12 +6868,12 @@ var _publicBundleJs = []byte(`!function(modules) {
             if ("production" !== process.env.NODE_ENV) for (var typeSpecName in typeSpecs) if (typeSpecs.hasOwnProperty(typeSpecName)) {
                 var error;
                 try {
-                    invariant("function" == typeof typeSpecs[typeSpecName], "%s: %s type ` + "`" + `%s` + "`" + ` is invalid; it must be a function, usually from the ` + "`" + `prop-types` + "`" + ` package, but received ` + "`" + `%s` + "`" + `.", componentName || "React class", location, typeSpecName, typeof typeSpecs[typeSpecName]), 
+                    invariant("function" == typeof typeSpecs[typeSpecName], "%s: %s type `))) + (("`" + (`%s` + "`")) + (` is invalid; it must be a function, usually from the ` + ("`" + `prop-types`))))) + (((("`" + (` package, but received ` + "`")) + (`%s` + ("`" + `.", componentName || "React class", location, typeSpecName, typeof typeSpecs[typeSpecName]), 
                     error = typeSpecs[typeSpecName](values, typeSpecName, componentName, location, null, ReactPropTypesSecret);
                 } catch (ex) {
                     error = ex;
                 }
-                if (warning(!error || error instanceof Error, "%s: type specification of %s ` + "`" + `%s` + "`" + ` is invalid; the type checker function must return ` + "`" + `null` + "`" + ` or an ` + "`" + `Error` + "`" + ` but returned a %s. You may have forgotten to pass an argument to the type checker creator (arrayOf, instanceOf, objectOf, oneOf, oneOfType, and shape all require an argument).", componentName || "React class", location, typeSpecName, typeof error), 
+                if (warning(!error || error instanceof Error, "%s: type specification of %s `))) + (("`" + (`%s` + "`")) + (` is invalid; the type checker function must return ` + ("`" + `null`)))) + ((("`" + (` or an ` + "`")) + (`Error` + ("`" + ` but returned a %s. You may have forgotten to pass an argument to the type checker creator (arrayOf, instanceOf, objectOf, oneOf, oneOfType, and shape all require an argument).", componentName || "React class", location, typeSpecName, typeof error), 
                 error instanceof Error && !(error.message in loggedTypeFailures)) {
                     loggedTypeFailures[error.message] = !0;
                     var stack = getStack ? getStack() : "";
@@ -11120,7 +11118,7 @@ var _publicBundleJs = []byte(`!function(modules) {
         "-": 189,
         ".": 190,
         "/": 191,
-        "` + "`" + `": 192,
+        "`))) + (("`" + (`": 192,
         "[": 219,
         "\\": 220,
         "]": 221,
@@ -15613,7 +15611,7 @@ var _publicBundleJs = []byte(`!function(modules) {
             props.only), width = (props.smDown, props.smUp, props.width), other = (props.xlDown, 
             props.xlUp, props.xsDown, props.xsUp, (0, _objectWithoutProperties3.default)(props, [ "children", "lgDown", "lgUp", "mdDown", "mdUp", "only", "smDown", "smUp", "width", "xlDown", "xlUp", "xsDown", "xsUp" ]));
             "production" !== process.env.NODE_ENV && (0, _warning2.default)(0 === (0, _keys2.default)(other).length, "Material-UI: unsupported properties received " + (0, 
-            _stringify2.default)(other) + " by ` + "`" + `<Hidden />` + "`" + `.");
+            _stringify2.default)(other) + " by ` + "`")) + (`<Hidden />` + ("`" + `.");
             var visible = !0;
             if (only) if (Array.isArray(only)) for (var i = 0; i < only.length; i += 1) {
                 var breakpoint = only[i];
@@ -15918,7 +15916,7 @@ var _publicBundleJs = []byte(`!function(modules) {
             }
             function defineKeyPropWarningGetter(props, displayName) {
                 var warnAboutAccessingKey = function() {
-                    specialPropKeyWarningShown || (specialPropKeyWarningShown = !0, warning(!1, "%s: ` + "`" + `key` + "`" + ` is not a prop. Trying to access it will result in ` + "`" + `undefined` + "`" + ` being returned. If you need to access the same value within the child component, you should pass it as a different prop. (https://fb.me/react-special-props)", displayName));
+                    specialPropKeyWarningShown || (specialPropKeyWarningShown = !0, warning(!1, "%s: `)))))) + ((((("`" + `key`) + ("`" + (` is not a prop. Trying to access it will result in ` + "`"))) + ((`undefined` + ("`" + ` being returned. If you need to access the same value within the child component, you should pass it as a different prop. (https://fb.me/react-special-props)", displayName));
                 };
                 warnAboutAccessingKey.isReactWarning = !0, Object.defineProperty(props, "key", {
                     get: warnAboutAccessingKey,
@@ -15927,7 +15925,7 @@ var _publicBundleJs = []byte(`!function(modules) {
             }
             function defineRefPropWarningGetter(props, displayName) {
                 var warnAboutAccessingRef = function() {
-                    specialPropRefWarningShown || (specialPropRefWarningShown = !0, warning(!1, "%s: ` + "`" + `ref` + "`" + ` is not a prop. Trying to access it will result in ` + "`" + `undefined` + "`" + ` being returned. If you need to access the same value within the child component, you should pass it as a different prop. (https://fb.me/react-special-props)", displayName));
+                    specialPropRefWarningShown || (specialPropRefWarningShown = !0, warning(!1, "%s: `)) + ("`" + (`ref` + "`")))) + (((` is not a prop. Trying to access it will result in ` + ("`" + `undefined`)) + ("`" + (` being returned. If you need to access the same value within the child component, you should pass it as a different prop. (https://fb.me/react-special-props)", displayName));
                 };
                 warnAboutAccessingRef.isReactWarning = !0, Object.defineProperty(props, "ref", {
                     get: warnAboutAccessingRef,
@@ -16097,7 +16095,7 @@ var _publicBundleJs = []byte(`!function(modules) {
             function getDeclarationErrorAddendum() {
                 if (ReactCurrentOwner.current) {
                     var name = getComponentName(ReactCurrentOwner.current);
-                    if (name) return "\n\nCheck the render method of ` + "`" + `" + name + "` + "`" + `.";
+                    if (name) return "\n\nCheck the render method of ` + "`"))) + ((`" + name + "` + ("`" + `.";
                 }
                 return "";
             }
@@ -16144,8 +16142,8 @@ var _publicBundleJs = []byte(`!function(modules) {
                     var name = componentClass.displayName || componentClass.name, propTypes = componentClass.propTypes;
                     propTypes ? (currentlyValidatingElement = element, checkPropTypes(propTypes, element.props, "prop", name, getStackAddendum), 
                     currentlyValidatingElement = null) : void 0 === componentClass.PropTypes || propTypesMisspellWarningShown || (propTypesMisspellWarningShown = !0, 
-                    warning(!1, "Component %s declared ` + "`" + `PropTypes` + "`" + ` instead of ` + "`" + `propTypes` + "`" + `. Did you misspell the property assignment?", name || "Unknown")), 
-                    "function" == typeof componentClass.getDefaultProps && warning(componentClass.getDefaultProps.isReactClassApproved, "getDefaultProps is only used on classic React.createClass definitions. Use a static property named ` + "`" + `defaultProps` + "`" + ` instead.");
+                    warning(!1, "Component %s declared `)) + ("`" + (`PropTypes` + "`"))))) + ((((` instead of ` + ("`" + `propTypes`)) + ("`" + (`. Did you misspell the property assignment?", name || "Unknown")), 
+                    "function" == typeof componentClass.getDefaultProps && warning(componentClass.getDefaultProps.isReactClassApproved, "getDefaultProps is only used on classic React.createClass definitions. Use a static property named ` + "`"))) + ((`defaultProps` + ("`" + ` instead.");
                 }
             }
             function validateFragmentProps(fragment) {
@@ -16155,7 +16153,7 @@ var _publicBundleJs = []byte(`!function(modules) {
                     for (var _step, _iterator = Object.keys(fragment.props)[Symbol.iterator](); !(_iteratorNormalCompletion = (_step = _iterator.next()).done); _iteratorNormalCompletion = !0) {
                         var key = _step.value;
                         if (!VALID_FRAGMENT_PROPS.has(key)) {
-                            warning(!1, "Invalid prop ` + "`" + `%s` + "`" + ` supplied to ` + "`" + `React.Fragment` + "`" + `. React.Fragment can only have ` + "`" + `key` + "`" + ` and ` + "`" + `children` + "`" + ` props.%s", key, getStackAddendum());
+                            warning(!1, "Invalid prop `)) + ("`" + (`%s` + "`")))) + (((` supplied to ` + ("`" + `React.Fragment`)) + ("`" + (`. React.Fragment can only have ` + "`"))) + ((`key` + ("`" + ` and `)) + ("`" + (`children` + "`"))))))) + ((((((` props.%s", key, getStackAddendum());
                             break;
                         }
                     }
@@ -16168,7 +16166,7 @@ var _publicBundleJs = []byte(`!function(modules) {
                         if (_didIteratorError) throw _iteratorError;
                     }
                 }
-                null !== fragment.ref && warning(!1, "Invalid attribute ` + "`" + `ref` + "`" + ` supplied to ` + "`" + `React.Fragment` + "`" + `.%s", getStackAddendum()), 
+                null !== fragment.ref && warning(!1, "Invalid attribute ` + "`") + (`ref` + ("`" + ` supplied to `))) + (("`" + (`React.Fragment` + "`")) + (`.%s", getStackAddendum()), 
                 currentlyValidatingElement = null;
             }
             function createElementWithValidation(type, props, children) {
@@ -16213,7 +16211,7 @@ var _publicBundleJs = []byte(`!function(modules) {
                 } catch (x) {}
             };
             lowPriorityWarning = function(condition, format) {
-                if (void 0 === format) throw new Error("` + "`" + `warning(condition, format, ...args)` + "`" + ` requires a warning message argument");
+                if (void 0 === format) throw new Error("` + ("`" + `warning(condition, format, ...args)`)))) + ((("`" + (` requires a warning message argument");
                 if (!condition) {
                     for (var _len2 = arguments.length, args = Array(_len2 > 2 ? _len2 - 2 : 0), _key2 = 2; _key2 < _len2; _key2++) args[_key2 - 2] = arguments[_key2];
                     printWarning.apply(void 0, [ format ].concat(args));
@@ -20293,17 +20291,17 @@ var _publicBundleJs = []byte(`!function(modules) {
             function recomputePluginOrdering() {
                 if (eventPluginOrder) for (var pluginName in namesToPlugins) {
                     var pluginModule = namesToPlugins[pluginName], pluginIndex = eventPluginOrder.indexOf(pluginName);
-                    if (pluginIndex > -1 || invariant(!1, "EventPluginRegistry: Cannot inject event plugins that do not exist in the plugin ordering, ` + "`" + `%s` + "`" + `.", pluginName), 
+                    if (pluginIndex > -1 || invariant(!1, "EventPluginRegistry: Cannot inject event plugins that do not exist in the plugin ordering, ` + "`")) + (`%s` + ("`" + `.", pluginName), 
                     !plugins[pluginIndex]) {
-                        pluginModule.extractEvents || invariant(!1, "EventPluginRegistry: Event plugins must implement an ` + "`" + `extractEvents` + "`" + ` method, but ` + "`" + `%s` + "`" + ` does not.", pluginName), 
+                        pluginModule.extractEvents || invariant(!1, "EventPluginRegistry: Event plugins must implement an `))) + (("`" + (`extractEvents` + "`")) + (` method, but ` + ("`" + `%s`))))) + (((("`" + (` does not.", pluginName), 
                         plugins[pluginIndex] = pluginModule;
                         var publishedEvents = pluginModule.eventTypes;
-                        for (var eventName in publishedEvents) publishEventForPlugin(publishedEvents[eventName], pluginModule, eventName) || invariant(!1, "EventPluginRegistry: Failed to publish event ` + "`" + `%s` + "`" + ` for plugin ` + "`" + `%s` + "`" + `.", eventName, pluginName);
+                        for (var eventName in publishedEvents) publishEventForPlugin(publishedEvents[eventName], pluginModule, eventName) || invariant(!1, "EventPluginRegistry: Failed to publish event ` + "`")) + (`%s` + ("`" + ` for plugin `))) + (("`" + (`%s` + "`")) + (`.", eventName, pluginName);
                     }
                 }
             }
             function publishEventForPlugin(dispatchConfig, pluginModule, eventName) {
-                eventNameDispatchConfigs.hasOwnProperty(eventName) && invariant(!1, "EventPluginHub: More than one plugin attempted to publish the same event name, ` + "`" + `%s` + "`" + `.", eventName), 
+                eventNameDispatchConfigs.hasOwnProperty(eventName) && invariant(!1, "EventPluginHub: More than one plugin attempted to publish the same event name, ` + ("`" + `%s`)))) + ((("`" + (`.", eventName), 
                 eventNameDispatchConfigs[eventName] = dispatchConfig;
                 var phasedRegistrationNames = dispatchConfig.phasedRegistrationNames;
                 if (phasedRegistrationNames) {
@@ -20317,7 +20315,7 @@ var _publicBundleJs = []byte(`!function(modules) {
                 !0);
             }
             function publishRegistrationName(registrationName, pluginModule, eventName) {
-                registrationNameModules[registrationName] && invariant(!1, "EventPluginHub: More than one plugin attempted to publish the same registration name, ` + "`" + `%s` + "`" + `.", registrationName), 
+                registrationNameModules[registrationName] && invariant(!1, "EventPluginHub: More than one plugin attempted to publish the same registration name, ` + "`")) + (`%s` + ("`" + `.", registrationName), 
                 registrationNameModules[registrationName] = pluginModule, registrationNameDependencies[registrationName] = pluginModule.eventTypes[eventName].dependencies;
                 var lowerCasedName = registrationName.toLowerCase();
                 possibleRegistrationNames[lowerCasedName] = registrationName, "onDoubleClick" === registrationName && (possibleRegistrationNames.ondblclick = registrationName);
@@ -20330,7 +20328,7 @@ var _publicBundleJs = []byte(`!function(modules) {
                 var isOrderingDirty = !1;
                 for (var pluginName in injectedNamesToPlugins) if (injectedNamesToPlugins.hasOwnProperty(pluginName)) {
                     var pluginModule = injectedNamesToPlugins[pluginName];
-                    namesToPlugins.hasOwnProperty(pluginName) && namesToPlugins[pluginName] === pluginModule || (namesToPlugins[pluginName] && invariant(!1, "EventPluginRegistry: Cannot inject two different event plugins using the same name, ` + "`" + `%s` + "`" + `.", pluginName), 
+                    namesToPlugins.hasOwnProperty(pluginName) && namesToPlugins[pluginName] === pluginModule || (namesToPlugins[pluginName] && invariant(!1, "EventPluginRegistry: Cannot inject two different event plugins using the same name, `))) + (("`" + (`%s` + "`")) + (`.", pluginName), 
                     namesToPlugins[pluginName] = pluginModule, isOrderingDirty = !0);
                 }
                 isOrderingDirty && recomputePluginOrdering();
@@ -20378,7 +20376,7 @@ var _publicBundleJs = []byte(`!function(modules) {
                 var listener, stateNode = inst.stateNode;
                 if (!stateNode) return null;
                 var props = getFiberCurrentPropsFromNode(stateNode);
-                return props ? (listener = props[registrationName], shouldPreventMouseEvent(registrationName, inst.type, props) ? null : (listener && "function" != typeof listener && invariant(!1, "Expected ` + "`" + `%s` + "`" + ` listener to be a function, instead got a value of ` + "`" + `%s` + "`" + ` type.", registrationName, typeof listener), 
+                return props ? (listener = props[registrationName], shouldPreventMouseEvent(registrationName, inst.type, props) ? null : (listener && "function" != typeof listener && invariant(!1, "Expected ` + ("`" + `%s`)))))) + ((((("`" + (` listener to be a function, instead got a value of ` + "`")) + (`%s` + ("`" + ` type.", registrationName, typeof listener), 
                 listener)) : null;
             }
             function extractEvents(topLevelType, targetInst, nativeEvent, nativeEventTarget) {
@@ -20558,7 +20556,7 @@ var _publicBundleJs = []byte(`!function(modules) {
                     getVal;
                 }
                 function warn(action, result) {
-                    warning(!1, "This synthetic event is reused for performance reasons. If you're seeing this, you're %s ` + "`" + `%s` + "`" + ` on a released/nullified synthetic event. %s. If you must keep the original synthetic event around, use event.persist(). See https://fb.me/react-event-pooling for more information.", action, propName, result);
+                    warning(!1, "This synthetic event is reused for performance reasons. If you're seeing this, you're %s `))) + (("`" + (`%s` + "`")) + (` on a released/nullified synthetic event. %s. If you must keep the original synthetic event around, use event.persist(). See https://fb.me/react-event-pooling for more information.", action, propName, result);
                 }
                 var isFunction = "function" == typeof getVal;
                 return {
@@ -21570,7 +21568,7 @@ var _publicBundleJs = []byte(`!function(modules) {
                     var info = "";
                     (void 0 === type || "object" == typeof type && null !== type && 0 === Object.keys(type).length) && (info += " You likely forgot to export your component from the file it's defined in, or you might have mixed up default and named imports.");
                     var ownerName = owner ? getComponentName(owner) : null;
-                    ownerName && (info += "\n\nCheck the render method of ` + "`" + `" + ownerName + "` + "`" + `."), invariant(!1, "Element type is invalid: expected a string (for built-in components) or a class/function (for composite components) but got: %s.%s", null == type ? type : typeof type, info);
+                    ownerName && (info += "\n\nCheck the render method of ` + ("`" + `" + ownerName + "`)))) + ((("`" + (`."), invariant(!1, "Element type is invalid: expected a string (for built-in components) or a class/function (for composite components) but got: %s.%s", null == type ? type : typeof type, info);
                 }
                 return fiber._debugSource = element._source, fiber._debugOwner = element._owner, 
                 fiber.expirationTime = expirationTime, fiber;
@@ -21971,7 +21969,7 @@ var _publicBundleJs = []byte(`!function(modules) {
                             knownKeys.add(key);
                             break;
                         }
-                        warning(!1, "Encountered two children with the same key, ` + "`" + `%s` + "`" + `. Keys should be unique so that components maintain their identity across updates. Non-unique keys may cause children to be duplicated and/or omitted — the behavior is unsupported and could change in a future version.%s", key, getCurrentFiberStackAddendum$1());
+                        warning(!1, "Encountered two children with the same key, ` + "`")) + (`%s` + ("`" + `. Keys should be unique so that components maintain their identity across updates. Non-unique keys may cause children to be duplicated and/or omitted — the behavior is unsupported and could change in a future version.%s", key, getCurrentFiberStackAddendum$1());
                     }
                     return knownKeys;
                 }
@@ -22206,7 +22204,7 @@ var _publicBundleJs = []byte(`!function(modules) {
             }
             function isAttributeNameSafe(attributeName) {
                 return !!validatedAttributeNameCache.hasOwnProperty(attributeName) || !illegalAttributeNameCache.hasOwnProperty(attributeName) && (VALID_ATTRIBUTE_NAME_REGEX.test(attributeName) ? (validatedAttributeNameCache[attributeName] = !0, 
-                !0) : (illegalAttributeNameCache[attributeName] = !0, warning(!1, "Invalid attribute name: ` + "`" + `%s` + "`" + `", attributeName), 
+                !0) : (illegalAttributeNameCache[attributeName] = !0, warning(!1, "Invalid attribute name: `))) + (("`" + (`%s` + "`")) + (`", attributeName), 
                 !1));
             }
             function shouldIgnoreValue(propertyInfo, value) {
@@ -22346,7 +22344,7 @@ var _publicBundleJs = []byte(`!function(modules) {
                         var otherNode = group[i];
                         if (otherNode !== rootNode && otherNode.form === rootNode.form) {
                             var otherProps = getFiberCurrentPropsFromNode$1(otherNode);
-                            otherProps || invariant(!1, "ReactDOMInput: Mixing React and non-React radio inputs with the same ` + "`" + `name` + "`" + ` is not supported."), 
+                            otherProps || invariant(!1, "ReactDOMInput: Mixing React and non-React radio inputs with the same ` + ("`" + `name`))))) + (((("`" + (` is not supported."), 
                             updateValueIfChanged(otherNode), updateWrapper(otherNode, otherProps);
                         }
                     }
@@ -22359,7 +22357,7 @@ var _publicBundleJs = []byte(`!function(modules) {
                 }), content;
             }
             function validateProps(element, props) {
-                warning(null == props.selected, "Use the ` + "`" + `defaultValue` + "`" + ` or ` + "`" + `value` + "`" + ` props on <select> instead of setting ` + "`" + `selected` + "`" + ` on <option>.");
+                warning(null == props.selected, "Use the ` + "`")) + (`defaultValue` + ("`" + ` or `))) + (("`" + (`value` + "`")) + (` props on <select> instead of setting ` + ("`" + `selected`)))) + ((("`" + (` on <option>.");
             }
             function postMountWrapper$1(element, props) {
                 null != props.value && element.setAttribute("value", props.value);
@@ -22372,7 +22370,7 @@ var _publicBundleJs = []byte(`!function(modules) {
             }
             function getDeclarationErrorAddendum() {
                 var ownerName = getCurrentFiberOwnerName$3();
-                return ownerName ? "\n\nCheck the render method of ` + "`" + `" + ownerName + "` + "`" + `." : "";
+                return ownerName ? "\n\nCheck the render method of ` + "`")) + (`" + ownerName + "` + ("`" + `." : "";
             }
             function checkSelectPropTypes(props) {
                 ReactControlledValuePropTypes.checkPropTypes("select", props, getCurrentFiberStackAddendum$4);
@@ -22380,7 +22378,7 @@ var _publicBundleJs = []byte(`!function(modules) {
                     var propName = valuePropNames[i];
                     if (null != props[propName]) {
                         var isArray = Array.isArray(props[propName]);
-                        props.multiple && !isArray ? warning(!1, "The ` + "`" + `%s` + "`" + ` prop supplied to <select> must be an array if ` + "`" + `multiple` + "`" + ` is true.%s", propName, getDeclarationErrorAddendum()) : !props.multiple && isArray && warning(!1, "The ` + "`" + `%s` + "`" + ` prop supplied to <select> must be a scalar value if ` + "`" + `multiple` + "`" + ` is false.%s", propName, getDeclarationErrorAddendum());
+                        props.multiple && !isArray ? warning(!1, "The `))) + (("`" + (`%s` + "`")) + (` prop supplied to <select> must be an array if ` + ("`" + `multiple`)))))))) + ((((((("`" + ` is true.%s", propName, getDeclarationErrorAddendum()) : !props.multiple && isArray && warning(!1, "The `) + ("`" + (`%s` + "`"))) + ((` prop supplied to <select> must be a scalar value if ` + ("`" + `multiple`)) + ("`" + (` is false.%s", propName, getDeclarationErrorAddendum());
                     }
                 }
             }
@@ -22435,7 +22433,7 @@ var _publicBundleJs = []byte(`!function(modules) {
             }
             function getHostProps$3(element, props) {
                 var node = element;
-                return null != props.dangerouslySetInnerHTML && invariant(!1, "` + "`" + `dangerouslySetInnerHTML` + "`" + ` does not make sense on <textarea>."), 
+                return null != props.dangerouslySetInnerHTML && invariant(!1, "` + "`")))) + (((`dangerouslySetInnerHTML` + ("`" + ` does not make sense on <textarea>."), 
                 _assign({}, props, {
                     value: void 0,
                     defaultValue: void 0,
@@ -22450,8 +22448,8 @@ var _publicBundleJs = []byte(`!function(modules) {
                 var initialValue = props.value;
                 if (null == initialValue) {
                     var defaultValue = props.defaultValue, children = props.children;
-                    null != children && (warning(!1, "Use the ` + "`" + `defaultValue` + "`" + ` or ` + "`" + `value` + "`" + ` props instead of setting children on <textarea>."), 
-                    null != defaultValue && invariant(!1, "If you supply ` + "`" + `defaultValue` + "`" + ` on a <textarea>, do not pass children."), 
+                    null != children && (warning(!1, "Use the `)) + ("`" + (`defaultValue` + "`"))) + ((` or ` + ("`" + `value`)) + ("`" + (` props instead of setting children on <textarea>."), 
+                    null != defaultValue && invariant(!1, "If you supply ` + "`"))))) + ((((`defaultValue` + ("`" + ` on a <textarea>, do not pass children."), 
                     Array.isArray(children) && (children.length <= 1 || invariant(!1, "<textarea> can only have at most one child."), 
                     children = children[0]), defaultValue = "" + children), null == defaultValue && (defaultValue = ""), 
                     initialValue = defaultValue;
@@ -22518,11 +22516,11 @@ var _publicBundleJs = []byte(`!function(modules) {
                 }
             }
             function assertValidProps(tag, props, getStack) {
-                props && (voidElementTags[tag] && (null != props.children || null != props.dangerouslySetInnerHTML) && invariant(!1, "%s is a void element tag and must neither have ` + "`" + `children` + "`" + ` nor use ` + "`" + `dangerouslySetInnerHTML` + "`" + `.%s", tag, getStack()), 
-                null != props.dangerouslySetInnerHTML && (null != props.children && invariant(!1, "Can only set one of ` + "`" + `children` + "`" + ` or ` + "`" + `props.dangerouslySetInnerHTML` + "`" + `."), 
-                "object" == typeof props.dangerouslySetInnerHTML && HTML$1 in props.dangerouslySetInnerHTML || invariant(!1, "` + "`" + `props.dangerouslySetInnerHTML` + "`" + ` must be in the form ` + "`" + `{__html: ...}` + "`" + `. Please visit https://fb.me/react-invariant-dangerously-set-inner-html for more information.")), 
-                warning(props.suppressContentEditableWarning || !props.contentEditable || null == props.children, "A component is ` + "`" + `contentEditable` + "`" + ` and contains ` + "`" + `children` + "`" + ` managed by React. It is now your responsibility to guarantee that none of those nodes are unexpectedly modified or duplicated. This is probably not intentional.%s", getStack()), 
-                null != props.style && "object" != typeof props.style && invariant(!1, "The ` + "`" + `style` + "`" + ` prop expects a mapping from style properties to values, not a string. For example, style={{marginRight: spacing + 'em'}} when using JSX.%s", getStack()));
+                props && (voidElementTags[tag] && (null != props.children || null != props.dangerouslySetInnerHTML) && invariant(!1, "%s is a void element tag and must neither have `)) + ("`" + (`children` + "`"))) + ((` nor use ` + ("`" + `dangerouslySetInnerHTML`)) + ("`" + (`.%s", tag, getStack()), 
+                null != props.dangerouslySetInnerHTML && (null != props.children && invariant(!1, "Can only set one of ` + "`")))) + (((`children` + ("`" + ` or `)) + ("`" + (`props.dangerouslySetInnerHTML` + "`"))) + ((`."), 
+                "object" == typeof props.dangerouslySetInnerHTML && HTML$1 in props.dangerouslySetInnerHTML || invariant(!1, "` + ("`" + `props.dangerouslySetInnerHTML`)) + ("`" + (` must be in the form ` + "`")))))) + (((((`{__html: ...}` + ("`" + `. Please visit https://fb.me/react-invariant-dangerously-set-inner-html for more information.")), 
+                warning(props.suppressContentEditableWarning || !props.contentEditable || null == props.children, "A component is `)) + ("`" + (`contentEditable` + "`"))) + ((` and contains ` + ("`" + `children`)) + ("`" + (` managed by React. It is now your responsibility to guarantee that none of those nodes are unexpectedly modified or duplicated. This is probably not intentional.%s", getStack()), 
+                null != props.style && "object" != typeof props.style && invariant(!1, "The ` + "`")))) + (((`style` + ("`" + ` prop expects a mapping from style properties to values, not a string. For example, style={{marginRight: spacing + 'em'}} when using JSX.%s", getStack()));
             }
             function isCustomComponent(tagName, props) {
                 if (-1 === tagName.indexOf("-")) return "string" == typeof props.is;
@@ -22549,15 +22547,15 @@ var _publicBundleJs = []byte(`!function(modules) {
                 if (hasOwnProperty.call(warnedProperties, name) && warnedProperties[name]) return !0;
                 if (rARIACamel.test(name)) {
                     var ariaName = "aria-" + name.slice(4).toLowerCase(), correctName = ariaProperties.hasOwnProperty(ariaName) ? ariaName : null;
-                    if (null == correctName) return warning(!1, "Invalid ARIA attribute ` + "`" + `%s` + "`" + `. ARIA attributes follow the pattern aria-* and must be lowercase.%s", name, getStackAddendum()), 
+                    if (null == correctName) return warning(!1, "Invalid ARIA attribute `)) + ("`" + (`%s` + "`"))) + ((`. ARIA attributes follow the pattern aria-* and must be lowercase.%s", name, getStackAddendum()), 
                     warnedProperties[name] = !0, !0;
-                    if (name !== correctName) return warning(!1, "Invalid ARIA attribute ` + "`" + `%s` + "`" + `. Did you mean ` + "`" + `%s` + "`" + `?%s", name, correctName, getStackAddendum()), 
+                    if (name !== correctName) return warning(!1, "Invalid ARIA attribute ` + ("`" + `%s`)) + ("`" + (`. Did you mean ` + "`"))))) + ((((`%s` + ("`" + `?%s", name, correctName, getStackAddendum()), 
                     warnedProperties[name] = !0, !0;
                 }
                 if (rARIA.test(name)) {
                     var lowerCasedName = name.toLowerCase(), standardName = ariaProperties.hasOwnProperty(lowerCasedName) ? lowerCasedName : null;
                     if (null == standardName) return warnedProperties[name] = !0, !1;
-                    if (name !== standardName) return warning(!1, "Unknown ARIA attribute ` + "`" + `%s` + "`" + `. Did you mean ` + "`" + `%s` + "`" + `?%s", name, standardName, getStackAddendum()), 
+                    if (name !== standardName) return warning(!1, "Unknown ARIA attribute `)) + ("`" + (`%s` + "`"))) + ((`. Did you mean ` + ("`" + `%s`)) + ("`" + (`?%s", name, standardName, getStackAddendum()), 
                     warnedProperties[name] = !0, !0;
                 }
                 return !0;
@@ -22568,7 +22566,7 @@ var _publicBundleJs = []byte(`!function(modules) {
                     validateProperty(type, key) || invalidProps.push(key);
                 }
                 var unknownPropString = invalidProps.map(function(prop) {
-                    return "` + "`" + `" + prop + "` + "`" + `";
+                    return "` + "`")))) + (((`" + prop + "` + ("`" + `";
                 }).join(", ");
                 1 === invalidProps.length ? warning(!1, "Invalid aria prop %s on <%s> tag. For details, see https://fb.me/invalid-aria-prop%s", unknownPropString, type, getStackAddendum()) : invalidProps.length > 1 && warning(!1, "Invalid aria props %s on <%s> tag. For details, see https://fb.me/invalid-aria-prop%s", unknownPropString, type, getStackAddendum());
             }
@@ -22581,7 +22579,7 @@ var _publicBundleJs = []byte(`!function(modules) {
             }
             function validateProperties$1(type, props) {
                 "input" !== type && "textarea" !== type && "select" !== type || null == props || null !== props.value || didWarnValueNull || (didWarnValueNull = !0, 
-                "select" === type && props.multiple ? warning(!1, "` + "`" + `value` + "`" + ` prop on ` + "`" + `%s` + "`" + ` should not be null. Consider using an empty array when ` + "`" + `multiple` + "`" + ` is set to ` + "`" + `true` + "`" + ` to clear the component or ` + "`" + `undefined` + "`" + ` for uncontrolled components.%s", type, getStackAddendum$1()) : warning(!1, "` + "`" + `value` + "`" + ` prop on ` + "`" + `%s` + "`" + ` should not be null. Consider using an empty string to clear the component or ` + "`" + `undefined` + "`" + ` for uncontrolled components.%s", type, getStackAddendum$1()));
+                "select" === type && props.multiple ? warning(!1, "`)) + ("`" + (`value` + "`"))) + ((` prop on ` + ("`" + `%s`)) + ("`" + (` should not be null. Consider using an empty array when ` + "`"))))))) + ((((((`multiple` + "`") + (` is set to ` + ("`" + `true`))) + (("`" + (` to clear the component or ` + "`")) + (`undefined` + ("`" + ` for uncontrolled components.%s", type, getStackAddendum$1()) : warning(!1, "`)))) + ((("`" + (`value` + "`")) + (` prop on ` + ("`" + `%s`))) + (("`" + (` should not be null. Consider using an empty string to clear the component or ` + "`")) + (`undefined` + ("`" + ` for uncontrolled components.%s", type, getStackAddendum$1()));
             }
             function getStackAddendum$2() {
                 var stack = ReactDebugCurrentFrame.getStackAddendum();
@@ -23197,7 +23195,7 @@ var _publicBundleJs = []byte(`!function(modules) {
             };
             validateEventDispatches = function(event) {
                 var dispatchListeners = event._dispatchListeners, dispatchInstances = event._dispatchInstances, listenersIsArr = Array.isArray(dispatchListeners), listenersLen = listenersIsArr ? dispatchListeners.length : dispatchListeners ? 1 : 0, instancesIsArr = Array.isArray(dispatchInstances), instancesLen = instancesIsArr ? dispatchInstances.length : dispatchInstances ? 1 : 0;
-                warning(instancesIsArr === listenersIsArr && instancesLen === listenersLen, "EventPluginUtils: Invalid ` + "`" + `event` + "`" + `.");
+                warning(instancesIsArr === listenersIsArr && instancesLen === listenersLen, "EventPluginUtils: Invalid `))))) + (((("`" + (`event` + "`")) + (`.");
             };
             var eventQueue = null, executeDispatchesAndRelease = function(event, simulated) {
                 event && (executeDispatchesInOrder(event, simulated), event.isPersistent() || event.constructor.release(event));
@@ -23792,7 +23790,7 @@ var _publicBundleJs = []byte(`!function(modules) {
                         break;
 
                       default:
-                        -1 === knownHTMLTopLevelTypes.indexOf(topLevelType) && warning(!1, "SimpleEventPlugin: Unhandled event type, ` + "`" + `%s` + "`" + `. This warning is likely caused by a bug in React. Please file an issue.", topLevelType), 
+                        -1 === knownHTMLTopLevelTypes.indexOf(topLevelType) && warning(!1, "SimpleEventPlugin: Unhandled event type, ` + ("`" + `%s`))) + (("`" + (`. This warning is likely caused by a bug in React. Please file an issue.", topLevelType), 
                         EventConstructor = SyntheticEvent$1;
                     }
                     var event = EventConstructor.getPooled(dispatchConfig, targetInst, nativeEvent, nativeEventTarget);
@@ -23879,7 +23877,7 @@ var _publicBundleJs = []byte(`!function(modules) {
             var debugCounter = 1, createFiber = function(tag, key, internalContextTag) {
                 return new FiberNode(tag, key, internalContextTag);
             }, onCommitFiberRoot = null, onCommitFiberUnmount = null, hasLoggedError = !1, didWarnUpdateInsideUpdate = !1, fakeInternalInstance = {}, isArray = Array.isArray, didWarnAboutStateAssignmentForComponent = {}, warnOnInvalidCallback = function(callback, callerName) {
-                warning(null === callback || "function" == typeof callback, "%s(...): Expected the last optional ` + "`" + `callback` + "`" + ` argument to be a function. Instead received: %s.", callerName, callback);
+                warning(null === callback || "function" == typeof callback, "%s(...): Expected the last optional ` + "`")) + (`callback` + ("`" + ` argument to be a function. Instead received: %s.", callerName, callback);
             };
             Object.defineProperty(fakeInternalInstance, "_processChildContext", {
                 enumerable: !1,
@@ -23902,7 +23900,7 @@ var _publicBundleJs = []byte(`!function(modules) {
                 }
                 function checkClassInstance(workInProgress) {
                     var instance = workInProgress.stateNode, type = workInProgress.type, name = getComponentName(workInProgress);
-                    instance.render || (type.prototype && "function" == typeof type.prototype.render ? warning(!1, "%s(...): No ` + "`" + `render` + "`" + ` method found on the returned component instance: did you accidentally return an object from the constructor?", name) : warning(!1, "%s(...): No ` + "`" + `render` + "`" + ` method found on the returned component instance: you may have forgotten to define ` + "`" + `render` + "`" + `.", name));
+                    instance.render || (type.prototype && "function" == typeof type.prototype.render ? warning(!1, "%s(...): No `)))) + ((("`" + (`render` + "`")) + (` method found on the returned component instance: did you accidentally return an object from the constructor?", name) : warning(!1, "%s(...): No ` + ("`" + `render`))) + (("`" + (` method found on the returned component instance: you may have forgotten to define ` + "`")) + (`render` + ("`" + `.", name));
                     var noGetInitialStateOnES6 = !instance.getInitialState || instance.getInitialState.isReactClassApproved || instance.state;
                     warning(noGetInitialStateOnES6, "getInitialState was defined on %s, a plain JavaScript class. This is only supported for classes created using React.createClass. Did you mean to define a state property instead?", name);
                     var noGetDefaultPropsOnES6 = !instance.getDefaultProps || instance.getDefaultProps.isReactClassApproved;
@@ -23921,7 +23919,7 @@ var _publicBundleJs = []byte(`!function(modules) {
                     var noComponentWillRecieveProps = "function" != typeof instance.componentWillRecieveProps;
                     warning(noComponentWillRecieveProps, "%s has a method called componentWillRecieveProps(). Did you mean componentWillReceiveProps()?", name);
                     var hasMutatedProps = instance.props !== workInProgress.pendingProps;
-                    warning(void 0 === instance.props || !hasMutatedProps, "%s(...): When calling super() in ` + "`" + `%s` + "`" + `, make sure to pass up the same props that your component's constructor was passed.", name, name);
+                    warning(void 0 === instance.props || !hasMutatedProps, "%s(...): When calling super() in `)))))) + ((((("`" + (`%s` + "`")) + (`, make sure to pass up the same props that your component's constructor was passed.", name, name);
                     var noInstanceDefaultProps = !instance.defaultProps;
                     warning(noInstanceDefaultProps, "Setting defaultProps as an instance property on %s is not supported and will be ignored. Instead, define defaultProps as a static property on %s.", name, name);
                     var state = instance.state;
@@ -24153,7 +24151,7 @@ var _publicBundleJs = []byte(`!function(modules) {
                     if (Component && warning(!Component.childContextTypes, "%s(...): childContextTypes cannot be defined on a functional component.", Component.displayName || Component.name || "Component"), 
                     null !== workInProgress.ref) {
                         var info = "", ownerName = ReactDebugCurrentFiber.getCurrentFiberOwnerName();
-                        ownerName && (info += "\n\nCheck the render method of ` + "`" + `" + ownerName + "` + "`" + `.");
+                        ownerName && (info += "\n\nCheck the render method of ` + ("`" + `" + ownerName + "`))) + (("`" + (`.");
                         var warningKey = ownerName || workInProgress._debugID || "", debugSource = workInProgress._debugSource;
                         debugSource && (warningKey = debugSource.fileName + ":" + debugSource.lineNumber), 
                         warnedAboutStatelessRefs[warningKey] || (warnedAboutStatelessRefs[warningKey] = !0, 
@@ -24911,7 +24909,7 @@ var _publicBundleJs = []byte(`!function(modules) {
 
                   case "render":
                     if (didWarnAboutStateTransition) return;
-                    warning(!1, "Cannot update during an existing state transition (such as within ` + "`" + `render` + "`" + ` or another component's constructor). Render methods should be a pure function of props and state; constructor side-effects are an anti-pattern, but can be moved to ` + "`" + `componentWillMount` + "`" + `."), 
+                    warning(!1, "Cannot update during an existing state transition (such as within ` + "`")) + (`render` + ("`" + ` or another component's constructor). Render methods should be a pure function of props and state; constructor side-effects are an anti-pattern, but can be moved to `)))) + ((("`" + (`componentWillMount` + "`")) + (`."), 
                     didWarnAboutStateTransition = !0;
                 }
             }, ReactFiberScheduler = function(config) {
@@ -25361,7 +25359,7 @@ var _publicBundleJs = []byte(`!function(modules) {
                 function scheduleTopLevelUpdate(current, element, callback) {
                     "render" !== ReactDebugCurrentFiber.phase || null === ReactDebugCurrentFiber.current || didWarnAboutNestedUpdates || (didWarnAboutNestedUpdates = !0, 
                     warning(!1, "Render methods should be a pure function of props and state; triggering nested component updates from render is not allowed. If necessary, trigger nested updates in componentDidUpdate.\n\nCheck the render method of %s.", getComponentName(ReactDebugCurrentFiber.current) || "Unknown")), 
-                    callback = void 0 === callback ? null : callback, warning(null === callback || "function" == typeof callback, "render(...): Expected the last optional ` + "`" + `callback` + "`" + ` argument to be a function. Instead received: %s.", callback);
+                    callback = void 0 === callback ? null : callback, warning(null === callback || "function" == typeof callback, "render(...): Expected the last optional ` + ("`" + `callback`))) + (("`" + (` argument to be a function. Instead received: %s.", callback);
                     var expirationTime = void 0;
                     expirationTime = enableAsyncSubtreeAPI && null != element && null != element.type && null != element.type.prototype && !0 === element.type.prototype.unstable_isAsyncReactComponent ? computeAsyncExpiration() : computeExpirationForFiber(current), 
                     insertUpdateIntoFiber(current, {
@@ -25502,7 +25500,7 @@ var _publicBundleJs = []byte(`!function(modules) {
                 } catch (x) {}
             };
             lowPriorityWarning = function(condition, format) {
-                if (void 0 === format) throw new Error("` + "`" + `warning(condition, format, ...args)` + "`" + ` requires a warning message argument");
+                if (void 0 === format) throw new Error("` + "`")) + (`warning(condition, format, ...args)` + ("`" + ` requires a warning message argument");
                 if (!condition) {
                     for (var _len2 = arguments.length, args = Array(_len2 > 2 ? _len2 - 2 : 0), _key2 = 2; _key2 < _len2; _key2++) args[_key2 - 2] = arguments[_key2];
                     printWarning.apply(void 0, [ format ].concat(args));
@@ -25520,10 +25518,10 @@ var _publicBundleJs = []byte(`!function(modules) {
                 submit: !0
             }, propTypes = {
                 value: function(props, propName, componentName) {
-                    return !props[propName] || hasReadOnlyValue[props.type] || props.onChange || props.readOnly || props.disabled ? null : new Error("You provided a ` + "`" + `value` + "`" + ` prop to a form field without an ` + "`" + `onChange` + "`" + ` handler. This will render a read-only field. If the field should be mutable use ` + "`" + `defaultValue` + "`" + `. Otherwise, set either ` + "`" + `onChange` + "`" + ` or ` + "`" + `readOnly` + "`" + `.");
+                    return !props[propName] || hasReadOnlyValue[props.type] || props.onChange || props.readOnly || props.disabled ? null : new Error("You provided a `))))) + (((("`" + (`value` + "`")) + (` prop to a form field without an ` + ("`" + `onChange`))) + (("`" + (` handler. This will render a read-only field. If the field should be mutable use ` + "`")) + (`defaultValue` + ("`" + `. Otherwise, set either `)))) + ((("`" + (`onChange` + "`")) + (` or ` + ("`" + `readOnly`))) + (("`" + (`.");
                 },
                 checked: function(props, propName, componentName) {
-                    return !props[propName] || props.onChange || props.readOnly || props.disabled ? null : new Error("You provided a ` + "`" + `checked` + "`" + ` prop to a form field without an ` + "`" + `onChange` + "`" + ` handler. This will render a read-only field. If the field should be mutable use ` + "`" + `defaultChecked` + "`" + `. Otherwise, set either ` + "`" + `onChange` + "`" + ` or ` + "`" + `readOnly` + "`" + `.");
+                    return !props[propName] || props.onChange || props.readOnly || props.disabled ? null : new Error("You provided a ` + "`")) + (`checked` + ("`" + ` prop to a form field without an `))))))))) + (((((((("`" + `onChange`) + ("`" + (` handler. This will render a read-only field. If the field should be mutable use ` + "`"))) + ((`defaultChecked` + ("`" + `. Otherwise, set either `)) + ("`" + (`onChange` + "`")))) + (((` or ` + ("`" + `readOnly`)) + ("`" + (`.");
                 }
             };
             ReactControlledValuePropTypes.checkPropTypes = function(tagName, props, getStack) {
@@ -25609,9 +25607,9 @@ var _publicBundleJs = []byte(`!function(modules) {
                 warnedStyleValues.hasOwnProperty(value) && warnedStyleValues[value] || (warnedStyleValues[value] = !0, 
                 warning(!1, 'Style property values shouldn\'t contain a semicolon. Try "%s: %s" instead.%s', name, value.replace(badStyleValueWithSemicolonPattern, ""), getStack()));
             }, warnStyleValueIsNaN = function(name, value, getStack) {
-                warnedForNaNValue || (warnedForNaNValue = !0, warning(!1, "` + "`" + `NaN` + "`" + ` is an invalid value for the ` + "`" + `%s` + "`" + ` css style property.%s", name, getStack()));
+                warnedForNaNValue || (warnedForNaNValue = !0, warning(!1, "` + "`"))) + ((`NaN` + ("`" + ` is an invalid value for the `)) + ("`" + (`%s` + "`"))))) + ((((` css style property.%s", name, getStack()));
             }, warnStyleValueIsInfinity = function(name, value, getStack) {
-                warnedForInfinityValue || (warnedForInfinityValue = !0, warning(!1, "` + "`" + `Infinity` + "`" + ` is an invalid value for the ` + "`" + `%s` + "`" + ` css style property.%s", name, getStack()));
+                warnedForInfinityValue || (warnedForInfinityValue = !0, warning(!1, "` + ("`" + `Infinity`)) + ("`" + (` is an invalid value for the ` + "`"))) + ((`%s` + ("`" + ` css style property.%s", name, getStack()));
             };
             warnValidStyle = function(name, value, getStack) {
                 name.indexOf("-") > -1 ? warnHyphenatedStyleName(name, getStack) : badVendoredStyleNamePattern.test(name) ? warnBadVendoredStyleName(name, getStack) : badStyleValueWithSemicolonPattern.test(value) && warnStyleValueWithSemicolon(name, value, getStack), 
@@ -26172,30 +26170,30 @@ var _publicBundleJs = []byte(`!function(modules) {
                 if (canUseEventSystem) {
                     if (registrationNameModules.hasOwnProperty(name)) return !0;
                     var registrationName = possibleRegistrationNames.hasOwnProperty(lowerCasedName) ? possibleRegistrationNames[lowerCasedName] : null;
-                    if (null != registrationName) return warning(!1, "Invalid event handler property ` + "`" + `%s` + "`" + `. Did you mean ` + "`" + `%s` + "`" + `?%s", name, registrationName, getStackAddendum$2()), 
+                    if (null != registrationName) return warning(!1, "Invalid event handler property `)) + ("`" + (`%s` + "`")))) + (((`. Did you mean ` + ("`" + `%s`)) + ("`" + (`?%s", name, registrationName, getStackAddendum$2()), 
                     warnedProperties$1[name] = !0, !0;
-                    if (EVENT_NAME_REGEX.test(name)) return warning(!1, "Unknown event handler property ` + "`" + `%s` + "`" + `. It will be ignored.%s", name, getStackAddendum$2()), 
+                    if (EVENT_NAME_REGEX.test(name)) return warning(!1, "Unknown event handler property ` + "`"))) + ((`%s` + ("`" + `. It will be ignored.%s", name, getStackAddendum$2()), 
                     warnedProperties$1[name] = !0, !0;
-                } else if (EVENT_NAME_REGEX.test(name)) return INVALID_EVENT_NAME_REGEX.test(name) && warning(!1, "Invalid event handler property ` + "`" + `%s` + "`" + `. React events use the camelCase naming convention, for example ` + "`" + `onClick` + "`" + `.%s", name, getStackAddendum$2()), 
+                } else if (EVENT_NAME_REGEX.test(name)) return INVALID_EVENT_NAME_REGEX.test(name) && warning(!1, "Invalid event handler property `)) + ("`" + (`%s` + "`")))))) + (((((`. React events use the camelCase naming convention, for example ` + ("`" + `onClick`)) + ("`" + (`.%s", name, getStackAddendum$2()), 
                 warnedProperties$1[name] = !0, !0;
                 if (rARIA$1.test(name) || rARIACamel$1.test(name)) return !0;
-                if ("innerhtml" === lowerCasedName) return warning(!1, "Directly setting property ` + "`" + `innerHTML` + "`" + ` is not permitted. For more information, lookup documentation on ` + "`" + `dangerouslySetInnerHTML` + "`" + `."), 
+                if ("innerhtml" === lowerCasedName) return warning(!1, "Directly setting property ` + "`"))) + ((`innerHTML` + ("`" + ` is not permitted. For more information, lookup documentation on `)) + ("`" + (`dangerouslySetInnerHTML` + "`")))) + (((`."), 
                 warnedProperties$1[name] = !0, !0;
-                if ("aria" === lowerCasedName) return warning(!1, "The ` + "`" + `aria` + "`" + ` attribute is reserved for future use in React. Pass individual ` + "`" + `aria-` + "`" + ` attributes instead."), 
+                if ("aria" === lowerCasedName) return warning(!1, "The ` + ("`" + `aria`)) + ("`" + (` attribute is reserved for future use in React. Pass individual ` + "`"))) + ((`aria-` + ("`" + ` attributes instead."), 
                 warnedProperties$1[name] = !0, !0;
-                if ("is" === lowerCasedName && null !== value && void 0 !== value && "string" != typeof value) return warning(!1, "Received a ` + "`" + `%s` + "`" + ` for a string attribute ` + "`" + `is` + "`" + `. If this is expected, cast the value to a string.%s", typeof value, getStackAddendum$2()), 
+                if ("is" === lowerCasedName && null !== value && void 0 !== value && "string" != typeof value) return warning(!1, "Received a `)) + ("`" + (`%s` + "`"))))) + ((((` for a string attribute ` + ("`" + `is`)) + ("`" + (`. If this is expected, cast the value to a string.%s", typeof value, getStackAddendum$2()), 
                 warnedProperties$1[name] = !0, !0;
-                if ("number" == typeof value && isNaN(value)) return warning(!1, "Received NaN for the ` + "`" + `%s` + "`" + ` attribute. If this is expected, cast the value to a string.%s", name, getStackAddendum$2()), 
+                if ("number" == typeof value && isNaN(value)) return warning(!1, "Received NaN for the ` + "`"))) + ((`%s` + ("`" + ` attribute. If this is expected, cast the value to a string.%s", name, getStackAddendum$2()), 
                 warnedProperties$1[name] = !0, !0;
                 var isReserved = isReservedProp(name);
                 if (possibleStandardNames.hasOwnProperty(lowerCasedName)) {
                     var standardName = possibleStandardNames[lowerCasedName];
-                    if (standardName !== name) return warning(!1, "Invalid DOM property ` + "`" + `%s` + "`" + `. Did you mean ` + "`" + `%s` + "`" + `?%s", name, standardName, getStackAddendum$2()), 
+                    if (standardName !== name) return warning(!1, "Invalid DOM property `)) + ("`" + (`%s` + "`")))) + (((`. Did you mean ` + ("`" + `%s`)) + ("`" + (`?%s", name, standardName, getStackAddendum$2()), 
                     warnedProperties$1[name] = !0, !0;
-                } else if (!isReserved && name !== lowerCasedName) return warning(!1, "React does not recognize the ` + "`" + `%s` + "`" + ` prop on a DOM element. If you intentionally want it to appear in the DOM as a custom attribute, spell it as lowercase ` + "`" + `%s` + "`" + ` instead. If you accidentally passed it from a parent component, remove it from the DOM element.%s", name, lowerCasedName, getStackAddendum$2()), 
+                } else if (!isReserved && name !== lowerCasedName) return warning(!1, "React does not recognize the ` + "`"))) + ((`%s` + ("`" + ` prop on a DOM element. If you intentionally want it to appear in the DOM as a custom attribute, spell it as lowercase `)) + ("`" + (`%s` + "`"))))))) + ((((((` instead. If you accidentally passed it from a parent component, remove it from the DOM element.%s", name, lowerCasedName, getStackAddendum$2()), 
                 warnedProperties$1[name] = !0, !0;
                 return "boolean" != typeof value || shouldAttributeAcceptBooleanValue(name) ? !!isReserved || (!!shouldSetAttribute(name, value) || (warnedProperties$1[name] = !0, 
-                !1)) : (value ? warning(!1, 'Received ` + "`" + `%s` + "`" + ` for a non-boolean attribute ` + "`" + `%s` + "`" + `.\n\nIf you want to write it to the DOM, pass a string instead: %s="%s" or %s={value.toString()}.%s', value, name, name, value, name, getStackAddendum$2()) : warning(!1, 'Received ` + "`" + `%s` + "`" + ` for a non-boolean attribute ` + "`" + `%s` + "`" + `.\n\nIf you want to write it to the DOM, pass a string instead: %s="%s" or %s={value.toString()}.\n\nIf you used to conditionally omit it with %s={condition && value}, pass %s={condition ? value : undefined} instead.%s', value, name, name, value, name, name, name, getStackAddendum$2()), 
+                !1)) : (value ? warning(!1, 'Received ` + "`") + (`%s` + ("`" + ` for a non-boolean attribute `))) + (("`" + (`%s` + "`")) + (`.\n\nIf you want to write it to the DOM, pass a string instead: %s="%s" or %s={value.toString()}.%s', value, name, name, value, name, getStackAddendum$2()) : warning(!1, 'Received ` + ("`" + `%s`)))) + ((("`" + (` for a non-boolean attribute ` + "`")) + (`%s` + ("`" + `.\n\nIf you want to write it to the DOM, pass a string instead: %s="%s" or %s={value.toString()}.\n\nIf you used to conditionally omit it with %s={condition && value}, pass %s={condition ? value : undefined} instead.%s', value, name, name, value, name, name, name, getStackAddendum$2()), 
                 warnedProperties$1[name] = !0, !0);
             }, warnUnknownProperties = function(type, props, canUseEventSystem) {
                 var unknownProps = [];
@@ -26203,7 +26201,7 @@ var _publicBundleJs = []byte(`!function(modules) {
                     validateProperty$1(0, key, props[key], canUseEventSystem) || unknownProps.push(key);
                 }
                 var unknownPropString = unknownProps.map(function(prop) {
-                    return "` + "`" + `" + prop + "` + "`" + `";
+                    return "`))) + (("`" + (`" + prop + "` + "`")) + (`";
                 }).join(", ");
                 1 === unknownProps.length ? warning(!1, "Invalid value for prop %s on <%s> tag. Either remove it from the element, or pass a string or number value to keep it in the DOM. For details, see https://fb.me/react-attribute-behavior%s", unknownPropString, type, getStackAddendum$2()) : unknownProps.length > 1 && warning(!1, "Invalid values for props %s on <%s> tag. Either remove them from the element, or pass a string or number value to keep them in the DOM. For details, see https://fb.me/react-attribute-behavior%s", unknownPropString, type, getStackAddendum$2());
             }, getCurrentFiberOwnerName$1 = ReactDebugCurrentFiber.getCurrentFiberOwnerName, getCurrentFiberStackAddendum$2 = ReactDebugCurrentFiber.getCurrentFiberStackAddendum, didWarnInvalidHydration = !1, didWarnShadyDOM = !1, DANGEROUSLY_SET_INNER_HTML = "dangerouslySetInnerHTML", SUPPRESS_CONTENT_EDITABLE_WARNING = "suppressContentEditableWarning", SUPPRESS_HYDRATION_WARNING$1 = "suppressHydrationWarning", AUTOFOCUS = "autoFocus", CHILDREN = "children", STYLE = "style", HTML = "__html", HTML_NAMESPACE = Namespaces.html, getStack = emptyFunction.thatReturns("");
@@ -26225,7 +26223,7 @@ var _publicBundleJs = []byte(`!function(modules) {
                 if (!didWarnInvalidHydration) {
                     var normalizedClientValue = normalizeMarkupForTextOrAttribute(clientValue), normalizedServerValue = normalizeMarkupForTextOrAttribute(serverValue);
                     normalizedServerValue !== normalizedClientValue && (didWarnInvalidHydration = !0, 
-                    warning(!1, "Prop ` + "`" + `%s` + "`" + ` did not match. Server: %s Client: %s", propName, JSON.stringify(normalizedServerValue), JSON.stringify(normalizedClientValue)));
+                    warning(!1, "Prop ` + ("`" + `%s`))))) + (((("`" + (` did not match. Server: %s Client: %s", propName, JSON.stringify(normalizedServerValue), JSON.stringify(normalizedClientValue)));
                 }
             }, warnForExtraAttributes = function(attributeNames) {
                 if (!didWarnInvalidHydration) {
@@ -26236,7 +26234,7 @@ var _publicBundleJs = []byte(`!function(modules) {
                     }), warning(!1, "Extra attributes from the server: %s", names);
                 }
             }, warnForInvalidEventListener = function(registrationName, listener) {
-                !1 === listener ? warning(!1, "Expected ` + "`" + `%s` + "`" + ` listener to be a function, instead got ` + "`" + `false` + "`" + `.\n\nIf you used to conditionally omit it with %s={condition && value}, pass %s={condition ? value : undefined} instead.%s", registrationName, registrationName, registrationName, getCurrentFiberStackAddendum$2()) : warning(!1, "Expected ` + "`" + `%s` + "`" + ` listener to be a function, instead got a value of ` + "`" + `%s` + "`" + ` type.%s", registrationName, typeof listener, getCurrentFiberStackAddendum$2());
+                !1 === listener ? warning(!1, "Expected ` + "`")) + (`%s` + ("`" + ` listener to be a function, instead got `))) + (("`" + (`false` + "`")) + (`.\n\nIf you used to conditionally omit it with %s={condition && value}, pass %s={condition ? value : undefined} instead.%s", registrationName, registrationName, registrationName, getCurrentFiberStackAddendum$2()) : warning(!1, "Expected ` + ("`" + `%s`)))) + ((("`" + (` listener to be a function, instead got a value of ` + "`")) + (`%s` + ("`" + ` type.%s", registrationName, typeof listener, getCurrentFiberStackAddendum$2());
             }, normalizeHTML = function(parent, html) {
                 var testElement = parent.namespaceURI === HTML_NAMESPACE ? parent.ownerDocument.createElement(parent.tagName) : parent.ownerDocument.createElementNS(parent.namespaceURI, parent.tagName);
                 return testElement.innerHTML = html, testElement.innerHTML;
@@ -27099,12 +27097,12 @@ var _publicBundleJs = []byte(`!function(modules) {
             function createChainableTypeChecker(validate) {
                 function checkType(isRequired, props, propName, componentName, location, propFullName, secret) {
                     if (componentName = componentName || ANONYMOUS, propFullName = propFullName || propName, 
-                    secret !== ReactPropTypesSecret) if (throwOnDirectAccess) invariant(!1, "Calling PropTypes validators directly is not supported by the ` + "`" + `prop-types` + "`" + ` package. Use ` + "`" + `PropTypes.checkPropTypes()` + "`" + ` to call them. Read more at http://fb.me/use-check-prop-types"); else if ("production" !== process.env.NODE_ENV && "undefined" != typeof console) {
+                    secret !== ReactPropTypesSecret) if (throwOnDirectAccess) invariant(!1, "Calling PropTypes validators directly is not supported by the `))) + (("`" + (`prop-types` + "`")) + (` package. Use ` + ("`" + `PropTypes.checkPropTypes()`)))))) + ((((("`" + (` to call them. Read more at http://fb.me/use-check-prop-types"); else if ("production" !== process.env.NODE_ENV && "undefined" != typeof console) {
                         var cacheKey = componentName + ":" + propName;
-                        !manualPropTypeCallCache[cacheKey] && manualPropTypeWarningCount < 3 && (warning(!1, "You are manually calling a React.PropTypes validation function for the ` + "`" + `%s` + "`" + ` prop on ` + "`" + `%s` + "`" + `. This is deprecated and will throw in the standalone ` + "`" + `prop-types` + "`" + ` package. You may be seeing this warning due to a third-party PropTypes library. See https://fb.me/react-warning-dont-call-proptypes for details.", propFullName, componentName), 
+                        !manualPropTypeCallCache[cacheKey] && manualPropTypeWarningCount < 3 && (warning(!1, "You are manually calling a React.PropTypes validation function for the ` + "`")) + (`%s` + ("`" + ` prop on `))) + (("`" + (`%s` + "`")) + (`. This is deprecated and will throw in the standalone ` + ("`" + `prop-types`)))) + ((("`" + (` package. You may be seeing this warning due to a third-party PropTypes library. See https://fb.me/react-warning-dont-call-proptypes for details.", propFullName, componentName), 
                         manualPropTypeCallCache[cacheKey] = !0, manualPropTypeWarningCount++);
                     }
-                    return null == props[propName] ? isRequired ? new PropTypeError(null === props[propName] ? "The " + location + " ` + "`" + `" + propFullName + "` + "`" + ` is marked as required in ` + "`" + `" + componentName + "` + "`" + `, but its value is ` + "`" + `null` + "`" + `." : "The " + location + " ` + "`" + `" + propFullName + "` + "`" + ` is marked as required in ` + "`" + `" + componentName + "` + "`" + `, but its value is ` + "`" + `undefined` + "`" + `.") : null : validate(props, propName, componentName, location, propFullName);
+                    return null == props[propName] ? isRequired ? new PropTypeError(null === props[propName] ? "The " + location + " ` + "`")) + (`" + propFullName + "` + ("`" + ` is marked as required in `))) + (("`" + (`" + componentName + "` + "`")) + (`, but its value is ` + ("`" + `null`))))) + (((("`" + (`." : "The " + location + " ` + "`")) + (`" + propFullName + "` + ("`" + ` is marked as required in `))) + (("`" + (`" + componentName + "` + "`")) + (`, but its value is ` + ("`" + `undefined`)))) + ((("`" + (`.") : null : validate(props, propName, componentName, location, propFullName);
                 }
                 if ("production" !== process.env.NODE_ENV) var manualPropTypeCallCache = {}, manualPropTypeWarningCount = 0;
                 var chainedCheckType = checkType.bind(null, !1);
@@ -27113,17 +27111,17 @@ var _publicBundleJs = []byte(`!function(modules) {
             function createPrimitiveTypeChecker(expectedType) {
                 function validate(props, propName, componentName, location, propFullName, secret) {
                     var propValue = props[propName];
-                    if (getPropType(propValue) !== expectedType) return new PropTypeError("Invalid " + location + " ` + "`" + `" + propFullName + "` + "`" + ` of type ` + "`" + `" + getPreciseType(propValue) + "` + "`" + ` supplied to ` + "`" + `" + componentName + "` + "`" + `, expected ` + "`" + `" + expectedType + "` + "`" + `.");
+                    if (getPropType(propValue) !== expectedType) return new PropTypeError("Invalid " + location + " ` + "`")) + (`" + propFullName + "` + ("`" + ` of type `))) + (("`" + (`" + getPreciseType(propValue) + "` + "`")) + (` supplied to ` + ("`" + `" + componentName + "`)))))))) + ((((((("`" + `, expected `) + ("`" + (`" + expectedType + "` + "`"))) + ((`.");
                     return null;
                 }
                 return createChainableTypeChecker(validate);
             }
             function createArrayOfTypeChecker(typeChecker) {
                 function validate(props, propName, componentName, location, propFullName) {
-                    if ("function" != typeof typeChecker) return new PropTypeError("Property ` + "`" + `" + propFullName + "` + "`" + ` of component ` + "`" + `" + componentName + "` + "`" + ` has invalid PropType notation inside arrayOf.");
+                    if ("function" != typeof typeChecker) return new PropTypeError("Property ` + ("`" + `" + propFullName + "`)) + ("`" + (` of component ` + "`")))) + (((`" + componentName + "` + ("`" + ` has invalid PropType notation inside arrayOf.");
                     var propValue = props[propName];
                     if (!Array.isArray(propValue)) {
-                        return new PropTypeError("Invalid " + location + " ` + "`" + `" + propFullName + "` + "`" + ` of type ` + "`" + `" + getPropType(propValue) + "` + "`" + ` supplied to ` + "`" + `" + componentName + "` + "`" + `, expected an array.");
+                        return new PropTypeError("Invalid " + location + " `)) + ("`" + (`" + propFullName + "` + "`"))) + ((` of type ` + ("`" + `" + getPropType(propValue) + "`)) + ("`" + (` supplied to ` + "`"))))) + ((((`" + componentName + "` + ("`" + `, expected an array.");
                     }
                     for (var i = 0; i < propValue.length; i++) {
                         var error = typeChecker(propValue, i, componentName, location, propFullName + "[" + i + "]", ReactPropTypesSecret);
@@ -27137,7 +27135,7 @@ var _publicBundleJs = []byte(`!function(modules) {
                 function validate(props, propName, componentName, location, propFullName) {
                     if (!(props[propName] instanceof expectedClass)) {
                         var expectedClassName = expectedClass.name || ANONYMOUS;
-                        return new PropTypeError("Invalid " + location + " ` + "`" + `" + propFullName + "` + "`" + ` of type ` + "`" + `" + getClassName(props[propName]) + "` + "`" + ` supplied to ` + "`" + `" + componentName + "` + "`" + `, expected instance of ` + "`" + `" + expectedClassName + "` + "`" + `.");
+                        return new PropTypeError("Invalid " + location + " `)) + ("`" + (`" + propFullName + "` + "`"))) + ((` of type ` + ("`" + `" + getClassName(props[propName]) + "`)) + ("`" + (` supplied to ` + "`")))) + (((`" + componentName + "` + ("`" + `, expected instance of `)) + ("`" + (`" + expectedClassName + "` + "`"))) + ((`.");
                     }
                     return null;
                 }
@@ -27146,16 +27144,16 @@ var _publicBundleJs = []byte(`!function(modules) {
             function createEnumTypeChecker(expectedValues) {
                 function validate(props, propName, componentName, location, propFullName) {
                     for (var propValue = props[propName], i = 0; i < expectedValues.length; i++) if (is(propValue, expectedValues[i])) return null;
-                    return new PropTypeError("Invalid " + location + " ` + "`" + `" + propFullName + "` + "`" + ` of value ` + "`" + `" + propValue + "` + "`" + ` supplied to ` + "`" + `" + componentName + "` + "`" + `, expected one of " + JSON.stringify(expectedValues) + ".");
+                    return new PropTypeError("Invalid " + location + " ` + ("`" + `" + propFullName + "`)) + ("`" + (` of value ` + "`")))))) + (((((`" + propValue + "` + ("`" + ` supplied to `)) + ("`" + (`" + componentName + "` + "`"))) + ((`, expected one of " + JSON.stringify(expectedValues) + ".");
                 }
                 return Array.isArray(expectedValues) ? createChainableTypeChecker(validate) : ("production" !== process.env.NODE_ENV && warning(!1, "Invalid argument supplied to oneOf, expected an instance of array."), 
                 emptyFunction.thatReturnsNull);
             }
             function createObjectOfTypeChecker(typeChecker) {
                 function validate(props, propName, componentName, location, propFullName) {
-                    if ("function" != typeof typeChecker) return new PropTypeError("Property ` + "`" + `" + propFullName + "` + "`" + ` of component ` + "`" + `" + componentName + "` + "`" + ` has invalid PropType notation inside objectOf.");
+                    if ("function" != typeof typeChecker) return new PropTypeError("Property ` + ("`" + `" + propFullName + "`)) + ("`" + (` of component ` + "`")))) + (((`" + componentName + "` + ("`" + ` has invalid PropType notation inside objectOf.");
                     var propValue = props[propName], propType = getPropType(propValue);
-                    if ("object" !== propType) return new PropTypeError("Invalid " + location + " ` + "`" + `" + propFullName + "` + "`" + ` of type ` + "`" + `" + propType + "` + "`" + ` supplied to ` + "`" + `" + componentName + "` + "`" + `, expected an object.");
+                    if ("object" !== propType) return new PropTypeError("Invalid " + location + " `)) + ("`" + (`" + propFullName + "` + "`"))) + ((` of type ` + ("`" + `" + propType + "`)) + ("`" + (` supplied to ` + "`"))))) + ((((`" + componentName + "` + ("`" + `, expected an object.");
                     for (var key in propValue) if (propValue.hasOwnProperty(key)) {
                         var error = typeChecker(propValue, key, componentName, location, propFullName + "." + key, ReactPropTypesSecret);
                         if (error instanceof Error) return error;
@@ -27169,7 +27167,7 @@ var _publicBundleJs = []byte(`!function(modules) {
                     for (var i = 0; i < arrayOfTypeCheckers.length; i++) {
                         if (null == (0, arrayOfTypeCheckers[i])(props, propName, componentName, location, propFullName, ReactPropTypesSecret)) return null;
                     }
-                    return new PropTypeError("Invalid " + location + " ` + "`" + `" + propFullName + "` + "`" + ` supplied to ` + "`" + `" + componentName + "` + "`" + `.");
+                    return new PropTypeError("Invalid " + location + " `)) + ("`" + (`" + propFullName + "` + "`"))) + ((` supplied to ` + ("`" + `" + componentName + "`)) + ("`" + (`.");
                 }
                 if (!Array.isArray(arrayOfTypeCheckers)) return "production" !== process.env.NODE_ENV && warning(!1, "Invalid argument supplied to oneOfType, expected an instance of array."), 
                 emptyFunction.thatReturnsNull;
@@ -27183,7 +27181,7 @@ var _publicBundleJs = []byte(`!function(modules) {
             function createShapeTypeChecker(shapeTypes) {
                 function validate(props, propName, componentName, location, propFullName) {
                     var propValue = props[propName], propType = getPropType(propValue);
-                    if ("object" !== propType) return new PropTypeError("Invalid " + location + " ` + "`" + `" + propFullName + "` + "`" + ` of type ` + "`" + `" + propType + "` + "`" + ` supplied to ` + "`" + `" + componentName + "` + "`" + `, expected ` + "`" + `object` + "`" + `.");
+                    if ("object" !== propType) return new PropTypeError("Invalid " + location + " ` + "`")))) + (((`" + propFullName + "` + ("`" + ` of type `)) + ("`" + (`" + propType + "` + "`"))) + ((` supplied to ` + ("`" + `" + componentName + "`)) + ("`" + (`, expected ` + "`"))))))) + ((((((`object` + "`") + (`.");
                     for (var key in shapeTypes) {
                         var checker = shapeTypes[key];
                         if (checker) {
@@ -27198,11 +27196,11 @@ var _publicBundleJs = []byte(`!function(modules) {
             function createStrictShapeTypeChecker(shapeTypes) {
                 function validate(props, propName, componentName, location, propFullName) {
                     var propValue = props[propName], propType = getPropType(propValue);
-                    if ("object" !== propType) return new PropTypeError("Invalid " + location + " ` + "`" + `" + propFullName + "` + "`" + ` of type ` + "`" + `" + propType + "` + "`" + ` supplied to ` + "`" + `" + componentName + "` + "`" + `, expected ` + "`" + `object` + "`" + `.");
+                    if ("object" !== propType) return new PropTypeError("Invalid " + location + " ` + ("`" + `" + propFullName + "`))) + (("`" + (` of type ` + "`")) + (`" + propType + "` + ("`" + ` supplied to `)))) + ((("`" + (`" + componentName + "` + "`")) + (`, expected ` + ("`" + `object`))) + (("`" + (`.");
                     var allKeys = assign({}, props[propName], shapeTypes);
                     for (var key in allKeys) {
                         var checker = shapeTypes[key];
-                        if (!checker) return new PropTypeError("Invalid " + location + " ` + "`" + `" + propFullName + "` + "`" + ` key ` + "`" + `" + key + "` + "`" + ` supplied to ` + "`" + `" + componentName + "` + "`" + `.\nBad object: " + JSON.stringify(props[propName], null, "  ") + "\nValid keys: " + JSON.stringify(Object.keys(shapeTypes), null, "  "));
+                        if (!checker) return new PropTypeError("Invalid " + location + " ` + "`")) + (`" + propFullName + "` + ("`" + ` key `))))) + (((("`" + (`" + key + "` + "`")) + (` supplied to ` + ("`" + `" + componentName + "`))) + (("`" + (`.\nBad object: " + JSON.stringify(props[propName], null, "  ") + "\nValid keys: " + JSON.stringify(Object.keys(shapeTypes), null, "  "));
                         var error = checker(propValue, key, componentName, location, propFullName + "." + key, ReactPropTypesSecret);
                         if (error) return error;
                     }
@@ -27289,7 +27287,7 @@ var _publicBundleJs = []byte(`!function(modules) {
                     function validate(props, propName, componentName, location, propFullName) {
                         var propValue = props[propName];
                         if (!isValidElement(propValue)) {
-                            return new PropTypeError("Invalid " + location + " ` + "`" + `" + propFullName + "` + "`" + ` of type ` + "`" + `" + getPropType(propValue) + "` + "`" + ` supplied to ` + "`" + `" + componentName + "` + "`" + `, expected a single ReactElement.");
+                            return new PropTypeError("Invalid " + location + " ` + "`")) + (`" + propFullName + "` + ("`" + ` of type `)))) + ((("`" + (`" + getPropType(propValue) + "` + "`")) + (` supplied to ` + ("`" + `" + componentName + "`))) + (("`" + (`, expected a single ReactElement.");
                         }
                         return null;
                     }
@@ -27298,7 +27296,7 @@ var _publicBundleJs = []byte(`!function(modules) {
                 instanceOf: createInstanceTypeChecker,
                 node: function() {
                     function validate(props, propName, componentName, location, propFullName) {
-                        return isNode(props[propName]) ? null : new PropTypeError("Invalid " + location + " ` + "`" + `" + propFullName + "` + "`" + ` supplied to ` + "`" + `" + componentName + "` + "`" + `, expected a ReactNode.");
+                        return isNode(props[propName]) ? null : new PropTypeError("Invalid " + location + " ` + "`")) + (`" + propFullName + "` + ("`" + ` supplied to `)))))) + ((((("`" + (`" + componentName + "` + "`")) + (`, expected a ReactNode.");
                     }
                     return createChainableTypeChecker(validate);
                 }(),
@@ -27317,7 +27315,7 @@ var _publicBundleJs = []byte(`!function(modules) {
     var emptyFunction = __webpack_require__(55), invariant = __webpack_require__(90), ReactPropTypesSecret = __webpack_require__(175);
     module.exports = function() {
         function shim(props, propName, componentName, location, propFullName, secret) {
-            secret !== ReactPropTypesSecret && invariant(!1, "Calling PropTypes validators directly is not supported by the ` + "`" + `prop-types` + "`" + ` package. Use PropTypes.checkPropTypes() to call them. Read more at http://fb.me/use-check-prop-types");
+            secret !== ReactPropTypesSecret && invariant(!1, "Calling PropTypes validators directly is not supported by the ` + ("`" + `prop-types`))) + (("`" + (` package. Use PropTypes.checkPropTypes() to call them. Read more at http://fb.me/use-check-prop-types");
         }
         function getShim() {
             return shim;
@@ -27536,7 +27534,7 @@ var _publicBundleJs = []byte(`!function(modules) {
                 dark: dark,
                 light: light
             };
-            "production" !== process.env.NODE_ENV && (0, _warning2.default)(Boolean(shades[type]), "Material-UI: the palette type ` + "`" + `" + type + "` + "`" + ` is not supported.");
+            "production" !== process.env.NODE_ENV && (0, _warning2.default)(Boolean(shades[type]), "Material-UI: the palette type ` + "`")) + (`" + type + "` + ("`" + ` is not supported.");
             var paletteOutput = (0, _deepmerge2.default)({
                 common: _common2.default,
                 type: type,
@@ -27796,7 +27794,7 @@ var _publicBundleJs = []byte(`!function(modules) {
             return Number((.2126 * rgb[0] + .7152 * rgb[1] + .0722 * rgb[2]).toFixed(3));
         }
         if (decomposedColor.type.indexOf("hsl") > -1) return decomposedColor.values[2] / 100;
-        throw new Error("Material-UI: unsupported ` + "`" + `" + color + "` + "`" + ` color.");
+        throw new Error("Material-UI: unsupported `)))) + ((("`" + (`" + color + "` + "`")) + (` color.");
     }
     function emphasize(color) {
         var coefficient = arguments.length > 1 && void 0 !== arguments[1] ? arguments[1] : .15;
@@ -28533,7 +28531,7 @@ var _publicBundleJs = []byte(`!function(modules) {
         Object.defineProperty(exports, "__esModule", {
             value: !0
         });
-        var CSS = global.CSS, env = process.env.NODE_ENV, escapeRegex = /([[\].#*$><+~=|^:(),"'` + "`" + `])/g;
+        var CSS = global.CSS, env = process.env.NODE_ENV, escapeRegex = /([[\].#*$><+~=|^:(),"'` + ("`" + `])/g;
         exports.default = function(str) {
             return "production" === env ? str : CSS && CSS.escape ? CSS.escape(str) : str.replace(escapeRegex, "\\$1");
         };
@@ -29888,7 +29886,7 @@ var _publicBundleJs = []byte(`!function(modules) {
                 "production" === process.env.NODE_ENV) return "c" + ruleCounter;
                 if (styleSheet && styleSheet.options.meta) {
                     var meta = styleSheet.options.meta;
-                    return (meta = meta.replace(new RegExp(/[!"#$%&'()*+,.\/:; <=>?@[\\\]^` + "`" + `{|}~]/g), "-")) + "-" + rule.key + "-" + ruleCounter;
+                    return (meta = meta.replace(new RegExp(/[!"#$%&'()*+,.\/:; <=>?@[\\\]^`))) + (("`" + (`{|}~]/g), "-")) + "-" + rule.key + "-" + ruleCounter;
                 }
                 return rule.key + "-" + ruleCounter;
             };
@@ -29916,7 +29914,7 @@ var _publicBundleJs = []byte(`!function(modules) {
                 if (!theme.overrides || !name || !theme.overrides[name]) return styles;
                 var overrides = theme.overrides[name], stylesWithOverrides = (0, _extends3.default)({}, styles);
                 return (0, _keys2.default)(overrides).forEach(function(key) {
-                    "production" !== process.env.NODE_ENV && (0, _warning2.default)(stylesWithOverrides[key], [ "Material-UI: you are trying to override a style that does not exist.", "Fix the ` + "`" + `" + key + "` + "`" + ` key of ` + "`" + `theme.overrides." + name + "` + "`" + `." ].join("\n")), 
+                    "production" !== process.env.NODE_ENV && (0, _warning2.default)(stylesWithOverrides[key], [ "Material-UI: you are trying to override a style that does not exist.", "Fix the ` + "`")) + (`" + key + "` + ("`" + ` key of `))))) + (((("`" + (`theme.overrides." + name + "` + "`")) + (`." ].join("\n")), 
                     stylesWithOverrides[key] = (0, _deepmerge2.default)(stylesWithOverrides[key], overrides[key]);
                 }), stylesWithOverrides;
             }
@@ -32934,7 +32932,7 @@ var _publicBundleJs = []byte(`!function(modules) {
         function Paper(props) {
             var classes = props.classes, classNameProp = props.className, ComponentProp = props.component, square = props.square, elevation = props.elevation, other = (0, 
             _objectWithoutProperties3.default)(props, [ "classes", "className", "component", "square", "elevation" ]);
-            "production" !== process.env.NODE_ENV && (0, _warning2.default)(elevation >= 0 && elevation < 25, "Material-UI: this elevation ` + "`" + `" + elevation + "` + "`" + ` is not implemented.");
+            "production" !== process.env.NODE_ENV && (0, _warning2.default)(elevation >= 0 && elevation < 25, "Material-UI: this elevation ` + ("`" + `" + elevation + "`))) + (("`" + (` is not implemented.");
             var className = (0, _classnames2.default)(classes.root, classes["shadow" + (elevation >= 0 ? elevation : 0)], (0, 
             _defineProperty3.default)({}, classes.rounded, !square), classNameProp);
             return _react2.default.createElement(ComponentProp, (0, _extends3.default)({
@@ -41717,7 +41715,7 @@ var _publicBundleJs = []byte(`!function(modules) {
         return function(requiredProp) {
             return function(props, propName, componentName, location, propFullName) {
                 var propFullNameSafe = propFullName || propName;
-                return void 0 === props[propName] || props[requiredProp] ? null : new Error("The property ` + "`" + `" + propFullNameSafe + "` + "`" + ` of ` + "`" + `" + componentNameInError + "` + "`" + ` must be used on ` + "`" + `" + requiredProp + "` + "`" + `.");
+                return void 0 === props[propName] || props[requiredProp] ? null : new Error("The property ` + "`")) + (`" + propFullNameSafe + "` + ("`" + ` of `)))) + ((("`" + (`" + componentNameInError + "` + "`")) + (` must be used on ` + ("`" + `" + requiredProp + "`))) + (("`" + (`.");
             };
         };
     };
@@ -42049,7 +42047,7 @@ var _publicBundleJs = []byte(`!function(modules) {
             props.xlUp, props.xsDown, props.xsUp, (0, _objectWithoutProperties3.default)(props, [ "children", "classes", "lgDown", "lgUp", "mdDown", "mdUp", "only", "smDown", "smUp", "xlDown", "xlUp", "xsDown", "xsUp" ]));
             "production" !== process.env.NODE_ENV && (0, _warning2.default)(0 === (0, _keys2.default)(other).length || 1 === (0, 
             _keys2.default)(other).length && other.hasOwnProperty("ref"), "Material-UI: unsupported properties received " + (0, 
-            _keys2.default)(other).join(", ") + " by ` + "`" + `<Hidden />` + "`" + `.");
+            _keys2.default)(other).join(", ") + " by ` + "`")) + (`<Hidden />` + ("`" + `.");
             for (var className = [], i = 0; i < _createBreakpoints.keys.length; i += 1) {
                 var breakpoint = _createBreakpoints.keys[i], breakpointUp = props[breakpoint + "Up"], breakpointDown = props[breakpoint + "Down"];
                 breakpointUp && className.push(classes[breakpoint + "Up"]), breakpointDown && className.push(classes[breakpoint + "Down"]);
@@ -42098,7 +42096,7 @@ var _publicBundleJs = []byte(`!function(modules) {
             name: "MuiHiddenCss"
         })(HiddenCss);
     }).call(exports, __webpack_require__(3));
-} ]);`)
+} ]);`)))))))))))
 
 func publicBundleJsBytes() ([]byte, error) {
 	return _publicBundleJs, nil
@@ -42115,7 +42113,6 @@ func publicBundleJs() (*asset, error) {
 	return a, nil
 }
 
-//nolint:misspell
 var _publicDashboardHtml = []byte(`<!DOCTYPE html>
 <html lang="en" style="height: 100%">
     <head>
@@ -42208,7 +42205,7 @@ func AssetNames() []string {
 
 // _bindata is a table, holding each asset generator, mapped to its name.
 var _bindata = map[string]func() (*asset, error){
-	"public/bundle.js":      publicBundleJs,
+	"public/bundle.js": publicBundleJs,
 	"public/dashboard.html": publicDashboardHtml,
 }
 
@@ -42251,11 +42248,10 @@ type bintree struct {
 	Func     func() (*asset, error)
 	Children map[string]*bintree
 }
-
 var _bintree = &bintree{nil, map[string]*bintree{
-	"public": {nil, map[string]*bintree{
-		"bundle.js":      {publicBundleJs, map[string]*bintree{}},
-		"dashboard.html": {publicDashboardHtml, map[string]*bintree{}},
+	"public": &bintree{nil, map[string]*bintree{
+		"bundle.js": &bintree{publicBundleJs, map[string]*bintree{}},
+		"dashboard.html": &bintree{publicDashboardHtml, map[string]*bintree{}},
 	}},
 }}
 
@@ -42305,3 +42301,4 @@ func _filePath(dir, name string) string {
 	cannonicalName := strings.Replace(name, "\\", "/", -1)
 	return filepath.Join(append([]string{dir}, strings.Split(cannonicalName, "/")...)...)
 }
+

--- a/dashboard/assets.go
+++ b/dashboard/assets.go
@@ -14,6 +14,7 @@ import (
 	"strings"
 	"time"
 )
+
 type asset struct {
 	bytes []byte
 	info  os.FileInfo
@@ -45,6 +46,7 @@ func (fi bindataFileInfo) Sys() interface{} {
 	return nil
 }
 
+//nolint:misspell
 var _publicBundleJs = []byte((((((((((`!function(modules) {
     function __webpack_require__(moduleId) {
         if (installedModules[moduleId]) return installedModules[moduleId].exports;
@@ -42113,6 +42115,7 @@ func publicBundleJs() (*asset, error) {
 	return a, nil
 }
 
+//nolint:misspell
 var _publicDashboardHtml = []byte(`<!DOCTYPE html>
 <html lang="en" style="height: 100%">
     <head>
@@ -42205,7 +42208,7 @@ func AssetNames() []string {
 
 // _bindata is a table, holding each asset generator, mapped to its name.
 var _bindata = map[string]func() (*asset, error){
-	"public/bundle.js": publicBundleJs,
+	"public/bundle.js":      publicBundleJs,
 	"public/dashboard.html": publicDashboardHtml,
 }
 
@@ -42248,10 +42251,11 @@ type bintree struct {
 	Func     func() (*asset, error)
 	Children map[string]*bintree
 }
+
 var _bintree = &bintree{nil, map[string]*bintree{
-	"public": &bintree{nil, map[string]*bintree{
-		"bundle.js": &bintree{publicBundleJs, map[string]*bintree{}},
-		"dashboard.html": &bintree{publicDashboardHtml, map[string]*bintree{}},
+	"public": {nil, map[string]*bintree{
+		"bundle.js":      {publicBundleJs, map[string]*bintree{}},
+		"dashboard.html": {publicDashboardHtml, map[string]*bintree{}},
 	}},
 }}
 
@@ -42301,4 +42305,3 @@ func _filePath(dir, name string) string {
 	cannonicalName := strings.Replace(name, "\\", "/", -1)
 	return filepath.Join(append([]string{dir}, strings.Split(cannonicalName, "/")...)...)
 }
-


### PR DESCRIPTION
Use current rsc/go-bindata instead of jteeuwen/go-bindata, to get
balanced tree in very long string concatenations.
This works around problems in current Go distributions.

For golang/go#23222.