### PR TITLE
swarm: fix global-store cmd tests on windows

### DIFF
--- a/cmd/swarm/global-store/global_store_test.go
+++ b/cmd/swarm/global-store/global_store_test.go
@@ -60,7 +60,7 @@ func TestHTTP_Database(t *testing.T) {
 func testHTTP(t *testing.T, put bool, args ...string) {
 	addr := findFreeTCPAddress(t)
 	testCmd := runGlobalStore(t, append([]string{"http", "--addr", addr}, args...)...)
-	defer testCmd.Interrupt()
+	defer testCmd.Kill()
 
 	client, err := rpc.DialHTTP("http://" + addr)
 	if err != nil {
@@ -135,7 +135,7 @@ func TestWebsocket_Database(t *testing.T) {
 func testWebsocket(t *testing.T, put bool, args ...string) {
 	addr := findFreeTCPAddress(t)
 	testCmd := runGlobalStore(t, append([]string{"ws", "--addr", addr}, args...)...)
-	defer testCmd.Interrupt()
+	defer testCmd.Kill()
 
 	var client *rpc.Client
 	var err error


### PR DESCRIPTION
This PR addresses issue with timeouts in cmd/swarm/global-store tests on windows. A subprocess needs to be terminated using Kill method not Interrupt.

fixes: ethersphere/go-ethereum#1229