### PR TITLE
p2p/discv5: add delay to refresh cycle when no seed nodes are found

### DIFF
--- a/p2p/discv5/net.go
+++ b/p2p/discv5/net.go
@@ -678,7 +678,7 @@ func (net *Network) refresh(done chan<- struct{}) {
 	}
 	if len(seeds) == 0 {
 		log.Trace("no seed nodes found")
-		close(done)
+		time.AfterFunc(time.Second*10, func() { close(done) })
 		return
 	}
 	for _, n := range seeds {


### PR DESCRIPTION
Fixes https://github.com/ethereum/go-ethereum/issues/16982
This PR is a quick solution to avoid a CPU-wasting infinite loop when net.refresh does not find any seed nodes.