### PR TITLE
Increase bzz version

### DIFF
--- a/swarm/network/protocol.go
+++ b/swarm/network/protocol.go
@@ -54,7 +54,7 @@ var BzzSpec = &protocols.Spec{
 // DiscoverySpec is the spec for the bzz discovery subprotocols
 var DiscoverySpec = &protocols.Spec{
 	Name:       "hive",
-	Version:    6,
+	Version:    8,
 	MaxMsgSize: 10 * 1024 * 1024,
 	Messages: []interface{}{
 		peersMsg{},

--- a/swarm/network/protocol.go
+++ b/swarm/network/protocol.go
@@ -44,7 +44,7 @@ const (
 // BzzSpec is the spec of the generic swarm handshake
 var BzzSpec = &protocols.Spec{
 	Name:       "bzz",
-	Version:    7,
+	Version:    8,
 	MaxMsgSize: 10 * 1024 * 1024,
 	Messages: []interface{}{
 		HandshakeMsg{},

--- a/swarm/network/protocol_test.go
+++ b/swarm/network/protocol_test.go
@@ -31,7 +31,7 @@ import (
 )
 
 const (
-	TestProtocolVersion   = 7
+	TestProtocolVersion   = 8
 	TestProtocolNetworkID = 3
 )
 


### PR DESCRIPTION
This PR increases the BZZ protocol version number.

The streamer version had been previously increased, resulting in BZZ version match and peers at kademlia level connecting, but streamer version mismatch.

This resulted in the `peer = nil` bug when requesting peers for chunks, as the kademlia peers would be iterated (BZZ, thus peers were connected) but the correspondent stream protocol peer was not found (version mismatch).

It also adds two tests to prove the version mismatch problem. These tests may be removed if the general version mismatch problem of BZZ-subprotocols will be addressed.

Closes https://github.com/ethersphere/go-ethereum/issues/999