### PR TITLE
cmd/abigen: allow using `abigen --pkg` flag with standard input

### DIFF
--- a/cmd/abigen/main.go
+++ b/cmd/abigen/main.go
@@ -81,7 +81,7 @@ func main() {
 		bins  []string
 		types []string
 	)
-	if *solFlag != "" || *vyFlag != "" || (*abiFlag == "-" && *pkgFlag == "") {
+	if *solFlag != "" || *vyFlag != "" || *abiFlag == "-" {
 		// Generate the list of types to exclude from binding
 		exclude := make(map[string]bool)
 		for _, kind := range strings.Split(*excFlag, ",") {

--- a/cmd/abigen/main.go
+++ b/cmd/abigen/main.go
@@ -129,13 +129,8 @@ func main() {
 		}
 	} else {
 		// Otherwise load up the ABI, optional bytecode and type name from the parameters
-		var abi []byte
-		var err error
-		if *abiFlag == "-" {
-			abi, err = ioutil.ReadAll(os.Stdin)
-		} else {
-			abi, err = ioutil.ReadFile(*abiFlag)
-		}
+		abi, err := ioutil.ReadFile(*abiFlag)
+
 		if err != nil {
 			fmt.Printf("Failed to read input ABI: %v\n", err)
 			os.Exit(-1)


### PR DESCRIPTION
Fix for https://github.com/ethereum/go-ethereum/issues/19292

Fix to allow using `abigen --pkg` flag with standard input.
See https://github.com/ethereum/go-ethereum/issues/17647#issuecomment-443110907 and https://github.com/ethereum/go-ethereum/issues/17647#issuecomment-464965285 for discussion