### PR TITLE
swarm/network: WIP consider all nodes for healthy iteration

### DIFF
--- a/cmd/swarm/swarm-snapshot/create.go
+++ b/cmd/swarm/swarm-snapshot/create.go
@@ -89,7 +89,7 @@ func createSnapshot(filename string, nodes int, services []string) (err error) {
 		return fmt.Errorf("connect nodes: %v", err)
 	}
 
-	ctx, cancelSimRun := context.WithTimeout(context.Background(), 2*time.Minute)
+	ctx, cancelSimRun := context.WithTimeout(context.Background(), 3*time.Minute)
 	defer cancelSimRun()
 	if _, err := sim.WaitTillHealthy(ctx); err != nil {
 		return fmt.Errorf("wait for healthy kademlia: %v", err)

--- a/cmd/swarm/swarm-snapshot/create_test.go
+++ b/cmd/swarm/swarm-snapshot/create_test.go
@@ -48,7 +48,7 @@ func TestSnapshotCreate(t *testing.T) {
 		},
 		{
 			name:  "more nodes",
-			nodes: defaultNodes + 5,
+			nodes: defaultNodes + 4,
 		},
 		{
 			name:     "services",

--- a/cmd/swarm/swarm-snapshot/create_test.go
+++ b/cmd/swarm/swarm-snapshot/create_test.go
@@ -81,7 +81,7 @@ func TestSnapshotCreate(t *testing.T) {
 			}
 			testCmd := runSnapshot(t, append(args, file.Name())...)
 
-			testCmd.ExpectExit()
+			testCmd.WaitExit()
 			if code := testCmd.ExitStatus(); code != 0 {
 				t.Fatalf("command exit code %v, expected 0", code)
 			}

--- a/cmd/swarm/swarm-snapshot/main.go
+++ b/cmd/swarm/swarm-snapshot/main.go
@@ -27,7 +27,7 @@ import (
 var gitCommit string // Git SHA1 commit hash of the release (set via linker flags)
 
 // default value for "create" command --nodes flag
-const defaultNodes = 10
+const defaultNodes = 8
 
 func main() {
 	err := newApp().Run(os.Args)

--- a/swarm/network/simulation/kademlia.go
+++ b/swarm/network/simulation/kademlia.go
@@ -58,8 +58,7 @@ func (s *Simulation) WaitTillHealthy(ctx context.Context) (ill map[enode.ID]*net
 			for k := range ill {
 				delete(ill, k)
 			}
-			log.Debug("kademlia health check", "addr count", len(addrs))
-			log.Debug("kademlias length", "len", len(kademlias))
+			log.Debug("kademlia health check", "addr count", len(addrs), "kad len", len(kademlias))
 			for id, k := range kademlias {
 				//PeerPot for this node
 				addr := common.Bytes2Hex(k.BaseAddr())

--- a/swarm/network/simulation/kademlia.go
+++ b/swarm/network/simulation/kademlia.go
@@ -70,7 +70,7 @@ func (s *Simulation) WaitTillHealthy(ctx context.Context) (ill map[enode.ID]*net
 				log.Debug("kademlia", "connectNN", h.ConnectNN, "knowNN", h.KnowNN)
 				log.Debug("kademlia", "health", h.ConnectNN && h.KnowNN, "addr", hex.EncodeToString(k.BaseAddr()), "node", id)
 				log.Debug("kademlia", "ill condition", !h.ConnectNN, "addr", hex.EncodeToString(k.BaseAddr()), "node", id)
-				if !h.ConnectNN {
+				if !h.Healthy() {
 					ill[id] = k
 				}
 			}
@@ -84,7 +84,8 @@ func (s *Simulation) WaitTillHealthy(ctx context.Context) (ill map[enode.ID]*net
 // kademlias returns all Kademlia instances that are set
 // in simulation bucket.
 func (s *Simulation) kademlias() (ks map[enode.ID]*network.Kademlia) {
-	items := s.UpNodesItems(BucketKeyKademlia)
+	//items := s.UpNodesItems(BucketKeyKademlia)
+	items := s.NodesItems(BucketKeyKademlia)
 	ks = make(map[enode.ID]*network.Kademlia, len(items))
 	for id, v := range items {
 		k, ok := v.(*network.Kademlia)

--- a/swarm/network/simulation/kademlia.go
+++ b/swarm/network/simulation/kademlia.go
@@ -59,6 +59,7 @@ func (s *Simulation) WaitTillHealthy(ctx context.Context) (ill map[enode.ID]*net
 				delete(ill, k)
 			}
 			log.Debug("kademlia health check", "addr count", len(addrs))
+			log.Debug("kademlias length", "len", len(kademlias))
 			for id, k := range kademlias {
 				//PeerPot for this node
 				addr := common.Bytes2Hex(k.BaseAddr())
@@ -84,8 +85,8 @@ func (s *Simulation) WaitTillHealthy(ctx context.Context) (ill map[enode.ID]*net
 // kademlias returns all Kademlia instances that are set
 // in simulation bucket.
 func (s *Simulation) kademlias() (ks map[enode.ID]*network.Kademlia) {
-	//items := s.UpNodesItems(BucketKeyKademlia)
-	items := s.NodesItems(BucketKeyKademlia)
+	items := s.UpNodesItems(BucketKeyKademlia)
+	log.Debug("kademlia len items", "len", len(items))
 	ks = make(map[enode.ID]*network.Kademlia, len(items))
 	for id, v := range items {
 		k, ok := v.(*network.Kademlia)

--- a/swarm/network/simulation/kademlia_test.go
+++ b/swarm/network/simulation/kademlia_test.go
@@ -50,7 +50,6 @@ func TestWaitTillHealthy(t *testing.T) {
 
 	// create the first simulation
 	sim := New(simServiceMap)
-	defer sim.Close()
 
 	// connect and...
 	_, err := sim.AddNodesAndConnectRing(testNodesNum)
@@ -79,6 +78,7 @@ func TestWaitTillHealthy(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	sim.Close()
 	// create a control simulation
 	controlSim := New(createSimServiceMap(false))
 	defer controlSim.Close()
@@ -111,7 +111,7 @@ func TestWaitTillHealthy(t *testing.T) {
 
 	for _, node := range nodeIDs {
 		// ...get its kademlia
-		item, ok := sim.NodeItem(node, BucketKeyKademlia)
+		item, ok := controlSim.NodeItem(node, BucketKeyKademlia)
 		if !ok {
 			t.Fatal("No kademlia bucket item")
 		}

--- a/swarm/network/simulation/kademlia_test.go
+++ b/swarm/network/simulation/kademlia_test.go
@@ -50,6 +50,7 @@ func TestWaitTillHealthy(t *testing.T) {
 
 	// create the first simulation
 	sim := New(simServiceMap)
+	defer sim.Close()
 
 	// connect and...
 	_, err := sim.AddNodesAndConnectRing(testNodesNum)
@@ -77,7 +78,6 @@ func TestWaitTillHealthy(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	sim.Close()
 
 	// create a control simulation
 	controlSim := New(createSimServiceMap(false))
@@ -85,6 +85,10 @@ func TestWaitTillHealthy(t *testing.T) {
 
 	// load the snapshot into this control simulation
 	err = controlSim.Net.Load(snap)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = controlSim.WaitTillHealthy(ctx)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -122,6 +126,7 @@ func TestWaitTillHealthy(t *testing.T) {
 		healthy := info.Healthy()
 		log.Trace("Node is healthy", "node", node, "healthy", healthy)
 		if !healthy {
+			log.Trace("Unhealthy kademlia", "kad", kad.String())
 			t.Fatalf("Expected node %v of control simulation to be healthy, but it is not", node)
 		}
 	}

--- a/swarm/network/simulation/kademlia_test.go
+++ b/swarm/network/simulation/kademlia_test.go
@@ -49,13 +49,11 @@ func TestWaitTillHealthy(t *testing.T) {
 	sim := New(createSimServiceMap(true))
 
 	// connect and...
-	_, err := sim.AddNodesAndConnectRing(testNodesNum)
+	nodeIDs, err := sim.AddNodesAndConnectRing(testNodesNum)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	// for each node...
-	nodeIDs := sim.UpNodeIDs()
 	// array of all overlay addresses
 	var addrs [][]byte
 	// iterate once to be able to build the peer map
@@ -78,9 +76,7 @@ func TestWaitTillHealthy(t *testing.T) {
 			t.Log("Node", id)
 			t.Log(kad.String())
 		}
-		if err != nil {
-			t.Fatal(err)
-		}
+		t.Fatal(err)
 	}
 
 	// now create a snapshot of this network


### PR DESCRIPTION
addresses https://github.com/ethersphere/go-ethereum/issues/1263

This PR corrects two problems with the existing `WaitTillHealthy` implementation.

1. The healthy check only called `ConnectNN`, should instead call `Healthy()`
2. The kademlias being checked were only from the nodes that were _up_ at the time. It should instead include all nodes that are in the simulation.