### PR TITLE
whisper: mailserver no longer supports the signature vaidation

### DIFF
--- a/whisper/mailserver/mailserver.go
+++ b/whisper/mailserver/mailserver.go
@@ -17,7 +17,6 @@
 package mailserver
 
 import (
-	"bytes"
 	"encoding/binary"
 	"fmt"
 
@@ -175,7 +174,10 @@ func (s *WMailServer) validateRequest(peerID []byte, request *whisper.Envelope) 
 	if len(src)-len(peerID) == 1 {
 		src = src[1:]
 	}
-	if !bytes.Equal(peerID, src) {
+
+	// if you want to check the signature, you can do it here. e.g.:
+	// if !bytes.Equal(peerID, src) {
+	if src == nil {
 		log.Warn(fmt.Sprintf("Wrong signature of p2p request"))
 		return false, 0, 0, topic
 	}

--- a/whisper/mailserver/server_test.go
+++ b/whisper/mailserver/server_test.go
@@ -167,7 +167,8 @@ func singleRequest(t *testing.T, server *WMailServer, env *whisper.Envelope, p *
 
 	src[0]++
 	ok, lower, upper, topic = server.validateRequest(src, request)
-	if ok {
+	if !ok {
+		// request should be valid regardless of signature
 		t.Fatalf("request validation false positive, seed: %d (lower: %d, upper: %d).", seed, lower, upper)
 	}
 }

--- a/whisper/mailserver/server_test.go
+++ b/whisper/mailserver/server_test.go
@@ -169,7 +169,7 @@ func singleRequest(t *testing.T, server *WMailServer, env *whisper.Envelope, p *
 	ok, lower, upper, topic = server.validateRequest(src, request)
 	if !ok {
 		// request should be valid regardless of signature
-		t.Fatalf("request validation false positive, seed: %d (lower: %d, upper: %d).", seed, lower, upper)
+		t.Fatalf("request validation false negative, seed: %d (lower: %d, upper: %d).", seed, lower, upper)
 	}
 }
 


### PR DESCRIPTION
this change was necessary due to https://github.com/ethereum/go-ethereum/pull/16102 and planned transition to libp2p