### PR TITLE
cmd: encapsulate les relative cli options

### DIFF
--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -93,10 +93,12 @@ var (
 		utils.SyncModeFlag,
 		utils.ExitWhenSyncedFlag,
 		utils.GCModeFlag,
-		utils.LightServFlag,
-		utils.LightBandwidthInFlag,
-		utils.LightBandwidthOutFlag,
-		utils.LightPeersFlag,
+		utils.LightServeFlag,
+		utils.LightLegacyServFlag,
+		utils.LightIngressFlag,
+		utils.LightEgressFlag,
+		utils.LightMaxPeersFlag,
+		utils.LightLegacyPeersFlag,
 		utils.LightKDFFlag,
 		utils.UltraLightServersFlag,
 		utils.UltraLightFractionFlag,
@@ -336,7 +338,7 @@ func startNode(ctx *cli.Context, stack *node.Node) {
 
 	// Set contract backend for ethereum service if local node
 	// is serving LES requests.
-	if ctx.GlobalInt(utils.LightServFlag.Name) > 0 {
+	if ctx.GlobalInt(utils.LightLegacyServFlag.Name) > 0 || ctx.GlobalInt(utils.LightServeFlag.Name) > 0 {
 		var ethService *eth.Ethereum
 		if err := stack.Service(&ethService); err != nil {
 			utils.Fatalf("Failed to retrieve ethereum service: %v", err)

--- a/cmd/geth/usage.go
+++ b/cmd/geth/usage.go
@@ -82,6 +82,13 @@ var AppHelpFlagGroups = []flagGroup{
 			utils.GCModeFlag,
 			utils.EthStatsURLFlag,
 			utils.IdentityFlag,
+			utils.LightKDFFlag,
+			utils.WhitelistFlag,
+		},
+	},
+	{
+		Name: "LES",
+		Flags: []cli.Flag{
 			utils.LightServFlag,
 			utils.LightBandwidthInFlag,
 			utils.LightBandwidthOutFlag,
@@ -89,8 +96,6 @@ var AppHelpFlagGroups = []flagGroup{
 			utils.UltraLightServersFlag,
 			utils.UltraLightFractionFlag,
 			utils.UltraLightOnlyAnnounceFlag,
-			utils.LightKDFFlag,
-			utils.WhitelistFlag,
 		},
 	},
 	{

--- a/cmd/geth/usage.go
+++ b/cmd/geth/usage.go
@@ -87,12 +87,12 @@ var AppHelpFlagGroups = []flagGroup{
 		},
 	},
 	{
-		Name: "LES",
+		Name: "LIGHT CLIENT",
 		Flags: []cli.Flag{
-			utils.LightServFlag,
-			utils.LightBandwidthInFlag,
-			utils.LightBandwidthOutFlag,
-			utils.LightPeersFlag,
+			utils.LightServeFlag,
+			utils.LightIngressFlag,
+			utils.LightEgressFlag,
+			utils.LightMaxPeersFlag,
 			utils.UltraLightServersFlag,
 			utils.UltraLightFractionFlag,
 			utils.UltraLightOnlyAnnounceFlag,
@@ -253,6 +253,8 @@ var AppHelpFlagGroups = []flagGroup{
 	{
 		Name: "DEPRECATED",
 		Flags: []cli.Flag{
+			utils.LightLegacyServFlag,
+			utils.LightLegacyPeersFlag,
 			utils.MinerLegacyThreadsFlag,
 			utils.MinerLegacyGasTargetFlag,
 			utils.MinerLegacyGasPriceFlag,

--- a/eth/config.go
+++ b/eth/config.go
@@ -102,10 +102,10 @@ type Config struct {
 	Whitelist map[uint64]common.Hash `toml:"-"`
 
 	// Light client options
-	LightServ         int `toml:",omitempty"` // Maximum percentage of time allowed for serving LES requests
-	LightBandwidthIn  int `toml:",omitempty"` // Incoming bandwidth limit for light servers
-	LightBandwidthOut int `toml:",omitempty"` // Outgoing bandwidth limit for light servers
-	LightPeers        int `toml:",omitempty"` // Maximum number of LES client peers
+	LightServ    int `toml:",omitempty"` // Maximum percentage of time allowed for serving LES requests
+	LightIngress int `toml:",omitempty"` // Incoming bandwidth limit for light servers
+	LightEgress  int `toml:",omitempty"` // Outgoing bandwidth limit for light servers
+	LightPeers   int `toml:",omitempty"` // Maximum number of LES client peers
 
 	// Ultra Light client options
 	UltraLightServers      []string `toml:",omitempty"` // List of trusted ultra light servers

--- a/eth/gen_config.go
+++ b/eth/gen_config.go
@@ -25,8 +25,8 @@ func (c Config) MarshalTOML() (interface{}, error) {
 		NoPrefetch              bool
 		Whitelist               map[uint64]common.Hash `toml:"-"`
 		LightServ               int                    `toml:",omitempty"`
-		LightBandwidthIn        int                    `toml:",omitempty"`
-		LightBandwidthOut       int                    `toml:",omitempty"`
+		LightIngress            int                    `toml:",omitempty"`
+		LightEgress             int                    `toml:",omitempty"`
 		LightPeers              int                    `toml:",omitempty"`
 		UltraLightServers       []string               `toml:",omitempty"`
 		UltraLightFraction      int                    `toml:",omitempty"`
@@ -58,8 +58,8 @@ func (c Config) MarshalTOML() (interface{}, error) {
 	enc.NoPrefetch = c.NoPrefetch
 	enc.Whitelist = c.Whitelist
 	enc.LightServ = c.LightServ
-	enc.LightBandwidthIn = c.LightBandwidthIn
-	enc.LightBandwidthOut = c.LightBandwidthOut
+	enc.LightIngress = c.LightIngress
+	enc.LightEgress = c.LightEgress
 	enc.LightPeers = c.LightPeers
 	enc.UltraLightServers = c.UltraLightServers
 	enc.UltraLightFraction = c.UltraLightFraction
@@ -95,8 +95,8 @@ func (c *Config) UnmarshalTOML(unmarshal func(interface{}) error) error {
 		NoPrefetch              *bool
 		Whitelist               map[uint64]common.Hash `toml:"-"`
 		LightServ               *int                   `toml:",omitempty"`
-		LightBandwidthIn        *int                   `toml:",omitempty"`
-		LightBandwidthOut       *int                   `toml:",omitempty"`
+		LightIngress            *int                   `toml:",omitempty"`
+		LightEgress             *int                   `toml:",omitempty"`
 		LightPeers              *int                   `toml:",omitempty"`
 		UltraLightServers       []string               `toml:",omitempty"`
 		UltraLightFraction      *int                   `toml:",omitempty"`
@@ -145,11 +145,11 @@ func (c *Config) UnmarshalTOML(unmarshal func(interface{}) error) error {
 	if dec.LightServ != nil {
 		c.LightServ = *dec.LightServ
 	}
-	if dec.LightBandwidthIn != nil {
-		c.LightBandwidthIn = *dec.LightBandwidthIn
+	if dec.LightIngress != nil {
+		c.LightIngress = *dec.LightIngress
 	}
-	if dec.LightBandwidthOut != nil {
-		c.LightBandwidthOut = *dec.LightBandwidthOut
+	if dec.LightEgress != nil {
+		c.LightEgress = *dec.LightEgress
 	}
 	if dec.LightPeers != nil {
 		c.LightPeers = *dec.LightPeers

--- a/les/costtracker.go
+++ b/les/costtracker.go
@@ -139,11 +139,11 @@ func newCostTracker(db ethdb.Database, config *eth.Config) (*costTracker, uint64
 		reqInfoCh:  make(chan reqInfo, 100),
 		utilTarget: utilTarget,
 	}
-	if config.LightBandwidthIn > 0 {
-		ct.inSizeFactor = utilTarget / float64(config.LightBandwidthIn)
+	if config.LightIngress > 0 {
+		ct.inSizeFactor = utilTarget / float64(config.LightIngress)
 	}
-	if config.LightBandwidthOut > 0 {
-		ct.outSizeFactor = utilTarget / float64(config.LightBandwidthOut)
+	if config.LightEgress > 0 {
+		ct.outSizeFactor = utilTarget / float64(config.LightEgress)
 	}
 	if makeCostStats {
 		ct.stats = make(map[uint64][]uint64)


### PR DESCRIPTION
This PR is based on #19814.

This PR encapsulates all les relative options and categories these options into `LES`.