### PR TITLE
swarm/docker: add global-store and split docker images

### DIFF
--- a/swarm/docker/Dockerfile
+++ b/swarm/docker/Dockerfile
@@ -10,14 +10,23 @@ RUN mkdir -p $GOPATH/src/github.com/ethereum && \
     git checkout ${VERSION} && \
     go install -ldflags "-X main.gitCommit=${VERSION}" ./cmd/swarm && \
     go install -ldflags "-X main.gitCommit=${VERSION}" ./cmd/swarm/swarm-smoke && \
-    go install -ldflags "-X main.gitCommit=${VERSION}" ./cmd/geth && \
-    cp $GOPATH/bin/swarm /swarm && cp $GOPATH/bin/geth /geth && cp $GOPATH/bin/swarm-smoke /swarm-smoke
+    go install -ldflags "-X main.gitCommit=${VERSION}" ./cmd/swarm/global-store && \
+    go install -ldflags "-X main.gitCommit=${VERSION}" ./cmd/geth
 
 
-# Release image with the required binaries and scripts
-FROM alpine:3.8
+FROM alpine:3.8 as swarm-smoke
 WORKDIR /
-COPY --from=builder /swarm /geth /swarm-smoke /
-ADD run.sh /run.sh
+COPY --from=builder /go/bin/swarm-smoke /
 ADD run-smoke.sh /run-smoke.sh
+ENTRYPOINT ["/run-smoke.sh"]
+
+FROM alpine:3.8 as swarm-global-store
+WORKDIR /
+COPY --from=builder /go/bin/global-store /
+ENTRYPOINT ["/global-store"]
+
+FROM alpine:3.8 as swarm
+WORKDIR /
+COPY --from=builder /go/bin/swarm /go/bin/geth /
+ADD run.sh /run.sh
 ENTRYPOINT ["/run.sh"]


### PR DESCRIPTION
Creating separate images for `swarm`,  `swarm-smoke` and `swarm global-store`.

Each image can be build individually by using the `--target` flag during `docker build`.