### PR TITLE
les: fix p2p.Protocol.PeerInfo

### DIFF
--- a/les/commons.go
+++ b/les/commons.go
@@ -64,7 +64,7 @@ func (c *lesCommons) makeProtocols(versions []uint) []p2p.Protocol {
 				return c.protocolManager.runPeer(version, p, rw)
 			},
 			PeerInfo: func(id enode.ID) interface{} {
-				if p := c.protocolManager.peers.Peer(fmt.Sprintf("%x", id[:8])); p != nil {
+				if p := c.protocolManager.peers.Peer(fmt.Sprintf("%x", id.Bytes())); p != nil {
 					return p.Info()
 				}
 				return nil


### PR DESCRIPTION
This PR fixes the node ID string encoding in the p2p.Protocol.PeerInfo function provided by the LES protocol handler. The bug caused admin.peers to report les: "handshake" even after the handshake finished successfully.