### PR TITLE
JSON-RPC Client notifications + bidirectional communication

### DIFF
--- a/rpc/http.go
+++ b/rpc/http.go
@@ -136,7 +136,7 @@ func (c *Client) sendHTTP(ctx context.Context, op *requestOp, msg interface{}) e
 		}
 		return err
 	}
-	if jsonrequest, ok := msg.(jsonrpcMessage); ok {
+	if jsonrequest, ok := msg.(*jsonrpcMessage); ok {
 		if jsonrequest.isNotification() {
 			// If we send a json-rpc notification, we expect no response
 			return nil

--- a/rpc/http.go
+++ b/rpc/http.go
@@ -136,6 +136,12 @@ func (c *Client) sendHTTP(ctx context.Context, op *requestOp, msg interface{}) e
 		}
 		return err
 	}
+	if jsonrequest, ok := msg.(jsonrpcMessage); ok {
+		if jsonrequest.isNotification() {
+			// If we send a json-rpc notification, we expect no response
+			return nil
+		}
+	}
 	var respmsg jsonrpcMessage
 	if err := json.NewDecoder(respBody).Decode(&respmsg); err != nil {
 		return err

--- a/signer/core/stdioui.go
+++ b/signer/core/stdioui.go
@@ -49,6 +49,15 @@ func (ui *StdIOUI) dispatch(serviceMethod string, args interface{}, reply interf
 	return err
 }
 
+// notify sends a request over the stdio, and does not listen for a response
+func (ui *StdIOUI) notify(serviceMethod string, args interface{}) error {
+	err := ui.client.Notify(serviceMethod, args)
+	if err != nil {
+		log.Info("Error", "exc", err.Error())
+	}
+	return err
+}
+
 func (ui *StdIOUI) ApproveTx(request *SignTxRequest) (SignTxResponse, error) {
 	var result SignTxResponse
 	err := ui.dispatch("ApproveTx", request, &result)
@@ -86,34 +95,34 @@ func (ui *StdIOUI) ApproveNewAccount(request *NewAccountRequest) (NewAccountResp
 }
 
 func (ui *StdIOUI) ShowError(message string) {
-	err := ui.dispatch("ShowError", &Message{message}, nil)
+	err := ui.notify("ShowError", &Message{message})
 	if err != nil {
 		log.Info("Error calling 'ShowError'", "exc", err.Error(), "msg", message)
 	}
 }
 
 func (ui *StdIOUI) ShowInfo(message string) {
-	err := ui.dispatch("ShowInfo", Message{message}, nil)
+	err := ui.notify("ShowInfo", Message{message})
 	if err != nil {
 		log.Info("Error calling 'ShowInfo'", "exc", err.Error(), "msg", message)
 	}
 }
 func (ui *StdIOUI) OnApprovedTx(tx ethapi.SignTransactionResult) {
-	err := ui.dispatch("OnApprovedTx", tx, nil)
+	err := ui.notify("OnApprovedTx", tx)
 	if err != nil {
 		log.Info("Error calling 'OnApprovedTx'", "exc", err.Error(), "tx", tx)
 	}
 }
 
 func (ui *StdIOUI) OnSignerStartup(info StartupInfo) {
-	err := ui.dispatch("OnSignerStartup", info, nil)
+	err := ui.notify("OnSignerStartup", info)
 	if err != nil {
 		log.Info("Error calling 'OnSignerStartup'", "exc", err.Error(), "info", info)
 	}
 }
 func (ui *StdIOUI) OnInputRequired(info UserInputRequest) (UserInputResponse, error) {
 	var result UserInputResponse
-	err := ui.dispatch("OnInputRequired", info, &result)
+	err := ui.notify("OnInputRequired", info)
 	if err != nil {
 		log.Info("Error calling 'OnInputRequired'", "exc", err.Error(), "info", info)
 	}


### PR DESCRIPTION
This PR contains two things
* Ability for the `Client` to send json-rpc notifications, which is useful in `clef` when we want to alert the UI about things, but do not want a response. 
* It also contains a poc for how to implement bidirectional communication, by extending the `Client` a bit. It's not complete, next step would be to add similar reflect-based invocation of the actual method that we're calling. 

I did not want to build that out completely, as it would be mostly copy-paste of `Server`. So the question is, basically, should we use the approach in this PR or base it off the `Server` implementation? IMO, the `Server` is overly complex for the `clef` usecase -- there's no need to have separate namespaces and modules, for example, or support HTTP protocol for the bidirectional communication. 

So, leaving this here for comments on how to proceed. 