### PR TITLE
common/compiler: remove "--add-std" arg, deprecated in solidity 0.4.21

### DIFF
--- a/common/compiler/solidity.go
+++ b/common/compiler/solidity.go
@@ -65,7 +65,6 @@ type solcOutput struct {
 func (s *Solidity) makeArgs() []string {
 	p := []string{
 		"--combined-json", "bin,abi,userdoc,devdoc",
-		"--add-std",  // include standard lib contracts
 		"--optimize", // code optimizer switched on
 	}
 	if s.Major > 0 || s.Minor > 4 || s.Patch > 6 {


### PR DESCRIPTION
PR to resolve the issue described here: https://github.com/ethereum/solidity/issues/3695
