### PR TITLE
miner: Removed duplicated code.

### DIFF
--- a/miner/miner.go
+++ b/miner/miner.go
@@ -105,8 +105,7 @@ out:
 
 func (self *Miner) Start(coinbase common.Address) {
 	atomic.StoreInt32(&self.shouldStart, 1)
-	self.worker.setEtherbase(coinbase)
-	self.coinbase = coinbase
+	self.SetEtherbase(coinbase)
 
 	if atomic.LoadInt32(&self.canStart) == 0 {
 		log.Info("Network syncing, will start miner afterwards")


### PR DESCRIPTION
There is duplicate code during code analysis, so I modify that and request a pull-request.

If you look at the code, the following code is duplicate code because you are already using the SetEtherbase function. So I tried to remove duplicate code.

> self.worker.setEtherbase(coinbase)
> self.coinbase = coinbase