### PR TITLE
travis: increase open file limits on macOS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,6 +29,14 @@ matrix:
     - os: osx
       go: 1.11.x
       script:
+        - echo "Increase the maximum number of open file descriptors on macOS"
+        - NOFILE=20480
+        - sudo sysctl -w kern.maxfiles=$NOFILE
+        - sudo sysctl -w kern.maxfilesperproc=$NOFILE
+        - sudo launchctl limit maxfiles $NOFILE $NOFILE
+        - sudo launchctl limit maxfiles
+        - ulimit -S -n $NOFILE
+        - ulimit -n
         - unset -f cd # workaround for https://github.com/travis-ci/travis-ci/issues/8703
         - go run build/ci.go install
         - go run build/ci.go test -coverage $TEST_PACKAGES


### PR DESCRIPTION
Some tests have been failing lately on macOS on Travis due to `too many open files`.

This PR is increasing the open file limits.

From:
```
$ sudo sysctl kern.maxfiles
kern.maxfiles: 12288

$ sudo sysctl kern.maxfilesperproc
kern.maxfilesperproc: 10240

$ sudo launchctl limit maxfiles
maxfiles    256            unlimited

$ ulimit -n
256
```

To:
```
$ sudo sysctl -w kern.maxfiles=$NOFILE
kern.maxfiles: 12288 -> 20480

$ sudo sysctl -w kern.maxfilesperproc=$NOFILE
kern.maxfilesperproc: 10240 -> 20480

$ ulimit -n
20480
```