### PR TITLE
swarm/api: remove ioutil.ReadAll for HandleGetFiles

### DIFF
--- a/swarm/api/http/server.go
+++ b/swarm/api/http/server.go
@@ -897,11 +897,11 @@ func (s *Server) HandleGetFile(w http.ResponseWriter, r *Request) {
 	ctx, sp = spancontext.StartSpan(
 		ctx,
 		"http.get.file")
+	defer sp.Finish()
 
 	// ensure the root path has a trailing slash so that relative URLs work
 	if r.uri.Path == "" && !strings.HasSuffix(r.URL.Path, "/") {
 		http.Redirect(w, &r.Request, r.URL.Path+"/", http.StatusMovedPermanently)
-		sp.Finish()
 		return
 	}
 	var err error
@@ -912,7 +912,6 @@ func (s *Server) HandleGetFile(w http.ResponseWriter, r *Request) {
 		if err != nil {
 			getFileFail.Inc(1)
 			Respond(w, r, fmt.Sprintf("cannot resolve %s: %s", r.uri.Addr, err), http.StatusNotFound)
-			sp.Finish()
 			return
 		}
 	} else {
@@ -928,7 +927,6 @@ func (s *Server) HandleGetFile(w http.ResponseWriter, r *Request) {
 	if noneMatchEtag != "" {
 		if bytes.Equal(storage.Address(common.Hex2Bytes(noneMatchEtag)), contentKey) {
 			Respond(w, r, "Not Modified", http.StatusNotModified)
-			sp.Finish()
 			return
 		}
 	}
@@ -942,7 +940,6 @@ func (s *Server) HandleGetFile(w http.ResponseWriter, r *Request) {
 			getFileFail.Inc(1)
 			Respond(w, r, err.Error(), http.StatusInternalServerError)
 		}
-		sp.Finish()
 		return
 	}
 
@@ -953,14 +950,12 @@ func (s *Server) HandleGetFile(w http.ResponseWriter, r *Request) {
 		if err != nil {
 			getFileFail.Inc(1)
 			Respond(w, r, err.Error(), http.StatusInternalServerError)
-			sp.Finish()
 			return
 		}
 
 		log.Debug(fmt.Sprintf("Multiple choices! --> %v", list), "ruid", r.ruid)
 		//show a nice page links to available entries
 		ShowMultipleChoices(w, r, list)
-		sp.Finish()
 		return
 	}
 
@@ -968,23 +963,11 @@ func (s *Server) HandleGetFile(w http.ResponseWriter, r *Request) {
 	if _, err := reader.Size(ctx, nil); err != nil {
 		getFileNotFound.Inc(1)
 		Respond(w, r, fmt.Sprintf("file not found %s: %s", r.uri, err), http.StatusNotFound)
-		sp.Finish()
 		return
 	}
-
-	buf, err := ioutil.ReadAll(newBufferedReadSeeker(reader, getFileBufferSize))
-	if err != nil {
-		getFileNotFound.Inc(1)
-		Respond(w, r, fmt.Sprintf("file not found %s: %s", r.uri, err), http.StatusNotFound)
-		sp.Finish()
-		return
-	}
-
-	log.Debug("got response in buffer", "len", len(buf), "ruid", r.ruid)
-	sp.Finish()
 
 	w.Header().Set("Content-Type", contentType)
-	http.ServeContent(w, &r.Request, "", time.Now(), bytes.NewReader(buf))
+	http.ServeContent(w, &r.Request, "", time.Now(), newBufferedReadSeeker(reader, getFileBufferSize))
 }
 
 // The size of buffer used for bufio.Reader on LazyChunkReader passed to


### PR DESCRIPTION
This PR is removing `ioutil.ReadAll` which we used to measure latency of requests within test cluster, without measuring client-side latency.