### PR TITLE
rpc: set timeouts for http server, see #16859

### DIFF
--- a/rpc/http.go
+++ b/rpc/http.go
@@ -165,7 +165,12 @@ func NewHTTPServer(cors []string, vhosts []string, srv *Server) *http.Server {
 	// Wrap the CORS-handler within a host-handler
 	handler := newCorsHandler(srv, cors)
 	handler = newVHostHandler(vhosts, handler)
-	return &http.Server{Handler: handler}
+	return &http.Server{
+		Handler:      handler,
+		ReadTimeout:  5 * time.Second,
+		WriteTimeout: 10 * time.Second,
+		IdleTimeout:  120 * time.Second,
+	}
 }
 
 // ServeHTTP serves JSON-RPC requests over HTTP.


### PR DESCRIPTION
This PR adds timeouts to the rpc http server. See https://github.com/ethereum/go-ethereum/issues/16859 and https://blog.cloudflare.com/exposing-go-on-the-internet/ for more context. 