### PR TITLE
p2p: preserve enode.ID type in the metered connection

### DIFF
--- a/p2p/enode/node.go
+++ b/p2p/enode/node.go
@@ -254,6 +254,7 @@ func RandomID(a ID, n int) (b ID) {
 	return b
 }
 
+// Equal returns a boolean reporting whether a and b contain the same bytes.
 func Equal(a, b ID) bool {
 	for i := range a {
 		if a[i] != b[i] {

--- a/p2p/enode/node.go
+++ b/p2p/enode/node.go
@@ -253,13 +253,3 @@ func RandomID(a ID, n int) (b ID) {
 	}
 	return b
 }
-
-// Equal returns a boolean reporting whether a and b contain the same bytes.
-func Equal(a, b ID) bool {
-	for i := range a {
-		if a[i] != b[i] {
-			return false
-		}
-	}
-	return true
-}

--- a/p2p/enode/node.go
+++ b/p2p/enode/node.go
@@ -253,3 +253,12 @@ func RandomID(a ID, n int) (b ID) {
 	}
 	return b
 }
+
+func Equal(a, b ID) bool {
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/p2p/metrics.go
+++ b/p2p/metrics.go
@@ -74,7 +74,7 @@ const (
 type MeteredPeerEvent struct {
 	Type    MeteredPeerEventType // Type of peer event
 	IP      net.IP               // IP address of the peer
-	ID      string               // NodeID of the peer
+	ID      enode.ID             // NodeID of the peer
 	Elapsed time.Duration        // Time elapsed between the connection and the handshake/disconnection
 	Ingress uint64               // Ingress count at the moment of the event
 	Egress  uint64               // Egress count at the moment of the event
@@ -93,7 +93,7 @@ type meteredConn struct {
 
 	connected time.Time // Connection time of the peer
 	ip        net.IP    // IP address of the peer
-	id        string    // NodeID of the peer
+	id        enode.ID  // NodeID of the peer
 
 	// trafficMetered denotes if the peer is registered in the traffic registries.
 	// Its value is true if the metered peer count doesn't reach the limit in the
@@ -161,18 +161,17 @@ func (c *meteredConn) Write(b []byte) (n int, err error) {
 // the ingress and the egress traffic registries using the peer's IP and node ID,
 // also emits connect event.
 func (c *meteredConn) handshakeDone(nodeID enode.ID) {
-	id := nodeID.String()
 	if atomic.AddInt32(&meteredPeerCount, 1) >= MeteredPeerLimit {
 		// Don't register the peer in the traffic registries.
 		atomic.AddInt32(&meteredPeerCount, -1)
 		c.lock.Lock()
-		c.id, c.trafficMetered = id, false
+		c.id, c.trafficMetered = nodeID, false
 		c.lock.Unlock()
 		log.Warn("Metered peer count reached the limit")
 	} else {
-		key := fmt.Sprintf("%s/%s", c.ip, id)
+		key := fmt.Sprintf("%s/%s", c.ip, nodeID.String())
 		c.lock.Lock()
-		c.id, c.trafficMetered = id, true
+		c.id, c.trafficMetered = nodeID, true
 		c.ingressMeter = metrics.NewRegisteredMeter(key, PeerIngressRegistry)
 		c.egressMeter = metrics.NewRegisteredMeter(key, PeerEgressRegistry)
 		c.lock.Unlock()
@@ -180,7 +179,7 @@ func (c *meteredConn) handshakeDone(nodeID enode.ID) {
 	meteredPeerFeed.Send(MeteredPeerEvent{
 		Type:    PeerConnected,
 		IP:      c.ip,
-		ID:      id,
+		ID:      nodeID,
 		Elapsed: time.Since(c.connected),
 	})
 }
@@ -190,7 +189,7 @@ func (c *meteredConn) handshakeDone(nodeID enode.ID) {
 func (c *meteredConn) Close() error {
 	err := c.Conn.Close()
 	c.lock.RLock()
-	if c.id == "" {
+	if enode.Equal(c.id, enode.ID{}) {
 		// If the peer disconnects before the handshake.
 		c.lock.RUnlock()
 		meteredPeerFeed.Send(MeteredPeerEvent{

--- a/p2p/metrics.go
+++ b/p2p/metrics.go
@@ -189,7 +189,7 @@ func (c *meteredConn) handshakeDone(id enode.ID) {
 func (c *meteredConn) Close() error {
 	err := c.Conn.Close()
 	c.lock.RLock()
-	if enode.Equal(c.id, enode.ID{}) {
+	if c.id == (enode.ID{}) {
 		// If the peer disconnects before the handshake.
 		c.lock.RUnlock()
 		meteredPeerFeed.Send(MeteredPeerEvent{


### PR DESCRIPTION
Change the type of the metered connection's `id` field from `string` to `enode.ID`. 