### PR TITLE
build: add targets for static linking

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,13 @@ geth:
 	@echo "Done building."
 	@echo "Run \"$(GOBIN)/geth\" to launch geth."
 
+geth-static:
+	build/env.sh go run build/ci.go install -static ./cmd/geth
+	@echo "Done building."
+	@echo "Run \"$(GOBIN)/geth\" to launch geth."
+
+static: geth-static
+
 swarm:
 	build/env.sh go run build/ci.go install ./cmd/swarm
 	@echo "Done building."
@@ -23,6 +30,9 @@ swarm:
 
 all:
 	build/env.sh go run build/ci.go install
+
+all-static:
+	build/env.sh go run build/ci.go install -static
 
 android:
 	build/env.sh go run build/ci.go aar --local

--- a/build/ci.go
+++ b/build/ci.go
@@ -173,12 +173,13 @@ func main() {
 
 func doInstall(cmdline []string) {
 	var (
-		arch = flag.String("arch", "", "Architecture to cross build for")
-		cc   = flag.String("cc", "", "C compiler to cross build with")
+		arch   = flag.String("arch", "", "Architecture to cross build for")
+		cc     = flag.String("cc", "", "C compiler to cross build with")
+		static = flag.Bool("static", false, "Build a static linked binary")
 	)
 	flag.CommandLine.Parse(cmdline)
 	env := build.Env()
-
+	env.Static = *static
 	// Check Go version. People regularly open issues about compilation
 	// failure with outdated Go. This should save them the trouble.
 	if !strings.Contains(runtime.Version(), "devel") {
@@ -246,13 +247,14 @@ func buildFlags(env build.Environment) (flags []string) {
 	if env.Commit != "" {
 		ld = append(ld, "-X", "main.gitCommit="+env.Commit)
 	}
-	if runtime.GOOS == "darwin" {
-		ld = append(ld, "-s")
+	ld = append(ld, "-s")
+	ld = append(ld, "-w")
+
+	if env.Static {
+		ld = append(ld, "-extldflags -static")
 	}
 
-	if len(ld) > 0 {
-		flags = append(flags, "-ldflags", strings.Join(ld, " "))
-	}
+	flags = append(flags, "-ldflags", strings.Join(ld, " "))
 	return flags
 }
 

--- a/internal/build/env.go
+++ b/internal/build/env.go
@@ -41,11 +41,12 @@ type Environment struct {
 	Buildnum            string
 	IsPullRequest       bool
 	IsCronJob           bool
+	Static              bool
 }
 
 func (env Environment) String() string {
-	return fmt.Sprintf("%s env (commit:%s branch:%s tag:%s buildnum:%s pr:%t)",
-		env.Name, env.Commit, env.Branch, env.Tag, env.Buildnum, env.IsPullRequest)
+	return fmt.Sprintf("%s env (commit:%s branch:%s tag:%s buildnum:%s pr:%t static:%t)",
+		env.Name, env.Commit, env.Branch, env.Tag, env.Buildnum, env.IsPullRequest, env.Static)
 }
 
 // Env returns metadata about the current CI environment, falling back to LocalEnv


### PR DESCRIPTION
This adds a new flag to the *ci.go install* script, `-static` which produces static linked binary.

Note: this is only tested on linux

Before, the `-s` flag was only used if the OS was darwin (apple). 

Now, use the following linker flags for all builds:
```
-w
	Omit the DWARF symbol table.
-s
	Omit the symbol table and debug information.
```

Results:

Smaller binaries, using -static or without.

### CURRENT BINARY SIZES (default build)
```
-rwxr-xr-x 1 user user 9.1M Jul 25 20:27 build/bin/abigen
-rwxr-xr-x 1 user user  26M Jul 25 20:27 build/bin/bootnode
-rwxr-xr-x 1 user user  29M Jul 25 20:27 build/bin/clef
-rwxr-xr-x 1 user user  27M Jul 25 20:27 build/bin/ethkey
-rwxr-xr-x 1 user user  25M Jul 25 20:27 build/bin/evm
-rwxr-xr-x 1 user user  20M Jul 25 20:27 build/bin/examples
-rwxr-xr-x 1 user user  28M Jul 25 20:27 build/bin/faucet
-rwxr-xr-x 1 user user  37M Jul 25 20:27 build/bin/geth
-rwxr-xr-x 1 user user  20M Jul 25 20:27 build/bin/p2psim
-rwxr-xr-x 1 user user  15M Jul 25 20:27 build/bin/puppeth
-rwxr-xr-x 1 user user 3.2M Jul 25 20:27 build/bin/rlpdump
-rwxr-xr-x 1 user user  20M Jul 25 20:27 build/bin/simulations
-rwxr-xr-x 1 user user  37M Jul 25 20:27 build/bin/swarm
-rwxr-xr-x 1 user user 8.1M Jul 25 20:27 build/bin/swarm-smoke
-rwxr-xr-x 1 user user  29M Jul 25 20:27 build/bin/wnode
```

### NEW (default build)
```
-rwxr-xr-x 1 user user 5.5M Jul 25 20:28 build/bin/abigen
-rwxr-xr-x 1 user user  15M Jul 25 20:28 build/bin/bootnode
-rwxr-xr-x 1 user user  17M Jul 25 20:28 build/bin/clef
-rwxr-xr-x 1 user user  16M Jul 25 20:28 build/bin/ethkey
-rwxr-xr-x 1 user user  15M Jul 25 20:28 build/bin/evm
-rwxr-xr-x 1 user user  12M Jul 25 20:29 build/bin/examples
-rwxr-xr-x 1 user user  16M Jul 25 20:29 build/bin/faucet
-rwxr-xr-x 1 user user  22M Jul 25 20:29 build/bin/geth
-rwxr-xr-x 1 user user  12M Jul 25 20:29 build/bin/p2psim
-rwxr-xr-x 1 user user 8.6M Jul 25 20:29 build/bin/puppeth
-rwxr-xr-x 1 user user 2.0M Jul 25 20:29 build/bin/rlpdump
-rwxr-xr-x 1 user user  12M Jul 25 20:29 build/bin/simulations
-rwxr-xr-x 1 user user  22M Jul 25 20:29 build/bin/swarm
-rwxr-xr-x 1 user user 5.2M Jul 25 20:29 build/bin/swarm-smoke
-rwxr-xr-x 1 user user  17M Jul 25 20:29 build/bin/wnode
```

### STATIC (with -static)
```
-rwxr-xr-x 1 user user 6.3M Jul 25 20:24 build/bin/abigen
-rwxr-xr-x 1 user user  17M Jul 25 20:24 build/bin/bootnode
-rwxr-xr-x 1 user user  19M Jul 25 20:24 build/bin/clef
-rwxr-xr-x 1 user user  17M Jul 25 20:24 build/bin/ethkey
-rwxr-xr-x 1 user user  16M Jul 25 20:24 build/bin/evm
-rwxr-xr-x 1 user user  13M Jul 25 20:24 build/bin/examples
-rwxr-xr-x 1 user user  17M Jul 25 20:24 build/bin/faucet
-rwxr-xr-x 1 user user  23M Jul 25 20:24 build/bin/geth
-rwxr-xr-x 1 user user  13M Jul 25 20:24 build/bin/p2psim
-rwxr-xr-x 1 user user 9.4M Jul 25 20:24 build/bin/puppeth
-rwxr-xr-x 1 user user 2.0M Jul 25 20:24 build/bin/rlpdump
-rwxr-xr-x 1 user user  13M Jul 25 20:24 build/bin/simulations
-rwxr-xr-x 1 user user  23M Jul 25 20:24 build/bin/swarm
-rwxr-xr-x 1 user user 5.2M Jul 25 20:24 build/bin/swarm-smoke
-rwxr-xr-x 1 user user  18M Jul 25 20:24 build/bin/wnode
```
