### PR TITLE
interfaces: fix a typo in FilterQuery{}

### DIFF
--- a/interfaces.go
+++ b/interfaces.go
@@ -144,7 +144,7 @@ type FilterQuery struct {
 	// {} or nil          matches any topic list
 	// {{A}}              matches topic A in first position
 	// {{}, {B}}          matches any topic in first position, B in second position
-	// {{A}}, {B}}        matches topic A in first position, B in second position
+	// {{A}, {B}}         matches topic A in first position, B in second position
 	// {{A, B}}, {C, D}}  matches topic (A OR B) in first position, (C OR D) in second position
 	Topics [][]common.Hash
 }


### PR DESCRIPTION
The example of "matches topic A in first position, B in second position" should be {{A}, {B}}