### PR TITLE
Fix EIP-712 domain map containing unused field

### DIFF
--- a/signer/core/signed_data.go
+++ b/signer/core/signed_data.go
@@ -894,8 +894,10 @@ func (domain *TypedDataDomain) validate() error {
 
 // Map is a helper function to generate a map version of the domain
 func (domain *TypedDataDomain) Map() map[string]interface{} {
-	dataMap := map[string]interface{}{
-		"chainId": domain.ChainId,
+	dataMap := map[string]interface{}{}
+
+	if domain.ChainId != nil {
+		dataMap["chainId"] = domain.ChainId
 	}
 
 	if len(domain.Name) > 0 {

--- a/signer/core/signed_data_test.go
+++ b/signer/core/signed_data_test.go
@@ -225,6 +225,40 @@ func TestSignData(t *testing.T) {
 	}
 }
 
+func TestDomainChainId(t *testing.T) {
+	withoutChainID := TypedData{
+		Types: Types{
+			"EIP712Domain": []Type{
+				{Name: "name", Type: "string"},
+			},
+		},
+		Domain: TypedDataDomain{
+			Name: "test",
+		},
+	}
+
+	if _, ok := withoutChainID.Domain.Map()["chainId"]; ok {
+		t.Errorf("Expected the chainId key to not be present in the domain map")
+	}
+
+	withChainID := TypedData{
+		Types: Types{
+			"EIP712Domain": []Type{
+				{Name: "name", Type: "string"},
+				{Name: "chainId", Type: "uint256"},
+			},
+		},
+		Domain: TypedDataDomain{
+			Name:    "test",
+			ChainId: big.NewInt(1),
+		},
+	}
+
+	if _, ok := withChainID.Domain.Map()["chainId"]; !ok {
+		t.Errorf("Expected the chainId key be present in the domain map")
+	}
+}
+
 func TestHashStruct(t *testing.T) {
 	hash, err := typedData.HashStruct(typedData.PrimaryType, typedData.Message)
 	if err != nil {


### PR DESCRIPTION
This fixes an issue I noticed with #17789 (cc @PaulRBerg) which resulted in a bad `PrettyPrint` of the `Domain` struct when attempting to debug message signing.

The original code makes the assumption that setting a key in a map to `nil` results in a noop, however in Go the key is still added to the map with its value set to nil, which yields a value showing up in `TypedData.Format()` even though it may not be specified by the user's `TypedData` struct.

This PR fixes this, moving `domain.ChainId` from the map's initializer down to a separate if statement which checks the existance of `ChainId`'s value, similar to the rest of the fields, before adding it. I've also included a new test to demonstrate the issue