### PR TITLE
cmd/p2psim: add exit error output and exit code

### DIFF
--- a/cmd/p2psim/main.go
+++ b/cmd/p2psim/main.go
@@ -180,7 +180,10 @@ func main() {
 			},
 		},
 	}
-	app.Run(os.Args)
+	if err := app.Run(os.Args); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
 }
 
 func showNetwork(ctx *cli.Context) error {


### PR DESCRIPTION
fix cmd/p2psim error exit output