### PR TITLE
internal/ethapi: add eth_nextNonce RPC method

### DIFF
--- a/eth/bind.go
+++ b/eth/bind.go
@@ -104,7 +104,7 @@ func toBlockNumber(num *big.Int) rpc.BlockNumber {
 // PendingAccountNonce implements bind.ContractTransactor retrieving the current
 // pending nonce associated with an account.
 func (b *ContractBackend) PendingNonceAt(ctx context.Context, account common.Address) (nonce uint64, err error) {
-	out, err := b.txapi.GetTransactionCount(ctx, account, rpc.PendingBlockNumber)
+	out, err := b.txapi.NextNonce(ctx, account)
 	if out != nil {
 		nonce = uint64(*out)
 	}

--- a/ethclient/ethclient.go
+++ b/ethclient/ethclient.go
@@ -400,7 +400,7 @@ func (ec *Client) PendingCodeAt(ctx context.Context, account common.Address) ([]
 // This is the nonce that should be used for the next transaction.
 func (ec *Client) PendingNonceAt(ctx context.Context, account common.Address) (uint64, error) {
 	var result hexutil.Uint64
-	err := ec.c.CallContext(ctx, &result, "eth_getTransactionCount", account, "pending")
+	err := ec.c.CallContext(ctx, &result, "eth_nextNonce", account)
 	return uint64(result), err
 }
 

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -971,6 +971,17 @@ func (s *PublicTransactionPoolAPI) GetTransactionCount(ctx context.Context, addr
 	return (*hexutil.Uint64)(&nonce), state.Error()
 }
 
+// NextNonce returns the next nonce for the given address taking into account any pending transactions the address has
+func (s *PublicTransactionPoolAPI) NextNonce(ctx context.Context, address common.Address) (*hexutil.Uint64, error) {
+	// Ask transaction pool for the nonce which includes pending transactions
+	nonce, err := s.b.GetPoolNonce(ctx, address)
+	if err != nil {
+		return nil, err
+	}
+
+	return (*hexutil.Uint64)(&nonce), nil
+}
+
 // GetTransactionByHash returns the transaction for the given hash
 func (s *PublicTransactionPoolAPI) GetTransactionByHash(ctx context.Context, hash common.Hash) *RPCTransaction {
 	// Try to return an already finalized transaction


### PR DESCRIPTION
#15794 notes that any client relying on Geth for the next nonce by using the `eth_getTransactionCount` RPC method will run into the issue of duplicate nonces if the client attempts to submit concurrent transactions. Changing `eth_getTransactionCount(.., "pending")` to ask the local node's transaction pool would be backwards incompatible because it would break the current definition of pending state (the pending block if you are a miner or the latest canonical block if you are not a miner).

This PR is a basic first attempt to mimic Parity's custom `parity_nextNonce` RPC method (https://github.com/paritytech/parity/wiki/JSONRPC-parity-module#parity_nextnonce) with a new `eth_nextNonce` RPC method. An additional benefit to adding this RPC method might be eventual cross compatibility.

`PendingNonceAt` is usually used to retrieve the pending nonce for an account - perhaps an additional `NextNonceAt` can be defined as well which uses the `eth_nextNonce` RPC method to also preserve the current definition for `PendingNonceAt`.