### PR TITLE
core: initial implementation of https://eips.ethereum.org/EIPS/eip-1884

### DIFF
--- a/core/vm/instructions.go
+++ b/core/vm/instructions.go
@@ -415,6 +415,12 @@ func opBalance(pc *uint64, interpreter *EVMInterpreter, contract *Contract, memo
 	return nil, nil
 }
 
+func opSelfBalance(pc *uint64, interpreter *EVMInterpreter, contract *Contract, memory *Memory, stack *Stack) ([]byte, error) {
+	balance := interpreter.intPool.get().Set(interpreter.evm.StateDB.GetBalance(contract.Address()))
+	stack.push(balance)
+	return nil, nil
+}
+
 func opOrigin(pc *uint64, interpreter *EVMInterpreter, contract *Contract, memory *Memory, stack *Stack) ([]byte, error) {
 	stack.push(interpreter.intPool.get().SetBytes(interpreter.evm.Origin.Bytes()))
 	return nil, nil

--- a/core/vm/interpreter.go
+++ b/core/vm/interpreter.go
@@ -91,6 +91,8 @@ func NewEVMInterpreter(evm *EVM, cfg Config) *EVMInterpreter {
 	// we'll set the default jump table.
 	if !cfg.JumpTable[STOP].valid {
 		switch {
+		case evm.ChainConfig().IsIstanbul(evm.BlockNumber):
+			cfg.JumpTable = istanbulInstructionSet
 		case evm.ChainConfig().IsConstantinople(evm.BlockNumber):
 			cfg.JumpTable = constantinopleInstructionSet
 		case evm.ChainConfig().IsByzantium(evm.BlockNumber):

--- a/core/vm/jump_table.go
+++ b/core/vm/jump_table.go
@@ -58,7 +58,20 @@ var (
 	homesteadInstructionSet      = newHomesteadInstructionSet()
 	byzantiumInstructionSet      = newByzantiumInstructionSet()
 	constantinopleInstructionSet = newConstantinopleInstructionSet()
+	istanbulInstructionSet       = newIstanbulInstructionSet()
 )
+
+func newIstanbulInstructionSet() [256]operation {
+	instructionSet := newConstantinopleInstructionSet()
+	instructionSet[SELFBALANCE] = operation{
+		execute:     opSelfBalance,
+		constantGas: GasFastStep,
+		minStack:    minStack(0, 1),
+		maxStack:    maxStack(0, 1),
+		valid:       true,
+	}
+	return instructionSet
+}
 
 // NewConstantinopleInstructionSet returns the frontier, homestead
 // byzantium and contantinople instructions.

--- a/core/vm/opcodes.go
+++ b/core/vm/opcodes.go
@@ -101,6 +101,7 @@ const (
 	NUMBER
 	DIFFICULTY
 	GASLIMIT
+	SELFBALANCE
 )
 
 // 0x50 range - 'storage' and execution.

--- a/params/gas_table.go
+++ b/params/gas_table.go
@@ -90,4 +90,16 @@ var (
 
 		CreateBySuicide: 25000,
 	}
+	// GasTableEipIstanbul contain the gas re-prices for EIP 1884
+	GasTableEipIstanbul = GasTable{
+		ExtcodeSize:     700,
+		ExtcodeCopy:     700,
+		ExtcodeHash:     400,
+		Balance:         700, // Increase from 400 to 700
+		SLoad:           800,
+		Calls:           700,
+		Suicide:         5000,
+		ExpByte:         50,
+		CreateBySuicide: 25000,
+	}
 )


### PR DESCRIPTION
This PR implements https://eips.ethereum.org/EIPS/eip-1884 . 
It adds 'Istanbul' as a new hard fork, but does not impement the full puppeth support -- we will need to know how parity and aleth defines it before we can fully add it there. 
Potential TODO: refactor how we handle fork configurations, to make it 

1.  More flexible, so we can more easily configure what eips goes into a particular named HF, 
2. More tightly coupled, so we don't risk missing a config/getter/setter in one place, or copy-paste with the wrong number

That should be in a separate PR, however. 