### PR TITLE
vendor: update karalabe/usb to fix CGO=0 builds

### DIFF
--- a/vendor/github.com/karalabe/usb/usb_disabled.go
+++ b/vendor/github.com/karalabe/usb/usb_disabled.go
@@ -44,3 +44,8 @@ func EnumerateRaw(vendorID uint16, productID uint16) ([]DeviceInfo, error) {
 func EnumerateHid(vendorID uint16, productID uint16) ([]DeviceInfo, error) {
 	return nil, nil
 }
+
+// Open connects to a previsouly discovered USB device.
+func (info DeviceInfo) Open() (Device, error) {
+	return nil, ErrUnsupportedPlatform
+}

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -243,10 +243,10 @@
 			"revisionTime": "2017-04-30T22:20:11Z"
 		},
 		{
-			"checksumSHA1": "TU/WaqL7fYPDovmGVRSo8btD4ZM=",
+			"checksumSHA1": "X7ZY5gt+qBd/lafKNbPbouL819w=",
 			"path": "github.com/karalabe/usb",
-			"revision": "4d6ba34a841453237dba721eeec1af0ef9a7a890",
-			"revisionTime": "2019-06-13T07:02:55Z",
+			"revision": "6a7de9d893feb2324aaef49331e923ce279c7973",
+			"revisionTime": "2019-07-03T09:51:11Z",
 			"tree": true
 		},
 		{


### PR DESCRIPTION
Update the vendored `karalabe/usb` package to ensure that `geth` builds on OpenBSD.