### PR TITLE
downloads: check that release name of Blobs start with geth

### DIFF
--- a/downloads/index.html
+++ b/downloads/index.html
@@ -332,6 +332,12 @@
               signatures[name] = true;
               continue;
             }
+
+            // Skip any blobs that do not start with "geth"
+            if (!name.startsWith("geth")) {
+              continue;
+            }
+
             // Otherwise add an entry to one of the release tables
             var parts = name.split("-");
             var date  = parts[parts.length-1].split(".")[0];


### PR DESCRIPTION
Related to https://github.com/ethereum/go-ethereum/pull/16988

In case we merge the above PR, and we start generating and uploading Swarm archives to Azure, we wouldn't want them to appear on https://geth.ethereum.org/downloads/