### PR TITLE
accounts/abi:  json-structtag for tuples

### DIFF
--- a/accounts/abi/type.go
+++ b/accounts/abi/type.go
@@ -188,6 +188,7 @@ func NewType(t string, components []ArgumentMarshaling) (typ Type, err error) {
 			fields = append(fields, reflect.StructField{
 				Name: ToCamelCase(c.Name), // reflect.StructOf will panic for any exported field.
 				Type: cType.Type,
+				Tag:  reflect.StructTag("json:\"" + c.Name + "\""),
 			})
 			elems = append(elems, &cType)
 			names = append(names, c.Name)

--- a/accounts/abi/type_test.go
+++ b/accounts/abi/type_test.go
@@ -95,7 +95,9 @@ func TestTypeRegexp(t *testing.T) {
 		// {"fixed[2]", nil, Type{}},
 		// {"fixed128x128[]", nil, Type{}},
 		// {"fixed128x128[2]", nil, Type{}},
-		{"tuple", []ArgumentMarshaling{{Name: "a", Type: "int64"}}, Type{Kind: reflect.Struct, T: TupleTy, Type: reflect.TypeOf(struct{ A int64 }{}), stringKind: "(int64)",
+		{"tuple", []ArgumentMarshaling{{Name: "a", Type: "int64"}}, Type{Kind: reflect.Struct, T: TupleTy, Type: reflect.TypeOf(struct {
+			A int64 `json:"a"`
+		}{}), stringKind: "(int64)",
 			TupleElems: []*Type{{Kind: reflect.Int64, T: IntTy, Type: reflect.TypeOf(int64(0)), Size: 64, stringKind: "int64"}}, TupleRawNames: []string{"a"}}},
 	}
 

--- a/accounts/abi/type_test.go
+++ b/accounts/abi/type_test.go
@@ -99,6 +99,10 @@ func TestTypeRegexp(t *testing.T) {
 			A int64 `json:"a"`
 		}{}), stringKind: "(int64)",
 			TupleElems: []*Type{{Kind: reflect.Int64, T: IntTy, Type: reflect.TypeOf(int64(0)), Size: 64, stringKind: "int64"}}, TupleRawNames: []string{"a"}}},
+		{"tuple with long name", []ArgumentMarshaling{{Name: "aTypicalParamName", Type: "int64"}}, Type{Kind: reflect.Struct, T: TupleTy, Type: reflect.TypeOf(struct {
+			ATypicalParamName int64 `json:"aTypicalParamName"`
+		}{}), stringKind: "(int64)",
+			TupleElems: []*Type{{Kind: reflect.Int64, T: IntTy, Type: reflect.TypeOf(int64(0)), Size: 64, stringKind: "int64"}}, TupleRawNames: []string{"aTypicalParamName"}}},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
This PR adds the original name of the tuple component as the json-structtag.

Today, if the ABI specifies components with names `firstParameter` and `secondParameter`, go-ethereum will create a struct with fields `FirstParameter` and `SecondParameter`. Marshalling this struct directly results in a json with capitalised keys. 

Here, we add the original name found in the ABI specification as the name of the keys in the marshalled json such that the json will have keys `firstParameter` and `secondParameter`.

I find this handy when marshaling arguments to functions.
