### PR TITLE
rpc: fix subscription buffer documentation and test

### DIFF
--- a/rpc/client.go
+++ b/rpc/client.go
@@ -412,7 +412,7 @@ func (c *Client) ShhSubscribe(ctx context.Context, channel interface{}, args ...
 // The context argument cancels the RPC request that sets up the subscription but has no
 // effect on the subscription after Subscribe has returned.
 //
-// Slow subscribers will be dropped eventually. Client buffers up to 8000 notifications
+// Slow subscribers will be dropped eventually. Client buffers up to 20000 notifications
 // before considering the subscriber dead. The subscription Err channel will receive
 // ErrSubscriptionQueueOverflow. Use a sufficiently large buffer on the channel or ensure
 // that the channel usually has at least one reader to prevent this issue.

--- a/rpc/client_test.go
+++ b/rpc/client_test.go
@@ -374,10 +374,13 @@ func TestClientNotificationStorm(t *testing.T) {
 				return
 			}
 		}
+		if wantError {
+			t.Fatalf("didn't get expected error")
+		}
 	}
 
 	doTest(8000, false)
-	doTest(10000, true)
+	doTest(21000, true)
 }
 
 func TestClientHTTP(t *testing.T) {


### PR DESCRIPTION
This PR updates a comment about the maximum client subscription buffer to reflect changes made previously, and fixes a test that wouldn't fail when `wantError == true` but execution did not return an error.

Triggering the desired error currently requires input >= ~500 over the max on my machine. Happy to drill into that further and/or break up these commits into two PRs if desirable, but was hoping to collect feedback first. Thanks!