### PR TITLE
ethapi: default to use eip-155 protected transactions

### DIFF
--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -356,11 +356,7 @@ func (s *PrivateAccountAPI) signTransaction(ctx context.Context, args *SendTxArg
 	// Assemble the transaction and sign with the wallet
 	tx := args.toTransaction()
 
-	var chainID *big.Int
-	if config := s.b.ChainConfig(); config.IsEIP155(s.b.CurrentBlock().Number()) {
-		chainID = config.ChainID
-	}
-	return wallet.SignTxWithPassphrase(account, passwd, tx, chainID)
+	return wallet.SignTxWithPassphrase(account, passwd, tx, s.b.ChainConfig().ChainID)
 }
 
 // SendTransaction will create a transaction from the given arguments and
@@ -1186,11 +1182,7 @@ func (s *PublicTransactionPoolAPI) sign(addr common.Address, tx *types.Transacti
 		return nil, err
 	}
 	// Request the wallet to sign the transaction
-	var chainID *big.Int
-	if config := s.b.ChainConfig(); config.IsEIP155(s.b.CurrentBlock().Number()) {
-		chainID = config.ChainID
-	}
-	return wallet.SignTx(account, tx, chainID)
+	return wallet.SignTx(account, tx, s.b.ChainConfig().ChainID)
 }
 
 // SendTxArgs represents the arguments to sumbit a new transaction into the transaction pool.
