### PR TITLE
eth: fix tracer GC which accidentally pruned the metaroot

### DIFF
--- a/eth/api_tracer.go
+++ b/eth/api_tracer.go
@@ -297,7 +297,9 @@ func (api *PrivateDebugAPI) traceChain(ctx context.Context, start, end *types.Bl
 				database.TrieDB().Reference(root, common.Hash{})
 			}
 			// Dereference all past tries we ourselves are done working with
-			database.TrieDB().Dereference(proot)
+			if proot != (common.Hash{}) {
+				database.TrieDB().Dereference(proot)
+			}
 			proot = root
 
 			// TODO(karalabe): Do we need the preimages? Won't they accumulate too much?
@@ -526,7 +528,9 @@ func (api *PrivateDebugAPI) computeStateDB(block *types.Block, reexec uint64) (*
 			return nil, err
 		}
 		database.TrieDB().Reference(root, common.Hash{})
-		database.TrieDB().Dereference(proot)
+		if proot != (common.Hash{}) {
+			database.TrieDB().Dereference(proot)
+		}
 		proot = root
 	}
 	nodes, imgs := database.TrieDB().Size()

--- a/trie/database.go
+++ b/trie/database.go
@@ -431,6 +431,11 @@ func (db *Database) reference(child common.Hash, parent common.Hash) {
 
 // Dereference removes an existing reference from a root node.
 func (db *Database) Dereference(root common.Hash) {
+	// Sanity check to ensure that the meta-root is not removed
+	if root == (common.Hash{}) {
+		log.Error("Attempted to dereference the trie cache meta root")
+		return
+	}
 	db.lock.Lock()
 	defer db.lock.Unlock()
 


### PR DESCRIPTION
Fixes https://github.com/ethereum/go-ethereum/issues/17355.

Block tracing that regenerates state is currently broken. It dereferences `common.Hash{}` in its first iteration when there is no parent block (thus the parent root is `0x00...0`). This ends up destroying the special node inside the cache `0x00...0` which acts as a meta-root for the account tries across blocks. 

This was broken all along, but didn't show up until now because the meta root has 0 references, and the trie cache originally underflowed when decrementing it. The underflow was fixed a while ago, which resulted in the meta root being garbage collected, and then paniced.