### PR TITLE
Update visualized snapshot test

### DIFF
--- a/swarm/network/stream/snapshot_sync_test.go
+++ b/swarm/network/stream/snapshot_sync_test.go
@@ -183,7 +183,7 @@ func streamerFunc(ctx *adapters.ServiceContext, bucket *sync.Map) (s node.Servic
 
 func testSyncingViaGlobalSync(t *testing.T, chunkCount int, nodeCount int) {
 
-	t.Skip("temporarily disabled as simulations.WaitTillHealthy cannot be trusted")
+	//t.Skip("temporarily disabled as simulations.WaitTillHealthy cannot be trusted")
 	sim := simulation.New(simServiceMap)
 	defer sim.Close()
 
@@ -266,6 +266,7 @@ func runSim(conf *synctestConfig, ctx context.Context, sim *simulation.Simulatio
 			}
 			sim.Net.Events().Send(evt)
 		}
+		fmt.Println(hashes)
 		conf.hashes = append(conf.hashes, hashes...)
 		mapKeysToNodes(conf)
 

--- a/swarm/network/stream/snapshot_sync_test.go
+++ b/swarm/network/stream/snapshot_sync_test.go
@@ -266,7 +266,6 @@ func runSim(conf *synctestConfig, ctx context.Context, sim *simulation.Simulatio
 			}
 			sim.Net.Events().Send(evt)
 		}
-		fmt.Println(hashes)
 		conf.hashes = append(conf.hashes, hashes...)
 		mapKeysToNodes(conf)
 

--- a/swarm/network/stream/snapshot_sync_test.go
+++ b/swarm/network/stream/snapshot_sync_test.go
@@ -183,7 +183,7 @@ func streamerFunc(ctx *adapters.ServiceContext, bucket *sync.Map) (s node.Servic
 
 func testSyncingViaGlobalSync(t *testing.T, chunkCount int, nodeCount int) {
 
-	//t.Skip("temporarily disabled as simulations.WaitTillHealthy cannot be trusted")
+	t.Skip("temporarily disabled as simulations.WaitTillHealthy cannot be trusted")
 	sim := simulation.New(simServiceMap)
 	defer sim.Close()
 

--- a/swarm/network/stream/visualized_snapshot_sync_sim_test.go
+++ b/swarm/network/stream/visualized_snapshot_sync_sim_test.go
@@ -245,7 +245,6 @@ func TestSnapshotSyncWithServer(t *testing.T) {
 	if result.Error != nil {
 		panic(result.Error)
 	}
-	//close(quit)
 	log.Info("Simulation ended")
 }
 

--- a/swarm/network/stream/visualized_snapshot_sync_sim_test.go
+++ b/swarm/network/stream/visualized_snapshot_sync_sim_test.go
@@ -96,7 +96,7 @@ func watchSim(sim *simulation.Simulation) (context.Context, context.CancelFunc) 
 //This test requests bogus hashes into the network
 func TestNonExistingHashesWithServer(t *testing.T) {
 
-	//t.Skip("temporarily disabled as simulations.WaitTillHealthy cannot be trusted")
+	t.Skip("temporarily disabled as simulations.WaitTillHealthy cannot be trusted")
 	nodeCount, _, sim := setupSim(retrievalSimServiceMap)
 	defer sim.Close()
 


### PR DESCRIPTION
The Tests in `swarm/network/stream/visualized_snapshot_sync_sim_test.go`, which contain special tests for the frontend visualizer, were broken after some recent refactor of the `swarm/network/simulation` package, because they are disabled with `t.Skip()`.

This PR fixes those tests. They are still disabled with `t.Skip()` though.

In any case, they need to be run with `-tags=withserver` or they will be ignored anyway. Reason is that these tests actually wait for a frontend signal (`POST /runsim`) to actually start.

The frontend is at https://github.com/ethersphere/simple-p2p-d3.
Use the `snapshot-sync-frontend` branch for correct interaction with this backend.