### PR TITLE
eth: prefer nil slices over zero-length slices

### DIFF
--- a/eth/downloader/downloader.go
+++ b/eth/downloader/downloader.go
@@ -1289,7 +1289,7 @@ func (d *Downloader) fetchParts(errCancel error, deliveryCh chan dataPack, deliv
 // queue until the stream ends or a failure occurs.
 func (d *Downloader) processHeaders(origin uint64, pivot uint64, td *big.Int) error {
 	// Keep a count of uncertain headers to roll back
-	rollback := []*types.Header{}
+	var rollback []*types.Header
 	defer func() {
 		if len(rollback) > 0 {
 			// Flatten the headers and roll them back

--- a/eth/downloader/queue.go
+++ b/eth/downloader/queue.go
@@ -423,7 +423,8 @@ func (q *queue) ReserveHeaders(p *peerConnection, count int) *fetchRequest {
 		return nil
 	}
 	// Retrieve a batch of hashes, skipping previously failed ones
-	send, skip := uint64(0), []uint64{}
+	var skip []uint64
+	send := uint64(0)
 	for send == 0 && !q.headerTaskQueue.Empty() {
 		from, _ := q.headerTaskQueue.Pop()
 		if q.headerPeerMiss[p.id] != nil {

--- a/eth/fetcher/fetcher.go
+++ b/eth/fetcher/fetcher.go
@@ -439,7 +439,9 @@ func (f *Fetcher) loop() {
 
 			// Split the batch of headers into unknown ones (to return to the caller),
 			// known incomplete ones (requiring body retrievals) and completed blocks.
-			unknown, incomplete, complete := []*types.Header{}, []*announce{}, []*types.Block{}
+			var complete []*types.Block
+			var incomplete []*announce
+			var unknown []*types.Header
 			for _, header := range task.headers {
 				hash := header.Hash()
 
@@ -513,7 +515,7 @@ func (f *Fetcher) loop() {
 			}
 			bodyFilterInMeter.Mark(int64(len(task.transactions)))
 
-			blocks := []*types.Block{}
+			var blocks []*types.Block
 			for i := 0; i < len(task.transactions) && i < len(task.uncles); i++ {
 				// Match up a body to any possible completion request
 				matched := false

--- a/eth/filters/filter_system_test.go
+++ b/eth/filters/filter_system_test.go
@@ -160,17 +160,17 @@ func TestBlockSubscription(t *testing.T) {
 	t.Parallel()
 
 	var (
-		mux         = new(event.TypeMux)
-		db          = ethdb.NewMemDatabase()
-		txFeed      = new(event.Feed)
-		rmLogsFeed  = new(event.Feed)
-		logsFeed    = new(event.Feed)
-		chainFeed   = new(event.Feed)
-		backend     = &testBackend{mux, db, 0, txFeed, rmLogsFeed, logsFeed, chainFeed}
-		api         = NewPublicFilterAPI(backend, false)
-		genesis     = new(core.Genesis).MustCommit(db)
-		chain, _    = core.GenerateChain(params.TestChainConfig, genesis, ethash.NewFaker(), db, 10, func(i int, gen *core.BlockGen) {})
-		chainEvents = []core.ChainEvent{}
+		mux                  = new(event.TypeMux)
+		db                    = ethdb.NewMemDatabase()
+		txFeed            = new(event.Feed)
+		rmLogsFeed    = new(event.Feed)
+		logsFeed        = new(event.Feed)
+		chainFeed      = new(event.Feed)
+		backend          = &testBackend{mux, db, 0, txFeed, rmLogsFeed, logsFeed, chainFeed}
+		api                  = NewPublicFilterAPI(backend, false)
+		genesis          = new(core.Genesis).MustCommit(db)
+		chain, _        = core.GenerateChain(params.TestChainConfig, genesis, ethash.NewFaker(), db, 10, func(i int, gen *core.BlockGen) {})
+		chainEvents []core.ChainEvent
 	)
 
 	for _, blk := range chain {

--- a/eth/handler_test.go
+++ b/eth/handler_test.go
@@ -203,7 +203,7 @@ func testGetBlockHeaders(t *testing.T, protocol int) {
 	// Run each of the tests and verify the results against the chain
 	for i, tt := range tests {
 		// Collect the headers to expect in the response
-		headers := []*types.Header{}
+		var headers []*types.Header
 		for _, hash := range tt.expect {
 			headers = append(headers, pm.blockchain.GetBlockByHash(hash).Header())
 		}
@@ -265,8 +265,9 @@ func testGetBlockBodies(t *testing.T, protocol int) {
 	// Run each of the tests and verify the results against the chain
 	for i, tt := range tests {
 		// Collect the hashes to request, and the response to expect
-		hashes, seen := []common.Hash{}, make(map[int64]bool)
-		bodies := []*blockBody{}
+		var hashes []common.Hash
+		seen := make(map[int64]bool)
+		var bodies []*blockBody
 
 		for j := 0; j < tt.random; j++ {
 			for {
@@ -343,7 +344,7 @@ func testGetNodeData(t *testing.T, protocol int) {
 	defer peer.close()
 
 	// Fetch for now the entire chain db
-	hashes := []common.Hash{}
+	var hashes []common.Hash
 	for _, key := range db.Keys() {
 		if len(key) == len(common.Hash{}) {
 			hashes = append(hashes, common.BytesToHash(key))
@@ -435,7 +436,8 @@ func testGetReceipt(t *testing.T, protocol int) {
 	defer peer.close()
 
 	// Collect the hashes to request, and the response to expect
-	hashes, receipts := []common.Hash{}, []types.Receipts{}
+	var receipts []types.Receipts
+	var hashes []common.Hash
 	for i := uint64(0); i <= pm.blockchain.CurrentBlock().NumberU64(); i++ {
 		block := pm.blockchain.GetBlockByNumber(i)
 


### PR DESCRIPTION
Golang best practice is to use a nil slice variable declaration instead of instantiating a zero-length slice [1].

[1] https://github.com/golang/go/wiki/CodeReviewComments#declaring-empty-slices