### PR TITLE
trie: fix merkle proof

### DIFF
--- a/trie/proof.go
+++ b/trie/proof.go
@@ -103,19 +103,15 @@ func (t *SecureTrie) Prove(key []byte, fromLevel uint, proofDb ethdb.Writer) err
 // VerifyProof checks merkle proofs. The given proof must contain the value for
 // key in a trie with the given root hash. VerifyProof returns an error if the
 // proof contains invalid trie nodes or the wrong value.
+//
+// Note, the method assumes that all key-values in proofDb satisfy key = hash(value).
 func VerifyProof(rootHash common.Hash, key []byte, proofDb ethdb.Reader) (value []byte, nodes int, err error) {
-	hasher := newHasher(nil)
-	defer returnHasherToPool(hasher)
-
 	key = keybytesToHex(key)
 	wantHash := rootHash
 	for i := 0; ; i++ {
 		buf, _ := proofDb.Get(wantHash[:])
 		if buf == nil {
 			return nil, i, fmt.Errorf("proof node %d (hash %064x) missing", i, wantHash)
-		}
-		if !bytes.Equal(hasher.makeHashNode(buf), wantHash.Bytes()) {
-			return nil, i, fmt.Errorf("proof node %d (hash %064x) invalid", i, wantHash)
 		}
 		n, err := decodeNode(wantHash[:], buf)
 		if err != nil {

--- a/trie/proof.go
+++ b/trie/proof.go
@@ -112,6 +112,9 @@ func VerifyProof(rootHash common.Hash, key []byte, proofDb ethdb.Reader) (value 
 		if buf == nil {
 			return nil, i, fmt.Errorf("proof node %d (hash %064x) missing", i, wantHash)
 		}
+		if bytes.Compare(crypto.Keccak256(buf), wantHash[:]) != 0 {
+			return nil, i, fmt.Errorf("proof node %d (hash %64x) invalid", i, wantHash)
+		}
 		n, err := decodeNode(wantHash[:], buf)
 		if err != nil {
 			return nil, i, fmt.Errorf("bad proof node %d: %v", i, err)

--- a/trie/proof_test.go
+++ b/trie/proof_test.go
@@ -125,35 +125,6 @@ func TestBadProof(t *testing.T) {
 	}
 }
 
-func TestMutateValueProof(t *testing.T) {
-	trie, vals := randomTrie(800)
-	root := trie.Hash()
-	for i, prover := range makeProvers(trie) {
-		for _, kv := range vals {
-			proof := prover(kv.k)
-			if proof == nil {
-				t.Fatalf("prover %d: nil proof", i)
-			}
-			it := proof.NewIterator()
-			for i, d := 0, mrand.Intn(proof.Len()); i <= d; i++ {
-				it.Next()
-			}
-			key := it.Key()
-			val, _ := proof.Get(key)
-			proof.Delete(key)
-			it.Release()
-
-			origin := crypto.Keccak256(val)
-			mutateByte(val)
-			proof.Put(origin, val)
-
-			if _, _, err := VerifyProof(root, kv.k, proof); err == nil {
-				t.Fatalf("prover %d: expected proof to fail for key %x", i, kv.k)
-			}
-		}
-	}
-}
-
 // Tests that missing keys can also be proven. The test explicitly uses a single
 // entry trie and checks for missing keys both before and after the single entry.
 func TestMissingKeyProof(t *testing.T) {


### PR DESCRIPTION
The security guarantee of merkle proof is: malicious attacker can't create fake data with valid hash.
It is correct for root hash checking, but for the remaining node checking, we should compare the hash and keccak256(value) first, otherwise e.g attacker can temper the value of leaf node.