### PR TITLE
core/asm: accept uppercase instructions.

### DIFF
--- a/core/asm/compiler.go
+++ b/core/asm/compiler.go
@@ -236,12 +236,12 @@ func (c *Compiler) pushBin(v interface{}) {
 // isPush returns whether the string op is either any of
 // push(N).
 func isPush(op string) bool {
-	return op == "push"
+	return strings.ToUpper(op) == "PUSH"
 }
 
 // isJump returns whether the string op is jump(i)
 func isJump(op string) bool {
-	return op == "jumpi" || op == "jump"
+	return strings.ToUpper(op) == "JUMPI" || strings.ToUpper(op) == "JUMP"
 }
 
 // toBinary converts text to a vm.OpCode


### PR DESCRIPTION
Current evm compiler doesn't accept uppercase instructions such as PUSH, JUMP, but it accept other instructions in upper case.

For example:

```
$ cat a.easm

PUSH 4
PUSH 0
RETURN
STOP

$ evm compile a.easm

a.easm:0 syntax error: unexpected 4, expected end of line
a.easm:0 syntax error: unexpected end of line, expected new line
a.easm:1 syntax error: unexpected 0, expected end of line
a.easm:1 syntax error: unexpected end of line, expected new line
compiling failed
```

Also, current evm compiler will not show errors when using captalized `PUSH` without arguments, and generate unexpected byte code.

For example:

```
$ cat b.easm

PUSH
STOP

$ evm --debug compile b.easm

0000: (new line            )
0000: (element             ) PUSH
0000: (end of line         )

0001: (new line            )
0001: (element             ) STOP
0001: (end of line         )

0002: (new line            )
0002: (EOF                 )
found 0 labels
0: STOP
1: STOP
0000
```