### PR TITLE
.github: add @janos as codeowner for p2p/simulations and p2p/protocols

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -10,6 +10,6 @@ les/                            @zsfelfoldi
 light/                          @zsfelfoldi
 mobile/                         @karalabe
 p2p/                            @fjl @zsfelfoldi
-p2p/simulations                 @zelig @nonsense
-p2p/protocols                   @zelig @nonsense
+p2p/simulations                 @zelig @nonsense @janos
+p2p/protocols                   @zelig @nonsense @janos
 whisper/                        @gballet @gluk256


### PR DESCRIPTION
I am adding myself to the codeowners of p2p/simulations and p2p/protocols packages.