### PR TITLE
build: gather info to investigate why builds fail on ARM

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,6 +47,8 @@ jobs:
       dist: xenial
       go: 1.13.x
       script:
+        - cat /proc/cpuinfo
+        - free -h
         - go run build/ci.go install
         - go run build/ci.go test -coverage $TEST_PACKAGES
 

--- a/build/ci.go
+++ b/build/ci.go
@@ -229,6 +229,9 @@ func doInstall(cmdline []string) {
 
 	if *arch == "" || *arch == runtime.GOARCH {
 		goinstall := goTool("install", buildFlags(env)...)
+		if runtime.GOARCH == "arm64" {
+			goinstall.Args = append(goinstall.Args, "-p", "1")
+		}
 		goinstall.Args = append(goinstall.Args, "-v")
 		goinstall.Args = append(goinstall.Args, packages...)
 		build.MustRun(goinstall)
@@ -241,6 +244,7 @@ func doInstall(cmdline []string) {
 			os.RemoveAll(filepath.Join(path, "pkg", runtime.GOOS+"_arm"))
 		}
 	}
+
 	// Seems we are cross compiling, work around forbidden GOBIN
 	goinstall := goToolArch(*arch, *cc, "install", buildFlags(env)...)
 	goinstall.Args = append(goinstall.Args, "-v")


### PR DESCRIPTION
Even though the ARM build works relatively well when running for a PR, it fails systematically during a push build.

This PR adds some probes to investigate the difference between the two execution environments, and also reduces the build concurrency in order to find out if this is the root cause of the issue.