### PR TITLE
all: Add an error return value to NewEVM

### DIFF
--- a/accounts/abi/bind/backends/simulated.go
+++ b/accounts/abi/bind/backends/simulated.go
@@ -304,7 +304,10 @@ func (b *SimulatedBackend) callContract(ctx context.Context, call ethereum.CallM
 	evmContext := core.NewEVMContext(msg, block.Header(), b.blockchain, nil)
 	// Create a new environment which holds all relevant information
 	// about the transaction and calling mechanisms.
-	vmenv := vm.NewEVM(evmContext, statedb, b.config, vm.Config{})
+	vmenv, err := vm.NewEVM(evmContext, statedb, b.config, vm.Config{})
+	if err != nil {
+		return nil, 0, false, err
+	}
 	gaspool := new(core.GasPool).AddGas(math.MaxUint64)
 
 	return core.NewStateTransition(vmenv, msg, gaspool).TransitionDb()

--- a/core/state_processor.go
+++ b/core/state_processor.go
@@ -94,7 +94,10 @@ func ApplyTransaction(config *params.ChainConfig, bc ChainContext, author *commo
 	context := NewEVMContext(msg, header, bc, author)
 	// Create a new environment which holds all relevant information
 	// about the transaction and calling mechanisms.
-	vmenv := vm.NewEVM(context, statedb, config, cfg)
+	vmenv, err := vm.NewEVM(context, statedb, config, cfg)
+	if err != nil {
+		return nil, 0, err
+	}
 	// Apply the transaction to the current state (included in the env)
 	_, gas, failed, err := ApplyMessage(vmenv, msg, gp)
 	if err != nil {

--- a/core/vm/evm.go
+++ b/core/vm/evm.go
@@ -129,7 +129,7 @@ type EVM struct {
 
 // NewEVM returns a new EVM. The returned EVM is not thread safe and should
 // only ever be used *once*.
-func NewEVM(ctx Context, statedb StateDB, chainConfig *params.ChainConfig, vmConfig Config) *EVM {
+func NewEVM(ctx Context, statedb StateDB, chainConfig *params.ChainConfig, vmConfig Config) (*EVM, error) {
 	evm := &EVM{
 		Context:      ctx,
 		StateDB:      statedb,
@@ -160,7 +160,7 @@ func NewEVM(ctx Context, statedb StateDB, chainConfig *params.ChainConfig, vmCon
 	evm.interpreters = append(evm.interpreters, NewEVMInterpreter(evm, vmConfig))
 	evm.interpreter = evm.interpreters[0]
 
-	return evm
+	return evm, nil
 }
 
 // Cancel cancels any running EVM operation. This may be called concurrently and

--- a/core/vm/instructions_test.go
+++ b/core/vm/instructions_test.go
@@ -33,8 +33,12 @@ type twoOperandTest struct {
 }
 
 func testTwoOperandOp(t *testing.T, tests []twoOperandTest, opFn func(pc *uint64, interpreter *EVMInterpreter, contract *Contract, memory *Memory, stack *Stack) ([]byte, error)) {
+	env, err := NewEVM(Context{}, nil, params.TestChainConfig, Config{})
+	if err != nil {
+		t.Fatalf("error creating the EVM object: %v", err)
+	}
+
 	var (
-		env            = NewEVM(Context{}, nil, params.TestChainConfig, Config{})
 		stack          = newstack()
 		pc             = uint64(0)
 		evmInterpreter = NewEVMInterpreter(env, env.vmConfig)
@@ -74,8 +78,11 @@ func testTwoOperandOp(t *testing.T, tests []twoOperandTest, opFn func(pc *uint64
 }
 
 func TestByteOp(t *testing.T) {
+	env, err := NewEVM(Context{}, nil, params.TestChainConfig, Config{})
+	if err != nil {
+		t.Fatalf("error creating the EVM object: %v", err)
+	}
 	var (
-		env            = NewEVM(Context{}, nil, params.TestChainConfig, Config{})
 		stack          = newstack()
 		evmInterpreter = NewEVMInterpreter(env, env.vmConfig)
 	)
@@ -209,8 +216,11 @@ func TestSLT(t *testing.T) {
 }
 
 func opBenchmark(bench *testing.B, op func(pc *uint64, interpreter *EVMInterpreter, contract *Contract, memory *Memory, stack *Stack) ([]byte, error), args ...string) {
+	env, err := NewEVM(Context{}, nil, params.TestChainConfig, Config{})
+	if err != nil {
+		bench.Fatalf("error creating the EVM object: %v", err)
+	}
 	var (
-		env            = NewEVM(Context{}, nil, params.TestChainConfig, Config{})
 		stack          = newstack()
 		evmInterpreter = NewEVMInterpreter(env, env.vmConfig)
 	)
@@ -444,8 +454,11 @@ func BenchmarkOpIsZero(b *testing.B) {
 }
 
 func TestOpMstore(t *testing.T) {
+	env, err := NewEVM(Context{}, nil, params.TestChainConfig, Config{})
+	if err != nil {
+		t.Fatalf("error creating the EVM object: %v", err)
+	}
 	var (
-		env            = NewEVM(Context{}, nil, params.TestChainConfig, Config{})
 		stack          = newstack()
 		mem            = NewMemory()
 		evmInterpreter = NewEVMInterpreter(env, env.vmConfig)
@@ -470,8 +483,11 @@ func TestOpMstore(t *testing.T) {
 }
 
 func BenchmarkOpMstore(bench *testing.B) {
+	env, err := NewEVM(Context{}, nil, params.TestChainConfig, Config{})
+	if err != nil {
+		bench.Fatalf("error creating the EVM object: %v", err)
+	}
 	var (
-		env            = NewEVM(Context{}, nil, params.TestChainConfig, Config{})
 		stack          = newstack()
 		mem            = NewMemory()
 		evmInterpreter = NewEVMInterpreter(env, env.vmConfig)
@@ -493,8 +509,11 @@ func BenchmarkOpMstore(bench *testing.B) {
 }
 
 func BenchmarkOpSHA3(bench *testing.B) {
+	env, err := NewEVM(Context{}, nil, params.TestChainConfig, Config{})
+	if err != nil {
+		bench.Fatalf("error creating the EVM object: %v", err)
+	}
 	var (
-		env            = NewEVM(Context{}, nil, params.TestChainConfig, Config{})
 		stack          = newstack()
 		mem            = NewMemory()
 		evmInterpreter = NewEVMInterpreter(env, env.vmConfig)

--- a/core/vm/logger_test.go
+++ b/core/vm/logger_test.go
@@ -49,8 +49,12 @@ type dummyStatedb struct {
 func (*dummyStatedb) GetRefund() uint64 { return 1337 }
 
 func TestStoreCapture(t *testing.T) {
+	env, err := NewEVM(Context{}, &dummyStatedb{}, params.TestChainConfig, Config{})
+	if err != nil {
+		t.Errorf("failed to create an EVM: %v", err)
+	}
+
 	var (
-		env      = NewEVM(Context{}, &dummyStatedb{}, params.TestChainConfig, Config{})
 		logger   = NewStructLogger(nil)
 		mem      = NewMemory()
 		stack    = newstack()

--- a/core/vm/runtime/env.go
+++ b/core/vm/runtime/env.go
@@ -22,7 +22,7 @@ import (
 	"github.com/ethereum/go-ethereum/core/vm"
 )
 
-func NewEnv(cfg *Config) *vm.EVM {
+func NewEnv(cfg *Config) (*vm.EVM, error) {
 	context := vm.Context{
 		CanTransfer: core.CanTransfer,
 		Transfer:    core.Transfer,

--- a/eth/api_backend.go
+++ b/eth/api_backend.go
@@ -125,12 +125,14 @@ func (b *EthAPIBackend) GetTd(blockHash common.Hash) *big.Int {
 	return b.eth.blockchain.GetTdByHash(blockHash)
 }
 
+// GetEVM creates a new EVM object
 func (b *EthAPIBackend) GetEVM(ctx context.Context, msg core.Message, state *state.StateDB, header *types.Header) (*vm.EVM, func() error, error) {
 	state.SetBalance(msg.From(), math.MaxBig256)
 	vmError := func() error { return nil }
 
 	context := core.NewEVMContext(msg, header, b.eth.BlockChain(), nil)
-	return vm.NewEVM(context, state, b.eth.chainConfig, *b.eth.blockchain.GetVMConfig()), vmError, nil
+	evm, err := vm.NewEVM(context, state, b.eth.chainConfig, *b.eth.blockchain.GetVMConfig())
+	return evm, vmError, err
 }
 
 func (b *EthAPIBackend) SubscribeRemovedLogsEvent(ch chan<- core.RemovedLogsEvent) event.Subscription {

--- a/eth/tracers/tracer_test.go
+++ b/eth/tracers/tracer_test.go
@@ -51,12 +51,15 @@ type dummyStatedb struct {
 func (*dummyStatedb) GetRefund() uint64 { return 1337 }
 
 func runTrace(tracer *Tracer) (json.RawMessage, error) {
-	env := vm.NewEVM(vm.Context{BlockNumber: big.NewInt(1)}, &dummyStatedb{}, params.TestChainConfig, vm.Config{Debug: true, Tracer: tracer})
+	env, err := vm.NewEVM(vm.Context{BlockNumber: big.NewInt(1)}, &dummyStatedb{}, params.TestChainConfig, vm.Config{Debug: true, Tracer: tracer})
+	if err != nil {
+		return nil, err
+	}
 
 	contract := vm.NewContract(account{}, account{}, big.NewInt(0), 10000)
 	contract.Code = []byte{byte(vm.PUSH1), 0x1, byte(vm.PUSH1), 0x1, 0x0}
 
-	_, err := env.Interpreter().Run(contract, []byte{}, false)
+	_, err = env.Interpreter().Run(contract, []byte{}, false)
 	if err != nil {
 		return nil, err
 	}
@@ -133,7 +136,10 @@ func TestHaltBetweenSteps(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	env := vm.NewEVM(vm.Context{BlockNumber: big.NewInt(1)}, &dummyStatedb{}, params.TestChainConfig, vm.Config{Debug: true, Tracer: tracer})
+	env, err := vm.NewEVM(vm.Context{BlockNumber: big.NewInt(1)}, &dummyStatedb{}, params.TestChainConfig, vm.Config{Debug: true, Tracer: tracer})
+	if err != nil {
+		t.Fatalf("error creating EVM object: %v", err)
+	}
 	contract := vm.NewContract(&account{}, &account{}, big.NewInt(0), 0)
 
 	tracer.CaptureState(env, 0, 0, 0, 0, nil, nil, contract, 0, nil)

--- a/eth/tracers/tracers_test.go
+++ b/eth/tracers/tracers_test.go
@@ -173,7 +173,10 @@ func TestPrestateTracerCreate2(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to create call tracer: %v", err)
 	}
-	evm := vm.NewEVM(context, statedb, params.MainnetChainConfig, vm.Config{Debug: true, Tracer: tracer})
+	evm, err := vm.NewEVM(context, statedb, params.MainnetChainConfig, vm.Config{Debug: true, Tracer: tracer})
+	if err != nil {
+		t.Fatalf("failed to create EVM: %v", err)
+	}
 
 	msg, err := tx.AsMessage(signer)
 	if err != nil {
@@ -247,7 +250,10 @@ func TestCallTracer(t *testing.T) {
 			if err != nil {
 				t.Fatalf("failed to create call tracer: %v", err)
 			}
-			evm := vm.NewEVM(context, statedb, test.Genesis.Config, vm.Config{Debug: true, Tracer: tracer})
+			evm, err := vm.NewEVM(context, statedb, test.Genesis.Config, vm.Config{Debug: true, Tracer: tracer})
+			if err != nil {
+				t.Fatalf("failed to create EVM: %v", err)
+			}
 
 			msg, err := tx.AsMessage(signer)
 			if err != nil {

--- a/les/api_backend.go
+++ b/les/api_backend.go
@@ -105,10 +105,12 @@ func (b *LesApiBackend) GetTd(hash common.Hash) *big.Int {
 	return b.eth.blockchain.GetTdByHash(hash)
 }
 
+// GetEVM creates a new EVM object
 func (b *LesApiBackend) GetEVM(ctx context.Context, msg core.Message, state *state.StateDB, header *types.Header) (*vm.EVM, func() error, error) {
 	state.SetBalance(msg.From(), math.MaxBig256)
 	context := core.NewEVMContext(msg, header, b.eth.blockchain, nil)
-	return vm.NewEVM(context, state, b.eth.chainConfig, vm.Config{}), state.Error, nil
+	vm, err := vm.NewEVM(context, state, b.eth.chainConfig, vm.Config{})
+	return vm, state.Error, err
 }
 
 func (b *LesApiBackend) SendTx(ctx context.Context, signedTx *types.Transaction) error {

--- a/light/odr_test.go
+++ b/light/odr_test.go
@@ -196,7 +196,10 @@ func odrContractCall(ctx context.Context, db ethdb.Database, bc *core.BlockChain
 		st.SetBalance(testBankAddress, math.MaxBig256)
 		msg := callmsg{types.NewMessage(testBankAddress, &testContractAddr, 0, new(big.Int), 1000000, new(big.Int), data, false)}
 		context := core.NewEVMContext(msg, header, chain, nil)
-		vmenv := vm.NewEVM(context, st, config, vm.Config{})
+		vmenv, err := vm.NewEVM(context, st, config, vm.Config{})
+		if err != nil {
+			return nil, err
+		}
 		gp := new(core.GasPool).AddGas(math.MaxUint64)
 		ret, _, _, _ := core.ApplyMessage(vmenv, msg, gp)
 		res = append(res, ret...)

--- a/tests/state_test_util.go
+++ b/tests/state_test_util.go
@@ -135,7 +135,10 @@ func (t *StateTest) Run(subtest StateSubtest, vmconfig vm.Config) (*state.StateD
 	}
 	context := core.NewEVMContext(msg, block.Header(), nil, &t.json.Env.Coinbase)
 	context.GetHash = vmTestBlockHash
-	evm := vm.NewEVM(context, statedb, config, vmconfig)
+	evm, err := vm.NewEVM(context, statedb, config, vmconfig)
+	if err != nil {
+		return nil, err
+	}
 
 	gaspool := new(core.GasPool)
 	gaspool.AddGas(block.GasLimit())

--- a/tests/vm_test_util.go
+++ b/tests/vm_test_util.go
@@ -115,12 +115,15 @@ func (t *VMTest) Run(vmconfig vm.Config) error {
 }
 
 func (t *VMTest) exec(statedb *state.StateDB, vmconfig vm.Config) ([]byte, uint64, error) {
-	evm := t.newEVM(statedb, vmconfig)
+	evm, err := t.newEVM(statedb, vmconfig)
+	if err != nil {
+		return nil, 0, err
+	}
 	e := t.json.Exec
 	return evm.Call(vm.AccountRef(e.Caller), e.Address, e.Data, e.GasLimit, e.Value)
 }
 
-func (t *VMTest) newEVM(statedb *state.StateDB, vmconfig vm.Config) *vm.EVM {
+func (t *VMTest) newEVM(statedb *state.StateDB, vmconfig vm.Config) (*vm.EVM, error) {
 	initialCall := true
 	canTransfer := func(db vm.StateDB, address common.Address, amount *big.Int) bool {
 		if initialCall {


### PR DESCRIPTION
With the introduction of [EVMC](https://github.com/ethereum/go-ethereum/pull/17954) some options passed during VM could make the process fail.

This introduces an `error` return value to `NewEVM` so that the VM creation doesn't have to panic. This is important, in case some instantiation during an RPC call (e.g. tracer) fails: we want the error to be reported to the RPC caller, while the main process (e.g. a full sync) continues.