### PR TITLE
eth: set networkID to chainID by default

### DIFF
--- a/eth/config.go
+++ b/eth/config.go
@@ -43,7 +43,7 @@ var DefaultConfig = Config{
 		DatasetsInMem:  1,
 		DatasetsOnDisk: 2,
 	},
-	NetworkId:          1,
+	NetworkId:          0,
 	LightPeers:         100,
 	UltraLightFraction: 75,
 	DatabaseCache:      512,
@@ -91,8 +91,10 @@ type Config struct {
 	// If nil, the Ethereum main net block is used.
 	Genesis *core.Genesis `toml:",omitempty"`
 
-	// Protocol options
-	NetworkId uint64 // Network ID to use for selecting peers to connect to
+	// Network ID separates blockchains on the peer-to-peer networking level. When left
+	// zero, the chain ID is used as network ID.
+	NetworkId uint64
+
 	SyncMode  downloader.SyncMode
 
 	NoPruning  bool // Whether to disable pruning and flush everything to disk

--- a/eth/config.go
+++ b/eth/config.go
@@ -95,7 +95,7 @@ type Config struct {
 	// zero, the chain ID is used as network ID.
 	NetworkId uint64
 
-	SyncMode  downloader.SyncMode
+	SyncMode downloader.SyncMode
 
 	NoPruning  bool // Whether to disable pruning and flush everything to disk
 	NoPrefetch bool // Whether to disable prefetching and only load state on demand


### PR DESCRIPTION
This improves the user experience when creating a private network
because the `--networkid` flag doesn't need to be specified anymore.