### PR TITLE
les: fix TxStatus message format

### DIFF
--- a/les/handler.go
+++ b/les/handler.go
@@ -1014,7 +1014,7 @@ func (pm *ProtocolManager) handleMsg(p *peer) error {
 		for i, stat := range stats {
 			if stat.Status == core.TxStatusUnknown {
 				if errs := pm.txpool.AddRemotes([]*types.Transaction{req.Txs[i]}); errs[0] != nil {
-					stats[i].Error = errs[0]
+					stats[i].Data = []byte(errs[0].Error())
 					continue
 				}
 				stats[i] = pm.txStatus([]common.Hash{hashes[i]})[0]
@@ -1055,7 +1055,7 @@ func (pm *ProtocolManager) handleMsg(p *peer) error {
 		p.Log().Trace("Received tx status response")
 		var resp struct {
 			ReqID, BV uint64
-			Status    []core.TxStatus
+			Status    []txStatus
 		}
 		if err := msg.Decode(&resp); err != nil {
 			return errResp(ErrDecode, "msg %v: %v", msg, err)
@@ -1116,7 +1116,7 @@ func (pm *ProtocolManager) txStatus(hashes []common.Hash) []txStatus {
 		if stat == core.TxStatusUnknown {
 			if block, number, index := core.GetTxLookupEntry(pm.chainDb, hashes[i]); block != (common.Hash{}) {
 				stats[i].Status = core.TxStatusIncluded
-				stats[i].Lookup = &core.TxLookupEntry{BlockHash: block, BlockIndex: number, Index: index}
+				stats[i].Data, _ = rlp.EncodeToBytes(core.TxLookupEntry{BlockHash: block, BlockIndex: number, Index: index})
 			}
 		}
 	}

--- a/les/peer.go
+++ b/les/peer.go
@@ -312,7 +312,7 @@ func (p *peer) RequestTxStatus(reqID, cost uint64, txHashes []common.Hash) error
 	return sendRequest(p.rw, GetTxStatusMsg, reqID, cost, txHashes)
 }
 
-// SendTxStatus sends a batch of transactions to be added to the remote transaction pool.
+// SendTxs sends a batch of transactions to be added to the remote transaction pool.
 func (p *peer) SendTxs(reqID, cost uint64, txs types.Transactions) error {
 	p.Log().Debug("Fetching batch of transactions", "count", len(txs))
 	switch p.version {

--- a/les/protocol.go
+++ b/les/protocol.go
@@ -224,6 +224,5 @@ type proofsData [][]rlp.RawValue
 
 type txStatus struct {
 	Status core.TxStatus
-	Lookup *core.TxLookupEntry
-	Error  error
+	Data   []byte // RLP-encoded core.TxLookupEntry or error string
 }


### PR DESCRIPTION
This PR fixes https://github.com/ethereum/go-ethereum/issues/15943
Problem: LES/2 clients dropped LES/2 servers after receiving a TxStatusMsg in response to SendTxsV2 because the message format of les.txStatus was broken (unable to RLP decode).
Solution: the message format has been changed back to the original format implemented in the original LES/2 PR before the cleanup. Changing the message format at this point is fine because it never worked until now anyway.