### PR TITLE
core: flush out trie cache more meaningfully on stop

### DIFF
--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -648,22 +648,21 @@ func (bc *BlockChain) Stop() {
 	bc.wg.Wait()
 
 	// Ensure the state of a recent block is also stored to disk before exiting.
-	// It is fine if this state does not exist (fast start/stop cycle), but it is
-	// advisable to leave an N block gap from the head so 1) a restart loads up
-	// the last N blocks as sync assistance to remote nodes; 2) a restart during
-	// a (small) reorg doesn't require deep reprocesses; 3) chain "repair" from
-	// missing states are constantly tested.
-	//
-	// This may be tuned a bit on mainnet if its too annoying to reprocess the last
-	// N blocks.
+	// We're writing three different states to catch different restart scenarios:
+	//  - HEAD:     So we don't need to reprocess any blocks in the general case
+	//  - HEAD-1:   So we don't do large reorgs if our HEAD becomes an uncle
+	//  - HEAD-127: So we have a hard limit on the number of blocks reexecuted
 	if !bc.cacheConfig.Disabled {
 		triedb := bc.stateCache.TrieDB()
-		if number := bc.CurrentBlock().NumberU64(); number >= triesInMemory {
-			recent := bc.GetBlockByNumber(bc.CurrentBlock().NumberU64() - triesInMemory + 1)
 
-			log.Info("Writing cached state to disk", "block", recent.Number(), "hash", recent.Hash(), "root", recent.Root())
-			if err := triedb.Commit(recent.Root(), true); err != nil {
-				log.Error("Failed to commit recent state trie", "err", err)
+		for _, offset := range []uint64{0, 1, triesInMemory - 1} {
+			if number := bc.CurrentBlock().NumberU64(); number > offset {
+				recent := bc.GetBlockByNumber(bc.CurrentBlock().NumberU64() - offset)
+
+				log.Info("Writing cached state to disk", "block", recent.Number(), "hash", recent.Hash(), "root", recent.Root())
+				if err := triedb.Commit(recent.Root(), true); err != nil {
+					log.Error("Failed to commit recent state trie", "err", err)
+				}
 			}
 		}
 		for !bc.triegc.Empty() {

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -657,7 +657,7 @@ func (bc *BlockChain) Stop() {
 
 		for _, offset := range []uint64{0, 1, triesInMemory - 1} {
 			if number := bc.CurrentBlock().NumberU64(); number > offset {
-				recent := bc.GetBlockByNumber(bc.CurrentBlock().NumberU64() - offset)
+				recent := bc.GetBlockByNumber(number - offset)
 
 				log.Info("Writing cached state to disk", "block", recent.Number(), "hash", recent.Hash(), "root", recent.Root())
 				if err := triedb.Commit(recent.Root(), true); err != nil {

--- a/core/genesis_test.go
+++ b/core/genesis_test.go
@@ -118,10 +118,12 @@ func TestSetupGenesis(t *testing.T) {
 				// Commit the 'old' genesis block with Homestead transition at #2.
 				// Advance to block #4, past the homestead transition block of customg.
 				genesis := oldcustomg.MustCommit(db)
+
 				bc, _ := NewBlockChain(db, nil, oldcustomg.Config, ethash.NewFullFaker(), vm.Config{})
 				defer bc.Stop()
-				bc.SetValidator(bproc{})
-				bc.InsertChain(makeBlockChainWithDiff(genesis, []int{2, 3, 4, 5}, 0))
+
+				blocks, _ := GenerateChain(oldcustomg.Config, genesis, ethash.NewFaker(), db, 4, nil)
+				bc.InsertChain(blocks)
 				bc.CurrentBlock()
 				// This should return a compatibility error.
 				return SetupGenesisBlock(db, &customg)


### PR DESCRIPTION
The current code writes out the HEAD-127 trie on graceful shutdown. The idea was:

 * On startup, we load the latest 128 tries into memory, immediately being able to serve remote nodes.
 * As long as the network did a reorg smaller than 128 blocks, we don't reexecute large chain segments.

Unfortunately this has the annoying drawback that starting the node always re-executes 128 blocks. Since people in general won't constantly start/stop/start/stop/etc, it's annoying to reprocess that many blocks. If your node was offline for more than 30 mins, you'll either way load enough tries into memory to help remote nodes sync.

This PR fixes the issue by writing out 3 tries instead of only one on stop:

 * `HEAD`:     So we don't need to reprocess any blocks in the general case.
 * `HEAD-1`:   So we don't do large reorgs if our HEAD becomes an uncle.
 * `HEAD-127`: So we have a hard limit on the number of blocks reexecuted during deep reorgs.

---

The second commit in this PR upgrades all the legacy blockchain tests to use test chains generated by the chain maker. The old code used "invalid" chains with only some specific header fields set (others left unset) in combination with disabled block validation. This however was both murky even until now, as well as caused the trie cache to blow up due to invalid state roots. Instead of continuing to patch the "invalid" chains to somehow pass the tests, I just completely dumped them and replaces with valid ones generated via chain makers.