### PR TITLE
signer/core: Fixes typo of method name in comment.

### DIFF
--- a/signer/core/api.go
+++ b/signer/core/api.go
@@ -82,7 +82,7 @@ type SignerUI interface {
 	// OnSignerStartup is invoked when the signer boots, and tells the UI info about external API location and version
 	// information
 	OnSignerStartup(info StartupInfo)
-	// OnInputRequried is invoked when clef requires user input, for example master password or
+	// OnInputRequired is invoked when clef requires user input, for example master password or
 	// pin-code for unlocking hardware wallets
 	OnInputRequired(info UserInputRequest) (UserInputResponse, error)
 }


### PR DESCRIPTION
Fixes typo of method name in comment in `signer/core/api.go`.