### PR TITLE
consensus/clique, light: light client snapshots on Rinkeby

### DIFF
--- a/consensus/clique/snapshot_test.go
+++ b/consensus/clique/snapshot_test.go
@@ -84,7 +84,7 @@ func (r *testerChainReader) GetHeaderByNumber(number uint64) *types.Header {
 	if number == 0 {
 		return rawdb.ReadHeader(r.db, rawdb.ReadCanonicalHash(r.db, 0), 0)
 	}
-	panic("not supported")
+	return nil
 }
 
 // Tests that voting is evaluated correctly for various simple and complex scenarios.

--- a/light/postprocess.go
+++ b/light/postprocess.go
@@ -58,28 +58,29 @@ type TrustedCheckpoint struct {
 	SectionHead, CHTRoot, BloomRoot common.Hash
 }
 
-var (
-	mainnetCheckpoint = TrustedCheckpoint{
+// trustedCheckpoints associates each known checkpoint with the genesis hash of the chain it belongs to
+var trustedCheckpoints = map[common.Hash]TrustedCheckpoint{
+	params.MainnetGenesisHash: {
 		name:        "mainnet",
 		SectionIdx:  187,
 		SectionHead: common.HexToHash("e6baa034efa31562d71ff23676512dec6562c1ad0301e08843b907e81958c696"),
 		CHTRoot:     common.HexToHash("28001955219719cf06de1b08648969139d123a9835fc760547a1e4dabdabc15a"),
 		BloomRoot:   common.HexToHash("395ca2373fc662720ac6b58b3bbe71f68aa0f38b63b2d3553dd32ff3c51eebc4"),
-	}
-
-	ropstenCheckpoint = TrustedCheckpoint{
+	},
+	params.TestnetGenesisHash: {
 		name:        "ropsten",
 		SectionIdx:  117,
 		SectionHead: common.HexToHash("9529b38631ae30783f56cbe4c3b9f07575b770ecba4f6e20a274b1e2f40fede1"),
 		CHTRoot:     common.HexToHash("6f48e9f101f1fac98e7d74fbbcc4fda138358271ffd974d40d2506f0308bb363"),
 		BloomRoot:   common.HexToHash("8242342e66e942c0cd893484e6736b9862ceb88b43ca344bb06a8285ac1b6d64"),
-	}
-)
-
-// trustedCheckpoints associates each known checkpoint with the genesis hash of the chain it belongs to
-var trustedCheckpoints = map[common.Hash]TrustedCheckpoint{
-	params.MainnetGenesisHash: mainnetCheckpoint,
-	params.TestnetGenesisHash: ropstenCheckpoint,
+	},
+	params.RinkebyGenesisHash: {
+		name:        "rinkeby",
+		SectionIdx:  85,
+		SectionHead: common.HexToHash("92cfa67afc4ad8ab0dcbc6fa49efd14b5b19402442e7317e6bc879d85f89d64d"),
+		CHTRoot:     common.HexToHash("2802ec92cd7a54a75bca96afdc666ae7b99e5d96cf8192dcfb09588812f51564"),
+		BloomRoot:   common.HexToHash("ebefeb31a9a42866d8cf2d2477704b4c3d7c20d0e4e9b5aaa77f396e016a1263"),
+	},
 }
 
 var (

--- a/params/config.go
+++ b/params/config.go
@@ -27,6 +27,7 @@ import (
 var (
 	MainnetGenesisHash = common.HexToHash("0xd4e56740f876aef8c010b86a40d5f56745a118d0906a34e69aec8c0db1cb8fa3")
 	TestnetGenesisHash = common.HexToHash("0x41941023680923e0fe4d74a34bdac8141f2540e3ae90623718e47d66d1ca4a2d")
+	RinkebyGenesisHash = common.HexToHash("0x6341fd3daf94b748c72ced5a5b26028f2474f5f00d824504e4fa37a75767e177")
 )
 
 var (


### PR DESCRIPTION
This PR extends the light client to support snapshot syncing on Rinkeby too:

 * Explicitly handle Clique chains by retrieving the epoch block, not the CHT head for a snapshot.
 * Extend Clique so snapshots can be trusted for epoch blocks too (with header), not just genesis.
 * Add the trusted checkpoint for block 2790000 on Rinkeby.