### PR TITLE
rpc: bump HTTP server timeouts

### DIFF
--- a/rpc/http.go
+++ b/rpc/http.go
@@ -167,8 +167,8 @@ func NewHTTPServer(cors []string, vhosts []string, srv *Server) *http.Server {
 	handler = newVHostHandler(vhosts, handler)
 	return &http.Server{
 		Handler:      handler,
-		ReadTimeout:  5 * time.Second,
-		WriteTimeout: 10 * time.Second,
+		ReadTimeout:  60 * time.Second,
+		WriteTimeout: 60 * time.Second,
 		IdleTimeout:  120 * time.Second,
 	}
 }


### PR DESCRIPTION
Client connection fails by "Invalid JSON".
Timeout is too short.