### PR TITLE
Go 1.12.8 breaks TestParseNode and TestClientNotificationStorm tests #19959

### DIFF
--- a/p2p/discv5/node_test.go
+++ b/p2p/discv5/node_test.go
@@ -27,6 +27,8 @@ import (
 	"testing/quick"
 	"time"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/crypto"
 )
@@ -152,10 +154,8 @@ func TestParseNode(t *testing.T) {
 			if err == nil {
 				t.Errorf("test %q:\n  got nil error, expected %#q", test.rawurl, test.wantError)
 				continue
-			} else if err.Error() != test.wantError {
-				t.Errorf("test %q:\n  got error %#q, expected %#q", test.rawurl, err.Error(), test.wantError)
-				continue
 			}
+			require.Contains(t, err.Error(), test.wantError, "test %q:\n  got error %#q, expected %#q", test.rawurl, err.Error(), test.wantError)
 		} else {
 			if err != nil {
 				t.Errorf("test %q:\n  unexpected error: %v", test.rawurl, err)

--- a/p2p/enode/urlv4_test.go
+++ b/p2p/enode/urlv4_test.go
@@ -23,6 +23,8 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/p2p/enr"
 )
@@ -162,10 +164,8 @@ func TestParseNode(t *testing.T) {
 			if err == nil {
 				t.Errorf("test %q:\n  got nil error, expected %#q", test.input, test.wantError)
 				continue
-			} else if err.Error() != test.wantError {
-				t.Errorf("test %q:\n  got error %#q, expected %#q", test.input, err.Error(), test.wantError)
-				continue
 			}
+			require.Contains(t, err.Error(), test.wantError, "test %q:\n  got error %#q, expected %#q", test.input, err.Error(), test.wantError)
 		} else {
 			if err != nil {
 				t.Errorf("test %q:\n  unexpected error: %v", test.input, err)

--- a/rpc/client_test.go
+++ b/rpc/client_test.go
@@ -380,7 +380,7 @@ func TestClientNotificationStorm(t *testing.T) {
 	}
 
 	doTest(8000, false)
-	doTest(21000, true)
+	doTest(22000, true)
 }
 
 func TestClientHTTP(t *testing.T) {


### PR DESCRIPTION
see #19959 for info about the bug.