### PR TITLE
les: fix nextRequest best variables selection

### DIFF
--- a/les/fetcher.go
+++ b/les/fetcher.go
@@ -410,6 +410,7 @@ func (f *lightFetcher) nextRequest() (*distReq, uint64) {
 		bestHash   common.Hash
 		bestAmount uint64
 	)
+	bestAmount--
 	bestTd := f.maxConfirmedTd
 	bestSyncing := false
 
@@ -417,7 +418,7 @@ func (f *lightFetcher) nextRequest() (*distReq, uint64) {
 		for hash, n := range fp.nodeByHash {
 			if !f.checkKnownNode(p, n) && !n.requested && (bestTd == nil || n.td.Cmp(bestTd) >= 0) {
 				amount := f.requestAmount(p, n)
-				if bestTd == nil || n.td.Cmp(bestTd) > 0 || amount < bestAmount {
+				if amount < bestAmount {
 					bestHash = hash
 					bestAmount = amount
 					bestTd = n.td


### PR DESCRIPTION
This PR fixes the best sync node selection algorithm in `nextRequest` function logic.
The next sync block node would be either
- The next block is having greater total difficulty then choose one with fewer request amount.
- The next block has the same total difficulty then choose the one with the fewest request amount.

The problems in the original code are that it will 
- stop syncing if there is not any block node having total difficulty strictly greater than our local one
- choose the one with fewest request amount among all the block nodes (including greater td and same td) after our for-loops walked through a block node with higher td.

To fix this, the algorithm would be described to find any block nodes with highest td and if there are more than one, return the shorted one measured by request amount, if we could not find any block nodes with td strictly greater than ours, return the one with less request amount.

I tried to implement it while keeping a clean code and better readability, these redundant lines are compromised. 

Say the bool expression for having greater td to be `g`, having smaller request amount to be `a`, and whether better td is found before to be `f`. 
And the action to refresh our variables to be `r`, to flag better td had found to be `uf`.

The bool expression would be
if `g && ( ! f || a )` then `r, uf`
if `! f && a` then `r`
This is equal to 
if `( a && g ) || ( ! f && g ) || ( ! f && a ) ` then `r`
if `( a && g ) || ( ! f && g )` then `uf`

None of these could be further simplified and the super long bool statements would be more ugly. Thus repetitive codes are kept for better readability.
Since there must be block nodes to be fetched, setting the `bestAmount` to be the largest uint64 and refresh these variables upon a better amount is found would be more reasonable.