### PR TITLE
update readme to use new miner threads flag instead of legacy minerth…

### DIFF
--- a/README.md
+++ b/README.md
@@ -303,7 +303,7 @@ ones either). To start a `geth` instance for mining, run it with all your usual 
 by:
 
 ```shell
-$ geth <usual-flags> --mine --minerthreads=1 --etherbase=0x0000000000000000000000000000000000000000
+$ geth <usual-flags> --mine --miner.threads=1 --etherbase=0x0000000000000000000000000000000000000000
 ```
 
 Which will start mining blocks and transactions on a single CPU thread, crediting all


### PR DESCRIPTION
Issue [#20161](https://github.com/ethereum/go-ethereum/issues/20161) is most likely due to outdated documentation referring to legacy miner threads flag.