### PR TITLE
Fix typo in sidebar for account management

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -11,7 +11,7 @@ Main entry points:
 
 * [Installation Instructions](../install-and-build/Building-Ethereum)
 * [Management APIs](../interface/Management-APIs)
-* [Managing Accounts](../how-to/Managing-your-accounts)
+* [Managing Accounts](../interface/Managing-your-accounts)
 * [Command Line Options](../interface/Command-Line-Options)
 * [JavaScript Console](../interface/JavaScript-Console)
 * [Private Network](../doc/Private-network)


### PR DESCRIPTION
This fixes #20014. The sidebar entry for `managing accounts`, has a typo.