### PR TITLE
core: force import known but rolled back blocks

### DIFF
--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -1070,8 +1070,12 @@ func (bc *BlockChain) insertChain(chain types.Blocks) (int, []interface{}, []*ty
 		}
 		switch {
 		case err == ErrKnownBlock:
-			stats.ignored++
-			continue
+			// Block and state both already known. However if the current block is below
+			// this number we did a rollback and we should reimport it nonetheless.
+			if bc.CurrentBlock().NumberU64() >= block.NumberU64() {
+				stats.ignored++
+				continue
+			}
 
 		case err == consensus.ErrFutureBlock:
 			// Allow up to MaxFuture second in the future blocks. If this limit is exceeded


### PR DESCRIPTION
The blockchain currently ignores any blocks it's given but that are already known (both block and state). This logic has two tiny corner cases around rollbacks:

 * If I blindly force the chain head to an earlier block, then all later blocks and state will be available. When we try to reimport the blocks, they will be mostly ignored. However, ignoring them also prevents the **current block** being incremented. When the first truly new block is encountered, the chain will detect a huge "reorg" that isn't really a reorg.
 * If I correctly roll back blocks to an earlier one, on Rinkeby empty blocks don't change the state root (no miner subsidy). As such, even if state is "missing", on Rinkeby it might still be present, hitting this branch and ignoring the block.

The solution to both of these cases is to only ignore the block if the chain head is further advanced than the one we're trying to import. If the chain head is in the past, import it as if the block was unknown. This can only ever happen if we rolled back blocks (manual via API or crash + lost data).

Fixes #15471, #14847, #14833, #14740, #14695.

```
ERROR[02-12|11:36:31] Impossible reorg, please file an issue   oldnum=1751009 oldhash=144a94…1276bc newnum=1751009 newhash=144a94…1276bc
```