### PR TITLE
cmd/utils: allow for multiple influxdb flags

### DIFF
--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -38,7 +38,7 @@ import (
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/metrics"
 	"github.com/ethereum/go-ethereum/node"
-	"gopkg.in/urfave/cli.v1"
+	cli "gopkg.in/urfave/cli.v1"
 )
 
 const (
@@ -173,7 +173,7 @@ var (
 		utils.MetricsInfluxDBDatabaseFlag,
 		utils.MetricsInfluxDBUsernameFlag,
 		utils.MetricsInfluxDBPasswordFlag,
-		utils.MetricsInfluxDBHostTagFlag,
+		utils.MetricsInfluxDBTagsFlag,
 	}
 )
 

--- a/cmd/geth/usage.go
+++ b/cmd/geth/usage.go
@@ -26,7 +26,7 @@ import (
 
 	"github.com/ethereum/go-ethereum/cmd/utils"
 	"github.com/ethereum/go-ethereum/internal/debug"
-	"gopkg.in/urfave/cli.v1"
+	cli "gopkg.in/urfave/cli.v1"
 )
 
 // AppHelpTemplate is the test template for the default, global app help topic.
@@ -229,7 +229,7 @@ var AppHelpFlagGroups = []flagGroup{
 			utils.MetricsInfluxDBDatabaseFlag,
 			utils.MetricsInfluxDBUsernameFlag,
 			utils.MetricsInfluxDBPasswordFlag,
-			utils.MetricsInfluxDBHostTagFlag,
+			utils.MetricsInfluxDBTagsFlag,
 		},
 	},
 	{

--- a/cmd/swarm/swarm-smoke/main.go
+++ b/cmd/swarm/swarm-smoke/main.go
@@ -130,7 +130,7 @@ func main() {
 		swarmmetrics.MetricsInfluxDBDatabaseFlag,
 		swarmmetrics.MetricsInfluxDBUsernameFlag,
 		swarmmetrics.MetricsInfluxDBPasswordFlag,
-		swarmmetrics.MetricsInfluxDBHostTagFlag,
+		swarmmetrics.MetricsInfluxDBTagsFlag,
 	}...)
 
 	app.Flags = append(app.Flags, tracing.Flags...)
@@ -183,13 +183,14 @@ func emitMetrics(ctx *cli.Context) error {
 			database = ctx.GlobalString(swarmmetrics.MetricsInfluxDBDatabaseFlag.Name)
 			username = ctx.GlobalString(swarmmetrics.MetricsInfluxDBUsernameFlag.Name)
 			password = ctx.GlobalString(swarmmetrics.MetricsInfluxDBPasswordFlag.Name)
-			hosttag  = ctx.GlobalString(swarmmetrics.MetricsInfluxDBHostTagFlag.Name)
+			tags     = ctx.GlobalString(swarmmetrics.MetricsInfluxDBTagsFlag.Name)
 		)
-		return influxdb.InfluxDBWithTagsOnce(gethmetrics.DefaultRegistry, endpoint, database, username, password, "swarm-smoke.", map[string]string{
-			"host":     hosttag,
-			"version":  gitCommit,
-			"filesize": fmt.Sprintf("%v", filesize),
-		})
+
+		tagsMap := utils.SplitTagsFlag(tags)
+		tagsMap["version"] = gitCommit
+		tagsMap["filesize"] = fmt.Sprintf("%v", filesize)
+
+		return influxdb.InfluxDBWithTagsOnce(gethmetrics.DefaultRegistry, endpoint, database, username, password, "swarm-smoke.", tagsMap)
 	}
 
 	return nil

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -1463,7 +1463,7 @@ func SetupMetrics(ctx *cli.Context) {
 		)
 
 		if enableExport {
-			tagsMap := splitTagsFlag(ctx.GlobalString(MetricsInfluxDBTagsFlag.Name))
+			tagsMap := SplitTagsFlag(ctx.GlobalString(MetricsInfluxDBTagsFlag.Name))
 
 			log.Info("Enabling metrics export to InfluxDB")
 
@@ -1472,7 +1472,7 @@ func SetupMetrics(ctx *cli.Context) {
 	}
 }
 
