### PR TITLE
eth, les: wait for the downloads to be complete before stopping

### DIFF
--- a/eth/downloader/downloader.go
+++ b/eth/downloader/downloader.go
@@ -141,6 +141,8 @@ type Downloader struct {
 	quitCh   chan struct{} // Quit channel to signal termination
 	quitLock sync.RWMutex  // Lock to prevent double closes
 
+	downloads sync.WaitGroup // Keeps track of the currently active downloads
+
 	// Testing hooks
 	syncInitHook     func(uint64, uint64)  // Method to call upon initiating a new sync run
 	bodyFetchHook    func([]*types.Header) // Method to call upon starting a block body fetch
@@ -398,7 +400,9 @@ func (d *Downloader) synchronise(id string, hash common.Hash, td *big.Int, mode 
 // specified peer and head hash.
 func (d *Downloader) syncWithPeer(p *peerConnection, hash common.Hash, td *big.Int) (err error) {
 	d.mux.Post(StartEvent{})
+	d.downloads.Add(1)
 	defer func() {
+		d.downloads.Done()
 		// reset on error
 		if err != nil {
 			d.mux.Post(FailedEvent{err})
@@ -528,6 +532,10 @@ func (d *Downloader) Terminate() {
 
 	// Cancel any pending download requests
 	d.Cancel()
+
+	// Wait, so external dependencies aren't destroyed
+	// until the download processing is done.
+	d.downloads.Wait()
 }
 
 // fetchHeight retrieves the head header of the remote peer to aid in estimating

--- a/eth/handler.go
+++ b/eth/handler.go
@@ -230,6 +230,9 @@ func (pm *ProtocolManager) Stop() {
 	// Quit fetcher, txsyncLoop.
 	close(pm.quitSync)
 
+	// Stop downloader and make sure that all the running downloads are complete.
+	pm.downloader.Terminate()
+
 	// Disconnect existing sessions.
 	// This also closes the gate for any new registrations on the peer set.
 	// sessions which are already established but not added to pm.peers yet

--- a/eth/sync.go
+++ b/eth/sync.go
@@ -135,7 +135,6 @@ func (pm *ProtocolManager) syncer() {
 	// Start and ensure cleanup of sync mechanisms
 	pm.fetcher.Start()
 	defer pm.fetcher.Stop()
-	defer pm.downloader.Terminate()
 
 	// Wait for different events to fire synchronisation operations
 	forceSync := time.NewTicker(forceSyncCycle)

--- a/les/handler.go
+++ b/les/handler.go
@@ -241,6 +241,9 @@ func (pm *ProtocolManager) Stop() {
 
 	close(pm.quitSync) // quits syncer, fetcher
 
+	// Stop downloader and make sure that all the running downloads are complete.
+	pm.downloader.Terminate()
+
 	// Disconnect existing sessions.
 	// This also closes the gate for any new registrations on the peer set.
 	// sessions which are already established but not added to pm.peers yet

--- a/les/sync.go
+++ b/les/sync.go
@@ -36,7 +36,6 @@ func (pm *ProtocolManager) syncer() {
 	// Start and ensure cleanup of sync mechanisms
 	//pm.fetcher.Start()
 	//defer pm.fetcher.Stop()
-	defer pm.downloader.Terminate()
 
 	// Wait for different events to fire synchronisation operations
 	//forceSync := time.Tick(forceSyncCycle)


### PR DESCRIPTION
When stopping a node, and the list of headers to rollback is full (in `downloader.go:1160`) the database might be closed before the rollback changes are written there.

That causes the crashes like https://github.com/status-im/status-go/issues/652 and might be a source of a potential data loss/corruption.

This PR adds a method to wait for the downloads to be actually processed before proceeding forward and closing the DB.