### PR TITLE
trie: don't report the root flushlist as an alloc

### DIFF
--- a/trie/database.go
+++ b/trie/database.go
@@ -297,7 +297,7 @@ func (db *Database) Cap(limit common.StorageSize) error {
 	// db.nodesSize only contains the useful data in the cache, but when reporting
 	// the total memory consumption, the maintenance metadata is also needed to be
 	// counted. For every useful node, we track 2 extra hashes as the flushlist.
-	size := db.nodesSize + common.StorageSize(len(db.nodes)*2*common.HashLength)
+	size := db.nodesSize + common.StorageSize((len(db.nodes)-1)*2*common.HashLength)
 
 	// If the preimage cache got large enough, push to disk. If it's still small
 	// leave for later to deduplicate writes.
@@ -512,6 +512,6 @@ func (db *Database) Size() (common.StorageSize, common.StorageSize) {
 	// db.nodesSize only contains the useful data in the cache, but when reporting
 	// the total memory consumption, the maintenance metadata is also needed to be
 	// counted. For every useful node, we track 2 extra hashes as the flushlist.
-	var flushlistSize = common.StorageSize(len(db.nodes) * 2 * common.HashLength)
+	var flushlistSize = common.StorageSize((len(db.nodes) - 1) * 2 * common.HashLength)
 	return db.nodesSize + flushlistSize, db.preimagesSize
 }


### PR DESCRIPTION
Fixes https://github.com/ethereum/go-ethereum/issues/16907.

The trie database (memcache) has a method to retrieve the currently consumed memory. When adding the streaming GC, I modified it so it also reports the size of the doubly-linked flushlist, which we use to flush out old data first.

There was a slight error in this reporting. The trie database has a root node (unkeyed), which acts as the singleton parent for all tries to ensure correct GC. The flushlist size was reported as the number of nodes * 2 hashes. The root node however is a metanode that's never destroyed, so if we count this node too into the flushlist size, the trie database will always report a non-zero size (64 bytes when empty).

This caused the blockchain to always print an `ERROR` log on exit, reporting that GC is faulty due to non-zero memory use after cleanup. The memory use however was only the root metanode. This PR fixes the size reporting so that it doesn't count the metanode any more into this group.