### PR TITLE
core: limit TxPool by tx size instead of count

### DIFF
--- a/core/tx_list.go
+++ b/core/tx_list.go
@@ -466,6 +466,50 @@ func (l *txPricedList) Cap(threshold *big.Int, local *accountSet) types.Transact
 	return drop
 }
 
+// FreeSize drops transactions that sum up to at least a certain total size.
+func (l *txPricedList) FreeSize(sizeToFree common.StorageSize, threshold *big.Int, locals *accountSet) (types.Transactions, bool) {
+	drop := make(types.Transactions, 0, 128) // Remote underpriced transactions to drop
+	save := make(types.Transactions, 0, 64)  // Local underpriced transactions to keep
+	totalSize := common.StorageSize(0)
+
+	for len(*l.items) > 0 {
+		// Discard stale transactions if found during cleanup
+		tx := heap.Pop(l.items).(*types.Transaction)
+		if l.all.Get(tx.Hash()) == nil {
+			l.stales--
+			continue
+		}
+		// Stop the discards if we've reached the threshold
+		if tx.GasPrice().Cmp(threshold) >= 0 {
+			save = append(save, tx)
+			break
+		}
+		// Keep local
+		if locals.containsTx(tx) {
+			save = append(save, tx)
+			continue
+		}
+		// Non stale transaction found
+		drop = append(drop, tx)
+		totalSize += tx.Size()
+		// Stop the discards if we've reached the required size
+		if totalSize >= sizeToFree {
+			break
+		}
+	}
+	for _, tx := range save {
+		heap.Push(l.items, tx)
+	}
+	// If not enough space, bring back removed transactions
+	if totalSize < sizeToFree {
+		for _, tx := range drop {
+			heap.Push(l.items, tx)
+		}
+		return make(types.Transactions, 0), false
+	}
+	return drop, true
+}
+
 // Underpriced checks whether a transaction is cheaper than (or as cheap as) the
 // lowest priced transaction currently being tracked.
 func (l *txPricedList) Underpriced(tx *types.Transaction, local *accountSet) bool {


### PR DESCRIPTION
Ethereum protocol allows transactions of size much larger then 32KB. We suggest adjusting the limit on the size of transactions to 300KB. There are increasing number of applications on Ethereum which requires transmission size which is larger then 32KB - mainly layer 2 scalabilities solutions such as Plasma and ZKP based systems. Those solutions increase the efficiency of Ethereum by removing computation and storage off-chain and currently are not compatible with Geth clients due to this limit

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ethereum/go-ethereum/19618)
<!-- Reviewable:end -->
