### PR TITLE
accounts/keystore: enable fallback Darwin w/o CGO

### DIFF
--- a/accounts/keystore/watch.go
+++ b/accounts/keystore/watch.go
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
 
-// +build darwin,!ios freebsd linux,!arm64 netbsd solaris
+// +build darwin,!ios,cgo freebsd linux,!arm64 netbsd solaris
 
 package keystore
 

--- a/accounts/keystore/watch_fallback.go
+++ b/accounts/keystore/watch_fallback.go
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
 
-// +build ios linux,arm64 windows !darwin,!freebsd,!linux,!netbsd,!solaris
+// +build darwin,!cgo ios linux,arm64 windows !darwin,!freebsd,!linux,!netbsd,!solaris
 
 // This is the fallback implementation of directory watching.
 // It is used on unsupported platforms.


### PR DESCRIPTION
With `GOOS=darwin` and `CGO_ENABLED=0`, the accounts/keystore package currently fails to build. This change causes that build permutation to succeed instead, by enabling the no-op fallback for file watching.