### PR TITLE
cmd/swarm/swarm-smoke: Trigger chunk debug on timeout

### DIFF
--- a/cmd/swarm/swarm-smoke/main.go
+++ b/cmd/swarm/swarm-smoke/main.go
@@ -37,16 +37,16 @@ var (
 )
 
 var (
-	allhosts          string
-	hosts             []string
-	filesize          int
-	syncDelay         int
-	httpPort          int
-	wsPort            int
-	verbosity         int
-	timeout           int
-	single            bool
-	getAllRefsTimeout int
+	allhosts     string
+	hosts        []string
+	filesize     int
+	syncDelay    int
+	httpPort     int
+	wsPort       int
+	verbosity    int
+	timeout      int
+	single       bool
+	trackTimeout int
 )
 
 func main() {
@@ -104,10 +104,10 @@ func main() {
 			Destination: &single,
 		},
 		cli.IntFlag{
-			Name:        "refs-timeout",
+			Name:        "track-timeout",
 			Value:       5,
 			Usage:       "timeout in seconds to wait for GetAllReferences to return",
-			Destination: &getAllRefsTimeout,
+			Destination: &trackTimeout,
 		},
 	}
 

--- a/cmd/swarm/swarm-smoke/main.go
+++ b/cmd/swarm/swarm-smoke/main.go
@@ -37,15 +37,16 @@ var (
 )
 
 var (
-	allhosts  string
-	hosts     []string
-	filesize  int
-	syncDelay int
-	httpPort  int
-	wsPort    int
-	verbosity int
-	timeout   int
-	single    bool
+	allhosts          string
+	hosts             []string
+	filesize          int
+	syncDelay         int
+	httpPort          int
+	wsPort            int
+	verbosity         int
+	timeout           int
+	single            bool
+	getAllRefsTimeout int
 )
 
 func main() {
@@ -101,6 +102,12 @@ func main() {
 			Name:        "single",
 			Usage:       "whether to fetch content from a single node or from all nodes",
 			Destination: &single,
+		},
+		cli.IntFlag{
+			Name:        "refs-timeout",
+			Value:       5,
+			Usage:       "timeout in seconds to wait for GetAllReferences to return",
+			Destination: &getAllRefsTimeout,
 		},
 	}
 

