### PR TITLE
scwallet: Disable macos support

### DIFF
--- a/vendor/github.com/gballet/go-libpcsclite/doc_darwin.go
+++ b/vendor/github.com/gballet/go-libpcsclite/doc_darwin.go
@@ -28,8 +28,8 @@
 // OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-// +build dragonfly freebsd netbsd openbsd solaris
+// +build darwin
 
 package pcsc
 
-const PCSCDSockName string = "/var/run/pcscd/pcscd.comm"
+const PCSCDSockName string = ""

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -135,10 +135,10 @@
 			"revisionTime": "2018-04-18T12:24:29Z"
 		},
 		{
-			"checksumSHA1": "+fiJGimxPPRSfi9sED4Lp6ytBeo=",
+			"checksumSHA1": "gsiYVjwKzFKe+JuIimgKlrPyipA=",
 			"path": "github.com/gballet/go-libpcsclite",
-			"revision": "2fd9b619dd3c5d74acbd975f997a6441984d74a7",
-			"revisionTime": "2019-05-28T10:50:17Z"
+			"revision": "2772fd86a8ff4306d2749f610a386bfee9e0d727",
+			"revisionTime": "2019-06-07T06:51:34Z"
 		},
 		{
 			"checksumSHA1": "gxV/cPPLkByTdY8y172t7v4qcZA=",


### PR DESCRIPTION
MacOS has its own vresion of PCSC buried into their [crypto token framework](https://developer.apple.com/documentation/cryptotokenkit/tksmartcard?language=objc), which has precedence over the PCSC-lite daemon. Hence, no readers are returned and `geth` doesn't report any wallet.

A platform-specific solution needs to be implemented, which is going to take time and shouldn't block 1.9. In any case, the search for the PCSC daemon path should be prevented, so that no irrelevant error message gets displayed.