### PR TITLE
abi: adding the method EventById and its test

### DIFF
--- a/accounts/abi/abi.go
+++ b/accounts/abi/abi.go
@@ -21,6 +21,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+
+	"github.com/ethereum/go-ethereum/common"
 )
 
 // The ABI holds information about a contract's context and available
@@ -144,4 +146,15 @@ func (abi *ABI) MethodById(sigdata []byte) (*Method, error) {
 		}
 	}
 	return nil, fmt.Errorf("no method with id: %#x", sigdata[:4])
+}
+
+// EventById looks up a event by the topic hash
+// returns nil if none found
+func (abi *ABI) EventById(topic common.Hash) (*Event, error) {
+	for _, event := range abi.Events {
+		if event.Id() == topic {
+			return &event, nil
+		}
+	}
+	return nil, fmt.Errorf("no event with topic: %#x", topic.Hex())
 }

--- a/accounts/abi/abi.go
+++ b/accounts/abi/abi.go
@@ -148,13 +148,13 @@ func (abi *ABI) MethodById(sigdata []byte) (*Method, error) {
 	return nil, fmt.Errorf("no method with id: %#x", sigdata[:4])
 }
 
-// EventById looks up a event by the topic hash
+// EventByID looks up a event by the topic hash
 // returns nil if none found
