### PR TITLE
params: set mainnet and Rinkeby Constantinople fork blocks

### DIFF
--- a/params/config.go
+++ b/params/config.go
@@ -42,7 +42,7 @@ var (
 		EIP155Block:         big.NewInt(2675000),
 		EIP158Block:         big.NewInt(2675000),
 		ByzantiumBlock:      big.NewInt(4370000),
-		ConstantinopleBlock: nil,
+		ConstantinopleBlock: big.NewInt(7080000),
 		Ethash:              new(EthashConfig),
 	}
 
@@ -90,7 +90,7 @@ var (
 		EIP155Block:         big.NewInt(3),
 		EIP158Block:         big.NewInt(3),
 		ByzantiumBlock:      big.NewInt(1035301),
-		ConstantinopleBlock: nil,
+		ConstantinopleBlock: big.NewInt(3660663),
 		Clique: &CliqueConfig{
 			Period: 15,
 			Epoch:  30000,


### PR DESCRIPTION
This PR enables the Constantinople hard fork on mainnet at block 7080000 per https://github.com/ethereum/EIPs/pull/1642 .

It also enables the fork on the Rinkeby testnet at block 3660663, scheduled a week before the mainnet hard fork (i.e. around the 9th of January).