### PR TITLE
rpc: Use `http.Request`'s context instead of creating our own.

### DIFF
--- a/rpc/http.go
+++ b/rpc/http.go
@@ -181,7 +181,7 @@ func (srv *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	// All checks passed, create a codec that reads direct from the request body
 	// untilEOF and writes the response to w and order the server to process a
 	// single request.
-	ctx := context.Background()
+	ctx := r.Context()
 	ctx = context.WithValue(ctx, "remote", r.RemoteAddr)
 	ctx = context.WithValue(ctx, "scheme", r.Proto)
 	ctx = context.WithValue(ctx, "local", r.Host)


### PR DESCRIPTION

I was experimenting with light clients and sent a request for an account balance for an older block number (and the light client did not have any archive-node peers).  The RPC never completed since `odrTrie.TryGet` tries the request for the block forever until cancelled.

What I then noticed is that the goroutine stuck around even after I cancelled the `curl` request that initiated it.  After working my way all the way up the stack, I realized it's because the `Context` passed into `(*PublicBlockChainAPI).GetBalance` was never cancelled because we are using a new `Background` context instead of passing in the one from the `http.Request` object.

After making the change in this PR the goroutine is no longer left dangling after the client goes away.  However, I've not tested every RPC, are there any that should explicitly *not* cancel if the client stops the request?  I'm thinking perhaps some obscure `debug_` or `admin_` RPCs could lead to issue if they were cancelled mid call?