### PR TITLE
eth, les: reject stale request

### DIFF
--- a/eth/backend.go
+++ b/eth/backend.go
@@ -481,6 +481,7 @@ func (s *Ethereum) EthVersion() int                    { return int(s.protocolMa
 func (s *Ethereum) NetVersion() uint64                 { return s.networkID }
 func (s *Ethereum) Downloader() *downloader.Downloader { return s.protocolManager.downloader }
 func (s *Ethereum) Synced() bool                       { return atomic.LoadUint32(&s.protocolManager.acceptTxs) == 1 }
+func (s *Ethereum) ArchiveMode() bool                  { return s.config.NoPruning }
 
 // Protocols implements node.Service, returning all the currently configured
 // network protocols to start.

--- a/les/handler.go
+++ b/les/handler.go
@@ -700,8 +700,9 @@ func (pm *ProtocolManager) handleMsg(p *peer) error {
 					}
 					// Refuse to search stale state data in the database since looking for
 					// a non-exist key is kind of expensive.
-					if !pm.server.archiveMode && header.Number.Uint64()+core.TriesInMemory <= pm.blockchain.CurrentHeader().Number.Uint64() {
-						p.Log().Debug("Reject stale code request", "number", header.Number.Uint64(), "head", pm.blockchain.CurrentHeader().Number.Uint64())
+					local := pm.blockchain.CurrentHeader().Number.Uint64()
+					if !pm.server.archiveMode && header.Number.Uint64()+core.TriesInMemory <= local {
+						p.Log().Debug("Reject stale code request", "number", header.Number.Uint64(), "head", local)
 						continue
 					}
 					triedb := pm.blockchain.StateCache().TrieDB()
@@ -860,8 +861,9 @@ func (pm *ProtocolManager) handleMsg(p *peer) error {
 						}
 						// Refuse to search stale state data in the database since looking for
 						// a non-exist key is kind of expensive.
-						if !pm.server.archiveMode && header.Number.Uint64()+core.TriesInMemory <= pm.blockchain.CurrentHeader().Number.Uint64() {
-							p.Log().Debug("Reject stale trie request", "number", header.Number.Uint64(), "head", pm.blockchain.CurrentHeader().Number.Uint64())
+						local := pm.blockchain.CurrentHeader().Number.Uint64()
+						if !pm.server.archiveMode && header.Number.Uint64()+core.TriesInMemory <= local {
+							p.Log().Debug("Reject stale trie request", "number", header.Number.Uint64(), "head", local)
 							continue
 						}
 						root = header.Root

--- a/les/handler.go
+++ b/les/handler.go
@@ -698,6 +698,12 @@ func (pm *ProtocolManager) handleMsg(p *peer) error {
 						p.Log().Warn("Failed to retrieve header for code", "block", *number, "hash", request.BHash)
 						continue
 					}
+					// Refuse to search stale state data in the database since looking for
+					// a non-exist key is kind of expensive.
+					if !pm.server.archiveMode && header.Number.Uint64()+core.TriesInMemory <= pm.blockchain.CurrentHeader().Number.Uint64() {
+						p.Log().Debug("Reject stale code request", "number", header.Number.Uint64(), "head", pm.blockchain.CurrentHeader().Number.Uint64())
+						continue
+					}
 					triedb := pm.blockchain.StateCache().TrieDB()
 
 					account, err := pm.getAccount(triedb, header.Root, common.BytesToHash(request.AccKey))
@@ -850,6 +856,12 @@ func (pm *ProtocolManager) handleMsg(p *peer) error {
 						}
 						if header = rawdb.ReadHeader(pm.chainDb, request.BHash, *number); header == nil {
 							p.Log().Warn("Failed to retrieve header for proof", "block", *number, "hash", request.BHash)
+							continue
+						}
+						// Refuse to search stale state data in the database since looking for
+						// a non-exist key is kind of expensive.
+						if !pm.server.archiveMode && header.Number.Uint64()+core.TriesInMemory <= pm.blockchain.CurrentHeader().Number.Uint64() {
+							p.Log().Debug("Reject stale trie request", "number", header.Number.Uint64(), "head", pm.blockchain.CurrentHeader().Number.Uint64())
 							continue
 						}
 						root = header.Root

--- a/les/peer.go
+++ b/les/peer.go
@@ -551,7 +551,14 @@ func (p *peer) Handshake(td *big.Int, head common.Hash, headNum uint64, genesis 
 			send = send.add("serveHeaders", nil)
 			send = send.add("serveChainSince", uint64(0))
 			send = send.add("serveStateSince", uint64(0))
-			send = send.add("serveRecentState", uint64(core.TriesInMemory-4))
+
+			// If local ethereum node is running in archive mode, advertise ourselves we have
+			// all version state data. Otherwise only recent state is available.
+			stateRecent := uint64(core.TriesInMemory - 4)
+			if server.archiveMode {
+				stateRecent = 0
+			}
+			send = send.add("serveRecentState", stateRecent)
 			send = send.add("txRelay", nil)
 		}
 		send = send.add("flowControl/BL", server.defParams.BufLimit)

--- a/les/server.go
+++ b/les/server.go
@@ -51,6 +51,8 @@ const (
 type LesServer struct {
 	lesCommons
 
+	archiveMode bool // Flag whether the ethereum node runs in archive mode.
+
 	fcManager    *flowcontrol.ClientManager // nil if our node is client only
 	costTracker  *costTracker
 	testCost     uint64
@@ -93,7 +95,8 @@ func NewLesServer(eth *eth.Ethereum, config *eth.Config) (*LesServer, error) {
 		nil,
 		quitSync,
 		new(sync.WaitGroup),
-		config.ULC, eth.Synced)
+		config.ULC,
+		eth.Synced)
 	if err != nil {
 		return nil, err
 	}
@@ -120,6 +123,7 @@ func NewLesServer(eth *eth.Ethereum, config *eth.Config) (*LesServer, error) {
 			bloomTrieIndexer: light.NewBloomTrieIndexer(eth.ChainDb(), nil, params.BloomBitsBlocks, params.BloomTrieFrequency),
 			protocolManager:  pm,
 		},
+		archiveMode:  eth.ArchiveMode(),
 		quitSync:     quitSync,
 		lesTopics:    lesTopics,
 		onlyAnnounce: config.OnlyAnnounce,


### PR DESCRIPTION
This PR rejects all stale les request if the server is not "archive" mode.

The rationale behind this: searching a non-exist key in leveldb is expensive. So that it can leave an attack vector that attacker can constructor "stale" request to drain out the capacity of server.