### PR TITLE
p2p: too many inbound connections

### DIFF
--- a/p2p/peer_error.go
+++ b/p2p/peer_error.go
@@ -69,23 +69,25 @@ const (
 	DiscUnexpectedIdentity
 	DiscSelf
 	DiscReadTimeout
+	DiscTooManyInboundConnections
 	DiscSubprotocolError = 0x10
 )
 
 var discReasonToString = [...]string{
-	DiscRequested:           "disconnect requested",
-	DiscNetworkError:        "network error",
-	DiscProtocolError:       "breach of protocol",
-	DiscUselessPeer:         "useless peer",
-	DiscTooManyPeers:        "too many peers",
-	DiscAlreadyConnected:    "already connected",
-	DiscIncompatibleVersion: "incompatible p2p protocol version",
-	DiscInvalidIdentity:     "invalid node identity",
-	DiscQuitting:            "client quitting",
-	DiscUnexpectedIdentity:  "unexpected identity",
-	DiscSelf:                "connected to self",
-	DiscReadTimeout:         "read timeout",
-	DiscSubprotocolError:    "subprotocol error",
+	DiscRequested:                 "disconnect requested",
+	DiscNetworkError:              "network error",
+	DiscProtocolError:             "breach of protocol",
+	DiscUselessPeer:               "useless peer",
+	DiscTooManyPeers:              "too many peers",
+	DiscTooManyInboundConnections: "too many inbound connections",
+	DiscAlreadyConnected:          "already connected",
+	DiscIncompatibleVersion:       "incompatible p2p protocol version",
+	DiscInvalidIdentity:           "invalid node identity",
+	DiscQuitting:                  "client quitting",
+	DiscUnexpectedIdentity:        "unexpected identity",
+	DiscSelf:                      "connected to self",
+	DiscReadTimeout:               "read timeout",
+	DiscSubprotocolError:          "subprotocol error",
 }
 
 func (d DiscReason) String() string {

--- a/p2p/server.go
+++ b/p2p/server.go
@@ -794,7 +794,7 @@ func (srv *Server) encHandshakeChecks(peers map[enode.ID]*Peer, inboundCount int
 	case !c.is(trustedConn|staticDialedConn) && len(peers) >= srv.MaxPeers:
 		return DiscTooManyPeers
 	case !c.is(trustedConn) && c.is(inboundConn) && inboundCount >= srv.maxInboundConns():
-		return DiscTooManyPeers
+		return DiscTooManyInboundConnections
 	case peers[c.node.ID()] != nil:
 		return DiscAlreadyConnected
 	case c.node.ID() == srv.localnode.ID():


### PR DESCRIPTION
This PR is proposing to add a new error - `too many inbound connections`.

The reason is that the error message `too many peers` is confusing at least on Swarm side, when we have the following scenario:

```
1. Node A and Node B have `maxpeers == 10`. Node A has 7 peers, and Node B has 20 peers.
2. Node A cannot connect with an outbound connection to Node B, because Node B already has more peers than `maxpeers`.
3. Node B cannot connect with an outbound connection to Node A either, because Node A has exhausted its inbound connection limit (set by the `DialRatio` and `maxpeers`).
```

The error messages on both sides currently are `too many peers`, which is not really the case for 3.

Given that `maxpeers` itself is confusing, as it does not limit the number of outbound connections, and is checked only for inbound connections, I hope that this error message will at least make some error scenarios more clear and easier to debug.