### PR TITLE
build: specify the key to use when invoking gpg:sign-and-deploy-file

### DIFF
--- a/build/ci.go
+++ b/build/ci.go
@@ -755,14 +755,17 @@ func doAndroidArchive(cmdline []string) {
 	os.Rename(archive, meta.Package+".aar")
 	if *signer != "" && *deploy != "" {
 		// Import the signing key into the local GPG instance
-		if b64key := os.Getenv(*signer); b64key != "" {
-			key, err := base64.StdEncoding.DecodeString(b64key)
-			if err != nil {
-				log.Fatalf("invalid base64 %s", *signer)
-			}
-			gpg := exec.Command("gpg", "--import")
-			gpg.Stdin = bytes.NewReader(key)
-			build.MustRun(gpg)
+		b64key := os.Getenv(*signer)
+		key, err := base64.StdEncoding.DecodeString(b64key)
+		if err != nil {
+			log.Fatalf("invalid base64 %s", *signer)
+		}
+		gpg := exec.Command("gpg", "--import")
+		gpg.Stdin = bytes.NewReader(key)
+		build.MustRun(gpg)
+		keyID, err := build.PGPKeyID(string(key))
+		if err != nil {
+			log.Fatal(err)
 		}
 		// Upload the artifacts to Sonatype and/or Maven Central
 		repo := *deploy + "/service/local/staging/deploy/maven2"
@@ -771,6 +774,7 @@ func doAndroidArchive(cmdline []string) {
 		}
 		build.MustRunCommand("mvn", "gpg:sign-and-deploy-file", "-e", "-X",
 			"-settings=build/mvn.settings", "-Durl="+repo, "-DrepositoryId=ossrh",
+			"-Dgpg.keyname="+keyID,
 			"-DpomFile="+meta.Package+".pom", "-Dfile="+meta.Package+".aar")
 	}
 }

--- a/build/ci.go
+++ b/build/ci.go
@@ -763,6 +763,7 @@ func doAndroidArchive(cmdline []string) {
 		gpg := exec.Command("gpg", "--import")
 		gpg.Stdin = bytes.NewReader(key)
 		build.MustRun(gpg)
+
 		keyID, err := build.PGPKeyID(string(key))
 		if err != nil {
 			log.Fatal(err)

--- a/internal/build/pgp.go
+++ b/internal/build/pgp.go
@@ -57,3 +57,15 @@ func PGPSignFile(input string, output string, pgpkey string) error {
 	// Generate the signature and return
 	return openpgp.ArmoredDetachSign(out, keys[0], in, nil)
 }
+
+// PGPKeyID parses an armored key and returns the key ID.
+func PGPKeyID(pgpkey string) (string, error) {
+	keys, err := openpgp.ReadArmoredKeyRing(bytes.NewBufferString(pgpkey))
+	if err != nil {
+		return "", err
+	}
+	if len(keys) != 1 {
+		return "", fmt.Errorf("key count mismatch: have %d, want %d", len(keys), 1)
+	}
+	return keys[0].PrimaryKey.KeyIdString(), nil
+}


### PR DESCRIPTION
This way I could locally upload after the initial problem that the wrong key was used to sign.

This should fix #16433