### PR TITLE
tests: do not exit early on log hash mismatch

### DIFF
--- a/tests/state_test_util.go
+++ b/tests/state_test_util.go
@@ -143,9 +143,6 @@ func (t *StateTest) Run(subtest StateSubtest, vmconfig vm.Config) (*state.StateD
 	if _, _, _, err := core.ApplyMessage(evm, msg, gaspool); err != nil {
 		statedb.RevertToSnapshot(snapshot)
 	}
-	if logs := rlpHash(statedb.Logs()); logs != common.Hash(post.Logs) {
-		return statedb, fmt.Errorf("post state logs hash mismatch: got %x, want %x", logs, post.Logs)
-	}
 	// Commit block
 	statedb.Commit(config.IsEIP158(block.Number()))
 	// Add 0-value mining reward. This only makes a difference in the cases
@@ -160,6 +157,9 @@ func (t *StateTest) Run(subtest StateSubtest, vmconfig vm.Config) (*state.StateD
 	// of suicides, and we need to touch the coinbase _after_ it has potentially suicided.
 	if root != common.Hash(post.Root) {
 		return statedb, fmt.Errorf("post state root mismatch: got %x, want %x", root, post.Root)
+	}
+	if logs := rlpHash(statedb.Logs()); logs != common.Hash(post.Logs) {
+		return statedb, fmt.Errorf("post state logs hash mismatch: got %x, want %x", logs, post.Logs)
 	}
 	return statedb, nil
 }


### PR DESCRIPTION
We had some false positives in the fuzz testing engine, which occurred typically when `LOG` operations were invoked. 
The reason was that the statetest executor bailed early when there was a logs mismatch, and didn't complete the `stateRoot` work (but even so returned the unfinished stateRoot). 
This PR fixes it. 
More context: https://gist.github.com/holiman/3639a708c16963b1f94773b68436c7d1