### PR TITLE
rlp: fix some golint warnings

### DIFF
--- a/rlp/decode.go
+++ b/rlp/decode.go
@@ -26,10 +26,26 @@ import (
 	"math/big"
 	"reflect"
 	"strings"
-	customErr "github.com/pkg/errors"
 )
 
 var (
+	// EOL is returned when the end of the current list
+	// has been reached during streaming.
+	EOL = errors.New("rlp: end of list")
+
+	// Actual Errors
+	ErrExpectedString   = errors.New("rlp: expected String or Byte")
+	ErrExpectedList     = errors.New("rlp: expected List")
+	ErrCanonInt         = errors.New("rlp: non-canonical integer format")
+	ErrCanonSize        = errors.New("rlp: non-canonical size information")
+	ErrElemTooLarge     = errors.New("rlp: element is larger than containing list")
+	ErrValueTooLarge    = errors.New("rlp: value size exceeds available input length")
+	ErrMoreThanOneValue = errors.New("rlp: input contains more than one value")
+
+	// internal errors
+	errNotInList     = errors.New("rlp: call of ListEnd outside of any list")
+	errNotAtEOL      = errors.New("rlp: call of ListEnd not positioned at EOL")
+	errUintOverflow  = errors.New("rlp: uint overflow")
 	errNoPointer     = errors.New("rlp: interface given to Decode must be a pointer")
 	errDecodeIntoNil = errors.New("rlp: pointer given to Decode must not be nil")
 )
