### PR TITLE
Update .gitattributes to add solidity highlighting

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,3 @@
 # Auto detect text files and perform LF normalization
 * text=auto
+*.sol linguist-language=Solidity


### PR DESCRIPTION
Update .gitattributes with the appropriate line to enable solidity syntax highlighting in the github web ui, as per github/linguist#3973