### PR TITLE
WIP: whisper:  switch to libp2p of the base communication layer

### DIFF
--- a/whisper/whisperv6/doc.go
+++ b/whisper/whisperv6/doc.go
@@ -72,6 +72,9 @@ const (
 
 	DefaultTTL           = 50 // seconds
 	DefaultSyncAllowance = 10 // seconds
+
+	WhisperPort           = 534848
+	WhisperProtocolString = "/whisper/6.0"
 )
 
 type unknownVersionError uint64


### PR DESCRIPTION
This is the first attempt at the switch to libp2p. The purpose of this PR is **to collect comments** and is by consequent **not intended to be integrated**. It is untested and most likely non-funcitonal at this stage.

The intent of this first pass is to see what happens when replacing `p2p.Send` with its equivalent. It can quickly become a ball of yarn to be unfurled, so I have introduced some clumsy attempts at preventing this.

For example, in order not to have to replace all the calls from `crypto` and replace them with their (much less functional) libp2p equivalent, I have just blindly copied the data from one format to the next, with no idea if this is going to work:

```go
    nodeiddata, err := nodeid.Bytes()
    if err != nil {
    	utils.Fatalf("Error converting libp2p key to geth key: %s", err)
    }
    nodeidkey, err := crypto.ToECDSA(nodeiddata)
    if err != nil {
    	utils.Fatalf("Error converting libp2p key to geth key: %s", err)
    }
```

I have sought to replace the `enode://` scheme with its libp2p equivalent, so the addresses are intended to look more like `/ip4/0.0.0.0/tcp/534848/whisper/6.0/TmQo41GybvrXk8y8Xnm1P7pfN4YEXCpfnLyzgBOnNbG35f`.

I will keep updating this PR for the time being, but the final work is likely to come in a different PR.