### PR TITLE
p2p/enode: use localItemKey for local sequence number

### DIFF
--- a/p2p/discover/table_test.go
+++ b/p2p/discover/table_test.go
@@ -624,6 +624,8 @@ func (tn *preminedTestnet) findnode(toid enode.ID, toaddr *net.UDPAddr, target e
 func (*preminedTestnet) close()                                        {}
 func (*preminedTestnet) ping(toid enode.ID, toaddr *net.UDPAddr) error { return nil }
 
+var _ = (*preminedTestnet).mine // avoid linter warning about mine being dead code.
+
 // mine generates a testnet struct literal with nodes at
 // various distances to the given target.
 func (tn *preminedTestnet) mine(target encPubkey) {

--- a/p2p/discover/table_util_test.go
+++ b/p2p/discover/table_util_test.go
@@ -17,7 +17,6 @@
 package discover
 
 import (
-	"crypto/ecdsa"
 	"encoding/hex"
 	"fmt"
 	"math/rand"
@@ -166,12 +165,4 @@ func hexEncPubkey(h string) (ret encPubkey) {
 	}
 	copy(ret[:], b)
 	return ret
-}
-
-func hexPubkey(h string) *ecdsa.PublicKey {
-	k, err := decodePubkey(hexEncPubkey(h))
-	if err != nil {
-		panic(err)
-	}
-	return k
 }

--- a/p2p/enode/nodedb.go
+++ b/p2p/enode/nodedb.go
@@ -57,7 +57,7 @@ const (
 const (
 	dbNodeExpiration = 24 * time.Hour // Time after which an unseen node should be dropped.
 	dbCleanupCycle   = time.Hour      // Time period for running the expiration task.
-	dbVersion        = 8
+	dbVersion        = 9
 )
 
 var zeroIP = make(net.IP, 16)
@@ -380,12 +380,12 @@ func (db *DB) UpdateFindFails(id ID, ip net.IP, fails int) error {
 
 // LocalSeq retrieves the local record sequence counter.
 func (db *DB) localSeq(id ID) uint64 {
-	return db.fetchUint64(nodeItemKey(id, zeroIP, dbLocalSeq))
+	return db.fetchUint64(localItemKey(id, dbLocalSeq))
 }
 
 // storeLocalSeq stores the local record sequence counter.
 func (db *DB) storeLocalSeq(id ID, n uint64) {
-	db.storeUint64(nodeItemKey(id, zeroIP, dbLocalSeq), n)
+	db.storeUint64(localItemKey(id, dbLocalSeq), n)
 }
 
 // QuerySeeds retrieves random nodes to be used as potential seed nodes

--- a/p2p/enode/nodedb_test.go
+++ b/p2p/enode/nodedb_test.go
@@ -71,7 +71,7 @@ func TestDBNodeItemKey(t *testing.T) {
 	if id != keytestID {
 		t.Errorf("splitNodeItemKey returned wrong ID: %v", id)
 	}
-	if !bytes.Equal(ip, wantIP) {
+	if !ip.Equal(wantIP) {
 		t.Errorf("splitNodeItemKey returned wrong IP: %v", ip)
 	}
 	if field != wantField {


### PR DESCRIPTION
I added localItemKey for this purpose in #18963, but then
forgot to actually use it. This changes the database layout
yet again and requires bumping the version number.