### PR TITLE
Removes "unsafe" package in exchange for binary.Size({} interface)

### DIFF
--- a/core/types/block.go
+++ b/core/types/block.go
@@ -24,7 +24,6 @@ import (
 	"sort"
 	"sync/atomic"
 	"time"
-	"unsafe"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
@@ -105,7 +104,8 @@ func (h *Header) Hash() common.Hash {
 // Size returns the approximate memory used by all internal contents. It is used
 // to approximate and limit the memory consumption of various caches.
 func (h *Header) Size() common.StorageSize {
-	return common.StorageSize(unsafe.Sizeof(*h)) + common.StorageSize(len(h.Extra)+(h.Difficulty.BitLen()+h.Number.BitLen()+h.Time.BitLen())/8)
+	size := binary.Size(h)
+	return common.StorageSize(size) + common.StorageSize(len(h.Extra)+(h.Difficulty.BitLen()+h.Number.BitLen()+h.Time.BitLen())/8)
 }
 
 func rlpHash(x interface{}) (h common.Hash) {

--- a/core/types/block.go
+++ b/core/types/block.go
@@ -19,9 +19,9 @@ package types
 
 import (
 	"encoding/binary"
-	"reflect"
 	"io"
 	"math/big"
+	"reflect"
 	"sort"
 	"sync/atomic"
 	"time"

--- a/core/types/block.go
+++ b/core/types/block.go
@@ -19,6 +19,7 @@ package types
 
 import (
 	"encoding/binary"
+	"reflect"
 	"io"
 	"math/big"
 	"sort"
@@ -101,11 +102,12 @@ func (h *Header) Hash() common.Hash {
 	return rlpHash(h)
 }
 
+var headerSize = common.StorageSize(reflect.TypeOf(Header{}).Size())
+
 // Size returns the approximate memory used by all internal contents. It is used
 // to approximate and limit the memory consumption of various caches.
 func (h *Header) Size() common.StorageSize {
-	size := binary.Size(h)
-	return common.StorageSize(size) + common.StorageSize(len(h.Extra)+(h.Difficulty.BitLen()+h.Number.BitLen()+h.Time.BitLen())/8)
+	return headerSize + common.StorageSize(len(h.Extra)+(h.Difficulty.BitLen()+h.Number.BitLen()+h.Time.BitLen())/8)
 }
 
 func rlpHash(x interface{}) (h common.Hash) {


### PR DESCRIPTION
When using Google App Cloud, the `go-app-builder` will complain because an "unsafe" package import: 

```
go-app-builder: Failed parsing input: parser: bad import "unsafe" in github.com/ethereum/go-ethereum/core/types/block.go from GOPATH
```

To get the size of `Header` interface, this PR changes the "unsafe" package for "encoding/binary" to get the size of a struct.