### PR TITLE
p2p: remove unused code

### DIFF
--- a/p2p/rlpx.go
+++ b/p2p/rlpx.go
@@ -422,16 +422,6 @@ func (h *encHandshake) makeAuthResp() (msg *authRespV4, err error) {
 	return msg, nil
 }
 
-func (msg *authMsgV4) sealPlain(h *encHandshake) ([]byte, error) {
-	buf := make([]byte, authMsgLen)
-	n := copy(buf, msg.Signature[:])
-	n += copy(buf[n:], crypto.Keccak256(exportPubkey(&h.randomPrivKey.PublicKey)))
-	n += copy(buf[n:], msg.InitiatorPubkey[:])
-	n += copy(buf[n:], msg.Nonce[:])
-	buf[n] = 0 // token-flag
-	return ecies.Encrypt(rand.Reader, h.remote, buf, nil, nil)
-}
-
 func (msg *authMsgV4) decodePlain(input []byte) {
 	n := copy(msg.Signature[:], input)
 	n += shaLen // skip sha3(initiator-ephemeral-pubk)

--- a/p2p/server.go
+++ b/p2p/server.go
@@ -199,7 +199,6 @@ type Server struct {
 	checkpointAddPeer       chan *conn
 
 	// State of run loop and listenLoop.
-	lastLookup     time.Time
 	inboundHistory expHeap
 }
 
@@ -410,7 +409,7 @@ type sharedUDPConn struct {
 func (s *sharedUDPConn) ReadFromUDP(b []byte) (n int, addr *net.UDPAddr, err error) {
 	packet, ok := <-s.unhandled
 	if !ok {
-		return 0, nil, errors.New("Connection was closed")
+		return 0, nil, errors.New("connection was closed")
 	}
 	l := len(packet.Data)
 	if l > len(b) {

--- a/p2p/util.go
+++ b/p2p/util.go
@@ -40,17 +40,6 @@ func (h *expHeap) add(item string, exp time.Time) {
 	heap.Push(h, expItem{item, exp})
 }
 
-// remove removes an item.
-func (h *expHeap) remove(item string) bool {
-	for i, v := range *h {
-		if v.item == item {
-			heap.Remove(h, i)
-			return true
-		}
-	}
-	return false
-}
-
 // contains checks whether an item is present.
 func (h expHeap) contains(item string) bool {
 	for _, v := range h {


### PR DESCRIPTION
This fixes the following staticcheck warnings:

```
p2p/util.go:44:19: func (*expHeap).remove is unused (U1000)
p2p/rlpx.go:425:23: func (*authMsgV4).sealPlain is unused (U1000)
p2p/server.go:202:2: field lastLookup is unused (U1000)
p2p/server.go:413:28: error strings should not be capitalized (ST1005)
```