### PR TITLE
p2p: measure subprotocol bandwidth usage

### DIFF
--- a/p2p/message.go
+++ b/p2p/message.go
@@ -39,9 +39,13 @@ import (
 // separate Msg with a bytes.Reader as Payload for each send.
 type Msg struct {
 	Code       uint64
-	Size       uint32 // size of the paylod
+	Size       uint32 // Size of the raw payload
 	Payload    io.Reader
 	ReceivedAt time.Time
+
+	meterCap  Cap    // Protocol name and version for egress metering
+	meterCode uint64 // Message within protocol for egress metering
+	meterSize uint32 // Compressed message size for ingress metering
 }
 
 // Decode parses the RLP content of a message into

--- a/p2p/peer.go
+++ b/p2p/peer.go
@@ -28,6 +28,7 @@ import (
 	"github.com/ethereum/go-ethereum/common/mclock"
 	"github.com/ethereum/go-ethereum/event"
 	"github.com/ethereum/go-ethereum/log"
+	"github.com/ethereum/go-ethereum/metrics"
 	"github.com/ethereum/go-ethereum/p2p/enode"
 	"github.com/ethereum/go-ethereum/p2p/enr"
 	"github.com/ethereum/go-ethereum/rlp"
@@ -300,6 +301,9 @@ func (p *Peer) handle(msg Msg) error {
 		if err != nil {
 			return fmt.Errorf("msg code out of range: %v", msg.Code)
 		}
+		if metrics.Enabled {
+			metrics.GetOrRegisterMeter(fmt.Sprintf("%s/%s/%d/%#02x", MetricsInboundTraffic, proto.Name, proto.Version, msg.Code-proto.offset), nil).Mark(int64(msg.meterSize))
+		}
 		select {
 		case proto.in <- msg:
 			return nil
@@ -398,7 +402,11 @@ func (rw *protoRW) WriteMsg(msg Msg) (err error) {
 	if msg.Code >= rw.Length {
 		return newPeerError(errInvalidMsgCode, "not handled")
 	}
+	msg.meterCap = rw.cap()
+	msg.meterCode = msg.Code
+
 	msg.Code += rw.offset
+
 	select {
 	case <-rw.wstart:
 		err = rw.w.WriteMsg(msg)

--- a/p2p/rlpx.go
+++ b/p2p/rlpx.go
@@ -38,6 +38,7 @@ import (
 	"github.com/ethereum/go-ethereum/common/bitutil"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/crypto/ecies"
+	"github.com/ethereum/go-ethereum/metrics"
 	"github.com/ethereum/go-ethereum/rlp"
 	"github.com/golang/snappy"
 	"golang.org/x/crypto/sha3"
@@ -602,6 +603,10 @@ func (rw *rlpxFrameRW) WriteMsg(msg Msg) error {
 		msg.Payload = bytes.NewReader(payload)
 		msg.Size = uint32(len(payload))
 	}
+	msg.meterSize = msg.Size
+	if metrics.Enabled && msg.meterCap.Name != "" { // don't meter non-subprotocol messages
+		metrics.GetOrRegisterMeter(fmt.Sprintf("%s/%s/%d/%#02x", MetricsOutboundTraffic, msg.meterCap.Name, msg.meterCap.Version, msg.meterCode), nil).Mark(int64(msg.meterSize))
+	}
 	// write header
 	headbuf := make([]byte, 32)
 	fsize := uint32(len(ptype)) + msg.Size
@@ -686,6 +691,7 @@ func (rw *rlpxFrameRW) ReadMsg() (msg Msg, err error) {
 		return msg, err
 	}
 	msg.Size = uint32(content.Len())
+	msg.meterSize = msg.Size
 	msg.Payload = content
 
 	// if snappy is enabled, verify and decompress message


### PR DESCRIPTION
Measures the Snappy compressed wire traffic belonging to individual subprotocols, down to the message type level.

```
"p2p/egress.count": 45975,
"p2p/egress.fifteen-minute": 47.08913611676422,
"p2p/egress.five-minute": 137.58761808377292,
"p2p/egress.mean": 897.3968326322948,
"p2p/egress.one-minute": 594.8198589965016,

"p2p/egress/eth/63/0x00.count": 2153,
"p2p/egress/eth/63/0x00.fifteen-minute": 16.843303813216284,
"p2p/egress/eth/63/0x00.five-minute": 19.683540466014865,
"p2p/egress/eth/63/0x00.mean": 51.209709917385624,
"p2p/egress/eth/63/0x00.one-minute": 35.49422974548988,

"p2p/egress/eth/63/0x01.count": 82,
"p2p/egress/eth/63/0x01.fifteen-minute": 16.128931842674525,
"p2p/egress/eth/63/0x01.five-minute": 15.600162561811711,
"p2p/egress/eth/63/0x01.mean": 4.23382797404747,
"p2p/egress/eth/63/0x01.one-minute": 12.772332842371043,

"p2p/egress/eth/63/0x03.count": 181,
"p2p/egress/eth/63/0x03.fifteen-minute": 4.065862227517339,
"p2p/egress/eth/63/0x03.five-minute": 4.1864402094221935,
"p2p/egress/eth/63/0x03.mean": 6.88672494387651,
"p2p/egress/eth/63/0x03.one-minute": 4.642039535224999,

"p2p/egress/eth/63/0x04.count": 453,
"p2p/egress/eth/63/0x04.fifteen-minute": 88.11796562674114,
"p2p/egress/eth/63/0x04.five-minute": 83.3560239654167,
"p2p/egress/eth/63/0x04.mean": 17.238322371992155,
"p2p/egress/eth/63/0x04.one-minute": 59.72720109616023,

"p2p/egress/eth/63/0x05.count": 214,
"p2p/egress/eth/63/0x05.fifteen-minute": 42.092578223565226,
"p2p/egress/eth/63/0x05.five-minute": 40.71261936863056,
"p2p/egress/eth/63/0x05.mean": 10.994022713117252,
"p2p/egress/eth/63/0x05.one-minute": 33.332673515456136,

"p2p/egress/eth/63/0x07.count": 1813,
"p2p/egress/eth/63/0x07.fifteen-minute": 356.60674915571843,
"p2p/egress/eth/63/0x07.five-minute": 344.9157893239589,
"p2p/egress/eth/63/0x07.mean": 114.04711546264019,
"p2p/egress/eth/63/0x07.one-minute": 282.39316394169145,

"p2p/egress/les/2/0x00.count": 462,
"p2p/egress/les/2/0x00.fifteen-minute": 91.88808995565246,
"p2p/egress/les/2/0x00.five-minute": 90.87276233311745,
"p2p/egress/les/2/0x00.mean": 81.71936660089445,
"p2p/egress/les/2/0x00.one-minute": 85.01210391174946,

"p2p/egress/les/3/0x00.count": 1394,
"p2p/egress/les/3/0x00.fifteen-minute": 92.8,
"p2p/egress/les/3/0x00.five-minute": 92.8,
"p2p/egress/les/3/0x00.mean": 236.06152047919977,
"p2p/egress/les/3/0x00.one-minute": 92.8,

"p2p/ingress.count": 44677,
"p2p/ingress.fifteen-minute": 46.546246595639545,
"p2p/ingress.five-minute": 135.57884391394614,
"p2p/ingress.mean": 872.0640342549666,
"p2p/ingress.one-minute": 574.1370626497356,

"p2p/ingress/eth/63/0x00.count": 1078,
"p2p/ingress/eth/63/0x00.fifteen-minute": 17.066759307254838,
"p2p/ingress/eth/63/0x00.five-minute": 17.61928447163463,
"p2p/ingress/eth/63/0x00.mean": 25.799724585087244,
"p2p/ingress/eth/63/0x00.one-minute": 21.28671625962244,

"p2p/ingress/eth/63/0x01.count": 238,
"p2p/ingress/eth/63/0x01.fifteen-minute": 23.538476218437953,
"p2p/ingress/eth/63/0x01.five-minute": 23.0326397021625,
"p2p/ingress/eth/63/0x01.mean": 15.044668734969248,
"p2p/ingress/eth/63/0x01.one-minute": 20.438401568921545,

"p2p/ingress/eth/63/0x03.count": 39,
"p2p/ingress/eth/63/0x03.fifteen-minute": 7.586314921507517,
"p2p/ingress/eth/63/0x03.five-minute": 7.176346434108722,
"p2p/ingress/eth/63/0x03.mean": 1.484045077773802,
"p2p/ingress/eth/63/0x03.one-minute": 5.142076915563463,

"p2p/ingress/eth/63/0x04.count": 6326,
"p2p/ingress/eth/63/0x04.fifteen-minute": 128.75518797578957,
"p2p/ingress/eth/63/0x04.five-minute": 133.83659928648922,
"p2p/ingress/eth/63/0x04.mean": 241.1141180129894,
"p2p/ingress/eth/63/0x04.one-minute": 154.0017024745396,

"p2p/ingress/eth/63/0x06.count": 3257,
"p2p/ingress/eth/63/0x06.fifteen-minute": 640.6333050194015,
"p2p/ingress/eth/63/0x06.five-minute": 619.6308471197652,
"p2p/ingress/eth/63/0x06.mean": 167.7340902039456,
"p2p/ingress/eth/63/0x06.one-minute": 507.31083009271316,

"p2p/ingress/eth/63/0x07.count": 2998,
"p2p/ingress/eth/63/0x07.fifteen-minute": 522.7989826665082,
"p2p/ingress/eth/63/0x07.five-minute": 506.42362285338055,
"p2p/ingress/eth/63/0x07.mean": 188.56899045614972,
"p2p/ingress/eth/63/0x07.one-minute": 419.1679380068846,

"p2p/ingress/les/3/0x00.count": 646,
"p2p/ingress/les/3/0x00.fifteen-minute": 63.42936331855083,
"p2p/ingress/les/3/0x00.five-minute": 63.09092077770582,
"p2p/ingress/les/3/0x00.mean": 109.31427995225799,
"p2p/ingress/les/3/0x00.one-minute": 61.137367970583156,
```