### PR TITLE
trie: fix a temporary memory leak in the memcache

### DIFF
--- a/trie/database.go
+++ b/trie/database.go
@@ -466,7 +466,13 @@ func (db *Database) dereference(child common.Hash, parent common.Hash) {
 		return
 	}
 	// If there are no more references to the child, delete it and cascade
-	node.parents--
+	if node.parents > 0 {
+		// This is a special cornercase where a node loaded from disk (i.e. not in the
+		// memcache any more) gets reinjected as a new node (short node split into full,
+		// then reverted into short), causing a cached node to have no parents. That is
+		// no problem in itself, but don't make maxint parents out of it.
+		node.parents--
+	}
 	if node.parents == 0 {
 		// Remove the node from the flush-list
 		if child == db.oldest {
@@ -716,4 +722,46 @@ func (db *Database) Size() (common.StorageSize, common.StorageSize) {
 	// counted. For every useful node, we track 2 extra hashes as the flushlist.
 	var flushlistSize = common.StorageSize((len(db.nodes) - 1) * 2 * common.HashLength)
 	return db.nodesSize + flushlistSize, db.preimagesSize
+}
+
+// verifyIntegrity is a debug method to iterate over the entire trie stored in
+// memory and check whether every node is reachable from the meta root. The goal
+// is to find any errors that might cause memory leaks and or trie nodes to go
+// missing.
+//
+// This method is extremely CPU and memory intensive, only use when must.
+func (db *Database) verifyIntegrity() {
+	// Iterate over all the cached nodes and accumulate them into a set
+	reachable := map[common.Hash]struct{}{{}: {}}
+
+	for child := range db.nodes[common.Hash{}].children {
+		db.accumulate(child, reachable)
+	}
+	// Find any unreachable but cached nodes
+	unreachable := []string{}
+	for hash, node := range db.nodes {
+		if _, ok := reachable[hash]; !ok {
+			unreachable = append(unreachable, fmt.Sprintf("%x: {Node: %v, Parents: %d, Prev: %x, Next: %x}",
+				hash, node.node, node.parents, node.flushPrev, node.flushNext))
+		}
+	}
+	if len(unreachable) != 0 {
+		panic(fmt.Sprintf("trie cache memory leak: %v", unreachable))
+	}
+}
+
+// accumulate iterates over the trie defined by hash and accumulates all the
+// cached children found in memory.
+func (db *Database) accumulate(hash common.Hash, reachable map[common.Hash]struct{}) {
+	// Mark the node reachable if present in the memory cache
+	node, ok := db.nodes[hash]
+	if !ok {
+		return
+	}
+	reachable[hash] = struct{}{}
+
+	// Iterate over all the children and accumulate them too
+	for _, child := range node.childs() {
+		db.accumulate(child, reachable)
+	}
 }


### PR DESCRIPTION
This PR is a 3 liner fix. The rest is just a repro/verification.

We've received from time to time reports that Geth closes with `ERROR[...] Dangling trie nodes after full cleanup`. We've been hacking on the memcache for quite a lot, so I'm unsure if the old issues are the same as the one this PR fixes, but this one addesses specifically an issue where certain nodes remain in the memory cache even though they have no more references left.

The issue happens when a trie node exists on disk (never loaded or already committed), and it's recreated by the trie again (short node split into full, and them merged back into short). This will cause the node to be inserted into the memcache, with a potentially invalid parent count (0). Dereferencing this trie node form memory will first overflow its counter to MAXINT, thus never cleaning it out.

The node still remains part of the flush-list, so it will eventually be pushed out to disk, but in the mean time it's a dangling node. The PR fixes it by adding an explicit check for the 0-parent case.