### PR TITLE
eth: remove redundant code

### DIFF
--- a/eth/peer.go
+++ b/eth/peer.go
@@ -207,9 +207,6 @@ func (p *peer) SendTransactions(txs types.Transactions) error {
 func (p *peer) AsyncSendTransactions(txs []*types.Transaction) {
 	select {
 	case p.queuedTxs <- txs:
-		for _, tx := range txs {
-			p.knownTxs.Add(tx.Hash())
-		}
 	default:
 		p.Log().Debug("Dropping transaction propagation", "count", len(txs))
 	}
@@ -235,7 +232,6 @@ func (p *peer) SendNewBlockHashes(hashes []common.Hash, numbers []uint64) error 
 func (p *peer) AsyncSendNewBlockHash(block *types.Block) {
 	select {
 	case p.queuedAnns <- block:
-		p.knownBlocks.Add(block.Hash())
 	default:
 		p.Log().Debug("Dropping block announcement", "number", block.NumberU64(), "hash", block.Hash())
 	}
@@ -252,7 +248,6 @@ func (p *peer) SendNewBlock(block *types.Block, td *big.Int) error {
 func (p *peer) AsyncSendNewBlock(block *types.Block, td *big.Int) {
 	select {
 	case p.queuedProps <- &propEvent{block: block, td: td}:
-		p.knownBlocks.Add(block.Hash())
 	default:
 		p.Log().Debug("Dropping block propagation", "number", block.NumberU64(), "hash", block.Hash())
 	}


### PR DESCRIPTION
This PR removes redundant code in file eth/peer.go, the reason is as follows:

When transactions is sent **asynchronously** `peer.AsyncSendTransactions()`, channel `peer.queuedTxs` receives txs in `peer.broadcast()` goroutine as soon as  list of transactions is sent to it, and then executes **sync** function `peer.SendTransactions()`.

I therefore don't think it is necessary to repeatedly add data to the known set in async function.