### PR TITLE
travis, appveyor: bump to Go 1.11.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -156,7 +156,7 @@ matrix:
       git:
         submodules: false # avoid cloning ethereum/tests
       before_install:
-        - curl https://storage.googleapis.com/golang/go1.11.4.linux-amd64.tar.gz | tar -xz
+        - curl https://storage.googleapis.com/golang/go1.11.5.linux-amd64.tar.gz | tar -xz
         - export PATH=`pwd`/go/bin:$PATH
         - export GOROOT=`pwd`/go
         - export GOPATH=$HOME/go

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -23,8 +23,8 @@ environment:
 install:
   - git submodule update --init
   - rmdir C:\go /s /q
-  - appveyor DownloadFile https://storage.googleapis.com/golang/go1.11.4.windows-%GETH_ARCH%.zip
-  - 7z x go1.11.4.windows-%GETH_ARCH%.zip -y -oC:\ > NUL
+  - appveyor DownloadFile https://storage.googleapis.com/golang/go1.11.5.windows-%GETH_ARCH%.zip
+  - 7z x go1.11.5.windows-%GETH_ARCH%.zip -y -oC:\ > NUL
   - go version
   - gcc --version
 


### PR DESCRIPTION
Release notes: https://golang.org/doc/devel/release.html#go1.11.minor ([with hash](https://go.googlesource.com/go/+/go1.11.5/doc/devel/release.html#70))

```bash
fd -H -t f -exec sed -i 's|go1.11.4|go1.11.5|g' {} \
```