### PR TITLE
core/types: fix func TxDifference

### DIFF
--- a/core/types/transaction.go
+++ b/core/types/transaction.go
@@ -266,7 +266,7 @@ func (s Transactions) GetRlp(i int) []byte {
 	return enc
 }
 
-// TxDifference returns a new set which is the difference between a to b.
+// TxDifference returns a new set which is the difference between a and b.
 func TxDifference(a, b Transactions) Transactions {
 	keep := make(Transactions, 0, len(a))
 

--- a/core/types/transaction.go
+++ b/core/types/transaction.go
@@ -266,9 +266,9 @@ func (s Transactions) GetRlp(i int) []byte {
 	return enc
 }
 
-// TxDifference returns a new set t which is the difference between a to b.
-func TxDifference(a, b Transactions) (keep Transactions) {
-	keep = make(Transactions, 0, len(a))
+// TxDifference returns a new set which is the difference between a to b.
+func TxDifference(a, b Transactions) Transactions {
+	keep := make(Transactions, 0, len(a))
 
 	remove := make(map[common.Hash]struct{})
 	for _, tx := range b {


### PR DESCRIPTION
fix a typo in func comment;
change named return to unnamed as there's explicit return in the body