### PR TITLE
core/state: dedup storage trie traversals on same value rewrites

### DIFF
--- a/core/state/state_object.go
+++ b/core/state/state_object.go
@@ -77,6 +77,7 @@ type stateObject struct {
 	trie Trie // storage trie, which becomes non-nil on first access
 	code Code // contract bytecode, which gets set when code is loaded
 
+	originStorage Storage // Storage cache of original entries to dedup rewrites
 	cachedStorage Storage // Storage entry cache to avoid duplicate reads
 	dirtyStorage  Storage // Storage entries that need to be flushed to disk
 
@@ -115,6 +116,7 @@ func newObject(db *StateDB, address common.Address, data Account) *stateObject {
 		address:       address,
 		addrHash:      crypto.Keccak256Hash(address[:]),
 		data:          data,
+		originStorage: make(Storage),
 		cachedStorage: make(Storage),
 		dirtyStorage:  make(Storage),
 	}
@@ -178,6 +180,7 @@ func (self *stateObject) GetState(db Database, key common.Hash) common.Hash {
 		}
 		value.SetBytes(content)
 	}
+	self.originStorage[key] = value
 	self.cachedStorage[key] = value
 	return value
 }
@@ -202,6 +205,9 @@ func (self *stateObject) updateTrie(db Database) Trie {
 	tr := self.getTrie(db)
 	for key, value := range self.dirtyStorage {
 		delete(self.dirtyStorage, key)
+		if value == self.originStorage[key] {
+			continue // reverted to original value
+		}
 		if (value == common.Hash{}) {
 			self.setError(tr.TryDelete(key[:]))
 			continue
@@ -280,6 +286,7 @@ func (self *stateObject) deepCopy(db *StateDB) *stateObject {
 	stateObject.code = self.code
 	stateObject.dirtyStorage = self.dirtyStorage.Copy()
 	stateObject.cachedStorage = self.dirtyStorage.Copy()
+	stateObject.originStorage = self.originStorage.Copy()
 	stateObject.suicided = self.suicided
 	stateObject.dirtyCode = self.dirtyCode
 	stateObject.deleted = self.deleted


### PR DESCRIPTION
This PR most probably has negligible effect on performance, but I thought it's worth a benchmark (running currently).

The idea is that if a transaction changes a storage slot, and then changes it back to its original value, we still consider it dirty and do a trie.TryUpdate, even though we know it won't have any effect. Now, this trie update isn't particularly expensive as internally we already handle the non-update scenario gracefully and not change anything, but to detect that no chage occurred, we nonetheless have to traverse the trie down to it's leaf.

My hunch is that we might get a bit of performance out of the code if we skipped the trie traversal altogether. That said, I don't know how often we so this storage slot change-then-change-back, so it may not add any value.