### PR TITLE
cmd/evm: evm input minor fixes

### DIFF
--- a/cmd/evm/runner.go
+++ b/cmd/evm/runner.go
@@ -142,7 +142,6 @@ func runCmd(ctx *cli.Context) error {
 					os.Exit(1)
 				}
 			}
-
 		} else {
 			hexcode = []byte(codeFlag)
 		}

--- a/cmd/evm/runner.go
+++ b/cmd/evm/runner.go
@@ -17,7 +17,6 @@
 package main
 
 import (
-	"bytes"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
@@ -121,28 +120,37 @@ func runCmd(ctx *cli.Context) error {
 		ret  []byte
 		err  error
 	)
-	// The '--code' or '--codefile' flag overrides code in state
-	if ctx.GlobalString(CodeFileFlag.Name) != "" {
-		var hexcode []byte
-		var err error
-		// If - is specified, it means that code comes from stdin
-		if ctx.GlobalString(CodeFileFlag.Name) == "-" {
-			//Try reading from stdin
-			if hexcode, err = ioutil.ReadAll(os.Stdin); err != nil {
-				fmt.Printf("Could not load code from stdin: %v\n", err)
-				os.Exit(1)
-			}
-		} else {
-			// Codefile with hex assembly
-			if hexcode, err = ioutil.ReadFile(ctx.GlobalString(CodeFileFlag.Name)); err != nil {
-				fmt.Printf("Could not load code from file: %v\n", err)
-				os.Exit(1)
-			}
-		}
-		code = common.Hex2Bytes(string(bytes.TrimRight(hexcode, "\n")))
+	codeFileFlag := ctx.GlobalString(CodeFileFlag.Name)
+	codeFlag := ctx.GlobalString(CodeFlag.Name)
 
-	} else if ctx.GlobalString(CodeFlag.Name) != "" {
-		code = common.Hex2Bytes(ctx.GlobalString(CodeFlag.Name))
+	// The '--code' or '--codefile' flag overrides code in state
+	if codeFileFlag != "" || codeFlag != "" {
+		var hexcode []byte
+		if codeFileFlag != "" {
+			var err error
+			// If - is specified, it means that code comes from stdin
+			if codeFileFlag == "-" {
+				//Try reading from stdin
+				if hexcode, err = ioutil.ReadAll(os.Stdin); err != nil {
+					fmt.Printf("Could not load code from stdin: %v\n", err)
+					os.Exit(1)
+				}
+			} else {
+				// Codefile with hex assembly
+				if hexcode, err = ioutil.ReadFile(codeFileFlag); err != nil {
+					fmt.Printf("Could not load code from file: %v\n", err)
+					os.Exit(1)
+				}
+			}
+
+		} else {
+			hexcode = []byte(codeFlag)
+		}
+		if len(hexcode)%2 != 0 {
+			fmt.Printf("Invalid input length for hex data (%d)\n", len(hexcode))
+			os.Exit(1)
+		}
+		code = common.FromHex(string(hexcode))
 	} else if fn := ctx.Args().First(); len(fn) > 0 {
 		// EASM-file to compile
 		src, err := ioutil.ReadFile(fn)
@@ -155,7 +163,6 @@ func runCmd(ctx *cli.Context) error {
 		}
 		code = common.Hex2Bytes(bin)
 	}
-
 	initialGas := ctx.GlobalUint64(GasFlag.Name)
 	if genesisConfig.GasLimit != 0 {
 		initialGas = genesisConfig.GasLimit


### PR DESCRIPTION
This PR fixes two minor things in the `evm` binary

- Validate length of hex input. 
- Accept `0x`-prefix on hex input

It also closes #18041 
## With this PR

Invalid length:
```
[user@work evm]$ ./evm --debug --code "585" run
Invalid input length for hex data (3)
```
Prefixed by `0x`:
```
[user@work evm]$ ./evm --debug --code "0x5858" run
Code is 0x5858
0x
#### TRACE ####
PC              pc=00000000 gas=10000000000 cost=0

PC              pc=00000001 gas=9999999998 cost=0
Stack:
00000000  0000000000000000000000000000000000000000000000000000000000000000

STOP            pc=00000002 gas=9999999996 cost=0
Stack:
00000000  0000000000000000000000000000000000000000000000000000000000000001
00000001  0000000000000000000000000000000000000000000000000000000000000000

#### LOGS ####
```
Not prefixed:
```
[user@work evm]$ ./evm --debug --code "5858" run
Code is 0x5858
0x
#### TRACE ####
PC              pc=00000000 gas=10000000000 cost=0

PC              pc=00000001 gas=9999999998 cost=0
Stack:
00000000  0000000000000000000000000000000000000000000000000000000000000000

STOP            pc=00000002 gas=9999999996 cost=0
Stack:
00000000  0000000000000000000000000000000000000000000000000000000000000001
00000001  0000000000000000000000000000000000000000000000000000000000000000

#### LOGS ####
```

## Before this PR

Invalid length:
```
[user@work evm]$ ./evm --debug --code "585" run
0x
#### TRACE ####
PC              pc=00000000 gas=10000000000 cost=0

STOP            pc=00000001 gas=9999999998 cost=0
Stack:
00000000  0000000000000000000000000000000000000000000000000000000000000000

#### LOGS ####
```
Prefixed by `0x`:
```
[user@work evm]$ ./evm --debug --code "0x5858" run
0x
#### TRACE ####
#### LOGS ####
```
Not prefixed:
```
[user@work evm]$ ./evm --debug --code "5858" run
0x
#### TRACE ####
PC              pc=00000000 gas=10000000000 cost=0

PC              pc=00000001 gas=9999999998 cost=0
Stack:
00000000  0000000000000000000000000000000000000000000000000000000000000000

STOP            pc=00000002 gas=9999999996 cost=0
Stack:
00000000  0000000000000000000000000000000000000000000000000000000000000001
00000001  0000000000000000000000000000000000000000000000000000000000000000

#### LOGS ####
```