### PR TITLE
Fix C compilation warning in duktape package

### DIFF
--- a/vendor/gopkg.in/olebedev/go-duktape.v3/duk_logging.c
+++ b/vendor/gopkg.in/olebedev/go-duktape.v3/duk_logging.c
@@ -135,7 +135,7 @@ static duk_ret_t duk__logger_prototype_log_shared(duk_context *ctx) {
 	duk_size_t arg_len;
 	duk_uint8_t *buf, *p;
 	const duk_uint8_t *q;
-	duk_uint8_t date_buf[32];  /* maximum format length is 24+1 (NUL), round up. */
+	duk_uint8_t date_buf[85];  /* maximum format length is 24+1 (NUL), round up. */
 	duk_size_t date_len;
 	duk_small_int_t rc;
 


### PR DESCRIPTION
```
# github.com/ethereum/go-ethereum/vendor/gopkg.in/olebedev/go-duktape.v3
duk_logging.c: In function ‘duk__logger_prototype_log_shared’:
duk_logging.c:184:64: warning: ‘Z’ directive writing 1 byte into a region of size between 0 and 9 [-Wformat-overflow=]
  sprintf((char *) date_buf, "%04d-%02d-%02dT%02d:%02d:%02d.%03dZ",
                                                                ^
In file included from /usr/include/stdio.h:867,
                 from duk_logging.c:5:
/usr/include/x86_64-linux-gnu/bits/stdio2.h:36:10: note: ‘__builtin___sprintf_chk’ output between 25 and 85 bytes into a destination of size 32
   return __builtin___sprintf_chk (__s, __USE_FORTIFY_LEVEL - 1,
          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
       __bos (__s), __fmt, __va_arg_pack ());
       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```