### PR TITLE
accounts/abi/bind: drop dependency on goimports for Go bindings

### DIFF
--- a/accounts/abi/bind/bind.go
+++ b/accounts/abi/bind/bind.go
@@ -29,7 +29,6 @@ import (
 	"unicode"
 
 	"github.com/ethereum/go-ethereum/accounts/abi"
-	"golang.org/x/tools/imports"
 )
 
 // Lang is a target programming language selector to generate bindings for.
@@ -145,15 +144,7 @@ func Bind(types []string, abis []string, bytecodes []string, pkg string, lang La
 	if err := tmpl.Execute(buffer, data); err != nil {
 		return "", err
 	}
-	// For Go bindings pass the code through goimports to clean it up and double check
-	if lang == LangGo {
-		code, err := imports.Process(".", buffer.Bytes(), nil)
-		if err != nil {
-			return "", fmt.Errorf("%v\n%s", err, buffer)
-		}
-		return string(code), nil
-	}
-	// For all others just return as is for now
+
 	return buffer.String(), nil
 }
 

--- a/accounts/abi/bind/template.go
+++ b/accounts/abi/bind/template.go
@@ -64,6 +64,30 @@ const tmplSourceGo = `
 
 package {{.Package}}
 
+import (
+	"math/big"
+	"strings"
+
+	ethereum "github.com/ethereum/go-ethereum"
+	"github.com/ethereum/go-ethereum/accounts/abi"
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/event"
+)
+
+// Reference imports to suppress errors if they are not otherwise used.
+var (
+	_ = big.NewInt
+	_ = strings.NewReader
+	_ = ethereum.NotFound
+	_ = abi.U256
+	_ = bind.Bind
+	_ = common.Big1
+	_ = types.BloomLookup
+	_ = event.NewSubscription
+)
+
 {{range $contract := .Contracts}}
 	// {{.Type}}ABI is the input ABI used to generate the binding from.
 	const {{.Type}}ABI = "{{.InputABI}}"


### PR DESCRIPTION
In projects with large GOPATHs, goimports can take a long time to run.

goimports has also not been updated for Go 1.11 modules:

https://github.com/golang/go/issues/27287
https://github.com/golang/go/issues/27865
https://github.com/golang/go/issues/24661

Instead of using goimports to insert import statements, this commit generates imports directly in the Go template.