### PR TITLE
les: check required message types in cost table

### DIFF
--- a/les/peer_test.go
+++ b/les/peer_test.go
@@ -54,7 +54,7 @@ func TestPeerHandshakeSetAnnounceTypeToAnnounceTypeSignedForTrustedPeer(t *testi
 				l = l.add("txRelay", nil)
 				l = l.add("flowControl/BL", uint64(0))
 				l = l.add("flowControl/MRR", uint64(0))
-				l = l.add("flowControl/MRC", RequestCostList{})
+				l = l.add("flowControl/MRC", testCostList())
 
 				return l
 			},
@@ -99,7 +99,7 @@ func TestPeerHandshakeAnnounceTypeSignedForTrustedPeersPeerNotInTrusted(t *testi
 				l = l.add("txRelay", nil)
 				l = l.add("flowControl/BL", uint64(0))
 				l = l.add("flowControl/MRR", uint64(0))
-				l = l.add("flowControl/MRC", RequestCostList{})
+				l = l.add("flowControl/MRC", testCostList())
 
 				return l
 			},


### PR DESCRIPTION
This PR adds a verification for required message types in the announced cost table.