### PR TITLE
core: prefer nil slices over zero-length slices

### DIFF
--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -673,7 +673,7 @@ func (bc *BlockChain) GetBlocksFromHash(hash common.Hash, n int) (blocks []*type
 // GetUnclesInChain retrieves all the uncles from a given block backwards until
 // a specific distance is reached.
 func (bc *BlockChain) GetUnclesInChain(block *types.Block, length int) []*types.Header {
-	uncles := []*types.Header{}
+	var uncles []*types.Header
 	for i := 0; block != nil && i < length; i++ {
 		uncles = append(uncles, block.Uncles()...)
 		block = bc.GetBlock(block.ParentHash(), block.NumberU64()-1)

--- a/core/blockchain_test.go
+++ b/core/blockchain_test.go
@@ -702,7 +702,7 @@ func TestLightVsFastVsFullChainHeads(t *testing.T) {
 	blocks, receipts := GenerateChain(gspec.Config, genesis, ethash.NewFaker(), gendb, int(height), nil)
 
 	// Configure a subchain to roll back
-	remove := []common.Hash{}
+	var remove []common.Hash
 	for _, block := range blocks[height/2:] {
 		remove = append(remove, block.Hash())
 	}

--- a/core/rawdb/accessors_chain.go
+++ b/core/rawdb/accessors_chain.go
@@ -288,7 +288,7 @@ func ReadReceipts(db DatabaseReader, hash common.Hash, number uint64) types.Rece
 		return nil
 	}
 	// Convert the receipts from their storage form to their internal representation
-	storageReceipts := []*types.ReceiptForStorage{}
+	var storageReceipts []*types.ReceiptForStorage
 	if err := rlp.DecodeBytes(data, &storageReceipts); err != nil {
 		log.Error("Invalid receipt array RLP", "hash", hash, "err", err)
 		return nil

--- a/core/state/sync_test.go
+++ b/core/state/sync_test.go
@@ -42,7 +42,7 @@ func makeTestState() (Database, common.Hash, []*testAccount) {
 	state, _ := New(common.Hash{}, db)
 
 	// Fill it with some arbitrary data
-	accounts := []*testAccount{}
+	var accounts []*testAccount
 	for i := byte(0); i < 96; i++ {
 		obj := state.GetOrNewStateObject(common.BytesToAddress([]byte{i}))
 		acc := &testAccount{address: common.BytesToAddress([]byte{i})}
@@ -298,7 +298,7 @@ func TestIncompleteStateSync(t *testing.T) {
 	dstDb := ethdb.NewMemDatabase()
 	sched := NewStateSync(srcRoot, dstDb)
 
-	added := []common.Hash{}
+	var added []common.Hash
 	queue := append([]common.Hash{}, sched.Missing(1)...)
 	for len(queue) > 0 {
 		// Fetch a batch of state nodes

--- a/core/tx_pool.go
+++ b/core/tx_pool.go
@@ -1015,7 +1015,7 @@ func (pool *TxPool) promoteExecutables(accounts []common.Address) {
 			}
 		}
 		// Gradually drop transactions from offenders
-		offenders := []common.Address{}
+		var offenders []common.Address
 		for pending > pool.config.GlobalSlots && !spammers.Empty() {
 			// Retrieve the next offender if not local address
 			offender, _ := spammers.Pop()

--- a/core/tx_pool_test.go
+++ b/core/tx_pool_test.go
@@ -571,7 +571,7 @@ func TestTransactionPostponing(t *testing.T) {
 		pool.currentState.AddBalance(crypto.PubkeyToAddress(keys[i].PublicKey), big.NewInt(50100))
 	}
 	// Add a batch consecutive pending transactions for validation
-	txs := []*types.Transaction{}
+	var txs []*types.Transaction
 	for i, key := range keys {
 
 		for j := 0; j < 100; j++ {
@@ -980,7 +980,7 @@ func testTransactionLimitingEquivalency(t *testing.T, origin uint64) {
 	account2, _ := deriveSender(transaction(0, 0, key2))
 	pool2.currentState.AddBalance(account2, big.NewInt(1000000))
 
-	txs := []*types.Transaction{}
+	var txs []*types.Transaction
 	for i := uint64(0); i < testTxPoolConfig.AccountQueue+5; i++ {
 		txs = append(txs, transaction(origin+i, 100000, key2))
 	}

--- a/core/types/receipt.go
+++ b/core/types/receipt.go
@@ -30,7 +30,7 @@ import (
 //go:generate gencodec -type Receipt -field-override receiptMarshaling -out gen_receipt_json.go
 
 var (
-	receiptStatusFailedRLP     = []byte{}
+	receiptStatusFailedRLP     []byte
 	receiptStatusSuccessfulRLP = []byte{0x01}
 )
 


### PR DESCRIPTION
Golang best practice is to use a nil slice variable declaration instead of instantiating a zero-length slice [1].

[1] https://github.com/golang/go/wiki/CodeReviewComments#declaring-empty-slices