### PR TITLE
cmd/evm: change error msg output to stderr

### DIFF
--- a/cmd/evm/compiler.go
+++ b/cmd/evm/compiler.go
@@ -50,6 +50,6 @@ func compileCmd(ctx *cli.Context) error {
 	if err != nil {
 		return err
 	}
-	fmt.Println(bin)
+	fmt.Fprintln(ctx.App.Writer, bin)
 	return nil
 }

--- a/cmd/evm/disasm.go
+++ b/cmd/evm/disasm.go
@@ -45,6 +45,6 @@ func disasmCmd(ctx *cli.Context) error {
 	}
 
 	code := strings.TrimSpace(string(in[:]))
-	fmt.Printf("%v\n", code)
+	fmt.Fprintf(ctx.App.Writer,"%v\n", code)
 	return asm.PrintDisassembled(code)
 }

--- a/cmd/evm/disasm.go
+++ b/cmd/evm/disasm.go
@@ -45,6 +45,6 @@ func disasmCmd(ctx *cli.Context) error {
 	}
 
 	code := strings.TrimSpace(string(in[:]))
-	fmt.Fprintf(ctx.App.Writer,"%v\n", code)
+	fmt.Fprintf(ctx.App.Writer, "%v\n", code)
 	return asm.PrintDisassembled(code)
 }

--- a/cmd/evm/internal/compiler/compiler.go
+++ b/cmd/evm/internal/compiler/compiler.go
@@ -30,10 +30,11 @@ func Compile(fn string, src []byte, debug bool) (string, error) {
 	bin, compileErrors := compiler.Compile()
 	if len(compileErrors) > 0 {
 		// report errors
+		errs := ""
 		for _, err := range compileErrors {
-			fmt.Printf("%s:%v\n", fn, err)
+			errs += fmt.Sprintf("%s:%v\n", fn, err)
 		}
-		return "", errors.New("compiling failed")
+		return "", errors.New(errs + "compiling failed\n")
 	}
 	return bin, nil
 }

