### PR TITLE
blockchain: more tests for sidechain import, fixes #19105

### DIFF
--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -588,13 +588,6 @@ func (bc *BlockChain) HasState(hash common.Hash) bool {
 	return err == nil
 }
 
-// IsCanon returns whether the given hash/number is part of the canon chain,
-// irrespective of whether the state has been pruned or not
-func (bc *BlockChain) IsCanon(hash common.Hash, number uint64) bool {
-	canonHash := rawdb.ReadCanonicalHash(bc.db, number)
-	return canonHash != (common.Hash{}) && canonHash == hash
-}
-
 // HasBlockAndState checks if a block and associated state trie is fully present
 // in the database or not, caching it if present.
 func (bc *BlockChain) HasBlockAndState(hash common.Hash, number uint64) bool {

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -1319,11 +1319,12 @@ func (bc *BlockChain) insertSidechain(block *types.Block, it *insertIterator) (i
 	for ; block != nil && (err == consensus.ErrPrunedAncestor); block, err = it.next() {
 		// Check the canonical state root for that number
 		if number := block.NumberU64(); current.NumberU64() >= number {
-			if canonical := bc.GetBlockByNumber(number); canonical != nil && canonical.Hash() == block.Hash() {
+			canonical := bc.GetBlockByNumber(number)
+			if canonical != nil && canonical.Hash() == block.Hash() {
 				// Not a sidechain block, this is a re-import of a canon block which has it's state pruned
 				continue
 			}
-			if canonical := bc.GetBlockByNumber(number); canonical != nil && canonical.Root() == block.Root() {
+			if canonical != nil && canonical.Root() == block.Root() {
 				// This is most likely a shadow-state attack. When a fork is imported into the
 				// database, and it eventually reaches a block height which is not pruned, we
 				// just found that the state already exist! This means that the sidechain block

--- a/core/blockchain_test.go
+++ b/core/blockchain_test.go
@@ -1580,14 +1580,15 @@ func testSideImport(t *testing.T, numCanonBlocksInSidechain, blocksBetweenCommon
 	// canon(pruned), side, side...
 
 	// Generate fork chain, make it longer than canon
-	parent := blocks[lastPrunedIndex+blocksBetweenCommonAncestorAndPruneblock]
+	parentIndex := lastPrunedIndex + blocksBetweenCommonAncestorAndPruneblock
+	parent := blocks[parentIndex]
 	fork, _ := GenerateChain(params.TestChainConfig, parent, engine, db, 2*triesInMemory, func(i int, b *BlockGen) {
 		b.SetCoinbase(common.Address{2})
 	})
 	// Prepend the parent(s)
 	var sidechain []*types.Block
 	for i := numCanonBlocksInSidechain; i > 0; i-- {
-		sidechain = append(sidechain, blocks[len(blocks)-i])
+		sidechain = append(sidechain, blocks[parentIndex+1-i])
 	}
 	sidechain = append(sidechain, fork...)
 	_, err = chain.InsertChain(sidechain)
@@ -1610,6 +1611,9 @@ func testSideImport(t *testing.T, numCanonBlocksInSidechain, blocksBetweenCommon
 // [ Cn, Cn+1, Cc, Sn+3 ... Sm]
 //   ^    ^    ^  pruned
 func TestPrunedImportSide(t *testing.T) {
+	//glogger := log.NewGlogHandler(log.StreamHandler(os.Stdout, log.TerminalFormat(false)))
+	//glogger.Verbosity(3)
+	//log.Root().SetHandler(log.Handler(glogger))
 	testSideImport(t, 3, 3)
 	testSideImport(t, 3, -3)
 	testSideImport(t, 10, 0)


### PR DESCRIPTION
This PR adds some testcases regarding sidechain import, specifcally trying to repro the situation described in #19105. 

- A sidechain is imported, but the chain contains a few blocks which are already in the canon chain.
- Those blocks would trigger a `ErrKnownBlock` error, and be ignored, 
- After that, the first sidechain block would not wind up in `insertSideChain`, which depends on the first block to have been an `errPrunedAncestor` error. 

This PR addresses that by removing already canonical blocks from the chain to be inserted, in the pre-flight check in `InsertChain`. 