### PR TITLE
types, rawdb, core, miner: add block location fields to receipt

### DIFF
--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -799,6 +799,11 @@ func SetReceiptsData(config *params.ChainConfig, block *types.Block, receipts ty
 		// The transaction hash can be retrieved from the transaction itself
 		receipts[j].TxHash = transactions[j].Hash()
 
+		// block location fields
+		receipts[j].BlockHash = block.Hash()
+		receipts[j].BlockNumber = block.Number()
+		receipts[j].TransactionIndex = big.NewInt(int64(j))
+
 		// The contract address can be derived from the transaction itself
 		if transactions[j].To() == nil {
 			// Deriving the signer is expensive, only do if it's actually needed

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -802,7 +802,7 @@ func SetReceiptsData(config *params.ChainConfig, block *types.Block, receipts ty
 		// block location fields
 		receipts[j].BlockHash = block.Hash()
 		receipts[j].BlockNumber = block.Number()
-		receipts[j].TransactionIndex = big.NewInt(int64(j))
+		receipts[j].TransactionIndex = uint(j)
 
 		// The contract address can be derived from the transaction itself
 		if transactions[j].To() == nil {

--- a/core/rawdb/accessors_chain.go
+++ b/core/rawdb/accessors_chain.go
@@ -306,6 +306,9 @@ func ReadReceipts(db DatabaseReader, hash common.Hash, number uint64) types.Rece
 			logIndex += 1
 		}
 		receipts[i] = (*types.Receipt)(receipt)
+		receipts[i].BlockHash = hash
+		receipts[i].BlockNumber = big.NewInt(0).SetUint64(number)
+		receipts[i].TransactionIndex = big.NewInt(int64(i))
 	}
 	return receipts
 }

--- a/core/rawdb/accessors_chain.go
+++ b/core/rawdb/accessors_chain.go
@@ -308,7 +308,7 @@ func ReadReceipts(db DatabaseReader, hash common.Hash, number uint64) types.Rece
 		receipts[i] = (*types.Receipt)(receipt)
 		receipts[i].BlockHash = hash
 		receipts[i].BlockNumber = big.NewInt(0).SetUint64(number)
-		receipts[i].TransactionIndex = big.NewInt(int64(i))
+		receipts[i].TransactionIndex = uint(i)
 	}
 	return receipts
 }

--- a/core/state/statedb.go
+++ b/core/state/statedb.go
@@ -221,8 +221,14 @@ func (self *StateDB) GetNonce(addr common.Address) uint64 {
 	return 0
 }
 
