### PR TITLE
les: add announcement safety check to light fetcher

### DIFF
--- a/les/fetcher.go
+++ b/les/fetcher.go
@@ -267,9 +267,16 @@ func (f *lightFetcher) announce(p *peer, head *announceData) {
 		}
 		n = n.parent
 	}
+	// n is now the reorg common ancestor, add a new branch of nodes
+	if n != nil && (head.Number >= n.number+maxNodeCount || head.Number <= n.number) {
+		// if announced head block height is lower or same as n or too far from it to add
+		// intermediate nodes then discard previous announcement info and trigger a resync
+		n = nil
+		fp.nodeCnt = 0
+		fp.nodeByHash = make(map[common.Hash]*fetcherTreeNode)
+	}
 	if n != nil {
-		// n is now the reorg common ancestor, add a new branch of nodes
-		// check if the node count is too high to add new nodes
+		// check if the node count is too high to add new nodes, discard oldest ones if necessary
 		locked := false
 		for uint64(fp.nodeCnt)+head.Number-n.number > maxNodeCount && fp.root != nil {
 			if !locked {


### PR DESCRIPTION
This PR adds a missing check to the block announcement handler routine of the light fetcher which avoids building too long fetcherTreeNode chains. Now the number of fetcherTreeNodes is always limited at maxNodeCount. If the existing tree structure can not be extended based on the new announcement then it is discarded and a resync is triggered.