### PR TITLE
config: add constantinople block to testchainconfig

### DIFF
--- a/params/config.go
+++ b/params/config.go
@@ -120,7 +120,7 @@ var (
 	// adding flags to the config to also have to set these fields.
 	AllCliqueProtocolChanges = &ChainConfig{big.NewInt(1337), big.NewInt(0), nil, false, big.NewInt(0), common.Hash{}, big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), nil, nil, &CliqueConfig{Period: 0, Epoch: 30000}}
 
-	TestChainConfig = &ChainConfig{big.NewInt(1), big.NewInt(0), nil, false, big.NewInt(0), common.Hash{}, big.NewInt(0), big.NewInt(0), big.NewInt(0), nil, nil, new(EthashConfig), nil}
+	TestChainConfig = &ChainConfig{big.NewInt(1), big.NewInt(0), nil, false, big.NewInt(0), common.Hash{}, big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), nil, new(EthashConfig), nil}
 	TestRules       = TestChainConfig.Rules(new(big.Int))
 )
 


### PR DESCRIPTION
Fixes failing testcases after https://github.com/ethereum/go-ethereum/pull/18162 by also adding the change to `TestChainConfig`. Note, though, it's actually still wrong internally, since some chains are generated with AllEthashProtocolChanges whereas chainmaker uses TestChainConfig. So a proper fix would be to ensure that we use the same config. It happens to work now (and previously) because the two are equal. 