### PR TITLE
les: fixed cost table update

### DIFF
--- a/les/costtracker.go
+++ b/les/costtracker.go
@@ -346,12 +346,14 @@ func (table requestCostTable) getCost(code, amount uint64) uint64 {
 }
 
 // decode converts a cost list to a cost table
-func (list RequestCostList) decode() requestCostTable {
+func (list RequestCostList) decode(protocolLength uint64) requestCostTable {
 	table := make(requestCostTable)
 	for _, e := range list {
-		table[e.MsgCode] = &requestCosts{
-			baseCost: e.BaseCost,
-			reqCost:  e.ReqCost,
+		if e.MsgCode < protocolLength {
+			table[e.MsgCode] = &requestCosts{
+				baseCost: e.BaseCost,
+				reqCost:  e.ReqCost,
+			}
 		}
 	}
 	return table

--- a/les/peer.go
+++ b/les/peer.go
@@ -479,7 +479,7 @@ func (p *peer) Handshake(td *big.Int, head common.Hash, headNum uint64, genesis 
 			costList = testCostList()
 		}
 		send = send.add("flowControl/MRC", costList)
-		p.fcCosts = costList.decode()
+		p.fcCosts = costList.decode(ProtocolLengths[uint(p.version)])
 		p.fcParams = server.defParams
 	} else {
 		//on client node
@@ -571,7 +571,7 @@ func (p *peer) Handshake(td *big.Int, head common.Hash, headNum uint64, genesis 
 		}
 		p.fcParams = params
 		p.fcServer = flowcontrol.NewServerNode(params, &mclock.System{})
-		p.fcCosts = MRC.decode()
+		p.fcCosts = MRC.decode(ProtocolLengths[uint(p.version)])
 		if !p.isOnlyAnnounce {
 			for msgCode := range reqAvgTimeCost {
 				if p.fcCosts[msgCode] == nil {
@@ -604,7 +604,10 @@ func (p *peer) updateFlowControl(update keyValueMap) {
 	}
 	var MRC RequestCostList
 	if update.get("flowControl/MRC", &MRC) == nil {
-		p.fcCosts = MRC.decode()
+		costUpdate := MRC.decode(ProtocolLengths[uint(p.version)])
+		for code, cost := range costUpdate {
+			p.fcCosts[code] = cost
+		}
 	}
 }
 

--- a/les/peer_test.go
+++ b/les/peer_test.go
@@ -13,7 +13,7 @@ import (
 
 const (
 	test_networkid   = 10
-	protocol_version = 2123
+	protocol_version = lpv2
 )
 
 var (


### PR DESCRIPTION
This PR fixes cost table updates by AnnounceMsg. Instead of overwriting the entire table (which also allowed sending an incomplete table) we only update entries that are present in the update. Entries for unknown message codes are discarded.