### PR TITLE
internal/web3ext: fix method name for enabling mutex profiling

### DIFF
--- a/internal/web3ext/web3ext.go
+++ b/internal/web3ext/web3ext.go
@@ -313,8 +313,8 @@ web3._extend({
 			params: 2
 		}),
 		new web3._extend.Method({
-			name: 'setMutexProfileRate',
-			call: 'debug_setMutexProfileRate',
+			name: 'setMutexProfileFraction',
+			call: 'debug_setMutexProfileFraction',
 			params: 1
 		}),
 		new web3._extend.Method({


### PR DESCRIPTION
This fixes an issue trying to enable mutex profiling via `geth attach`:

```
> debug.setMutexProfileRate(1)
Error: The method debug_setMutexProfileRate does not exist/is not available
    at web3.js:3143:20
    at web3.js:6347:15
    at web3.js:5081:36
    at <anonymous>:1:1
```

The issue is that the actual Golang function is named `SetMutexProfileFraction` in the `debug` package, so this updates web3ext to match, and works now:

```
> debug.setMutexProfileFraction(1)
null
> debug.setMutexProfileFraction(0)
null
```