### PR TITLE
cmd/utils, node: switch over default peer count to 50

### DIFF
--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -565,12 +565,12 @@ var (
 	MaxPeersFlag = cli.IntFlag{
 		Name:  "maxpeers",
 		Usage: "Maximum number of network peers (network disabled if set to 0)",
-		Value: 25,
+		Value: node.DefaultConfig.P2P.MaxPeers,
 	}
 	MaxPendingPeersFlag = cli.IntFlag{
 		Name:  "maxpendpeers",
 		Usage: "Maximum number of pending connection attempts (defaults used if set to 0)",
-		Value: 0,
+		Value: node.DefaultConfig.P2P.MaxPendingPeers,
 	}
 	ListenPortFlag = cli.IntFlag{
 		Name:  "port",

--- a/node/defaults.go
+++ b/node/defaults.go
@@ -47,7 +47,7 @@ var DefaultConfig = Config{
 	WSModules:        []string{"net", "web3"},
 	P2P: p2p.Config{
 		ListenAddr: ":30303",
-		MaxPeers:   25,
+		MaxPeers:   50,
 		NAT:        nat.Any(),
 	},
 }


### PR DESCRIPTION
This is a tiny PR to bump the default peer count form 25 to 50. This is especially helpful during fast sync (reduces sync time by 2 hours) as it permits more concurrent state retrievals to be running. On the flip side, it does increase baseline network chatter post-sync from 40 to 80KB/s.