### PR TITLE
Matching messages acceleration

### DIFF
--- a/whisper/whisperv5/filter_test.go
+++ b/whisper/whisperv5/filter_test.go
@@ -797,7 +797,7 @@ func TestTopicsMapping(t *testing.T) {
 		matched := []string{}
 		fs.topicMatcher.matchedTopics(env.Topic, &matched)
 		if !hasFilterID(matched, filterID) {
-			t.Fatalf("failed MatchEnvelope symmetric with seed %d, step %d.", seed, i)
+			t.Fatalf("failed matchedTopics, step %d.", i)
 		}
 
 		//test match without filter
@@ -807,7 +807,7 @@ func TestTopicsMapping(t *testing.T) {
 		matched = matched[:0]
 		fs.topicMatcher.matchedTopics(env.Topic, &matched)
 		if hasFilterID(matched, filterID) {
-			t.Fatalf("failed MatchEnvelope symmetric with seed %d, step %d.", seed, i)
+			t.Fatalf("failed match without filter, step %d.", i)
 		}
 
 		//test match with changed topic
@@ -819,7 +819,7 @@ func TestTopicsMapping(t *testing.T) {
 		matched = matched[:0]
 		fs.topicMatcher.matchedTopics(env.Topic, &matched)
 		if hasFilterID(matched, filterID) {
-			t.Fatalf("failed MatchEnvelope symmetric with seed %d, step %d.", seed, i)
+			t.Fatalf("failed match with changed topic, step %d.", i)
 		}
 		if !fs.Uninstall(filterID) {
 			t.Fatal("Failed to uninstall filter")
@@ -850,7 +850,7 @@ func TestTopicsMapping_MatchAllTopics_Success(t *testing.T) {
 	matched := []string{}
 	fs.topicMatcher.matchedTopics(topic, &matched)
 	if !hasFilterID(matched, filterID) {
-		t.Fatalf("failed MatchEnvelope symmetric with seed %d, step %d.", seed)
+		t.Fatal("failed matchedTopics")
 	}
 	if _, ok := fs.topicMatcher.mapper[ALL_TOPICS][filterID]; !ok {
 		t.Fatal("watcher mapping incorrect")
@@ -863,7 +863,7 @@ func TestTopicsMapping_MatchAllTopics_Success(t *testing.T) {
 	matched = matched[:0]
 	fs.topicMatcher.matchedTopics(topic, &matched)
 	if hasFilterID(matched, filterID) {
-		t.Fatalf("failed MatchEnvelope symmetric with seed %d, step %d.", seed)
+		t.Fatal("failed match without filter")
 	}
 
 	if _, ok := fs.topicMatcher.mapper[ALL_TOPICS][filterID]; ok {
@@ -925,7 +925,7 @@ func benchFilter_MatchMessage(b *testing.B, numOfFilters int) {
 
 		_, err = fs.Install(f)
 		if err != nil {
-			b.Fatalf("failed generateFilter with seed %d: %s.", seed, err)
+			b.Fatalf("failed install filter with seed %d: %s.", seed, err)
 		}
 
 	}

--- a/whisper/whisperv5/filter_test.go
+++ b/whisper/whisperv5/filter_test.go
@@ -723,6 +723,7 @@ func TestVariableTopics(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed generateFilter with seed %d: %s.", seed, err)
 	}
+
 	fs := generateFilters()
 
 	filterID, err := fs.Install(f)

--- a/whisper/whisperv5/whisper_test.go
+++ b/whisper/whisperv5/whisper_test.go
@@ -542,7 +542,7 @@ func TestCustomization(t *testing.T) {
 
 	const smallPoW = 0.00001
 
-	f, err := generateFilter(t, true)
+	f, err := generateFilter(true)
 	if err != nil {
 		t.Fatalf("failed generateMessageParams with seed %d: %s.", seed, err)
 	}
@@ -636,7 +636,7 @@ func TestSymmetricSendCycle(t *testing.T) {
 	w.Start(nil)
 	defer w.Stop()
 
-	filter1, err := generateFilter(t, true)
+	filter1, err := generateFilter(true)
 	if err != nil {
 		t.Fatalf("failed generateMessageParams with seed %d: %s.", seed, err)
 	}
@@ -725,7 +725,7 @@ func TestSymmetricSendWithoutAKey(t *testing.T) {
 	w.Start(nil)
 	defer w.Stop()
 
-	filter, err := generateFilter(t, true)
+	filter, err := generateFilter(true)
 	if err != nil {
 		t.Fatalf("failed generateMessageParams with seed %d: %s.", seed, err)
 	}
@@ -793,7 +793,7 @@ func TestSymmetricSendKeyMismatch(t *testing.T) {
 	w.Start(nil)
 	defer w.Stop()
 
-	filter, err := generateFilter(t, true)
+	filter, err := generateFilter(true)
 	if err != nil {
 		t.Fatalf("failed generateMessageParams with seed %d: %s.", seed, err)
 	}

--- a/whisper/whisperv6/filter.go
+++ b/whisper/whisperv6/filter.go
@@ -26,6 +26,11 @@ import (
 	"github.com/ethereum/go-ethereum/log"
 )
 
+const (
+	ALL_TOPICS        = ""
+	MAX_POOL_CAPACITY = 1000
+)
+
 // Filter represents a Whisper message filter
 type Filter struct {
 	Src        *ecdsa.PublicKey  // Sender of the message
@@ -42,16 +47,18 @@ type Filter struct {
 
 // Filters represents a collection of filters
 type Filters struct {
-	watchers map[string]*Filter
-	whisper  *Whisper
-	mutex    sync.RWMutex
+	watchers     map[string]*Filter
+	whisper      *Whisper
+	mutex        sync.RWMutex
+	topicMatcher *topicMatcher
 }
 
 // NewFilters returns a newly created filter collection
 func NewFilters(w *Whisper) *Filters {
 	return &Filters{
-		watchers: make(map[string]*Filter),
-		whisper:  w,
+		watchers:     make(map[string]*Filter),
+		whisper:      w,
+		topicMatcher: newTopicMatcher(),
 	}
 }
 
@@ -82,6 +89,7 @@ func (fs *Filters) Install(watcher *Filter) (string, error) {
 	}
 
 	fs.watchers[id] = watcher
+	fs.topicMatcher.addFilterToTopicsMapping(watcher, id)
 	return id, err
 }
 
@@ -92,6 +100,7 @@ func (fs *Filters) Uninstall(id string) bool {
 	defer fs.mutex.Unlock()
 	if fs.watchers[id] != nil {
 		delete(fs.watchers, id)
+		fs.topicMatcher.removeTopicFromTopicMapping(id)
 		return true
 	}
 	return false
@@ -108,15 +117,22 @@ func (fs *Filters) Get(id string) *Filter {
 // for the envelope's topic.
 func (fs *Filters) NotifyWatchers(env *Envelope, p2pMessage bool) {
 	var msg *ReceivedMessage
+	matchedTopics := fs.topicMatcher.take()
+	defer fs.topicMatcher.resolve(matchedTopics)
 
 	fs.mutex.RLock()
 	defer fs.mutex.RUnlock()
 
-	i := -1 // only used for logging info
-	for _, watcher := range fs.watchers {
-		i++
+	fs.topicMatcher.matchedTopics(env.Topic, &matchedTopics)
+	for _, watcherID := range matchedTopics {
+		watcher, ok := fs.watchers[watcherID]
+		if !ok {
+			log.Trace(fmt.Sprintf("msg [%x], filter [%s]: filter not exists", env.Hash(), watcherID))
+			continue
+		}
+
 		if p2pMessage && !watcher.AllowP2P {
-			log.Trace(fmt.Sprintf("msg [%x], filter [%d]: p2p messages are not allowed", env.Hash(), i))
+			log.Trace(fmt.Sprintf("msg [%x], filter [%s]: p2p messages are not allowed", env.Hash(), watcherID))
 			continue
 		}
 
@@ -128,10 +144,10 @@ func (fs *Filters) NotifyWatchers(env *Envelope, p2pMessage bool) {
 			if match {
 				msg = env.Open(watcher)
 				if msg == nil {
-					log.Trace("processing message: failed to open", "message", env.Hash().Hex(), "filter", i)
+					log.Trace("processing message: failed to open", "message", env.Hash().Hex(), "filter", watcherID)
 				}
 			} else {
-				log.Trace("processing message: does not match", "message", env.Hash().Hex(), "filter", i)
+				log.Trace("processing message: does not match", "message", env.Hash().Hex(), "filter", watcherID)
 			}
 		}
 
@@ -201,9 +217,9 @@ func (f *Filter) MatchMessage(msg *ReceivedMessage) bool {
 	}
 
 	if f.expectsAsymmetricEncryption() && msg.isAsymmetricEncryption() {
-		return IsPubKeyEqual(&f.KeyAsym.PublicKey, msg.Dst) && f.MatchTopic(msg.Topic)
+		return IsPubKeyEqual(&f.KeyAsym.PublicKey, msg.Dst)
 	} else if f.expectsSymmetricEncryption() && msg.isSymmetricEncryption() {
-		return f.SymKeyHash == msg.SymKeyHash && f.MatchTopic(msg.Topic)
+		return f.SymKeyHash == msg.SymKeyHash
 	}
 	return false
 }
@@ -216,38 +232,6 @@ func (f *Filter) MatchEnvelope(envelope *Envelope) bool {
 		return false
 	}
 
-	return f.MatchTopic(envelope.Topic)
-}
-
-// MatchTopic checks that the filter captures a given topic.
-func (f *Filter) MatchTopic(topic TopicType) bool {
-	if len(f.Topics) == 0 {
-		// any topic matches
-		return true
-	}
-
-	for _, bt := range f.Topics {
-		if matchSingleTopic(topic, bt) {
-			return true
-		}
-	}
-	return false
-}
-
-func matchSingleTopic(topic TopicType, bt []byte) bool {
-	if len(bt) > TopicLength {
-		bt = bt[:TopicLength]
-	}
-
-	if len(bt) < TopicLength {
-		return false
-	}
-
-	for j, b := range bt {
-		if topic[j] != b {
-			return false
-		}
-	}
 	return true
 }
 
@@ -260,4 +244,83 @@ func IsPubKeyEqual(a, b *ecdsa.PublicKey) bool {
 	}
 	// the curve is always the same, just compare the points
 	return a.X.Cmp(b.X) == 0 && a.Y.Cmp(b.Y) == 0
+}
+
+type topicMatcher struct {
+	//structure - map[topic]map[filterID]
+	//mapping for topics
+	//"" topic means that the filter allows all topic values
+	mapper map[string]map[string]struct{}
+	mx     sync.RWMutex
+	pool   sync.Pool
+}
+
+func newTopicMatcher() *topicMatcher {
+	tm := new(topicMatcher)
+	tm.mapper = make(map[string]map[string]struct{})
+	tm.mapper[ALL_TOPICS] = make(map[string]struct{})
+	tm.pool.New = func() interface{} {
+		return []string{}
+	}
+	return tm
+}
+
+func (fs *topicMatcher) take() []string {
+	return fs.pool.Get().([]string)
+}
+func (fs *topicMatcher) resolve(s []string) {
+	if cap(s) > MAX_POOL_CAPACITY {
+		return
+	}
+	fs.pool.Put(s[:0])
+}
+
+func (fs *topicMatcher) addFilterToTopicsMapping(watcher *Filter, id string) {
+	fs.mx.Lock()
+	defer fs.mx.Unlock()
+
+	for i := range fs.prepareTopicsMapping(watcher) {
+		topicMapping, ok := fs.mapper[i]
+		if !ok {
+			fs.mapper[i] = make(map[string]struct{})
+			topicMapping = fs.mapper[i]
+		}
+		topicMapping[id] = struct{}{}
+	}
+}
+
+func (fs *topicMatcher) removeTopicFromTopicMapping(id string) {
+	fs.mx.Lock()
+	defer fs.mx.Unlock()
+	for i := range fs.mapper {
+		delete(fs.mapper[i], id)
+	}
+}
+
+func (fs *topicMatcher) prepareTopicsMapping(watcher *Filter) map[string]struct{} {
+	topics := make(map[string]struct{}, len(watcher.Topics))
+
+	if len(watcher.Topics) == 0 {
+		topics[ALL_TOPICS] = struct{}{}
+		return topics
+	}
+
+	for _, topic := range watcher.Topics {
+		topics[common.ToHex(topic)] = struct{}{}
+	}
+
+	return topics
+}
+
+func (fs *topicMatcher) matchedTopics(topic TopicType, matched *[]string) {
+	fs.mx.RLock()
+	defer fs.mx.RUnlock()
+
+	for i := range fs.mapper[ALL_TOPICS] {
+		*matched = append(*matched, i)
+	}
+
+	for i := range fs.mapper[topic.String()] {
+		*matched = append(*matched, i)
+	}
 }

--- a/whisper/whisperv6/filter_test.go
+++ b/whisper/whisperv6/filter_test.go
@@ -844,7 +844,7 @@ func TestTopicsMapping(t *testing.T) {
 		matched := []string{}
 		fs.topicMatcher.matchedTopics(env.Topic, &matched)
 		if !hasFilterID(matched, filterID) {
-			t.Fatalf("failed MatchEnvelope symmetric with seed %d, step %d.", seed, i)
+			t.Fatalf("failed matchedTopics, step %d.", seed, i)
 		}
 
 		//test match without filter
@@ -854,7 +854,7 @@ func TestTopicsMapping(t *testing.T) {
 		matched = matched[:0]
 		fs.topicMatcher.matchedTopics(env.Topic, &matched)
 		if hasFilterID(matched, filterID) {
-			t.Fatalf("failed MatchEnvelope symmetric with seed %d, step %d.", seed, i)
+			t.Fatalf("failed match without filter, step %d.", i)
 		}
 
 		//test match with changed topic
@@ -866,7 +866,7 @@ func TestTopicsMapping(t *testing.T) {
 		matched = matched[:0]
 		fs.topicMatcher.matchedTopics(env.Topic, &matched)
 		if hasFilterID(matched, filterID) {
-			t.Fatalf("failed MatchEnvelope symmetric with seed %d, step %d.", seed, i)
+			t.Fatalf("failed match with changed topic, step %d.", i)
 		}
 		if !fs.Uninstall(filterID) {
 			t.Fatal("Failed to uninstall filter")
@@ -897,7 +897,7 @@ func TestTopicsMapping_MatchAllTopics_Success(t *testing.T) {
 	matched := []string{}
 	fs.topicMatcher.matchedTopics(topic, &matched)
 	if !hasFilterID(matched, filterID) {
-		t.Fatalf("failed MatchEnvelope symmetric with seed %d, step %d.", seed)
+		t.Fatal("failed matchedTopics")
 	}
 	if _, ok := fs.topicMatcher.mapper[ALL_TOPICS][filterID]; !ok {
 		t.Fatal("watcher mapping incorrect")
@@ -910,7 +910,7 @@ func TestTopicsMapping_MatchAllTopics_Success(t *testing.T) {
 	matched = matched[:0]
 	fs.topicMatcher.matchedTopics(topic, &matched)
 	if hasFilterID(matched, filterID) {
-		t.Fatalf("failed MatchEnvelope symmetric with seed %d, step %d.", seed)
+		t.Fatal("failed match without filter")
 	}
 
 	if _, ok := fs.topicMatcher.mapper[ALL_TOPICS][filterID]; ok {
@@ -972,7 +972,7 @@ func benchFilter_MatchMessage(b *testing.B, numOfFilters int) {
 
 		_, err = fs.Install(f)
 		if err != nil {
-			b.Fatalf("failed generateFilter with seed %d: %s.", seed, err)
+			b.Fatalf("failed install filter with seed %d: %s.", seed, err)
 		}
 
 	}

--- a/whisper/whisperv6/filter_test.go
+++ b/whisper/whisperv6/filter_test.go
@@ -844,7 +844,7 @@ func TestTopicsMapping(t *testing.T) {
 		matched := []string{}
 		fs.topicMatcher.matchedTopics(env.Topic, &matched)
 		if !hasFilterID(matched, filterID) {
-			t.Fatalf("failed matchedTopics, step %d.", seed, i)
+			t.Fatalf("failed matchedTopics, step %d.", i)
 		}
 
 		//test match without filter

--- a/whisper/whisperv6/filter_test.go
+++ b/whisper/whisperv6/filter_test.go
@@ -22,6 +22,7 @@ import (
 	"testing"
 	"time"
 
+	"fmt"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/crypto"
 )
@@ -48,7 +49,7 @@ type FilterTestCase struct {
 	msgCnt int
 }
 
-func generateFilter(t *testing.T, symmetric bool) (*Filter, error) {
+func generateFilter(symmetric bool) (*Filter, error) {
 	var f Filter
 	f.Messages = make(map[common.Hash]*ReceivedMessage)
 
@@ -62,8 +63,7 @@ func generateFilter(t *testing.T, symmetric bool) (*Filter, error) {
 
 	key, err := crypto.GenerateKey()
 	if err != nil {
-		t.Fatalf("generateFilter 1 failed with seed %d.", seed)
-		return nil, err
+		return nil, fmt.Errorf("generateFilter 1 failed with seed %d. Error: %s", seed, err.Error())
 	}
 	f.Src = &key.PublicKey
 
@@ -74,8 +74,7 @@ func generateFilter(t *testing.T, symmetric bool) (*Filter, error) {
 	} else {
 		f.KeyAsym, err = crypto.GenerateKey()
 		if err != nil {
-			t.Fatalf("generateFilter 2 failed with seed %d.", seed)
-			return nil, err
+			return nil, fmt.Errorf("generateFilter 2 failed with seed %d. Error: %s", seed, err.Error())
 		}
 	}
 
@@ -94,7 +93,10 @@ func generateFilters() *Filters {
 func generateTestCases(t *testing.T, SizeTestFilters int) []FilterTestCase {
 	cases := make([]FilterTestCase, SizeTestFilters)
 	for i := 0; i < SizeTestFilters; i++ {
-		f, _ := generateFilter(t, true)
+		f, err := generateFilter(true)
+		if err != nil {
+			t.Fatal(err)
+		}
 		cases[i].f = f
 		cases[i].alive = mrand.Int()&int(1) == 0
 	}
@@ -145,8 +147,10 @@ func TestInstallSymKeyGeneratesHash(t *testing.T) {
 
 	w := New(&Config{})
 	filters := NewFilters(w)
-	filter, _ := generateFilter(t, true)
-
+	filter, err := generateFilter(true)
+	if err != nil {
+		t.Fatal(err)
+	}
 	// save the current SymKeyHash for comparison
 	initialSymKeyHash := filter.SymKeyHash
 
@@ -154,7 +158,7 @@ func TestInstallSymKeyGeneratesHash(t *testing.T) {
 	var invalid common.Hash
 	filter.SymKeyHash = invalid
 
-	_, err := filters.Install(filter)
+	_, err = filters.Install(filter)
 
 	if err != nil {
 		t.Fatalf("Error installing the filter: %s", err)
@@ -172,7 +176,10 @@ func TestInstallIdenticalFilters(t *testing.T) {
 
 	w := New(&Config{})
 	filters := NewFilters(w)
-	filter1, _ := generateFilter(t, true)
+	filter1, err := generateFilter(true)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	// Copy the first filter since some of its fields
 	// are randomly gnerated.
@@ -184,7 +191,7 @@ func TestInstallIdenticalFilters(t *testing.T) {
 		Messages: make(map[common.Hash]*ReceivedMessage),
 	}
 
-	_, err := filters.Install(filter1)
+	_, err = filters.Install(filter1)
 
 	if err != nil {
 		t.Fatalf("Error installing the first filter with seed %d: %s", seed, err)
@@ -242,7 +249,10 @@ func TestInstallFilterWithSymAndAsymKeys(t *testing.T) {
 
 	w := New(&Config{})
 	filters := NewFilters(w)
-	filter1, _ := generateFilter(t, true)
+	filter1, err := generateFilter(true)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	asymKey, err := crypto.GenerateKey()
 	if err != nil {
@@ -296,12 +306,12 @@ func TestComparePubKey(t *testing.T) {
 func TestMatchEnvelope(t *testing.T) {
 	InitSingleTest()
 
-	fsym, err := generateFilter(t, true)
+	fsym, err := generateFilter(true)
 	if err != nil {
 		t.Fatalf("failed generateFilter with seed %d: %s.", seed, err)
 	}
 
-	fasym, err := generateFilter(t, false)
+	fasym, err := generateFilter(false)
 	if err != nil {
 		t.Fatalf("failed generateFilter() with seed %d: %s.", seed, err)
 	}
@@ -407,7 +417,7 @@ func TestMatchMessageSym(t *testing.T) {
 		t.Fatalf("failed generateMessageParams with seed %d: %s.", seed, err)
 	}
 
-	f, err := generateFilter(t, true)
+	f, err := generateFilter(true)
 	if err != nil {
 		t.Fatalf("failed generateFilter with seed %d: %s.", seed, err)
 	}
@@ -486,7 +496,7 @@ func TestMatchMessageSym(t *testing.T) {
 func TestMatchMessageAsym(t *testing.T) {
 	InitSingleTest()
 
-	f, err := generateFilter(t, false)
+	f, err := generateFilter(false)
 	if err != nil {
 		t.Fatalf("failed generateFilter with seed %d: %s.", seed, err)
 	}
@@ -764,7 +774,7 @@ func TestVariableTopics(t *testing.T) {
 		t.Fatalf("failed Wrap with seed %d: %s.", seed, err)
 	}
 
-	f, err := generateFilter(t, true)
+	f, err := generateFilter(true)
 	if err != nil {
 		t.Fatalf("failed generateFilter with seed %d: %s.", seed, err)
 	}
@@ -817,7 +827,7 @@ func TestTopicsMapping(t *testing.T) {
 		t.Fatalf("failed Wrap with seed %d: %s.", seed, err)
 	}
 
-	f, err := generateFilter(t, true)
+	f, err := generateFilter(true)
 	if err != nil {
 		t.Fatalf("failed generateFilter with seed %d: %s.", seed, err)
 	}
@@ -867,7 +877,7 @@ func TestTopicsMapping(t *testing.T) {
 func TestTopicsMapping_MatchAllTopics_Success(t *testing.T) {
 	InitSingleTest()
 
-	f, err := generateFilter(t, true)
+	f, err := generateFilter(true)
 	if err != nil {
 		t.Fatalf("failed generateFilter with seed %d: %s.", seed, err)
 	}
@@ -915,4 +925,64 @@ func hasFilterID(matched []string, filterID string) bool {
 		}
 	}
 	return false
+}
+
+func BenchmarkFilter_MatchEnvelope_5Filters(b *testing.B) {
+	InitSingleTest()
+	benchFilter_MatchMessage(b, 5)
+}
+func BenchmarkFilter_MatchEnvelope_10Filters(b *testing.B) {
+	InitSingleTest()
+	benchFilter_MatchMessage(b, 10)
+}
+func BenchmarkFilter_MatchEnvelope_20Filters(b *testing.B) {
+	InitSingleTest()
+	benchFilter_MatchMessage(b, 20)
+}
+func BenchmarkFilter_MatchEnvelope_50Filters(b *testing.B) {
+	InitSingleTest()
+	benchFilter_MatchMessage(b, 50)
+}
+func BenchmarkFilter_MatchEnvelope_100Filters(b *testing.B) {
+	InitSingleTest()
+	benchFilter_MatchMessage(b, 100)
+}
+
+func benchFilter_MatchMessage(b *testing.B, numOfFilters int) {
+	params, err := generateMessageParams()
+	if err != nil {
+		b.Fatalf("failed generateMessageParams with seed %d: %s.", seed, err)
+	}
+	msg, err := NewSentMessage(params)
+	if err != nil {
+		b.Fatalf("failed to create new message with seed %d: %s.", seed, err)
+	}
+	env, err := msg.Wrap(params)
+	if err != nil {
+		b.Fatalf("failed Wrap with seed %d: %s.", seed, err)
+	}
+
+	fs := generateFilters()
+
+	for i := 0; i < numOfFilters; i++ {
+		f, err := generateFilter(true)
+		if err != nil {
+			b.Fatalf("failed generateFilter with seed %d: %s.", seed, err)
+		}
+
+		_, err = fs.Install(f)
+		if err != nil {
+			b.Fatalf("failed generateFilter with seed %d: %s.", seed, err)
+		}
+
+	}
+
+	var topic TopicType
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		mrand.Read(topic[:])
+		env.Topic = topic
+
+		fs.NotifyWatchers(env, false)
+	}
 }

--- a/whisper/whisperv6/whisper_test.go
+++ b/whisper/whisperv6/whisper_test.go
@@ -524,7 +524,7 @@ func TestCustomization(t *testing.T) {
 
 	const smallPoW = 0.00001
 
-	f, err := generateFilter(t, true)
+	f, err := generateFilter(true)
 	if err != nil {
 		t.Fatalf("failed generateMessageParams with seed %d: %s.", seed, err)
 	}
@@ -618,7 +618,7 @@ func TestSymmetricSendCycle(t *testing.T) {
 	w.Start(nil)
 	defer w.Stop()
 
-	filter1, err := generateFilter(t, true)
+	filter1, err := generateFilter(true)
 	if err != nil {
 		t.Fatalf("failed generateMessageParams with seed %d: %s.", seed, err)
 	}
@@ -707,7 +707,7 @@ func TestSymmetricSendWithoutAKey(t *testing.T) {
 	w.Start(nil)
 	defer w.Stop()
 
-	filter, err := generateFilter(t, true)
+	filter, err := generateFilter(true)
 	if err != nil {
 		t.Fatalf("failed generateMessageParams with seed %d: %s.", seed, err)
 	}
@@ -775,7 +775,7 @@ func TestSymmetricSendKeyMismatch(t *testing.T) {
 	w.Start(nil)
 	defer w.Stop()
 
-	filter, err := generateFilter(t, true)
+	filter, err := generateFilter(true)
 	if err != nil {
 		t.Fatalf("failed generateMessageParams with seed %d: %s.", seed, err)
 	}


### PR DESCRIPTION
NotifyWatchers has to iterate over all filters. It could become a bottleneck for users with a large number of filters.
Results of benchmark(8 topics per filter):

|   | 100 filters  | 50 filters  | 20 filters  | 10 filters  | 5 filters  |
|---|---|---|---|---|---|
| before  | 187707 ns/op  | 61981 ns/op  | 26762 ns/op  | 12554 ns/op  | 6283 ns/op  |
|  after | 424 ns/op  | 422 ns/op  |  412 ns/op | 406 ns/op  | 405 ns/op  |

Closes https://github.com/status-im/status-go/issues/642
