### PR TITLE
 trie: move dirty data to clean cache on flush

### DIFF
--- a/trie/database.go
+++ b/trie/database.go
@@ -769,6 +769,11 @@ func (db *Database) uncache(hash common.Hash) {
 	}
 	delete(db.dirties, hash)
 	db.dirtiesSize -= common.StorageSize(common.HashLength + int(node.size))
+
+	// Move the flushed node into the clean cache to prevent insta-reloads
+	if db.cleans != nil {
+		db.cleans.Set(string(hash[:]), node.rlp())
+	}
 }
 
 // Size returns the current storage size of the memory cache in front of the


### PR DESCRIPTION
This is a tiny PR to test whether the clean cache can offset the archive performance hit of wiping the trie cache generations. For full nodes that seemed to have less impact (the dirty cache probably covering most of the trie cache generation surface), but for archive nodes the impact was too much. Lets see what happens now.