### PR TITLE
internal/ethapi: fix getTransactionReceipt

### DIFF
--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -1035,14 +1035,14 @@ func (s *PublicTransactionPoolAPI) GetRawTransactionByHash(ctx context.Context, 
 func (s *PublicTransactionPoolAPI) GetTransactionReceipt(ctx context.Context, hash common.Hash) (map[string]interface{}, error) {
 	tx, blockHash, blockNumber, index := core.GetTransaction(s.b.ChainDb(), hash)
 	if tx == nil {
-		return nil, errors.New("unknown transaction")
+		return nil, nil
 	}
 	receipts, err := s.b.GetReceipts(ctx, blockHash)
 	if err != nil {
 		return nil, err
 	}
 	if len(receipts) <= int(index) {
-		return nil, errors.New("unknown receipt")
+		return nil, nil
 	}
 	receipt := receipts[index]
 


### PR DESCRIPTION
This PR is a half revert of https://github.com/ethereum/go-ethereum/pull/15665.

The original issue the above PR was meant to fix is the graceful handling of some database corruption where a receipt was missing. Unfortunately the PR broke our RPC APIs.

In Go world it generally makes sense to return an `error` if something is not found, but the RPC API doesn't have standardized errors speced. Every tool assumes that if the thing requested is not available, `null` is returned. The above PR broke this. This PR tries to fix it.

*Note: It is debatable whether or not the spec should be changed, but we should conform to the spec and the expected behavior, not the "clean" behavior unfortunately.*

Fixes #16213
Fixes #16092 