### PR TITLE
eth/downloader: don't require state for ancestor lookups

### DIFF
--- a/eth/downloader/downloader_test.go
+++ b/eth/downloader/downloader_test.go
@@ -221,14 +221,9 @@ func (dl *downloadTester) HasHeader(hash common.Hash, number uint64) bool {
 	return dl.GetHeaderByHash(hash) != nil
 }
 
-// HasBlockAndState checks if a block and associated state is present in the testers canonical chain.
-func (dl *downloadTester) HasBlockAndState(hash common.Hash, number uint64) bool {
-	block := dl.GetBlockByHash(hash)
-	if block == nil {
-		return false
-	}
-	_, err := dl.stateDb.Get(block.Root().Bytes())
-	return err == nil
+// HasBlock checks if a block is present in the testers canonical chain.
+func (dl *downloadTester) HasBlock(hash common.Hash, number uint64) bool {
+	return dl.GetBlockByHash(hash) != nil
 }
 
 // GetHeader retrieves a header from the testers canonical chain.


### PR DESCRIPTION
When a sync cycle starts, we start by looking up the common ancestor between our chain and a remote chain to act as the sync starting point. The common ancestor for a full node was until now defined as a common block for which we have the state locally available.

This invariant however does not hold any more, since the introduction of trie pruning means that most past blocks will **not** have the state available. This is a problem, because binary-search based lookup is dead.

This PR changes the invariant so we only look up availability of full blocks, but not associated state. This will allow us to find a common block, and the blockchain internally will roll back and reexecute anything missing before that point.