### PR TITLE
mobile: Make sync mode configurable

### DIFF
--- a/mobile/geth.go
+++ b/mobile/geth.go
@@ -38,6 +38,13 @@ import (
 	whisper "github.com/ethereum/go-ethereum/whisper/whisperv6"
 )
 
+// I am intentionally duplicating these constants different from downloader.SyncMode integer values, to ensure the
+// backwards compatibility where the mobile node defaults to LightSync.
+const SyncModeUnset = 0 // will be treated as SyncModeLightSync
+const SyncModeFullSync = 1
+const SyncModeFastSync = 2
+const SyncModeLightSync = 3
+
 // NodeConfig represents the collection of configuration values to fine tune the Geth
 // node embedded into a mobile process. The available values are a subset of the
 // entire API provided by go-ethereum to reduce the maintenance surface and dev
@@ -76,6 +83,10 @@ type NodeConfig struct {
 
 	// Listening address of pprof server.
 	PprofAddress string
+
+	// Sync mode for the node (eth/downloader/modes.go)
+	// This has to be integer since Enum exports to Java are not supported by "gomobile"
+	SyncMode int
 }
 
 // defaultNodeConfig contains the default node configuration values to use if all
@@ -186,6 +197,23 @@ func NewNode(datadir string, config *NodeConfig) (stack *Node, _ error) {
 		}
 	}
 	return &Node{rawStack}, nil
+}
+
+func getSyncMode(syncMode int) downloader.SyncMode {
+	switch syncMode {
+	case SyncModeFullSync:
+		return downloader.FullSync
+	case SyncModeFastSync:
+		return downloader.FastSync
+	case SyncModeUnset:
+		fallthrough
+		// If unset, default to light sync.
+		// This maintains backward compatibility.
+	case SyncModeLightSync:
+		return downloader.LightSync
+	default:
+		panic(fmt.Sprintf("Unexpected sync mode value: %d", syncMode))
+	}
 }
 
 // Start creates a live P2P node and starts running it.


### PR DESCRIPTION
Make sync mode configurable. Keep Light as the default sync mode to
maintain backward-compatibility.

The mode can be configured by calling `NodeConfig.setSyncMode()`

Fixes issue https://github.com/ethereum/go-ethereum/issues/17979