### PR TITLE
eth: increase timeout in TestBroadcastBlock

### DIFF
--- a/eth/handler_test.go
+++ b/eth/handler_test.go
@@ -585,7 +585,7 @@ func testBroadcastBlock(t *testing.T, totalPeers, broadcastExpected int) {
 			}
 		}(peer)
 	}
-	timeoutCh := time.NewTimer(time.Millisecond * 100).C
+	timeout := time.After(300 * time.Millisecond)
 	var receivedCount int
 outer:
 	for {
@@ -597,7 +597,7 @@ outer:
 			if receivedCount == totalPeers {
 				break outer
 			}
-		case <-timeoutCh:
+		case <-timeout:
 			break outer
 		}
 	}


### PR DESCRIPTION
TestBroadcastBlock fails occasionally when the CI builder is under heavy load. Increase the
timeout slightly to avoid such failures.