### PR TITLE
internal: fix a typo that caused a lint error on travis

### DIFF
--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -333,7 +333,7 @@ func (s *PrivateAccountAPI) LockAccount(addr common.Address) bool {
 	return fetchKeystore(s.am).Lock(addr) == nil
 }
 
-// signTransactions sets defaults and signs the given transation
+// signTransactions sets defaults and signs the given transaction
 // NOTE: the caller needs to ensure that the nonceLock is held, if applicable,
 // and release it after the transaction has been submitted to the tx pool
 func (s *PrivateAccountAPI) signTransaction(ctx context.Context, args SendTxArgs, passwd string) (*types.Transaction, error) {


### PR DESCRIPTION
There was a typo in the comments and that caused Travis to fail. This fixes the typo and, hopefully, subsequent builds.