### PR TITLE
txpool: smaller lock portion

### DIFF
--- a/core/tx_pool.go
+++ b/core/tx_pool.go
@@ -803,18 +803,17 @@ func (pool *TxPool) addTxsLocked(txs []*types.Transaction, local bool) ([]error,
 // Status returns the status (unknown/pending/queued) of a batch of transactions
 // identified by their hashes.
 func (pool *TxPool) Status(hashes []common.Hash) []TxStatus {
-	pool.mu.RLock()
-	defer pool.mu.RUnlock()
-
 	status := make([]TxStatus, len(hashes))
 	for i, hash := range hashes {
-		if tx := pool.all.Get(hash); tx != nil {
+		if tx := pool.Get(hash); tx != nil {
 			from, _ := types.Sender(pool.signer, tx) // already validated
-			if pool.pending[from] != nil && pool.pending[from].txs.items[tx.Nonce()] != nil {
+			pool.mu.RLock()
+			if txList := pool.pending[from]; txList != nil && txList.txs.items[tx.Nonce()] != nil {
 				status[i] = TxStatusPending
 			} else {
 				status[i] = TxStatusQueued
 			}
+			pool.mu.RUnlock()
 		}
 	}
 	return status


### PR DESCRIPTION
The LES server handling seems to put a strain on the txpool. One such point which takes very long time seems to be checking `Status` of a transaction. 

This PR changes the lock section of `Status`, to perform better when a transaction is missing. In that case, we don't need to obtain the full `pool.mu.RLock`, since the `all.Get` operation is already mutex:ed internally. 
LES always only checks the status of the transactions one at a time, so even if the transactions are present in the pool, this particular change does not degrade performance a lot -- before this PR, the LES server caused the lock to be obtained `N` times, which is the case even after.  

