### PR TITLE
les: fix block announcements

### DIFF
--- a/les/server.go
+++ b/les/server.go
@@ -280,8 +280,8 @@ func (pm *ProtocolManager) blockLoop() {
 						)
 
 						for _, p := range peers {
+							p := p
 							switch p.announceType {
-
 							case announceTypeSimple:
 								p.queueSend(func() { p.SendAnnounce(announce) })
 							case announceTypeSigned:
@@ -290,7 +290,6 @@ func (pm *ProtocolManager) blockLoop() {
 									signedAnnounce.sign(pm.server.privateKey)
 									signed = true
 								}
-
 								p.queueSend(func() { p.SendAnnounce(signedAnnounce) })
 							}
 						}


### PR DESCRIPTION
This PR fixes a bug in the LES server which caused it to send new block announcements to the same peer multiple times instead of once for every peer. Eventually it also triggered a disconnection from the "lucky" client because receiving many useless announcements is considered an error.