### PR TITLE
cmd/swarm: dont connect to bootnodes in tests

### DIFF
--- a/cmd/swarm/run_test.go
+++ b/cmd/swarm/run_test.go
@@ -82,6 +82,18 @@ func TestMain(m *testing.M) {
 func runSwarm(t *testing.T, args ...string) *cmdtest.TestCmd {
 	tt := cmdtest.NewTestCmd(t, nil)
 
+	found := false
+	for _, v := range args {
+		if v == "--bootnodes" {
+			found = true
+			break
+		}
+	}
+
+	if !found {
+		args = append([]string{"--bootnodes", ""}, args...)
+	}
+
 	// Boot "swarm". This actually runs the test binary but the TestMain
 	// function will prevent any tests from running.
 	tt.Run("swarm-test", args...)
@@ -252,6 +264,7 @@ func existingTestNode(t *testing.T, dir string, bzzaccount string) *testNode {
 
 	// start the node
 	node.Cmd = runSwarm(t,
+		"--bootnodes", "",
 		"--port", p2pPort,
 		"--nat", "extip:127.0.0.1",
 		"--datadir", dir,
@@ -327,6 +340,7 @@ func newTestNode(t *testing.T, dir string) *testNode {
 
 	// start the node
 	node.Cmd = runSwarm(t,
+		"--bootnodes", "",
 		"--port", p2pPort,
 		"--nat", "extip:127.0.0.1",
 		"--datadir", dir,

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -779,6 +779,7 @@ func setBootstrapNodes(ctx *cli.Context, cfg *p2p.Config) {
 			node, err := enode.ParseV4(url)
 			if err != nil {
 				log.Crit("Bootstrap URL invalid", "enode", url, "err", err)
+				continue
 			}
 			cfg.BootstrapNodes = append(cfg.BootstrapNodes, node)
 		}
@@ -806,12 +807,14 @@ func setBootstrapNodesV5(ctx *cli.Context, cfg *p2p.Config) {
 
 	cfg.BootstrapNodesV5 = make([]*discv5.Node, 0, len(urls))
 	for _, url := range urls {
-		node, err := discv5.ParseNode(url)
-		if err != nil {
-			log.Error("Bootstrap URL invalid", "enode", url, "err", err)
-			continue
+		if url != "" {
+			node, err := discv5.ParseNode(url)
+			if err != nil {
+				log.Error("Bootstrap URL invalid", "enode", url, "err", err)
+				continue
+			}
+			cfg.BootstrapNodesV5 = append(cfg.BootstrapNodesV5, node)
 		}
-		cfg.BootstrapNodesV5 = append(cfg.BootstrapNodesV5, node)
 	}
 }
 


### PR DESCRIPTION
this PR adds a flag that empties the bootnodes array so that tests don't connect to our production environment.