### PR TITLE
eth: allow ecosystem projects to speed up builds by specifying packages to test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ matrix:
         - sudo chmod 666 /dev/fuse
         - sudo chown root:$USER /etc/fuse.conf
         - go run build/ci.go install
-        - go run build/ci.go test -coverage
+        - go run build/ci.go test -coverage $TEST_PACKAGES
 
     # These are the latest Go versions.
     - os: linux
@@ -24,7 +24,7 @@ matrix:
         - sudo chmod 666 /dev/fuse
         - sudo chown root:$USER /etc/fuse.conf
         - go run build/ci.go install
-        - go run build/ci.go test -coverage
+        - go run build/ci.go test -coverage $TEST_PACKAGES
 
     - os: osx
       go: "1.10"
@@ -34,7 +34,7 @@ matrix:
         - brew install caskroom/cask/brew-cask
         - brew cask install osxfuse
         - go run build/ci.go install
-        - go run build/ci.go test -coverage
+        - go run build/ci.go test -coverage $TEST_PACKAGES
 
     # This builder only tests code linters on latest version of Go
     - os: linux


### PR DESCRIPTION
hi there,
this PR is meant to allow ecosystem projects (such as `ethersphere`) to minimize CI build times by specifying an environment variable with the specified packages to test for.
in the case of `swarm` it would be set to `github.com/ethereum/go-ethereum/swarm/... github.com/ethereum/go-ethereum/p2p/...` and so on.
if the environment variable isn't defined - the build script will test for all packages, so this should not affect the main `go-ethereum` repository.