### PR TITLE
Fix race condition in Downloader.Cancel

### DIFF
--- a/eth/downloader/downloader.go
+++ b/eth/downloader/downloader.go
@@ -471,12 +471,18 @@ func (d *Downloader) syncWithPeer(p *peerConnection, hash common.Hash, td *big.I
 	} else if d.mode == FullSync {
 		fetchers = append(fetchers, d.processFullSyncContent)
 	}
-	return d.spawnSync(fetchers)
+	return d.spawnSync(errCancelHeaderFetch, fetchers)
 }
 
 // spawnSync runs d.process and all given fetcher functions to completion in
 // separate goroutines, returning the first error that appears.
-func (d *Downloader) spawnSync(fetchers []func() error) error {
+func (d *Downloader) spawnSync(errCancel error, fetchers []func() error) error {
+	select {
+	case <-d.cancelCh:
+		return errCancel
+	default:
+	}
+
 	errc := make(chan error, len(fetchers))
 	d.cancelWg.Add(len(fetchers))
 	for _, fn := range fetchers {


### PR DESCRIPTION
Happens when `Cancel` is called before `WaitGroup.Add` is called in `spawnSync`

Reproduced while running https://github.com/status-im/status-go/blob/develop/t/e2e/node/manager_test.go#L237 with `-race` flag

[log.txt](https://github.com/ethereum/go-ethereum/files/1954447/log.txt)

