### PR TITLE
eth: fixed the minor typo inside the comments

### DIFF
--- a/eth/protocol.go
+++ b/eth/protocol.go
@@ -37,7 +37,7 @@ const (
 // ProtocolName is the official short name of the protocol used during capability negotiation.
 var ProtocolName = "eth"
 
-// ProtocolVersions are the upported versions of the eth protocol (first is primary).
+// ProtocolVersions are the supported versions of the eth protocol (first is primary).
 var ProtocolVersions = []uint{eth63, eth62}
 
 // ProtocolLengths are the number of implemented message corresponding to different protocol versions.


### PR DESCRIPTION
Inside the comments,  the word should be "supported"  instead of "upported"