### PR TITLE
Introduce debug_increaseTime RPC method

### DIFF
--- a/common/aclock/aclock.go
+++ b/common/aclock/aclock.go
@@ -1,0 +1,50 @@
+// Copyright 2018 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+// Package aclock contains an adjustable clock implementation. The time can be
+// adjusted by adding an offset.
+package aclock
+
+import (
+	"errors"
+	"time"
+)
+
+var offset time.Duration
+
+// AddOffset adds offset d to the current offset. d cannot be negative, and an
+// error will be returned if the resulting offset overflows time.Duration.
+func AddOffset(d time.Duration) (time.Duration, error) {
+	if d < 0 {
+		return 0, errors.New("aclock: duration for offset cannot be negative")
+	}
+	if offset+d < offset {
+		return 0, errors.New("aclock: offset overflow")
+	}
+	offset += d
+	return offset, nil
+}
+
+// Now returns the current time with the offset applied.
+func Now() time.Time {
+	return time.Now().Add(offset)
+}
+
+// NowWithOffset returns the current time with the offset applied and the offset
+// itself.
+func NowWithOffset() (time.Time, time.Duration) {
+	return time.Now().Add(offset), offset
+}

--- a/consensus/clique/clique.go
+++ b/consensus/clique/clique.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/ethereum/go-ethereum/accounts"
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/aclock"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/consensus"
 	"github.com/ethereum/go-ethereum/consensus/misc"
@@ -279,7 +280,7 @@ func (c *Clique) verifyHeader(chain consensus.ChainReader, header *types.Header,
 	number := header.Number.Uint64()
 
 	// Don't waste time checking blocks from the future
-	if header.Time.Cmp(big.NewInt(time.Now().Unix())) > 0 {
+	if header.Time.Cmp(big.NewInt(aclock.Now().Unix())) > 0 {
 		return consensus.ErrFutureBlock
 	}
 	// Checkpoint blocks need to enforce zero beneficiary
@@ -571,8 +572,8 @@ func (c *Clique) Prepare(chain consensus.ChainReader, header *types.Header) erro
 		return consensus.ErrUnknownAncestor
 	}
 	header.Time = new(big.Int).Add(parent.Time, new(big.Int).SetUint64(c.config.Period))
-	if header.Time.Int64() < time.Now().Unix() {
-		header.Time = big.NewInt(time.Now().Unix())
+	if header.Time.Int64() < aclock.Now().Unix() {
+		header.Time = big.NewInt(aclock.Now().Unix())
 	}
 	return nil
 }
@@ -637,7 +638,7 @@ func (c *Clique) Seal(chain consensus.ChainReader, block *types.Block, results c
 		}
 	}
 	// Sweet, the protocol permits us to sign the block, wait for our time
-	delay := time.Unix(header.Time.Int64(), 0).Sub(time.Now()) // nolint: gosimple
+	delay := time.Unix(header.Time.Int64(), 0).Sub(aclock.Now()) // nolint: gosimple
 	if header.Difficulty.Cmp(diffNoTurn) == 0 {
 		// It's not our turn explicitly to sign, delay it a bit
 		wiggle := time.Duration(len(snap.Signers)/2+1) * wiggleTime

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -43,7 +43,7 @@ import (
 	"github.com/ethereum/go-ethereum/params"
 	"github.com/ethereum/go-ethereum/rlp"
 	"github.com/ethereum/go-ethereum/trie"
-	"github.com/hashicorp/golang-lru"
+	lru "github.com/hashicorp/golang-lru"
 )
 
 var (

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -29,6 +29,7 @@ import (
 	"github.com/ethereum/go-ethereum/accounts"
 	"github.com/ethereum/go-ethereum/accounts/keystore"
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/aclock"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/common/math"
 	"github.com/ethereum/go-ethereum/consensus/ethash"
@@ -1560,6 +1561,16 @@ func (api *PrivateDebugAPI) ChaindbCompact() error {
 // SetHead rewinds the head of the blockchain to a previous block.
 func (api *PrivateDebugAPI) SetHead(number hexutil.Uint64) {
 	api.b.SetHead(uint64(number))
+}
+
+// IncreaseTime increase the time offset for the clock used in consensus and
+// mining. It has the effect of changing the timestamp of the next mined block.
+func (api *PrivateDebugAPI) IncreaseTime(seconds uint64) (uint64, error) {
+	offset, err := aclock.AddOffset(time.Duration(seconds) * time.Second)
+	if err != nil {
+		return 0, err
+	}
+	return uint64(offset.Seconds()), nil
 }
 
 // PublicNetAPI offers network related RPC methods

--- a/internal/web3ext/web3ext.go
+++ b/internal/web3ext/web3ext.go
@@ -237,6 +237,11 @@ web3._extend({
 			params: 1
 		}),
 		new web3._extend.Method({
+			name: 'increaseTime',
+			call: 'debug_increaseTime',
+			params: 1
+		}),
+		new web3._extend.Method({
 			name: 'seedHash',
 			call: 'debug_seedHash',
 			params: 1


### PR DESCRIPTION
We are using Geth to tests our smart contracts in a single-node private testnet. Some of those contracts have time dependencies (e.g., a funds can be released only after a certain amount of time). The ability to increase time artificially greatly improves the performance and reliability of our tests.

This PR introduces a new RPC method `debug_increaseTime` which has the effect of increasing the timestamp of the next mined block. It's modeled after the [`evm_increaseTime` endpoint in Ganache](https://github.com/trufflesuite/ganache-cli#implemented-methods) and behaves similarly. The endpoint takes a single parameter, an offset to apply to an adjustable clock in seconds. Internally, this is implemented via a new "aclock" package.

Time can only be increased, and can never be decreased or the offset restored to its previous value. The reason is that I expect a lot code would break (or goroutines would stall) if we went backwards in time.

Our smart contract tests utilize this new RPC method right now (running on our forked version of Geth) and it seems to work. I would also be willing to write some tests for the new method in go-ethereum itself, but would need some guidance on the best way to do that.