### PR TITLE
whisper: log errors on failed tests

### DIFF
--- a/whisper/whisperv5/peer_test.go
+++ b/whisper/whisperv5/peer_test.go
@@ -139,7 +139,7 @@ func initialize(t *testing.T) {
 
 		err = node.server.Start()
 		if err != nil {
-			t.Fatalf("failed to start server %d.", i)
+			t.Fatalf("failed to start server %d. err: %v", i, err)
 		}
 
 		for j := 0; j < i; j++ {

--- a/whisper/whisperv6/peer_test.go
+++ b/whisper/whisperv6/peer_test.go
@@ -232,7 +232,7 @@ func initialize(t *testing.T) {
 func startServer(t *testing.T, s *p2p.Server) {
 	err := s.Start()
 	if err != nil {
-		t.Fatalf("failed to start the fisrt server.")
+		t.Fatalf("failed to start the first server. err: %v", err)
 	}
 
 	atomic.AddInt64(&result.started, 1)


### PR DESCRIPTION
Whisper's `TestSimulation` is very flaky lately on macOS on Travis.

This PR is adding a bunch of logs for the errors returned, so that we can try to figure out why the test is flaky and fix it. It seems to be flaky both under `whisperv5` and `whisperv6` packages.

---

For reference, see https://travis-ci.org/ethereum/go-ethereum/jobs/456978160

```
--- FAIL: TestSimulation (0.19s)
    peer_test.go:142: failed to start server 15.
FAIL
coverage: 57.6% of statements
FAIL	github.com/ethereum/go-ethereum/whisper/whisperv5	13.730s
```