### PR TITLE
whisper: get wnode to work with v6

### DIFF
--- a/whisper/mailserver/mailserver.go
+++ b/whisper/mailserver/mailserver.go
@@ -26,7 +26,7 @@ import (
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/rlp"
-	whisper "github.com/ethereum/go-ethereum/whisper/whisperv5"
+	whisper "github.com/ethereum/go-ethereum/whisper/whisperv6"
 	"github.com/syndtr/goleveldb/leveldb"
 	"github.com/syndtr/goleveldb/leveldb/util"
 )

--- a/whisper/mailserver/server_test.go
+++ b/whisper/mailserver/server_test.go
@@ -26,7 +26,7 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/crypto"
-	whisper "github.com/ethereum/go-ethereum/whisper/whisperv5"
+	whisper "github.com/ethereum/go-ethereum/whisper/whisperv6"
 )
 
 const powRequirement = 0.00001

--- a/whisper/whisperv6/api.go
+++ b/whisper/whisperv6/api.go
@@ -292,7 +292,7 @@ func (api *PublicWhisperAPI) Post(ctx context.Context, req NewMessage) (bool, er
 	}
 
 	// encrypt and sent message
-	whisperMsg, err := newSentMessage(params)
+	whisperMsg, err := NewSentMessage(params)
 	if err != nil {
 		return false, err
 	}

