### PR TITLE
metrics: fix expensive metrics flag processing

### DIFF
--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -46,7 +46,7 @@ func init() {
 			}
 		}
 		for _, enabler := range expensiveEnablerFlags {
-			if !Enabled && flag == enabler {
+			if !EnabledExpensive && flag == enabler {
 				log.Info("Enabling expensive metrics collection")
 				EnabledExpensive = true
 			}


### PR DESCRIPTION
This PR fixes a bug where the `--metrics` flag accidentally disabled `--metrics.expensive` if it was placed before it on the CLI arg list. 