### PR TITLE
cmd/*: prefer nil slices over zero-length slices

### DIFF
--- a/cmd/abigen/main.go
+++ b/cmd/abigen/main.go
@@ -124,7 +124,7 @@ func main() {
 		}
 		abis = append(abis, string(abi))
 
-		bin := []byte{}
+		var bin []byte
 		if *binFlag != "" {
 			if bin, err = ioutil.ReadFile(*binFlag); err != nil {
 				fmt.Printf("Failed to read input bytecode: %v\n", err)

--- a/cmd/geth/monitorcmd.go
+++ b/cmd/geth/monitorcmd.go
@@ -169,7 +169,7 @@ func retrieveMetrics(client *rpc.Client) (map[string]interface{}, error) {
 // resolveMetrics takes a list of input metric patterns, and resolves each to one
 // or more canonical metric names.
 func resolveMetrics(metrics map[string]interface{}, patterns []string) []string {
-	res := []string{}
+	var res []string
 	for _, pattern := range patterns {
 		res = append(res, resolveMetric(metrics, pattern, "")...)
 	}
@@ -179,7 +179,7 @@ func resolveMetrics(metrics map[string]interface{}, patterns []string) []string 
 // resolveMetrics takes a single of input metric pattern, and resolves it to one
 // or more canonical metric names.
 func resolveMetric(metrics map[string]interface{}, pattern string, path string) []string {
-	results := []string{}
+	var results []string
 
 	// If a nested metric was requested, recurse optionally branching (via comma)
 	parts := strings.SplitN(pattern, "/", 2)
@@ -215,7 +215,7 @@ func resolveMetric(metrics map[string]interface{}, pattern string, path string) 
 // expandMetrics expands the entire tree of metrics into a flat list of paths.
 func expandMetrics(metrics map[string]interface{}, path string) []string {
 	// Iterate over all fields and expand individually
-	list := []string{}
+	var list []string
 	for name, metric := range metrics {
 		switch metric := metric.(type) {
 		case float64:

--- a/cmd/geth/usage.go
+++ b/cmd/geth/usage.go
@@ -308,7 +308,7 @@ func init() {
 					categorized[flag.String()] = struct{}{}
 				}
 			}
-			uncategorized := []cli.Flag{}
+			var uncategorized []cli.Flag
 			for _, flag := range data.(*cli.App).Flags {
 				if _, ok := categorized[flag.String()]; !ok {
 					if strings.HasPrefix(flag.GetName(), "dashboard") {

--- a/cmd/swarm/access.go
+++ b/cmd/swarm/access.go
@@ -178,8 +178,8 @@ func accessNewACT(ctx *cli.Context) {
 		accessKey            []byte
 		err                  error
 		ref                  = args[0]
-		pkGrantees           = []string{}
-		passGrantees         = []string{}
+		pkGrantees           []string
+		passGrantees         []string
 		pkGranteesFilename   = ctx.String(SwarmAccessGrantKeysFlag.Name)
 		passGranteesFilename = ctx.String(utils.PasswordFileFlag.Name)
 		privateKey           = getPrivKey(ctx)

--- a/cmd/swarm/access_test.go
+++ b/cmd/swarm/access_test.go
@@ -397,7 +397,7 @@ func testACT(t *testing.T, bogusEntries int) {
 	}
 
 	ref := matches[0]
-	grantees := []string{}
+	var grantees []string
 	for i, v := range cluster.Nodes {
 		if i == nodeToSkip {
 			continue
@@ -408,7 +408,7 @@ func testACT(t *testing.T, bogusEntries int) {
 	}
 
 	if bogusEntries > 0 {
-		bogusGrantees := []string{}
+		var bogusGrantees []string
 
 		for i := 0; i < bogusEntries; i++ {
 			prv, err := ecies.GenerateKey(rand.Reader, DefaultCurve, nil)

--- a/cmd/swarm/fs.go
+++ b/cmd/swarm/fs.go
@@ -123,7 +123,7 @@ func listMounts(cliContext *cli.Context) {
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
-	mf := []fuse.MountInfo{}
+	var mf []fuse.MountInfo
 	err = client.CallContext(ctx, &mf, "swarmfs_listmounts")
 	if err != nil {
 		utils.Fatalf("encountered an error calling the RPC endpoint while listing mounts: %v", err)

--- a/cmd/swarm/swarm-smoke/sliding_window.go
+++ b/cmd/swarm/swarm-smoke/sliding_window.go
@@ -56,7 +56,7 @@ func slidingWindowCmd(ctx *cli.Context, tuid string) error {
 }
 
 func slidingWindow(ctx *cli.Context, tuid string) error {
-	hashes := []uploadResult{} //swarm hashes of the uploads
+	var hashes []uploadResult //swarm hashes of the uploads
 	nodes := len(hosts)
 	const iterationTimeout = 30 * time.Second
 	log.Info("sliding window test started", "tuid", tuid, "nodes", nodes, "filesize(kb)", filesize, "timeout", timeout)

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -1613,7 +1613,7 @@ func MakeConsolePreloads(ctx *cli.Context) []string {
 		return nil
 	}
 	// Otherwise resolve absolute paths and return them
-	preloads := []string{}
+	var preloads []string
 
 	assets := ctx.GlobalString(JSpathFlag.Name)
 	for _, file := range strings.Split(ctx.GlobalString(PreloadJSFlag.Name), ",") {


### PR DESCRIPTION
Golang best practice is to use a nil slice variable declaration instead of instantiating a zero-length slice [1].

[1] https://github.com/golang/go/wiki/CodeReviewComments#declaring-empty-slices