### PR TITLE
miner: increase worker test timeout

### DIFF
--- a/miner/worker_test.go
+++ b/miner/worker_test.go
@@ -357,7 +357,7 @@ func testEmptyWork(t *testing.T, chainConfig *params.ChainConfig, engine consens
 	for i := 0; i < 2; i += 1 {
 		select {
 		case <-taskCh:
-		case <-time.NewTimer(4 * time.Second).C:
+		case <-time.NewTimer(30 * time.Second).C:
 			t.Error("new task timeout")
 		}
 	}


### PR DESCRIPTION
`worker_test` tends to fail because on a timeout on travis. This PR increases that timeout.