### PR TITLE
core: fix chain indexer

### DIFF
--- a/core/chain_indexer.go
+++ b/core/chain_indexer.go
@@ -418,7 +418,7 @@ func (c *ChainIndexer) processSection(section uint64, lastHead common.Hash) (com
 // actual canonical chain and rolls back reorged sections if necessary to ensure that stored
 // sections are all valid
 func (c *ChainIndexer) verifyLastHead() {
-	for c.storedSections > 0 {
+	for c.storedSections > 0 && c.storedSections > c.checkpointSections {
 		if c.SectionHead(c.storedSections-1) == rawdb.ReadCanonicalHash(c.chainDb, c.storedSections*c.sectionSize-1) {
 			return
 		}


### PR DESCRIPTION
This PR fixes an issue in chain indexer. Currently chain indexer will
validate whether the stored data is canonical by comparing section head
and canonical hash. But the header of the checkpoint may not exist in
the database. We should skip validation for sections below the
checkpoint.