### PR TITLE
scwallet: don't error when pcsc socket is missing

### DIFF
--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -1161,7 +1161,7 @@ func setSmartCard(ctx *cli.Context, cfg *node.Config) {
 	// Sanity check that the smartcard path is valid
 	fi, err := os.Stat(path)
 	if err != nil {
-		log.Error("Failed to verify smartcard daemon path", "path", path, "err", err)
+		log.Info("smartcard daemon scoket path not found, disabling", "path", path, "err", err)
 		return
 	}
 	if fi.Mode()&os.ModeType != os.ModeSocket {

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -1161,7 +1161,7 @@ func setSmartCard(ctx *cli.Context, cfg *node.Config) {
 	// Sanity check that the smartcard path is valid
 	fi, err := os.Stat(path)
 	if err != nil {
-		log.Info("smartcard daemon scoket path not found, disabling", "path", path, "err", err)
+		log.Info("Smartcard socket not found, disabling", "path", path, "err", err)
 		return
 	}
 	if fi.Mode()&os.ModeType != os.ModeSocket {

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -1161,7 +1161,7 @@ func setSmartCard(ctx *cli.Context, cfg *node.Config) {
 	// Sanity check that the smartcard path is valid
 	fi, err := os.Stat(path)
 	if err != nil {
-		log.Info("Smartcard socket not found, disabling", "path", path, "err", err)
+		log.Info("Smartcard socket not found, disabling", err", err)
 		return
 	}
 	if fi.Mode()&os.ModeType != os.ModeSocket {


### PR DESCRIPTION
If `pcscd` isn't present on the system, an error will be displayed that confuses users:

```
ERROR[06-04|14:59:45.281] Failed to verify smartcard daemon path   path=/var/run/pcscd/pcscd.comm err="stat /var/run/pcscd/pcscd.comm: no such file or directory"
```

Instead of reporting an error, it is just displayed as information so that users won't attribute all their woes to it.