### PR TITLE
Servicerefactor

### DIFF
--- a/cmd/geth/chaincmd.go
+++ b/cmd/geth/chaincmd.go
@@ -205,7 +205,7 @@ func initGenesis(ctx *cli.Context) error {
 		utils.Fatalf("invalid genesis file: %v", err)
 	}
 	// Open an initialise both full and light databases
-	stack := makeFullNode(ctx)
+	stack := makeNode(ctx)
 	defer stack.Close()
 
 	for _, name := range []string{"chaindata", "lightchaindata"} {
@@ -227,7 +227,7 @@ func importChain(ctx *cli.Context) error {
 	if len(ctx.Args()) < 1 {
 		utils.Fatalf("This command requires an argument.")
 	}
-	stack := makeFullNode(ctx)
+	stack := makeNode(ctx)
 	defer stack.Close()
 
 	chain, db := utils.MakeChain(ctx, stack)
@@ -317,7 +317,7 @@ func exportChain(ctx *cli.Context) error {
 	if len(ctx.Args()) < 1 {
 		utils.Fatalf("This command requires an argument.")
 	}
-	stack := makeFullNode(ctx)
+	stack := makeNode(ctx)
 	defer stack.Close()
 
 	chain, _ := utils.MakeChain(ctx, stack)
@@ -352,7 +352,7 @@ func importPreimages(ctx *cli.Context) error {
 	if len(ctx.Args()) < 1 {
 		utils.Fatalf("This command requires an argument.")
 	}
-	stack := makeFullNode(ctx)
+	stack := makeNode(ctx)
 	defer stack.Close()
 
 	db := utils.MakeChainDatabase(ctx, stack)
@@ -370,7 +370,7 @@ func exportPreimages(ctx *cli.Context) error {
 	if len(ctx.Args()) < 1 {
 		utils.Fatalf("This command requires an argument.")
 	}
-	stack := makeFullNode(ctx)
+	stack := makeNode(ctx)
 	defer stack.Close()
 
 	db := utils.MakeChainDatabase(ctx, stack)
@@ -392,7 +392,7 @@ func copyDb(ctx *cli.Context) error {
 		utils.Fatalf("Source ancient chain directory path argument missing")
 	}
 	// Initialize a new chain for the running node to sync into
-	stack := makeFullNode(ctx)
+	stack := makeNode(ctx)
 	defer stack.Close()
 
 	chain, chainDb := utils.MakeChain(ctx, stack)
@@ -500,7 +500,7 @@ func confirmAndRemoveDB(database string, kind string) {
 }
 
 func dump(ctx *cli.Context) error {
-	stack := makeFullNode(ctx)
+	stack := makeNode(ctx)
 	defer stack.Close()
 
 	chain, chainDb := utils.MakeChain(ctx, stack)

--- a/cmd/geth/consolecmd.go
+++ b/cmd/geth/consolecmd.go
@@ -77,7 +77,7 @@ JavaScript API. See https://github.com/ethereum/go-ethereum/wiki/JavaScript-Cons
 // same time.
 func localConsole(ctx *cli.Context) error {
 	// Create and start the node based on the CLI flags
-	node := makeFullNode(ctx)
+	node := makeNode(ctx)
 	startNode(ctx, node)
 	defer node.Close()
 
@@ -178,7 +178,7 @@ func dialRPC(endpoint string) (*rpc.Client, error) {
 // everything down.
 func ephemeralConsole(ctx *cli.Context) error {
 	// Create and start the node based on the CLI flags
-	node := makeFullNode(ctx)
+	node := makeNode(ctx)
 	startNode(ctx, node)
 	defer node.Close()
 

--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -298,7 +298,7 @@ func geth(ctx *cli.Context) error {
 	if args := ctx.Args(); len(args) > 0 {
 		return fmt.Errorf("invalid command: %q", args[0])
 	}
-	node := makeFullNode(ctx)
+	node := makeNode(ctx)
 	defer node.Close()
 	startNode(ctx, node)
 	node.Wait()

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -20,6 +20,7 @@ package utils
 import (
 	"crypto/ecdsa"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"math/big"
@@ -1497,25 +1498,50 @@ func SetDashboardConfig(ctx *cli.Context, cfg *dashboard.Config) {
 	cfg.Refresh = ctx.GlobalDuration(DashboardRefreshFlag.Name)
 }
 
-// RegisterEthService adds an Ethereum client to the stack.
-func RegisterEthService(stack *node.Node, cfg *eth.Config) {
-	var err error
+// RegisterLesClientService adds a Light Client service to the stack if the config permits
+func RegisterLesClientService(stack *node.Node, cfg *eth.Config) {
+
+	//if the light client is requested
 	if cfg.SyncMode == downloader.LightSync {
-		err = stack.Register(func(ctx *node.ServiceContext) (node.Service, error) {
+		//register a light client
+		if err := stack.Register(func(ctx *node.ServiceContext) (node.Service, error) {
 			return les.New(ctx, cfg)
-		})
-	} else {
-		err = stack.Register(func(ctx *node.ServiceContext) (node.Service, error) {
-			fullNode, err := eth.New(ctx, cfg)
-			if fullNode != nil && cfg.LightServ > 0 {
-				ls, _ := les.NewLesServer(fullNode, cfg)
-				fullNode.AddLesServer(ls)
-			}
-			return fullNode, err
-		})
+		}); err != nil {
+			Fatalf("Failed to register the Light Client service: %v", err)
+		}
 	}
-	if err != nil {
-		Fatalf("Failed to register the Ethereum service: %v", err)
+}
+
+// RegisterLesServerService adds a Light Server service to the stack if the config permits
+func RegisterLesServerService(stack *node.Node, cfg *eth.Config) {
+
+	//if the light client is not requested and the light server is requested
+	if cfg.SyncMode != downloader.LightSync && cfg.LightServ > 0 {
+		//register a light server service
+		if err := stack.Register(func(ctx *node.ServiceContext) (node.Service, error) {
+			//check if the main Eth protocol service is running
+			var ethService *eth.Ethereum
+			if ctx.Service(&ethService) != nil {
+				return nil, errors.New("Failed to start the Les Server service because Ethereum service is not running")
+			}
+			return les.NewLesServer(ethService, cfg)
+		}); err != nil {
+			Fatalf("Failed to register the Light Server service: %v", err)
+		}
+	}
+}
+
+// RegisterEthService adds an Ethereum client to the stack if the config permits
+func RegisterEthService(stack *node.Node, cfg *eth.Config) {
+
+	//if the light client is not requested
+	if cfg.SyncMode != downloader.LightSync {
+		//register a service for the Eth protocol
+		if err := stack.Register(func(ctx *node.ServiceContext) (node.Service, error) {
+			return eth.New(ctx, cfg)
+		}); err != nil {
+			Fatalf("Failed to register the Ethereum service: %v", err)
+		}
 	}
 }
 

--- a/go-ethereum.code-workspace
+++ b/go-ethereum.code-workspace
@@ -1,0 +1,8 @@
+{
+	"folders": [
+		{
+			"path": "."
+		}
+	],
+	"settings": {}
+}

--- a/go-ethereum.code-workspace
+++ b/go-ethereum.code-workspace
@@ -1,8 +1,0 @@
-{
-	"folders": [
-		{
-			"path": "."
-		}
-	],
-	"settings": {}
-}

--- a/les/api.go
+++ b/les/api.go
@@ -31,8 +31,11 @@ import (
 )
 
 var (
-	ErrMinCap               = errors.New("capacity too small")
-	ErrTotalCap             = errors.New("total capacity exceeded")
+	// ErrMinCap capacity too small
+	ErrMinCap = errors.New("capacity too small")
+	// ErrTotalCap total capacity exceeded
+	ErrTotalCap = errors.New("total capacity exceeded")
+	// ErrUnknownBenchmarkType unknown benchmark type
 	ErrUnknownBenchmarkType = errors.New("unknown benchmark type")
 
 	dropCapacityDelay = time.Second // delay applied to decreasing capacity changes

--- a/les/api_backend.go
+++ b/les/api_backend.go
@@ -225,7 +225,6 @@ func (b *ClientBackend) ChainDb() ethdb.Database {
 	return b.eth.chainDb
 }
 
-// EventMux ...
 func (b *ClientBackend) EventMux() *event.TypeMux {
 	return b.eth.eventMux
 }
@@ -240,12 +239,14 @@ func (b *ClientBackend) ExtRPCEnabled() bool {
 	return b.extRPCEnabled
 }
 
-// RPCGasCap - return the  global gas cap for eth_call over rpc (DoS protection)
+// RPCGasCap return the  global gas cap for eth_call over rpc (DoS protection)
 func (b *ClientBackend) RPCGasCap() *big.Int {
 	return b.eth.config.RPCGasCap
 }
 
-// BloomStatus ..
+// BloomStatus returns the number of BloomBitsBlocksClient (the number of blocks a single bloom bit section vector
+// contains on the light client side) and sections, (which is the number of processed sections maintained by the indexer
+// and also the information about the last header indexed for potential canonical verifications).
 func (b *ClientBackend) BloomStatus() (uint64, uint64) {
 	if b.eth.bloomIndexer == nil {
 		return 0, 0
@@ -254,7 +255,6 @@ func (b *ClientBackend) BloomStatus() (uint64, uint64) {
 	return params.BloomBitsBlocksClient, sections
 }
 
-// ServiceFilter ...
 func (b *ClientBackend) ServiceFilter(ctx context.Context, session *bloombits.MatcherSession) {
 	for i := 0; i < bloomFilterThreads; i++ {
 		go session.Multiplex(bloomRetrievalBatch, bloomRetrievalWait, b.eth.bloomRequests)

--- a/les/benchmark.go
+++ b/les/benchmark.go
@@ -74,9 +74,9 @@ func (b *benchmarkBlockHeaders) init(pm *ProtocolManager, count int) error {
 func (b *benchmarkBlockHeaders) request(peer *peer, index int) error {
 	if b.byHash {
 		return peer.RequestHeadersByHash(0, 0, b.hashes[index], b.amount, b.skip, b.reverse)
-	} else {
-		return peer.RequestHeadersByNumber(0, 0, uint64(b.offset+rand.Int63n(b.randMax)), b.amount, b.skip, b.reverse)
 	}
+	return peer.RequestHeadersByNumber(0, 0, uint64(b.offset+rand.Int63n(b.randMax)), b.amount, b.skip, b.reverse)
+
 }
 
 // benchmarkBodiesOrReceipts implements requestBenchmark
@@ -97,9 +97,9 @@ func (b *benchmarkBodiesOrReceipts) init(pm *ProtocolManager, count int) error {
 func (b *benchmarkBodiesOrReceipts) request(peer *peer, index int) error {
 	if b.receipts {
 		return peer.RequestReceipts(0, 0, []common.Hash{b.hashes[index]})
-	} else {
-		return peer.RequestBodies(0, 0, []common.Hash{b.hashes[index]})
 	}
+	return peer.RequestBodies(0, 0, []common.Hash{b.hashes[index]})
+
 }
 
 // benchmarkProofsOrCode implements requestBenchmark
@@ -118,9 +118,9 @@ func (b *benchmarkProofsOrCode) request(peer *peer, index int) error {
 	rand.Read(key)
 	if b.code {
 		return peer.RequestCode(0, 0, []CodeReq{{BHash: b.headHash, AccKey: key}})
-	} else {
-		return peer.RequestProofs(0, 0, []ProofReq{{BHash: b.headHash, Key: key}})
 	}
+	return peer.RequestProofs(0, 0, []ProofReq{{BHash: b.headHash, Key: key}})
+
 }
 
 // benchmarkHelperTrie implements requestBenchmark
@@ -281,8 +281,8 @@ func (pm *ProtocolManager) measure(setup *benchmarkSetup, count int) error {
 	serverMeteredPipe := &meteredPipe{rw: serverPipe}
 	var id enode.ID
 	rand.Read(id[:])
-	clientPeer := pm.newPeer(lpv2, NetworkId, p2p.NewPeer(id, "client", nil), clientMeteredPipe)
-	serverPeer := pm.newPeer(lpv2, NetworkId, p2p.NewPeer(id, "server", nil), serverMeteredPipe)
+	clientPeer := pm.newPeer(lpv2, NetworkID, p2p.NewPeer(id, "client", nil), clientMeteredPipe)
+	serverPeer := pm.newPeer(lpv2, NetworkID, p2p.NewPeer(id, "server", nil), serverMeteredPipe)
 	serverPeer.sendQueue = newExecQueue(count)
 	serverPeer.announceType = announceTypeNone
 	serverPeer.fcCosts = make(requestCostTable)

--- a/les/freeclient_test.go
+++ b/les/freeclient_test.go
@@ -51,7 +51,7 @@ func testFreeClientPool(t *testing.T, connLimit, clientCount int) {
 		peerAddress = func(i int) string {
 			return fmt.Sprintf("addr #%d", i)
 		}
-		peerId = func(i int) string {
+		peerID = func(i int) string {
 			return fmt.Sprintf("id #%d", i)
 		}
 		disconnFn = func(id string) {
@@ -67,14 +67,14 @@ func testFreeClientPool(t *testing.T, connLimit, clientCount int) {
 
 	// pool should accept new peers up to its connected limit
 	for i := 0; i < connLimit; i++ {
-		if pool.connect(peerAddress(i), peerId(i)) {
+		if pool.connect(peerAddress(i), peerID(i)) {
 			connected[i] = true
 		} else {
 			t.Fatalf("Test peer #%d rejected", i)
 		}
 	}
 	// since all accepted peers are new and should not be kicked out, the next one should be rejected
-	if pool.connect(peerAddress(connLimit), peerId(connLimit)) {
+	if pool.connect(peerAddress(connLimit), peerID(connLimit)) {
 		connected[connLimit] = true
 		t.Fatalf("Peer accepted over connected limit")
 	}
@@ -89,7 +89,7 @@ func testFreeClientPool(t *testing.T, connLimit, clientCount int) {
 			connected[i] = false
 			connTicks[i] += tickCounter
 		} else {
-			if pool.connect(peerAddress(i), peerId(i)) {
+			if pool.connect(peerAddress(i), peerID(i)) {
 				connected[i] = true
 				connTicks[i] -= tickCounter
 			}
@@ -135,7 +135,7 @@ func testFreeClientPool(t *testing.T, connLimit, clientCount int) {
 
 	// try connecting all known peers (connLimit should be filled up)
 	for i := 0; i < clientCount; i++ {
-		pool.connect(peerAddress(i), peerId(i))
+		pool.connect(peerAddress(i), peerID(i))
 	}
 	// expect pool to remember known nodes and kick out one of them to accept a new one
 	if !pool.connect("newAddr2", "newId2") {

--- a/les/handler.go
+++ b/les/handler.go
@@ -50,21 +50,21 @@ const (
 
 	ethVersion = 63 // equivalent eth version for the downloader
 
-	// MaxHeaderFetch -  Amount of block headers to be fetched per retrieval request
+	// MaxHeaderFetch is the maximum number of block headers to be fetched per retrieval request
 	MaxHeaderFetch = 192
-	// MaxBodyFetch - Amount of block bodies to be fetched per retrieval request
+	// MaxBodyFetch is the maximum number of block bodies to be fetched per retrieval request
 	MaxBodyFetch = 32
-	// MaxReceiptFetch - Amount of transaction receipts to allow fetching per request
+	// MaxReceiptFetch is the maximum number of transaction receipts to allow to be fetched per request
 	MaxReceiptFetch = 128
-	// MaxCodeFetch - Amount of contract codes to allow fetching per request
+	// MaxCodeFetch is the maximum number of contract codes to allow to be fetched per request
 	MaxCodeFetch = 64
-	// MaxProofsFetch - Amount of merkle proofs to be fetched per retrieval request
+	// MaxProofsFetch is the maximum number of merkle proofs to be fetched per retrieval request
 	MaxProofsFetch = 64
-	// MaxHelperTrieProofsFetch - Amount of merkle proofs to be fetched per retrieval request
+	// MaxHelperTrieProofsFetch is the maximum number of merkle proofs to be fetched per retrieval request
 	MaxHelperTrieProofsFetch = 64
-	// MaxTxSend - Amount of transactions to be send per request
+	// MaxTxSend is the maximum number of transactions to be sent per request
 	MaxTxSend = 64
-	// MaxTxStatus - Amount of transactions to queried per request
+	// MaxTxStatus is the maximum number of transactions to queried per request
 	MaxTxStatus = 256
 
 	disableClientRemovePeer = false
@@ -74,7 +74,7 @@ func errResp(code errCode, format string, v ...interface{}) error {
 	return fmt.Errorf("%v - %v", code, fmt.Sprintf(format, v...))
 }
 
-// BlockChain - a blockchain
+// BlockChain represents a blockchain, offering functions to query and maintain it
 type BlockChain interface {
 	Config() *params.ChainConfig
 	HasHeader(hash common.Hash, number uint64) bool

--- a/les/handler.go
+++ b/les/handler.go
@@ -50,14 +50,22 @@ const (
 
 	ethVersion = 63 // equivalent eth version for the downloader
 
-	MaxHeaderFetch           = 192 // Amount of block headers to be fetched per retrieval request
-	MaxBodyFetch             = 32  // Amount of block bodies to be fetched per retrieval request
-	MaxReceiptFetch          = 128 // Amount of transaction receipts to allow fetching per request
-	MaxCodeFetch             = 64  // Amount of contract codes to allow fetching per request
-	MaxProofsFetch           = 64  // Amount of merkle proofs to be fetched per retrieval request
-	MaxHelperTrieProofsFetch = 64  // Amount of merkle proofs to be fetched per retrieval request
-	MaxTxSend                = 64  // Amount of transactions to be send per request
-	MaxTxStatus              = 256 // Amount of transactions to queried per request
+	// MaxHeaderFetch -  Amount of block headers to be fetched per retrieval request
+	MaxHeaderFetch = 192
+	// MaxBodyFetch - Amount of block bodies to be fetched per retrieval request
+	MaxBodyFetch = 32
+	// MaxReceiptFetch - Amount of transaction receipts to allow fetching per request
+	MaxReceiptFetch = 128
+	// MaxCodeFetch - Amount of contract codes to allow fetching per request
+	MaxCodeFetch = 64
+	// MaxProofsFetch - Amount of merkle proofs to be fetched per retrieval request
+	MaxProofsFetch = 64
+	// MaxHelperTrieProofsFetch - Amount of merkle proofs to be fetched per retrieval request
+	MaxHelperTrieProofsFetch = 64
+	// MaxTxSend - Amount of transactions to be send per request
+	MaxTxSend = 64
+	// MaxTxStatus - Amount of transactions to queried per request
+	MaxTxStatus = 256
 
 	disableClientRemovePeer = false
 )
@@ -66,6 +74,7 @@ func errResp(code errCode, format string, v ...interface{}) error {
 	return fmt.Errorf("%v - %v", code, fmt.Sprintf(format, v...))
 }
 
+// BlockChain - a blockchain
 type BlockChain interface {
 	Config() *params.ChainConfig
 	HasHeader(hash common.Hash, number uint64) bool
@@ -87,6 +96,7 @@ type txPool interface {
 	Status(hashes []common.Hash) []core.TxStatus
 }
 
+// ProtocolManager handles protocol messages and other protocol-specific tasks
 type ProtocolManager struct {
 	// Configs
 	chainConfig *params.ChainConfig
@@ -94,7 +104,7 @@ type ProtocolManager struct {
 
 	client    bool   // The indicator whether the node is light client
 	maxPeers  int    // The maximum number peers allowed to connect.
-	networkId uint64 // The identity of network.
+	networkID uint64 // The identity of network.
 
 	txpool       txPool
 	txrelay      *LesTxRelay
@@ -131,7 +141,7 @@ func NewProtocolManager(
 	chainConfig *params.ChainConfig,
 	indexerConfig *light.IndexerConfig,
 	client bool,
-	networkId uint64,
+	networkID uint64,
 	mux *event.TypeMux,
 	engine consensus.Engine,
 	peers *peerSet,
@@ -153,7 +163,7 @@ func NewProtocolManager(
 		iConfig:     indexerConfig,
 		chainDb:     chainDb,
 		odr:         odr,
-		networkId:   networkId,
+		networkID:   networkID,
 		txpool:      txpool,
 		txrelay:     txrelay,
 		serverPool:  serverPool,
@@ -194,6 +204,7 @@ func (pm *ProtocolManager) removePeer(id string) {
 	pm.peers.Unregister(id)
 }
 
+// Start starts the protocol manager and is called during node startup only
 func (pm *ProtocolManager) Start(maxPeers int) {
 	pm.maxPeers = maxPeers
 	if pm.client {
@@ -206,6 +217,7 @@ func (pm *ProtocolManager) Start(maxPeers int) {
 	}
 }
 
+// Stop stops the protocol manager and is called during node shutdown only
 func (pm *ProtocolManager) Stop() {
 	// Showing a log message. During download / process this could actually
 	// take between 5 to 10 seconds and therefor feedback is required.
@@ -236,7 +248,7 @@ func (pm *ProtocolManager) Stop() {
 // runPeer is the p2p protocol run function for the given version.
 func (pm *ProtocolManager) runPeer(version uint, p *p2p.Peer, rw p2p.MsgReadWriter) error {
 	var entry *poolEntry
-	peer := pm.newPeer(int(version), pm.networkId, p, rw)
+	peer := pm.newPeer(int(version), pm.networkID, p, rw)
 	if pm.serverPool != nil {
 		entry = pm.serverPool.connect(peer, peer.Node())
 	}

--- a/les/helper_test.go
+++ b/les/helper_test.go
@@ -171,7 +171,7 @@ func newTestProtocolManager(lightSync bool, blocks int, generator func(int, *cor
 	if lightSync {
 		indexConfig = light.TestClientIndexerConfig
 	}
-	pm, err := NewProtocolManager(gspec.Config, indexConfig, lightSync, NetworkId, evmux, engine, peers, chain, pool, db, odr, nil, nil, make(chan struct{}), new(sync.WaitGroup), ulcConfig, func() bool { return true })
+	pm, err := NewProtocolManager(gspec.Config, indexConfig, lightSync, NetworkID, evmux, engine, peers, chain, pool, db, odr, nil, nil, make(chan struct{}), new(sync.WaitGroup), ulcConfig, func() bool { return true })
 	if err != nil {
 		return nil, err
 	}
@@ -220,7 +220,7 @@ func newTestPeer(t *testing.T, name string, version int, pm *ProtocolManager, sh
 	var id enode.ID
 	rand.Read(id[:])
 
-	peer := pm.newPeer(version, NetworkId, p2p.NewPeer(id, name, nil), net)
+	peer := pm.newPeer(version, NetworkID, p2p.NewPeer(id, name, nil), net)
 
 	// Start the peer on a new thread
 	errc := make(chan error, 1)
@@ -257,8 +257,8 @@ func newTestPeerPair(name string, version int, pm, pm2 *ProtocolManager) (*peer,
 	var id enode.ID
 	rand.Read(id[:])
 
-	peer := pm.newPeer(version, NetworkId, p2p.NewPeer(id, name, nil), net)
-	peer2 := pm2.newPeer(version, NetworkId, p2p.NewPeer(id, name, nil), app)
+	peer := pm.newPeer(version, NetworkID, p2p.NewPeer(id, name, nil), net)
+	peer2 := pm2.newPeer(version, NetworkID, p2p.NewPeer(id, name, nil), app)
 
 	// Start the peer on a new thread
 	errc := make(chan error, 1)
@@ -287,7 +287,7 @@ func newTestPeerPair(name string, version int, pm, pm2 *ProtocolManager) (*peer,
 func (p *testPeer) handshake(t *testing.T, td *big.Int, head common.Hash, headNum uint64, genesis common.Hash, testCost uint64) {
 	var expList keyValueList
 	expList = expList.add("protocolVersion", uint64(p.version))
-	expList = expList.add("networkId", uint64(NetworkId))
+	expList = expList.add("networkId", uint64(NetworkID))
 	expList = expList.add("headTd", td)
 	expList = expList.add("headHash", head)
 	expList = expList.add("headNum", headNum)

--- a/les/odr.go
+++ b/les/odr.go
@@ -82,17 +82,17 @@ func (odr *LesOdr) IndexerConfig() *light.IndexerConfig {
 }
 
 const (
-	// MsgBlockBodies - block bodies request
+	// MsgBlockBodies represents a block bodies request
 	MsgBlockBodies = iota
-	// MsgCode - code request
+	// MsgCode represents a code request
 	MsgCode
-	// MsgReceipts - receipts request
+	// MsgReceipts represents a receipts request
 	MsgReceipts
-	// MsgProofsV2 - proofs request
+	// MsgProofsV2 represents a v2 proofs request
 	MsgProofsV2
-	// MsgHelperTrieProofs - helper trie proofs request
+	// MsgHelperTrieProofs represents a helper trie proofs request
 	MsgHelperTrieProofs
-	// MsgTxStatus - transaction status request
+	// MsgTxStatus represents a transaction status request
 	MsgTxStatus
 )
 

--- a/les/odr.go
+++ b/les/odr.go
@@ -34,6 +34,7 @@ type LesOdr struct {
 	stop                                       chan struct{}
 }
 
+// NewLesOdr - construct a new LES on demand request
 func NewLesOdr(db ethdb.Database, config *light.IndexerConfig, retriever *retrieveManager) *LesOdr {
 	return &LesOdr{
 		db:            db,
@@ -81,11 +82,17 @@ func (odr *LesOdr) IndexerConfig() *light.IndexerConfig {
 }
 
 const (
+	// MsgBlockBodies - block bodies request
 	MsgBlockBodies = iota
+	// MsgCode - code request
 	MsgCode
+	// MsgReceipts - receipts request
 	MsgReceipts
+	// MsgProofsV2 - proofs request
 	MsgProofsV2
+	// MsgHelperTrieProofs - helper trie proofs request
 	MsgHelperTrieProofs
+	// MsgTxStatus - transaction status request
 	MsgTxStatus
 )
 

--- a/les/odr_requests.go
+++ b/les/odr_requests.go
@@ -45,7 +45,7 @@ var (
 	errUselessNodes        = errors.New("useless nodes in merkle proof nodeset")
 )
 
-// LesOdrRequest - an on-demand request
+// LesOdrRequest represents an on-demand request from a client
 type LesOdrRequest interface {
 	GetCost(*peer) uint64
 	CanSend(*peer) bool
@@ -53,7 +53,7 @@ type LesOdrRequest interface {
 	Validate(ethdb.Database, *Msg) error
 }
 
-// LesRequest - generate a LES on demand request from a light one
+// LesRequest generates a LES on demand request based on an on-demand request from the 'light' namespace
 func LesRequest(req light.OdrRequest) LesOdrRequest {
 	switch r := req.(type) {
 	case *light.BlockRequest:
@@ -180,14 +180,14 @@ func (r *ReceiptsRequest) Validate(db ethdb.Database, msg *Msg) error {
 	return nil
 }
 
-// ProofReq - a request for a proof
+// ProofReq is a message requesting a proof
 type ProofReq struct {
 	BHash       common.Hash
 	AccKey, Key []byte
 	FromLevel   uint
 }
 
-// TrieRequest -  ODR request type for state/storage trie entries, see LesOdrRequest interface
+// TrieRequest is an ODR request message for state/storage trie entries, see LesOdrRequest interface
 type TrieRequest light.TrieRequest
 
 // GetCost returns the cost of the given ODR request according to the serving
@@ -236,13 +236,13 @@ func (r *TrieRequest) Validate(db ethdb.Database, msg *Msg) error {
 	return nil
 }
 
-// CodeReq - a request for contract code
+// CodeReq a request for contract code
 type CodeReq struct {
 	BHash  common.Hash
 	AccKey []byte
 }
 
-// CodeRequest -  ODR request type for node data (used for retrieving contract code), see LesOdrRequest interface
+// CodeRequest is an ODR request type for code (used for retrieving contract code)
 type CodeRequest light.CodeRequest
 
 // GetCost returns the cost of the given ODR request according to the serving
@@ -301,7 +301,7 @@ const (
 	auxHeader = 2
 )
 
-// HelperTrieReq - a request for part of a trie
+// HelperTrieReq is a request for part of a trie
 type HelperTrieReq struct {
 	Type              uint
 	TrieIdx           uint64
@@ -309,13 +309,13 @@ type HelperTrieReq struct {
 	FromLevel, AuxReq uint
 }
 
-// HelperTrieResps - response to HelperTrieReq, providing merkle proofs
+// HelperTrieResps response to HelperTrieReq, providing merkle proofs
 type HelperTrieResps struct { // describes all responses, not just a single one
 	Proofs  light.NodeList
 	AuxData [][]byte
 }
 
-// ChtRequest - ODR request type for requesting headers by Canonical Hash Trie, see LesOdrRequest interface
+// ChtRequest is an ODR request type for requesting headers by Canonical Hash Trie
 type ChtRequest light.ChtRequest
 
 // GetCost returns the cost of the given ODR request according to the serving
@@ -399,12 +399,10 @@ func (r *ChtRequest) Validate(db ethdb.Database, msg *Msg) error {
 	return nil
 }
 
-// BloomReq -
 type BloomReq struct {
 	BloomTrieNum, BitIdx, SectionIndex, FromLevel uint64
 }
 
-// BloomRequest - ODR request type for requesting headers by Canonical Hash Trie, see LesOdrRequest interface
 type BloomRequest light.BloomRequest
 
 // GetCost returns the cost of the given ODR request according to the serving

--- a/les/peer.go
+++ b/les/peer.go
@@ -610,7 +610,7 @@ func (p *peer) Handshake(td *big.Int, head common.Hash, headNum uint64, genesis 
 		return errResp(ErrGenesisBlockMismatch, "%x (!= %x)", rGenesis[:8], genesis[:8])
 	}
 	if rNetwork != p.network {
-		return errResp(ErrNetworkIdMismatch, "%d (!= %d)", rNetwork, p.network)
+		return errResp(ErrNetworkIDMismatch, "%d (!= %d)", rNetwork, p.network)
 	}
 	if int(rVersion) != p.version {
 		return errResp(ErrProtocolVersionMismatch, "%d (!= %d)", rVersion, p.version)

--- a/les/peer_test.go
+++ b/les/peer_test.go
@@ -12,8 +12,8 @@ import (
 )
 
 const (
-	test_networkid   = 10
-	protocol_version = lpv2
+	testNetworkID   = 10
+	protocolVersion = lpv2
 )
 
 var (
@@ -30,7 +30,7 @@ func TestPeerHandshakeSetAnnounceTypeToAnnounceTypeSignedForTrustedPeer(t *testi
 	//peer to connect(on ulc side)
 	p := peer{
 		Peer:      p2p.NewPeer(id, "test peer", []p2p.Cap{}),
-		version:   protocol_version,
+		version:   protocolVersion,
 		isTrusted: true,
 		rw: &rwStub{
 			WriteHook: func(recvList keyValueList) {
@@ -59,7 +59,7 @@ func TestPeerHandshakeSetAnnounceTypeToAnnounceTypeSignedForTrustedPeer(t *testi
 				return l
 			},
 		},
-		network: test_networkid,
+		network: testNetworkID,
 	}
 
 	err := p.Handshake(td, hash, headNum, genesis, nil)
@@ -76,7 +76,7 @@ func TestPeerHandshakeAnnounceTypeSignedForTrustedPeersPeerNotInTrusted(t *testi
 	id := newNodeID(t).ID()
 	p := peer{
 		Peer:    p2p.NewPeer(id, "test peer", []p2p.Cap{}),
-		version: protocol_version,
+		version: protocolVersion,
 		rw: &rwStub{
 			WriteHook: func(recvList keyValueList) {
 				//checking that ulc sends to peer allowedRequests=noRequests and announceType != announceTypeSigned
@@ -104,7 +104,7 @@ func TestPeerHandshakeAnnounceTypeSignedForTrustedPeersPeerNotInTrusted(t *testi
 				return l
 			},
 		},
-		network: test_networkid,
+		network: testNetworkID,
 	}
 
 	err := p.Handshake(td, hash, headNum, genesis, nil)
@@ -123,7 +123,7 @@ func TestPeerHandshakeDefaultAllRequests(t *testing.T) {
 
 	p := peer{
 		Peer:    p2p.NewPeer(id, "test peer", []p2p.Cap{}),
-		version: protocol_version,
+		version: protocolVersion,
 		rw: &rwStub{
 			ReadHook: func(l keyValueList) keyValueList {
 				l = l.add("announceType", uint64(announceTypeSigned))
@@ -132,7 +132,7 @@ func TestPeerHandshakeDefaultAllRequests(t *testing.T) {
 				return l
 			},
 		},
-		network: test_networkid,
+		network: testNetworkID,
 	}
 
 	err := p.Handshake(td, hash, headNum, genesis, s)
@@ -153,7 +153,7 @@ func TestPeerHandshakeServerSendOnlyAnnounceRequestsHeaders(t *testing.T) {
 
 	p := peer{
 		Peer:    p2p.NewPeer(id, "test peer", []p2p.Cap{}),
-		version: protocol_version,
+		version: protocolVersion,
 		rw: &rwStub{
 			ReadHook: func(l keyValueList) keyValueList {
 				l = l.add("announceType", uint64(announceTypeSigned))
@@ -171,7 +171,7 @@ func TestPeerHandshakeServerSendOnlyAnnounceRequestsHeaders(t *testing.T) {
 				}
 			},
 		},
-		network: test_networkid,
+		network: testNetworkID,
 	}
 
 	err := p.Handshake(td, hash, headNum, genesis, s)
@@ -184,7 +184,7 @@ func TestPeerHandshakeClientReceiveOnlyAnnounceRequestsHeaders(t *testing.T) {
 
 	p := peer{
 		Peer:    p2p.NewPeer(id, "test peer", []p2p.Cap{}),
-		version: protocol_version,
+		version: protocolVersion,
 		rw: &rwStub{
 			ReadHook: func(l keyValueList) keyValueList {
 				l = l.add("flowControl/BL", uint64(0))
@@ -196,7 +196,7 @@ func TestPeerHandshakeClientReceiveOnlyAnnounceRequestsHeaders(t *testing.T) {
 				return l
 			},
 		},
-		network:   test_networkid,
+		network:   testNetworkID,
 		isTrusted: true,
 	}
 
@@ -215,7 +215,7 @@ func TestPeerHandshakeClientReturnErrorOnUselessPeer(t *testing.T) {
 
 	p := peer{
 		Peer:    p2p.NewPeer(id, "test peer", []p2p.Cap{}),
-		version: protocol_version,
+		version: protocolVersion,
 		rw: &rwStub{
 			ReadHook: func(l keyValueList) keyValueList {
 				l = l.add("flowControl/BL", uint64(0))
@@ -227,7 +227,7 @@ func TestPeerHandshakeClientReturnErrorOnUselessPeer(t *testing.T) {
 				return l
 			},
 		},
-		network: test_networkid,
+		network: testNetworkID,
 	}
 
 	err := p.Handshake(td, hash, headNum, genesis, nil)
@@ -254,8 +254,8 @@ type rwStub struct {
 
 func (s *rwStub) ReadMsg() (p2p.Msg, error) {
 	payload := keyValueList{}
-	payload = payload.add("protocolVersion", uint64(protocol_version))
-	payload = payload.add("networkId", uint64(test_networkid))
+	payload = payload.add("protocolVersion", uint64(protocolVersion))
+	payload = payload.add("networkId", uint64(testNetworkID))
 	payload = payload.add("headTd", td)
 	payload = payload.add("headHash", hash)
 	payload = payload.add("headNum", headNum)

--- a/les/protocol.go
+++ b/les/protocol.go
@@ -102,35 +102,20 @@ var requests = map[uint64]requestInfo{
 type errCode int
 
 const (
-	// ErrMsgTooLarge - message too large
 	ErrMsgTooLarge = iota
-	// ErrDecode - decode error
 	ErrDecode
-	// ErrInvalidMsgCode - invalid message error
 	ErrInvalidMsgCode
-	// ErrProtocolVersionMismatch - mismatched protocol version
 	ErrProtocolVersionMismatch
-	// ErrNetworkIDMismatch - wrong network id
 	ErrNetworkIDMismatch
-	// ErrGenesisBlockMismatch - incompatible genesis blocks
 	ErrGenesisBlockMismatch
-	// ErrNoStatusMsg -
 	ErrNoStatusMsg
-	// ErrExtraStatusMsg -
 	ErrExtraStatusMsg
-	// ErrSuspendedPeer -
 	ErrSuspendedPeer
-	// ErrUselessPeer -
 	ErrUselessPeer
-	// ErrRequestRejected -
 	ErrRequestRejected
-	// ErrUnexpectedResponse -
 	ErrUnexpectedResponse
-	// ErrInvalidResponse -
 	ErrInvalidResponse
-	// ErrTooManyTimeouts -
 	ErrTooManyTimeouts
-	// ErrMissingKey -
 	ErrMissingKey
 )
 

--- a/les/protocol.go
+++ b/les/protocol.go
@@ -42,17 +42,8 @@ var (
 	AdvertiseProtocolVersions = []uint{lpv2} // clients are searching for the first advertised protocol in the list
 )
 
-<<<<<<< HEAD
-// Number of implemented message corresponding to different protocol versions.
+// ProtocolLengths is the number of implemented message corresponding to different protocol versions.
 var ProtocolLengths = map[uint]uint64{lpv2: 22, lpv3: 24}
-=======
-// ProtocolLengths - Number of implemented message corresponding to different protocol versions.
-<<<<<<< HEAD
-var ProtocolLengths = map[uint]uint64{lpv2: 22}
->>>>>>> Further LES cleanup
-=======
-var ProtocolLengths = map[uint]uint64{lpv2: 22, lpv3: 24}
->>>>>>> resolving conflicts
 
 const (
 	// NetworkID - the network id

--- a/les/protocol.go
+++ b/les/protocol.go
@@ -47,8 +47,12 @@ var (
 var ProtocolLengths = map[uint]uint64{lpv2: 22, lpv3: 24}
 =======
 // ProtocolLengths - Number of implemented message corresponding to different protocol versions.
+<<<<<<< HEAD
 var ProtocolLengths = map[uint]uint64{lpv2: 22}
 >>>>>>> Further LES cleanup
+=======
+var ProtocolLengths = map[uint]uint64{lpv2: 22, lpv3: 24}
+>>>>>>> resolving conflicts
 
 const (
 	// NetworkID - the network id

--- a/les/protocol.go
+++ b/les/protocol.go
@@ -42,12 +42,19 @@ var (
 	AdvertiseProtocolVersions = []uint{lpv2} // clients are searching for the first advertised protocol in the list
 )
 
+<<<<<<< HEAD
 // Number of implemented message corresponding to different protocol versions.
 var ProtocolLengths = map[uint]uint64{lpv2: 22, lpv3: 24}
+=======
+// ProtocolLengths - Number of implemented message corresponding to different protocol versions.
+var ProtocolLengths = map[uint]uint64{lpv2: 22}
+>>>>>>> Further LES cleanup
 
 const (
-	NetworkId          = 1
-	ProtocolMaxMsgSize = 10 * 1024 * 1024 // Maximum cap on the size of a protocol message
+	// NetworkID - the network id
+	NetworkID = 1
+	// ProtocolMaxMsgSize - Maximum cap on the size of a protocol message
+	ProtocolMaxMsgSize = 10 * 1024 * 1024
 )
 
 // les protocol message codes
@@ -95,20 +102,35 @@ var requests = map[uint64]requestInfo{
 type errCode int
 
 const (
+	// ErrMsgTooLarge - message too large
 	ErrMsgTooLarge = iota
+	// ErrDecode - decode error
 	ErrDecode
+	// ErrInvalidMsgCode - invalid message error
 	ErrInvalidMsgCode
+	// ErrProtocolVersionMismatch - mismatched protocol version
 	ErrProtocolVersionMismatch
-	ErrNetworkIdMismatch
+	// ErrNetworkIDMismatch - wrong network id
+	ErrNetworkIDMismatch
+	// ErrGenesisBlockMismatch - incompatible genesis blocks
 	ErrGenesisBlockMismatch
+	// ErrNoStatusMsg -
 	ErrNoStatusMsg
+	// ErrExtraStatusMsg -
 	ErrExtraStatusMsg
+	// ErrSuspendedPeer -
 	ErrSuspendedPeer
+	// ErrUselessPeer -
 	ErrUselessPeer
+	// ErrRequestRejected -
 	ErrRequestRejected
+	// ErrUnexpectedResponse -
 	ErrUnexpectedResponse
+	// ErrInvalidResponse -
 	ErrInvalidResponse
+	// ErrTooManyTimeouts -
 	ErrTooManyTimeouts
+	// ErrMissingKey -
 	ErrMissingKey
 )
 
@@ -122,7 +144,7 @@ var errorToString = map[int]string{
 	ErrDecode:                  "Invalid message",
 	ErrInvalidMsgCode:          "Invalid message code",
 	ErrProtocolVersionMismatch: "Protocol version mismatch",
-	ErrNetworkIdMismatch:       "NetworkId mismatch",
+	ErrNetworkIDMismatch:       "NetworkId mismatch",
 	ErrGenesisBlockMismatch:    "Genesis block mismatch",
 	ErrNoStatusMsg:             "No status message",
 	ErrExtraStatusMsg:          "Extra status message",

--- a/les/server.go
+++ b/les/server.go
@@ -39,10 +39,6 @@ import (
 
 const bufLimitRatio = 6000 // fixed bufLimit/MRR ratio
 
-<<<<<<< HEAD
-<<<<<<< HEAD
-=======
->>>>>>> resolving conflicts
 const (
 	logFileName          = ""    // csv log file name (disabled if empty)
 	logClientPoolMetrics = true  // log client pool metrics
@@ -52,12 +48,7 @@ const (
 	logProtocolHandler   = true  // log protocol handler events
 )
 
-<<<<<<< HEAD
-=======
-=======
->>>>>>> resolving conflicts
 // LesServer is a node service running a LES server
->>>>>>> Correcting documentation format
 type LesServer struct {
 	lesCommons
 
@@ -310,10 +301,7 @@ func (s *LesServer) SetBloomBitsIndexer(bloomIndexer *core.ChainIndexer) {
 func (s *LesServer) Stop() error {
 	s.fcManager.Stop()
 	s.chtIndexer.Close()
-<<<<<<< HEAD
-=======
 
->>>>>>> resolving conflicts
 	// bloom trie indexer is closed by parent bloombits indexer
 	go func() {
 		<-s.protocolManager.noMorePeers

--- a/les/server.go
+++ b/les/server.go
@@ -70,6 +70,7 @@ type LesServer struct {
 	priorityClientPool         *priorityClientPool
 }
 
+// NewLesServer - ctor creating a LES server node service
 func NewLesServer(eth *eth.Ethereum, config *eth.Config) (*LesServer, error) {
 	var csvLogger *csvlogger.Logger
 	if logFileName != "" {
@@ -153,9 +154,13 @@ func NewLesServer(eth *eth.Ethereum, config *eth.Config) (*LesServer, error) {
 	}
 
 	srv.chtIndexer.Start(eth.BlockChain())
+
+	eth.GetBloomIndexer().AddChildIndexer(srv.bloomTrieIndexer)
+
 	return srv, nil
 }
 
+// APIs - the RPC APIs offered by this server
 func (s *LesServer) APIs() []rpc.API {
 	return []rpc.API{
 		{
@@ -227,12 +232,13 @@ func (s *LesServer) startEventLoop() {
 	}()
 }
 
+// Protocols - rlpx capabilities offered by this LES server
 func (s *LesServer) Protocols() []p2p.Protocol {
 	return s.makeProtocols(ServerProtocolVersions)
 }
 
 // Start starts the LES server
-func (s *LesServer) Start(srvr *p2p.Server) {
+func (s *LesServer) Start(srvr *p2p.Server) error {
 	s.maxPeers = s.config.LightPeers
 	totalRecharge := s.costTracker.totalRecharge()
 	if s.maxPeers > 0 {
@@ -282,24 +288,30 @@ func (s *LesServer) Start(srvr *p2p.Server) {
 	}
 	s.privateKey = srvr.PrivateKey
 	s.protocolManager.blockLoop()
+	return nil
 }
 
+// SetBloomBitsIndexer - adds the bloombits indexer as a child indexer to the bloomtrie indexer
 func (s *LesServer) SetBloomBitsIndexer(bloomIndexer *core.ChainIndexer) {
 	bloomIndexer.AddChildIndexer(s.bloomTrieIndexer)
 }
 
 // Stop stops the LES service
-func (s *LesServer) Stop() {
+func (s *LesServer) Stop() error {
 	s.fcManager.Stop()
 	s.chtIndexer.Close()
 	// bloom trie indexer is closed by parent bloombits indexer
 	go func() {
 		<-s.protocolManager.noMorePeers
 	}()
+
 	s.freeClientPool.stop()
+
 	s.costTracker.stop()
+
 	s.protocolManager.Stop()
 	s.csvLogger.Stop()
+	return nil
 }
 
 // todo(rjl493456442) separate client and server implementation.

--- a/les/server.go
+++ b/les/server.go
@@ -39,6 +39,7 @@ import (
 
 const bufLimitRatio = 6000 // fixed bufLimit/MRR ratio
 
+<<<<<<< HEAD
 const (
 	logFileName          = ""    // csv log file name (disabled if empty)
 	logClientPoolMetrics = true  // log client pool metrics
@@ -48,6 +49,9 @@ const (
 	logProtocolHandler   = true  // log protocol handler events
 )
 
+=======
+// LesServer is a node service running a LES server
+>>>>>>> Correcting documentation format
 type LesServer struct {
 	lesCommons
 
@@ -70,7 +74,7 @@ type LesServer struct {
 	priorityClientPool         *priorityClientPool
 }
 
-// NewLesServer - ctor creating a LES server node service
+// NewLesServer creates a LES server node service
 func NewLesServer(eth *eth.Ethereum, config *eth.Config) (*LesServer, error) {
 	var csvLogger *csvlogger.Logger
 	if logFileName != "" {
@@ -160,7 +164,7 @@ func NewLesServer(eth *eth.Ethereum, config *eth.Config) (*LesServer, error) {
 	return srv, nil
 }
 
-// APIs - the RPC APIs offered by this server
+// APIs lists the RPC APIs offered by this server
 func (s *LesServer) APIs() []rpc.API {
 	return []rpc.API{
 		{
@@ -232,7 +236,7 @@ func (s *LesServer) startEventLoop() {
 	}()
 }
 
-// Protocols - rlpx capabilities offered by this LES server
+// Protocols lists the rlpx capabilities offered by this LES server
 func (s *LesServer) Protocols() []p2p.Protocol {
 	return s.makeProtocols(ServerProtocolVersions)
 }
@@ -291,7 +295,7 @@ func (s *LesServer) Start(srvr *p2p.Server) error {
 	return nil
 }
 
-// SetBloomBitsIndexer - adds the bloombits indexer as a child indexer to the bloomtrie indexer
+// SetBloomBitsIndexer adds the bloombits indexer as a child indexer to the bloomtrie indexer
 func (s *LesServer) SetBloomBitsIndexer(bloomIndexer *core.ChainIndexer) {
 	bloomIndexer.AddChildIndexer(s.bloomTrieIndexer)
 }

--- a/les/server.go
+++ b/les/server.go
@@ -40,6 +40,9 @@ import (
 const bufLimitRatio = 6000 // fixed bufLimit/MRR ratio
 
 <<<<<<< HEAD
+<<<<<<< HEAD
+=======
+>>>>>>> resolving conflicts
 const (
 	logFileName          = ""    // csv log file name (disabled if empty)
 	logClientPoolMetrics = true  // log client pool metrics
@@ -49,7 +52,10 @@ const (
 	logProtocolHandler   = true  // log protocol handler events
 )
 
+<<<<<<< HEAD
 =======
+=======
+>>>>>>> resolving conflicts
 // LesServer is a node service running a LES server
 >>>>>>> Correcting documentation format
 type LesServer struct {
@@ -304,6 +310,10 @@ func (s *LesServer) SetBloomBitsIndexer(bloomIndexer *core.ChainIndexer) {
 func (s *LesServer) Stop() error {
 	s.fcManager.Stop()
 	s.chtIndexer.Close()
+<<<<<<< HEAD
+=======
+
+>>>>>>> resolving conflicts
 	// bloom trie indexer is closed by parent bloombits indexer
 	go func() {
 		<-s.protocolManager.noMorePeers

--- a/les/ulc_test.go
+++ b/les/ulc_test.go
@@ -176,8 +176,8 @@ func connectPeers(full, light pairPeer, version int) (*peer, *peer, error) {
 	// Create a message pipe to communicate through
 	app, net := p2p.MsgPipe()
 
-	peerLight := full.PM.newPeer(version, NetworkId, p2p.NewPeer(light.Node.ID(), light.Name, nil), net)
-	peerFull := light.PM.newPeer(version, NetworkId, p2p.NewPeer(full.Node.ID(), full.Name, nil), app)
+	peerLight := full.PM.newPeer(version, NetworkID, p2p.NewPeer(light.Node.ID(), light.Name, nil), net)
+	peerFull := light.PM.newPeer(version, NetworkID, p2p.NewPeer(full.Node.ID(), full.Name, nil), app)
 
 	// Start the peerLight on a new thread
 	errc1 := make(chan error, 1)


### PR DESCRIPTION
This PR does two things:
1) Separates the LES node.Service from ETH, as until now they are conflated, while cleaning up the initialisation.
2) Fixes a bunch of go-lint warnings. 