### PR TITLE
core/state: fix db test random args

### DIFF
--- a/core/state/statedb_test.go
+++ b/core/state/statedb_test.go
@@ -296,7 +296,7 @@ func newTestAction(addr common.Address, r *rand.Rand) testAction {
 	if !action.noAddr {
 		nameargs = append(nameargs, addr.Hex())
 	}
-	for _, i := range action.args {
+	for i := range action.args {
 		action.args[i] = rand.Int63n(100)
 		nameargs = append(nameargs, fmt.Sprint(action.args[i]))
 	}


### PR DESCRIPTION
The random argument should be spread to args. Current code only randomly generates the first argument and the second one is always 0. 