### PR TITLE
swarm: modify context key

### DIFF
--- a/swarm/api/http/sctx.go
+++ b/swarm/api/http/sctx.go
@@ -7,14 +7,10 @@ import (
 	"github.com/ethereum/go-ethereum/swarm/sctx"
 )
 
-type contextKey int
-
-const (
-	uriKey contextKey = iota
-)
+type uriKey struct{}
 
 func GetRUID(ctx context.Context) string {
-	v, ok := ctx.Value(sctx.HTTPRequestIDKey).(string)
+	v, ok := ctx.Value(sctx.HTTPRequestIDKey{}).(string)
 	if ok {
 		return v
 	}
@@ -22,11 +18,11 @@ func GetRUID(ctx context.Context) string {
 }
 
 func SetRUID(ctx context.Context, ruid string) context.Context {
-	return context.WithValue(ctx, sctx.HTTPRequestIDKey, ruid)
+	return context.WithValue(ctx, sctx.HTTPRequestIDKey{}, ruid)
 }
 
 func GetURI(ctx context.Context) *api.URI {
-	v, ok := ctx.Value(uriKey).(*api.URI)
+	v, ok := ctx.Value(uriKey{}).(*api.URI)
 	if ok {
 		return v
 	}
@@ -34,5 +30,5 @@ func GetURI(ctx context.Context) *api.URI {
 }
 
 func SetURI(ctx context.Context, uri *api.URI) context.Context {
-	return context.WithValue(ctx, uriKey, uri)
+	return context.WithValue(ctx, uriKey{}, uri)
 }

--- a/swarm/sctx/sctx.go
+++ b/swarm/sctx/sctx.go
@@ -2,19 +2,17 @@ package sctx
 
 import "context"
 
-type ContextKey int
-
-const (
-	HTTPRequestIDKey ContextKey = iota
-	requestHostKey
+type (
+	HTTPRequestIDKey struct{}
+	requestHostKey struct{}
 )
 
 func SetHost(ctx context.Context, domain string) context.Context {
-	return context.WithValue(ctx, requestHostKey, domain)
+	return context.WithValue(ctx, requestHostKey{}, domain)
 }
 
 func GetHost(ctx context.Context) string {
-	v, ok := ctx.Value(requestHostKey).(string)
+	v, ok := ctx.Value(requestHostKey{}).(string)
 	if ok {
 		return v
 	}

--- a/swarm/sctx/sctx.go
+++ b/swarm/sctx/sctx.go
@@ -4,7 +4,7 @@ import "context"
 
 type (
 	HTTPRequestIDKey struct{}
-	requestHostKey struct{}
+	requestHostKey   struct{}
 )
 
 func SetHost(ctx context.Context, domain string) context.Context {


### PR DESCRIPTION
I think that define type with struct{} and using it as a context key is more go-ish.

And, actually golang/go project has been using it.

