### PR TITLE
swarm/fuse: Disable fuse tests, they are flaky

### DIFF
--- a/swarm/fuse/swarmfs_test.go
+++ b/swarm/fuse/swarmfs_test.go
@@ -1637,6 +1637,7 @@ func (ta *testAPI) appendFileContentsToEnd(t *testing.T, toEncrypt bool) {
 
 //run all the tests
 func TestFUSE(t *testing.T) {
+	t.Skip("disable fuse tests until they are stable")
 	//create a data directory for swarm
 	datadir, err := ioutil.TempDir("", "fuse")
 	if err != nil {


### PR DESCRIPTION
Fuse tests sometimes stall and hung the tests on travis. It seemed to be fixed, but it actually happens, e.g.: https://travis-ci.org/ethereum/go-ethereum/jobs/395633091

Let's disable these tests until they are properly fixed, so Travis can remain green