### PR TITLE
Add new command line option --database-handles (#16796)

### DIFF
--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -92,6 +92,7 @@ var (
 		utils.CacheDatabaseFlag,
 		utils.CacheGCFlag,
 		utils.TrieCacheGenFlag,
+		utils.DatabaseHandles,
 		utils.ListenPortFlag,
 		utils.MaxPeersFlag,
 		utils.MaxPendingPeersFlag,

--- a/cmd/geth/usage.go
+++ b/cmd/geth/usage.go
@@ -134,6 +134,7 @@ var AppHelpFlagGroups = []flagGroup{
 			utils.CacheDatabaseFlag,
 			utils.CacheGCFlag,
 			utils.TrieCacheGenFlag,
+			utils.DatabaseHandles,
 		},
 	},
 	{

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -307,6 +307,11 @@ var (
 		Usage: "Number of trie node generations to keep in memory",
 		Value: int(state.MaxTrieCacheGen),
 	}
+	DatabaseHandles = cli.IntFlag{
+		Name:  "database-handles",
+		Usage: "Number of file handles to use for database io",
+		Value: makeDatabaseHandles(),
+	}
 	// Miner settings
 	MiningEnabledFlag = cli.BoolFlag{
 		Name:  "mine",
@@ -1136,7 +1141,8 @@ func SetEthConfig(ctx *cli.Context, stack *node.Node, cfg *eth.Config) {
 	if ctx.GlobalIsSet(CacheFlag.Name) || ctx.GlobalIsSet(CacheDatabaseFlag.Name) {
 		cfg.DatabaseCache = ctx.GlobalInt(CacheFlag.Name) * ctx.GlobalInt(CacheDatabaseFlag.Name) / 100
 	}
-	cfg.DatabaseHandles = makeDatabaseHandles()
+
+	cfg.DatabaseHandles = ctx.GlobalInt(DatabaseHandles.Name)
 
 	if gcmode := ctx.GlobalString(GCModeFlag.Name); gcmode != "full" && gcmode != "archive" {
 		Fatalf("--%s must be either 'full' or 'archive'", GCModeFlag.Name)


### PR DESCRIPTION
This allows tuning the `go-leveldb OpenFilesCacheCapacity` option (capacity of
the open files) and thus improve performance by reducing the number of
`open/close` syscalls.

By increasing the number of DB handles to 100000 I was able to reduce the number of `open/close` syscalls (10 seconds interval) significantly from:

```
  open                                                            219
  close                                                           221

```

to 
```
  close                                                            26
  open                                                             48
```

and thus increase the sync rate.

This Graphs shows the sync rate (Blocks/Minute) running with defaults (1024 handles) till 7:20 and `--database-handles 100000`  from 7:20.

![eth](https://user-images.githubusercontent.com/52547/45174062-28e03700-b20a-11e8-9a44-10ac7469a63e.png)

