### PR TITLE
accounts/abi: Fix method overwritten by same name methods.

### DIFF
--- a/accounts/abi/abi.go
+++ b/accounts/abi/abi.go
@@ -138,21 +138,27 @@ func (abi *ABI) UnmarshalJSON(data []byte) error {
 			}
 		// empty defaults to function according to the abi spec
 		case "function", "":
+			_, ok := abi.Methods[field.Name]
+			if ok {
+				abi.Methods[field.Name+strconv.Itoa(functionCnt)] = abi.Methods[field.Name]
+			}
 			abi.Methods[field.Name] = Method{
 				Name:    field.Name,
 				Const:   field.Constant,
 				Inputs:  field.Inputs,
 				Outputs: field.Outputs,
 			}
-			abi.Methods[field.Name+strconv.Itoa(functionCnt)] = abi.Methods[field.Name]
 			functionCnt++
 		case "event":
+			_, ok := abi.Events[field.Name]
+			if ok {
+				abi.Events[field.Name+strconv.Itoa(eventCnt)] = abi.Events[field.Name]
+			}
 			abi.Events[field.Name] = Event{
 				Name:      field.Name,
 				Anonymous: field.Anonymous,
 				Inputs:    field.Inputs,
 			}
-			abi.Events[field.Name+strconv.Itoa(eventCnt)] = abi.Events[field.Name]
 			eventCnt++
 		}
 	}

--- a/accounts/abi/abi.go
+++ b/accounts/abi/abi.go
@@ -21,6 +21,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"strconv"
 
 	"github.com/ethereum/go-ethereum/common"
 )
@@ -128,6 +129,7 @@ func (abi *ABI) UnmarshalJSON(data []byte) error {
 
 	abi.Methods = make(map[string]Method)
 	abi.Events = make(map[string]Event)
+	functionCnt, eventCnt := 0, 0
 	for _, field := range fields {
 		switch field.Type {
 		case "constructor":
@@ -142,12 +144,16 @@ func (abi *ABI) UnmarshalJSON(data []byte) error {
 				Inputs:  field.Inputs,
 				Outputs: field.Outputs,
 			}
+			abi.Methods[field.Name+strconv.Itoa(functionCnt)] = abi.Methods[field.Name]
+			functionCnt++
 		case "event":
 			abi.Events[field.Name] = Event{
 				Name:      field.Name,
 				Anonymous: field.Anonymous,
 				Inputs:    field.Inputs,
 			}
+			abi.Events[field.Name+strconv.Itoa(eventCnt)] = abi.Events[field.Name]
+			eventCnt++
 		}
 	}
 

--- a/accounts/abi/abi.go
+++ b/accounts/abi/abi.go
@@ -21,7 +21,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"strconv"
 
 	"github.com/ethereum/go-ethereum/common"
 )
@@ -129,7 +128,6 @@ func (abi *ABI) UnmarshalJSON(data []byte) error {
 
 	abi.Methods = make(map[string]Method)
 	abi.Events = make(map[string]Event)
-	functionCnt, eventCnt := 0, 0
 	for _, field := range fields {
 		switch field.Type {
 		case "constructor":
@@ -138,28 +136,30 @@ func (abi *ABI) UnmarshalJSON(data []byte) error {
 			}
 		// empty defaults to function according to the abi spec
 		case "function", "":
-			_, ok := abi.Methods[field.Name]
-			if ok {
-				abi.Methods[field.Name+strconv.Itoa(functionCnt)] = abi.Methods[field.Name]
+			name := field.Name
+			_, ok := abi.Methods[name]
+			for idx := 0; ok; idx++ {
+				name = fmt.Sprintf("%s%d", field.Name, idx)
+				_, ok = abi.Methods[name]
 			}
-			abi.Methods[field.Name] = Method{
-				Name:    field.Name,
+			abi.Methods[name] = Method{
+				Name:    name,
 				Const:   field.Constant,
 				Inputs:  field.Inputs,
 				Outputs: field.Outputs,
 			}
-			functionCnt++
 		case "event":
-			_, ok := abi.Events[field.Name]
-			if ok {
-				abi.Events[field.Name+strconv.Itoa(eventCnt)] = abi.Events[field.Name]
+			name := field.Name
+			_, ok := abi.Events[name]
+			for idx := 0; ok; idx++ {
+				name = fmt.Sprintf("%s%d", field.Name, idx)
+				_, ok = abi.Events[name]
 			}
-			abi.Events[field.Name] = Event{
-				Name:      field.Name,
+			abi.Events[name] = Event{
+				Name:      name,
 				Anonymous: field.Anonymous,
 				Inputs:    field.Inputs,
 			}
-			eventCnt++
 		}
 	}
 

--- a/accounts/abi/bind/base_test.go
+++ b/accounts/abi/bind/base_test.go
@@ -345,29 +345,3 @@ func TestUnpackIndexedBytesTyLogIntoMap(t *testing.T) {
 		t.Error("unpacked map does not match expected map")
 	}
 }
-
-func TestUnpackIntoMapNamingConflict(t *testing.T) {
-	hash := crypto.Keccak256Hash([]byte("testName"))
-	mockLog := types.Log{
-		Address: common.HexToAddress("0x0"),
-		Topics: []common.Hash{
-			common.HexToHash("0x0"),
-			hash,
-		},
-		Data:        hexutil.MustDecode(hexData),
-		BlockNumber: uint64(26),
-		TxHash:      common.HexToHash("0x0"),
-		TxIndex:     111,
-		BlockHash:   common.BytesToHash([]byte{1, 2, 3, 4, 5}),
-		Index:       7,
-		Removed:     false,
-	}
-
-	abiString := `[{"anonymous":false,"inputs":[{"indexed":true,"name":"name","type":"string"},{"indexed":false,"name":"sender","type":"address"},{"indexed":false,"name":"amount","type":"uint256"},{"indexed":false,"name":"memo","type":"bytes"}],"name":"received","type":"event"},{"anonymous":false,"inputs":[{"indexed":false,"name":"sender","type":"address"}],"name":"received","type":"event"}]`
-	parsedAbi, _ := abi.JSON(strings.NewReader(abiString))
-	bc := bind.NewBoundContract(common.HexToAddress("0x0"), parsedAbi, nil, nil, nil)
-	receivedMap := make(map[string]interface{})
-	if err := bc.UnpackLogIntoMap(receivedMap, "received", mockLog); err == nil {
-		t.Error("naming conflict between two events; error expected")
-	}
-}


### PR DESCRIPTION
I'm writing a test tool for Ethereum smart contract based on go-ethereum. 
The implementation in `abi.UnmarshaIJSON(data)` uses the Go map to store Method, which will overwrite the previous method.
Thus, when use it, I can only get the last overloaded function/method and event.