### PR TITLE
core/state: optimize some internals during encoding

### DIFF
--- a/common/bytes.go
+++ b/common/bytes.go
@@ -134,3 +134,14 @@ func LeftPadBytes(slice []byte, l int) []byte {
 
 	return padded
 }
+
+// TrimLeftZeroes returns a subslice of s without leading zeroes
+func TrimLeftZeroes(s []byte) []byte {
+	idx := 0
+	for ; idx < len(s); idx++ {
+		if s[idx] != 0 {
+			break
+		}
+	}
+	return s[idx:]
+}

--- a/core/state/state_object.go
+++ b/core/state/state_object.go
@@ -274,7 +274,7 @@ func (s *stateObject) updateTrie(db Database) Trie {
 			continue
 		}
 		// Encoding []byte cannot fail, ok to ignore the error.
-		v, _ := rlp.EncodeToBytes(bytes.TrimLeft(value[:], "\x00"))
+		v, _ := rlp.EncodeToBytes(common.TrimLeftZeroes(value[:]))
 		s.setError(tr.TryUpdate(key[:], v))
 	}
 	return tr

--- a/core/state/state_object_test.go
+++ b/core/state/state_object_test.go
@@ -1,0 +1,70 @@
+// Copyright 2019 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+package state
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"testing"
+	"time"
+
+	"github.com/ethereum/go-ethereum/common"
+)
+
+func BenchmarkCutOriginal(b *testing.B) {
+	value := common.HexToHash("0x01")
+	for i := 0; i < b.N; i++ {
+		bytes.TrimLeft(value[:], "\x00")
+	}
+}
+
+func BenchmarkCutsetterFn(b *testing.B) {
+	value := common.HexToHash("0x01")
+	cutSetFn := func(r rune) bool {
+		return int32(r) == int32(0)
+	}
+	for i := 0; i < b.N; i++ {
+		bytes.TrimLeftFunc(value[:], cutSetFn)
+	}
+}
+
+func BenchmarkCutCustomTrim(b *testing.B) {
+	value := common.HexToHash("0x01")
+	for i := 0; i < b.N; i++ {
+		common.TrimLeftZeroes(value[:])
+	}
+}
+
+func xTestFuzzCutter(t *testing.T) {
+	rand.Seed(time.Now().Unix())
+	for {
+		v := make([]byte, 20)
+		zeroes := rand.Intn(21)
+		rand.Read(v[zeroes:])
+		exp := bytes.TrimLeft(v[:], "\x00")
+		got := common.TrimLeftZeroes(v)
+		if !bytes.Equal(exp, got) {
+
+			fmt.Printf("Input %x\n", v)
+			fmt.Printf("Exp %x\n", exp)
+			fmt.Printf("Got %x\n", got)
+			t.Fatalf("Error")
+		}
+		//break
+	}
+}


### PR DESCRIPTION
I noticed this wile investigating the state a bit. What we currently do before RLP-encoding a slot value is to call `TrimLeft`:
```golang
func TrimLeft(s []byte, cutset string) []byte {
	return TrimLeftFunc(s, makeCutsetFunc(cutset))
}
```
... which dynamically creates a `cutSetFunction` . 
Then it calls `TrimLeftFunc`, which: 
```golang
// TrimLeftFunc treats s as UTF-8-encoded bytes and returns a subslice of s by slicing off
// all leading UTF-8-encoded code points c that satisfy f(c).
func TrimLeftFunc(s []byte, f func(r rune) bool) []byte {
```
It interprets the data as `UTF-8` encoded data, and parses runes. 

In our case, it's the wrong abstraction, what we want to do here is simply trim leading zeroes, which has nothing whatsoever to do with `UTF-8` and runes. 

This PR replaces that with a simple for-loop, more or less. 

benchmark results:
```
[user@work state]$ go test . -bench BenchmarkCut*
OK: 5 passed
goos: linux
goarch: amd64
pkg: github.com/ethereum/go-ethereum/core/state
BenchmarkCutOriginal-6     	10000000	       146 ns/op
BenchmarkCutsetterFn-6     	20000000	        86.3 ns/op
BenchmarkCutCustomTrim-6   	50000000	        28.9 ns/op
PASS
ok  	github.com/ethereum/go-ethereum/core/state	11.941s
```
It's probably a drop in the ocean though... 