### PR TITLE
vendor: update elastic/gosigar so that it compiles on OpenBSD again

### DIFF
--- a/vendor/github.com/elastic/gosigar/CHANGELOG.md
+++ b/vendor/github.com/elastic/gosigar/CHANGELOG.md
@@ -8,9 +8,20 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 
+- Added missing runtime import for FreeBSD. #104
+
 ### Changed
 
 ### Deprecated
+
+## [0.9.0]
+
+### Added
+- Added support for huge TLB pages on Linux #97  
+- Added support for big endian platform #100 
+
+### Fixed
+- Add missing method for OpenBSD #99
 
 ## [0.8.0]
 

--- a/vendor/github.com/elastic/gosigar/README.md
+++ b/vendor/github.com/elastic/gosigar/README.md
@@ -26,6 +26,7 @@ The features vary by operating system.
 | FDUsage         |   X   |        |         |         |    X    |
 | FileSystemList  |   X   |    X   |    X    |    X    |    X    |
 | FileSystemUsage |   X   |    X   |    X    |    X    |    X    |
+| HugeTLBPages    |   X   |        |         |         |         |
 | LoadAverage     |   X   |    X   |         |    X    |    X    |
 | Mem             |   X   |    X   |    X    |    X    |    X    |
 | ProcArgs        |   X   |    X   |    X    |         |    X    |

--- a/vendor/github.com/elastic/gosigar/concrete_sigar.go
+++ b/vendor/github.com/elastic/gosigar/concrete_sigar.go
@@ -62,6 +62,12 @@ func (c *ConcreteSigar) GetSwap() (Swap, error) {
 	return s, err
 }
 
