### PR TITLE
accounts, cmd, node: Added "--stdoutkeystore" parameter to "account new"

### DIFF
--- a/accounts/keystore/key.go
+++ b/accounts/keystore/key.go
@@ -53,6 +53,8 @@ type keyStore interface {
 	GetKey(addr common.Address, filename string, auth string) (*Key, error)
 	// Writes and encrypts the key.
 	StoreKey(filename string, k *Key, auth string) error
+	// Creates and encrypts the key and returns in JSON
+	CreateKeyStore(k *Key, auth string) ([]byte, error)
 	// Joins filename with the key directory unless it is already absolute.
 	JoinPath(filename string) string
 }
@@ -177,6 +179,19 @@ func storeNewKey(ks keyStore, rand io.Reader, auth string) (*Key, accounts.Accou
 		return nil, a, err
 	}
 	return key, a, err
+}
+
+func newKeyStore(ks keyStore, rand io.Reader, auth string) (*Key, []byte, error) {
+	key, err := newKey(rand)
+	if err != nil {
+		return nil, []byte{}, err
+	}
+	json, err := ks.CreateKeyStore(key, auth)
+	if err != nil {
+		zeroKey(key.PrivateKey)
+		return nil, []byte{}, err
+	}
+	return key, json, err
 }
 
 func writeKeyFile(file string, content []byte) error {

--- a/accounts/keystore/keystore_passphrase.go
+++ b/accounts/keystore/keystore_passphrase.go
@@ -98,11 +98,25 @@ func StoreKey(dir, auth string, scryptN, scryptP int) (common.Address, error) {
 }
 
 func (ks keyStorePassphrase) StoreKey(filename string, key *Key, auth string) error {
-	keyjson, err := EncryptKey(key, auth, ks.scryptN, ks.scryptP)
+	keyjson, err := ks.CreateKeyStore(key, auth)
 	if err != nil {
 		return err
 	}
 	return writeKeyFile(filename, keyjson)
+}
+
+// CreateKeyStore generates a key, encrypts with 'auth'
+func CreateKeyStore(auth string, scryptN, scryptP int) ([]byte, error) {
+	_, json, err := newKeyStore(&keyStorePassphrase{scryptN: scryptN, scryptP: scryptP}, crand.Reader, auth)
+	return json, err
+}
+
+func (ks keyStorePassphrase) CreateKeyStore(key *Key, auth string) ([]byte, error) {
+	keyjson, err := EncryptKey(key, auth, ks.scryptN, ks.scryptP)
+	if err != nil {
+		return []byte{}, err
+	}
+	return keyjson, nil
 }
 
 func (ks keyStorePassphrase) JoinPath(filename string) string {

--- a/accounts/keystore/keystore_plain.go
+++ b/accounts/keystore/keystore_plain.go
@@ -53,6 +53,14 @@ func (ks keyStorePlain) StoreKey(filename string, key *Key, auth string) error {
 	return writeKeyFile(filename, content)
 }
 
+func (ks keyStorePlain) CreateKeyStore(key *Key, auth string) ([]byte, error) {
+	content, err := json.Marshal(key)
+	if err != nil {
+		return []byte{}, err
+	}
+	return content, nil
+}
+
 func (ks keyStorePlain) JoinPath(filename string) string {
 	if filepath.IsAbs(filename) {
 		return filename

--- a/cmd/geth/accountcmd.go
+++ b/cmd/geth/accountcmd.go
@@ -110,6 +110,7 @@ Print a short summary of all accounts`,
 					utils.KeyStoreDirFlag,
 					utils.PasswordFileFlag,
 					utils.LightKDFFlag,
+					utils.WriteKeyStoreOnlyToStdout,
 				},
 				Description: `
     geth account new
@@ -307,12 +308,20 @@ func accountCreate(ctx *cli.Context) error {
 
 	password := getPassPhrase("Your new account is locked with a password. Please give a password. Do not forget this password.", true, 0, utils.MakePasswordList(ctx))
 
-	address, err := keystore.StoreKey(keydir, password, scryptN, scryptP)
-
-	if err != nil {
-		utils.Fatalf("Failed to create account: %v", err)
+	if ctx.GlobalBool(utils.WriteKeyStoreOnlyToStdout.Name) {
+		keystore, err := keystore.CreateKeyStore(password, scryptN, scryptP)
+		if err != nil {
+			utils.Fatalf("Failed to create account: %v", err)
+		}
+		fmt.Printf("%s\n", keystore)
+	} else {
+		address, err := keystore.StoreKey(keydir, password, scryptN, scryptP)
+		if err != nil {
+			utils.Fatalf("Failed to create account: %v", err)
+		}
+		fmt.Printf("Address: {%x}\n", address)
 	}
-	fmt.Printf("Address: {%x}\n", address)
+
 	return nil
 }
 

--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -60,6 +60,7 @@ var (
 		utils.BootnodesV5Flag,
 		utils.DataDirFlag,
 		utils.KeyStoreDirFlag,
+		utils.WriteKeyStoreOnlyToStdout,
 		utils.NoUSBFlag,
 		utils.DashboardEnabledFlag,
 		utils.DashboardAddrFlag,

--- a/cmd/geth/usage.go
+++ b/cmd/geth/usage.go
@@ -135,6 +135,7 @@ var AppHelpFlagGroups = []flagGroup{
 		Flags: []cli.Flag{
 			utils.UnlockedAccountFlag,
 			utils.PasswordFileFlag,
+			utils.WriteKeyStoreOnlyToStdout,
 		},
 	},
 	{

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -122,6 +122,10 @@ var (
 		Name:  "keystore",
 		Usage: "Directory for the keystore (default = inside the datadir)",
 	}
+	WriteKeyStoreOnlyToStdout = cli.BoolFlag{
+		Name:  "stdoutkeystore",
+		Usage: "Prevents writing keystore to file, instead outputs the keystore to standard output (stdout)",
+	}
 	NoUSBFlag = cli.BoolFlag{
 		Name:  "nousb",
 		Usage: "Disables monitoring for and managing USB hardware wallets",
@@ -857,6 +861,9 @@ func SetNodeConfig(ctx *cli.Context, cfg *node.Config) {
 
 	if ctx.GlobalIsSet(KeyStoreDirFlag.Name) {
 		cfg.KeyStoreDir = ctx.GlobalString(KeyStoreDirFlag.Name)
+	}
+	if ctx.GlobalIsSet(WriteKeyStoreOnlyToStdout.Name) {
+		cfg.WriteKeyStoreOnlyToStdout = ctx.GlobalBool(WriteKeyStoreOnlyToStdout.Name)
 	}
 	if ctx.GlobalIsSet(LightKDFFlag.Name) {
 		cfg.UseLightweightKDF = ctx.GlobalBool(LightKDFFlag.Name)

--- a/node/config.go
+++ b/node/config.go
@@ -78,6 +78,9 @@ type Config struct {
 	// is created by New and destroyed when the node is stopped.
 	KeyStoreDir string `toml:",omitempty"`
 
+	// Prevents writing keystore to file, instead outputs the keystore to standard output (stdout)
+	WriteKeyStoreOnlyToStdout bool `toml:",omitempty"`
+
 	// UseLightweightKDF lowers the memory and CPU requirements of the key store
 	// scrypt KDF at the expense of security.
 	UseLightweightKDF bool `toml:",omitempty"`


### PR DESCRIPTION
Added parameter to "account new" command to allow generating keystores in standard output (stdout).

When used this parameter ensures there is no I/O operations for keystore files. Useful when generating wallet addresses on the fly for a service.