### PR TITLE
p2p/simulations: fix data race on swarm/network/simulations

### DIFF
--- a/p2p/simulations/events.go
+++ b/p2p/simulations/events.go
@@ -73,8 +73,7 @@ func NewEvent(v interface{}) *Event {
 	switch v := v.(type) {
 	case *Node:
 		event.Type = EventTypeNode
-		node := *v
-		event.Node = &node
+		event.Node = v
 	case *Conn:
 		event.Type = EventTypeConn
 		conn := *v

--- a/p2p/simulations/events.go
+++ b/p2p/simulations/events.go
@@ -73,7 +73,8 @@ func NewEvent(v interface{}) *Event {
 	switch v := v.(type) {
 	case *Node:
 		event.Type = EventTypeNode
-		event.Node = v
+		node := *v
+		event.Node = &node
 	case *Conn:
 		event.Type = EventTypeConn
 		conn := *v


### PR DESCRIPTION
This PR addresses a data race caused by copying the node struct when creating a node event. This copy is done without synchronisation thus causing the data race warning.
Passing the underlying pointer instead eliminates the warning.

fixes https://github.com/ethersphere/go-ethereum/issues/1110