### PR TITLE
whisper: Instrument whisper with configurable source of time

### DIFF
--- a/whisper/whisperv6/api.go
+++ b/whisper/whisperv6/api.go
@@ -284,7 +284,7 @@ func (api *PublicWhisperAPI) Post(ctx context.Context, req NewMessage) (hexutil.
 	}
 
 	var result []byte
-	env, err := whisperMsg.Wrap(params)
+	env, err := whisperMsg.Wrap(params, api.w.GetCurrentTime())
 	if err != nil {
 		return nil, err
 	}

--- a/whisper/whisperv6/benchmarks_test.go
+++ b/whisper/whisperv6/benchmarks_test.go
@@ -19,6 +19,7 @@ package whisperv6
 import (
 	"crypto/sha256"
 	"testing"
+	"time"
 
 	"github.com/ethereum/go-ethereum/crypto"
 	"golang.org/x/crypto/pbkdf2"
@@ -40,7 +41,7 @@ func BenchmarkEncryptionSym(b *testing.B) {
 
 	for i := 0; i < b.N; i++ {
 		msg, _ := NewSentMessage(params)
-		_, err := msg.Wrap(params)
+		_, err := msg.Wrap(params, time.Now())
 		if err != nil {
 			b.Errorf("failed Wrap with seed %d: %s.", seed, err)
 			b.Errorf("i = %d, len(msg.Raw) = %d, params.Payload = %d.", i, len(msg.Raw), len(params.Payload))
@@ -65,7 +66,7 @@ func BenchmarkEncryptionAsym(b *testing.B) {
 
 	for i := 0; i < b.N; i++ {
 		msg, _ := NewSentMessage(params)
-		_, err := msg.Wrap(params)
+		_, err := msg.Wrap(params, time.Now())
 		if err != nil {
 			b.Fatalf("failed Wrap with seed %d: %s.", seed, err)
 		}
@@ -80,7 +81,7 @@ func BenchmarkDecryptionSymValid(b *testing.B) {
 		b.Fatalf("failed generateMessageParams with seed %d: %s.", seed, err)
 	}
 	msg, _ := NewSentMessage(params)
-	env, err := msg.Wrap(params)
+	env, err := msg.Wrap(params, time.Now())
 	if err != nil {
 		b.Fatalf("failed Wrap with seed %d: %s.", seed, err)
 	}
@@ -102,7 +103,7 @@ func BenchmarkDecryptionSymInvalid(b *testing.B) {
 		b.Fatalf("failed generateMessageParams with seed %d: %s.", seed, err)
 	}
 	msg, _ := NewSentMessage(params)
-	env, err := msg.Wrap(params)
+	env, err := msg.Wrap(params, time.Now())
 	if err != nil {
 		b.Fatalf("failed Wrap with seed %d: %s.", seed, err)
 	}
@@ -131,7 +132,7 @@ func BenchmarkDecryptionAsymValid(b *testing.B) {
 	params.KeySym = nil
 	params.Dst = &key.PublicKey
 	msg, _ := NewSentMessage(params)
-	env, err := msg.Wrap(params)
+	env, err := msg.Wrap(params, time.Now())
 	if err != nil {
 		b.Fatalf("failed Wrap with seed %d: %s.", seed, err)
 	}
@@ -158,7 +159,7 @@ func BenchmarkDecryptionAsymInvalid(b *testing.B) {
 	params.KeySym = nil
 	params.Dst = &key.PublicKey
 	msg, _ := NewSentMessage(params)
-	env, err := msg.Wrap(params)
+	env, err := msg.Wrap(params, time.Now())
 	if err != nil {
 		b.Fatalf("failed Wrap with seed %d: %s.", seed, err)
 	}
@@ -200,7 +201,7 @@ func BenchmarkPoW(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		increment(params.Payload)
 		msg, _ := NewSentMessage(params)
-		_, err := msg.Wrap(params)
+		_, err := msg.Wrap(params, time.Now())
 		if err != nil {
 			b.Fatalf("failed Wrap with seed %d: %s.", seed, err)
 		}

--- a/whisper/whisperv6/envelope.go
+++ b/whisper/whisperv6/envelope.go
@@ -62,9 +62,9 @@ func (e *Envelope) rlpWithoutNonce() []byte {
 
 // NewEnvelope wraps a Whisper message with expiration and destination data
 // included into an envelope for network forwarding.
-func NewEnvelope(ttl uint32, topic TopicType, msg *sentMessage) *Envelope {
+func NewEnvelope(ttl uint32, topic TopicType, msg *sentMessage, now time.Time) *Envelope {
 	env := Envelope{
-		Expiry: uint32(time.Now().Add(time.Second * time.Duration(ttl)).Unix()),
+		Expiry: uint32(now.Add(time.Second * time.Duration(ttl)).Unix()),
 		TTL:    ttl,
 		Topic:  topic,
 		Data:   msg.Raw,

--- a/whisper/whisperv6/envelope_test.go
+++ b/whisper/whisperv6/envelope_test.go
@@ -21,6 +21,7 @@ package whisperv6
 import (
 	mrand "math/rand"
 	"testing"
+	"time"
 
 	"github.com/ethereum/go-ethereum/crypto"
 )
@@ -50,7 +51,7 @@ func TestEnvelopeOpenAcceptsOnlyOneKeyTypeInFilter(t *testing.T) {
 		t.Fatalf("failed to create new message with seed %d: %s.", seed, err)
 	}
 
-	e, err := msg.Wrap(&params)
+	e, err := msg.Wrap(&params, time.Now())
 	if err != nil {
 		t.Fatalf("Failed to Wrap the message in an envelope with seed %d: %s", seed, err)
 	}

--- a/whisper/whisperv6/filter_test.go
+++ b/whisper/whisperv6/filter_test.go
@@ -203,7 +203,7 @@ func TestInstallIdenticalFilters(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to create new message with seed %d: %s.", seed, err)
 	}
-	env, err := sentMessage.Wrap(params)
+	env, err := sentMessage.Wrap(params, time.Now())
 	if err != nil {
 		t.Fatalf("failed Wrap with seed %d: %s.", seed, err)
 	}
@@ -309,7 +309,7 @@ func TestMatchEnvelope(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to create new message with seed %d: %s.", seed, err)
 	}
-	env, err := msg.Wrap(params)
+	env, err := msg.Wrap(params, time.Now())
 	if err != nil {
 		t.Fatalf("failed Wrap with seed %d: %s.", seed, err)
 	}
@@ -322,7 +322,7 @@ func TestMatchEnvelope(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to create new message with seed %d: %s.", seed, err)
 	}
-	env, err = msg.Wrap(params)
+	env, err = msg.Wrap(params, time.Now())
 	if err != nil {
 		t.Fatalf("failed Wrap() with seed %d: %s.", seed, err)
 	}
@@ -367,7 +367,7 @@ func TestMatchEnvelope(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to create new message with seed %d: %s.", seed, err)
 	}
-	env, err = msg.Wrap(params)
+	env, err = msg.Wrap(params, time.Now())
 	if err != nil {
 		t.Fatalf("failed Wrap() with seed %d: %s.", seed, err)
 	}
@@ -449,7 +449,7 @@ func TestMatchMessageSym(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to create new message with seed %d: %s.", seed, err)
 	}
-	env, err := sentMessage.Wrap(params)
+	env, err := sentMessage.Wrap(params, time.Now())
 	if err != nil {
 		t.Fatalf("failed Wrap with seed %d: %s.", seed, err)
 	}
@@ -543,7 +543,7 @@ func TestMatchMessageAsym(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to create new message with seed %d: %s.", seed, err)
 	}
-	env, err := sentMessage.Wrap(params)
+	env, err := sentMessage.Wrap(params, time.Now())
 	if err != nil {
 		t.Fatalf("failed Wrap with seed %d: %s.", seed, err)
 	}
@@ -628,7 +628,7 @@ func generateCompatibeEnvelope(t *testing.T, f *Filter) *Envelope {
 	if err != nil {
 		t.Fatalf("failed to create new message with seed %d: %s.", seed, err)
 	}
-	env, err := sentMessage.Wrap(params)
+	env, err := sentMessage.Wrap(params, time.Now())
 	if err != nil {
 		t.Fatalf("failed Wrap with seed %d: %s.", seed, err)
 		return nil
@@ -804,7 +804,7 @@ func TestVariableTopics(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to create new message with seed %d: %s.", seed, err)
 	}
-	env, err := msg.Wrap(params)
+	env, err := msg.Wrap(params, time.Now())
 	if err != nil {
 		t.Fatalf("failed Wrap with seed %d: %s.", seed, err)
 	}

--- a/whisper/whisperv6/message.go
+++ b/whisper/whisperv6/message.go
@@ -27,6 +27,7 @@ import (
 	"errors"
 	mrand "math/rand"
 	"strconv"
+	"time"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/crypto"
@@ -234,7 +235,7 @@ func generateSecureRandomData(length int) ([]byte, error) {
 }
 
 // Wrap bundles the message into an Envelope to transmit over the network.
-func (msg *sentMessage) Wrap(options *MessageParams) (envelope *Envelope, err error) {
+func (msg *sentMessage) Wrap(options *MessageParams, now time.Time) (envelope *Envelope, err error) {
 	if options.TTL == 0 {
 		options.TTL = DefaultTTL
 	}
@@ -254,7 +255,7 @@ func (msg *sentMessage) Wrap(options *MessageParams) (envelope *Envelope, err er
 		return nil, err
 	}
 
-	envelope = NewEnvelope(options.TTL, options.Topic, msg)
+	envelope = NewEnvelope(options.TTL, options.Topic, msg, now)
 	if err = envelope.Seal(options); err != nil {
 		return nil, err
 	}

--- a/whisper/whisperv6/message_test.go
+++ b/whisper/whisperv6/message_test.go
@@ -22,6 +22,7 @@ import (
 	"crypto/cipher"
 	mrand "math/rand"
 	"testing"
+	"time"
 
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/crypto"
@@ -77,7 +78,7 @@ func singleMessageTest(t *testing.T, symmetric bool) {
 	if err != nil {
 		t.Fatalf("failed to create new message with seed %d: %s.", seed, err)
 	}
-	env, err := msg.Wrap(params)
+	env, err := msg.Wrap(params, time.Now())
 	if err != nil {
 		t.Fatalf("failed Wrap with seed %d: %s.", seed, err)
 	}
@@ -138,7 +139,7 @@ func TestMessageWrap(t *testing.T) {
 	params.TTL = 1
 	params.WorkTime = 12
 	params.PoW = target
-	env, err := msg.Wrap(params)
+	env, err := msg.Wrap(params, time.Now())
 	if err != nil {
 		t.Fatalf("failed Wrap with seed %d: %s.", seed, err)
 	}
@@ -156,7 +157,7 @@ func TestMessageWrap(t *testing.T) {
 	params.TTL = 1000000
 	params.WorkTime = 1
 	params.PoW = 10000000.0
-	_, err = msg2.Wrap(params)
+	_, err = msg2.Wrap(params, time.Now())
 	if err == nil {
 		t.Fatalf("unexpectedly reached the PoW target with seed %d.", seed)
 	}
@@ -178,7 +179,7 @@ func TestMessageSeal(t *testing.T) {
 	}
 	params.TTL = 1
 
-	env := NewEnvelope(params.TTL, params.Topic, msg)
+	env := NewEnvelope(params.TTL, params.Topic, msg, time.Now())
 	if err != nil {
 		t.Fatalf("failed Wrap with seed %d: %s.", seed, err)
 	}
@@ -238,7 +239,7 @@ func singleEnvelopeOpenTest(t *testing.T, symmetric bool) {
 	if err != nil {
 		t.Fatalf("failed to create new message with seed %d: %s.", seed, err)
 	}
-	env, err := msg.Wrap(params)
+	env, err := msg.Wrap(params, time.Now())
 	if err != nil {
 		t.Fatalf("failed Wrap with seed %d: %s.", seed, err)
 	}
@@ -294,7 +295,7 @@ func TestEncryptWithZeroKey(t *testing.T) {
 		t.Fatalf("failed to create new message with seed %d: %s.", seed, err)
 	}
 	params.KeySym = make([]byte, aesKeyLength)
-	_, err = msg.Wrap(params)
+	_, err = msg.Wrap(params, time.Now())
 	if err == nil {
 		t.Fatalf("wrapped with zero key, seed: %d.", seed)
 	}
@@ -308,7 +309,7 @@ func TestEncryptWithZeroKey(t *testing.T) {
 		t.Fatalf("failed to create new message with seed %d: %s.", seed, err)
 	}
 	params.KeySym = make([]byte, 0)
-	_, err = msg.Wrap(params)
+	_, err = msg.Wrap(params, time.Now())
 	if err == nil {
 		t.Fatalf("wrapped with empty key, seed: %d.", seed)
 	}
@@ -322,7 +323,7 @@ func TestEncryptWithZeroKey(t *testing.T) {
 		t.Fatalf("failed to create new message with seed %d: %s.", seed, err)
 	}
 	params.KeySym = nil
-	_, err = msg.Wrap(params)
+	_, err = msg.Wrap(params, time.Now())
 	if err == nil {
 		t.Fatalf("wrapped with nil key, seed: %d.", seed)
 	}
@@ -339,7 +340,7 @@ func TestRlpEncode(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to create new message with seed %d: %s.", seed, err)
 	}
-	env, err := msg.Wrap(params)
+	env, err := msg.Wrap(params, time.Now())
 	if err != nil {
 		t.Fatalf("wrapped with zero key, seed: %d.", seed)
 	}
@@ -383,7 +384,7 @@ func singlePaddingTest(t *testing.T, padSize int) {
 	if err != nil {
 		t.Fatalf("failed to create new message with seed %d: %s.", seed, err)
 	}
-	env, err := msg.Wrap(params)
+	env, err := msg.Wrap(params, time.Now())
 	if err != nil {
 		t.Fatalf("failed to wrap, seed: %d and sz=%d.", seed, padSize)
 	}

--- a/whisper/whisperv6/peer_test.go
+++ b/whisper/whisperv6/peer_test.go
@@ -381,7 +381,7 @@ func sendMsg(t *testing.T, expected bool, id int) {
 	if err != nil {
 		t.Fatalf("failed to create new message with seed %d: %s.", seed, err)
 	}
-	envelope, err := msg.Wrap(&opt)
+	envelope, err := msg.Wrap(&opt, time.Now())
 	if err != nil {
 		t.Fatalf("failed to seal message: %s", err)
 	}
@@ -405,7 +405,7 @@ func TestPeerBasic(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to create new message with seed %d: %s.", seed, err)
 	}
-	env, err := msg.Wrap(params)
+	env, err := msg.Wrap(params, time.Now())
 	if err != nil {
 		t.Fatalf("failed Wrap with seed %d.", seed)
 	}

--- a/whisper/whisperv6/whisper_test.go
+++ b/whisper/whisperv6/whisper_test.go
@@ -477,7 +477,7 @@ func TestExpiry(t *testing.T) {
 		if err != nil {
 			t.Fatalf("failed to create new message with seed %d: %s.", seed, err)
 		}
-		env, err := msg.Wrap(params)
+		env, err := msg.Wrap(params, time.Now())
 		if err != nil {
 			t.Fatalf("failed Wrap with seed %d: %s.", seed, err)
 		}
@@ -544,7 +544,7 @@ func TestCustomization(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to create new message with seed %d: %s.", seed, err)
 	}
-	env, err := msg.Wrap(params)
+	env, err := msg.Wrap(params, time.Now())
 	if err != nil {
 		t.Fatalf("failed Wrap with seed %d: %s.", seed, err)
 	}
@@ -565,7 +565,7 @@ func TestCustomization(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to create new message with seed %d: %s.", seed, err)
 	}
-	env, err = msg.Wrap(params)
+	env, err = msg.Wrap(params, time.Now())
 	if err != nil {
 		t.Fatalf("failed Wrap with seed %d: %s.", seed, err)
 	}
@@ -649,7 +649,7 @@ func TestSymmetricSendCycle(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to create new message with seed %d: %s.", seed, err)
 	}
-	env, err := msg.Wrap(params)
+	env, err := msg.Wrap(params, time.Now())
 	if err != nil {
 		t.Fatalf("failed Wrap with seed %d: %s.", seed, err)
 	}
@@ -727,7 +727,7 @@ func TestSymmetricSendWithoutAKey(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to create new message with seed %d: %s.", seed, err)
 	}
-	env, err := msg.Wrap(params)
+	env, err := msg.Wrap(params, time.Now())
 	if err != nil {
 		t.Fatalf("failed Wrap with seed %d: %s.", seed, err)
 	}
@@ -793,7 +793,7 @@ func TestSymmetricSendKeyMismatch(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to create new message with seed %d: %s.", seed, err)
 	}
-	env, err := msg.Wrap(params)
+	env, err := msg.Wrap(params, time.Now())
 	if err != nil {
 		t.Fatalf("failed Wrap with seed %d: %s.", seed, err)
 	}


### PR DESCRIPTION
Whisper depends on time synchronization between connected peers. Time doesn't have to be perfectly synchronized, but time difference between two connected peers should be at most 10s.

When whisper is used on mobile devices or personal laptops it is not possible to control time synchronization. In our patched version of whisper we are using NTP time source that periodically computes mean time from multiple queries to ntp servers.

I don't like to patch msg.Wrap with time.Now for all test cases, but i don't see any other way. In current codebase msg.Wrap is strongly decoupled from whisper instance.