### PR TITLE
reducing from Warn to Info on "message loop" logs

### DIFF
--- a/whisper/whisperv5/whisper.go
+++ b/whisper/whisperv5/whisper.go
@@ -499,7 +499,7 @@ func (w *Whisper) runMessageLoop(p *Peer, rw p2p.MsgReadWriter) error {
 		// fetch the next packet
 		packet, err := rw.ReadMsg()
 		if err != nil {
-			log.Warn("message loop", "peer", p.peer.ID(), "err", err)
+			log.Info("message loop", "peer", p.peer.ID(), "err", err)
 			return err
 		}
 		if packet.Size > w.MaxMessageSize() {

--- a/whisper/whisperv6/whisper.go
+++ b/whisper/whisperv6/whisper.go
@@ -650,7 +650,7 @@ func (whisper *Whisper) runMessageLoop(p *Peer, rw p2p.MsgReadWriter) error {
 		// fetch the next packet
 		packet, err := rw.ReadMsg()
 		if err != nil {
-			log.Warn("message loop", "peer", p.peer.ID(), "err", err)
+			log.Info("message loop", "peer", p.peer.ID(), "err", err)
 			return err
 		}
 		if packet.Size > whisper.MaxMessageSize() {


### PR DESCRIPTION
Logs are full of Warning messages like this:
```
message loop                             peer=4e0a8db9b73403c9 err=EOF
```
This message happens when a peer gets disconnected. If that is indeed the case then why is it a warning? Seems like part of regular operations of this software, so at most it could be an info level message.

### Implementation

Reduced from Warn to Info the level of "message loop" logs.