### PR TITLE
swarm/storage/localstore: fix synchronization in TestDB_gcSize

### DIFF
--- a/swarm/storage/localstore/gc_test.go
+++ b/swarm/storage/localstore/gc_test.go
@@ -289,12 +289,9 @@ func TestDB_gcSize(t *testing.T) {
 	}
 
 	// DB.Close writes gc size to disk, so
-	// Instead calling Close, simulate database shutdown
+	// Instead calling Close, close the database
 	// without it.
-	close(db.close)
-	db.updateGCWG.Wait()
-	err = db.shed.Close()
-	if err != nil {
+	if err := db.closeWithOptions(false); err != nil {
 		t.Fatal(err)
 	}
 


### PR DESCRIPTION
This PR adds a missing synchronization to TestDB_gcSize test, where recently introduced writeGCSizeWorkerDone was not read in that test to ensure that all writeGCSizeWorker iterations were finished, but not to call writeGCSize function when closing the database. This PR adds function closeWithOptions to ensure that future changes will be affective in both production code and test.

This failures were only detected on Travis.

fixes: https://github.com/ethersphere/go-ethereum/issues/1287