### PR TITLE
README: Mention go 1.10 as minumum - context #19246

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ For prerequisites and detailed build instructions please read the
 [Installation Instructions](https://github.com/ethereum/go-ethereum/wiki/Building-Ethereum)
 on the wiki.
 
-Building geth requires both a Go (version 1.9 or later) and a C compiler.
+Building geth requires both a Go (version 1.10 or later) and a C compiler.
 You can install them using your favourite package manager.
 Once the dependencies are installed, run
 


### PR DESCRIPTION
the user with the problem in #19246 tried to build with 1.9.1 which failed - make the README reflect this and prevent users falling in the same trap