### PR TITLE
p2p, swarm: remove unused testing.T in protocol tester

### DIFF
--- a/p2p/protocols/protocol_test.go
+++ b/p2p/protocols/protocol_test.go
@@ -142,9 +142,9 @@ func newProtocol(pp *p2ptest.TestPeerPool) func(*p2p.Peer, p2p.MsgReadWriter) er
 	}
 }
 
-func protocolTester(t *testing.T, pp *p2ptest.TestPeerPool) *p2ptest.ProtocolTester {
+func protocolTester(pp *p2ptest.TestPeerPool) *p2ptest.ProtocolTester {
 	conf := adapters.RandomNodeConfig()
-	return p2ptest.NewProtocolTester(t, conf.ID, 2, newProtocol(pp))
+	return p2ptest.NewProtocolTester(conf.ID, 2, newProtocol(pp))
 }
 
 func protoHandshakeExchange(id enode.ID, proto *protoHandshake) []p2ptest.Exchange {
@@ -173,7 +173,7 @@ func protoHandshakeExchange(id enode.ID, proto *protoHandshake) []p2ptest.Exchan
 
 func runProtoHandshake(t *testing.T, proto *protoHandshake, errs ...error) {
 	pp := p2ptest.NewTestPeerPool()
-	s := protocolTester(t, pp)
+	s := protocolTester(pp)
 	// TODO: make this more than one handshake
 	node := s.Nodes[0]
 	if err := s.TestExchanges(protoHandshakeExchange(node.ID(), proto)...); err != nil {
@@ -250,7 +250,7 @@ func TestProtocolHook(t *testing.T) {
 	}
 
 	conf := adapters.RandomNodeConfig()
-	tester := p2ptest.NewProtocolTester(t, conf.ID, 2, runFunc)
+	tester := p2ptest.NewProtocolTester(conf.ID, 2, runFunc)
 	err := tester.TestExchanges(p2ptest.Exchange{
 		Expects: []p2ptest.Expect{
 			{
@@ -389,7 +389,7 @@ func moduleHandshakeExchange(id enode.ID, resp uint) []p2ptest.Exchange {
 
 func runModuleHandshake(t *testing.T, resp uint, errs ...error) {
 	pp := p2ptest.NewTestPeerPool()
-	s := protocolTester(t, pp)
+	s := protocolTester(pp)
 	node := s.Nodes[0]
 	if err := s.TestExchanges(protoHandshakeExchange(node.ID(), &protoHandshake{42, "420"})...); err != nil {
 		t.Fatal(err)
@@ -469,7 +469,7 @@ func testMultiPeerSetup(a, b enode.ID) []p2ptest.Exchange {
 
 func runMultiplePeers(t *testing.T, peer int, errs ...error) {
 	pp := p2ptest.NewTestPeerPool()
-	s := protocolTester(t, pp)
+	s := protocolTester(pp)
 
 	if err := s.TestExchanges(testMultiPeerSetup(s.Nodes[0].ID(), s.Nodes[1].ID())...); err != nil {
 		t.Fatal(err)

--- a/p2p/testing/protocoltester.go
+++ b/p2p/testing/protocoltester.go
@@ -30,7 +30,6 @@ import (
 	"io/ioutil"
 	"strings"
 	"sync"
-	"testing"
 
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/node"
@@ -52,7 +51,7 @@ type ProtocolTester struct {
 // NewProtocolTester constructs a new ProtocolTester
 // it takes as argument the pivot node id, the number of dummy peers and the
 // protocol run function called on a peer connection by the p2p server
-func NewProtocolTester(t *testing.T, id enode.ID, n int, run func(*p2p.Peer, p2p.MsgReadWriter) error) *ProtocolTester {
+func NewProtocolTester(id enode.ID, n int, run func(*p2p.Peer, p2p.MsgReadWriter) error) *ProtocolTester {
 	services := adapters.Services{
 		"test": func(ctx *adapters.ServiceContext) (node.Service, error) {
 			return &testNode{run}, nil

--- a/swarm/network/protocol_test.go
+++ b/swarm/network/protocol_test.go
@@ -82,7 +82,7 @@ func newBzzBaseTester(t *testing.T, n int, addr *BzzAddr, spec *protocols.Spec, 
 		return srv(&BzzPeer{Peer: protocols.NewPeer(p, rw, spec), BzzAddr: NewAddr(p.Node())})
 	}
 
-	s := p2ptest.NewProtocolTester(t, addr.ID(), n, protocol)
+	s := p2ptest.NewProtocolTester(addr.ID(), n, protocol)
 
 	for _, node := range s.Nodes {
 		cs[node.ID().String()] = make(chan bool)
@@ -115,9 +115,9 @@ func newBzz(addr *BzzAddr, lightNode bool) *Bzz {
 	return bzz
 }
 
-func newBzzHandshakeTester(t *testing.T, n int, addr *BzzAddr, lightNode bool) *bzzTester {
+func newBzzHandshakeTester(n int, addr *BzzAddr, lightNode bool) *bzzTester {
 	bzz := newBzz(addr, lightNode)
-	pt := p2ptest.NewProtocolTester(t, addr.ID(), n, bzz.runBzz)
+	pt := p2ptest.NewProtocolTester(addr.ID(), n, bzz.runBzz)
 
 	return &bzzTester{
 		addr:           addr,
@@ -165,7 +165,7 @@ func correctBzzHandshake(addr *BzzAddr, lightNode bool) *HandshakeMsg {
 func TestBzzHandshakeNetworkIDMismatch(t *testing.T) {
 	lightNode := false
 	addr := RandomAddr()
-	s := newBzzHandshakeTester(t, 1, addr, lightNode)
+	s := newBzzHandshakeTester(1, addr, lightNode)
 	node := s.Nodes[0]
 
 	err := s.testHandshake(
@@ -182,7 +182,7 @@ func TestBzzHandshakeNetworkIDMismatch(t *testing.T) {
 func TestBzzHandshakeVersionMismatch(t *testing.T) {
 	lightNode := false
 	addr := RandomAddr()
-	s := newBzzHandshakeTester(t, 1, addr, lightNode)
+	s := newBzzHandshakeTester(1, addr, lightNode)
 	node := s.Nodes[0]
 
 	err := s.testHandshake(
@@ -199,7 +199,7 @@ func TestBzzHandshakeVersionMismatch(t *testing.T) {
 func TestBzzHandshakeSuccess(t *testing.T) {
 	lightNode := false
 	addr := RandomAddr()
-	s := newBzzHandshakeTester(t, 1, addr, lightNode)
+	s := newBzzHandshakeTester(1, addr, lightNode)
 	node := s.Nodes[0]
 
 	err := s.testHandshake(
@@ -224,7 +224,7 @@ func TestBzzHandshakeLightNode(t *testing.T) {
 	for _, test := range lightNodeTests {
 		t.Run(test.name, func(t *testing.T) {
 			randomAddr := RandomAddr()
-			pt := newBzzHandshakeTester(t, 1, randomAddr, false)
+			pt := newBzzHandshakeTester(1, randomAddr, false)
 			node := pt.Nodes[0]
 			addr := NewAddr(node)
 

--- a/swarm/network/protocol_test.go
+++ b/swarm/network/protocol_test.go
@@ -226,7 +226,7 @@ func TestBzzHandshakeLightNode(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			randomAddr := RandomAddr()
 			pt := newBzzHandshakeTester(1, randomAddr, false)
-      
+
 			node := pt.Nodes[0]
 			addr := NewAddr(node)
 

--- a/swarm/network/stream/common_test.go
+++ b/swarm/network/stream/common_test.go
@@ -27,7 +27,6 @@ import (
 	"os"
 	"strings"
 	"sync/atomic"
-	"testing"
 	"time"
 
 	"github.com/ethereum/go-ethereum/log"
@@ -67,7 +66,7 @@ func init() {
 	log.Root().SetHandler(log.LvlFilterHandler(log.Lvl(*loglevel), log.StreamHandler(colorable.NewColorableStderr(), log.TerminalFormat(true))))
 }
 
-func newStreamerTester(t *testing.T, registryOptions *RegistryOptions) (*p2ptest.ProtocolTester, *Registry, *storage.LocalStore, func(), error) {
+func newStreamerTester(registryOptions *RegistryOptions) (*p2ptest.ProtocolTester, *Registry, *storage.LocalStore, func(), error) {
 	// setup
 	addr := network.RandomAddr() // tested peers peer address
 	to := network.NewKademlia(addr.OAddr, network.NewKadParams())
@@ -102,7 +101,7 @@ func newStreamerTester(t *testing.T, registryOptions *RegistryOptions) (*p2ptest
 		streamer.Close()
 		removeDataDir()
 	}
-	protocolTester := p2ptest.NewProtocolTester(t, addr.ID(), 1, streamer.runProtocol)
+	protocolTester := p2ptest.NewProtocolTester(addr.ID(), 1, streamer.runProtocol)
 
 	err = waitForPeers(streamer, 1*time.Second, 1)
 	if err != nil {

--- a/swarm/network/stream/delivery_test.go
+++ b/swarm/network/stream/delivery_test.go
@@ -48,7 +48,7 @@ func TestStreamerRetrieveRequest(t *testing.T) {
 		Retrieval: RetrievalClientOnly,
 		Syncing:   SyncingDisabled,
 	}
-	tester, streamer, _, teardown, err := newStreamerTester(t, regOpts)
+	tester, streamer, _, teardown, err := newStreamerTester(regOpts)
 	defer teardown()
 	if err != nil {
 		t.Fatal(err)
@@ -97,7 +97,7 @@ func TestStreamerRetrieveRequest(t *testing.T) {
 //Test requesting a chunk from a peer then issuing a "empty" OfferedHashesMsg (no hashes available yet)
 //Should time out as the peer does not have the chunk (no syncing happened previously)
 func TestStreamerUpstreamRetrieveRequestMsgExchangeWithoutStore(t *testing.T) {
-	tester, streamer, _, teardown, err := newStreamerTester(t, &RegistryOptions{
+	tester, streamer, _, teardown, err := newStreamerTester(&RegistryOptions{
 		Retrieval: RetrievalEnabled,
 		Syncing:   SyncingDisabled, //do no syncing
 	})
@@ -169,7 +169,7 @@ func TestStreamerUpstreamRetrieveRequestMsgExchangeWithoutStore(t *testing.T) {
 // upstream request server receives a retrieve Request and responds with
 // offered hashes or delivery if skipHash is set to true
 func TestStreamerUpstreamRetrieveRequestMsgExchange(t *testing.T) {
-	tester, streamer, localStore, teardown, err := newStreamerTester(t, &RegistryOptions{
+	tester, streamer, localStore, teardown, err := newStreamerTester(&RegistryOptions{
 		Retrieval: RetrievalEnabled,
 		Syncing:   SyncingDisabled,
 	})
@@ -359,7 +359,7 @@ func TestRequestFromPeersWithLightNode(t *testing.T) {
 }
 
 func TestStreamerDownstreamChunkDeliveryMsgExchange(t *testing.T) {
-	tester, streamer, localStore, teardown, err := newStreamerTester(t, &RegistryOptions{
+	tester, streamer, localStore, teardown, err := newStreamerTester(&RegistryOptions{
 		Retrieval: RetrievalDisabled,
 		Syncing:   SyncingDisabled,
 	})

--- a/swarm/network/stream/lightnode_test.go
+++ b/swarm/network/stream/lightnode_test.go
@@ -28,7 +28,7 @@ func TestLigthnodeRetrieveRequestWithRetrieve(t *testing.T) {
 		Retrieval: RetrievalClientOnly,
 		Syncing:   SyncingDisabled,
 	}
-	tester, _, _, teardown, err := newStreamerTester(t, registryOptions)
+	tester, _, _, teardown, err := newStreamerTester(registryOptions)
 	defer teardown()
 	if err != nil {
 		t.Fatal(err)
@@ -67,7 +67,7 @@ func TestLigthnodeRetrieveRequestWithoutRetrieve(t *testing.T) {
 		Retrieval: RetrievalDisabled,
 		Syncing:   SyncingDisabled,
 	}
-	tester, _, _, teardown, err := newStreamerTester(t, registryOptions)
+	tester, _, _, teardown, err := newStreamerTester(registryOptions)
 	defer teardown()
 	if err != nil {
 		t.Fatal(err)
@@ -111,7 +111,7 @@ func TestLigthnodeRequestSubscriptionWithSync(t *testing.T) {
 		Retrieval: RetrievalDisabled,
 		Syncing:   SyncingRegisterOnly,
 	}
-	tester, _, _, teardown, err := newStreamerTester(t, registryOptions)
+	tester, _, _, teardown, err := newStreamerTester(registryOptions)
 	defer teardown()
 	if err != nil {
 		t.Fatal(err)
@@ -156,7 +156,7 @@ func TestLigthnodeRequestSubscriptionWithoutSync(t *testing.T) {
 		Retrieval: RetrievalDisabled,
 		Syncing:   SyncingDisabled,
 	}
-	tester, _, _, teardown, err := newStreamerTester(t, registryOptions)
+	tester, _, _, teardown, err := newStreamerTester(registryOptions)
 	defer teardown()
 	if err != nil {
 		t.Fatal(err)

--- a/swarm/network/stream/streamer_test.go
+++ b/swarm/network/stream/streamer_test.go
@@ -34,7 +34,7 @@ import (
 )
 
 func TestStreamerSubscribe(t *testing.T) {
-	tester, streamer, _, teardown, err := newStreamerTester(t, nil)
+	tester, streamer, _, teardown, err := newStreamerTester(nil)
 	defer teardown()
 	if err != nil {
 		t.Fatal(err)
@@ -48,7 +48,7 @@ func TestStreamerSubscribe(t *testing.T) {
 }
 
 func TestStreamerRequestSubscription(t *testing.T) {
-	tester, streamer, _, teardown, err := newStreamerTester(t, nil)
+	tester, streamer, _, teardown, err := newStreamerTester(nil)
 	defer teardown()
 	if err != nil {
 		t.Fatal(err)
@@ -139,7 +139,7 @@ func (self *testServer) Close() {
 }
 
 func TestStreamerDownstreamSubscribeUnsubscribeMsgExchange(t *testing.T) {
-	tester, streamer, _, teardown, err := newStreamerTester(t, nil)
+	tester, streamer, _, teardown, err := newStreamerTester(nil)
 	defer teardown()
 	if err != nil {
 		t.Fatal(err)
@@ -232,7 +232,7 @@ func TestStreamerDownstreamSubscribeUnsubscribeMsgExchange(t *testing.T) {
 }
 
 func TestStreamerUpstreamSubscribeUnsubscribeMsgExchange(t *testing.T) {
-	tester, streamer, _, teardown, err := newStreamerTester(t, nil)
+	tester, streamer, _, teardown, err := newStreamerTester(nil)
 	defer teardown()
 	if err != nil {
 		t.Fatal(err)
@@ -299,7 +299,7 @@ func TestStreamerUpstreamSubscribeUnsubscribeMsgExchange(t *testing.T) {
 }
 
 func TestStreamerUpstreamSubscribeUnsubscribeMsgExchangeLive(t *testing.T) {
-	tester, streamer, _, teardown, err := newStreamerTester(t, nil)
+	tester, streamer, _, teardown, err := newStreamerTester(nil)
 	defer teardown()
 	if err != nil {
 		t.Fatal(err)
@@ -365,7 +365,7 @@ func TestStreamerUpstreamSubscribeUnsubscribeMsgExchangeLive(t *testing.T) {
 }
 
 func TestStreamerUpstreamSubscribeErrorMsgExchange(t *testing.T) {
-	tester, streamer, _, teardown, err := newStreamerTester(t, nil)
+	tester, streamer, _, teardown, err := newStreamerTester(nil)
 	defer teardown()
 	if err != nil {
 		t.Fatal(err)
@@ -409,7 +409,7 @@ func TestStreamerUpstreamSubscribeErrorMsgExchange(t *testing.T) {
 }
 
 func TestStreamerUpstreamSubscribeLiveAndHistory(t *testing.T) {
-	tester, streamer, _, teardown, err := newStreamerTester(t, nil)
+	tester, streamer, _, teardown, err := newStreamerTester(nil)
 	defer teardown()
 	if err != nil {
 		t.Fatal(err)
@@ -472,7 +472,7 @@ func TestStreamerUpstreamSubscribeLiveAndHistory(t *testing.T) {
 }
 
 func TestStreamerDownstreamCorruptHashesMsgExchange(t *testing.T) {
-	tester, streamer, _, teardown, err := newStreamerTester(t, nil)
+	tester, streamer, _, teardown, err := newStreamerTester(nil)
 	defer teardown()
 	if err != nil {
 		t.Fatal(err)
@@ -537,7 +537,7 @@ func TestStreamerDownstreamCorruptHashesMsgExchange(t *testing.T) {
 }
 
 func TestStreamerDownstreamOfferedHashesMsgExchange(t *testing.T) {
-	tester, streamer, _, teardown, err := newStreamerTester(t, nil)
+	tester, streamer, _, teardown, err := newStreamerTester(nil)
 	defer teardown()
 	if err != nil {
 		t.Fatal(err)
@@ -636,7 +636,7 @@ func TestStreamerDownstreamOfferedHashesMsgExchange(t *testing.T) {
 }
 
 func TestStreamerRequestSubscriptionQuitMsgExchange(t *testing.T) {
-	tester, streamer, _, teardown, err := newStreamerTester(t, nil)
+	tester, streamer, _, teardown, err := newStreamerTester(nil)
 	defer teardown()
 	if err != nil {
 		t.Fatal(err)
@@ -769,7 +769,7 @@ func TestStreamerRequestSubscriptionQuitMsgExchange(t *testing.T) {
 // leaving place for new streams.
 func TestMaxPeerServersWithUnsubscribe(t *testing.T) {
 	var maxPeerServers = 6
-	tester, streamer, _, teardown, err := newStreamerTester(t, &RegistryOptions{
+	tester, streamer, _, teardown, err := newStreamerTester(&RegistryOptions{
 		Retrieval:      RetrievalDisabled,
 		Syncing:        SyncingDisabled,
 		MaxPeerServers: maxPeerServers,
@@ -845,7 +845,7 @@ func TestMaxPeerServersWithUnsubscribe(t *testing.T) {
 // error message exchange.
 func TestMaxPeerServersWithoutUnsubscribe(t *testing.T) {
 	var maxPeerServers = 6
-	tester, streamer, _, teardown, err := newStreamerTester(t, &RegistryOptions{
+	tester, streamer, _, teardown, err := newStreamerTester(&RegistryOptions{
 		MaxPeerServers: maxPeerServers,
 	})
 	defer teardown()
@@ -930,7 +930,7 @@ func TestMaxPeerServersWithoutUnsubscribe(t *testing.T) {
 //TestHasPriceImplementation is to check that the Registry has a
 //`Price` interface implementation
 func TestHasPriceImplementation(t *testing.T) {
-	_, r, _, teardown, err := newStreamerTester(t, &RegistryOptions{
+	_, r, _, teardown, err := newStreamerTester(&RegistryOptions{
 		Retrieval: RetrievalDisabled,
 		Syncing:   SyncingDisabled,
 	})


### PR DESCRIPTION
This PR removes an unused `testing.T` parameter from the p2p protocol tester