### PR TITLE
Fix websocket log line parsing in exec p2p/simulations adapter

### DIFF
--- a/p2p/simulations/adapters/ws.go
+++ b/p2p/simulations/adapters/ws.go
@@ -1,0 +1,51 @@
+package adapters
+
+import (
+	"bufio"
+	"errors"
+	"io"
+	"regexp"
+	"strings"
+	"time"
+)
+
+// wsAddrPattern is a regex used to read the WebSocket address from the node's
+// log
+var wsAddrPattern = regexp.MustCompile(`ws://[\d.:]+`)
+
+func matchWSAddr(str string) (string, bool) {
+	if !strings.Contains(str, "WebSocket endpoint opened") {
+		return "", false
+	}
+
+	return wsAddrPattern.FindString(str), true
+}
+
+// findWSAddr scans through reader r, looking for the log entry with
+// WebSocket address information.
+func findWSAddr(r io.Reader, timeout time.Duration) (string, error) {
+	ch := make(chan string)
+
+	go func() {
+		s := bufio.NewScanner(r)
+		for s.Scan() {
+			addr, ok := matchWSAddr(s.Text())
+			if ok {
+				ch <- addr
+			}
+		}
+		close(ch)
+	}()
+
+	var wsAddr string
+	select {
+	case wsAddr = <-ch:
+		if wsAddr == "" {
+			return "", errors.New("empty result")
+		}
+	case <-time.After(timeout):
+		return "", errors.New("timed out")
+	}
+
+	return wsAddr, nil
+}

--- a/p2p/simulations/adapters/ws_test.go
+++ b/p2p/simulations/adapters/ws_test.go
@@ -1,0 +1,21 @@
+package adapters
+
+import (
+	"bytes"
+	"testing"
+	"time"
+)
+
+func TestFindWSAddr(t *testing.T) {
+	line := `t=2018-05-02T19:00:45+0200 lvl=info msg="WebSocket endpoint opened"  node.id=26c65a606d1125a44695bc08573190d047152b6b9a776ccbbe593e90f91444d9c1ebdadac6a775ad9fdd0923468a1d698ed3a842c1fb89c1bc0f9d4801f8c39c url=ws://127.0.0.1:59975`
+	buf := bytes.NewBufferString(line)
+	got, err := findWSAddr(buf, 10*time.Second)
+	if err != nil {
+		t.Fatalf("Failed to find addr: %v", err)
+	}
+	expected := `ws://127.0.0.1:59975`
+
+	if got != expected {
+		t.Fatalf("Expected to get '%s', but got '%s'", expected, got)
+	}
+}


### PR DESCRIPTION
In the `p2p/simulations` package, `exec` adapter relies on the log output to determine WebSocket address of the simulated node. (`docker` adapter also relies on this code).

Log format has changed in https://github.com/ethereum/go-ethereum/commit/589b603a9b1e17930d1e83ca64ce7cdc4c3d5c85#diff-380e79adccbaf1276bf6c91cc551cd7fL451, but the code that parses log output has not.

This PR fixes this and adds a small test to make this log parsing more explicit and visible.

## Steps to reproduce

```
cd p2p/simulations/examples

# in one terminal
go run ping-pong.go --adapter exec

# in another terminal
./ping-pong.sh
```
and observe a bunch of timed out errors:
```
WARN [05-03|12:02:45] start up failed: error getting WebSocket address: timed out
```

## Details
In `p2p/simulations/adapters/exec` there is a simple log parsing check:
```go
if strings.Contains(s.Text(), "WebSocket endpoint opened:") {
```
but current log produces output similar to this:
```
t=2018-05-02T19:00:45+0200 lvl=info msg="WebSocket endpoint opened"  node.id=26c65a606d1125a44695bc08573190d047152b6b9a776ccbbe593e90f91444d9c1ebdadac6a775ad9fdd0923468a1d698ed3a842c1fb89c1bc0f9d4801f8c39c url=ws://127.0.0.1:59975
```
which doesn't match the rule, and thus websocket address never gets obtained.

## Solution
Update matching rule (remove ':' basically). Add a test for this piece of code, as it may change in the future again.