### PR TITLE
Minor fixes

### DIFF
--- a/core/vm/gas_table.go
+++ b/core/vm/gas_table.go
@@ -380,7 +380,7 @@ func gasExp(gt params.GasTable, evm *EVM, contract *Contract, stack *Stack, mem 
 		gas      = expByteLen * gt.ExpByte // no overflow check required. Max is 256 * ExpByte gas
 		overflow bool
 	)
-	if gas, overflow = math.SafeAdd(gas, GasSlowStep); overflow {
+	if gas, overflow = math.SafeAdd(gas, params.ExpGas); overflow {
 		return 0, errGasUintOverflow
 	}
 	return gas, nil

--- a/core/vm/gas_table.go
+++ b/core/vm/gas_table.go
@@ -22,7 +22,7 @@ import (
 	"github.com/ethereum/go-ethereum/params"
 )
 
-// memoryGasCosts calculates the quadratic gas for memory expansion. It does so
+// memoryGasCost calculates the quadratic gas for memory expansion. It does so
 // only for the memory region that is expanded, not the total memory.
 func memoryGasCost(mem *Memory, newMemSize uint64) (uint64, error) {
 

--- a/params/protocol_params.go
+++ b/params/protocol_params.go
@@ -52,7 +52,7 @@ const (
 	NetSstoreResetRefund      uint64 = 4800  // Once per SSTORE operation for resetting to the original non-zero value
 	NetSstoreResetClearRefund uint64 = 19800 // Once per SSTORE operation for resetting to the original zero value
 
-	JumpdestGas      uint64 = 1     // Refunded gas, once per SSTORE operation if the zeroness changes to zero.
+	JumpdestGas      uint64 = 1     // Once per JUMPDEST operation.
 	EpochDuration    uint64 = 30000 // Duration between proof-of-work epochs.
 	CallGas          uint64 = 40    // Once per CALL operation & message call transaction.
 	CreateDataGas    uint64 = 200   //


### PR DESCRIPTION
Minor fixes:

- core/vm/gas_table: fix minor comment typo
- core/vm/gas_table: Use ExpGas param in gasExp computation
- params/protocol_params: Fix JumpdestGas comment