### PR TITLE
core/*: golint updates for this or self warning

### DIFF
--- a/core/vm/contract.go
+++ b/core/vm/contract.go
@@ -139,15 +139,15 @@ func (c *Contract) Value() *big.Int {
 }
 
 // SetCode sets the code to the contract
-func (self *Contract) SetCode(hash common.Hash, code []byte) {
-	self.Code = code
-	self.CodeHash = hash
+func (c *Contract) SetCode(hash common.Hash, code []byte) {
+	c.Code = code
+	c.CodeHash = hash
 }
 
 // SetCallCode sets the code of the contract and address of the backing data
 // object
-func (self *Contract) SetCallCode(addr *common.Address, hash common.Hash, code []byte) {
-	self.Code = code
-	self.CodeHash = hash
-	self.CodeAddr = addr
+func (c *Contract) SetCallCode(addr *common.Address, hash common.Hash, code []byte) {
+	c.Code = code
+	c.CodeHash = hash
+	c.CodeAddr = addr
 }

--- a/core/vm/logger.go
+++ b/core/vm/logger.go
@@ -31,9 +31,9 @@ import (
 
 type Storage map[common.Hash]common.Hash
 
-func (self Storage) Copy() Storage {
+func (s Storage) Copy() Storage {
 	cpy := make(Storage)
-	for key, value := range self {
+	for key, value := range s {
 		cpy[key] = value
 	}
 

--- a/core/vm/memory.go
+++ b/core/vm/memory.go
@@ -51,14 +51,14 @@ func (m *Memory) Resize(size uint64) {
 }
 
 // Get returns offset + size as a new slice
-func (self *Memory) Get(offset, size int64) (cpy []byte) {
+func (m *Memory) Get(offset, size int64) (cpy []byte) {
 	if size == 0 {
 		return nil
 	}
 
-	if len(self.store) > int(offset) {
+	if len(m.store) > int(offset) {
 		cpy = make([]byte, size)
-		copy(cpy, self.store[offset:offset+size])
+		copy(cpy, m.store[offset:offset+size])
 
 		return
 	}
@@ -67,13 +67,13 @@ func (self *Memory) Get(offset, size int64) (cpy []byte) {
 }
 
 // GetPtr returns the offset + size
-func (self *Memory) GetPtr(offset, size int64) []byte {
+func (m *Memory) GetPtr(offset, size int64) []byte {
 	if size == 0 {
 		return nil
 	}
 
-	if len(self.store) > int(offset) {
-		return self.store[offset : offset+size]
+	if len(m.store) > int(offset) {
+		return m.store[offset : offset+size]
 	}
 
 	return nil

--- a/core/vm/opcodes.go
+++ b/core/vm/opcodes.go
@@ -375,10 +375,10 @@ var opCodeToString = map[OpCode]string{
 	SWAP: "SWAP",
 }
 
-func (o OpCode) String() string {
-	str := opCodeToString[o]
+func (op OpCode) String() string {
+	str := opCodeToString[op]
 	if len(str) == 0 {
-		return fmt.Sprintf("Missing opcode 0x%x", int(o))
+		return fmt.Sprintf("Missing opcode 0x%x", int(op))
 	}
 
 	return str


### PR DESCRIPTION
In the core directory, I have updated the variable names for receivers generating a golint warning regarding use of generic names like this or self.