### PR TITLE
rpc: fixup change to not verify websocket origin

### DIFF
--- a/rpc/websocket.go
+++ b/rpc/websocket.go
@@ -129,7 +129,7 @@ func wsHandshakeValidator(allowedOrigins []string) func(*websocket.Config, *http
 		// Origin. Non-browser software can put anything in origin and checking it doesn't
 		// provide additional security.
 		if _, ok := req.Header["Origin"]; !ok {
-			return
+			return nil
 		}
 		// Verify origin against whitelist.
 		origin := strings.ToLower(req.Header.Get("Origin"))


### PR DESCRIPTION
This corrects the previous change which broke the build and
was pushed to master by accident. 

This closes #16608.