### PR TITLE
dashboard: log dashboard url

### DIFF
--- a/dashboard/dashboard.go
+++ b/dashboard/dashboard.go
@@ -125,7 +125,7 @@ func (db *Dashboard) APIs() []rpc.API { return nil }
 // Start starts the data collection thread and the listening server of the dashboard.
 // Implements the node.Service interface.
 func (db *Dashboard) Start(server *p2p.Server) error {
-	log.Info("Starting dashboard")
+	log.Info("Starting dashboard", "url", fmt.Sprintf("http://%s:%d", db.config.Host, db.config.Port))
 
 	db.wg.Add(3)
 	go db.collectSystemData()


### PR DESCRIPTION
I found it a bit annoying that I couldn't see easily where I could access the dashboard, so this PR adds that info to the logs. 
```
INFO [09-24|10:07:21.980] New local node record                    seq=2 id=7c38e6b9bf1e0c03 ip=127.0.0.1 udp=30303 tcp=30303
INFO [09-24|10:07:21.980] Starting dashboard                       host=localhost port=8080
```