### PR TITLE
[WIP] arm64/aarch64 build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,7 @@ jobs:
       - sudo mount --bind /proc chrootdir/proc
       - sudo mount --bind /sys chrootdir/sys
       - sudo chroot chrootdir qemu-aarch64-static /bin/bash -c "export GOROOT=/usr/local/go; export PATH=\$PATH:\$GOROOT/bin; cd ${TRAVIS_BUILD_DIR} && go run build/ci.go install"
-      - sudo chroot chrootdir qemu-aarch64-static /bin/bash -c "export GOROOT=/usr/local/go; export PATH=\$PATH:\$GOROOT/bin; cd ${TRAVIS_BUILD_DIR} && go run build/ci.go test"
+      - HOME=/root sudo chroot chrootdir qemu-aarch64-static /bin/bash -c "export GOROOT=/usr/local/go; export PATH=\$PATH:\$GOROOT/bin; cd ${TRAVIS_BUILD_DIR} && go run build/ci.go test"
 
     - stage: build
       os: linux

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ jobs:
       - wget https://github.com/gballet/ubuntu-18.4-go-rootfs/releases/download/ubuntu1804-go113/rootfs_v1.txz
       - sudo tar xfJ rootfs_v1.txz -C chrootdir
       - rm rootfs_v1.txz
-      - sudo cp /etc/resolv.conf chrootdir/etc
+      - sudo cp --remove-destination /etc/resolv.conf chrootdir/etc
       - sudo cp `which qemu-aarch64-static` chrootdir/usr/bin
       - sudo mkdir -p chrootdir/${TRAVIS_BUILD_DIR}
       - sudo rsync -a --exclude 'chrootdir' ${TRAVIS_BUILD_DIR}/ chrootdir/${TRAVIS_BUILD_DIR}/

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,7 @@ jobs:
       - wget https://github.com/gballet/ubuntu-18.4-go-rootfs/releases/download/ubuntu1804-go113/rootfs_v1.txz
       - sudo tar xfJ rootfs_v1.txz -C chrootdir
       - rm rootfs_v1.txz
+      - sudo cp /etc/resolv.conf chrootdir/etc
       - sudo cp `which qemu-aarch64-static` chrootdir/usr/bin
       - sudo mkdir -p chrootdir/${TRAVIS_BUILD_DIR}
       - sudo rsync -a --exclude 'chrootdir' ${TRAVIS_BUILD_DIR}/ chrootdir/${TRAVIS_BUILD_DIR}/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: go
 go_import_path: github.com/ethereum/go-ethereum
-sudo: false
+sudo: true
 jobs:
   include:
         # This builder only tests code linters on latest version of Go
@@ -14,6 +14,24 @@ jobs:
         submodules: false # avoid cloning ethereum/tests
       script:
         - go run build/ci.go lint
+
+    - stage: build
+      os: linux
+      dist: bionic
+      before_install:
+      - sudo apt install -y qemu-user-static xz-utils # qemu-system qemu-efi debootstrap
+      script:
+      - mkdir -p chrootdir
+      - wget https://github.com/gballet/ubuntu-18.4-go-rootfs/releases/download/ubuntu1804-go113/rootfs_v1.txz
+      - sudo tar xfJ rootfs_v1.txz -C chrootdir
+      - rm rootfs_v1.txz
+      - sudo cp `which qemu-aarch64-static` chrootdir/usr/bin
+      - sudo mkdir -p chrootdir/${TRAVIS_BUILD_DIR}
+      - sudo rsync -a --exclude 'chrootdir' ${TRAVIS_BUILD_DIR}/ chrootdir/${TRAVIS_BUILD_DIR}/
+      - sudo mount --bind /proc chrootdir/proc
+      - sudo mount --bind /sys chrootdir/sys
+      - sudo chroot chrootdir qemu-aarch64-static /bin/bash -c "export GOROOT=/usr/local/go; export PATH=\$PATH:\$GOROOT/bin; cd ${TRAVIS_BUILD_DIR} && go run build/ci.go install"
+      - sudo chroot chrootdir qemu-aarch64-static /bin/bash -c "export GOROOT=/usr/local/go; export PATH=\$PATH:\$GOROOT/bin; cd ${TRAVIS_BUILD_DIR} && go run build/ci.go test"
 
     - stage: build
       os: linux

--- a/build/ci.go
+++ b/build/ci.go
@@ -311,11 +311,16 @@ func doTest(cmdline []string) {
 		packages = flag.CommandLine.Args()
 	}
 
