### PR TITLE
p2p: remove "cap" enr entry

### DIFF
--- a/p2p/protocol.go
+++ b/p2p/protocol.go
@@ -79,5 +79,3 @@ func (cs capsByNameAndVersion) Swap(i, j int) { cs[i], cs[j] = cs[j], cs[i] }
 func (cs capsByNameAndVersion) Less(i, j int) bool {
 	return cs[i].Name < cs[j].Name || (cs[i].Name == cs[j].Name && cs[i].Version < cs[j].Version)
 }
-
-func (capsByNameAndVersion) ENRKey() string { return "cap" }

--- a/p2p/server.go
+++ b/p2p/server.go
@@ -488,7 +488,6 @@ func (srv *Server) setupLocalNode() error {
 	srv.nodedb = db
 	srv.localnode = enode.NewLocalNode(db, srv.PrivateKey)
 	srv.localnode.SetFallbackIP(net.IP{127, 0, 0, 1})
-	srv.localnode.Set(capsByNameAndVersion(srv.ourHandshake.Caps))
 	// TODO: check conflicts
 	for _, p := range srv.Protocols {
 		for _, e := range p.Attributes {


### PR DESCRIPTION
This entry was an experiment, but we're moving on to the
entry-per-protocol model instead.