### PR TITLE
internal: fix downloader synchronising judgement

### DIFF
--- a/eth/downloader/downloader.go
+++ b/eth/downloader/downloader.go
@@ -253,10 +253,18 @@ func (d *Downloader) Progress() ethereum.SyncProgress {
 	case LightSync:
 		current = d.lightchain.CurrentHeader().Number.Uint64()
 	}
+
+	// If the current block number is greater than the highest block number when synchronization started
+	// due to pivot point moving, using the current block number as a replacement.
+	highest := d.syncStatsChainHeight
+	if current > highest {
+		highest = current
+	}
+
 	return ethereum.SyncProgress{
 		StartingBlock: d.syncStatsChainOrigin,
 		CurrentBlock:  current,
-		HighestBlock:  d.syncStatsChainHeight,
+		HighestBlock:  highest,
 		PulledStates:  d.syncStatsState.processed,
 		KnownStates:   d.syncStatsState.processed + d.syncStatsState.pending,
 	}

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -80,7 +80,7 @@ func (s *PublicEthereumAPI) Syncing() (interface{}, error) {
 	progress := s.b.Downloader().Progress()
 
 	// Return not syncing if the synchronisation already completed
-	if progress.CurrentBlock >= progress.HighestBlock {
+	if !s.b.Downloader().Synchronising() {
 		return false, nil
 	}
 	// Otherwise gather the block sync stats


### PR DESCRIPTION
During the `fast sync`, the pivot point may move if the pivot block is stale. So the original  judgement is inaccurate if the pivot point is moved.

We should judgement whether downloader is in work or not always by the `synchronising` status flag.