### PR TITLE
eth: add debug_accountRange

### DIFF
--- a/cmd/geth/retesteth.go
+++ b/cmd/geth/retesteth.go
@@ -86,7 +86,7 @@ type RetestethEthAPI interface {
 }
 
 type RetestethDebugAPI interface {
-	AccountRangeAt(ctx context.Context,
+	AccountRange(ctx context.Context,
 		blockHashOrNumber *math.HexOrDecimal256, txIndex uint64,
 		addressHash *math.HexOrDecimal256, maxResults uint64,
 	) (AccountRangeResult, error)
@@ -604,7 +604,7 @@ func (api *RetestethAPI) GetBlockByNumber(ctx context.Context, blockNr math.HexO
 	return nil, fmt.Errorf("block %d not found", blockNr)
 }
 
-func (api *RetestethAPI) AccountRangeAt(ctx context.Context,
+func (api *RetestethAPI) AccountRange(ctx context.Context,
 	blockHashOrNumber *math.HexOrDecimal256, txIndex uint64,
 	addressHash *math.HexOrDecimal256, maxResults uint64,
 ) (AccountRangeResult, error) {

--- a/eth/api.go
+++ b/eth/api.go
@@ -368,9 +368,8 @@ func accountRange(st state.Trie, start *common.Hash, maxResults int) (AccountRan
 	return result, nil
 }
 
-const (
-	AccountRangeMaxResults = 256
-)
+// AccountRangeMaxResults is the maximum number of results to be returned per call
+const AccountRangeMaxResults = 256
 
 // AccountRange enumerates all accounts in the latest state
 func (api *PrivateDebugAPI) AccountRange(ctx context.Context, start *common.Hash, maxResults int) (AccountRangeResult, error) {

--- a/eth/api.go
+++ b/eth/api.go
@@ -19,8 +19,8 @@ package eth
 import (
 	"compress/gzip"
 	"context"
-	"errors"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"io"
 	"math/big"
@@ -363,11 +363,19 @@ func accountRange(st state.Trie, start *common.Address, maxResult int) (AccountR
 	return result, nil
 }
 
-// enumerate all accounts in the latest state
+const (
+	AccountRangeAtMaxResults = 256
+)
+
+// AccountRangeAt enumerates all accounts in the latest state
 func (api *PrivateDebugAPI) AccountRangeAt(ctx context.Context, startAddr *common.Address, maxResults int) (AccountRangeResult, error) {
-	var statedb *state.StateDB = nil
-	var err error = nil
-	var block = api.eth.blockchain.CurrentBlock()
+	var statedb *state.StateDB
+	var err error
+	block := api.eth.blockchain.CurrentBlock()
+
+	if maxResults > AccountRangeAtMaxResults {
+		maxResults = AccountRangeAtMaxResults
+	}
 
 	if len(block.Transactions()) == 0 {
 		parent := api.eth.blockchain.GetBlock(block.ParentHash(), block.NumberU64()-1)

--- a/eth/api.go
+++ b/eth/api.go
@@ -356,7 +356,7 @@ func accountRange(st state.Trie, start *common.Address, maxResult int) (AccountR
 	return result, nil
 }
 
-//block hash or number, tx index, start address hash, max results
+// enumerate all accounts in the state after the last transaction in the latest block
 func (api *PrivateDebugAPI) AccountRangeAt(ctx context.Context, startAddr *common.Address, maxResults int) (AccountRangeResult, error) {
 	var statedb *state.StateDB = nil
 	var err error = nil

--- a/eth/api.go
+++ b/eth/api.go
@@ -28,13 +28,13 @@ import (
 	"strings"
 	"time"
 
-	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/core"
 	"github.com/ethereum/go-ethereum/core/rawdb"
 	"github.com/ethereum/go-ethereum/core/state"
 	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/internal/ethapi"
 	"github.com/ethereum/go-ethereum/rlp"
 	"github.com/ethereum/go-ethereum/rpc"
@@ -336,10 +336,10 @@ func (api *PrivateDebugAPI) GetBadBlocks(ctx context.Context) ([]*BadBlockArgs, 
 }
 
 type AccountRangeResult struct {
-	Addresses []common.Address `json:"addresses"`
-	Next common.Address `json:"next"`
-	Preimages []common.Hash `json:"preimages"`
-	NextPreimage common.Hash `json:"nextPreimage"`
+	Addresses    []common.Address `json:"addresses"`
+	Next         common.Address   `json:"next"`
+	Preimages    []common.Hash    `json:"preimages"`
+	NextPreimage common.Hash      `json:"nextPreimage"`
 }
 
 func accountRange(st state.Trie, start *common.Address, maxResult int) (AccountRangeResult, error) {

--- a/eth/api.go
+++ b/eth/api.go
@@ -19,7 +19,6 @@ package eth
 import (
 	"compress/gzip"
 	"context"
-	"encoding/hex"
 	"errors"
 	"fmt"
 	"io"
@@ -363,11 +362,7 @@ func accountRange(st state.Trie, start *common.Hash, maxResults int) (AccountRan
 	}
 
 	if it.Next() {
-		if preimage := st.GetKey(it.Key); preimage != nil {
-			result.Next = common.BytesToHash(it.Key)
-		} else {
-			return AccountRangeResult{}, fmt.Errorf("preimage not found for 0x%s", hex.EncodeToString(it.Key))
-		}
+		result.Next = common.BytesToHash(it.Key)
 	}
 
 	return result, nil

--- a/eth/api.go
+++ b/eth/api.go
@@ -378,11 +378,7 @@ func (api *PrivateDebugAPI) AccountRangeAt(ctx context.Context, start *common.Ha
 	block := api.eth.blockchain.CurrentBlock()
 
 	if len(block.Transactions()) == 0 {
-		parent := api.eth.blockchain.GetBlock(block.ParentHash(), block.NumberU64()-1)
-		if parent == nil {
-			return AccountRangeResult{}, fmt.Errorf("parent %x not found", block.ParentHash())
-		}
-		statedb, err = api.computeStateDB(parent, defaultTraceReexec)
+		statedb, err = api.computeStateDB(block, defaultTraceReexec)
 		if err != nil {
 			return AccountRangeResult{}, err
 		}

--- a/eth/api.go
+++ b/eth/api.go
@@ -345,8 +345,8 @@ func accountRange(st state.Trie, start *common.Address, maxResults int) (Account
 	it := trie.NewIterator(st.NodeIterator(crypto.Keccak256(start[:])))
 	result := AccountRangeResult{Addresses: []common.Address{}, Next: common.Address{}}
 
-	if maxResults > AccountRangeAtMaxResults {
-		maxResults = AccountRangeAtMaxResults
+	if maxResults > AccountRangeMaxResults {
+		maxResults = AccountRangeMaxResults
 	}
 
 	for i := 0; i < maxResults && it.Next(); i++ {
@@ -369,7 +369,7 @@ func accountRange(st state.Trie, start *common.Address, maxResults int) (Account
 }
 
 const (
-	AccountRangeAtMaxResults = 256
+	AccountRangeMaxResults = 256
 )
 
 // AccountRangeAt enumerates all accounts in the latest state

--- a/eth/api.go
+++ b/eth/api.go
@@ -371,8 +371,8 @@ const (
 	AccountRangeMaxResults = 256
 )
 
-// AccountRangeAt enumerates all accounts in the latest state
-func (api *PrivateDebugAPI) AccountRangeAt(ctx context.Context, start *common.Hash, maxResults int) (AccountRangeResult, error) {
+// AccountRange enumerates all accounts in the latest state
+func (api *PrivateDebugAPI) AccountRange(ctx context.Context, start *common.Hash, maxResults int) (AccountRangeResult, error) {
 	var statedb *state.StateDB
 	var err error
 	block := api.eth.blockchain.CurrentBlock()

--- a/eth/api.go
+++ b/eth/api.go
@@ -344,6 +344,9 @@ type AccountRangeResult struct {
 }
 
 func accountRange(st state.Trie, start *common.Hash, maxResults int) (AccountRangeResult, error) {
+	if start == nil {
+		start = &common.Hash{0}
+	}
 	it := trie.NewIterator(st.NodeIterator(start.Bytes()))
 	result := AccountRangeResult{Accounts: make(map[common.Hash]*common.Address), Next: common.Hash{}}
 

--- a/eth/api.go
+++ b/eth/api.go
@@ -338,19 +338,28 @@ func (api *PrivateDebugAPI) GetBadBlocks(ctx context.Context) ([]*BadBlockArgs, 
 type AccountRangeResult struct {
 	Addresses []common.Address `json:"addresses"`
 	Next common.Address `json:"next"`
+	Preimages []common.Hash `json:"preimages"`
+	NextPreimage common.Hash `json:"nextPreimage"`
 }
 
 func accountRange(st state.Trie, start *common.Address, maxResult int) (AccountRangeResult, error) {
 	it := trie.NewIterator(st.NodeIterator(crypto.Keccak256(start[:])))
-	result := AccountRangeResult{Addresses: []common.Address{}, Next: common.Address{}}
+	result := AccountRangeResult{Addresses: []common.Address{}, Next: common.Address{}, Preimages: []common.Hash{}, NextPreimage: common.Hash{}}
 	for i := 0; i < maxResult && it.Next(); i++ {
 		if preimage := st.GetKey(it.Key); preimage != nil {
 			result.Addresses = append(result.Addresses, common.BytesToAddress(preimage))
+		} else {
+			result.Preimages = append(result.Preimages, common.BytesToHash(preimage))
 		}
 	}
 
 	if it.Next() {
-		result.Next = common.BytesToAddress(st.GetKey(it.Key))
+		if preimage := st.GetKey(it.Key); preimage != nil {
+			result.Next = common.BytesToAddress(st.GetKey(preimage))
+		} else {
+			result.NextPreimage = common.BytesToHash(preimage)
+		}
+
 	}
 
 	return result, nil

--- a/eth/api.go
+++ b/eth/api.go
@@ -357,7 +357,7 @@ func accountRange(st state.Trie, start *common.Address, maxResult int) (AccountR
 }
 
 //block hash or number, tx index, start address hash, max results
-func (api *PrivateDebugAPI) AccountRangeAt(ctx context.Context, txIndex int, startAddr *common.Address, maxResults int) (AccountRangeResult, error) {
+func (api *PrivateDebugAPI) AccountRangeAt(ctx context.Context, startAddr *common.Address, maxResults int) (AccountRangeResult, error) {
 	var statedb *state.StateDB = nil
 	var err error = nil
 	var block = api.eth.blockchain.CurrentBlock()

--- a/eth/api.go
+++ b/eth/api.go
@@ -336,20 +336,20 @@ func (api *PrivateDebugAPI) GetBadBlocks(ctx context.Context) ([]*BadBlockArgs, 
 }
 
 type AccountRangeResult struct {
-	Addresses    []common.Address `json:"addresses"`
-	Next         common.Address   `json:"next"`
-	Preimages    []common.Hash    `json:"preimages"`
-	NextPreimage common.Hash      `json:"nextPreimage"`
+	Addresses []common.Address `json:"addresses"`
+	Next      common.Address   `json:"next"`
+	Images    []common.Hash    `json:"preimages"`
+	NextImage common.Hash      `json:"nextPreimage"`
 }
 
 func accountRange(st state.Trie, start *common.Address, maxResult int) (AccountRangeResult, error) {
 	it := trie.NewIterator(st.NodeIterator(crypto.Keccak256(start[:])))
-	result := AccountRangeResult{Addresses: []common.Address{}, Next: common.Address{}, Preimages: []common.Hash{}, NextPreimage: common.Hash{}}
+	result := AccountRangeResult{Addresses: []common.Address{}, Next: common.Address{}, Images: []common.Hash{}, NextImage: common.Hash{}}
 	for i := 0; i < maxResult && it.Next(); i++ {
 		if preimage := st.GetKey(it.Key); preimage != nil {
 			result.Addresses = append(result.Addresses, common.BytesToAddress(preimage))
 		} else {
-			result.Preimages = append(result.Preimages, common.BytesToHash(preimage))
+			result.Images = append(result.Images, common.BytesToHash(it.Key))
 		}
 	}
 
@@ -357,9 +357,8 @@ func accountRange(st state.Trie, start *common.Address, maxResult int) (AccountR
 		if preimage := st.GetKey(it.Key); preimage != nil {
 			result.Next = common.BytesToAddress(st.GetKey(preimage))
 		} else {
-			result.NextPreimage = common.BytesToHash(preimage)
+			result.NextImage = common.BytesToHash(it.Key)
 		}
-
 	}
 
 	return result, nil

--- a/eth/api_test.go
+++ b/eth/api_test.go
@@ -27,6 +27,8 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/rawdb"
 	"github.com/ethereum/go-ethereum/core/state"
+	"github.com/ethereum/go-ethereum/ethdb"
+	"github.com/ethereum/go-ethereum/crypto"
 )
 
 var dumper = spew.ConfigState{Indent: "    "}
@@ -55,12 +57,19 @@ func TestAccountRangeAt(t *testing.T) {
 		statedb  = state.NewDatabase(ethdb.NewMemDatabase())
 		state, _ = state.New(common.Hash{}, statedb)
 		addrs    = [AccountRangeMaxResults * 2]common.Address{}
+		m	 = map[common.Address]bool{}
 	)
 
 	for i := range addrs {
-		addr := fmt.Sprintf("%x", i)
-		addrs[i] = common.HexToAddress(addr)
+		hash := common.HexToHash(fmt.Sprintf("%x", i))
+		addr := common.BytesToAddress(crypto.Keccak256Hash(hash.Bytes()).Bytes())
+		addrs[i] = addr
 		state.SetBalance(addrs[i], big.NewInt(1))
+		if _, ok := m[addr]; ok {
+			t.Fatalf("bad")
+		} else {
+			m[addr] = true
+		}
 	}
 
 	state.Commit(true)

--- a/eth/api_test.go
+++ b/eth/api_test.go
@@ -27,13 +27,13 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/rawdb"
 	"github.com/ethereum/go-ethereum/core/state"
-	"github.com/ethereum/go-ethereum/ethdb"
 	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/ethdb"
 )
 
 var dumper = spew.ConfigState{Indent: "    "}
 
-func accountRangeTest(t *testing.T, trie *state.Trie, statedb *state.StateDB, start *common.Address, requestedNum int, expectedNum int) AccountRangeResult {
+func accountRangeTest(t *testing.T, trie *state.Trie, statedb *state.StateDB, start *common.Hash, requestedNum int, expectedNum int) AccountRangeResult {
 	result, err := accountRange(*trie, start, requestedNum)
 	if err != nil {
 		t.Fatal(err)
@@ -57,7 +57,7 @@ func TestAccountRangeAt(t *testing.T) {
 		statedb  = state.NewDatabase(ethdb.NewMemDatabase())
 		state, _ = state.New(common.Hash{}, statedb)
 		addrs    = [AccountRangeMaxResults * 2]common.Address{}
-		m	 = map[common.Address]bool{}
+		m        = map[common.Address]bool{}
 	)
 
 	for i := range addrs {
@@ -81,15 +81,15 @@ func TestAccountRangeAt(t *testing.T) {
 	}
 
 	t.Logf("test getting number of results less than max")
-	accountRangeTest(t, &trie, state, &common.Address{0x0}, AccountRangeMaxResults / 2, AccountRangeMaxResults / 2)
+	accountRangeTest(t, &trie, state, &common.Hash{0x0}, AccountRangeMaxResults/2, AccountRangeMaxResults/2)
 
 	t.Logf("test getting number of results greater than max %d", AccountRangeMaxResults)
-	accountRangeTest(t, &trie, state, &common.Address{0x0}, AccountRangeMaxResults * 2, AccountRangeMaxResults)
+	accountRangeTest(t, &trie, state, &common.Hash{0x0}, AccountRangeMaxResults*2, AccountRangeMaxResults)
 
 	t.Logf("test pagination")
 
 	// test pagination
-	firstResult := accountRangeTest(t, &trie, state, &common.Address{0x0}, AccountRangeMaxResults, AccountRangeMaxResults)
+	firstResult := accountRangeTest(t, &trie, state, &common.Hash{0x0}, AccountRangeMaxResults, AccountRangeMaxResults)
 
 	t.Logf("test pagination 2")
 	secondResult := accountRangeTest(t, &trie, state, &firstResult.Next, AccountRangeMaxResults, AccountRangeMaxResults)

--- a/eth/api_test.go
+++ b/eth/api_test.go
@@ -102,6 +102,32 @@ func TestAccountRangeAt(t *testing.T) {
 	}
 }
 
+func TestEmptyAccountRangeAt(t *testing.T) {
+	var (
+		statedb  = state.NewDatabase(rawdb.NewMemoryDatabase())
+		state, _ = state.New(common.Hash{}, statedb)
+	)
+
+	state.Commit(true)
+	root := state.IntermediateRoot(true)
+
+	trie, err := statedb.OpenTrie(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	results, err := accountRange(trie, &common.Hash{0x0}, AccountRangeMaxResults)
+	if err != nil {
+		t.Fatalf("Empty results should not trigger an error: %v", err)
+	}
+	if results.Next != common.HexToHash("0") {
+		t.Fatalf("Empty results should not return a second page")
+	}
+	if len(results.Addresses) != 0 {
+		t.Fatalf("Empty state should not return addresses: %v", results.Addresses)
+	}
+}
+
 func TestStorageRangeAt(t *testing.T) {
 	// Create a state where account 0x010000... has a few storage entries.
 	var (

--- a/eth/api_test.go
+++ b/eth/api_test.go
@@ -45,14 +45,12 @@ func TestAccountRangeAt(t *testing.T) {
 		state.SetBalance(addrs[i], big.NewInt(1))
 	}
 
-	// test retrieving less than max results
+	state.CommitTrie() // is this needed?
 
-/*
-	result := accountRangeAt(state.Trie(), common.Address{0x0}, 128)
+	result := accountRange(state.Database().OpenTrie(/* root ??? */), common.Address{0x0}, 128)
 	if len(result.Addresses) != 128 {
 		t.Fatalf("expected 128 results.  Got %d", len(result.Addresses))
 	}
-*/
 }
 
 func TestStorageRangeAt(t *testing.T) {

--- a/eth/api_test.go
+++ b/eth/api_test.go
@@ -19,9 +19,7 @@ package eth
 import (
 	"reflect"
 	"testing"
-        "math/big"
 
-        "github.com/ethereum/go-ethereum/crypto"
 	"github.com/davecgh/go-spew/spew"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/rawdb"

--- a/eth/api_test.go
+++ b/eth/api_test.go
@@ -51,7 +51,7 @@ func accountRangeTest(t *testing.T, trie *state.Trie, statedb *state.StateDB, st
 	return result
 }
 
-func TestAccountRangeAt(t *testing.T) {
+func TestAccountRange(t *testing.T) {
 	var (
 		statedb  = state.NewDatabase(rawdb.NewMemoryDatabase())
 		state, _ = state.New(common.Hash{}, statedb)
@@ -102,7 +102,7 @@ func TestAccountRangeAt(t *testing.T) {
 	}
 }
 
-func TestEmptyAccountRangeAt(t *testing.T) {
+func TestEmptyAccountRange(t *testing.T) {
 	var (
 		statedb  = state.NewDatabase(rawdb.NewMemoryDatabase())
 		state, _ = state.New(common.Hash{}, statedb)

--- a/eth/api_test.go
+++ b/eth/api_test.go
@@ -88,6 +88,9 @@ func TestAccountRange(t *testing.T) {
 	t.Logf("test getting number of results greater than max %d", AccountRangeMaxResults)
 	accountRangeTest(t, &trie, state, &common.Hash{0x0}, AccountRangeMaxResults*2, AccountRangeMaxResults)
 
+	t.Logf("test with empty 'start' hash")
+	accountRangeTest(t, &trie, state, nil, AccountRangeMaxResults, AccountRangeMaxResults)
+
 	t.Logf("test pagination")
 
 	// test pagination

--- a/eth/api_test.go
+++ b/eth/api_test.go
@@ -30,51 +30,6 @@ import (
 
 var dumper = spew.ConfigState{Indent: "    "}
 
-func TestAccountRange(t *testing.T) {
-        state, _ := state.New(common.Hash{}, state.NewDatabase(ethdb.NewMemDatabase()))
-        expectedPreimages := make(map[common.Hash]interface{})
-
-        // create some accounts
-        for i := 0; i < 256; i++ {
-                address := common.Address{byte(i)}
-                obj := state.GetOrNewStateObject(address)
-                expectedPreimages[crypto.Keccak256Hash(address.Bytes())] = true
-                obj.AddBalance(big.NewInt(22))
-                obj.SetCode(crypto.Keccak256Hash([]byte{3, 3, 3, 3, 3, 3, 3}), []byte{3, 3, 3, 3, 3, 3, 3})
-
-                //root = state.Commit(false)
-        }
-
-        root, err := state.Commit(false)
-        if err != nil {
-                t.Fatalf("%s", err)
-        }
-
-        state.Finalise(false)
-
-        trie, err := state.Database().OpenTrie(root)
-        if err != nil {
-                t.Fatalf("%s", err)
-        }
-
-        zeroHash := crypto.Keccak256Hash(common.Hash{}.Bytes())
-        result, err := accountRange(trie, &zeroHash, 256)
-        if err != nil {
-                t.Fatalf("%s", err)
-        }
-
-        if len(result.Preimages) != 99 {
-                t.Fatalf("maximum number of results returned should be 99, returned %d", len(result.Preimages))
-        }
-
-        for _, v := range result.Preimages {
-                if _, ok := expectedPreimages[v]; !ok {
-                        t.Fatalf("expected to find preimage %s in result", v.String())
-                }
-        }
-
-}
-
 func TestStorageRangeAt(t *testing.T) {
 	// Create a state where account 0x010000... has a few storage entries.
 	var (

--- a/eth/api_test.go
+++ b/eth/api_test.go
@@ -17,6 +17,8 @@
 package eth
 
 import (
+	"math/big"
+	"fmt"
 	"reflect"
 	"testing"
 
@@ -27,6 +29,31 @@ import (
 )
 
 var dumper = spew.ConfigState{Indent: "    "}
+
+func TestAccountRangeAt(t *testing.T) {
+	var (
+		state, _ = state.New(common.Hash{}, state.NewDatabase(ethdb.NewMemDatabase()))
+		addrs = [512]common.Address{}
+	)
+
+	for i := 0; i < 512; i++ {
+		addr := fmt.Sprintf("%x", i)
+		addrs[i] = common.HexToAddress(addr)
+	}
+
+	for i := range addrs {
+		state.SetBalance(addrs[i], big.NewInt(1))
+	}
+
+	// test retrieving less than max results
+
+/*
+	result := accountRangeAt(state.Trie(), common.Address{0x0}, 128)
+	if len(result.Addresses) != 128 {
+		t.Fatalf("expected 128 results.  Got %d", len(result.Addresses))
+	}
+*/
+}
 
 func TestStorageRangeAt(t *testing.T) {
 	// Create a state where account 0x010000... has a few storage entries.

--- a/eth/api_test.go
+++ b/eth/api_test.go
@@ -28,7 +28,6 @@ import (
 	"github.com/ethereum/go-ethereum/core/rawdb"
 	"github.com/ethereum/go-ethereum/core/state"
 	"github.com/ethereum/go-ethereum/crypto"
-	"github.com/ethereum/go-ethereum/ethdb"
 )
 
 var dumper = spew.ConfigState{Indent: "    "}
@@ -54,7 +53,7 @@ func accountRangeTest(t *testing.T, trie *state.Trie, statedb *state.StateDB, st
 
 func TestAccountRangeAt(t *testing.T) {
 	var (
-		statedb  = state.NewDatabase(ethdb.NewMemDatabase())
+		statedb  = state.NewDatabase(rawdb.NewMemoryDatabase())
 		state, _ = state.New(common.Hash{}, statedb)
 		addrs    = [AccountRangeMaxResults * 2]common.Address{}
 		m        = map[common.Address]bool{}

--- a/eth/api_test.go
+++ b/eth/api_test.go
@@ -18,8 +18,8 @@ package eth
 
 import (
 	"bytes"
-	"math/big"
 	"fmt"
+	"math/big"
 	"reflect"
 	"testing"
 
@@ -52,9 +52,9 @@ func accountRangeExpect(t *testing.T, trie *state.Trie, statedb *state.StateDB, 
 
 func TestAccountRangeAt(t *testing.T) {
 	var (
-		statedb = state.NewDatabase(ethdb.NewMemDatabase())
+		statedb  = state.NewDatabase(ethdb.NewMemDatabase())
 		state, _ = state.New(common.Hash{}, statedb)
-		addrs = [512]common.Address{}
+		addrs    = [512]common.Address{}
 	)
 
 	for i := 0; i < 512; i++ {


### PR DESCRIPTION
**WIP** Adds a debug API method `AccountRangeAt` which returns all accounts in the state for a given block and transaction index.