### PR TITLE
travis: remove Go 1.9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,17 +6,6 @@ matrix:
     - os: linux
       dist: trusty
       sudo: required
-      go: 1.9.x
-      script:
-        - sudo modprobe fuse
-        - sudo chmod 666 /dev/fuse
-        - sudo chown root:$USER /etc/fuse.conf
-        - go run build/ci.go install
-        - go run build/ci.go test -coverage $TEST_PACKAGES
-
-    - os: linux
-      dist: trusty
-      sudo: required
       go: 1.10.x
       script:
       - sudo modprobe fuse


### PR DESCRIPTION
Go 1.9 won't contain any more security updates (if any are released), because Go 1.11 is released.

I think there is not much point keeping the Go 1.9 build anymore, since we have Go 1.10 and Go 1.11, furthermore we are putting additional load on Travis.