### PR TITLE
abigen: Support passing extra flags to solc

### DIFF
--- a/cmd/abigen/main.go
+++ b/cmd/abigen/main.go
@@ -33,9 +33,10 @@ var (
 	binFlag = flag.String("bin", "", "Path to the Ethereum contract bytecode (generate deploy method)")
 	typFlag = flag.String("type", "", "Struct name for the binding (default = package name)")
 
-	solFlag  = flag.String("sol", "", "Path to the Ethereum contract Solidity source to build and bind")
-	solcFlag = flag.String("solc", "solc", "Solidity compiler to use if source builds are requested")
-	excFlag  = flag.String("exc", "", "Comma separated types to exclude from binding")
+	solFlag      = flag.String("sol", "", "Path to the Ethereum contract Solidity source to build and bind")
+	solcFlag     = flag.String("solc", "solc", "Solidity compiler to use if source builds are requested")
+	excFlag      = flag.String("exc", "", "Comma separated types to exclude from binding")
+	solcArgsFlag = flag.String("flags", "", "Space separated extra flags to pass to solc")
 
 	pkgFlag  = flag.String("pkg", "", "Package name to generate the binding into")
 	outFlag  = flag.String("out", "", "Output file for the generated binding (default = stdout)")
@@ -81,7 +82,11 @@ func main() {
 		for _, kind := range strings.Split(*excFlag, ",") {
 			exclude[strings.ToLower(kind)] = true
 		}
-		contracts, err := compiler.CompileSolidity(*solcFlag, *solFlag)
+		var solcArgs []string
+		if *solcArgsFlag != "" {
+			solcArgs = strings.Split(*solcArgsFlag, " ")
+		}
+		contracts, err := compiler.CompileSolidity(*solcFlag, solcArgs, *solFlag)
 		if err != nil {
 			fmt.Printf("Failed to build Solidity contract: %v\n", err)
 			os.Exit(-1)

--- a/common/compiler/solidity.go
+++ b/common/compiler/solidity.go
@@ -119,7 +119,7 @@ func CompileSolidityString(solc, source string) (map[string]*Contract, error) {
 }
 
 // CompileSolidity compiles all given Solidity source files.
-func CompileSolidity(solc string, sourcefiles ...string) (map[string]*Contract, error) {
+func CompileSolidity(solc string, extraArgs []string, sourcefiles ...string) (map[string]*Contract, error) {
 	if len(sourcefiles) == 0 {
 		return nil, errors.New("solc: no source files")
 	}
@@ -131,7 +131,8 @@ func CompileSolidity(solc string, sourcefiles ...string) (map[string]*Contract, 
 	if err != nil {
 		return nil, err
 	}
-	args := append(s.makeArgs(), "--")
+	args := append(s.makeArgs(), extraArgs...)
+	args = append(args, "--")
 	cmd := exec.Command(s.Path, append(args, sourcefiles...)...)
 	return s.run(cmd, source)
 }


### PR DESCRIPTION
My use case is that I want to pass `--allow-paths` to `solc`, as without it
I cannot compile my contracts.

Currently, it is impossible to invoke `abigen` with custom `solc` flags. Rather than
proxying every single `solc` flag, add a `-flags` flag which allows space separated
overrides.

Usage:
```
abigen -sol contract.sol -pkg something -out somefile.go -flags "--allow-paths foo/bar"
```