### PR TITLE
swarm/api: close tar writer in GetDirectoryTar to flush and clean

### DIFF
--- a/swarm/api/api.go
+++ b/swarm/api/api.go
@@ -525,6 +525,10 @@ func (a *API) GetDirectoryTar(ctx context.Context, uri *URI) (io.ReadCloser, err
 
 			return nil
 		})
+		// close tar writer before closing pipew
+		// to flush remaining data to pipew
+		// regardless of error value
+		tw.Close()
 		if err != nil {
 			apiGetTarFail.Inc(1)
 			pipew.CloseWithError(err)


### PR DESCRIPTION
This PR fixes the problem described here https://github.com/ethersphere/go-ethereum/issues/857.

With recent changes, tar writer in GetDirectoryTar was not closed, that prevented tar writer flush to write zero padding at the end of a response.