### PR TITLE
ethclient: add DialContext and Close

### DIFF
--- a/ethclient/ethclient.go
+++ b/ethclient/ethclient.go
@@ -39,11 +39,7 @@ type Client struct {
 
 // Dial connects a client to the given URL.
 func Dial(rawurl string) (*Client, error) {
-	c, err := rpc.Dial(rawurl)
-	if err != nil {
-		return nil, err
-	}
-	return NewClient(c), nil
+	return DialContext(context.Background(), rawurl)
 }
 
 func DialContext(ctx context.Context, rawurl string) (*Client, error) {

--- a/ethclient/ethclient.go
+++ b/ethclient/ethclient.go
@@ -46,6 +46,14 @@ func Dial(rawurl string) (*Client, error) {
 	return NewClient(c), nil
 }
 
+func DialContext(ctx context.Context, rawurl string) (*Client, error) {
+	c, err := rpc.DialContext(ctx, rawurl)
+	if err != nil {
+		return nil, err
+	}
+	return NewClient(c), nil
+}
+
 // NewClient creates a client that uses the given RPC client.
 func NewClient(c *rpc.Client) *Client {
 	return &Client{c}

--- a/ethclient/ethclient.go
+++ b/ethclient/ethclient.go
@@ -55,6 +55,10 @@ func NewClient(c *rpc.Client) *Client {
 	return &Client{c}
 }
 
+func (ec *Client) Close() {
+	ec.c.Close()
+}
+
 // Blockchain Access
 
 // BlockByHash returns the given full block.


### PR DESCRIPTION
This PR adds:

* `ethclient.DialContext`, which is useful to handle cancellation
* `ethclient.Close`, which is useful to manually close the underlying connection

Both of these are just wrappers around the underlying implementations in the `rpc` package.