### PR TITLE
build/deb: use custom cache for PPA builder

### DIFF
--- a/build/deb/ethereum-swarm/deb.rules
+++ b/build/deb/ethereum-swarm/deb.rules
@@ -4,6 +4,9 @@
 # Uncomment this to turn on verbose mode.
 #export DH_VERBOSE=1
 
+# Launchpad rejects Go's access to $HOME/.cache, use custom folder
+export GOCACHE /tmp/go-build
+
 override_dh_auto_build:
 	build/env.sh /usr/lib/go-1.11/bin/go run build/ci.go install -git-commit={{.Env.Commit}} -git-branch={{.Env.Branch}} -git-tag={{.Env.Tag}} -buildnum={{.Env.Buildnum}} -pull-request={{.Env.IsPullRequest}}
 

--- a/build/deb/ethereum/deb.rules
+++ b/build/deb/ethereum/deb.rules
@@ -4,6 +4,9 @@
 # Uncomment this to turn on verbose mode.
 #export DH_VERBOSE=1
 
+# Launchpad rejects Go's access to $HOME/.cache, use custom folder
+export GOCACHE /tmp/go-build
+
 override_dh_auto_build:
 	build/env.sh /usr/lib/go-1.11/bin/go run build/ci.go install -git-commit={{.Env.Commit}} -git-branch={{.Env.Branch}} -git-tag={{.Env.Tag}} -buildnum={{.Env.Buildnum}} -pull-request={{.Env.IsPullRequest}}
 


### PR DESCRIPTION
Launchpad by default sets the `$HOME` directory to `/sbuild-nonexistent`, which does not exist. The idea is that builders should not touch anything in HOME. Unfortunately Go 1.11+ uses `$HOME/.cache/go-build` by default as a build cache, failing with a permission denied error.

This PR points the build cache to `/tmp`. No idea if this will work or not.