### PR TITLE
common, core, light: add block age into info logs

### DIFF
--- a/common/format.go
+++ b/common/format.go
@@ -38,3 +38,45 @@ func (d PrettyDuration) String() string {
 	}
 	return label
 }
+
+// PrettyAge is a pretty printed version of a time.Duration value that rounds
+// the values up to a single most significant unit, days/weeks/years included.
+type PrettyAge time.Time
+
+// ageUnits is a list of units the age pretty printing uses.
+var ageUnits = []struct {
+	Size   time.Duration
+	Symbol string
+}{
+	{12 * 30 * 24 * time.Hour, "y"},
+	{30 * 24 * time.Hour, "mo"},
+	{7 * 24 * time.Hour, "w"},
+	{24 * time.Hour, "d"},
+	{time.Hour, "h"},
+	{time.Minute, "m"},
+	{time.Second, "s"},
+}
+
+// String implements the Stringer interface, allowing pretty printing of duration
+// values rounded to the most significant time unit.
+func (t PrettyAge) String() string {
+	// Calculate the time difference and handle the 0 cornercase
+	diff := time.Since(time.Time(t))
+	if diff < time.Second {
+		return "0"
+	}
+	// Accumulate a precision of 3 components before returning
+	result, prec := "", 0
+
+	for _, unit := range ageUnits {
+		if diff > unit.Size {
+			result = fmt.Sprintf("%s%d%s", result, diff/unit.Size, unit.Symbol)
+			diff %= unit.Size
+
+			if prec += 1; prec >= 3 {
+				break
+			}
+		}
+	}
+	return result
+}

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -251,9 +251,9 @@ func (bc *BlockChain) loadLastState() error {
 	blockTd := bc.GetTd(currentBlock.Hash(), currentBlock.NumberU64())
 	fastTd := bc.GetTd(currentFastBlock.Hash(), currentFastBlock.NumberU64())
 
-	log.Info("Loaded most recent local header", "number", currentHeader.Number, "hash", currentHeader.Hash(), "td", headerTd)
-	log.Info("Loaded most recent local full block", "number", currentBlock.Number(), "hash", currentBlock.Hash(), "td", blockTd)
-	log.Info("Loaded most recent local fast block", "number", currentFastBlock.Number(), "hash", currentFastBlock.Hash(), "td", fastTd)
+	log.Info("Loaded most recent local header", "number", currentHeader.Number, "hash", currentHeader.Hash(), "td", headerTd, "age", common.PrettyAge(time.Unix(currentHeader.Time.Int64(), 0)))
+	log.Info("Loaded most recent local full block", "number", currentBlock.Number(), "hash", currentBlock.Hash(), "td", blockTd, "age", common.PrettyAge(time.Unix(currentBlock.Time().Int64(), 0)))
+	log.Info("Loaded most recent local fast block", "number", currentFastBlock.Number(), "hash", currentFastBlock.Hash(), "td", fastTd, "age", common.PrettyAge(time.Unix(currentFastBlock.Time().Int64(), 0)))
 
 	return nil
 }
@@ -850,13 +850,16 @@ func (bc *BlockChain) InsertReceiptChain(blockChain types.Blocks, receiptChain [
 	}
 	bc.mu.Unlock()
 
-	log.Info("Imported new block receipts",
-		"count", stats.processed,
-		"elapsed", common.PrettyDuration(time.Since(start)),
-		"number", head.Number(),
-		"hash", head.Hash(),
+	context := []interface{}{
+		"count", stats.processed, "elapsed", common.PrettyDuration(time.Since(start)),
+		"number", head.Number(), "hash", head.Hash(), "age", common.PrettyAge(time.Unix(head.Time().Int64(), 0)),
 		"size", common.StorageSize(bytes),
-		"ignored", stats.ignored)
+	}
+	if stats.ignored > 0 {
+		context = append(context, []interface{}{"ignored", stats.ignored}...)
+	}
+	log.Info("Imported new block receipts", context...)
+
 	return 0, nil
 }
 
@@ -1229,8 +1232,13 @@ func (st *insertStats) report(chain []*types.Block, index int, cache common.Stor
 		context := []interface{}{
 			"blocks", st.processed, "txs", txs, "mgas", float64(st.usedGas) / 1000000,
 			"elapsed", common.PrettyDuration(elapsed), "mgasps", float64(st.usedGas) * 1000 / float64(elapsed),
-			"number", end.Number(), "hash", end.Hash(), "cache", cache,
+			"number", end.Number(), "hash", end.Hash(),
 		}
+		if timestamp := time.Unix(end.Time().Int64(), 0); time.Since(timestamp) > time.Minute {
+			context = append(context, []interface{}{"age", common.PrettyAge(timestamp)}...)
+		}
+		context = append(context, []interface{}{"cache", cache}...)
+
 		if st.queued > 0 {
 			context = append(context, []interface{}{"queued", st.queued}...)
 		}

--- a/core/headerchain.go
+++ b/core/headerchain.go
@@ -281,8 +281,18 @@ func (hc *HeaderChain) InsertHeaderChain(chain []*types.Header, writeHeader WhCa
 	}
 	// Report some public statistics so the user has a clue what's going on
 	last := chain[len(chain)-1]
-	log.Info("Imported new block headers", "count", stats.processed, "elapsed", common.PrettyDuration(time.Since(start)),
-		"number", last.Number, "hash", last.Hash(), "ignored", stats.ignored)
+
+	context := []interface{}{
+		"count", stats.processed, "elapsed", common.PrettyDuration(time.Since(start)),
+		"number", last.Number, "hash", last.Hash(),
+	}
+	if timestamp := time.Unix(last.Time.Int64(), 0); time.Since(timestamp) > time.Minute {
+		context = append(context, []interface{}{"age", common.PrettyAge(timestamp)}...)
+	}
+	if stats.ignored > 0 {
+		context = append(context, []interface{}{"ignored", stats.ignored}...)
+	}
+	log.Info("Imported new block headers", context...)
 
 	return 0, nil
 }

