### PR TITLE
swarm/storage: Add ordered garbage collection test for ldb

### DIFF
--- a/swarm/storage/ldbstore.go
+++ b/swarm/storage/ldbstore.go
@@ -248,7 +248,7 @@ func decodeData(addr Address, data []byte) (*chunk, error) {
 }
 
 func (s *LDBStore) collectGarbage(ratio float32) {
-	log.Trace("collectGarbage", "ratio", ratio)
+	log.Trace("collectGarbage", "ratio", ratio, "entrycnt", s.entryCnt)
 
 	metrics.GetOrRegisterCounter("ldbstore.collectgarbage", nil).Inc(1)
 
@@ -258,7 +258,7 @@ func (s *LDBStore) collectGarbage(ratio float32) {
 	garbage := []*gcItem{}
 	gcnt := 0
 
-	for ok := it.Seek([]byte{keyIndex}); ok && (gcnt < maxGCitems) && (uint64(gcnt) < s.entryCnt); ok = it.Next() {
+	for ok := it.Seek([]byte{keyIndex}); ok && (uint64(gcnt) < s.entryCnt); ok = it.Next() {
 		itkey := it.Key()
 
 		if (itkey == nil) || (itkey[0] != keyIndex) {
@@ -290,7 +290,11 @@ func (s *LDBStore) collectGarbage(ratio float32) {
 
 	sort.Slice(garbage[:gcnt], func(i, j int) bool { return garbage[i].value < garbage[j].value })
 
+	if gcnt > maxGCitems {
+		gcnt = maxGCitems
+	}
 	cutoff := int(float32(gcnt) * ratio)
+
 	metrics.GetOrRegisterCounter("ldbstore.collectgarbage.delete", nil).Inc(int64(cutoff))
 
 	for i := 0; i < cutoff; i++ {

--- a/swarm/storage/ldbstore.go
+++ b/swarm/storage/ldbstore.go
@@ -719,14 +719,16 @@ func (s *LDBStore) tryAccessIdx(ikey []byte, index *dpaDBIndex) bool {
 	}
 	decodeIndex(idata, index)
 	s.batch.Put(keyAccessCnt, U64ToBytes(s.accessCnt))
-	s.accessCnt++
-	index.Access = s.accessCnt
+	// presumably, we only want to increase the access count of the chunk in question, and not the offset of any future ones?
+	//s.accessCnt++
+	index.Access = s.accessCnt + 1
 	idata = encodeIndex(index)
 	s.batch.Put(ikey, idata)
 	select {
 	case s.batchesC <- struct{}{}:
 	default:
 	}
+	log.Trace("tryaccessidx", "addr", fmt.Sprintf("%x", ikey[1:]), "indexdata", index, "data", idata)
 	return true
 }
 

--- a/swarm/storage/ldbstore.go
+++ b/swarm/storage/ldbstore.go
@@ -719,9 +719,8 @@ func (s *LDBStore) tryAccessIdx(ikey []byte, index *dpaDBIndex) bool {
 	}
 	decodeIndex(idata, index)
 	s.batch.Put(keyAccessCnt, U64ToBytes(s.accessCnt))
-	// presumably, we only want to increase the access count of the chunk in question, and not the offset of any future ones?
-	//s.accessCnt++
-	index.Access = s.accessCnt + 1
+	s.accessCnt++
+	index.Access = s.accessCnt
 	idata = encodeIndex(index)
 	s.batch.Put(ikey, idata)
 	select {

--- a/swarm/storage/ldbstore_test.go
+++ b/swarm/storage/ldbstore_test.go
@@ -343,9 +343,9 @@ func TestLDBStoreCollectGarbage(t *testing.T) {
 
 // TestLDBStoreCollectGarbageOrdered checks if the most recently added chunks according to capacity are left after garbage collection
 func TestLDBStoreCollectGarbageOrdered(t *testing.T) {
-	capacity := 10000
-	chunkCount := 20000
 	gcThreshold := int(maxGCitems * gcArrayFreeRatio)
+	capacity := maxGCitems * 2
+	chunkCount := capacity * 2
 	hasher := MakeHashFunc(DefaultHash)()
 	writeBatchTolerance := 128 // according to log ldb seems to write in batches of 6
 


### PR DESCRIPTION
This PR investigates reports that chunks go missing from storage, and the suspicion that the garbage collector is not exhibiting expected behavior of conserving the most recent chunks.

https://github.com/ethersphere/go-ethereum/issues/936

https://github.com/ethersphere/go-ethereum/issues/931

Current status of PR:

* Sets capacity to half of the total chunk count, and uploads sequential data. Expect to retrieve the last chunks added up to the garbage collection threshold. This always fails for test `capacity = 2 * maxGCCount`, `chunkcount = 2 * capacity`