### PR TITLE
swarm: Fix mockNetFetcher data races in storage

### DIFF
--- a/swarm/storage/netstore_test.go
+++ b/swarm/storage/netstore_test.go
@@ -43,6 +43,7 @@ type mockNetFetcher struct {
 	quit            <-chan struct{}
 	ctx             context.Context
 	hopCounts       []uint8
+	mu              sync.Mutex
 }
 
 func (m *mockNetFetcher) Offer(ctx context.Context, source *enode.ID) {
@@ -51,6 +52,9 @@ func (m *mockNetFetcher) Offer(ctx context.Context, source *enode.ID) {
 }
 
 func (m *mockNetFetcher) Request(ctx context.Context, hopCount uint8) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
 	m.requestCalled = true
 	var peers []Address
 	m.peers.Range(func(key interface{}, _ interface{}) bool {


### PR DESCRIPTION
This PR fixes ethersphere/go-ethereum#1117. It just adds a mutex to protect mockNetFetcher on change. This is a fetcher used only in tests, so no performance degradation in production is introduced. The change is small and simple, so the PR is submitted directly to the ethereum repo.