### PR TITLE
cmd/swarm: speed up tests - use global cluster

### DIFF
--- a/cmd/swarm/access_test.go
+++ b/cmd/swarm/access_test.go
@@ -14,8 +14,6 @@
 // You should have received a copy of the GNU General Public License
 // along with go-ethereum. If not, see <http://www.gnu.org/licenses/>.
 
-// +build !windows
-
 package main
 
 import (

--- a/cmd/swarm/access_test.go
+++ b/cmd/swarm/access_test.go
@@ -30,7 +30,6 @@ import (
 	"os"
 	"runtime"
 	"strings"
-	"sync"
 	"testing"
 	"time"
 
@@ -49,17 +48,6 @@ const (
 )
 
 var DefaultCurve = crypto.S256()
-
-const clusterSize = 3
-
-var clusteronce sync.Once
-var cluster *testCluster
-
-func initCluster(t *testing.T) {
-	clusteronce.Do(func() {
-		cluster = newTestCluster(t, clusterSize)
-	})
-}
 
 func TestACT(t *testing.T) {
 	if runtime.GOOS == "windows" {

--- a/cmd/swarm/access_test.go
+++ b/cmd/swarm/access_test.go
@@ -37,8 +37,7 @@ import (
 	"github.com/ethereum/go-ethereum/crypto/sha3"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/swarm/api"
-	swarm "github.com/ethereum/go-ethereum/swarm/api/client"
-	swarmhttp "github.com/ethereum/go-ethereum/swarm/api/http"
+	swarmapi "github.com/ethereum/go-ethereum/swarm/api/client"
 	"github.com/ethereum/go-ethereum/swarm/testutil"
 )
 
@@ -49,22 +48,42 @@ const (
 
 var DefaultCurve = crypto.S256()
 
+var cluster *testCluster
+
+const clusterSize = 3
+
+func TestACT(t *testing.T) {
+	cases := []struct {
+		name string
+		f    func(t *testing.T)
+	}{
+		{"PK", tTestAccessPK},
+		{"ACT", tTestAccessACT},
+		{"ACTScale", tTestAccessACTScale},
+		{"Password", tTestAccessPassword},
+	}
+
+	cluster = newTestCluster(t, clusterSize)
+	defer cluster.Shutdown()
+
+	for _, tc := range cases {
+		t.Run(tc.name, tc.f)
+	}
+}
+
 // TestAccessPassword tests for the correct creation of an ACT manifest protected by a password.
 // The test creates bogus content, uploads it encrypted, then creates the wrapping manifest with the Access entry
 // The parties participating - node (publisher), uploads to second node then disappears. Content which was uploaded
 // is then fetched through 2nd node. since the tested code is not key-aware - we can just
 // fetch from the 2nd node using HTTP BasicAuth
-func TestAccessPassword(t *testing.T) {
-	srv := swarmhttp.NewTestSwarmServer(t, serverFunc, nil)
-	defer srv.Close()
-
+func tTestAccessPassword(t *testing.T) {
 	dataFilename := testutil.TempFileWithContent(t, data)
 	defer os.RemoveAll(dataFilename)
 
 	// upload the file with 'swarm up' and expect a hash
 	up := runSwarm(t,
 		"--bzzapi",
-		srv.URL, //it doesn't matter through which node we upload content
+		cluster.Nodes[0].URL,
 		"up",
 		"--encrypt",
 		dataFilename)
@@ -138,16 +157,17 @@ func TestAccessPassword(t *testing.T) {
 	if a.Publisher != "" {
 		t.Fatal("should be empty")
 	}
-	client := swarm.NewClient(srv.URL)
+
+	client := swarmapi.NewClient(cluster.Nodes[0].URL)
 
 	hash, err := client.UploadManifest(&m, false)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	httpClient := &http.Client{}
+	url := cluster.Nodes[0].URL + "/" + "bzz:/" + hash
 
-	url := srv.URL + "/" + "bzz:/" + hash
+	httpClient := &http.Client{}
 	response, err := httpClient.Get(url)
 	if err != nil {
 		t.Fatal(err)
@@ -189,7 +209,7 @@ func TestAccessPassword(t *testing.T) {
 	//download file with 'swarm down' with wrong password
 	up = runSwarm(t,
 		"--bzzapi",
-		srv.URL,
+		cluster.Nodes[0].URL,
 		"down",
 		"bzz:/"+hash,
 		tmp,
@@ -208,11 +228,7 @@ func TestAccessPassword(t *testing.T) {
 // The parties participating - node (publisher), uploads to second node (which is also the grantee) then disappears.
 // Content which was uploaded is then fetched through the grantee's http proxy. Since the tested code is private-key aware,
 // the test will fail if the proxy's given private key is not granted on the ACT.
-func TestAccessPK(t *testing.T) {
-	// Setup Swarm and upload a test file to it
-	cluster := newTestCluster(t, 2)
-	defer cluster.Shutdown()
-
+func tTestAccessPK(t *testing.T) {
 	dataFilename := testutil.TempFileWithContent(t, data)
 	defer os.RemoveAll(dataFilename)
 
@@ -318,7 +334,7 @@ func TestAccessPK(t *testing.T) {
 	if a.Publisher != pkComp {
 		t.Fatal("publisher key did not match")
 	}
-	client := swarm.NewClient(cluster.Nodes[0].URL)
+	client := swarmapi.NewClient(cluster.Nodes[0].URL)
 
 	hash, err := client.UploadManifest(&m, false)
 	if err != nil {
@@ -345,12 +361,12 @@ func TestAccessPK(t *testing.T) {
 }
 
 // TestAccessACT tests the creation of the ACT manifest end-to-end, without any bogus entries (i.e. default scenario = 3 nodes 1 unauthorized)
-func TestAccessACT(t *testing.T) {
+func tTestAccessACT(t *testing.T) {
 	testAccessACT(t, 0)
 }
 
 // TestAccessACTScale tests the creation of the ACT manifest end-to-end, with 1000 bogus entries (i.e. 1000 EC keys + default scenario = 3 nodes 1 unauthorized = 1003 keys in the ACT manifest)
-func TestAccessACTScale(t *testing.T) {
+func tTestAccessACTScale(t *testing.T) {
 	testAccessACT(t, 1000)
 }
 
@@ -360,13 +376,8 @@ func TestAccessACTScale(t *testing.T) {
 // the third node then then tries to download using a correct password (and succeeds) then uses a wrong password and fails.
 // the publisher uploads through one of the nodes then disappears.
 func testAccessACT(t *testing.T, bogusEntries int) {
-	// Setup Swarm and upload a test file to it
-	const clusterSize = 3
-	cluster := newTestCluster(t, clusterSize)
-	defer cluster.Shutdown()
-
 	var uploadThroughNode = cluster.Nodes[0]
-	client := swarm.NewClient(uploadThroughNode.URL)
+	client := swarmapi.NewClient(uploadThroughNode.URL)
 
 	r1 := gorand.New(gorand.NewSource(time.Now().UnixNano()))
 	nodeToSkip := r1.Intn(clusterSize) // a number between 0 and 2 (node indices in `cluster`)

--- a/cmd/swarm/access_test.go
+++ b/cmd/swarm/access_test.go
@@ -57,10 +57,10 @@ func TestACT(t *testing.T) {
 		name string
 		f    func(t *testing.T)
 	}{
-		{"PK", tTestAccessPK},
-		{"ACT", tTestAccessACT},
-		{"ACTScale", tTestAccessACTScale},
-		{"Password", tTestAccessPassword},
+		{"Password", testPassword},
+		{"PK", testPK},
+		{"ACTWithoutBogus", testACTWithoutBogus},
+		{"ACTWithBogus", testACTWithBogus},
 	}
 
 	cluster = newTestCluster(t, clusterSize)
@@ -71,12 +71,12 @@ func TestACT(t *testing.T) {
 	}
 }
 
-// TestAccessPassword tests for the correct creation of an ACT manifest protected by a password.
+// testPassword tests for the correct creation of an ACT manifest protected by a password.
 // The test creates bogus content, uploads it encrypted, then creates the wrapping manifest with the Access entry
 // The parties participating - node (publisher), uploads to second node then disappears. Content which was uploaded
 // is then fetched through 2nd node. since the tested code is not key-aware - we can just
 // fetch from the 2nd node using HTTP BasicAuth
-func tTestAccessPassword(t *testing.T) {
+func testPassword(t *testing.T) {
 	dataFilename := testutil.TempFileWithContent(t, data)
 	defer os.RemoveAll(dataFilename)
 
@@ -223,12 +223,12 @@ func tTestAccessPassword(t *testing.T) {
 	up.ExpectExit()
 }
 
-// TestAccessPK tests for the correct creation of an ACT manifest between two parties (publisher and grantee).
+// testPK tests for the correct creation of an ACT manifest between two parties (publisher and grantee).
 // The test creates bogus content, uploads it encrypted, then creates the wrapping manifest with the Access entry
 // The parties participating - node (publisher), uploads to second node (which is also the grantee) then disappears.
 // Content which was uploaded is then fetched through the grantee's http proxy. Since the tested code is private-key aware,
 // the test will fail if the proxy's given private key is not granted on the ACT.
-func tTestAccessPK(t *testing.T) {
+func testPK(t *testing.T) {
 	dataFilename := testutil.TempFileWithContent(t, data)
 	defer os.RemoveAll(dataFilename)
 
@@ -360,22 +360,22 @@ func tTestAccessPK(t *testing.T) {
 	}
 }
 
-// TestAccessACT tests the creation of the ACT manifest end-to-end, without any bogus entries (i.e. default scenario = 3 nodes 1 unauthorized)
-func tTestAccessACT(t *testing.T) {
-	testAccessACT(t, 0)
+// testACTWithoutBogus tests the creation of the ACT manifest end-to-end, without any bogus entries (i.e. default scenario = 3 nodes 1 unauthorized)
+func testACTWithoutBogus(t *testing.T) {
+	testACT(t, 0)
 }
 
-// TestAccessACTScale tests the creation of the ACT manifest end-to-end, with 1000 bogus entries (i.e. 1000 EC keys + default scenario = 3 nodes 1 unauthorized = 1003 keys in the ACT manifest)
-func tTestAccessACTScale(t *testing.T) {
-	testAccessACT(t, 1000)
+// testACTWithBogus tests the creation of the ACT manifest end-to-end, with 100 bogus entries (i.e. 100 EC keys + default scenario = 3 nodes 1 unauthorized = 103 keys in the ACT manifest)
+func testACTWithBogus(t *testing.T) {
+	testACT(t, 100)
 }
 
-// TestAccessACT tests the e2e creation, uploading and downloading of an ACT access control with both EC keys AND password protection
+// testACT tests the e2e creation, uploading and downloading of an ACT access control with both EC keys AND password protection
 // the test fires up a 3 node cluster, then randomly picks 2 nodes which will be acting as grantees to the data
 // set and also protects the ACT with a password. the third node should fail decoding the reference as it will not be granted access.
 // the third node then then tries to download using a correct password (and succeeds) then uses a wrong password and fails.
 // the publisher uploads through one of the nodes then disappears.
-func testAccessACT(t *testing.T, bogusEntries int) {
+func testACT(t *testing.T, bogusEntries int) {
 	var uploadThroughNode = cluster.Nodes[0]
 	client := swarmapi.NewClient(uploadThroughNode.URL)
 

--- a/cmd/swarm/export_test.go
+++ b/cmd/swarm/export_test.go
@@ -43,8 +43,8 @@ func TestCLISwarmExportImport(t *testing.T) {
 	}
 	cluster := newTestCluster(t, 1)
 
-	// generate random 10mb file
-	content := testutil.RandomBytes(1, 10000000)
+	// generate random 1mb file
+	content := testutil.RandomBytes(1, 1000000)
 	fileName := testutil.TempFileWithContent(t, string(content))
 	defer os.Remove(fileName)
 

--- a/cmd/swarm/feeds_test.go
+++ b/cmd/swarm/feeds_test.go
@@ -36,7 +36,6 @@ import (
 )
 
 func TestCLIFeedUpdate(t *testing.T) {
-
 	srv := swarmhttp.NewTestSwarmServer(t, func(api *api.API) swarmhttp.TestServer {
 		return swarmhttp.NewServer(api, "")
 	}, nil)
@@ -44,7 +43,6 @@ func TestCLIFeedUpdate(t *testing.T) {
 	defer srv.Close()
 
 	// create a private key file for signing
-
 	privkeyHex := "0000000000000000000000000000000000000000000000000000000000001979"
 	privKey, _ := crypto.HexToECDSA(privkeyHex)
 	address := crypto.PubkeyToAddress(privKey.PublicKey)

--- a/cmd/swarm/fs_test.go
+++ b/cmd/swarm/fs_test.go
@@ -29,13 +29,7 @@ import (
 	"time"
 
 	"github.com/ethereum/go-ethereum/log"
-	colorable "github.com/mattn/go-colorable"
 )
-
-func init() {
-	log.PrintOrigins(true)
-	log.Root().SetHandler(log.LvlFilterHandler(log.Lvl(*loglevel), log.StreamHandler(colorable.NewColorableStderr(), log.TerminalFormat(true))))
-}
 
 type testFile struct {
 	filePath string

--- a/cmd/swarm/run_test.go
+++ b/cmd/swarm/run_test.go
@@ -57,6 +57,17 @@ func init() {
 	})
 }
 
+const clusterSize = 3
+
+var clusteronce sync.Once
+var cluster *testCluster
+
+func initCluster(t *testing.T) {
+	clusteronce.Do(func() {
+		cluster = newTestCluster(t, clusterSize)
+	})
+}
+
 func serverFunc(api *api.API) swarmhttp.TestServer {
 	return swarmhttp.NewServer(api, "")
 }

--- a/cmd/swarm/upload_test.go
+++ b/cmd/swarm/upload_test.go
@@ -46,6 +46,8 @@ func TestSwarmUp(t *testing.T) {
 		t.Skip()
 	}
 
+	initCluster(t)
+
 	cases := []struct {
 		name string
 		f    func(t *testing.T)
@@ -56,9 +58,6 @@ func TestSwarmUp(t *testing.T) {
 		{"RecursiveEncrypted", testRecursiveEncrypted},
 		{"DefaultPathAll", testDefaultPathAll},
 	}
-
-	cluster = newTestCluster(t, clusterSize)
-	defer cluster.Shutdown()
 
 	for _, tc := range cases {
 		t.Run(tc.name, tc.f)

--- a/cmd/swarm/upload_test.go
+++ b/cmd/swarm/upload_test.go
@@ -41,16 +41,20 @@ func init() {
 	log.Root().SetHandler(log.LvlFilterHandler(log.Lvl(*loglevel), log.StreamHandler(colorable.NewColorableStderr(), log.TerminalFormat(true))))
 }
 
-func TestCLI(t *testing.T) {
+func TestSwarmUp(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip()
+	}
+
 	cases := []struct {
 		name string
 		f    func(t *testing.T)
 	}{
-		{"SwarmUp", tTestCLISwarmUp},
-		{"SwarmUpEncrypted", tTestCLISwarmUpEncrypted},
-		{"SwarmUpRecursive", tTestCLISwarmUpRecursive},
-		{"SwarmUpEncryptedRecursive", tTestCLISwarmUpEncryptedRecursive},
-		{"SwarmUpDefaultPath", tTestCLISwarmUpDefaultPath},
+		{"NoEncryption", testNoEncryption},
+		{"Encrypted", testEncrypted},
+		{"RecursiveNoEncryption", testRecursiveNoEncryption},
+		{"RecursiveEncrypted", testRecursiveEncrypted},
+		{"DefaultPathAll", testDefaultPathAll},
 	}
 
 	cluster = newTestCluster(t, clusterSize)
@@ -61,38 +65,27 @@ func TestCLI(t *testing.T) {
 	}
 }
 
-// TestCLISwarmUp tests that running 'swarm up' makes the resulting file
+// testNoEncryption tests that running 'swarm up' makes the resulting file
 // available from all nodes via the HTTP API
-func tTestCLISwarmUp(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip()
-	}
-
-	testCLISwarmUp(false, t)
-}
-func tTestCLISwarmUpRecursive(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip()
-	}
-	testCLISwarmUpRecursive(false, t)
+func testNoEncryption(t *testing.T) {
+	testDefault(false, t)
 }
 
-// TestCLISwarmUpEncrypted tests that running 'swarm encrypted-up' makes the resulting file
+// testEncrypted tests that running 'swarm up --encrypted' makes the resulting file
 // available from all nodes via the HTTP API
-func tTestCLISwarmUpEncrypted(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip()
-	}
-	testCLISwarmUp(true, t)
-}
-func tTestCLISwarmUpEncryptedRecursive(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip()
-	}
-	testCLISwarmUpRecursive(true, t)
+func testEncrypted(t *testing.T) {
+	testDefault(true, t)
 }
 
-func testCLISwarmUp(toEncrypt bool, t *testing.T) {
+func testRecursiveNoEncryption(t *testing.T) {
+	testRecursive(false, t)
+}
+
+func testRecursiveEncrypted(t *testing.T) {
+	testRecursive(true, t)
+}
+
+func testDefault(toEncrypt bool, t *testing.T) {
 	tmpFileName := testutil.TempFileWithContent(t, data)
 	defer os.Remove(tmpFileName)
 
@@ -197,7 +190,7 @@ func testCLISwarmUp(toEncrypt bool, t *testing.T) {
 	}
 }
 
-func testCLISwarmUpRecursive(toEncrypt bool, t *testing.T) {
+func testRecursive(toEncrypt bool, t *testing.T) {
 	tmpUploadDir, err := ioutil.TempDir("", "swarm-test")
 	if err != nil {
 		t.Fatal(err)
@@ -285,19 +278,16 @@ func testCLISwarmUpRecursive(toEncrypt bool, t *testing.T) {
 	}
 }
 
-// TestCLISwarmUpDefaultPath tests swarm recursive upload with relative and absolute
+// testDefaultPathAll tests swarm recursive upload with relative and absolute
 // default paths and with encryption.
-func tTestCLISwarmUpDefaultPath(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip()
-	}
-	testCLISwarmUpDefaultPath(false, false, t)
-	testCLISwarmUpDefaultPath(false, true, t)
-	testCLISwarmUpDefaultPath(true, false, t)
-	testCLISwarmUpDefaultPath(true, true, t)
+func testDefaultPathAll(t *testing.T) {
+	testDefaultPath(false, false, t)
+	testDefaultPath(false, true, t)
+	testDefaultPath(true, false, t)
+	testDefaultPath(true, true, t)
 }
 
-func testCLISwarmUpDefaultPath(toEncrypt bool, absDefaultPath bool, t *testing.T) {
+func testDefaultPath(toEncrypt bool, absDefaultPath bool, t *testing.T) {
 	tmp, err := ioutil.TempDir("", "swarm-defaultpath-test")
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
Updated tests to use a global cluster, instead of starting one within each test.

Improvement of ~1min. to `/cmd/swarm` test package.