### PR TITLE
node,rpc: remove unused log in ipc listener function

### DIFF
--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -445,7 +445,11 @@ func (bc *BlockChain) repair(head **types.Block) error {
 			return nil
 		}
 		// Otherwise rewind one block and recheck state availability there
-		(*head) = bc.GetBlock((*head).ParentHash(), (*head).NumberU64()-1)
+		block := bc.GetBlock((*head).ParentHash(), (*head).NumberU64()-1)
+		if block == nil {
+			return fmt.Errorf("failed to repair block, can not get block at height %d", (*head).NumberU64())
+		}
+		(*head) = block
 	}
 }
 

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -445,11 +445,7 @@ func (bc *BlockChain) repair(head **types.Block) error {
 			return nil
 		}
 		// Otherwise rewind one block and recheck state availability there
-		block := bc.GetBlock((*head).ParentHash(), (*head).NumberU64()-1)
-		if block == nil {
-			return fmt.Errorf("failed to repair block, can not get block at height %d", (*head).NumberU64())
-		}
-		(*head) = block
+		(*head) = bc.GetBlock((*head).ParentHash(), (*head).NumberU64()-1)
 	}
 }
 

--- a/node/node.go
+++ b/node/node.go
@@ -322,7 +322,7 @@ func (n *Node) stopIPC() {
 		n.ipcListener.Close()
 		n.ipcListener = nil
 
-		n.log.Info("IPC endpoint closed", "endpoint", n.ipcEndpoint)
+		n.log.Info("IPC endpoint closed", "url", n.ipcEndpoint)
 	}
 	if n.ipcHandler != nil {
 		n.ipcHandler.Stop()

--- a/rpc/ipc.go
+++ b/rpc/ipc.go
@@ -24,7 +24,7 @@ import (
 	"github.com/ethereum/go-ethereum/p2p/netutil"
 )
 
-// ServeListener accepts connections on l, serving IPC-RPC on them.
+// ServeListener accepts connections on l, serving JSON-RPC on them.
 func (srv *Server) ServeListener(l net.Listener) error {
 	for {
 		conn, err := l.Accept()

--- a/rpc/ipc.go
+++ b/rpc/ipc.go
@@ -24,17 +24,17 @@ import (
 	"github.com/ethereum/go-ethereum/p2p/netutil"
 )
 
-// ServeListener accepts connections on l, serving JSON-RPC on them.
+// ServeListener accepts connections on l, serving IPC-RPC on them.
 func (srv *Server) ServeListener(l net.Listener) error {
 	for {
 		conn, err := l.Accept()
 		if netutil.IsTemporaryError(err) {
-			log.Warn("RPC accept error", "err", err)
+			log.Warn("IPC accept error", "err", err)
 			continue
 		} else if err != nil {
 			return err
 		}
-		log.Trace("Accepted connection", "addr", conn.RemoteAddr())
+		log.Trace("IPC accepted connection")
 		go srv.ServeCodec(NewJSONCodec(conn), OptionMethodInvocation|OptionSubscriptions)
 	}
 }


### PR DESCRIPTION
there are three changes for the commit:
1. remove "conn.RemoteAddr()" in rpc/ipc.go, because it always `null` for the ipc call.
2. add "IPC" at some places in rpc/ipc.go
3. change "endpoint" -> "url" in node/node.go, just for a consistency with other places.