### PR TITLE
rpc/json.go : add response status

### DIFF
--- a/rpc/json.go
+++ b/rpc/json.go
@@ -46,6 +46,7 @@ type jsonRequest struct {
 
 type jsonSuccessResponse struct {
 	Version string      `json:"jsonrpc"`
+	Status  string      `json:"status"`
 	Id      interface{} `json:"id,omitempty"`
 	Result  interface{} `json:"result"`
 }
@@ -58,6 +59,7 @@ type jsonError struct {
 
 type jsonErrResponse struct {
 	Version string      `json:"jsonrpc"`
+	Status  string 	    `json:"status"`
 	Id      interface{} `json:"id,omitempty"`
 	Error   jsonError   `json:"error"`
 }
@@ -320,12 +322,12 @@ func parsePositionalArguments(rawArgs json.RawMessage, types []reflect.Type) ([]
 
 // CreateResponse will create a JSON-RPC success response with the given id and reply as result.
 func (c *jsonCodec) CreateResponse(id interface{}, reply interface{}) interface{} {
-	return &jsonSuccessResponse{Version: jsonrpcVersion, Id: id, Result: reply}
+	return &jsonSuccessResponse{Version: jsonrpcVersion,Status:"success", Id: id, Result: reply}
 }
 
 // CreateErrorResponse will create a JSON-RPC error response with the given id and error.
 func (c *jsonCodec) CreateErrorResponse(id interface{}, err Error) interface{} {
-	return &jsonErrResponse{Version: jsonrpcVersion, Id: id, Error: jsonError{Code: err.ErrorCode(), Message: err.Error()}}
+	return &jsonErrResponse{Version: jsonrpcVersion,Status:"failed", Id: id, Error: jsonError{Code: err.ErrorCode(), Message: err.Error()}}
 }
 
 // CreateErrorResponseWithInfo will create a JSON-RPC error response with the given id and error.


### PR DESCRIPTION
clients can distinguish the state of the request