### PR TITLE
core: fix import errors on clique crashes + empty blocks

### DIFF
--- a/consensus/clique/clique_test.go
+++ b/consensus/clique/clique_test.go
@@ -1,0 +1,113 @@
+// Copyright 2019 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+package clique
+
+import (
+	"math/big"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core"
+	"github.com/ethereum/go-ethereum/core/rawdb"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/core/vm"
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/params"
+)
+
+// This test case is a repro of an annoying bug that took us forever to catch.
+// In Clique PoA networks (Rinkeby, Görli, etc), consecutive blocks might have
+// the same state root (no block subsidy, empty block). If a node crashes, the
+// chain ends up losing the recent state and needs to regenerate it from blocks
+// already in the database. The bug was that processing the block *prior* to an
+// empty one **also completes** the empty one, ending up in a known-block error.
+func TestReimportMirroredState(t *testing.T) {
+	// Initialize a Clique chain with a single signer
+	var (
+		db     = rawdb.NewMemoryDatabase()
+		key, _ = crypto.HexToECDSA("b71c71a67e1177ad4e901695e1b4b9ee17ae16c6668d313eac2f96dbcda3f291")
+		addr   = crypto.PubkeyToAddress(key.PublicKey)
+		engine = New(params.AllCliqueProtocolChanges.Clique, db)
+		signer = new(types.HomesteadSigner)
+	)
+	genspec := &core.Genesis{
+		ExtraData: make([]byte, extraVanity+common.AddressLength+extraSeal),
+		Alloc: map[common.Address]core.GenesisAccount{
+			addr: {Balance: big.NewInt(1)},
+		},
+	}
+	copy(genspec.ExtraData[extraVanity:], addr[:])
+	genesis := genspec.MustCommit(db)
+
+	// Generate a batch of blocks, each properly signed
+	chain, _ := core.NewBlockChain(db, nil, params.AllCliqueProtocolChanges, engine, vm.Config{}, nil)
+	defer chain.Stop()
+
+	blocks, _ := core.GenerateChain(params.AllCliqueProtocolChanges, genesis, engine, db, 3, func(i int, block *core.BlockGen) {
+		// The chain maker doesn't have access to a chain, so the difficulty will be
+		// lets unset (nil). Set it here to the correct value.
+		block.SetDifficulty(diffInTurn)
+
+		// We want to simulate an empty middle block, having the same state as the
+		// first one. The last is needs a state change again to force a reorg.
+		if i != 1 {
+			tx, err := types.SignTx(types.NewTransaction(block.TxNonce(addr), common.Address{0x00}, new(big.Int), params.TxGas, nil, nil), signer, key)
+			if err != nil {
+				panic(err)
+			}
+			block.AddTxWithChain(chain, tx)
+		}
+	})
+	for i, block := range blocks {
+		header := block.Header()
+		if i > 0 {
+			header.ParentHash = blocks[i-1].Hash()
+		}
+		header.Extra = make([]byte, extraVanity+extraSeal)
+		header.Difficulty = diffInTurn
+
+		sig, _ := crypto.Sign(SealHash(header).Bytes(), key)
+		copy(header.Extra[len(header.Extra)-extraSeal:], sig)
+		blocks[i] = block.WithSeal(header)
+	}
+	// Insert the first two blocks and make sure the chain is valid
+	db = rawdb.NewMemoryDatabase()
+	genspec.MustCommit(db)
+
+	chain, _ = core.NewBlockChain(db, nil, params.AllCliqueProtocolChanges, engine, vm.Config{}, nil)
+	defer chain.Stop()
+
+	if _, err := chain.InsertChain(blocks[:2]); err != nil {
+		t.Fatalf("failed to insert initial blocks: %v", err)
+	}
+	if head := chain.CurrentBlock().NumberU64(); head != 2 {
+		t.Fatalf("chain head mismatch: have %d, want %d", head, 2)
+	}
+
+	// Simulate a crash by creating a new chain on top of the database, without
+	// flushing the dirty states out. Insert the last block, trigerring a sidechain
+	// reimport.
+	chain, _ = core.NewBlockChain(db, nil, params.AllCliqueProtocolChanges, engine, vm.Config{}, nil)
+	defer chain.Stop()
+
+	if _, err := chain.InsertChain(blocks[2:]); err != nil {
+		t.Fatalf("failed to insert final block: %v", err)
+	}
+	if head := chain.CurrentBlock().NumberU64(); head != 3 {
+		t.Fatalf("chain head mismatch: have %d, want %d", head, 3)
+	}
+}

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -1238,7 +1238,11 @@ func (bc *BlockChain) insertChain(chain types.Blocks, verifySeals bool) (int, []
 		// just skip the block (we already validated it once fully (and crashed), since
 		// its header and body was already in the database).
 		if err == ErrKnownBlock {
-			log.Debug("Inserted known block", "number", block.Number(), "hash", block.Hash(),
+			logger := log.Debug
+			if bc.chainConfig.Clique == nil {
+				logger = log.Warn
+			}
+			logger("Inserted known block", "number", block.Number(), "hash", block.Hash(),
 				"uncles", len(block.Uncles()), "txs", len(block.Transactions()), "gas", block.GasUsed(),
 				"root", block.Root())
 

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -1247,9 +1247,8 @@ func (bc *BlockChain) insertChain(chain types.Blocks, verifySeals bool) (int, []
 			}
 			stats.processed++
 
-			// TODO(karalabe): Can we assume canonicalness here? Can we assume no logs?
-			// In theory I can make a block *with* transactions but *no* state change if
-			// the only transactions are miner-self-sends or 0-price-self-sends.
+			// We can assume that logs are empty here, since the only way for consecutive
+			// Clique blocks to have the same state is if there are no transactions.
 			events = append(events, ChainEvent{block, block.Hash(), nil})
 			lastCanon = block
 

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -1169,7 +1169,9 @@ func (bc *BlockChain) insertChain(chain types.Blocks, verifySeals bool) (int, []
 			if localTd.Cmp(externTd) < 0 {
 				break
 			}
+			log.Debug("Ignoring already known block", "number", block.Number(), "hash", block.Hash())
 			stats.ignored++
+
 			block, err = it.next()
 		}
 		// The remaining blocks are still known blocks, the only scenario here is:
@@ -1181,6 +1183,7 @@ func (bc *BlockChain) insertChain(chain types.Blocks, verifySeals bool) (int, []
 		// `insertChain` while a part of them have higher total difficulty than current
 		// head full block(new pivot point).
 		for block != nil && err == ErrKnownBlock {
+			log.Debug("Writing previously known block", "number", block.Number(), "hash", block.Hash())
 			if err := bc.writeKnownBlock(block); err != nil {
 				return it.index, nil, nil, err
 			}
@@ -1190,15 +1193,16 @@ func (bc *BlockChain) insertChain(chain types.Blocks, verifySeals bool) (int, []
 		}
 		// Falls through to the block import
 	}
-
 	switch {
 	// First block is pruned, insert as sidechain and reorg only if TD grows enough
 	case err == consensus.ErrPrunedAncestor:
+		log.Debug("Pruned ancestor, inserting as sidechain", "number", block.Number(), "hash", block.Hash())
 		return bc.insertSideChain(block, it)
 
 	// First block is future, shove it (and all children) to the future queue (unknown ancestor)
 	case err == consensus.ErrFutureBlock || (err == consensus.ErrUnknownAncestor && bc.futureBlocks.Contains(it.first().ParentHash())):
 		for block != nil && (it.index == 0 || err == consensus.ErrUnknownAncestor) {
+			log.Debug("Future block, postponing import", "number", block.Number(), "hash", block.Hash())
 			if err := bc.addFutureBlock(block); err != nil {
 				return it.index, events, coalescedLogs, err
 			}
@@ -1217,7 +1221,7 @@ func (bc *BlockChain) insertChain(chain types.Blocks, verifySeals bool) (int, []
 		return it.index, events, coalescedLogs, err
 	}
 	// No validation errors for the first block (or chain prefix skipped)
-	for ; block != nil && err == nil; block, err = it.next() {
+	for ; block != nil && err == nil || err == ErrKnownBlock; block, err = it.next() {
 		// If the chain is terminating, stop processing blocks
 		if atomic.LoadInt32(&bc.procInterrupt) == 1 {
 			log.Debug("Premature abort during blocks processing")
@@ -1227,6 +1231,29 @@ func (bc *BlockChain) insertChain(chain types.Blocks, verifySeals bool) (int, []
 		if BadHashes[block.Hash()] {
 			bc.reportBlock(block, nil, ErrBlacklistedHash)
 			return it.index, events, coalescedLogs, ErrBlacklistedHash
+		}
+		// If the block is known (in the middle of the chain), it's a special case for
+		// Clique blocks where they can share state among each other, so importing an
+		// older block might complete the state of the subsequent one. In this case,
+		// just skip the block (we already validated it once fully (and crashed), since
+		// its header and body was already in the database).
+		if err == ErrKnownBlock {
+			log.Debug("Inserted known block", "number", block.Number(), "hash", block.Hash(),
+				"uncles", len(block.Uncles()), "txs", len(block.Transactions()), "gas", block.GasUsed(),
+				"root", block.Root())
+
+			if err := bc.writeKnownBlock(block); err != nil {
+				return it.index, nil, nil, err
+			}
+			stats.processed++
+
+			// TODO(karalabe): Can we assume canonicalness here? Can we assume no logs?
+			// In theory I can make a block *with* transactions but *no* state change if
+			// the only transactions are miner-self-sends or 0-price-self-sends.
+			events = append(events, ChainEvent{block, block.Hash(), nil})
+			lastCanon = block
+
+			continue
 		}
 		// Retrieve the parent block and it's state to execute on top
 		start := time.Now()
@@ -1327,6 +1354,14 @@ func (bc *BlockChain) insertChain(chain types.Blocks, verifySeals bool) (int, []
 				"txs", len(block.Transactions()), "gas", block.GasUsed(), "uncles", len(block.Uncles()),
 				"root", block.Root())
 			events = append(events, ChainSideEvent{block})
+
+		default:
+			// This in theory is impossible, but lets be nice to our future selves and leave
+			// a log, instead of trying to track down blocks imports that don't emit logs.
+			log.Warn("Inserted block with unknown status", "number", block.Number(), "hash", block.Hash(),
+				"diff", block.Difficulty(), "elapsed", common.PrettyDuration(time.Since(start)),
+				"txs", len(block.Transactions()), "gas", block.GasUsed(), "uncles", len(block.Uncles()),
+				"root", block.Root())
 		}
 		stats.processed++
 		stats.usedGas += usedGas

--- a/core/chain_makers.go
+++ b/core/chain_makers.go
@@ -71,6 +71,13 @@ func (b *BlockGen) SetNonce(nonce types.BlockNonce) {
 	b.header.Nonce = nonce
 }
 
+// SetDifficulty sets the difficulty field of the generated block. This method is
+// useful for Clique tests where the difficulty does not depend on time. For the
+// ethash tests, please use OffsetTime, which implicitly recalculates the diff.
+func (b *BlockGen) SetDifficulty(diff *big.Int) {
+	b.header.Difficulty = diff
+}
+
 // AddTx adds a transaction to the generated block. If no coinbase has
 // been set, the block's coinbase is set to the zero address.
 //


### PR DESCRIPTION
This PR fixes an issue during reimporting old blocks on a Clique network after a node crash.

The root of the issue is that Clique doesn't have block subsidy, so it can happen that two consecutive blocks have the same state (e.g. no transactions, self-transactions with 0 gas price, self-transactions by the miner).

If the node crashes (we lose the recent state), Geth will rewind the head block to the first one that we do have the state for. From that point onward, we try to reprocess all the blocks. If however two **previously known** blocks have the same state, processing the first one will also complete the second. Currently the block importer rejects the second with a "known block" error, since it doesn't expect this scenario (it rewound because no state was present, how did the state reappear out of the blue?).

This PR adds a new clause to the block importer, so that instead of rejecting an already known block, we simply ignore it and proceed to the next one. Although the code seems simple, we should try to ensure that nothing breaks.

**Q: Until now we rejected known blocks in such cases. Is it a problem that we do not any more?**
A: Although we did reject a known block previously, it just failed the sync, we restarted it, and the restart completely skipped the block (since it was known). As such, ignoring it instead of *temporarily* rejecting seems fine.

Test output for inspection:

```
=== RUN   TestReimportMirroredState
INFO [05-10|15:39:29.564] Persisted trie from memory database      nodes=1 size=140.00B time=8.789µs gcnodes=0 gcsize=0.00B gctime=0s livenodes=1 livesize=0.00B
INFO [05-10|15:39:29.572] Loaded most recent local header          number=0 hash=7b72ae…73d63e td=0 age=50y3w5d
INFO [05-10|15:39:29.572] Loaded most recent local full block      number=0 hash=7b72ae…73d63e td=0 age=50y3w5d
INFO [05-10|15:39:29.572] Loaded most recent local fast block      number=0 hash=7b72ae…73d63e td=0 age=50y3w5d
DEBUG[05-10|15:39:29.572] Persisted trie from memory database      nodes=1 size=140.00B time=4.573µs gcnodes=0 gcsize=0.00B gctime=0s livenodes=1 livesize=0.00B
DEBUG[05-10|15:39:29.572] Persisted trie from memory database      nodes=0 size=0.00B   time=926ns   gcnodes=0 gcsize=0.00B gctime=0s livenodes=1 livesize=0.00B
DEBUG[05-10|15:39:29.573] Persisted trie from memory database      nodes=1 size=140.00B time=3.207µs gcnodes=0 gcsize=0.00B gctime=0s livenodes=1 livesize=0.00B
INFO [05-10|15:39:29.573] Persisted trie from memory database      nodes=1 size=140.00B time=3µs     gcnodes=0 gcsize=0.00B gctime=0s livenodes=1 livesize=0.00B
INFO [05-10|15:39:29.581] Loaded most recent local header          number=0 hash=7b72ae…73d63e td=0 age=50y3w5d
INFO [05-10|15:39:29.581] Loaded most recent local full block      number=0 hash=7b72ae…73d63e td=0 age=50y3w5d
INFO [05-10|15:39:29.581] Loaded most recent local fast block      number=0 hash=7b72ae…73d63e td=0 age=50y3w5d
INFO [05-10|15:39:29.582] Stored checkpoint snapshot to disk       number=0 hash=7b72ae…73d63e
DEBUG[05-10|15:39:29.583] Inserted new block                       number=1 hash=9fa29f…98fa04 uncles=0 txs=1 gas=21000 elapsed=432.077µs root=9f1331…374441
DEBUG[05-10|15:39:29.583] Inserted new block                       number=2 hash=66a17b…b3a422 uncles=0 txs=0 gas=0     elapsed=41.416µs  root=9f1331…374441
INFO [05-10|15:39:29.583] Imported new chain segment               blocks=2 txs=1 mgas=0.021 elapsed=1.279ms   mgasps=16.411 number=2 hash=66a17b…b3a422 age=50y3w5d dirty=236.00B
WARN [05-10|15:39:29.589] Head state missing, repairing chain      number=2 hash=66a17b…b3a422
INFO [05-10|15:39:29.589] Rewound blockchain to past state         number=0 hash=7b72ae…73d63e
INFO [05-10|15:39:29.589] Loaded most recent local header          number=2 hash=66a17b…b3a422 td=4 age=50y3w5d
INFO [05-10|15:39:29.589] Loaded most recent local full block      number=0 hash=7b72ae…73d63e td=0 age=50y3w5d
INFO [05-10|15:39:29.589] Loaded most recent local fast block      number=2 hash=66a17b…b3a422 td=4 age=50y3w5d
DEBUG[05-10|15:39:29.590] Pruned ancestor, inserting as sidechain  number=3 hash=76a91d…17cfbd
DEBUG[05-10|15:39:29.590] Injected sidechain block                 number=3 hash=76a91d…17cfbd diff=2 elapsed=29.853µs  txs=1 gas=21000 uncles=0 root=2806f8…f63b47
INFO [05-10|15:39:29.590] Importing sidechain segment              start=1 end=3
DEBUG[05-10|15:39:29.591] Inserted new block                       number=1 hash=9fa29f…98fa04 uncles=0 txs=1 gas=21000 elapsed=391.125µs root=9f1331…374441
DEBUG[05-10|15:39:29.591] Inserted known block                     number=2 hash=66a17b…b3a422 uncles=0 txs=0 gas=0     root=9f1331…374441
DEBUG[05-10|15:39:29.591] Inserted new block                       number=3 hash=76a91d…17cfbd uncles=0 txs=1 gas=21000 elapsed=338.405µs root=2806f8…f63b47
INFO [05-10|15:39:29.591] Imported new chain segment               blocks=3 txs=2 mgas=0.042 elapsed=928.437µs mgasps=45.237 number=3 hash=76a91d…17cfbd age=50y3w5d dirty=472.00B
```

Fixes: https://github.com/ethereum/go-ethereum/issues/19360, https://github.com/ethereum/go-ethereum/issues/19302, https://github.com/ethereum/go-ethereum/issues/19258.