### PR TITLE
ethdb/leveldb: use larger table files to decrease filesys load

### DIFF
--- a/ethdb/leveldb/leveldb.go
+++ b/ethdb/leveldb/leveldb.go
@@ -91,10 +91,12 @@ func New(file string, cache int, handles int, namespace string) (*Database, erro
 
 	// Open the db and recover any potential corruptions
 	db, err := leveldb.OpenFile(file, &opt.Options{
-		OpenFilesCacheCapacity: handles,
-		BlockCacheCapacity:     cache / 2 * opt.MiB,
-		WriteBuffer:            cache / 4 * opt.MiB, // Two of these are used internally
-		Filter:                 filter.NewBloomFilter(10),
+		OpenFilesCacheCapacity:                handles,
+		BlockCacheCapacity:                    cache / 2 * opt.MiB,
+		WriteBuffer:                           cache / 4 * opt.MiB, // Two of these are used internally
+		Filter:                                filter.NewBloomFilter(10),
+		CompactionTableSize:                   4 * opt.MiB,
+		CompactionTableSizeMultiplierPerLevel: []float64{1, 2, 4, 8, 8, 8, 8}, // Cap at 32MB files, higher explodes disk IO
 	})
 	if _, corrupted := err.(*errors.ErrCorrupted); corrupted {
 		db, err = leveldb.RecoverFile(file, nil)


### PR DESCRIPTION
**Don't merge yet, open for benchmarking!**

Need to answer the questions:

 * What is the maximum file size after which disk IO explodes?
   * 64MB seems too much
   * 32MB seems too much
   * 16MB seems too much
 * What is the minimum file size after which disk IO explodes? 2/4/8?

---

Currently our leveldb database is configured to use 2MB data tables on all levels. This works well on Linux and MacOS, but can fail miserably on Windows, because NTFS is not optimized to handle folders with thousands of files.

Whilst NTFS archive nodes might be a far out goal (1M files), this PR attempts to relieve the stress a bit for full nodes running on NTFS. It does so by increasing the database table file sizes from the default 2MB, to some exponential numbers from 2MB to 32MB (capped for all higher levels).

**It's important to emphasize that the larger the data files are, the more data the compaction needs to read and write!** In Ethereum's random insertion use-case, even deeper levels get updated and compacted regularly. The current cap was the result of experimental runs for fast sync and full sync. The next bump blew the disk IO out the window.

---

Ok, this PR seems to blow up spectacularly.

Originally I've tried using leveldb file sizes capped at 64MB. That exploded disk io at around block 5.25M:

![Screenshot from 2019-05-26 00-31-01](https://user-images.githubusercontent.com/129561/58374841-00da6480-7f4e-11e9-9b10-113810440a67.png)

As a second try, I reduced the cap to 32MB. Lo and behold, same performance hit at mostly the same range.

![Screenshot from 2019-05-26 00-31-16](https://user-images.githubusercontent.com/129561/58374843-03d55500-7f4e-11e9-9963-8931a3bcf5a2.png)

Third try, still capped at 32MB, but starting levels cut in half. Still the same IO explosion at the same range.

![Screenshot from 2019-05-28 23-50-37](https://user-images.githubusercontent.com/129561/58511573-c79b3200-81a3-11e9-82f1-630a399c7a57.png)

Fourth try, capped at 16MB, still explodes.

![Screenshot from 2019-06-11 10-50-55](https://user-images.githubusercontent.com/129561/59253510-12eb2100-8c37-11e9-85b7-ec0e2016755f.png)
