### PR TITLE
Change a log.Error() to log.Warn() to match comments

### DIFF
--- a/core/tx_pool.go
+++ b/core/tx_pool.go
@@ -1111,7 +1111,7 @@ func (pool *TxPool) demoteUnexecutables() {
 		if list.Len() > 0 && list.txs.Get(nonce) == nil {
 			for _, tx := range list.Cap(0) {
 				hash := tx.Hash()
-				log.Error("Demoting invalidated transaction", "hash", hash)
+				log.Warn("Demoting invalidated transaction", "hash", hash)
 				pool.enqueueTx(hash, tx)
 			}
 		}


### PR DESCRIPTION
Alternatively, the comment could be changed to say it is an error rather than a warning.  I'm happy to close this PR and open one that does that if preferred, but the code and comments should be in sync.