### PR TITLE
p2p/discv5: fix topic register panic at shutdown

### DIFF
--- a/p2p/discv5/ticket.go
+++ b/p2p/discv5/ticket.go
@@ -350,7 +350,7 @@ func (s *ticketStore) nextFilteredTicket() (*ticketRef, time.Duration) {
 
 		regTime := now + mclock.AbsTime(wait)
 		topic := ticket.t.topics[ticket.idx]
-		if regTime >= s.tickets[topic].nextReg {
+		if s.tickets[topic] != nil && regTime >= s.tickets[topic].nextReg {
 			return ticket, wait
 		}
 		s.removeTicketRef(*ticket)


### PR DESCRIPTION
This PR fixes a panic in nextFilteredTicket that was caused by removeRegisterTopic removing a topic from s.tickets and then nextRegisterableTicket() still returning s.nextTicketCached that referred to that topic.
```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x10 pc=0x9b3208]

goroutine 91 [running]:
github.com/ethereum/go-ethereum/p2p/discv5.(*ticketStore).nextFilteredTicket(0xc42045e460, 0xc44bb7e360, 0xc44bb7e360)
	/home/fefe/go/src/github.com/ethereum/go-ethereum/p2p/discv5/ticket.go:353 +0x228
github.com/ethereum/go-ethereum/p2p/discv5.(*Network).loop.func2()
	/home/fefe/go/src/github.com/ethereum/go-ethereum/p2p/discv5/net.go:383 +0x50
github.com/ethereum/go-ethereum/p2p/discv5.(*Network).loop(0xc423b10200)
	/home/fefe/go/src/github.com/ethereum/go-ethereum/p2p/discv5/net.go:414 +0x354
created by github.com/ethereum/go-ethereum/p2p/discv5.newNetwork
	/home/fefe/go/src/github.com/ethereum/go-ethereum/p2p/discv5/net.go:169 +0x82b
```