### PR TITLE
swarm/pss: remove fwdPool

### DIFF
--- a/p2p/peer.go
+++ b/p2p/peer.go
@@ -345,6 +345,17 @@ outer:
 	return result
 }
 
+func (p *Peer) GetRW(name string, version uint) (MsgReadWriter, error) {
+	for _, proto := range p.running {
+		if proto.Name == name && proto.Version == version {
+			var rw MsgReadWriter = proto
+			return rw, nil
+		}
+	}
+
+	return nil, errors.New("not found")
+}
+
 func (p *Peer) startProtocols(writeStart <-chan struct{}, writeErr chan<- error) {
 	p.wg.Add(len(p.running))
 	for _, proto := range p.running {

--- a/p2p/protocols/protocol.go
+++ b/p2p/protocols/protocol.go
@@ -223,10 +223,15 @@ func NewPeer(p *p2p.Peer, rw p2p.MsgReadWriter, spec *Spec) *Peer {
 }
 
 // ClonePeer constructs a peer object with an arbitrary Spec, based on an existing Peer
+// if Peer doesn't support Spec, it returns nil
 func ClonePeer(p *Peer, spec *Spec) *Peer {
+	rw, err := p.Peer.GetRW(spec.Name, spec.Version)
+	if err != nil {
+		return nil
+	}
 	return &Peer{
 		Peer: p.Peer,
-		rw:   p.rw,
+		rw:   rw,
 		spec: spec,
 	}
 }

--- a/p2p/protocols/protocol.go
+++ b/p2p/protocols/protocol.go
@@ -298,7 +298,7 @@ func (p *Peer) Send(ctx context.Context, msg interface{}) error {
 
 	code, found := p.spec.GetCode(msg)
 	if !found {
-		return errorf(ErrInvalidMsgType, "%v", code)
+		return errorf(ErrInvalidMsgType, "%v %s", code, p.spec.Name)
 	}
 	return p2p.Send(p.rw, code, wmsg)
 }

--- a/p2p/protocols/protocol.go
+++ b/p2p/protocols/protocol.go
@@ -222,6 +222,15 @@ func NewPeer(p *p2p.Peer, rw p2p.MsgReadWriter, spec *Spec) *Peer {
 	}
 }
 
+// ClonePeer constructs a peer object with an arbitrary Spec, based on an existing Peer
+func ClonePeer(p *Peer, spec *Spec) *Peer {
+	return &Peer{
+		Peer: p.Peer,
+		rw:   p.rw,
+		spec: spec,
+	}
+}
+
 // Run starts the forever loop that handles incoming messages
 // called within the p2p.Protocol#Run function
 // the handler argument is a function which is called for each message received

--- a/swarm/pss/pss.go
+++ b/swarm/pss/pss.go
@@ -904,7 +904,12 @@ func sendMsg(p *Pss, sp *network.Peer, msg *PssMsg) bool {
 		return false
 	}
 
-	err := sp.Send(context.TODO(), msg)
+	// get a Peer value, which supports the `pss` protocol
+	// `sp.BzzPeer.Peer` is a protocols.Peer, which is linked to the `hive` protocol, and
+	// doesn't support `pss` protocol messages.
+	pp := protocols.ClonePeer(sp.BzzPeer.Peer, pssSpec)
+
+	err := pp.Send(context.TODO(), msg)
 	if err != nil {
 		metrics.GetOrRegisterCounter("pss.pp.send.error", nil).Inc(1)
 		log.Error(err.Error())


### PR DESCRIPTION
~Looks like `fwdPool` is redundant, therefore removing it.~

`fwdPool` keeps a mapping between `protocols.NewPeer(peer, rw, pssSpec)` (peer linked to `pss` protocol) and `network.Peer` (peer linked to the `hive` protocol).

This PR is an effort to simplify this, and get rid of this mapping and directly use the underlying peer value with `pss`.