### PR TITLE
geth: correct comment typo in geth.go

### DIFF
--- a/mobile/geth.go
+++ b/mobile/geth.go
@@ -193,7 +193,7 @@ func (n *Node) Start() error {
 	return n.node.Start()
 }
 
-// Stop terminates a running node along with all it's services. In the node was
+// Stop terminates a running node along with all it's services. If the node was
 // not started, an error is returned.
 func (n *Node) Stop() error {
 	return n.node.Stop()


### PR DESCRIPTION
**In** the node was not started, an error is returned -> **If** the node was not started, an error is returned