### PR TITLE
downloader: fix edgecase where returned index is OOB for downloader

### DIFF
--- a/eth/downloader/downloader.go
+++ b/eth/downloader/downloader.go
@@ -1491,6 +1491,10 @@ func (d *Downloader) importBlockResults(results []*fetchResult) error {
 		if index < len(results) {
 			log.Debug("Downloaded item processing failed", "number", results[index].Header.Number, "hash", results[index].Header.Hash(), "err", err)
 		} else {
+			// The InsertChain method in blockchain.go will sometimes return an out-of-bounds index,
+			// when it needs to preprocess blocks to import a sidechain.
+			// The importer will put together a new list of blocks to import, which is a superset
+			// of the blocks delivered from the downloader, and the indexing will be off.
 			log.Debug("Downloaded item processing failed on sidechain import", "index", index, "err", err)
 		}
 		return errInvalidChain

--- a/eth/downloader/downloader.go
+++ b/eth/downloader/downloader.go
@@ -1488,7 +1488,11 @@ func (d *Downloader) importBlockResults(results []*fetchResult) error {
 		blocks[i] = types.NewBlockWithHeader(result.Header).WithBody(result.Transactions, result.Uncles)
 	}
 	if index, err := d.blockchain.InsertChain(blocks); err != nil {
-		log.Debug("Downloaded item processing failed", "number", results[index].Header.Number, "hash", results[index].Header.Hash(), "err", err)
+		if index < len(results) {
+			log.Debug("Downloaded item processing failed", "number", results[index].Header.Number, "hash", results[index].Header.Hash(), "err", err)
+		} else {
+			log.Debug("Downloaded item processing failed on sidechain import", "index", index, "err", err)
+		}
 		return errInvalidChain
 	}
 	return nil


### PR DESCRIPTION
This PR fixes an issue that was surfaced by https://github.com/ethereum/go-ethereum/issues/18317. where the `InsertChain` method in `blockchain.go` sometimes, when it needs to preprocess blocks to import a sidechain, will return an index that is out-of-bounds. 

The importer will put together a new list of blocks to import, which is a superset of the blocks delivered from the downloader, and the indexing will be off.