### PR TITLE
miner: diff log level for miner and normal node.

### DIFF
--- a/miner/worker.go
+++ b/miner/worker.go
@@ -831,7 +831,12 @@ func (w *worker) commitNewWork(interrupt *int32, noempty bool, timestamp int64) 
 		header.Coinbase = w.coinbase
 	}
 	if err := w.engine.Prepare(w.chain, header); err != nil {
-		log.Error("Failed to prepare header for mining", "err", err)
+		if w.isRunning() {
+			log.Error("Failed to prepare header for mining", "err", err)
+		} else {
+			log.Trace("Failed to prepare header for mining", "err", err)
+		}
+		
 		return
 	}
 	// If we are care about TheDAO hard-fork check whether to override the extra-data or not


### PR DESCRIPTION
This pr try to make log level different from miner and normal node when prepares header by consensus engine. Normal node don't mine a block or something, so the result of preparing header is not a big thing for this nodes. But if the node got some error which don't make sense for other function, the lasting log error info is quit bothering.