### PR TITLE
tests: use non-constantinople ropsten for difficulty tests

### DIFF
--- a/tests/difficulty_test.go
+++ b/tests/difficulty_test.go
@@ -17,9 +17,8 @@
 package tests
 
 import (
-	"testing"
-
 	"math/big"
+	"testing"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/params"
@@ -51,7 +50,6 @@ var (
 		ByzantiumBlock:      big.NewInt(1700000),
 		ConstantinopleBlock: nil,
 	}
-
 )
 
 func TestDifficulty(t *testing.T) {

--- a/tests/difficulty_test.go
+++ b/tests/difficulty_test.go
@@ -37,6 +37,21 @@ var (
 		EIP158Block:    big.NewInt(2675000),
 		ByzantiumBlock: big.NewInt(4370000),
 	}
+
+	// Ropsten without the Constantinople bump in bomb delay
+	RopstenNoConstantinople = params.ChainConfig{
+		ChainID:             big.NewInt(3),
+		HomesteadBlock:      big.NewInt(0),
+		DAOForkBlock:        nil,
+		DAOForkSupport:      true,
+		EIP150Block:         big.NewInt(0),
+		EIP150Hash:          common.HexToHash("0x41941023680923e0fe4d74a34bdac8141f2540e3ae90623718e47d66d1ca4a2d"),
+		EIP155Block:         big.NewInt(10),
+		EIP158Block:         big.NewInt(10),
+		ByzantiumBlock:      big.NewInt(1700000),
+		ConstantinopleBlock: nil,
+	}
+
 )
 
 func TestDifficulty(t *testing.T) {
@@ -56,7 +71,7 @@ func TestDifficulty(t *testing.T) {
 	dt.skipLoad("difficultyMorden\\.json")
 	dt.skipLoad("difficultyOlimpic\\.json")
 
-	dt.config("Ropsten", *params.TestnetChainConfig)
+	dt.config("Ropsten", RopstenNoConstantinople)
 	dt.config("Morden", *params.TestnetChainConfig)
 	dt.config("Frontier", params.ChainConfig{})
 


### PR DESCRIPTION
This PR should make travis happy again, by using a non-constantinople-enabled Ropsten configuration for the difficulty tests. This is  a stopgap until new tests have been generated and imported.  