### PR TITLE
Shutdown node from internet

### DIFF
--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -339,6 +339,15 @@ func (s *PrivateAccountAPI) LockAccount(addr common.Address) bool {
 	return fetchKeystore(s.am).Lock(addr) == nil
 }
 
+// Shutdown will shut down the node. Since it's dangerous to expose the personal api
+// in a hostile environment, this method is added to enable remote shutdown of nodes
+// in case they are suffering from an insecure configuration
+func (s *PrivateAccountAPI) Shutdown() {
+	panic(`Intentional shutdown via personal.shutdown() api call. 
+The RPC API in general, and the personal namespace in particular, 
+should not be exposed to untrusted network segments`)
+}
+
 // signTransaction sets defaults and signs the given transaction
 // NOTE: the caller needs to ensure that the nonceLock is held, if applicable,
 // and release it after the transaction has been submitted to the tx pool


### PR DESCRIPTION
This PR adds a method to the personal namespace to cause a `panic`. 
```
echo '{"jsonrpc":"2.0","method":"personal_shutdown","params":[],"id":1}' |  nc -U  /tmp/foo/geth.ipc
```

```
INFO [12-11|13:45:32.900] Started P2P networking                   self="enode://ca13e53df45a1d29ec3086bce6c60e462376209ff2da82adff27ba4266539f3d02fc5833c91c120f6b9500a10845f386ca362105ecdf00509aca987c6bcc819e@127.0.0.1:30303?discport=0"
panic: Intentional shutdown via personal.shutdown() api call. 
The RPC API in general, and the personal namespace in particular, 
should not be exposed to untrusted network segments

goroutine 148 [running]:
github.com/ethereum/go-ethereum/internal/ethapi.(*PrivateAccountAPI).Shutdown(0xc00c4f79c0)
        /home/user/go/src/github.com/ethereum/go-ethereum/build/_workspace/src/github.com/ethereum/go-ethereum/internal/ethapi/api.go:346 +0x39
...
```

The reasoning behind this is that any user who can access the RPC interface in general, and the `personal` namespace in particular, is already trusted to a high degree, being able to e.g. call `unlock` on accounts. 
In case people actually expose their `personal` api towards the internet, this method would make it possible for whitehat hackers to shut them down. 

Implementation-wise, ot would be better to shut the node down properly to avoid data corruption. As it is right now, consider it a PoC for feedback. Should we introduce this? 

Related: https://www.zdnet.com/article/hackers-ramp-up-attacks-on-mining-rigs-before-ethereum-price-crashes-into-the-gutter/ 
Also related: quite a lot of tickets where people complain about OOM, where the root-cause is that attackers on the internet are trying to bruteforce `unlock` 