### PR TITLE
trie/database: fix overflow in parent tracking

### DIFF
--- a/trie/database.go
+++ b/trie/database.go
@@ -141,7 +141,7 @@ type cachedNode struct {
 	node node   // Cached collapsed trie node, or raw rlp data
 	size uint16 // Byte size of the useful cached data
 
-	parents  uint16                 // Number of live nodes referencing this one
+	parents  uint32                 // Number of live nodes referencing this one
 	children map[common.Hash]uint16 // External children referenced by this node
 
 	flushPrev common.Hash // Previous node in the flush-list


### PR DESCRIPTION
Geth's in-memory pruning mechanism keeps a reference about how many `parents` a trie node has. 

When geth is running on a machine with a large cache allowance, this cache can become very large, and during certain circumstances, the parent counter would overflow. 

Example of what happens with bittrex wallets when the number of references exceed `65535` during a period when a lot of contracts were created, all referencing the codehash `0xce3220..`
```
parent=829a04a370589f53...                                              child.parents=65535 parent.children=1
INFO [11-22|13:50:17.664] trie/database adding reference           child/codehash=0xce33220..                                                        parent=90e152f8135795ea...                                              child.parents=0     parent.children=1
INFO [11-22|13:50:17.667] db.dereference                           child=0c31ac230373470aa0ea3512150dc1c54555e30116f1aacb65240092121f4cd4 parent=0000000000000000000000000000000000000000000000000000000000000000
INFO [11-22|13:50:17.667] db.dereference                           child=a8315373ed5c811962749bfd081ebe3bf940c2676af7478c2608a6f77f1556ae parent=0c31ac230373470aa0ea3512150dc1c54555e30116f1aacb65240092121f4cd4
INFO [11-22|13:50:17.667] db.dereference                           child=2d41a74e12e7296be5592765a89f21c6aefbba65f33eb9bd98137da898d6f8de parent=a8315373ed5c811962749bfd081ebe3bf940c2676af7478c2608a6f77f1556ae
```
This PR bumps it to `uint32`, which should be sufficient for even the most extreme cache allowances. 