### PR TITLE
Add a way to get the BlockNumber from ethclient. Fixes #15210

### DIFF
--- a/ethclient/ethclient.go
+++ b/ethclient/ethclient.go
@@ -194,8 +194,8 @@ func (ec *Client) TransactionByHash(ctx context.Context, hash common.Hash) (tx *
 	return json.tx, json.BlockNumber == nil, nil
 }
 
-// BlockNumberByTransactionHash returns block number for the transaction with the given hash.
-func (ec *Client) BlockNumberByTransactionHash(ctx context.Context, hash common.Hash) (blockNumber uint64, err error) {
+// TransactionInclusionBlock returns block number for the transaction with the given hash.
+func (ec *Client) TransactionInclusionBlock(ctx context.Context, hash common.Hash) (blockNumber uint64, err error) {
 	var json *rpcTransaction
 	err = ec.c.CallContext(ctx, &json, "eth_getTransactionByHash", hash)
 	if err != nil {

--- a/ethclient/ethclient.go
+++ b/ethclient/ethclient.go
@@ -202,15 +202,8 @@ func (ec *Client) TransactionInclusionBlock(ctx context.Context, hash common.Has
 		return 0, err
 	} else if json == nil {
 		return 0, ethereum.NotFound
-	} else if _, r, _ := json.tx.RawSignatureValues(); r == nil {
-		return 0, fmt.Errorf("server returned transaction without signature")
 	}
-	setSenderFromServer(json.tx, json.From, json.BlockHash)
-	blockNumber, err = strconv.ParseUint(*json.BlockNumber, 0, 64)
-	if err != nil {
-		return 0, err
-	}
-	return blockNumber, nil
+	return strconv.ParseUint(*json.BlockNumber, 0, 64)
 }
 
 // TransactionSender returns the sender address of the given transaction. The transaction


### PR DESCRIPTION
I'm not sure if it is the right way to do it, but at least it is tested and works.

The blocknumber is returned as a uint64.