### PR TITLE
accounts/abi: Events always return a tuple

### DIFF
--- a/accounts/abi/abi.go
+++ b/accounts/abi/abi.go
@@ -86,7 +86,7 @@ func (abi ABI) Unpack(v interface{}, name string, output []byte) (err error) {
 		}
 		return method.Outputs.Unpack(v, output)
 	} else if event, ok := abi.Events[name]; ok {
-		return event.Inputs.Unpack(v, output)
+		return event.Inputs.unpackTuple(v, output)
 	}
 	return fmt.Errorf("abi: could not locate named method or event")
 }

--- a/accounts/abi/abi_test.go
+++ b/accounts/abi/abi_test.go
@@ -621,14 +621,16 @@ func TestBareEvents(t *testing.T) {
 // TestUnpackEvent is based on this contract:
 //    contract T {
 //      event received(address sender, uint amount, bytes memo);
+//			event receivedAddr(address sender);
 //      function receive(bytes memo) external payable {
 //        received(msg.sender, msg.value, memo);
+//				receivedAddr(msg.sender);
 //      }
 //    }
 // When receive("X") is called with sender 0x00... and value 1, it produces this tx receipt:
 //   receipt{status=1 cgas=23949 bloom=00000000004000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000800000000000000000000000000000000000040200000000000000000000000000000000001000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000080000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000 logs=[log: b6818c8064f645cd82d99b59a1a267d6d61117ef [75fd880d39c1daf53b6547ab6cb59451fc6452d27caa90e5b6649dd8293b9eed] 000000000000000000000000376c47978271565f56deb45495afa69e59c16ab200000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000000060000000000000000000000000000000000000000000000000000000000000000158 9ae378b6d4409eada347a5dc0c180f186cb62dc68fcc0f043425eb917335aa28 0 95d429d309bb9d753954195fe2d69bd140b4ae731b9b5b605c34323de162cf00 0]}
 func TestUnpackEvent(t *testing.T) {
-	const abiJSON = `[{"constant":false,"inputs":[{"name":"memo","type":"bytes"}],"name":"receive","outputs":[],"payable":true,"stateMutability":"payable","type":"function"},{"anonymous":false,"inputs":[{"indexed":false,"name":"sender","type":"address"},{"indexed":false,"name":"amount","type":"uint256"},{"indexed":false,"name":"memo","type":"bytes"}],"name":"received","type":"event"}]`
+	const abiJSON = `[{"constant":false,"inputs":[{"name":"memo","type":"bytes"}],"name":"receive","outputs":[],"payable":true,"stateMutability":"payable","type":"function"},{"anonymous":false,"inputs":[{"indexed":false,"name":"sender","type":"address"},{"indexed":false,"name":"amount","type":"uint256"},{"indexed":false,"name":"memo","type":"bytes"}],"name":"received","type":"event"},{"anonymous":false,"inputs":[{"indexed":false,"name":"sender","type":"address"}],"name":"receivedAddr","type":"event"}]`
 	abi, err := JSON(strings.NewReader(abiJSON))
 	if err != nil {
 		t.Fatal(err)
@@ -655,6 +657,17 @@ func TestUnpackEvent(t *testing.T) {
 		t.Error(err)
 	} else {
 		t.Logf("len(data): %d; received event: %+v", len(data), ev)
+	}
+
+	type ReceivedAddrEvent struct {
+		Address common.Address
+	}
+	var receivedAddrEv ReceivedAddrEvent
+	err = abi.Unpack(&receivedAddrEv, "receivedAddr", data)
+	if err != nil {
+		t.Error(err)
+	} else {
+		t.Logf("len(data): %d; received event: %+v", len(data), receivedAddrEv)
 	}
 }
 

--- a/accounts/abi/abi_test.go
+++ b/accounts/abi/abi_test.go
@@ -621,10 +621,10 @@ func TestBareEvents(t *testing.T) {
 // TestUnpackEvent is based on this contract:
 //    contract T {
 //      event received(address sender, uint amount, bytes memo);
-//			event receivedAddr(address sender);
+//      event receivedAddr(address sender);
 //      function receive(bytes memo) external payable {
 //        received(msg.sender, msg.value, memo);
-//				receivedAddr(msg.sender);
+//        receivedAddr(msg.sender);
 //      }
 //    }
 // When receive("X") is called with sender 0x00... and value 1, it produces this tx receipt:


### PR DESCRIPTION
An event with just one parameter will fail when trying to `unpackAtomic`