### PR TITLE
swarm/api/http: bzz-immutable handler bug

### DIFF
--- a/swarm/api/http/server.go
+++ b/swarm/api/http/server.go
@@ -129,7 +129,7 @@ func NewServer(api *api.API, corsString string) *Server {
 	})
 	mux.Handle("/bzz-immutable:/", methodHandler{
 		"GET": Adapt(
-			http.HandlerFunc(server.HandleGet),
+			http.HandlerFunc(server.HandleBzzGet),
 			defaultMiddlewares...,
 		),
 	})

--- a/swarm/api/http/server_test.go
+++ b/swarm/api/http/server_test.go
@@ -672,7 +672,7 @@ func testBzzGetPath(encrypted bool, t *testing.T) {
 
 	nonhashresponses := []string{
 		`cannot resolve name: no DNS to resolve name: "name"`,
-		`cannot resolve nonhash: immutable address not a content hash: "nonhash"`,
+		`cannot resolve nonhash: no DNS to resolve name: "nonhash"`,
 		`cannot resolve nonhash: no DNS to resolve name: "nonhash"`,
 		`cannot resolve nonhash: no DNS to resolve name: "nonhash"`,
 		`cannot resolve nonhash: no DNS to resolve name: "nonhash"`,


### PR DESCRIPTION
this PR addresses a bug in which the `bzz-immutable` handler wasn't pointing in the correct middleware handler. this caused a request to `bzz-immutable` to result in a no content reply.

the handler was adjusted to be the `bzz` get handler instead, in which the `immutable` difference in handling only occurs in the resolver.

the appropriate test was mended accordingly.

fixes https://github.com/ethersphere/go-ethereum/issues/912