### PR TITLE
core, internal/ethapi: add and use LRU cache for receipts

### DIFF
--- a/eth/api_backend.go
+++ b/eth/api_backend.go
@@ -25,7 +25,6 @@ import (
 	"github.com/ethereum/go-ethereum/common/math"
 	"github.com/ethereum/go-ethereum/core"
 	"github.com/ethereum/go-ethereum/core/bloombits"
-	"github.com/ethereum/go-ethereum/core/rawdb"
 	"github.com/ethereum/go-ethereum/core/state"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/core/vm"
@@ -107,18 +106,11 @@ func (b *EthAPIBackend) GetBlock(ctx context.Context, hash common.Hash) (*types.
 }
 
 func (b *EthAPIBackend) GetReceipts(ctx context.Context, hash common.Hash) (types.Receipts, error) {
-	if number := rawdb.ReadHeaderNumber(b.eth.chainDb, hash); number != nil {
-		return rawdb.ReadReceipts(b.eth.chainDb, hash, *number), nil
-	}
-	return nil, nil
+	return b.eth.blockchain.GetReceiptsByHash(hash), nil
 }
 
 func (b *EthAPIBackend) GetLogs(ctx context.Context, hash common.Hash) ([][]*types.Log, error) {
-	number := rawdb.ReadHeaderNumber(b.eth.chainDb, hash)
-	if number == nil {
-		return nil, nil
-	}
-	receipts := rawdb.ReadReceipts(b.eth.chainDb, hash, *number)
+	receipts := b.eth.blockchain.GetReceiptsByHash(hash)
 	if receipts == nil {
 		return nil, nil
 	}


### PR DESCRIPTION
This PR adds an LRU cache for receipts to `BlockChain`, following the model of the other LRUs in that object, and also removes the last direct `rawdb` reads from `EthAPIBackend`, which uses the embedded blockchain object for reading receipts instead. 

I've noticed recently that `eth_getLogs` performance is suffering, to the point that a node under a moderate amount of RPC load actually gets to a point where it can't keep up with the new blocks coming in over devp2p and eventually reverts to syncing.

When debugging this, I used a less than optimal, but not uncommon, query to get all the ERC-20 transfers between two addresses on mainnet:

```json
{
  "method":"eth_getLogs","id":1,"jsonrpc":"2.0", 
  "params":[{
    "fromBlock":"0x1","toBlock":"latest",
    "topics":[ 
      "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef",
      "0x0000000000000000000000009035e9004a4f1e88c296be507c5cea8f99ff8a63", 
      "0x0000000000000000000000004be0cd2553356b4abb8b6a1882325dabc8d3013d"
    ],
    "address":"0x09d8b66c48424324b25754a873e290cae5dca439"
  }]
}
```

I was surprised to see that even under a moderate level of concurrency (5-20 copies of the same RPC above) that the node was spending almost 50% of it's CPU time decoding receipts:

```
      flat  flat%   sum%        cum   cum%
         0     0%     0%     50.31s 52.25%  github.com/ethereum/go-ethereum/eth/filters.(*Filter).Logs
         0     0%     0%     50.31s 52.25%  github.com/ethereum/go-ethereum/eth/filters.(*PublicFilterAPI).GetLogs
...
     0.02s 0.021% 0.052%     48.17s 50.03%  github.com/ethereum/go-ethereum/eth.(*EthAPIBackend).GetLogs
     0.01s  0.01% 0.062%     47.86s 49.70%  github.com/ethereum/go-ethereum/core/rawdb.ReadReceipts
```

Going through the code, I saw that while there are LRU caches for most other items in `Blockchain`, there isn't one for transaction receipts.  I found that adding a *large enough* LRU cache for receipts drastically improved performance:

- first request (cold LRU): `5.167s`
- second request (warm LRU, max 256 blocks): `2.640s`
- second request (warm LRU, max 2048 blocks): `0.735s`

For this particular query, "large enough" needs to be greater than 547, as that's how many blocks the bloom filter scans let through.  Which is also in itself a little surprising, since of those 547 blocks, only 6 were a match.  I'm not well versed at all in how bloom filters work, but I suspect the recent increase in standardized events like ERC-20 and ERC-721 has led to more and more blocks containing receipts with `topic[0]` matching one of those standard events, and that is leading to an  increase in the false positive rate of the filter.

So, currently, this PR contains a receipt LRU of size `256` to match the other LRU caches, but I'd be more than happy to discuss raising that (and potentially all the LRU sizes).  A value of 256 should work very well for a low-traffic node with lots of log queries around the chain head, but multiple "full scan" queries with wide `fromBlock`/`toBlock` ranges will just lead to eviction races.

I'll file issues for the "high" false positive rate, and the fact that running several `eth_getLogs` RPCs concurrently greatly effects node availability so those items can be discussed separately.