### PR TITLE
core/asm: remove unused condition.

### DIFF
--- a/core/asm/compiler.go
+++ b/core/asm/compiler.go
@@ -247,9 +247,6 @@ func isJump(op string) bool {
 
 // toBinary converts text to a vm.OpCode
 func toBinary(text string) vm.OpCode {
-	if isPush(text) {
-		text = "push1"
-	}
 	return vm.StringToOp(strings.ToUpper(text))
 }
 


### PR DESCRIPTION
Since all push instruction are handled by
https://github.com/ethereum/go-ethereum/blob/2e247705cd27e919e806f29ff2adcd57c163b1ac/core/asm/compiler.go#L191

We no longer need to check `isPush(text)` in `toBinary(text)`.