### PR TITLE
docs(CONTRIBUTING.md): Add Contributing instructions

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,16 +1,41 @@
+# Contributing
+
+Thank you for considering to help out with the source code! We welcome 
+contributions from anyone on the internet, and are grateful for even the 
+smallest of fixes!
+
+If you'd like to contribute to go-ethereum, please fork, fix, commit and send a 
+pull request for the maintainers to review and merge into the main code base. If
+ you wish to submit more complex changes though, please check up with the core 
+ devs first on [our gitter channel](https://gitter.im/ethereum/go-ethereum) to 
+ ensure those changes are in line with the general philosophy of the project 
+ and/or get some early feedback which can make both your efforts much lighter as
+  well as our review and merge procedures quick and simple.
+
+## Coding guidelines
+
+Please make sure your contributions adhere to our coding guidelines:
+
+ * Code must adhere to the official Go 
+[formatting](https://golang.org/doc/effective_go.html#formatting) guidelines 
+(i.e. uses [gofmt](https://golang.org/cmd/gofmt/)).
+ * Code must be documented adhering to the official Go 
+[commentary](https://golang.org/doc/effective_go.html#commentary) guidelines.
+ * Pull requests need to be based on and opened against the `master` branch.
+ * Commit messages should be prefixed with the package(s) they modify.
+   * E.g. "eth, rpc: make trace configs optional"
+
 ## Can I have feature X
 
-Before you do a feature request please check and make sure that it isn't possible
-through some other means. The JavaScript enabled console is a powerful feature
-in the right hands. Please check our [Wiki page](https://github.com/ethereum/go-ethereum/wiki) for more info
+Before you submit a feature request, please check and make sure that it isn't 
+possible through some other means. The JavaScript-enabled console is a powerful 
+feature in the right hands. Please check our 
+[Wiki page](https://github.com/ethereum/go-ethereum/wiki) for more info
 and help.
 
-## Contributing
+## Configuration, dependencies, and tests
 
-If you'd like to contribute to go-ethereum please fork, fix, commit and
-send a pull request. Commits which do not comply with the coding standards
-are ignored (use gofmt!).
-
-See [Developers' Guide](https://github.com/ethereum/go-ethereum/wiki/Developers'-Guide)
-for more details on configuring your environment, testing, and
-dependency management.
+Please see the [Developers' 
+Guide](https://github.com/ethereum/go-ethereum/wiki/Developers'-Guide)
+for more details on configuring your environment, managing project dependencies
+and testing procedures.

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -6,11 +6,11 @@ smallest of fixes!
 
 If you'd like to contribute to go-ethereum, please fork, fix, commit and send a 
 pull request for the maintainers to review and merge into the main code base. If
- you wish to submit more complex changes though, please check up with the core 
- devs first on [our gitter channel](https://gitter.im/ethereum/go-ethereum) to 
- ensure those changes are in line with the general philosophy of the project 
- and/or get some early feedback which can make both your efforts much lighter as
-  well as our review and merge procedures quick and simple.
+you wish to submit more complex changes though, please check up with the core 
+devs first on [our gitter channel](https://gitter.im/ethereum/go-ethereum) to 
+ensure those changes are in line with the general philosophy of the project 
+and/or get some early feedback which can make both your efforts much lighter as
+well as our review and merge procedures quick and simple.
 
 ## Coding guidelines
 
@@ -35,7 +35,6 @@ and help.
 
 ## Configuration, dependencies, and tests
 
-Please see the [Developers' 
-Guide](https://github.com/ethereum/go-ethereum/wiki/Developers'-Guide)
+Please see the [Developers' Guide](https://github.com/ethereum/go-ethereum/wiki/Developers'-Guide)
 for more details on configuring your environment, managing project dependencies
 and testing procedures.


### PR DESCRIPTION
The contributing instructions in the README are not in the GitHub contributing guide, which means that people coming from the GitHub issues are less likely to see them. By copying those instructions here, we are more likely to have less errors like not using gofmt and so on. Another option would be removing the section from the README, and pointing users to the Contribute guide there, to stop duplication. But I am not sure this is entirely necessary.