### PR TITLE
common/compiler: support relative import paths

### DIFF
--- a/common/compiler/solidity.go
+++ b/common/compiler/solidity.go
@@ -72,6 +72,7 @@ func (s *Solidity) makeArgs() []string {
 	p := []string{
 		"--combined-json", "bin,abi,userdoc,devdoc",
 		"--optimize", // code optimizer switched on
+		"--allow-paths", "., ./, ../", //default to support relative path： ./  ../  . 
 	}
 	if s.Major > 0 || s.Minor > 4 || s.Patch > 6 {
 		p[1] += ",metadata"


### PR DESCRIPTION
in the  solidity contacts import paths, default to support relative path：" ./  ../  . " .