### PR TITLE
downloader: measure successfull deliveries, not failed

### DIFF
--- a/eth/downloader/statesync.go
+++ b/eth/downloader/statesync.go
@@ -313,11 +313,12 @@ func (s *stateSync) loop() (err error) {
 				s.d.dropPeer(req.peer.id)
 			}
 			// Process all the received blobs and check for stale delivery
-			if err = s.process(req); err != nil {
+			numDelivered, err := s.process(req)
+			if err != nil {
 				log.Warn("Node data write error", "err", err)
 				return err
 			}
-			req.peer.SetNodeDataIdle(len(req.response))
+			req.peer.SetNodeDataIdle(numDelivered)
 		}
 	}
 	return nil
@@ -398,9 +399,11 @@ func (s *stateSync) fillTasks(n int, req *stateReq) {
 // process iterates over a batch of delivered state data, injecting each item
 // into a running state sync, re-queuing any items that were requested but not
 // delivered.
-func (s *stateSync) process(req *stateReq) error {
+// Returns whether the peer actually managed to deliver anything of value,
+// and any error that occurred
+func (s *stateSync) process(req *stateReq) (int, error) {
 	// Collect processing stats and update progress if valid data was received
-	duplicate, unexpected := 0, 0
+	duplicate, unexpected, successfull := 0, 0, 0
 
 	defer func(start time.Time) {
 		if duplicate > 0 || unexpected > 0 {
@@ -410,7 +413,6 @@ func (s *stateSync) process(req *stateReq) error {
 
 	// Iterate over all the delivered data and inject one-by-one into the trie
 	progress := false
-
 	for _, blob := range req.response {
 		prog, hash, err := s.processNodeData(blob)
 		switch err {
@@ -418,12 +420,13 @@ func (s *stateSync) process(req *stateReq) error {
 			s.numUncommitted++
 			s.bytesUncommitted += len(blob)
 			progress = progress || prog
+			successfull++
 		case trie.ErrNotRequested:
 			unexpected++
 		case trie.ErrAlreadyProcessed:
 			duplicate++
 		default:
-			return fmt.Errorf("invalid state node %s: %v", hash.TerminalString(), err)
+			return successfull, fmt.Errorf("invalid state node %s: %v", hash.TerminalString(), err)
 		}
 		if _, ok := req.tasks[hash]; ok {
 			delete(req.tasks, hash)
@@ -441,12 +444,12 @@ func (s *stateSync) process(req *stateReq) error {
 		// If we've requested the node too many times already, it may be a malicious
 		// sync where nobody has the right data. Abort.
 		if len(task.attempts) >= npeers {
-			return fmt.Errorf("state node %s failed with all peers (%d tries, %d peers)", hash.TerminalString(), len(task.attempts), npeers)
+			return successfull, fmt.Errorf("state node %s failed with all peers (%d tries, %d peers)", hash.TerminalString(), len(task.attempts), npeers)
 		}
 		// Missing item, place into the retry queue.
 		s.tasks[hash] = task
 	}
-	return nil
+	return successfull, nil
 }
 
 // processNodeData tries to inject a trie node data blob delivered from a remote


### PR DESCRIPTION
Sometimes, during fast-sync, there's this behaviour:
```
Imported new state entries  count=1556 retry=176  duplicate=527503      unexpected=1463081 
Imported new state entries  count=1536 retry=0    duplicate=527503      unexpected=1463081 
Imported new state entries  count=0    retry=208  duplicate=527544 +41  unexpected=1463248 +167
```
Where the number of `duplicate` and `unexpected` equals the number of `retry`: `41+167 = 208`
```
Imported new state entries  count=2096 retry=208  duplicate=527544      unexpected=1463248 
Imported new state entries  count=1732 retry=0    duplicate=527544      unexpected=1463248 
Imported new state entries  count=0    retry=176  duplicate=527567 +23  unexpected=1463401 +153
```
`153+23 = 176`
```
Imported new state entries  count=1744 retry=0    duplicate=527567      unexpected=1463401 
Imported new state entries  count=1920 retry=0    duplicate=527567      unexpected=1463401 
Imported new state entries  count=1920 retry=0    duplicate=527567      unexpected=1463401 
Imported new state entries  count=0    retry=208  duplicate=527595 +28  unexpected=1463581 +180
```
`180+28 = 208`

## The problem

The likely explanation for this is
- We request `N` items from peer `x` (at time `t0`)
- Peer `x` is slow in delivering them, or delivers only parts of it. We then get  those items delivered from another peer. 
- In `assignTasks`, we now assign `x` with `N` new items, and request those from him (at time `t1`)
- Now, peer `x` delivers the first batch (at time `t2`). Even though we discard everything as `duplicates` and `unexpected`, we still update his throughut measure: he delivered `N` items in the time `t2-t1`. While in actual fact, it took him `t2-t0` to deliver it. 

This PR changes the measurement to look at how many `successfull` deliveries were made, instead of the total count. A more correct approach would be to look at the correct time for the requests, but that would add a lot more tracking overhead. 

Consider this a PoC, I haven't tested it extensively yet.   
