### PR TITLE
les: short circuit in the unregister if peer is not registered

### DIFF
--- a/les/freeclient.go
+++ b/les/freeclient.go
@@ -166,7 +166,11 @@ func (f *freeClientPool) disconnect(address string) {
 	if f.closed {
 		return
 	}
+	// Short circuit if the peer hasn't been registered.
 	e := f.addressMap[address]
+	if e == nil {
+		return
+	}
 	now := f.clock.Now()
 	if !e.connected {
 		log.Debug("Client already disconnected", "address", address)


### PR DESCRIPTION
This PR fixes an issue in the free client pool.

This issue is caused by **free client pool** itself. System sets the `totalCap` to a very low value which lower than the `freeClientCap`, so that the `connectedLimit` in `freeClientPool` is 0.

When `freeClientPool` tries to register a new peer, it failed and then call the `unregister` callback which tries to evict an non-exist peer from the `freeClientPool`.