### PR TITLE
swarm/network: Use actual remote peer ip in underlay

### DIFF
--- a/swarm/network/protocol.go
+++ b/swarm/network/protocol.go
@@ -234,7 +234,6 @@ func sanitizeEnodeRemote(paddr net.Addr, baddr *BzzAddr) {
 		log.Debug("rewrote peer uaddr host/port", "addr", baddr)
 		baddr.UAddr = regexpEnodeIP.ReplaceAll(baddr.UAddr, []byte(remoteStr))
 	}
-	return
 }
 
 // runBzz is the p2p protocol run function for the bzz base protocol

--- a/swarm/network/protocol.go
+++ b/swarm/network/protocol.go
@@ -213,6 +213,7 @@ func (b *Bzz) performHandshake(p *protocols.Peer, handshake *HandshakeMsg) error
 		handshake.err = err
 		return err
 	}
+	log.Warn("have hs", "remote", p.RemoteAddr(), "hs", rsh.(*HandshakeMsg).Addr)
 	handshake.peerAddr = rsh.(*HandshakeMsg).Addr
 	handshake.LightNode = rsh.(*HandshakeMsg).LightNode
 	return nil

--- a/swarm/network/protocol.go
+++ b/swarm/network/protocol.go
@@ -216,7 +216,8 @@ func (b *Bzz) performHandshake(p *protocols.Peer, handshake *HandshakeMsg) error
 		handshake.err = err
 		return err
 	}
-	handshake.peerAddr = sanitizeEnodeRemote(p.RemoteAddr(), rsh.(*HandshakeMsg).Addr)
+	handshake.peerAddr = rsh.(*HandshakeMsg).Addr
+	sanitizeEnodeRemote(p.RemoteAddr(), handshake.peerAddr)
 	handshake.LightNode = rsh.(*HandshakeMsg).LightNode
 	return nil
 }
@@ -225,7 +226,7 @@ func (b *Bzz) performHandshake(p *protocols.Peer, handshake *HandshakeMsg) error
 // this method ensures that the addr of the peer will be the one
 // applicable on the interface the connection came in on
 // it modifies the passed bzzaddr in place, and returns the same pointer
-func sanitizeEnodeRemote(paddr net.Addr, baddr *BzzAddr) *BzzAddr {
+func sanitizeEnodeRemote(paddr net.Addr, baddr *BzzAddr) {
 	hsSubmatch := regexpEnodeIP.FindSubmatch(baddr.UAddr)
 	ip, _, err := net.SplitHostPort(paddr.String())
 	if err == nil && string(hsSubmatch[1]) != ip {
@@ -233,7 +234,7 @@ func sanitizeEnodeRemote(paddr net.Addr, baddr *BzzAddr) *BzzAddr {
 		log.Debug("rewrote peer uaddr host/port", "addr", baddr)
 		baddr.UAddr = regexpEnodeIP.ReplaceAll(baddr.UAddr, []byte(remoteStr))
 	}
-	return baddr
+	return
 }
 
 // runBzz is the p2p protocol run function for the bzz base protocol

--- a/swarm/network/protocol.go
+++ b/swarm/network/protocol.go
@@ -229,6 +229,7 @@ func (b *Bzz) performHandshake(p *protocols.Peer, handshake *HandshakeMsg) error
 func sanitizeEnodeRemote(paddr net.Addr, baddr *BzzAddr) {
 	hsSubmatch := regexpEnodeIP.FindSubmatch(baddr.UAddr)
 	ip, _, err := net.SplitHostPort(paddr.String())
+	// since we expect nothing else than ipv4 here, a panic on missing submatch is desired
 	if err == nil && string(hsSubmatch[1]) != ip {
 		remoteStr := fmt.Sprintf("@%s:%s", ip, string(hsSubmatch[2]))
 		log.Debug("rewrote peer uaddr host/port", "addr", baddr)

--- a/swarm/network/protocol_test.go
+++ b/swarm/network/protocol_test.go
@@ -272,8 +272,8 @@ func TestSanitizeEnodeRemote(t *testing.T) {
 	baddr := RandomAddr()
 	oldUAddr := []byte(nodLocal.String())
 	baddr.UAddr = oldUAddr
-	newUAddr := sanitizeEnodeRemote(&remoteAddr, baddr).UAddr
-	if !bytes.Equal(newUAddr, []byte(nodRemote.String())) {
-		t.Fatalf("insane address. expected %v, got %v", nodRemote.String(), string(newUAddr))
+	sanitizeEnodeRemote(&remoteAddr, baddr)
+	if !bytes.Equal(baddr.UAddr, []byte(nodRemote.String())) {
+		t.Fatalf("insane address. expected %v, got %v", nodRemote.String(), string(baddr.UAddr))
 	}
 }

--- a/swarm/network/protocol_test.go
+++ b/swarm/network/protocol_test.go
@@ -17,12 +17,15 @@
 package network
 
 import (
+	"bytes"
 	"flag"
 	"fmt"
+	"net"
 	"os"
 	"testing"
 	"time"
 
+	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/p2p"
 	"github.com/ethereum/go-ethereum/p2p/enode"
@@ -249,5 +252,28 @@ func TestBzzHandshakeLightNode(t *testing.T) {
 				t.Fatal("test timeout")
 			}
 		})
+	}
+}
+
+// Tests the overwriting of localhost enode in handshake if actual remote ip is known
+// (swarm.network/protocol.go:sanitizeEnodeRemote)
+func TestSanitizeEnodeRemote(t *testing.T) {
+	pk, err := crypto.GenerateKey()
+	if err != nil {
+		t.Fatal(err)
+	}
+	remoteIP := net.IPv4(0x80, 0x40, 0x20, 0x10)
+	remoteAddr := net.TCPAddr{
+		IP:   remoteIP,
+		Port: 30399,
+	}
+	nodLocal := enode.NewV4(&pk.PublicKey, net.IPv4(0x7f, 0x00, 0x00, 0x01), 30341, 30341)
+	nodRemote := enode.NewV4(&pk.PublicKey, remoteIP, 30341, 30341)
+	baddr := RandomAddr()
+	oldUAddr := []byte(nodLocal.String())
+	baddr.UAddr = oldUAddr
+	newUAddr := sanitizeEnodeRemote(&remoteAddr, baddr).UAddr
+	if !bytes.Equal(newUAddr, []byte(nodRemote.String())) {
+		t.Fatalf("insane address. expected %v, got %v", nodRemote.String(), string(newUAddr))
 	}
 }


### PR DESCRIPTION
Resolves https://github.com/ethersphere/go-ethereum/issues/1219 (see description below) by extracting the remote address of the `p2p.Peer` and overwriting the `BzzAddr.UAddr` if they differ.

This is a temporary fix awaiting ENR refactor.

---

Example; Nodes `A`, `B` and `C` are started without `--nat` flag. Their enode strings _used in the swarm handshake_ will all have localhost.

You find a subnet ip for `A` that's reachable from `B` and `C`. You replace the localhost in the enode string with this ip. Then you execute RPC call `admin.addPeer` with that enode string to `B` and `C`. 

**Result: `B` and `C` will have connected to `A`, but not have connected to each other.**

It seems that in the discovery protocol, `B` and `C` still "convince" A that they exist on localhost, and when A suggests B to C, it will be with localhost as the host part.

Instead, it would be more natural that A stores the ip from the interface the request can in on, and propagates _this_ as the host part.

Note; the same problem applies if you do the `admin.addPeer` on `A` to `B` and `C`.