### PR TITLE
core/les: import header chains in batches

### DIFF
--- a/consensus/consensus.go
+++ b/consensus/consensus.go
@@ -39,6 +39,9 @@ type ChainReader interface {
 	// GetHeader retrieves a block header from the database by hash and number.
 	GetHeader(hash common.Hash, number uint64) *types.Header
 
+	// HasHeader checks presence of header in the database by hash and number.
+	HasHeader(hash common.Hash, number uint64) bool
+
 	// GetHeaderByNumber retrieves a block header from the database by number.
 	GetHeaderByNumber(number uint64) *types.Header
 

--- a/core/chain_makers.go
+++ b/core/chain_makers.go
@@ -297,3 +297,4 @@ func (cr *fakeChainReader) GetHeaderByNumber(number uint64) *types.Header       
 func (cr *fakeChainReader) GetHeaderByHash(hash common.Hash) *types.Header          { return nil }
 func (cr *fakeChainReader) GetHeader(hash common.Hash, number uint64) *types.Header { return nil }
 func (cr *fakeChainReader) GetBlock(hash common.Hash, number uint64) *types.Block   { return nil }
+func (cr *fakeChainReader) HasHeader(hash common.Hash, number uint64) bool          { return false }


### PR DESCRIPTION
This PR tries to improve a couple of things are in fast-sync.
 
- Process headers in chains, not one-by-one
  - This means db writes will be batched, 
  - Also means that there is less reading-back what we just wrote
- A minor change in ethash uncle validation to do less lookups of ancestors uncles (to not have to load the full ancestor block in most cases)
- Makes `HasHeader` a part of the `ChainReader` interface. This can save a few lookups where we don't have to load from disk
- Increase `numberCache`

~~Needs some general cleanup, and probably some tests will fail, and it needs some fixes for LES to keep working, but I'll post some charts here later on.~~ 