### PR TITLE
les: handle conn/disc/reg logic in the eventloop

### DIFF
--- a/les/serverpool.go
+++ b/les/serverpool.go
@@ -219,7 +219,7 @@ func (pool *serverPool) disconnect(entry *poolEntry) {
 	log.Debug("Disconnected old entry", "enode", entry.id)
 	req := &disconnReq{entry: entry, stopped: stopped, done: make(chan struct{})}
 
-	// Block until disconnection request be served.
+	// Block until disconnection request is served.
 	pool.disconnCh <- req
 	<-req.done
 }
@@ -384,13 +384,13 @@ func (pool *serverPool) eventLoop() {
 				close(pool.discSetPeriod)
 			}
 
-			// Spawn a goroutine to close the disconnCh until all connections are disconnected.
+			// Spawn a goroutine to close the disconnCh after all connections are disconnected.
 			go func() {
 				pool.connWg.Wait()
 				close(pool.disconnCh)
 			}()
 
-			// Handle all remain disconnection requests before exit.
+			// Handle all remaining disconnection requests before exit.
 			for req := range pool.disconnCh {
 				disconnect(req, true)
 			}


### PR DESCRIPTION
This pr fix #16610 .

Now almost all operations are done in the eventloop, so we can ensure the concurrency safety. But some operations exposed by serverpool (e.g. connect, disconnect, register) are handled in different way, it can introduce concurrency problems.

E.g, like described in the issue, a node is discovered, eventloop will try to update the `newSelect` to schedule a new dial. But in the mean time a peer's registration operation can happen and `knownQueue` is oversize, which can leads to the least recently entry be deleted. So `newSelect` is suffered a concurrency problem.