### PR TITLE
Makefile: add env var to enable args to test cmd

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ ios:
 	@echo "Import \"$(GOBIN)/Geth.framework\" to use the library."
 
 test: all
-	build/env.sh go run build/ci.go test
+	build/env.sh go run build/ci.go test $(testargs)
 
 lint: ## Run linters.
 	build/env.sh go run build/ci.go lint


### PR DESCRIPTION
This allows make command to handle -coverage and other arbitrary
flags to the go command.

Usage:

```
> make testargs=foo test
```

eg.

```
> make testargs=./core test # Test only ./core package
> make testargs='-coverage' test # Include coverage info
```
