### PR TITLE
core: improve getBadBlocks to return full block rlp

### DIFF
--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -1385,34 +1385,16 @@ func (bc *BlockChain) update() {
 	}
 }
 
-// BadBlockArgs represents the entries in the list returned when bad blocks are queried.
-type BadBlockArgs struct {
-	Hash     common.Hash   `json:"hash"`
-	Header   *types.Header `json:"header"`
-	BlockRLP string        `json:"blockrlp"`
-}
-
 // BadBlocks returns a list of the last 'bad blocks' that the client has seen on the network
-func (bc *BlockChain) BadBlocks() ([]BadBlockArgs, error) {
-	blocks := make([]BadBlockArgs, 0, bc.badBlocks.Len())
-	var (
-		err     error
-		rlpData []byte
-	)
+func (bc *BlockChain) BadBlocks() []*types.Block {
+	blocks := make([]*types.Block, 0, bc.badBlocks.Len())
 	for _, hash := range bc.badBlocks.Keys() {
 		if blk, exist := bc.badBlocks.Peek(hash); exist {
 			block := blk.(*types.Block)
-			rlpData, err = rlp.EncodeToBytes(block)
-			if err != nil {
-				break
-			}
-			blocks = append(blocks, BadBlockArgs{
-				Hash:     block.Hash(),
-				Header:   block.Header(),
-				BlockRLP: fmt.Sprintf("%x", rlpData)})
+			blocks = append(blocks, block)
 		}
 	}
-	return blocks, err
+	return blocks
 }
 
 // addBadBlock adds a bad block to the bad-block LRU cache

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -792,10 +792,10 @@ func FormatLogs(logs []vm.StructLog) []StructLogRes {
 	return formatted
 }
 
-// rpcOutputBlock converts the given block to the RPC output which depends on fullTx. If inclTx is true transactions are
+// RpcMarshalBlock converts the given block to the RPC output which depends on fullTx. If inclTx is true transactions are
 // returned. When fullTx is true the returned block contains full transaction details, otherwise it will only contain
 // transaction hashes.
-func (s *PublicBlockChainAPI) rpcOutputBlock(b *types.Block, inclTx bool, fullTx bool) (map[string]interface{}, error) {
+func RpcMarshalBlock(b *types.Block, inclTx bool, fullTx bool) (map[string]interface{}, error) {
 	head := b.Header() // copies the header once
 	fields := map[string]interface{}{
 		"number":           (*hexutil.Big)(head.Number),
@@ -808,7 +808,6 @@ func (s *PublicBlockChainAPI) rpcOutputBlock(b *types.Block, inclTx bool, fullTx
 		"stateRoot":        head.Root,
 		"miner":            head.Coinbase,
 		"difficulty":       (*hexutil.Big)(head.Difficulty),
-		"totalDifficulty":  (*hexutil.Big)(s.b.GetTd(b.Hash())),
 		"extraData":        hexutil.Bytes(head.Extra),
 		"size":             hexutil.Uint64(b.Size()),
 		"gasLimit":         hexutil.Uint64(head.GasLimit),
@@ -822,17 +821,15 @@ func (s *PublicBlockChainAPI) rpcOutputBlock(b *types.Block, inclTx bool, fullTx
 		formatTx := func(tx *types.Transaction) (interface{}, error) {
 			return tx.Hash(), nil
 		}
-
 		if fullTx {
 			formatTx = func(tx *types.Transaction) (interface{}, error) {
 				return newRPCTransactionFromBlockHash(b, tx.Hash()), nil
 			}
 		}
-
 		txs := b.Transactions()
 		transactions := make([]interface{}, len(txs))
 		var err error
-		for i, tx := range b.Transactions() {
+		for i, tx := range txs {
 			if transactions[i], err = formatTx(tx); err != nil {
 				return nil, err
 			}
@@ -848,6 +845,17 @@ func (s *PublicBlockChainAPI) rpcOutputBlock(b *types.Block, inclTx bool, fullTx
 	fields["uncles"] = uncleHashes
 
 	return fields, nil
+}
+
+// rpcOutputBlock uses the generalized output filler, then adds the total difficulty field, which requires
+// a `PublicBlockchainAPI`.
+func (s *PublicBlockChainAPI) rpcOutputBlock(b *types.Block, inclTx bool, fullTx bool) (map[string]interface{}, error) {
+	fields, err := RpcMarshalBlock(b, inclTx, fullTx)
+	if err != nil {
+		return nil, err
+	}
+	fields["totalDifficulty"] = (*hexutil.Big)(s.b.GetTd(b.Hash()))
+	return fields, err
 }
 
 // RPCTransaction represents a transaction that will serialize to the RPC representation of a transaction

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -792,10 +792,10 @@ func FormatLogs(logs []vm.StructLog) []StructLogRes {
 	return formatted
 }
 
-// RpcMarshalBlock converts the given block to the RPC output which depends on fullTx. If inclTx is true transactions are
+// RPCMarshalBlock converts the given block to the RPC output which depends on fullTx. If inclTx is true transactions are
 // returned. When fullTx is true the returned block contains full transaction details, otherwise it will only contain
 // transaction hashes.
-func RpcMarshalBlock(b *types.Block, inclTx bool, fullTx bool) (map[string]interface{}, error) {
+func RPCMarshalBlock(b *types.Block, inclTx bool, fullTx bool) (map[string]interface{}, error) {
 	head := b.Header() // copies the header once
 	fields := map[string]interface{}{
 		"number":           (*hexutil.Big)(head.Number),
@@ -850,7 +850,7 @@ func RpcMarshalBlock(b *types.Block, inclTx bool, fullTx bool) (map[string]inter
 // rpcOutputBlock uses the generalized output filler, then adds the total difficulty field, which requires
 // a `PublicBlockchainAPI`.
 func (s *PublicBlockChainAPI) rpcOutputBlock(b *types.Block, inclTx bool, fullTx bool) (map[string]interface{}, error) {
-	fields, err := RpcMarshalBlock(b, inclTx, fullTx)
+	fields, err := RPCMarshalBlock(b, inclTx, fullTx)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This PR improves bad block reporting by also returning the full `rlp` for bad blocks. 

Example output

```
> debug.getBadBlocks()
[{
    blockrlp: "f9021ff9021aa0ebbe421c854373936f1210583dc23ff12d5678781d4719a75eae7a59bc6a29afa01dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347945088d623ba0fcf0131e0897a91734a4d83596aa0a0ed1908812b8324f32f58869e1013bf2512be16e9db89a62811d021621771c212a056e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421a056e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421b90100000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000008505473271f4820246821388808455ba478ba0476574682f76312e302e302d66633739643332642f6c696e75782f676f312e34a0b8d04bb5819bd0898e7735a8700e2b5fe6f633f0deee48241128923bdfed3db3885fa2d30e23d4a477c0c0",
    hash: "0x513abdfde2fe8a44c6e5bfae0ac2391a89ccd12fb07e82e41c850bce0e1f36ef",
    header: {
      difficulty: "0x5473271f4",
      extraData: "0x476574682f76312e302e302d66633739643332642f6c696e75782f676f312e34",
      gasLimit: "0x1388",
      gasUsed: "0x0",
      hash: "0x513abdfde2fe8a44c6e5bfae0ac2391a89ccd12fb07e82e41c850bce0e1f36ef",
      logsBloom: "0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
      miner: "0x5088d623ba0fcf0131e0897a91734a4d83596aa0",
      mixHash: "0xb8d04bb5819bd0898e7735a8700e2b5fe6f633f0deee48241128923bdfed3db3",
      nonce: "0x5fa2d30e23d4a477",
      number: "0x246",
      parentHash: "0xebbe421c854373936f1210583dc23ff12d5678781d4719a75eae7a59bc6a29af",
      receiptsRoot: "0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421",
      sha3Uncles: "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
      stateRoot: "0xed1908812b8324f32f58869e1013bf2512be16e9db89a62811d021621771c212",
      timestamp: "0x55ba478b",
      transactionsRoot: "0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421"
    }
}, {
    blockrlp: "f9043cf9021aa0513abdfde2fe8a44c6e5bfae0ac2391a89ccd12fb07e82e41c850bce0e1f36efa08f345295423be9a76395ebc10cf69b3b86ce24a67d575cb03dd3abcadd24d7da94dd2f1e6e498202e86d8f5442af596580a4f03c2ca0d02a07b8d9e3414cf1592b224416b15bc73168d27f2576368311bcf16a5f3ab0a056e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421a056e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421b9010000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000850547db5842820247821388808455ba478da0476574682f76312e302e302d30636463373634372f6c696e75782f676f312e34a0764e5b9ba6f5fdd586d2b81bf2f3a770393e2d392f57db3579556b77d052cc9288795a2ebfc3f00542c0f9021bf90218a0a84b1363c1aee8c6af7a61f5967f94f3ca2e5c983c85ba1d9b03c28a679eeb76a01dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d4934794bb7b8287f3f0a933474a79eae42cbca977791171a073de43b3e4abf4895cc471edf9c20474211e75ef4d13a4c2392aef5a41194a8ca056e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421a056e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421b9010000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000850545383d9d820243821388808455ba47869e476574682f4c5649562f76312e302e302f6c696e75782f676f312e342e32a023a6cb95d1e8f9d750cf954d9dbf5a374025422f86d307d1f3980e8e8006923c8851525f4975f66c4e",
    hash: "0xc7107ac61fc11ee5592b50c701bbbfc3f1a4bcc8ce14e8dfb37fad9af9ba713b",
    header: {
      difficulty: "0x547db5842",
      extraData: "0x476574682f76312e302e302d30636463373634372f6c696e75782f676f312e34",
      gasLimit: "0x1388",
      gasUsed: "0x0",
      hash: "0xc7107ac61fc11ee5592b50c701bbbfc3f1a4bcc8ce14e8dfb37fad9af9ba713b",
      logsBloom: "0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
      miner: "0xdd2f1e6e498202e86d8f5442af596580a4f03c2c",
      mixHash: "0x764e5b9ba6f5fdd586d2b81bf2f3a770393e2d392f57db3579556b77d052cc92",
      nonce: "0x795a2ebfc3f00542",
      number: "0x247",
      parentHash: "0x513abdfde2fe8a44c6e5bfae0ac2391a89ccd12fb07e82e41c850bce0e1f36ef",
      receiptsRoot: "0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421",
      sha3Uncles: "0x8f345295423be9a76395ebc10cf69b3b86ce24a67d575cb03dd3abcadd24d7da",
      stateRoot: "0xd02a07b8d9e3414cf1592b224416b15bc73168d27f2576368311bcf16a5f3ab0",
      timestamp: "0x55ba478d",
      transactionsRoot: "0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421"
    }
}, 
...
```
