### PR TITLE
accounts, cmd, internal, signer: add note about backing up the keystore

### DIFF
--- a/accounts/keystore/key.go
+++ b/accounts/keystore/key.go
@@ -179,8 +179,6 @@ func storeNewKey(ks keyStore, rand io.Reader, auth string) (*Key, accounts.Accou
 		zeroKey(key.PrivateKey)
 		return nil, a, err
 	}
-	fmt.Printf("Your new key is generated. Please backup the key file: %s\n", a.URL)
-
 	return key, a, err
 }
 

--- a/accounts/keystore/key.go
+++ b/accounts/keystore/key.go
@@ -179,6 +179,8 @@ func storeNewKey(ks keyStore, rand io.Reader, auth string) (*Key, accounts.Accou
 		zeroKey(key.PrivateKey)
 		return nil, a, err
 	}
+	fmt.Printf("Your new key is generated. Please backup the key file: %s\n", a.URL)
+
 	return key, a, err
 }
 

--- a/accounts/keystore/passphrase.go
+++ b/accounts/keystore/passphrase.go
@@ -38,6 +38,7 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/ethereum/go-ethereum/accounts"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/math"
 	"github.com/ethereum/go-ethereum/crypto"
@@ -97,9 +98,9 @@ func (ks keyStorePassphrase) GetKey(addr common.Address, filename, auth string) 
 }
 
 // StoreKey generates a key, encrypts with 'auth' and stores in the given directory
