### PR TITLE
accounts/scwallet: fix card pairing instruction message

### DIFF
--- a/accounts/scwallet/wallet.go
+++ b/accounts/scwallet/wallet.go
@@ -303,7 +303,7 @@ func (w *Wallet) Status() (string, error) {
 
 	// If the card is not paired, we can only wait
 	if !w.session.paired() {
-		return "Unpaired, waiting for PUK", nil
+		return "Unpaired, waiting for pairing password", nil
 	}
 	// Yay, we have an encrypted session, retrieve the actual status
 	status, err := w.session.walletStatus()


### PR DESCRIPTION
When the user need to pair their smartcard, je message currently displayed is `Unpaired, waiting for PUK`, which corresponds to an older version of the card app. Later versions expect a pairing password, so this PR makes sure the correct instruction is displayed.