### PR TITLE
remove formatting from ResettingTimer metrics if requested in raw format

### DIFF
--- a/node/api.go
+++ b/node/api.go
@@ -343,13 +343,13 @@ func (api *PublicDebugAPI) Metrics(raw bool) (map[string]interface{}, error) {
 				ps := t.Percentiles([]float64{5, 20, 50, 80, 95})
 				root[name] = map[string]interface{}{
 					"Measurements": len(t.Values()),
-					"Mean":         time.Duration(t.Mean()).String(),
+					"Mean":         t.Mean(),
 					"Percentiles": map[string]interface{}{
-						"5":  time.Duration(ps[0]).String(),
-						"20": time.Duration(ps[1]).String(),
-						"50": time.Duration(ps[2]).String(),
-						"80": time.Duration(ps[3]).String(),
-						"95": time.Duration(ps[4]).String(),
+						"5":  ps[0],
+						"20": ps[1],
+						"50": ps[2],
+						"80": ps[3],
+						"95": ps[4],
 					},
 				}
 


### PR DESCRIPTION
`metrics.ResettingTimer` are always formatted as strings even when `debug_metrics` is called passing `true`, which is used to get raw metrics.
In this PR I removed the formatting of `metrics.ResettingTimer` metrics if `raw` is `true`.

here an example, we can look at `trie.memcache.flush.time` metrics, that have the final `s`:
```
> debug.metrics(true).trie.memcache.flush
{
  nodes: {
    AvgRate01Min: 0,
    AvgRate05Min: 0,
    AvgRate15Min: 0,
    MeanRate: 0,
    Overall: 0
  },
  size: {
    AvgRate01Min: 0,
    AvgRate05Min: 0,
    AvgRate15Min: 0,
    MeanRate: 0,
    Overall: 0
  },
  time: {
    Mean: "0s",
    Measurements: 0,
    Percentiles: {
      20: "0s",
      5: "0s",
      50: "0s",
      80: "0s",
      95: "0s"
    }
  }
}
``` 

on this branch:

```
> debug.metrics(true).trie.memcache.flush
{
  nodes: {
    AvgRate01Min: 0,
    AvgRate05Min: 0,
    AvgRate15Min: 0,
    MeanRate: 0,
    Overall: 0
  },
  size: {
    AvgRate01Min: 0,
    AvgRate05Min: 0,
    AvgRate15Min: 0,
    MeanRate: 0,
    Overall: 0
  },
  time: {
    Mean: 0,
    Measurements: 0,
    Percentiles: {
      20: 0,
      5: 0,
      50: 0,
      80: 0,
      95: 0
    }
  }
}
```