### PR TITLE
core,eth: fixed TrieTimeLimit

### DIFF
--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -92,6 +92,7 @@ var (
 		utils.SyncModeFlag,
 		utils.ExitWhenSyncedFlag,
 		utils.GCModeFlag,
+		utils.TrieTimeoutFlag,
 		utils.LightServFlag,
 		utils.LightPeersFlag,
 		utils.LightKDFFlag,

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -197,6 +197,11 @@ var (
 		Usage: `Blockchain garbage collection mode ("full", "archive")`,
 		Value: "full",
 	}
+	TrieTimeoutFlag = cli.DurationFlag{
+		Name:  "trietimeout",
+		Usage: `Time limit after which to flush the current in-memory trie to disk (default: 10s)`,
+		Value: eth.DefaultConfig.TrieTimeout,
+	}
 	LightServFlag = cli.IntFlag{
 		Name:  "lightserv",
 		Usage: "Maximum percentage of time allowed for serving LES requests (0-90)",
@@ -1588,7 +1593,7 @@ func MakeChain(ctx *cli.Context, stack *node.Node) (chain *core.BlockChain, chai
 		Disabled:       ctx.GlobalString(GCModeFlag.Name) == "archive",
 		TrieCleanLimit: eth.DefaultConfig.TrieCleanCache,
 		TrieDirtyLimit: eth.DefaultConfig.TrieDirtyCache,
-		TrieTimeLimit:  eth.DefaultConfig.TrieTimeout,
+		TrieTimeLimit:  ctx.GlobalDuration(TrieTimeoutFlag.Name),
 	}
 	if ctx.GlobalIsSet(CacheFlag.Name) || ctx.GlobalIsSet(CacheTrieFlag.Name) {
 		cache.TrieCleanLimit = ctx.GlobalInt(CacheFlag.Name) * ctx.GlobalInt(CacheTrieFlag.Name) / 100


### PR DESCRIPTION
**this is a bug report PR.**

fixed `TrieTimeLimit` to flush triedb roughly every ~~30 min~~ ~5 hours, ~1250 blocks

currently, the default `TrieTimeLimit` value is 60 min. but it seems too big.

- about ~8ms consumed per block and it means 30 minutes required per ~120 blocks
- for `TrieTimeLimit: 60 * time.Minute` case. it means `triedb.Commit()` executed after ~460,800 blocks (~80 days)

this PR reduce the default `TrieTimeLimit` value to ~~1 sec~~ 10 sec to flush triedb roughly every ~~30 min~~ ~5 hours
or we can fix `TrieTimeLimit` to 2 sec(~1 hour) or some more acceptable value to fit a realistic situation.