### PR TITLE
p2p/enode: use unix timestamp as base ENR sequence number

### DIFF
--- a/p2p/discover/v5wire/encoding_test.go
+++ b/p2p/discover/v5wire/encoding_test.go
@@ -512,9 +512,6 @@ func (n *handshakeTestNode) init(key *ecdsa.PrivateKey, ip net.IP, clock mclock.
 	db, _ := enode.OpenDB("")
 	n.ln = enode.NewLocalNode(db, key)
 	n.ln.SetStaticIP(ip)
-	if n.ln.Node().Seq() != 1 {
-		panic(fmt.Errorf("unexpected seq %d", n.ln.Node().Seq()))
-	}
 	n.c = NewCodec(n.ln, key, clock)
 }
 

--- a/p2p/enode/localnode_test.go
+++ b/p2p/enode/localnode_test.go
@@ -20,7 +20,6 @@ import (
 	"math/rand"
 	"net"
 	"testing"
-	"time"
 
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/p2p/enr"
@@ -34,10 +33,6 @@ func newLocalNodeForTesting() (*LocalNode, *DB) {
 }
 
 func TestLocalNode(t *testing.T) {
-	// Disable throttling for this test
-	defer func(throttle time.Duration) { recordUpdateThrottle = throttle }(recordUpdateThrottle)
-	recordUpdateThrottle = 0
-
 	ln, db := newLocalNodeForTesting()
 	defer db.Close()
 
@@ -54,49 +49,45 @@ func TestLocalNode(t *testing.T) {
 	}
 }
 
+// This test checks that the sequence number is persisted between restarts.
 func TestLocalNodeSeqPersist(t *testing.T) {
-	// Disable throttling for this test
-	defer func(throttle time.Duration) { recordUpdateThrottle = throttle }(recordUpdateThrottle)
-	recordUpdateThrottle = 0
-
-	timestamp := uint64(time.Now().Unix())
+	timestamp := nowMilliseconds()
 
 	ln, db := newLocalNodeForTesting()
 	defer db.Close()
 
-	if s := ln.Node().Seq(); s != timestamp+1 {
-		t.Fatalf("wrong initial seq %d, want %d", s, timestamp+1)
+	initialSeq := ln.Node().Seq()
+	if initialSeq < timestamp {
+		t.Fatalf("wrong initial seq %d, want at least %d", initialSeq, timestamp)
 	}
+
 	ln.Set(enr.WithEntry("x", uint(1)))
-	if s := ln.Node().Seq(); s != timestamp+2 {
-		t.Fatalf("wrong seq %d after set, want 2", s)
+	if s := ln.Node().Seq(); s != initialSeq+1 {
+		t.Fatalf("wrong seq %d after set, want %d", s, initialSeq+1)
 	}
 
 	// Create a new instance, it should reload the sequence number.
 	// The number increases just after that because a new record is
 	// created without the "x" entry.
 	ln2 := NewLocalNode(db, ln.key)
-	if s := ln2.Node().Seq(); s != timestamp+3 {
-		t.Fatalf("wrong seq %d on new instance, want 3", s)
+	if s := ln2.Node().Seq(); s != initialSeq+2 {
+		t.Fatalf("wrong seq %d on new instance, want %d", s, initialSeq+2)
 	}
+
+	finalSeq := ln2.Node().Seq()
 
 	// Create a new instance with a different node key on the same database.
 	// This should reset the sequence number.
 	key, _ := crypto.GenerateKey()
 	ln3 := NewLocalNode(db, key)
-	if s := ln3.Node().Seq(); s != timestamp+1 {
-		t.Fatalf("wrong seq %d on instance with changed key, want 1", s)
+	if s := ln3.Node().Seq(); s < finalSeq {
+		t.Fatalf("wrong seq %d on instance with changed key, want >= %d", s, finalSeq)
 	}
 }
 
 // This test checks behavior of the endpoint predictor.
 func TestLocalNodeEndpoint(t *testing.T) {
-	// Disable throttling for this test
-	defer func(throttle time.Duration) { recordUpdateThrottle = throttle }(recordUpdateThrottle)
-	recordUpdateThrottle = 0
-
 	var (
-		timestamp = uint64(time.Now().Unix())
 		fallback  = &net.UDPAddr{IP: net.IP{127, 0, 0, 1}, Port: 80}
 		predicted = &net.UDPAddr{IP: net.IP{127, 0, 1, 2}, Port: 81}
 		staticIP  = net.IP{127, 0, 1, 2}
@@ -107,20 +98,20 @@ func TestLocalNodeEndpoint(t *testing.T) {
 	// Nothing is set initially.
 	assert.Equal(t, net.IP(nil), ln.Node().IP())
 	assert.Equal(t, 0, ln.Node().UDP())
-	assert.Equal(t, uint64(timestamp+1), ln.Node().Seq())
+	initialSeq := ln.Node().Seq()
 
 	// Set up fallback address.
 	ln.SetFallbackIP(fallback.IP)
 	ln.SetFallbackUDP(fallback.Port)
 	assert.Equal(t, fallback.IP, ln.Node().IP())
 	assert.Equal(t, fallback.Port, ln.Node().UDP())
-	assert.Equal(t, uint64(timestamp+2), ln.Node().Seq())
+	assert.Equal(t, initialSeq+1, ln.Node().Seq())
 
 	// Add endpoint statements from random hosts.
 	for i := 0; i < iptrackMinStatements; i++ {
 		assert.Equal(t, fallback.IP, ln.Node().IP())
 		assert.Equal(t, fallback.Port, ln.Node().UDP())
-		assert.Equal(t, uint64(timestamp+2), ln.Node().Seq())
+		assert.Equal(t, initialSeq+1, ln.Node().Seq())
 
 		from := &net.UDPAddr{IP: make(net.IP, 4), Port: 90}
 		rand.Read(from.IP)
@@ -128,57 +119,11 @@ func TestLocalNodeEndpoint(t *testing.T) {
 	}
 	assert.Equal(t, predicted.IP, ln.Node().IP())
 	assert.Equal(t, predicted.Port, ln.Node().UDP())
-	assert.Equal(t, uint64(timestamp+3), ln.Node().Seq())
+	assert.Equal(t, initialSeq+2, ln.Node().Seq())
 
 	// Static IP overrides prediction.
 	ln.SetStaticIP(staticIP)
 	assert.Equal(t, staticIP, ln.Node().IP())
 	assert.Equal(t, fallback.Port, ln.Node().UDP())
-	assert.Equal(t, uint64(timestamp+4), ln.Node().Seq())
-}
-
-// Tests that multiple updates to a node record are throttled until the specified
-// timeout expires.
-func TestLocalNodeThrottling(t *testing.T) {
-	var n uint
-
-	// Create and retrieve an initial node record to force an update
-	ln, db := newLocalNodeForTesting()
-	defer db.Close()
-
-	ln.Set(enr.WithEntry("x", uint(3)))
-	ln.Set(enr.WithEntry("y", uint(2)))
-	ln.Set(enr.WithEntry("z", uint(1)))
-
-	timestamp := uint64(time.Now().Unix())
-	if s := ln.Node().Seq(); s != timestamp+1 {
-		t.Fatalf("wrong initial seq %d, want %d", s, timestamp+1)
-	}
-	ln.Node().Load(enr.WithEntry("x", &n))
-	assert.Equal(t, uint(3), n)
-	ln.Node().Load(enr.WithEntry("y", &n))
-	assert.Equal(t, uint(2), n)
-	ln.Node().Load(enr.WithEntry("z", &n))
-	assert.Equal(t, uint(1), n)
-
-	// Trigger a set of updates and ensure they don't publish yet
-	ln.Set(enr.WithEntry("x", uint(1)))
-	ln.Delete(enr.WithEntry("y", uint(2)))
-	ln.Set(enr.WithEntry("z", uint(3)))
-
-	ln.Node().Load(enr.WithEntry("x", &n))
-	assert.Equal(t, uint(3), n)
-	ln.Node().Load(enr.WithEntry("y", &n))
-	assert.Equal(t, uint(2), n)
-	ln.Node().Load(enr.WithEntry("z", &n))
-	assert.Equal(t, uint(1), n)
-
-	// Wait for the timeout to trigger and check again
-	time.Sleep(recordUpdateThrottle)
-
-	ln.Node().Load(enr.WithEntry("x", &n))
-	assert.Equal(t, uint(1), n)
-	ln.Node().Load(enr.WithEntry("z", &n))
-	assert.Equal(t, uint(3), n)
-	assert.EqualError(t, ln.Node().Load(enr.WithEntry("y", &n)), "missing ENR key \"y\"")
+	assert.Equal(t, initialSeq+3, ln.Node().Seq())
 }

--- a/p2p/enode/nodedb.go
+++ b/p2p/enode/nodedb.go
@@ -427,9 +427,14 @@ func (db *DB) UpdateFindFailsV5(id ID, ip net.IP, fails int) error {
 	return db.storeInt64(v5Key(id, ip, dbNodeFindFails), int64(fails))
 }
 
-// LocalSeq retrieves the local record sequence counter.
+// localSeq retrieves the local record sequence counter, defaulting to the current
+// timestamp if no previous exists. This ensures that wiping all data associated
+// with a node (apart from its key) will not generate already used sequence nums.
 func (db *DB) localSeq(id ID) uint64 {
-	return db.fetchUint64(localItemKey(id, dbLocalSeq))
+	if seq := db.fetchUint64(localItemKey(id, dbLocalSeq)); seq > 0 {
+		return seq
+	}
+	return uint64(time.Now().Unix())
 }
 
 // storeLocalSeq stores the local record sequence counter.

--- a/p2p/enode/nodedb.go
+++ b/p2p/enode/nodedb.go
@@ -434,7 +434,7 @@ func (db *DB) localSeq(id ID) uint64 {
 	if seq := db.fetchUint64(localItemKey(id, dbLocalSeq)); seq > 0 {
 		return seq
 	}
-	return uint64(time.Now().Unix())
+	return nowMilliseconds()
 }
 
 // storeLocalSeq stores the local record sequence counter.


### PR DESCRIPTION
This PR ensures that wiping all data associated with a node (apart from its key) will not generate already used sequence number for the ENRs, since all remote nodes would reject them until they out-number the previously published largest one.