### PR TITLE
vendor: update docker/docker/pkg/reexec so that it compiles on OpenBSD

### DIFF
--- a/vendor/github.com/docker/docker/pkg/reexec/command_linux.go
+++ b/vendor/github.com/docker/docker/pkg/reexec/command_linux.go
@@ -1,10 +1,10 @@
-// +build linux
-
-package reexec
+package reexec // import "github.com/docker/docker/pkg/reexec"
 
 import (
 	"os/exec"
 	"syscall"
+
+	"golang.org/x/sys/unix"
 )
 
 // Self returns the path to the current process's binary.
@@ -22,7 +22,7 @@ func Command(args ...string) *exec.Cmd {
 		Path: Self(),
 		Args: args,
 		SysProcAttr: &syscall.SysProcAttr{
-			Pdeathsig: syscall.SIGTERM,
+			Pdeathsig: unix.SIGTERM,
 		},
 	}
 }

--- a/vendor/github.com/docker/docker/pkg/reexec/command_unix.go
+++ b/vendor/github.com/docker/docker/pkg/reexec/command_unix.go
@@ -1,6 +1,6 @@
-// +build freebsd solaris darwin
+// +build freebsd darwin
 
-package reexec
+package reexec // import "github.com/docker/docker/pkg/reexec"
 
 import (
 	"os/exec"

--- a/vendor/github.com/docker/docker/pkg/reexec/command_unsupported.go
+++ b/vendor/github.com/docker/docker/pkg/reexec/command_unsupported.go
@@ -1,12 +1,16 @@
-// +build !linux,!windows,!freebsd,!solaris,!darwin
+// +build !linux,!windows,!freebsd,!darwin
 
-package reexec
+package reexec // import "github.com/docker/docker/pkg/reexec"
 
 import (
 	"os/exec"
 )
 
-// Command is unsupported on operating systems apart from Linux, Windows, Solaris and Darwin.
+func Self() string {
+	return ""
+}
+
+// Command is unsupported on operating systems apart from Linux, Windows, and Darwin.
 func Command(args ...string) *exec.Cmd {
 	return nil
 }

--- a/vendor/github.com/docker/docker/pkg/reexec/command_windows.go
+++ b/vendor/github.com/docker/docker/pkg/reexec/command_windows.go
@@ -1,6 +1,4 @@
-// +build windows
-
-package reexec
+package reexec // import "github.com/docker/docker/pkg/reexec"
 
 import (
 	"os/exec"

--- a/vendor/github.com/docker/docker/pkg/reexec/reexec.go
+++ b/vendor/github.com/docker/docker/pkg/reexec/reexec.go
@@ -1,4 +1,4 @@
-package reexec
+package reexec // import "github.com/docker/docker/pkg/reexec"
 
 import (
 	"fmt"

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -81,10 +81,10 @@
 			"revisionTime": "2017-02-01T22:58:49Z"
 		},
 		{
-			"checksumSHA1": "lutCa+IVM60R1OYBm9RtDAW50Ys=",
+			"checksumSHA1": "Ad8LPSCP9HctFrmskh+S5HpHXcs=",
 			"path": "github.com/docker/docker/pkg/reexec",
-			"revision": "83ee902ecc3790c33c1e2d87334074436056bb49",
-			"revisionTime": "2017-04-22T21:51:12Z"
+			"revision": "8e610b2b55bfd1bfa9436ab110d311f5e8a74dcb",
+			"revisionTime": "2018-06-25T18:44:42Z"
 		},
 		{
 			"checksumSHA1": "zYnPsNAVm1/ViwCkN++dX2JQhBo=",


### PR DESCRIPTION
Hi,

another vendor update is required to build all tools on OpenBSD. This PR updates
docker/docker/pkg/reexec so that it includes https://github.com/moby/moby/commit/21537b818de5e4167c5a3856c25b9b06cf16d87d .

See also https://github.com/moby/moby/pull/37301 .

Cheers,
Fabian

CC: @qbit