### PR TITLE
core: s/isEIP155/isEIP2/ (fix IntrinsicGas signature var name)

### DIFF
--- a/core/state_transition.go
+++ b/core/state_transition.go
@@ -76,10 +76,10 @@ type Message interface {
 }
 
 // IntrinsicGas computes the 'intrinsic gas' for a message with the given data.
-func IntrinsicGas(data []byte, contractCreation, isEIP155 bool, isEIP2028 bool) (uint64, error) {
+func IntrinsicGas(data []byte, contractCreation, isEIP2 bool, isEIP2028 bool) (uint64, error) {
 	// Set the starting gas for the raw transaction
 	var gas uint64
-	if contractCreation && isEIP155 {
+	if contractCreation && isEIP2 {
 		gas = params.TxGasContractCreation
 	} else {
 		gas = params.TxGas

--- a/core/state_transition.go
+++ b/core/state_transition.go
@@ -76,10 +76,10 @@ type Message interface {
 }
 
 // IntrinsicGas computes the 'intrinsic gas' for a message with the given data.
-func IntrinsicGas(data []byte, contractCreation, isEIP2 bool, isEIP2028 bool) (uint64, error) {
+func IntrinsicGas(data []byte, contractCreation, isHomestead bool, isEIP2028 bool) (uint64, error) {
 	// Set the starting gas for the raw transaction
 	var gas uint64
-	if contractCreation && isEIP2 {
+	if contractCreation && isHomestead {
 		gas = params.TxGasContractCreation
 	} else {
 		gas = params.TxGas


### PR DESCRIPTION
This signature variable name reflects a spec'd change
in gas cost for creating contracts as documented in EIP2 (Homestead HF).

https://github.com/ethereum/EIPs/blob/master/EIPS/eip-2.md#specification