### PR TITLE
cmd/utils: change maxpeers vs lightpeers logic to always add lightpeers

### DIFF
--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -818,6 +818,9 @@ func SetP2PConfig(ctx *cli.Context, cfg *p2p.Config) {
 
 	if ctx.GlobalIsSet(MaxPeersFlag.Name) {
 		cfg.MaxPeers = ctx.GlobalInt(MaxPeersFlag.Name)
+		if lightServer && !ctx.GlobalIsSet(LightPeersFlag.Name) {
+			cfg.MaxPeers += lightPeers
+		}
 	} else {
 		if lightServer {
 			cfg.MaxPeers += lightPeers


### PR DESCRIPTION
See issue here:
https://www.reddit.com/r/ethereum/comments/7xi4m1/geth_v180_iceberg_go_and_sync_mainnet_within_a/duap40f/?context=3