### PR TITLE
p2p accounting

### DIFF
--- a/p2p/protocols/accounting.go
+++ b/p2p/protocols/accounting.go
@@ -104,6 +104,9 @@ func NewAccounting(balance Balance, po Prices) *Accounting {
 }
 
 //Implement Hook.Send
+// Send takes a peer, a size and a msg and
+// - calculates the cost for the local node sending a msg of size to peer using the Prices interface
+// - credits/debits local node using balance interface
 func (ah *Accounting) Send(peer *Peer, size uint32, msg interface{}) error {
 	//get the price for a message (through the protocol spec)
 	price := ah.Price(msg)
@@ -121,6 +124,9 @@ func (ah *Accounting) Send(peer *Peer, size uint32, msg interface{}) error {
 }
 
 //Implement Hook.Receive
+// Receive takes a peer, a size and a msg and
+// - calculates the cost for the local node receiving a msg of size from peer using the Prices interface
+// - credits/debits local node using balance interface
 func (ah *Accounting) Receive(peer *Peer, size uint32, msg interface{}) error {
 	//get the price for a message (through the protocol spec)
 	price := ah.Price(msg)
@@ -139,21 +145,19 @@ func (ah *Accounting) Receive(peer *Peer, size uint32, msg interface{}) error {
 
 //record some metrics
 func (ah *Accounting) doMetrics(price int64, size uint32, err error) {
-	/*
-		if price > 0 {
-			mBalanceCredit.Inc(int64(price))
-			mBytesCredit.Inc(int64(size))
-			mMsgCredit.Inc(1)
-			if err != nil {
-				mPeerDrops.Inc(1)
-			}
-		} else {
-			mBalanceDebit.Inc(int64(price))
-			mBytesDebit.Inc(int64(size))
-			mMsgDebit.Inc(1)
-			if err != nil {
-				mSelfDrops.Inc(1)
-			}
+	if price > 0 {
+		mBalanceCredit.Inc(price)
+		mBytesCredit.Inc(int64(size))
+		mMsgCredit.Inc(1)
+		if err != nil {
+			mPeerDrops.Inc(1)
 		}
-	*/
+	} else {
+		mBalanceDebit.Inc(price)
+		mBytesDebit.Inc(int64(size))
+		mMsgDebit.Inc(1)
+		if err != nil {
+			mSelfDrops.Inc(1)
+		}
+	}
 }

--- a/p2p/protocols/accounting.go
+++ b/p2p/protocols/accounting.go
@@ -1,0 +1,159 @@
+// Copyright 2018 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+package protocols
+
+import "github.com/ethereum/go-ethereum/metrics"
+
+//define some metrics
+var (
+	//NOTE: these metrics just define the interfaces and are currently *NOT persisted* over sessions
+	//All metrics are cumulative
+
+	//total amount of units credited
+	mBalanceCredit = metrics.NewRegisteredCounterForced("account.balance.credit", nil)
+	//total amount of units debited
+	mBalanceDebit = metrics.NewRegisteredCounterForced("account.balance.debit", nil)
+	//total amount of bytes credited
+	mBytesCredit = metrics.NewRegisteredCounterForced("account.bytes.credit", nil)
+	//total amount of bytes debited
+	mBytesDebit = metrics.NewRegisteredCounterForced("account.bytes.debit", nil)
+	//total amount of credited messages
+	mMsgCredit = metrics.NewRegisteredCounterForced("account.msg.credit", nil)
+	//total amount of debited messages
+	mMsgDebit = metrics.NewRegisteredCounterForced("account.msg.debit", nil)
+	//how many times local node had to drop remote peers
+	mPeerDrops = metrics.NewRegisteredCounterForced("account.peerdrops", nil)
+	//how many times local node overdrafted and dropped
+	mSelfDrops = metrics.NewRegisteredCounterForced("account.selfdrops", nil)
+	//how many cheques have been issued
+	//mChequesIssued = metrics.NewRegisteredCounterForced("account.cheques.issued", nil)
+	//how many cheques have been received
+	//mChequesReceived = metrics.NewRegisteredCounterForced("account.cheques.received", nil)
+)
+
+//Prices defines how prices are being passed on to the accounting instance
+type Prices interface {
+	//Return the Price for a message
+	Price(interface{}) *Price
+}
+
+type Payer bool
+
+const (
+	Sender   = Payer(true)
+	Receiver = Payer(false)
+)
+
+//Price represents the costs of a message
+type Price struct {
+	Value   uint64 //
+	PerByte bool   //True if the price is per byte or for unit
+	Payer   Payer
+}
+
+//ForSender gives back the price for sending a message
+func (p *Price) For(payer Payer, size uint32) int64 {
+	price := p.Value
+	if p.PerByte {
+		price *= uint64(size)
+	}
+	if p.Payer == payer {
+		return 0 - int64(price)
+	}
+	return int64(price)
+}
+
+//Balance is the actual accounting instance
+//Balance defines the operations needed for accounting
+//Implementations internally maintain the balance for every peer
+type Balance interface {
+	//Adds amount to the local balance with remote node `peer`;
+	//positive amount = credit local node
+	//negative amount = debit local node
+	Add(amount int64, peer *Peer) error
+}
+
+//Accounting implements the Hook interface
+//It interfaces to the balances through the Balance interface,
+//while interfacing with protocols and its prices through the Prices interface
+type Accounting struct {
+	Balance //interface to accounting logic
+	Prices  //interface to prices logic
+}
+
+func NewAccounting(balance Balance, po Prices) *Accounting {
+	ah := &Accounting{
+		Prices:  po,
+		Balance: balance,
+	}
+	return ah
+}
+
+//Implement Hook.Send
+func (ah *Accounting) Send(peer *Peer, size uint32, msg interface{}) error {
+	//get the price for a message (through the protocol spec)
+	price := ah.Price(msg)
+	//this message doesn't need accounting
+	if price == nil {
+		return nil
+	}
+	//evaluate the price for sending messages
+	costToLocalNode := price.For(Sender, size)
+	//do the accounting
+	err := ah.Add(costToLocalNode, peer)
+	//record metrics
+	ah.doMetrics(costToLocalNode, size, err)
+	return err
+}
+
+//Implement Hook.Receive
+func (ah *Accounting) Receive(peer *Peer, size uint32, msg interface{}) error {
+	//get the price for a message (through the protocol spec)
+	price := ah.Price(msg)
+	//this message doesn't need accounting
+	if price == nil {
+		return nil
+	}
+	//evaluate the price for receiving messages
+	costToLocalNode := price.For(Receiver, size)
+	//do the accounting
+	err := ah.Add(costToLocalNode, peer)
+	//record metrics
+	ah.doMetrics(costToLocalNode, size, err)
+	return err
+}
+
+//record some metrics
+func (ah *Accounting) doMetrics(price int64, size uint32, err error) {
+	/*
+		if price > 0 {
+			mBalanceCredit.Inc(int64(price))
+			mBytesCredit.Inc(int64(size))
+			mMsgCredit.Inc(1)
+			if err != nil {
+				mPeerDrops.Inc(1)
+			}
+		} else {
+			mBalanceDebit.Inc(int64(price))
+			mBytesDebit.Inc(int64(size))
+			mMsgDebit.Inc(1)
+			if err != nil {
+				mSelfDrops.Inc(1)
+			}
+		}
+	*/
+}

--- a/p2p/protocols/accounting_simulation_test.go
+++ b/p2p/protocols/accounting_simulation_test.go
@@ -1,3 +1,19 @@
+// Copyright 2018 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
 package protocols
 
 import (
@@ -27,8 +43,8 @@ const (
 )
 
 var (
-	nodes    = flag.Int("nodes", 30, "number of nodes to create (default 10)")
-	msgs     = flag.Int("msgs", 100, "number of messages sent by node (default 10)")
+	nodes    = flag.Int("nodes", 30, "number of nodes to create (default 30)")
+	msgs     = flag.Int("msgs", 100, "number of messages sent by node (default 100)")
 	loglevel = flag.Int("loglevel", 0, "verbosity of logs")
 	rawlog   = flag.Bool("rawlog", false, "remove terminal formatting from logs")
 )
@@ -39,13 +55,24 @@ func init() {
 	log.Root().SetHandler(log.LvlFilterHandler(log.Lvl(*loglevel), log.StreamHandler(colorable.NewColorableStderr(), log.TerminalFormat(!*rawlog))))
 }
 
+//TestAccountingSimulation runs a p2p/simulations simulation
+//It creates a *nodes number of nodes, connects each one with each other,
+//then sends out a random selection of messages up to *msgs amount of messages
+//from the test protocol spec.
+//The spec has some accounted messages defined through the Prices interface.
+//The test does accounting for all the message exchanged, and then checks
+//that every node has the same balance with a peer, but with opposite signs.
+//Balance(AwithB) = 0 - Balance(BwithA) or Abs|Balance(AwithB)| == Abs|Balance(BwithA)|
 func TestAccountingSimulation(t *testing.T) {
+	//setup the balances objects for every node
 	bal := newBalances(*nodes)
+	//define the node.Service for this test
 	services := adapters.Services{
 		"accounting": func(ctx *adapters.ServiceContext) (node.Service, error) {
 			return bal.newNode(), nil
 		},
 	}
+	//setup the simulation
 	adapter := adapters.NewSimAdapter(services)
 	net := simulations.NewNetwork(adapter, &simulations.NetworkConfig{DefaultService: "accounting"})
 	defer net.Shutdown()
@@ -57,6 +84,8 @@ func TestAccountingSimulation(t *testing.T) {
 		// wait for all of them to arrive
 		bal.wg.Wait()
 		// then trigger a check
+		// the selected node for the trigger is irrelevant,
+		// we just want to trigger the end of the simulation
 		trigger <- net.Nodes[0].ID()
 	}()
 
@@ -102,10 +131,6 @@ func TestAccountingSimulation(t *testing.T) {
 		},
 	})
 
-	// check if balance matrix is symmetric
-	if err := bal.symmetric(); err != nil {
-		t.Fatal(err)
-	}
 	if result.Error != nil {
 		t.Fatal(result.Error)
 	}
@@ -116,11 +141,19 @@ func TestAccountingSimulation(t *testing.T) {
 	}
 }
 
+// matrix is a matrix of nodes and its balances
+// matrix is in fact a linear array of size n*n,
+// so the balance for any node A with B is at index
+// A*n + B, while the balance of node B with A is at
+// B*n + A
+// (n entries in the array will not be filled -
+//  the balance of a node with itself)
 type matrix struct {
-	n int
-	m []int64
+	n int     //number of nodes
+	m []int64 //array of balances
 }
 
+// create a new matrix
 func newMatrix(n int) *matrix {
 	return &matrix{
 		n: n,
@@ -128,16 +161,24 @@ func newMatrix(n int) *matrix {
 	}
 }
 
+// called from the testBalance's Add accounting function: register balance change
 func (m *matrix) add(i, j int, v int64) error {
+	// index for the balance of local node i with remote nodde j is
+	// i * number of nodes + remote node
 	mi := i*m.n + j
+	// register that balance
 	m.m[mi] += v
 	return nil
 }
 
+// check that the balances are symmetric:
+// balance of node i with node j is the same as j with i but with inverted signs
 func (m *matrix) symmetric() error {
+	//iterate all nodes
 	for i := 0; i < m.n; i++ {
+		//iterate starting +1
 		for j := i + 1; j < m.n; j++ {
-			log.Warn("bal", "1", i, "2", j, "i,j", m.m[i*m.n+j], "j,i", m.m[j*m.n+i])
+			log.Debug("bal", "1", i, "2", j, "i,j", m.m[i*m.n+j], "j,i", m.m[j*m.n+i])
 			if m.m[i*m.n+j] != -m.m[j*m.n+i] {
 				return fmt.Errorf("value mismatch. m[%v, %v] = %v; m[%v, %v] = %v", i, j, m.m[i*m.n+j], j, i, m.m[j*m.n+i])
 			}
@@ -146,6 +187,7 @@ func (m *matrix) symmetric() error {
 	return nil
 }
 
+// all the balances
 type balances struct {
 	i int
 	*matrix
@@ -161,12 +203,13 @@ func newBalances(n int) *balances {
 	}
 }
 
+// create a new testNode for every node created as part of the service
 func (b *balances) newNode() *testNode {
 	defer func() { b.i++ }()
 	return &testNode{
 		bal:   b,
 		i:     b.i,
-		peers: make([]*testPeer, b.n),
+		peers: make([]*testPeer, b.n), //a node will be connected to n-1 peers
 	}
 }
 
@@ -178,30 +221,39 @@ type testNode struct {
 	peerCount int
 }
 
+// do the accounting for the peer's test protocol
+// testNode implements protocols.Balance
 func (t *testNode) Add(a int64, p *Peer) error {
+	//get the index for the remote peer
 	remote := t.bal.id2n[p.ID()]
-	log.Warn("add", "local", t.i, "remote", remote, "amount", a)
+	log.Debug("add", "local", t.i, "remote", remote, "amount", a)
 	return t.bal.add(t.i, remote, a)
 }
 
+//run the p2p protocol
+//for every node, represented by testNode, create a remote testPeer
 func (t *testNode) run(p *p2p.Peer, rw p2p.MsgReadWriter) error {
 	spec := createTestSpec()
+	//create accounting hook
 	spec.Hook = NewAccounting(t, &dummyPrices{})
 
+	//create a peer for this node
 	tp := &testPeer{NewPeer(p, rw, spec), t.i, t.bal.id2n[p.ID()], t.bal.wg}
 	t.lock.Lock()
 	t.peers[t.bal.id2n[p.ID()]] = tp
 	t.peerCount++
 	if t.peerCount == t.bal.n-1 {
+		//when all peer connections are established, start sending messages from this peer
 		go t.send()
 	}
 	t.lock.Unlock()
 	return tp.Run(tp.handle)
 }
 
+// p2p message receive handler function
 func (tp *testPeer) handle(ctx context.Context, msg interface{}) error {
 	tp.wg.Done()
-	log.Warn("receive", "from", tp.remote, "to", tp.local, "type", reflect.TypeOf(msg), "msg", msg)
+	log.Debug("receive", "from", tp.remote, "to", tp.local, "type", reflect.TypeOf(msg), "msg", msg)
 	return nil
 }
 
@@ -212,8 +264,9 @@ type testPeer struct {
 }
 
 func (t *testNode) send() {
-	log.Warn("start sending")
+	log.Debug("start sending")
 	for i := 0; i < *msgs; i++ {
+		//determine randomly to which peer to send
 		whom := rand.Intn(t.bal.n - 1)
 		if whom >= t.i {
 			whom++
@@ -222,6 +275,7 @@ func (t *testNode) send() {
 		p := t.peers[whom]
 		t.lock.Unlock()
 
+		//determine a random message from the spec's messages to be sent
 		which := rand.Intn(len(p.spec.Messages))
 		msg := p.spec.Messages[which]
 		switch msg.(type) {
@@ -230,11 +284,12 @@ func (t *testNode) send() {
 		case *perBytesMsgSenderPays:
 			msg = &perBytesMsgSenderPays{Content: content[:rand.Intn(len(content))]}
 		}
-		log.Warn("send", "from", t.i, "to", whom, "type", reflect.TypeOf(msg), "msg", msg)
+		log.Debug("send", "from", t.i, "to", whom, "type", reflect.TypeOf(msg), "msg", msg)
 		p.Send(context.TODO(), msg)
 	}
 }
 
+// define the protocol
 func (t *testNode) Protocols() []p2p.Protocol {
 	return []p2p.Protocol{{
 		Length: 100,

--- a/p2p/protocols/accounting_simulation_test.go
+++ b/p2p/protocols/accounting_simulation_test.go
@@ -1,0 +1,255 @@
+package protocols
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"math/rand"
+	"reflect"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/mattn/go-colorable"
+
+	"github.com/ethereum/go-ethereum/log"
+	"github.com/ethereum/go-ethereum/rpc"
+
+	"github.com/ethereum/go-ethereum/node"
+	"github.com/ethereum/go-ethereum/p2p"
+	"github.com/ethereum/go-ethereum/p2p/enode"
+	"github.com/ethereum/go-ethereum/p2p/simulations"
+	"github.com/ethereum/go-ethereum/p2p/simulations/adapters"
+)
+
+const (
+	content = "123456789"
+)
+
+var (
+	nodes    = flag.Int("nodes", 30, "number of nodes to create (default 10)")
+	msgs     = flag.Int("msgs", 100, "number of messages sent by node (default 10)")
+	loglevel = flag.Int("loglevel", 0, "verbosity of logs")
+	rawlog   = flag.Bool("rawlog", false, "remove terminal formatting from logs")
+)
+
+func init() {
+	flag.Parse()
+	log.PrintOrigins(true)
+	log.Root().SetHandler(log.LvlFilterHandler(log.Lvl(*loglevel), log.StreamHandler(colorable.NewColorableStderr(), log.TerminalFormat(!*rawlog))))
+}
+
+func TestAccountingSimulation(t *testing.T) {
+	bal := newBalances(*nodes)
+	services := adapters.Services{
+		"accounting": func(ctx *adapters.ServiceContext) (node.Service, error) {
+			return bal.newNode(), nil
+		},
+	}
+	adapter := adapters.NewSimAdapter(services)
+	net := simulations.NewNetwork(adapter, &simulations.NetworkConfig{DefaultService: "accounting"})
+	defer net.Shutdown()
+
+	// we send msgs messages per node, wait for all messages to arrive
+	bal.wg.Add(*nodes * *msgs)
+	trigger := make(chan enode.ID)
+	go func() {
+		// wait for all of them to arrive
+		bal.wg.Wait()
+		// then trigger a check
+		trigger <- net.Nodes[0].ID()
+	}()
+
+	// create nodes and start them
+	for i := 0; i < *nodes; i++ {
+		conf := adapters.RandomNodeConfig()
+		bal.id2n[conf.ID] = i
+		if _, err := net.NewNodeWithConfig(conf); err != nil {
+			t.Fatal(err)
+		}
+		if err := net.Start(conf.ID); err != nil {
+			t.Fatal(err)
+		}
+	}
+	// fully connect nodes
+	for i, n := range net.Nodes {
+		for _, m := range net.Nodes[i+1:] {
+			if err := net.Connect(n.ID(), m.ID()); err != nil {
+				t.Fatal(err)
+			}
+		}
+	}
+
+	// empty action
+	action := func(ctx context.Context) error {
+		return nil
+	}
+	// 	check always checks out
+	check := func(ctx context.Context, id enode.ID) (bool, error) {
+		return true, nil
+	}
+
+	// run simulation
+	timeout := 30 * time.Second
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+	result := simulations.NewSimulation(net).Run(ctx, &simulations.Step{
+		Action:  action,
+		Trigger: trigger,
+		Expect: &simulations.Expectation{
+			Nodes: []enode.ID{net.Nodes[0].ID()},
+			Check: check,
+		},
+	})
+
+	// check if balance matrix is symmetric
+	if err := bal.symmetric(); err != nil {
+		t.Fatal(err)
+	}
+	if result.Error != nil {
+		t.Fatal(result.Error)
+	}
+
+	// check if balance matrix is symmetric
+	if err := bal.symmetric(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+type matrix struct {
+	n int
+	m []int64
+}
+
+func newMatrix(n int) *matrix {
+	return &matrix{
+		n: n,
+		m: make([]int64, n*n),
+	}
+}
+
+func (m *matrix) add(i, j int, v int64) error {
+	mi := i*m.n + j
+	m.m[mi] += v
+	return nil
+}
+
+func (m *matrix) symmetric() error {
+	for i := 0; i < m.n; i++ {
+		for j := i + 1; j < m.n; j++ {
+			log.Warn("bal", "1", i, "2", j, "i,j", m.m[i*m.n+j], "j,i", m.m[j*m.n+i])
+			if m.m[i*m.n+j] != -m.m[j*m.n+i] {
+				return fmt.Errorf("value mismatch. m[%v, %v] = %v; m[%v, %v] = %v", i, j, m.m[i*m.n+j], j, i, m.m[j*m.n+i])
+			}
+		}
+	}
+	return nil
+}
+
+type balances struct {
+	i int
+	*matrix
+	id2n map[enode.ID]int
+	wg   *sync.WaitGroup
+}
+
+func newBalances(n int) *balances {
+	return &balances{
+		matrix: newMatrix(n),
+		id2n:   make(map[enode.ID]int),
+		wg:     &sync.WaitGroup{},
+	}
+}
+
+func (b *balances) newNode() *testNode {
+	defer func() { b.i++ }()
+	return &testNode{
+		bal:   b,
+		i:     b.i,
+		peers: make([]*testPeer, b.n),
+	}
+}
+
+type testNode struct {
+	bal       *balances
+	i         int
+	lock      sync.Mutex
+	peers     []*testPeer
+	peerCount int
+}
+
+func (t *testNode) Add(a int64, p *Peer) error {
+	remote := t.bal.id2n[p.ID()]
+	log.Warn("add", "local", t.i, "remote", remote, "amount", a)
+	return t.bal.add(t.i, remote, a)
+}
+
+func (t *testNode) run(p *p2p.Peer, rw p2p.MsgReadWriter) error {
+	spec := createTestSpec()
+	spec.Hook = NewAccounting(t, &dummyPrices{})
+
+	tp := &testPeer{NewPeer(p, rw, spec), t.i, t.bal.id2n[p.ID()], t.bal.wg}
+	t.lock.Lock()
+	t.peers[t.bal.id2n[p.ID()]] = tp
+	t.peerCount++
+	if t.peerCount == t.bal.n-1 {
+		go t.send()
+	}
+	t.lock.Unlock()
+	return tp.Run(tp.handle)
+}
+
+func (tp *testPeer) handle(ctx context.Context, msg interface{}) error {
+	tp.wg.Done()
+	log.Warn("receive", "from", tp.remote, "to", tp.local, "type", reflect.TypeOf(msg), "msg", msg)
+	return nil
+}
+
+type testPeer struct {
+	*Peer
+	local, remote int
+	wg            *sync.WaitGroup
+}
+
+func (t *testNode) send() {
+	log.Warn("start sending")
+	for i := 0; i < *msgs; i++ {
+		whom := rand.Intn(t.bal.n - 1)
+		if whom >= t.i {
+			whom++
+		}
+		t.lock.Lock()
+		p := t.peers[whom]
+		t.lock.Unlock()
+
+		which := rand.Intn(len(p.spec.Messages))
+		msg := p.spec.Messages[which]
+		switch msg.(type) {
+		case *perBytesMsgReceiverPays:
+			msg = &perBytesMsgReceiverPays{Content: content[:rand.Intn(len(content))]}
+		case *perBytesMsgSenderPays:
+			msg = &perBytesMsgSenderPays{Content: content[:rand.Intn(len(content))]}
+		}
+		log.Warn("send", "from", t.i, "to", whom, "type", reflect.TypeOf(msg), "msg", msg)
+		p.Send(context.TODO(), msg)
+	}
+}
+
+func (t *testNode) Protocols() []p2p.Protocol {
+	return []p2p.Protocol{{
+		Length: 100,
+		Run:    t.run,
+	}}
+}
+
+func (t *testNode) APIs() []rpc.API {
+	return nil
+}
+
+func (t *testNode) Start(server *p2p.Server) error {
+	return nil
+}
+
+func (t *testNode) Stop() error {
+	return nil
+}

--- a/p2p/protocols/accounting_test.go
+++ b/p2p/protocols/accounting_test.go
@@ -424,12 +424,12 @@ func createTestSpec() *Spec {
 		Version:    42,
 		MaxMsgSize: 10 * 1024,
 		Messages: []interface{}{
-			perBytesMsgReceiverPays{},
-			perBytesMsgSenderPays{},
-			perUnitMsgReceiverPays{},
-			perUnitMsgSenderPays{},
-			zeroPriceMsg{},
-			nilPriceMsg{},
+			&perBytesMsgReceiverPays{},
+			&perBytesMsgSenderPays{},
+			&perUnitMsgReceiverPays{},
+			&perUnitMsgSenderPays{},
+			&zeroPriceMsg{},
+			&nilPriceMsg{},
 		},
 	}
 	return spec

--- a/p2p/protocols/accounting_test.go
+++ b/p2p/protocols/accounting_test.go
@@ -1,0 +1,356 @@
+// Copyright 2018 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+package protocols
+
+import (
+	"bytes"
+	"context"
+	"testing"
+	"time"
+
+	"github.com/ethereum/go-ethereum/p2p"
+	"github.com/ethereum/go-ethereum/p2p/simulations/adapters"
+	"github.com/ethereum/go-ethereum/rlp"
+)
+
+//dummy Balance implementation
+type dummyBalance struct {
+	amount int64
+	peer   *Peer
+}
+
+//dummy Prices implementation
+type dummyPrices struct{}
+
+//a dummy message which needs size based accounting
+//sender pays
+type perBytesMsgSenderPays struct {
+	Content string
+}
+
+//a dummy message which needs size based accounting
+//receiver pays
+type perBytesMsgReceiverPays struct {
+	Content string
+}
+
+//a dummy message which is paid for per unit
+//sender pays
+type perUnitMsgSenderPays struct{}
+
+//receiver pays
+type perUnitMsgReceiverPays struct{}
+
+//a dummy message which has zero as its price
+type zeroPriceMsg struct{}
+
+//a dummy message which has no accounting
+type nilPriceMsg struct{}
+
+//return the price for the defined messages
+func (d *dummyPrices) Price(msg interface{}) *Price {
+	switch msg.(type) {
+	//size based message cost, receiver pays
+	case *perBytesMsgReceiverPays:
+		return &Price{
+			PerByte: true,
+			Value:   uint64(100),
+			Payer:   Receiver,
+		}
+	//size based message cost, sender pays
+	case *perBytesMsgSenderPays:
+		return &Price{
+			PerByte: true,
+			Value:   uint64(100),
+			Payer:   Sender,
+		}
+		//unitary cost, receiver pays
+	case *perUnitMsgReceiverPays:
+		return &Price{
+			PerByte: false,
+			Value:   uint64(99),
+			Payer:   Receiver,
+		}
+		//unitary cost, sender pays
+	case *perUnitMsgSenderPays:
+		return &Price{
+			PerByte: false,
+			Value:   uint64(99),
+			Payer:   Sender,
+		}
+	case *zeroPriceMsg:
+		return &Price{
+			PerByte: false,
+			Value:   uint64(0),
+			Payer:   Sender,
+		}
+	case *nilPriceMsg:
+		return nil
+	}
+	return nil
+}
+
+//dummy accounting implementation, only stores values for later check
+func (d *dummyBalance) Add(amount int64, peer *Peer) error {
+	d.amount = amount
+	d.peer = peer
+	return nil
+}
+
+type testCase struct {
+	msg        interface{}
+	size       uint32
+	sendResult int64
+	recvResult int64
+}
+
+//lowest level unit test
+func TestBalance(t *testing.T) {
+	//create instances
+	balance := &dummyBalance{}
+	prices := &dummyPrices{}
+	//create the spec
+	spec := createTestSpec()
+	//create the accounting hook for the spec
+	acc := NewAccounting(balance, prices)
+	//create a peer
+	id := adapters.RandomNodeConfig().ID
+	p := p2p.NewPeer(id, "testPeer", nil)
+	peer := NewPeer(p, &dummyRW{}, spec)
+	//price depends on size, receiver pays
+	msg := &perBytesMsgReceiverPays{Content: "testBalance"}
+	size, _ := rlp.EncodeToBytes(msg)
+
+	testCases := []testCase{
+		{
+			msg,
+			uint32(len(size)),
+			int64(len(size) * 100),
+			int64(len(size) * -100),
+		},
+		{
+			&perBytesMsgSenderPays{Content: "testBalance"},
+			uint32(len(size)),
+			int64(len(size) * -100),
+			int64(len(size) * 100),
+		},
+		{
+			&perUnitMsgSenderPays{},
+			0,
+			int64(-99),
+			int64(99),
+		},
+		{
+			&perUnitMsgReceiverPays{},
+			0,
+			int64(99),
+			int64(-99),
+		},
+		{
+			&zeroPriceMsg{},
+			0,
+			int64(0),
+			int64(0),
+		},
+		{
+			&nilPriceMsg{},
+			0,
+			int64(0),
+			int64(0),
+		},
+	}
+	checkAccountingTestCases(t, testCases, acc, peer, balance, true)
+	checkAccountingTestCases(t, testCases, acc, peer, balance, false)
+}
+
+func TestBalanceWithPeer(t *testing.T) {
+	//create instances
+	balance := &dummyBalance{}
+	prices := &dummyPrices{}
+	//create the spec
+	spec := createTestSpec()
+	//create the accounting hook for the spec
+	spec.Hook = NewAccounting(balance, prices)
+	//create a peer
+	id := adapters.RandomNodeConfig().ID
+	p := p2p.NewPeer(id, "testPeer", nil)
+	peer := NewPeer(p, &dummyRW{}, spec)
+	//price depends on size, receiver pays
+	msg := &perBytesMsgReceiverPays{Content: "testBalance"}
+	size, _ := rlp.EncodeToBytes(msg)
+	testCases := []testCase{
+		{
+			msg,
+			uint32(len(size)),
+			int64(len(size) * 100),
+			int64(len(size) * -100),
+		},
+		{
+			&perBytesMsgSenderPays{Content: "testBalance"},
+			uint32(len(size)),
+			int64(len(size) * -100),
+			int64(len(size) * 100),
+		},
+		{
+			&perUnitMsgSenderPays{},
+			0,
+			int64(-99),
+			int64(99),
+		},
+		{
+			&perUnitMsgReceiverPays{},
+			0,
+			int64(99),
+			int64(-99),
+		},
+		{
+			&zeroPriceMsg{},
+			0,
+			int64(0),
+			int64(0),
+		},
+		{
+			&nilPriceMsg{},
+			0,
+			int64(0),
+			int64(0),
+		},
+	}
+	checkPeerTestCases(t, testCases, peer, balance, spec, true)
+	checkPeerTestCases(t, testCases, peer, balance, spec, false)
+}
+
+func TestAccountedMsgSimulation(t *testing.T) {
+
+	/*
+		  using this type of simulation introduces circular dependency
+			and drags the swap package into this package
+
+			sim := simulation.New(map[string]simulation.ServiceFunc{
+				"dummyService": func(ctx *adapters.ServiceContext, bucket *sync.Map) (s node.Service, cleanup func(), err error) {
+				},
+			})
+			defer sim.Close()
+	*/
+}
+
+func checkAccountingTestCases(t *testing.T, cases []testCase, acc *Accounting, peer *Peer, balance *dummyBalance, send bool) {
+	for _, c := range cases {
+		var err error
+		var expectedResult int64
+		//reset balance before every check
+		balance.amount = 0
+		if send {
+			err = acc.Send(peer, c.size, c.msg)
+			expectedResult = c.sendResult
+		} else {
+			err = acc.Receive(peer, c.size, c.msg)
+			expectedResult = c.recvResult
+		}
+
+		checkResults(t, err, balance, peer, expectedResult)
+	}
+}
+
+func checkPeerTestCases(t *testing.T, cases []testCase, peer *Peer, balance *dummyBalance, spec *Spec, send bool) {
+	for _, c := range cases {
+		var err error
+		var expectedResult int64
+		//reset balance before every check
+		balance.amount = 0
+		var ctx context.Context
+		if send {
+			err = peer.Send(ctx, c.msg)
+			expectedResult = c.sendResult
+		} else {
+			peer.rw.(*dummyRW).msg = c.msg
+			peer.rw.(*dummyRW).code, _ = spec.GetCode(c.msg)
+			err = peer.handleIncoming(func(ctx context.Context, msg interface{}) error {
+				return nil
+			})
+			expectedResult = c.recvResult
+		}
+
+		checkResults(t, err, balance, peer, expectedResult)
+	}
+}
+
+func checkResults(t *testing.T, err error, balance *dummyBalance, peer *Peer, result int64) {
+	if err != nil {
+		t.Fatal(err)
+	}
+	if balance.peer != peer {
+		t.Fatalf("expected Add to be called with peer %v, got %v", peer, balance.peer)
+	}
+	if balance.amount != result {
+		t.Fatalf("Expected balance to be %d but is %d", result, balance.amount)
+	}
+}
+
+//dummy implementation of a MsgReadWriter
+//this allows for quick and easy unit tests without
+//having to build up the complete protocol
+type dummyRW struct {
+	msg  interface{}
+	size uint32
+	code uint64
+}
+
+func (d *dummyRW) WriteMsg(msg p2p.Msg) error {
+	return nil
+}
+
+func (d *dummyRW) ReadMsg() (p2p.Msg, error) {
+	enc := bytes.NewReader(d.getDummyMsg())
+	return p2p.Msg{
+		Code:       d.code,
+		Size:       d.size,
+		Payload:    enc,
+		ReceivedAt: time.Now(),
+	}, nil
+}
+
+func (d *dummyRW) getDummyMsg() []byte {
+	r, _ := rlp.EncodeToBytes(d.msg)
+	var b bytes.Buffer
+	wmsg := WrappedMsg{
+		Context: b.Bytes(),
+		Size:    uint32(len(r)),
+		Payload: r,
+	}
+	rr, _ := rlp.EncodeToBytes(wmsg)
+	d.size = uint32(len(rr))
+	return rr
+}
+
+//create a test spec
+func createTestSpec() *Spec {
+	spec := &Spec{
+		Name:       "test",
+		Version:    42,
+		MaxMsgSize: 10 * 1024,
+		Messages: []interface{}{
+			perBytesMsgReceiverPays{},
+			perBytesMsgSenderPays{},
+			perUnitMsgReceiverPays{},
+			perUnitMsgSenderPays{},
+			zeroPriceMsg{},
+			nilPriceMsg{},
+		},
+	}
+	return spec
+}

--- a/p2p/protocols/accounting_test.go
+++ b/p2p/protocols/accounting_test.go
@@ -20,7 +20,6 @@ import (
 	"testing"
 
 	"github.com/ethereum/go-ethereum/p2p"
-	"github.com/ethereum/go-ethereum/p2p/enode"
 	"github.com/ethereum/go-ethereum/p2p/simulations/adapters"
 	"github.com/ethereum/go-ethereum/rlp"
 )
@@ -29,11 +28,6 @@ import (
 type dummyBalance struct {
 	amount int64
 	peer   *Peer
-}
-
-//dummy Balance implementation
-type testExchangeBalance struct {
-	balances map[enode.ID]int64
 }
 
 //dummy Prices implementation
@@ -111,12 +105,6 @@ func (d *dummyPrices) Price(msg interface{}) *Price {
 func (d *dummyBalance) Add(amount int64, peer *Peer) error {
 	d.amount = amount
 	d.peer = peer
-	return nil
-}
-
-//test exchanges balance implementation
-func (d *testExchangeBalance) Add(amount int64, peer *Peer) error {
-	d.balances[peer.ID()] += amount
 	return nil
 }
 

--- a/p2p/protocols/protocol.go
+++ b/p2p/protocols/protocol.go
@@ -32,6 +32,7 @@ import (
 	"bufio"
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"reflect"
@@ -122,6 +123,16 @@ type WrappedMsg struct {
 	Payload []byte
 }
 
+//For accounting, the design is to allow the Spec to describe which and how its messages are priced
+//To access this functionality, we provide a Hook interface which will call accounting methods
+//NOTE: there could be more such (horizontal) hooks in the future
+type Hook interface {
+	//A hook for sending messages
+	Send(peer *Peer, size uint32, msg interface{}) error
+	//A hook for receiving messages
+	Receive(peer *Peer, size uint32, msg interface{}) error
+}
+
 // Spec is a protocol specification including its name and version as well as
 // the types of messages which are exchanged
 type Spec struct {
@@ -140,6 +151,9 @@ type Spec struct {
 	// 0, 1 and 2 respectively)
 	// each message must have a single unique data type
 	Messages []interface{}
+
+	//hook for accounting (could be extended to multiple hooks in the future)
+	Hook Hook
 
 	initOnce sync.Once
 	codes    map[reflect.Type]uint64
@@ -274,6 +288,15 @@ func (p *Peer) Send(ctx context.Context, msg interface{}) error {
 		Payload: r,
 	}
 
+	//if the accounting hook is set, call it
+	if p.spec.Hook != nil {
+		err := p.spec.Hook.Send(p, wmsg.Size, msg)
+		if err != nil {
+			p.Drop(err)
+			return err
+		}
+	}
+
 	code, found := p.spec.GetCode(msg)
 	if !found {
 		return errorf(ErrInvalidMsgType, "%v", code)
@@ -334,6 +357,19 @@ func (p *Peer) handleIncoming(handle func(ctx context.Context, msg interface{}) 
 	}
 	if err := rlp.DecodeBytes(wmsg.Payload, val); err != nil {
 		return errorf(ErrDecode, "<= %v: %v", msg, err)
+	}
+
+	//if the accounting hook is set, call it
+	if p.spec.Hook != nil {
+		if wmsg.Size != uint32(len(wmsg.Payload)) {
+			errMsg := "Advertised message size and payload length don't match"
+			log.Warn(errMsg)
+			p.Drop(errors.New(errMsg))
+		}
+		err := p.spec.Hook.Receive(p, wmsg.Size, val)
+		if err != nil {
+			return err
+		}
 	}
 
 	// call the registered handler callbacks

--- a/p2p/protocols/protocol_test.go
+++ b/p2p/protocols/protocol_test.go
@@ -262,7 +262,7 @@ func TestProtocolHook(t *testing.T) {
 	if testHook.msg == nil || testHook.msg.(*dummyMsg).Content != "handshake" {
 		t.Fatal("Expected msg to be set, but it is not")
 	}
-	if testHook.send != true {
+	if !testHook.send {
 		t.Fatal("Expected a send message, but it is not")
 	}
 	if testHook.peer == nil || testHook.peer.ID() != tester.Nodes[0].ID() {
@@ -290,7 +290,7 @@ func TestProtocolHook(t *testing.T) {
 	if testHook.msg == nil || testHook.msg.(*dummyMsg).Content != "response" {
 		t.Fatal("Expected msg to be set, but it is not")
 	}
-	if testHook.send != false {
+	if testHook.send {
 		t.Fatal("Expected a send message, but it is not")
 	}
 	if testHook.peer == nil || testHook.peer.ID() != tester.Nodes[1].ID() {


### PR DESCRIPTION
This PR introduces the first phase of **p2p accounting** for message exchange, which forms the basis for swarm's incentivization layer and accounting.

This current implementation only does the accounting part, no cryptoeconomic features are implemented yet (price negotiation, claim settling, etc.). This means this implementation just keeps track of how many units are exchanged between nodes and maintains a balance with them.

Basic design:

`p2p/protocols/accounting.go` defines the basic interfaces:

`Balance` defines the actual accounting interface. It only has an `Add` function. This function will be called with a peer instance and an amount. If the amount is negative, then the local node is being debited, if it is positive, the local node is being credited.

`Prices` is an interface that defines how prices are being expected. Every accounted protocol should provide an implementation, and return a Price structure for every message for which it requires accounting. This struct contains a `Value uint64` field, which represents the price for that message. The `PerBytes bool` field specifies if the message needs accounting based on the message size, and the `Payer Payer` field defines who is to be charged for a message, if either a `Sender` or the `Receiver`.

An accounted protocol needs to provide a `Hook` inside its `Spec`, where it defines its messages. The `Hook` contains a `Balance` and a `Prices` interface, which allows the messaging infrastructure to transparently do the accounting.