### PR TITLE
about clique poa

### DIFF
--- a/consensus/clique/snapshot.go
+++ b/consensus/clique/snapshot.go
@@ -139,6 +139,11 @@ func (s *Snapshot) copy() *Snapshot {
 // given snapshot context (e.g. don't try to add an already authorized signer).
 func (s *Snapshot) validVote(address common.Address, authorize bool) bool {
 	_, signer := s.Signers[address]
+
+	if len(s.Signers) == 1 && signer && authorize == false {
+		return false
+	}
+
 	return (signer && !authorize) || (!signer && authorize)
 }
 

--- a/consensus/clique/snapshot.go
+++ b/consensus/clique/snapshot.go
@@ -24,6 +24,7 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/ethdb"
+	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/params"
 	lru "github.com/hashicorp/golang-lru"
 )
@@ -308,5 +309,11 @@ func (s *Snapshot) inturn(number uint64, signer common.Address) bool {
 	for offset < len(signers) && signers[offset] != signer {
 		offset++
 	}
+
+	if len(signers) == 0 {
+		log.Warn("no signer. len(signers)==0")
+		return false
+	}
+
 	return (number % uint64(len(signers))) == uint64(offset)
 }


### PR DESCRIPTION
I found a problem with clique: if there is only one signer in the whole network, it can vote to set its own permission to false. After the resolution is passed, len(signers) will be equal to 0, which will cause this code to crash in this line.
return (number % uint64(len(signers))) == uint64(offset)
Crash information: 
panic: runtime error: integer divide by zero