### PR TITLE
puppeth: Adding verbosity flag

### DIFF
--- a/cmd/puppeth/module_node.go
+++ b/cmd/puppeth/module_node.go
@@ -221,7 +221,7 @@ func checkNode(client *sshClient, network string, boot bool) (*nodeInfos, error)
 
 	// Container available, retrieve its node ID and its genesis json
 	var out []byte
-	if out, err = client.Run(fmt.Sprintf("docker exec %s_%s_1 geth --exec admin.nodeInfo.id attach", network, kind)); err != nil {
+	if out, err = client.Run(fmt.Sprintf("docker exec %s_%s_1 geth --verbosity 0 --exec admin.nodeInfo.id attach", network, kind)); err != nil {
 		return nil, ErrServiceUnreachable
 	}
 	id := bytes.Trim(bytes.TrimSpace(out), "\"")


### PR DESCRIPTION
This change solves issue #16905 by disabling log output when asking for enode address from a deployed node.