### PR TITLE
fix: fix builtin shadowing

### DIFF
--- a/accounts/abi/pack.go
+++ b/accounts/abi/pack.go
@@ -27,8 +27,8 @@ import (
 // packBytesSlice packs the given bytes as [L, V] as the canonical representation
 // bytes slice
 func packBytesSlice(bytes []byte, l int) []byte {
-	len := packNum(reflect.ValueOf(l))
-	return append(len, common.RightPadBytes(bytes, (l+31)/32*32)...)
+	length := packNum(reflect.ValueOf(l))
+	return append(length, common.RightPadBytes(bytes, (l+31)/32*32)...)
 }
 
 // packElement packs the given reflect value according to the abi specification in

--- a/common/math/integer.go
+++ b/common/math/integer.go
@@ -42,11 +42,11 @@ type HexOrDecimal64 uint64
 
 // UnmarshalText implements encoding.TextUnmarshaler.
 func (i *HexOrDecimal64) UnmarshalText(input []byte) error {
-	int, ok := ParseUint64(string(input))
+	integer, ok := ParseUint64(string(input))
 	if !ok {
 		return fmt.Errorf("invalid hex or decimal integer %q", input)
 	}
-	*i = HexOrDecimal64(int)
+	*i = HexOrDecimal64(integer)
 	return nil
 }
 

--- a/core/asm/lexer.go
+++ b/core/asm/lexer.go
@@ -116,14 +116,14 @@ func Lex(source []byte, debug bool) <-chan token {
 }
 
 // next returns the next rune in the program's source.
-func (l *lexer) next() (rune rune) {
+func (l *lexer) next() (r rune) {
 	if l.pos >= len(l.input) {
 		l.width = 0
 		return 0
 	}
-	rune, l.width = utf8.DecodeRuneInString(l.input[l.pos:])
+	r, l.width = utf8.DecodeRuneInString(l.input[l.pos:])
 	l.pos += l.width
-	return rune
+	return r
 }
 
 // backup backsup the last parsed element (multi-character)

--- a/event/feed_test.go
+++ b/event/feed_test.go
@@ -66,11 +66,11 @@ func TestFeedPanics(t *testing.T) {
 
 func checkPanic(want error, fn func()) (err error) {
 	defer func() {
-		panic := recover()
-		if panic == nil {
+		pnc := recover()
+		if pnc == nil {
 			err = fmt.Errorf("didn't panic")
-		} else if !reflect.DeepEqual(panic, want) {
-			err = fmt.Errorf("panicked with wrong error: got %q, want %q", panic, want)
+		} else if !reflect.DeepEqual(pnc, want) {
+			err = fmt.Errorf("panicked with wrong error: got %q, want %q", pnc, want)
 		}
 	}()
 	fn()

--- a/internal/jsre/pretty.go
+++ b/internal/jsre/pretty.go
@@ -110,8 +110,8 @@ func (ctx ppctx) printObject(obj *otto.Object, level int, inArray bool) {
 	switch obj.Class() {
 	case "Array", "GoArray":
 		lv, _ := obj.Get("length")
-		len, _ := lv.ToInteger()
-		if len == 0 {
+		length, _ := lv.ToInteger()
+		if length == 0 {
 			fmt.Fprintf(ctx.w, "[]")
 			return
 		}
@@ -120,12 +120,12 @@ func (ctx ppctx) printObject(obj *otto.Object, level int, inArray bool) {
 			return
 		}
 		fmt.Fprint(ctx.w, "[")
-		for i := int64(0); i < len; i++ {
+		for i := int64(0); i < length; i++ {
 			el, err := obj.Get(strconv.FormatInt(i, 10))
 			if err == nil {
 				ctx.printValue(el, level+1, true)
 			}
-			if i < len-1 {
+			if i < length-1 {
 				fmt.Fprintf(ctx.w, ", ")
 			}
 		}

--- a/log/format.go
+++ b/log/format.go
@@ -28,8 +28,8 @@ var locationTrims = []string{
 
 // PrintOrigins sets or unsets log location (file:line) printing for terminal
 // format output.
-func PrintOrigins(print bool) {
-	if print {
+func PrintOrigins(setPrint bool) {
+	if setPrint {
 		atomic.StoreUint32(&locationEnabled, 1)
 	} else {
 		atomic.StoreUint32(&locationEnabled, 0)

--- a/rlp/decode.go
+++ b/rlp/decode.go
@@ -648,11 +648,11 @@ func NewStream(r io.Reader, inputLimit uint64) *Stream {
 
 // NewListStream creates a new stream that pretends to be positioned
 // at an encoded list of the given length.
-func NewListStream(r io.Reader, len uint64) *Stream {
+func NewListStream(r io.Reader, length uint64) *Stream {
 	s := new(Stream)
-	s.Reset(r, len)
+	s.Reset(r, length)
 	s.kind = List
-	s.size = len
+	s.size = length
 	return s
 }
 

--- a/rlp/decode_test.go
+++ b/rlp/decode_test.go
@@ -51,16 +51,16 @@ func TestStreamKind(t *testing.T) {
 	for i, test := range tests {
 		// using plainReader to inhibit input limit errors.
 		s := NewStream(newPlainReader(unhex(test.input)), 0)
-		kind, len, err := s.Kind()
+		gotKind, gotLen, err := s.Kind()
 		if err != nil {
 			t.Errorf("test %d: Kind returned error: %v", i, err)
 			continue
 		}
-		if kind != test.wantKind {
-			t.Errorf("test %d: kind mismatch: got %d, want %d", i, kind, test.wantKind)
+		if gotKind != test.wantKind {
+			t.Errorf("test %d: kind mismatch: got %d, want %d", i, gotKind, test.wantKind)
 		}
-		if len != test.wantLen {
-			t.Errorf("test %d: len mismatch: got %d, want %d", i, len, test.wantLen)
+		if gotLen != test.wantLen {
+			t.Errorf("test %d: len mismatch: got %d, want %d", i, gotLen, test.wantLen)
 		}
 	}
 }
@@ -229,12 +229,12 @@ testfor:
 func TestStreamList(t *testing.T) {
 	s := NewStream(bytes.NewReader(unhex("C80102030405060708")), 0)
 
-	len, err := s.List()
+	gotLen, err := s.List()
 	if err != nil {
 		t.Fatalf("List error: %v", err)
 	}
-	if len != 8 {
-		t.Fatalf("List returned invalid length, got %d, want 8", len)
+	if gotLen != 8 {
+		t.Fatalf("List returned invalid length, got %d, want 8", gotLen)
 	}
 
 	for i := uint64(1); i <= 8; i++ {

--- a/rlp/encode.go
+++ b/rlp/encode.go
@@ -448,9 +448,9 @@ func writeByteArray(val reflect.Value, w *encbuf) error {
 	if !val.CanAddr() {
 		// Slice requires the value to be addressable.
 		// Make it addressable by copying.
-		copy := reflect.New(val.Type()).Elem()
-		copy.Set(val)
-		val = copy
+		cp := reflect.New(val.Type()).Elem()
+		cp.Set(val)
+		val = cp
 	}
 	size := val.Len()
 	slice := val.Slice(0, size).Bytes()

--- a/rpc/service.go
+++ b/rpc/service.go
@@ -220,8 +220,8 @@ func (c *callback) call(ctx context.Context, method string, args []reflect.Value
 
 // Is this an exported - upper case - name?
 func isExported(name string) bool {
-	rune, _ := utf8.DecodeRuneInString(name)
-	return unicode.IsUpper(rune)
+	r, _ := utf8.DecodeRuneInString(name)
+	return unicode.IsUpper(r)
 }
 
 // Are all those types exported or built-in?


### PR DESCRIPTION
As `copy`, `len`, `int`,`panic`, `rune` and `print` are pre-declared identifiers in GoLang, we should avoid using them to name variables, in order to avoid shadowing and confusions.