### PR TITLE
Accounts: added transactorFromKeyStore

### DIFF
--- a/accounts/abi/bind/auth.go
+++ b/accounts/abi/bind/auth.go
@@ -22,6 +22,7 @@ import (
 	"io"
 	"io/ioutil"
 
+	"github.com/ethereum/go-ethereum/accounts"
 	"github.com/ethereum/go-ethereum/accounts/keystore"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
@@ -40,6 +41,24 @@ func NewTransactor(keyin io.Reader, passphrase string) (*TransactOpts, error) {
 		return nil, err
 	}
 	return NewKeyedTransactor(key.PrivateKey), nil
+}
+
+// NewTransactor is a utility method to easily create a transaction signer from
+// an decrypted key from a keystore
+func NewTransactorFromKeyStore(keystore *keystore.KeyStore, account accounts.Account) (*TransactOpts, error) {
+	return &TransactOpts{
+		From: account.Address,
+		Signer: func(signer types.Signer, address common.Address, tx *types.Transaction) (*types.Transaction, error) {
+			if address != account.Address {
+				return nil, errors.New("not authorized to sign this account")
+			}
+			signature, err := keystore.SignHash(account, signer.Hash(tx).Bytes())
+			if err != nil {
+				return nil, err
+			}
+			return tx.WithSignature(signer, signature)
+		},
+	}, nil
 }
 
 // NewKeyedTransactor is a utility method to easily create a transaction signer


### PR DESCRIPTION
Currently user need to handle their keys manually in order to create TransactOpts. 
This utility function should improve the workflow for users that let their keys be handled by a keystore. 