### PR TITLE
p2p/discover: `deleteInBucket` does not remove an entry from `replacements`.

### DIFF
--- a/p2p/discover/table.go
+++ b/p2p/discover/table.go
@@ -691,6 +691,7 @@ func (tab *Table) bumpOrAdd(b *bucket, n *node) bool {
 
 func (tab *Table) deleteInBucket(b *bucket, n *node) {
 	b.entries = deleteNode(b.entries, n)
+	b.replacements = deleteNode(b.replacements, n)
 	tab.removeIP(b, n.IP())
 }
 


### PR DESCRIPTION
I found that `deleteInBucket` did not delete an entry as a parameter from replacements.
Generally we delete nodes from buckets when the node does not work properly.
So we expect that `deleteInBucket` deletes everything related with the bad node.