### PR TITLE
all: regenerate codecs with gencodec commit 90983d99de 

### DIFF
--- a/core/gen_genesis.go
+++ b/core/gen_genesis.go
@@ -56,7 +56,7 @@ func (g *Genesis) UnmarshalJSON(input []byte) error {
 		Config     *params.ChainConfig                         `json:"config"`
 		Nonce      *math.HexOrDecimal64                        `json:"nonce"`
 		Timestamp  *math.HexOrDecimal64                        `json:"timestamp"`
-		ExtraData  hexutil.Bytes                               `json:"extraData"`
+		ExtraData  *hexutil.Bytes                              `json:"extraData"`
 		GasLimit   *math.HexOrDecimal64                        `json:"gasLimit"   gencodec:"required"`
 		Difficulty *math.HexOrDecimal256                       `json:"difficulty" gencodec:"required"`
 		Mixhash    *common.Hash                                `json:"mixHash"`
@@ -80,7 +80,7 @@ func (g *Genesis) UnmarshalJSON(input []byte) error {
 		g.Timestamp = uint64(*dec.Timestamp)
 	}
 	if dec.ExtraData != nil {
-		g.ExtraData = dec.ExtraData
+		g.ExtraData = *dec.ExtraData
 	}
 	if dec.GasLimit == nil {
 		return errors.New("missing required field 'gasLimit' for Genesis")

--- a/core/gen_genesis_account.go
+++ b/core/gen_genesis_account.go
@@ -38,18 +38,18 @@ func (g GenesisAccount) MarshalJSON() ([]byte, error) {
 
 func (g *GenesisAccount) UnmarshalJSON(input []byte) error {
 	type GenesisAccount struct {
-		Code       hexutil.Bytes               `json:"code,omitempty"`
+		Code       *hexutil.Bytes              `json:"code,omitempty"`
 		Storage    map[storageJSON]storageJSON `json:"storage,omitempty"`
 		Balance    *math.HexOrDecimal256       `json:"balance" gencodec:"required"`
 		Nonce      *math.HexOrDecimal64        `json:"nonce,omitempty"`
-		PrivateKey hexutil.Bytes               `json:"secretKey,omitempty"`
+		PrivateKey *hexutil.Bytes              `json:"secretKey,omitempty"`
 	}
 	var dec GenesisAccount
 	if err := json.Unmarshal(input, &dec); err != nil {
 		return err
 	}
 	if dec.Code != nil {
-		g.Code = dec.Code
+		g.Code = *dec.Code
 	}
 	if dec.Storage != nil {
 		g.Storage = make(map[common.Hash]common.Hash, len(dec.Storage))
@@ -65,7 +65,7 @@ func (g *GenesisAccount) UnmarshalJSON(input []byte) error {
 		g.Nonce = uint64(*dec.Nonce)
 	}
 	if dec.PrivateKey != nil {
-		g.PrivateKey = dec.PrivateKey
+		g.PrivateKey = *dec.PrivateKey
 	}
 	return nil
 }

--- a/core/types/gen_header_json.go
+++ b/core/types/gen_header_json.go
@@ -66,7 +66,7 @@ func (h *Header) UnmarshalJSON(input []byte) error {
 		GasLimit    *hexutil.Uint64 `json:"gasLimit"         gencodec:"required"`
 		GasUsed     *hexutil.Uint64 `json:"gasUsed"          gencodec:"required"`
 		Time        *hexutil.Big    `json:"timestamp"        gencodec:"required"`
-		Extra       hexutil.Bytes   `json:"extraData"        gencodec:"required"`
+		Extra       *hexutil.Bytes  `json:"extraData"        gencodec:"required"`
 		MixDigest   *common.Hash    `json:"mixHash"          gencodec:"required"`
 		Nonce       *BlockNonce     `json:"nonce"            gencodec:"required"`
 	}
@@ -125,7 +125,7 @@ func (h *Header) UnmarshalJSON(input []byte) error {
 	if dec.Extra == nil {
 		return errors.New("missing required field 'extraData' for Header")
 	}
-	h.Extra = dec.Extra
+	h.Extra = *dec.Extra
 	if dec.MixDigest == nil {
 		return errors.New("missing required field 'mixHash' for Header")
 	}

--- a/core/types/gen_log_json.go
+++ b/core/types/gen_log_json.go
@@ -41,7 +41,7 @@ func (l *Log) UnmarshalJSON(input []byte) error {
 	type Log struct {
 		Address     *common.Address `json:"address" gencodec:"required"`
 		Topics      []common.Hash   `json:"topics" gencodec:"required"`
-		Data        hexutil.Bytes   `json:"data" gencodec:"required"`
+		Data        *hexutil.Bytes  `json:"data" gencodec:"required"`
 		BlockNumber *hexutil.Uint64 `json:"blockNumber"`
 		TxHash      *common.Hash    `json:"transactionHash" gencodec:"required"`
 		TxIndex     *hexutil.Uint   `json:"transactionIndex" gencodec:"required"`
@@ -64,7 +64,7 @@ func (l *Log) UnmarshalJSON(input []byte) error {
 	if dec.Data == nil {
 		return errors.New("missing required field 'data' for Log")
 	}
-	l.Data = dec.Data
+	l.Data = *dec.Data
 	if dec.BlockNumber != nil {
 		l.BlockNumber = uint64(*dec.BlockNumber)
 	}

--- a/core/types/gen_receipt_json.go
+++ b/core/types/gen_receipt_json.go
@@ -37,7 +37,7 @@ func (r Receipt) MarshalJSON() ([]byte, error) {
 
 func (r *Receipt) UnmarshalJSON(input []byte) error {
 	type Receipt struct {
-		PostState         hexutil.Bytes   `json:"root"`
+		PostState         *hexutil.Bytes  `json:"root"`
 		Status            *hexutil.Uint   `json:"status"`
 		CumulativeGasUsed *hexutil.Uint64 `json:"cumulativeGasUsed" gencodec:"required"`
 		Bloom             *Bloom          `json:"logsBloom"         gencodec:"required"`
@@ -51,7 +51,7 @@ func (r *Receipt) UnmarshalJSON(input []byte) error {
 		return err
 	}
 	if dec.PostState != nil {
-		r.PostState = dec.PostState
+		r.PostState = *dec.PostState
 	}
 	if dec.Status != nil {
 		r.Status = uint(*dec.Status)

--- a/core/types/gen_tx_json.go
+++ b/core/types/gen_tx_json.go
@@ -47,7 +47,7 @@ func (t *txdata) UnmarshalJSON(input []byte) error {
 		GasLimit     *hexutil.Uint64 `json:"gas"      gencodec:"required"`
 		Recipient    *common.Address `json:"to"       rlp:"nil"`
 		Amount       *hexutil.Big    `json:"value"    gencodec:"required"`
-		Payload      hexutil.Bytes   `json:"input"    gencodec:"required"`
+		Payload      *hexutil.Bytes  `json:"input"    gencodec:"required"`
 		V            *hexutil.Big    `json:"v" gencodec:"required"`
 		R            *hexutil.Big    `json:"r" gencodec:"required"`
 		S            *hexutil.Big    `json:"s" gencodec:"required"`
@@ -79,7 +79,7 @@ func (t *txdata) UnmarshalJSON(input []byte) error {
 	if dec.Payload == nil {
 		return errors.New("missing required field 'input' for txdata")
 	}
-	t.Payload = dec.Payload
+	t.Payload = *dec.Payload
 	if dec.V == nil {
 		return errors.New("missing required field 'v' for txdata")
 	}

--- a/core/vm/gen_structlog.go
+++ b/core/vm/gen_structlog.go
@@ -55,7 +55,7 @@ func (s *StructLog) UnmarshalJSON(input []byte) error {
 		Op         *OpCode                     `json:"op"`
 		Gas        *math.HexOrDecimal64        `json:"gas"`
 		GasCost    *math.HexOrDecimal64        `json:"gasCost"`
-		Memory     hexutil.Bytes               `json:"memory"`
+		Memory     *hexutil.Bytes              `json:"memory"`
 		MemorySize *int                        `json:"memSize"`
 		Stack      []*math.HexOrDecimal256     `json:"stack"`
 		Storage    map[common.Hash]common.Hash `json:"-"`
@@ -79,7 +79,7 @@ func (s *StructLog) UnmarshalJSON(input []byte) error {
 		s.GasCost = uint64(*dec.GasCost)
 	}
 	if dec.Memory != nil {
-		s.Memory = dec.Memory
+		s.Memory = *dec.Memory
 	}
 	if dec.MemorySize != nil {
 		s.MemorySize = *dec.MemorySize

--- a/eth/gen_config.go
+++ b/eth/gen_config.go
@@ -68,7 +68,7 @@ func (c *Config) UnmarshalTOML(unmarshal func(interface{}) error) error {
 		DatabaseCache           *int
 		Etherbase               *common.Address `toml:",omitempty"`
 		MinerThreads            *int            `toml:",omitempty"`
-		ExtraData               hexutil.Bytes   `toml:",omitempty"`
+		ExtraData               *hexutil.Bytes  `toml:",omitempty"`
 		GasPrice                *big.Int
 		Ethash                  *ethash.Config
 		TxPool                  *core.TxPoolConfig
@@ -111,7 +111,7 @@ func (c *Config) UnmarshalTOML(unmarshal func(interface{}) error) error {
 		c.MinerThreads = *dec.MinerThreads
 	}
 	if dec.ExtraData != nil {
-		c.ExtraData = dec.ExtraData
+		c.ExtraData = *dec.ExtraData
 	}
 	if dec.GasPrice != nil {
 		c.GasPrice = dec.GasPrice

--- a/tests/gen_btheader.go
+++ b/tests/gen_btheader.go
@@ -66,7 +66,7 @@ func (b *btHeader) UnmarshalJSON(input []byte) error {
 		StateRoot        *common.Hash
 		TransactionsTrie *common.Hash
 		UncleHash        *common.Hash
-		ExtraData        hexutil.Bytes
+		ExtraData        *hexutil.Bytes
 		Difficulty       *math.HexOrDecimal256
 		GasLimit         *math.HexOrDecimal64
 		GasUsed          *math.HexOrDecimal64
@@ -110,7 +110,7 @@ func (b *btHeader) UnmarshalJSON(input []byte) error {
 		b.UncleHash = *dec.UncleHash
 	}
 	if dec.ExtraData != nil {
-		b.ExtraData = dec.ExtraData
+		b.ExtraData = *dec.ExtraData
 	}
 	if dec.Difficulty != nil {
 		b.Difficulty = (*big.Int)(dec.Difficulty)

--- a/tests/gen_sttransaction.go
+++ b/tests/gen_sttransaction.go
@@ -46,7 +46,7 @@ func (s *stTransaction) UnmarshalJSON(input []byte) error {
 		Data       []string              `json:"data"`
 		GasLimit   []math.HexOrDecimal64 `json:"gasLimit"`
 		Value      []string              `json:"value"`
-		PrivateKey hexutil.Bytes         `json:"secretKey"`
+		PrivateKey *hexutil.Bytes        `json:"secretKey"`
 	}
 	var dec stTransaction
 	if err := json.Unmarshal(input, &dec); err != nil {
@@ -74,7 +74,7 @@ func (s *stTransaction) UnmarshalJSON(input []byte) error {
 		s.Value = dec.Value
 	}
 	if dec.PrivateKey != nil {
-		s.PrivateKey = dec.PrivateKey
+		s.PrivateKey = *dec.PrivateKey
 	}
 	return nil
 }

--- a/tests/gen_tttransaction.go
+++ b/tests/gen_tttransaction.go
@@ -41,7 +41,7 @@ func (t ttTransaction) MarshalJSON() ([]byte, error) {
 
 func (t *ttTransaction) UnmarshalJSON(input []byte) error {
 	type ttTransaction struct {
-		Data     hexutil.Bytes         `gencodec:"required"`
+		Data     *hexutil.Bytes        `gencodec:"required"`
 		GasLimit *math.HexOrDecimal64  `gencodec:"required"`
 		GasPrice *math.HexOrDecimal256 `gencodec:"required"`
 		Nonce    *math.HexOrDecimal64  `gencodec:"required"`
@@ -58,7 +58,7 @@ func (t *ttTransaction) UnmarshalJSON(input []byte) error {
 	if dec.Data == nil {
 		return errors.New("missing required field 'data' for ttTransaction")
 	}
-	t.Data = dec.Data
+	t.Data = *dec.Data
 	if dec.GasLimit == nil {
 		return errors.New("missing required field 'gasLimit' for ttTransaction")
 	}

--- a/tests/gen_vmexec.go
+++ b/tests/gen_vmexec.go
@@ -42,8 +42,8 @@ func (v *vmExec) UnmarshalJSON(input []byte) error {
 		Address  *common.UnprefixedAddress `json:"address"  gencodec:"required"`
 		Caller   *common.UnprefixedAddress `json:"caller"   gencodec:"required"`
 		Origin   *common.UnprefixedAddress `json:"origin"   gencodec:"required"`
-		Code     hexutil.Bytes             `json:"code"     gencodec:"required"`
-		Data     hexutil.Bytes             `json:"data"     gencodec:"required"`
+		Code     *hexutil.Bytes            `json:"code"     gencodec:"required"`
+		Data     *hexutil.Bytes            `json:"data"     gencodec:"required"`
 		Value    *math.HexOrDecimal256     `json:"value"    gencodec:"required"`
 		GasLimit *math.HexOrDecimal64      `json:"gas"      gencodec:"required"`
 		GasPrice *math.HexOrDecimal256     `json:"gasPrice" gencodec:"required"`
@@ -67,11 +67,11 @@ func (v *vmExec) UnmarshalJSON(input []byte) error {
 	if dec.Code == nil {
 		return errors.New("missing required field 'code' for vmExec")
 	}
-	v.Code = dec.Code
+	v.Code = *dec.Code
 	if dec.Data == nil {
 		return errors.New("missing required field 'data' for vmExec")
 	}
-	v.Data = dec.Data
+	v.Data = *dec.Data
 	if dec.Value == nil {
 		return errors.New("missing required field 'value' for vmExec")
 	}

--- a/whisper/whisperv5/gen_criteria_json.go
+++ b/whisper/whisperv5/gen_criteria_json.go
@@ -31,12 +31,12 @@ func (c Criteria) MarshalJSON() ([]byte, error) {
 
 func (c *Criteria) UnmarshalJSON(input []byte) error {
 	type Criteria struct {
-		SymKeyID     *string       `json:"symKeyID"`
-		PrivateKeyID *string       `json:"privateKeyID"`
-		Sig          hexutil.Bytes `json:"sig"`
-		MinPow       *float64      `json:"minPow"`
-		Topics       []TopicType   `json:"topics"`
-		AllowP2P     *bool         `json:"allowP2P"`
+		SymKeyID     *string        `json:"symKeyID"`
+		PrivateKeyID *string        `json:"privateKeyID"`
+		Sig          *hexutil.Bytes `json:"sig"`
+		MinPow       *float64       `json:"minPow"`
+		Topics       []TopicType    `json:"topics"`
+		AllowP2P     *bool          `json:"allowP2P"`
 	}
 	var dec Criteria
 	if err := json.Unmarshal(input, &dec); err != nil {
@@ -49,7 +49,7 @@ func (c *Criteria) UnmarshalJSON(input []byte) error {
 		c.PrivateKeyID = *dec.PrivateKeyID
 	}
 	if dec.Sig != nil {
-		c.Sig = dec.Sig
+		c.Sig = *dec.Sig
 	}
 	if dec.MinPow != nil {
 		c.MinPow = *dec.MinPow

--- a/whisper/whisperv5/gen_message_json.go
+++ b/whisper/whisperv5/gen_message_json.go
@@ -37,22 +37,22 @@ func (m Message) MarshalJSON() ([]byte, error) {
 
 func (m *Message) UnmarshalJSON(input []byte) error {
 	type Message struct {
-		Sig       hexutil.Bytes `json:"sig,omitempty"`
-		TTL       *uint32       `json:"ttl"`
-		Timestamp *uint32       `json:"timestamp"`
-		Topic     *TopicType    `json:"topic"`
-		Payload   hexutil.Bytes `json:"payload"`
-		Padding   hexutil.Bytes `json:"padding"`
-		PoW       *float64      `json:"pow"`
-		Hash      hexutil.Bytes `json:"hash"`
-		Dst       hexutil.Bytes `json:"recipientPublicKey,omitempty"`
+		Sig       *hexutil.Bytes `json:"sig,omitempty"`
+		TTL       *uint32        `json:"ttl"`
+		Timestamp *uint32        `json:"timestamp"`
+		Topic     *TopicType     `json:"topic"`
+		Payload   *hexutil.Bytes `json:"payload"`
+		Padding   *hexutil.Bytes `json:"padding"`
+		PoW       *float64       `json:"pow"`
+		Hash      *hexutil.Bytes `json:"hash"`
+		Dst       *hexutil.Bytes `json:"recipientPublicKey,omitempty"`
 	}
 	var dec Message
 	if err := json.Unmarshal(input, &dec); err != nil {
 		return err
 	}
 	if dec.Sig != nil {
-		m.Sig = dec.Sig
+		m.Sig = *dec.Sig
 	}
 	if dec.TTL != nil {
 		m.TTL = *dec.TTL
@@ -64,19 +64,19 @@ func (m *Message) UnmarshalJSON(input []byte) error {
 		m.Topic = *dec.Topic
 	}
 	if dec.Payload != nil {
-		m.Payload = dec.Payload
+		m.Payload = *dec.Payload
 	}
 	if dec.Padding != nil {
-		m.Padding = dec.Padding
+		m.Padding = *dec.Padding
 	}
 	if dec.PoW != nil {
 		m.PoW = *dec.PoW
 	}
 	if dec.Hash != nil {
-		m.Hash = dec.Hash
+		m.Hash = *dec.Hash
 	}
 	if dec.Dst != nil {
-		m.Dst = dec.Dst
+		m.Dst = *dec.Dst
 	}
 	return nil
 }

--- a/whisper/whisperv5/gen_newmessage_json.go
+++ b/whisper/whisperv5/gen_newmessage_json.go
@@ -39,16 +39,16 @@ func (n NewMessage) MarshalJSON() ([]byte, error) {
 
 func (n *NewMessage) UnmarshalJSON(input []byte) error {
 	type NewMessage struct {
-		SymKeyID   *string       `json:"symKeyID"`
-		PublicKey  hexutil.Bytes `json:"pubKey"`
-		Sig        *string       `json:"sig"`
-		TTL        *uint32       `json:"ttl"`
-		Topic      *TopicType    `json:"topic"`
-		Payload    hexutil.Bytes `json:"payload"`
-		Padding    hexutil.Bytes `json:"padding"`
-		PowTime    *uint32       `json:"powTime"`
-		PowTarget  *float64      `json:"powTarget"`
-		TargetPeer *string       `json:"targetPeer"`
+		SymKeyID   *string        `json:"symKeyID"`
+		PublicKey  *hexutil.Bytes `json:"pubKey"`
+		Sig        *string        `json:"sig"`
+		TTL        *uint32        `json:"ttl"`
+		Topic      *TopicType     `json:"topic"`
+		Payload    *hexutil.Bytes `json:"payload"`
+		Padding    *hexutil.Bytes `json:"padding"`
+		PowTime    *uint32        `json:"powTime"`
+		PowTarget  *float64       `json:"powTarget"`
+		TargetPeer *string        `json:"targetPeer"`
 	}
 	var dec NewMessage
 	if err := json.Unmarshal(input, &dec); err != nil {
@@ -58,7 +58,7 @@ func (n *NewMessage) UnmarshalJSON(input []byte) error {
 		n.SymKeyID = *dec.SymKeyID
 	}
 	if dec.PublicKey != nil {
-		n.PublicKey = dec.PublicKey
+		n.PublicKey = *dec.PublicKey
 	}
 	if dec.Sig != nil {
 		n.Sig = *dec.Sig
@@ -70,10 +70,10 @@ func (n *NewMessage) UnmarshalJSON(input []byte) error {
 		n.Topic = *dec.Topic
 	}
 	if dec.Payload != nil {
-		n.Payload = dec.Payload
+		n.Payload = *dec.Payload
 	}
 	if dec.Padding != nil {
-		n.Padding = dec.Padding
+		n.Padding = *dec.Padding
 	}
 	if dec.PowTime != nil {
 		n.PowTime = *dec.PowTime

--- a/whisper/whisperv6/gen_criteria_json.go
+++ b/whisper/whisperv6/gen_criteria_json.go
@@ -31,12 +31,12 @@ func (c Criteria) MarshalJSON() ([]byte, error) {
 
 func (c *Criteria) UnmarshalJSON(input []byte) error {
 	type Criteria struct {
-		SymKeyID     *string       `json:"symKeyID"`
-		PrivateKeyID *string       `json:"privateKeyID"`
-		Sig          hexutil.Bytes `json:"sig"`
-		MinPow       *float64      `json:"minPow"`
-		Topics       []TopicType   `json:"topics"`
-		AllowP2P     *bool         `json:"allowP2P"`
+		SymKeyID     *string        `json:"symKeyID"`
+		PrivateKeyID *string        `json:"privateKeyID"`
+		Sig          *hexutil.Bytes `json:"sig"`
+		MinPow       *float64       `json:"minPow"`
+		Topics       []TopicType    `json:"topics"`
+		AllowP2P     *bool          `json:"allowP2P"`
 	}
 	var dec Criteria
 	if err := json.Unmarshal(input, &dec); err != nil {
@@ -49,7 +49,7 @@ func (c *Criteria) UnmarshalJSON(input []byte) error {
 		c.PrivateKeyID = *dec.PrivateKeyID
 	}
 	if dec.Sig != nil {
-		c.Sig = dec.Sig
+		c.Sig = *dec.Sig
 	}
 	if dec.MinPow != nil {
 		c.MinPow = *dec.MinPow

--- a/whisper/whisperv6/gen_message_json.go
+++ b/whisper/whisperv6/gen_message_json.go
@@ -37,22 +37,22 @@ func (m Message) MarshalJSON() ([]byte, error) {
 
 func (m *Message) UnmarshalJSON(input []byte) error {
 	type Message struct {
-		Sig       hexutil.Bytes `json:"sig,omitempty"`
-		TTL       *uint32       `json:"ttl"`
-		Timestamp *uint32       `json:"timestamp"`
-		Topic     *TopicType    `json:"topic"`
-		Payload   hexutil.Bytes `json:"payload"`
-		Padding   hexutil.Bytes `json:"padding"`
-		PoW       *float64      `json:"pow"`
-		Hash      hexutil.Bytes `json:"hash"`
-		Dst       hexutil.Bytes `json:"recipientPublicKey,omitempty"`
+		Sig       *hexutil.Bytes `json:"sig,omitempty"`
+		TTL       *uint32        `json:"ttl"`
+		Timestamp *uint32        `json:"timestamp"`
+		Topic     *TopicType     `json:"topic"`
+		Payload   *hexutil.Bytes `json:"payload"`
+		Padding   *hexutil.Bytes `json:"padding"`
+		PoW       *float64       `json:"pow"`
+		Hash      *hexutil.Bytes `json:"hash"`
+		Dst       *hexutil.Bytes `json:"recipientPublicKey,omitempty"`
 	}
 	var dec Message
 	if err := json.Unmarshal(input, &dec); err != nil {
 		return err
 	}
 	if dec.Sig != nil {
-		m.Sig = dec.Sig
+		m.Sig = *dec.Sig
 	}
 	if dec.TTL != nil {
 		m.TTL = *dec.TTL
@@ -64,19 +64,19 @@ func (m *Message) UnmarshalJSON(input []byte) error {
 		m.Topic = *dec.Topic
 	}
 	if dec.Payload != nil {
-		m.Payload = dec.Payload
+		m.Payload = *dec.Payload
 	}
 	if dec.Padding != nil {
-		m.Padding = dec.Padding
+		m.Padding = *dec.Padding
 	}
 	if dec.PoW != nil {
 		m.PoW = *dec.PoW
 	}
 	if dec.Hash != nil {
-		m.Hash = dec.Hash
+		m.Hash = *dec.Hash
 	}
 	if dec.Dst != nil {
-		m.Dst = dec.Dst
+		m.Dst = *dec.Dst
 	}
 	return nil
 }

--- a/whisper/whisperv6/gen_newmessage_json.go
+++ b/whisper/whisperv6/gen_newmessage_json.go
@@ -39,16 +39,16 @@ func (n NewMessage) MarshalJSON() ([]byte, error) {
 
 func (n *NewMessage) UnmarshalJSON(input []byte) error {
 	type NewMessage struct {
-		SymKeyID   *string       `json:"symKeyID"`
-		PublicKey  hexutil.Bytes `json:"pubKey"`
-		Sig        *string       `json:"sig"`
-		TTL        *uint32       `json:"ttl"`
-		Topic      *TopicType    `json:"topic"`
-		Payload    hexutil.Bytes `json:"payload"`
-		Padding    hexutil.Bytes `json:"padding"`
-		PowTime    *uint32       `json:"powTime"`
-		PowTarget  *float64      `json:"powTarget"`
-		TargetPeer *string       `json:"targetPeer"`
+		SymKeyID   *string        `json:"symKeyID"`
+		PublicKey  *hexutil.Bytes `json:"pubKey"`
+		Sig        *string        `json:"sig"`
+		TTL        *uint32        `json:"ttl"`
+		Topic      *TopicType     `json:"topic"`
+		Payload    *hexutil.Bytes `json:"payload"`
+		Padding    *hexutil.Bytes `json:"padding"`
+		PowTime    *uint32        `json:"powTime"`
+		PowTarget  *float64       `json:"powTarget"`
+		TargetPeer *string        `json:"targetPeer"`
 	}
 	var dec NewMessage
 	if err := json.Unmarshal(input, &dec); err != nil {
@@ -58,7 +58,7 @@ func (n *NewMessage) UnmarshalJSON(input []byte) error {
 		n.SymKeyID = *dec.SymKeyID
 	}
 	if dec.PublicKey != nil {
-		n.PublicKey = dec.PublicKey
+		n.PublicKey = *dec.PublicKey
 	}
 	if dec.Sig != nil {
 		n.Sig = *dec.Sig
@@ -70,10 +70,10 @@ func (n *NewMessage) UnmarshalJSON(input []byte) error {
 		n.Topic = *dec.Topic
 	}
 	if dec.Payload != nil {
-		n.Payload = dec.Payload
+		n.Payload = *dec.Payload
 	}
 	if dec.Padding != nil {
-		n.Padding = dec.Padding
+		n.Padding = *dec.Padding
 	}
 	if dec.PowTime != nil {
 		n.PowTime = *dec.PowTime


### PR DESCRIPTION
Fixes #15777 because null is now allowed for hexutil.Bytes.
The corresponding gencodec change is https://github.com/fjl/gencodec/compare/55422dcc4da5f055387399b86b6e1f8427f4f67e...90983d99deb1a46a57ef60a7fd16e4ccfa7409e3.
  