### PR TITLE
swarm/bmt: ignore data longer then 4096 bytes in Hasher.Write

### DIFF
--- a/swarm/bmt/bmt.go
+++ b/swarm/bmt/bmt.go
@@ -318,7 +318,7 @@ func (h *Hasher) Sum(b []byte) (s []byte) {
 // with every full segment calls writeSection in a go routine
 func (h *Hasher) Write(b []byte) (int, error) {
 	l := len(b)
-	if l == 0 {
+	if l == 0 || l > 4096 {
 		return 0, nil
 	}
 	t := h.getTree()


### PR DESCRIPTION
This PR fixes BMT panic when data longer then 4096 bytes is passed to Hasher.Write method. Currently, we have chunks longer then 4096 bytes on the production cluster and this change will just ignore them on hashing. This PR does not add any support for larger chunks, just tries to fix the panic.

https://github.com/ethersphere/go-ethereum/issues/837