### PR TITLE
eth: disallow overwrite files via admin.exportChain

### DIFF
--- a/eth/api.go
+++ b/eth/api.go
@@ -168,6 +168,11 @@ func NewPrivateAdminAPI(eth *Ethereum) *PrivateAdminAPI {
 
 // ExportChain exports the current blockchain into a local file.
 func (api *PrivateAdminAPI) ExportChain(file string) (bool, error) {
+	if _, err := os.Stat(file); err == nil {
+		// File already exists. Allowing overwrite could be a DoS vecotor,
+		// since the 'file' may point to arbitrary paths on the drive
+		return false, errors.New("location would overwrite an existing file")
+	}
 	// Make sure we can create the file to export into
 	out, err := os.OpenFile(file, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, os.ModePerm)
 	if err != nil {


### PR DESCRIPTION
This is a minor change in `admin.exportChain`, to disallow overwriting existing files. The `admin` namespace really should not be open against external attackers, but if it happens to be, better safe than sorry. 