### PR TITLE
state: fix emptyStatet to emptyRoot

### DIFF
--- a/core/state/statedb.go
+++ b/core/state/statedb.go
@@ -37,8 +37,8 @@ type revision struct {
 }
 
 var (
-	// emptyState is the known hash of an empty state trie entry.
-	emptyState = crypto.Keccak256Hash(nil)
+	// emptyRoot is the known root hash of an empty trie.
+	emptyRoot = common.HexToHash("56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421")
 
 	// emptyCode is the known hash of the empty EVM bytecode.
 	emptyCode = crypto.Keccak256Hash(nil)
@@ -653,7 +653,7 @@ func (s *StateDB) Commit(deleteEmptyObjects bool) (root common.Hash, err error) 
 		if err := rlp.DecodeBytes(leaf, &account); err != nil {
 			return nil
 		}
-		if account.Root != emptyState {
+		if account.Root != emptyRoot {
 			s.db.TrieDB().Reference(account.Root, parent)
 		}
 		code := common.BytesToHash(account.CodeHash)


### PR DESCRIPTION
The account state root will never be `crypto.Keccak256Hash(nil)`. Since the empty tire root would be an empty hash (an all zero 32-byte array), an array is initialized to all zero array in stead of nil as the case in slice. The empty account root will only be `crypto.Keccak256Hash(Hash{})`, which is equal to `0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421`. So essentially, the root of a trie will never be nil, but it would be all zero hash before commit and `emptyRoot` after commit an empty trie.

I think is mistake was introduced unintentionally by the author, the object was to filter out empty accounts and never reference to them. Because it does not incur fatal error but a slight performance degrade for reference to empty trie, this problem is not unveiled before careful inspection.