+func (c *ConcreteSigar) GetHugeTLBPages() (HugeTLBPages, error) {
+	p := HugeTLBPages{}
+	err := p.Get()
+	return p, err
+}
+
 func (c *ConcreteSigar) GetFileSystemUsage(path string) (FileSystemUsage, error) {
 	f := FileSystemUsage{}
 	err := f.Get(path)

--- a/vendor/github.com/elastic/gosigar/sigar_darwin.go
+++ b/vendor/github.com/elastic/gosigar/sigar_darwin.go
@@ -91,6 +91,10 @@ func (self *Swap) Get() error {
 	return nil
 }
 
+func (self *HugeTLBPages) Get() error {
+	return ErrNotImplemented{runtime.GOOS}
+}
+
 func (self *Cpu) Get() error {
 	var count C.mach_msg_type_number_t = C.HOST_CPU_LOAD_INFO_COUNT
 	var cpuload C.host_cpu_load_info_data_t

--- a/vendor/github.com/elastic/gosigar/sigar_freebsd.go
+++ b/vendor/github.com/elastic/gosigar/sigar_freebsd.go
@@ -4,6 +4,7 @@ package gosigar
 
 import (
 	"io/ioutil"
+	"runtime"
 	"strconv"
 	"strings"
 	"unsafe"
@@ -95,6 +96,10 @@ func (self *ProcFDUsage) Get(pid int) error {
 	self.Open = uint64(len(fds))
 
 	return nil
+}
+
+func (self *HugeTLBPages) Get() error {
+	return ErrNotImplemented{runtime.GOOS}
 }
 
 func parseCpuStat(self *Cpu, line string) error {

--- a/vendor/github.com/elastic/gosigar/sigar_interface.go
+++ b/vendor/github.com/elastic/gosigar/sigar_interface.go
@@ -26,6 +26,7 @@ type Sigar interface {
 	GetLoadAverage() (LoadAverage, error)
 	GetMem() (Mem, error)
 	GetSwap() (Swap, error)
+	GetHugeTLBPages(HugeTLBPages, error)
 	GetFileSystemUsage(string) (FileSystemUsage, error)
 	GetFDUsage() (FDUsage, error)
 	GetRusage(who int) (Rusage, error)
@@ -80,6 +81,15 @@ type Swap struct {
 	Total uint64
 	Used  uint64
 	Free  uint64
+}
+
+type HugeTLBPages struct {
+	Total              uint64
+	Free               uint64
+	Reserved           uint64
+	Surplus            uint64
+	DefaultSize        uint64
+	TotalAllocatedSize uint64
 }
 
 type CpuList struct {

--- a/vendor/github.com/elastic/gosigar/sigar_linux_common.go
+++ b/vendor/github.com/elastic/gosigar/sigar_linux_common.go
@@ -379,12 +379,16 @@ func parseMeminfo() (map[string]uint64, error) {
 			return true // skip on errors
 		}
 
-		num := strings.TrimLeft(fields[1], " ")
-		val, err := strtoull(strings.Fields(num)[0])
+		valueUnit := strings.Fields(fields[1])
+		value, err := strtoull(valueUnit[0])
 		if err != nil {
 			return true // skip on errors
 		}
-		table[fields[0]] = val * 1024 //in bytes
+
+		if len(valueUnit) > 1 && valueUnit[1] == "kB" {
+			value *= 1024
+		}
+		table[fields[0]] = value
 
 		return true
 	})
@@ -420,8 +424,18 @@ func procFileName(pid int, name string) string {
 	return Procd + "/" + strconv.Itoa(pid) + "/" + name
 }
 
-func readProcFile(pid int, name string) ([]byte, error) {
+func readProcFile(pid int, name string) (content []byte, err error) {
 	path := procFileName(pid, name)
+
+	// Panics have been reported when reading proc files, let's recover and
+	// report the path if this happens
+	// See https://github.com/elastic/beats/issues/6692
+	defer func() {
+		if r := recover(); r != nil {
+			content = nil
+			err = fmt.Errorf("recovered panic when reading proc file '%s': %v", path, r)
+		}
+	}()
 	contents, err := ioutil.ReadFile(path)
 
 	if err != nil {

--- a/vendor/github.com/elastic/gosigar/sigar_openbsd.go
+++ b/vendor/github.com/elastic/gosigar/sigar_openbsd.go
@@ -294,6 +294,10 @@ func (self *Swap) Get() error {
 	return nil
 }
 
+func (self *HugeTLBPages) Get() error {
+	return ErrNotImplemented{runtime.GOOS}
+}
+
 func (self *Cpu) Get() error {
 	load := [C.CPUSTATES]C.long{C.CP_USER, C.CP_NICE, C.CP_SYS, C.CP_INTR, C.CP_IDLE}
 
@@ -378,6 +382,10 @@ func (self *ProcExe) Get(pid int) error {
 }
 
 func (self *ProcFDUsage) Get(pid int) error {
+	return ErrNotImplemented{runtime.GOOS}
+}
+
+func (self *Rusage) Get(pid int) error {
 	return ErrNotImplemented{runtime.GOOS}
 }
 

--- a/vendor/github.com/elastic/gosigar/sigar_stub.go
+++ b/vendor/github.com/elastic/gosigar/sigar_stub.go
@@ -22,6 +22,10 @@ func (s *Swap) Get() error {
 	return ErrNotImplemented{runtime.GOOS}
 }
 
+func (s *HugeTLBPages) Get() error {
+	return ErrNotImplemented{runtime.GOOS}
+}
+
 func (f *FDUsage) Get() error {
 	return ErrNotImplemented{runtime.GOOS}
 }

--- a/vendor/github.com/elastic/gosigar/sigar_windows.go
+++ b/vendor/github.com/elastic/gosigar/sigar_windows.go
@@ -120,6 +120,10 @@ func (self *Swap) Get() error {
 	return nil
 }
 
+func (self *HugeTLBPages) Get() error {
+	return ErrNotImplemented{runtime.GOOS}
+}
+
 func (self *Cpu) Get() error {
 	idle, kernel, user, err := windows.GetSystemTimes()
 	if err != nil {

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -93,10 +93,10 @@
 			"revisionTime": "2016-05-12T03:30:02Z"
 		},
 		{
-			"checksumSHA1": "Fc8BCxCoQ7ZmghDT6X1cASR10Ec=",
+			"checksumSHA1": "jElNoLEe7m/iaoF1vYIHyNaS2SE=",
 			"path": "github.com/elastic/gosigar",
-			"revision": "a3814ce5008e612a0c6d027608b54e1d0d9a5613",
-			"revisionTime": "2018-01-22T22:25:45Z"
+			"revision": "37f05ff46ffa7a825d1b24cf2b62d4a4c1a9d2e8",
+			"revisionTime": "2018-03-30T10:04:40Z"
 		},
 		{
 			"checksumSHA1": "qDsgp2kAeI9nhj565HUScaUyjU4=",


### PR DESCRIPTION
Hi,

i'm currenly in the process of updating OpenBSD's [WIP port](https://github.com/jasperla/openbsd-wip/tree/master/net/geth) of go-ethereum 1.7.3. The build fails because of https://github.com/elastic/gosigar/commit/01b55aeacddd04369e674d32e0eb9a3e7e4394fe. This PR updates elastic/gosigar to the latest commit and geth builds fine on OpenBSD again.

Cheers,
Fabian

CC: @qbit