### PR TITLE
cmd/clef, signer: refresh tutorial, fix noticed issues

### DIFF
--- a/cmd/clef/README.md
+++ b/cmd/clef/README.md
@@ -1,26 +1,21 @@
-Clef
-----
-Clef can be used to sign transactions and data and is meant as a replacement for geth's account management.
-This allows DApps not to depend on geth's account management. When a DApp wants to sign data it can send the data to
-the signer, the signer will then provide the user with context and asks the user for permission to sign the data. If
-the users grants the signing request the signer will send the signature back to the DApp.
-  
-This setup allows a DApp to connect to a remote Ethereum node and send transactions that are locally signed. This can
-help in situations when a DApp is connected to a remote node because a local Ethereum node is not available, not
-synchronised with the chain or a particular Ethereum node that has no built-in (or limited) account management.
-  
-Clef can run as a daemon on the same machine, or off a usb-stick like [usb armory](https://inversepath.com/usbarmory),
-or a separate VM in a [QubesOS](https://www.qubes-os.org/) type os setup.
+# Clef
 
-Check out 
+Clef can be used to sign transactions and data and is meant as a(n eventual) replacement for Geth's account management. This allows DApps to not depend on Geth's account management. When a DApp wants to sign data (or a transaction), it can send the content to Clef, which will then provide the user with context and asks for permission to sign the content. If the users grants the signing request, Clef will send the signature back to the DApp.
 
-* the [tutorial](tutorial.md) for some concrete examples on how the signer works.
-* the [setup docs](docs/setup.md) for some information on how to configure it to work on QubesOS or USBArmory. 
-* the [data types](datatypes.md) for detailed information on the json types used in the communication between
-  clef and an external UI 
+This setup allows a DApp to connect to a remote Ethereum node and send transactions that are locally signed. This can help in situations when a DApp is connected to an untrusted remote Ethereum node, because a local one is not available, not synchronised with the chain, or is a node that has no built-in (or limited) account management.
+
+Clef can run as a daemon on the same machine, off a usb-stick like [USB armory](https://inversepath.com/usbarmory), or even a separate VM in a [QubesOS](https://www.qubes-os.org/) type setup.
+
+Check out the
+
+* [CLI tutorial](tutorial.md) for some concrete examples on how Clef works.
+* [Setup docs](docs/setup.md) for infos on how to configure Clef on QubesOS or USB Armory.
+* [Data types](datatypes.md) for details on the communication messages between Clef and an external UI.
 
 ## Command line flags
+
 Clef accepts the following command line options:
+
 ```
 COMMANDS:
    init    Initialize the signer, generate secret storage
@@ -28,7 +23,7 @@ COMMANDS:
    setpw   Store a credential for a keystore file
    gendoc  Generate documentation about json-rpc format
    help    Shows a list of commands or help for one command
-   
+
 GLOBAL OPTIONS:
    --loglevel value        log level to emit to the screen (default: 4)
    --keystore value        Directory for the keystore (default: "$HOME/.ethereum/keystore")
@@ -36,6 +31,7 @@ GLOBAL OPTIONS:
    --chainid value         Chain id to use for signing (1=mainnet, 3=ropsten, 4=rinkeby, 5=Goerli) (default: 1)
    --lightkdf              Reduce key-derivation RAM & CPU usage at some expense of KDF strength
    --nousb                 Disables monitoring for and managing USB hardware wallets
+   --pcscdpath value       Path to the smartcard daemon (pcscd) socket file (default: "/run/pcscd/pcscd.comm")
    --rpcaddr value         HTTP-RPC server listening interface (default: "localhost")
    --rpcvhosts value       Comma separated list of virtual hostnames from which to accept requests (server enforced). Accepts '*' wildcard. (default: "localhost")
    --ipcdisable            Disable the IPC-RPC server
@@ -43,24 +39,21 @@ GLOBAL OPTIONS:
    --rpc                   Enable the HTTP-RPC server
    --rpcport value         HTTP-RPC server listening port (default: 8550)
    --signersecret value    A file containing the (encrypted) master seed to encrypt Clef data, e.g. keystore credentials and ruleset hash
-   --4bytedb value         File containing 4byte-identifiers (default: "./4byte.json")
    --4bytedb-custom value  File used for writing new 4byte-identifiers submitted via API (default: "./4byte-custom.json")
    --auditlog value        File used to emit audit logs. Set to "" to disable (default: "audit.log")
-   --rules value           Enable rule-engine (default: "rules.json")
+   --rules value           Enable rule-engine
    --stdio-ui              Use STDIN/STDOUT as a channel for an external UI. This means that an STDIN/STDOUT is used for RPC-communication with a e.g. a graphical user interface, and can be used when Clef is started by an external process.
    --stdio-ui-test         Mechanism to test interface between Clef and UI. Requires 'stdio-ui'.
    --advanced              If enabled, issues warnings instead of rejections for suspicious requests. Default off
    --help, -h              show help
    --version, -v           print the version
-   
 ```
-
 
 Example:
-```
-signer -keystore /my/keystore -chainid 4
-```
 
+```
+clef -keystore /my/keystore -chainid 4
+```
 
 ## Security model
 
@@ -187,7 +180,7 @@ None
 #### Result
   - address [string]: account address that is derived from the generated key
   - url [string]: location of the keyfile
-  
+
 #### Sample call
 ```json
 {
@@ -221,9 +214,9 @@ None
 #### Result
   - array with account records:
      - account.address [string]: account address that is derived from the generated key
-     - account.type [string]: type of the 
+     - account.type [string]: type of the
      - account.url [string]: location of the account
-  
+
 #### Sample call
 ```json
 {
@@ -272,7 +265,7 @@ Response
 
 #### Result
   - signed transaction in RLP encoded form [data]
-  
+
 #### Sample call
 ```json
 {
@@ -372,7 +365,7 @@ Bash example:
 
 #### Result
   - calculated signature [data]
-  
+
 #### Sample call
 ```json
 {
@@ -407,7 +400,7 @@ Response
 
 #### Result
   - calculated signature [data]
-  
+
 #### Sample call
 ```json
 {
@@ -505,7 +498,7 @@ Derive the address from the account that was used to sign data with content type
 
 #### Result
   - derived account [address]
-  
+
 #### Sample call
 ```json
 {
@@ -534,16 +527,16 @@ Response
 #### Import account
    Import a private key into the keystore. The imported key is expected to be encrypted according to the web3 keystore
    format.
-   
+
 #### Arguments
-  - account [object]: key in [web3 keystore format](https://github.com/ethereum/wiki/wiki/Web3-Secret-Storage-Definition) (retrieved with account_export) 
+  - account [object]: key in [web3 keystore format](https://github.com/ethereum/wiki/wiki/Web3-Secret-Storage-Definition) (retrieved with account_export)
 
 #### Result
   - imported key [object]:
      - key.address [address]: address of the imported key
      - key.type [string]: type of the account
      - key.url [string]: key URL
-  
+
 #### Sample call
 ```json
 {
@@ -594,14 +587,14 @@ Response
 #### Export account from keystore
    Export a private key from the keystore. The exported private key is encrypted with the original passphrase. When the
    key is imported later this passphrase is required.
-   
+
 #### Arguments
   - account [address]: export private key that is associated with this account
 
 #### Result
   - exported key, see [web3 keystore format](https://github.com/ethereum/wiki/wiki/Web3-Secret-Storage-Definition) for
   more information
-  
+
 #### Sample call
 ```json
 {
@@ -953,9 +946,9 @@ A UI should conform to the following rules.
 along with the UI.
 
 
-### UI Implementations 
+### UI Implementations
 
-There are a couple of implementation for a UI. We'll try to keep this list up to date. 
+There are a couple of implementation for a UI. We'll try to keep this list up to date.
 
 | Name | Repo | UI type| No external resources| Blocky support| Verifies permissions | Hash information | No secondary storage | Statically linked| Can modify parameters|
 | ---- | ---- | -------| ---- | ---- | ---- |---- | ---- | ---- | ---- |

--- a/cmd/clef/datatypes.md
+++ b/cmd/clef/datatypes.md
@@ -11,7 +11,7 @@ Example:
   "content_type": "text/plain",
   "address": "0xDEADbEeF000000000000000000000000DeaDbeEf",
   "raw_data": "GUV0aGVyZXVtIFNpZ25lZCBNZXNzYWdlOgoxMWhlbGxvIHdvcmxk",
-  "message": [
+  "messages": [
     {
       "name": "message",
       "value": "\u0019Ethereum Signed Message:\n11hello world",
@@ -133,7 +133,7 @@ This occurs _after_ successful completion of the entire signing procedure, but r
 
 A ruleset that implements a rate limitation needs to know what transactions are sent out to the external interface. By hooking into this methods, the ruleset can maintain track of that count.
 
-**OBS:** Note that if an attacker can restore your `clef` data to a previous point in time (e.g through a backup), the attacker can reset such windows, even if he/she is unable to decrypt the content. 
+**OBS:** Note that if an attacker can restore your `clef` data to a previous point in time (e.g through a backup), the attacker can reset such windows, even if he/she is unable to decrypt the content.
 
 The `OnApproved` method cannot be responded to, it's purely informative
 
@@ -179,7 +179,7 @@ Example:
 ```
 ### ListRequest
 
-Sent when a request has been made to list addresses. The UI is provided with the full `account`s, including local directory names. Note: this information is not passed back to the external caller, who only sees the `address`es. 
+Sent when a request has been made to list addresses. The UI is provided with the full `account`s, including local directory names. Note: this information is not passed back to the external caller, who only sees the `address`es.
 
 Example:
 ```json

--- a/cmd/clef/extapi_changelog.md
+++ b/cmd/clef/extapi_changelog.md
@@ -1,4 +1,15 @@
-### Changelog for external API
+## Changelog for external API
+
+The API uses [semantic versioning](https://semver.org/).
+
+TL;DR: Given a version number MAJOR.MINOR.PATCH, increment the:
+
+* MAJOR version when you make incompatible API changes,
+* MINOR version when you add functionality in a backwards-compatible manner, and
+* PATCH version when you make backwards-compatible bug fixes.
+
+Additional labels for pre-release and build metadata are available as extensions to the MAJOR.MINOR.PATCH format.
+
 
 ### 6.0.0
 
@@ -14,15 +25,15 @@ The addition of `contentType` makes it possible to use the method for different 
   * signing clique headers,
   * signing plain personal messages,
 * The external method `account_signTypedData` implements [EIP-712](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-712.md) and makes it possible to sign typed data.
-  
+
 #### 4.0.0
 
-* The external `account_Ecrecover`-method was removed. 
+* The external `account_Ecrecover`-method was removed.
 * The external `account_Import`-method was removed.
 
 #### 3.0.0
 
-* The external `account_List`-method was changed to not expose `url`, which contained info about the local filesystem. It now returns only a list of addresses. 
+* The external `account_List`-method was changed to not expose `url`, which contained info about the local filesystem. It now returns only a list of addresses.
 
 #### 2.0.0
 
@@ -33,15 +44,3 @@ makes the `accounts_signTransaction` identical to the old `eth_signTransaction`.
 #### 1.0.0
 
 Initial release.
-
-### Versioning
-
-The API uses [semantic versioning](https://semver.org/).
-
-TLDR; Given a version number MAJOR.MINOR.PATCH, increment the:
-
-* MAJOR version when you make incompatible API changes,
-* MINOR version when you add functionality in a backwards-compatible manner, and
-* PATCH version when you make backwards-compatible bug fixes.
-
-Additional labels for pre-release and build metadata are available as extensions to the MAJOR.MINOR.PATCH format.

--- a/cmd/clef/intapi_changelog.md
+++ b/cmd/clef/intapi_changelog.md
@@ -1,24 +1,38 @@
-### Changelog for internal API (ui-api)
+## Changelog for internal API (ui-api)
 
-### 6.0.0 
+The API uses [semantic versioning](https://semver.org/).
 
-Removed `password` from responses to operations which require them. This is for two reasons, 
+TL;DR: Given a version number MAJOR.MINOR.PATCH, increment the:
 
-- Consistency between how rulesets operate and how manual processing works. A rule can `Approve` but require the actual password to be stored in the clef storage. 
-With this change, the same stored password can be used even if rulesets are not enabled, but storage is. 
-- It also removes the usability-shortcut that a UI might otherwise want to implement; remembering passwords. Since we now will not require the 
-password on every `Approve`, there's no need for the UI to cache it locally. 
-  - In a future update, we'll likely add `clef_storePassword` to the internal API, so the user can store it via his UI (currently only CLI works). 
+* MAJOR version when you make incompatible API changes,
+* MINOR version when you add functionality in a backwards-compatible manner, and
+* PATCH version when you make backwards-compatible bug fixes.
+
+Additional labels for pre-release and build metadata are available as extensions to the MAJOR.MINOR.PATCH format.
+
+### 7.0.0
+
+- The `message` field was renamed to `messages` in all data signing request methods to better reflect that it's a list, not a value.
+
+### 6.0.0
+
+Removed `password` from responses to operations which require them. This is for two reasons,
+
+- Consistency between how rulesets operate and how manual processing works. A rule can `Approve` but require the actual password to be stored in the clef storage.
+With this change, the same stored password can be used even if rulesets are not enabled, but storage is.
+- It also removes the usability-shortcut that a UI might otherwise want to implement; remembering passwords. Since we now will not require the
+password on every `Approve`, there's no need for the UI to cache it locally.
+  - In a future update, we'll likely add `clef_storePassword` to the internal API, so the user can store it via his UI (currently only CLI works).
 
 Affected datatypes:
 - `SignTxResponse`
 - `SignDataResponse`
 - `NewAccountResponse`
 
-If `clef` requires a password, the `OnInputRequired` will be used to collect it. 
+If `clef` requires a password, the `OnInputRequired` will be used to collect it.
 
 
-### 5.0.0 
+### 5.0.0
 
 Changed the namespace format to adhere to the legacy ethereum format: `name_methodName`. Changes:
 
@@ -38,7 +52,7 @@ Changed the namespace format to adhere to the legacy ethereum format: `name_meth
 ### 4.0.0
 
 * Bidirectional communication implemented, so the UI can query `clef` via the stdin/stdout RPC channel. Methods implemented are:
-  - `clef_listWallets` 
+  - `clef_listWallets`
   - `clef_listAccounts`
   - `clef_listWallets`
   - `clef_deriveAccount`
@@ -48,10 +62,10 @@ Changed the namespace format to adhere to the legacy ethereum format: `name_meth
   - `clef_setChainId`
   - `clef_export`
   - `clef_import`
- 
-* The type `Account` was modified (the json-field `type` was removed), to consist of 
 
-```golang
+* The type `Account` was modified (the json-field `type` was removed), to consist of
+
+```go
 type Account struct {
 	Address common.Address `json:"address"` // Ethereum account address derived from the key
 	URL     URL            `json:"url"`     // Optional resource locator within a backend
@@ -64,7 +78,7 @@ type Account struct {
 * Make `ShowError`, `OnApprovedTx`, `OnSignerStartup` be json-rpc [notifications](https://www.jsonrpc.org/specification#notification):
 
 > A Notification is a Request object without an "id" member. A Request object that is a Notification signifies the Client's lack of interest in the corresponding Response object, and as such no Response object needs to be returned to the client. The Server MUST NOT reply to a Notification, including those that are within a batch request.
-> 
+>
 >  Notifications are not confirmable by definition, since they do not have a Response object to be returned. As such, the Client would not be aware of any errors (like e.g. "Invalid params","Internal error"
 ### 3.1.0
 
@@ -79,15 +93,17 @@ type Account struct {
 * Add `OnInputRequired(info UserInputRequest)` to internal API. This method is used when Clef needs user input, e.g. passwords.
 
 The following structures are used:
-```golang
-       UserInputRequest struct {
-               Prompt     string `json:"prompt"`
-               Title      string `json:"title"`
-               IsPassword bool   `json:"isPassword"`
-       }
-       UserInputResponse struct {
-               Text string `json:"text"`
-       }
+
+```go
+UserInputRequest struct {
+	Prompt     string `json:"prompt"`
+	Title      string `json:"title"`
+	IsPassword bool   `json:"isPassword"`
+}
+UserInputResponse struct {
+	Text string `json:"text"`
+}
+```
 
 ### 2.0.0
 
@@ -161,15 +177,3 @@ Example call:
 #### 1.0.0
 
 Initial release.
-
-### Versioning
-
-The API uses [semantic versioning](https://semver.org/).
-
-TLDR; Given a version number MAJOR.MINOR.PATCH, increment the:
-
-* MAJOR version when you make incompatible API changes,
-* MINOR version when you add functionality in a backwards-compatible manner, and
-* PATCH version when you make backwards-compatible bug fixes.
-
-Additional labels for pre-release and build metadata are available as extensions to the MAJOR.MINOR.PATCH format.

--- a/cmd/clef/intapi_changelog.md
+++ b/cmd/clef/intapi_changelog.md
@@ -13,6 +13,7 @@ Additional labels for pre-release and build metadata are available as extensions
 ### 7.0.0
 
 - The `message` field was renamed to `messages` in all data signing request methods to better reflect that it's a list, not a value.
+- The `storage.Put` and `storage.Get` methods in the rule execution engine were lower-cased to `storage.put` and `storage.get` to be consistent with JavaScript call conventions.
 
 ### 6.0.0
 

--- a/cmd/clef/main.go
+++ b/cmd/clef/main.go
@@ -172,8 +172,7 @@ Clef that the file is 'safe' to execute.`,
 			signerSecretFlag,
 		},
 		Description: `
-The setpw command stores a password for a given address (keyfile). If you enter a blank passphrase, it will
-remove any stored credential for that address (keyfile)
+The setpw command stores a password for a given address (keyfile).
 `}
 	gendocCommand = cli.Command{
 		Action: GenDoc,
@@ -221,11 +220,20 @@ func main() {
 }
 
 func initializeSecrets(c *cli.Context) error {
+	// Get past the legal message
 	if err := initialize(c); err != nil {
 		return err
 	}
+	// Ensure the master key does not yet exist, we're not willing to overwrite
 	configDir := c.GlobalString(configdirFlag.Name)
-
+	if err := os.Mkdir(configDir, 0700); err != nil && !os.IsExist(err) {
+		return err
+	}
+	location := filepath.Join(configDir, "masterseed.json")
+	if _, err := os.Stat(location); err == nil {
+		return fmt.Errorf("master key %v already exists, will not overwrite", location)
+	}
+	// Key file does not exist yet, generate a new one and encrypt it
 	masterSeed := make([]byte, 256)
 	num, err := io.ReadFull(rand.Reader, masterSeed)
 	if err != nil {
@@ -234,18 +242,18 @@ func initializeSecrets(c *cli.Context) error {
 	if num != len(masterSeed) {
 		return fmt.Errorf("failed to read enough random")
 	}
-
 	n, p := keystore.StandardScryptN, keystore.StandardScryptP
 	if c.GlobalBool(utils.LightKDFFlag.Name) {
 		n, p = keystore.LightScryptN, keystore.LightScryptP
 	}
-	text := "The master seed of clef is locked with a password. Please give a password. Do not forget this password."
+	text := "The master seed of clef will be locked with a password.\nPlease specify a password. Do not forget this password!"
 	var password string
 	for {
 		password = getPassPhrase(text, true)
 		if err := core.ValidatePasswordFormat(password); err != nil {
 			fmt.Printf("invalid password: %v\n", err)
 		} else {
+			fmt.Println()
 			break
 		}
 	}
@@ -253,28 +261,27 @@ func initializeSecrets(c *cli.Context) error {
 	if err != nil {
 		return fmt.Errorf("failed to encrypt master seed: %v", err)
 	}
-
-	err = os.Mkdir(configDir, 0700)
-	if err != nil && !os.IsExist(err) {
+	// Double check the master key path to ensure nothing wrote there in between
+	if err = os.Mkdir(configDir, 0700); err != nil && !os.IsExist(err) {
 		return err
 	}
-	location := filepath.Join(configDir, "masterseed.json")
 	if _, err := os.Stat(location); err == nil {
-		return fmt.Errorf("file %v already exists, will not overwrite", location)
+		return fmt.Errorf("master key %v already exists, will not overwrite", location)
 	}
-	err = ioutil.WriteFile(location, cipherSeed, 0400)
-	if err != nil {
+	// Write the file and print the usual warning message
+	if err = ioutil.WriteFile(location, cipherSeed, 0400); err != nil {
 		return err
 	}
 	fmt.Printf("A master seed has been generated into %s\n", location)
 	fmt.Printf(`
-This is required to be able to store credentials, such as :
+This is required to be able to store credentials, such as:
 * Passwords for keystores (used by rule engine)
-* Storage for javascript rules
-* Hash of rule-file
+* Storage for JavaScript auto-signing rules
+* Hash of JavaScript rule-file
 
-You should treat that file with utmost secrecy, and make a backup of it.
-NOTE: This file does not contain your accounts. Those need to be backed up separately!
+You should treat 'masterseed.json' with utmost secrecy and make a backup of it!
+* The password is necessary but not enough, you need to back up the master seed too!
+* The master seed does not contain your accounts, those need to be backed up separately!
 
 `)
 	return nil
@@ -305,14 +312,19 @@ func attestFile(ctx *cli.Context) error {
 
 func setCredential(ctx *cli.Context) error {
 	if len(ctx.Args()) < 1 {
-		utils.Fatalf("This command requires an address to be passed as an argument.")
+		utils.Fatalf("This command requires an address to be passed as an argument")
 	}
 	if err := initialize(ctx); err != nil {
 		return err
 	}
 
-	address := ctx.Args().First()
-	password := getPassPhrase("Enter a passphrase to store with this address.", true)
+	addr := ctx.Args().First()
+	if !common.IsHexAddress(addr) {
+		utils.Fatalf("Invalid address specified: %s", addr)
+	}
+	address := common.HexToAddress(addr)
+	password := getPassPhrase("Please enter a passphrase to store for this address:", true)
+	fmt.Println()
 
 	stretchedKey, err := readMasterKey(ctx, nil)
 	if err != nil {
@@ -324,7 +336,7 @@ func setCredential(ctx *cli.Context) error {
 
 	// Initialize the encrypted storages
 	pwStorage := storage.NewAESEncryptedStorage(filepath.Join(vaultLocation, "credentials.json"), pwkey)
-	pwStorage.Put(address, password)
+	pwStorage.Put(address.Hex(), password)
 	log.Info("Credential store updated", "key", address)
 	return nil
 }
@@ -340,8 +352,8 @@ func initialize(c *cli.Context) error {
 		if !confirm(legalWarning) {
 			return fmt.Errorf("aborted by user")
 		}
+		fmt.Println()
 	}
-
 	log.Root().SetHandler(log.LvlFilterHandler(log.Lvl(c.Int(logLevelFlag.Name)), log.StreamHandler(logOutput, log.TerminalFormat(true))))
 	return nil
 }
@@ -376,7 +388,7 @@ func signer(c *cli.Context) error {
 
 	configDir := c.GlobalString(configdirFlag.Name)
 	if stretchedKey, err := readMasterKey(c, ui); err != nil {
-		log.Info("No master seed provided, rules disabled", "error", err)
+		log.Warn("Failed to open master, rules disabled", "err", err)
 	} else {
 		vaultLocation := filepath.Join(configDir, common.Bytes2Hex(crypto.Keccak256([]byte("vault"), stretchedKey)[:10]))
 
@@ -390,17 +402,17 @@ func signer(c *cli.Context) error {
 		jsStorage := storage.NewAESEncryptedStorage(filepath.Join(vaultLocation, "jsstorage.json"), jskey)
 		configStorage := storage.NewAESEncryptedStorage(filepath.Join(vaultLocation, "config.json"), confkey)
 
-		//Do we have a rule-file?
+		// Do we have a rule-file?
 		if ruleFile := c.GlobalString(ruleFlag.Name); ruleFile != "" {
-			ruleJS, err := ioutil.ReadFile(c.GlobalString(ruleFile))
+			ruleJS, err := ioutil.ReadFile(ruleFile)
 			if err != nil {
-				log.Info("Could not load rulefile, rules not enabled", "file", "rulefile")
+				log.Warn("Could not load rules, disabling", "file", ruleFile, "err", err)
 			} else {
 				shasum := sha256.Sum256(ruleJS)
 				foundShaSum := hex.EncodeToString(shasum[:])
-				storedShasum := configStorage.Get("ruleset_sha256")
+				storedShasum, _ := configStorage.Get("ruleset_sha256")
 				if storedShasum != foundShaSum {
-					log.Info("Could not validate ruleset hash, rules not enabled", "got", foundShaSum, "expected", storedShasum)
+					log.Warn("Rule hash not attested, disabling", "hash", foundShaSum, "attested", storedShasum)
 				} else {
 					// Initialize rules
 					ruleEngine, err := rules.NewRuleEvaluator(ui, jsStorage)
@@ -452,7 +464,6 @@ func signer(c *cli.Context) error {
 			Version:   "1.0"},
 	}
 	if c.GlobalBool(utils.RPCEnabledFlag.Name) {
-
 		vhosts := splitAndTrim(c.GlobalString(utils.RPCVirtualHostsFlag.Name))
 		cors := splitAndTrim(c.GlobalString(utils.RPCCORSDomainFlag.Name))
 
@@ -469,7 +480,6 @@ func signer(c *cli.Context) error {
 			listener.Close()
 			log.Info("HTTP endpoint closed", "url", httpEndpoint)
 		}()
-
 	}
 	if !c.GlobalBool(utils.IPCDisabledFlag.Name) {
 		if c.IsSet(utils.IPCPathFlag.Name) {
@@ -496,8 +506,8 @@ func signer(c *cli.Context) error {
 	}
 	ui.OnSignerStartup(core.StartupInfo{
 		Info: map[string]interface{}{
-			"extapi_version": core.ExternalAPIVersion,
 			"intapi_version": core.InternalAPIVersion,
+			"extapi_version": core.ExternalAPIVersion,
 			"extapi_http":    extapiURL,
 			"extapi_ipc":     ipcapiURL,
 		},
@@ -592,7 +602,6 @@ func readMasterKey(ctx *cli.Context, ui core.UIClientAPI) ([]byte, error) {
 	if len(masterSeed) < 256 {
 		return nil, fmt.Errorf("master seed of insufficient length, expected >255 bytes, got %d", len(masterSeed))
 	}
-
 	// Create vault location
 	vaultLocation := filepath.Join(configDir, common.Bytes2Hex(crypto.Keccak256([]byte("vault"), masterSeed)[:10]))
 	err = os.Mkdir(vaultLocation, 0700)
@@ -620,13 +629,12 @@ func checkFile(filename string) error {
 // confirm displays a text and asks for user confirmation
 func confirm(text string) bool {
 	fmt.Printf(text)
-	fmt.Printf("\nEnter 'ok' to proceed:\n>")
+	fmt.Printf("\nEnter 'ok' to proceed:\n> ")
 
 	text, err := bufio.NewReader(os.Stdin).ReadString('\n')
 	if err != nil {
 		log.Crit("Failed to read user input", "err", err)
 	}
-
 	if text := strings.TrimSpace(text); text == "ok" {
 		return true
 	}
@@ -642,7 +650,7 @@ func testExternalUI(api *core.SignerAPI) {
 
 	a := common.HexToAddress("0xdeadbeef000000000000000000000000deadbeef")
 	addErr := func(errStr string) {
-		log.Info("Test error", "error", errStr)
+		log.Info("Test error", "err", errStr)
 		errs = append(errs, errStr)
 	}
 
@@ -864,14 +872,14 @@ func GenDoc(ctx *cli.Context) {
 			"of the work in canonicalizing and making sense of the data, and it's up to the UI to present" +
 			"the user with the contents of the `message`"
 		sighash, msg := accounts.TextAndHash([]byte("hello world"))
-		message := []*core.NameValueType{{"message", msg, accounts.MimetypeTextPlain}}
+		messages := []*core.NameValueType{{"message", msg, accounts.MimetypeTextPlain}}
 
 		add("SignDataRequest", desc, &core.SignDataRequest{
 			Address:     common.NewMixedcaseAddress(a),
 			Meta:        meta,
 			ContentType: accounts.MimetypeTextPlain,
 			Rawdata:     []byte(msg),
-			Message:     message,
+			Messages:    messages,
 			Hash:        sighash})
 	}
 	{ // Sign plain text response
@@ -982,29 +990,3 @@ These data types are defined in the channel between clef and the UI`)
 		fmt.Println(elem)
 	}
 }
-
-/**
-//Create Account
-
-curl -H "Content-Type: application/json" -X POST --data '{"jsonrpc":"2.0","method":"account_new","params":["test"],"id":67}' localhost:8550
-
-// List accounts
-
-curl -i -H "Content-Type: application/json" -X POST --data '{"jsonrpc":"2.0","method":"account_list","params":[""],"id":67}' http://localhost:8550/
-
-// Make Transaction
-// safeSend(0x12)
-// 4401a6e40000000000000000000000000000000000000000000000000000000000000012
-
-// supplied abi
-curl -i -H "Content-Type: application/json" -X POST --data '{"jsonrpc":"2.0","method":"account_signTransaction","params":[{"from":"0x82A2A876D39022B3019932D30Cd9c97ad5616813","gas":"0x333","gasPrice":"0x123","nonce":"0x0","to":"0x07a565b7ed7d7a678680a4c162885bedbb695fe0", "value":"0x10", "data":"0x4401a6e40000000000000000000000000000000000000000000000000000000000000012"},"test"],"id":67}' http://localhost:8550/
-
-// Not supplied
-curl -i -H "Content-Type: application/json" -X POST --data '{"jsonrpc":"2.0","method":"account_signTransaction","params":[{"from":"0x82A2A876D39022B3019932D30Cd9c97ad5616813","gas":"0x333","gasPrice":"0x123","nonce":"0x0","to":"0x07a565b7ed7d7a678680a4c162885bedbb695fe0", "value":"0x10", "data":"0x4401a6e40000000000000000000000000000000000000000000000000000000000000012"}],"id":67}' http://localhost:8550/
-
-// Sign data
-
-curl -i -H "Content-Type: application/json" -X POST --data '{"jsonrpc":"2.0","method":"account_sign","params":["0x694267f14675d7e1b9494fd8d72fefe1755710fa","bazonk gaz baz"],"id":67}' http://localhost:8550/
-
-
-**/

--- a/cmd/clef/pythonsigner.py
+++ b/cmd/clef/pythonsigner.py
@@ -42,7 +42,6 @@ class PipeTransport(ServerTransport):
         self.output.write("\n")
 
 class StdIOHandler():
-
     def __init__(self):
         pass
 
@@ -76,7 +75,7 @@ class StdIOHandler():
         :param transaction: transaction info
         :param call_info: info abou the call, e.g. if ABI info could not be
         :param meta: metadata about the request, e.g. where the call comes from
-        :return: 
+        :return:
         """
         transaction = req.get('transaction')
         _from       = req.get('from')
@@ -158,8 +157,7 @@ class StdIOHandler():
         return
 
 def main(args):
-
-    cmd = ["./clef", "--stdio-ui"]
+    cmd = ["clef", "--stdio-ui"]
     if len(args) > 0 and args[0] == "test":
         cmd.extend(["--stdio-ui-test"])
     print("cmd: {}".format(" ".join(cmd)))

--- a/cmd/clef/tutorial.md
+++ b/cmd/clef/tutorial.md
@@ -1,200 +1,278 @@
-## Initializing the signer
+## Initializing Clef
 
-First, initialize the master seed.
+First thing's first, Clef needs to store some data itself. Since that data might be sensitive (passwords, signing rules, accounts), Clef's entire storage is encrypted. To support encrypting data, the first step is to initialize Clef with a random master seed, itself too encrypted with your chosen password:
 
 ```text
-#./signer init
+$ clef init
 
 WARNING!
 
-The signer is alpha software, and not yet publically released. This software has _not_ been audited, and there
-are no guarantees about the workings of this software. It may contain severe flaws. You should not use this software
-unless you agree to take full responsibility for doing so, and know what you are doing.
+Clef is an account management tool. It may, like any software, contain bugs.
 
-TLDR; THIS IS NOT PRODUCTION-READY SOFTWARE!
+Please take care to
+- backup your keystore files,
+- verify that the keystore(s) can be opened with your password.
 
+Clef is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+PURPOSE. See the GNU General Public License for more details.
 
 Enter 'ok' to proceed:
->ok
-A master seed has been generated into /home/martin/.signer/secrets.dat
+> ok
 
-This is required to be able to store credentials, such as :
+The master seed of clef will be locked with a password.
+Please specify a password. Do not forget this password!
+Passphrase:
+Repeat passphrase:
+
+A master seed has been generated into /home/martin/.clef/masterseed.json
+
+This is required to be able to store credentials, such as:
 * Passwords for keystores (used by rule engine)
-* Storage for javascript rules
-* Hash of rule-file
+* Storage for JavaScript auto-signing rules
+* Hash of JavaScript rule-file
 
-You should treat that file with utmost secrecy, and make a backup of it.
-NOTE: This file does not contain your accounts. Those need to be backed up separately!
+You should treat 'masterseed.json' with utmost secrecy and make a backup of it!
+* The password is necessary but not enough, you need to back up the master seed too!
+* The master seed does not contain your accounts, those need to be backed up separately!
 ```
 
-(for readability purposes, we'll remove the WARNING printout in the rest of this document)
+*For readability purposes, we'll remove the WARNING printout, user confirmation and the unlocking of the master seed in the rest of this document.*
 
-## Creating rules
+## Remote interactions
 
-Now, you can create a rule-file. Note that it is not mandatory to use predefined rules, but it's really handy.
+Clef is capable of managing both key-file based accounts as well as hardware wallets. To evaluate clef, we're going to point it to our Rinkeby testnet keystore and specify the Rinkeby chain ID for signing (Clef doesn't have a backing chain, so it doesn't know what network it runs on).
 
-```javascript
-function ApproveListing(){
+```text
+$ clef --keystore ~/.ethereum/rinkeby/keystore --chainid 4
+
+INFO [07-01|11:00:46.385] Starting signer                          chainid=4 keystore=$HOME/.ethereum/rinkeby/keystore light-kdf=false advanced=false
+DEBUG[07-01|11:00:46.389] FS scan times                            list=3.521941ms set=9.017µs diff=4.112µs
+DEBUG[07-01|11:00:46.391] Ledger support enabled
+DEBUG[07-01|11:00:46.391] Trezor support enabled via HID
+DEBUG[07-01|11:00:46.391] Trezor support enabled via WebUSB
+INFO [07-01|11:00:46.391] Audit logs configured                    file=audit.log
+DEBUG[07-01|11:00:46.392] IPC registered                           namespace=account
+INFO [07-01|11:00:46.392] IPC endpoint opened                      url=$HOME/.clef/clef.ipc
+------- Signer info -------
+* intapi_version : 7.0.0
+* extapi_version : 6.0.0
+* extapi_http : n/a
+* extapi_ipc : $HOME/.clef/clef.ipc
+```
+
+By default, Clef starts up in CLI (Command Line Interface) mode. Arbitrary remote processes may *request* account interactions (e.g. sign a transaction), which the user will need to individually *confirm*.
+
+To test this out, we can *request* Clef to list all account via its *External API endpoint*:
+
+```text
+echo '{"id": 1, "jsonrpc": "2.0", "method": "account_list"}' | nc -U ~/.clef/clef.ipc
+```
+
+This will prompt the user within the Clef CLI to confirm or deny the request:
+
+```text
+-------- List Account request--------------
+A request has been made to list all accounts.
+You can select which accounts the caller can see
+  [x] 0xD9C9Cd5f6779558b6e0eD4e6Acf6b1947E7fA1F3
+    URL: keystore://$HOME/.ethereum/rinkeby/keystore/UTC--2017-04-14T15-15-00.327614556Z--d9c9cd5f6779558b6e0ed4e6acf6b1947e7fa1f3
+  [x] 0x086278A6C067775F71d6B2BB1856Db6E28c30418
+    URL: keystore://$HOME/.ethereum/rinkeby/keystore/UTC--2018-02-06T22-53-11.211657239Z--086278a6c067775f71d6b2bb1856db6e28c30418
+-------------------------------------------
+Request context:
+	NA -> NA -> NA
+
+Additional HTTP header data, provided by the external caller:
+	User-Agent:
+	Origin:
+Approve? [y/N]:
+>
+```
+
+Depending on whether we approve or deny the request, the original NetCat process will get:
+
+```text
+{"jsonrpc":"2.0","id":1,"result":["0xd9c9cd5f6779558b6e0ed4e6acf6b1947e7fa1f3","0x086278a6c067775f71d6b2bb1856db6e28c30418"]}
+
+or
+
+{"jsonrpc":"2.0","id":1,"error":{"code":-32000,"message":"Request denied"}}
+```
+
+Apart from listing accounts, you can also *request* creating a new account; signing transactions and data; and recovering signatures. You can find the available methods in the Clef [External API Spec](https://github.com/ethereum/go-ethereum/tree/master/cmd/clef#external-api-1) and the [External API Changelog](https://github.com/ethereum/go-ethereum/blob/master/cmd/clef/extapi_changelog.md).
+
+*Note, the number of things you can do from the External API is deliberately small, since we want to limit the power of remote calls by as much as possible! Clef has an [Internal API](https://github.com/ethereum/go-ethereum/tree/master/cmd/clef#ui-api-1) too for the UI (User Interface) which is much richer and can support custom interfaces on top. But that's out of scope here.*
+
+## Automatic rules
+
+For most users, manually confirming every transaction is the way to go. However, there are cases when it makes sense to set up some rules which permit Clef to sign a transaction without prompting the user. One such example would be running a signer on Rinkeby or other PoA networks.
+
+For starters, we can create a rule file that automatically permits anyone to list our available accounts without user confirmation. The rule file is a tiny JavaScript snippet that you can program however you want:
+
+```js
+function ApproveListing() {
     return "Approve"
 }
 ```
 
-Get the `sha256` hash. If you have openssl, you can do `openssl sha256 rules.js`...
-```text
-#sha256sum rules.js
-6c21d1737429d6d4f2e55146da0797782f3c0a0355227f19d702df377c165d72  rules.js
-```
-...now `attest` the file...
-```text
-#./signer attest 6c21d1737429d6d4f2e55146da0797782f3c0a0355227f19d702df377c165d72
+Of course, Clef isn't going to just accept and run arbitrary scripts you give it, that would be dangerous if someone changes your rule file! Instead, you need to explicitly *attest* the rule file, which entails injecting its hash into Clef's secure store.
 
-INFO [02-21|12:14:38] Ruleset attestation updated              sha256=6c21d1737429d6d4f2e55146da0797782f3c0a0355227f19d702df377c165d72
-```
-
-...and (this is required only for non-production versions) load a mock-up `4byte.json` by copying the file from the source to your current working directory:
 ```text
-#cp $GOPATH/src/github.com/ethereum/go-ethereum/cmd/clef/4byte.json $PWD
+$ sha256sum rules.js
+645b58e4f945e24d0221714ff29f6aa8e860382ced43490529db1695f5fcc71c  rules.js
+
+$ clef attest 645b58e4f945e24d0221714ff29f6aa8e860382ced43490529db1695f5fcc71c
+Decrypt master seed of clef
+Passphrase:
+INFO [07-01|13:25:03.290] Ruleset attestation updated              sha256=645b58e4f945e24d0221714ff29f6aa8e860382ced43490529db1695f5fcc71c
 ```
 
-At this point, we can start the signer with the rule-file:
-```text
-#./signer --rules rules.js --rpc
+At this point, we can start Clef with the rule file:
 
-INFO [09-25|20:28:11.866] Using CLI as UI-channel 
-INFO [09-25|20:28:11.876] Loaded 4byte db                          signatures=5509 file=./4byte.json
-INFO [09-25|20:28:11.877] Rule engine configured                   file=./rules.js
-DEBUG[09-25|20:28:11.877] FS scan times                            list=100.781µs set=13.253µs diff=5.761µs
-DEBUG[09-25|20:28:11.884] Ledger support enabled 
-DEBUG[09-25|20:28:11.888] Trezor support enabled 
-INFO [09-25|20:28:11.888] Audit logs configured                    file=audit.log
-DEBUG[09-25|20:28:11.888] HTTP registered                          namespace=account
-INFO [09-25|20:28:11.890] HTTP endpoint opened                     url=http://localhost:8550
-DEBUG[09-25|20:28:11.890] IPC registered                           namespace=account
-INFO [09-25|20:28:11.890] IPC endpoint opened                      url=<nil>
+```text
+$ clef --keystore ~/.ethereum/rinkeby/keystore --chainid 4 --rules rules.js
+
+INFO [07-01|13:39:49.726] Rule engine configured                   file=rules.js
+INFO [07-01|13:39:49.726] Starting signer                          chainid=4 keystore=$HOME/.ethereum/rinkeby/keystore light-kdf=false advanced=false
+DEBUG[07-01|13:39:49.726] FS scan times                            list=35.15µs set=4.251µs diff=2.766µs
+DEBUG[07-01|13:39:49.727] Ledger support enabled
+DEBUG[07-01|13:39:49.727] Trezor support enabled via HID
+DEBUG[07-01|13:39:49.727] Trezor support enabled via WebUSB
+INFO [07-01|13:39:49.728] Audit logs configured                    file=audit.log
+DEBUG[07-01|13:39:49.728] IPC registered                           namespace=account
+INFO [07-01|13:39:49.728] IPC endpoint opened                      url=$HOME/.clef/clef.ipc
 ------- Signer info -------
-* extapi_version : 2.0.0
-* intapi_version : 2.0.0
-* extapi_http : http://localhost:8550
-* extapi_ipc : <nil>
+* intapi_version : 7.0.0
+* extapi_version : 6.0.0
+* extapi_http : n/a
+* extapi_ipc : $HOME/.clef/clef.ipc
 ```
 
-Any list-requests will now be auto-approved by our rule-file.
+Any account listing *request* will now be auto-approved by the rule file:
+
+```text
+$ echo '{"id": 1, "jsonrpc": "2.0", "method": "account_list"}' | nc -U ~/.clef/clef.ipc
+{"jsonrpc":"2.0","id":1,"result":["0xd9c9cd5f6779558b6e0ed4e6acf6b1947e7fa1f3","0x086278a6c067775f71d6b2bb1856db6e28c30418"]}
+```
 
 ## Under the hood
 
 While doing the operations above, these files have been created:
 
 ```text
-#ls -laR ~/.signer/
-/home/martin/.signer/:
-total 16
-drwx------  3 martin martin 4096 feb 21 12:14 .
-drwxr-xr-x 71 martin martin 4096 feb 21 12:12 ..
-drwx------  2 martin martin 4096 feb 21 12:14 43f73718397aa54d1b22
--rwx------  1 martin martin  256 feb 21 12:12 secrets.dat
+$ ls -laR ~/.clef/
 
-/home/martin/.signer/43f73718397aa54d1b22:
+$HOME/.clef/:
+total 24
+drwxr-x--x   3 user user  4096 Jul  1 13:45 .
+drwxr-xr-x 102 user user 12288 Jul  1 13:39 ..
+drwx------   2 user user  4096 Jul  1 13:25 02f90c0603f4f2f60188
+-r--------   1 user user   868 Jun 28 13:55 masterseed.json
+
+$HOME/.clef/02f90c0603f4f2f60188:
 total 12
-drwx------ 2 martin martin 4096 feb 21 12:14 .
-drwx------ 3 martin martin 4096 feb 21 12:14 ..
--rw------- 1 martin martin  159 feb 21 12:14 config.json
+drwx------ 2 user user 4096 Jul  1 13:25 .
+drwxr-x--x 3 user user 4096 Jul  1 13:45 ..
+-rw------- 1 user user  159 Jul  1 13:25 config.json
 
-#cat /home/martin/.signer/43f73718397aa54d1b22/config.json
-{"ruleset_sha256":{"iv":"6v4W4tfJxj3zZFbl","c":"6dt5RTDiTq93yh1qDEjpsat/tsKG7cb+vr3sza26IPL2fvsQ6ZoqFx++CPUa8yy6fD9Bbq41L01ehkKHTG3pOAeqTW6zc/+t0wv3AB6xPmU="}}
-
+$ cat ~/.clef/02f90c0603f4f2f60188/config.json
+{"ruleset_sha256":{"iv":"SWWEtnl+R+I+wfG7","c":"I3fjmwmamxVcfGax7D0MdUOL29/rBWcs73WBILmYK0o1CrX7wSMc3y37KsmtlZUAjp0oItYq01Ow8VGUOzilG91tDHInB5YHNtm/YkufEbo="}}
 ```
 
-In `~/.signer`, the `secrets.dat` file was created, containing the `master_seed`.
-The `master_seed` was then used to derive a few other things:
+In `$HOME/.clef`, the `masterseed.json` file was created, containing the master seed. This seed was then used to derive a few other things:
 
-- `vault_location` : in this case `43f73718397aa54d1b22` .
-   - Thus, if you use a different `master_seed`, another `vault_location` will be used that does not conflict with each other.
-   - Example: `signer --signersecret /path/to/afile ...`
-- `config.json` which is the encrypted key/value storage for configuration data, containing the key `ruleset_sha256`.
+- **Vault location**: in this case `02f90c0603f4f2f60188`.
+   - If you use a different master seed, a different vault location will be used that does not conflict with each other (e.g. `clef --signersecret /path/to/file`). This allows you to run multiple instances of Clef, each with its own rules (e.g. mainnet + testnet).
+- **`config.json`**: the encrypted key/value storage for configuration data, currently only containing the key `ruleset_sha256`, the attested hash of the automatic rules to use.
 
+## Advanced rules
 
-## Adding credentials
-
-In order to make more useful rules like signing transactions, the signer needs access to the passwords needed to unlock keystores.
+In order to make more useful rules - like signing transactions - the signer needs access to the passwords needed to unlock keys from the keystore. You can inject an unlock password via `clef setpw`.
 
 ```text
-#./signer addpw "0x694267f14675d7e1b9494fd8d72fefe1755710fa" "test_password"
+$ clef setpw 0xd9c9cd5f6779558b6e0ed4e6acf6b1947e7fa1f3
 
-INFO [02-21|13:43:21] Credential store updated                 key=0x694267f14675d7e1b9494fd8d72fefe1755710fa
+Please enter a passphrase to store for this address:
+Passphrase:
+Repeat passphrase:
+
+Decrypt master seed of clef
+Passphrase:
+INFO [07-01|14:05:56.031] Credential store updated                 key=0xd9c9cd5f6779558b6e0ed4e6acf6b1947e7fa1f3
 ```
-## More advanced rules
 
-Now let's update the rules to make use of credentials:
+Now let's update the rules to make use of the new credentials:
 
-```javascript
-function ApproveListing(){
+```js
+function ApproveListing() {
     return "Approve"
 }
-function ApproveSignData(r){
-    if( r.address.toLowerCase() == "0x694267f14675d7e1b9494fd8d72fefe1755710fa")
-    {
-        if(r.message.indexOf("bazonk") >= 0){
+
+function ApproveSignData(req) {
+    if (req.address.toLowerCase() == "0xd9c9cd5f6779558b6e0ed4e6acf6b1947e7fa1f3") {
+        if (req.messages[0].value.indexOf("bazonk") >= 0) {
             return "Approve"
         }
         return "Reject"
     }
     // Otherwise goes to manual processing
 }
-
 ```
+
 In this example:
-* Any requests to sign data with the account `0x694...` will be
-    * auto-approved if the message contains with `bazonk`
-    * auto-rejected if it does not.
-* Any other signing-requests will be passed along for manual approve/reject.
 
-_Note: make sure that `0x694...` is an account you have access to. You can create it either via the clef or the traditional account cli tool. If the latter was chosen, make sure both clef and geth use the same keystore by specifing `--keystore path/to/your/keystore` when running clef._
+- Any requests to sign data with the account `0xd9c9...` will be:
+    - Auto-approved if the message contains `bazonk`,
+    - Auto-rejected if the message does not contain `bazonk`,
+- Any other requests will be passed along for manual confirmation.
 
-Attest the new file...
+*Note, to make this example work, please use you own accounts. You can create a new account either via Clef or the traditional account CLI tools. If the latter was chosen, make sure both Clef and Geth use the same keystore by specifing `--keystore path/to/your/keystore` when running Clef.*
+
+Attest the new rule file so that Clef will accept loading it:
+
 ```text
-#sha256sum rules.js
-2a0cb661dacfc804b6e95d935d813fd17c0997a7170e4092ffbc34ca976acd9f  rules.js
+$ sha256sum rules.js
+f163a1738b649259bb9b369c593fdc4c6b6f86cc87e343c3ba58faee03c2a178  rules.js
 
-#./signer attest 2a0cb661dacfc804b6e95d935d813fd17c0997a7170e4092ffbc34ca976acd9f
-
-INFO [02-21|14:36:30] Ruleset attestation updated              sha256=2a0cb661dacfc804b6e95d935d813fd17c0997a7170e4092ffbc34ca976acd9f
+$ clef attest f163a1738b649259bb9b369c593fdc4c6b6f86cc87e343c3ba58faee03c2a178
+Decrypt master seed of clef
+Passphrase:
+INFO [07-01|14:11:28.509] Ruleset attestation updated              sha256=f163a1738b649259bb9b369c593fdc4c6b6f86cc87e343c3ba58faee03c2a178
 ```
 
-And start the signer:
+Restart Clef with the new rules in place:
 
 ```
-#./signer --rules rules.js --rpc
+$ clef --keystore ~/.ethereum/rinkeby/keystore --chainid 4 --rules rules.js
 
-INFO [09-25|21:02:16.450] Using CLI as UI-channel 
-INFO [09-25|21:02:16.466] Loaded 4byte db                          signatures=5509 file=./4byte.json
-INFO [09-25|21:02:16.467] Rule engine configured                   file=./rules.js
-DEBUG[09-25|21:02:16.468] FS scan times                            list=1.45262ms set=21.926µs diff=6.944µs
-DEBUG[09-25|21:02:16.473] Ledger support enabled 
-DEBUG[09-25|21:02:16.475] Trezor support enabled 
-INFO [09-25|21:02:16.476] Audit logs configured                    file=audit.log
-DEBUG[09-25|21:02:16.476] HTTP registered                          namespace=account
-INFO [09-25|21:02:16.478] HTTP endpoint opened                     url=http://localhost:8550
-DEBUG[09-25|21:02:16.478] IPC registered                           namespace=account
-INFO [09-25|21:02:16.478] IPC endpoint opened                      url=<nil>
+INFO [07-01|14:12:41.636] Rule engine configured                   file=rules.js
+INFO [07-01|14:12:41.636] Starting signer                          chainid=4 keystore=$HOME/.ethereum/rinkeby/keystore light-kdf=false advanced=false
+DEBUG[07-01|14:12:41.636] FS scan times                            list=46.722µs set=4.47µs diff=2.157µs
+DEBUG[07-01|14:12:41.637] Ledger support enabled
+DEBUG[07-01|14:12:41.637] Trezor support enabled via HID
+DEBUG[07-01|14:12:41.638] Trezor support enabled via WebUSB
+INFO [07-01|14:12:41.638] Audit logs configured                    file=audit.log
+DEBUG[07-01|14:12:41.638] IPC registered                           namespace=account
+INFO [07-01|14:12:41.638] IPC endpoint opened                      url=$HOME/.clef/clef.ipc
 ------- Signer info -------
-* extapi_version : 2.0.0
-* intapi_version : 2.0.0
-* extapi_http : http://localhost:8550
-* extapi_ipc : <nil>
+* intapi_version : 7.0.0
+* extapi_version : 6.0.0
+* extapi_http : n/a
+* extapi_ipc : $HOME/.clef/clef.ipc
 ```
 
-And then test signing, once with `bazonk` and once without:
+Then test signing, once with `bazonk` and once without:
 
 ```
-#curl -H "Content-Type: application/json" -X POST --data "{\"jsonrpc\":\"2.0\",\"method\":\"account_sign\",\"params\":[\"0x694267f14675d7e1b9494fd8d72fefe1755710fa\",\"0x$(xxd -pu <<< '  bazonk baz gaz')\"],\"id\":67}" http://localhost:8550/
-{"jsonrpc":"2.0","id":67,"result":"0x93e6161840c3ae1efc26dc68dedab6e8fc233bb3fefa1b4645dbf6609b93dace160572ea4ab33240256bb6d3dadb60dcd9c515d6374d3cf614ee897408d41d541c"}
+$ echo '{"id": 1, "jsonrpc":"2.0", "method":"account_signData", "params":["data/plain", "0xd9c9cd5f6779558b6e0ed4e6acf6b1947e7fa1f3", "0x202062617a6f6e6b2062617a2067617a0a"]}' | nc -U ~/.clef/clef.ipc
+{"jsonrpc":"2.0","id":1,"result":"0x4f93e3457027f6be99b06b3392d0ebc60615ba448bb7544687ef1248dea4f5317f789002df783979c417d969836b6fda3710f5bffb296b4d51c8aaae6e2ac4831c"}
 
-#curl -H "Content-Type: application/json" -X POST --data "{\"jsonrpc\":\"2.0\",\"method\":\"account_sign\",\"params\":[\"0x694267f14675d7e1b9494fd8d72fefe1755710fa\",\"0x$(xxd -pu <<< '  bonk baz gaz')\"],\"id\":67}" http://localhost:8550/
-{"jsonrpc":"2.0","id":67,"error":{"code":-32000,"message":"Request denied"}}
-
+$ echo '{"id": 1, "jsonrpc":"2.0", "method":"account_signData", "params":["data/plain", "0xd9c9cd5f6779558b6e0ed4e6acf6b1947e7fa1f3", "0x2020626f6e6b2062617a2067617a0a"]}' | nc -U ~/.clef/clef.ipc
+{"jsonrpc":"2.0","id":1,"error":{"code":-32000,"message":"Request denied"}}
 ```
 
-Meanwhile, in the signer output:
+Meanwhile, in the Clef output log you can see:
 ```text
 INFO [02-21|14:42:41] Op approved
 INFO [02-21|14:42:56] Op rejected
@@ -203,9 +281,11 @@ INFO [02-21|14:42:56] Op rejected
 The signer also stores all traffic over the external API in a log file. The last 4 lines shows the two requests and their responses:
 
 ```text
-#tail -n 4 audit.log
-t=2018-02-21T14:42:41+0100 lvl=info msg=Sign       api=signer type=request  metadata="{\"remote\":\"127.0.0.1:49706\",\"local\":\"localhost:8550\",\"scheme\":\"HTTP/1.1\"}" addr="0x694267f14675d7e1b9494fd8d72fefe1755710fa [chksum INVALID]" data=202062617a6f6e6b2062617a2067617a0a
-t=2018-02-21T14:42:42+0100 lvl=info msg=Sign       api=signer type=response data=93e6161840c3ae1efc26dc68dedab6e8fc233bb3fefa1b4645dbf6609b93dace160572ea4ab33240256bb6d3dadb60dcd9c515d6374d3cf614ee897408d41d541c error=nil
-t=2018-02-21T14:42:56+0100 lvl=info msg=Sign       api=signer type=request  metadata="{\"remote\":\"127.0.0.1:49708\",\"local\":\"localhost:8550\",\"scheme\":\"HTTP/1.1\"}" addr="0x694267f14675d7e1b9494fd8d72fefe1755710fa [chksum INVALID]" data=2020626f6e6b2062617a2067617a0a
-t=2018-02-21T14:42:56+0100 lvl=info msg=Sign       api=signer type=response data=                                                                                                                                   error="Request denied"
+$ tail -n 4 audit.log
+t=2019-07-01T15:52:14+0300 lvl=info msg=SignData   api=signer type=request  metadata="{\"remote\":\"NA\",\"local\":\"NA\",\"scheme\":\"NA\",\"User-Agent\":\"\",\"Origin\":\"\"}" addr="0xd9c9cd5f6779558b6e0ed4e6acf6b1947e7fa1f3 [chksum INVALID]" data=0x202062617a6f6e6b2062617a2067617a0a content-type=data/plain
+t=2019-07-01T15:52:14+0300 lvl=info msg=SignData   api=signer type=response data=4f93e3457027f6be99b06b3392d0ebc60615ba448bb7544687ef1248dea4f5317f789002df783979c417d969836b6fda3710f5bffb296b4d51c8aaae6e2ac4831c error=nil
+t=2019-07-01T15:52:23+0300 lvl=info msg=SignData   api=signer type=request  metadata="{\"remote\":\"NA\",\"local\":\"NA\",\"scheme\":\"NA\",\"User-Agent\":\"\",\"Origin\":\"\"}" addr="0xd9c9cd5f6779558b6e0ed4e6acf6b1947e7fa1f3 [chksum INVALID]" data=0x2020626f6e6b2062617a2067617a0a     content-type=data/plain
+t=2019-07-01T15:52:23+0300 lvl=info msg=SignData   api=signer type=response data=                                     error="Request denied"
 ```
+
+For more details on writing automatic rules, please see the [rules spec](https://github.com/ethereum/go-ethereum/blob/master/cmd/clef/rules.md).

--- a/signer/core/cliui.go
+++ b/signer/core/cliui.go
@@ -169,13 +169,12 @@ func (ui *CommandlineUI) ApproveSignData(request *SignDataRequest) (SignDataResp
 
 	fmt.Printf("-------- Sign data request--------------\n")
 	fmt.Printf("Account:  %s\n", request.Address.String())
-	fmt.Printf("message:\n")
-	for _, nvt := range request.Message {
+	fmt.Printf("messages:\n")
+	for _, nvt := range request.Messages {
 		fmt.Printf("%v\n", nvt.Pprint(1))
 	}
-	//fmt.Printf("message:  \n%v\n", request.Message)
 	fmt.Printf("raw data:  \n%q\n", request.Rawdata)
-	fmt.Printf("message hash:  %v\n", request.Hash)
+	fmt.Printf("data hash:  %v\n", request.Hash)
 	fmt.Printf("-------------------------------------------\n")
 	showMetadata(request.Meta)
 	if !ui.confirm() {
@@ -187,7 +186,6 @@ func (ui *CommandlineUI) ApproveSignData(request *SignDataRequest) (SignDataResp
 // ApproveListing prompt the user for confirmation to list accounts
 // the list of accounts to list can be modified by the UI
 func (ui *CommandlineUI) ApproveListing(request *ListRequest) (ListResponse, error) {
-
 	ui.mu.Lock()
 	defer ui.mu.Unlock()
 

--- a/signer/core/signed_data.go
+++ b/signer/core/signed_data.go
@@ -123,11 +123,10 @@ type TypedDataDomain struct {
 var typedDataReferenceTypeRegexp = regexp.MustCompile(`^[A-Z](\w*)(\[\])?$`)
 
 // sign receives a request and produces a signature
-
+//
 // Note, the produced signature conforms to the secp256k1 curve R, S and V values,
 // where the V value will be 27 or 28 for legacy reasons, if legacyV==true.
 func (api *SignerAPI) sign(addr common.MixedcaseAddress, req *SignDataRequest, legacyV bool) (hexutil.Bytes, error) {
-
 	// We make the request prior to looking up if we actually have the account, to prevent
 	// account-enumeration via the API
 	res, err := api.UI.ApproveSignData(req)
@@ -169,7 +168,6 @@ func (api *SignerAPI) SignData(ctx context.Context, contentType string, addr com
 	if err != nil {
 		return nil, err
 	}
-
 	signature, err := api.sign(addr, req, transformV)
 	if err != nil {
 		api.UI.ShowError(err.Error())
@@ -202,7 +200,7 @@ func (api *SignerAPI) determineSignatureFormat(ctx context.Context, contentType 
 			return nil, useEthereumV, err
 		}
 		sighash, msg := SignTextValidator(validatorData)
-		message := []*NameValueType{
+		messages := []*NameValueType{
 			{
 				Name:  "This is a request to sign data intended for a particular validator (see EIP 191 version 0)",
 				Typ:   "description",
@@ -224,7 +222,7 @@ func (api *SignerAPI) determineSignatureFormat(ctx context.Context, contentType 
 				Value: fmt.Sprintf("0x%x", msg),
 			},
 		}
-		req = &SignDataRequest{ContentType: mediaType, Rawdata: []byte(msg), Message: message, Hash: sighash}
+		req = &SignDataRequest{ContentType: mediaType, Rawdata: []byte(msg), Messages: messages, Hash: sighash}
 	case ApplicationClique.Mime:
 		// Clique is the Ethereum PoA standard
 		stringData, ok := data.(string)
@@ -251,7 +249,7 @@ func (api *SignerAPI) determineSignatureFormat(ctx context.Context, contentType 
 		if err != nil {
 			return nil, useEthereumV, err
 		}
-		message := []*NameValueType{
+		messages := []*NameValueType{
 			{
 				Name:  "Clique header",
 				Typ:   "clique",
@@ -260,7 +258,7 @@ func (api *SignerAPI) determineSignatureFormat(ctx context.Context, contentType 
 		}
 		// Clique uses V on the form 0 or 1
 		useEthereumV = false
-		req = &SignDataRequest{ContentType: mediaType, Rawdata: cliqueRlp, Message: message, Hash: sighash}
+		req = &SignDataRequest{ContentType: mediaType, Rawdata: cliqueRlp, Messages: messages, Hash: sighash}
 	default: // also case TextPlain.Mime:
 		// Calculates an Ethereum ECDSA signature for:
 		// hash = keccak256("\x19${byteVersion}Ethereum Signed Message:\n${message length}${message}")
@@ -272,21 +270,20 @@ func (api *SignerAPI) determineSignatureFormat(ctx context.Context, contentType 
 				return nil, useEthereumV, err
 			} else {
 				sighash, msg := accounts.TextAndHash(textData)
-				message := []*NameValueType{
+				messages := []*NameValueType{
 					{
 						Name:  "message",
 						Typ:   accounts.MimetypeTextPlain,
 						Value: msg,
 					},
 				}
-				req = &SignDataRequest{ContentType: mediaType, Rawdata: []byte(msg), Message: message, Hash: sighash}
+				req = &SignDataRequest{ContentType: mediaType, Rawdata: []byte(msg), Messages: messages, Hash: sighash}
 			}
 		}
 	}
 	req.Address = addr
 	req.Meta = MetadataFromContext(ctx)
 	return req, useEthereumV, nil
-
 }
 
 // SignTextWithValidator signs the given message which can be further recovered
@@ -327,11 +324,11 @@ func (api *SignerAPI) SignTypedData(ctx context.Context, addr common.MixedcaseAd
 	}
 	rawData := []byte(fmt.Sprintf("\x19\x01%s%s", string(domainSeparator), string(typedDataHash)))
 	sighash := crypto.Keccak256(rawData)
-	message, err := typedData.Format()
+	messages, err := typedData.Format()
 	if err != nil {
 		return nil, err
 	}
-	req := &SignDataRequest{ContentType: DataTyped.Mime, Rawdata: rawData, Message: message, Hash: sighash}
+	req := &SignDataRequest{ContentType: DataTyped.Mime, Rawdata: rawData, Messages: messages, Hash: sighash}
 	signature, err := api.sign(addr, req, true)
 	if err != nil {
 		api.UI.ShowError(err.Error())

--- a/signer/rules/rules.go
+++ b/signer/rules/rules.go
@@ -83,7 +83,12 @@ func (r *rulesetUI) execute(jsfunc string, jsarg interface{}) (otto.Value, error
 	vm.Set("storage", struct{}{})
 	storageObj, _ := vm.Get("storage")
 	storageObj.Object().Set("put", func(call otto.FunctionCall) otto.Value {
-		r.storage.Put(call.Argument(0).String(), call.Argument(1).String())
+		key, val := call.Argument(0).String(), call.Argument(1).String()
+		if val == "" {
+			r.storage.Del(key)
+		} else {
+			r.storage.Put(key, val)
+		}
 		return otto.NullValue()
 	})
 	storageObj.Object().Set("get", func(call otto.FunctionCall) otto.Value {

--- a/signer/rules/rules.go
+++ b/signer/rules/rules.go
@@ -74,12 +74,23 @@ func (r *rulesetUI) execute(jsfunc string, jsarg interface{}) (otto.Value, error
 
 	// Instantiate a fresh vm engine every time
 	vm := otto.New()
+
 	// Set the native callbacks
 	consoleObj, _ := vm.Get("console")
 	consoleObj.Object().Set("log", consoleOutput)
 	consoleObj.Object().Set("error", consoleOutput)
-	vm.Set("storage", r.storage)
 
+	vm.Set("storage", struct{}{})
+	storageObj, _ := vm.Get("storage")
+	storageObj.Object().Set("put", func(call otto.FunctionCall) otto.Value {
+		r.storage.Put(call.Argument(0).String(), call.Argument(1).String())
+		return otto.NullValue()
+	})
+	storageObj.Object().Set("get", func(call otto.FunctionCall) otto.Value {
+		goval, _ := r.storage.Get(call.Argument(0).String())
+		jsval, _ := otto.ToValue(goval)
+		return jsval
+	})
 	// Load bootstrap libraries
 	script, err := vm.Compile("bignumber.js", BigNumber_JS)
 	if err != nil {

--- a/signer/rules/rules_test.go
+++ b/signer/rules/rules_test.go
@@ -301,23 +301,23 @@ func TestStorage(t *testing.T) {
 
 	js := `
 	function testStorage(){
-		storage.Put("mykey", "myvalue")
-		a = storage.Get("mykey")
+		storage.put("mykey", "myvalue")
+		a = storage.get("mykey")
 
-		storage.Put("mykey", ["a", "list"])  	// Should result in "a,list"
-		a += storage.Get("mykey")
-
-
-		storage.Put("mykey", {"an": "object"}) 	// Should result in "[object Object]"
-		a += storage.Get("mykey")
+		storage.put("mykey", ["a", "list"])  	// Should result in "a,list"
+		a += storage.get("mykey")
 
 
-		storage.Put("mykey", JSON.stringify({"an": "object"})) // Should result in '{"an":"object"}'
-		a += storage.Get("mykey")
+		storage.put("mykey", {"an": "object"}) 	// Should result in "[object Object]"
+		a += storage.get("mykey")
 
-		a += storage.Get("missingkey")		//Missing keys should result in empty string
-		storage.Put("","missing key==noop") // Can't store with 0-length key
-		a += storage.Get("")				// Should result in ''
+
+		storage.put("mykey", JSON.stringify({"an": "object"})) // Should result in '{"an":"object"}'
+		a += storage.get("mykey")
+
+		a += storage.get("missingkey")		//Missing keys should result in empty string
+		storage.put("","missing key==noop") // Can't store with 0-length key
+		a += storage.get("")				// Should result in ''
 
 		var b = new BigNumber(2)
 		var c = new BigNumber(16)//"0xf0",16)
@@ -337,7 +337,6 @@ func TestStorage(t *testing.T) {
 	if err != nil {
 		t.Errorf("Unexpected error %v", err)
 	}
-
 	retval, err := v.ToString()
 
 	if err != nil {
@@ -369,7 +368,7 @@ const ExampleTxWindow = `
 		var windowstart = new Date().getTime() - window;
 
 		var txs = [];
-		var stored = storage.Get('txs');
+		var stored = storage.get('txs');
 
 		if(stored != ""){
 			txs = JSON.parse(stored)
@@ -414,19 +413,18 @@ const ExampleTxWindow = `
 		var value = big(resp.tx.value)
 		var txs = []
 		// Load stored transactions
-		var stored = storage.Get('txs');
+		var stored = storage.get('txs');
 		if(stored != ""){
 			txs = JSON.parse(stored)
 		}
 		// Add this to the storage
 		txs.push({tstamp: new Date().getTime(), value: value});
-		storage.Put("txs", JSON.stringify(txs));
+		storage.put("txs", JSON.stringify(txs));
 	}
 
 `
 
 func dummyTx(value hexutil.Big) *core.SignTxRequest {
-
 	to, _ := mixAddr("000000000000000000000000000000000000dead")
 	from, _ := mixAddr("000000000000000000000000000000000000dead")
 	n := hexutil.Uint64(3)
@@ -448,28 +446,27 @@ func dummyTx(value hexutil.Big) *core.SignTxRequest {
 		Meta: core.Metadata{Remote: "remoteip", Local: "localip", Scheme: "inproc"},
 	}
 }
-func dummyTxWithV(value uint64) *core.SignTxRequest {
 
+func dummyTxWithV(value uint64) *core.SignTxRequest {
 	v := big.NewInt(0).SetUint64(value)
 	h := hexutil.Big(*v)
 	return dummyTx(h)
 }
+
 func dummySigned(value *big.Int) *types.Transaction {
 	to := common.HexToAddress("000000000000000000000000000000000000dead")
 	gas := uint64(21000)
 	gasPrice := big.NewInt(2000000)
 	data := make([]byte, 0)
 	return types.NewTransaction(3, to, value, gas, gasPrice, data)
-
 }
-func TestLimitWindow(t *testing.T) {
 
+func TestLimitWindow(t *testing.T) {
 	r, err := initRuleEngine(ExampleTxWindow)
 	if err != nil {
 		t.Errorf("Couldn't create evaluator %v", err)
 		return
 	}
-
 	// 0.3 ether: 429D069189E0000 wei
 	v := big.NewInt(0).SetBytes(common.Hex2Bytes("0429D069189E0000"))
 	h := hexutil.Big(*v)
@@ -496,7 +493,6 @@ func TestLimitWindow(t *testing.T) {
 	if resp.Approved {
 		t.Errorf("Expected check to resolve to 'Reject'")
 	}
-
 }
 
 // dontCallMe is used as a next-handler that does not want to be called - it invokes test failure
@@ -508,6 +504,7 @@ func (d *dontCallMe) OnInputRequired(info core.UserInputRequest) (core.UserInput
 	d.t.Fatalf("Did not expect next-handler to be called")
 	return core.UserInputResponse{}, nil
 }
+
 func (d *dontCallMe) RegisterUIServer(api *core.UIServerAPI) {
 }
 
@@ -589,7 +586,7 @@ func TestSignData(t *testing.T) {
 function ApproveSignData(r){
     if( r.address.toLowerCase() == "0x694267f14675d7e1b9494fd8d72fefe1755710fa")
     {
-        if(r.message[0].value.indexOf("bazonk") >= 0){
+        if(r.messages[0].value.indexOf("bazonk") >= 0){
             return "Approve"
         }
         return "Reject"
@@ -615,11 +612,11 @@ function ApproveSignData(r){
 		},
 	}
 	resp, err := r.ApproveSignData(&core.SignDataRequest{
-		Address: *addr,
-		Message: nvt,
-		Hash:    hash,
-		Meta:    core.Metadata{Remote: "remoteip", Local: "localip", Scheme: "inproc"},
-		Rawdata: []byte(rawdata),
+		Address:  *addr,
+		Messages: nvt,
+		Hash:     hash,
+		Meta:     core.Metadata{Remote: "remoteip", Local: "localip", Scheme: "inproc"},
+		Rawdata:  []byte(rawdata),
 	})
 	if err != nil {
 		t.Fatalf("Unexpected error %v", err)

--- a/signer/storage/aes_gcm_storage.go
+++ b/signer/storage/aes_gcm_storage.go
@@ -75,27 +75,28 @@ func (s *AESEncryptedStorage) Put(key, value string) {
 	}
 }
 
-// Get returns the previously stored value, or the empty string if it does not exist or key is of 0-length
-func (s *AESEncryptedStorage) Get(key string) string {
+// Get returns the previously stored value, or an error if it does not exist or
+// key is of 0-length.
+func (s *AESEncryptedStorage) Get(key string) (string, error) {
 	if len(key) == 0 {
-		return ""
+		return "", ErrZeroKey
 	}
 	data, err := s.readEncryptedStorage()
 	if err != nil {
 		log.Warn("Failed to read encrypted storage", "err", err, "file", s.filename)
-		return ""
+		return "", err
 	}
 	encrypted, exist := data[key]
 	if !exist {
 		log.Warn("Key does not exist", "key", key)
-		return ""
+		return "", ErrNotFound
 	}
 	entry, err := decrypt(s.key, encrypted.Iv, encrypted.CipherText, []byte(key))
 	if err != nil {
 		log.Warn("Failed to decrypt key", "key", key)
-		return ""
+		return "", err
 	}
-	return string(entry)
+	return string(entry), nil
 }
 
 // readEncryptedStorage reads the file with encrypted creds

--- a/signer/storage/aes_gcm_storage.go
+++ b/signer/storage/aes_gcm_storage.go
@@ -53,7 +53,7 @@ func NewAESEncryptedStorage(filename string, key []byte) *AESEncryptedStorage {
 	}
 }
 
-// Put stores a value by key. 0-length keys results in no-op
+// Put stores a value by key. 0-length keys results in noop.
 func (s *AESEncryptedStorage) Put(key, value string) {
 	if len(key) == 0 {
 		return
@@ -97,6 +97,19 @@ func (s *AESEncryptedStorage) Get(key string) (string, error) {
 		return "", err
 	}
 	return string(entry), nil
+}
+
+// Del removes a key-value pair. If the key doesn't exist, the method is a noop.
+func (s *AESEncryptedStorage) Del(key string) {
+	data, err := s.readEncryptedStorage()
+	if err != nil {
+		log.Warn("Failed to read encrypted storage", "err", err, "file", s.filename)
+		return
+	}
+	delete(data, key)
+	if err = s.writeEncryptedStorage(data); err != nil {
+		log.Warn("Failed to write entry", "err", err)
+	}
 }
 
 // readEncryptedStorage reads the file with encrypted creds

--- a/signer/storage/aes_gcm_storage_test.go
+++ b/signer/storage/aes_gcm_storage_test.go
@@ -110,8 +110,8 @@ func TestEnd2End(t *testing.T) {
 	}
 
 	s1.Put("bazonk", "foobar")
-	if v := s2.Get("bazonk"); v != "foobar" {
-		t.Errorf("Expected bazonk->foobar, got '%v'", v)
+	if v, err := s2.Get("bazonk"); v != "foobar" || err != nil {
+		t.Errorf("Expected bazonk->foobar (nil error), got '%v' (%v error)", v, err)
 	}
 }
 
@@ -154,11 +154,11 @@ func TestSwappedKeys(t *testing.T) {
 		}
 	}
 	swap()
-	if v := s1.Get("k1"); v != "" {
+	if v, _ := s1.Get("k1"); v != "" {
 		t.Errorf("swapped value should return empty")
 	}
 	swap()
-	if v := s1.Get("k1"); v != "v1" {
+	if v, _ := s1.Get("k1"); v != "v1" {
 		t.Errorf("double-swapped value should work fine")
 	}
 }

--- a/signer/storage/storage.go
+++ b/signer/storage/storage.go
@@ -28,12 +28,15 @@ var (
 )
 
 type Storage interface {
-	// Put stores a value by key. 0-length keys results in no-op
+	// Put stores a value by key. 0-length keys results in noop.
 	Put(key, value string)
 
 	// Get returns the previously stored value, or an error if the key is 0-length
 	// or unknown.
 	Get(key string) (string, error)
+
+	// Del removes a key-value pair. If the key doesn't exist, the method is a noop.
+	Del(key string)
 }
 
 // EphemeralStorage is an in-memory storage that does
@@ -43,6 +46,7 @@ type EphemeralStorage struct {
 	namespace string
 }
 
+// Put stores a value by key. 0-length keys results in noop.
 func (s *EphemeralStorage) Put(key, value string) {
 	if len(key) == 0 {
 		return
@@ -62,6 +66,11 @@ func (s *EphemeralStorage) Get(key string) (string, error) {
 	return "", ErrNotFound
 }
 
+// Del removes a key-value pair. If the key doesn't exist, the method is a noop.
+func (s *EphemeralStorage) Del(key string) {
+	delete(s.data, key)
+}
+
 func NewEphemeralStorage() Storage {
 	s := &EphemeralStorage{
 		data: make(map[string]string),
@@ -73,6 +82,7 @@ func NewEphemeralStorage() Storage {
 type NoStorage struct{}
 
 func (s *NoStorage) Put(key, value string) {}
+func (s *NoStorage) Del(key string)        {}
 func (s *NoStorage) Get(key string) (string, error) {
 	return "", errors.New("I forgot")
 }

--- a/signer/storage/storage.go
+++ b/signer/storage/storage.go
@@ -17,11 +17,23 @@
 
 package storage
 
+import "errors"
+
+var (
+	// ErrZeroKey is returned if an attempt was made to inset a 0-length key.
+	ErrZeroKey = errors.New("0-length key")
+
+	// ErrNotFound is returned if an unknown key is attempted to be retrieved.
+	ErrNotFound = errors.New("not found")
+)
+
 type Storage interface {
 	// Put stores a value by key. 0-length keys results in no-op
 	Put(key, value string)
-	// Get returns the previously stored value, or the empty string if it does not exist or key is of 0-length
-	Get(key string) string
+
+	// Get returns the previously stored value, or an error if the key is 0-length
+	// or unknown.
+	Get(key string) (string, error)
 }
 
 // EphemeralStorage is an in-memory storage that does
@@ -35,19 +47,19 @@ func (s *EphemeralStorage) Put(key, value string) {
 	if len(key) == 0 {
 		return
 	}
-	//fmt.Printf("storage: put %v -> %v\n", key, value)
 	s.data[key] = value
 }
 
-func (s *EphemeralStorage) Get(key string) string {
+// Get returns the previously stored value, or an error if the key is 0-length
+// or unknown.
+func (s *EphemeralStorage) Get(key string) (string, error) {
 	if len(key) == 0 {
-		return ""
+		return "", ErrZeroKey
 	}
-	//fmt.Printf("storage: get %v\n", key)
-	if v, exist := s.data[key]; exist {
-		return v
+	if v, ok := s.data[key]; ok {
+		return v, nil
 	}
-	return ""
+	return "", ErrNotFound
 }
 
 func NewEphemeralStorage() Storage {
@@ -61,6 +73,6 @@ func NewEphemeralStorage() Storage {
 type NoStorage struct{}
 
 func (s *NoStorage) Put(key, value string) {}
-func (s *NoStorage) Get(key string) string {
-	return ""
+func (s *NoStorage) Get(key string) (string, error) {
+	return "", errors.New("I forgot")
 }


### PR DESCRIPTION
The goal of this PR was to refresh the Clef tutorial so it's up to date with the current code base. Apart from making sure all the code snippets, command, rules, etc. run, I've also tried to make the tutorial a bit more rounded, adding a few more sections + explanations.

During the refresh, I've noticed and fixed a few issues, please take a look at these in particular:

 * When running `clef init`, if there's already a `masterseed.json`, I abort immediately. Previously we asked the user for the full passphrase entry and only afterwards failed (we still check afterwards too).
 * When running `clef setpw`, the PR changes the stored key to the check-summed address (also modifies the counterpart that loads the password to use the checksum). Previously there was an issue here because the read enforced all lowercase but the write used whatever the user gave, potentially not finding an account. I chose the check-summed version because that seemed the better alternative long term.
 * The PR introduces `clef delpw` to support removing a stored key (previously you needed to set it to `""`, which was both confusing and also still left the key in the store, just the value zeroed out).
 * The PR adds a check to explicitly disallow unknown commands (e.g. `clef addpw` won't start, rather will tell you it's an unknown command).
 * `signer.Storage.Get` was originally defined to return the empty string if a) the key is 0-length b) the key is not found c) the value is the empty string. I think it is dangerous to convolute so many possibilities, since the empty value might be legitimately useful (e.g. empty password for an account). The PR changes the `Get` signature so it returns an `error` too, so we can split between a value being `""`, or not present.
* The above signature change broke the rule engine's `storage.Get`. Since it is also ugly to use capitalized `storage.Get` and `storage.Put` in JavaScript, the PR hid the original methods and instead surfaced lowercase `storage.get` and `storage.put`. The latter just calling the original whereas the former ignoring the error and just returning the value. This way the original behavior is retained.
* `storage.put` in the rule engine was extended to call `storage.Del` if the value is empty. This is consistent with the old behavior, just results in the key actually being fully deleted instead of set to the encrypted empty string.
* A while back (not sure when) the `SignDataRequest.Message` was changed from `string` to `[]*NameValueType`. Referring in continuation to this field as `message` seemed misleading (took me 1 hour of digging through the Go code to figure out why my rule was failing). I renamed this fields to `messages` and bumped the internal API to 7.0.0.

Would be nice, but maybe for the future:

- [ ] The sign data requests on the internal API spec weren't updated to the list-version of `message` when that change was introduced. We need to update that spec to have the correct documentation.
- [ ] The `account_import` and `account_export` is still listed as available on the external API. I guess we need to moved those into the internal API section.