### PR TITLE
p2p/discover: fix nil-dereference due to race

### DIFF
--- a/p2p/discover/table.go
+++ b/p2p/discover/table.go
@@ -119,7 +119,6 @@ func newTable(t transport, db *enode.DB, bootnodes []*enode.Node, log log.Logger
 	tab.seedRand()
 	tab.loadSeedNodes()
 
-	go tab.loop()
 	return tab, nil
 }
 

--- a/p2p/discover/table_util_test.go
+++ b/p2p/discover/table_util_test.go
@@ -42,6 +42,7 @@ func init() {
 func newTestTable(t transport) (*Table, *enode.DB) {
 	db, _ := enode.OpenDB("")
 	tab, _ := newTable(t, db, nil, log.Root())
+	go tab.loop()
 	return tab, db
 }
 

--- a/p2p/discover/v4_udp.go
+++ b/p2p/discover/v4_udp.go
@@ -253,6 +253,7 @@ func ListenV4(c UDPConn, ln *enode.LocalNode, cfg Config) (*UDPv4, error) {
 		return nil, err
 	}
 	t.tab = tab
+	go tab.loop()
 
 	t.wg.Add(2)
 	go t.loop()


### PR DESCRIPTION
 This PR fixes a race where table loop would self-lookup before returning from constructor

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x6e5c57]

goroutine 366 [running]:
github.com/ethereum/go-ethereum/p2p/discover.(*UDPv4).lookup(0xc0003c7a80, 0xd68ef85fa6bffa2e, 0x15c4ae6f4fcf3994, 0x866cafdc3250963, 0xeab8debbf12d1d74, 0xafe4f862677775d3, 0x86b9c414031113c9, 0xbfdeddd14dab098c, 0xc55787c859379260, 0x8, ...)
    /work/src/github.com/ethereum/go-ethereum/p2p/discover/v4_udp.go:329 +0x2a7
github.com/ethereum/go-ethereum/p2p/discover.(*UDPv4).lookupSelf(0xc0003c7a80, 0xc88eb8, 0xc00037e960, 0x0)
    /work/src/github.com/ethereum/go-ethereum/p2p/discover/v4_udp.go:309 +0xb5
github.com/ethereum/go-ethereum/p2p/discover.(*Table).doRefresh(0xc000495400, 0xc00037e960)
    /work/src/github.com/ethereum/go-ethereum/p2p/discover/table.go:304 +0x72
created by github.com/ethereum/go-ethereum/p2p/discover.(*Table).loop
    /work/src/github.com/ethereum/go-ethereum/p2p/discover/table.go:245 +0x1a0
FAIL    github.com/ethereum/go-ethereum/node    0.645s
```
The `table.loop()`, starts `go tab.doRefresh(refreshDone)` which calls `tab.net.lookupSelf()` which touches the not-yet-initialized `t.tab`.