### PR TITLE
cmd/puppeth: force tiny memory for geth attach in id lookup

### DIFF
--- a/cmd/puppeth/module_node.go
+++ b/cmd/puppeth/module_node.go
@@ -221,7 +221,7 @@ func checkNode(client *sshClient, network string, boot bool) (*nodeInfos, error)
 
 	// Container available, retrieve its node ID and its genesis json
 	var out []byte
-	if out, err = client.Run(fmt.Sprintf("docker exec %s_%s_1 geth --exec admin.nodeInfo.id attach", network, kind)); err != nil {
+	if out, err = client.Run(fmt.Sprintf("docker exec %s_%s_1 geth --exec admin.nodeInfo.id --cache=16 attach", network, kind)); err != nil {
 		return nil, ErrServiceUnreachable
 	}
 	id := bytes.Trim(bytes.TrimSpace(out), "\"")


### PR DESCRIPTION
Fixes https://github.com/ethereum/go-ethereum/issues/16905.

We use `geth --exec admin.nodeInfo.id attach` to retrieve the ID of deployed nodes. If however the host machine has less than 2GB memory, geth will display a sanitizing warning stating that `--cache` is reduced to X bytes. Normally this is not an issue because the result of the call goes to`stdout` and the log to `stderr`.

In the case of puppeth + docker, we use combined output, which causes the resulting combo-text to be invalid. An alternative solution would be to separate the two streams within puppeth, but that makes it harder to display errors if the command genuinely fails. We could also track both `stdout` and `stdout + stderr` separately, but that requires a lot of glue code.

The simplest solution for now seemed to just explicitly set a tiny cache, avoiding the warning log in the first place.