### PR TITLE
update node last ping/pong time

### DIFF
--- a/p2p/discv5/net.go
+++ b/p2p/discv5/net.go
@@ -1112,6 +1112,9 @@ func (net *Network) ping(n *Node, addr *net.UDPAddr) {
 	n.pingTopics = net.ticketStore.regTopicSet()
 	n.pingEcho = net.conn.sendPing(n, addr, n.pingTopics)
 	net.timedEvent(respTimeout, n, pongTimeout)
+
+	//update last ping sent to Node n
+	net.db.updateLastPing(n.ID, time.Now())
 }
 
 func (net *Network) handlePing(n *Node, pkt *ingressPacket) {
@@ -1140,6 +1143,9 @@ func (net *Network) handleKnownPong(n *Node, pkt *ingressPacket) error {
 	} else {
 		log.Trace("Failed to convert pong to ticket", "err", err)
 	}
+	//update Node n last seen pong time
+	net.db.updateLastPong(n.ID, time.Now())
+
 	n.pingEcho = nil
 	n.pingTopics = nil
 	return err


### PR DESCRIPTION
```
func (db *nodeDB) expireNodes() error {
	//....
	for it.Next() {
		//...
		// Skip the node if not expired yet (and not self)
		if !bytes.Equal(id[:], db.self[:]) {
			if seen := db.lastPong(id); seen.After(threshold) {
				continue
			}
		}
		//
	}
	return nil
}
```

method `db.expireNodes`  checks last pong time of a node, but there is no place to call `db.updateLastPong` method,  and this pr alse update last ping time .