### PR TITLE
Accounts in alloc field must already exist

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,7 +233,7 @@ aware of and agree upon. This consists of a small JSON file (e.g. call it `genes
 
 The above fields should be fine for most purposes, although we'd recommend changing
 the `nonce` to some random value so you prevent unknown remote nodes from being able
-to connect to you. If you'd like to pre-fund some accounts for easier testing, you can
+to connect to you. If you'd like to pre-fund some existing accounts for easier testing, you can
 populate the `alloc` field with account configs:
 
 ```json


### PR DESCRIPTION
Note that accounts in alloc field must already exist, as pointed out by Simeon Vanov in https://gettoshare.com/2017/10/30/how-to-use-genesis-json-alloc-property/