### PR TITLE
SHA3 word cost for CREATE2

### DIFF
--- a/core/vm/gas_table.go
+++ b/core/vm/gas_table.go
@@ -347,6 +347,17 @@ func gasCreate2(gt params.GasTable, evm *EVM, contract *Contract, stack *Stack, 
 	if gas, overflow = math.SafeAdd(gas, params.Create2Gas); overflow {
 		return 0, errGasUintOverflow
 	}
+	wordGas, overflow := bigUint64(stack.Back(2))
+	if overflow {
+		return 0, errGasUintOverflow
+	}
+	if wordGas, overflow = math.SafeMul(toWordSize(wordGas), params.Sha3WordGas); overflow {
+		return 0, errGasUintOverflow
+	}
+	if gas, overflow = math.SafeAdd(gas, wordGas); overflow {
+		return 0, errGasUintOverflow
+	}
+
 	return gas, nil
 }
 

--- a/core/vm/instructions_test.go
+++ b/core/vm/instructions_test.go
@@ -559,7 +559,7 @@ func TestCreate2Addreses(t *testing.T) {
 			fmt.Printf("Example %d\n* address `0x%x`\n* salt `0x%x`\n* init_code `0x%x`\n* gas (assuming no mem expansion): `%v`\n* result: `%s`\n\n", i,origin, salt, code, gas, address.String())
 		*/
 		expected := common.BytesToAddress(common.FromHex(tt.expected))
-		if bytes.Compare(expected.Bytes(), address.Bytes()) != 0 {
+		if !bytes.Equal(expected.Bytes(), address.Bytes()) {
 			t.Errorf("test %d: expected %s, got %s", i, expected.String(), address.String())
 		}
 

--- a/core/vm/instructions_test.go
+++ b/core/vm/instructions_test.go
@@ -18,12 +18,11 @@ package vm
 
 import (
 	"bytes"
-	"fmt"
-	"github.com/ethereum/go-ethereum/crypto"
 	"math/big"
 	"testing"
 
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/params"
 )
 
@@ -544,14 +543,21 @@ func TestCreate2Addreses(t *testing.T) {
 			code:     "0x",
 			expected: "0xE33C0C7F7df4809055C3ebA6c09CFe4BaF1BD9e0",
 		},
-
 	} {
 
 		origin := common.BytesToAddress(common.FromHex(tt.origin))
 		salt := common.BytesToHash(common.FromHex(tt.salt))
 		code := common.FromHex(tt.code)
 		address := crypto.CreateAddress2(origin, salt, code)
-		fmt.Printf("Example %d\n* address `0x%x`\n* salt `0x%x`\n* code `0x%x`\n* result: `%s`\n\n", i,origin, salt, code, address.String())
+		/*
+			stack          := newstack()
+			// salt, but we don't need that for this test
+			stack.push(big.NewInt(int64(len(code)))) //size
+			stack.push(big.NewInt(0)) // memstart
+			stack.push(big.NewInt(0)) // value
+			gas, _ := gasCreate2(params.GasTable{}, nil, nil, stack, nil, 0)
+			fmt.Printf("Example %d\n* address `0x%x`\n* salt `0x%x`\n* init_code `0x%x`\n* gas (assuming no mem expansion): `%v`\n* result: `%s`\n\n", i,origin, salt, code, gas, address.String())
+		*/
 		expected := common.BytesToAddress(common.FromHex(tt.expected))
 		if bytes.Compare(expected.Bytes(), address.Bytes()) != 0 {
 			t.Errorf("test %d: expected %s, got %s", i, expected.String(), address.String())

--- a/core/vm/instructions_test.go
+++ b/core/vm/instructions_test.go
@@ -17,6 +17,9 @@
 package vm
 
 import (
+	"bytes"
+	"fmt"
+	"github.com/ethereum/go-ethereum/crypto"
 	"math/big"
 	"testing"
 
@@ -488,4 +491,71 @@ func BenchmarkOpMstore(bench *testing.B) {
 		opMstore(&pc, evmInterpreter, nil, mem, stack)
 	}
 	poolOfIntPools.put(evmInterpreter.intPool)
+}
+
+func TestCreate2Addreses(t *testing.T) {
+	type testcase struct {
+		origin   string
+		salt     string
+		code     string
+		expected string
+	}
+
+	for i, tt := range []testcase{
+		{
+			origin:   "0x0000000000000000000000000000000000000000",
+			salt:     "0x0000000000000000000000000000000000000000",
+			code:     "0x00",
+			expected: "0x4d1a2e2bb4f88f0250f26ffff098b0b30b26bf38",
+		},
+		{
+			origin:   "0xdeadbeef00000000000000000000000000000000",
+			salt:     "0x0000000000000000000000000000000000000000",
+			code:     "0x00",
+			expected: "0xB928f69Bb1D91Cd65274e3c79d8986362984fDA3",
+		},
+		{
+			origin:   "0xdeadbeef00000000000000000000000000000000",
+			salt:     "0xfeed000000000000000000000000000000000000",
+			code:     "0x00",
+			expected: "0xD04116cDd17beBE565EB2422F2497E06cC1C9833",
+		},
+		{
+			origin:   "0x0000000000000000000000000000000000000000",
+			salt:     "0x0000000000000000000000000000000000000000",
+			code:     "0xdeadbeef",
+			expected: "0x70f2b2914A2a4b783FaEFb75f459A580616Fcb5e",
+		},
+		{
+			origin:   "0x00000000000000000000000000000000deadbeef",
+			salt:     "0xcafebabe",
+			code:     "0xdeadbeef",
+			expected: "0x60f3f640a8508fC6a86d45DF051962668E1e8AC7",
+		},
+		{
+			origin:   "0x00000000000000000000000000000000deadbeef",
+			salt:     "0xcafebabe",
+			code:     "0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef",
+			expected: "0x1d8bfDC5D46DC4f61D6b6115972536eBE6A8854C",
+		},
+		{
+			origin:   "0x0000000000000000000000000000000000000000",
+			salt:     "0x0000000000000000000000000000000000000000",
+			code:     "0x",
+			expected: "0xE33C0C7F7df4809055C3ebA6c09CFe4BaF1BD9e0",
+		},
+
+	} {
+
+		origin := common.BytesToAddress(common.FromHex(tt.origin))
+		salt := common.BytesToHash(common.FromHex(tt.salt))
+		code := common.FromHex(tt.code)
+		address := crypto.CreateAddress2(origin, salt, code)
+		fmt.Printf("Example %d\n* address `0x%x`\n* salt `0x%x`\n* code `0x%x`\n* result: `%s`\n\n", i,origin, salt, code, address.String())
+		expected := common.BytesToAddress(common.FromHex(tt.expected))
+		if bytes.Compare(expected.Bytes(), address.Bytes()) != 0 {
+			t.Errorf("test %d: expected %s, got %s", i, expected.String(), address.String())
+		}
+
+	}
 }


### PR DESCRIPTION
This adds a per-word cost to `CREATE2`, as discussed in https://gitter.im/ethereum/AllCoreDevs?at=5bb315de6e5a401c2d037971