### PR TITLE
abigen: objc not supported, don't mention it

### DIFF
--- a/accounts/abi/bind/bind.go
+++ b/accounts/abi/bind/bind.go
@@ -38,7 +38,6 @@ type Lang int
 const (
 	LangGo Lang = iota
 	LangJava
-	LangObjC
 )
 
 // Bind generates a Go wrapper around a contract ABI. This wrapper isn't meant

--- a/cmd/abigen/main.go
+++ b/cmd/abigen/main.go
@@ -42,7 +42,7 @@ var (
 
 	pkgFlag  = flag.String("pkg", "", "Package name to generate the binding into")
 	outFlag  = flag.String("out", "", "Output file for the generated binding (default = stdout)")
-	langFlag = flag.String("lang", "go", "Destination language for the bindings (go, java, objc)")
+	langFlag = flag.String("lang", "go", "Destination language for the bindings (go, java)")
 )
 
 func main() {
@@ -69,8 +69,6 @@ func main() {
 		lang = bind.LangGo
 	case "java":
 		lang = bind.LangJava
-	case "objc":
-		lang = bind.LangObjC
 	default:
 		fmt.Printf("Unsupported destination language \"%s\" (--lang)\n", *langFlag)
 		os.Exit(-1)


### PR DESCRIPTION
The help message for `abigen` mentions Objective C as a valid language for its `--lang` option, but no code is present for the generation of objc bindings.