### PR TITLE
Fix typos across go-ethereum repository

### DIFF
--- a/cmd/clef/rules.md
+++ b/cmd/clef/rules.md
@@ -70,7 +70,7 @@ The Otto vm has a few [caveats](https://github.com/robertkrimen/otto):
 Additionally, a few more have been added
 
 * The rule execution cannot load external javascript files.
-* The only preloaded libary is [`bignumber.js`](https://github.com/MikeMcl/bignumber.js) version `2.0.3`. This one is fairly old, and is not aligned with the documentation at the github repository.
+* The only preloaded library is [`bignumber.js`](https://github.com/MikeMcl/bignumber.js) version `2.0.3`. This one is fairly old, and is not aligned with the documentation at the github repository.
 * Each invocation is made in a fresh virtual machine. This means that you cannot store data in global variables between invocations. This is a deliberate choice -- if you want to store data, use the disk-backed `storage`, since rules should not rely on ephemeral data.
 * Javascript API parameters are _always_ an object. This is also a design choice, to ensure that parameters are accessed by _key_ and not by order. This is to prevent mistakes due to missing parameters or parameter changes.
 * The JS engine has access to `storage` and `console`.

--- a/cmd/clef/tutorial.md
+++ b/cmd/clef/tutorial.md
@@ -227,7 +227,7 @@ In this example:
     - Auto-rejected if the message does not contain `bazonk`,
 - Any other requests will be passed along for manual confirmation.
 
-*Note, to make this example work, please use you own accounts. You can create a new account either via Clef or the traditional account CLI tools. If the latter was chosen, make sure both Clef and Geth use the same keystore by specifing `--keystore path/to/your/keystore` when running Clef.*
+*Note, to make this example work, please use you own accounts. You can create a new account either via Clef or the traditional account CLI tools. If the latter was chosen, make sure both Clef and Geth use the same keystore by specifying `--keystore path/to/your/keystore` when running Clef.*
 
 Attest the new rule file so that Clef will accept loading it:
 

--- a/crypto/secp256k1/libsecp256k1/src/asm/field_10x26_arm.s
+++ b/crypto/secp256k1/libsecp256k1/src/asm/field_10x26_arm.s
@@ -23,7 +23,7 @@ Note:
 	.eabi_attribute 10, 0 @ Tag_FP_arch = none
 	.eabi_attribute 24, 1 @ Tag_ABI_align_needed = 8-byte
 	.eabi_attribute 25, 1 @ Tag_ABI_align_preserved = 8-byte, except leaf SP
-	.eabi_attribute 30, 2 @ Tag_ABI_optimization_goals = Agressive Speed
+	.eabi_attribute 30, 2 @ Tag_ABI_optimization_goals = Aggressive Speed
 	.eabi_attribute 34, 1 @ Tag_CPU_unaligned_access = v6
 	.text
 

--- a/eth/tracers/internal/tracers/evmdis_tracer.js
+++ b/eth/tracers/internal/tracers/evmdis_tracer.js
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
 
-// evmdisTracer returns sufficent information from a trace to perform evmdis-style
+// evmdisTracer returns sufficient information from a trace to perform evmdis-style
 // disassembly.
 {
 	stack: [{ops: []}],

--- a/internal/jsre/deps/web3.js
+++ b/internal/jsre/deps/web3.js
@@ -2231,7 +2231,7 @@ var toTwosComplement = function (number) {
  * Checks if the given string is strictly an address
  *
  * @method isStrictAddress
- * @param {String} address the given HEX adress
+ * @param {String} address the given HEX address
  * @return {Boolean}
 */
 var isStrictAddress = function (address) {
@@ -2242,7 +2242,7 @@ var isStrictAddress = function (address) {
  * Checks if the given string is an address
  *
  * @method isAddress
- * @param {String} address the given HEX adress
+ * @param {String} address the given HEX address
  * @return {Boolean}
 */
 var isAddress = function (address) {
@@ -2262,7 +2262,7 @@ var isAddress = function (address) {
  * Checks if the given string is a checksummed address
  *
  * @method isChecksumAddress
- * @param {String} address the given HEX adress
+ * @param {String} address the given HEX address
  * @return {Boolean}
 */
 var isChecksumAddress = function (address) {
@@ -2285,7 +2285,7 @@ var isChecksumAddress = function (address) {
  * Makes a checksum address
  *
  * @method toChecksumAddress
- * @param {String} address the given HEX adress
+ * @param {String} address the given HEX address
  * @return {String}
 */
 var toChecksumAddress = function (address) {
@@ -3003,7 +3003,7 @@ var ContractFactory = function (eth, abi) {
 
         if (callback) {
 
-            // wait for the contract address adn check if the code was deployed
+            // wait for the contract address and check if the code was deployed
             this.eth.sendTransaction(options, function (err, hash) {
                 if (err) {
                     callback(err);
@@ -6735,7 +6735,7 @@ var transferToAddress = function (eth, from, to, value, callback) {
  * @method deposit
  * @param {String} from
  * @param {String} to
- * @param {Value} value to be transfered
+ * @param {Value} value to be transferred
  * @param {String} client unique identifier
  * @param {Function} callback, callback
  */


### PR DESCRIPTION
Fix typos across **go-ethereum** repository

**Fixed Files**
```
go-ethereum/cmd/clef/rules.md:73:21: "libary" is a misspelling of "library"
go-ethereum/cmd/clef/tutorial.md:230:226: "specifing" is a misspelling of "specifying"
go-ethereum/crypto/secp256k1/libsecp256k1/src/asm/field_10x26_arm.s:26:54: "Agressive" is a misspelling of "Aggressive"
go-ethereum/eth/tracers/internal/tracers/evmdis_tracer.js:17:24: "sufficent" is a misspelling of "sufficient"
go-ethereum/internal/jsre/deps/web3.js:2234:41: "adress" is a misspelling of "address"
go-ethereum/internal/jsre/deps/web3.js:2245:41: "adress" is a misspelling of "address"
go-ethereum/internal/jsre/deps/web3.js:2265:41: "adress" is a misspelling of "address"
go-ethereum/internal/jsre/deps/web3.js:2288:41: "adress" is a misspelling of "address"
go-ethereum/internal/jsre/deps/web3.js:2310:52: "addres" is a misspelling of "address"
go-ethereum/internal/jsre/deps/web3.js:3006:45: "adn" is a misspelling of "and"
go-ethereum/internal/jsre/deps/web3.js:6738:30: "transfered" is a misspelling of "transferred"
```

Do we need to fix this one too? **`go-ethereum/dashboard/assets.go`**

```
go-ethereum/dashboard/assets.go:38135:2770: "intergration" is a misspelling of "integration"
go-ethereum/dashboard/assets.go:38361:1989: "seperated" is a misspelling of "separated"
go-ethereum/dashboard/assets.go:38367:1262: "enviroments" is a misspelling of "environments"
go-ethereum/dashboard/assets.go:38367:2298: "enviroments" is a misspelling of "environments"
go-ethereum/dashboard/assets.go:38367:4643: "predictible" is a misspelling of "predictable"
```