### PR TITLE
cmd/utils: max out the OS file allowance, don't cap to 2K

### DIFF
--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -824,17 +824,12 @@ func setIPC(ctx *cli.Context, cfg *node.Config) {
 // makeDatabaseHandles raises out the number of allowed file handles per process
 // for Geth and returns half of the allowance to assign to the database.
 func makeDatabaseHandles() int {
-	limit, err := fdlimit.Current()
+	limit, err := fdlimit.Maximum()
 	if err != nil {
 		Fatalf("Failed to retrieve file descriptor allowance: %v", err)
 	}
-	if limit < 2048 {
-		if err := fdlimit.Raise(2048); err != nil {
-			Fatalf("Failed to raise file descriptor allowance: %v", err)
-		}
-	}
-	if limit > 2048 { // cap database file descriptors even if more is available
-		limit = 2048
+	if err := fdlimit.Raise(uint64(limit)); err != nil {
+		Fatalf("Failed to raise file descriptor allowance: %v", err)
 	}
 	return limit / 2 // Leave half for networking and other stuff
 }


### PR DESCRIPTION
Supersedes https://github.com/ethereum/go-ethereum/pull/17597, as it can achieve the same results without any flags (i.e. automagically), whilst also ensuring we don't accidentally go over any OS limits (panic in leveldb).

Fast sync benchmarks, 4096 cache, i3.2xlarge (post sync):

The curious thing here is that memory usage seems to be a lot lower and more stable, which is an interesting find. Why would more file descriptors cause less memory? Perhaps there's some issue in leveldb which leaks memory, at least temporarily? **Idea: perhaps it's the transaction pool, not the database!**

![screenshot from 2018-12-04 13-27-42](https://user-images.githubusercontent.com/129561/49439011-9cbdbb80-f7c8-11e8-8fc5-97280cf5c03f.png)

Full sync bnchmarks, 2084 cache, i3.2xlarge:

The speed seems to be more or less the same (4h difference over the course of 4 days, might as well just be a slightly different machine). Database IO wise the "infinite" file descriptors do seem to result in a a 6-7% lower rate. Probably nothing spectacular.

![screenshot from 2018-12-07 14-05-16](https://user-images.githubusercontent.com/129561/49646914-50bd8180-fa29-11e8-9619-11d7ec6953be.png)

---

All in all benchmarks point that there's nothing spectacular happening with this PR, at least on the Linux VMs. I think it's safe to merge just to get rid of an artificial limit we had in our code until now.