### PR TITLE
p2p: add more info to peer addition and removal logs

### DIFF
--- a/p2p/server.go
+++ b/p2p/server.go
@@ -744,7 +744,7 @@ running:
 					p.events = &srv.peerFeed
 				}
 				name := truncateName(c.name)
-				srv.log.Debug("Adding p2p peer", "name", name, "addr", c.fd.RemoteAddr(), "peers", len(peers)+1)
+				p.log.Debug("Adding p2p peer", "addr", p.RemoteAddr(), "peers", len(peers)+1, "name", name)
 				go srv.runPeer(p)
 				peers[c.node.ID()] = p
 				if p.Inbound() {
@@ -759,7 +759,7 @@ running:
 		case pd := <-srv.delpeer:
 			// A peer disconnected.
 			d := common.PrettyDuration(mclock.Now() - pd.created)
-			pd.log.Debug("Removing p2p peer", "duration", d, "peers", len(peers)-1, "req", pd.requested, "err", pd.err)
+			pd.log.Debug("Removing p2p peer", "addr", pd.RemoteAddr(), "peers", len(peers)-1, "duration", d, "req", pd.requested, "err", pd.err)
 			delete(peers, pd.ID())
 			if pd.Inbound() {
 				inboundCount--


### PR DESCRIPTION
```text
DEBUG[06-13|11:29:29.658] Adding p2p peer            id=6ff68d1c2df1fcb1 conn=dyndial addr=51.77.141.55:30303 peers=1 name=Pirl/v1.8.27-v6-mast...
DEBUG[06-13|11:29:29.677] Removing p2p peer          id=6ff68d1c2df1fcb1 conn=dyndial addr=51.77.141.55:30303 peers=0 duration=19.777ms req=true err="subprotocol error"
```