### PR TITLE
Clique signing in Clef

### DIFF
--- a/cmd/clef/extapi_changelog.md
+++ b/cmd/clef/extapi_changelog.md
@@ -1,5 +1,12 @@
 ### Changelog for external API
 
+### 5.0.0
+
+* The external method `accounts_Sign(address, data)` was replaced with `accounts_signData(contentType, address, data)`.
+The addition of `contentType` makes it possible to use the method for different types of objects, such as
+  * signing clique headers,
+  * signing [ERC-712](https://eips.ethereum.org/EIPS/eip-712) typed data structures (not yet implemented)
+
 #### 4.0.0
 
 * The external `account_Ecrecover`-method was removed. 

--- a/cmd/clef/main.go
+++ b/cmd/clef/main.go
@@ -39,14 +39,17 @@ import (
 	"github.com/ethereum/go-ethereum/cmd/utils"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/console"
+	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/node"
+	"github.com/ethereum/go-ethereum/rlp"
 	"github.com/ethereum/go-ethereum/rpc"
 	"github.com/ethereum/go-ethereum/signer/core"
 	"github.com/ethereum/go-ethereum/signer/rules"
 	"github.com/ethereum/go-ethereum/signer/storage"
 	"gopkg.in/urfave/cli.v1"
+	"math/big"
 )
 
 // ExternalAPIVersion -- see extapi_changelog.md
@@ -631,10 +634,38 @@ func testExternalUI(api *core.SignerAPI) {
 	}
 	var err error
 
+	cliqueHeader := types.Header{
+		common.HexToHash("0000H45H"),
+		common.HexToHash("0000H45H"),
+		common.HexToAddress("0000H45H"),
+		common.HexToHash("0000H00H"),
+		common.HexToHash("0000H45H"),
+		common.HexToHash("0000H45H"),
+		types.Bloom{},
+		big.NewInt(1337),
+		big.NewInt(1337),
+		1338,
+		1338,
+		big.NewInt(1338),
+		[]byte("Extra data Extra data Extra data  Extra data  Extra data  Extra data  Extra data Extra data"),
+		common.HexToHash("0x0000H45H"),
+		types.BlockNonce{},
+	}
+	cliqueRlp, err := rlp.EncodeToBytes(cliqueHeader)
+	if err != nil {
+		utils.Fatalf("Should not error: %v", err)
+	}
+	addr, err:= common.NewMixedcaseAddressFromString("0x0011223344556677889900112233445566778899")
+	if err != nil {
+		utils.Fatalf("Should not error: %v", err)
+	}
+	_, err = api.SignData(ctx, "application/clique", *addr, cliqueRlp)
+	checkErr("SignData", err)
+
 	_, err = api.SignTransaction(ctx, core.SendTxArgs{From: common.MixedcaseAddress{}}, nil)
 	checkErr("SignTransaction", err)
-	_, err = api.Sign(ctx, common.MixedcaseAddress{}, common.Hex2Bytes("01020304"))
-	checkErr("Sign", err)
+	//_, err = api.Sign(ctx, common.MixedcaseAddress{}, common.Hex2Bytes("01020304"))
+	//checkErr("Sign", err)
 	_, err = api.List(ctx)
 	checkErr("List", err)
 	_, err = api.New(ctx)

--- a/signer/core/api_test.go
+++ b/signer/core/api_test.go
@@ -259,7 +259,7 @@ func TestSignData(t *testing.T) {
 
 	control <- "Y"
 	control <- "wrongpassword"
-	h, err := api.Sign(context.Background(), a, []byte("EHLO world"))
+	h, err := api.SignData(context.Background(), "text/plain", a, []byte("EHLO world"))
 	if h != nil {
 		t.Errorf("Expected nil-data, got %x", h)
 	}
@@ -267,7 +267,7 @@ func TestSignData(t *testing.T) {
 		t.Errorf("Expected ErrLocked! %v", err)
 	}
 	control <- "No way"
-	h, err = api.Sign(context.Background(), a, []byte("EHLO world"))
+	h, err = api.SignData(context.Background(), "text/plain", a, []byte("EHLO world"))
 	if h != nil {
 		t.Errorf("Expected nil-data, got %x", h)
 	}
@@ -276,7 +276,7 @@ func TestSignData(t *testing.T) {
 	}
 	control <- "Y"
 	control <- "a_long_password"
-	h, err = api.Sign(context.Background(), a, []byte("EHLO world"))
+	h, err = api.SignData(context.Background(), "text/plain", a, []byte("EHLO world"))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/signer/core/auditlog.go
+++ b/signer/core/auditlog.go
@@ -63,11 +63,11 @@ func (l *AuditLogger) SignTransaction(ctx context.Context, args SendTxArgs, meth
 	return res, e
 }
 
-func (l *AuditLogger) Sign(ctx context.Context, addr common.MixedcaseAddress, data hexutil.Bytes) (hexutil.Bytes, error) {
-	l.log.Info("Sign", "type", "request", "metadata", MetadataFromContext(ctx).String(),
-		"addr", addr.String(), "data", common.Bytes2Hex(data))
-	b, e := l.api.Sign(ctx, addr, data)
-	l.log.Info("Sign", "type", "response", "data", common.Bytes2Hex(b), "error", e)
+func (l *AuditLogger) SignData(ctx context.Context, contentType string, addr common.MixedcaseAddress, data hexutil.Bytes) (hexutil.Bytes, error) {
+	l.log.Info("SignData", "type", "request", "metadata", MetadataFromContext(ctx).String(),
+		"addr", addr.String(), "data", common.Bytes2Hex(data), "content-type", contentType)
+	b, e := l.api.SignData(ctx, contentType, addr, data)
+	l.log.Info("SignData", "type", "response", "data", common.Bytes2Hex(b), "error", e)
 	return b, e
 }
 


### PR DESCRIPTION
This PR adds ability into Clef to sign Clique headers, a prerequisite for moving account management out of Geth. The same schema with content-types will also be used for other types of signing, such as eip-712. 
cc @PaulRBerg 