### PR TITLE
p2p/discv5: fix removeTicketRef cached ticket removal

### DIFF
--- a/p2p/discv5/ticket.go
+++ b/p2p/discv5/ticket.go
@@ -420,11 +420,14 @@ func (s *ticketStore) nextRegisterableTicket() (*ticketRef, time.Duration) {
 func (s *ticketStore) removeTicketRef(ref ticketRef) {
 	log.Trace("Removing discovery ticket reference", "node", ref.t.node.ID, "serial", ref.t.serial)
 
+	// Make nextRegisterableTicket return the next available ticket.
+	s.nextTicketCached = nil
+
 	topic := ref.topic()
 	tickets := s.tickets[topic]
 
 	if tickets == nil {
-		log.Warn("Removing tickets from unknown topic", "topic", topic)
+		log.Trace("Removing tickets from unknown topic", "topic", topic)
 		return
 	}
 	bucket := timeBucket(ref.t.regTime[ref.idx] / mclock.AbsTime(ticketTimeBucketLen))
@@ -450,9 +453,6 @@ func (s *ticketStore) removeTicketRef(ref ticketRef) {
 		delete(s.nodes, ref.t.node)
 		delete(s.nodeLastReq, ref.t.node)
 	}
-
-	// Make nextRegisterableTicket return the next available ticket.
-	s.nextTicketCached = nil
 }
 
 type lookupInfo struct {


### PR DESCRIPTION
This PR fixes an infinite loop in the topic register mechanism at shutdown. https://github.com/ethereum/go-ethereum/pull/15946 intended to fix a scenario when nextTicketCached was returned while the belonging topic was already removed. The panic was avoided but removeTicketRef should also clear the cached ticket (so that it is not returned again) and this also did not happen when the topic was missing. This PR moves the cache clearing before the missing topic check.
If also sets the log level of "Removing tickets from unknown topic" to Trace because this is a normal and frequently happening scenario during shutdown and we should not regularly print warning messages because of it.