### PR TITLE
tests: Add flag to use EVMC for state tests

### DIFF
--- a/tests/state_test.go
+++ b/tests/state_test.go
@@ -18,10 +18,12 @@ package tests
 
 import (
 	"bytes"
+	"flag"
 	"fmt"
 	"reflect"
 	"testing"
 
+	"github.com/ethereum/go-ethereum/cmd/utils"
 	"github.com/ethereum/go-ethereum/core/vm"
 )
 
@@ -65,8 +67,17 @@ func TestState(t *testing.T) {
 // Transactions with gasLimit above this value will not get a VM trace on failure.
 const traceErrorLimit = 400000
 
+// The VM config for state tests that accepts --vm.* command line arguments.
+var testVMConfig = func() vm.Config {
+	vmconfig := vm.Config{}
+	flag.StringVar(&vmconfig.EVMInterpreter, utils.EVMInterpreterFlag.Name, utils.EVMInterpreterFlag.Value, utils.EVMInterpreterFlag.Usage)
+	flag.StringVar(&vmconfig.EWASMInterpreter, utils.EWASMInterpreterFlag.Name, utils.EWASMInterpreterFlag.Value, utils.EWASMInterpreterFlag.Usage)
+	flag.Parse()
+	return vmconfig
+}()
+
 func withTrace(t *testing.T, gasLimit uint64, test func(vm.Config) error) {
-	err := test(vm.Config{})
+	err := test(testVMConfig)
 	if err == nil {
 		return
 	}


### PR DESCRIPTION
This allows running state tests with any EVMC compatible EVM.
