### PR TITLE
core, eth: fix tracer dirty finalization

### DIFF
--- a/core/state/statedb.go
+++ b/core/state/statedb.go
@@ -572,27 +572,6 @@ func (self *StateDB) Prepare(thash, bhash common.Hash, ti int) {
 	self.txIndex = ti
 }
 
-// DeleteSuicides flags the suicided objects for deletion so that it
-// won't be referenced again when called / queried up on.
-//
-// DeleteSuicides should not be used for consensus related updates
-// under any circumstances.
-func (s *StateDB) DeleteSuicides() {
-	// Reset refund so that any used-gas calculations can use this method.
-	s.clearJournalAndRefund()
-
-	for addr := range s.stateObjectsDirty {
-		stateObject := s.stateObjects[addr]
-
-		// If the object has been removed by a suicide
-		// flag the object as deleted.
-		if stateObject.suicided {
-			stateObject.deleted = true
-		}
-		delete(s.stateObjectsDirty, addr)
-	}
-}
-
 func (s *StateDB) clearJournalAndRefund() {
 	s.journal = newJournal()
 	s.validRevisions = s.validRevisions[:0]

--- a/core/vm/evm.go
+++ b/core/vm/evm.go
@@ -160,6 +160,11 @@ func (evm *EVM) Call(caller ContractRef, addr common.Address, input []byte, gas 
 			precompiles = PrecompiledContractsByzantium
 		}
 		if precompiles[addr] == nil && evm.ChainConfig().IsEIP158(evm.BlockNumber) && value.Sign() == 0 {
+			// Calling a non existing account, don't do antything, but ping the tracer
+			if evm.vmConfig.Debug && evm.depth == 0 {
+				evm.vmConfig.Tracer.CaptureStart(caller.Address(), addr, false, input, gas, value)
+				evm.vmConfig.Tracer.CaptureEnd(ret, 0, 0, nil)
+			}
 			return nil, gas, nil
 		}
 		evm.StateDB.CreateAccount(addr)


### PR DESCRIPTION
This PR fixes two tracer bugs:

 * The tracer used a weird "optimized" version of dirty object deletion, to avoid having to hash the state trie after each transaction. This was an implementation issue pre-Byzantium where the state object finalization and state trie hashing was a single op. After Byzantium we separated the two, having `statedb.Finalise` only do the cleanup, but not the expensive hash. The tracer's were never updated to use this new code, and the old legacy optimization/hack probably rotted away as noone was actively testing it. This PR gets rid of that legacy hack and uses the actual consensus code in the tracer too.
 * The second fix is a small tracer bug where if a transaction did a zero value call into a non existent account, our EVM returned early, but did not tell the tracer about it. The outer trace caller then tried to retrieve the results, but the tracer wasn't even inited yet, so it reported errors. The fix is to ensure that our early-break path also tells the tracer it exists.

Fixes https://github.com/ethereum/go-ethereum/issues/16582.