### PR TITLE
 cmd: Fix bug preventing --lightserv NN w/ --syncmode=full

### DIFF
--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -1085,11 +1085,14 @@ func checkExclusive(ctx *cli.Context, args ...interface{}) {
 		if i+1 < len(args) {
 			switch option := args[i+1].(type) {
 			case string:
-				// Extended flag, expand the name and shift the arguments
+				// Extended flag check, make sure value set doesn't conflict with passed in option
 				if ctx.GlobalString(flag.GetName()) == option {
 					name += "=" + option
+					set = append(set, "--"+name)
 				}
+				// shift arguments and continue
 				i++
+				continue
 
 			case cli.Flag:
 			default:


### PR DESCRIPTION

Currently in `master` this combination of flags fails:

```
$ ./build/bin/geth dumpconfig --lightserv 90 --syncmode=full --gcmode=archive
INFO [10-01|14:15:20.621] Maximum peer count                       ETH=25 LES=100 total=125
Fatal: Flags --lightserv, --syncmode can't be used at the same time
```

However, the intent was to prevent `--lightserv NN` and `--syncmode=light`.  
There was a bug in the validation logic, this PR fixes said logic so that the above works, but the intended conflict still fails:

```
$ ./build/bin/geth dumpconfig --lightserv 90 --syncmode=light
INFO [10-01|14:18:05.744] Maximum peer count                       ETH=0 LES=100 total=125
Fatal: Flags --lightserv, --syncmode=light can't be used at the same time
```

```
$ ./build/bin/geth dumpconfig --lightserv 90 --syncmode=full
INFO [10-01|14:18:22.200] Maximum peer count                       ETH=25 LES=100 total=125
[Eth]
NetworkId = 1
...rest of config elided..
```

Note this is effectively a refresh of #16862 which was sitting in PR limbo for awhile.
