### PR TITLE
WIP: Faster blocks

### DIFF
--- a/accounts/abi/bind/backends/simulated.go
+++ b/accounts/abi/bind/backends/simulated.go
@@ -283,9 +283,12 @@ func (b *SimulatedBackend) callContract(ctx context.Context, call ethereum.CallM
 	msg := callmsg{call}
 
 	evmContext := core.NewEVMContext(msg, block.Header(), b.blockchain, nil)
+	// Ignore error, we're past header validation
+	beneficiary, _ := b.blockchain.Engine().Author(block.Header())
+	blockContext := core.NewBlockContext(block.Header(), beneficiary, b.config)
 	// Create a new environment which holds all relevant information
 	// about the transaction and calling mechanisms.
-	vmenv := vm.NewEVM(evmContext, statedb, b.config, vm.Config{})
+	vmenv := vm.NewEVM(evmContext, statedb, b.config, &vm.Config{}, blockContext)
 	gaspool := new(core.GasPool).AddGas(math.MaxUint64)
 
 	return core.NewStateTransition(vmenv, msg, gaspool).TransitionDb()

--- a/accounts/abi/bind/backends/simulated.go
+++ b/accounts/abi/bind/backends/simulated.go
@@ -282,7 +282,7 @@ func (b *SimulatedBackend) callContract(ctx context.Context, call ethereum.CallM
 	// Execute the call.
 	msg := callmsg{call}
 
-	evmContext := core.NewEVMContext(msg, block.Header(), b.blockchain, nil)
+	evmContext := core.NewEVMContext(msg, block.Header(), b.blockchain)
 	// Ignore error, we're past header validation
 	beneficiary, _ := b.blockchain.Engine().Author(block.Header())
 	blockContext := core.NewBlockContext(block.Header(), beneficiary, b.config)

--- a/core/chain_makers.go
+++ b/core/chain_makers.go
@@ -98,7 +98,9 @@ func (b *BlockGen) AddTxWithChain(bc *BlockChain, tx *types.Transaction) {
 		b.SetCoinbase(common.Address{})
 	}
 	b.statedb.Prepare(tx.Hash(), common.Hash{}, len(b.txs))
-	receipt, _, err := ApplyTransaction(b.config, bc, &b.header.Coinbase, b.gasPool, b.statedb, b.header, tx, &b.header.GasUsed, vm.Config{})
+	signer := types.MakeSigner(b.config, b.header.Number)
+
+	receipt, _, err := ApplyTransaction(b.config, bc, &b.header.Coinbase, b.gasPool, b.statedb, b.header, tx, &b.header.GasUsed, vm.Config{}, &signer)
 	if err != nil {
 		panic(err)
 	}

--- a/core/chain_makers.go
+++ b/core/chain_makers.go
@@ -111,7 +111,7 @@ func (b *BlockGen) AddTxWithChain(bc *BlockChain, tx *types.Transaction) {
 		Difficulty:  b.header.Difficulty,
 	}
 
-	receipt, _, err := ApplyTransaction(b.config, bc, &b.header.Coinbase, b.gasPool, b.statedb, b.header, tx, &b.header.GasUsed, vm.Config{}, blockContext)
+	receipt, _, err := ApplyTransaction(b.config, bc, &b.header.Coinbase, b.gasPool, b.statedb, b.header, tx, &b.header.GasUsed, &vm.Config{}, blockContext)
 	if err != nil {
 		panic(err)
 	}

--- a/core/chain_makers.go
+++ b/core/chain_makers.go
@@ -53,8 +53,7 @@ type BlockGen struct {
 
 	config *params.ChainConfig
 	engine consensus.Engine
-
-	}
+}
 
 // SetCoinbase sets the coinbase of the generated block.
 // It can be called at most once.
@@ -100,18 +99,8 @@ func (b *BlockGen) AddTxWithChain(bc *BlockChain, tx *types.Transaction) {
 	}
 	b.statedb.Prepare(tx.Hash(), common.Hash{}, len(b.txs))
 
-	blockContext := &vm.BlockContext{
-		BlockNumber: b.header.Number,
-		Coinbase:    b.header.Coinbase,
-		GasLimit:    b.header.GasLimit,
-		Signer:      types.MakeSigner(b.config, b.header.Number),
-		Precompiles: vm.PrecompiledContractsByzantium, // TODO fix
-		Intpool:     vm.NewIntpool(),
-		Time:        b.header.Time,
-		Difficulty:  b.header.Difficulty,
-	}
-
-	receipt, _, err := ApplyTransaction(b.config, bc, &b.header.Coinbase, b.gasPool, b.statedb, b.header, tx, &b.header.GasUsed, &vm.Config{}, blockContext)
+	blockContext := NewBlockContext(b.header, b.header.Coinbase, b.config)
+	receipt, _, err := ApplyTransaction(b.config, bc, b.gasPool, b.statedb, b.header, tx, &b.header.GasUsed, &vm.Config{}, blockContext)
 	if err != nil {
 		panic(err)
 	}

--- a/core/chain_makers.go
+++ b/core/chain_makers.go
@@ -53,7 +53,8 @@ type BlockGen struct {
 
 	config *params.ChainConfig
 	engine consensus.Engine
-}
+
+	}
 
 // SetCoinbase sets the coinbase of the generated block.
 // It can be called at most once.
@@ -98,9 +99,19 @@ func (b *BlockGen) AddTxWithChain(bc *BlockChain, tx *types.Transaction) {
 		b.SetCoinbase(common.Address{})
 	}
 	b.statedb.Prepare(tx.Hash(), common.Hash{}, len(b.txs))
-	signer := types.MakeSigner(b.config, b.header.Number)
 
-	receipt, _, err := ApplyTransaction(b.config, bc, &b.header.Coinbase, b.gasPool, b.statedb, b.header, tx, &b.header.GasUsed, vm.Config{}, &signer)
+	blockContext := &vm.BlockContext{
+		BlockNumber: b.header.Number,
+		Coinbase:    b.header.Coinbase,
+		GasLimit:    b.header.GasLimit,
+		Signer:      types.MakeSigner(b.config, b.header.Number),
+		Precompiles: vm.PrecompiledContractsByzantium, // TODO fix
+		Intpool:     vm.NewIntpool(),
+		Time:        b.header.Time,
+		Difficulty:  b.header.Difficulty,
+	}
+
+	receipt, _, err := ApplyTransaction(b.config, bc, &b.header.Coinbase, b.gasPool, b.statedb, b.header, tx, &b.header.GasUsed, vm.Config{}, blockContext)
 	if err != nil {
 		panic(err)
 	}

