### PR TITLE
core/vm: Correct the Memory Gas Overflow condition

### DIFF
--- a/core/vm/gas_table.go
+++ b/core/vm/gas_table.go
@@ -25,21 +25,17 @@ import (
 // memoryGasCost calculates the quadratic gas for memory expansion. It does so
 // only for the memory region that is expanded, not the total memory.
 func memoryGasCost(mem *Memory, newMemSize uint64) (uint64, error) {
-
 	if newMemSize == 0 {
 		return 0, nil
 	}
-	// The maximum that will fit in a uint64 is max_word_count - 1
-	// anything above that will result in an overflow.
-	// Additionally, a newMemSize which results in a
-	// newMemSizeWords larger than 0xFFFFFFFF will cause the square operation
-	// to overflow.
-	// The constant 0x1FFFFFFFE0 is the highest number that can be used without
-	// overflowing the gas calculation
+	// The maximum that will fit in a uint64 is max_word_count - 1. Anything above
+	// that will result in an overflow. Additionally, a newMemSize which results in
+	// a newMemSizeWords larger than 0xFFFFFFFF will cause the square operation to
+	// overflow. The constant 0x1FFFFFFFE0 is the highest number that can be used
+	// without overflowing the gas calculation.
 	if newMemSize > 0x1FFFFFFFE0 {
 		return 0, errGasUintOverflow
 	}
-
 	newMemSizeWords := toWordSize(newMemSize)
 	newMemSize = newMemSizeWords * 32
 

--- a/core/vm/gas_table.go
+++ b/core/vm/gas_table.go
@@ -32,11 +32,11 @@ func memoryGasCost(mem *Memory, newMemSize uint64) (uint64, error) {
 	// The maximum that will fit in a uint64 is max_word_count - 1
 	// anything above that will result in an overflow.
 	// Additionally, a newMemSize which results in a
-	// newMemSizeWords larger than 0x7ffffffff will cause the square operation
+	// newMemSizeWords larger than 0xFFFFFFFF will cause the square operation
 	// to overflow.
-	// The constant 0xffffffffe0 is the highest number that can be used without
+	// The constant 0x1FFFFFFFE0 is the highest number that can be used without
 	// overflowing the gas calculation
-	if newMemSize > 0xffffffffe0 {
+	if newMemSize > 0x1FFFFFFFE0 {
 		return 0, errGasUintOverflow
 	}
 


### PR DESCRIPTION
previous overflow condition is too big to use.
0x7FFFFFFFF squre operation is overflowed uint64.

0x7FFFFFFFF^2 = 0x3F FFFF FFF0 0000 0001

the minimal number cause uint64 overflow is 0x100000000^2 = (uint64) 0
test code is 
func main() {
        var min_overflow uint64
        var mem_sz uint64
        var word_sz uint64

        min_overflow = 0x100000000
   
        fmt.Printf("result of 0x%X square op is 0x%X\n", min_overflow, min_overflow*min_overflow)

        mem_sz = 0x1FFFFFFFE0
        word_sz= (mem_sz+31)/32

	fmt.Printf("mem_sz is 0x%X, word sz is 0x%X\n", mem_sz, word_sz)	
}





