### PR TITLE
cmd/evm: remove surrounding whitespace in hex input code

### DIFF
--- a/cmd/evm/runner.go
+++ b/cmd/evm/runner.go
@@ -17,6 +17,7 @@
 package main
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
@@ -145,6 +146,7 @@ func runCmd(ctx *cli.Context) error {
 		} else {
 			hexcode = []byte(codeFlag)
 		}
+		hexcode = bytes.TrimSpace(hexcode)
 		if len(hexcode)%2 != 0 {
 			fmt.Printf("Invalid input length for hex data (%d)\n", len(hexcode))
 			os.Exit(1)


### PR DESCRIPTION
This way, the output of `evm compile` can be used directly in `evm
--codefile code.txt run`, without stripping the trailing newline first.