### PR TITLE
internal/ethapi: make resent gas params optional

### DIFF
--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -1337,10 +1337,10 @@ func (s *PublicTransactionPoolAPI) Resend(ctx context.Context, sendArgs SendTxAr
 
 		if pFrom, err := types.Sender(signer, p); err == nil && pFrom == sendArgs.From && signer.Hash(p) == wantSigHash {
 			// Match. Re-sign and send the transaction.
-			if gasPrice != nil {
+			if gasPrice != nil && (*big.Int)(gasPrice).Sign() != 0 {
 				sendArgs.GasPrice = gasPrice
 			}
-			if gasLimit != nil {
+			if gasLimit != nil && *gasLimit != 0 {
 				sendArgs.Gas = gasLimit
 			}
 			signedTx, err := s.sign(sendArgs.From, sendArgs.toTransaction())


### PR DESCRIPTION
Fixes https://github.com/ethereum/go-ethereum/issues/16284 .

In our RPC apis, we usually use pointers for optional parameters, and check whether they are `nil` or not. There's an odd interplay with web3 formatters though. If a decimal formatter is specified, then web3 will submit `0x0` if a parameter is not specified. In `eth_resend`, this causes any missing parameter (e.g. gas limit) to be replaced via a 0 gas limit, causing the transaction resend to fail.