### PR TITLE
common/fdlimit: Move fdlimit files to separate package

### DIFF
--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -31,6 +31,7 @@ import (
 	"github.com/ethereum/go-ethereum/accounts"
 	"github.com/ethereum/go-ethereum/accounts/keystore"
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/fdlimit"
 	"github.com/ethereum/go-ethereum/consensus"
 	"github.com/ethereum/go-ethereum/consensus/clique"
 	"github.com/ethereum/go-ethereum/consensus/ethash"
@@ -721,10 +722,10 @@ func setIPC(ctx *cli.Context, cfg *node.Config) {
 // makeDatabaseHandles raises out the number of allowed file handles per process
 // for Geth and returns half of the allowance to assign to the database.
 func makeDatabaseHandles() int {
-	if err := raiseFdLimit(2048); err != nil {
+	if err := fdlimit.RaiseFdLimit(2048); err != nil {
 		Fatalf("Failed to raise file descriptor allowance: %v", err)
 	}
-	limit, err := getFdLimit()
+	limit, err := fdlimit.GetFdLimit()
 	if err != nil {
 		Fatalf("Failed to retrieve file descriptor allowance: %v", err)
 	}

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -725,7 +725,7 @@ func makeDatabaseHandles() int {
 	if err := fdlimit.Raise(2048); err != nil {
 		Fatalf("Failed to raise file descriptor allowance: %v", err)
 	}
-	limit, err := fdlimit.Get()
+	limit, err := fdlimit.Current()
 	if err != nil {
 		Fatalf("Failed to retrieve file descriptor allowance: %v", err)
 	}

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -722,10 +722,10 @@ func setIPC(ctx *cli.Context, cfg *node.Config) {
 // makeDatabaseHandles raises out the number of allowed file handles per process
 // for Geth and returns half of the allowance to assign to the database.
 func makeDatabaseHandles() int {
-	if err := fdlimit.RaiseFdLimit(2048); err != nil {
+	if err := fdlimit.Raise(2048); err != nil {
 		Fatalf("Failed to raise file descriptor allowance: %v", err)
 	}
-	limit, err := fdlimit.GetFdLimit()
+	limit, err := fdlimit.Get()
 	if err != nil {
 		Fatalf("Failed to retrieve file descriptor allowance: %v", err)
 	}

--- a/common/fdlimit/fdlimit_freebsd.go
+++ b/common/fdlimit/fdlimit_freebsd.go
@@ -43,9 +43,9 @@ func Raise(max uint64) error {
 	return nil
 }
 
-// Get retrieves the number of file descriptors allowed to be opened by this
+// Current retrieves the number of file descriptors allowed to be opened by this
 // process.
-func Get() (int, error) {
+func Current() (int, error) {
 	var limit syscall.Rlimit
 	if err := syscall.Getrlimit(syscall.RLIMIT_NOFILE, &limit); err != nil {
 		return 0, err
@@ -53,9 +53,9 @@ func Get() (int, error) {
 	return int(limit.Cur), nil
 }
 
-// GetMax retrieves the maximum number of file descriptors this process is
+// Maximum retrieves the maximum number of file descriptors this process is
 // allowed to request for itself.
-func GetMax() (int, error) {
+func Maximum() (int, error) {
 	var limit syscall.Rlimit
 	if err := syscall.Getrlimit(syscall.RLIMIT_NOFILE, &limit); err != nil {
 		return 0, err

--- a/common/fdlimit/fdlimit_freebsd.go
+++ b/common/fdlimit/fdlimit_freebsd.go
@@ -24,9 +24,9 @@ import "syscall"
 // but Rlimit fields have type int64 on FreeBSD so it needs
 // an extra conversion.
 
-// RaiseFdLimit tries to maximize the file descriptor allowance of this process
+// Raise tries to maximize the file descriptor allowance of this process
 // to the maximum hard-limit allowed by the OS.
-func RaiseFdLimit(max uint64) error {
+func Raise(max uint64) error {
 	// Get the current limit
 	var limit syscall.Rlimit
 	if err := syscall.Getrlimit(syscall.RLIMIT_NOFILE, &limit); err != nil {
@@ -43,9 +43,9 @@ func RaiseFdLimit(max uint64) error {
 	return nil
 }
 
-// GetFdLimit retrieves the number of file descriptors allowed to be opened by this
+// Get retrieves the number of file descriptors allowed to be opened by this
 // process.
-func GetFdLimit() (int, error) {
+func Get() (int, error) {
 	var limit syscall.Rlimit
 	if err := syscall.Getrlimit(syscall.RLIMIT_NOFILE, &limit); err != nil {
 		return 0, err
@@ -53,9 +53,9 @@ func GetFdLimit() (int, error) {
 	return int(limit.Cur), nil
 }
 
-// GetFdMaxLimit retrieves the maximum number of file descriptors this process is
+// GetMax retrieves the maximum number of file descriptors this process is
 // allowed to request for itself.
-func GetFdMaxLimit() (int, error) {
+func GetMax() (int, error) {
 	var limit syscall.Rlimit
 	if err := syscall.Getrlimit(syscall.RLIMIT_NOFILE, &limit); err != nil {
 		return 0, err

--- a/common/fdlimit/fdlimit_freebsd.go
+++ b/common/fdlimit/fdlimit_freebsd.go
@@ -14,15 +14,19 @@
 // You should have received a copy of the GNU General Public License
 // along with go-ethereum. If not, see <http://www.gnu.org/licenses/>.
 
-// +build linux darwin netbsd openbsd solaris
+// +build freebsd
 
-package utils
+package fdlimit
 
 import "syscall"
 
-// raiseFdLimit tries to maximize the file descriptor allowance of this process
+// This file is largely identical to fdlimit_unix.go,
+// but Rlimit fields have type int64 on FreeBSD so it needs
+// an extra conversion.
+
+// RaiseFdLimit tries to maximize the file descriptor allowance of this process
 // to the maximum hard-limit allowed by the OS.
-func raiseFdLimit(max uint64) error {
+func RaiseFdLimit(max uint64) error {
 	// Get the current limit
 	var limit syscall.Rlimit
 	if err := syscall.Getrlimit(syscall.RLIMIT_NOFILE, &limit); err != nil {
@@ -30,8 +34,8 @@ func raiseFdLimit(max uint64) error {
 	}
 	// Try to update the limit to the max allowance
 	limit.Cur = limit.Max
-	if limit.Cur > max {
-		limit.Cur = max
+	if limit.Cur > int64(max) {
+		limit.Cur = int64(max)
 	}
 	if err := syscall.Setrlimit(syscall.RLIMIT_NOFILE, &limit); err != nil {
 		return err
@@ -39,9 +43,9 @@ func raiseFdLimit(max uint64) error {
 	return nil
 }
 
-// getFdLimit retrieves the number of file descriptors allowed to be opened by this
+// GetFdLimit retrieves the number of file descriptors allowed to be opened by this
 // process.
-func getFdLimit() (int, error) {
+func GetFdLimit() (int, error) {
 	var limit syscall.Rlimit
 	if err := syscall.Getrlimit(syscall.RLIMIT_NOFILE, &limit); err != nil {
 		return 0, err
@@ -49,9 +53,9 @@ func getFdLimit() (int, error) {
 	return int(limit.Cur), nil
 }
 
-// getFdMaxLimit retrieves the maximum number of file descriptors this process is
+// GetFdMaxLimit retrieves the maximum number of file descriptors this process is
 // allowed to request for itself.
-func getFdMaxLimit() (int, error) {
+func GetFdMaxLimit() (int, error) {
 	var limit syscall.Rlimit
 	if err := syscall.Getrlimit(syscall.RLIMIT_NOFILE, &limit); err != nil {
 		return 0, err

--- a/common/fdlimit/fdlimit_test.go
+++ b/common/fdlimit/fdlimit_test.go
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with go-ethereum. If not, see <http://www.gnu.org/licenses/>.
 
-package utils
+package fdlimit
 
 import (
 	"fmt"
@@ -25,7 +25,7 @@ import (
 // per this process can be retrieved.
 func TestFileDescriptorLimits(t *testing.T) {
 	target := 4096
-	hardlimit, err := getFdMaxLimit()
+	hardlimit, err := GetFdMaxLimit()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -33,13 +33,13 @@ func TestFileDescriptorLimits(t *testing.T) {
 		t.Skip(fmt.Sprintf("system limit is less than desired test target: %d < %d", hardlimit, target))
 	}
 
-	if limit, err := getFdLimit(); err != nil || limit <= 0 {
+	if limit, err := GetFdLimit(); err != nil || limit <= 0 {
 		t.Fatalf("failed to retrieve file descriptor limit (%d): %v", limit, err)
 	}
-	if err := raiseFdLimit(uint64(target)); err != nil {
+	if err := RaiseFdLimit(uint64(target)); err != nil {
 		t.Fatalf("failed to raise file allowance")
 	}
-	if limit, err := getFdLimit(); err != nil || limit < target {
+	if limit, err := GetFdLimit(); err != nil || limit < target {
 		t.Fatalf("failed to retrieve raised descriptor limit (have %v, want %v): %v", limit, target, err)
 	}
 }

--- a/common/fdlimit/fdlimit_test.go
+++ b/common/fdlimit/fdlimit_test.go
@@ -25,7 +25,7 @@ import (
 // per this process can be retrieved.
 func TestFileDescriptorLimits(t *testing.T) {
 	target := 4096
-	hardlimit, err := GetFdMaxLimit()
+	hardlimit, err := GetMax()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -33,13 +33,13 @@ func TestFileDescriptorLimits(t *testing.T) {
 		t.Skip(fmt.Sprintf("system limit is less than desired test target: %d < %d", hardlimit, target))
 	}
 
-	if limit, err := GetFdLimit(); err != nil || limit <= 0 {
+	if limit, err := Get(); err != nil || limit <= 0 {
 		t.Fatalf("failed to retrieve file descriptor limit (%d): %v", limit, err)
 	}
-	if err := RaiseFdLimit(uint64(target)); err != nil {
+	if err := Raise(uint64(target)); err != nil {
 		t.Fatalf("failed to raise file allowance")
 	}
-	if limit, err := GetFdLimit(); err != nil || limit < target {
+	if limit, err := Get(); err != nil || limit < target {
 		t.Fatalf("failed to retrieve raised descriptor limit (have %v, want %v): %v", limit, target, err)
 	}
 }

--- a/common/fdlimit/fdlimit_test.go
+++ b/common/fdlimit/fdlimit_test.go
@@ -25,7 +25,7 @@ import (
 // per this process can be retrieved.
 func TestFileDescriptorLimits(t *testing.T) {
 	target := 4096
-	hardlimit, err := GetMax()
+	hardlimit, err := Maximum()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -33,13 +33,13 @@ func TestFileDescriptorLimits(t *testing.T) {
 		t.Skip(fmt.Sprintf("system limit is less than desired test target: %d < %d", hardlimit, target))
 	}
 
-	if limit, err := Get(); err != nil || limit <= 0 {
+	if limit, err := Current(); err != nil || limit <= 0 {
 		t.Fatalf("failed to retrieve file descriptor limit (%d): %v", limit, err)
 	}
 	if err := Raise(uint64(target)); err != nil {
 		t.Fatalf("failed to raise file allowance")
 	}
-	if limit, err := Get(); err != nil || limit < target {
+	if limit, err := Current(); err != nil || limit < target {
 		t.Fatalf("failed to retrieve raised descriptor limit (have %v, want %v): %v", limit, target, err)
 	}
 }

--- a/common/fdlimit/fdlimit_unix.go
+++ b/common/fdlimit/fdlimit_unix.go
@@ -20,9 +20,9 @@ package fdlimit
 
 import "syscall"
 
-// RaiseFdLimit tries to maximize the file descriptor allowance of this process
+// Raise tries to maximize the file descriptor allowance of this process
 // to the maximum hard-limit allowed by the OS.
-func RaiseFdLimit(max uint64) error {
+func Raise(max uint64) error {
 	// Get the current limit
 	var limit syscall.Rlimit
 	if err := syscall.Getrlimit(syscall.RLIMIT_NOFILE, &limit); err != nil {
@@ -39,9 +39,9 @@ func RaiseFdLimit(max uint64) error {
 	return nil
 }
 
-// GetFdLimit retrieves the number of file descriptors allowed to be opened by this
+// Get retrieves the number of file descriptors allowed to be opened by this
 // process.
-func GetFdLimit() (int, error) {
+func Get() (int, error) {
 	var limit syscall.Rlimit
 	if err := syscall.Getrlimit(syscall.RLIMIT_NOFILE, &limit); err != nil {
 		return 0, err
@@ -49,9 +49,9 @@ func GetFdLimit() (int, error) {
 	return int(limit.Cur), nil
 }
 
-// GetFdMaxLimit retrieves the maximum number of file descriptors this process is
+// GetMax retrieves the maximum number of file descriptors this process is
 // allowed to request for itself.
-func GetFdMaxLimit() (int, error) {
+func GetMax() (int, error) {
 	var limit syscall.Rlimit
 	if err := syscall.Getrlimit(syscall.RLIMIT_NOFILE, &limit); err != nil {
 		return 0, err

--- a/common/fdlimit/fdlimit_unix.go
+++ b/common/fdlimit/fdlimit_unix.go
@@ -39,9 +39,9 @@ func Raise(max uint64) error {
 	return nil
 }
 
-// Get retrieves the number of file descriptors allowed to be opened by this
+// Current retrieves the number of file descriptors allowed to be opened by this
 // process.
-func Get() (int, error) {
+func Current() (int, error) {
 	var limit syscall.Rlimit
 	if err := syscall.Getrlimit(syscall.RLIMIT_NOFILE, &limit); err != nil {
 		return 0, err
@@ -49,9 +49,9 @@ func Get() (int, error) {
 	return int(limit.Cur), nil
 }
 
-// GetMax retrieves the maximum number of file descriptors this process is
+// Maximum retrieves the maximum number of file descriptors this process is
 // allowed to request for itself.
-func GetMax() (int, error) {
+func Maximum() (int, error) {
 	var limit syscall.Rlimit
 	if err := syscall.Getrlimit(syscall.RLIMIT_NOFILE, &limit); err != nil {
 		return 0, err

--- a/common/fdlimit/fdlimit_unix.go
+++ b/common/fdlimit/fdlimit_unix.go
@@ -14,19 +14,15 @@
 // You should have received a copy of the GNU General Public License
 // along with go-ethereum. If not, see <http://www.gnu.org/licenses/>.
 
-// +build freebsd
+// +build linux darwin netbsd openbsd solaris
 
-package utils
+package fdlimit
 
 import "syscall"
 
-// This file is largely identical to fdlimit_unix.go,
-// but Rlimit fields have type int64 on FreeBSD so it needs
-// an extra conversion.
-
-// raiseFdLimit tries to maximize the file descriptor allowance of this process
+// RaiseFdLimit tries to maximize the file descriptor allowance of this process
 // to the maximum hard-limit allowed by the OS.
-func raiseFdLimit(max uint64) error {
+func RaiseFdLimit(max uint64) error {
 	// Get the current limit
 	var limit syscall.Rlimit
 	if err := syscall.Getrlimit(syscall.RLIMIT_NOFILE, &limit); err != nil {
@@ -34,8 +30,8 @@ func raiseFdLimit(max uint64) error {
 	}
 	// Try to update the limit to the max allowance
 	limit.Cur = limit.Max
-	if limit.Cur > int64(max) {
-		limit.Cur = int64(max)
+	if limit.Cur > max {
+		limit.Cur = max
 	}
 	if err := syscall.Setrlimit(syscall.RLIMIT_NOFILE, &limit); err != nil {
 		return err
@@ -43,9 +39,9 @@ func raiseFdLimit(max uint64) error {
 	return nil
 }
 
-// getFdLimit retrieves the number of file descriptors allowed to be opened by this
+// GetFdLimit retrieves the number of file descriptors allowed to be opened by this
 // process.
-func getFdLimit() (int, error) {
+func GetFdLimit() (int, error) {
 	var limit syscall.Rlimit
 	if err := syscall.Getrlimit(syscall.RLIMIT_NOFILE, &limit); err != nil {
 		return 0, err
@@ -53,9 +49,9 @@ func getFdLimit() (int, error) {
 	return int(limit.Cur), nil
 }
 
-// getFdMaxLimit retrieves the maximum number of file descriptors this process is
+// GetFdMaxLimit retrieves the maximum number of file descriptors this process is
 // allowed to request for itself.
-func getFdMaxLimit() (int, error) {
+func GetFdMaxLimit() (int, error) {
 	var limit syscall.Rlimit
 	if err := syscall.Getrlimit(syscall.RLIMIT_NOFILE, &limit); err != nil {
 		return 0, err

--- a/common/fdlimit/fdlimit_windows.go
+++ b/common/fdlimit/fdlimit_windows.go
@@ -18,9 +18,9 @@ package fdlimit
 
 import "errors"
 
-// RaiseFdLimit tries to maximize the file descriptor allowance of this process
+// Raise tries to maximize the file descriptor allowance of this process
 // to the maximum hard-limit allowed by the OS.
-func RaiseFdLimit(max uint64) error {
+func Raise(max uint64) error {
 	// This method is NOP by design:
 	//  * Linux/Darwin counterparts need to manually increase per process limits
 	//  * On Windows Go uses the CreateFile API, which is limited to 16K files, non
@@ -33,15 +33,15 @@ func RaiseFdLimit(max uint64) error {
 	return nil
 }
 
-// GetFdLimit retrieves the number of file descriptors allowed to be opened by this
+// Get retrieves the number of file descriptors allowed to be opened by this
 // process.
-func GetFdLimit() (int, error) {
-	// Please see RaiseFdLimit for the reason why we use hard coded 16K as the limit
+func Get() (int, error) {
+	// Please see Raise for the reason why we use hard coded 16K as the limit
 	return 16384, nil
 }
 
-// GetFdMaxLimit retrieves the maximum number of file descriptors this process is
+// GetMax retrieves the maximum number of file descriptors this process is
 // allowed to request for itself.
-func GetFdMaxLimit() (int, error) {
-	return GetFdLimit()
+func GetMax() (int, error) {
+	return Get()
 }

--- a/common/fdlimit/fdlimit_windows.go
+++ b/common/fdlimit/fdlimit_windows.go
@@ -14,13 +14,13 @@
 // You should have received a copy of the GNU General Public License
 // along with go-ethereum. If not, see <http://www.gnu.org/licenses/>.
 
-package utils
+package fdlimit
 
 import "errors"
 
-// raiseFdLimit tries to maximize the file descriptor allowance of this process
+// RaiseFdLimit tries to maximize the file descriptor allowance of this process
 // to the maximum hard-limit allowed by the OS.
-func raiseFdLimit(max uint64) error {
+func RaiseFdLimit(max uint64) error {
 	// This method is NOP by design:
 	//  * Linux/Darwin counterparts need to manually increase per process limits
 	//  * On Windows Go uses the CreateFile API, which is limited to 16K files, non
@@ -33,15 +33,15 @@ func raiseFdLimit(max uint64) error {
 	return nil
 }
 
-// getFdLimit retrieves the number of file descriptors allowed to be opened by this
+// GetFdLimit retrieves the number of file descriptors allowed to be opened by this
 // process.
-func getFdLimit() (int, error) {
-	// Please see raiseFdLimit for the reason why we use hard coded 16K as the limit
+func GetFdLimit() (int, error) {
+	// Please see RaiseFdLimit for the reason why we use hard coded 16K as the limit
 	return 16384, nil
 }
 
-// getFdMaxLimit retrieves the maximum number of file descriptors this process is
+// GetFdMaxLimit retrieves the maximum number of file descriptors this process is
 // allowed to request for itself.
-func getFdMaxLimit() (int, error) {
-	return getFdLimit()
+func GetFdMaxLimit() (int, error) {
+	return GetFdLimit()
 }

--- a/common/fdlimit/fdlimit_windows.go
+++ b/common/fdlimit/fdlimit_windows.go
@@ -33,15 +33,15 @@ func Raise(max uint64) error {
 	return nil
 }
 
-// Get retrieves the number of file descriptors allowed to be opened by this
+// Current retrieves the number of file descriptors allowed to be opened by this
 // process.
-func Get() (int, error) {
+func Current() (int, error) {
 	// Please see Raise for the reason why we use hard coded 16K as the limit
 	return 16384, nil
 }
 
-// GetMax retrieves the maximum number of file descriptors this process is
+// Maximum retrieves the maximum number of file descriptors this process is
 // allowed to request for itself.
-func GetMax() (int, error) {
-	return Get()
+func Maximum() (int, error) {
+	return Current()
 }


### PR DESCRIPTION
When `go-ethereum` is used as a library the calling program need to set the FD limit.

This commit extract fdlimit files to a separate package so it can be used outside of `go-ethereum`.

#15833 