### PR TITLE
signer: remove ineffectual assignments

### DIFF
--- a/signer/core/abihelper_test.go
+++ b/signer/core/abihelper_test.go
@@ -38,17 +38,13 @@ func verify(t *testing.T, jsondata, calldata string, exp []interface{}) {
 	cd := common.Hex2Bytes(calldata)
 	sigdata, argdata := cd[:4], cd[4:]
 	method, err := abispec.MethodById(sigdata)
-
 	if err != nil {
 		t.Fatal(err)
 	}
-
 	data, err := method.Inputs.UnpackValues(argdata)
-
 	if err != nil {
 		t.Fatal(err)
 	}
-
 	if len(data) != len(exp) {
 		t.Fatalf("Mismatched length, expected %d, got %d", len(exp), len(data))
 	}

--- a/signer/core/abihelper_test.go
+++ b/signer/core/abihelper_test.go
@@ -45,6 +45,10 @@ func verify(t *testing.T, jsondata, calldata string, exp []interface{}) {
 
 	data, err := method.Inputs.UnpackValues(argdata)
 
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	if len(data) != len(exp) {
 		t.Fatalf("Mismatched length, expected %d, got %d", len(exp), len(data))
 	}

--- a/signer/rules/rules_test.go
+++ b/signer/rules/rules_test.go
@@ -151,7 +151,7 @@ func TestListRequest(t *testing.T) {
 		t.Errorf("Couldn't create evaluator %v", err)
 		return
 	}
-	resp, err := r.ApproveListing(&core.ListRequest{
+	resp, _ := r.ApproveListing(&core.ListRequest{
 		Accounts: accs,
 		Meta:     core.Metadata{Remote: "remoteip", Local: "localip", Scheme: "inproc"},
 	})
@@ -515,7 +515,7 @@ func TestLimitWindow(t *testing.T) {
 		r.OnApprovedTx(response)
 	}
 	// Fourth should fail
-	resp, err := r.ApproveTx(dummyTx(h))
+	resp, _ := r.ApproveTx(dummyTx(h))
 	if resp.Approved {
 		t.Errorf("Expected check to resolve to 'Reject'")
 	}
@@ -609,8 +609,8 @@ func TestContextIsCleared(t *testing.T) {
 		t.Fatalf("Failed to load bootstrap js: %v", err)
 	}
 	tx := dummyTxWithV(0)
-	r1, err := r.ApproveTx(tx)
-	r2, err := r.ApproveTx(tx)
+	r1, _ := r.ApproveTx(tx)
+	r2, _ := r.ApproveTx(tx)
 	if r1.Approved != r2.Approved {
 		t.Errorf("Expected execution context to be cleared between executions")
 	}


### PR DESCRIPTION
This PR fixes some ineffectual assignments as found by https://goreportcard.com/report/github.com/ethereum/go-ethereum#ineffassign