### PR TITLE
mobile: fix missing return for CallMsg.SetTo(nil)

### DIFF
--- a/mobile/ethereum.go
+++ b/mobile/ethereum.go
@@ -67,6 +67,7 @@ func (msg *CallMsg) SetData(data []byte)       { msg.msg.Data = common.CopyBytes
 func (msg *CallMsg) SetTo(address *Address) {
 	if address == nil {
 		msg.msg.To = nil
+		return
 	}
 	msg.msg.To = &address.address
 }


### PR DESCRIPTION
Fix https://github.com/ethereum/go-ethereum/issues/17296.