--- a/core/evm.go
+++ b/core/evm.go
@@ -37,23 +37,11 @@ type ChainContext interface {
 
 // NewEVMContext creates a new context for use in the EVM.
 func NewEVMContext(msg Message, header *types.Header, chain ChainContext, author *common.Address) vm.Context {
-	// If we don't have an explicit author (i.e. not mining), extract from the header
-	var beneficiary common.Address
-	if author == nil {
-		beneficiary, _ = chain.Engine().Author(header) // Ignore error, we're past header validation
-	} else {
-		beneficiary = *author
-	}
 	return vm.Context{
 		CanTransfer: CanTransfer,
 		Transfer:    Transfer,
 		GetHash:     GetHashFn(header, chain),
 		Origin:      msg.From(),
-		Coinbase:    beneficiary,
-		BlockNumber: new(big.Int).Set(header.Number),
-		Time:        new(big.Int).Set(header.Time),
-		Difficulty:  new(big.Int).Set(header.Difficulty),
-		GasLimit:    header.GasLimit,
 		GasPrice:    new(big.Int).Set(msg.GasPrice()),
 	}
 }

--- a/core/evm.go
+++ b/core/evm.go
@@ -36,8 +36,8 @@ type ChainContext interface {
 }
 
 // NewEVMContext creates a new context for use in the EVM.
-func NewEVMContext(msg Message, header *types.Header, chain ChainContext, author *common.Address) vm.Context {
-	return vm.Context{
+func NewEVMContext(msg Message, header *types.Header, chain ChainContext, author *common.Address) *vm.Context {
+	return &vm.Context{
 		CanTransfer: CanTransfer,
 		Transfer:    Transfer,
 		GetHash:     GetHashFn(header, chain),

--- a/core/state/statedb.go
+++ b/core/state/statedb.go
@@ -23,6 +23,7 @@ import (
 	"sort"
 	"sync"
 
+	"bytes"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/crypto"
@@ -617,9 +618,8 @@ func (s *StateDB) Commit(deleteEmptyObjects bool) (root common.Hash, err error) 
 		if account.Root != emptyState {
 			s.db.TrieDB().Reference(account.Root, parent)
 		}
-		code := common.BytesToHash(account.CodeHash)
-		if code != emptyCode {
-			s.db.TrieDB().Reference(code, parent)
+		if !bytes.Equal(emptyCodeHash, account.CodeHash) {
+			s.db.TrieDB().Reference(common.BytesToHash(account.CodeHash), parent)
 		}
 		return nil
 	})

--- a/core/state/statedb.go
+++ b/core/state/statedb.go
@@ -18,12 +18,12 @@
 package state
 
 import (
+	"bytes"
 	"fmt"
 	"math/big"
 	"sort"
 	"sync"
 
-	"bytes"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/crypto"

--- a/core/state_processor.go
+++ b/core/state_processor.go
@@ -88,7 +88,7 @@ func (p *StateProcessor) Process(block *types.Block, statedb *state.StateDB, cfg
 	receipts = make([]*types.Receipt, len(block.Transactions()))
 	for i, tx := range block.Transactions() {
 		statedb.Prepare(tx.Hash(), block.Hash(), i)
-		receipt, _, err := ApplyTransaction(p.config, p.bc, nil, gp, statedb, header, tx, usedGas, cfg, blockContext)
+		receipt, _, err := ApplyTransaction(p.config, p.bc, nil, gp, statedb, header, tx, usedGas, &cfg, blockContext)
 		if err != nil {
 			return nil, nil, 0, err
 		}
@@ -105,7 +105,7 @@ func (p *StateProcessor) Process(block *types.Block, statedb *state.StateDB, cfg
 // and uses the input parameters for its environment. It returns the receipt
 // for the transaction, gas used and an error if the transaction failed,
 // indicating the block was invalid.
-func ApplyTransaction(config *params.ChainConfig, bc *BlockChain, author *common.Address, gp *GasPool, statedb *state.StateDB, header *types.Header, tx *types.Transaction, usedGas *uint64, cfg vm.Config, blockContext *vm.BlockContext) (*types.Receipt, uint64, error) {
+func ApplyTransaction(config *params.ChainConfig, bc *BlockChain, author *common.Address, gp *GasPool, statedb *state.StateDB, header *types.Header, tx *types.Transaction, usedGas *uint64, cfg *vm.Config, blockContext *vm.BlockContext) (*types.Receipt, uint64, error) {
 	msg, err := tx.AsMessage(blockContext.Signer)
 	if err != nil {
 		return nil, 0, err

--- a/core/state_processor.go
+++ b/core/state_processor.go
@@ -66,13 +66,14 @@ func (p *StateProcessor) Process(block *types.Block, statedb *state.StateDB, cfg
 		misc.ApplyDAOHardFork(statedb)
 	}
 	// Iterate over and process the individual transactions
+	receipts = make([]*types.Receipt, len(block.Transactions()))
 	for i, tx := range block.Transactions() {
 		statedb.Prepare(tx.Hash(), block.Hash(), i)
 		receipt, _, err := ApplyTransaction(p.config, p.bc, nil, gp, statedb, header, tx, usedGas, cfg)
 		if err != nil {
 			return nil, nil, 0, err
 		}
-		receipts = append(receipts, receipt)
+		receipts[i] = receipt
 		allLogs = append(allLogs, receipt.Logs...)
 	}
 	// Finalize the block, applying any consensus engine specific extras (e.g. block rewards)

--- a/core/state_processor.go
+++ b/core/state_processor.go
@@ -65,11 +65,12 @@ func (p *StateProcessor) Process(block *types.Block, statedb *state.StateDB, cfg
 	if p.config.DAOForkSupport && p.config.DAOForkBlock != nil && p.config.DAOForkBlock.Cmp(block.Number()) == 0 {
 		misc.ApplyDAOHardFork(statedb)
 	}
+	signer := types.MakeSigner(p.config, header.Number)
 	// Iterate over and process the individual transactions
 	receipts = make([]*types.Receipt, len(block.Transactions()))
 	for i, tx := range block.Transactions() {
 		statedb.Prepare(tx.Hash(), block.Hash(), i)
-		receipt, _, err := ApplyTransaction(p.config, p.bc, nil, gp, statedb, header, tx, usedGas, cfg)
+		receipt, _, err := ApplyTransaction(p.config, p.bc, nil, gp, statedb, header, tx, usedGas, cfg, &signer)
 		if err != nil {
 			return nil, nil, 0, err
 		}
@@ -86,8 +87,8 @@ func (p *StateProcessor) Process(block *types.Block, statedb *state.StateDB, cfg
 // and uses the input parameters for its environment. It returns the receipt
 // for the transaction, gas used and an error if the transaction failed,
 // indicating the block was invalid.
-func ApplyTransaction(config *params.ChainConfig, bc *BlockChain, author *common.Address, gp *GasPool, statedb *state.StateDB, header *types.Header, tx *types.Transaction, usedGas *uint64, cfg vm.Config) (*types.Receipt, uint64, error) {
-	msg, err := tx.AsMessage(types.MakeSigner(config, header.Number))
+func ApplyTransaction(config *params.ChainConfig, bc *BlockChain, author *common.Address, gp *GasPool, statedb *state.StateDB, header *types.Header, tx *types.Transaction, usedGas *uint64, cfg vm.Config, signer *types.Signer) (*types.Receipt, uint64, error) {
+	msg, err := tx.AsMessage(*signer)
 	if err != nil {
 		return nil, 0, err
 	}

--- a/core/state_transition.go
+++ b/core/state_transition.go
@@ -186,7 +186,7 @@ func (st *StateTransition) TransitionDb() (ret []byte, usedGas uint64, failed bo
 	}
 	msg := st.msg
 	sender := vm.AccountRef(msg.From())
-	homestead := st.evm.ChainConfig().IsHomestead(st.evm.BlockNumber)
+	homestead := st.evm.ChainConfig().IsHomestead(st.evm.BlockContext.BlockNumber)
 	contractCreation := msg.To() == nil
 
 	// Pay intrinsic gas
@@ -222,7 +222,7 @@ func (st *StateTransition) TransitionDb() (ret []byte, usedGas uint64, failed bo
 		}
 	}
 	st.refundGas()
-	st.state.AddBalance(st.evm.Coinbase, new(big.Int).Mul(new(big.Int).SetUint64(st.gasUsed()), st.gasPrice))
+	st.state.AddBalance(st.evm.BlockContext.Coinbase, new(big.Int).Mul(new(big.Int).SetUint64(st.gasUsed()), st.gasPrice))
 
 	return ret, st.gasUsed(), vmerr != nil, err
 }

--- a/core/vm/contract.go
+++ b/core/vm/contract.go
@@ -65,7 +65,7 @@ type Contract struct {
 }
 
 // NewPrecompiledContract returns a new contract environment for the execution of a precompiled contract
-func NewPrecompiledContract( caller ContractRef,  object ContractRef,value *big.Int, gas uint64) *Contract{
+func NewPrecompiledContract(caller ContractRef, object ContractRef, value *big.Int, gas uint64) *Contract {
 
 	c := &Contract{CallerAddress: caller.Address(), caller: caller, self: object, Args: nil}
 	// Gas should be a pointer so it can safely be reduced through the run

--- a/core/vm/contract.go
+++ b/core/vm/contract.go
@@ -64,6 +64,18 @@ type Contract struct {
 	DelegateCall bool
 }
 
+func NewPrecompiledContract( caller ContractRef,  object ContractRef,value *big.Int, gas uint64) *Contract{
+
+	c := &Contract{CallerAddress: caller.Address(), caller: caller, self: object, Args: nil}
+	// Gas should be a pointer so it can safely be reduced through the run
+	// This pointer will be off the state transition
+	c.Gas = gas
+	// ensures a value is set
+	c.value = value
+	return c
+
+}
+
 // NewContract returns a new contract environment for the execution of EVM.
 func NewContract(caller ContractRef, object ContractRef, value *big.Int, gas uint64) *Contract {
 	c := &Contract{CallerAddress: caller.Address(), caller: caller, self: object, Args: nil}

--- a/core/vm/contract.go
+++ b/core/vm/contract.go
@@ -64,6 +64,7 @@ type Contract struct {
 	DelegateCall bool
 }
 
+// NewPrecompiledContract returns a new contract environment for the execution of a precompiled contract
 func NewPrecompiledContract( caller ContractRef,  object ContractRef,value *big.Int, gas uint64) *Contract{
 
 	c := &Contract{CallerAddress: caller.Address(), caller: caller, self: object, Args: nil}

--- a/core/vm/contracts.go
+++ b/core/vm/contracts.go
@@ -59,6 +59,14 @@ var PrecompiledContractsByzantium = map[common.Address]PrecompiledContract{
 	common.BytesToAddress([]byte{8}): &bn256Pairing{},
 }
 
+// PrecompilesAt returns the map of active precompiled contracts at the given blocknumber and config
+func PrecompilesAt(c *params.ChainConfig, blockNumber *big.Int) map[common.Address]PrecompiledContract {
+	if c.ByzantiumBlock.Cmp(blockNumber) <= 0 {
+		return PrecompiledContractsByzantium
+	}
+	return PrecompiledContractsHomestead
+}
+
 // RunPrecompiledContract runs and evaluates the output of a precompiled contract.
 func RunPrecompiledContract(p PrecompiledContract, input []byte, contract *Contract) (ret []byte, err error) {
 	gas := p.RequiredGas(input)

--- a/core/vm/evm.go
+++ b/core/vm/evm.go
@@ -98,7 +98,7 @@ type BlockContext struct{
 type EVM struct {
 	BlockContext *BlockContext
 	// Context provides auxiliary blockchain related information
-	Context
+	*Context
 	// StateDB gives access to the underlying state
 	StateDB StateDB
 	// Depth is the current call stack
@@ -110,7 +110,7 @@ type EVM struct {
 	chainRules params.Rules
 	// virtual machine configuration options used to initialise the
 	// evm.
-	vmConfig Config
+	vmConfig *Config
 	// global (to this context) ethereum virtual machine
 	// used throughout the execution of the tx.
 	interpreter *Interpreter
@@ -125,7 +125,7 @@ type EVM struct {
 
 // NewEVM returns a new EVM. The returned EVM is not thread safe and should
 // only ever be used *once*.
-func NewEVM(ctx Context, statedb StateDB, chainConfig *params.ChainConfig, vmConfig Config,blockContext *BlockContext) *EVM {
+func NewEVM(ctx *Context, statedb StateDB, chainConfig *params.ChainConfig, vmConfig *Config,blockContext *BlockContext) *EVM {
 	evm := &EVM{
 		Context:      ctx,
 		StateDB:      statedb,

--- a/core/vm/gas_table.go
+++ b/core/vm/gas_table.go
@@ -319,7 +319,7 @@ func gasCall(gt params.GasTable, evm *EVM, contract *Contract, stack *Stack, mem
 		gas            = gt.Calls
 		transfersValue = stack.Back(2).Sign() != 0
 		address        = common.BigToAddress(stack.Back(1))
-		eip158         = evm.ChainConfig().IsEIP158(evm.BlockNumber)
+		eip158         = evm.ChainConfig().IsEIP158(evm.BlockContext.BlockNumber)
 	)
 	if eip158 {
 		if transfersValue && evm.StateDB.Empty(address) {
@@ -385,11 +385,11 @@ func gasRevert(gt params.GasTable, evm *EVM, contract *Contract, stack *Stack, m
 func gasSuicide(gt params.GasTable, evm *EVM, contract *Contract, stack *Stack, mem *Memory, memorySize uint64) (uint64, error) {
 	var gas uint64
 	// EIP150 homestead gas reprice fork:
-	if evm.ChainConfig().IsEIP150(evm.BlockNumber) {
+	if evm.ChainConfig().IsEIP150(evm.BlockContext.BlockNumber) {
 		gas = gt.Suicide
 		var (
 			address = common.BigToAddress(stack.Back(0))
-			eip158  = evm.ChainConfig().IsEIP158(evm.BlockNumber)
+			eip158  = evm.ChainConfig().IsEIP158(evm.BlockContext.BlockNumber)
 		)
 
 		if eip158 {

--- a/core/vm/instructions.go
+++ b/core/vm/instructions.go
@@ -41,7 +41,7 @@ func opAdd(pc *uint64, evm *EVM, contract *Contract, memory *Memory, stack *Stac
 	x, y := stack.pop(), stack.peek()
 	math.U256(y.Add(x, y))
 
-	evm.interpreter.intPool.put(x)
+	evm.BlockContext.Intpool.put(x)
 	return nil, nil
 }
 
@@ -49,7 +49,7 @@ func opSub(pc *uint64, evm *EVM, contract *Contract, memory *Memory, stack *Stac
 	x, y := stack.pop(), stack.peek()
 	math.U256(y.Sub(x, y))
 
-	evm.interpreter.intPool.put(x)
+	evm.BlockContext.Intpool.put(x)
 	return nil, nil
 }
 
@@ -57,7 +57,7 @@ func opMul(pc *uint64, evm *EVM, contract *Contract, memory *Memory, stack *Stac
 	x, y := stack.pop(), stack.pop()
 	stack.push(math.U256(x.Mul(x, y)))
 
-	evm.interpreter.intPool.put(y)
+	evm.BlockContext.Intpool.put(y)
 
 	return nil, nil
 }
@@ -69,13 +69,13 @@ func opDiv(pc *uint64, evm *EVM, contract *Contract, memory *Memory, stack *Stac
 	} else {
 		y.SetUint64(0)
 	}
-	evm.interpreter.intPool.put(x)
+	evm.BlockContext.Intpool.put(x)
 	return nil, nil
 }
 
 func opSdiv(pc *uint64, evm *EVM, contract *Contract, memory *Memory, stack *Stack) ([]byte, error) {
 	x, y := math.S256(stack.pop()), math.S256(stack.pop())
-	res := evm.interpreter.intPool.getZero()
+	res := evm.BlockContext.Intpool.getZero()
 
 	if y.Sign() == 0 || x.Sign() == 0 {
 		stack.push(res)
@@ -88,7 +88,7 @@ func opSdiv(pc *uint64, evm *EVM, contract *Contract, memory *Memory, stack *Sta
 		}
 		stack.push(math.U256(res))
 	}
-	evm.interpreter.intPool.put(x, y)
+	evm.BlockContext.Intpool.put(x, y)
 	return nil, nil
 }
 
@@ -99,13 +99,13 @@ func opMod(pc *uint64, evm *EVM, contract *Contract, memory *Memory, stack *Stac
 	} else {
 		stack.push(math.U256(x.Mod(x, y)))
 	}
-	evm.interpreter.intPool.put(y)
+	evm.BlockContext.Intpool.put(y)
 	return nil, nil
 }
 
 func opSmod(pc *uint64, evm *EVM, contract *Contract, memory *Memory, stack *Stack) ([]byte, error) {
 	x, y := math.S256(stack.pop()), math.S256(stack.pop())
-	res := evm.interpreter.intPool.getZero()
+	res := evm.BlockContext.Intpool.getZero()
 
 	if y.Sign() == 0 {
 		stack.push(res)
@@ -118,7 +118,7 @@ func opSmod(pc *uint64, evm *EVM, contract *Contract, memory *Memory, stack *Sta
 		}
 		stack.push(math.U256(res))
 	}
-	evm.interpreter.intPool.put(x, y)
+	evm.BlockContext.Intpool.put(x, y)
 	return nil, nil
 }
 
@@ -126,7 +126,7 @@ func opExp(pc *uint64, evm *EVM, contract *Contract, memory *Memory, stack *Stac
 	base, exponent := stack.pop(), stack.pop()
 	stack.push(math.Exp(base, exponent))
 
-	evm.interpreter.intPool.put(base, exponent)
+	evm.BlockContext.Intpool.put(base, exponent)
 
 	return nil, nil
 }
@@ -147,7 +147,7 @@ func opSignExtend(pc *uint64, evm *EVM, contract *Contract, memory *Memory, stac
 		stack.push(math.U256(num))
 	}
 
-	evm.interpreter.intPool.put(back)
+	evm.BlockContext.Intpool.put(back)
 	return nil, nil
 }
 
@@ -164,7 +164,7 @@ func opLt(pc *uint64, evm *EVM, contract *Contract, memory *Memory, stack *Stack
 	} else {
 		y.SetUint64(0)
 	}
-	evm.interpreter.intPool.put(x)
+	evm.BlockContext.Intpool.put(x)
 	return nil, nil
 }
 
@@ -175,7 +175,7 @@ func opGt(pc *uint64, evm *EVM, contract *Contract, memory *Memory, stack *Stack
 	} else {
 		y.SetUint64(0)
 	}
-	evm.interpreter.intPool.put(x)
+	evm.BlockContext.Intpool.put(x)
 	return nil, nil
 }
 
@@ -199,7 +199,7 @@ func opSlt(pc *uint64, evm *EVM, contract *Contract, memory *Memory, stack *Stac
 			y.SetUint64(0)
 		}
 	}
-	evm.interpreter.intPool.put(x)
+	evm.BlockContext.Intpool.put(x)
 	return nil, nil
 }
 
@@ -223,7 +223,7 @@ func opSgt(pc *uint64, evm *EVM, contract *Contract, memory *Memory, stack *Stac
 			y.SetUint64(0)
 		}
 	}
-	evm.interpreter.intPool.put(x)
+	evm.BlockContext.Intpool.put(x)
 	return nil, nil
 }
 
@@ -234,7 +234,7 @@ func opEq(pc *uint64, evm *EVM, contract *Contract, memory *Memory, stack *Stack
 	} else {
 		y.SetUint64(0)
 	}
-	evm.interpreter.intPool.put(x)
+	evm.BlockContext.Intpool.put(x)
 	return nil, nil
 }
 
@@ -252,7 +252,7 @@ func opAnd(pc *uint64, evm *EVM, contract *Contract, memory *Memory, stack *Stac
 	x, y := stack.pop(), stack.pop()
 	stack.push(x.And(x, y))
 
-	evm.interpreter.intPool.put(y)
+	evm.BlockContext.Intpool.put(y)
 	return nil, nil
 }
 
@@ -260,7 +260,7 @@ func opOr(pc *uint64, evm *EVM, contract *Contract, memory *Memory, stack *Stack
 	x, y := stack.pop(), stack.peek()
 	y.Or(x, y)
 
-	evm.interpreter.intPool.put(x)
+	evm.BlockContext.Intpool.put(x)
 	return nil, nil
 }
 
@@ -268,7 +268,7 @@ func opXor(pc *uint64, evm *EVM, contract *Contract, memory *Memory, stack *Stac
 	x, y := stack.pop(), stack.peek()
 	y.Xor(x, y)
 
-	evm.interpreter.intPool.put(x)
+	evm.BlockContext.Intpool.put(x)
 	return nil, nil
 }
 
@@ -280,7 +280,7 @@ func opByte(pc *uint64, evm *EVM, contract *Contract, memory *Memory, stack *Sta
 	} else {
 		val.SetUint64(0)
 	}
-	evm.interpreter.intPool.put(th)
+	evm.BlockContext.Intpool.put(th)
 	return nil, nil
 }
 
@@ -293,7 +293,7 @@ func opAddmod(pc *uint64, evm *EVM, contract *Contract, memory *Memory, stack *S
 	} else {
 		stack.push(x.SetUint64(0))
 	}
-	evm.interpreter.intPool.put(y, z)
+	evm.BlockContext.Intpool.put(y, z)
 	return nil, nil
 }
 
@@ -306,7 +306,7 @@ func opMulmod(pc *uint64, evm *EVM, contract *Contract, memory *Memory, stack *S
 	} else {
 		stack.push(x.SetUint64(0))
 	}
-	evm.interpreter.intPool.put(y, z)
+	evm.BlockContext.Intpool.put(y, z)
 	return nil, nil
 }
 
@@ -316,7 +316,7 @@ func opMulmod(pc *uint64, evm *EVM, contract *Contract, memory *Memory, stack *S
 func opSHL(pc *uint64, evm *EVM, contract *Contract, memory *Memory, stack *Stack) ([]byte, error) {
 	// Note, second operand is left in the stack; accumulate result into it, and no need to push it afterwards
 	shift, value := math.U256(stack.pop()), math.U256(stack.peek())
-	defer evm.interpreter.intPool.put(shift) // First operand back into the pool
+	defer evm.BlockContext.Intpool.put(shift) // First operand back into the pool
 
 	if shift.Cmp(common.Big256) >= 0 {
 		value.SetUint64(0)
@@ -334,7 +334,7 @@ func opSHL(pc *uint64, evm *EVM, contract *Contract, memory *Memory, stack *Stac
 func opSHR(pc *uint64, evm *EVM, contract *Contract, memory *Memory, stack *Stack) ([]byte, error) {
 	// Note, second operand is left in the stack; accumulate result into it, and no need to push it afterwards
 	shift, value := math.U256(stack.pop()), math.U256(stack.peek())
-	defer evm.interpreter.intPool.put(shift) // First operand back into the pool
+	defer evm.BlockContext.Intpool.put(shift) // First operand back into the pool
 
 	if shift.Cmp(common.Big256) >= 0 {
 		value.SetUint64(0)
@@ -352,7 +352,7 @@ func opSHR(pc *uint64, evm *EVM, contract *Contract, memory *Memory, stack *Stac
 func opSAR(pc *uint64, evm *EVM, contract *Contract, memory *Memory, stack *Stack) ([]byte, error) {
 	// Note, S256 returns (potentially) a new bigint, so we're popping, not peeking this one
 	shift, value := math.U256(stack.pop()), math.S256(stack.pop())
-	defer evm.interpreter.intPool.put(shift) // First operand back into the pool
+	defer evm.BlockContext.Intpool.put(shift) // First operand back into the pool
 
 	if shift.Cmp(common.Big256) >= 0 {
 		if value.Sign() > 0 {
@@ -378,9 +378,9 @@ func opSha3(pc *uint64, evm *EVM, contract *Contract, memory *Memory, stack *Sta
 	if evm.vmConfig.EnablePreimageRecording {
 		evm.StateDB.AddPreimage(common.BytesToHash(hash), data)
 	}
-	stack.push(evm.interpreter.intPool.get().SetBytes(hash))
+	stack.push(evm.BlockContext.Intpool.get().SetBytes(hash))
 
-	evm.interpreter.intPool.put(offset, size)
+	evm.BlockContext.Intpool.put(offset, size)
 	return nil, nil
 }
 
@@ -406,17 +406,17 @@ func opCaller(pc *uint64, evm *EVM, contract *Contract, memory *Memory, stack *S
 }
 
 func opCallValue(pc *uint64, evm *EVM, contract *Contract, memory *Memory, stack *Stack) ([]byte, error) {
-	stack.push(evm.interpreter.intPool.get().Set(contract.value))
+	stack.push(evm.BlockContext.Intpool.get().Set(contract.value))
 	return nil, nil
 }
 
 func opCallDataLoad(pc *uint64, evm *EVM, contract *Contract, memory *Memory, stack *Stack) ([]byte, error) {
-	stack.push(evm.interpreter.intPool.get().SetBytes(getDataBig(contract.Input, stack.pop(), big32)))
+	stack.push(evm.BlockContext.Intpool.get().SetBytes(getDataBig(contract.Input, stack.pop(), big32)))
 	return nil, nil
 }
 
 func opCallDataSize(pc *uint64, evm *EVM, contract *Contract, memory *Memory, stack *Stack) ([]byte, error) {
-	stack.push(evm.interpreter.intPool.get().SetInt64(int64(len(contract.Input))))
+	stack.push(evm.BlockContext.Intpool.get().SetInt64(int64(len(contract.Input))))
 	return nil, nil
 }
 
@@ -428,12 +428,12 @@ func opCallDataCopy(pc *uint64, evm *EVM, contract *Contract, memory *Memory, st
 	)
 	memory.Set(memOffset.Uint64(), length.Uint64(), getDataBig(contract.Input, dataOffset, length))
 
-	evm.interpreter.intPool.put(memOffset, dataOffset, length)
+	evm.BlockContext.Intpool.put(memOffset, dataOffset, length)
 	return nil, nil
 }
 
 func opReturnDataSize(pc *uint64, evm *EVM, contract *Contract, memory *Memory, stack *Stack) ([]byte, error) {
-	stack.push(evm.interpreter.intPool.get().SetUint64(uint64(len(evm.interpreter.returnData))))
+	stack.push(evm.BlockContext.Intpool.get().SetUint64(uint64(len(evm.interpreter.returnData))))
 	return nil, nil
 }
 
@@ -443,9 +443,9 @@ func opReturnDataCopy(pc *uint64, evm *EVM, contract *Contract, memory *Memory, 
 		dataOffset = stack.pop()
 		length     = stack.pop()
 
-		end = evm.interpreter.intPool.get().Add(dataOffset, length)
+		end = evm.BlockContext.Intpool.get().Add(dataOffset, length)
 	)
-	defer evm.interpreter.intPool.put(memOffset, dataOffset, length, end)
+	defer evm.BlockContext.Intpool.put(memOffset, dataOffset, length, end)
 
 	if end.BitLen() > 64 || uint64(len(evm.interpreter.returnData)) < end.Uint64() {
 		return nil, errReturnDataOutOfBounds
@@ -463,7 +463,7 @@ func opExtCodeSize(pc *uint64, evm *EVM, contract *Contract, memory *Memory, sta
 }
 
 func opCodeSize(pc *uint64, evm *EVM, contract *Contract, memory *Memory, stack *Stack) ([]byte, error) {
-	l := evm.interpreter.intPool.get().SetInt64(int64(len(contract.Code)))
+	l := evm.BlockContext.Intpool.get().SetInt64(int64(len(contract.Code)))
 	stack.push(l)
 
 	return nil, nil
@@ -478,7 +478,7 @@ func opCodeCopy(pc *uint64, evm *EVM, contract *Contract, memory *Memory, stack 
 	codeCopy := getDataBig(contract.Code, codeOffset, length)
 	memory.Set(memOffset.Uint64(), length.Uint64(), codeCopy)
 
-	evm.interpreter.intPool.put(memOffset, codeOffset, length)
+	evm.BlockContext.Intpool.put(memOffset, codeOffset, length)
 	return nil, nil
 }
 
@@ -492,64 +492,64 @@ func opExtCodeCopy(pc *uint64, evm *EVM, contract *Contract, memory *Memory, sta
 	codeCopy := getDataBig(evm.StateDB.GetCode(addr), codeOffset, length)
 	memory.Set(memOffset.Uint64(), length.Uint64(), codeCopy)
 
-	evm.interpreter.intPool.put(memOffset, codeOffset, length)
+	evm.BlockContext.Intpool.put(memOffset, codeOffset, length)
 	return nil, nil
 }
 
 func opGasprice(pc *uint64, evm *EVM, contract *Contract, memory *Memory, stack *Stack) ([]byte, error) {
-	stack.push(evm.interpreter.intPool.get().Set(evm.GasPrice))
+	stack.push(evm.BlockContext.Intpool.get().Set(evm.GasPrice))
 	return nil, nil
 }
 
 func opBlockhash(pc *uint64, evm *EVM, contract *Contract, memory *Memory, stack *Stack) ([]byte, error) {
 	num := stack.pop()
 
-	n := evm.interpreter.intPool.get().Sub(evm.BlockNumber, common.Big257)
-	if num.Cmp(n) > 0 && num.Cmp(evm.BlockNumber) < 0 {
+	n := evm.BlockContext.Intpool.get().Sub(evm.BlockContext.BlockNumber, common.Big257)
+	if num.Cmp(n) > 0 && num.Cmp(evm.BlockContext.BlockNumber) < 0 {
 		stack.push(evm.GetHash(num.Uint64()).Big())
 	} else {
-		stack.push(evm.interpreter.intPool.getZero())
+		stack.push(evm.BlockContext.Intpool.getZero())
 	}
-	evm.interpreter.intPool.put(num, n)
+	evm.BlockContext.Intpool.put(num, n)
 	return nil, nil
 }
 
 func opCoinbase(pc *uint64, evm *EVM, contract *Contract, memory *Memory, stack *Stack) ([]byte, error) {
-	stack.push(evm.Coinbase.Big())
+	stack.push(evm.BlockContext.Coinbase.Big())
 	return nil, nil
 }
 
 func opTimestamp(pc *uint64, evm *EVM, contract *Contract, memory *Memory, stack *Stack) ([]byte, error) {
-	stack.push(math.U256(evm.interpreter.intPool.get().Set(evm.Time)))
+	stack.push(math.U256(evm.BlockContext.Intpool.get().Set(evm.BlockContext.Time)))
 	return nil, nil
 }
 
 func opNumber(pc *uint64, evm *EVM, contract *Contract, memory *Memory, stack *Stack) ([]byte, error) {
-	stack.push(math.U256(evm.interpreter.intPool.get().Set(evm.BlockNumber)))
+	stack.push(math.U256(evm.BlockContext.Intpool.get().Set(evm.BlockContext.BlockNumber)))
 	return nil, nil
 }
 
 func opDifficulty(pc *uint64, evm *EVM, contract *Contract, memory *Memory, stack *Stack) ([]byte, error) {
-	stack.push(math.U256(evm.interpreter.intPool.get().Set(evm.Difficulty)))
+	stack.push(math.U256(evm.BlockContext.Intpool.get().Set(evm.BlockContext.Difficulty)))
 	return nil, nil
 }
 
 func opGasLimit(pc *uint64, evm *EVM, contract *Contract, memory *Memory, stack *Stack) ([]byte, error) {
-	stack.push(math.U256(evm.interpreter.intPool.get().SetUint64(evm.GasLimit)))
+	stack.push(math.U256(evm.BlockContext.Intpool.get().SetUint64(evm.BlockContext.GasLimit)))
 	return nil, nil
 }
 
 func opPop(pc *uint64, evm *EVM, contract *Contract, memory *Memory, stack *Stack) ([]byte, error) {
-	evm.interpreter.intPool.put(stack.pop())
+	evm.BlockContext.Intpool.put(stack.pop())
 	return nil, nil
 }
 
 func opMload(pc *uint64, evm *EVM, contract *Contract, memory *Memory, stack *Stack) ([]byte, error) {
 	offset := stack.pop()
-	val := evm.interpreter.intPool.get().SetBytes(memory.Get(offset.Int64(), 32))
+	val := evm.BlockContext.Intpool.get().SetBytes(memory.Get(offset.Int64(), 32))
 	stack.push(val)
 
-	evm.interpreter.intPool.put(offset)
+	evm.BlockContext.Intpool.put(offset)
 	return nil, nil
 }
 
@@ -558,7 +558,7 @@ func opMstore(pc *uint64, evm *EVM, contract *Contract, memory *Memory, stack *S
 	mStart, val := stack.pop(), stack.pop()
 	memory.Set(mStart.Uint64(), 32, math.PaddedBigBytes(val, 32))
 
-	evm.interpreter.intPool.put(mStart, val)
+	evm.BlockContext.Intpool.put(mStart, val)
 	return nil, nil
 }
 
@@ -581,7 +581,7 @@ func opSstore(pc *uint64, evm *EVM, contract *Contract, memory *Memory, stack *S
 	val := stack.pop()
 	evm.StateDB.SetState(contract.Address(), loc, common.BigToHash(val))
 
-	evm.interpreter.intPool.put(val)
+	evm.BlockContext.Intpool.put(val)
 	return nil, nil
 }
 
@@ -593,7 +593,7 @@ func opJump(pc *uint64, evm *EVM, contract *Contract, memory *Memory, stack *Sta
 	}
 	*pc = pos.Uint64()
 
-	evm.interpreter.intPool.put(pos)
+	evm.BlockContext.Intpool.put(pos)
 	return nil, nil
 }
 
@@ -609,7 +609,7 @@ func opJumpi(pc *uint64, evm *EVM, contract *Contract, memory *Memory, stack *St
 		*pc++
 	}
 
-	evm.interpreter.intPool.put(pos, cond)
+	evm.BlockContext.Intpool.put(pos, cond)
 	return nil, nil
 }
 
@@ -618,17 +618,17 @@ func opJumpdest(pc *uint64, evm *EVM, contract *Contract, memory *Memory, stack 
 }
 
 func opPc(pc *uint64, evm *EVM, contract *Contract, memory *Memory, stack *Stack) ([]byte, error) {
-	stack.push(evm.interpreter.intPool.get().SetUint64(*pc))
+	stack.push(evm.BlockContext.Intpool.get().SetUint64(*pc))
 	return nil, nil
 }
 
 func opMsize(pc *uint64, evm *EVM, contract *Contract, memory *Memory, stack *Stack) ([]byte, error) {
-	stack.push(evm.interpreter.intPool.get().SetInt64(int64(memory.Len())))
+	stack.push(evm.BlockContext.Intpool.get().SetInt64(int64(memory.Len())))
 	return nil, nil
 }
 
 func opGas(pc *uint64, evm *EVM, contract *Contract, memory *Memory, stack *Stack) ([]byte, error) {
-	stack.push(evm.interpreter.intPool.get().SetUint64(contract.Gas))
+	stack.push(evm.BlockContext.Intpool.get().SetUint64(contract.Gas))
 	return nil, nil
 }
 
@@ -639,7 +639,7 @@ func opCreate(pc *uint64, evm *EVM, contract *Contract, memory *Memory, stack *S
 		input        = memory.Get(offset.Int64(), size.Int64())
 		gas          = contract.Gas
 	)
-	if evm.ChainConfig().IsEIP150(evm.BlockNumber) {
+	if evm.ChainConfig().IsEIP150(evm.BlockContext.BlockNumber) {
 		gas -= gas / 64
 	}
 
@@ -649,15 +649,15 @@ func opCreate(pc *uint64, evm *EVM, contract *Contract, memory *Memory, stack *S
 	// homestead we must check for CodeStoreOutOfGasError (homestead only
 	// rule) and treat as an error, if the ruleset is frontier we must
 	// ignore this error and pretend the operation was successful.
-	if evm.ChainConfig().IsHomestead(evm.BlockNumber) && suberr == ErrCodeStoreOutOfGas {
-		stack.push(evm.interpreter.intPool.getZero())
+	if evm.ChainConfig().IsHomestead(evm.BlockContext.BlockNumber) && suberr == ErrCodeStoreOutOfGas {
+		stack.push(evm.BlockContext.Intpool.getZero())
 	} else if suberr != nil && suberr != ErrCodeStoreOutOfGas {
-		stack.push(evm.interpreter.intPool.getZero())
+		stack.push(evm.BlockContext.Intpool.getZero())
 	} else {
 		stack.push(addr.Big())
 	}
 	contract.Gas += returnGas
-	evm.interpreter.intPool.put(value, offset, size)
+	evm.BlockContext.Intpool.put(value, offset, size)
 
 	if suberr == errExecutionReverted {
 		return res, nil
@@ -667,7 +667,7 @@ func opCreate(pc *uint64, evm *EVM, contract *Contract, memory *Memory, stack *S
 
 func opCall(pc *uint64, evm *EVM, contract *Contract, memory *Memory, stack *Stack) ([]byte, error) {
 	// Pop gas. The actual gas in in evm.callGasTemp.
-	evm.interpreter.intPool.put(stack.pop())
+	evm.BlockContext.Intpool.put(stack.pop())
 	gas := evm.callGasTemp
 	// Pop other call parameters.
 	addr, value, inOffset, inSize, retOffset, retSize := stack.pop(), stack.pop(), stack.pop(), stack.pop(), stack.pop(), stack.pop()
@@ -681,22 +681,22 @@ func opCall(pc *uint64, evm *EVM, contract *Contract, memory *Memory, stack *Sta
 	}
 	ret, returnGas, err := evm.Call(contract, toAddr, args, gas, value)
 	if err != nil {
-		stack.push(evm.interpreter.intPool.getZero())
+		stack.push(evm.BlockContext.Intpool.getZero())
 	} else {
-		stack.push(evm.interpreter.intPool.get().SetUint64(1))
+		stack.push(evm.BlockContext.Intpool.get().SetUint64(1))
 	}
 	if err == nil || err == errExecutionReverted {
 		memory.Set(retOffset.Uint64(), retSize.Uint64(), ret)
 	}
 	contract.Gas += returnGas
 
-	evm.interpreter.intPool.put(addr, value, inOffset, inSize, retOffset, retSize)
+	evm.BlockContext.Intpool.put(addr, value, inOffset, inSize, retOffset, retSize)
 	return ret, nil
 }
 
 func opCallCode(pc *uint64, evm *EVM, contract *Contract, memory *Memory, stack *Stack) ([]byte, error) {
 	// Pop gas. The actual gas is in evm.callGasTemp.
-	evm.interpreter.intPool.put(stack.pop())
+	evm.BlockContext.Intpool.put(stack.pop())
 	gas := evm.callGasTemp
 	// Pop other call parameters.
 	addr, value, inOffset, inSize, retOffset, retSize := stack.pop(), stack.pop(), stack.pop(), stack.pop(), stack.pop(), stack.pop()
@@ -710,22 +710,22 @@ func opCallCode(pc *uint64, evm *EVM, contract *Contract, memory *Memory, stack 
 	}
 	ret, returnGas, err := evm.CallCode(contract, toAddr, args, gas, value)
 	if err != nil {
-		stack.push(evm.interpreter.intPool.getZero())
+		stack.push(evm.BlockContext.Intpool.getZero())
 	} else {
-		stack.push(evm.interpreter.intPool.get().SetUint64(1))
+		stack.push(evm.BlockContext.Intpool.get().SetUint64(1))
 	}
 	if err == nil || err == errExecutionReverted {
 		memory.Set(retOffset.Uint64(), retSize.Uint64(), ret)
 	}
 	contract.Gas += returnGas
 
-	evm.interpreter.intPool.put(addr, value, inOffset, inSize, retOffset, retSize)
+	evm.BlockContext.Intpool.put(addr, value, inOffset, inSize, retOffset, retSize)
 	return ret, nil
 }
 
 func opDelegateCall(pc *uint64, evm *EVM, contract *Contract, memory *Memory, stack *Stack) ([]byte, error) {
 	// Pop gas. The actual gas is in evm.callGasTemp.
-	evm.interpreter.intPool.put(stack.pop())
+	evm.BlockContext.Intpool.put(stack.pop())
 	gas := evm.callGasTemp
 	// Pop other call parameters.
 	addr, inOffset, inSize, retOffset, retSize := stack.pop(), stack.pop(), stack.pop(), stack.pop(), stack.pop()
@@ -735,22 +735,22 @@ func opDelegateCall(pc *uint64, evm *EVM, contract *Contract, memory *Memory, st
 
 	ret, returnGas, err := evm.DelegateCall(contract, toAddr, args, gas)
 	if err != nil {
-		stack.push(evm.interpreter.intPool.getZero())
+		stack.push(evm.BlockContext.Intpool.getZero())
 	} else {
-		stack.push(evm.interpreter.intPool.get().SetUint64(1))
+		stack.push(evm.BlockContext.Intpool.get().SetUint64(1))
 	}
 	if err == nil || err == errExecutionReverted {
 		memory.Set(retOffset.Uint64(), retSize.Uint64(), ret)
 	}
 	contract.Gas += returnGas
 
-	evm.interpreter.intPool.put(addr, inOffset, inSize, retOffset, retSize)
+	evm.BlockContext.Intpool.put(addr, inOffset, inSize, retOffset, retSize)
 	return ret, nil
 }
 
 func opStaticCall(pc *uint64, evm *EVM, contract *Contract, memory *Memory, stack *Stack) ([]byte, error) {
 	// Pop gas. The actual gas is in evm.callGasTemp.
-	evm.interpreter.intPool.put(stack.pop())
+	evm.BlockContext.Intpool.put(stack.pop())
 	gas := evm.callGasTemp
 	// Pop other call parameters.
 	addr, inOffset, inSize, retOffset, retSize := stack.pop(), stack.pop(), stack.pop(), stack.pop(), stack.pop()
@@ -760,16 +760,16 @@ func opStaticCall(pc *uint64, evm *EVM, contract *Contract, memory *Memory, stac
 
 	ret, returnGas, err := evm.StaticCall(contract, toAddr, args, gas)
 	if err != nil {
-		stack.push(evm.interpreter.intPool.getZero())
+		stack.push(evm.BlockContext.Intpool.getZero())
 	} else {
-		stack.push(evm.interpreter.intPool.get().SetUint64(1))
+		stack.push(evm.BlockContext.Intpool.get().SetUint64(1))
 	}
 	if err == nil || err == errExecutionReverted {
 		memory.Set(retOffset.Uint64(), retSize.Uint64(), ret)
 	}
 	contract.Gas += returnGas
 
-	evm.interpreter.intPool.put(addr, inOffset, inSize, retOffset, retSize)
+	evm.BlockContext.Intpool.put(addr, inOffset, inSize, retOffset, retSize)
 	return ret, nil
 }
 
@@ -777,7 +777,7 @@ func opReturn(pc *uint64, evm *EVM, contract *Contract, memory *Memory, stack *S
 	offset, size := stack.pop(), stack.pop()
 	ret := memory.GetPtr(offset.Int64(), size.Int64())
 
-	evm.interpreter.intPool.put(offset, size)
+	evm.BlockContext.Intpool.put(offset, size)
 	return ret, nil
 }
 
@@ -785,7 +785,7 @@ func opRevert(pc *uint64, evm *EVM, contract *Contract, memory *Memory, stack *S
 	offset, size := stack.pop(), stack.pop()
 	ret := memory.GetPtr(offset.Int64(), size.Int64())
 
-	evm.interpreter.intPool.put(offset, size)
+	evm.BlockContext.Intpool.put(offset, size)
 	return ret, nil
 }
 
@@ -819,10 +819,10 @@ func makeLog(size int) executionFunc {
 			Data:    d,
 			// This is a non-consensus field, but assigned here because
 			// core/state doesn't know the current block number.
-			BlockNumber: evm.BlockNumber.Uint64(),
+			BlockNumber: evm.BlockContext.BlockNumber.Uint64(),
 		})
 
-		evm.interpreter.intPool.put(mStart, mSize)
+		evm.BlockContext.Intpool.put(mStart, mSize)
 		return nil, nil
 	}
 }
@@ -842,7 +842,7 @@ func makePush(size uint64, pushByteSize int) executionFunc {
 			endMin = startMin + pushByteSize
 		}
 
-		integer := evm.interpreter.intPool.get()
+		integer := evm.BlockContext.Intpool.get()
 		stack.push(integer.SetBytes(common.RightPadBytes(contract.Code[startMin:endMin], pushByteSize)))
 
 		*pc += size
@@ -853,7 +853,7 @@ func makePush(size uint64, pushByteSize int) executionFunc {
 // make dup instruction function
 func makeDup(size int64) executionFunc {
 	return func(pc *uint64, evm *EVM, contract *Contract, memory *Memory, stack *Stack) ([]byte, error) {
-		stack.dup(evm.interpreter.intPool, int(size))
+		stack.dup(evm.BlockContext.Intpool, int(size))
 		return nil, nil
 	}
 }

--- a/core/vm/instructions_test.go
+++ b/core/vm/instructions_test.go
@@ -32,9 +32,10 @@ type twoOperandTest struct {
 
 func testTwoOperandOp(t *testing.T, tests []twoOperandTest, opFn func(pc *uint64, evm *EVM, contract *Contract, memory *Memory, stack *Stack) ([]byte, error)) {
 	var (
-		env   = NewEVM(Context{}, nil, params.TestChainConfig, Config{})
-		stack = newstack()
-		pc    = uint64(0)
+		blockContext = &BlockContext{Coinbase: common.Address{}, BlockNumber: big.NewInt(1337), Intpool: NewIntpool()}
+		env          = NewEVM(&Context{}, nil, params.TestChainConfig, &Config{}, blockContext)
+		stack        = newstack()
+		pc           = uint64(0)
 	)
 	for i, test := range tests {
 		x := new(big.Int).SetBytes(common.Hex2Bytes(test.x))
@@ -50,13 +51,13 @@ func testTwoOperandOp(t *testing.T, tests []twoOperandTest, opFn func(pc *uint64
 		// Check pool usage
 		// 1.pool is not allowed to contain anything on the stack
 		// 2.pool is not allowed to contain the same pointers twice
-		if env.interpreter.intPool.pool.len() > 0 {
+		if env.BlockContext.Intpool.pool.len() > 0 {
 
 			poolvals := make(map[*big.Int]struct{})
 			poolvals[actual] = struct{}{}
 
-			for env.interpreter.intPool.pool.len() > 0 {
-				key := env.interpreter.intPool.get()
+			for env.BlockContext.Intpool.pool.len() > 0 {
+				key := env.BlockContext.Intpool.get()
 				if _, exist := poolvals[key]; exist {
 					t.Errorf("Testcase %d, pool contains double-entry", i)
 				}
@@ -68,8 +69,9 @@ func testTwoOperandOp(t *testing.T, tests []twoOperandTest, opFn func(pc *uint64
 
 func TestByteOp(t *testing.T) {
 	var (
-		env   = NewEVM(Context{}, nil, params.TestChainConfig, Config{})
-		stack = newstack()
+		blockContext = &BlockContext{Coinbase: common.Address{}, BlockNumber: big.NewInt(1337), Intpool: NewIntpool()}
+		env          = NewEVM(&Context{}, nil, params.TestChainConfig, &Config{}, blockContext)
+		stack        = newstack()
 	)
 	tests := []struct {
 		v        string
@@ -198,8 +200,9 @@ func TestSLT(t *testing.T) {
 
 func opBenchmark(bench *testing.B, op func(pc *uint64, evm *EVM, contract *Contract, memory *Memory, stack *Stack) ([]byte, error), args ...string) {
 	var (
-		env   = NewEVM(Context{}, nil, params.TestChainConfig, Config{})
-		stack = newstack()
+		blockContext = &BlockContext{Coinbase: common.Address{}, BlockNumber: big.NewInt(1337), Intpool: NewIntpool()}
+		env          = NewEVM(&Context{}, nil, params.TestChainConfig, &Config{}, blockContext)
+		stack        = newstack()
 	)
 	// convert args
 	byteArgs := make([][]byte, len(args))

--- a/core/vm/int_pool_verifier.go
+++ b/core/vm/int_pool_verifier.go
@@ -22,7 +22,7 @@ import "fmt"
 
 const verifyPool = true
 
-func verifyIntegerPool(ip *intPool) {
+func verifyIntegerPool(ip *IntPool) {
 	for i, item := range ip.pool.data {
 		if item.Cmp(checkVal) != 0 {
 			panic(fmt.Sprintf("%d'th item failed aggressive pool check. Value was modified", i))

--- a/core/vm/int_pool_verifier_empty.go
+++ b/core/vm/int_pool_verifier_empty.go
@@ -20,4 +20,4 @@ package vm
 
 const verifyPool = false
 
-func verifyIntegerPool(ip *intPool) {}
+func verifyIntegerPool(ip *IntPool) {}

--- a/core/vm/interpreter.go
+++ b/core/vm/interpreter.go
@@ -47,7 +47,7 @@ type Config struct {
 // configuration.
 type Interpreter struct {
 	evm      *EVM
-	cfg      Config
+	cfg      *Config
 	gasTable params.GasTable
 
 	readOnly    bool   // Whether to throw on stateful modifications
@@ -56,7 +56,7 @@ type Interpreter struct {
 }
 
 // NewInterpreter returns a new instance of the Interpreter.
-func NewInterpreter(evm *EVM, cfg Config,blockContext *BlockContext) *Interpreter {
+func NewInterpreter(evm *EVM, cfg *Config,blockContext *BlockContext) *Interpreter {
 	// We use the STOP instruction whether to see
 	// the jump table was initialised. If it was not
 	// we'll set the default jump table.

--- a/core/vm/interpreter.go
+++ b/core/vm/interpreter.go
@@ -50,13 +50,13 @@ type Interpreter struct {
 	cfg      *Config
 	gasTable params.GasTable
 
-	readOnly    bool   // Whether to throw on stateful modifications
-	returnData  []byte // Last CALL's return data for subsequent reuse
+	readOnly     bool   // Whether to throw on stateful modifications
+	returnData   []byte // Last CALL's return data for subsequent reuse
 	blockContext *BlockContext
 }
 
 // NewInterpreter returns a new instance of the Interpreter.
-func NewInterpreter(evm *EVM, cfg *Config,blockContext *BlockContext) *Interpreter {
+func NewInterpreter(evm *EVM, cfg *Config, blockContext *BlockContext) *Interpreter {
 	// We use the STOP instruction whether to see
 	// the jump table was initialised. If it was not
 	// we'll set the default jump table.
@@ -74,9 +74,9 @@ func NewInterpreter(evm *EVM, cfg *Config,blockContext *BlockContext) *Interpret
 	}
 
 	return &Interpreter{
-		evm:         evm,
-		cfg:         cfg,
-		gasTable:    evm.ChainConfig().GasTable(blockContext.BlockNumber),
+		evm:          evm,
+		cfg:          cfg,
+		gasTable:     evm.ChainConfig().GasTable(blockContext.BlockNumber),
 		blockContext: blockContext,
 	}
 }

--- a/core/vm/intpool.go
+++ b/core/vm/intpool.go
@@ -32,6 +32,10 @@ func newIntPool() *intPool {
 	return &intPool{pool: newstack()}
 }
 
+func newZerosizeIntPool() *intPool {
+	return &intPool{pool: newZeroSizeStack()}
+}
+
 // get retrieves a big int from the pool, allocating one if the pool is empty.
 // Note, the returned int's value is arbitrary and will not be zeroed!
 func (p *intPool) get() *big.Int {

--- a/core/vm/intpool.go
+++ b/core/vm/intpool.go
@@ -22,23 +22,23 @@ var checkVal = big.NewInt(-42)
 
 const poolLimit = 256
 
-// intPool is a pool of big integers that
+// IntPool is a pool of big integers that
 // can be reused for all big.Int operations.
-type intPool struct {
+type IntPool struct {
 	pool *Stack
 }
 
-func newIntPool() *intPool {
-	return &intPool{pool: newstack()}
+func NewIntpool() *IntPool {
+	return &IntPool{pool: newstack()}
 }
 
-func newZerosizeIntPool() *intPool {
-	return &intPool{pool: newZeroSizeStack()}
+func newZerosizeIntPool() *IntPool {
+	return &IntPool{pool: newZeroSizeStack()}
 }
 
 // get retrieves a big int from the pool, allocating one if the pool is empty.
 // Note, the returned int's value is arbitrary and will not be zeroed!
-func (p *intPool) get() *big.Int {
+func (p *IntPool) get() *big.Int {
 	if p.pool.len() > 0 {
 		return p.pool.pop()
 	}
@@ -47,7 +47,7 @@ func (p *intPool) get() *big.Int {
 
 // getZero retrieves a big int from the pool, setting it to zero or allocating
 // a new one if the pool is empty.
-func (p *intPool) getZero() *big.Int {
+func (p *IntPool) getZero() *big.Int {
 	if p.pool.len() > 0 {
 		return p.pool.pop().SetUint64(0)
 	}
@@ -56,7 +56,7 @@ func (p *intPool) getZero() *big.Int {
 
 // put returns an allocated big int to the pool to be later reused by get calls.
 // Note, the values as saved as is; neither put nor get zeroes the ints out!
-func (p *intPool) put(is ...*big.Int) {
+func (p *IntPool) put(is ...*big.Int) {
 	if len(p.pool.data) > poolLimit {
 		return
 	}

--- a/core/vm/logger_test.go
+++ b/core/vm/logger_test.go
@@ -48,7 +48,10 @@ type dummyStateDB struct {
 
 func TestStoreCapture(t *testing.T) {
 	var (
-		env      = NewEVM(Context{}, nil, params.TestChainConfig, Config{})
+		blkCtx = &BlockContext{
+			Intpool: NewIntpool(),
+		}
+		env      = NewEVM(&Context{}, nil, params.TestChainConfig, &Config{}, blkCtx)
 		logger   = NewStructLogger(nil)
 		mem      = NewMemory()
 		stack    = newstack()

--- a/core/vm/runtime/env.go
+++ b/core/vm/runtime/env.go
@@ -19,23 +19,24 @@ package runtime
 import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core"
+	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/core/vm"
 )
 
 func NewEnv(cfg *Config) *vm.EVM {
-	context := vm.Context{
+	context := &vm.Context{
 		CanTransfer: core.CanTransfer,
 		Transfer:    core.Transfer,
 		GetHash:     func(uint64) common.Hash { return common.Hash{} },
-
 		Origin:      cfg.Origin,
-		Coinbase:    cfg.Coinbase,
-		BlockNumber: cfg.BlockNumber,
-		Time:        cfg.Time,
-		Difficulty:  cfg.Difficulty,
-		GasLimit:    cfg.GasLimit,
 		GasPrice:    cfg.GasPrice,
 	}
-
-	return vm.NewEVM(context, cfg.State, cfg.ChainConfig, cfg.EVMConfig)
+	header := &types.Header{
+		Number:     cfg.BlockNumber,
+		Time:       cfg.Time,
+		Difficulty: cfg.Difficulty,
+		GasLimit:   cfg.GasLimit,
+	}
+	blockContext := core.NewBlockContext(header, cfg.Coinbase, cfg.ChainConfig)
+	return vm.NewEVM(context, cfg.State, cfg.ChainConfig, &cfg.EVMConfig, blockContext)
 }

--- a/core/vm/stack.go
+++ b/core/vm/stack.go
@@ -32,6 +32,10 @@ func newstack() *Stack {
 	return &Stack{data: make([]*big.Int, 0, 1024)}
 }
 
+func newZeroSizeStack() *Stack {
+	return &Stack{data: make([]*big.Int, 0)}
+}
+
 func (st *Stack) Data() []*big.Int {
 	return st.data
 }

--- a/core/vm/stack.go
+++ b/core/vm/stack.go
@@ -64,7 +64,7 @@ func (st *Stack) swap(n int) {
 	st.data[st.len()-n], st.data[st.len()-1] = st.data[st.len()-1], st.data[st.len()-n]
 }
 
-func (st *Stack) dup(pool *intPool, n int) {
+func (st *Stack) dup(pool *IntPool, n int) {
 	st.push(pool.get().Set(st.data[st.len()-n]))
 }
 

--- a/eth/api.go
+++ b/eth/api.go
@@ -369,7 +369,7 @@ type storageEntry struct {
 	Key   *common.Hash `json:"key"`
 	Value common.Hash  `json:"value"`
 }
-
+/*
 // StorageRangeAt returns the storage at the given block height and transaction index.
 func (api *PrivateDebugAPI) StorageRangeAt(ctx context.Context, blockHash common.Hash, txIndex int, contractAddress common.Address, keyStart hexutil.Bytes, maxResult int) (StorageRangeResult, error) {
 	_, _, statedb, err := api.computeTxEnv(blockHash, txIndex, 0)
@@ -405,7 +405,7 @@ func storageRangeAt(st state.Trie, start []byte, maxResult int) (StorageRangeRes
 	}
 	return result, nil
 }
-
+*/
 // GetModifiedAccountsByumber returns all accounts that have changed between the
 // two blocks specified. A change is defined as a difference in nonce, balance,
 // code hash, or storage hash.

--- a/eth/api.go
+++ b/eth/api.go
@@ -369,10 +369,10 @@ type storageEntry struct {
 	Key   *common.Hash `json:"key"`
 	Value common.Hash  `json:"value"`
 }
-/*
+
 // StorageRangeAt returns the storage at the given block height and transaction index.
 func (api *PrivateDebugAPI) StorageRangeAt(ctx context.Context, blockHash common.Hash, txIndex int, contractAddress common.Address, keyStart hexutil.Bytes, maxResult int) (StorageRangeResult, error) {
-	_, _, statedb, err := api.computeTxEnv(blockHash, txIndex, 0)
+	_, _, _, statedb, err := api.computeTxEnv(blockHash, txIndex, 0)
 	if err != nil {
 		return StorageRangeResult{}, err
 	}
@@ -405,7 +405,7 @@ func storageRangeAt(st state.Trie, start []byte, maxResult int) (StorageRangeRes
 	}
 	return result, nil
 }
-*/
+
 // GetModifiedAccountsByumber returns all accounts that have changed between the
 // two blocks specified. A change is defined as a difference in nonce, balance,
 // code hash, or storage hash.

--- a/eth/api_backend.go
+++ b/eth/api_backend.go
@@ -22,19 +22,19 @@ import (
 
 	"github.com/ethereum/go-ethereum/accounts"
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/common/math"
 	"github.com/ethereum/go-ethereum/core"
 	"github.com/ethereum/go-ethereum/core/bloombits"
 	"github.com/ethereum/go-ethereum/core/rawdb"
 	"github.com/ethereum/go-ethereum/core/state"
 	"github.com/ethereum/go-ethereum/core/types"
-	"github.com/ethereum/go-ethereum/core/vm"
 	"github.com/ethereum/go-ethereum/eth/downloader"
 	"github.com/ethereum/go-ethereum/eth/gasprice"
 	"github.com/ethereum/go-ethereum/ethdb"
 	"github.com/ethereum/go-ethereum/event"
 	"github.com/ethereum/go-ethereum/params"
 	"github.com/ethereum/go-ethereum/rpc"
+	"github.com/ethereum/go-ethereum/core/vm"
+	"github.com/ethereum/go-ethereum/common/math"
 )
 
 // EthAPIBackend implements ethapi.Backend for full nodes
@@ -133,7 +133,7 @@ func (b *EthAPIBackend) GetEVM(ctx context.Context, msg core.Message, state *sta
 	vmError := func() error { return nil }
 
 	context := core.NewEVMContext(msg, header, b.eth.BlockChain(), nil)
-	return vm.NewEVM(context, state, b.eth.chainConfig, vmCfg), vmError, nil
+	return vm.NewEVM(context, state, b.eth.chainConfig, &vmCfg, &vm.BlockContext{} ), vmError, nil
 }
 
 func (b *EthAPIBackend) SubscribeRemovedLogsEvent(ch chan<- core.RemovedLogsEvent) event.Subscription {

--- a/eth/api_backend.go
+++ b/eth/api_backend.go
@@ -22,19 +22,19 @@ import (
 
 	"github.com/ethereum/go-ethereum/accounts"
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/math"
 	"github.com/ethereum/go-ethereum/core"
 	"github.com/ethereum/go-ethereum/core/bloombits"
 	"github.com/ethereum/go-ethereum/core/rawdb"
 	"github.com/ethereum/go-ethereum/core/state"
 	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/core/vm"
 	"github.com/ethereum/go-ethereum/eth/downloader"
 	"github.com/ethereum/go-ethereum/eth/gasprice"
 	"github.com/ethereum/go-ethereum/ethdb"
 	"github.com/ethereum/go-ethereum/event"
 	"github.com/ethereum/go-ethereum/params"
 	"github.com/ethereum/go-ethereum/rpc"
-	"github.com/ethereum/go-ethereum/core/vm"
-	"github.com/ethereum/go-ethereum/common/math"
 )
 
 // EthAPIBackend implements ethapi.Backend for full nodes
@@ -132,8 +132,11 @@ func (b *EthAPIBackend) GetEVM(ctx context.Context, msg core.Message, state *sta
 	state.SetBalance(msg.From(), math.MaxBig256)
 	vmError := func() error { return nil }
 
-	context := core.NewEVMContext(msg, header, b.eth.BlockChain(), nil)
-	return vm.NewEVM(context, state, b.eth.chainConfig, &vmCfg, &vm.BlockContext{} ), vmError, nil
+	context := core.NewEVMContext(msg, header, b.eth.BlockChain())
+	beneficiary, _ := b.eth.BlockChain().Engine().Author(header)
+	blockContext := core.NewBlockContext(header, beneficiary, b.ChainConfig())
+
+	return vm.NewEVM(context, state, b.eth.chainConfig, &vmCfg, blockContext), vmError, nil
 }
 
 func (b *EthAPIBackend) SubscribeRemovedLogsEvent(ch chan<- core.RemovedLogsEvent) event.Subscription {

--- a/eth/api_tracer.go
+++ b/eth/api_tracer.go
@@ -17,15 +17,17 @@
 package eth
 
 import (
+	"bytes"
+	"context"
 	"errors"
 	"fmt"
+	"io/ioutil"
+	"runtime"
+	"sync"
 	"time"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
-
-	"bytes"
-	"context"
 	"github.com/ethereum/go-ethereum/core"
 	"github.com/ethereum/go-ethereum/core/rawdb"
 	"github.com/ethereum/go-ethereum/core/state"
@@ -37,9 +39,6 @@ import (
 	"github.com/ethereum/go-ethereum/rlp"
 	"github.com/ethereum/go-ethereum/rpc"
 	"github.com/ethereum/go-ethereum/trie"
-	"io/ioutil"
-	"runtime"
-	"sync"
 )
 
 const (

--- a/eth/api_tracer.go
+++ b/eth/api_tracer.go
@@ -17,27 +17,18 @@
 package eth
 
 import (
-	"bytes"
-	"context"
 	"errors"
 	"fmt"
-	"io/ioutil"
-	"runtime"
-	"sync"
 	"time"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
-	"github.com/ethereum/go-ethereum/core"
-	"github.com/ethereum/go-ethereum/core/rawdb"
+
+
 	"github.com/ethereum/go-ethereum/core/state"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/core/vm"
-	"github.com/ethereum/go-ethereum/eth/tracers"
-	"github.com/ethereum/go-ethereum/internal/ethapi"
 	"github.com/ethereum/go-ethereum/log"
-	"github.com/ethereum/go-ethereum/rlp"
-	"github.com/ethereum/go-ethereum/rpc"
 	"github.com/ethereum/go-ethereum/trie"
 )
 
@@ -89,7 +80,7 @@ type txTraceTask struct {
 	statedb *state.StateDB // Intermediate state prepped for tracing
 	index   int            // Transaction offset in the block
 }
-
+/*
 // TraceChain returns the structured logs created during the execution of EVM
 // between two blocks (excluding start) and returns them as a JSON object.
 func (api *PrivateDebugAPI) TraceChain(ctx context.Context, start, end rpc.BlockNumber, config *TraceConfig) (*rpc.Subscription, error) {
@@ -125,6 +116,7 @@ func (api *PrivateDebugAPI) TraceChain(ctx context.Context, start, end rpc.Block
 // traceChain configures a new tracer according to the provided configuration, and
 // executes all the transactions contained within. The return value will be one item
 // per transaction, dependent on the requestd tracer.
+
 func (api *PrivateDebugAPI) traceChain(ctx context.Context, start, end *types.Block, config *TraceConfig) (*rpc.Subscription, error) {
 	// Tracing a chain is a **long** operation, only do with subscriptions
 	notifier, supported := rpc.NotifierFromContext(ctx)
@@ -386,6 +378,7 @@ func (api *PrivateDebugAPI) TraceBlockFromFile(ctx context.Context, file string,
 // traceBlock configures a new tracer according to the provided configuration, and
 // executes all the transactions contained within. The return value will be one item
 // per transaction, dependent on the requestd tracer.
+/*
 func (api *PrivateDebugAPI) traceBlock(ctx context.Context, block *types.Block, config *TraceConfig) ([]*txTraceResult, error) {
 	// Create the parent state database
 	if err := api.eth.engine.VerifyHeader(api.eth.blockchain, block.Header(), true); err != nil {
@@ -463,7 +456,7 @@ func (api *PrivateDebugAPI) traceBlock(ctx context.Context, block *types.Block, 
 	}
 	return results, nil
 }
-
+*/
 // computeStateDB retrieves the state database associated with a certain block.
 // If no state is locally available for the given block, a number of blocks are
 // attempted to be reexecuted to generate the desired state.
@@ -529,7 +522,7 @@ func (api *PrivateDebugAPI) computeStateDB(block *types.Block, reexec uint64) (*
 	log.Info("Historical state regenerated", "block", block.NumberU64(), "elapsed", time.Since(start), "size", database.TrieDB().Size())
 	return statedb, nil
 }
-
+/*
 // TraceTransaction returns the structured logs created during the execution of EVM
 // and returns them as a JSON object.
 func (api *PrivateDebugAPI) TraceTransaction(ctx context.Context, hash common.Hash, config *TraceConfig) (interface{}, error) {
@@ -646,3 +639,4 @@ func (api *PrivateDebugAPI) computeTxEnv(blockHash common.Hash, txIndex int, ree
 	}
 	return nil, vm.Context{}, nil, fmt.Errorf("tx index %d out of range for block %x", txIndex, blockHash)
 }
+*/

--- a/eth/tracers/tracer.go
+++ b/eth/tracers/tracer.go
@@ -514,7 +514,7 @@ func (jst *Tracer) CaptureState(env *vm.EVM, pc uint64, op vm.OpCode, gas, cost 
 	if jst.err == nil {
 		// Initialize the context if it wasn't done yet
 		if !jst.inited {
-			jst.ctx["block"] = env.BlockNumber.Uint64()
+			jst.ctx["block"] = env.BlockContext.BlockNumber.Uint64()
 			jst.inited = true
 		}
 		// If tracing was interrupted, set the error and stop

--- a/les/api_backend.go
+++ b/les/api_backend.go
@@ -105,7 +105,7 @@ func (b *LesApiBackend) GetTd(hash common.Hash) *big.Int {
 func (b *LesApiBackend) GetEVM(ctx context.Context, msg core.Message, state *state.StateDB, header *types.Header, vmCfg vm.Config) (*vm.EVM, func() error, error) {
 	state.SetBalance(msg.From(), math.MaxBig256)
 	context := core.NewEVMContext(msg, header, b.eth.blockchain, nil)
-	return vm.NewEVM(context, state, b.eth.chainConfig, vmCfg), state.Error, nil
+	return vm.NewEVM(context, state, b.eth.chainConfig, &vmCfg, &vm.BlockContext{}), state.Error, nil
 }
 
 func (b *LesApiBackend) SendTx(ctx context.Context, signedTx *types.Transaction) error {

--- a/les/api_backend.go
+++ b/les/api_backend.go
@@ -104,8 +104,10 @@ func (b *LesApiBackend) GetTd(hash common.Hash) *big.Int {
 
 func (b *LesApiBackend) GetEVM(ctx context.Context, msg core.Message, state *state.StateDB, header *types.Header, vmCfg vm.Config) (*vm.EVM, func() error, error) {
 	state.SetBalance(msg.From(), math.MaxBig256)
-	context := core.NewEVMContext(msg, header, b.eth.blockchain, nil)
-	return vm.NewEVM(context, state, b.eth.chainConfig, &vmCfg, &vm.BlockContext{}), state.Error, nil
+	context := core.NewEVMContext(msg, header, b.eth.blockchain)
+	beneficiary, _ := b.eth.BlockChain().Engine().Author(header)
+	blockContext := core.NewBlockContext(header, beneficiary, b.ChainConfig())
+	return vm.NewEVM(context, state, b.eth.chainConfig, &vmCfg, blockContext), state.Error, nil
 }
 
 func (b *LesApiBackend) SendTx(ctx context.Context, signedTx *types.Transaction) error {

--- a/les/odr_test.go
+++ b/les/odr_test.go
@@ -135,8 +135,11 @@ func odrContractCall(ctx context.Context, db ethdb.Database, config *params.Chai
 
 				msg := callmsg{types.NewMessage(from.Address(), &testContractAddr, 0, new(big.Int), 100000, new(big.Int), data, false)}
 
-				context := core.NewEVMContext(msg, header, bc, nil)
-				vmenv := vm.NewEVM(context, statedb, config, vm.Config{})
+				context := core.NewEVMContext(msg, header, bc)
+				beneficiary, _ := bc.Engine().Author(header)
+				blockContext := core.NewBlockContext(header, beneficiary, bc.Config())
+
+				vmenv := vm.NewEVM(context, statedb, config, &vm.Config{}, blockContext)
 
 				//vmenv := core.NewEnv(statedb, config, bc, msg, header, vm.Config{})
 				gp := new(core.GasPool).AddGas(math.MaxUint64)
@@ -148,8 +151,10 @@ func odrContractCall(ctx context.Context, db ethdb.Database, config *params.Chai
 			state := light.NewState(ctx, header, lc.Odr())
 			state.SetBalance(testBankAddress, math.MaxBig256)
 			msg := callmsg{types.NewMessage(testBankAddress, &testContractAddr, 0, new(big.Int), 100000, new(big.Int), data, false)}
-			context := core.NewEVMContext(msg, header, lc, nil)
-			vmenv := vm.NewEVM(context, state, config, vm.Config{})
+			context := core.NewEVMContext(msg, header, lc)
+			beneficiary, _ := bc.Engine().Author(header)
+			blockContext := core.NewBlockContext(header, beneficiary, bc.Config())
+			vmenv := vm.NewEVM(context, state, config, &vm.Config{}, blockContext)
 			gp := new(core.GasPool).AddGas(math.MaxUint64)
 			ret, _, _, _ := core.ApplyMessage(vmenv, msg, gp)
 			if state.Error() == nil {

--- a/light/odr_test.go
+++ b/light/odr_test.go
@@ -190,8 +190,10 @@ func odrContractCall(ctx context.Context, db ethdb.Database, bc *core.BlockChain
 		// Perform read-only call.
 		st.SetBalance(testBankAddress, math.MaxBig256)
 		msg := callmsg{types.NewMessage(testBankAddress, &testContractAddr, 0, new(big.Int), 1000000, new(big.Int), data, false)}
-		context := core.NewEVMContext(msg, header, chain, nil)
-		vmenv := vm.NewEVM(context, st, config, vm.Config{})
+		context := core.NewEVMContext(msg, header, chain)
+		beneficiary, _ := bc.Engine().Author(header)
+		blockContext := core.NewBlockContext(header, beneficiary, bc.Config())
+		vmenv := vm.NewEVM(context, st, config, &vm.Config{}, blockContext)
 		gp := new(core.GasPool).AddGas(math.MaxUint64)
 		ret, _, _, _ := core.ApplyMessage(vmenv, msg, gp)
 		res = append(res, ret...)

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -30,6 +30,7 @@ import (
 	"github.com/ethereum/go-ethereum/core"
 	"github.com/ethereum/go-ethereum/core/state"
 	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/core/vm"
 	"github.com/ethereum/go-ethereum/ethdb"
 	"github.com/ethereum/go-ethereum/event"
 	"github.com/ethereum/go-ethereum/log"
@@ -614,11 +615,10 @@ func (env *Work) commitTransactions(mux *event.TypeMux, txs *types.TransactionsB
 
 func (env *Work) commitTransaction(tx *types.Transaction, bc *core.BlockChain, coinbase common.Address, gp *core.GasPool) (error, []*types.Log) {
 
-	return fmt.Errorf("Mining disabled"), nil
-	/*
 	snap := env.state.Snapshot()
-
-	receipt, _, err := core.ApplyTransaction(env.config, bc, &coinbase, gp, env.state, env.header, tx, &env.header.GasUsed, vm.Config{})
+	//This could probably be moved to the Work-scope, and be reused
+	blockContext := core.NewBlockContext(env.header, coinbase, env.config)
+	receipt, _, err := core.ApplyTransaction(env.config, bc, gp, env.state, env.header, tx, &env.header.GasUsed, &vm.Config{}, blockContext)
 	if err != nil {
 		env.state.RevertToSnapshot(snap)
 		return err, nil
@@ -627,5 +627,4 @@ func (env *Work) commitTransaction(tx *types.Transaction, bc *core.BlockChain, c
 	env.receipts = append(env.receipts, receipt)
 
 	return nil, receipt.Logs
-	*/
 }

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -30,7 +30,6 @@ import (
 	"github.com/ethereum/go-ethereum/core"
 	"github.com/ethereum/go-ethereum/core/state"
 	"github.com/ethereum/go-ethereum/core/types"
-	"github.com/ethereum/go-ethereum/core/vm"
 	"github.com/ethereum/go-ethereum/ethdb"
 	"github.com/ethereum/go-ethereum/event"
 	"github.com/ethereum/go-ethereum/log"
@@ -614,6 +613,9 @@ func (env *Work) commitTransactions(mux *event.TypeMux, txs *types.TransactionsB
 }
 
 func (env *Work) commitTransaction(tx *types.Transaction, bc *core.BlockChain, coinbase common.Address, gp *core.GasPool) (error, []*types.Log) {
+
+	return fmt.Errorf("Mining disabled"), nil
+	/*
 	snap := env.state.Snapshot()
 
 	receipt, _, err := core.ApplyTransaction(env.config, bc, &coinbase, gp, env.state, env.header, tx, &env.header.GasUsed, vm.Config{})
@@ -625,4 +627,5 @@ func (env *Work) commitTransaction(tx *types.Transaction, bc *core.BlockChain, c
 	env.receipts = append(env.receipts, receipt)
 
 	return nil, receipt.Logs
+	*/
 }

--- a/tests/state_test_util.go
+++ b/tests/state_test_util.go
@@ -133,9 +133,12 @@ func (t *StateTest) Run(subtest StateSubtest, vmconfig vm.Config) (*state.StateD
 	if err != nil {
 		return nil, err
 	}
-	context := core.NewEVMContext(msg, block.Header(), nil, &t.json.Env.Coinbase)
+	context := core.NewEVMContext(msg, block.Header(), nil)
+	beneficiary := t.json.Env.Coinbase
+	blockContext := core.NewBlockContext(block.Header(), beneficiary, config)
+
 	context.GetHash = vmTestBlockHash
-	evm := vm.NewEVM(context, statedb, config, vmconfig)
+	evm := vm.NewEVM(context, statedb, config, &vmconfig, blockContext)
 
 	gaspool := new(core.GasPool)
 	gaspool.AddGas(block.GasLimit())

--- a/tests/vm_test_util.go
+++ b/tests/vm_test_util.go
@@ -27,6 +27,7 @@ import (
 	"github.com/ethereum/go-ethereum/common/math"
 	"github.com/ethereum/go-ethereum/core"
 	"github.com/ethereum/go-ethereum/core/state"
+	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/core/vm"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/ethdb"
@@ -135,15 +136,18 @@ func (t *VMTest) newEVM(statedb *state.StateDB, vmconfig vm.Config) *vm.EVM {
 		Transfer:    transfer,
 		GetHash:     vmTestBlockHash,
 		Origin:      t.json.Exec.Origin,
-		Coinbase:    t.json.Env.Coinbase,
-		BlockNumber: new(big.Int).SetUint64(t.json.Env.Number),
-		Time:        new(big.Int).SetUint64(t.json.Env.Timestamp),
-		GasLimit:    t.json.Env.GasLimit,
-		Difficulty:  t.json.Env.Difficulty,
 		GasPrice:    t.json.Exec.GasPrice,
 	}
+	header := &types.Header{
+		Coinbase:   t.json.Env.Coinbase,
+		Number:     new(big.Int).SetUint64(t.json.Env.Number),
+		Time:       new(big.Int).SetUint64(t.json.Env.Timestamp),
+		GasLimit:   t.json.Env.GasLimit,
+		Difficulty: t.json.Env.Difficulty,
+	}
+	blockContext := core.NewBlockContext(header, header.Coinbase, params.MainnetChainConfig)
 	vmconfig.NoRecursion = true
-	return vm.NewEVM(context, statedb, params.MainnetChainConfig, vmconfig)
+	return vm.NewEVM(&context, statedb, params.MainnetChainConfig, &vmconfig, blockContext)
 }
 
 func vmTestBlockHash(n uint64) common.Hash {


### PR DESCRIPTION
This is a work in progress. Is __not__ ready for merging.

The benchmarks below are based on the following cases:

1. `BlockChain_1x1000ValueTransferToNonexisting` : importing one block, filled with `1000` transactions that each send a wei to a non-existing recipient. No data. 
2. `BlockChain_1x1000ValueTransferToExisting` : importing one block, filled with `1000` transactions that each send a wei to an _existing_ recipient. No data. 
3. `BlockChain_1x1000Executions`:  importing one block, filled with `1000` transactions that each invoke an existing contract which has code to do a `push` and a `pop`. No data. 

### Not allocating 1024 for intpool every tx

```
[user@work core]$ benchstat oldtimes.txt zerosizetimes.txt 
name                                           old time/op  new time/op  delta
BlockChain_1x1000ValueTransferToNonexisting-2  90.6ms ± 2%  85.5ms ± 5%   -5.54%  (p=0.032 n=5+5)
BlockChain_1x1000ValueTransferToExisting-2     62.8ms ± 6%  56.4ms ± 7%  -10.30%  (p=0.016 n=5+5)
BlockChain_1x1000Executions-2                  64.7ms ± 4%  60.7ms ± 4%   -6.08%  (p=0.008 n=5+5)
```
### Using a block-specific context

A per-block struct is used for things that does not change between transactions. This also hosts an intpool and the `precompile` list, among other things. Quite a large change. It has some benefits, but not extreme:
```
# Use block-context, which is not created anew each time
[user@work core]$ benchstat oldtimes.txt newtimes.txt 
name                                           old time/op  new time/op  delta
BlockChain_1x1000ValueTransferToNonexisting-2  90.6ms ± 2%  82.6ms ± 8%   -8.82%  (p=0.016 n=5+5)
BlockChain_1x1000ValueTransferToExisting-2     62.8ms ± 6%  56.0ms ± 7%  -10.81%  (p=0.008 n=5+5)
BlockChain_1x1000Executions-2                  64.7ms ± 4%  58.1ms ± 5%  -10.12%  (p=0.008 n=5+5)
```
### Pointers instead of objects

The last optimization is to replace large objects in the call chain for executing transactions, and using pointers instead. This change resulted in significant improvements. We need to ensure that at no point can anything mess with the data, though. 
```
# using pointers instead of passing around large structs
[user@work core]$ benchstat oldtimes.txt morepointertimes.txt 
name                                           old time/op  new time/op  delta
BlockChain_1x1000ValueTransferToNonexisting-2  90.6ms ± 2%  67.5ms ± 4%  -25.44%  (p=0.008 n=5+5)
BlockChain_1x1000ValueTransferToExisting-2     62.8ms ± 6%  42.1ms ± 4%  -33.02%  (p=0.008 n=5+5)
BlockChain_1x1000Executions-2                  64.7ms ± 4%  44.7ms ±12%  -30.89%  (p=0.008 n=5+5)
```

I'll post some graphs once I've run it on the aws cluster. 