### PR TITLE
les: add missing lock around peer access

### DIFF
--- a/les/fetcher.go
+++ b/les/fetcher.go
@@ -425,6 +425,9 @@ func (f *lightFetcher) nextRequest() (*distReq, uint64) {
 			},
 			canSend: func(dp distPeer) bool {
 				p := dp.(*peer)
+				f.lock.Lock()
+				defer f.lock.Unlock()
+
 				fp := f.peers[p]
 				return fp != nil && fp.nodeByHash[bestHash] != nil
 			},


### PR DESCRIPTION
I think this lock was desperately needed here.

May fix https://github.com/ethereum/go-ethereum/issues/16094, not sure.