### PR TITLE
whisper: fixed dataraces

### DIFF
--- a/whisper/whisperv6/peer_test.go
+++ b/whisper/whisperv6/peer_test.go
@@ -472,9 +472,9 @@ func checkBloomFilterExchangeOnce(t *testing.T, mustPass bool) bool {
 	for i, node := range nodes {
 		for peer := range node.shh.peers {
 			peer.bloomMu.Lock()
-			eqals := bytes.Equal(peer.bloomFilter, masterBloomFilter)
+			equals := bytes.Equal(peer.bloomFilter, masterBloomFilter)
 			peer.bloomMu.Unlock()
-			if !eqals {
+			if !equals {
 				if mustPass {
 					t.Fatalf("node %d: failed to exchange bloom filter requirement in round %d. \n%x expected \n%x got",
 						i, round, masterBloomFilter, peer.bloomFilter)

--- a/whisper/whisperv6/peer_test.go
+++ b/whisper/whisperv6/peer_test.go
@@ -23,6 +23,7 @@ import (
 	mrand "math/rand"
 	"net"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -71,7 +72,7 @@ var keys = []string{
 }
 
 type TestData struct {
-	started int
+	started int64
 	counter [NumNodes]int
 	mutex   sync.RWMutex
 }
@@ -240,9 +241,7 @@ func startServer(t *testing.T, s *p2p.Server) {
 		t.Fatalf("failed to start the fisrt server.")
 	}
 
-	result.mutex.Lock()
-	defer result.mutex.Unlock()
-	result.started++
+	atomic.AddInt64(&result.started, 1)
 }
 
 func stopServers() {
@@ -472,7 +471,10 @@ func checkPowExchange(t *testing.T) {
 func checkBloomFilterExchangeOnce(t *testing.T, mustPass bool) bool {
 	for i, node := range nodes {
 		for peer := range node.shh.peers {
-			if !bytes.Equal(peer.bloomFilter, masterBloomFilter) {
+			peer.bloomMu.Lock()
+			eqals := bytes.Equal(peer.bloomFilter, masterBloomFilter)
+			peer.bloomMu.Unlock()
+			if !eqals {
 				if mustPass {
 					t.Fatalf("node %d: failed to exchange bloom filter requirement in round %d. \n%x expected \n%x got",
 						i, round, masterBloomFilter, peer.bloomFilter)
@@ -500,11 +502,13 @@ func checkBloomFilterExchange(t *testing.T) {
 
 func waitForServersToStart(t *testing.T) {
 	const iterations = 200
+	var started int64
 	for j := 0; j < iterations; j++ {
 		time.Sleep(50 * time.Millisecond)
-		if result.started == NumNodes {
+		started = atomic.LoadInt64(&result.started)
+		if started == NumNodes {
 			return
 		}
 	}
-	t.Fatalf("Failed to start all the servers, running: %d", result.started)
+	t.Fatalf("Failed to start all the servers, running: %d", started)
 }


### PR DESCRIPTION
Fixed dataraces:

```
WARNING: DATA RACE
Read at 0x00c4200c8f88 by goroutine 39:
  github.com/ethereum/go-ethereum/whisper/whisperv6.checkBloomFilterExchangeOnce()
      /home/b00ris/go/src/github.com/ethereum/go-ethereum/whisper/whisperv6/peer_test.go:475 +0x16d
  github.com/ethereum/go-ethereum/whisper/whisperv6.checkBloomFilterExchange()
      /home/b00ris/go/src/github.com/ethereum/go-ethereum/whisper/whisperv6/peer_test.go:493 +0x58
  github.com/ethereum/go-ethereum/whisper/whisperv6.TestSimulation()
      /home/b00ris/go/src/github.com/ethereum/go-ethereum/whisper/whisperv6/peer_test.go:134 +0x118
  testing.tRunner()
      /usr/local/go/src/testing/testing.go:657 +0x107

Previous write at 0x00c4200c8f88 by goroutine 345:
  github.com/ethereum/go-ethereum/whisper/whisperv6.(*Peer).setBloomFilter()
      /home/b00ris/go/src/github.com/ethereum/go-ethereum/whisper/whisperv6/peer.go:238 +0x92
  github.com/ethereum/go-ethereum/whisper/whisperv6.(*Whisper).runMessageLoop()
      /home/b00ris/go/src/github.com/ethereum/go-ethereum/whisper/whisperv6/whisper.go:712 +0x1f61
  github.com/ethereum/go-ethereum/whisper/whisperv6.(*Whisper).HandlePeer()
      /home/b00ris/go/src/github.com/ethereum/go-ethereum/whisper/whisperv6/whisper.go:644 +0x1d2
  github.com/ethereum/go-ethereum/whisper/whisperv6.(*Whisper).HandlePeer-fm()
      /home/b00ris/go/src/github.com/ethereum/go-ethereum/whisper/whisperv6/whisper.go:122 +0x63
  github.com/ethereum/go-ethereum/p2p.(*Peer).startProtocols.func1()
      /home/b00ris/go/src/github.com/ethereum/go-ethereum/p2p/peer.go:349 +0x8b

```

and 

```
WARNING: DATA RACE
Read at 0x00c42001f538 by goroutine 39:
  github.com/ethereum/go-ethereum/whisper/whisperv6.checkBloomFilterExchangeOnce()
      /home/b00ris/go/src/github.com/ethereum/go-ethereum/whisper/whisperv6/peer_test.go:474 +0x16d
  github.com/ethereum/go-ethereum/whisper/whisperv6.checkBloomFilterExchange()
      /home/b00ris/go/src/github.com/ethereum/go-ethereum/whisper/whisperv6/peer_test.go:492 +0x58
  github.com/ethereum/go-ethereum/whisper/whisperv6.TestSimulation()
      /home/b00ris/go/src/github.com/ethereum/go-ethereum/whisper/whisperv6/peer_test.go:135 +0x118
  testing.tRunner()
      /usr/local/go/src/testing/testing.go:657 +0x107

Previous write at 0x00c42001f538 by goroutine 370:
  github.com/ethereum/go-ethereum/whisper/whisperv6.(*Peer).setBloomFilter()
      /home/b00ris/go/src/github.com/ethereum/go-ethereum/whisper/whisperv6/peer.go:238 +0x92
  github.com/ethereum/go-ethereum/whisper/whisperv6.(*Whisper).runMessageLoop()
      /home/b00ris/go/src/github.com/ethereum/go-ethereum/whisper/whisperv6/whisper.go:712 +0x1f61
  github.com/ethereum/go-ethereum/whisper/whisperv6.(*Whisper).HandlePeer()
      /home/b00ris/go/src/github.com/ethereum/go-ethereum/whisper/whisperv6/whisper.go:644 +0x1d2
  github.com/ethereum/go-ethereum/whisper/whisperv6.(*Whisper).HandlePeer-fm()
      /home/b00ris/go/src/github.com/ethereum/go-ethereum/whisper/whisperv6/whisper.go:122 +0x63
  github.com/ethereum/go-ethereum/p2p.(*Peer).startProtocols.func1()
      /home/b00ris/go/src/github.com/ethereum/go-ethereum/p2p/peer.go:349 +0x8b

```