### PR TITLE
Revert "build: switch PPA from Gophers dep to manual download"

### DIFF
--- a/build/ci-notes.md
+++ b/build/ci-notes.md
@@ -22,16 +22,19 @@ variables `PPA_SIGNING_KEY` and `PPA_SSH_KEY` on Travis.
 
 We want to build go-ethereum with the most recent version of Go, irrespective of the Go
 version that is available in the main Ubuntu repository. In order to make this possible,
-our PPA always fetches a recent Go release for the upstream server and uses that.
+our PPA depends on the ~gophers/ubuntu/archive PPA. Our source package build-depends on
+golang-1.11, which is co-installable alongside the regular golang package. PPA dependencies
+can be edited at https://launchpad.net/%7Eethereum/+archive/ubuntu/ethereum/+edit-dependencies
 
 ## Building Packages Locally (for testing)
 
 You need to run Ubuntu to do test packaging.
 
-Install Go and the Debian packaging tools:
+Add the gophers PPA and install Go 1.11 and Debian packaging tools:
 
+    $ sudo apt-add-repository ppa:gophers/ubuntu/archive
     $ sudo apt-get update
-    $ sudo apt-get install build-essential golang devscripts debhelper python-bzrlib python-paramiko
+    $ sudo apt-get install build-essential golang-1.11 devscripts debhelper python-bzrlib python-paramiko
 
 Create the source packages:
 

--- a/build/deb/ethereum/deb.control
+++ b/build/deb/ethereum/deb.control
@@ -2,7 +2,7 @@ Source: {{.Name}}
 Section: science
 Priority: extra
 Maintainer: {{.Author}}
-Build-Depends: debhelper (>= 8.0.0), golang
+Build-Depends: debhelper (>= 8.0.0), golang-1.11
 Standards-Version: 3.9.5
 Homepage: https://ethereum.org
 Vcs-Git: git://github.com/ethereum/go-ethereum.git

--- a/build/deb/ethereum/deb.rules
+++ b/build/deb/ethereum/deb.rules
@@ -4,12 +4,11 @@
 # Uncomment this to turn on verbose mode.
 #export DH_VERBOSE=1
 
-# Launchpad rejects Go's access to $HOME, use custom folder
-export HOME=/tmp/home
+# Launchpad rejects Go's access to $HOME/.cache, use custom folder
+export GOCACHE=/tmp/go-build
 
 override_dh_auto_build:
-	go get golang.org/dl/go1.13 && $HOME/go/bin/go1.13 download
-	build/env.sh $HOME/go/bin/go1.13 run build/ci.go install -git-commit={{.Env.Commit}} -git-branch={{.Env.Branch}} -git-tag={{.Env.Tag}} -buildnum={{.Env.Buildnum}} -pull-request={{.Env.IsPullRequest}}
+	build/env.sh /usr/lib/go-1.11/bin/go run build/ci.go install -git-commit={{.Env.Commit}} -git-branch={{.Env.Branch}} -git-tag={{.Env.Tag}} -buildnum={{.Env.Buildnum}} -pull-request={{.Env.IsPullRequest}}
 
 override_dh_auto_test:
 


### PR DESCRIPTION
Reverts ethereum/go-ethereum#20059

Launchpad apparently doesn't allow remote servers to be accessed during a build, so we can't fetch the upstream Go this way. Bummer.