### PR TITLE
cmd/puppeth: enforce lowercase network names

### DIFF
--- a/cmd/puppeth/puppeth.go
+++ b/cmd/puppeth/puppeth.go
@@ -49,8 +49,8 @@ func main() {
 		rand.Seed(time.Now().UnixNano())
 
 		network := c.String("network")
-		if strings.Contains(network, " ") || strings.Contains(network, "-") {
-			log.Crit("No spaces or hyphens allowed in network name")
+		if strings.Contains(network, " ") || strings.Contains(network, "-") || strings.ToLower(network) != network {
+			log.Crit("No spaces, hyphens or capital letters allowed in network name")
 		}
 		// Start the wizard and relinquish control
 		makeWizard(c.String("network")).run()

--- a/cmd/puppeth/wizard_intro.go
+++ b/cmd/puppeth/wizard_intro.go
@@ -61,14 +61,14 @@ func (w *wizard) run() {
 	// Make sure we have a good network name to work with	fmt.Println()
 	// Docker accepts hyphens in image names, but doesn't like it for container names
 	if w.network == "" {
-		fmt.Println("Please specify a network name to administer (no spaces or hyphens, please)")
+		fmt.Println("Please specify a network name to administer (no spaces, hyphens or capital letters please)")
 		for {
 			w.network = w.readString()
-			if !strings.Contains(w.network, " ") && !strings.Contains(w.network, "-") {
+			if !strings.Contains(w.network, " ") && !strings.Contains(w.network, "-") && strings.ToLower(w.network) == w.network {
 				fmt.Printf("\nSweet, you can set this via --network=%s next time!\n\n", w.network)
 				break
 			}
-			log.Error("I also like to live dangerously, still no spaces or hyphens")
+			log.Error("I also like to live dangerously, still no spaces, hyphens or capital letters")
 		}
 	}
 	log.Info("Administering Ethereum network", "name", w.network)


### PR DESCRIPTION
Fixes https://github.com/ethereum/go-ethereum/issues/17976.

Puppeth explicitly checked that users didn't supply spaces or hyphens in the network names, but it did not do so for uppercase letters. Apparently however docker (or docker compose, not sure) rejects image names with capital letters, so we need to forbid those too.