### PR TITLE
[WIP] add ed25519 sig verification precompile

### DIFF
--- a/core/vm/evm.go
+++ b/core/vm/evm.go
@@ -45,6 +45,9 @@ func run(evm *EVM, contract *Contract, input []byte) ([]byte, error) {
 		if evm.ChainConfig().IsByzantium(evm.BlockNumber) {
 			precompiles = PrecompiledContractsByzantium
 		}
+		if evm.ChainConfig().IsConstantinople(evm.BlockNumber) {
+			precompiles = PrecompiledContractsConstantinople
+		}
 		if p := precompiles[*contract.CodeAddr]; p != nil {
 			return RunPrecompiledContract(p, input, contract)
 		}
@@ -158,6 +161,9 @@ func (evm *EVM) Call(caller ContractRef, addr common.Address, input []byte, gas 
 		precompiles := PrecompiledContractsHomestead
 		if evm.ChainConfig().IsByzantium(evm.BlockNumber) {
 			precompiles = PrecompiledContractsByzantium
+		}
+		if evm.ChainConfig().IsConstantinople(evm.BlockNumber) {
+			precompiles = PrecompiledContractsConstantinople
 		}
 		if precompiles[addr] == nil && evm.ChainConfig().IsEIP158(evm.BlockNumber) && value.Sign() == 0 {
 			return nil, gas, nil

--- a/params/protocol_params.go
+++ b/params/protocol_params.go
@@ -77,6 +77,7 @@ const (
 	Bn256ScalarMulGas       uint64 = 40000  // Gas needed for an elliptic curve scalar multiplication
 	Bn256PairingBaseGas     uint64 = 100000 // Base price for an elliptic curve pairing check
 	Bn256PairingPerPointGas uint64 = 80000  // Per-point price for an elliptic curve pairing check
+	Ed25519VerifyGas        uint64 = 2000   // Ed25519 signature verification gas price
 )
 
 var (


### PR DESCRIPTION
this is a first take at https://github.com/ethereum/EIPs/blob/master/EIPS/eip-665.md - compiles and runs, but not yet tested. I am putting this up to see the CI results, have a reference in the dev meeting, and gather feedback. also missing, bits in `core/vm/contracts_test.go` and `eth/tracers/tracer.go`:

```
oberstet@thinkpad-t430s:~/scm/oberstet/go-ethereum$ find . -type f -exec grep -Hi "PrecompiledContractsByzantium" {} \;
./core/vm/contracts_test.go:	p := PrecompiledContractsByzantium[common.HexToAddress(addr)]
./core/vm/contracts_test.go:	p := PrecompiledContractsByzantium[common.HexToAddress(addr)]
./core/vm/evm.go:			precompiles = PrecompiledContractsByzantium
./core/vm/evm.go:			precompiles = PrecompiledContractsByzantium
./core/vm/contracts.go:// PrecompiledContractsByzantium contains the default set of pre-compiled Ethereum
./core/vm/contracts.go:var PrecompiledContractsByzantium = map[common.Address]PrecompiledContract{
./eth/tracers/tracer.go:		_, ok := vm.PrecompiledContractsByzantium[common.BytesToAddress(popSlice(ctx))]
Übereinstimmungen in Binärdatei ./build/bin/geth
oberstet@thinkpad-t430s:~/scm/oberstet/go-ethereum$ find . -type f -exec grep -Hi "PrecompiledContractsConstantinople" {} \;
./core/vm/evm.go:			precompiles = PrecompiledContractsConstantinople
./core/vm/evm.go:			precompiles = PrecompiledContractsConstantinople
./core/vm/contracts.go:// PrecompiledContractsConstantinople contains the default set of pre-compiled Ethereum
./core/vm/contracts.go:var PrecompiledContractsConstantinople = map[common.Address]PrecompiledContract{
Übereinstimmungen in Binärdatei ./build/bin/geth
oberstet@thinkpad-t430s:~/scm/oberstet/go-ethereum$ 
```