### PR TITLE
p2p/simulations, swarm/network: Custom services in snapshot

### DIFF
--- a/p2p/simulations/http_test.go
+++ b/p2p/simulations/http_test.go
@@ -605,6 +605,7 @@ func TestHTTPSnapshot(t *testing.T) {
 	if err := client.ConnectNode(nodes[0].ID, nodes[1].ID); err != nil {
 		t.Fatalf("error connecting nodes: %s", err)
 	}
+	time.Sleep(time.Second)
 
 	// store some state in the test services
 	states := make([]string, nodeCount)

--- a/p2p/simulations/http_test.go
+++ b/p2p/simulations/http_test.go
@@ -605,7 +605,6 @@ func TestHTTPSnapshot(t *testing.T) {
 	if err := client.ConnectNode(nodes[0].ID, nodes[1].ID); err != nil {
 		t.Fatalf("error connecting nodes: %s", err)
 	}
-	time.Sleep(time.Second)
 
 	// store some state in the test services
 	states := make([]string, nodeCount)

--- a/p2p/simulations/network.go
+++ b/p2p/simulations/network.go
@@ -116,7 +116,7 @@ func (net *Network) NewNodeWithConfig(conf *adapters.NodeConfig) (*Node, error) 
 		Node:   adapterNode,
 		Config: conf,
 	}
-	log.Trace("Node created", "id", conf.ID)
+	log.Trace(fmt.Sprintf("node %v created", conf.ID))
 	net.nodeMap[conf.ID] = len(net.Nodes)
 	net.Nodes = append(net.Nodes, node)
 
@@ -167,7 +167,6 @@ func (net *Network) Start(id enode.ID) error {
 func (net *Network) startWithSnapshots(id enode.ID, snapshots map[string][]byte) error {
 	net.lock.Lock()
 	defer net.lock.Unlock()
-
 	node := net.getNode(id)
 	if node == nil {
 		return fmt.Errorf("node %v does not exist", id)
@@ -175,13 +174,13 @@ func (net *Network) startWithSnapshots(id enode.ID, snapshots map[string][]byte)
 	if node.Up {
 		return fmt.Errorf("node %v already up", id)
 	}
-	log.Trace("Starting node", "id", id, "adapter", net.nodeAdapter.Name())
+	log.Trace(fmt.Sprintf("starting node %v: %v using %v", id, node.Up, net.nodeAdapter.Name()))
 	if err := node.Start(snapshots); err != nil {
-		log.Warn("Node startup failed", "id", id, "err", err)
+		log.Warn(fmt.Sprintf("start up failed: %v", err))
 		return err
 	}
 	node.Up = true
-	log.Info("Started node", "id", id)
+	log.Info(fmt.Sprintf("started node %v: %v", id, node.Up))
 
 	net.events.Send(NewEvent(node))
 
@@ -210,6 +209,7 @@ func (net *Network) watchPeerEvents(id enode.ID, events chan *p2p.PeerEvent, sub
 		defer net.lock.Unlock()
 		node := net.getNode(id)
 		if node == nil {
+			log.Error("Can not find node for id", "id", id)
 			return
 		}
 		node.Up = false
@@ -240,7 +240,7 @@ func (net *Network) watchPeerEvents(id enode.ID, events chan *p2p.PeerEvent, sub
 
 		case err := <-sub.Err():
 			if err != nil {
-				log.Error("Error in peer event subscription", "id", id, "err", err)
+				log.Error(fmt.Sprintf("error getting peer events for node %v", id), "err", err)
 			}
 			return
 		}
@@ -250,6 +250,7 @@ func (net *Network) watchPeerEvents(id enode.ID, events chan *p2p.PeerEvent, sub
 // Stop stops the node with the given ID
 func (net *Network) Stop(id enode.ID) error {
 	net.lock.Lock()
+	defer net.lock.Unlock()
 	node := net.getNode(id)
 	if node == nil {
 		return fmt.Errorf("node %v does not exist", id)
@@ -257,17 +258,12 @@ func (net *Network) Stop(id enode.ID) error {
 	if !node.Up {
 		return fmt.Errorf("node %v already down", id)
 	}
-	node.Up = false
-	net.lock.Unlock()
-
-	err := node.Stop()
-	if err != nil {
-		net.lock.Lock()
-		node.Up = true
-		net.lock.Unlock()
+	if err := node.Stop(); err != nil {
 		return err
 	}
-	log.Info("Stopped node", "id", id, "err", err)
+	node.Up = false
+	log.Info(fmt.Sprintf("stop node %v: %v", id, node.Up))
+
 	net.events.Send(ControlEvent(node))
 	return nil
 }
@@ -275,7 +271,7 @@ func (net *Network) Stop(id enode.ID) error {
 // Connect connects two nodes together by calling the "admin_addPeer" RPC
 // method on the "one" node so that it connects to the "other" node
 func (net *Network) Connect(oneID, otherID enode.ID) error {
-	log.Debug("Connecting nodes with addPeer", "id", oneID, "other", otherID)
+	log.Debug(fmt.Sprintf("connecting %s to %s", oneID, otherID))
 	conn, err := net.InitConn(oneID, otherID)
 	if err != nil {
 		return err
@@ -485,10 +481,10 @@ func (net *Network) InitConn(oneID, otherID enode.ID) (*Conn, error) {
 
 	err = conn.nodesUp()
 	if err != nil {
-		log.Trace("Nodes not up", "err", err)
+		log.Trace(fmt.Sprintf("nodes not up: %v", err))
 		return nil, fmt.Errorf("nodes not up: %v", err)
 	}
-	log.Debug("Connection initiated", "id", oneID, "other", otherID)
+	log.Debug("InitConn - connection initiated")
 	conn.initiated = time.Now()
 	return conn, nil
 }
@@ -496,9 +492,9 @@ func (net *Network) InitConn(oneID, otherID enode.ID) (*Conn, error) {
 // Shutdown stops all nodes in the network and closes the quit channel
 func (net *Network) Shutdown() {
 	for _, node := range net.Nodes {
-		log.Debug("Stopping node", "id", node.ID())
+		log.Debug(fmt.Sprintf("stopping node %s", node.ID().TerminalString()))
 		if err := node.Stop(); err != nil {
-			log.Warn("Can't stop node", "id", node.ID(), "err", err)
+			log.Warn(fmt.Sprintf("error stopping node %s", node.ID().TerminalString()), "err", err)
 		}
 	}
 	close(net.quitc)
@@ -656,7 +652,6 @@ func (net *Network) snapshot(addServices []string, removeServices []string) (*Sn
 	defer net.lock.Unlock()
 	snap := &Snapshot{
 		Nodes: make([]NodeSnapshot, len(net.Nodes)),
-		//Conns: make([]Conn, len(net.Conns)),
 	}
 	for i, node := range net.Nodes {
 		snap.Nodes[i] = NodeSnapshot{Node: *node}
@@ -671,19 +666,15 @@ func (net *Network) snapshot(addServices []string, removeServices []string) (*Sn
 		for _, addSvc := range addServices {
 			haveSvc := false
 			for _, svc := range snap.Nodes[i].Node.Config.Services {
-
 				if svc == addSvc {
 					haveSvc = true
 					break
 				}
-
 			}
 			if !haveSvc {
-				log.Debug("addsvc in network", "addsvc", addSvc)
 				snap.Nodes[i].Node.Config.Services = append(snap.Nodes[i].Node.Config.Services, addSvc)
 			}
 		}
-		log.Debug("nodeservices", "svc", snap.Nodes[i].Node.Config.Services)
 		if len(removeServices) > 0 {
 			var cleanedServices []string
 			for _, svc := range snap.Nodes[i].Node.Config.Services {
@@ -704,7 +695,6 @@ func (net *Network) snapshot(addServices []string, removeServices []string) (*Sn
 	}
 	for _, conn := range net.Conns {
 		if conn.Up {
-			//snap.Conns[i] = *conn
 			snap.Conns = append(snap.Conns, *conn)
 		}
 	}
@@ -756,18 +746,18 @@ func (net *Network) Subscribe(events chan *Event) {
 }
 
 func (net *Network) executeControlEvent(event *Event) {
-	log.Trace("Executing control event", "type", event.Type, "event", event)
+	log.Trace("execute control event", "type", event.Type, "event", event)
 	switch event.Type {
 	case EventTypeNode:
 		if err := net.executeNodeEvent(event); err != nil {
-			log.Error("Error executing node event", "event", event, "err", err)
+			log.Error("error executing node event", "event", event, "err", err)
 		}
 	case EventTypeConn:
 		if err := net.executeConnEvent(event); err != nil {
-			log.Error("Error executing conn event", "event", event, "err", err)
+			log.Error("error executing conn event", "event", event, "err", err)
 		}
 	case EventTypeMsg:
-		log.Warn("Ignoring control msg event")
+		log.Warn("ignoring control msg event")
 	}
 }
 

--- a/p2p/simulations/network.go
+++ b/p2p/simulations/network.go
@@ -116,7 +116,7 @@ func (net *Network) NewNodeWithConfig(conf *adapters.NodeConfig) (*Node, error) 
 		Node:   adapterNode,
 		Config: conf,
 	}
-	log.Trace(fmt.Sprintf("node %v created", conf.ID))
+	log.Trace("Node created", "id", conf.ID)
 	net.nodeMap[conf.ID] = len(net.Nodes)
 	net.Nodes = append(net.Nodes, node)
 
@@ -167,6 +167,7 @@ func (net *Network) Start(id enode.ID) error {
 func (net *Network) startWithSnapshots(id enode.ID, snapshots map[string][]byte) error {
 	net.lock.Lock()
 	defer net.lock.Unlock()
+
 	node := net.getNode(id)
 	if node == nil {
 		return fmt.Errorf("node %v does not exist", id)
@@ -174,13 +175,13 @@ func (net *Network) startWithSnapshots(id enode.ID, snapshots map[string][]byte)
 	if node.Up {
 		return fmt.Errorf("node %v already up", id)
 	}
-	log.Trace(fmt.Sprintf("starting node %v: %v using %v", id, node.Up, net.nodeAdapter.Name()))
+	log.Trace("Starting node", "id", id, "adapter", net.nodeAdapter.Name())
 	if err := node.Start(snapshots); err != nil {
-		log.Warn(fmt.Sprintf("start up failed: %v", err))
+		log.Warn("Node startup failed", "id", id, "err", err)
 		return err
 	}
 	node.Up = true
-	log.Info(fmt.Sprintf("started node %v: %v", id, node.Up))
+	log.Info("Started node", "id", id)
 
 	net.events.Send(NewEvent(node))
 
@@ -209,7 +210,6 @@ func (net *Network) watchPeerEvents(id enode.ID, events chan *p2p.PeerEvent, sub
 		defer net.lock.Unlock()
 		node := net.getNode(id)
 		if node == nil {
-			log.Error("Can not find node for id", "id", id)
 			return
 		}
 		node.Up = false
@@ -240,7 +240,7 @@ func (net *Network) watchPeerEvents(id enode.ID, events chan *p2p.PeerEvent, sub
 
 		case err := <-sub.Err():
 			if err != nil {
-				log.Error(fmt.Sprintf("error getting peer events for node %v", id), "err", err)
+				log.Error("Error in peer event subscription", "id", id, "err", err)
 			}
 			return
 		}
@@ -250,7 +250,6 @@ func (net *Network) watchPeerEvents(id enode.ID, events chan *p2p.PeerEvent, sub
 // Stop stops the node with the given ID
 func (net *Network) Stop(id enode.ID) error {
 	net.lock.Lock()
-	defer net.lock.Unlock()
 	node := net.getNode(id)
 	if node == nil {
 		return fmt.Errorf("node %v does not exist", id)
@@ -258,12 +257,17 @@ func (net *Network) Stop(id enode.ID) error {
 	if !node.Up {
 		return fmt.Errorf("node %v already down", id)
 	}
-	if err := node.Stop(); err != nil {
+	node.Up = false
+	net.lock.Unlock()
+
+	err := node.Stop()
+	if err != nil {
+		net.lock.Lock()
+		node.Up = true
+		net.lock.Unlock()
 		return err
 	}
-	node.Up = false
-	log.Info(fmt.Sprintf("stop node %v: %v", id, node.Up))
-
+	log.Info("Stopped node", "id", id, "err", err)
 	net.events.Send(ControlEvent(node))
 	return nil
 }
@@ -271,7 +275,7 @@ func (net *Network) Stop(id enode.ID) error {
 // Connect connects two nodes together by calling the "admin_addPeer" RPC
 // method on the "one" node so that it connects to the "other" node
 func (net *Network) Connect(oneID, otherID enode.ID) error {
-	log.Debug(fmt.Sprintf("connecting %s to %s", oneID, otherID))
+	log.Debug("Connecting nodes with addPeer", "id", oneID, "other", otherID)
 	conn, err := net.InitConn(oneID, otherID)
 	if err != nil {
 		return err
@@ -481,10 +485,10 @@ func (net *Network) InitConn(oneID, otherID enode.ID) (*Conn, error) {
 
 	err = conn.nodesUp()
 	if err != nil {
-		log.Trace(fmt.Sprintf("nodes not up: %v", err))
+		log.Trace("Nodes not up", "err", err)
 		return nil, fmt.Errorf("nodes not up: %v", err)
 	}
-	log.Debug("InitConn - connection initiated")
+	log.Debug("Connection initiated", "id", oneID, "other", otherID)
 	conn.initiated = time.Now()
 	return conn, nil
 }
@@ -492,9 +496,9 @@ func (net *Network) InitConn(oneID, otherID enode.ID) (*Conn, error) {
 // Shutdown stops all nodes in the network and closes the quit channel
 func (net *Network) Shutdown() {
 	for _, node := range net.Nodes {
-		log.Debug(fmt.Sprintf("stopping node %s", node.ID().TerminalString()))
+		log.Debug("Stopping node", "id", node.ID())
 		if err := node.Stop(); err != nil {
-			log.Warn(fmt.Sprintf("error stopping node %s", node.ID().TerminalString()), "err", err)
+			log.Warn("Can't stop node", "id", node.ID(), "err", err)
 		}
 	}
 	close(net.quitc)
@@ -746,18 +750,18 @@ func (net *Network) Subscribe(events chan *Event) {
 }
 
 func (net *Network) executeControlEvent(event *Event) {
-	log.Trace("execute control event", "type", event.Type, "event", event)
+	log.Trace("Executing control event", "type", event.Type, "event", event)
 	switch event.Type {
 	case EventTypeNode:
 		if err := net.executeNodeEvent(event); err != nil {
-			log.Error("error executing node event", "event", event, "err", err)
+			log.Error("Error executing node event", "event", event, "err", err)
 		}
 	case EventTypeConn:
 		if err := net.executeConnEvent(event); err != nil {
-			log.Error("error executing conn event", "event", event, "err", err)
+			log.Error("Error executing conn event", "event", event, "err", err)
 		}
 	case EventTypeMsg:
-		log.Warn("ignoring control msg event")
+		log.Warn("Ignoring control msg event")
 	}
 }
 

--- a/p2p/simulations/network.go
+++ b/p2p/simulations/network.go
@@ -644,11 +644,19 @@ type NodeSnapshot struct {
 
 // Snapshot creates a network snapshot
 func (net *Network) Snapshot() (*Snapshot, error) {
+	return net.snapshot(nil, nil)
+}
+
+func (net *Network) SnapshotWithServices(addServices []string, removeServices []string) (*Snapshot, error) {
+	return net.snapshot(addServices, removeServices)
+}
+
+func (net *Network) snapshot(addServices []string, removeServices []string) (*Snapshot, error) {
 	net.lock.Lock()
 	defer net.lock.Unlock()
 	snap := &Snapshot{
 		Nodes: make([]NodeSnapshot, len(net.Nodes)),
-		Conns: make([]Conn, len(net.Conns)),
+		//Conns: make([]Conn, len(net.Conns)),
 	}
 	for i, node := range net.Nodes {
 		snap.Nodes[i] = NodeSnapshot{Node: *node}
@@ -660,9 +668,42 @@ func (net *Network) Snapshot() (*Snapshot, error) {
 			return nil, err
 		}
 		snap.Nodes[i].Snapshots = snapshots
+		for _, addSvc := range addServices {
+			haveSvc := false
+			for _, svc := range snap.Nodes[i].Node.Config.Services {
+				if svc == addSvc {
+					haveSvc = true
+					break
+				}
+				if !haveSvc {
+					snap.Nodes[i].Node.Config.Services = append(snap.Nodes[i].Node.Config.Services, addSvc)
+				}
+
+			}
+		}
+		if len(removeServices) > 0 {
+			var cleanedServices []string
+			haveSvc := false
+			for _, svc := range snap.Nodes[i].Node.Config.Services {
+				for _, rmSvc := range removeServices {
+					if rmSvc == svc {
+						haveSvc = true
+						break
+					}
+				}
+				if !haveSvc {
+					cleanedServices = append(cleanedServices, svc)
+				}
+
+			}
+			snap.Nodes[i].Node.Config.Services = cleanedServices
+		}
 	}
-	for i, conn := range net.Conns {
-		snap.Conns[i] = *conn
+	for _, conn := range net.Conns {
+		if conn.Up {
+			//snap.Conns[i] = *conn
+			snap.Conns = append(snap.Conns, *conn)
+		}
 	}
 	return snap, nil
 }

--- a/p2p/simulations/network.go
+++ b/p2p/simulations/network.go
@@ -671,20 +671,23 @@ func (net *Network) snapshot(addServices []string, removeServices []string) (*Sn
 		for _, addSvc := range addServices {
 			haveSvc := false
 			for _, svc := range snap.Nodes[i].Node.Config.Services {
+
 				if svc == addSvc {
 					haveSvc = true
 					break
 				}
-				if !haveSvc {
-					snap.Nodes[i].Node.Config.Services = append(snap.Nodes[i].Node.Config.Services, addSvc)
-				}
 
 			}
+			if !haveSvc {
+				log.Debug("addsvc in network", "addsvc", addSvc)
+				snap.Nodes[i].Node.Config.Services = append(snap.Nodes[i].Node.Config.Services, addSvc)
+			}
 		}
+		log.Debug("nodeservices", "svc", snap.Nodes[i].Node.Config.Services)
 		if len(removeServices) > 0 {
 			var cleanedServices []string
-			haveSvc := false
 			for _, svc := range snap.Nodes[i].Node.Config.Services {
+				haveSvc := false
 				for _, rmSvc := range removeServices {
 					if rmSvc == svc {
 						haveSvc = true

--- a/p2p/simulations/network_test.go
+++ b/p2p/simulations/network_test.go
@@ -18,123 +18,13 @@ package simulations
 
 import (
 	"context"
-	"flag"
 	"fmt"
-	"os"
 	"testing"
 	"time"
 
-	"github.com/ethereum/go-ethereum/log"
-	"github.com/ethereum/go-ethereum/node"
-	"github.com/ethereum/go-ethereum/p2p"
 	"github.com/ethereum/go-ethereum/p2p/enode"
 	"github.com/ethereum/go-ethereum/p2p/simulations/adapters"
-	"github.com/ethereum/go-ethereum/rpc"
 )
-
-var loglevel = flag.Int("loglevel", 2, "verbosity of logs")
-
-func init() {
-	log.Root().SetHandler(log.LvlFilterHandler(log.Lvl(*loglevel), log.StreamHandler(os.Stderr, log.TerminalFormat(true))))
-}
-
-//TestSnapshotExplicit tests that nodes connect and disconnect properly
-//and that the exposed services are as perscribed
-func TestSnapshotExplicit(t *testing.T) {
-	adapter := adapters.NewSimAdapter(adapters.Services{
-		"dummy":  newDummyService,
-		"dummy2": newDummy2Service,
-	})
-	network := NewNetwork(adapter, &NetworkConfig{
-		DefaultService: "dummy",
-	})
-	defer network.Shutdown()
-	nodeCount := 3
-	ids := make([]enode.ID, nodeCount)
-	for i := 0; i < nodeCount; i++ {
-		conf := adapters.RandomNodeConfig()
-		conf.Services = []string{"dummy", "dummy2"}
-		node, err := network.NewNodeWithConfig(conf)
-		if err != nil {
-			t.Fatalf("error creating node: %s", err)
-		}
-		if err := network.Start(node.ID()); err != nil {
-			t.Fatalf("error starting node: %s", err)
-		}
-		ids[i] = node.ID()
-	}
-	var eventsDone = make(chan struct{})
-	count := 2
-	events := make(chan *Event)
-	sub := network.Events().Subscribe(events)
-	go func() {
-		for event := range events {
-			if event.Type == EventTypeConn && !event.Control {
-				count--
-				if count == 0 {
-					eventsDone <- struct{}{}
-					return
-				}
-			}
-		}
-	}()
-	err := network.Connect(ids[0], ids[1])
-	if err != nil {
-		t.Fatal(err)
-	}
-	err = network.Connect(ids[0], ids[2])
-	if err != nil {
-		t.Fatal(err)
-	}
-	<-eventsDone
-	go func() {
-		defer sub.Unsubscribe()
-		for event := range events {
-			if event.Type == EventTypeConn && !event.Control {
-				eventsDone <- struct{}{}
-				return
-			}
-		}
-	}()
-	err = network.Disconnect(ids[0], ids[2])
-	if err != nil {
-		t.Fatal(err)
-	}
-	<-eventsDone
-
-	snap, err := network.Snapshot()
-	if err != nil {
-		t.Fatal(err)
-	}
-	if len(snap.Conns) > 1 {
-		t.Fatalf("expected one connect object")
-	}
-	for _, svc := range snap.Nodes[0].Node.Config.Services {
-		if svc != "dummy" && svc != "dummy2" {
-			t.Fatalf("unexpected service %s", svc)
-		}
-	}
-
-	snap, err = network.SnapshotWithServices([]string{"bzz"}, nil)
-	if err != nil {
-		t.Fatal(err)
-	}
-	for _, svc := range snap.Nodes[0].Node.Config.Services {
-		if svc != "dummy" && svc != "dummy2" && svc != "bzz" {
-			t.Fatalf("unexpected service %s", svc)
-		}
-	}
-
-	snap, err = network.SnapshotWithServices([]string{"bzz"}, []string{"dummy2"})
-	if err != nil {
-		t.Fatal(err)
-	}
-	for _, svc := range snap.Nodes[0].Node.Config.Services {
-		if svc != "dummy" && svc != "bzz" {
-			t.Fatalf("unexpected service %s", svc)
-		}
-	}
-}
 
 // TestNetworkSimulation creates a multi-node simulation network with each node
 // connected in a ring topology, checks that all nodes successfully handshake
@@ -267,29 +157,4 @@ func triggerChecks(ctx context.Context, ids []enode.ID, trigger chan enode.ID, i
 			return
 		}
 	}
-}
-
-type dummyService struct {
-}
-type dummy2Service struct {
-	dummyService
-}
-
-func newDummyService(ctx *adapters.ServiceContext) (node.Service, error) {
-	return &dummyService{}, nil
-}
-func newDummy2Service(ctx *adapters.ServiceContext) (node.Service, error) {
-	return &dummy2Service{}, nil
-}
-func (p *dummyService) APIs() []rpc.API {
-	return []rpc.API{}
-}
-func (p *dummyService) Protocols() []p2p.Protocol {
-	return []p2p.Protocol{}
-}
-func (p *dummyService) Start(server *p2p.Server) error {
-	return nil
-}
-func (p *dummyService) Stop() error {
-	return nil
 }

--- a/swarm/network/simulations/discovery/discovery_test.go
+++ b/swarm/network/simulations/discovery/discovery_test.go
@@ -87,7 +87,7 @@ func getDbStore(nodeID string) (*state.DBStore, error) {
 var (
 	nodeCount       = flag.Int("nodes", 10, "number of nodes to create (default 10)")
 	initCount       = flag.Int("conns", 1, "number of originally connected peers	 (default 1)")
-	snapshotFile    = flag.String("snapshot", "", "create snapshot")
+	snapshotFile    = flag.String("snapshot", "", "path to create snapshot file in")
 	loglevel        = flag.Int("loglevel", 3, "verbosity of logs")
 	rawlog          = flag.Bool("rawlog", false, "remove terminal formatting from logs")
 	serviceOverride = flag.String("services", "", "remove or add services to the node snapshot; prefix with \"+\" to add, \"-\" to remove; example: +pss,-discovery")
@@ -317,6 +317,8 @@ func discoverySimulation(nodes, conns int, adapter adapters.NodeAdapter) (*simul
 					addServices = append(addServices, osvc[1:])
 				} else if strings.Index(osvc, "-") == 0 {
 					removeServices = append(removeServices, osvc[1:])
+				} else {
+					panic("stick to the rules, you know what they are")
 				}
 			}
 			snap, err = net.SnapshotWithServices(addServices, removeServices)

--- a/swarm/network/simulations/discovery/discovery_test.go
+++ b/swarm/network/simulations/discovery/discovery_test.go
@@ -85,11 +85,12 @@ func getDbStore(nodeID string) (*state.DBStore, error) {
 }
 
 var (
-	nodeCount    = flag.Int("nodes", 10, "number of nodes to create (default 10)")
-	initCount    = flag.Int("conns", 1, "number of originally connected peers	 (default 1)")
-	snapshotFile = flag.String("snapshot", "", "create snapshot")
-	loglevel     = flag.Int("loglevel", 3, "verbosity of logs")
-	rawlog       = flag.Bool("rawlog", false, "remove terminal formatting from logs")
+	nodeCount       = flag.Int("nodes", 10, "number of nodes to create (default 10)")
+	initCount       = flag.Int("conns", 1, "number of originally connected peers	 (default 1)")
+	snapshotFile    = flag.String("snapshot", "", "create snapshot")
+	loglevel        = flag.Int("loglevel", 3, "verbosity of logs")
+	rawlog          = flag.Bool("rawlog", false, "remove terminal formatting from logs")
+	serviceOverride = flag.String("services", "", "remove or add services to the node snapshot; prefix with \"+\" to add, \"-\" to remove; example: +pss,-discovery")
 )
 
 func init() {
@@ -306,7 +307,27 @@ func discoverySimulation(nodes, conns int, adapter adapters.NodeAdapter) (*simul
 	}
 
 	if *snapshotFile != "" {
-		snap, err := net.Snapshot()
+		var err error
+		var snap *simulations.Snapshot
+		if len(*serviceOverride) > 0 {
+			log.Debug("fooooo")
+			var addServices []string
+			var removeServices []string
+			for _, osvc := range strings.Split(*serviceOverride, ",") {
+				log.Debug("serviceoverride", "osc", osvc)
+				if strings.Index(osvc, "+") == 0 {
+					log.Debug("add", "a", osvc)
+					addServices = append(addServices, osvc[1:])
+				} else if strings.Index(osvc, "-") == 0 {
+					log.Debug("drop", "d", osvc)
+					removeServices = append(removeServices, osvc[1:])
+				}
+			}
+			snap, err = net.SnapshotWithServices(addServices, removeServices)
+		} else {
+			snap, err = net.Snapshot()
+		}
+
 		if err != nil {
 			return nil, errors.New("no shapshot dude")
 		}

--- a/swarm/network/simulations/discovery/discovery_test.go
+++ b/swarm/network/simulations/discovery/discovery_test.go
@@ -126,22 +126,6 @@ func BenchmarkDiscovery_64_4(b *testing.B)  { benchmarkDiscovery(b, 64, 4) }
 func BenchmarkDiscovery_128_4(b *testing.B) { benchmarkDiscovery(b, 128, 4) }
 func BenchmarkDiscovery_256_4(b *testing.B) { benchmarkDiscovery(b, 256, 4) }
 
-func TestDiscoverySimulationDockerAdapter(t *testing.T) {
-	testDiscoverySimulationDockerAdapter(t, *nodeCount, *initCount)
-}
-
-func testDiscoverySimulationDockerAdapter(t *testing.T, nodes, conns int) {
-	adapter, err := adapters.NewDockerAdapter()
-	if err != nil {
-		if err == adapters.ErrLinuxOnly {
-			t.Skip(err)
-		} else {
-			t.Fatal(err)
-		}
-	}
-	testDiscoverySimulation(t, nodes, conns, adapter)
-}
-
 func TestDiscoverySimulationExecAdapter(t *testing.T) {
 	testDiscoverySimulationExecAdapter(t, *nodeCount, *initCount)
 }
@@ -562,8 +546,7 @@ func triggerChecks(trigger chan enode.ID, net *simulations.Network, id enode.ID)
 }
 
 func newService(ctx *adapters.ServiceContext) (node.Service, error) {
-	node := enode.NewV4(&ctx.Config.PrivateKey.PublicKey, adapters.ExternalIP(), int(ctx.Config.Port), int(ctx.Config.Port))
-	addr := network.NewAddr(node)
+	addr := network.NewAddr(ctx.Config.Node())
 
 	kp := network.NewKadParams()
 	kp.MinProxBinSize = testMinProxBinSize


### PR DESCRIPTION
This PR makes it possible to selectively add and remove services from snapshot generated from simulations discovery test. 

It also prunes connection objects that have status down from the generated snapshots.

Note; this uses sleeps for the `TestSnapshotExplicit` test because the timing of peer events and actual changes in state in the simulated nodes seems to be imprecise (and the test in itself is very simple). Fixing this will be a separate PR.