### PR TITLE
Accounting metrics reporter

### DIFF
--- a/p2p/protocols/accounting.go
+++ b/p2p/protocols/accounting.go
@@ -109,8 +109,14 @@ func NewAccounting(balance Balance, po Prices) *Accounting {
 	return ah
 }
 
+//SetupAccountingMetrics creates a separate registry for p2p accounting metrics;
+//this registry should be independent of any other metrics as it persists at different endpoints.
+//It also instantiates the given metrics and starts the persisting go-routine which
+//at the passed interval writes the metrics to a LevelDB
 func SetupAccountingMetrics(reportInterval time.Duration, path string) *leveldb.DB {
+	//create an empty registry
 	registry := metrics.NewRegistry()
+	//instantiate the metrics
 	mBalanceCredit = metrics.NewRegisteredCounterForced("account.balance.credit", registry)
 	mBalanceDebit = metrics.NewRegisteredCounterForced("account.balance.debit", registry)
 	mBytesCredit = metrics.NewRegisteredCounterForced("account.bytes.credit", registry)
@@ -119,7 +125,7 @@ func SetupAccountingMetrics(reportInterval time.Duration, path string) *leveldb.
 	mMsgDebit = metrics.NewRegisteredCounterForced("account.msg.debit", registry)
 	mPeerDrops = metrics.NewRegisteredCounterForced("account.peerdrops", registry)
 	mSelfDrops = metrics.NewRegisteredCounterForced("account.selfdrops", registry)
-
+	//create the DB and start persisting
 	return NewMetricsDB(registry, reportInterval, path)
 }
 

--- a/p2p/protocols/accounting.go
+++ b/p2p/protocols/accounting.go
@@ -20,7 +20,6 @@ import (
 	"time"
 
 	"github.com/ethereum/go-ethereum/metrics"
-	"github.com/syndtr/goleveldb/leveldb"
 )
 
 //define some metrics
