### PR TITLE
all: replace t.Log(); t.FailNow() with t.Fatal()

### DIFF
--- a/accounts/abi/abi_test.go
+++ b/accounts/abi/abi_test.go
@@ -20,7 +20,6 @@ import (
 	"bytes"
 	"encoding/hex"
 	"fmt"
-	"log"
 	"math/big"
 	"reflect"
 	"strings"
@@ -102,8 +101,7 @@ func TestReader(t *testing.T) {
 func TestTestNumbers(t *testing.T) {
 	abi, err := JSON(strings.NewReader(jsondata2))
 	if err != nil {
-		t.Error(err)
-		t.FailNow()
+		t.Fatal(err)
 	}
 
 	if _, err := abi.Pack("balance"); err != nil {
@@ -140,8 +138,7 @@ func TestTestNumbers(t *testing.T) {
 func TestTestString(t *testing.T) {
 	abi, err := JSON(strings.NewReader(jsondata2))
 	if err != nil {
-		t.Error(err)
-		t.FailNow()
+		t.Fatal(err)
 	}
 
 	if _, err := abi.Pack("string", "hello world"); err != nil {
@@ -152,8 +149,7 @@ func TestTestString(t *testing.T) {
 func TestTestBool(t *testing.T) {
 	abi, err := JSON(strings.NewReader(jsondata2))
 	if err != nil {
-		t.Error(err)
-		t.FailNow()
+		t.Fatal(err)
 	}
 
 	if _, err := abi.Pack("bool", true); err != nil {
@@ -164,8 +160,7 @@ func TestTestBool(t *testing.T) {
 func TestTestSlice(t *testing.T) {
 	abi, err := JSON(strings.NewReader(jsondata2))
 	if err != nil {
-		t.Error(err)
-		t.FailNow()
+		t.Fatal(err)
 	}
 
 	slice := make([]uint64, 2)
@@ -221,8 +216,7 @@ func TestMethodSignature(t *testing.T) {
 func TestMultiPack(t *testing.T) {
 	abi, err := JSON(strings.NewReader(jsondata2))
 	if err != nil {
-		t.Error(err)
-		t.FailNow()
+		t.Fatal(err)
 	}
 
 	sig := crypto.Keccak256([]byte("bar(uint32,uint16)"))[:4]
@@ -232,10 +226,8 @@ func TestMultiPack(t *testing.T) {
 
 	packed, err := abi.Pack("bar", uint32(10), uint16(11))
 	if err != nil {
-		t.Error(err)
-		t.FailNow()
+		t.Fatal(err)
 	}
-
 	if !bytes.Equal(packed, sig) {
 		t.Errorf("expected %x got %x", sig, packed)
 	}
@@ -246,11 +238,11 @@ func ExampleJSON() {
 
 	abi, err := JSON(strings.NewReader(definition))
 	if err != nil {
-		log.Fatalln(err)
+		panic(err)
 	}
 	out, err := abi.Pack("isBar", common.HexToAddress("01"))
 	if err != nil {
-		log.Fatalln(err)
+		panic(err)
 	}
 
 	fmt.Printf("%x\n", out)

--- a/core/types/transaction_test.go
+++ b/core/types/transaction_test.go
@@ -89,17 +89,15 @@ func TestRecipientEmpty(t *testing.T) {
 	_, addr := defaultTestKey()
 	tx, err := decodeTx(common.Hex2Bytes("f8498080808080011ca09b16de9d5bdee2cf56c28d16275a4da68cd30273e2525f3959f5d62557489921a0372ebd8fb3345f7db7b5a86d42e24d36e983e259b0664ceb8c227ec9af572f3d"))
 	if err != nil {
-		t.Error(err)
-		t.FailNow()
+		t.Fatal(err)
 	}
 
 	from, err := Sender(HomesteadSigner{}, tx)
 	if err != nil {
-		t.Error(err)
-		t.FailNow()
+		t.Fatal(err)
 	}
 	if addr != from {
-		t.Error("derived address doesn't match")
+		t.Fatal("derived address doesn't match")
 	}
 }
 
@@ -108,18 +106,15 @@ func TestRecipientNormal(t *testing.T) {
 
 	tx, err := decodeTx(common.Hex2Bytes("f85d80808094000000000000000000000000000000000000000080011ca0527c0d8f5c63f7b9f41324a7c8a563ee1190bcbf0dac8ab446291bdbf32f5c79a0552c4ef0a09a04395074dab9ed34d3fbfb843c2f2546cc30fe89ec143ca94ca6"))
 	if err != nil {
-		t.Error(err)
-		t.FailNow()
+		t.Fatal(err)
 	}
 
 	from, err := Sender(HomesteadSigner{}, tx)
 	if err != nil {
-		t.Error(err)
-		t.FailNow()
+		t.Fatal(err)
 	}
-
 	if addr != from {
-		t.Error("derived address doesn't match")
+		t.Fatal("derived address doesn't match")
 	}
 }
 

--- a/crypto/ecies/ecies_test.go
+++ b/crypto/ecies/ecies_test.go
@@ -58,12 +58,10 @@ func TestKDF(t *testing.T) {
 
 	k, err := concatKDF(h, msg, nil, 64)
 	if err != nil {
-		t.Log(err.Error())
-		t.FailNow()
+		t.Fatal(err)
 	}
 	if len(k) != 64 {
-		t.Logf("KDF: generated key is the wrong size (%d instead of 64\n", len(k))
-		t.FailNow()
+		t.Fatalf("KDF: generated key is the wrong size (%d instead of 64\n", len(k))
 	}
 }
 
@@ -97,32 +95,27 @@ func cmpPublic(pub1, pub2 PublicKey) bool {
 func TestSharedKey(t *testing.T) {
 	prv1, err := GenerateKey(rand.Reader, DefaultCurve, nil)
 	if err != nil {
-		t.Log(err.Error())
-		t.FailNow()
+		t.Fatal(err)
 	}
 	skLen := MaxSharedKeyLength(&prv1.PublicKey) / 2
 
 	prv2, err := GenerateKey(rand.Reader, DefaultCurve, nil)
 	if err != nil {
-		t.Log(err.Error())
-		t.FailNow()
+		t.Fatal(err)
 	}
 
 	sk1, err := prv1.GenerateShared(&prv2.PublicKey, skLen, skLen)
 	if err != nil {
-		t.Log(err.Error())
-		t.FailNow()
+		t.Fatal(err)
 	}
 
 	sk2, err := prv2.GenerateShared(&prv1.PublicKey, skLen, skLen)
 	if err != nil {
-		t.Log(err.Error())
-		t.FailNow()
+		t.Fatal(err)
 	}
 
 	if !bytes.Equal(sk1, sk2) {
-		t.Log(ErrBadSharedKeys.Error())
-		t.FailNow()
+		t.Fatal(ErrBadSharedKeys)
 	}
 }
 
@@ -169,26 +162,22 @@ func TestSharedKeyPadding(t *testing.T) {
 func TestTooBigSharedKey(t *testing.T) {
 	prv1, err := GenerateKey(rand.Reader, DefaultCurve, nil)
 	if err != nil {
-		t.Log(err.Error())
-		t.FailNow()
+		t.Fatal(err)
 	}
 
 	prv2, err := GenerateKey(rand.Reader, DefaultCurve, nil)
 	if err != nil {
-		t.Log(err.Error())
-		t.FailNow()
+		t.Fatal(err)
 	}
 
 	_, err = prv1.GenerateShared(&prv2.PublicKey, 32, 32)
 	if err != ErrSharedKeyTooBig {
-		t.Log("ecdh: shared key should be too large for curve")
-		t.FailNow()
+		t.Fatal("ecdh: shared key should be too large for curve")
 	}
 
 	_, err = prv2.GenerateShared(&prv1.PublicKey, 32, 32)
 	if err != ErrSharedKeyTooBig {
-		t.Log("ecdh: shared key should be too large for curve")
-		t.FailNow()
+		t.Fatal("ecdh: shared key should be too large for curve")
 	}
 }
 
@@ -196,8 +185,7 @@ func TestTooBigSharedKey(t *testing.T) {
 func BenchmarkGenerateKeyP256(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		if _, err := GenerateKey(rand.Reader, elliptic.P256(), nil); err != nil {
-			b.Log(err.Error())
-			b.FailNow()
+			b.Fatal(err)
 		}
 	}
 }
@@ -206,15 +194,13 @@ func BenchmarkGenerateKeyP256(b *testing.B) {
 func BenchmarkGenSharedKeyP256(b *testing.B) {
 	prv, err := GenerateKey(rand.Reader, elliptic.P256(), nil)
 	if err != nil {
-		b.Log(err.Error())
-		b.FailNow()
+		b.Fatal(err)
 	}
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		_, err := prv.GenerateShared(&prv.PublicKey, 16, 16)
 		if err != nil {
-			b.Log(err.Error())
-			b.FailNow()
+			b.Fatal(err)
 		}
 	}
 }
@@ -223,15 +209,13 @@ func BenchmarkGenSharedKeyP256(b *testing.B) {
 func BenchmarkGenSharedKeyS256(b *testing.B) {
 	prv, err := GenerateKey(rand.Reader, crypto.S256(), nil)
 	if err != nil {
-		b.Log(err.Error())
-		b.FailNow()
+		b.Fatal(err)
 	}
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		_, err := prv.GenerateShared(&prv.PublicKey, 16, 16)
 		if err != nil {
-			b.Log(err.Error())
-			b.FailNow()
+			b.Fatal(err)
 		}
 	}
 }
@@ -240,38 +224,32 @@ func BenchmarkGenSharedKeyS256(b *testing.B) {
 func TestEncryptDecrypt(t *testing.T) {
 	prv1, err := GenerateKey(rand.Reader, DefaultCurve, nil)
 	if err != nil {
-		t.Log(err.Error())
-		t.FailNow()
+		t.Fatal(err)
 	}
 
 	prv2, err := GenerateKey(rand.Reader, DefaultCurve, nil)
 	if err != nil {
-		t.Log(err.Error())
-		t.FailNow()
+		t.Fatal(err)
 	}
 
 	message := []byte("Hello, world.")
 	ct, err := Encrypt(rand.Reader, &prv2.PublicKey, message, nil, nil)
 	if err != nil {
-		t.Log(err.Error())
-		t.FailNow()
+		t.Fatal(err)
 	}
 
 	pt, err := prv2.Decrypt(ct, nil, nil)
 	if err != nil {
-		t.Log(err.Error())
-		t.FailNow()
+		t.Fatal(err)
 	}
 
 	if !bytes.Equal(pt, message) {
-		t.Log("ecies: plaintext doesn't match message")
-		t.FailNow()
+		t.Fatal("ecies: plaintext doesn't match message")
 	}
 
 	_, err = prv1.Decrypt(ct, nil, nil)
 	if err == nil {
-		t.Log("ecies: encryption should not have succeeded")
-		t.FailNow()
+		t.Fatal("ecies: encryption should not have succeeded")
 	}
 }
 
@@ -341,50 +319,39 @@ func TestParamSelection(t *testing.T) {
 func testParamSelection(t *testing.T, c testCase) {
 	params := ParamsFromCurve(c.Curve)
 	if params == nil && c.Expected != nil {
-		t.Logf("%s (%s)\n", ErrInvalidParams.Error(), c.Name)
-		t.FailNow()
+		t.Fatalf("%s (%s)\n", ErrInvalidParams.Error(), c.Name)
 	} else if params != nil && !cmpParams(params, c.Expected) {
-		t.Logf("ecies: parameters should be invalid (%s)\n",
-			c.Name)
-		t.FailNow()
+		t.Fatalf("ecies: parameters should be invalid (%s)\n", c.Name)
 	}
 
 	prv1, err := GenerateKey(rand.Reader, DefaultCurve, nil)
 	if err != nil {
-		t.Logf("%s (%s)\n", err.Error(), c.Name)
-		t.FailNow()
+		t.Fatalf("%s (%s)\n", err.Error(), c.Name)
 	}
 
 	prv2, err := GenerateKey(rand.Reader, DefaultCurve, nil)
 	if err != nil {
-		t.Logf("%s (%s)\n", err.Error(), c.Name)
-		t.FailNow()
+		t.Fatalf("%s (%s)\n", err.Error(), c.Name)
 	}
 
 	message := []byte("Hello, world.")
 	ct, err := Encrypt(rand.Reader, &prv2.PublicKey, message, nil, nil)
 	if err != nil {
-		t.Logf("%s (%s)\n", err.Error(), c.Name)
-		t.FailNow()
+		t.Fatalf("%s (%s)\n", err.Error(), c.Name)
 	}
 
 	pt, err := prv2.Decrypt(ct, nil, nil)
 	if err != nil {
-		t.Logf("%s (%s)\n", err.Error(), c.Name)
-		t.FailNow()
+		t.Fatalf("%s (%s)\n", err.Error(), c.Name)
 	}
 
 	if !bytes.Equal(pt, message) {
-		t.Logf("ecies: plaintext doesn't match message (%s)\n",
-			c.Name)
-		t.FailNow()
+		t.Fatalf("ecies: plaintext doesn't match message (%s)\n", c.Name)
 	}
 
 	_, err = prv1.Decrypt(ct, nil, nil)
 	if err == nil {
-		t.Logf("ecies: encryption should not have succeeded (%s)\n",
-			c.Name)
-		t.FailNow()
+		t.Fatalf("ecies: encryption should not have succeeded (%s)\n", c.Name)
 	}
 
 }
@@ -396,23 +363,20 @@ func TestBasicKeyValidation(t *testing.T) {
 
 	prv, err := GenerateKey(rand.Reader, DefaultCurve, nil)
 	if err != nil {
-		t.Log(err.Error())
-		t.FailNow()
+		t.Fatal(err)
 	}
 
 	message := []byte("Hello, world.")
 	ct, err := Encrypt(rand.Reader, &prv.PublicKey, message, nil, nil)
 	if err != nil {
-		t.Log(err.Error())
-		t.FailNow()
+		t.Fatal(err)
 	}
 
 	for _, b := range badBytes {
 		ct[0] = b
 		_, err := prv.Decrypt(ct, nil, nil)
 		if err != ErrInvalidPublicKey {
-			t.Log("ecies: validated an invalid key")
-			t.FailNow()
+			t.Fatal("ecies: validated an invalid key")
 		}
 	}
 }
@@ -450,19 +414,16 @@ func TestSharedKeyStatic(t *testing.T) {
 
 	sk1, err := prv1.GenerateShared(&prv2.PublicKey, skLen, skLen)
 	if err != nil {
-		t.Log(err.Error())
-		t.FailNow()
+		t.Fatal(err)
 	}
 
 	sk2, err := prv2.GenerateShared(&prv1.PublicKey, skLen, skLen)
 	if err != nil {
-		t.Log(err.Error())
-		t.FailNow()
+		t.Fatal(err)
 	}
 
 	if !bytes.Equal(sk1, sk2) {
-		t.Log(ErrBadSharedKeys.Error())
-		t.FailNow()
+		t.Fatal(ErrBadSharedKeys)
 	}
 
 	sk, _ := hex.DecodeString("167ccc13ac5e8a26b131c3446030c60fbfac6aa8e31149d0869f93626a4cdf62")

--- a/rpc/websocket_test.go
+++ b/rpc/websocket_test.go
@@ -21,34 +21,26 @@ import "testing"
 func TestWSGetConfigNoAuth(t *testing.T) {
 	config, err := wsGetConfig("ws://example.com:1234", "")
 	if err != nil {
-		t.Logf("wsGetConfig failed: %s", err)
-		t.Fail()
-		return
+		t.Fatalf("wsGetConfig failed: %s", err)
 	}
 	if config.Location.User != nil {
-		t.Log("User should have been stripped from the URL")
-		t.Fail()
+		t.Fatalf("User should have been stripped from the URL")
 	}
 	if config.Location.Hostname() != "example.com" ||
 		config.Location.Port() != "1234" || config.Location.Scheme != "ws" {
-		t.Logf("Unexpected URL: %s", config.Location)
-		t.Fail()
+		t.Fatalf("Unexpected URL: %s", config.Location)
 	}
 }
 
 func TestWSGetConfigWithBasicAuth(t *testing.T) {
 	config, err := wsGetConfig("wss://testuser:test-PASS_01@example.com:1234", "")
 	if err != nil {
-		t.Logf("wsGetConfig failed: %s", err)
-		t.Fail()
-		return
+		t.Fatalf("wsGetConfig failed: %s", err)
 	}
 	if config.Location.User != nil {
-		t.Log("User should have been stripped from the URL")
-		t.Fail()
+		t.Fatal("User should have been stripped from the URL")
 	}
 	if config.Header.Get("Authorization") != "Basic dGVzdHVzZXI6dGVzdC1QQVNTXzAx" {
-		t.Log("Basic auth header is incorrect")
-		t.Fail()
+		t.Fatal("Basic auth header is incorrect")
 	}
 }


### PR DESCRIPTION
This is a follow up to #19670, cleaning up those call sites a bit more.