### PR TITLE
accounts/mananger, internal/ethapi/api: Add new function AllAccounts …

### DIFF
--- a/accounts/manager.go
+++ b/accounts/manager.go
@@ -148,8 +148,8 @@ func (am *Manager) Wallet(url string) (Wallet, error) {
 	return nil, ErrUnknownWallet
 }
 
-// AllAccounts returns all account addresses of all wallets within the account manager
-func (am *Manager) AllAccounts() []common.Address {
+// Accounts returns all account addresses of all wallets within the account manager
+func (am *Manager) Accounts() []common.Address {
 	am.lock.RLock()
 	defer am.lock.RUnlock()
 

--- a/accounts/manager.go
+++ b/accounts/manager.go
@@ -21,6 +21,7 @@ import (
 	"sort"
 	"sync"
 
+	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/event"
 )
 
@@ -145,6 +146,20 @@ func (am *Manager) Wallet(url string) (Wallet, error) {
 		}
 	}
 	return nil, ErrUnknownWallet
+}
+
+// AllAccounts returns all account addresses of all wallets within the account manager
+func (am *Manager) AllAccounts() []common.Address {
+	am.lock.RLock()
+	defer am.lock.RUnlock()
+
+	addresses := make([]common.Address, 0) // return [] instead of nil if empty
+	for _, wallet := range am.wallets {
+		for _, account := range wallet.Accounts() {
+			addresses = append(addresses, account.Address)
+		}
+	}
+	return addresses
 }
 
 // Find attempts to locate the wallet corresponding to a specific account. Since

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -190,7 +190,7 @@ func NewPublicAccountAPI(am *accounts.Manager) *PublicAccountAPI {
 
 // Accounts returns the collection of accounts this node manages
 func (s *PublicAccountAPI) Accounts() []common.Address {
-	return s.am.AllAccounts()
+	return s.am.Accounts()
 }
 
 // PrivateAccountAPI provides an API to access accounts managed by this node.
@@ -213,7 +213,7 @@ func NewPrivateAccountAPI(b Backend, nonceLock *AddrLocker) *PrivateAccountAPI {
 
 // ListAccounts will return a list of addresses for accounts this node manages.
 func (s *PrivateAccountAPI) ListAccounts() []common.Address {
-	return s.am.AllAccounts()
+	return s.am.Accounts()
 }
 
 // rawWallet is a JSON representation of an accounts.Wallet interface, with its

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -190,13 +190,7 @@ func NewPublicAccountAPI(am *accounts.Manager) *PublicAccountAPI {
 
 // Accounts returns the collection of accounts this node manages
 func (s *PublicAccountAPI) Accounts() []common.Address {
-	addresses := make([]common.Address, 0) // return [] instead of nil if empty
-	for _, wallet := range s.am.Wallets() {
-		for _, account := range wallet.Accounts() {
-			addresses = append(addresses, account.Address)
-		}
-	}
-	return addresses
+	return s.am.AllAccounts()
 }
 
 // PrivateAccountAPI provides an API to access accounts managed by this node.
@@ -219,13 +213,7 @@ func NewPrivateAccountAPI(b Backend, nonceLock *AddrLocker) *PrivateAccountAPI {
 
 // ListAccounts will return a list of addresses for accounts this node manages.
 func (s *PrivateAccountAPI) ListAccounts() []common.Address {
-	addresses := make([]common.Address, 0) // return [] instead of nil if empty
-	for _, wallet := range s.am.Wallets() {
-		for _, account := range wallet.Accounts() {
-			addresses = append(addresses, account.Address)
-		}
-	}
-	return addresses
+	return s.am.AllAccounts()
 }
 
 // rawWallet is a JSON representation of an accounts.Wallet interface, with its


### PR DESCRIPTION
…on account manager to remove the duplication code on getting all wallets accounts

Refactor: remove the duplication code on getting all account addresses, extract the logic into account manager .