### PR TITLE
les: don't bother cmManager if client request cost exceeds the limit

### DIFF
--- a/les/flowcontrol/manager.go
+++ b/les/flowcontrol/manager.go
@@ -184,7 +184,7 @@ func (self *ClientManager) queueProc() {
 	}
 }
 
-func (self *ClientManager) accept(node *cmNode, time mclock.AbsTime) bool {
+func (self *ClientManager) accept(node *cmNode, time mclock.AbsTime) {
 	self.lock.Lock()
 	defer self.lock.Unlock()
 
@@ -196,14 +196,13 @@ func (self *ClientManager) accept(node *cmNode, time mclock.AbsTime) bool {
 		<-resume
 		self.lock.Lock()
 		if _, ok := self.nodes[node]; !ok {
-			return false // reject if node has been removed or manager has been stopped
+			panic("the node should never be removed during the request waiting")
 		}
 	}
 	self.simReqCnt++
 	node.set(true, self.simReqCnt, self.sumWeight)
 	node.startValue = node.rcValue
 	self.update(self.time)
-	return true
 }
 
 func (self *ClientManager) stop(node *cmNode, time mclock.AbsTime) {

--- a/les/handler.go
+++ b/les/handler.go
@@ -350,12 +350,12 @@ func (pm *ProtocolManager) handleMsg(p *peer) error {
 		if p.fcClient == nil || reqCnt > maxCnt {
 			return true
 		}
-		bufValue, _ := p.fcClient.AcceptRequest()
 		cost := costs.baseCost + reqCnt*costs.reqCost
 		if cost > pm.server.defParams.BufLimit {
 			cost = pm.server.defParams.BufLimit
 		}
-		if cost > bufValue {
+		bufValue, serve := p.fcClient.AcceptRequest(cost)
+		if !serve {
 			recharge := time.Duration((cost - bufValue) * 1000000 / pm.server.defParams.MinRecharge)
 			p.Log().Error("Request came too early", "recharge", common.PrettyDuration(recharge))
 			return true


### PR DESCRIPTION
This PR fixes a logic that for the server side flow control, we should not bother "real cost counter" if the client peer doesn't comply with the flow control rules and drop the peer directly. 
Though the previous logic doesn't affect the result because "bad behaviour" client peer will be dropped anyway, but it will be better make the logic clean.