--- a/whisper/whisperv6/benchmarks_test.go
+++ b/whisper/whisperv6/benchmarks_test.go
@@ -39,7 +39,7 @@ func BenchmarkEncryptionSym(b *testing.B) {
 	}
 
 	for i := 0; i < b.N; i++ {
-		msg, _ := newSentMessage(params)
+		msg, _ := NewSentMessage(params)
 		_, err := msg.Wrap(params)
 		if err != nil {
 			b.Errorf("failed Wrap with seed %d: %s.", seed, err)
@@ -64,7 +64,7 @@ func BenchmarkEncryptionAsym(b *testing.B) {
 	params.Dst = &key.PublicKey
 
 	for i := 0; i < b.N; i++ {
-		msg, _ := newSentMessage(params)
+		msg, _ := NewSentMessage(params)
 		_, err := msg.Wrap(params)
 		if err != nil {
 			b.Fatalf("failed Wrap with seed %d: %s.", seed, err)
@@ -79,7 +79,7 @@ func BenchmarkDecryptionSymValid(b *testing.B) {
 	if err != nil {
 		b.Fatalf("failed generateMessageParams with seed %d: %s.", seed, err)
 	}
-	msg, _ := newSentMessage(params)
+	msg, _ := NewSentMessage(params)
 	env, err := msg.Wrap(params)
 	if err != nil {
 		b.Fatalf("failed Wrap with seed %d: %s.", seed, err)
@@ -101,7 +101,7 @@ func BenchmarkDecryptionSymInvalid(b *testing.B) {
 	if err != nil {
 		b.Fatalf("failed generateMessageParams with seed %d: %s.", seed, err)
 	}
-	msg, _ := newSentMessage(params)
+	msg, _ := NewSentMessage(params)
 	env, err := msg.Wrap(params)
 	if err != nil {
 		b.Fatalf("failed Wrap with seed %d: %s.", seed, err)
@@ -130,7 +130,7 @@ func BenchmarkDecryptionAsymValid(b *testing.B) {
 	f := Filter{KeyAsym: key}
 	params.KeySym = nil
 	params.Dst = &key.PublicKey
-	msg, _ := newSentMessage(params)
+	msg, _ := NewSentMessage(params)
 	env, err := msg.Wrap(params)
 	if err != nil {
 		b.Fatalf("failed Wrap with seed %d: %s.", seed, err)
@@ -157,7 +157,7 @@ func BenchmarkDecryptionAsymInvalid(b *testing.B) {
 	}
 	params.KeySym = nil
 	params.Dst = &key.PublicKey
-	msg, _ := newSentMessage(params)
+	msg, _ := NewSentMessage(params)
 	env, err := msg.Wrap(params)
 	if err != nil {
 		b.Fatalf("failed Wrap with seed %d: %s.", seed, err)
@@ -199,7 +199,7 @@ func BenchmarkPoW(b *testing.B) {
 
 	for i := 0; i < b.N; i++ {
 		increment(params.Payload)
-		msg, _ := newSentMessage(params)
+		msg, _ := NewSentMessage(params)
 		_, err := msg.Wrap(params)
 		if err != nil {
 			b.Fatalf("failed Wrap with seed %d: %s.", seed, err)

--- a/whisper/whisperv6/envelope_test.go
+++ b/whisper/whisperv6/envelope_test.go
@@ -45,7 +45,7 @@ func TestEnvelopeOpenAcceptsOnlyOneKeyTypeInFilter(t *testing.T) {
 
 	mrand.Read(params.Payload)
 
-	msg, err := newSentMessage(&params)
+	msg, err := NewSentMessage(&params)
 	if err != nil {
 		t.Fatalf("failed to create new message with seed %d: %s.", seed, err)
 	}

--- a/whisper/whisperv6/filter_test.go
+++ b/whisper/whisperv6/filter_test.go
@@ -199,7 +199,7 @@ func TestInstallIdenticalFilters(t *testing.T) {
 	filter1.Src = &params.Src.PublicKey
 	filter2.Src = &params.Src.PublicKey
 
-	sentMessage, err := newSentMessage(params)
+	sentMessage, err := NewSentMessage(params)
 	if err != nil {
 		t.Fatalf("failed to create new message with seed %d: %s.", seed, err)
 	}
@@ -306,7 +306,7 @@ func TestMatchEnvelope(t *testing.T) {
 	params.Topic[0] = 0xFF // ensure mismatch
 
 	// mismatch with pseudo-random data
-	msg, err := newSentMessage(params)
+	msg, err := NewSentMessage(params)
 	if err != nil {
 		t.Fatalf("failed to create new message with seed %d: %s.", seed, err)
 	}
@@ -327,7 +327,7 @@ func TestMatchEnvelope(t *testing.T) {
 	i := mrand.Int() % 4
 	fsym.Topics[i] = params.Topic[:]
 	fasym.Topics[i] = params.Topic[:]
-	msg, err = newSentMessage(params)
+	msg, err = NewSentMessage(params)
 	if err != nil {
 		t.Fatalf("failed to create new message with seed %d: %s.", seed, err)
 	}
@@ -372,7 +372,7 @@ func TestMatchEnvelope(t *testing.T) {
 	}
 	params.KeySym = nil
 	params.Dst = &key.PublicKey
-	msg, err = newSentMessage(params)
+	msg, err = NewSentMessage(params)
 	if err != nil {
 		t.Fatalf("failed to create new message with seed %d: %s.", seed, err)
 	}
@@ -453,7 +453,7 @@ func TestMatchMessageSym(t *testing.T) {
 	params.KeySym = f.KeySym
 	params.Topic = BytesToTopic(f.Topics[index])
 
-	sentMessage, err := newSentMessage(params)
+	sentMessage, err := NewSentMessage(params)
 	if err != nil {
 		t.Fatalf("failed to create new message with seed %d: %s.", seed, err)
 	}
@@ -546,7 +546,7 @@ func TestMatchMessageAsym(t *testing.T) {
 	keySymOrig := params.KeySym
 	params.KeySym = nil
 
-	sentMessage, err := newSentMessage(params)
+	sentMessage, err := NewSentMessage(params)
 	if err != nil {
 		t.Fatalf("failed to create new message with seed %d: %s.", seed, err)
 	}
@@ -630,7 +630,7 @@ func generateCompatibeEnvelope(t *testing.T, f *Filter) *Envelope {
 
 	params.KeySym = f.KeySym
 	params.Topic = BytesToTopic(f.Topics[2])
-	sentMessage, err := newSentMessage(params)
+	sentMessage, err := NewSentMessage(params)
 	if err != nil {
 		t.Fatalf("failed to create new message with seed %d: %s.", seed, err)
 	}
@@ -806,7 +806,7 @@ func TestVariableTopics(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed generateMessageParams with seed %d: %s.", seed, err)
 	}
-	msg, err := newSentMessage(params)
+	msg, err := NewSentMessage(params)
 	if err != nil {
 		t.Fatalf("failed to create new message with seed %d: %s.", seed, err)
 	}

--- a/whisper/whisperv6/message.go
+++ b/whisper/whisperv6/message.go
@@ -89,7 +89,7 @@ func (msg *ReceivedMessage) isAsymmetricEncryption() bool {
 }
 
 // NewSentMessage creates and initializes a non-signed, non-encrypted Whisper message.
-func newSentMessage(params *MessageParams) (*sentMessage, error) {
+func NewSentMessage(params *MessageParams) (*sentMessage, error) {
 	const payloadSizeFieldMaxSize = 4
 	msg := sentMessage{}
 	msg.Raw = make([]byte, 1,

--- a/whisper/whisperv6/message_test.go
+++ b/whisper/whisperv6/message_test.go
@@ -73,7 +73,7 @@ func singleMessageTest(t *testing.T, symmetric bool) {
 	text := make([]byte, 0, 512)
 	text = append(text, params.Payload...)
 
-	msg, err := newSentMessage(params)
+	msg, err := NewSentMessage(params)
 	if err != nil {
 		t.Fatalf("failed to create new message with seed %d: %s.", seed, err)
 	}
@@ -131,7 +131,7 @@ func TestMessageWrap(t *testing.T) {
 		t.Fatalf("failed generateMessageParams with seed %d: %s.", seed, err)
 	}
 
-	msg, err := newSentMessage(params)
+	msg, err := NewSentMessage(params)
 	if err != nil {
 		t.Fatalf("failed to create new message with seed %d: %s.", seed, err)
 	}
@@ -149,7 +149,7 @@ func TestMessageWrap(t *testing.T) {
 	}
 
 	// set PoW target too high, expect error
-	msg2, err := newSentMessage(params)
+	msg2, err := NewSentMessage(params)
 	if err != nil {
 		t.Fatalf("failed to create new message with seed %d: %s.", seed, err)
 	}
@@ -172,7 +172,7 @@ func TestMessageSeal(t *testing.T) {
 		t.Fatalf("failed generateMessageParams with seed %d: %s.", seed, err)
 	}
 
-	msg, err := newSentMessage(params)
+	msg, err := NewSentMessage(params)
 	if err != nil {
 		t.Fatalf("failed to create new message with seed %d: %s.", seed, err)
 	}
@@ -234,7 +234,7 @@ func singleEnvelopeOpenTest(t *testing.T, symmetric bool) {
 	text := make([]byte, 0, 512)
 	text = append(text, params.Payload...)
 
-	msg, err := newSentMessage(params)
+	msg, err := NewSentMessage(params)
 	if err != nil {
 		t.Fatalf("failed to create new message with seed %d: %s.", seed, err)
 	}
@@ -289,7 +289,7 @@ func TestEncryptWithZeroKey(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed generateMessageParams with seed %d: %s.", seed, err)
 	}
-	msg, err := newSentMessage(params)
+	msg, err := NewSentMessage(params)
 	if err != nil {
 		t.Fatalf("failed to create new message with seed %d: %s.", seed, err)
 	}
@@ -303,7 +303,7 @@ func TestEncryptWithZeroKey(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed generateMessageParams with seed %d: %s.", seed, err)
 	}
-	msg, err = newSentMessage(params)
+	msg, err = NewSentMessage(params)
 	if err != nil {
 		t.Fatalf("failed to create new message with seed %d: %s.", seed, err)
 	}
@@ -317,7 +317,7 @@ func TestEncryptWithZeroKey(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed generateMessageParams with seed %d: %s.", seed, err)
 	}
-	msg, err = newSentMessage(params)
+	msg, err = NewSentMessage(params)
 	if err != nil {
 		t.Fatalf("failed to create new message with seed %d: %s.", seed, err)
 	}
@@ -335,7 +335,7 @@ func TestRlpEncode(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed generateMessageParams with seed %d: %s.", seed, err)
 	}
-	msg, err := newSentMessage(params)
+	msg, err := NewSentMessage(params)
 	if err != nil {
 		t.Fatalf("failed to create new message with seed %d: %s.", seed, err)
 	}
@@ -379,7 +379,7 @@ func singlePaddingTest(t *testing.T, padSize int) {
 	if n != padSize {
 		t.Fatalf("padding is not copied (seed %d): %s", seed, err)
 	}
-	msg, err := newSentMessage(params)
+	msg, err := NewSentMessage(params)
 	if err != nil {
 		t.Fatalf("failed to create new message with seed %d: %s.", seed, err)
 	}

--- a/whisper/whisperv6/peer_test.go
+++ b/whisper/whisperv6/peer_test.go
@@ -344,7 +344,7 @@ func sendMsg(t *testing.T, expected bool, id int) {
 		opt.Payload = opt.Payload[1:]
 	}
 
-	msg, err := newSentMessage(&opt)
+	msg, err := NewSentMessage(&opt)
 	if err != nil {
 		t.Fatalf("failed to create new message with seed %d: %s.", seed, err)
 	}
@@ -368,7 +368,7 @@ func TestPeerBasic(t *testing.T) {
 	}
 
 	params.PoW = 0.001
-	msg, err := newSentMessage(params)
+	msg, err := NewSentMessage(params)
 	if err != nil {
 		t.Fatalf("failed to create new message with seed %d: %s.", seed, err)
 	}

--- a/whisper/whisperv6/whisper_test.go
+++ b/whisper/whisperv6/whisper_test.go
@@ -471,7 +471,7 @@ func TestExpiry(t *testing.T) {
 	}
 
 	params.TTL = 1
-	msg, err := newSentMessage(params)
+	msg, err := NewSentMessage(params)
 	if err != nil {
 		t.Fatalf("failed to create new message with seed %d: %s.", seed, err)
 	}
@@ -537,7 +537,7 @@ func TestCustomization(t *testing.T) {
 	params.Topic = BytesToTopic(f.Topics[2])
 	params.PoW = smallPoW
 	params.TTL = 3600 * 24 // one day
-	msg, err := newSentMessage(params)
+	msg, err := NewSentMessage(params)
 	if err != nil {
 		t.Fatalf("failed to create new message with seed %d: %s.", seed, err)
 	}
@@ -558,7 +558,7 @@ func TestCustomization(t *testing.T) {
 	}
 
 	params.TTL++
-	msg, err = newSentMessage(params)
+	msg, err = NewSentMessage(params)
 	if err != nil {
 		t.Fatalf("failed to create new message with seed %d: %s.", seed, err)
 	}
@@ -647,7 +647,7 @@ func TestSymmetricSendCycle(t *testing.T) {
 	params.PoW = filter1.PoW
 	params.WorkTime = 10
 	params.TTL = 50
-	msg, err := newSentMessage(params)
+	msg, err := NewSentMessage(params)
 	if err != nil {
 		t.Fatalf("failed to create new message with seed %d: %s.", seed, err)
 	}
@@ -725,7 +725,7 @@ func TestSymmetricSendWithoutAKey(t *testing.T) {
 	params.PoW = filter.PoW
 	params.WorkTime = 10
 	params.TTL = 50
-	msg, err := newSentMessage(params)
+	msg, err := NewSentMessage(params)
 	if err != nil {
 		t.Fatalf("failed to create new message with seed %d: %s.", seed, err)
 	}
@@ -791,7 +791,7 @@ func TestSymmetricSendKeyMismatch(t *testing.T) {
 	params.PoW = filter.PoW
 	params.WorkTime = 10
 	params.TTL = 50
-	msg, err := newSentMessage(params)
+	msg, err := NewSentMessage(params)
 	if err != nil {
 		t.Fatalf("failed to create new message with seed %d: %s.", seed, err)
 	}


### PR DESCRIPTION
The bulk of the issue was to adapt to the new requirement
that a v6 filter has to either contain a symmertric key or
an asymmetric one.

This commits revert one of the fixes that I made to remove
a linter warning: unexporting NewSentMessage. This is not
really a problem as I have a cleanup in the pipe that will
solve this issue.