### PR TITLE
ethclient: added BlockNumber

### DIFF
--- a/ethclient/ethclient.go
+++ b/ethclient/ethclient.go
@@ -382,6 +382,13 @@ func (ec *Client) PendingBalanceAt(ctx context.Context, account common.Address) 
 	return (*big.Int)(&result), err
 }
 
+// BlockNumber returns the number of most recent block.
+func (ec *Client) BlockNumber(ctx context.Context) (*big.Int, error) {
+	var result hexutil.Big
+	err := ec.c.CallContext(ctx, &result, "eth_blockNumber")
+	return (*big.Int)(&result), err
+}
+
 // PendingStorageAt returns the value of key in the contract storage of the given account in the pending state.
 func (ec *Client) PendingStorageAt(ctx context.Context, account common.Address, key common.Hash) ([]byte, error) {
 	var result hexutil.Bytes


### PR DESCRIPTION
Implementing: `eth_blockNumber`

Returns the number of most recent block.

[JSONRPC](https://github.com/ethereum/wiki/wiki/JSON-RPC#eth_blocknumber) documentation link.