### PR TITLE
light: fix duplicated argument in bytes.Equal call

### DIFF
--- a/light/trie_test.go
+++ b/light/trie_test.go
@@ -64,7 +64,7 @@ func diffTries(t1, t2 state.Trie) error {
 			spew.Dump(i2)
 			return fmt.Errorf("tries have different keys %x, %x", i1.Key, i2.Key)
 		}
-		if !bytes.Equal(i2.Value, i2.Value) {
+		if !bytes.Equal(i1.Value, i2.Value) {
 			return fmt.Errorf("tries differ at key %x", i1.Key)
 		}
 	}


### PR DESCRIPTION
Most probably a copy/paste kind of error.
Found with gocritic `dupArg` checker.