### PR TITLE
consensus/ethash/ethash.go: fixed typo

### DIFF
--- a/consensus/ethash/ethash.go
+++ b/consensus/ethash/ethash.go
@@ -389,7 +389,7 @@ type Config struct {
 	PowMode        Mode
 }
 
-// Ethash is a consensus engine based on proot-of-work implementing the ethash
+// Ethash is a consensus engine based on proof-of-work implementing the ethash
 // algorithm.
 type Ethash struct {
 	config Config


### PR DESCRIPTION
line 392: "proot-of-work" to "proof-of-work"