### PR TITLE
whisper: message format changed

### DIFF
--- a/whisper/whisperv6/api.go
+++ b/whisper/whisperv6/api.go
@@ -113,29 +113,17 @@ func (api *PublicWhisperAPI) Info(ctx context.Context) Info {
 // SetMaxMessageSize sets the maximum message size that is accepted.
 // Upper limit is defined by MaxMessageSize.
 func (api *PublicWhisperAPI) SetMaxMessageSize(ctx context.Context, size uint32) (bool, error) {
-	err := api.w.SetMaxMessageSize(size)
-	if err != nil {
-		return false, err
-	}
-	return true, nil
+	return true, api.w.SetMaxMessageSize(size)
 }
 
 // SetMinPow sets the minimum PoW, and notifies the peers.
 func (api *PublicWhisperAPI) SetMinPoW(ctx context.Context, pow float64) (bool, error) {
-	err := api.w.SetMinimumPoW(pow)
-	if err != nil {
-		return false, err
-	}
-	return true, nil
+	return true, api.w.SetMinimumPoW(pow)
 }
 
 // SetBloomFilter sets the new value of bloom filter, and notifies the peers.
 func (api *PublicWhisperAPI) SetBloomFilter(ctx context.Context, bloom hexutil.Bytes) (bool, error) {
-	err := api.w.SetBloomFilter(bloom)
-	if err != nil {
-		return false, err
-	}
-	return true, nil
+	return true, api.w.SetBloomFilter(bloom)
 }
 
 // MarkTrustedPeer marks a peer trusted, which will allow it to send historic (expired) messages.

--- a/whisper/whisperv6/api.go
+++ b/whisper/whisperv6/api.go
@@ -113,15 +113,32 @@ func (api *PublicWhisperAPI) Info(ctx context.Context) Info {
 // SetMaxMessageSize sets the maximum message size that is accepted.
 // Upper limit is defined by MaxMessageSize.
 func (api *PublicWhisperAPI) SetMaxMessageSize(ctx context.Context, size uint32) (bool, error) {
-	return true, api.w.SetMaxMessageSize(size)
+	err := api.w.SetMaxMessageSize(size)
+	if err != nil {
+		return false, err
+	}
+	return true, nil
 }
 
-// SetMinPow sets the minimum PoW for a message before it is accepted.
+// SetMinPow sets the minimum PoW, and notifies the peers.
 func (api *PublicWhisperAPI) SetMinPoW(ctx context.Context, pow float64) (bool, error) {
-	return true, api.w.SetMinimumPoW(pow)
+	err := api.w.SetMinimumPoW(pow)
+	if err != nil {
+		return false, err
+	}
+	return true, nil
 }
 
-// MarkTrustedPeer marks a peer trusted. , which will allow it to send historic (expired) messages.
+// SetBloomFilter sets the new value of bloom filter, and notifies the peers.
+func (api *PublicWhisperAPI) SetBloomFilter(ctx context.Context, bloom hexutil.Bytes) (bool, error) {
+	err := api.w.SetBloomFilter(bloom)
+	if err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
+// MarkTrustedPeer marks a peer trusted, which will allow it to send historic (expired) messages.
 // Note: This function is not adding new nodes, the node needs to exists as a peer.
 func (api *PublicWhisperAPI) MarkTrustedPeer(ctx context.Context, enode string) (bool, error) {
 	n, err := discover.ParseNode(enode)

--- a/whisper/whisperv6/api.go
+++ b/whisper/whisperv6/api.go
@@ -277,7 +277,7 @@ func (api *PublicWhisperAPI) Post(ctx context.Context, req NewMessage) (bool, er
 		if params.KeySym, err = api.w.GetSymKey(req.SymKeyID); err != nil {
 			return false, err
 		}
-		if !validateSymmetricKey(params.KeySym) {
+		if !validateRandomData(params.KeySym, aesKeyLength) {
 			return false, ErrInvalidSymmetricKey
 		}
 	}
@@ -383,7 +383,7 @@ func (api *PublicWhisperAPI) Messages(ctx context.Context, crit Criteria) (*rpc.
 		if err != nil {
 			return nil, err
 		}
-		if !validateSymmetricKey(key) {
+		if !validateRandomData(key, aesKeyLength) {
 			return nil, ErrInvalidSymmetricKey
 		}
 		filter.KeySym = key
@@ -555,7 +555,7 @@ func (api *PublicWhisperAPI) NewMessageFilter(req Criteria) (string, error) {
 		if keySym, err = api.w.GetSymKey(req.SymKeyID); err != nil {
 			return "", err
 		}
-		if !validateSymmetricKey(keySym) {
+		if !validateRandomData(keySym, aesKeyLength) {
 			return "", ErrInvalidSymmetricKey
 		}
 	}

--- a/whisper/whisperv6/doc.go
+++ b/whisper/whisperv6/doc.go
@@ -54,7 +54,7 @@ const (
 	TopicLength     = 4  // in bytes
 	signatureLength = 65 // in bytes
 	aesKeyLength    = 32 // in bytes
-	AESNonceLength  = 12 // in bytes; also returned by aesgcm.NonceSize()
+	aesNonceLength  = 12 // in bytes; for more info please see cipher.gcmStandardNonceSize & aesgcm.NonceSize()
 	keyIdSize       = 32 // in bytes
 	bloomFilterSize = 64 // in bytes
 

--- a/whisper/whisperv6/doc.go
+++ b/whisper/whisperv6/doc.go
@@ -35,7 +35,6 @@ import (
 )
 
 const (
-	EnvelopeVersion    = uint64(0)
 	ProtocolVersion    = uint64(6)
 	ProtocolVersionStr = "6.0"
 	ProtocolName       = "shh"
@@ -57,6 +56,7 @@ const (
 	aesKeyLength    = 32
 	AESNonceLength  = 12
 	keyIdSize       = 32
+	bloomFilterSize = 64
 
 	MaxMessageSize        = uint32(10 * 1024 * 1024) // maximum accepted size of a message.
 	DefaultMaxMessageSize = uint32(1024 * 1024)

--- a/whisper/whisperv6/doc.go
+++ b/whisper/whisperv6/doc.go
@@ -68,8 +68,8 @@ const (
 	expirationCycle   = time.Second
 	transmissionCycle = 300 * time.Millisecond
 
-	DefaultTTL     = 50 // seconds
-	SynchAllowance = 10 // seconds
+	DefaultTTL           = 50 // seconds
+	DefaultSyncAllowance = 10 // seconds
 
 	EnvelopeHeaderLength = 20
 )

--- a/whisper/whisperv6/doc.go
+++ b/whisper/whisperv6/doc.go
@@ -48,13 +48,13 @@ const (
 	p2pMessageCode       = 127 // peer-to-peer message (to be consumed by the peer, but not forwarded any further)
 	NumberOfMessageCodes = 128
 
-	paddingMask   = byte(3)
-	signatureFlag = byte(4)
+	auxFieldSizeMask = byte(3) // mask used to extract the size of auxiliary field from the flags
+	signatureFlag    = byte(4)
 
 	TopicLength     = 4  // in bytes
 	signatureLength = 65 // in bytes
 	aesKeyLength    = 32 // in bytes
-	AESNonceLength  = 12 // in bytes
+	AESNonceLength  = 12 // in bytes; also returned by aesgcm.NonceSize()
 	keyIdSize       = 32 // in bytes
 	bloomFilterSize = 64 // in bytes
 
@@ -64,7 +64,7 @@ const (
 	DefaultMaxMessageSize = uint32(1024 * 1024)
 	DefaultMinimumPoW     = 0.2
 
-	padSizeLimit      = 256 // just an arbitrary number, could be changed without breaking the protocol (must not exceed 2^24)
+	padSizeLimit      = 256 // just an arbitrary number, could be changed without breaking the protocol
 	messageQueueLimit = 1024
 
 	expirationCycle   = time.Second

--- a/whisper/whisperv6/doc.go
+++ b/whisper/whisperv6/doc.go
@@ -58,6 +58,8 @@ const (
 	keyIdSize       = 32 // in bytes
 	bloomFilterSize = 64 // in bytes
 
+	EnvelopeHeaderLength = 20
+
 	MaxMessageSize        = uint32(10 * 1024 * 1024) // maximum accepted size of a message.
 	DefaultMaxMessageSize = uint32(1024 * 1024)
 	DefaultMinimumPoW     = 0.2

--- a/whisper/whisperv6/doc.go
+++ b/whisper/whisperv6/doc.go
@@ -51,12 +51,12 @@ const (
 	paddingMask   = byte(3)
 	signatureFlag = byte(4)
 
-	TopicLength     = 4
-	signatureLength = 65
-	aesKeyLength    = 32
-	AESNonceLength  = 12
-	keyIdSize       = 32
-	bloomFilterSize = 64
+	TopicLength     = 4  // in bytes
+	signatureLength = 65 // in bytes
+	aesKeyLength    = 32 // in bytes
+	AESNonceLength  = 12 // in bytes
+	keyIdSize       = 32 // in bytes
+	bloomFilterSize = 64 // in bytes
 
 	MaxMessageSize        = uint32(10 * 1024 * 1024) // maximum accepted size of a message.
 	DefaultMaxMessageSize = uint32(1024 * 1024)
@@ -70,8 +70,6 @@ const (
 
 	DefaultTTL           = 50 // seconds
 	DefaultSyncAllowance = 10 // seconds
-
-	EnvelopeHeaderLength = 20
 )
 
 type unknownVersionError uint64

--- a/whisper/whisperv6/envelope.go
+++ b/whisper/whisperv6/envelope.go
@@ -42,9 +42,11 @@ type Envelope struct {
 	Data   []byte
 	Nonce  uint64
 
-	pow  float64     // Message-specific PoW as described in the Whisper specification.
-	hash common.Hash // Cached hash of the envelope to avoid rehashing every time.
-	// Don't access hash directly, use Hash() function instead.
+	pow float64 // Message-specific PoW as described in the Whisper specification.
+
+	// the following variables should not be accessed directly, use the corresponding function instead: Hash(), Bloom()
+	hash  common.Hash // Cached hash of the envelope to avoid rehashing every time.
+	bloom []byte
 }
 
 // size returns the size of envelope as it is sent (i.e. public fields only)
@@ -226,4 +228,31 @@ func (e *Envelope) Open(watcher *Filter) (msg *ReceivedMessage) {
 		msg.EnvelopeHash = e.Hash()
 	}
 	return msg
+}
+
+// Bloom maps 4-bytes Topic into 64-byte bloom filter with 3 bits set (at most).
+func (e *Envelope) Bloom() []byte {
+	if e.bloom == nil {
+		e.bloom = TopicToBloom(e.Topic)
+	}
+	return e.bloom
+}
+
+func TopicToBloom(topic TopicType) []byte {
+	var powers = [...]byte{1, 2, 4, 8, 16, 32, 64, 128}
+	b := make([]byte, bloomFilterSize)
+	var index [3]int
+	for j := 0; j < 3; j++ {
+		index[j] = int(topic[j])
+		if (topic[3] & powers[j]) != 0 {
+			index[j] += 256
+		}
+	}
+
+	for j := 0; j < 3; j++ {
+		byteIndex := index[j] / 8
+		bitIndex := index[j] % 8
+		b[byteIndex] = powers[bitIndex]
+	}
+	return b
 }

--- a/whisper/whisperv6/envelope.go
+++ b/whisper/whisperv6/envelope.go
@@ -198,29 +198,25 @@ func (e *Envelope) OpenSymmetric(key []byte) (msg *ReceivedMessage, err error) {
 
 // Open tries to decrypt an envelope, and populates the message fields in case of success.
 func (e *Envelope) Open(watcher *Filter) (msg *ReceivedMessage) {
-	// The API interface forbids filters doing both symmetric and
-	// asymmetric encryption.
+	// The API interface forbids filters doing both symmetric and asymmetric encryption.
 	if watcher.expectsAsymmetricEncryption() && watcher.expectsSymmetricEncryption() {
 		return nil
 	}
 
-	var symmetric bool
 	if watcher.expectsAsymmetricEncryption() {
 		msg, _ = e.OpenAsymmetric(watcher.KeyAsym)
 		if msg != nil {
-			symmetric = false
 			msg.Dst = &watcher.KeyAsym.PublicKey
 		}
 	} else if watcher.expectsSymmetricEncryption() {
 		msg, _ = e.OpenSymmetric(watcher.KeySym)
 		if msg != nil {
-			symmetric = true
 			msg.SymKeyHash = crypto.Keccak256Hash(watcher.KeySym)
 		}
 	}
 
 	if msg != nil {
-		ok := msg.ValidateAndParse(symmetric)
+		ok := msg.ValidateAndParse()
 		if !ok {
 			return nil
 		}

--- a/whisper/whisperv6/envelope.go
+++ b/whisper/whisperv6/envelope.go
@@ -204,20 +204,23 @@ func (e *Envelope) Open(watcher *Filter) (msg *ReceivedMessage) {
 		return nil
 	}
 
+	var symmetric bool
 	if watcher.expectsAsymmetricEncryption() {
 		msg, _ = e.OpenAsymmetric(watcher.KeyAsym)
 		if msg != nil {
+			symmetric = false
 			msg.Dst = &watcher.KeyAsym.PublicKey
 		}
 	} else if watcher.expectsSymmetricEncryption() {
 		msg, _ = e.OpenSymmetric(watcher.KeySym)
 		if msg != nil {
+			symmetric = true
 			msg.SymKeyHash = crypto.Keccak256Hash(watcher.KeySym)
 		}
 	}
 
 	if msg != nil {
-		ok := msg.Validate()
+		ok := msg.ValidateAndParse(symmetric)
 		if !ok {
 			return nil
 		}

--- a/whisper/whisperv6/envelope.go
+++ b/whisper/whisperv6/envelope.go
@@ -51,7 +51,6 @@ type Envelope struct {
 
 // size returns the size of envelope as it is sent (i.e. public fields only)
 func (e *Envelope) size() int {
-	const EnvelopeHeaderLength = 20
 	return EnvelopeHeaderLength + len(e.Data)
 }
 

--- a/whisper/whisperv6/envelope.go
+++ b/whisper/whisperv6/envelope.go
@@ -51,6 +51,7 @@ type Envelope struct {
 
 // size returns the size of envelope as it is sent (i.e. public fields only)
 func (e *Envelope) size() int {
+	const EnvelopeHeaderLength = 20
 	return EnvelopeHeaderLength + len(e.Data)
 }
 
@@ -238,13 +239,13 @@ func (e *Envelope) Bloom() []byte {
 	return e.bloom
 }
 
+// TopicToBloom converts the topic (4 bytes) to the bloom filter (64 bytes)
 func TopicToBloom(topic TopicType) []byte {
-	var powers = [...]byte{1, 2, 4, 8, 16, 32, 64, 128}
 	b := make([]byte, bloomFilterSize)
 	var index [3]int
 	for j := 0; j < 3; j++ {
 		index[j] = int(topic[j])
-		if (topic[3] & powers[j]) != 0 {
+		if (topic[3] & (1 << uint(j))) != 0 {
 			index[j] += 256
 		}
 	}
@@ -252,7 +253,7 @@ func TopicToBloom(topic TopicType) []byte {
 	for j := 0; j < 3; j++ {
 		byteIndex := index[j] / 8
 		bitIndex := index[j] % 8
-		b[byteIndex] = powers[bitIndex]
+		b[byteIndex] = (1 << uint(bitIndex))
 	}
 	return b
 }

--- a/whisper/whisperv6/message.go
+++ b/whisper/whisperv6/message.go
@@ -25,6 +25,7 @@ import (
 	crand "crypto/rand"
 	"encoding/binary"
 	"errors"
+	mrand "math/rand"
 	"strconv"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -89,80 +90,95 @@ func (msg *ReceivedMessage) isAsymmetricEncryption() bool {
 // NewMessage creates and initializes a non-signed, non-encrypted Whisper message.
 func NewSentMessage(params *MessageParams) (*sentMessage, error) {
 	msg := sentMessage{}
-	msg.Raw = make([]byte, 1, len(params.Payload)+len(params.Padding)+signatureLength+padSizeLimit)
+	msg.Raw = make([]byte, 1, 5+len(params.Payload)+len(params.Padding)+signatureLength+padSizeLimit)
 	msg.Raw[0] = 0 // set all the flags to zero
-	err := msg.appendPadding(params)
-	if err != nil {
-		return nil, err
-	}
+	msg.addPayloadSizeField(params.Payload)
 	msg.Raw = append(msg.Raw, params.Payload...)
-	return &msg, nil
+	err := msg.appendPadding(params)
+	return &msg, err
 }
 
-// getSizeOfLength returns the number of bytes necessary to encode the entire size padding (including these bytes)
-func getSizeOfLength(b []byte) (sz int, err error) {
-	sz = intSize(len(b))      // first iteration
-	sz = intSize(len(b) + sz) // second iteration
-	if sz > 3 {
-		err = errors.New("oversized padding parameter")
-	}
-	return sz, err
+// appendPayloadSizeField appends the auxiliary field containing the size of payload
+func (msg *sentMessage) addPayloadSizeField(payload []byte) {
+	fieldSize := getAuxFieldSize(payload)
+	field := make([]byte, fieldSize)
+	binary.LittleEndian.PutUint32(field, uint32(len(payload)))
+	msg.Raw = append(msg.Raw, field...)
+	msg.Raw[0] |= byte(fieldSize)
 }
 
-// sizeOfIntSize returns minimal number of bytes necessary to encode an integer value
-func intSize(i int) (s int) {
-	for s = 1; i >= 256; s++ {
-		i /= 256
+// getSizeOfLength returns the number of bytes necessary to encode the size of padding
+//func getAuxFieldSize(payload []byte) (sz int, err error) {
+//	sz = intSize(len(b))      // first iteration
+//	sz = intSize(len(b) + sz) // second iteration
+//	if sz > 3 {
+//		err = errors.New("oversized padding parameter")
+//	}
+//	return sz, err
+//}
+
+// getAuxFieldSize returns the number of bytes necessary to encode the size of payload
+func getAuxFieldSize(payload []byte) int {
+	s := 1
+	for i := len(payload); i >= 256; i /= 256 {
+		s++
 	}
 	return s
 }
 
-// appendPadding appends the pseudorandom padding bytes and sets the padding flag.
-// The last byte contains the size of padding (thus, its size must not exceed 256).
+// appendPadding appends the padding specified in params.
+// If no padding is provided in params, then random padding is generated.
 func (msg *sentMessage) appendPadding(params *MessageParams) error {
-	rawSize := len(params.Payload) + 1
+	if len(params.Padding) != 0 {
+		// padding data was provided by the Dapp, just use it as is
+		msg.Raw = append(msg.Raw, params.Padding...)
+		return nil
+	}
+
+	auxFieldSize := getAuxFieldSize(params.Payload)
+	rawSize := 1 + auxFieldSize + len(params.Payload)
 	if params.Src != nil {
 		rawSize += signatureLength
 	}
-
 	if params.KeySym != nil {
 		rawSize += AESNonceLength
 	}
 	odd := rawSize % padSizeLimit
 
-	if len(params.Padding) != 0 {
-		padSize := len(params.Padding)
-		padLengthSize, err := getSizeOfLength(params.Padding)
-		if err != nil {
-			return err
-		}
-		totalPadSize := padSize + padLengthSize
-		buf := make([]byte, 8)
-		binary.LittleEndian.PutUint32(buf, uint32(totalPadSize))
-		buf = buf[:padLengthSize]
-		msg.Raw = append(msg.Raw, buf...)
-		msg.Raw = append(msg.Raw, params.Padding...)
-		msg.Raw[0] |= byte(padLengthSize) // number of bytes indicating the padding size
-	} else if odd != 0 {
-		totalPadSize := padSizeLimit - odd
-		if totalPadSize > 255 {
-			// this algorithm is only valid if padSizeLimit < 256.
-			// if padSizeLimit will ever change, please fix the algorithm
-			// (please see also ReceivedMessage.extractPadding() function).
-			panic("please fix the padding algorithm before releasing new version")
-		}
-		buf := make([]byte, totalPadSize)
-		_, err := crand.Read(buf[1:])
-		if err != nil {
-			return err
-		}
-		if totalPadSize > 6 && !validateSymmetricKey(buf) {
-			return errors.New("failed to generate random padding of size " + strconv.Itoa(totalPadSize))
-		}
-		buf[0] = byte(totalPadSize)
-		msg.Raw = append(msg.Raw, buf...)
-		msg.Raw[0] |= byte(0x1) // number of bytes indicating the padding size
+	//if len(params.Padding) != 0 {
+	//	// padding data was provided by the Dapp, just use it as is
+	//	padSize := len(params.Padding)
+	//	padLengthSize, err := intSize(len(params.Padding))
+	//	if err != nil {
+	//		return err
+	//	}
+	//	totalPadSize := padSize + padLengthSize
+	//	buf := make([]byte, 8)
+	//	binary.LittleEndian.PutUint32(buf, uint32(totalPadSize))
+	//	buf = buf[:padLengthSize]
+	//	msg.Raw = append(msg.Raw, buf...)
+	//	msg.Raw = append(msg.Raw, params.Padding...)
+	//	msg.Raw[0] |= byte(padLengthSize) // number of bytes indicating the padding size
+	//} else if odd != 0 {
+	paddingSize := padSizeLimit - odd
+	//if totalPadSize > 255 {
+	//	// this algorithm is only valid if padSizeLimit < 256.
+	//	// if padSizeLimit will ever change, please fix the algorithm
+	//	// (please see also ReceivedMessage.extractPadding() function).
+	//	panic("please fix the padding algorithm before releasing new version")
+	//}
+	pad := make([]byte, paddingSize)
+	_, err := crand.Read(pad)
+	if err != nil {
+		return err
 	}
+	if !validateSymmetricKey(pad) {
+		return errors.New("failed to generate random padding of size " + strconv.Itoa(paddingSize))
+	}
+	//buf[0] = byte(totalPadSize)
+	msg.Raw = append(msg.Raw, pad...)
+	//msg.Raw[0] |= byte(0x1) // number of bytes indicating the padding size
+	//}
 	return nil
 }
 
@@ -175,14 +191,15 @@ func (msg *sentMessage) sign(key *ecdsa.PrivateKey) error {
 		return nil
 	}
 
-	msg.Raw[0] |= signatureFlag
+	msg.Raw[0] |= signatureFlag // it is important to set this flag before signing
 	hash := crypto.Keccak256(msg.Raw)
 	signature, err := crypto.Sign(hash, key)
 	if err != nil {
-		msg.Raw[0] &= ^signatureFlag // clear the flag
+		msg.Raw[0] ^= signatureFlag // clear the flag
 		return err
 	}
 	msg.Raw = append(msg.Raw, signature...)
+
 	return nil
 }
 
@@ -204,7 +221,6 @@ func (msg *sentMessage) encryptSymmetric(key []byte) (err error) {
 	if !validateSymmetricKey(key) {
 		return errors.New("invalid key provided for symmetric encryption")
 	}
-
 	block, err := aes.NewCipher(key)
 	if err != nil {
 		return err
@@ -213,18 +229,41 @@ func (msg *sentMessage) encryptSymmetric(key []byte) (err error) {
 	if err != nil {
 		return err
 	}
-
-	// never use more than 2^32 random nonces with a given key
-	salt := make([]byte, aesgcm.NonceSize())
-	_, err = crand.Read(salt)
+	salt, err := generateSalt(aesgcm)
 	if err != nil {
 		return err
-	} else if !validateSymmetricKey(salt) {
-		return errors.New("crypto/rand failed to generate salt")
 	}
-
-	msg.Raw = append(aesgcm.Seal(nil, salt, msg.Raw, nil), salt...)
+	encrypted := aesgcm.Seal(nil, salt, msg.Raw, nil)
+	msg.Raw = append(encrypted, salt...)
 	return nil
+}
+
+func generateSalt(aesgcm cipher.AEAD) ([]byte, error) {
+	// never use more than 2^32 random nonces with a given key
+	sz := aesgcm.NonceSize()
+	x1 := make([]byte, sz)
+	x2 := make([]byte, sz)
+	salt := make([]byte, sz)
+
+	_, err := crand.Read(x1)
+	if err != nil {
+		return nil, err
+	} else if !validateSymmetricKey(x1) {
+		return nil, errors.New("crypto/rand failed to generate salt")
+	}
+	_, err = mrand.Read(x2)
+	if err != nil {
+		return nil, err
+	} else if !validateSymmetricKey(x2) {
+		return nil, errors.New("math/rand failed to generate salt")
+	}
+	for i := 0; i < sz; i++ {
+		salt[i] = x1[i] ^ x2[i]
+	}
+	if !validateSymmetricKey(salt) {
+		return nil, errors.New("failed to generate salt")
+	}
+	return salt, nil
 }
 
 // Wrap bundles the message into an Envelope to transmit over the network.
@@ -295,11 +334,15 @@ func (msg *ReceivedMessage) decryptAsymmetric(key *ecdsa.PrivateKey) error {
 	return err
 }
 
-// Validate checks the validity and extracts the fields in case of success
-func (msg *ReceivedMessage) Validate() bool {
+// Validate checks the message validity and extracts the fields in case of success.
+func (msg *ReceivedMessage) ValidateAndParse(symmetric bool) bool {
 	end := len(msg.Raw)
 	if end < 1 {
 		return false
+	}
+
+	if symmetric {
+		end -= AESNonceLength
 	}
 
 	if isMessageSigned(msg.Raw[0]) {
@@ -307,19 +350,34 @@ func (msg *ReceivedMessage) Validate() bool {
 		if end <= 1 {
 			return false
 		}
-		msg.Signature = msg.Raw[end:]
+		msg.Signature = msg.Raw[end : end+signatureLength]
 		msg.Src = msg.SigToPubKey()
 		if msg.Src == nil {
 			return false
 		}
 	}
 
-	padSize, ok := msg.extractPadding(end)
-	if !ok {
-		return false
+	beg := 1
+	payloadSize := 0
+	auxFieldSize := int(msg.Raw[0] & auxFieldSizeMask) // number of bytes indicating the size of payload
+	if auxFieldSize != 0 {
+		payloadSize = int(bytesToUintLittleEndian(msg.Raw[beg : beg+auxFieldSize]))
+		if payloadSize+1 > end {
+			return false
+		}
+		beg += auxFieldSize
+		msg.Payload = msg.Raw[beg : beg+payloadSize]
 	}
 
-	msg.Payload = msg.Raw[1+padSize : end]
+	beg += payloadSize
+	msg.Padding = msg.Raw[beg:end]
+
+	//padSize, ok := msg.extractPadding(end)
+	//if !ok {
+	//	return false
+	//}
+	//msg.Payload = msg.Raw[1+padSize : end]
+
 	return true
 }
 
@@ -327,19 +385,18 @@ func (msg *ReceivedMessage) Validate() bool {
 // although we don't support sending messages with padding size
 // exceeding 255 bytes, such messages are perfectly valid, and
 // can be successfully decrypted.
-func (msg *ReceivedMessage) extractPadding(end int) (int, bool) {
-	paddingSize := 0
-	sz := int(msg.Raw[0] & paddingMask) // number of bytes indicating the entire size of padding (including these bytes)
-	// could be zero -- it means no padding
-	if sz != 0 {
-		paddingSize = int(bytesToUintLittleEndian(msg.Raw[1 : 1+sz]))
-		if paddingSize < sz || paddingSize+1 > end {
-			return 0, false
-		}
-		msg.Padding = msg.Raw[1+sz : 1+paddingSize]
-	}
-	return paddingSize, true
-}
+//func (msg *ReceivedMessage) extractPadding(end int) (int, bool) {
+//	payloadSize := 0
+//	auxFieldSize := int(msg.Raw[0] & auxFieldSizeMask) // number of bytes indicating the size of payload
+//	if sz != 0 {
+//		paddingSize = int(bytesToUintLittleEndian(msg.Raw[1 : 1+sz]))
+//		if paddingSize < sz || paddingSize+1 > end {
+//			return 0, false
+//		}
+//		msg.Padding = msg.Raw[1+sz : 1+paddingSize]
+//	}
+//	return paddingSize, true
+//}
 
 // Recover retrieves the public key of the message signer.
 func (msg *ReceivedMessage) SigToPubKey() *ecdsa.PublicKey {
@@ -353,7 +410,7 @@ func (msg *ReceivedMessage) SigToPubKey() *ecdsa.PublicKey {
 	return pub
 }
 
-// hash calculates the SHA3 checksum of the message flags, payload and padding.
+// hash calculates the SHA3 checksum of the message flags, auxiliary field, payload and padding.
 func (msg *ReceivedMessage) hash() []byte {
 	if isMessageSigned(msg.Raw[0]) {
 		sz := len(msg.Raw) - signatureLength

--- a/whisper/whisperv6/message_test.go
+++ b/whisper/whisperv6/message_test.go
@@ -465,6 +465,6 @@ func TestAesNonce(t *testing.T) {
 	// This is the most important single test in this package.
 	// If it fails, whisper will not be working.
 	if aesgcm.NonceSize() != aesNonceLength {
-		t.Fatalf("Nonce size is wrong. This is a critical error. Apparently AES nonce size have changed in the new version of AES GCM package. Whisper will not be working untill this problem is resolved.")
+		t.Fatalf("Nonce size is wrong. This is a critical error. Apparently AES nonce size have changed in the new version of AES GCM package. Whisper will not be working until this problem is resolved.")
 	}
 }

--- a/whisper/whisperv6/message_test.go
+++ b/whisper/whisperv6/message_test.go
@@ -90,7 +90,7 @@ func singleMessageTest(t *testing.T, symmetric bool) {
 		t.Fatalf("failed to encrypt with seed %d: %s.", seed, err)
 	}
 
-	if !decrypted.Validate() {
+	if !decrypted.ValidateAndParse(symmetric) {
 		t.Fatalf("failed to validate with seed %d.", seed)
 	}
 

--- a/whisper/whisperv6/message_test.go
+++ b/whisper/whisperv6/message_test.go
@@ -18,9 +18,12 @@ package whisperv6
 
 import (
 	"bytes"
+	"crypto/aes"
+	"crypto/cipher"
 	mrand "math/rand"
 	"testing"
 
+	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/rlp"
 )
@@ -206,7 +209,7 @@ func TestEnvelopeOpen(t *testing.T) {
 	InitSingleTest()
 
 	var symmetric bool
-	for i := 0; i < 256; i++ {
+	for i := 0; i < 32; i++ {
 		singleEnvelopeOpenTest(t, symmetric)
 		symmetric = !symmetric
 	}
@@ -417,30 +420,6 @@ func TestPadding(t *testing.T) {
 	}
 }
 
-func TestPaddingAppendedToSymMessages(t *testing.T) {
-	params := &MessageParams{
-		Payload: make([]byte, 246),
-		KeySym:  make([]byte, aesKeyLength),
-	}
-
-	// Simulate a message with a payload just under 256 so that
-	// payload + flag + aesnonce > 256. Check that the result
-	// is padded on the next 256 boundary.
-	msg := sentMessage{}
-	msg.Raw = make([]byte, 1+1+len(params.Payload))
-
-	err := msg.appendPadding(params)
-
-	if err != nil {
-		t.Fatalf("Error appending padding to message %v", err)
-		return
-	}
-
-	if len(msg.Raw) != 512-AESNonceLength {
-		t.Errorf("Invalid size %d != 512", len(msg.Raw))
-	}
-}
-
 func TestPaddingAppendedToSymMessagesWithSignature(t *testing.T) {
 	params := &MessageParams{
 		Payload: make([]byte, 246),
@@ -456,7 +435,7 @@ func TestPaddingAppendedToSymMessagesWithSignature(t *testing.T) {
 	params.Src = pSrc
 
 	// Simulate a message with a payload just under 256 so that
-	// payload + flag + aesnonce > 256. Check that the result
+	// payload + flag + signature > 256. Check that the result
 	// is padded on the next 256 boundary.
 	msg := sentMessage{}
 	msg.Raw = make([]byte, 1+1+len(params.Payload))
@@ -468,7 +447,24 @@ func TestPaddingAppendedToSymMessagesWithSignature(t *testing.T) {
 		return
 	}
 
-	if len(msg.Raw) != 512-AESNonceLength-signatureLength {
+	if len(msg.Raw) != 512-signatureLength {
 		t.Errorf("Invalid size %d != 512", len(msg.Raw))
+	}
+}
+
+func TestAesNonce(t *testing.T) {
+	key := hexutil.MustDecode("0x03ca634cae0d49acb401d8a4c6b6fe8c55b70d115bf400769cc1400f3258cd31")
+	block, err := aes.NewCipher(key)
+	if err != nil {
+		t.Fatalf("NewCipher failed: %s", err)
+	}
+	aesgcm, err := cipher.NewGCM(block)
+	if err != nil {
+		t.Fatalf("NewGCM failed: %s", err)
+	}
+	// This is the most important single test in this package.
+	// If it fails, whisper will not be working.
+	if aesgcm.NonceSize() != aesNonceLength {
+		t.Fatalf("Nonce size is wrong. This is a critical error. Apparently AES nonce size have changed in the new version of AES GCM package. Whisper will not be working untill this problem is resolved.")
 	}
 }

--- a/whisper/whisperv6/message_test.go
+++ b/whisper/whisperv6/message_test.go
@@ -90,8 +90,8 @@ func singleMessageTest(t *testing.T, symmetric bool) {
 		t.Fatalf("failed to encrypt with seed %d: %s.", seed, err)
 	}
 
-	if !decrypted.ValidateAndParse(symmetric) {
-		t.Fatalf("failed to validate with seed %d.", seed)
+	if !decrypted.ValidateAndParse() {
+		t.Fatalf("failed to validate with seed %d, symmetric = %v.", seed, symmetric)
 	}
 
 	if !bytes.Equal(text, decrypted.Payload) {
@@ -427,7 +427,7 @@ func TestPaddingAppendedToSymMessages(t *testing.T) {
 	// payload + flag + aesnonce > 256. Check that the result
 	// is padded on the next 256 boundary.
 	msg := sentMessage{}
-	msg.Raw = make([]byte, len(params.Payload)+1+AESNonceLength)
+	msg.Raw = make([]byte, 1+1+len(params.Payload))
 
 	err := msg.appendPadding(params)
 
@@ -436,7 +436,7 @@ func TestPaddingAppendedToSymMessages(t *testing.T) {
 		return
 	}
 
-	if len(msg.Raw) != 512 {
+	if len(msg.Raw) != 512-AESNonceLength {
 		t.Errorf("Invalid size %d != 512", len(msg.Raw))
 	}
 }
@@ -459,7 +459,7 @@ func TestPaddingAppendedToSymMessagesWithSignature(t *testing.T) {
 	// payload + flag + aesnonce > 256. Check that the result
 	// is padded on the next 256 boundary.
 	msg := sentMessage{}
-	msg.Raw = make([]byte, len(params.Payload)+1+AESNonceLength+signatureLength)
+	msg.Raw = make([]byte, 1+1+len(params.Payload))
 
 	err = msg.appendPadding(params)
 
@@ -468,7 +468,7 @@ func TestPaddingAppendedToSymMessagesWithSignature(t *testing.T) {
 		return
 	}
 
-	if len(msg.Raw) != 512 {
+	if len(msg.Raw) != 512-AESNonceLength-signatureLength {
 		t.Errorf("Invalid size %d != 512", len(msg.Raw))
 	}
 }

--- a/whisper/whisperv6/peer.go
+++ b/whisper/whisperv6/peer.go
@@ -36,7 +36,7 @@ type Peer struct {
 
 	trusted        bool
 	powRequirement float64
-	bloomFilter    []byte
+	bloomFilter    []byte // may contain nil in case of full node
 
 	known *set.Set // Messages already known by the peer to avoid wasting bandwidth
 

--- a/whisper/whisperv6/peer_test.go
+++ b/whisper/whisperv6/peer_test.go
@@ -178,7 +178,7 @@ func initialize(t *testing.T) {
 		node.shh = New(&DefaultConfig)
 		node.shh.SetMinimumPoW(masterPow)
 		node.shh.SetBloomFilter(b)
-		if !isBloomFilterEqual(node.shh.BloomFilter(), masterBloomFilter) {
+		if !bytes.Equal(node.shh.BloomFilter(), masterBloomFilter) {
 			t.Fatalf("bloom mismatch on init.")
 		}
 		node.shh.Start(nil)
@@ -421,7 +421,7 @@ func checkPowExchange(t *testing.T) {
 func checkBloomFilterExchange(t *testing.T) {
 	for i, node := range nodes {
 		for peer := range node.shh.peers {
-			if !isBloomFilterEqual(peer.bloomFilter, masterBloomFilter) {
+			if !bytes.Equal(peer.bloomFilter, masterBloomFilter) {
 				t.Fatalf("node %d: failed to exchange bloom filter requirement in round %d. \n%x expected \n%x got",
 					i, round, masterBloomFilter, peer.bloomFilter)
 			}

--- a/whisper/whisperv6/peer_test.go
+++ b/whisper/whisperv6/peer_test.go
@@ -20,6 +20,7 @@ import (
 	"bytes"
 	"crypto/ecdsa"
 	"fmt"
+	mrand "math/rand"
 	"net"
 	"sync"
 	"testing"
@@ -87,6 +88,9 @@ var nodes [NumNodes]*TestNode
 var sharedKey []byte = []byte("some arbitrary data here")
 var sharedTopic TopicType = TopicType{0xF, 0x1, 0x2, 0}
 var expectedMessage []byte = []byte("per rectum ad astra")
+var masterBloomFilter []byte
+var masterPow = 0.00000001
+var round int = 1
 
 func TestSimulation(t *testing.T) {
 	// create a chain of whisper nodes,
@@ -104,8 +108,13 @@ func TestSimulation(t *testing.T) {
 	// check if each node have received and decrypted exactly one message
 	checkPropagation(t, true)
 
-	// send protocol-level messages (powRequirementCode) and check the new PoW requirement values
-	powReqExchange(t)
+	// check if Status message was correctly decoded
+	checkBloomFilterExchange(t)
+	checkPowExchange(t)
+
+	// send new pow and bloom exchange messages
+	resetParams(t)
+	round++
 
 	// node #1 sends one expected (decryptable) message
 	sendMsg(t, true, 1)
@@ -113,18 +122,65 @@ func TestSimulation(t *testing.T) {
 	// check if each node (except node #0) have received and decrypted exactly one message
 	checkPropagation(t, false)
 
+	for i := 1; i < NumNodes; i++ {
+		time.Sleep(20 * time.Millisecond)
+		sendMsg(t, true, i)
+	}
+
+	// check if corresponding protocol-level messages were correctly decoded
+	checkPowExchangeForNodeZero(t)
+	checkBloomFilterExchange(t)
+
 	stopServers()
 }
 
+func resetParams(t *testing.T) {
+	// change pow only for node zero
+	masterPow = 7777777.0
+	nodes[0].shh.SetMinimumPoW(masterPow)
+
+	// change bloom for all nodes
+	masterBloomFilter = TopicToBloom(sharedTopic)
+	for i := 0; i < NumNodes; i++ {
+		nodes[i].shh.SetBloomFilter(masterBloomFilter)
+	}
+}
+
+func initBloom(t *testing.T) {
+	masterBloomFilter = make([]byte, bloomFilterSize)
+	_, err := mrand.Read(masterBloomFilter)
+	if err != nil {
+		t.Fatalf("rand failed: %s.", err)
+	}
+
+	msgBloom := TopicToBloom(sharedTopic)
+	masterBloomFilter = addBloom(masterBloomFilter, msgBloom)
+	for i := 0; i < 32; i++ {
+		masterBloomFilter[i] = 0xFF
+	}
+
+	if !bloomFilterMatch(masterBloomFilter, msgBloom) {
+		t.Fatalf("bloom mismatch on initBloom.")
+	}
+}
+
 func initialize(t *testing.T) {
+	initBloom(t)
+
 	var err error
 	ip := net.IPv4(127, 0, 0, 1)
 	port0 := 30303
 
 	for i := 0; i < NumNodes; i++ {
 		var node TestNode
+		b := make([]byte, bloomFilterSize)
+		copy(b, masterBloomFilter)
 		node.shh = New(&DefaultConfig)
-		node.shh.SetMinimumPowTest(0.00000001)
+		node.shh.SetMinimumPoW(masterPow)
+		node.shh.SetBloomFilter(b)
+		if !isBloomFilterEqual(node.shh.BloomFilter(), masterBloomFilter) {
+			t.Fatalf("bloom mismatch on init.")
+		}
 		node.shh.Start(nil)
 		topics := make([]TopicType, 0)
 		topics = append(topics, sharedTopic)
@@ -206,7 +262,7 @@ func checkPropagation(t *testing.T, includingNodeZero bool) {
 		for i := first; i < NumNodes; i++ {
 			f := nodes[i].shh.GetFilter(nodes[i].filerId)
 			if f == nil {
-				t.Fatalf("failed to get filterId %s from node %d.", nodes[i].filerId, i)
+				t.Fatalf("failed to get filterId %s from node %d, round %d.", nodes[i].filerId, i, round)
 			}
 
 			mail := f.Retrieve()
@@ -332,34 +388,52 @@ func TestPeerBasic(t *testing.T) {
 	}
 }
 
-func powReqExchange(t *testing.T) {
-	for i, node := range nodes {
-		for peer := range node.shh.peers {
-			if peer.powRequirement > 1000.0 {
-				t.Fatalf("node %d: one of the peers' pow requirement is too big (%f).", i, peer.powRequirement)
-			}
-		}
-	}
-
-	const pow float64 = 7777777.0
-	nodes[0].shh.SetMinimumPoW(pow)
-
-	// wait until all the messages are delivered
-	time.Sleep(64 * time.Millisecond)
-
+func checkPowExchangeForNodeZero(t *testing.T) {
 	cnt := 0
 	for i, node := range nodes {
 		for peer := range node.shh.peers {
 			if peer.peer.ID() == discover.PubkeyID(&nodes[0].id.PublicKey) {
 				cnt++
-				if peer.powRequirement != pow {
+				if peer.powRequirement != masterPow {
 					t.Fatalf("node %d: failed to set the new pow requirement.", i)
 				}
 			}
 		}
 	}
-
 	if cnt == 0 {
 		t.Fatalf("no matching peers found.")
 	}
+}
+
+func checkPowExchange(t *testing.T) {
+	for i, node := range nodes {
+		for peer := range node.shh.peers {
+			if peer.peer.ID() != discover.PubkeyID(&nodes[0].id.PublicKey) {
+				if peer.powRequirement != masterPow {
+					t.Fatalf("node %d: failed to exchange pow requirement in round %d; expected %f, got %f",
+						i, round, masterPow, peer.powRequirement)
+				}
+			}
+		}
+	}
+}
+
+func checkBloomFilterExchange(t *testing.T) {
+	for i, node := range nodes {
+		for peer := range node.shh.peers {
+			if !isBloomFilterEqual(peer.bloomFilter, masterBloomFilter) {
+				t.Fatalf("node %d: failed to exchange bloom filter requirement in round %d. \n%x expected \n%x got",
+					i, round, masterBloomFilter, peer.bloomFilter)
+			}
+		}
+	}
+}
+
+func isBloomFilterEqual(a, b []byte) bool {
+	for i := 0; i < bloomFilterSize; i++ {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
 }

--- a/whisper/whisperv6/peer_test.go
+++ b/whisper/whisperv6/peer_test.go
@@ -428,12 +428,3 @@ func checkBloomFilterExchange(t *testing.T) {
 		}
 	}
 }
-
-func isBloomFilterEqual(a, b []byte) bool {
-	for i := 0; i < bloomFilterSize; i++ {
-		if a[i] != b[i] {
-			return false
-		}
-	}
-	return true
-}

--- a/whisper/whisperv6/peer_test.go
+++ b/whisper/whisperv6/peer_test.go
@@ -27,6 +27,7 @@ import (
 	"time"
 
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/p2p"
 	"github.com/ethereum/go-ethereum/p2p/discover"
@@ -85,7 +86,7 @@ type TestNode struct {
 
 var result TestData
 var nodes [NumNodes]*TestNode
-var sharedKey []byte = []byte("some arbitrary data here")
+var sharedKey []byte = hexutil.MustDecode("0x03ca634cae0d49acb401d8a4c6b6fe8c55b70d115bf400769cc1400f3258cd31")
 var sharedTopic TopicType = TopicType{0xF, 0x1, 0x2, 0}
 var expectedMessage []byte = []byte("per rectum ad astra")
 var masterBloomFilter []byte

--- a/whisper/whisperv6/whisper.go
+++ b/whisper/whisperv6/whisper.go
@@ -1067,12 +1067,3 @@ func addBloom(a, b []byte) []byte {
 	}
 	return c
 }
-
-func isBloomFilterEqual(a, b []byte) bool {
-	for i := 0; i < bloomFilterSize; i++ {
-		if a[i] != b[i] {
-			return false
-		}
-	}
-	return true
-}

--- a/whisper/whisperv6/whisper.go
+++ b/whisper/whisperv6/whisper.go
@@ -48,10 +48,12 @@ type Statistics struct {
 }
 
 const (
-	minPowIdx      = iota // Minimal PoW required by the whisper node
-	maxMsgSizeIdx  = iota // Maximal message length allowed by the whisper node
-	overflowIdx    = iota // Indicator of message queue overflow
-	bloomFilterIdx = iota // Bloom filter for topics of interest for this node
+	maxMsgSizeIdx           = iota // Maximal message length allowed by the whisper node
+	overflowIdx             = iota // Indicator of message queue overflow
+	minPowIdx               = iota // Minimal PoW required by the whisper node
+	minPowToleranceIdx      = iota // Minimal PoW tolerated by the whisper node for a limited time
+	bloomFilterIdx          = iota // Bloom filter for topics of interest for this node
+	bloomFilterToleranceIdx = iota // Bloom filter tolerated by the whisper node for a limited time
 )
 
 // Whisper represents a dark communication interface through the Ethereum
@@ -77,7 +79,7 @@ type Whisper struct {
 
 	settings syncmap.Map // holds configuration settings that can be dynamically changed
 
-	reactionAllowance int // maximum time in seconds allowed to process the whisper-related messages
+	syncAllowance int // maximum time in seconds allowed to process the whisper-related messages
 
 	statsMu sync.Mutex // guard stats
 	stats   Statistics // Statistics of whisper node
@@ -92,15 +94,15 @@ func New(cfg *Config) *Whisper {
 	}
 
 	whisper := &Whisper{
-		privateKeys:       make(map[string]*ecdsa.PrivateKey),
-		symKeys:           make(map[string][]byte),
-		envelopes:         make(map[common.Hash]*Envelope),
-		expirations:       make(map[uint32]*set.SetNonTS),
-		peers:             make(map[*Peer]struct{}),
-		messageQueue:      make(chan *Envelope, messageQueueLimit),
-		p2pMsgQueue:       make(chan *Envelope, messageQueueLimit),
-		quit:              make(chan struct{}),
-		reactionAllowance: SynchAllowance,
+		privateKeys:   make(map[string]*ecdsa.PrivateKey),
+		symKeys:       make(map[string][]byte),
+		envelopes:     make(map[common.Hash]*Envelope),
+		expirations:   make(map[uint32]*set.SetNonTS),
+		peers:         make(map[*Peer]struct{}),
+		messageQueue:  make(chan *Envelope, messageQueueLimit),
+		p2pMsgQueue:   make(chan *Envelope, messageQueueLimit),
+		quit:          make(chan struct{}),
+		syncAllowance: DefaultSyncAllowance,
 	}
 
 	whisper.filters = NewFilters(whisper)
@@ -129,11 +131,33 @@ func New(cfg *Config) *Whisper {
 
 func (w *Whisper) MinPow() float64 {
 	val, _ := w.settings.Load(minPowIdx)
+	if val == nil {
+		return DefaultMinimumPoW
+	}
+	return val.(float64)
+}
+
+func (w *Whisper) MinPowTolerance() float64 {
+	val, _ := w.settings.Load(minPowToleranceIdx)
+	if val == nil {
+		return DefaultMinimumPoW
+	}
 	return val.(float64)
 }
 
 func (w *Whisper) BloomFilter() []byte {
 	val, _ := w.settings.Load(bloomFilterIdx)
+	if val == nil {
+		return nil
+	}
+	return val.([]byte)
+}
+
+func (w *Whisper) BloomFilterTolerance() []byte {
+	val, _ := w.settings.Load(bloomFilterToleranceIdx)
+	if val == nil {
+		return nil
+	}
 	return val.([]byte)
 }
 
@@ -192,12 +216,13 @@ func (w *Whisper) SetBloomFilter(bloom []byte) error {
 		return fmt.Errorf("invalid bloom filter size: %d", len(bloom))
 	}
 
+	w.settings.Store(bloomFilterIdx, bloom)
 	w.notifyPeersAboutBloomFilterChange(bloom)
 
 	go func() {
 		// allow some time before all the peers have processed the notification
-		time.Sleep(time.Duration(w.reactionAllowance) * time.Second)
-		w.settings.Store(bloomFilterIdx, bloom)
+		time.Sleep(time.Duration(w.syncAllowance) * time.Second)
+		w.settings.Store(bloomFilterToleranceIdx, bloom)
 	}()
 
 	return nil
@@ -209,12 +234,13 @@ func (w *Whisper) SetMinimumPoW(val float64) error {
 		return fmt.Errorf("invalid PoW: %f", val)
 	}
 
+	w.settings.Store(minPowIdx, val)
 	w.notifyPeersAboutPowRequirementChange(val)
 
 	go func() {
 		// allow some time before all the peers have processed the notification
-		time.Sleep(time.Duration(w.reactionAllowance) * time.Second)
-		w.settings.Store(minPowIdx, val)
+		time.Sleep(time.Duration(w.syncAllowance) * time.Second)
+		w.settings.Store(minPowToleranceIdx, val)
 	}()
 
 	return nil
@@ -222,14 +248,16 @@ func (w *Whisper) SetMinimumPoW(val float64) error {
 
 // SetMinimumPoW sets the minimal PoW in test environment
 func (w *Whisper) SetMinimumPowTest(val float64) {
-	w.notifyPeersAboutPowRequirementChange(val)
 	w.settings.Store(minPowIdx, val)
+	w.notifyPeersAboutPowRequirementChange(val)
+	w.settings.Store(minPowToleranceIdx, val)
 }
 
 // SetBloomFilterTest sets the Bloom Filter in test environment
 func (w *Whisper) SetBloomFilterTest(bloom []byte) {
+	w.settings.Store(bloomFilterIdx, bloom)
 	w.notifyPeersAboutBloomFilterChange(bloom)
-	w.settings.Store(minPowIdx, bloom)
+	w.settings.Store(bloomFilterToleranceIdx, bloom)
 }
 
 func (w *Whisper) notifyPeersAboutPowRequirementChange(pow float64) {
@@ -505,7 +533,28 @@ func (w *Whisper) GetSymKey(id string) ([]byte, error) {
 // Subscribe installs a new message handler used for filtering, decrypting
 // and subsequent storing of incoming messages.
 func (w *Whisper) Subscribe(f *Filter) (string, error) {
-	return w.filters.Install(f)
+	s, err := w.filters.Install(f)
+	if err == nil {
+		w.updateBloomFilter(f)
+	}
+	return s, err
+}
+
+// updateBloomFilter recalculates the new value of bloom filter,
+// and informs the peers if necessary.
+func (w *Whisper) updateBloomFilter(f *Filter) {
+	aggregate := make([]byte, bloomFilterSize)
+	for _, t := range f.Topics {
+		top := BytesToTopic(t)
+		b := TopicToBloom(top)
+		aggregate = addBloom(aggregate, b)
+	}
+
+	if !bloomFilterMatch(w.BloomFilter(), aggregate) {
+		// existing bloom filter must be updated
+		aggregate = addBloom(w.BloomFilter(), aggregate)
+		w.SetBloomFilter(aggregate)
+	}
 }
 
 // GetFilter returns the filter by id.
@@ -693,7 +742,7 @@ func (wh *Whisper) add(envelope *Envelope) (bool, error) {
 	sent := envelope.Expiry - envelope.TTL
 
 	if sent > now {
-		if sent-SynchAllowance > now {
+		if sent-DefaultSyncAllowance > now {
 			return false, fmt.Errorf("envelope created in the future [%x]", envelope.Hash())
 		} else {
 			// recalculate PoW, adjusted for the time difference, plus one second for latency
@@ -702,7 +751,7 @@ func (wh *Whisper) add(envelope *Envelope) (bool, error) {
 	}
 
 	if envelope.Expiry < now {
-		if envelope.Expiry+SynchAllowance*2 < now {
+		if envelope.Expiry+DefaultSyncAllowance*2 < now {
 			return false, fmt.Errorf("very old message")
 		} else {
 			log.Debug("expired envelope dropped", "hash", envelope.Hash().Hex())
@@ -715,15 +764,23 @@ func (wh *Whisper) add(envelope *Envelope) (bool, error) {
 	}
 
 	if envelope.PoW() < wh.MinPow() {
-		log.Debug("envelope with low PoW dropped", "PoW", envelope.PoW(), "hash", envelope.Hash().Hex())
-		return false, nil // drop envelope without error for now
+		// maybe the value was recently changed, and the peers did not adjust yet.
+		// some tolerance might be still allowed for a short period of adjustment time.
+		if envelope.PoW() < wh.MinPowTolerance() {
+			log.Debug("envelope with low PoW dropped", "PoW", envelope.PoW(), "hash", envelope.Hash().Hex())
+			return false, nil // drop envelope without error for now
+		}
 
 		// once the status message includes the PoW requirement, an error should be returned here:
 		//return false, fmt.Errorf("envelope with low PoW received: PoW=%f, hash=[%v]", envelope.PoW(), envelope.Hash().Hex())
 	}
 
 	if !bloomFilterMatch(wh.BloomFilter(), envelope.Bloom()) {
-		return false, fmt.Errorf("envelope does not match bloom filter, hash=[%v]", envelope.Hash().Hex())
+		// maybe the value was recently changed, and the peers did not adjust yet.
+		// some tolerance might be still allowed for a short period of adjustment time.
+		if !bloomFilterMatch(wh.BloomFilterTolerance(), envelope.Bloom()) {
+			return false, fmt.Errorf("envelope does not match bloom filter, hash=[%v]", envelope.Hash().Hex())
+		}
 	}
 
 	hash := envelope.Hash()
@@ -963,6 +1020,9 @@ func GenerateRandomID() (id string, err error) {
 }
 
 func isFulNode(bloom []byte) bool {
+	if bloom == nil {
+		return true
+	}
 	for _, b := range bloom {
 		if b != 255 {
 			return false
@@ -972,6 +1032,11 @@ func isFulNode(bloom []byte) bool {
 }
 
 func bloomFilterMatch(filter, sample []byte) bool {
+	if filter == nil {
+		// full node, accepts all messages
+		return true
+	}
+
 	for i := 0; i < bloomFilterSize; i++ {
 		f := filter[i]
 		s := sample[i]
@@ -981,4 +1046,12 @@ func bloomFilterMatch(filter, sample []byte) bool {
 	}
 
 	return true
+}
+
+func addBloom(a, b []byte) []byte {
+	c := make([]byte, bloomFilterSize)
+	for i := 0; i < bloomFilterSize; i++ {
+		c[i] = a[i] | b[i]
+	}
+	return c
 }

--- a/whisper/whisperv6/whisper.go
+++ b/whisper/whisperv6/whisper.go
@@ -984,7 +984,13 @@ func validatePrivateKey(k *ecdsa.PrivateKey) bool {
 // validateSymmetricKey returns false if the key contains all zeros,
 // which is a simplest and the most common bug.
 func validateRandomData(k []byte, expectedSize int) bool {
-	return len(k) == expectedSize && !containsOnlyZeros(k)
+	if len(k) != expectedSize {
+		return false
+	}
+	if expectedSize > 4 && containsOnlyZeros(k) {
+		return false
+	}
+	return true
 }
 
 // containsOnlyZeros checks if the data contain only zeros.

--- a/whisper/whisperv6/whisper_test.go
+++ b/whisper/whisperv6/whisper_test.go
@@ -81,7 +81,7 @@ func TestWhisperBasic(t *testing.T) {
 	}
 
 	derived := pbkdf2.Key([]byte(peerID), nil, 65356, aesKeyLength, sha256.New)
-	if !validateSymmetricKey(derived) {
+	if !validateRandomData(derived, aesKeyLength) {
 		t.Fatalf("failed validateSymmetricKey with param = %v.", derived)
 	}
 	if containsOnlyZeros(derived) {
@@ -448,23 +448,11 @@ func TestWhisperSymKeyManagement(t *testing.T) {
 	if !w.HasSymKey(id2) {
 		t.Fatalf("HasSymKey(id2) failed.")
 	}
-	if k1 == nil {
-		t.Fatalf("k1 does not exist.")
-	}
-	if k2 == nil {
-		t.Fatalf("k2 does not exist.")
+	if !validateRandomData(k2, aesKeyLength) {
+		t.Fatalf("key validation failed.")
 	}
 	if !bytes.Equal(k1, k2) {
 		t.Fatalf("k1 != k2.")
-	}
-	if len(k1) != aesKeyLength {
-		t.Fatalf("wrong length of k1.")
-	}
-	if len(k2) != aesKeyLength {
-		t.Fatalf("wrong length of k2.")
-	}
-	if !validateSymmetricKey(k2) {
-		t.Fatalf("key validation failed.")
 	}
 }
 


### PR DESCRIPTION
Now message contains the following fields: Flags (1 byte), Auxiliary Field containing the size of the payload (up to 4 bytes), Payload, Padding, Signature (65 bytes). In case of symmetric encryption, AES nonce is appended to the encrypted message, but it is not considered to be one of the fields. 

The padding does not take into account the AES nonce, because symmetric and asymmetric encryption have different fingerprint anyway. It's not worth to complicate the crypto logic, if symmetric and asymmetric messages are still to be easily distinguished. Readability is much more important in this case.