### PR TITLE
core: remove unused gas return in ApplyTransaction

### DIFF
--- a/cmd/geth/retesteth.go
+++ b/cmd/geth/retesteth.go
@@ -508,7 +508,7 @@ func (api *RetestethAPI) mineBlock() error {
 				statedb.Prepare(tx.Hash(), common.Hash{}, txCount)
 				snap := statedb.Snapshot()
 
-				receipt, _, err := core.ApplyTransaction(
+				receipt, err := core.ApplyTransaction(
 					api.chainConfig,
 					api.blockchain,
 					&api.author,

--- a/core/chain_makers.go
+++ b/core/chain_makers.go
@@ -103,7 +103,7 @@ func (b *BlockGen) AddTxWithChain(bc *BlockChain, tx *types.Transaction) {
 		b.SetCoinbase(common.Address{})
 	}
 	b.statedb.Prepare(tx.Hash(), common.Hash{}, len(b.txs))
-	receipt, _, err := ApplyTransaction(b.config, bc, &b.header.Coinbase, b.gasPool, b.statedb, b.header, tx, &b.header.GasUsed, vm.Config{})
+	receipt, err := ApplyTransaction(b.config, bc, &b.header.Coinbase, b.gasPool, b.statedb, b.header, tx, &b.header.GasUsed, vm.Config{})
 	if err != nil {
 		panic(err)
 	}

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -704,7 +704,7 @@ func (w *worker) updateSnapshot() {
 func (w *worker) commitTransaction(tx *types.Transaction, coinbase common.Address) ([]*types.Log, error) {
 	snap := w.current.state.Snapshot()
 
-	receipt, _, err := core.ApplyTransaction(w.chainConfig, w.chain, &coinbase, w.current.gasPool, w.current.state, w.current.header, tx, &w.current.header.GasUsed, *w.chain.GetVMConfig())
+	receipt, err := core.ApplyTransaction(w.chainConfig, w.chain, &coinbase, w.current.gasPool, w.current.state, w.current.header, tx, &w.current.header.GasUsed, *w.chain.GetVMConfig())
 	if err != nil {
 		w.current.state.RevertToSnapshot(snap)
 		return nil, err


### PR DESCRIPTION
Currently, `ApplyTransaction` returns `gas` as the second return value - but this value is unused (and included on the first return value: `receipt`).

Had asked about this in Discord but didn't hear back, hoping to get a feel for if there are cases where preserving unused code is desirable in this repo.