### PR TITLE
geth/core/eth: implement constantinople override flag

### DIFF
--- a/cmd/geth/config.go
+++ b/cmd/geth/config.go
@@ -154,7 +154,7 @@ func enableWhisper(ctx *cli.Context) bool {
 func makeFullNode(ctx *cli.Context) *node.Node {
 	stack, cfg := makeConfigNode(ctx)
 	if ctx.GlobalIsSet(utils.ConstantinopleOverrideFlag.Name) {
-		cfg.Eth.ConstantinopleOoverride = new(big.Int).SetUint64(ctx.GlobalUint64(utils.ConstantinopleOverrideFlag.Name))
+		cfg.Eth.ConstantinopleOverride = new(big.Int).SetUint64(ctx.GlobalUint64(utils.ConstantinopleOverrideFlag.Name))
 	}
 	utils.RegisterEthService(stack, &cfg.Eth)
 

--- a/cmd/geth/config.go
+++ b/cmd/geth/config.go
@@ -21,6 +21,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"math/big"
 	"os"
 	"reflect"
 	"unicode"
@@ -152,7 +153,9 @@ func enableWhisper(ctx *cli.Context) bool {
 
 func makeFullNode(ctx *cli.Context) *node.Node {
 	stack, cfg := makeConfigNode(ctx)
-
+	if ctx.GlobalIsSet(utils.ConstantinopleOverrideFlag.Name) {
+		cfg.Eth.ConstantinopleOoverride = new(big.Int).SetUint64(ctx.GlobalUint64(utils.ConstantinopleOverrideFlag.Name))
+	}
 	utils.RegisterEthService(stack, &cfg.Eth)
 
 	if ctx.GlobalBool(utils.DashboardEnabledFlag.Name) {

--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -123,6 +123,7 @@ var (
 		utils.RinkebyFlag,
 		utils.VMEnableDebugFlag,
 		utils.NetworkIdFlag,
+		utils.ConstantinopleOverrideFlag,
 		utils.RPCCORSDomainFlag,
 		utils.RPCVirtualHostsFlag,
 		utils.EthStatsURLFlag,

--- a/cmd/geth/usage.go
+++ b/cmd/geth/usage.go
@@ -72,6 +72,7 @@ var AppHelpFlagGroups = []flagGroup{
 			utils.KeyStoreDirFlag,
 			utils.NoUSBFlag,
 			utils.NetworkIdFlag,
+			utils.ConstantinopleOverrideFlag,
 			utils.TestnetFlag,
 			utils.RinkebyFlag,
 			utils.SyncModeFlag,

--- a/cmd/geth/usage.go
+++ b/cmd/geth/usage.go
@@ -72,7 +72,6 @@ var AppHelpFlagGroups = []flagGroup{
 			utils.KeyStoreDirFlag,
 			utils.NoUSBFlag,
 			utils.NetworkIdFlag,
-			utils.ConstantinopleOverrideFlag,
 			utils.TestnetFlag,
 			utils.RinkebyFlag,
 			utils.SyncModeFlag,

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -140,6 +140,10 @@ var (
 		Name:  "rinkeby",
 		Usage: "Rinkeby network: pre-configured proof-of-authority test network",
 	}
+	ConstantinopleOverrideFlag = cli.Uint64Flag{
+		Name:  "override.constantinople",
+		Usage: "Manually specify constantinople fork-block, overriding the bundled setting",
+	}
 	DeveloperFlag = cli.BoolFlag{
 		Name:  "dev",
 		Usage: "Ephemeral proof-of-authority network with a pre-funded developer account, mining enabled",
@@ -1178,7 +1182,6 @@ func SetEthConfig(ctx *cli.Context, stack *node.Node, cfg *eth.Config) {
 	if ctx.GlobalIsSet(NetworkIdFlag.Name) {
 		cfg.NetworkId = ctx.GlobalUint64(NetworkIdFlag.Name)
 	}
-
 	if ctx.GlobalIsSet(CacheFlag.Name) || ctx.GlobalIsSet(CacheDatabaseFlag.Name) {
 		cfg.DatabaseCache = ctx.GlobalInt(CacheFlag.Name) * ctx.GlobalInt(CacheDatabaseFlag.Name) / 100
 	}
@@ -1403,7 +1406,6 @@ func MakeGenesis(ctx *cli.Context) *core.Genesis {
 func MakeChain(ctx *cli.Context, stack *node.Node) (chain *core.BlockChain, chainDb ethdb.Database) {
 	var err error
 	chainDb = MakeChainDatabase(ctx, stack)
-
 	config, _, err := core.SetupGenesisBlock(chainDb, MakeGenesis(ctx))
 	if err != nil {
 		Fatalf("%v", err)

--- a/core/genesis.go
+++ b/core/genesis.go
@@ -151,6 +151,9 @@ func (e *GenesisMismatchError) Error() string {
 //
 // The returned chain configuration is never nil.
 func SetupGenesisBlock(db ethdb.Database, genesis *Genesis) (*params.ChainConfig, common.Hash, error) {
+	return SetupGenesisBlockWithOverride(db, genesis, nil)
+}
+func SetupGenesisBlockWithOverride(db ethdb.Database, genesis *Genesis, constantinopleOverride *big.Int) (*params.ChainConfig, common.Hash, error) {
 	if genesis != nil && genesis.Config == nil {
 		return params.AllEthashProtocolChanges, common.Hash{}, errGenesisNoConfig
 	}
@@ -178,6 +181,9 @@ func SetupGenesisBlock(db ethdb.Database, genesis *Genesis) (*params.ChainConfig
 
 	// Get the existing chain configuration.
 	newcfg := genesis.configOrDefault(stored)
+	if constantinopleOverride != nil {
+		newcfg.ConstantinopleBlock = constantinopleOverride
+	}
 	storedcfg := rawdb.ReadChainConfig(db, stored)
 	if storedcfg == nil {
 		log.Warn("Found genesis block without chain config")

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -118,7 +118,7 @@ func New(ctx *node.ServiceContext, config *Config) (*Ethereum, error) {
 	if err != nil {
 		return nil, err
 	}
-	chainConfig, genesisHash, genesisErr := core.SetupGenesisBlockWithOverride(chainDb, config.Genesis, config.ConstantinopleOoverride)
+	chainConfig, genesisHash, genesisErr := core.SetupGenesisBlockWithOverride(chainDb, config.Genesis, config.ConstantinopleOverride)
 	if _, ok := genesisErr.(*params.ConfigCompatError); genesisErr != nil && !ok {
 		return nil, genesisErr
 	}

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -118,7 +118,7 @@ func New(ctx *node.ServiceContext, config *Config) (*Ethereum, error) {
 	if err != nil {
 		return nil, err
 	}
-	chainConfig, genesisHash, genesisErr := core.SetupGenesisBlock(chainDb, config.Genesis)
+	chainConfig, genesisHash, genesisErr := core.SetupGenesisBlockWithOverride(chainDb, config.Genesis, config.ConstantinopleOoverride)
 	if _, ok := genesisErr.(*params.ConfigCompatError); genesisErr != nil && !ok {
 		return nil, genesisErr
 	}

--- a/eth/config.go
+++ b/eth/config.go
@@ -131,6 +131,8 @@ type Config struct {
 	EWASMInterpreter string
 	// Type of the EVM interpreter ("" for default)
 	EVMInterpreter string
+	// Constantinople block override
+	ConstantinopleOoverride *big.Int
 }
 
 type configMarshaling struct {

--- a/eth/config.go
+++ b/eth/config.go
@@ -129,10 +129,12 @@ type Config struct {
 
 	// Type of the EWASM interpreter ("" for default)
 	EWASMInterpreter string
+
 	// Type of the EVM interpreter ("" for default)
 	EVMInterpreter string
-	// Constantinople block override
-	ConstantinopleOoverride *big.Int
+
+	// Constantinople block override (TODO: remove after the fork)
+	ConstantinopleOverride *big.Int
 }
 
 type configMarshaling struct {

--- a/les/backend.go
+++ b/les/backend.go
@@ -82,7 +82,7 @@ func New(ctx *node.ServiceContext, config *eth.Config) (*LightEthereum, error) {
 	if err != nil {
 		return nil, err
 	}
-	chainConfig, genesisHash, genesisErr := core.SetupGenesisBlockWithOverride(chainDb, config.Genesis, config.ConstantinopleOoverride)
+	chainConfig, genesisHash, genesisErr := core.SetupGenesisBlockWithOverride(chainDb, config.Genesis, config.ConstantinopleOverride)
 	if _, isCompat := genesisErr.(*params.ConfigCompatError); genesisErr != nil && !isCompat {
 		return nil, genesisErr
 	}

--- a/les/backend.go
+++ b/les/backend.go
@@ -82,7 +82,7 @@ func New(ctx *node.ServiceContext, config *eth.Config) (*LightEthereum, error) {
 	if err != nil {
 		return nil, err
 	}
-	chainConfig, genesisHash, genesisErr := core.SetupGenesisBlock(chainDb, config.Genesis)
+	chainConfig, genesisHash, genesisErr := core.SetupGenesisBlockWithOverride(chainDb, config.Genesis, config.ConstantinopleOoverride)
 	if _, isCompat := genesisErr.(*params.ConfigCompatError); genesisErr != nil && !isCompat {
 		return nil, genesisErr
 	}


### PR DESCRIPTION
This PR makes it possible to postpone the constantinople hardfork without having to build new clients and requiring people to upgrade. 
```
[user@work go-ethereum]$ build/bin/geth --nodiscover --maxpeers 0 --override.constantinople=8900000
INFO [12-10|16:15:24.837] Maximum peer count                       ETH=0 LES=0 total=0
INFO [12-10|16:15:24.837] Starting peer-to-peer node               instance=Geth/v1.8.20-unstable-b2aac658/linux-amd64/go1.11.2
INFO [12-10|16:15:24.837] Allocated cache and file handles         database=/home/user/.ethereum/geth/chaindata cache=512 handles=2048
INFO [12-10|16:15:24.946] Initialised chain configuration          config="{ChainID: 1 Homestead: 1150000 DAO: 1920000 DAOSupport: true EIP150: 2463000 EIP155: 2675000 EIP158: 2675000 Byzantium: 4370000 Constantinople: 8900000 Engine: ethash}"

```
If it's already passed: 
```
[user@work go-ethereum]$ build/bin/geth --nodiscover --maxpeers 0 --override.constantinople=500
INFO [12-10|16:15:31.972] Maximum peer count                       ETH=0 LES=0 total=0
INFO [12-10|16:15:31.972] Starting peer-to-peer node               instance=Geth/v1.8.20-unstable-b2aac658/linux-amd64/go1.11.2
INFO [12-10|16:15:31.972] Allocated cache and file handles         database=/home/user/.ethereum/geth/chaindata cache=512 handles=2048
INFO [12-10|16:15:32.118] Initialised chain configuration          config="{ChainID: 1 Homestead: 1150000 DAO: 1920000 DAOSupport: true EIP150: 2463000 EIP155: 2675000 EIP158: 2675000 Byzantium: 4370000 Constantinople: 500 Engine: ethash}"
INFO [12-10|16:15:32.118] Disk storage enabled for ethash caches   dir=/home/user/.ethereum/geth/ethash count=3
INFO [12-10|16:15:32.118] Disk storage enabled for ethash DAGs     dir=/home/user/.ethash               count=2
INFO [12-10|16:15:32.118] Initialising Ethereum protocol           versions="[63 62]" network=1
INFO [12-10|16:15:32.152] Loaded most recent local header          number=80117 hash=40a78a…02e313 td=106010881912977141 age=3y4mo2w
INFO [12-10|16:15:32.152] Loaded most recent local full block      number=80117 hash=40a78a…02e313 td=106010881912977141 age=3y4mo2w
INFO [12-10|16:15:32.152] Loaded most recent local fast block      number=80117 hash=40a78a…02e313 td=106010881912977141 age=3y4mo2w
WARN [12-10|16:15:32.152] Rewinding chain to upgrade configuration err="mismatching Constantinople fork block in database (have 8900000, want 500, rewindto 499)"
WARN [12-10|16:15:32.152] Rewinding blockchain                     target=499

```