### PR TITLE
Warn the user when the path name is too long for the ipc endpoint on linux

### DIFF
--- a/rpc/ipc_unix.go
+++ b/rpc/ipc_unix.go
@@ -23,10 +23,17 @@ import (
 	"net"
 	"os"
 	"path/filepath"
+
+	"github.com/ethereum/go-ethereum/log"
 )
 
 // ipcListen will create a Unix socket on the given endpoint.
 func ipcListen(endpoint string) (net.Listener, error) {
+	if len(endpoint) > 107 {
+		log.Warn("The ipc endpoint is longer than 107 characters and is restricted to this size by linux. "+
+			"Shorten this path to less than 108 characters.", "endpoint", endpoint)
+	}
+
 	// Ensure the IPC path exists and remove any previous leftover
 	if err := os.MkdirAll(filepath.Dir(endpoint), 0751); err != nil {
 		return nil, err

--- a/rpc/ipc_unix.go
+++ b/rpc/ipc_unix.go
@@ -20,6 +20,7 @@ package rpc
 
 import (
 	"context"
+	"fmt"
 	"net"
 	"os"
 	"path/filepath"
@@ -27,11 +28,21 @@ import (
 	"github.com/ethereum/go-ethereum/log"
 )
 
+/*
+#include <sys/un.h>
+
+int max_socket_path_size() {
+struct sockaddr_un s;
+return sizeof(s.sun_path);
+}
+*/
+import "C"
+
 // ipcListen will create a Unix socket on the given endpoint.
 func ipcListen(endpoint string) (net.Listener, error) {
-	if len(endpoint) > 107 {
-		log.Warn("The ipc endpoint is longer than 107 characters and is restricted to this size by linux. "+
-			"Shorten this path to less than 108 characters.", "endpoint", endpoint)
+	if len(endpoint) > int(C.max_socket_path_size()) {
+		log.Warn(fmt.Sprintf("The ipc endpoint is longer than %d characters. ", C.max_socket_path_size()),
+			"endpoint", endpoint)
 	}
 
 	// Ensure the IPC path exists and remove any previous leftover


### PR DESCRIPTION
Issue https://github.com/ethereum/go-ethereum/issues/18278
Issue https://github.com/ethereum/go-ethereum/issues/16342

@adamschmideg The ticket says log a warning but I feel this should this not just log it as an error instead? It will always fail anyway.

I don't think I can test that log.warn was called in golang.

108 chars fails. 107 chars passes.