### PR TITLE
whisper/mailserver: pass init error to the caller

### DIFF
--- a/cmd/wnode/main.go
+++ b/cmd/wnode/main.go
@@ -271,7 +271,9 @@ func initialize() {
 
 	if *mailServerMode {
 		shh.RegisterServer(&mailServer)
-		mailServer.Init(shh, *argDBPath, msPassword, *argServerPoW)
+		if err := mailServer.Init(shh, *argDBPath, msPassword, *argServerPoW); err != nil {
+			utils.Fatalf("Failed to init MailServer: %s", err)
+		}
 	}
 
 	server = &p2p.Server{

--- a/whisper/mailserver/mailserver.go
+++ b/whisper/mailserver/mailserver.go
@@ -20,7 +20,6 @@ import (
 	"encoding/binary"
 	"fmt"
 
-	"github.com/ethereum/go-ethereum/cmd/utils"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/log"
@@ -54,19 +53,19 @@ func NewDbKey(t uint32, h common.Hash) *DBKey {
 	return &k
 }
 
-func (s *WMailServer) Init(shh *whisper.Whisper, path string, password string, pow float64) {
+func (s *WMailServer) Init(shh *whisper.Whisper, path string, password string, pow float64) error {
 	var err error
 	if len(path) == 0 {
-		utils.Fatalf("DB file is not specified")
+		return fmt.Errorf("DB file is not specified")
 	}
 
 	if len(password) == 0 {
-		utils.Fatalf("Password is not specified for MailServer")
+		fmt.Errorf("password is not specified")
 	}
 
 	s.db, err = leveldb.OpenFile(path, nil)
 	if err != nil {
-		utils.Fatalf("Failed to open DB file: %s", err)
+		fmt.Errorf("open DB file: %s", err)
 	}
 
 	s.w = shh
@@ -74,12 +73,13 @@ func (s *WMailServer) Init(shh *whisper.Whisper, path string, password string, p
 
 	MailServerKeyID, err := s.w.AddSymKeyFromPassword(password)
 	if err != nil {
-		utils.Fatalf("Failed to create symmetric key for MailServer: %s", err)
+		fmt.Errorf("create symmetric key: %s", err)
 	}
 	s.key, err = s.w.GetSymKey(MailServerKeyID)
 	if err != nil {
-		utils.Fatalf("Failed to save symmetric key for MailServer")
+		fmt.Errorf("save symmetric key: %s", err)
 	}
+	return nil
 }
 
 func (s *WMailServer) Close() {

--- a/whisper/mailserver/mailserver.go
+++ b/whisper/mailserver/mailserver.go
@@ -60,12 +60,12 @@ func (s *WMailServer) Init(shh *whisper.Whisper, path string, password string, p
 	}
 
 	if len(password) == 0 {
-		fmt.Errorf("password is not specified")
+		return fmt.Errorf("password is not specified")
 	}
 
 	s.db, err = leveldb.OpenFile(path, nil)
 	if err != nil {
-		fmt.Errorf("open DB file: %s", err)
+		return fmt.Errorf("open DB file: %s", err)
 	}
 
 	s.w = shh
@@ -73,11 +73,11 @@ func (s *WMailServer) Init(shh *whisper.Whisper, path string, password string, p
 
 	MailServerKeyID, err := s.w.AddSymKeyFromPassword(password)
 	if err != nil {
-		fmt.Errorf("create symmetric key: %s", err)
+		return fmt.Errorf("create symmetric key: %s", err)
 	}
 	s.key, err = s.w.GetSymKey(MailServerKeyID)
 	if err != nil {
-		fmt.Errorf("save symmetric key: %s", err)
+		return fmt.Errorf("save symmetric key: %s", err)
 	}
 	return nil
 }

--- a/whisper/mailserver/server_test.go
+++ b/whisper/mailserver/server_test.go
@@ -92,7 +92,10 @@ func TestMailServer(t *testing.T) {
 	shh = whisper.New(&whisper.DefaultConfig)
 	shh.RegisterServer(&server)
 
-	server.Init(shh, dir, password, powRequirement)
+	err = server.Init(shh, dir, password, powRequirement)
+	if err != nil {
+		t.Fatal(err)
+	}
 	defer server.Close()
 
 	keyID, err = shh.AddSymKeyFromPassword(password)


### PR DESCRIPTION
This PR changes `whisper/mailserver.(*WMailServer).Init()` signature to return `error` type instead of calling `utils.Fatalf()` from the this lib.

One of the goals is to remove `mailserver`'s dependency on `cmd/utils` package (which in its turn, brings in `dashboard` package and, probably more). Also, this seems to be an originally intended way to use `utils.Fatalf` – call it only from commands in `cmd/`, and not from the library itself.