### PR TITLE
Mobile, accounts/keystore: export private key

### DIFF
--- a/accounts/keystore/keystore.go
+++ b/accounts/keystore/keystore.go
@@ -444,6 +444,15 @@ func (ks *KeyStore) Import(keyJSON []byte, passphrase, newPassphrase string) (ac
 	return ks.importKey(key, newPassphrase)
 }
 
+// ExportECDSA exports as an unencrypted key.
+func (ks *KeyStore) ExportECDSA(a accounts.Account, passphrase string) (priv *ecdsa.PrivateKey, err error) {
+	_, key, err := ks.getDecryptedKey(a, passphrase)
+	if err != nil {
+		return nil, err
+	}
+	return key.PrivateKey, nil
+}
+
 // ImportECDSA stores the given key into the key directory, encrypting it with the passphrase.
 func (ks *KeyStore) ImportECDSA(priv *ecdsa.PrivateKey, passphrase string) (accounts.Account, error) {
 	key := newKeyFromECDSA(priv)

--- a/mobile/accounts.go
+++ b/mobile/accounts.go
@@ -188,6 +188,15 @@ func (ks *KeyStore) ExportKey(account *Account, passphrase, newPassphrase string
 	return ks.keystore.Export(account.account, passphrase, newPassphrase)
 }
 
+// ExportECDSA exports as an unencrypted key.
+func (ks *KeyStore) ExportECDSAKey(account *Account, passphrase string) (key []byte, _ error) {
+	priv, err := ks.keystore.ExportECDSA(account.account, passphrase)
+	if err != nil {
+		return nil, err
+	}
+	return crypto.FromECDSA(priv), nil
+}
+
 // ImportKey stores the given encrypted JSON key into the key directory.
 func (ks *KeyStore) ImportKey(keyJSON []byte, passphrase, newPassphrase string) (account *Account, _ error) {
 	acc, err := ks.keystore.Import(common.CopyBytes(keyJSON), passphrase, newPassphrase)

--- a/mobile/accounts.go
+++ b/mobile/accounts.go
@@ -206,7 +206,7 @@ func (ks *KeyStore) ImportKey(keyJSON []byte, passphrase, newPassphrase string) 
 	return &Account{acc}, nil
 }
 
-// ImportECDSAKey stores the given encrypted JSON key into the key directory.
+// ImportECDSAKey stores the given key into the key directory, encrypting it with the passphrase.
 func (ks *KeyStore) ImportECDSAKey(key []byte, passphrase string) (account *Account, _ error) {
 	privkey, err := crypto.ToECDSA(common.CopyBytes(key))
 	if err != nil {


### PR DESCRIPTION
Enable the export of the private key and expose the function from the mobile library.
Also, fix the documentation of the import key function.