### PR TITLE
eth: fix empty pointer issue

### DIFF
--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -107,7 +107,6 @@ type BlockChain struct {
 	chainmu sync.RWMutex // blockchain insertion lock
 	procmu  sync.RWMutex // block processor lock
 
-	checkpoint       int          // checkpoint counts towards the new checkpoint
 	currentBlock     atomic.Value // Current head of the block chain
 	currentFastBlock atomic.Value // Current head of the fast-sync chain (may be above the block chain!)
 

--- a/eth/sync.go
+++ b/eth/sync.go
@@ -171,7 +171,7 @@ func (pm *ProtocolManager) synchronise(peer *peer) {
 	td := pm.blockchain.GetTd(currentBlock.Hash(), currentBlock.NumberU64())
 
 	pHead, pTd := peer.Head()
-	if pTd.Cmp(td) <= 0 {
+	if pTd == nil || pTd.Cmp(td) <= 0 {
 		return
 	}
 	// Otherwise try to sync with the downloader
@@ -190,8 +190,10 @@ func (pm *ProtocolManager) synchronise(peer *peer) {
 	}
 
 	if mode == downloader.FastSync {
+		currentFastBlock := pm.blockchain.CurrentFastBlock()
+		fastTd := pm.blockchain.GetTd(currentFastBlock.Hash(), currentFastBlock.NumberU64())
 		// Make sure the peer's total difficulty we are synchronizing is higher.
-		if pm.blockchain.GetTdByHash(pm.blockchain.CurrentFastBlock().Hash()).Cmp(pTd) >= 0 {
+		if pTd.Cmp(fastTd) <= 0 {
 			return
 		}
 	}


### PR DESCRIPTION
Fix #17379
**Still work in progress to find the true cause for `empty fastTd`**
