### PR TITLE
Add logging for missing --rpcvhosts on server

### DIFF
--- a/cmd/geth/consolecmd.go
+++ b/cmd/geth/consolecmd.go
@@ -28,7 +28,6 @@ import (
 	"github.com/ethereum/go-ethereum/console"
 	"github.com/ethereum/go-ethereum/node"
 	"github.com/ethereum/go-ethereum/rpc"
-	"github.com/ethereum/go-ethereum/log"
 	"gopkg.in/urfave/cli.v1"
 )
 
@@ -117,7 +116,6 @@ func localConsole(ctx *cli.Context) error {
 func remoteConsole(ctx *cli.Context) error {
 	// Attach to a remotely running geth instance and start the JavaScript console
 	endpoint := ctx.Args().First()
-        log.Debug(fmt.Sprintf("remote endpoint is %s", endpoint))
 	if endpoint == "" {
 		path := node.DefaultDataDir()
 		if ctx.GlobalIsSet(utils.DataDirFlag.Name) {

--- a/cmd/geth/consolecmd.go
+++ b/cmd/geth/consolecmd.go
@@ -28,6 +28,7 @@ import (
 	"github.com/ethereum/go-ethereum/console"
 	"github.com/ethereum/go-ethereum/node"
 	"github.com/ethereum/go-ethereum/rpc"
+	"github.com/ethereum/go-ethereum/log"
 	"gopkg.in/urfave/cli.v1"
 )
 
@@ -95,7 +96,7 @@ func localConsole(ctx *cli.Context) error {
 
 	console, err := console.New(config)
 	if err != nil {
-		utils.Fatalf("Failed to start the JavaScript console: %v", err)
+		utils.Fatalf("Failed to start the local JavaScript console: %v", err)
 	}
 	defer console.Stop(false)
 
@@ -116,6 +117,7 @@ func localConsole(ctx *cli.Context) error {
 func remoteConsole(ctx *cli.Context) error {
 	// Attach to a remotely running geth instance and start the JavaScript console
 	endpoint := ctx.Args().First()
+        log.Debug(fmt.Sprintf("remote endpoint is %s", endpoint))
 	if endpoint == "" {
 		path := node.DefaultDataDir()
 		if ctx.GlobalIsSet(utils.DataDirFlag.Name) {
@@ -143,7 +145,7 @@ func remoteConsole(ctx *cli.Context) error {
 
 	console, err := console.New(config)
 	if err != nil {
-		utils.Fatalf("Failed to start the JavaScript console: %v", err)
+		utils.Fatalf("Failed to start the remote JavaScript console: %v", err)
 	}
 	defer console.Stop(false)
 
@@ -196,7 +198,7 @@ func ephemeralConsole(ctx *cli.Context) error {
 
 	console, err := console.New(config)
 	if err != nil {
-		utils.Fatalf("Failed to start the JavaScript console: %v", err)
+		utils.Fatalf("Failed to start the ephemeral JavaScript console: %v", err)
 	}
 	defer console.Stop(false)
 

--- a/console/console.go
+++ b/console/console.go
@@ -131,9 +131,10 @@ func (c *Console) init(preload []string) error {
 		return fmt.Errorf("web3 provider: %v", err)
 	}
 	// Load the supported APIs into the JavaScript runtime environment
+        // This is where the Zeroconf DNS bails
 	apis, err := c.client.SupportedModules()
 	if err != nil {
-		return fmt.Errorf("api modules: %v", err)
+		return fmt.Errorf("cannot create api client modules: %v", err)
 	}
 	flatten := "var eth = web3.eth; var personal = web3.personal; "
 	for api := range apis {

--- a/console/console.go
+++ b/console/console.go
@@ -131,7 +131,6 @@ func (c *Console) init(preload []string) error {
 		return fmt.Errorf("web3 provider: %v", err)
 	}
 	// Load the supported APIs into the JavaScript runtime environment
-        // This is where the Zeroconf DNS bails
 	apis, err := c.client.SupportedModules()
 	if err != nil {
 		return fmt.Errorf("cannot create api client modules: %v", err)

--- a/rpc/client.go
+++ b/rpc/client.go
@@ -168,6 +168,7 @@ func DialContext(ctx context.Context, rawurl string) (*Client, error) {
 	}
 	switch u.Scheme {
 	case "http", "https":
+                log.Debug(fmt.Sprintf("connecting to rpc url %s", rawurl))
 		return DialHTTP(rawurl)
 	case "ws", "wss":
 		return DialWebsocket(ctx, rawurl, "")

--- a/rpc/client.go
+++ b/rpc/client.go
@@ -168,7 +168,6 @@ func DialContext(ctx context.Context, rawurl string) (*Client, error) {
 	}
 	switch u.Scheme {
 	case "http", "https":
-                log.Debug(fmt.Sprintf("connecting to rpc url %s", rawurl))
 		return DialHTTP(rawurl)
 	case "ws", "wss":
 		return DialWebsocket(ctx, rawurl, "")

--- a/rpc/http.go
+++ b/rpc/http.go
@@ -32,6 +32,7 @@ import (
 	"time"
 
 	"github.com/rs/cors"
+	"github.com/ethereum/go-ethereum/log"
 )
 
 const (
@@ -70,6 +71,7 @@ func (hc *httpConn) Close() error {
 // using the provided HTTP Client.
 func DialHTTPWithClient(endpoint string, client *http.Client) (*Client, error) {
 	req, err := http.NewRequest(http.MethodPost, endpoint, nil)
+        log.Debug(fmt.Sprintf("connecting to HTTP endpoint %s", endpoint))
 	if err != nil {
 		return nil, err
 	}
@@ -90,12 +92,15 @@ func DialHTTP(endpoint string) (*Client, error) {
 func (c *Client) sendHTTP(ctx context.Context, op *requestOp, msg interface{}) error {
 	hc := c.writeConn.(*httpConn)
 	respBody, err := hc.doRequest(ctx, msg)
+        log.Debug(fmt.Sprintf("Sending message %s",msg))
 	if err != nil {
 		return err
 	}
 	defer respBody.Close()
 	var respmsg jsonrpcMessage
+        log.Debug(fmt.Sprintf("Got response %s",respmsg))
 	if err := json.NewDecoder(respBody).Decode(&respmsg); err != nil {
+                log.Debug(fmt.Sprintf("Error decoding JSON response: %s", err))
 		return err
 	}
 	op.resp <- &respmsg


### PR DESCRIPTION
#16457

I couldn't figure out where the error output in the referenced issue originated so I added some extra strings to the debug output when it bails.

This happens when any DNS name is used with `geth attach ...` and the server has not specified that same DNS name via `--rpcvhosts`