### PR TITLE
swarm/api/http: added logging to denote request ended

### DIFF
--- a/swarm/api/http/middleware.go
+++ b/swarm/api/http/middleware.go
@@ -64,8 +64,8 @@ func ParseURI(h http.Handler) http.Handler {
 func InitLoggingResponseWriter(h http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		writer := newLoggingResponseWriter(w)
-
 		h.ServeHTTP(writer, r)
+		log.Debug("request served", "ruid", GetRUID(r.Context()), "code", writer.statusCode)
 	})
 }
 

--- a/swarm/api/http/response.go
+++ b/swarm/api/http/response.go
@@ -84,15 +84,16 @@ func RespondError(w http.ResponseWriter, r *http.Request, msg string, code int) 
 }
 
 func respond(w http.ResponseWriter, r *http.Request, params *ResponseParams) {
+
 	w.WriteHeader(params.Code)
 
 	if params.Code >= 400 {
-		w.Header().Del("Cache-Control") //avoid sending cache headers for errors!
+		w.Header().Del("Cache-Control")
 		w.Header().Del("ETag")
 	}
 
 	acceptHeader := r.Header.Get("Accept")
-	// this cannot be in a switch form since an Accept header can be in the form of "Accept: */*, text/html, application/xhtml+xml, application/xml;q=0.9, */*;q=0.8"
+	// this cannot be in a switch since an Accept header can have multiple values: "Accept: */*, text/html, application/xhtml+xml, application/xml;q=0.9, */*;q=0.8"
 	if strings.Contains(acceptHeader, "application/json") {
 		if err := respondJSON(w, r, params); err != nil {
 			RespondError(w, r, "Internal server error", http.StatusInternalServerError)


### PR DESCRIPTION
this PR addresses a necessary log line that indicates with which status code a request was served

resolves https://github.com/ethersphere/go-ethereum/issues/875
