### PR TITLE
whisper: only use the node id as a p2p id, not for sending messages

### DIFF
--- a/cmd/wnode/main.go
+++ b/cmd/wnode/main.go
@@ -265,7 +265,7 @@ func initialize() {
 		Config: p2p.Config{
 			PrivateKey:     nodeid,
 			MaxPeers:       maxPeers,
-			Name:           common.MakeName("wnode", "5.0"),
+			Name:           common.MakeName("wnode", "6.0"),
 			Protocols:      shh.Protocols(),
 			ListenAddr:     *argIP,
 			NAT:            nat.Any(),
@@ -656,7 +656,7 @@ func requestExpiredMessagesLoop() {
 		params.PoW = *argServerPoW
 		params.Payload = data
 		params.KeySym = key
-		params.Src = nodeid
+		params.Src = asymKey
 		params.WorkTime = 5
 
 		msg, err := whisper.NewSentMessage(&params)


### PR DESCRIPTION
This is in preparation for the switch to libp2p: the ID generated will be from a private key created with the help of libp2p's crypto library, while Whisper will still use Go's default crypto libraries for encrypting its messages. This change removes a conflict.
It shouldn't have any impact as the person receiving emails is the user, not the node.