### PR TITLE
swarm/api/http: remove ModTime=now for direct and multipart uploads

### DIFF
--- a/swarm/api/http/server.go
+++ b/swarm/api/http/server.go
@@ -409,7 +409,6 @@ func (s *Server) handleMultipartUpload(r *http.Request, boundary string, mw *api
 			Path:        path,
 			ContentType: part.Header.Get("Content-Type"),
 			Size:        size,
-			ModTime:     time.Now(),
 		}
 		log.Debug("adding path to new manifest", "ruid", ruid, "bytes", entry.Size, "path", entry.Path)
 		contentKey, err := mw.AddEntry(r.Context(), reader, entry)
@@ -428,7 +427,6 @@ func (s *Server) handleDirectUpload(r *http.Request, mw *api.ManifestWriter) err
 		ContentType: r.Header.Get("Content-Type"),
 		Mode:        0644,
 		Size:        r.ContentLength,
-		ModTime:     time.Now(),
 	})
 	if err != nil {
 		return err


### PR DESCRIPTION
This PR removes the default setting of `ModTime: time.Now()` for files uploaded directly or through multipart.
This will result in identical hashes for identical content.
