### PR TITLE
core/vm: tweak the `--vm.ewasm=` option format

### DIFF
--- a/core/vm/interpreter.go
+++ b/core/vm/interpreter.go
@@ -43,7 +43,7 @@ type Config struct {
 	JumpTable [256]operation
 
 	// Type of the EWASM interpreter
-	EWASMInterpreter string
+	EWASMInterpreter map[string]string
 	// Type of the EVM interpreter
 	EVMInterpreter string
 }

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"math/big"
 	"runtime"
+	"strings"
 	"sync"
 	"sync/atomic"
 
@@ -148,10 +149,22 @@ func New(ctx *node.ServiceContext, config *Config) (*Ethereum, error) {
 		}
 		rawdb.WriteDatabaseVersion(chainDb, core.BlockChainVersion)
 	}
+
+	ewasmOptions := make(map[string]string)
+	if len(config.EWASMInterpreter) > 0 {
+		for _, option := range strings.Split(config.EWASMInterpreter, ",") {
+			opt := strings.Split(option, ":")
+			if len(opt) != 2 || len(opt[0]) == 0 {
+				panic(fmt.Sprintf("Invalid ewasm option: expected a format of name:value, got: %s", option))
+			}
+			ewasmOptions[opt[0]] = opt[1]
+		}
+	}
+
 	var (
 		vmConfig = vm.Config{
 			EnablePreimageRecording: config.EnablePreimageRecording,
-			EWASMInterpreter:        config.EWASMInterpreter,
+			EWASMInterpreter:        ewasmOptions,
 			EVMInterpreter:          config.EVMInterpreter,
 		}
 		cacheConfig = &core.CacheConfig{Disabled: config.NoPruning, TrieNodeLimit: config.TrieCache, TrieTimeLimit: config.TrieTimeout}


### PR DESCRIPTION
wagon will also need to use the `--vm.ewasm=` option to see if contract metering should be enabled. Since this is also useful to #17050, might as well make it generic. The goal is to have options passed as `--vm.ewasm=option1:value1,option2:value2,..."