### PR TITLE
p2p/peer: Don't discard reason sent by Disconnect()

### DIFF
--- a/p2p/peer.go
+++ b/p2p/peer.go
@@ -220,6 +220,7 @@ loop:
 			reason = discReasonForError(err)
 			break loop
 		case err = <-p.disc:
+			reason = discReasonForError(err)
 			break loop
 		}
 	}


### PR DESCRIPTION
Peer.run() was discarding the reason for disconnection sent to the disc channel by Disconnect()