### PR TITLE
cmd/evm: commit statedb if dump is requested

### DIFF
--- a/cmd/evm/runner.go
+++ b/cmd/evm/runner.go
@@ -206,6 +206,7 @@ func runCmd(ctx *cli.Context) error {
 	execTime := time.Since(tstart)
 
 	if ctx.GlobalBool(DumpFlag.Name) {
+		statedb.Commit(true)
 		statedb.IntermediateRoot(true)
 		fmt.Println(string(statedb.Dump()))
 	}


### PR DESCRIPTION
Add a call `statedb.Commit(true)` if the `Dump` flag is on, as otherwise the `storage` output in the dump is always empty.