### PR TITLE
RPC API: get receipts by block number

### DIFF
--- a/ethclient/ethclient.go
+++ b/ethclient/ethclient.go
@@ -268,6 +268,14 @@ func (ec *Client) TransactionReceipt(ctx context.Context, txHash common.Hash) (*
 	return r, err
 }
 
+// BlockReceipts returns the receipts of a transaction by block number.
+func (ec *Client) BlockReceipts(ctx context.Context, number *big.Int) (types.Receipts, error) {
+	var result types.Receipts
+	err := ec.c.CallContext(ctx, &result, "eth_getBlockReceipts", toBlockNumArg(number))
+
+	return result, err
+}
+
 func toBlockNumArg(number *big.Int) string {
 	if number == nil {
 		return "latest"

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -1241,6 +1241,71 @@ func (s *PublicTransactionPoolAPI) GetTransactionReceipt(ctx context.Context, ha
 	return fields, nil
 }
 
+// GetBlockReceipts returns the block receipts for the given block number.
+func (s *PublicTransactionPoolAPI) GetBlockReceipts(ctx context.Context, blockNr rpc.BlockNumber) ([]map[string]interface{}, error) {
+	block, err := s.b.BlockByNumber(ctx, blockNr)
+	if err != nil {
+		return nil, err
+	}
+	if block == nil {
+		return nil, nil
+	}
+
+	txs := block.Transactions()
+
+	receipts, err := s.b.GetReceipts(ctx, block.Hash())
+	if err != nil {
+		return nil, err
+	}
+
+	if len(receipts) != len(txs) {
+		return nil, fmt.Errorf("receipt and transaction count mismatch")
+	}
+
+	result := make([]map[string]interface{}, 0, len(receipts))
+
+	for index, receipt := range receipts {
+		tx := txs[index]
+		var signer types.Signer = types.FrontierSigner{}
+		if tx.Protected() {
+			signer = types.NewEIP155Signer(tx.ChainId())
+		}
+		from, _ := types.Sender(signer, tx)
+
+		fields := map[string]interface{}{
+			"blockHash":         block.Hash(),
+			"blockNumber":       hexutil.Uint64(blockNr),
+			"transactionHash":   receipt.TxHash,
+			"transactionIndex":  hexutil.Uint64(index),
+			"from":              from,
+			"to":                tx.To(),
+			"gasUsed":           hexutil.Uint64(receipt.GasUsed),
+			"cumulativeGasUsed": hexutil.Uint64(receipt.CumulativeGasUsed),
+			"contractAddress":   nil,
+			"logs":              receipt.Logs,
+			"logsBloom":         receipt.Bloom,
+		}
+
+		// Assign receipt status or post state.
+		if len(receipt.PostState) > 0 {
+			fields["root"] = hexutil.Bytes(receipt.PostState)
+		} else {
+			fields["status"] = hexutil.Uint(receipt.Status)
+		}
+		if receipt.Logs == nil {
+			fields["logs"] = [][]*types.Log{}
+		}
+		// If the ContractAddress is 20 0x0 bytes, assume it is not a contract creation
+		if receipt.ContractAddress != (common.Address{}) {
+			fields["contractAddress"] = receipt.ContractAddress
+		}
+
+		result = append(result, fields)
+	}
+
+	return result, nil
+}
+
 // sign is a helper function that signs a transaction with the private key of the given address.
 func (s *PublicTransactionPoolAPI) sign(addr common.Address, tx *types.Transaction) (*types.Transaction, error) {
 	// Look up the wallet containing the requested signer


### PR DESCRIPTION
For issue #19634

Added new RPC API: `eth_getBlockReceipts`. It returns receipts by block number.

Also, implemented tests for:
 - eth_getTransactionByBlockHashAndIndex
 - eth_getBlockReceipts