### PR TITLE
metrics: fix flaky Example metrics test

### DIFF
--- a/metrics/metrics_test.go
+++ b/metrics/metrics_test.go
@@ -6,6 +6,7 @@ import (
 	"log"
 	"sync"
 	"testing"
+	"time"
 )
 
 const FANOUT = 128
@@ -114,7 +115,7 @@ func Example() {
 
 	// Threadsafe registration
 	t := GetOrRegisterTimer("db.get.latency", nil)
-	t.Time(func() {})
+	t.Time(func() { time.Sleep(10 * time.Millisecond) })
 	t.Update(1)
 
 	fmt.Println(c.Count())

--- a/metrics/timer_test.go
+++ b/metrics/timer_test.go
@@ -47,8 +47,8 @@ func TestTimerStop(t *testing.T) {
 func TestTimerFunc(t *testing.T) {
 	tm := NewTimer()
 	tm.Time(func() { time.Sleep(50e6) })
-	if max := tm.Max(); 45e6 > max || max > 55e6 {
-		t.Errorf("tm.Max(): 45e6 > %v || %v > 55e6\n", max, max)
+	if max := tm.Max(); 35e6 > max || max > 95e6 {
+		t.Errorf("tm.Max(): 35e6 > %v || %v > 95e6\n", max, max)
 	}
 }
 


### PR DESCRIPTION
1. `Example` test is failing on AppVeyor, as the timing of the empty function updates the timer sample with value 0 due to Windows' time resolution. Adding a short sleep should predictably fix the output with 1 being the lowest value in the sample.

2. `TestTimerFunc` constraints are relaxed, because of a failure I saw on Travis:
```
--- FAIL: TestTimerFunc (0.08s)

	timer_test.go:51: tm.Max(): 45e6 > 82254038 || 82254038 > 55e6

FAIL
```