### PR TITLE
les: enforce mixed caps variable names

### DIFF
--- a/les/peer_test.go
+++ b/les/peer_test.go
@@ -12,8 +12,8 @@ import (
 )
 
 const (
-	test_networkid   = 10
-	protocol_version = 2123
+	testNetworkId   = 10
+	protocolVersion = 2123
 )
 
 var (
@@ -31,7 +31,7 @@ func TestPeerHandshakeSetAnnounceTypeToAnnounceTypeSignedForTrustedPeer(t *testi
 	//peer to connect(on ulc side)
 	p := peer{
 		Peer:      p2p.NewPeer(id, "test peer", []p2p.Cap{}),
-		version:   protocol_version,
+		version:   protocolVersion,
 		isTrusted: true,
 		rw: &rwStub{
 			WriteHook: func(recvList keyValueList) {
@@ -60,7 +60,7 @@ func TestPeerHandshakeSetAnnounceTypeToAnnounceTypeSignedForTrustedPeer(t *testi
 				return l
 			},
 		},
-		network: test_networkid,
+		network: testNetworkId,
 	}
 
 	err := p.Handshake(td, hash, headNum, genesis, nil)
@@ -77,7 +77,7 @@ func TestPeerHandshakeAnnounceTypeSignedForTrustedPeersPeerNotInTrusted(t *testi
 	var id enode.ID = newNodeID(t).ID()
 	p := peer{
 		Peer:    p2p.NewPeer(id, "test peer", []p2p.Cap{}),
-		version: protocol_version,
+		version: protocolVersion,
 		rw: &rwStub{
 			WriteHook: func(recvList keyValueList) {
 				//checking that ulc sends to peer allowedRequests=noRequests and announceType != announceTypeSigned
@@ -105,7 +105,7 @@ func TestPeerHandshakeAnnounceTypeSignedForTrustedPeersPeerNotInTrusted(t *testi
 				return l
 			},
 		},
-		network: test_networkid,
+		network: testNetworkId,
 	}
 
 	err := p.Handshake(td, hash, headNum, genesis, nil)
@@ -124,7 +124,7 @@ func TestPeerHandshakeDefaultAllRequests(t *testing.T) {
 
 	p := peer{
 		Peer:    p2p.NewPeer(id, "test peer", []p2p.Cap{}),
-		version: protocol_version,
+		version: protocolVersion,
 		rw: &rwStub{
 			ReadHook: func(l keyValueList) keyValueList {
 				l = l.add("announceType", uint64(announceTypeSigned))
@@ -133,7 +133,7 @@ func TestPeerHandshakeDefaultAllRequests(t *testing.T) {
 				return l
 			},
 		},
-		network: test_networkid,
+		network: testNetworkId,
 	}
 
 	err := p.Handshake(td, hash, headNum, genesis, s)
@@ -154,7 +154,7 @@ func TestPeerHandshakeServerSendOnlyAnnounceRequestsHeaders(t *testing.T) {
 
 	p := peer{
 		Peer:    p2p.NewPeer(id, "test peer", []p2p.Cap{}),
-		version: protocol_version,
+		version: protocolVersion,
 		rw: &rwStub{
 			ReadHook: func(l keyValueList) keyValueList {
 				l = l.add("announceType", uint64(announceTypeSigned))
@@ -172,7 +172,7 @@ func TestPeerHandshakeServerSendOnlyAnnounceRequestsHeaders(t *testing.T) {
 				}
 			},
 		},
-		network: test_networkid,
+		network: testNetworkId,
 	}
 
 	err := p.Handshake(td, hash, headNum, genesis, s)
@@ -185,7 +185,7 @@ func TestPeerHandshakeClientReceiveOnlyAnnounceRequestsHeaders(t *testing.T) {
 
 	p := peer{
 		Peer:    p2p.NewPeer(id, "test peer", []p2p.Cap{}),
-		version: protocol_version,
+		version: protocolVersion,
 		rw: &rwStub{
 			ReadHook: func(l keyValueList) keyValueList {
 				l = l.add("flowControl/BL", uint64(0))
@@ -197,7 +197,7 @@ func TestPeerHandshakeClientReceiveOnlyAnnounceRequestsHeaders(t *testing.T) {
 				return l
 			},
 		},
-		network:   test_networkid,
+		network:   testNetworkId,
 		isTrusted: true,
 	}
 
@@ -216,7 +216,7 @@ func TestPeerHandshakeClientReturnErrorOnUselessPeer(t *testing.T) {
 
 	p := peer{
 		Peer:    p2p.NewPeer(id, "test peer", []p2p.Cap{}),
-		version: protocol_version,
+		version: protocolVersion,
 		rw: &rwStub{
 			ReadHook: func(l keyValueList) keyValueList {
 				l = l.add("flowControl/BL", uint64(0))
@@ -228,7 +228,7 @@ func TestPeerHandshakeClientReturnErrorOnUselessPeer(t *testing.T) {
 				return l
 			},
 		},
-		network: test_networkid,
+		network: testNetworkId,
 	}
 
 	err := p.Handshake(td, hash, headNum, genesis, nil)
@@ -261,8 +261,8 @@ type rwStub struct {
 
 func (s *rwStub) ReadMsg() (p2p.Msg, error) {
 	payload := keyValueList{}
-	payload = payload.add("protocolVersion", uint64(protocol_version))
-	payload = payload.add("networkId", uint64(test_networkid))
+	payload = payload.add("protocolVersion", uint64(protocolVersion))
+	payload = payload.add("networkId", uint64(testNetworkId))
 	payload = payload.add("headTd", td)
 	payload = payload.add("headHash", hash)
 	payload = payload.add("headNum", headNum)


### PR DESCRIPTION
Mixed caps variable names is a golang best practice [1].

[1] https://golang.org/doc/effective_go.html#mixed-caps