### PR TITLE
cmd/swarm: disable export and upload tests on Windows

### DIFF
--- a/cmd/swarm/export_test.go
+++ b/cmd/swarm/export_test.go
@@ -14,6 +14,8 @@
 // You should have received a copy of the GNU General Public License
 // along with go-ethereum. If not, see <http://www.gnu.org/licenses/>.
 
+// +build !windows
+
 package main
 
 import (

--- a/cmd/swarm/upload_test.go
+++ b/cmd/swarm/upload_test.go
@@ -14,6 +14,8 @@
 // You should have received a copy of the GNU General Public License
 // along with go-ethereum. If not, see <http://www.gnu.org/licenses/>.
 
+// +build !windows
+
 package main
 
 import (


### PR DESCRIPTION
This PR is disabling some of Swarm tests on Windows, until we solve their flakiness.

Related issue: https://github.com/ethersphere/go-ethereum/issues/955