### PR TITLE
les: implement server priority API

### DIFF
--- a/internal/web3ext/web3ext.go
+++ b/internal/web3ext/web3ext.go
@@ -445,6 +445,11 @@ web3._extend({
 			params: 2,
 			inputFormatter:[null, null],
 		}),
+		new web3._extend.Method({
+			name: 'freezeClient',
+			call: 'debug_freezeClient',
+			params: 1,
+		}),
 	],
 	properties: []
 });
@@ -798,6 +803,31 @@ web3._extend({
 			call: 'les_getCheckpoint',
 			params: 1
 		}),
+		new web3._extend.Method({
+			name: 'clientInfo',
+			call: 'les_clientInfo',
+			params: 1
+		}),
+		new web3._extend.Method({
+			name: 'priorityClientInfo',
+			call: 'les_priorityClientInfo',
+			params: 3
+		}),
+		new web3._extend.Method({
+			name: 'setClientParams',
+			call: 'les_setClientParams',
+			params: 2
+		}),
+		new web3._extend.Method({
+			name: 'setDefaultParams',
+			call: 'les_setDefaultParams',
+			params: 1
+		}),
+		new web3._extend.Method({
+			name: 'updateBalance',
+			call: 'les_updateBalance',
+			params: 4
+		}),
 	],
 	properties:
 	[
@@ -808,6 +838,10 @@ web3._extend({
 		new web3._extend.Property({
 			name: 'checkpointContractAddress',
 			getter: 'les_getCheckpointContractAddress'
+		}),
+		new web3._extend.Property({
+			name: 'serverInfo',
+			getter: 'les_serverInfo'
 		}),
 	]
 });

