### PR TITLE
eth/filters: Derive FilterCriteria from ethereum.FilterQuery

### DIFF
--- a/eth/filters/api.go
+++ b/eth/filters/api.go
@@ -268,14 +268,8 @@ func (api *PublicFilterAPI) Logs(ctx context.Context, crit FilterCriteria) (*rpc
 }
 
 // FilterCriteria represents a request to create a new filter.
-//
-// TODO(karalabe): Kill this in favor of ethereum.FilterQuery.
-type FilterCriteria struct {
-	FromBlock *big.Int
-	ToBlock   *big.Int
-	Addresses []common.Address
-	Topics    [][]common.Hash
-}
+// Same as ethereum.FilterQuery but with UnmarshalJSON() method.
+type FilterCriteria ethereum.FilterQuery
 
 // NewFilter creates a new filter and returns the filter id. It can be
 // used to retrieve logs when the state changes. This method cannot be


### PR DESCRIPTION
Eliminates redundant struct definition--but I do think it's good to leave both declarations there rather than combining them entirely.  

The `UnmarshalJSON()` method for this struct is only needed in `eth/filters/api.go`, so it wouldn't make too much sense to move it into interfaces.go where `FilterQuery` lives.  And the code seems more readable repeating `FilterCriteria` a lot in this file rather than repeating `ethereum.FilterQuery`.