### PR TITLE
github: reinstate swarm codeowners to p2p package submodules

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -10,4 +10,6 @@ les/                            @zsfelfoldi
 light/                          @zsfelfoldi
 mobile/                         @karalabe
 p2p/                            @fjl @zsfelfoldi
+p2p/simulations                 @zelig @nonsense @janos
+p2p/protocols                   @zelig @nonsense @janos
 whisper/                        @gballet @gluk256


### PR DESCRIPTION
This PR reinstates swarm codeowners to the `p2p` package submodules that are managed by the team