### PR TITLE
cmd/swarm/swarm-smoke: remove wrong metrics

### DIFF
--- a/cmd/swarm/swarm-smoke/sliding_window.go
+++ b/cmd/swarm/swarm-smoke/sliding_window.go
@@ -43,13 +43,6 @@ type uploadResult struct {
 }
 
 func slidingWindow(c *cli.Context) error {
-	defer func(now time.Time) {
-		totalTime := time.Since(now)
-
-		log.Info("total time", "time", totalTime)
-		metrics.GetOrRegisterCounter("sliding-window.total-time", nil).Inc(int64(totalTime))
-	}(time.Now())
-
 	generateEndpoints(scheme, cluster, appName, from, to)
 	hashes := []uploadResult{} //swarm hashes of the uploads
 	nodes := to - from

--- a/cmd/swarm/swarm-smoke/upload_and_sync.go
+++ b/cmd/swarm/swarm-smoke/upload_and_sync.go
@@ -33,12 +33,6 @@ import (
 )
 
 func uploadAndSync(c *cli.Context) error {
-	defer func(now time.Time) {
-		totalTime := time.Since(now)
-		log.Info("total time", "time", totalTime, "kb", filesize)
-		metrics.GetOrRegisterResettingTimer("upload-and-sync.total-time", nil).Update(totalTime)
-	}(time.Now())
-
 	generateEndpoints(scheme, cluster, appName, from, to)
 	seed := int(time.Now().UnixNano() / 1e6)
 

--- a/cmd/swarm/swarm-smoke/upload_speed.go
+++ b/cmd/swarm/swarm-smoke/upload_speed.go
@@ -30,13 +30,6 @@ import (
 )
 
 func uploadSpeed(c *cli.Context) error {
-	defer func(now time.Time) {
-		totalTime := time.Since(now)
-
-		log.Info("total time", "time", totalTime, "kb", filesize)
-		metrics.GetOrRegisterCounter("upload-speed.total-time", nil).Inc(int64(totalTime))
-	}(time.Now())
-
 	endpoint := generateEndpoint(scheme, cluster, appName, from)
 	seed := int(time.Now().UnixNano() / 1e6)
 	log.Info("uploading to "+endpoint, "seed", seed)

--- a/cmd/swarm/swarm-smoke/util.go
+++ b/cmd/swarm/swarm-smoke/util.go
@@ -46,12 +46,12 @@ var (
 func wrapCliCommand(name string, killOnTimeout bool, command func(*cli.Context) error) func(*cli.Context) error {
 	return func(ctx *cli.Context) error {
 		log.PrintOrigins(true)
-		log.Root().SetHandler(log.LvlFilterHandler(log.Lvl(verbosity), log.StreamHandler(os.Stdout, log.TerminalFormat(true))))
+		log.Root().SetHandler(log.LvlFilterHandler(log.Lvl(verbosity), log.StreamHandler(os.Stdout, log.TerminalFormat(false))))
+
 		defer func(now time.Time) {
 			totalTime := time.Since(now)
-
-			log.Info("total time", "time", totalTime)
-			metrics.GetOrRegisterCounter(name+".total-time", nil).Inc(int64(totalTime))
+			log.Info("total time", "time", totalTime, "kb", filesize)
+			metrics.GetOrRegisterResettingTimer(name+".total-time", nil).Update(totalTime)
 		}(time.Now())
 
 		log.Info("smoke test starting", "task", name, "timeout", timeout)


### PR DESCRIPTION
This PR is removing the measurement for `total time` in each individual command, because this is already part of the `wrapCli` wrapper, which wraps every command.

It also changes `Counter` to `ResettingTimer` for measuring the `total time`.

It also removes colouring in the logs, so that smoke test logs are readable when we aggregate them in Elastic Search.