### PR TITLE
core: avoid limit lower than MinGasLimit

### DIFF
--- a/core/block_validator.go
+++ b/core/block_validator.go
@@ -120,9 +120,7 @@ func CalcGasLimit(parent *types.Block, gasFloor, gasCeil uint64) uint64 {
 		from parentGasLimit * (2/3) parentGasUsed is.
 	*/
 	limit := parent.GasLimit() - decay + contrib
-	if limit < params.MinGasLimit {
-		limit = params.MinGasLimit
-	}
+
 	// If we're outside our allowed gas range, we try to hone towards them
 	if limit < gasFloor {
 		limit = parent.GasLimit() + decay
@@ -135,5 +133,10 @@ func CalcGasLimit(parent *types.Block, gasFloor, gasCeil uint64) uint64 {
 			limit = gasCeil
 		}
 	}
+
+	if limit < params.MinGasLimit {
+		limit = params.MinGasLimit
+	}
+
 	return limit
 }


### PR DESCRIPTION
If accidentally set a wrong value for gasFloor/gasCeil