### PR TITLE
core: check txn length when building a transaction set

### DIFF
--- a/core/types/transaction.go
+++ b/core/types/transaction.go
@@ -331,12 +331,14 @@ func NewTransactionsByPriceAndNonce(signer Signer, txs map[common.Address]Transa
 	// Initialize a price based heap with the head transactions
 	heads := make(TxByPrice, 0, len(txs))
 	for from, accTxs := range txs {
-		heads = append(heads, accTxs[0])
-		// Ensure the sender address is from the signer
-		acc, _ := Sender(signer, accTxs[0])
-		txs[acc] = accTxs[1:]
-		if from != acc {
-			delete(txs, from)
+		if len(accTxs) > 0 {
+			heads = append(heads, accTxs[0])
+			// Ensure the sender address is from the signer
+			acc, _ := Sender(signer, accTxs[0])
+			txs[acc] = accTxs[1:]
+			if from != acc {
+				delete(txs, from)
+			}
 		}
 	}
 	heap.Init(&heads)


### PR DESCRIPTION
This PR proposes a length check to prevent an `index out of range` panic when building `NewTransactionsByPriceAndNonce`. Perhaps empty slice values are actually 'bad data' which shouldn't have been in the input map in the first place, but this check is cheap.

```
panic: runtime error: index out of range

goroutine 105 [running]:
github.com/ethereum/go-ethereum/core/types.NewTransactionsByPriceAndNonce(0x10cd7e0, 0xc4214605a0, 0xc422d00f90, 0x0)
	/go-ethereum/build/_workspace/src/github.com/ethereum/go-ethereum/core/types/transaction.go:334 +0x4ec
github.com/ethereum/go-ethereum/miner.(*worker).commitNewWork(0xc4202534a0)
	/go-ethereum/build/_workspace/src/github.com/ethereum/go-ethereum/miner/worker.go:454 +0x9dc
github.com/ethereum/go-ethereum/miner.(*worker).update(0xc4202534a0)
	/go-ethereum/build/_workspace/src/github.com/ethereum/go-ethereum/miner/worker.go:254 +0x781
created by github.com/ethereum/go-ethereum/miner.newWorker
	/go-ethereum/build/_workspace/src/github.com/ethereum/go-ethereum/miner/worker.go:158 +0x4ae
```
