### PR TITLE
p2p: change metered connection ip and node id

### DIFF
--- a/p2p/dial.go
+++ b/p2p/dial.go
@@ -350,7 +350,7 @@ func (t *dialTask) dial(srv *Server, dest *enode.Node) error {
 	if err != nil {
 		return &dialError{err}
 	}
-	mfd := newMeteredConn(fd, false, dest.IP())
+	mfd := newMeteredConn(fd, false, &net.TCPAddr{IP: dest.IP(), Port: dest.TCP()})
 	return srv.SetupConn(mfd, t.flags, dest)
 }
 

--- a/p2p/metrics.go
+++ b/p2p/metrics.go
@@ -191,10 +191,13 @@ func (c *meteredConn) encHandshakeDone(id enode.ID) {
 
 // peerAdded is called after the connection passes the protocol handshake.
 func (c *meteredConn) peerAdded(info *PeerInfo) {
+	c.lock.RLock()
+	id := c.id
+	c.lock.RUnlock()
 	meteredPeerFeed.Send(MeteredPeerEvent{
 		Type: PeerProtoHandshakeSucceeded,
 		Addr: c.addr.String(),
-		ID:   c.id,
+		ID:   id,
 		Info: info,
 	})
 }

--- a/p2p/server.go
+++ b/p2p/server.go
@@ -863,11 +863,11 @@ func (srv *Server) listenLoop() {
 			}
 		}
 
-		var ip net.IP
+		var addr *net.TCPAddr
 		if tcp, ok := fd.RemoteAddr().(*net.TCPAddr); ok {
-			ip = tcp.IP
+			addr = tcp
 		}
-		fd = newMeteredConn(fd, true, ip)
+		fd = newMeteredConn(fd, true, addr)
 		srv.log.Trace("Accepted connection", "addr", fd.RemoteAddr())
 		go func() {
 			srv.SetupConn(fd, inboundConn, nil)
@@ -921,7 +921,7 @@ func (srv *Server) setupConn(c *conn, flags connFlag, dialDest *enode.Node) erro
 		c.node = nodeFromConn(remotePubkey, c.fd)
 	}
 	if conn, ok := c.fd.(*meteredConn); ok {
-		conn.handshakeDone(c.node.ID())
+		conn.handshakeDone(c.node)
 	}
 	clog := srv.log.New("id", c.node.ID(), "addr", c.fd.RemoteAddr(), "conn", c.flags)
 	err = srv.checkpoint(c, srv.posthandshake)


### PR DESCRIPTION
This PR changes two fields of the metered connection in the `p2p` package:
 - `IP` -> `Addr` in order to include the port
- `ID` -> `Node` in order to use the node URL instead of the pure node ID

The corresponding `MeteredPeerEvent` fields' types are `string` in order to prevent the unwanted modification of the original objects.
This can be changed using `deepcopy` if needed.