### PR TITLE
cmd/puppeth: allow specifying a version for geth and faucet

### DIFF
--- a/cmd/puppeth/module_faucet.go
+++ b/cmd/puppeth/module_faucet.go
@@ -33,7 +33,7 @@ import (
 // faucetDockerfile is the Dockerfile required to build a faucet container to
 // grant crypto tokens based on GitHub authentications.
 var faucetDockerfile = `
-FROM ethereum/client-go:alltools-latest
+FROM ethereum/client-go:alltools-{{.Version}}
 
 ADD genesis.json /genesis.json
 ADD account.json /account.json
@@ -90,6 +90,7 @@ func deployFaucet(client *sshClient, network string, bootnodes []string, config 
 
 	dockerfile := new(bytes.Buffer)
 	template.Must(template.New("").Parse(faucetDockerfile)).Execute(dockerfile, map[string]interface{}{
+		"Version":       config.node.version,
 		"NetworkID":     config.node.network,
 		"Bootnodes":     strings.Join(bootnodes, ","),
 		"Ethstats":      config.node.ethstats,

--- a/cmd/puppeth/module_node.go
+++ b/cmd/puppeth/module_node.go
@@ -32,7 +32,7 @@ import (
 
 // nodeDockerfile is the Dockerfile required to run an Ethereum node.
 var nodeDockerfile = `
-FROM ethereum/client-go:latest
+FROM ethereum/client-go:{{.Version}}
 
 ADD genesis.json /genesis.json
 {{if .Unlock}}
@@ -97,6 +97,7 @@ func deployNode(client *sshClient, network string, bootnodes []string, config *n
 	}
 	dockerfile := new(bytes.Buffer)
 	template.Must(template.New("").Parse(nodeDockerfile)).Execute(dockerfile, map[string]interface{}{
+		"Version":   config.version,
 		"NetworkID": config.network,
 		"Port":      config.port,
 		"Peers":     config.peersTotal,
@@ -165,6 +166,7 @@ type nodeInfos struct {
 	gasTarget  float64
 	gasLimit   float64
 	gasPrice   float64
+	version    string
 }
 
 // Report converts the typed struct into a plain string->string map, containing

--- a/cmd/puppeth/wizard_faucet.go
+++ b/cmd/puppeth/wizard_faucet.go
@@ -38,7 +38,7 @@ func (w *wizard) deployFaucet() {
 	infos, err := checkFaucet(client, w.network)
 	if err != nil {
 		infos = &faucetInfos{
-			node:    &nodeInfos{port: 30303, peersTotal: 25},
+			node:    &nodeInfos{port: 30303, peersTotal: 25, version: "latest"},
 			port:    80,
 			host:    client.server,
 			amount:  1,
@@ -102,6 +102,11 @@ func (w *wizard) deployFaucet() {
 			infos.captchaSecret = w.readPassword()
 		}
 	}
+	// Figure out which version of faucet to use
+	fmt.Println()
+	fmt.Printf("Which version of faucet to use? (default = %s)\n", infos.node.version)
+	infos.node.version = w.readDefaultVersion(infos.node.version)
+
 	// Figure out where the user wants to store the persistent data
 	fmt.Println()
 	if infos.node.datadir == "" {

--- a/cmd/puppeth/wizard_node.go
+++ b/cmd/puppeth/wizard_node.go
@@ -55,8 +55,14 @@ func (w *wizard) deployNode(boot bool) {
 	}
 	existed := err == nil
 
+	infos.version = "latest"
 	infos.genesis, _ = json.MarshalIndent(w.conf.Genesis, "", "  ")
 	infos.network = w.conf.Genesis.Config.ChainID.Int64()
+
+	// Figure out which version of geth to use
+	fmt.Println()
+	fmt.Printf("Which version of geth to use? (default = %s)\n", infos.version)
+	infos.version = w.readDefaultVersion(infos.version)
 
 	// Figure out where the user wants to store the persistent data
 	fmt.Println()


### PR DESCRIPTION
This change allows a user to specify which version of the geth and faucet (alltools) container images to use. It defaults to "latest" which was the previous behaviour. Useful when testing different versions and how they interact.