### PR TITLE
whisper/shhclient: update call to shh_post to expect string instead of bool

### DIFF
--- a/whisper/shhclient/client.go
+++ b/whisper/shhclient/client.go
@@ -159,9 +159,9 @@ func (sc *Client) DeleteSymmetricKey(ctx context.Context, id string) error {
 }
 
 // Post a message onto the network.
-func (sc *Client) Post(ctx context.Context, message whisper.NewMessage) error {
-	var ignored bool
-	return sc.c.CallContext(ctx, &ignored, "shh_post", message)
+func (sc *Client) Post(ctx context.Context, message whisper.NewMessage) (string, error) {
+	var hash string
+	return hash, sc.c.CallContext(ctx, &hash, "shh_post", message)
 }
 
 // SubscribeMessages subscribes to messages that match the given criteria. This method


### PR DESCRIPTION
Calling the `Post` methods of the whisper client fails with:

`cannot unmarshal string into Go value of type bool`

The returned value of `shh_post` is now the hash of the message sent.

This PR update the `Post` method to expect a string and return `(string, error)`.