### PR TITLE
core: use channel for promoted transactions to improve order during high volume

### DIFF
--- a/core/tx_pool.go
+++ b/core/tx_pool.go
@@ -192,6 +192,7 @@ type TxPool struct {
 	chainHeadSub event.Subscription
 	signer       types.Signer
 	mu           sync.RWMutex
+	promotedTxCh chan TxPreEvent
 
 	currentState  *state.StateDB      // Current state in the blockchain head
 	pendingState  *state.ManagedState // Pending state tracking virtual nonces
@@ -219,16 +220,17 @@ func NewTxPool(config TxPoolConfig, chainconfig *params.ChainConfig, chain block
 
 	// Create the transaction pool with its initial settings
 	pool := &TxPool{
-		config:      config,
-		chainconfig: chainconfig,
-		chain:       chain,
-		signer:      types.NewEIP155Signer(chainconfig.ChainId),
-		pending:     make(map[common.Address]*txList),
-		queue:       make(map[common.Address]*txList),
-		beats:       make(map[common.Address]time.Time),
-		all:         make(map[common.Hash]*types.Transaction),
-		chainHeadCh: make(chan ChainHeadEvent, chainHeadChanSize),
-		gasPrice:    new(big.Int).SetUint64(config.PriceLimit),
+		config:       config,
+		chainconfig:  chainconfig,
+		chain:        chain,
+		signer:       types.NewEIP155Signer(chainconfig.ChainId),
+		pending:      make(map[common.Address]*txList),
+		queue:        make(map[common.Address]*txList),
+		beats:        make(map[common.Address]time.Time),
+		all:          make(map[common.Hash]*types.Transaction),
+		chainHeadCh:  make(chan ChainHeadEvent, chainHeadChanSize),
+		gasPrice:     new(big.Int).SetUint64(config.PriceLimit),
+		promotedTxCh: make(chan TxPreEvent, config.GlobalSlots),
 	}
 	pool.locals = newAccountSet(pool.signer)
 	pool.priced = newTxPricedList(&pool.all)
@@ -333,6 +335,10 @@ func (pool *TxPool) loop() {
 				}
 				pool.mu.Unlock()
 			}
+
+		// Handle promoted transaction
+		case txPreEvent := <-pool.promotedTxCh:
+			pool.txFeed.Send(txPreEvent)
 		}
 	}
 }
@@ -653,7 +659,9 @@ func (pool *TxPool) add(tx *types.Transaction, local bool) (bool, error) {
 		log.Trace("Pooled new executable transaction", "hash", hash, "from", from, "to", tx.To())
 
 		// We've directly injected a replacement transaction, notify subsystems
-		go pool.txFeed.Send(TxPreEvent{tx})
+		go func(tx *types.Transaction) {
+			pool.promotedTxCh <- TxPreEvent{tx}
+		}(tx)
 
 		return old != nil, nil
 	}
@@ -747,7 +755,9 @@ func (pool *TxPool) promoteTx(addr common.Address, hash common.Hash, tx *types.T
 	pool.beats[addr] = time.Now()
 	pool.pendingState.SetNonce(addr, tx.Nonce()+1)
 
-	go pool.txFeed.Send(TxPreEvent{tx})
+	go func(tx *types.Transaction) {
+		pool.promotedTxCh <- TxPreEvent{tx}
+	}(tx)
 }
 
 // AddLocal enqueues a single transaction into the pool if it is valid, marking


### PR DESCRIPTION
Related: #16617 and #14669.

This works around what seems to be a source of contention when `event.Feed.Send` is called from multiple goroutines at high volume.  For example, see the `debug.stacks()` output in #16617:

```
goroutine 43158053 [chan receive, 136 minutes]:
github.com/ethereum/go-ethereum/event.(*Feed).Send(0xc420313e38, 0xdef1a0, 0xc4b5ae3320, 0x60c977)
  /home/ubuntu/geth/go-ethereum/build/_workspace/src/github.com/ethereum/go-ethereum/event/feed.go:133 +0xcc
created by github.com/ethereum/go-ethereum/core.(*TxPool).promoteTx
  /home/ubuntu/geth/go-ethereum/build/_workspace/src/github.com/ethereum/go-ethereum/core/tx_pool.go:750 +0x2ae

goroutine 43750113 [chan receive, 57 minutes]:
github.com/ethereum/go-ethereum/event.(*Feed).Send(0xc420313e38, 0xdef1a0, 0xc5403ca6c0, 0x60c977)
  /home/ubuntu/geth/go-ethereum/build/_workspace/src/github.com/ethereum/go-ethereum/event/feed.go:133 +0xcc
created by github.com/ethereum/go-ethereum/core.(*TxPool).promoteTx
  /home/ubuntu/geth/go-ethereum/build/_workspace/src/github.com/ethereum/go-ethereum/core/tx_pool.go:750 +0x2ae

goroutine 43016550 [chan receive, 154 minutes]:
github.com/ethereum/go-ethereum/event.(*Feed).Send(0xc420313e38, 0xdef1a0, 0xc4935fddd0, 0x60c977)
  /home/ubuntu/geth/go-ethereum/build/_workspace/src/github.com/ethereum/go-ethereum/event/feed.go:133 +0xcc
created by github.com/ethereum/go-ethereum/core.(*TxPool).promoteTx
  /home/ubuntu/geth/go-ethereum/build/_workspace/src/github.com/ethereum/go-ethereum/core/tx_pool.go:750 +0x2ae

goroutine 43928769 [chan receive, 35 minutes]:
github.com/ethereum/go-ethereum/event.(*Feed).Send(0xc420313e38, 0xdef1a0, 0xc5059bf710, 0x60c977)
  /home/ubuntu/geth/go-ethereum/build/_workspace/src/github.com/ethereum/go-ethereum/event/feed.go:133 +0xcc
created by github.com/ethereum/go-ethereum/core.(*TxPool).promoteTx
  /home/ubuntu/geth/go-ethereum/build/_workspace/src/github.com/ethereum/go-ethereum/core/tx_pool.go:750 +0x2ae
```

As mentioned in #14669 I was unable to find the root cause of what appears to be the non-FIFO nature of the semaphore in `event.Feed.Send`, however by routing all the `TxPool.promoteTx` calls to a channel serviced in `loop` the contention is removed.

IMO the root cause of `event.Feed.Send` issues should still be investigated, but this change is orthogonal to any fix in that subsystem.  