### PR TITLE
rpc: url.Parse can't parse filepath in windows

### DIFF
--- a/rpc/client.go
+++ b/rpc/client.go
@@ -27,6 +27,7 @@ import (
 	"net/url"
 	"os"
 	"reflect"
+	"runtime"
 	"strconv"
 	"strings"
 	"sync"
@@ -177,6 +178,13 @@ func DialContext(ctx context.Context, rawurl string) (*Client, error) {
 	case "":
 		return DialIPC(ctx, rawurl)
 	default:
+		if runtime.GOOS == "windows" && len(u.Scheme) == 1 {
+			for s := 'a'; s <= 'z'; s++ {
+				if rune(u.Scheme[0]) == s {
+					return DialIPC(ctx, rawurl)
+				}
+			}
+		}
 		return nil, fmt.Errorf("no known transport for URL scheme %q", u.Scheme)
 	}
 }


### PR DESCRIPTION
As #17141 said, CI failed in Windowss after PR #17041 merged, because #17041 introduced a new test case `TestNewSwarm` in [swarm_test.go#L38](https://github.com/ethereum/go-ethereum/blob/master/swarm/swarm_test.go#L38), [diff](https://github.com/ethereum/go-ethereum/pull/17041/files#diff-a690be1dbdc6e4dac043558611dd8cfeR35). AFAIK, this bug exists for a long time, long before PR #17041, and it happened in that PR. 

