### PR TITLE
swarm/pss: Add same api interface for all Send* methods

### DIFF
--- a/swarm/pss/api.go
+++ b/swarm/pss/api.go
@@ -164,6 +164,10 @@ func (pssapi *API) SendSym(symkeyhex string, topic Topic, msg hexutil.Bytes) err
 	return pssapi.Pss.SendSym(symkeyhex, topic, msg[:])
 }
 
+func (pssapi *API) SendRaw(addr hexutil.Bytes, topic Topic, msg hexutil.Bytes) error {
+	return pssapi.Pss.SendRaw(PssAddress(addr), topic, msg[:])
+}
+
 func (pssapi *API) GetPeerTopics(pubkeyhex string) ([]Topic, error) {
 	topics, _, err := pssapi.Pss.GetPublickeyPeers(pubkeyhex)
 	return topics, err

--- a/swarm/pss/pss_test.go
+++ b/swarm/pss/pss_test.go
@@ -1064,7 +1064,7 @@ func testSendRaw(t *testing.T) {
 
 	// send and verify delivery
 	lmsg := []byte("plugh")
-	err = clients[1].Call(nil, "pss_sendRaw", loaddrhex, topic, lmsg)
+	err = clients[1].Call(nil, "pss_sendRaw", loaddrhex, topic, hexutil.Encode(lmsg))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1077,7 +1077,7 @@ func testSendRaw(t *testing.T) {
 		t.Fatalf("test message (left) timed out: %v", cerr)
 	}
 	rmsg := []byte("xyzzy")
-	err = clients[0].Call(nil, "pss_sendRaw", roaddrhex, topic, rmsg)
+	err = clients[0].Call(nil, "pss_sendRaw", roaddrhex, topic, hexutil.Encode(rmsg))
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
Previously, the `pss_sendRaw` method had different datatypes for the api call than `pss_sendAsym` and `pss_sendSym`. This PR makes the interfaces uniform.