### PR TITLE
consensus/clique: re-export the status struct

### DIFF
--- a/consensus/clique/api.go
+++ b/consensus/clique/api.go
@@ -120,7 +120,7 @@ func (api *API) Discard(address common.Address) {
 	delete(api.clique.proposals, address)
 }
 
-type status struct {
+type Status struct {
 	InturnPercent float64                `json:"inturnPercent"`
 	SigningStatus map[common.Address]int `json:"sealerActivity"`
 	NumBlocks     uint64                 `json:"numBlocks"`
@@ -130,7 +130,7 @@ type status struct {
 // - the number of active signers,
 // - the number of signers,
 // - the percentage of in-turn blocks
-func (api *API) Status() (*status, error) {
+func (api *API) Status() (*Status, error) {
 	var (
 		numBlocks = uint64(64)
 		header    = api.chain.CurrentHeader()
@@ -169,7 +169,7 @@ func (api *API) Status() (*status, error) {
 		}
 		signStatus[sealer]++
 	}
-	return &status{
+	return &Status{
 		InturnPercent: float64((100 * optimals)) / float64(numBlocks),
 		SigningStatus: signStatus,
 		NumBlocks:     numBlocks,


### PR DESCRIPTION
For some reason, the clique_getstatus (https://github.com/ethereum/go-ethereum/pull/20103) stopped working on https://github.com/ethereum/go-ethereum/pull/20316. Re-exporting the `status` struct makes the computer happy again. :man_shrugging: 

Current master: 
```
[user@work ~]$ echo '{"jsonrpc":"2.0","method":"clique_status","params":[],"id":1}' | nc -U /tmp/geth.ipc | jq .
{
  "jsonrpc": "2.0",
  "id": 1,
  "error": {
    "code": -32601,
    "message": "the method clique_status does not exist/is not available"
  }
}
```
On this PR: 
```
[user@work ~]$ echo '{"jsonrpc":"2.0","method":"clique_status","params":[],"id":1}' | nc -U /tmp/geth.ipc | jq .
{
  "jsonrpc": "2.0",
  "id": 1,
  "result": {
    "inturnPercent": 0,
    "sealerActivity": {
      "0x70a562efc38046dd806feac16ce4b5ac4555ec89": 0
    },
    "numBlocks": 18446744073709552000
  }
}
```
