### PR TITLE
swarm: handleDirectUpload remove ModTime

### DIFF
--- a/swarm/api/http/server.go
+++ b/swarm/api/http/server.go
@@ -427,8 +427,7 @@ func (s *Server) handleDirectUpload(r *http.Request, mw *api.ManifestWriter) err
 		Path:        GetURI(r.Context()).Path,
 		ContentType: r.Header.Get("Content-Type"),
 		Mode:        0644,
-		Size:        r.ContentLength,
-		ModTime:     time.Now(),
+		Size:        r.ContentLength
 	})
 	if err != nil {
 		return err


### PR DESCRIPTION
Delete ModTime field in manifest when using direct file upload so that the same upload always results in the same manifest, not only the same hash inside the manifest.


$ curl -s http://localhost:8500/bzz-raw:/1deaf48d4f9858473afedd4916a63c84b753029                                                 9c6fd6107bf9cc59aff7e293c
`{"entries": [{"hash":"b45cc5ddaaa6c22c403b763ddb3f901ede412c7cfc8ca5c4b0dd12b398b                                                 6f7e3","contentType":"application/pdf","mode":420,"size":184292,"mod_time":"2018                                                 -10-09T14:13:11.0730891+02:00"}]}`


$ curl -s http://localhost:8500/bzz-raw:/971cdf9729571f5d6761fbe007f0e5bf4bafed658c55ecdb6706ed35e1e4c479
`{"entries":[{"hash":"b45cc5ddaaa6c22c403b763ddb3f901ede412c7cfc8ca5c4b0dd12b398b6f7e3","contentType":"application/pdf","mode":420,"size":184292,"mod_time":"2018-10-09T14:27:57.0220772+02:00"}]}`
