### PR TITLE
Fix race in TestLDBStoreCollectGarbage and disable flaky testLDBStoreRemoveThenCollectGarbage

### DIFF
--- a/swarm/storage/ldbstore_test.go
+++ b/swarm/storage/ldbstore_test.go
@@ -465,6 +465,7 @@ func TestLDBStoreAddRemove(t *testing.T) {
 }
 
 func testLDBStoreRemoveThenCollectGarbage(t *testing.T) {
+	t.Skip("flaky with -race flag")
 
 	params := strings.Split(t.Name(), "/")
 	capacity, err := strconv.Atoi(params[2])
@@ -783,6 +784,9 @@ func TestCleanIndex(t *testing.T) {
 	}
 }
 
+// Note: waitGc does not guarantee that we wait 1 GC round; it only
+// guarantees that if the GC is running we wait for that run to finish
+// ticket: https://github.com/ethersphere/go-ethereum/issues/1151
 func waitGc(ldb *LDBStore) {
 	<-ldb.gc.runC
 	ldb.gc.runC <- struct{}{}

--- a/swarm/storage/ldbstore_test.go
+++ b/swarm/storage/ldbstore_test.go
@@ -388,7 +388,9 @@ func testLDBStoreCollectGarbage(t *testing.T) {
 			t.Fatal(err.Error())
 		}
 		allChunks = append(allChunks, chunks...)
+		ldb.lock.Lock()
 		log.Debug("ldbstore", "entrycnt", ldb.entryCnt, "accesscnt", ldb.accessCnt, "cap", capacity, "n", n)
+		ldb.lock.Unlock()
 
 		ctx, cancel := context.WithTimeout(context.Background(), time.Second*10)
 		defer cancel()
@@ -537,7 +539,9 @@ func testLDBStoreRemoveThenCollectGarbage(t *testing.T) {
 		remaining -= putCount
 		for putCount > 0 {
 			ldb.Put(context.TODO(), chunks[puts])
+			ldb.lock.Lock()
 			log.Debug("ldbstore", "entrycnt", ldb.entryCnt, "accesscnt", ldb.accessCnt, "cap", capacity, "n", n, "puts", puts, "remaining", remaining, "roundtarget", roundTarget)
+			ldb.lock.Unlock()
 			puts++
 			putCount--
 		}

--- a/swarm/storage/ldbstore_test.go
+++ b/swarm/storage/ldbstore_test.go
@@ -388,9 +388,9 @@ func testLDBStoreCollectGarbage(t *testing.T) {
 			t.Fatal(err.Error())
 		}
 		allChunks = append(allChunks, chunks...)
-		ldb.lock.Lock()
+		ldb.lock.RLock()
 		log.Debug("ldbstore", "entrycnt", ldb.entryCnt, "accesscnt", ldb.accessCnt, "cap", capacity, "n", n)
-		ldb.lock.Unlock()
+		ldb.lock.RUnlock()
 
 		ctx, cancel := context.WithTimeout(context.Background(), time.Second*10)
 		defer cancel()
@@ -539,9 +539,9 @@ func testLDBStoreRemoveThenCollectGarbage(t *testing.T) {
 		remaining -= putCount
 		for putCount > 0 {
 			ldb.Put(context.TODO(), chunks[puts])
-			ldb.lock.Lock()
+			ldb.lock.RLock()
 			log.Debug("ldbstore", "entrycnt", ldb.entryCnt, "accesscnt", ldb.accessCnt, "cap", capacity, "n", n, "puts", puts, "remaining", remaining, "roundtarget", roundTarget)
-			ldb.lock.Unlock()
+			ldb.lock.RUnlock()
 			puts++
 			putCount--
 		}

--- a/swarm/storage/ldbstore_test.go
+++ b/swarm/storage/ldbstore_test.go
@@ -26,7 +26,6 @@ import (
 	"strconv"
 	"strings"
 	"testing"
-	"time"
 
 	"github.com/ethereum/go-ethereum/common"
 	ch "github.com/ethereum/go-ethereum/swarm/chunk"
@@ -392,9 +391,7 @@ func testLDBStoreCollectGarbage(t *testing.T) {
 		log.Debug("ldbstore", "entrycnt", ldb.entryCnt, "accesscnt", ldb.accessCnt, "cap", capacity, "n", n)
 		ldb.lock.RUnlock()
 
-		ctx, cancel := context.WithTimeout(context.Background(), time.Second*10)
-		defer cancel()
-		waitGc(ctx, ldb)
+		waitGc(ldb)
 	}
 
 	// attempt gets on all put chunks
@@ -498,9 +495,7 @@ func testLDBStoreRemoveThenCollectGarbage(t *testing.T) {
 		}
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second*10)
-	defer cancel()
-	waitGc(ctx, ldb)
+	waitGc(ldb)
 
 	// delete all chunks
 	// (only count the ones actually deleted, the rest will have been gc'd)
@@ -546,9 +541,7 @@ func testLDBStoreRemoveThenCollectGarbage(t *testing.T) {
 			putCount--
 		}
 
-		ctx, cancel := context.WithTimeout(context.Background(), time.Second*10)
-		defer cancel()
-		waitGc(ctx, ldb)
+		waitGc(ldb)
 	}
 
 	// expect first surplus chunks to be missing, because they have the smallest access value
@@ -601,9 +594,7 @@ func TestLDBStoreCollectGarbageAccessUnlikeIndex(t *testing.T) {
 	}
 
 	// wait for garbage collection to kick in on the responsible actor
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second*10)
-	defer cancel()
-	waitGc(ctx, ldb)
+	waitGc(ldb)
 
 	var missing int
 	for i, ch := range chunks[2 : capacity/2] {
@@ -792,7 +783,7 @@ func TestCleanIndex(t *testing.T) {
 	}
 }
 
-func waitGc(ctx context.Context, ldb *LDBStore) {
+func waitGc(ldb *LDBStore) {
 	<-ldb.gc.runC
 	ldb.gc.runC <- struct{}{}
 }


### PR DESCRIPTION
fixes ethersphere/go-ethereum#1118

`TestLDBStoreCollectGarbage` data race fixed with locks (only needed in tests)

`testLDBStoreRemoveThenCollectGarbage` fails unreliably when run with `-race` flag. As waitGC() does not work as expected, it might just continue (not block) if GC is not
running already. We might end up with or without a chunk, depending
on goroutine scheduling. As localstore rewrite is at the finish line and this blocks
ethersphere#741 => Skip.
