### PR TITLE
travis: Remove traces and use travis_wait in ARM build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -48,7 +48,7 @@ jobs:
       go: 1.13.x
       script:
         - go run build/ci.go install
-        - go run build/ci.go test -coverage $TEST_PACKAGES
+        - travis_wait go run build/ci.go test -coverage $TEST_PACKAGES
 
     - stage: build
       os: osx

--- a/.travis.yml
+++ b/.travis.yml
@@ -47,8 +47,6 @@ jobs:
       dist: xenial
       go: 1.13.x
       script:
-        - cat /proc/cpuinfo
-        - free -h
         - go run build/ci.go install
         - go run build/ci.go test -coverage $TEST_PACKAGES
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -48,7 +48,7 @@ jobs:
       go: 1.13.x
       script:
         - go run build/ci.go install
-        - travis_wait go run build/ci.go test -coverage $TEST_PACKAGES
+        - travis_wait 30 go run build/ci.go test -coverage $TEST_PACKAGES
 
     - stage: build
       os: osx


### PR DESCRIPTION
This is a continuation of #20281, that fixed the build. Now, the tests are failing in the same fashion and this PR is a first attempt at fixing this new problem.