### PR TITLE
ethapi: prevent creating contract if no data is provided

### DIFF
--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -1135,6 +1135,18 @@ func (args *SendTxArgs) setDefaults(ctx context.Context, b Backend) error {
 	if args.Data != nil && args.Input != nil && !bytes.Equal(*args.Data, *args.Input) {
 		return errors.New(`Both "data" and "input" are set and not equal. Please use "input" to pass transaction call data.`)
 	}
+	if args.To == nil {
+		// Contract creation
+		var input []byte
+		if args.Data != nil {
+			input = *args.Data
+		} else if args.Input != nil {
+			input = *args.Input
+		}
+		if len(input) == 0 {
+			return errors.New(`Contract creation without any data provided`)
+		}
+	}
 	return nil
 }
 

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -1144,7 +1144,7 @@ func (args *SendTxArgs) setDefaults(ctx context.Context, b Backend) error {
 			input = *args.Input
 		}
 		if len(input) == 0 {
-			return errors.New(`Contract creation without any data provided`)
+			return errors.New(`contract creation without any data provided`)
 		}
 	}
 	return nil


### PR DESCRIPTION
This is a fix that would have prevented https://github.com/ethereum/go-ethereum/issues/16106 . 

Tests: 
```
> personal.signTransaction({from: eth.accounts[1], to:eth.accounts[1],gas:1, gasPrice:1, nonce:1},"test")
{
...
}
> personal.signTransaction({from: eth.accounts[1], gas:1, gasPrice:1, nonce:1},"test")
Error: Contract creation without any data provided
    at web3.js:3143:20
    at web3.js:6347:15
    at web3.js:5081:36
    at <anonymous>:1:1

> personal.signTransaction({from: eth.accounts[1], data: "0x00", gas:1, gasPrice:1, nonce:1},"test")
{
  raw: ...
}
> personal.signTransaction({from: eth.accounts[1], input: "0x00", gas:1, gasPrice:1, nonce:1},"test")
{
...
}
> personal.sendTransaction({from: eth.accounts[1], gas:1, gasPrice:1, nonce:1},"test")
Error: Contract creation without any data provided
    at web3.js:3143:20
    at web3.js:6347:15
    at web3.js:5081:36
    at <anonymous>:1:1

> eth.sendTransaction({from: eth.accounts[1], gas:1, gasPrice:1, nonce:1})
Error: Contract creation without any data provided
    at web3.js:3143:20
    at web3.js:6347:15
    at web3.js:5081:36
    at <anonymous>:1:1

```