### PR TITLE
whisper: Fix interpretation of `to` parameter in `shh_requestMessages`

### DIFF
--- a/whisper/mailserver/mailserver.go
+++ b/whisper/mailserver/mailserver.go
@@ -118,7 +118,7 @@ func (s *WMailServer) processRequest(peer *whisper.Peer, lower, upper uint32, bl
 	var err error
 	var zero common.Hash
 	kl := NewDbKey(lower, zero)
-	ku := NewDbKey(upper, zero)
+	ku := NewDbKey(upper+1, zero) // LevelDB is exclusive, while the Whisper API is inclusive
 	i := s.db.NewIterator(&util.Range{Start: kl.raw, Limit: ku.raw}, nil)
 	defer i.Release()
 


### PR DESCRIPTION
The argument is inclusive rather than exclusive, according to [docs](https://github.com/status-im/status-go/wiki/Additional-JSON-RPC-API#shh_requestmessages). Therefore we need to add 1 second to the upper bound value, since the LevelDB API will interpret the upper bound as exclusive.