### PR TITLE
les: fix distReq.sentChn double close bug

### DIFF
--- a/les/distributor.go
+++ b/les/distributor.go
@@ -114,7 +114,9 @@ func (d *requestDistributor) loop() {
 			d.lock.Lock()
 			elem := d.reqQueue.Front()
 			for elem != nil {
-				close(elem.Value.(*distReq).sentChn)
+				req := elem.Value.(*distReq)
+				close(req.sentChn)
+				req.sentChn = nil
 				elem = elem.Next()
 			}
 			d.lock.Unlock()


### PR DESCRIPTION
This PR fixes https://github.com/ethereum/go-ethereum/issues/17619 by always ensuring that distReq,sentChn is set to nil after being closed while requestDistributor.lock is being held. This scheme was previously violated by the shutdown mechanism which meant that cancelling a request after stopping the distributor caused a panic.