### PR TITLE
cmd/swarm: fix resource leaks in tests

### DIFF
--- a/cmd/swarm/run_test.go
+++ b/cmd/swarm/run_test.go
@@ -59,15 +59,6 @@ func init() {
 
 const clusterSize = 3
 
-var clusteronce sync.Once
-var cluster *testCluster
-
-func initCluster(t *testing.T) {
-	clusteronce.Do(func() {
-		cluster = newTestCluster(t, clusterSize)
-	})
-}
-
 func serverFunc(api *api.API) swarmhttp.TestServer {
 	return swarmhttp.NewServer(api, "")
 }

--- a/cmd/swarm/run_test.go
+++ b/cmd/swarm/run_test.go
@@ -165,10 +165,8 @@ outer:
 }
 
 func (c *testCluster) Shutdown() {
-	for _, node := range c.Nodes {
-		node.Shutdown()
-	}
-	os.RemoveAll(c.TmpDir)
+	c.Stop()
+	c.Cleanup()
 }
 
 func (c *testCluster) Stop() {
@@ -179,16 +177,35 @@ func (c *testCluster) Stop() {
 
 func (c *testCluster) StartNewNodes(t *testing.T, size int) {
 	c.Nodes = make([]*testNode, 0, size)
+
+	errors := make(chan error, size)
+	nodes := make(chan *testNode, size)
 	for i := 0; i < size; i++ {
-		dir := filepath.Join(c.TmpDir, fmt.Sprintf("swarm%02d", i))
-		if err := os.Mkdir(dir, 0700); err != nil {
-			t.Fatal(err)
+		go func(nodeIndex int) {
+			dir := filepath.Join(c.TmpDir, fmt.Sprintf("swarm%02d", nodeIndex))
+			if err := os.Mkdir(dir, 0700); err != nil {
+				errors <- err
+				return
+			}
+
+			node := newTestNode(t, dir)
+			node.Name = fmt.Sprintf("swarm%02d", nodeIndex)
+			nodes <- node
+		}(i)
+	}
+
+	for i := 0; i < size; i++ {
+		select {
+		case node := <-nodes:
+			c.Nodes = append(c.Nodes, node)
+		case err := <-errors:
+			t.Error(err)
 		}
+	}
 
-		node := newTestNode(t, dir)
-		node.Name = fmt.Sprintf("swarm%02d", i)
-
-		c.Nodes = append(c.Nodes, node)
+	if t.Failed() {
+		c.Shutdown()
+		t.FailNow()
 	}
 }
 

--- a/swarm/api/client/client_test.go
+++ b/swarm/api/client/client_test.go
@@ -25,6 +25,8 @@ import (
 	"sort"
 	"testing"
 
+	"github.com/ethereum/go-ethereum/swarm/testutil"
+
 	"github.com/ethereum/go-ethereum/swarm/storage"
 	"github.com/ethereum/go-ethereum/swarm/storage/feed/lookup"
 
@@ -43,7 +45,13 @@ func serverFunc(api *api.API) swarmhttp.TestServer {
 func TestClientUploadDownloadRaw(t *testing.T) {
 	testClientUploadDownloadRaw(false, t)
 }
+
 func TestClientUploadDownloadRawEncrypted(t *testing.T) {
+	if testutil.RaceEnabled {
+		t.Skip("flaky with -race on Travis")
+		// See: https://github.com/ethersphere/go-ethereum/issues/1254
+	}
+
 	testClientUploadDownloadRaw(true, t)
 }
 

--- a/swarm/storage/ldbstore_test.go
+++ b/swarm/storage/ldbstore_test.go
@@ -27,6 +27,8 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/ethereum/go-ethereum/swarm/testutil"
+
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/swarm/chunk"
 	"github.com/ethereum/go-ethereum/swarm/log"
@@ -322,6 +324,12 @@ func TestLDBStoreCollectGarbage(t *testing.T) {
 	initialCap := defaultMaxGCRound / 100
 	cap := initialCap / 2
 	t.Run(fmt.Sprintf("A/%d/%d", cap, cap*4), testLDBStoreCollectGarbage)
+
+	if testutil.RaceEnabled {
+		t.Skip("only the simplest case run as others are flaky with race")
+		// Note: some tests fail consistently and even locally with `-race`
+	}
+
 	t.Run(fmt.Sprintf("B/%d/%d", cap, cap*4), testLDBStoreRemoveThenCollectGarbage)
 
 	// at max round


### PR DESCRIPTION
**Summary**

* This PR fixes some process (+memory) and file descriptor leaks.
* It also disables `TestClientUploadDownloadRawEncrypted` and `TestLDBStoreCollectGarbage` as those tests are known to be flaky with `-race`.

**A few details** 

* We got rid of the 'global' `testCluster` from `cmd/swarm/run_test.go`. => That adds some time to test runs, but answers the question: who is responsible for cleanup.
* To counterbalance the slowdown, nodes are started in parallel now. => At the end we are just 7s slower on Travis, but we freed up 10% of CI memory after the tests complete.

Note:
* We were leaking process, so even when the test binary exited some processes continued running and consumed significant memory. That is more of a problem locally than on an ephemeral CI environment.
* Currently, there is no limit on how many nodes are starting at the same time. If that becomes problematic in the future we can limit parallel starts with a small rewrite of the function starting the nodes.


Approved downstream: https://github.com/ethersphere/go-ethereum/pull/1312
(cause of the failing race detector job: https://github.com/ethersphere/go-ethereum/issues/1331)
