### PR TITLE
add fuzzit.dev continous fuzzing integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -223,3 +223,19 @@ jobs:
         submodules: false # avoid cloning ethereum/tests
       script:
         - go run build/ci.go purge -store gethstore/builds -days 14
+
+    # This builder does continuous fuzz testing
+    - stage: Fuzz-Tests
+      go: 1.12.x
+      services:
+        - docker
+      script:
+        - ./build/fuzzit.sh sanity
+
+    - stage: Fuzzit (Fuzzing)
+      env:
+        secure: "Gd0njFhyjzOSJc1ybygwQ1ObdHUW5ORCnNZSHPwuozMiFdcMbClq4gyJvQoZDWN5moUDCsZ1CFacvf1bUiiJ4N3MydnLpL+SaqKj9JVbk7Vzb32oBaztfmvhRUCDNM7g1jSTSGKcAJ9PA6QYxVQ10R95SzPOelGu5HTDRgL+Kcc="
+      if: branch = master AND type IN (push)
+      go: 1.12.x
+      script:
+        - ./build/fuzzit.sh fuzzing

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ https://camo.githubusercontent.com/915b7be44ada53c290eb157634330494ebe3e30a/6874
 [![Go Report Card](https://goreportcard.com/badge/github.com/ethereum/go-ethereum)](https://goreportcard.com/report/github.com/ethereum/go-ethereum)
 [![Travis](https://travis-ci.org/ethereum/go-ethereum.svg?branch=master)](https://travis-ci.org/ethereum/go-ethereum)
 [![Discord](https://img.shields.io/badge/discord-join%20chat-blue.svg)](https://discord.gg/nthXNEv)
+[![fuzzit](https://app.fuzzit.dev/badge?org_id=ethereum=master)](https://fuzzit.dev)
 
 Automated builds are available for stable releases and the unstable master branch. Binary
 archives are published at https://geth.ethereum.org/downloads/.

--- a/build/fuzzit.sh
+++ b/build/fuzzit.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+set -xe
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+
+if [ -z ${1+x} ]; then
+    echo "must call with job type as first argument e.g. 'fuzzing' or 'sanity'"
+    echo "see https://github.com/fuzzitdev/example-go/blob/master/.travis.yml"
+    exit 1
+fi
+
+$DIR/libfuzzer_targets.sh
+
+# submit fuzz targets to fuzzit.dev for continuous fuzzing
+
+wget -q -O fuzzit https://github.com/fuzzitdev/fuzzit/releases/download/v2.4.12/fuzzit_Linux_x86_64
+chmod a+x fuzzit
+
+for TARGET in "${TARGETS[@]}"
+do
+    # create fuzzing target on the server if it doesn't already exist
+    ./fuzzit create target ${TARGET} || true
+
+    # submit a new fuzzing job for that target
+    if [ $1 == "fuzzing" ]; then
+        ./fuzzit auth ${FUZZIT_API_KEY}
+        ./fuzzit create job --branch $TRAVIS_BRANCH --revision $TRAVIS_COMMIT ${TARGET} "./${TARGET}"
+    else
+        ./fuzzit create job --local ethereum/${TARGET} "./${TARGET}"
+    fi
+done

--- a/build/libfuzzer_targets.sh
+++ b/build/libfuzzer_targets.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+set -x
+
+## go-fuzz doesn't support modules for now, so ensure we do everything
+## in the old style GOPATH way
+export GO111MODULE="off"
+
+## Install go-fuzz
+go get -u github.com/dvyukov/go-fuzz/go-fuzz github.com/dvyukov/go-fuzz/go-fuzz-build
+
+## build fuzz targets
+
+TARGETS=("bitutil-fuzzer" "bn256-add-fuzzer" "bn256-mul-fuzzer" "bn256-pair-fuzzer")
+
+go-fuzz-build -libfuzzer -o bitutil-fuzzer.a ./common/bitutil
+go-fuzz-build -libfuzzer -func FuzzAdd -o bn256-add-fuzzer.a ./crypto/bn256
+go-fuzz-build -libfuzzer -func FuzzMul -o bn256-mul-fuzzer.a ./crypto/bn256
+go-fuzz-build -libfuzzer -func FuzzPair -o bn256-pair-fuzzer.a ./crypto/bn256
+
+for TARGET in "${TARGETS[@]}"
+do
+    clang -fsanitize=fuzzer ${TARGET}.a -o ${TARGET}
+done


### PR DESCRIPTION
Hi Team,

The PR is ready for review: more instruction in a later [comment](https://github.com/ethereum/go-ethereum/pull/19927#issuecomment-519695895)

This PR adds a continuous fuzzing integration to go-ethereum's travis pipeline via https://fuzzit.dev service.

This continuous fuzzing workflow consist of

Continuously fuzzing up-to-date master generating new test cases, crashes and corpus.

Running quick regression tests with the generated corpus and fixed crashes on every PR to catch bugs earlier

I'm the founder of fuzzit.dev and the service is free for open source projects (you can see some great projects that we serve on our website).

To make integration as easy as possible, we've created an organisation at https://app.fuzzit.dev/orgs/ethereum/dashboard.

To take ownership of the organisation, please login to https://app.fuzzit.dev and let us know your account.

build/fuzzit.sh script is an additional step in Travis pipeline which builds fuzzit targets and uploads them to fuzzit.dev servers for continuous fuzzing.

This PR uses a temporary API key. After merging, please get the API key from https://app.fuzzit.dev/orgs/ethereum/settings and set FUZZIT_API_KEY env variable via Travis UI (https://travis-ci.org/ethereum/go-ethereum/settings).

Let me know if you have any questions.