### PR TITLE
p2p/simulations: enforce mixed caps variable names

### DIFF
--- a/p2p/simulations/network_test.go
+++ b/p2p/simulations/network_test.go
@@ -192,7 +192,7 @@ OUTER:
 
 	connEventCount = nodeCount
 
-OUTER_TWO:
+OuterTwo:
 	for {
 		select {
 		case <-ctx.Done():
@@ -210,7 +210,7 @@ OUTER_TWO:
 				connEventCount--
 				log.Debug("ev", "count", connEventCount)
 				if connEventCount == 0 {
-					break OUTER_TWO
+					break OuterTwo
 				}
 			}
 		}


### PR DESCRIPTION
Mixed caps variable names is a golang best practice [1].

[1] https://golang.org/doc/effective_go.html#mixed-caps