### PR TITLE
Update CI builders to Go 1.12, PPA to Go 1.11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,11 +14,22 @@ matrix:
       - go run build/ci.go install
       - go run build/ci.go test -coverage $TEST_PACKAGES
 
-    # These are the latest Go versions.
     - os: linux
       dist: trusty
       sudo: required
       go: 1.11.x
+      script:
+      - sudo modprobe fuse
+      - sudo chmod 666 /dev/fuse
+      - sudo chown root:$USER /etc/fuse.conf
+      - go run build/ci.go install
+      - go run build/ci.go test -coverage $TEST_PACKAGES
+
+    # These are the latest Go versions.
+    - os: linux
+      dist: trusty
+      sudo: required
+      go: 1.12.x
       script:
         - sudo modprobe fuse
         - sudo chmod 666 /dev/fuse
@@ -27,7 +38,7 @@ matrix:
         - go run build/ci.go test -coverage $TEST_PACKAGES
 
     - os: osx
-      go: 1.11.x
+      go: 1.12.x
       script:
         - echo "Increase the maximum number of open file descriptors on macOS"
         - NOFILE=20480
@@ -44,7 +55,7 @@ matrix:
     # This builder only tests code linters on latest version of Go
     - os: linux
       dist: trusty
-      go: 1.11.x
+      go: 1.12.x
       env:
         - lint
       git:
@@ -56,7 +67,7 @@ matrix:
     - if: repo = ethereum/go-ethereum AND type = push
       os: linux
       dist: trusty
-      go: 1.11.x
+      go: 1.12.x
       env:
         - ubuntu-ppa
       git:
@@ -79,7 +90,7 @@ matrix:
       os: linux
       dist: trusty
       sudo: required
-      go: 1.11.x
+      go: 1.12.x
       env:
         - azure-linux
       git:
@@ -114,7 +125,7 @@ matrix:
       dist: trusty
       services:
         - docker
-      go: 1.11.x
+      go: 1.12.x
       env:
         - azure-linux-mips
       git:
@@ -177,7 +188,7 @@ matrix:
     # This builder does the OSX Azure, iOS CocoaPods and iOS Azure uploads
     - if: repo = ethereum/go-ethereum AND type = push
       os: osx
-      go: 1.11.x
+      go: 1.12.x
       env:
         - azure-osx
         - azure-ios
@@ -207,7 +218,7 @@ matrix:
     - if: repo = ethereum/go-ethereum AND type = cron
       os: linux
       dist: trusty
-      go: 1.11.x
+      go: 1.12.x
       env:
         - azure-purge
       git:
@@ -215,11 +226,12 @@ matrix:
       script:
         - go run build/ci.go purge -store gethstore/builds -days 14
 
+    # This builder runs the race detector tests on the Swarm repo
     - name: Race Detector for Swarm
       if: repo = ethersphere/go-ethereum
       os: linux
       dist: trusty
-      go: 1.11.x
+      go: 1.12.x
       git:
         submodules: false # avoid cloning ethereum/tests
       script: ./build/travis_keepalive.sh go test -v -timeout 20m -race ./swarm...

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -23,8 +23,8 @@ environment:
 install:
   - git submodule update --init
   - rmdir C:\go /s /q
-  - appveyor DownloadFile https://storage.googleapis.com/golang/go1.11.5.windows-%GETH_ARCH%.zip
-  - 7z x go1.11.5.windows-%GETH_ARCH%.zip -y -oC:\ > NUL
+  - appveyor DownloadFile https://storage.googleapis.com/golang/go1.12.windows-%GETH_ARCH%.zip
+  - 7z x go1.12.windows-%GETH_ARCH%.zip -y -oC:\ > NUL
   - go version
   - gcc --version
 


### PR DESCRIPTION
Two weeks ago the Go 1.11 packages appeared on the Gophers PPA repo. Bump our PPR builders finally from Go 1.10 to 1.11 (https://launchpad.net/~gophers/+archive/ubuntu/archive).

Today Go 1.12 was released, bump our CI builders from Go 1.11.5 to 1.12 (https://golang.org/doc/go1.12).