### PR TITLE
p2p: fix bug in TestPeerDisconnect

### DIFF
--- a/p2p/peer_test.go
+++ b/p2p/peer_test.go
@@ -150,7 +150,7 @@ func TestPeerDisconnect(t *testing.T) {
 // This test is supposed to verify that Peer can reliably handle
 // multiple causes of disconnection occurring at the same time.
 func TestPeerDisconnectRace(t *testing.T) {
-	maybe := func() bool { return rand.Intn(1) == 1 }
+	maybe := func() bool { return rand.Intn(2) == 1 }
 
 	for i := 0; i < 1000; i++ {
 		protoclose := make(chan error)


### PR DESCRIPTION
`maybe` must return true probabilistically, but always return false. Therefore, the 50% probability is corrected to be true.