### PR TITLE
consensus/ethash: add algorithm identifier

### DIFF
--- a/consensus/ethash/api.go
+++ b/consensus/ethash/api.go
@@ -38,27 +38,28 @@ type API struct {
 //   result[1] - 32 bytes hex encoded seed hash used for DAG
 //   result[2] - 32 bytes hex encoded boundary condition ("target"), 2^256/difficulty
 //   result[3] - hex encoded block number
-func (api *API) GetWork() ([4]string, error) {
+//   result[4] - algorithm name and version tag.
+func (api *API) GetWork() ([5]string, error) {
 	if api.ethash.config.PowMode != ModeNormal && api.ethash.config.PowMode != ModeTest {
-		return [4]string{}, errors.New("not supported")
+		return [5]string{}, errors.New("not supported")
 	}
 
 	var (
-		workCh = make(chan [4]string, 1)
+		workCh = make(chan [5]string, 1)
 		errc   = make(chan error, 1)
 	)
 
 	select {
 	case api.ethash.fetchWorkCh <- &sealWork{errc: errc, res: workCh}:
 	case <-api.ethash.exitCh:
-		return [4]string{}, errEthashStopped
+		return [5]string{}, errEthashStopped
 	}
 
 	select {
 	case work := <-workCh:
 		return work, nil
 	case err := <-errc:
-		return [4]string{}, err
+		return [5]string{}, err
 	}
 }
 

--- a/consensus/ethash/ethash.go
+++ b/consensus/ethash/ethash.go
@@ -43,6 +43,11 @@ import (
 	"github.com/hashicorp/golang-lru/simplelru"
 )
 
+const (
+	algorithmName    = "ethash" // PoW algorithm name
+	algorithmVersion = "1.0.0"  // Algorithm revision information
+)
+
 var ErrInvalidDumpMagic = errors.New("invalid dump magic")
 
 var (
@@ -432,7 +437,7 @@ type hashrate struct {
 // sealWork wraps a seal work package for remote sealer.
 type sealWork struct {
 	errc chan error
-	res  chan [4]string
+	res  chan [5]string
 }
 
 // Ethash is a consensus engine based on proof-of-work implementing the ethash

--- a/consensus/ethash/ethash.go
+++ b/consensus/ethash/ethash.go
@@ -43,10 +43,7 @@ import (
 	"github.com/hashicorp/golang-lru/simplelru"
 )
 
-const (
-	algorithmName    = "ethash" // PoW algorithm name
-	algorithmVersion = "1.0.0"  // Algorithm revision information
-)
+const algorithmVersion = "ethash/1.0.0" // PoW algorithm version
 
 var ErrInvalidDumpMagic = errors.New("invalid dump magic")
 

--- a/consensus/ethash/sealer.go
+++ b/consensus/ethash/sealer.go
@@ -26,7 +26,6 @@ import (
 	"math/rand"
 	"net/http"
 	"runtime"
-	"strings"
 	"sync"
 	"time"
 
@@ -244,7 +243,7 @@ func (ethash *Ethash) remote(notify []string, noverify bool) {
 		currentWork[1] = common.BytesToHash(SeedHash(block.NumberU64())).Hex()
 		currentWork[2] = common.BytesToHash(new(big.Int).Div(two256, block.Difficulty()).Bytes()).Hex()
 		currentWork[3] = hexutil.EncodeBig(block.Number())
-		currentWork[4] = strings.Join([]string{algorithmName, algorithmVersion}, "/")
+		currentWork[4] = algorithmVersion
 
 		// Trace the seal work fetched by remote sealer.
 		currentBlock = block

--- a/consensus/ethash/sealer.go
+++ b/consensus/ethash/sealer.go
@@ -26,6 +26,7 @@ import (
 	"math/rand"
 	"net/http"
 	"runtime"
+	"strings"
 	"sync"
 	"time"
 
@@ -194,7 +195,7 @@ func (ethash *Ethash) remote(notify []string, noverify bool) {
 
 		results      chan<- *types.Block
 		currentBlock *types.Block
-		currentWork  [4]string
+		currentWork  [5]string
 
 		notifyTransport = &http.Transport{}
 		notifyClient    = &http.Client{
@@ -243,6 +244,7 @@ func (ethash *Ethash) remote(notify []string, noverify bool) {
 		currentWork[1] = common.BytesToHash(SeedHash(block.NumberU64())).Hex()
 		currentWork[2] = common.BytesToHash(new(big.Int).Div(two256, block.Difficulty()).Bytes()).Hex()
 		currentWork[3] = hexutil.EncodeBig(block.Number())
+		currentWork[4] = strings.Join([]string{algorithmName, algorithmVersion}, "/")
 
 		// Trace the seal work fetched by remote sealer.
 		currentBlock = block


### PR DESCRIPTION
Please not merge this PR now.

A mining feature required by @chfast. Nowadays community is discussing switching to ProgPow. So that we need an identifier to distinguish ethash and progpow when progpow happen. 