### PR TITLE
accounts/usbwallet: trezor signed message support

### DIFF
--- a/accounts/usbwallet/ledger.go
+++ b/accounts/usbwallet/ledger.go
@@ -169,7 +169,7 @@ func (w *ledgerDriver) SignTx(path accounts.DerivationPath, tx *types.Transactio
 }
 
 // SignData sends a blob of data to the USB device and waits for the user to confirm
-// or deny the transaction.
+// or deny the signing request.
 func (w *ledgerDriver) SignData(path accounts.DerivationPath, hash []byte) (common.Address, []byte, error) {
 	return common.Address{}, nil, accounts.ErrNotSupported
 }

--- a/accounts/usbwallet/ledger.go
+++ b/accounts/usbwallet/ledger.go
@@ -168,6 +168,12 @@ func (w *ledgerDriver) SignTx(path accounts.DerivationPath, tx *types.Transactio
 	return w.ledgerSign(path, tx, chainID)
 }
 
+// SignData sends a blob of data to the USB device and waits for the user to confirm
+// or deny the transaction.
+func (w *ledgerDriver) SignData(path accounts.DerivationPath, hash []byte) (common.Address, []byte, error) {
+	return common.Address{}, nil, accounts.ErrNotSupported
+}
+
 // ledgerVersion retrieves the current version of the Ethereum wallet app running
 // on the Ledger wallet.
 //

