### PR TITLE
fix link error

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ https://camo.githubusercontent.com/915b7be44ada53c290eb157634330494ebe3e30a/6874
 [![Discord](https://img.shields.io/badge/discord-join%20chat-blue.svg)](https://discord.gg/nthXNEv)
 
 Automated builds are available for stable releases and the unstable master branch.
-Binary archives are published at https://geth.ethereum.org/downloads/.
+Binary archives are published at https://geth.ethereum.org/downloads.
 
 ## Building the source
 


### PR DESCRIPTION
**What this PR does / why we need it:**
Fix link error in the main README.md. The old link returns `File not found`.