### PR TITLE
eth: reject mining request if node is not synced

### DIFF
--- a/eth/protocol_test.go
+++ b/eth/protocol_test.go
@@ -99,7 +99,7 @@ func TestRecvTransactions63(t *testing.T) { testRecvTransactions(t, 63) }
 func testRecvTransactions(t *testing.T, protocol int) {
 	txAdded := make(chan []*types.Transaction)
 	pm, _ := newTestProtocolManagerMust(t, downloader.FullSync, 0, nil, txAdded)
-	pm.acceptTxs = 1 // mark synced to accept transactions
+	pm.synced = 1 // mark synced to accept transactions
 	p, _ := newTestPeer("peer", protocol, pm, true)
 	defer pm.Stop()
 	defer p.close()

--- a/eth/sync.go
+++ b/eth/sync.go
@@ -209,7 +209,7 @@ func (pm *ProtocolManager) synchronise(peer *peer) {
 		// Checkpoint passed, sanity check the timestamp to have a fallback mechanism
 		// for non-checkpointed (number = 0) private networks.
 		if head.Time() >= uint64(time.Now().AddDate(0, -1, 0).Unix()) {
-			atomic.StoreUint32(&pm.acceptTxs, 1)
+			atomic.StoreUint32(&pm.synced, 1)
 		}
 	}
 	if head.NumberU64() > 0 {


### PR DESCRIPTION
This PR adds an extra check for starting mining. If the node is not synced yet, we should disable mining request.

Question:
* Should we consider reject local transactions if the "full node/light client" is not synced yet?
    We can't verify the validity of the local transaction(enough balance).
    We can't provide a valid nonce for transaction assembling.
    But we can relay them to the network. 

* Should we consider reject remote transactions if the "full node/light client" is not synced yet?
    Yes, since we can't verify the transaction really meaningfully.