### PR TITLE
vendor: update leveldb

### DIFF
--- a/vendor/github.com/syndtr/goleveldb/leveldb/version.go
+++ b/vendor/github.com/syndtr/goleveldb/leveldb/version.go
@@ -486,6 +486,12 @@ func (p *versionStaging) finish(trivial bool) *version {
 				nt = append(nt, t)
 			}
 
+			// Avoid resort if only files in this level are deleted
+			if len(scratch.added) == 0 {
+				nv.levels[level] = nt
+				continue
+			}
+
 			// For normal table compaction, one compaction will only involve two levels
 			// of files. And the new files generated after merging the source level and
 			// source+1 level related files can be inserted as a whole into source+1 level

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -455,10 +455,10 @@
 			"revisionTime": "2017-07-05T02:17:15Z"
 		},
 		{
-			"checksumSHA1": "4DuP8qJfeXFfdbcl4wr7l1VppcY=",
+			"checksumSHA1": "4vxle8JfbPDO0ndiBUjMmRXGBQM=",
 			"path": "github.com/syndtr/goleveldb/leveldb",
-			"revision": "4217c9f31f5816db02addc94e56061da77f288d8",
-			"revisionTime": "2019-02-26T15:37:22Z"
+			"revision": "3a907f965fc16db5f7787e18d4434bbe46d47f6e",
+			"revisionTime": "2019-03-04T06:08:05Z"
 		},
 		{
 			"checksumSHA1": "mPNraL2edpk/2FYq26rSXfMHbJg=",


### PR DESCRIPTION
This PR includes a leveldb fix for reducing `version.commit` overhead.

Please see the upstream PR https://github.com/syndtr/goleveldb/pull/267 for detail. 