### PR TITLE
miner: don't update pending state when no transactions are added

### DIFF
--- a/miner/worker.go
+++ b/miner/worker.go
@@ -463,8 +463,13 @@ func (w *worker) mainLoop() {
 					txs[acc] = append(txs[acc], tx)
 				}
 				txset := types.NewTransactionsByPriceAndNonce(w.current.signer, txs)
+				tcount := w.current.tcount
 				w.commitTransactions(txset, coinbase, nil)
-				w.updateSnapshot()
+				// Only update the snapshot if any new transactons were added
+				// to the pending block
+				if tcount != w.current.tcount {
+					w.updateSnapshot()
+				}
 			} else {
 				// If clique is running in dev mode(period is 0), disable
 				// advance sealing here.

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -453,6 +453,10 @@ func (w *worker) mainLoop() {
 			// already included in the current mining block. These transactions will
 			// be automatically eliminated.
 			if !w.isRunning() && w.current != nil {
+				// If block is already full, abort
+				if gp := w.current.gasPool; gp != nil && gp.Gas() < params.TxGas {
+					continue
+				}
 				w.mu.RLock()
 				coinbase := w.coinbase
 				w.mu.RUnlock()


### PR DESCRIPTION
When the miner (not mining) receivew event feeds from the txpool, it tries to add it to the pending state. Most often, the pending state is already full, and new transactions does not actually make it into the pending block. If that happens, we can avoid updating the snapshot, which is a pretty expensive operations, creating a full new block (deep copying and hashing) and deep-copying the state.  