### PR TITLE
eth, les: Consider context errors in vmError function

### DIFF
--- a/eth/api_backend.go
+++ b/eth/api_backend.go
@@ -127,7 +127,7 @@ func (b *EthAPIBackend) GetTd(blockHash common.Hash) *big.Int {
 
 func (b *EthAPIBackend) GetEVM(ctx context.Context, msg core.Message, state *state.StateDB, header *types.Header) (*vm.EVM, func() error, error) {
 	state.SetBalance(msg.From(), math.MaxBig256)
-	vmError := func() error { return nil }
+	vmError := func() error { return ctx.Err() }
 
 	context := core.NewEVMContext(msg, header, b.eth.BlockChain(), nil)
 	return vm.NewEVM(context, state, b.eth.chainConfig, *b.eth.blockchain.GetVMConfig()), vmError, nil

--- a/les/api_backend.go
+++ b/les/api_backend.go
@@ -108,7 +108,13 @@ func (b *LesApiBackend) GetTd(hash common.Hash) *big.Int {
 func (b *LesApiBackend) GetEVM(ctx context.Context, msg core.Message, state *state.StateDB, header *types.Header) (*vm.EVM, func() error, error) {
 	state.SetBalance(msg.From(), math.MaxBig256)
 	context := core.NewEVMContext(msg, header, b.eth.blockchain, nil)
-	return vm.NewEVM(context, state, b.eth.chainConfig, vm.Config{}), state.Error, nil
+	vmError := func() error {
+		if err := state.Error(); err != nil {
+			return err
+		}
+		return ctx.Err()
+	}
+	return vm.NewEVM(context, state, b.eth.chainConfig, vm.Config{}), vmError, nil
 }
 
 func (b *LesApiBackend) SendTx(ctx context.Context, signedTx *types.Transaction) error {


### PR DESCRIPTION
In an `eth_call` request, if the EVM processing takes > 5 seconds
the request gets cancelled, but this is not resulting in an error
to the `eth_call` request (instead it responds with a result of "0x"
regardless of the called function).

With this in place, when a request times out, it will return an error
of:

`"error":{"code":-32000,"message":"context deadline exceeded"}`

Rather than incorrectly returning a null value.