### PR TITLE
swarm/storage: leveldb usage metrics

### DIFF
--- a/swarm/api/http/server_test.go
+++ b/swarm/api/http/server_test.go
@@ -891,14 +891,14 @@ func TestMethodsNotAllowed(t *testing.T) {
 	}{
 		{
 			url:  fmt.Sprintf("%s/bzz-list:/", srv.URL),
-			code: 405,
+			code: http.StatusMethodNotAllowed,
 		}, {
 			url:  fmt.Sprintf("%s/bzz-hash:/", srv.URL),
-			code: 405,
+			code: http.StatusMethodNotAllowed,
 		},
 		{
 			url:  fmt.Sprintf("%s/bzz-immutable:/", srv.URL),
-			code: 405,
+			code: http.StatusMethodNotAllowed,
 		},
 	} {
 		res, _ := http.Post(c.url, "text/plain", bytes.NewReader([]byte(databytes)))
@@ -956,7 +956,7 @@ func TestGet(t *testing.T) {
 			uri:                fmt.Sprintf("%s/", srv.URL),
 			method:             "GET",
 			headers:            map[string]string{"Accept": "text/html"},
-			expectedStatusCode: 200,
+			expectedStatusCode: http.StatusOK,
 			assertResponseBody: "Swarm: Serverless Hosting Incentivised Peer-To-Peer Storage And Content Distribution",
 			verbose:            false,
 		},
@@ -964,7 +964,7 @@ func TestGet(t *testing.T) {
 			uri:                fmt.Sprintf("%s/", srv.URL),
 			method:             "GET",
 			headers:            map[string]string{"Accept": "application/json"},
-			expectedStatusCode: 200,
+			expectedStatusCode: http.StatusOK,
 			assertResponseBody: "Swarm: Please request a valid ENS or swarm hash with the appropriate bzz scheme",
 			verbose:            false,
 		},
@@ -972,7 +972,7 @@ func TestGet(t *testing.T) {
 			uri:                fmt.Sprintf("%s/robots.txt", srv.URL),
 			method:             "GET",
 			headers:            map[string]string{"Accept": "text/html"},
-			expectedStatusCode: 200,
+			expectedStatusCode: http.StatusOK,
 			assertResponseBody: "User-agent: *\nDisallow: /",
 			verbose:            false,
 		},
@@ -980,38 +980,37 @@ func TestGet(t *testing.T) {
 			uri:                fmt.Sprintf("%s/nonexistent_path", srv.URL),
 			method:             "GET",
 			headers:            map[string]string{},
-			expectedStatusCode: 404,
+			expectedStatusCode: http.StatusNotFound,
 			verbose:            false,
 		},
 		{
 			uri:                fmt.Sprintf("%s/bzz:asdf/", srv.URL),
 			method:             "GET",
 			headers:            map[string]string{},
-			expectedStatusCode: 404,
+			expectedStatusCode: http.StatusNotFound,
 			verbose:            false,
 		},
 		{
 			uri:                fmt.Sprintf("%s/tbz2/", srv.URL),
 			method:             "GET",
 			headers:            map[string]string{},
-			expectedStatusCode: 404,
+			expectedStatusCode: http.StatusNotFound,
 			verbose:            false,
 		},
 		{
 			uri:                fmt.Sprintf("%s/bzz-rack:/", srv.URL),
 			method:             "GET",
 			headers:            map[string]string{},
-			expectedStatusCode: 404,
+			expectedStatusCode: http.StatusNotFound,
 			verbose:            false,
 		},
 		{
 			uri:                fmt.Sprintf("%s/bzz-ls", srv.URL),
 			method:             "GET",
 			headers:            map[string]string{},
-			expectedStatusCode: 404,
+			expectedStatusCode: http.StatusNotFound,
 			verbose:            false,
-		},
-	} {
+		}} {
 		t.Run("GET "+testCase.uri, func(t *testing.T) {
 			res, body := httpDo(testCase.method, testCase.uri, nil, testCase.headers, testCase.verbose, t)
 			if res.StatusCode != testCase.expectedStatusCode {
@@ -1058,7 +1057,7 @@ func TestModify(t *testing.T) {
 			uri:                fmt.Sprintf("%s/bzz:/%s", srv.URL, hash),
 			method:             "DELETE",
 			headers:            map[string]string{},
-			expectedStatusCode: 200,
+			expectedStatusCode: http.StatusOK,
 			assertResponseBody: "8b634aea26eec353ac0ecbec20c94f44d6f8d11f38d4578a4c207a84c74ef731",
 			verbose:            false,
 		},
@@ -1066,21 +1065,21 @@ func TestModify(t *testing.T) {
 			uri:                fmt.Sprintf("%s/bzz:/%s", srv.URL, hash),
 			method:             "PUT",
 			headers:            map[string]string{},
-			expectedStatusCode: 405,
+			expectedStatusCode: http.StatusMethodNotAllowed,
 			verbose:            false,
 		},
 		{
 			uri:                fmt.Sprintf("%s/bzz-raw:/%s", srv.URL, hash),
 			method:             "PUT",
 			headers:            map[string]string{},
-			expectedStatusCode: 405,
+			expectedStatusCode: http.StatusMethodNotAllowed,
 			verbose:            false,
 		},
 		{
 			uri:                fmt.Sprintf("%s/bzz:/%s", srv.URL, hash),
 			method:             "PATCH",
 			headers:            map[string]string{},
-			expectedStatusCode: 405,
+			expectedStatusCode: http.StatusMethodNotAllowed,
 			verbose:            false,
 		},
 		{
@@ -1088,7 +1087,7 @@ func TestModify(t *testing.T) {
 			method:                "POST",
 			headers:               map[string]string{},
 			requestBody:           []byte("POSTdata"),
-			expectedStatusCode:    200,
+			expectedStatusCode:    http.StatusOK,
 			assertResponseHeaders: map[string]string{"Content-Length": "64"},
 			verbose:               false,
 		},
@@ -1097,7 +1096,7 @@ func TestModify(t *testing.T) {
 			method:                "POST",
 			headers:               map[string]string{},
 			requestBody:           []byte("POSTdata"),
-			expectedStatusCode:    200,
+			expectedStatusCode:    http.StatusOK,
 			assertResponseHeaders: map[string]string{"Content-Length": "128"},
 			verbose:               false,
 		},
@@ -1146,7 +1145,7 @@ func TestMultiPartUpload(t *testing.T) {
 	}
 	res, body := httpDo("POST", url, buf, headers, verbose, t)
 
-	if res.StatusCode != 200 {
+	if res.StatusCode != http.StatusOK {
 		t.Fatalf("expected POST multipart/form-data to return 200, but it returned %d", res.StatusCode)
 	}
 	if len(body) != 64 {

--- a/swarm/storage/ldbstore.go
+++ b/swarm/storage/ldbstore.go
@@ -49,6 +49,10 @@ const (
 )
 
 var (
+	dbEntryCount = metrics.NewRegisteredCounter("ldbstore.entryCnt", nil)
+)
+
+var (
 	keyIndex       = byte(0)
 	keyOldData     = byte(1)
 	keyAccessCnt   = []byte{2}
@@ -495,6 +499,7 @@ func (s *LDBStore) delete(idx uint64, idxKey []byte, po uint8) {
 	batch.Delete(idxKey)
 	batch.Delete(getDataKey(idx, po))
 	s.entryCnt--
+	dbEntryCount.Dec(1)
 	s.bucketCnt[po]--
 	cntKey := make([]byte, 2)
 	cntKey[0] = keyDistanceCnt
@@ -566,6 +571,7 @@ func (s *LDBStore) doPut(chunk *Chunk, index *dpaDBIndex, po uint8) {
 	index.Idx = s.dataIdx
 	s.bucketCnt[po] = s.dataIdx
 	s.entryCnt++
+	dbEntryCount.Inc(1)
 	s.dataIdx++
 
 	cntKey := make([]byte, 2)


### PR DESCRIPTION
this PR adds metrics for measuring a node's LevelDB entry count using the `metrics` package.

resolves https://github.com/ethersphere/go-ethereum/issues/244