### PR TITLE
eth: check for DefaultConfig.NetworkId in test

### DIFF
--- a/eth/protocol_test.go
+++ b/eth/protocol_test.go
@@ -64,7 +64,7 @@ func testStatusMsgErrors(t *testing.T, protocol int) {
 		},
 		{
 			code: StatusMsg, data: statusData{uint32(protocol), 999, td, head.Hash(), genesis.Hash()},
-			wantError: errResp(ErrNetworkIdMismatch, "999 (!= 1)"),
+			wantError: errResp(ErrNetworkIdMismatch, "999 (!= %d)", DefaultConfig.NetworkId),
 		},
 		{
 			code: StatusMsg, data: statusData{uint32(protocol), DefaultConfig.NetworkId, td, head.Hash(), common.Hash{3}},


### PR DESCRIPTION
In our fork of go-ethereum, we use a different default NetworkId and `protocol_test.go` fails. 
Change is simple but given i'm totally newbie, please let me know if my understanding is not right.