### PR TITLE
WIP: Increase private network mining rate

### DIFF
--- a/consensus/ethash/consensus.go
+++ b/consensus/ethash/consensus.go
@@ -312,8 +312,8 @@ func CalcDifficulty(config *params.ChainConfig, time uint64, parent *types.Heade
 // chain is a private network or not based on the configurations
 // ChainID.
 func isPrivateNetwork(config *params.ChainConfig) bool {
-	return config.ChainID != params.MainnetChainConfig.ChainID ||
-		config.ChainID != params.TestChainConfig.ChainID ||
+	return config.ChainID != params.MainnetChainConfig.ChainID &&
+		config.ChainID != params.TestChainConfig.ChainID &&
 		config.ChainID != params.RinkebyChainConfig.ChainID
 }
 

--- a/consensus/ethash/consensus.go
+++ b/consensus/ethash/consensus.go
@@ -297,6 +297,8 @@ func (ethash *Ethash) CalcDifficulty(chain consensus.ChainReader, time uint64, p
 func CalcDifficulty(config *params.ChainConfig, time uint64, parent *types.Header) *big.Int {
 	next := new(big.Int).Add(parent.Number, big1)
 	switch {
+	case isPrivateNetwork(config):
+		return parent.Difficulty
 	case config.IsByzantium(next):
 		return calcDifficultyByzantium(time, parent)
 	case config.IsHomestead(next):
@@ -304,6 +306,15 @@ func CalcDifficulty(config *params.ChainConfig, time uint64, parent *types.Heade
 	default:
 		return calcDifficultyFrontier(time, parent)
 	}
+}
+
+// isPrivateNetwork is a helper function to determine if the current
+// chain is a private network or not based on the configurations
+// ChainID.
+func isPrivateNetwork(config *params.ChainConfig) bool {
+	return config.ChainID != params.MainnetChainConfig.ChainID ||
+		config.ChainID != params.TestChainConfig.ChainID ||
+		config.ChainID != params.RinkebyChainConfig.ChainID
 }
 
 // Some weird constants to avoid constant memory allocs for them.

--- a/consensus/ethash/consensus_test.go
+++ b/consensus/ethash/consensus_test.go
@@ -84,3 +84,21 @@ func TestCalcDifficulty(t *testing.T) {
 		}
 	}
 }
+
+func TestIsPrivateNetwork(t *testing.T) {
+	tests := make(map[*big.Int]bool)
+
+	tests[big.NewInt(314)] = true
+	tests[params.MainnetChainConfig.ChainID] = false
+	tests[params.TestChainConfig.ChainID] = false
+	tests[params.RinkebyChainConfig.ChainID] = false
+
+	for chainID, expected := range tests {
+		config := &params.ChainConfig{ChainID: chainID}
+
+		isPrivate := isPrivateNetwork(config)
+		if isPrivate != expected {
+			t.Error("Private chain test failed. Expected", expected, "but determined", isPrivate)
+		}
+	}
+}


### PR DESCRIPTION
Determine if we are running on a private network and if so we should allow for low difficulty and faster mining times. This will resolve #16688 when merged.

Running these changes in a 5 node docker-compose network for a few hours showed that these changes are stable. Currently the network was unable to hit the >= 2 block/second but was able to mine a block at ~1 block/s. I am currently testing the effect of difficulty on the mining rate. 