### PR TITLE
build/ci.go: fix a typo

### DIFF
--- a/build/ci.go
+++ b/build/ci.go
@@ -133,10 +133,10 @@ var (
 
 	// Distros for which packages are created.
 	// Note: vivid is unsupported because there is no golang-1.6 package for it.
-	// Note: wily is unsupported because it was officially deprecated on lanchpad.
-	// Note: yakkety is unsupported because it was officially deprecated on lanchpad.
-	// Note: zesty is unsupported because it was officially deprecated on lanchpad.
-	// Note: artful is unsupported because it was officially deprecated on lanchpad.
+	// Note: wily is unsupported because it was officially deprecated on Launchpad.
+	// Note: yakkety is unsupported because it was officially deprecated on Launchpad.
+	// Note: zesty is unsupported because it was officially deprecated on Launchpad.
+	// Note: artful is unsupported because it was officially deprecated on Launchpad.
 	debDistros = []string{"trusty", "xenial", "bionic", "cosmic", "disco"}
 )
 


### PR DESCRIPTION
Changes:
- `lanchpad` becomes `Launchpad`