### PR TITLE
les: fix light server bugs

### DIFF
--- a/les/peer.go
+++ b/les/peer.go
@@ -105,6 +105,7 @@ func newPeer(version int, network uint64, isTrusted bool, p *p2p.Peer, rw p2p.Ms
 		network:   network,
 		id:        fmt.Sprintf("%x", p.ID().Bytes()),
 		isTrusted: isTrusted,
+		errCh:     make(chan error, 1),
 	}
 }
 

--- a/les/peer.go
+++ b/les/peer.go
@@ -98,14 +98,12 @@ type peer struct {
 }
 
 func newPeer(version int, network uint64, isTrusted bool, p *p2p.Peer, rw p2p.MsgReadWriter) *peer {
-	id := p.ID()
-
 	return &peer{
 		Peer:      p,
 		rw:        rw,
 		version:   version,
 		network:   network,
-		id:        fmt.Sprintf("%x", id),
+		id:        fmt.Sprintf("%x", p.ID().Bytes()),
 		isTrusted: isTrusted,
 	}
 }


### PR DESCRIPTION
This PR fixes two light server bugs:
- peer.id format was wrong, it was a hex string converted to hex again
- a part of the error handling of reply send was missing, causing deadlocks at peer disconnection
