### PR TITLE
swarm/network/simulation: do not copy node mutex in UploadSnapshot

### DIFF
--- a/swarm/network/simulation/node.go
+++ b/swarm/network/simulation/node.go
@@ -222,11 +222,11 @@ func (s *Simulation) UploadSnapshot(snapshotFile string, opts ...AddNodeOption) 
 	//the snapshot probably has the property EnableMsgEvents not set
 	//just in case, set it to true!
 	//(we need this to wait for messages before uploading)
-	for _, n := range snap.Nodes {
-		n.Node.Config.EnableMsgEvents = true
-		n.Node.Config.Services = s.serviceNames
+	for i := range snap.Nodes {
+		snap.Nodes[i].Node.Config.EnableMsgEvents = true
+		snap.Nodes[i].Node.Config.Services = s.serviceNames
 		for _, o := range opts {
-			o(n.Node.Config)
+			o(snap.Nodes[i].Node.Config)
 		}
 	}
 


### PR DESCRIPTION
This PR addresses the issue with coping `upMu` mutex that was recently added to the p2p/simulations.Node.

```sh
$ go vet github.com/ethereum/go-ethereum/swarm/network/simulation                                                        (git)-[master] 
# github.com/ethereum/go-ethereum/swarm/network/simulation
swarm/network/simulation/node.go:225: range var n copies lock: github.com/ethereum/go-ethereum/p2p/simulations.NodeSnapshot contains github.com/ethereum/go-ethereum/p2p/simulations.Node contains sync.RWMutex
```

Swarm PR: https://github.com/ethersphere/go-ethereum/pull/1261