### PR TITLE
trie: cleaner logic, one less func call

### DIFF
--- a/trie/hasher.go
+++ b/trie/hasher.go
@@ -196,12 +196,12 @@ func (h *hasher) store(n node, db *Database, force bool) (node, error) {
 		if h.onleaf != nil {
 			switch n := n.(type) {
 			case *shortNode:
-				if child, ok := n.Val.(valueNode); ok {
+				if child, ok := n.Val.(valueNode); ok && child != nil {
 					h.onleaf(child, hash)
 				}
 			case *fullNode:
 				for i := 0; i < 16; i++ {
-					if child, ok := n.Children[i].(valueNode); ok {
+					if child, ok := n.Children[i].(valueNode); ok && child != nil {
 						h.onleaf(child, hash)
 					}
 				}


### PR DESCRIPTION
This PR is a very tiny fix, that doesn't really have any impact other than code clarity. When hashing the account trie, whenever we reached a leaf node (account), we called `onleaf`. This `onleaf` method is used by `statedb` for trie pruning to link this leaf account to its storage trie.

There was a slight oversight I didn't realize while adding this logic: full trie nodes are often incomplete (i.e. some of its children are nil), but not flat out `nil`, rather `valuenode(nil)`. This means that `if child, ok := n.Children[i].(valueNode); ok {` actually returns true and we call `onleaf` for dangling terminators. This is not an issue in our code, since `onleaf` tries to parse the leaf as an account, `nil` will fail parsing and returns, but this is an extra function call overhead we don't need.

Code clarity wise it took me 3 hours of debugging to realize why the `path` leading to such a "leaf" was invalid. Because it was not an actual leaf, just a dangling terminator. This is mostly what prompted this PR, so the next person touching this code won't waste 3 more hours ;P