### PR TITLE
swarm/storage: Accesscount-indexcount index for gc

### DIFF
--- a/swarm/storage/ldbstore.go
+++ b/swarm/storage/ldbstore.go
@@ -60,7 +60,7 @@ var (
 	keyDataIdx     = []byte{4}
 	keyData        = byte(6)
 	keyDistanceCnt = byte(7)
-	keySchema      = byte(8)
+	keySchema      = []byte{8}
 )
 
 var (

--- a/swarm/storage/ldbstore.go
+++ b/swarm/storage/ldbstore.go
@@ -575,9 +575,6 @@ func (s *LDBStore) delete(idx *dpaDBIndex, idxKey []byte, po uint8) {
 	gcIdxKey := getGCIdxKey(idx)
 	batch.Delete(gcIdxKey)
 	batch.Delete(getDataKey(idx.Idx, po))
-	if s.entryCnt == 0 {
-		panic("")
-	}
 	s.entryCnt--
 	dbEntryCount.Dec(1)
 	cntKey := make([]byte, 2)

--- a/swarm/storage/ldbstore.go
+++ b/swarm/storage/ldbstore.go
@@ -60,7 +60,7 @@ var (
 	keyDataIdx     = []byte{4}
 	keyData        = byte(6)
 	keyDistanceCnt = byte(7)
-	keySchema      = []byte{8}
+	keySchema      = byte(8)
 )
 
 var (

--- a/swarm/storage/ldbstore_test.go
+++ b/swarm/storage/ldbstore_test.go
@@ -385,8 +385,10 @@ func TestLDBStoreAddRemove(t *testing.T) {
 
 // TestLDBStoreRemoveThenCollectGarbage tests that we can delete chunks and that we can trigger garbage collection
 func TestLDBStoreRemoveThenCollectGarbage(t *testing.T) {
-	capacity := 11
-	surplus := 4
+	//capacity := 11
+	//surplus := 4
+	capacity := 10000
+	surplus := 10000
 
 	ldb, cleanup := newLDBStore(t)
 	ldb.setCapacity(uint64(capacity))
@@ -423,7 +425,8 @@ func TestLDBStoreRemoveThenCollectGarbage(t *testing.T) {
 	cleanup()
 
 	ldb, cleanup = newLDBStore(t)
-	capacity = 10
+	//capacity = 10
+	capacity = 10000
 	ldb.setCapacity(uint64(capacity))
 	defer cleanup()
 

--- a/swarm/storage/ldbstore_test.go
+++ b/swarm/storage/ldbstore_test.go
@@ -312,7 +312,6 @@ func TestLDBStoreCollectGarbage(t *testing.T) {
 // TestLDBStoreCollectGarbage tests that we can put more chunks than LevelDB's capacity, and
 // retrieve only some of them, because garbage collection must have cleared some of them
 func testLDBStoreCollectGarbage(t *testing.T) {
-
 	params := strings.Split(t.Name(), "/")
 	capacity, err := strconv.Atoi(params[2])
 	if err != nil {
@@ -482,4 +481,48 @@ func testLDBStoreRemoveThenCollectGarbage(t *testing.T) {
 			t.Fatal("expected to get the same data back, but got smth else")
 		}
 	}
+}
+
+// TestLDBStoreCollectGarbageAccessUnlikeIndex tests garbage collection where accesscount differs from indexcount
+func TestLDBStoreCollectGarbageAccessUnlikeIndex(t *testing.T) {
+
+	capacity := maxGCItems
+	n := capacity - 1
+
+	ldb, cleanup := newLDBStore(t)
+	ldb.setCapacity(uint64(capacity))
+	defer cleanup()
+
+	chunks, err := mputRandomChunks(ldb, n, int64(ch.DefaultSize))
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+	log.Info("ldbstore", "entrycnt", ldb.entryCnt, "accesscnt", ldb.accessCnt)
+
+	// set first added capacity/2 chunks to highest accesscount
+	for i := 0; i < capacity/2; i++ {
+		ldb.Get(context.TODO(), chunks[i].Address())
+	}
+	_, err = mputRandomChunks(ldb, 2, int64(ch.DefaultSize))
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+
+	// wait for garbage collection to kick in on the responsible actor
+	time.Sleep(1 * time.Second)
+
+	var missing int
+	for _, ch := range chunks[:capacity/2] {
+		ret, err := ldb.Get(context.Background(), ch.Address())
+		if err == ErrChunkNotFound || err == ldberrors.ErrNotFound {
+			t.Fatalf("fail find chunk %s: %v", ch.Address(), err)
+		}
+
+		if !bytes.Equal(ret.Data(), ch.Data()) {
+			t.Fatal("expected to get the same data back, but got smth else")
+		}
+		log.Trace("got back chunk", "chunk", ret)
+	}
+
+	log.Info("ldbstore", "total", n, "missing", missing, "entrycnt", ldb.entryCnt, "accesscnt", ldb.accessCnt)
 }

--- a/swarm/swarm.go
+++ b/swarm/swarm.go
@@ -159,11 +159,6 @@ func NewSwarm(config *api.Config, mockStore *mock.NodeStore) (self *Swarm, err e
 		return nil, err
 	}
 
-	err = lstore.Migrate()
-	if err != nil {
-		return nil, err
-	}
-
 	self.netStore, err = storage.NewNetStore(lstore, nil)
 	if err != nil {
 		return nil, err
@@ -200,6 +195,11 @@ func NewSwarm(config *api.Config, mockStore *mock.NodeStore) (self *Swarm, err e
 	lstore.Validators = []storage.ChunkValidator{
 		storage.NewContentAddressValidator(storage.MakeHashFunc(storage.DefaultHash)),
 		feedsHandler,
+	}
+
+	err = lstore.Migrate()
+	if err != nil {
+		return nil, err
 	}
 
 	err = lstore.Migrate()

--- a/swarm/swarm.go
+++ b/swarm/swarm.go
@@ -159,6 +159,11 @@ func NewSwarm(config *api.Config, mockStore *mock.NodeStore) (self *Swarm, err e
 		return nil, err
 	}
 
+	err = lstore.Migrate()
+	if err != nil {
+		return nil, err
+	}
+
 	self.netStore, err = storage.NewNetStore(lstore, nil)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
This PR addresses design shortcomings in the db and a regression bug in garbage collection that causes only a subset of chunks to be considered for obsoletion. More specifically, chunk selection iteration stops at `maxGCitems` chunks, ordered by the value of `Chunk.Address`.

The correct behavior is to only delete `n` chunks with lowest `accessCnt` (accessCount being incremental for _total_ number of accesses to the database since creation). `n` is defined as `entryCount*gcArrayFreeRatio`, or `maxGCitems*gcArrayFreeRatio` if `entryCount` > `maxGCitems`.

Proposed solution is to introduce a separate db index `keyGCIdx` laid out as follows:

* **key**: `keyGCIdx`|`accessCnt`
* **value**: `po`|`indexCnt`|`Address`

(indexCnt is incremental for _total_ number of additions to database since creation).

The behavior will be as follows:

* Upon `Put()`, a new index is created
* Upon `Get()` the `accessCnt` and `indexCnt` will be known at retrieval of chunk. Delete old `keyGCIdx` entry and create new.
* Upon gc, seek db to `keyGCIdx`, retrieve the first `n` rows, delete the data and metadata entry corresponding to the retrieved values, then delete the `keyGCIdx` rows themselves.

This is intended to be a tempoary solution until a more solid db framework is implemented. The performance implications are:

* Put(): +1 `Put` 
* Get(): +1 `Delete`, +1 `Put`
* gc(): +`n` `Get`s, +`n` `Delete`s
