### PR TITLE
RPC: Dns rebind protection

### DIFF
--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -111,6 +111,7 @@ var (
 		utils.VMEnableDebugFlag,
 		utils.NetworkIdFlag,
 		utils.RPCCORSDomainFlag,
+		utils.RPCAllowedHostsFlag,
 		utils.EthStatsURLFlag,
 		utils.MetricsEnabledFlag,
 		utils.FakePoWFlag,

--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -111,7 +111,7 @@ var (
 		utils.VMEnableDebugFlag,
 		utils.NetworkIdFlag,
 		utils.RPCCORSDomainFlag,
-		utils.RPCAllowedHostsFlag,
+		utils.RPCVirtualHostsFlag,
 		utils.EthStatsURLFlag,
 		utils.MetricsEnabledFlag,
 		utils.FakePoWFlag,

--- a/cmd/geth/usage.go
+++ b/cmd/geth/usage.go
@@ -152,7 +152,7 @@ var AppHelpFlagGroups = []flagGroup{
 			utils.IPCDisabledFlag,
 			utils.IPCPathFlag,
 			utils.RPCCORSDomainFlag,
-			utils.RPCAllowedHostsFlag,
+			utils.RPCVirtualHostsFlag,
 			utils.JSpathFlag,
 			utils.ExecFlag,
 			utils.PreloadJSFlag,

--- a/cmd/geth/usage.go
+++ b/cmd/geth/usage.go
@@ -152,6 +152,7 @@ var AppHelpFlagGroups = []flagGroup{
 			utils.IPCDisabledFlag,
 			utils.IPCPathFlag,
 			utils.RPCCORSDomainFlag,
+			utils.RPCAllowedHostsFlag,
 			utils.JSpathFlag,
 			utils.ExecFlag,
 			utils.PreloadJSFlag,

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -385,7 +385,7 @@ var (
 	}
 	RPCAllowedHostsFlag = cli.StringFlag{
 		Name:  "rpcallowedhosts",
-		Usage: "Comma separated list of hostnames from which to accept requests (server enforced)",
+		Usage: "Comma separated list of hostnames from which to accept requests (server enforced). Set to * to disable this protection.",
 		Value: "localhost,127.0.0.1",
 	}
 	RPCApiFlag = cli.StringFlag{

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -383,10 +383,10 @@ var (
 		Usage: "Comma separated list of domains from which to accept cross origin requests (browser enforced)",
 		Value: "",
 	}
-	RPCAllowedHostsFlag = cli.StringFlag{
-		Name:  "rpcallowedhosts",
-		Usage: "Comma separated list of hostnames from which to accept requests (server enforced). Set to * to disable this protection.",
-		Value: "localhost,127.0.0.1",
+	RPCVirtualHostsFlag = cli.StringFlag{
+		Name:  "rpcvhosts",
+		Usage: "Comma separated list of virtual hostnames from which to accept requests (server enforced). Set to * to disable this protection.",
+		Value: "localhost",
 	}
 	RPCApiFlag = cli.StringFlag{
 		Name:  "rpcapi",
@@ -682,7 +682,7 @@ func setHTTP(ctx *cli.Context, cfg *node.Config) {
 		cfg.HTTPModules = splitAndTrim(ctx.GlobalString(RPCApiFlag.Name))
 	}
 
-	cfg.HTTPHosts = splitAndTrim(ctx.GlobalString(RPCAllowedHostsFlag.Name))
+	cfg.HTTPVirtualHostnames = splitAndTrim(ctx.GlobalString(RPCVirtualHostsFlag.Name))
 }
 
 // setWS creates the WebSocket RPC listener interface string from the set

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -385,7 +385,7 @@ var (
 	}
 	RPCVirtualHostsFlag = cli.StringFlag{
 		Name:  "rpcvhosts",
-		Usage: "Comma separated list of virtual hostnames from which to accept requests (server enforced). Set to * to disable this protection.",
+		Usage: "Comma separated list of virtual hostnames from which to accept requests (server enforced). Accepts '*' wildcard.",
 		Value: "localhost",
 	}
 	RPCApiFlag = cli.StringFlag{
@@ -682,7 +682,7 @@ func setHTTP(ctx *cli.Context, cfg *node.Config) {
 		cfg.HTTPModules = splitAndTrim(ctx.GlobalString(RPCApiFlag.Name))
 	}
 
-	cfg.HTTPVirtualHostnames = splitAndTrim(ctx.GlobalString(RPCVirtualHostsFlag.Name))
+	cfg.HTTPVirtualHosts = splitAndTrim(ctx.GlobalString(RPCVirtualHostsFlag.Name))
 }
 
 // setWS creates the WebSocket RPC listener interface string from the set

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -383,6 +383,11 @@ var (
 		Usage: "Comma separated list of domains from which to accept cross origin requests (browser enforced)",
 		Value: "",
 	}
+	RPCAllowedHostsFlag = cli.StringFlag{
+		Name:  "rpcallowedhosts",
+		Usage: "Comma separated list of hostnames from which to accept requests (server enforced)",
+		Value: "localhost,127.0.0.1",
+	}
 	RPCApiFlag = cli.StringFlag{
 		Name:  "rpcapi",
 		Usage: "API's offered over the HTTP-RPC interface",
@@ -676,6 +681,8 @@ func setHTTP(ctx *cli.Context, cfg *node.Config) {
 	if ctx.GlobalIsSet(RPCApiFlag.Name) {
 		cfg.HTTPModules = splitAndTrim(ctx.GlobalString(RPCApiFlag.Name))
 	}
+
+	cfg.HTTPHosts = splitAndTrim(ctx.GlobalString(RPCAllowedHostsFlag.Name))
 }
 
 // setWS creates the WebSocket RPC listener interface string from the set

--- a/node/api.go
+++ b/node/api.go
@@ -142,7 +142,7 @@ func (api *PrivateAdminAPI) StartRPC(host *string, port *int, cors *string, apis
 	}
 
 	allowedHosts := api.node.config.HTTPHosts
-	if hosts != nil{
+	if hosts != nil {
 		allowedHosts = nil
 		for _, host := range strings.Split(*host, ",") {
 			allowedHosts = append(allowedHosts, strings.TrimSpace(host))

--- a/node/api.go
+++ b/node/api.go
@@ -114,7 +114,7 @@ func (api *PrivateAdminAPI) PeerEvents(ctx context.Context) (*rpc.Subscription, 
 }
 
 // StartRPC starts the HTTP RPC API server.
-func (api *PrivateAdminAPI) StartRPC(host *string, port *int, cors *string, apis *string) (bool, error) {
+func (api *PrivateAdminAPI) StartRPC(host *string, port *int, cors *string, apis *string, hosts *string) (bool, error) {
 	api.node.lock.Lock()
 	defer api.node.lock.Unlock()
 
@@ -141,6 +141,14 @@ func (api *PrivateAdminAPI) StartRPC(host *string, port *int, cors *string, apis
 		}
 	}
 
+	allowedHosts := api.node.config.HTTPHosts
+	if hosts != nil{
+		allowedHosts = nil
+		for _, host := range strings.Split(*host, ",") {
+			allowedHosts = append(allowedHosts, strings.TrimSpace(host))
+		}
+	}
+
 	modules := api.node.httpWhitelist
 	if apis != nil {
 		modules = nil
@@ -149,7 +157,7 @@ func (api *PrivateAdminAPI) StartRPC(host *string, port *int, cors *string, apis
 		}
 	}
 
-	if err := api.node.startHTTP(fmt.Sprintf("%s:%d", *host, *port), api.node.rpcAPIs, modules, allowedOrigins); err != nil {
+	if err := api.node.startHTTP(fmt.Sprintf("%s:%d", *host, *port), api.node.rpcAPIs, modules, allowedOrigins, allowedHosts); err != nil {
 		return false, err
 	}
 	return true, nil

--- a/node/api.go
+++ b/node/api.go
@@ -141,7 +141,7 @@ func (api *PrivateAdminAPI) StartRPC(host *string, port *int, cors *string, apis
 		}
 	}
 
-	allowedHosts := api.node.config.HTTPHosts
+	allowedHosts := api.node.config.HTTPVirtualHostnames
 	if hosts != nil {
 		allowedHosts = nil
 		for _, host := range strings.Split(*host, ",") {

--- a/node/api.go
+++ b/node/api.go
@@ -114,7 +114,7 @@ func (api *PrivateAdminAPI) PeerEvents(ctx context.Context) (*rpc.Subscription, 
 }
 
 // StartRPC starts the HTTP RPC API server.
-func (api *PrivateAdminAPI) StartRPC(host *string, port *int, cors *string, apis *string, hosts *string) (bool, error) {
+func (api *PrivateAdminAPI) StartRPC(host *string, port *int, cors *string, apis *string, vhosts *string) (bool, error) {
 	api.node.lock.Lock()
 	defer api.node.lock.Unlock()
 
@@ -141,11 +141,11 @@ func (api *PrivateAdminAPI) StartRPC(host *string, port *int, cors *string, apis
 		}
 	}
 
-	allowedHosts := api.node.config.HTTPVirtualHostnames
-	if hosts != nil {
-		allowedHosts = nil
-		for _, host := range strings.Split(*host, ",") {
-			allowedHosts = append(allowedHosts, strings.TrimSpace(host))
+	allowedVHosts := api.node.config.HTTPVirtualHosts
+	if vhosts != nil {
+		allowedVHosts = nil
+		for _, vhost := range strings.Split(*host, ",") {
+			allowedVHosts = append(allowedVHosts, strings.TrimSpace(vhost))
 		}
 	}
 
@@ -157,7 +157,7 @@ func (api *PrivateAdminAPI) StartRPC(host *string, port *int, cors *string, apis
 		}
 	}
 
-	if err := api.node.startHTTP(fmt.Sprintf("%s:%d", *host, *port), api.node.rpcAPIs, modules, allowedOrigins, allowedHosts); err != nil {
+	if err := api.node.startHTTP(fmt.Sprintf("%s:%d", *host, *port), api.node.rpcAPIs, modules, allowedOrigins, allowedVHosts); err != nil {
 		return false, err
 	}
 	return true, nil

--- a/node/config.go
+++ b/node/config.go
@@ -105,13 +105,14 @@ type Config struct {
 	// useless for custom HTTP clients.
 	HTTPCors []string `toml:",omitempty"`
 
-	// HTTPHosts is the list of hosts which are allowed on incoming requests.
-	// This is by default {'localhost','127.0.0.1'}. Using this prevents attacks like
+	// HTTPVirtualHostnames is the list of virtual hostnames which are allowed on incoming requests.
+	// This is by default {'localhost'}. Using this prevents attacks like
 	// DNS rebinding, which bypasses SOP by simply masquerading as being within the same
 	// origin. These attacks do not utilize CORS, since they are not cross-domain.
 	// By explicitly checking the Host-header, the server will not allow requests
 	// made against the server with a malicious host domain.
-	HTTPHosts []string `toml:",omitempty"`
+	// Requests using ip address directly are not affected
+	HTTPVirtualHostnames []string `toml:",omitempty"`
 
 	// HTTPModules is a list of API modules to expose via the HTTP RPC interface.
 	// If the module list is empty, all RPC API endpoints designated public will be

--- a/node/config.go
+++ b/node/config.go
@@ -105,6 +105,14 @@ type Config struct {
 	// useless for custom HTTP clients.
 	HTTPCors []string `toml:",omitempty"`
 
+	// HTTPHosts is the list of hosts which are allowed on incoming requests.
+	// This is by default {'localhost','127.0.0.1'}. Using this prevents attacks like
+	// DNS rebinding, which bypasses SOP by simply masquerading as being within the same
+	// origin. These attacks do not utilize CORS, since they are not cross-domain.
+	// By explicitly checking the Host-header, the server will not allow requests
+	// made against the server with a malicious host domain.
+	HTTPHosts []string `toml:",omitempty"`
+
 	// HTTPModules is a list of API modules to expose via the HTTP RPC interface.
 	// If the module list is empty, all RPC API endpoints designated public will be
 	// exposed.

--- a/node/config.go
+++ b/node/config.go
@@ -105,14 +105,14 @@ type Config struct {
 	// useless for custom HTTP clients.
 	HTTPCors []string `toml:",omitempty"`
 
-	// HTTPVirtualHostnames is the list of virtual hostnames which are allowed on incoming requests.
+	// HTTPVirtualHosts is the list of virtual hostnames which are allowed on incoming requests.
 	// This is by default {'localhost'}. Using this prevents attacks like
 	// DNS rebinding, which bypasses SOP by simply masquerading as being within the same
 	// origin. These attacks do not utilize CORS, since they are not cross-domain.
 	// By explicitly checking the Host-header, the server will not allow requests
 	// made against the server with a malicious host domain.
 	// Requests using ip address directly are not affected
-	HTTPVirtualHostnames []string `toml:",omitempty"`
+	HTTPVirtualHosts []string `toml:",omitempty"`
 
 	// HTTPModules is a list of API modules to expose via the HTTP RPC interface.
 	// If the module list is empty, all RPC API endpoints designated public will be

--- a/node/config.go
+++ b/node/config.go
@@ -145,7 +145,7 @@ type Config struct {
 	WSExposeAll bool `toml:",omitempty"`
 
 	// Logger is a custom logger to use with the p2p.Server.
-	Logger log.Logger
+	Logger log.Logger `toml:",omitempty"`
 }
 
 // IPCEndpoint resolves an IPC endpoint based on a configured value, taking into

--- a/node/node.go
+++ b/node/node.go
@@ -263,7 +263,7 @@ func (n *Node) startRPC(services map[reflect.Type]Service) error {
 		n.stopInProc()
 		return err
 	}
-	if err := n.startHTTP(n.httpEndpoint, apis, n.config.HTTPModules, n.config.HTTPCors, n.config.HTTPHosts); err != nil {
+	if err := n.startHTTP(n.httpEndpoint, apis, n.config.HTTPModules, n.config.HTTPCors, n.config.HTTPVirtualHostnames); err != nil {
 		n.stopIPC()
 		n.stopInProc()
 		return err
@@ -395,7 +395,7 @@ func (n *Node) startHTTP(endpoint string, apis []rpc.API, modules []string, cors
 	}
 	go rpc.NewHTTPServer(cors, allowedHosts, handler).Serve(listener)
 	n.log.Info(fmt.Sprintf("HTTP endpoint opened: http://%s", endpoint))
-	n.log.Info(fmt.Sprintf("HTTP config: cors %v, hosts%v", cors, allowedHosts))
+	n.log.Info(fmt.Sprintf("HTTP config: cors %v, vhosts%v", cors, allowedHosts))
 	// All listeners booted successfully
 	n.httpEndpoint = endpoint
 	n.httpListener = listener

--- a/node/node.go
+++ b/node/node.go
@@ -263,7 +263,7 @@ func (n *Node) startRPC(services map[reflect.Type]Service) error {
 		n.stopInProc()
 		return err
 	}
-	if err := n.startHTTP(n.httpEndpoint, apis, n.config.HTTPModules, n.config.HTTPCors, n.config.HTTPVirtualHostnames); err != nil {
+	if err := n.startHTTP(n.httpEndpoint, apis, n.config.HTTPModules, n.config.HTTPCors, n.config.HTTPVirtualHosts); err != nil {
 		n.stopIPC()
 		n.stopInProc()
 		return err
@@ -365,7 +365,7 @@ func (n *Node) stopIPC() {
 }
 
 // startHTTP initializes and starts the HTTP RPC endpoint.
-func (n *Node) startHTTP(endpoint string, apis []rpc.API, modules []string, cors []string, allowedHosts []string) error {
+func (n *Node) startHTTP(endpoint string, apis []rpc.API, modules []string, cors []string, vhosts []string) error {
 	// Short circuit if the HTTP endpoint isn't being exposed
 	if endpoint == "" {
 		return nil
@@ -393,9 +393,9 @@ func (n *Node) startHTTP(endpoint string, apis []rpc.API, modules []string, cors
 	if listener, err = net.Listen("tcp", endpoint); err != nil {
 		return err
 	}
-	go rpc.NewHTTPServer(cors, allowedHosts, handler).Serve(listener)
+	go rpc.NewHTTPServer(cors, vhosts, handler).Serve(listener)
 	n.log.Info(fmt.Sprintf("HTTP endpoint opened: http://%s", endpoint))
-	n.log.Info(fmt.Sprintf("HTTP config: cors %v, vhosts%v", cors, allowedHosts))
+	n.log.Info(fmt.Sprintf("HTTP config: cors %v, vhosts%v", cors, vhosts))
 	// All listeners booted successfully
 	n.httpEndpoint = endpoint
 	n.httpListener = listener

--- a/node/node.go
+++ b/node/node.go
@@ -395,7 +395,7 @@ func (n *Node) startHTTP(endpoint string, apis []rpc.API, modules []string, cors
 	}
 	go rpc.NewHTTPServer(cors, allowedHosts, handler).Serve(listener)
 	n.log.Info(fmt.Sprintf("HTTP endpoint opened: http://%s", endpoint))
-	n.log.Info(fmt.Sprintf("HTTP config: cors %v, hosts%v", cors,allowedHosts))
+	n.log.Info(fmt.Sprintf("HTTP config: cors %v, hosts%v", cors, allowedHosts))
 	// All listeners booted successfully
 	n.httpEndpoint = endpoint
 	n.httpListener = listener

--- a/node/node.go
+++ b/node/node.go
@@ -287,7 +287,7 @@ func (n *Node) startInProc(apis []rpc.API) error {
 		if err := handler.RegisterName(api.Namespace, api.Service); err != nil {
 			return err
 		}
-		n.log.Debug(fmt.Sprintf("InProc registered %T under '%s'", api.Service, api.Namespace))
+		n.log.Debug("InProc registered", "service", api.Service, "namespace", api.Namespace)
 	}
 	n.inprocHandler = handler
 	return nil
@@ -313,7 +313,7 @@ func (n *Node) startIPC(apis []rpc.API) error {
 		if err := handler.RegisterName(api.Namespace, api.Service); err != nil {
 			return err
 		}
-		n.log.Debug(fmt.Sprintf("IPC registered %T under '%s'", api.Service, api.Namespace))
+		n.log.Debug("IPC registered", "service", api.Service, "namespace", api.Namespace)
 	}
 	// All APIs registered, start the IPC listener
 	var (
@@ -324,7 +324,7 @@ func (n *Node) startIPC(apis []rpc.API) error {
 		return err
 	}
 	go func() {
-		n.log.Info(fmt.Sprintf("IPC endpoint opened: %s", n.ipcEndpoint))
+		n.log.Info("IPC endpoint opened", "url", fmt.Sprintf("%s", n.ipcEndpoint))
 
 		for {
 			conn, err := listener.Accept()
@@ -337,7 +337,7 @@ func (n *Node) startIPC(apis []rpc.API) error {
 					return
 				}
 				// Not closed, just some error; report and continue
-				n.log.Error(fmt.Sprintf("IPC accept failed: %v", err))
+				n.log.Error("IPC accept failed", "err", err)
 				continue
 			}
 			go handler.ServeCodec(rpc.NewJSONCodec(conn), rpc.OptionMethodInvocation|rpc.OptionSubscriptions)
@@ -356,7 +356,7 @@ func (n *Node) stopIPC() {
 		n.ipcListener.Close()
 		n.ipcListener = nil
 
-		n.log.Info(fmt.Sprintf("IPC endpoint closed: %s", n.ipcEndpoint))
+		n.log.Info("IPC endpoint closed", "endpoint", n.ipcEndpoint)
 	}
 	if n.ipcHandler != nil {
 		n.ipcHandler.Stop()
@@ -382,7 +382,7 @@ func (n *Node) startHTTP(endpoint string, apis []rpc.API, modules []string, cors
 			if err := handler.RegisterName(api.Namespace, api.Service); err != nil {
 				return err
 			}
-			n.log.Debug(fmt.Sprintf("HTTP registered %T under '%s'", api.Service, api.Namespace))
+			n.log.Debug("HTTP registered", "service", api.Service, "namespace", api.Namespace)
 		}
 	}
 	// All APIs registered, start the HTTP listener
@@ -394,8 +394,7 @@ func (n *Node) startHTTP(endpoint string, apis []rpc.API, modules []string, cors
 		return err
 	}
 	go rpc.NewHTTPServer(cors, vhosts, handler).Serve(listener)
-	n.log.Info(fmt.Sprintf("HTTP endpoint opened: http://%s", endpoint))
-	n.log.Info(fmt.Sprintf("HTTP config: cors %v, vhosts%v", cors, vhosts))
+	n.log.Info("HTTP endpoint opened", "url", fmt.Sprintf("http://%s", endpoint), "cors", strings.Join(cors, ","), "hvosts", strings.Join(vhosts, ","))
 	// All listeners booted successfully
 	n.httpEndpoint = endpoint
 	n.httpListener = listener
@@ -410,7 +409,7 @@ func (n *Node) stopHTTP() {
 		n.httpListener.Close()
 		n.httpListener = nil
 
-		n.log.Info(fmt.Sprintf("HTTP endpoint closed: http://%s", n.httpEndpoint))
+		n.log.Info("HTTP endpoint closed", "url", fmt.Sprintf("http://%s", n.httpEndpoint))
 	}
 	if n.httpHandler != nil {
 		n.httpHandler.Stop()
@@ -436,7 +435,7 @@ func (n *Node) startWS(endpoint string, apis []rpc.API, modules []string, wsOrig
 			if err := handler.RegisterName(api.Namespace, api.Service); err != nil {
 				return err
 			}
-			n.log.Debug(fmt.Sprintf("WebSocket registered %T under '%s'", api.Service, api.Namespace))
+			n.log.Debug("WebSocket registered", "service", api.Service, "namespace", api.Namespace)
 		}
 	}
 	// All APIs registered, start the HTTP listener
@@ -448,7 +447,7 @@ func (n *Node) startWS(endpoint string, apis []rpc.API, modules []string, wsOrig
 		return err
 	}
 	go rpc.NewWSServer(wsOrigins, handler).Serve(listener)
-	n.log.Info(fmt.Sprintf("WebSocket endpoint opened: ws://%s", listener.Addr()))
+	n.log.Info("WebSocket endpoint opened", "url", fmt.Sprintf("ws://%s", listener.Addr()))
 
 	// All listeners booted successfully
 	n.wsEndpoint = endpoint
@@ -464,7 +463,7 @@ func (n *Node) stopWS() {
 		n.wsListener.Close()
 		n.wsListener = nil
 
-		n.log.Info(fmt.Sprintf("WebSocket endpoint closed: ws://%s", n.wsEndpoint))
+		n.log.Info("WebSocket endpoint closed", "url", fmt.Sprintf("ws://%s", n.wsEndpoint))
 	}
 	if n.wsHandler != nil {
 		n.wsHandler.Stop()

--- a/node/node.go
+++ b/node/node.go
@@ -263,7 +263,7 @@ func (n *Node) startRPC(services map[reflect.Type]Service) error {
 		n.stopInProc()
 		return err
 	}
-	if err := n.startHTTP(n.httpEndpoint, apis, n.config.HTTPModules, n.config.HTTPCors); err != nil {
+	if err := n.startHTTP(n.httpEndpoint, apis, n.config.HTTPModules, n.config.HTTPCors, n.config.HTTPHosts); err != nil {
 		n.stopIPC()
 		n.stopInProc()
 		return err
@@ -365,7 +365,7 @@ func (n *Node) stopIPC() {
 }
 
 // startHTTP initializes and starts the HTTP RPC endpoint.
-func (n *Node) startHTTP(endpoint string, apis []rpc.API, modules []string, cors []string) error {
+func (n *Node) startHTTP(endpoint string, apis []rpc.API, modules []string, cors []string, allowedHosts []string) error {
 	// Short circuit if the HTTP endpoint isn't being exposed
 	if endpoint == "" {
 		return nil
@@ -393,9 +393,9 @@ func (n *Node) startHTTP(endpoint string, apis []rpc.API, modules []string, cors
 	if listener, err = net.Listen("tcp", endpoint); err != nil {
 		return err
 	}
-	go rpc.NewHTTPServer(cors, handler).Serve(listener)
+	go rpc.NewHTTPServer(cors, allowedHosts, handler).Serve(listener)
 	n.log.Info(fmt.Sprintf("HTTP endpoint opened: http://%s", endpoint))
-
+	n.log.Info(fmt.Sprintf("HTTP config: cors %v, hosts%v", cors,allowedHosts))
 	// All listeners booted successfully
 	n.httpEndpoint = endpoint
 	n.httpListener = listener

--- a/p2p/server.go
+++ b/p2p/server.go
@@ -138,7 +138,7 @@ type Config struct {
 	EnableMsgEvents bool
 
 	// Logger is a custom logger to use with the p2p.Server.
-	Logger log.Logger
+	Logger log.Logger `toml:",omitempty"`
 }
 
 // Server manages all peer connections.

--- a/rpc/http.go
+++ b/rpc/http.go
@@ -143,7 +143,7 @@ func (t *httpReadWriteNopCloser) Close() error {
 // NewHTTPServer creates a new HTTP RPC server around an API provider.
 //
 // Deprecated: Server implements http.Handler
-func NewHTTPServer(cors []string, hosts[] string, srv *Server) *http.Server {
+func NewHTTPServer(cors []string, hosts []string, srv *Server) *http.Server {
 	// Wrap the CORS-handler within a host-handler
 	handler := newCorsHandler(srv, cors)
 	handler = newHostHandler(hosts, handler)
@@ -224,8 +224,9 @@ func (h *hostHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		hostpart := parseHost(r.Host)
 		requestAllowed := false
 		for _, allowedHost := range h.AllowedHosts {
-			if strings.ToLower(allowedHost) == hostpart {
+			if strings.ToLower(allowedHost) == hostpart || allowedHost == "*" {
 				requestAllowed = true
+				break
 			}
 		}
 		if !requestAllowed {

--- a/rpc/http.go
+++ b/rpc/http.go
@@ -202,17 +202,17 @@ func newCorsHandler(srv *Server, allowedOrigins []string) http.Handler {
 	return c.Handler(srv)
 }
 
-// virtalHostHandler is a handler which validates the Host-header of incoming requests.
-// The virtalHostHandler can prevent DNS rebinding attacks, which do not utilize CORS-headers,
+// virtualHostHandler is a handler which validates the Host-header of incoming requests.
+// The virtualHostHandler can prevent DNS rebinding attacks, which do not utilize CORS-headers,
 // since they do in-domain requests against the RPC api. Instead, we can see on the Host-header
 // which domain was used, and validate that against a whitelist.
-type virtalHostHandler struct {
+type virtualHostHandler struct {
 	vhosts map[string]struct{}
 	next   http.Handler
 }
 
 // ServeHTTP serves JSON-RPC requests over HTTP, implements http.Handler
-func (h *virtalHostHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+func (h *virtualHostHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	// if r.Host is not set, we can continue serving since a browser would set the Host header
 	if r.Host == "" {
 		h.next.ServeHTTP(w, r)
@@ -247,5 +247,5 @@ func newVHostHandler(vhosts []string, next http.Handler) http.Handler {
 	for _, allowedHost := range vhosts {
 		vhostMap[strings.ToLower(allowedHost)] = struct{}{}
 	}
-	return &virtalHostHandler{vhostMap, next}
+	return &virtualHostHandler{vhostMap, next}
 }


### PR DESCRIPTION
This pr introduces the flag `--rpcvhosts=<hosts>`, which tells the RPC server about the hostname(s) to expect for incoming requests (defaults to `localhost` unless specified). This protection mechanism also does not bother preventing requests made against a raw ip address, either v4 or v6.  

This prevents attacks like DNS rebinding, which bypasses SOP by simply masquerading as being within the same origin. These attacks do not utilize CORS, since they are not cross-domain.

By explicitly checking the Host-header, the server will not allow requests made against the server with a malicious host domain.

Additionally, this PR fixes a bug introduced in https://github.com/ethereum/go-ethereum/commit/54aeb8e4c0bb9f0e7a6c67258af67df3b266af3d, which caused the `dumpconfig` command to fail with 
```
#build/bin/geth  --maxpeers=0 --nodiscover --rpc dumpconfig
toml: cannot marshal nil log.Logger
``` 

This PR potentially breaks applications which publish RPC ports towards the world; in order to continue doing so, geth needs to be started like this: 
```
geth <flags> --rpcvhosts=infura.io,www.infura.io,...
```

There's also the possibility to use wildcards, effectively disabling the host-protection: 
```
geth <flags> --rpcvhosts=*
```
