### PR TITLE
internal/ethapi: support block number or hash on state-related methods

### DIFF
--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -2133,6 +2133,11 @@ func (bc *BlockChain) HasHeader(hash common.Hash, number uint64) bool {
 	return bc.hc.HasHeader(hash, number)
 }
 
+// GetCanonicalHash returns the canonical hash for a given block number
+func (bc *BlockChain) GetCanonicalHash(number uint64) common.Hash {
+	return bc.hc.GetCanonicalHash(number)
+}
+
 // GetBlockHashesFromHash retrieves a number of block hashes starting at a given
 // hash, fetching towards the genesis block.
 func (bc *BlockChain) GetBlockHashesFromHash(hash common.Hash, max uint64) []common.Hash {

--- a/core/headerchain.go
+++ b/core/headerchain.go
@@ -445,6 +445,10 @@ func (hc *HeaderChain) GetHeaderByNumber(number uint64) *types.Header {
 	return hc.GetHeader(hash, number)
 }
 
+func (hc *HeaderChain) GetCanonicalHash(number uint64) common.Hash {
+	return rawdb.ReadCanonicalHash(hc.chainDb, number)
+}
+
 // CurrentHeader retrieves the current head header of the canonical chain. The
 // header is retrieved from the HeaderChain's internal cache.
 func (hc *HeaderChain) CurrentHeader() *types.Header {

--- a/eth/api_backend.go
+++ b/eth/api_backend.go
@@ -72,6 +72,23 @@ func (b *EthAPIBackend) HeaderByNumber(ctx context.Context, number rpc.BlockNumb
 	return b.eth.blockchain.GetHeaderByNumber(uint64(number)), nil
 }
 
+func (b *EthAPIBackend) HeaderByNumberOrHash(ctx context.Context, blockNrOrHash rpc.BlockNumberOrHash) (*types.Header, error) {
+	if blockNr, ok := blockNrOrHash.Number(); ok {
+		return b.HeaderByNumber(ctx, blockNr)
+	}
+	if hash, ok := blockNrOrHash.Hash(); ok {
+		header := b.eth.blockchain.GetHeaderByHash(hash)
+		if header == nil {
+			return nil, errors.New("header for hash not found")
+		}
+		if blockNrOrHash.RequireCanonical && b.eth.blockchain.GetCanonicalHash(header.Number.Uint64()) != hash {
+			return nil, errors.New("hash is not currently canonical")
+		}
+		return header, nil
+	}
+	return nil, errors.New("invalid arguments; neither block nor hash specified")
+}
+
 func (b *EthAPIBackend) HeaderByHash(ctx context.Context, hash common.Hash) (*types.Header, error) {
 	return b.eth.blockchain.GetHeaderByHash(hash), nil
 }
@@ -93,6 +110,27 @@ func (b *EthAPIBackend) BlockByHash(ctx context.Context, hash common.Hash) (*typ
 	return b.eth.blockchain.GetBlockByHash(hash), nil
 }
 
+func (b *EthAPIBackend) BlockByNumberOrHash(ctx context.Context, blockNrOrHash rpc.BlockNumberOrHash) (*types.Block, error) {
+	if blockNr, ok := blockNrOrHash.Number(); ok {
+		return b.BlockByNumber(ctx, blockNr)
+	}
+	if hash, ok := blockNrOrHash.Hash(); ok {
+		header := b.eth.blockchain.GetHeaderByHash(hash)
+		if header == nil {
+			return nil, errors.New("header for hash not found")
+		}
+		if blockNrOrHash.RequireCanonical && b.eth.blockchain.GetCanonicalHash(header.Number.Uint64()) != hash {
+			return nil, errors.New("hash is not currently canonical")
+		}
+		block := b.eth.blockchain.GetBlock(hash, header.Number.Uint64())
+		if block == nil {
+			return nil, errors.New("header found, but block body is missing")
+		}
+		return block, nil
+	}
+	return nil, errors.New("invalid arguments; neither block nor hash specified")
+}
+
 func (b *EthAPIBackend) StateAndHeaderByNumber(ctx context.Context, number rpc.BlockNumber) (*state.StateDB, *types.Header, error) {
 	// Pending state is only known by the miner
 	if number == rpc.PendingBlockNumber {
@@ -109,6 +147,27 @@ func (b *EthAPIBackend) StateAndHeaderByNumber(ctx context.Context, number rpc.B
 	}
 	stateDb, err := b.eth.BlockChain().StateAt(header.Root)
 	return stateDb, header, err
+}
+
+func (b *EthAPIBackend) StateAndHeaderByNumberOrHash(ctx context.Context, blockNrOrHash rpc.BlockNumberOrHash) (*state.StateDB, *types.Header, error) {
+	if blockNr, ok := blockNrOrHash.Number(); ok {
+		return b.StateAndHeaderByNumber(ctx, blockNr)
+	}
+	if hash, ok := blockNrOrHash.Hash(); ok {
+		header, err := b.HeaderByHash(ctx, hash)
+		if err != nil {
+			return nil, nil, err
+		}
+		if header == nil {
+			return nil, nil, errors.New("header for hash not found")
+		}
+		if blockNrOrHash.RequireCanonical && b.eth.blockchain.GetCanonicalHash(header.Number.Uint64()) != hash {
+			return nil, nil, errors.New("hash is not currently canonical")
+		}
+		stateDb, err := b.eth.BlockChain().StateAt(header.Root)
+		return stateDb, header, err
+	}
+	return nil, nil, errors.New("invalid arguments; neither block nor hash specified")
 }
 
 func (b *EthAPIBackend) GetReceipts(ctx context.Context, hash common.Hash) (types.Receipts, error) {

--- a/graphql/graphql.go
+++ b/graphql/graphql.go
@@ -36,20 +36,19 @@ import (
 )
 
 var (
-	errOnlyOnMainChain = errors.New("this operation is only available for blocks on the canonical chain")
-	errBlockInvariant  = errors.New("block objects must be instantiated with at least one of num or hash")
+	errBlockInvariant = errors.New("block objects must be instantiated with at least one of num or hash")
 )
 
 // Account represents an Ethereum account at a particular block.
 type Account struct {
-	backend     ethapi.Backend
-	address     common.Address
-	blockNumber rpc.BlockNumber
+	backend       ethapi.Backend
+	address       common.Address
+	blockNrOrHash rpc.BlockNumberOrHash
 }
 
 // getState fetches the StateDB object for an account.
 func (a *Account) getState(ctx context.Context) (*state.StateDB, error) {
-	state, _, err := a.backend.StateAndHeaderByNumber(ctx, a.blockNumber)
+	state, _, err := a.backend.StateAndHeaderByNumberOrHash(ctx, a.blockNrOrHash)
 	return state, err
 }
 
@@ -102,9 +101,9 @@ func (l *Log) Transaction(ctx context.Context) *Transaction {
 
 func (l *Log) Account(ctx context.Context, args BlockNumberArgs) *Account {
 	return &Account{
-		backend:     l.backend,
-		address:     l.log.Address,
-		blockNumber: args.Number(),
+		backend:       l.backend,
+		address:       l.log.Address,
+		blockNrOrHash: args.NumberOrLatest(),
 	}
 }
 
@@ -136,10 +135,10 @@ func (t *Transaction) resolve(ctx context.Context) (*types.Transaction, error) {
 		tx, blockHash, _, index := rawdb.ReadTransaction(t.backend.ChainDb(), t.hash)
 		if tx != nil {
 			t.tx = tx
+			blockNrOrHash := rpc.BlockNumberOrHashWithHash(blockHash, false)
 			t.block = &Block{
-				backend:   t.backend,
-				hash:      blockHash,
-				canonical: unknown,
+				backend:      t.backend,
+				numberOrHash: &blockNrOrHash,
 			}
 			t.index = index
 		} else {
@@ -203,9 +202,9 @@ func (t *Transaction) To(ctx context.Context, args BlockNumberArgs) (*Account, e
 		return nil, nil
 	}
 	return &Account{
-		backend:     t.backend,
-		address:     *to,
-		blockNumber: args.Number(),
+		backend:       t.backend,
+		address:       *to,
+		blockNrOrHash: args.NumberOrLatest(),
 	}, nil
 }
 
@@ -221,9 +220,9 @@ func (t *Transaction) From(ctx context.Context, args BlockNumberArgs) (*Account,
 	from, _ := types.Sender(signer, tx)
 
 	return &Account{
-		backend:     t.backend,
-		address:     from,
-		blockNumber: args.Number(),
+		backend:       t.backend,
+		address:       from,
+		blockNrOrHash: args.NumberOrLatest(),
 	}, nil
 }
 
@@ -293,9 +292,9 @@ func (t *Transaction) CreatedContract(ctx context.Context, args BlockNumberArgs)
 		return nil, err
 	}
 	return &Account{
-		backend:     t.backend,
-		address:     receipt.ContractAddress,
-		blockNumber: args.Number(),
+		backend:       t.backend,
+		address:       receipt.ContractAddress,
+		blockNrOrHash: args.NumberOrLatest(),
 	}, nil
 }
 
@@ -317,45 +316,16 @@ func (t *Transaction) Logs(ctx context.Context) (*[]*Log, error) {
 
 type BlockType int
 
-const (
-	unknown BlockType = iota
-	isCanonical
-	notCanonical
-)
-
 // Block represents an Ethereum block.
-// backend, and either num or hash are mandatory. All other fields are lazily fetched
+// backend, and numberOrHash are mandatory. All other fields are lazily fetched
 // when required.
 type Block struct {
-	backend   ethapi.Backend
-	num       *rpc.BlockNumber
-	hash      common.Hash
-	header    *types.Header
-	block     *types.Block
-	receipts  []*types.Receipt
-	canonical BlockType // Indicates if this block is on the main chain or not.
-}
-
-func (b *Block) onMainChain(ctx context.Context) error {
-	if b.canonical == unknown {
-		header, err := b.resolveHeader(ctx)
-		if err != nil {
-			return err
-		}
-		canonHeader, err := b.backend.HeaderByNumber(ctx, rpc.BlockNumber(header.Number.Uint64()))
-		if err != nil {
-			return err
-		}
-		if header.Hash() == canonHeader.Hash() {
-			b.canonical = isCanonical
-		} else {
-			b.canonical = notCanonical
-		}
-	}
-	if b.canonical != isCanonical {
-		return errOnlyOnMainChain
-	}
-	return nil
+	backend      ethapi.Backend
+	numberOrHash *rpc.BlockNumberOrHash
+	hash         common.Hash
+	header       *types.Header
+	block        *types.Block
+	receipts     []*types.Receipt
 }
 
 // resolve returns the internal Block object representing this block, fetching
@@ -364,14 +334,17 @@ func (b *Block) resolve(ctx context.Context) (*types.Block, error) {
 	if b.block != nil {
 		return b.block, nil
 	}
-	var err error
-	if b.hash != (common.Hash{}) {
-		b.block, err = b.backend.BlockByHash(ctx, b.hash)
-	} else {
-		b.block, err = b.backend.BlockByNumber(ctx, *b.num)
+	if b.numberOrHash == nil {
+		latest := rpc.BlockNumberOrHashWithNumber(rpc.LatestBlockNumber)
+		b.numberOrHash = &latest
 	}
+	var err error
+	b.block, err = b.backend.BlockByNumberOrHash(ctx, *b.numberOrHash)
 	if b.block != nil && b.header == nil {
 		b.header = b.block.Header()
+		if hash, ok := b.numberOrHash.Hash(); ok {
+			b.hash = hash
+		}
 	}
 	return b.block, err
 }
@@ -380,7 +353,7 @@ func (b *Block) resolve(ctx context.Context) (*types.Block, error) {
 // if necessary. Call this function instead of `resolve` unless you need the
 // additional data (transactions and uncles).
 func (b *Block) resolveHeader(ctx context.Context) (*types.Header, error) {
-	if b.num == nil && b.hash == (common.Hash{}) {
+	if b.numberOrHash == nil && b.hash == (common.Hash{}) {
 		return nil, errBlockInvariant
 	}
 	var err error
@@ -388,7 +361,7 @@ func (b *Block) resolveHeader(ctx context.Context) (*types.Header, error) {
 		if b.hash != (common.Hash{}) {
 			b.header, err = b.backend.HeaderByHash(ctx, b.hash)
 		} else {
-			b.header, err = b.backend.HeaderByNumber(ctx, *b.num)
+			b.header, err = b.backend.HeaderByNumberOrHash(ctx, *b.numberOrHash)
 		}
 	}
 	return b.header, err
@@ -416,15 +389,12 @@ func (b *Block) resolveReceipts(ctx context.Context) ([]*types.Receipt, error) {
 }
 
 func (b *Block) Number(ctx context.Context) (hexutil.Uint64, error) {
-	if b.num == nil || *b.num == rpc.LatestBlockNumber {
-		header, err := b.resolveHeader(ctx)
-		if err != nil {
-			return 0, err
-		}
-		num := rpc.BlockNumber(header.Number.Uint64())
-		b.num = &num
+	header, err := b.resolveHeader(ctx)
+	if err != nil {
+		return 0, err
 	}
-	return hexutil.Uint64(*b.num), nil
+
+	return hexutil.Uint64(header.Number.Uint64()), nil
 }
 
 func (b *Block) Hash(ctx context.Context) (common.Hash, error) {
@@ -456,26 +426,17 @@ func (b *Block) GasUsed(ctx context.Context) (hexutil.Uint64, error) {
 
 func (b *Block) Parent(ctx context.Context) (*Block, error) {
 	// If the block header hasn't been fetched, and we'll need it, fetch it.
-	if b.num == nil && b.hash != (common.Hash{}) && b.header == nil {
+	if b.numberOrHash == nil && b.header == nil {
 		if _, err := b.resolveHeader(ctx); err != nil {
 			return nil, err
 		}
 	}
 	if b.header != nil && b.header.Number.Uint64() > 0 {
-		num := rpc.BlockNumber(b.header.Number.Uint64() - 1)
+		num := rpc.BlockNumberOrHashWithNumber(rpc.BlockNumber(b.header.Number.Uint64() - 1))
 		return &Block{
-			backend:   b.backend,
-			num:       &num,
-			hash:      b.header.ParentHash,
-			canonical: unknown,
-		}, nil
-	}
-	if b.num != nil && *b.num != 0 {
-		num := *b.num - 1
-		return &Block{
-			backend:   b.backend,
-			num:       &num,
-			canonical: isCanonical,
+			backend:      b.backend,
+			numberOrHash: &num,
+			hash:         b.header.ParentHash,
 		}, nil
 	}
 	return nil, nil
@@ -561,13 +522,11 @@ func (b *Block) Ommers(ctx context.Context) (*[]*Block, error) {
 	}
 	ret := make([]*Block, 0, len(block.Uncles()))
 	for _, uncle := range block.Uncles() {
-		blockNumber := rpc.BlockNumber(uncle.Number.Uint64())
+		blockNumberOrHash := rpc.BlockNumberOrHashWithHash(uncle.Hash(), false)
 		ret = append(ret, &Block{
-			backend:   b.backend,
-			num:       &blockNumber,
-			hash:      uncle.Hash(),
-			header:    uncle,
-			canonical: notCanonical,
+			backend:      b.backend,
+			numberOrHash: &blockNumberOrHash,
+			header:       uncle,
 		})
 	}
 	return &ret, nil
@@ -603,16 +562,26 @@ func (b *Block) TotalDifficulty(ctx context.Context) (hexutil.Big, error) {
 
 // BlockNumberArgs encapsulates arguments to accessors that specify a block number.
 type BlockNumberArgs struct {
+	// TODO: Ideally we could use input unions to allow the query to specify the
+	// block parameter by hash, block number, or tag but input unions aren't part of the
+	// standard GraphQL schema SDL yet, see: https://github.com/graphql/graphql-spec/issues/488
 	Block *hexutil.Uint64
 }
 
-// Number returns the provided block number, or rpc.LatestBlockNumber if none
+// NumberOr returns the provided block number argument, or the "current" block number or hash if none
 // was provided.
-func (a BlockNumberArgs) Number() rpc.BlockNumber {
+func (a BlockNumberArgs) NumberOr(current rpc.BlockNumberOrHash) rpc.BlockNumberOrHash {
 	if a.Block != nil {
-		return rpc.BlockNumber(*a.Block)
+		blockNr := rpc.BlockNumber(*a.Block)
+		return rpc.BlockNumberOrHashWithNumber(blockNr)
 	}
-	return rpc.LatestBlockNumber
+	return current
+}
+
+// NumberOrLatest returns the provided block number argument, or the "latest" block number if none
+// was provided.
+func (a BlockNumberArgs) NumberOrLatest() rpc.BlockNumberOrHash {
+	return a.NumberOr(rpc.BlockNumberOrHashWithNumber(rpc.LatestBlockNumber))
 }
 
 func (b *Block) Miner(ctx context.Context, args BlockNumberArgs) (*Account, error) {
@@ -621,9 +590,9 @@ func (b *Block) Miner(ctx context.Context, args BlockNumberArgs) (*Account, erro
 		return nil, err
 	}
 	return &Account{
-		backend:     b.backend,
-		address:     header.Coinbase,
-		blockNumber: args.Number(),
+		backend:       b.backend,
+		address:       header.Coinbase,
+		blockNrOrHash: args.NumberOrLatest(),
 	}, nil
 }
 
@@ -683,13 +652,11 @@ func (b *Block) OmmerAt(ctx context.Context, args struct{ Index int32 }) (*Block
 		return nil, nil
 	}
 	uncle := uncles[args.Index]
-	blockNumber := rpc.BlockNumber(uncle.Number.Uint64())
+	blockNumberOrHash := rpc.BlockNumberOrHashWithHash(uncle.Hash(), false)
 	return &Block{
-		backend:   b.backend,
-		num:       &blockNumber,
-		hash:      uncle.Hash(),
-		header:    uncle,
-		canonical: notCanonical,
+		backend:      b.backend,
+		numberOrHash: &blockNumberOrHash,
+		header:       uncle,
 	}, nil
 }
 
@@ -757,20 +724,16 @@ func (b *Block) Logs(ctx context.Context, args struct{ Filter BlockFilterCriteri
 func (b *Block) Account(ctx context.Context, args struct {
 	Address common.Address
 }) (*Account, error) {
-	err := b.onMainChain(ctx)
-	if err != nil {
-		return nil, err
-	}
-	if b.num == nil {
+	if b.numberOrHash == nil {
 		_, err := b.resolveHeader(ctx)
 		if err != nil {
 			return nil, err
 		}
 	}
 	return &Account{
-		backend:     b.backend,
-		address:     args.Address,
-		blockNumber: *b.num,
+		backend:       b.backend,
+		address:       args.Address,
+		blockNrOrHash: *b.numberOrHash,
 	}, nil
 }
 
@@ -807,17 +770,13 @@ func (c *CallResult) Status() hexutil.Uint64 {
 func (b *Block) Call(ctx context.Context, args struct {
 	Data ethapi.CallArgs
 }) (*CallResult, error) {
-	err := b.onMainChain(ctx)
-	if err != nil {
-		return nil, err
-	}
-	if b.num == nil {
-		_, err := b.resolveHeader(ctx)
+	if b.numberOrHash == nil {
+		_, err := b.resolve(ctx)
 		if err != nil {
 			return nil, err
 		}
 	}
-	result, gas, failed, err := ethapi.DoCall(ctx, b.backend, args.Data, *b.num, nil, vm.Config{}, 5*time.Second, b.backend.RPCGasCap())
+	result, gas, failed, err := ethapi.DoCall(ctx, b.backend, args.Data, *b.numberOrHash, nil, vm.Config{}, 5*time.Second, b.backend.RPCGasCap())
 	status := hexutil.Uint64(1)
 	if failed {
 		status = 0
@@ -832,17 +791,13 @@ func (b *Block) Call(ctx context.Context, args struct {
 func (b *Block) EstimateGas(ctx context.Context, args struct {
 	Data ethapi.CallArgs
 }) (hexutil.Uint64, error) {
-	err := b.onMainChain(ctx)
-	if err != nil {
-		return hexutil.Uint64(0), err
-	}
-	if b.num == nil {
+	if b.numberOrHash == nil {
 		_, err := b.resolveHeader(ctx)
 		if err != nil {
 			return hexutil.Uint64(0), err
 		}
 	}
-	gas, err := ethapi.DoEstimateGas(ctx, b.backend, args.Data, *b.num, b.backend.RPCGasCap())
+	gas, err := ethapi.DoEstimateGas(ctx, b.backend, args.Data, *b.numberOrHash, b.backend.RPCGasCap())
 	return gas, err
 }
 
@@ -875,17 +830,19 @@ func (p *Pending) Transactions(ctx context.Context) (*[]*Transaction, error) {
 func (p *Pending) Account(ctx context.Context, args struct {
 	Address common.Address
 }) *Account {
+	pendingBlockNr := rpc.BlockNumberOrHashWithNumber(rpc.PendingBlockNumber)
 	return &Account{
-		backend:     p.backend,
-		address:     args.Address,
-		blockNumber: rpc.PendingBlockNumber,
+		backend:       p.backend,
+		address:       args.Address,
+		blockNrOrHash: pendingBlockNr,
 	}
 }
 
 func (p *Pending) Call(ctx context.Context, args struct {
 	Data ethapi.CallArgs
 }) (*CallResult, error) {
-	result, gas, failed, err := ethapi.DoCall(ctx, p.backend, args.Data, rpc.PendingBlockNumber, nil, vm.Config{}, 5*time.Second, p.backend.RPCGasCap())
+	pendingBlockNr := rpc.BlockNumberOrHashWithNumber(rpc.PendingBlockNumber)
+	result, gas, failed, err := ethapi.DoCall(ctx, p.backend, args.Data, pendingBlockNr, nil, vm.Config{}, 5*time.Second, p.backend.RPCGasCap())
 	status := hexutil.Uint64(1)
 	if failed {
 		status = 0
@@ -900,7 +857,8 @@ func (p *Pending) Call(ctx context.Context, args struct {
 func (p *Pending) EstimateGas(ctx context.Context, args struct {
 	Data ethapi.CallArgs
 }) (hexutil.Uint64, error) {
-	return ethapi.DoEstimateGas(ctx, p.backend, args.Data, rpc.PendingBlockNumber, p.backend.RPCGasCap())
+	pendingBlockNr := rpc.BlockNumberOrHashWithNumber(rpc.PendingBlockNumber)
+	return ethapi.DoEstimateGas(ctx, p.backend, args.Data, pendingBlockNr, p.backend.RPCGasCap())
 }
 
 // Resolver is the top-level object in the GraphQL hierarchy.
@@ -914,24 +872,23 @@ func (r *Resolver) Block(ctx context.Context, args struct {
 }) (*Block, error) {
 	var block *Block
 	if args.Number != nil {
-		num := rpc.BlockNumber(uint64(*args.Number))
+		number := rpc.BlockNumber(uint64(*args.Number))
+		numberOrHash := rpc.BlockNumberOrHashWithNumber(number)
 		block = &Block{
-			backend:   r.backend,
-			num:       &num,
-			canonical: isCanonical,
+			backend:      r.backend,
+			numberOrHash: &numberOrHash,
 		}
 	} else if args.Hash != nil {
+		numberOrHash := rpc.BlockNumberOrHashWithHash(*args.Hash, false)
 		block = &Block{
-			backend:   r.backend,
-			hash:      *args.Hash,
-			canonical: unknown,
+			backend:      r.backend,
+			numberOrHash: &numberOrHash,
 		}
 	} else {
-		num := rpc.LatestBlockNumber
+		numberOrHash := rpc.BlockNumberOrHashWithNumber(rpc.LatestBlockNumber)
 		block = &Block{
-			backend:   r.backend,
-			num:       &num,
-			canonical: isCanonical,
+			backend:      r.backend,
+			numberOrHash: &numberOrHash,
 		}
 	}
 	// Resolve the header, return nil if it doesn't exist.
@@ -963,11 +920,10 @@ func (r *Resolver) Blocks(ctx context.Context, args struct {
 	}
 	ret := make([]*Block, 0, to-from+1)
 	for i := from; i <= to; i++ {
-		num := i
+		numberOrHash := rpc.BlockNumberOrHashWithNumber(i)
 		ret = append(ret, &Block{
-			backend:   r.backend,
-			num:       &num,
-			canonical: isCanonical,
+			backend:      r.backend,
+			numberOrHash: &numberOrHash,
 		})
 	}
 	return ret, nil

--- a/internal/ethapi/backend.go
+++ b/internal/ethapi/backend.go
@@ -52,9 +52,12 @@ type Backend interface {
 	SetHead(number uint64)
 	HeaderByNumber(ctx context.Context, number rpc.BlockNumber) (*types.Header, error)
 	HeaderByHash(ctx context.Context, hash common.Hash) (*types.Header, error)
+	HeaderByNumberOrHash(ctx context.Context, blockNrOrHash rpc.BlockNumberOrHash) (*types.Header, error)
 	BlockByNumber(ctx context.Context, number rpc.BlockNumber) (*types.Block, error)
 	BlockByHash(ctx context.Context, hash common.Hash) (*types.Block, error)
+	BlockByNumberOrHash(ctx context.Context, blockNrOrHash rpc.BlockNumberOrHash) (*types.Block, error)
 	StateAndHeaderByNumber(ctx context.Context, number rpc.BlockNumber) (*state.StateDB, *types.Header, error)
+	StateAndHeaderByNumberOrHash(ctx context.Context, blockNrOrHash rpc.BlockNumberOrHash) (*state.StateDB, *types.Header, error)
 	GetReceipts(ctx context.Context, hash common.Hash) (types.Receipts, error)
 	GetTd(hash common.Hash) *big.Int
 	GetEVM(ctx context.Context, msg core.Message, state *state.StateDB, header *types.Header) (*vm.EVM, func() error, error)

--- a/light/lightchain.go
+++ b/light/lightchain.go
@@ -426,6 +426,11 @@ func (lc *LightChain) HasHeader(hash common.Hash, number uint64) bool {
 	return lc.hc.HasHeader(hash, number)
 }
 
+// GetCanonicalHash returns the canonical hash for a given block number
+func (bc *LightChain) GetCanonicalHash(number uint64) common.Hash {
+	return bc.hc.GetCanonicalHash(number)
+}
+
 // GetBlockHashesFromHash retrieves a number of block hashes starting at a given
 // hash, fetching towards the genesis block.
 func (lc *LightChain) GetBlockHashesFromHash(hash common.Hash, max uint64) []common.Hash {

--- a/rpc/types.go
+++ b/rpc/types.go
@@ -18,10 +18,12 @@ package rpc
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"math"
 	"strings"
 
+	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 )
 
@@ -104,4 +106,95 @@ func (bn *BlockNumber) UnmarshalJSON(data []byte) error {
 
 func (bn BlockNumber) Int64() int64 {
 	return (int64)(bn)
+}
+
+type BlockNumberOrHash struct {
+	BlockNumber      *BlockNumber `json:"blockNumber,omitempty"`
+	BlockHash        *common.Hash `json:"blockHash,omitempty"`
+	RequireCanonical bool         `json:"requireCanonical,omitempty"`
+}
+
+func (bnh *BlockNumberOrHash) UnmarshalJSON(data []byte) error {
+	type erased BlockNumberOrHash
+	e := erased{}
+	err := json.Unmarshal(data, &e)
+	if err == nil {
+		if e.BlockNumber != nil && e.BlockHash != nil {
+			return fmt.Errorf("cannot specify both BlockHash and BlockNumber, choose one or the other")
+		}
+		bnh.BlockNumber = e.BlockNumber
+		bnh.BlockHash = e.BlockHash
+		bnh.RequireCanonical = e.RequireCanonical
+		return nil
+	}
+	var input string
+	err = json.Unmarshal(data, &input)
+	if err != nil {
+		return err
+	}
+	switch input {
+	case "earliest":
+		bn := EarliestBlockNumber
+		bnh.BlockNumber = &bn
+		return nil
+	case "latest":
+		bn := LatestBlockNumber
+		bnh.BlockNumber = &bn
+		return nil
+	case "pending":
+		bn := PendingBlockNumber
+		bnh.BlockNumber = &bn
+		return nil
+	default:
+		if len(input) == 66 {
+			hash := common.Hash{}
+			err := hash.UnmarshalText([]byte(input))
+			if err != nil {
+				return err
+			}
+			bnh.BlockHash = &hash
+			return nil
+		} else {
+			blckNum, err := hexutil.DecodeUint64(input)
+			if err != nil {
+				return err
+			}
+			if blckNum > math.MaxInt64 {
+				return fmt.Errorf("blocknumber too high")
+			}
+			bn := BlockNumber(blckNum)
+			bnh.BlockNumber = &bn
+			return nil
+		}
+	}
+}
+
+func (bnh *BlockNumberOrHash) Number() (BlockNumber, bool) {
+	if bnh.BlockNumber != nil {
+		return *bnh.BlockNumber, true
+	}
+	return BlockNumber(0), false
+}
+
+func (bnh *BlockNumberOrHash) Hash() (common.Hash, bool) {
+	if bnh.BlockHash != nil {
+		return *bnh.BlockHash, true
+	}
+	return common.Hash{}, false
+}
+
+func BlockNumberOrHashWithNumber(blockNr BlockNumber) BlockNumberOrHash {
+	return BlockNumberOrHash{
+		BlockNumber:      &blockNr,
+		BlockHash:        nil,
+		RequireCanonical: false,
+	}
+}
+
+func BlockNumberOrHashWithHash(hash common.Hash, canonical bool) BlockNumberOrHash {
+	return BlockNumberOrHash{
+		BlockNumber:      nil,
+		BlockHash:        &hash,
+		RequireCanonical: canonical,
+	}
 }

--- a/rpc/types_test.go
+++ b/rpc/types_test.go
@@ -20,6 +20,7 @@ import (
 	"encoding/json"
 	"testing"
 
+	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/math"
 )
 
@@ -61,6 +62,63 @@ func TestBlockNumberJSONUnmarshal(t *testing.T) {
 		}
 		if num != test.expected {
 			t.Errorf("Test %d got unexpected value, want %d, got %d", i, test.expected, num)
+		}
+	}
+}
+
+func TestBlockNumberOrHash_UnmarshalJSON(t *testing.T) {
+	tests := []struct {
+		input    string
+		mustFail bool
+		expected BlockNumberOrHash
+	}{
+		0:  {`"0x"`, true, BlockNumberOrHash{}},
+		1:  {`"0x0"`, false, BlockNumberOrHashWithNumber(0)},
+		2:  {`"0X1"`, false, BlockNumberOrHashWithNumber(1)},
+		3:  {`"0x00"`, true, BlockNumberOrHash{}},
+		4:  {`"0x01"`, true, BlockNumberOrHash{}},
+		5:  {`"0x1"`, false, BlockNumberOrHashWithNumber(1)},
+		6:  {`"0x12"`, false, BlockNumberOrHashWithNumber(18)},
+		7:  {`"0x7fffffffffffffff"`, false, BlockNumberOrHashWithNumber(math.MaxInt64)},
+		8:  {`"0x8000000000000000"`, true, BlockNumberOrHash{}},
+		9:  {"0", true, BlockNumberOrHash{}},
+		10: {`"ff"`, true, BlockNumberOrHash{}},
+		11: {`"pending"`, false, BlockNumberOrHashWithNumber(PendingBlockNumber)},
+		12: {`"latest"`, false, BlockNumberOrHashWithNumber(LatestBlockNumber)},
+		13: {`"earliest"`, false, BlockNumberOrHashWithNumber(EarliestBlockNumber)},
+		14: {`someString`, true, BlockNumberOrHash{}},
+		15: {`""`, true, BlockNumberOrHash{}},
+		16: {``, true, BlockNumberOrHash{}},
+		17: {`"0x0000000000000000000000000000000000000000000000000000000000000000"`, false, BlockNumberOrHashWithHash(common.HexToHash("0x0000000000000000000000000000000000000000000000000000000000000000"), false)},
+		18: {`{"blockHash":"0x0000000000000000000000000000000000000000000000000000000000000000"}`, false, BlockNumberOrHashWithHash(common.HexToHash("0x0000000000000000000000000000000000000000000000000000000000000000"), false)},
+		19: {`{"blockHash":"0x0000000000000000000000000000000000000000000000000000000000000000","requireCanonical":false}`, false, BlockNumberOrHashWithHash(common.HexToHash("0x0000000000000000000000000000000000000000000000000000000000000000"), false)},
+		20: {`{"blockHash":"0x0000000000000000000000000000000000000000000000000000000000000000","requireCanonical":true}`, false, BlockNumberOrHashWithHash(common.HexToHash("0x0000000000000000000000000000000000000000000000000000000000000000"), true)},
+		21: {`{"blockNumber":"0x1"}`, false, BlockNumberOrHashWithNumber(1)},
+		22: {`{"blockNumber":"pending"}`, false, BlockNumberOrHashWithNumber(PendingBlockNumber)},
+		23: {`{"blockNumber":"latest"}`, false, BlockNumberOrHashWithNumber(LatestBlockNumber)},
+		24: {`{"blockNumber":"earliest"}`, false, BlockNumberOrHashWithNumber(EarliestBlockNumber)},
+		25: {`{"blockNumber":"0x1", "blockHash":"0x0000000000000000000000000000000000000000000000000000000000000000"}`, true, BlockNumberOrHash{}},
+	}
+
+	for i, test := range tests {
+		var bnh BlockNumberOrHash
+		err := json.Unmarshal([]byte(test.input), &bnh)
+		if test.mustFail && err == nil {
+			t.Errorf("Test %d should fail", i)
+			continue
+		}
+		if !test.mustFail && err != nil {
+			t.Errorf("Test %d should pass but got err: %v", i, err)
+			continue
+		}
+		hash, hashOk := bnh.Hash()
+		expectedHash, expectedHashOk := test.expected.Hash()
+		num, numOk := bnh.Number()
+		expectedNum, expectedNumOk := test.expected.Number()
+		if bnh.RequireCanonical != test.expected.RequireCanonical ||
+			hash != expectedHash || hashOk != expectedHashOk ||
+			num != expectedNum || numOk != expectedNumOk {
+			t.Errorf("Test %d got unexpected value, want %v, got %v", i, test.expected, bnh)
 		}
 	}
 }


### PR DESCRIPTION
This adds support for [EIP-1898](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-1898.md) and supersedes https://github.com/ethereum/go-ethereum/pull/19459 which I forgot was based on 1.8.x.

### Outstanding Issues

- [x] Fix regression in GraphQL around `canonical` setting
- [ ] Potentially rename `BlockNumberOrHash` to `BlockSpecifier`
- [x] Determine behavior when specifier includes both hash and number (https://github.com/ethereum/EIPs/issues/2247)

### Rationale

As mentioned in #19394 there's a couple scenarios where I could see this being useful:

As a DApp developer, I might have logic like:

```golang
result := eth_call({....}, "latest")
// do some potentially slow processing w/ result
// send another RPC a couple seconds later
balance := eth_getBalance(0xsomeAdress, "latest")
```

The issue above is that `"latest"` could refer to totally different blocks.  So next one tries:

```golang
latest := eth_getBlockByNumber("latest", false)
result := eth_call({....}, latest.Number)
// do some potentially slow processing w/ result
// send another RPC a couple seconds later
balance := eth_getBalance(0xsomeAdress, latest.Number)
```

But even still, because of reorgs, block number 0x7654321 might refer to two different blocks depending on when it is used.  So my PR allows:

```golang
latest := eth_getBlockByNumber("latest", false)
result := eth_call({...}, latest.Hash)
// do some potentially slow processing w/ result
// send another RPC a couple seconds later
balance := eth_getBalance(0xsomeAdress, latest.Hash)
```

So now you  are sure you are referring to the same block in both calls.

This also becomes very useful for Exchanges or Infura-a-likes, basically anyone w/ enough RPC load or need for HA that they need to run more than one node, since the chances of 0x7654321 pointing to two different blocks on two different nodes is even higher.  And if one of the nodes hasn't seen that block hash yet, the caller gets an error rather than a 0-values result.  So, this actually skirts the breaking behavior of https://github.com/ethereum/go-ethereum/pull/18346 by continuing to behave like 1.8.x for block numbers, but returns explicit errors for block hashes.

In addition, to be compliant w/ EIP-1898 and the discussion in #19394 this PR accepts the hash as either a string or a `{blockHash:,}` object (w/ optional `requireCanonical` field, which defaults to false if not specified).

### GraphQL changes

The only real changes from #19459 are to make my changes work w/ the new GraphQL module, and actually they allowed for a fair bit of code cleanup in there as well, since it was going through some gymnastics to support looking up data by block number or hash.

However, two changes related to GraphQL (thus /cc @Arachnid and @kshinn):

- I removed all the canonical checks, since we now support looking up non-canonical blocks by hash.
- While I found it odd that a query like:

```graphql
block(hash: "0x....") {
   miner {
      balance
   }
}
```

Was returning the miner's balance at `"latest"`, I did *not* change this behavior since I think the best way to change this behavior requires schema changes and I feel like those should be addressed in a follow-on PR.