### PR TITLE
swarm: Get all chunk references for a given file

### DIFF
--- a/swarm/storage/filestore.go
+++ b/swarm/storage/filestore.go
@@ -111,11 +111,10 @@ func (f *FileStore) GetAllReferences(ctx context.Context, data io.Reader, toEncr
 		return nil, err
 	}
 	// collect all references
-	arr := make([]Address, 0)
+	addrs = NewAddressCollection(0)
 	for _, ref := range putter.References {
-		arr = append(arr, Address(ref))
+		addrs = append(addrs, Address(ref))
 	}
-	addrs = NewAddressCollection(len(arr))
 	sort.Sort(addrs)
 	return addrs, nil
 }

--- a/swarm/storage/filestore.go
+++ b/swarm/storage/filestore.go
@@ -98,11 +98,11 @@ func (f *FileStore) HashSize() int {
 }
 
 // Public API. This endpoint returns all chunk hashes (only) for a given file
-func (f *FileStore) GetAllReferences(ctx context.Context, data io.Reader) (addrs []Address, err error) {
+func (f *FileStore) GetAllReferences(ctx context.Context, data io.Reader, toEncrypt bool) (addrs []Address, err error) {
 	addrs = make([]Address, 0)
 	// create a special kind of putter, which only will store the references
 	putter := &HashExplorer{
-		hasherStore: NewHasherStore(f.ChunkStore, f.hashFunc, false),
+		hasherStore: NewHasherStore(f.ChunkStore, f.hashFunc, toEncrypt),
 		References:  make([]Reference, 0),
 	}
 	// do the actual splitting anyway, no way around it

--- a/swarm/storage/filestore.go
+++ b/swarm/storage/filestore.go
@@ -19,6 +19,7 @@ package storage
 import (
 	"context"
 	"io"
+	"sort"
 )
 
 /*
@@ -98,8 +99,7 @@ func (f *FileStore) HashSize() int {
 }
 
 // Public API. This endpoint returns all chunk hashes (only) for a given file
-func (f *FileStore) GetAllReferences(ctx context.Context, data io.Reader, toEncrypt bool) (addrs []Address, err error) {
-	addrs = make([]Address, 0)
+func (f *FileStore) GetAllReferences(ctx context.Context, data io.Reader, toEncrypt bool) (addrs AddressCollection, err error) {
 	// create a special kind of putter, which only will store the references
 	putter := &HashExplorer{
 		hasherStore: NewHasherStore(f.ChunkStore, f.hashFunc, toEncrypt),
@@ -111,9 +111,12 @@ func (f *FileStore) GetAllReferences(ctx context.Context, data io.Reader, toEncr
 		return nil, err
 	}
 	// collect all references
+	arr := make([]Address, 0)
 	for _, ref := range putter.References {
-		addrs = append(addrs, Address(ref))
+		arr = append(arr, Address(ref))
 	}
+	addrs = NewAddressCollection(len(arr))
+	sort.Sort(addrs)
 	return addrs, nil
 }
 

--- a/swarm/storage/filestore.go
+++ b/swarm/storage/filestore.go
@@ -99,20 +99,20 @@ func (f *FileStore) HashSize() int {
 
 // Public API. This endpoint returns all chunk hashes (only) for a given file
 func (f *FileStore) GetAllReferences(ctx context.Context, data io.Reader) (addrs []Address, err error) {
-	var addrs = make([]Address, 0)
+	addrs = make([]Address, 0)
 	// create a special kind of putter, which only will store the references
 	putter := &HashExplorer{
 		hasherStore: NewHasherStore(f.ChunkStore, f.hashFunc, false),
 		References:  make([]Reference, 0),
 	}
 	// do the actual splitting anyway, no way around it
-	_, _, err := PyramidSplit(ctx, data, putter, putter)
+	_, _, err = PyramidSplit(ctx, data, putter, putter)
 	if err != nil {
 		return nil, err
 	}
 	// collect all references
 	for _, ref := range putter.References {
-		addrs = append(addrs, ref)
+		addrs = append(addrs, Address(ref))
 	}
 	return addrs, nil
 }

--- a/swarm/storage/filestore.go
+++ b/swarm/storage/filestore.go
@@ -96,3 +96,41 @@ func (f *FileStore) Store(ctx context.Context, data io.Reader, size int64, toEnc
 func (f *FileStore) HashSize() int {
 	return f.hashFunc().Size()
 }
+
+// Public API. This endpoint returns all chunk hashes (only) for a given file
+func (f *FileStore) GetAllReferences(ctx context.Context, data io.Reader) (addrs []Address, err error) {
+	var addrs = make([]Address, 0)
+	// create a special kind of putter, which only will store the references
+	putter := &HashExplorer{
+		hasherStore: NewHasherStore(f.ChunkStore, f.hashFunc, false),
+		References:  make([]Reference, 0),
+	}
+	// do the actual splitting anyway, no way around it
+	_, _, err := PyramidSplit(ctx, data, putter, putter)
+	if err != nil {
+		return nil, err
+	}
+	// collect all references
+	for _, ref := range putter.References {
+		addrs = append(addrs, ref)
+	}
+	return addrs, nil
+}
+
+// HashExplorer is a special kind of putter which will only store chunk references
+type HashExplorer struct {
+	*hasherStore
+	References []Reference
+}
+
+// HashExplorer's Put will add just the chunk hashes to its `References`
+func (he *HashExplorer) Put(ctx context.Context, chunkData ChunkData) (Reference, error) {
+	// Need to do the actual Put, which returns the references
+	ref, err := he.hasherStore.Put(ctx, chunkData)
+	if err != nil {
+		return nil, err
+	}
+	// internally store the reference
+	he.References = append(he.References, ref)
+	return ref, nil
+}

--- a/swarm/storage/filestore_test.go
+++ b/swarm/storage/filestore_test.go
@@ -173,3 +173,39 @@ func testFileStoreCapacity(toEncrypt bool, t *testing.T) {
 		t.Fatalf("Comparison error after clearing memStore.")
 	}
 }
+
+// TestGetAllReferences only tests that GetAllReferences returns an expected
+// number of references for a given file
+func TestGetAllReferences(t *testing.T) {
+	tdb, cleanup, err := newTestDbStore(false, false)
+	defer cleanup()
+	if err != nil {
+		t.Fatalf("init dbStore failed: %v", err)
+	}
+	db := tdb.LDBStore
+	memStore := NewMemStore(NewDefaultStoreParams(), db)
+	localStore := &LocalStore{
+		memStore: memStore,
+		DbStore:  db,
+	}
+	fileStore := NewFileStore(localStore, NewFileStoreParams())
+
+	checkRefs := func(dataSize int, expectedLen int) {
+		slice := testutil.RandomBytes(1, dataSize)
+
+		addrs, err := fileStore.GetAllReferences(context.Background(), bytes.NewReader(slice))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(addrs) != expectedLen {
+			t.Fatalf("Expected reference array length to be %d, but is %d", expectedLen, len(addrs))
+		}
+	}
+
+	// testRuns[i] and expectedLen[i] are dataSize and expected length respectively
+	testRuns := []int{1024, 8192, 16000, 30000, 1000000}
+	expectedLens := []int{1, 3, 5, 9, 248}
+	for i, r := range testRuns {
+		checkRefs(r, expectedLens[i])
+	}
+}

--- a/swarm/storage/filestore_test.go
+++ b/swarm/storage/filestore_test.go
@@ -193,7 +193,7 @@ func TestGetAllReferences(t *testing.T) {
 	checkRefs := func(dataSize int, expectedLen int) {
 		slice := testutil.RandomBytes(1, dataSize)
 
-		addrs, err := fileStore.GetAllReferences(context.Background(), bytes.NewReader(slice))
+		addrs, err := fileStore.GetAllReferences(context.Background(), bytes.NewReader(slice), false)
 		if err != nil {
 			t.Fatal(err)
 		}


### PR DESCRIPTION
This PR adds an endpoint to `FileStore` which allows to get a list of hashes for a given file.

It has been discussed in the swarm team at https://github.com/ethersphere/go-ethereum/pull/1185 and reopened here for merging.

It is part of the solution for issue https://github.com/ethersphere/go-ethereum/issues/1099