### PR TITLE
swarm: Chunk refactor improvements

### DIFF
--- a/swarm/network/protocol.go
+++ b/swarm/network/protocol.go
@@ -54,7 +54,7 @@ var BzzSpec = &protocols.Spec{
 // DiscoverySpec is the spec for the bzz discovery subprotocols
 var DiscoverySpec = &protocols.Spec{
 	Name:       "hive",
-	Version:    5,
+	Version:    6,
 	MaxMsgSize: 10 * 1024 * 1024,
 	Messages: []interface{}{
 		peersMsg{},

--- a/swarm/network/protocol.go
+++ b/swarm/network/protocol.go
@@ -44,7 +44,7 @@ const (
 // BzzSpec is the spec of the generic swarm handshake
 var BzzSpec = &protocols.Spec{
 	Name:       "bzz",
-	Version:    6,
+	Version:    7,
 	MaxMsgSize: 10 * 1024 * 1024,
 	Messages: []interface{}{
 		HandshakeMsg{},

--- a/swarm/network/protocol_test.go
+++ b/swarm/network/protocol_test.go
@@ -31,7 +31,7 @@ import (
 )
 
 const (
-	TestProtocolVersion   = 6
+	TestProtocolVersion   = 7
 	TestProtocolNetworkID = 3
 )
 

--- a/swarm/network/stream/stream.go
+++ b/swarm/network/stream/stream.go
@@ -41,8 +41,8 @@ const (
 	Mid
 	High
 	Top
-	PriorityQueue    = 4   // number of priority queues - Low, Mid, High, Top
-	PriorityQueueCap = 128 // queue capacity
+	PriorityQueue    = 4    // number of priority queues - Low, Mid, High, Top
+	PriorityQueueCap = 4096 // queue capacity
 	HashSize         = 32
 )
 

--- a/swarm/network/stream/stream.go
+++ b/swarm/network/stream/stream.go
@@ -639,7 +639,7 @@ func (c *clientParams) clientCreated() {
 // Spec is the spec of the streamer protocol
 var Spec = &protocols.Spec{
 	Name:       "stream",
-	Version:    5,
+	Version:    6,
 	MaxMsgSize: 10 * 1024 * 1024,
 	Messages: []interface{}{
 		UnsubscribeMsg{},


### PR DESCRIPTION
# 1. Protocol version bumps

In the chunk refactor project we had plenty of changes regarding syncing between nodes. To make QA simpler we should bump the protocol version, so we don't have to handle the complexity of a mixed swarm cluster consisting of old and new peers.

# 2. Increase priority queue size

We encountered peer drops because of priority queue contention. Because sync batch size is 128 and there 32 streams between 2 peers, we can theoretically have 4096 chunk delivery messages at the same time. That is why the cap is significantly increased.