### PR TITLE
Fix for issue #16243.

### DIFF
--- a/les/retrieve.go
+++ b/les/retrieve.go
@@ -268,6 +268,7 @@ func (r *sentReq) update(ev reqPeerEvent) {
 		r.reqSent = false
 		r.reqSrtoCount++
 	case rpHardTimeout, rpDeliveredValid, rpDeliveredInvalid:
+		r.reqSent = false
 		r.reqSrtoCount--
 	}
 }


### PR DESCRIPTION
Fix to make sure that stateStopped() will not hang if a soft timeout never happens.