### PR TITLE
Fix method overwritten by same name methods.

### DIFF
--- a/accounts/abi/abi.go
+++ b/accounts/abi/abi.go
@@ -21,6 +21,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"strconv"
 )
 
 // The ABI holds information about a contract's context and available
@@ -108,6 +109,7 @@ func (abi *ABI) UnmarshalJSON(data []byte) error {
 
 	abi.Methods = make(map[string]Method)
 	abi.Events = make(map[string]Event)
+	functionCnt, eventCnt := 0, 0
 	for _, field := range fields {
 		switch field.Type {
 		case "constructor":
@@ -122,12 +124,16 @@ func (abi *ABI) UnmarshalJSON(data []byte) error {
 				Inputs:  field.Inputs,
 				Outputs: field.Outputs,
 			}
+			abi.Methods[field.Name+strconv.Itoa(functionCnt)] = abi.Methods[field.Name]
+			functionCnt++
 		case "event":
 			abi.Events[field.Name] = Event{
 				Name:      field.Name,
 				Anonymous: field.Anonymous,
 				Inputs:    field.Inputs,
 			}
+			abi.Events[field.Name+strconv.Itoa(eventCnt)] = abi.Events[field.Name]
+			eventCnt++
 		}
 	}
 

--- a/build/goimports.sh
+++ b/build/goimports.sh
@@ -1,18 +1,18 @@
-#!/usr/bin/env bash
+#!/bin/sh
 
 find_files() {
-  find . -not \( \
+  find . ! \( \
       \( \
-        -wholename '.github' \
-        -o -wholename './build/_workspace' \
-        -o -wholename './build/bin' \
-        -o -wholename './crypto/bn256' \
-        -o -wholename '*/vendor/*' \
+        -path '.github' \
+        -o -path './build/_workspace' \
+        -o -path './build/bin' \
+        -o -path './crypto/bn256' \
+        -o -path '*/vendor/*' \
       \) -prune \
     \) -name '*.go'
 }
 
-GOFMT="gofmt -s -w";
-GOIMPORTS="goimports -w";
-find_files | xargs $GOFMT;
-find_files | xargs $GOIMPORTS;
+GOFMT="gofmt -s -w"
+GOIMPORTS="goimports -w"
+find_files | xargs $GOFMT
+find_files | xargs $GOIMPORTS


### PR DESCRIPTION
I'm writing a test tool for Ethereum smart contract based on go-ethereum. 
When I use `abi.JSON(reader)` I can just get the last overloaded function/method because the implementation in `abi.UnmarshalJSON(data)` uses the Go map to store `Method` that will overwrite the previous method.