### PR TITLE
eth/api: add eth_listAccounts API

### DIFF
--- a/core/state/statedb.go
+++ b/core/state/statedb.go
@@ -568,6 +568,11 @@ func (self *StateDB) GetRefund() uint64 {
 	return self.refund
 }
 
+// GetTrie returns the current value of the trie.
+func (self *StateDB) GetTrie() Trie {
+	return self.trie
+}
+
 // Finalise finalises the state by removing the self destructed objects
 // and clears the journal as well as the refunds.
 func (s *StateDB) Finalise(deleteEmptyObjects bool) {

--- a/eth/api.go
+++ b/eth/api.go
@@ -34,6 +34,7 @@ import (
 	"github.com/ethereum/go-ethereum/core/rawdb"
 	"github.com/ethereum/go-ethereum/core/state"
 	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/internal/ethapi"
 	"github.com/ethereum/go-ethereum/params"
 	"github.com/ethereum/go-ethereum/rlp"
@@ -74,6 +75,50 @@ func (api *PublicEthereumAPI) ChainId() hexutil.Uint64 {
 		chainID = config.ChainID
 	}
 	return (hexutil.Uint64)(chainID.Uint64())
+}
+
+// ListAccounts retrieves accounts of the database at a given block.
+func (api *PublicEthereumAPI) ListAccounts(count uint64, offset *common.Address, blockNr *rpc.BlockNumber) ([]common.Address, error) {
+	var block *types.Block = nil
+	var tr state.Trie
+
+	if blockNr == nil || *blockNr == rpc.LatestBlockNumber {
+		block = api.e.blockchain.CurrentBlock()
+	} else if *blockNr != rpc.PendingBlockNumber {
+		block = api.e.blockchain.GetBlockByNumber(uint64(*blockNr))
+	}
+	if block != nil {
+		stateDb, err := api.e.BlockChain().StateAt(block.Root())
+		if err != nil {
+			return nil, err
+		}
+		tr, err = stateDb.Database().OpenTrie(block.Root())
+		if err != nil {
+			return nil, err
+		}
+	} else if *blockNr != rpc.PendingBlockNumber {
+		return nil, fmt.Errorf("block #%d not found", *blockNr)
+	} else {
+		// Get the pending state
+		_, stateDb := api.e.miner.Pending()
+		tr = stateDb.GetTrie()
+	}
+
+	var accounts []common.Address
+	var it *trie.Iterator
+
+	if offset != nil && *offset != (common.Address{}) {
+		it = trie.NewIterator(tr.NodeIterator(crypto.Keccak256(offset[:])))
+		it.Next()
+	} else {
+		it = trie.NewIterator(tr.NodeIterator(nil))
+	}
+
+	for ; count > 0 && it.Next(); count-- {
+		addr := tr.GetKey(it.Key)
+		accounts = append(accounts, common.BytesToAddress(addr))
+	}
+	return accounts, nil
 }
 
 // PublicMinerAPI provides an API to control the miner.

--- a/internal/web3ext/web3ext.go
+++ b/internal/web3ext/web3ext.go
@@ -500,6 +500,12 @@ web3._extend({
 			params: 3,
 			inputFormatter: [web3._extend.formatters.inputAddressFormatter, null, web3._extend.formatters.inputBlockNumberFormatter]
 		}),
+		new web3._extend.Method({
+			name: 'listAccounts',
+			call: 'eth_listAccounts',
+			params: 3,
+			inputFormatter: [null, null, web3._extend.formatters.inputDefaultBlockNumberFormatter],
+		}),
 	],
 	properties: [
 		new web3._extend.Property({


### PR DESCRIPTION
support `eth_listAccounts()` to make the geth compatible with the `parity_listAccounts` of the parity-ethereum.

Please see https://wiki.parity.io/JSONRPC-parity-module#parity_listaccounts

see also https://github.com/ethereum/go-ethereum/pull/17438
