### PR TITLE
swarm/storage/feed: Expose MaxUpdateDataLength constant

### DIFF
--- a/swarm/storage/feed/update.go
+++ b/swarm/storage/feed/update.go
@@ -42,7 +42,9 @@ type Update struct {
 }
 
 const minimumUpdateDataLength = idLength + headerLength + 1
-const maxUpdateDataLength = chunk.DefaultSize - signatureLength - idLength - headerLength
+
+//MaxUpdateDataLength indicates the maximum payload size for a feed update
+const MaxUpdateDataLength = chunk.DefaultSize - signatureLength - idLength - headerLength
 
 // binaryPut serializes the feed update information into the given slice
 func (r *Update) binaryPut(serializedData []byte) error {
@@ -51,8 +53,8 @@ func (r *Update) binaryPut(serializedData []byte) error {
 		return NewError(ErrInvalidValue, "a feed update must contain data")
 	}
 
-	if datalength > maxUpdateDataLength {
-		return NewErrorf(ErrInvalidValue, "feed update data is too big (length=%d). Max length=%d", datalength, maxUpdateDataLength)
+	if datalength > MaxUpdateDataLength {
+		return NewErrorf(ErrInvalidValue, "feed update data is too big (length=%d). Max length=%d", datalength, MaxUpdateDataLength)
 	}
 
 	if len(serializedData) != r.binaryLength() {

--- a/swarm/storage/feed/update_test.go
+++ b/swarm/storage/feed/update_test.go
@@ -35,7 +35,7 @@ func TestUpdateLengthCheck(t *testing.T) {
 	testBinarySerializerLengthCheck(t, getTestFeedUpdate())
 	// Test fail if update is too big
 	update := getTestFeedUpdate()
-	update.data = make([]byte, maxUpdateDataLength+100)
+	update.data = make([]byte, MaxUpdateDataLength+100)
 	serialized := make([]byte, update.binaryLength())
 	if err := update.binaryPut(serialized); err == nil {
 		t.Fatal("Expected update.binaryPut to fail since update is too big")


### PR DESCRIPTION
This PR exposes the `MaxUpdateDataLength` constant so client code can check if the payload to be sent is too big to fit in an update.