### PR TITLE
Add egress/ingress traffic metrics to discv5 udp transport

### DIFF
--- a/p2p/discv5/metrics.go
+++ b/p2p/discv5/metrics.go
@@ -1,0 +1,8 @@
+package discv5
+
+import "github.com/ethereum/go-ethereum/metrics"
+
+var (
+	ingressTrafficMeter = metrics.NewRegisteredMeter("discv5/InboundTraffic", nil)
+	egressTrafficMeter  = metrics.NewRegisteredMeter("discv5/OutboundTraffic", nil)
+)

--- a/p2p/discv5/udp.go
+++ b/p2p/discv5/udp.go
@@ -342,8 +342,10 @@ func (t *udp) sendPacket(toid NodeID, toaddr *net.UDPAddr, ptype byte, req inter
 		return hash, err
 	}
 	log.Trace(fmt.Sprintf(">>> %v to %x@%v", nodeEvent(ptype), toid[:8], toaddr))
-	if _, err = t.conn.WriteToUDP(packet, toaddr); err != nil {
+	if nbytes, err := t.conn.WriteToUDP(packet, toaddr); err != nil {
 		log.Trace(fmt.Sprint("UDP send failed:", err))
+	} else {
+		egressTrafficMeter.Mark(int64(nbytes))
 	}
 	//fmt.Println(err)
 	return hash, err
@@ -382,6 +384,7 @@ func (t *udp) readLoop() {
 	buf := make([]byte, 1280)
 	for {
 		nbytes, from, err := t.conn.ReadFromUDP(buf)
+		ingressTrafficMeter.Mark(int64(nbytes))
 		if netutil.IsTemporaryError(err) {
 			// Ignore temporary read errors.
 			log.Debug(fmt.Sprintf("Temporary read error: %v", err))


### PR DESCRIPTION
Extremely useful to measure an impact of additional search/register queries.