### PR TITLE
.ldb filesize 2MB=>128MB

### DIFF
--- a/ethdb/database.go
+++ b/ethdb/database.go
@@ -78,6 +78,7 @@ func NewLDBDatabase(file string, cache int, handles int) (*LDBDatabase, error) {
 		BlockCacheCapacity:     cache / 2 * opt.MiB,
 		WriteBuffer:            cache / 4 * opt.MiB, // Two of these are used internally
 		Filter:                 filter.NewBloomFilter(10),
+		CompactionTableSize:    128 * opt.MiB,
 	})
 	if _, corrupted := err.(*errors.ErrCorrupted); corrupted {
 		db, err = leveldb.RecoverFile(file, nil)


### PR DESCRIPTION
Changes the level-0 .ldb file size from the default of 2MB to 128MB.
This reduces the number of files in the db directory substantially, helping to reduce the amount of filesystem overhead required to manipulate the db.