### PR TITLE
eth, node: use APPDATA env to support cygwin/msys correctly

### DIFF
--- a/cmd/clef/main.go
+++ b/cmd/clef/main.go
@@ -494,7 +494,12 @@ func DefaultConfigDir() string {
 		if runtime.GOOS == "darwin" {
 			return filepath.Join(home, "Library", "Signer")
 		} else if runtime.GOOS == "windows" {
-			return filepath.Join(home, "AppData", "Roaming", "Signer")
+			appdata := os.Getenv("APPDATA")
+			if appdata != "" {
+				return filepath.Join(appdata, "Signer")
+			} else {
+				return filepath.Join(home, "AppData", "Roaming", "Signer")
+			}
 		} else {
 			return filepath.Join(home, ".clef")
 		}

--- a/eth/config.go
+++ b/eth/config.go
@@ -67,8 +67,15 @@ func init() {
 			home = user.HomeDir
 		}
 	}
-	if runtime.GOOS == "windows" {
-		DefaultConfig.Ethash.DatasetDir = filepath.Join(home, "AppData", "Ethash")
+	if runtime.GOOS == "darwin" {
+		DefaultConfig.Ethash.DatasetDir = filepath.Join(home, "Library", "Ethash")
+	} else if runtime.GOOS == "windows" {
+		localappdata := os.Getenv("LOCALAPPDATA")
+		if localappdata != "" {
+			DefaultConfig.Ethash.DatasetDir = filepath.Join(localappdata, "Ethash")
+		} else {
+			DefaultConfig.Ethash.DatasetDir = filepath.Join(home, "AppData", "Local", "Ethash")
+		}
 	} else {
 		DefaultConfig.Ethash.DatasetDir = filepath.Join(home, ".ethash")
 	}

--- a/node/defaults.go
+++ b/node/defaults.go
@@ -59,7 +59,7 @@ func DefaultDataDir() string {
 		if runtime.GOOS == "darwin" {
 			return filepath.Join(home, "Library", "Ethereum")
 		} else if runtime.GOOS == "windows" {
-			return filepath.Join(home, "AppData", "Roaming", "Ethereum")
+			return filepath.Join(os.Getenv("APPDATA"), "Ethereum")
 		} else {
 			return filepath.Join(home, ".ethereum")
 		}

--- a/node/defaults.go
+++ b/node/defaults.go
@@ -59,7 +59,12 @@ func DefaultDataDir() string {
 		if runtime.GOOS == "darwin" {
 			return filepath.Join(home, "Library", "Ethereum")
 		} else if runtime.GOOS == "windows" {
-			return filepath.Join(os.Getenv("APPDATA"), "Ethereum")
+			appdata := os.Getenv("APPDATA")
+			if appdata != "" {
+				return filepath.Join(appdata, "Ethereum")
+			} else {
+				return filepath.Join(home, "AppData", "Roaming", "Ethereum")
+			}
 		} else {
 			return filepath.Join(home, ".ethereum")
 		}

--- a/node/defaults.go
+++ b/node/defaults.go
@@ -56,21 +56,45 @@ func DefaultDataDir() string {
 	// Try to place the data folder in the user's home dir
 	home := homeDir()
 	if home != "" {
-		if runtime.GOOS == "darwin" {
+		switch runtime.GOOS {
+		case "darwin":
 			return filepath.Join(home, "Library", "Ethereum")
-		} else if runtime.GOOS == "windows" {
-			appdata := os.Getenv("APPDATA")
-			if appdata != "" {
-				return filepath.Join(appdata, "Ethereum")
-			} else {
-				return filepath.Join(home, "AppData", "Roaming", "Ethereum")
+		case "windows":
+			// We used to put everything in %HOME%\AppData\Roaming, but this caused
+			// problems with non-typical setups. If this fallback location exists and
+			// is non-empty, use it, otherwise DTRT and check %LOCALAPPDATA%.
+			fallback := filepath.Join(home, "AppData", "Roaming", "Ethereum")
+			appdata := windowsAppData()
+			if appdata == "" || isNonEmptyDir(fallback) {
+				return fallback
 			}
-		} else {
+			return filepath.Join(appdata, "Ethereum")
+		default:
 			return filepath.Join(home, ".ethereum")
 		}
 	}
 	// As we cannot guess a stable location, return empty and handle later
 	return ""
+}
+
+func windowsAppData() string {
+	if v := os.Getenv("LOCALAPPDATA"); v != "" {
+		return v // Vista+
+	}
+	if v := os.Getenv("APPDATA"); v != "" {
+		return filepath.Join(v, "Local")
+	}
+	return ""
+}
+
+func isNonEmptyDir(dir string) bool {
+	f, err := os.Open(dir)
+	if err != nil {
+		return false
+	}
+	names, _ := f.Readdir(1)
+	f.Close()
+	return len(names) > 0
 }
 
 func homeDir() string {


### PR DESCRIPTION
since windows XP `$APPDATA (%APPDATA%)` is used.
Please see also
- http://environmentvariables.org/AppData
- https://www.askvg.com/list-of-environment-variables-in-windows-xp-vista-and-7/

for normal windows native environment, `%HOME%(C:\Users\foobar) + \AppData\Roaming` is correctly interpreted as `%APPDATA%`, but for cygwin/msys2 environment or powershell, `%HOME%` is `/home/foobar/` and `%HOME%` + `\AppData\Roaming` is not `%APPDATA%` anymore.

Simply using `%APPDATA%` fix this issue.