### PR TITLE
utils: fix #16138 by checking if vhosts flag is set

### DIFF
--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -695,8 +695,11 @@ func setHTTP(ctx *cli.Context, cfg *node.Config) {
 	if ctx.GlobalIsSet(RPCApiFlag.Name) {
 		cfg.HTTPModules = splitAndTrim(ctx.GlobalString(RPCApiFlag.Name))
 	}
-
-	cfg.HTTPVirtualHosts = splitAndTrim(ctx.GlobalString(RPCVirtualHostsFlag.Name))
+	if ctx.GlobalIsSet(RPCVirtualHostsFlag.Name) {
+		cfg.HTTPVirtualHosts = splitAndTrim(ctx.GlobalString(RPCVirtualHostsFlag.Name))
+	} else if len(cfg.HTTPVirtualHosts) == 0 {
+		cfg.HTTPVirtualHosts = splitAndTrim(ctx.GlobalString(RPCVirtualHostsFlag.Name))
+	}
 }
 
 // setWS creates the WebSocket RPC listener interface string from the set

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -697,8 +697,6 @@ func setHTTP(ctx *cli.Context, cfg *node.Config) {
 	}
 	if ctx.GlobalIsSet(RPCVirtualHostsFlag.Name) {
 		cfg.HTTPVirtualHosts = splitAndTrim(ctx.GlobalString(RPCVirtualHostsFlag.Name))
-	} else if len(cfg.HTTPVirtualHosts) == 0 {
-		cfg.HTTPVirtualHosts = splitAndTrim(ctx.GlobalString(RPCVirtualHostsFlag.Name))
 	}
 }
 

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -400,7 +400,7 @@ var (
 	RPCVirtualHostsFlag = cli.StringFlag{
 		Name:  "rpcvhosts",
 		Usage: "Comma separated list of virtual hostnames from which to accept requests (server enforced). Accepts '*' wildcard.",
-		Value: "localhost",
+		Value: strings.Join(node.DefaultConfig.HTTPVirtualHosts, ","),
 	}
 	RPCApiFlag = cli.StringFlag{
 		Name:  "rpcapi",

--- a/node/defaults.go
+++ b/node/defaults.go
@@ -45,6 +45,7 @@ var DefaultConfig = Config{
 		MaxPeers:   25,
 		NAT:        nat.Any(),
 	},
+	HTTPVirtualHosts: []string{"localhost"},
 }
 
 // DefaultDataDir is the default data directory to use for the databases and other

--- a/node/defaults.go
+++ b/node/defaults.go
@@ -35,17 +35,17 @@ const (
 
 // DefaultConfig contains reasonable default settings.
 var DefaultConfig = Config{
-	DataDir:     DefaultDataDir(),
-	HTTPPort:    DefaultHTTPPort,
-	HTTPModules: []string{"net", "web3"},
-	WSPort:      DefaultWSPort,
-	WSModules:   []string{"net", "web3"},
+	DataDir:          DefaultDataDir(),
+	HTTPPort:         DefaultHTTPPort,
+	HTTPModules:      []string{"net", "web3"},
+	HTTPVirtualHosts: []string{"localhost"},
+	WSPort:           DefaultWSPort,
+	WSModules:        []string{"net", "web3"},
 	P2P: p2p.Config{
 		ListenAddr: ":30303",
 		MaxPeers:   25,
 		NAT:        nat.Any(),
 	},
-	HTTPVirtualHosts: []string{"localhost"},
 }
 
 // DefaultDataDir is the default data directory to use for the databases and other


### PR DESCRIPTION
Snippet from TOML file
```
[Node]
DataDir = "/tmp/foo"
IPCPath = "geth.ipc"
HTTPHost = "127.0.0.1"
HTTPPort = 8545
HTTPVirtualHosts = ["test.com"]
HTTPModules = ["net", "web3", "eth", "shh"]
WSPort = 8546
WSModules = ["net", "web3", "eth", "shh"]

```

Before fix: 

```
#build/bin/geth --config testvhosts.config
[...]
INFO [02-20|13:27:43] HTTP endpoint opened                     url=http://127.0.0.1:8545 cors= vhosts=localhost

```

After fix

```
#build/bin/geth --config testvhosts.config
[...]
INFO [02-20|13:28:57] HTTP endpoint opened                     url=http://127.0.0.1:8545 cors= vhosts=test.com
```
After fix (override)

```
#build/bin/geth --config testvhosts.config --rpcvhosts "foobar"
[...]
INFO [02-20|13:29:11] HTTP endpoint opened                     url=http://127.0.0.1:8545 cors= vhosts=foobar
```

