### PR TITLE
Put debug state capture before memory resize to capture pre-execution

### DIFF
--- a/core/vm/interpreter.go
+++ b/core/vm/interpreter.go
@@ -189,13 +189,14 @@ func (in *Interpreter) Run(contract *Contract, input []byte) (ret []byte, err er
 		if err != nil || !contract.UseGas(cost) {
 			return nil, ErrOutOfGas
 		}
-		if memorySize > 0 {
-			mem.Resize(memorySize)
-		}
 
 		if in.cfg.Debug {
 			in.cfg.Tracer.CaptureState(in.evm, pc, op, gasCopy, cost, mem, stack, contract, in.evm.depth, err)
 			logged = true
+		}
+
+		if memorySize > 0 {
+			mem.Resize(memorySize)
 		}
 
 		// execute the operation


### PR DESCRIPTION
`in.cfg.Tracer.CaptureState` is intended to capture pre-execution state, we have a copy of gas for it and run it before vm execution. However memory resize is currently called before and user is getting extended memory in VM Trace which could confuse. I've tried to fix it by swapping call order.