### PR TITLE
core, ethdb, trie: mode dirty data to clean cache on flush

### DIFF
--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -301,7 +301,7 @@ func (bc *BlockChain) SetHead(head uint64) error {
 	defer bc.chainmu.Unlock()
 
 	// Rewind the header chain, deleting all block bodies until then
-	delFn := func(db ethdb.Deleter, hash common.Hash, num uint64) {
+	delFn := func(db ethdb.Writer, hash common.Hash, num uint64) {
 		rawdb.DeleteBody(db, hash, num)
 	}
 	bc.hc.SetHead(head, delFn)

--- a/core/headerchain.go
+++ b/core/headerchain.go
@@ -455,7 +455,7 @@ func (hc *HeaderChain) SetCurrentHeader(head *types.Header) {
 
 // DeleteCallback is a callback function that is called by SetHead before
 // each header is deleted.
-type DeleteCallback func(ethdb.Deleter, common.Hash, uint64)
+type DeleteCallback func(ethdb.Writer, common.Hash, uint64)
 
 // SetHead rewinds the local chain to a new head. Everything above the new head
 // will be deleted and the new one set.

--- a/core/rawdb/accessors_chain.go
+++ b/core/rawdb/accessors_chain.go
@@ -45,7 +45,7 @@ func WriteCanonicalHash(db ethdb.Writer, hash common.Hash, number uint64) {
 }
 
 // DeleteCanonicalHash removes the number to hash canonical mapping.
-func DeleteCanonicalHash(db ethdb.Deleter, number uint64) {
+func DeleteCanonicalHash(db ethdb.Writer, number uint64) {
 	if err := db.Delete(headerHashKey(number)); err != nil {
 		log.Crit("Failed to delete number to hash mapping", "err", err)
 	}
@@ -180,7 +180,7 @@ func WriteHeader(db ethdb.Writer, header *types.Header) {
 }
 
 // DeleteHeader removes all block header data associated with a hash.
-func DeleteHeader(db ethdb.Deleter, hash common.Hash, number uint64) {
+func DeleteHeader(db ethdb.Writer, hash common.Hash, number uint64) {
 	deleteHeaderWithoutNumber(db, hash, number)
 	if err := db.Delete(headerNumberKey(hash)); err != nil {
 		log.Crit("Failed to delete hash to number mapping", "err", err)
@@ -189,7 +189,7 @@ func DeleteHeader(db ethdb.Deleter, hash common.Hash, number uint64) {
 
 // deleteHeaderWithoutNumber removes only the block header but does not remove
 // the hash to number mapping.
-func deleteHeaderWithoutNumber(db ethdb.Deleter, hash common.Hash, number uint64) {
+func deleteHeaderWithoutNumber(db ethdb.Writer, hash common.Hash, number uint64) {
 	if err := db.Delete(headerKey(number, hash)); err != nil {
 		log.Crit("Failed to delete header", "err", err)
 	}
@@ -240,7 +240,7 @@ func WriteBody(db ethdb.Writer, hash common.Hash, number uint64, body *types.Bod
 }
 
 // DeleteBody removes all block body data associated with a hash.
-func DeleteBody(db ethdb.Deleter, hash common.Hash, number uint64) {
+func DeleteBody(db ethdb.Writer, hash common.Hash, number uint64) {
 	if err := db.Delete(blockBodyKey(number, hash)); err != nil {
 		log.Crit("Failed to delete block body", "err", err)
 	}
@@ -278,7 +278,7 @@ func WriteTd(db ethdb.Writer, hash common.Hash, number uint64, td *big.Int) {
 }
 
 // DeleteTd removes all block total difficulty data associated with a hash.
-func DeleteTd(db ethdb.Deleter, hash common.Hash, number uint64) {
+func DeleteTd(db ethdb.Writer, hash common.Hash, number uint64) {
 	if err := db.Delete(headerTDKey(number, hash)); err != nil {
 		log.Crit("Failed to delete block total difficulty", "err", err)
 	}
@@ -347,7 +347,7 @@ func WriteReceipts(db ethdb.Writer, hash common.Hash, number uint64, receipts ty
 }
 
 // DeleteReceipts removes all receipt data associated with a block hash.
-func DeleteReceipts(db ethdb.Deleter, hash common.Hash, number uint64) {
+func DeleteReceipts(db ethdb.Writer, hash common.Hash, number uint64) {
 	if err := db.Delete(blockReceiptsKey(number, hash)); err != nil {
 		log.Crit("Failed to delete block receipts", "err", err)
 	}
@@ -378,7 +378,7 @@ func WriteBlock(db ethdb.Writer, block *types.Block) {
 }
 
 // DeleteBlock removes all block data associated with a hash.
-func DeleteBlock(db ethdb.Deleter, hash common.Hash, number uint64) {
+func DeleteBlock(db ethdb.Writer, hash common.Hash, number uint64) {
 	DeleteReceipts(db, hash, number)
 	DeleteHeader(db, hash, number)
 	DeleteBody(db, hash, number)
@@ -387,7 +387,7 @@ func DeleteBlock(db ethdb.Deleter, hash common.Hash, number uint64) {
 
 // deleteBlockWithoutNumber removes all block data associated with a hash, except
 // the hash to number mapping.
-func deleteBlockWithoutNumber(db ethdb.Deleter, hash common.Hash, number uint64) {
+func deleteBlockWithoutNumber(db ethdb.Writer, hash common.Hash, number uint64) {
 	DeleteReceipts(db, hash, number)
 	deleteHeaderWithoutNumber(db, hash, number)
 	DeleteBody(db, hash, number)

--- a/core/rawdb/accessors_indexes.go
+++ b/core/rawdb/accessors_indexes.go
@@ -54,7 +54,7 @@ func WriteTxLookupEntries(db ethdb.Writer, block *types.Block) {
 }
 
 // DeleteTxLookupEntry removes all transaction data associated with a hash.
-func DeleteTxLookupEntry(db ethdb.Deleter, hash common.Hash) {
+func DeleteTxLookupEntry(db ethdb.Writer, hash common.Hash) {
 	db.Delete(txLookupKey(hash))
 }
 

--- a/core/rawdb/table.go
+++ b/core/rawdb/table.go
@@ -124,6 +124,10 @@ type tableBatch struct {
 	prefix string
 }
 
+func (b *tableBatch) Replay(replay ethdb.DbEventLogger) error {
+	panic("implement me")
+}
+
 // Put inserts the given value into the batch for later committing.
 func (b *tableBatch) Put(key, value []byte) error {
 	return b.batch.Put(append([]byte(b.prefix), key...), value)

--- a/core/rawdb/table.go
+++ b/core/rawdb/table.go
@@ -150,6 +150,6 @@ func (b *tableBatch) Reset() {
 }
 
 // Replay replays the batch contents.
-func (b *tableBatch) Replay(r ethdb.Replayee) error {
-	return b.batch.Replay(r)
+func (b *tableBatch) Replay(w ethdb.Writer) error {
+	return b.batch.Replay(w)
 }

--- a/core/rawdb/table.go
+++ b/core/rawdb/table.go
@@ -124,10 +124,6 @@ type tableBatch struct {
 	prefix string
 }
 
-func (b *tableBatch) Replay(replay ethdb.DbEventLogger) error {
-	panic("implement me")
-}
-
 // Put inserts the given value into the batch for later committing.
 func (b *tableBatch) Put(key, value []byte) error {
 	return b.batch.Put(append([]byte(b.prefix), key...), value)
@@ -151,4 +147,9 @@ func (b *tableBatch) Write() error {
 // Reset resets the batch for reuse.
 func (b *tableBatch) Reset() {
 	b.batch.Reset()
+}
+
+// Replay replays the batch contents.
+func (b *tableBatch) Replay(r ethdb.Replayee) error {
+	return b.batch.Replay(r)
 }

--- a/core/state/statedb.go
+++ b/core/state/statedb.go
@@ -53,6 +53,10 @@ func (n *proofList) Put(key []byte, value []byte) error {
 	return nil
 }
 
+func (n *proofList) Delete(key []byte) error {
+	panic("not supported")
+}
+
 // StateDBs within the ethereum protocol are used to store anything
 // within the merkle trie. StateDBs take care of caching and storing
 // nested states. It's the general query interface to retrieve:

--- a/ethdb/batch.go
+++ b/ethdb/batch.go
@@ -34,6 +34,9 @@ type Batch interface {
 
 	// Reset resets the batch for reuse
 	Reset()
+
+	// Replay replays the batch into another batch
+	Replay(logger DbEventLogger) error
 }
 
 // Batcher wraps the NewBatch method of a backing data store.

--- a/ethdb/batch.go
+++ b/ethdb/batch.go
@@ -32,11 +32,11 @@ type Batch interface {
 	// Write flushes any accumulated data to disk.
 	Write() error
 
-	// Reset resets the batch for reuse
+	// Reset resets the batch for reuse.
 	Reset()
 
-	// Replay replays the batch into another batch
-	Replay(logger DbEventLogger) error
+	// Replay replays the batch contents.
+	Replay(replayer Replayee) error
 }
 
 // Batcher wraps the NewBatch method of a backing data store.

--- a/ethdb/batch.go
+++ b/ethdb/batch.go
@@ -24,7 +24,6 @@ const IdealBatchSize = 100 * 1024
 // when Write is called. A batch cannot be used concurrently.
 type Batch interface {
 	Writer
-	Deleter
 
 	// ValueSize retrieves the amount of data queued up for writing.
 	ValueSize() int
@@ -36,7 +35,7 @@ type Batch interface {
 	Reset()
 
 	// Replay replays the batch contents.
-	Replay(replayer Replayee) error
+	Replay(w Writer) error
 }
 
 // Batcher wraps the NewBatch method of a backing data store.

--- a/ethdb/database.go
+++ b/ethdb/database.go
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
 
-// Package database defines the interfaces for an Ethereum data store.
+// Package ethdb defines the interfaces for an Ethereum data store.
 package ethdb
 
 import "io"
@@ -40,9 +40,9 @@ type Deleter interface {
 	Delete(key []byte) error
 }
 
-// DbEventLogger wraps Put and Delete to serve as a recipient
-// for batch replays
-type DbEventLogger interface {
+// Replayee wraps basic batch operations to allow replaying an existing batch
+// on top of multiple databases.
+type Replayee interface {
 	Writer
 	Deleter
 }

--- a/ethdb/database.go
+++ b/ethdb/database.go
@@ -40,6 +40,13 @@ type Deleter interface {
 	Delete(key []byte) error
 }
 
+// DbEventLogger wraps Put and Delete to serve as a recipient
+// for batch replays
+type DbEventLogger interface {
+	Writer
+	Deleter
+}
+
 // Stater wraps the Stat method of a backing data store.
 type Stater interface {
 	// Stat returns a particular internal stat of the database.

--- a/ethdb/database.go
+++ b/ethdb/database.go
@@ -32,19 +32,9 @@ type Reader interface {
 type Writer interface {
 	// Put inserts the given value into the key-value data store.
 	Put(key []byte, value []byte) error
-}
 
-// Deleter wraps the Delete method of a backing data store.
-type Deleter interface {
 	// Delete removes the key from the key-value data store.
 	Delete(key []byte) error
-}
-
-// Replayee wraps basic batch operations to allow replaying an existing batch
-// on top of multiple databases.
-type Replayee interface {
-	Writer
-	Deleter
 }
 
 // Stater wraps the Stat method of a backing data store.
@@ -70,7 +60,6 @@ type Compacter interface {
 type KeyValueStore interface {
 	Reader
 	Writer
-	Deleter
 	Batcher
 	Iteratee
 	Stater
@@ -83,7 +72,6 @@ type KeyValueStore interface {
 type Database interface {
 	Reader
 	Writer
-	Deleter
 	Batcher
 	Iteratee
 	Stater

--- a/ethdb/leveldb/leveldb.go
+++ b/ethdb/leveldb/leveldb.go
@@ -418,14 +418,14 @@ func (b *batch) Reset() {
 }
 
 // Replay replays the batch contents.
-func (b *batch) Replay(r ethdb.Replayee) error {
-	return b.b.Replay(&replayer{replayer: r})
+func (b *batch) Replay(w ethdb.Writer) error {
+	return b.b.Replay(&replayer{writer: w})
 }
 
 // replayer is a small wrapper to implement the correct replay methods.
 type replayer struct {
-	replayer ethdb.Replayee
-	failure  error
+	writer  ethdb.Writer
+	failure error
 }
 
 // Put inserts the given value into the key-value data store.
@@ -434,7 +434,7 @@ func (r *replayer) Put(key, value []byte) {
 	if r.failure != nil {
 		return
 	}
-	r.failure = r.replayer.Put(key, value)
+	r.failure = r.writer.Put(key, value)
 }
 
 // Delete removes the key from the key-value data store.
@@ -443,5 +443,5 @@ func (r *replayer) Delete(key []byte) {
 	if r.failure != nil {
 		return
 	}
-	r.failure = r.replayer.Delete(key)
+	r.failure = r.writer.Delete(key)
 }

--- a/ethdb/leveldb/leveldb.go
+++ b/ethdb/leveldb/leveldb.go
@@ -172,6 +172,23 @@ func (db *Database) NewBatch() ethdb.Batch {
 	}
 }
 
+type dbWrapper struct {
+	wrapped ethdb.DbEventLogger
+}
+
+func (dbw *dbWrapper) Put(key, value []byte) {
+	dbw.wrapped.Put(key, value)
+}
+
+func (dbw *dbWrapper) Delete(key []byte) {
+	dbw.wrapped.Delete(key)
+}
+
+// Replay replays batch contents.
+func (b *batch) Replay(r ethdb.DbEventLogger) error {
+	return b.b.Replay(&dbWrapper{r})
+}
+
 // NewIterator creates a binary-alphabetical iterator over the entire keyspace
 // contained within the leveldb database.
 func (db *Database) NewIterator() ethdb.Iterator {

--- a/ethdb/memorydb/memorydb.go
+++ b/ethdb/memorydb/memorydb.go
@@ -241,13 +241,17 @@ func (b *batch) Reset() {
 }
 
 // Replay replays the batch contents.
-func (b *batch) Replay(r ethdb.Replayee) error {
+func (b *batch) Replay(w ethdb.Writer) error {
 	for _, keyvalue := range b.writes {
 		if keyvalue.delete {
-			r.Delete(keyvalue.key)
+			if err := w.Delete(keyvalue.key); err != nil {
+				return err
+			}
 			continue
 		}
-		r.Put(keyvalue.key, keyvalue.value)
+		if err := w.Put(keyvalue.key, keyvalue.value); err != nil {
+			return err
+		}
 	}
 	return nil
 }

--- a/ethdb/memorydb/memorydb.go
+++ b/ethdb/memorydb/memorydb.go
@@ -200,6 +200,17 @@ type batch struct {
 	size   int
 }
 
+func (b *batch) Replay(replay ethdb.DbEventLogger) error {
+	for _, keyvalue := range b.writes {
+		if keyvalue.delete {
+			replay.Delete(keyvalue.key)
+			continue
+		}
+		replay.Put(keyvalue.key, keyvalue.value)
+	}
+	return nil
+}
+
 // Put inserts the given value into the batch for later committing.
 func (b *batch) Put(key, value []byte) error {
 	b.writes = append(b.writes, keyvalue{common.CopyBytes(key), common.CopyBytes(value), false})

--- a/light/nodeset.go
+++ b/light/nodeset.go
@@ -60,6 +60,15 @@ func (db *NodeSet) Put(key []byte, value []byte) error {
 	return nil
 }
 
+// Delete removes a node from the set
+func (db *NodeSet) Delete(key []byte) error {
+	db.lock.Lock()
+	defer db.lock.Unlock()
+
+	delete(db.nodes, string(key))
+	return nil
+}
+
 // Get returns a stored node
 func (db *NodeSet) Get(key []byte) ([]byte, error) {
 	db.lock.RLock()
@@ -136,6 +145,11 @@ func (n NodeList) NodeSet() *NodeSet {
 func (n *NodeList) Put(key []byte, value []byte) error {
 	*n = append(*n, value)
 	return nil
+}
+
+// Delete panics as there's no reason to remove a node from the list.
+func (n *NodeList) Delete(key []byte) error {
+	panic("not supported")
 }
 
 // DataSize returns the aggregated data size of nodes in the list

--- a/trie/database.go
+++ b/trie/database.go
@@ -784,6 +784,11 @@ func (db *Database) uncache(hash common.Hash) {
 	}
 	delete(db.dirties, hash)
 	db.dirtiesSize -= common.StorageSize(common.HashLength + int(node.size))
+
+	// Move the flushed node into the clean cache to prevent insta-reloads
+	if db.cleans != nil {
+		db.cleans.Set(string(hash[:]), node.rlp())
+	}
 }
 
 // Size returns the current storage size of the memory cache in front of the

--- a/trie/database.go
+++ b/trie/database.go
@@ -293,13 +293,12 @@ func NewDatabaseWithCache(diskdb ethdb.KeyValueStore, cache int) *Database {
 			Hasher:             trienodeHasher{},
 		})
 	}
-	db := &Database{
+	return &Database{
 		diskdb:    diskdb,
 		cleans:    cleans,
 		dirties:   map[common.Hash]*cachedNode{{}: {}},
 		preimages: make(map[common.Hash][]byte),
 	}
-	return db
 }
 
 // DiskDB retrieves the persistent storage backing the trie database.

--- a/trie/database.go
+++ b/trie/database.go
@@ -81,8 +81,7 @@ type Database struct {
 	dirtiesSize   common.StorageSize // Storage size of the dirty node cache (exc. flushlist)
 	preimagesSize common.StorageSize // Storage size of the preimages cache
 
-	lock        sync.RWMutex
-	batchLogger *BatchEventLogger
+	lock sync.RWMutex
 }
 
 // rawNode is a simple binary blob used to differentiate between collapsed trie
@@ -300,7 +299,6 @@ func NewDatabaseWithCache(diskdb ethdb.KeyValueStore, cache int) *Database {
 		dirties:   map[common.Hash]*cachedNode{{}: {}},
 		preimages: make(map[common.Hash][]byte),
 	}
-	db.batchLogger = newBatchEventLogger(db)
 	return db
 }
 
@@ -663,61 +661,6 @@ func (db *Database) Cap(limit common.StorageSize) error {
 	return nil
 }
 
-type BatchEventLogger struct {
-	db *Database
-}
-
-func newBatchEventLogger(db *Database) *BatchEventLogger {
-	return &BatchEventLogger{db}
-}
-
-// Put reacts to batch writes, and implements uncache:
-// is the post-processing step of a commit operation where the already
-// persisted trie is removed from the cache. The reason behind the two-phase
-// commit is to ensure consistent data availability while moving from memory
-// to disk.
-func (p *BatchEventLogger) Put(key []byte, value []byte) error {
-	// key is hash
-	// value is rlp
-	//log.Info("proxybatch", "key", fmt.Sprintf("0x%x", key))
-	hash := common.BytesToHash(key)
-	db := p.db
-	rlp := value
-	// If the node does not exist, we're done on this path
-	node, ok := db.dirties[hash]
-	if !ok {
-		return nil
-	}
-	// Node still exists, remove it from the flush-list
-	switch hash {
-	case db.oldest:
-		db.oldest = node.flushNext
-		db.dirties[node.flushNext].flushPrev = common.Hash{}
-	case db.newest:
-		db.newest = node.flushPrev
-		db.dirties[node.flushPrev].flushNext = common.Hash{}
-	default:
-		db.dirties[node.flushPrev].flushNext = node.flushNext
-		db.dirties[node.flushNext].flushPrev = node.flushPrev
-	}
-	// Uncache the node's subtries and remove the node itself too
-	//for _, child := range node.childs() {
-	//	db.uncache(child)
-	//}
-	delete(db.dirties, hash)
-	db.dirtiesSize -= common.StorageSize(common.HashLength + int(node.size))
-
-	// Move the flushed node into the clean cache to prevent insta-reloads
-	if db.cleans != nil {
-		db.cleans.Set(string(hash[:]), rlp)
-	}
-	return nil
-}
-
-func (p *BatchEventLogger) Delete(key []byte) error {
-	panic("Not implemented")
-}
-
 // Commit iterates over all the children of a particular node, writes them out
 // to disk, forcefully tearing down all references in both directions.
 //
@@ -731,6 +674,7 @@ func (db *Database) Commit(node common.Hash, report bool) error {
 
 	start := time.Now()
 	batch := db.diskdb.NewBatch()
+
 	// Move all of the accumulated preimages into a write batch
 	for hash, preimage := range db.preimages {
 		if err := batch.Put(db.secureKey(hash[:]), preimage); err != nil {
@@ -738,6 +682,7 @@ func (db *Database) Commit(node common.Hash, report bool) error {
 			db.lock.RUnlock()
 			return err
 		}
+		// If the batch is too large, flush to disk
 		if batch.ValueSize() > ethdb.IdealBatchSize {
 			if err := batch.Write(); err != nil {
 				db.lock.RUnlock()
@@ -746,31 +691,39 @@ func (db *Database) Commit(node common.Hash, report bool) error {
 			batch.Reset()
 		}
 	}
+	// Since we're going to replay trie node writes into the clean cache, flush out
+	// any batched pre-images before continuing.
 	if err := batch.Write(); err != nil {
 		db.lock.RUnlock()
 		return err
 	}
 	batch.Reset()
+
 	// Move the trie itself into the batch, flushing if enough data is accumulated
 	nodes, storage := len(db.dirties), db.dirtiesSize
-	if err := db.commit(node, batch); err != nil {
+
+	uncacher := &cleaner{db}
+	if err := db.commit(node, batch, uncacher); err != nil {
 		log.Error("Failed to commit trie from trie database", "err", err)
 		db.lock.RUnlock()
 		return err
 	}
-	// Write batch ready, unlock for readers during persistence
+	// Trie mostly committed to disk, flush any batch leftovers
 	if err := batch.Write(); err != nil {
 		log.Error("Failed to write trie to disk", "err", err)
 		db.lock.RUnlock()
 		return err
 	}
 	db.lock.RUnlock()
-	// Write successful, clear out the flushed data
+
+	// Uncache any leftovers in the last batch
 	db.lock.Lock()
 	defer db.lock.Unlock()
-	batch.Replay(db.batchLogger)
+
+	batch.Replay(uncacher)
 	batch.Reset()
 
+	// Reset the storage counters and bumpd metrics
 	db.preimages = make(map[common.Hash][]byte)
 	db.preimagesSize = 0
 
@@ -793,14 +746,14 @@ func (db *Database) Commit(node common.Hash, report bool) error {
 }
 
 // commit is the private locked version of Commit.
-func (db *Database) commit(hash common.Hash, batch ethdb.Batch) error {
+func (db *Database) commit(hash common.Hash, batch ethdb.Batch, uncacher *cleaner) error {
 	// If the node does not exist, it's a previously committed node
 	node, ok := db.dirties[hash]
 	if !ok {
 		return nil
 	}
 	for _, child := range node.childs() {
-		if err := db.commit(child, batch); err != nil {
+		if err := db.commit(child, batch, uncacher); err != nil {
 			return err
 		}
 	}
@@ -815,13 +768,59 @@ func (db *Database) commit(hash common.Hash, batch ethdb.Batch) error {
 		db.lock.RUnlock()
 		{
 			db.lock.Lock()
-			batch.Replay(db.batchLogger)
-			batch.Reset()
+			batch.Replay(uncacher)
 			db.lock.Unlock()
+			batch.Reset()
 		}
 		db.lock.RLock()
 	}
 	return nil
+}
+
+// cleaner is a database batch replayer that takes a batch of write operations
+// and cleans up the trie database from anything written to disk.
+type cleaner struct {
+	db *Database
+}
+
+// Put reacts to database writes and implements dirty data uncaching. This is the
+// post-processing step of a commit operation where the already persisted trie is
+// removed from the dirty cache and moved into the clean cache. The reason behind
+// the two-phase commit is to ensure ensure data availability while moving from
+// memory to disk.
+func (c *cleaner) Put(key []byte, rlp []byte) error {
+	hash := common.BytesToHash(key)
+
+	// If the node does not exist, we're done on this path
+	node, ok := c.db.dirties[hash]
+	if !ok {
+		return nil
+	}
+	// Node still exists, remove it from the flush-list
+	switch hash {
+	case c.db.oldest:
+		c.db.oldest = node.flushNext
+		c.db.dirties[node.flushNext].flushPrev = common.Hash{}
+	case c.db.newest:
+		c.db.newest = node.flushPrev
+		c.db.dirties[node.flushPrev].flushNext = common.Hash{}
+	default:
+		c.db.dirties[node.flushPrev].flushNext = node.flushNext
+		c.db.dirties[node.flushNext].flushPrev = node.flushPrev
+	}
+	// Remove the node from the dirty cache
+	delete(c.db.dirties, hash)
+	c.db.dirtiesSize -= common.StorageSize(common.HashLength + int(node.size))
+
+	// Move the flushed node into the clean cache to prevent insta-reloads
+	if c.db.cleans != nil {
+		c.db.cleans.Set(string(hash[:]), rlp)
+	}
+	return nil
+}
+
+func (c *cleaner) Delete(key []byte) error {
+	panic("Not implemented")
 }
 
 // Size returns the current storage size of the memory cache in front of the


### PR DESCRIPTION
This PR is a more advanced form of the dirty-to-clean cacher (https://github.com/ethereum/go-ethereum/pull/18995), where we reuse previous database write batches as datasets to uncache, saving a dirty-trie-iteration and a dirty-trie-rlp-reencoding per block.