### PR TITLE
cmd/evm: Add --bench flag for benchmarking

### DIFF
--- a/cmd/evm/main.go
+++ b/cmd/evm/main.go
@@ -87,6 +87,10 @@ var (
 		Name:  "verbosity",
 		Usage: "sets the verbosity level",
 	}
+	BenchFlag = cli.BoolFlag{
+		Name:  "bench",
+		Usage: "benchmark the execution",
+	}
 	CreateFlag = cli.BoolFlag{
 		Name:  "create",
 		Usage: "indicates the action should be create rather than call",
@@ -124,6 +128,7 @@ var (
 
 func init() {
 	app.Flags = []cli.Flag{
+		BenchFlag,
 		CreateFlag,
 		DebugFlag,
 		VerbosityFlag,


### PR DESCRIPTION
The --bench flag uses the testing.B to execute the EVM bytecode many times and get the average exeuction time out of it.