### PR TITLE
core: add additional judgement when repair the blockchain

### DIFF
--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -48,7 +48,9 @@ import (
 var (
 	blockInsertTimer = metrics.NewRegisteredTimer("chain/inserts", nil)
 
-	ErrNoGenesis = errors.New("Genesis not found in chain")
+	ErrNoGenesis              = errors.New("Genesis not found in chain")
+	errGenesisStateIncomplete = errors.New("genesis state is incomplete")
+	errMissingBlock           = errors.New("missing block")
 )
 
 const (
@@ -432,8 +434,18 @@ func (bc *BlockChain) repair(head **types.Block) error {
 			log.Info("Rewound blockchain to past state", "number", (*head).Number(), "hash", (*head).Hash())
 			return nil
 		}
-		// Otherwise rewind one block and recheck state availability there
-		(*head) = bc.GetBlock((*head).ParentHash(), (*head).NumberU64()-1)
+		// Abort if the genesis block's state is still incomplete.
+		if (*head).NumberU64() == 0 {
+			log.Info("The state of genesis block is incomplete")
+			return errGenesisStateIncomplete
+		}
+		// Rewind one block and recheck state availability there
+		block := bc.GetBlock((*head).ParentHash(), (*head).NumberU64()-1)
+		if block == nil {
+			log.Info("Rewound to a missing block", "number", (*head).NumberU64()-1)
+			return errMissingBlock
+		}
+		*head = block
 	}
 }
 


### PR DESCRIPTION
Fix this exception:

```
INFO [04-19|13:18:26] Disk storage enabled for ethash DAGs     dir=/home/hyperchain/.ethash               count=2
WARN [04-19|13:18:26] Head state missing, repairing chain      number=0 hash=d4e567…cb8fa3
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x875c1a]

goroutine 1 [running]:
github.com/ethereum/go-ethereum/core/types.(*Block).Root(...)
        /home/hyperchain/go/src/github.com/ethereum/go-ethereum/core/types/block.go:315
github.com/ethereum/go-ethereum/core.(*BlockChain).repair(0xc420ce8000, 0xc4204a62a8, 0xc4204a6338, 0x4)
        /home/hyperchain/go/src/github.com/ethereum/go-ethereum/core/blockchain.go:431 +0x7a
github.com/ethereum/go-ethereum/core.(*BlockChain).loadLastState(0xc420ce8000, 0x0, 0xc4202f43f0)
        /home/hyperchain/go/src/github.com/ethereum/go-ethereum/core/blockchain.go:222 +0x1141
github.com/ethereum/go-ethereum/core.NewBlockChain(0x1864080, 0xc42009d3f0, 0xc4204fe380, 0x182e200, 0x1865a40, 0xc420252500, 0x0, 0x0, 0x0, 0x0, ...)
```
While the reason for genesis state incomplete is need further investgation
