### PR TITLE
build: use sftp for launchpad upload

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -65,9 +65,11 @@ matrix:
             - dput
             - gcc-multilib
             - fakeroot
+            - python-bzrlib
+            - python-paramiko
       script:
         # Build for the primary platforms that Trusty can manage
-        - go run build/ci.go debsrc -signer "Go Ethereum Linux Builder <geth-ci@ethereum.org>" -upload ppa:ethereum/ethereum
+        - go run build/ci.go debsrc -signer "Go Ethereum Linux Builder <geth-ci@ethereum.org>" -sftp-user geth-ci -upload ethereum/ethereum
         - go run build/ci.go install
         - go run build/ci.go archive -type tar -signer LINUX_SIGNING_KEY -upload gethstore/builds
         - go run build/ci.go install -arch 386

--- a/build/ci-notes.md
+++ b/build/ci-notes.md
@@ -27,7 +27,7 @@ Add the gophers PPA and install Go 1.10 and Debian packaging tools:
 
     $ sudo apt-add-repository ppa:gophers/ubuntu/archive
     $ sudo apt-get update
-    $ sudo apt-get install build-essential golang-1.10 devscripts debhelper
+    $ sudo apt-get install build-essential golang-1.10 devscripts debhelper python-bzrlib python-paramiko
 
 Create the source packages:
 

--- a/build/dput-launchpad.cf
+++ b/build/dput-launchpad.cf
@@ -1,0 +1,7 @@
+[{{.LaunchpadUser}}/{{.LaunchpadPPA}}]
+fqdn = ppa.launchpad.net
+method = sftp
+incoming = ~{{.LaunchpadUser}}/ubuntu/{{.LaunchpadPPA}}/
+login = {{.LaunchpadUserSSH}}
+allow_unsigned_uploads = 0
+{{if .IdentityFile}}ssh_config_options = IdentityFile {{.IdentityFile}}{{end}}


### PR DESCRIPTION
This PR changes the transport for Launchpad uploads to SFTP instead of plain FTP. This requires adding an SSH key in the secret Travis environment variable PPA_SSH_KEY. The corresponding public key needs to be added to the geth-ci launchpad user.