### PR TITLE
cmd/puppeth: Accept ssh identity in the server string

### DIFF
--- a/cmd/puppeth/wizard_network.go
+++ b/cmd/puppeth/wizard_network.go
@@ -18,6 +18,7 @@ package main
 
 import (
 	"fmt"
+	"os/user"
 	"strings"
 
 	"github.com/ethereum/go-ethereum/log"
@@ -62,14 +63,22 @@ func (w *wizard) manageServers() {
 	}
 }
 
-// makeServer reads a single line from stdin and interprets it as a hostname to
-// connect to. It tries to establish a new SSH session and also executing some
+// makeServer reads a single line from stdin and interprets it as
+// username:identity@hostname to connect to.
+// It tries to establish a new SSH session and also executing some
 // baseline validations.
 //
 // If connection succeeds, the server is added to the wizards configs!
 func (w *wizard) makeServer() string {
+	login := ""
+	user, err := user.Current()
+	if err == nil {
+		login = user.Username
+	}
+
 	fmt.Println()
-	fmt.Println("Please enter remote server's address:")
+	fmt.Println("Please enter remote server (username:identity@hostname:port)")
+	fmt.Printf("If not given, will use username = %s, identity = id_rsa\n", login)
 
 	// Read and dial the server to ensure docker is present
 	input := w.readString()

--- a/cmd/puppeth/wizard_network.go
+++ b/cmd/puppeth/wizard_network.go
@@ -18,7 +18,6 @@ package main
 
 import (
 	"fmt"
-	"os/user"
 	"strings"
 
 	"github.com/ethereum/go-ethereum/log"
@@ -64,21 +63,13 @@ func (w *wizard) manageServers() {
 }
 
 // makeServer reads a single line from stdin and interprets it as
-// username:identity@hostname to connect to.
-// It tries to establish a new SSH session and also executing some
-// baseline validations.
+// username:identity@hostname to connect to. It tries to establish a
+// new SSH session and also executing some baseline validations.
 //
 // If connection succeeds, the server is added to the wizards configs!
 func (w *wizard) makeServer() string {
-	login := ""
-	user, err := user.Current()
-	if err == nil {
-		login = user.Username
-	}
-
 	fmt.Println()
-	fmt.Println("Please enter remote server (username:identity@hostname:port)")
-	fmt.Printf("If not given, will use username = %s, identity = id_rsa\n", login)
+	fmt.Println("What is the remote server's address ([username[:identity]@]hostname[:port])?")
 
 	// Read and dial the server to ensure docker is present
 	input := w.readString()


### PR DESCRIPTION
This should fix #15532 .

Server string can now be in this format: username:identity@hostname:port. Only hostname is mandatory. We now fall back to username = current system username, identity = id_rsa and port = 22.

This allows the user to specify a different SSH identity file for each server and persist it.

The entire server string is returned as a label because I couldn't find the rationale for current behavior which seems over-complicated.