+// TxIndex returns the current transaction index set by Prepare.
 func (self *StateDB) TxIndex() int {
 	return self.txIndex
+}
+
+// BlockHash returns the current block hash set by Prepare.
+func (self *StateDB) BlockHash() common.Hash {
+	return self.bhash
 }
 
 func (self *StateDB) GetCode(addr common.Address) []byte {

--- a/core/state/statedb.go
+++ b/core/state/statedb.go
@@ -221,6 +221,10 @@ func (self *StateDB) GetNonce(addr common.Address) uint64 {
 	return 0
 }
 
+func (self *StateDB) TxIndex() int {
+	return self.txIndex
+}
+
 func (self *StateDB) GetCode(addr common.Address) []byte {
 	stateObject := self.getStateObject(addr)
 	if stateObject != nil {

--- a/core/state_processor.go
+++ b/core/state_processor.go
@@ -121,7 +121,7 @@ func ApplyTransaction(config *params.ChainConfig, bc ChainContext, author *commo
 	// Set the receipt logs and create a bloom for filtering
 	receipt.Logs = statedb.GetLogs(tx.Hash())
 	receipt.Bloom = types.CreateBloom(types.Receipts{receipt})
-	receipt.BlockHash = header.Hash()
+	receipt.BlockHash = statedb.BlockHash()
 	receipt.BlockNumber = header.Number
 	receipt.TransactionIndex = uint(statedb.TxIndex())
 

--- a/core/state_processor.go
+++ b/core/state_processor.go
@@ -25,7 +25,6 @@ import (
 	"github.com/ethereum/go-ethereum/core/vm"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/params"
-	"math/big"
 )
 
 // StateProcessor is a basic Processor, which takes care of transitioning
@@ -124,7 +123,7 @@ func ApplyTransaction(config *params.ChainConfig, bc ChainContext, author *commo
 	receipt.Bloom = types.CreateBloom(types.Receipts{receipt})
 	receipt.BlockHash = header.Hash()
 	receipt.BlockNumber = header.Number
-	receipt.TransactionIndex = big.NewInt(int64(statedb.TxIndex()))
+	receipt.TransactionIndex = uint(statedb.TxIndex())
 
 	return receipt, gas, err
 }

--- a/core/state_processor.go
+++ b/core/state_processor.go
@@ -25,6 +25,7 @@ import (
 	"github.com/ethereum/go-ethereum/core/vm"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/params"
+	"math/big"
 )
 
 // StateProcessor is a basic Processor, which takes care of transitioning
@@ -121,6 +122,9 @@ func ApplyTransaction(config *params.ChainConfig, bc ChainContext, author *commo
 	// Set the receipt logs and create a bloom for filtering
 	receipt.Logs = statedb.GetLogs(tx.Hash())
 	receipt.Bloom = types.CreateBloom(types.Receipts{receipt})
+	receipt.BlockHash = header.Hash()
+	receipt.BlockNumber = header.Number
+	receipt.TransactionIndex = big.NewInt(int64(statedb.TxIndex()))
 
 	return receipt, gas, err
 }

--- a/core/types/gen_receipt_json.go
+++ b/core/types/gen_receipt_json.go
@@ -26,7 +26,7 @@ func (r Receipt) MarshalJSON() ([]byte, error) {
 		GasUsed           hexutil.Uint64 `json:"gasUsed" gencodec:"required"`
 		BlockHash         common.Hash    `json:"blockHash,omitempty"`
 		BlockNumber       *hexutil.Big   `json:"blockNumber,omitempty"`
-		TransactionIndex  *hexutil.Big   `json:"transactionIndex,omitempty"`
+		TransactionIndex  hexutil.Uint   `json:"transactionIndex"`
 	}
 	var enc Receipt
 	enc.PostState = r.PostState
@@ -39,7 +39,7 @@ func (r Receipt) MarshalJSON() ([]byte, error) {
 	enc.GasUsed = hexutil.Uint64(r.GasUsed)
 	enc.BlockHash = r.BlockHash
 	enc.BlockNumber = (*hexutil.Big)(r.BlockNumber)
-	enc.TransactionIndex = (*hexutil.Big)(r.TransactionIndex)
+	enc.TransactionIndex = hexutil.Uint(r.TransactionIndex)
 	return json.Marshal(&enc)
 }
 
@@ -56,7 +56,7 @@ func (r *Receipt) UnmarshalJSON(input []byte) error {
 		GasUsed           *hexutil.Uint64 `json:"gasUsed" gencodec:"required"`
 		BlockHash         *common.Hash    `json:"blockHash,omitempty"`
 		BlockNumber       *hexutil.Big    `json:"blockNumber,omitempty"`
-		TransactionIndex  *hexutil.Big    `json:"transactionIndex,omitempty"`
+		TransactionIndex  *hexutil.Uint   `json:"transactionIndex"`
 	}
 	var dec Receipt
 	if err := json.Unmarshal(input, &dec); err != nil {
@@ -98,7 +98,7 @@ func (r *Receipt) UnmarshalJSON(input []byte) error {
 		r.BlockNumber = (*big.Int)(dec.BlockNumber)
 	}
 	if dec.TransactionIndex != nil {
-		r.TransactionIndex = (*big.Int)(dec.TransactionIndex)
+		r.TransactionIndex = uint(*dec.TransactionIndex)
 	}
 	return nil
 }

--- a/core/types/gen_receipt_json.go
+++ b/core/types/gen_receipt_json.go
@@ -5,6 +5,7 @@ package types
 import (
 	"encoding/json"
 	"errors"
+	"math/big"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
@@ -23,6 +24,9 @@ func (r Receipt) MarshalJSON() ([]byte, error) {
 		TxHash            common.Hash    `json:"transactionHash" gencodec:"required"`
 		ContractAddress   common.Address `json:"contractAddress"`
 		GasUsed           hexutil.Uint64 `json:"gasUsed" gencodec:"required"`
+		BlockHash         common.Hash    `json:"blockHash,omitempty"`
+		BlockNumber       *hexutil.Big   `json:"blockNumber,omitempty"`
+		TransactionIndex  *hexutil.Big   `json:"transactionIndex,omitempty"`
 	}
 	var enc Receipt
 	enc.PostState = r.PostState
@@ -33,6 +37,9 @@ func (r Receipt) MarshalJSON() ([]byte, error) {
 	enc.TxHash = r.TxHash
 	enc.ContractAddress = r.ContractAddress
 	enc.GasUsed = hexutil.Uint64(r.GasUsed)
+	enc.BlockHash = r.BlockHash
+	enc.BlockNumber = (*hexutil.Big)(r.BlockNumber)
+	enc.TransactionIndex = (*hexutil.Big)(r.TransactionIndex)
 	return json.Marshal(&enc)
 }
 
@@ -47,6 +54,9 @@ func (r *Receipt) UnmarshalJSON(input []byte) error {
 		TxHash            *common.Hash    `json:"transactionHash" gencodec:"required"`
 		ContractAddress   *common.Address `json:"contractAddress"`
 		GasUsed           *hexutil.Uint64 `json:"gasUsed" gencodec:"required"`
+		BlockHash         *common.Hash    `json:"blockHash,omitempty"`
+		BlockNumber       *hexutil.Big    `json:"blockNumber,omitempty"`
+		TransactionIndex  *hexutil.Big    `json:"transactionIndex,omitempty"`
 	}
 	var dec Receipt
 	if err := json.Unmarshal(input, &dec); err != nil {
@@ -81,5 +91,14 @@ func (r *Receipt) UnmarshalJSON(input []byte) error {
 		return errors.New("missing required field 'gasUsed' for Receipt")
 	}
 	r.GasUsed = uint64(*dec.GasUsed)
+	if dec.BlockHash != nil {
+		r.BlockHash = *dec.BlockHash
+	}
+	if dec.BlockNumber != nil {
+		r.BlockNumber = (*big.Int)(dec.BlockNumber)
+	}
+	if dec.TransactionIndex != nil {
+		r.TransactionIndex = (*big.Int)(dec.TransactionIndex)
+	}
 	return nil
 }

--- a/core/types/gen_tx_json.go
+++ b/core/types/gen_tx_json.go
@@ -13,6 +13,7 @@ import (
 
 var _ = (*txdataMarshaling)(nil)
 
+// MarshalJSON marshals as JSON.
 func (t txdata) MarshalJSON() ([]byte, error) {
 	type txdata struct {
 		AccountNonce hexutil.Uint64  `json:"nonce"    gencodec:"required"`
@@ -40,6 +41,7 @@ func (t txdata) MarshalJSON() ([]byte, error) {
 	return json.Marshal(&enc)
 }
 
+// UnmarshalJSON unmarshals from JSON.
 func (t *txdata) UnmarshalJSON(input []byte) error {
 	type txdata struct {
 		AccountNonce *hexutil.Uint64 `json:"nonce"    gencodec:"required"`

--- a/core/types/receipt.go
+++ b/core/types/receipt.go
@@ -20,6 +20,7 @@ import (
 	"bytes"
 	"fmt"
 	"io"
+	"math/big"
 	"unsafe"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -55,6 +56,11 @@ type Receipt struct {
 	TxHash          common.Hash    `json:"transactionHash" gencodec:"required"`
 	ContractAddress common.Address `json:"contractAddress"`
 	GasUsed         uint64         `json:"gasUsed" gencodec:"required"`
+
+	// Block location fields - not part of the rlp
+	BlockHash        common.Hash `json:"blockHash,omitempty"`
+	BlockNumber      *big.Int    `json:"blockNumber,omitempty"`
+	TransactionIndex *big.Int    `json:"transactionIndex,omitempty"`
 }
 
 type receiptMarshaling struct {
@@ -62,6 +68,8 @@ type receiptMarshaling struct {
 	Status            hexutil.Uint64
 	CumulativeGasUsed hexutil.Uint64
 	GasUsed           hexutil.Uint64
+	BlockNumber       *hexutil.Big
+	TransactionIndex  *hexutil.Big
 }
 
 // receiptRLP is the consensus encoding of a receipt.

--- a/core/types/receipt.go
+++ b/core/types/receipt.go
@@ -45,22 +45,24 @@ const (
 
 // Receipt represents the results of a transaction.
 type Receipt struct {
-	// Consensus fields
+	// Consensus fields: These fields are defined by the Yellow Paper
 	PostState         []byte `json:"root"`
 	Status            uint64 `json:"status"`
 	CumulativeGasUsed uint64 `json:"cumulativeGasUsed" gencodec:"required"`
 	Bloom             Bloom  `json:"logsBloom"         gencodec:"required"`
 	Logs              []*Log `json:"logs"              gencodec:"required"`
 
-	// Implementation fields (don't reorder!)
+	// Implementation fields: These fields are added by geth when processing a transaction.
+	// They are stored in the chain database.
 	TxHash          common.Hash    `json:"transactionHash" gencodec:"required"`
 	ContractAddress common.Address `json:"contractAddress"`
 	GasUsed         uint64         `json:"gasUsed" gencodec:"required"`
 
-	// Block location fields - not part of the rlp
+	// Inclusion information: These fields provide information about the inclusion of the
+	// transaction corresponding to this receipt.
 	BlockHash        common.Hash `json:"blockHash,omitempty"`
 	BlockNumber      *big.Int    `json:"blockNumber,omitempty"`
-	TransactionIndex *big.Int    `json:"transactionIndex,omitempty"`
+	TransactionIndex uint        `json:"transactionIndex"`
 }
 
 type receiptMarshaling struct {
@@ -69,7 +71,7 @@ type receiptMarshaling struct {
 	CumulativeGasUsed hexutil.Uint64
 	GasUsed           hexutil.Uint64
 	BlockNumber       *hexutil.Big
-	TransactionIndex  *hexutil.Big
+	TransactionIndex  hexutil.Uint
 }
 
 // receiptRLP is the consensus encoding of a receipt.

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -569,7 +569,7 @@ func (w *worker) resultLoop() {
 				// add block location fields
 				receipt.BlockHash = hash
 				receipt.BlockNumber = block.Number()
-				receipt.TransactionIndex = big.NewInt(int64(i))
+				receipt.TransactionIndex = uint(i)
 
 				receipts[i] = new(types.Receipt)
 				*receipts[i] = *receipt

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -566,6 +566,11 @@ func (w *worker) resultLoop() {
 				logs     []*types.Log
 			)
 			for i, receipt := range task.receipts {
+				// add block location fields
+				receipt.BlockHash = hash
+				receipt.BlockNumber = block.Number()
+				receipt.TransactionIndex = big.NewInt(int64(i))
+
 				receipts[i] = new(types.Receipt)
 				*receipts[i] = *receipt
 				// Update the block hash in all logs since it is now available and not when the


### PR DESCRIPTION
Solves https://github.com/ethereum/go-ethereum/issues/15210 without changing consensus, in a backwards compatible way, by adding the block location fields from ReadReceipt to the Receipt struct. 

Update: In particular this improves consistency between the go client interface and the [json rpc spec](https://github.com/ethereum/wiki/wiki/JSON-RPC#eth_gettransactionreceipt) and allows go clients to use transaction receipts to watch for block confirmations for particular transactions - see #15210.