--- a/accounts/usbwallet/ledger.go
+++ b/accounts/usbwallet/ledger.go
@@ -170,7 +170,7 @@ func (w *ledgerDriver) SignTx(path accounts.DerivationPath, tx *types.Transactio
 
 // SignData sends a blob of data to the USB device and waits for the user to confirm
 // or deny the signing request.
-func (w *ledgerDriver) SignData(path accounts.DerivationPath, hash []byte) (common.Address, []byte, error) {
+func (w *ledgerDriver) SignData(path accounts.DerivationPath, data []byte) (common.Address, []byte, error) {
 	return common.Address{}, nil, accounts.ErrNotSupported
 }
 

--- a/accounts/usbwallet/trezor.go
+++ b/accounts/usbwallet/trezor.go
@@ -185,12 +185,12 @@ func (w *trezorDriver) SignTx(path accounts.DerivationPath, tx *types.Transactio
 	return w.trezorSign(path, tx, chainID)
 }
 
-// SignData sends a blob of data to the xUSB device and waits for the user to confirm
-// or deny the transaction.
-func (w *trezorDriver) SignData(path accounts.DerivationPath, hash []byte) (common.Address, []byte, error) {
+// SignData sends a blob of data to the USB device and waits for the user to confirm
+// or deny the signing request.
+func (w *trezorDriver) SignData(path accounts.DerivationPath, data []byte) (common.Address, []byte, error) {
 	request := &trezor.EthereumSignMessage{
 		AddressN: path,
-		Message:  hash,
+		Message:  data,
 	}
 	response := new(trezor.EthereumMessageSignature)
 	if _, err := w.trezorExchange(request, response); err != nil {

--- a/accounts/usbwallet/wallet.go
+++ b/accounts/usbwallet/wallet.go
@@ -29,7 +29,6 @@ import (
 	"github.com/ethereum/go-ethereum/accounts"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
-	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/karalabe/usb"
 )
@@ -518,7 +517,7 @@ func (w *wallet) SelfDerive(bases []accounts.DerivationPath, chain ethereum.Chai
 
 // signHash implements accounts.Wallet, however signing arbitrary data is not
 // supported for hardware wallets, so this method will always return an error.
-func (w *wallet) signHash(account accounts.Account, hash []byte) ([]byte, error) {
+func (w *wallet) signData(account accounts.Account, data []byte) ([]byte, error) {
 	w.stateLock.RLock() // Comms have their own mutex
 	defer w.stateLock.RUnlock()
 
@@ -549,7 +548,7 @@ func (w *wallet) signHash(account accounts.Account, hash []byte) ([]byte, error)
 	}()
 
 	// Sign the transaction and verify the sender to avoid hardware fault surprises
-	sender, signed, err := w.driver.SignData(path, hash)
+	sender, signed, err := w.driver.SignData(path, data)
 	if err != nil {
 		return nil, err
 	}
@@ -561,7 +560,7 @@ func (w *wallet) signHash(account accounts.Account, hash []byte) ([]byte, error)
 
 // SignData signs keccak256(data). The mimetype parameter describes the type of data being signed
 func (w *wallet) SignData(account accounts.Account, mimeType string, data []byte) ([]byte, error) {
-	return w.signHash(account, crypto.Keccak256(data))
+	return w.signData(account, data)
 }
 
 // SignDataWithPassphrase implements accounts.Wallet, attempting to sign the given
@@ -572,7 +571,7 @@ func (w *wallet) SignDataWithPassphrase(account accounts.Account, passphrase, mi
 }
 
 func (w *wallet) SignText(account accounts.Account, text []byte) ([]byte, error) {
-	return w.signHash(account, accounts.TextHash(text))
+	return w.signData(account, accounts.TextHash(text))
 }
 
 // SignTx implements accounts.Wallet. It sends the transaction over to the Ledger

--- a/accounts/usbwallet/wallet.go
+++ b/accounts/usbwallet/wallet.go
@@ -515,7 +515,7 @@ func (w *wallet) SelfDerive(bases []accounts.DerivationPath, chain ethereum.Chai
 	w.deriveChain = chain
 }
 
-// signHash implements accounts.Wallet, however signing arbitrary data is not
+// signData implements accounts.Wallet, however signing arbitrary data is not
 // supported for hardware wallets, so this method will always return an error.
 func (w *wallet) signData(account accounts.Account, data []byte) ([]byte, error) {
 	w.stateLock.RLock() // Comms have their own mutex

--- a/accounts/usbwallet/wallet.go
+++ b/accounts/usbwallet/wallet.go
@@ -69,7 +69,7 @@ type driver interface {
 	SignTx(path accounts.DerivationPath, tx *types.Transaction, chainID *big.Int) (common.Address, *types.Transaction, error)
 
 	// SignData sends a blob of data to the USB device and waits for the user to confirm
-	// or deny the transaction.
+	// or deny the signing request.
 	SignData(path accounts.DerivationPath, hash []byte) (common.Address, []byte, error)
 }
 

--- a/signer/core/signed_data.go
+++ b/signer/core/signed_data.go
@@ -144,7 +144,7 @@ func (api *SignerAPI) sign(addr common.MixedcaseAddress, req *SignDataRequest, l
 	}
 	// Only ask for the passphrase if the account is keystore based
 	pw := ""
-	if strings.Compare(wallet.URL().Scheme, "keystore") == 0 {
+	if wallet.URL().Scheme == "keystore" {
 		pw, err = api.lookupOrQueryPassword(account.Address,
 			"Password for signing",
 			fmt.Sprintf("Please enter password for signing data with account %s", account.Address.Hex()))

--- a/signer/core/signed_data.go
+++ b/signer/core/signed_data.go
@@ -142,11 +142,15 @@ func (api *SignerAPI) sign(addr common.MixedcaseAddress, req *SignDataRequest, l
 	if err != nil {
 		return nil, err
 	}
-	pw, err := api.lookupOrQueryPassword(account.Address,
-		"Password for signing",
-		fmt.Sprintf("Please enter password for signing data with account %s, or just press 'RETURN'", account.Address.Hex()))
-	if err != nil {
-		return nil, err
+	// Only ask for the passphrase if the account is keystore based
+	pw := ""
+	if strings.Compare(wallet.URL().Scheme, "keystore") == 0 {
+		pw, err = api.lookupOrQueryPassword(account.Address,
+			"Password for signing",
+			fmt.Sprintf("Please enter password for signing data with account %s", account.Address.Hex()))
+		if err != nil {
+			return nil, err
+		}
 	}
 	// Sign the data with the wallet
 	signature, err := wallet.SignDataWithPassphrase(account, pw, req.ContentType, req.Rawdata)

--- a/signer/core/signed_data.go
+++ b/signer/core/signed_data.go
@@ -144,7 +144,7 @@ func (api *SignerAPI) sign(addr common.MixedcaseAddress, req *SignDataRequest, l
 	}
 	pw, err := api.lookupOrQueryPassword(account.Address,
 		"Password for signing",
-		fmt.Sprintf("Please enter password for signing data with account %s", account.Address.Hex()))
+		fmt.Sprintf("Please enter password for signing data with account %s, or just press 'RETURN'", account.Address.Hex()))
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Implements `signData` for trezor. This has been tested with both the pre-1.8 version of the firmware and the latest. Fixes #19812 

**To work, this PR needs #19827**