### PR TITLE
accounts/usbwallet: enable the Nano X and upcoming Ledger IDs

### DIFF
--- a/accounts/usbwallet/hub.go
+++ b/accounts/usbwallet/hub.go
@@ -68,7 +68,20 @@ type Hub struct {
 
 // NewLedgerHub creates a new hardware wallet manager for Ledger devices.
 func NewLedgerHub() (*Hub, error) {
-	return newHub(LedgerScheme, 0x2c97, []uint16{0x0000 /* Ledger Blue */, 0x0001 /* Ledger Nano S */}, 0xffa0, 0, newLedgerDriver)
+	return newHub(LedgerScheme, 0x2c97, []uint16{
+		// Original product IDs
+		0x0000, /* Ledger Blue */
+		0x0001, /* Ledger Nano S */
+		0x0004, /* Ledger Nano X */
+
+		// Upcoming product IDs: https://www.ledger.com/2019/05/17/windows-10-update-sunsetting-u2f-tunnel-transport-for-ledger-devices/
+		0x0015, /* HID + U2F + WebUSB Ledger Blue */
+		0x1015, /* HID + U2F + WebUSB Ledger Nano S */
+		0x4015, /* HID + U2F + WebUSB Ledger Nano X */
+		0x0011, /* HID + WebUSB Ledger Blue */
+		0x1011, /* HID + WebUSB Ledger Nano S */
+		0x4011, /* HID + WebUSB Ledger Nano X */
+	}, 0xffa0, 0, newLedgerDriver)
 }
 
 // NewTrezorHub creates a new hardware wallet manager for Trezor devices.


### PR DESCRIPTION
The current Ledger Nano X USB product ID is `0x0004`. Enabling that seems to have been enough to support it (thank you @LedgerHQ for retaining the original USB protocol).

The second two sets of IDs are based on [announced upcoming firmware changes](https://www.ledger.com/2019/05/17/windows-10-update-sunsetting-u2f-tunnel-transport-for-ledger-devices/ ). We'll need to double check after those arrive whether the bridge is still functional or not. Based on the promises in the blog post to keep the protocols, hopefully the ID enumeration here will be enough.