### PR TITLE
swarm: enable p2p/discovery and disable dynamic dialling

### DIFF
--- a/cmd/swarm/main.go
+++ b/cmd/swarm/main.go
@@ -287,8 +287,8 @@ func bzzd(ctx *cli.Context) error {
 	//setup the ethereum node
 	utils.SetNodeConfig(ctx, &cfg)
 
-	//always disable discovery from p2p package - swarm discovery is done with the `hive` protocol
-	cfg.P2P.NoDiscovery = true
+	//disable dynamic dialing from p2p/discovery
+	cfg.P2P.NoDial = true
 
 	stack, err := node.New(&cfg)
 	if err != nil {

--- a/swarm/api/inspector.go
+++ b/swarm/api/inspector.go
@@ -18,6 +18,7 @@ package api
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/ethereum/go-ethereum/swarm/network"
 	"github.com/ethereum/go-ethereum/swarm/storage"
@@ -36,6 +37,14 @@ func NewInspector(api *API, hive *network.Hive, netStore *storage.NetStore) *Ins
 // Hive prints the kademlia table
 func (inspector *Inspector) Hive() string {
 	return inspector.hive.String()
+}
+
+func (inspector *Inspector) ListKnown() []string {
+	res := []string{}
+	for _, v := range inspector.hive.Kademlia.ListKnown() {
+		res = append(res, fmt.Sprintf("%v", v))
+	}
+	return res
 }
 
 type HasInfo struct {

--- a/swarm/network/kademlia.go
+++ b/swarm/network/kademlia.go
@@ -140,6 +140,7 @@ func (k *Kademlia) Register(peers ...*BzzAddr) error {
 	defer k.lock.Unlock()
 	var known, size int
 	for _, p := range peers {
+		log.Trace("kademlia trying to register", "addr", p)
 		// error if self received, peer should know better
 		// and should be punished for this
 		if bytes.Equal(p.Address(), k.base) {
@@ -149,10 +150,16 @@ func (k *Kademlia) Register(peers ...*BzzAddr) error {
 		k.addrs, _, found, _ = pot.Swap(k.addrs, p, Pof, func(v pot.Val) pot.Val {
 			// if not found
 			if v == nil {
+				log.Trace("registering new peer", "addr", p)
 				// insert new offline peer into conns
 				return newEntry(p)
 			}
-			// found among known peers, do nothing
+
+			e, ok := v.(*entry)
+			if ok {
+				log.Trace("found among known peers, do nothing", "new", p, "old", e.BzzAddr)
+			}
+
 			return v
 		})
 		if found {
@@ -415,6 +422,18 @@ func (k *Kademlia) Off(p *Peer) {
 		}
 		k.sendNeighbourhoodDepthChange()
 	}
+}
+
+func (k *Kademlia) ListKnown() []*BzzAddr {
+	res := []*BzzAddr{}
+
+	k.addrs.Each(func(val pot.Val) bool {
+		e := val.(*entry)
+		res = append(res, e.BzzAddr)
+		return true
+	})
+
+	return res
 }
 
 // EachConn is an iterator with args (base, po, f) applies f to each live peer

--- a/swarm/network/kademlia.go
+++ b/swarm/network/kademlia.go
@@ -158,7 +158,7 @@ func (k *Kademlia) Register(peers ...*BzzAddr) error {
 			e := v.(*entry)
 
 			// if underlay address is different, still add
-			if bytes.Compare(e.BzzAddr.UAddr, p.UAddr) != 0 {
+			if !bytes.Equal(e.BzzAddr.UAddr, p.UAddr) {
 				log.Trace("underlay addr is different, so add again", "new", p, "old", e.BzzAddr)
 				// insert new offline peer into conns
 				return newEntry(p)

--- a/swarm/network/kademlia.go
+++ b/swarm/network/kademlia.go
@@ -155,10 +155,16 @@ func (k *Kademlia) Register(peers ...*BzzAddr) error {
 				return newEntry(p)
 			}
 
-			e, ok := v.(*entry)
-			if ok {
-				log.Trace("found among known peers, do nothing", "new", p, "old", e.BzzAddr)
+			e := v.(*entry)
+
+			// if underlay address is different, still add
+			if bytes.Compare(e.BzzAddr.UAddr, p.UAddr) != 0 {
+				log.Trace("underlay addr is different, so add again", "new", p, "old", e.BzzAddr)
+				// insert new offline peer into conns
+				return newEntry(p)
 			}
+
+			log.Trace("found among known peers, underlay addr is same, do nothing", "new", p, "old", e.BzzAddr)
 
 			return v
 		})


### PR DESCRIPTION
This PR is re-enabling p2p discovery, but disabling the dynamic dialling functionality - the reason why we didn't want to have the p2p discovery in the first place.

The reason for this is - the `hive` protocol and the `Kademlia` table implementation on Swarm side does not update the underlay addresses of peers. More specifically `Kademlia.Register` does not update the underlay addresses ever, but `Kademlia.On` and `Kademlia.Off` do. This means that sometimes we are left with outdated destinations for nodes in our state store.

The `p2p` package handles that with:

```
    err := t.dial(srv, t.dest)
    if err != nil {
        log.Trace("Dial error", "task", t, "err", err)
        // Try resolving the ID of static nodes if dialing failed.
        if _, ok := err.(*dialError); ok && t.flags&staticDialedConn != 0 {
            if t.resolve(srv) {
                t.dial(srv, t.dest)
            }
        }
    }
```

Namely, if `dialling` fails, it tries to `resolve` an up-to-date destination for the node - something that is only done when `discovery` is enabled.

Bottom line: `hive` protocol relies heavily on the discovery functionality in the `p2p` package, so for now it is not wise to disable discovery on `p2p`.

Addresses: https://github.com/ethersphere/go-ethereum/issues/1268

-----

I also considered solving this directly on Swarm side, but the `hive` protocol implementation is not straight-forward and it is not clear how to determine what an up-to-date / accurate node destination is. What happens is that when a new node starts up and loads an out-dated node destination, it might receive a `hive` message with a different destination for a given node, and it can't determine which one is correct, without trying them both. We don't have functionality to do that, and implementing this seems like a major change in the `hive` protocol.