### PR TITLE
travis.yml: remove obsolete brew-cask install

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,6 @@ matrix:
       script:
         - unset -f cd # workaround for https://github.com/travis-ci/travis-ci/issues/8703
         - brew update
-        - brew install caskroom/cask/brew-cask
         - brew cask install osxfuse
         - go run build/ci.go install
         - go run build/ci.go test -coverage $TEST_PACKAGES


### PR DESCRIPTION
This cask no longer exists and is not necessary for brew cask to work.  Trying to install It causes an extra build error message on Travis.

https://github.com/Homebrew/homebrew-core/issues/131