### PR TITLE
p2p/protocols: fix rare data race in Peer.Handshake()

### DIFF
--- a/p2p/protocols/protocol.go
+++ b/p2p/protocols/protocol.go
@@ -386,10 +386,12 @@ func (p *Peer) handleIncoming(handle func(ctx context.Context, msg interface{}) 
 // * the dialing peer needs to send the handshake first and then waits for remote
 // * the listening peer waits for the remote handshake and then sends it
 // returns the remote handshake and an error
-func (p *Peer) Handshake(ctx context.Context, hs interface{}, verify func(interface{}) error) (rhs interface{}, err error) {
+func (p *Peer) Handshake(ctx context.Context, hs interface{}, verify func(interface{}) error) (interface{}, error) {
 	if _, ok := p.spec.GetCode(hs); !ok {
 		return nil, errorf(ErrHandshake, "unknown handshake message type: %T", hs)
 	}
+
+	var rhs interface{}
 	errc := make(chan error, 2)
 	handle := func(ctx context.Context, msg interface{}) error {
 		rhs = msg
@@ -412,6 +414,7 @@ func (p *Peer) Handshake(ctx context.Context, hs interface{}, verify func(interf
 	}()
 
 	for i := 0; i < 2; i++ {
+		var err error
 		select {
 		case err = <-errc:
 		case <-ctx.Done():


### PR DESCRIPTION
The race occurred in the `!p.Inbound()` case if `send()`
did return an error.

Write 1: in handle closure `rhs = msg` (goroutine)
Write 2: `return nil, error` => `nil` is written to `rhs` (main thread)

fixes ethersphere/go-ethereum#1160

---

I did not manage to write a reliable (commitable) test to show the issue. See https://github.com/ethersphere/go-ethereum/issues/1160#issuecomment-457589898 for the hacky way.