### PR TITLE
whisper/whisperv6: fix staticcheck warnings

### DIFF
--- a/whisper/whisperv6/filter_test.go
+++ b/whisper/whisperv6/filter_test.go
@@ -36,11 +36,6 @@ func InitSingleTest() {
 	mrand.Seed(seed)
 }
 
-func InitDebugTest(i int64) {
-	seed = i
-	mrand.Seed(seed)
-}
-
 type FilterTestCase struct {
 	f      *Filter
 	id     string
@@ -309,8 +304,7 @@ func TestMatchEnvelope(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to create new message with seed %d: %s.", seed, err)
 	}
-	env, err := msg.Wrap(params)
-	if err != nil {
+	if _, err = msg.Wrap(params); err != nil {
 		t.Fatalf("failed Wrap with seed %d: %s.", seed, err)
 	}
 
@@ -322,7 +316,7 @@ func TestMatchEnvelope(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to create new message with seed %d: %s.", seed, err)
 	}
-	env, err = msg.Wrap(params)
+	env, err := msg.Wrap(params)
 	if err != nil {
 		t.Fatalf("failed Wrap() with seed %d: %s.", seed, err)
 	}

--- a/whisper/whisperv6/peer_test.go
+++ b/whisper/whisperv6/peer_test.go
@@ -22,7 +22,6 @@ import (
 	"fmt"
 	mrand "math/rand"
 	"sync"
-	"sync/atomic"
 	"testing"
 	"time"
 
@@ -74,7 +73,6 @@ var keys = []string{
 }
 
 type TestData struct {
-	started int64
 	counter [NumNodes]int
 	mutex   sync.RWMutex
 }
@@ -212,12 +210,9 @@ func initialize(t *testing.T) {
 			},
 		}
 
-		go startServer(t, node.server)
-
+		startServer(t, node.server)
 		nodes[i] = &node
 	}
-
-	waitForServersToStart(t)
 
 	for i := 0; i < NumNodes; i++ {
 		for j := 0; j < i; j++ {
@@ -234,8 +229,6 @@ func startServer(t *testing.T, s *p2p.Server) {
 	if err != nil {
 		t.Fatalf("failed to start the first server. err: %v", err)
 	}
-
-	atomic.AddInt64(&result.started, 1)
 }
 
 func stopServers() {
@@ -492,19 +485,6 @@ func checkBloomFilterExchange(t *testing.T) {
 		}
 		time.Sleep(50 * time.Millisecond)
 	}
-}
-
-func waitForServersToStart(t *testing.T) {
-	const iterations = 200
-	var started int64
-	for j := 0; j < iterations; j++ {
-		time.Sleep(50 * time.Millisecond)
-		started = atomic.LoadInt64(&result.started)
-		if started == NumNodes {
-			return
-		}
-	}
-	t.Fatalf("Failed to start all the servers, running: %d", started)
 }
 
 //two generic whisper node handshake


### PR DESCRIPTION
This fixes the following warnings:

```
whisper/whisperv6/filter_test.go:39:6: func InitDebugTest is unused (U1000)
whisper/whisperv6/filter_test.go:312:2: this value of env is never used (SA4006)
whisper/whisperv6/peer_test.go:215:3: the goroutine calls T.Fatalf, which must be called in the same goroutine as the test (SA2002)
```