-func splitTagsFlag(tagsFlag string) map[string]string {
+func SplitTagsFlag(tagsFlag string) map[string]string {
 	tags := strings.Split(tagsFlag, ",")
 	tagsMap := map[string]string{}
 

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -58,7 +58,7 @@ import (
 	"github.com/ethereum/go-ethereum/p2p/netutil"
 	"github.com/ethereum/go-ethereum/params"
 	whisper "github.com/ethereum/go-ethereum/whisper/whisperv6"
-	"gopkg.in/urfave/cli.v1"
+	cli "gopkg.in/urfave/cli.v1"
 )
 
 var (
@@ -656,14 +656,14 @@ var (
 		Usage: "Password to authorize access to the database",
 		Value: "test",
 	}
-	// The `host` tag is part of every measurement sent to InfluxDB. Queries on tags are faster in InfluxDB.
-	// It is used so that we can group all nodes and average a measurement across all of them, but also so
-	// that we can select a specific node and inspect its measurements.
+	// Tags are part of every measurement sent to InfluxDB. Queries on tags are faster in InfluxDB.
+	// For example `host` tag could be used so that we can group all nodes and average a measurement
+	// across all of them, but also so that we can select a specific node and inspect its measurements.
 	// https://docs.influxdata.com/influxdb/v1.4/concepts/key_concepts/#tag-key
-	MetricsInfluxDBHostTagFlag = cli.StringFlag{
-		Name:  "metrics.influxdb.host.tag",
-		Usage: "InfluxDB `host` tag attached to all measurements",
-		Value: "localhost",
+	MetricsInfluxDBTagsFlag = cli.StringFlag{
+		Name:  "metrics.influxdb.tags",
+		Usage: "Comma-separated InfluxDB tags (key/values) attached to all measurements",
+		Value: "host=localhost",
 	}
 
 	EWASMInterpreterFlag = cli.StringFlag{
@@ -1460,16 +1460,33 @@ func SetupMetrics(ctx *cli.Context) {
 			database     = ctx.GlobalString(MetricsInfluxDBDatabaseFlag.Name)
 			username     = ctx.GlobalString(MetricsInfluxDBUsernameFlag.Name)
 			password     = ctx.GlobalString(MetricsInfluxDBPasswordFlag.Name)
-			hosttag      = ctx.GlobalString(MetricsInfluxDBHostTagFlag.Name)
 		)
 
 		if enableExport {
+			tagsMap := splitTagsFlag(ctx.GlobalString(MetricsInfluxDBTagsFlag.Name))
+
 			log.Info("Enabling metrics export to InfluxDB")
-			go influxdb.InfluxDBWithTags(metrics.DefaultRegistry, 10*time.Second, endpoint, database, username, password, "geth.", map[string]string{
-				"host": hosttag,
-			})
+
+			go influxdb.InfluxDBWithTags(metrics.DefaultRegistry, 10*time.Second, endpoint, database, username, password, "geth.", tagsMap)
 		}
 	}
+}
+
+func splitTagsFlag(tagsFlag string) map[string]string {
+	tags := strings.Split(tagsFlag, ",")
+	tagsMap := map[string]string{}
+
+	for _, t := range tags {
+		if t != "" {
+			kv := strings.Split(t, "=")
+
+			if len(kv) == 2 {
+				tagsMap[kv[0]] = kv[1]
+			}
+		}
+	}
+
+	return tagsMap
 }
 
 // MakeChainDatabase open an LevelDB using the flags passed to the client and will hard crash if it fails.

--- a/cmd/utils/flags_test.go
+++ b/cmd/utils/flags_test.go
@@ -1,0 +1,64 @@
+// Copyright 2019 The go-ethereum Authors
+// This file is part of go-ethereum.
+//
+// go-ethereum is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// go-ethereum is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with go-ethereum. If not, see <http://www.gnu.org/licenses/>.
+
+// Package utils contains internal helper functions for go-ethereum commands.
+package utils
+
+import (
+	"reflect"
+	"testing"
+)
+
+func Test_splitTagsFlag(t *testing.T) {
+	tests := []struct {
+		name string
+		args string
+		want map[string]string
+	}{
+		{
+			"2 tags case",
+			"host=localhost,bzzkey=123",
+			map[string]string{
+				"host":   "localhost",
+				"bzzkey": "123",
+			},
+		},
+		{
+			"1 tag case",
+			"host=localhost123",
+			map[string]string{
+				"host": "localhost123",
+			},
+		},
+		{
+			"empty case",
+			"",
+			map[string]string{},
+		},
+		{
+			"garbage",
+			"smth=smthelse=123",
+			map[string]string{},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := splitTagsFlag(tt.args); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("splitTagsFlag() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/cmd/utils/flags_test.go
+++ b/cmd/utils/flags_test.go
@@ -22,7 +22,7 @@ import (
 	"testing"
 )
 
-func Test_splitTagsFlag(t *testing.T) {
+func Test_SplitTagsFlag(t *testing.T) {
 	tests := []struct {
 		name string
 		args string
@@ -56,7 +56,7 @@ func Test_splitTagsFlag(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := splitTagsFlag(tt.args); !reflect.DeepEqual(got, tt.want) {
+			if got := SplitTagsFlag(tt.args); !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("splitTagsFlag() = %v, want %v", got, tt.want)
 			}
 		})

--- a/swarm/metrics/flags.go
+++ b/swarm/metrics/flags.go
@@ -23,7 +23,7 @@ import (
 	gethmetrics "github.com/ethereum/go-ethereum/metrics"
 	"github.com/ethereum/go-ethereum/metrics/influxdb"
 	"github.com/ethereum/go-ethereum/swarm/log"
-	"gopkg.in/urfave/cli.v1"
+	cli "gopkg.in/urfave/cli.v1"
 )
 
 var (
@@ -55,14 +55,14 @@ var (
 		Usage: "Metrics InfluxDB password",
 		Value: "",
 	}
-	// The `host` tag is part of every measurement sent to InfluxDB. Queries on tags are faster in InfluxDB.
-	// It is used so that we can group all nodes and average a measurement across all of them, but also so
-	// that we can select a specific node and inspect its measurements.
+	// Tags are part of every measurement sent to InfluxDB. Queries on tags are faster in InfluxDB.
+	// For example `host` tag could be used so that we can group all nodes and average a measurement
+	// across all of them, but also so that we can select a specific node and inspect its measurements.
 	// https://docs.influxdata.com/influxdb/v1.4/concepts/key_concepts/#tag-key
-	MetricsInfluxDBHostTagFlag = cli.StringFlag{
-		Name:  "metrics.influxdb.host.tag",
-		Usage: "Metrics InfluxDB `host` tag attached to all measurements",
-		Value: "localhost",
+	MetricsInfluxDBTagsFlag = cli.StringFlag{
+		Name:  "metrics.influxdb.tags",
+		Usage: "Comma-separated InfluxDB tags (key/values) attached to all measurements",
+		Value: "host=localhost",
 	}
 )
 
@@ -75,37 +75,34 @@ var Flags = []cli.Flag{
 	MetricsInfluxDBDatabaseFlag,
 	MetricsInfluxDBUsernameFlag,
 	MetricsInfluxDBPasswordFlag,
-	MetricsInfluxDBHostTagFlag,
+	MetricsInfluxDBTagsFlag,
 }
 
 func Setup(ctx *cli.Context) {
 	if gethmetrics.Enabled {
 		log.Info("Enabling swarm metrics collection")
 		var (
-			enableExport           = ctx.GlobalBool(MetricsEnableInfluxDBExportFlag.Name)
-			enableAccountingExport = ctx.GlobalBool(MetricsEnableInfluxDBAccountingExportFlag.Name)
 			endpoint               = ctx.GlobalString(MetricsInfluxDBEndpointFlag.Name)
 			database               = ctx.GlobalString(MetricsInfluxDBDatabaseFlag.Name)
 			username               = ctx.GlobalString(MetricsInfluxDBUsernameFlag.Name)
 			password               = ctx.GlobalString(MetricsInfluxDBPasswordFlag.Name)
-			hosttag                = ctx.GlobalString(MetricsInfluxDBHostTagFlag.Name)
+			enableExport           = ctx.GlobalBool(MetricsEnableInfluxDBExportFlag.Name)
+			enableAccountingExport = ctx.GlobalBool(MetricsEnableInfluxDBAccountingExportFlag.Name)
 		)
 
 		// Start system runtime metrics collection
 		go gethmetrics.CollectProcessMetrics(2 * time.Second)
 
+		tagsMap := utils.SplitTagsFlag(ctx.GlobalString(MetricsInfluxDBTagsFlag.Name))
+
 		if enableExport {
 			log.Info("Enabling swarm metrics export to InfluxDB")
-			go influxdb.InfluxDBWithTags(gethmetrics.DefaultRegistry, 10*time.Second, endpoint, database, username, password, "swarm.", map[string]string{
-				"host": hosttag,
-			})
+			go influxdb.InfluxDBWithTags(gethmetrics.DefaultRegistry, 10*time.Second, endpoint, database, username, password, "swarm.", tagsMap)
 		}
 
 		if enableAccountingExport {
-			log.Info("Exporting accounting metrics to InfluxDB")
-			go influxdb.InfluxDBWithTags(gethmetrics.AccountingRegistry, 10*time.Second, endpoint, database, username, password, "accounting.", map[string]string{
-				"host": hosttag,
-			})
+			log.Info("Exporting swarm accounting metrics to InfluxDB")
+			go influxdb.InfluxDBWithTags(gethmetrics.AccountingRegistry, 10*time.Second, endpoint, database, username, password, "accounting.", tagsMap)
 		}
 	}
 }


### PR DESCRIPTION
This PR is replacing the `metrics.influxdb.host.tag` cmd-line flag with `metrics.influxdb.tags` - a comma-separated key/value tags, that are passed to the InfluxDB reporter, so that we can index measurements with multiple tags, and not just one `host` tag.

This will be useful for Swarm, where we want to index measurements not just with the host tag, but also with `bzzkey` and `git commit` version (for long-running deployments).