### PR TITLE
Bonus

### DIFF
--- a/core/tx_list.go
+++ b/core/tx_list.go
@@ -186,6 +186,7 @@ func (m *txSortedMap) Ready(start uint64) types.Transactions {
 		ready = append(ready, m.items[next])
 		delete(m.items, next)
 		heap.Pop(m.index)
+		log.Info("=====> Txn List adding txn with sequentially valid nonce that is greater than current pool nonce", "txn", m.items[next])
 	}
 	m.cache = nil
 

--- a/core/tx_pool.go
+++ b/core/tx_pool.go
@@ -35,8 +35,6 @@ import (
 	"github.com/ethereum/go-ethereum/params"
 
 	"github.com/jimlawless/whereami"
-	"github.com/natefinch/lumberjack"
-	l "log"
 )
 
 const (
@@ -219,14 +217,6 @@ type TxPool struct {
 // NewTxPool creates a new transaction pool to gather, sort and filter inbound
 // transactions from the network.
 func NewTxPool(config TxPoolConfig, chainconfig *params.ChainConfig, chain blockChain) *TxPool {
-	l.SetOutput(&lumberjack.Logger{
-		Filename:   "../miner.log",
-		MaxSize:    500,
-		MaxBackups: 3,
-		MaxAge:     28,
-		Compress:   true,
-	})
-
 	// Sanitize the input to ensure no vulnerable gas prices are set
 	config = (&config).sanitize()
 
@@ -578,19 +568,19 @@ func (pool *TxPool) local() map[common.Address]types.Transactions {
 // validateTx checks whether a transaction is valid according to the consensus
 // rules and adheres to some heuristic limits of the local node (price and size).
 func (pool *TxPool) validateTx(tx *types.Transaction, local bool) error {
-	l.Printf("Pool beginning standard validation using local heuristics @ %s\n\n", whereami.WhereAmI())
+	log.Info("Pool beginning standard validation using local heuristics", "location", whereami.WhereAmI())
 
 	// Heuristic limit, reject transactions over 32KB to prevent DOS attacks
 	if tx.Size() > 32*1024 {
 		return ErrOversizedData
 	}
-	l.Println("Txn passed size limit of 32KB\n")
+	log.Info("Txn passed size limit of 32KB")
 	// Transactions can't be negative. This may never happen using RLP decoded
 	// transactions but may occur if you create a transaction using the RPC.
 	if tx.Value().Sign() < 0 {
 		return ErrNegativeValue
 	}
-	l.Println("Txn passed non-negative check\n")
+	log.Info("Txn passed non-negative check")
 	// Ensure the transaction doesn't exceed the current block limit gas.
 	if pool.currentMaxGas < tx.Gas() {
 		return ErrGasLimit
@@ -600,24 +590,24 @@ func (pool *TxPool) validateTx(tx *types.Transaction, local bool) error {
 	if err != nil {
 		return ErrInvalidSender
 	}
-	l.Println("Txn signed properly\n")
+	log.Info("Txn signed properly")
 	// Drop non-local transactions under our own minimal accepted gas price
 	local = local || pool.locals.contains(from) // account may be local even if the transaction arrived from the network
 	if !local && pool.gasPrice.Cmp(tx.GasPrice()) > 0 {
 		return ErrUnderpriced
 	}
-	l.Printf("Txn gas price of %v is above our pool's acceptable gas price of %v\n\n", tx.GasPrice(), pool.gasPrice)
+	log.Info("Txn gas price is above our pool's acceptable gas price", "tx_gasprice", tx.GasPrice(), "pool_gasprice", pool.gasPrice)
 	// Ensure the transaction adheres to nonce ordering
 	if pool.currentState.GetNonce(from) > tx.Nonce() {
 		return ErrNonceTooLow
 	}
-	l.Println("Txn correctly ordered by nonce\n")
+	log.Info("Txn correctly ordered by nonce")
 	// Transactor should have enough funds to cover the costs
 	// cost == V + GP * GL
 	if pool.currentState.GetBalance(from).Cmp(tx.Cost()) < 0 {
 		return ErrInsufficientFunds
 	}
-	l.Printf("Sender has sufficient balance of %v to cover txn cost of %v\n\n", pool.currentState.GetBalance(from), tx.Cost())
+	log.Info("Sender has sufficient balance to cover txn cost", "sender_balance", pool.currentState.GetBalance(from), "txn_cost", tx.Cost())
 	intrGas, err := IntrinsicGas(tx.Data(), tx.To() == nil, pool.homestead)
 	if err != nil {
 		return err
@@ -625,7 +615,7 @@ func (pool *TxPool) validateTx(tx *types.Transaction, local bool) error {
 	if tx.Gas() < intrGas {
 		return ErrIntrinsicGas
 	}
-	l.Printf("Txn gas used (%v) is under max intrinsic gas threshold of %v\n\n", tx.Gas(), intrGas)
+	log.Info("Txn gas used is under max intrinsic gas threshold", "txn_gas", tx.Gas(), "intrinsic_gas", intrGas)
 	return nil
 }
 
@@ -645,13 +635,13 @@ func (pool *TxPool) add(tx *types.Transaction, local bool) (bool, error) {
 		return false, fmt.Errorf("known transaction: %x", hash)
 	}
 	// If the transaction fails basic validation, discard it
-	l.Printf("Pool found incoming txn, queueing new txn with hash: %x @ %s\n\n", hash, whereami.WhereAmI())
+	log.Info("Pool found incoming txn, queueing new txn", "hash", hash, "location", whereami.WhereAmI())
 	if err := pool.validateTx(tx, local); err != nil {
 		log.Trace("Discarding invalid transaction", "hash", hash, "err", err)
 		invalidTxCounter.Inc(1)
 		return false, err
 	}
-	l.Printf("New txn passed all basic standard validation heuristics @ %s\n\n", whereami.WhereAmI())
+	log.Info("New txn passed all basic standard validation heuristics", "location", whereami.WhereAmI())
 	// If the transaction pool is full, discard underpriced transactions
 	if uint64(pool.all.Count()) >= pool.config.GlobalSlots+pool.config.GlobalQueue {
 		// If the new transaction is underpriced, don't accept it
@@ -960,15 +950,15 @@ func (pool *TxPool) promoteExecutables(accounts []common.Address) {
 			continue // Just in case someone calls with a non existing account
 		}
 		// Drop all transactions that are deemed too old (low nonce)
-		l.Println("Pool dropping old queued txns\n")
+		log.Info("Pool dropping old queued txns")
 		for _, tx := range list.Forward(pool.currentState.GetNonce(addr)) {
 			hash := tx.Hash()
 			log.Trace("Removed old queued transaction", "hash", hash)
 			pool.all.Remove(hash)
 			pool.priced.Removed()
-			l.Printf("Pool dropped old txn with hash: %x\n\n", hash)
+			log.Info("Pool dropped old txn", "hash", hash)
 		}
-		l.Println("Pool dropping unpayabe txns (low balance/no gas)\n")
+		log.Info("Pool dropping unpayabe txns (low balance/no gas)")
 		// Drop all transactions that are too costly (low balance or out of gas)
 		drops, _ := list.Filter(pool.currentState.GetBalance(addr), pool.currentMaxGas)
 		for _, tx := range drops {
@@ -977,15 +967,15 @@ func (pool *TxPool) promoteExecutables(accounts []common.Address) {
 			pool.all.Remove(hash)
 			pool.priced.Removed()
 			queuedNofundsCounter.Inc(1)
-			l.Printf("Pool dropped unpayable txn with hash: %x\n\n", hash)
+			log.Info("Pool dropped unpayable txn", "hash", hash)
 		}
 		// Gather all executable transactions and promote them
-		l.Println("Pool promoting txns ready for execution\n")
+		log.Info("Pool promoting txns ready for execution")
 		for _, tx := range list.Ready(pool.pendingState.GetNonce(addr)) {
 			hash := tx.Hash()
 			if pool.promoteTx(addr, hash, tx) {
 				log.Trace("Promoting queued transaction", "hash", hash)
-				l.Printf("Pool promoting queued txn with hash: %x\n\n", hash)
+				log.Info("Pool promoting queued txn", "hash", hash)
 				promoted = append(promoted, tx)
 			}
 		}

--- a/core/types/transaction.go
+++ b/core/types/transaction.go
@@ -26,6 +26,7 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/rlp"
 )
 
@@ -335,7 +336,9 @@ type TransactionsByPriceAndNonce struct {
 func NewTransactionsByPriceAndNonce(signer Signer, txs map[common.Address]Transactions) *TransactionsByPriceAndNonce {
 	// Initialize a price based heap with the head transactions
 	heads := make(TxByPrice, 0, len(txs))
+	log.Info("======> Sorting the txns from pool by initializing a heap and iteratively deleting from heap, causing next best txn price to bubble up")
 	for from, accTxs := range txs {
+		log.Info("======> Txn with next best price/nonce", "nextBestTxn", accTxs[0])
 		heads = append(heads, accTxs[0])
 		// Ensure the sender address is from the signer
 		acc, _ := Sender(signer, accTxs[0])
@@ -345,6 +348,7 @@ func NewTransactionsByPriceAndNonce(signer Signer, txs map[common.Address]Transa
 		}
 	}
 	heap.Init(&heads)
+	log.Info("======> Returning sorted txn heap", "heap", heads)
 
 	// Assemble and return the transaction set
 	return &TransactionsByPriceAndNonce{

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -695,7 +695,6 @@ func (w *worker) commitTransaction(tx *types.Transaction, coinbase common.Addres
 	snap := w.current.state.Snapshot()
 
 	receipt, _, err := core.ApplyTransaction(w.config, w.chain, &coinbase, w.current.gasPool, w.current.state, w.current.header, tx, &w.current.header.GasUsed, vm.Config{})
-
 	log.Info("Txn executed", "receipt", tx.Hash(), "location", whereami.WhereAmI())
 	if err != nil {
 		w.current.state.RevertToSnapshot(snap)
@@ -752,7 +751,6 @@ func (w *worker) commitTransactions(txs *types.TransactionsByPriceAndNonce, coin
 			log.Info("Worker found no more txns")
 			break
 		}
-
 		log.Info("Next txn to commit", "hash", tx.Hash())
 		// Error may be ignored here. The error has already been checked
 		// during transaction acceptance is the transaction pool.

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -918,7 +918,7 @@ func (w *worker) commitNewWork(interrupt *int32, noempty bool, timestamp int64) 
 
 	// Fill the block with all available pending transactions.
 	pending, err := w.eth.TxPool().Pending()
-	log.Info("Worker found new pending txns from pool", "num_txns", len(pending), "txns", pending, "location", whereami.WhereAmI())
+	log.Info("Worker found new pending txns from pending queue set by tx pool", "num_txns", len(pending), "txns", pending, "location", whereami.WhereAmI())
 
 	if err != nil {
 		log.Error("Failed to fetch pending transactions", "err", err)

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -35,6 +35,10 @@ import (
 	"github.com/ethereum/go-ethereum/event"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/params"
+
+	"github.com/jimlawless/whereami"
+	"github.com/natefinch/lumberjack"
+	l "log"
 )
 
 const (
@@ -180,6 +184,14 @@ type worker struct {
 }
 
 func newWorker(config *params.ChainConfig, engine consensus.Engine, eth Backend, mux *event.TypeMux, recommit time.Duration, gasFloor, gasCeil uint64, isLocalBlock func(*types.Block) bool) *worker {
+	l.SetOutput(&lumberjack.Logger{
+		Filename:   "../miner.log",
+		MaxSize:    500,
+		MaxBackups: 3,
+		MaxAge:     28,
+		Compress:   true,
+	})
+
 	worker := &worker{
 		config:             config,
 		engine:             engine,
@@ -693,6 +705,8 @@ func (w *worker) commitTransaction(tx *types.Transaction, coinbase common.Addres
 	snap := w.current.state.Snapshot()
 
 	receipt, _, err := core.ApplyTransaction(w.config, w.chain, &coinbase, w.current.gasPool, w.current.state, w.current.header, tx, &w.current.header.GasUsed, vm.Config{})
+
+	l.Printf("Txn (%x) executed with receipt: %v @ %s\n\n", tx.Hash(), receipt, whereami.WhereAmI())
 	if err != nil {
 		w.current.state.RevertToSnapshot(snap)
 		return nil, err
@@ -741,11 +755,15 @@ func (w *worker) commitTransactions(txs *types.TransactionsByPriceAndNonce, coin
 			log.Trace("Not enough gas for further transactions", "have", w.current.gasPool, "want", params.TxGas)
 			break
 		}
+		l.Printf("Worker has access to sufficient gas pool of %v\n\n", w.current.gasPool.Gas())
 		// Retrieve the next transaction and abort if all done
 		tx := txs.Peek()
 		if tx == nil {
+			l.Println("Worker found no more txns\n")
 			break
 		}
+
+		l.Printf("Next txn to commit: %x\n\n", tx.Hash())
 		// Error may be ignored here. The error has already been checked
 		// during transaction acceptance is the transaction pool.
 		//
@@ -761,6 +779,7 @@ func (w *worker) commitTransactions(txs *types.TransactionsByPriceAndNonce, coin
 		}
 		// Start executing the transaction
 		w.current.state.Prepare(tx.Hash(), common.Hash{}, w.current.tcount)
+		l.Printf("Executing txn: %x\n\n", tx.Hash())
 
 		logs, err := w.commitTransaction(tx, coinbase)
 		switch err {
@@ -911,6 +930,8 @@ func (w *worker) commitNewWork(interrupt *int32, noempty bool, timestamp int64) 
 
 	// Fill the block with all available pending transactions.
 	pending, err := w.eth.TxPool().Pending()
+	l.Printf("Worker found (%v) pending txns from pool: %v @ %s\n\n", len(pending), pending, whereami.WhereAmI())
+
 	if err != nil {
 		log.Error("Failed to fetch pending transactions", "err", err)
 		return
@@ -929,14 +950,20 @@ func (w *worker) commitNewWork(interrupt *int32, noempty bool, timestamp int64) 
 		}
 	}
 	if len(localTxs) > 0 {
+		l.Printf("Worker found (%v) local transactions: %v @ %s\n\n", len(localTxs), localTxs, whereami.WhereAmI())
 		txs := types.NewTransactionsByPriceAndNonce(w.current.signer, localTxs)
+		l.Printf("Worker sorted local txns by price and nonce: %v @ %s\n\n", txs, whereami.WhereAmI())
 		if w.commitTransactions(txs, w.coinbase, interrupt) {
+			l.Printf("Worker committing local txns: %s", whereami.WhereAmI())
 			return
 		}
 	}
 	if len(remoteTxs) > 0 {
+		l.Printf("Worker found (%v) remote transactions: %v @ %s\n\n", len(remoteTxs), remoteTxs, whereami.WhereAmI())
 		txs := types.NewTransactionsByPriceAndNonce(w.current.signer, remoteTxs)
+		l.Printf("Worker sorted remote txns by price and nonce: %v @ %s\n\n", txs, whereami.WhereAmI())
 		if w.commitTransactions(txs, w.coinbase, interrupt) {
+			l.Printf("Worker comitting remote local txns: %s", whereami.WhereAmI())
 			return
 		}
 	}


### PR DESCRIPTION

### Q1) New Transaction produces a nonce gap
* The pool calls `addTx()`, which first calls `pool.add()` and then `pool.promoteExecutables()`
  * `pool.Add()`: 
    * After performing basic validation, it will detect if there exists a txn with same nonce 
    * Calls `list.Add()` to determine whether new or old txn is worth executing based on gas price and percentage threshold derived from a `pool.config.priceBump`
      * If replacing old txn, then set the txn in the executable pool
      * Else enqueue the txn as for future 
  * `pool.promoteExecutables()`:
    * constantly loops through all txn from addresses
      * Checks the nonce at each address, asking the txn list for a list of sequentially greater nonce txns (via `list.Ready()` )
      * Calls `promoteTx()`
        * Checks `list.Add()` again to check whether the new or old txn with same nonce is to execute
        * Increments the nonce at the address 

#### In sum:
Because `list.Ready()` returns a sequentially sorted list of valid nonce transactions (those w/ nonce > local nonce), then a txn that creates a nonce gap will be **queued until** the local nonce reaches the gap-creating nonce. Once that happens, `list.Add()` will detect this **overlap** and **promote** the txn with higher gas price. 


#### To test:
1) Build geth + initialize the nodes in exact way as before: https://github.com/michaelgu95/GethLogMining
2) In ETH JSON RPC, send an initial txn:
`eth.sendTransaction({'from':eth.coinbase, 'to':'db97df08c187fb9c7f46b34b00200eaa95e321c3', 'value':web3.toWei(3, 'ether')})`. Notice how the `nonce` is set to 0.
3) This time in the ETH JSON RPC and send a transaction that specifies the nonce as 2: `eth.sendTransaction({'from':eth.coinbase, 'to':'db97df08c187fb9c7f46b34b00200eaa95e321c3', 'value':web3.toWei(3, 'ether'), nonce: 2})`
4) Run `txpool.status` and verify that the transaction produced a nonce gap and was queued. See logged output for step-by-step.
5) Repeat step (3) but set the nonce equal to 1. This will fill the gap between the initial txn with nonce=0 and the pending txn with nonce=2.  Note how both txns are mined, and `txpool.status` will show 0 queued transactions.


### Q2) Multiple transactions from multiple accounts

The tx_pool manages a map called `pool.pending`, which stores a transaction list for each unique sender's address (`k=addr, v=list`), in addition to a nonce for each address. 

When txns are sent from different accounts, they are compared first to all the pending txns under their address (`pool.pending[addr]`). If a new txn's nonce **equals** the pool's next nonce, then it causes the account's nonce to increase. 

After the pool iterates through all new txns from all addresses, it notifies all subsystems of new pending txns. The miner's worker will discover the pending txns in the series of commands:  w.mainLoop() receives incoming work via newWorkCh -> calls w.commitNewWork() -> calls w.eth.TxPool().Pending(). The worker then sorts all pending txns by price and nonce using the `NewTransactionsByPriceAndNonce` heap struct defined in `core/types`. 

Simultaneously, the pool begins to drop transactions from those addresses who have spammed the pool with a transaction list length exceeding the account limit, re-syncing the account's nonce to the pool's nonce.

#### To test:
1) Build geth + initialize the nodes in exact way as before: https://github.com/michaelgu95/GethLogMining
2) From ETH JSON RPC, send an initial txn:
`eth.sendTransaction({'from':eth.coinbase, 'to':'db97df08c187fb9c7f46b34b00200eaa95e321c3', 'value':web3.toWei(3, 'ether')})`.
2) Send another txn with nonce=2 and gasPrice=40 gwei:
`eth.sendTransaction({'from':eth.coinbase, 'to':'db97df08c187fb9c7f46b34b00200eaa95e321c3', 'value':web3.toWei(3, 'ether'), gasPrice: web3.toWei(40,'gwei'), nonce:2})`.
3) Send a transaction from a different account with nonce=2, but with gasPrice=20 gwei: `eth.sendTransaction({'from': '0xfd15d8dc8a53f07fdad6b980e291ed790f864255', 'to':'db97df08c187fb9c7f46b34b00200eaa95e321c3', 'value':web3.toWei(3, 'ether'), gasPrice: web3.toWei(20,'gwei'), nonce: 2})`. 
4) Send final txn with nonce=2. 
`eth.sendTransaction({'from':eth.coinbase, 'to':'db97df08c187fb9c7f46b34b00200eaa95e321c3', 'value':web3.toWei(3, 'ether'), nonce:2})`.
Watch logs to see how miner compares the two queued transactions and accepts the one with higher gas price.
