### PR TITLE
Enable longrunning tests to run

### DIFF
--- a/p2p/simulations/network.go
+++ b/p2p/simulations/network.go
@@ -841,7 +841,7 @@ func (net *Network) snapshot(addServices []string, removeServices []string) (*Sn
 }
 
 // longrunning tests may need a longer timeout
-var snapshotLoadTimeout = 7200 * time.Second
+var snapshotLoadTimeout = 900 * time.Second
 
 // Load loads a network snapshot
 func (net *Network) Load(snap *Snapshot) error {

--- a/p2p/simulations/network.go
+++ b/p2p/simulations/network.go
@@ -840,7 +840,8 @@ func (net *Network) snapshot(addServices []string, removeServices []string) (*Sn
 	return snap, nil
 }
 
-var snapshotLoadTimeout = 6000 * time.Second
+// longrunning tests may need a longer timeout
+var snapshotLoadTimeout = 7200 * time.Second
 
 // Load loads a network snapshot
 func (net *Network) Load(snap *Snapshot) error {

--- a/p2p/simulations/network.go
+++ b/p2p/simulations/network.go
@@ -840,7 +840,7 @@ func (net *Network) snapshot(addServices []string, removeServices []string) (*Sn
 	return snap, nil
 }
 
-var snapshotLoadTimeout = 120 * time.Second
+var snapshotLoadTimeout = 6000 * time.Second
 
 // Load loads a network snapshot
 func (net *Network) Load(snap *Snapshot) error {

--- a/swarm/network/stream/common_test.go
+++ b/swarm/network/stream/common_test.go
@@ -134,6 +134,9 @@ func netStoreAndDeliveryWithAddr(ctx *adapters.ServiceContext, bucket *sync.Map,
 	bucket.Store(bucketKeyDB, netStore)
 	bucket.Store(bucketKeyDelivery, delivery)
 	bucket.Store(bucketKeyFileStore, fileStore)
+	// for the kademlia object, we use the global key from the simulation package,
+	// as the simulation will try to access it in the WaitTillHealthy with that key
+	bucket.Store(simulation.BucketKeyKademlia, kad)
 
 	cleanup := func() {
 		netStore.Close()

--- a/swarm/network/stream/delivery_test.go
+++ b/swarm/network/stream/delivery_test.go
@@ -536,9 +536,11 @@ func testDeliveryFromNodes(t *testing.T, nodes, chunkCount int, skipCheck bool) 
 
 			log.Debug("Waiting for kademlia")
 			// TODO this does not seem to be correct usage of the function, as the simulation may have no kademlias
-			if _, err := sim.WaitTillHealthy(ctx); err != nil {
-				return err
-			}
+			/*
+				if _, err := sim.WaitTillHealthy(ctx); err != nil {
+					return err
+				}
+			*/
 
 			//get the pivot node's filestore
 			item, ok := sim.NodeItem(pivot, bucketKeyFileStore)

--- a/swarm/network/stream/delivery_test.go
+++ b/swarm/network/stream/delivery_test.go
@@ -534,14 +534,6 @@ func testDeliveryFromNodes(t *testing.T, nodes, chunkCount int, skipCheck bool) 
 				return err
 			}
 
-			log.Debug("Waiting for kademlia")
-			// TODO this does not seem to be correct usage of the function, as the simulation may have no kademlias
-			/*
-				if _, err := sim.WaitTillHealthy(ctx); err != nil {
-					return err
-				}
-			*/
-
 			//get the pivot node's filestore
 			item, ok := sim.NodeItem(pivot, bucketKeyFileStore)
 			if !ok {

--- a/swarm/network/stream/snapshot_retrieval_test.go
+++ b/swarm/network/stream/snapshot_retrieval_test.go
@@ -53,8 +53,8 @@ func TestFileRetrieval(t *testing.T) {
 		nodeCount = []int{16}
 
 		if *longrunning {
-			nodeCount = append(nodeCount, 32, 64, 128)
-			//nodeCount = append(nodeCount, 32, 64)
+			//nodeCount = append(nodeCount, 32, 64, 128)
+			nodeCount = append(nodeCount, 48)
 		} else if testutil.RaceEnabled {
 			nodeCount = []int{4}
 		}
@@ -87,8 +87,10 @@ func TestRetrieval(t *testing.T) {
 		chnkCnt := []int{32}
 
 		if *longrunning {
-			nodeCnt = []int{16, 32, 128}
-			chnkCnt = []int{4, 32, 256}
+			//nodeCnt = []int{16, 32, 128}
+			nodeCnt = []int{32, 48}
+			chnkCnt = []int{64, 128}
+			//chnkCnt = []int{4, 32, 256}
 		} else if testutil.RaceEnabled {
 			nodeCnt = []int{4}
 			chnkCnt = []int{4}

--- a/swarm/network/stream/snapshot_retrieval_test.go
+++ b/swarm/network/stream/snapshot_retrieval_test.go
@@ -54,6 +54,7 @@ func TestFileRetrieval(t *testing.T) {
 
 		if *longrunning {
 			nodeCount = append(nodeCount, 32, 64, 128)
+			//nodeCount = append(nodeCount, 32, 64)
 		} else if testutil.RaceEnabled {
 			nodeCount = []int{4}
 		}

--- a/swarm/network/stream/snapshot_retrieval_test.go
+++ b/swarm/network/stream/snapshot_retrieval_test.go
@@ -86,7 +86,7 @@ func TestRetrieval(t *testing.T) {
 		chnkCnt := []int{32}
 
 		if *longrunning {
-			nodeCnt = []int{16, 32, 128}
+			nodeCnt = []int{16, 32, 64}
 			chnkCnt = []int{4, 32, 256}
 		} else if testutil.RaceEnabled {
 			nodeCnt = []int{4}

--- a/swarm/network/stream/snapshot_retrieval_test.go
+++ b/swarm/network/stream/snapshot_retrieval_test.go
@@ -53,7 +53,7 @@ func TestFileRetrieval(t *testing.T) {
 		nodeCount = []int{16}
 
 		if *longrunning {
-			nodeCount = append(nodeCount, 32, 64, 128)
+			nodeCount = append(nodeCount, 32, 64)
 		} else if testutil.RaceEnabled {
 			nodeCount = []int{4}
 		}
@@ -86,7 +86,7 @@ func TestRetrieval(t *testing.T) {
 		chnkCnt := []int{32}
 
 		if *longrunning {
-			nodeCnt = []int{16, 32, 128}
+			nodeCnt = []int{16, 32, 64}
 			chnkCnt = []int{4, 32, 256}
 		} else if testutil.RaceEnabled {
 			nodeCnt = []int{4}
@@ -115,7 +115,7 @@ var retrievalSimServiceMap = map[string]simulation.ServiceFunc{
 
 		syncUpdateDelay := 1 * time.Second
 		if *longrunning {
-			syncUpdateDelay = 5 * time.Second
+			syncUpdateDelay = 3 * time.Second
 		}
 
 		r := NewRegistry(addr.ID(), delivery, netStore, state.NewInmemoryStore(), &RegistryOptions{

--- a/swarm/network/stream/snapshot_retrieval_test.go
+++ b/swarm/network/stream/snapshot_retrieval_test.go
@@ -115,7 +115,7 @@ var retrievalSimServiceMap = map[string]simulation.ServiceFunc{
 
 		syncUpdateDelay := 1 * time.Second
 		if *longrunning {
-			syncUpdateDelay = 15 * time.Second
+			syncUpdateDelay = 5 * time.Second
 		}
 
 		r := NewRegistry(addr.ID(), delivery, netStore, state.NewInmemoryStore(), &RegistryOptions{
@@ -145,7 +145,7 @@ func runFileRetrievalTest(nodeCount int) error {
 	sim := simulation.New(retrievalSimServiceMap)
 	defer sim.Close()
 
-	log.Info("Initializing test config")
+	log.Info("Initializing test config", "node count", nodeCount)
 
 	conf := &synctestConfig{}
 	//map of discover ID to indexes of chunks expected at that ID
@@ -162,6 +162,8 @@ func runFileRetrievalTest(nodeCount int) error {
 
 	ctx, cancelSimRun := context.WithTimeout(context.Background(), 3*time.Minute)
 	defer cancelSimRun()
+
+	log.Info("Starting simulation")
 
 	result := sim.Run(ctx, func(ctx context.Context, sim *simulation.Simulation) error {
 		nodeIDs := sim.UpNodeIDs()
@@ -190,6 +192,8 @@ func runFileRetrievalTest(nodeCount int) error {
 			return err
 		}
 
+		log.Info("network healthy, start file checks")
+
 		// File retrieval check is repeated until all uploaded files are retrieved from all nodes
 		// or until the timeout is reached.
 	REPEAT:
@@ -216,6 +220,8 @@ func runFileRetrievalTest(nodeCount int) error {
 			return nil
 		}
 	})
+
+	log.Info("Simulation terminated")
 
 	if result.Error != nil {
 		return result.Error

--- a/swarm/network/stream/snapshot_retrieval_test.go
+++ b/swarm/network/stream/snapshot_retrieval_test.go
@@ -113,10 +113,15 @@ var retrievalSimServiceMap = map[string]simulation.ServiceFunc{
 			return nil, nil, err
 		}
 
+		syncUpdateDelay := 1 * time.Second
+		if *longrunning {
+			syncUpdateDelay = 15 * time.Second
+		}
+
 		r := NewRegistry(addr.ID(), delivery, netStore, state.NewInmemoryStore(), &RegistryOptions{
 			Retrieval:       RetrievalEnabled,
 			Syncing:         SyncingAutoSubscribe,
-			SyncUpdateDelay: 3 * time.Second,
+			SyncUpdateDelay: syncUpdateDelay,
 		}, nil)
 
 		cleanup = func() {

--- a/swarm/network/stream/snapshot_retrieval_test.go
+++ b/swarm/network/stream/snapshot_retrieval_test.go
@@ -86,7 +86,7 @@ func TestRetrieval(t *testing.T) {
 		chnkCnt := []int{32}
 
 		if *longrunning {
-			nodeCnt = []int{16, 32, 64}
+			nodeCnt = []int{16, 32, 128}
 			chnkCnt = []int{4, 32, 256}
 		} else if testutil.RaceEnabled {
 			nodeCnt = []int{4}

--- a/swarm/network/stream/snapshot_retrieval_test.go
+++ b/swarm/network/stream/snapshot_retrieval_test.go
@@ -53,8 +53,7 @@ func TestFileRetrieval(t *testing.T) {
 		nodeCount = []int{16}
 
 		if *longrunning {
-			//nodeCount = append(nodeCount, 32, 64, 128)
-			nodeCount = append(nodeCount, 48)
+			nodeCount = append(nodeCount, 32, 64, 128)
 		} else if testutil.RaceEnabled {
 			nodeCount = []int{4}
 		}
@@ -87,10 +86,8 @@ func TestRetrieval(t *testing.T) {
 		chnkCnt := []int{32}
 
 		if *longrunning {
-			//nodeCnt = []int{16, 32, 128}
-			nodeCnt = []int{32, 48}
-			chnkCnt = []int{64, 128}
-			//chnkCnt = []int{4, 32, 256}
+			nodeCnt = []int{16, 32, 128}
+			chnkCnt = []int{4, 32, 256}
 		} else if testutil.RaceEnabled {
 			nodeCnt = []int{4}
 			chnkCnt = []int{4}

--- a/swarm/network/stream/snapshot_sync_test.go
+++ b/swarm/network/stream/snapshot_sync_test.go
@@ -94,9 +94,9 @@ func TestSyncingViaGlobalSync(t *testing.T) {
 		//if the `longrunning` flag has been provided
 		//run more test combinations
 		if *longrunning {
-			chunkCounts = []int{1, 8, 32, 256, 1024}
-			nodeCounts = []int{16, 32, 64, 128, 256}
-			//nodeCounts = []int{16, 32, 64}
+			chunkCounts = []int{64, 128}
+			//nodeCounts = []int{16, 32, 64, 128, 256}
+			nodeCounts = []int{32, 48}
 		}
 
 		for _, chunkCount := range chunkCounts {

--- a/swarm/network/stream/snapshot_sync_test.go
+++ b/swarm/network/stream/snapshot_sync_test.go
@@ -95,7 +95,7 @@ func TestSyncingViaGlobalSync(t *testing.T) {
 		//run more test combinations
 		if *longrunning {
 			chunkCounts = []int{64, 128}
-			nodeCounts = []int{64, 128}
+			nodeCounts = []int{32, 64}
 		}
 
 		for _, chunkCount := range chunkCounts {

--- a/swarm/network/stream/snapshot_sync_test.go
+++ b/swarm/network/stream/snapshot_sync_test.go
@@ -95,8 +95,7 @@ func TestSyncingViaGlobalSync(t *testing.T) {
 		//run more test combinations
 		if *longrunning {
 			chunkCounts = []int{64, 128}
-			//nodeCounts = []int{16, 32, 64, 128, 256}
-			nodeCounts = []int{32, 48}
+			nodeCounts = []int{64, 128}
 		}
 
 		for _, chunkCount := range chunkCounts {

--- a/swarm/network/stream/snapshot_sync_test.go
+++ b/swarm/network/stream/snapshot_sync_test.go
@@ -96,6 +96,7 @@ func TestSyncingViaGlobalSync(t *testing.T) {
 		if *longrunning {
 			chunkCounts = []int{1, 8, 32, 256, 1024}
 			nodeCounts = []int{16, 32, 64, 128, 256}
+			//nodeCounts = []int{16, 32, 64}
 		}
 
 		for _, chunkCount := range chunkCounts {

--- a/swarm/network/stream/syncer_test.go
+++ b/swarm/network/stream/syncer_test.go
@@ -173,10 +173,6 @@ func testSyncBetweenNodes(t *testing.T, nodes, chunkCount int, skipCheck bool, p
 			}
 		}
 		// here we distribute chunks of a random file into stores 1...nodes
-		if _, err := sim.WaitTillHealthy(ctx); err != nil {
-			return err
-		}
-
 		// collect hashes in po 1 bin for each node
 		hashes := make([][]storage.Address, nodes)
 		totalHashes := 0


### PR DESCRIPTION
This PR introduces a series of bug fixes which would prevent longrunning tests to succeed.
These tests need to be enabled with the `longrunning` flag, and were up to today ignored.
We can deploy these tests now to the kubernetes test environment, allowing to have better insights about network behavior with bigger networks.