### PR TITLE
swarm: Change Proximity function and add TestProximity test

### DIFF
--- a/swarm/storage/types.go
+++ b/swarm/storage/types.go
@@ -100,9 +100,6 @@ func Proximity(one, other []byte) (ret int) {
 	m := 8
 	for i := 0; i < b; i++ {
 		oxo := one[i] ^ other[i]
-		if i == b-1 {
-			m = MaxPO % 8
-		}
 		for j := 0; j < m; j++ {
 			if (oxo>>uint8(7-j))&0x01 != 0 {
 				return i*8 + j

--- a/swarm/storage/types_test.go
+++ b/swarm/storage/types_test.go
@@ -1,0 +1,186 @@
+// Copyright 2018 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+package storage
+
+import (
+	"strconv"
+	"testing"
+)
+
+// TestProximity validates Proximity function with explicit
+// values in a table-driven test. It is highly dependant on
+// MaxPO constant and it validates cases up to MaxPO=32.
+func TestProximity(t *testing.T) {
+	// integer from base2 encoded string
+	bx := func(s string) uint8 {
+		i, err := strconv.ParseUint(s, 2, 8)
+		if err != nil {
+			t.Fatal(err)
+		}
+		return uint8(i)
+	}
+	// adjust expected bins in respect to MaxPO
+	limitPO := func(po uint8) uint8 {
+		if po > MaxPO {
+			return MaxPO
+		}
+		return po
+	}
+	base := []byte{bx("00000000"), bx("00000000"), bx("00000000"), bx("00000000")}
+	for _, tc := range []struct {
+		addr []byte
+		po   uint8
+	}{
+		{
+			addr: base,
+			po:   MaxPO,
+		},
+		{
+			addr: []byte{bx("10000000"), bx("00000000"), bx("00000000"), bx("00000000")},
+			po:   limitPO(0),
+		},
+		{
+			addr: []byte{bx("01000000"), bx("00000000"), bx("00000000"), bx("00000000")},
+			po:   limitPO(1),
+		},
+		{
+			addr: []byte{bx("00100000"), bx("00000000"), bx("00000000"), bx("00000000")},
+			po:   limitPO(2),
+		},
+		{
+			addr: []byte{bx("00010000"), bx("00000000"), bx("00000000"), bx("00000000")},
+			po:   limitPO(3),
+		},
+		{
+			addr: []byte{bx("00001000"), bx("00000000"), bx("00000000"), bx("00000000")},
+			po:   limitPO(4),
+		},
+		{
+			addr: []byte{bx("00000100"), bx("00000000"), bx("00000000"), bx("00000000")},
+			po:   limitPO(5),
+		},
+		{
+			addr: []byte{bx("00000010"), bx("00000000"), bx("00000000"), bx("00000000")},
+			po:   limitPO(6),
+		},
+		{
+			addr: []byte{bx("00000001"), bx("00000000"), bx("00000000"), bx("00000000")},
+			po:   limitPO(7),
+		},
+		{
+			addr: []byte{bx("00000000"), bx("10000000"), bx("00000000"), bx("00000000")},
+			po:   limitPO(8),
+		},
+		{
+			addr: []byte{bx("00000000"), bx("01000000"), bx("00000000"), bx("00000000")},
+			po:   limitPO(9),
+		},
+		{
+			addr: []byte{bx("00000000"), bx("00100000"), bx("00000000"), bx("00000000")},
+			po:   limitPO(10),
+		},
+		{
+			addr: []byte{bx("00000000"), bx("00010000"), bx("00000000"), bx("00000000")},
+			po:   limitPO(11),
+		},
+		{
+			addr: []byte{bx("00000000"), bx("00001000"), bx("00000000"), bx("00000000")},
+			po:   limitPO(12),
+		},
+		{
+			addr: []byte{bx("00000000"), bx("00000100"), bx("00000000"), bx("00000000")},
+			po:   limitPO(13),
+		},
+		{
+			addr: []byte{bx("00000000"), bx("00000010"), bx("00000000"), bx("00000000")},
+			po:   limitPO(14),
+		},
+		{
+			addr: []byte{bx("00000000"), bx("00000001"), bx("00000000"), bx("00000000")},
+			po:   limitPO(15),
+		},
+		{
+			addr: []byte{bx("00000000"), bx("00000000"), bx("10000000"), bx("00000000")},
+			po:   limitPO(16),
+		},
+		{
+			addr: []byte{bx("00000000"), bx("00000000"), bx("01000000"), bx("00000000")},
+			po:   limitPO(17),
+		},
+		{
+			addr: []byte{bx("00000000"), bx("00000000"), bx("00100000"), bx("00000000")},
+			po:   limitPO(18),
+		},
+		{
+			addr: []byte{bx("00000000"), bx("00000000"), bx("00010000"), bx("00000000")},
+			po:   limitPO(19),
+		},
+		{
+			addr: []byte{bx("00000000"), bx("00000000"), bx("00001000"), bx("00000000")},
+			po:   limitPO(20),
+		},
+		{
+			addr: []byte{bx("00000000"), bx("00000000"), bx("00000100"), bx("00000000")},
+			po:   limitPO(21),
+		},
+		{
+			addr: []byte{bx("00000000"), bx("00000000"), bx("00000010"), bx("00000000")},
+			po:   limitPO(22),
+		},
+		{
+			addr: []byte{bx("00000000"), bx("00000000"), bx("00000001"), bx("00000000")},
+			po:   limitPO(23),
+		},
+		{
+			addr: []byte{bx("00000000"), bx("00000000"), bx("00000000"), bx("10000000")},
+			po:   limitPO(24),
+		},
+		{
+			addr: []byte{bx("00000000"), bx("00000000"), bx("00000000"), bx("01000000")},
+			po:   limitPO(25),
+		},
+		{
+			addr: []byte{bx("00000000"), bx("00000000"), bx("00000000"), bx("00100000")},
+			po:   limitPO(26),
+		},
+		{
+			addr: []byte{bx("00000000"), bx("00000000"), bx("00000000"), bx("00010000")},
+			po:   limitPO(27),
+		},
+		{
+			addr: []byte{bx("00000000"), bx("00000000"), bx("00000000"), bx("00001000")},
+			po:   limitPO(28),
+		},
+		{
+			addr: []byte{bx("00000000"), bx("00000000"), bx("00000000"), bx("00000100")},
+			po:   limitPO(29),
+		},
+		{
+			addr: []byte{bx("00000000"), bx("00000000"), bx("00000000"), bx("00000010")},
+			po:   limitPO(30),
+		},
+		{
+			addr: []byte{bx("00000000"), bx("00000000"), bx("00000000"), bx("00000001")},
+			po:   limitPO(31),
+		},
+	} {
+		got := uint8(Proximity(base, tc.addr))
+		if got != tc.po {
+			t.Errorf("got %v bin, want %v", got, tc.po)
+		}
+	}
+}


### PR DESCRIPTION
This PR changes Proximity function in storage package to successfully pass all test cases in a newly added TestProximity function. Current Proximity function returns MaxPO value for MaxPO-9 to MaxPO-1 (last 8 bins of MaxPO bins, or last byte) instead lower values.

For example, for MaxPO=16 the test will fail with incorrect values for bins 8-15 with value 16 for all of them, and for MaxPO=32 bins 24-31 will have value of 32.

This is a resubmission of https://github.com/ethersphere/go-ethereum/pull/1079 PR. 