### PR TITLE
consensus/clique: add clique_status API method

### DIFF
--- a/consensus/clique/api.go
+++ b/consensus/clique/api.go
@@ -17,6 +17,8 @@
 package clique
 
 import (
+	"fmt"
+
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/consensus"
 	"github.com/ethereum/go-ethereum/core/types"
@@ -116,4 +118,61 @@ func (api *API) Discard(address common.Address) {
 	defer api.clique.lock.Unlock()
 
 	delete(api.clique.proposals, address)
+}
+
+type CliqueStatus struct {
+	InturnPercent float64                `json:"inturnPercent"`
+	SigningStatus map[common.Address]int `json:"sealerActivity""`
+	NumBlocks     uint64                 `json:"numBlocks"`
+}
+
+// Status returns the status of the last N blocks,
+// - the number of active signers,
+// - the number of signers,
+// - the percentage of in-turn blocks
+func (api *API) Status() (*CliqueStatus, error) {
+	var (
+		numBlocks = uint64(64)
+		header    = api.chain.CurrentHeader()
+		diff      = uint64(0)
+		optimals  = 0
+	)
+	snap, err := api.clique.snapshot(api.chain, header.Number.Uint64(), header.Hash(), nil)
+	if err != nil {
+		return nil, err
+	}
+	var (
+		signers = snap.signers()
+		end     = header.Number.Uint64()
+		start   = end - numBlocks
+	)
+	if numBlocks > end {
+		start = 1
+		numBlocks = end - start
+	}
+	signStatus := make(map[common.Address]int)
+	for _, s := range signers {
+		signStatus[s] = 0
+	}
+	for n := start; n < end; n++ {
+		h := api.chain.GetHeaderByNumber(n)
+		if h != nil {
+			if h.Difficulty.Cmp(diffInTurn) == 0 {
+				optimals += 1
+			}
+			diff += h.Difficulty.Uint64()
+			if sealer, err := api.clique.Author(h); err != nil {
+				return nil, err
+			} else {
+				signStatus[sealer] += 1
+			}
+		} else {
+			return nil, fmt.Errorf("missing block %d", n)
+		}
+	}
+	return &CliqueStatus{
+		InturnPercent: float64((100 * optimals)) / float64(numBlocks),
+		SigningStatus: signStatus,
+		NumBlocks:     numBlocks,
+	}, nil
 }


### PR DESCRIPTION
This PR introduces `clique_status` which gives info about the health of the clique network. 
- Which signers are currently active, and have signed blocks in the last `N` (set to 64) blocks? 
- How many blocks has each signer signed? 
- What is the difficulty in the last `N` blocks, compared to the theoretical max ? 

It's currently a bit PITA to find out how a clique network is performing, and it can easily happen that sealers drop off -- and everything is 'fine' until one more signer drops off, and the network suddenly halts. 

This is WIP, but before I polish it (e.g. lowercase json), I'd like some feedback / proposals for things to have here. 
Currently: 
```
[user@work go-ethereum]$ echo '{"jsonrpc":"2.0","method":"clique_status","params":[],"id":1}' | nc -U /tmp/geth.ipc | jq .
{
  "jsonrpc": "2.0",
  "id": 1,
  "result": {
    "MaxDifficulty": 128,
    "ActualDifficulty": 128,
    "SigningStatus": {
      "0x92de766bbe05bf764a4502db0d2cba76ccdecd20": 64
    },
    "NumBlocks": 64
  }
}
```
So, what do we want to have here? 

cc @5chdn -- might be appreciated for goerli too? We should also agree with Parity about this one, if we want it. 