### PR TITLE
p2p/rlpx.go: remove useless parameter

### DIFF
--- a/p2p/rlpx.go
+++ b/p2p/rlpx.go
@@ -128,7 +128,7 @@ func (t *rlpx) doProtoHandshake(our *protoHandshake) (their *protoHandshake, err
 	// as the error so it can be tracked elsewhere.
 	werr := make(chan error, 1)
 	go func() { werr <- Send(t.rw, handshakeMsg, our) }()
-	if their, err = readProtocolHandshake(t.rw, our); err != nil {
+	if their, err = readProtocolHandshake(t.rw); err != nil {
 		<-werr // make sure the write terminates too
 		return nil, err
 	}
@@ -141,7 +141,7 @@ func (t *rlpx) doProtoHandshake(our *protoHandshake) (their *protoHandshake, err
 	return their, nil
 }
 
-func readProtocolHandshake(rw MsgReader, our *protoHandshake) (*protoHandshake, error) {
+func readProtocolHandshake(rw MsgReader) (*protoHandshake, error) {
 	msg, err := rw.ReadMsg()
 	if err != nil {
 		return nil, err

--- a/p2p/rlpx_test.go
+++ b/p2p/rlpx_test.go
@@ -258,7 +258,7 @@ func TestProtocolHandshakeErrors(t *testing.T) {
 	for i, test := range tests {
 		p1, p2 := MsgPipe()
 		go Send(p1, test.code, test.msg)
-		_, err := readProtocolHandshake(p2, our)
+		_, err := readProtocolHandshake(p2)
 		if !reflect.DeepEqual(err, test.err) {
 			t.Errorf("test %d: error mismatch: got %q, want %q", i, err, test.err)
 		}

--- a/p2p/rlpx_test.go
+++ b/p2p/rlpx_test.go
@@ -221,8 +221,7 @@ func TestProtocolHandshake(t *testing.T) {
 	wg.Wait()
 }
 
-func TestProtocolHandshakeErrors(t *testing.T) {
-	our := &protoHandshake{Version: 3, Caps: []Cap{{"foo", 2}, {"bar", 3}}, Name: "quux"}
+func TestProtocolHandshakeErrors(t *testing.T) {	
 	tests := []struct {
 		code uint64
 		msg  interface{}


### PR DESCRIPTION
remove useless parameter