### PR TITLE
cmd/swarm/swarm-smoke: sliding window test

### DIFF
--- a/cmd/swarm/swarm-smoke/feed_upload_and_sync.go
+++ b/cmd/swarm/swarm-smoke/feed_upload_and_sync.go
@@ -2,13 +2,10 @@ package main
 
 import (
 	"bytes"
-	"context"
 	"crypto/md5"
 	"fmt"
 	"io"
 	"io/ioutil"
-	"net/http"
-	"net/http/httptrace"
 	"os"
 	"os/exec"
 	"strings"
@@ -18,13 +15,8 @@ import (
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/log"
-	"github.com/ethereum/go-ethereum/metrics"
-	"github.com/ethereum/go-ethereum/swarm/api/client"
-	"github.com/ethereum/go-ethereum/swarm/spancontext"
 	"github.com/ethereum/go-ethereum/swarm/storage/feed"
 	"github.com/ethereum/go-ethereum/swarm/testutil"
-	colorable "github.com/mattn/go-colorable"
-	opentracing "github.com/opentracing/opentracing-go"
 	"github.com/pborman/uuid"
 	cli "gopkg.in/urfave/cli.v1"
 )
@@ -32,27 +24,6 @@ import (
 const (
 	feedRandomDataLength = 8
 )
-
-func cliFeedUploadAndSync(c *cli.Context) error {
-	metrics.GetOrRegisterCounter("feed-and-sync", nil).Inc(1)
-	log.Root().SetHandler(log.CallerFileHandler(log.LvlFilterHandler(log.Lvl(verbosity), log.StreamHandler(colorable.NewColorableStderr(), log.TerminalFormat(true)))))
-
-	errc := make(chan error)
-	go func() {
-		errc <- feedUploadAndSync(c)
-	}()
-
-	select {
-	case err := <-errc:
-		if err != nil {
-			metrics.GetOrRegisterCounter("feed-and-sync.fail", nil).Inc(1)
-		}
-		return err
-	case <-time.After(time.Duration(timeout) * time.Second):
-		metrics.GetOrRegisterCounter("feed-and-sync.timeout", nil).Inc(1)
-		return fmt.Errorf("timeout after %v sec", timeout)
-	}
-}
 
 // TODO: retrieve with manifest + extract repeating code
 func feedUploadAndSync(c *cli.Context) error {
@@ -304,63 +275,6 @@ func feedUploadAndSync(c *cli.Context) error {
 	}
 	wg.Wait()
 	log.Info("all endpoints synced random file successfully")
-
-	return nil
-}
-
-func fetchFeed(topic string, user string, endpoint string, original []byte, ruid string) error {
-	ctx, sp := spancontext.StartSpan(context.Background(), "feed-and-sync.fetch")
-	defer sp.Finish()
-
-	log.Trace("sleeping", "ruid", ruid)
-	time.Sleep(3 * time.Second)
-
-	log.Trace("http get request (feed)", "ruid", ruid, "api", endpoint, "topic", topic, "user", user)
-
-	var tn time.Time
-	reqUri := endpoint + "/bzz-feed:/?topic=" + topic + "&user=" + user
-	req, _ := http.NewRequest("GET", reqUri, nil)
-
-	opentracing.GlobalTracer().Inject(
-		sp.Context(),
-		opentracing.HTTPHeaders,
-		opentracing.HTTPHeadersCarrier(req.Header))
-
-	trace := client.GetClientTrace("feed-and-sync - http get", "feed-and-sync", ruid, &tn)
-
-	req = req.WithContext(httptrace.WithClientTrace(ctx, trace))
-	transport := http.DefaultTransport
-
-	//transport.TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
-
-	tn = time.Now()
-	res, err := transport.RoundTrip(req)
-	if err != nil {
-		log.Error(err.Error(), "ruid", ruid)
-		return err
-	}
-
-	log.Trace("http get response (feed)", "ruid", ruid, "api", endpoint, "topic", topic, "user", user, "code", res.StatusCode, "len", res.ContentLength)
-
-	if res.StatusCode != 200 {
-		return fmt.Errorf("expected status code %d, got %v (ruid %v)", 200, res.StatusCode, ruid)
-	}
-
-	defer res.Body.Close()
-
-	rdigest, err := digest(res.Body)
-	if err != nil {
-		log.Warn(err.Error(), "ruid", ruid)
-		return err
-	}
-
-	if !bytes.Equal(rdigest, original) {
-		err := fmt.Errorf("downloaded imported file md5=%x is not the same as the generated one=%x", rdigest, original)
-		log.Warn(err.Error(), "ruid", ruid)
-		return err
-	}
-
-	log.Trace("downloaded file matches random file", "ruid", ruid, "len", res.ContentLength)
 
 	return nil
 }

--- a/cmd/swarm/swarm-smoke/main.go
+++ b/cmd/swarm/swarm-smoke/main.go
@@ -123,12 +123,6 @@ func main() {
 			Usage:       "whether to fetch content from a single node or from all nodes",
 			Destination: &single,
 		},
-		cli.IntFlag{
-			Name:        "store",
-			Value:       5000,
-			Usage:       "individual node store size",
-			Destination: &storeSize,
-		},
 	}
 
 	app.Flags = append(app.Flags, []cli.Flag{

--- a/cmd/swarm/swarm-smoke/main.go
+++ b/cmd/swarm/swarm-smoke/main.go
@@ -49,7 +49,6 @@ var (
 	verbosity        int
 	timeout          int
 	single           bool
-	storeSize        int
 )
 
 func main() {

--- a/cmd/swarm/swarm-smoke/main.go
+++ b/cmd/swarm/swarm-smoke/main.go
@@ -49,6 +49,7 @@ var (
 	verbosity        int
 	timeout          int
 	single           bool
+	storeSize        int
 )
 
 func main() {
@@ -122,6 +123,12 @@ func main() {
 			Usage:       "whether to fetch content from a single node or from all nodes",
 			Destination: &single,
 		},
+		cli.IntFlag{
+			Name:        "store",
+			Value:       5000,
+			Usage:       "individual node store size",
+			Destination: &storeSize,
+		},
 	}
 
 	app.Flags = append(app.Flags, []cli.Flag{
@@ -140,19 +147,25 @@ func main() {
 			Name:    "upload_and_sync",
 			Aliases: []string{"c"},
 			Usage:   "upload and sync",
-			Action:  cliUploadAndSync,
+			Action:  wrapCliCommand("upload-and-sync", uploadAndSync),
 		},
 		{
 			Name:    "feed_sync",
 			Aliases: []string{"f"},
 			Usage:   "feed update generate, upload and sync",
-			Action:  cliFeedUploadAndSync,
+			Action:  wrapCliCommand("feed-and-sync", feedUploadAndSync),
 		},
 		{
 			Name:    "upload_speed",
 			Aliases: []string{"u"},
 			Usage:   "measure upload speed",
-			Action:  cliUploadSpeed,
+			Action:  wrapCliCommand("upload-speed", uploadSpeed),
+		},
+		{
+			Name:    "sliding_window",
+			Aliases: []string{"s"},
+			Usage:   "measure network aggregate capacity",
+			Action:  wrapCliCommand("sliding-window", slidingWindow),
 		},
 	}
 

--- a/cmd/swarm/swarm-smoke/main.go
+++ b/cmd/swarm/swarm-smoke/main.go
@@ -147,25 +147,25 @@ func main() {
 			Name:    "upload_and_sync",
 			Aliases: []string{"c"},
 			Usage:   "upload and sync",
-			Action:  wrapCliCommand("upload-and-sync", uploadAndSync),
+			Action:  wrapCliCommand("upload-and-sync", true, uploadAndSync),
 		},
 		{
 			Name:    "feed_sync",
 			Aliases: []string{"f"},
 			Usage:   "feed update generate, upload and sync",
-			Action:  wrapCliCommand("feed-and-sync", feedUploadAndSync),
+			Action:  wrapCliCommand("feed-and-sync", true, feedUploadAndSync),
 		},
 		{
 			Name:    "upload_speed",
 			Aliases: []string{"u"},
 			Usage:   "measure upload speed",
-			Action:  wrapCliCommand("upload-speed", uploadSpeed),
+			Action:  wrapCliCommand("upload-speed", true, uploadSpeed),
 		},
 		{
 			Name:    "sliding_window",
 			Aliases: []string{"s"},
 			Usage:   "measure network aggregate capacity",
-			Action:  wrapCliCommand("sliding-window", slidingWindow),
+			Action:  wrapCliCommand("sliding-window", false, slidingWindow),
 		},
 	}
 

--- a/cmd/swarm/swarm-smoke/sliding_window.go
+++ b/cmd/swarm/swarm-smoke/sliding_window.go
@@ -20,8 +20,6 @@ import (
 	"bytes"
 	"fmt"
 	"math/rand"
-	"sync"
-	"sync/atomic"
 	"time"
 
 	"github.com/ethereum/go-ethereum/log"
@@ -53,13 +51,16 @@ func slidingWindow(c *cli.Context) error {
 	generateEndpoints(scheme, cluster, appName, from, to)
 	storeSize = storeSize * 4096 //store size is in chunks - transform to bytes
 	hashes := []uploadResult{}   //swarm hashes of the uploads
-	filesize := storeSize / 7    //each file to upload, bytes
 	nodes := to - from
 	networkCapacity := float64(storeSize) * float64(nodes)
 	const iterationTimeout = 30 * time.Second
 	log.Info("sliding window test started", "store size(kb)", int(storeSize/1000), "nodes", nodes, "filesize(kb)", int(filesize/1000), "network capacity(kb)", int(networkCapacity/1000), "timeout", timeout)
 	uploadedBytes := 0
-	for uploadedBytes = 0; uploadedBytes <= int(networkCapacity); uploadedBytes += filesize {
+	networkDepth := 0
+	errored := false
+
+outer:
+	for {
 		seed := int(time.Now().UnixNano() / 1e6)
 		log.Info("uploading to "+endpoints[0]+" and syncing", "seed", seed)
 
@@ -79,103 +80,33 @@ func slidingWindow(c *cli.Context) error {
 			return err
 		}
 
-		log.Info("uploaded successfully", "hash", hash, "digest", fmt.Sprintf("%x", fhash))
+		log.Info("uploaded successfully", "hash", hash, "digest", fmt.Sprintf("%x", fhash), "sleeping", syncDelay)
 		hashes = append(hashes, uploadResult{hash: hash, digest: fhash})
-	}
+		time.Sleep(time.Duration(syncDelay) * time.Second)
+		uploadedBytes += filesize
 
-	log.Info("done uploading files", "len(hashes)", len(hashes), "sleep for", syncDelay)
-
-	time.Sleep(time.Duration(syncDelay) * time.Second)
-
-	networkDepth := 0
-	var errored int32 = 0
-
-	timedOut := false
-
-LOOP:
-	for i := len(hashes) - 1; i >= 0; i-- {
-		wg := sync.WaitGroup{}
-		done := time.After(iterationTimeout)
-		if single {
+		for i, v := range hashes {
 			rand.Seed(time.Now().UTC().UnixNano())
 			randIndex := 1 + rand.Intn(len(endpoints)-1)
 			ruid := uuid.New()[:8]
-			wg.Add(1)
-			go func(endpoint string, ruid string) {
-				// points to address:
-				// need to measure min/max/mean for the results when not in single mode (not all nodes would necessarily give the same result, though they should)
-				defer wg.Done()
-
-			inner:
-				for {
-					select {
-					case <-done:
-						metrics.GetOrRegisterCounter("sliding-window.single.timeout", nil).Inc(1)
-						atomic.AddInt32(&errored, 1)
-						break inner
-					default:
-					}
-
-					start := time.Now()
-					err := fetch(hashes[i].hash, endpoint, hashes[i].digest, ruid)
-					fetchTime := time.Since(start)
-					if err != nil {
-						continue
-					}
-
-					metrics.GetOrRegisterMeter("sliding-window.single.fetch-time", nil).Mark(int64(fetchTime))
-					return
-				}
-
-			}(endpoints[randIndex], ruid)
-		} else {
-			for _, endpoint := range endpoints {
-				ruid := uuid.New()[:8]
-				wg.Add(1)
-				go func(endpoint string, ruid string) {
-					defer wg.Done()
-
-				inner:
-					for {
-						select {
-						case <-done:
-							metrics.GetOrRegisterCounter("sliding-window.multi.timeout", nil).Inc(1)
-							atomic.AddInt32(&errored, 1)
-							break inner
-						default:
-						}
-
-						start := time.Now()
-						err := fetch(hashes[i].hash, endpoint, hashes[i].digest, ruid)
-						fetchTime := time.Since(start)
-						if err != nil {
-							continue
-						}
-
-						metrics.GetOrRegisterMeter("sliding-window.each.fetch-time", nil).Mark(int64(fetchTime))
-						return
-					}
-				}(endpoint, ruid)
+			start := time.Now()
+			err := fetch(v.hash, endpoints[randIndex], v.digest, ruid)
+			fetchTime := time.Since(start)
+			if err != nil {
+				errored = true
+				log.Error("error retrieving hash", "hash idx", i, "err", err)
+				metrics.GetOrRegisterCounter("sliding-window.single.error", nil).Inc(1)
+				networkDepth = i
+				break outer
 			}
-		}
 
-		wg.Wait()
-		networkDepth = len(hashes) - i
-		if errored > 0 {
-			break LOOP
-		}
-		select {
-		case <-done:
-			timedOut = true
-			break LOOP
-		default:
+			metrics.GetOrRegisterMeter("sliding-window.single.fetch-time", nil).Mark(int64(fetchTime))
 		}
 	}
 
-	log.Info("sliding window test finished", "timed out?", timedOut, "errored?", errored > 0, "networkDepth", networkDepth, "networkDepth(kb)", int(networkDepth*filesize/1000))
+	log.Info("sliding window test finished", "errored?", errored, "networkDepth", networkDepth, "networkDepth(kb)", int(networkDepth*filesize/1000))
 	log.Info("stats", "uploadedFiles", len(hashes), "uploadedKb", uploadedBytes/1000, "filesizeKb", filesize/1000, "networkCapacityKb", int(networkCapacity/1000), "networkCapacityMb", int(networkCapacity/1000000))
 
 	metrics.GetOrRegisterMeter("sliding-window.network-depth", nil).Mark(int64(networkDepth))
-	metrics.GetOrRegisterMeter("sliding-window.uploaded-bytes", nil).Mark(int64(uploadedBytes))
 	return nil
 }

--- a/cmd/swarm/swarm-smoke/sliding_window.go
+++ b/cmd/swarm/swarm-smoke/sliding_window.go
@@ -111,12 +111,12 @@ outer:
 				break outer
 			}
 			networkDepth = i
+			metrics.GetOrRegisterGauge("sliding-window.network-depth", nil).Update(int64(networkDepth))
 		}
 	}
 
 	log.Info("sliding window test finished", "errored?", errored, "networkDepth", networkDepth, "networkDepth(kb)", networkDepth*filesize)
 	log.Info("stats", "uploadedFiles", len(hashes), "uploadedKb", uploadedBytes/1000, "filesizeKb", filesize)
 
-	metrics.GetOrRegisterMeter("sliding-window.network-depth", nil).Mark(int64(networkDepth))
 	return nil
 }

--- a/cmd/swarm/swarm-smoke/sliding_window.go
+++ b/cmd/swarm/swarm-smoke/sliding_window.go
@@ -54,7 +54,7 @@ func slidingWindow(c *cli.Context) error {
 	nodes := to - from
 	networkCapacity := float64(storeSize) * float64(nodes)
 	const iterationTimeout = 30 * time.Second
-	log.Info("sliding window test started", "store size(kb)", int(storeSize/1000), "nodes", nodes, "filesize(kb)", int(filesize/1000), "network capacity(kb)", int(networkCapacity/1000), "timeout", timeout)
+	log.Info("sliding window test started", "store size(kb)", int(storeSize/1000), "nodes", nodes, "filesize(kb)", filesize, "network capacity(kb)", int(networkCapacity/1000), "timeout", timeout)
 	uploadedBytes := 0
 	networkDepth := 0
 	errored := false
@@ -64,7 +64,7 @@ outer:
 		seed := int(time.Now().UnixNano() / 1e6)
 		log.Info("uploading to "+endpoints[0]+" and syncing", "seed", seed)
 
-		randomBytes := testutil.RandomBytes(seed, filesize)
+		randomBytes := testutil.RandomBytes(seed, filesize*1000)
 
 		t1 := time.Now()
 		hash, err := upload(&randomBytes, endpoints[0])
@@ -83,7 +83,7 @@ outer:
 		log.Info("uploaded successfully", "hash", hash, "digest", fmt.Sprintf("%x", fhash), "sleeping", syncDelay)
 		hashes = append(hashes, uploadResult{hash: hash, digest: fhash})
 		time.Sleep(time.Duration(syncDelay) * time.Second)
-		uploadedBytes += filesize
+		uploadedBytes += filesize * 1000
 
 		for i, v := range hashes {
 			rand.Seed(time.Now().UTC().UnixNano())
@@ -104,8 +104,8 @@ outer:
 		}
 	}
 
-	log.Info("sliding window test finished", "errored?", errored, "networkDepth", networkDepth, "networkDepth(kb)", int(networkDepth*filesize/1000))
-	log.Info("stats", "uploadedFiles", len(hashes), "uploadedKb", uploadedBytes/1000, "filesizeKb", filesize/1000, "networkCapacityKb", int(networkCapacity/1000), "networkCapacityMb", int(networkCapacity/1000000))
+	log.Info("sliding window test finished", "errored?", errored, "networkDepth", networkDepth, "networkDepth(kb)", int(networkDepth*filesize))
+	log.Info("stats", "uploadedFiles", len(hashes), "uploadedKb", uploadedBytes/1000, "filesizeKb", filesize, "networkCapacityKb", int(networkCapacity/1000), "networkCapacityMb", int(networkCapacity/1000000))
 
 	metrics.GetOrRegisterMeter("sliding-window.network-depth", nil).Mark(int64(networkDepth))
 	return nil

--- a/cmd/swarm/swarm-smoke/sliding_window.go
+++ b/cmd/swarm/swarm-smoke/sliding_window.go
@@ -1,0 +1,181 @@
+// Copyright 2018 The go-ethereum Authors
+// This file is part of go-ethereum.
+//
+// go-ethereum is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// go-ethereum is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with go-ethereum. If not, see <http://www.gnu.org/licenses/>.
+
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/ethereum/go-ethereum/log"
+	"github.com/ethereum/go-ethereum/metrics"
+	"github.com/ethereum/go-ethereum/swarm/testutil"
+	"github.com/pborman/uuid"
+
+	cli "gopkg.in/urfave/cli.v1"
+)
+
+type uploadResult struct {
+	hash   string
+	digest []byte
+}
+
+func slidingWindow(c *cli.Context) error {
+	// test dscription:
+	// 1. upload repeatedly the same file size, maintain a slice in which swarm hashes are stored, first hash at idx=0
+	// 2. select a random node, start downloading the hashes, starting with the LAST one first (it should always be availble), till the FIRST hash
+	// 3. when
+
+	defer func(now time.Time) {
+		totalTime := time.Since(now)
+
+		log.Info("total time", "time", totalTime)
+		metrics.GetOrRegisterCounter("sliding-window.total-time", nil).Inc(int64(totalTime))
+	}(time.Now())
+
+	generateEndpoints(scheme, cluster, appName, from, to)
+	storeSize = storeSize * 4096 //store size is in chunks - transform to bytes
+	hashes := []uploadResult{}   //swarm hashes of the uploads
+	filesize := storeSize / 7    //each file to upload, bytes
+	nodes := to - from
+	networkCapacity := float64(storeSize) * float64(nodes)
+	const iterationTimeout = 30 * time.Second
+	log.Info("sliding window test started", "store size(kb)", int(storeSize/1000), "nodes", nodes, "filesize(kb)", int(filesize/1000), "network capacity(kb)", int(networkCapacity/1000), "timeout", timeout)
+	uploadedBytes := 0
+	for uploadedBytes = 0; uploadedBytes <= int(networkCapacity); uploadedBytes += filesize {
+		seed := int(time.Now().UnixNano() / 1e6)
+		log.Info("uploading to "+endpoints[0]+" and syncing", "seed", seed)
+
+		randomBytes := testutil.RandomBytes(seed, filesize)
+
+		t1 := time.Now()
+		hash, err := upload(&randomBytes, endpoints[0])
+		if err != nil {
+			log.Error(err.Error())
+			return err
+		}
+		metrics.GetOrRegisterCounter("sliding-window.upload-time", nil).Inc(int64(time.Since(t1)))
+
+		fhash, err := digest(bytes.NewReader(randomBytes))
+		if err != nil {
+			log.Error(err.Error())
+			return err
+		}
+
+		log.Info("uploaded successfully", "hash", hash, "digest", fmt.Sprintf("%x", fhash))
+		hashes = append(hashes, uploadResult{hash: hash, digest: fhash})
+	}
+
+	log.Info("done uploading files", "len(hashes)", len(hashes), "sleep for", syncDelay)
+
+	time.Sleep(time.Duration(syncDelay) * time.Second)
+
+	networkDepth := 0
+	var errored int32 = 0
+
+	timedOut := false
+
+LOOP:
+	for i := len(hashes) - 1; i >= 0; i-- {
+		wg := sync.WaitGroup{}
+		done := time.After(iterationTimeout)
+		if single {
+			rand.Seed(time.Now().UTC().UnixNano())
+			randIndex := 1 + rand.Intn(len(endpoints)-1)
+			ruid := uuid.New()[:8]
+			wg.Add(1)
+			go func(endpoint string, ruid string) {
+				// points to address:
+				// need to measure min/max/mean for the results when not in single mode (not all nodes would necessarily give the same result, though they should)
+				defer wg.Done()
+
+			inner:
+				for {
+					select {
+					case <-done:
+						metrics.GetOrRegisterCounter("sliding-window.single.timeout", nil).Inc(1)
+						atomic.AddInt32(&errored, 1)
+						break inner
+					default:
+					}
+
+					start := time.Now()
+					err := fetch(hashes[i].hash, endpoint, hashes[i].digest, ruid)
+					fetchTime := time.Since(start)
+					if err != nil {
+						continue
+					}
+
+					metrics.GetOrRegisterMeter("sliding-window.single.fetch-time", nil).Mark(int64(fetchTime))
+					return
+				}
+
+			}(endpoints[randIndex], ruid)
+		} else {
+			for _, endpoint := range endpoints {
+				ruid := uuid.New()[:8]
+				wg.Add(1)
+				go func(endpoint string, ruid string) {
+					defer wg.Done()
+
+				inner:
+					for {
+						select {
+						case <-done:
+							metrics.GetOrRegisterCounter("sliding-window.multi.timeout", nil).Inc(1)
+							atomic.AddInt32(&errored, 1)
+							break inner
+						default:
+						}
+
+						start := time.Now()
+						err := fetch(hashes[i].hash, endpoint, hashes[i].digest, ruid)
+						fetchTime := time.Since(start)
+						if err != nil {
+							continue
+						}
+
+						metrics.GetOrRegisterMeter("sliding-window.each.fetch-time", nil).Mark(int64(fetchTime))
+						return
+					}
+				}(endpoint, ruid)
+			}
+		}
+
+		wg.Wait()
+		networkDepth = len(hashes) - i
+		if errored > 0 {
+			break LOOP
+		}
+		select {
+		case <-done:
+			timedOut = true
+			break LOOP
+		default:
+		}
+	}
+
+	log.Info("sliding window test finished", "timed out?", timedOut, "errored?", errored > 0, "networkDepth", networkDepth, "networkDepth(kb)", int(networkDepth*filesize/1000))
+	log.Info("stats", "uploadedFiles", len(hashes), "uploadedKb", uploadedBytes/1000, "filesizeKb", filesize/1000, "networkCapacityKb", int(networkCapacity/1000), "networkCapacityMb", int(networkCapacity/1000000))
+
+	metrics.GetOrRegisterMeter("sliding-window.network-depth", nil).Mark(int64(networkDepth))
+	metrics.GetOrRegisterMeter("sliding-window.uploaded-bytes", nil).Mark(int64(uploadedBytes))
+	return nil
+}

--- a/cmd/swarm/swarm-smoke/sliding_window.go
+++ b/cmd/swarm/swarm-smoke/sliding_window.go
@@ -83,7 +83,7 @@ outer:
 		uploadedBytes += filesize * 1000
 
 		for i, v := range hashes {
-			timeout := time.After(30 * time.Second)
+			timeout := time.After(time.Duration(timeout) * time.Second)
 			errored = false
 
 		inner:
@@ -93,6 +93,7 @@ outer:
 					errored = true
 					log.Error("error retrieving hash. timeout", "hash idx", i, "err", err)
 					metrics.GetOrRegisterCounter("sliding-window.single.error", nil).Inc(1)
+					break inner
 				default:
 					randIndex := 1 + rand.Intn(len(endpoints)-1)
 					ruid := uuid.New()[:8]

--- a/cmd/swarm/swarm-smoke/upload_and_sync.go
+++ b/cmd/swarm/swarm-smoke/upload_and_sync.go
@@ -18,74 +18,18 @@ package main
 
 import (
 	"bytes"
-	"context"
-	"crypto/md5"
-	crand "crypto/rand"
-	"errors"
 	"fmt"
-	"io"
-	"io/ioutil"
 	"math/rand"
-	"net/http"
-	"net/http/httptrace"
-	"os"
 	"sync"
 	"time"
 
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/metrics"
-	"github.com/ethereum/go-ethereum/swarm/api"
-	"github.com/ethereum/go-ethereum/swarm/api/client"
-	"github.com/ethereum/go-ethereum/swarm/spancontext"
 	"github.com/ethereum/go-ethereum/swarm/testutil"
-	opentracing "github.com/opentracing/opentracing-go"
 	"github.com/pborman/uuid"
 
 	cli "gopkg.in/urfave/cli.v1"
 )
-
-func generateEndpoints(scheme string, cluster string, app string, from int, to int) {
-	if cluster == "prod" {
-		for port := from; port < to; port++ {
-			endpoints = append(endpoints, fmt.Sprintf("%s://%v.swarm-gateways.net", scheme, port))
-		}
-	} else if cluster == "private-internal" {
-		for port := from; port < to; port++ {
-			endpoints = append(endpoints, fmt.Sprintf("%s://swarm-private-internal-%v:8500", scheme, port))
-		}
-	} else {
-		for port := from; port < to; port++ {
-			endpoints = append(endpoints, fmt.Sprintf("%s://%s-%v-%s.stg.swarm-gateways.net", scheme, app, port, cluster))
-		}
-	}
-
-	if includeLocalhost {
-		endpoints = append(endpoints, "http://localhost:8500")
-	}
-}
-
-func cliUploadAndSync(c *cli.Context) error {
-	log.PrintOrigins(true)
-	log.Root().SetHandler(log.LvlFilterHandler(log.Lvl(verbosity), log.StreamHandler(os.Stdout, log.TerminalFormat(true))))
-
-	metrics.GetOrRegisterCounter("upload-and-sync", nil).Inc(1)
-
-	errc := make(chan error)
-	go func() {
-		errc <- uploadAndSync(c)
-	}()
-
-	select {
-	case err := <-errc:
-		if err != nil {
-			metrics.GetOrRegisterCounter("upload-and-sync.fail", nil).Inc(1)
-		}
-		return err
-	case <-time.After(time.Duration(timeout) * time.Second):
-		metrics.GetOrRegisterCounter("upload-and-sync.timeout", nil).Inc(1)
-		return fmt.Errorf("timeout after %v sec", timeout)
-	}
-}
 
 func uploadAndSync(c *cli.Context) error {
 	defer func(now time.Time) {
@@ -160,97 +104,4 @@ func uploadAndSync(c *cli.Context) error {
 	log.Info("all endpoints synced random file successfully")
 
 	return nil
-}
-
-// fetch is getting the requested `hash` from the `endpoint` and compares it with the `original` file
-func fetch(hash string, endpoint string, original []byte, ruid string) error {
-	ctx, sp := spancontext.StartSpan(context.Background(), "upload-and-sync.fetch")
-	defer sp.Finish()
-
-	log.Trace("http get request", "ruid", ruid, "api", endpoint, "hash", hash)
-
-	var tn time.Time
-	reqUri := endpoint + "/bzz:/" + hash + "/"
-	req, _ := http.NewRequest("GET", reqUri, nil)
-
-	opentracing.GlobalTracer().Inject(
-		sp.Context(),
-		opentracing.HTTPHeaders,
-		opentracing.HTTPHeadersCarrier(req.Header))
-
-	trace := client.GetClientTrace("upload-and-sync - http get", "upload-and-sync", ruid, &tn)
-
-	req = req.WithContext(httptrace.WithClientTrace(ctx, trace))
-	transport := http.DefaultTransport
-
-	//transport.TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
-
-	tn = time.Now()
-	res, err := transport.RoundTrip(req)
-	if err != nil {
-		log.Error(err.Error(), "ruid", ruid)
-		return err
-	}
-	log.Trace("http get response", "ruid", ruid, "api", endpoint, "hash", hash, "code", res.StatusCode, "len", res.ContentLength)
-
-	if res.StatusCode != 200 {
-		err := fmt.Errorf("expected status code %d, got %v", 200, res.StatusCode)
-		log.Warn(err.Error(), "ruid", ruid)
-		return err
-	}
-
-	defer res.Body.Close()
-
-	rdigest, err := digest(res.Body)
-	if err != nil {
-		log.Warn(err.Error(), "ruid", ruid)
-		return err
-	}
-
-	if !bytes.Equal(rdigest, original) {
-		err := fmt.Errorf("downloaded imported file md5=%x is not the same as the generated one=%x", rdigest, original)
-		log.Warn(err.Error(), "ruid", ruid)
-		return err
-	}
-
-	log.Trace("downloaded file matches random file", "ruid", ruid, "len", res.ContentLength)
-
-	return nil
-}
-
-// upload is uploading a file `f` to `endpoint` via the `swarm up` cmd
-func upload(dataBytes *[]byte, endpoint string) (string, error) {
-	swarm := client.NewClient(endpoint)
-	f := &client.File{
-		ReadCloser: ioutil.NopCloser(bytes.NewReader(*dataBytes)),
-		ManifestEntry: api.ManifestEntry{
-			ContentType: "text/plain",
-			Mode:        0660,
-			Size:        int64(len(*dataBytes)),
-		},
-	}
-
-	// upload data to bzz:// and retrieve the content-addressed manifest hash, hex-encoded.
-	return swarm.Upload(f, "", false)
-}
-
-func digest(r io.Reader) ([]byte, error) {
-	h := md5.New()
-	_, err := io.Copy(h, r)
-	if err != nil {
-		return nil, err
-	}
-	return h.Sum(nil), nil
-}
-
-// generates random data in heap buffer
-func generateRandomData(datasize int) ([]byte, error) {
-	b := make([]byte, datasize)
-	c, err := crand.Read(b)
-	if err != nil {
-		return nil, err
-	} else if c != datasize {
-		return nil, errors.New("short read")
-	}
-	return b, nil
 }

--- a/cmd/swarm/swarm-smoke/upload_speed.go
+++ b/cmd/swarm/swarm-smoke/upload_speed.go
@@ -19,7 +19,6 @@ package main
 import (
 	"bytes"
 	"fmt"
-	"os"
 	"time"
 
 	"github.com/ethereum/go-ethereum/log"
@@ -29,42 +28,6 @@ import (
 	cli "gopkg.in/urfave/cli.v1"
 )
 
-var endpoint string
-
-//just use the first endpoint
-func generateEndpoint(scheme string, cluster string, app string, from int) {
-	if cluster == "prod" {
-		endpoint = fmt.Sprintf("%s://%v.swarm-gateways.net", scheme, from)
-	} else if cluster == "private-internal" {
-		endpoint = fmt.Sprintf("%s://swarm-private-internal-%v:8500", scheme, from)
-	} else {
-		endpoint = fmt.Sprintf("%s://%s-%v-%s.stg.swarm-gateways.net", scheme, app, from, cluster)
-	}
-}
-
-func cliUploadSpeed(c *cli.Context) error {
-	log.PrintOrigins(true)
-	log.Root().SetHandler(log.LvlFilterHandler(log.Lvl(verbosity), log.StreamHandler(os.Stdout, log.TerminalFormat(true))))
-
-	metrics.GetOrRegisterCounter("upload-speed", nil).Inc(1)
-
-	errc := make(chan error)
-	go func() {
-		errc <- uploadSpeed(c)
-	}()
-
-	select {
-	case err := <-errc:
-		if err != nil {
-			metrics.GetOrRegisterCounter("upload-speed.fail", nil).Inc(1)
-		}
-		return err
-	case <-time.After(time.Duration(timeout) * time.Second):
-		metrics.GetOrRegisterCounter("upload-speed.timeout", nil).Inc(1)
-		return fmt.Errorf("timeout after %v sec", timeout)
-	}
-}
-
 func uploadSpeed(c *cli.Context) error {
 	defer func(now time.Time) {
 		totalTime := time.Since(now)
@@ -73,7 +36,7 @@ func uploadSpeed(c *cli.Context) error {
 		metrics.GetOrRegisterCounter("upload-speed.total-time", nil).Inc(int64(totalTime))
 	}(time.Now())
 
-	generateEndpoint(scheme, cluster, appName, from)
+	endpoint := generateEndpoint(scheme, cluster, appName, from)
 	seed := int(time.Now().UnixNano() / 1e6)
 	log.Info("uploading to "+endpoint, "seed", seed)
 

--- a/cmd/swarm/swarm-smoke/util.go
+++ b/cmd/swarm/swarm-smoke/util.go
@@ -39,7 +39,9 @@ import (
 	cli "gopkg.in/urfave/cli.v1"
 )
 
-var commandName = ""
+var (
+	commandName = ""
+)
 
 func wrapCliCommand(name string, command func(*cli.Context) error) func(*cli.Context) error {
 	return func(ctx *cli.Context) error {
@@ -72,6 +74,10 @@ func generateEndpoints(scheme string, cluster string, app string, from int, to i
 		for port := from; port < to; port++ {
 			endpoints = append(endpoints, fmt.Sprintf("%s://%v.swarm-gateways.net", scheme, port))
 		}
+	} else if cluster == "private-internal" {
+		for port := from; port < to; port++ {
+			endpoints = append(endpoints, fmt.Sprintf("%s://swarm-private-internal-%v:8500", scheme, port))
+		}
 	} else {
 		for port := from; port < to; port++ {
 			endpoints = append(endpoints, fmt.Sprintf("%s://%s-%v-%s.stg.swarm-gateways.net", scheme, app, port, cluster))
@@ -87,6 +93,8 @@ func generateEndpoints(scheme string, cluster string, app string, from int, to i
 func generateEndpoint(scheme string, cluster string, app string, from int) string {
 	if cluster == "prod" {
 		return fmt.Sprintf("%s://%v.swarm-gateways.net", scheme, from)
+	} else if cluster == "private-internal" {
+		return fmt.Sprintf("%s://swarm-private-internal-%v:8500", scheme, from)
 	} else {
 		return fmt.Sprintf("%s://%s-%v-%s.stg.swarm-gateways.net", scheme, app, from, cluster)
 	}

--- a/cmd/swarm/swarm-smoke/util.go
+++ b/cmd/swarm/swarm-smoke/util.go
@@ -1,0 +1,240 @@
+// Copyright 2018 The go-ethereum Authors
+// This file is part of go-ethereum.
+//
+// go-ethereum is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// go-ethereum is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with go-ethereum. If not, see <http://www.gnu.org/licenses/>.
+
+package main
+
+import (
+	"bytes"
+	"context"
+	"crypto/md5"
+	crand "crypto/rand"
+	"errors"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptrace"
+	"os"
+	"time"
+
+	"github.com/ethereum/go-ethereum/log"
+	"github.com/ethereum/go-ethereum/metrics"
+	"github.com/ethereum/go-ethereum/swarm/api"
+	"github.com/ethereum/go-ethereum/swarm/api/client"
+	"github.com/ethereum/go-ethereum/swarm/spancontext"
+	opentracing "github.com/opentracing/opentracing-go"
+	cli "gopkg.in/urfave/cli.v1"
+)
+
+func wrapCliCommand(name string, command func(*cli.Context) error) func(*cli.Context) error {
+	return func(ctx *cli.Context) error {
+		log.PrintOrigins(true)
+		log.Root().SetHandler(log.LvlFilterHandler(log.Lvl(verbosity), log.StreamHandler(os.Stdout, log.TerminalFormat(true))))
+		log.Info("smoke test starting", "task", name, "timeout", timeout)
+		metrics.GetOrRegisterCounter(name, nil).Inc(1)
+
+		errc := make(chan error)
+		go func() {
+			errc <- command(ctx)
+		}()
+
+		select {
+		case err := <-errc:
+			if err != nil {
+				metrics.GetOrRegisterCounter(fmt.Sprintf("%s.fail", name), nil).Inc(1)
+			}
+			return err
+		case <-time.After(time.Duration(timeout) * time.Second):
+			metrics.GetOrRegisterCounter(fmt.Sprintf("%s.timeout", name), nil).Inc(1)
+			return fmt.Errorf("timeout after %v sec", timeout)
+		}
+	}
+}
+
+func generateEndpoints(scheme string, cluster string, app string, from int, to int) {
+	if cluster == "prod" {
+		for port := from; port < to; port++ {
+			endpoints = append(endpoints, fmt.Sprintf("%s://%v.swarm-gateways.net", scheme, port))
+		}
+	} else {
+		for port := from; port < to; port++ {
+			endpoints = append(endpoints, fmt.Sprintf("%s://%s-%v-%s.stg.swarm-gateways.net", scheme, app, port, cluster))
+		}
+	}
+
+	if includeLocalhost {
+		endpoints = append(endpoints, "http://localhost:8500")
+	}
+}
+
+//just use the first endpoint
+func generateEndpoint(scheme string, cluster string, app string, from int) string {
+	if cluster == "prod" {
+		return fmt.Sprintf("%s://%v.swarm-gateways.net", scheme, from)
+	} else {
+		return fmt.Sprintf("%s://%s-%v-%s.stg.swarm-gateways.net", scheme, app, from, cluster)
+	}
+}
+
+func fetchFeed(topic string, user string, endpoint string, original []byte, ruid string) error {
+	ctx, sp := spancontext.StartSpan(context.Background(), "feed-and-sync.fetch")
+	defer sp.Finish()
+
+	log.Trace("sleeping", "ruid", ruid)
+	time.Sleep(3 * time.Second)
+
+	log.Trace("http get request (feed)", "ruid", ruid, "api", endpoint, "topic", topic, "user", user)
+
+	var tn time.Time
+	reqUri := endpoint + "/bzz-feed:/?topic=" + topic + "&user=" + user
+	req, _ := http.NewRequest("GET", reqUri, nil)
+
+	opentracing.GlobalTracer().Inject(
+		sp.Context(),
+		opentracing.HTTPHeaders,
+		opentracing.HTTPHeadersCarrier(req.Header))
+
+	trace := client.GetClientTrace("feed-and-sync - http get", "feed-and-sync", ruid, &tn)
+
+	req = req.WithContext(httptrace.WithClientTrace(ctx, trace))
+	transport := http.DefaultTransport
+
+	//transport.TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
+
+	tn = time.Now()
+	res, err := transport.RoundTrip(req)
+	if err != nil {
+		log.Error(err.Error(), "ruid", ruid)
+		return err
+	}
+
+	log.Trace("http get response (feed)", "ruid", ruid, "api", endpoint, "topic", topic, "user", user, "code", res.StatusCode, "len", res.ContentLength)
+
+	if res.StatusCode != 200 {
+		return fmt.Errorf("expected status code %d, got %v (ruid %v)", 200, res.StatusCode, ruid)
+	}
+
+	defer res.Body.Close()
+
+	rdigest, err := digest(res.Body)
+	if err != nil {
+		log.Warn(err.Error(), "ruid", ruid)
+		return err
+	}
+
+	if !bytes.Equal(rdigest, original) {
+		err := fmt.Errorf("downloaded imported file md5=%x is not the same as the generated one=%x", rdigest, original)
+		log.Warn(err.Error(), "ruid", ruid)
+		return err
+	}
+
+	log.Trace("downloaded file matches random file", "ruid", ruid, "len", res.ContentLength)
+
+	return nil
+}
+
+// fetch is getting the requested `hash` from the `endpoint` and compares it with the `original` file
+func fetch(hash string, endpoint string, original []byte, ruid string) error {
+	ctx, sp := spancontext.StartSpan(context.Background(), "upload-and-sync.fetch")
+	defer sp.Finish()
+
+	log.Trace("http get request", "ruid", ruid, "api", endpoint, "hash", hash)
+
+	var tn time.Time
+	reqUri := endpoint + "/bzz:/" + hash + "/"
+	req, _ := http.NewRequest("GET", reqUri, nil)
+
+	opentracing.GlobalTracer().Inject(
+		sp.Context(),
+		opentracing.HTTPHeaders,
+		opentracing.HTTPHeadersCarrier(req.Header))
+
+	trace := client.GetClientTrace("upload-and-sync - http get", "upload-and-sync", ruid, &tn)
+
+	req = req.WithContext(httptrace.WithClientTrace(ctx, trace))
+	transport := http.DefaultTransport
+
+	//transport.TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
+
+	tn = time.Now()
+	res, err := transport.RoundTrip(req)
+	if err != nil {
+		log.Error(err.Error(), "ruid", ruid)
+		return err
+	}
+	log.Trace("http get response", "ruid", ruid, "api", endpoint, "hash", hash, "code", res.StatusCode, "len", res.ContentLength)
+
+	if res.StatusCode != 200 {
+		err := fmt.Errorf("expected status code %d, got %v", 200, res.StatusCode)
+		log.Warn(err.Error(), "ruid", ruid)
+		return err
+	}
+
+	defer res.Body.Close()
+
+	rdigest, err := digest(res.Body)
+	if err != nil {
+		log.Warn(err.Error(), "ruid", ruid)
+		return err
+	}
+
+	if !bytes.Equal(rdigest, original) {
+		err := fmt.Errorf("downloaded imported file md5=%x is not the same as the generated one=%x", rdigest, original)
+		log.Warn(err.Error(), "ruid", ruid)
+		return err
+	}
+
+	log.Trace("downloaded file matches random file", "ruid", ruid, "len", res.ContentLength)
+
+	return nil
+}
+
+// upload an arbitrary byte as a plaintext file  to `endpoint` using the api client
+func upload(dataBytes *[]byte, endpoint string) (string, error) {
+	swarm := client.NewClient(endpoint)
+	f := &client.File{
+		ReadCloser: ioutil.NopCloser(bytes.NewReader(*dataBytes)),
+		ManifestEntry: api.ManifestEntry{
+			ContentType: "text/plain",
+			Mode:        0660,
+			Size:        int64(len(*dataBytes)),
+		},
+	}
+
+	// upload data to bzz:// and retrieve the content-addressed manifest hash, hex-encoded.
+	return swarm.Upload(f, "", false)
+}
+
+func digest(r io.Reader) ([]byte, error) {
+	h := md5.New()
+	_, err := io.Copy(h, r)
+	if err != nil {
+		return nil, err
+	}
+	return h.Sum(nil), nil
+}
+
+// generates random data in heap buffer
+func generateRandomData(datasize int) ([]byte, error) {
+	b := make([]byte, datasize)
+	c, err := crand.Read(b)
+	if err != nil {
+		return nil, err
+	} else if c != datasize {
+		return nil, errors.New("short read")
+	}
+	return b, nil
+}

--- a/cmd/swarm/swarm-smoke/util.go
+++ b/cmd/swarm/swarm-smoke/util.go
@@ -203,14 +203,14 @@ func fetch(hash string, endpoint string, original []byte, ruid string) error {
 }
 
 // upload an arbitrary byte as a plaintext file  to `endpoint` using the api client
-func upload(dataBytes *[]byte, endpoint string) (string, error) {
+func upload(r io.Reader, size int, endpoint string) (string, error) {
 	swarm := client.NewClient(endpoint)
 	f := &client.File{
-		ReadCloser: ioutil.NopCloser(bytes.NewReader(*dataBytes)),
+		ReadCloser: ioutil.NopCloser(r),
 		ManifestEntry: api.ManifestEntry{
 			ContentType: "text/plain",
 			Mode:        0660,
-			Size:        int64(len(*dataBytes)),
+			Size:        int64(size),
 		},
 	}
 

--- a/cmd/swarm/swarm-smoke/util.go
+++ b/cmd/swarm/swarm-smoke/util.go
@@ -39,11 +39,14 @@ import (
 	cli "gopkg.in/urfave/cli.v1"
 )
 
+var commandName = ""
+
 func wrapCliCommand(name string, command func(*cli.Context) error) func(*cli.Context) error {
 	return func(ctx *cli.Context) error {
 		log.PrintOrigins(true)
 		log.Root().SetHandler(log.LvlFilterHandler(log.Lvl(verbosity), log.StreamHandler(os.Stdout, log.TerminalFormat(true))))
 		log.Info("smoke test starting", "task", name, "timeout", timeout)
+		commandName = name
 		metrics.GetOrRegisterCounter(name, nil).Inc(1)
 
 		errc := make(chan error)
@@ -162,7 +165,7 @@ func fetch(hash string, endpoint string, original []byte, ruid string) error {
 		opentracing.HTTPHeaders,
 		opentracing.HTTPHeadersCarrier(req.Header))
 
-	trace := client.GetClientTrace("upload-and-sync - http get", "upload-and-sync", ruid, &tn)
+	trace := client.GetClientTrace(commandName+" - http get", commandName, ruid, &tn)
 
 	req = req.WithContext(httptrace.WithClientTrace(ctx, trace))
 	transport := http.DefaultTransport


### PR DESCRIPTION
This PR adds a smoke test that tries to assert the overall network capacity of a given Swarm cluster.
The test constantly pumps the same file size into the cluster and tries to download the uploaded hashes until it fails, then reports the depth of the network in number of files as a result.

This test is currently triggered through a cron job which is not ideal since the time it takes for the network to fail on an uploaded hash is very high (`4 hours` on a `10 node` cluster with `1000 chunk` store size). Ideally this test should be run as a _one-off_ at least until we figure the cron intervals in which it is supposed to run in.

closes https://github.com/ethersphere/go-ethereum/issues/1095
previously discussed in https://github.com/ethersphere/go-ethereum/pull/1136

example k8s deployment manifest:
```
smoke:
  image:
    repository: ethdevops/swarm
    tag: <tag>
  enabled: true
  schedule: "21 * * * *"
  size: 1000
  config:
    swarmReplicas: 10
    operation: "sliding_window"
    extraFlags:
      - --sync-delay=30
      - --timeout=900
      - --single
```