### PR TITLE
abigen support for `--type` flag with piped data

### DIFF
--- a/cmd/abigen/main.go
+++ b/cmd/abigen/main.go
@@ -115,16 +115,12 @@ func main() {
 		var err error
 		if *abiFlag == "-" {
 			abi, err = ioutil.ReadAll(os.Stdin)
-			if err != nil {
-				fmt.Printf("Failed to read input ABI from stdin: %v\n", err)
-				os.Exit(-1)
-			}
 		} else {
 			abi, err = ioutil.ReadFile(*abiFlag)
-			if err != nil {
-				fmt.Printf("Failed to read input ABI: %v\n", err)
-				os.Exit(-1)
-			}
+		}
+		if err != nil {
+			fmt.Printf("Failed to read input ABI: %v\n", err)
+			os.Exit(-1)
 		}
 		abis = append(abis, string(abi))
 


### PR DESCRIPTION
`abigen` fails to support the `--type` flag when data is piped to it.
Ethereum Issue: #17647

This change is to fix the command line processing to support
a piped ABI to `abigen` and use the `--type` flag.