### PR TITLE
cmd, ethkey: Fixing the README of ethkey, to match the updated commands

### DIFF
--- a/cmd/ethkey/README.md
+++ b/cmd/ethkey/README.md
@@ -25,12 +25,20 @@ make sure to use this feature with great caution!
 
 Sign the message with a keyfile.
 It is possible to refer to a file containing the message.
+To sign a message contained in a file, use the `--msgfile` flag.
 
 
 ### `ethkey verifymessage <address> <signature> <message/file>`
 
 Verify the signature of the message.
 It is possible to refer to a file containing the message.
+To sign a message contained in a file, use the --msgfile flag.
+
+
+### `ethkey changepassphrase <keyfile>`
+
+Change the passphrase of a keyfile.
+use the `--newpasswordfile` to point to the new password file.
 
 
 ## Passphrases
@@ -39,3 +47,7 @@ For every command that uses a keyfile, you will be prompted to provide the
 passphrase for decrypting the keyfile.  To avoid this message, it is possible
 to pass the passphrase by using the `--passwordfile` flag pointing to a file that
 contains the passphrase.
+
+## JSON
+
+In case you need to output the result in a JSON format, you shall by using the `--json` flag.

--- a/cmd/ethkey/README.md
+++ b/cmd/ethkey/README.md
@@ -21,13 +21,13 @@ Private key information can be printed by using the `--private` flag;
 make sure to use this feature with great caution!
 
 
-### `ethkey sign <keyfile> <message/file>`
+### `ethkey signmessage <keyfile> <message/file>`
 
 Sign the message with a keyfile.
 It is possible to refer to a file containing the message.
 
 
-### `ethkey verify <address> <signature> <message/file>`
+### `ethkey verifymessage <address> <signature> <message/file>`
 
 Verify the signature of the message.
 It is possible to refer to a file containing the message.
@@ -37,5 +37,5 @@ It is possible to refer to a file containing the message.
 
 For every command that uses a keyfile, you will be prompted to provide the 
 passphrase for decrypting the keyfile.  To avoid this message, it is possible
-to pass the passphrase by using the `--passphrase` flag pointing to a file that
+to pass the passphrase by using the `--passwordfile` flag pointing to a file that
 contains the passphrase.


### PR DESCRIPTION
Seems like the commands had been updated since #15438 but the README is stating the wrong commands. I think this will save some minutes of code scavenging in the future.