### PR TITLE
build: fix bash->sh function declaration

### DIFF
--- a/build/clean_go_build_cache.sh
+++ b/build/clean_go_build_cache.sh
@@ -1,6 +1,8 @@
 #!/bin/sh
 
-function version_gt() { test "$(printf '%s\n' "$@" | sort -V | head -n 1)" != "$1"; }
+version_gt() {
+  test "$(printf '%s\n' "$@" | sort -V | head -n 1)" != "$1"
+}
 
 golang_version=$(go version |cut -d' ' -f3 |sed 's/go//')
 


### PR DESCRIPTION
The original cleaner code was written for `bash`. Later a followup commit changed it to `sh`, but did not change the function declaration. This PR fixes that too.