### PR TITLE
accounts,signer: better support for EIP-191 intended validator

### DIFF
--- a/accounts/accounts.go
+++ b/accounts/accounts.go
@@ -36,7 +36,7 @@ type Account struct {
 }
 
 const (
-	MimetypeTextWithValidator = "text/validator"
+	MimetypeDataWithValidator = "data/validator"
 	MimetypeTypedData         = "data/typed"
 	MimetypeClique            = "application/x-clique-header"
 	MimetypeTextPlain         = "text/plain"

--- a/signer/core/signed_data.go
+++ b/signer/core/signed_data.go
@@ -46,8 +46,8 @@ type SigFormat struct {
 }
 
 var (
-	TextValidator = SigFormat{
-		accounts.MimetypeTextWithValidator,
+	IntendedValidator = SigFormat{
+		accounts.MimetypeDataWithValidator,
 		0x00,
 	}
 	DataTyped = SigFormat{
@@ -191,7 +191,7 @@ func (api *SignerAPI) determineSignatureFormat(ctx context.Context, contentType 
 	}
 
 	switch mediaType {
-	case TextValidator.Mime:
+	case IntendedValidator.Mime:
 		// Data with an intended validator
 		validatorData, err := UnmarshalValidatorData(data)
 		if err != nil {
@@ -200,9 +200,24 @@ func (api *SignerAPI) determineSignatureFormat(ctx context.Context, contentType 
 		sighash, msg := SignTextValidator(validatorData)
 		message := []*NameValueType{
 			{
-				Name:  "message",
-				Typ:   "text",
-				Value: msg,
+				Name:  "This is a request to sign data intended for a particular validator (see EIP 191 version 0)",
+				Typ:   "description",
+				Value: "",
+			},
+			{
+				Name:  "Intended validator address",
+				Typ:   "address",
+				Value: validatorData.Address.String(),
+			},
+			{
+				Name:  "Application-specific data",
+				Typ:   "hexdata",
+				Value: validatorData.Message,
+			},
+			{
+				Name:  "Full message for signing",
+				Typ:   "hexdata",
+				Value: fmt.Sprintf("0x%x", msg),
 			},
 		}
 		req = &SignDataRequest{ContentType: mediaType, Rawdata: []byte(msg), Message: message, Hash: sighash}
@@ -275,7 +290,6 @@ func (api *SignerAPI) determineSignatureFormat(ctx context.Context, contentType 
 // hash = keccak256("\x19\x00"${address}${data}).
 func SignTextValidator(validatorData ValidatorData) (hexutil.Bytes, string) {
 	msg := fmt.Sprintf("\x19\x00%s%s", string(validatorData.Address.Bytes()), string(validatorData.Message))
-	fmt.Printf("SignTextValidator:%s\n", msg)
 	return crypto.Keccak256([]byte(msg)), msg
 }
 


### PR DESCRIPTION
This PR is in support of https://github.com/ethereum/go-ethereum/pull/17578 , to make use of Clef and EIp-191 to sign data with intended validators. 
With this PR, the signature can be obtained thus: 
This is the request data : 
```json
{
  "id": 68,
  "jsonrpc": "2.0",
  "method": "account_signData",
  "params": [
    "data/validator",
    "0x8a8eafb1cf62bfbeb1741769dae1a9dd47996192",
    {
      "address": "0xdeadfeeedcafe000000000000000000000000cff",
      "message": "0x000000e3a2e0b25d72c2fc6e35a7f853cdacb193b4b4f95c606accf7f8fa8415283582c7"
    }
  ]
}
```
It the `0x000000e3a2e0b25d72c2fc6e35a7f853cdacb193b4b4f95c606accf7f8fa8415283582c7` is, in that case, the `sectionId` and the `hash` we want to sign. That data cannot be validated by clef, it's application-speciic data. However, the `address` of the intended validator can be shown to the user. 

The user is presented with the following:
```
-------- Sign data request--------------
Account:  0x8a8eafb1cf62bfbeb1741769dae1a9dd47996192 [chksum INVALID]
message:
  This is a request to sign data intended for a particular validator [description]: "(see EIP 191 version 0)"

  Intended validator address [address]: "0xdEAdfEeEdCAfE000000000000000000000000CfF"

  Application-specific data [hexdata]: "0x000000e3a2e0b25d72c2fc6e35a7f853cdacb193b4b4f95c606accf7f8fa8415283582c7"

  Full message for signing [hexdata]: "0x1900deadfeeedcafe000000000000000000000000cff000000e3a2e0b25d72c2fc6e35a7f853cdacb193b4b4f95c606accf7f8fa8415283582c7"

raw data:  
"\x19\x00ޭ\xfe\xeeܯ\xe0\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\f\xff\x00\x00\x00\xe3\xa2\xe0\xb2]r\xc2\xfcn5\xa7\xf8Sͬ\xb1\x93\xb4\xb4\xf9\\`j\xcc\xf7\xf8\xfa\x84\x15(5\x82\xc7"
message hash:  0x0866a62bc5239cf21161b898e9415be7e3e94ba1fbfcf589c4e00b151729a6aa
-------------------------------------------
Request context:
        127.0.0.1:41582 -> HTTP/1.1 -> localhost:8550

Additional HTTP header data, provided by the external caller:
        User-Agent: curl/7.59.0
        Origin: 
Approve? [y/N]:
```
And the response:
```
HTTP/1.1 200 OK
Content-Type: application/json
Vary: Origin
Date: Fri, 03 May 2019 12:09:35 GMT
Content-Length: 170

{"jsonrpc":"2.0","id":68,"result":"0xe372691180069c73a7247f27f652a0c15b0ac4ff6ee299619f98ea48a213ccd53f8e3c8cbd29bd87e570905020041a1ef655b308f1b479991a074fe5010bceec1c"}
```
The produced signature is in the `[R || S || V]`  form, where `V` is  27 or 28. 