### PR TITLE
cmd/swarm: update should error on manifest mismatch

### DIFF
--- a/cmd/swarm/feeds.go
+++ b/cmd/swarm/feeds.go
@@ -169,13 +169,17 @@ func feedUpdate(ctx *cli.Context) {
 		query = new(feed.Query)
 		query.User = signer.Address()
 		query.Topic = getTopic(ctx)
-
 	}
 
 	// Retrieve a feed update request
 	updateRequest, err = client.GetFeedRequest(query, manifestAddressOrDomain)
 	if err != nil {
 		utils.Fatalf("Error retrieving feed status: %s", err.Error())
+	}
+
+	// Check that the provided signer matches the request to sign
+	if updateRequest.User != signer.Address() {
+		utils.Fatalf("Signer address does not match the update request")
 	}
 
 	// set the new data

--- a/cmd/swarm/feeds_test.go
+++ b/cmd/swarm/feeds_test.go
@@ -19,7 +19,6 @@ package main
 import (
 	"bytes"
 	"encoding/json"
-	"fmt"
 	"io/ioutil"
 	"os"
 	"testing"
@@ -69,7 +68,7 @@ func TestCLIFeedUpdate(t *testing.T) {
 		hexData}
 
 	// create an update and expect an exit without errors
-	log.Info(fmt.Sprintf("updating a feed with 'swarm feed update'"))
+	log.Info("updating a feed with 'swarm feed update'")
 	cmd := runSwarm(t, flags...)
 	cmd.ExpectExit()
 
@@ -116,7 +115,7 @@ func TestCLIFeedUpdate(t *testing.T) {
 		"--user", address.Hex(),
 	}
 
-	log.Info(fmt.Sprintf("getting feed info with 'swarm feed info'"))
+	log.Info("getting feed info with 'swarm feed info'")
 	cmd = runSwarm(t, flags...)
 	_, matches := cmd.ExpectRegexp(`.*`) // regex hack to extract stdout
 	cmd.ExpectExit()
@@ -141,7 +140,7 @@ func TestCLIFeedUpdate(t *testing.T) {
 		"--topic", topic.Hex(),
 	}
 
-	log.Info(fmt.Sprintf("Publishing manifest with 'swarm feed create'"))
+	log.Info("Publishing manifest with 'swarm feed create'")
 	cmd = runSwarm(t, flags...)
 	_, matches = cmd.ExpectRegexp(`[a-f\d]{64}`) // regex hack to extract stdout
 	cmd.ExpectExit()
@@ -166,13 +165,12 @@ func TestCLIFeedUpdate(t *testing.T) {
 	// test publishing a manifest for a different user
 	flags = []string{
 		"--bzzapi", srv.URL,
-		"--bzzaccount", pkFileName,
 		"feed", "create",
 		"--topic", topic.Hex(),
 		"--user", "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", // different user
 	}
 
-	log.Info(fmt.Sprintf("Publishing manifest with 'swarm feed create' for a different user"))
+	log.Info("Publishing manifest with 'swarm feed create' for a different user")
 	cmd = runSwarm(t, flags...)
 	_, matches = cmd.ExpectRegexp(`[a-f\d]{64}`) // regex hack to extract stdout
 	cmd.ExpectExit()
@@ -187,8 +185,8 @@ func TestCLIFeedUpdate(t *testing.T) {
 		"--manifest", manifestAddress,
 		hexData}
 
-	// create an update and expect an exit without errors
-	log.Info(fmt.Sprintf("updating a feed with 'swarm feed update'"))
+	// create an update and expect an error given there is a user mismatch
+	log.Info("updating a feed with 'swarm feed update'")
 	cmd = runSwarm(t, flags...)
 	cmd.ExpectRegexp("Fatal:.*") // best way so far to detect a failure.
 	cmd.ExpectExit()

--- a/cmd/swarm/feeds_test.go
+++ b/cmd/swarm/feeds_test.go
@@ -142,7 +142,7 @@ func TestCLIFeedUpdate(t *testing.T) {
 
 	log.Info("Publishing manifest with 'swarm feed create'")
 	cmd = runSwarm(t, flags...)
-	_, matches = cmd.ExpectRegexp(`[a-f\d]{64}`) // regex hack to extract stdout
+	_, matches = cmd.ExpectRegexp(`[a-f\d]{64}`)
 	cmd.ExpectExit()
 
 	manifestAddress := matches[0] // read the received feed manifest
@@ -172,7 +172,7 @@ func TestCLIFeedUpdate(t *testing.T) {
 
 	log.Info("Publishing manifest with 'swarm feed create' for a different user")
 	cmd = runSwarm(t, flags...)
-	_, matches = cmd.ExpectRegexp(`[a-f\d]{64}`) // regex hack to extract stdout
+	_, matches = cmd.ExpectRegexp(`[a-f\d]{64}`)
 	cmd.ExpectExit()
 
 	manifestAddress = matches[0] // read the received feed manifest


### PR DESCRIPTION
This PR fixes https://github.com/ethersphere/go-ethereum/issues/979. The CLI will now return with an error if attempting to update a manifest that does not match the signer.