### PR TITLE
eth: fix storageRangeAt for empty blocks

### DIFF
--- a/eth/api_tracer.go
+++ b/eth/api_tracer.go
@@ -795,6 +795,11 @@ func (api *PrivateDebugAPI) computeTxEnv(blockHash common.Hash, txIndex int, ree
 	if err != nil {
 		return nil, vm.Context{}, nil, err
 	}
+
+	if txIndex == 0 && len(block.Transactions()) == 0 {
+		return nil, vm.Context{}, statedb, nil
+	}
+
 	// Recompute transactions up to the target index.
 	signer := types.MakeSigner(api.eth.blockchain.Config(), block.Number())
 


### PR DESCRIPTION
When calling `debug_storageRangeAt` on an empty block, geth returns an error "tx index 0 out of range for block ...". This fixes storageRangeAt for empty blocks.

cc @jwasinger