### PR TITLE
ethdb/memorydb: allow noop compact on memdb

### DIFF
--- a/ethdb/memorydb/memorydb.go
+++ b/ethdb/memorydb/memorydb.go
@@ -197,9 +197,10 @@ func (db *Database) Stat(property string) (string, error) {
 	return "", errors.New("unknown property")
 }
 
-// Compact is not supported on a memory database.
+// Compact is not supported on a memory database, but there's no need either as
+// a memory database doens't waste space anyway.
 func (db *Database) Compact(start []byte, limit []byte) error {
-	return errors.New("unsupported operation")
+	return nil
 }
 
 // Len returns the number of entries currently present in the memory database.

--- a/ethdb/memorydb/memorydb.go
+++ b/ethdb/memorydb/memorydb.go
@@ -198,7 +198,7 @@ func (db *Database) Stat(property string) (string, error) {
 }
 
 // Compact is not supported on a memory database, but there's no need either as
-// a memory database doens't waste space anyway.
+// a memory database doesn't waste space anyway.
 func (db *Database) Compact(start []byte, limit []byte) error {
 	return nil
 }


### PR DESCRIPTION
We don't manually trigger compaction anywhere in the code (mostly because we don't delete anything). However, when we start deleting stuff and manually compacting (e.g. my future snapshot work), `ethdb.Database.Compact` is expected to work with all database backends.

Currently compaction fails for `memorydb` because it's not implemented. However, it doesn't need to be implemented because the `memorydb` is always compact anyway. This PR replaces the error with a noop. This is needed for tests that touch code that compacts.