### PR TITLE
p2p/discv5: make idx bounds checking more sound

### DIFF
--- a/p2p/discv5/net.go
+++ b/p2p/discv5/net.go
@@ -1228,7 +1228,7 @@ func (net *Network) checkTopicRegister(data *topicRegister) (*pong, error) {
 	if rlpHash(data.Topics) != pongpkt.data.(*pong).TopicHash {
 		return nil, errors.New("topic hash mismatch")
 	}
-	if int(data.Idx) < 0 || int(data.Idx) >= len(data.Topics) {
+	if data.Idx >= uint(len(data.Topics)) {
 		return nil, errors.New("topic index out of range")
 	}
 	return pongpkt.data.(*pong), nil


### PR DESCRIPTION
in _golang_, for convenience, return type of `len()` is `int` instead of `uint`,so that we don't need to code like `len(array) >= uint(bound)`,

however, the value of `len()` cannot be negative.

there's a previous fix https://github.com/ethereum/go-ethereum/pull/17274, because converting idx to int can bypass the check if idx overflows int.

I believe my change will make the checking logic more sound.