### PR TITLE
 report error if event not not found by name when processing log

### DIFF
--- a/accounts/abi/bind/base_test.go
+++ b/accounts/abi/bind/base_test.go
@@ -1,0 +1,29 @@
+package bind
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/accounts/abi"
+	"github.com/ethereum/go-ethereum/core/types"
+)
+
+func TestUnkownEventName(t *testing.T) {
+	errorPrefix := "abi: event"
+	c := &BoundContract{}
+	c.abi.Events = make(map[string]abi.Event)
+	c.abi.Events["event1"] = abi.Event{}
+	if _, _, err := c.FilterLogs(nil, "event_not_exist"); err == nil || !strings.HasPrefix(err.Error(), errorPrefix) {
+		t.Fatal("should report error if event not found")
+	}
+
+	if _, _, err := c.WatchLogs(nil, "event_not_exist"); err == nil || !strings.HasPrefix(err.Error(), errorPrefix) {
+		t.Fatal("should report error if event not found")
+	}
+
+	var v interface{}
+	elog := types.Log{}
+	if err := c.UnpackLog(v, "event_not_exist", elog); err == nil || !strings.HasPrefix(err.Error(), errorPrefix) {
+		t.Fatal("should report error if event not found")
+	}
+}


### PR DESCRIPTION
when watch or filter logs with a **event not exist in a contract**, the client just does not any event notification. We should report an error when the client try to subscribe events.

map `abi.Events` has struct `Event` instead of pointer to struct `*Event` as values, so a `zero value` of `Event` returns when we get event by a not exist event name. Call to `event.ID()` and `event.Inputs` return `zero value` also. So some logic goes wrong path.