### PR TITLE
Topics does not support nil data

### DIFF
--- a/interfaces.go
+++ b/interfaces.go
@@ -147,7 +147,7 @@ type FilterQuery struct {
 	// {{}, {B}}          matches any topic in first position, B in second position
 	// {{A}, {B}}         matches topic A in first position, B in second position
 	// {{A, B}, {C, D}}   matches topic (A OR B) in first position, (C OR D) in second position
-	Topics [][]common.Hash
+	Topics [][]*common.Hash
 }
 
 // LogFilterer provides access to contract log events using a one-off query or continuous


### PR DESCRIPTION
Golang version of geth works differently from curl.  It does not work: 
curl -X POST --data '{"jsonrpc":"2.0","method":"eth_getLogs","params":[{"fromBlock":"0x494E40", "toBlock":"0x494E40", "topics":[["0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef",null],["0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef",null]]}], "id":1}' https://ropsten.infura.io