### PR TITLE
core: make txpool handle reorg due to setHead

### DIFF
--- a/core/tx_pool.go
+++ b/core/tx_pool.go
@@ -387,11 +387,26 @@ func (pool *TxPool) reset(oldHead, newHead *types.Header) {
 		} else {
 			// Reorg seems shallow enough to pull in all transactions into memory
 			var discarded, included types.Transactions
-
 			var (
 				rem = pool.chain.GetBlock(oldHead.Hash(), oldHead.Number.Uint64())
 				add = pool.chain.GetBlock(newHead.Hash(), newHead.Number.Uint64())
 			)
+			if rem == nil {
+				// This can happen if a setHead is performed, where we simply discard the old
+				// head from the chain.
+				// If that is the case, we don't have the lost transactions any more, and
+				// there's nothing to add
+				if newNum < oldNum {
+					// If the reorg ended up on a lower number, it's indicative of setHead being the cause
+					log.Debug("Skipping transaction reset caused by setHead",
+						"old", oldHead.Hash(), "oldnum", oldNum, "new", newHead.Hash(), "newnum", newNum)
+				} else {
+					// If we reorged to a same or higher number, then it's not a case of setHead
+					log.Warn("Transaction pool reset with missing oldhead",
+						"old", oldHead.Hash(), "oldnum", oldNum, "new", newHead.Hash(), "newnum", newNum)
+				}
+				return
+			}
 			for rem.NumberU64() > add.NumberU64() {
 				discarded = append(discarded, rem.Transactions()...)
 				if rem = pool.chain.GetBlock(rem.ParentHash(), rem.NumberU64()-1); rem == nil {


### PR DESCRIPTION
This PR supersedes https://github.com/ethereum/go-ethereum/pull/16713 and https://github.com/ethereum/go-ethereum/pull/19216 , and resolves #19212.

It's more or less same as #19216 in the end, but with some more logging and documentation about the root cause. 

It's very easy to replicate the bug thanks to the reports above, 
```
build/bin/geth  --dev --dev.period 1
```
```
> build/bin/geth attach /tmp/geth.ipc
# wait a few seconds
> miner.stop(); debug.setHead(web3.toHex(eth.blockNumber -5));miner.start()
```