### PR TITLE
core/state: fix state iterator

### DIFF
--- a/core/state/statedb.go
+++ b/core/state/statedb.go
@@ -486,7 +486,14 @@ func (db *StateDB) ForEachStorage(addr common.Address, cb func(key, value common
 			cb(key, value)
 			continue
 		}
-		cb(key, common.BytesToHash(it.Value))
+
+		if len(it.Value) > 0 {
+			_, content, _, err := rlp.Split(it.Value)
+			if err != nil {
+				continue
+			}
+			cb(key, common.BytesToHash(content))
+		}
 	}
 }
 

--- a/core/vm/interface.go
+++ b/core/vm/interface.go
@@ -63,7 +63,7 @@ type StateDB interface {
 	AddLog(*types.Log)
 	AddPreimage(common.Hash, []byte)
 
-	ForEachStorage(common.Address, func(common.Hash, common.Hash) bool)
+	ForEachStorage(common.Address, func(common.Hash, common.Hash) bool) error
 }
 
 // CallContext provides a basic interface for the EVM calling conventions. The EVM


### PR DESCRIPTION
This PR introduces a fix to `state.ForEachStorage` function. 

Since before inserting data into trie, there is an additional RLP encode operation. 
While in the `state.ForEachStorage` function, it relies on the trie iterator to iterate all leaf nodes(aka state data), but the rlp decode operation is missing there.