### PR TITLE
p2p: remove unused code

### DIFF
--- a/p2p/message.go
+++ b/p2p/message.go
@@ -112,30 +112,6 @@ func SendItems(w MsgWriter, msgcode uint64, elems ...interface{}) error {
 	return Send(w, msgcode, elems)
 }
 
-// netWrapper wraps a MsgReadWriter with locks around
-// ReadMsg/WriteMsg and applies read/write deadlines.
-type netWrapper struct {
-	rmu, wmu sync.Mutex
-
-	rtimeout, wtimeout time.Duration
-	conn               net.Conn
-	wrapped            MsgReadWriter
-}
-
-func (rw *netWrapper) ReadMsg() (Msg, error) {
-	rw.rmu.Lock()
-	defer rw.rmu.Unlock()
-	rw.conn.SetReadDeadline(time.Now().Add(rw.rtimeout))
-	return rw.wrapped.ReadMsg()
-}
-
-func (rw *netWrapper) WriteMsg(msg Msg) error {
-	rw.wmu.Lock()
-	defer rw.wmu.Unlock()
-	rw.conn.SetWriteDeadline(time.Now().Add(rw.wtimeout))
-	return rw.wrapped.WriteMsg(msg)
-}
-
 // eofSignal wraps a reader with eof signaling. the eof channel is
 // closed when the wrapped reader returns an error or when count bytes
 // have been read.

--- a/p2p/message.go
+++ b/p2p/message.go
@@ -22,8 +22,6 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
-	"net"
-	"sync"
 	"sync/atomic"
 	"time"
 

--- a/p2p/server.go
+++ b/p2p/server.go
@@ -36,9 +36,7 @@ import (
 )
 
 const (
-	defaultDialTimeout      = 15 * time.Second
-	refreshPeersInterval    = 30 * time.Second
-	staticPeerCheckInterval = 15 * time.Second
+	defaultDialTimeout = 15 * time.Second
 
 	// Connectivity defaults.
 	maxActiveDialTasks     = 16


### PR DESCRIPTION
This PR removes unused code from `p2p` package.

Namely:
 - `staticPeerCheckInterval` and `refreshPeersInterval` constants
 - `netWrapper` structure

Both become unused after introducing new dialer in https://github.com/ethereum/go-ethereum/commit/1440f9a37a8baf67b989ddf0b8cc30c9a1970e14

Usually, deadcode is not harmful, but one of the unpleasant consequences here is that someone may get wrong assumptions about p2p layer behavior looking at those constants.