### PR TITLE
Resolve network deadlock due to reorgs in low sync high latency setup.

### DIFF
--- a/eth/handler.go
+++ b/eth/handler.go
@@ -182,7 +182,19 @@ func NewProtocolManager(config *params.ChainConfig, mode downloader.SyncMode, ne
 		atomic.StoreUint32(&manager.acceptTxs, 1) // Mark initial sync done on any fetcher import
 		return manager.blockchain.InsertChain(blocks)
 	}
-	manager.fetcher = fetcher.New(blockchain.GetBlockByHash, validator, manager.BroadcastBlock, heighter, inserter, manager.removePeer)
+	headerRequest := func(id string) func(common.Hash) error {
+		if peer := manager.peers.Peer(id); peer != nil {
+			return peer.RequestOneHeader
+		}
+		return nil
+	}
+	bodyRequest := func(id string) func([]common.Hash) error {
+		if peer := manager.peers.Peer(id); peer != nil {
+			return peer.RequestBodies
+		}
+		return nil
+	}
+	manager.fetcher = fetcher.New(blockchain.GetBlockByHash, validator, manager.BroadcastBlock, heighter, inserter, manager.removePeer, headerRequest, bodyRequest)
 
 	return manager, nil
 }

--- a/eth/sync.go
+++ b/eth/sync.go
@@ -171,7 +171,11 @@ func (pm *ProtocolManager) synchronise(peer *peer) {
 	td := pm.blockchain.GetTd(currentBlock.Hash(), currentBlock.NumberU64())
 
 	pHead, pTd := peer.Head()
-	if pTd.Cmp(td) <= 0 {
+	if cmp := pTd.Cmp(td); cmp <= 0 {
+		if cmp < 0 {
+			// propagate our better chain back to peers
+			go pm.BroadcastBlock(currentBlock, true)
+		}
 		return
 	}
 	// Otherwise try to sync with the downloader


### PR DESCRIPTION
To fix https://github.com/ethereum/go-ethereum/issues/18402 and https://github.com/ethereum/go-ethereum/issues/16406

## ROOT CAUSE
Consensuses with high rate of re-orgs are not properly handled by geth. Nodes are failed to switch between 2 disconnected forks if the parent of the better chain head has not been imported.

## REPRODUCE STEPS
The issue happens occasionally and randomly, here are some factors to increase the chance of reproduction:

- Shorter blocktime (1s)
- Low connectivity (use --maxpeers=3 for Clique network of 4/6)
- High latency and loss package: use Linux tool: "tc qdisc netem" to configure the network for this. (delay 0-2s, block lost rate = 0.1-0.9%)

## SOLUTION
- When syncing with other peer (usually the best peer), in case the remote chain is worse than our local chain, we should propagate our better chain back to the network, or atleast the target peer.
- When importing a block with unknown parent, node should request (from the same peer) the parent block instead of discard the original block.
- Recommend: consistent chain comparision rule. (This is consensus specific so it's not included in this PR)

## RESULT
The fix has been tested in extreme condition, which the deadlock can easily happen before:
- Clique blocktime 1s, 4/6 nodes.
- Network jittering latency 0-1000ms.

![image](https://user-images.githubusercontent.com/37166829/54005078-973a8d80-418a-11e9-9619-98115249dd87.png)
No deadlock.

Increasing the latency sometime can cause the last peer (of n/2+1) dropped failling response to ping/pong message. But it eventually will be connected and the network continue. No deadlock so far.
![image](https://user-images.githubusercontent.com/37166829/54005231-437c7400-418b-11e9-93a1-6bad4725968c.png)