### PR TITLE
remove the tail "," from genesis config

### DIFF
--- a/cmd/geth/genesis_test.go
+++ b/cmd/geth/genesis_test.go
@@ -77,7 +77,7 @@ var customGenesisTests = []struct {
 				"homesteadBlock" : 314,
 				"daoForkBlock"   : 141,
 				"daoForkSupport" : true
-			},
+			}
 		}`,
 		query:  "eth.getBlock(0).nonce",
 		result: "0x0000000000000042",


### PR DESCRIPTION
cmd/geth: remove the tail "," from genesis config,  which will cause genesis config parse error .