### PR TITLE
node/api: fixed rate formatter

### DIFF
--- a/node/api.go
+++ b/node/api.go
@@ -312,7 +312,7 @@ func NewPublicDebugAPI(node *Node) *PublicDebugAPI {
 // Metrics retrieves all the known system metric collected by the node.
 func (api *PublicDebugAPI) Metrics(raw bool) (map[string]interface{}, error) {
 	// Create a rate formatter
-	units := []string{"", "K", "M", "G", "T", "P", "E", "Z", "Y"}
+	units := []string{"", "k", "M", "G", "T", "P", "E", "Z", "Y"}
 	round := func(value float64, prec int) string {
 		unit := 0
 		for value >= 1000 && unit < 9 {

--- a/node/api.go
+++ b/node/api.go
@@ -312,10 +312,10 @@ func NewPublicDebugAPI(node *Node) *PublicDebugAPI {
 // Metrics retrieves all the known system metric collected by the node.
 func (api *PublicDebugAPI) Metrics(raw bool) (map[string]interface{}, error) {
 	// Create a rate formatter
-	units := []string{"", "K", "M", "G", "T", "E", "P"}
+	units := []string{"", "K", "M", "G", "T", "P", "E", "Z", "Y"}
 	round := func(value float64, prec int) string {
 		unit := 0
-		for value >= 1000 {
+		for value >= 1000 && unit < 9 {
 			unit, value, prec = unit+1, value/1000, 2
 		}
 		return fmt.Sprintf(fmt.Sprintf("%%.%df%s", prec, units[unit]), value)


### PR DESCRIPTION
- fix `E`, `P` unit order, add `Z`, `Y` units
- range check