### PR TITLE
all: add vim temp files to gitignore file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,10 @@ profile.cov
 # VS Code
 .vscode
 
+# vim swap files
+.*.sw?
+.sw?
+
 # dashboard
 /dashboard/assets/flow-typed
 /dashboard/assets/node_modules


### PR DESCRIPTION
Current "git ignore file" does not include the vim temporary files.
This PR adds them.