### PR TITLE
internal/ethapi: don't query wallets at every execution of gas estimation

### DIFF
--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -906,6 +906,18 @@ func DoEstimateGas(ctx context.Context, b Backend, args CallArgs, blockNrOrHash 
 	}
 	cap = hi
 
+	// Set sender address or use a default if none specified
+	if args.From == nil {
+		if wallets := b.AccountManager().Wallets(); len(wallets) > 0 {
+			if accounts := wallets[0].Accounts(); len(accounts) > 0 {
+				args.From = &accounts[0].Address
+			}
+		}
+	}
+	// Use zero-address if none other is available
+	if args.From == nil {
+		args.From = &common.Address{}
+	}
 	// Create a helper to check if a gas allowance results in an executable transaction
 	executable := func(gas uint64) bool {
 		args.Gas = (*hexutil.Uint64)(&gas)


### PR DESCRIPTION
A user ( @sarvesh-ost ) reported that doing `estimateGas` with clef as a backend caused it to prompt for approval 26 times. 
This PR changes the gas estimator so it resolves the address to use only once, not once for each execution. 

@sarvesh-ost  , could you please check if this solves the issue? 