### PR TITLE
crypto: Added checks for nil pointers in Marshal functions

### DIFF
--- a/crypto/bn256/cloudflare/bn256.go
+++ b/crypto/bn256/cloudflare/bn256.go
@@ -100,6 +100,10 @@ func (e *G1) Marshal() []byte {
 	// Each value is a 256-bit number.
 	const numBytes = 256 / 8
 
+	if e.p == nil {
+		e.p = &curvePoint{}
+	}
+
 	e.p.MakeAffine()
 	ret := make([]byte, numBytes*2)
 	if e.p.IsInfinity() {
@@ -381,6 +385,10 @@ func (e *GT) Finalize() *GT {
 func (e *GT) Marshal() []byte {
 	// Each value is a 256-bit number.
 	const numBytes = 256 / 8
+
+	if e.p == nil {
+		e.p = &gfP12{}
+	}
 
 	ret := make([]byte, numBytes*12)
 	temp := &gfP{}

--- a/crypto/bn256/cloudflare/bn256.go
+++ b/crypto/bn256/cloudflare/bn256.go
@@ -388,6 +388,7 @@ func (e *GT) Marshal() []byte {
 
 	if e.p == nil {
 		e.p = &gfP12{}
+		e.p.SetOne()
 	}
 
 	ret := make([]byte, numBytes*12)


### PR DESCRIPTION
The `Marshal` functions for elements in `G1` and in `GT` were not checking if the pointer to the group element was nil or not. Hence, a panic was thrown in we called these functions from a nil pointer.

For `G2`, a check was written. I added the check to the `G1` and `GT` functions.

## Reproduce the panic

```
e := new(G1)
res := e.Marshal()
```