### PR TITLE
p2p/discover: added logging to match discv5

### DIFF
--- a/p2p/discover/udp.go
+++ b/p2p/discover/udp.go
@@ -261,6 +261,7 @@ func newUDP(c conn, ln *enode.LocalNode, cfg Config) (*Table, *udp, error) {
 		return nil, nil, err
 	}
 	udp.tab = tab
+	log.Info("UDP listener up", "net", tab.self())
 
 	udp.wg.Add(2)
 	go udp.loop()


### PR DESCRIPTION
https://github.com/ethereum/go-ethereum/issues/18252

Steps to Reproduce
```
 bootnode --genkey boot.key
 bootnode --nodekey boot.key
 bootnode --nodekey boot.key -v5
```

When bootnode is called it doesn't log the Enode, however when v5 is enabled it does. It appears that `discv5.ListenUDP(...)` containing logging and `discover.ListenUDP(...)` does not.

This PR simply adds the same logging to the `discover.ListenUDP()` function which should resolve the mentioned issue