### PR TITLE
ethclient: fix parity compatibility on newHeads

### DIFF
--- a/ethclient/ethclient.go
+++ b/ethclient/ethclient.go
@@ -296,7 +296,7 @@ func (ec *Client) SyncProgress(ctx context.Context) (*ethereum.SyncProgress, err
 // SubscribeNewHead subscribes to notifications about the current blockchain head
 // on the given channel.
 func (ec *Client) SubscribeNewHead(ctx context.Context, ch chan<- *types.Header) (ethereum.Subscription, error) {
-	return ec.c.EthSubscribe(ctx, ch, "newHeads", map[string]struct{}{})
+	return ec.c.EthSubscribe(ctx, ch, "newHeads")
 }
 
 // State Access


### PR DESCRIPTION
This issue addresses an incompatibility between `ethclient` and Parity - currently, there is no way to use the `newHeads` call of the pubsub spec with a Parity node.

It appears that Parity has a stricter argument check on second argument of the `eth_subscribe` JSON-RPC call.

While `ethclient` sends a subscription message that looks like:
```
{"id": 1, "method": "eth_subscribe", "params": ["newHeads", {}]}
```

Reference: https://github.com/ethereum/go-ethereum/blob/762f3a48a00da02fe58063cb6ce8dc2d08821f15/ethclient/ethclient.go#L299

Parity rejects it with this error: https://github.com/paritytech/parity/blob/d7a7f034db6e7d84e2182ab2cd76cfc0a438723c/rpc/src/v1/impls/eth_pubsub.rs#L276

**Therefore making Geth's `ethclient` package incompatible with the implementation in Parity**

The issue has been discussed here:
https://github.com/paritytech/parity/issues/7731

And a fix has been proposed but closed here:
https://github.com/paritytech/parity/pull/7732

The fixes are either:
1. Do not send a second argument (empty map) in `ethclient`
2. Loosen the requirement on parity

To me (1) makes more sense, since the second argument is redundant anyway. It should be noted that this change makes `ethclient` compatible with Parity without breaking any compatibility with Geth.

Unfortunately, there are no specifics regarding the second argument in https://github.com/ethereum/go-ethereum/wiki/RPC-PUB-SUB 