### PR TITLE
cmd: Fix bug checking value conflicts (e.g. `--lightserv` conflicting with `--syncmode=light`).

### DIFF
--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -976,13 +976,17 @@ func checkExclusive(ctx *cli.Context, args ...interface{}) {
 		name := flag.GetName()
 
 		if i+1 < len(args) {
-			switch option := args[i+1].(type) {
+			switch args[i+1].(type) {
 			case string:
-				// Extended flag, expand the name and shift the arguments
+				// Extended flag check, make sure value set doesn't conflict with passed in option
+				option := args[i+1].(string)
 				if ctx.GlobalString(flag.GetName()) == option {
 					name += "=" + option
+					set = append(set, "--"+name)
 				}
+				// shift arguments and continue
 				i++
+				continue
 
 			case cli.Flag:
 			default:


### PR DESCRIPTION
Fixes #16345.

The gist of the issue is that it wasn't breaking out of the loop after comparing the values, so would proceed to add the flag to the `set` whether or not the value set conflicted.