### PR TITLE
swarm/storage: temporarily disable TestGetAllReferences - hashing bug

### DIFF
--- a/swarm/storage/filestore_test.go
+++ b/swarm/storage/filestore_test.go
@@ -177,6 +177,7 @@ func testFileStoreCapacity(toEncrypt bool, t *testing.T) {
 // TestGetAllReferences only tests that GetAllReferences returns an expected
 // number of references for a given file
 func TestGetAllReferences(t *testing.T) {
+	t.Skip("Flaky due to BUG in hashing results!")
 	tdb, cleanup, err := newTestDbStore(false, false)
 	defer cleanup()
 	if err != nil {


### PR DESCRIPTION
This PR is to skip a test which has been shown to be flaky due to a bug in the hashing algorithm.

Until the bug is fixed, this test should remain disabled.

The bug is not related to the functionality of this test nor to the functionality it tests. To resolve the bug, further investigation is needed.