### PR TITLE
cmd, internal/build,docker:tag final stage docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ ADD . /go-ethereum
 RUN cd /go-ethereum && make geth
 
 # Pull Geth into a second stage deploy alpine container
-FROM alpine:latest
+FROM alpine:3.10
 
 RUN apk add --no-cache ca-certificates
 COPY --from=builder /go-ethereum/build/bin/geth /usr/local/bin/

--- a/Dockerfile.alltools
+++ b/Dockerfile.alltools
@@ -7,7 +7,7 @@ ADD . /go-ethereum
 RUN cd /go-ethereum && make all
 
 # Pull all binaries into a second stage deploy alpine container
-FROM alpine:latest
+FROM alpine:3.10
 
 RUN apk add --no-cache ca-certificates
 COPY --from=builder /go-ethereum/build/bin/* /usr/local/bin/


### PR DESCRIPTION
It's a good practice to add a specific tag to the docker images, instead of latest, this will lead to consistent builds in the future. This PR changes the tag from latest to 3.10, which is what the builder docker image (golang:1.12-alpine) uses as it's [base](https://github.com/docker-library/golang/blob/2f6469ffe955721dd25e4cbb3013506659998aad/1.12/alpine3.10/Dockerfile)