-func (abi *ABI) EventById(topic common.Hash) *Event {
+func (abi *ABI) EventByID(topic common.Hash) (*Event, error) {
 	for _, event := range abi.Events {
-		if event.Id() == topic {
-			return &event
+		if bytes.Equal(event.Id().Bytes(), topic.Bytes()) {
+			return &event, nil
 		}
 	}
-	return nil
+	return nil, fmt.Errorf("no event with id: %#x", topic.Hex())
 }

--- a/accounts/abi/abi.go
+++ b/accounts/abi/abi.go
@@ -148,8 +148,8 @@ func (abi *ABI) MethodById(sigdata []byte) (*Method, error) {
 	return nil, fmt.Errorf("no method with id: %#x", sigdata[:4])
 }
 
-// EventByID looks up a event by the topic hash
-// returns nil if none found
+// EventByID looks an event up by its topic hash in the
+// ABI and returns nil if none found.
 func (abi *ABI) EventByID(topic common.Hash) (*Event, error) {
 	for _, event := range abi.Events {
 		if bytes.Equal(event.Id().Bytes(), topic.Bytes()) {

--- a/accounts/abi/abi.go
+++ b/accounts/abi/abi.go
@@ -150,11 +150,11 @@ func (abi *ABI) MethodById(sigdata []byte) (*Method, error) {
 
 // EventById looks up a event by the topic hash
 // returns nil if none found
-func (abi *ABI) EventById(topic common.Hash) (*Event, error) {
+func (abi *ABI) EventById(topic common.Hash) *Event {
 	for _, event := range abi.Events {
 		if event.Id() == topic {
-			return &event, nil
+			return &event
 		}
 	}
-	return nil, fmt.Errorf("no event with topic: %#x", topic.Hex())
+	return nil
 }

--- a/accounts/abi/abi_test.go
+++ b/accounts/abi/abi_test.go
@@ -745,3 +745,30 @@ func TestABI_MethodById(t *testing.T) {
 		t.Errorf("Expected error, nil is short to decode data")
 	}
 }
+
+func TestABI_EventById(t *testing.T) {
+	const abiJSON = `[
+		{"type":"event","name":"received","anonymous":false,"inputs":[
+			{"indexed":false,"name":"sender","type":"address"},
+			{"indexed":false,"name":"amount","type":"uint256"},
+			{"indexed":false,"name":"memo","type":"bytes"}
+			]
+		}]`
+
+	abi, err := JSON(strings.NewReader(abiJSON))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	topic := "received(address,uint256,bytes)"
+	topicID := crypto.Keccak256Hash([]byte(topic))
+
+	event, err := abi.EventById(topicID)
+	if err != nil {
+		t.Fatalf("Failed to look up ABI event: %v", err)
+	}
+
+	if event.Id() != topicID {
+		t.Errorf("topic %v (id %v) not 'findable' by id in ABI", topic, topicID)
+	}
+}

--- a/accounts/abi/abi_test.go
+++ b/accounts/abi/abi_test.go
@@ -772,8 +772,8 @@ func TestABI_EventById(t *testing.T) {
 		t.Errorf("topic %v (id %v) not 'findable' by id in ABI", topic, topicID)
 	}
 
-	UnknowntopicID := crypto.Keccak256Hash([]byte("unkownEvent"))
-	if _, err := abi.EventById(UnknowntopicID); err == nil {
+	unknowntopicID := crypto.Keccak256Hash([]byte("unknownEvent"))
+	if _, err := abi.EventById(unknowntopicID); err == nil {
 		t.Errorf("Expected error, no matching event id")
 	}
 }

--- a/accounts/abi/abi_test.go
+++ b/accounts/abi/abi_test.go
@@ -757,23 +757,24 @@ func TestABI_EventById(t *testing.T) {
 
 	abi, err := JSON(strings.NewReader(abiJSON))
 	if err != nil {
-		t.Fatal(err)
+		t.Error(err)
 	}
 
 	topic := "received(address,uint256,bytes)"
 	topicID := crypto.Keccak256Hash([]byte(topic))
 
-	event, err := abi.EventById(topicID)
-	if err != nil {
-		t.Fatalf("Failed to look up ABI event: %v", err)
+	event := abi.EventById(topicID)
+	if event == nil {
+		t.Errorf("we should find a event for topic %s", topicID.Hex())
 	}
 
 	if event.Id() != topicID {
-		t.Errorf("topic %v (id %v) not 'findable' by id in ABI", topic, topicID)
+		t.Errorf("event id %s does not match topic %s", event.Id().Hex(), topicID.Hex())
 	}
 
 	unknowntopicID := crypto.Keccak256Hash([]byte("unknownEvent"))
-	if _, err := abi.EventById(unknowntopicID); err == nil {
-		t.Errorf("Expected error, no matching event id")
+	unknownEvent := abi.EventById(unknowntopicID)
+	if unknownEvent != nil {
+		t.Errorf("we should not find any event for topic %s", unknowntopicID.Hex())
 	}
 }

--- a/accounts/abi/abi_test.go
+++ b/accounts/abi/abi_test.go
@@ -747,34 +747,69 @@ func TestABI_MethodById(t *testing.T) {
 }
 
 func TestABI_EventById(t *testing.T) {
-	const abiJSON = `[
-		{"type":"event","name":"received","anonymous":false,"inputs":[
-			{"indexed":false,"name":"sender","type":"address"},
-			{"indexed":false,"name":"amount","type":"uint256"},
-			{"indexed":false,"name":"memo","type":"bytes"}
-			]
-		}]`
-
-	abi, err := JSON(strings.NewReader(abiJSON))
-	if err != nil {
-		t.Error(err)
+	tests := []struct {
+		name  string
+		json  string
+		event string
+	}{
+		{
+			name: "",
+			json: `[
+			{"type":"event","name":"received","anonymous":false,"inputs":[
+				{"indexed":false,"name":"sender","type":"address"},
+				{"indexed":false,"name":"amount","type":"uint256"},
+				{"indexed":false,"name":"memo","type":"bytes"}
+				]
+			}]`,
+			event: "received(address,uint256,bytes)",
+		}, {
+			name: "",
+			json: `[
+				{ "constant": true, "inputs": [], "name": "name", "outputs": [ { "name": "", "type": "string" } ], "payable": false, "stateMutability": "view", "type": "function" },
+				{ "constant": false, "inputs": [ { "name": "_spender", "type": "address" }, { "name": "_value", "type": "uint256" } ], "name": "approve", "outputs": [ { "name": "", "type": "bool" } ], "payable": false, "stateMutability": "nonpayable", "type": "function" },
+				{ "constant": true, "inputs": [], "name": "totalSupply", "outputs": [ { "name": "", "type": "uint256" } ], "payable": false, "stateMutability": "view", "type": "function" },
+				{ "constant": false, "inputs": [ { "name": "_from", "type": "address" }, { "name": "_to", "type": "address" }, { "name": "_value", "type": "uint256" } ], "name": "transferFrom", "outputs": [ { "name": "", "type": "bool" } ], "payable": false, "stateMutability": "nonpayable", "type": "function" },
+				{ "constant": true, "inputs": [], "name": "decimals", "outputs": [ { "name": "", "type": "uint8" } ], "payable": false, "stateMutability": "view", "type": "function" },
+				{ "constant": true, "inputs": [ { "name": "_owner", "type": "address" } ], "name": "balanceOf", "outputs": [ { "name": "balance", "type": "uint256" } ], "payable": false, "stateMutability": "view", "type": "function" },
+				{ "constant": true, "inputs": [], "name": "symbol", "outputs": [ { "name": "", "type": "string" } ], "payable": false, "stateMutability": "view", "type": "function" },
+				{ "constant": false, "inputs": [ { "name": "_to", "type": "address" }, { "name": "_value", "type": "uint256" } ], "name": "transfer", "outputs": [ { "name": "", "type": "bool" } ], "payable": false, "stateMutability": "nonpayable", "type": "function" },
+				{ "constant": true, "inputs": [ { "name": "_owner", "type": "address" }, { "name": "_spender", "type": "address" } ], "name": "allowance", "outputs": [ { "name": "", "type": "uint256" } ], "payable": false, "stateMutability": "view", "type": "function" },
+				{ "payable": true, "stateMutability": "payable", "type": "fallback" },
+				{ "anonymous": false, "inputs": [ { "indexed": true, "name": "owner", "type": "address" }, { "indexed": true, "name": "spender", "type": "address" }, { "indexed": false, "name": "value", "type": "uint256" } ], "name": "Approval", "type": "event" },
+				{ "anonymous": false, "inputs": [ { "indexed": true, "name": "from", "type": "address" }, { "indexed": true, "name": "to", "type": "address" }, { "indexed": false, "name": "value", "type": "uint256" } ], "name": "Transfer", "type": "event" }
+			]`,
+			event: "Transfer(address,address,uint256)",
+		},
 	}
 
-	topic := "received(address,uint256,bytes)"
-	topicID := crypto.Keccak256Hash([]byte(topic))
+	for testnum, test := range tests {
+		abi, err := JSON(strings.NewReader(test.json))
+		if err != nil {
+			t.Error(err)
+		}
 
-	event := abi.EventById(topicID)
-	if event == nil {
-		t.Errorf("we should find a event for topic %s", topicID.Hex())
-	}
+		topic := test.event
+		topicID := crypto.Keccak256Hash([]byte(topic))
 
-	if event.Id() != topicID {
-		t.Errorf("event id %s does not match topic %s", event.Id().Hex(), topicID.Hex())
-	}
+		event, err := abi.EventByID(topicID)
+		if err != nil {
+			t.Fatalf("Failed to look up ABI method: %v, test #%d", err, testnum)
+		}
+		if event == nil {
+			t.Errorf("We should find a event for topic %s, test #%d", topicID.Hex(), testnum)
+		}
 
-	unknowntopicID := crypto.Keccak256Hash([]byte("unknownEvent"))
-	unknownEvent := abi.EventById(unknowntopicID)
-	if unknownEvent != nil {
-		t.Errorf("we should not find any event for topic %s", unknowntopicID.Hex())
+		if event.Id() != topicID {
+			t.Errorf("Event id %s does not match topic %s, test #%d", event.Id().Hex(), topicID.Hex(), testnum)
+		}
+
+		unknowntopicID := crypto.Keccak256Hash([]byte("unknownEvent"))
+		unknownEvent, err := abi.EventByID(unknowntopicID)
+		if err == nil {
+			t.Errorf("EventByID should return an error if a topic is not found, test #%d", testnum)
+		}
+		if unknownEvent != nil {
+			t.Errorf("We should not find any event for topic %s, test #%d", unknowntopicID.Hex(), testnum)
+		}
 	}
 }

--- a/accounts/abi/abi_test.go
+++ b/accounts/abi/abi_test.go
@@ -771,4 +771,9 @@ func TestABI_EventById(t *testing.T) {
 	if event.Id() != topicID {
 		t.Errorf("topic %v (id %v) not 'findable' by id in ABI", topic, topicID)
 	}
+
+	UnknowntopicID := crypto.Keccak256Hash([]byte("unkownEvent"))
+	if _, err := abi.EventById(UnknowntopicID); err == nil {
+		t.Errorf("Expected error, no matching event id")
+	}
 }


### PR DESCRIPTION
adding the method `EventById` to the ABI, that allows to retrieve the event given a topic hash. Use case is similar to the method `MethodById`: given a transactoionReceipt with a log slice and the contract ABI, `EventById` returns the corresponding event "object" matching the log's topic field.