### PR TITLE
whisper: broadcast received hashes to peers

### DIFF
--- a/whisper/whisperv5/doc.go
+++ b/whisper/whisperv5/doc.go
@@ -44,6 +44,7 @@ const (
 	messagesCode         = 1 // normal whisper message
 	p2pCode              = 2 // peer-to-peer message (to be consumed by the peer, but not forwarded any further)
 	p2pRequestCode       = 3 // peer-to-peer message, used by Dapp protocol
+	hashesCode           = 4 // code used to populate known hashes of the peer
 	NumberOfMessageCodes = 64
 
 	paddingMask   = byte(3)

--- a/whisper/whisperv5/peer.go
+++ b/whisper/whisperv5/peer.go
@@ -34,20 +34,23 @@ type Peer struct {
 	ws      p2p.MsgReadWriter
 	trusted bool
 
-	known *set.Set // Messages already known by the peer to avoid wasting bandwidth
-
-	quit chan struct{}
+	known      *set.Set // Messages already known by the peer to avoid wasting bandwidth
+	advertised map[common.Hash]struct{}
+	hashes     chan common.Hash
+	quit       chan struct{}
 }
 
 // newPeer creates a new whisper peer object, but does not run the handshake itself.
 func newPeer(host *Whisper, remote *p2p.Peer, rw p2p.MsgReadWriter) *Peer {
 	return &Peer{
-		host:    host,
-		peer:    remote,
-		ws:      rw,
-		trusted: false,
-		known:   set.New(),
-		quit:    make(chan struct{}),
+		host:       host,
+		peer:       remote,
+		ws:         rw,
+		trusted:    false,
+		known:      set.New(),
+		advertised: make(map[common.Hash]struct{}),
+		hashes:     make(chan common.Hash, 20),
+		quit:       make(chan struct{}),
 	}
 }
 
@@ -101,7 +104,8 @@ func (p *Peer) update() {
 	// Start the tickers for the updates
 	expire := time.NewTicker(expirationCycle)
 	transmit := time.NewTicker(transmissionCycle)
-
+	hashesTransmit := time.NewTicker(100 * time.Millisecond)
+	hashes := make([]common.Hash, 0, 10)
 	// Loop and transmit until termination is requested
 	for {
 		select {
@@ -113,7 +117,27 @@ func (p *Peer) update() {
 				log.Trace("broadcast failed", "reason", err, "peer", p.ID())
 				return
 			}
-
+		case <-hashesTransmit.C:
+			if err := p.broadcastHashes(hashes); err != nil {
+				log.Trace("broadcast of hashes failed", err, "peer", p.ID)
+				return
+			}
+			hashes = hashes[:0]
+		case hash := <-p.hashes:
+			if _, ok := p.advertised[hash]; ok {
+				continue
+			}
+			if p.known.Has(hash) {
+				continue
+			}
+			hashes = append(hashes, hash)
+			if len(hashes) == cap(hashes) {
+				if err := p.broadcastHashes(hashes); err != nil {
+					log.Trace("broadcast of hashes failed", err, "peer", p.ID)
+					return
+				}
+				hashes = hashes[:0]
+			}
 		case <-p.quit:
 			return
 		}
@@ -146,6 +170,10 @@ func (peer *Peer) expire() {
 	}
 }
 
+func (p *Peer) addHash(hash common.Hash) {
+	p.hashes <- hash
+}
+
 // broadcast iterates over the collection of envelopes and transmits yet unknown
 // ones over the network.
 func (p *Peer) broadcast() error {
@@ -164,6 +192,20 @@ func (p *Peer) broadcast() error {
 	}
 	if cnt > 0 {
 		log.Trace("broadcast", "num. messages", cnt)
+	}
+	return nil
+}
+
+func (p *Peer) broadcastHashes(hashes []common.Hash) error {
+	if len(hashes) == 0 {
+		return nil
+	}
+	log.Trace("broadcast", "hashes", hashes)
+	if err := p2p.Send(p.ws, hashesCode, hashes); err != nil {
+		return err
+	}
+	for _, hash := range hashes {
+		p.advertised[hash] = struct{}{}
 	}
 	return nil
 }


### PR DESCRIPTION
This is an attempt to reduce amount of duplicates that are flowing in a network. The idea is to advertise hashes of received envelopes to all peers, that will be used to prevent sending unnecessary traffic.
While bloom filters will allow to reduce incoming traffic they will not change situation with amount of duplicates.

Below you can find measurements from a simulation with a 25 nodes cluster, max peers 14, 25 messages sent with interval of 2s, 9 peers are sending messages. Payload of envelope is 2kb, important to note that the bigger envelope the better are the results.

original v5
========
|HEADERS	|ingress	|egress		|dups	|new	|dups/new|
|-		|-		|-		|-	|-	|-|
|0		|4.650906 mb	|4.858862 mb	|1811	|200	|9.055000|
|1		|5.224706 mb	|4.788949 mb	|2053	|207	|9.917874|
|2		|5.837126 mb	|4.611247 mb	|2322	|200	|11.610000|
|3		|2.371715 mb	|2.882069 mb	|823	|200	|4.115000|
|4		|3.354016 mb	|3.730333 mb	|1249	|200	|6.245000|
|5		|4.243025 mb	|5.917380 mb	|1629	|201	|8.104478|
|6		|5.662559 mb	|4.854089 mb	|2250	|200	|11.250000|
|7		|4.124252 mb	|4.731426 mb	|1583	|200	|7.915000|
|8		|5.808520 mb	|5.695569 mb	|2313	|200	|11.565000|
|9		|4.585557 mb	|5.364363 mb	|1758	|225	|7.813333|
|10		|3.791601 mb	|4.308519 mb	|1414	|225	|6.284444|
|11		|6.080945 mb	|4.504841 mb	|2407	|225	|10.697778|
|12		|5.535078 mb	|6.088154 mb	|2170	|225	|9.644444|
|13		|5.848533 mb	|5.085782 mb	|2306	|225	|10.248889|
|14		|5.708219 mb	|5.911208 mb	|2245	|225	|9.977778|
|15		|2.678413 mb	|2.380754 mb	|927	|225	|4.120000|
|16		|5.293447 mb	|5.675974 mb	|2062	|228	|9.043860|
|17		|4.901472 mb	|4.993619 mb	|1893	|227	|8.339207|
|18		|6.213817 mb	|5.649539 mb	|2463	|226	|10.898230|
|19		|5.363989 mb	|4.228207 mb	|2095	|225	|9.311111|
|20		|5.191960 mb	|5.654901 mb	|2020	|225	|8.977778|
|21		|4.822301 mb	|5.128402 mb	|1858	|225	|8.257778|
|22		|3.413013 mb	|2.849374 mb	|1248	|226	|5.522124|
|23		|5.159920 mb	|5.616253 mb	|2006	|226	|8.876106|
|24		|5.208689 mb	|5.579086 mb	|2021	|229	|8.825328|
|TOTAL		|121.073777 mb	|121.088900 mb	|46926	|5420	|8.664622|

patched version
============
|HEADERS	|ingress	|egress		|dups	|new	|dups/new|
|-		|-		|-		|-	|-	|-|
|0		|2.137692 mb	|2.717945 mb	|669	|200	|3.345000|
|1		|1.831609 mb	|2.728533 mb	|549	|200	|2.745000|
|2		|2.534937 mb	|2.657415 mb	|818	|200	|4.090000|
|3		|2.305786 mb	|2.973900 mb	|736	|200	|3.680000|
|4		|3.097743 mb	|4.141762 mb	|1069	|200	|5.345000|
|5		|2.591569 mb	|3.735047 mb	|864	|200	|4.320000|
|6		|2.659815 mb	|2.879127 mb	|898	|200	|4.490000|
|7		|2.186933 mb	|3.398160 mb	|668	|200	|3.340000|
|8		|2.422804 mb	|1.441340 mb	|803	|200	|4.015000|
|9		|2.736456 mb	|2.718990 mb	|879	|225	|3.906667|
|10		|2.819260 mb	|2.617402 mb	|908	|225	|4.035556|
|11		|3.734951 mb	|2.567705 mb	|1331	|225	|5.915556|
|12		|2.493158 mb	|2.407930 mb	|782	|226	|3.460177|
|13		|2.673105 mb	|3.482759 mb	|861	|225	|3.826667|
|14		|2.955128 mb	|1.982976 mb	|969	|225	|4.306667|
|15		|2.715248 mb	|2.518011 mb	|887	|225	|3.942222|
|16		|2.501511 mb	|2.546142 mb	|775	|225	|3.444444|
|17		|3.613091 mb	|2.005834 mb	|1249	|225	|5.551111|
|18		|2.710604 mb	|3.135862 mb	|865	|225	|3.844444|
|19		|2.567820 mb	|3.103974 mb	|799	|227	|3.519824|
|20		|3.872074 mb	|2.490708 mb	|1356	|229	|5.921397|
|21		|2.107553 mb	|3.288716 mb	|608	|225	|2.702222|
|22		|3.202368 mb	|2.038315 mb	|1073	|225	|4.768889|
|23		|2.802233 mb	|2.798034 mb	|903	|226	|3.995575|
|24		|3.576537 mb	|2.504315 mb	|1229	|225	|5.462222|
|TOTAL		|68.849984 mb	|68.880903 mb	|22548	|5408	|4.158946|

As you see received traffic is reduced almost in half, while the latency should stay the same. This change is obviously should be implemented against v6 protocol. But I really want to hear your feedback about the idea.
