### PR TITLE
accounts, cmd, contracts, les: integrate clef for transaction signing

### DIFF
--- a/accounts/abi/bind/auth.go
+++ b/accounts/abi/bind/auth.go
@@ -44,7 +44,7 @@ func NewTransactor(keyin io.Reader, passphrase string) (*TransactOpts, error) {
 	return NewKeyedTransactor(key.PrivateKey), nil
 }
 
-// NewKeystoreTransactor is a utility method to easily create a transaction signer from
+// NewKeyStoreTransactor is a utility method to easily create a transaction signer from
 // an decrypted key from a keystore
 func NewKeyStoreTransactor(keystore *keystore.KeyStore, account accounts.Account) (*TransactOpts, error) {
 	return &TransactOpts{
@@ -83,14 +83,14 @@ func NewKeyedTransactor(key *ecdsa.PrivateKey) *TransactOpts {
 
 // NewClefTransactor is a utility method to easily create a transaction signer
 // with a clef backend.
-func NewClefTransactor(clefSigner *external.ExternalSigner, account accounts.Account) *TransactOpts {
+func NewClefTransactor(clef *external.ExternalSigner, account accounts.Account) *TransactOpts {
 	return &TransactOpts{
 		From: account.Address,
 		Signer: func(signer types.Signer, address common.Address, transaction *types.Transaction) (*types.Transaction, error) {
 			if address != account.Address {
 				return nil, errors.New("not authorized to sign this account")
 			}
-			return clefSigner.SignTx(account, transaction, nil) // ChainId is never used here.
+			return clef.SignTx(account, transaction, nil) // Clef enforces its own chain id
 		},
 	}
 }

--- a/accounts/abi/bind/auth.go
+++ b/accounts/abi/bind/auth.go
@@ -23,6 +23,7 @@ import (
 	"io/ioutil"
 
 	"github.com/ethereum/go-ethereum/accounts"
+	"github.com/ethereum/go-ethereum/accounts/external"
 	"github.com/ethereum/go-ethereum/accounts/keystore"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
@@ -76,6 +77,20 @@ func NewKeyedTransactor(key *ecdsa.PrivateKey) *TransactOpts {
 				return nil, err
 			}
 			return tx.WithSignature(signer, signature)
+		},
+	}
+}
+
+// NewClefTransactor is a utility method to easily create a transaction signer
+// with a clef backend.
+func NewClefTransactor(clefSigner *external.ExternalSigner, account accounts.Account) *TransactOpts {
+	return &TransactOpts{
+		From: account.Address,
+		Signer: func(signer types.Signer, address common.Address, transaction *types.Transaction) (*types.Transaction, error) {
+			if address != account.Address {
+				return nil, errors.New("not authorized to sign this account")
+			}
+			return clefSigner.SignTx(account, transaction, nil) // ChainId is never used here.
 		},
 	}
 }

--- a/accounts/external/backend.go
+++ b/accounts/external/backend.go
@@ -182,18 +182,21 @@ func (api *ExternalSigner) SignText(account accounts.Account, text []byte) ([]by
 
 func (api *ExternalSigner) SignTx(account accounts.Account, tx *types.Transaction, chainID *big.Int) (*types.Transaction, error) {
 	res := ethapi.SignTransactionResult{}
-	to := common.NewMixedcaseAddress(*tx.To())
 	data := hexutil.Bytes(tx.Data())
+	var to *common.MixedcaseAddress
+	if tx.To() != nil {
+		t := common.NewMixedcaseAddress(*tx.To())
+		to = &t
+	}
 	args := &core.SendTxArgs{
 		Data:     &data,
 		Nonce:    hexutil.Uint64(tx.Nonce()),
 		Value:    hexutil.Big(*tx.Value()),
 		Gas:      hexutil.Uint64(tx.Gas()),
 		GasPrice: hexutil.Big(*tx.GasPrice()),
-		To:       &to,
+		To:       to,
 		From:     common.NewMixedcaseAddress(account.Address),
 	}
-
 	if err := api.client.Call(&res, "account_signTransaction", args); err != nil {
 		return nil, err
 	}

--- a/cmd/checkpoint-admin/common.go
+++ b/cmd/checkpoint-admin/common.go
@@ -112,10 +112,9 @@ func newContract(client *rpc.Client) (common.Address, *checkpointoracle.Checkpoi
 
 // newClefSigner sets up a clef backend and returns a clef transaction signer.
 func newClefSigner(ctx *cli.Context) *bind.TransactOpts {
-	clefSigner, err := external.NewExternalSigner(ctx.GlobalString(clefURLFlag.Name))
+	clef, err := external.NewExternalSigner(ctx.String(clefURLFlag.Name))
 	if err != nil {
 		utils.Fatalf("Failed to create clef signer %v", err)
 	}
-	transactor := bind.NewClefTransactor(clefSigner, accounts.Account{Address: common.HexToAddress(ctx.String(signerFlag.Name))})
-	return transactor
+	return bind.NewClefTransactor(clef, accounts.Account{Address: common.HexToAddress(ctx.String(signerFlag.Name))})
 }

--- a/cmd/checkpoint-admin/common.go
+++ b/cmd/checkpoint-admin/common.go
@@ -17,14 +17,13 @@
 package main
 
 import (
-	"io/ioutil"
 	"strconv"
-	"strings"
 
-	"github.com/ethereum/go-ethereum/accounts/keystore"
+	"github.com/ethereum/go-ethereum/accounts"
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum/accounts/external"
 	"github.com/ethereum/go-ethereum/cmd/utils"
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/console"
 	"github.com/ethereum/go-ethereum/contracts/checkpointoracle"
 	"github.com/ethereum/go-ethereum/ethclient"
 	"github.com/ethereum/go-ethereum/params"
@@ -111,56 +110,12 @@ func newContract(client *rpc.Client) (common.Address, *checkpointoracle.Checkpoi
 	return addr, contract
 }
 
-// promptPassphrase prompts the user for a passphrase.
-// Set confirmation to true to require the user to confirm the passphrase.
-func promptPassphrase(confirmation bool) string {
-	passphrase, err := console.Stdin.PromptPassword("Passphrase: ")
+// newClefSigner sets up a clef backend and returns a clef transaction signer.
+func newClefSigner(ctx *cli.Context) *bind.TransactOpts {
+	clefSigner, err := external.NewExternalSigner(ctx.GlobalString(clefURLFlag.Name))
 	if err != nil {
-		utils.Fatalf("Failed to read passphrase: %v", err)
+		utils.Fatalf("Failed to create clef signer %v", err)
 	}
-
-	if confirmation {
-		confirm, err := console.Stdin.PromptPassword("Repeat passphrase: ")
-		if err != nil {
-			utils.Fatalf("Failed to read passphrase confirmation: %v", err)
-		}
-		if passphrase != confirm {
-			utils.Fatalf("Passphrases do not match")
-		}
-	}
-	return passphrase
-}
-
-// getPassphrase obtains a passphrase given by the user. It first checks the
-// --password command line flag and ultimately prompts the user for a
-// passphrase.
-func getPassphrase(ctx *cli.Context) string {
-	passphraseFile := ctx.String(utils.PasswordFileFlag.Name)
-	if passphraseFile != "" {
-		content, err := ioutil.ReadFile(passphraseFile)
-		if err != nil {
-			utils.Fatalf("Failed to read passphrase file '%s': %v",
-				passphraseFile, err)
-		}
-		return strings.TrimRight(string(content), "\r\n")
-	}
-	// Otherwise prompt the user for the passphrase.
-	return promptPassphrase(false)
-}
-
-// getKey retrieves the user key through specified key file.
-func getKey(ctx *cli.Context) *keystore.Key {
-	// Read key from file.
-	keyFile := ctx.GlobalString(keyFileFlag.Name)
-	keyJson, err := ioutil.ReadFile(keyFile)
-	if err != nil {
-		utils.Fatalf("Failed to read the keyfile at '%s': %v", keyFile, err)
-	}
-	// Decrypt key with passphrase.
-	passphrase := getPassphrase(ctx)
-	key, err := keystore.DecryptKey(keyJson, passphrase)
-	if err != nil {
-		utils.Fatalf("Failed to decrypt user key '%s': %v", keyFile, err)
-	}
-	return key
+	transactor := bind.NewClefTransactor(clefSigner, accounts.Account{Address: common.HexToAddress(ctx.String(signerFlag.Name))})
+	return transactor
 }

--- a/cmd/checkpoint-admin/main.go
+++ b/cmd/checkpoint-admin/main.go
@@ -59,10 +59,8 @@ func init() {
 	}
 	app.Flags = []cli.Flag{
 		oracleFlag,
-		keyFileFlag,
 		nodeURLFlag,
 		clefURLFlag,
-		utils.PasswordFileFlag,
 	}
 	cli.CommandHelpTemplate = commandHelperTemplate
 }
@@ -85,10 +83,6 @@ var (
 		Name:  "threshold",
 		Usage: "Minimal number of signatures required to approve a checkpoint",
 	}
-	keyFileFlag = cli.StringFlag{
-		Name:  "keyfile",
-		Usage: "The private key file (keyfile signature is not recommended)",
-	}
 	nodeURLFlag = cli.StringFlag{
 		Name:  "rpc",
 		Value: "http://localhost:8545",
@@ -101,7 +95,7 @@ var (
 	}
 	signerFlag = cli.StringFlag{
 		Name:  "signer",
-		Usage: "Signer address for clef mode signing",
+		Usage: "Signer address for clef signing",
 	}
 	signersFlag = cli.StringFlag{
 		Name:  "signers",

--- a/cmd/checkpoint-admin/main.go
+++ b/cmd/checkpoint-admin/main.go
@@ -60,7 +60,6 @@ func init() {
 	app.Flags = []cli.Flag{
 		oracleFlag,
 		nodeURLFlag,
-		clefURLFlag,
 	}
 	cli.CommandHelpTemplate = commandHelperTemplate
 }

--- a/contracts/checkpointoracle/oracle.go
+++ b/contracts/checkpointoracle/oracle.go
@@ -20,7 +20,6 @@ package checkpointoracle
 //go:generate abigen --sol contract/oracle.sol --pkg contract --out contract/oracle.go
 
 import (
-	"crypto/ecdsa"
 	"errors"
 	"math/big"
 
@@ -73,7 +72,7 @@ func (oracle *CheckpointOracle) LookupCheckpointEvents(blockLogs [][]*types.Log,
 //
 // Notably all signatures given should be transformed to "ethereum style" which transforms
 // v from 0/1 to 27/28 according to the yellow paper.
-func (oracle *CheckpointOracle) RegisterCheckpoint(key *ecdsa.PrivateKey, index uint64, hash []byte, rnum *big.Int, rhash [32]byte, sigs [][]byte) (*types.Transaction, error) {
+func (oracle *CheckpointOracle) RegisterCheckpoint(opts *bind.TransactOpts, index uint64, hash []byte, rnum *big.Int, rhash [32]byte, sigs [][]byte) (*types.Transaction, error) {
 	var (
 		r [][32]byte
 		s [][32]byte
@@ -87,5 +86,5 @@ func (oracle *CheckpointOracle) RegisterCheckpoint(key *ecdsa.PrivateKey, index 
 		s = append(s, common.BytesToHash(sigs[i][32:64]))
 		v = append(v, sigs[i][64])
 	}
-	return oracle.contract.SetCheckpoint(bind.NewKeyedTransactor(key), rnum, rhash, common.BytesToHash(hash), index, v, r, s)
+	return oracle.contract.SetCheckpoint(opts, rnum, rhash, common.BytesToHash(hash), index, v, r, s)
 }

--- a/les/sync_test.go
+++ b/les/sync_test.go
@@ -22,6 +22,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/core"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/light"
@@ -82,7 +83,7 @@ func testCheckpointSyncing(t *testing.T, protocol int, syncMode int) {
 			data := append([]byte{0x19, 0x00}, append(registrarAddr.Bytes(), append([]byte{0, 0, 0, 0, 0, 0, 0, 0}, cp.Hash().Bytes()...)...)...)
 			sig, _ := crypto.Sign(crypto.Keccak256(data), signerKey)
 			sig[64] += 27 // Transform V from 0/1 to 27/28 according to the yellow paper
-			if _, err := server.pm.reg.contract.RegisterCheckpoint(signerKey, cp.SectionIndex, cp.Hash().Bytes(), new(big.Int).Sub(header.Number, big.NewInt(1)), header.ParentHash, [][]byte{sig}); err != nil {
+			if _, err := server.pm.reg.contract.RegisterCheckpoint(bind.NewKeyedTransactor(signerKey), cp.SectionIndex, cp.Hash().Bytes(), new(big.Int).Sub(header.Number, big.NewInt(1)), header.ParentHash, [][]byte{sig}); err != nil {
 				t.Error("register checkpoint failed", err)
 			}
 			server.backend.Commit()

--- a/signer/core/cliui.go
+++ b/signer/core/cliui.go
@@ -171,7 +171,7 @@ func (ui *CommandlineUI) ApproveSignData(request *SignDataRequest) (SignDataResp
 	fmt.Printf("Account:  %s\n", request.Address.String())
 	fmt.Printf("messages:\n")
 	for _, nvt := range request.Messages {
-		fmt.Printf("%v\n", nvt.Pprint(1))
+		fmt.Printf("\u00a0\u00a0%v\n", strings.TrimSpace(nvt.Pprint(1)))
 	}
 	fmt.Printf("raw data:  \n%q\n", request.Rawdata)
 	fmt.Printf("data hash:  %v\n", request.Hash)


### PR DESCRIPTION
This PR integrates clef into checkpoint oracle. So that we can relay all signing operations to clef to get rid of keyfile.