### PR TITLE
light: odrTrie tryUpdate should use update

### DIFF
--- a/light/trie.go
+++ b/light/trie.go
@@ -108,7 +108,7 @@ func (t *odrTrie) TryGet(key []byte) ([]byte, error) {
 func (t *odrTrie) TryUpdate(key, value []byte) error {
 	key = crypto.Keccak256(key)
 	return t.do(key, func() error {
-		return t.trie.TryDelete(key)
+		return t.trie.TryUpdate(key, value)
 	})
 }
 


### PR DESCRIPTION
This is something I've noticed a week ago. I think this is a mistake. Though I commented on the specific commit and the PR towards the introduction of the code, there is no further explanation about it.
`TryUpdate` does not call `t.trie.TryUpdate(key, value)` and calls `t.trie.TryDelete` instead. The update operation simply deletes the corresponding entry, though it could retrieve later by odr. However, it adds further network overhead.