### PR TITLE
rpc: fix a subscription name

### DIFF
--- a/rpc/client_example_test.go
+++ b/rpc/client_example_test.go
@@ -66,7 +66,7 @@ func subscribeBlocks(client *rpc.Client, subch chan Block) {
 	defer cancel()
 
 	// Subscribe to new blocks.
-	sub, err := client.EthSubscribe(ctx, subch, "newBlocks")
+	sub, err := client.EthSubscribe(ctx, subch, "newHeads")
 	if err != nil {
 		fmt.Println("subscribe error:", err)
 		return


### PR DESCRIPTION
fix a wrong subscription name
"newBlocks" deprecated
so, change it to "newHeads"