### PR TITLE
internal/debug: use pprof goroutine writer for debug_stacks

### DIFF
--- a/internal/debug/api.go
+++ b/internal/debug/api.go
@@ -191,7 +191,7 @@ func (*HandlerT) WriteMemProfile(file string) error {
 
 // Stacks returns a printed representation of the stacks of all goroutines.
 func (*HandlerT) Stacks() string {
-	var buf bytes.Buffer
+	buf := new(bytes.Buffer)
 	pprof.Lookup("goroutine").WriteTo(buf, 2)
 	return buf.String()
 }

--- a/internal/debug/api.go
+++ b/internal/debug/api.go
@@ -191,9 +191,9 @@ func (*HandlerT) WriteMemProfile(file string) error {
 
 // Stacks returns a printed representation of the stacks of all goroutines.
 func (*HandlerT) Stacks() string {
-	var b bytes.Buffer
-	pprof.Lookup("goroutine").WriteTo(w, 2)
-	return b.String()
+	var buf bytes.Buffer
+	pprof.Lookup("goroutine").WriteTo(buf, 2)
+	return buf.String()
 }
 
 // FreeOSMemory returns unused memory to the OS.

--- a/internal/debug/api.go
+++ b/internal/debug/api.go
@@ -21,6 +21,7 @@
 package debug
 
 import (
+	"bytes"
 	"errors"
 	"io"
 	"os"
@@ -33,8 +34,6 @@ import (
 	"sync"
 	"time"
 
-	"bufio"
-	"bytes"
 	"github.com/ethereum/go-ethereum/log"
 )
 
@@ -193,11 +192,7 @@ func (*HandlerT) WriteMemProfile(file string) error {
 // Stacks returns a printed representation of the stacks of all goroutines.
 func (*HandlerT) Stacks() string {
 	var b bytes.Buffer
-	b.Grow(1024 * 1024)
-	w := bufio.NewWriter(&b)
 	pprof.Lookup("goroutine").WriteTo(w, 2)
-	w.Flush()
-
 	return b.String()
 }
 

--- a/internal/debug/api.go
+++ b/internal/debug/api.go
@@ -33,6 +33,8 @@ import (
 	"sync"
 	"time"
 
+	"bufio"
+	"bytes"
 	"github.com/ethereum/go-ethereum/log"
 )
 
@@ -190,9 +192,13 @@ func (*HandlerT) WriteMemProfile(file string) error {
 
 // Stacks returns a printed representation of the stacks of all goroutines.
 func (*HandlerT) Stacks() string {
-	buf := make([]byte, 1024*1024)
-	buf = buf[:runtime.Stack(buf, true)]
-	return string(buf)
+	var b bytes.Buffer
+	b.Grow(1024 * 1024)
+	w := bufio.NewWriter(&b)
+	pprof.Lookup("goroutine").WriteTo(w, 2)
+	w.Flush()
+
+	return b.String()
 }
 
 // FreeOSMemory returns unused memory to the OS.


### PR DESCRIPTION
When debugging an issue today, I found that `debug.Stacks()` is limited to 1M of goroutines, and sure enough because of a bunch of wayward goroutines related to the `Feed.Send` calls discussed in #16673 the goroutine I was really interested wasn't included in the dump.

So, at first I was going to submit a simple fix like this, to dynamically resize the dump buffer (stolen from the go source for debug.Stack):

```
		buf := make([]byte, 1024*1204)
		for {
			n := runtime.Stack(buf, true)
			if n < len(buf) {
				return string(buf[:n])
			}
			buf = make([]byte, 2*len(buf))
		}
```

However, that felt dirty (and potentially very slow), so I started to look around if there was anything that deduped similar goroutines before dumping, and came across the older dump format in `pprof`, which does goroutine de-duping:

```
goroutine profile: total 148
16 @ 0x442edc 0x442fce 0x41a0b4 0x419d5b 0x986c85 0x984523 0x9842c2 0x983fea 0x98b30b 0x4728a1
#	0x986c84	github.com/ethereum/go-ethereum/p2p/discover.(*udp).ping+0x364			/ext-go/1/src/github.com/ethereum/go-ethereum/p2p/discover/udp.go:289
#	0x984522	github.com/ethereum/go-ethereum/p2p/discover.(*Table).ping+0xd2			/ext-go/1/src/github.com/ethereum/go-ethereum/p2p/discover/table.go:663
#	0x9842c1	github.com/ethereum/go-ethereum/p2p/discover.(*Table).pingpong+0xb1		/ext-go/1/src/github.com/ethereum/go-ethereum/p2p/discover/table.go:644
#	0x983fe9	github.com/ethereum/go-ethereum/p2p/discover.(*Table).bond+0x659		/ext-go/1/src/github.com/ethereum/go-ethereum/p2p/discover/table.go:616
#	0x98b30a	github.com/ethereum/go-ethereum/p2p/discover.(*Table).bondall.func1+0xda	/ext-go/1/src/github.com/ethereum/go-ethereum/p2p/discover/table.go:562
```

The first `16` means that 16 goroutines were found with a similar stack trace.

Here's a [full dump](https://gist.githubusercontent.com/ryanschneider/9c4b16c6779f6cd168230d6ee2913b59/raw/275e85a91f0112d774acf9be4a74e827bced95f0/debug.stacks.log) from a recently started node as well.

Personally, I find the new format very readable, but it is different than the old format, but I think that de-duping is really worthwhile.