### PR TITLE
core: fix fast head updating logic

### DIFF
--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -930,6 +930,8 @@ func (bc *BlockChain) truncateAncient(head uint64) error {
 // InsertReceiptChain attempts to complete an already existing header chain with
 // transaction and receipt data.
 func (bc *BlockChain) InsertReceiptChain(blockChain types.Blocks, receiptChain []types.Receipts, ancientLimit uint64) (int, error) {
+	// We don't require the chainMu here since we want to maximize the
+	// concurrency of header insertion and receipt insertion.
 	bc.wg.Add(1)
 	defer bc.wg.Done()
 
@@ -962,19 +964,21 @@ func (bc *BlockChain) InsertReceiptChain(blockChain types.Blocks, receiptChain [
 	// updateHead updates the head fast sync block if the inserted blocks are better
 	// and returns a indicator whether the inserted blocks are canonical.
 	updateHead := func(head *types.Block) bool {
-		var isCanonical bool
 		bc.chainmu.Lock()
-		if td := bc.GetTd(head.Hash(), head.NumberU64()); td != nil { // Rewind may have occurred, skip in that case
-			currentFastBlock := bc.CurrentFastBlock()
+
+		// Rewind may have occurred, skip in that case.
+		if bc.CurrentHeader().Number.Cmp(head.Number()) >= 0 {
+			currentFastBlock, td := bc.CurrentFastBlock(), bc.GetTd(head.Hash(), head.NumberU64())
 			if bc.GetTd(currentFastBlock.Hash(), currentFastBlock.NumberU64()).Cmp(td) < 0 {
 				rawdb.WriteHeadFastBlockHash(bc.db, head.Hash())
 				bc.currentFastBlock.Store(head)
 				headFastBlockGauge.Update(int64(head.NumberU64()))
-				isCanonical = true
+				bc.chainmu.Unlock()
+				return true
 			}
 		}
 		bc.chainmu.Unlock()
-		return isCanonical
+		return false
 	}
 	// writeAncient writes blockchain and corresponding receipt chain into ancient store.
 	//


### PR DESCRIPTION
This PR fixes a panic in current fast sync.

The fixed scenario is:

* 1. Node is inserting some ancient receipts(e.g. 100->120) and wait for the `chainMu`
* 2. At the same time, `Rollback` happens which reverts all inserted ancient data(e.g. 120->90)
* 3. Step(1) obtains the `chainMu` and set the fast head as 120. 

Next time fast sync happens, the `td` relative with height 120 is missing. Panic happens.

For more information, check the panic log:

https://gist.github.com/rjl493456442/a0c905cf575e9e74afbdab7a7ac9b8ae

TODO:
Not sure how much performance hit it will introduce. Later we should try to reduce the granularity of lock. Instead of having a global lock `chainMu` in `blockchain`, we need maintain more locks to guarantee better concurrency