### PR TITLE
cmd/evm: make evm default to all ethash protocol changes

### DIFF
--- a/cmd/evm/runner.go
+++ b/cmd/evm/runner.go
@@ -198,6 +198,8 @@ func runCmd(ctx *cli.Context) error {
 
 	if chainConfig != nil {
 		runtimeConfig.ChainConfig = chainConfig
+	} else {
+		runtimeConfig.ChainConfig = params.AllEthashProtocolChanges
 	}
 	tstart := time.Now()
 	var leftOverGas uint64


### PR DESCRIPTION
This is a tiny change, so the `evm` can more easily be used to try out opcodes introduced after Frontier... (note: `AllEthashProtocolChanges` does _not_ contain future forks, like Istanbul) 