### PR TITLE
[DO NOT MERGE] Deterministic trie database batching

### DIFF
--- a/core/vm/interface.go
+++ b/core/vm/interface.go
@@ -20,12 +20,15 @@ import (
 	"math/big"
 
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/state"
 	"github.com/ethereum/go-ethereum/core/types"
 )
 
 // StateDB is an EVM database for full state querying.
 type StateDB interface {
 	CreateAccount(common.Address)
+
+	RawDump() state.Dump
 
 	SubBalance(common.Address, *big.Int)
 	AddBalance(common.Address, *big.Int)

--- a/trie/database.go
+++ b/trie/database.go
@@ -622,12 +622,6 @@ func (db *Database) Commit(node common.Hash, report bool) error {
 			db.lock.RUnlock()
 			return err
 		}
-		if batch.ValueSize() > ethdb.IdealBatchSize {
-			if err := batch.Write(); err != nil {
-				return err
-			}
-			batch.Reset()
-		}
 	}
 	// Move the trie itself into the batch, flushing if enough data is accumulated
 	nodes, storage := len(db.nodes), db.nodesSize
@@ -685,13 +679,6 @@ func (db *Database) commit(hash common.Hash, batch ethdb.Batch) error {
 	}
 	if err := batch.Put(hash[:], node.rlp()); err != nil {
 		return err
-	}
-	// If we've reached an optimal batch size, commit and start over
-	if batch.ValueSize() >= ethdb.IdealBatchSize {
-		if err := batch.Write(); err != nil {
-			return err
-		}
-		batch.Reset()
 	}
 	return nil
 }


### PR DESCRIPTION
Force `trie.Database.Commit()` to write everything out in a single batch.

Iteration order over `db.preimages` is not deterministic, sorting the batch contents when the batch is written can be used to work around this. However, when multiple batches are written out the contents of
each batch will differ every time, therefore sorting the contents of each batch is not sufficient to ensure deterministic in-order writes to the underlying store. These changes ensure the `trie.Database.Commit()`
writes everything out in a single batch to avoid that particular problem.