--- a/light/lightchain.go
+++ b/light/lightchain.go
@@ -157,7 +157,7 @@ func (self *LightChain) loadLastState() error {
 	// Issue a status log and return
 	header := self.hc.CurrentHeader()
 	headerTd := self.GetTd(header.Hash(), header.Number.Uint64())
-	log.Info("Loaded most recent local header", "number", header.Number, "hash", header.Hash(), "td", headerTd)
+	log.Info("Loaded most recent local header", "number", header.Number, "hash", header.Hash(), "td", headerTd, "age", common.PrettyAge(time.Unix(header.Time.Int64(), 0)))
 
 	return nil
 }
@@ -488,7 +488,7 @@ func (self *LightChain) SyncCht(ctx context.Context) bool {
 
 		// Ensure the chain didn't move past the latest block while retrieving it
 		if self.hc.CurrentHeader().Number.Uint64() < header.Number.Uint64() {
-			log.Info("Updated latest header based on CHT", "number", header.Number, "hash", header.Hash())
+			log.Info("Updated latest header based on CHT", "number", header.Number, "hash", header.Hash(), "age", common.PrettyAge(time.Unix(header.Time.Int64(), 0)))
 			self.hc.SetCurrentHeader(header)
 		}
 		return true


### PR DESCRIPTION
While catching up with the chain (you turned off your machine for a few days), it's generally annoying that you don't know **where** in the sync you are progress wise. Checking against a block explorer is of course an option, but it would be nice if the logs helped you a bit out.

This PR adds an `age` field to all the import logs (receipt, block, header) and also to the "loaded most recent" logs. This hopefully provides a bit more context as to how long a catch-up might take:

Startup logs:
 
```
INFO [09-20|11:39:23.581] Loaded most recent local header          number=3002486 hash=0a0b16…555511 td=5587832 age=3d2h38m
INFO [09-20|11:39:23.581] Loaded most recent local full block      number=3002486 hash=0a0b16…555511 td=5587832 age=3d2h38m
INFO [09-20|11:39:23.581] Loaded most recent local fast block      number=3002486 hash=0a0b16…555511 td=5587832 age=3d2h38m
```

Import logs:

```
INFO [09-20|12:11:26.785] Imported new block headers               count=384 elapsed=328.229ms number=4074232 hash=633555…f35f7f age=10h15m48s
INFO [09-20|12:11:26.976] Imported new block headers               count=192 elapsed=174.491ms number=4074424 hash=2aa83c…a08d66 age=9h31m36s
INFO [09-20|12:11:27.465] Imported new block headers               count=576 elapsed=469.789ms number=4075000 hash=a32347…47afd9 age=7h25m36s
INFO [09-20|12:11:27.644] Imported new block headers               count=192 elapsed=162.887ms number=4075192 hash=274c76…d5b962 age=6h47m5s
INFO [09-20|12:11:28.334] Imported new block headers               count=768 elapsed=670.033ms number=4075960 hash=9397fe…8dd879 age=3h54m55s
INFO [09-20|12:11:28.647] Imported new block headers               count=384 elapsed=290.009ms number=4076344 hash=b69eea…c5a0e2 age=2h31m51s
INFO [09-20|12:11:29.113] Imported new block headers               count=576 elapsed=447.128ms number=4076920 hash=c64a30…7894ab age=29m2s
INFO [09-20|12:11:29.243] Imported new block headers               count=127 elapsed=110.961ms number=4077047 hash=ea1c6b…eb6b18 age=35s
INFO [09-20|12:11:50.367] Imported new block headers               count=2   elapsed=5.152ms   number=4077049 hash=d59587…a766ac age=9s
INFO [09-20|12:12:02.047] Imported new block headers               count=1   elapsed=11.174ms  number=4077050 hash=b1db79…07c590 age=13s
```

*Note, this PR drops the `mgas` log field from imports. It's a cute statistic, but it's not really useful. Blocks are generally full, so there's not much surprise in `mgas`. Also, the `mgas` is just the `elapsed * mgasps` that we sill log so you can calculate it if you really must.*