### PR TITLE
internal/build: accept any host key for SFTP

### DIFF
--- a/internal/build/util.go
+++ b/internal/build/util.go
@@ -182,7 +182,7 @@ func ExpandPackagesNoVendor(patterns []string) []string {
 // The destination host may be specified either as [user@]host[: or as a URI in
 // the form sftp://[user@]host[:port].
 func UploadSFTP(identityFile, host, dir string, files []string) error {
-	sftp := exec.Command("sftp")
+	sftp := exec.Command("sftp", "-o", "StrictHostKeyChecking=no", "-o", "UserKnownHostsFile=/dev/null")
 	sftp.Stdout = nil
 	sftp.Stderr = os.Stderr
 	if identityFile != "" {


### PR DESCRIPTION
This is OK because transport security isn't important for Launchpad
uploads. We're using SFTP as a replacement for unencrypted FTP and files
we upload are signed using GPG.