+	timeout := "5m"
+	if runtime.GOARCH == "arm64" && os.Getenv("CI") == "true" {
+		timeout = "10m"
+	}
+
 	// Run the actual tests.
 	// Test a single package at a time. CI builders are slow
 	// and some tests run into timeouts under load.
 	gotest := goTool("test", buildFlags(env)...)
-	gotest.Args = append(gotest.Args, "-p", "1", "-timeout", "5m")
+	gotest.Args = append(gotest.Args, "-p", "1", "-timeout", timeout)
 	if *coverage {
 		gotest.Args = append(gotest.Args, "-covermode=atomic", "-cover")
 	}

--- a/metrics/doc.go
+++ b/metrics/doc.go
@@ -1,0 +1,4 @@
+package metrics
+
+const Epsilon = 0.0000000000000001
+const EpsilonPercentile = .00000000001

--- a/metrics/ewma_test.go
+++ b/metrics/ewma_test.go
@@ -1,6 +1,9 @@
 package metrics
 
-import "testing"
+import (
+	"math"
+	"testing"
+)
 
 func BenchmarkEWMA(b *testing.B) {
 	a := NewEWMA1()
@@ -15,67 +18,67 @@ func TestEWMA1(t *testing.T) {
 	a := NewEWMA1()
 	a.Update(3)
 	a.Tick()
-	if rate := a.Rate(); 0.6 != rate {
+	if rate := a.Rate(); math.Abs(0.6-rate) > Epsilon {
 		t.Errorf("initial a.Rate(): 0.6 != %v\n", rate)
 	}
 	elapseMinute(a)
-	if rate := a.Rate(); 0.22072766470286553 != rate {
+	if rate := a.Rate(); math.Abs(0.22072766470286553-rate) > Epsilon {
 		t.Errorf("1 minute a.Rate(): 0.22072766470286553 != %v\n", rate)
 	}
 	elapseMinute(a)
-	if rate := a.Rate(); 0.08120116994196772 != rate {
+	if rate := a.Rate(); math.Abs(0.08120116994196772-rate) > Epsilon {
 		t.Errorf("2 minute a.Rate(): 0.08120116994196772 != %v\n", rate)
 	}
 	elapseMinute(a)
-	if rate := a.Rate(); 0.029872241020718428 != rate {
+	if rate := a.Rate(); math.Abs(0.029872241020718428-rate) > Epsilon {
 		t.Errorf("3 minute a.Rate(): 0.029872241020718428 != %v\n", rate)
 	}
 	elapseMinute(a)
-	if rate := a.Rate(); 0.01098938333324054 != rate {
+	if rate := a.Rate(); math.Abs(0.01098938333324054-rate) > Epsilon {
 		t.Errorf("4 minute a.Rate(): 0.01098938333324054 != %v\n", rate)
 	}
 	elapseMinute(a)
-	if rate := a.Rate(); 0.004042768199451294 != rate {
+	if rate := a.Rate(); math.Abs(0.004042768199451294-rate) > Epsilon {
 		t.Errorf("5 minute a.Rate(): 0.004042768199451294 != %v\n", rate)
 	}
 	elapseMinute(a)
-	if rate := a.Rate(); 0.0014872513059998212 != rate {
+	if rate := a.Rate(); math.Abs(0.0014872513059998212-rate) > Epsilon {
 		t.Errorf("6 minute a.Rate(): 0.0014872513059998212 != %v\n", rate)
 	}
 	elapseMinute(a)
-	if rate := a.Rate(); 0.0005471291793327122 != rate {
+	if rate := a.Rate(); math.Abs(0.0005471291793327122-rate) > Epsilon {
 		t.Errorf("7 minute a.Rate(): 0.0005471291793327122 != %v\n", rate)
 	}
 	elapseMinute(a)
-	if rate := a.Rate(); 0.00020127757674150815 != rate {
+	if rate := a.Rate(); math.Abs(0.00020127757674150815-rate) > Epsilon {
 		t.Errorf("8 minute a.Rate(): 0.00020127757674150815 != %v\n", rate)
 	}
 	elapseMinute(a)
-	if rate := a.Rate(); 7.404588245200814e-05 != rate {
+	if rate := a.Rate(); math.Abs(7.404588245200814e-05-rate) > Epsilon {
 		t.Errorf("9 minute a.Rate(): 7.404588245200814e-05 != %v\n", rate)
 	}
 	elapseMinute(a)
-	if rate := a.Rate(); 2.7239957857491083e-05 != rate {
+	if rate := a.Rate(); math.Abs(2.7239957857491083e-05-rate) > Epsilon {
 		t.Errorf("10 minute a.Rate(): 2.7239957857491083e-05 != %v\n", rate)
 	}
 	elapseMinute(a)
-	if rate := a.Rate(); 1.0021020474147462e-05 != rate {
+	if rate := a.Rate(); math.Abs(1.0021020474147462e-05-rate) > Epsilon {
 		t.Errorf("11 minute a.Rate(): 1.0021020474147462e-05 != %v\n", rate)
 	}
 	elapseMinute(a)
-	if rate := a.Rate(); 3.6865274119969525e-06 != rate {
+	if rate := a.Rate(); math.Abs(3.6865274119969525e-06-rate) > Epsilon {
 		t.Errorf("12 minute a.Rate(): 3.6865274119969525e-06 != %v\n", rate)
 	}
 	elapseMinute(a)
-	if rate := a.Rate(); 1.3561976441886433e-06 != rate {
+	if rate := a.Rate(); math.Abs(1.3561976441886433e-06-rate) > Epsilon {
 		t.Errorf("13 minute a.Rate(): 1.3561976441886433e-06 != %v\n", rate)
 	}
 	elapseMinute(a)
-	if rate := a.Rate(); 4.989172314621449e-07 != rate {
+	if rate := a.Rate(); math.Abs(4.989172314621449e-07-rate) > Epsilon {
 		t.Errorf("14 minute a.Rate(): 4.989172314621449e-07 != %v\n", rate)
 	}
 	elapseMinute(a)
-	if rate := a.Rate(); 1.8354139230109722e-07 != rate {
+	if rate := a.Rate(); math.Abs(1.8354139230109722e-07-rate) > Epsilon {
 		t.Errorf("15 minute a.Rate(): 1.8354139230109722e-07 != %v\n", rate)
 	}
 }
@@ -84,67 +87,67 @@ func TestEWMA5(t *testing.T) {
 	a := NewEWMA5()
 	a.Update(3)
 	a.Tick()
-	if rate := a.Rate(); 0.6 != rate {
+	if rate := a.Rate(); math.Abs(0.6-rate) > Epsilon {
 		t.Errorf("initial a.Rate(): 0.6 != %v\n", rate)
 	}
 	elapseMinute(a)
-	if rate := a.Rate(); 0.49123845184678905 != rate {
+	if rate := a.Rate(); math.Abs(0.49123845184678905-rate) > Epsilon {
 		t.Errorf("1 minute a.Rate(): 0.49123845184678905 != %v\n", rate)
 	}
 	elapseMinute(a)
-	if rate := a.Rate(); 0.4021920276213837 != rate {
+	if rate := a.Rate(); math.Abs(0.4021920276213837-rate) > Epsilon {
 		t.Errorf("2 minute a.Rate(): 0.4021920276213837 != %v\n", rate)
 	}
 	elapseMinute(a)
-	if rate := a.Rate(); 0.32928698165641596 != rate {
+	if rate := a.Rate(); math.Abs(0.32928698165641596-rate) > Epsilon {
 		t.Errorf("3 minute a.Rate(): 0.32928698165641596 != %v\n", rate)
 	}
 	elapseMinute(a)
-	if rate := a.Rate(); 0.269597378470333 != rate {
+	if rate := a.Rate(); math.Abs(0.269597378470333-rate) > Epsilon {
 		t.Errorf("4 minute a.Rate(): 0.269597378470333 != %v\n", rate)
 	}
 	elapseMinute(a)
-	if rate := a.Rate(); 0.2207276647028654 != rate {
+	if rate := a.Rate(); math.Abs(0.2207276647028654-rate) > Epsilon {
 		t.Errorf("5 minute a.Rate(): 0.2207276647028654 != %v\n", rate)
 	}
 	elapseMinute(a)
-	if rate := a.Rate(); 0.18071652714732128 != rate {
+	if rate := a.Rate(); math.Abs(0.18071652714732128-rate) > Epsilon {
 		t.Errorf("6 minute a.Rate(): 0.18071652714732128 != %v\n", rate)
 	}
 	elapseMinute(a)
-	if rate := a.Rate(); 0.14795817836496392 != rate {
+	if rate := a.Rate(); math.Abs(0.14795817836496392-rate) > Epsilon {
 		t.Errorf("7 minute a.Rate(): 0.14795817836496392 != %v\n", rate)
 	}
 	elapseMinute(a)
-	if rate := a.Rate(); 0.12113791079679326 != rate {
+	if rate := a.Rate(); math.Abs(0.12113791079679326-rate) > Epsilon {
 		t.Errorf("8 minute a.Rate(): 0.12113791079679326 != %v\n", rate)
 	}
 	elapseMinute(a)
-	if rate := a.Rate(); 0.09917933293295193 != rate {
+	if rate := a.Rate(); math.Abs(0.09917933293295193-rate) > Epsilon {
 		t.Errorf("9 minute a.Rate(): 0.09917933293295193 != %v\n", rate)
 	}
 	elapseMinute(a)
-	if rate := a.Rate(); 0.08120116994196763 != rate {
+	if rate := a.Rate(); math.Abs(0.08120116994196763-rate) > Epsilon {
 		t.Errorf("10 minute a.Rate(): 0.08120116994196763 != %v\n", rate)
 	}
 	elapseMinute(a)
-	if rate := a.Rate(); 0.06648189501740036 != rate {
+	if rate := a.Rate(); math.Abs(0.06648189501740036-rate) > Epsilon {
 		t.Errorf("11 minute a.Rate(): 0.06648189501740036 != %v\n", rate)
 	}
 	elapseMinute(a)
-	if rate := a.Rate(); 0.05443077197364752 != rate {
+	if rate := a.Rate(); math.Abs(0.05443077197364752-rate) > Epsilon {
 		t.Errorf("12 minute a.Rate(): 0.05443077197364752 != %v\n", rate)
 	}
 	elapseMinute(a)
-	if rate := a.Rate(); 0.04456414692860035 != rate {
+	if rate := a.Rate(); math.Abs(0.04456414692860035-rate) > Epsilon {
 		t.Errorf("13 minute a.Rate(): 0.04456414692860035 != %v\n", rate)
 	}
 	elapseMinute(a)
-	if rate := a.Rate(); 0.03648603757513079 != rate {
+	if rate := a.Rate(); math.Abs(0.03648603757513079-rate) > Epsilon {
 		t.Errorf("14 minute a.Rate(): 0.03648603757513079 != %v\n", rate)
 	}
 	elapseMinute(a)
-	if rate := a.Rate(); 0.0298722410207183831020718428 != rate {
+	if rate := a.Rate(); math.Abs(0.0298722410207183831020718428-rate) > Epsilon {
 		t.Errorf("15 minute a.Rate(): 0.0298722410207183831020718428 != %v\n", rate)
 	}
 }
@@ -153,67 +156,67 @@ func TestEWMA15(t *testing.T) {
 	a := NewEWMA15()
 	a.Update(3)
 	a.Tick()
-	if rate := a.Rate(); 0.6 != rate {
+	if rate := a.Rate(); math.Abs(0.6-rate) > Epsilon {
 		t.Errorf("initial a.Rate(): 0.6 != %v\n", rate)
 	}
 	elapseMinute(a)
-	if rate := a.Rate(); 0.5613041910189706 != rate {
+	if rate := a.Rate(); math.Abs(0.5613041910189706-rate) > Epsilon {
 		t.Errorf("1 minute a.Rate(): 0.5613041910189706 != %v\n", rate)
 	}
 	elapseMinute(a)
-	if rate := a.Rate(); 0.5251039914257684 != rate {
+	if rate := a.Rate(); math.Abs(0.5251039914257684-rate) > Epsilon {
 		t.Errorf("2 minute a.Rate(): 0.5251039914257684 != %v\n", rate)
 	}
 	elapseMinute(a)
-	if rate := a.Rate(); 0.4912384518467888184678905 != rate {
+	if rate := a.Rate(); math.Abs(0.4912384518467888184678905-rate) > Epsilon {
 		t.Errorf("3 minute a.Rate(): 0.4912384518467888184678905 != %v\n", rate)
 	}
 	elapseMinute(a)
-	if rate := a.Rate(); 0.459557003018789 != rate {
+	if rate := a.Rate(); math.Abs(0.459557003018789-rate) > Epsilon {
 		t.Errorf("4 minute a.Rate(): 0.459557003018789 != %v\n", rate)
 	}
 	elapseMinute(a)
-	if rate := a.Rate(); 0.4299187863442732 != rate {
+	if rate := a.Rate(); math.Abs(0.4299187863442732-rate) > Epsilon {
 		t.Errorf("5 minute a.Rate(): 0.4299187863442732 != %v\n", rate)
 	}
 	elapseMinute(a)
-	if rate := a.Rate(); 0.4021920276213831 != rate {
+	if rate := a.Rate(); math.Abs(0.4021920276213831-rate) > Epsilon {
 		t.Errorf("6 minute a.Rate(): 0.4021920276213831 != %v\n", rate)
 	}
 	elapseMinute(a)
-	if rate := a.Rate(); 0.37625345116383313 != rate {
+	if rate := a.Rate(); math.Abs(0.37625345116383313-rate) > Epsilon {
 		t.Errorf("7 minute a.Rate(): 0.37625345116383313 != %v\n", rate)
 	}
 	elapseMinute(a)
-	if rate := a.Rate(); 0.3519877317060185 != rate {
+	if rate := a.Rate(); math.Abs(0.3519877317060185-rate) > Epsilon {
 		t.Errorf("8 minute a.Rate(): 0.3519877317060185 != %v\n", rate)
 	}
 	elapseMinute(a)
-	if rate := a.Rate(); 0.3292869816564153165641596 != rate {
+	if rate := a.Rate(); math.Abs(0.3292869816564153165641596-rate) > Epsilon {
 		t.Errorf("9 minute a.Rate(): 0.3292869816564153165641596 != %v\n", rate)
 	}
 	elapseMinute(a)
-	if rate := a.Rate(); 0.3080502714195546 != rate {
+	if rate := a.Rate(); math.Abs(0.3080502714195546-rate) > Epsilon {
 		t.Errorf("10 minute a.Rate(): 0.3080502714195546 != %v\n", rate)
 	}
 	elapseMinute(a)
-	if rate := a.Rate(); 0.2881831806538789 != rate {
+	if rate := a.Rate(); math.Abs(0.2881831806538789-rate) > Epsilon {
 		t.Errorf("11 minute a.Rate(): 0.2881831806538789 != %v\n", rate)
 	}
 	elapseMinute(a)
-	if rate := a.Rate(); 0.26959737847033216 != rate {
+	if rate := a.Rate(); math.Abs(0.26959737847033216-rate) > Epsilon {
 		t.Errorf("12 minute a.Rate(): 0.26959737847033216 != %v\n", rate)
 	}
 	elapseMinute(a)
-	if rate := a.Rate(); 0.2522102307052083 != rate {
+	if rate := a.Rate(); math.Abs(0.2522102307052083-rate) > Epsilon {
 		t.Errorf("13 minute a.Rate(): 0.2522102307052083 != %v\n", rate)
 	}
 	elapseMinute(a)
-	if rate := a.Rate(); 0.23594443252115815 != rate {
+	if rate := a.Rate(); math.Abs(0.23594443252115815-rate) > Epsilon {
 		t.Errorf("14 minute a.Rate(): 0.23594443252115815 != %v\n", rate)
 	}
 	elapseMinute(a)
-	if rate := a.Rate(); 0.2207276647028646247028654470286553 != rate {
+	if rate := a.Rate(); math.Abs(0.2207276647028646247028654470286553-rate) > Epsilon {
 		t.Errorf("15 minute a.Rate(): 0.2207276647028646247028654470286553 != %v\n", rate)
 	}
 }

--- a/metrics/sample_test.go
+++ b/metrics/sample_test.go
@@ -1,6 +1,7 @@
 package metrics
 
 import (
+	"math"
 	"math/rand"
 	"runtime"
 	"testing"
@@ -326,7 +327,7 @@ func testUniformSampleStatistics(t *testing.T, s Sample) {
 	if 7380.5 != ps[1] {
 		t.Errorf("75th percentile: 7380.5 != %v\n", ps[1])
 	}
-	if 9986.429999999998 != ps[2] {
+	if math.Abs(9986.429999999998-ps[2]) > EpsilonPercentile {
 		t.Errorf("99th percentile: 9986.429999999998 != %v\n", ps[2])
 	}
 }


### PR DESCRIPTION
This modifies the Travis build in order to include `aarch64` (aka arm64) as a target.

In order to circumvent the limitations imposed by Travis' build environment, it:
  * doesn't run the full virtual machine, and instead just emulates the useland execution, this is to not hit the "10 minutes without input" limit
  * uses a prepared rootfs that includes golang, in order not to have to handle the download of packages from a different architecture, which proved surprisingly tricky