### PR TITLE
Increase default gas limit to 11M

### DIFF
--- a/eth/config.go
+++ b/eth/config.go
@@ -51,8 +51,8 @@ var DefaultConfig = Config{
 	TrieDirtyCache:     256,
 	TrieTimeout:        60 * time.Minute,
 	Miner: miner.Config{
-		GasFloor: 8000000,
-		GasCeil:  8000000,
+		GasFloor: 11000000,
+		GasCeil:  11000000,
 		GasPrice: big.NewInt(params.GWei),
 		Recommit: 3 * time.Second,
 	},


### PR DESCRIPTION
The default gas limit should be increased in Geth and Parity. This will signal to miners that developers think that new limit is safe. Some miners are also lazy and do not adjust defaults. Let's get it done!