### PR TITLE
swarm/storage: Batched database migration

### DIFF
--- a/swarm/storage/ldbstore.go
+++ b/swarm/storage/ldbstore.go
@@ -615,6 +615,8 @@ func (s *LDBStore) CleanGCIndex() error {
 		var chunkHashes [][]byte
 		var pos []uint8
 		it := s.db.NewIterator()
+
+		batch.Reset()
 		it.Seek(lastIdxKey)
 
 		var i int
@@ -672,12 +674,13 @@ func (s *LDBStore) CleanGCIndex() error {
 		if err != nil {
 			return err
 		}
-		batch.Reset()
 
 		log.Debug("clean gc index pass", "batch", cleanBatchCount, "checked", i, "kept", len(idxs))
 	}
 
 	log.Debug("gc cleanup entries", "ok", okEntryCount, "total", totalEntryCount, "batchlen", batch.Len())
+
+	batch.Reset()
 
 	var entryCount [8]byte
 	binary.BigEndian.PutUint64(entryCount[:], okEntryCount)

--- a/swarm/storage/ldbstore.go
+++ b/swarm/storage/ldbstore.go
@@ -284,7 +284,7 @@ func getGCIdxValue(index *dpaDBIndex, po uint8, addr Address) []byte {
 	return val
 }
 
-func parseGCIdxKey(key []byte) (byte, []byte) {
+func parseIdxKey(key []byte) (byte, []byte) {
 	return key[0], key[1:]
 }
 
@@ -589,7 +589,7 @@ func (s *LDBStore) CleanGCIndex() error {
 	it.Seek([]byte{keyGCIdx})
 	var gcDeletes int
 	for it.Valid() {
-		rowType, _ := parseGCIdxKey(it.Key())
+		rowType, _ := parseIdxKey(it.Key())
 		if rowType != keyGCIdx {
 			break
 		}
@@ -639,7 +639,7 @@ func (s *LDBStore) CleanGCIndex() error {
 			}
 
 			// if it's not keyindex anymore we're done iterating
-			rowType, chunkHash := parseGCIdxKey(it.Key())
+			rowType, chunkHash := parseIdxKey(it.Key())
 			if rowType != keyIndex {
 				doneIterating = true
 				break

--- a/swarm/storage/ldbstore.go
+++ b/swarm/storage/ldbstore.go
@@ -672,6 +672,7 @@ func (s *LDBStore) CleanGCIndex() error {
 		if err != nil {
 			return err
 		}
+		batch.Reset()
 
 		log.Debug("clean gc index pass", "batch", cleanBatchCount, "checked", i, "kept", len(idxs))
 	}

--- a/swarm/storage/ldbstore.go
+++ b/swarm/storage/ldbstore.go
@@ -633,6 +633,9 @@ func (s *LDBStore) CleanGCIndex() error {
 			}
 		}
 		totalEntryCount++
+		if err := s.db.Write(&batch); err != nil {
+			return err
+		}
 		it.Next()
 	}
 

--- a/swarm/storage/ldbstore.go
+++ b/swarm/storage/ldbstore.go
@@ -607,13 +607,18 @@ func (s *LDBStore) CleanGCIndex() error {
 	var poPtrs [256]uint64
 	var doneIterating bool
 	lastIdxKey := []byte{keyIndex}
+	var cleanBatchCount int
 	for !doneIterating {
+
+		cleanBatchCount++
 		var idxs []dpaDBIndex
 		var chunkHashes [][]byte
 		var pos []uint8
 		it := s.db.NewIterator()
 		it.Seek(lastIdxKey)
-		for i := 0; i < 4096; i++ {
+
+		var i int
+		for i = 0; i < 4096; i++ {
 			if !it.Valid() {
 				doneIterating = true
 				break
@@ -667,6 +672,8 @@ func (s *LDBStore) CleanGCIndex() error {
 		if err != nil {
 			return err
 		}
+
+		log.Debug("clean gc index pass", "batch", cleanBatchCount, "checked", i, "kept", len(idxs))
 	}
 
 	log.Debug("gc cleanup entries", "ok", okEntryCount, "total", totalEntryCount, "batchlen", batch.Len())

--- a/swarm/storage/ldbstore.go
+++ b/swarm/storage/ldbstore.go
@@ -663,6 +663,7 @@ func (s *LDBStore) CleanGCIndex() error {
 		if err != nil {
 			return err
 		}
+		batch.Reset()
 
 		for i, okIdx := range idxs {
 			gcIdxKey := getGCIdxKey(&okIdx)

--- a/swarm/storage/ldbstore_test.go
+++ b/swarm/storage/ldbstore_test.go
@@ -705,7 +705,7 @@ func TestCleanIndex(t *testing.T) {
 
 	// second gc index should still be fixed
 	if _, err := ldb.db.Get(gcSecondCorrectKey); err != nil {
-		t.Fatalf("expected gc 1 idx to be present: %v", idxKey)
+		t.Fatalf("expected gc 1 idx %v to be present: %v", gcSecondCorrectKey, idxKey)
 	}
 
 	// third gc index should be unchanged

--- a/swarm/storage/ldbstore_test.go
+++ b/swarm/storage/ldbstore_test.go
@@ -705,7 +705,7 @@ func TestCleanIndex(t *testing.T) {
 
 	// second gc index should still be fixed
 	if _, err := ldb.db.Get(gcSecondCorrectKey); err != nil {
-		t.Fatalf("expected gc 1 idx %v to be present: %v", idxKey)
+		t.Fatalf("expected gc 1 idx to be present: %v", idxKey)
 	}
 
 	// third gc index should be unchanged

--- a/swarm/storage/ldbstore_test.go
+++ b/swarm/storage/ldbstore_test.go
@@ -705,7 +705,7 @@ func TestCleanIndex(t *testing.T) {
 
 	// second gc index should still be fixed
 	if _, err := ldb.db.Get(gcSecondCorrectKey); err != nil {
-		t.Fatalf("expected gc 1 idx %v to be present: %v", gcSecondCorrectKey, idxKey)
+		t.Fatalf("expected gc 1 idx %v to be present: %v", idxKey)
 	}
 
 	// third gc index should be unchanged


### PR DESCRIPTION
Current migration from `purity` to `halloween` tries to load the whole db into memory. That's bad news. This PR fixes that, by chunking up the index processing in batches of 4096.