### PR TITLE
swarm/network: measure time of messages in priority queue

### DIFF
--- a/cmd/swarm/swarm-smoke/main.go
+++ b/cmd/swarm/swarm-smoke/main.go
@@ -40,6 +40,7 @@ var (
 	allhosts     string
 	hosts        []string
 	filesize     int
+	inputSeed    int
 	syncDelay    int
 	httpPort     int
 	wsPort       int
@@ -73,6 +74,12 @@ func main() {
 			Value:       8546,
 			Usage:       "ws port",
 			Destination: &wsPort,
+		},
+		cli.IntFlag{
+			Name:        "seed",
+			Value:       0,
+			Usage:       "input seed in case we need deterministic upload",
+			Destination: &inputSeed,
 		},
 		cli.IntFlag{
 			Name:        "filesize",

--- a/cmd/swarm/swarm-smoke/upload_and_sync.go
+++ b/cmd/swarm/swarm-smoke/upload_and_sync.go
@@ -74,8 +74,6 @@ func uploadAndSyncCmd(ctx *cli.Context, tuid string) error {
 }
 
 func trackChunks(testData []byte) error {
-	log.Warn("Test timed out, running chunk debug sequence")
-
 	addrs, err := getAllRefs(testData)
 	if err != nil {
 		return err
@@ -123,7 +121,6 @@ func trackChunks(testData []byte) error {
 }
 
 func getAllRefs(testData []byte) (storage.AddressCollection, error) {
-	log.Trace("Getting all references for given root hash")
 	datadir, err := ioutil.TempDir("", "chunk-debug")
 	if err != nil {
 		return nil, fmt.Errorf("unable to create temp dir: %v", err)

--- a/cmd/swarm/swarm-smoke/upload_and_sync.go
+++ b/cmd/swarm/swarm-smoke/upload_and_sync.go
@@ -39,6 +39,11 @@ import (
 )
 
 func uploadAndSyncCmd(ctx *cli.Context, tuid string) error {
+	// use input seed if it has been set
+	if inputSeed != 0 {
+		seed = inputSeed
+	}
+
 	randomBytes := testutil.RandomBytes(seed, filesize*1000)
 
 	errc := make(chan error)

--- a/cmd/swarm/swarm-smoke/upload_and_sync.go
+++ b/cmd/swarm/swarm-smoke/upload_and_sync.go
@@ -94,14 +94,14 @@ func trackChunks(testData []byte) error {
 
 		rpcClient, err := rpc.Dial(httpHost)
 		if err != nil {
-			log.Error("Error dialing host", "err", err)
+			log.Error("error dialing host", "err", err, "host", httpHost)
 			continue
 		}
 
 		var hasInfo []api.HasInfo
 		err = rpcClient.Call(&hasInfo, "bzz_has", addrs)
 		if err != nil {
-			log.Error("Error calling host", "err", err)
+			log.Error("error calling rpc client", "err", err, "host", httpHost)
 			continue
 		}
 

--- a/metrics/influxdb/influxdb.go
+++ b/metrics/influxdb/influxdb.go
@@ -91,6 +91,7 @@ func (r *reporter) makeClient() (err error) {
 		URL:      r.url,
 		Username: r.username,
 		Password: r.password,
+		Timeout:  10 * time.Second,
 	})
 
 	return

--- a/swarm/network/fetcher.go
+++ b/swarm/network/fetcher.go
@@ -30,7 +30,7 @@ import (
 )
 
 const (
-	defaultSearchTimeout = 4 * time.Second
+	defaultSearchTimeout = 1 * time.Second
 	// maximum number of forwarded requests (hops), to make sure requests are not
 	// forwarded forever in peer loops
 	maxHopCount uint8 = 20
@@ -38,7 +38,7 @@ const (
 
 // Time to consider peer to be skipped.
 // Also used in stream delivery.
-var RequestTimeout = 15 * time.Second
+var RequestTimeout = 10 * time.Second
 
 type RequestFunc func(context.Context, *Request) (*enode.ID, chan struct{}, error)
 
@@ -272,7 +272,6 @@ func (f *Fetcher) run(peers *sync.Map) {
 // * the peer's address is removed from prospective sources, and
 // * a go routine is started that reports on the gone channel if the peer is disconnected (or terminated their streamer)
 func (f *Fetcher) doRequest(gone chan *enode.ID, peersToSkip *sync.Map, sources []*enode.ID, hopCount uint8) ([]*enode.ID, error) {
-
 	var i int
 	var sourceID *enode.ID
 	var quit chan struct{}

--- a/swarm/network/fetcher.go
+++ b/swarm/network/fetcher.go
@@ -30,7 +30,7 @@ import (
 )
 
 const (
-	defaultSearchTimeout = 1 * time.Second
+	defaultSearchTimeout = 3 * time.Second
 	// maximum number of forwarded requests (hops), to make sure requests are not
 	// forwarded forever in peer loops
 	maxHopCount uint8 = 20
@@ -272,7 +272,6 @@ func (f *Fetcher) run(peers *sync.Map) {
 // * the peer's address is removed from prospective sources, and
 // * a go routine is started that reports on the gone channel if the peer is disconnected (or terminated their streamer)
 func (f *Fetcher) doRequest(gone chan *enode.ID, peersToSkip *sync.Map, sources []*enode.ID, hopCount uint8) ([]*enode.ID, error) {
-	log.Trace("fetcher.doRequest", "request addr", f.addr)
 
 	var i int
 	var sourceID *enode.ID
@@ -290,6 +289,7 @@ func (f *Fetcher) doRequest(gone chan *enode.ID, peersToSkip *sync.Map, sources 
 	for i = 0; i < len(sources); i++ {
 		req.Source = sources[i]
 		var err error
+		log.Trace("fetcher.doRequest", "request addr", f.addr, "peer", req.Source.String())
 		sourceID, quit, err = f.protoRequestFunc(f.ctx, req)
 		if err == nil {
 			// remove the peer from known sources

--- a/swarm/network/fetcher.go
+++ b/swarm/network/fetcher.go
@@ -30,7 +30,7 @@ import (
 )
 
 const (
-	defaultSearchTimeout = 8 * time.Second
+	defaultSearchTimeout = 4 * time.Second
 	// maximum number of forwarded requests (hops), to make sure requests are not
 	// forwarded forever in peer loops
 	maxHopCount uint8 = 20
@@ -38,7 +38,7 @@ const (
 
 // Time to consider peer to be skipped.
 // Also used in stream delivery.
-var RequestTimeout = 26 * time.Second
+var RequestTimeout = 15 * time.Second
 
 type RequestFunc func(context.Context, *Request) (*enode.ID, chan struct{}, error)
 

--- a/swarm/network/fetcher.go
+++ b/swarm/network/fetcher.go
@@ -204,24 +204,24 @@ func (f *Fetcher) run(peers *sync.Map) {
 
 		// incoming request
 		case hopCount = <-f.requestC:
-			log.Trace("new request", "request addr", f.addr)
 			// 2) chunk is requested, set requested flag
 			// launch a request iff none been launched yet
 			doRequest = !requested
+			log.Trace("new request", "request addr", f.addr, "doRequest", doRequest)
 			requested = true
 
 			// peer we requested from is gone. fall back to another
 			// and remove the peer from the peers map
 		case id := <-gone:
-			log.Trace("peer gone", "peer id", id.String(), "request addr", f.addr)
 			peers.Delete(id.String())
 			doRequest = requested
+			log.Trace("peer gone", "peer id", id.String(), "request addr", f.addr, "doRequest", doRequest)
 
 		// search timeout: too much time passed since the last request,
 		// extend the search to a new peer if we can find one
 		case <-waitC:
-			log.Trace("search timed out: requesting", "request addr", f.addr)
 			doRequest = requested
+			log.Trace("search timed out: requesting", "request addr", f.addr, "doRequest", doRequest)
 
 			// all Fetcher context closed, can quit
 		case <-f.ctx.Done():
@@ -272,6 +272,8 @@ func (f *Fetcher) run(peers *sync.Map) {
 // * the peer's address is removed from prospective sources, and
 // * a go routine is started that reports on the gone channel if the peer is disconnected (or terminated their streamer)
 func (f *Fetcher) doRequest(gone chan *enode.ID, peersToSkip *sync.Map, sources []*enode.ID, hopCount uint8) ([]*enode.ID, error) {
+	log.Trace("fetcher.doRequest", "request addr", f.addr)
+
 	var i int
 	var sourceID *enode.ID
 	var quit chan struct{}

--- a/swarm/network/fetcher.go
+++ b/swarm/network/fetcher.go
@@ -30,7 +30,7 @@ import (
 )
 
 const (
-	defaultSearchTimeout = 3 * time.Second
+	defaultSearchTimeout = 8 * time.Second
 	// maximum number of forwarded requests (hops), to make sure requests are not
 	// forwarded forever in peer loops
 	maxHopCount uint8 = 20
@@ -38,7 +38,7 @@ const (
 
 // Time to consider peer to be skipped.
 // Also used in stream delivery.
-var RequestTimeout = 10 * time.Second
+var RequestTimeout = 26 * time.Second
 
 type RequestFunc func(context.Context, *Request) (*enode.ID, chan struct{}, error)
 

--- a/swarm/network/priorityqueue/priorityqueue.go
+++ b/swarm/network/priorityqueue/priorityqueue.go
@@ -28,8 +28,9 @@ package priorityqueue
 import (
 	"context"
 	"errors"
+	"time"
 
-	"github.com/ethereum/go-ethereum/log"
+	"github.com/ethereum/go-ethereum/metrics"
 )
 
 var (
@@ -69,13 +70,16 @@ READ:
 		case <-ctx.Done():
 			return
 		case x := <-q:
-			log.Trace("priority.queue f(x)", "p", p, "len(Queues[p])", len(pq.Queues[p]))
-			f(x)
+			val := x.(struct {
+				v interface{}
+				t time.Time
+			})
+			f(val.v)
+			metrics.GetOrRegisterResettingTimer("pq.run", nil).UpdateSince(val.t)
 			p = top
 		default:
 			if p > 0 {
 				p--
-				log.Trace("priority.queue p > 0", "p", p)
 				continue READ
 			}
 			p = top
@@ -83,7 +87,6 @@ READ:
 			case <-ctx.Done():
 				return
 			case <-pq.wakeup:
-				log.Trace("priority.queue wakeup", "p", p)
 			}
 		}
 	}
@@ -95,9 +98,15 @@ func (pq *PriorityQueue) Push(x interface{}, p int) error {
 	if p < 0 || p >= len(pq.Queues) {
 		return errBadPriority
 	}
-	log.Trace("priority.queue push", "p", p, "len(Queues[p])", len(pq.Queues[p]))
+	val := struct {
+		v interface{}
+		t time.Time
+	}{
+		x,
+		time.Now(),
+	}
 	select {
-	case pq.Queues[p] <- x:
+	case pq.Queues[p] <- val:
 	default:
 		return ErrContention
 	}

--- a/swarm/network/stream/delivery.go
+++ b/swarm/network/stream/delivery.go
@@ -228,7 +228,7 @@ func (d *Delivery) handleChunkDeliveryMsg(ctx context.Context, sp *Peer, req *Ch
 	spanId := fmt.Sprintf("stream.send.request.%v.%v", sp.ID(), req.Addr)
 	span := tracing.ShiftSpanByKey(spanId)
 
-	log.Trace("handle.chunk.delivery", "ref", req.Addr)
+	log.Trace("handle.chunk.delivery", "ref", req.Addr, "from peer", sp.ID())
 
 	go func() {
 		defer osp.Finish()

--- a/swarm/network/stream/delivery.go
+++ b/swarm/network/stream/delivery.go
@@ -295,11 +295,13 @@ func (d *Delivery) RequestFromPeers(ctx context.Context, req *network.Request) (
 	// this span will finish only when delivery is handled (or times out)
 	ctx = context.WithValue(ctx, tracing.StoreLabelId, "stream.send.request")
 	ctx = context.WithValue(ctx, tracing.StoreLabelMeta, fmt.Sprintf("%v.%v", sp.ID(), req.Addr))
-	err := sp.SendPriority(ctx, &RetrieveRequestMsg{
+	ctx = tracing.StartSaveSpan(ctx)
+	log.Trace("request.from.peers", "peer", sp.ID(), "ref", req.Addr)
+	err := sp.Send(ctx, &RetrieveRequestMsg{
 		Addr:      req.Addr,
 		SkipCheck: req.SkipCheck,
 		HopCount:  req.HopCount,
-	}, Top)
+	})
 	if err != nil {
 		return nil, nil, err
 	}

--- a/swarm/network/stream/delivery.go
+++ b/swarm/network/stream/delivery.go
@@ -185,6 +185,7 @@ func (d *Delivery) handleRetrieveRequestMsg(ctx context.Context, sp *Peer, req *
 			if err != nil {
 				log.Warn("ERROR in handleRetrieveRequestMsg", "err", err)
 			}
+			osp.LogFields(olog.Bool("delivered", true))
 			return
 		}
 		osp.LogFields(olog.Bool("skipCheck", false))

--- a/swarm/network/stream/delivery.go
+++ b/swarm/network/stream/delivery.go
@@ -217,6 +217,10 @@ type ChunkDeliveryMsgSyncing ChunkDeliveryMsg
 
 // chunk delivery msg is response to retrieverequest msg
 func (d *Delivery) handleChunkDeliveryMsg(ctx context.Context, sp *Peer, req *ChunkDeliveryMsg) error {
+	var osp opentracing.Span
+	ctx, osp = spancontext.StartSpan(
+		ctx,
+		"handle.chunk.delivery")
 
 	processReceivedChunksCount.Inc(1)
 
@@ -225,6 +229,8 @@ func (d *Delivery) handleChunkDeliveryMsg(ctx context.Context, sp *Peer, req *Ch
 	span := tracing.ShiftSpanByKey(spanId)
 
 	go func() {
+		defer osp.Finish()
+
 		if span != nil {
 			span.LogFields(olog.String("finish", "from handleChunkDeliveryMsg"))
 			defer span.Finish()

--- a/swarm/network/stream/delivery.go
+++ b/swarm/network/stream/delivery.go
@@ -295,13 +295,12 @@ func (d *Delivery) RequestFromPeers(ctx context.Context, req *network.Request) (
 	// this span will finish only when delivery is handled (or times out)
 	ctx = context.WithValue(ctx, tracing.StoreLabelId, "stream.send.request")
 	ctx = context.WithValue(ctx, tracing.StoreLabelMeta, fmt.Sprintf("%v.%v", sp.ID(), req.Addr))
-	ctx = tracing.StartSaveSpan(ctx)
 	log.Trace("request.from.peers", "peer", sp.ID(), "ref", req.Addr)
-	err := sp.Send(ctx, &RetrieveRequestMsg{
+	err := sp.SendPriority(ctx, &RetrieveRequestMsg{
 		Addr:      req.Addr,
 		SkipCheck: req.SkipCheck,
 		HopCount:  req.HopCount,
-	})
+	}, Top)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/swarm/network/stream/delivery.go
+++ b/swarm/network/stream/delivery.go
@@ -228,6 +228,8 @@ func (d *Delivery) handleChunkDeliveryMsg(ctx context.Context, sp *Peer, req *Ch
 	spanId := fmt.Sprintf("stream.send.request.%v.%v", sp.ID(), req.Addr)
 	span := tracing.ShiftSpanByKey(spanId)
 
+	log.Trace("handle.chunk.delivery", "ref", req.Addr)
+
 	go func() {
 		defer osp.Finish()
 
@@ -237,6 +239,7 @@ func (d *Delivery) handleChunkDeliveryMsg(ctx context.Context, sp *Peer, req *Ch
 		}
 
 		req.peer = sp
+		log.Trace("handle.chunk.delivery", "put", req.Addr)
 		err := d.chunkStore.Put(ctx, storage.NewChunk(req.Addr, req.SData))
 		if err != nil {
 			if err == storage.ErrChunkInvalid {
@@ -246,6 +249,7 @@ func (d *Delivery) handleChunkDeliveryMsg(ctx context.Context, sp *Peer, req *Ch
 				req.peer.Drop(err)
 			}
 		}
+		log.Trace("handle.chunk.delivery", "done put", req.Addr, "err", err)
 	}()
 	return nil
 }

--- a/swarm/network/stream/peer.go
+++ b/swarm/network/stream/peer.go
@@ -154,7 +154,7 @@ func (p *Peer) Deliver(ctx context.Context, chunk storage.Chunk, priority uint8,
 	}
 
 	ctx = context.WithValue(ctx, "stream_send_tag", nil)
-	return p.SendPriority(ctx, msg, priority)
+	return p.Send(ctx, msg)
 }
 
 // SendPriority sends message to the peer using the outgoing priority queue

--- a/swarm/network/stream/peer.go
+++ b/swarm/network/stream/peer.go
@@ -154,7 +154,7 @@ func (p *Peer) Deliver(ctx context.Context, chunk storage.Chunk, priority uint8,
 	}
 
 	ctx = context.WithValue(ctx, "stream_send_tag", nil)
-	return p.Send(ctx, msg)
+	return p.SendPriority(ctx, msg, priority)
 }
 
 // SendPriority sends message to the peer using the outgoing priority queue

--- a/swarm/network/stream/stream.go
+++ b/swarm/network/stream/stream.go
@@ -910,7 +910,7 @@ func (r *Registry) APIs() []rpc.API {
 			Namespace: "stream",
 			Version:   "3.0",
 			Service:   r.api,
-			Public:    true,
+			Public:    false,
 		},
 	}
 }

--- a/swarm/storage/chunker.go
+++ b/swarm/storage/chunker.go
@@ -560,12 +560,12 @@ func (r *LazyChunkReader) join(ctx context.Context, b []byte, off int64, eoff in
 
 // Read keeps a cursor so cannot be called simulateously, see ReadAt
 func (r *LazyChunkReader) Read(b []byte) (read int, err error) {
-	log.Debug("lazychunkreader.read", "key", r.addr)
+	log.Trace("lazychunkreader.read", "key", r.addr)
 	metrics.GetOrRegisterCounter("lazychunkreader.read", nil).Inc(1)
 
 	read, err = r.ReadAt(b, r.off)
 	if err != nil && err != io.EOF {
-		log.Debug("lazychunkreader.readat", "read", read, "err", err)
+		log.Trace("lazychunkreader.readat", "read", read, "err", err)
 		metrics.GetOrRegisterCounter("lazychunkreader.read.err", nil).Inc(1)
 	}
 

--- a/swarm/storage/chunker.go
+++ b/swarm/storage/chunker.go
@@ -536,7 +536,6 @@ func (r *LazyChunkReader) join(ctx context.Context, b []byte, off int64, eoff in
 			chunkData, err := r.getter.Get(ctx, Reference(childAddress))
 			if err != nil {
 				metrics.GetOrRegisterResettingTimer("lcr.getter.get.err", nil).UpdateSince(startTime)
-				log.Debug("lazychunkreader.join", "key", fmt.Sprintf("%x", childAddress), "err", err)
 				select {
 				case errC <- fmt.Errorf("chunk %v-%v not found; key: %s", off, off+treeSize, fmt.Sprintf("%x", childAddress)):
 				case <-quitC:

--- a/swarm/storage/netstore.go
+++ b/swarm/storage/netstore.go
@@ -87,9 +87,9 @@ func (n *NetStore) Put(ctx context.Context, ch Chunk) error {
 
 	// if chunk is now put in the store, check if there was an active fetcher and call deliver on it
 	// (this delivers the chunk to requestors via the fetcher)
-	log.Debug("n.getFetcher", "ref", ch.Address())
+	log.Trace("n.getFetcher", "ref", ch.Address())
 	if f := n.getFetcher(ch.Address()); f != nil {
-		log.Debug("n.getFetcher deliver", "ref", ch.Address())
+		log.Trace("n.getFetcher deliver", "ref", ch.Address())
 		f.deliver(ctx, ch)
 	}
 	return nil
@@ -343,6 +343,6 @@ func (f *fetcher) deliver(ctx context.Context, ch Chunk) {
 		f.chunk = ch
 		// closing the deliveredC channel will terminate ongoing requests
 		close(f.deliveredC)
-		log.Debug("n.getFetcher close deliveredC", "ref", ch.Address())
+		log.Trace("n.getFetcher close deliveredC", "ref", ch.Address())
 	})
 }

--- a/swarm/storage/netstore.go
+++ b/swarm/storage/netstore.go
@@ -87,7 +87,9 @@ func (n *NetStore) Put(ctx context.Context, ch Chunk) error {
 
 	// if chunk is now put in the store, check if there was an active fetcher and call deliver on it
 	// (this delivers the chunk to requestors via the fetcher)
+	log.Debug("n.getFetcher", "ref", ch.Address())
 	if f := n.getFetcher(ch.Address()); f != nil {
+		log.Debug("n.getFetcher deliver", "ref", ch.Address())
 		f.deliver(ctx, ch)
 	}
 	return nil
@@ -341,5 +343,6 @@ func (f *fetcher) deliver(ctx context.Context, ch Chunk) {
 		f.chunk = ch
 		// closing the deliveredC channel will terminate ongoing requests
 		close(f.deliveredC)
+		log.Debug("n.getFetcher close deliveredC", "ref", ch.Address())
 	})
 }

--- a/swarm/swarm.go
+++ b/swarm/swarm.go
@@ -522,6 +522,8 @@ func (s *Swarm) APIs() []rpc.API {
 
 	apis = append(apis, s.bzz.APIs()...)
 
+	apis = append(apis, s.streamer.APIs()...)
+
 	if s.ps != nil {
 		apis = append(apis, s.ps.APIs()...)
 	}

--- a/vendor/github.com/opentracing/opentracing-go/CHANGELOG.md
+++ b/vendor/github.com/opentracing/opentracing-go/CHANGELOG.md
@@ -10,5 +10,5 @@ Changes by Version
 1.0.0 (2016-09-26)
 -------------------
 
-- This release implements OpenTracing Specification 1.0 (http://opentracing.io/spec)
+- This release implements OpenTracing Specification 1.0 (https://opentracing.io/spec)
 

--- a/vendor/github.com/opentracing/opentracing-go/Makefile
+++ b/vendor/github.com/opentracing/opentracing-go/Makefile
@@ -1,26 +1,15 @@
-PACKAGES := . ./mocktracer/... ./ext/...
-
 .DEFAULT_GOAL := test-and-lint
 
-.PHONE: test-and-lint
-
+.PHONY: test-and-lint
 test-and-lint: test lint
 
 .PHONY: test
 test:
 	go test -v -cover -race ./...
 
+.PHONY: cover
 cover:
-	@rm -rf cover-all.out
-	$(foreach pkg, $(PACKAGES), $(MAKE) cover-pkg PKG=$(pkg) || true;)
-	@grep mode: cover.out > coverage.out
-	@cat cover-all.out >> coverage.out
-	go tool cover -html=coverage.out -o cover.html
-	@rm -rf cover.out cover-all.out coverage.out
-
-cover-pkg:
-	go test -coverprofile cover.out $(PKG)
-	@grep -v mode: cover.out >> cover-all.out
+	go test -v -coverprofile=coverage.txt -covermode=atomic -race ./...
 
 .PHONY: lint
 lint:
@@ -29,4 +18,3 @@ lint:
 	@# Run again with magic to exit non-zero if golint outputs anything.
 	@! (golint ./... | read dummy)
 	go vet ./...
-

--- a/vendor/github.com/opentracing/opentracing-go/README.md
+++ b/vendor/github.com/opentracing/opentracing-go/README.md
@@ -8,8 +8,8 @@ This package is a Go platform API for OpenTracing.
 ## Required Reading
 
 In order to understand the Go platform API, one must first be familiar with the
-[OpenTracing project](http://opentracing.io) and
-[terminology](http://opentracing.io/documentation/pages/spec.html) more specifically.
+[OpenTracing project](https://opentracing.io) and
+[terminology](https://opentracing.io/specification/) more specifically.
 
 ## API overview for those adding instrumentation
 

--- a/vendor/github.com/opentracing/opentracing-go/propagation.go
+++ b/vendor/github.com/opentracing/opentracing-go/propagation.go
@@ -160,7 +160,7 @@ type HTTPHeadersCarrier http.Header
 // Set conforms to the TextMapWriter interface.
 func (c HTTPHeadersCarrier) Set(key, val string) {
 	h := http.Header(c)
-	h.Add(key, val)
+	h.Set(key, val)
 }
 
 // ForeachKey conforms to the TextMapReader interface.

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -352,10 +352,10 @@
 			"revisionTime": "2017-01-28T05:05:32Z"
 		},
 		{
-			"checksumSHA1": "wIcN7tZiF441h08RHAm4NV8cYO4=",
+			"checksumSHA1": "a/DHmc9bdsYlZZcwp6i3xhvV7Pk=",
 			"path": "github.com/opentracing/opentracing-go",
-			"revision": "bd9c3193394760d98b2fa6ebb2291f0cd1d06a7d",
-			"revisionTime": "2018-06-06T20:41:48Z"
+			"revision": "25a84ff92183e2f8ac018ba1db54f8a07b3c0e04",
+			"revisionTime": "2019-02-18T02:30:34Z"
 		},
 		{
 			"checksumSHA1": "uhDxBvLEqRAMZKgpTZ8MFuLIIM8=",


### PR DESCRIPTION
This PR is:
1. Updating our vendored OpenTracing Go library.
2. Adding an `inputSeed` flag to the smoke tests, so that we can reproduce an exact upload to a given Swarm deployment.
3. Executing `trackChunks` both on successful and on failed smoke test runs, so that we can compare between them.
4. Reducing amount of `Debug` and `Trace` logs in some packages.
5. Adding a timeout to the InfluxDB HTTP client, so that we don't wait indefinitely in case of a blocking InfluxDB metrics report call.
6. Adding a timer around the `f()` (generally a `p2p.Send()` call) in our priority queue.
7. Making the `stream` API private.