### PR TITLE
appveyor, Dockerfile: upgrade to Go 1.12.1

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -23,8 +23,8 @@ environment:
 install:
   - git submodule update --init
   - rmdir C:\go /s /q
-  - appveyor DownloadFile https://dl.google.com/go/go1.12.windows-%GETH_ARCH%.zip
-  - 7z x go1.12.windows-%GETH_ARCH%.zip -y -oC:\ > NUL
+  - appveyor DownloadFile https://dl.google.com/go/go1.12.1.windows-%GETH_ARCH%.zip
+  - 7z x go1.12.1.windows-%GETH_ARCH%.zip -y -oC:\ > NUL
   - go version
   - gcc --version
 

--- a/internal/build/util.go
+++ b/internal/build/util.go
@@ -143,9 +143,9 @@ func CopyFile(dst, src string, mode os.FileMode) {
 // so that go commands executed by build use the same version of Go as the 'host' that runs
 // build code. e.g.
 //
-//     /usr/lib/go-1.12/bin/go run build/ci.go ...
+//     /usr/lib/go-1.12.1/bin/go run build/ci.go ...
 //
-// runs using go 1.12 and invokes go 1.12 tools from the same GOROOT. This is also important
+// runs using go 1.12.1 and invokes go 1.12.1 tools from the same GOROOT. This is also important
 // because runtime.Version checks on the host should match the tools that are run.
 func GoTool(tool string, args ...string) *exec.Cmd {
 	args = append([]string{tool}, args...)


### PR DESCRIPTION
Travis is now using `go: 1.12.x` so doesn't need a PR every patch version bump.

Release notes: https://golang.org/doc/devel/release.html#go1.12.minor