### PR TITLE
rpc: increased maxRequestContentLength size to 512kB

### DIFF
--- a/rpc/http.go
+++ b/rpc/http.go
@@ -37,7 +37,7 @@ import (
 
 const (
 	contentType             = "application/json"
-	maxRequestContentLength = 1024 * 128
+	maxRequestContentLength = 1024 * 512
 )
 
 var nullAddr, _ = net.ResolveTCPAddr("tcp", "127.0.0.1:0")


### PR DESCRIPTION
The current `maxRequestContentLength` size is only 128kB after commit a7bae3b2a6, rpc payload restriction applied.

- introduced by commit fd764d4f (2015) - `maxHttpSizeReqLength = 1024 * 1024`
- accidentally(?) removed by commit 19b2640e89 (2015/12/16)
- reintroduced by commit a7bae3b2a6 (same author 2016/2/24)- `maxHTTPRequestContentLength = 1024 * 128`

For some large rpc batch command like as 2000 `eth_getBalance` batch job, it cause `Invalid JSON RPC response: "content length too large (236894>131072)\n"`.

parity-ethereum v2.1.x now support `"--jsonrpc-max-payload=[MB]"` option (please see https://github.com/paritytech/parity-ethereum/commit/67721f3413cf2ecaff050c0a1bad1261cfd0b783 (L157) `.max_request_body_size(max_payload * 1024 * 1024);` ),
the default rpc-max-payload is 1MB, and parity can manage about ~10000 `eth_getBalance` batch rpc job in 1 sec.

How about to increase maxRequestContentLength size again? I think it's not a big deal, almost all public RPC service already use their own proxy to wrap local geth node/nodes and control rate-limit or request size to protect their node from DDoS. we don't have to much worry about `maxRequestContentLength`.

It is worthwhile to implement configurable `maxRequestContentLength` but I think increasing its default value is enough.

