### PR TITLE
swarm: handle errors in cmdLineOverride and envVarsOverride

### DIFF
--- a/cmd/swarm/config.go
+++ b/cmd/swarm/config.go
@@ -179,7 +179,9 @@ func cmdLineOverride(currentConfig *bzzapi.Config, ctx *cli.Context) *bzzapi.Con
 		if err != nil {
 			utils.Fatalf("invalid cli flag %s: %v", SwarmNetworkIdFlag.Name, err)
 		}
-		currentConfig.NetworkID = id
+		if id != 0 {
+			currentConfig.NetworkID = id
+		}
 	}
 
 	if ctx.GlobalIsSet(utils.DataDirFlag.Name) {
@@ -272,7 +274,9 @@ func envVarsOverride(currentConfig *bzzapi.Config) (config *bzzapi.Config) {
 		if err != nil {
 			utils.Fatalf("invalid environment variable %s: %v", SWARM_ENV_NETWORK_ID, err)
 		}
-		currentConfig.NetworkID = id
+		if id != 0 {
+			currentConfig.NetworkID = id
+		}
 	}
 
 	if datadir := os.Getenv(GETH_ENV_DATADIR); datadir != "" {

--- a/cmd/swarm/config.go
+++ b/cmd/swarm/config.go
@@ -175,9 +175,11 @@ func cmdLineOverride(currentConfig *bzzapi.Config, ctx *cli.Context) *bzzapi.Con
 	}
 
 	if networkid := ctx.GlobalString(SwarmNetworkIdFlag.Name); networkid != "" {
-		if id, _ := strconv.Atoi(networkid); id != 0 {
-			currentConfig.NetworkID = uint64(id)
+		id, err := strconv.ParseUint(networkid, 10, 64)
+		if err != nil {
+			utils.Fatalf("invalid cli flag %s: %v", SwarmNetworkIdFlag.Name, err)
 		}
+		currentConfig.NetworkID = id
 	}
 
 	if ctx.GlobalIsSet(utils.DataDirFlag.Name) {
@@ -266,9 +268,11 @@ func envVarsOverride(currentConfig *bzzapi.Config) (config *bzzapi.Config) {
 	}
 
 	if networkid := os.Getenv(SWARM_ENV_NETWORK_ID); networkid != "" {
-		if id, _ := strconv.Atoi(networkid); id != 0 {
-			currentConfig.NetworkID = uint64(id)
+		id, err := strconv.ParseUint(networkid, 10, 64)
+		if err != nil {
+			utils.Fatalf("invalid environment variable %s: %v", SWARM_ENV_NETWORK_ID, err)
 		}
+		currentConfig.NetworkID = id
 	}
 
 	if datadir := os.Getenv(GETH_ENV_DATADIR); datadir != "" {
@@ -285,33 +289,42 @@ func envVarsOverride(currentConfig *bzzapi.Config) (config *bzzapi.Config) {
 	}
 
 	if swapenable := os.Getenv(SWARM_ENV_SWAP_ENABLE); swapenable != "" {
-		if swap, err := strconv.ParseBool(swapenable); err != nil {
-			currentConfig.SwapEnabled = swap
+		swap, err := strconv.ParseBool(swapenable)
+		if err != nil {
+			utils.Fatalf("invalid environment variable %s: %v", SWARM_ENV_SWAP_ENABLE, err)
 		}
+		currentConfig.SwapEnabled = swap
 	}
 
 	if syncdisable := os.Getenv(SWARM_ENV_SYNC_DISABLE); syncdisable != "" {
-		if sync, err := strconv.ParseBool(syncdisable); err != nil {
-			currentConfig.SyncEnabled = !sync
+		sync, err := strconv.ParseBool(syncdisable)
+		if err != nil {
+			utils.Fatalf("invalid environment variable %s: %v", SWARM_ENV_SYNC_DISABLE, err)
 		}
+		currentConfig.SyncEnabled = !sync
 	}
 
 	if v := os.Getenv(SWARM_ENV_DELIVERY_SKIP_CHECK); v != "" {
-		if skipCheck, err := strconv.ParseBool(v); err != nil {
+		skipCheck, err := strconv.ParseBool(v)
+		if err != nil {
 			currentConfig.DeliverySkipCheck = skipCheck
 		}
 	}
 
 	if v := os.Getenv(SWARM_ENV_SYNC_UPDATE_DELAY); v != "" {
-		if d, err := time.ParseDuration(v); err != nil {
-			currentConfig.SyncUpdateDelay = d
+		d, err := time.ParseDuration(v)
+		if err != nil {
+			utils.Fatalf("invalid environment variable %s: %v", SWARM_ENV_SYNC_UPDATE_DELAY, err)
 		}
+		currentConfig.SyncUpdateDelay = d
 	}
 
 	if lne := os.Getenv(SWARM_ENV_LIGHT_NODE_ENABLE); lne != "" {
-		if lightnode, err := strconv.ParseBool(lne); err != nil {
-			currentConfig.LightNodeEnabled = lightnode
+		lightnode, err := strconv.ParseBool(lne)
+		if err != nil {
+			utils.Fatalf("invalid environment variable %s: %v", SWARM_ENV_LIGHT_NODE_ENABLE, err)
 		}
+		currentConfig.LightNodeEnabled = lightnode
 	}
 
 	if swapapi := os.Getenv(SWARM_ENV_SWAP_API); swapapi != "" {

--- a/cmd/swarm/main.go
+++ b/cmd/swarm/main.go
@@ -95,6 +95,7 @@ var (
 		Name:   "bzznetworkid",
 		Usage:  "Network identifier (integer, default 3=swarm testnet)",
 		EnvVar: SWARM_ENV_NETWORK_ID,
+		Value:  3,
 	}
 	SwarmSwapEnabledFlag = cli.BoolFlag{
 		Name:   "swap",

--- a/cmd/swarm/main.go
+++ b/cmd/swarm/main.go
@@ -95,7 +95,6 @@ var (
 		Name:   "bzznetworkid",
 		Usage:  "Network identifier (integer, default 3=swarm testnet)",
 		EnvVar: SWARM_ENV_NETWORK_ID,
-		Value:  3,
 	}
 	SwarmSwapEnabledFlag = cli.BoolFlag{
 		Name:   "swap",


### PR DESCRIPTION
This PR addresses the incorrect handling of errors in swarm cmd package.

The problem was that values are set when there were errors. With this changes, errors are propagated to the user and the program execution is stopped.