### PR TITLE
core, trie: fix state log deep copy

### DIFF
--- a/core/state/statedb.go
+++ b/core/state/statedb.go
@@ -489,10 +489,13 @@ func (self *StateDB) Copy() *StateDB {
 			state.stateObjectsDirty[addr] = struct{}{}
 		}
 	}
-
 	for hash, logs := range self.logs {
-		state.logs[hash] = make([]*types.Log, len(logs))
-		copy(state.logs[hash], logs)
+		cpy := make([]*types.Log, len(logs))
+		for i, l := range logs {
+			cpy[i] = new(types.Log)
+			*cpy[i] = *l
+		}
+		state.logs[hash] = cpy
 	}
 	for hash, preimage := range self.preimages {
 		state.preimages[hash] = preimage


### PR DESCRIPTION
This PR mainly fixes two things: state deep copy and secure trie deep copy.
Regarding the secure trie, the secure cache content (trie key's preimages) will be discarded for the copied trie in the current codebase, it will definitely introduce some trouble when we want to dump state.