### PR TITLE
swarm/api: improve not found error msg

### DIFF
--- a/swarm/api/api.go
+++ b/swarm/api/api.go
@@ -472,7 +472,7 @@ func (a *API) Get(ctx context.Context, decrypt DecryptFunc, manifestAddr storage
 		// no entry found
 		status = http.StatusNotFound
 		apiGetNotFound.Inc(1)
-		err = fmt.Errorf("manifest entry for '%s' not found", path)
+		err = fmt.Errorf("Not found: could not find resource '%s'", path)
 		log.Trace("manifest entry not found", "key", contentAddr, "path", path)
 	}
 	return


### PR DESCRIPTION
this PR improves the cryptic error returned to the user when a manifest entry is not found.

fixes https://github.com/ethersphere/go-ethereum/issues/726