### PR TITLE
event: remove unused field 'closed'

### DIFF
--- a/event/feed.go
+++ b/event/feed.go
@@ -39,10 +39,9 @@ type Feed struct {
 	sendCases caseList         // the active set of select cases used by Send
 
 	// The inbox holds newly subscribed channels until they are added to sendCases.
-	mu     sync.Mutex
-	inbox  caseList
-	etype  reflect.Type
-	closed bool
+	mu    sync.Mutex
+	inbox caseList
+	etype reflect.Type
 }
 
 // This is the index of the first actual subscription channel in sendCases.


### PR DESCRIPTION
```
event/feed.go:45:2: field closed is unused (U1000)
```