### PR TITLE
Fixed tracing of the chain in api_tracer.go

### DIFF
--- a/eth/api_tracer.go
+++ b/eth/api_tracer.go
@@ -295,7 +295,7 @@ func (api *PrivateDebugAPI) traceChain(ctx context.Context, start, end *types.Bl
 				break
 			}
 			// Finalize the state so any modifications are written to the trie
-			root, err := statedb.Commit(true)
+			root, err := statedb.Commit(api.eth.chainConfig.IsEIP158(block.Number()))
 			if err != nil {
 				failed = err
 				break


### PR DESCRIPTION
Without this, the tracer will eventually run out of founds.

Fixes #19337

I am not sure whether this fix is correct. But it worked in my small usecase.