### PR TITLE
eth/downloader: close queue after all fetchers finished

### DIFF
--- a/eth/downloader/downloader.go
+++ b/eth/downloader/downloader.go
@@ -486,13 +486,16 @@ func (d *Downloader) spawnSync(fetchers []func() error) error {
 	// Wait for the first error, then terminate the others.
 	var err error
 	for i := 0; i < len(fetchers); i++ {
+		err = <-errc
+
 		if i == len(fetchers)-1 {
 			// Close the queue when all fetchers have exited.
 			// This will cause the block processor to end when
 			// it has processed the queue.
 			d.queue.Close()
 		}
-		if err = <-errc; err != nil {
+
+		if err != nil {
 			break
 		}
 	}


### PR DESCRIPTION
Queue should be closed after all fetchers are finished. And it is that time when all `errc` is read.

First if-statement is executed when `i = len(fetchers) - 1` but last fetcher may not write `errc` at the moment.

For the docummented(_Close the queue when all fetchers have exited._) behavior, all `errc` must be read first.

