### PR TITLE
cmd/swarm: disable ACT tests on windows

### DIFF
--- a/cmd/swarm/access_test.go
+++ b/cmd/swarm/access_test.go
@@ -13,6 +13,9 @@
 //
 // You should have received a copy of the GNU General Public License
 // along with go-ethereum. If not, see <http://www.gnu.org/licenses/>.
+
+// +build !windows
+
 package main
 
 import (


### PR DESCRIPTION
This PR disables ACT tests on Windows as they are consistently failing with: `No connection could be made because the target machine actively refused it.`

Until we fix this, these should not run on Windows, as AppVeyor is used to build artefacts during release.