### PR TITLE
check suicide result before transfer

### DIFF
--- a/core/vm/instructions.go
+++ b/core/vm/instructions.go
@@ -878,9 +878,11 @@ func opStop(pc *uint64, interpreter *EVMInterpreter, contract *Contract, memory 
 
 func opSuicide(pc *uint64, interpreter *EVMInterpreter, contract *Contract, memory *Memory, stack *Stack) ([]byte, error) {
 	balance := interpreter.evm.StateDB.GetBalance(contract.Address())
-	interpreter.evm.StateDB.AddBalance(common.BigToAddress(stack.pop()), balance)
 
-	interpreter.evm.StateDB.Suicide(contract.Address())
+	suicided := interpreter.evm.StateDB.Suicide(contract.Address())
+	if suicided {
+		interpreter.evm.StateDB.AddBalance(common.BigToAddress(stack.pop()), balance)
+	}
 	return nil, nil
 }
 


### PR DESCRIPTION
Make sure contract suicides successfully before add balance to other address.