### PR TITLE
rpc: reset write deadline

### DIFF
--- a/rpc/client.go
+++ b/rpc/client.go
@@ -487,6 +487,7 @@ func (c *Client) write(ctx context.Context, msg interface{}) error {
 	}
 	c.writeConn.SetWriteDeadline(deadline)
 	err := json.NewEncoder(c.writeConn).Encode(msg)
+	c.writeConn.SetWriteDeadline(time.Time{})
 	if err != nil {
 		c.writeConn = nil
 	}


### PR DESCRIPTION
When using [ethclient](https://github.com/ethereum/go-ethereum/blob/master/ethclient/ethclient.go) to subscribe to new blocks over a websocket to a node running [Ganache](https://github.com/trufflesuite/ganache-core) I noticed the following error 20 seconds after connecting:

    write tcp 127.0.0.1:47670->127.0.0.1:9545: i/o timeout

This error could not be reproduced when connecting to other nodes. Ganache’s websocket implementation is sending a [ping frame](https://tools.ietf.org/html/rfc6455#section-5.5.2) every 20 seconds which golang’s [websocket](https://godoc.org/golang.org/x/net/websocket) implementation [supports](https://go.googlesource.com/net/+/master/websocket/hybi.go#291).

However, the `go-ethereum/rpc` module uses a write deadline in its write function to implement write timeouts. 

~~~~golang
defaultWriteTimeout  = 10 * time.Second
~~~~

The deadlines are a different beast as can be seen from [net](https://golang.org/pkg/net/#Conn)’s documentation:

> A deadline is an absolute time after which I/O operations fail with a timeout (see type Error) instead of blocking.

This means that once the deadline has been reach all further operations on the connection throw a timeout error. This does not affect standard RPC request/reply pattern but it results in a timeout error for websocket subscriptions.

~~~~
> {"id": 1, "method": "eth_subscribe", "params": ["newHeads"]}
< {"id":1,"result":"0x01"}
.... 20 seconds pass with potentially info about blocks produced in the time interval ...
.... more importantly during this interval the write deadline expires ...
< Ping received
> Send pong (fail with a timeout error since the write deadline has expired)
~~~~

So what we want to do is set the write deadline prior to writing data to the underlying connection and reset the deadline right after. According to the documentation s zero value for the write deadline means Write will not time out.

~~~~golang 
package main

import (
        "context"
        "log"

        "github.com/ethereum/go-ethereum/core/types"
        "github.com/ethereum/go-ethereum/ethclient"
)

func main() {
        conn, err := ethclient.Dial("ws://localhost:9545")

        if err != nil {
                log.Fatalf("Failed to connect to the Ethereum client: %v", err)
        }

        ch := make(chan *types.Header)
        sub, err := conn.SubscribeNewHead(context.Background(), ch)

        for {
                select {
                case err := <-sub.Err():
                        log.Fatal(err)
                case h := <-ch:
                        log.Printf("%d: %x\n", h.Number, h.Hash())
                }
        }
}
~~~~