### PR TITLE
build: switch PPA from Gophers dep to manual download

### DIFF
--- a/build/ci-notes.md
+++ b/build/ci-notes.md
@@ -22,19 +22,16 @@ variables `PPA_SIGNING_KEY` and `PPA_SSH_KEY` on Travis.
 
 We want to build go-ethereum with the most recent version of Go, irrespective of the Go
 version that is available in the main Ubuntu repository. In order to make this possible,
-our PPA depends on the ~gophers/ubuntu/archive PPA. Our source package build-depends on
-golang-1.11, which is co-installable alongside the regular golang package. PPA dependencies
-can be edited at https://launchpad.net/%7Eethereum/+archive/ubuntu/ethereum/+edit-dependencies
+our PPA always fetches a recent Go release for the upstream server and uses that.
 
 ## Building Packages Locally (for testing)
 
 You need to run Ubuntu to do test packaging.
 
-Add the gophers PPA and install Go 1.11 and Debian packaging tools:
+Install Go and the Debian packaging tools:
 
-    $ sudo apt-add-repository ppa:gophers/ubuntu/archive
     $ sudo apt-get update
-    $ sudo apt-get install build-essential golang-1.11 devscripts debhelper python-bzrlib python-paramiko
+    $ sudo apt-get install build-essential golang devscripts debhelper python-bzrlib python-paramiko
 
 Create the source packages:
 

--- a/build/deb/ethereum/deb.control
+++ b/build/deb/ethereum/deb.control
@@ -2,7 +2,7 @@ Source: {{.Name}}
 Section: science
 Priority: extra
 Maintainer: {{.Author}}
-Build-Depends: debhelper (>= 8.0.0), golang-1.11
+Build-Depends: debhelper (>= 8.0.0), golang
 Standards-Version: 3.9.5
 Homepage: https://ethereum.org
 Vcs-Git: git://github.com/ethereum/go-ethereum.git

--- a/build/deb/ethereum/deb.rules
+++ b/build/deb/ethereum/deb.rules
@@ -4,11 +4,12 @@
 # Uncomment this to turn on verbose mode.
 #export DH_VERBOSE=1
 
-# Launchpad rejects Go's access to $HOME/.cache, use custom folder
-export GOCACHE=/tmp/go-build
+# Launchpad rejects Go's access to $HOME, use custom folder
+export HOME=/tmp/home
 
 override_dh_auto_build:
-	build/env.sh /usr/lib/go-1.11/bin/go run build/ci.go install -git-commit={{.Env.Commit}} -git-branch={{.Env.Branch}} -git-tag={{.Env.Tag}} -buildnum={{.Env.Buildnum}} -pull-request={{.Env.IsPullRequest}}
+	go get golang.org/dl/go1.13 && $HOME/go/bin/go1.13 download
+	build/env.sh $HOME/go/bin/go1.13 run build/ci.go install -git-commit={{.Env.Commit}} -git-branch={{.Env.Branch}} -git-tag={{.Env.Tag}} -buildnum={{.Env.Buildnum}} -pull-request={{.Env.IsPullRequest}}
 
 override_dh_auto_test:
 


### PR DESCRIPTION
The Gophers PPA repo is abandoned and stuck at Go 1.11. We need to switch away from it. Since we definitely don't want to maintain our own Go PPA, we can instead fall back to using Google's pinned binary downloader instead.