### PR TITLE
core/vm: Check values passed to --vm.{evm,ewasm} flags

### DIFF
--- a/cmd/evm/main.go
+++ b/cmd/evm/main.go
@@ -23,6 +23,7 @@ import (
 	"os"
 
 	"github.com/ethereum/go-ethereum/cmd/utils"
+	"github.com/ethereum/go-ethereum/core/vm"
 	"gopkg.in/urfave/cli.v1"
 )
 
@@ -110,10 +111,11 @@ var (
 		Name:  "nostack",
 		Usage: "disable stack output",
 	}
-	EVMInterpreterFlag = cli.StringFlag{
+	defaultEVMInterpreter = vm.Selector("")
+	EVMInterpreterFlag    = utils.TextMarshalerFlag{
 		Name:  "vm.evm",
-		Usage: "External EVM configuration (default = built-in interpreter)",
-		Value: "",
+		Usage: "EVM configuration",
+		Value: &defaultEVMInterpreter,
 	}
 )
 

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -687,15 +687,17 @@ var (
 		Value: "host=localhost",
 	}
 
-	EWASMInterpreterFlag = cli.StringFlag{
-		Name:  "vm.ewasm",
-		Usage: "External ewasm configuration (default = built-in interpreter)",
-		Value: "",
-	}
-	EVMInterpreterFlag = cli.StringFlag{
+	defaultEVMInterpreter = vm.Selector("")
+	EVMInterpreterFlag    = TextMarshalerFlag{
 		Name:  "vm.evm",
-		Usage: "External EVM configuration (default = built-in interpreter)",
-		Value: "",
+		Usage: "EVM configuration",
+		Value: &defaultEVMInterpreter,
+	}
+	defaultEWASMInterpreter = vm.Selector("")
+	EWASMInterpreterFlag    = TextMarshalerFlag{
+		Name:  "vm.ewasm",
+		Usage: "Ewasm configuration",
+		Value: &defaultEWASMInterpreter,
 	}
 )
 

--- a/core/vm/evm.go
+++ b/core/vm/evm.go
@@ -17,6 +17,7 @@
 package vm
 
 import (
+	"fmt"
 	"math/big"
 	"sync/atomic"
 	"time"
@@ -25,6 +26,34 @@ import (
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/params"
 )
+
+// Selector selects and keeps configuration for VM implementations.
+type Selector string
+
+// String implements stringer interface.
+func (sel Selector) String() string {
+	if sel == "" {
+		return "interpreter"
+	}
+	return "unknown"
+}
+
+// MarshalText implements encoding.TextMarshaler interface.
+func (sel Selector) MarshalText() (text []byte, err error) {
+	if sel == "" {
+		return []byte(string(sel)), nil
+	}
+	return nil, fmt.Errorf("unknown option %q", sel)
+}
+
+// UnmarshalText implements encoding.TextUnmarshaler interface.
+func (sel *Selector) UnmarshalText(text []byte) error {
+	if string(text) == string(*sel) {
+		*sel = ""
+		return nil
+	}
+	return fmt.Errorf(`unknown option %q, want "interpreter"`, text)
+}
 
 // emptyCodeHash is used by create to ensure deployment is disallowed to already
 // deployed contract addresses (relevant after the account abstraction).

--- a/tests/state_test.go
+++ b/tests/state_test.go
@@ -74,8 +74,8 @@ const traceErrorLimit = 400000
 // The VM config for state tests that accepts --vm.* command line arguments.
 var testVMConfig = func() vm.Config {
 	vmconfig := vm.Config{}
-	flag.StringVar(&vmconfig.EVMInterpreter, utils.EVMInterpreterFlag.Name, utils.EVMInterpreterFlag.Value, utils.EVMInterpreterFlag.Usage)
-	flag.StringVar(&vmconfig.EWASMInterpreter, utils.EWASMInterpreterFlag.Name, utils.EWASMInterpreterFlag.Value, utils.EWASMInterpreterFlag.Usage)
+	flag.StringVar(&vmconfig.EVMInterpreter, utils.EVMInterpreterFlag.Name, "", utils.EVMInterpreterFlag.Usage)
+	flag.StringVar(&vmconfig.EWASMInterpreter, utils.EWASMInterpreterFlag.Name, "", utils.EWASMInterpreterFlag.Usage)
 	flag.Parse()
 	return vmconfig
 }()


### PR DESCRIPTION
This change allows setting "interpreter" value only for --vm.evm and --vm.ewasm flags.
Previously any string was accepted. This will be later extended with EVMC configuration options.

Error messages:
```
invalid value "jit" for flag -vm.evm: unknown option "jit", want "interpreter"
invalid value "jit" for flag -vm.ewasm: unknown option "jit", want "interpreter"
```

Help:
```
  --vm.evm "interpreter"    EVM configuration
  --vm.ewasm "interpreter"  Ewasm configuration
```