### PR TITLE
core/blockchain: trigger disk flush near hard fork

### DIFF
--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -1316,7 +1316,9 @@ func (bc *BlockChain) writeBlockWithState(block *types.Block, receipts []*types.
 			chosen := current - TriesInMemory
 
 			// If we exceeded out time allowance, flush an entire trie to disk
-			if bc.gcproc > bc.cacheConfig.TrieTimeLimit {
+			flushToDisk := bc.gcproc > bc.cacheConfig.TrieTimeLimit ||
+				bc.chainConfig.isForkBlock(current+1)
+			if flushToDisk {
 				// If the header is missing (canonical chain behind), we're reorging a low
 				// diff sidechain. Suspend committing until this operation is completed.
 				header := bc.GetHeaderByNumber(chosen)

--- a/params/config.go
+++ b/params/config.go
@@ -469,6 +469,30 @@ func isForked(s, head *big.Int) bool {
 	return s.Cmp(head) <= 0
 }
 
+// isForkBlock returns whether the given block number designates a fork block
+func (c *ChainConfig) isForkBlock(n uint64) bool {
+	number := big.NewInt(n)
+	for _, forkNum := range []*big.Int{
+		c.HomesteadBlock,
+		c.DAOForkBlock,
+		c.EIP150Block,
+		c.EIP155Block,
+		c.EIP158Block,
+		c.ByzantiumBlock,
+		c.ConstantinopleBlock,
+		c.PetersburgBlock,
+		c.IstanbulBlock,
+	} {
+		h := forkNum.Cmp(number)
+		if h < 0 {
+			return false
+		}
+		if h == 0 {
+			return true
+		}
+	}
+}
+
 func configNumEqual(x, y *big.Int) bool {
 	if x == nil {
 		return y == nil

--- a/params/config.go
+++ b/params/config.go
@@ -483,6 +483,9 @@ func (c *ChainConfig) IsForkBlock(n uint64) bool {
 		c.PetersburgBlock,
 		c.IstanbulBlock,
 	} {
+		if forkNum == nil {
+			return false
+		}
 		h := number.Cmp(forkNum)
 		if h < 0 {
 			return false

--- a/params/config.go
+++ b/params/config.go
@@ -470,8 +470,8 @@ func isForked(s, head *big.Int) bool {
 }
 
 // isForkBlock returns whether the given block number designates a fork block
-func (c *ChainConfig) isForkBlock(n uint64) bool {
-	number := big.NewInt(n)
+func (c *ChainConfig) IsForkBlock(n uint64) bool {
+	number := new(big.Int).SetUint64(n)
 	for _, forkNum := range []*big.Int{
 		c.HomesteadBlock,
 		c.DAOForkBlock,
@@ -483,7 +483,7 @@ func (c *ChainConfig) isForkBlock(n uint64) bool {
 		c.PetersburgBlock,
 		c.IstanbulBlock,
 	} {
-		h := forkNum.Cmp(number)
+		h := number.Cmp(forkNum)
 		if h < 0 {
 			return false
 		}
@@ -491,6 +491,7 @@ func (c *ChainConfig) isForkBlock(n uint64) bool {
 			return true
 		}
 	}
+	return false
 }
 
 func configNumEqual(x, y *big.Int) bool {


### PR DESCRIPTION
This PR is meant to address #20150 

- [x] Force commit state for block `FORK_BLOCK - 1` 
- [x] Prevent nodes from regenerating state from genesis
- [ ] Force commit state of common ancestor when importing sidechain

I'm a bit unsure about my implementation of the first item, I think it will, when it hits `FORK_BLOCK-1`, instead flush `FORK_BLOCK-129`. However, I'm not sure that's a bad thing, since there's still reorgs to take into account... ? 