### PR TITLE
consensus/ethash: do GOMAXPROCS lookup at init time

### DIFF
--- a/consensus/ethash/consensus.go
+++ b/consensus/ethash/consensus.go
@@ -98,7 +98,7 @@ func (ethash *Ethash) VerifyHeaders(chain consensus.ChainReader, headers []*type
 	}
 
 	// Spawn as many workers as allowed threads
-	workers := runtime.GOMAXPROCS(0)
+	workers := runtime.NumCPU()
 	if len(headers) < workers {
 		workers = len(headers)
 	}


### PR DESCRIPTION
The call to `runtime.GOMAXPROCS(0)` is the same as `NumCPU()`, but the former also stops the world. 