### PR TITLE
core/rawdb: return database version as uint64

### DIFF
--- a/core/rawdb/accessors_metadata.go
+++ b/core/rawdb/accessors_metadata.go
@@ -1,4 +1,4 @@
-// Copyright 2018 The go-ethereum Authors
+// Copyright 2019 The go-ethereum Authors
 // This file is part of the go-ethereum library.
 //
 // The go-ethereum library is free software: you can redistribute it and/or modify
@@ -25,19 +25,21 @@ import (
 	"github.com/ethereum/go-ethereum/rlp"
 )
 
+const NoVersion = uint64(0)
+
 // ReadDatabaseVersion retrieves the version number of the database.
-func ReadDatabaseVersion(db DatabaseReader) *uint64 {
+func ReadDatabaseVersion(db DatabaseReader) uint64 {
 	var version uint64
 
 	enc, _ := db.Get(databaseVerisionKey)
 	if len(enc) == 0 {
-		return nil
+		return NoVersion
 	}
 	if err := rlp.DecodeBytes(enc, &version); err != nil {
-		return nil
+		return NoVersion
 	}
 
-	return &version
+	return version
 }
 
 // WriteDatabaseVersion stores the version number of the database

--- a/core/rawdb/accessors_metadata_test.go
+++ b/core/rawdb/accessors_metadata_test.go
@@ -1,0 +1,42 @@
+// Copyright 2019 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+package rawdb
+
+import (
+	"testing"
+
+	"github.com/ethereum/go-ethereum/ethdb"
+)
+
+func TestReadWriteDatabaseVersion(t *testing.T) {
+	db := ethdb.NewMemDatabase()
+	want := uint64(4)
+
+	WriteDatabaseVersion(db, want)
+	if got := ReadDatabaseVersion(db); want != got {
+		t.Fatalf("ReadDatabaseVersion(db) = %d, want %d", want, got)
+	}
+}
+
+func TestReadDatabaseVersion_Empty_ReturnsZero(t *testing.T) {
+	db := ethdb.NewMemDatabase()
+
+	if got := ReadDatabaseVersion(db); NoVersion != got {
+		t.Fatalf("ReadDatabaseVersion(db) = %d, want %d", NoVersion, got)
+
+	}
+}

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -1,4 +1,4 @@
-// Copyright 2014 The go-ethereum Authors
+// Copyright 2019 The go-ethereum Authors
 // This file is part of the go-ethereum library.
 //
 // The go-ethereum library is free software: you can redistribute it and/or modify
@@ -143,10 +143,10 @@ func New(ctx *node.ServiceContext, config *Config) (*Ethereum, error) {
 
 	if !config.SkipBcVersionCheck {
 		bcVersion := rawdb.ReadDatabaseVersion(chainDb)
-		if bcVersion != nil && *bcVersion > core.BlockChainVersion {
-			return nil, fmt.Errorf("database version is v%d, Geth %s only supports v%d", *bcVersion, params.VersionWithMeta, core.BlockChainVersion)
-		} else if bcVersion != nil && *bcVersion < core.BlockChainVersion {
-			log.Warn("Upgrade blockchain database version", "from", *bcVersion, "to", core.BlockChainVersion)
+		if bcVersion != rawdb.NoVersion && bcVersion > core.BlockChainVersion {
+			return nil, fmt.Errorf("database version is v%d, Geth %s only supports v%d", bcVersion, params.VersionWithMeta, core.BlockChainVersion)
+		} else if bcVersion != rawdb.NoVersion && bcVersion < core.BlockChainVersion {
+			log.Warn("Upgrade blockchain database version", "from", bcVersion, "to", core.BlockChainVersion)
 		}
 		rawdb.WriteDatabaseVersion(chainDb, core.BlockChainVersion)
 	}


### PR DESCRIPTION
rawdb.ReadDatabaseVersion returns a pointer to a local variable, which
can return an invalid memory address error as the variable is no longer
in scope outside the method it was invoked in.

The return value is now just a uint64, which is no less expensive to
return and makes the method signature more idiomatic.