### PR TITLE
core/asm: assembly parser label fixes

### DIFF
--- a/core/asm/compiler.go
+++ b/core/asm/compiler.go
@@ -201,8 +201,8 @@ func (c *Compiler) compileElement(element token) error {
 		case stringValue:
 			value = []byte(rvalue.text[1 : len(rvalue.text)-1])
 		case label:
-			value = make([]byte, 4)
-			copy(value, big.NewInt(int64(c.labels[rvalue.text])).Bytes())
+			value = big.NewInt(int64(c.labels[rvalue.text])).Bytes()
+			value = append(make([]byte, 4-len(value)), value...)
 		default:
 			return compileErr(rvalue, rvalue.text, "number, string or label")
 		}

--- a/core/asm/compiler.go
+++ b/core/asm/compiler.go
@@ -186,6 +186,8 @@ func (c *Compiler) compileElement(element token) error {
 			pos := big.NewInt(int64(c.labels[rvalue.text])).Bytes()
 			pos = append(make([]byte, 4-len(pos)), pos...)
 			c.pushBin(pos)
+		case lineEnd:
+			c.pos--
 		default:
 			return compileErr(rvalue, rvalue.text, "number, string or label")
 		}

--- a/core/asm/compiler.go
+++ b/core/asm/compiler.go
@@ -57,6 +57,7 @@ func NewCompiler(debug bool) *Compiler {
 // second stage to push labels and determine the right
 // position.
 func (c *Compiler) Feed(ch <-chan token) {
+	var prev token
 	for i := range ch {
 		switch i.typ {
 		case number:
@@ -73,10 +74,14 @@ func (c *Compiler) Feed(ch <-chan token) {
 			c.labels[i.text] = c.pc
 			c.pc++
 		case label:
-			c.pc += 5
+			c.pc += 4
+			if prev.typ == element && isJump(prev.text) {
+				c.pc++
+			}
 		}
 
 		c.tokens = append(c.tokens, i)
+		prev = i
 	}
 	if c.debug {
 		fmt.Fprintln(os.Stderr, "found", len(c.labels), "labels")

--- a/core/asm/compiler_test.go
+++ b/core/asm/compiler_test.go
@@ -1,0 +1,49 @@
+// Copyright 2019 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+package asm
+
+import (
+	"testing"
+)
+
+func TestCompiler(t *testing.T) {
+	tests := []struct {
+		input, output string
+	}{
+		{
+			input: `
+	GAS
+	label:
+	PUSH @label
+`,
+			output: "5a5b6300000001",
+		},
+	}
+	for _, test := range tests {
+		ch := Lex([]byte(test.input), false)
+		c := NewCompiler(false)
+		c.Feed(ch)
+		output, err := c.Compile()
+		if len(err) != 0 {
+			t.Errorf("compile error: %v\ninput: %s", err, test.input)
+			continue
+		}
+		if output != test.output {
+			t.Errorf("incorrect output\ninput: %sgot:  %s\nwant: %s\n", test.input, output, test.output)
+		}
+	}
+}

--- a/core/asm/compiler_test.go
+++ b/core/asm/compiler_test.go
@@ -39,6 +39,21 @@ func TestCompiler(t *testing.T) {
 `,
 			output: "63000000055b",
 		},
+		{
+			input: `
+	PUSH @label
+	JUMP
+	label:
+`,
+			output: "6300000006565b",
+		},
+		{
+			input: `
+	JUMP @label
+	label:
+`,
+			output: "6300000006565b",
+		},
 	}
 	for _, test := range tests {
 		ch := Lex([]byte(test.input), false)

--- a/core/asm/compiler_test.go
+++ b/core/asm/compiler_test.go
@@ -32,6 +32,13 @@ func TestCompiler(t *testing.T) {
 `,
 			output: "5a5b6300000001",
 		},
+		{
+			input: `
+	PUSH @label
+	label:
+`,
+			output: "63000000055b",
+		},
 	}
 	for _, test := range tests {
 		ch := Lex([]byte(test.input), false)


### PR DESCRIPTION
This pull request fixes several issues in the ASM parser:

- If label `@foo` resolves to `0x123`, then `PUSH @foo` is assembled as `PUSH 0x12300000` rather than `PUSH 0x00000123`.
- When parsing the instruction `PUSH @foo`, PC is incremented by 6 (1 + 5), rather than 5 (1 + 4), since there is no implicit `PUSH` as with `JUMP @foo`.
- `JUMP` with no argument is not allowed, though it could be useful to jump to a label whose address is stored on the stack.