### PR TITLE
eth: fix sync bloom panic

### DIFF
--- a/eth/handler_test.go
+++ b/eth/handler_test.go
@@ -468,27 +468,22 @@ func TestCheckpointChallenge(t *testing.T) {
 		// If checkpointing is not enabled locally, don't challenge and don't drop
 		{downloader.FullSync, false, false, false, false, false},
 		{downloader.FastSync, false, false, false, false, false},
-		{downloader.LightSync, false, false, false, false, false},
 
 		// If checkpointing is enabled locally and remote response is empty, only drop during fast sync
 		{downloader.FullSync, true, false, true, false, false},
 		{downloader.FastSync, true, false, true, false, true}, // Special case, fast sync, unsynced peer
-		{downloader.LightSync, true, false, true, false, false},
 
 		// If checkpointing is enabled locally and remote response mismatches, always drop
 		{downloader.FullSync, true, false, false, false, true},
 		{downloader.FastSync, true, false, false, false, true},
-		{downloader.LightSync, true, false, false, false, true},
 
 		// If checkpointing is enabled locally and remote response matches, never drop
 		{downloader.FullSync, true, false, false, true, false},
 		{downloader.FastSync, true, false, false, true, false},
-		{downloader.LightSync, true, false, false, true, false},
 
 		// If checkpointing is enabled locally and remote times out, always drop
 		{downloader.FullSync, true, true, false, true, true},
 		{downloader.FastSync, true, true, false, true, true},
-		{downloader.LightSync, true, true, false, true, true},
 	}
 	for _, tt := range tests {
 		t.Run(fmt.Sprintf("sync %v checkpoint %v timeout %v empty %v match %v", tt.syncmode, tt.checkpoint, tt.timeout, tt.empty, tt.match), func(t *testing.T) {

--- a/eth/sync.go
+++ b/eth/sync.go
@@ -179,14 +179,6 @@ func (pm *ProtocolManager) synchronise(peer *peer) {
 	if atomic.LoadUint32(&pm.fastSync) == 1 {
 		// Fast sync was explicitly requested, and explicitly granted
 		mode = downloader.FastSync
-	} else if currentBlock.NumberU64() == 0 && pm.blockchain.CurrentFastBlock().NumberU64() > 0 {
-		// The database seems empty as the current block is the genesis. Yet the fast
-		// block is ahead, so fast sync was enabled for this node at a certain point.
-		// The only scenario where this can happen is if the user manually (or via a
-		// bad block) rolled back a fast sync node below the sync point. In this case
-		// however it's safe to reenable fast sync.
-		atomic.StoreUint32(&pm.fastSync, 1)
-		mode = downloader.FastSync
 	}
 	if mode == downloader.FastSync {
 		// Make sure the peer's total difficulty we are synchronizing is higher.


### PR DESCRIPTION
This PR fixes a fast sync panic under this scenario:

The user previously synced the data via fast sync, but the fast sync was not completed.
Later the user tries to sync the data again with **full sync**. In this case, geth will convert the 
sync mode to **fast sync** quietly while the `syncBloom` is not initialized.