### PR TITLE
eth, les, geth: implement cli-configurable global gas cap for RPC calls

### DIFF
--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -57,7 +57,6 @@ var (
 		utils.IdentityFlag,
 		utils.UnlockedAccountFlag,
 		utils.PasswordFileFlag,
-		utils.InsecureUnlockAllowedFlag,
 		utils.BootnodesFlag,
 		utils.BootnodesV4Flag,
 		utils.BootnodesV5Flag,
@@ -136,8 +135,6 @@ var (
 		utils.VMEnableDebugFlag,
 		utils.NetworkIdFlag,
 		utils.ConstantinopleOverrideFlag,
-		utils.RPCCORSDomainFlag,
-		utils.RPCVirtualHostsFlag,
 		utils.EthStatsURLFlag,
 		utils.FakePoWFlag,
 		utils.NoCompactionFlag,
@@ -152,6 +149,8 @@ var (
 		utils.RPCEnabledFlag,
 		utils.RPCListenAddrFlag,
 		utils.RPCPortFlag,
+		utils.RPCCORSDomainFlag,
+		utils.RPCVirtualHostsFlag,
 		utils.GraphQLEnabledFlag,
 		utils.GraphQLListenAddrFlag,
 		utils.GraphQLPortFlag,
@@ -165,6 +164,8 @@ var (
 		utils.WSAllowedOriginsFlag,
 		utils.IPCDisabledFlag,
 		utils.IPCPathFlag,
+		utils.InsecureUnlockAllowedFlag,
+		utils.RPCGlobalGasCap,
 	}
 
 	whisperFlags = []cli.Flag{

--- a/cmd/geth/usage.go
+++ b/cmd/geth/usage.go
@@ -158,6 +158,7 @@ var AppHelpFlagGroups = []flagGroup{
 			utils.RPCListenAddrFlag,
 			utils.RPCPortFlag,
 			utils.RPCApiFlag,
+			utils.RPCGlobalGasCap,
 			utils.WSEnabledFlag,
 			utils.WSListenAddrFlag,
 			utils.WSPortFlag,

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -448,6 +448,10 @@ var (
 		Name:  "allow-insecure-unlock",
 		Usage: "Allow insecure account unlocking when account-related RPCs are exposed by http",
 	}
+	RPCGlobalGasCap = cli.Uint64Flag{
+		Name:  "rpc.gascap",
+		Usage: "Sets a cap on gas that can be used in eth_call/estimateGas",
+	}
 	// Logging and debug settings
 	EthStatsURLFlag = cli.StringFlag{
 		Name:  "ethstats",
@@ -1399,6 +1403,9 @@ func SetEthConfig(ctx *cli.Context, stack *node.Node, cfg *eth.Config) {
 
 	if ctx.GlobalIsSet(EVMInterpreterFlag.Name) {
 		cfg.EVMInterpreter = ctx.GlobalString(EVMInterpreterFlag.Name)
+	}
+	if ctx.GlobalIsSet(RPCGlobalGasCap.Name) {
+		cfg.RPCGasCap = new(big.Int).SetUint64(ctx.GlobalUint64(RPCGlobalGasCap.Name))
 	}
 
 	// Override any default configs for hard coded networks.

--- a/eth/api_backend.go
+++ b/eth/api_backend.go
@@ -218,6 +218,10 @@ func (b *EthAPIBackend) ExtRPCEnabled() bool {
 	return b.extRPCEnabled
 }
 
+func (b *EthAPIBackend) RPCGasCap() *big.Int {
+	return b.eth.config.RPCGasCap
+}
+
 func (b *EthAPIBackend) BloomStatus() (uint64, uint64) {
 	sections, _, _ := b.eth.bloomIndexer.Sections()
 	return params.BloomBitsBlocks, sections

--- a/eth/config.go
+++ b/eth/config.go
@@ -151,6 +151,9 @@ type Config struct {
 
 	// Constantinople block override (TODO: remove after the fork)
 	ConstantinopleOverride *big.Int
+
+	// RPCGasCap is the global gas cap for eth-call variants.
+	RPCGasCap *big.Int `toml:",omitempty"`
 }
 
 type configMarshaling struct {

--- a/graphql/graphql.go
+++ b/graphql/graphql.go
@@ -856,7 +856,7 @@ func (b *Block) Call(ctx context.Context, args struct {
 		}
 	}
 
-	result, gas, failed, err := ethapi.DoCall(ctx, b.backend, args.Data, *b.num, vm.Config{}, 5*time.Second)
+	result, gas, failed, err := ethapi.DoCall(ctx, b.backend, args.Data, *b.num, vm.Config{}, 5*time.Second, b.backend.RPCGasCap())
 	status := hexutil.Uint64(1)
 	if failed {
 		status = 0
@@ -883,7 +883,7 @@ func (b *Block) EstimateGas(ctx context.Context, args struct {
 		}
 	}
 
-	gas, err := ethapi.DoEstimateGas(ctx, b.backend, args.Data, *b.num)
+	gas, err := ethapi.DoEstimateGas(ctx, b.backend, args.Data, *b.num, b.backend.RPCGasCap())
 	return gas, err
 }
 
@@ -927,7 +927,7 @@ func (p *Pending) Account(ctx context.Context, args struct {
 func (p *Pending) Call(ctx context.Context, args struct {
 	Data ethapi.CallArgs
 }) (*CallResult, error) {
-	result, gas, failed, err := ethapi.DoCall(ctx, p.backend, args.Data, rpc.PendingBlockNumber, vm.Config{}, 5*time.Second)
+	result, gas, failed, err := ethapi.DoCall(ctx, p.backend, args.Data, rpc.PendingBlockNumber, vm.Config{}, 5*time.Second, p.backend.RPCGasCap())
 	status := hexutil.Uint64(1)
 	if failed {
 		status = 0
@@ -942,7 +942,7 @@ func (p *Pending) Call(ctx context.Context, args struct {
 func (p *Pending) EstimateGas(ctx context.Context, args struct {
 	Data ethapi.CallArgs
 }) (hexutil.Uint64, error) {
-	return ethapi.DoEstimateGas(ctx, p.backend, args.Data, rpc.PendingBlockNumber)
+	return ethapi.DoEstimateGas(ctx, p.backend, args.Data, rpc.PendingBlockNumber, p.backend.RPCGasCap())
 }
 
 // Resolver is the top-level object in the GraphQL hierarchy.

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -698,7 +698,7 @@ func DoCall(ctx context.Context, b Backend, args CallArgs, blockNr rpc.BlockNumb
 		gas = uint64(*args.Gas)
 	}
 	if globalGasCap != nil && globalGasCap.Uint64() < gas {
-		log.Warn("Applying cap on gas, caller requested amount above limit", "cap", globalGasCap, "attempted", gas)
+		log.Warn("Caller gas above allowance, capping", "requested", gas, "cap", globalGasCap)
 		gas = globalGasCap.Uint64()
 	}
 	gasPrice := new(big.Int).SetUint64(defaultGasPrice)
@@ -778,7 +778,7 @@ func DoEstimateGas(ctx context.Context, b Backend, args CallArgs, blockNr rpc.Bl
 		hi = block.GasLimit()
 	}
 	if gasCap != nil && hi > gasCap.Uint64() {
-		log.Warn("Applying cap on gas, caller requested amount above limit", "cap", gasCap, "attempted", hi)
+		log.Warn("Caller gas above allowance, capping", "requested", hi, "cap", gasCap)
 		hi = gasCap.Uint64()
 	}
 	cap = hi

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -674,7 +674,7 @@ type CallArgs struct {
 	Data     *hexutil.Bytes  `json:"data"`
 }
 
-func DoCall(ctx context.Context, b Backend, args CallArgs, blockNr rpc.BlockNumber, vmCfg vm.Config, timeout time.Duration) ([]byte, uint64, bool, error) {
+func DoCall(ctx context.Context, b Backend, args CallArgs, blockNr rpc.BlockNumber, vmCfg vm.Config, timeout time.Duration, globalGasCap *big.Int) ([]byte, uint64, bool, error) {
 	defer func(start time.Time) { log.Debug("Executing EVM call finished", "runtime", time.Since(start)) }(time.Now())
 
 	state, header, err := b.StateAndHeaderByNumber(ctx, blockNr)
@@ -696,6 +696,10 @@ func DoCall(ctx context.Context, b Backend, args CallArgs, blockNr rpc.BlockNumb
 	gas := uint64(math.MaxUint64 / 2)
 	if args.Gas != nil {
 		gas = uint64(*args.Gas)
+	}
+	if globalGasCap != nil && globalGasCap.Uint64() < gas {
+		log.Warn("Applying cap on gas, caller requested amount above limit", "cap", globalGasCap, "attempted", gas)
+		gas = globalGasCap.Uint64()
 	}
 	gasPrice := new(big.Int).SetUint64(defaultGasPrice)
 	if args.GasPrice != nil {
@@ -752,25 +756,11 @@ func DoCall(ctx context.Context, b Backend, args CallArgs, blockNr rpc.BlockNumb
 // Call executes the given transaction on the state for the given block number.
 // It doesn't make and changes in the state/blockchain and is useful to execute and retrieve values.
 func (s *PublicBlockChainAPI) Call(ctx context.Context, args CallArgs, blockNr rpc.BlockNumber) (hexutil.Bytes, error) {
-	if gasCap := s.b.RPCGasCap(); gasCap != nil {
-		if new(big.Int).SetUint64(uint64(*args.Gas)).Cmp(gasCap) > 0 {
-			log.Warn("Applying cap on gas, caller requested amount above limit", "cap", gasCap, "requested", args.Gas)
-			newGas := hexutil.Uint64(gasCap.Uint64())
-			*args.Gas = newGas
-		}
-		result, _, _, err := DoCall(ctx, s.b, args, blockNr, vm.Config{}, 5*time.Second)
-		if err != nil {
-			err = fmt.Errorf("%v (gas capped at: %d)", err, *args.Gas)
-		}
-		return (hexutil.Bytes)(result), err
-	} else {
-		result, _, _, err := DoCall(ctx, s.b, args, blockNr, vm.Config{}, 5*time.Second)
-		return (hexutil.Bytes)(result), err
-	}
-
+	result, _, _, err := DoCall(ctx, s.b, args, blockNr, vm.Config{}, 5*time.Second, s.b.RPCGasCap())
+	return (hexutil.Bytes)(result), err
 }
 
-func DoEstimateGas(ctx context.Context, b Backend, args CallArgs, blockNr rpc.BlockNumber) (hexutil.Uint64, error) {
+func DoEstimateGas(ctx context.Context, b Backend, args CallArgs, blockNr rpc.BlockNumber, gasCap *big.Int) (hexutil.Uint64, error) {
 	// Binary search the gas requirement, as it may be higher than the amount used
 	var (
 		lo  uint64 = params.TxGas - 1
@@ -787,13 +777,17 @@ func DoEstimateGas(ctx context.Context, b Backend, args CallArgs, blockNr rpc.Bl
 		}
 		hi = block.GasLimit()
 	}
+	if gasCap != nil && hi > gasCap.Uint64() {
+		log.Warn("Applying cap on gas, caller requested amount above limit", "cap", gasCap, "attempted", hi)
+		hi = gasCap.Uint64()
+	}
 	cap = hi
 
 	// Create a helper to check if a gas allowance results in an executable transaction
 	executable := func(gas uint64) bool {
 		args.Gas = (*hexutil.Uint64)(&gas)
 
-		_, _, failed, err := DoCall(ctx, b, args, rpc.PendingBlockNumber, vm.Config{}, 0)
+		_, _, failed, err := DoCall(ctx, b, args, rpc.PendingBlockNumber, vm.Config{}, 0, gasCap)
 		if err != nil || failed {
 			return false
 		}
@@ -820,14 +814,7 @@ func DoEstimateGas(ctx context.Context, b Backend, args CallArgs, blockNr rpc.Bl
 // EstimateGas returns an estimate of the amount of gas needed to execute the
 // given transaction against the current pending block.
 func (s *PublicBlockChainAPI) EstimateGas(ctx context.Context, args CallArgs) (hexutil.Uint64, error) {
-	if gasCap := s.b.RPCGasCap(); gasCap != nil {
-		if new(big.Int).SetUint64(uint64(*args.Gas)).Cmp(gasCap) > 0 {
-			log.Warn("Applying cap on gas, caller requested amount above limit", "cap", gasCap, "requested", args.Gas)
-			newGas := hexutil.Uint64(gasCap.Uint64())
-			*args.Gas = newGas
-		}
-	}
-	return DoEstimateGas(ctx, s.b, args, rpc.PendingBlockNumber)
+	return DoEstimateGas(ctx, s.b, args, rpc.PendingBlockNumber, s.b.RPCGasCap())
 }
 
 // ExecutionResult groups all structured logs emitted by the EVM

--- a/internal/ethapi/backend.go
+++ b/internal/ethapi/backend.go
@@ -45,6 +45,7 @@ type Backend interface {
 	EventMux() *event.TypeMux
 	AccountManager() *accounts.Manager
 	ExtRPCEnabled() bool
+	RPCGasCap() *big.Int // global gas cap for eth_call over rpc: DoS protection
 
 	// BlockChain API
 	SetHead(number uint64)

--- a/les/api_backend.go
+++ b/les/api_backend.go
@@ -192,6 +192,10 @@ func (b *LesApiBackend) ExtRPCEnabled() bool {
 	return b.extRPCEnabled
 }
 
+func (b *LesApiBackend) RPCGasCap() *big.Int {
+	return b.eth.config.RPCGasCap
+}
+
 func (b *LesApiBackend) BloomStatus() (uint64, uint64) {
 	if b.eth.bloomIndexer == nil {
 		return 0, 0


### PR DESCRIPTION
This PR adds a CLI-configurable global gas cap on `eth_call` and `eth_estimateGas`. Although node operators should not expose rpc api to untrusted users (like, the internet), even with http level load balancing in front it is difficult to protect against dos via eth_call variants.
 
This makes it possible to enforce a cap on the gas that a caller can use, by using the flag `rpc.gascap`

## eth_call

Start geth
```
build/bin/geth --dev --rpc --rpc.gascap 33000
```
Caller:
```
[user@work go-ethereum]$ curl 127.0.0.1:8545 -H "Content-Type: application/json" --data '{"jsonrpc":"2.0","id":1,"method":"eth_call","params":[{"data":"0x641fffffffe06000f3","gas":"0xffffffffffffffff"},"latest"]}'
{"jsonrpc":"2.0","id":1,"error":{"code":-32000,"message":"out of gas (gas capped at: 33000)"}}

```
Server: 
```
WARN [04-05|11:54:35.515] Applying cap on gas, caller requested amount above limit cap=33000 requested=0xffffffffffffffff
WARN [04-05|11:54:35.515] Served eth_call                          conn=127.0.0.1:44770 reqid=1 t=325.624µs err="out of gas (gas capped at: 33000)"
```

## eth_estimategas

caller
```
[user@work go-ethereum]$ curl  127.0.0.1:8545 -H "Content-Type: application/json" --data '{"jsonrpc":"2.0","id":1,"method":"eth_estimateGas","params":[{"data":"0x641fffffffe06000f3","gas":"0xffffffffffffffff"}]}'
{"jsonrpc":"2.0","id":1,"error":{"code":-32000,"message":"gas required exceeds allowance (33000) or always failing transaction"}}
```
server
```
WARN [04-05|11:56:46.578] Applying cap on gas, caller requested amount above limit cap=33000 requested=0xffffffffffffffff
WARN [04-05|11:56:46.579] Served eth_estimateGas                   conn=127.0.0.1:44786 reqid=1 t=983.184µs err="gas required exceeds allowance (33000) or always failing transaction"
```