### PR TITLE
core: write chain data in atomic way

### DIFF
--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -408,7 +408,7 @@ func (bc *BlockChain) SetHead(head uint64) error {
 			rawdb.WriteHeadBlockHash(db, newHeadBlock.Hash())
 
 			// Degrade the chain markers if they are explicitly reverted.
-			// In thoery we should update all in-memory markers in the
+			// In theory we should update all in-memory markers in the
 			// last step, however the direction of SetHead is from high
 			// to low, so it's safe the update in-memory markers directly.
 			bc.currentBlock.Store(newHeadBlock)
@@ -425,7 +425,7 @@ func (bc *BlockChain) SetHead(head uint64) error {
 			rawdb.WriteHeadFastBlockHash(db, newHeadFastBlock.Hash())
 
 			// Degrade the chain markers if they are explicitly reverted.
-			// In thoery we should update all in-memory markers in the
+			// In theory we should update all in-memory markers in the
 			// last step, however the direction of SetHead is from high
 			// to low, so it's safe the update in-memory markers directly.
 			bc.currentFastBlock.Store(newHeadFastBlock)
@@ -903,7 +903,7 @@ func (bc *BlockChain) Rollback(chain []common.Hash) {
 		hash := chain[i]
 
 		// Degrade the chain markers if they are explicitly reverted.
-		// In thoery we should update all in-memory markers in the
+		// In theory we should update all in-memory markers in the
 		// last step, however the direction of rollback is from high
 		// to low, so it's safe the update in-memory markers directly.
 		currentHeader := bc.hc.CurrentHeader()

--- a/core/headerchain.go
+++ b/core/headerchain.go
@@ -45,6 +45,14 @@ const (
 // HeaderChain implements the basic block header chain logic that is shared by
 // core.BlockChain and light.LightChain. It is not usable in itself, only as
 // a part of either structure.
+//
+// HeaderChain is responsible for maintaining the header chain including the
+// header query and updating.
+//
+// The components maintained by headerchain includes: (1) total difficult
+// (2) header (3) block hash -> number mapping (4) canonical number -> hash mapping
+// and (5) head header flag.
+//
 // It is not thread safe either, the encapsulating chain structures should do
 // the necessary mutex locking/unlocking.
 type HeaderChain struct {
@@ -66,10 +74,8 @@ type HeaderChain struct {
 	engine consensus.Engine
 }
 
-// NewHeaderChain creates a new HeaderChain structure.
-//  getValidator should return the parent's validator
-//  procInterrupt points to the parent's interrupt semaphore
-//  wg points to the parent's shutdown wait group
+// NewHeaderChain creates a new HeaderChain structure. ProcInterrupt points
+// to the parent's interrupt semaphore.
 func NewHeaderChain(chainDb ethdb.Database, config *params.ChainConfig, engine consensus.Engine, procInterrupt func() bool) (*HeaderChain, error) {
 	headerCache, _ := lru.New(headerCacheLimit)
 	tdCache, _ := lru.New(tdCacheLimit)
@@ -147,25 +153,33 @@ func (hc *HeaderChain) WriteHeader(header *types.Header) (status WriteStatus, er
 	externTd := new(big.Int).Add(header.Difficulty, ptd)
 
 	// Irrelevant of the canonical status, write the td and header to the database
-	if err := hc.WriteTd(hash, number, externTd); err != nil {
-		log.Crit("Failed to write header total difficulty", "err", err)
+	//
+	// Note all the components of header(td, hash->number index and header) should
+	// be written atomically.
+	headerBatch := hc.chainDb.NewBatch()
+	hc.WriteTd(headerBatch, hash, number, externTd)
+	rawdb.WriteHeader(headerBatch, header)
+	if err := headerBatch.Write(); err != nil {
+		log.Crit("Failed to write header into disk", "err", err)
 	}
-	rawdb.WriteHeader(hc.chainDb, header)
-
 	// If the total difficulty is higher than our known, add it to the canonical chain
 	// Second clause in the if statement reduces the vulnerability to selfish mining.
 	// Please refer to http://www.cs.cornell.edu/~ie53/publications/btcProcFC.pdf
 	if externTd.Cmp(localTd) > 0 || (externTd.Cmp(localTd) == 0 && mrand.Float64() < 0.5) {
+		// If the header can be added into canonical chain, adjust the
+		// header chain markers(canonical indexes and head header flag).
+		//
+		// Note all markers should be written atomically.
+
 		// Delete any canonical number assignments above the new head
-		batch := hc.chainDb.NewBatch()
+		markerBatch := hc.chainDb.NewBatch()
 		for i := number + 1; ; i++ {
 			hash := rawdb.ReadCanonicalHash(hc.chainDb, i)
 			if hash == (common.Hash{}) {
 				break
 			}
-			rawdb.DeleteCanonicalHash(batch, i)
+			rawdb.DeleteCanonicalHash(markerBatch, i)
 		}
-		batch.Write()
 
 		// Overwrite any stale canonical number assignments
 		var (
@@ -174,16 +188,18 @@ func (hc *HeaderChain) WriteHeader(header *types.Header) (status WriteStatus, er
 			headHeader = hc.GetHeader(headHash, headNumber)
 		)
 		for rawdb.ReadCanonicalHash(hc.chainDb, headNumber) != headHash {
-			rawdb.WriteCanonicalHash(hc.chainDb, headHash, headNumber)
+			rawdb.WriteCanonicalHash(markerBatch, headHash, headNumber)
 
 			headHash = headHeader.ParentHash
 			headNumber = headHeader.Number.Uint64() - 1
 			headHeader = hc.GetHeader(headHash, headNumber)
 		}
 		// Extend the canonical chain with the new header
-		rawdb.WriteCanonicalHash(hc.chainDb, hash, number)
-		rawdb.WriteHeadHeaderHash(hc.chainDb, hash)
-
+		rawdb.WriteCanonicalHash(markerBatch, hash, number)
+		rawdb.WriteHeadHeaderHash(markerBatch, hash)
+		if err := markerBatch.Write(); err != nil {
+			log.Crit("Failed to write header markers into disk", "err", err)
+		}
 		hc.currentHeaderHash = hash
 		hc.currentHeader.Store(types.CopyHeader(header))
 		headHeaderGauge.Update(header.Number.Int64())
@@ -194,7 +210,6 @@ func (hc *HeaderChain) WriteHeader(header *types.Header) (status WriteStatus, er
 	}
 	hc.headerCache.Add(hash, header)
 	hc.numberCache.Add(hash, number)
-
 	return
 }
 
@@ -398,8 +413,8 @@ func (hc *HeaderChain) GetTdByHash(hash common.Hash) *big.Int {
 
 // WriteTd stores a block's total difficulty into the database, also caching it
 // along the way.
-func (hc *HeaderChain) WriteTd(hash common.Hash, number uint64, td *big.Int) error {
-	rawdb.WriteTd(hc.chainDb, hash, number, td)
+func (hc *HeaderChain) WriteTd(db ethdb.KeyValueWriter, hash common.Hash, number uint64, td *big.Int) error {
+	rawdb.WriteTd(db, hash, number, td)
 	hc.tdCache.Add(hash, new(big.Int).Set(td))
 	return nil
 }
@@ -431,6 +446,8 @@ func (hc *HeaderChain) GetHeaderByHash(hash common.Hash) *types.Header {
 }
 
 // HasHeader checks if a block header is present in the database or not.
+// In theory, if header is present in the database, all relative components
+// like td and hash->number should be present too.
 func (hc *HeaderChain) HasHeader(hash common.Hash, number uint64) bool {
 	if hc.numberCache.Contains(hash) || hc.headerCache.Contains(hash) {
 		return true
@@ -460,11 +477,16 @@ func (hc *HeaderChain) CurrentHeader() *types.Header {
 
 // SetCurrentHeader sets the current head header of the canonical chain.
 func (hc *HeaderChain) SetCurrentHeader(head *types.Header) {
-	rawdb.WriteHeadHeaderHash(hc.chainDb, head.Hash())
-
 	hc.currentHeader.Store(head)
 	hc.currentHeaderHash = head.Hash()
 	headHeaderGauge.Update(head.Number.Int64())
+}
+
+// WriteHeadHeader sets the current head header of the canonical chain
+// and write the marker into database.
+func (hc *HeaderChain) WriteHeadHeader(db ethdb.KeyValueWriter, head *types.Header) {
+	rawdb.WriteHeadHeaderHash(db, head.Hash())
+	hc.SetCurrentHeader(head)
 }
 
 type (
@@ -500,12 +522,15 @@ func (hc *HeaderChain) SetHead(head uint64, updateFn UpdateHeadBlocksCallback, d
 		// first then remove the relative data from the database.
 		//
 		// Update head first(head fast block, head full block) before deleting the data.
+		markerBatch := hc.chainDb.NewBatch()
 		if updateFn != nil {
-			updateFn(hc.chainDb, parent)
+			updateFn(markerBatch, parent)
 		}
 		// Update head header then.
-		rawdb.WriteHeadHeaderHash(hc.chainDb, parentHash)
-
+		rawdb.WriteHeadHeaderHash(markerBatch, parentHash)
+		if err := markerBatch.Write(); err != nil {
+			log.Crit("Failed to update chain markers", "error", err)
+		}
 		// Remove the relative data from the database.
 		if delFn != nil {
 			delFn(batch, hash, num)
@@ -519,8 +544,10 @@ func (hc *HeaderChain) SetHead(head uint64, updateFn UpdateHeadBlocksCallback, d
 		hc.currentHeaderHash = parentHash
 		headHeaderGauge.Update(parent.Number.Int64())
 	}
-	batch.Write()
-
+	// Flush all accumulated deletions.
+	if err := batch.Write(); err != nil {
+		log.Crit("Failed to rewind block", "error", err)
+	}
 	// Clear out any stale content from the caches
 	hc.headerCache.Purge()
 	hc.tdCache.Purge()

--- a/light/lightchain.go
+++ b/light/lightchain.go
@@ -206,6 +206,7 @@ func (lc *LightChain) ResetWithGenesisBlock(genesis *types.Block) {
 	}
 	lc.genesisBlock = genesis
 	lc.hc.SetGenesis(lc.genesisBlock.Header())
+	lc.hc.SetCurrentHeader(lc.genesisBlock.Header())
 }
 
 // Accessors
@@ -329,7 +330,7 @@ func (lc *LightChain) Rollback(chain []common.Hash) {
 	for i := len(chain) - 1; i >= 0; i-- {
 		hash := chain[i]
 
-		// Degrade the chain markers if they are explictly reverted.
+		// Degrade the chain markers if they are explicitly reverted.
 		// In thoery we should update all in-memory markers in the
 		// last step, however the direction of rollback is from high
 		// to low, so it's safe the update in-memory markers directly.

--- a/light/lightchain.go
+++ b/light/lightchain.go
@@ -331,7 +331,7 @@ func (lc *LightChain) Rollback(chain []common.Hash) {
 		hash := chain[i]
 
 		// Degrade the chain markers if they are explicitly reverted.
-		// In thoery we should update all in-memory markers in the
+		// In theory we should update all in-memory markers in the
 		// last step, however the direction of rollback is from high
 		// to low, so it's safe the update in-memory markers directly.
 		if head := lc.hc.CurrentHeader(); head.Hash() == hash {

--- a/light/lightchain.go
+++ b/light/lightchain.go
@@ -200,14 +200,12 @@ func (lc *LightChain) ResetWithGenesisBlock(genesis *types.Block) {
 	batch := lc.chainDb.NewBatch()
 	rawdb.WriteTd(batch, genesis.Hash(), genesis.NumberU64(), genesis.Difficulty())
 	rawdb.WriteBlock(batch, genesis)
-
-	lc.genesisBlock = genesis
-	lc.hc.SetGenesis(lc.genesisBlock.Header())
-	lc.hc.WriteHeadHeader(batch, lc.genesisBlock.Header())
-
+	rawdb.WriteHeadHeaderHash(batch, genesis.Hash())
 	if err := batch.Write(); err != nil {
 		log.Crit("Failed to reset genesis block", "err", err)
 	}
+	lc.genesisBlock = genesis
+	lc.hc.SetGenesis(lc.genesisBlock.Header())
 }
 
 // Accessors
@@ -327,12 +325,21 @@ func (lc *LightChain) Rollback(chain []common.Hash) {
 	lc.chainmu.Lock()
 	defer lc.chainmu.Unlock()
 
+	batch := lc.chainDb.NewBatch()
 	for i := len(chain) - 1; i >= 0; i-- {
 		hash := chain[i]
 
+		// Degrade the chain markers if they are explictly reverted.
+		// In thoery we should update all in-memory markers in the
+		// last step, however the direction of rollback is from high
+		// to low, so it's safe the update in-memory markers directly.
 		if head := lc.hc.CurrentHeader(); head.Hash() == hash {
-			lc.hc.WriteHeadHeader(lc.chainDb, lc.GetHeader(head.ParentHash, head.Number.Uint64()-1))
+			rawdb.WriteHeadHeaderHash(batch, head.ParentHash)
+			lc.hc.SetCurrentHeader(lc.GetHeader(head.ParentHash, head.Number.Uint64()-1))
 		}
+	}
+	if err := batch.Write(); err != nil {
+		log.Crit("Failed to rollback light chain", "error", err)
 	}
 }
 
@@ -497,7 +504,8 @@ func (lc *LightChain) SyncCheckpoint(ctx context.Context, checkpoint *params.Tru
 		// Ensure the chain didn't move past the latest block while retrieving it
 		if lc.hc.CurrentHeader().Number.Uint64() < header.Number.Uint64() {
 			log.Info("Updated latest header based on CHT", "number", header.Number, "hash", header.Hash(), "age", common.PrettyAge(time.Unix(int64(header.Time), 0)))
-			lc.hc.WriteHeadHeader(lc.chainDb, header)
+			rawdb.WriteHeadHeaderHash(lc.chainDb, header.Hash())
+			lc.hc.SetCurrentHeader(header)
 		}
 		return true
 	}


### PR DESCRIPTION
This PR changes the way to write chain data.

Now we can classify the chain data into two parts:
* Header chain data
* Block chain data

The reason we classify it is: 
* for light client, it only maintains the header chain
* for sync, we write header chain first and then fulfill the remaining data like body and receipts.

So that there are two separate data structures `headerchain` and `blockchain`.

The pain point is both `header chain data`  and `block chain data` are divided into several components
For `header chain`, we have:
* header
* total difficulty
* hash -> number mapping

For `block chain`, we have:
* header
* total difficulty
* hash -> number mapping
* body
* receipts

So in order to ensure the integrity of the chain data, all the components have to be written in an atomic way.
So this is the first thing this PR does.

And what's more, except the chain data, there are some additional index data.
For `header chain`, there are:
* canonical index(number -> hash mapping)
* head header flag

For `block chain`, there are:
* canonical index(number -> hash mapping)
* head header flag
* tx indexes(tx hash -> canonical block number)
* head fast block flag
* head full block flag.

So for these indexes, they also have to be written in an atomic way. But they are independent with chain data. The basic work flow is: write the chain data first irrelevant of the canonical status, then commit the indexes if it's a canonical header or block.

So this PR also ensures all indexes are written in an atomic way.

##

**So finally we can address some issues caused by uncompleteness of chain data.**
* The panic here https://github.com/ethereum/go-ethereum/blob/master/eth/downloader/downloader.go#L877
* #20239 
