### PR TITLE
eth/gasprice: set default percentile to 60%, count blocks instead of transactions

### DIFF
--- a/eth/config.go
+++ b/eth/config.go
@@ -50,7 +50,7 @@ var DefaultConfig = Config{
 	TxPool: core.DefaultTxPoolConfig,
 	GPO: gasprice.Config{
 		Blocks:     100,
-		Percentile: 35,
+		Percentile: 60,
 	},
 }
 

--- a/eth/config.go
+++ b/eth/config.go
@@ -49,8 +49,8 @@ var DefaultConfig = Config{
 
 	TxPool: core.DefaultTxPoolConfig,
 	GPO: gasprice.Config{
-		Blocks:     10,
-		Percentile: 50,
+		Blocks:     100,
+		Percentile: 35,
 	},
 }
 

--- a/eth/config.go
+++ b/eth/config.go
@@ -49,7 +49,7 @@ var DefaultConfig = Config{
 
 	TxPool: core.DefaultTxPoolConfig,
 	GPO: gasprice.Config{
-		Blocks:     100,
+		Blocks:     20,
 		Percentile: 60,
 	},
 }

--- a/eth/gasprice/gasprice.go
+++ b/eth/gasprice/gasprice.go
@@ -154,8 +154,8 @@ type getBlockPricesResult struct {
 
 type transactionsByGasPrice []*types.Transaction
 
-func (t transactionsByGasPrice) Len() int { return len(t) }
-func (t transactionsByGasPrice) Swap(i, j int) { t[i], t[j] = t[j], t[i] }
+func (t transactionsByGasPrice) Len() int           { return len(t) }
+func (t transactionsByGasPrice) Swap(i, j int)      { t[i], t[j] = t[j], t[i] }
 func (t transactionsByGasPrice) Less(i, j int) bool { return t[i].GasPrice().Cmp(t[j].GasPrice()) < 0 }
 
 // getBlockPrices calculates the lowest transaction gas price in a given block

--- a/eth/gasprice/gasprice.go
+++ b/eth/gasprice/gasprice.go
@@ -152,7 +152,13 @@ type getBlockPricesResult struct {
 	err   error
 }
 
-// getLowestPrice calculates the lowest transaction gas price in a given block
+type transactionsByGasPrice []*types.Transaction
+
+func (t transactionsByGasPrice) Len() int { return len(t) }
+func (t transactionsByGasPrice) Swap(i, j int) { t[i], t[j] = t[j], t[i] }
+func (t transactionsByGasPrice) Less(i, j int) bool { return t[i].GasPrice().Cmp(t[j].GasPrice()) < 0 }
+
+// getBlockPrices calculates the lowest transaction gas price in a given block
 // and sends it to the result channel. If the block is empty, price is nil.
 func (gpo *Oracle) getBlockPrices(ctx context.Context, signer types.Signer, blockNum uint64, ch chan getBlockPricesResult) {
 	block, err := gpo.backend.BlockByNumber(ctx, rpc.BlockNumber(blockNum))
@@ -160,18 +166,18 @@ func (gpo *Oracle) getBlockPrices(ctx context.Context, signer types.Signer, bloc
 		ch <- getBlockPricesResult{nil, err}
 		return
 	}
+
 	txs := block.Transactions()
-	var minPrice *big.Int
+	sort.Sort(transactionsByGasPrice(txs))
+
 	for _, tx := range txs {
 		sender, err := types.Sender(signer, tx)
-		if err != nil || sender == block.Coinbase() {
-			continue
-		}
-		if minPrice == nil || tx.GasPrice().Cmp(minPrice) < 0 {
-			minPrice = tx.GasPrice()
+		if err == nil && sender != block.Coinbase() {
+			ch <- getBlockPricesResult{tx.GasPrice(), nil}
+			return
 		}
 	}
-	ch <- getBlockPricesResult{minPrice, nil}
+	ch <- getBlockPricesResult{nil, nil}
 }
 
 type bigIntArray []*big.Int

--- a/eth/gasprice/gasprice.go
+++ b/eth/gasprice/gasprice.go
@@ -118,6 +118,7 @@ func (gpo *Oracle) SuggestPrice(ctx context.Context) (*big.Int, error) {
 		exp--
 		if res.price != nil {
 			blockPrices = append(blockPrices, res.price)
+			continue
 		}
 		if maxEmpty > 0 {
 			maxEmpty--

--- a/eth/gasprice/gasprice.go
+++ b/eth/gasprice/gasprice.go
@@ -149,7 +149,7 @@ func (gpo *Oracle) SuggestPrice(ctx context.Context) (*big.Int, error) {
 
 type getBlockPricesResult struct {
 	price *big.Int
-	err    error
+	err   error
 }
 
 // getLowestPrice calculates the lowest transaction gas price in a given block

--- a/eth/gasprice/gasprice.go
+++ b/eth/gasprice/gasprice.go
@@ -167,7 +167,9 @@ func (gpo *Oracle) getBlockPrices(ctx context.Context, signer types.Signer, bloc
 		return
 	}
 
-	txs := block.Transactions()
+	blockTxs := block.Transactions()
+	txs := make([]*types.Transaction, len(blockTxs))
+	copy(txs, blockTxs)
 	sort.Sort(transactionsByGasPrice(txs))
 
 	for _, tx := range txs {


### PR DESCRIPTION
The first should address a long term issue where we recommend a gas price that is greater than that required for 50% of transactions in recent blocks, which can lead to gas price inflation as people take this figure and add a margin to it, resulting in a positive feedback loop.

The latter is a more experimental change following ethgasstation's suggestion: https://twitter.com/ETHGasStation/status/949264877788585984

The insight being that each miner can set their own inclusion policy; rather than looking at a percentile of recent transactions, we should instead look at a percentile of recent blocks; a gas price that was sufficient to be included in n% of recent blocks should be sufficient to get our TX included quickly.

This will need some experimentation and trialling on nodes to see how well it fares before public release.

Still todo:
 - Allow users to specify the percentile in calls to the oracle
 - Allow users to specify a gas limit, and only consider transactions with at least that much gas when estimating gas price.