@@ -113,7 +112,7 @@ func NewAccounting(balance Balance, po Prices) *Accounting {
 //this registry should be independent of any other metrics as it persists at different endpoints.
 //It also instantiates the given metrics and starts the persisting go-routine which
 //at the passed interval writes the metrics to a LevelDB
-func SetupAccountingMetrics(reportInterval time.Duration, path string) *leveldb.DB {
+func SetupAccountingMetrics(reportInterval time.Duration, path string) *AccountingMetrics {
 	//create an empty registry
 	registry := metrics.NewRegistry()
 	//instantiate the metrics
@@ -126,7 +125,7 @@ func SetupAccountingMetrics(reportInterval time.Duration, path string) *leveldb.
 	mPeerDrops = metrics.NewRegisteredCounterForced("account.peerdrops", registry)
 	mSelfDrops = metrics.NewRegisteredCounterForced("account.selfdrops", registry)
 	//create the DB and start persisting
-	return NewMetricsDB(registry, reportInterval, path)
+	return NewAccountingMetrics(registry, reportInterval, path)
 }
 
 //Implement Hook.Send

--- a/p2p/protocols/accounting_simulation_test.go
+++ b/p2p/protocols/accounting_simulation_test.go
@@ -20,7 +20,10 @@ import (
 	"context"
 	"flag"
 	"fmt"
+	"io/ioutil"
 	"math/rand"
+	"os"
+	"path/filepath"
 	"reflect"
 	"sync"
 	"testing"
@@ -66,6 +69,13 @@ func init() {
 func TestAccountingSimulation(t *testing.T) {
 	//setup the balances objects for every node
 	bal := newBalances(*nodes)
+	//setup the metrics system or tests will fail trying to write metrics
+	dir, err := ioutil.TempDir("", "account-sim")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(dir)
+	SetupAccountingMetrics(1*time.Second, filepath.Join(dir, "metrics.db"))
 	//define the node.Service for this test
 	services := adapters.Services{
 		"accounting": func(ctx *adapters.ServiceContext) (node.Service, error) {

--- a/p2p/protocols/reporter.go
+++ b/p2p/protocols/reporter.go
@@ -128,7 +128,6 @@ func (r *reporter) run() {
 
 //send the metrics to the DB
 func (r *reporter) save() error {
-	var err error
 	//create a LevelDB Batch
 	batch := leveldb.Batch{}
 	//for each metric in the registry (which is independent)...
@@ -144,13 +143,5 @@ func (r *reporter) save() error {
 			batch.Put([]byte(name), byteVal)
 		}
 	})
-	if batch.Len() > 0 {
-		err = r.db.Write(&batch, nil)
-		if err != nil {
-			return err
-		}
-		batch.Reset()
-	}
-
-	return err
+	return r.db.Write(&batch, nil)
 }

--- a/p2p/protocols/reporter.go
+++ b/p2p/protocols/reporter.go
@@ -1,0 +1,71 @@
+// Copyright 2018 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+package protocols
+
+import (
+	"time"
+
+	"github.com/ethereum/go-ethereum/log"
+	"github.com/ethereum/go-ethereum/swarm/state"
+	"github.com/rcrowley/go-metrics"
+)
+
+type reporter struct {
+	reg        metrics.Registry
+	interval   time.Duration
+	stateStore *state.DBStore
+}
+
+func NewMetricsStateStore(r metrics.Registry, d time.Duration, path string) {
+	stateStore, err := state.NewDBStore(path)
+	if err != nil {
+		return
+	}
+
+	rep := &reporter{
+		reg:        r,
+		interval:   d,
+		stateStore: stateStore,
+	}
+
+	rep.run()
+}
+
+func (r *reporter) run() {
+	intervalTicker := time.NewTicker(r.interval)
+
+	for _ = range intervalTicker.C {
+		if err := r.send(); err != nil {
+			log.Error("unable to send metrics to InfluxDB. err=%v", err)
+		}
+	}
+}
+
+func (r *reporter) send() error {
+
+	var err error
+
+	r.reg.Each(func(name string, i interface{}) {
+		switch metric := i.(type) {
+		case metrics.Counter:
+			ms := metric.Snapshot()
+			err = r.stateStore.Put(name, ms.Count())
+		}
+	})
+
+	return err
+}

--- a/p2p/protocols/reporter_test.go
+++ b/p2p/protocols/reporter_test.go
@@ -1,0 +1,74 @@
+// Copyright 2018 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+package protocols
+
+import (
+	"os"
+	"testing"
+	"time"
+
+	"github.com/ethereum/go-ethereum/swarm/state"
+	"github.com/rcrowley/go-metrics"
+)
+
+func TestReporter(t *testing.T) {
+	dir := os.TempDir()
+	defer os.RemoveAll(dir)
+
+	stateStore, err := state.NewDBStore(dir + "/test.db")
+	if err != nil {
+		return
+	}
+
+	rep := &reporter{
+		reg:        metrics.NewRegistry(),
+		interval:   time.Millisecond,
+		stateStore: stateStore,
+	}
+	go rep.run()
+	time.Sleep(1 * time.Second)
+	mBalanceCredit.Inc(12)
+	mBytesCredit.Inc(34)
+	mMsgDebit.Inc(9)
+
+	rep = nil
+	stateStore.Close()
+	stateStore, err = state.NewDBStore(dir + "/test.db")
+	if err != nil {
+		return
+	}
+	rep = &reporter{
+		reg:        metrics.NewRegistry(),
+		interval:   time.Millisecond,
+		stateStore: stateStore,
+	}
+	go rep.run()
+	time.Sleep(1 * time.Second)
+	mBalanceCredit.Inc(11)
+	mBytesCredit.Inc(22)
+	mMsgDebit.Inc(7)
+
+	if mBalanceCredit.Count() != 23 {
+		t.Fatalf("Expected counter to be %d, but is %d", 23, mBalanceCredit.Count())
+	}
+	if mBytesCredit.Count() != 56 {
+		t.Fatalf("Expected counter to be %d, but is %d", 23, mBytesCredit.Count())
+	}
+	if mMsgDebit.Count() != 16 {
+		t.Fatalf("Expected counter to be %d, but is %d", 23, mMsgDebit.Count())
+	}
+}

--- a/p2p/protocols/reporter_test.go
+++ b/p2p/protocols/reporter_test.go
@@ -39,8 +39,8 @@ func TestReporter(t *testing.T) {
 
 	//setup the metrics
 	log.Debug("Setting up metrics first time")
-	reportInterval := 100 * time.Millisecond
-	db := SetupAccountingMetrics(reportInterval, filepath.Join(dir, "test.db"))
+	reportInterval := 5 * time.Millisecond
+	metrics := SetupAccountingMetrics(reportInterval, filepath.Join(dir, "test.db"))
 	log.Debug("Done.")
 
 	//do some metrics
@@ -49,18 +49,19 @@ func TestReporter(t *testing.T) {
 	mMsgDebit.Inc(9)
 
 	//give the reporter time to write the metrics to DB
-	time.Sleep(500 * time.Millisecond)
+	time.Sleep(20 * time.Millisecond)
 
 	//set the metrics to nil - this effectively simulates the node having shut down...
 	mBalanceCredit = nil
 	mBytesCredit = nil
 	mMsgDebit = nil
 	//close the DB also, or we can't create a new one
-	db.Close()
+	metrics.Close()
 
 	//setup the metrics again
 	log.Debug("Setting up metrics second time")
-	SetupAccountingMetrics(reportInterval, filepath.Join(dir, "test.db"))
+	metrics = SetupAccountingMetrics(reportInterval, filepath.Join(dir, "test.db"))
+	defer metrics.Close()
 	log.Debug("Done.")
 
 	//now check the metrics, they should have the same value as before "shutdown"

--- a/swarm/swap/swap.go
+++ b/swarm/swap/swap.go
@@ -91,3 +91,8 @@ func (s *Swap) loadState(peer *protocols.Peer) (err error) {
 	}
 	return
 }
+
+//Clean up Swap
+func (swap *Swap) Close() {
+	swap.stateStore.Close()
+}

--- a/swarm/swarm.go
+++ b/swarm/swarm.go
@@ -461,11 +461,12 @@ func (self *Swarm) Stop() error {
 	self.sfs.Stop()
 	stopCounter.Inc(1)
 	self.streamer.Stop()
+
+	err := self.bzz.Stop()
 	if self.stateStore != nil {
 		self.stateStore.Close()
 	}
-
-	return self.bzz.Stop()
+	return err
 }
 
 // implements the node.Service interface

--- a/swarm/swarm.go
+++ b/swarm/swarm.go
@@ -179,6 +179,7 @@ func NewSwarm(config *api.Config, mockStore *mock.NodeStore) (self *Swarm, err e
 			return nil, err
 		}
 		self.swap = swap.New(balancesStore)
+		protocols.SetupAccountingMetrics(10 *time.Second, filepath.Join(config.Path, "metrics.db"))
 	}
 
 	var nodeID enode.ID

--- a/swarm/swarm.go
+++ b/swarm/swarm.go
@@ -136,7 +136,7 @@ func NewSwarm(config *api.Config, mockStore *mock.NodeStore) (self *Swarm, err e
 		LightNode:   config.LightNodeEnabled,
 	}
 
-	stateStore, err := state.NewDBStore(filepath.Join(config.Path, "state-store.db"))
+	self.stateStore, err = state.NewDBStore(filepath.Join(config.Path, "state-store.db"))
 	if err != nil {
 		return
 	}
@@ -206,7 +206,7 @@ func NewSwarm(config *api.Config, mockStore *mock.NodeStore) (self *Swarm, err e
 		SyncUpdateDelay: config.SyncUpdateDelay,
 		MaxPeerServers:  config.MaxStreamPeerServers,
 	}
-	self.streamer = stream.NewRegistry(nodeID, delivery, self.netStore, stateStore, registryOptions, self.swap)
+	self.streamer = stream.NewRegistry(nodeID, delivery, self.netStore, self.stateStore, registryOptions, self.swap)
 
 	// Swarm Hash Merklised Chunking for Arbitrary-length Document/File storage
 	self.fileStore = storage.NewFileStore(self.netStore, self.config.FileStoreParams)
@@ -229,7 +229,7 @@ func NewSwarm(config *api.Config, mockStore *mock.NodeStore) (self *Swarm, err e
 
 	log.Debug("Setup local storage")
 
-	self.bzz = network.NewBzz(bzzconfig, to, stateStore, self.streamer.GetSpec(), self.streamer.Run)
+	self.bzz = network.NewBzz(bzzconfig, to, self.stateStore, self.streamer.GetSpec(), self.streamer.Run)
 
 	// Pss = postal service over swarm (devp2p over bzz)
 	self.ps, err = pss.NewPss(to, config.Pss)

--- a/swarm/swarm.go
+++ b/swarm/swarm.go
@@ -455,16 +455,16 @@ func (self *Swarm) Stop() error {
 	if self.accountingMetrics != nil {
 		self.accountingMetrics.Close()
 	}
-	if self.stateStore != nil {
-		self.stateStore.Close()
-	}
-
 	if self.netStore != nil {
 		self.netStore.Close()
 	}
 	self.sfs.Stop()
 	stopCounter.Inc(1)
 	self.streamer.Stop()
+	if self.stateStore != nil {
+		self.stateStore.Close()
+	}
+
 	return self.bzz.Stop()
 }
 


### PR DESCRIPTION
The first p2p accounting PR https://github.com/ethereum/go-ethereum/pull/17951 introduced a couple of metrics for the accounting (accounted bytes sent/received, accounted messages sent/received, etc.).

Those metrics though were not persisted, and would be reset after every node restart.

These are metrics of interest to the end user, and represent (crypto-)economic indicators, which may give her insights to how her node is performing in terms of profitability.

This PR introduces functionality to persist these metrics to a DB.
The set of metrics can be extended later if required.