### PR TITLE
cmd/utils: fix #16006 by not lowering OS ulimit

### DIFF
--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -714,12 +714,14 @@ func setIPC(ctx *cli.Context, cfg *node.Config) {
 // makeDatabaseHandles raises out the number of allowed file handles per process
 // for Geth and returns half of the allowance to assign to the database.
 func makeDatabaseHandles() int {
-	if err := fdlimit.Raise(2048); err != nil {
-		Fatalf("Failed to raise file descriptor allowance: %v", err)
-	}
 	limit, err := fdlimit.Current()
 	if err != nil {
 		Fatalf("Failed to retrieve file descriptor allowance: %v", err)
+	}
+	if limit < 2048 {
+		if err := fdlimit.Raise(2048); err != nil {
+			Fatalf("Failed to raise file descriptor allowance: %v", err)
+		}
 	}
 	if limit > 2048 { // cap database file descriptors even if more is available
 		limit = 2048


### PR DESCRIPTION
This PR fixes  #16006 by not lowering `ulimit` in case the OS is already configured with a higher max allowed files than we require. 

I'm _believe_ this is the actual intention of the earlier implementation, based on the documentation of `Raise`:
```
// Raise tries to maximize the file descriptor allowance of this process
// to the maximum hard-limit allowed by the OS.
```