### PR TITLE
Dockerfile: extended version with Go binaries and version control systems

### DIFF
--- a/Dockerfile.extended
+++ b/Dockerfile.extended
@@ -3,23 +3,17 @@ FROM golang:1.10-alpine as builder
 
 RUN apk add --no-cache make gcc musl-dev linux-headers
 
+# Install dependencies for `go get`
+RUN apk update && apk upgrade && \
+    apk add --no-cache bash git openssh mercurial bzr
+
 ADD . /go-ethereum
 RUN cd /go-ethereum && make all
 
 # Pull all binaries into a second stage deploy alpine container
-FROM alpine:latest
+FROM builder
 
 RUN apk add --no-cache ca-certificates
-COPY --from=builder /go-ethereum/build/bin/geth /usr/local/bin/
-
-# Pull golang directory and set related environment variables
-COPY --from=builder /usr/local/go /usr/local/go
-ENV GOPATH /go
-ENV PATH $GOPATH/bin:/usr/local/go/bin:$PATH
-RUN mkdir -p "$GOPATH/src" "$GOPATH/bin" && chmod -R 777 "$GOPATH"
-
-# Install dependencies for `go get`
-RUN apk update && apk upgrade && \
-    apk add --no-cache bash git openssh mercurial bzr
+COPY --from=builder /go-ethereum/build/bin/* /usr/local/bin/
 
 EXPOSE 8545 8546 30303 30303/udp

--- a/Dockerfile.extended
+++ b/Dockerfile.extended
@@ -1,0 +1,25 @@
+# Build Geth in a stock Go builder container
+FROM golang:1.10-alpine as builder
+
+RUN apk add --no-cache make gcc musl-dev linux-headers
+
+ADD . /go-ethereum
+RUN cd /go-ethereum && make all
+
+# Pull all binaries into a second stage deploy alpine container
+FROM alpine:latest
+
+RUN apk add --no-cache ca-certificates
+COPY --from=builder /go-ethereum/build/bin/geth /usr/local/bin/
+
+# Pull golang directory and set related environment variables
+COPY --from=builder /usr/local/go /usr/local/go
+ENV GOPATH /go
+ENV PATH $GOPATH/bin:/usr/local/go/bin:$PATH
+RUN mkdir -p "$GOPATH/src" "$GOPATH/bin" && chmod -R 777 "$GOPATH"
+
+# Install dependencies for `go get`
+RUN apk update && apk upgrade && \
+    apk add --no-cache bash git openssh mercurial bzr
+
+EXPOSE 8545 8546 30303 30303/udp


### PR DESCRIPTION
Modern cloud CI environments use containerized builds for better isolation. Sometimes, integration tests in Go packages depend on running Geth node in development mode. To achieve that, there are two ways:

* First, you can re-use `cmd/geth` codebase to start a development node directly in tests inside a separate goroutine. But you can't just import `cmd/geth`, because it is a `main` package, so you'll probably have to copypaste all necessary code that is required by `startNode()` function.
* Second (and slightly more simplistic) way is to launch another OS process directly inside tests, using `os/exec` package and then terminate it at the end of the test suite.

This extended image is implementation of the second way. It contains `geth`, all the binaries from `cmd` subpackage, Golang binaries & libraries from base builder image and version control systems supported by `go get`.