### PR TITLE
cmd/swarm: solve rare cases of using the same random port in tests

### DIFF
--- a/cmd/swarm/config_test.go
+++ b/cmd/swarm/config_test.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
+	"net"
 	"os"
 	"os/exec"
 	"testing"
@@ -558,4 +559,17 @@ func TestValidateConfig(t *testing.T) {
 			t.Errorf("unexpected error %q", err)
 		}
 	}
+}
+
+func assignTCPPort() (string, error) {
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		return "", err
+	}
+	l.Close()
+	_, port, err := net.SplitHostPort(l.Addr().String())
+	if err != nil {
+		return "", err
+	}
+	return port, nil
 }


### PR DESCRIPTION
This PR addresses two cases where the same tcp port can be selected when running newTestCluster or newTestNode in cmd/swarm tests. This has been detected in Travis build logs, but extremely rarely.

Function newTestNode selects two ports, one for http and one for rpc, using assignTCPPort function in sequence. That functions closes the listener so it is possible that the same port is selected for http and rpc listeners. New function getAvailableTCPPorts is created to solve this problem. Function assignTCPPort is moved to a file where it is only used.

If newTestCluster is creating more then one node, it is possible that one node can get the same http or rpc port as the previous one if the previous one did not start all listeners. New function waitTCPPorts is created and used to ensure that all expected listeners are active on provided ports.