### PR TITLE
eth: only disable fast sync after success

### DIFF
--- a/eth/sync.go
+++ b/eth/sync.go
@@ -189,17 +189,12 @@ func (pm *ProtocolManager) synchronise(peer *peer) {
 		mode = downloader.FastSync
 	}
 	// Run the sync cycle, and disable fast sync if we've went past the pivot block
-	err := pm.downloader.Synchronise(peer.id, pHead, pTd, mode)
-
-	if atomic.LoadUint32(&pm.fastSync) == 1 {
-		// Disable fast sync if we indeed have something in our chain
-		if pm.blockchain.CurrentBlock().NumberU64() > 0 {
-			log.Info("Fast sync complete, auto disabling")
-			atomic.StoreUint32(&pm.fastSync, 0)
-		}
-	}
-	if err != nil {
+	if err := pm.downloader.Synchronise(peer.id, pHead, pTd, mode); err != nil {
 		return
+	}
+	if atomic.LoadUint32(&pm.fastSync) == 1 {
+		log.Info("Fast sync complete, auto disabling")
+		atomic.StoreUint32(&pm.fastSync, 0)
 	}
 	atomic.StoreUint32(&pm.acceptTxs, 1) // Mark initial sync done
 	if head := pm.blockchain.CurrentBlock(); head.NumberU64() > 0 {


### PR DESCRIPTION
With the trie pruning PR (https://github.com/ethereum/go-ethereum/pull/15857), we're redefined fast sync to not hard reset to block 0 if downloading the pivot fails 10 times. This is a subsequent change along the same line to not revert to full sync if fast sync fails, only if it succeeds. 

This code path was hit by Rinkeby miners which insta-mined a block on startup, started fast sync, failed, and switched to full sync because of the sole mined block at height 1. This change ensures that blocks mined locally don't disable fast sync.