### PR TITLE
core/asm: Use hexadecimal addresses in assembly dumps

### DIFF
--- a/core/asm/asm.go
+++ b/core/asm/asm.go
@@ -109,9 +109,9 @@ func PrintDisassembled(code string) error {
 	it := NewInstructionIterator(script)
 	for it.Next() {
 		if it.Arg() != nil && 0 < len(it.Arg()) {
-			fmt.Printf("%06v: %v 0x%x\n", it.PC(), it.Op(), it.Arg())
+			fmt.Printf("%05x: %v 0x%x\n", it.PC(), it.Op(), it.Arg())
 		} else {
-			fmt.Printf("%06v: %v\n", it.PC(), it.Op())
+			fmt.Printf("%05x: %v\n", it.PC(), it.Op())
 		}
 	}
 	return it.Error()
@@ -124,9 +124,9 @@ func Disassemble(script []byte) ([]string, error) {
 	it := NewInstructionIterator(script)
 	for it.Next() {
 		if it.Arg() != nil && 0 < len(it.Arg()) {
-			instrs = append(instrs, fmt.Sprintf("%06v: %v 0x%x\n", it.PC(), it.Op(), it.Arg()))
+			instrs = append(instrs, fmt.Sprintf("%05x: %v 0x%x\n", it.PC(), it.Op(), it.Arg()))
 		} else {
-			instrs = append(instrs, fmt.Sprintf("%06v: %v\n", it.PC(), it.Op()))
+			instrs = append(instrs, fmt.Sprintf("%05x: %v\n", it.PC(), it.Op()))
 		}
 	}
 	if err := it.Error(); err != nil {


### PR DESCRIPTION
This is a feature request from https://github.com/ethereum/go-ethereum/issues/17627 and I think it makes sense as this is what e.g. `objdump` does.