@@ -536,8 +552,6 @@ func decodeDecoder(s *Stream, val reflect.Value) error {
 // Kind represents the kind of value contained in an RLP stream.
 type Kind int
 
-// Const list indicates the kind of value in an RLP stream 
-// and its next value is incremented by Kind().
 const (
 	Byte Kind = iota
 	String
@@ -556,34 +570,6 @@ func (k Kind) String() string {
 		return fmt.Sprintf("Unknown(%d)", k)
 	}
 }
-
-var (
-	// EOL is returned when the end of the current list
-	// has been reached during streaming.
-	EOL = customErr.New(fmt.Sprintf("rlp: end of list"))
-
-	//ActualErrors
-
-	//ErrExpectedString is returned if kind is not string or Byte.
-	ErrExpectedString = errors.New("rlp: expected String or Byte")
-	//ErrExpectedList is returned if kind is not a list.
-	ErrExpectedList   = errors.New("rlp: expected List")
-	//ErrCanonInt is returned if integer is a non-canonical format .
-	ErrCanonInt       = errors.New("rlp: non-canonical integer format")
-	//ErrCanonSize is returned if integer has non-canonical size information. 
-	ErrCanonSize      = errors.New("rlp: non-canonical size information")
-	//ErrElemTooLarge is returned if the element is larger than the list. 
-	ErrElemTooLarge   = errors.New("rlp: element is larger than containing list")
-	//ErrValueTooLarge is returned if the element is larger than available input length. 
-	ErrValueTooLarge  = errors.New("rlp: value size exceeds available input length")
-	//ErrMoreThanOneValue is reported by DecodeBytes if the slice contains additional data after the first RLP value.
-	ErrMoreThanOneValue = errors.New("rlp: input contains more than one value")
-
-	// internal errors
-	errNotInList    = errors.New("rlp: call of ListEnd outside of any list")
-	errNotAtEOL     = errors.New("rlp: call of ListEnd not positioned at EOL")
-	errUintOverflow = errors.New("rlp: uint overflow")
-)
 
 // ByteReader must be implemented by any input reader for a Stream. It
 // is implemented by e.g. bufio.Reader and bytes.Reader.

--- a/rlp/decode.go
+++ b/rlp/decode.go
@@ -537,7 +537,7 @@ func decodeDecoder(s *Stream, val reflect.Value) error {
 type Kind int
 
 // Const list indicates the kind of value in an RLP stream 
-// and and its next value is incremented by Kind().
+// and its next value is incremented by Kind().
 const (
 	Byte Kind = iota
 	String

--- a/rlp/decode.go
+++ b/rlp/decode.go
@@ -26,6 +26,7 @@ import (
 	"math/big"
 	"reflect"
 	"strings"
+	customErr "github.com/pkg/errors"
 )
 
 var (
@@ -274,9 +275,8 @@ func makeListDecoder(typ reflect.Type, tag tags) (decoder, error) {
 	if etype.Kind() == reflect.Uint8 && !reflect.PtrTo(etype).Implements(decoderInterface) {
 		if typ.Kind() == reflect.Array {
 			return decodeByteArray, nil
-		} else {
-			return decodeByteSlice, nil
 		}
+		return decodeByteSlice, nil
 	}
 	etypeinfo, err := cachedTypeInfo1(etype, tags{})
 	if err != nil {
@@ -536,6 +536,8 @@ func decodeDecoder(s *Stream, val reflect.Value) error {
 // Kind represents the kind of value contained in an RLP stream.
 type Kind int
 
+// Const list indicates the kind of value in an RLP stream 
+// and and its next value is incremented by Kind().
 const (
 	Byte Kind = iota
 	String
@@ -558,18 +560,23 @@ func (k Kind) String() string {
 var (
 	// EOL is returned when the end of the current list
 	// has been reached during streaming.
-	EOL = errors.New("rlp: end of list")
+	EOL = customErr.New(fmt.Sprintf("rlp: end of list"))
 
-	// Actual Errors
+	//ActualErrors
+
+	//ErrExpectedString is returned if kind is not string or Byte.
 	ErrExpectedString = errors.New("rlp: expected String or Byte")
+	//ErrExpectedList is returned if kind is not a list.
 	ErrExpectedList   = errors.New("rlp: expected List")
+	//ErrCanonInt is returned if integer is a non-canonical format .
 	ErrCanonInt       = errors.New("rlp: non-canonical integer format")
+	//ErrCanonSize is returned if integer has non-canonical size information. 
 	ErrCanonSize      = errors.New("rlp: non-canonical size information")
+	//ErrElemTooLarge is returned if the element is larger than the list. 
 	ErrElemTooLarge   = errors.New("rlp: element is larger than containing list")
+	//ErrValueTooLarge is returned if the element is larger than available input length. 
 	ErrValueTooLarge  = errors.New("rlp: value size exceeds available input length")
-
-	// This error is reported by DecodeBytes if the slice contains
-	// additional data after the first RLP value.
+	//ErrMoreThanOneValue is reported by DecodeBytes if the slice contains additional data after the first RLP value.
 	ErrMoreThanOneValue = errors.New("rlp: input contains more than one value")
 
 	// internal errors

--- a/rlp/encode.go
+++ b/rlp/encode.go
@@ -25,9 +25,9 @@ import (
 )
 
 var (
-	//EmptyString is a common encoded values useful when implementing EncodeRLP.
+	//EmptyString accepts a common encoded value useful for implementing EncodeRLP.
 	EmptyString = []byte{0x80}
-	//EmptyList is a common encoded values useful when implementing EncodeRLP.
+	//EmptyList accepts a common encoded value useful for implementing EncodeRLP.
 	EmptyList   = []byte{0xC0}
 )
 

--- a/rlp/encode.go
+++ b/rlp/encode.go
@@ -25,9 +25,9 @@ import (
 )
 
 var (
-	//EmptyString accepts a common encoded value useful for implementing EncodeRLP.
+	// Common encoded values.
+	// These are useful when implementing EncodeRLP.
 	EmptyString = []byte{0x80}
-	//EmptyList accepts a common encoded value useful for implementing EncodeRLP.
 	EmptyList   = []byte{0xC0}
 )
 
@@ -217,7 +217,7 @@ func (w *encbuf) list() *listhead {
 func (w *encbuf) listEnd(lh *listhead) {
 	lh.size = w.size() - lh.offset - lh.size
 	if lh.size < 56 {
-		w.lhsize ++ // length encoded into kind tag
+		w.lhsize++ // length encoded into kind tag
 	} else {
 		w.lhsize += 1 + intsize(uint64(lh.size))
 	}

--- a/rlp/encode.go
+++ b/rlp/encode.go
@@ -25,9 +25,9 @@ import (
 )
 
 var (
-	// Common encoded values.
-	// These are useful when implementing EncodeRLP.
+	//EmptyString is a common encoded values useful when implementing EncodeRLP.
 	EmptyString = []byte{0x80}
+	//EmptyList is a common encoded values useful when implementing EncodeRLP.
 	EmptyList   = []byte{0xC0}
 )
 
@@ -92,7 +92,7 @@ func Encode(w io.Writer, val interface{}) error {
 	return eb.toWriter(w)
 }
 
-// EncodeBytes returns the RLP encoding of val.
+// EncodeToBytes returns the RLP encoding of val.
 // Please see the documentation of Encode for the encoding rules.
 func EncodeToBytes(val interface{}) ([]byte, error) {
 	eb := encbufPool.Get().(*encbuf)
@@ -104,7 +104,7 @@ func EncodeToBytes(val interface{}) ([]byte, error) {
 	return eb.toBytes(), nil
 }
 
-// EncodeReader returns a reader from which the RLP encoding of val
+// EncodeToReader returns a reader from which the RLP encoding of val
 // can be read. The returned size is the total size of the encoded
 // data.
 //
@@ -151,11 +151,10 @@ func puthead(buf []byte, smalltag, largetag byte, size uint64) int {
 	if size < 56 {
 		buf[0] = smalltag + byte(size)
 		return 1
-	} else {
-		sizesize := putint(buf[1:], size)
-		buf[0] = largetag + byte(sizesize)
-		return sizesize + 1
 	}
+	sizesize := putint(buf[1:], size)
+	buf[0] = largetag + byte(sizesize)
+	return sizesize + 1
 }
 
 // encbufs are pooled.
@@ -218,7 +217,7 @@ func (w *encbuf) list() *listhead {
 func (w *encbuf) listEnd(lh *listhead) {
 	lh.size = w.size() - lh.offset - lh.size
 	if lh.size < 56 {
-		w.lhsize += 1 // length encoded into kind tag
+		w.lhsize ++ // length encoded into kind tag
 	} else {
 		w.lhsize += 1 + intsize(uint64(lh.size))
 	}
@@ -322,10 +321,9 @@ func (r *encReader) next() []byte {
 			p := r.buf.str[r.strpos:head.offset]
 			r.strpos += sizebefore
 			return p
-		} else {
-			r.lhpos++
-			return head.encode(r.buf.sizebuf)
 		}
+		r.lhpos++
+		return head.encode(r.buf.sizebuf)
 
 	case r.strpos < len(r.buf.str):
 		// String data at the end, after all list headers.
@@ -576,9 +574,8 @@ func makePtrWriter(typ reflect.Type) (writer, error) {
 	writer := func(val reflect.Value, w *encbuf) error {
 		if val.IsNil() {
 			return nilfunc(w)
-		} else {
-			return etypeinfo.writer(val.Elem(), w)
 		}
+		return etypeinfo.writer(val.Elem(), w)
 	}
 	return writer, err
 }


### PR DESCRIPTION
 This push passes all golint checks.

The new package import and change to the EOL definition were suggested by this closed golint issue: https://github.com/golang/lint/issues/350