### PR TITLE
 core, params: implement EIP-1087, net storage gas metering

### DIFF
--- a/accounts/abi/bind/backends/simulated.go
+++ b/accounts/abi/bind/backends/simulated.go
@@ -154,7 +154,7 @@ func (b *SimulatedBackend) StorageAt(ctx context.Context, contract common.Addres
 		return nil, errBlockNumberUnsupported
 	}
 	statedb, _ := b.blockchain.State()
-	val := statedb.GetState(contract, key)
+	val, _ := statedb.GetState(contract, key)
 	return val[:], nil
 }
 

--- a/core/state/journal.go
+++ b/core/state/journal.go
@@ -108,8 +108,10 @@ type (
 		prev    uint64
 	}
 	storageChange struct {
-		account       *common.Address
-		key, prevalue common.Hash
+		account   *common.Address
+		key       common.Hash
+		prevValue common.Hash
+		prevDirty bool
 	}
 	codeChange struct {
 		account            *common.Address
@@ -196,7 +198,7 @@ func (ch codeChange) dirtied() *common.Address {
 }
 
 func (ch storageChange) revert(s *StateDB) {
-	s.getStateObject(*ch.account).setState(ch.key, ch.prevalue)
+	s.getStateObject(*ch.account).setState(ch.key, ch.prevValue, ch.prevDirty)
 }
 
 func (ch storageChange) dirtied() *common.Address {

--- a/core/state/statedb.go
+++ b/core/state/statedb.go
@@ -27,6 +27,7 @@ import (
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/log"
+	"github.com/ethereum/go-ethereum/params"
 	"github.com/ethereum/go-ethereum/rlp"
 	"github.com/ethereum/go-ethereum/trie"
 )
@@ -236,12 +237,12 @@ func (self *StateDB) GetCodeHash(addr common.Address) common.Hash {
 	return common.BytesToHash(stateObject.CodeHash())
 }
 
-func (self *StateDB) GetState(addr common.Address, bhash common.Hash) common.Hash {
+func (self *StateDB) GetState(addr common.Address, bhash common.Hash) (common.Hash, bool) {
 	stateObject := self.getStateObject(addr)
 	if stateObject != nil {
 		return stateObject.GetState(self.db, bhash)
 	}
-	return common.Hash{}
+	return common.Hash{}, false
 }
 
 // Database retrieves the low level database supporting the lower level trie ops.
@@ -430,24 +431,19 @@ func (self *StateDB) CreateAccount(addr common.Address) {
 	}
 }
 
-func (db *StateDB) ForEachStorage(addr common.Address, cb func(key, value common.Hash) bool) {
+func (db *StateDB) ForEachStorage(addr common.Address, cb func(key, value common.Hash, dirty bool) bool) {
 	so := db.getStateObject(addr)
 	if so == nil {
 		return
 	}
-
-	// When iterating over the storage check the cache first
-	for h, value := range so.cachedStorage {
-		cb(h, value)
-	}
-
 	it := trie.NewIterator(so.getTrie(db.db).NodeIterator(nil))
 	for it.Next() {
-		// ignore cached values
 		key := common.BytesToHash(db.trie.GetKey(it.Key))
-		if _, ok := so.cachedStorage[key]; !ok {
-			cb(key, common.BytesToHash(it.Value))
+		if value, dirty := so.dirtyStorage[key]; dirty {
+			cb(key, value, true)
+			continue
 		}
+		cb(key, common.BytesToHash(it.Value), false)
 	}
 }
 
@@ -524,9 +520,36 @@ func (self *StateDB) RevertToSnapshot(revid int) {
 	self.validRevisions = self.validRevisions[:idx]
 }
 
-// GetRefund returns the current value of the refund counter.
-func (self *StateDB) GetRefund() uint64 {
-	return self.refund
+// GetRefund returns the current value of the refund counter and any out-of-band
+// refunds at the end of the transaction.
+func (self *StateDB) GetRefund(netSstoreMeter bool) uint64 {
+	// If legacy gas metering is used, return the current refund counter
+	refund := self.refund
+	if !netSstoreMeter {
+		return refund
+	}
+	// If we're already using the Constantinople net sstore gas metering, refund noops
+	for addr := range self.journal.dirties {
+		object := self.stateObjects[addr]
+		for key, value := range object.dirtyStorage {
+			// If the slot didn't change in the end, refund most gas
+			if value == object.originStorage[key] {
+				if value == (common.Hash{}) {
+					refund += params.NetSstoreRefundNoopZero
+				} else {
+					refund += params.NetSstoreRefundNoopNonZero
+				}
+				continue
+			}
+			// If the slot did change, but was set to zero, refund
+			if value == (common.Hash{}) {
+				refund += params.NetSstoreRefund
+				continue
+			}
+			// Sorry, no refund for this slot
+		}
+	}
+	return refund
 }
 
 // Finalise finalises the state by removing the self destructed objects

--- a/core/state_transition.go
+++ b/core/state_transition.go
@@ -229,9 +229,11 @@ func (st *StateTransition) TransitionDb() (ret []byte, usedGas uint64, failed bo
 
 func (st *StateTransition) refundGas() {
 	// Apply refund counter, capped to half of the used gas.
-	refund := st.gasUsed() / 2
-	if refund > st.state.GetRefund() {
-		refund = st.state.GetRefund()
+	netSstoreMeter := st.evm.ChainConfig().IsConstantinople(st.evm.BlockNumber)
+
+	refund := st.state.GetRefund(netSstoreMeter)
+	if refund > st.gasUsed()/2 {
+		refund = st.gasUsed() / 2
 	}
 	st.gas += refund
 

--- a/core/vm/instructions.go
+++ b/core/vm/instructions.go
@@ -604,7 +604,7 @@ func opMstore8(pc *uint64, interpreter *EVMInterpreter, contract *Contract, memo
 
 func opSload(pc *uint64, interpreter *EVMInterpreter, contract *Contract, memory *Memory, stack *Stack) ([]byte, error) {
 	loc := stack.peek()
-	val := interpreter.evm.StateDB.GetState(contract.Address(), common.BigToHash(loc))
+	val, _ := interpreter.evm.StateDB.GetState(contract.Address(), common.BigToHash(loc))
 	loc.SetBytes(val.Bytes())
 	return nil, nil
 }

--- a/core/vm/interface.go
+++ b/core/vm/interface.go
@@ -40,9 +40,9 @@ type StateDB interface {
 	GetCodeSize(common.Address) int
 
 	AddRefund(uint64)
-	GetRefund() uint64
+	GetRefund(bool) uint64
 
-	GetState(common.Address, common.Hash) common.Hash
+	GetState(common.Address, common.Hash) (common.Hash, bool)
 	SetState(common.Address, common.Hash, common.Hash)
 
 	Suicide(common.Address) bool
@@ -61,7 +61,7 @@ type StateDB interface {
 	AddLog(*types.Log)
 	AddPreimage(common.Hash, []byte)
 
-	ForEachStorage(common.Address, func(common.Hash, common.Hash) bool)
+	ForEachStorage(common.Address, func(common.Hash, common.Hash, bool) bool)
 }
 
 // CallContext provides a basic interface for the EVM calling conventions. The EVM EVM

--- a/core/vm/interpreter.go
+++ b/core/vm/interpreter.go
@@ -133,7 +133,6 @@ func (in *EVMInterpreter) Run(contract *Contract, input []byte) (ret []byte, err
 			in.intPool = nil
 		}()
 	}
-
 	// Increment the call depth which is restricted to 1024
 	in.evm.depth++
 	defer func() { in.evm.depth-- }()

--- a/eth/tracers/tracer.go
+++ b/eth/tracers/tracer.go
@@ -214,7 +214,7 @@ func (dw *dbWrapper) pushObject(vm *duktape.Context) {
 		hash := popSlice(ctx)
 		addr := popSlice(ctx)
 
-		state := dw.db.GetState(common.BytesToAddress(addr), common.BytesToHash(hash))
+		state, _ := dw.db.GetState(common.BytesToAddress(addr), common.BytesToHash(hash))
 
 		ptr := ctx.PushFixedBuffer(len(state))
 		copy(makeSlice(ptr, uint(len(state))), state[:])

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -597,7 +597,7 @@ func (s *PublicBlockChainAPI) GetStorageAt(ctx context.Context, address common.A
 	if state == nil || err != nil {
 		return nil, err
 	}
-	res := state.GetState(address, common.HexToHash(key))
+	res, _ := state.GetState(address, common.HexToHash(key))
 	return res[:], state.Error()
 }
 

--- a/params/config.go
+++ b/params/config.go
@@ -334,7 +334,7 @@ func (err *ConfigCompatError) Error() string {
 type Rules struct {
 	ChainID                                   *big.Int
 	IsHomestead, IsEIP150, IsEIP155, IsEIP158 bool
-	IsByzantium                               bool
+	IsByzantium, IsConstantinople             bool
 }
 
 // Rules ensures c's ChainID is not nil.
@@ -343,5 +343,12 @@ func (c *ChainConfig) Rules(num *big.Int) Rules {
 	if chainID == nil {
 		chainID = new(big.Int)
 	}
-	return Rules{ChainID: new(big.Int).Set(chainID), IsHomestead: c.IsHomestead(num), IsEIP150: c.IsEIP150(num), IsEIP155: c.IsEIP155(num), IsEIP158: c.IsEIP158(num), IsByzantium: c.IsByzantium(num)}
+	return Rules{
+		ChainID:          new(big.Int).Set(chainID),
+		IsHomestead:      c.IsHomestead(num),
+		IsEIP150:         c.IsEIP150(num),
+		IsEIP155:         c.IsEIP155(num),
+		IsEIP158:         c.IsEIP158(num),
+		IsByzantium:      c.IsByzantium(num),
+		IsConstantinople: c.IsConstantinople(num)}
 }

--- a/params/protocol_params.go
+++ b/params/protocol_params.go
@@ -36,15 +36,25 @@ const (
 	TxGasContractCreation uint64 = 53000 // Per transaction that creates a contract. NOTE: Not payable on data of calls between transactions.
 	TxDataZeroGas         uint64 = 4     // Per byte of data attached to a transaction that equals zero. NOTE: Not payable on data of calls between transactions.
 	QuadCoeffDiv          uint64 = 512   // Divisor for the quadratic particle of the memory cost equation.
-	SstoreSetGas          uint64 = 20000 // Once per SLOAD operation.
 	LogDataGas            uint64 = 8     // Per byte in a LOG* operation's data.
 	CallStipend           uint64 = 2300  // Free gas given at beginning of call.
 
-	Sha3Gas          uint64 = 30    // Once per SHA3 operation.
-	Sha3WordGas      uint64 = 6     // Once per word of the SHA3 operation's data.
-	SstoreResetGas   uint64 = 5000  // Once per SSTORE operation if the zeroness changes from zero.
-	SstoreClearGas   uint64 = 5000  // Once per SSTORE operation if the zeroness doesn't change.
-	SstoreRefundGas  uint64 = 15000 // Once per SSTORE operation if the zeroness changes to zero.
+	Sha3Gas     uint64 = 30 // Once per SHA3 operation.
+	Sha3WordGas uint64 = 6  // Once per word of the SHA3 operation's data.
+
+	SstoreSetGas    uint64 = 20000 // Once per SSTORE operation.
+	SstoreResetGas  uint64 = 5000  // Once per SSTORE operation if the zeroness changes from zero.
+	SstoreClearGas  uint64 = 5000  // Once per SSTORE operation if the zeroness doesn't change.
+	SstoreRefundGas uint64 = 15000 // Once per SSTORE operation if the zeroness changes to zero.
+
+	NetSstoreNoopGas           uint64 = 200   // Once per SSTORE operation if the value doesn't change.
+	NetSstoreDirtyGas          uint64 = 200   // Once per SSTORE operation from dirty.
+	NetSstoreCleanInitgas      uint64 = 20000 // Once per SSTORE operation from clean zero.
+	NetSstoreCleanUpdateGas    uint64 = 5000  // Once per SSTORE operation from clean non-zero.
+	NetSstoreRefundNoopZero    uint64 = 19800 // Once per dirty slot if it was changed from zero to non-zero and back to zero.
+	NetSstoreRefundNoopNonZero uint64 = 4800  // Once per dirty slot if it was changed from non-zero to anything and back to the orignal.
+	NetSstoreRefund            uint64 = 10000 // Once per dirty slot if it was changed from non-zero to zero.
+
 	JumpdestGas      uint64 = 1     // Refunded gas, once per SSTORE operation if the zeroness changes to zero.
 	EpochDuration    uint64 = 30000 // Duration between proof-of-work epochs.
 	CallGas          uint64 = 40    // Once per CALL operation & message call transaction.

--- a/tests/vm_test_util.go
+++ b/tests/vm_test_util.go
@@ -100,7 +100,7 @@ func (t *VMTest) Run(vmconfig vm.Config) error {
 	}
 	for addr, account := range t.json.Post {
 		for k, wantV := range account.Storage {
-			if haveV := statedb.GetState(addr, k); haveV != wantV {
+			if haveV, _ := statedb.GetState(addr, k); haveV != wantV {
 				return fmt.Errorf("wrong storage value at %x:\n  got  %x\n  want %x", k, haveV, wantV)
 			}
 		}


### PR DESCRIPTION
Implements https://eips.ethereum.org/EIPS/eip-1087.

**An important thing to note in this PR**: Until now, the `dirtyStorage` set inside the `stateObject` was an *optimization*. It of course correctly tracked the dirtiness when something was changed, but code until now didn't much care about revertals (i.e. it still kept it dirty). This was not an issue because it was just a tiny amount of extra work during commit. With the net gas metering EIP enabled however, the SSTORE gas costs depend on accurate tracking of the dirtiness, so we need to take better care from now on (i.e. this PR starts tracking the dirtiness in the journal too).

~~The EIP doesn’t really specify what happens if an inner transaction makes a storage slot dirty, but then reverts. Should the slot be reverted to clean (thus incurring an additional gas hit when modifying it again), or should the slot be kept dirty? Our code currently reverts the dirtiness too but I guess we can change if needed. However this is an important subtlety to emphasize in the spec.~~ Clarified in the EIP.

Ping @Arachnid, PTAL.