### PR TITLE
node: do not continue if 'signer' is used but connection fails

### DIFF
--- a/node/config.go
+++ b/node/config.go
@@ -482,7 +482,7 @@ func makeAccountManager(conf *Config) (*accounts.Manager, string, error) {
 		if extapi, err := external.NewExternalBackend(conf.ExternalSigner); err == nil {
 			backends = append(backends, extapi)
 		} else {
-			log.Info("Error configuring external signer", "error", err)
+			return nil, "", fmt.Errorf("error connecting to external signer: %v", err)
 		}
 	}
 	if len(backends) == 0 {


### PR DESCRIPTION
If `--signer` is used, currently geth will continue without the external signer in case the external signer is not present (ipc not present or http port not open). This PR changes it so that geth fails instead of falling back to local keystore. 