### PR TITLE
Test fix for build in xgo

### DIFF
--- a/vendor/gopkg.in/olebedev/go-duktape.v3/duk_minimal_printf.c
+++ b/vendor/gopkg.in/olebedev/go-duktape.v3/duk_minimal_printf.c
@@ -5,7 +5,7 @@
 
 #include <stdarg.h>  /* va_list etc */
 #include <stddef.h>  /* size_t */
-#include <stdint.h>  /* SIZE_MAX */
+#include "duktape.h"  /* SIZE_MAX */
 
 /* Write character with bound checking.  Offset 'off' is updated regardless
  * of whether an actual write is made.  This is necessary to satisfy snprintf()


### PR DESCRIPTION
Following suggestion in https://gitter.im/olebedev/go-duktape:

> @PombeirP I have a funky suggestion. If you have a fix, apply it to the vendored duktape code in the go-ethereum repo, and open a PR with it. It won't be accepted of course, but it will run all our CI against it (linux, macos, windows, arm, mips, whatnot) so you'll get some early feedback if it goes belly up or not. If it's clean, you can open an upstream PR without being afraid that it breaks something (in our code)