### PR TITLE
les: fix pubkey index typo

### DIFF
--- a/les/serverpool.go
+++ b/les/serverpool.go
@@ -683,7 +683,7 @@ func (e *poolEntry) DecodeRLP(s *rlp.Stream) error {
 }
 
 func encodePubkey64(pub *ecdsa.PublicKey) []byte {
-	return crypto.FromECDSAPub(pub)[:1]
+	return crypto.FromECDSAPub(pub)[1:]
 }
 
 func decodePubkey64(b []byte) (*ecdsa.PublicKey, error) {


### PR DESCRIPTION
This is an apparent typo. So no test cases are provided. 
It seems like the code did not cover `poolEntry`'s RLP coding.