### PR TITLE
appveyor: bump to Go 1.12.9

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -24,7 +24,7 @@ install:
   - git submodule update --init
   - rmdir C:\go /s /q
   - appveyor DownloadFile https://dl.google.com/go/go1.12.7.windows-%GETH_ARCH%.zip
-  - 7z x go1.12.7.windows-%GETH_ARCH%.zip -y -oC:\ > NUL
+  - 7z x go1.12.8.windows-%GETH_ARCH%.zip -y -oC:\ > NUL
   - go version
   - gcc --version
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -23,8 +23,8 @@ environment:
 install:
   - git submodule update --init
   - rmdir C:\go /s /q
-  - appveyor DownloadFile https://dl.google.com/go/go1.12.7.windows-%GETH_ARCH%.zip
-  - 7z x go1.12.8.windows-%GETH_ARCH%.zip -y -oC:\ > NUL
+  - appveyor DownloadFile https://dl.google.com/go/go1.12.9.windows-%GETH_ARCH%.zip
+  - 7z x go1.12.9.windows-%GETH_ARCH%.zip -y -oC:\ > NUL
   - go version
   - gcc --version
 


### PR DESCRIPTION
Release notes: https://golang.org/doc/devel/release.html#go1.12.minor

BTW: Might be worth waiting for https://github.com/karalabe/usb/pull/6