### PR TITLE
add methods to abi that allow for the generic unpacking of event logs into map[string]interface{}

### DIFF
--- a/accounts/abi/abi.go
+++ b/accounts/abi/abi.go
@@ -72,37 +72,39 @@ func (abi ABI) Pack(name string, args ...interface{}) ([]byte, error) {
 }
 
 // Unpack output in v according to the abi specification
-func (abi ABI) Unpack(v interface{}, name string, output []byte) (err error) {
-	if len(output) == 0 {
+func (abi ABI) Unpack(v interface{}, name string, data []byte) (err error) {
+	if len(data) == 0 {
 		return fmt.Errorf("abi: unmarshalling empty output")
 	}
 	// since there can't be naming collisions with contracts and events,
 	// we need to decide whether we're calling a method or an event
 	if method, ok := abi.Methods[name]; ok {
-		if len(output)%32 != 0 {
-			return fmt.Errorf("abi: improperly formatted output: %s - Bytes: [%+v]", string(output), output)
+		if len(data)%32 != 0 {
+			return fmt.Errorf("abi: improperly formatted output: %s - Bytes: [%+v]", string(data), data)
 		}
-		return method.Outputs.Unpack(v, output)
-	} else if event, ok := abi.Events[name]; ok {
-		return event.Inputs.Unpack(v, output)
+		return method.Outputs.Unpack(v, data)
+	}
+	if event, ok := abi.Events[name]; ok {
+		return event.Inputs.Unpack(v, data)
 	}
 	return fmt.Errorf("abi: could not locate named method or event")
 }
 
-// Unpack output into a map according to the abi specification
-func (abi ABI) UnpackIntoMap(v map[string]interface{}, name string, output []byte) (err error) {
-	if len(output) == 0 {
+// UnpackIntoMap unpacks a log into the provided map[string]interface{}
+func (abi ABI) UnpackIntoMap(v map[string]interface{}, name string, data []byte) (err error) {
+	if len(data) == 0 {
 		return fmt.Errorf("abi: unmarshalling empty output")
 	}
 	// since there can't be naming collisions with contracts and events,
 	// we need to decide whether we're calling a method or an event
 	if method, ok := abi.Methods[name]; ok {
-		if len(output)%32 != 0 {
+		if len(data)%32 != 0 {
 			return fmt.Errorf("abi: improperly formatted output")
 		}
-		return method.Outputs.UnpackIntoMap(v, output)
-	} else if event, ok := abi.Events[name]; ok {
-		return event.Inputs.UnpackIntoMap(v, output)
+		return method.Outputs.UnpackIntoMap(v, data)
+	}
+	if event, ok := abi.Events[name]; ok {
+		return event.Inputs.UnpackIntoMap(v, data)
 	}
 	return fmt.Errorf("abi: could not locate named method or event")
 }

--- a/accounts/abi/abi_test.go
+++ b/accounts/abi/abi_test.go
@@ -694,7 +694,7 @@ func TestUnpackEvent(t *testing.T) {
 	}
 }
 
-func TestUnpackIntoMapEvent(t *testing.T) {
+func TestUnpackEventIntoMap(t *testing.T) {
 	const abiJSON = `[{"constant":false,"inputs":[{"name":"memo","type":"bytes"}],"name":"receive","outputs":[],"payable":true,"stateMutability":"payable","type":"function"},{"anonymous":false,"inputs":[{"indexed":false,"name":"sender","type":"address"},{"indexed":false,"name":"amount","type":"uint256"},{"indexed":false,"name":"memo","type":"bytes"}],"name":"received","type":"event"},{"anonymous":false,"inputs":[{"indexed":false,"name":"sender","type":"address"}],"name":"receivedAddr","type":"event"}]`
 	abi, err := JSON(strings.NewReader(abiJSON))
 	if err != nil {
@@ -716,37 +716,37 @@ func TestUnpackIntoMapEvent(t *testing.T) {
 		"amount": big.NewInt(1),
 		"memo":   []uint8{88},
 	}
-
-	err = abi.UnpackIntoMap(receivedMap, "received", data)
-	if err != nil {
+	if err := abi.UnpackIntoMap(receivedMap, "received", data); err != nil {
 		t.Error(err)
 	}
 
+	if len(receivedMap) != 3 {
+		t.Error("unpacked map expected to have length 3")
+	}
 	if receivedMap["sender"] != expectedReceivedMap["sender"] {
-		t.Errorf("unpacked map does not match expected map")
+		t.Error("unpacked map does not match expected map")
 	}
-
 	if receivedMap["amount"].(*big.Int).String() != expectedReceivedMap["amount"].(*big.Int).String() {
-		t.Errorf("unpacked map does not match expected map")
+		t.Error("unpacked map does not match expected map")
 	}
-
 	u8 := receivedMap["memo"].([]uint8)
 	expectedU8 := expectedReceivedMap["memo"].([]uint8)
 	for i, v := range expectedU8 {
 		if u8[i] != v {
-			t.Errorf("unpacked map does not match expected map")
+			t.Error("unpacked map does not match expected map")
 		}
 	}
 
 	receivedAddrMap := map[string]interface{}{}
-
-	err = abi.UnpackIntoMap(receivedAddrMap, "receivedAddr", data)
-	if err != nil {
+	if err = abi.UnpackIntoMap(receivedAddrMap, "receivedAddr", data); err != nil {
 		t.Error(err)
 	}
 
+	if len(receivedAddrMap) != 1 {
+		t.Error("unpacked map expected to have length 1")
+	}
 	if receivedAddrMap["sender"] != expectedReceivedMap["sender"] {
-		t.Errorf("unpacked map does not match expected map")
+		t.Error("unpacked map does not match expected map")
 	}
 }
 

--- a/accounts/abi/abi_test.go
+++ b/accounts/abi/abi_test.go
@@ -714,39 +714,169 @@ func TestUnpackEventIntoMap(t *testing.T) {
 	expectedReceivedMap := map[string]interface{}{
 		"sender": common.HexToAddress("0x376c47978271565f56DEB45495afa69E59c16Ab2"),
 		"amount": big.NewInt(1),
-		"memo":   []uint8{88},
+		"memo":   []byte{88},
 	}
 	if err := abi.UnpackIntoMap(receivedMap, "received", data); err != nil {
 		t.Error(err)
 	}
-
 	if len(receivedMap) != 3 {
-		t.Error("unpacked map expected to have length 3")
+		t.Error("unpacked `received` map expected to have length 3")
 	}
 	if receivedMap["sender"] != expectedReceivedMap["sender"] {
-		t.Error("unpacked map does not match expected map")
+		t.Error("unpacked `received` map does not match expected map")
 	}
-	if receivedMap["amount"].(*big.Int).String() != expectedReceivedMap["amount"].(*big.Int).String() {
-		t.Error("unpacked map does not match expected map")
+	if receivedMap["amount"].(*big.Int).Cmp(expectedReceivedMap["amount"].(*big.Int)) != 0 {
+		t.Error("unpacked `received` map does not match expected map")
 	}
-	u8 := receivedMap["memo"].([]uint8)
-	expectedU8 := expectedReceivedMap["memo"].([]uint8)
-	for i, v := range expectedU8 {
-		if u8[i] != v {
-			t.Error("unpacked map does not match expected map")
-		}
+	if !bytes.Equal(receivedMap["memo"].([]byte), expectedReceivedMap["memo"].([]byte)) {
+		t.Error("unpacked `received` map does not match expected map")
 	}
 
 	receivedAddrMap := map[string]interface{}{}
 	if err = abi.UnpackIntoMap(receivedAddrMap, "receivedAddr", data); err != nil {
 		t.Error(err)
 	}
-
 	if len(receivedAddrMap) != 1 {
-		t.Error("unpacked map expected to have length 1")
+		t.Error("unpacked `receivedAddr` map expected to have length 1")
 	}
 	if receivedAddrMap["sender"] != expectedReceivedMap["sender"] {
-		t.Error("unpacked map does not match expected map")
+		t.Error("unpacked `receivedAddr` map does not match expected map")
+	}
+}
+
+func TestUnpackMethodIntoMap(t *testing.T) {
+	const abiJSON = `[{"constant":false,"inputs":[{"name":"memo","type":"bytes"}],"name":"receive","outputs":[],"payable":true,"stateMutability":"payable","type":"function"},{"constant":false,"inputs":[],"name":"send","outputs":[{"name":"amount","type":"uint256"}],"payable":true,"stateMutability":"payable","type":"function"},{"constant":false,"inputs":[{"name":"addr","type":"address"}],"name":"get","outputs":[{"name":"hash","type":"bytes"}],"payable":true,"stateMutability":"payable","type":"function"}]`
+	abi, err := JSON(strings.NewReader(abiJSON))
+	if err != nil {
+		t.Fatal(err)
+	}
+	const hexdata = `00000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000000060000000000000000000000000000000000000000000000000000000000000015800000000000000000000000000000000000000000000000000000000000000600000000000000000000000000000000000000000000000000000000000000158000000000000000000000000000000000000000000000000000000000000006000000000000000000000000000000000000000000000000000000000000001580000000000000000000000000000000000000000000000000000000000000060000000000000000000000000000000000000000000000000000000000000015800000000000000000000000000000000000000000000000000000000000000600000000000000000000000000000000000000000000000000000000000000158`
+	data, err := hex.DecodeString(hexdata)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(data)%32 != 0 {
+		t.Errorf("len(data) is %d, want a multiple of 32", len(data))
+	}
+
+	// Tests a method with no outputs
+	receiveMap := map[string]interface{}{}
+	if err = abi.UnpackIntoMap(receiveMap, "receive", data); err != nil {
+		t.Error(err)
+	}
+	if len(receiveMap) > 0 {
+		t.Error("unpacked `receive` map expected to have length 0")
+	}
+
+	// Tests a method with only outputs
+	sendMap := map[string]interface{}{}
+	if err = abi.UnpackIntoMap(sendMap, "send", data); err != nil {
+		t.Error(err)
+	}
+	if len(sendMap) != 1 {
+		t.Error("unpacked `send` map expected to have length 1")
+	}
+	if sendMap["amount"].(*big.Int).Cmp(big.NewInt(1)) != 0 {
+		t.Error("unpacked `send` map expected `amount` value of 1")
+	}
+
+	// Tests a method with outputs and inputs
+	getMap := map[string]interface{}{}
+	if err = abi.UnpackIntoMap(getMap, "get", data); err != nil {
+		t.Error(err)
+	}
+	if len(sendMap) != 1 {
+		t.Error("unpacked `get` map expected to have length 1")
+	}
+	expectedBytes := []byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 96, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 88, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 96, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 88, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 96, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 88, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 96, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 88, 0}
+	if !bytes.Equal(getMap["hash"].([]byte), expectedBytes) {
+		t.Errorf("unpacked `get` map expected `hash` value of %v", expectedBytes)
+	}
+}
+
+func TestUnpackIntoMapNamingConflict(t *testing.T) {
+	// Two methods have the same name
+	var abiJSON = `[{"constant":false,"inputs":[{"name":"memo","type":"bytes"}],"name":"get","outputs":[],"payable":true,"stateMutability":"payable","type":"function"},{"constant":false,"inputs":[],"name":"send","outputs":[{"name":"amount","type":"uint256"}],"payable":true,"stateMutability":"payable","type":"function"},{"constant":false,"inputs":[{"name":"addr","type":"address"}],"name":"get","outputs":[{"name":"hash","type":"bytes"}],"payable":true,"stateMutability":"payable","type":"function"}]`
+	abi, err := JSON(strings.NewReader(abiJSON))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var hexdata = `00000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000000060000000000000000000000000000000000000000000000000000000000000000158`
+	data, err := hex.DecodeString(hexdata)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(data)%32 == 0 {
+		t.Errorf("len(data) is %d, want a non-multiple of 32", len(data))
+	}
+	getMap := map[string]interface{}{}
+	if err = abi.UnpackIntoMap(getMap, "get", data); err == nil {
+		t.Error("naming conflict between two methods; error expected")
+	}
+
+	// Two events have the same name
+	abiJSON = `[{"constant":false,"inputs":[{"name":"memo","type":"bytes"}],"name":"receive","outputs":[],"payable":true,"stateMutability":"payable","type":"function"},{"anonymous":false,"inputs":[{"indexed":false,"name":"sender","type":"address"},{"indexed":false,"name":"amount","type":"uint256"},{"indexed":false,"name":"memo","type":"bytes"}],"name":"received","type":"event"},{"anonymous":false,"inputs":[{"indexed":false,"name":"sender","type":"address"}],"name":"received","type":"event"}]`
+	abi, err = JSON(strings.NewReader(abiJSON))
+	if err != nil {
+		t.Fatal(err)
+	}
+	hexdata = `000000000000000000000000376c47978271565f56deb45495afa69e59c16ab200000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000000060000000000000000000000000000000000000000000000000000000000000000158`
+	data, err = hex.DecodeString(hexdata)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(data)%32 == 0 {
+		t.Errorf("len(data) is %d, want a non-multiple of 32", len(data))
+	}
+	receivedMap := map[string]interface{}{}
+	if err = abi.UnpackIntoMap(receivedMap, "received", data); err != nil {
+		t.Error("naming conflict between two events; no error expected")
+	}
+	if len(receivedMap) != 1 {
+		t.Error("naming conflict between two events; event defined latest in the abi expected to be used")
+	}
+
+	// Method and event have the same name
+	abiJSON = `[{"constant":false,"inputs":[{"name":"memo","type":"bytes"}],"name":"received","outputs":[],"payable":true,"stateMutability":"payable","type":"function"},{"anonymous":false,"inputs":[{"indexed":false,"name":"sender","type":"address"},{"indexed":false,"name":"amount","type":"uint256"},{"indexed":false,"name":"memo","type":"bytes"}],"name":"received","type":"event"},{"anonymous":false,"inputs":[{"indexed":false,"name":"sender","type":"address"}],"name":"receivedAddr","type":"event"}]`
+	abi, err = JSON(strings.NewReader(abiJSON))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(data)%32 == 0 {
+		t.Errorf("len(data) is %d, want a non-multiple of 32", len(data))
+	}
+	if err = abi.UnpackIntoMap(receivedMap, "received", data); err == nil {
+		t.Error("naming conflict between an event and a method; error expected")
+	}
+
+	// Conflict is case sensitive
+	abiJSON = `[{"constant":false,"inputs":[{"name":"memo","type":"bytes"}],"name":"received","outputs":[],"payable":true,"stateMutability":"payable","type":"function"},{"anonymous":false,"inputs":[{"indexed":false,"name":"sender","type":"address"},{"indexed":false,"name":"amount","type":"uint256"},{"indexed":false,"name":"memo","type":"bytes"}],"name":"Received","type":"event"},{"anonymous":false,"inputs":[{"indexed":false,"name":"sender","type":"address"}],"name":"receivedAddr","type":"event"}]`
+	abi, err = JSON(strings.NewReader(abiJSON))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(data)%32 == 0 {
+		t.Errorf("len(data) is %d, want a non-multiple of 32", len(data))
+	}
+	expectedReceivedMap := map[string]interface{}{
+		"sender": common.HexToAddress("0x376c47978271565f56DEB45495afa69E59c16Ab2"),
+		"amount": big.NewInt(1),
+		"memo":   []byte{88},
+	}
+	if err = abi.UnpackIntoMap(receivedMap, "Received", data); err != nil {
+		t.Error(err)
+	}
+	if len(receivedMap) != 3 {
+		t.Error("unpacked `received` map expected to have length 3")
+	}
+	if receivedMap["sender"] != expectedReceivedMap["sender"] {
+		t.Error("unpacked `received` map does not match expected map")
+	}
+	if receivedMap["amount"].(*big.Int).Cmp(expectedReceivedMap["amount"].(*big.Int)) != 0 {
+		t.Error("unpacked `received` map does not match expected map")
+	}
+	if !bytes.Equal(receivedMap["memo"].([]byte), expectedReceivedMap["memo"].([]byte)) {
+		t.Error("unpacked `received` map does not match expected map")
 	}
 }
 

--- a/accounts/abi/argument.go
+++ b/accounts/abi/argument.go
@@ -102,7 +102,7 @@ func (arguments Arguments) Unpack(v interface{}, data []byte) error {
 	return arguments.unpackAtomic(v, marshalledValues[0])
 }
 
-// Unpack performs the operation hexdata -> mapping of argument name to argument value
+// UnpackIntoMap performs the operation hexdata -> mapping of argument name to argument value
 func (arguments Arguments) UnpackIntoMap(v map[string]interface{}, data []byte) error {
 	marshalledValues, err := arguments.UnpackValues(data)
 	if err != nil {
@@ -170,7 +170,7 @@ func unpack(t *Type, dst interface{}, src interface{}) error {
 	return nil
 }
 
-// Unpack arguments into map
+// unpackIntoMap unpacks marshalledValues into the provided map[string]interface{}
 func (arguments Arguments) unpackIntoMap(v map[string]interface{}, marshalledValues []interface{}) error {
 	// Make sure map is not nil
 	if v == nil {

--- a/accounts/abi/argument.go
+++ b/accounts/abi/argument.go
@@ -102,6 +102,16 @@ func (arguments Arguments) Unpack(v interface{}, data []byte) error {
 	return arguments.unpackAtomic(v, marshalledValues[0])
 }
 
+// Unpack performs the operation hexdata -> mapping of argument name to argument value
+func (arguments Arguments) UnpackIntoMap(v map[string]interface{}, data []byte) error {
+	marshalledValues, err := arguments.UnpackValues(data)
+	if err != nil {
+		return err
+	}
+
+	return arguments.unpackIntoMap(v, marshalledValues)
+}
+
 // unpack sets the unmarshalled value to go format.
 // Note the dst here must be settable.
 func unpack(t *Type, dst interface{}, src interface{}) error {
@@ -156,6 +166,19 @@ func unpack(t *Type, dst interface{}, src interface{}) error {
 			}
 		}
 		dstVal.Set(array)
+	}
+	return nil
+}
+
+// Unpack arguments into map
+func (arguments Arguments) unpackIntoMap(v map[string]interface{}, marshalledValues []interface{}) error {
+	// Make sure map is not nil
+	if v == nil {
+		return fmt.Errorf("abi: cannot unpack into a nil map")
+	}
+
+	for i, arg := range arguments.NonIndexed() {
+		v[arg.Name] = marshalledValues[i]
 	}
 	return nil
 }

--- a/accounts/abi/bind/base.go
+++ b/accounts/abi/bind/base.go
@@ -340,6 +340,22 @@ func (c *BoundContract) UnpackLog(out interface{}, event string, log types.Log) 
 	return parseTopics(out, indexed, log.Topics[1:])
 }
 
+// UnpackLogIntoMap unpacks a retrieved log into the provided map.
+func (c *BoundContract) UnpackLogIntoMap(out map[string]interface{}, event string, log types.Log) error {
+	if len(log.Data) > 0 {
+		if err := c.abi.UnpackIntoMap(out, event, log.Data); err != nil {
+			return err
+		}
+	}
+	var indexed abi.Arguments
+	for _, arg := range c.abi.Events[event].Inputs {
+		if arg.Indexed {
+			indexed = append(indexed, arg)
+		}
+	}
+	return parseTopicsIntoMap(out, indexed, log.Topics[1:])
+}
+
 // ensureContext is a helper method to ensure a context is not nil, even if the
 // user specified it as such.
 func ensureContext(ctx context.Context) context.Context {

--- a/accounts/abi/bind/topics.go
+++ b/accounts/abi/bind/topics.go
@@ -218,6 +218,16 @@ func parseTopicsIntoMap(out map[string]interface{}, fields abi.Arguments, topics
 			out[arg.Name] = topics[0]
 		case abi.BytesTy, abi.FixedBytesTy:
 			out[arg.Name] = topics[0][:]
+		case abi.StringTy:
+			bytes := topics[0].Bytes()
+			var trimmedBytes []byte
+			for i, by := range bytes {
+				if by != 0 {
+					trimmedBytes = bytes[i:]
+					break
+				}
+			}
+			out[arg.Name] = string(trimmedBytes)
 		default:
 		}
 

--- a/accounts/abi/bind/topics.go
+++ b/accounts/abi/bind/topics.go
@@ -17,6 +17,7 @@
 package bind
 
 import (
+	"encoding/binary"
 	"errors"
 	"fmt"
 	"math/big"
@@ -188,7 +189,7 @@ func parseTopics(out interface{}, fields abi.Arguments, topics []common.Hash) er
 	return nil
 }
 
-// parseTopics converts the indexed topic field-value pairs into map key-value pairs
+// parseTopicsIntoMap converts the indexed topic field-value pairs into map key-value pairs
 func parseTopicsIntoMap(out map[string]interface{}, fields abi.Arguments, topics []common.Hash) error {
 	// Sanity check that the fields and topics match up
 	if len(fields) != len(topics) {
@@ -202,11 +203,7 @@ func parseTopicsIntoMap(out map[string]interface{}, fields abi.Arguments, topics
 
 		switch arg.Type.T {
 		case abi.BoolTy:
-			if topics[0][common.HashLength-1] == 1 {
-				out[arg.Name] = true
-			} else {
-				out[arg.Name] = false
-			}
+			out[arg.Name] = topics[0][common.HashLength-1] == 1
 		case abi.IntTy, abi.UintTy:
 			num := new(big.Int).SetBytes(topics[0][:])
 			out[arg.Name] = num
@@ -216,19 +213,21 @@ func parseTopicsIntoMap(out map[string]interface{}, fields abi.Arguments, topics
 			out[arg.Name] = addr
 		case abi.HashTy:
 			out[arg.Name] = topics[0]
-		case abi.BytesTy, abi.FixedBytesTy:
+		case abi.FixedBytesTy:
 			out[arg.Name] = topics[0][:]
-		case abi.StringTy:
-			bytes := topics[0].Bytes()
-			var trimmedBytes []byte
-			for i, by := range bytes {
-				if by != 0 {
-					trimmedBytes = bytes[i:]
-					break
-				}
+		case abi.StringTy, abi.BytesTy, abi.SliceTy, abi.ArrayTy:
+			// Array types (including strings and bytes) have their keccak256 hashes stored in the topic- not a hash
+			// whose bytes can be decoded to the actual value- so the best we can do is retrieve that hash
+			out[arg.Name] = topics[0]
+		case abi.FunctionTy:
+			if garbage := binary.BigEndian.Uint64(topics[0][0:8]); garbage != 0 {
+				return fmt.Errorf("bind: got improperly encoded function type, got %v", topics[0].Bytes())
 			}
-			out[arg.Name] = string(trimmedBytes)
-		default:
+			var tmp [24]byte
+			copy(tmp[:], topics[0][8:32])
+			out[arg.Name] = tmp
+		default: // Not handling tuples
+			return fmt.Errorf("unsupported indexed type: %v", arg.Type)
 		}
 
 		topics = topics[1:]

--- a/accounts/abi/unpack.go
+++ b/accounts/abi/unpack.go
@@ -269,7 +269,7 @@ func lengthPrefixPointsTo(index int, output []byte) (start int, length int, err 
 	totalSize.Add(totalSize, bigOffsetEnd)
 	totalSize.Add(totalSize, lengthBig)
 	if totalSize.BitLen() > 63 {
-		return 0, 0, fmt.Errorf("abi length larger than int64: %v", totalSize)
+		return 0, 0, fmt.Errorf("abi: length larger than int64: %v", totalSize)
 	}
 
 	if totalSize.Cmp(outputLength) > 0 {


### PR DESCRIPTION
This PR introduces an `abi.UnpackIntoMap` method which can be used to unpack an event without having had to first define a `struct` with matching field names to unpack it into. This allows for dynamic unpacking of event logs using a contract's ABI. Additionally, since the purpose of this method is to trade some type safety for flexibility, this method uses a `bind.parseTopicsIntoMap` function which allows for unpacking of event logs which have an indexed string. 

While it makes sense to me that we want to exclude strings and other types of unbound size from `topics`, there is nothing stopping this from being implemented on the contract side of things (and it [is](https://etherscan.io/address/0x6090A6e47849629b7245Dfa1Ca21D94cd15878Ef#code)) so I think it would be good to have a method to handle this case. Again, since this PR creates a new method for unpacking, we can introduce this capability without weakening the safety of the `abi.Unpack` method.