### PR TITLE
travis, appveyor: bump to Go 1.11.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -144,7 +144,7 @@ matrix:
       git:
         submodules: false # avoid cloning ethereum/tests
       before_install:
-        - curl https://storage.googleapis.com/golang/go1.11.linux-amd64.tar.gz | tar -xz
+        - curl https://storage.googleapis.com/golang/go1.11.1.linux-amd64.tar.gz | tar -xz
         - export PATH=`pwd`/go/bin:$PATH
         - export GOROOT=`pwd`/go
         - export GOPATH=$HOME/go

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -23,8 +23,8 @@ environment:
 install:
   - git submodule update --init
   - rmdir C:\go /s /q
-  - appveyor DownloadFile https://storage.googleapis.com/golang/go1.11.windows-%GETH_ARCH%.zip
-  - 7z x go1.11.windows-%GETH_ARCH%.zip -y -oC:\ > NUL
+  - appveyor DownloadFile https://storage.googleapis.com/golang/go1.11.1.windows-%GETH_ARCH%.zip
+  - 7z x go1.11.1.windows-%GETH_ARCH%.zip -y -oC:\ > NUL
   - go version
   - gcc --version
 


### PR DESCRIPTION
```
fd -H -t f -exec sed -i 's|go1.11.|go1.11.1.|g' {} \;
```

Details from yesterday's release: https://go.googlesource.com/go/+/f99fc3a119dbb98fa9dddcb2e31a6c51925fde77/doc/devel/release.html

Download page has been updated: https://golang.org/dl/