### PR TITLE
miner: minor fix for the interrupt memory allocation

### DIFF
--- a/miner/worker.go
+++ b/miner/worker.go
@@ -299,8 +299,9 @@ func (w *worker) newWorkLoop(recommit time.Duration) {
 	commit := func(noempty bool, s int32) {
 		if interrupt != nil {
 			atomic.StoreInt32(interrupt, s)
+		} else {
+			interrupt = new(int32)
 		}
-		interrupt = new(int32)
 		w.newWorkCh <- &newWorkReq{interrupt: interrupt, noempty: noempty, timestamp: timestamp}
 		timer.Reset(recommit)
 		atomic.StoreInt32(&w.newTxs, 0)


### PR DESCRIPTION
if the interrupter pointer is NULL then allocate memory for it.
if the interrupter point is not NULL then reuse original one.
current code always allocate memory for the pointer and overwrite the original pointer. 