### PR TITLE
ethdb_test: convert put/get test to a testing table

### DIFF
--- a/ethdb/database_test.go
+++ b/ethdb/database_test.go
@@ -27,11 +27,110 @@ import (
 	"github.com/ethereum/go-ethereum/ethdb"
 )
 
-func newTestLDB() (*ethdb.LDBDatabase, func()) {
+var values = []string{"", "a", "1251", "\x00123\x00"}
+
+func TestLDB_PutGet(t *testing.T) {
+	ldb, remove := newTestLDB(t)
+	defer remove()
+
+	tests := []struct {
+		name string
+		db   ethdb.Database
+	}{
+		{"LDB", ldb},
+		{"MemoryDB", ethdb.NewMemDatabase()},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			for _, k := range values {
+				err := tc.db.Put([]byte(k), nil)
+				if err != nil {
+					t.Fatalf("tc.db.Put(%q, <nil>) = %v, want <nil>", k, err)
+				}
+			}
+
+			for _, k := range values {
+				data, err := tc.db.Get([]byte(k))
+				if err != nil || len(data) != 0 {
+					t.Fatalf("tc.db.Get(%q) = %q, %v, want \"\", <nil>", k, string(data), err)
+				}
+			}
+
+			data, err := tc.db.Get([]byte("non-exist-key"))
+			if err == nil {
+				t.Fatalf("tc.db.Get(\"non-exist-key\") = %q, %v, want <nil>, <error: \"not found\">", string(data), err)
+			}
+
+			for _, v := range values {
+				err := tc.db.Put([]byte(v), []byte(v))
+				if err != nil {
+					t.Fatalf("tc.db.Put(%q, %q) = %v, want <nil>", v, v, err)
+				}
+			}
+
+			for _, v := range values {
+				data, err := tc.db.Get([]byte(v))
+				if err != nil || !bytes.Equal(data, []byte(v)) {
+					t.Fatalf("tc.db.Get(%q) = %q, %v, want %q, <nil>", v, string(data), err, v)
+				}
+			}
+
+			for _, v := range values {
+				err := tc.db.Put([]byte(v), []byte("?"))
+				if err != nil {
+					t.Fatalf("tc.db.Put(%q, \"?\") = %v, want <nil>", v, err)
+				}
+			}
+
+			for _, v := range values {
+				data, err := tc.db.Get([]byte(v))
+				if err != nil || !bytes.Equal(data, []byte("?")) {
+					t.Fatalf("tc.db.Get(%q) = %q, %v, want \"?\", <nil>", v, string(data), err)
+
+				}
+			}
+
+			for _, v := range values {
+				orig, err := tc.db.Get([]byte(v))
+				if err != nil || !bytes.Equal(orig, []byte("?")) {
+					t.Fatalf("tc.db.Get(%q) = %q, %v, want \"?\", <nil>", v, string(orig), err)
+				}
+				// Mutate the original to ensure that the database is not returning the same value instance.
+				orig[0] = byte(0xff)
+				data, err := tc.db.Get([]byte(v))
+				if err != nil || !bytes.Equal(data, []byte("?")) {
+					t.Fatalf("tc.db.Get(%q) = %q, %v, want \"?\", <nil>", v, string(data), err)
+				}
+			}
+
+			for _, v := range values {
+				err := tc.db.Delete([]byte(v))
+				if err != nil {
+					t.Fatalf("tc.db.Delete(%q) = %v, want <nil>", v, err)
+				}
+			}
+
+			for _, v := range values {
+				data, err := tc.db.Get([]byte(v))
+				if err == nil {
+					t.Fatalf("tc.db.Get(%q) = %q, %v, want \"\", <error: \"not found\">", v, string(data), err)
+				}
+			}
+		})
+	}
+}
+
+func newTestLDB(t *testing.T) (*ethdb.LDBDatabase, func()) {
+	t.Helper()
+
 	dirname, err := ioutil.TempDir(os.TempDir(), "ethdb_test_")
 	if err != nil {
 		panic("failed to create test file: " + err.Error())
 	}
+
 	db, err := ethdb.NewLDBDatabase(dirname, 0, 0)
 	if err != nil {
 		panic("failed to create test database: " + err.Error())
@@ -40,106 +139,5 @@ func newTestLDB() (*ethdb.LDBDatabase, func()) {
 	return db, func() {
 		db.Close()
 		os.RemoveAll(dirname)
-	}
-}
-
-var test_values = []string{"", "a", "1251", "\x00123\x00"}
-
-func TestLDB_PutGet(t *testing.T) {
-	db, remove := newTestLDB()
-	defer remove()
-	testPutGet(db, t)
-}
-
-func TestMemoryDB_PutGet(t *testing.T) {
-	testPutGet(ethdb.NewMemDatabase(), t)
-}
-
-func testPutGet(db ethdb.Database, t *testing.T) {
-	t.Parallel()
-
-	for _, k := range test_values {
-		err := db.Put([]byte(k), nil)
-		if err != nil {
-			t.Fatalf("put failed: %v", err)
-		}
-	}
-
-	for _, k := range test_values {
-		data, err := db.Get([]byte(k))
-		if err != nil {
-			t.Fatalf("get failed: %v", err)
-		}
-		if len(data) != 0 {
-			t.Fatalf("get returned wrong result, got %q expected nil", string(data))
-		}
-	}
-
-	_, err := db.Get([]byte("non-exist-key"))
-	if err == nil {
-		t.Fatalf("expect to return a not found error")
-	}
-
-	for _, v := range test_values {
-		err := db.Put([]byte(v), []byte(v))
-		if err != nil {
-			t.Fatalf("put failed: %v", err)
-		}
-	}
-
-	for _, v := range test_values {
-		data, err := db.Get([]byte(v))
-		if err != nil {
-			t.Fatalf("get failed: %v", err)
-		}
-		if !bytes.Equal(data, []byte(v)) {
-			t.Fatalf("get returned wrong result, got %q expected %q", string(data), v)
-		}
-	}
-
-	for _, v := range test_values {
-		err := db.Put([]byte(v), []byte("?"))
-		if err != nil {
-			t.Fatalf("put override failed: %v", err)
-		}
-	}
-
-	for _, v := range test_values {
-		data, err := db.Get([]byte(v))
-		if err != nil {
-			t.Fatalf("get failed: %v", err)
-		}
-		if !bytes.Equal(data, []byte("?")) {
-			t.Fatalf("get returned wrong result, got %q expected ?", string(data))
-		}
-	}
-
-	for _, v := range test_values {
-		orig, err := db.Get([]byte(v))
-		if err != nil {
-			t.Fatalf("get failed: %v", err)
-		}
-		orig[0] = byte(0xff)
-		data, err := db.Get([]byte(v))
-		if err != nil {
-			t.Fatalf("get failed: %v", err)
-		}
-		if !bytes.Equal(data, []byte("?")) {
-			t.Fatalf("get returned wrong result, got %q expected ?", string(data))
-		}
-	}
-
-	for _, v := range test_values {
-		err := db.Delete([]byte(v))
-		if err != nil {
-			t.Fatalf("delete %q failed: %v", v, err)
-		}
-	}
-
-	for _, v := range test_values {
-		_, err := db.Get([]byte(v))
-		if err == nil {
-			t.Fatalf("got deleted value %q", v)
-		}
 	}
 }

--- a/ethdb/database_test.go
+++ b/ethdb/database_test.go
@@ -20,11 +20,8 @@ package ethdb_test
 
 import (
 	"bytes"
-	"fmt"
 	"io/ioutil"
 	"os"
-	"strconv"
-	"sync"
 	"testing"
 
 	"github.com/ethereum/go-ethereum/ethdb"
@@ -145,70 +142,4 @@ func testPutGet(db ethdb.Database, t *testing.T) {
 			t.Fatalf("got deleted value %q", v)
 		}
 	}
-}
-
-func TestLDB_ParallelPutGet(t *testing.T) {
-	db, remove := newTestLDB()
-	defer remove()
-	testParallelPutGet(db, t)
-}
-
-func TestMemoryDB_ParallelPutGet(t *testing.T) {
-	testParallelPutGet(ethdb.NewMemDatabase(), t)
-}
-
-func testParallelPutGet(db ethdb.Database, t *testing.T) {
-	const n = 8
-	var pending sync.WaitGroup
-
-	pending.Add(n)
-	for i := 0; i < n; i++ {
-		go func(key string) {
-			defer pending.Done()
-			err := db.Put([]byte(key), []byte("v"+key))
-			if err != nil {
-				panic("put failed: " + err.Error())
-			}
-		}(strconv.Itoa(i))
-	}
-	pending.Wait()
-
-	pending.Add(n)
-	for i := 0; i < n; i++ {
-		go func(key string) {
-			defer pending.Done()
-			data, err := db.Get([]byte(key))
-			if err != nil {
-				panic("get failed: " + err.Error())
-			}
-			if !bytes.Equal(data, []byte("v"+key)) {
-				panic(fmt.Sprintf("get failed, got %q expected %q", []byte(data), []byte("v"+key)))
-			}
-		}(strconv.Itoa(i))
-	}
-	pending.Wait()
-
-	pending.Add(n)
-	for i := 0; i < n; i++ {
-		go func(key string) {
-			defer pending.Done()
-			err := db.Delete([]byte(key))
-			if err != nil {
-				panic("delete failed: " + err.Error())
-			}
-		}(strconv.Itoa(i))
-	}
-	pending.Wait()
-
-	pending.Add(n)
-	for i := 0; i < n; i++ {
-		go func(key string) {
-			defer pending.Done()
-			_, err := db.Get([]byte(key))
-			if err == nil {
-				panic("get succeeded")
-			}
-		}(strconv.Itoa(i))
-	}
-	pending.Wait()
 }


### PR DESCRIPTION
The paradigm being used to test a LDBDatabase and MemDatabase is amenable
to using testing tables.

Additionally some minor refactorings were performed to improve test failure
reporting and the helper function for creating the LDBDatabase now uses a
testing.T to report errors, rather than using a panic.

This follows up #18414 