### PR TITLE
crypto/secp256k1: fix bug in affineFromJacobian

### DIFF
--- a/crypto/secp256k1/curve.go
+++ b/crypto/secp256k1/curve.go
@@ -116,6 +116,10 @@ func (BitCurve *BitCurve) IsOnCurve(x, y *big.Int) bool {
 // affineFromJacobian reverses the Jacobian transform. See the comment at the
 // top of the file.
 func (BitCurve *BitCurve) affineFromJacobian(x, y, z *big.Int) (xOut, yOut *big.Int) {
+	if z.Sign() == 0 {
+		return new(big.Int), new(big.Int)
+	}
+
 	zinv := new(big.Int).ModInverse(z, BitCurve.P)
 	zinvsq := new(big.Int).Mul(zinv, zinv)
 


### PR DESCRIPTION
I made some custom features using `crypto/secp256k1` to `Add` two points on the curve, which invokes function `affineFromJacobian`, but if the input param `z` is zero, `zinv` wil be `nil` and then the code will crash.