### PR TITLE
accounts/abi: allow interface as the destination

### DIFF
--- a/accounts/abi/reflect.go
+++ b/accounts/abi/reflect.go
@@ -74,7 +74,7 @@ func mustArrayToByteSlice(value reflect.Value) reflect.Value {
 func set(dst, src reflect.Value) error {
 	dstType, srcType := dst.Type(), src.Type()
 	switch {
-	case dstType.Kind() == reflect.Interface:
+	case dstType.Kind() == reflect.Interface && dst.Elem().IsValid():
 		return set(dst.Elem(), src)
 	case dstType.Kind() == reflect.Ptr && dstType.Elem() != derefbigT:
 		return set(dst.Elem(), src)

--- a/accounts/abi/unpack_test.go
+++ b/accounts/abi/unpack_test.go
@@ -512,6 +512,11 @@ func TestMethodMultiReturn(t *testing.T) {
 		Int    *big.Int
 	}
 
+	newInterfaceSlice := func(len int) interface{} {
+		slice := make([]interface{}, len)
+		return &slice
+	}
+
 	abi, data, expected := methodMultiReturn(require.New(t))
 	bigint := new(big.Int)
 	var testCases = []struct {
@@ -539,6 +544,16 @@ func TestMethodMultiReturn(t *testing.T) {
 		&[2]interface{}{&expected.Int, &expected.String},
 		"",
 		"Can unpack into an array",
+	}, {
+		&[2]interface{}{},
+		&[2]interface{}{expected.Int, expected.String},
+		"",
+		"Can unpack into interface array",
+	}, {
+		newInterfaceSlice(2),
+		&[]interface{}{expected.Int, expected.String},
+		"",
+		"Can unpack into interface slice",
 	}, {
 		&[]interface{}{new(int), new(int)},
 		&[]interface{}{&expected.Int, &expected.String},


### PR DESCRIPTION
In this PR, interface as the abi unpack destination is allowed. 

It means user could pass a pointer to an empty interface (v) to the `abi.Unpack(v interface{}, data []byte)` method in order to unpack values returned from contract method calls **without needing to know the type of the returned values beforehand**(Copy from #18480 issue description).

Also this PR fix #18480