### PR TITLE
node: detect and fill counters as part of debug_api/metrics rpc

### DIFF
--- a/node/api.go
+++ b/node/api.go
@@ -308,6 +308,11 @@ func (api *PublicDebugAPI) Metrics(raw bool) (map[string]interface{}, error) {
 		// Fill the counter with the metric details, formatting if requested
 		if raw {
 			switch metric := metric.(type) {
+			case metrics.Counter:
+				root[name] = map[string]interface{}{
+					"Overall": float64(metric.Count()),
+				}
+
 			case metrics.Meter:
 				root[name] = map[string]interface{}{
 					"AvgRate01Min": metric.Rate1(),
@@ -338,6 +343,11 @@ func (api *PublicDebugAPI) Metrics(raw bool) (map[string]interface{}, error) {
 			}
 		} else {
 			switch metric := metric.(type) {
+			case metrics.Counter:
+				root[name] = map[string]interface{}{
+					"Overall": float64(metric.Count()),
+				}
+
 			case metrics.Meter:
 				root[name] = map[string]interface{}{
 					"Avg01Min": format(metric.Rate1()*60, metric.Rate1()),


### PR DESCRIPTION
This PR addresses https://github.com/ethereum/go-ethereum/issues/15933

I am not 100% sure this is the correct way to fix the problem, but all counters are listed as type string and default value "Unknown metric type" when returned by this RPC.

I am not sure how this ever worked, considering that we have many counters as part of the codebase - @karalabe were they ever displayed in the `geth monitor`?