### PR TITLE
cmd/utils: randomly enable light server by default

### DIFF
--- a/cmd/geth/accountcmd.go
+++ b/cmd/geth/accountcmd.go
@@ -298,7 +298,7 @@ func accountCreate(ctx *cli.Context) error {
 			utils.Fatalf("%v", err)
 		}
 	}
-	utils.SetNodeConfig(ctx, &cfg.Node)
+	utils.SetNodeConfig(ctx, &cfg.Node, nil)
 	scryptN, scryptP, keydir, err := cfg.Node.AccountConfig()
 
 	if err != nil {

--- a/cmd/geth/config.go
+++ b/cmd/geth/config.go
@@ -125,8 +125,8 @@ func makeConfigNode(ctx *cli.Context) (*node.Node, gethConfig) {
 	}
 
 	// Apply flags.
-	utils.SetULC(ctx, &cfg.Eth)
-	utils.SetNodeConfig(ctx, &cfg.Node)
+	utils.SetLesConfig(ctx, &cfg.Eth)
+	utils.SetNodeConfig(ctx, &cfg.Node, &cfg.Eth)
 	stack, err := node.New(&cfg.Node)
 	if err != nil {
 		utils.Fatalf("Failed to create the protocol stack: %v", err)

--- a/cmd/swarm/fs.go
+++ b/cmd/swarm/fs.go
@@ -149,7 +149,7 @@ func dialRPC(ctx *cli.Context) (*rpc.Client, error) {
 
 func getIPCEndpoint(ctx *cli.Context) string {
 	cfg := defaultNodeConfig
-	utils.SetNodeConfig(ctx, &cfg)
+	utils.SetNodeConfig(ctx, &cfg, nil)
 
 	endpoint := cfg.IPCEndpoint()
 

--- a/cmd/swarm/main.go
+++ b/cmd/swarm/main.go
@@ -285,7 +285,7 @@ func bzzd(ctx *cli.Context) error {
 	//optionally set the bootnodes before configuring the node
 	setSwarmBootstrapNodes(ctx, &cfg)
 	//setup the ethereum node
-	utils.SetNodeConfig(ctx, &cfg)
+	utils.SetNodeConfig(ctx, &cfg, nil)
 
 	//disable dynamic dialing from p2p/discovery
 	cfg.P2P.NoDial = true
@@ -377,7 +377,7 @@ func getPrivKey(ctx *cli.Context) *ecdsa.PrivateKey {
 	if _, err := os.Stat(bzzconfig.Path); err == nil {
 		cfg.DataDir = bzzconfig.Path
 	}
-	utils.SetNodeConfig(ctx, &cfg)
+	utils.SetNodeConfig(ctx, &cfg, nil)
 	stack, err := node.New(&cfg)
 	if err != nil {
 		utils.Fatalf("can't create node: %v", err)

--- a/les/backend.go
+++ b/les/backend.go
@@ -259,7 +259,6 @@ func (s *LightEthereum) Protocols() []p2p.Protocol {
 // Start implements node.Service, starting all internal goroutines needed by the
 // Ethereum protocol implementation.
 func (s *LightEthereum) Start(srvr *p2p.Server) error {
-	log.Warn("Light client mode is an experimental feature")
 	s.startBloomHandlers(params.BloomBitsBlocksClient)
 	s.netRPCService = ethapi.NewPublicNetAPI(srvr, s.networkId)
 	// clients are searching for the first advertised protocol in the list


### PR DESCRIPTION
This PR enables light server mode with 20% chance (lightserv=50) if we are running a full node, mining is not enabled and lightserv is not explicitly specified. Random server mode can still be disabled by specifying lightserv=0.
The PR also removes the "Light client is an experimental feature" warning.