### PR TITLE
cmd/ethkey: fix file permissions in changepassword command

### DIFF
--- a/cmd/ethkey/changepassword.go
+++ b/cmd/ethkey/changepassword.go
@@ -77,7 +77,7 @@ Change the password of a keyfile.`,
 		}
 
 		// Then write the new keyfile in place of the old one.
-		if err := ioutil.WriteFile(keyfilepath, newJson, 600); err != nil {
+		if err := ioutil.WriteFile(keyfilepath, newJson, 0600); err != nil {
 			utils.Fatalf("Error writing new keyfile to disk: %v", err)
 		}
 


### PR DESCRIPTION
Found by staticcheck.

```
cmd/ethkey/changepassword.go:80:52: SA9002: file mode '600' evaluates to 01130; did you mean '0600'? (staticcheck)
		if err := ioutil.WriteFile(keyfilepath, newJson, 600); err != nil {
		                                                 ^
```