### PR TITLE
rpc: make ExampleClientSubscription work with the geth API

### DIFF
--- a/rpc/client_example_test.go
+++ b/rpc/client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2019 The go-ethereum Authors
+// Copyright 2016 The go-ethereum Authors
 // This file is part of the go-ethereum library.
 //
 // The go-ethereum library is free software: you can redistribute it and/or modify

--- a/rpc/client_example_test.go
+++ b/rpc/client_example_test.go
@@ -18,11 +18,10 @@ package rpc_test
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
-	"math/big"
 	"time"
 
+	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/rpc"
 )
 
@@ -36,28 +35,12 @@ import (
 //    creates a subscription which fires block objects when new blocks arrive.
 
 type Block struct {
-	Number *BigInt
-}
-
-type BigInt struct {
-	big.Int
-}
-
-func (i *BigInt) UnmarshalJSON(b []byte) error {
-	var val string
-	err := json.Unmarshal(b, &val)
-	if err != nil {
-		return err
-	}
-
-	i.SetString(val[2:], 16)
-
-	return nil
+	Number *hexutil.Big
 }
 
 func ExampleClientSubscription() {
 	// Connect the client.
-	client, _ := rpc.Dial("ws://127.0.0.1:8485")
+	client, _ := rpc.Dial("ws://127.0.0.1:8545")
 	subch := make(chan Block)
 
 	// Ensure that subch receives the latest block.
@@ -92,7 +75,8 @@ func subscribeBlocks(client *rpc.Client, subch chan Block) {
 	// The connection is established now.
 	// Update the channel with the current block.
 	var lastBlock Block
-	if err := client.CallContext(ctx, &lastBlock, "eth_getBlockByNumber", "latest", false); err != nil {
+	err = client.CallContext(ctx, &lastBlock, "eth_getBlockByNumber", "latest", false)
+	if err != nil {
 		fmt.Println("can't get latest block:", err)
 		return
 	}


### PR DESCRIPTION
Correct call to eth_getBlockByNumber. Fixes error:
```
can't get latest block: missing value for required argument 1
```

Properly unmarshall JSON. Fixes errors like this:
```
can't get latest block: math/big: cannot unmarshal "\"0xc5311\"" into a *big.Int
```
