### PR TITLE
les: fix CHTRoot on nodeinfo for les2 mode

### DIFF
--- a/les/commons.go
+++ b/les/commons.go
@@ -87,7 +87,7 @@ func (c *lesCommons) nodeInfo() interface{} {
 		cht = light.TrustedCheckpoint{
 			SectionIdx:  sectionIndex,
 			SectionHead: sectionHead,
-			CHTRoot:     light.GetChtRoot(c.chainDb, sectionIndex, sectionHead),
+			CHTRoot:     light.GetChtV2Root(c.chainDb, sectionIndex, sectionHead),
 			BloomRoot:   light.GetBloomTrieRoot(c.chainDb, sectionIndex, sectionHead),
 		}
 	}


### PR DESCRIPTION
Fixing `CHTRoot: "0x0000000000000000000000000000000000000000000000000000000000000000"` while light sync is enabled as les2 by default