### PR TITLE
blockchain: fix flaw in block import

### DIFF
--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -1742,6 +1742,11 @@ func (bc *BlockChain) insertSideChain(block *types.Block, it *insertIterator) (i
 			canonical := bc.GetBlockByNumber(number)
 			if canonical != nil && canonical.Hash() == block.Hash() {
 				// Not a sidechain block, this is a re-import of a canon block which has it's state pruned
+
+				// Collect the TD of the block. Since we know it's a canon one,
+				// we can get it directly, and not (like further below) use
+				// the parent and then add the block on top
+				externTd = bc.GetTd(block.Hash(), block.NumberU64())
 				continue
 			}
 			if canonical != nil && canonical.Root() == block.Root() {

--- a/core/blockchain_test.go
+++ b/core/blockchain_test.go
@@ -2281,7 +2281,7 @@ func TestSideImportPrunedBlocks(t *testing.T) {
 		t.Errorf("Block %d pruned", firstNonPrunedBlock.NumberU64())
 	}
 	// Now re-import some old blocks
-	blockToReimport := blocks[5 : 8]
+	blockToReimport := blocks[5:8]
 	_, err = chain.InsertChain(blockToReimport)
 	if err != nil {
 		t.Errorf("Got error, %v", err)

--- a/core/blockchain_test.go
+++ b/core/blockchain_test.go
@@ -2242,12 +2242,15 @@ func BenchmarkBlockChain_1x1000Executions(b *testing.B) {
 	benchmarkLargeNumberOfValueToNonexisting(b, numTxs, numBlocks, recipientFn, dataFn)
 }
 
-// Tests that importing a some old blocks, where the first one is before the
+// Tests that importing a some old blocks, where all blocks are before the
 // pruning point.
 // This internally leads to a sidechain import, since the blocks trigger an
 // ErrPrunedAncestor error.
+// This may e.g. happen if
+//   1. Downloader rollbacks a batch of inserted blocks and exits
+//   2. Downloader starts to sync again
+//   3. The blocks fetched are all known and canonical blocks
 func TestSideImportPrunedBlocks(t *testing.T) {
-
 	// Generate a canonical chain to act as the main dataset
 	engine := ethash.NewFaker()
 	db := rawdb.NewMemoryDatabase()
@@ -2272,15 +2275,13 @@ func TestSideImportPrunedBlocks(t *testing.T) {
 	if chain.HasBlockAndState(lastPrunedBlock.Hash(), lastPrunedBlock.NumberU64()) {
 		t.Errorf("Block %d not pruned", lastPrunedBlock.NumberU64())
 	}
-
 	firstNonPrunedBlock := blocks[len(blocks)-TriesInMemory]
 	// Verify firstNonPrunedBlock is not pruned
 	if !chain.HasBlockAndState(firstNonPrunedBlock.Hash(), firstNonPrunedBlock.NumberU64()) {
 		t.Errorf("Block %d pruned", firstNonPrunedBlock.NumberU64())
 	}
-
 	// Now re-import some old blocks
-	blockToReimport := blocks[5 : len(blocks)-TriesInMemory]
+	blockToReimport := blocks[5 : 8]
 	_, err = chain.InsertChain(blockToReimport)
 	if err != nil {
 		t.Errorf("Got error, %v", err)

--- a/core/blockchain_test.go
+++ b/core/blockchain_test.go
@@ -2241,3 +2241,48 @@ func BenchmarkBlockChain_1x1000Executions(b *testing.B) {
 	}
 	benchmarkLargeNumberOfValueToNonexisting(b, numTxs, numBlocks, recipientFn, dataFn)
 }
+
+// Tests that importing a some old blocks, where the first one is before the
+// pruning point.
+// This internally leads to a sidechain import, since the blocks trigger an
+// ErrPrunedAncestor error.
+func TestSideImportPrunedBlocks(t *testing.T) {
+
+	// Generate a canonical chain to act as the main dataset
+	engine := ethash.NewFaker()
+	db := rawdb.NewMemoryDatabase()
+	genesis := new(Genesis).MustCommit(db)
+
+	// Generate and import the canonical chain
+	blocks, _ := GenerateChain(params.TestChainConfig, genesis, engine, db, 2*TriesInMemory, nil)
+	diskdb := rawdb.NewMemoryDatabase()
+	new(Genesis).MustCommit(diskdb)
+	chain, err := NewBlockChain(diskdb, nil, params.TestChainConfig, engine, vm.Config{}, nil)
+	if err != nil {
+		t.Fatalf("failed to create tester chain: %v", err)
+	}
+	if n, err := chain.InsertChain(blocks); err != nil {
+		t.Fatalf("block %d: failed to insert into chain: %v", n, err)
+	}
+
+	lastPrunedIndex := len(blocks) - TriesInMemory - 1
+	lastPrunedBlock := blocks[lastPrunedIndex]
+
+	// Verify pruning of lastPrunedBlock
+	if chain.HasBlockAndState(lastPrunedBlock.Hash(), lastPrunedBlock.NumberU64()) {
+		t.Errorf("Block %d not pruned", lastPrunedBlock.NumberU64())
+	}
+
+	firstNonPrunedBlock := blocks[len(blocks)-TriesInMemory]
+	// Verify firstNonPrunedBlock is not pruned
+	if !chain.HasBlockAndState(firstNonPrunedBlock.Hash(), firstNonPrunedBlock.NumberU64()) {
+		t.Errorf("Block %d pruned", firstNonPrunedBlock.NumberU64())
+	}
+
+	// Now re-import some old blocks
+	blockToReimport := blocks[5 : len(blocks)-TriesInMemory]
+	_, err = chain.InsertChain(blockToReimport)
+	if err != nil {
+		t.Errorf("Got error, %v", err)
+	}
+}


### PR DESCRIPTION
This PR fixes a problem which we've seen on the monitoring nodes

```
WARN [08-20|11:36:00.080] Reduced total capacity                   maxFreePeers=153
INFO [08-20|11:36:07.994] Imported new chain segment               blocks=1  txs=104  mgas=8.003  elapsed=9.274s    mgasps=0.863   number=8386921 hash=5c37c8…03da03 age=15m52s   dirty=201.49MiB
INFO [08-20|11:36:16.709] Deep froze chain segment                 blocks=10 elapsed=1.344s    number=8296920 hash=19882b…ac6077
INFO [08-20|11:36:26.607] Imported new chain segment               blocks=1  txs=107  mgas=7.828  elapsed=18.613s   mgasps=0.421   number=8386922 hash=9e95e0…7fcadd age=16m4s    dirty=201.60MiB
INFO [08-20|11:36:46.553] Imported new chain segment               blocks=3  txs=290  mgas=23.962 elapsed=19.945s   mgasps=1.201   number=8386925 hash=626756…e38e0f age=16m10s   dirty=201.54MiB
INFO [08-20|11:36:55.482] Imported new chain segment               blocks=2  txs=266  mgas=15.963 elapsed=8.929s    mgasps=1.788   number=8386927 hash=3f1233…0d2a07 age=15m53s   dirty=201.96MiB
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x522a9e]
goroutine 6200928 [running]:
math/big.(*Int).Cmp(0xc068601b20, 0x0, 0xb29f47668c56a78d)
	/usr/local/go/src/math/big/int.go:326 +0x2e
github.com/ethereum/go-ethereum/core.(*BlockChain).insertSideChain(0xc000222000, 0xc0bc3b46c0, 0xc0b2973c00, 0x4, 0xc0b2973b00, 0x4, 0x4, 0x2, 0x1, 0xc1465c8f60, ...)
	/go-ethereum/build/_workspace/src/github.com/ethereum/go-ethereum/core/blockchain.go:1786 +0x1303
github.com/ethereum/go-ethereum/core.(*BlockChain).insertChain(0xc000222000, 0xc12bee5ec8, 0x1, 0x1, 0x1c3dd01, 0x0, 0x0, 0x0, 0x0, 0x0, ...)
	/go-ethereum/build/_workspace/src/github.com/ethereum/go-ethereum/core/blockchain.go:1525 +0x4874
github.com/ethereum/go-ethereum/core.(*BlockChain).InsertChain(0xc000222000, 0xc12bee5ec8, 0x1, 0x1, 0x0, 0x0, 0x0)
	/go-ethereum/build/_workspace/src/github.com/ethereum/go-ethereum/core/blockchain.go:1431 +0xd61
github.com/ethereum/go-ethereum/eth.NewProtocolManager.func3(0xc12bee5ec8, 0x1, 0x1, 0x2227501, 0xc0bd2f6bd0, 0x1e85cfc0628d07e0)
	/go-ethereum/build/_workspace/src/github.com/ethereum/go-ethereum/eth/handler.go:181 +0x73f
github.com/ethereum/go-ethereum/eth/fetcher.(*Fetcher).insert.func1(0xc01cb54d00, 0x3c3b7b00c197e6c0, 0x1b409f6a1917b835, 0x1e85cfc0628d07e0, 0x27e55d3693e5bb46, 0xc0bc3b46c0, 0xc0a04bb000, 0x10)
	/go-ethereum/build/_workspace/src/github.com/ethereum/go-ethereum/eth/fetcher/fetcher.go:667 +0x571
created by github.com/ethereum/go-ethereum/eth/fetcher.(*Fetcher).insert
	/go-ethereum/build/_workspace/src/github.com/ethereum/go-ethereum/eth/fetcher/fetcher.go:641 +0x2bc
INFO [08-20|11:36:57.600] Starting pprof server                    addr=http://0.0.0.0:6060/debug/pprof
INFO [08-20|11:36:57.600] Bumping default cache on mainnet         provided=1024 updated=4096 
```

The testcase added in this PR triggers the same bug. For some reason, `blockchain` is given a chunk of blocks that are already canon and imported, but have been pruned already (more than 128 blocks back). Pruned but canon blocks make the sidechain import loop `continue` early, and unless a non-canon block is found, the loop ends without setting `externTd`, leaving it `nil`, which causes a seg violation later on. 