### PR TITLE
cmd/puppeth: add grace period to faucet timeout

### DIFF
--- a/cmd/faucet/faucet.go
+++ b/cmd/faucet/faucet.go
@@ -506,7 +506,7 @@ func (f *faucet) apiHandler(conn *websocket.Conn) {
 				Time:    time.Now(),
 				Tx:      signed,
 			})
-			f.timeouts[username] = time.Now().Add(time.Duration(*minutesFlag*int(math.Pow(3, float64(msg.Tier)))) * time.Minute)
+			f.timeouts[username] = time.Now().Add(time.Duration(*minutesFlag*int(math.Pow(3, float64(msg.Tier)))-5) * time.Minute)
 			fund = true
 		}
 		f.lock.Unlock()

--- a/cmd/faucet/faucet.go
+++ b/cmd/faucet/faucet.go
@@ -506,7 +506,10 @@ func (f *faucet) apiHandler(conn *websocket.Conn) {
 				Time:    time.Now(),
 				Tx:      signed,
 			})
-			f.timeouts[username] = time.Now().Add(time.Duration(*minutesFlag*int(math.Pow(3, float64(msg.Tier)))-5) * time.Minute)
+			timeout := time.Duration(*minutesFlag*int(math.Pow(3, float64(msg.Tier)))) * time.Minute
+			grace := timeout / 288 // 24h timeout => 5m grace
+
+			f.timeouts[username] = time.Now().Add(timeout - grace)
 			fund = true
 		}
 		f.lock.Unlock()


### PR DESCRIPTION
I recognize that the Rinkeby faucet is meant to give allowances every 8, 24, or 72 hours depending on the user's selection.  I think the basic idea is that if someone needs a bunch more, they can come back on a regular interval.
This feature request is to not change the published interval, but to be a bit less strict about it, so that users coming back after the specified number of hours are less likely to see a super-strict message like this:
![699.131ms left until next allowance](https://user-images.githubusercontent.com/563406/48512979-ae92eb00-e828-11e8-90fc-a1ceb3309607.png)

Do we as a community really think it's important to enforce the published lags down to the microsecond? 
My suggestion is that the actual gap until the next allowance be shorter than the published interval by 5 minutes.   Then users who need more testnet ether can set and use a recurring reminder more effectively.

I believe the attached commit would implement this feature request.  