### PR TITLE
core: changes mgasps to a speed rating

### DIFF
--- a/core/blockchain_insert.go
+++ b/core/blockchain_insert.go
@@ -55,9 +55,10 @@ func (st *insertStats) report(chain []*types.Block, index int, cache common.Stor
 		end := chain[index]
 
 		// Assemble the log context and send it to the logger
+		sp := float64(st.usedGas) * 1000 / float64(elapsed) * 13 / 8 // ~13s/blk / max 8Mgas/blk = blk/s @ max gas
 		context := []interface{}{
 			"blocks", st.processed, "txs", txs, "mgas", float64(st.usedGas) / 1000000,
-			"elapsed", common.PrettyDuration(elapsed), "mgasps", float64(st.usedGas) * 1000 / float64(elapsed),
+			"elapsed", common.PrettyDuration(elapsed), "speed", sp,
 			"number", end.Number(), "hash", end.Hash(),
 		}
 		if timestamp := time.Unix(end.Time().Int64(), 0); time.Since(timestamp) > time.Minute {


### PR DESCRIPTION
Speed is relative to the maximum speed of the Ethereum blockchain in Mgas/s:
1 speed = 8Mgas/block * 1 block/13s ~= .615 Mgas/s

This speed provides an easy way to understand how fast blocks are being processed.