### PR TITLE
tests: run state subtests in parallel

### DIFF
--- a/tests/state_test.go
+++ b/tests/state_test.go
@@ -59,6 +59,8 @@ func TestState(t *testing.T) {
 			key := fmt.Sprintf("%s/%d", subtest.Fork, subtest.Index)
 			name := name + "/" + key
 			t.Run(key, func(t *testing.T) {
+				t.Parallel()
+
 				withTrace(t, test.gasLimit(subtest), func(vmconfig vm.Config) error {
 					_, err := test.Run(subtest, vmconfig)
 					return st.checkFailure(t, name, err)


### PR DESCRIPTION
The tests with `tests/` consume a significant amount of total test runtime (~25% currently). 