### PR TITLE
common, graphql: fix hash/address decoding + UI content type

### DIFF
--- a/common/types.go
+++ b/common/types.go
@@ -149,7 +149,7 @@ func (h *Hash) UnmarshalGraphQL(input interface{}) error {
 	var err error
 	switch input := input.(type) {
 	case string:
-		*h = HexToHash(input)
+		err = h.UnmarshalText([]byte(input))
 	default:
 		err = fmt.Errorf("Unexpected type for Bytes32: %v", input)
 	}
@@ -288,7 +288,7 @@ func (a *Address) UnmarshalGraphQL(input interface{}) error {
 	var err error
 	switch input := input.(type) {
 	case string:
-		*a = HexToAddress(input)
+		err = a.UnmarshalText([]byte(input))
 	default:
 		err = fmt.Errorf("Unexpected type for Address: %v", input)
 	}

--- a/graphql/graphiql.go
+++ b/graphql/graphiql.go
@@ -52,7 +52,7 @@ func (h GraphiQL) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		respond(w, errorJSON("only GET requests are supported"), http.StatusMethodNotAllowed)
 		return
 	}
-
+	w.Header().Set("Content-Type", "text/html")
 	w.Write(graphiql)
 }
 


### PR DESCRIPTION
Fixes https://github.com/ethereum/go-ethereum/issues/20041.
Fixes graphiql content type.