### PR TITLE
eth/downloader: fix nil droppeer in state sync

### DIFF
--- a/eth/downloader/statesync.go
+++ b/eth/downloader/statesync.go
@@ -310,7 +310,13 @@ func (s *stateSync) loop() (err error) {
 				// 2 items are the minimum requested, if even that times out, we've no use of
 				// this peer at the moment.
 				log.Warn("Stalling state sync, dropping peer", "peer", req.peer.id)
-				s.d.dropPeer(req.peer.id)
+				if s.d.dropPeer == nil {
+					// The dropPeer method is nil when `--copydb` is used for a local copy.
+					// Timeouts can occur if e.g. compaction hits at the wrong time, and can be ignored
+					req.peer.log.Warn("Downloader wants to drop peer, but peerdrop-function is not set", "peer", req.peer.id)
+				} else {
+					s.d.dropPeer(req.peer.id)
+				}
 			}
 			// Process all the received blobs and check for stale delivery
 			delivered, err := s.process(req)


### PR DESCRIPTION
Supersedes https://github.com/ethereum/go-ethereum/pull/19010, fixes https://github.com/ethereum/go-ethereum/issues/18525.