### PR TITLE
swarm/api/http: fixed resolver bug

### DIFF
--- a/swarm/api/http/server.go
+++ b/swarm/api/http/server.go
@@ -820,7 +820,7 @@ func (s *Server) HandleGetFile(w http.ResponseWriter, r *http.Request) {
 	manifestAddr := uri.Address()
 
 	if manifestAddr == nil {
-		manifestAddr, err = s.api.ResolveURI(r.Context(), uri, credentials)
+		manifestAddr, err = s.api.Resolve(r.Context(), uri.Addr)
 		if err != nil {
 			getFileFail.Inc(1)
 			RespondError(w, r, fmt.Sprintf("cannot resolve %s: %s", uri.Addr, err), http.StatusNotFound)


### PR DESCRIPTION
This PR fixes a bug with resolving ENS names that was introduced as part of refactoring the `swarm/api` package.

Without it, fetching paths like `bzz:/theswarm.eth/css/sticky-footer-navbar.css` results in an error `404 Not Found`, whereas fetching the path that uses the actual hash that `theswarm.eth` resolves to, such as `bzz:/3f04f0076ccf39b410f3421e5476a9e79edc4e327d59d7929aa6ad9fc73f672b/css/sticky-footer-navbar.css` returns correct result.