### PR TITLE
core/type: change receipt status code

### DIFF
--- a/core/types/receipt.go
+++ b/core/types/receipt.go
@@ -36,10 +36,10 @@ var (
 
 const (
 	// ReceiptStatusFailed is the status code of a transaction if execution failed.
-	ReceiptStatusFailed = uint64(0)
+	ReceiptStatusFailed = uint64(1)
 
 	// ReceiptStatusSuccessful is the status code of a transaction if execution succeeded.
-	ReceiptStatusSuccessful = uint64(1)
+	ReceiptStatusSuccessful = uint64(0)
 )
 
 // Receipt represents the results of a transaction.


### PR DESCRIPTION
Code History : bool -> uint-> uint64 

In PR(https://github.com/ethereum/go-ethereum/pull/15042)  description, we know a question

`there are multiple failures
[Out of gas] or [Bad jump destination]
how does statutscode express`

so solution is use ‘’uint ‘’  replace ‘’bool ‘’  for multiple failures .

But, irrational  status code compared with linux exit code. 
As everyone knows ， linux command exit code , 0 represent success, other codes reprsent multiple failures 