### PR TITLE
swarm: disable act compile

### DIFF
--- a/cmd/swarm/access_test.go
+++ b/cmd/swarm/access_test.go
@@ -13,6 +13,9 @@
 //
 // You should have received a copy of the GNU General Public License
 // along with go-ethereum. If not, see <http://www.gnu.org/licenses/>.
+//
+// +build linux
+
 package main
 
 import (


### PR DESCRIPTION
DO NOT MERGE: disabling act tests to try and trace why our mac builds are red