### PR TITLE
ecies: drop randomness parameter from `PrivateKey.Decrypt`

### DIFF
--- a/crypto/ecies/ecies.go
+++ b/crypto/ecies/ecies.go
@@ -230,7 +230,7 @@ func symEncrypt(rand io.Reader, params *ECIESParams, key, m []byte) (ct []byte, 
 
 // symDecrypt carries out CTR decryption using the block cipher specified in
 // the parameters
-func symDecrypt(rand io.Reader, params *ECIESParams, key, ct []byte) (m []byte, err error) {
+func symDecrypt(params *ECIESParams, key, ct []byte) (m []byte, err error) {
 	c, err := params.Cipher(key)
 	if err != nil {
 		return
@@ -292,7 +292,7 @@ func Encrypt(rand io.Reader, pub *PublicKey, m, s1, s2 []byte) (ct []byte, err e
 }
 
 // Decrypt decrypts an ECIES ciphertext.
-func (prv *PrivateKey) Decrypt(rand io.Reader, c, s1, s2 []byte) (m []byte, err error) {
+func (prv *PrivateKey) Decrypt(c, s1, s2 []byte) (m []byte, err error) {
 	if len(c) == 0 {
 		return nil, ErrInvalidMessage
 	}
@@ -361,6 +361,6 @@ func (prv *PrivateKey) Decrypt(rand io.Reader, c, s1, s2 []byte) (m []byte, err 
 		return
 	}
 
-	m, err = symDecrypt(rand, params, Ke, c[mStart:mEnd])
+	m, err = symDecrypt(params, Ke, c[mStart:mEnd])
 	return
 }

--- a/crypto/ecies/ecies_test.go
+++ b/crypto/ecies/ecies_test.go
@@ -270,7 +270,7 @@ func TestEncryptDecrypt(t *testing.T) {
 		t.FailNow()
 	}
 
-	pt, err := prv2.Decrypt(rand.Reader, ct, nil, nil)
+	pt, err := prv2.Decrypt(ct, nil, nil)
 	if err != nil {
 		fmt.Println(err.Error())
 		t.FailNow()
@@ -281,7 +281,7 @@ func TestEncryptDecrypt(t *testing.T) {
 		t.FailNow()
 	}
 
-	_, err = prv1.Decrypt(rand.Reader, ct, nil, nil)
+	_, err = prv1.Decrypt(ct, nil, nil)
 	if err == nil {
 		fmt.Println("ecies: encryption should not have succeeded")
 		t.FailNow()
@@ -301,7 +301,7 @@ func TestDecryptShared2(t *testing.T) {
 	}
 
 	// Check that decrypting with correct shared data works.
-	pt, err := prv.Decrypt(rand.Reader, ct, nil, shared2)
+	pt, err := prv.Decrypt(ct, nil, shared2)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -310,10 +310,10 @@ func TestDecryptShared2(t *testing.T) {
 	}
 
 	// Decrypting without shared data or incorrect shared data fails.
-	if _, err = prv.Decrypt(rand.Reader, ct, nil, nil); err == nil {
+	if _, err = prv.Decrypt(ct, nil, nil); err == nil {
 		t.Fatal("ecies: decrypting without shared data didn't fail")
 	}
-	if _, err = prv.Decrypt(rand.Reader, ct, nil, []byte("garbage")); err == nil {
+	if _, err = prv.Decrypt(ct, nil, []byte("garbage")); err == nil {
 		t.Fatal("ecies: decrypting with incorrect shared data didn't fail")
 	}
 }
@@ -381,7 +381,7 @@ func testParamSelection(t *testing.T, c testCase) {
 		t.FailNow()
 	}
 
-	pt, err := prv2.Decrypt(rand.Reader, ct, nil, nil)
+	pt, err := prv2.Decrypt(ct, nil, nil)
 	if err != nil {
 		fmt.Printf("%s (%s)\n", err.Error(), c.Name)
 		t.FailNow()
@@ -393,7 +393,7 @@ func testParamSelection(t *testing.T, c testCase) {
 		t.FailNow()
 	}
 
-	_, err = prv1.Decrypt(rand.Reader, ct, nil, nil)
+	_, err = prv1.Decrypt(ct, nil, nil)
 	if err == nil {
 		fmt.Printf("ecies: encryption should not have succeeded (%s)\n",
 			c.Name)
@@ -422,7 +422,7 @@ func TestBasicKeyValidation(t *testing.T) {
 
 	for _, b := range badBytes {
 		ct[0] = b
-		_, err := prv.Decrypt(rand.Reader, ct, nil, nil)
+		_, err := prv.Decrypt(ct, nil, nil)
 		if err != ErrInvalidPublicKey {
 			fmt.Println("ecies: validated an invalid key")
 			t.FailNow()
@@ -441,14 +441,14 @@ func TestBox(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	pt, err := prv2.Decrypt(rand.Reader, ct, nil, nil)
+	pt, err := prv2.Decrypt(ct, nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
 	if !bytes.Equal(pt, message) {
 		t.Fatal("ecies: plaintext doesn't match message")
 	}
-	if _, err = prv1.Decrypt(rand.Reader, ct, nil, nil); err == nil {
+	if _, err = prv1.Decrypt(ct, nil, nil); err == nil {
 		t.Fatal("ecies: encryption should not have succeeded")
 	}
 }

--- a/p2p/rlpx.go
+++ b/p2p/rlpx.go
@@ -491,7 +491,7 @@ func readHandshakeMsg(msg plainDecoder, plainSize int, prv *ecdsa.PrivateKey, r 
 	}
 	// Attempt decoding pre-EIP-8 "plain" format.
 	key := ecies.ImportECDSA(prv)
-	if dec, err := key.Decrypt(rand.Reader, buf, nil, nil); err == nil {
+	if dec, err := key.Decrypt(buf, nil, nil); err == nil {
 		msg.decodePlain(dec)
 		return buf, nil
 	}
@@ -505,7 +505,7 @@ func readHandshakeMsg(msg plainDecoder, plainSize int, prv *ecdsa.PrivateKey, r 
 	if _, err := io.ReadFull(r, buf[plainSize:]); err != nil {
 		return buf, err
 	}
-	dec, err := key.Decrypt(rand.Reader, buf[2:], nil, prefix)
+	dec, err := key.Decrypt(buf[2:], nil, prefix)
 	if err != nil {
 		return buf, err
 	}

--- a/whisper/whisperv5/message.go
+++ b/whisper/whisperv5/message.go
@@ -277,7 +277,7 @@ func (msg *ReceivedMessage) decryptSymmetric(key []byte, nonce []byte) error {
 
 // decryptAsymmetric decrypts an encrypted payload with a private key.
 func (msg *ReceivedMessage) decryptAsymmetric(key *ecdsa.PrivateKey) error {
-	decrypted, err := ecies.ImportECDSA(key).Decrypt(crand.Reader, msg.Raw, nil, nil)
+	decrypted, err := ecies.ImportECDSA(key).Decrypt(msg.Raw, nil, nil)
 	if err == nil {
 		msg.Raw = decrypted
 	}

--- a/whisper/whisperv6/message.go
+++ b/whisper/whisperv6/message.go
@@ -289,7 +289,7 @@ func (msg *ReceivedMessage) decryptSymmetric(key []byte) error {
 
 // decryptAsymmetric decrypts an encrypted payload with a private key.
 func (msg *ReceivedMessage) decryptAsymmetric(key *ecdsa.PrivateKey) error {
-	decrypted, err := ecies.ImportECDSA(key).Decrypt(crand.Reader, msg.Raw, nil, nil)
+	decrypted, err := ecies.ImportECDSA(key).Decrypt(msg.Raw, nil, nil)
 	if err == nil {
 		msg.Raw = decrypted
 	}


### PR DESCRIPTION
The parameter `rand` is unused in `PrivateKey.Decrypt`. Decryption in
the ECIES encryption scheme is deterministic, so randomness isn't
needed.