### PR TITLE
cmd/swarm: password threw on upload manifest

### DIFF
--- a/cmd/swarm/access.go
+++ b/cmd/swarm/access.go
@@ -62,7 +62,6 @@ func accessNewPass(ctx *cli.Context) {
 			utils.Fatalf("had an error printing the manifests: %v", err)
 		}
 	} else {
-		utils.Fatalf("uploading manifests")
 		err = uploadManifests(ctx, m, nil)
 		if err != nil {
 			utils.Fatalf("had an error uploading the manifests: %v", err)


### PR DESCRIPTION
this PR adresses a leftover debug fatal exception that throws on a wet run when using only password protection on ACT.
it was not revealed due to lack of test coverage on this code block.