### PR TITLE
internal/web3ext: Add eth.getProof

### DIFF
--- a/internal/web3ext/web3ext.go
+++ b/internal/web3ext/web3ext.go
@@ -481,6 +481,12 @@ web3._extend({
 			params: 2,
 			inputFormatter: [web3._extend.formatters.inputBlockNumberFormatter, web3._extend.utils.toHex]
 		}),
+		new web3._extend.Method({
+			name: 'getProof',
+			call: 'eth_getProof',
+			params: 3,
+			inputFormatter: [web3._extend.formatters.inputAddressFormatter, null, web3._extend.formatters.inputBlockNumberFormatter]
+		}),
 	],
 	properties: [
 		new web3._extend.Property({


### PR DESCRIPTION
I wanted to give `eth_getProof` a test drive but found that it wasn't available in the console provided by `geth attach` so added it to `web3ext`.  It's not 100% clear to me when I should add methods to `web3ext` vs. `internal/jsre/deps/web3.js` (followed by a `go generate`), so I'm happy to change this PR to do the changes in `web3.js` instead if preferred.

Both ways give me the same result (I elided the proof values below with `"..."` to keep this PR text from being too long, in the actual output the correct hex strings are output.

```
> eth.getProof("0x09d8b66c48424324b25754a873e290cae5dca439", ["0x0"], "latest")
{
  accountProof: ["...", "...", "...", "...", "...", "...", "...", "..."],
  address: "0x09d8b66c48424324b25754a873e290cae5dca439",
  balance: "0x0",
  codeHash: "0x49a2e4941f66f56811a3ba9153696e692b305bc57c3b4e0a727b8c0c422f275f",
  nonce: "0x1",
  storageHash: "0x8c07d8edd90c3adf163ddcd046e482b1b061fac7fb31e10306aedc8f1d84f26f",
  storageProof: [{
      key: "0x0",
      proof: ["...", "...", "...", "..."],
      value: "0xdff10fcaccc3b18a1604509e9b4d0b9a7091278"
  }]
}
```