### PR TITLE
core/blockchain, downloader: abort early on bad sidechains

### DIFF
--- a/eth/downloader/downloader.go
+++ b/eth/downloader/downloader.go
@@ -1400,7 +1400,7 @@ func (d *Downloader) importBlockResults(results []*fetchResult) error {
 		blocks[i] = types.NewBlockWithHeader(result.Header).WithBody(result.Transactions, result.Uncles)
 	}
 	if index, err := d.blockchain.InsertChain(blocks); err != nil {
-		log.Debug("Downloaded item processing failed", "number", results[index].Header.Number, "hash", results[index].Header.Hash(), "err", err)
+		log.Debug("Downloaded item processing failed", "number", results[index].Header.Number, "hash", results[index].Header.Hash(), "blocks", len(blocks), "err", err)
 		return errInvalidChain
 	}
 	return nil
@@ -1621,7 +1621,7 @@ func (d *Downloader) qosTuner() {
 		atomic.StoreUint64(&d.rttConfidence, conf)
 
 		// Log the new QoS values and sleep until the next RTT
-		log.Debug("Recalculated downloader QoS values", "rtt", rtt, "confidence", float64(conf)/1000000.0, "ttl", d.requestTTL())
+		//log.Debug("Recalculated downloader QoS values", "rtt", rtt, "confidence", float64(conf)/1000000.0, "ttl", d.requestTTL())
 		select {
 		case <-d.quitCh:
 			return


### PR DESCRIPTION
This is an attempt to fix problems with block import logic, which was evident on Ropsten after the constantinople mess. 

Here's a block, `4229929`, that got imported yesterday at 7pm, then again this morning as a forked block:
```
Oct 17 19:17:22 ropsten.ethdevops.io geth: INFO [10-17|17:17:22.450] Imported new chain segment               blocks=154 txs=19431 mgas=1070.237 elapsed=8.040s        mgasps=133.114  number=4229929 hash=5757c5…1f5f9f age=4d2h11m    cache=531.70mB 
Oct 18 08:48:36 ropsten.ethdevops.io geth: DEBUG[10-18|06:48:36.538] Inserted forked block                    number=4229929 hash=5757c5…1f5f9f diff=14806172370 elapsed=41.400ms        txs=107   gas=7996108 uncles=0 
Oct 18 08:58:22 ropsten.ethdevops.io geth: DEBUG[10-18|06:58:22.034] Inserted forked block                    number=4229929 hash=5757c5…1f5f9f diff=14806172370 elapsed=44.352ms        txs=107   gas=7996108 uncles=0 
```
It probably got imported several times more, every ten minutes or so -- the reason it's only shown twice as `Inserted forked block` is that I only enabled verbosity `DEBUG` this morning. 

I believe the reason it was imported several times, is that inside `blockchain.go:insertBlocks`, there's a recursiveness. If the remote TD is higher than the local, _and_ the state for that other chain has been pruned, it loads the required blocks from disk and calls `insertBlocks` again. This causes a massive block churn, and is bound to fail again. 

This PR 

* Adds a log output when this situation occurrs, 
* Looks through the amassed list of blocks, and if one of them has previously been flagged as `bad`, it will abort the sidechain import. 

I have deployed this code on the Ropsten node, but after restarting it I have not seen the block-churn behaviour any more. I was hoping to see more messages about "Found bad hash", but I guess the canon chain difficulty has now outgrown the sidechains, so the restart fixed the problems I was trying to solve - and I can't really tell how well this works :(. 