### PR TITLE
les: prefer nil slices over zero-length slices

### DIFF
--- a/les/handler_test.go
+++ b/les/handler_test.go
@@ -160,7 +160,7 @@ func testGetBlockHeaders(t *testing.T, protocol int) {
 	var reqID uint64
 	for i, tt := range tests {
 		// Collect the headers to expect in the response
-		headers := []*types.Header{}
+		var headers []*types.Header
 		for _, hash := range tt.expect {
 			headers = append(headers, bc.GetHeaderByHash(hash))
 		}
@@ -214,8 +214,9 @@ func testGetBlockBodies(t *testing.T, protocol int) {
 	var reqID uint64
 	for i, tt := range tests {
 		// Collect the hashes to request, and the response to expect
-		hashes, seen := []common.Hash{}, make(map[int64]bool)
-		bodies := []*types.Body{}
+		var hashes []common.Hash
+		seen := make(map[int64]bool)
+		var bodies []*types.Body
 
 		for j := 0; j < tt.random; j++ {
 			for {
@@ -292,7 +293,8 @@ func testGetReceipt(t *testing.T, protocol int) {
 	bc := server.pm.blockchain.(*core.BlockChain)
 
 	// Collect the hashes to request, and the response to expect
-	hashes, receipts := []common.Hash{}, []types.Receipts{}
+	var receipts []types.Receipts
+	var hashes []common.Hash
 	for i := uint64(0); i <= bc.CurrentBlock().NumberU64(); i++ {
 		block := bc.GetBlockByNumber(i)
 


### PR DESCRIPTION
Golang best practice is to use a nil slice variable declaration instead of instantiating a zero-length slice [1].

[1] https://github.com/golang/go/wiki/CodeReviewComments#declaring-empty-slices