### PR TITLE
tests, core: update tests and make STATICCALL cause touch-delete

### DIFF
--- a/core/vm/evm.go
+++ b/core/vm/evm.go
@@ -339,6 +339,12 @@ func (evm *EVM) StaticCall(caller ContractRef, addr common.Address, input []byte
 	contract := NewContract(caller, to, new(big.Int), gas)
 	contract.SetCallCode(&addr, evm.StateDB.GetCodeHash(addr), evm.StateDB.GetCode(addr))
 
+	// We do an AddBalance of zero here, just in order to trigger a touch.
+	// This doesn't matter on Mainnet, where all empties are gone at the time of Byzantium,
+	// but is the correct thing to do and matters on other networks, in tests, and potential
+	// future scenarios
+	evm.StateDB.AddBalance(addr, bigZero)
+
 	// When an error was returned by the EVM or when setting the creation code
 	// above we revert to the snapshot and consume any gas remaining. Additionally
 	// when we're in Homestead this also counts for code storage gas errors.

--- a/tests/init.go
+++ b/tests/init.go
@@ -86,6 +86,15 @@ var Forks = map[string]*params.ChainConfig{
 		EIP158Block:    big.NewInt(0),
 		ByzantiumBlock: big.NewInt(5),
 	},
+	"ByzantiumToConstantinopleAt5": {
+		ChainID:             big.NewInt(1),
+		HomesteadBlock:      big.NewInt(0),
+		EIP150Block:         big.NewInt(0),
+		EIP155Block:         big.NewInt(0),
+		EIP158Block:         big.NewInt(0),
+		ByzantiumBlock:      big.NewInt(0),
+		ConstantinopleBlock: big.NewInt(5),
+	},
 }
 
 // UnsupportedForkError is returned when a test requests a fork that isn't implemented.


### PR DESCRIPTION
Apart from updating the tests to the most recent source, this also adds the following to a `STATICCALL`:
```
    evm.StateDB.AddBalance(addr, bigZero)
```
This makes `STATICCALL` perform touch-delete. It appears that both parity and aleth is implemented like this. 
Although it's a simple fix, I just wanted to call some attention to this fact, and ask -- is that really the Right Way to consider `STATICCALL`? 

cc @chriseth @sorpaas @winsvega @chfast @ehildenb  @pipermerriam @vbuterin 

Edit to add : this is not an issue for mainet, but could potentially be an issue for other networks, if empties are created and then not cleaned up before transitioning to byzantium. 