### PR TITLE
eth: change comment to match code more closely

### DIFF
--- a/core/tx_pool.go
+++ b/core/tx_pool.go
@@ -1107,7 +1107,7 @@ func (pool *TxPool) demoteUnexecutables() {
 			log.Trace("Demoting pending transaction", "hash", hash)
 			pool.enqueueTx(hash, tx)
 		}
-		// If there's a gap in front, warn (should never happen) and postpone all transactions
+		// If there's a gap in front, alert (should never happen) and postpone all transactions
 		if list.Len() > 0 && list.txs.Get(nonce) == nil {
 			for _, tx := range list.Cap(0) {
 				hash := tx.Hash()


### PR DESCRIPTION
This is the follow up to #16962 (changing the comment instead of the code).