### PR TITLE
accounts/abi: fix case of generated java functions

### DIFF
--- a/accounts/abi/bind/bind.go
+++ b/accounts/abi/bind/bind.go
@@ -381,7 +381,7 @@ func namedTypeJava(javaKind string, solKind abi.Type) string {
 // methodNormalizer is a name transformer that modifies Solidity method names to
 // conform to target language naming concentions.
 var methodNormalizer = map[Lang]func(string) string{
-	LangGo:   capitalise,
+	LangGo:   abi.ToCamelCase,
 	LangJava: decapitalise,
 }
 
@@ -392,10 +392,8 @@ func capitalise(input string) string {
 
 // decapitalise makes a camel-case string which starts with a lower case character.
 func decapitalise(input string) string {
-	// NOTE: This is the current behavior, it doesn't match the comment
-	// above and needs to be investigated.
-	return abi.ToCamelCase(input)
-
+	goForm := abi.ToCamelCase(input)
+	return strings.ToLower(goForm[:1]) + goForm[1:]
 }
 
 // structured checks whether a list of ABI data types has enough information to

--- a/accounts/abi/bind/bind.go
+++ b/accounts/abi/bind/bind.go
@@ -392,6 +392,10 @@ func capitalise(input string) string {
 
 // decapitalise makes a camel-case string which starts with a lower case character.
 func decapitalise(input string) string {
+	if len(input) == 0 {
+		return input
+	}
+
 	goForm := abi.ToCamelCase(input)
 	return strings.ToLower(goForm[:1]) + goForm[1:]
 }


### PR DESCRIPTION
The case of generated java functions did not follow the [java convention](https://www.oracle.com/technetwork/java/codeconventions-135099.html) in spite of claiming to do it in the comments.