### PR TITLE
node: prefer nil slices over zero-length slices

### DIFF
--- a/node/config.go
+++ b/node/config.go
@@ -466,7 +466,7 @@ func makeAccountManager(conf *Config) (*accounts.Manager, string, error) {
 		return nil, "", err
 	}
 	// Assemble the account manager and supported backends
-	backends := []accounts.Backend{}
+	var backends []accounts.Backend
 	if len(conf.ExternalSigner) > 0 {
 		log.Info("Using external signer", "url", conf.ExternalSigner)
 		if extapi, err := external.NewExternalBackend(conf.ExternalSigner); err == nil {

--- a/node/node.go
+++ b/node/node.go
@@ -220,7 +220,7 @@ func (n *Node) Start() error {
 		return convertFileLockError(err)
 	}
 	// Start each of the services
-	started := []reflect.Type{}
+	var started []reflect.Type
 	for kind, service := range services {
 		// Start the next service, stopping all previous upon failure
 		if err := service.Start(running); err != nil {


### PR DESCRIPTION
Golang best practice is to use a nil slice variable declaration instead of instantiating a zero-length slice [1].

[1] https://github.com/golang/go/wiki/CodeReviewComments#declaring-empty-slices