### PR TITLE
GetRefund function: sync.Mutex is passed by value.

### DIFF
--- a/core/vm/logger_test.go
+++ b/core/vm/logger_test.go
@@ -46,7 +46,7 @@ type dummyStatedb struct {
 	state.StateDB
 }
 
-func (dummyStatedb) GetRefund() uint64 { return 1337 }
+func (*dummyStatedb) GetRefund() uint64 { return 1337 }
 
 func TestStoreCapture(t *testing.T) {
 	var (

--- a/eth/tracers/tracer_test.go
+++ b/eth/tracers/tracer_test.go
@@ -48,7 +48,7 @@ type dummyStatedb struct {
 	state.StateDB
 }
 
-func (dummyStatedb) GetRefund() uint64 { return 1337 }
+func (*dummyStatedb) GetRefund() uint64 { return 1337 }
 
 func runTrace(tracer *Tracer) (json.RawMessage, error) {
 	env := vm.NewEVM(vm.Context{BlockNumber: big.NewInt(1)}, &dummyStatedb{}, params.TestChainConfig, vm.Config{Debug: true, Tracer: tracer})


### PR DESCRIPTION
Both vm.dummyStatedb and tracers.dummyStatedb contain github.com/ethereum/go-ethereum/core/state.StateDB, and StateDB contains sync.Mutex, so sync.Mutex is passed by value. It is better to pass it as pointer. Otherwise, there may be deadlock risk if lock being passed into the two functions as a copied value is used in future.