### PR TITLE
travis: remove brew update and osxfuse install

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,8 +30,6 @@ matrix:
       go: 1.10.x
       script:
         - unset -f cd # workaround for https://github.com/travis-ci/travis-ci/issues/8703
-        - brew update
-        - brew cask install osxfuse
         - go run build/ci.go install
         - go run build/ci.go test -coverage $TEST_PACKAGES
 


### PR DESCRIPTION
FUSE tests have been disabled on macOS, see https://github.com/ethereum/go-ethereum/pull/17340

Because of this, I believe we don't need `brew update` or `brew install osxfuse`, which together take >80sec per test run on macOS.