### PR TITLE
ethclient: remove use of common.ToHex

### DIFF
--- a/ethclient/ethclient.go
+++ b/ethclient/ethclient.go
@@ -514,7 +514,7 @@ func (ec *Client) SendTransaction(ctx context.Context, tx *types.Transaction) er
 	if err != nil {
 		return err
 	}
-	return ec.c.CallContext(ctx, nil, "eth_sendRawTransaction", common.ToHex(data))
+	return ec.c.CallContext(ctx, nil, "eth_sendRawTransaction", hexutil.Encode(data))
 }
 
 func toCallArg(msg ethereum.CallMsg) interface{} {


### PR DESCRIPTION
```
ethclient/ethclient.go:517:62: common.ToHex is deprecated: use hexutil.Encode instead.  (SA1019)
```