### PR TITLE
Prevent usage of invalid command or bootnodes

### DIFF
--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -251,6 +251,9 @@ func main() {
 // It creates a default node based on the command line arguments and runs it in
 // blocking mode, waiting for it to be shut down.
 func geth(ctx *cli.Context) error {
+	if args := ctx.Args(); len(args) > 0 {
+		return fmt.Errorf("invalid command: %q", args[0])
+	}
 	node := makeFullNode(ctx)
 	startNode(ctx, node)
 	node.Wait()

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -644,8 +644,7 @@ func setBootstrapNodes(ctx *cli.Context, cfg *p2p.Config) {
 	for _, url := range urls {
 		node, err := discover.ParseNode(url)
 		if err != nil {
-			log.Error("Bootstrap URL invalid", "enode", url, "err", err)
-			continue
+			log.Crit("Bootstrap URL invalid", "enode", url, "err", err)
 		}
 		cfg.BootstrapNodes = append(cfg.BootstrapNodes, node)
 	}


### PR DESCRIPTION
Adds two fatal startup errors, to prevent unintended behavior due to invalid flag usage.

  * bootnode is not able to be parsed
  * command is not recognized