### PR TITLE
graphql, internal/ethapi: extend eth_call

### DIFF
--- a/core/state/state_object.go
+++ b/core/state/state_object.go
@@ -230,18 +230,13 @@ func (s *stateObject) SetState(db Database, key, value common.Hash) {
 	s.setState(key, value)
 }
 
-// SetStatesForDebug replaces the entire state storage with the given one.
+// SetStorage replaces the entire state storage with the given one.
 //
 // After this function is called, all original state will be ignored and state
 // lookup only happens in the fake state storage.
 //
 // Note this function should only be used for debugging purpose.
-func (s *stateObject) SetStatesForDebug(storage map[common.Hash]common.Hash) {
-	// Clean the fake storage if debugging is done.
-	if storage == nil {
-		s.fakeStorage = nil
-		return
-	}
+func (s *stateObject) SetStorage(storage map[common.Hash]common.Hash) {
 	// Allocate fake storage if it's nil.
 	if s.fakeStorage == nil {
 		s.fakeStorage = make(Storage)

--- a/core/state/state_object.go
+++ b/core/state/state_object.go
@@ -81,6 +81,7 @@ type stateObject struct {
 
 	originStorage Storage // Storage cache of original entries to dedup rewrites
 	dirtyStorage  Storage // Storage entries that need to be flushed to disk
+	fakeStorage   Storage // Fake storage which constructed by caller for debugging purpose.
 
 	// Cache flags.
 	// When an object is marked suicided it will be delete from the trie
@@ -163,6 +164,10 @@ func (s *stateObject) getTrie(db Database) Trie {
 
 // GetState retrieves a value from the account storage trie.
 func (s *stateObject) GetState(db Database, key common.Hash) common.Hash {
+	// If the fake storage is set, only lookup the state here(in the debugging mode)
+	if s.fakeStorage != nil {
+		return s.fakeStorage[key]
+	}
 	// If we have a dirty value for this state entry, return it
 	value, dirty := s.dirtyStorage[key]
 	if dirty {
@@ -174,12 +179,16 @@ func (s *stateObject) GetState(db Database, key common.Hash) common.Hash {
 
 // GetCommittedState retrieves a value from the committed account storage trie.
 func (s *stateObject) GetCommittedState(db Database, key common.Hash) common.Hash {
+	// If the fake storage is set, only lookup the state here(in the debugging mode)
+	if s.fakeStorage != nil {
+		return s.fakeStorage[key]
+	}
 	// If we have the original value cached, return that
 	value, cached := s.originStorage[key]
 	if cached {
 		return value
 	}
-	// Track the amount of time wasted on reading the storge trie
+	// Track the amount of time wasted on reading the storage trie
 	if metrics.EnabledExpensive {
 		defer func(start time.Time) { s.db.StorageReads += time.Since(start) }(time.Now())
 	}
@@ -202,6 +211,11 @@ func (s *stateObject) GetCommittedState(db Database, key common.Hash) common.Has
 
 // SetState updates a value in account storage.
 func (s *stateObject) SetState(db Database, key, value common.Hash) {
+	// If the fake storage is set, put the temporary state update here.
+	if s.fakeStorage != nil {
+		s.fakeStorage[key] = value
+		return
+	}
 	// If the new value is the same as old, don't set
 	prev := s.GetState(db, key)
 	if prev == value {
@@ -214,6 +228,29 @@ func (s *stateObject) SetState(db Database, key, value common.Hash) {
 		prevalue: prev,
 	})
 	s.setState(key, value)
+}
+
+// SetStatesForDebug replaces the entire state storage with the given one.
+//
+// After this function is called, all original state will be ignored and state
+// lookup only happens in the fake state storage.
+//
+// Note this function should only be used for debugging purpose.
+func (s *stateObject) SetStatesForDebug(storage map[common.Hash]common.Hash) {
+	// Clean the fake storage if debugging is done.
+	if storage == nil {
+		s.fakeStorage = nil
+		return
+	}
+	// Allocate fake storage if it's nil.
+	if s.fakeStorage == nil {
+		s.fakeStorage = make(Storage)
+	}
+	for key, value := range storage {
+		s.fakeStorage[key] = value
+	}
+	// Don't bother journal since this function should only be used for
+	// debugging and the `fake` storage won't be committed to database.
 }
 
 func (s *stateObject) setState(key, value common.Hash) {

--- a/core/state/statedb.go
+++ b/core/state/statedb.go
@@ -386,10 +386,12 @@ func (self *StateDB) SetState(addr common.Address, key, value common.Hash) {
 	}
 }
 
-func (self *StateDB) SetStateForDebug(addr common.Address, storage map[common.Hash]common.Hash) {
+// SetStorage replaces the entire storage for the specified account with given
+// storage. This function should only be used for debugging.
+func (self *StateDB) SetStorage(addr common.Address, storage map[common.Hash]common.Hash) {
 	stateObject := self.GetOrNewStateObject(addr)
 	if stateObject != nil {
-		stateObject.SetStatesForDebug(storage)
+		stateObject.SetStorage(storage)
 	}
 }
 

--- a/core/state/statedb.go
+++ b/core/state/statedb.go
@@ -386,6 +386,13 @@ func (self *StateDB) SetState(addr common.Address, key, value common.Hash) {
 	}
 }
 
+func (self *StateDB) SetStateForDebug(addr common.Address, storage map[common.Hash]common.Hash) {
+	stateObject := self.GetOrNewStateObject(addr)
+	if stateObject != nil {
+		stateObject.SetStatesForDebug(storage)
+	}
+}
+
 // Suicide marks the given account as suicided.
 // This clears the account balance.
 //

--- a/graphql/graphql.go
+++ b/graphql/graphql.go
@@ -817,7 +817,7 @@ func (b *Block) Call(ctx context.Context, args struct {
 			return nil, err
 		}
 	}
-	result, gas, failed, err := ethapi.DoCall(ctx, b.backend, args.Data, *b.num, vm.Config{}, 5*time.Second, b.backend.RPCGasCap())
+	result, gas, failed, err := ethapi.DoCall(ctx, b.backend, args.Data, *b.num, nil, vm.Config{}, 5*time.Second, b.backend.RPCGasCap())
 	status := hexutil.Uint64(1)
 	if failed {
 		status = 0
@@ -885,7 +885,7 @@ func (p *Pending) Account(ctx context.Context, args struct {
 func (p *Pending) Call(ctx context.Context, args struct {
 	Data ethapi.CallArgs
 }) (*CallResult, error) {
-	result, gas, failed, err := ethapi.DoCall(ctx, p.backend, args.Data, rpc.PendingBlockNumber, vm.Config{}, 5*time.Second, p.backend.RPCGasCap())
+	result, gas, failed, err := ethapi.DoCall(ctx, p.backend, args.Data, rpc.PendingBlockNumber, nil, vm.Config{}, 5*time.Second, p.backend.RPCGasCap())
 	status := hexutil.Uint64(1)
 	if failed {
 		status = 0


### PR DESCRIPTION
This PR implements the feature required by #19836 

The JSON RPC spec of this API is

**eth_call**
Executes a new message call with a set of overloaded contract code.

**Parameters**
**1. Object** - The transaction call object
`from`: DATA, 20 Bytes - (optional) The address the transaction is sent from.
`to`: DATA, 20 Bytes - The address the transaction is directed to.
`gas`: QUANTITY - (optional) Integer of the gas provided for the transaction execution. eth_call consumes zero gas, but this parameter may be needed by some executions.
`gasPrice`: QUANTITY - (optional) Integer of the gasPrice used for each paid gas
`value`: QUANTITY - (optional) Integer of the value sent with this transaction
`data`: DATA - (optional) Hash of the method signature and encoded parameters. For details see Ethereum Contract ABI

**2. Block number**
QUANTITY|TAG - integer block number, or the string "latest", "earliest" or "pending", see the default block parameter

**3. Codes**
DATA: DATA - (optional) the override map contains all contract address and new execution code mappings.

**Returns**
DATA - the return value of executed contract.

curl example:

```
curl -H "Content-Type: application/json" -X POST  localhost:8545 --data '{"jsonrpc":"2.0","method":"eth_call","params":[{"to": "oxaddr", "data": "oxdata"}, "latest", {"0xaddr1":"0xcode1...", "0xaddr2":"0xcode2..."}],"id":1}'
```
or

```
curl -H "Content-Type: application/json" -X POST  localhost:8545 --data '{"jsonrpc":"2.0","method":"eth_call","params":[{"to": "oxaddr", "data": "oxdata"}, "latest"],"id":1}'
```