### PR TITLE
eth: update higest block we know during the sync if a higher was found

### DIFF
--- a/eth/downloader/downloader.go
+++ b/eth/downloader/downloader.go
@@ -1300,7 +1300,7 @@ func (d *Downloader) processHeaders(origin uint64, pivot uint64, td *big.Int) er
 			// Update the highest block number we know if a higher one is found.
 			d.syncStatsLock.Lock()
 			if d.syncStatsChainHeight < origin {
-				d.syncStatsChainHeight = origin
+				d.syncStatsChainHeight = origin - 1
 			}
 			d.syncStatsLock.Unlock()
 

--- a/eth/downloader/downloader.go
+++ b/eth/downloader/downloader.go
@@ -1296,6 +1296,14 @@ func (d *Downloader) processHeaders(origin uint64, pivot uint64, td *big.Int) er
 				headers = headers[limit:]
 				origin += uint64(limit)
 			}
+
+			// Update the highest block number we know if a higher one is found.
+			d.syncStatsLock.Lock()
+			if d.syncStatsChainHeight < origin {
+				d.syncStatsChainHeight = origin
+			}
+			d.syncStatsLock.Unlock()
+
 			// Signal the content downloaders of the availablility of new tasks
 			for _, ch := range []chan bool{d.bodyWakeCh, d.receiptWakeCh} {
 				select {

--- a/eth/sync.go
+++ b/eth/sync.go
@@ -188,6 +188,14 @@ func (pm *ProtocolManager) synchronise(peer *peer) {
 		atomic.StoreUint32(&pm.fastSync, 1)
 		mode = downloader.FastSync
 	}
+
+	if mode == downloader.FastSync {
+		// Make sure the peer's total difficulty we are synchronizing is higher.
+		if pm.blockchain.GetTdByHash(pm.blockchain.CurrentFastBlock().Hash()).Cmp(pTd) >= 0 {
+			return
+		}
+	}
+
 	// Run the sync cycle, and disable fast sync if we've went past the pivot block
 	if err := pm.downloader.Synchronise(peer.id, pHead, pTd, mode); err != nil {
 		return

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -80,7 +80,7 @@ func (s *PublicEthereumAPI) Syncing() (interface{}, error) {
 	progress := s.b.Downloader().Progress()
 
 	// Return not syncing if the synchronisation already completed
-	if progress.CurrentBlock >= progress.HighestBlock {
+	if !s.b.Downloader().Synchronising() {
 		return false, nil
 	}
 	// Otherwise gather the block sync stats

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -80,7 +80,7 @@ func (s *PublicEthereumAPI) Syncing() (interface{}, error) {
 	progress := s.b.Downloader().Progress()
 
 	// Return not syncing if the synchronisation already completed
-	if !s.b.Downloader().Synchronising() {
+	if progress.CurrentBlock >= progress.HighestBlock {
 		return false, nil
 	}
 	// Otherwise gather the block sync stats


### PR DESCRIPTION
In this PR, fix two problems:

1. Avoid useless synchronization during the fast sync if the peer doesn't have higher difficulty than our fast block head.

2. Update highest block we know during the sync