### PR TITLE
cmd/swarm/swarm-smoke: refactor generateEndpoints

### DIFF
--- a/cmd/swarm/swarm-smoke/feed_upload_and_sync.go
+++ b/cmd/swarm/swarm-smoke/feed_upload_and_sync.go
@@ -26,11 +26,11 @@ const (
 	feedRandomDataLength = 8
 )
 
-func feedUploadAndSync(ctx *cli.Context, tuid string) error {
+func feedUploadAndSyncCmd(ctx *cli.Context, tuid string) error {
 	errc := make(chan error)
 
 	go func() {
-		errc <- fuas(ctx, tuid)
+		errc <- feedUploadAndSync(ctx, tuid)
 	}()
 
 	select {
@@ -46,7 +46,7 @@ func feedUploadAndSync(ctx *cli.Context, tuid string) error {
 	}
 }
 
-func fuas(c *cli.Context, tuid string) error {
+func feedUploadAndSync(c *cli.Context, tuid string) error {
 	log.Info("generating and uploading feeds to " + httpEndpoint(hosts[0]) + " and syncing")
 
 	// create a random private key to sign updates with and derive the address

--- a/cmd/swarm/swarm-smoke/feed_upload_and_sync.go
+++ b/cmd/swarm/swarm-smoke/feed_upload_and_sync.go
@@ -256,7 +256,7 @@ func feedUploadAndSync(c *cli.Context) error {
 			ruid := uuid.New()[:8]
 			go func(url string, endpoint string, ruid string) {
 				for {
-					err := fetch(url, endpoint, fileHash, ruid)
+					err := fetch(url, endpoint, fileHash, ruid, "")
 					if err != nil {
 						continue
 					}

--- a/cmd/swarm/swarm-smoke/main.go
+++ b/cmd/swarm/swarm-smoke/main.go
@@ -120,25 +120,25 @@ func main() {
 			Name:    "upload_and_sync",
 			Aliases: []string{"c"},
 			Usage:   "upload and sync",
-			Action:  wrapCliCommand("upload-and-sync", uploadAndSync),
+			Action:  wrapCliCommand("upload-and-sync", uploadAndSyncCmd),
 		},
 		{
 			Name:    "feed_sync",
 			Aliases: []string{"f"},
 			Usage:   "feed update generate, upload and sync",
-			Action:  wrapCliCommand("feed-and-sync", feedUploadAndSync),
+			Action:  wrapCliCommand("feed-and-sync", feedUploadAndSyncCmd),
 		},
 		{
 			Name:    "upload_speed",
 			Aliases: []string{"u"},
 			Usage:   "measure upload speed",
-			Action:  wrapCliCommand("upload-speed", uploadSpeed),
+			Action:  wrapCliCommand("upload-speed", uploadSpeedCmd),
 		},
 		{
 			Name:    "sliding_window",
 			Aliases: []string{"s"},
 			Usage:   "measure network aggregate capacity",
-			Action:  wrapCliCommand("sliding-window", slidingWindow),
+			Action:  wrapCliCommand("sliding-window", slidingWindowCmd),
 		},
 	}
 

--- a/cmd/swarm/swarm-smoke/main.go
+++ b/cmd/swarm/swarm-smoke/main.go
@@ -37,18 +37,15 @@ var (
 )
 
 var (
-	endpoints        []string
-	includeLocalhost bool
-	cluster          string
-	appName          string
-	scheme           string
-	filesize         int
-	syncDelay        int
-	from             int
-	to               int
-	verbosity        int
-	timeout          int
-	single           bool
+	allhosts  string
+	hosts     []string
+	filesize  int
+	syncDelay int
+	httpPort  int
+	wsPort    int
+	verbosity int
+	timeout   int
+	single    bool
 )
 
 func main() {
@@ -59,39 +56,22 @@ func main() {
 
 	app.Flags = []cli.Flag{
 		cli.StringFlag{
-			Name:        "cluster-endpoint",
-			Value:       "prod",
-			Usage:       "cluster to point to (prod or a given namespace)",
-			Destination: &cluster,
-		},
-		cli.StringFlag{
-			Name:        "app",
-			Value:       "swarm",
-			Usage:       "application to point to (swarm or swarm-private)",
-			Destination: &appName,
+			Name:        "hosts",
+			Value:       "",
+			Usage:       "comma-separated list of swarm hosts",
+			Destination: &allhosts,
 		},
 		cli.IntFlag{
-			Name:        "cluster-from",
-			Value:       8501,
-			Usage:       "swarm node (from)",
-			Destination: &from,
+			Name:        "http-port",
+			Value:       80,
+			Usage:       "http port",
+			Destination: &httpPort,
 		},
 		cli.IntFlag{
-			Name:        "cluster-to",
-			Value:       8512,
-			Usage:       "swarm node (to)",
-			Destination: &to,
-		},
-		cli.StringFlag{
-			Name:        "cluster-scheme",
-			Value:       "http",
-			Usage:       "http or https",
-			Destination: &scheme,
-		},
-		cli.BoolFlag{
-			Name:        "include-localhost",
-			Usage:       "whether to include localhost:8500 as an endpoint",
-			Destination: &includeLocalhost,
+			Name:        "ws-port",
+			Value:       8546,
+			Usage:       "ws port",
+			Destination: &wsPort,
 		},
 		cli.IntFlag{
 			Name:        "filesize",

--- a/cmd/swarm/swarm-smoke/main.go
+++ b/cmd/swarm/swarm-smoke/main.go
@@ -120,25 +120,25 @@ func main() {
 			Name:    "upload_and_sync",
 			Aliases: []string{"c"},
 			Usage:   "upload and sync",
-			Action:  wrapCliCommand("upload-and-sync", true, uploadAndSync),
+			Action:  wrapCliCommand("upload-and-sync", uploadAndSync),
 		},
 		{
 			Name:    "feed_sync",
 			Aliases: []string{"f"},
 			Usage:   "feed update generate, upload and sync",
-			Action:  wrapCliCommand("feed-and-sync", true, feedUploadAndSync),
+			Action:  wrapCliCommand("feed-and-sync", feedUploadAndSync),
 		},
 		{
 			Name:    "upload_speed",
 			Aliases: []string{"u"},
 			Usage:   "measure upload speed",
-			Action:  wrapCliCommand("upload-speed", true, uploadSpeed),
+			Action:  wrapCliCommand("upload-speed", uploadSpeed),
 		},
 		{
 			Name:    "sliding_window",
 			Aliases: []string{"s"},
 			Usage:   "measure network aggregate capacity",
-			Action:  wrapCliCommand("sliding-window", false, slidingWindow),
+			Action:  wrapCliCommand("sliding-window", slidingWindow),
 		},
 	}
 

--- a/cmd/swarm/swarm-smoke/sliding_window.go
+++ b/cmd/swarm/swarm-smoke/sliding_window.go
@@ -17,36 +17,49 @@
 package main
 
 import (
-	"crypto/md5"
-	crand "crypto/rand"
+	"bytes"
 	"fmt"
-	"io"
 	"math/rand"
 	"time"
 
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/metrics"
+	"github.com/ethereum/go-ethereum/swarm/testutil"
 	"github.com/pborman/uuid"
 
 	cli "gopkg.in/urfave/cli.v1"
 )
-
-var seed = time.Now().UTC().UnixNano()
-
-func init() {
-	rand.Seed(seed)
-}
 
 type uploadResult struct {
 	hash   string
 	digest []byte
 }
 
-func slidingWindow(c *cli.Context) error {
+func slidingWindow(ctx *cli.Context, tuid string) error {
+	errc := make(chan error)
+
+	go func() {
+		errc <- sl(ctx, tuid)
+	}()
+
+	select {
+	case err := <-errc:
+		if err != nil {
+			metrics.GetOrRegisterCounter(fmt.Sprintf("%s.fail", commandName), nil).Inc(1)
+		}
+		return err
+	case <-time.After(time.Duration(timeout) * time.Second):
+		metrics.GetOrRegisterCounter(fmt.Sprintf("%s.timeout", commandName), nil).Inc(1)
+
+		return fmt.Errorf("timeout after %v sec", timeout)
+	}
+}
+
+func sl(ctx *cli.Context, tuid string) error {
 	hashes := []uploadResult{} //swarm hashes of the uploads
 	nodes := len(hosts)
 	const iterationTimeout = 30 * time.Second
-	log.Info("sliding window test started", "nodes", nodes, "filesize(kb)", filesize, "timeout", timeout)
+	log.Info("sliding window test started", "tuid", tuid, "nodes", nodes, "filesize(kb)", filesize, "timeout", timeout)
 	uploadedBytes := 0
 	networkDepth := 0
 	errored := false
@@ -55,11 +68,11 @@ outer:
 	for {
 		log.Info("uploading to "+httpEndpoint(hosts[0])+" and syncing", "seed", seed)
 
-		h := md5.New()
-		r := io.TeeReader(io.LimitReader(crand.Reader, int64(filesize*1000)), h)
 		t1 := time.Now()
 
-		hash, err := upload(r, filesize*1000, httpEndpoint(hosts[0]))
+		randomBytes := testutil.RandomBytes(seed, filesize*1000)
+
+		hash, err := upload(randomBytes, httpEndpoint(hosts[0]))
 		if err != nil {
 			log.Error(err.Error())
 			return err
@@ -67,7 +80,11 @@ outer:
 
 		metrics.GetOrRegisterResettingTimer("sliding-window.upload-time", nil).UpdateSince(t1)
 
-		fhash := h.Sum(nil)
+		fhash, err := digest(bytes.NewReader(randomBytes))
+		if err != nil {
+			log.Error(err.Error())
+			return err
+		}
 
 		log.Info("uploaded successfully", "hash", hash, "digest", fmt.Sprintf("%x", fhash), "sleeping", syncDelay)
 		hashes = append(hashes, uploadResult{hash: hash, digest: fhash})

--- a/cmd/swarm/swarm-smoke/sliding_window.go
+++ b/cmd/swarm/swarm-smoke/sliding_window.go
@@ -90,7 +90,7 @@ outer:
 					idx := 1 + rand.Intn(len(hosts)-1)
 					ruid := uuid.New()[:8]
 					start := time.Now()
-					err := fetch(v.hash, httpEndpoint(hosts[idx]), v.digest, ruid)
+					err := fetch(v.hash, httpEndpoint(hosts[idx]), v.digest, ruid, "")
 					if err != nil {
 						continue inner
 					}

--- a/cmd/swarm/swarm-smoke/sliding_window.go
+++ b/cmd/swarm/swarm-smoke/sliding_window.go
@@ -35,11 +35,11 @@ type uploadResult struct {
 	digest []byte
 }
 
-func slidingWindow(ctx *cli.Context, tuid string) error {
+func slidingWindowCmd(ctx *cli.Context, tuid string) error {
 	errc := make(chan error)
 
 	go func() {
-		errc <- sl(ctx, tuid)
+		errc <- slidingWindow(ctx, tuid)
 	}()
 
 	select {
@@ -55,7 +55,7 @@ func slidingWindow(ctx *cli.Context, tuid string) error {
 	}
 }
 
-func sl(ctx *cli.Context, tuid string) error {
+func slidingWindow(ctx *cli.Context, tuid string) error {
 	hashes := []uploadResult{} //swarm hashes of the uploads
 	nodes := len(hosts)
 	const iterationTimeout = 30 * time.Second

--- a/cmd/swarm/swarm-smoke/upload_and_sync.go
+++ b/cmd/swarm/swarm-smoke/upload_and_sync.go
@@ -31,13 +31,13 @@ import (
 	cli "gopkg.in/urfave/cli.v1"
 )
 
-func uploadAndSync(ctx *cli.Context, tuid string) error {
+func uploadAndSyncCmd(ctx *cli.Context, tuid string) error {
 	randomBytes := testutil.RandomBytes(seed, filesize*1000)
 
 	errc := make(chan error)
 
 	go func() {
-		errc <- uas(ctx, randomBytes, tuid)
+		errc <- uplaodAndSync(ctx, randomBytes, tuid)
 	}()
 
 	select {
@@ -55,7 +55,7 @@ func uploadAndSync(ctx *cli.Context, tuid string) error {
 	}
 }
 
-func uas(c *cli.Context, randomBytes []byte, tuid string) error {
+func uplaodAndSync(c *cli.Context, randomBytes []byte, tuid string) error {
 	log.Info("uploading to "+httpEndpoint(hosts[0])+" and syncing", "tuid", tuid, "seed", seed)
 
 	t1 := time.Now()

--- a/cmd/swarm/swarm-smoke/upload_speed.go
+++ b/cmd/swarm/swarm-smoke/upload_speed.go
@@ -17,38 +17,56 @@
 package main
 
 import (
-	"crypto/md5"
-	crand "crypto/rand"
+	"bytes"
 	"fmt"
-	"io"
 	"time"
 
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/metrics"
+	"github.com/ethereum/go-ethereum/swarm/testutil"
 
 	cli "gopkg.in/urfave/cli.v1"
 )
 
-func uploadSpeed(c *cli.Context) error {
-	if len(hosts) < 2 {
-		log.Crit("less than 2 hosts")
+func uploadSpeed(ctx *cli.Context, tuid string) error {
+	log.Info("uploading to "+hosts[0], "tuid", tuid, "seed", seed)
+	randomBytes := testutil.RandomBytes(seed, filesize*1000)
+
+	errc := make(chan error)
+
+	go func() {
+		errc <- us(ctx, tuid, randomBytes)
+	}()
+
+	select {
+	case err := <-errc:
+		if err != nil {
+			metrics.GetOrRegisterCounter(fmt.Sprintf("%s.fail", commandName), nil).Inc(1)
+		}
+		return err
+	case <-time.After(time.Duration(timeout) * time.Second):
+		metrics.GetOrRegisterCounter(fmt.Sprintf("%s.timeout", commandName), nil).Inc(1)
+
+		// trigger debug functionality on randomBytes
+
+		return fmt.Errorf("timeout after %v sec", timeout)
 	}
+}
 
-	seed := int(time.Now().UnixNano() / 1e6)
-	log.Info("uploading to "+hosts[0], "seed", seed)
-
-	h := md5.New()
-	r := io.TeeReader(io.LimitReader(crand.Reader, int64(filesize*1000)), h)
-
+func us(c *cli.Context, tuid string, data []byte) error {
 	t1 := time.Now()
-	hash, err := upload(r, filesize*1000, hosts[0])
+	hash, err := upload(data, hosts[0])
 	if err != nil {
 		log.Error(err.Error())
 		return err
 	}
 	metrics.GetOrRegisterCounter("upload-speed.upload-time", nil).Inc(int64(time.Since(t1)))
 
-	fhash := h.Sum(nil)
+	fhash, err := digest(bytes.NewReader(data))
+	if err != nil {
+		log.Error(err.Error())
+		return err
+	}
 
 	log.Info("uploaded successfully", "hash", hash, "digest", fmt.Sprintf("%x", fhash))
 	return nil

--- a/cmd/swarm/swarm-smoke/upload_speed.go
+++ b/cmd/swarm/swarm-smoke/upload_speed.go
@@ -28,14 +28,14 @@ import (
 	cli "gopkg.in/urfave/cli.v1"
 )
 
-func uploadSpeed(ctx *cli.Context, tuid string) error {
+func uploadSpeedCmd(ctx *cli.Context, tuid string) error {
 	log.Info("uploading to "+hosts[0], "tuid", tuid, "seed", seed)
 	randomBytes := testutil.RandomBytes(seed, filesize*1000)
 
 	errc := make(chan error)
 
 	go func() {
-		errc <- us(ctx, tuid, randomBytes)
+		errc <- uploadSpeed(ctx, tuid, randomBytes)
 	}()
 
 	select {
@@ -53,7 +53,7 @@ func uploadSpeed(ctx *cli.Context, tuid string) error {
 	}
 }
 
-func us(c *cli.Context, tuid string, data []byte) error {
+func uploadSpeed(c *cli.Context, tuid string, data []byte) error {
 	t1 := time.Now()
 	hash, err := upload(data, hosts[0])
 	if err != nil {

--- a/cmd/swarm/swarm-smoke/upload_speed.go
+++ b/cmd/swarm/swarm-smoke/upload_speed.go
@@ -30,15 +30,18 @@ import (
 )
 
 func uploadSpeed(c *cli.Context) error {
-	endpoint := generateEndpoint(scheme, cluster, appName, from)
+	if len(hosts) < 2 {
+		log.Crit("less than 2 hosts")
+	}
+
 	seed := int(time.Now().UnixNano() / 1e6)
-	log.Info("uploading to "+endpoint, "seed", seed)
+	log.Info("uploading to "+hosts[0], "seed", seed)
 
 	h := md5.New()
 	r := io.TeeReader(io.LimitReader(crand.Reader, int64(filesize*1000)), h)
 
 	t1 := time.Now()
-	hash, err := upload(r, filesize*1000, endpoint)
+	hash, err := upload(r, filesize*1000, hosts[0])
 	if err != nil {
 		log.Error(err.Error())
 		return err

--- a/cmd/swarm/swarm-smoke/util.go
+++ b/cmd/swarm/swarm-smoke/util.go
@@ -43,12 +43,12 @@ import (
 )
 
 var (
-	commandName       = ""
-	seed        int64 = time.Now().UTC().UnixNano()
+	commandName = ""
+	seed        = int(time.Now().UTC().UnixNano())
 )
 
 func init() {
-	rand.Seed(seed)
+	rand.Seed(int64(seed))
 }
 
 func httpEndpoint(host string) string {

--- a/cmd/swarm/swarm-smoke/util.go
+++ b/cmd/swarm/swarm-smoke/util.go
@@ -154,11 +154,11 @@ func fetchFeed(topic string, user string, endpoint string, original []byte, ruid
 }
 
 // fetch is getting the requested `hash` from the `endpoint` and compares it with the `original` file
-func fetch(hash string, endpoint string, original []byte, ruid string) error {
+func fetch(hash string, endpoint string, original []byte, ruid string, tuid string) error {
 	ctx, sp := spancontext.StartSpan(context.Background(), "upload-and-sync.fetch")
 	defer sp.Finish()
 
-	log.Trace("http get request", "ruid", ruid, "api", endpoint, "hash", hash)
+	log.Info("http get request", "tuid", tuid, "ruid", ruid, "endpoint", endpoint, "hash", hash)
 
 	var tn time.Time
 	reqUri := endpoint + "/bzz:/" + hash + "/"
@@ -182,7 +182,7 @@ func fetch(hash string, endpoint string, original []byte, ruid string) error {
 		log.Error(err.Error(), "ruid", ruid)
 		return err
 	}
-	log.Trace("http get response", "ruid", ruid, "api", endpoint, "hash", hash, "code", res.StatusCode, "len", res.ContentLength)
+	log.Info("http get response", "tuid", tuid, "ruid", ruid, "endpoint", endpoint, "hash", hash, "code", res.StatusCode, "len", res.ContentLength)
 
 	if res.StatusCode != 200 {
 		err := fmt.Errorf("expected status code %d, got %v", 200, res.StatusCode)

--- a/swarm/testutil/file.go
+++ b/swarm/testutil/file.go
@@ -47,9 +47,9 @@ func TempFileWithContent(t *testing.T, content string) string {
 
 // RandomBytes returns pseudo-random deterministic result
 // because test fails must be reproducible
-func RandomBytes(seed int64, length int) []byte {
+func RandomBytes(seed, length int) []byte {
 	b := make([]byte, length)
-	reader := rand.New(rand.NewSource(seed))
+	reader := rand.New(rand.NewSource(int64(seed)))
 	for n := 0; n < length; {
 		read, err := reader.Read(b[n:])
 		if err != nil {
@@ -60,6 +60,6 @@ func RandomBytes(seed int64, length int) []byte {
 	return b
 }
 
-func RandomReader(seed int64, length int) *bytes.Reader {
+func RandomReader(seed, length int) *bytes.Reader {
 	return bytes.NewReader(RandomBytes(seed, length))
 }

--- a/swarm/testutil/file.go
+++ b/swarm/testutil/file.go
@@ -47,9 +47,9 @@ func TempFileWithContent(t *testing.T, content string) string {
 
 // RandomBytes returns pseudo-random deterministic result
 // because test fails must be reproducible
-func RandomBytes(seed, length int) []byte {
+func RandomBytes(seed int64, length int) []byte {
 	b := make([]byte, length)
-	reader := rand.New(rand.NewSource(int64(seed)))
+	reader := rand.New(rand.NewSource(seed))
 	for n := 0; n < length; {
 		read, err := reader.Read(b[n:])
 		if err != nil {
@@ -60,6 +60,6 @@ func RandomBytes(seed, length int) []byte {
 	return b
 }
 
-func RandomReader(seed, length int) *bytes.Reader {
+func RandomReader(seed int64, length int) *bytes.Reader {
 	return bytes.NewReader(RandomBytes(seed, length))
 }


### PR DESCRIPTION
This PR is:
1. Removing the `generateEndpoints` methods, and just uses the `hosts` provided to the command. Then we can target easily `http` or `ws` or any other endpoint, depending on what command we run.
2. Updating `wrapCliCommand` to NOT abstract the timeout handling per command.
3. Reverting changes to the `upload` method, so that we have access to the actual random content used in the smoke tests (necessary so that we can get all chunk hashes, in case of fetch failure).

Also adds logs for duration of tests and global test identifier.