### PR TITLE
swarm/network/stream: disambiguate chunk delivery messages (retrieval…

### DIFF
--- a/swarm/network/stream/delivery.go
+++ b/swarm/network/stream/delivery.go
@@ -173,7 +173,8 @@ func (d *Delivery) handleRetrieveRequestMsg(ctx context.Context, sp *Peer, req *
 			return
 		}
 		if req.SkipCheck {
-			err = sp.Deliver(ctx, chunk, s.priority)
+			syncing := false
+			err = sp.Deliver(ctx, chunk, s.priority, syncing)
 			if err != nil {
 				log.Warn("ERROR in handleRetrieveRequestMsg", "err", err)
 			}
@@ -189,11 +190,22 @@ func (d *Delivery) handleRetrieveRequestMsg(ctx context.Context, sp *Peer, req *
 	return nil
 }
 
+//Chunk delivery always uses the same message type....
 type ChunkDeliveryMsg struct {
-	Addr  storage.Address
-	SData []byte // the stored chunk Data (incl size)
-	peer  *Peer  // set in handleChunkDeliveryMsg
+	Addr    storage.Address
+	SData   []byte // the stored chunk Data (incl size)
+	peer    *Peer  // set in handleChunkDeliveryMsg
+	Syncing bool   // if true, this is a delivery for syncing (no SWAP accounting needed)
 }
+
+//...but swap accounting needs to disambiguate if it is a delivery for syncing or for retrieval
+//as it decides based on message type if it needs to account for this message or not
+
+//defines a chunk delivery for retrieval (with accounting)
+type ChunkDeliveryMsgRetrieval ChunkDeliveryMsg
+
+//defines a chunk delivery for syncing (without accounting)
+type ChunkDeliveryMsgSyncing ChunkDeliveryMsg
 
 // TODO: Fix context SNAFU
 func (d *Delivery) handleChunkDeliveryMsg(ctx context.Context, sp *Peer, req *ChunkDeliveryMsg) error {

--- a/swarm/network/stream/delivery.go
+++ b/swarm/network/stream/delivery.go
@@ -192,10 +192,9 @@ func (d *Delivery) handleRetrieveRequestMsg(ctx context.Context, sp *Peer, req *
 
 //Chunk delivery always uses the same message type....
 type ChunkDeliveryMsg struct {
-	Addr    storage.Address
-	SData   []byte // the stored chunk Data (incl size)
-	peer    *Peer  // set in handleChunkDeliveryMsg
-	Syncing bool   // if true, this is a delivery for syncing (no SWAP accounting needed)
+	Addr  storage.Address
+	SData []byte // the stored chunk Data (incl size)
+	peer  *Peer  // set in handleChunkDeliveryMsg
 }
 
 //...but swap accounting needs to disambiguate if it is a delivery for syncing or for retrieval

--- a/swarm/network/stream/messages.go
+++ b/swarm/network/stream/messages.go
@@ -347,7 +347,8 @@ func (p *Peer) handleWantedHashesMsg(ctx context.Context, req *WantedHashesMsg) 
 				return fmt.Errorf("handleWantedHashesMsg get data %x: %v", hash, err)
 			}
 			chunk := storage.NewChunk(hash, data)
-			if err := p.Deliver(ctx, chunk, s.priority); err != nil {
+			syncing := true
+			if err := p.Deliver(ctx, chunk, s.priority, syncing); err != nil {
 				return err
 			}
 		}

--- a/swarm/network/stream/peer.go
+++ b/swarm/network/stream/peer.go
@@ -128,16 +128,31 @@ func NewPeer(peer *protocols.Peer, streamer *Registry) *Peer {
 }
 
 // Deliver sends a storeRequestMsg protocol message to the peer
-func (p *Peer) Deliver(ctx context.Context, chunk storage.Chunk, priority uint8) error {
+// Depending on the `syncing` parameter we send different message types
+func (p *Peer) Deliver(ctx context.Context, chunk storage.Chunk, priority uint8, syncing bool) error {
 	var sp opentracing.Span
 	ctx, sp = spancontext.StartSpan(
 		ctx,
 		"send.chunk.delivery")
 	defer sp.Finish()
 
-	msg := &ChunkDeliveryMsg{
-		Addr:  chunk.Address(),
-		SData: chunk.Data(),
+	var msg interface{}
+
+	//we send different types of messages if delivery is for syncing or retrievals,
+	//even if handling and content of the message are the same,
+	//because swap accounting decides which messages need accounting based on the message type
+	if syncing {
+		msg = &ChunkDeliveryMsgSyncing{
+			Addr:    chunk.Address(),
+			SData:   chunk.Data(),
+			Syncing: syncing,
+		}
+	} else {
+		msg = &ChunkDeliveryMsgRetrieval{
+			Addr:    chunk.Address(),
+			SData:   chunk.Data(),
+			Syncing: syncing,
+		}
 	}
 	return p.SendPriority(ctx, msg, priority)
 }

--- a/swarm/network/stream/peer.go
+++ b/swarm/network/stream/peer.go
@@ -131,29 +131,31 @@ func NewPeer(peer *protocols.Peer, streamer *Registry) *Peer {
 // Depending on the `syncing` parameter we send different message types
 func (p *Peer) Deliver(ctx context.Context, chunk storage.Chunk, priority uint8, syncing bool) error {
 	var sp opentracing.Span
-	ctx, sp = spancontext.StartSpan(
-		ctx,
-		"send.chunk.delivery")
-	defer sp.Finish()
-
 	var msg interface{}
+
+	spanName := "send.chunk.delivery"
 
 	//we send different types of messages if delivery is for syncing or retrievals,
 	//even if handling and content of the message are the same,
 	//because swap accounting decides which messages need accounting based on the message type
 	if syncing {
 		msg = &ChunkDeliveryMsgSyncing{
-			Addr:    chunk.Address(),
-			SData:   chunk.Data(),
-			Syncing: syncing,
+			Addr:  chunk.Address(),
+			SData: chunk.Data(),
 		}
+		spanName += ".syncing"
 	} else {
 		msg = &ChunkDeliveryMsgRetrieval{
-			Addr:    chunk.Address(),
-			SData:   chunk.Data(),
-			Syncing: syncing,
+			Addr:  chunk.Address(),
+			SData: chunk.Data(),
 		}
+		spanName += ".retrieval"
 	}
+	ctx, sp = spancontext.StartSpan(
+		ctx,
+		spanName)
+	defer sp.Finish()
+
 	return p.SendPriority(ctx, msg, priority)
 }
 

--- a/swarm/network/stream/stream.go
+++ b/swarm/network/stream/stream.go
@@ -675,7 +675,7 @@ func (c *clientParams) clientCreated() {
 // Spec is the spec of the streamer protocol
 var Spec = &protocols.Spec{
 	Name:       "stream",
-	Version:    7,
+	Version:    8,
 	MaxMsgSize: 10 * 1024 * 1024,
 	Messages: []interface{}{
 		UnsubscribeMsg{},

--- a/swarm/network/stream/stream.go
+++ b/swarm/network/stream/stream.go
@@ -478,8 +478,13 @@ func (p *Peer) HandleMsg(ctx context.Context, msg interface{}) error {
 	case *WantedHashesMsg:
 		return p.handleWantedHashesMsg(ctx, msg)
 
-	case *ChunkDeliveryMsg:
-		return p.streamer.delivery.handleChunkDeliveryMsg(ctx, p, msg)
+	case *ChunkDeliveryMsgRetrieval:
+		//handling chunk delivery is the same for retrieval and syncing, so let's cast the msg
+		return p.streamer.delivery.handleChunkDeliveryMsg(ctx, p, ((*ChunkDeliveryMsg)(msg)))
+
+	case *ChunkDeliveryMsgSyncing:
+		//handling chunk delivery is the same for retrieval and syncing, so let's cast the msg
+		return p.streamer.delivery.handleChunkDeliveryMsg(ctx, p, ((*ChunkDeliveryMsg)(msg)))
 
 	case *RetrieveRequestMsg:
 		return p.streamer.delivery.handleRetrieveRequestMsg(ctx, p, msg)
@@ -679,10 +684,11 @@ var Spec = &protocols.Spec{
 		TakeoverProofMsg{},
 		SubscribeMsg{},
 		RetrieveRequestMsg{},
-		ChunkDeliveryMsg{},
+		ChunkDeliveryMsgRetrieval{},
 		SubscribeErrorMsg{},
 		RequestSubscriptionMsg{},
 		QuitMsg{},
+		ChunkDeliveryMsgSyncing{},
 	},
 }
 


### PR DESCRIPTION
Currently, we have a `ChunkDeliveryMsg` type which is used both to deliver chunks requested for **syncing** and for **retrieval**.

For accounting though, only **retrieval** messages should be accounted. Syncing is integral to the swarm protocol and are not charged.

Thus, we need to disambiguate the two messages in order to allow automatic accounting. 