### PR TITLE
cmd/swarm: speed up tests

### DIFF
--- a/cmd/swarm/manifest_test.go
+++ b/cmd/swarm/manifest_test.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/ethereum/go-ethereum/swarm/api"
 	swarm "github.com/ethereum/go-ethereum/swarm/api/client"
+	"github.com/ethereum/go-ethereum/swarm/testutil"
 )
 
 // TestManifestChange tests manifest add, update and remove
@@ -57,8 +58,8 @@ func TestManifestChangeEncrypted(t *testing.T) {
 // Argument encrypt controls whether to use encryption or not.
 func testManifestChange(t *testing.T, encrypt bool) {
 	t.Parallel()
-	cluster := newTestCluster(t, 1)
-	defer cluster.Shutdown()
+	srv := testutil.NewTestSwarmServer(t, serverFunc, nil)
+	defer srv.Close()
 
 	tmp, err := ioutil.TempDir("", "swarm-manifest-test")
 	if err != nil {
@@ -94,7 +95,7 @@ func testManifestChange(t *testing.T, encrypt bool) {
 
 	args := []string{
 		"--bzzapi",
-		cluster.Nodes[0].URL,
+		srv.URL,
 		"--recursive",
 		"--defaultpath",
 		indexDataFilename,
@@ -109,7 +110,7 @@ func testManifestChange(t *testing.T, encrypt bool) {
 
 	checkHashLength(t, origManifestHash, encrypt)
 
-	client := swarm.NewClient(cluster.Nodes[0].URL)
+	client := swarm.NewClient(srv.URL)
 
 	// upload a new file and use its manifest to add it the original manifest.
 	t.Run("add", func(t *testing.T) {
@@ -122,14 +123,14 @@ func testManifestChange(t *testing.T, encrypt bool) {
 
 		humansManifestHash := runSwarmExpectHash(t,
 			"--bzzapi",
-			cluster.Nodes[0].URL,
+			srv.URL,
 			"up",
 			humansDataFilename,
 		)
 
 		newManifestHash := runSwarmExpectHash(t,
 			"--bzzapi",
-			cluster.Nodes[0].URL,
+			srv.URL,
 			"manifest",
 			"add",
 			origManifestHash,
@@ -177,14 +178,14 @@ func testManifestChange(t *testing.T, encrypt bool) {
 
 		robotsManifestHash := runSwarmExpectHash(t,
 			"--bzzapi",
-			cluster.Nodes[0].URL,
+			srv.URL,
 			"up",
 			robotsDataFilename,
 		)
 
 		newManifestHash := runSwarmExpectHash(t,
 			"--bzzapi",
-			cluster.Nodes[0].URL,
+			srv.URL,
 			"manifest",
 			"add",
 			origManifestHash,
@@ -237,14 +238,14 @@ func testManifestChange(t *testing.T, encrypt bool) {
 
 		indexManifestHash := runSwarmExpectHash(t,
 			"--bzzapi",
-			cluster.Nodes[0].URL,
+			srv.URL,
 			"up",
 			indexDataFilename,
 		)
 
 		newManifestHash := runSwarmExpectHash(t,
 			"--bzzapi",
-			cluster.Nodes[0].URL,
+			srv.URL,
 			"manifest",
 			"update",
 			origManifestHash,
@@ -295,14 +296,14 @@ func testManifestChange(t *testing.T, encrypt bool) {
 
 		humansManifestHash := runSwarmExpectHash(t,
 			"--bzzapi",
-			cluster.Nodes[0].URL,
+			srv.URL,
 			"up",
 			robotsDataFilename,
 		)
 
 		newManifestHash := runSwarmExpectHash(t,
 			"--bzzapi",
-			cluster.Nodes[0].URL,
+			srv.URL,
 			"manifest",
 			"update",
 			origManifestHash,
@@ -348,7 +349,7 @@ func testManifestChange(t *testing.T, encrypt bool) {
 	t.Run("remove", func(t *testing.T) {
 		newManifestHash := runSwarmExpectHash(t,
 			"--bzzapi",
-			cluster.Nodes[0].URL,
+			srv.URL,
 			"manifest",
 			"remove",
 			origManifestHash,
@@ -376,7 +377,7 @@ func testManifestChange(t *testing.T, encrypt bool) {
 	t.Run("remove nested", func(t *testing.T) {
 		newManifestHash := runSwarmExpectHash(t,
 			"--bzzapi",
-			cluster.Nodes[0].URL,
+			srv.URL,
 			"manifest",
 			"remove",
 			origManifestHash,
@@ -429,8 +430,8 @@ func TestNestedDefaultEntryUpdateEncrypted(t *testing.T) {
 
 func testNestedDefaultEntryUpdate(t *testing.T, encrypt bool) {
 	t.Parallel()
-	cluster := newTestCluster(t, 1)
-	defer cluster.Shutdown()
+	srv := testutil.NewTestSwarmServer(t, serverFunc, nil)
+	defer srv.Close()
 
 	tmp, err := ioutil.TempDir("", "swarm-manifest-test")
 	if err != nil {
@@ -458,7 +459,7 @@ func testNestedDefaultEntryUpdate(t *testing.T, encrypt bool) {
 
 	args := []string{
 		"--bzzapi",
-		cluster.Nodes[0].URL,
+		srv.URL,
 		"--recursive",
 		"--defaultpath",
 		indexDataFilename,
@@ -473,7 +474,7 @@ func testNestedDefaultEntryUpdate(t *testing.T, encrypt bool) {
 
 	checkHashLength(t, origManifestHash, encrypt)
 
-	client := swarm.NewClient(cluster.Nodes[0].URL)
+	client := swarm.NewClient(srv.URL)
 
 	newIndexData := []byte("<h1>Ethereum Swarm</h1>")
 	newIndexDataFilename := filepath.Join(tmp, "index.html")
@@ -484,14 +485,14 @@ func testNestedDefaultEntryUpdate(t *testing.T, encrypt bool) {
 
 	newIndexManifestHash := runSwarmExpectHash(t,
 		"--bzzapi",
-		cluster.Nodes[0].URL,
+		srv.URL,
 		"up",
 		newIndexDataFilename,
 	)
 
 	newManifestHash := runSwarmExpectHash(t,
 		"--bzzapi",
-		cluster.Nodes[0].URL,
+		srv.URL,
 		"manifest",
 		"update",
 		origManifestHash,

--- a/cmd/swarm/run_test.go
+++ b/cmd/swarm/run_test.go
@@ -40,6 +40,9 @@ import (
 	"github.com/ethereum/go-ethereum/p2p"
 	"github.com/ethereum/go-ethereum/rpc"
 	"github.com/ethereum/go-ethereum/swarm"
+	"github.com/ethereum/go-ethereum/swarm/api"
+	swarmhttp "github.com/ethereum/go-ethereum/swarm/api/http"
+	"github.com/ethereum/go-ethereum/swarm/testutil"
 )
 
 var loglevel = flag.Int("loglevel", 3, "verbosity of logs")
@@ -55,6 +58,9 @@ func init() {
 	})
 }
 
+func serverFunc(api *api.API) testutil.TestServer {
+	return swarmhttp.NewServer(api, "")
+}
 func TestMain(m *testing.M) {
 	// check if we have been reexec'd
 	if reexec.Init() {

--- a/cmd/swarm/upload_test.go
+++ b/cmd/swarm/upload_test.go
@@ -32,6 +32,7 @@ import (
 
 	"github.com/ethereum/go-ethereum/log"
 	swarm "github.com/ethereum/go-ethereum/swarm/api/client"
+	"github.com/ethereum/go-ethereum/swarm/testutil"
 	"github.com/mattn/go-colorable"
 )
 
@@ -298,8 +299,8 @@ func TestCLISwarmUpDefaultPath(t *testing.T) {
 }
 
 func testCLISwarmUpDefaultPath(toEncrypt bool, absDefaultPath bool, t *testing.T) {
-	cluster := newTestCluster(t, 1)
-	defer cluster.Shutdown()
+	srv := testutil.NewTestSwarmServer(t, serverFunc, nil)
+	defer srv.Close()
 
 	tmp, err := ioutil.TempDir("", "swarm-defaultpath-test")
 	if err != nil {
@@ -323,7 +324,7 @@ func testCLISwarmUpDefaultPath(toEncrypt bool, absDefaultPath bool, t *testing.T
 
 	args := []string{
 		"--bzzapi",
-		cluster.Nodes[0].URL,
+		srv.URL,
 		"--recursive",
 		"--defaultpath",
 		defaultPath,
@@ -340,7 +341,7 @@ func testCLISwarmUpDefaultPath(toEncrypt bool, absDefaultPath bool, t *testing.T
 	up.ExpectExit()
 	hash := matches[0]
 
-	client := swarm.NewClient(cluster.Nodes[0].URL)
+	client := swarm.NewClient(srv.URL)
 
 	m, isEncrypted, err := client.DownloadManifest(hash)
 	if err != nil {


### PR DESCRIPTION
this PR addresses ongoing efforts to speed up travis in continuation to @fjl's PR https://github.com/ethereum/go-ethereum/pull/17854
we will continue to work on this in order to improve test run performance.

these minor changes already shaved off around 30s:
`github.com/ethereum/go-ethereum/cmd/swarm	163.721s`