### PR TITLE
cmd/geth: user friendly light miner error

### DIFF
--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -278,9 +278,12 @@ func startNode(ctx *cli.Context, stack *node.Node) {
 	// Start auxiliary services if enabled
 	if ctx.GlobalBool(utils.MiningEnabledFlag.Name) || ctx.GlobalBool(utils.DeveloperFlag.Name) {
 		// Mining only makes sense if a full Ethereum node is running
+		if ctx.GlobalBool(utils.LightModeFlag.Name) || ctx.GlobalString(utils.SyncModeFlag.Name) == "light" {
+			utils.Fatalf("Light clients do not support mining")
+		}
 		var ethereum *eth.Ethereum
 		if err := stack.Service(&ethereum); err != nil {
-			utils.Fatalf("ethereum service not running: %v", err)
+			utils.Fatalf("Ethereum service not running: %v", err)
 		}
 		// Use a reduced number of threads if requested
 		if threads := ctx.GlobalInt(utils.MinerThreadsFlag.Name); threads > 0 {


### PR DESCRIPTION
Fixes https://github.com/ethereum/go-ethereum/issues/15860.

When starting the miner in light client mode, it currently fails with:

```
$ geth --light --mine
[...]
Fatal: ethereum service not running: unknown service
```

This doesn't really help users understand what the problem is, so this PR expands on the error by explicitly stating that light clients cannot mine:

```
$ geth --light --mine
[...]
Fatal: Light clients do not support mining
```