### PR TITLE
p2p/netutil: fix staticcheck warning

### DIFF
--- a/p2p/netutil/net.go
+++ b/p2p/netutil/net.go
@@ -212,7 +212,7 @@ func sameNet(bits uint, ip, other net.IP) bool {
 	if mask != 0 && nb < len(ip) && ip[nb]&mask != other[nb]&mask {
 		return false
 	}
-	return nb <= len(ip) && bytes.Equal(ip[:nb], other[:nb])
+	return nb <= len(ip) && ip[:nb].Equal(other[:nb])
 }
 
 // DistinctNetSet tracks IPs, ensuring that at most N of them


### PR DESCRIPTION
This fixes the following staticcheck warning:

```
p2p/netutil/net.go:215:37: SA1021: use net.IP.Equal to compare net.IPs, not bytes.Equal (staticcheck)
	return nb <= len(ip) && bytes.Equal(ip[:nb], other[:nb])
	                                   ^
```