### PR TITLE
Update flags.go

### DIFF
--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -167,7 +167,7 @@ var (
 	}
 	ExitWhenSyncedFlag = cli.BoolFlag{
 		Name:  "exitwhensynced",
-		Usage: "Exists syncing after block synchronisation",
+		Usage: "Exits after block synchronisation completes",
 	}
 	ULCModeConfigFlag = cli.StringFlag{
 		Name:  "ulc.config",


### PR DESCRIPTION
Corrected error for ExitWhenSyncedFlag, clarifying that the program exits after syncing completes.