### PR TITLE
swarm/network: bump bzz protocol version

### DIFF
--- a/swarm/network/protocol.go
+++ b/swarm/network/protocol.go
@@ -44,7 +44,7 @@ const (
 // BzzSpec is the spec of the generic swarm handshake
 var BzzSpec = &protocols.Spec{
 	Name:       "bzz",
-	Version:    5,
+	Version:    6,
 	MaxMsgSize: 10 * 1024 * 1024,
 	Messages: []interface{}{
 		HandshakeMsg{},

--- a/swarm/network/protocol_test.go
+++ b/swarm/network/protocol_test.go
@@ -31,7 +31,7 @@ import (
 )
 
 const (
-	TestProtocolVersion   = 5
+	TestProtocolVersion   = 6
 	TestProtocolNetworkID = 3
 )
 


### PR DESCRIPTION
This PR is needed because of https://github.com/ethersphere/go-ethereum/pull/816 - otherwise we would be getting errors after the handshake, due to nodes not being able to deserialise messages.