### PR TITLE
ethdb: Add testsuite for ethdb backends

### DIFF
--- a/ethdb/dbtest/testsuite.go
+++ b/ethdb/dbtest/testsuite.go
@@ -14,18 +14,20 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
 
-package ethdb
+package dbtest
 
 import (
 	"bytes"
 	"reflect"
 	"sort"
 	"testing"
+
+	"github.com/ethereum/go-ethereum/ethdb"
 )
 
 // TestDatabaseSuite runs a suite of tests against a KeyValueStore database
 // implementation.
-func TestDatabaseSuite(t *testing.T, New func() KeyValueStore) {
+func TestDatabaseSuite(t *testing.T, New func() ethdb.KeyValueStore) {
 	t.Run("Iterator", func(t *testing.T) {
 		tests := []struct {
 			content map[string]string
@@ -166,7 +168,7 @@ func TestDatabaseSuite(t *testing.T, New func() KeyValueStore) {
 
 		if got, err := db.Has(key); err != nil {
 			t.Error(err)
-		} else if got != false {
+		} else if got {
 			t.Errorf("wrong value: %t", got)
 		}
 
@@ -177,13 +179,13 @@ func TestDatabaseSuite(t *testing.T, New func() KeyValueStore) {
 
 		if got, err := db.Has(key); err != nil {
 			t.Error(err)
-		} else if got != true {
+		} else if !got {
 			t.Errorf("wrong value: %t", got)
 		}
 
 		if got, err := db.Get(key); err != nil {
 			t.Error(err)
-		} else if bytes.Compare(got, value) != 0 {
+		} else if !bytes.Equal(got, value) {
 			t.Errorf("wrong value: %q", got)
 		}
 
@@ -193,7 +195,7 @@ func TestDatabaseSuite(t *testing.T, New func() KeyValueStore) {
 
 		if got, err := db.Has(key); err != nil {
 			t.Error(err)
-		} else if got != false {
+		} else if got {
 			t.Errorf("wrong value: %t", got)
 		}
 	})
@@ -279,7 +281,7 @@ func TestDatabaseSuite(t *testing.T, New func() KeyValueStore) {
 
 }
 
-func iterateKeys(it Iterator) []string {
+func iterateKeys(it ethdb.Iterator) []string {
 	keys := []string{}
 	for it.Next() {
 		keys = append(keys, string(it.Key()))

--- a/ethdb/leveldb/leveldb_test.go
+++ b/ethdb/leveldb/leveldb_test.go
@@ -14,18 +14,26 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
 
-package memorydb
+package leveldb
 
 import (
 	"testing"
 
 	"github.com/ethereum/go-ethereum/ethdb"
+	"github.com/syndtr/goleveldb/leveldb"
+	"github.com/syndtr/goleveldb/leveldb/storage"
 )
 
-func TestMemoryDB(t *testing.T) {
+func TestLevelDB(t *testing.T) {
 	t.Run("DatabaseSuite", func(t *testing.T) {
 		ethdb.TestDatabaseSuite(t, func() ethdb.KeyValueStore {
-			return New()
+			db, err := leveldb.Open(storage.NewMemStorage(), nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+			return &Database{
+				db: db,
+			}
 		})
 	})
 }

--- a/ethdb/leveldb/leveldb_test.go
+++ b/ethdb/leveldb/leveldb_test.go
@@ -20,13 +20,14 @@ import (
 	"testing"
 
 	"github.com/ethereum/go-ethereum/ethdb"
+	"github.com/ethereum/go-ethereum/ethdb/dbtest"
 	"github.com/syndtr/goleveldb/leveldb"
 	"github.com/syndtr/goleveldb/leveldb/storage"
 )
 
 func TestLevelDB(t *testing.T) {
 	t.Run("DatabaseSuite", func(t *testing.T) {
-		ethdb.TestDatabaseSuite(t, func() ethdb.KeyValueStore {
+		dbtest.TestDatabaseSuite(t, func() ethdb.KeyValueStore {
 			db, err := leveldb.Open(storage.NewMemStorage(), nil)
 			if err != nil {
 				t.Fatal(err)

--- a/ethdb/memorydb/memorydb_test.go
+++ b/ethdb/memorydb/memorydb_test.go
@@ -20,11 +20,12 @@ import (
 	"testing"
 
 	"github.com/ethereum/go-ethereum/ethdb"
+	"github.com/ethereum/go-ethereum/ethdb/dbtest"
 )
 
 func TestMemoryDB(t *testing.T) {
 	t.Run("DatabaseSuite", func(t *testing.T) {
-		ethdb.TestDatabaseSuite(t, func() ethdb.KeyValueStore {
+		dbtest.TestDatabaseSuite(t, func() ethdb.KeyValueStore {
 			return New()
 		})
 	})

--- a/ethdb/testsuite.go
+++ b/ethdb/testsuite.go
@@ -1,0 +1,289 @@
+// Copyright 2019 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+package ethdb
+
+import (
+	"bytes"
+	"reflect"
+	"sort"
+	"testing"
+)
+
+// TestDatabaseSuite runs a suite of tests against a KeyValueStore database
+// implementation.
+func TestDatabaseSuite(t *testing.T, New func() KeyValueStore) {
+	t.Run("Iterator", func(t *testing.T) {
+		tests := []struct {
+			content map[string]string
+			prefix  string
+			order   []string
+		}{
+			// Empty databases should be iterable
+			{map[string]string{}, "", nil},
+			{map[string]string{}, "non-existent-prefix", nil},
+
+			// Single-item databases should be iterable
+			{map[string]string{"key": "val"}, "", []string{"key"}},
+			{map[string]string{"key": "val"}, "k", []string{"key"}},
+			{map[string]string{"key": "val"}, "l", nil},
+
+			// Multi-item databases should be fully iterable
+			{
+				map[string]string{"k1": "v1", "k5": "v5", "k2": "v2", "k4": "v4", "k3": "v3"},
+				"",
+				[]string{"k1", "k2", "k3", "k4", "k5"},
+			},
+			{
+				map[string]string{"k1": "v1", "k5": "v5", "k2": "v2", "k4": "v4", "k3": "v3"},
+				"k",
+				[]string{"k1", "k2", "k3", "k4", "k5"},
+			},
+			{
+				map[string]string{"k1": "v1", "k5": "v5", "k2": "v2", "k4": "v4", "k3": "v3"},
+				"l",
+				nil,
+			},
+			// Multi-item databases should be prefix-iterable
+			{
+				map[string]string{
+					"ka1": "va1", "ka5": "va5", "ka2": "va2", "ka4": "va4", "ka3": "va3",
+					"kb1": "vb1", "kb5": "vb5", "kb2": "vb2", "kb4": "vb4", "kb3": "vb3",
+				},
+				"ka",
+				[]string{"ka1", "ka2", "ka3", "ka4", "ka5"},
+			},
+			{
+				map[string]string{
+					"ka1": "va1", "ka5": "va5", "ka2": "va2", "ka4": "va4", "ka3": "va3",
+					"kb1": "vb1", "kb5": "vb5", "kb2": "vb2", "kb4": "vb4", "kb3": "vb3",
+				},
+				"kc",
+				nil,
+			},
+		}
+		for i, tt := range tests {
+			// Create the key-value data store
+			db := New()
+			for key, val := range tt.content {
+				if err := db.Put([]byte(key), []byte(val)); err != nil {
+					t.Fatalf("test %d: failed to insert item %s:%s into database: %v", i, key, val, err)
+				}
+			}
+			// Iterate over the database with the given configs and verify the results
+			it, idx := db.NewIteratorWithPrefix([]byte(tt.prefix)), 0
+			for it.Next() {
+				if len(tt.order) <= idx {
+					t.Errorf("test %d: more items than expected: checking idx=%d, have len=%d", i, idx, len(tt.order))
+					continue
+				}
+				if !bytes.Equal(it.Key(), []byte(tt.order[idx])) {
+					t.Errorf("test %d: item %d: key mismatch: have %s, want %s", i, idx, string(it.Key()), tt.order[idx])
+				}
+				if !bytes.Equal(it.Value(), []byte(tt.content[tt.order[idx]])) {
+					t.Errorf("test %d: item %d: value mismatch: have %s, want %s", i, idx, string(it.Value()), tt.content[tt.order[idx]])
+				}
+				idx++
+			}
+			if err := it.Error(); err != nil {
+				t.Errorf("test %d: iteration failed: %v", i, err)
+			}
+			if idx != len(tt.order) {
+				t.Errorf("test %d: iteration terminated prematurely: have %d, want %d", i, idx, len(tt.order))
+			}
+			db.Close()
+		}
+	})
+
+	t.Run("IteratorWith", func(t *testing.T) {
+		db := New()
+		defer db.Close()
+
+		keys := []string{"1", "2", "3", "4", "10", "11", "12", "20", "21", "22"}
+		sort.Strings(keys) // 1, 10, 11, etc
+
+		for _, k := range keys {
+			if err := db.Put([]byte(k), nil); err != nil {
+				t.Fatal(err)
+			}
+		}
+
+		{
+			it := db.NewIterator()
+			got, want := iterateKeys(it), keys
+			if err := it.Error(); err != nil {
+				t.Fatal(err)
+			}
+			it.Release()
+			if !reflect.DeepEqual(got, want) {
+				t.Errorf("Iterator: got: %s; want: %s", got, want)
+			}
+		}
+
+		{
+			it := db.NewIteratorWithPrefix([]byte("1"))
+			got, want := iterateKeys(it), []string{"1", "10", "11", "12"}
+			if err := it.Error(); err != nil {
+				t.Fatal(err)
+			}
+			it.Release()
+			if !reflect.DeepEqual(got, want) {
+				t.Errorf("IteratorWithPrefix(1): got: %s; want: %s", got, want)
+			}
+		}
+
+		{
+			it := db.NewIteratorWithStart([]byte("2"))
+			got, want := iterateKeys(it), []string{"2", "20", "21", "22", "3", "4"}
+			if err := it.Error(); err != nil {
+				t.Fatal(err)
+			}
+			it.Release()
+			if !reflect.DeepEqual(got, want) {
+				t.Errorf("IteratorWithStart(2): got: %s; want: %s", got, want)
+			}
+		}
+	})
+
+	t.Run("KeyValueOperations", func(t *testing.T) {
+		db := New()
+		defer db.Close()
+
+		key := []byte("foo")
+
+		if got, err := db.Has(key); err != nil {
+			t.Error(err)
+		} else if got != false {
+			t.Errorf("wrong value: %t", got)
+		}
+
+		value := []byte("hello world")
+		if err := db.Put(key, value); err != nil {
+			t.Error(err)
+		}
+
+		if got, err := db.Has(key); err != nil {
+			t.Error(err)
+		} else if got != true {
+			t.Errorf("wrong value: %t", got)
+		}
+
+		if got, err := db.Get(key); err != nil {
+			t.Error(err)
+		} else if bytes.Compare(got, value) != 0 {
+			t.Errorf("wrong value: %q", got)
+		}
+
+		if err := db.Delete(key); err != nil {
+			t.Error(err)
+		}
+
+		if got, err := db.Has(key); err != nil {
+			t.Error(err)
+		} else if got != false {
+			t.Errorf("wrong value: %t", got)
+		}
+	})
+
+	t.Run("Batch", func(t *testing.T) {
+		db := New()
+		defer db.Close()
+
+		b := db.NewBatch()
+		for _, k := range []string{"1", "2", "3", "4"} {
+			if err := b.Put([]byte(k), nil); err != nil {
+				t.Fatal(err)
+			}
+		}
+
+		if has, err := db.Has([]byte("1")); err != nil {
+			t.Fatal(err)
+		} else if has {
+			t.Error("db contains element before batch write")
+		}
+
+		if err := b.Write(); err != nil {
+			t.Fatal(err)
+		}
+
+		{
+			it := db.NewIterator()
+			if got, want := iterateKeys(it), []string{"1", "2", "3", "4"}; !reflect.DeepEqual(got, want) {
+				t.Errorf("got: %s; want: %s", got, want)
+			}
+			it.Release()
+		}
+
+		b.Reset()
+
+		// Mix writes and deletes in batch
+		b.Put([]byte("5"), nil)
+		b.Delete([]byte("1"))
+		b.Put([]byte("6"), nil)
+		b.Delete([]byte("3"))
+		b.Put([]byte("3"), nil)
+
+		if err := b.Write(); err != nil {
+			t.Fatal(err)
+		}
+
+		{
+			it := db.NewIterator()
+			if got, want := iterateKeys(it), []string{"2", "3", "4", "5", "6"}; !reflect.DeepEqual(got, want) {
+				t.Errorf("got: %s; want: %s", got, want)
+			}
+			it.Release()
+		}
+	})
+
+	t.Run("BatchReplay", func(t *testing.T) {
+		db := New()
+		defer db.Close()
+
+		want := []string{"1", "2", "3", "4"}
+		b := db.NewBatch()
+		for _, k := range want {
+			if err := b.Put([]byte(k), nil); err != nil {
+				t.Fatal(err)
+			}
+		}
+
+		b2 := db.NewBatch()
+		if err := b.Replay(b2); err != nil {
+			t.Fatal(err)
+		}
+
+		if err := b2.Replay(db); err != nil {
+			t.Fatal(err)
+		}
+
+		it := db.NewIterator()
+		if got := iterateKeys(it); !reflect.DeepEqual(got, want) {
+			t.Errorf("got: %s; want: %s", got, want)
+		}
+		it.Release()
+	})
+
+}
+
+func iterateKeys(it Iterator) []string {
+	keys := []string{}
+	for it.Next() {
+		keys = append(keys, string(it.Key()))
+	}
+	sort.Strings(keys)
+	return keys
+}


### PR DESCRIPTION
Hi there, I've been experimenting with different ethdb backend implementations and I found it helpful to write an ethdb testsuite to clarify and exercise nuances about some of the different interfaces that can be used by all the backends.

- Move the existing tests from memorydb into a generalized testsuite that can be run by any ethdb backend implementation.
- Add several more test cases to clarify some non-obvious nuances when implementing a custom ethdb backend, such as the behaviour of `NewIteratorWithPrefix` vs `NewIteratorWithStart`.
- Add leveldb to the testsuite using in-memory storage for fast execution.