### PR TITLE
p2p: fix rare deadlock in Stop

### DIFF
--- a/p2p/server.go
+++ b/p2p/server.go
@@ -340,8 +340,8 @@ func (srv *Server) makeSelf(listener net.Listener, ntab discoverTable) *discover
 // It blocks until all active connections have been closed.
 func (srv *Server) Stop() {
 	srv.lock.Lock()
-	defer srv.lock.Unlock()
 	if !srv.running {
+		srv.lock.Unlock()
 		return
 	}
 	srv.running = false
@@ -350,6 +350,7 @@ func (srv *Server) Stop() {
 		srv.listener.Close()
 	}
 	close(srv.quit)
+	srv.lock.Unlock()
 	srv.loopWG.Wait()
 }
 


### PR DESCRIPTION
This PR has a small change, but significant to solving a potential deadlock in p2p package.

The problem was detected on running a newly created test:

```
go test -v -count 1 -timeout 3m github.com/ethereum/go-ethereum/swarm/network/simulation -run TestConnectToNodesStar
```

Most of the times, the test passes, but due to synchronization issue between p2p.Server.lock and p2.Server.loopWG, it is possible to get into a deadlock state.

The test TestConnectToNodesStar creates a network simulation, adds a number of nodes, connects them in a certain way and checks if expected connections are made. But the network Shutdown is called as deferred function, which can cause a deadlock if it is scheduled before any function that is called by Server.run and that tries to acquire Server.lock. In that case, Server.run will wait for the lock acquired by Server.Stop while Server.Stop will not release the lock until Server.loopWG is at 0, and Server.run will not finish execution and decrement the last Server.loopWG on line p2p/server.go:540.

Here are the stacks of to goroutines that are in a described deadlock.

The first one is waiting for on Server.Stop call for Server.loopWG, at which the Server.lock is acquired.

```
goroutine 1461 [semacquire, 3 minutes]:
sync.runtime_Semacquire(0xc4201cdac4)
	/usr/local/go/src/runtime/sema.go:56 +0x39
sync.(*WaitGroup).Wait(0xc4201cdab8)
	/usr/local/go/src/sync/waitgroup.go:129 +0x72
github.com/ethereum/go-ethereum/p2p.(*Server).Stop(0xc4201cd900)
	/Users/janos/go/src/github.com/ethereum/go-ethereum/p2p/server.go:353 +0xb1
github.com/ethereum/go-ethereum/node.(*Node).Stop(0xc4201cd680, 0x0, 0x0)
	/Users/janos/go/src/github.com/ethereum/go-ethereum/node/node.go:423 +0x2bb
github.com/ethereum/go-ethereum/p2p/simulations/adapters.(*SimNode).Stop(0xc4203eee10, 0x1e, 0x0)
	/Users/janos/go/src/github.com/ethereum/go-ethereum/p2p/simulations/adapters/inproc.go:296 +0x5e
github.com/ethereum/go-ethereum/p2p/simulations.(*Network).Shutdown(0xc420516100)
	/Users/janos/go/src/github.com/ethereum/go-ethereum/p2p/simulations/network.go:496 +0x1c8
github.com/ethereum/go-ethereum/swarm/network/simulation.(*Simulation).Close(0xc4203ee090)
	/Users/janos/go/src/github.com/ethereum/go-ethereum/swarm/network/simulation/simulation.go:193 +0x1fa
github.com/ethereum/go-ethereum/swarm/network/simulation.TestConnectToNodesStar(0xc4202f50e0)
	/Users/janos/go/src/github.com/ethereum/go-ethereum/swarm/network/simulation/connect_test.go:263 +0x235
testing.tRunner(0xc4202f50e0, 0x475d200)
	/usr/local/go/src/testing/testing.go:777 +0xd0
created by testing.(*T).Run
	/usr/local/go/src/testing/testing.go:824 +0x2e0
```

The second is waiting at Server.Self for the Server.lock, and blocking the execution of Server.run function up to the stack, creating a deadlock.


```
goroutine 1599 [semacquire, 3 minutes]:
sync.runtime_SemacquireMutex(0xc4201cda24, 0x948d8700)
	/usr/local/go/src/runtime/sema.go:71 +0x3d
sync.(*Mutex).Lock(0xc4201cda20)
	/usr/local/go/src/sync/mutex.go:134 +0x108
github.com/ethereum/go-ethereum/p2p.(*Server).Self(0xc4201cd900, 0x0)
	/Users/janos/go/src/github.com/ethereum/go-ethereum/p2p/server.go:310 +0x46
github.com/ethereum/go-ethereum/p2p.(*Server).encHandshakeChecks(0xc4201cd900, 0xc420486f60, 0x0, 0xc4205e1c20, 0x0, 0xc42051dba8)
	/Users/janos/go/src/github.com/ethereum/go-ethereum/p2p/server.go:712 +0x84
github.com/ethereum/go-ethereum/p2p.(*Server).protoHandshakeChecks(0xc4201cd900, 0xc420486f60, 0x0, 0xc4205e1c20, 0x8, 0x8)
	/Users/janos/go/src/github.com/ethereum/go-ethereum/p2p/server.go:701 +0x67
github.com/ethereum/go-ethereum/p2p.(*Server).run(0xc4201cd900, 0x47b3c20, 0xc4203fc140)
	/Users/janos/go/src/github.com/ethereum/go-ethereum/p2p/server.go:635 +0xba3
created by github.com/ethereum/go-ethereum/p2p.(*Server).Start
	/Users/janos/go/src/github.com/ethereum/go-ethereum/p2p/server.go:504 +0x78c
```

The change in this PR removes Server.loopWG in Server.Stop from the Server.lock scope.