### PR TITLE
consensus/ethash: better block submission pow verification

### DIFF
--- a/consensus/ethash/ethash.go
+++ b/consensus/ethash/ethash.go
@@ -223,7 +223,7 @@ func (c *cache) generate(dir string, limit int, test bool) {
 			size = 1024
 		}
 		// If we don't store anything on disk, generate and return.
-		if dir == "" {
+		if dir == "" || limit <= 0 {
 			c.cache = make([]uint32, size/4)
 			generateCache(c.cache, c.epoch, seed)
 			return
@@ -305,7 +305,7 @@ func (d *dataset) generate(dir string, limit int, test bool) {
 			dsize = 32 * 1024
 		}
 		// If we don't store anything on disk, generate and return
-		if dir == "" {
+		if dir == "" || limit <= 0 {
 			cache := make([]uint32, csize/4)
 			generateCache(cache, d.epoch, seed)
 

--- a/consensus/ethash/sealer.go
+++ b/consensus/ethash/sealer.go
@@ -269,7 +269,7 @@ func (ethash *Ethash) remote(notify []string, noverify bool) {
 
 		start := time.Now()
 		if !noverify {
-			if err := ethash.verifySeal(nil, header, true); err != nil {
+			if err := ethash.verifySeal(nil, header, false); err != nil {
 				log.Warn("Invalid proof-of-work submitted", "sealhash", sealhash, "elapsed", common.PrettyDuration(time.Since(start)), "err", err)
 				return false
 			}


### PR DESCRIPTION
The block submission RPC in current geth takes some non-trivial time (>1s).

- It uses the full DAG to verify PoW solution.
- The full DAG is actually mmaped. The random access of DAG causes swap I/O operations.

This PR addresses the issue by making the following changes.

- Uses light version of PoW verification for block submission.
- Disable mmap for PoW verification cache/dataset if we are not storing them on disk.

In worst case it is using mmaped light cache to verify block submission, which is way smaller and the speed would be faster than full DAG verification. And it is still not bad comparing full DAG if no mmap is used. A modern machine can do a light verification within 2ms and it is trivial for block submission, which occurs only every 10 to 15 seconds.