### PR TITLE
p2p/discv5: fix idx can be negative after uint convert to int(can cause crash)

### DIFF
--- a/p2p/discv5/net.go
+++ b/p2p/discv5/net.go
@@ -1228,7 +1228,7 @@ func (net *Network) checkTopicRegister(data *topicRegister) (*pong, error) {
 	if rlpHash(data.Topics) != pongpkt.data.(*pong).TopicHash {
 		return nil, errors.New("topic hash mismatch")
 	}
-	if data.Idx < 0 || int(data.Idx) >= len(data.Topics) {
+	if int(data.Idx) < 0 || int(data.Idx) >= len(data.Topics) {
 		return nil, errors.New("topic index out of range")
 	}
 	return pongpkt.data.(*pong), nil


### PR DESCRIPTION
When data.Idx(topicRegister.Idx) is lower than max uint and higher than max int, it will pass [index out of range checking](https://github.com/ethereum/go-ethereum/blob/master/p2p/discv5/net.go#L1231), after the type conversion the Idx may be a negative number and it is used to be an [index of array](https://github.com/ethereum/go-ethereum/blob/93c0f1715d1ce6e590811a659d20f0e80277ba6a/p2p/discv5/topic.go#L262), this may cause a node crash.
