### PR TITLE
vendor: bump duktape to get rid of build warning

### DIFF
--- a/vendor/gopkg.in/olebedev/go-duktape.v3/api.go
+++ b/vendor/gopkg.in/olebedev/go-duktape.v3/api.go
@@ -1,8 +1,8 @@
 package duktape
 
 /*
-#cgo !windows CFLAGS: -std=c99 -O3 -Wall -fomit-frame-pointer -fstrict-aliasing
-#cgo windows CFLAGS: -O3 -Wall -fomit-frame-pointer -fstrict-aliasing
+#cgo !windows CFLAGS: -std=c99 -O3 -Wall -Wno-unused-value -fomit-frame-pointer -fstrict-aliasing
+#cgo windows CFLAGS: -O3 -Wall -Wno-unused-value -fomit-frame-pointer -fstrict-aliasing
 
 #include "duktape.h"
 #include "duk_logging.h"

--- a/vendor/gopkg.in/olebedev/go-duktape.v3/duktape.go
+++ b/vendor/gopkg.in/olebedev/go-duktape.v3/duktape.go
@@ -5,6 +5,7 @@ package duktape
 #cgo windows CFLAGS: -O3 -Wall -fomit-frame-pointer -fstrict-aliasing
 #cgo linux LDFLAGS: -lm
 #cgo freebsd LDFLAGS: -lm
+#cgo openbsd LDFLAGS: -lm
 
 #include "duktape.h"
 #include "duk_logging.h"

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -742,10 +742,10 @@
 			"revisionTime": "2016-06-21T03:49:01Z"
 		},
 		{
-			"checksumSHA1": "YvuEbc0a032zr+BTp/YbBQojiuY=",
+			"checksumSHA1": "vndxs5Tv09/8S+Dr2PBAiM557lI=",
 			"path": "gopkg.in/olebedev/go-duktape.v3",
-			"revision": "9af39127cb024b355a6a0221769f6ddfe3f542e7",
-			"revisionTime": "2017-12-20T12:19:14Z"
+			"revision": "abf0ba0be5d5d36b1f9266463cc320b9a5ab224e",
+			"revisionTime": "2018-03-02T12:15:09Z"
 		},
 		{
 			"checksumSHA1": "4BwmmgQUhWtizsR2soXND0nqZ1I=",


### PR DESCRIPTION
Tiny irrelevant version bump to get rid of one C compiler warning littering the builds.