### PR TITLE
cmd/geth: add 'dumpgenesis' cmd

### DIFF
--- a/cmd/geth/chaincmd.go
+++ b/cmd/geth/chaincmd.go
@@ -67,10 +67,7 @@ It expects the genesis file as argument.`,
 		},
 		Category: "BLOCKCHAIN COMMANDS",
 		Description: `
-The dumpgenesis command dumps the genesis block configuration in JSON format to stdout.
-
-This data can be used as a template or passed to the 'init' command. 
-`,
+The dumpgenesis command dumps the genesis block configuration in JSON format to stdout.`,
 	}
 	importCommand = cli.Command{
 		Action:    utils.MigrateFlags(importChain),

--- a/cmd/geth/chaincmd.go
+++ b/cmd/geth/chaincmd.go
@@ -244,6 +244,9 @@ func initGenesis(ctx *cli.Context) error {
 
 func dumpGenesis(ctx *cli.Context) error {
 	genesis := utils.MakeGenesis(ctx)
+	if genesis == nil {
+		genesis = core.DefaultGenesisBlock()
+	}
 	if err := json.NewEncoder(os.Stdout).Encode(genesis); err != nil {
 		utils.Fatalf("could not encode defaulty genesis")
 	}

--- a/cmd/geth/chaincmd.go
+++ b/cmd/geth/chaincmd.go
@@ -248,7 +248,7 @@ func dumpGenesis(ctx *cli.Context) error {
 		genesis = core.DefaultGenesisBlock()
 	}
 	if err := json.NewEncoder(os.Stdout).Encode(genesis); err != nil {
-		utils.Fatalf("could not encode defaulty genesis")
+		utils.Fatalf("could not encode genesis")
 	}
 	return nil
 }

--- a/cmd/geth/chaincmd.go
+++ b/cmd/geth/chaincmd.go
@@ -57,6 +57,21 @@ participating.
 
 It expects the genesis file as argument.`,
 	}
+	dumpGenesisCommand = cli.Command{
+		Action:    utils.MigrateFlags(dumpGenesis),
+		Name:      "dumpgenesis",
+		Usage:     "Dumps genesis block JSON configuration to stdout",
+		ArgsUsage: "",
+		Flags: []cli.Flag{
+			utils.DataDirFlag,
+		},
+		Category: "BLOCKCHAIN COMMANDS",
+		Description: `
+The dumpgenesis command dumps the genesis block configuration in JSON format to stdout.
+
+This data can be used as a template or passed to the 'init' command. 
+`,
+	}
 	importCommand = cli.Command{
 		Action:    utils.MigrateFlags(importChain),
 		Name:      "import",
@@ -223,6 +238,14 @@ func initGenesis(ctx *cli.Context) error {
 		}
 		chaindb.Close()
 		log.Info("Successfully wrote genesis state", "database", name, "hash", hash)
+	}
+	return nil
+}
+
+func dumpGenesis(ctx *cli.Context) error {
+	genesis := utils.MakeGenesis(ctx)
+	if err := json.NewEncoder(os.Stdout).Encode(genesis); err != nil {
+		utils.Fatalf("could not encode defaulty genesis")
 	}
 	return nil
 }

--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -208,6 +208,7 @@ func init() {
 		copydbCommand,
 		removedbCommand,
 		dumpCommand,
+		dumpGenesisCommand,
 		inspectCommand,
 		// See accountcmd.go:
 		accountCommand,


### PR DESCRIPTION
Adds `geth dumpgenesis` command, which writes the configured genesis in JSON format to _stdout_.

This provides a way to generate the data (structure and content) that can then be used with the `geth init` command.

```
$ ./build/bin/geth dumpgenesis | jj -p | head -30
{
  "config": {
    "chainId": 1,
    "homesteadBlock": 1150000,
    "daoForkBlock": 1920000,
    "daoForkSupport": true,
    "eip150Block": 2463000,
    "eip150Hash": "0x2086799aeebeae135c246c65021c82b4e15a2c451340993aacfd2751886514f0",
    "eip155Block": 2675000,
    "eip158Block": 2675000,
    "byzantiumBlock": 4370000,
    "constantinopleBlock": 7280000,
    "petersburgBlock": 7280000,
    "ethash": {}
  },
  "nonce": "0x42",
  "timestamp": "0x0",
  "extraData": "0x11bbe8db4e347b4e8c937c1c8370e4b5ed33adb3db69cbdb7a38e1e50b1b82fa",
  "gasLimit": "0x1388",
  "difficulty": "0x400000000",
  "mixHash": "0x0000000000000000000000000000000000000000000000000000000000000000",
  "coinbase": "0x0000000000000000000000000000000000000000",
  "alloc": {
    "000d836201318ec6899a67540690382780743280": {
      "balance": "0xad78ebc5ac6200000"
    },
    "001762430ea9c3a26e5749afdb70da5f78ddbb8c": {
      "balance": "0xad78ebc5ac6200000"
    },
    "001d14804b399c6ef80e64576f657660804fec0b": {
``` 