### PR TITLE
feat(core/tx_pool.go): ignore local tx on discard process

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -172,3 +172,4 @@ yoza <yoza.is12s@gmail.com>
 ΞTHΞЯSPHΞЯΞ <{viktor.tron,nagydani,zsfelfoldi}@gmail.com>
 Максим Чусовлянов <mchusovlianov@gmail.com>
 Ralph Caraveo <deckarep@gmail.com>
+hpf <hpf@hackerful.cn>

--- a/core/tx_pool.go
+++ b/core/tx_pool.go
@@ -630,7 +630,7 @@ func (pool *TxPool) add(tx *types.Transaction, local bool) (bool, error) {
 		return false, err
 	}
 	// If the transaction pool is full, discard underpriced transactions
-	if uint64(pool.all.Count()) >= pool.config.GlobalSlots+pool.config.GlobalQueue {
+	if !local && uint64(pool.all.Count()) >= pool.config.GlobalSlots+pool.config.GlobalQueue {
 		// If the new transaction is underpriced, don't accept it
 		if !local && pool.priced.Underpriced(tx, pool.locals) {
 			log.Trace("Discarding underpriced transaction", "hash", hash, "price", tx.GasPrice())


### PR DESCRIPTION
When geth starts, if local txs are too many (>10k), load and try to discard underpriced txs can be very very slowly!
But the local txs are never discard on this process, so we can ignore local txs.