### PR TITLE
contracts/ens: revert bmt to keccak256

### DIFF
--- a/contracts/ens/cid.go
+++ b/contracts/ens/cid.go
@@ -31,7 +31,7 @@ const (
 	nsSwarm = 0xe4
 
 	swarmTypecode = 0xfa //swarm manifest, see https://github.com/multiformats/multicodec/blob/master/table.csv
-	swarmHashtype = 0xd6 // BMT, see https://github.com/multiformats/multicodec/blob/master/table.csv
+	swarmHashtype = 0x1b // BMT, see https://github.com/multiformats/multicodec/blob/master/table.csv
 
 	hashLength = 32
 )
@@ -106,7 +106,7 @@ func EncodeSwarmHash(hash common.Hash) ([]byte, error) {
 		nsSwarm,       //swarm namespace
 		cidv1,         // CIDv1
 		swarmTypecode, // swarm hash
-		swarmHashtype, // swarm bmt hash
+		swarmHashtype, // keccak256 hash
 		hashLength,    //hash length. 32 bytes
 	}
 

--- a/contracts/ens/cid.go
+++ b/contracts/ens/cid.go
@@ -30,8 +30,8 @@ const (
 	nsIpfs  = 0xe3
 	nsSwarm = 0xe4
 
-	swarmTypecode = 0xfa //swarm manifest, see https://github.com/multiformats/multicodec/blob/master/table.csv
-	swarmHashtype = 0x1b // BMT, see https://github.com/multiformats/multicodec/blob/master/table.csv
+	swarmTypecode = 0xfa // swarm manifest, see https://github.com/multiformats/multicodec/blob/master/table.csv
+	swarmHashtype = 0x1b // keccak256, see https://github.com/multiformats/multicodec/blob/master/table.csv
 
 	hashLength = 32
 )

--- a/contracts/ens/cid_test.go
+++ b/contracts/ens/cid_test.go
@@ -76,17 +76,17 @@ func TestManualCidDecode(t *testing.T) {
 	}{
 		{
 			name:        "values correct, should not fail",
-			headerBytes: []byte{0xe4, 0x01, 0xfa, 0xd6, 0x20},
+			headerBytes: []byte{0xe4, 0x01, 0xfa, 0x1b, 0x20},
 			wantErr:     false,
 		},
 		{
 			name:        "cid version wrong, should fail",
-			headerBytes: []byte{0xe4, 0x00, 0xfa, 0xd6, 0x20},
+			headerBytes: []byte{0xe4, 0x00, 0xfa, 0x1b, 0x20},
 			wantErr:     true,
 		},
 		{
 			name:        "hash length wrong, should fail",
-			headerBytes: []byte{0xe4, 0x01, 0xfa, 0xd6, 0x1f},
+			headerBytes: []byte{0xe4, 0x01, 0xfa, 0x1b, 0x1f},
 			wantErr:     true,
 		},
 		{


### PR DESCRIPTION
as per the discussion in https://github.com/ensdomains/ens-app/issues/113 (ENS Manager integration of EIP-1577), we are going to use `keccak256` instead of `bmt` for ENS `contentHash`es