### PR TITLE
cmd, les: remove stutter from les package type declarations

### DIFF
--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -1427,7 +1427,7 @@ func RegisterEthService(stack *node.Node, cfg *eth.Config) {
 		err = stack.Register(func(ctx *node.ServiceContext) (node.Service, error) {
 			fullNode, err := eth.New(ctx, cfg)
 			if fullNode != nil && cfg.LightServ > 0 {
-				ls, _ := les.NewLesServer(fullNode, cfg)
+				ls, _ := les.NewServer(fullNode, cfg)
 				fullNode.AddLesServer(ls)
 			}
 			return fullNode, err

--- a/les/api_backend.go
+++ b/les/api_backend.go
@@ -38,36 +38,36 @@ import (
 	"github.com/ethereum/go-ethereum/rpc"
 )
 
-type LesApiBackend struct {
+type ApiBackend struct {
 	eth *LightEthereum
 	gpo *gasprice.Oracle
 }
 
-func (b *LesApiBackend) ChainConfig() *params.ChainConfig {
+func (b *ApiBackend) ChainConfig() *params.ChainConfig {
 	return b.eth.chainConfig
 }
 
-func (b *LesApiBackend) CurrentBlock() *types.Block {
+func (b *ApiBackend) CurrentBlock() *types.Block {
 	return types.NewBlockWithHeader(b.eth.BlockChain().CurrentHeader())
 }
 
-func (b *LesApiBackend) SetHead(number uint64) {
+func (b *ApiBackend) SetHead(number uint64) {
 	b.eth.protocolManager.downloader.Cancel()
 	b.eth.blockchain.SetHead(number)
 }
 
-func (b *LesApiBackend) HeaderByNumber(ctx context.Context, blockNr rpc.BlockNumber) (*types.Header, error) {
+func (b *ApiBackend) HeaderByNumber(ctx context.Context, blockNr rpc.BlockNumber) (*types.Header, error) {
 	if blockNr == rpc.LatestBlockNumber || blockNr == rpc.PendingBlockNumber {
 		return b.eth.blockchain.CurrentHeader(), nil
 	}
 	return b.eth.blockchain.GetHeaderByNumberOdr(ctx, uint64(blockNr))
 }
 
-func (b *LesApiBackend) HeaderByHash(ctx context.Context, hash common.Hash) (*types.Header, error) {
+func (b *ApiBackend) HeaderByHash(ctx context.Context, hash common.Hash) (*types.Header, error) {
 	return b.eth.blockchain.GetHeaderByHash(hash), nil
 }
 
-func (b *LesApiBackend) BlockByNumber(ctx context.Context, blockNr rpc.BlockNumber) (*types.Block, error) {
+func (b *ApiBackend) BlockByNumber(ctx context.Context, blockNr rpc.BlockNumber) (*types.Block, error) {
 	header, err := b.HeaderByNumber(ctx, blockNr)
 	if header == nil || err != nil {
 		return nil, err
@@ -75,7 +75,7 @@ func (b *LesApiBackend) BlockByNumber(ctx context.Context, blockNr rpc.BlockNumb
 	return b.GetBlock(ctx, header.Hash())
 }
 
-func (b *LesApiBackend) StateAndHeaderByNumber(ctx context.Context, blockNr rpc.BlockNumber) (*state.StateDB, *types.Header, error) {
+func (b *ApiBackend) StateAndHeaderByNumber(ctx context.Context, blockNr rpc.BlockNumber) (*state.StateDB, *types.Header, error) {
 	header, err := b.HeaderByNumber(ctx, blockNr)
 	if header == nil || err != nil {
 		return nil, nil, err
@@ -83,111 +83,111 @@ func (b *LesApiBackend) StateAndHeaderByNumber(ctx context.Context, blockNr rpc.
 	return light.NewState(ctx, header, b.eth.odr), header, nil
 }
 
-func (b *LesApiBackend) GetBlock(ctx context.Context, blockHash common.Hash) (*types.Block, error) {
+func (b *ApiBackend) GetBlock(ctx context.Context, blockHash common.Hash) (*types.Block, error) {
 	return b.eth.blockchain.GetBlockByHash(ctx, blockHash)
 }
 
-func (b *LesApiBackend) GetReceipts(ctx context.Context, hash common.Hash) (types.Receipts, error) {
+func (b *ApiBackend) GetReceipts(ctx context.Context, hash common.Hash) (types.Receipts, error) {
 	if number := rawdb.ReadHeaderNumber(b.eth.chainDb, hash); number != nil {
 		return light.GetBlockReceipts(ctx, b.eth.odr, hash, *number)
 	}
 	return nil, nil
 }
 
-func (b *LesApiBackend) GetLogs(ctx context.Context, hash common.Hash) ([][]*types.Log, error) {
+func (b *ApiBackend) GetLogs(ctx context.Context, hash common.Hash) ([][]*types.Log, error) {
 	if number := rawdb.ReadHeaderNumber(b.eth.chainDb, hash); number != nil {
 		return light.GetBlockLogs(ctx, b.eth.odr, hash, *number)
 	}
 	return nil, nil
 }
 
-func (b *LesApiBackend) GetTd(hash common.Hash) *big.Int {
+func (b *ApiBackend) GetTd(hash common.Hash) *big.Int {
 	return b.eth.blockchain.GetTdByHash(hash)
 }
 
-func (b *LesApiBackend) GetEVM(ctx context.Context, msg core.Message, state *state.StateDB, header *types.Header) (*vm.EVM, func() error, error) {
+func (b *ApiBackend) GetEVM(ctx context.Context, msg core.Message, state *state.StateDB, header *types.Header) (*vm.EVM, func() error, error) {
 	state.SetBalance(msg.From(), math.MaxBig256)
 	context := core.NewEVMContext(msg, header, b.eth.blockchain, nil)
 	return vm.NewEVM(context, state, b.eth.chainConfig, vm.Config{}), state.Error, nil
 }
 
-func (b *LesApiBackend) SendTx(ctx context.Context, signedTx *types.Transaction) error {
+func (b *ApiBackend) SendTx(ctx context.Context, signedTx *types.Transaction) error {
 	return b.eth.txPool.Add(ctx, signedTx)
 }
 
-func (b *LesApiBackend) RemoveTx(txHash common.Hash) {
+func (b *ApiBackend) RemoveTx(txHash common.Hash) {
 	b.eth.txPool.RemoveTx(txHash)
 }
 
-func (b *LesApiBackend) GetPoolTransactions() (types.Transactions, error) {
+func (b *ApiBackend) GetPoolTransactions() (types.Transactions, error) {
 	return b.eth.txPool.GetTransactions()
 }
 
-func (b *LesApiBackend) GetPoolTransaction(txHash common.Hash) *types.Transaction {
+func (b *ApiBackend) GetPoolTransaction(txHash common.Hash) *types.Transaction {
 	return b.eth.txPool.GetTransaction(txHash)
 }
 
-func (b *LesApiBackend) GetPoolNonce(ctx context.Context, addr common.Address) (uint64, error) {
+func (b *ApiBackend) GetPoolNonce(ctx context.Context, addr common.Address) (uint64, error) {
 	return b.eth.txPool.GetNonce(ctx, addr)
 }
 
-func (b *LesApiBackend) Stats() (pending int, queued int) {
+func (b *ApiBackend) Stats() (pending int, queued int) {
 	return b.eth.txPool.Stats(), 0
 }
 
-func (b *LesApiBackend) TxPoolContent() (map[common.Address]types.Transactions, map[common.Address]types.Transactions) {
+func (b *ApiBackend) TxPoolContent() (map[common.Address]types.Transactions, map[common.Address]types.Transactions) {
 	return b.eth.txPool.Content()
 }
 
-func (b *LesApiBackend) SubscribeNewTxsEvent(ch chan<- core.NewTxsEvent) event.Subscription {
+func (b *ApiBackend) SubscribeNewTxsEvent(ch chan<- core.NewTxsEvent) event.Subscription {
 	return b.eth.txPool.SubscribeNewTxsEvent(ch)
 }
 
-func (b *LesApiBackend) SubscribeChainEvent(ch chan<- core.ChainEvent) event.Subscription {
+func (b *ApiBackend) SubscribeChainEvent(ch chan<- core.ChainEvent) event.Subscription {
 	return b.eth.blockchain.SubscribeChainEvent(ch)
 }
 
-func (b *LesApiBackend) SubscribeChainHeadEvent(ch chan<- core.ChainHeadEvent) event.Subscription {
+func (b *ApiBackend) SubscribeChainHeadEvent(ch chan<- core.ChainHeadEvent) event.Subscription {
 	return b.eth.blockchain.SubscribeChainHeadEvent(ch)
 }
 
-func (b *LesApiBackend) SubscribeChainSideEvent(ch chan<- core.ChainSideEvent) event.Subscription {
+func (b *ApiBackend) SubscribeChainSideEvent(ch chan<- core.ChainSideEvent) event.Subscription {
 	return b.eth.blockchain.SubscribeChainSideEvent(ch)
 }
 
-func (b *LesApiBackend) SubscribeLogsEvent(ch chan<- []*types.Log) event.Subscription {
+func (b *ApiBackend) SubscribeLogsEvent(ch chan<- []*types.Log) event.Subscription {
 	return b.eth.blockchain.SubscribeLogsEvent(ch)
 }
 
-func (b *LesApiBackend) SubscribeRemovedLogsEvent(ch chan<- core.RemovedLogsEvent) event.Subscription {
+func (b *ApiBackend) SubscribeRemovedLogsEvent(ch chan<- core.RemovedLogsEvent) event.Subscription {
 	return b.eth.blockchain.SubscribeRemovedLogsEvent(ch)
 }
 
-func (b *LesApiBackend) Downloader() *downloader.Downloader {
+func (b *ApiBackend) Downloader() *downloader.Downloader {
 	return b.eth.Downloader()
 }
 
-func (b *LesApiBackend) ProtocolVersion() int {
+func (b *ApiBackend) ProtocolVersion() int {
 	return b.eth.LesVersion() + 10000
 }
 
-func (b *LesApiBackend) SuggestPrice(ctx context.Context) (*big.Int, error) {
+func (b *ApiBackend) SuggestPrice(ctx context.Context) (*big.Int, error) {
 	return b.gpo.SuggestPrice(ctx)
 }
 
-func (b *LesApiBackend) ChainDb() ethdb.Database {
+func (b *ApiBackend) ChainDb() ethdb.Database {
 	return b.eth.chainDb
 }
 
-func (b *LesApiBackend) EventMux() *event.TypeMux {
+func (b *ApiBackend) EventMux() *event.TypeMux {
 	return b.eth.eventMux
 }
 
-func (b *LesApiBackend) AccountManager() *accounts.Manager {
+func (b *ApiBackend) AccountManager() *accounts.Manager {
 	return b.eth.accountManager
 }
 
-func (b *LesApiBackend) BloomStatus() (uint64, uint64) {
+func (b *ApiBackend) BloomStatus() (uint64, uint64) {
 	if b.eth.bloomIndexer == nil {
 		return 0, 0
 	}
@@ -195,7 +195,7 @@ func (b *LesApiBackend) BloomStatus() (uint64, uint64) {
 	return params.BloomBitsBlocksClient, sections
 }
 
-func (b *LesApiBackend) ServiceFilter(ctx context.Context, session *bloombits.MatcherSession) {
+func (b *ApiBackend) ServiceFilter(ctx context.Context, session *bloombits.MatcherSession) {
 	for i := 0; i < bloomFilterThreads; i++ {
 		go session.Multiplex(bloomRetrievalBatch, bloomRetrievalWait, b.eth.bloomRequests)
 	}

--- a/les/commons.go
+++ b/les/commons.go
@@ -30,8 +30,8 @@ import (
 	"github.com/ethereum/go-ethereum/params"
 )
 
-// lesCommons contains fields needed by both server and client.
-type lesCommons struct {
+// commons contains fields needed by both server and client.
+type commons struct {
 	config                       *eth.Config
 	iConfig                      *light.IndexerConfig
 	chainDb                      ethdb.Database
@@ -51,7 +51,7 @@ type NodeInfo struct {
 }
 
 // makeProtocols creates protocol descriptors for the given LES versions.
-func (c *lesCommons) makeProtocols(versions []uint) []p2p.Protocol {
+func (c *commons) makeProtocols(versions []uint) []p2p.Protocol {
 	protos := make([]p2p.Protocol, len(versions))
 	for i, version := range versions {
 		version := version
@@ -75,7 +75,7 @@ func (c *lesCommons) makeProtocols(versions []uint) []p2p.Protocol {
 }
 
 // nodeInfo retrieves some protocol metadata about the running host node.
-func (c *lesCommons) nodeInfo() interface{} {
+func (c *commons) nodeInfo() interface{} {
 	var cht params.TrustedCheckpoint
 	sections, _, _ := c.chtIndexer.Sections()
 	sections2, _, _ := c.bloomTrieIndexer.Sections()

--- a/les/fetcher.go
+++ b/les/fetcher.go
@@ -42,7 +42,7 @@ const (
 // and announced that block.
 type lightFetcher struct {
 	pm    *ProtocolManager
-	odr   *LesOdr
+	odr   *Odr
 	chain lightChain
 
 	lock            sync.Mutex // lock protects access to the fetcher's internal state variables except sent requests

--- a/les/handler.go
+++ b/les/handler.go
@@ -92,14 +92,14 @@ type txPool interface {
 type ProtocolManager struct {
 	lightSync   bool
 	txpool      txPool
-	txrelay     *LesTxRelay
+	txrelay     *TxRelay
 	networkId   uint64
 	chainConfig *params.ChainConfig
 	iConfig     *light.IndexerConfig
 	blockchain  BlockChain
 	chainDb     ethdb.Database
-	odr         *LesOdr
-	server      *LesServer
+	odr         *Odr
+	server      *Server
 	serverPool  *serverPool
 	clientPool  *freeClientPool
 	lesTopic    discv5.Topic
@@ -137,8 +137,8 @@ func NewProtocolManager(
 	blockchain BlockChain,
 	txpool txPool,
 	chainDb ethdb.Database,
-	odr *LesOdr,
-	txrelay *LesTxRelay,
+	odr *Odr,
+	txrelay *TxRelay,
 	serverPool *serverPool,
 	quitSync chan struct{},
 	wg *sync.WaitGroup,

--- a/les/helper_test.go
+++ b/les/helper_test.go
@@ -146,7 +146,7 @@ func testRCL() RequestCostList {
 // newTestProtocolManager creates a new protocol manager for testing purposes,
 // with the given number of blocks already known, potential notification
 // channels for different events and relative chain indexers array.
-func newTestProtocolManager(lightSync bool, blocks int, generator func(int, *core.BlockGen), odr *LesOdr, peers *peerSet, db ethdb.Database, ulcConfig *eth.ULCConfig) (*ProtocolManager, error) {
+func newTestProtocolManager(lightSync bool, blocks int, generator func(int, *core.BlockGen), odr *Odr, peers *peerSet, db ethdb.Database, ulcConfig *eth.ULCConfig) (*ProtocolManager, error) {
 	var (
 		evmux  = new(event.TypeMux)
 		engine = ethash.NewFaker()
@@ -181,7 +181,7 @@ func newTestProtocolManager(lightSync bool, blocks int, generator func(int, *cor
 		return nil, err
 	}
 	if !lightSync {
-		srv := &LesServer{lesCommons: lesCommons{protocolManager: pm}}
+		srv := &Server{commons: commons{protocolManager: pm}}
 		pm.server = srv
 
 		srv.defParams = &flowcontrol.ServerParams{
@@ -200,7 +200,7 @@ func newTestProtocolManager(lightSync bool, blocks int, generator func(int, *cor
 // with the given number of blocks already known, potential notification
 // channels for different events and relative chain indexers array. In case of an error, the constructor force-
 // fails the test.
-func newTestProtocolManagerMust(t *testing.T, lightSync bool, blocks int, generator func(int, *core.BlockGen), odr *LesOdr, peers *peerSet, db ethdb.Database, ulcConfig *eth.ULCConfig) *ProtocolManager {
+func newTestProtocolManagerMust(t *testing.T, lightSync bool, blocks int, generator func(int, *core.BlockGen), odr *Odr, peers *peerSet, db ethdb.Database, ulcConfig *eth.ULCConfig) *ProtocolManager {
 	pm, err := newTestProtocolManager(lightSync, blocks, generator, odr, peers, db, ulcConfig)
 	if err != nil {
 		t.Fatalf("Failed to create protocol manager: %v", err)
@@ -377,7 +377,7 @@ func newClientServerEnv(t *testing.T, blocks int, protocol int, waitIndexers fun
 
 	dist := newRequestDistributor(lPeers, make(chan struct{}))
 	rm := newRetrieveManager(lPeers, dist, nil)
-	odr := NewLesOdr(ldb, light.TestClientIndexerConfig, rm)
+	odr := NewOdr(ldb, light.TestClientIndexerConfig, rm)
 
 	cIndexer, bIndexer, btIndexer := testIndexers(db, nil, light.TestServerIndexerConfig)
 	lcIndexer, lbIndexer, lbtIndexer := testIndexers(ldb, odr, light.TestClientIndexerConfig)

--- a/les/odr.go
+++ b/les/odr.go
@@ -25,8 +25,8 @@ import (
 	"github.com/ethereum/go-ethereum/log"
 )
 
-// LesOdr implements light.OdrBackend
-type LesOdr struct {
+// Odr implements light.OdrBackend
+type Odr struct {
 	db                                         ethdb.Database
 	indexerConfig                              *light.IndexerConfig
 	chtIndexer, bloomTrieIndexer, bloomIndexer *core.ChainIndexer
@@ -34,8 +34,8 @@ type LesOdr struct {
 	stop                                       chan struct{}
 }
 
-func NewLesOdr(db ethdb.Database, config *light.IndexerConfig, retriever *retrieveManager) *LesOdr {
-	return &LesOdr{
+func NewOdr(db ethdb.Database, config *light.IndexerConfig, retriever *retrieveManager) *Odr {
+	return &Odr{
 		db:            db,
 		indexerConfig: config,
 		retriever:     retriever,
@@ -44,39 +44,39 @@ func NewLesOdr(db ethdb.Database, config *light.IndexerConfig, retriever *retrie
 }
 
 // Stop cancels all pending retrievals
-func (odr *LesOdr) Stop() {
+func (odr *Odr) Stop() {
 	close(odr.stop)
 }
 
 // Database returns the backing database
-func (odr *LesOdr) Database() ethdb.Database {
+func (odr *Odr) Database() ethdb.Database {
 	return odr.db
 }
 
 // SetIndexers adds the necessary chain indexers to the ODR backend
-func (odr *LesOdr) SetIndexers(chtIndexer, bloomTrieIndexer, bloomIndexer *core.ChainIndexer) {
+func (odr *Odr) SetIndexers(chtIndexer, bloomTrieIndexer, bloomIndexer *core.ChainIndexer) {
 	odr.chtIndexer = chtIndexer
 	odr.bloomTrieIndexer = bloomTrieIndexer
 	odr.bloomIndexer = bloomIndexer
 }
 
 // ChtIndexer returns the CHT chain indexer
-func (odr *LesOdr) ChtIndexer() *core.ChainIndexer {
+func (odr *Odr) ChtIndexer() *core.ChainIndexer {
 	return odr.chtIndexer
 }
 
 // BloomTrieIndexer returns the bloom trie chain indexer
-func (odr *LesOdr) BloomTrieIndexer() *core.ChainIndexer {
+func (odr *Odr) BloomTrieIndexer() *core.ChainIndexer {
 	return odr.bloomTrieIndexer
 }
 
 // BloomIndexer returns the bloombits chain indexer
-func (odr *LesOdr) BloomIndexer() *core.ChainIndexer {
+func (odr *Odr) BloomIndexer() *core.ChainIndexer {
 	return odr.bloomIndexer
 }
 
 // IndexerConfig returns the indexer config.
-func (odr *LesOdr) IndexerConfig() *light.IndexerConfig {
+func (odr *Odr) IndexerConfig() *light.IndexerConfig {
 	return odr.indexerConfig
 }
 
@@ -99,8 +99,8 @@ type Msg struct {
 
 // Retrieve tries to fetch an object from the LES network.
 // If the network retrieval was successful, it stores the object in local db.
-func (odr *LesOdr) Retrieve(ctx context.Context, req light.OdrRequest) (err error) {
-	lreq := LesRequest(req)
+func (odr *Odr) Retrieve(ctx context.Context, req light.OdrRequest) (err error) {
+	lreq := Request(req)
 
 	reqID := genReqID()
 	rq := &distReq{

--- a/les/odr_requests.go
+++ b/les/odr_requests.go
@@ -47,14 +47,14 @@ var (
 	errUselessNodes        = errors.New("useless nodes in merkle proof nodeset")
 )
 
-type LesOdrRequest interface {
+type OdrRequest interface {
 	GetCost(*peer) uint64
 	CanSend(*peer) bool
 	Request(uint64, *peer) error
 	Validate(ethdb.Database, *Msg) error
 }
 
-func LesRequest(req light.OdrRequest) LesOdrRequest {
+func Request(req light.OdrRequest) OdrRequest {
 	switch r := req.(type) {
 	case *light.BlockRequest:
 		return (*BlockRequest)(r)
@@ -77,7 +77,7 @@ func LesRequest(req light.OdrRequest) LesOdrRequest {
 type BlockRequest light.BlockRequest
 
 // GetCost returns the cost of the given ODR request according to the serving
-// peer's cost table (implementation of LesOdrRequest)
+// peer's cost table (implementation of OdrRequest)
 func (r *BlockRequest) GetCost(peer *peer) uint64 {
 	return peer.GetRequestCost(GetBlockBodiesMsg, 1)
 }
@@ -87,7 +87,7 @@ func (r *BlockRequest) CanSend(peer *peer) bool {
 	return peer.HasBlock(r.Hash, r.Number, false)
 }
 
-// Request sends an ODR request to the LES network (implementation of LesOdrRequest)
+// Request sends an ODR request to the LES network (implementation of OdrRequest)
 func (r *BlockRequest) Request(reqID uint64, peer *peer) error {
 	peer.Log().Debug("Requesting block body", "hash", r.Hash)
 	return peer.RequestBodies(reqID, r.GetCost(peer), []common.Hash{r.Hash})
@@ -95,7 +95,7 @@ func (r *BlockRequest) Request(reqID uint64, peer *peer) error {
 
 // Valid processes an ODR request reply message from the LES network
 // returns true and stores results in memory if the message was a valid reply
-// to the request (implementation of LesOdrRequest)
+// to the request (implementation of OdrRequest)
 func (r *BlockRequest) Validate(db ethdb.Database, msg *Msg) error {
 	log.Debug("Validating block body", "hash", r.Hash)
 
@@ -133,7 +133,7 @@ func (r *BlockRequest) Validate(db ethdb.Database, msg *Msg) error {
 type ReceiptsRequest light.ReceiptsRequest
 
 // GetCost returns the cost of the given ODR request according to the serving
-// peer's cost table (implementation of LesOdrRequest)
+// peer's cost table (implementation of OdrRequest)
 func (r *ReceiptsRequest) GetCost(peer *peer) uint64 {
 	return peer.GetRequestCost(GetReceiptsMsg, 1)
 }
@@ -143,7 +143,7 @@ func (r *ReceiptsRequest) CanSend(peer *peer) bool {
 	return peer.HasBlock(r.Hash, r.Number, false)
 }
 
-// Request sends an ODR request to the LES network (implementation of LesOdrRequest)
+// Request sends an ODR request to the LES network (implementation of OdrRequest)
 func (r *ReceiptsRequest) Request(reqID uint64, peer *peer) error {
 	peer.Log().Debug("Requesting block receipts", "hash", r.Hash)
 	return peer.RequestReceipts(reqID, r.GetCost(peer), []common.Hash{r.Hash})
@@ -151,7 +151,7 @@ func (r *ReceiptsRequest) Request(reqID uint64, peer *peer) error {
 
 // Valid processes an ODR request reply message from the LES network
 // returns true and stores results in memory if the message was a valid reply
-// to the request (implementation of LesOdrRequest)
+// to the request (implementation of OdrRequest)
 func (r *ReceiptsRequest) Validate(db ethdb.Database, msg *Msg) error {
 	log.Debug("Validating block receipts", "hash", r.Hash)
 
@@ -184,11 +184,11 @@ type ProofReq struct {
 	FromLevel   uint
 }
 
-// ODR request type for state/storage trie entries, see LesOdrRequest interface
+// ODR request type for state/storage trie entries, see OdrRequest interface
 type TrieRequest light.TrieRequest
 
 // GetCost returns the cost of the given ODR request according to the serving
-// peer's cost table (implementation of LesOdrRequest)
+// peer's cost table (implementation of OdrRequest)
 func (r *TrieRequest) GetCost(peer *peer) uint64 {
 	switch peer.version {
 	case lpv1:
@@ -205,7 +205,7 @@ func (r *TrieRequest) CanSend(peer *peer) bool {
 	return peer.HasBlock(r.Id.BlockHash, r.Id.BlockNumber, true)
 }
 
-// Request sends an ODR request to the LES network (implementation of LesOdrRequest)
+// Request sends an ODR request to the LES network (implementation of OdrRequest)
 func (r *TrieRequest) Request(reqID uint64, peer *peer) error {
 	peer.Log().Debug("Requesting trie proof", "root", r.Id.Root, "key", r.Key)
 	req := ProofReq{
@@ -218,7 +218,7 @@ func (r *TrieRequest) Request(reqID uint64, peer *peer) error {
 
 // Valid processes an ODR request reply message from the LES network
 // returns true and stores results in memory if the message was a valid reply
-// to the request (implementation of LesOdrRequest)
+// to the request (implementation of OdrRequest)
 func (r *TrieRequest) Validate(db ethdb.Database, msg *Msg) error {
 	log.Debug("Validating trie proof", "root", r.Id.Root, "key", r.Key)
 
@@ -261,11 +261,11 @@ type CodeReq struct {
 	AccKey []byte
 }
 
-// ODR request type for node data (used for retrieving contract code), see LesOdrRequest interface
+// ODR request type for node data (used for retrieving contract code), see OdrRequest interface
 type CodeRequest light.CodeRequest
 
 // GetCost returns the cost of the given ODR request according to the serving
-// peer's cost table (implementation of LesOdrRequest)
+// peer's cost table (implementation of OdrRequest)
 func (r *CodeRequest) GetCost(peer *peer) uint64 {
 	return peer.GetRequestCost(GetCodeMsg, 1)
 }
@@ -275,7 +275,7 @@ func (r *CodeRequest) CanSend(peer *peer) bool {
 	return peer.HasBlock(r.Id.BlockHash, r.Id.BlockNumber, true)
 }
 
-// Request sends an ODR request to the LES network (implementation of LesOdrRequest)
+// Request sends an ODR request to the LES network (implementation of OdrRequest)
 func (r *CodeRequest) Request(reqID uint64, peer *peer) error {
 	peer.Log().Debug("Requesting code data", "hash", r.Hash)
 	req := CodeReq{
@@ -287,7 +287,7 @@ func (r *CodeRequest) Request(reqID uint64, peer *peer) error {
 
 // Valid processes an ODR request reply message from the LES network
 // returns true and stores results in memory if the message was a valid reply
-// to the request (implementation of LesOdrRequest)
+// to the request (implementation of OdrRequest)
 func (r *CodeRequest) Validate(db ethdb.Database, msg *Msg) error {
 	log.Debug("Validating code data", "hash", r.Hash)
 
@@ -344,11 +344,11 @@ type ChtResp struct {
 	Proof  []rlp.RawValue
 }
 
-// ODR request type for requesting headers by Canonical Hash Trie, see LesOdrRequest interface
+// ODR request type for requesting headers by Canonical Hash Trie, see OdrRequest interface
 type ChtRequest light.ChtRequest
 
 // GetCost returns the cost of the given ODR request according to the serving
-// peer's cost table (implementation of LesOdrRequest)
+// peer's cost table (implementation of OdrRequest)
 func (r *ChtRequest) GetCost(peer *peer) uint64 {
 	switch peer.version {
 	case lpv1:
@@ -368,7 +368,7 @@ func (r *ChtRequest) CanSend(peer *peer) bool {
 	return peer.headInfo.Number >= r.Config.ChtConfirms && r.ChtNum <= (peer.headInfo.Number-r.Config.ChtConfirms)/r.Config.ChtSize
 }
 
-// Request sends an ODR request to the LES network (implementation of LesOdrRequest)
+// Request sends an ODR request to the LES network (implementation of OdrRequest)
 func (r *ChtRequest) Request(reqID uint64, peer *peer) error {
 	peer.Log().Debug("Requesting CHT", "cht", r.ChtNum, "block", r.BlockNum)
 	var encNum [8]byte
@@ -398,7 +398,7 @@ func (r *ChtRequest) Request(reqID uint64, peer *peer) error {
 
 // Valid processes an ODR request reply message from the LES network
 // returns true and stores results in memory if the message was a valid reply
-// to the request (implementation of LesOdrRequest)
+// to the request (implementation of OdrRequest)
 func (r *ChtRequest) Validate(db ethdb.Database, msg *Msg) error {
 	log.Debug("Validating CHT", "cht", r.ChtNum, "block", r.BlockNum)
 
@@ -481,11 +481,11 @@ type BloomReq struct {
 	BloomTrieNum, BitIdx, SectionIndex, FromLevel uint64
 }
 
-// ODR request type for requesting headers by Canonical Hash Trie, see LesOdrRequest interface
+// ODR request type for requesting headers by Canonical Hash Trie, see OdrRequest interface
 type BloomRequest light.BloomRequest
 
 // GetCost returns the cost of the given ODR request according to the serving
-// peer's cost table (implementation of LesOdrRequest)
+// peer's cost table (implementation of OdrRequest)
 func (r *BloomRequest) GetCost(peer *peer) uint64 {
 	return peer.GetRequestCost(GetHelperTrieProofsMsg, len(r.SectionIndexList))
 }
@@ -501,7 +501,7 @@ func (r *BloomRequest) CanSend(peer *peer) bool {
 	return peer.headInfo.Number >= r.Config.BloomTrieConfirms && r.BloomTrieNum <= (peer.headInfo.Number-r.Config.BloomTrieConfirms)/r.Config.BloomTrieSize
 }
 
-// Request sends an ODR request to the LES network (implementation of LesOdrRequest)
+// Request sends an ODR request to the LES network (implementation of OdrRequest)
 func (r *BloomRequest) Request(reqID uint64, peer *peer) error {
 	peer.Log().Debug("Requesting BloomBits", "bloomTrie", r.BloomTrieNum, "bitIdx", r.BitIdx, "sections", r.SectionIndexList)
 	reqs := make([]HelperTrieReq, len(r.SectionIndexList))
@@ -522,7 +522,7 @@ func (r *BloomRequest) Request(reqID uint64, peer *peer) error {
 
 // Valid processes an ODR request reply message from the LES network
 // returns true and stores results in memory if the message was a valid reply
-// to the request (implementation of LesOdrRequest)
+// to the request (implementation of OdrRequest)
 func (r *BloomRequest) Validate(db ethdb.Database, msg *Msg) error {
 	log.Debug("Validating BloomBits", "bloomTrie", r.BloomTrieNum, "bitIdx", r.BitIdx, "sections", r.SectionIndexList)
 

--- a/les/peer.go
+++ b/les/peer.go
@@ -393,7 +393,7 @@ func (p *peer) sendReceiveHandshake(sendList keyValueList) (keyValueList, error)
 
 // Handshake executes the les protocol handshake, negotiating version number,
 // network IDs, difficulties, head and genesis blocks.
-func (p *peer) Handshake(td *big.Int, head common.Hash, headNum uint64, genesis common.Hash, server *LesServer) error {
+func (p *peer) Handshake(td *big.Int, head common.Hash, headNum uint64, genesis common.Hash, server *Server) error {
 	p.lock.Lock()
 	defer p.lock.Unlock()
 

--- a/les/peer_test.go
+++ b/les/peer_test.go
@@ -237,8 +237,8 @@ func TestPeerHandshakeClientReturnErrorOnUselessPeer(t *testing.T) {
 	}
 }
 
-func generateLesServer() *LesServer {
-	s := &LesServer{
+func generateLesServer() *Server {
+	s := &Server{
 		defParams: &flowcontrol.ServerParams{
 			BufLimit:    uint64(300000000),
 			MinRecharge: uint64(50000),

--- a/les/server.go
+++ b/les/server.go
@@ -38,8 +38,8 @@ import (
 	"github.com/ethereum/go-ethereum/rlp"
 )
 
-type LesServer struct {
-	lesCommons
+type Server struct {
+	commons
 
 	fcManager    *flowcontrol.ClientManager // nil if our node is client only
 	fcCostStats  *requestCostStats
@@ -50,7 +50,7 @@ type LesServer struct {
 	onlyAnnounce bool
 }
 
-func NewLesServer(eth *eth.Ethereum, config *eth.Config) (*LesServer, error) {
+func NewServer(eth *eth.Ethereum, config *eth.Config) (*Server, error) {
 	quitSync := make(chan struct{})
 	pm, err := NewProtocolManager(
 		eth.BlockChain().Config(),
@@ -78,8 +78,8 @@ func NewLesServer(eth *eth.Ethereum, config *eth.Config) (*LesServer, error) {
 		lesTopics[i] = lesTopic(eth.BlockChain().Genesis().Hash(), pv)
 	}
 
-	srv := &LesServer{
-		lesCommons: lesCommons{
+	srv := &Server{
+		commons: commons{
 			config:           config,
 			chainDb:          eth.ChainDb(),
 			iConfig:          light.DefaultServerIndexerConfig,
@@ -125,12 +125,12 @@ func NewLesServer(eth *eth.Ethereum, config *eth.Config) (*LesServer, error) {
 	return srv, nil
 }
 
-func (s *LesServer) Protocols() []p2p.Protocol {
+func (s *Server) Protocols() []p2p.Protocol {
 	return s.makeProtocols(ServerProtocolVersions)
 }
 
 // Start starts the LES server
-func (s *LesServer) Start(srvr *p2p.Server) {
+func (s *Server) Start(srvr *p2p.Server) {
 	s.protocolManager.Start(s.config.LightPeers)
 	if srvr.DiscV5 != nil {
 		for _, topic := range s.lesTopics {
@@ -148,12 +148,12 @@ func (s *LesServer) Start(srvr *p2p.Server) {
 	s.protocolManager.blockLoop()
 }
 
-func (s *LesServer) SetBloomBitsIndexer(bloomIndexer *core.ChainIndexer) {
+func (s *Server) SetBloomBitsIndexer(bloomIndexer *core.ChainIndexer) {
 	bloomIndexer.AddChildIndexer(s.bloomTrieIndexer)
 }
 
 // Stop stops the LES service
-func (s *LesServer) Stop() {
+func (s *Server) Stop() {
 	s.chtIndexer.Close()
 	// bloom trie indexer is closed by parent bloombits indexer
 	s.fcCostStats.store()

--- a/les/txrelay.go
+++ b/les/txrelay.go
@@ -28,7 +28,7 @@ type ltrInfo struct {
 	sentTo map[*peer]struct{}
 }
 
-type LesTxRelay struct {
+type TxRelay struct {
 	txSent       map[common.Hash]*ltrInfo
 	txPending    map[common.Hash]struct{}
 	ps           *peerSet
@@ -39,8 +39,8 @@ type LesTxRelay struct {
 	reqDist *requestDistributor
 }
 
-func NewLesTxRelay(ps *peerSet, reqDist *requestDistributor) *LesTxRelay {
-	r := &LesTxRelay{
+func NewTxRelay(ps *peerSet, reqDist *requestDistributor) *TxRelay {
+	r := &TxRelay{
 		txSent:    make(map[common.Hash]*ltrInfo),
 		txPending: make(map[common.Hash]struct{}),
 		ps:        ps,
@@ -50,14 +50,14 @@ func NewLesTxRelay(ps *peerSet, reqDist *requestDistributor) *LesTxRelay {
 	return r
 }
 
-func (self *LesTxRelay) registerPeer(p *peer) {
+func (self *TxRelay) registerPeer(p *peer) {
 	self.lock.Lock()
 	defer self.lock.Unlock()
 
 	self.peerList = self.ps.AllPeers()
 }
 
-func (self *LesTxRelay) unregisterPeer(p *peer) {
+func (self *TxRelay) unregisterPeer(p *peer) {
 	self.lock.Lock()
 	defer self.lock.Unlock()
 
@@ -66,7 +66,7 @@ func (self *LesTxRelay) unregisterPeer(p *peer) {
 
 // send sends a list of transactions to at most a given number of peers at
 // once, never resending any particular transaction to the same peer twice
-func (self *LesTxRelay) send(txs types.Transactions, count int) {
+func (self *TxRelay) send(txs types.Transactions, count int) {
 	sendTo := make(map[*peer]types.Transactions)
 
 	self.peerStartPos++ // rotate the starting position of the peer list
@@ -134,14 +134,14 @@ func (self *LesTxRelay) send(txs types.Transactions, count int) {
 	}
 }
 
-func (self *LesTxRelay) Send(txs types.Transactions) {
+func (self *TxRelay) Send(txs types.Transactions) {
 	self.lock.Lock()
 	defer self.lock.Unlock()
 
 	self.send(txs, 3)
 }
 
-func (self *LesTxRelay) NewHead(head common.Hash, mined []common.Hash, rollback []common.Hash) {
+func (self *TxRelay) NewHead(head common.Hash, mined []common.Hash, rollback []common.Hash) {
 	self.lock.Lock()
 	defer self.lock.Unlock()
 
@@ -164,7 +164,7 @@ func (self *LesTxRelay) NewHead(head common.Hash, mined []common.Hash, rollback 
 	}
 }
 
-func (self *LesTxRelay) Discard(hashes []common.Hash) {
+func (self *TxRelay) Discard(hashes []common.Hash) {
 	self.lock.Lock()
 	defer self.lock.Unlock()
 

--- a/les/ulc_test.go
+++ b/les/ulc_test.go
@@ -221,7 +221,7 @@ func newLightPeer(t *testing.T, ulcConfig *eth.ULCConfig) pairPeer {
 	rm := newRetrieveManager(peers, dist, nil)
 	ldb := ethdb.NewMemDatabase()
 
-	odr := NewLesOdr(ldb, light.DefaultClientIndexerConfig, rm)
+	odr := NewOdr(ldb, light.DefaultClientIndexerConfig, rm)
 
 	pmLight := newTestProtocolManagerMust(t, true, 0, nil, odr, peers, ldb, ulcConfig)
 	peerPairLight := pairPeer{


### PR DESCRIPTION
Removes the "Les" prefix from types declared in the les package in
accordance with golang best practices [1]

[1] "Avoid stutter": https://blog.golang.org/package-names