### PR TITLE
Resolve issue with wrong static path on /docs/ page

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1,5 +1,6 @@
 ---
 title: Documentation
+root: ..
 ---
 * User documentation can be found at our [Ethereum User Guide and reference manual](http://ethereum.gitbooks.io/frontier-guide/content/).
 * For the API reference and developer documentation head over to the auto generated [GoDoc](https://godoc.org/github.com/ethereum/go-ethereum) documentation.


### PR DESCRIPTION
The issue on page: https://geth.ethereum.org/docs/ wrong path to static files.
