### PR TITLE
 p2p/discover: add support for EIP-868 (v4 ENR extension)

### DIFF
--- a/p2p/discover/table.go
+++ b/p2p/discover/table.go
@@ -62,6 +62,9 @@ const (
 	seedMaxAge          = 5 * 24 * time.Hour
 )
 
+// Table is the 'node table', a Kademlia-like index of neighbor nodes. The table keeps
+// itself up-to-date by verifying the liveness of neighbors and requesting their node
+// records when announcements of a new record version are received.
 type Table struct {
 	mutex   sync.Mutex        // protects buckets, bucket content, nursery, rand
 	buckets [nBuckets]*bucket // index of known nodes by distance
@@ -80,12 +83,13 @@ type Table struct {
 	nodeAddedHook func(*node) // for testing
 }
 
-// transport is implemented by UDP transports.
+// transport is implemented by the UDP transports.
 type transport interface {
 	Self() *enode.Node
 	lookupRandom() []*enode.Node
 	lookupSelf() []*enode.Node
-	ping(*enode.Node) error
+	ping(*enode.Node) (seq uint64, err error)
+	requestENR(*enode.Node) (*enode.Node, error)
 }
 
 // bucket contains nodes, ordered by their last activity. the entry
@@ -176,14 +180,16 @@ func (tab *Table) ReadRandomNodes(buf []*enode.Node) (n int) {
 	return i + 1
 }
 
-// Resolve searches for a specific node with the given ID.
-// It returns nil if the node could not be found.
-func (tab *Table) Resolve(n *enode.Node) *enode.Node {
+// getNode returns the node with the given ID or nil if it isn't in the table.
+func (tab *Table) getNode(id enode.ID) *enode.Node {
 	tab.mutex.Lock()
-	cl := tab.closest(n.ID(), 1, false)
-	tab.mutex.Unlock()
-	if len(cl.entries) > 0 && cl.entries[0].ID() == n.ID() {
-		return unwrapNode(cl.entries[0])
+	defer tab.mutex.Unlock()
+
+	b := tab.bucket(id)
+	for _, e := range b.entries {
+		if e.ID() == id {
+			return unwrapNode(e)
+		}
 	}
 	return nil
 }
@@ -227,7 +233,7 @@ func (tab *Table) refresh() <-chan struct{} {
 	return done
 }
 
-// loop schedules refresh, revalidate runs and coordinates shutdown.
+// loop schedules runs of doRefresh, doRevalidate and copyLiveNodes.
 func (tab *Table) loop() {
 	var (
 		revalidate     = time.NewTimer(tab.nextRevalidateTime())
@@ -289,9 +295,8 @@ loop:
 	close(tab.closed)
 }
 
-// doRefresh performs a lookup for a random target to keep buckets
-// full. seed nodes are inserted if the table is empty (initial
-// bootstrap or discarded faulty peers).
+// doRefresh performs a lookup for a random target to keep buckets full. seed nodes are
+// inserted if the table is empty (initial bootstrap or discarded faulty peers).
 func (tab *Table) doRefresh(done chan struct{}) {
 	defer close(done)
 
@@ -325,8 +330,8 @@ func (tab *Table) loadSeedNodes() {
 	}
 }
 
-// doRevalidate checks that the last node in a random bucket is still live
-// and replaces or deletes the node if it isn't.
+// doRevalidate checks that the last node in a random bucket is still live and replaces or
+// deletes the node if it isn't.
 func (tab *Table) doRevalidate(done chan<- struct{}) {
 	defer func() { done <- struct{}{} }()
 
@@ -337,7 +342,17 @@ func (tab *Table) doRevalidate(done chan<- struct{}) {
 	}
 
 	// Ping the selected node and wait for a pong.
-	err := tab.net.ping(unwrapNode(last))
+	remoteSeq, err := tab.net.ping(unwrapNode(last))
+
+	// Also fetch record if the node replied and returned a higher sequence number.
+	if last.Seq() < remoteSeq {
+		n, err := tab.net.requestENR(unwrapNode(last))
+		if err != nil {
+			tab.log.Debug("ENR request failed", "id", last.ID(), "addr", last.addr(), "err", err)
+		} else {
+			last = &node{Node: *n, addedAt: last.addedAt, livenessChecks: last.livenessChecks}
+		}
+	}
 
 	tab.mutex.Lock()
 	defer tab.mutex.Unlock()

--- a/p2p/discover/table.go
+++ b/p2p/discover/table.go
@@ -53,13 +53,12 @@ const (
 	bucketIPLimit, bucketSubnet = 2, 24 // at most 2 addresses from the same /24
 	tableIPLimit, tableSubnet   = 10, 24
 
-	maxFindnodeFailures = 5 // Nodes exceeding this limit are dropped
-	refreshInterval     = 30 * time.Minute
-	revalidateInterval  = 10 * time.Second
-	copyNodesInterval   = 30 * time.Second
-	seedMinTableTime    = 5 * time.Minute
-	seedCount           = 30
-	seedMaxAge          = 5 * 24 * time.Hour
+	refreshInterval    = 30 * time.Minute
+	revalidateInterval = 10 * time.Second
+	copyNodesInterval  = 30 * time.Second
+	seedMinTableTime   = 5 * time.Minute
+	seedCount          = 30
+	seedMaxAge         = 5 * 24 * time.Hour
 )
 
 // Table is the 'node table', a Kademlia-like index of neighbor nodes. The table keeps

--- a/p2p/discover/table_util_test.go
+++ b/p2p/discover/table_util_test.go
@@ -97,6 +97,7 @@ func fillTable(tab *Table, nodes []*node) {
 type pingRecorder struct {
 	mu           sync.Mutex
 	dead, pinged map[enode.ID]bool
+	records      map[enode.ID]*enode.Node
 	n            *enode.Node
 }
 
@@ -106,37 +107,52 @@ func newPingRecorder() *pingRecorder {
 	n := enode.SignNull(&r, enode.ID{})
 
 	return &pingRecorder{
-		dead:   make(map[enode.ID]bool),
-		pinged: make(map[enode.ID]bool),
-		n:      n,
+		dead:    make(map[enode.ID]bool),
+		pinged:  make(map[enode.ID]bool),
+		records: make(map[enode.ID]*enode.Node),
+		n:       n,
 	}
 }
 
-func (t *pingRecorder) Self() *enode.Node {
-	return nullNode
+// setRecord updates a node record. Future calls to ping and
+// requestENR will return this record.
+func (t *pingRecorder) updateRecord(n *enode.Node) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.records[n.ID()] = n
 }
 
-func (t *pingRecorder) ping(n *enode.Node) error {
+// Stubs to satisfy the transport interface.
+func (t *pingRecorder) Self() *enode.Node           { return nullNode }
+func (t *pingRecorder) lookupSelf() []*enode.Node   { return nil }
+func (t *pingRecorder) lookupRandom() []*enode.Node { return nil }
+func (t *pingRecorder) close()                      {}
+
+// ping simulates a ping request.
+func (t *pingRecorder) ping(n *enode.Node) (seq uint64, err error) {
 	t.mu.Lock()
 	defer t.mu.Unlock()
 
 	t.pinged[n.ID()] = true
 	if t.dead[n.ID()] {
-		return errTimeout
-	} else {
-		return nil
+		return 0, errTimeout
 	}
+	if t.records[n.ID()] != nil {
+		seq = t.records[n.ID()].Seq()
+	}
+	return seq, nil
 }
 
-func (t *pingRecorder) lookupSelf() []*enode.Node {
-	return nil
-}
+// requestENR simulates an ENR request.
+func (t *pingRecorder) requestENR(n *enode.Node) (*enode.Node, error) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
 
-func (t *pingRecorder) lookupRandom() []*enode.Node {
-	return nil
+	if t.dead[n.ID()] || t.records[n.ID()] == nil {
+		return nil, errTimeout
+	}
+	return t.records[n.ID()], nil
 }
-
-func (t *pingRecorder) close() {}
 
 func hasDuplicates(slice []*node) bool {
 	seen := make(map[enode.ID]bool)

--- a/p2p/discover/v4_udp.go
+++ b/p2p/discover/v4_udp.go
@@ -48,12 +48,12 @@ var (
 	errClosed           = errors.New("socket closed")
 )
 
-// Timeouts
 const (
 	respTimeout    = 500 * time.Millisecond
 	expiration     = 20 * time.Second
 	bondExpiration = 24 * time.Hour
 
+	maxFindnodeFailures = 5                // nodes exceeding this limit are dropped
 	ntpFailureThreshold = 32               // Continuous timeouts after which to check NTP
 	ntpWarningCooldown  = 10 * time.Minute // Minimum amount of time to pass before repeating NTP warning
 	driftThreshold      = 10 * time.Second // Allowed clock drift before warning user
@@ -840,7 +840,7 @@ func (t *UDPv4) checkBond(id enode.ID, ip net.IP) bool {
 // This ensures there is a valid endpoint proof on the remote end.
 func (t *UDPv4) ensureBond(toid enode.ID, toaddr *net.UDPAddr) {
 	tooOld := time.Since(t.db.LastPingReceived(toid, toaddr.IP)) > bondExpiration
-	if tooOld || t.db.FindFails(toid, toaddr.IP) > 5 {
+	if tooOld || t.db.FindFails(toid, toaddr.IP) > maxFindnodeFailures {
 		rm := t.sendPing(toid, toaddr, nil)
 		<-rm.errc
 		// Wait for them to ping back and process our pong.

--- a/p2p/discover/v4_udp.go
+++ b/p2p/discover/v4_udp.go
@@ -551,6 +551,9 @@ func (t *UDPv4) requestENR(n *enode.Node) (*enode.Node, error) {
 	if respN.ID() != n.ID() {
 		return nil, fmt.Errorf("invalid ID in response record")
 	}
+	if respN.Seq() < n.Seq() {
+		return n, nil // response record is older
+	}
 	if err := netutil.CheckRelayIP(addr.IP, respN.IP()); err != nil {
 		return nil, fmt.Errorf("invalid IP in response record: %v", err)
 	}

--- a/p2p/discover/v4_udp_lookup_test.go
+++ b/p2p/discover/v4_udp_lookup_test.go
@@ -54,11 +54,11 @@ func TestUDPv4_Lookup(t *testing.T) {
 			n, key := lookupTestnet.nodeByAddr(to)
 			switch p.(type) {
 			case *pingV4:
-				test.packetInFrom(nil, key, to, p_pongV4, &pongV4{Expiration: futureExp, ReplyTok: hash})
+				test.packetInFrom(nil, key, to, &pongV4{Expiration: futureExp, ReplyTok: hash})
 			case *findnodeV4:
 				dist := enode.LogDist(n.ID(), lookupTestnet.target.id())
 				nodes := lookupTestnet.nodesAtDistance(dist - 1)
-				test.packetInFrom(nil, key, to, p_neighborsV4, &neighborsV4{Expiration: futureExp, Nodes: nodes})
+				test.packetInFrom(nil, key, to, &neighborsV4{Expiration: futureExp, Nodes: nodes})
 			}
 		})
 	}


### PR DESCRIPTION
This change implements [EIP-868]. The UDPv4 transport announces support
for the extension in ping/pong and handles enrRequest messages.

There are two uses of the extension: If a remote node announces support
for EIP-868 in their pong, node revalidation pulls the node's record.
The Resolve method requests the record unconditionally.

[EIP-868]: https://eips.ethereum.org/EIPS/eip-868