### PR TITLE
p2p/discv5: don't hash findnode target in lookup against table

### DIFF
--- a/p2p/discv5/net.go
+++ b/p2p/discv5/net.go
@@ -800,7 +800,7 @@ func (n *nodeNetGuts) startNextQuery(net *Network) {
 func (q *findnodeQuery) start(net *Network) bool {
 	// Satisfy queries against the local node directly.
 	if q.remote == net.tab.self {
-		closest := net.tab.closest(crypto.Keccak256Hash(q.target[:]), bucketSize)
+		closest := net.tab.closest(q.target, bucketSize)
 		q.reply <- closest.entries
 		return true
 	}


### PR DESCRIPTION
q.target is the hash that needs to be found, no need to hash again.