### PR TITLE
travis: retry tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ matrix:
       - sudo chmod 666 /dev/fuse
       - sudo chown root:$USER /etc/fuse.conf
       - go run build/ci.go install
-      - go run build/ci.go test -coverage $TEST_PACKAGES
+      - travis_retry go run build/ci.go test -coverage $TEST_PACKAGES
 
     # These are the latest Go versions.
     - os: linux
@@ -24,7 +24,7 @@ matrix:
         - sudo chmod 666 /dev/fuse
         - sudo chown root:$USER /etc/fuse.conf
         - go run build/ci.go install
-        - go run build/ci.go test -coverage $TEST_PACKAGES
+        - travis_retry go run build/ci.go test -coverage $TEST_PACKAGES
 
     - os: osx
       go: 1.11.x
@@ -39,7 +39,7 @@ matrix:
         - ulimit -n
         - unset -f cd # workaround for https://github.com/travis-ci/travis-ci/issues/8703
         - go run build/ci.go install
-        - go run build/ci.go test -coverage $TEST_PACKAGES
+        - travis_retry go run build/ci.go test -coverage $TEST_PACKAGES
 
     # This builder only tests code linters on latest version of Go
     - os: linux


### PR DESCRIPTION
- Use `travis_retry` to retry test. There are some flaky tests that cause TravisCI to fail and rerun the tests took lots of time. Tests already passed will not rerun because of the cache in golang test. 