### PR TITLE
travis, build: switch to NDK 19b, fix gomobile builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -137,7 +137,7 @@ matrix:
         - go run build/ci.go archive -arch mips64le -type tar -signer LINUX_SIGNING_KEY -upload gethstore/builds
 
     # This builder does the Android Maven and Azure uploads
-    - if: repo = ethereum/go-ethereum
+    - if: repo = ethereum/go-ethereum AND type = push
       os: linux
       dist: trusty
       addons:

--- a/.travis.yml
+++ b/.travis.yml
@@ -137,7 +137,7 @@ matrix:
         - go run build/ci.go archive -arch mips64le -type tar -signer LINUX_SIGNING_KEY -upload gethstore/builds
 
     # This builder does the Android Maven and Azure uploads
-    - if: repo = ethereum/go-ethereum AND type = push
+    - if: repo = ethereum/go-ethereum
       os: linux
       dist: trusty
       addons:
@@ -165,10 +165,10 @@ matrix:
         - export GOPATH=$HOME/go
       script:
         # Build the Android archive and upload it to Maven Central and Azure
-        - curl https://dl.google.com/android/repository/android-ndk-r17b-linux-x86_64.zip -o android-ndk-r17b.zip
-        - unzip -q android-ndk-r17b.zip && rm android-ndk-r17b.zip
-        - mv android-ndk-r17b $HOME
-        - export ANDROID_NDK=$HOME/android-ndk-r17b
+        - curl https://dl.google.com/android/repository/android-ndk-r19b-linux-x86_64.zip -o android-ndk-r19b.zip
+        - unzip -q android-ndk-r19b.zip && rm android-ndk-r19b.zip
+        - mv android-ndk-r19b $HOME
+        - export NDK_PATH=$HOME/android-ndk-r19b
 
         - mkdir -p $GOPATH/src/github.com/ethereum
         - ln -s `pwd` $GOPATH/src/github.com/ethereum/go-ethereum

--- a/.travis.yml
+++ b/.travis.yml
@@ -167,8 +167,7 @@ matrix:
         # Build the Android archive and upload it to Maven Central and Azure
         - curl https://dl.google.com/android/repository/android-ndk-r19b-linux-x86_64.zip -o android-ndk-r19b.zip
         - unzip -q android-ndk-r19b.zip && rm android-ndk-r19b.zip
-        - mv android-ndk-r19b $HOME
-        - export NDK_PATH=$HOME/android-ndk-r19b
+        - mv android-ndk-r19b $ANDROID_HOME/ndk-bundle
 
         - mkdir -p $GOPATH/src/github.com/ethereum
         - ln -s `pwd` $GOPATH/src/github.com/ethereum/go-ethereum

--- a/build/ci.go
+++ b/build/ci.go
@@ -800,12 +800,11 @@ func doAndroidArchive(cmdline []string) {
 	if os.Getenv("ANDROID_HOME") == "" {
 		log.Fatal("Please ensure ANDROID_HOME points to your Android SDK")
 	}
-	if os.Getenv("ANDROID_NDK") == "" {
-		log.Fatal("Please ensure ANDROID_NDK points to your Android NDK")
+	if os.Getenv("NDK_PATH") == "" {
+		log.Fatal("Please ensure NDK_PATH points to your Android NDK")
 	}
 	// Build the Android archive and Maven resources
 	build.MustRun(goTool("get", "golang.org/x/mobile/cmd/gomobile", "golang.org/x/mobile/cmd/gobind"))
-	build.MustRun(gomobileTool("init", "--ndk", os.Getenv("ANDROID_NDK")))
 	build.MustRun(gomobileTool("bind", "-ldflags", "-s -w", "--target", "android", "--javapkg", "org.ethereum", "-v", "github.com/ethereum/go-ethereum/mobile"))
 
 	if *local {

--- a/build/ci.go
+++ b/build/ci.go
@@ -800,9 +800,6 @@ func doAndroidArchive(cmdline []string) {
 	if os.Getenv("ANDROID_HOME") == "" {
 		log.Fatal("Please ensure ANDROID_HOME points to your Android SDK")
 	}
-	if os.Getenv("NDK_PATH") == "" {
-		log.Fatal("Please ensure NDK_PATH points to your Android NDK")
-	}
 	// Build the Android archive and Maven resources
 	build.MustRun(goTool("get", "golang.org/x/mobile/cmd/gomobile", "golang.org/x/mobile/cmd/gobind"))
 	build.MustRun(gomobileTool("bind", "-ldflags", "-s -w", "--target", "android", "--javapkg", "org.ethereum", "-v", "github.com/ethereum/go-ethereum/mobile"))


### PR DESCRIPTION
Fixes Android builds broken due to https://github.com/golang/mobile/commit/ca80213619811c2fbed3ff8345accbd4ba924d45.

**Note, this PR enabled the Android build job. That's a temporary thing to see whether builds work properly without having to merge. I'll revert that change when builds are green.**