### PR TITLE
consensus/clique: fix test copy paste error, test what's documented

### DIFF
--- a/consensus/clique/snapshot_test.go
+++ b/consensus/clique/snapshot_test.go
@@ -246,10 +246,10 @@ func TestClique(t *testing.T) {
 			// Votes from deauthorized signers are discarded immediately (auth votes)
 			signers: []string{"A", "B", "C"},
 			votes: []testerVote{
-				{signer: "C", voted: "B", auth: false},
+				{signer: "C", voted: "D", auth: true},
 				{signer: "A", voted: "C", auth: false},
 				{signer: "B", voted: "C", auth: false},
-				{signer: "A", voted: "B", auth: false},
+				{signer: "A", voted: "D", auth: true},
 			},
 			results: []string{"A", "B"},
 		}, {


### PR DESCRIPTION
I copy-pasted a test but forgot to update it. The test above the "bad" one tested that voters who are deauthorized don't get to influence future votes by voting to drop someone. The "bad" test should have tested the same thing for voting to add someone. Fixed it here.