### PR TITLE
build: add clef to alltools and deb

### DIFF
--- a/build/ci.go
+++ b/build/ci.go
@@ -80,6 +80,7 @@ var (
 		executablePath("puppeth"),
 		executablePath("rlpdump"),
 		executablePath("wnode"),
+		executablePath("clef"),
 	}
 
 	// Files that end up in the swarm*.zip archive.
@@ -117,6 +118,10 @@ var (
 		{
 			BinaryName:  "wnode",
 			Description: "Ethereum Whisper diagnostic tool",
+		},
+		{
+			BinaryName:  "clef",
+			Description: "Ethereum account management tool.",
 		},
 	}
 


### PR DESCRIPTION
This PR adds `clef` to the alltools docker image, and also to the `deb` packages. I'm not 100% sure I've done everything that's needed, nor how to properly verify that it works as intended. 

We can wait with this one until https://github.com/ethereum/go-ethereum/pull/19112 and https://github.com/ethereum/go-ethereum/pull/19047 are merged