### PR TITLE
miner: regenerate mining work every 3 seconds

### DIFF
--- a/core/events.go
+++ b/core/events.go
@@ -29,9 +29,6 @@ type PendingLogsEvent struct {
 	Logs []*types.Log
 }
 
-// PendingStateEvent is posted pre mining and notifies of pending state changes.
-type PendingStateEvent struct{}
-
 // NewMinedBlockEvent is posted when a block has been imported.
 type NewMinedBlockEvent struct{ Block *types.Block }
 


### PR DESCRIPTION
*Copy from peter's PR description*

Ideally every time a new transaction arrives, miners would integrate it immediately into the current block, potentially pushing older ones out. Practically there is a trade-off to balance: it's cheap to run a transaction on top of an existing block, but it might not fit (usually, won't). It's expensive to push an existing transaction out (requires rerunning everything), but gets us the most profit.

In an ideal world, we would regenerate the block for every received transaction, but that's not realistic. In a more pragmatic approach, we can run a timer within a miner to regenerate the mining block every 3 seconds. That will with a very high probability maximize mining profits, whilst keeping spurious processing down. This PR implements this algorithm.

The streaming transaction inclusion could be further expanded to inject new transactions immediately on top of the existing ones when they arrive, but that assumes blocks are not full in the first place. Maybe on some private networks this could hold, but I'm not really sure it's worth the added complexity.