### PR TITLE
For Ledger use BIP-44 by default and BIP-32 if requested.

### DIFF
--- a/accounts/hd.go
+++ b/accounts/hd.go
@@ -34,10 +34,10 @@ var DefaultRootDerivationPath = DerivationPath{0x80000000 + 44, 0x80000000 + 60,
 // at m/44'/60'/0'/0/1, etc.
 var DefaultBaseDerivationPath = DerivationPath{0x80000000 + 44, 0x80000000 + 60, 0x80000000 + 0, 0, 0}
 
-// DefaultLedgerBaseDerivationPath is the base path from which custom derivation endpoints
-// are incremented. As such, the first account will be at m/44'/60'/0'/0, the second
-// at m/44'/60'/0'/1, etc.
-var DefaultLedgerBaseDerivationPath = DerivationPath{0x80000000 + 44, 0x80000000 + 60, 0x80000000 + 0, 0}
+// DefaultLegacyLedgerBaseDerivationPath is the base path from which custom derivation
+// endpoints were incremented before the switch to BIP-44. As such, the first account
+// will be at m/44'/60'/0'/0, the second at m/44'/60'/0'/1, etc.
+var DefaultLegacyLedgerBaseDerivationPath = DerivationPath{0x80000000 + 44, 0x80000000 + 60, 0x80000000 + 0, 0}
 
 // DerivationPath represents the computer friendly version of a hierarchical
 // deterministic wallet account derivaion path.

--- a/cmd/clef/main.go
+++ b/cmd/clef/main.go
@@ -421,11 +421,12 @@ func signer(c *cli.Context) error {
 		lightKdf = c.GlobalBool(utils.LightKDFFlag.Name)
 		advanced = c.GlobalBool(advancedMode.Name)
 		nousb    = c.GlobalBool(utils.NoUSBFlag.Name)
+		ldgrLeg  = c.GlobalBool(utils.LedgerLegacyHDDerivationPath.Name)
 	)
 	log.Info("Starting signer", "chainid", chainId, "keystore", ksLoc,
 		"light-kdf", lightKdf, "advanced", advanced)
 	am := core.StartClefAccountManager(ksLoc, nousb, lightKdf)
-	apiImpl := core.NewSignerAPI(am, chainId, nousb, ui, db, advanced, pwStorage)
+	apiImpl := core.NewSignerAPI(am, chainId, nousb, ldgrLeg, ui, db, advanced, pwStorage)
 
 	// Establish the bidirectional communication, by creating a new UI backend and registering
 	// it with the UI.

--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -64,6 +64,7 @@ var (
 		utils.KeyStoreDirFlag,
 		utils.ExternalSignerFlag,
 		utils.NoUSBFlag,
+		utils.LedgerLegacyHDDerivationPath,
 		utils.DashboardEnabledFlag,
 		utils.DashboardAddrFlag,
 		utils.DashboardPortFlag,
@@ -337,8 +338,8 @@ func startNode(ctx *cli.Context, stack *node.Node) {
 				log.Info("New wallet appeared", "url", event.Wallet.URL(), "status", status)
 
 				derivationPath := accounts.DefaultBaseDerivationPath
-				if event.Wallet.URL().Scheme == "ledger" {
-					derivationPath = accounts.DefaultLedgerBaseDerivationPath
+				if event.Wallet.URL().Scheme == "ledger" && ctx.GlobalIsSet(utils.LedgerLegacyHDDerivationPath.Name) {
+					derivationPath = accounts.DefaultLegacyLedgerBaseDerivationPath
 				}
 				event.Wallet.SelfDerive(derivationPath, stateReader)
 

--- a/cmd/geth/usage.go
+++ b/cmd/geth/usage.go
@@ -71,6 +71,7 @@ var AppHelpFlagGroups = []flagGroup{
 			utils.DataDirFlag,
 			utils.KeyStoreDirFlag,
 			utils.NoUSBFlag,
+			utils.LedgerLegacyHDDerivationPath,
 			utils.NetworkIdFlag,
 			utils.TestnetFlag,
 			utils.RinkebyFlag,

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -127,6 +127,10 @@ var (
 		Name:  "nousb",
 		Usage: "Disables monitoring for and managing USB hardware wallets",
 	}
+	LedgerLegacyHDDerivationPath = cli.BoolFlag{
+		Name:  "ledgerlegacyhdderivationpath",
+		Usage: "For Ledger Hardware Wallet Use BIP32 to access old derivation path (not supported by Ledger Live anymore) ",
+	}
 	NetworkIdFlag = cli.Uint64Flag{
 		Name:  "networkid",
 		Usage: "Network identifier (integer, 1=Frontier, 2=Morden (disused), 3=Ropsten, 4=Rinkeby)",
@@ -1125,6 +1129,9 @@ func SetNodeConfig(ctx *cli.Context, cfg *node.Config) {
 	}
 	if ctx.GlobalIsSet(NoUSBFlag.Name) {
 		cfg.NoUSB = ctx.GlobalBool(NoUSBFlag.Name)
+	}
+	if ctx.GlobalIsSet(LedgerLegacyHDDerivationPath.Name) {
+		cfg.LedgerLegacyHDDerivationPath = ctx.GlobalBool(LedgerLegacyHDDerivationPath.Name)
 	}
 }
 

--- a/node/config.go
+++ b/node/config.go
@@ -91,6 +91,10 @@ type Config struct {
 	// NoUSB disables hardware wallet monitoring and connectivity.
 	NoUSB bool `toml:",omitempty"`
 
+	// LedgerLegacyHDDerivationPath uses older BIP-32 HD derivation path that has
+	// dropped from Ledger Live in favor of BIP-44.
+	LedgerLegacyHDDerivationPath bool `toml:",omitempty"`
+
 	// IPCPath is the requested location to place the IPC endpoint. If the path is
 	// a simple file name, it is placed inside the data directory (or on the root
 	// pipe path on Windows), whereas if it's a resolvable path name (absolute or

--- a/signer/core/api_test.go
+++ b/signer/core/api_test.go
@@ -124,7 +124,7 @@ func setup(t *testing.T) (*SignerAPI, *headlessUi) {
 	}
 	ui := &headlessUi{make(chan string, 20), make(chan string, 20)}
 	am := StartClefAccountManager(tmpDirName(t), true, true)
-	api := NewSignerAPI(am, 1337, true, ui, db, true, &storage.NoStorage{})
+	api := NewSignerAPI(am, 1337, true, true, ui, db, true, &storage.NoStorage{})
 	return api, ui
 
 }


### PR DESCRIPTION
The legacy BIP-32 is made optional and can be activated using option LedgerLegacyHDDerivationPath in the command line.

I think it makes sense as the official Ledger Live application has switched and used old BIP-32 by default just creates unnecessary entities. There is a commandline option that allows falling back on the old derivation path in case someone needs it.

I understand if the variable names might be seen as less then graceful.

I also have a version for 1.8 that I use locally. I can create separate PR for it if there is any chance for it to get in quicker. [Here](https://github.com/ethereum/go-ethereum/compare/release/1.8...ar-qun:ledger-release).