### PR TITLE
accounts/scwallet: Display PUK retry count

### DIFF
--- a/accounts/scwallet/wallet.go
+++ b/accounts/scwallet/wallet.go
@@ -982,12 +982,10 @@ func (s *Session) derive(path accounts.DerivationPath) (accounts.Account, error)
 	copy(sig[32-len(rbytes):32], rbytes)
 	copy(sig[64-len(sbytes):64], sbytes)
 
-	pubkey, err := determinePublicKey(sig, sigdata.PublicKey)
-	if err != nil {
+	if err := confirmPublicKey(sig, sigdata.PublicKey); err != nil {
 		return accounts.Account{}, err
 	}
-
-	pub, err := crypto.UnmarshalPubkey(pubkey)
+	pub, err := crypto.UnmarshalPubkey(sigdata.PublicKey)
 	if err != nil {
 		return accounts.Account{}, err
 	}
@@ -1057,10 +1055,10 @@ func (s *Session) sign(path accounts.DerivationPath, hash []byte) ([]byte, error
 	return sig, nil
 }
 
-// determinePublicKey uses a signature and the X component of a public key to
-// recover the entire public key.
-func determinePublicKey(sig, pubkeyX []byte) ([]byte, error) {
-	return makeRecoverableSignature(DerivationSignatureHash[:], sig, pubkeyX)
+// confirmPublicKey confirms that the given signature belongs to the specified key.
+func confirmPublicKey(sig, pubkey []byte) error {
+	_, err := makeRecoverableSignature(DerivationSignatureHash[:], sig, pubkey)
+	return err
 }
 
 // makeRecoverableSignature uses a signature and an expected public key to


### PR DESCRIPTION
The remaining PUK count wasn't displayed in the console's status message.

There was another issue with the length of the PIN and PUK not being checked. If they are under their minimum length (6 and 12 respectively) the card will not decrease the retry count - and confuse the user. As a result, there will be a data. With this PR, the user is now warned that their input is too short.