### PR TITLE
cmd/evm, core/vm, internal/ethapi: don't disable call gas metering

### DIFF
--- a/cmd/evm/main.go
+++ b/cmd/evm/main.go
@@ -86,10 +86,6 @@ var (
 		Name:  "create",
 		Usage: "indicates the action should be create rather than call",
 	}
-	DisableGasMeteringFlag = cli.BoolFlag{
-		Name:  "nogasmetering",
-		Usage: "disable gas metering",
-	}
 	GenesisFlag = cli.StringFlag{
 		Name:  "prestate",
 		Usage: "JSON file with prestate (genesis) config",
@@ -128,7 +124,6 @@ func init() {
 		ValueFlag,
 		DumpFlag,
 		InputFlag,
-		DisableGasMeteringFlag,
 		MemProfileFlag,
 		CPUProfileFlag,
 		StatDumpFlag,

--- a/cmd/evm/runner.go
+++ b/cmd/evm/runner.go
@@ -161,9 +161,8 @@ func runCmd(ctx *cli.Context) error {
 		GasPrice: utils.GlobalBig(ctx, PriceFlag.Name),
 		Value:    utils.GlobalBig(ctx, ValueFlag.Name),
 		EVMConfig: vm.Config{
-			Tracer:             tracer,
-			Debug:              ctx.GlobalBool(DebugFlag.Name) || ctx.GlobalBool(MachineFlag.Name),
-			DisableGasMetering: ctx.GlobalBool(DisableGasMeteringFlag.Name),
+			Tracer: tracer,
+			Debug:  ctx.GlobalBool(DebugFlag.Name) || ctx.GlobalBool(MachineFlag.Name),
 		},
 	}
 

--- a/core/vm/interpreter.go
+++ b/core/vm/interpreter.go
@@ -37,8 +37,6 @@ type Config struct {
 	// NoRecursion disabled Interpreter call, callcode,
 	// delegate call and create.
 	NoRecursion bool
-	// Disable gas metering
-	DisableGasMetering bool
 	// Enable recording of SHA3/keccak preimages
 	EnablePreimageRecording bool
 	// JumpTable contains the EVM instruction table. This
@@ -189,14 +187,11 @@ func (in *Interpreter) Run(contract *Contract, input []byte) (ret []byte, err er
 				return nil, errGasUintOverflow
 			}
 		}
-
-		if !in.cfg.DisableGasMetering {
-			// consume the gas and return an error if not enough gas is available.
-			// cost is explicitly set so that the capture state defer method cas get the proper cost
-			cost, err = operation.gasCost(in.gasTable, in.evm, contract, stack, mem, memorySize)
-			if err != nil || !contract.UseGas(cost) {
-				return nil, ErrOutOfGas
-			}
+		// consume the gas and return an error if not enough gas is available.
+		// cost is explicitly set so that the capture state defer method cas get the proper cost
+		cost, err = operation.gasCost(in.gasTable, in.evm, contract, stack, mem, memorySize)
+		if err != nil || !contract.UseGas(cost) {
+			return nil, ErrOutOfGas
 		}
 		if memorySize > 0 {
 			mem.Resize(memorySize)


### PR DESCRIPTION
Fixes #16193 

Our VM currently supports disabling gas metering, which was forcefully enabled for `eth_call`. Unfortunately, not all code paths check properly this debug property. This issue didn't surface until https://github.com/ethereum/go-ethereum/pull/15563 was merged, which started tracking some gas dynamics off the stack. These calculations didn't happen any more with `DisableGasMetering == true`, resulting in CALLs to precompiles to be done with gas 0. Apparently, some code didn't get the memo that gas metering was disabled and failed the call with OOG.

This PR gets rid of `DisableGasMetering` altogether. **This might not be the best approach**, since then gas calculation will be incurred with any `eth_call`. The reasons I did it like this is because 1) eth_call will behave exactly as eth_sendTransaction, which is arguably good; and 2) it seems dangerous to me especially long term that we'll have similar breakages.

Open to feedback or alternative proposals.