### PR TITLE
swarm/network: Correct ambiguity in compared addresses

### DIFF
--- a/swarm/network/networkid_test.go
+++ b/swarm/network/networkid_test.go
@@ -95,8 +95,7 @@ func TestNetworkID(t *testing.T) {
 			kademlias[node].EachAddr(nil, 0, func(addr *BzzAddr, _ int, _ bool) bool {
 				found := false
 				for _, nd := range netIDGroup {
-					p := nd.Bytes()
-					if bytes.Equal(p, addr.Address()) {
+					if bytes.Equal(kademlias[nd].BaseAddr(), addr.Address()) {
 						found = true
 					}
 				}


### PR DESCRIPTION
Previously the changed iterator compared the bytes of `enode.ID` to bytes of `BzzAddr.OAddr`. While this coincidentally was correct since the same value is used in both, it's not semantically correct and may cause confusion in evaluating the test later.