### PR TITLE
call shh_generateSymKeyFromPassword passing a string

### DIFF
--- a/whisper/shhclient/client.go
+++ b/whisper/shhclient/client.go
@@ -135,9 +135,9 @@ func (sc *Client) AddSymmetricKey(ctx context.Context, key []byte) (string, erro
 }
 
 // GenerateSymmetricKeyFromPassword generates the key from password, stores it, and returns its identifier.
-func (sc *Client) GenerateSymmetricKeyFromPassword(ctx context.Context, passwd []byte) (string, error) {
+func (sc *Client) GenerateSymmetricKeyFromPassword(ctx context.Context, passwd string) (string, error) {
 	var id string
-	return id, sc.c.CallContext(ctx, &id, "shh_generateSymKeyFromPassword", hexutil.Bytes(passwd))
+	return id, sc.c.CallContext(ctx, &id, "shh_generateSymKeyFromPassword", passwd)
 }
 
 // HasSymmetricKey returns an indication if the key associated with the given id is stored in the node.


### PR DESCRIPTION
Using `shhclient` I noticed that the symmetric key generated calling `GenerateSymmetricKeyFromPassword` was different from the one generated using `web3` and the same password.

Example using `geth attach geth.ipc`:

```
> web3.shh.getSymKey(web3.shh.generateSymKeyFromPassword("test"))
"0xa82a520aff70f7a989098376e48ec128f25f767085e84d7fb995a9815eebff0a"
```

Example using `shhclient`:

```
package main

import (
	"context"
	"fmt"

	"github.com/ethereum/go-ethereum/whisper/shhclient"
)

func main() {
	w, _ := shhclient.Dial("geth.ipc")
	ctx := context.Background()
	symKeyID, _ := w.GenerateSymmetricKeyFromPassword(ctx, []byte("test"))
	key, _ := w.GetSymmetricKey(ctx, symKeyID)
	fmt.Printf("0x%+x\n", key)
}
```

output (different from the `web3` output):

`0x31588605fda6a8fe17e91ee0246c594f3fd2ec03af6cefdc9e3a2a8266967520`

Example using this PR:

```
package main

import (
	"context"
	"fmt"

	"github.com/ethereum/go-ethereum/whisper/shhclient"
)

func main() {
	w, _ := shhclient.Dial("geth.ipc")
	ctx := context.Background()
	symKeyID, _ := w.GenerateSymmetricKeyFromPassword(ctx, "test")
	key, _ := w.GetSymmetricKey(ctx, symKeyID)
	fmt.Printf("0x%+x\n", key)
}
```

output (same as `web3`):

`0xa82a520aff70f7a989098376e48ec128f25f767085e84d7fb995a9815eebff0a`
