### PR TITLE
rpc: cancel root context after all requests are served

### DIFF
--- a/rpc/handler.go
+++ b/rpc/handler.go
@@ -151,8 +151,8 @@ func (h *handler) handleMsg(msg *jsonrpcMessage) {
 // call goroutines to shut down.
 func (h *handler) close(err error, inflightReq *requestOp) {
 	h.cancelAllRequests(err, inflightReq)
-	h.cancelRoot()
 	h.callWG.Wait()
+	h.cancelRoot()
 	h.cancelServerSubscriptions(err)
 }
 


### PR DESCRIPTION
Fix #19428 #19429  #19409