### PR TITLE
whisper: some components are still using v5, switch to v6

### DIFF
--- a/cmd/geth/config.go
+++ b/cmd/geth/config.go
@@ -32,7 +32,7 @@ import (
 	"github.com/ethereum/go-ethereum/eth"
 	"github.com/ethereum/go-ethereum/node"
 	"github.com/ethereum/go-ethereum/params"
-	whisper "github.com/ethereum/go-ethereum/whisper/whisperv5"
+	whisper "github.com/ethereum/go-ethereum/whisper/whisperv6"
 	"github.com/naoina/toml"
 )
 

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -55,7 +55,7 @@ import (
 	"github.com/ethereum/go-ethereum/p2p/nat"
 	"github.com/ethereum/go-ethereum/p2p/netutil"
 	"github.com/ethereum/go-ethereum/params"
-	whisper "github.com/ethereum/go-ethereum/whisper/whisperv5"
+	whisper "github.com/ethereum/go-ethereum/whisper/whisperv6"
 	"gopkg.in/urfave/cli.v1"
 )
 

--- a/mobile/geth.go
+++ b/mobile/geth.go
@@ -34,7 +34,7 @@ import (
 	"github.com/ethereum/go-ethereum/p2p"
 	"github.com/ethereum/go-ethereum/p2p/nat"
 	"github.com/ethereum/go-ethereum/params"
-	whisper "github.com/ethereum/go-ethereum/whisper/whisperv5"
+	whisper "github.com/ethereum/go-ethereum/whisper/whisperv6"
 )
 
 // NodeConfig represents the collection of configuration values to fine tune the Geth

--- a/whisper/shhclient/client.go
+++ b/whisper/shhclient/client.go
@@ -22,10 +22,10 @@ import (
 	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/rpc"
-	whisper "github.com/ethereum/go-ethereum/whisper/whisperv5"
+	whisper "github.com/ethereum/go-ethereum/whisper/whisperv6"
 )
 
-// Client defines typed wrappers for the Whisper v5 RPC API.
+// Client defines typed wrappers for the Whisper v6 RPC API.
 type Client struct {
 	c *rpc.Client
 }
@@ -168,27 +168,27 @@ func (sc *Client) Post(ctx context.Context, message whisper.NewMessage) error {
 // SubscribeMessages subscribes to messages that match the given criteria. This method
 // is only supported on bi-directional connections such as websockets and IPC.
 // NewMessageFilter uses polling and is supported over HTTP.
-func (ec *Client) SubscribeMessages(ctx context.Context, criteria whisper.Criteria, ch chan<- *whisper.Message) (ethereum.Subscription, error) {
-	return ec.c.ShhSubscribe(ctx, ch, "messages", criteria)
+func (sc *Client) SubscribeMessages(ctx context.Context, criteria whisper.Criteria, ch chan<- *whisper.Message) (ethereum.Subscription, error) {
+	return sc.c.ShhSubscribe(ctx, ch, "messages", criteria)
 }
 
 // NewMessageFilter creates a filter within the node. This filter can be used to poll
 // for new messages (see FilterMessages) that satisfy the given criteria. A filter can
 // timeout when it was polled for in whisper.filterTimeout.
-func (ec *Client) NewMessageFilter(ctx context.Context, criteria whisper.Criteria) (string, error) {
+func (sc *Client) NewMessageFilter(ctx context.Context, criteria whisper.Criteria) (string, error) {
 	var id string
-	return id, ec.c.CallContext(ctx, &id, "shh_newMessageFilter", criteria)
+	return id, sc.c.CallContext(ctx, &id, "shh_newMessageFilter", criteria)
 }
 
 // DeleteMessageFilter removes the filter associated with the given id.
-func (ec *Client) DeleteMessageFilter(ctx context.Context, id string) error {
+func (sc *Client) DeleteMessageFilter(ctx context.Context, id string) error {
 	var ignored bool
-	return ec.c.CallContext(ctx, &ignored, "shh_deleteMessageFilter", id)
+	return sc.c.CallContext(ctx, &ignored, "shh_deleteMessageFilter", id)
 }
 
 // FilterMessages retrieves all messages that are received between the last call to
 // this function and match the criteria that where given when the filter was created.
-func (ec *Client) FilterMessages(ctx context.Context, id string) ([]*whisper.Message, error) {
+func (sc *Client) FilterMessages(ctx context.Context, id string) ([]*whisper.Message, error) {
 	var messages []*whisper.Message
-	return messages, ec.c.CallContext(ctx, &messages, "shh_getFilterMessages", id)
+	return messages, sc.c.CallContext(ctx, &messages, "shh_getFilterMessages", id)
 }


### PR DESCRIPTION
The command line client and the mobile client were still using whisper v5. This completes the switch.

Also removed some unrelated warnings that had been dormant for seemingly ages, and that appeared as I recompiled some files.