### PR TITLE
core/asm: fixed typo (labal -> label)

### DIFF
--- a/core/asm/compiler.go
+++ b/core/asm/compiler.go
@@ -122,7 +122,7 @@ func (c *Compiler) next() token {
 }
 
 // compile line compiles a single line instruction e.g.
-// "push 1", "jump @labal".
+// "push 1", "jump @label".
 func (c *Compiler) compileLine() error {
 	n := c.next()
 	if n.typ != lineStart {

--- a/core/asm/lexer.go
+++ b/core/asm/lexer.go
@@ -48,7 +48,7 @@ const (
 	lineEnd                           // emitted when a line ends
 	invalidStatement                  // any invalid statement
 	element                           // any element during element parsing
-	label                             // label is emitted when a labal is found
+	label                             // label is emitted when a label is found
 	labelDef                          // label definition is emitted when a new label is found
 	number                            // number is emitted when a number is found
 	stringValue                       // stringValue is emitted when a string has been found


### PR DESCRIPTION
This patch replaced "labal" with "label" in "core/asm/compiler.go" and "core/asm/lexer.go".