### PR TITLE
build: do not require `ethereum-swarm` deb when installing `ethereum`

### DIFF
--- a/build/ci.go
+++ b/build/ci.go
@@ -644,17 +644,6 @@ func (meta debMetadata) ExeName(exe debExecutable) string {
 	return exe.Package()
 }
 
-// EthereumSwarmPackageName returns the name of the swarm package based on
-// environment, e.g. "ethereum-swarm-unstable", or "ethereum-swarm".
-// This is needed so that we make sure that "ethereum" package,
-// depends on and installs "ethereum-swarm"
-func (meta debMetadata) EthereumSwarmPackageName() string {
-	if isUnstableBuild(meta.Env) {
-		return debSwarm.Name + "-unstable"
-	}
-	return debSwarm.Name
-}
-
 // ExeConflicts returns the content of the Conflicts field
 // for executable packages.
 func (meta debMetadata) ExeConflicts(exe debExecutable) string {

--- a/build/deb/ethereum/deb.control
+++ b/build/deb/ethereum/deb.control
@@ -10,7 +10,7 @@ Vcs-Browser: https://github.com/ethereum/go-ethereum
 
 Package: {{.Name}}
 Architecture: any
-Depends: ${misc:Depends}, {{.EthereumSwarmPackageName}}, {{.ExeList}}
+Depends: ${misc:Depends}, {{.ExeList}}
 Description: Meta-package to install geth, swarm, and other tools
  Meta-package to install geth, swarm and other tools
 


### PR DESCRIPTION
This PR is removing the hack which explicitly added `ethereum-swarm` as a requirement for `ethereum` deb package.