### PR TITLE
support 'optimize-runs' arg for solc

### DIFF
--- a/common/compiler/solidity.go
+++ b/common/compiler/solidity.go
@@ -31,6 +31,8 @@ import (
 
 var versionRegexp = regexp.MustCompile(`([0-9]+)\.([0-9]+)\.([0-9]+)`)
 
+var optimizeRuns int64 = 200
+
 type Contract struct {
 	Code string       `json:"code"`
 	Info ContractInfo `json:"info"`
@@ -67,10 +69,18 @@ func (s *Solidity) makeArgs() []string {
 		"--combined-json", "bin,abi,userdoc,devdoc",
 		"--optimize", // code optimizer switched on
 	}
+	if optimizeRuns != 200 {
+		p = append(p, "-optimize-runs",strconv.FormatInt(optimizeRuns, 10))
+	}
 	if s.Major > 0 || s.Minor > 4 || s.Patch > 6 {
 		p[1] += ",metadata"
 	}
 	return p
+}
+
+// SetOptimizeRuns set the number of optimize runs for solc
+func SetOptimizeRuns(_optimizeRuns int64) {
+	optimizeRuns = _optimizeRuns
 }
 
 // SolidityVersion runs solc and parses its version output.

--- a/common/compiler/solidity_test.go
+++ b/common/compiler/solidity_test.go
@@ -40,7 +40,7 @@ func skipWithoutSolc(t *testing.T) {
 
 func TestCompiler(t *testing.T) {
 	skipWithoutSolc(t)
-
+	SetOptimizeRuns(2000)
 	contracts, err := CompileSolidityString("", testSource)
 	if err != nil {
 		t.Fatalf("error compiling source. result %v: %v", contracts, err)


### PR DESCRIPTION
This would allow developers to compile smart contracts for the different purposes. Large optimize runs can reduce gas cost for frequently used functions.