### PR TITLE
Adding a donation button to get donations/sponsorships

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+custom: https://donate.unlock-protocol.com/?r=ethereum/go-ethereum

--- a/.unlock-protocol.config.json
+++ b/.unlock-protocol.config.json
@@ -1,0 +1,14 @@
+{
+  "persistentCheckout": true,
+  "icon": "",
+  "callToAction": {
+    "default": "Please show your support for the Go-Ethereum team's work!",
+    "pending": "Thank you for your support. It means a lot to us!",
+    "confirmed": "Thank you for your support. It means a lot to us!"
+  },
+  "locks": {
+    "0x0364c5D9C268a1870f49AD2819801624d8Ce0fF0": {
+      "name": "Go Ethereum Supporters"
+    }
+  }
+}


### PR DESCRIPTION
Hello!

First of all, thanks for your (hard) work!

As an OpenSource project, I believe Geth should have a `FUNDING.yml` file which lets people make donations if they enjoy the software.

This pull requests adds donation thru an [Unlock](https://unlock-protocol.com/) lock. Locks are smart contract which let people become members by purchasing a key. The key itself is a non fungible token: 🗝 . (you can view the NFT on [OpenSea](https://opensea.io/assets/0x0364c5d9c268a1870f49ad2819801624d8ce0ff0/1) for example)

This specific lock is at [`0x0364c5d9c268a1870f49ad2819801624d8ce0ff0`](https://etherscan.io/address/0x0364c5d9c268a1870f49ad2819801624d8ce0ff0). The current key price is 0.01Eth. I currently own the lock but I'll happily transfer its ownership to you if you can send me an address ;) Keys are valid for 1 month and there can be an infinite number of keys.

The pull-request adds 2 files: `FUNDING.yml` which is a github standard file to add a "donation button" with the right links when people click on it and a file which includes the configuration for the donation page.

You can try this on another project which already uses the donation button such as [Unlock](https://github.com/unlock-protocol/unlock/), [MyCrypto](https://github.com/mycryptohq/mycrypto), or [WalletConnect](https://github.com/WalletConnect/walletconnect-monorepo/)...

When/if you merge this you also need to enable donations in the settings (see https://github.com/ethereum/go-ethereum/settings): 

<img width="747" alt="image" src="https://user-images.githubusercontent.com/17735/63268593-88d8bd80-c262-11e9-92f7-2d458c07e74f.png">


