### PR TITLE
consensus/ethash: increase timeout in test

### DIFF
--- a/consensus/ethash/sealer_test.go
+++ b/consensus/ethash/sealer_test.go
@@ -40,6 +40,18 @@ func TestRemoteNotify(t *testing.T) {
 
 	go server.Serve(listener)
 
+	// Wait for server to start listening
+	var tries int
+	for tries = 0; tries < 10; tries++ {
+		conn, _ := net.DialTimeout("tcp", listener.Addr().String(), 1*time.Second)
+		if conn != nil {
+			break
+		}
+	}
+	if tries == 10 {
+		t.Fatal("tcp listener not ready for more than 10 seconds")
+	}
+
 	// Create the custom ethash engine
 	ethash := NewTester([]string{"http://" + listener.Addr().String()})
 	defer ethash.Close()

--- a/consensus/ethash/sealer_test.go
+++ b/consensus/ethash/sealer_test.go
@@ -61,7 +61,7 @@ func TestRemoteNotify(t *testing.T) {
 		if want := common.BytesToHash(target.Bytes()).Hex(); work[2] != want {
 			t.Errorf("work packet target mismatch: have %s, want %s", work[2], want)
 		}
-	case <-time.After(time.Second):
+	case <-time.After(3 * time.Second):
 		t.Fatalf("notification timed out")
 	}
 }
@@ -108,7 +108,7 @@ func TestRemoteMultiNotify(t *testing.T) {
 	for i := 0; i < cap(sink); i++ {
 		select {
 		case <-sink:
-		case <-time.After(250 * time.Millisecond):
+		case <-time.After(3 * time.Second):
 			t.Fatalf("notification %d timed out", i)
 		}
 	}


### PR DESCRIPTION
This PR is an effort to fix the flaky tests at `consensus/ethash` under macOS: `TestRemoteNotify` and `TestRemoteMultiNotify`.