### PR TITLE
swarm/network: Saturation check for healthy networks

### DIFF
--- a/swarm/network/kademlia.go
+++ b/swarm/network/kademlia.go
@@ -710,6 +710,11 @@ func (k *Kademlia) saturation() int {
 func (k *Kademlia) isSaturated(peersPerBin []int, depth int) bool {
 	// depth could be calculated from k but as this is called from `GetHealthInfo()`,
 	// the depth has already been calculated so we can require it as a parameter
+
+	// early check for depth
+	if depth != len(peersPerBin) {
+		return false
+	}
 	unsaturatedBins := make([]int, 0)
 	k.conns.EachBin(k.base, Pof, 0, func(po, size int, f func(func(val pot.Val) bool) bool) bool {
 
@@ -726,10 +731,6 @@ func (k *Kademlia) isSaturated(peersPerBin []int, depth int) bool {
 	})
 
 	log.Trace("list of unsaturated bins", "unsaturatedBins", unsaturatedBins)
-	// early check for depth
-	if depth != len(peersPerBin) {
-		return false
-	}
 	return len(unsaturatedBins) == 0
 }
 

--- a/swarm/network/kademlia.go
+++ b/swarm/network/kademlia.go
@@ -836,7 +836,7 @@ func (k *Kademlia) GetHealthInfo(pp *PeerPot) *Health {
 
 	// check saturation
 	unsaturatedBins := k.getUnsaturatedBins(pp.PeersPerBin, depth)
-	saturated := len(unsaturatedBins) == 0 && depth == len(pp.PeersPerBin)
+	saturated := depth == len(pp.PeersPerBin) && len(unsaturatedBins) == 0
 
 	log.Trace(fmt.Sprintf("%08x: healthy: knowNNs: %v, gotNNs: %v, saturated: %v\n", k.base, knownn, gotnn, saturated))
 	return &Health{

--- a/swarm/network/kademlia.go
+++ b/swarm/network/kademlia.go
@@ -836,7 +836,7 @@ func (k *Kademlia) GetHealthInfo(pp *PeerPot) *Health {
 
 	// check saturation
 	unsaturatedBins := k.getUnsaturatedBins(pp.PeersPerBin, depth)
-	saturated := len(unsaturatedBins) == 0
+	saturated := len(unsaturatedBins) == 0 && depth == len(pp.PeersPerBin)
 
 	log.Trace(fmt.Sprintf("%08x: healthy: knowNNs: %v, gotNNs: %v, saturated: %v\n", k.base, knownn, gotnn, saturated))
 	return &Health{

--- a/swarm/network/kademlia.go
+++ b/swarm/network/kademlia.go
@@ -683,6 +683,24 @@ func NewPeerPotMap(neighbourhoodSize int, addrs [][]byte) map[string]*PeerPot {
 	return ppmap
 }
 
+// saturation returns the smallest po value in which the node has less than MinBinSize peers
+// if the iterator reaches neighbourhood radius, then the last bin + 1 is returned
+func (k *Kademlia) saturation() int {
+	prev := -1
+	radius := neighbourhoodRadiusForPot(k.conns, k.NeighbourhoodSize, k.base)
+	k.conns.EachBin(k.base, Pof, 0, func(po, size int, f func(func(val pot.Val) bool) bool) bool {
+		prev++
+		if po >= radius {
+			return false
+		}
+		return prev == po && size >= k.MinBinSize
+	})
+	if prev < 0 {
+		return 0
+	}
+	return prev
+}
+
 // getUnsaturatedBins returns an array of ints; each item in that array corresponds
 // to the bin which is unsaturated (number of connections < k.MinBinSize).
 // The bin is considered unsaturated only if there are actual peers in that PeerPot's bin (peersPerBin)

--- a/swarm/network/kademlia_test.go
+++ b/swarm/network/kademlia_test.go
@@ -241,7 +241,7 @@ func TestHealthStrict(t *testing.T) {
 	// know three peers, connected to the two deepest
 	// healthy
 	tk.Register("00000000")
-	tk.checkHealth(true)
+	tk.checkHealth(false)
 
 	// know three peers, connected to all three
 	// healthy
@@ -279,9 +279,9 @@ func TestHealthStrict(t *testing.T) {
 	tk.checkHealth(true)
 
 	// add peer in bin 1
-	// healthy, as it is known but not connected
+	// unhealthy, as it is known but not connected
 	tk.Register("10000000")
-	tk.checkHealth(true)
+	tk.checkHealth(false)
 
 	// connect  peer in bin 1
 	// depth change, is now 1
@@ -305,9 +305,9 @@ func TestHealthStrict(t *testing.T) {
 	tk.checkHealth(true)
 
 	// add peer in bin 2
-	// healthy, no depth change
+	// unhealthy, no depth change
 	tk.Register("11000000")
-	tk.checkHealth(true)
+	tk.checkHealth(false)
 
 	// connect peer in bin 2
 	// depth change - as we already have peers in bin 3 and 4,

--- a/swarm/network/simulation/kademlia.go
+++ b/swarm/network/simulation/kademlia.go
@@ -64,7 +64,7 @@ func (s *Simulation) WaitTillHealthy(ctx context.Context) (ill map[enode.ID]*net
 				addr := common.Bytes2Hex(k.BaseAddr())
 				pp := ppmap[addr]
 				//call Healthy RPC
-				h := k.Healthy(pp)
+				h := k.GetHealthInfo(pp)
 				//print info
 				log.Debug(k.String())
 				log.Debug("kademlia", "connectNN", h.ConnectNN, "knowNN", h.KnowNN)

--- a/swarm/network/simulations/discovery/discovery_test.go
+++ b/swarm/network/simulations/discovery/discovery_test.go
@@ -267,7 +267,7 @@ func discoverySimulation(nodes, conns int, adapter adapters.NodeAdapter) (*simul
 		}
 
 		healthy := &network.Health{}
-		if err := client.Call(&healthy, "hive_healthy", ppmap[common.Bytes2Hex(id.Bytes())]); err != nil {
+		if err := client.Call(&healthy, "hive_getHealthInfo", ppmap[common.Bytes2Hex(id.Bytes())]); err != nil {
 			return false, fmt.Errorf("error getting node health: %s", err)
 		}
 		log.Debug(fmt.Sprintf("node %4s healthy: connected nearest neighbours: %v, know nearest neighbours: %v,\n\n%v", id, healthy.ConnectNN, healthy.KnowNN, healthy.Hive))
@@ -352,7 +352,7 @@ func discoveryPersistenceSimulation(nodes, conns int, adapter adapters.NodeAdapt
 				healthy := &network.Health{}
 				addr := id.String()
 				ppmap := network.NewPeerPotMap(network.NewKadParams().NeighbourhoodSize, addrs)
-				if err := client.Call(&healthy, "hive_healthy", ppmap[common.Bytes2Hex(id.Bytes())]); err != nil {
+				if err := client.Call(&healthy, "hive_getHealthInfo", ppmap[common.Bytes2Hex(id.Bytes())]); err != nil {
 					return fmt.Errorf("error getting node health: %s", err)
 				}
 
@@ -422,7 +422,7 @@ func discoveryPersistenceSimulation(nodes, conns int, adapter adapters.NodeAdapt
 		healthy := &network.Health{}
 		ppmap := network.NewPeerPotMap(network.NewKadParams().NeighbourhoodSize, addrs)
 
-		if err := client.Call(&healthy, "hive_healthy", ppmap[common.Bytes2Hex(id.Bytes())]); err != nil {
+		if err := client.Call(&healthy, "hive_getHealthInfo", ppmap[common.Bytes2Hex(id.Bytes())]); err != nil {
 			return false, fmt.Errorf("error getting node health: %s", err)
 		}
 		log.Info(fmt.Sprintf("node %4s healthy: got nearest neighbours: %v, know nearest neighbours: %v", id, healthy.ConnectNN, healthy.KnowNN))


### PR DESCRIPTION
This PR introduces a new implementation for saturation.

Saturation is a prerequisite to consider a network healthy.
This is reflected with the new `Healthy()` method.

A new function `isSaturated()` has been added, which will check the list of unsaturated bins (array of `int`) and return a `bool`, `true` for saturated and `false` for not.

It is considered saturated if the length of the array is zero (equivalent to all bins below depth have the saturation criteria fulfilled) and the `depth` is equal to the length of the `peersPerBin`.

A bin is saturated if we have connections >= `MinBinSize` or, if there are less connections than `MinBinSize`, the number of connections corresponds to the available number of peers in the `PeerPot`.

Closes https://github.com/ethersphere/go-ethereum/issues/1145 and supersedes https://github.com/ethersphere/go-ethereum/pull/1195 which was the discussion PR before opening this upstream.