### PR TITLE
rpc: enable building with CGO_ENABLED=0

### DIFF
--- a/rpc/ipc_unix.go
+++ b/rpc/ipc_unix.go
@@ -28,20 +28,19 @@ import (
 	"github.com/ethereum/go-ethereum/log"
 )
 
-/*
-#include <sys/un.h>
-
-int max_socket_path_size() {
-struct sockaddr_un s;
-return sizeof(s.sun_path);
-}
-*/
-import "C"
+// maxIPCPathLength is a conservative estimate of the OS-dependent IPC
+// path length limit. If we are built with CGO enabled, we will use
+// an OS-specific limit from <sys/un.h>.
+// See:
+//   https://unix.stackexchange.com/questions/367008/why-is-socket-path-length-limited-to-a-hundred-chars/367012#367012
+// and
+//   https://github.com/ethereum/go-ethereum/issues/16342
+var maxIPCPathLength = 103
 
 // ipcListen will create a Unix socket on the given endpoint.
 func ipcListen(endpoint string) (net.Listener, error) {
-	if len(endpoint) > int(C.max_socket_path_size()) {
-		log.Warn(fmt.Sprintf("The ipc endpoint is longer than %d characters. ", C.max_socket_path_size()),
+	if len(endpoint) > maxIPCPathLength {
+		log.Warn(fmt.Sprintf("The ipc endpoint is longer than %d characters. ", maxIPCPathLength),
 			"endpoint", endpoint)
 	}
 

--- a/rpc/ipc_unix_cgo.go
+++ b/rpc/ipc_unix_cgo.go
@@ -1,0 +1,34 @@
+// Copyright 2015 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+// +build cgo
+// +build darwin dragonfly freebsd linux nacl netbsd openbsd solaris
+
+package rpc
+
+/*
+#include <sys/un.h>
+
+int max_socket_path_size() {
+struct sockaddr_un s;
+return sizeof(s.sun_path);
+}
+*/
+import "C"
+
+func init() {
+	maxIPCPathLength = int(C.max_socket_path_size())
+}


### PR DESCRIPTION
I build CLI tools with go-ethereum libraries, and I find it useful to do cross-compilation with CGO_ENABLED=0. Unfortunately, I can't do that with the rpc package, because it depends on CGO.

But it is very close to not needing CGO. This package only uses CGO to print a single warning message, customized by a header file on the builder's host OS. We can instead use a conservative default for this value if CGO is disabled. This seems like a good graceful degradation to me and a worthwhile trade for getting to cross-compile this package in client code.

If you'd prefer, we could also hard-code in different defaults for each `runtime.GOOS` and thereby approximate the CGO behavior even more closely.