### PR TITLE
cmd/swarm/swarm-smoke: fix smoke tests url scheme to fit new k8s setup

### DIFF
--- a/cmd/swarm/swarm-smoke/main.go
+++ b/cmd/swarm/swarm-smoke/main.go
@@ -45,8 +45,8 @@ func main() {
 	app.Flags = []cli.Flag{
 		cli.StringFlag{
 			Name:        "cluster-endpoint",
-			Value:       "testing",
-			Usage:       "cluster to point to (local, open or testing)",
+			Value:       "prod",
+			Usage:       "cluster to point to (prod or a given namespace)",
 			Destination: &cluster,
 		},
 		cli.IntFlag{


### PR DESCRIPTION
This PR is updating the way we invoke the smoke tests for the Swarm clusters.

Production gateways is located at:
https://swarm-gateways.net

Other temporary gateways are located under the stg.swarm-gateways.net endpoint.