### PR TITLE
swarm: fix relationship between spans in open tracing

### DIFF
--- a/swarm/network/stream/peer.go
+++ b/swarm/network/stream/peer.go
@@ -160,7 +160,7 @@ func (p *Peer) Deliver(ctx context.Context, chunk storage.Chunk, priority uint8,
 // SendPriority sends message to the peer using the outgoing priority queue
 func (p *Peer) SendPriority(ctx context.Context, msg interface{}, priority uint8) error {
 	defer metrics.GetOrRegisterResettingTimer(fmt.Sprintf("peer.sendpriority_t.%d", priority), nil).UpdateSince(time.Now())
-	tracing.StartSaveSpan(ctx)
+	ctx = tracing.StartSaveSpan(ctx)
 	metrics.GetOrRegisterCounter(fmt.Sprintf("peer.sendpriority.%d", priority), nil).Inc(1)
 	wmsg := WrappedPriorityMsg{
 		Context: ctx,

--- a/swarm/storage/netstore.go
+++ b/swarm/storage/netstore.go
@@ -28,6 +28,7 @@ import (
 	"github.com/ethereum/go-ethereum/swarm/log"
 	"github.com/ethereum/go-ethereum/swarm/spancontext"
 	"github.com/opentracing/opentracing-go"
+	olog "github.com/opentracing/opentracing-go/log"
 
 	lru "github.com/hashicorp/golang-lru"
 )
@@ -215,6 +216,8 @@ func (n *NetStore) getOrCreateFetcher(ctx context.Context, ref Address) *fetcher
 		cctx,
 		"netstore.fetcher",
 	)
+
+	sp.LogFields(olog.String("ref", ref.String()))
 	fetcher := newFetcher(sp, ref, n.NewNetFetcherFunc(cctx, ref, peers), destroy, peers, n.closeC)
 	n.fetchers.Add(key, fetcher)
 


### PR DESCRIPTION
This PR is fixing the relationship between `stream.send.request` and `stream.handle.retrieve` spans and also stopping sibling spans when a chunk gets delivered.