### PR TITLE
build: tweak debian source package build/upload options

### DIFF
--- a/build/ci.go
+++ b/build/ci.go
@@ -513,7 +513,7 @@ func doDebianSource(cmdline []string) {
 		for _, distro := range debDistros {
 			meta := newDebMetadata(distro, *signer, env, now, pkg.Name, pkg.Version, pkg.Executables)
 			pkgdir := stageDebianSource(*workdir, meta)
-			debuild := exec.Command("debuild", "-S", "-sa", "-us", "-uc")
+			debuild := exec.Command("debuild", "-S", "-sa", "-us", "-uc", "-d")
 			debuild.Dir = pkgdir
 			build.MustRun(debuild)
 
@@ -523,7 +523,7 @@ func doDebianSource(cmdline []string) {
 				build.MustRunCommand("debsign", changes)
 			}
 			if *upload != "" {
-				build.MustRunCommand("dput", *upload, changes)
+				build.MustRunCommand("dput", "--passive", "--no-upload-log", *upload, changes)
 			}
 		}
 	}


### PR DESCRIPTION
dput --passive should make repo pushes from Travis work again.
dput --no-upload-log works around an issue I had while uploading locally.

debuild -d says that debuild shouldn't check for build dependencies when
creating the source package. This option is needed to make builds work
in environments where the installed Go version doesn't match the
declared dependency in the source package.