### PR TITLE
les/flowcontrol: remove a no-op line in the code

### DIFF
--- a/les/flowcontrol/control.go
+++ b/les/flowcontrol/control.go
@@ -82,7 +82,6 @@ func (peer *ClientNode) RequestProcessed(cost uint64) (bv, realCost uint64) {
 	time := mclock.Now()
 	peer.recalcBV(time)
 	peer.bufValue -= cost
-	peer.recalcBV(time)
 	rcValue, rcost := peer.cm.processed(peer.cmNode, time)
 	if rcValue < peer.params.BufLimit {
 		bv := peer.params.BufLimit - rcValue


### PR DESCRIPTION
This PR removes a line in the code that doesn't seem to be doing anything. Consider the body of the `recalcBV` function:

```go
func (peer *ClientNode) recalcBV(time mclock.AbsTime) {
	dt := uint64(time - peer.lastTime)
	if time < peer.lastTime {
		dt = 0
	}
	peer.bufValue += peer.params.MinRecharge * dt / uint64(fcTimeConst)
	if peer.bufValue > peer.params.BufLimit {
		peer.bufValue = peer.params.BufLimit
	}
	peer.lastTime = time
}
```

In the original code, it's called twice in a row with the same `time` value. The second execution will be equivalent to:

```go
dt := 0
peer.bufValue += 0
peer.lastTime = peer.lastTime
```

... which is a no-op, so it should be safe to remove it.