### PR TITLE
swarm/storage: fix loop bound for database cleanup

### DIFF
--- a/swarm/storage/ldbstore.go
+++ b/swarm/storage/ldbstore.go
@@ -529,8 +529,8 @@ func (s *LDBStore) Cleanup(f func(*chunk) bool) {
 		if err != nil {
 			found := false
 
-			// highest possible proximity is 255
-			for po = 1; po <= 255; po++ {
+			// The highest possible proximity is 255, so exit loop upon overflow.
+			for po = uint8(1); po != 0; po++ {
 				datakey = getDataKey(index.Idx, po)
 				data, err = s.db.Get(datakey)
 				if err == nil {


### PR DESCRIPTION
The current loop continuation condition is always true as a uint8
is always being checked whether it is less than 255 (its maximum
value). Since the loop starts with the value 1, the loop termination
can be guarranteed to exit once the value overflows to 0.