### PR TITLE
trie: remove some leftover dead code

### DIFF
--- a/trie/trie.go
+++ b/trie/trie.go
@@ -65,9 +65,8 @@ type LeafCallback func(leaf []byte, parent common.Hash) error
 //
 // Trie is not safe for concurrent use.
 type Trie struct {
-	db           *Database
-	root         node
-	originalRoot common.Hash
+	db   *Database
+	root node
 
 	// Cache generation values.
 	// cachegen increases by one with each commit operation.
@@ -98,8 +97,7 @@ func New(root common.Hash, db *Database) (*Trie, error) {
 		panic("trie.New called without a database")
 	}
 	trie := &Trie{
-		db:           db,
-		originalRoot: root,
+		db: db,
 	}
 	if root != (common.Hash{}) && root != emptyRoot {
 		rootnode, err := trie.resolveHash(root[:], nil)


### PR DESCRIPTION
There's an extra field in the trie that's not used for anything. Possibly either some leftover or maybe some not-yet-implemented pruning thing? Either way, get rid of it for now.