### PR TITLE
mobile: prefer nil slices over zero-length slices

### DIFF
--- a/mobile/p2p.go
+++ b/mobile/p2p.go
@@ -37,7 +37,7 @@ func (ni *NodeInfo) GetDiscoveryPort() int      { return ni.info.Ports.Discovery
 func (ni *NodeInfo) GetListenerPort() int       { return ni.info.Ports.Listener }
 func (ni *NodeInfo) GetListenerAddress() string { return ni.info.ListenAddr }
 func (ni *NodeInfo) GetProtocols() *Strings {
-	protos := []string{}
+	var protos []string
 	for proto := range ni.info.Protocols {
 		protos = append(protos, proto)
 	}


### PR DESCRIPTION
Golang best practice is to use a nil slice variable declaration instead of instantiating a zero-length slice [1].

[1] https://github.com/golang/go/wiki/CodeReviewComments#declaring-empty-slices