### PR TITLE
eth/downloader: fix light client cht binary search issue

### DIFF
--- a/eth/downloader/downloader.go
+++ b/eth/downloader/downloader.go
@@ -99,6 +99,7 @@ type Downloader struct {
 	mode SyncMode       // Synchronisation mode defining the strategy used (per sync cycle)
 	mux  *event.TypeMux // Event multiplexer to announce sync operation events
 
+	genesis uint64   // Genesis block number to limit sync to (e.g. light client CHT)
 	queue   *queue   // Scheduler for selecting the hashes to download
 	peers   *peerSet // Set of active peers from which download can proceed
 	stateDB ethdb.Database
@@ -664,7 +665,28 @@ func (d *Downloader) findAncestor(p *peerConnection, remoteHeader *types.Header)
 	}
 	p.log.Debug("Looking for common ancestor", "local", localHeight, "remote", remoteHeight)
 	if localHeight >= MaxForkAncestry {
+		// We're above the max reorg threshold, find the earliest fork point
 		floor = int64(localHeight - MaxForkAncestry)
+
+		// If we're doing a light sync, ensure the floor doesn't go below the CHT, as
+		// all headers before that point will be missing.
+		if d.mode == LightSync {
+			// If we dont know the current CHT position, find it
+			if d.genesis == 0 {
+				header := d.lightchain.CurrentHeader()
+				for header != nil {
+					d.genesis = header.Number.Uint64()
+					if floor >= int64(d.genesis)-1 {
+						break
+					}
+					header = d.lightchain.GetHeaderByHash(header.ParentHash)
+				}
+			}
+			// We already know the "genesis" block number, cap floor to that
+			if floor < int64(d.genesis)-1 {
+				floor = int64(d.genesis) - 1
+			}
+		}
 	}
 	from, count, skip, max := calculateRequestSpan(remoteHeight, localHeight)
 


### PR DESCRIPTION
The binary search based ancestor lookup doesn't work for light clients. The reason is that a light client will inject a random header (the one stored in the CHT) and will want to sync from that point onward. A binary search will however try to find the common ancestor from `[HEAD-90K, REMOTE_HEAD]`. Mapping that interval to our header chain would look something like `[nil, nil, nil, nil, nil, CHT_HEADER, nil]`. You can't binary search on this.

The only proper solution is to start from the current header and set the floor of the binary search either to the `HEAD-90K` limit, or to the earliest ancestor that we do have in our database. Unfortunately there's no way to actually find that apart from traversing the chain backward, so that's what this PR does. It also caches the result so we don't do it on every sync cycle.

PS: The reason this worked previously is because the ancestor lookup shortcut always retrieved the current header too. A previous polish of this code however resulted in the current head never being retrieved, only it's parent.