### PR TITLE
les, light: reduce les testing stress

### DIFF
--- a/les/distributor_test.go
+++ b/les/distributor_test.go
@@ -87,7 +87,7 @@ const (
 	testDistBufLimit       = 10000000
 	testDistMaxCost        = 1000000
 	testDistPeerCount      = 5
-	testDistReqCount       = 50000
+	testDistReqCount       = 5000
 	testDistMaxResendCount = 3
 )
 

--- a/light/postprocess.go
+++ b/light/postprocess.go
@@ -84,23 +84,23 @@ var (
 	}
 	// TestServerIndexerConfig wraps a set of configs as a test indexer config for server side.
 	TestServerIndexerConfig = &IndexerConfig{
-		ChtSize:           256,
-		PairChtSize:       2048,
-		ChtConfirms:       16,
-		BloomSize:         256,
-		BloomConfirms:     16,
-		BloomTrieSize:     2048,
-		BloomTrieConfirms: 16,
+		ChtSize:           64,
+		PairChtSize:       512,
+		ChtConfirms:       4,
+		BloomSize:         64,
+		BloomConfirms:     4,
+		BloomTrieSize:     512,
+		BloomTrieConfirms: 4,
 	}
 	// TestClientIndexerConfig wraps a set of configs as a test indexer config for client side.
 	TestClientIndexerConfig = &IndexerConfig{
-		ChtSize:           2048,
-		PairChtSize:       256,
-		ChtConfirms:       128,
-		BloomSize:         2048,
-		BloomConfirms:     128,
-		BloomTrieSize:     2048,
-		BloomTrieConfirms: 128,
+		ChtSize:           512,
+		PairChtSize:       64,
+		ChtConfirms:       32,
+		BloomSize:         512,
+		BloomConfirms:     32,
+		BloomTrieSize:     512,
+		BloomTrieConfirms: 32,
 	}
 )
 


### PR DESCRIPTION
Speed up les part unit tests, refer #17854

Reduce unit tests from 
```
ok  	github.com/ethereum/go-ethereum/les	20.230s
```
to 
```
ok  	github.com/ethereum/go-ethereum/les	11.531s
```