### PR TITLE
whisper: improve a log message to analyze a travis issue

### DIFF
--- a/whisper/whisperv6/peer_test.go
+++ b/whisper/whisperv6/peer_test.go
@@ -274,7 +274,7 @@ func checkPropagation(t *testing.T, includingNodeZero bool) {
 		time.Sleep(cycle * time.Millisecond)
 	}
 
-	t.Fatalf("Test was not complete: timeout %d seconds.", iterations*cycle/1000)
+	t.Fatalf("Test was not complete: timeout %d seconds. nodes=%v", iterations*cycle/1000, nodes)
 
 	if !includingNodeZero {
 		f := nodes[0].shh.GetFilter(nodes[0].filerID)


### PR DESCRIPTION
This logs all the info needed to investigate what happens on MacOS when there is a timeout during a Travis run. It can not be reproduced locally, which makes us resort to this unfortunate method.