### PR TITLE
crypto: Removed comment section referring to Cloudflare's bn curve parameters

### DIFF
--- a/crypto/bn256/cloudflare/constants.go
+++ b/crypto/bn256/cloudflare/constants.go
@@ -13,7 +13,7 @@ func bigFromBase10(s string) *big.Int {
 	return n
 }
 
-// u is the BN parameter that determines the prime: 1868033³.
+// u is the BN parameter
 var u = bigFromBase10("4965661367192848881")
 
 // Order is the number of elements in both G₁ and G₂: 36u⁴+36u³+18u²+6u+1.

--- a/crypto/bn256/cloudflare/constants.go
+++ b/crypto/bn256/cloudflare/constants.go
@@ -13,10 +13,13 @@ func bigFromBase10(s string) *big.Int {
 	return n
 }
 
-// u is the BN parameter
+// u is the BN parameter.
 var u = bigFromBase10("4965661367192848881")
 
 // Order is the number of elements in both G₁ and G₂: 36u⁴+36u³+18u²+6u+1.
+// Needs to be highly 2-adic for efficient SNARK key and proof generation.
+// Order - 1 = 2^28 * 3^2 * 13 * 29 * 983 * 11003 * 237073 * 405928799 * 1670836401704629 * 13818364434197438864469338081.
+// Refer to https://eprint.iacr.org/2013/879.pdf and https://eprint.iacr.org/2013/507.pdf for more information on these parameters.
 var Order = bigFromBase10("21888242871839275222246405745257275088548364400416034343698204186575808495617")
 
 // P is a prime over which we form a basic field: 36u⁴+36u³+24u²+6u+1.

--- a/crypto/bn256/cloudflare/gfp6.go
+++ b/crypto/bn256/cloudflare/gfp6.go
@@ -5,7 +5,7 @@ package bn256
 // http://eprint.iacr.org/2006/471.pdf.
 
 // gfP6 implements the field of size p⁶ as a cubic extension of gfP2 where τ³=ξ
-// and ξ=i+3.
+// and ξ=i+9.
 type gfP6 struct {
 	x, y, z gfP2 // value is xτ² + yτ + z
 }


### PR DESCRIPTION
Hi everyone,

Just looked at the `constants.go` file in the bn256 library used from Cloudflare, and I wonder how these parameters were generated? Did you follow the first steps of the `Algorithm 1` in https://eprint.iacr.org/2005/133.pdf, and ran the function `P(x) = 36x^4 + 36x^3 + 24x^2 + 6x + 1` until you found the smallest `u ~ 2^(m/4)` st `log_2(P(-u)) = m` (where I assume that `m` was set to `256`)? These parameters were set to these values to match with `libsnark` I guess but I do not find a paper that specifies how they were generated (maybe I am missing something obvious?)

Moreover, the given `u` does not factor in `1868033^3`, but factors in `u = 3 * 13 * 29 * 983 * 11003 * 405928799` so I removed the comment that was initially written by the Cloudflare people I assume (since the param `u` they used indeed factored in `1868033^3`).

Thanks by advance for your help

[EDIT] I see that some related comments from @shamatar and @fanbsb stayed unanswered on the PR https://github.com/ethereum/go-ethereum/pull/16203