### PR TITLE
cmd/evm: print vm output when debug flag is on.

### DIFF
--- a/cmd/evm/runner.go
+++ b/cmd/evm/runner.go
@@ -235,9 +235,7 @@ Gas used:           %d
 
 `, execTime, mem.HeapObjects, mem.Alloc, mem.TotalAlloc, mem.NumGC, initialGas-leftOverGas)
 	}
-	if tracer != nil {
-		tracer.CaptureEnd(ret, initialGas-leftOverGas, execTime, err)
-	} else {
+	if tracer == nil {
 		fmt.Printf("0x%x\n", ret)
 		if err != nil {
 			fmt.Printf(" error: %v\n", err)

--- a/cmd/evm/runner.go
+++ b/cmd/evm/runner.go
@@ -76,6 +76,7 @@ func runCmd(ctx *cli.Context) error {
 	logconfig := &vm.LogConfig{
 		DisableMemory: ctx.GlobalBool(DisableMemoryFlag.Name),
 		DisableStack:  ctx.GlobalBool(DisableStackFlag.Name),
+		Debug:         ctx.GlobalBool(DebugFlag.Name),
 	}
 
 	var (
@@ -236,10 +237,6 @@ Gas used:           %d
 	}
 	if tracer != nil {
 		tracer.CaptureEnd(ret, initialGas-leftOverGas, execTime, err)
-		fmt.Printf("0x%x", ret)
-		if err != nil {
-			fmt.Printf(" error: %v\n", err)
-		}
 	} else {
 		fmt.Printf("0x%x\n", ret)
 		if err != nil {

--- a/cmd/evm/runner.go
+++ b/cmd/evm/runner.go
@@ -236,6 +236,10 @@ Gas used:           %d
 	}
 	if tracer != nil {
 		tracer.CaptureEnd(ret, initialGas-leftOverGas, execTime, err)
+		fmt.Printf("0x%x", ret)
+		if err != nil {
+			fmt.Printf(" error: %v\n", err)
+		}
 	} else {
 		fmt.Printf("0x%x\n", ret)
 		if err != nil {

--- a/core/vm/logger.go
+++ b/core/vm/logger.go
@@ -45,6 +45,7 @@ type LogConfig struct {
 	DisableMemory  bool // disable memory capture
 	DisableStack   bool // disable stack capture
 	DisableStorage bool // disable storage capture
+	Debug          bool // print output during capture end
 	Limit          int  // maximum length of output, but zero means unlimited
 }
 
@@ -184,6 +185,12 @@ func (l *StructLogger) CaptureFault(env *EVM, pc uint64, op OpCode, gas, cost ui
 func (l *StructLogger) CaptureEnd(output []byte, gasUsed uint64, t time.Duration, err error) error {
 	l.output = output
 	l.err = err
+	if l.cfg.Debug {
+		fmt.Printf("0x%x", output)
+		if err != nil {
+			fmt.Printf(" error: %v\n", err)
+		}
+	}
 	return nil
 }
 

--- a/core/vm/logger.go
+++ b/core/vm/logger.go
@@ -186,7 +186,7 @@ func (l *StructLogger) CaptureEnd(output []byte, gasUsed uint64, t time.Duration
 	l.output = output
 	l.err = err
 	if l.cfg.Debug {
-		fmt.Printf("0x%x", output)
+		fmt.Printf("0x%x\n", output)
 		if err != nil {
 			fmt.Printf(" error: %v\n", err)
 		}


### PR DESCRIPTION
Commit 1c2378b926b4ae96ae42a4e802058a2fcd42c87b accidently remove output data when debug flag is on. I just add it back.

## Problem

```
$ evm --code 60016000f300 run             # will print output 0x00
0x00

$ evm --debug --code 60016000f300 run     # will not print output 0x00
#### TRACE ####
PUSH1           pc=00000000 gas=10000000000 cost=3

PUSH1           pc=00000002 gas=9999999997 cost=3
Stack:
00000000  0000000000000000000000000000000000000000000000000000000000000001

RETURN          pc=00000004 gas=9999999994 cost=3
Stack:
00000000  0000000000000000000000000000000000000000000000000000000000000000
00000001  0000000000000000000000000000000000000000000000000000000000000001
Memory:
00000000  00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00  |................|
00000010  00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00  |................|

#### LOGS ####
```

## Expected result

```
$ evm --debug --code 60016000f300 run
#### TRACE ####
PUSH1           pc=00000000 gas=10000000000 cost=3

PUSH1           pc=00000002 gas=9999999997 cost=3
Stack:
00000000  0000000000000000000000000000000000000000000000000000000000000001

RETURN          pc=00000004 gas=9999999994 cost=3
Stack:
00000000  0000000000000000000000000000000000000000000000000000000000000000
00000001  0000000000000000000000000000000000000000000000000000000000000001
Memory:
00000000  00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00  |................|
00000010  00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00  |................|

#### LOGS ####
0x00
```