### PR TITLE
ethapi: add personal.signTransaction

### DIFF
--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -381,6 +381,15 @@ func (s *PrivateAccountAPI) SendTransaction(ctx context.Context, args SendTxArgs
 func (s *PrivateAccountAPI) SignTransaction(ctx context.Context, args SendTxArgs, passwd string) (*SignTransactionResult, error) {
 	// No need to obtain the noncelock mutex, since we won't be sending this
 	// tx into the transaction pool, but right back to the user
+	if args.Gas == nil {
+		return nil, fmt.Errorf("gas not specified")
+	}
+	if args.GasPrice == nil {
+		return nil, fmt.Errorf("gasPrice not specified")
+	}
+	if args.Nonce == nil {
+		return nil, fmt.Errorf("nonce not specified")
+	}
 	signed, err := s.signTransaction(ctx, args, passwd)
 	if err != nil {
 		return nil, err
@@ -1243,11 +1252,14 @@ type SignTransactionResult struct {
 // The node needs to have the private key of the account corresponding with
 // the given from address and it needs to be unlocked.
 func (s *PublicTransactionPoolAPI) SignTransaction(ctx context.Context, args SendTxArgs) (*SignTransactionResult, error) {
+	if args.Gas == nil {
+		return nil, fmt.Errorf("gas not specified")
+	}
+	if args.GasPrice == nil {
+		return nil, fmt.Errorf("gasPrice not specified")
+	}
 	if args.Nonce == nil {
-		// Hold the addresse's mutex around signing to prevent concurrent assignment of
-		// the same nonce to multiple accounts.
-		s.nonceLock.LockAddr(args.From)
-		defer s.nonceLock.UnlockAddr(args.From)
+		return nil, fmt.Errorf("nonce not specified")
 	}
 	if err := args.setDefaults(ctx, s.b); err != nil {
 		return nil, err

--- a/internal/web3ext/web3ext.go
+++ b/internal/web3ext/web3ext.go
@@ -517,6 +517,12 @@ web3._extend({
 			call: 'personal_deriveAccount',
 			params: 3
 		}),
+		new web3._extend.Method({
+			name: 'signTransaction',
+			call: 'personal_signTransaction',
+			params: 2,
+			inputFormatter: [web3._extend.formatters.inputTransactionFormatter, null]
+		}),
 	],
 	properties: [
 		new web3._extend.Property({


### PR DESCRIPTION
This pr adds `personal.signTransaction( <tx> , <pw>) `, which is a deficiency at the moment. 

In order to create offline transactions, there's currently no great way to accomplish that: 

1. Use personal.unlock and then eth.signTransaction
   * `unlock`is dangerous for various reasons
2. Start geth in `--nodiscover --maxpeers=0`, and use `personal.sendTransaction(<tx>,<pw>)`. 
   * This is also dangerous, since locally submitted transactions are stored in `transactions.rlp`, and geth will broadcast these on the next startup unless the file is deleted. 

This pr resolves https://github.com/ethereum/go-ethereum/issues/15953 