### PR TITLE
eth, les: Allow exceeding maxPeers for trusted peers

### DIFF
--- a/eth/handler.go
+++ b/eth/handler.go
@@ -249,7 +249,8 @@ func (pm *ProtocolManager) newPeer(pv int, p *p2p.Peer, rw p2p.MsgReadWriter) *p
 // handle is the callback invoked to manage the life cycle of an eth peer. When
 // this function terminates, the peer is disconnected.
 func (pm *ProtocolManager) handle(p *peer) error {
-	if pm.peers.Len() >= pm.maxPeers {
+	// Ignore maxPeers if this is a trusted peer
+	if pm.peers.Len() >= pm.maxPeers && !p.Peer.Info().Network.Trusted {
 		return p2p.DiscTooManyPeers
 	}
 	p.Log().Debug("Ethereum peer connected", "name", p.Name())

--- a/les/handler.go
+++ b/les/handler.go
@@ -260,7 +260,8 @@ func (pm *ProtocolManager) newPeer(pv int, nv uint64, p *p2p.Peer, rw p2p.MsgRea
 // handle is the callback invoked to manage the life cycle of a les peer. When
 // this function terminates, the peer is disconnected.
 func (pm *ProtocolManager) handle(p *peer) error {
-	if pm.peers.Len() >= pm.maxPeers {
+	// Ignore maxPeers if this is a trusted peer
+	if pm.peers.Len() >= pm.maxPeers && !p.Peer.Info().Network.Trusted {
 		return p2p.DiscTooManyPeers
 	}
 


### PR DESCRIPTION
Trusted peers are supposed to be able to bypass the maxPeers limit. This logic was appropriately executed in [p2p/server.go](https://github.com/ethereum/go-ethereum/blob/master/p2p/server.go#L706-L709), but the eth handler and les handler also check maxPeers which were previously ignoring the trusted flag for peers.

I tested this locally with some empty blockchains (I'm on bad wifi, can't complete a sync right now), and the "too many peers" error did indeed go away after this fix.

Let me know if there is a good place to write a test for this, or if this is good enough as is (fairly simple change).

Fixes #3326, #14472