### PR TITLE
Detect and return error on eth_call on timeout 

### DIFF
--- a/core/vm/evm.go
+++ b/core/vm/evm.go
@@ -169,6 +169,11 @@ func (evm *EVM) Cancel() {
 	atomic.StoreInt32(&evm.abort, 1)
 }
 
+// Cancelled returns true if Cancel has been called
+func (evm *EVM) Cancelled() bool {
+	return atomic.LoadInt32(&evm.abort) == 1
+}
+
 // Interpreter returns the current interpreter
 func (evm *EVM) Interpreter() Interpreter {
 	return evm.interpreter

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -802,6 +802,10 @@ func DoCall(ctx context.Context, b Backend, args CallArgs, blockNr rpc.BlockNumb
 	if err := vmError(); err != nil {
 		return nil, 0, false, err
 	}
+	// If the timer caused an abort, return an appropriate error message
+	if evm.Cancelled() {
+		return nil, 0, false, fmt.Errorf("execution aborted (timeout = %v)", timeout)
+	}
 	return res, gas, failed, err
 }
 


### PR DESCRIPTION
This PR fixes https://github.com/ethereum/go-ethereum/issues/19186 

Problem: on `eth_call` and derivates using the same mechansm, there's a timeout that can trigger at any time. We currently do not signal this to the user, thus returning erroneous values when execution is aborted. 

This PR addresses thsi in a somewhat opportunistic way, since the timeout happens async in another goroutine. When we return from the actuall call, we check if the `Cancel` has been called on the `evm`. There is a tiny chance that the cancel was called _after_ the execution finished correctly, but it's bettter to error on the safe side than how we do it now (and the chances of that happening are really quite slim). 

Example when running this PR in `geth --dev console`, using an eternal loop (`jumpdest; push 0, jump`):
```
> eth.call({"gas":800000000000000000, "data":"0x5b600056"})
WARN [06-19|12:41:51.398] Served eth_call                          reqid=26 t=5.000339274s err="execution aborted (timeout = 5s)"
 ```
Without this PR: 
```
> eth.call({"gas":800000000000000000, "data":"0x5b600056"})
"0x"
```

 