### PR TITLE
common/compiler: fixed testSource

### DIFF
--- a/common/compiler/solidity_test.go
+++ b/common/compiler/solidity_test.go
@@ -23,9 +23,10 @@ import (
 
 const (
 	testSource = `
+pragma solidity >0.0.0;
 contract test {
    /// @notice Will multiply ` + "`a`" + ` by 7.
-   function multiply(uint a) returns(uint d) {
+   function multiply(uint a) public returns(uint d) {
        return a * 7;
    }
 }


### PR DESCRIPTION
The test for the `common/compiler` package fails because the string that is fed into `solc` doesn't declare a solidity pragma. This declaration is needed in `solc >=0.4.0`.

It might be better to replace `>0.0.0` for `>=0.4.0`.
