### PR TITLE
Better bad block printouts

### DIFF
--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -1470,7 +1470,7 @@ func (bc *BlockChain) reportBlock(block *types.Block, receipts types.Receipts, e
 
 	var receiptString string
 	for i, receipt := range receipts {
-		receiptString += fmt.Sprintf("\t %d: cumulative: %v gas: %v contrract: %v status: %v tx: %v logs: %v bloom: %x state: %x\n",
+		receiptString += fmt.Sprintf("\t %d: cumulative: %v gas: %v contract: %v status: %v tx: %v logs: %v bloom: %x state: %x\n",
 			i, receipt.CumulativeGasUsed, receipt.GasUsed, receipt.ContractAddress.Hex(),
 			receipt.Status, receipt.TxHash.Hex(), receipt.Logs, receipt.Bloom, receipt.PostState)
 	}

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -1469,8 +1469,10 @@ func (bc *BlockChain) reportBlock(block *types.Block, receipts types.Receipts, e
 	bc.addBadBlock(block)
 
 	var receiptString string
-	for _, receipt := range receipts {
-		receiptString += fmt.Sprintf("\t%v\n", receipt)
+	for i, receipt := range receipts {
+		receiptString += fmt.Sprintf("\t %d: cumulative: %v gas: %v contrract: %v status: %v tx: %v logs: %v bloom: %x state: %x\n",
+			i, receipt.CumulativeGasUsed, receipt.GasUsed, receipt.ContractAddress.Hex(),
+			receipt.Status, receipt.TxHash.Hex(), receipt.Logs, receipt.Bloom, receipt.PostState)
 	}
 	log.Error(fmt.Sprintf(`
 ########## BAD BLOCK #########


### PR DESCRIPTION
This PR improves the current bad block reports that gets shown in the console. 
Example:
```
########## BAD BLOCK #########
Chain config: {ChainID: 1 Homestead: 1150000 DAO: 1920000 DAOSupport: true EIP150: 2463000 EIP155: 2675000 EIP158: 2675000 Byzantium: 4370000 Constantinople: <nil> Engine: ethash}

Number: 79589
Hash: 0x29f38d3e0b76d14d48b0e21cbf5c094f8f721f2908eb492de610b9f907dff3f1
	 0: cumGasUsed: 21000 gasUsed: 21000 cAddress 0x0000000000000000000000000000000000000000 status 1 txHash 0xe18b4c8e1b1777c865deeed6ec9418aa52d2ec3567f7e2192d7041630daa41fa logs [] bloom 00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000 postState 5e4690f6300b73d7b8e44b47dc89c81a414284419abef44cf94bc132c9bdb4aa
	 1: cumGasUsed: 83247 gasUsed: 62247 cAddress 0x0000000000000000000000000000000000000000 status 1 txHash 0x12c1e8c0d3a9d53600bdd7497bf63d44d449c5253ab1e8eb03fcc080ee05a4bd logs [] bloom 00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000 postState 52e8d26745cbd957e02630484b0ee8b860d70f213969bea38ac273f9e03ce14d


Error: test
##############################
```

Without this PR: 
```
 ########## BAD BLOCK ######### 
 Chain config: {ChainID: 1 Homestead: 1150000 DAO: 1920000 DAOSupport: true EIP150: 2463000 EIP155: 2675000 EIP158: 2675000 Byzantium: 4370000 Constantinople: <nil> Engine: ethash} 
 Number: 4181245 
 Hash: 0x6f983c419d5d439a737bf99ad996d11710eee861e72143c21cf607239666e51b 
 	&{[165 157 2 159 26 40 185 100 251 228 152 3 21 240 23 41 46 151 142 206 125 211 83 38 115 35 0 135 187 65 26 222] 1 21000 [0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0] [] [149 129 57 75 30 73 29 237 26 141 32 210 48 19 43 124 8 250 144 170 35 109 221 13 84 61 168 52 169 4 123 24] [0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0] 21000} 
 	&{[181 147 98 65 97 125 163 111 176 206 183 90 240 110 32 212 138 105 170 23 188 221 137 229 132 127 62 198 202 71 206 42] 1 42000 [0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0] [] [1 153 163 200 138 54 214 199 100 164 89 109 199 27 197 156 62 193 119 64 68 96 86 105 132 116 12 139 116 229 34 73] [0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0] 21000} 
```