### PR TITLE
Ci race detector handle failing tests

### DIFF
--- a/swarm/network/simulations/discovery/discovery_test.go
+++ b/swarm/network/simulations/discovery/discovery_test.go
@@ -27,6 +27,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/ethereum/go-ethereum/swarm/testutil"
+
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/node"
@@ -82,11 +84,18 @@ func getDbStore(nodeID string) (*state.DBStore, error) {
 }
 
 var (
-	nodeCount = flag.Int("nodes", 32, "number of nodes to create (default 32)")
+	nodeCount = flag.Int("nodes", defaultNodeCount(), "number of nodes to create (default 32)")
 	initCount = flag.Int("conns", 1, "number of originally connected peers	 (default 1)")
 	loglevel  = flag.Int("loglevel", 3, "verbosity of logs")
 	rawlog    = flag.Bool("rawlog", false, "remove terminal formatting from logs")
 )
+
+func defaultNodeCount() int {
+	if testutil.RaceEnabled {
+		return 8
+	}
+	return 32
+}
 
 func init() {
 	flag.Parse()

--- a/swarm/network/stream/delivery_test.go
+++ b/swarm/network/stream/delivery_test.go
@@ -446,6 +446,12 @@ func TestDeliveryFromNodes(t *testing.T) {
 	testDeliveryFromNodes(t, 2, dataChunkCount, false)
 	testDeliveryFromNodes(t, 4, dataChunkCount, true)
 	testDeliveryFromNodes(t, 4, dataChunkCount, false)
+
+	if testutil.RaceEnabled {
+		// Travis cannot handle more nodes with -race; would time out.
+		return
+	}
+
 	testDeliveryFromNodes(t, 8, dataChunkCount, true)
 	testDeliveryFromNodes(t, 8, dataChunkCount, false)
 	testDeliveryFromNodes(t, 16, dataChunkCount, true)

--- a/swarm/network/stream/snapshot_retrieval_test.go
+++ b/swarm/network/stream/snapshot_retrieval_test.go
@@ -22,6 +22,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/ethereum/go-ethereum/swarm/testutil"
+
 	"github.com/ethereum/go-ethereum/node"
 	"github.com/ethereum/go-ethereum/p2p/enode"
 	"github.com/ethereum/go-ethereum/p2p/simulations/adapters"
@@ -43,23 +45,24 @@ const (
 //Files are uploaded to nodes, other nodes try to retrieve the file
 //Number of nodes can be provided via commandline too.
 func TestFileRetrieval(t *testing.T) {
+	var nodeCount []int
+
 	if *nodes != 0 {
-		err := runFileRetrievalTest(*nodes)
-		if err != nil {
-			t.Fatal(err)
-		}
+		nodeCount = []int{*nodes}
 	} else {
-		nodeCnt := []int{16}
-		//if the `longrunning` flag has been provided
-		//run more test combinations
+		nodeCount = []int{16}
+
 		if *longrunning {
-			nodeCnt = append(nodeCnt, 32, 64, 128)
+			nodeCount = append(nodeCount, 32, 64, 128)
+		} else if testutil.RaceEnabled {
+			nodeCount = []int{4}
 		}
-		for _, n := range nodeCnt {
-			err := runFileRetrievalTest(n)
-			if err != nil {
-				t.Fatal(err)
-			}
+
+	}
+
+	for _, nc := range nodeCount {
+		if err := runFileRetrievalTest(nc); err != nil {
+			t.Error(err)
 		}
 	}
 }

--- a/swarm/network/stream/snapshot_retrieval_test.go
+++ b/swarm/network/stream/snapshot_retrieval_test.go
@@ -82,18 +82,17 @@ func TestRetrieval(t *testing.T) {
 			t.Fatal(err)
 		}
 	} else {
-		var nodeCnt []int
-		var chnkCnt []int
-		//if the `longrunning` flag has been provided
-		//run more test combinations
+		nodeCnt := []int{16}
+		chnkCnt := []int{32}
+
 		if *longrunning {
 			nodeCnt = []int{16, 32, 128}
 			chnkCnt = []int{4, 32, 256}
-		} else {
-			//default test
-			nodeCnt = []int{16}
-			chnkCnt = []int{32}
+		} else if testutil.RaceEnabled {
+			nodeCnt = []int{4}
+			chnkCnt = []int{4}
 		}
+
 		for _, n := range nodeCnt {
 			for _, c := range chnkCnt {
 				t.Run(fmt.Sprintf("TestRetrieval_%d_%d", n, c), func(t *testing.T) {

--- a/swarm/network/stream/snapshot_sync_test.go
+++ b/swarm/network/stream/snapshot_sync_test.go
@@ -42,8 +42,6 @@ import (
 	"github.com/ethereum/go-ethereum/swarm/testutil"
 )
 
-const MaxTimeout = 600
-
 type synctestConfig struct {
 	addrs         [][]byte
 	hashes        []storage.Address
@@ -93,7 +91,7 @@ func TestSyncingViaGlobalSync(t *testing.T) {
 		if *longrunning {
 			chnkCnt = []int{1, 8, 32, 256, 1024}
 			nodeCnt = []int{16, 32, 64, 128, 256}
-		} else if raceTest {
+		} else if testutil.RaceEnabled {
 			// TestSyncingViaGlobalSync allocates a lot of memory
 			// with race detector. By reducing the number of chunks
 			// and nodes, memory consumption is lower and data races
@@ -125,7 +123,7 @@ var simServiceMap = map[string]simulation.ServiceFunc{
 
 		var dir string
 		var store *state.DBStore
-		if raceTest {
+		if testutil.RaceEnabled {
 			// Use on-disk DBStore to reduce memory consumption in race tests.
 			dir, err = ioutil.TempDir("", "swarm-stream-")
 			if err != nil {

--- a/swarm/network/stream/snapshot_sync_test.go
+++ b/swarm/network/stream/snapshot_sync_test.go
@@ -19,7 +19,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"runtime"
 	"sync"
@@ -78,37 +77,31 @@ func TestSyncingViaGlobalSync(t *testing.T) {
 	if runtime.GOOS == "darwin" && os.Getenv("TRAVIS") == "true" {
 		t.Skip("Flaky on mac on travis")
 	}
+
+	if testutil.RaceEnabled {
+		t.Skip("Segfaults on Travis with -race")
+	}
+
 	//if nodes/chunks have been provided via commandline,
 	//run the tests with these values
 	if *nodes != 0 && *chunks != 0 {
 		log.Info(fmt.Sprintf("Running test with %d chunks and %d nodes...", *chunks, *nodes))
 		testSyncingViaGlobalSync(t, *chunks, *nodes)
 	} else {
-		var nodeCnt []int
-		var chnkCnt []int
+		chunkCounts := []int{4, 32}
+		nodeCounts := []int{32, 16}
+
 		//if the `longrunning` flag has been provided
 		//run more test combinations
 		if *longrunning {
-			chnkCnt = []int{1, 8, 32, 256, 1024}
-			nodeCnt = []int{16, 32, 64, 128, 256}
-		} else if testutil.RaceEnabled {
-			// TestSyncingViaGlobalSync allocates a lot of memory
-			// with race detector. By reducing the number of chunks
-			// and nodes, memory consumption is lower and data races
-			// are still checked, while correctness of syncing is
-			// tested with more chunks and nodes in regular (!race)
-			// tests.
-			chnkCnt = []int{4}
-			nodeCnt = []int{16}
-		} else {
-			//default test
-			chnkCnt = []int{4, 32}
-			nodeCnt = []int{32, 16}
+			chunkCounts = []int{1, 8, 32, 256, 1024}
+			nodeCounts = []int{16, 32, 64, 128, 256}
 		}
-		for _, chnk := range chnkCnt {
-			for _, n := range nodeCnt {
-				log.Info(fmt.Sprintf("Long running test with %d chunks and %d nodes...", chnk, n))
-				testSyncingViaGlobalSync(t, chnk, n)
+
+		for _, chunkCount := range chunkCounts {
+			for _, n := range nodeCounts {
+				log.Info(fmt.Sprintf("Long running test with %d chunks and %d nodes...", chunkCount, n))
+				testSyncingViaGlobalSync(t, chunkCount, n)
 			}
 		}
 	}
@@ -121,21 +114,7 @@ var simServiceMap = map[string]simulation.ServiceFunc{
 			return nil, nil, err
 		}
 
-		var dir string
-		var store *state.DBStore
-		if testutil.RaceEnabled {
-			// Use on-disk DBStore to reduce memory consumption in race tests.
-			dir, err = ioutil.TempDir("", "swarm-stream-")
-			if err != nil {
-				return nil, nil, err
-			}
-			store, err = state.NewDBStore(dir)
-			if err != nil {
-				return nil, nil, err
-			}
-		} else {
-			store = state.NewInmemoryStore()
-		}
+		store := state.NewInmemoryStore()
 
 		r := NewRegistry(addr.ID(), delivery, netStore, store, &RegistryOptions{
 			Retrieval:       RetrievalDisabled,

--- a/swarm/network/stream/streamer_test.go
+++ b/swarm/network/stream/streamer_test.go
@@ -21,11 +21,14 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
 	"strconv"
 	"strings"
 	"sync"
 	"testing"
 	"time"
+
+	"github.com/ethereum/go-ethereum/swarm/testutil"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/log"
@@ -1177,6 +1180,11 @@ starts the simulation, waits for SyncUpdateDelay in order to kick off
 stream registration, then tests that there are subscriptions.
 */
 func TestGetSubscriptionsRPC(t *testing.T) {
+
+	if testutil.RaceEnabled && os.Getenv("TRAVIS") == "true" {
+		t.Skip("flaky with -race on Travis")
+		// Note: related ticket https://github.com/ethersphere/go-ethereum/issues/1234
+	}
 
 	// arbitrarily set to 4
 	nodeCount := 4

--- a/swarm/network/stream/syncer_test.go
+++ b/swarm/network/stream/syncer_test.go
@@ -48,7 +48,7 @@ func TestSyncerSimulation(t *testing.T) {
 	// race detector. Allow it to finish successfully by
 	// reducing its scope, and still check for data races
 	// with the smallest number of nodes.
-	if !raceTest {
+	if !testutil.RaceEnabled {
 		testSyncBetweenNodes(t, 4, dataChunkCount, true, 1)
 		testSyncBetweenNodes(t, 8, dataChunkCount, true, 1)
 		testSyncBetweenNodes(t, 16, dataChunkCount, true, 1)
@@ -88,7 +88,7 @@ func testSyncBetweenNodes(t *testing.T, nodes, chunkCount int, skipCheck bool, p
 
 			var dir string
 			var store *state.DBStore
-			if raceTest {
+			if testutil.RaceEnabled {
 				// Use on-disk DBStore to reduce memory consumption in race tests.
 				dir, err = ioutil.TempDir("", "swarm-stream-")
 				if err != nil {

--- a/swarm/network/stream/visualized_snapshot_sync_sim_test.go
+++ b/swarm/network/stream/visualized_snapshot_sync_sim_test.go
@@ -136,16 +136,6 @@ func TestSnapshotSyncWithServer(t *testing.T) {
 	//define a wrapper object to be able to pass around data
 	wrapper := &netWrapper{}
 
-	nodeCount := *nodes
-	chunkCount := *chunks
-
-	if nodeCount == 0 || chunkCount == 0 {
-		nodeCount = 32
-		chunkCount = 1
-	}
-
-	log.Info(fmt.Sprintf("Running the simulation with %d nodes and %d chunks", nodeCount, chunkCount))
-
 	sim := simulation.New(map[string]simulation.ServiceFunc{
 		"streamer": func(ctx *adapters.ServiceContext, bucket *sync.Map) (s node.Service, cleanup func(), err error) {
 			addr, netStore, delivery, clean, err := newNetStoreAndDeliveryWithRequestFunc(ctx, bucket, dummyRequestFromPeers)
@@ -178,6 +168,7 @@ func TestSnapshotSyncWithServer(t *testing.T) {
 	nodeCount, chunkCount, sim := setupSim(simServiceMap)
 	defer sim.Close()
 
+	log.Info(fmt.Sprintf("Running the simulation with %d nodes and %d chunks", nodeCount, chunkCount))
 	log.Info("Initializing test config")
 
 	conf := &synctestConfig{}

--- a/swarm/storage/common_test.go
+++ b/swarm/storage/common_test.go
@@ -142,7 +142,7 @@ func mget(store ChunkStore, hs []Address, f func(h Address, chunk Chunk) error) 
 		close(errc)
 	}()
 	var err error
-	timeout := 10 * time.Second
+	timeout := 20 * time.Second
 	select {
 	case err = <-errc:
 	case <-time.NewTimer(timeout).C:

--- a/swarm/storage/localstore/gc_test.go
+++ b/swarm/storage/localstore/gc_test.go
@@ -47,6 +47,8 @@ func TestDB_collectGarbageWorker_multipleBatches(t *testing.T) {
 // testDB_collectGarbageWorker is a helper test function to test
 // garbage collection runs by uploading and syncing a number of chunks.
 func testDB_collectGarbageWorker(t *testing.T) {
+	t.Helper()
+
 	chunkCount := 150
 
 	testHookCollectGarbageChan := make(chan int64)

--- a/swarm/storage/localstore/subscription_pull_test.go
+++ b/swarm/storage/localstore/subscription_pull_test.go
@@ -20,11 +20,13 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"os"
 	"sync"
 	"testing"
 	"time"
 
 	"github.com/ethereum/go-ethereum/swarm/storage"
+	"github.com/ethereum/go-ethereum/swarm/testutil"
 )
 
 // TestDB_SubscribePull uploads some chunks before and after
@@ -32,6 +34,12 @@ import (
 // all addresses are received in the right order
 // for expected proximity order bins.
 func TestDB_SubscribePull(t *testing.T) {
+
+	if testutil.RaceEnabled && os.Getenv("TRAVIS") == "true" {
+		t.Skip("does not complete with -race on Travis")
+		// Note: related ticket TODO
+	}
+
 	db, cleanupFunc := newTestDB(t, nil)
 	defer cleanupFunc()
 
@@ -79,6 +87,12 @@ func TestDB_SubscribePull(t *testing.T) {
 // validates if all addresses are received in the right order
 // for expected proximity order bins.
 func TestDB_SubscribePull_multiple(t *testing.T) {
+
+	if testutil.RaceEnabled && os.Getenv("TRAVIS") == "true" {
+		t.Skip("does not complete with -race on Travis")
+		// Note: related ticket TODO
+	}
+
 	db, cleanupFunc := newTestDB(t, nil)
 	defer cleanupFunc()
 
@@ -132,6 +146,12 @@ func TestDB_SubscribePull_multiple(t *testing.T) {
 // and validates if all expected addresses are received in the
 // right order for expected proximity order bins.
 func TestDB_SubscribePull_since(t *testing.T) {
+
+	if testutil.RaceEnabled && os.Getenv("TRAVIS") == "true" {
+		t.Skip("does not complete with -race on Travis")
+		// Note: related ticket TODO
+	}
+
 	db, cleanupFunc := newTestDB(t, nil)
 	defer cleanupFunc()
 
@@ -222,6 +242,12 @@ func TestDB_SubscribePull_since(t *testing.T) {
 // and validates if all expected addresses are received in the
 // right order for expected proximity order bins.
 func TestDB_SubscribePull_until(t *testing.T) {
+
+	if testutil.RaceEnabled && os.Getenv("TRAVIS") == "true" {
+		t.Skip("does not complete with -race on Travis")
+		// Note: related ticket TODO
+	}
+
 	db, cleanupFunc := newTestDB(t, nil)
 	defer cleanupFunc()
 
@@ -311,6 +337,12 @@ func TestDB_SubscribePull_until(t *testing.T) {
 // and until arguments, and validates if all expected addresses
 // are received in the right order for expected proximity order bins.
 func TestDB_SubscribePull_sinceAndUntil(t *testing.T) {
+
+	if testutil.RaceEnabled && os.Getenv("TRAVIS") == "true" {
+		t.Skip("does not complete with -race on Travis")
+		// Note: related ticket TODO
+	}
+
 	db, cleanupFunc := newTestDB(t, nil)
 	defer cleanupFunc()
 

--- a/swarm/testutil/norace.go
+++ b/swarm/testutil/norace.go
@@ -16,9 +16,11 @@
 
 // +build !race
 
-package stream
+package testutil
 
-// Provide a flag to reduce the scope of tests when running them
-// with race detector. Some of the tests are doing a lot of allocations
-// on the heap, and race detector uses much more memory to track them.
-const raceTest = false
+// RaceEnabled is true when -race flag is provided to the go tool. This const
+// might be used in tests to skip some cases as the race detector may increase
+// memory usage 5-10x and execution time by 2-20x. That might causes problems
+// on Travis. Please, use this flag sparingly and keep your unit tests
+// as light on resources as possible.
+const RaceEnabled = false

--- a/swarm/testutil/race.go
+++ b/swarm/testutil/race.go
@@ -16,8 +16,8 @@
 
 // +build race
 
-package stream
+package testutil
 
-// Reduce the scope of some tests when running with race detector,
-// as it raises the memory consumption significantly.
-const raceTest = true
+// RaceEnabled is true when -race flag is provided to the go tool.
+// See norace.go for more.
+const RaceEnabled = true


### PR DESCRIPTION
The goal is to make all tests stable and passing on Travis with `-race` flag. ASAP. We might create separate tickets to remove skip/resource restrictions on tests.

Travis has limited resources. We mostly hit memory limitations, but sometimes time limits, too. With `testutil.RaceEnabled` bool we can detect if we are running with `-race` and skip resource heavy tests cases, while still keeping the smaller ones to benefit from race detection.

fixes https://github.com/ethersphere/go-ethereum/issues/1226