### PR TITLE
cmd/utils: add regular v5 bootnodes too in rinkeby light mode

### DIFF
--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -626,7 +626,7 @@ func setBootstrapNodesV5(ctx *cli.Context, cfg *p2p.Config) {
 			urls = strings.Split(ctx.GlobalString(BootnodesFlag.Name), ",")
 		}
 	case ctx.GlobalBool(RinkebyFlag.Name):
-		urls = params.RinkebyBootnodes
+		urls = append(urls, params.RinkebyBootnodes...)
 	case cfg.BootstrapNodesV5 != nil:
 		return // already set, don't apply defaults.
 	}


### PR DESCRIPTION
This PR ensures reliable light connection to Rinkeby even when the Rinkeby bootnodes are down or unresponsive.