### PR TITLE
usbwallet: correct comment typo in ledger.go

### DIFF
--- a/accounts/usbwallet/ledger.go
+++ b/accounts/usbwallet/ledger.go
@@ -302,7 +302,7 @@ func (w *ledgerDriver) ledgerSign(derivationPath []uint32, tx *types.Transaction
 	for i, component := range derivationPath {
 		binary.BigEndian.PutUint32(path[1+4*i:], component)
 	}
-	// Create the transaction RLP based on whether legacy or EIP155 signing was requeste
+	// Create the transaction RLP based on whether legacy or EIP155 signing was requested
 	var (
 		txrlp []byte
 		err   error


### PR DESCRIPTION
Create the transaction RLP based on whether legacy or EIP155 signing was **requeste** ->
Create the transaction RLP based on whether legacy or EIP155 signing was **requested**