### PR TITLE
les: verify existence of peer entry in freeClientPool.disconnect

### DIFF
--- a/les/freeclient.go
+++ b/les/freeclient.go
@@ -194,6 +194,9 @@ func (f *freeClientPool) disconnect(address string) {
 		return
 	}
 	e := f.addressMap[address]
+	if e == nil {
+		return
+	}
 	now := f.clock.Now()
 	if !e.connected {
 		log.Debug("Client already disconnected", "address", address)


### PR DESCRIPTION
This PR fixes a nil panic in freeClientPool.disconnect in case unregisterPeer was called twice or if the pool entry was dropped right after disconnection initiated by the pool itself.