### PR TITLE
core/vm : fix failing testcase

### DIFF
--- a/core/vm/instructions_test.go
+++ b/core/vm/instructions_test.go
@@ -548,7 +548,8 @@ func TestCreate2Addreses(t *testing.T) {
 		origin := common.BytesToAddress(common.FromHex(tt.origin))
 		salt := common.BytesToHash(common.FromHex(tt.salt))
 		code := common.FromHex(tt.code)
-		address := crypto.CreateAddress2(origin, salt, code)
+		codeHash := crypto.Keccak256Hash(code)
+		address := crypto.CreateAddress2(origin, salt, codeHash.Bytes())
 		/*
 			stack          := newstack()
 			// salt, but we don't need that for this test

--- a/core/vm/instructions_test.go
+++ b/core/vm/instructions_test.go
@@ -548,8 +548,8 @@ func TestCreate2Addreses(t *testing.T) {
 		origin := common.BytesToAddress(common.FromHex(tt.origin))
 		salt := common.BytesToHash(common.FromHex(tt.salt))
 		code := common.FromHex(tt.code)
-		codeHash := crypto.Keccak256Hash(code)
-		address := crypto.CreateAddress2(origin, salt, codeHash.Bytes())
+		codeHash := crypto.Keccak256(code)
+		address := crypto.CreateAddress2(origin, salt, codeHash)
 		/*
 			stack          := newstack()
 			// salt, but we don't need that for this test


### PR DESCRIPTION
This fixes the failing testcases on master, using the inithash instead of the code