### PR TITLE
Print vm output when debug flag is on.

### DIFF
--- a/cmd/evm/runner.go
+++ b/cmd/evm/runner.go
@@ -236,6 +236,10 @@ Gas used:           %d
 	}
 	if tracer != nil {
 		tracer.CaptureEnd(ret, initialGas-leftOverGas, execTime, err)
+		fmt.Printf("0x%x", ret)
+		if err != nil {
+			fmt.Printf(" error: %v\n", err)
+		}
 	} else {
 		fmt.Printf("0x%x\n", ret)
 		if err != nil {


### PR DESCRIPTION
Commit 1c2378b926b4ae96ae42a4e802058a2fcd42c87b accidently remove output data when debug flag is on. I just add it back.

## Problem

```
$ evm --code 60016000f300 run             # will print output 0x00
0x00

$ evm --debug --code 60016000f300 run     # will not print output 0x00
#### TRACE ####
PUSH1           pc=00000000 gas=10000000000 cost=3

PUSH1           pc=00000002 gas=9999999997 cost=3
Stack:
00000000  0000000000000000000000000000000000000000000000000000000000000001

RETURN          pc=00000004 gas=9999999994 cost=3
Stack:
00000000  0000000000000000000000000000000000000000000000000000000000000000
00000001  0000000000000000000000000000000000000000000000000000000000000001
Memory:
00000000  00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00  |................|
00000010  00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00  |................|

#### LOGS ####
```

## Expected result

```
$ evm --debug --code 60016000f300 run
#### TRACE ####
PUSH1           pc=00000000 gas=10000000000 cost=3

PUSH1           pc=00000002 gas=9999999997 cost=3
Stack:
00000000  0000000000000000000000000000000000000000000000000000000000000001

RETURN          pc=00000004 gas=9999999994 cost=3
Stack:
00000000  0000000000000000000000000000000000000000000000000000000000000000
00000001  0000000000000000000000000000000000000000000000000000000000000001
Memory:
00000000  00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00  |................|
00000010  00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00  |................|

#### LOGS ####
0x00
```