### PR TITLE
cmd/faucet: resolve twitter user from final redirect

### DIFF
--- a/cmd/faucet/faucet.go
+++ b/cmd/faucet/faucet.go
@@ -686,8 +686,6 @@ func authTwitter(url string) (string, string, common.Address, error) {
 	if len(parts) < 4 || parts[len(parts)-2] != "status" {
 		return "", "", common.Address{}, errors.New("Invalid Twitter status URL")
 	}
-	username := parts[len(parts)-3]
-
 	// Twitter's API isn't really friendly with direct links. Still, we don't
 	// want to do ask read permissions from users, so just load the public posts and
 	// scrape it for the Ethereum address and profile URL.
@@ -696,6 +694,13 @@ func authTwitter(url string) (string, string, common.Address, error) {
 		return "", "", common.Address{}, err
 	}
 	defer res.Body.Close()
+
+	// Resolve the username from the final redirect, no intermediate junk
+	parts = strings.Split(res.Request.URL.String(), "/")
+	if len(parts) < 4 || parts[len(parts)-2] != "status" {
+		return "", "", common.Address{}, errors.New("Invalid Twitter status URL")
+	}
+	username := parts[len(parts)-3]
 
 	body, err := ioutil.ReadAll(res.Body)
 	if err != nil {


### PR DESCRIPTION
Twitter gladly ignores the user field of a tweet URL, doing a redirect under the hood to the real user.

The faucet unfortunately looked only at the original URL to derive the user, so a malicious user could just keep changing the url to random junk users, and whilst Twitter returns a live tweet, the faucet detects it coming form different junk users instead of the real one.

This PR swaps the username resolution logic to operate on the final redirect URL, not the original one.