### PR TITLE
all: avoid copying arrays in loops

### DIFF
--- a/p2p/discover/table.go
+++ b/p2p/discover/table.go
@@ -160,7 +160,7 @@ func (tab *Table) ReadRandomNodes(buf []*Node) (n int) {
 
 	// Find all non-empty buckets and get a fresh slice of their entries.
 	var buckets [][]*Node
-	for _, b := range tab.buckets {
+	for _, b := range &tab.buckets {
 		if len(b.entries) > 0 {
 			buckets = append(buckets, b.entries[:])
 		}
@@ -508,7 +508,7 @@ func (tab *Table) copyLiveNodes() {
 	defer tab.mutex.Unlock()
 
 	now := time.Now()
-	for _, b := range tab.buckets {
+	for _, b := range &tab.buckets {
 		for _, n := range b.entries {
 			if now.Sub(n.addedAt) >= seedMinTableTime {
 				tab.db.updateNode(n)
@@ -524,7 +524,7 @@ func (tab *Table) closest(target common.Hash, nresults int) *nodesByDistance {
 	// obviously correct. I believe that tree-based buckets would make
 	// this easier to implement efficiently.
 	close := &nodesByDistance{target: target}
-	for _, b := range tab.buckets {
+	for _, b := range &tab.buckets {
 		for _, n := range b.entries {
 			close.push(n, nresults)
 		}
@@ -533,7 +533,7 @@ func (tab *Table) closest(target common.Hash, nresults int) *nodesByDistance {
 }
 
 func (tab *Table) len() (n int) {
-	for _, b := range tab.buckets {
+	for _, b := range &tab.buckets {
 		n += len(b.entries)
 	}
 	return n

--- a/p2p/discv5/net_test.go
+++ b/p2p/discv5/net_test.go
@@ -355,7 +355,7 @@ func (tn *preminedTestnet) mine(target NodeID) {
 	fmt.Printf("	target: %#v,\n", tn.target)
 	fmt.Printf("	targetSha: %#v,\n", tn.targetSha)
 	fmt.Printf("	dists: [%d][]NodeID{\n", len(tn.dists))
-	for ld, ns := range tn.dists {
+	for ld, ns := range &tn.dists {
 		if len(ns) == 0 {
 			continue
 		}

--- a/p2p/discv5/table.go
+++ b/p2p/discv5/table.go
@@ -81,7 +81,7 @@ func (tab *Table) chooseBucketRefreshTarget() common.Hash {
 	if printTable {
 		fmt.Println()
 	}
-	for i, b := range tab.buckets {
+	for i, b := range &tab.buckets {
 		entries += len(b.entries)
 		if printTable {
 			for _, e := range b.entries {
@@ -93,7 +93,7 @@ func (tab *Table) chooseBucketRefreshTarget() common.Hash {
 	prefix := binary.BigEndian.Uint64(tab.self.sha[0:8])
 	dist := ^uint64(0)
 	entry := int(randUint(uint32(entries + 1)))
-	for _, b := range tab.buckets {
+	for _, b := range &tab.buckets {
 		if entry < len(b.entries) {
 			n := b.entries[entry]
 			dist = binary.BigEndian.Uint64(n.sha[0:8]) ^ prefix
@@ -121,7 +121,7 @@ func (tab *Table) readRandomNodes(buf []*Node) (n int) {
 	// TODO: tree-based buckets would help here
 	// Find all non-empty buckets and get a fresh slice of their entries.
 	var buckets [][]*Node
-	for _, b := range tab.buckets {
+	for _, b := range &tab.buckets {
 		if len(b.entries) > 0 {
 			buckets = append(buckets, b.entries[:])
 		}
@@ -175,7 +175,7 @@ func (tab *Table) closest(target common.Hash, nresults int) *nodesByDistance {
 	// obviously correct. I believe that tree-based buckets would make
 	// this easier to implement efficiently.
 	close := &nodesByDistance{target: target}
-	for _, b := range tab.buckets {
+	for _, b := range &tab.buckets {
 		for _, n := range b.entries {
 			close.push(n, nresults)
 		}

--- a/swarm/api/manifest.go
+++ b/swarm/api/manifest.go
@@ -159,7 +159,7 @@ func (m *ManifestWalker) Walk(walkFn WalkFn) error {
 }
 
 func (m *ManifestWalker) walk(trie *manifestTrie, prefix string, walkFn WalkFn) error {
-	for _, entry := range trie.entries {
+	for _, entry := range &trie.entries {
 		if entry == nil {
 			continue
 		}
@@ -308,7 +308,7 @@ func (mt *manifestTrie) addEntry(entry *manifestTrieEntry, quitC chan bool) {
 }
 
 func (mt *manifestTrie) getCountLast() (cnt int, entry *manifestTrieEntry) {
-	for _, e := range mt.entries {
+	for _, e := range &mt.entries {
 		if e != nil {
 			cnt++
 			entry = e
@@ -362,7 +362,7 @@ func (mt *manifestTrie) recalcAndStore() error {
 	buffer.WriteString(`{"entries":[`)
 
 	list := &Manifest{}
-	for _, entry := range mt.entries {
+	for _, entry := range &mt.entries {
 		if entry != nil {
 			if entry.Hash == "" { // TODO: paralellize
 				err := entry.subtrie.recalcAndStore()

--- a/trie/node.go
+++ b/trie/node.go
@@ -55,7 +55,7 @@ var nilValueNode = valueNode(nil)
 func (n *fullNode) EncodeRLP(w io.Writer) error {
 	var nodes [17]node
 
-	for i, child := range n.Children {
+	for i, child := range &n.Children {
 		if child != nil {
 			nodes[i] = child
 		} else {
@@ -98,7 +98,7 @@ func (n valueNode) String() string  { return n.fstring("") }
 
 func (n *fullNode) fstring(ind string) string {
 	resp := fmt.Sprintf("[\n%s  ", ind)
-	for i, node := range n.Children {
+	for i, node := range &n.Children {
 		if node == nil {
 			resp += fmt.Sprintf("%s: <nil> ", indices[i])
 		} else {

--- a/trie/trie.go
+++ b/trie/trie.go
@@ -356,7 +356,7 @@ func (t *Trie) delete(n node, prefix, key []byte) (bool, node, error) {
 		// value that is left in n or -2 if n contains at least two
 		// values.
 		pos := -1
-		for i, cld := range n.Children {
+		for i, cld := range &n.Children {
 			if cld != nil {
 				if pos == -1 {
 					pos = i


### PR DESCRIPTION
Avoid copying arrays of heavy structs (100 bytes and more) in loops. Found by the go-critic linter.
Linter's log:
```bash
check-package: $GOPATH/src/github.com/ethereum/go-ethereum/swarm/api/manifest.go:162:2: rangeExprCopy: copy of trie.entries (2056 bytes) can be avoided with &trie.entries
check-package: $GOPATH/src/github.com/ethereum/go-ethereum/swarm/api/manifest.go:311:2: rangeExprCopy: copy of mt.entries (2056 bytes) can be avoided with &mt.entries
check-package: $GOPATH/src/github.com/ethereum/go-ethereum/swarm/api/manifest.go:365:2: rangeExprCopy: copy of mt.entries (2056 bytes) can be avoided with &mt.entries

check-package: $GOPATH/src/github.com/ethereum/go-ethereum/trie/node.go:58:2: rangeExprCopy: copy of n.Children (272 bytes) can be avoided with &n.Children
check-package: $GOPATH/src/github.com/ethereum/go-ethereum/trie/node.go:101:2: rangeExprCopy: copy of n.Children (272 bytes) can be avoided with &n.Children
check-package: $GOPATH/src/github.com/ethereum/go-ethereum/trie/trie.go:359:3: rangeExprCopy: copy of n.Children (272 bytes) can be avoided with &n.Children

check-package: $GOPATH/src/github.com/ethereum/go-ethereum/p2p/discover/table.go:163:2: rangeExprCopy: copy of tab.buckets (136 bytes) can be avoided with &tab.buckets
check-package: $GOPATH/src/github.com/ethereum/go-ethereum/p2p/discover/table.go:511:2: rangeExprCopy: copy of tab.buckets (136 bytes) can be avoided with &tab.buckets
check-package: $GOPATH/src/github.com/ethereum/go-ethereum/p2p/discover/table.go:527:2: rangeExprCopy: copy of tab.buckets (136 bytes) can be avoided with &tab.buckets
check-package: $GOPATH/src/github.com/ethereum/go-ethereum/p2p/discover/table.go:536:2: rangeExprCopy: copy of tab.buckets (136 bytes) can be avoided with &tab.buckets

check-package: $GOPATH/src/github.com/ethereum/go-ethereum/p2p/discover/table_test.go:598:2: rangeExprCopy: copy of tn.dists (6168 bytes) can be avoided with &tn.dists

check-package: $GOPATH/src/github.com/ethereum/go-ethereum/p2p/discv5/table.go:84:2: rangeExprCopy: copy of tab.buckets (2056 bytes) can be avoided with &tab.buckets
check-package: $GOPATH/src/github.com/ethereum/go-ethereum/p2p/discv5/table.go:96:2: rangeExprCopy: copy of tab.buckets (2056 bytes) can be avoided with &tab.buckets
check-package: $GOPATH/src/github.com/ethereum/go-ethereum/p2p/discv5/table.go:124:2: rangeExprCopy: copy of tab.buckets (2056 bytes) can be avoided with &tab.buckets
check-package: $GOPATH/src/github.com/ethereum/go-ethereum/p2p/discv5/table.go:178:2: rangeExprCopy: copy of tab.buckets (2056 bytes) can be avoided with &tab.buckets

check-package: $GOPATH/src/github.com/ethereum/go-ethereum/p2p/discv5/net_test.go:358:2: rangeExprCopy: copy of tn.dists (6168 bytes) can be avoided with &tn.dists
```