### PR TITLE
core/types: fix receipt legacy decoding

### DIFF
--- a/core/types/log.go
+++ b/core/types/log.go
@@ -115,8 +115,12 @@ func (l *LogForStorage) EncodeRLP(w io.Writer) error {
 //
 // Note some redundant fields(e.g. block number, tx hash etc) will be assembled later.
 func (l *LogForStorage) DecodeRLP(s *rlp.Stream) error {
+	blob, err := s.Raw()
+	if err != nil {
+		return err
+	}
 	var dec rlpStorageLog
-	err := s.Decode(&dec)
+	err = rlp.DecodeBytes(blob, &dec)
 	if err == nil {
 		*l = LogForStorage{
 			Address: dec.Address,
@@ -126,7 +130,7 @@ func (l *LogForStorage) DecodeRLP(s *rlp.Stream) error {
 	} else {
 		// Try to decode log with previous definition.
 		var dec LegacyRlpStorageLog
-		err = s.Decode(&dec)
+		err = rlp.DecodeBytes(blob, &dec)
 		if err == nil {
 			*l = LogForStorage{
 				Address: dec.Address,

--- a/core/types/receipt.go
+++ b/core/types/receipt.go
@@ -184,10 +184,14 @@ func (r *ReceiptForStorage) EncodeRLP(w io.Writer) error {
 // DecodeRLP implements rlp.Decoder, and loads both consensus and implementation
 // fields of a receipt from an RLP stream.
 func (r *ReceiptForStorage) DecodeRLP(s *rlp.Stream) error {
+	blob, err := s.Raw()
+	if err != nil {
+		return err
+	}
 	var dec receiptStorageRLP
-	if err := s.Decode(&dec); err != nil {
+	if err := rlp.DecodeBytes(blob, &dec); err != nil {
 		var sdec LegacyReceiptStorageRLP
-		if err := s.Decode(&sdec); err != nil {
+		if err := rlp.DecodeBytes(blob, &sdec); err != nil {
 			return err
 		}
 		dec.PostStateOrStatus = common.CopyBytes(sdec.PostStateOrStatus)


### PR DESCRIPTION
https://github.com/ethereum/go-ethereum/pull/17106 reworked our database schema to store less redundant data. To cater for old nodes upgrading, loading the data was extended to first try to access new formats, and if that fails, try the old format.

The log and receipt decoder was unfortunately not implemented fully correctly, as they were operating on an RLP stream. If the loader that tried to access the new format fails, it already advanced the RLP stream and read the first few bytes, so the legacy format decoder would always fail.

This PR fixes it by first loading the entire next RLP raw item from the stream, and then attempting to decode the entire thing first in the new format, then in the legacy one.