### PR TITLE
ethkey: Added --stdoutkeystore parameter to avoid I/O operations

### DIFF
--- a/cmd/ethkey/README.md
+++ b/cmd/ethkey/README.md
@@ -13,6 +13,8 @@ If you want to use an existing private key to use in the keyfile, it can be
 specified by setting `--privatekey` with the location of the file containing the 
 private key.
 
+`--stdoutkeystore` option is available to avoid writing the keystore to file and
+instead output and entire contents of the keystore to standard output (stdout).
 
 ### `ethkey inspect <keyfile>`
 
@@ -39,3 +41,8 @@ For every command that uses a keyfile, you will be prompted to provide the
 passphrase for decrypting the keyfile.  To avoid this message, it is possible
 to pass the passphrase by using the `--passphrase` flag pointing to a file that
 contains the passphrase.
+
+## JSON
+
+For every command with output, the `--json` option is available to output JSON
+instead of human-readable format.

--- a/cmd/ethkey/README.md
+++ b/cmd/ethkey/README.md
@@ -39,7 +39,7 @@ It is possible to refer to a file containing the message.
 
 For every command that uses a keyfile, you will be prompted to provide the 
 passphrase for decrypting the keyfile.  To avoid this message, it is possible
-to pass the passphrase by using the `--passphrase` flag pointing to a file that
+to pass the passphrase by using the `--passwordfile` flag pointing to a file that
 contains the passphrase.
 
 ## JSON


### PR DESCRIPTION
Added "--stdoutkeystore" parameter to "ethkey generate" to allow generating keystores in standard output (stdout).

When used this parameter ensures there is no I/O operations for keystore files. Useful when generating wallet addresses on the fly for a service.