### PR TITLE
Clef timeout on external api

### DIFF
--- a/signer/core/api.go
+++ b/signer/core/api.go
@@ -36,7 +36,7 @@ import (
 	"github.com/ethereum/go-ethereum/rlp"
 )
 
-const(
+const (
 	// numberOfAccountsToDerive For hardware wallets, the number of accounts to derive
 	numberOfAccountsToDerive = 10
 	// ExternalAPIVersion -- see extapi_changelog.md

--- a/signer/core/api.go
+++ b/signer/core/api.go
@@ -36,8 +36,14 @@ import (
 	"github.com/ethereum/go-ethereum/rlp"
 )
 
-// numberOfAccountsToDerive For hardware wallets, the number of accounts to derive
-const numberOfAccountsToDerive = 10
+const(
+	// numberOfAccountsToDerive For hardware wallets, the number of accounts to derive
+	numberOfAccountsToDerive = 10
+	// ExternalAPIVersion -- see extapi_changelog.md
+	ExternalAPIVersion = "4.0.0"
+	// InternalAPIVersion -- see intapi_changelog.md
+	InternalAPIVersion = "3.0.0"
+)
 
 // ExternalAPI defines the external API through which signing requests are made.
 type ExternalAPI interface {

--- a/signer/core/timeout.go
+++ b/signer/core/timeout.go
@@ -1,0 +1,135 @@
+package core
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"github.com/ethereum/go-ethereum/accounts"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/ethereum/go-ethereum/internal/ethapi"
+	"github.com/ethereum/go-ethereum/log"
+	"time"
+)
+
+// The TimedExternalAPI implements ExternalAPI, but can be configured to time out after a specified interval.
+// This can be used to ensure that callers get a response within reasonable time,
+// even if the user is unresponsive.
+type TimedExternalAPI struct {
+	timeout time.Duration
+	next    ExternalAPI
+}
+
+func NewTimedExternalAPI(next ExternalAPI, timeout time.Duration) ExternalAPI {
+	return &TimedExternalAPI{timeout, next}
+}
+
+var (
+	ErrTimeout = fmt.Errorf("timeout occurred")
+)
+
+func (t *TimedExternalAPI) List(ctx context.Context) ([]common.Address, error) {
+	type response struct {
+		addr []common.Address
+		err  error
+	}
+	ch := make(chan response)
+	go func() {
+		addr, err := t.next.List(ctx)
+		ch <- response{addr, err}
+	}()
+
+	select {
+	case r := <-ch:
+		return r.addr, r.err
+	case <-time.After(t.timeout):
+		log.Info("timeout", "op", "list")
+		go func() { <-ch }()
+		return []common.Address{}, ErrTimeout
+	}
+}
+
+func (t *TimedExternalAPI) New(ctx context.Context) (accounts.Account, error) {
+	type response struct {
+		acc accounts.Account
+		err error
+	}
+	ch := make(chan response)
+	go func() {
+		acc, err := t.next.New(ctx)
+		ch <- response{acc, err}
+	}()
+
+	select {
+	case r := <-ch:
+		return r.acc, r.err
+	case <-time.After(t.timeout):
+		log.Info("timeout", "op", "list")
+		go func() { <-ch }()
+		return accounts.Account{}, ErrTimeout
+	}
+}
+
+func (t *TimedExternalAPI) SignTransaction(ctx context.Context, args SendTxArgs, methodSelector *string) (*ethapi.SignTransactionResult, error) {
+	type response struct {
+		res *ethapi.SignTransactionResult
+		err error
+	}
+	ch := make(chan response)
+	go func() {
+		res, err := t.next.SignTransaction(ctx, args, methodSelector)
+		ch <- response{res, err}
+	}()
+	select {
+	case r := <-ch:
+		return r.res, r.err
+	case <-time.After(t.timeout):
+		log.Info("timeout", "op", "signTransaction")
+		go func() { <-ch }()
+		return nil, ErrTimeout
+	}
+}
+
+func (t *TimedExternalAPI) Sign(ctx context.Context, addr common.MixedcaseAddress, data hexutil.Bytes) (hexutil.Bytes, error) {
+	type response struct {
+		res hexutil.Bytes
+		err error
+	}
+	ch := make(chan response)
+	go func() {
+		res, err := t.next.Sign(ctx, addr, data)
+		ch <- response{res, err}
+	}()
+	select {
+	case r := <-ch:
+		return r.res, r.err
+	case <-time.After(t.timeout):
+		log.Info("timeout", "op", "sign")
+		go func() { <-ch }()
+		return nil, ErrTimeout
+	}
+}
+
+func (t *TimedExternalAPI) Export(ctx context.Context, addr common.Address) (json.RawMessage, error) {
+	type response struct {
+		res json.RawMessage
+		err error
+	}
+	ch := make(chan response)
+	go func() {
+		res, err := t.next.Export(ctx, addr)
+		ch <- response{res, err}
+	}()
+	select {
+	case r := <-ch:
+		return r.res, r.err
+	case <-time.After(t.timeout):
+		log.Info("timeout", "op", "sign")
+		go func() { <-ch }()
+		return json.RawMessage{}, ErrTimeout
+	}
+}
+
+func (t *TimedExternalAPI) Version(ctx context.Context) (string, error) {
+	return ExternalAPIVersion, nil
+}

--- a/signer/core/timeout.go
+++ b/signer/core/timeout.go
@@ -1,3 +1,19 @@
+// Copyright 2018 The go-ethereum Authors
+// This file is part of go-ethereum.
+//
+// go-ethereum is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// go-ethereum is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with go-ethereum. If not, see <http://www.gnu.org/licenses/>.
+
 package core
 
 import (

--- a/signer/core/timeout_test.go
+++ b/signer/core/timeout_test.go
@@ -1,0 +1,65 @@
+package core
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/ethereum/go-ethereum/accounts"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/ethereum/go-ethereum/internal/ethapi"
+)
+
+type nonResponsiveHander struct {
+	sleepTime time.Duration
+}
+
+func (n nonResponsiveHander) List(ctx context.Context) ([]common.Address, error) {
+	time.Sleep(n.sleepTime)
+	return []common.Address{common.HexToAddress("0xdeadbeef")}, nil
+}
+
+func (nonResponsiveHander) New(ctx context.Context) (accounts.Account, error) {
+	panic("implement me")
+}
+
+func (nonResponsiveHander) SignTransaction(ctx context.Context, args SendTxArgs, methodSelector *string) (*ethapi.SignTransactionResult, error) {
+	panic("implement me")
+}
+
+func (nonResponsiveHander) Sign(ctx context.Context, addr common.MixedcaseAddress, data hexutil.Bytes) (hexutil.Bytes, error) {
+	panic("implement me")
+}
+
+func (nonResponsiveHander) Export(ctx context.Context, addr common.Address) (json.RawMessage, error) {
+	panic("implement me")
+}
+
+// TestTimeout checks that it does timeout
+func TestTimeout(t *testing.T) {
+	a := &nonResponsiveHander{1 * time.Second}
+	api := NewTimedExternalAPI(a, 1*time.Millisecond)
+	addr, err := api.List(nil)
+	if len(addr) > 0 {
+		t.Errorf("expected no accounts, got %d", len(addr))
+	}
+	if err == nil {
+		t.Errorf("expected err")
+
+	}
+}
+
+// TestTimeout checks that it does timeout
+func TestNotTimeout(t *testing.T) {
+	a := &nonResponsiveHander{1 * time.Millisecond}
+	api := NewTimedExternalAPI(a, 1*time.Second)
+	addr, err := api.List(nil)
+	if len(addr) != 1 {
+		t.Errorf("expected 1 accounts, got %d", len(addr))
+	}
+	if err != nil {
+		t.Errorf("expected no err, got %v", err)
+	}
+}


### PR DESCRIPTION
This PR implements a timeout feature, so even in the event that the user does not act in time, the caller gets a response. 
It is implemented similarly to the audit log, just by placing the timeout in the pipeline. 
```
auditloggerAPI <--> timeoutAPI <--> real API <--> Ui 
```
It's fairly trivial, and could otherwise be implemented as a UI api instead of an ExternalAPI. 