### PR TITLE
[package miner worker.go]Change the judgment into if :P

### DIFF
--- a/miner/worker.go
+++ b/miner/worker.go
@@ -417,8 +417,7 @@ func (self *worker) commitNewWork() {
 		}
 	}
 	// Could potentially happen if starting to mine in an odd state.
-	err := self.makeCurrent(parent, header)
-	if err != nil {
+	if err := self.makeCurrent(parent, header); err != nil {
 		log.Error("Failed to create mining context", "err", err)
 		return
 	}


### PR DESCRIPTION
I move "err := self.makeCurrent(parent, header)" into if
because when i make geth on Ubuntu. Sometime it will happen the following mistake T_T

miner/worker.go:420:6: no new variables on left side of :=