### PR TITLE
les/handler: avoid lookup missing state

### DIFF
--- a/les/handler.go
+++ b/les/handler.go
@@ -868,6 +868,10 @@ func (pm *ProtocolManager) handleMsg(p *peer) error {
 						}
 						root = header.Root
 					}
+					// If a header lookup failed (non existent), ignore subsequent requests for the same header
+					if root == (common.Hash{}) {
+						continue
+					}
 					// Open the account or storage trie for the request
 					statedb := pm.blockchain.StateCache()
 


### PR DESCRIPTION
If a request comes in with the same missing block hash in all requests, the check `if request.BHash != lastBHash ` is false for all requests after the first one, and `root` is unset. This PR aborts if that happens