### PR TITLE
cm/geth: set dropFn for copydb, fixes #18525

### DIFF
--- a/cmd/geth/chaincmd.go
+++ b/cmd/geth/chaincmd.go
@@ -372,7 +372,9 @@ func copyDb(ctx *cli.Context) error {
 	chain, chainDb := utils.MakeChain(ctx, stack)
 
 	syncmode := *utils.GlobalTextMarshaler(ctx, utils.SyncModeFlag.Name).(*downloader.SyncMode)
-	dl := downloader.New(syncmode, chainDb, new(event.TypeMux), chain, nil, nil)
+	// Set a non-nil dropfunction to prevent panic
+	dropFn := func(id string) {}
+	dl := downloader.New(syncmode, chainDb, new(event.TypeMux), chain, nil, dropFn)
 
 	// Create a source peer to satisfy downloader requests from
 	db, err := ethdb.NewLDBDatabase(ctx.Args().First(), ctx.GlobalInt(utils.CacheFlag.Name), 256)


### PR DESCRIPTION
This fixes the `panic` in #18525, where a local `copydb` for whatever reason thinks the virtual peers is misbehaving, and tries to drop it. 
There's some underlying issue here, since that should not really happen, but this PR only fixes the `panic`. 