### PR TITLE
swarm: fix oom in pss notify test

### DIFF
--- a/swarm/pss/notify/notify_test.go
+++ b/swarm/pss/notify/notify_test.go
@@ -51,6 +51,7 @@ func TestStart(t *testing.T) {
 		ID:             "0",
 		DefaultService: "bzz",
 	})
+	defer net.Shutdown()
 	leftNodeConf := adapters.RandomNodeConfig()
 	leftNodeConf.Services = []string{"bzz", "pss"}
 	leftNode, err := net.NewNodeWithConfig(leftNodeConf)


### PR DESCRIPTION
This PR fixes an out of memory issue https://github.com/ethersphere/go-ethereum/issues/1165#issuecomment-457606374 in pss notify test TestStart by shutting down the network at the end of the test. Nodes were not closed leaving databases open after the test is done.