### PR TITLE
cmd: allow empty bootnodes flag override

### DIFF
--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -731,11 +731,13 @@ func setBootstrapNodes(ctx *cli.Context, cfg *p2p.Config) {
 
 	cfg.BootstrapNodes = make([]*enode.Node, 0, len(urls))
 	for _, url := range urls {
-		node, err := enode.ParseV4(url)
-		if err != nil {
-			log.Crit("Bootstrap URL invalid", "enode", url, "err", err)
+		if url != "" {
+			node, err := enode.ParseV4(url)
+			if err != nil {
+				log.Crit("Bootstrap URL invalid", "enode", url, "err", err)
+			}
+			cfg.BootstrapNodes = append(cfg.BootstrapNodes, node)
 		}
-		cfg.BootstrapNodes = append(cfg.BootstrapNodes, node)
 	}
 }
 


### PR DESCRIPTION
This PR is adding a `if url != ""` check, prior to trying to parse the `enode` from the command-line arguments.

Currently there is no way to specify that we want to have an empty bootnodes list in the resulting `cfg.BootstrapNodes` - you can either override the bootnodes list with entries, or use the provided defaults, but never use an empty list.

When we start a new deployment, and start a new bootnode, we might want it to not try to connect to any peers.