### PR TITLE
les, les/flowcontrol: improved request serving and flow control

### DIFF
--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -93,6 +93,8 @@ var (
 		utils.ExitWhenSyncedFlag,
 		utils.GCModeFlag,
 		utils.LightServFlag,
+		utils.LightBandwidthInFlag,
+		utils.LightBandwidthOutFlag,
 		utils.LightPeersFlag,
 		utils.LightKDFFlag,
 		utils.WhitelistFlag,

--- a/cmd/geth/usage.go
+++ b/cmd/geth/usage.go
@@ -81,6 +81,8 @@ var AppHelpFlagGroups = []flagGroup{
 			utils.EthStatsURLFlag,
 			utils.IdentityFlag,
 			utils.LightServFlag,
+			utils.LightBandwidthInFlag,
+			utils.LightBandwidthOutFlag,
 			utils.LightPeersFlag,
 			utils.LightKDFFlag,
 			utils.WhitelistFlag,

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -199,8 +199,18 @@ var (
 	}
 	LightServFlag = cli.IntFlag{
 		Name:  "lightserv",
-		Usage: "Maximum percentage of time allowed for serving LES requests (0-90)",
+		Usage: "Maximum percentage of time allowed for serving LES requests (multi-threaded processing allows values over 100)",
 		Value: 0,
+	}
+	LightBandwidthInFlag = cli.IntFlag{
+		Name:  "lightbwin",
+		Usage: "Incoming bandwidth limit for light server (1000 bytes/sec, 0 = unlimited)",
+		Value: 1000,
+	}
+	LightBandwidthOutFlag = cli.IntFlag{
+		Name:  "lightbwout",
+		Usage: "Outgoing bandwidth limit for light server (1000 bytes/sec, 0 = unlimited)",
+		Value: 5000,
 	}
 	LightPeersFlag = cli.IntFlag{
 		Name:  "lightpeers",
@@ -1305,6 +1315,8 @@ func SetEthConfig(ctx *cli.Context, stack *node.Node, cfg *eth.Config) {
 	if ctx.GlobalIsSet(LightServFlag.Name) {
 		cfg.LightServ = ctx.GlobalInt(LightServFlag.Name)
 	}
+	cfg.LightBandwidthIn = ctx.GlobalInt(LightBandwidthInFlag.Name)
+	cfg.LightBandwidthOut = ctx.GlobalInt(LightBandwidthOutFlag.Name)
 	if ctx.GlobalIsSet(LightPeersFlag.Name) {
 		cfg.LightPeers = ctx.GlobalInt(LightPeersFlag.Name)
 	}

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -54,6 +54,7 @@ import (
 type LesServer interface {
 	Start(srvr *p2p.Server)
 	Stop()
+	APIs() []rpc.API
 	Protocols() []p2p.Protocol
 	SetBloomBitsIndexer(bbIndexer *core.ChainIndexer)
 }
@@ -267,6 +268,10 @@ func CreateConsensusEngine(ctx *node.ServiceContext, chainConfig *params.ChainCo
 func (s *Ethereum) APIs() []rpc.API {
 	apis := ethapi.GetAPIs(s.APIBackend)
 
+	// Append any APIs exposed explicitly by the les server
+	if s.lesServer != nil {
+		apis = append(apis, s.lesServer.APIs()...)
+	}
 	// Append any APIs exposed explicitly by the consensus engine
 	apis = append(apis, s.engine.APIs(s.BlockChain())...)
 

--- a/eth/config.go
+++ b/eth/config.go
@@ -98,9 +98,11 @@ type Config struct {
 	Whitelist map[uint64]common.Hash `toml:"-"`
 
 	// Light client options
-	LightServ    int  `toml:",omitempty"` // Maximum percentage of time allowed for serving LES requests
-	LightPeers   int  `toml:",omitempty"` // Maximum number of LES client peers
-	OnlyAnnounce bool // Maximum number of LES client peers
+	LightServ         int  `toml:",omitempty"` // Maximum percentage of time allowed for serving LES requests
+	LightBandwidthIn  int  `toml:",omitempty"` // Incoming bandwidth limit for light servers
+	LightBandwidthOut int  `toml:",omitempty"` // Outgoing bandwidth limit for light servers
+	LightPeers        int  `toml:",omitempty"` // Maximum number of LES client peers
+	OnlyAnnounce      bool // Maximum number of LES client peers
 
 	// Ultra Light client options
 	ULC *ULCConfig `toml:",omitempty"`

--- a/eth/gen_config.go
+++ b/eth/gen_config.go
@@ -24,6 +24,8 @@ func (c Config) MarshalTOML() (interface{}, error) {
 		SyncMode                downloader.SyncMode
 		NoPruning               bool
 		LightServ               int `toml:",omitempty"`
+		LightBandwidthIn        int `toml:",omitempty"`
+		LightBandwidthOut       int `toml:",omitempty"`
 		LightPeers              int `toml:",omitempty"`
 		OnlyAnnounce            bool
 		ULC                     *ULCConfig `toml:",omitempty"`
@@ -55,6 +57,8 @@ func (c Config) MarshalTOML() (interface{}, error) {
 	enc.SyncMode = c.SyncMode
 	enc.NoPruning = c.NoPruning
 	enc.LightServ = c.LightServ
+	enc.LightBandwidthIn = c.LightBandwidthIn
+	enc.LightBandwidthOut = c.LightBandwidthOut
 	enc.LightPeers = c.LightPeers
 	enc.OnlyAnnounce = c.OnlyAnnounce
 	enc.ULC = c.ULC
@@ -91,6 +95,8 @@ func (c *Config) UnmarshalTOML(unmarshal func(interface{}) error) error {
 		SyncMode                *downloader.SyncMode
 		NoPruning               *bool
 		LightServ               *int `toml:",omitempty"`
+		LightBandwidthIn        *int `toml:",omitempty"`
+		LightBandwidthOut       *int `toml:",omitempty"`
 		LightPeers              *int `toml:",omitempty"`
 		OnlyAnnounce            *bool
 		ULC                     *ULCConfig `toml:",omitempty"`
@@ -134,6 +140,12 @@ func (c *Config) UnmarshalTOML(unmarshal func(interface{}) error) error {
 	}
 	if dec.LightServ != nil {
 		c.LightServ = *dec.LightServ
+	}
+	if dec.LightBandwidthIn != nil {
+		c.LightBandwidthIn = *dec.LightBandwidthIn
+	}
+	if dec.LightBandwidthOut != nil {
+		c.LightBandwidthOut = *dec.LightBandwidthOut
 	}
 	if dec.LightPeers != nil {
 		c.LightPeers = *dec.LightPeers

--- a/les/api.go
+++ b/les/api.go
@@ -1,0 +1,176 @@
+// Copyright 2018 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+package les
+
+import (
+	"errors"
+	"sync"
+
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/ethereum/go-ethereum/p2p/enode"
+)
+
+var (
+	ErrMinBW   = errors.New("bandwidth too small")
+	ErrTotalBW = errors.New("total bandwidth exceeded")
+)
+
+// PublicLesServerAPI  provides an API to access the les server.
+// It offers only methods that operate on public data that is freely available to anyone.
+type PrivateLesServerAPI struct {
+	server *LesServer
+	pm     *ProtocolManager
+	vip    *vipClientPool
+}
+
+// NewPublicLesServerAPI creates a new les server API.
+func NewPrivateLesServerAPI(server *LesServer) *PrivateLesServerAPI {
+	vip := &vipClientPool{
+		clients: make(map[enode.ID]vipClientInfo),
+		totalBw: server.totalBandwidth,
+		pm:      server.protocolManager,
+	}
+	server.protocolManager.vipClientPool = vip
+	return &PrivateLesServerAPI{
+		server: server,
+		pm:     server.protocolManager,
+		vip:    vip,
+	}
+}
+
+// TotalBandwidth queries total available bandwidth for all clients
+func (api *PrivateLesServerAPI) TotalBandwidth() hexutil.Uint64 {
+	return hexutil.Uint64(api.server.totalBandwidth)
+}
+
+// MinimumBandwidth queries minimum assignable bandwidth for a single client
+func (api *PrivateLesServerAPI) MinimumBandwidth() hexutil.Uint64 {
+	return hexutil.Uint64(api.server.minBandwidth)
+}
+
+// vipClientPool stores information about prioritized clients
+type vipClientPool struct {
+	lock                                  sync.Mutex
+	pm                                    *ProtocolManager
+	clients                               map[enode.ID]vipClientInfo
+	totalBw, totalVipBw, totalConnectedBw uint64
+	vipCount                              int
+}
+
+// vipClientInfo entries exist for all prioritized clients and currently connected free clients
+type vipClientInfo struct {
+	bw        uint64 // zero for non-vip clients
+	connected bool
+	updateBw  func(uint64)
+}
+
+// SetClientBandwidth sets the priority bandwidth assigned to a given client.
+// If the assigned bandwidth is bigger than zero then connection is always
+// guaranteed. The sum of bandwidth assigned to priority clients can not exceed
+// the total available bandwidth.
+//
+// Note: assigned bandwidth can be changed while the client is connected with
+// immediate effect.
+func (api *PrivateLesServerAPI) SetClientBandwidth(id enode.ID, bw uint64) error {
+	if bw != 0 && bw < api.server.minBandwidth {
+		return ErrMinBW
+	}
+
+	api.vip.lock.Lock()
+	defer api.vip.lock.Unlock()
+
+	c := api.vip.clients[id]
+	if api.vip.totalVipBw+bw > api.vip.totalBw+c.bw {
+		return ErrTotalBW
+	}
+	api.vip.totalVipBw += bw - c.bw
+	if c.updateBw != nil && bw != 0 {
+		c.updateBw(bw)
+	}
+	if c.connected {
+		if c.bw != 0 {
+			api.vip.vipCount--
+		}
+		if bw != 0 {
+			api.vip.vipCount++
+		}
+		api.vip.totalConnectedBw += bw - c.bw
+		api.pm.clientPool.setConnLimit(api.pm.maxFreePeers(api.vip.vipCount, api.vip.totalConnectedBw))
+	}
+	if c.updateBw != nil && bw == 0 {
+		c.updateBw(bw)
+	}
+	if bw != 0 || c.connected {
+		c.bw = bw
+		api.vip.clients[id] = c
+	} else {
+		delete(api.vip.clients, id)
+	}
+	return nil
+}
+
+// GetClientBandwidth returns the bandwidth assigned to a given client
+func (api *PrivateLesServerAPI) GetClientBandwidth(id enode.ID) hexutil.Uint64 {
+	api.vip.lock.Lock()
+	defer api.vip.lock.Unlock()
+
+	return hexutil.Uint64(api.vip.clients[id].bw)
+}
+
+// connect should be called when a new client is connected. The callback function
+// is called when the assigned bandwidth is changed while the client is connected.
+// It returns the priority bandwidth or zero if the client is not prioritized.
+// It also returns whether the client can be accepted.
+//
+// Note: vipClientPool also stores a record about free clients while they are
+// connected in order to be able to assign priority to them later with the callback
+// function if necessary.
+func (v *vipClientPool) connect(id enode.ID, updateBw func(uint64)) (uint64, bool) {
+	v.lock.Lock()
+	defer v.lock.Unlock()
+
+	c := v.clients[id]
+	if c.connected {
+		return 0, false
+	}
+	c.connected = true
+	c.updateBw = updateBw
+	v.clients[id] = c
+	if c.bw != 0 {
+		v.vipCount++
+	}
+	v.totalConnectedBw += c.bw
+	v.pm.clientPool.setConnLimit(v.pm.maxFreePeers(v.vipCount, v.totalConnectedBw))
+	return c.bw, true
+}
+
+// disconnect should be called when a client is disconnected.
+// It should be called for all clients accepted by connect even if not prioritized.
+func (v *vipClientPool) disconnect(id enode.ID) {
+	v.lock.Lock()
+	defer v.lock.Unlock()
+
+	c := v.clients[id]
+	c.connected = false
+	if c.bw != 0 {
+		v.clients[id] = c
+		v.vipCount--
+	} else {
+		delete(v.clients, id)
+	}
+	v.totalConnectedBw -= c.bw
+	v.pm.clientPool.setConnLimit(v.pm.maxFreePeers(v.vipCount, v.totalConnectedBw))
+}

--- a/les/api.go
+++ b/les/api.go
@@ -43,7 +43,7 @@ func NewPrivateLesServerAPI(server *LesServer) *PrivateLesServerAPI {
 
 // TotalCapacity queries total available capacity for all clients
 func (api *PrivateLesServerAPI) TotalCapacity() hexutil.Uint64 {
-	return hexutil.Uint64(api.server.totalCapacity)
+	return hexutil.Uint64(api.server.priorityClientPool.totalCapacity())
 }
 
 // MinimumCapacity queries minimum assignable capacity for a single client
@@ -193,6 +193,13 @@ func (v *priorityClientPool) setLimits(count int, totalCap uint64) {
 	if v.child != nil {
 		v.child.setLimits(v.maxPeers-v.priorityCount, v.totalCap-v.totalConnectedCap)
 	}
+}
+
+func (v *priorityClientPool) totalCapacity() uint64 {
+	v.lock.Lock()
+	defer v.lock.Unlock()
+
+	return v.totalCap
 }
 
 func (v *priorityClientPool) setClientCapacity(id enode.ID, cap uint64) error {

--- a/les/api.go
+++ b/les/api.go
@@ -24,8 +24,8 @@ import (
 )
 
 var (
-	ErrMinBW   = errors.New("bandwidth too small")
-	ErrTotalBW = errors.New("total bandwidth exceeded")
+	ErrMinBW   = errors.New("capacity too small")
+	ErrTotalBW = errors.New("total capacity exceeded")
 )
 
 // PublicLesServerAPI  provides an API to access the les server.
@@ -40,7 +40,7 @@ type PrivateLesServerAPI struct {
 func NewPrivateLesServerAPI(server *LesServer) *PrivateLesServerAPI {
 	vip := &vipClientPool{
 		clients: make(map[enode.ID]vipClientInfo),
-		totalBw: server.totalBandwidth,
+		totalBw: server.totalCapacity,
 		pm:      server.protocolManager,
 	}
 	server.protocolManager.vipClientPool = vip
@@ -51,14 +51,14 @@ func NewPrivateLesServerAPI(server *LesServer) *PrivateLesServerAPI {
 	}
 }
 
-// TotalBandwidth queries total available bandwidth for all clients
-func (api *PrivateLesServerAPI) TotalBandwidth() hexutil.Uint64 {
-	return hexutil.Uint64(api.server.totalBandwidth)
+// TotalCapacity queries total available capacity for all clients
+func (api *PrivateLesServerAPI) TotalCapacity() hexutil.Uint64 {
+	return hexutil.Uint64(api.server.totalCapacity)
 }
 
-// MinimumBandwidth queries minimum assignable bandwidth for a single client
-func (api *PrivateLesServerAPI) MinimumBandwidth() hexutil.Uint64 {
-	return hexutil.Uint64(api.server.minBandwidth)
+// MinimumCapacity queries minimum assignable capacity for a single client
+func (api *PrivateLesServerAPI) MinimumCapacity() hexutil.Uint64 {
+	return hexutil.Uint64(api.server.minCapacity)
 }
 
 // vipClientPool stores information about prioritized clients
@@ -77,15 +77,15 @@ type vipClientInfo struct {
 	updateBw  func(uint64)
 }
 
-// SetClientBandwidth sets the priority bandwidth assigned to a given client.
-// If the assigned bandwidth is bigger than zero then connection is always
-// guaranteed. The sum of bandwidth assigned to priority clients can not exceed
-// the total available bandwidth.
+// SetClientCapacity sets the priority capacity assigned to a given client.
+// If the assigned capacity is bigger than zero then connection is always
+// guaranteed. The sum of capacity assigned to priority clients can not exceed
+// the total available capacity.
 //
-// Note: assigned bandwidth can be changed while the client is connected with
+// Note: assigned capacity can be changed while the client is connected with
 // immediate effect.
-func (api *PrivateLesServerAPI) SetClientBandwidth(id enode.ID, bw uint64) error {
-	if bw != 0 && bw < api.server.minBandwidth {
+func (api *PrivateLesServerAPI) SetClientCapacity(id enode.ID, bw uint64) error {
+	if bw != 0 && bw < api.server.minCapacity {
 		return ErrMinBW
 	}
 
@@ -122,8 +122,8 @@ func (api *PrivateLesServerAPI) SetClientBandwidth(id enode.ID, bw uint64) error
 	return nil
 }
 
-// GetClientBandwidth returns the bandwidth assigned to a given client
-func (api *PrivateLesServerAPI) GetClientBandwidth(id enode.ID) hexutil.Uint64 {
+// GetClientCapacity returns the capacity assigned to a given client
+func (api *PrivateLesServerAPI) GetClientCapacity(id enode.ID) hexutil.Uint64 {
 	api.vip.lock.Lock()
 	defer api.vip.lock.Unlock()
 
@@ -131,8 +131,8 @@ func (api *PrivateLesServerAPI) GetClientBandwidth(id enode.ID) hexutil.Uint64 {
 }
 
 // connect should be called when a new client is connected. The callback function
-// is called when the assigned bandwidth is changed while the client is connected.
-// It returns the priority bandwidth or zero if the client is not prioritized.
+// is called when the assigned capacity is changed while the client is connected.
+// It returns the priority capacity or zero if the client is not prioritized.
 // It also returns whether the client can be accepted.
 //
 // Note: vipClientPool also stores a record about free clients while they are

--- a/les/api.go
+++ b/les/api.go
@@ -83,7 +83,7 @@ type (
 
 // send sends a changed total capacity event to the subscribers
 func (s tcSubs) send(tc uint64, underrun bool) {
-	for sub, _ := range s {
+	for sub := range s {
 		select {
 		case <-sub.rpcSub.Err():
 			delete(s, sub)

--- a/les/api_test.go
+++ b/les/api_test.go
@@ -71,10 +71,10 @@ func TestCapacityAPI10(t *testing.T) {
 }
 
 // testCapacityAPI runs an end-to-end simulation test connecting one server with
-// a given number of clients. It sets different priority capacitys to all clients
+// a given number of clients. It sets different priority capacities to all clients
 // except a randomly selected one which runs in free client mode. All clients send
 // similar requests at the maximum allowed rate and the test verifies whether the
-// ratio of processed requests is close enough to the ratio of assigned capacitys.
+// ratio of processed requests is close enough to the ratio of assigned capacities.
 // Running multiple rounds with different settings ensures that changing capacity
 // while connected and going back and forth between free and priority mode with
 // the supplied API calls is also thoroughly tested.

--- a/les/api_test.go
+++ b/les/api_test.go
@@ -183,7 +183,7 @@ func testCapacityAPI(t *testing.T, clientCount int) {
 
 		processedSince := func(start []uint64) []uint64 {
 			res := make([]uint64, len(reqCount))
-			for i, _ := range reqCount {
+			for i := range reqCount {
 				res[i] = atomic.LoadUint64(&reqCount[i])
 				if start != nil {
 					res[i] -= start[i]
@@ -197,7 +197,7 @@ func testCapacityAPI(t *testing.T, clientCount int) {
 			setCapacity(ctx, t, serverRpcClient, clients[freeIdx].ID(), freeCap)
 			freeIdx = rand.Intn(len(clients))
 			var sum float64
-			for i, _ := range clients {
+			for i := range clients {
 				if i == freeIdx {
 					weights[i] = 0
 				} else {
@@ -220,14 +220,14 @@ func testCapacityAPI(t *testing.T, clientCount int) {
 				}
 			}
 			weights[freeIdx] = float64(freeCap)
-			for i, _ := range clients {
+			for i := range clients {
 				weights[i] /= float64(testCap)
 			}
 
 			time.Sleep(flowcontrol.DecParamDelay)
 			fmt.Println("Starting measurement")
 			fmt.Printf("Relative weights:")
-			for i, _ := range clients {
+			for i := range clients {
 				fmt.Printf("  %f", weights[i])
 			}
 			fmt.Println()
@@ -459,7 +459,7 @@ func testSim(t *testing.T, serverCount, clientCount int, serverDir, clientDir []
 	servers := make([]*simulations.Node, serverCount)
 	clients := make([]*simulations.Node, clientCount)
 
-	for i, _ := range clients {
+	for i := range clients {
 		clientconf := adapters.RandomNodeConfig()
 		clientconf.Services = []string{"lesclient"}
 		if len(clientDir) == clientCount {
@@ -472,7 +472,7 @@ func testSim(t *testing.T, serverCount, clientCount int, serverDir, clientDir []
 		clients[i] = client
 	}
 
-	for i, _ := range servers {
+	for i := range servers {
 		serverconf := adapters.RandomNodeConfig()
 		serverconf.Services = []string{"lesserver"}
 		if len(serverDir) == serverCount {

--- a/les/backend.go
+++ b/les/backend.go
@@ -25,6 +25,7 @@ import (
 	"github.com/ethereum/go-ethereum/accounts"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/ethereum/go-ethereum/common/mclock"
 	"github.com/ethereum/go-ethereum/consensus"
 	"github.com/ethereum/go-ethereum/core"
 	"github.com/ethereum/go-ethereum/core/bloombits"
@@ -100,7 +101,7 @@ func New(ctx *node.ServiceContext, config *eth.Config) (*LightEthereum, error) {
 		chainConfig:    chainConfig,
 		eventMux:       ctx.EventMux,
 		peers:          peers,
-		reqDist:        newRequestDistributor(peers, quitSync),
+		reqDist:        newRequestDistributor(peers, quitSync, &mclock.System{}),
 		accountManager: ctx.AccountManager,
 		engine:         eth.CreateConsensusEngine(ctx, chainConfig, &config.Ethash, nil, false, chainDb),
 		shutdownChan:   make(chan bool),

--- a/les/bandwidth_api_test.go
+++ b/les/bandwidth_api_test.go
@@ -1,0 +1,475 @@
+// Copyright 2016 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+package les
+
+import (
+	"context"
+	"errors"
+	"flag"
+	"fmt"
+	"io/ioutil"
+	"math/rand"
+	"os"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/ethereum/go-ethereum/consensus/ethash"
+	"github.com/ethereum/go-ethereum/eth"
+	"github.com/ethereum/go-ethereum/eth/downloader"
+	"github.com/ethereum/go-ethereum/les/flowcontrol"
+	"github.com/ethereum/go-ethereum/log"
+	"github.com/ethereum/go-ethereum/node"
+	"github.com/ethereum/go-ethereum/p2p/enode"
+	"github.com/ethereum/go-ethereum/p2p/simulations"
+	"github.com/ethereum/go-ethereum/p2p/simulations/adapters"
+	"github.com/ethereum/go-ethereum/rpc"
+	colorable "github.com/mattn/go-colorable"
+)
+
+/*
+This test is not meant to be a part of the automatic testing process because it
+runs for a long time and also requires a large database in order to do a meaningful
+request performance test. When testServerDataDir is empty, the test is skipped.
+*/
+
+const (
+	testServerDataDir   = "" // should always be empty on the master branch
+	testServerBandwidth = 200
+	testMaxClients      = 10
+	testTolerance       = 0.1
+	minRelBw            = 0.2
+)
+
+func TestBandwidthAPI3(t *testing.T) {
+	testBandwidthAPI(t, 3)
+}
+
+func TestBandwidthAPI6(t *testing.T) {
+	testBandwidthAPI(t, 6)
+}
+
+func TestBandwidthAPI10(t *testing.T) {
+	testBandwidthAPI(t, 10)
+}
+
+// testBandwidthAPI runs an end-to-end simulation test connecting one server with
+// a given number of clients. It sets different priority bandwidths to all clients
+// except a randomly selected one which runs in free client mode. All clients send
+// similar requests at the maximum allowed rate and the test verifies whether the
+// ratio of processed requests is close enough to the ratio of assigned bandwidths.
+// Running multiple rounds with different settings ensures that changing bandwidth
+// while connected and going back and forth between free and priority mode with
+// the supplied API calls is also thoroughly tested.
+func testBandwidthAPI(t *testing.T, clientCount int) {
+	if testServerDataDir == "" {
+		// Skip test if no data dir specified
+		return
+	}
+
+	testSim(t, 1, clientCount, []string{testServerDataDir}, nil, func(ctx context.Context, net *simulations.Network, servers []*simulations.Node, clients []*simulations.Node) {
+		if len(servers) != 1 {
+			t.Fatalf("Invalid number of servers: %d", len(servers))
+		}
+		server := servers[0]
+
+		clientRpcClients := make([]*rpc.Client, len(clients))
+
+		serverRpcClient, err := server.Client()
+		if err != nil {
+			t.Fatalf("Failed to obtain rpc client: %v", err)
+		}
+		headNum, headHash := getHead(ctx, t, serverRpcClient)
+		totalBw, minBw := bandwidthLimits(ctx, t, serverRpcClient)
+		fmt.Printf("Server totalBw: %d  minBw: %d  head number: %d  head hash: %064x\n", totalBw, minBw, headNum, headHash)
+		reqMinBw := uint64(float64(totalBw) * minRelBw / (minRelBw + float64(len(clients)-1)))
+		if minBw > reqMinBw {
+			t.Fatalf("Minimum client bandwidth (%d) bigger than required minimum for this test (%d)", minBw, reqMinBw)
+		}
+
+		freeIdx := rand.Intn(len(clients))
+		freeBw := totalBw / testMaxClients
+
+		for i, client := range clients {
+			var err error
+			clientRpcClients[i], err = client.Client()
+			if err != nil {
+				t.Fatalf("Failed to obtain rpc client: %v", err)
+			}
+
+			fmt.Println("connecting client", i)
+			if i != freeIdx {
+				setBandwidth(ctx, t, serverRpcClient, client.ID(), totalBw/uint64(len(clients)))
+			}
+			net.Connect(client.ID(), server.ID())
+
+			for {
+				select {
+				case <-ctx.Done():
+					t.Fatalf("Timeout")
+				default:
+				}
+				num, hash := getHead(ctx, t, clientRpcClients[i])
+				if num == headNum && hash == headHash {
+					fmt.Println("client", i, "synced")
+					break
+				}
+				time.Sleep(time.Millisecond * 200)
+			}
+		}
+
+		var wg sync.WaitGroup
+		stop := make(chan struct{})
+
+		reqCount := make([]uint64, len(clientRpcClients))
+		for i, c := range clientRpcClients {
+			wg.Add(1)
+			i, c := i, c
+			go func() {
+				queue := make(chan struct{}, 100)
+				var count uint64
+				for {
+					select {
+					case queue <- struct{}{}:
+						wg.Add(1)
+						go func() {
+							testRequest(ctx, t, c)
+							wg.Done()
+							<-queue
+							count++
+							atomic.StoreUint64(&reqCount[i], count)
+						}()
+					case <-stop:
+						wg.Done()
+						return
+					case <-ctx.Done():
+						wg.Done()
+						return
+					}
+				}
+			}()
+		}
+
+		processedSince := func(start []uint64) []uint64 {
+			res := make([]uint64, len(reqCount))
+			for i, _ := range reqCount {
+				res[i] = atomic.LoadUint64(&reqCount[i])
+				if start != nil {
+					res[i] -= start[i]
+				}
+			}
+			return res
+		}
+
+		weights := make([]float64, len(clients))
+		for c := 0; c < 5; c++ {
+			setBandwidth(ctx, t, serverRpcClient, clients[freeIdx].ID(), freeBw)
+			freeIdx = rand.Intn(len(clients))
+			var sum float64
+			for i, _ := range clients {
+				if i == freeIdx {
+					weights[i] = 0
+				} else {
+					weights[i] = rand.Float64()*(1-minRelBw) + minRelBw
+				}
+				sum += weights[i]
+			}
+			for i, client := range clients {
+				weights[i] *= float64(totalBw-freeBw-100) / sum
+				bandwidth := uint64(weights[i])
+				if i != freeIdx && bandwidth < getBandwidth(ctx, t, serverRpcClient, client.ID()) {
+					setBandwidth(ctx, t, serverRpcClient, client.ID(), bandwidth)
+				}
+			}
+			setBandwidth(ctx, t, serverRpcClient, clients[freeIdx].ID(), 0)
+			for i, client := range clients {
+				bandwidth := uint64(weights[i])
+				if i != freeIdx && bandwidth > getBandwidth(ctx, t, serverRpcClient, client.ID()) {
+					setBandwidth(ctx, t, serverRpcClient, client.ID(), bandwidth)
+				}
+			}
+			weights[freeIdx] = float64(freeBw)
+			for i, _ := range clients {
+				weights[i] /= float64(totalBw)
+			}
+
+			time.Sleep(flowcontrol.DecParamDelay)
+			fmt.Println("starting measurement")
+			start := processedSince(nil)
+			for {
+				select {
+				case <-ctx.Done():
+					t.Fatalf("Timeout")
+				default:
+				}
+
+				processed := processedSince(start)
+				var avg uint64
+				fmt.Printf("Processed")
+				for i, p := range processed {
+					fmt.Printf(" %d", p)
+					processed[i] = uint64(float64(p) / weights[i])
+					avg += processed[i]
+				}
+				avg /= uint64(len(processed))
+
+				if avg >= 10000 {
+					var maxDev float64
+					for _, p := range processed {
+						dev := float64(int64(p-avg)) / float64(avg)
+						fmt.Printf(" %7.4f", dev)
+						if dev < 0 {
+							dev = -dev
+						}
+						if dev > maxDev {
+							maxDev = dev
+						}
+					}
+					fmt.Printf("  max deviation: %f\n", maxDev)
+					if maxDev <= testTolerance {
+						fmt.Println("success")
+						break
+					}
+				} else {
+					fmt.Println()
+				}
+				time.Sleep(time.Millisecond * 200)
+			}
+		}
+
+		close(stop)
+		wg.Wait()
+
+		for i, count := range reqCount {
+			fmt.Println("client", i, "processed", count)
+		}
+	})
+}
+
+func getHead(ctx context.Context, t *testing.T, client *rpc.Client) (uint64, common.Hash) {
+	res := make(map[string]interface{})
+	if err := client.CallContext(ctx, &res, "eth_getBlockByNumber", "latest", false); err != nil {
+		t.Fatalf("Failed to obtain head block: %v", err)
+	}
+	numStr, ok := res["number"].(string)
+	if !ok {
+		t.Fatalf("RPC block number field invalid")
+	}
+	num, err := hexutil.DecodeUint64(numStr)
+	if err != nil {
+		t.Fatalf("Failed to decode RPC block number: %v", err)
+	}
+	hashStr, ok := res["hash"].(string)
+	if !ok {
+		t.Fatalf("RPC block number field invalid")
+	}
+	hash := common.HexToHash(hashStr)
+	return num, hash
+}
+
+func testRequest(ctx context.Context, t *testing.T, client *rpc.Client) {
+	//res := make(map[string]interface{})
+	var res string
+	var addr common.Address
+	rand.Read(addr[:])
+	//	if err := client.CallContext(ctx, &res, "eth_getProof", addr, nil, "latest"); err != nil {
+	if err := client.CallContext(ctx, &res, "eth_getBalance", addr, "latest"); err != nil {
+		t.Fatalf("Failed to obtain Merkle proof: %v", err)
+	}
+}
+
+func setBandwidth(ctx context.Context, t *testing.T, server *rpc.Client, clientID enode.ID, bw uint64) {
+	if err := server.CallContext(ctx, nil, "les_setClientBandwidth", clientID, bw); err != nil {
+		t.Fatalf("Failed to set client bandwidth: %v", err)
+	}
+}
+
+func getBandwidth(ctx context.Context, t *testing.T, server *rpc.Client, clientID enode.ID) uint64 {
+	var s string
+	if err := server.CallContext(ctx, &s, "les_getClientBandwidth", clientID); err != nil {
+		t.Fatalf("Failed to get client bandwidth: %v", err)
+	}
+	bw, err := hexutil.DecodeUint64(s)
+	if err != nil {
+		t.Fatalf("Failed to decode client bandwidth: %v", err)
+	}
+	return bw
+}
+
+func bandwidthLimits(ctx context.Context, t *testing.T, server *rpc.Client) (uint64, uint64) {
+	var s string
+	if err := server.CallContext(ctx, &s, "les_totalBandwidth"); err != nil {
+		t.Fatalf("Failed to query total bandwidth: %v", err)
+	}
+	total, err := hexutil.DecodeUint64(s)
+	if err != nil {
+		t.Fatalf("Failed to decode total bandwidth: %v", err)
+	}
+	if err := server.CallContext(ctx, &s, "les_minimumBandwidth"); err != nil {
+		t.Fatalf("Failed to query minimum bandwidth: %v", err)
+	}
+	min, err := hexutil.DecodeUint64(s)
+	if err != nil {
+		t.Fatalf("Failed to decode minimum bandwidth: %v", err)
+	}
+	return total, min
+}
+
+func init() {
+	flag.Parse()
+	// register the Delivery service which will run as a devp2p
+	// protocol when using the exec adapter
+	adapters.RegisterServices(services)
+
+	log.PrintOrigins(true)
+	log.Root().SetHandler(log.LvlFilterHandler(log.Lvl(*loglevel), log.StreamHandler(colorable.NewColorableStderr(), log.TerminalFormat(true))))
+}
+
+var (
+	adapter  = flag.String("adapter", "exec", "type of simulation: sim|socket|exec|docker")
+	loglevel = flag.Int("loglevel", 0, "verbosity of logs")
+	nodes    = flag.Int("nodes", 0, "number of nodes")
+)
+
+var services = adapters.Services{
+	"lesclient": newLesClientService,
+	"lesserver": newLesServerService,
+}
+
+func NewNetwork() (*simulations.Network, func(), error) {
+	adapter, adapterTeardown, err := NewAdapter(*adapter, services)
+	if err != nil {
+		return nil, adapterTeardown, err
+	}
+	defaultService := "streamer"
+	net := simulations.NewNetwork(adapter, &simulations.NetworkConfig{
+		ID:             "0",
+		DefaultService: defaultService,
+	})
+	teardown := func() {
+		adapterTeardown()
+		net.Shutdown()
+	}
+
+	return net, teardown, nil
+}
+
+func NewAdapter(adapterType string, services adapters.Services) (adapter adapters.NodeAdapter, teardown func(), err error) {
+	teardown = func() {}
+	switch adapterType {
+	case "sim":
+		adapter = adapters.NewSimAdapter(services)
+		//	case "socket":
+		//		adapter = adapters.NewSocketAdapter(services)
+	case "exec":
+		baseDir, err0 := ioutil.TempDir("", "les-test")
+		if err0 != nil {
+			return nil, teardown, err0
+		}
+		teardown = func() { os.RemoveAll(baseDir) }
+		adapter = adapters.NewExecAdapter(baseDir)
+	/*case "docker":
+	adapter, err = adapters.NewDockerAdapter()
+	if err != nil {
+		return nil, teardown, err
+	}*/
+	default:
+		return nil, teardown, errors.New("adapter needs to be one of sim, socket, exec, docker")
+	}
+	return adapter, teardown, nil
+}
+
+func testSim(t *testing.T, serverCount, clientCount int, serverDir, clientDir []string, test func(ctx context.Context, net *simulations.Network, servers []*simulations.Node, clients []*simulations.Node)) {
+	net, teardown, err := NewNetwork()
+	defer teardown()
+	if err != nil {
+		t.Fatalf("Failed to create network: %v", err)
+	}
+	timeout := 1800 * time.Second
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
+	servers := make([]*simulations.Node, serverCount)
+	clients := make([]*simulations.Node, clientCount)
+
+	for i, _ := range clients {
+		clientconf := adapters.RandomNodeConfig()
+		clientconf.Services = []string{"lesclient"}
+		if len(clientDir) == clientCount {
+			clientconf.DataDir = clientDir[i]
+		}
+		client, err := net.NewNodeWithConfig(clientconf)
+		if err != nil {
+			t.Fatalf("Failed to create client: %v", err)
+		}
+		clients[i] = client
+	}
+
+	for i, _ := range servers {
+		serverconf := adapters.RandomNodeConfig()
+		serverconf.Services = []string{"lesserver"}
+		if len(serverDir) == serverCount {
+			serverconf.DataDir = serverDir[i]
+		}
+		server, err := net.NewNodeWithConfig(serverconf)
+		if err != nil {
+			t.Fatalf("Failed to create server: %v", err)
+		}
+		servers[i] = server
+	}
+
+	for _, client := range clients {
+		if err := net.Start(client.ID()); err != nil {
+			t.Fatalf("Failed to start client node: %v", err)
+		}
+	}
+	for _, server := range servers {
+		if err := net.Start(server.ID()); err != nil {
+			t.Fatalf("Failed to start server node: %v", err)
+		}
+	}
+
+	test(ctx, net, servers, clients)
+}
+
+func newLesClientService(ctx *adapters.ServiceContext) (node.Service, error) {
+	config := eth.DefaultConfig
+	config.SyncMode = downloader.LightSync
+	config.Ethash.PowMode = ethash.ModeFake
+	return New(ctx.NodeContext, &config)
+}
+
+func newLesServerService(ctx *adapters.ServiceContext) (node.Service, error) {
+	config := eth.DefaultConfig
+	config.SyncMode = downloader.FullSync
+	config.LightServ = testServerBandwidth
+	config.LightPeers = testMaxClients
+	ethereum, err := eth.New(ctx.NodeContext, &config)
+	if err != nil {
+		return nil, err
+	}
+
+	server, err := NewLesServer(ethereum, &config)
+	if err != nil {
+		return nil, err
+	}
+	ethereum.AddLesServer(server)
+	return ethereum, nil
+}

--- a/les/benchmark.go
+++ b/les/benchmark.go
@@ -44,6 +44,7 @@ type requestBenchmark interface {
 	request(peer *peer, index int) error
 }
 
+// benchmarkBlockHeaders implements requestBenchmark
 type benchmarkBlockHeaders struct {
 	amount, skip    int
 	reverse, byHash bool
@@ -78,6 +79,7 @@ func (b *benchmarkBlockHeaders) request(peer *peer, index int) error {
 	}
 }
 
+// benchmarkBodiesOrReceipts implements requestBenchmark
 type benchmarkBodiesOrReceipts struct {
 	receipts bool
 	hashes   []common.Hash
@@ -100,6 +102,7 @@ func (b *benchmarkBodiesOrReceipts) request(peer *peer, index int) error {
 	}
 }
 
+// benchmarkProofsOrCode implements requestBenchmark
 type benchmarkProofsOrCode struct {
 	code     bool
 	headHash common.Hash
@@ -120,6 +123,7 @@ func (b *benchmarkProofsOrCode) request(peer *peer, index int) error {
 	}
 }
 
+// benchmarkHelperTrie implements requestBenchmark
 type benchmarkHelperTrie struct {
 	bloom                 bool
 	reqCount              int
@@ -162,6 +166,7 @@ func (b *benchmarkHelperTrie) request(peer *peer, index int) error {
 	return peer.RequestHelperTrieProofs(0, 0, reqs)
 }
 
+// benchmarkTxSend implements requestBenchmark
 type benchmarkTxSend struct {
 	txs types.Transactions
 }
@@ -189,6 +194,7 @@ func (b *benchmarkTxSend) request(peer *peer, index int) error {
 	return peer.SendTxs(0, 0, enc)
 }
 
+// benchmarkTxStatus implements requestBenchmark
 type benchmarkTxStatus struct{}
 
 func (b *benchmarkTxStatus) init(pm *ProtocolManager, count int) error {

--- a/les/benchmark.go
+++ b/les/benchmark.go
@@ -1,0 +1,632 @@
+// Copyright 2018 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+package les
+
+import (
+	"encoding/binary"
+	"fmt"
+	"math/big"
+	"math/rand"
+	"sort"
+	"sync/atomic"
+	"time"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/mclock"
+	"github.com/ethereum/go-ethereum/core/rawdb"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/les/flowcontrol"
+	"github.com/ethereum/go-ethereum/log"
+	"github.com/ethereum/go-ethereum/p2p"
+	"github.com/ethereum/go-ethereum/p2p/enode"
+	"github.com/ethereum/go-ethereum/params"
+	"github.com/ethereum/go-ethereum/rlp"
+)
+
+// requestBenchmark is an interface for different randomized request generators
+type requestBenchmark interface {
+	// init initializes the generator for generating the given number of randomized requests
+	init(pm *ProtocolManager, count int) error
+	// request initiates sending a single request to the given peer
+	request(peer *peer, index int) error
+}
+
+type benchmarkBlockHeaders struct {
+	amount, skip    int
+	reverse, byHash bool
+	offset, randMax int64
+	hashes          []common.Hash
+}
+
+func (b *benchmarkBlockHeaders) init(pm *ProtocolManager, count int) error {
+	d := int64(b.amount-1) * int64(b.skip+1)
+	b.offset = 0
+	b.randMax = pm.blockchain.CurrentHeader().Number.Int64() + 1 - d
+	if b.randMax < 0 {
+		return fmt.Errorf("chain is too short")
+	}
+	if b.reverse {
+		b.offset = d
+	}
+	if b.byHash {
+		b.hashes = make([]common.Hash, count)
+		for i, _ := range b.hashes {
+			b.hashes[i] = rawdb.ReadCanonicalHash(pm.chainDb, uint64(b.offset+rand.Int63n(b.randMax)))
+		}
+	}
+	return nil
+}
+
+func (b *benchmarkBlockHeaders) request(peer *peer, index int) error {
+	if b.byHash {
+		return peer.RequestHeadersByHash(0, 0, b.hashes[index], b.amount, b.skip, b.reverse)
+	} else {
+		return peer.RequestHeadersByNumber(0, 0, uint64(b.offset+rand.Int63n(b.randMax)), b.amount, b.skip, b.reverse)
+	}
+}
+
+type benchmarkBodiesOrReceipts struct {
+	receipts bool
+	hashes   []common.Hash
+}
+
+func (b *benchmarkBodiesOrReceipts) init(pm *ProtocolManager, count int) error {
+	randMax := pm.blockchain.CurrentHeader().Number.Int64() + 1
+	b.hashes = make([]common.Hash, count)
+	for i, _ := range b.hashes {
+		b.hashes[i] = rawdb.ReadCanonicalHash(pm.chainDb, uint64(rand.Int63n(randMax)))
+	}
+	return nil
+}
+
+func (b *benchmarkBodiesOrReceipts) request(peer *peer, index int) error {
+	if b.receipts {
+		return peer.RequestReceipts(0, 0, []common.Hash{b.hashes[index]})
+	} else {
+		return peer.RequestBodies(0, 0, []common.Hash{b.hashes[index]})
+	}
+}
+
+type benchmarkProofsOrCode struct {
+	code     bool
+	headHash common.Hash
+}
+
+func (b *benchmarkProofsOrCode) init(pm *ProtocolManager, count int) error {
+	b.headHash = pm.blockchain.CurrentHeader().Hash()
+	return nil
+}
+
+func (b *benchmarkProofsOrCode) request(peer *peer, index int) error {
+	key := make([]byte, 32)
+	rand.Read(key)
+	if b.code {
+		return peer.RequestCode(0, 0, []CodeReq{CodeReq{BHash: b.headHash, AccKey: key}})
+	} else {
+		return peer.RequestProofs(0, 0, []ProofReq{ProofReq{BHash: b.headHash, Key: key}})
+	}
+}
+
+type benchmarkHelperTrie struct {
+	bloom                 bool
+	reqCount              int
+	sectionCount, headNum uint64
+}
+
+func (b *benchmarkHelperTrie) init(pm *ProtocolManager, count int) error {
+	if b.bloom {
+		b.sectionCount, b.headNum, _ = pm.server.bloomTrieIndexer.Sections()
+	} else {
+		b.sectionCount, _, _ = pm.server.chtIndexer.Sections()
+		b.sectionCount /= (params.CHTFrequencyClient / params.CHTFrequencyServer)
+		b.headNum = b.sectionCount*params.CHTFrequencyClient - 1
+	}
+	if b.sectionCount == 0 {
+		return fmt.Errorf("no processed sections available")
+	}
+	return nil
+}
+
+func (b *benchmarkHelperTrie) request(peer *peer, index int) error {
+	reqs := make([]HelperTrieReq, b.reqCount)
+
+	if b.bloom {
+		bitIdx := uint16(rand.Intn(2048))
+		for i, _ := range reqs {
+			key := make([]byte, 10)
+			binary.BigEndian.PutUint16(key[:2], bitIdx)
+			binary.BigEndian.PutUint64(key[2:], uint64(rand.Int63n(int64(b.sectionCount))))
+			reqs[i] = HelperTrieReq{Type: htBloomBits, TrieIdx: b.sectionCount - 1, Key: key}
+		}
+	} else {
+		for i, _ := range reqs {
+			key := make([]byte, 8)
+			binary.BigEndian.PutUint64(key[:], uint64(rand.Int63n(int64(b.headNum))))
+			reqs[i] = HelperTrieReq{Type: htCanonical, TrieIdx: b.sectionCount - 1, Key: key, AuxReq: auxHeader}
+		}
+	}
+
+	return peer.RequestHelperTrieProofs(0, 0, reqs)
+}
+
+type benchmarkTxSend struct {
+	txs types.Transactions
+}
+
+func (b *benchmarkTxSend) init(pm *ProtocolManager, count int) error {
+	key, _ := crypto.GenerateKey()
+	addr := crypto.PubkeyToAddress(key.PublicKey)
+	signer := types.NewEIP155Signer(big.NewInt(18))
+	b.txs = make(types.Transactions, count)
+
+	for i, _ := range b.txs {
+		data := make([]byte, txSizeCostLimit)
+		rand.Read(data)
+		tx, err := types.SignTx(types.NewTransaction(0, addr, new(big.Int), 0, new(big.Int), data), signer, key)
+		if err != nil {
+			panic(err)
+		}
+		b.txs[i] = tx
+	}
+	return nil
+}
+
+func (b *benchmarkTxSend) request(peer *peer, index int) error {
+	enc, _ := rlp.EncodeToBytes(types.Transactions{b.txs[index]})
+	return peer.SendTxs(0, 0, enc)
+}
+
+type benchmarkTxStatus struct{}
+
+func (b *benchmarkTxStatus) init(pm *ProtocolManager, count int) error {
+	return nil
+}
+
+func (b *benchmarkTxStatus) request(peer *peer, index int) error {
+	var hash common.Hash
+	rand.Read(hash[:])
+	return peer.RequestTxStatus(0, 0, []common.Hash{hash})
+}
+
+type benchmarkType struct {
+	name        string
+	newInstance func() requestBenchmark
+	outSizeCorr uint32
+	avgTimeCorr float64
+}
+
+// benchmarkTypes describes different benchmark scenarios
+var benchmarkTypes = map[string]benchmarkType{
+	"header1n": {name: "header by number (single)", newInstance: func() requestBenchmark {
+		return &benchmarkBlockHeaders{amount: 1}
+	}},
+	"header1h": {name: "header by hash (single)", newInstance: func() requestBenchmark {
+		return &benchmarkBlockHeaders{amount: 1, byHash: true}
+	}},
+	"header192n": {name: "headers by number (192)", newInstance: func() requestBenchmark {
+		return &benchmarkBlockHeaders{amount: 192}
+	}},
+	"header192hr": {name: "headers by hash  (192, reverse)", newInstance: func() requestBenchmark {
+		return &benchmarkBlockHeaders{amount: 192, byHash: true, reverse: true}
+	}},
+	"body": {name: "block body", newInstance: func() requestBenchmark {
+		return &benchmarkBodiesOrReceipts{receipts: false}
+	}},
+	"receipts": {name: "block receipts", newInstance: func() requestBenchmark {
+		return &benchmarkBodiesOrReceipts{receipts: true}
+	}},
+	"proof": {name: "merkle proof", newInstance: func() requestBenchmark {
+		return &benchmarkProofsOrCode{code: false}
+	}, outSizeCorr: 500, avgTimeCorr: 2.5},
+	"code": {name: "contract code", newInstance: func() requestBenchmark {
+		return &benchmarkProofsOrCode{code: true}
+	}, outSizeCorr: 100000, avgTimeCorr: 1.5},
+	"cht1": {name: "cht (single)", newInstance: func() requestBenchmark {
+		return &benchmarkHelperTrie{bloom: false, reqCount: 1}
+	}},
+	"cht16": {name: "cht (16)", newInstance: func() requestBenchmark {
+		return &benchmarkHelperTrie{bloom: false, reqCount: 16}
+	}},
+	"bloom1": {name: "bloom trie (single)", newInstance: func() requestBenchmark {
+		return &benchmarkHelperTrie{bloom: true, reqCount: 1}
+	}},
+	"bloom16": {name: "bloom trie (16)", newInstance: func() requestBenchmark {
+		return &benchmarkHelperTrie{bloom: true, reqCount: 16}
+	}},
+	"txsend": {name: "send transaction", newInstance: func() requestBenchmark {
+		return &benchmarkTxSend{}
+	}, outSizeCorr: 50},
+	"txstatus": {name: "get transaction status", newInstance: func() requestBenchmark {
+		return &benchmarkTxStatus{}
+	}, outSizeCorr: 50},
+}
+
+// reqBenchMap defines the calculation method for different request costs based on
+// the benchmark results
+var reqBenchMap = []struct {
+	code uint64 // message code
+	// id contains a list of benchmarks that correspond to the cost of a single request
+	// the cost estimate of a single request is based on the highest benchmark result from the list
+	id []string
+	// idMax contains a list of benchmarks that correspond to the cost of a request with maxCount elements
+	// if idMax is not specified then the cost of additional request elements is the same as the cost
+	// of the single request
+	idMax    []string
+	maxCount uint64
+}{
+	{GetBlockHeadersMsg, []string{"header1n", "header1h"}, []string{"header192n", "header192hr"}, 192},
+	{GetBlockBodiesMsg, []string{"body"}, nil, 1},
+	{GetReceiptsMsg, []string{"receipts"}, nil, 1},
+	{GetCodeMsg, []string{"code"}, nil, 1},
+	{GetProofsV1Msg, []string{"proof"}, nil, 1},
+	{GetProofsV2Msg, []string{"proof"}, nil, 1},
+	{GetHeaderProofsMsg, []string{"cht1"}, []string{"cht16"}, 16},
+	{GetHelperTrieProofsMsg, []string{"cht1", "bloom1"}, []string{"cht16", "bloom16"}, 16},
+	{SendTxMsg, []string{"txsend"}, nil, 1},
+	{SendTxV2Msg, []string{"txsend"}, nil, 1},
+	{GetTxStatusMsg, []string{"txstatus"}, nil, 1},
+}
+
+// benchmarkSetup stores measurement data for a single benchmark type
+type benchmarkSetup struct {
+	req                   requestBenchmark
+	id, name              string
+	totalCount            int
+	totalTime, avgTime    time.Duration
+	maxInSize, maxOutSize uint32
+	err                   error
+}
+
+// reqBenchmarkKey is the database key for storing measurement data
+var reqBenchmarkKey = []byte("_requestBenchmarks__")
+
+const (
+	passCount          = 10               // number of passes in which all benchmark types are measured
+	firstCount         = 50               // request count for each type in the first pass (adjusted in subsequent passes)
+	totalBenchmarkTime = time.Second * 20 // targeted total run time for the given number of passes
+	discardAge         = 100000           // block age after which a stored benchmark entry is discarded
+	rerunAge           = 10000            // if the newest entry is older than rerunAge then a new benchmark is started
+	rerunCount         = 5                // if the number of stored entries is less than rerunCount then a new benchmark is started
+)
+
+// benchmarkData is the database storage format of benchmark results for a single type
+type benchmarkData struct {
+	BlockNumber, AvgTime  uint64
+	MaxInSize, MaxOutSize uint32
+}
+
+type benchmarkDataByTime []benchmarkData
+
+func (s benchmarkDataByTime) Len() int           { return len(s) }
+func (s benchmarkDataByTime) Less(i, j int) bool { return s[i].AvgTime < s[j].AvgTime }
+func (s benchmarkDataByTime) Swap(i, j int)      { s[i], s[j] = s[j], s[i] }
+
+// dataToCost calculates request cost estimates used by the flow control system
+func dataToCost(id string, data []benchmarkData, inSizeCostFactor, outSizeCostFactor float64) uint64 {
+	var (
+		maxInSize, maxOutSize uint32
+		avgTime               uint64
+	)
+	for _, d := range data {
+		if d.MaxInSize > maxInSize {
+			maxInSize = d.MaxInSize
+		}
+		if d.MaxOutSize > maxOutSize {
+			maxOutSize = d.MaxOutSize
+		}
+	}
+	var cost uint64
+	if len(data) > 0 {
+		sort.Sort(benchmarkDataByTime(data))
+		skip := len(data) / 5
+		for i := skip; i < len(data)-skip; i++ {
+			avgTime += data[i].AvgTime
+		}
+		avgTime /= uint64(len(data) - skip*2)
+		bt := benchmarkTypes[id]
+		maxOutSize += bt.outSizeCorr
+		if bt.avgTimeCorr != 0 {
+			avgTime = uint64(float64(avgTime) * bt.avgTimeCorr)
+		}
+		cost = avgTime * 2
+	}
+	inSizeCost := uint64(float64(maxInSize) * inSizeCostFactor * 1.25)
+	outSizeCost := uint64(float64(maxOutSize) * outSizeCostFactor * 1.25)
+	if inSizeCost > cost {
+		cost = inSizeCost
+	}
+	if outSizeCost > cost {
+		cost = outSizeCost
+	}
+	return cost
+}
+
+// benchmarkCosts checks the database for existing entries and initiates a benchmark
+// cycle for all types if necessary. It returns the cost list to be announced for
+// clients and the minimum buffer limit that can be assigned to each client.
+func (pm *ProtocolManager) benchmarkCosts(threadCount int, inSizeCostFactor, outSizeCostFactor float64) (costList RequestCostList, minBufLimit uint64) {
+	blockNumber := pm.blockchain.CurrentHeader().Number.Uint64()
+	allData := make(map[string][]benchmarkData)
+	run := false
+	for id, _ := range benchmarkTypes {
+		var data []benchmarkData
+		if enc, err := pm.chainDb.Get(append(reqBenchmarkKey, []byte(id)...)); err == nil {
+			if rlp.DecodeBytes(enc, &data) != nil {
+				data = nil
+			}
+		}
+		for len(data) > 0 && data[0].BlockNumber+discardAge <= blockNumber {
+			data = data[1:]
+		}
+		if len(data) < rerunCount || data[len(data)-1].BlockNumber+rerunAge <= blockNumber {
+			run = true
+		}
+		allData[id] = data
+	}
+
+	if run {
+		res := pm.runBenchmark()
+		for _, r := range res {
+			if r.err == nil {
+				data := append(allData[r.id], benchmarkData{BlockNumber: blockNumber, AvgTime: uint64(r.avgTime) * uint64(threadCount), MaxInSize: r.maxInSize, MaxOutSize: r.maxOutSize})
+				allData[r.id] = data
+				if enc, err := rlp.EncodeToBytes(data); err == nil {
+					pm.chainDb.Put(append(reqBenchmarkKey, []byte(r.id)...), enc)
+				}
+			}
+		}
+	}
+
+	// calculate upper cost estimates based on AvgTime and MaxSize
+	costs := make(map[string]uint64)
+	for id, data := range allData {
+		costs[id] = dataToCost(id, data, inSizeCostFactor, outSizeCostFactor)
+	}
+	var maxAllCosts uint64
+	// create linear cost functions for actual request types using reqBenchMap
+	res := make(RequestCostList, len(reqBenchMap))
+	for i, m := range reqBenchMap {
+		res[i].MsgCode = m.code
+		var cost uint64
+		for _, id := range m.id {
+			if c, ok := costs[id]; ok {
+				if c > cost {
+					cost = c
+				}
+			} else {
+				panic(nil)
+			}
+		}
+		if m.idMax == nil {
+			res[i].BaseCost = 0
+			res[i].ReqCost = cost
+		} else {
+			var maxCost uint64
+			for _, id := range m.idMax {
+				if c, ok := costs[id]; ok {
+					if c > maxCost {
+						maxCost = c
+					}
+				} else {
+					panic(nil)
+				}
+			}
+			if maxCost < cost {
+				maxCost = cost
+			}
+			if maxCost > maxAllCosts {
+				maxAllCosts = maxCost
+			}
+			dc := (maxCost - cost) / (m.maxCount - 1)
+			if cost < dc {
+				dc = maxCost / m.maxCount
+				cost = dc
+			}
+			res[i].BaseCost = cost - dc
+			res[i].ReqCost = dc
+		}
+	}
+	return res, maxAllCosts * 2
+}
+
+// runBenchmark runs a benchmark cycle for all benchmark types in the specified
+// number of passes
+func (pm *ProtocolManager) runBenchmark() []*benchmarkSetup {
+	log.Info("running benchmark")
+	setup := make([]*benchmarkSetup, len(benchmarkTypes))
+	i := 0
+	for id, bt := range benchmarkTypes {
+		setup[i] = &benchmarkSetup{id: id, name: bt.name, req: bt.newInstance()}
+		i++
+	}
+	targetTime := totalBenchmarkTime / time.Duration(len(benchmarkTypes)*passCount)
+	for i := 0; i < passCount; i++ {
+		todo := make([]*benchmarkSetup, len(benchmarkTypes))
+		copy(todo, setup)
+		for len(todo) > 0 {
+			// select a random element
+			index := rand.Intn(len(todo))
+			next := todo[index]
+			todo[index] = todo[len(todo)-1]
+			todo = todo[:len(todo)-1]
+
+			if next.err == nil {
+				// calculate request count
+				count := firstCount
+				if next.totalTime > 0 {
+					count = int(uint64(next.totalCount) * uint64(targetTime) / uint64(next.totalTime))
+				}
+				if err := pm.measure(next, count); err != nil {
+					next.err = err
+				}
+			}
+		}
+		log.Info("benchmark completed", "percent", (i+1)*100/passCount)
+	}
+
+	for _, s := range setup {
+		if s.err == nil {
+			s.avgTime = s.totalTime / time.Duration(s.totalCount)
+			log.Debug("benchmark result", "name", s.name, "avgTime", s.avgTime, "reqCount", s.totalCount, "maxInSize", s.maxInSize, "maxOutSize", s.maxOutSize)
+		} else {
+			log.Warn("benchmark failed", "name", s.name, "error", s.err)
+		}
+	}
+	return setup
+}
+
+// meteredPipe implements p2p.MsgReadWriter and remembers the largest single
+// message size sent through the pipe
+type meteredPipe struct {
+	rw      p2p.MsgReadWriter
+	maxSize uint32
+}
+
+func (m *meteredPipe) ReadMsg() (p2p.Msg, error) {
+	return m.rw.ReadMsg()
+}
+
+func (m *meteredPipe) WriteMsg(msg p2p.Msg) error {
+	if msg.Size > m.maxSize {
+		m.maxSize = msg.Size
+	}
+	return m.rw.WriteMsg(msg)
+}
+
+// measure runs a benchmark for a single type in a single pass, with the given
+// number of requests
+func (pm *ProtocolManager) measure(setup *benchmarkSetup, count int) error {
+	clientPipe, serverPipe := p2p.MsgPipe()
+	clientMeteredPipe := &meteredPipe{rw: clientPipe}
+	serverMeteredPipe := &meteredPipe{rw: serverPipe}
+	var id enode.ID
+	rand.Read(id[:])
+	clientPeer := pm.newPeer(lpv2, NetworkId, p2p.NewPeer(id, "client", nil), clientMeteredPipe)
+	serverPeer := pm.newPeer(lpv2, NetworkId, p2p.NewPeer(id, "server", nil), serverMeteredPipe)
+	serverPeer.sendQueue = newExecQueue(count)
+	serverPeer.announceType = announceTypeNone
+	serverPeer.fcCosts = make(requestCostTable)
+	c := &requestCosts{}
+	for code, _ := range requests {
+		serverPeer.fcCosts[code] = c
+	}
+	serverPeer.fcParams = flowcontrol.ServerParams{BufLimit: 1, MinRecharge: 1}
+	serverPeer.fcClient = flowcontrol.NewClientNode(pm.server.fcManager, serverPeer.fcParams)
+
+	if err := setup.req.init(pm, count); err != nil {
+		return err
+	}
+
+	errCh := make(chan error, 10)
+	start := mclock.Now()
+
+	go func() {
+		for i := 0; i < count; i++ {
+			if err := setup.req.request(clientPeer, i); err != nil {
+				errCh <- err
+				return
+			}
+		}
+	}()
+	go func() {
+		for i := 0; i < count; i++ {
+			if err := pm.handleMsg(serverPeer); err != nil {
+				errCh <- err
+				return
+			}
+		}
+	}()
+	go func() {
+		for i := 0; i < count; i++ {
+			msg, err := clientPipe.ReadMsg()
+			if err != nil {
+				errCh <- err
+				return
+			}
+			var i interface{}
+			msg.Decode(&i)
+		}
+		// at this point we can be sure that the other two
+		// goroutines finished successfully too
+		close(errCh)
+	}()
+	select {
+	case err := <-errCh:
+		if err != nil {
+			return err
+		}
+	case <-pm.quitSync:
+		clientPipe.Close()
+		serverPipe.Close()
+		return fmt.Errorf("Benchmark cancelled")
+	}
+
+	setup.totalTime += time.Duration(mclock.Now() - start)
+	setup.totalCount += count
+	setup.maxInSize = clientMeteredPipe.maxSize
+	setup.maxOutSize = serverMeteredPipe.maxSize
+	clientPipe.Close()
+	serverPipe.Close()
+	//serverPeer.fcClient.Remove(pm.server.fcManager)
+	return nil
+}
+
+// requestCostStats is a statistics tool that compares the distribution of actual
+// request serving costs during normal operation to the costs estimated by the benchmark
+type requestCostStats struct {
+	costs requestCostTable
+	stats map[uint64][]uint64
+}
+
+// newCostStats creates a new requestCostStats
+func newCostStats(table requestCostTable) *requestCostStats {
+	stats := make(map[uint64][]uint64)
+	for code, _ := range table {
+		stats[code] = make([]uint64, 10)
+	}
+	return &requestCostStats{
+		costs: table,
+		stats: stats,
+	}
+}
+
+// update adds a new data point to the statistics
+func (s *requestCostStats) update(msgCode, reqCnt, cost uint64) {
+	if s == nil {
+		return // not initialized yet during benchmark
+	}
+	c := s.costs[msgCode]
+	est := c.baseCost + reqCnt*c.reqCost
+	cost <<= 4
+	l := 0
+	for l < 9 && cost > est {
+		l++
+		cost >>= 1
+	}
+	ptr := &s.stats[msgCode][l]
+	atomic.AddUint64(ptr, 1)
+}
+
+// printStats prints the distribution of real request cost relative to the estimates
+func (s *requestCostStats) printStats() {
+	if s.stats == nil {
+		return
+	}
+	for code, arr := range s.stats {
+		log.Info("cost stats", "code", code, "1/16", arr[0], "1/8", arr[1], "1/4", arr[2], "1/2", arr[3], "1", arr[4], "2", arr[5], "4", arr[6], "8", arr[7], "16", arr[8], ">16", arr[9])
+	}
+}

--- a/les/benchmark.go
+++ b/les/benchmark.go
@@ -13,6 +13,7 @@
 //
 // You should have received a copy of the GNU Lesser General Public License
 // along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
 package les
 
 import (

--- a/les/benchmark.go
+++ b/les/benchmark.go
@@ -64,7 +64,7 @@ func (b *benchmarkBlockHeaders) init(pm *ProtocolManager, count int) error {
 	}
 	if b.byHash {
 		b.hashes = make([]common.Hash, count)
-		for i, _ := range b.hashes {
+		for i := range b.hashes {
 			b.hashes[i] = rawdb.ReadCanonicalHash(pm.chainDb, uint64(b.offset+rand.Int63n(b.randMax)))
 		}
 	}
@@ -88,7 +88,7 @@ type benchmarkBodiesOrReceipts struct {
 func (b *benchmarkBodiesOrReceipts) init(pm *ProtocolManager, count int) error {
 	randMax := pm.blockchain.CurrentHeader().Number.Int64() + 1
 	b.hashes = make([]common.Hash, count)
-	for i, _ := range b.hashes {
+	for i := range b.hashes {
 		b.hashes[i] = rawdb.ReadCanonicalHash(pm.chainDb, uint64(rand.Int63n(randMax)))
 	}
 	return nil
@@ -117,9 +117,9 @@ func (b *benchmarkProofsOrCode) request(peer *peer, index int) error {
 	key := make([]byte, 32)
 	rand.Read(key)
 	if b.code {
-		return peer.RequestCode(0, 0, []CodeReq{CodeReq{BHash: b.headHash, AccKey: key}})
+		return peer.RequestCode(0, 0, []CodeReq{{BHash: b.headHash, AccKey: key}})
 	} else {
-		return peer.RequestProofs(0, 0, []ProofReq{ProofReq{BHash: b.headHash, Key: key}})
+		return peer.RequestProofs(0, 0, []ProofReq{{BHash: b.headHash, Key: key}})
 	}
 }
 
@@ -149,14 +149,14 @@ func (b *benchmarkHelperTrie) request(peer *peer, index int) error {
 
 	if b.bloom {
 		bitIdx := uint16(rand.Intn(2048))
-		for i, _ := range reqs {
+		for i := range reqs {
 			key := make([]byte, 10)
 			binary.BigEndian.PutUint16(key[:2], bitIdx)
 			binary.BigEndian.PutUint64(key[2:], uint64(rand.Int63n(int64(b.sectionCount))))
 			reqs[i] = HelperTrieReq{Type: htBloomBits, TrieIdx: b.sectionCount - 1, Key: key}
 		}
 	} else {
-		for i, _ := range reqs {
+		for i := range reqs {
 			key := make([]byte, 8)
 			binary.BigEndian.PutUint64(key[:], uint64(rand.Int63n(int64(b.headNum))))
 			reqs[i] = HelperTrieReq{Type: htCanonical, TrieIdx: b.sectionCount - 1, Key: key, AuxReq: auxHeader}
@@ -177,7 +177,7 @@ func (b *benchmarkTxSend) init(pm *ProtocolManager, count int) error {
 	signer := types.NewEIP155Signer(big.NewInt(18))
 	b.txs = make(types.Transactions, count)
 
-	for i, _ := range b.txs {
+	for i := range b.txs {
 		data := make([]byte, txSizeCostLimit)
 		rand.Read(data)
 		tx, err := types.SignTx(types.NewTransaction(0, addr, new(big.Int), 0, new(big.Int), data), signer, key)
@@ -288,7 +288,7 @@ func (pm *ProtocolManager) measure(setup *benchmarkSetup, count int) error {
 	serverPeer.announceType = announceTypeNone
 	serverPeer.fcCosts = make(requestCostTable)
 	c := &requestCosts{}
-	for code, _ := range requests {
+	for code := range requests {
 		serverPeer.fcCosts[code] = c
 	}
 	serverPeer.fcParams = flowcontrol.ServerParams{BufLimit: 1, MinRecharge: 1}

--- a/les/costtracker.go
+++ b/les/costtracker.go
@@ -1,0 +1,378 @@
+// Copyright 2016 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more detailct.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+package les
+
+import (
+	"encoding/binary"
+	"math"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/ethereum/go-ethereum/common/mclock"
+	"github.com/ethereum/go-ethereum/eth"
+	"github.com/ethereum/go-ethereum/ethdb"
+	"github.com/ethereum/go-ethereum/les/flowcontrol"
+	"github.com/ethereum/go-ethereum/log"
+)
+
+const makeCostStats = false // make request cost statistics during operation
+
+var (
+	// average request cost estimates based on serving time
+	reqAvgTimeCost = requestCostTable{
+		GetBlockHeadersMsg:     {150000, 30000},
+		GetBlockBodiesMsg:      {0, 700000},
+		GetReceiptsMsg:         {0, 1000000},
+		GetCodeMsg:             {0, 450000},
+		GetProofsV1Msg:         {0, 600000},
+		GetProofsV2Msg:         {0, 600000},
+		GetHeaderProofsMsg:     {0, 1000000},
+		GetHelperTrieProofsMsg: {0, 1000000},
+		SendTxMsg:              {0, 450000},
+		SendTxV2Msg:            {0, 450000},
+		GetTxStatusMsg:         {0, 250000},
+	}
+	// maximum incoming message size estimates
+	reqMaxInSize = requestCostTable{
+		GetBlockHeadersMsg:     {40, 0},
+		GetBlockBodiesMsg:      {0, 40},
+		GetReceiptsMsg:         {0, 40},
+		GetCodeMsg:             {0, 80},
+		GetProofsV1Msg:         {0, 80},
+		GetProofsV2Msg:         {0, 80},
+		GetHeaderProofsMsg:     {0, 20},
+		GetHelperTrieProofsMsg: {0, 20},
+		SendTxMsg:              {0, 66000},
+		SendTxV2Msg:            {0, 66000},
+		GetTxStatusMsg:         {0, 50},
+	}
+	// maximum outgoing message size estimates
+	reqMaxOutSize = requestCostTable{
+		GetBlockHeadersMsg:     {0, 556},
+		GetBlockBodiesMsg:      {0, 100000},
+		GetReceiptsMsg:         {0, 200000},
+		GetCodeMsg:             {0, 50000},
+		GetProofsV1Msg:         {0, 4000},
+		GetProofsV2Msg:         {0, 4000},
+		GetHeaderProofsMsg:     {0, 4000},
+		GetHelperTrieProofsMsg: {0, 4000},
+		SendTxMsg:              {0, 0},
+		SendTxV2Msg:            {0, 100},
+		GetTxStatusMsg:         {0, 100},
+	}
+	minBufLimit = uint64(50000000 * maxCostFactor)          // minimum buffer limit allowed for a client
+	minCapacity = uint64((minBufLimit-1)/bufLimitRatio + 1) // minimum capacity allowed for a client
+)
+
+const (
+	maxCostFactor    = 2 // ratio of maximum and average cost estimates
+	gfInitWeight     = time.Second * 10
+	gfMaxWeight      = time.Hour
+	gfUsageThreshold = 0.5
+	gfUsageTC        = time.Second
+	gfDbKey          = "_globalCostFactor"
+)
+
+// costTracker is responsible for calculating costs and cost estimates on the
+// server side. It continously updates the global cost factor which is defined
+// as the number of cost units per nanosecond of serving time in a single thread.
+// It is based on statistics collected during serving requests in high-load periods
+// and practically acts as a one-dimension request price scaling factor over the
+// pre-defined cost estimate table. Instead of scaling the cost values, the real
+// value of cost units is changed by applying the factor to the serving times. This
+// is more convenient because the changes in the cost factor can be applied immediately
+// without always notifying the clients about the changed cost tables.
+type costTracker struct {
+	db     ethdb.Database
+	stopCh chan chan struct{}
+
+	inSizeFactor, outSizeFactor float64
+	gf, utilTarget              float64
+
+	gfUpdateCh      chan gfUpdate
+	gfLock          sync.RWMutex
+	totalRechargeCh chan uint64
+
+	stats map[uint64][]uint64
+}
+
+// newCostTracker creates a cost tracker and loads the cost factor statistics from the database
+func newCostTracker(db ethdb.Database, config *eth.Config) *costTracker {
+	utilTarget := float64(config.LightServ) * flowcontrol.FixedPointMultiplier / 100
+	ct := &costTracker{
+		db:         db,
+		stopCh:     make(chan chan struct{}),
+		utilTarget: utilTarget,
+	}
+	if config.LightBandwidthIn > 0 {
+		ct.inSizeFactor = utilTarget / float64(config.LightBandwidthIn)
+	}
+	if config.LightBandwidthOut > 0 {
+		ct.outSizeFactor = utilTarget / float64(config.LightBandwidthOut)
+	}
+	if makeCostStats {
+		ct.stats = make(map[uint64][]uint64)
+		for code, _ := range reqAvgTimeCost {
+			ct.stats[code] = make([]uint64, 10)
+		}
+	}
+	ct.gfLoop()
+	return ct
+}
+
+// stop stops the cost tracker and saves the cost factor statistics to the database
+func (ct *costTracker) stop() {
+	stopCh := make(chan struct{})
+	ct.stopCh <- stopCh
+	<-stopCh
+	if makeCostStats {
+		ct.printStats()
+	}
+}
+
+// makeCostList returns upper cost estimates based on the hardcoded cost estimate
+// tables and the optionally specified incoming/outgoing bandwidth limits
+func (ct *costTracker) makeCostList() RequestCostList {
+	maxCost := func(avgTime, inSize, outSize uint64) uint64 {
+		globalFactor := ct.globalFactor()
+
+		cost := avgTime * maxCostFactor
+		inSizeCost := uint64(float64(inSize) * ct.inSizeFactor * globalFactor * maxCostFactor)
+		if inSizeCost > cost {
+			cost = inSizeCost
+		}
+		outSizeCost := uint64(float64(outSize) * ct.outSizeFactor * globalFactor * maxCostFactor)
+		if outSizeCost > cost {
+			cost = outSizeCost
+		}
+		return cost
+	}
+	var list RequestCostList
+	for code, data := range reqAvgTimeCost {
+		list = append(list, requestCostListItem{
+			MsgCode:  code,
+			BaseCost: maxCost(data.baseCost, reqMaxInSize[code].baseCost, reqMaxOutSize[code].baseCost),
+			ReqCost:  maxCost(data.reqCost, reqMaxInSize[code].reqCost, reqMaxOutSize[code].reqCost),
+		})
+	}
+	return list
+}
+
+type gfUpdate struct {
+	avgTime, servingTime float64
+}
+
+// gfLoop starts an event loop which updates the global cost factor which is
+// calculated as a weighted average of the average estimate / serving time ratio.
+// The applied weight equals the serving time if gfUsage is over a threshold,
+// zero otherwise. gfUsage is the recent average serving time per time unit in
+// an exponential moving window. This ensures that statistics are collected only
+// under high-load circumstances where the measured serving times are relevant.
+// The total recharge parameter of the flow control system which controls the
+// total allowed serving time per second but nominated in cost units, should
+// also be scaled with the cost factor and is also updated by this loop.
+func (ct *costTracker) gfLoop() {
+	var gfUsage, gfSum, gfWeight float64
+	lastUpdate := mclock.Now()
+	expUpdate := lastUpdate
+
+	data, _ := ct.db.Get([]byte(gfDbKey))
+	if len(data) == 16 {
+		gfSum = math.Float64frombits(binary.BigEndian.Uint64(data[0:8]))
+		gfWeight = math.Float64frombits(binary.BigEndian.Uint64(data[8:16]))
+	}
+	if gfWeight < float64(gfInitWeight) {
+		gfSum = float64(gfInitWeight)
+		gfWeight = float64(gfInitWeight)
+	}
+	gf := gfSum / gfWeight
+	ct.gf = gf
+	ct.gfUpdateCh = make(chan gfUpdate, 100)
+
+	go func() {
+		for {
+			select {
+			case r := <-ct.gfUpdateCh:
+				now := mclock.Now()
+				max := r.servingTime * gf
+				if r.avgTime > max {
+					max = r.avgTime
+				}
+				dt := float64(now - expUpdate)
+				expUpdate = now
+				gfUsage = gfUsage*math.Exp(-dt/float64(gfUsageTC)) + max*1000000/float64(gfUsageTC)
+
+				if gfUsage >= gfUsageThreshold*ct.utilTarget*gf {
+					gfSum += r.avgTime
+					gfWeight += r.servingTime
+					if time.Duration(now-lastUpdate) > time.Second {
+						gf = gfSum / gfWeight
+						if gfWeight >= float64(gfMaxWeight) {
+							gfSum = gf * float64(gfMaxWeight)
+							gfWeight = float64(gfMaxWeight)
+						}
+						lastUpdate = now
+						ct.gfLock.Lock()
+						ct.gf = gf
+						ch := ct.totalRechargeCh
+						ct.gfLock.Unlock()
+						if ch != nil {
+							select {
+							case ct.totalRechargeCh <- uint64(ct.utilTarget * gf):
+							default:
+							}
+						}
+						log.Debug("global cost factor updated", "gf", gf, "weight", time.Duration(gfWeight))
+					}
+				}
+			case stopCh := <-ct.stopCh:
+				var data [16]byte
+				binary.BigEndian.PutUint64(data[0:8], math.Float64bits(gfSum))
+				binary.BigEndian.PutUint64(data[8:16], math.Float64bits(gfWeight))
+				ct.db.Put([]byte(gfDbKey), data[:])
+				log.Debug("global cost factor saved", "sum", time.Duration(gfSum), "weight", time.Duration(gfWeight))
+				close(stopCh)
+				return
+			}
+		}
+	}()
+}
+
+// globalFactor returns the current value of the global cost factor
+func (ct *costTracker) globalFactor() float64 {
+	ct.gfLock.RLock()
+	defer ct.gfLock.RUnlock()
+
+	return ct.gf
+}
+
+// totalRecharge returns the current total recharge parameter which is used by
+// flowcontrol.ClientManager and is scaled by the global cost factor
+func (ct *costTracker) totalRecharge() uint64 {
+	ct.gfLock.RLock()
+	defer ct.gfLock.RUnlock()
+
+	return uint64(ct.gf * ct.utilTarget)
+}
+
+// subscribeTotalRecharge returns all future updates to the total recharge value
+// through a channel and also returns the current value
+func (ct *costTracker) subscribeTotalRecharge(ch chan uint64) uint64 {
+	ct.gfLock.Lock()
+	defer ct.gfLock.Unlock()
+
+	ct.totalRechargeCh = ch
+	return uint64(ct.gf * ct.utilTarget)
+}
+
+// updateStats updates the global cost factor and (if enabled) the real cost vs.
+// average estimate statistics
+func (ct *costTracker) updateStats(code, amount, servingTime, realCost uint64) {
+	avg := reqAvgTimeCost[code]
+	avgTime := avg.baseCost + amount*avg.reqCost
+	select {
+	case ct.gfUpdateCh <- gfUpdate{float64(avgTime), float64(servingTime)}:
+	default:
+	}
+	if makeCostStats {
+		realCost <<= 4
+		l := 0
+		for l < 9 && realCost > avgTime {
+			l++
+			realCost >>= 1
+		}
+		atomic.AddUint64(&ct.stats[code][l], 1)
+	}
+}
+
+// realCost calculates the final cost of a request based on actual serving time,
+// incoming and outgoing message size
+//
+// Note: message size is only taken into account if bandwidth limitation is applied
+// and the cost based on either message size is greater than the cost based on
+// serving time. A maximum of the three costs is applied instead of their sum
+// because the three limited resources (serving thread time and i/o bandwidth) can
+// also be maxed out simultaneously.
+func (ct *costTracker) realCost(servingTime uint64, inSize, outSize uint32) uint64 {
+	cost := float64(servingTime)
+	inSizeCost := float64(inSize) * ct.inSizeFactor
+	if inSizeCost > cost {
+		cost = inSizeCost
+	}
+	outSizeCost := float64(outSize) * ct.outSizeFactor
+	if outSizeCost > cost {
+		cost = outSizeCost
+	}
+	return uint64(cost * ct.globalFactor())
+}
+
+// printStats prints the distribution of real request cost relative to the average estimates
+func (ct *costTracker) printStats() {
+	if ct.stats == nil {
+		return
+	}
+	for code, arr := range ct.stats {
+		log.Info("request", "code", code, "1/16", arr[0], "1/8", arr[1], "1/4", arr[2], "1/2", arr[3], "1", arr[4], "2", arr[5], "4", arr[6], "8", arr[7], "16", arr[8], ">16", arr[9])
+	}
+}
+
+type (
+	// requestCostTable assigns a cost estimate function to each request type
+	// which is a linear function of the requested amount
+	// (cost = baseCost + reqCost * amount)
+	requestCostTable map[uint64]*requestCosts
+	requestCosts     struct {
+		baseCost, reqCost uint64
+	}
+
+	// RequestCostList is a list representation of request costs which is used for
+	// database storage and communication through the network
+	RequestCostList     []requestCostListItem
+	requestCostListItem struct {
+		MsgCode, BaseCost, ReqCost uint64
+	}
+)
+
+// getCost calculates the estimated cost for a given request type and amount
+func (table requestCostTable) getCost(code, amount uint64) uint64 {
+	costs := table[code]
+	return costs.baseCost + amount*costs.reqCost
+}
+
+// decode converts a cost list to a cost table
+func (list RequestCostList) decode() requestCostTable {
+	table := make(requestCostTable)
+	for _, e := range list {
+		table[e.MsgCode] = &requestCosts{
+			baseCost: e.BaseCost,
+			reqCost:  e.ReqCost,
+		}
+	}
+	return table
+}
+
+// testCostList returns a dummy request cost list used by tests
+func testCostList() RequestCostList {
+	cl := make(RequestCostList, len(reqAvgTimeCost))
+	for i, req := range reqBenchMap {
+		cl[i].MsgCode = req.code
+		cl[i].BaseCost = 0
+		cl[i].ReqCost = 0
+	}
+	return cl
+}

--- a/les/costtracker.go
+++ b/les/costtracker.go
@@ -327,7 +327,7 @@ func (ct *costTracker) printStats() {
 		return
 	}
 	for code, arr := range ct.stats {
-		log.Info("request", "code", code, "1/16", arr[0], "1/8", arr[1], "1/4", arr[2], "1/2", arr[3], "1", arr[4], "2", arr[5], "4", arr[6], "8", arr[7], "16", arr[8], ">16", arr[9])
+		log.Info("Request cost statistics", "code", code, "1/16", arr[0], "1/8", arr[1], "1/4", arr[2], "1/2", arr[3], "1", arr[4], "2", arr[5], "4", arr[6], "8", arr[7], "16", arr[8], ">16", arr[9])
 	}
 }
 
@@ -369,10 +369,20 @@ func (list RequestCostList) decode() requestCostTable {
 // testCostList returns a dummy request cost list used by tests
 func testCostList() RequestCostList {
 	cl := make(RequestCostList, len(reqAvgTimeCost))
-	for i, req := range reqBenchMap {
-		cl[i].MsgCode = req.code
-		cl[i].BaseCost = 0
-		cl[i].ReqCost = 0
+	var max uint64
+	for code, _ := range reqAvgTimeCost {
+		if code > max {
+			max = code
+		}
+	}
+	i := 0
+	for code := uint64(0); code <= max; code++ {
+		if _, ok := reqAvgTimeCost[code]; ok {
+			cl[i].MsgCode = code
+			cl[i].BaseCost = 0
+			cl[i].ReqCost = 0
+			i++
+		}
 	}
 	return cl
 }

--- a/les/costtracker.go
+++ b/les/costtracker.go
@@ -76,7 +76,7 @@ var (
 		GetTxStatusMsg:         {0, 100},
 	}
 	minBufLimit = uint64(50000000 * maxCostFactor)          // minimum buffer limit allowed for a client
-	minCapacity = uint64((minBufLimit-1)/bufLimitRatio + 1) // minimum capacity allowed for a client
+	minCapacity = (minBufLimit-1)/bufLimitRatio + 1 // minimum capacity allowed for a client
 )
 
 const (

--- a/les/costtracker.go
+++ b/les/costtracker.go
@@ -89,7 +89,7 @@ const (
 )
 
 // costTracker is responsible for calculating costs and cost estimates on the
-// server side. It continously updates the global cost factor which is defined
+// server side. It continuously updates the global cost factor which is defined
 // as the number of cost units per nanosecond of serving time in a single thread.
 // It is based on statistics collected during serving requests in high-load periods
 // and practically acts as a one-dimension request price scaling factor over the
@@ -127,7 +127,7 @@ func newCostTracker(db ethdb.Database, config *eth.Config) *costTracker {
 	}
 	if makeCostStats {
 		ct.stats = make(map[uint64][]uint64)
-		for code, _ := range reqAvgTimeCost {
+		for code := range reqAvgTimeCost {
 			ct.stats[code] = make([]uint64, 10)
 		}
 	}
@@ -370,7 +370,7 @@ func (list RequestCostList) decode() requestCostTable {
 func testCostList() RequestCostList {
 	cl := make(RequestCostList, len(reqAvgTimeCost))
 	var max uint64
-	for code, _ := range reqAvgTimeCost {
+	for code := range reqAvgTimeCost {
 		if code > max {
 			max = code
 		}

--- a/les/costtracker.go
+++ b/les/costtracker.go
@@ -75,7 +75,7 @@ var (
 		SendTxV2Msg:            {0, 100},
 		GetTxStatusMsg:         {0, 100},
 	}
-	minBufLimit = uint64(50000000 * maxCostFactor)          // minimum buffer limit allowed for a client
+	minBufLimit = uint64(50000000 * maxCostFactor)  // minimum buffer limit allowed for a client
 	minCapacity = (minBufLimit-1)/bufLimitRatio + 1 // minimum capacity allowed for a client
 )
 

--- a/les/distributor.go
+++ b/les/distributor.go
@@ -14,8 +14,6 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
 
-// Package light implements on-demand retrieval capable state and chain objects
-// for the Ethereum Light Client.
 package les
 
 import (

--- a/les/distributor.go
+++ b/les/distributor.go
@@ -22,12 +22,15 @@ import (
 	"container/list"
 	"sync"
 	"time"
+
+	"github.com/ethereum/go-ethereum/common/mclock"
 )
 
 // requestDistributor implements a mechanism that distributes requests to
 // suitable peers, obeying flow control rules and prioritizing them in creation
 // order (even when a resend is necessary).
 type requestDistributor struct {
+	clock            mclock.Clock
 	reqQueue         *list.List
 	lastReqOrder     uint64
 	peers            map[distPeer]struct{}
@@ -67,8 +70,9 @@ type distReq struct {
 }
 
 // newRequestDistributor creates a new request distributor
-func newRequestDistributor(peers *peerSet, stopChn chan struct{}) *requestDistributor {
+func newRequestDistributor(peers *peerSet, stopChn chan struct{}, clock mclock.Clock) *requestDistributor {
 	d := &requestDistributor{
+		clock:    clock,
 		reqQueue: list.New(),
 		loopChn:  make(chan struct{}, 2),
 		stopChn:  stopChn,
@@ -148,7 +152,7 @@ func (d *requestDistributor) loop() {
 						wait = distMaxWait
 					}
 					go func() {
-						time.Sleep(wait)
+						d.clock.Sleep(wait)
 						d.loopChn <- struct{}{}
 					}()
 					break loop

--- a/les/distributor_test.go
+++ b/les/distributor_test.go
@@ -14,8 +14,6 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
 
-// Package light implements on-demand retrieval capable state and chain objects
-// for the Ethereum Light Client.
 package les
 
 import (

--- a/les/distributor_test.go
+++ b/les/distributor_test.go
@@ -23,6 +23,8 @@ import (
 	"sync"
 	"testing"
 	"time"
+
+	"github.com/ethereum/go-ethereum/common/mclock"
 )
 
 type testDistReq struct {
@@ -121,7 +123,7 @@ func testRequestDistributor(t *testing.T, resend bool) {
 	stop := make(chan struct{})
 	defer close(stop)
 
-	dist := newRequestDistributor(nil, stop)
+	dist := newRequestDistributor(nil, stop, &mclock.System{})
 	var peers [testDistPeerCount]*testDistPeer
 	for i := range peers {
 		peers[i] = &testDistPeer{}

--- a/les/fetcher.go
+++ b/les/fetcher.go
@@ -14,7 +14,6 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
 
-// Package les implements the Light Ethereum Subprotocol.
 package les
 
 import (

--- a/les/fetcher.go
+++ b/les/fetcher.go
@@ -559,7 +559,7 @@ func (f *lightFetcher) newFetcherDistReq(bestHash common.Hash, reqID uint64, bes
 			f.lock.Unlock()
 
 			cost := p.GetRequestCost(GetBlockHeadersMsg, int(bestAmount))
-			p.fcServer.QueueRequest(reqID, cost)
+			p.fcServer.QueuedRequest(reqID, cost)
 			f.reqMu.Lock()
 			f.requested[reqID] = fetchRequest{hash: bestHash, amount: bestAmount, peer: p, sent: mclock.Now()}
 			f.reqMu.Unlock()

--- a/les/flowcontrol/control.go
+++ b/les/flowcontrol/control.go
@@ -18,182 +18,326 @@
 package flowcontrol
 
 import (
+	"fmt"
 	"sync"
 	"time"
 
 	"github.com/ethereum/go-ethereum/common/mclock"
+	"github.com/ethereum/go-ethereum/log"
 )
 
-const fcTimeConst = time.Millisecond
+const (
+	// fcTimeConst is the time constant applied for MinRecharge during linear
+	// buffer recharge period
+	fcTimeConst = time.Millisecond
+	// DecParamDelay is applied at server side when decreasing bandwidth in order to
+	// avoid a buffer underrun error due to requests sent by the client before
+	// receiving the bandwidth update announcement
+	DecParamDelay = time.Second * 2
+	// keepLogs is the duration of keeping logs; logging is not used if zero
+	keepLogs = 0
+)
 
+// ServerParams are the flow control parameters specified by a server for a client
+//
+// Note: a server can assign different amounts of bandwidth to each client by giving
+// different parameters to them.
 type ServerParams struct {
 	BufLimit, MinRecharge uint64
 }
 
-type ClientNode struct {
-	params   ServerParams
-	bufValue uint64
-	lastTime mclock.AbsTime
-	lock     sync.Mutex
-	cm       *ClientManager
-	cmNode   *cmNode
+type scheduledUpdate struct {
+	time   mclock.AbsTime
+	params ServerParams
 }
 
+// ClientNode is the flow control system's representation of a client
+// (used in server mode only)
+type ClientNode struct {
+	params         ServerParams
+	bufValue       uint64
+	lastTime       mclock.AbsTime
+	updateSchedule []scheduledUpdate
+	sumCost        uint64            // sum of req costs received from this client
+	accepted       map[uint64]uint64 // value = sumCost after accepting the given req
+	lock           sync.Mutex
+	cm             *ClientManager
+	log            *logger
+	cmNodeFields
+}
+
+// NewClientNode returns a new ClientNode
 func NewClientNode(cm *ClientManager, params ServerParams) *ClientNode {
 	node := &ClientNode{
 		cm:       cm,
 		params:   params,
 		bufValue: params.BufLimit,
-		lastTime: mclock.Now(),
+		lastTime: cm.clock.Now(),
+		accepted: make(map[uint64]uint64),
 	}
-	node.cmNode = cm.addNode(node)
+	if keepLogs > 0 {
+		node.log = newLogger(keepLogs)
+	}
+	cm.init(node)
 	return node
 }
 
-func (peer *ClientNode) Remove(cm *ClientManager) {
-	cm.removeNode(peer.cmNode)
+func (node *ClientNode) update(now mclock.AbsTime) {
+	for len(node.updateSchedule) > 0 && node.updateSchedule[0].time <= now {
+		node.recalcBV(node.updateSchedule[0].time)
+		node.updateParams(node.updateSchedule[0].params, now)
+		node.updateSchedule = node.updateSchedule[1:]
+	}
+	node.recalcBV(now)
 }
 
-func (peer *ClientNode) recalcBV(time mclock.AbsTime) {
-	dt := uint64(time - peer.lastTime)
-	if time < peer.lastTime {
+func (node *ClientNode) recalcBV(now mclock.AbsTime) {
+	dt := uint64(now - node.lastTime)
+	if now < node.lastTime {
 		dt = 0
 	}
-	peer.bufValue += peer.params.MinRecharge * dt / uint64(fcTimeConst)
-	if peer.bufValue > peer.params.BufLimit {
-		peer.bufValue = peer.params.BufLimit
+	node.bufValue += node.params.MinRecharge * dt / uint64(fcTimeConst)
+	if node.bufValue > node.params.BufLimit {
+		node.bufValue = node.params.BufLimit
 	}
-	peer.lastTime = time
+	if node.log != nil {
+		node.log.add(now, fmt.Sprintf("updated  bv=%d  MRR=%d  BufLimit=%d", node.bufValue, node.params.MinRecharge, node.params.BufLimit))
+	}
+	node.lastTime = now
 }
 
-func (peer *ClientNode) AcceptRequest() (uint64, bool) {
-	peer.lock.Lock()
-	defer peer.lock.Unlock()
+func (node *ClientNode) UpdateParams(params ServerParams) {
+	node.lock.Lock()
+	defer node.lock.Unlock()
 
-	time := mclock.Now()
-	peer.recalcBV(time)
-	return peer.bufValue, peer.cm.accept(peer.cmNode, time)
-}
-
-func (peer *ClientNode) RequestProcessed(cost uint64) (bv, realCost uint64) {
-	peer.lock.Lock()
-	defer peer.lock.Unlock()
-
-	time := mclock.Now()
-	peer.recalcBV(time)
-	peer.bufValue -= cost
-	rcValue, rcost := peer.cm.processed(peer.cmNode, time)
-	if rcValue < peer.params.BufLimit {
-		bv := peer.params.BufLimit - rcValue
-		if bv > peer.bufValue {
-			peer.bufValue = bv
+	now := node.cm.clock.Now()
+	node.update(now)
+	if params.MinRecharge >= node.params.MinRecharge {
+		node.updateSchedule = nil
+		node.updateParams(params, now)
+	} else {
+		for i, s := range node.updateSchedule {
+			if params.MinRecharge >= s.params.MinRecharge {
+				s.params = params
+				node.updateSchedule = node.updateSchedule[:i+1]
+				return
+			}
 		}
+		node.updateSchedule = append(node.updateSchedule, scheduledUpdate{time: now + mclock.AbsTime(DecParamDelay), params: params})
 	}
-	return peer.bufValue, rcost
 }
 
+func (node *ClientNode) updateParams(params ServerParams, now mclock.AbsTime) {
+	diff := params.BufLimit - node.params.BufLimit
+	if int64(diff) > 0 {
+		node.bufValue += diff
+	} else if node.bufValue > params.BufLimit {
+		node.bufValue = params.BufLimit
+	}
+	node.cm.updateParams(node, params, now)
+}
+
+// AcceptRequest returns whether a new request can be accepted and the missing
+// buffer amount if it was rejected due to a buffer underrun. If accepted, maxCost
+// is deducted from the flow control buffer.
+func (node *ClientNode) AcceptRequest(reqID, index, maxCost uint64) (accepted bool, bufShort uint64, priority int64) {
+	node.lock.Lock()
+	defer node.lock.Unlock()
+
+	now := node.cm.clock.Now()
+	node.update(now)
+	if maxCost > node.bufValue {
+		if node.log != nil {
+			node.log.add(now, fmt.Sprintf("rejected  reqID=%d  bv=%d  maxCost=%d", reqID, node.bufValue, maxCost))
+			node.log.dump(now)
+		}
+		return false, maxCost - node.bufValue, 0
+	}
+	node.bufValue -= maxCost
+	node.sumCost += maxCost
+	if node.log != nil {
+		node.log.add(now, fmt.Sprintf("accepted  reqID=%d  bv=%d  maxCost=%d  sumCost=%d", reqID, node.bufValue, maxCost, node.sumCost))
+	}
+	node.accepted[index] = node.sumCost
+	return true, 0, node.cm.accepted(node, maxCost, now)
+}
+
+// RequestProcessed should be called when the request has been processed
+func (node *ClientNode) RequestProcessed(reqID, index, maxCost, realCost uint64) (bv uint64) {
+	node.lock.Lock()
+	defer node.lock.Unlock()
+
+	now := node.cm.clock.Now()
+	node.update(now)
+	node.cm.processed(node, maxCost, realCost, now)
+	bv = node.bufValue + node.sumCost - node.accepted[index]
+	if node.log != nil {
+		node.log.add(now, fmt.Sprintf("processed  reqID=%d  bv=%d  maxCost=%d  realCost=%d  sumCost=%d  oldSumCost=%d  reportedBV=%d", reqID, node.bufValue, maxCost, realCost, node.sumCost, node.accepted[index], bv))
+	}
+	delete(node.accepted, index)
+	return
+}
+
+// ServerNode is the flow control system's representation of a server
+// (used in client mode only)
 type ServerNode struct {
+	clock       mclock.Clock
 	bufEstimate uint64
+	bufRecharge bool
 	lastTime    mclock.AbsTime
 	params      ServerParams
 	sumCost     uint64            // sum of req costs sent to this server
 	pending     map[uint64]uint64 // value = sumCost after sending the given req
+	log         *logger
 	lock        sync.RWMutex
 }
 
-func NewServerNode(params ServerParams) *ServerNode {
-	return &ServerNode{
+// NewServerNode returns a new ServerNode
+func NewServerNode(params ServerParams, clock mclock.Clock) *ServerNode {
+	node := &ServerNode{
+		clock:       clock,
 		bufEstimate: params.BufLimit,
-		lastTime:    mclock.Now(),
+		bufRecharge: false,
+		lastTime:    clock.Now(),
 		params:      params,
 		pending:     make(map[uint64]uint64),
 	}
+	if keepLogs > 0 {
+		node.log = newLogger(keepLogs)
+	}
+	return node
 }
 
 // UpdateParams updates flow control parameters
-func (peer *ServerNode) UpdateParams(params ServerParams) {
-	peer.lock.Lock()
-	defer peer.lock.Unlock()
+func (node *ServerNode) UpdateParams(params ServerParams) {
+	node.lock.Lock()
+	defer node.lock.Unlock()
 
-	peer.recalcBLE(mclock.Now())
-	if params.BufLimit > peer.params.BufLimit {
-		peer.bufEstimate += params.BufLimit - peer.params.BufLimit
+	node.recalcBLE(mclock.Now())
+	if params.BufLimit > node.params.BufLimit {
+		node.bufEstimate += params.BufLimit - node.params.BufLimit
 	} else {
-		if peer.bufEstimate > params.BufLimit {
-			peer.bufEstimate = params.BufLimit
+		if node.bufEstimate > params.BufLimit {
+			node.bufEstimate = params.BufLimit
 		}
 	}
-	peer.params = params
+	node.params = params
 }
 
-func (peer *ServerNode) recalcBLE(time mclock.AbsTime) {
-	dt := uint64(time - peer.lastTime)
-	if time < peer.lastTime {
-		dt = 0
+func (node *ServerNode) recalcBLE(now mclock.AbsTime) {
+	if now < node.lastTime {
+		return
 	}
-	peer.bufEstimate += peer.params.MinRecharge * dt / uint64(fcTimeConst)
-	if peer.bufEstimate > peer.params.BufLimit {
-		peer.bufEstimate = peer.params.BufLimit
+	if node.bufRecharge {
+		dt := uint64(now - node.lastTime)
+		node.bufEstimate += node.params.MinRecharge * dt / uint64(fcTimeConst)
+		if node.bufEstimate >= node.params.BufLimit {
+			node.bufEstimate = node.params.BufLimit
+			node.bufRecharge = false
+		}
 	}
-	peer.lastTime = time
+	node.lastTime = now
+	if node.log != nil {
+		node.log.add(now, fmt.Sprintf("updated  bufEst=%d  MRR=%d  BufLimit=%d", node.bufEstimate, node.params.MinRecharge, node.params.BufLimit))
+	}
 }
 
 // safetyMargin is added to the flow control waiting time when estimated buffer value is low
 const safetyMargin = time.Millisecond
 
-func (peer *ServerNode) canSend(maxCost uint64) (time.Duration, float64) {
-	peer.recalcBLE(mclock.Now())
-	maxCost += uint64(safetyMargin) * peer.params.MinRecharge / uint64(fcTimeConst)
-	if maxCost > peer.params.BufLimit {
-		maxCost = peer.params.BufLimit
-	}
-	if peer.bufEstimate >= maxCost {
-		return 0, float64(peer.bufEstimate-maxCost) / float64(peer.params.BufLimit)
-	}
-	return time.Duration((maxCost - peer.bufEstimate) * uint64(fcTimeConst) / peer.params.MinRecharge), 0
-}
-
 // CanSend returns the minimum waiting time required before sending a request
 // with the given maximum estimated cost. Second return value is the relative
 // estimated buffer level after sending the request (divided by BufLimit).
-func (peer *ServerNode) CanSend(maxCost uint64) (time.Duration, float64) {
-	peer.lock.RLock()
-	defer peer.lock.RUnlock()
+func (node *ServerNode) CanSend(maxCost uint64) (time.Duration, float64) {
+	node.lock.RLock()
+	defer node.lock.RUnlock()
 
-	return peer.canSend(maxCost)
-}
-
-// QueueRequest should be called when the request has been assigned to the given
-// server node, before putting it in the send queue. It is mandatory that requests
-// are sent in the same order as the QueueRequest calls are made.
-func (peer *ServerNode) QueueRequest(reqID, maxCost uint64) {
-	peer.lock.Lock()
-	defer peer.lock.Unlock()
-
-	peer.bufEstimate -= maxCost
-	peer.sumCost += maxCost
-	peer.pending[reqID] = peer.sumCost
-}
-
-// GotReply adjusts estimated buffer value according to the value included in
-// the latest request reply.
-func (peer *ServerNode) GotReply(reqID, bv uint64) {
-
-	peer.lock.Lock()
-	defer peer.lock.Unlock()
-
-	if bv > peer.params.BufLimit {
-		bv = peer.params.BufLimit
+	now := node.clock.Now()
+	node.recalcBLE(now)
+	maxCost += uint64(safetyMargin) * node.params.MinRecharge / uint64(fcTimeConst)
+	if maxCost > node.params.BufLimit {
+		maxCost = node.params.BufLimit
 	}
-	sc, ok := peer.pending[reqID]
+	if node.bufEstimate >= maxCost {
+		relBuf := float64(node.bufEstimate-maxCost) / float64(node.params.BufLimit)
+		if node.log != nil {
+			node.log.add(now, fmt.Sprintf("canSend  bufEst=%d  maxCost=%d  true  relBuf=%f", node.bufEstimate, maxCost, relBuf))
+		}
+		return 0, relBuf
+	}
+	timeLeft := time.Duration((maxCost - node.bufEstimate) * uint64(fcTimeConst) / node.params.MinRecharge)
+	if node.log != nil {
+		node.log.add(now, fmt.Sprintf("canSend  bufEst=%d  maxCost=%d  false  timeLeft=%v", node.bufEstimate, maxCost, timeLeft))
+	}
+	return timeLeft, 0
+}
+
+// QueuedRequest should be called when the request has been assigned to the given
+// server node, before putting it in the send queue. It is mandatory that requests
+// are sent in the same order as the QueuedRequest calls are made.
+func (node *ServerNode) QueuedRequest(reqID, maxCost uint64) {
+	node.lock.Lock()
+	defer node.lock.Unlock()
+
+	now := node.clock.Now()
+	node.recalcBLE(now)
+	// Note: we do not know when requests actually arrive to the server so bufRecharge
+	// is not turned on here if buffer was full; in this case it is going to be turned
+	// on by the first reply's bufValue feedback
+	if node.bufEstimate >= maxCost {
+		node.bufEstimate -= maxCost
+	} else {
+		log.Error("Queued request with insufficient buffer estimate")
+		node.bufEstimate = 0
+	}
+	node.sumCost += maxCost
+	node.pending[reqID] = node.sumCost
+	if node.log != nil {
+		node.log.add(now, fmt.Sprintf("queued  reqID=%d  bufEst=%d  maxCost=%d  sumCost=%d", reqID, node.bufEstimate, maxCost, node.sumCost))
+	}
+}
+
+// ReceivedReply adjusts estimated buffer value according to the value included in
+// the latest request reply.
+func (node *ServerNode) ReceivedReply(reqID, bv uint64) {
+	node.lock.Lock()
+	defer node.lock.Unlock()
+
+	now := node.clock.Now()
+	node.recalcBLE(now)
+	if bv > node.params.BufLimit {
+		bv = node.params.BufLimit
+	}
+	sc, ok := node.pending[reqID]
 	if !ok {
 		return
 	}
-	delete(peer.pending, reqID)
-	cc := peer.sumCost - sc
-	peer.bufEstimate = 0
+	delete(node.pending, reqID)
+	cc := node.sumCost - sc
+	newEstimate := uint64(0)
 	if bv > cc {
-		peer.bufEstimate = bv - cc
+		newEstimate = bv - cc
 	}
-	peer.lastTime = mclock.Now()
+	if newEstimate > node.bufEstimate {
+		// Note: we never reduce the buffer estimate based on the reported value because
+		// this can only happen because of the delayed delivery of the latest reply.
+		// The lowest estimate based on the previous reply can still be considered valid.
+		node.bufEstimate = newEstimate
+	}
+
+	node.bufRecharge = node.bufEstimate < node.params.BufLimit
+	node.lastTime = now
+	if node.log != nil {
+		node.log.add(now, fmt.Sprintf("received  reqID=%d  bufEst=%d  reportedBv=%d  sumCost=%d  oldSumCost=%d", reqID, node.bufEstimate, bv, node.sumCost, sc))
+	}
+}
+
+// DumpLogs dumps the event log if logging is used
+func (node *ServerNode) DumpLogs() {
+	node.lock.Lock()
+	defer node.lock.Unlock()
+
+	if node.log != nil {
+		node.log.dump(node.clock.Now())
+	}
 }

--- a/les/flowcontrol/control.go
+++ b/les/flowcontrol/control.go
@@ -30,9 +30,9 @@ const (
 	// fcTimeConst is the time constant applied for MinRecharge during linear
 	// buffer recharge period
 	fcTimeConst = time.Millisecond
-	// DecParamDelay is applied at server side when decreasing bandwidth in order to
+	// DecParamDelay is applied at server side when decreasing capacity in order to
 	// avoid a buffer underrun error due to requests sent by the client before
-	// receiving the bandwidth update announcement
+	// receiving the capacity update announcement
 	DecParamDelay = time.Second * 2
 	// keepLogs is the duration of keeping logs; logging is not used if zero
 	keepLogs = 0
@@ -40,7 +40,7 @@ const (
 
 // ServerParams are the flow control parameters specified by a server for a client
 //
-// Note: a server can assign different amounts of bandwidth to each client by giving
+// Note: a server can assign different amounts of capacity to each client by giving
 // different parameters to them.
 type ServerParams struct {
 	BufLimit, MinRecharge uint64

--- a/les/flowcontrol/control.go
+++ b/les/flowcontrol/control.go
@@ -82,6 +82,10 @@ func NewClientNode(cm *ClientManager, params ServerParams) *ClientNode {
 	return node
 }
 
+func (node *ClientNode) Disconnect() {
+	node.cm.disconnect(node)
+}
+
 func (node *ClientNode) update(now mclock.AbsTime) {
 	for len(node.updateSchedule) > 0 && node.updateSchedule[0].time <= now {
 		node.recalcBV(node.updateSchedule[0].time)

--- a/les/flowcontrol/control.go
+++ b/les/flowcontrol/control.go
@@ -31,7 +31,7 @@ type ServerParams struct {
 }
 
 type ClientNode struct {
-	params   *ServerParams
+	params   ServerParams
 	bufValue uint64
 	lastTime mclock.AbsTime
 	lock     sync.Mutex
@@ -39,7 +39,7 @@ type ClientNode struct {
 	cmNode   *cmNode
 }
 
-func NewClientNode(cm *ClientManager, params *ServerParams) *ClientNode {
+func NewClientNode(cm *ClientManager, params ServerParams) *ClientNode {
 	node := &ClientNode{
 		cm:       cm,
 		params:   params,
@@ -95,19 +95,35 @@ func (peer *ClientNode) RequestProcessed(cost uint64) (bv, realCost uint64) {
 type ServerNode struct {
 	bufEstimate uint64
 	lastTime    mclock.AbsTime
-	params      *ServerParams
+	params      ServerParams
 	sumCost     uint64            // sum of req costs sent to this server
 	pending     map[uint64]uint64 // value = sumCost after sending the given req
 	lock        sync.RWMutex
 }
 
-func NewServerNode(params *ServerParams) *ServerNode {
+func NewServerNode(params ServerParams) *ServerNode {
 	return &ServerNode{
 		bufEstimate: params.BufLimit,
 		lastTime:    mclock.Now(),
 		params:      params,
 		pending:     make(map[uint64]uint64),
 	}
+}
+
+// UpdateParams updates flow control parameters
+func (peer *ServerNode) UpdateParams(params ServerParams) {
+	peer.lock.Lock()
+	defer peer.lock.Unlock()
+
+	peer.recalcBLE(mclock.Now())
+	if params.BufLimit > peer.params.BufLimit {
+		peer.bufEstimate += params.BufLimit - peer.params.BufLimit
+	} else {
+		if peer.bufEstimate > params.BufLimit {
+			peer.bufEstimate = params.BufLimit
+		}
+	}
+	peer.params = params
 }
 
 func (peer *ServerNode) recalcBLE(time mclock.AbsTime) {

--- a/les/flowcontrol/logger.go
+++ b/les/flowcontrol/logger.go
@@ -14,7 +14,6 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
 
-// Package flowcontrol implements a client side flow control mechanism
 package flowcontrol
 
 import (

--- a/les/flowcontrol/logger.go
+++ b/les/flowcontrol/logger.go
@@ -1,0 +1,66 @@
+// Copyright 2018 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+// Package flowcontrol implements a client side flow control mechanism
+package flowcontrol
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/ethereum/go-ethereum/common/mclock"
+)
+
+// logger collects events in string format and discards events older than the
+// "keep" parameter
+type logger struct {
+	events           map[uint64]logEvent
+	writePtr, delPtr uint64
+	keep             time.Duration
+}
+
+// logEvent describes a single event
+type logEvent struct {
+	time  mclock.AbsTime
+	event string
+}
+
+// newLogger creates a new logger
+func newLogger(keep time.Duration) *logger {
+	return &logger{
+		events: make(map[uint64]logEvent),
+		keep:   keep,
+	}
+}
+
+// add adds a new event and discards old events if possible
+func (l *logger) add(now mclock.AbsTime, event string) {
+	keepAfter := now - mclock.AbsTime(l.keep)
+	for l.delPtr < l.writePtr && l.events[l.delPtr].time <= keepAfter {
+		delete(l.events, l.delPtr)
+		l.delPtr++
+	}
+	l.events[l.writePtr] = logEvent{now, event}
+	l.writePtr++
+}
+
+// dump prints all stored events
+func (l *logger) dump(now mclock.AbsTime) {
+	for i := l.delPtr; i < l.writePtr; i++ {
+		e := l.events[i]
+		fmt.Println(time.Duration(e.time-now), e.event)
+	}
+}

--- a/les/flowcontrol/manager.go
+++ b/les/flowcontrol/manager.go
@@ -45,7 +45,7 @@ type cmNodeFields struct {
 // values and perfect precision is required.
 const FixedPointMultiplier = 1000000
 
-// ClientManager controls the bandwidth assigned to the clients of a server.
+// ClientManager controls the capacity assigned to the clients of a server.
 // Since ServerParams guarantee a safe lower estimate for processable requests
 // even in case of all clients being active, ClientManager calculates a
 // corrigated buffer value and usually allows a higher remaining buffer value

--- a/les/flowcontrol/manager.go
+++ b/les/flowcontrol/manager.go
@@ -1,4 +1,4 @@
-// Copyright 2016 The go-ethereum Authors
+// Copyright 2018 The go-ethereum Authors
 // This file is part of the go-ethereum library.
 //
 // The go-ethereum library is free software: you can redistribute it and/or modify
@@ -18,207 +18,269 @@
 package flowcontrol
 
 import (
+	"fmt"
 	"sync"
-	"time"
 
 	"github.com/ethereum/go-ethereum/common/mclock"
+	"github.com/ethereum/go-ethereum/common/prque"
 )
 
-const rcConst = 1000000
-
-type cmNode struct {
-	node                         *ClientNode
-	lastUpdate                   mclock.AbsTime
-	serving, recharging          bool
-	rcWeight                     uint64
-	rcValue, rcDelta, startValue int64
-	finishRecharge               mclock.AbsTime
+// cmNodeFields are ClientNode fields used by the client manager
+// Note: these fields are locked by the client manager's mutex
+type cmNodeFields struct {
+	corrBufValue   int64 // buffer value adjusted with the extra recharge amount
+	rcLastIntValue int64 // past recharge integrator value when corrBufValue was last updated
+	rcFullIntValue int64 // future recharge integrator value when corrBufValue will reach maximum
+	queueIndex     int   // position in the recharge queue (-1 if not queued)
 }
 
-func (node *cmNode) update(time mclock.AbsTime) {
-	dt := int64(time - node.lastUpdate)
-	node.rcValue += node.rcDelta * dt / rcConst
-	node.lastUpdate = time
-	if node.recharging && time >= node.finishRecharge {
-		node.recharging = false
-		node.rcDelta = 0
-		node.rcValue = 0
-	}
-}
+// FixedPointMultiplier is applied to the recharge integrator and the recharge curve.
+//
+// Note: fixed point arithmetic is required for the integrator because it is a
+// constantly increasing value that can wrap around int64 limits (which behavior is
+// also supported by the priority queue). A floating point value would gradually lose
+// precision in this application.
+// The recharge curve and all recharge values are encoded as fixed point because
+// sumRecharge is frequently updated by adding or subtracting individual recharge
+// values and perfect precision is required.
+const FixedPointMultiplier = 1000000
 
-func (node *cmNode) set(serving bool, simReqCnt, sumWeight uint64) {
-	if node.serving && !serving {
-		node.recharging = true
-		sumWeight += node.rcWeight
-	}
-	node.serving = serving
-	if node.recharging && serving {
-		node.recharging = false
-		sumWeight -= node.rcWeight
-	}
-
-	node.rcDelta = 0
-	if serving {
-		node.rcDelta = int64(rcConst / simReqCnt)
-	}
-	if node.recharging {
-		node.rcDelta = -int64(node.node.cm.rcRecharge * node.rcWeight / sumWeight)
-		node.finishRecharge = node.lastUpdate + mclock.AbsTime(node.rcValue*rcConst/(-node.rcDelta))
-	}
-}
-
+// ClientManager controls the bandwidth assigned to the clients of a server.
+// Since ServerParams guarantee a safe lower estimate for processable requests
+// even in case of all clients being active, ClientManager calculates a
+// corrigated buffer value and usually allows a higher remaining buffer value
+// to be returned with each reply.
 type ClientManager struct {
-	lock                             sync.Mutex
-	nodes                            map[*cmNode]struct{}
-	simReqCnt, sumWeight, rcSumValue uint64
-	maxSimReq, maxRcSum              uint64
-	rcRecharge                       uint64
-	resumeQueue                      chan chan bool
-	time                             mclock.AbsTime
+	clock     mclock.Clock
+	lock      sync.Mutex
+	nodes     map[*ClientNode]struct{}
+	enabledCh chan struct{}
+
+	curve       PieceWiseLinear
+	sumRecharge uint64
+	// recharge integrator is increasing in each moment with a rate of
+	// (totalRecharge / sumRecharge)*FixedPointMultiplier or 0 if sumRecharge==0
+	rcLastUpdate   mclock.AbsTime // last time the recharge integrator was updated
+	rcLastIntValue int64          // last updated value of the recharge integrator
+	// recharge queue is a priority queue with currently recharging client nodes
+	// as elements. The priority value is rcFullIntValue which allows to quickly
+	// determine which client will first finish recharge.
+	rcQueue *prque.Prque
 }
 
-func NewClientManager(rcTarget, maxSimReq, maxRcSum uint64) *ClientManager {
+// NewClientManager returns a new client manager.
+// Client manager enhances flow control performance by allowing client buffers
+// to recharge quicker than the minimum guaranteed recharge rate if possible.
+// The sum of all minimum recharge rates (sumRecharge) is updated each time
+// a clients starts or finishes buffer recharging. Then an adjusted total
+// recharge rate is calculated using a piecewise linear recharge curve:
+//
+// totalRecharge = curve(sumRecharge)
+// (totalRecharge >= sumRecharge is enforced)
+//
+// Then the "bonus" buffer recharge is distributed between currently recharging
+// clients proportionally to their minimum recharge rates.
+//
+// Note: total recharge is proportional to the average number of parallel running
+// serving threads. A recharge value of 1000000 corresponds to one thread in average.
+// The maximum number of allowed serving threads should always be considerably
+// higher than the targeted average number.
+//
+// Note 2: although it is possible to specify a curve allowing the total target
+// recharge starting from zero sumRecharge, it makes sense to add a linear ramp
+// starting from zero in order to not let a single low-priority client use up
+// the entire server capacity and thus ensure quick availability for others at
+// any moment.
+func NewClientManager(curve PieceWiseLinear, clock mclock.Clock) *ClientManager {
 	cm := &ClientManager{
-		nodes:       make(map[*cmNode]struct{}),
-		resumeQueue: make(chan chan bool),
-		rcRecharge:  rcConst * rcConst / (100*rcConst/rcTarget - rcConst),
-		maxSimReq:   maxSimReq,
-		maxRcSum:    maxRcSum,
+		clock:   clock,
+		nodes:   make(map[*ClientNode]struct{}),
+		rcQueue: prque.New(func(a interface{}, i int) { a.(*ClientNode).queueIndex = i }),
+		curve:   curve,
 	}
-	go cm.queueProc()
 	return cm
 }
 
-func (self *ClientManager) Stop() {
-	self.lock.Lock()
-	defer self.lock.Unlock()
+// SetRechargeCurve updates the recharge curve
+func (cm *ClientManager) SetRechargeCurve(curve PieceWiseLinear) {
+	cm.lock.Lock()
+	defer cm.lock.Unlock()
 
-	// signal any waiting accept routines to return false
-	self.nodes = make(map[*cmNode]struct{})
-	close(self.resumeQueue)
+	cm.updateRecharge(cm.clock.Now())
+	cm.curve = curve
 }
 
-func (self *ClientManager) addNode(cnode *ClientNode) *cmNode {
-	time := mclock.Now()
-	node := &cmNode{
-		node:           cnode,
-		lastUpdate:     time,
-		finishRecharge: time,
-		rcWeight:       1,
+// init initializes the ClientManager specific fields of a ClientNode structure
+func (cm *ClientManager) init(node *ClientNode) {
+	cm.lock.Lock()
+	defer cm.lock.Unlock()
+
+	node.corrBufValue = int64(node.params.BufLimit)
+	node.rcLastIntValue = cm.rcLastIntValue
+	node.queueIndex = -1
+}
+
+// accepted deduces the upper estimate for request cost from the buffer and returns a priority
+// value based on current buffer status which is used by the serving queue.
+func (cm *ClientManager) accepted(node *ClientNode, maxCost uint64, now mclock.AbsTime) (priority int64) {
+	cm.lock.Lock()
+	defer cm.lock.Unlock()
+
+	cm.updateNodeRc(node, -int64(maxCost), &node.params, now)
+	rcTime := (node.params.BufLimit - uint64(node.corrBufValue)) * FixedPointMultiplier / node.params.MinRecharge
+	return -int64(now) - int64(rcTime)
+}
+
+// processed updates the client buffer according to actual request cost after
+// serving has been finished.
+//
+// Note: processed should always be called for all accepted requests
+func (cm *ClientManager) processed(node *ClientNode, maxCost, realCost uint64, now mclock.AbsTime) {
+	cm.lock.Lock()
+	defer cm.lock.Unlock()
+
+	if realCost > maxCost {
+		realCost = maxCost
 	}
-	self.lock.Lock()
-	defer self.lock.Unlock()
-
-	self.nodes[node] = struct{}{}
-	self.update(mclock.Now())
-	return node
-}
-
-func (self *ClientManager) removeNode(node *cmNode) {
-	self.lock.Lock()
-	defer self.lock.Unlock()
-
-	time := mclock.Now()
-	self.stop(node, time)
-	delete(self.nodes, node)
-	self.update(time)
-}
-
-// recalc sumWeight
-func (self *ClientManager) updateNodes(time mclock.AbsTime) (rce bool) {
-	var sumWeight, rcSum uint64
-	for node := range self.nodes {
-		rc := node.recharging
-		node.update(time)
-		if rc && !node.recharging {
-			rce = true
+	cm.updateNodeRc(node, int64(maxCost-realCost), &node.params, now)
+	if uint64(node.corrBufValue) > node.bufValue {
+		if node.log != nil {
+			node.log.add(now, fmt.Sprintf("corrected  bv=%d  oldBv=%d", node.corrBufValue, node.bufValue))
 		}
-		if node.recharging {
-			sumWeight += node.rcWeight
-		}
-		rcSum += uint64(node.rcValue)
+		node.bufValue = uint64(node.corrBufValue)
 	}
-	self.sumWeight = sumWeight
-	self.rcSumValue = rcSum
-	return
 }
 
-func (self *ClientManager) update(time mclock.AbsTime) {
-	for {
-		firstTime := time
-		for node := range self.nodes {
-			if node.recharging && node.finishRecharge < firstTime {
-				firstTime = node.finishRecharge
-			}
+func (cm *ClientManager) updateParams(node *ClientNode, params ServerParams, now mclock.AbsTime) {
+	cm.lock.Lock()
+	defer cm.lock.Unlock()
+
+	cm.updateNodeRc(node, 0, &params, now)
+}
+
+// updateRecharge updates the recharge integrator and checks the recharge queue
+// for nodes with recently filled buffers
+func (cm *ClientManager) updateRecharge(now mclock.AbsTime) {
+	lastUpdate := cm.rcLastUpdate
+	cm.rcLastUpdate = now
+	// updating is done in multiple steps if node buffers are filled and sumRecharge
+	// is decreased before the given target time
+	for cm.sumRecharge > 0 {
+		bonusRatio := cm.curve.ValueAt(cm.sumRecharge) / float64(cm.sumRecharge)
+		if bonusRatio < 1 {
+			bonusRatio = 1
 		}
-		if self.updateNodes(firstTime) {
-			for node := range self.nodes {
-				if node.recharging {
-					node.set(node.serving, self.simReqCnt, self.sumWeight)
-				}
-			}
-		} else {
-			self.time = time
+		dt := now - lastUpdate
+		// fetch the client that finishes first
+
+		if cm.rcQueue.Empty() { // debug
+			fmt.Println("cm.sumRecharge", cm.sumRecharge)
+			panic("rcQueue is empty")
+		}
+
+		rcqNode := cm.rcQueue.PopItem().(*ClientNode) // if sumRecharge > 0 then the queue cannot be empty
+		// check whether it has already finished
+		dtNext := mclock.AbsTime(float64(rcqNode.rcFullIntValue-cm.rcLastIntValue) / bonusRatio)
+		if dt < dtNext {
+			// not finished yet, put it back, update integrator according
+			// to current bonusRatio and return
+			cm.rcQueue.Push(rcqNode, -rcqNode.rcFullIntValue)
+			cm.rcLastIntValue += int64(bonusRatio * float64(dt))
 			return
 		}
-	}
-}
-
-func (self *ClientManager) canStartReq() bool {
-	return self.simReqCnt < self.maxSimReq && self.rcSumValue < self.maxRcSum
-}
-
-func (self *ClientManager) queueProc() {
-	for rc := range self.resumeQueue {
-		for {
-			time.Sleep(time.Millisecond * 10)
-			self.lock.Lock()
-			self.update(mclock.Now())
-			cs := self.canStartReq()
-			self.lock.Unlock()
-			if cs {
-				break
-			}
+		// finished recharging, update corrBufValue and sumRecharge if necessary and do next step
+		if rcqNode.corrBufValue < int64(rcqNode.params.BufLimit) {
+			rcqNode.corrBufValue = int64(rcqNode.params.BufLimit)
+			cm.sumRecharge -= rcqNode.params.MinRecharge
 		}
-		close(rc)
+		lastUpdate += dtNext
+		cm.rcLastIntValue = rcqNode.rcFullIntValue
 	}
 }
 
-func (self *ClientManager) accept(node *cmNode, time mclock.AbsTime) bool {
-	self.lock.Lock()
-	defer self.lock.Unlock()
+// updateNodeRc updates a node's corrBufValue and adds an external correction value.
+// It also adds or removes the rcQueue entry and updates ServerParams and sumRecharge if necessary.
+func (cm *ClientManager) updateNodeRc(node *ClientNode, bvc int64, params *ServerParams, now mclock.AbsTime) {
+	cm.updateRecharge(now)
+	wasFull := true
+	if node.corrBufValue != int64(node.params.BufLimit) {
+		wasFull = false
+		node.corrBufValue += (cm.rcLastIntValue - node.rcLastIntValue) * int64(node.params.MinRecharge) / FixedPointMultiplier
+		if node.corrBufValue > int64(node.params.BufLimit) {
+			node.corrBufValue = int64(node.params.BufLimit)
+		}
+		node.rcLastIntValue = cm.rcLastIntValue
+	}
+	node.corrBufValue += bvc
+	if node.corrBufValue < 0 {
+		node.corrBufValue = 0
+	}
+	diff := int64(params.BufLimit - node.params.BufLimit)
+	if diff > 0 {
+		node.corrBufValue += diff
+	}
+	isFull := false
+	if node.corrBufValue >= int64(params.BufLimit) {
+		node.corrBufValue = int64(params.BufLimit)
+		isFull = true
+	}
+	if !wasFull {
+		cm.sumRecharge -= node.params.MinRecharge
+	}
+	if params != &node.params {
+		node.params = *params
+	}
+	if !isFull {
+		cm.sumRecharge += node.params.MinRecharge
+		if node.queueIndex != -1 {
+			cm.rcQueue.Remove(node.queueIndex)
+		}
+		node.rcLastIntValue = cm.rcLastIntValue
+		node.rcFullIntValue = cm.rcLastIntValue + (int64(node.params.BufLimit)-node.corrBufValue)*FixedPointMultiplier/int64(node.params.MinRecharge)
+		cm.rcQueue.Push(node, -node.rcFullIntValue)
+	}
+}
 
-	self.update(time)
-	if !self.canStartReq() {
-		resume := make(chan bool)
-		self.lock.Unlock()
-		self.resumeQueue <- resume
-		<-resume
-		self.lock.Lock()
-		if _, ok := self.nodes[node]; !ok {
-			return false // reject if node has been removed or manager has been stopped
+// PieceWiseLinear is used to describe recharge curves
+type PieceWiseLinear []struct{ X, Y uint64 }
+
+// ValueAt returns the curve's value at a given point
+func (pwl PieceWiseLinear) ValueAt(x uint64) float64 {
+	l := 0
+	h := len(pwl)
+	if h == 0 {
+		return 0
+	}
+	for h != l {
+		m := (l + h) / 2
+		if x > pwl[m].X {
+			l = m + 1
+		} else {
+			h = m
 		}
 	}
-	self.simReqCnt++
-	node.set(true, self.simReqCnt, self.sumWeight)
-	node.startValue = node.rcValue
-	self.update(self.time)
+	if l == 0 {
+		return float64(pwl[0].Y)
+	}
+	l--
+	if h == len(pwl) {
+		return float64(pwl[l].Y)
+	}
+	dx := pwl[h].X - pwl[l].X
+	if dx < 1 {
+		return float64(pwl[l].Y)
+	}
+	return float64(pwl[l].Y) + float64(pwl[h].Y-pwl[l].Y)*float64(x-pwl[l].X)/float64(dx)
+}
+
+// Valid returns true if the X coordinates of the curve points are non-strictly monotonic
+func (pwl PieceWiseLinear) Valid() bool {
+	var lastX uint64
+	for _, i := range pwl {
+		if i.X < lastX {
+			return false
+		}
+		lastX = i.X
+	}
 	return true
-}
-
-func (self *ClientManager) stop(node *cmNode, time mclock.AbsTime) {
-	if node.serving {
-		self.update(time)
-		self.simReqCnt--
-		node.set(false, self.simReqCnt, self.sumWeight)
-		self.update(time)
-	}
-}
-
-func (self *ClientManager) processed(node *cmNode, time mclock.AbsTime) (rcValue, rcCost uint64) {
-	self.lock.Lock()
-	defer self.lock.Unlock()
-
-	self.stop(node, time)
-	return uint64(node.rcValue), uint64(node.rcValue - node.startValue)
 }

--- a/les/flowcontrol/manager.go
+++ b/les/flowcontrol/manager.go
@@ -131,7 +131,7 @@ func (cm *ClientManager) SetRechargeCurve(curve PieceWiseLinear) {
 }
 
 // connect should be called when a client is connected, before passing it to any
-// other ClientManager funtion
+// other ClientManager function
 func (cm *ClientManager) connect(node *ClientNode) {
 	cm.lock.Lock()
 	defer cm.lock.Unlock()

--- a/les/flowcontrol/manager_test.go
+++ b/les/flowcontrol/manager_test.go
@@ -1,0 +1,124 @@
+// Copyright 2018 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+// Package flowcontrol implements a client side flow control mechanism
+package flowcontrol
+
+import (
+	"math/rand"
+	"testing"
+	"time"
+
+	"github.com/ethereum/go-ethereum/common/mclock"
+)
+
+type testNode struct {
+	node                *ClientNode
+	bufLimit, bandwidth uint64
+	waitUntil           mclock.AbsTime
+	index, totalCost    uint64
+}
+
+const (
+	testMaxCost = 1000000
+	testLength  = 100000
+)
+
+// testConstantTotalBandwidth simulates multiple request sender nodes and verifies
+// whether the total amount of served requests matches the expected value based on
+// the total bandwidth and the duration of the test.
+// Some nodes are sending requests occasionally so that their buffer should regularly
+// reach the maximum while other nodes (the "max capacity nodes") are sending at the
+// maximum permitted rate. The max capacity nodes are changed multiple times during
+// a single test.
+func TestConstantTotalBandwidth(t *testing.T) {
+	testConstantTotalBandwidth(t, 10, 1, 0)
+	testConstantTotalBandwidth(t, 10, 1, 1)
+	testConstantTotalBandwidth(t, 30, 1, 0)
+	testConstantTotalBandwidth(t, 30, 2, 3)
+	testConstantTotalBandwidth(t, 100, 1, 0)
+	testConstantTotalBandwidth(t, 100, 3, 5)
+	testConstantTotalBandwidth(t, 100, 5, 10)
+}
+
+func testConstantTotalBandwidth(t *testing.T, nodeCount, maxCapacityNodes, randomSend int) {
+	clock := &mclock.Simulated{}
+	nodes := make([]*testNode, nodeCount)
+	var totalBandwidth uint64
+	for i, _ := range nodes {
+		nodes[i] = &testNode{bandwidth: uint64(50000 + rand.Intn(100000))}
+		totalBandwidth += nodes[i].bandwidth
+	}
+	m := NewClientManager(PieceWiseLinear{{0, totalBandwidth}}, clock)
+	for _, n := range nodes {
+		n.bufLimit = n.bandwidth * 6000 //uint64(2000+rand.Intn(10000))
+		n.node = NewClientNode(m, ServerParams{BufLimit: n.bufLimit, MinRecharge: n.bandwidth})
+	}
+	maxNodes := make([]int, maxCapacityNodes)
+	for i, _ := range maxNodes {
+		// we don't care if some indexes are selected multiple times
+		// in that case we have fewer max nodes
+		maxNodes[i] = rand.Intn(nodeCount)
+	}
+
+	for i := 0; i < testLength; i++ {
+		now := clock.Now()
+		for _, idx := range maxNodes {
+			for nodes[idx].send(t, now) {
+			}
+		}
+		if rand.Intn(testLength) < maxCapacityNodes*3 {
+			maxNodes[rand.Intn(maxCapacityNodes)] = rand.Intn(nodeCount)
+		}
+
+		sendCount := randomSend
+		for sendCount > 0 {
+			if nodes[rand.Intn(nodeCount)].send(t, now) {
+				sendCount--
+			}
+		}
+
+		clock.Run(time.Millisecond)
+	}
+
+	var totalCost uint64
+	for _, n := range nodes {
+		totalCost += n.totalCost
+	}
+	ratio := float64(totalCost) / float64(totalBandwidth) / testLength
+	if ratio < 0.98 || ratio > 1.02 {
+		t.Errorf("totalCost/totalBandwidth/testLength ratio incorrect (expected: 1, got: %f)", ratio)
+	}
+
+}
+
+func (n *testNode) send(t *testing.T, now mclock.AbsTime) bool {
+	if now < n.waitUntil {
+		return false
+	}
+	n.index++
+	if ok, _, _ := n.node.AcceptRequest(0, n.index, testMaxCost); !ok {
+		t.Fatalf("Rejected request after expected waiting time has passed")
+	}
+	rcost := uint64(rand.Int63n(testMaxCost))
+	bv := n.node.RequestProcessed(0, n.index, testMaxCost, rcost)
+	if bv < testMaxCost {
+		n.waitUntil = now + mclock.AbsTime((testMaxCost-bv)*1001000/n.bandwidth)
+	}
+	//n.waitUntil = now + mclock.AbsTime(float64(testMaxCost)*1001000/float64(n.bandwidth)*(1-float64(bv)/float64(n.bufLimit)))
+	n.totalCost += rcost
+	return true
+}

--- a/les/flowcontrol/manager_test.go
+++ b/les/flowcontrol/manager_test.go
@@ -14,7 +14,6 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
 
-// Package flowcontrol implements a client side flow control mechanism
 package flowcontrol
 
 import (
@@ -26,10 +25,10 @@ import (
 )
 
 type testNode struct {
-	node                *ClientNode
+	node               *ClientNode
 	bufLimit, capacity uint64
-	waitUntil           mclock.AbsTime
-	index, totalCost    uint64
+	waitUntil          mclock.AbsTime
+	index, totalCost   uint64
 }
 
 const (

--- a/les/flowcontrol/manager_test.go
+++ b/les/flowcontrol/manager_test.go
@@ -57,7 +57,7 @@ func testConstantTotalCapacity(t *testing.T, nodeCount, maxCapacityNodes, random
 	clock := &mclock.Simulated{}
 	nodes := make([]*testNode, nodeCount)
 	var totalCapacity uint64
-	for i, _ := range nodes {
+	for i := range nodes {
 		nodes[i] = &testNode{capacity: uint64(50000 + rand.Intn(100000))}
 		totalCapacity += nodes[i].capacity
 	}
@@ -67,7 +67,7 @@ func testConstantTotalCapacity(t *testing.T, nodeCount, maxCapacityNodes, random
 		n.node = NewClientNode(m, ServerParams{BufLimit: n.bufLimit, MinRecharge: n.capacity})
 	}
 	maxNodes := make([]int, maxCapacityNodes)
-	for i, _ := range maxNodes {
+	for i := range maxNodes {
 		// we don't care if some indexes are selected multiple times
 		// in that case we have fewer max nodes
 		maxNodes[i] = rand.Intn(nodeCount)

--- a/les/freeclient.go
+++ b/les/freeclient.go
@@ -14,11 +14,9 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
 
-// Package les implements the Light Ethereum Subprotocol.
 package les
 
 import (
-	"fmt"
 	"io"
 	"math"
 	"net"
@@ -189,7 +187,6 @@ func (f *freeClientPool) setLimits(count int, totalCap uint64) {
 	f.lock.Lock()
 	defer f.lock.Unlock()
 
-	fmt.Println("setLimits", count, totalCap, f.freeClientCap)
 	f.connectedLimit = int(totalCap / f.freeClientCap)
 	if count < f.connectedLimit {
 		f.connectedLimit = count

--- a/les/freeclient.go
+++ b/les/freeclient.go
@@ -142,6 +142,7 @@ func (f *freeClientPool) connect(address, id string) bool {
 	}
 	f.disconnPool.Remove(e.index)
 	e.connected = true
+	e.id = id
 	f.connPool.Push(e, e.linUsage)
 	if f.connPool.Size()+f.disconnPool.Size() > f.totalLimit {
 		f.disconnPool.Pop()

--- a/les/freeclient_test.go
+++ b/les/freeclient_test.go
@@ -14,8 +14,6 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
 
-// Package light implements on-demand retrieval capable state and chain objects
-// for the Ethereum Light Client.
 package les
 
 import (

--- a/les/freeclient_test.go
+++ b/les/freeclient_test.go
@@ -21,6 +21,7 @@ package les
 import (
 	"fmt"
 	"math/rand"
+	"strconv"
 	"testing"
 	"time"
 
@@ -44,32 +45,38 @@ const testFreeClientPoolTicks = 500000
 
 func testFreeClientPool(t *testing.T, connLimit, clientCount int) {
 	var (
-		clock     mclock.Simulated
-		db        = ethdb.NewMemDatabase()
-		pool      = newFreeClientPool(db, connLimit, 10000, &clock)
-		connected = make([]bool, clientCount)
-		connTicks = make([]int, clientCount)
-		disconnCh = make(chan int, clientCount)
-	)
-	peerId := func(i int) string {
-		return fmt.Sprintf("test peer #%d", i)
-	}
-	disconnFn := func(i int) func() {
-		return func() {
+		clock       mclock.Simulated
+		db          = ethdb.NewMemDatabase()
+		connected   = make([]bool, clientCount)
+		connTicks   = make([]int, clientCount)
+		disconnCh   = make(chan int, clientCount)
+		peerAddress = func(i int) string {
+			return fmt.Sprintf("addr #%d", i)
+		}
+		peerId = func(i int) string {
+			return fmt.Sprintf("id #%d", i)
+		}
+		disconnFn = func(id string) {
+			i, err := strconv.Atoi(id[4:])
+			if err != nil {
+				panic(err)
+			}
 			disconnCh <- i
 		}
-	}
+		pool = newFreeClientPool(db, 1, 10000, &clock, disconnFn)
+	)
+	pool.setLimits(connLimit, uint64(connLimit))
 
 	// pool should accept new peers up to its connected limit
 	for i := 0; i < connLimit; i++ {
-		if pool.connect(peerId(i), disconnFn(i)) {
+		if pool.connect(peerAddress(i), peerId(i)) {
 			connected[i] = true
 		} else {
 			t.Fatalf("Test peer #%d rejected", i)
 		}
 	}
 	// since all accepted peers are new and should not be kicked out, the next one should be rejected
-	if pool.connect(peerId(connLimit), disconnFn(connLimit)) {
+	if pool.connect(peerAddress(connLimit), peerId(connLimit)) {
 		connected[connLimit] = true
 		t.Fatalf("Peer accepted over connected limit")
 	}
@@ -80,11 +87,11 @@ func testFreeClientPool(t *testing.T, connLimit, clientCount int) {
 
 		i := rand.Intn(clientCount)
 		if connected[i] {
-			pool.disconnect(peerId(i))
+			pool.disconnect(peerAddress(i))
 			connected[i] = false
 			connTicks[i] += tickCounter
 		} else {
-			if pool.connect(peerId(i), disconnFn(i)) {
+			if pool.connect(peerAddress(i), peerId(i)) {
 				connected[i] = true
 				connTicks[i] -= tickCounter
 			}
@@ -93,7 +100,7 @@ func testFreeClientPool(t *testing.T, connLimit, clientCount int) {
 		for {
 			select {
 			case i := <-disconnCh:
-				pool.disconnect(peerId(i))
+				pool.disconnect(peerAddress(i))
 				if connected[i] {
 					connTicks[i] += tickCounter
 					connected[i] = false
@@ -119,20 +126,21 @@ func testFreeClientPool(t *testing.T, connLimit, clientCount int) {
 	}
 
 	// a previously unknown peer should be accepted now
-	if !pool.connect("newPeer", func() {}) {
+	if !pool.connect("newAddr", "newId") {
 		t.Fatalf("Previously unknown peer rejected")
 	}
 
 	// close and restart pool
 	pool.stop()
-	pool = newFreeClientPool(db, connLimit, 10000, &clock)
+	pool = newFreeClientPool(db, 1, 10000, &clock, disconnFn)
+	pool.setLimits(connLimit, uint64(connLimit))
 
 	// try connecting all known peers (connLimit should be filled up)
 	for i := 0; i < clientCount; i++ {
-		pool.connect(peerId(i), func() {})
+		pool.connect(peerAddress(i), peerId(i))
 	}
 	// expect pool to remember known nodes and kick out one of them to accept a new one
-	if !pool.connect("newPeer2", func() {}) {
+	if !pool.connect("newAddr2", "newId2") {
 		t.Errorf("Previously unknown peer rejected after restarting pool")
 	}
 	pool.stop()

--- a/les/handler.go
+++ b/les/handler.go
@@ -14,7 +14,6 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
 
-// Package les implements the Light Ethereum Subprotocol.
 package les
 
 import (

--- a/les/handler.go
+++ b/les/handler.go
@@ -197,12 +197,12 @@ func (pm *ProtocolManager) removePeer(id string) {
 }
 
 // maxFreePeers returns the maximum number of free client slots based on the number
-// and total bandwidth of other clients
+// and total capacity of other clients
 func (pm *ProtocolManager) maxFreePeers(otherPeers int, otherBw uint64) int {
-	if otherPeers >= pm.maxPeers || otherBw >= pm.server.totalBandwidth {
+	if otherPeers >= pm.maxPeers || otherBw >= pm.server.totalCapacity {
 		return 0
 	}
-	maxPeers := int((pm.server.totalBandwidth - otherBw) / pm.freeClientBw)
+	maxPeers := int((pm.server.totalCapacity - otherBw) / pm.freeClientBw)
 	if maxPeers <= pm.maxPeers-otherPeers {
 		return maxPeers
 	}
@@ -212,9 +212,9 @@ func (pm *ProtocolManager) maxFreePeers(otherPeers int, otherBw uint64) int {
 func (pm *ProtocolManager) Start(maxPeers int) {
 	pm.maxPeers = maxPeers
 	if pm.server != nil && maxPeers > 0 {
-		pm.freeClientBw = pm.server.totalBandwidth / uint64(maxPeers)
-		if pm.freeClientBw < pm.server.minBandwidth {
-			pm.freeClientBw = pm.server.minBandwidth
+		pm.freeClientBw = pm.server.totalCapacity / uint64(maxPeers)
+		if pm.freeClientBw < pm.server.minCapacity {
+			pm.freeClientBw = pm.server.minCapacity
 		}
 		if pm.freeClientBw > 0 {
 			pm.server.defParams = flowcontrol.ServerParams{
@@ -365,7 +365,7 @@ func (pm *ProtocolManager) handle(p *peer) error {
 					free = false
 				}
 				vip = true
-				p.updateBandwidth(bw)
+				p.updateCapacity(bw)
 			}
 			if vip {
 				if bw == 0 {
@@ -378,10 +378,10 @@ func (pm *ProtocolManager) handle(p *peer) error {
 						free = true
 					}
 					vip = false
-					p.updateBandwidth(pm.freeClientBw)
+					p.updateCapacity(pm.freeClientBw)
 				} else {
-					// just update vip bandwidth
-					p.updateBandwidth(bw)
+					// just update vip capacity
+					p.updateCapacity(bw)
 				}
 			}
 		}
@@ -399,7 +399,7 @@ func (pm *ProtocolManager) handle(p *peer) error {
 			defer pm.vipClientPool.disconnect(p.ID())
 			if vipBw != 0 {
 				vip = true
-				p.updateBandwidth(vipBw)
+				p.updateCapacity(vipBw)
 			}
 		}
 

--- a/les/handler.go
+++ b/les/handler.go
@@ -381,9 +381,14 @@ func (pm *ProtocolManager) handleMsg(p *peer) error {
 		if reply != nil {
 			replySize = reply.size()
 		}
-		realCost := pm.server.costTracker.realCost(servingTime, msg.Size, replySize)
+		var realCost uint64
+		if pm.server.costTracker != nil {
+			realCost = pm.server.costTracker.realCost(servingTime, msg.Size, replySize)
+			pm.server.costTracker.updateStats(msg.Code, amount, servingTime, realCost)
+		} else {
+			realCost = maxCost
+		}
 		bv := p.fcClient.RequestProcessed(reqID, responseCount, maxCost, realCost)
-		pm.server.costTracker.updateStats(msg.Code, amount, servingTime, realCost)
 		if reply != nil {
 			p.queueSend(func() {
 				if err := reply.send(bv); err != nil {

--- a/les/handler.go
+++ b/les/handler.go
@@ -211,6 +211,10 @@ func (pm *ProtocolManager) Stop() {
 
 	close(pm.quitSync) // quits syncer, fetcher
 
+	if pm.servingQueue != nil {
+		pm.servingQueue.stop()
+	}
+
 	// Disconnect existing sessions.
 	// This also closes the gate for any new registrations on the peer set.
 	// sessions which are already established but not added to pm.peers yet

--- a/les/handler.go
+++ b/les/handler.go
@@ -223,11 +223,15 @@ func (pm *ProtocolManager) Start(maxPeers int) {
 			}
 		}
 	}
+	freePeers := pm.maxFreePeers(0, 0)
+	if freePeers < maxPeers {
+		log.Warn("Light peer count limited", "specified", maxPeers, "allowed", freePeers)
+	}
 
 	if pm.lightSync {
 		go pm.syncer()
 	} else {
-		pm.clientPool = newFreeClientPool(pm.chainDb, pm.maxFreePeers(0, 0), 10000, mclock.System{})
+		pm.clientPool = newFreeClientPool(pm.chainDb, freePeers, 10000, mclock.System{})
 		go func() {
 			for range pm.newPeerCh {
 			}

--- a/les/helper_test.go
+++ b/les/helper_test.go
@@ -192,8 +192,6 @@ func newTestProtocolManager(lightSync bool, blocks int, generator func(int, *cor
 		}
 
 		srv.fcManager = flowcontrol.NewClientManager(nil, &mclock.System{})
-		srv.fcCostList = testRCL()
-		srv.fcCostTable = srv.fcCostList.decode()
 	}
 	pm.Start(1000)
 	return pm, nil

--- a/les/helper_test.go
+++ b/les/helper_test.go
@@ -134,16 +134,6 @@ func testIndexers(db ethdb.Database, odr light.OdrBackend, iConfig *light.Indexe
 	return chtIndexer, bloomIndexer, bloomTrieIndexer
 }
 
-func testRCL() RequestCostList {
-	cl := make(RequestCostList, len(reqBenchMap))
-	for i, req := range reqBenchMap {
-		cl[i].MsgCode = req.code
-		cl[i].BaseCost = 0
-		cl[i].ReqCost = 0
-	}
-	return cl
-}
-
 // newTestProtocolManager creates a new protocol manager for testing purposes,
 // with the given number of blocks already known, potential notification
 // channels for different events and relative chain indexers array.
@@ -305,7 +295,7 @@ func (p *testPeer) handshake(t *testing.T, td *big.Int, head common.Hash, headNu
 	expList = expList.add("txRelay", nil)
 	expList = expList.add("flowControl/BL", testBufLimit)
 	expList = expList.add("flowControl/MRR", uint64(1))
-	expList = expList.add("flowControl/MRC", testRCL())
+	expList = expList.add("flowControl/MRC", testCostList())
 
 	if err := p2p.ExpectMsg(p.app, StatusMsg, expList); err != nil {
 		t.Fatalf("status recv: %v", err)

--- a/les/helper_test.go
+++ b/les/helper_test.go
@@ -184,7 +184,7 @@ func newTestProtocolManager(lightSync bool, blocks int, generator func(int, *cor
 		srv := &LesServer{lesCommons: lesCommons{protocolManager: pm}}
 		pm.server = srv
 
-		srv.defParams = &flowcontrol.ServerParams{
+		srv.defParams = flowcontrol.ServerParams{
 			BufLimit:    testBufLimit,
 			MinRecharge: 1,
 		}
@@ -313,7 +313,7 @@ func (p *testPeer) handshake(t *testing.T, td *big.Int, head common.Hash, headNu
 		t.Fatalf("status send: %v", err)
 	}
 
-	p.fcServerParams = &flowcontrol.ServerParams{
+	p.fcServerParams = flowcontrol.ServerParams{
 		BufLimit:    testBufLimit,
 		MinRecharge: 1,
 	}

--- a/les/odr.go
+++ b/les/odr.go
@@ -117,7 +117,7 @@ func (odr *LesOdr) Retrieve(ctx context.Context, req light.OdrRequest) (err erro
 		request: func(dp distPeer) func() {
 			p := dp.(*peer)
 			cost := lreq.GetCost(p)
-			p.fcServer.QueueRequest(reqID, cost)
+			p.fcServer.QueuedRequest(reqID, cost)
 			return func() { lreq.Request(reqID, p) }
 		},
 	}

--- a/les/odr_requests.go
+++ b/les/odr_requests.go
@@ -14,8 +14,6 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
 
-// Package light implements on-demand retrieval capable state and chain objects
-// for the Ethereum Light Client.
 package les
 
 import (

--- a/les/peer.go
+++ b/les/peer.go
@@ -14,7 +14,6 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
 
-// Package les implements the Light Ethereum Subprotocol.
 package les
 
 import (

--- a/les/peer.go
+++ b/les/peer.go
@@ -188,15 +188,15 @@ func (p *peer) waitBefore(maxCost uint64) (time.Duration, float64) {
 
 // updateCapacity updates the request serving capacity assigned to a given client
 // and also sends an announcement about the updated flow control parameters
-func (p *peer) updateCapacity(bw uint64) {
+func (p *peer) updateCapacity(cap uint64) {
 	p.responseLock.Lock()
 	defer p.responseLock.Unlock()
 
-	p.fcParams = flowcontrol.ServerParams{MinRecharge: bw, BufLimit: bw * bufLimitRatio}
+	p.fcParams = flowcontrol.ServerParams{MinRecharge: cap, BufLimit: cap * bufLimitRatio}
 	p.fcClient.UpdateParams(p.fcParams)
 	var kvList keyValueList
-	kvList = kvList.add("flowControl/MRR", bw)
-	kvList = kvList.add("flowControl/BL", bw*bufLimitRatio)
+	kvList = kvList.add("flowControl/MRR", cap)
+	kvList = kvList.add("flowControl/BL", cap*bufLimitRatio)
 	p.queueSend(func() { p.SendAnnounce(announceData{Update: kvList}) })
 }
 

--- a/les/peer.go
+++ b/les/peer.go
@@ -106,7 +106,7 @@ func newPeer(version int, network uint64, isTrusted bool, p *p2p.Peer, rw p2p.Ms
 		rw:        rw,
 		version:   version,
 		network:   network,
-		id:        fmt.Sprintf("%x", id[:8]),
+		id:        fmt.Sprintf("%x", id),
 		isTrusted: isTrusted,
 	}
 }

--- a/les/peer.go
+++ b/les/peer.go
@@ -519,7 +519,12 @@ func (p *peer) Handshake(td *big.Int, head common.Hash, headNum uint64, genesis 
 		}
 		send = send.add("flowControl/BL", server.defParams.BufLimit)
 		send = send.add("flowControl/MRR", server.defParams.MinRecharge)
-		costList := server.costTracker.makeCostList()
+		var costList RequestCostList
+		if server.costTracker != nil {
+			costList = server.costTracker.makeCostList()
+		} else {
+			costList = testRCL()
+		}
 		send = send.add("flowControl/MRC", costList)
 		p.fcCosts = costList.decode()
 		p.fcParams = server.defParams

--- a/les/peer.go
+++ b/les/peer.go
@@ -519,7 +519,7 @@ func (p *peer) Handshake(td *big.Int, head common.Hash, headNum uint64, genesis 
 		}
 		send = send.add("flowControl/BL", server.defParams.BufLimit)
 		send = send.add("flowControl/MRR", server.defParams.MinRecharge)
-		costList := server.makeCostList()
+		costList := server.costTracker.makeCostList()
 		send = send.add("flowControl/MRC", costList)
 		p.fcCosts = costList.decode()
 		p.fcParams = server.defParams

--- a/les/peer.go
+++ b/les/peer.go
@@ -523,7 +523,7 @@ func (p *peer) Handshake(td *big.Int, head common.Hash, headNum uint64, genesis 
 		if server.costTracker != nil {
 			costList = server.costTracker.makeCostList()
 		} else {
-			costList = testRCL()
+			costList = testCostList()
 		}
 		send = send.add("flowControl/MRC", costList)
 		p.fcCosts = costList.decode()

--- a/les/peer.go
+++ b/les/peer.go
@@ -43,7 +43,7 @@ var (
 
 const maxResponseErrors = 50 // number of invalid responses tolerated (makes the protocol less brittle but still avoids spam)
 
-// bandwidth limitation for parameter updates
+// capacity limitation for parameter updates
 const (
 	allowedUpdateBytes = 100000                // initial/maximum allowed update size
 	allowedUpdateRate  = time.Millisecond * 10 // time constant for recharging one byte of allowance
@@ -112,7 +112,7 @@ func newPeer(version int, network uint64, isTrusted bool, p *p2p.Peer, rw p2p.Ms
 }
 
 // rejectUpdate returns true if a parameter update has to be rejected because
-// the size and/or rate of updates exceed the bandwidth limitation
+// the size and/or rate of updates exceed the capacity limitation
 func (p *peer) rejectUpdate(size uint64) bool {
 	now := mclock.Now()
 	if p.updateCounter == 0 {
@@ -186,9 +186,9 @@ func (p *peer) waitBefore(maxCost uint64) (time.Duration, float64) {
 	return p.fcServer.CanSend(maxCost)
 }
 
-// updateBandwidth updates the request serving bandwidth assigned to a given client
+// updateCapacity updates the request serving capacity assigned to a given client
 // and also sends an announcement about the updated flow control parameters
-func (p *peer) updateBandwidth(bw uint64) {
+func (p *peer) updateCapacity(bw uint64) {
 	p.responseLock.Lock()
 	defer p.responseLock.Unlock()
 

--- a/les/peer.go
+++ b/les/peer.go
@@ -519,8 +519,9 @@ func (p *peer) Handshake(td *big.Int, head common.Hash, headNum uint64, genesis 
 		}
 		send = send.add("flowControl/BL", server.defParams.BufLimit)
 		send = send.add("flowControl/MRR", server.defParams.MinRecharge)
-		send = send.add("flowControl/MRC", server.fcCostList)
-		p.fcCosts = server.fcCostTable
+		costList := server.makeCostList()
+		send = send.add("flowControl/MRC", costList)
+		p.fcCosts = costList.decode()
 		p.fcParams = server.defParams
 	} else {
 		//on client node

--- a/les/peer_test.go
+++ b/les/peer_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/mclock"
 	"github.com/ethereum/go-ethereum/les/flowcontrol"
 	"github.com/ethereum/go-ethereum/p2p"
 	"github.com/ethereum/go-ethereum/p2p/enode"
@@ -36,7 +37,7 @@ func TestPeerHandshakeSetAnnounceTypeToAnnounceTypeSignedForTrustedPeer(t *testi
 		rw: &rwStub{
 			WriteHook: func(recvList keyValueList) {
 				//checking that ulc sends to peer allowedRequests=onlyAnnounceRequests and announceType = announceTypeSigned
-				recv := recvList.decode()
+				recv, _ := recvList.decode()
 				var reqType uint64
 
 				err := recv.get("announceType", &reqType)
@@ -81,7 +82,7 @@ func TestPeerHandshakeAnnounceTypeSignedForTrustedPeersPeerNotInTrusted(t *testi
 		rw: &rwStub{
 			WriteHook: func(recvList keyValueList) {
 				//checking that ulc sends to peer allowedRequests=noRequests and announceType != announceTypeSigned
-				recv := recvList.decode()
+				recv, _ := recvList.decode()
 				var reqType uint64
 
 				err := recv.get("announceType", &reqType)
@@ -239,17 +240,11 @@ func TestPeerHandshakeClientReturnErrorOnUselessPeer(t *testing.T) {
 
 func generateLesServer() *LesServer {
 	s := &LesServer{
-		defParams: &flowcontrol.ServerParams{
+		defParams: flowcontrol.ServerParams{
 			BufLimit:    uint64(300000000),
 			MinRecharge: uint64(50000),
 		},
-		fcManager: flowcontrol.NewClientManager(1, 2, 3),
-		fcCostStats: &requestCostStats{
-			stats: make(map[uint64]*linReg, len(reqList)),
-		},
-	}
-	for _, code := range reqList {
-		s.fcCostStats.stats[code] = &linReg{cnt: 100}
+		fcManager: flowcontrol.NewClientManager(nil, &mclock.System{}),
 	}
 	return s
 }

--- a/les/protocol.go
+++ b/les/protocol.go
@@ -14,7 +14,6 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
 
-// Package les implements the Light Ethereum Subprotocol.
 package les
 
 import (

--- a/les/protocol.go
+++ b/les/protocol.go
@@ -146,9 +146,9 @@ func (a *announceData) sign(privKey *ecdsa.PrivateKey) {
 }
 
 // checkSignature verifies if the block announcement has a valid signature by the given pubKey
-func (a *announceData) checkSignature(id enode.ID) error {
+func (a *announceData) checkSignature(id enode.ID, update keyValueMap) error {
 	var sig []byte
-	if err := a.Update.decode().get("sign", &sig); err != nil {
+	if err := update.get("sign", &sig); err != nil {
 		return err
 	}
 	rlp, _ := rlp.EncodeToBytes(announceBlock{a.Hash, a.Number, a.Td})

--- a/les/protocol.go
+++ b/les/protocol.go
@@ -81,6 +81,25 @@ const (
 	TxStatusMsg            = 0x15
 )
 
+type requestInfo struct {
+	name     string
+	maxCount uint64
+}
+
+var requests = map[uint64]requestInfo{
+	GetBlockHeadersMsg:     {"GetBlockHeaders", MaxHeaderFetch},
+	GetBlockBodiesMsg:      {"GetBlockBodies", MaxBodyFetch},
+	GetReceiptsMsg:         {"GetReceipts", MaxReceiptFetch},
+	GetProofsV1Msg:         {"GetProofsV1", MaxProofsFetch},
+	GetCodeMsg:             {"GetCode", MaxCodeFetch},
+	SendTxMsg:              {"SendTx", MaxTxSend},
+	GetHeaderProofsMsg:     {"GetHeaderProofs", MaxHelperTrieProofsFetch},
+	GetProofsV2Msg:         {"GetProofsV2", MaxProofsFetch},
+	GetHelperTrieProofsMsg: {"GetHelperTrieProofs", MaxHelperTrieProofsFetch},
+	SendTxV2Msg:            {"SendTxV2", MaxTxSend},
+	GetTxStatusMsg:         {"GetTxStatus", MaxTxStatus},
+}
+
 type errCode int
 
 const (

--- a/les/randselect.go
+++ b/les/randselect.go
@@ -14,7 +14,6 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
 
-// Package les implements the Light Ethereum Subprotocol.
 package les
 
 import (

--- a/les/retrieve.go
+++ b/les/retrieve.go
@@ -14,8 +14,6 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
 
-// Package light implements on-demand retrieval capable state and chain objects
-// for the Ethereum Light Client.
 package les
 
 import (

--- a/les/server.go
+++ b/les/server.go
@@ -43,7 +43,7 @@ type LesServer struct {
 
 	fcManager    *flowcontrol.ClientManager // nil if our node is client only
 	fcCostStats  *requestCostStats
-	defParams    *flowcontrol.ServerParams
+	defParams    flowcontrol.ServerParams
 	lesTopics    []discv5.Topic
 	privateKey   *ecdsa.PrivateKey
 	quitSync     chan struct{}
@@ -116,7 +116,7 @@ func NewLesServer(eth *eth.Ethereum, config *eth.Config) (*LesServer, error) {
 	srv.chtIndexer.Start(eth.BlockChain())
 	pm.server = srv
 
-	srv.defParams = &flowcontrol.ServerParams{
+	srv.defParams = flowcontrol.ServerParams{
 		BufLimit:    300000000,
 		MinRecharge: 50000,
 	}

--- a/les/server.go
+++ b/les/server.go
@@ -200,7 +200,7 @@ func (s *LesServer) Start(srvr *p2p.Server) {
 		log.Warn("Light peer count limited", "specified", s.maxPeers, "allowed", freePeers)
 	}
 
-	s.freeClientPool = newFreeClientPool(s.chainDb, s.freeClientCap, 10000, mclock.System{}, s.protocolManager.removePeer)
+	s.freeClientPool = newFreeClientPool(s.chainDb, s.freeClientCap, 10000, mclock.System{}, func(id string) { go s.protocolManager.removePeer(id) })
 	s.priorityClientPool = newPriorityClientPool(s.freeClientCap, s.protocolManager.peers, s.freeClientPool)
 
 	s.protocolManager.peers.notify(s.priorityClientPool)

--- a/les/server.go
+++ b/les/server.go
@@ -14,7 +14,6 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
 
-// Package les implements the Light Ethereum Subprotocol.
 package les
 
 import (
@@ -137,7 +136,7 @@ func (s *LesServer) APIs() []rpc.API {
 		{
 			Namespace: "les",
 			Version:   "1.0",
-			Service:   NewPrivateLesServerAPI(s),
+			Service:   NewPrivateLightServerAPI(s),
 			Public:    false,
 		},
 	}

--- a/les/server.go
+++ b/les/server.go
@@ -185,7 +185,7 @@ func (s *LesServer) Start(srvr *p2p.Server) {
 	s.maxPeers = s.config.LightPeers
 	totalRecharge := s.costTracker.totalRecharge()
 	if s.maxPeers > 0 {
-		s.freeClientCap = totalRecharge / uint64(s.maxPeers)
+		s.freeClientCap = minCapacity //totalRecharge / uint64(s.maxPeers)
 		if s.freeClientCap < minCapacity {
 			s.freeClientCap = minCapacity
 		}
@@ -198,7 +198,7 @@ func (s *LesServer) Start(srvr *p2p.Server) {
 	}
 	freePeers := int(totalRecharge / s.freeClientCap)
 	if freePeers < s.maxPeers {
-		log.Warn("Light peer count limited", "specified", s.maxPeers, "allowed", freePeers) //qqq
+		log.Warn("Light peer count limited", "specified", s.maxPeers, "allowed", freePeers)
 	}
 
 	s.freeClientPool = newFreeClientPool(s.chainDb, s.freeClientCap, 10000, mclock.System{}, s.protocolManager.removePeer)

--- a/les/serverpool.go
+++ b/les/serverpool.go
@@ -14,7 +14,6 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
 
-// Package les implements the Light Ethereum Subprotocol.
 package les
 
 import (

--- a/les/servingqueue.go
+++ b/les/servingqueue.go
@@ -14,7 +14,6 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
 
-// Package flowcontrol implements a client side flow control mechanism
 package les
 
 import (
@@ -93,8 +92,6 @@ func (sq *servingQueue) addTask(task *servingTask) {
 // Note: either blocking should be false or currentTask should be nil.
 func (sq *servingQueue) getNewTask(currentTask *servingTask, blocking bool) *servingTask {
 	sq.lock.Lock()
-	if sq.stopCount != 0 {
-	}
 	if sq.stopCount == 0 {
 		if sq.best != nil && (currentTask == nil || sq.best.priority <= currentTask.priority-sq.suspendBias) {
 			best := sq.best

--- a/les/servingqueue.go
+++ b/les/servingqueue.go
@@ -1,0 +1,191 @@
+// Copyright 2018 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+// Package flowcontrol implements a client side flow control mechanism
+package les
+
+import (
+	"sync"
+
+	"github.com/ethereum/go-ethereum/common/mclock"
+	"github.com/ethereum/go-ethereum/common/prque"
+)
+
+// servingQueue runs serving tasks in a limited number of threads and puts the
+// waiting tasks in a priority queue
+type servingQueue struct {
+	lock        sync.Mutex
+	threadCount int                 // number of currently running threads
+	stopCount   int                 // number of threads to be stopped after they finish their current task
+	queue       *prque.Prque        // priority queue for waiting or suspended tasks
+	best        *servingTask        // either best == nil (queue empty) or waitingForTask is empty
+	waiting     []chan *servingTask // threads waiting for a task
+	suspendBias int64               // priority bias against suspending an already running task
+}
+
+// servingTask represents a request serving task. Tasks can be implemented to
+// run in multiple steps, allowing the serving queue to suspend execution between
+// steps if higher priority tasks are entered. The creator of the task should
+// set the following fields:
+//
+// - priority: greater value means higher priority; values can wrap around the int64 range
+// - run: execute a single step; return true if finished
+// - after: executed after run finishes or returns an error, receives the total serving time
+type servingTask struct {
+	servingTime uint64
+	done        bool
+	err         error
+	priority    int64
+	run         func() (finished bool, err error)
+	send        func(servingTime uint64)
+	fail        func(err error)
+}
+
+// newServingQueue returns a new servingQueue
+func newServingQueue(_suspendBias int64) *servingQueue {
+	return &servingQueue{
+		queue:       prque.New(nil),
+		suspendBias: _suspendBias,
+	}
+}
+
+// addTask adds a new task, either starting it immediately or queueing it
+func (sq *servingQueue) addTask(task *servingTask) {
+	sq.lock.Lock()
+	defer sq.lock.Unlock()
+
+	if l := len(sq.waiting); l != 0 {
+		l--
+		sq.waiting[l] <- task
+		sq.waiting = sq.waiting[:l]
+		return
+	}
+
+	if sq.best == nil {
+		sq.best = task
+		return
+	}
+	if task.priority < sq.best.priority {
+		sq.queue.Push(sq.best, sq.best.priority)
+		sq.best = task
+		return
+	}
+	sq.queue.Push(task, task.priority)
+}
+
+// getNewTask selects a new task to be processed. If blocking == true then it waits
+// until a runnable task arrives or returns nil if the thread should be stopped.
+// if currentTask != nil then it returns immediately and only returns a new task
+// if the current one should be suspended.
+// Note: either blocking should be false or currentTask should be nil.
+func (sq *servingQueue) getNewTask(currentTask *servingTask, blocking bool) *servingTask {
+	sq.lock.Lock()
+	if sq.stopCount != 0 {
+	}
+	if sq.stopCount == 0 {
+		if sq.best != nil && (currentTask == nil || sq.best.priority <= currentTask.priority-sq.suspendBias) {
+			best := sq.best
+			if sq.queue.Size() == 0 {
+				sq.best = nil
+			} else {
+				sq.best, _ = sq.queue.PopItem().(*servingTask)
+			}
+			sq.lock.Unlock()
+			return best
+		}
+		if blocking {
+			ch := make(chan *servingTask)
+			sq.waiting = append(sq.waiting, ch)
+			sq.lock.Unlock()
+			return <-ch
+		}
+	} else {
+		sq.stopCount--
+		sq.threadCount--
+	}
+	sq.lock.Unlock()
+	return nil
+}
+
+// setThreads sets the processing thread count, suspending tasks as soon as
+// possible if necessary.
+func (sq *servingQueue) setThreads(threadCount int) {
+	sq.lock.Lock()
+	defer sq.lock.Unlock()
+
+	diff := threadCount - sq.threadCount + sq.stopCount
+	if diff > 0 {
+		// start more threads
+		if sq.stopCount >= diff {
+			sq.stopCount -= diff
+		} else {
+			diff -= sq.stopCount
+			sq.stopCount = 0
+			sq.threadCount += diff
+			for ; diff > 0; diff-- {
+				go sq.servingThread()
+			}
+		}
+	}
+	if diff < 0 {
+		// stop some threads
+		lw := len(sq.waiting)
+		sq.stopCount -= diff
+		for diff < 0 && lw > 0 {
+			diff++
+			lw--
+			sq.waiting[lw] <- nil
+			sq.stopCount--
+			sq.threadCount--
+		}
+		sq.waiting = sq.waiting[:lw]
+	}
+}
+
+// stop stops task processing as soon as possible
+func (sq *servingQueue) stop() {
+	sq.setThreads(0)
+}
+
+// servingThread implements a single serving thread
+func (sq *servingQueue) servingThread() {
+	for {
+		task := sq.getNewTask(nil, true)
+		if task == nil {
+			return
+		}
+		task.servingTime -= uint64(mclock.Now())
+		for {
+			task.done, task.err = task.run()
+			if task.done || task.err != nil {
+				task.servingTime += uint64(mclock.Now())
+				if task.err == nil {
+					task.send(task.servingTime)
+				} else {
+					task.fail(task.err)
+				}
+				break
+			}
+			if newTask := sq.getNewTask(task, false); newTask != nil {
+				now := uint64(mclock.Now())
+				task.servingTime += now
+				sq.addTask(task)
+				task = newTask
+				task.servingTime -= now
+			}
+		}
+	}
+}

--- a/les/txrelay.go
+++ b/les/txrelay.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/rlp"
 )
 
 type ltrInfo struct {
@@ -113,21 +114,22 @@ func (self *LesTxRelay) send(txs types.Transactions, count int) {
 	for p, list := range sendTo {
 		pp := p
 		ll := list
+		enc, _ := rlp.EncodeToBytes(ll)
 
 		reqID := genReqID()
 		rq := &distReq{
 			getCost: func(dp distPeer) uint64 {
 				peer := dp.(*peer)
-				return peer.GetRequestCost(SendTxMsg, len(ll))
+				return peer.GetTxRelayCost(len(ll), len(enc))
 			},
 			canSend: func(dp distPeer) bool {
 				return !dp.(*peer).isOnlyAnnounce && dp.(*peer) == pp
 			},
 			request: func(dp distPeer) func() {
 				peer := dp.(*peer)
-				cost := peer.GetRequestCost(SendTxMsg, len(ll))
+				cost := peer.GetTxRelayCost(len(ll), len(enc))
 				peer.fcServer.QueueRequest(reqID, cost)
-				return func() { peer.SendTxs(reqID, cost, ll) }
+				return func() { peer.SendTxs(reqID, cost, enc) }
 			},
 		}
 		self.reqDist.queue(rq)

--- a/les/txrelay.go
+++ b/les/txrelay.go
@@ -128,7 +128,7 @@ func (self *LesTxRelay) send(txs types.Transactions, count int) {
 			request: func(dp distPeer) func() {
 				peer := dp.(*peer)
 				cost := peer.GetTxRelayCost(len(ll), len(enc))
-				peer.fcServer.QueueRequest(reqID, cost)
+				peer.fcServer.QueuedRequest(reqID, cost)
 				return func() { peer.SendTxs(reqID, cost, enc) }
 			},
 		}

--- a/les/ulc_test.go
+++ b/les/ulc_test.go
@@ -11,6 +11,7 @@ import (
 	"crypto/ecdsa"
 	"math/big"
 
+	"github.com/ethereum/go-ethereum/common/mclock"
 	"github.com/ethereum/go-ethereum/core"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/eth"
@@ -217,7 +218,7 @@ func newFullPeerPair(t *testing.T, index int, numberOfblocks int, chainGen func(
 // newLightPeer creates node with light sync mode
 func newLightPeer(t *testing.T, ulcConfig *eth.ULCConfig) pairPeer {
 	peers := newPeerSet()
-	dist := newRequestDistributor(peers, make(chan struct{}))
+	dist := newRequestDistributor(peers, make(chan struct{}), &mclock.System{})
 	rm := newRetrieveManager(peers, dist, nil)
 	ldb := ethdb.NewMemDatabase()
 

--- a/light/lightchain.go
+++ b/light/lightchain.go
@@ -14,6 +14,8 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
 
+// Package light implements on-demand retrieval capable state and chain objects
+// for the Ethereum Light Client.
 package light
 
 import (

--- a/light/odr.go
+++ b/light/odr.go
@@ -14,8 +14,6 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
 
-// Package light implements on-demand retrieval capable state and chain objects
-// for the Ethereum Light Client.
 package light
 
 import (

--- a/node/config.go
+++ b/node/config.go
@@ -337,13 +337,7 @@ func (c *Config) instanceDir() string {
 	if c.DataDir == "" {
 		return ""
 	}
-	name := c.name()
-	if name == "p2p-node" {
-		// use original data dir with network simulator in order to allow using
-		// an existing database for a simulated node instead of a temporary one
-		name = "geth"
-	}
-	return filepath.Join(c.DataDir, name)
+	return filepath.Join(c.DataDir, c.name())
 }
 
 // NodeKey retrieves the currently configured private key of the node, checking

--- a/node/config.go
+++ b/node/config.go
@@ -337,7 +337,13 @@ func (c *Config) instanceDir() string {
 	if c.DataDir == "" {
 		return ""
 	}
-	return filepath.Join(c.DataDir, c.name())
+	name := c.name()
+	if name == "p2p-node" {
+		// use original data dir with network simulator in order to allow using
+		// an existing database for a simulated node instead of a temporary one
+		name = "geth"
+	}
+	return filepath.Join(c.DataDir, name)
 }
 
 // NodeKey retrieves the currently configured private key of the node, checking

--- a/p2p/simulations/adapters/exec.go
+++ b/p2p/simulations/adapters/exec.go
@@ -97,7 +97,11 @@ func (e *ExecAdapter) NewNode(config *NodeConfig) (Node, error) {
 		Stack: node.DefaultConfig,
 		Node:  config,
 	}
-	conf.Stack.DataDir = filepath.Join(dir, "data")
+	if config.DataDir != "" {
+		conf.Stack.DataDir = config.DataDir
+	} else {
+		conf.Stack.DataDir = filepath.Join(dir, "data")
+	}
 	conf.Stack.WSHost = "127.0.0.1"
 	conf.Stack.WSPort = 0
 	conf.Stack.WSOrigins = []string{"*"}
@@ -177,7 +181,7 @@ func (n *ExecNode) Start(snapshots map[string][]byte) (err error) {
 	}
 
 	// start the one-shot server that waits for startup information
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 40*time.Second)
 	defer cancel()
 	statusURL, statusC := n.waitForStartupJSON(ctx)
 

--- a/p2p/simulations/adapters/exec.go
+++ b/p2p/simulations/adapters/exec.go
@@ -181,7 +181,7 @@ func (n *ExecNode) Start(snapshots map[string][]byte) (err error) {
 	}
 
 	// start the one-shot server that waits for startup information
-	ctx, cancel := context.WithTimeout(context.Background(), 40*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 	statusURL, statusC := n.waitForStartupJSON(ctx)
 

--- a/p2p/simulations/adapters/types.go
+++ b/p2p/simulations/adapters/types.go
@@ -90,6 +90,9 @@ type NodeConfig struct {
 	// Name is a human friendly name for the node like "node01"
 	Name string
 
+	// Use an existing database instead of a temporary one if non-empty
+	DataDir string
+
 	// Services are the names of the services which should be run when
 	// starting the node (for SimNodes it should be the names of services
 	// contained in SimAdapter.services, for other nodes it should be


### PR DESCRIPTION
This PR
- replaces the existing request cost estimation method with a benchmark which gives much more consistent results
  - this also means the server can now estimate its own serving capacity properly and limit the number of accepted clients if necessary. Until now the allowed number of light peers was just a guess which probably contributed a lot to the fluctuating quality of available service.
- reimplements flowcontrol.ClientManager in a cleaner and more efficient way, with added capabilities:
  - better bandwidth control which allows using the flow control parameters for client prioritization
  - allowing target utilization over 100 percent at full load (parallel request processing allows this but the old client manager logic could not handle it)
  - reducing total serving bandwidth during block processing
- implements parallel LES request serving even for a single peer (a requirement for the new client manager logic)
- implements a simple private API for LES servers allowing server operators to assign priority bandwidth to certain clients and change prioritized status even while the client is connected
- adds a unit test for the new client manager
- adds an end-to-end test using the network simulator that tests bandwidth control functions through the new API

Note: there is a plan to implement in-protocol payment using the SWAP payment channel. This PR provides most of the functionality needed to implement such a feature. While the actual payment protocol is being developed the API can already be used and tested with other payment schemes (like a simple monthly subscription using on-chain payments).

Note 2: this PR is based on https://github.com/ethereum/go-ethereum/pull/17948

See also: https://gist.github.com/zsfelfoldi/93792da3c56dffdb594ff91aebd74262