### PR TITLE
eth: bump the state node count and add metrics

### DIFF
--- a/eth/downloader/downloader.go
+++ b/eth/downloader/downloader.go
@@ -38,13 +38,12 @@ import (
 )
 
 var (
-	MaxHashFetch    = 512 // Amount of hashes to be fetched per retrieval request
-	MaxBlockFetch   = 128 // Amount of blocks to be fetched per retrieval request
-	MaxHeaderFetch  = 192 // Amount of block headers to be fetched per retrieval request
-	MaxSkeletonSize = 128 // Number of header fetches to need for a skeleton assembly
-	MaxBodyFetch    = 128 // Amount of block bodies to be fetched per retrieval request
-	MaxReceiptFetch = 256 // Amount of transaction receipts to allow fetching per request
-	MaxStateFetch   = 384 // Amount of node state values to allow fetching per request
+	MaxHashFetch    = 512  // Amount of hashes to be fetched per retrieval request
+	MaxBlockFetch   = 128  // Amount of blocks to be fetched per retrieval request
+	MaxHeaderFetch  = 192  // Amount of block headers to be fetched per retrieval request
+	MaxSkeletonSize = 128  // Number of header fetches to need for a skeleton assembly
+	MaxReceiptFetch = 256  // Amount of transaction receipts to allow fetching per request
+	MaxStateFetch   = 1024 // Amount of node state values to allow fetching per request
 
 	rttMinEstimate   = 2 * time.Second  // Minimum round-trip time to target for download requests
 	rttMaxEstimate   = 20 * time.Second // Maximum round-trip time to target for download requests

--- a/eth/downloader/metrics.go
+++ b/eth/downloader/metrics.go
@@ -38,6 +38,9 @@ var (
 	receiptDropMeter    = metrics.NewRegisteredMeter("eth/downloader/receipts/drop", nil)
 	receiptTimeoutMeter = metrics.NewRegisteredMeter("eth/downloader/receipts/timeout", nil)
 
-	stateInMeter   = metrics.NewRegisteredMeter("eth/downloader/states/in", nil)
-	stateDropMeter = metrics.NewRegisteredMeter("eth/downloader/states/drop", nil)
+	stateInMeter       = metrics.NewRegisteredMeter("eth/downloader/states/in", nil)
+	stateReqTimer      = metrics.NewRegisteredTimer("eth/download/state/req", nil)
+	stateDropMeter     = metrics.NewRegisteredMeter("eth/downloader/states/drop", nil)
+	stateNodeSizeMeter = metrics.NewRegisteredMeter("eth/download/state/nodesize", nil)
+	stateRespSizeMeter = metrics.NewRegisteredMeter("eth/download/state/size", nil)
 )

--- a/eth/metrics.go
+++ b/eth/metrics.go
@@ -46,6 +46,7 @@ var (
 	reqStateInTrafficMeter    = metrics.NewRegisteredMeter("eth/req/states/in/traffic", nil)
 	reqStateOutPacketsMeter   = metrics.NewRegisteredMeter("eth/req/states/out/packets", nil)
 	reqStateOutTrafficMeter   = metrics.NewRegisteredMeter("eth/req/states/out/traffic", nil)
+	reqStateLookupTimer       = metrics.NewRegisteredTimer("eth/req/states/out/lookup", nil)
 	reqReceiptInPacketsMeter  = metrics.NewRegisteredMeter("eth/req/receipts/in/packets", nil)
 	reqReceiptInTrafficMeter  = metrics.NewRegisteredMeter("eth/req/receipts/in/traffic", nil)
 	reqReceiptOutPacketsMeter = metrics.NewRegisteredMeter("eth/req/receipts/out/packets", nil)


### PR DESCRIPTION
This PR is mainly for benchmarking.

In this PR, trie node limit of a state request is bumped. The reason behind this is:

* Now mainnet has more than 3M trie nodes for a single version state.
* The trie node upper limit of request currently is 384
* Therefore at least 781250.0 network round trip is necessary. While the average trie node size **I guess** is around 100bytes. So as we all know small size data transmission is inefficient.

So I want to do some experiments to bump the limit. It won't have too much side effect at least in the Geth side. Since the server will ignore the extra node request if the number beyond the old limit.
The syncer will retry the missing data in a response if any useful data is delivered.

Besides, this PR adds some metrics to get a reasonable node limit number. There are two main concerns: (1) the cost of reading trie nodes from the database in the server-side (2) the RTT of state request.
