### PR TITLE
core: fix unnecessary ancestor lookup after a fast sync

### DIFF
--- a/core/chain_indexer.go
+++ b/core/chain_indexer.go
@@ -219,13 +219,13 @@ func (c *ChainIndexer) eventLoop(currentHeader *types.Header, events chan ChainE
 			}
 			header := ev.Block.Header()
 			if header.ParentHash != prevHash {
-				// Reorg to the common ancestor (might not exist in light sync mode, skip reorg then)
+				// Reorg to the common ancestor if needed (might not exist in light sync mode, skip reorg then)
 				// TODO(karalabe, zsfelfoldi): This seems a bit brittle, can we detect this case explicitly?
 
-				// TODO(karalabe): This operation is expensive and might block, causing the event system to
-				// potentially also lock up. We need to do with on a different thread somehow.
-				if h := rawdb.FindCommonAncestor(c.chainDb, prevHeader, header); h != nil {
-					c.newHead(h.Number.Uint64(), true)
+				if rawdb.ReadCanonicalHash(c.chainDb, prevHeader.Number.Uint64()) != prevHash {
+					if h := rawdb.FindCommonAncestor(c.chainDb, prevHeader, header); h != nil {
+						c.newHead(h.Number.Uint64(), true)
+					}
 				}
 			}
 			c.newHead(header.Number.Uint64(), false)


### PR DESCRIPTION
After completing a fast sync, Geth gets stuck for a few minutes. Turned out that the chain indexer started itself with block 0 as the "previous head" and when it received block 6.5M as the next head, it did an ancestor lookup, which scanned the entire chain backwards.

The ancestor lookup is only necessary if there was a reorg. This PR fixes this corner case by explicitly checking the canonical-ness of the previous head before starting the expensive ancestor lookup.