@@ -1306,11 +1298,7 @@ func (s *PublicTransactionPoolAPI) SendTransaction(ctx context.Context, args Sen
 	// Assemble the transaction and sign with the wallet
 	tx := args.toTransaction()
 
-	var chainID *big.Int
-	if config := s.b.ChainConfig(); config.IsEIP155(s.b.CurrentBlock().Number()) {
-		chainID = config.ChainID
-	}
-	signed, err := wallet.SignTx(account, tx, chainID)
+	signed, err := wallet.SignTx(account, tx, s.b.ChainConfig().ChainID)
 	if err != nil {
 		return common.Hash{}, err
 	}


### PR DESCRIPTION
Using a node which isn't particularly synced at all
```
INFO [02-07|12:03:31.676] Initialised chain configuration          config="{ChainID: 1 Homestead: 1150000 DAO: 1920000 DAOSupport: true EIP150: 2463000 EIP155: 2675000 EIP158: 2675000 Byzantium: 4370000 Constantinople: 7280000  ConstantinopleFix: 7280000 Engine: ethash}"
...
INFO [02-07|12:03:31.714] Loaded most recent local header          number=249053 hash=049228…c4077c td=1067030628162730226 age=3y5mo1w
INFO [02-07|12:03:31.714] Loaded most recent local full block      number=0      hash=d4e567…cb8fa3 td=17179869184         age=49y9mo3w
INFO [02-07|12:03:31.714] Loaded most recent local fast block      number=248199 hash=2ee315…410c90 td=1061919596019900131 age=3y5mo1w
```
This PR changes the behaviour to use eip-155 replay protected transactions regardless of whether the node is synched to head or not. 

There's one cornercase drawback, if people are running private networks without Eip-155 support.
It could be argued that they should switch to use Eip-155, since cross-network replay attacks are a thing, and we should not maintain insecure functionality/behaviour to cater for quirky edgecases.

```
> eth.signTransaction({from: eth.accounts[0], to: eth.accounts[0], value:1 , gas: 1 , gasPrice: 1, nonce:100})
{
  raw: "0xf85d640101948a8eafb1cf62bfbeb1741769dae1a9dd47996192018026a0716bd90515acb1e68e5ac5867aa11a1e65399c3349d479f5fb698554ebc6f293a04e8a4ebfff434e971e0ef12c5bf3a881b06fd04fc3f8b8a7291fb67a26a1d4ed",
  tx: {
    gas: "0x1",
    gasPrice: "0x1",
    hash: "0x662f6d772692dd692f1b5e8baa77a9ff95bbd909362df3fc3d301aafebde5441",
    input: "0x",
    nonce: "0x64",
    r: "0x716bd90515acb1e68e5ac5867aa11a1e65399c3349d479f5fb698554ebc6f293",
    s: "0x4e8a4ebfff434e971e0ef12c5bf3a881b06fd04fc3f8b8a7291fb67a26a1d4ed",
    to: "0x8a8eafb1cf62bfbeb1741769dae1a9dd47996192",
    v: "0x26",
    value: "0x1"
  }
}


> personal.signTransaction({from: eth.accounts[0], to: eth.accounts[0], value:1 , gas: 1 , gasPrice: 1, nonce: 100},pw)
{
  raw: "0xf85d640101948a8eafb1cf62bfbeb1741769dae1a9dd47996192018026a0716bd90515acb1e68e5ac5867aa11a1e65399c3349d479f5fb698554ebc6f293a04e8a4ebfff434e971e0ef12c5bf3a881b06fd04fc3f8b8a7291fb67a26a1d4ed",
  tx: {
    gas: "0x1",
    gasPrice: "0x1",
    hash: "0x662f6d772692dd692f1b5e8baa77a9ff95bbd909362df3fc3d301aafebde5441",
    input: "0x",
    nonce: "0x64",
    r: "0x716bd90515acb1e68e5ac5867aa11a1e65399c3349d479f5fb698554ebc6f293",
    s: "0x4e8a4ebfff434e971e0ef12c5bf3a881b06fd04fc3f8b8a7291fb67a26a1d4ed",
    to: "0x8a8eafb1cf62bfbeb1741769dae1a9dd47996192",
    v: "0x26",
    value: "0x1"
  }
}
```
Master, however, tries to look at the current block number, and concludes that it should use a homestead-signer, thus not replay protected:
```
> eth.signTransaction({from: eth.accounts[0], to: eth.accounts[0], value:1 , gas: 1 , gasPrice: 1, nonce:100})
{
  raw: "0xf85d640101948a8eafb1cf62bfbeb1741769dae1a9dd4799619201801ba06efcf97cc3fe9231373f7aaef3174671d249a62a04df515892c8601e79355d61a07b94504466e41f7950782a4a583b44cb1ae20698f6c6527a481b6803670f7717",
  tx: {
    gas: "0x1",
    gasPrice: "0x1",
    hash: "0x59339afccc72728146f447fff25017be4beafd6748e852980dadd7db9ad3f368",
    input: "0x",
    nonce: "0x64",
    r: "0x6efcf97cc3fe9231373f7aaef3174671d249a62a04df515892c8601e79355d61",
    s: "0x7b94504466e41f7950782a4a583b44cb1ae20698f6c6527a481b6803670f7717",
    to: "0x8a8eafb1cf62bfbeb1741769dae1a9dd47996192",
    v: "0x1b",
    value: "0x1"
  }
}

> personal.signTransaction({from: eth.accounts[0], to: eth.accounts[0], value:1 , gas: 1 , gasPrice: 1, nonce: 100},pw)
{
  raw: "0xf85d640101948a8eafb1cf62bfbeb1741769dae1a9dd4799619201801ba06efcf97cc3fe9231373f7aaef3174671d249a62a04df515892c8601e79355d61a07b94504466e41f7950782a4a583b44cb1ae20698f6c6527a481b6803670f7717",
  tx: {
    gas: "0x1",
    gasPrice: "0x1",
    hash: "0x59339afccc72728146f447fff25017be4beafd6748e852980dadd7db9ad3f368",
    input: "0x",
    nonce: "0x64",
    r: "0x6efcf97cc3fe9231373f7aaef3174671d249a62a04df515892c8601e79355d61",
    s: "0x7b94504466e41f7950782a4a583b44cb1ae20698f6c6527a481b6803670f7717",
    to: "0x8a8eafb1cf62bfbeb1741769dae1a9dd47996192",
    v: "0x1b",
    value: "0x1"
  }
}
```
