### PR TITLE
Small improvements to better work with Travis+`-race`

### DIFF
--- a/swarm/network/simulations/discovery/discovery_test.go
+++ b/swarm/network/simulations/discovery/discovery_test.go
@@ -362,9 +362,6 @@ func discoveryPersistenceSimulation(nodes, conns int, adapter adapters.NodeAdapt
 					return fmt.Errorf("error getting node string %s", err)
 				}
 				log.Info(nodeStr)
-				for _, a := range addrs {
-					log.Info(common.Bytes2Hex(a))
-				}
 				if !healthy.ConnectNN || healthy.CountKnowNN == 0 {
 					isHealthy = false
 					break

--- a/swarm/storage/common_test.go
+++ b/swarm/storage/common_test.go
@@ -142,10 +142,11 @@ func mget(store ChunkStore, hs []Address, f func(h Address, chunk Chunk) error) 
 		close(errc)
 	}()
 	var err error
+	timeout := 10 * time.Second
 	select {
 	case err = <-errc:
-	case <-time.NewTimer(5 * time.Second).C:
-		err = fmt.Errorf("timed out after 5 seconds")
+	case <-time.NewTimer(timeout).C:
+		err = fmt.Errorf("timed out after %v", timeout)
 	}
 	return err
 }


### PR DESCRIPTION
- Remove log from tests producing 1.5k lines per run
- Increase timeout so test won't fail with `-race`