### PR TITLE
swarm: Added lightnode flag

### DIFF
--- a/cmd/swarm/config.go
+++ b/cmd/swarm/config.go
@@ -308,8 +308,8 @@ func envVarsOverride(currentConfig *bzzapi.Config) (config *bzzapi.Config) {
 		}
 	}
 
-	if lightnodeenable := os.Getenv(SWARM_ENV_LIGHT_NODE_ENABLE); lightnodeenable != "" {
-		if lightnode, err := strconv.ParseBool(lightnodeenable); err != nil {
+	if lne := os.Getenv(SWARM_ENV_LIGHT_NODE_ENABLE); lne != "" {
+		if lightnode, err := strconv.ParseBool(lne); err != nil {
 			currentConfig.LightNodeEnabled = lightnode
 		}
 	}

--- a/cmd/swarm/config.go
+++ b/cmd/swarm/config.go
@@ -70,6 +70,7 @@ const (
 	SWARM_ENV_SWAP_API             = "SWARM_SWAP_API"
 	SWARM_ENV_SYNC_DISABLE         = "SWARM_SYNC_DISABLE"
 	SWARM_ENV_SYNC_UPDATE_DELAY    = "SWARM_ENV_SYNC_UPDATE_DELAY"
+	SWARM_ENV_LIGHT_NODE_ENABLE    = "SWARM_LIGHT_NODE_ENABLE"
 	SWARM_ENV_DELIVERY_SKIP_CHECK  = "SWARM_DELIVERY_SKIP_CHECK"
 	SWARM_ENV_ENS_API              = "SWARM_ENS_API"
 	SWARM_ENV_ENS_ADDR             = "SWARM_ENS_ADDR"
@@ -206,6 +207,10 @@ func cmdLineOverride(currentConfig *bzzapi.Config, ctx *cli.Context) *bzzapi.Con
 		currentConfig.SyncUpdateDelay = d
 	}
 
+	if ctx.GlobalIsSet(SwarmLightNodeEnabled.Name) {
+		currentConfig.LightNodeEnabled = true
+	}
+
 	if ctx.GlobalIsSet(SwarmDeliverySkipCheckFlag.Name) {
 		currentConfig.DeliverySkipCheck = true
 	}
@@ -300,6 +305,12 @@ func envVarsOverride(currentConfig *bzzapi.Config) (config *bzzapi.Config) {
 	if v := os.Getenv(SWARM_ENV_SYNC_UPDATE_DELAY); v != "" {
 		if d, err := time.ParseDuration(v); err != nil {
 			currentConfig.SyncUpdateDelay = d
+		}
+	}
+
+	if lightnodeenable := os.Getenv(SWARM_ENV_LIGHT_NODE_ENABLE); lightnodeenable != "" {
+		if lightnode, err := strconv.ParseBool(lightnodeenable); err != nil {
+			currentConfig.LightNodeEnabled = lightnode
 		}
 	}
 

--- a/cmd/swarm/main.go
+++ b/cmd/swarm/main.go
@@ -123,6 +123,11 @@ var (
 		Usage:  "Duration for sync subscriptions update after no new peers are added (default 15s)",
 		EnvVar: SWARM_ENV_SYNC_UPDATE_DELAY,
 	}
+	SwarmLightNodeEnabled = cli.BoolTFlag{
+		Name:   "lightnode",
+		Usage:  "Enable Swarm LightNode (default false)",
+		EnvVar: SWARM_ENV_LIGHT_NODE_ENABLE,
+	}
 	SwarmDeliverySkipCheckFlag = cli.BoolFlag{
 		Name:   "delivery-skip-check",
 		Usage:  "Skip chunk delivery check (default false)",
@@ -464,6 +469,7 @@ pv(1) tool to get a progress bar:
 		SwarmSwapAPIFlag,
 		SwarmSyncDisabledFlag,
 		SwarmSyncUpdateDelay,
+		SwarmLightNodeEnabled,
 		SwarmDeliverySkipCheckFlag,
 		SwarmListenAddrFlag,
 		SwarmPortFlag,

--- a/cmd/swarm/main.go
+++ b/cmd/swarm/main.go
@@ -123,7 +123,7 @@ var (
 		Usage:  "Duration for sync subscriptions update after no new peers are added (default 15s)",
 		EnvVar: SWARM_ENV_SYNC_UPDATE_DELAY,
 	}
-	SwarmLightNodeEnabled = cli.BoolTFlag{
+	SwarmLightNodeEnabled = cli.BoolFlag{
 		Name:   "lightnode",
 		Usage:  "Enable Swarm LightNode (default false)",
 		EnvVar: SWARM_ENV_LIGHT_NODE_ENABLE,

--- a/swarm/api/config.go
+++ b/swarm/api/config.go
@@ -63,6 +63,7 @@ type Config struct {
 	SwapEnabled       bool
 	SyncEnabled       bool
 	DeliverySkipCheck bool
+	LightNodeEnabled  bool
 	SyncUpdateDelay   time.Duration
 	SwapAPI           string
 	Cors              string

--- a/swarm/network/protocol.go
+++ b/swarm/network/protocol.go
@@ -94,12 +94,14 @@ type BzzConfig struct {
 	UnderlayAddr []byte // node's underlay address
 	HiveParams   *HiveParams
 	NetworkID    uint64
+	LightNode    bool
 }
 
 // Bzz is the swarm protocol bundle
 type Bzz struct {
 	*Hive
 	NetworkID    uint64
+	LightNode    bool
 	localAddr    *BzzAddr
 	mtx          sync.Mutex
 	handshakes   map[discover.NodeID]*HandshakeMsg
@@ -116,6 +118,7 @@ func NewBzz(config *BzzConfig, kad Overlay, store state.Store, streamerSpec *pro
 	return &Bzz{
 		Hive:         NewHive(config.HiveParams, kad, store),
 		NetworkID:    config.NetworkID,
+		LightNode:    config.LightNode,
 		localAddr:    &BzzAddr{config.OverlayAddr, config.UnderlayAddr},
 		handshakes:   make(map[discover.NodeID]*HandshakeMsg),
 		streamerRun:  streamerRun,
@@ -209,7 +212,11 @@ func (b *Bzz) RunProtocol(spec *protocols.Spec, run func(*BzzPeer) error) func(*
 			localAddr:  b.localAddr,
 			BzzAddr:    handshake.peerAddr,
 			lastActive: time.Now(),
+			LightNode:  handshake.LightNode,
 		}
+
+		log.Info("peer created: %s", handshake.peerAddr.String())
+
 		return run(peer)
 	}
 }
@@ -228,6 +235,7 @@ func (b *Bzz) performHandshake(p *protocols.Peer, handshake *HandshakeMsg) error
 		return err
 	}
 	handshake.peerAddr = rsh.(*HandshakeMsg).Addr
+	handshake.LightNode = rsh.(*HandshakeMsg).LightNode
 	return nil
 }
 
@@ -263,6 +271,7 @@ type BzzPeer struct {
 	localAddr       *BzzAddr  // local Peers address
 	*BzzAddr                  // remote address -> implements Addr interface = protocols.Peer
 	lastActive      time.Time // time is updated whenever mutexes are releasing
+	LightNode       bool
 }
 
 func NewBzzTestPeer(p *protocols.Peer, addr *BzzAddr) *BzzPeer {
@@ -294,6 +303,7 @@ type HandshakeMsg struct {
 	Version   uint64
 	NetworkID uint64
 	Addr      *BzzAddr
+	LightNode bool
 
 	// peerAddr is the address received in the peer handshake
 	peerAddr *BzzAddr
@@ -305,7 +315,7 @@ type HandshakeMsg struct {
 
 // String pretty prints the handshake
 func (bh *HandshakeMsg) String() string {
-	return fmt.Sprintf("Handshake: Version: %v, NetworkID: %v, Addr: %v", bh.Version, bh.NetworkID, bh.Addr)
+	return fmt.Sprintf("Handshake: Version: %v, NetworkID: %v, Addr: %v, LightNode: %v, peerAddr: %v", bh.Version, bh.NetworkID, bh.Addr, bh.LightNode, bh.peerAddr)
 }
 
 // Perform initiates the handshake and validates the remote handshake message
@@ -338,6 +348,7 @@ func (b *Bzz) GetHandshake(peerID discover.NodeID) (*HandshakeMsg, bool) {
 			Version:   uint64(BzzSpec.Version),
 			NetworkID: b.NetworkID,
 			Addr:      b.localAddr,
+			LightNode: b.LightNode,
 			init:      make(chan bool, 1),
 			done:      make(chan struct{}),
 		}

--- a/swarm/network/protocol.go
+++ b/swarm/network/protocol.go
@@ -215,7 +215,7 @@ func (b *Bzz) RunProtocol(spec *protocols.Spec, run func(*BzzPeer) error) func(*
 			LightNode:  handshake.LightNode,
 		}
 
-		log.Info("peer created: %s", handshake.peerAddr.String())
+		log.Debug("peer created", "addr", handshake.peerAddr.String())
 
 		return run(peer)
 	}

--- a/swarm/network/protocol_test.go
+++ b/swarm/network/protocol_test.go
@@ -31,7 +31,7 @@ import (
 )
 
 const (
-	TestProtocolVersion   = 5
+	TestProtocolVersion   = 6
 	TestProtocolNetworkID = 3
 )
 

--- a/swarm/network/protocol_test.go
+++ b/swarm/network/protocol_test.go
@@ -30,7 +30,7 @@ import (
 	p2ptest "github.com/ethereum/go-ethereum/p2p/testing"
 )
 
-const DefaultVersion = 5
+const TestProtocolVersion = 5
 
 var (
 	loglevel = flag.Int("loglevel", 2, "verbosity of logs")
@@ -195,7 +195,7 @@ func (s *bzzTester) testHandshake(lhs, rhs *HandshakeMsg, disconnects ...*p2ptes
 
 func correctBzzHandshake(addr *BzzAddr, lightNode bool) *HandshakeMsg {
 	return &HandshakeMsg{
-		Version:   DefaultVersion,
+		Version:   TestProtocolVersion,
 		NetworkID: DefaultNetworkID,
 		Addr:      addr,
 		LightNode: lightNode,
@@ -210,7 +210,7 @@ func TestBzzHandshakeNetworkIDMismatch(t *testing.T) {
 
 	err := s.testHandshake(
 		correctBzzHandshake(addr, lightNode),
-		&HandshakeMsg{Version: DefaultVersion, NetworkID: 321, Addr: NewAddrFromNodeID(id)},
+		&HandshakeMsg{Version: TestProtocolVersion, NetworkID: 321, Addr: NewAddrFromNodeID(id)},
 		&p2ptest.Disconnect{Peer: id, Error: fmt.Errorf("Handshake error: Message handler error: (msg code 0): network id mismatch 321 (!= 3)")},
 	)
 
@@ -228,7 +228,7 @@ func TestBzzHandshakeVersionMismatch(t *testing.T) {
 	err := s.testHandshake(
 		correctBzzHandshake(addr, lightNode),
 		&HandshakeMsg{Version: 0, NetworkID: DefaultNetworkID, Addr: NewAddrFromNodeID(id)},
-		&p2ptest.Disconnect{Peer: id, Error: fmt.Errorf("Handshake error: Message handler error: (msg code 0): version mismatch 0 (!= %d)", DefaultVersion)},
+		&p2ptest.Disconnect{Peer: id, Error: fmt.Errorf("Handshake error: Message handler error: (msg code 0): version mismatch 0 (!= %d)", TestProtocolVersion)},
 	)
 
 	if err != nil {
@@ -244,7 +244,7 @@ func TestBzzHandshakeSuccess(t *testing.T) {
 
 	err := s.testHandshake(
 		correctBzzHandshake(addr, lightNode),
-		&HandshakeMsg{Version: DefaultVersion, NetworkID: DefaultNetworkID, Addr: NewAddrFromNodeID(id)},
+		&HandshakeMsg{Version: TestProtocolVersion, NetworkID: DefaultNetworkID, Addr: NewAddrFromNodeID(id)},
 	)
 
 	if err != nil {
@@ -261,7 +261,7 @@ func TestBzzHandshakeLightNodeOff(t *testing.T) {
 
 	err := pt.testHandshake(
 		correctBzzHandshake(randomAddr, false),
-		&HandshakeMsg{Version: DefaultVersion, NetworkID: DefaultNetworkID, Addr: addr, LightNode: peerLightNode},
+		&HandshakeMsg{Version: TestProtocolVersion, NetworkID: DefaultNetworkID, Addr: addr, LightNode: peerLightNode},
 	)
 
 	if err != nil {
@@ -269,7 +269,7 @@ func TestBzzHandshakeLightNodeOff(t *testing.T) {
 	}
 
 	if pt.bzz.handshakes[id].LightNode != peerLightNode {
-		t.Fatal(fmt.Sprintf("peer LightNode flag is %v, should be %v", pt.bzz.handshakes[id].LightNode, peerLightNode))
+		t.Fatalf("peer LightNode flag is %v, should be %v", pt.bzz.handshakes[id].LightNode, peerLightNode)
 	}
 }
 
@@ -282,7 +282,7 @@ func TestBzzHandshakeLightNodeOn(t *testing.T) {
 
 	err := pt.testHandshake(
 		correctBzzHandshake(randomAddr, false),
-		&HandshakeMsg{Version: DefaultVersion, NetworkID: DefaultNetworkID, Addr: addr, LightNode: peerLightNode},
+		&HandshakeMsg{Version: TestProtocolVersion, NetworkID: DefaultNetworkID, Addr: addr, LightNode: peerLightNode},
 	)
 
 	if err != nil {
@@ -290,6 +290,6 @@ func TestBzzHandshakeLightNodeOn(t *testing.T) {
 	}
 
 	if pt.bzz.handshakes[id].LightNode != peerLightNode {
-		t.Fatal(fmt.Sprintf("peer LightNode flag is %v, should be %v", pt.bzz.handshakes[id].LightNode, peerLightNode))
+		t.Fatalf("peer LightNode flag is %v, should be %v", pt.bzz.handshakes[id].LightNode, peerLightNode)
 	}
 }

--- a/swarm/network/protocol_test.go
+++ b/swarm/network/protocol_test.go
@@ -255,15 +255,15 @@ func TestBzzHandshakeSuccess(t *testing.T) {
 	}
 }
 
-var lightNodeTests = []struct {
-	name      string
-	lightNode bool
-}{
-	{"on", true},
-	{"off", false},
-}
-
 func TestBzzHandshakeLightNode(t *testing.T) {
+	var lightNodeTests = []struct {
+		name      string
+		lightNode bool
+	}{
+		{"on", true},
+		{"off", false},
+	}
+
 	for _, test := range lightNodeTests {
 		t.Run(test.name, func(t *testing.T) {
 			randomAddr := RandomAddr()

--- a/swarm/network/protocol_test.go
+++ b/swarm/network/protocol_test.go
@@ -31,7 +31,7 @@ import (
 )
 
 const (
-	TestProtocolVersion   = 6
+	TestProtocolVersion   = 5
 	TestProtocolNetworkID = 3
 )
 

--- a/swarm/network/protocol_test.go
+++ b/swarm/network/protocol_test.go
@@ -30,6 +30,8 @@ import (
 	p2ptest "github.com/ethereum/go-ethereum/p2p/testing"
 )
 
+const DefaultVersion = 5
+
 var (
 	loglevel = flag.Int("loglevel", 2, "verbosity of logs")
 )
@@ -127,23 +129,30 @@ type bzzTester struct {
 	*p2ptest.ProtocolTester
 	addr *BzzAddr
 	cs   map[string]chan bool
+	bzz  *Bzz
 }
 
-func newBzzHandshakeTester(t *testing.T, n int, addr *BzzAddr) *bzzTester {
+func newBzz(addr *BzzAddr, lightNode bool) *Bzz {
 	config := &BzzConfig{
 		OverlayAddr:  addr.Over(),
 		UnderlayAddr: addr.Under(),
 		HiveParams:   NewHiveParams(),
 		NetworkID:    DefaultNetworkID,
+		LightNode:    lightNode,
 	}
 	kad := NewKademlia(addr.OAddr, NewKadParams())
 	bzz := NewBzz(config, kad, nil, nil, nil)
+	return bzz
+}
 
-	s := p2ptest.NewProtocolTester(t, NewNodeIDFromAddr(addr), 1, bzz.runBzz)
+func newBzzHandshakeTester(t *testing.T, n int, addr *BzzAddr, lightNode bool) *bzzTester {
+	bzz := newBzz(addr, lightNode)
+	pt := p2ptest.NewProtocolTester(t, NewNodeIDFromAddr(addr), n, bzz.runBzz)
 
 	return &bzzTester{
 		addr:           addr,
-		ProtocolTester: s,
+		ProtocolTester: pt,
+		bzz:            bzz,
 	}
 }
 
@@ -184,22 +193,24 @@ func (s *bzzTester) testHandshake(lhs, rhs *HandshakeMsg, disconnects ...*p2ptes
 	return nil
 }
 
-func correctBzzHandshake(addr *BzzAddr) *HandshakeMsg {
+func correctBzzHandshake(addr *BzzAddr, lightNode bool) *HandshakeMsg {
 	return &HandshakeMsg{
-		Version:   5,
+		Version:   DefaultVersion,
 		NetworkID: DefaultNetworkID,
 		Addr:      addr,
+		LightNode: lightNode,
 	}
 }
 
 func TestBzzHandshakeNetworkIDMismatch(t *testing.T) {
+	lightNode := false
 	addr := RandomAddr()
-	s := newBzzHandshakeTester(t, 1, addr)
+	s := newBzzHandshakeTester(t, 1, addr, lightNode)
 	id := s.IDs[0]
 
 	err := s.testHandshake(
-		correctBzzHandshake(addr),
-		&HandshakeMsg{Version: 5, NetworkID: 321, Addr: NewAddrFromNodeID(id)},
+		correctBzzHandshake(addr, lightNode),
+		&HandshakeMsg{Version: DefaultVersion, NetworkID: 321, Addr: NewAddrFromNodeID(id)},
 		&p2ptest.Disconnect{Peer: id, Error: fmt.Errorf("Handshake error: Message handler error: (msg code 0): network id mismatch 321 (!= 3)")},
 	)
 
@@ -209,14 +220,15 @@ func TestBzzHandshakeNetworkIDMismatch(t *testing.T) {
 }
 
 func TestBzzHandshakeVersionMismatch(t *testing.T) {
+	lightNode := false
 	addr := RandomAddr()
-	s := newBzzHandshakeTester(t, 1, addr)
+	s := newBzzHandshakeTester(t, 1, addr, lightNode)
 	id := s.IDs[0]
 
 	err := s.testHandshake(
-		correctBzzHandshake(addr),
-		&HandshakeMsg{Version: 0, NetworkID: 3, Addr: NewAddrFromNodeID(id)},
-		&p2ptest.Disconnect{Peer: id, Error: fmt.Errorf("Handshake error: Message handler error: (msg code 0): version mismatch 0 (!= 5)")},
+		correctBzzHandshake(addr, lightNode),
+		&HandshakeMsg{Version: 0, NetworkID: DefaultNetworkID, Addr: NewAddrFromNodeID(id)},
+		&p2ptest.Disconnect{Peer: id, Error: fmt.Errorf("Handshake error: Message handler error: (msg code 0): version mismatch 0 (!= %d)", DefaultVersion)},
 	)
 
 	if err != nil {
@@ -225,16 +237,59 @@ func TestBzzHandshakeVersionMismatch(t *testing.T) {
 }
 
 func TestBzzHandshakeSuccess(t *testing.T) {
+	lightNode := false
 	addr := RandomAddr()
-	s := newBzzHandshakeTester(t, 1, addr)
+	s := newBzzHandshakeTester(t, 1, addr, lightNode)
 	id := s.IDs[0]
 
 	err := s.testHandshake(
-		correctBzzHandshake(addr),
-		&HandshakeMsg{Version: 5, NetworkID: 3, Addr: NewAddrFromNodeID(id)},
+		correctBzzHandshake(addr, lightNode),
+		&HandshakeMsg{Version: DefaultVersion, NetworkID: DefaultNetworkID, Addr: NewAddrFromNodeID(id)},
 	)
 
 	if err != nil {
 		t.Fatal(err)
+	}
+}
+
+func TestBzzHandshakeLightNodeOff(t *testing.T) {
+	randomAddr := RandomAddr()
+	pt := newBzzHandshakeTester(t, 1, randomAddr, false)
+	id := pt.IDs[0]
+	addr := NewAddrFromNodeID(id)
+	peerLightNode := false
+
+	err := pt.testHandshake(
+		correctBzzHandshake(randomAddr, false),
+		&HandshakeMsg{Version: DefaultVersion, NetworkID: DefaultNetworkID, Addr: addr, LightNode: peerLightNode},
+	)
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if pt.bzz.handshakes[id].LightNode != peerLightNode {
+		t.Fatal(fmt.Sprintf("peer LightNode flag is %v, should be %v", pt.bzz.handshakes[id].LightNode, peerLightNode))
+	}
+}
+
+func TestBzzHandshakeLightNodeOn(t *testing.T) {
+	randomAddr := RandomAddr()
+	pt := newBzzHandshakeTester(t, 1, randomAddr, false)
+	id := pt.IDs[0]
+	addr := NewAddrFromNodeID(id)
+	peerLightNode := true
+
+	err := pt.testHandshake(
+		correctBzzHandshake(randomAddr, false),
+		&HandshakeMsg{Version: DefaultVersion, NetworkID: DefaultNetworkID, Addr: addr, LightNode: peerLightNode},
+	)
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if pt.bzz.handshakes[id].LightNode != peerLightNode {
+		t.Fatal(fmt.Sprintf("peer LightNode flag is %v, should be %v", pt.bzz.handshakes[id].LightNode, peerLightNode))
 	}
 }

--- a/swarm/network/protocol_test.go
+++ b/swarm/network/protocol_test.go
@@ -30,7 +30,10 @@ import (
 	p2ptest "github.com/ethereum/go-ethereum/p2p/testing"
 )
 
-const TestProtocolVersion = 5
+const (
+	TestProtocolVersion   = 5
+	TestProtocolNetworkID = 3
+)
 
 var (
 	loglevel = flag.Int("loglevel", 2, "verbosity of logs")
@@ -196,7 +199,7 @@ func (s *bzzTester) testHandshake(lhs, rhs *HandshakeMsg, disconnects ...*p2ptes
 func correctBzzHandshake(addr *BzzAddr, lightNode bool) *HandshakeMsg {
 	return &HandshakeMsg{
 		Version:   TestProtocolVersion,
-		NetworkID: DefaultNetworkID,
+		NetworkID: TestProtocolNetworkID,
 		Addr:      addr,
 		LightNode: lightNode,
 	}
@@ -227,7 +230,7 @@ func TestBzzHandshakeVersionMismatch(t *testing.T) {
 
 	err := s.testHandshake(
 		correctBzzHandshake(addr, lightNode),
-		&HandshakeMsg{Version: 0, NetworkID: DefaultNetworkID, Addr: NewAddrFromNodeID(id)},
+		&HandshakeMsg{Version: 0, NetworkID: TestProtocolNetworkID, Addr: NewAddrFromNodeID(id)},
 		&p2ptest.Disconnect{Peer: id, Error: fmt.Errorf("Handshake error: Message handler error: (msg code 0): version mismatch 0 (!= %d)", TestProtocolVersion)},
 	)
 
@@ -244,7 +247,7 @@ func TestBzzHandshakeSuccess(t *testing.T) {
 
 	err := s.testHandshake(
 		correctBzzHandshake(addr, lightNode),
-		&HandshakeMsg{Version: TestProtocolVersion, NetworkID: DefaultNetworkID, Addr: NewAddrFromNodeID(id)},
+		&HandshakeMsg{Version: TestProtocolVersion, NetworkID: TestProtocolNetworkID, Addr: NewAddrFromNodeID(id)},
 	)
 
 	if err != nil {
@@ -261,7 +264,7 @@ func TestBzzHandshakeLightNodeOff(t *testing.T) {
 
 	err := pt.testHandshake(
 		correctBzzHandshake(randomAddr, false),
-		&HandshakeMsg{Version: TestProtocolVersion, NetworkID: DefaultNetworkID, Addr: addr, LightNode: peerLightNode},
+		&HandshakeMsg{Version: TestProtocolVersion, NetworkID: TestProtocolNetworkID, Addr: addr, LightNode: peerLightNode},
 	)
 
 	if err != nil {
@@ -282,7 +285,7 @@ func TestBzzHandshakeLightNodeOn(t *testing.T) {
 
 	err := pt.testHandshake(
 		correctBzzHandshake(randomAddr, false),
-		&HandshakeMsg{Version: TestProtocolVersion, NetworkID: DefaultNetworkID, Addr: addr, LightNode: peerLightNode},
+		&HandshakeMsg{Version: TestProtocolVersion, NetworkID: TestProtocolNetworkID, Addr: addr, LightNode: peerLightNode},
 	)
 
 	if err != nil {

--- a/swarm/network/protocol_test.go
+++ b/swarm/network/protocol_test.go
@@ -255,44 +255,34 @@ func TestBzzHandshakeSuccess(t *testing.T) {
 	}
 }
 
-func TestBzzHandshakeLightNodeOff(t *testing.T) {
-	randomAddr := RandomAddr()
-	pt := newBzzHandshakeTester(t, 1, randomAddr, false)
-	id := pt.IDs[0]
-	addr := NewAddrFromNodeID(id)
-	peerLightNode := false
-
-	err := pt.testHandshake(
-		correctBzzHandshake(randomAddr, false),
-		&HandshakeMsg{Version: TestProtocolVersion, NetworkID: TestProtocolNetworkID, Addr: addr, LightNode: peerLightNode},
-	)
-
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	if pt.bzz.handshakes[id].LightNode != peerLightNode {
-		t.Fatalf("peer LightNode flag is %v, should be %v", pt.bzz.handshakes[id].LightNode, peerLightNode)
-	}
+var lightNodeTests = []struct {
+	name      string
+	lightNode bool
+}{
+	{"on", true},
+	{"off", false},
 }
 
-func TestBzzHandshakeLightNodeOn(t *testing.T) {
-	randomAddr := RandomAddr()
-	pt := newBzzHandshakeTester(t, 1, randomAddr, false)
-	id := pt.IDs[0]
-	addr := NewAddrFromNodeID(id)
-	peerLightNode := true
+func TestBzzHandshakeLightNode(t *testing.T) {
+	for _, test := range lightNodeTests {
+		t.Run(test.name, func(t *testing.T) {
+			randomAddr := RandomAddr()
+			pt := newBzzHandshakeTester(t, 1, randomAddr, false)
+			id := pt.IDs[0]
+			addr := NewAddrFromNodeID(id)
 
-	err := pt.testHandshake(
-		correctBzzHandshake(randomAddr, false),
-		&HandshakeMsg{Version: TestProtocolVersion, NetworkID: TestProtocolNetworkID, Addr: addr, LightNode: peerLightNode},
-	)
+			err := pt.testHandshake(
+				correctBzzHandshake(randomAddr, false),
+				&HandshakeMsg{Version: TestProtocolVersion, NetworkID: TestProtocolNetworkID, Addr: addr, LightNode: test.lightNode},
+			)
 
-	if err != nil {
-		t.Fatal(err)
-	}
+			if err != nil {
+				t.Fatal(err)
+			}
 
-	if pt.bzz.handshakes[id].LightNode != peerLightNode {
-		t.Fatalf("peer LightNode flag is %v, should be %v", pt.bzz.handshakes[id].LightNode, peerLightNode)
+			if pt.bzz.handshakes[id].LightNode != test.lightNode {
+				t.Fatalf("peer LightNode flag is %v, should be %v", pt.bzz.handshakes[id].LightNode, test.lightNode)
+			}
+		})
 	}
 }

--- a/swarm/swarm.go
+++ b/swarm/swarm.go
@@ -143,6 +143,7 @@ func NewSwarm(config *api.Config, mockStore *mock.NodeStore) (self *Swarm, err e
 		OverlayAddr:  addr.OAddr,
 		UnderlayAddr: addr.UAddr,
 		HiveParams:   config.HiveParams,
+		LightNode:    config.LightNodeEnabled,
 	}
 
 	stateStore, err := state.NewDBStore(filepath.Join(config.Path, "state-store.db"))


### PR DESCRIPTION
Added a command-line argument and config option to enable Swarm lightnodes.
Currently it does not do anything, later we will add the implementation
so that light nodes does not participate in routing in Kademlia.
For more details see https://hackmd.io/O5PvHQVhQnaNCbhJbAJVog?view

The PR is already approved by the Swarm team:
https://github.com/ethersphere/go-ethereum/pull/816

