### PR TITLE
swarm/metrics: track runtime metrics

### DIFF
--- a/swarm/metrics/flags.go
+++ b/swarm/metrics/flags.go
@@ -20,6 +20,7 @@ import (
 	"time"
 
 	"github.com/ethereum/go-ethereum/cmd/utils"
+	"github.com/ethereum/go-ethereum/metrics"
 	gethmetrics "github.com/ethereum/go-ethereum/metrics"
 	"github.com/ethereum/go-ethereum/metrics/influxdb"
 	"github.com/ethereum/go-ethereum/swarm/log"
@@ -91,7 +92,10 @@ func Setup(ctx *cli.Context) {
 		)
 
 		// Start system runtime metrics collection
-		go gethmetrics.CollectProcessMetrics(2 * time.Second)
+		go gethmetrics.CollectProcessMetrics(4 * time.Second)
+
+		gethmetrics.RegisterRuntimeMemStats(metrics.DefaultRegistry)
+		go gethmetrics.CaptureRuntimeMemStats(metrics.DefaultRegistry, 4*time.Second)
 
 		tagsMap := utils.SplitTagsFlag(ctx.GlobalString(MetricsInfluxDBTagsFlag.Name))
 


### PR DESCRIPTION
This PR is starting the runtime metrics collector alongside our application metrics.

I think for now we don't need fine-grained flags to enable one or the other - generally if someone is interested in metrics of Swarm currently, they are probably interested in all kinds of metrics.

I've already added a Grafana dashboard to display some of these.

This will be useful when we review the chunker fix that @jmozah submitted, AFAIK some of it is a fix for goroutine leaks.