### PR TITLE
core/vm: adds refund as part of the json standard trace

### DIFF
--- a/cmd/evm/json_logger.go
+++ b/cmd/evm/json_logger.go
@@ -45,14 +45,15 @@ func (l *JSONLogger) CaptureStart(from common.Address, to common.Address, create
 // CaptureState outputs state information on the logger.
 func (l *JSONLogger) CaptureState(env *vm.EVM, pc uint64, op vm.OpCode, gas, cost uint64, memory *vm.Memory, stack *vm.Stack, contract *vm.Contract, depth int, err error) error {
 	log := vm.StructLog{
-		Pc:         pc,
-		Op:         op,
-		Gas:        gas,
-		GasCost:    cost,
-		MemorySize: memory.Len(),
-		Storage:    nil,
-		Depth:      depth,
-		Err:        err,
+		Pc:            pc,
+		Op:            op,
+		Gas:           gas,
+		GasCost:       cost,
+		MemorySize:    memory.Len(),
+		Storage:       nil,
+		Depth:         depth,
+		RefundCounter: env.StateDB.GetRefund(),
+		Err:           err,
 	}
 	if !l.cfg.DisableMemory {
 		log.Memory = memory.Data()

--- a/core/vm/gen_structlog.go
+++ b/core/vm/gen_structlog.go
@@ -13,20 +13,22 @@ import (
 
 var _ = (*structLogMarshaling)(nil)
 
+// MarshalJSON marshals as JSON.
 func (s StructLog) MarshalJSON() ([]byte, error) {
 	type StructLog struct {
-		Pc          uint64                      `json:"pc"`
-		Op          OpCode                      `json:"op"`
-		Gas         math.HexOrDecimal64         `json:"gas"`
-		GasCost     math.HexOrDecimal64         `json:"gasCost"`
-		Memory      hexutil.Bytes               `json:"memory"`
-		MemorySize  int                         `json:"memSize"`
-		Stack       []*math.HexOrDecimal256     `json:"stack"`
-		Storage     map[common.Hash]common.Hash `json:"-"`
-		Depth       int                         `json:"depth"`
-		Err         error                       `json:"-"`
-		OpName      string                      `json:"opName"`
-		ErrorString string                      `json:"error"`
+		Pc            uint64                      `json:"pc"`
+		Op            OpCode                      `json:"op"`
+		Gas           math.HexOrDecimal64         `json:"gas"`
+		GasCost       math.HexOrDecimal64         `json:"gasCost"`
+		Memory        hexutil.Bytes               `json:"memory"`
+		MemorySize    int                         `json:"memSize"`
+		Stack         []*math.HexOrDecimal256     `json:"stack"`
+		Storage       map[common.Hash]common.Hash `json:"-"`
+		Depth         int                         `json:"depth"`
+		RefundCounter uint64                      `json:"refund"`
+		Err           error                       `json:"-"`
+		OpName        string                      `json:"opName"`
+		ErrorString   string                      `json:"error"`
 	}
 	var enc StructLog
 	enc.Pc = s.Pc
@@ -43,24 +45,27 @@ func (s StructLog) MarshalJSON() ([]byte, error) {
 	}
 	enc.Storage = s.Storage
 	enc.Depth = s.Depth
+	enc.RefundCounter = s.RefundCounter
 	enc.Err = s.Err
 	enc.OpName = s.OpName()
 	enc.ErrorString = s.ErrorString()
 	return json.Marshal(&enc)
 }
 
+// UnmarshalJSON unmarshals from JSON.
 func (s *StructLog) UnmarshalJSON(input []byte) error {
 	type StructLog struct {
-		Pc         *uint64                     `json:"pc"`
-		Op         *OpCode                     `json:"op"`
-		Gas        *math.HexOrDecimal64        `json:"gas"`
-		GasCost    *math.HexOrDecimal64        `json:"gasCost"`
-		Memory     *hexutil.Bytes              `json:"memory"`
-		MemorySize *int                        `json:"memSize"`
-		Stack      []*math.HexOrDecimal256     `json:"stack"`
-		Storage    map[common.Hash]common.Hash `json:"-"`
-		Depth      *int                        `json:"depth"`
-		Err        error                       `json:"-"`
+		Pc            *uint64                     `json:"pc"`
+		Op            *OpCode                     `json:"op"`
+		Gas           *math.HexOrDecimal64        `json:"gas"`
+		GasCost       *math.HexOrDecimal64        `json:"gasCost"`
+		Memory        *hexutil.Bytes              `json:"memory"`
+		MemorySize    *int                        `json:"memSize"`
+		Stack         []*math.HexOrDecimal256     `json:"stack"`
+		Storage       map[common.Hash]common.Hash `json:"-"`
+		Depth         *int                        `json:"depth"`
+		RefundCounter *uint64                     `json:"refund"`
+		Err           error                       `json:"-"`
 	}
 	var dec StructLog
 	if err := json.Unmarshal(input, &dec); err != nil {
@@ -95,6 +100,9 @@ func (s *StructLog) UnmarshalJSON(input []byte) error {
 	}
 	if dec.Depth != nil {
 		s.Depth = *dec.Depth
+	}
+	if dec.RefundCounter != nil {
+		s.RefundCounter = *dec.RefundCounter
 	}
 	if dec.Err != nil {
 		s.Err = dec.Err

--- a/core/vm/logger.go
+++ b/core/vm/logger.go
@@ -56,16 +56,17 @@ type LogConfig struct {
 // StructLog is emitted to the EVM each cycle and lists information about the current internal state
 // prior to the execution of the statement.
 type StructLog struct {
-	Pc         uint64                      `json:"pc"`
-	Op         OpCode                      `json:"op"`
-	Gas        uint64                      `json:"gas"`
-	GasCost    uint64                      `json:"gasCost"`
-	Memory     []byte                      `json:"memory"`
-	MemorySize int                         `json:"memSize"`
-	Stack      []*big.Int                  `json:"stack"`
-	Storage    map[common.Hash]common.Hash `json:"-"`
-	Depth      int                         `json:"depth"`
-	Err        error                       `json:"-"`
+	Pc            uint64                      `json:"pc"`
+	Op            OpCode                      `json:"op"`
+	Gas           uint64                      `json:"gas"`
+	GasCost       uint64                      `json:"gasCost"`
+	Memory        []byte                      `json:"memory"`
+	MemorySize    int                         `json:"memSize"`
+	Stack         []*big.Int                  `json:"stack"`
+	Storage       map[common.Hash]common.Hash `json:"-"`
+	Depth         int                         `json:"depth"`
+	RefundCounter uint64                      `json:"refund"`
+	Err           error                       `json:"-"`
 }
 
 // overrides for gencodec
@@ -177,7 +178,7 @@ func (l *StructLogger) CaptureState(env *EVM, pc uint64, op OpCode, gas, cost ui
 		storage = l.changedValues[contract.Address()].Copy()
 	}
 	// create a new snaptshot of the EVM.
-	log := StructLog{pc, op, gas, cost, mem, memory.Len(), stck, storage, depth, err}
+	log := StructLog{pc, op, gas, cost, mem, memory.Len(), stck, storage, depth, env.StateDB.GetRefund(), err}
 
 	l.logs = append(l.logs, log)
 	return nil

--- a/core/vm/logger_test.go
+++ b/core/vm/logger_test.go
@@ -17,11 +17,11 @@
 package vm
 
 import (
-	"github.com/ethereum/go-ethereum/core/types"
 	"math/big"
 	"testing"
 
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/params"
 )
 

--- a/core/vm/logger_test.go
+++ b/core/vm/logger_test.go
@@ -17,6 +17,7 @@
 package vm
 
 import (
+	"github.com/ethereum/go-ethereum/core/types"
 	"math/big"
 	"testing"
 
@@ -41,9 +42,40 @@ func (d *dummyContractRef) SetBalance(*big.Int)        {}
 func (d *dummyContractRef) SetNonce(uint64)            {}
 func (d *dummyContractRef) Balance() *big.Int          { return new(big.Int) }
 
+type dummyStatedb struct {
+}
+
+func (dummyStatedb) CreateAccount(common.Address)                              { panic("implement me") }
+func (dummyStatedb) SubBalance(common.Address, *big.Int)                       { panic("implement me") }
+func (dummyStatedb) AddBalance(common.Address, *big.Int)                       { panic("implement me") }
+func (dummyStatedb) GetBalance(common.Address) *big.Int                        { panic("implement me") }
+func (dummyStatedb) GetNonce(common.Address) uint64                            { panic("implement me") }
+func (dummyStatedb) SetNonce(common.Address, uint64)                           { panic("implement me") }
+func (dummyStatedb) GetCodeHash(common.Address) common.Hash                    { panic("implement me") }
+func (dummyStatedb) GetCode(common.Address) []byte                             { panic("implement me") }
+func (dummyStatedb) SetCode(common.Address, []byte)                            { panic("implement me") }
+func (dummyStatedb) GetCodeSize(common.Address) int                            { panic("implement me") }
+func (dummyStatedb) AddRefund(uint64)                                          { panic("implement me") }
+func (dummyStatedb) SubRefund(uint64)                                          { panic("implement me") }
+func (dummyStatedb) GetRefund() uint64                                         { return 1337 }
+func (dummyStatedb) GetCommittedState(common.Address, common.Hash) common.Hash { panic("implement me") }
+func (dummyStatedb) GetState(common.Address, common.Hash) common.Hash          { panic("implement me") }
+func (dummyStatedb) SetState(common.Address, common.Hash, common.Hash)         { panic("implement me") }
+func (dummyStatedb) Suicide(common.Address) bool                               { panic("implement me") }
+func (dummyStatedb) HasSuicided(common.Address) bool                           { panic("implement me") }
+func (dummyStatedb) Exist(common.Address) bool                                 { panic("implement me") }
+func (dummyStatedb) Empty(common.Address) bool                                 { panic("implement me") }
+func (dummyStatedb) RevertToSnapshot(int)                                      { panic("implement me") }
+func (dummyStatedb) Snapshot() int                                             { panic("implement me") }
+func (dummyStatedb) AddLog(*types.Log)                                         { panic("implement me") }
+func (dummyStatedb) AddPreimage(common.Hash, []byte)                           { panic("implement me") }
+func (dummyStatedb) ForEachStorage(common.Address, func(common.Hash, common.Hash) bool) {
+	panic("implement me")
+}
+
 func TestStoreCapture(t *testing.T) {
 	var (
-		env      = NewEVM(Context{}, nil, params.TestChainConfig, Config{})
+		env      = NewEVM(Context{}, dummyStatedb{}, params.TestChainConfig, Config{})
 		logger   = NewStructLogger(nil)
 		mem      = NewMemory()
 		stack    = newstack()

--- a/eth/tracers/tracer_test.go
+++ b/eth/tracers/tracer_test.go
@@ -25,7 +25,7 @@ import (
 	"time"
 
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/core/state"
 	"github.com/ethereum/go-ethereum/core/vm"
 	"github.com/ethereum/go-ethereum/params"
 )
@@ -45,38 +45,13 @@ func (account) SetCode(common.Hash, []byte)                         {}
 func (account) ForEachStorage(cb func(key, value common.Hash) bool) {}
 
 type dummyStatedb struct {
+	state.StateDB
 }
 
-func (dummyStatedb) CreateAccount(common.Address)                              { panic("implement me") }
-func (dummyStatedb) SubBalance(common.Address, *big.Int)                       { panic("implement me") }
-func (dummyStatedb) AddBalance(common.Address, *big.Int)                       { panic("implement me") }
-func (dummyStatedb) GetBalance(common.Address) *big.Int                        { panic("implement me") }
-func (dummyStatedb) GetNonce(common.Address) uint64                            { panic("implement me") }
-func (dummyStatedb) SetNonce(common.Address, uint64)                           { panic("implement me") }
-func (dummyStatedb) GetCodeHash(common.Address) common.Hash                    { panic("implement me") }
-func (dummyStatedb) GetCode(common.Address) []byte                             { panic("implement me") }
-func (dummyStatedb) SetCode(common.Address, []byte)                            { panic("implement me") }
-func (dummyStatedb) GetCodeSize(common.Address) int                            { panic("implement me") }
-func (dummyStatedb) AddRefund(uint64)                                          { panic("implement me") }
-func (dummyStatedb) SubRefund(uint64)                                          { panic("implement me") }
-func (dummyStatedb) GetRefund() uint64                                         { return 1337 }
-func (dummyStatedb) GetCommittedState(common.Address, common.Hash) common.Hash { panic("implement me") }
-func (dummyStatedb) GetState(common.Address, common.Hash) common.Hash          { panic("implement me") }
-func (dummyStatedb) SetState(common.Address, common.Hash, common.Hash)         { panic("implement me") }
-func (dummyStatedb) Suicide(common.Address) bool                               { panic("implement me") }
-func (dummyStatedb) HasSuicided(common.Address) bool                           { panic("implement me") }
-func (dummyStatedb) Exist(common.Address) bool                                 { panic("implement me") }
-func (dummyStatedb) Empty(common.Address) bool                                 { panic("implement me") }
-func (dummyStatedb) RevertToSnapshot(int)                                      { panic("implement me") }
-func (dummyStatedb) Snapshot() int                                             { panic("implement me") }
-func (dummyStatedb) AddLog(*types.Log)                                         { panic("implement me") }
-func (dummyStatedb) AddPreimage(common.Hash, []byte)                           { panic("implement me") }
-func (dummyStatedb) ForEachStorage(common.Address, func(common.Hash, common.Hash) bool) {
-	panic("implement me")
-}
+func (dummyStatedb) GetRefund() uint64 { return 1337 }
 
 func runTrace(tracer *Tracer) (json.RawMessage, error) {
-	env := vm.NewEVM(vm.Context{BlockNumber: big.NewInt(1)}, dummyStatedb{}, params.TestChainConfig, vm.Config{Debug: true, Tracer: tracer})
+	env := vm.NewEVM(vm.Context{BlockNumber: big.NewInt(1)}, &dummyStatedb{}, params.TestChainConfig, vm.Config{Debug: true, Tracer: tracer})
 
 	contract := vm.NewContract(account{}, account{}, big.NewInt(0), 10000)
 	contract.Code = []byte{byte(vm.PUSH1), 0x1, byte(vm.PUSH1), 0x1, 0x0}
@@ -158,7 +133,7 @@ func TestHaltBetweenSteps(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	env := vm.NewEVM(vm.Context{BlockNumber: big.NewInt(1)}, dummyStatedb{}, params.TestChainConfig, vm.Config{Debug: true, Tracer: tracer})
+	env := vm.NewEVM(vm.Context{BlockNumber: big.NewInt(1)}, &dummyStatedb{}, params.TestChainConfig, vm.Config{Debug: true, Tracer: tracer})
 	contract := vm.NewContract(&account{}, &account{}, big.NewInt(0), 0)
 
 	tracer.CaptureState(env, 0, 0, 0, 0, nil, nil, contract, 0, nil)

--- a/eth/tracers/tracer_test.go
+++ b/eth/tracers/tracer_test.go
@@ -20,12 +20,12 @@ import (
 	"bytes"
 	"encoding/json"
 	"errors"
-	"github.com/ethereum/go-ethereum/core/types"
 	"math/big"
 	"testing"
 	"time"
 
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/core/vm"
 	"github.com/ethereum/go-ethereum/params"
 )

--- a/eth/tracers/tracer_test.go
+++ b/eth/tracers/tracer_test.go
@@ -20,6 +20,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"errors"
+	"github.com/ethereum/go-ethereum/core/types"
 	"math/big"
 	"testing"
 	"time"
@@ -43,8 +44,39 @@ func (account) ReturnGas(*big.Int)                                  {}
 func (account) SetCode(common.Hash, []byte)                         {}
 func (account) ForEachStorage(cb func(key, value common.Hash) bool) {}
 
+type dummyStatedb struct {
+}
+
+func (dummyStatedb) CreateAccount(common.Address)                              { panic("implement me") }
+func (dummyStatedb) SubBalance(common.Address, *big.Int)                       { panic("implement me") }
+func (dummyStatedb) AddBalance(common.Address, *big.Int)                       { panic("implement me") }
+func (dummyStatedb) GetBalance(common.Address) *big.Int                        { panic("implement me") }
+func (dummyStatedb) GetNonce(common.Address) uint64                            { panic("implement me") }
+func (dummyStatedb) SetNonce(common.Address, uint64)                           { panic("implement me") }
+func (dummyStatedb) GetCodeHash(common.Address) common.Hash                    { panic("implement me") }
+func (dummyStatedb) GetCode(common.Address) []byte                             { panic("implement me") }
+func (dummyStatedb) SetCode(common.Address, []byte)                            { panic("implement me") }
+func (dummyStatedb) GetCodeSize(common.Address) int                            { panic("implement me") }
+func (dummyStatedb) AddRefund(uint64)                                          { panic("implement me") }
+func (dummyStatedb) SubRefund(uint64)                                          { panic("implement me") }
+func (dummyStatedb) GetRefund() uint64                                         { return 1337 }
+func (dummyStatedb) GetCommittedState(common.Address, common.Hash) common.Hash { panic("implement me") }
+func (dummyStatedb) GetState(common.Address, common.Hash) common.Hash          { panic("implement me") }
+func (dummyStatedb) SetState(common.Address, common.Hash, common.Hash)         { panic("implement me") }
+func (dummyStatedb) Suicide(common.Address) bool                               { panic("implement me") }
+func (dummyStatedb) HasSuicided(common.Address) bool                           { panic("implement me") }
+func (dummyStatedb) Exist(common.Address) bool                                 { panic("implement me") }
+func (dummyStatedb) Empty(common.Address) bool                                 { panic("implement me") }
+func (dummyStatedb) RevertToSnapshot(int)                                      { panic("implement me") }
+func (dummyStatedb) Snapshot() int                                             { panic("implement me") }
+func (dummyStatedb) AddLog(*types.Log)                                         { panic("implement me") }
+func (dummyStatedb) AddPreimage(common.Hash, []byte)                           { panic("implement me") }
+func (dummyStatedb) ForEachStorage(common.Address, func(common.Hash, common.Hash) bool) {
+	panic("implement me")
+}
+
 func runTrace(tracer *Tracer) (json.RawMessage, error) {
-	env := vm.NewEVM(vm.Context{BlockNumber: big.NewInt(1)}, nil, params.TestChainConfig, vm.Config{Debug: true, Tracer: tracer})
+	env := vm.NewEVM(vm.Context{BlockNumber: big.NewInt(1)}, dummyStatedb{}, params.TestChainConfig, vm.Config{Debug: true, Tracer: tracer})
 
 	contract := vm.NewContract(account{}, account{}, big.NewInt(0), 10000)
 	contract.Code = []byte{byte(vm.PUSH1), 0x1, byte(vm.PUSH1), 0x1, 0x0}
@@ -126,7 +158,7 @@ func TestHaltBetweenSteps(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	env := vm.NewEVM(vm.Context{BlockNumber: big.NewInt(1)}, nil, params.TestChainConfig, vm.Config{Debug: true, Tracer: tracer})
+	env := vm.NewEVM(vm.Context{BlockNumber: big.NewInt(1)}, dummyStatedb{}, params.TestChainConfig, vm.Config{Debug: true, Tracer: tracer})
 	contract := vm.NewContract(&account{}, &account{}, big.NewInt(0), 0)
 
 	tracer.CaptureState(env, 0, 0, 0, 0, nil, nil, contract, 0, nil)


### PR DESCRIPTION
This adds `refund`, the global accumulated value, to the standard json output , as a `numeric` json value. Previously, this was not very interesting, since it was not used much, but with the new sstore gas changes, the value is a lot more interesting from a consensus investigation perspective. 
```
build/bin/evm --code "6040" --json run
{"pc":0,"op":96,"gas":"0x2540be400","gasCost":"0x3","memory":"0x","memSize":0,"stack":[],"depth":1,"refund":0,"opName":"PUSH1","error":""}
{"pc":2,"op":0,"gas":"0x2540be3fd","gasCost":"0x0","memory":"0x","memSize":0,"stack":["0x40"],"depth":1,"refund":0,"opName":"STOP","error":""}
{"output":"","gasUsed":"0x3","time":113299}
```