### PR TITLE
mobile: added constructor for BigInts

### DIFF
--- a/mobile/big.go
+++ b/mobile/big.go
@@ -84,6 +84,13 @@ func (bi *BigInt) SetString(x string, base int) {
 // BigInts represents a slice of big ints.
 type BigInts struct{ bigints []*big.Int }
 
+// NewBigInts creates a slice of uninitialized big numbers.
+func NewBigInts(size int) *BigInts {
+	return &BigInts{
+		bigints: make([]*big.Int, size),
+	}
+}
+
 // Size returns the number of big ints in the slice.
 func (bi *BigInts) Size() int {
 	return len(bi.bigints)


### PR DESCRIPTION
The mobile type BigInts lacked the constructor, that led to inability to create an instance of that type in mobile apps.