### PR TITLE
core/asm: fixed typo (posititon -> position)

### DIFF
--- a/core/asm/compiler.go
+++ b/core/asm/compiler.go
@@ -114,7 +114,7 @@ func (c *Compiler) Compile() (string, []error) {
 }
 
 // next returns the next token and increments the
-// posititon.
+// position.
 func (c *Compiler) next() token {
 	token := c.tokens[c.pos]
 	c.pos++


### PR DESCRIPTION
This patch replaced "posititon" with "position" in "core/asm/compiler.go".