### PR TITLE
core/rawdb, eth/downloader: align 64bit atomic fields

### DIFF
--- a/core/rawdb/freezer.go
+++ b/core/rawdb/freezer.go
@@ -66,8 +66,12 @@ const (
 //   reserving it for go-ethereum. This would also reduce the memory requirements
 //   of Geth, and thus also GC overhead.
 type freezer struct {
+	// WARNING: The `frozen` field is accessed atomically. On 32 bit platforms, only
+	// 64-bit aligned fields can be atomic. The struct is guaranteed to be so aligned,
+	// so take advantage of that (https://golang.org/pkg/sync/atomic/#pkg-note-BUG).
+	frozen uint64 // Number of blocks already frozen
+
 	tables       map[string]*freezerTable // Data tables for storing everything
-	frozen       uint64                   // Number of blocks already frozen
 	instanceLock fileutil.Releaser        // File-system lock to prevent double opens
 }
 

--- a/eth/downloader/downloader.go
+++ b/eth/downloader/downloader.go
@@ -98,6 +98,13 @@ var (
 )
 
 type Downloader struct {
+	// WARNING: The `rttEstimate` and `rttConfidence` fields are accessed atomically.
+	// On 32 bit platforms, only 64-bit aligned fields can be atomic. The struct is
+	// guaranteed to be so aligned, so take advantage of that. For more information,
+	// see https://golang.org/pkg/sync/atomic/#pkg-note-BUG.
+	rttEstimate   uint64 // Round trip time to target for download requests
+	rttConfidence uint64 // Confidence in the estimated RTT (unit: millionths to allow atomic ops)
+
 	mode SyncMode       // Synchronisation mode defining the strategy used (per sync cycle)
 	mux  *event.TypeMux // Event multiplexer to announce sync operation events
 
@@ -108,9 +115,6 @@ type Downloader struct {
 
 	stateDB    ethdb.Database  // Database to state sync into (and deduplicate via)
 	stateBloom *trie.SyncBloom // Bloom filter for fast trie node existence checks
-
-	rttEstimate   uint64 // Round trip time to target for download requests
-	rttConfidence uint64 // Confidence in the estimated RTT (unit: millionths to allow atomic ops)
 
 	// Statistics
 	syncStatsChainOrigin uint64 // Origin block number where syncing started at


### PR DESCRIPTION
The freezer and the downloader contain a few atomic `uint64` fields. Fun fact:

> On ARM, x86-32, and 32-bit MIPS, it is the caller's responsibility to arrange for 64-bit alignment of 64-bit words accessed atomically. The first word in a variable or in an allocated struct, array, or slice can be relied upon to be 64-bit aligned. https://golang.org/pkg/sync/atomic/#pkg-note-BUG

This PR moves the atomics in the freezer and downloader to the head of the struct to ensure 64bit alignment.

Fixes https://github.com/ethereum/go-ethereum/issues/19590.