### PR TITLE
miner: only commit work when mining

### DIFF
--- a/miner/worker.go
+++ b/miner/worker.go
@@ -861,10 +861,10 @@ func (w *worker) commitNewWork(interrupt *int32, noempty bool, timestamp int64) 
 			return
 		}
 		header.Coinbase = w.coinbase
-	}
-	if err := w.engine.Prepare(w.chain, header); err != nil {
-		log.Error("Failed to prepare header for mining", "err", err)
-		return
+		if err := w.engine.Prepare(w.chain, header); err != nil {
+			log.Error("Failed to prepare header for mining", "err", err)
+			return
+		}
 	}
 	// If we are care about TheDAO hard-fork check whether to override the extra-data or not
 	if daoBlock := w.chainConfig.DAOForkBlock; daoBlock != nil {


### PR DESCRIPTION
On some customize other consensus, calling commit work which in-turn will call unnecessary `engine.Prepare()` when not mining and might make unexpected error. This PR to fix this problem by only call commit work when mining 