### PR TITLE
fix a bug in "github.com/ethereum/go-ethereum/compression/rle" package

### DIFF
--- a/compression/rle/read_write.go
+++ b/compression/rle/read_write.go
@@ -68,7 +68,7 @@ func compressChunk(dat []byte) (ret []byte, n int) {
 		return []byte{token, tokenToken}, 1
 	case len(dat) > 1 && dat[0] == 0x0 && dat[1] == 0x0:
 		j := 0
-		for j <= 254 && j < len(dat) {
+		for j <= 249 && j < len(dat) {
 			if dat[j] != 0 {
 				break
 			}

--- a/compression/rle/read_write_test.go
+++ b/compression/rle/read_write_test.go
@@ -48,3 +48,10 @@ func (s *CompressionRleSuite) TestDecompressSimple(c *checker.C) {
 	c.Assert(res, checker.DeepEquals, make([]byte, 10))
 
 }
+
+func (s *CompressionRleSuite) TestIdentity(c *checker.C) {
+	var exp []byte = make([]byte, 251)
+	res, err := Decompress(Compress(exp))
+	c.Assert(err, checker.IsNil)
+	c.Assert(res, checker.DeepEquals, exp)
+}


### PR DESCRIPTION
Fix a bug of rle.Compress's wrong result while parameter `dat` is a slice of 251 - 253 zeros(\x0)