### PR TITLE
rpc: improve error message for bad url scheme

### DIFF
--- a/rpc/client.go
+++ b/rpc/client.go
@@ -177,7 +177,7 @@ func DialContext(ctx context.Context, rawurl string) (*Client, error) {
 	case "":
 		return DialIPC(ctx, rawurl)
 	default:
-		return nil, fmt.Errorf("no known transport for URL scheme %q", u.Scheme)
+		return nil, fmt.Errorf("unknown transport for URL scheme %q", u.Scheme)
 	}
 }
 


### PR DESCRIPTION
Replace `no known` with `unknown`