### PR TITLE
p2p/discv5: logs info about discv5 node info at bind time

### DIFF
--- a/p2p/discv5/udp.go
+++ b/p2p/discv5/udp.go
@@ -247,6 +247,7 @@ func ListenUDP(priv *ecdsa.PrivateKey, conn conn, realaddr *net.UDPAddr, nodeDBP
 	if err != nil {
 		return nil, err
 	}
+	log.Info("UDP listener up", "net", net.tab.self)
 	transport.net = net
 	go transport.readLoop()
 	return net, nil


### PR DESCRIPTION
When `-v5` is specified, the node does not output node-info at startup. 

The following was show (not `-v5`) even before this PR:
```
#build/bin/bootnode -nodekeyhex 1212121212121212121212121212121212121212121212121212121212121212
INFO [01-23|08:51:33] UDP listener up                          self=enode://6360e856310ce5d294e8be33fc807077dc56ac80d95d9cd4ddbd21325eff73f7eb1c2784a65901538479361e94c0a2597973adef0836a6a7eddf50b7997c88a3@[::]:30301
``` 
With this PR, `-v5` behaves similarly:
```
#build/bin/bootnode -v5 -nodekeyhex 1212121212121212121212121212121212121212121212121212121212121212
INFO [01-23|08:50:51] UDP listener up                          net=enode://6360e856310ce5d294e8be33fc807077dc56ac80d95d9cd4ddbd21325eff73f7eb1c2784a65901538479361e94c0a2597973adef0836a6a7eddf50b7997c88a3@[::]:30301

```
