### PR TITLE
core: fix transaction event asynchronicity

### DIFF
--- a/core/tx_pool.go
+++ b/core/tx_pool.go
@@ -962,7 +962,7 @@ func (pool *TxPool) promoteExecutables(accounts []common.Address) {
 	}
 	// Notify subsystem for new promoted transactions.
 	if len(promoted) > 0 {
-		pool.txFeed.Send(NewTxsEvent{promoted})
+		go pool.txFeed.Send(NewTxsEvent{promoted})
 	}
 	// If the pending limit is overflown, start equalizing allowances
 	pending := uint64(0)


### PR DESCRIPTION
Fixes https://github.com/ethereum/go-ethereum/issues/16840.

https://github.com/ethereum/go-ethereum/pull/16720 reworked transaction event raises and accidentally removed a goroutine when the transaction pool promoted a transaction ([old](https://github.com/ethereum/go-ethereum/pull/16720/files#diff-8fecce9bb4c486ebc22226cf681416e2L750) vs [new](https://github.com/ethereum/go-ethereum/pull/16720/files#diff-8fecce9bb4c486ebc22226cf681416e2R968)). This unfortunately means that the transaction pool lock is kept held while the event is being processed. If a subsystem is however subscribed to transaction events and at the same time waiting for the transaction pool lock, this synchronicity will lock the process up. This PR fixes the oversight.