### PR TITLE
swarm/storage: simplify ChunkValidator interface

### DIFF
--- a/swarm/storage/feed/handler.go
+++ b/swarm/storage/feed/handler.go
@@ -82,9 +82,8 @@ func (h *Handler) SetStore(store *storage.NetStore) {
 // Validate is a chunk validation method
 // If it looks like a feed update, the chunk address is checked against the userAddr of the update's signature
 // It implements the storage.ChunkValidator interface
-func (h *Handler) Validate(chunkAddr storage.Address, data []byte) bool {
-	dataLength := len(data)
-	if dataLength < minimumSignedUpdateLength {
+func (h *Handler) Validate(chunk storage.Chunk) bool {
+	if len(chunk.Data()) < minimumSignedUpdateLength {
 		return false
 	}
 
@@ -94,8 +93,8 @@ func (h *Handler) Validate(chunkAddr storage.Address, data []byte) bool {
 
 	// First, deserialize the chunk
 	var r Request
-	if err := r.fromChunk(chunkAddr, data); err != nil {
-		log.Debug("Invalid feed update chunk", "addr", chunkAddr.Hex(), "err", err.Error())
+	if err := r.fromChunk(chunk); err != nil {
+		log.Debug("Invalid feed update chunk", "addr", chunk.Address(), "err", err)
 		return false
 	}
 
@@ -198,7 +197,7 @@ func (h *Handler) Lookup(ctx context.Context, query *Query) (*cacheEntry, error)
 		}
 
 		var request Request
-		if err := request.fromChunk(chunk.Address(), chunk.Data()); err != nil {
+		if err := request.fromChunk(chunk); err != nil {
 			return nil, nil
 		}
 		if request.Time <= timeLimit {

--- a/swarm/storage/feed/handler_test.go
+++ b/swarm/storage/feed/handler_test.go
@@ -366,7 +366,7 @@ func TestValidator(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !rh.Validate(chunk.Address(), chunk.Data()) {
+	if !rh.Validate(chunk) {
 		t.Fatal("Chunk validator fail on update chunk")
 	}
 
@@ -375,7 +375,7 @@ func TestValidator(t *testing.T) {
 	address[0] = 11
 	address[15] = 99
 
-	if rh.Validate(address, chunk.Data()) {
+	if rh.Validate(storage.NewChunk(address, chunk.Data())) {
 		t.Fatal("Expected Validate to fail with false chunk address")
 	}
 }

--- a/swarm/storage/feed/request.go
+++ b/swarm/storage/feed/request.go
@@ -171,8 +171,10 @@ func (r *Request) toChunk() (storage.Chunk, error) {
 }
 
 // fromChunk populates this structure from chunk data. It does not verify the signature is valid.
-func (r *Request) fromChunk(updateAddr storage.Address, chunkdata []byte) error {
+func (r *Request) fromChunk(chunk storage.Chunk) error {
 	// for update chunk layout see Request definition
+
+	chunkdata := chunk.Data()
 
 	//deserialize the feed update portion
 	if err := r.Update.binaryGet(chunkdata[:len(chunkdata)-signatureLength]); err != nil {
@@ -189,7 +191,7 @@ func (r *Request) fromChunk(updateAddr storage.Address, chunkdata []byte) error 
 	}
 
 	r.Signature = signature
-	r.idAddr = updateAddr
+	r.idAddr = chunk.Address()
 	r.binaryData = chunkdata
 
 	return nil

--- a/swarm/storage/feed/request_test.go
+++ b/swarm/storage/feed/request_test.go
@@ -197,7 +197,7 @@ func TestUpdateChunkSerializationErrorChecking(t *testing.T) {
 
 	// Test that parseUpdate fails if the chunk is too small
 	var r Request
-	if err := r.fromChunk(storage.ZeroAddr, make([]byte, minimumUpdateDataLength-1+signatureLength)); err == nil {
+	if err := r.fromChunk(storage.NewChunk(storage.ZeroAddr, make([]byte, minimumUpdateDataLength-1+signatureLength))); err == nil {
 		t.Fatalf("Expected request.fromChunk to fail when chunkData contains less than %d bytes", minimumUpdateDataLength)
 	}
 
@@ -226,7 +226,7 @@ func TestUpdateChunkSerializationErrorChecking(t *testing.T) {
 	compareByteSliceToExpectedHex(t, "chunk", chunk.Data(), "0x0000000000000000776f726c64206e657773207265706f72742c20657665727920686f7572000000876a8936a7cd0b79ef0735ad0896c1afe278781ce803000000000019416c206269656e206861636572206a616dc3a173206c652066616c7461207072656d696f5a0ffe0bc27f207cd5b00944c8b9cee93e08b89b5ada777f123ac535189333f174a6a4ca2f43a92c4a477a49d774813c36ce8288552c58e6205b0ac35d0507eb00")
 
 	var recovered Request
-	recovered.fromChunk(chunk.Address(), chunk.Data())
+	recovered.fromChunk(chunk)
 	if !reflect.DeepEqual(recovered, r) {
 		t.Fatal("Expected recovered feed update request to equal the original one")
 	}
@@ -282,7 +282,7 @@ func TestReverse(t *testing.T) {
 
 	// check that we can recover the owner account from the update chunk's signature
 	var checkUpdate Request
-	if err := checkUpdate.fromChunk(chunk.Address(), chunk.Data()); err != nil {
+	if err := checkUpdate.fromChunk(chunk); err != nil {
 		t.Fatal(err)
 	}
 	checkdigest, err := checkUpdate.GetDigest()

--- a/swarm/storage/localstore.go
+++ b/swarm/storage/localstore.go
@@ -92,7 +92,7 @@ func (ls *LocalStore) isValid(chunk Chunk) bool {
 	// ls.Validators contains a list of one validator per chunk type.
 	// if one validator succeeds, then the chunk is valid
 	for _, v := range ls.Validators {
-		if valid = v.Validate(chunk.Address(), chunk.Data()); valid {
+		if valid = v.Validate(chunk); valid {
 			break
 		}
 	}

--- a/swarm/storage/localstore_test.go
+++ b/swarm/storage/localstore_test.go
@@ -118,7 +118,7 @@ func TestValidator(t *testing.T) {
 
 type boolTestValidator bool
 
-func (self boolTestValidator) Validate(addr Address, data []byte) bool {
+func (self boolTestValidator) Validate(chunk Chunk) bool {
 	return bool(self)
 }
 

--- a/swarm/storage/types.go
+++ b/swarm/storage/types.go
@@ -327,7 +327,7 @@ func (c ChunkData) Data() []byte {
 }
 
 type ChunkValidator interface {
-	Validate(addr Address, data []byte) bool
+	Validate(chunk Chunk) bool
 }
 
 // Provides method for validation of content address in chunks
@@ -344,7 +344,8 @@ func NewContentAddressValidator(hasher SwarmHasher) *ContentAddressValidator {
 }
 
 // Validate that the given key is a valid content address for the given data
-func (v *ContentAddressValidator) Validate(addr Address, data []byte) bool {
+func (v *ContentAddressValidator) Validate(chunk Chunk) bool {
+	data := chunk.Data()
 	if l := len(data); l < 9 || l > ch.DefaultSize+8 {
 		// log.Error("invalid chunk size", "chunk", addr.Hex(), "size", l)
 		return false
@@ -355,7 +356,7 @@ func (v *ContentAddressValidator) Validate(addr Address, data []byte) bool {
 	hasher.Write(data[8:])
 	hash := hasher.Sum(nil)
 
-	return bytes.Equal(hash, addr[:])
+	return bytes.Equal(hash, chunk.Address())
 }
 
 type ChunkStore interface {


### PR DESCRIPTION
I noticed that most code using `Validate()` was unfolding a given chunk rather than just passing the chunk variable itself. Refactored code so that the interface looks like this:

```go
type ChunkValidator interface {
	Validate(chunk Chunk) bool
}
```
