### PR TITLE
github: more information bot configuration

### DIFF
--- a/.github/no-response.yml
+++ b/.github/no-response.yml
@@ -1,0 +1,11 @@
+# Number of days of inactivity before an Issue is closed for lack of response
+daysUntilClose: 30
+# Label requiring a response
+responseRequiredLabel: more-information-needed
+# Comment to post when closing an Issue for lack of response. Set to `false` to disable
+closeComment: >
+  This issue has been automatically closed because there has been no response
+  to our request for more information from the original author. With only the
+  information that is currently in the issue, we don't have enough information
+  to take action. Please reach out if you have or find the answers we need so
+  that we can investigate further.


### PR DESCRIPTION
This PR is adding configuration for the https://github.com/probot/no-response bot. I have already added the required label (`more-information-needed`), so we just need to install the bot, and enable it on the go-ethereum repo, and it should be ready for use.