### PR TITLE
core/types: add Transaction.From()

### DIFF
--- a/core/types/transaction.go
+++ b/core/types/transaction.go
@@ -185,6 +185,20 @@ func (tx *Transaction) Value() *big.Int    { return new(big.Int).Set(tx.data.Amo
 func (tx *Transaction) Nonce() uint64      { return tx.data.AccountNonce }
 func (tx *Transaction) CheckNonce() bool   { return true }
 
+// From returns the sender address of the transaction.
+// It returns nil if the transaction is unsigned.
+func (tx *Transaction) From() *common.Address {
+	if tx.data.V == nil {
+		return nil
+	}
+	signer := deriveSigner(tx.data.V)
+	if from, err := Sender(signer, tx); err != nil {
+		return nil
+	} else {
+		return &from
+	}
+}
+
 // To returns the recipient address of the transaction.
 // It returns nil if the transaction is a contract creation.
 func (tx *Transaction) To() *common.Address {

--- a/core/types/transaction_test.go
+++ b/core/types/transaction_test.go
@@ -93,12 +93,12 @@ func TestRecipientEmpty(t *testing.T) {
 		t.FailNow()
 	}
 
-	from, err := Sender(HomesteadSigner{}, tx)
-	if err != nil {
-		t.Error(err)
+	from := tx.From()
+	if from == nil {
+		t.Error("derived address not present")
 		t.FailNow()
 	}
-	if addr != from {
+	if addr != *from {
 		t.Error("derived address doesn't match")
 	}
 }
@@ -112,13 +112,13 @@ func TestRecipientNormal(t *testing.T) {
 		t.FailNow()
 	}
 
-	from, err := Sender(HomesteadSigner{}, tx)
-	if err != nil {
-		t.Error(err)
+	from := tx.From()
+	if from == nil {
+		t.Error("derived address not present")
 		t.FailNow()
 	}
 
-	if addr != from {
+	if addr != *from {
 		t.Error("derived address doesn't match")
 	}
 }
@@ -155,11 +155,19 @@ func TestTransactionPriceNonceSort(t *testing.T) {
 		t.Errorf("expected %d transactions, found %d", 25*25, len(txs))
 	}
 	for i, txi := range txs {
-		fromi, _ := Sender(signer, txi)
+		fromi := txi.From()
+		if fromi == nil {
+			t.Error("derived address not present")
+			t.FailNow()
+		}
 
 		// Make sure the nonce order is valid
 		for j, txj := range txs[i+1:] {
-			fromj, _ := Sender(signer, txj)
+			fromj := txj.From()
+			if fromj == nil {
+				t.Error("derived address not present")
+				t.FailNow()
+			}
 
 			if fromi == fromj && txi.Nonce() > txj.Nonce() {
 				t.Errorf("invalid nonce ordering: tx #%d (A=%x N=%v) < tx #%d (A=%x N=%v)", i, fromi[:4], txi.Nonce(), i+j, fromj[:4], txj.Nonce())
@@ -168,13 +176,13 @@ func TestTransactionPriceNonceSort(t *testing.T) {
 		// Find the previous and next nonce of this account
 		prev, next := i-1, i+1
 		for j := i - 1; j >= 0; j-- {
-			if fromj, _ := Sender(signer, txs[j]); fromi == fromj {
+			if fromj, _ := Sender(signer, txs[j]); *fromi == fromj {
 				prev = j
 				break
 			}
 		}
 		for j := i + 1; j < len(txs); j++ {
-			if fromj, _ := Sender(signer, txs[j]); fromi == fromj {
+			if fromj, _ := Sender(signer, txs[j]); *fromi == fromj {
 				next = j
 				break
 			}


### PR DESCRIPTION
This patch adds a function with the signature `(tx *Transaction) From() *common.Address`

It returns `nil` if the from address of the transaction cannot be obtained.

Although `transaction_signing.go` has a `Sender()` function it is not part of `Transaction` and it also requires the `Signer`, which requires internal functions to calculate.  `From()` obtains the signer and then calls `Sender()` to provide a suitable response.

The patch also changes some of the tests in `transaction_test.go` to use `From()` rather than `Sender()` to add it to the test suite.