--- a/cmd/swarm/swarm-smoke/upload_and_sync.go
+++ b/cmd/swarm/swarm-smoke/upload_and_sync.go
@@ -76,15 +76,20 @@ func triggerChunkDebug(testData []byte) error {
 	// has-chunks
 	for _, host := range hosts {
 		httpHost := fmt.Sprintf("ws://%s:%d", host, 8546)
+		log.Trace("Calling `Has` on host", "httpHost", httpHost)
 		rpcClient, err := rpc.Dial(httpHost)
 		if err != nil {
+			log.Trace("Error dialing host", "err", err)
 			return err
 		}
+		log.Trace("rpc dial ok")
 		var hasInfo []api.HasInfo
 		err = rpcClient.Call(&hasInfo, "bzz_has", addrs)
 		if err != nil {
+			log.Trace("Error calling host", "err", err)
 			return err
 		}
+		log.Trace("rpc call ok")
 		count := 0
 		for _, info := range hasInfo {
 			if !info.Has {
@@ -100,6 +105,7 @@ func triggerChunkDebug(testData []byte) error {
 }
 
 func getAllRefs(testData []byte) (storage.AddressCollection, error) {
+	log.Trace("Getting all references for given root hash")
 	datadir, err := ioutil.TempDir("", "chunk-debug")
 	if err != nil {
 		return nil, fmt.Errorf("unable to create temp dir: %v", err)
@@ -117,6 +123,7 @@ func getAllRefs(testData []byte) (storage.AddressCollection, error) {
 	if err != nil {
 		return nil, err
 	}
+	log.Trace("All references retrieved")
 	return addrs, err
 }
 

--- a/cmd/swarm/swarm-smoke/upload_and_sync.go
+++ b/cmd/swarm/swarm-smoke/upload_and_sync.go
@@ -57,7 +57,7 @@ func uploadAndSyncCmd(ctx *cli.Context, tuid string) error {
 
 		e := fmt.Errorf("timeout after %v sec", timeout)
 		// trigger debug functionality on randomBytes
-		err := triggerChunkDebug(randomBytes[:])
+		err := trackChunks(randomBytes[:])
 		if err != nil {
 			e = fmt.Errorf("%v; triggerChunkDebug failed: %v", e, err)
 		}
@@ -66,7 +66,7 @@ func uploadAndSyncCmd(ctx *cli.Context, tuid string) error {
 	}
 }
 
-func triggerChunkDebug(testData []byte) error {
+func trackChunks(testData []byte) error {
 	log.Warn("Test timed out; running chunk debug sequence")
 
 	addrs, err := getAllRefs(testData)
@@ -117,7 +117,7 @@ func getAllRefs(testData []byte) (storage.AddressCollection, error) {
 	if err != nil {
 		return nil, err
 	}
-	ctx, cancel := context.WithTimeout(context.Background(), time.Duration(getAllRefsTimeout)*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), time.Duration(trackTimeout)*time.Second)
 	defer cancel()
 
 	reader := bytes.NewReader(testData)

--- a/cmd/swarm/swarm-smoke/upload_and_sync.go
+++ b/cmd/swarm/swarm-smoke/upload_and_sync.go
@@ -75,7 +75,8 @@ func triggerChunkDebug(testData []byte) error {
 
 	// has-chunks
 	for _, host := range hosts {
-		rpcClient, err := rpc.Dial(host + ":8545")
+		httpHost := fmt.Sprintf("http://%s:%d", host, 8545)
+		rpcClient, err := rpc.Dial(httpHost)
 		if err != nil {
 			return err
 		}
@@ -88,11 +89,11 @@ func triggerChunkDebug(testData []byte) error {
 		for _, info := range hasInfo {
 			if !info.Has {
 				count++
-				log.Error("Host does not have chunk", "host", host, "chunk", info.Addr)
+				log.Error("Host does not have chunk", "host", httpHost, "chunk", info.Addr)
 			}
 		}
 		if count == 0 {
-			log.Info("Host reported to have all chunks", "host", host)
+			log.Info("Host reported to have all chunks", "host", httpHost)
 		}
 	}
 	return nil

--- a/cmd/swarm/swarm-smoke/upload_and_sync.go
+++ b/cmd/swarm/swarm-smoke/upload_and_sync.go
@@ -75,8 +75,7 @@ func triggerChunkDebug(testData []byte) error {
 
 	// has-chunks
 	for _, host := range hosts {
-		//httpHost := fmt.Sprintf("http://%s:%d", host, 8545)
-		httpHost := host
+		httpHost := fmt.Sprintf("ws://%s:%d", host, 8546)
 		rpcClient, err := rpc.Dial(httpHost)
 		if err != nil {
 			return err

--- a/cmd/swarm/swarm-smoke/upload_and_sync.go
+++ b/cmd/swarm/swarm-smoke/upload_and_sync.go
@@ -50,6 +50,9 @@ func uploadAndSyncCmd(ctx *cli.Context, tuid string) error {
 		metrics.GetOrRegisterCounter(fmt.Sprintf("%s.timeout", commandName), nil).Inc(1)
 
 		// trigger debug functionality on randomBytes
+		// get all references
+		//httpEndpoint(hosts[0])
+		// has-chunks
 
 		return fmt.Errorf("timeout after %v sec", timeout)
 	}

--- a/cmd/swarm/swarm-smoke/upload_and_sync.go
+++ b/cmd/swarm/swarm-smoke/upload_and_sync.go
@@ -75,7 +75,8 @@ func triggerChunkDebug(testData []byte) error {
 
 	// has-chunks
 	for _, host := range hosts {
-		httpHost := fmt.Sprintf("http://%s:%d", host, 8545)
+		//httpHost := fmt.Sprintf("http://%s:%d", host, 8545)
+		httpHost := host
 		rpcClient, err := rpc.Dial(httpHost)
 		if err != nil {
 			return err


### PR DESCRIPTION
Swarm now has a `GetAllReferences()` call, which can return a list of all references for a given file, and the `Has(chunkAddresses []storage.Address)` RPC endpoint, through which a node can be queried if it is locally storing the set of chunk references in the parameters.

This PR implements ticket https://github.com/ethersphere/go-ethereum/issues/1196, which requests that for debugging purposes, if a smoke test times out, the set of nodes in a cluster is queried for each of the references of the test file, in order to evaluate which of the nodes does not have the requested chunks.

It is thus only relevant in the realm of the smoke test.