### PR TITLE
contracts/chequebook: increase interval between auto deposits

### DIFF
--- a/contracts/chequebook/cheque_test.go
+++ b/contracts/chequebook/cheque_test.go
@@ -281,8 +281,8 @@ func TestDeposit(t *testing.T) {
 		t.Fatalf("expected balance %v, got %v", exp, chbook.Balance())
 	}
 
-	// autodeposit every 30ms if new cheque issued
-	interval := 30 * time.Millisecond
+	// autodeposit every 200ms if new cheque issued
+	interval := 200 * time.Millisecond
 	chbook.AutoDeposit(interval, common.Big1, balance)
 	_, err = chbook.Issue(addr1, amount)
 	if err != nil {


### PR DESCRIPTION
This PR is supposed to address the flaky `TestDeposit` test, which we have on master (for example see https://travis-ci.org/ethereum/go-ethereum/jobs/345245972 )

I am able to reproduce the failure locally when decreasing the interval between auto deposits, and considering that Travis arch is less powerful, increasing the timeout should reduce/remove the flakiness of this time-based test.