### PR TITLE
core: use headers only where blocks are unnecessary

### DIFF
--- a/core/block_validator.go
+++ b/core/block_validator.go
@@ -77,7 +77,7 @@ func (v *BlockValidator) ValidateBody(block *types.Block) error {
 // transition, such as amount of used gas, the receipt roots and the state root
 // itself. ValidateState returns a database batch if the validation was a success
 // otherwise nil and an error is returned.
-func (v *BlockValidator) ValidateState(block, parent *types.Block, statedb *state.StateDB, receipts types.Receipts, usedGas uint64) error {
+func (v *BlockValidator) ValidateState(block *types.Block, statedb *state.StateDB, receipts types.Receipts, usedGas uint64) error {
 	header := block.Header()
 	if block.GasUsed() != usedGas {
 		return fmt.Errorf("invalid gas used (remote: %d local: %d)", block.GasUsed(), usedGas)

--- a/core/blockchain_insert.go
+++ b/core/blockchain_insert.go
@@ -111,12 +111,12 @@ func (it *insertIterator) next() (*types.Block, error) {
 	return it.chain[it.index], it.validator.ValidateBody(it.chain[it.index])
 }
 
-// previous returns the previous block was being processed, or nil
-func (it *insertIterator) previous() *types.Block {
+// previous returns the previous header that was being processed, or nil.
+func (it *insertIterator) previous() *types.Header {
 	if it.index < 1 {
 		return nil
 	}
-	return it.chain[it.index-1]
+	return it.chain[it.index-1].Header()
 }
 
 // first returns the first block in the it.

--- a/core/blockchain_test.go
+++ b/core/blockchain_test.go
@@ -149,7 +149,7 @@ func testBlockChainImport(chain types.Blocks, blockchain *BlockChain) error {
 			blockchain.reportBlock(block, receipts, err)
 			return err
 		}
-		err = blockchain.validator.ValidateState(block, blockchain.GetBlockByHash(block.ParentHash()), statedb, receipts, usedGas)
+		err = blockchain.validator.ValidateState(block, statedb, receipts, usedGas)
 		if err != nil {
 			blockchain.reportBlock(block, receipts, err)
 			return err

--- a/core/types.go
+++ b/core/types.go
@@ -32,7 +32,7 @@ type Validator interface {
 
 	// ValidateState validates the given statedb and optionally the receipts and
 	// gas used.
-	ValidateState(block, parent *types.Block, state *state.StateDB, receipts types.Receipts, usedGas uint64) error
+	ValidateState(block *types.Block, state *state.StateDB, receipts types.Receipts, usedGas uint64) error
 }
 
 // Processor is an interface for processing blocks using a given initial state.


### PR DESCRIPTION
This is a tiny PR to use headers in a few places where we used blocks previously, but were unnecessary.