### PR TITLE
shh: fix loop in expire()

### DIFF
--- a/whisper/whisperv5/whisper.go
+++ b/whisper/whisperv5/whisper.go
@@ -717,7 +717,7 @@ func (w *Whisper) expire() {
 				w.stats.messagesCleared++
 				w.stats.memoryCleared += sz
 				w.stats.memoryUsed -= sz
-				return true
+				return false
 			})
 			w.expirations[expiry].Clear()
 			delete(w.expirations, expiry)

--- a/whisper/whisperv5/whisper_test.go
+++ b/whisper/whisperv5/whisper_test.go
@@ -487,27 +487,34 @@ func TestExpiry(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed generateMessageParams with seed %d: %s.", seed, err)
 	}
-
 	params.TTL = 1
-	msg, err := NewSentMessage(params)
-	if err != nil {
-		t.Fatalf("failed to create new message with seed %d: %s.", seed, err)
-	}
-	env, err := msg.Wrap(params)
-	if err != nil {
-		t.Fatalf("failed Wrap with seed %d: %s.", seed, err)
-	}
 
-	err = w.Send(env)
-	if err != nil {
-		t.Fatalf("failed to send envelope with seed %d: %s.", seed, err)
+	messagesCount := 5
+
+	// Send a few messages one after another. Due to low PoW and expiration buckets
+	// with one second resolution, it covers a case when there are multiple items
+	// in a single expiration bucket.
+	for i := 0; i < messagesCount; i++ {
+		msg, err := NewSentMessage(params)
+		if err != nil {
+			t.Fatalf("failed to create new message with seed %d: %s.", seed, err)
+		}
+		env, err := msg.Wrap(params)
+		if err != nil {
+			t.Fatalf("failed Wrap with seed %d: %s.", seed, err)
+		}
+
+		err = w.Send(env)
+		if err != nil {
+			t.Fatalf("failed to send envelope with seed %d: %s.", seed, err)
+		}
 	}
 
 	// wait till received or timeout
 	var received, expired bool
 	for j := 0; j < 20; j++ {
 		time.Sleep(100 * time.Millisecond)
-		if len(w.Envelopes()) > 0 {
+		if len(w.Envelopes()) == messagesCount {
 			received = true
 			break
 		}

--- a/whisper/whisperv6/whisper.go
+++ b/whisper/whisperv6/whisper.go
@@ -900,7 +900,7 @@ func (whisper *Whisper) expire() {
 				whisper.stats.messagesCleared++
 				whisper.stats.memoryCleared += sz
 				whisper.stats.memoryUsed -= sz
-				return true
+				return false
 			})
 			whisper.expirations[expiry].Clear()
 			delete(whisper.expirations, expiry)

--- a/whisper/whisperv6/whisper_test.go
+++ b/whisper/whisperv6/whisper_test.go
@@ -465,27 +465,34 @@ func TestExpiry(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed generateMessageParams with seed %d: %s.", seed, err)
 	}
-
 	params.TTL = 1
-	msg, err := NewSentMessage(params)
-	if err != nil {
-		t.Fatalf("failed to create new message with seed %d: %s.", seed, err)
-	}
-	env, err := msg.Wrap(params)
-	if err != nil {
-		t.Fatalf("failed Wrap with seed %d: %s.", seed, err)
-	}
 
-	err = w.Send(env)
-	if err != nil {
-		t.Fatalf("failed to send envelope with seed %d: %s.", seed, err)
+	messagesCount := 5
+
+	// Send a few messages one after another. Due to low PoW and expiration buckets
+	// with one second resolution, it covers a case when there are multiple items
+	// in a single expiration bucket.
+	for i := 0; i < messagesCount; i++ {
+		msg, err := NewSentMessage(params)
+		if err != nil {
+			t.Fatalf("failed to create new message with seed %d: %s.", seed, err)
+		}
+		env, err := msg.Wrap(params)
+		if err != nil {
+			t.Fatalf("failed Wrap with seed %d: %s.", seed, err)
+		}
+
+		err = w.Send(env)
+		if err != nil {
+			t.Fatalf("failed to send envelope with seed %d: %s.", seed, err)
+		}
 	}
 
 	// wait till received or timeout
 	var received, expired bool
 	for j := 0; j < 20; j++ {
 		time.Sleep(100 * time.Millisecond)
-		if len(w.Envelopes()) > 0 {
+		if len(w.Envelopes()) == messagesCount {
 			received = true
 			break
 		}


### PR DESCRIPTION
In the PR https://github.com/ethereum/go-ethereum/pull/16873, a library implementing `Set` data structure was changed. Both previous and current implementations provide `Each()` method but they work differently.

[Old implementation](https://github.com/fatih/set/blob/master/set_nots.go#L134-L143):
> // Each traverses the items in the Set, calling the provided function for each
> // set member. Traversal will continue until all items in the Set have been
> // visited, or if the closure returns **false**.

[New implementation](https://github.com/deckarep/golang-set/blob/master/set.go#L129-L131):
> // Iterates over elements and executes the passed func against each element.
> // If passed func returns **true**, stop iteration at the time.

This difference is a source of a bug when not all expired envelopes are removed and a node keeps broadcasting very old messages.