### PR TITLE
miner: avoid unnecessary work

### DIFF
--- a/core/gaspool.go
+++ b/core/gaspool.go
@@ -44,6 +44,11 @@ func (gp *GasPool) SubGas(amount uint64) error {
 	return nil
 }
 
+// Gas returns the amount of gas remaining in the pool.
+func (gp *GasPool) Gas() uint64 {
+	return uint64(*gp)
+}
+
 func (gp *GasPool) String() string {
 	return fmt.Sprintf("%d", *gp)
 }

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -512,6 +512,11 @@ func (env *Work) commitTransactions(mux *event.TypeMux, txs *types.TransactionsB
 	var coalescedLogs []*types.Log
 
 	for {
+		// If we don't have enough gas for any further transactions then we're done
+		if gp.Gas() < params.TxGas {
+			log.Trace("Not enough gas for further transactions", "gp", gp)
+			break
+		}
 		// Retrieve the next transaction and abort if all done
 		tx := txs.Peek()
 		if tx == nil {


### PR DESCRIPTION
At current the miner worker's `commitTransactions()` attempts to add every pending transaction from a transaction set in to the block.  If a node has hundreds or thousands of pending transactions then the block quickly fills up but the loop continues to set up and run each of the remaining transactions even though they are guaranteed to fail.

This patch adds a condition to the loop such that if the remaining gas in the pool falls below the base transaction cost i.e. is out of space then it breaks out of the loop, saving CPU and memory.