### PR TITLE
swarm/storage: fix SubscribePull to not skip chunks

### DIFF
--- a/swarm/network/stream/syncer.go
+++ b/swarm/network/stream/syncer.go
@@ -93,10 +93,6 @@ func (s *SwarmSyncerServer) SessionIndex() (uint64, error) {
 // are added in batchTimeout period, the batch will be returned. This function
 // will block until new chunks are received from localstore pull subscription.
 func (s *SwarmSyncerServer) SetNextBatch(from, to uint64) ([]byte, uint64, uint64, *HandoverProof, error) {
-	//TODO: maybe add unit test for intervals usage in netstore/localstore together with SwarmSyncerServer?
-	if from > 0 {
-		from--
-	}
 	batchStart := time.Now()
 	descriptors, stop := s.netStore.SubscribePull(context.Background(), s.po, from, to)
 	defer stop()

--- a/swarm/storage/localstore/subscription_pull.go
+++ b/swarm/storage/localstore/subscription_pull.go
@@ -31,9 +31,9 @@ import (
 
 // SubscribePull returns a channel that provides chunk addresses and stored times from pull syncing index.
 // Pull syncing index can be only subscribed to a particular proximity order bin. If since
-// is not 0, the iteration will start from the first item stored after that id. If until is not 0,
+// is not 0, the iteration will start from the since item (the item with binID == since). If until is not 0,
 // only chunks stored up to this id will be sent to the channel, and the returned channel will be
-// closed. The since-until interval is open on since side, and closed on until side: (since,until] <=> [since+1,until]. Returned stop
+// closed. The since-until interval is closed on since side, and closed on until side: [since,until]. Returned stop
 // function will terminate current and further iterations without errors, and also close the returned channel.
 // Make sure that you check the second returned parameter from the channel to stop iteration when its value
 // is false.
@@ -135,7 +135,9 @@ func (db *DB) SubscribePull(ctx context.Context, bin uint8, since, until uint64)
 					log.Error("localstore pull subscription iteration", "bin", bin, "since", since, "until", until, "err", err)
 					return
 				}
-				first = false
+				if count > 0 {
+					first = false
+				}
 			case <-stopChan:
 				// terminate the subscription
 				// on stop


### PR DESCRIPTION
This PR is fixing a bug in SubscribePull where on occasion it would skip the chunk pointed to by the `since` cursor.

1. SubscribePull has always been accepting a closed interval with respect to its arguments `since` and `until` - the godoc has been amended.

2. https://github.com/ethersphere/go-ethereum/issues/1375 is fixed as a result.

---

The bug this PR is addressing is that if on first iteration, the iterator within `SubscribePull` returns chunks - then the behaviour of `SubscribePull` is correct.
However if on first iteration, the iterator returns no chunks, and the `since` chunk is stored after the subscription is established, then it the chunk pointed at by `since` is not returned by the iterator, because `first` is set to `false`, and the item is skipped.