### PR TITLE
build: bump PPAs to Go 1.13 (via longsleep), keep Trusty on 1.11

### DIFF
--- a/build/ci-notes.md
+++ b/build/ci-notes.md
@@ -22,19 +22,20 @@ variables `PPA_SIGNING_KEY` and `PPA_SSH_KEY` on Travis.
 
 We want to build go-ethereum with the most recent version of Go, irrespective of the Go
 version that is available in the main Ubuntu repository. In order to make this possible,
-our PPA depends on the ~gophers/ubuntu/archive PPA. Our source package build-depends on
-golang-1.11, which is co-installable alongside the regular golang package. PPA dependencies
-can be edited at https://launchpad.net/%7Eethereum/+archive/ubuntu/ethereum/+edit-dependencies
+our we depend on ~gophers/ubuntu/archive and ~longsleep/ubuntu/golang-backports PPAs. Our
+source package build-depends on golang-1.11 on Tusty and golang-1.13 on others, which is
+co-installable alongside the regular golang package. PPA dependencies can be edited at
+https://launchpad.net/%7Eethereum/+archive/ubuntu/ethereum/+edit-dependencies
 
 ## Building Packages Locally (for testing)
 
 You need to run Ubuntu to do test packaging.
 
-Add the gophers PPA and install Go 1.11 and Debian packaging tools:
+Add the longsleep PPA and install Go 1.13 and Debian packaging tools:
 
-    $ sudo apt-add-repository ppa:gophers/ubuntu/archive
+    $ sudo apt-add-repository ppa:longsleep/ubuntu/golang-backports
     $ sudo apt-get update
-    $ sudo apt-get install build-essential golang-1.11 devscripts debhelper python-bzrlib python-paramiko
+    $ sudo apt-get install build-essential golang-1.13 devscripts debhelper python-bzrlib python-paramiko
 
 Create the source packages:
 
@@ -42,10 +43,10 @@ Create the source packages:
 
 Then go into the source package directory for your running distribution and build the package:
 
-    $ cd dist/ethereum-unstable-1.6.0+xenial
+    $ cd dist/ethereum-unstable-1.9.6+bionic
     $ dpkg-buildpackage
 
 Built packages are placed in the dist/ directory.
 
     $ cd ..
-    $ dpkg-deb -c geth-unstable_1.6.0+xenial_amd64.deb
+    $ dpkg-deb -c geth-unstable_1.9.6+bionic_amd64.deb

--- a/build/deb/ethereum/deb.control
+++ b/build/deb/ethereum/deb.control
@@ -2,7 +2,7 @@ Source: {{.Name}}
 Section: science
 Priority: extra
 Maintainer: {{.Author}}
-Build-Depends: debhelper (>= 8.0.0), golang-1.11
+Build-Depends: debhelper (>= 8.0.0), golang-{{.GoVersion}}
 Standards-Version: 3.9.5
 Homepage: https://ethereum.org
 Vcs-Git: git://github.com/ethereum/go-ethereum.git

--- a/build/deb/ethereum/deb.rules
+++ b/build/deb/ethereum/deb.rules
@@ -8,7 +8,7 @@
 export GOCACHE=/tmp/go-build
 
 override_dh_auto_build:
-	build/env.sh /usr/lib/go-1.11/bin/go run build/ci.go install -git-commit={{.Env.Commit}} -git-branch={{.Env.Branch}} -git-tag={{.Env.Tag}} -buildnum={{.Env.Buildnum}} -pull-request={{.Env.IsPullRequest}}
+	build/env.sh /usr/lib/go-{{.GoVersion}}/bin/go run build/ci.go install -git-commit={{.Env.Commit}} -git-branch={{.Env.Branch}} -git-tag={{.Env.Tag}} -buildnum={{.Env.Buildnum}} -pull-request={{.Env.IsPullRequest}}
 
 override_dh_auto_test:
 


### PR DESCRIPTION
This PR soups up our PPA builds:

- Bump the Go version from 1.11 to 1.13. This was done by adding a new PPA dependency, `ppa:longsleep/golang-backports`. However this only supports Ubuntu Xenial and upwards.
- Special case Ubuntu Trusty to keep using the old `ppa:gophers/archive` PPA dependency, keeping it stuck at Go 1.11. The only other option is to drop Trusty (official EOL is April 2022).

Questions:

- Do we feel comfortable with swapping out the `gophers` PPA to `longsleep`? Without maintaining our own packages, it's this way or the highway.

Todos:

- If we decide to go ahead, we need to enable `~longsleep/ubuntu/golang-backports` on our PPA deps at https://launchpad.net/%7Eethereum/+archive/ubuntu/ethereum/+edit-dependencies.
- The `longsleep` Go packages are built for `amd64`, `i386`, `arm64` and `armhf`. If we go down this PR path, we should enable those architectures our PPA builds, since there's no point in not shipping binaries we get for free: https://launchpad.net/~ethereum/+archive/ubuntu/ethereum/+edit

Remarks:

- The `longsleep` Go packages are build on Ubuntu Xenial and copied over to the newer distros. This should be fine as `glibc` is backward compatible generally (and the Go compiler should not use any fancy features really). This should not mean however that Geth will use old libc, since we will be building on the live distros, so the actual compilation will pick the latest available, even if the compiler itself was linked against an older one.
- An alternative idea was to try going down the Snaps approach. Whilst it's a promising platform, I kind of feel that it targets a different use case, which we can do as an extension to, but not replacement of the PPAs. Most importantly, Snaps have mandatory auto-updates every 6 hours, which is not compatible with critical service infrastructure. It would open a can of UX worms to silently replace one with the other. We can start publishing Snaps and then see in the future how PPAs evolve.
- Keeping Ubuntu Trusty supported but stuck at Go 1.11 means we can't use Go modules like they were intended. However, as long as we switch to Go modules but keep the dependencies vendored in, Go 1.11 should be oblivious as to how the deps are aggregated, so we should be able to keep Go 1.11 happy whilst using the newer dependency management ourselves.