### PR TITLE
cmd/swarm: do not ignore cache size=0

### DIFF
--- a/cmd/swarm/config.go
+++ b/cmd/swarm/config.go
@@ -255,8 +255,8 @@ func cmdLineOverride(currentConfig *bzzapi.Config, ctx *cli.Context) *bzzapi.Con
 		currentConfig.LocalStoreParams.DbCapacity = storeCapacity
 	}
 
-	if storeCacheCapacity := ctx.GlobalUint(SwarmStoreCacheCapacity.Name); storeCacheCapacity != 0 {
-		currentConfig.LocalStoreParams.CacheCapacity = storeCacheCapacity
+	if ctx.GlobalIsSet(SwarmStoreCacheCapacity.Name) {
+		currentConfig.LocalStoreParams.CacheCapacity = ctx.GlobalUint(SwarmStoreCacheCapacity.Name)
 	}
 
 	if ctx.GlobalIsSet(SwarmBootnodeModeFlag.Name) {


### PR DESCRIPTION
This PR fixes an edge case where the in-memory cache size flag was ignored when the size was set to `0`. As a result the cache could not be disabled.

fixes https://github.com/ethersphere/go-ethereum/issues/1267