### PR TITLE
les, light: fix receipt reconstruction in client

### DIFF
--- a/light/odr.go
+++ b/light/odr.go
@@ -26,6 +26,7 @@ import (
 	"github.com/ethereum/go-ethereum/core"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/ethdb"
+	"github.com/ethereum/go-ethereum/params"
 )
 
 // NoOdr is the default context passed to an ODR capable function when the ODR
@@ -118,14 +119,14 @@ func (req *BlockRequest) StoreResult(db ethdb.Database) {
 // ReceiptsRequest is the ODR request type for retrieving block bodies
 type ReceiptsRequest struct {
 	OdrRequest
-	Hash     common.Hash
-	Number   uint64
+	Config   *params.ChainConfig
+	Block    *types.Block
 	Receipts types.Receipts
 }
 
 // StoreResult stores the retrieved data in local database
 func (req *ReceiptsRequest) StoreResult(db ethdb.Database) {
-	core.WriteBlockReceipts(db, req.Hash, req.Number, req.Receipts)
+	core.WriteBlockReceipts(db, req.Block.Hash(), req.Block.NumberU64(), req.Receipts)
 }
 
 // ChtRequest is the ODR request type for state/storage trie entries

--- a/light/odr_test.go
+++ b/light/odr_test.go
@@ -72,7 +72,7 @@ func (odr *testOdr) Retrieve(ctx context.Context, req OdrRequest) error {
 	case *BlockRequest:
 		req.Rlp = core.GetBodyRLP(odr.sdb, req.Hash, core.GetBlockNumber(odr.sdb, req.Hash))
 	case *ReceiptsRequest:
-		req.Receipts = core.GetBlockReceipts(odr.sdb, req.Hash, core.GetBlockNumber(odr.sdb, req.Hash))
+		req.Receipts = core.GetBlockReceipts(odr.sdb, req.Block.Hash(), req.Block.NumberU64())
 	case *TrieRequest:
 		t, _ := trie.New(req.Id.Root, trie.NewDatabase(odr.sdb))
 		nodes := NewNodeSet()

--- a/light/odr_util.go
+++ b/light/odr_util.go
@@ -130,7 +130,15 @@ func GetBlockReceipts(ctx context.Context, odr OdrBackend, hash common.Hash, num
 	if receipts != nil {
 		return receipts, nil
 	}
-	r := &ReceiptsRequest{Hash: hash, Number: number}
+	// Receipts unavailable locally, we need the full block to reconstruct
+	block, err := GetBlock(ctx, odr, hash, number)
+	if err != nil {
+		return nil, err
+	}
+	genesis := core.GetCanonicalHash(odr.Database(), 0)
+	config, _ := core.GetChainConfig(odr.Database(), genesis)
+
+	r := &ReceiptsRequest{Config: config, Block: block}
 	if err := odr.Retrieve(ctx, r); err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
The light client currently only retrieves the remote receipts and stores it in the database as is. However, the consensus fields are not enough for proper filtering, rather there are derived fields in receipts too. This PR patches up the light client to generate all the derived fields locally before storing it in the database.

There are no modifications to the light client protocol or the light servers, so any patched client will work. The only place this PR won't work is for receipts retrieved before updating the clients as those are already stored in the database without the derived data reconstructed. I can live with this.

Supersedes https://github.com/ethereum/go-ethereum/pull/16159.