### PR TITLE
cmd/swarm/swarm-smoke: do not fail if a node does not respond to rpc

### DIFF
--- a/cmd/swarm/swarm-smoke/upload_and_sync.go
+++ b/cmd/swarm/swarm-smoke/upload_and_sync.go
@@ -87,14 +87,14 @@ func trackChunks(testData []byte) error {
 		rpcClient, err := rpc.Dial(httpHost)
 		if err != nil {
 			log.Error("Error dialing host", "err", err)
-			return err
+			continue
 		}
 
 		var hasInfo []api.HasInfo
 		err = rpcClient.Call(&hasInfo, "bzz_has", addrs)
 		if err != nil {
 			log.Error("Error calling host", "err", err)
-			return err
+			continue
 		}
 
 		count := 0

--- a/cmd/swarm/swarm-smoke/upload_and_sync.go
+++ b/cmd/swarm/swarm-smoke/upload_and_sync.go
@@ -44,7 +44,7 @@ func uploadAndSyncCmd(ctx *cli.Context, tuid string) error {
 	errc := make(chan error)
 
 	go func() {
-		errc <- uplaodAndSync(ctx, randomBytes, tuid)
+		errc <- uploadAndSync(ctx, randomBytes, tuid)
 	}()
 
 	select {
@@ -65,6 +65,14 @@ func uploadAndSyncCmd(ctx *cli.Context, tuid string) error {
 
 		return e
 	}
+
+	// trigger debug functionality on randomBytes even on successful runs
+	err := trackChunks(randomBytes[:])
+	if err != nil {
+		log.Error(err.Error())
+	}
+
+	return nil
 }
 
 func trackChunks(testData []byte) error {
@@ -134,7 +142,7 @@ func getAllRefs(testData []byte) (storage.AddressCollection, error) {
 	return fileStore.GetAllReferences(ctx, reader, false)
 }
 
-func uplaodAndSync(c *cli.Context, randomBytes []byte, tuid string) error {
+func uploadAndSync(c *cli.Context, randomBytes []byte, tuid string) error {
 	log.Info("uploading to "+httpEndpoint(hosts[0])+" and syncing", "tuid", tuid, "seed", seed)
 
 	t1 := time.Now()


### PR DESCRIPTION
If one node of the deployment is offline, we are still interested in the distribution of chunks across the rest of the nodes.