### PR TITLE
crypto/secp256k1: remove useless code

### DIFF
--- a/crypto/secp256k1/libsecp256k1/src/secp256k1.c
+++ b/crypto/secp256k1/libsecp256k1/src/secp256k1.c
@@ -26,7 +26,6 @@
 } while(0)
 
 static void default_illegal_callback_fn(const char* str, void* data) {
-    (void)data;
     fprintf(stderr, "[libsecp256k1] illegal argument: %s\n", str);
     abort();
 }
@@ -37,7 +36,6 @@ static const secp256k1_callback default_illegal_callback = {
 };
 
 static void default_error_callback_fn(const char* str, void* data) {
-    (void)data;
     fprintf(stderr, "[libsecp256k1] internal consistency check failed: %s\n", str);
     abort();
 }


### PR DESCRIPTION
`(void)data;` may cause link error on Windows. After removing this code, the process of link is success.

Compiler: gcc version 5.3.0 (x86_64-posix-seh-rev0, Built by MinGW-W64 project)
Target: x86_64-w64-mingw32

LOG:
```
\Go\pkg\tool\windows_amd64\link.exe: running gcc failed: exit status 1
\Temp\go-link-676803019\000003.o: In function `default_error_callback_fn':
\go\src\github.com\ethereum\go-ethereum\crypto\secp256k1/./libsecp256k1/src/secp256k1.c:41: undefined reference to `__getreent'
\Temp\go-link-676803019\000003.o: In function `default_illegal_callback_fn':
\go\src\github.com\ethereum\go-ethereum\crypto\secp256k1/./libsecp256k1/src/secp256k1.c:30: undefined reference to `__getreent'
collect2.exe: error: ld returned 1 exit status
```