### PR TITLE
eth, les, eth/filter: paralellized log search in bloom filter matches

### DIFF
--- a/accounts/abi/bind/backends/simulated.go
+++ b/accounts/abi/bind/backends/simulated.go
@@ -346,7 +346,7 @@ func (b *SimulatedBackend) FilterLogs(ctx context.Context, query ethereum.Filter
 	var filter *filters.Filter
 	if query.BlockHash != nil {
 		// Block filter requested, construct a single-shot filter
-		filter = filters.NewBlockFilter(&filterBackend{b.database, b.blockchain}, *query.BlockHash, query.Addresses, query.Topics)
+		filter = filters.NewBlockFilter(&filterBackend{b.database, b.blockchain, nil}, *query.BlockHash, query.Addresses, query.Topics)
 	} else {
 		// Initialize unset filter boundaried to run from genesis to chain head
 		from := int64(0)

--- a/eth/api_backend.go
+++ b/eth/api_backend.go
@@ -225,6 +225,6 @@ func (b *EthAPIBackend) ServiceFilter(ctx context.Context, session *bloombits.Ma
 	}
 }
 
-func (b *EthApiBackend) FilterTaskChannel() chan *filters.BlockFilterTask {
+func (b *EthAPIBackend) FilterTaskChannel() chan *filters.BlockFilterTask {
 	return b.eth.filterTasks
 }

--- a/eth/api_backend.go
+++ b/eth/api_backend.go
@@ -29,6 +29,7 @@ import (
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/core/vm"
 	"github.com/ethereum/go-ethereum/eth/downloader"
+	"github.com/ethereum/go-ethereum/eth/filters"
 	"github.com/ethereum/go-ethereum/eth/gasprice"
 	"github.com/ethereum/go-ethereum/ethdb"
 	"github.com/ethereum/go-ethereum/event"
@@ -222,4 +223,8 @@ func (b *EthAPIBackend) ServiceFilter(ctx context.Context, session *bloombits.Ma
 	for i := 0; i < bloomFilterThreads; i++ {
 		go session.Multiplex(bloomRetrievalBatch, bloomRetrievalWait, b.eth.bloomRequests)
 	}
+}
+
+func (b *EthApiBackend) FilterTaskChannel() chan *filters.BlockFilterTask {
+	return b.eth.filterTasks
 }

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -80,6 +80,7 @@ type Ethereum struct {
 	accountManager *accounts.Manager
 
 	bloomRequests chan chan *bloombits.Retrieval // Channel receiving bloom data retrieval requests
+	filterTasks   chan *filters.BlockFilterTask  // Channel receiving block filter tasks
 	bloomIndexer  *core.ChainIndexer             // Bloom indexer operating during block imports
 
 	APIBackend *EthAPIBackend
@@ -142,6 +143,7 @@ func New(ctx *node.ServiceContext, config *Config) (*Ethereum, error) {
 		gasPrice:       config.MinerGasPrice,
 		etherbase:      config.Etherbase,
 		bloomRequests:  make(chan chan *bloombits.Retrieval),
+		filterTasks:    make(chan *filters.BlockFilterTask),
 		bloomIndexer:   NewBloomIndexer(chainDb, params.BloomBitsBlocks, params.BloomConfirms),
 	}
 

--- a/eth/bloombits.go
+++ b/eth/bloombits.go
@@ -34,6 +34,10 @@ const (
 	// instance to service bloombits lookups for all running filters.
 	bloomServiceThreads = 16
 
+	// filterTaskServiceThreads is the number of goroutines used globally by an Ethereum
+	// instance to service block filter tasks for all running filters.
+	filterTaskServiceThreads = 16
+
 	// bloomFilterThreads is the number of goroutines used locally per filter to
 	// multiplex requests onto the global servicing goroutines.
 	bloomFilterThreads = 3
@@ -73,6 +77,20 @@ func (eth *Ethereum) startBloomHandlers(sectionSize uint64) {
 						}
 					}
 					request <- task
+				}
+			}
+		}()
+	}
+
+	for i := 0; i < filterTaskServiceThreads; i++ {
+		go func() {
+			for {
+				select {
+				case <-eth.shutdownChan:
+					return
+
+				case task := <-eth.filterTasks:
+					task.Do()
 				}
 			}
 		}()

--- a/eth/filters/bench_test.go
+++ b/eth/filters/bench_test.go
@@ -130,7 +130,7 @@ func benchmarkBloomBits(b *testing.B, sectionSize uint64) {
 		if i%20 == 0 {
 			db.Close()
 			db, _ = ethdb.NewLDBDatabase(benchDataDir, 128, 1024)
-			backend = &testBackend{mux, db, cnt, new(event.Feed), new(event.Feed), new(event.Feed), new(event.Feed)}
+			backend = &testBackend{mux, db, cnt, new(event.Feed), new(event.Feed), new(event.Feed), new(event.Feed), nil}
 		}
 		var addr common.Address
 		addr[0] = byte(i)
@@ -191,7 +191,7 @@ func BenchmarkNoBloomBits(b *testing.B) {
 	fmt.Println("Running filter benchmarks...")
 	start := time.Now()
 	mux := new(event.TypeMux)
-	backend := &testBackend{mux, db, 0, new(event.Feed), new(event.Feed), new(event.Feed), new(event.Feed)}
+	backend := &testBackend{mux, db, 0, new(event.Feed), new(event.Feed), new(event.Feed), new(event.Feed), nil}
 	filter := NewRangeFilter(backend, 0, int64(*headNum), []common.Address{{}}, nil)
 	filter.Logs(context.Background())
 	d := time.Since(start)

--- a/eth/filters/filter.go
+++ b/eth/filters/filter.go
@@ -316,7 +316,6 @@ func (f *Filter) unindexedLogs(ctx context.Context, tasks chan *BlockFilterTask,
 		case <-ctx.Done():
 			return ctx.Err()
 		}
-		logs = append(logs, found...)
 	}
 	return nil
 }

--- a/eth/filters/filter_system_test.go
+++ b/eth/filters/filter_system_test.go
@@ -368,7 +368,7 @@ func TestInvalidGetLogsRequest(t *testing.T) {
 		rmLogsFeed = new(event.Feed)
 		logsFeed   = new(event.Feed)
 		chainFeed  = new(event.Feed)
-		backend    = &testBackend{mux, db, 0, txFeed, rmLogsFeed, logsFeed, chainFeed}
+		backend    = &testBackend{mux, db, 0, txFeed, rmLogsFeed, logsFeed, chainFeed, nil}
 		api        = NewPublicFilterAPI(backend, false)
 		blockHash  = common.HexToHash("0x1111111111111111111111111111111111111111111111111111111111111111")
 	)

--- a/eth/filters/filter_test.go
+++ b/eth/filters/filter_test.go
@@ -57,7 +57,7 @@ func BenchmarkFilters(b *testing.B) {
 		rmLogsFeed = new(event.Feed)
 		logsFeed   = new(event.Feed)
 		chainFeed  = new(event.Feed)
-		backend    = &testBackend{mux, db, 0, txFeed, rmLogsFeed, logsFeed, chainFeed}
+		backend    = &testBackend{mux, db, 0, txFeed, rmLogsFeed, logsFeed, chainFeed, nil}
 		key1, _    = crypto.HexToECDSA("b71c71a67e1177ad4e901695e1b4b9ee17ae16c6668d313eac2f96dbcda3f291")
 		addr1      = crypto.PubkeyToAddress(key1.PublicKey)
 		addr2      = common.BytesToAddress([]byte("jeff"))
@@ -116,7 +116,7 @@ func TestFilters(t *testing.T) {
 		rmLogsFeed = new(event.Feed)
 		logsFeed   = new(event.Feed)
 		chainFeed  = new(event.Feed)
-		backend    = &testBackend{mux, db, 0, txFeed, rmLogsFeed, logsFeed, chainFeed}
+		backend    = &testBackend{mux, db, 0, txFeed, rmLogsFeed, logsFeed, chainFeed, nil}
 		key1, _    = crypto.HexToECDSA("b71c71a67e1177ad4e901695e1b4b9ee17ae16c6668d313eac2f96dbcda3f291")
 		addr       = crypto.PubkeyToAddress(key1.PublicKey)
 

--- a/les/api_backend.go
+++ b/les/api_backend.go
@@ -30,6 +30,7 @@ import (
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/core/vm"
 	"github.com/ethereum/go-ethereum/eth/downloader"
+	"github.com/ethereum/go-ethereum/eth/filters"
 	"github.com/ethereum/go-ethereum/eth/gasprice"
 	"github.com/ethereum/go-ethereum/ethdb"
 	"github.com/ethereum/go-ethereum/event"
@@ -199,4 +200,8 @@ func (b *LesApiBackend) ServiceFilter(ctx context.Context, session *bloombits.Ma
 	for i := 0; i < bloomFilterThreads; i++ {
 		go session.Multiplex(bloomRetrievalBatch, bloomRetrievalWait, b.eth.bloomRequests)
 	}
+}
+
+func (b *LesApiBackend) FilterTaskChannel() chan *filters.BlockFilterTask {
+	return b.eth.filterTasks
 }

--- a/les/backend.go
+++ b/les/backend.go
@@ -63,6 +63,7 @@ type LightEthereum struct {
 	retriever  *retrieveManager
 
 	bloomRequests chan chan *bloombits.Retrieval // Channel receiving bloom data retrieval requests
+	filterTasks   chan *filters.BlockFilterTask  // Channel receiving block filter tasks
 	bloomIndexer  *core.ChainIndexer
 
 	ApiBackend *LesApiBackend
@@ -106,6 +107,7 @@ func New(ctx *node.ServiceContext, config *eth.Config) (*LightEthereum, error) {
 		shutdownChan:   make(chan bool),
 		networkId:      config.NetworkId,
 		bloomRequests:  make(chan chan *bloombits.Retrieval),
+		filterTasks:    make(chan *filters.BlockFilterTask),
 		bloomIndexer:   eth.NewBloomIndexer(chainDb, params.BloomBitsBlocksClient, params.HelperTrieConfirmations),
 	}
 

--- a/les/bloombits.go
+++ b/les/bloombits.go
@@ -28,6 +28,10 @@ const (
 	// instance to service bloombits lookups for all running filters.
 	bloomServiceThreads = 16
 
+	// filterTaskServiceThreads is the number of goroutines used globally by an Ethereum
+	// instance to service block filter tasks for all running filters.
+	filterTaskServiceThreads = 16
+
 	// bloomFilterThreads is the number of goroutines used locally per filter to
 	// multiplex requests onto the global servicing goroutines.
 	bloomFilterThreads = 3
@@ -67,6 +71,20 @@ func (eth *LightEthereum) startBloomHandlers(sectionSize uint64) {
 						task.Error = err
 					}
 					request <- task
+				}
+			}
+		}()
+	}
+
+	for i := 0; i < filterTaskServiceThreads; i++ {
+		go func() {
+			for {
+				select {
+				case <-eth.shutdownChan:
+					return
+
+				case task := <-eth.filterTasks:
+					task.Do()
 				}
 			}
 		}()


### PR DESCRIPTION
This PR improves log search performance in both full and light client mode by paralellized processing of individual blocks. Block filter tasks are sent to a common channel provided by the filter backend which runs a fixed number of threads and calls a Do() callback on each task. BlockFilterTask.Do() retrieves the header, optionally checks the bloom filter, then (if necessary) retrieves the block receipts and looks for relevant logs. Bloom filter checking is disabled when processing bloombits sections because in those sections a block filter task is only generated for bloom match blocks.

Note: recently the number of false positive bloom filter matches has increased drastically which decreased filtering performance. Parallel processing of matches is definitely needed and also helps this situation temporarily but in the long run we need to either increase the bloom filter size in consensus (maybe make it adaptive) or at least create larger bloom filters in Geth, outside the consensus (and also add them to LES bloom bits trie).