### PR TITLE
eth/downloader: refactor downloader queue

### DIFF
--- a/core/types/block.go
+++ b/core/types/block.go
@@ -136,6 +136,17 @@ func rlpHash(x interface{}) (h common.Hash) {
 	return h
 }
 
+// EmptyBody returns true if there is no additional 'body' to complete the header
+// that is: no transactions and no uncles
+func (h *Header) EmptyBody() bool{
+	return h.TxHash == EmptyRootHash && h.UncleHash == EmptyUncleHash
+}
+
+// EmptyReceipts returns true if there are no receipts for this header/block
+func (h *Header) EmptyReceipts() bool{
+	return h.ReceiptHash == EmptyRootHash
+}
+
 // Body is a simple (mutable, non-safe) data container for storing and moving
 // a block's data contents (transactions and uncles) together.
 type Body struct {

--- a/core/types/block.go
+++ b/core/types/block.go
@@ -138,12 +138,12 @@ func rlpHash(x interface{}) (h common.Hash) {
 
 // EmptyBody returns true if there is no additional 'body' to complete the header
 // that is: no transactions and no uncles
-func (h *Header) EmptyBody() bool{
+func (h *Header) EmptyBody() bool {
 	return h.TxHash == EmptyRootHash && h.UncleHash == EmptyUncleHash
 }
 
 // EmptyReceipts returns true if there are no receipts for this header/block
-func (h *Header) EmptyReceipts() bool{
+func (h *Header) EmptyReceipts() bool {
 	return h.ReceiptHash == EmptyRootHash
 }
 

--- a/core/types/block.go
+++ b/core/types/block.go
@@ -137,12 +137,12 @@ func rlpHash(x interface{}) (h common.Hash) {
 }
 
 // EmptyBody returns true if there is no additional 'body' to complete the header
-// that is: no transactions and no uncles
+// that is: no transactions and no uncles.
 func (h *Header) EmptyBody() bool {
 	return h.TxHash == EmptyRootHash && h.UncleHash == EmptyUncleHash
 }
 
-// EmptyReceipts returns true if there are no receipts for this header/block
+// EmptyReceipts returns true if there are no receipts for this header/block.
 func (h *Header) EmptyReceipts() bool {
 	return h.ReceiptHash == EmptyRootHash
 }

--- a/eth/downloader/downloader.go
+++ b/eth/downloader/downloader.go
@@ -219,7 +219,7 @@ func New(checkpoint uint64, stateDb ethdb.Database, stateBloom *trie.SyncBloom, 
 		stateBloom:     stateBloom,
 		mux:            mux,
 		checkpoint:     checkpoint,
-		queue:          newQueue(),
+		queue:          newQueue(blockCacheItems),
 		peers:          newPeerSet(),
 		rttEstimate:    uint64(rttMaxEstimate),
 		rttConfidence:  uint64(1000000),
@@ -619,7 +619,7 @@ func (d *Downloader) fetchHeight(p *peerConnection) (*types.Header, error) {
 			// Make sure the peer actually gave something valid
 			headers := packet.(*headerPack).headers
 			if len(headers) != 1 {
-				p.log.Debug("Multiple headers for single request", "headers", len(headers))
+				p.log.Info("Multiple headers for single request", "headers", len(headers))
 				return nil, errBadPeer
 			}
 			head := headers[0]
@@ -851,7 +851,7 @@ func (d *Downloader) findAncestor(p *peerConnection, remoteHeader *types.Header)
 				// Make sure the peer actually gave something valid
 				headers := packer.(*headerPack).headers
 				if len(headers) != 1 {
-					p.log.Debug("Multiple headers for single request", "headers", len(headers))
+					p.log.Info("Multiple headers for single request", "headers", len(headers))
 					return 0, errBadPeer
 				}
 				arrived = true
@@ -875,7 +875,7 @@ func (d *Downloader) findAncestor(p *peerConnection, remoteHeader *types.Header)
 				}
 				header := d.lightchain.GetHeaderByHash(h) // Independent of sync mode, header surely exists
 				if header.Number.Uint64() != check {
-					p.log.Debug("Received non requested header", "number", header.Number, "hash", header.Hash(), "request", check)
+					p.log.Info("Received non requested header", "number", header.Number, "hash", header.Hash(), "request", check)
 					return 0, errBadPeer
 				}
 				start = check
@@ -1120,7 +1120,7 @@ func (d *Downloader) fetchBodies(from uint64) error {
 			pack := packet.(*bodyPack)
 			return d.queue.DeliverBodies(pack.peerID, pack.transactions, pack.uncles)
 		}
-		expire   = func() map[string]int { return d.queue.ExpireBodies(d.requestTTL()) }
+		expire   = func() map[string]int {return d.queue.ExpireBodies(d.requestTTL())}
 		fetch    = func(p *peerConnection, req *fetchRequest) error { return p.FetchBodies(req) }
 		capacity = func(p *peerConnection) int { return p.BlockCapacity(d.requestRTT()) }
 		setIdle  = func(p *peerConnection, accepted int) { p.SetBodiesIdle(accepted) }
@@ -1188,7 +1188,7 @@ func (d *Downloader) fetchParts(deliveryCh chan dataPack, deliver func(dataPack)
 	idle func() ([]*peerConnection, int), setIdle func(*peerConnection, int), kind string) error {
 
 	// Create a ticker to detect expired retrieval tasks
-	ticker := time.NewTicker(100 * time.Millisecond)
+	ticker := time.NewTicker(200 * time.Millisecond)
 	defer ticker.Stop()
 
 	update := make(chan struct{}, 1)
@@ -1264,7 +1264,7 @@ func (d *Downloader) fetchParts(deliveryCh chan dataPack, deliver func(dataPack)
 					// The reason the minimum threshold is 2 is because the downloader tries to estimate the bandwidth
 					// and latency of a peer separately, which requires pushing the measures capacity a bit and seeing
 					// how response times reacts, to it always requests one more than the minimum (i.e. min 2).
-					if fails > 2 {
+					if fails > 8 {
 						peer.log.Trace("Data delivery timed out", "type", kind)
 						setIdle(peer, 0)
 					} else {
@@ -1323,6 +1323,7 @@ func (d *Downloader) fetchParts(deliveryCh chan dataPack, deliver func(dataPack)
 					progressed = true
 				}
 				if request == nil {
+					//peer.log.Info("no request allocated this loop", "type", kind)
 					continue
 				}
 				if request.From > 0 {
@@ -1359,6 +1360,7 @@ func (d *Downloader) fetchParts(deliveryCh chan dataPack, deliver func(dataPack)
 func (d *Downloader) processHeaders(origin uint64, pivot uint64, td *big.Int) error {
 	// Keep a count of uncertain headers to roll back
 	var rollback []*types.Header
+	var rollbackErr error
 	defer func() {
 		if len(rollback) > 0 {
 			// Flatten the headers and roll them back
@@ -1380,7 +1382,7 @@ func (d *Downloader) processHeaders(origin uint64, pivot uint64, td *big.Int) er
 			log.Warn("Rolled back headers", "count", len(hashes),
 				"header", fmt.Sprintf("%d->%d", lastHeader, d.lightchain.CurrentHeader().Number),
 				"fast", fmt.Sprintf("%d->%d", lastFastBlock, curFastBlock),
-				"block", fmt.Sprintf("%d->%d", lastBlock, curBlock))
+				"block", fmt.Sprintf("%d->%d", lastBlock, curBlock), "reason", rollbackErr)
 		}
 	}()
 
@@ -1469,9 +1471,10 @@ func (d *Downloader) processHeaders(origin uint64, pivot uint64, td *big.Int) er
 					if n, err := d.lightchain.InsertHeaderChain(chunk, frequency); err != nil {
 						// If some headers were inserted, add them too to the rollback list
 						if n > 0 {
+							rollbackErr = err
 							rollback = append(rollback, chunk[:n]...)
 						}
-						log.Debug("Invalid header encountered", "number", chunk[n].Number, "hash", chunk[n].Hash(), "err", err)
+						log.Info("Invalid header encountered", "number", chunk[n].Number, "hash", chunk[n].Hash(), "err", err)
 						return errInvalidChain
 					}
 					// All verifications passed, store newly found uncertain headers
@@ -1493,7 +1496,7 @@ func (d *Downloader) processHeaders(origin uint64, pivot uint64, td *big.Int) er
 					// Otherwise insert the headers for content retrieval
 					inserts := d.queue.Schedule(chunk, origin)
 					if len(inserts) != len(chunk) {
-						log.Debug("Stale headers")
+						rollbackErr = fmt.Errorf("stale headers: len inserts %v len(chunk) %v", len(inserts), len(chunk))
 						return errBadPeer
 					}
 				}
@@ -1693,7 +1696,7 @@ func (d *Downloader) commitFastSyncData(results []*fetchResult, stateSync *state
 	}
 	// Retrieve the a batch of results to import
 	first, last := results[0].Header, results[len(results)-1].Header
-	log.Debug("Inserting fast-sync blocks", "items", len(results),
+	log.Info("Inserting fast-sync blocks", "items", len(results),
 		"firstnum", first.Number, "firsthash", first.Hash(),
 		"lastnumn", last.Number, "lasthash", last.Hash(),
 	)

--- a/eth/downloader/downloader.go
+++ b/eth/downloader/downloader.go
@@ -367,7 +367,7 @@ func (d *Downloader) synchronise(id string, hash common.Hash, td *big.Int, mode 
 		d.stateBloom.Close()
 	}
 	// Reset the queue, peer set and wake channels to clean any internal leftover state
-	d.queue.Reset()
+	d.queue.Reset(blockCacheItems)
 	d.peers.Reset()
 
 	for _, ch := range []chan bool{d.bodyWakeCh, d.receiptWakeCh} {
@@ -1644,7 +1644,6 @@ func (d *Downloader) processFastSyncContent(latest *types.Header) error {
 			}
 		}
 		P, beforeP, afterP := splitAroundPivot(pivot, results)
-		results = nil
 		if err := d.commitFastSyncData(beforeP, sync); err != nil {
 			return err
 		}

--- a/eth/downloader/downloader.go
+++ b/eth/downloader/downloader.go
@@ -1191,7 +1191,7 @@ func (d *Downloader) fetchParts(deliveryCh chan dataPack, deliver func(dataPack)
 	idle func() ([]*peerConnection, int), setIdle func(*peerConnection, int, time.Time), kind string) error {
 
 	// Create a ticker to detect expired retrieval tasks
-	ticker := time.NewTicker(200 * time.Millisecond)
+	ticker := time.NewTicker(100 * time.Millisecond)
 	defer ticker.Stop()
 
 	update := make(chan struct{}, 1)
@@ -1328,7 +1328,7 @@ func (d *Downloader) fetchParts(deliveryCh chan dataPack, deliver func(dataPack)
 				}
 				if throttle {
 					throttled = true
-					throttleBlockCounter.Inc(1)
+					throttleCounter.Inc(1)
 				}
 				if request != nil {
 					if request.From > 0 {

--- a/eth/downloader/downloader_test.go
+++ b/eth/downloader/downloader_test.go
@@ -19,7 +19,6 @@ package downloader
 import (
 	"errors"
 	"fmt"
-	"github.com/ethereum/go-ethereum/log"
 	"math/big"
 	"strings"
 	"sync"
@@ -735,7 +734,6 @@ func testBoundedHeavyForkedSync(t *testing.T, protocol int, mode SyncMode) {
 	if err := tester.sync("heavy-rewriter", nil, mode); err != errInvalidAncestor {
 		t.Fatalf("sync failure mismatch: have %v, want %v", err, errInvalidAncestor)
 	}
-	fmt.Printf("terminating\n")
 	tester.terminate()
 }
 

--- a/eth/downloader/downloader_test.go
+++ b/eth/downloader/downloader_test.go
@@ -261,7 +261,7 @@ func (dl *downloadTester) InsertHeaderChain(headers []*types.Header, checkFreq i
 	defer dl.lock.Unlock()
 	// Do a quick check, as the blockchain.InsertHeaderChain doesn't insert anything in case of errors
 	if _, ok := dl.getHeader(headers[0].ParentHash); !ok {
-		return 0, errors.New("unknown parentx")
+		return 0, errors.New("unknown parent")
 	}
 	for i := 1; i < len(headers); i++ {
 		if headers[i].ParentHash != headers[i-1].Hash() {

--- a/eth/downloader/downloader_test.go
+++ b/eth/downloader/downloader_test.go
@@ -624,7 +624,6 @@ func testForkedSync(t *testing.T, protocol int, mode SyncMode) {
 	chainB := testChainForkLightB.shorten(testChainBase.len() + 80)
 	tester.newPeer("fork A", protocol, chainA)
 	tester.newPeer("fork B", protocol, chainB)
-
 	// Synchronise with the peer and make sure all blocks were retrieved
 	if err := tester.sync("fork A", nil, mode); err != nil {
 		t.Fatalf("failed to synchronise blocks: %v", err)
@@ -1002,7 +1001,6 @@ func testInvalidHeaderRollback(t *testing.T, protocol int, mode SyncMode) {
 	t.Parallel()
 
 	tester := newTester()
-	defer tester.terminate()
 
 	// Create a small enough block chain to download
 	targetBlocks := 3*fsHeaderSafetyNet + 256 + fsMinFullBlocks
@@ -1082,6 +1080,7 @@ func testInvalidHeaderRollback(t *testing.T, protocol int, mode SyncMode) {
 			t.Fatalf("synchronised blocks mismatch: have %v, want %v", bs, chain.len())
 		}
 	}
+	tester.terminate()
 }
 
 // Tests that a peer advertising an high TD doesn't get to stall the downloader
@@ -1097,13 +1096,13 @@ func testHighTDStarvationAttack(t *testing.T, protocol int, mode SyncMode) {
 	t.Parallel()
 
 	tester := newTester()
-	defer tester.terminate()
 
 	chain := testChainBase.shorten(1)
 	tester.newPeer("attack", protocol, chain)
 	if err := tester.sync("attack", big.NewInt(1000000), mode); err != errStallingPeer {
 		t.Fatalf("synchronisation error mismatch: have %v, want %v", err, errStallingPeer)
 	}
+	tester.terminate()
 }
 
 // Tests that misbehaving peers are disconnected, whilst behaving ones are not.

--- a/eth/downloader/metrics.go
+++ b/eth/downloader/metrics.go
@@ -40,4 +40,7 @@ var (
 
 	stateInMeter   = metrics.NewRegisteredMeter("eth/downloader/states/in", nil)
 	stateDropMeter = metrics.NewRegisteredMeter("eth/downloader/states/drop", nil)
+
+	throttleBlockCounter   = metrics.NewRegisteredCounter("eth/downloader/throttle/blocks", nil)
+	throttleReceiptCounter = metrics.NewRegisteredCounter("eth/downloader/throttle/receipts", nil)
 )

--- a/eth/downloader/metrics.go
+++ b/eth/downloader/metrics.go
@@ -41,6 +41,5 @@ var (
 	stateInMeter   = metrics.NewRegisteredMeter("eth/downloader/states/in", nil)
 	stateDropMeter = metrics.NewRegisteredMeter("eth/downloader/states/drop", nil)
 
-	throttleBlockCounter   = metrics.NewRegisteredCounter("eth/downloader/throttle/blocks", nil)
-	throttleReceiptCounter = metrics.NewRegisteredCounter("eth/downloader/throttle/receipts", nil)
+	throttleCounter = metrics.NewRegisteredCounter("eth/downloader/throttle", nil)
 )

--- a/eth/downloader/peer.go
+++ b/eth/downloader/peer.go
@@ -175,12 +175,14 @@ func (p *peerConnection) FetchBodies(request *fetchRequest) error {
 	}
 	p.blockStarted = time.Now()
 
-	// Convert the header set to a retrievable slice
-	hashes := make([]common.Hash, 0, len(request.Headers))
-	for _, header := range request.Headers {
-		hashes = append(hashes, header.Hash())
-	}
-	go p.peer.RequestBodies(hashes)
+	go func() {
+		// Convert the header set to a retrievable slice
+		hashes := make([]common.Hash, 0, len(request.Headers))
+		for _, header := range request.Headers {
+			hashes = append(hashes, header.Hash())
+		}
+		p.peer.RequestBodies(hashes)
+	}()
 
 	return nil
 }
@@ -197,12 +199,14 @@ func (p *peerConnection) FetchReceipts(request *fetchRequest) error {
 	}
 	p.receiptStarted = time.Now()
 
-	// Convert the header set to a retrievable slice
-	hashes := make([]common.Hash, 0, len(request.Headers))
-	for _, header := range request.Headers {
-		hashes = append(hashes, header.Hash())
-	}
-	go p.peer.RequestReceipts(hashes)
+	go func() {
+		// Convert the header set to a retrievable slice
+		hashes := make([]common.Hash, 0, len(request.Headers))
+		for _, header := range request.Headers {
+			hashes = append(hashes, header.Hash())
+		}
+		p.peer.RequestReceipts(hashes)
+	}()
 
 	return nil
 }

--- a/eth/downloader/peer.go
+++ b/eth/downloader/peer.go
@@ -267,7 +267,7 @@ func (p *peerConnection) setIdle(elapsed time.Duration, delivered int, throughpu
 		return
 	}
 	// Otherwise update the throughput with a new measurement
-	if elapsed <= 0{
+	if elapsed <= 0 {
 		elapsed = 1 // +1 (ns) to ensure non-zero divisor
 	}
 	measured := float64(delivered) / (float64(elapsed) / float64(time.Second))

--- a/eth/downloader/peer.go
+++ b/eth/downloader/peer.go
@@ -477,12 +477,6 @@ func (ps *peerSet) HeaderIdlePeers() ([]*peerConnection, int) {
 	return ps.idlePeers(62, 65, idle, throughput)
 }
 
-func fullyIdle(p *peerConnection) bool {
-	return atomic.LoadInt32(&p.blockIdle) == 0 &&
-		atomic.LoadInt32(&p.receiptIdle) == 0 &&
-		atomic.LoadInt32(&p.stateIdle) == 0
-}
-
 // BodyIdlePeers retrieves a flat list of all the currently body-idle peers within
 // the active peer set, ordered by their reputation.
 func (ps *peerSet) BodyIdlePeers() ([]*peerConnection, int) {

--- a/eth/downloader/peer.go
+++ b/eth/downloader/peer.go
@@ -115,15 +115,11 @@ func (w *lightPeerWrapper) RequestNodeData([]common.Hash) error {
 // newPeerConnection creates a new downloader peer.
 func newPeerConnection(id string, version int, peer Peer, logger log.Logger) *peerConnection {
 	return &peerConnection{
-		id:                id,
-		lacking:           make(map[common.Hash]struct{}),
-		peer:              peer,
-		version:           version,
-		log:               logger,
-		headerThroughput:  float64(MaxHeaderFetch / 8),
-		blockThroughput:   float64(MaxBlockFetch / 8),
-		receiptThroughput: float64(MaxReceiptFetch / 8),
-		stateThroughput:   float64(MaxStateFetch / 8),
+		id:      id,
+		lacking: make(map[common.Hash]struct{}),
+		peer:    peer,
+		version: version,
+		log:     logger,
 	}
 }
 
@@ -137,10 +133,10 @@ func (p *peerConnection) Reset() {
 	atomic.StoreInt32(&p.receiptIdle, 0)
 	atomic.StoreInt32(&p.stateIdle, 0)
 
-	p.headerThroughput = float64(MaxHeaderFetch / 8)
-	p.blockThroughput = float64(MaxBlockFetch / 8)
-	p.receiptThroughput = float64(MaxReceiptFetch / 8)
-	p.stateThroughput = float64(MaxStateFetch / 8)
+	p.headerThroughput = 0
+	p.blockThroughput = 0
+	p.receiptThroughput = 0
+	p.stateThroughput = 0
 
 	p.lacking = make(map[common.Hash]struct{})
 }

--- a/eth/downloader/peer_test.go
+++ b/eth/downloader/peer_test.go
@@ -1,0 +1,37 @@
+package downloader
+
+import (
+	"sort"
+	"testing"
+)
+
+func TestPeerThroughputSorting(t *testing.T){
+	a := &peerConnection{
+		id:"a",
+		headerThroughput:1.25,
+	}
+	b := &peerConnection{
+		id: "b",
+		headerThroughput:1.21,
+	}
+	c := &peerConnection{
+		id: "c",
+		headerThroughput:1.23,
+	}
+
+	peers := []*peerConnection{a,b,c}
+	tps := []float64{a.headerThroughput,
+	b.headerThroughput, c.headerThroughput}
+	sortPeers := &peerThroughputSort{peers, tps}
+	sort.Sort(sortPeers)
+	if got, exp := sortPeers.p[0].id , "a"; got != exp{
+		t.Errorf("sort fail, got %v exp %v", got, exp)
+	}
+	if got, exp := sortPeers.p[1].id , "c"; got != exp{
+		t.Errorf("sort fail, got %v exp %v", got, exp)
+	}
+	if got, exp := sortPeers.p[2].id , "b"; got != exp{
+		t.Errorf("sort fail, got %v exp %v", got, exp)
+	}
+
+}

--- a/eth/downloader/peer_test.go
+++ b/eth/downloader/peer_test.go
@@ -5,32 +5,32 @@ import (
 	"testing"
 )
 
-func TestPeerThroughputSorting(t *testing.T){
+func TestPeerThroughputSorting(t *testing.T) {
 	a := &peerConnection{
-		id:"a",
-		headerThroughput:1.25,
+		id:               "a",
+		headerThroughput: 1.25,
 	}
 	b := &peerConnection{
-		id: "b",
-		headerThroughput:1.21,
+		id:               "b",
+		headerThroughput: 1.21,
 	}
 	c := &peerConnection{
-		id: "c",
-		headerThroughput:1.23,
+		id:               "c",
+		headerThroughput: 1.23,
 	}
 
-	peers := []*peerConnection{a,b,c}
+	peers := []*peerConnection{a, b, c}
 	tps := []float64{a.headerThroughput,
-	b.headerThroughput, c.headerThroughput}
+		b.headerThroughput, c.headerThroughput}
 	sortPeers := &peerThroughputSort{peers, tps}
 	sort.Sort(sortPeers)
-	if got, exp := sortPeers.p[0].id , "a"; got != exp{
+	if got, exp := sortPeers.p[0].id, "a"; got != exp {
 		t.Errorf("sort fail, got %v exp %v", got, exp)
 	}
-	if got, exp := sortPeers.p[1].id , "c"; got != exp{
+	if got, exp := sortPeers.p[1].id, "c"; got != exp {
 		t.Errorf("sort fail, got %v exp %v", got, exp)
 	}
-	if got, exp := sortPeers.p[2].id , "b"; got != exp{
+	if got, exp := sortPeers.p[2].id, "b"; got != exp {
 		t.Errorf("sort fail, got %v exp %v", got, exp)
 	}
 

--- a/eth/downloader/peer_test.go
+++ b/eth/downloader/peer_test.go
@@ -1,3 +1,19 @@
+// Copyright 2020 The go-ethereum Authors
+// This file is part of go-ethereum.
+//
+// go-ethereum is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// go-ethereum is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with go-ethereum. If not, see <http://www.gnu.org/licenses/>.
+
 package downloader
 
 import (

--- a/eth/downloader/queue.go
+++ b/eth/downloader/queue.go
@@ -509,10 +509,6 @@ func (q *queue) reserveHeaders(p *peerConnection, count int, taskPool map[common
 		if throttle {
 			// There are no resultslots available. Put it back in the task queue
 			taskQueue.Push(header, -int64(header.Number.Uint64()))
-			// Set progress to true -- otherwise the peer will get
-			// penalized for not 'accepting' requests, while in fact it's
-			// because we don't have room for more results right now
-			progress = true
 			// However, if there are any left as 'skipped', we should not tell
 			// the caller to throttle, since we still want some other
 			// peer to fetch those for us

--- a/eth/downloader/queue.go
+++ b/eth/downloader/queue.go
@@ -316,14 +316,14 @@ func (q *queue) Schedule(headers []*types.Header, from uint64) []*types.Header {
 			log.Warn("Header broke chain ancestry", "number", header.Number, "hash", hash)
 			break
 		}
-		if !header.EmptyBody() {
-			// Make sure no duplicate requests are executed
-			if _, ok := q.blockTaskPool[hash]; ok {
-				log.Warn("Header already scheduled for block fetch", "number", header.Number, "hash", hash)
-			} else {
-				q.blockTaskPool[hash] = header
-				q.blockTaskQueue.Push(header, -int64(header.Number.Uint64()))
-			}
+		// Make sure no duplicate requests are executed
+		// We cannot skip this, even if the block is empty, since this is
+		// what triggers the fetchResult creation.
+		if _, ok := q.blockTaskPool[hash]; ok {
+			log.Warn("Header already scheduled for block fetch", "number", header.Number, "hash", hash)
+		} else {
+			q.blockTaskPool[hash] = header
+			q.blockTaskQueue.Push(header, -int64(header.Number.Uint64()))
 		}
 		// Queue for receipt retrieval
 		if q.mode == FastSync && !header.EmptyReceipts() {

--- a/eth/downloader/queue.go
+++ b/eth/downloader/queue.go
@@ -847,7 +847,6 @@ func (q *queue) deliver(id string, taskPool map[common.Hash]*types.Header,
 		i++
 	}
 
-	q.lock.Lock()
 	var acceptCount = 0
 	for _, header := range request.Headers[:i] {
 		if res, stale, err := q.resultCache.GetDeliverySlot(header.Number.Uint64()); err == nil {
@@ -871,7 +870,6 @@ func (q *queue) deliver(id string, taskPool map[common.Hash]*types.Header,
 	if acceptCount > 0 {
 		q.active.Signal()
 	}
-	q.lock.Unlock()
 	// If none of the data was good, it's a stale delivery
 	switch {
 	case failure == nil || failure == errInvalidChain:

--- a/eth/downloader/queue.go
+++ b/eth/downloader/queue.go
@@ -860,7 +860,7 @@ func (q *queue) deliver(id string, taskPool map[common.Hash]*types.Header,
 	q.lock.Lock()
 	var acceptCount = 0
 	for _, header := range request.Headers[:i] {
-		if res, stale, err := q.resultCache.GetFetchResult(header); err == nil {
+		if res, stale, err := q.resultCache.GetDeliverySlot(header); err == nil {
 			reconstruct(acceptCount, res)
 		} else {
 			// else: betweeen here and above, some other peer filled this result,

--- a/eth/downloader/queue_test.go
+++ b/eth/downloader/queue_test.go
@@ -242,11 +242,11 @@ func TestEmptyBlocks(t *testing.T) {
 
 }
 
-// xTestDelivery does some more extensive testing of events that happen,
+// XTestDelivery does some more extensive testing of events that happen,
 // blocks that become known and peers that make reservations and deliveries.
 // disabled since it's not really a unit-test, but can be executed to test
 // some more advanced scenarios
-func xTestDelivery(t *testing.T) {
+func XTestDelivery(t *testing.T) {
 	// the outside network, holding blocks
 	blo, rec := makeChain(128, 0, genesis, false)
 	world := newNetwork()

--- a/eth/downloader/queue_test.go
+++ b/eth/downloader/queue_test.go
@@ -1,0 +1,439 @@
+// Copyright 2019 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+package downloader
+
+import (
+	"fmt"
+	"math/big"
+	"math/rand"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/consensus/ethash"
+	"github.com/ethereum/go-ethereum/core"
+	"github.com/ethereum/go-ethereum/core/rawdb"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/log"
+	"github.com/ethereum/go-ethereum/params"
+)
+
+var (
+	testdb  = rawdb.NewMemoryDatabase()
+	genesis = core.GenesisBlockForTesting(testdb, testAddress, big.NewInt(1000000000))
+)
+
+// makeChain creates a chain of n blocks starting at and including parent.
+// the returned hash chain is ordered head->parent. In addition, every 3rd block
+// contains a transaction and every 5th an uncle to allow testing correct block
+// reassembly.
+func makeChain(n int, seed byte, parent *types.Block, empty bool) ([]*types.Block, []types.Receipts) {
+	blocks, receipts := core.GenerateChain(params.TestChainConfig, parent, ethash.NewFaker(), testdb, n, func(i int, block *core.BlockGen) {
+		block.SetCoinbase(common.Address{seed})
+		// Add one tx to every secondblock
+		if !empty && i%2 == 0 {
+			signer := types.MakeSigner(params.TestChainConfig, block.Number())
+			tx, err := types.SignTx(types.NewTransaction(block.TxNonce(testAddress), common.Address{seed}, big.NewInt(1000), params.TxGas, nil, nil), signer, testKey)
+			if err != nil {
+				panic(err)
+			}
+			block.AddTx(tx)
+		}
+	})
+	return blocks, receipts
+}
+
+type chainData struct {
+	blocks []*types.Block
+	offset int
+}
+
+var chain *chainData
+var emptyChain *chainData
+
+func init() {
+	// Create a chain of blocks to import
+	targetBlocks := 128
+	blocks, _ := makeChain(targetBlocks, 0, genesis, false)
+	chain = &chainData{blocks, 0}
+
+	blocks, _ = makeChain(targetBlocks, 0, genesis, true)
+	emptyChain = &chainData{blocks, 0}
+}
+func (chain *chainData) headers() []*types.Header {
+	hdrs := make([]*types.Header, len(chain.blocks))
+	for i, b := range chain.blocks {
+		hdrs[i] = b.Header()
+	}
+	return hdrs
+}
+func (chain *chainData) Len() int {
+	return len(chain.blocks)
+}
+
+func dummyPeer(id string) *peerConnection {
+	p := &peerConnection{
+		id:      id,
+		lacking: make(map[common.Hash]struct{}),
+	}
+	return p
+}
+
+func TestBasics(t *testing.T) {
+
+	q := newQueue(10)
+	if !q.Idle() {
+		t.Errorf("new queue should be idle")
+	}
+	q.Prepare(1, FastSync)
+	if res := q.Results(false); len(res) != 0 {
+		t.Fatal("new queue should have 0 results")
+	}
+
+	// Schedule a batch of headers
+	q.Schedule(chain.headers(), 1)
+	if q.Idle() {
+		t.Errorf("queue should not be idle")
+	}
+	if got, exp := q.PendingBlocks(), chain.Len(); got != exp {
+		t.Errorf("wrong pending block count, got %d, exp %d", got, exp)
+	}
+	// Only non-empty receipts get added to task-queue
+	if got, exp := q.PendingReceipts(), 64; got != exp {
+		t.Errorf("wrong pending receipt count, got %d, exp %d", got, exp)
+	}
+	// Items are now queued for downloading, next step is that we tell the
+	// queue that a certain peer will deliver them for us
+	{
+		peer := dummyPeer("peer-1")
+		fetchReq, _, throttle, err := q.ReserveBodies(peer, 50)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !throttle {
+			// queue size is only 10, so throttling should occur
+			t.Fatal("should throttle")
+		}
+		// But we should still get the first things to fetch
+		if got, exp := len(fetchReq.Headers), 8; got != exp {
+			t.Fatalf("expected %d requests, got %d", exp, got)
+		}
+		if got, exp := fetchReq.Headers[0].Number.Uint64(), uint64(1); got != exp {
+			t.Fatalf("expected header %d, got %d", exp, got)
+		}
+	}
+	{
+		peer := dummyPeer("peer-2")
+		fetchReq, _, throttle, err := q.ReserveBodies(peer, 50)
+		if err != nil {
+			t.Fatal(err)
+		}
+		// The second peer should hit throttling
+		if !throttle {
+			t.Fatalf("should not throttle")
+		}
+		// And not get any fetches at all, since it was throttled to begin with
+		if fetchReq != nil {
+			t.Fatalf("should have no fetches, got %d", len(fetchReq.Headers))
+		}
+	}
+	//fmt.Printf("blockTaskQueue len: %d\n", q.blockTaskQueue.Size())
+	//fmt.Printf("receiptTaskQueue len: %d\n", q.receiptTaskQueue.Size())
+	{
+		// The receipt delivering peer should not be affected
+		// by the throttling of body deliveries
+		peer := dummyPeer("peer-3")
+		fetchReq, _, throttle, err := q.ReserveReceipts(peer, 50)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !throttle {
+			// queue size is only 10, so throttling should occur
+			t.Fatal("should throttle")
+		}
+		// But we should still get the first things to fetch
+		if got, exp := len(fetchReq.Headers), 8; got != exp {
+			t.Fatalf("expected %d requests, got %d", exp, got)
+		}
+		if got, exp := fetchReq.Headers[0].Number.Uint64(), uint64(1); got != exp {
+			t.Fatalf("expected header %d, got %d", exp, got)
+		}
+
+	}
+	//fmt.Printf("blockTaskQueue len: %d\n", q.blockTaskQueue.Size())
+	//fmt.Printf("receiptTaskQueue len: %d\n", q.receiptTaskQueue.Size())
+	//fmt.Printf("processable: %d\n", q.resultCache.countCompleted())
+}
+
+func TestEmptyBlocks(t *testing.T) {
+
+	q := newQueue(10)
+
+	q.Prepare(1, FastSync)
+	// Schedule a batch of headers
+	q.Schedule(emptyChain.headers(), 1)
+	if q.Idle() {
+		t.Errorf("queue should not be idle")
+	}
+	if got, exp := q.PendingBlocks(), len(emptyChain.blocks); got != exp {
+		t.Errorf("wrong pending block count, got %d, exp %d", got, exp)
+	}
+	if got, exp := q.PendingReceipts(), 0; got != exp {
+		t.Errorf("wrong pending receipt count, got %d, exp %d", got, exp)
+	}
+	// They won't be processable, because the fetchresults haven't been
+	// created yet
+	if got, exp := q.resultCache.countCompleted(), 0; got != exp {
+		t.Errorf("wrong processable count, got %d, exp %d", got, exp)
+	}
+
+	// Items are now queued for downloading, next step is that we tell the
+	// queue that a certain peer will deliver them for us
+	// That should trigger all of them to suddenly become 'done'
+	{
+		// Reserve blocks
+		peer := dummyPeer("peer-1")
+		fetchReq, _, _, err := q.ReserveBodies(peer, 50)
+		if err != nil {
+			t.Fatal(err)
+		}
+		// there should be nothing to fetch, blocks are empty
+		if fetchReq != nil {
+			t.Fatal("there should be no body fetch tasks remaining")
+		}
+
+	}
+	if q.blockTaskQueue.Size() != len(emptyChain.blocks)-(10*2*3/4) {
+		t.Errorf("expected block task queue to be 0, got %d", q.blockTaskQueue.Size())
+	}
+	if q.receiptTaskQueue.Size() != 0 {
+		t.Errorf("expected receipt task queue to be 0, got %d", q.receiptTaskQueue.Size())
+	}
+	//fmt.Printf("receiptTaskQueue len: %d\n", q.receiptTaskQueue.Size())
+	{
+		peer := dummyPeer("peer-3")
+		fetchReq, _, _, err := q.ReserveReceipts(peer, 50)
+		if err != nil {
+			t.Fatal(err)
+		}
+		// there should be nothing to fetch, blocks are empty
+		if fetchReq != nil {
+			t.Fatal("there should be no body fetch tasks remaining")
+		}
+	}
+	if got, exp := q.resultCache.countCompleted(), (10 * 2 * 3 / 4); got != exp {
+		t.Errorf("wrong processable count, got %d, exp %d", got, exp)
+	}
+
+}
+
+// xTestDelivery does some more extensive testing of events that happen,
+// blocks that become known and peers that make reservations and deliveries.
+// disabled since it's not really a unit-test, but can be executed to test
+// some more advanced scenarios
+func xTestDelivery(t *testing.T) {
+	// the outside network, holding blocks
+	blo, rec := makeChain(128, 0, genesis, false)
+	world := newNetwork()
+	world.receipts = rec
+	world.chain = blo
+	world.progress(10)
+	if false {
+		log.Root().SetHandler(log.StdoutHandler)
+
+	}
+	q := newQueue(10)
+	var wg sync.WaitGroup
+	q.Prepare(1, FastSync)
+	wg.Add(1)
+	go func() {
+		// deliver headers
+		defer wg.Done()
+		c := 1
+		for {
+			//fmt.Printf("getting headers from %d\n", c)
+			hdrs := world.headers(c)
+			l := len(hdrs)
+			//fmt.Printf("scheduling %d headers, first %d last %d\n",
+			//	l, hdrs[0].Number.Uint64(), hdrs[len(hdrs)-1].Number.Uint64())
+			q.Schedule(hdrs, uint64(c))
+			c += l
+		}
+	}()
+	wg.Add(1)
+	go func() {
+		// collect results
+		defer wg.Done()
+		tot := 0
+		for {
+			res := q.Results(true)
+			tot += len(res)
+			fmt.Printf("got %d results, %d tot\n", len(res), tot)
+			// Now we can forget about these
+			world.forget(res[len(res)-1].Header.Number.Uint64())
+
+		}
+	}()
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		// reserve body fetch
+		i := 4
+		for {
+			peer := dummyPeer(fmt.Sprintf("peer-%d", i))
+			f, _, _, _ := q.ReserveBodies(peer, rand.Intn(30))
+			if f != nil {
+				var emptyList []*types.Header
+				var txs [][]*types.Transaction
+				var uncles [][]*types.Header
+				numToSkip := rand.Intn(len(f.Headers))
+				for _, hdr := range f.Headers[0 : len(f.Headers)-numToSkip] {
+					txs = append(txs, world.getTransactions(hdr.Number.Uint64()))
+					uncles = append(uncles, emptyList)
+				}
+				time.Sleep(100 * time.Millisecond)
+				_, err := q.DeliverBodies(peer.id, txs, uncles)
+				if err != nil {
+					fmt.Printf("delivered %d bodies %v\n", len(txs), err)
+				}
+			} else {
+				i++
+				time.Sleep(200 * time.Millisecond)
+			}
+		}
+	}()
+	go func() {
+		defer wg.Done()
+		// reserve receiptfetch
+		peer := dummyPeer("peer-3")
+		for {
+			f, _, _, _ := q.ReserveReceipts(peer, rand.Intn(50))
+			if f != nil {
+				var rcs [][]*types.Receipt
+				for _, hdr := range f.Headers {
+					rcs = append(rcs, world.getReceipts(hdr.Number.Uint64()))
+				}
+				_, err := q.DeliverReceipts(peer.id, rcs)
+				if err != nil {
+					fmt.Printf("delivered %d receipts %v\n", len(rcs), err)
+				}
+				time.Sleep(100 * time.Millisecond)
+			} else {
+				time.Sleep(200 * time.Millisecond)
+			}
+		}
+	}()
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < 50; i++ {
+			time.Sleep(300 * time.Millisecond)
+			//world.tick()
+			//fmt.Printf("trying to progress\n")
+			world.progress(rand.Intn(100))
+		}
+		for i := 0; i < 50; i++ {
+			time.Sleep(2990 * time.Millisecond)
+
+		}
+	}()
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for {
+			time.Sleep(990 * time.Millisecond)
+			fmt.Printf("world block tip is %d\n",
+				world.chain[len(world.chain)-1].Header().Number.Uint64())
+			fmt.Println(q.Stats())
+		}
+	}()
+	wg.Wait()
+}
+
+func newNetwork() *network {
+	var l sync.RWMutex
+	return &network{
+		cond:   sync.NewCond(&l),
+		offset: 1, // block 1 is at blocks[0]
+	}
+}
+
+// represents the network
+type network struct {
+	offset   int
+	chain    []*types.Block
+	receipts []types.Receipts
+	lock     sync.RWMutex
+	cond     *sync.Cond
+}
+
+func (n *network) getTransactions(blocknum uint64) types.Transactions {
+	index := blocknum - uint64(n.offset)
+	return n.chain[index].Transactions()
+}
+func (n *network) getReceipts(blocknum uint64) types.Receipts {
+	index := blocknum - uint64(n.offset)
+	if got := n.chain[index].Header().Number.Uint64(); got != blocknum {
+		fmt.Printf("Err, got %d exp %d\n", got, blocknum)
+		panic("sd")
+	}
+	return n.receipts[index]
+}
+
+func (n *network) forget(blocknum uint64) {
+	index := blocknum - uint64(n.offset)
+	n.chain = n.chain[index:]
+	n.receipts = n.receipts[index:]
+	n.offset = int(blocknum)
+
+}
+func (n *network) progress(numBlocks int) {
+
+	n.lock.Lock()
+	defer n.lock.Unlock()
+	//fmt.Printf("progressing...\n")
+	newBlocks, newR := makeChain(numBlocks, 0, n.chain[len(n.chain)-1], false)
+	n.chain = append(n.chain, newBlocks...)
+	n.receipts = append(n.receipts, newR...)
+	n.cond.Broadcast()
+
+}
+
+func (n *network) headers(from int) []*types.Header {
+	numHeaders := 128
+	var hdrs []*types.Header
+	index := from - n.offset
+
+	for index >= len(n.chain) {
+		// wait for progress
+		n.cond.L.Lock()
+		//fmt.Printf("header going into wait\n")
+		n.cond.Wait()
+		index = from - n.offset
+		n.cond.L.Unlock()
+	}
+	n.lock.RLock()
+	defer n.lock.RUnlock()
+	for i, b := range n.chain[index:] {
+		hdrs = append(hdrs, b.Header())
+		if i >= numHeaders {
+			break
+		}
+	}
+	return hdrs
+}

--- a/eth/downloader/resultcache.go
+++ b/eth/downloader/resultcache.go
@@ -1,0 +1,258 @@
+// Copyright 2019 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+// resultcache implements a structure for maintaining fetchResults, tracking their
+// download-progress and delivering (finished) results
+
+package downloader
+
+import (
+	"fmt"
+	"github.com/ethereum/go-ethereum/log"
+	"sync"
+	"sync/atomic"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+)
+
+type resultStore struct {
+	items        []*fetchResult     // Downloaded but not yet delivered fetch results
+	lock         *sync.RWMutex      // lock protect internals
+	resultOffset uint64             // Offset of the first cached fetch result in the block chain
+	resultSize   common.StorageSize // Approximate size of a block (exponential moving average)
+
+	// Internal index of first non-completed entry, updated atomically when needed.
+	// If all items are complete, this will equal length(items), so
+	// *important* : is not safe to use for indexing without checking against length
+	indexIncomplete int32
+}
+
+func newResultStore(size int) *resultStore {
+	return &resultStore{
+		resultOffset: 0,
+		items:        make([]*fetchResult, size),
+		resultSize:   0, // TODO: use a saner default, left at zero as it was legacy
+		lock:         new(sync.RWMutex),
+	}
+}
+
+// AddFetch adds a header for body/receipt fetching.
+// returning
+// stale -- if true, this item is already passed, and should not be requested again
+// fetchResult -- if `nil`, that means no fetch was created, and that the
+// if an error is returned, that most likely means backpressure prevents the results from expanding,
+// and someone needs to take care of results
+func (r *resultStore) AddFetch(header *types.Header, fastSync bool) (stale bool, item *fetchResult, err error) {
+	hash := header.Hash()
+	r.lock.RLock()
+	item, _, stale, err = r.getFetchResult(header)
+	if err != nil {
+		r.lock.RUnlock()
+		log.Info("resultcache addfetch err [1]", "error", err.Error())
+		// can't create a fetchResult right away
+		return stale, nil, err
+	}
+	if item != nil {
+		r.lock.RUnlock()
+		return false, item, nil
+	}
+	r.lock.RUnlock()
+	// Need to create a fetchresult, and as we've just release the Rlock,
+	// we need to check again after obtaining the writelock
+	r.lock.Lock()
+	defer r.lock.Unlock()
+	var index int
+	item, index, stale, err = r.getFetchResult(header)
+	if err != nil {
+		// can't create a fetchResult right away
+		log.Info("resultcache addfetch err [2]", "error", err.Error())
+		return stale, nil, err
+
+	}
+	if item == nil {
+		item = &fetchResult{
+			Hash:   hash,
+			Header: header,
+		}
+		// Need to fetch body?
+		if !header.EmptyBody() {
+			// yes
+			item.Pending |= 0x1
+		}
+		// Do we need to fetch receipts?
+		if fastSync && !header.EmptyReceipts() {
+			item.Pending |= 0x2
+		}
+		r.items[index] = item
+	}
+	return false, item, nil
+
+}
+
+func (r *resultStore) GetFetchResult(header *types.Header) (*fetchResult, bool, error) {
+	r.lock.RLock()
+	defer r.lock.RUnlock()
+	res, _, stale, err := r.getFetchResult(header)
+	return res, stale, err
+}
+
+// getFetchResult returns the fetchResult corresponding to the given item, and the index where
+// the result is stored.
+// There are two ways it can error:
+// 1. The header is too far off in the future, and we don't have room for it.
+// 2. The header is stale, and the results for that header has already been delivered upstream.
+func (r *resultStore) getFetchResult(header *types.Header) (item *fetchResult, index int, stale bool, err error) {
+	index = int(header.Number.Int64() - int64(r.resultOffset))
+	if index >= len(r.items) {
+		err = fmt.Errorf("index allocation went beyond available resultStore space "+
+			"(index [%d] = header [%d] - resultOffset [%d], len(resultStore) = %d",
+			index, header.Number.Int64(), r.resultOffset, len(r.items))
+		return item, index, stale, err
+	}
+	if index < 0 {
+		stale = true
+		err = fmt.Errorf("index allocation went beyond available resultStore space "+
+			"(index [%d] = header [%d] - resultOffset [%d], len(resultStore) = %d",
+			index, header.Number.Int64(), r.resultOffset, len(r.items))
+		return item, index, stale, err
+	}
+	item = r.items[index]
+	return item, index, stale, err
+}
+
+// numberSpan returns the header number start and end, for the headers
+// currently "allocated" for download (both completed, in-flight and pending)
+func (r *resultStore) NumberSpan() (uint64, uint64) {
+	r.lock.RLock()
+	defer r.lock.RUnlock()
+	return r.resultOffset, r.resultOffset + uint64(len(r.items))
+
+}
+
+// hasCompletedItems returns true if there are processable items available
+// this method is cheaper than countCompleted
+func (r *resultStore) HasCompletedItems() bool {
+	r.lock.RLock()
+	defer r.lock.RUnlock()
+	if len(r.items) == 0 {
+		return false
+	}
+	if item := r.items[0]; item != nil && item.Pending == 0 {
+		return true
+	}
+	return false
+}
+
+// CountCompleted returns the number of items completed
+func (r *resultStore) CountCompleted() int {
+	r.lock.RLock()
+	defer r.lock.RUnlock()
+	return r.countCompleted()
+}
+
+// countCompleted returns the number of items completed
+// assumes (at least) rlock is held
+func (r *resultStore) countCompleted() int {
+	// We iterate from the already known complete point, and see
+	// if any more has completed since last count
+	// debug
+	/*
+		var (
+			nils         = 0
+			fins         = 0
+			bodyneeds    = 0
+			receiptneeds = 0
+		)
+		var ctx []interface{}
+		for _, item := range r.items {
+			if item == nil {
+				nils++
+			} else {
+				if item.Pending == 0 {
+					fins++
+				} else {
+					if item.Pending&0x01 != 0 {
+						bodyneeds++
+					} else {
+						receiptneeds++
+					}
+				}
+			}
+		}
+		ctx = append(ctx, "items", len(r.items), "nils", nil, "fins", fins,
+			"needB", bodyneeds, "needR", receiptneeds)
+	*/
+	/// end debug
+	index := atomic.LoadInt32(&r.indexIncomplete)
+	for ; ; index++ {
+		if index >= int32(len(r.items)) {
+			break
+		}
+		result := r.items[index]
+		if result == nil || result.Pending > 0 {
+			break
+		}
+	}
+	/*
+		if index < int32(len(r.items)) {
+			//ctx = append(ctx, []interface{}{"index", index, "blocknum", uint64(index) + r.resultOffset}...)
+			if r.items[index] != nil {
+				log.Info("resultstore", ctx...)
+			} else {
+				ctx = append(ctx, []interface{}{"first missing", "nil"}...)
+				log.Info("resultstore", ctx...)
+			}
+		} else {
+			ctx = append(ctx, []interface{}{"first missing", "out of range"}...)
+			log.Info("resultstore", ctx...)
+		}
+	*/
+	atomic.StoreInt32(&r.indexIncomplete, index)
+	return int(index)
+}
+
+// getCompleted returns the next batch of completed fetchresults
+func (r *resultStore) GetCompleted(limit int) []*fetchResult {
+	r.lock.Lock()
+	defer r.lock.Unlock()
+
+	completed := r.countCompleted()
+	if limit > completed {
+		limit = completed
+	}
+	results := make([]*fetchResult, limit)
+	copy(results, r.items[:limit])
+
+	// Delete the results from the cache and clear the tail.
+	copy(r.items, r.items[limit:])
+	for i := len(r.items) - limit; i < len(r.items); i++ {
+		r.items[i] = nil
+	}
+	// Advance the expected block number of the first cache entry.
+	r.resultOffset += uint64(limit)
+	// And subtract the number of items from our two indexes
+	atomic.StoreInt32(&r.indexIncomplete, int32(completed-limit))
+	return results
+}
+
+func (r *resultStore) Prepare(offset uint64) {
+	r.lock.Lock()
+	if r.resultOffset < offset {
+		r.resultOffset = offset
+	}
+	r.lock.Unlock()
+}

--- a/eth/fetcher/block_fetcher.go
+++ b/eth/fetcher/block_fetcher.go
@@ -538,40 +538,51 @@ func (f *BlockFetcher) loop() {
 				return
 			}
 			bodyFilterInMeter.Mark(int64(len(task.transactions)))
-
 			blocks := []*types.Block{}
-			for i := 0; i < len(task.transactions) && i < len(task.uncles); i++ {
-				// Match up a body to any possible completion request
-				matched := false
-
-				for hash, announce := range f.completing {
-					if f.queued[hash] == nil {
-						txnHash := types.DeriveSha(types.Transactions(task.transactions[i]))
-						uncleHash := types.CalcUncleHash(task.uncles[i])
-
-						if txnHash == announce.header.TxHash && uncleHash == announce.header.UncleHash && announce.origin == task.peer {
-							// Mark the body matched, reassemble if still unknown
-							matched = true
-
-							if f.getBlock(hash) == nil {
-								block := types.NewBlockWithHeader(announce.header).WithBody(task.transactions[i], task.uncles[i])
-								block.ReceivedAt = task.time
-
-								blocks = append(blocks, block)
-							} else {
-								f.forgetHash(hash)
-							}
+			// abort early if there's nothing explicitly requested
+			if len(f.completing) > 0 {
+				for i := 0; i < len(task.transactions) && i < len(task.uncles); i++ {
+					// Match up a body to any possible completion request
+					var (
+						matched   = false
+						uncleHash common.Hash // calculated lazily and reused
+						txnHash   common.Hash // calculated lazily and reused
+					)
+					for hash, announce := range f.completing {
+						if f.queued[hash] != nil || announce.origin != task.peer {
+							continue
 						}
+						if uncleHash == (common.Hash{}) {
+							uncleHash = types.CalcUncleHash(task.uncles[i])
+						}
+						if uncleHash != announce.header.UncleHash {
+							continue
+						}
+						if txnHash == (common.Hash{}) {
+							txnHash = types.DeriveSha(types.Transactions(task.transactions[i]))
+						}
+						if txnHash != announce.header.TxHash {
+							continue
+						}
+						// Mark the body matched, reassemble if still unknown
+						matched = true
+						if f.getBlock(hash) == nil {
+							block := types.NewBlockWithHeader(announce.header).WithBody(task.transactions[i], task.uncles[i])
+							block.ReceivedAt = task.time
+							blocks = append(blocks, block)
+						} else {
+							f.forgetHash(hash)
+						}
+
+					}
+					if matched {
+						task.transactions = append(task.transactions[:i], task.transactions[i+1:]...)
+						task.uncles = append(task.uncles[:i], task.uncles[i+1:]...)
+						i--
+						continue
 					}
 				}
-				if matched {
-					task.transactions = append(task.transactions[:i], task.transactions[i+1:]...)
-					task.uncles = append(task.uncles[:i], task.uncles[i+1:]...)
-					i--
-					continue
-				}
 			}
-
 			bodyFilterOutMeter.Mark(int64(len(task.transactions)))
 			select {
 			case filter <- task:


### PR DESCRIPTION
This PR contains a massive refactoring in the downloader + queue area. It's not quite ready to be merged yet, I'd like to see how the tests perform. 

Todo: add some more unit-tests regarding the resultstore implementation, and the queue. 

## Throttling

Previously, we had a `doneQueue` which was a map where we kept track of all downloaded items (receipts, block bodies). This map was updated when deliveries came in, and cleaned when results were pulled from the `resultCache`. It was quite finicky, and modifications to how the download functioned was dangerous: if these were not kept in check, it was possible that the `doneQueue` would blow up. 

It was also quite resource intensive, where a lot of counting and cross-checking was going on between the various pools and queues. 

This has now been reworked, so that 

- the `resultCache` maintains (like previously) a slice of `*fetchResult`s, with a length of `blockCacheLimit * 2`. 
- the `resultCache` also knows that it should only consider the first `75%` of available slots to be up for filling. Thus, when a `reserve` request comes in (we want do give a task to a peer), the resultCache checks if the proposed download-task is in that priority segment. Otherwise, it flags for throttling. 
- Once the results are fetched for processing, and removed from the internal slice, the priority segment moves organically, and new data become eligible for fetching. 
 
This means I could drop all `donePool` thingies, which simplified things a bit. 

## Concurrency

Previously, the queue maintained one lock to rule them all. Now, the resultCache has it's own lock, and can handle concurrency internally. This means that body and receipt fetch/delivery can happen simultaneously, and also that verification (sha:ing) of the bodies/receipts doesn't block other threads waiting for the lock. 

Previously, I think it was kind of racy when setting the `Pending` on the `fetchResult`. This has been fixed. 

## Tests

The downloader tests failed quite often; when receipts are added in the backend, the headers (`ownHeaders`) were deleted and moved into `ancientHeaders`. If this happened quickly enough, the next batch of headers errored with `unknown parent`. This has been fixed so the backend also queries `ancientHeaders` for header existence. 

## Minor changes

- Set the incoming response time earlier in the flow, so it doesn't have to wait for obtaining locks before setting it. Should make the `rtt` measurements a bit more closer to the thuth. 
- the idle check used some bubble sort algo, replaced
- the fetcher did a lot of useless work, iterating in the block filter (every block) and calculating hashes over and over again. This was simplified