### PR TITLE
params: configure mainnet istanbul block 9069K

### DIFF
--- a/core/forkid/forkid_test.go
+++ b/core/forkid/forkid_test.go
@@ -56,7 +56,9 @@ func TestCreation(t *testing.T) {
 				{4370000, ID{Hash: checksumToBytes(0xa00bc324), Next: 7280000}}, // First Byzantium block
 				{7279999, ID{Hash: checksumToBytes(0xa00bc324), Next: 7280000}}, // Last Byzantium block
 				{7280000, ID{Hash: checksumToBytes(0x668db0af), Next: 9069000}}, // First and last Constantinople, first Petersburg block
-				{9069001, ID{Hash: checksumToBytes(0x879d6e30), Next: 0}},       // Today Istanbul block
+				{9068999, ID{Hash: checksumToBytes(0x668db0af), Next: 9069000}}, // Last Petersburg block
+				{9069000, ID{Hash: checksumToBytes(0x879d6e30), Next: 0}},       // Today Istanbul block
+				{10000000, ID{Hash: checksumToBytes(0x879d6e30), Next: 0}},      // Future Istanbul block
 			},
 		},
 		// Ropsten test cases

--- a/core/forkid/forkid_test.go
+++ b/core/forkid/forkid_test.go
@@ -55,8 +55,8 @@ func TestCreation(t *testing.T) {
 				{4369999, ID{Hash: checksumToBytes(0x3edd5b10), Next: 4370000}}, // Last Spurious block
 				{4370000, ID{Hash: checksumToBytes(0xa00bc324), Next: 7280000}}, // First Byzantium block
 				{7279999, ID{Hash: checksumToBytes(0xa00bc324), Next: 7280000}}, // Last Byzantium block
-				{7280000, ID{Hash: checksumToBytes(0x668db0af), Next: 0}},       // First and last Constantinople, first Petersburg block
-				{7987396, ID{Hash: checksumToBytes(0x668db0af), Next: 0}},       // Today Petersburg block
+				{7280000, ID{Hash: checksumToBytes(0x668db0af), Next: 9069000}}, // First and last Constantinople, first Petersburg block
+				{9069001, ID{Hash: checksumToBytes(0x879d6e30), Next: 0}},       // Today Istanbul block
 			},
 		},
 		// Ropsten test cases
@@ -179,11 +179,11 @@ func TestValidation(t *testing.T) {
 		// Local is mainnet Petersburg, remote is Rinkeby Petersburg.
 		{7987396, ID{Hash: checksumToBytes(0xafec6b27), Next: 0}, ErrLocalIncompatibleOrStale},
 
-		// Local is mainnet Petersburg, far in the future. Remote announces Gopherium (non existing fork)
+		// Local is mainnet Istanbul, far in the future. Remote announces Gopherium (non existing fork)
 		// at some future block 88888888, for itself, but past block for local. Local is incompatible.
 		//
 		// This case detects non-upgraded nodes with majority hash power (typical Ropsten mess).
-		{88888888, ID{Hash: checksumToBytes(0x668db0af), Next: 88888888}, ErrLocalIncompatibleOrStale},
+		{88888888, ID{Hash: checksumToBytes(0x879d6e30), Next: 88888888}, ErrLocalIncompatibleOrStale},
 
 		// Local is mainnet Byzantium. Remote is also in Byzantium, but announces Gopherium (non existing
 		// fork) at block 7279999, before Petersburg. Local is incompatible.

--- a/params/config.go
+++ b/params/config.go
@@ -65,7 +65,7 @@ var (
 		ByzantiumBlock:      big.NewInt(4370000),
 		ConstantinopleBlock: big.NewInt(7280000),
 		PetersburgBlock:     big.NewInt(7280000),
-		IstanbulBlock:       nil,
+		IstanbulBlock:       big.NewInt(9069000),
 		Ethash:              new(EthashConfig),
 	}
 


### PR DESCRIPTION
This PR enables istanbul for mainnet at block `9069000`