### PR TITLE
github: config for probot-stale bot

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,0 +1,17 @@
+# Number of days of inactivity before an issue becomes stale
+daysUntilStale: 366
+# Number of days of inactivity before a stale issue is closed
+daysUntilClose: 40
+# Issues with these labels will never be considered stale
+exemptLabels:
+  - pinned
+  - security
+# Label to use when marking an issue as stale
+staleLabel: wontfix
+# Comment to post when marking an issue as stale. Set to `false` to disable
+markComment: >
+  This issue has been automatically marked as stale because it has not had
+  recent activity. It will be closed if no further activity occurs. Thank you
+  for your contributions.
+# Comment to post when closing a stale issue. Set to `false` to disable
+closeComment: false

--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,13 +1,13 @@
 # Number of days of inactivity before an issue becomes stale
 daysUntilStale: 366
 # Number of days of inactivity before a stale issue is closed
-daysUntilClose: 40
+daysUntilClose: 42
 # Issues with these labels will never be considered stale
 exemptLabels:
   - pinned
   - security
 # Label to use when marking an issue as stale
-staleLabel: wontfix
+staleLabel: stale
 # Comment to post when marking an issue as stale. Set to `false` to disable
 markComment: >
   This issue has been automatically marked as stale because it has not had


### PR DESCRIPTION
This PR is about introducing the stale bot (https://probot.github.io/apps/stale/) to the go-ethereum repo. It has to be enabled/installed by someone with admin access to the Github organisation.

The idea is to mark as stale all PRs and Issues which are older than one year, and in case there is no activity on them, close them 40 days later.

cc @karalabe @fjl 

In case this is approved (and AFAIK it has already been discussed and approved), then @holiman you would have to click the install and point the bot to the go-ethereum repo, which should just pick-up this file.