### PR TITLE
core: lessen mem-spike during 1.8->1.9 conversion

### DIFF
--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -927,6 +927,12 @@ func (bc *BlockChain) truncateAncient(head uint64) error {
 	return nil
 }
 
+// numberHash is just a container for a number and a hash, to represent a block
+type numberHash struct {
+	number uint64
+	hash   common.Hash
+}
+
 // InsertReceiptChain attempts to complete an already existing header chain with
 // transaction and receipt data.
 func (bc *BlockChain) InsertReceiptChain(blockChain types.Blocks, receiptChain []types.Receipts, ancientLimit uint64) (int, error) {
@@ -994,7 +1000,7 @@ func (bc *BlockChain) InsertReceiptChain(blockChain types.Blocks, receiptChain [
 				}
 			}
 		}()
-		var deleted types.Blocks
+		var deleted []*numberHash
 		for i, block := range blockChain {
 			// Short circuit insertion if shutting down or processing failed
 			if atomic.LoadInt32(&bc.procInterrupt) == 1 {
@@ -1029,7 +1035,7 @@ func (bc *BlockChain) InsertReceiptChain(blockChain types.Blocks, receiptChain [
 
 				// Always keep genesis block in active database.
 				if b.NumberU64() != 0 {
-					deleted = append(deleted, b)
+					deleted = append(deleted, &numberHash{b.NumberU64(), b.Hash()})
 				}
 				if time.Since(logged) > 8*time.Second {
 					log.Info("Migrating ancient blocks", "count", count, "elapsed", common.PrettyDuration(time.Since(start)))
@@ -1062,7 +1068,14 @@ func (bc *BlockChain) InsertReceiptChain(blockChain types.Blocks, receiptChain [
 		previous = nil // disable rollback explicitly
 
 		// Wipe out canonical block data.
-		for _, block := range append(deleted, blockChain...) {
+		for _, nh := range deleted {
+			// Always keep genesis block in active database.
+			if nh.number != 0 {
+				rawdb.DeleteBlockWithoutNumber(batch, nh.hash, nh.number)
+				rawdb.DeleteCanonicalHash(batch, nh.number)
+			}
+		}
+		for _, block := range blockChain {
 			// Always keep genesis block in active database.
 			if block.NumberU64() != 0 {
 				rawdb.DeleteBlockWithoutNumber(batch, block.Hash(), block.NumberU64())
@@ -1075,7 +1088,15 @@ func (bc *BlockChain) InsertReceiptChain(blockChain types.Blocks, receiptChain [
 		batch.Reset()
 
 		// Wipe out side chain too.
-		for _, block := range append(deleted, blockChain...) {
+		for _, nh := range deleted {
+			// Always keep genesis block in active database.
+			if nh.number != 0 {
+				for _, hash := range rawdb.ReadAllHashes(bc.db, nh.number) {
+					rawdb.DeleteBlock(batch, hash, nh.number)
+				}
+			}
+		}
+		for _, block := range blockChain {
 			// Always keep genesis block in active database.
 			if block.NumberU64() != 0 {
 				for _, hash := range rawdb.ReadAllHashes(bc.db, block.NumberU64()) {


### PR DESCRIPTION
When we ran a 1.8 fast-sync, aborted and went over to 1.9, the db migration which shoves from leveldb to ancients caused a _huge_ memory spike. 
This is because it went through ~4M blocks, and stored each block in `deleted` during the process. 

This PR for now only changes it to store the same amont of `numberHash` objects in memory. Still a lot of objects, but should be a lot smaller in memory. 

Original mem usage:
![Screenshot_2019-05-22 Enterprise Benchmark Dashboard Pro+ Datadog](https://user-images.githubusercontent.com/142290/58165686-8cbb6a80-7c88-11e9-97ff-9fc52f815298.png)

We should do a more proper fix to incrementally process the blocks, instead of doing it in one go. 