### PR TITLE
internal/ethapi: implement fillTransaction

### DIFF
--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -1441,6 +1441,22 @@ func (s *PublicTransactionPoolAPI) SendTransaction(ctx context.Context, args Sen
 	return SubmitTransaction(ctx, s.b, signed)
 }
 
+// FillTransaction fills the defaults (nonce, gas, gasPrice) on a given unsigned transaction,
+// and returns it to the caller for further processing (signing + broadcast)
+func (s *PublicTransactionPoolAPI) FillTransaction(ctx context.Context, args SendTxArgs) (*SignTransactionResult, error) {
+	// Set some sanity defaults and terminate on failure
+	if err := args.setDefaults(ctx, s.b); err != nil {
+		return nil, err
+	}
+	// Assemble the transaction and obtain rlp
+	tx := args.toTransaction()
+	data, err := rlp.EncodeToBytes(tx)
+	if err != nil {
+		return nil, err
+	}
+	return &SignTransactionResult{data, tx}, nil
+}
+
 // SendRawTransaction will add the signed transaction to the transaction pool.
 // The sender is responsible for signing the transaction and using the correct nonce.
 func (s *PublicTransactionPoolAPI) SendRawTransaction(ctx context.Context, encodedTx hexutil.Bytes) (common.Hash, error) {

--- a/internal/web3ext/web3ext.go
+++ b/internal/web3ext/web3ext.go
@@ -484,6 +484,12 @@ web3._extend({
 			inputFormatter: [web3._extend.formatters.inputTransactionFormatter]
 		}),
 		new web3._extend.Method({
+			name: 'fillTransaction',
+			call: 'eth_fillTransaction',
+			params: 1,
+			inputFormatter: [web3._extend.formatters.inputTransactionFormatter]
+		}),
+		new web3._extend.Method({
 			name: 'getHeaderByNumber',
 			call: 'eth_getHeaderByNumber',
 			params: 1


### PR DESCRIPTION

This PR adds `eth.fillTransaction`, which is useful if signing is done outside of the actual node. 

Below is a reference about what methods exist today (we might want to make it into a table and place in the docs)

### Example 
Example when using `geth --dev`, which does not really have a sensible GPO. 
```
> eth.fillTransaction({"to":"0x17Ff1b635D4A1E4Ba1377E06d1dD0e1C9015FB5f", value:"100", from:"0x17Ff1b635D4A1E4Ba1377E06d1dD0e1C9015FB5f"})
{
  raw: "0xdf80018252089417ff1b635d4a1e4ba1377e06d1dd0e1c9015fb5f6480808080",
  tx: {
    gas: "0x5208",
    gasPrice: "0x1",
    hash: "0xea7d97f5fe68d9fc638410cf134f3785ef690330660069252e5d7bb2f122f6c7",
    input: "0x",
    nonce: "0x0",
    r: "0x0",
    s: "0x0",
    to: "0x17ff1b635d4a1e4ba1377e06d1dd0e1c9015fb5f",
    v: "0x0",
    value: "0x64"
  }
}
```

### Transaction methods

| Namespace  | Function            | Broadcasts | Requires accounts| Output                    | Fills defaults|
|------------|---------------------|------------|------------------|---------------------------|---------------|
| `eth`      | `sendTransaction`   | Yes        | Yes              |`hash`                     | Yes           |
| `eth`      | `sendRawTransaction`| Yes        | No               |`hash`                     | No            |
| `eth`      | `signTransaction`   | No         | Yes              |`RLP` + `JSON` (signed tx) | No            |
| `eth`      | `resend`            | Yes        | Yes              | `hash`                    | Yes           |
| `eth`      | `fillTransaction`   | No         | No               | `RLP`+`JSON` (unsigned tx)| Yes           |
| `personal` | `sendTransaction`   | Yes        | Yes              | `hash`                    | Yes           |
| `personal` | `signTransaction`   | No         | Yes              | `RLP`+`JSON` (signed tx)  | No            |


- `eth.sendTransaction`
   - Creates a transaction from input, sign it and broadcast
   - Sets defaults
- `eth.sendRawTransaction`
   - Takes a fully complete (filled and signed) transactoin in RLP-form, and broadcasts
- `eth.signTransaction`
   - Takes a fully filled (unsigned) transaction, signs and broadasts
- `eth.resend`
   - Matches `nonce` if sending-account to an existing tx, applies modifications, signs and broadcasts
   - Requires `nonce`, fills other defaults
- `eth.fillTransaction`
   - Fills defaults and returns `RLP` + `JSON`
- `personal.sendTransaction`
   - Creates a transaction from input, fills defaults, sign it and broadcast
- `personal.signTransaction`
   - Creates a fully filled transaction from input, sign it and returns `RLP` + `JSON`