-func StoreKey(dir, auth string, scryptN, scryptP int) (common.Address, error) {
+func StoreKey(dir, auth string, scryptN, scryptP int) (accounts.Account, error) {
 	_, a, err := storeNewKey(&keyStorePassphrase{dir, scryptN, scryptP, false}, rand.Reader, auth)
-	return a.Address, err
+	return a, err
 }
 
 func (ks keyStorePassphrase) StoreKey(filename string, key *Key, auth string) error {

--- a/cmd/geth/accountcmd.go
+++ b/cmd/geth/accountcmd.go
@@ -307,12 +307,13 @@ func accountCreate(ctx *cli.Context) error {
 
 	password := getPassPhrase("Your new account is locked with a password. Please give a password. Do not forget this password.", true, 0, utils.MakePasswordList(ctx))
 
-	address, err := keystore.StoreKey(keydir, password, scryptN, scryptP)
+	account, err := keystore.StoreKey(keydir, password, scryptN, scryptP)
 
 	if err != nil {
 		utils.Fatalf("Failed to create account: %v", err)
 	}
-	fmt.Printf("Address: {%x}\n", address)
+	fmt.Printf("Your new key is generated. Please backup the key file: %s\n", account.URL.Path)
+	fmt.Printf("Address: {%x}\n", account.Address)
 	return nil
 }
 

--- a/cmd/geth/accountcmd.go
+++ b/cmd/geth/accountcmd.go
@@ -312,8 +312,11 @@ func accountCreate(ctx *cli.Context) error {
 	if err != nil {
 		utils.Fatalf("Failed to create account: %v", err)
 	}
-	fmt.Printf("Your new key is generated. Please backup the key file: %s\n", account.URL.Path)
+	fmt.Printf("Your new key was generated\n")
 	fmt.Printf("Address: {%x}\n", account.Address)
+	fmt.Printf("Please backup your key file!\n")
+	fmt.Printf("Path:    {%s}\n", account.URL.Path)
+	fmt.Printf("Please remember your password!\n")
 	return nil
 }
 

--- a/cmd/geth/accountcmd.go
+++ b/cmd/geth/accountcmd.go
@@ -312,11 +312,13 @@ func accountCreate(ctx *cli.Context) error {
 	if err != nil {
 		utils.Fatalf("Failed to create account: %v", err)
 	}
-	fmt.Printf("Your new key was generated\n")
-	fmt.Printf("Address: {%x}\n", account.Address)
-	fmt.Printf("Please backup your key file!\n")
-	fmt.Printf("Path:    {%s}\n", account.URL.Path)
-	fmt.Printf("Please remember your password!\n")
+	fmt.Printf("\nYour new key was generated\n\n")
+	fmt.Printf("Public address of the key:   %s\n", account.Address.Hex())
+	fmt.Printf("Path of the secret key file: %s\n\n", account.URL.Path)
+	fmt.Printf("- You can share your public address with anyone. Others need it to interact with you.\n")
+	fmt.Printf("- You must NEVER share the secret key with anyone! The key controls access to your funds!\n")
+	fmt.Printf("- You must BACKUP your key file! Without the key, it's impossible to access account funds!\n")
+	fmt.Printf("- You must REMEMBER your password! Without the password, it's impossible to decrypt the key!\n\n")
 	return nil
 }
 

--- a/cmd/geth/accountcmd_test.go
+++ b/cmd/geth/accountcmd_test.go
@@ -74,8 +74,18 @@ Your new account is locked with a password. Please give a password. Do not forge
 !! Unsupported terminal, password will be echoed.
 Passphrase: {{.InputLine "foobar"}}
 Repeat passphrase: {{.InputLine "foobar"}}
+
+Your new key was generated
 `)
-	geth.ExpectRegexp(`Address: \{[0-9a-f]{40}\}\n`)
+	geth.ExpectRegexp(`
+Public address of the key:   0x[0-9a-fA-F]{40}
+Path of the secret key file: .*UTC--.+--[0-9a-f]{40}
+
+- You can share your public address with anyone. Others need it to interact with you.
+- You must NEVER share the secret key with anyone! The key controls access to your funds!
+- You must BACKUP your key file! Without the key, it's impossible to access account funds!
+- You must REMEMBER your password! Without the password, it's impossible to decrypt the key!
+`)
 }
 
 func TestAccountNewBadRepeat(t *testing.T) {

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -295,6 +295,7 @@ func (s *PrivateAccountAPI) DeriveAccount(url string, path string, pin *bool) (a
 func (s *PrivateAccountAPI) NewAccount(password string) (common.Address, error) {
 	acc, err := fetchKeystore(s.am).NewAccount(password)
 	if err == nil {
+		log.Info("Your new key is generated. Please backup the key file", "path", acc.URL.Path)
 		return acc.Address, nil
 	}
 	return common.Address{}, err

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -295,7 +295,9 @@ func (s *PrivateAccountAPI) DeriveAccount(url string, path string, pin *bool) (a
 func (s *PrivateAccountAPI) NewAccount(password string) (common.Address, error) {
 	acc, err := fetchKeystore(s.am).NewAccount(password)
 	if err == nil {
-		log.Info("Your new key is generated. Please backup the key file", "path", acc.URL.Path)
+		log.Info("Your new key was generated", "address", acc.Address)
+		log.Warn("Please backup your key file!", "path", acc.URL.Path)
+		log.Warn("Please remember your password!")
 		return acc.Address, nil
 	}
 	return common.Address{}, err

--- a/signer/core/api.go
+++ b/signer/core/api.go
@@ -392,6 +392,7 @@ func (api *SignerAPI) New(ctx context.Context) (common.Address, error) {
 		} else {
 			// No error
 			acc, err := be[0].(*keystore.KeyStore).NewAccount(resp.Text)
+			log.Info("Your new key is generated. Please backup the key file", "path", acc.URL.Path)
 			return acc.Address, err
 		}
 	}

--- a/signer/core/api.go
+++ b/signer/core/api.go
@@ -392,7 +392,9 @@ func (api *SignerAPI) New(ctx context.Context) (common.Address, error) {
 		} else {
 			// No error
 			acc, err := be[0].(*keystore.KeyStore).NewAccount(resp.Text)
-			log.Info("Your new key is generated. Please backup the key file", "path", acc.URL.Path)
+			log.Info("Your new key was generated", "address", acc.Address)
+			log.Warn("Please backup your key file!", "path", acc.URL.Path)
+			log.Warn("Please remember your password!")
 			return acc.Address, err
 		}
 	}


### PR DESCRIPTION
Fixes https://github.com/ethereum/go-ethereum/issues/19165

Running `geth account new`:

```
Your new account is locked with a password. Please give a password. Do not forget this password.
Passphrase: 
Repeat passphrase: 
Your new key was generated
Address: {adbb1348ab38e354ca79f7284701d701d02b351c}
Please backup your key file!
Path:    {/home/user/.ethereum/keystore/UTC--2019-04-25T11-07-21.800464724Z--adbb1348ab38e354ca79f7284701d701d02b351c}
Please remember your password!
``` 

In `geth console` running `personal.newAccount()`:

```
Passphrase: 
Repeat passphrase: 
INFO [04-25|13:53:24.946] Your new key was generated               address=0xbD8603B63EaC7633987e1F331D542a5e99dA4418
WARN [04-25|13:53:24.946] Please backup your key file!             path=/home/user/.ethereum/rinkeby/keystore/UTC--2019-04-25T10-53-23.649181805Z--bd8603b63eac7633987e1f331d542a5e99da4418
WARN [04-25|13:53:24.946] Please remember your password! 
"0xbd8603b63eac7633987e1f331d542a5e99da4418"

```

`clef`:
```
curl -H "Content-Type: application/json" -X POST --data "{\"jsonrpc\":\"2.0\",\"method\":\"account_new\", \"id\":67}" http://localhost:8550/
```

```
-------- New Account request--------------

A request has been made to create a new account. 
Approving this operation means that a new account is created,
and the address is returned to the external caller

Request context:
	127.0.0.1:58370 -> HTTP/1.1 -> localhost:8550

Additional HTTP header data, provided by the external caller:
	User-Agent: curl/7.58.0
	Origin: 
Approve? [y/N]:
> y
## New account password

Please enter a password for the new account to be created (attempt 0 of 3)
> -----------------------
INFO [04-25|13:59:59.010] Your new key was generated               address=0xD84f83cdf440061b7259dCb1EC39b83B747836C6
WARN [04-25|13:59:59.010] Please backup your key file!             path=/home/user/.ethereum/keystore/UTC--2019-04-25T10-59-57.750166407Z--d84f83cdf440061b7259dcb1ec39b83b747836c6
WARN [04-25|13:59:59.010] Please remember your password!
```