### PR TITLE
core: fix chain indexer reorg bug

### DIFF
--- a/core/chain_indexer.go
+++ b/core/chain_indexer.go
@@ -243,7 +243,7 @@ func (c *ChainIndexer) newHead(head uint64, reorg bool) {
 	// If a reorg happened, invalidate all sections until that point
 	if reorg {
 		// Revert the known section number to the reorg point
-		known := head / c.sectionSize
+		known := (head + 1) / c.sectionSize
 		stored := known
 		if known < c.checkpointSections {
 			known = 0

--- a/core/chain_indexer.go
+++ b/core/chain_indexer.go
@@ -323,6 +323,7 @@ func (c *ChainIndexer) updateLoop() {
 					updated = time.Now()
 				}
 				// Cache the current section count and head to allow unlocking the mutex
+				c.verifyLastHead()
 				section := c.storedSections
 				var oldHead common.Hash
 				if section > 0 {
@@ -342,8 +343,8 @@ func (c *ChainIndexer) updateLoop() {
 				}
 				c.lock.Lock()
 
-				// If processing succeeded and no reorgs occcurred, mark the section completed
-				if err == nil && oldHead == c.SectionHead(section-1) {
+				// If processing succeeded and no reorgs occurred, mark the section completed
+				if err == nil && (section == 0 || oldHead == c.SectionHead(section-1)) {
 					c.setSectionHead(section, newHead)
 					c.setValidSections(section + 1)
 					if c.storedSections == c.knownSections && updating {
@@ -358,6 +359,7 @@ func (c *ChainIndexer) updateLoop() {
 				} else {
 					// If processing failed, don't retry until further notification
 					c.log.Debug("Chain index processing failed", "section", section, "err", err)
+					c.verifyLastHead()
 					c.knownSections = c.storedSections
 				}
 			}
@@ -411,6 +413,18 @@ func (c *ChainIndexer) processSection(section uint64, lastHead common.Hash) (com
 	return lastHead, nil
 }
 
+// verifyLastHead compares last stored section head with the corresponding block hash in the
+// actual canonical chain and rolls back reorged sections if necessary to ensure that stored
+// sections are all valid
+func (c *ChainIndexer) verifyLastHead() {
+	for c.storedSections > 0 {
+		if c.SectionHead(c.storedSections-1) == rawdb.ReadCanonicalHash(c.chainDb, c.storedSections*c.sectionSize-1) {
+			return
+		}
+		c.setValidSections(c.storedSections - 1)
+	}
+}
+
 // Sections returns the number of processed sections maintained by the indexer
 // and also the information about the last header indexed for potential canonical
 // verifications.
@@ -418,6 +432,7 @@ func (c *ChainIndexer) Sections() (uint64, uint64, common.Hash) {
 	c.lock.Lock()
 	defer c.lock.Unlock()
 
+	c.verifyLastHead()
 	return c.storedSections, c.storedSections*c.sectionSize - 1, c.SectionHead(c.storedSections - 1)
 }
 


### PR DESCRIPTION
This PR fixes a bug in the chain indexer that caused repeated "chain reorged during section processing" errors under some rare circumstances.
https://github.com/ethereum/go-ethereum/blob/master/core/chain_indexer.go#L400
Here processSection checks for each processed header whether is parentHash equals the last block hash. The parent of the first block in a section is compared against the last section head which is passed as a parameter.
https://github.com/ethereum/go-ethereum/blob/master/core/chain_indexer.go#L333
The last section head is passed here which is assumed to be canonical bacause a reorg should theoretically trigger a rollback of stored sections. The problem is that this is not guaranteed to happen before the new section processing begins. If there is a stored section whose head does not match the most recent canonical hash at this point then processSection will fail but the invalid last stored section is never rolled back so processSection will try and fail again and again, assuming a wrong lastHead and failing on the first parent check.
In this fix verifyLastHead() always verifies whether the last stored section is still canonical and rolls it back if necessary. This prevents being stuck in this invalid state and as an extra bonus it always makes sure that the result of Sections() is up to date.

Fixes
https://github.com/ethereum/go-ethereum/issues/15169
https://github.com/ethereum/go-ethereum/issues/17227
https://github.com/ethereum/go-ethereum/issues/19711
https://github.com/ethereum/go-ethereum/issues/19720

