### PR TITLE
travis: deactivate arm build during push

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,13 +42,14 @@ jobs:
         - go run build/ci.go test -coverage $TEST_PACKAGES
 
     - stage: build
+      if: type = pull_request
       os: linux
       arch: arm64
       dist: xenial
       go: 1.13.x
       script:
-        - travis_wait 20 go run build/ci.go install
-        - travis_wait 30 go run build/ci.go test -coverage $TEST_PACKAGES
+        - go run build/ci.go install
+        - go run build/ci.go test -coverage $TEST_PACKAGES
 
     - stage: build
       os: osx


### PR DESCRIPTION
For some reason, Travis works fine when pushing a pull request, and stalls when building master.

It makes no sense to stall a potential release because of this, especially since arm builds will be checked during the pull request. I'm going to do all my builds on a different repo so as not to pollute master, then bring the issue to Travis when I have gathered enough information.