### PR TITLE
whisper: Fix PoW calculations to match the spec

### DIFF
--- a/whisper/whisperv6/envelope.go
+++ b/whisper/whisperv6/envelope.go
@@ -130,13 +130,14 @@ func (e *Envelope) PoW() float64 {
 
 func (e *Envelope) calculatePoW(diff uint32) {
 	buf := make([]byte, 64)
-	h := crypto.Keccak256(e.rlpWithoutNonce())
+	rlp := e.rlpWithoutNonce()
+	h := crypto.Keccak256(rlp)
 	copy(buf[:32], h)
 	binary.BigEndian.PutUint64(buf[56:], e.Nonce)
-	d := new(big.Int).SetBytes(crypto.Keccak256(buf))
-	firstBit := math.FirstBitSet(d)
-	x := gmath.Pow(2, float64(firstBit))
-	x /= float64(e.size())
+	powHash := new(big.Int).SetBytes(crypto.Keccak256(buf))
+	leadingZeroes := 256 - powHash.BitLen()
+	x := gmath.Pow(2, float64(leadingZeroes))
+	x /= float64(len(rlp))
 	x /= float64(e.TTL + diff)
 	e.pow = x
 }

--- a/whisper/whisperv6/envelope_test.go
+++ b/whisper/whisperv6/envelope_test.go
@@ -25,6 +25,33 @@ import (
 	"github.com/ethereum/go-ethereum/crypto"
 )
 
+func TestPoWCalculationsWithNoLeadingZeros(t *testing.T) {
+	e := Envelope{
+		TTL:   1,
+		Data:  []byte{0xde, 0xad, 0xbe, 0xef},
+		Nonce: 100000,
+	}
+
+	e.calculatePoW(0)
+
+	if e.pow != 0.07692307692307693 {
+		t.Fatalf("invalid PoW calculation. Expected 0.07692307692307693, got %v", e.pow)
+	}
+}
+
+func TestPoWCalculationsWith8LeadingZeros(t *testing.T) {
+	e := Envelope{
+		TTL:   1,
+		Data:  []byte{0xde, 0xad, 0xbe, 0xef},
+		Nonce: 48159,
+	}
+	e.calculatePoW(0)
+
+	if e.pow != 40329.846153846156 {
+		t.Fatalf("invalid PoW calculation. Expected 0.07692307692307693, got %v", e.pow)
+	}
+}
+
 func TestEnvelopeOpenAcceptsOnlyOneKeyTypeInFilter(t *testing.T) {
 	symKey := make([]byte, aesKeyLength)
 	mrand.Read(symKey)


### PR DESCRIPTION
This PR fixes two issues in the PoW calculation of a Whisper envelope, compared to the [spec](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-627.md) (see PoW Requirements):

  * The pow is supposed to take the leading number of zeroes (i.e. most significant zeroes) and what it did was to take the number of trailing zeroes (i.e. least significant zeroes). It has been fixed to match what the spec and Parity does.
  * The spec expects to use the size of the RLP encoded envelope, and it took something else, as described in https://github.com/ethereum/go-ethereum/issues/18070