### PR TITLE
Set rpcRequest.service as methodNotFoundError.service value

### DIFF
--- a/rpc/server.go
+++ b/rpc/server.go
@@ -421,7 +421,7 @@ func (s *Server) readRequest(codec ServerCodec) ([]*serverRequest, bool, Error) 
 					}
 				}
 			} else {
-				requests[i] = &serverRequest{id: r.id, err: &methodNotFoundError{r.method, r.method}}
+				requests[i] = &serverRequest{id: r.id, err: &methodNotFoundError{r.service, r.method}}
 			}
 			continue
 		}


### PR DESCRIPTION
RPC Server readRequest method sets the serverRequest error service
value as the rpcRequest.method and this change sets it to the right
service value.