### PR TITLE
swarm: use swarm/mock/mem as mock global store

### DIFF
--- a/swarm/network/stream/common_test.go
+++ b/swarm/network/stream/common_test.go
@@ -38,7 +38,6 @@ import (
 	"github.com/ethereum/go-ethereum/swarm/pot"
 	"github.com/ethereum/go-ethereum/swarm/state"
 	"github.com/ethereum/go-ethereum/swarm/storage"
-	mockdb "github.com/ethereum/go-ethereum/swarm/storage/mock/db"
 	"github.com/ethereum/go-ethereum/swarm/testutil"
 	colorable "github.com/mattn/go-colorable"
 )
@@ -67,21 +66,6 @@ func init() {
 
 	log.PrintOrigins(true)
 	log.Root().SetHandler(log.LvlFilterHandler(log.Lvl(*loglevel), log.StreamHandler(colorable.NewColorableStderr(), log.TerminalFormat(true))))
-}
-
-func createGlobalStore() (string, *mockdb.GlobalStore, error) {
-	var globalStore *mockdb.GlobalStore
-	globalStoreDir, err := ioutil.TempDir("", "global.store")
-	if err != nil {
-		log.Error("Error initiating global store temp directory!", "err", err)
-		return "", nil, err
-	}
-	globalStore, err = mockdb.NewGlobalStore(globalStoreDir)
-	if err != nil {
-		log.Error("Error initiating global store!", "err", err)
-		return "", nil, err
-	}
-	return globalStoreDir, globalStore, nil
 }
 
 func newStreamerTester(t *testing.T, registryOptions *RegistryOptions) (*p2ptest.ProtocolTester, *Registry, *storage.LocalStore, func(), error) {

--- a/swarm/network/stream/snapshot_sync_test.go
+++ b/swarm/network/stream/snapshot_sync_test.go
@@ -35,7 +35,8 @@ import (
 	"github.com/ethereum/go-ethereum/swarm/pot"
 	"github.com/ethereum/go-ethereum/swarm/state"
 	"github.com/ethereum/go-ethereum/swarm/storage"
-	mockdb "github.com/ethereum/go-ethereum/swarm/storage/mock/db"
+	"github.com/ethereum/go-ethereum/swarm/storage/mock"
+	mockmem "github.com/ethereum/go-ethereum/swarm/storage/mock/mem"
 	"github.com/ethereum/go-ethereum/swarm/testutil"
 )
 
@@ -268,20 +269,9 @@ func runSim(conf *synctestConfig, ctx context.Context, sim *simulation.Simulatio
 
 		// File retrieval check is repeated until all uploaded files are retrieved from all nodes
 		// or until the timeout is reached.
-		var gDir string
-		var globalStore *mockdb.GlobalStore
+		var globalStore mock.GlobalStorer
 		if *useMockStore {
-			gDir, globalStore, err = createGlobalStore()
-			if err != nil {
-				return fmt.Errorf("Something went wrong; using mockStore enabled but globalStore is nil")
-			}
-			defer func() {
-				os.RemoveAll(gDir)
-				err := globalStore.Close()
-				if err != nil {
-					log.Error("Error closing global store! %v", "err", err)
-				}
-			}()
+			globalStore = mockmem.NewGlobalStore()
 		}
 	REPEAT:
 		for {
@@ -476,14 +466,9 @@ func testSyncingViaDirectSubscribe(t *testing.T, chunkCount int, nodeCount int) 
 			return err
 		}
 
-		var gDir string
-		var globalStore *mockdb.GlobalStore
+		var globalStore mock.GlobalStorer
 		if *useMockStore {
-			gDir, globalStore, err = createGlobalStore()
-			if err != nil {
-				return fmt.Errorf("Something went wrong; using mockStore enabled but globalStore is nil")
-			}
-			defer os.RemoveAll(gDir)
+			globalStore = mockmem.NewGlobalStore()
 		}
 		// File retrieval check is repeated until all uploaded files are retrieved from all nodes
 		// or until the timeout is reached.

--- a/swarm/network/stream/syncer_test.go
+++ b/swarm/network/stream/syncer_test.go
@@ -35,7 +35,8 @@ import (
 	"github.com/ethereum/go-ethereum/swarm/network/simulation"
 	"github.com/ethereum/go-ethereum/swarm/state"
 	"github.com/ethereum/go-ethereum/swarm/storage"
-	mockdb "github.com/ethereum/go-ethereum/swarm/storage/mock/db"
+	"github.com/ethereum/go-ethereum/swarm/storage/mock"
+	mockmem "github.com/ethereum/go-ethereum/swarm/storage/mock/mem"
 	"github.com/ethereum/go-ethereum/swarm/testutil"
 )
 
@@ -48,7 +49,7 @@ func TestSyncerSimulation(t *testing.T) {
 	testSyncBetweenNodes(t, 16, 1, dataChunkCount, true, 1)
 }
 
-func createMockStore(globalStore *mockdb.GlobalStore, id enode.ID, addr *network.BzzAddr) (lstore storage.ChunkStore, datadir string, err error) {
+func createMockStore(globalStore mock.GlobalStorer, id enode.ID, addr *network.BzzAddr) (lstore storage.ChunkStore, datadir string, err error) {
 	address := common.BytesToAddress(id.Bytes())
 	mockStore := globalStore.NewNodeStore(address)
 	params := storage.NewDefaultLocalStoreParams()
@@ -70,8 +71,7 @@ func testSyncBetweenNodes(t *testing.T, nodes, conns, chunkCount int, skipCheck 
 	sim := simulation.New(map[string]simulation.ServiceFunc{
 		"streamer": func(ctx *adapters.ServiceContext, bucket *sync.Map) (s node.Service, cleanup func(), err error) {
 			var store storage.ChunkStore
-			var globalStore *mockdb.GlobalStore
-			var gDir, datadir string
+			var datadir string
 
 			node := ctx.Config.Node()
 			addr := network.NewAddr(node)
@@ -79,11 +79,7 @@ func testSyncBetweenNodes(t *testing.T, nodes, conns, chunkCount int, skipCheck 
 			addr.OAddr[0] = byte(0)
 
 			if *useMockStore {
-				gDir, globalStore, err = createGlobalStore()
-				if err != nil {
-					return nil, nil, fmt.Errorf("Something went wrong; using mockStore enabled but globalStore is nil")
-				}
-				store, datadir, err = createMockStore(globalStore, node.ID(), addr)
+				store, datadir, err = createMockStore(mockmem.NewGlobalStore(), node.ID(), addr)
 			} else {
 				store, datadir, err = createTestLocalStorageForID(node.ID(), addr)
 			}
@@ -94,13 +90,6 @@ func testSyncBetweenNodes(t *testing.T, nodes, conns, chunkCount int, skipCheck 
 			cleanup = func() {
 				store.Close()
 				os.RemoveAll(datadir)
-				if *useMockStore {
-					err := globalStore.Close()
-					if err != nil {
-						log.Error("Error closing global store! %v", "err", err)
-					}
-					os.RemoveAll(gDir)
-				}
 			}
 			localStore := store.(*storage.LocalStore)
 			netStore, err := storage.NewNetStore(localStore, nil)


### PR DESCRIPTION
This PR has been discussed and reviewed here https://github.com/ethersphere/go-ethereum/pull/1009.