--- a/internal/web3ext/web3ext.go
+++ b/internal/web3ext/web3ext.go
@@ -826,7 +826,7 @@ web3._extend({
 		new web3._extend.Method({
 			name: 'updateBalance',
 			call: 'les_updateBalance',
-			params: 4
+			params: 3
 		}),
 	],
 	properties:

--- a/les/api.go
+++ b/les/api.go
@@ -107,14 +107,19 @@ func (api *PrivateLightServerAPI) PriorityClientInfo(start, stop enode.ID, maxCo
 func (api *PrivateLightServerAPI) clientInfo(c *clientInfo, id enode.ID) map[string]interface{} {
 	info := make(map[string]interface{})
 	if c != nil {
+		now := mclock.Now()
 		info["isConnected"] = true
+		info["connectionTime"] = float64(now-c.connectedAt) / float64(time.Second)
 		info["capacity"] = c.capacity
-		info["pricing/balance"], info["pricing/negBalance"] = c.balanceTracker.getBalance(mclock.Now())
+		pb, nb := c.balanceTracker.getBalance(now)
+		info["pricing/balance"], info["pricing/negBalance"] = pb, nb
 		info["pricing/balanceMeta"] = c.balanceMetaInfo
+		info["priority"] = pb != 0
 	} else {
 		info["isConnected"] = false
 		pb := api.server.clientPool.getPosBalance(id)
 		info["pricing/balance"], info["pricing/balanceMeta"] = pb.value, pb.meta
+		info["priority"] = pb.value != 0
 	}
 	return info
 }

--- a/les/api.go
+++ b/les/api.go
@@ -20,7 +20,6 @@ import (
 	"errors"
 	"fmt"
 	"math"
-	"sync"
 	"time"
 
 	"github.com/ethereum/go-ethereum/common/hexutil"
@@ -38,15 +37,10 @@ var (
 
 const maxBalance = math.MaxInt64
 
-type clientApiFields struct {
-	balanceUpdatePeriod uint64
-}
-
 // PrivateLightServerAPI provides an API to access the LES light server.
 type PrivateLightServerAPI struct {
 	server                               *LesServer
 	defaultPosFactors, defaultNegFactors priceFactors
-	lock                                 sync.Mutex
 }
 
 // NewPrivateLightServerAPI creates a new LES light server API.
@@ -157,7 +151,8 @@ func (api *PrivateLightServerAPI) setParams(params map[string]interface{}, clien
 		case !defParams && name == "capacity":
 			if capacity, ok := value.(float64); ok && uint64(capacity) >= api.server.minCapacity {
 				err = api.server.clientPool.setCapacity(client, uint64(capacity))
-				updateFactors = true
+				// Don't have to call factor update explicitly. It's already done
+				// in setCapacity function.
 			} else {
 				err = errValue()
 			}

--- a/les/api.go
+++ b/les/api.go
@@ -17,15 +17,399 @@
 package les
 
 import (
+	"context"
 	"errors"
+	"fmt"
+	"math"
+	"sync"
+	"time"
 
 	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/ethereum/go-ethereum/common/mclock"
+	"github.com/ethereum/go-ethereum/p2p/enode"
+	"github.com/ethereum/go-ethereum/rpc"
 )
 
 var (
-	errNoCheckpoint = errors.New("no local checkpoint provided")
-	errNotActivated = errors.New("checkpoint registrar is not activated")
+	errNoCheckpoint         = errors.New("no local checkpoint provided")
+	errNotActivated         = errors.New("checkpoint registrar is not activated")
+	errUnknownBenchmarkType = errors.New("unknown benchmark type")
+	errClientNotConnected   = errors.New("client is not connected")
+	errBalanceOverflow      = errors.New("balance overflow")
+	errNoPriority           = errors.New("not enough priority")
 )
+
+const maxBalance = math.MaxInt64
+
+type clientApiFields struct {
+	balanceUpdatePeriod uint64
+}
+
+// PrivateLightServerAPI provides an API to access the LES light server.
+type PrivateLightServerAPI struct {
+	server                               *LesServer
+	defaultPosFactors, defaultNegFactors priceFactors
+	subs                                 map[*eventSub]struct{}
+	lock                                 sync.Mutex
+}
+
+// NewPrivateLightServerAPI creates a new LES light server API.
+func NewPrivateLightServerAPI(server *LesServer) *PrivateLightServerAPI {
+	api := &PrivateLightServerAPI{
+		server:            server,
+		defaultPosFactors: server.clientPool.defaultPosFactors,
+		defaultNegFactors: server.clientPool.defaultNegFactors,
+		subs:              make(map[*eventSub]struct{}),
+	}
+	server.clientPool.eventHook = api.sendEvent
+	return api
+}
+
+// ServerInfo returns global server parameters
+func (api *PrivateLightServerAPI) ServerInfo() map[string]interface{} {
+	res := make(map[string]interface{})
+	res["minimumCapacity"] = api.server.minCapacity
+	res["maximumCapacity"] = api.server.maxCapacity
+	res["freeClientCapacity"] = api.server.freeCapacity
+	res["totalCapacity"], res["totalConnectedCapacity"], res["priorityConnectedCapacity"] = api.server.clientPool.capacityInfo()
+	return res
+}
+
+// ClientInfo returns information about clients listed in the ids list or matching the given tags
+func (api *PrivateLightServerAPI) ClientInfo(ids []enode.ID) map[enode.ID]map[string]interface{} {
+	res := make(map[enode.ID]map[string]interface{})
+	api.server.clientPool.forClients(ids, func(client *clientInfo, id enode.ID) {
+		res[id] = api.clientInfo(client, id)
+	})
+	return res
+}
+
+// PriorityClientInfo returns information about clients with a positive balance
+// in the given ID range (stop excluded). If stop is null then the iterator stops
+// only at the end of the ID space. MaxCount limits the number of results returned.
+// If maxCount limit is applied but there are more potential results then the ID
+// of the next potential result is included in the map with an empty structure
+// assigned to it.
+func (api *PrivateLightServerAPI) PriorityClientInfo(start, stop enode.ID, maxCount int) map[enode.ID]map[string]interface{} {
+	res := make(map[enode.ID]map[string]interface{})
+	ids := api.server.clientPool.ndb.getPosBalanceIDs(start, stop, maxCount+1)
+	if len(ids) > maxCount {
+		res[ids[maxCount]] = make(map[string]interface{})
+		ids = ids[:maxCount]
+	}
+	api.server.clientPool.forClients(ids, func(client *clientInfo, id enode.ID) {
+		res[id] = api.clientInfo(client, id)
+	})
+	return res
+}
+
+// clientInfo creates a client info data structure
+func (api *PrivateLightServerAPI) clientInfo(c *clientInfo, id enode.ID) map[string]interface{} {
+	info := make(map[string]interface{})
+	if c != nil {
+		info["isConnected"] = true
+		info["capacity"] = c.capacity
+		info["pricing/balance"], info["pricing/negBalance"] = c.balanceTracker.getBalance(mclock.Now())
+		info["pricing/balanceMeta"] = c.balanceMetaInfo
+	} else {
+		info["isConnected"] = false
+		pb := api.server.clientPool.getPosBalance(id)
+		info["pricing/balance"], info["pricing/balanceMeta"] = pb.value, pb.meta
+	}
+	return info
+}
+
+// sendEvent sends an event to the subscribers interested in it. For global events client == nil.
+func (api *PrivateLightServerAPI) sendEvent(clientEvent string, client *clientInfo) {
+	if len(api.subs) == 0 {
+		return
+	}
+
+	event := make(map[string]interface{})
+	event["totalCapacity"], event["totalConnectedCapacity"], event["priorityConnectedCapacity"] = api.server.clientPool.capacityInfo()
+	if client != nil {
+		event["clientEvent"] = clientEvent
+		event["clientId"] = client.id
+		event["clientInfo"] = api.clientInfo(client, client.id)
+	}
+
+	for sub := range api.subs {
+		select {
+		case <-sub.rpcSub.Err():
+			delete(api.subs, sub)
+		case <-sub.notifier.Closed():
+			delete(api.subs, sub)
+		default:
+			sub.notifier.Notify(sub.rpcSub.ID, event)
+		}
+	}
+}
+
+// setParams either sets the given parameters for a single client (if ID is specified)
+// or the default parameters applicable to clients connected in the future
+func (api *PrivateLightServerAPI) setParams(params map[string]interface{}, client *clientInfo, id enode.ID, posFactors, negFactors *priceFactors) (updateFactors bool, err error) {
+	if client != nil {
+		posFactors, negFactors = &client.posFactors, &client.negFactors
+	}
+	defParams := id == enode.ID{}
+loop:
+	for name, value := range params {
+		errValue := func() error {
+			return fmt.Errorf("invalid value for parameter '%s'", name)
+		}
+		setFactor := func(v *float64) {
+			if posFactors != nil {
+				if val, ok := value.(float64); ok && val >= 0 {
+					*v = val / float64(time.Second)
+					updateFactors = true
+				} else {
+					err = errValue()
+				}
+			} else {
+				err = errClientNotConnected
+			}
+		}
+
+		processed := true
+		switch name {
+		case "pricing/timeFactor":
+			setFactor(&posFactors.timeFactor)
+		case "pricing/capacityFactor":
+			setFactor(&posFactors.capacityFactor)
+		case "pricing/requestCostFactor":
+			setFactor(&posFactors.requestFactor)
+		case "pricing/negative/timeFactor":
+			setFactor(&negFactors.timeFactor)
+		case "pricing/negative/capacityFactor":
+			setFactor(&negFactors.capacityFactor)
+		case "pricing/negative/requestCostFactor":
+			setFactor(&negFactors.requestFactor)
+		default:
+			processed = false
+			if defParams {
+				err = fmt.Errorf("invalid default parameter '%s'", name)
+				continue loop
+			}
+		}
+		if processed {
+			continue loop
+		}
+		switch name {
+		case "capacity":
+			if client != nil {
+				if capacity, ok := value.(float64); ok && (capacity == 0 || uint64(capacity) >= api.server.minCapacity) {
+					err = api.server.clientPool.setCapacity(client, uint64(capacity))
+					updateFactors = true
+				} else {
+					err = errValue()
+				}
+			} else {
+				err = errClientNotConnected
+			}
+		case "pricing/alert":
+			if client != nil {
+				if val, ok := value.(float64); ok && val >= 0 {
+					api.setBalanceUpdate(client, uint64(val), false)
+				} else {
+					err = errValue()
+				}
+			} else {
+				err = errClientNotConnected
+			}
+		case "pricing/periodicUpdate":
+			if client != nil {
+				if val, ok := value.(float64); ok && val >= 0 {
+					api.setBalanceUpdate(client, uint64(val), true)
+				} else {
+					err = errValue()
+				}
+			} else {
+				err = errClientNotConnected
+			}
+		default:
+			err = fmt.Errorf("invalid client parameter '%s'", name)
+		}
+	}
+	return updateFactors, err
+}
+
+// UpdateBalance updates the balance of a client (either overwrites it or adds to it).
+// It also updates the balance meta info string.
+func (api *PrivateLightServerAPI) UpdateBalance(id enode.ID, value int64, add bool, meta string) error {
+	return api.server.clientPool.updateBalance(id, value, add, meta)
+}
+
+// SetClientParams sets client parameters for all clients listed in the ids list
+// or all connected clients if the list is empty
+func (api *PrivateLightServerAPI) SetClientParams(ids []enode.ID, params map[string]interface{}) error {
+	var finalErr error
+	api.server.clientPool.forClients(ids, func(client *clientInfo, id enode.ID) {
+		update, err := api.setParams(params, client, id, nil, nil)
+		if err != nil {
+			finalErr = err
+		}
+		if update {
+			client.updatePriceFactors()
+		}
+	})
+	return finalErr
+}
+
+// SetDefaultParams sets the default parameters applicable to clients connected in the future
+func (api *PrivateLightServerAPI) SetDefaultParams(params map[string]interface{}) error {
+	update, err := api.setParams(params, nil, enode.ID{}, &api.defaultPosFactors, &api.defaultNegFactors)
+	if update {
+		api.server.clientPool.setDefaultFactors(api.defaultPosFactors, api.defaultNegFactors)
+	}
+	return err
+}
+
+// balanceUpdate sends a price update client event and schedules a new update with the
+// price tracker if necessary.
+func (api *PrivateLightServerAPI) balanceUpdate(client *clientInfo) {
+	api.lock.Lock()
+	defer api.lock.Unlock()
+
+	api.sendEvent("balanceUpdate", client)
+	if client.balanceUpdatePeriod != 0 {
+		api.setBalanceUpdate(client, client.balanceUpdatePeriod, true)
+	}
+}
+
+// setBalanceUpdate schedules a price update when the balance reaches the given limit.
+// If periodic is false then the limit is interpreted as an absolute value while if true
+// it is relative to the current totalAmount value or the its value at the last future update.
+func (api *PrivateLightServerAPI) setBalanceUpdate(client *clientInfo, value uint64, periodic bool) {
+	balance := balance{pos: value}
+	if periodic {
+		client.balanceUpdatePeriod = value
+		balance.pos, _ = client.balanceTracker.getBalance(mclock.Now())
+		if balance.pos > value {
+			balance.pos -= value
+		} else {
+			balance.pos = 0
+		}
+	} else {
+		client.balanceUpdatePeriod = 0
+	}
+	client.balanceTracker.addCallback(balanceCallbackApi, client.balanceTracker.balanceToPriority(balance), func() { api.balanceUpdate(client) })
+}
+
+// eventSub represents an event subscription
+type eventSub struct {
+	notifier *rpc.Notifier
+	rpcSub   *rpc.Subscription
+}
+
+// SubscribeEvent subscribes to global events and client events related to the clients matching the given tags.
+// If totalCapUnderrun is true then totalCapacity updates are only sent when totalCapacity drops under totalConnectedCapacity.
+func (api *PrivateLightServerAPI) SubscribeEvent(ctx context.Context) (*rpc.Subscription, error) {
+	notifier, supported := rpc.NotifierFromContext(ctx)
+	if !supported {
+		return &rpc.Subscription{}, rpc.ErrNotificationsUnsupported
+	}
+	rpcSub := notifier.CreateSubscription()
+	api.subs[&eventSub{notifier, rpcSub}] = struct{}{}
+	return rpcSub, nil
+}
+
+// Benchmark runs a request performance benchmark with a given set of measurement setups
+// in multiple passes specified by passCount. The measurement time for each setup in each
+// pass is specified in milliseconds by length.
+//
+// Note: measurement time is adjusted for each pass depending on the previous ones.
+// Therefore a controlled total measurement time is achievable in multiple passes.
+func (api *PrivateLightServerAPI) Benchmark(setups []map[string]interface{}, passCount, length int) ([]map[string]interface{}, error) {
+	benchmarks := make([]requestBenchmark, len(setups))
+	for i, setup := range setups {
+		if t, ok := setup["type"].(string); ok {
+			getInt := func(field string, def int) int {
+				if value, ok := setup[field].(float64); ok {
+					return int(value)
+				}
+				return def
+			}
+			getBool := func(field string, def bool) bool {
+				if value, ok := setup[field].(bool); ok {
+					return value
+				}
+				return def
+			}
+			switch t {
+			case "header":
+				benchmarks[i] = &benchmarkBlockHeaders{
+					amount:  getInt("amount", 1),
+					skip:    getInt("skip", 1),
+					byHash:  getBool("byHash", false),
+					reverse: getBool("reverse", false),
+				}
+			case "body":
+				benchmarks[i] = &benchmarkBodiesOrReceipts{receipts: false}
+			case "receipts":
+				benchmarks[i] = &benchmarkBodiesOrReceipts{receipts: true}
+			case "proof":
+				benchmarks[i] = &benchmarkProofsOrCode{code: false}
+			case "code":
+				benchmarks[i] = &benchmarkProofsOrCode{code: true}
+			case "cht":
+				benchmarks[i] = &benchmarkHelperTrie{
+					bloom:    false,
+					reqCount: getInt("amount", 1),
+				}
+			case "bloom":
+				benchmarks[i] = &benchmarkHelperTrie{
+					bloom:    true,
+					reqCount: getInt("amount", 1),
+				}
+			case "txSend":
+				benchmarks[i] = &benchmarkTxSend{}
+			case "txStatus":
+				benchmarks[i] = &benchmarkTxStatus{}
+			default:
+				return nil, errUnknownBenchmarkType
+			}
+		} else {
+			return nil, errUnknownBenchmarkType
+		}
+	}
+	rs := api.server.handler.runBenchmark(benchmarks, passCount, time.Millisecond*time.Duration(length))
+	result := make([]map[string]interface{}, len(setups))
+	for i, r := range rs {
+		res := make(map[string]interface{})
+		if r.err == nil {
+			res["totalCount"] = r.totalCount
+			res["avgTime"] = r.avgTime
+			res["maxInSize"] = r.maxInSize
+			res["maxOutSize"] = r.maxOutSize
+		} else {
+			res["error"] = r.err.Error()
+		}
+		result[i] = res
+	}
+	return result, nil
+}
+
+// PrivateDebugAPI provides an API to debug LES light server functionality.
+type PrivateDebugAPI struct {
+	server *LesServer
+}
+
+// NewPrivateDebugAPI creates a new LES light server debug API.
+func NewPrivateDebugAPI(server *LesServer) *PrivateDebugAPI {
+	return &PrivateDebugAPI{
+		server: server,
+	}
+}
+
+// FreezeClient forces a temporary client freeze which normally happens when the server is overloaded
+func (api *PrivateDebugAPI) FreezeClient(id enode.ID) error {
+	err := errClientNotConnected
+	api.server.clientPool.forClients([]enode.ID{id}, func(c *clientInfo, id enode.ID) {
+		c.peer.freezeClient()
+		err = nil
+	})
+	return err
+}
 
 // PrivateLightAPI provides an API to access the LES light server or light client.
 type PrivateLightAPI struct {

--- a/les/api.go
+++ b/les/api.go
@@ -35,7 +35,7 @@ var (
 	errNotActivated         = errors.New("checkpoint registrar is not activated")
 	errUnknownBenchmarkType = errors.New("unknown benchmark type")
 	errBalanceOverflow      = errors.New("balance overflow")
-	errNoPriority           = errors.New("not enough priority")
+	errNoPriority           = errors.New("priority too low to raise capacity")
 )
 
 const maxBalance = math.MaxInt64

--- a/les/api.go
+++ b/les/api.go
@@ -97,9 +97,11 @@ func (api *PrivateLightServerAPI) PriorityClientInfo(start, stop enode.ID, maxCo
 		res[ids[maxCount]] = make(map[string]interface{})
 		ids = ids[:maxCount]
 	}
-	api.server.clientPool.forClients(ids, func(client *clientInfo, id enode.ID) {
-		res[id] = api.clientInfo(client, id)
-	})
+	if len(ids) != 0 {
+		api.server.clientPool.forClients(ids, func(client *clientInfo, id enode.ID) {
+			res[id] = api.clientInfo(client, id)
+		})
+	}
 	return res
 }
 

--- a/les/api.go
+++ b/les/api.go
@@ -235,8 +235,8 @@ loop:
 
 // UpdateBalance updates the balance of a client (either overwrites it or adds to it).
 // It also updates the balance meta info string.
-func (api *PrivateLightServerAPI) UpdateBalance(id enode.ID, value int64, add bool, meta string) error {
-	return api.server.clientPool.updateBalance(id, value, add, meta)
+func (api *PrivateLightServerAPI) UpdateBalance(id enode.ID, value int64, meta string) error {
+	return api.server.clientPool.updateBalance(id, value, meta)
 }
 
 // SetClientParams sets client parameters for all clients listed in the ids list

--- a/les/api.go
+++ b/les/api.go
@@ -225,8 +225,12 @@ loop:
 
 // UpdateBalance updates the balance of a client (either overwrites it or adds to it).
 // It also updates the balance meta info string.
-func (api *PrivateLightServerAPI) UpdateBalance(id enode.ID, value int64, meta string) error {
-	return api.server.clientPool.updateBalance(id, value, meta)
+func (api *PrivateLightServerAPI) UpdateBalance(id enode.ID, value int64, meta string) (map[string]uint64, error) {
+	oldBalance, newBalance, err := api.server.clientPool.updateBalance(id, value, meta)
+	m := make(map[string]uint64)
+	m["old"] = oldBalance
+	m["new"] = newBalance
+	return m, err
 }
 
 // SetClientParams sets client parameters for all clients listed in the ids list

--- a/les/balance.go
+++ b/les/balance.go
@@ -26,6 +26,7 @@ import (
 const (
 	balanceCallbackQueue = iota
 	balanceCallbackZero
+	balanceCallbackApi
 	balanceCallbackCount
 )
 

--- a/les/balance.go
+++ b/les/balance.go
@@ -26,7 +26,6 @@ import (
 const (
 	balanceCallbackQueue = iota
 	balanceCallbackZero
-	balanceCallbackApi
 	balanceCallbackCount
 )
 

--- a/les/balance.go
+++ b/les/balance.go
@@ -161,6 +161,14 @@ func (bt *balanceTracker) timeUntil(priority int64) (time.Duration, bool) {
 	return time.Duration(dt), true
 }
 
+// setCapacity updates the capacity value used for priority calculation
+func (bt *balanceTracker) setCapacity(capacity uint64) {
+	bt.lock.Lock()
+	defer bt.lock.Unlock()
+
+	bt.capacity = capacity
+}
+
 // getPriority returns the actual priority based on the current balance
 func (bt *balanceTracker) getPriority(now mclock.AbsTime) int64 {
 	bt.lock.Lock()

--- a/les/clientpool.go
+++ b/les/clientpool.go
@@ -113,6 +113,7 @@ type clientPeer interface {
 type clientInfo struct {
 	address                string
 	id                     enode.ID
+	connectedAt            mclock.AbsTime
 	capacity               uint64
 	priority               bool
 	pool                   *clientPool
@@ -241,6 +242,7 @@ func (f *clientPool) connect(peer clientPeer, capacity uint64) bool {
 		address:         freeID,
 		queueIndex:      -1,
 		id:              id,
+		connectedAt:     now,
 		priority:        posBalance != 0,
 		posFactors:      f.defaultPosFactors,
 		negFactors:      f.defaultNegFactors,

--- a/les/clientpool.go
+++ b/les/clientpool.go
@@ -564,7 +564,7 @@ func (f *clientPool) getPosBalance(id enode.ID) posBalance {
 
 // updateBalance updates the balance of a client (either overwrites it or adds to it).
 // It also updates the balance meta info string.
-func (f *clientPool) updateBalance(id enode.ID, amount int64, add bool, meta string) error {
+func (f *clientPool) updateBalance(id enode.ID, amount int64, meta string) error {
 	f.lock.Lock()
 	defer f.lock.Unlock()
 
@@ -588,27 +588,17 @@ func (f *clientPool) updateBalance(id enode.ID, amount int64, add bool, meta str
 			c.balanceMetaInfo = meta
 		}()
 	}
-	if add {
-		if amount > 0 {
-			if amount > maxBalance || pb.value > maxBalance-uint64(amount) {
-				return errBalanceOverflow
-			}
-			pb.value += uint64(amount)
-		} else {
-			if uint64(-amount) > pb.value {
-				pb.value = 0
-			} else {
-				pb.value -= uint64(-amount)
-			}
-		}
-	} else {
-		if amount > maxBalance {
+	if amount > 0 {
+		if amount > maxBalance || pb.value > maxBalance-uint64(amount) {
 			return errBalanceOverflow
 		}
-		if amount < 0 {
-			amount = 0
+		pb.value += uint64(amount)
+	} else {
+		if uint64(-amount) > pb.value {
+			pb.value = 0
+		} else {
+			pb.value -= uint64(-amount)
 		}
-		pb.value = uint64(amount)
 	}
 	pb.meta = meta
 	f.ndb.setPB(id, pb)

--- a/les/clientpool.go
+++ b/les/clientpool.go
@@ -19,6 +19,7 @@ package les
 import (
 	"bytes"
 	"encoding/binary"
+	"fmt"
 	"io"
 	"math"
 	"sync"
@@ -483,7 +484,7 @@ func (f *clientPool) setLimits(totalConn int, totalCap uint64) {
 // setCapacity sets the assigned capacity of a connected client
 func (f *clientPool) setCapacity(c *clientInfo, capacity uint64) error {
 	if f.connectedMap[c.id] != c {
-		return errClientNotConnected
+		return fmt.Errorf("client %064x is not connected", c.id[:])
 	}
 	if c.capacity == capacity {
 		return nil

--- a/les/clientpool.go
+++ b/les/clientpool.go
@@ -446,6 +446,7 @@ func (f *clientPool) balanceExhausted(id enode.ID) {
 		f.connectedCap += f.freeClientCap - c.capacity
 		totalConnectedGauge.Update(int64(f.connectedCap))
 		c.capacity = f.freeClientCap
+		c.balanceTracker.setCapacity(c.capacity)
 		c.peer.updateCapacity(c.capacity)
 	}
 	pb := f.ndb.getOrNewPB(id)

--- a/les/clientpool.go
+++ b/les/clientpool.go
@@ -343,19 +343,24 @@ func (f *clientPool) disconnect(p clientPeer) {
 // forClients iterates through a list of clients, calling the callback for each one.
 // If a client is not connected then clientInfo is nil. If the specified list is empty
 // then the callback is called for all connected clients.
-func (f *clientPool) forClients(ids []enode.ID, callback func(*clientInfo, enode.ID)) {
+func (f *clientPool) forClients(ids []enode.ID, callback func(*clientInfo, enode.ID) error) error {
 	f.lock.Lock()
 	defer f.lock.Unlock()
 
 	if len(ids) > 0 {
 		for _, id := range ids {
-			callback(f.connectedMap[id], id)
+			if err := callback(f.connectedMap[id], id); err != nil {
+				return err
+			}
 		}
 	} else {
 		for _, c := range f.connectedMap {
-			callback(c, c.id)
+			if err := callback(c, c.id); err != nil {
+				return err
+			}
 		}
 	}
+	return nil
 }
 
 // setDefaultFactors sets the default price factors applied to subsequently connected clients

--- a/les/clientpool.go
+++ b/les/clientpool.go
@@ -122,7 +122,6 @@ type clientInfo struct {
 	balanceTracker         balanceTracker
 	posFactors, negFactors priceFactors
 	balanceMetaInfo        string
-	clientApiFields
 }
 
 // connSetIndex callback updates clientInfo item index in connectedQueue
@@ -645,7 +644,10 @@ func (e *negBalance) DecodeRLP(s *rlp.Stream) error {
 
 const (
 	// nodeDBVersion is the version identifier of the node data in db
-	nodeDBVersion = 0
+	//
+	// Changelog:
+	// * Replace `lastTotal` with `meta` in positive balance: version 0=>1
+	nodeDBVersion = 1
 
 	// dbCleanupCycle is the cycle of db for useless data cleanup
 	dbCleanupCycle = time.Hour

--- a/les/clientpool_test.go
+++ b/les/clientpool_test.go
@@ -444,8 +444,8 @@ func TestNodeDB(t *testing.T) {
 	ndb := newNodeDB(rawdb.NewMemoryDatabase(), mclock.System{})
 	defer ndb.close()
 
-	if !bytes.Equal(ndb.verbuf[:], []byte{0x00, 0x00}) {
-		t.Fatalf("version buffer mismatch, want %v, got %v", []byte{0x00, 0x00}, ndb.verbuf)
+	if !bytes.Equal(ndb.verbuf[:], []byte{0x00, nodeDBVersion}) {
+		t.Fatalf("version buffer mismatch, want %v, got %v", []byte{0x00, nodeDBVersion}, ndb.verbuf)
 	}
 	var cases = []struct {
 		id       enode.ID

--- a/les/server.go
+++ b/les/server.go
@@ -50,9 +50,9 @@ type LesServer struct {
 	servingQueue *servingQueue
 	clientPool   *clientPool
 
-	freeCapacity uint64 // The minimal client capacity used for free client.
-	threadsIdle  int    // Request serving threads count when system is idle.
-	threadsBusy  int    // Request serving threads count when system is busy(block insertion).
+	minCapacity, maxCapacity, freeCapacity uint64
+	threadsIdle                            int // Request serving threads count when system is idle.
+	threadsBusy                            int // Request serving threads count when system is busy(block insertion).
 }
 
 func NewLesServer(e *eth.Ethereum, config *eth.Config) (*LesServer, error) {
@@ -88,7 +88,8 @@ func NewLesServer(e *eth.Ethereum, config *eth.Config) (*LesServer, error) {
 		threadsIdle:  threads,
 	}
 	srv.handler = newServerHandler(srv, e.BlockChain(), e.ChainDb(), e.TxPool(), e.Synced)
-	srv.costTracker, srv.freeCapacity = newCostTracker(e.ChainDb(), config)
+	srv.costTracker, srv.minCapacity = newCostTracker(e.ChainDb(), config)
+	srv.freeCapacity = srv.minCapacity
 
 	// Set up checkpoint oracle.
 	oracle := config.CheckpointOracle
@@ -108,13 +109,13 @@ func NewLesServer(e *eth.Ethereum, config *eth.Config) (*LesServer, error) {
 	// to send requests most of the time. Our goal is to serve as many clients as
 	// possible while the actually used server capacity does not exceed the limits
 	totalRecharge := srv.costTracker.totalRecharge()
-	maxCapacity := srv.freeCapacity * uint64(srv.config.LightPeers)
-	if totalRecharge > maxCapacity {
-		maxCapacity = totalRecharge
+	srv.maxCapacity = srv.freeCapacity * uint64(srv.config.LightPeers)
+	if totalRecharge > srv.maxCapacity {
+		srv.maxCapacity = totalRecharge
 	}
-	srv.fcManager.SetCapacityLimits(srv.freeCapacity, maxCapacity, srv.freeCapacity*2)
+	srv.fcManager.SetCapacityLimits(srv.freeCapacity, srv.maxCapacity, srv.freeCapacity*2)
 	srv.clientPool = newClientPool(srv.chainDb, srv.freeCapacity, mclock.System{}, func(id enode.ID) { go srv.peers.Unregister(peerIdToString(id)) })
-	srv.clientPool.setPriceFactors(priceFactors{0, 1, 1}, priceFactors{0, 1, 1})
+	srv.clientPool.setDefaultFactors(priceFactors{0, 1, 1}, priceFactors{0, 1, 1})
 
 	checkpoint := srv.latestLocalCheckpoint()
 	if !checkpoint.Empty() {
@@ -131,6 +132,18 @@ func (s *LesServer) APIs() []rpc.API {
 			Namespace: "les",
 			Version:   "1.0",
 			Service:   NewPrivateLightAPI(&s.lesCommons),
+			Public:    false,
+		},
+		{
+			Namespace: "les",
+			Version:   "1.0",
+			Service:   NewPrivateLightServerAPI(s),
+			Public:    false,
+		},
+		{
+			Namespace: "debug",
+			Version:   "1.0",
+			Service:   NewPrivateDebugAPI(s),
 			Public:    false,
 		},
 	}


### PR DESCRIPTION
This PR implements the LES server API. These are the functions provided for server capacity/balance/priority management (see descriptions in api.go):

```
func (api *PrivateLightServerAPI) ServerInfo() map[string]interface{} {
func (api *PrivateLightServerAPI) ClientInfo(ids []enode.ID) map[enode.ID]map[string]interface{} {
func (api *PrivateLightServerAPI) PriorityClientInfo(start, stop enode.ID, maxCount int) map[enode.ID]map[string]interface{} {
func (api *PrivateLightServerAPI) UpdateBalance(id enode.ID, value int64, add bool, meta string) error {
func (api *PrivateLightServerAPI) SetClientParams(ids []enode.ID, params map[string]interface{}) error {
func (api *PrivateLightServerAPI) SetDefaultParams(params map[string]interface{}) error {
func (api *PrivateLightServerAPI) SubscribeEvent(ctx context.Context) (*rpc.Subscription, error) {
```

A note on the "meta" parameter of balance update: this field is stored and updated together with the client balance. It can be used for multiple things:
- remember the last transaction already added to the balance
- store some meta-info about the balance, for example implement token expiration
- tag the client as part of a special subgroup
- store client balance in multiple currencies

The point is that the client pool and the balance tracker only needs to know about a scalar balance/priority value, all other information about clients is handled and interpreted by higher layers so the server code does not need to be more complicated.