--- a/cmd/evm/runner.go
+++ b/cmd/evm/runner.go
@@ -128,13 +128,13 @@ func runCmd(ctx *cli.Context) error {
 		if ctx.GlobalString(CodeFileFlag.Name) == "-" {
 			//Try reading from stdin
 			if hexcode, err = ioutil.ReadAll(os.Stdin); err != nil {
-				fmt.Fprintf(ctx.App.ErrWriter,"Could not load code from stdin: %v\n", err)
+				fmt.Fprintf(ctx.App.ErrWriter, "Could not load code from stdin: %v\n", err)
 				os.Exit(1)
 			}
 		} else {
 			// Codefile with hex assembly
 			if hexcode, err = ioutil.ReadFile(ctx.GlobalString(CodeFileFlag.Name)); err != nil {
-				fmt.Fprintf(ctx.App.ErrWriter,"Could not load code from file: %v\n", err)
+				fmt.Fprintf(ctx.App.ErrWriter, "Could not load code from file: %v\n", err)
 				os.Exit(1)
 			}
 		}
@@ -172,11 +172,11 @@ func runCmd(ctx *cli.Context) error {
 	if cpuProfilePath := ctx.GlobalString(CPUProfileFlag.Name); cpuProfilePath != "" {
 		f, err := os.Create(cpuProfilePath)
 		if err != nil {
-			fmt.Fprintf(ctx.App.ErrWriter,"could not create CPU profile: %v\n", err)
+			fmt.Fprintf(ctx.App.ErrWriter, "could not create CPU profile: %v\n", err)
 			os.Exit(1)
 		}
 		if err := pprof.StartCPUProfile(f); err != nil {
-			fmt.Fprintf(ctx.App.ErrWriter,"could not start CPU profile: %v\n", err)
+			fmt.Fprintf(ctx.App.ErrWriter, "could not start CPU profile: %v\n", err)
 			os.Exit(1)
 		}
 		defer pprof.StopCPUProfile()
@@ -206,11 +206,11 @@ func runCmd(ctx *cli.Context) error {
 	if memProfilePath := ctx.GlobalString(MemProfileFlag.Name); memProfilePath != "" {
 		f, err := os.Create(memProfilePath)
 		if err != nil {
-			fmt.Fprintln(ctx.App.ErrWriter,"could not create memory profile: %v\n", err)
+			fmt.Fprintf(ctx.App.ErrWriter, "could not create memory profile: %v\n", err)
 			os.Exit(1)
 		}
 		if err := pprof.WriteHeapProfile(f); err != nil {
-			fmt.Fprintln(ctx.App.ErrWriter,"could not create memory profile: %v\n", err)
+			fmt.Fprintf(ctx.App.ErrWriter, "could not create memory profile: %v\n", err)
 			os.Exit(1)
 		}
 		f.Close()

--- a/cmd/evm/runner.go
+++ b/cmd/evm/runner.go
@@ -128,13 +128,13 @@ func runCmd(ctx *cli.Context) error {
 		if ctx.GlobalString(CodeFileFlag.Name) == "-" {
 			//Try reading from stdin
 			if hexcode, err = ioutil.ReadAll(os.Stdin); err != nil {
-				fmt.Printf("Could not load code from stdin: %v\n", err)
+				fmt.Fprintf(ctx.App.ErrWriter,"Could not load code from stdin: %v\n", err)
 				os.Exit(1)
 			}
 		} else {
 			// Codefile with hex assembly
 			if hexcode, err = ioutil.ReadFile(ctx.GlobalString(CodeFileFlag.Name)); err != nil {
-				fmt.Printf("Could not load code from file: %v\n", err)
+				fmt.Fprintf(ctx.App.ErrWriter,"Could not load code from file: %v\n", err)
 				os.Exit(1)
 			}
 		}
@@ -172,11 +172,11 @@ func runCmd(ctx *cli.Context) error {
 	if cpuProfilePath := ctx.GlobalString(CPUProfileFlag.Name); cpuProfilePath != "" {
 		f, err := os.Create(cpuProfilePath)
 		if err != nil {
-			fmt.Println("could not create CPU profile: ", err)
+			fmt.Fprintf(ctx.App.ErrWriter,"could not create CPU profile: %v\n", err)
 			os.Exit(1)
 		}
 		if err := pprof.StartCPUProfile(f); err != nil {
-			fmt.Println("could not start CPU profile: ", err)
+			fmt.Fprintf(ctx.App.ErrWriter,"could not start CPU profile: %v\n", err)
 			os.Exit(1)
 		}
 		defer pprof.StopCPUProfile()
@@ -200,17 +200,17 @@ func runCmd(ctx *cli.Context) error {
 
 	if ctx.GlobalBool(DumpFlag.Name) {
 		statedb.IntermediateRoot(true)
-		fmt.Println(string(statedb.Dump()))
+		fmt.Fprintln(ctx.App.Writer, string(statedb.Dump()))
 	}
 
 	if memProfilePath := ctx.GlobalString(MemProfileFlag.Name); memProfilePath != "" {
 		f, err := os.Create(memProfilePath)
 		if err != nil {
-			fmt.Println("could not create memory profile: ", err)
+			fmt.Fprintln(ctx.App.ErrWriter,"could not create memory profile: %v\n", err)
 			os.Exit(1)
 		}
 		if err := pprof.WriteHeapProfile(f); err != nil {
-			fmt.Println("could not write memory profile: ", err)
+			fmt.Fprintln(ctx.App.ErrWriter,"could not create memory profile: %v\n", err)
 			os.Exit(1)
 		}
 		f.Close()
@@ -218,17 +218,17 @@ func runCmd(ctx *cli.Context) error {
 
 	if ctx.GlobalBool(DebugFlag.Name) {
 		if debugLogger != nil {
-			fmt.Fprintln(os.Stderr, "#### TRACE ####")
-			vm.WriteTrace(os.Stderr, debugLogger.StructLogs())
+			fmt.Fprintln(ctx.App.ErrWriter, "#### TRACE ####")
+			vm.WriteTrace(ctx.App.ErrWriter, debugLogger.StructLogs())
 		}
-		fmt.Fprintln(os.Stderr, "#### LOGS ####")
-		vm.WriteLogs(os.Stderr, statedb.Logs())
+		fmt.Fprintln(ctx.App.ErrWriter, "#### LOGS ####")
+		vm.WriteLogs(ctx.App.ErrWriter, statedb.Logs())
 	}
 
 	if ctx.GlobalBool(StatDumpFlag.Name) {
 		var mem goruntime.MemStats
 		goruntime.ReadMemStats(&mem)
-		fmt.Fprintf(os.Stderr, `evm execution time: %v
+		fmt.Fprintf(ctx.App.ErrWriter, `evm execution time: %v
 heap objects:       %d
 allocations:        %d
 total allocations:  %d
@@ -238,9 +238,9 @@ Gas used:           %d
 `, execTime, mem.HeapObjects, mem.Alloc, mem.TotalAlloc, mem.NumGC, initialGas-leftOverGas)
 	}
 	if tracer == nil {
-		fmt.Printf("0x%x\n", ret)
+		fmt.Fprintf(ctx.App.Writer, "0x%x\n", ret)
 		if err != nil {
-			fmt.Printf(" error: %v\n", err)
+			fmt.Fprintf(ctx.App.ErrWriter, " error: %v\n", err)
 		}
 	}
 

--- a/cmd/evm/staterunner.go
+++ b/cmd/evm/staterunner.go
@@ -107,7 +107,7 @@ func stateTestCmd(ctx *cli.Context) error {
 			}
 			// print state root for evmlab tracing (already committed above, so no need to delete objects again
 			if ctx.GlobalBool(MachineFlag.Name) && state != nil {
-				fmt.Fprintf(os.Stderr, "{\"stateRoot\": \"%x\"}\n", state.IntermediateRoot(false))
+				fmt.Fprintf(ctx.App.ErrWriter, "{\"stateRoot\": \"%x\"}\n", state.IntermediateRoot(false))
 			}
 
 			results = append(results, *result)
@@ -115,13 +115,13 @@ func stateTestCmd(ctx *cli.Context) error {
 			// Print any structured logs collected
 			if ctx.GlobalBool(DebugFlag.Name) {
 				if debugger != nil {
-					fmt.Fprintln(os.Stderr, "#### TRACE ####")
-					vm.WriteTrace(os.Stderr, debugger.StructLogs())
+					fmt.Fprintln(ctx.App.ErrWriter, "#### TRACE ####")
+					vm.WriteTrace(ctx.App.ErrWriter, debugger.StructLogs())
 				}
 			}
 		}
 	}
 	out, _ := json.MarshalIndent(results, "", "  ")
-	fmt.Println(string(out))
+	fmt.Fprintln(ctx.App.Writer, string(out))
 	return nil
 }


### PR DESCRIPTION
use the `ctx.Writer` and `ctx.ErrWriter` as output witer,

before:

```
$> ./evm compile test.sol 2>/dev/null
test.sol:0 syntax error: unexpected hello, expected end of line
test.sol:0 syntax error: unexpected EOF, expected new line
```

after:

```
$> ./evm compile test.sol 2>/dev/null
```
