### PR TITLE
console: prefer nil slices over zero-length slices

### DIFF
--- a/console/console.go
+++ b/console/console.go
@@ -236,7 +236,7 @@ func (c *Console) clearHistory() {
 // consoleOutput is an override for the console.log and console.error methods to
 // stream the output into the configured output stream instead of stdout.
 func (c *Console) consoleOutput(call otto.FunctionCall) otto.Value {
-	output := []string{}
+	var output []string
 	for _, argument := range call.ArgumentList {
 		output = append(output, fmt.Sprintf("%v", argument))
 	}


### PR DESCRIPTION
Golang best practice is to use a nil slice variable declaration instead of instantiating a zero-length slice [1].

[1] https://github.com/golang/go/wiki/CodeReviewComments#declaring-empty-slices