### PR TITLE
rpc: Support specifying HTTP client in RPC dialing

### DIFF
--- a/rpc/http.go
+++ b/rpc/http.go
@@ -65,7 +65,7 @@ func (hc *httpConn) Close() error {
 	return nil
 }
 
-// DialHTTPWithClient creates a new RPC clients that connection to an RPC server over HTTP
+// DialHTTPWithClient creates a new RPC client that connects to an RPC server over HTTP
 // using the provided HTTP Client.
 func DialHTTPWithClient(endpoint string, client *http.Client) (*Client, error) {
 	req, err := http.NewRequest(http.MethodPost, endpoint, nil)
@@ -81,7 +81,7 @@ func DialHTTPWithClient(endpoint string, client *http.Client) (*Client, error) {
 	})
 }
 
-// DialHTTP creates a new RPC clients that connection to an RPC server over HTTP.
+// DialHTTP creates a new RPC client that connects to an RPC server over HTTP.
 func DialHTTP(endpoint string) (*Client, error) {
 	return DialHTTPWithClient(endpoint, new(http.Client))
 }

--- a/rpc/http.go
+++ b/rpc/http.go
@@ -65,8 +65,9 @@ func (hc *httpConn) Close() error {
 	return nil
 }
 
-// DialHTTP creates a new RPC clients that connection to an RPC server over HTTP.
-func DialHTTP(endpoint string) (*Client, error) {
+// DialHTTPWithClient creates a new RPC clients that connection to an RPC server over HTTP
+// using the provided HTTP Client.
+func DialHTTPWithClient(endpoint string, client *http.Client) (*Client, error) {
 	req, err := http.NewRequest(http.MethodPost, endpoint, nil)
 	if err != nil {
 		return nil, err
@@ -76,8 +77,13 @@ func DialHTTP(endpoint string) (*Client, error) {
 
 	initctx := context.Background()
 	return newClient(initctx, func(context.Context) (net.Conn, error) {
-		return &httpConn{client: new(http.Client), req: req, closed: make(chan struct{})}, nil
+		return &httpConn{client: client, req: req, closed: make(chan struct{})}, nil
 	})
+}
+
+// DialHTTP creates a new RPC clients that connection to an RPC server over HTTP.
+func DialHTTP(endpoint string) (*Client, error) {
+	return DialHTTPWithClient(endpoint, new(http.Client))
 }
 
 func (c *Client) sendHTTP(ctx context.Context, op *requestOp, msg interface{}) error {


### PR DESCRIPTION
Adds a minimal interface that captures `http.Client` and adds a new method `rpc.DialHTTPClient` that takes a client using that interface. The existing `rpc.DialHTTP` method is then alternatively implemented by using the new `rpc.DialHTTPClient` method provided with a standard `*http.Client`.