### PR TITLE
core: return error if repair block failed

### DIFF
--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -445,7 +445,11 @@ func (bc *BlockChain) repair(head **types.Block) error {
 			return nil
 		}
 		// Otherwise rewind one block and recheck state availability there
-		(*head) = bc.GetBlock((*head).ParentHash(), (*head).NumberU64()-1)
+		block := bc.GetBlock((*head).ParentHash(), (*head).NumberU64()-1)
+		if block == nil {
+			return fmt.Errorf("failed to repair block, can not get block at height %d", (*head).NumberU64())
+		}
+		(*head) = block
 	}
 }
 

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -447,7 +447,7 @@ func (bc *BlockChain) repair(head **types.Block) error {
 		// Otherwise rewind one block and recheck state availability there
 		block := bc.GetBlock((*head).ParentHash(), (*head).NumberU64()-1)
 		if block == nil {
-			return fmt.Errorf("failed to repair block, can not get block at height %d", (*head).NumberU64())
+			return fmt.Errorf("missing block %d [%x]", (*head).NumberU64()-1, (*head).ParentHash())
 		}
 		(*head) = block
 	}


### PR DESCRIPTION
If `bc.GetBlock()` return nil, it will crash at the next loop because `(*head).Root()` == `nil.Root()`.