### PR TITLE
Dockerfile*: default non-privileged user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,8 @@ RUN apk add --no-cache ca-certificates
 COPY --from=builder /go-ethereum/build/bin/geth /usr/local/bin/
 
 RUN addgroup -g 1000 geth && \
-    adduser -D -u 1000 -G geth geth
+    adduser -D -u 1000 -G geth geth && \
+    chown geth:geth /root
 
 USER geth
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,5 +12,10 @@ FROM alpine:latest
 RUN apk add --no-cache ca-certificates
 COPY --from=builder /go-ethereum/build/bin/geth /usr/local/bin/
 
+RUN addgroup -g 1000 geth && \
+    adduser -D -u 1000 -G geth geth
+
+USER geth
+
 EXPOSE 8545 8546 30303 30303/udp 30304/udp
 ENTRYPOINT ["geth"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ RUN apk add --no-cache ca-certificates
 COPY --from=builder /go-ethereum/build/bin/geth /usr/local/bin/
 
 RUN addgroup -g 1000 geth && \
-    adduser -D -u 1000 -G geth geth && \
+    adduser -h /root -D -u 1000 -G geth geth && \
     chown geth:geth /root
 
 USER geth

--- a/Dockerfile.alltools
+++ b/Dockerfile.alltools
@@ -13,7 +13,7 @@ RUN apk add --no-cache ca-certificates
 COPY --from=builder /go-ethereum/build/bin/* /usr/local/bin/
 
 RUN addgroup -g 1000 geth && \
-    adduser -D -u 1000 -G geth geth \
+    adduser -h /root -D -u 1000 -G geth geth \
     chown geth:geth /root
 
 USER geth

--- a/Dockerfile.alltools
+++ b/Dockerfile.alltools
@@ -12,4 +12,9 @@ FROM alpine:latest
 RUN apk add --no-cache ca-certificates
 COPY --from=builder /go-ethereum/build/bin/* /usr/local/bin/
 
+RUN addgroup -g 1000 geth && \
+    adduser -D -u 1000 -G geth geth
+
+USER geth
+
 EXPOSE 8545 8546 30303 30303/udp 30304/udp

--- a/Dockerfile.alltools
+++ b/Dockerfile.alltools
@@ -13,7 +13,8 @@ RUN apk add --no-cache ca-certificates
 COPY --from=builder /go-ethereum/build/bin/* /usr/local/bin/
 
 RUN addgroup -g 1000 geth && \
-    adduser -D -u 1000 -G geth geth
+    adduser -D -u 1000 -G geth geth \
+    chown geth:geth /root
 
 USER geth
 

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ Specifying the `--testnet` flag however will reconfigure your Geth instance a bi
    `geth attach <datadir>/testnet/geth.ipc`. Windows users are not affected by this.
  * Instead of connecting the main Ethereum network, the client will connect to the test network,
    which uses different P2P bootnodes, different network IDs and genesis states.
-   
+
 *Note: Although there are some internal protective measures to prevent transactions from crossing
 over between the main network and test network, you should make sure to always use separate accounts
 for play-money and real-money. Unless you manually move accounts, Geth will by default correctly
@@ -123,7 +123,7 @@ $ geth --your-favourite-flags dumpconfig
 One of the quickest ways to get Ethereum up and running on your machine is by using Docker:
 
 ```
-docker run -d --name ethereum-node -v /Users/alice/ethereum:/root \
+docker run -d --name ethereum-node -v /Users/alice/ethereum:/home/geth \
            -p 8545:8545 -p 30303:30303 \
            ethereum/client-go --fast --cache=512
 ```

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ Specifying the `--testnet` flag however will reconfigure your Geth instance a bi
    `geth attach <datadir>/testnet/geth.ipc`. Windows users are not affected by this.
  * Instead of connecting the main Ethereum network, the client will connect to the test network,
    which uses different P2P bootnodes, different network IDs and genesis states.
-
+   
 *Note: Although there are some internal protective measures to prevent transactions from crossing
 over between the main network and test network, you should make sure to always use separate accounts
 for play-money and real-money. Unless you manually move accounts, Geth will by default correctly
@@ -123,7 +123,7 @@ $ geth --your-favourite-flags dumpconfig
 One of the quickest ways to get Ethereum up and running on your machine is by using Docker:
 
 ```
-docker run -d --name ethereum-node -v /Users/alice/ethereum:/home/geth \
+docker run -d --name ethereum-node -v /Users/alice/ethereum:/root \
            -p 8545:8545 -p 30303:30303 \
            ethereum/client-go --fast --cache=512
 ```


### PR DESCRIPTION
Dockerfile*: default non-provileged user

Creates a `geth` user and group (1000:1000) and defaults to it for regular and alltools images. Also updated suggested docker command in README to mount volume in the non-privileged user home.

Closes: #15816 