### PR TITLE
swarm: snapshot load improvement

### DIFF
--- a/p2p/simulations/network.go
+++ b/p2p/simulations/network.go
@@ -754,6 +754,11 @@ func (net *Network) Load(snap *Snapshot) error {
 		for {
 			select {
 			case e := <-events:
+				// Ignore control events as they do not represent
+				// connect or disconnect (Up) state change.
+				if e.Control {
+					continue
+				}
 				// Detect only connection events.
 				if e.Type != EventTypeConn {
 					continue

--- a/p2p/simulations/network.go
+++ b/p2p/simulations/network.go
@@ -707,6 +707,8 @@ func (net *Network) snapshot(addServices []string, removeServices []string) (*Sn
 	return snap, nil
 }
 
+var snapshotLoadTimeout = 120 * time.Second
+
 // Load loads a network snapshot
 func (net *Network) Load(snap *Snapshot) error {
 	// Start nodes.
@@ -814,7 +816,7 @@ func (net *Network) Load(snap *Snapshot) error {
 	// Wait until all connections from the snapshot are established.
 	case <-allConnected:
 	// Make sure that we do not wait forever.
-	case <-time.After(120 * time.Second):
+	case <-time.After(snapshotLoadTimeout):
 		return errors.New("snapshot connections not established")
 	}
 	return nil

--- a/p2p/simulations/network.go
+++ b/p2p/simulations/network.go
@@ -22,7 +22,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"strings"
 	"sync"
 	"time"
 
@@ -792,7 +791,7 @@ func (net *Network) Load(snap *Snapshot) error {
 			//so it would result in the snapshot `Load` to fail
 			continue
 		}
-		if err := net.Connect(conn.One, conn.Other); err != nil && !strings.Contains(err.Error(), "already connected") {
+		if err := net.Connect(conn.One, conn.Other); err != nil {
 			return err
 		}
 	}

--- a/p2p/simulations/network.go
+++ b/p2p/simulations/network.go
@@ -760,6 +760,7 @@ func (net *Network) Load(snap *Snapshot) error {
 					// Delete the connection from the set of established connections.
 					// This will prevent false positive in case disconnections happen.
 					delete(connections, connection)
+					log.Warn("load snapshot: unexpected disconnection", "one", e.Conn.One, "other", e.Conn.Other)
 					continue
 				}
 				// Check that the connection is from the snapshot.

--- a/swarm/network/hive.go
+++ b/swarm/network/hive.go
@@ -165,8 +165,8 @@ func (h *Hive) Run(p *BzzPeer) error {
 			// otherwise just send depth to new peer
 			dp.NotifyDepth(depth)
 		}
+		NotifyPeer(p.BzzAddr, h.Kademlia)
 	}
-	NotifyPeer(p.BzzAddr, h.Kademlia)
 	defer h.Off(dp)
 	return dp.Run(dp.HandleMsg)
 }

--- a/swarm/network/simulation/kademlia_test.go
+++ b/swarm/network/simulation/kademlia_test.go
@@ -33,7 +33,6 @@ func TestWaitTillHealthy(t *testing.T) {
 		"bzz": func(ctx *adapters.ServiceContext, b *sync.Map) (node.Service, func(), error) {
 			addr := network.NewAddr(ctx.Config.Node())
 			hp := network.NewHiveParams()
-			hp.Discovery = false
 			config := &network.BzzConfig{
 				OverlayAddr:  addr.Over(),
 				UnderlayAddr: addr.Under(),


### PR DESCRIPTION
This PR addresses the issue when loading a snapshot does not wait for all connections to be established.

Changes:
1. p2p/simulatons.Network.Load function now listens on "connect" events and waits for all connections from the snapshot
2. swarm/network.Hive.Run does not call NotifyPeer if the Discovery is disabled
3. swarm/network/simulation.TestWaitTillHealthy test must use discovery to pass

Change _2._ is required for change _1._ and change _3._ is needed because of the change _2._

Change _2._ is required as establishing a large number of connections takes exponentially more time on snapshot loading with peer notifications. This change is apparently the correct behaviour in respect to the Discovery option. But ti requires that discovery is enabled in TestWaitTillHealthy test.