### PR TITLE
swarm/storage: disable open tracing on indices

### DIFF
--- a/swarm/storage/localstore/subscription_pull.go
+++ b/swarm/storage/localstore/subscription_pull.go
@@ -26,9 +26,6 @@ import (
 	"github.com/ethereum/go-ethereum/metrics"
 	"github.com/ethereum/go-ethereum/swarm/chunk"
 	"github.com/ethereum/go-ethereum/swarm/shed"
-	"github.com/ethereum/go-ethereum/swarm/spancontext"
-	"github.com/opentracing/opentracing-go"
-	olog "github.com/opentracing/opentracing-go/log"
 	"github.com/syndtr/goleveldb/leveldb"
 )
 
@@ -88,9 +85,6 @@ func (db *DB) SubscribePull(ctx context.Context, bin uint8, since, until uint64)
 				// - context is done
 				metrics.GetOrRegisterCounter(metricName+".iter", nil).Inc(1)
 
-				ctx, sp := spancontext.StartSpan(ctx, metricName+".iter")
-				sp.LogFields(olog.Int("bin", int(bin)), olog.Uint64("since", since), olog.Uint64("until", until))
-
 				iterStart := time.Now()
 				var count int
 				err := db.pullIndex.Iterate(func(item shed.Item) (stop bool, err error) {
@@ -130,15 +124,6 @@ func (db *DB) SubscribePull(ctx context.Context, bin uint8, since, until uint64)
 				})
 
 				totalTimeMetric(metricName+".iter", iterStart)
-
-				sp.FinishWithOptions(opentracing.FinishOptions{
-					LogRecords: []opentracing.LogRecord{
-						{
-							Timestamp: time.Now(),
-							Fields:    []olog.Field{olog.Int("count", count)},
-						},
-					},
-				})
 
 				if err != nil {
 					if err == errStopSubscription {


### PR DESCRIPTION
These traces are too spammy. We should address them as part of https://github.com/ethersphere/go-ethereum/issues/1393

We should also be trying out traces and spans in deployments, before adding them to the code.