### PR TITLE
les: rename UpdateBalance to AddBalance and simplify return format

### DIFF
--- a/internal/web3ext/web3ext.go
+++ b/internal/web3ext/web3ext.go
@@ -824,8 +824,8 @@ web3._extend({
 			params: 1
 		}),
 		new web3._extend.Method({
-			name: 'updateBalance',
-			call: 'les_updateBalance',
+			name: 'addBalance',
+			call: 'les_addBalance',
 			params: 3
 		}),
 	],

--- a/les/api.go
+++ b/les/api.go
@@ -170,14 +170,11 @@ func (api *PrivateLightServerAPI) setParams(params map[string]interface{}, clien
 	return
 }
 
-// UpdateBalance updates the balance of a client (either overwrites it or adds to it).
+// AddBalance updates the balance of a client (either overwrites it or adds to it).
 // It also updates the balance meta info string.
-func (api *PrivateLightServerAPI) UpdateBalance(id enode.ID, value int64, meta string) (map[string]uint64, error) {
-	oldBalance, newBalance, err := api.server.clientPool.updateBalance(id, value, meta)
-	m := make(map[string]uint64)
-	m["old"] = oldBalance
-	m["new"] = newBalance
-	return m, err
+func (api *PrivateLightServerAPI) AddBalance(id enode.ID, value int64, meta string) ([2]uint64, error) {
+	oldBalance, newBalance, err := api.server.clientPool.addBalance(id, value, meta)
+	return [2]uint64{oldBalance, newBalance}, err
 }
 
 // SetClientParams sets client parameters for all clients listed in the ids list

--- a/les/balance.go
+++ b/les/balance.go
@@ -80,7 +80,7 @@ func (bt *balanceTracker) stop(now mclock.AbsTime) {
 	defer bt.lock.Unlock()
 
 	bt.stopped = true
-	bt.updateBalance(now)
+	bt.addBalance(now)
 	bt.negTimeFactor = 0
 	bt.negRequestFactor = 0
 	bt.timeFactor = 0
@@ -173,7 +173,7 @@ func (bt *balanceTracker) getPriority(now mclock.AbsTime) int64 {
 	bt.lock.Lock()
 	defer bt.lock.Unlock()
 
-	bt.updateBalance(now)
+	bt.addBalance(now)
 	return bt.balanceToPriority(bt.balance)
 }
 
@@ -194,8 +194,8 @@ func (bt *balanceTracker) estimatedPriority(at mclock.AbsTime, addReqCost bool) 
 	return bt.balanceToPriority(bt.reducedBalance(at, avgReqCost))
 }
 
-// updateBalance updates balance based on the time factor
-func (bt *balanceTracker) updateBalance(now mclock.AbsTime) {
+// addBalance updates balance based on the time factor
+func (bt *balanceTracker) addBalance(now mclock.AbsTime) {
 	if now > bt.lastUpdate {
 		bt.balance = bt.reducedBalance(now, 0)
 		bt.lastUpdate = now
@@ -253,7 +253,7 @@ func (bt *balanceTracker) updateAfter(dt time.Duration) {
 
 				if bt.callbackCount != 0 {
 					now := bt.clock.Now()
-					bt.updateBalance(now)
+					bt.addBalance(now)
 					bt.checkCallbacks(now)
 				}
 			})
@@ -270,7 +270,7 @@ func (bt *balanceTracker) requestCost(cost uint64) {
 		return
 	}
 	now := bt.clock.Now()
-	bt.updateBalance(now)
+	bt.addBalance(now)
 	fcost := float64(cost)
 
 	if bt.balance.pos != 0 {
@@ -302,7 +302,7 @@ func (bt *balanceTracker) getBalance(now mclock.AbsTime) (uint64, uint64) {
 	bt.lock.Lock()
 	defer bt.lock.Unlock()
 
-	bt.updateBalance(now)
+	bt.addBalance(now)
 	return bt.balance.pos, bt.balance.neg
 }
 
@@ -312,7 +312,7 @@ func (bt *balanceTracker) setBalance(pos, neg uint64) error {
 	defer bt.lock.Unlock()
 
 	now := bt.clock.Now()
-	bt.updateBalance(now)
+	bt.addBalance(now)
 	bt.balance.pos = pos
 	bt.balance.neg = neg
 	bt.checkCallbacks(now)
@@ -329,7 +329,7 @@ func (bt *balanceTracker) setFactors(neg bool, timeFactor, requestFactor float64
 		return
 	}
 	now := bt.clock.Now()
-	bt.updateBalance(now)
+	bt.addBalance(now)
 	if neg {
 		bt.negTimeFactor = timeFactor
 		bt.negRequestFactor = requestFactor
@@ -360,7 +360,7 @@ func (bt *balanceTracker) addCallback(id int, threshold int64, callback func()) 
 	bt.callbackIndex[id] = idx
 	bt.callbacks[idx] = balanceCallback{id, threshold, callback}
 	now := bt.clock.Now()
-	bt.updateBalance(now)
+	bt.addBalance(now)
 	bt.checkCallbacks(now)
 }
 

--- a/les/clientpool.go
+++ b/les/clientpool.go
@@ -553,9 +553,9 @@ func (f *clientPool) getPosBalance(id enode.ID) posBalance {
 	return f.ndb.getOrNewPB(id)
 }
 
-// updateBalance updates the balance of a client (either overwrites it or adds to it).
+// addBalance updates the balance of a client (either overwrites it or adds to it).
 // It also updates the balance meta info string.
-func (f *clientPool) updateBalance(id enode.ID, amount int64, meta string) (uint64, uint64, error) {
+func (f *clientPool) addBalance(id enode.ID, amount int64, meta string) (uint64, uint64, error) {
 	f.lock.Lock()
 	defer f.lock.Unlock()
 

--- a/les/clientpool_test.go
+++ b/les/clientpool_test.go
@@ -111,7 +111,7 @@ func testClientPool(t *testing.T, connLimit, clientCount, paidCount int, randomD
 			// give a positive balance to some of the peers
 			amount := testClientPoolTicks / 2 * int64(time.Second) // enough for half of the simulation period
 			for i := 0; i < paidCount; i++ {
-				pool.updateBalance(poolTestPeer(i).ID(), amount, "")
+				pool.addBalance(poolTestPeer(i).ID(), amount, "")
 			}
 		}
 
@@ -178,7 +178,7 @@ func TestConnectPaidClient(t *testing.T) {
 	pool.setDefaultFactors(priceFactors{1, 0, 1}, priceFactors{1, 0, 1})
 
 	// Add balance for an external client and mark it as paid client
-	pool.updateBalance(poolTestPeer(0).ID(), 1000, "")
+	pool.addBalance(poolTestPeer(0).ID(), 1000, "")
 
 	if !pool.connect(poolTestPeer(0), 10) {
 		t.Fatalf("Failed to connect paid client")
@@ -196,7 +196,7 @@ func TestConnectPaidClientToSmallPool(t *testing.T) {
 	pool.setDefaultFactors(priceFactors{1, 0, 1}, priceFactors{1, 0, 1})
 
 	// Add balance for an external client and mark it as paid client
-	pool.updateBalance(poolTestPeer(0).ID(), 1000, "")
+	pool.addBalance(poolTestPeer(0).ID(), 1000, "")
 
 	// Connect a fat paid client to pool, should reject it.
 	if pool.connect(poolTestPeer(0), 100) {
@@ -216,15 +216,15 @@ func TestConnectPaidClientToFullPool(t *testing.T) {
 	pool.setDefaultFactors(priceFactors{1, 0, 1}, priceFactors{1, 0, 1})
 
 	for i := 0; i < 10; i++ {
-		pool.updateBalance(poolTestPeer(i).ID(), 1000000000, "")
+		pool.addBalance(poolTestPeer(i).ID(), 1000000000, "")
 		pool.connect(poolTestPeer(i), 1)
 	}
-	pool.updateBalance(poolTestPeer(11).ID(), 1000, "") // Add low balance to new paid client
+	pool.addBalance(poolTestPeer(11).ID(), 1000, "") // Add low balance to new paid client
 	if pool.connect(poolTestPeer(11), 1) {
 		t.Fatalf("Low balance paid client should be rejected")
 	}
 	clock.Run(time.Second)
-	pool.updateBalance(poolTestPeer(12).ID(), 1000000000*60*3, "") // Add high balance to new paid client
+	pool.addBalance(poolTestPeer(12).ID(), 1000000000*60*3, "") // Add high balance to new paid client
 	if !pool.connect(poolTestPeer(12), 1) {
 		t.Fatalf("High balance paid client should be accpected")
 	}
@@ -243,7 +243,7 @@ func TestPaidClientKickedOut(t *testing.T) {
 	pool.setDefaultFactors(priceFactors{1, 0, 1}, priceFactors{1, 0, 1})
 
 	for i := 0; i < 10; i++ {
-		pool.updateBalance(poolTestPeer(i).ID(), 1000000000, "") // 1 second allowance
+		pool.addBalance(poolTestPeer(i).ID(), 1000000000, "") // 1 second allowance
 		pool.connect(poolTestPeer(i), 1)
 		clock.Run(time.Millisecond)
 	}
@@ -351,7 +351,7 @@ func TestPositiveBalanceCalculation(t *testing.T) {
 	pool.setLimits(10, uint64(10)) // Total capacity limit is 10
 	pool.setDefaultFactors(priceFactors{1, 0, 1}, priceFactors{1, 0, 1})
 
-	pool.updateBalance(poolTestPeer(0).ID(), int64(time.Minute*3), "")
+	pool.addBalance(poolTestPeer(0).ID(), int64(time.Minute*3), "")
 	pool.connect(poolTestPeer(0), 10)
 	clock.Run(time.Minute)
 
@@ -377,7 +377,7 @@ func TestDowngradePriorityClient(t *testing.T) {
 	p := &poolTestPeerWithCap{
 		poolTestPeer: poolTestPeer(0),
 	}
-	pool.updateBalance(p.ID(), int64(time.Minute), "")
+	pool.addBalance(p.ID(), int64(time.Minute), "")
 	pool.connect(p, 10)
 	if p.cap != 10 {
 		t.Fatalf("The capcacity of priority peer hasn't been updated, got: %d", p.cap)
@@ -393,7 +393,7 @@ func TestDowngradePriorityClient(t *testing.T) {
 		t.Fatalf("Positive balance mismatch, want %v, got %v", 0, pb.value)
 	}
 
-	pool.updateBalance(poolTestPeer(0).ID(), int64(time.Minute), "")
+	pool.addBalance(poolTestPeer(0).ID(), int64(time.Minute), "")
 	pb = pool.ndb.getOrNewPB(poolTestPeer(0).ID())
 	if pb.value != uint64(time.Minute) {
 		t.Fatalf("Positive balance mismatch, want %v, got %v", uint64(time.Minute), pb.value)


### PR DESCRIPTION
This PR renames UpdateBalance to AddBalance because now it only does relative modification (addition). The return value is also simplified.
Latest API docs: https://github.com/ethereum/go-ethereum/pull/20303