### PR TITLE
Imply that SwarmApiFlag is the API endpoint to connect to, not to lis…

### DIFF
--- a/cmd/swarm/flags.go
+++ b/cmd/swarm/flags.go
@@ -88,7 +88,7 @@ var (
 	}
 	SwarmApiFlag = cli.StringFlag{
 		Name:  "bzzapi",
-		Usage: "Swarm HTTP endpoint",
+		Usage: "Specifies the Swarm HTTP endpoint to connect to",
 		Value: "http://127.0.0.1:8500",
 	}
 	SwarmRecursiveFlag = cli.BoolFlag{


### PR DESCRIPTION
This PR addresses a minor change in the Swarm CLI to disambiguate meaning in regards to the Swarm API flag (previously it might have suggested that this is the listening address/endpoint).

fixes https://github.com/ethersphere/go-ethereum/issues/891