### PR TITLE
metrics: return an empty snapshot for NilResettingTimer

### DIFF
--- a/metrics/resetting_timer.go
+++ b/metrics/resetting_timer.go
@@ -58,7 +58,11 @@ type NilResettingTimer struct {
 func (NilResettingTimer) Values() []int64 { return nil }
 
 // Snapshot is a no-op.
-func (NilResettingTimer) Snapshot() ResettingTimer { return NilResettingTimer{} }
+func (NilResettingTimer) Snapshot() ResettingTimer {
+	return &ResettingTimerSnapshot{
+		values: []int64{},
+	}
+}
 
 // Time is a no-op.
 func (NilResettingTimer) Time(func()) {}


### PR DESCRIPTION
When starting `geth` without the `--metrics` flag, all resetting timers become `NilResettingTimer`. It is currently returning an incorrect value for its `Snapshot`, which results in a panic if we try to get percentiles out of it.

Steps to reproduce:
1. Start `geth` without `--metrics`
2. Attach to geth with `geth attach`
3. Try to get metrics with `debug.metrics(false)`