### PR TITLE
signer/core: fix reference issue in key derivation

### DIFF
--- a/accounts/usbwallet/wallet.go
+++ b/accounts/usbwallet/wallet.go
@@ -479,6 +479,7 @@ func (w *wallet) Derive(path accounts.DerivationPath, pin bool) (accounts.Accoun
 
 	if _, ok := w.paths[address]; !ok {
 		w.accounts = append(w.accounts, account)
+		w.paths[address] = make(accounts.DerivationPath, len(path))
 		copy(w.paths[address], path)
 	}
 	return account, nil

--- a/accounts/usbwallet/wallet.go
+++ b/accounts/usbwallet/wallet.go
@@ -479,7 +479,7 @@ func (w *wallet) Derive(path accounts.DerivationPath, pin bool) (accounts.Accoun
 
 	if _, ok := w.paths[address]; !ok {
 		w.accounts = append(w.accounts, account)
-		w.paths[address] = path
+		copy(w.paths[address], path)
 	}
 	return account, nil
 }


### PR DESCRIPTION
Currently in ~~`clé`~~ `clef`, the derivation process reuses the same derivation path array as input to the `Derive` function. That `Derive` function creates an account and keeps a pointer to the derivation path for other purposes.

Since the derivation path gets updated each time `Derive` is called, all accounts end up having the rug pulled from under their feet: the derivation path they point to will be that of the first non-valid account.

So this PR simply makes sure that one derivation path is allocated each time.