### PR TITLE
console/console: correct comments typo

### DIFF
--- a/console/console.go
+++ b/console/console.go
@@ -60,7 +60,7 @@ type Config struct {
 	Preload  []string     // Absolute paths to JavaScript files to preload
 }
 
-// Console is a JavaScript interpreted runtime environment. It is a fully fleged
+// Console is a JavaScript interpreted runtime environment. It is a fully fledged
 // JavaScript console attached to a running node via an external or in-process RPC
 // client.
 type Console struct {


### PR DESCRIPTION
console/console: correct comments typo