### PR TITLE
Indicate that --light and --fast options are replaced by --syncmode

### DIFF
--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -158,11 +158,11 @@ var (
 	}
 	FastSyncFlag = cli.BoolFlag{
 		Name:  "fast",
-		Usage: "Enable fast syncing through state downloads",
+		Usage: "Enable fast syncing through state downloads (replaced by --syncmode)",
 	}
 	LightModeFlag = cli.BoolFlag{
 		Name:  "light",
-		Usage: "Enable light client mode",
+		Usage: "Enable light client mode (replaced by --syncmode)",
 	}
 	defaultSyncMode = eth.DefaultConfig.SyncMode
 	SyncModeFlag    = TextMarshalerFlag{


### PR DESCRIPTION
`--fast` and `--light` are deprecated but where they are listed there is no mention of what replaces them. This commit extends their descriptions to point users to `--syncmode`.