### PR TITLE
build: explicitly name all packages to be cross-compiled

### DIFF
--- a/build/ci.go
+++ b/build/ci.go
@@ -147,6 +147,9 @@ var (
 		debEthereum,
 	}
 
+	// Packages to be cross-compiled by the xgo command
+	allCrossCompiledArchiveFiles = append(allToolsArchiveFiles, swarmArchiveFiles...)
+
 	// Distros for which packages are created.
 	// Note: vivid is unsupported because there is no golang-1.6 package for it.
 	// Note: wily is unsupported because it was officially deprecated on lanchpad.
@@ -1009,7 +1012,7 @@ func doXgo(cmdline []string) {
 
 	if *alltools {
 		args = append(args, []string{"--dest", GOBIN}...)
-		for _, res := range allToolsArchiveFiles {
+		for _, res := range allCrossCompiledArchiveFiles {
 			if strings.HasPrefix(res, GOBIN) {
 				// Binary tool found, cross build it explicitly
 				args = append(args, "./"+filepath.Join("cmd", filepath.Base(res)))


### PR DESCRIPTION
This PR fixes a bug where `swarm` is not cross-compiled, but we try to archive it into archives for various architectures.

The `var` that is used to select binaries for cross-compilation is decoupled from the `var` that selects the binaries for the `geth-alltools` archive.