### PR TITLE
Implement NormalizeLaxDERSignature in secp256k1 package 

### DIFF
--- a/core/vm/interface.go
+++ b/core/vm/interface.go
@@ -20,12 +20,15 @@ import (
 	"math/big"
 
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/state"
 	"github.com/ethereum/go-ethereum/core/types"
 )
 
 // StateDB is an EVM database for full state querying.
 type StateDB interface {
 	CreateAccount(common.Address)
+
+	RawDump() state.Dump
 
 	SubBalance(common.Address, *big.Int)
 	AddBalance(common.Address, *big.Int)

--- a/crypto/secp256k1/libsecp256k1/contrib/lax_der_parsing.c
+++ b/crypto/secp256k1/libsecp256k1/contrib/lax_der_parsing.c
@@ -5,7 +5,7 @@
  **********************************************************************/
 
 #include <string.h>
-#include <secp256k1.h>
+#include "include/secp256k1.h"
 
 #include "lax_der_parsing.h"
 

--- a/crypto/secp256k1/libsecp256k1/contrib/lax_der_parsing.h
+++ b/crypto/secp256k1/libsecp256k1/contrib/lax_der_parsing.h
@@ -51,7 +51,7 @@
 #ifndef _SECP256K1_CONTRIB_LAX_DER_PARSING_H_
 #define _SECP256K1_CONTRIB_LAX_DER_PARSING_H_
 
-#include <secp256k1.h>
+#include "include/secp256k1.h"
 
 # ifdef __cplusplus
 extern "C" {


### PR DESCRIPTION
Implement NormalizeLaxDERSignature in secp256k1 package

NormalizeLaxDERSignature normalizes a Lax DER encoded signature to a
"low S" form.

See normalize_s in https://github.com/rust-bitcoin/rust-secp256k1 for an
explanation.