### PR TITLE
Casper-FFG: process casper votes

### DIFF
--- a/common/types.go
+++ b/common/types.go
@@ -35,8 +35,9 @@ const (
 )
 
 var (
-	hashT    = reflect.TypeOf(Hash{})
-	addressT = reflect.TypeOf(Address{})
+	hashT          = reflect.TypeOf(Hash{})
+	addressT       = reflect.TypeOf(Address{})
+	NullSenderAddr = HexToAddress("0xffffffffffffffffffffffffffffffffffffffff")
 )
 
 // Hash represents the 32 byte Keccak256 hash of arbitrary data.
@@ -193,6 +194,11 @@ func (a Address) String() string {
 // without going through the stringer interface used for logging.
 func (a Address) Format(s fmt.State, c rune) {
 	fmt.Fprintf(s, "%"+string(c), a[:])
+}
+
+// IsNullSender returns true if this address is NullSenderAddr
+func (a Address) IsNullSender() bool {
+	return a == NullSenderAddr
 }
 
 // Sets the address to the value of b. If b is larger than len(a) it will panic

--- a/core/error.go
+++ b/core/error.go
@@ -32,4 +32,7 @@ var (
 	// ErrNonceTooHigh is returned if the nonce of a transaction is higher than the
 	// next one expected based on the local chain.
 	ErrNonceTooHigh = errors.New("nonce too high")
+
+	// ErrFailedVote is returned if a vote failed in the Casper contract.
+	ErrFailedVote = errors.New("casper vote failed")
 )


### PR DESCRIPTION
Implementing Casper vote processing per [EIP#1011](https://eips.ethereum.org/EIPS/eip-1011). Specifically:
- Transactions that are deemed as Casper votes has its `from` field as `NULL_SENDER`
- Votes are stored in tx pool in a separate queue and share as much as validation/reorg logic with the normal transactions as possible
- Vote transactions are executed after all normal transactions are completed. 
  - Cumulative gas used by votes is tracked separately and not included in the header
  - Cumulative gas used by votes cannot exceed the block gas limit, independent of gas used by normal transactions

