### PR TITLE
metrics, p2p: add ephemeral registry

### DIFF
--- a/metrics/registry.go
+++ b/metrics/registry.go
@@ -311,7 +311,10 @@ func (r *PrefixedRegistry) UnregisterAll() {
 	r.underlying.UnregisterAll()
 }
 
-var DefaultRegistry Registry = NewRegistry()
+var (
+	DefaultRegistry = NewRegistry()
+	EphemeralRegistry = NewRegistry()
+)
 
 // Call the given function for each registered metric.
 func Each(f func(string, interface{})) {

--- a/metrics/registry.go
+++ b/metrics/registry.go
@@ -312,7 +312,7 @@ func (r *PrefixedRegistry) UnregisterAll() {
 }
 
 var (
-	DefaultRegistry = NewRegistry()
+	DefaultRegistry   = NewRegistry()
 	EphemeralRegistry = NewRegistry()
 )
 

--- a/p2p/metrics.go
+++ b/p2p/metrics.go
@@ -47,8 +47,8 @@ var (
 	egressConnectMeter  = metrics.NewRegisteredMeter(MetricsOutboundConnects, nil) // Meter counting the egress connections
 	egressTrafficMeter  = metrics.NewRegisteredMeter(MetricsOutboundTraffic, nil)  // Meter metering the cumulative egress traffic
 
-	PeerIngressRegistry = metrics.NewPrefixedChildRegistry(metrics.DefaultRegistry, MetricsInboundTraffic+"/")  // Registry containing the peer ingress
-	PeerEgressRegistry  = metrics.NewPrefixedChildRegistry(metrics.DefaultRegistry, MetricsOutboundTraffic+"/") // Registry containing the peer egress
+	PeerIngressRegistry = metrics.NewPrefixedChildRegistry(metrics.EphemeralRegistry, MetricsInboundTraffic+"/")  // Registry containing the peer ingress
+	PeerEgressRegistry  = metrics.NewPrefixedChildRegistry(metrics.EphemeralRegistry, MetricsOutboundTraffic+"/") // Registry containing the peer egress
 
 	meteredPeerFeed  event.Feed // Event feed for peer metrics
 	meteredPeerCount int32      // Actually stored peer connection count


### PR DESCRIPTION
This PR creates a separate global registry for the individually metered peers in order to prevent the overflooding of the metrics.