### PR TITLE
vm: fix typo 'EVM EVM' ==> 'EVM'

### DIFF
--- a/core/vm/interface.go
+++ b/core/vm/interface.go
@@ -64,7 +64,7 @@ type StateDB interface {
 	ForEachStorage(common.Address, func(common.Hash, common.Hash) bool)
 }
 
-// CallContext provides a basic interface for the EVM calling conventions. The EVM EVM
+// CallContext provides a basic interface for the EVM calling conventions. The EVM
 // depends on this context being implemented for doing subcalls and initialising new EVM contracts.
 type CallContext interface {
 	// Call another contract


### PR DESCRIPTION
vm: fix typo 'EVM EVM' ==> 'EVM'