### PR TITLE
cmd/bootnode: fix exit behavior with -genkey

### DIFF
--- a/cmd/bootnode/main.go
+++ b/cmd/bootnode/main.go
@@ -70,7 +70,9 @@ func main() {
 		if err = crypto.SaveECDSA(*genKey, nodeKey); err != nil {
 			utils.Fatalf("%v", err)
 		}
-		return
+		if !*writeAddr {
+			return
+		}
 	case *nodeKeyFile == "" && *nodeKeyHex == "":
 		utils.Fatalf("Use -nodekey or -nodekeyhex to specify a private key")
 	case *nodeKeyFile != "" && *nodeKeyHex != "":


### PR DESCRIPTION
For #17579, when generating a key, if the `-writeaddress` flag is passed, print out the address that was generated, and then `os.Exit(0)` is called.   

If `-writeaddress` is not passed in, then the `return` will happen as it did before this change.

Example with `-writeaddress`:

```
$ ./build/bin/bootnode -genkey /tmp/tmp.txt -writeaddress
f53dd1d94cd2e0b2d0386ee4bfd1d12c4c471eb68133b6e509074f4dc6cd64e1e8e4a36d5c447857200235f572b3ecd5f7d743ebffc54ea8387677f5e09b3b9a
$
```
Without `-writeaddress`:

```
$ ./build/bin/bootnode -genkey /tmp/tmp.txt
$ 
```

@karalabe I don't have permission to formally add reviewers, please review if possible.  Or is there a team I can mention to request a review?