### PR TITLE
les, p2p/discv5: implement in-protocol payment

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -101,6 +101,7 @@ github.com/influxdata/influxdb v1.2.3-0.20180221223340-01288bdb0883 h1:FSeK4fZCo
 github.com/influxdata/influxdb v1.2.3-0.20180221223340-01288bdb0883/go.mod h1:qZna6X/4elxqT3yI9iZYdZrWWdeFOOprn86kgg4+IzY=
 github.com/jackpal/go-nat-pmp v1.0.2-0.20160603034137-1fa385a6f458 h1:6OvNmYgJyexcZ3pYbTI9jWx5tHo1Dee/tWbLMfPe2TA=
 github.com/jackpal/go-nat-pmp v1.0.2-0.20160603034137-1fa385a6f458/go.mod h1:QPH045xvCAeXUZOxsnwmrtiCoxIr9eob+4orBN1SBKc=
+github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af h1:pmfjZENx5imkbgOkpRUYLnmbU7UEFbjtDA2hxJ1ichM=
 github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=
 github.com/julienschmidt/httprouter v1.1.1-0.20170430222011-975b5c4c7c21 h1:F/iKcka0K2LgnKy/fgSBf235AETtm1n1TvBzqu40LE0=
 github.com/julienschmidt/httprouter v1.1.1-0.20170430222011-975b5c4c7c21/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7VTCxuUUipMqKk8s4w=

--- a/internal/web3ext/web3ext.go
+++ b/internal/web3ext/web3ext.go
@@ -868,6 +868,31 @@ web3._extend({
 			call: 'lespay_connection',
 			params: 6
 		}),
+		new web3._extend.Method({
+			name: 'deposit',
+			call: 'lespay_deposit',
+			params: 4
+		}),
+		new web3._extend.Method({
+			name: 'buyTokens',
+			call: 'lespay_buyTokens',
+			params: 6
+		}),
+		new web3._extend.Method({
+			name: 'getBalance',
+			call: 'lespay_getBalance',
+			params: 2
+		}),
+		new web3._extend.Method({
+			name: 'info',
+			call: 'lespay_info',
+			params: 2
+		}),
+		new web3._extend.Method({
+			name: 'remoteInfo',
+			call: 'lespay_remoteInfo',
+			params: 3
+		}),
 	],
 	properties:
 	[

--- a/internal/web3ext/web3ext.go
+++ b/internal/web3ext/web3ext.go
@@ -33,6 +33,7 @@ var Modules = map[string]string{
 	"swarmfs":    SwarmfsJs,
 	"txpool":     TxpoolJs,
 	"les":        LESJs,
+	"lespay":     LESPAYJs,
 }
 
 const ChequebookJs = `
@@ -853,6 +854,23 @@ web3._extend({
 			name: 'serverInfo',
 			getter: 'les_serverInfo'
 		}),
+	]
+});
+`
+
+const LESPAYJs = `
+web3._extend({
+	property: 'lespay',
+	methods:
+	[
+		new web3._extend.Method({
+			name: 'connection',
+			call: 'lespay_connection',
+			params: 6
+		}),
+	],
+	properties:
+	[
 	]
 });
 `

--- a/les/api.go
+++ b/les/api.go
@@ -473,8 +473,8 @@ func (api *PrivateLespayAPI) Deposit(ctx context.Context, remote bool, node stri
 	return
 }
 
-func (api *PrivateLespayAPI) BuyTokens(ctx context.Context, remote bool, node string, maxSpend, minReceive uint64, spendAll bool) (results tsBuyTokensResults, err error) {
-	params := tsBuyTokensParams{maxSpend, minReceive, spendAll}
+func (api *PrivateLespayAPI) BuyTokens(ctx context.Context, remote bool, node string, maxSpend, minReceive uint64, relative, spendAll bool) (results tsBuyTokensResults, err error) {
+	params := tsBuyTokensParams{maxSpend, minReceive, relative, spendAll}
 	enc, _ := rlp.EncodeToBytes(&params)
 	var resEnc []byte
 	resEnc, err = api.makeCall(ctx, remote, node, append([]byte{tsBuyTokens}, enc...))

--- a/les/api.go
+++ b/les/api.go
@@ -147,7 +147,7 @@ func (api *PrivateLightServerAPI) setParams(params map[string]interface{}, clien
 			setFactor(&negFactors.requestFactor)
 		case !defParams && name == "capacity":
 			if capacity, ok := value.(float64); ok && uint64(capacity) >= api.server.minCapacity {
-				err = api.server.clientPool.setCapacity(client, uint64(capacity))
+				_, _, err = api.server.clientPool.setCapacity(client, uint64(capacity))
 				// Don't have to call factor update explicitly. It's already done
 				// in setCapacity function.
 			} else {

--- a/les/api.go
+++ b/les/api.go
@@ -19,7 +19,6 @@ package les
 import (
 	"errors"
 	"fmt"
-	"math"
 	"time"
 
 	"github.com/ethereum/go-ethereum/common/hexutil"
@@ -34,8 +33,6 @@ var (
 	errBalanceOverflow      = errors.New("balance overflow")
 	errNoPriority           = errors.New("priority too low to raise capacity")
 )
-
-const maxBalance = math.MaxInt64
 
 // PrivateLightServerAPI provides an API to access the LES light server.
 type PrivateLightServerAPI struct {
@@ -184,7 +181,7 @@ func (api *PrivateLightServerAPI) SetClientParams(ids []enode.ID, params map[str
 		if client != nil {
 			update, err := api.setParams(params, client, nil, nil)
 			if update {
-				client.updatePriceFactors()
+				updatePriceFactors(&client.balanceTracker, client.posFactors, client.negFactors, client.capacity)
 			}
 			return err
 		} else {

--- a/les/api.go
+++ b/les/api.go
@@ -147,7 +147,7 @@ func (api *PrivateLightServerAPI) setParams(params map[string]interface{}, clien
 			setFactor(&negFactors.requestFactor)
 		case !defParams && name == "capacity":
 			if capacity, ok := value.(float64); ok && uint64(capacity) >= api.server.minCapacity {
-				_, _, err = api.server.clientPool.setCapacity(client, uint64(capacity))
+				_, _, err = api.server.clientPool.setCapacity(client.id, client.freeID, uint64(capacity), 0, true)
 				// Don't have to call factor update explicitly. It's already done
 				// in setCapacity function.
 			} else {

--- a/les/api.go
+++ b/les/api.go
@@ -407,10 +407,8 @@ func (api *PrivateLespayAPI) makeCall(ctx context.Context, remote bool, nodeStr 
 			if api.clientHandler == nil {
 				return nil, errors.New("client handler not available")
 			}
-			cancelFn = api.clientHandler.makeLespayCall(peer, [][]byte{cmd}, func(replies [][]byte) bool {
-				if len(replies) == 1 {
-					reply = replies[0]
-				}
+			cancelFn = api.clientHandler.makeLespayCall(peer, cmd, func(r []byte) bool {
+				reply = r
 				close(delivered)
 				return reply != nil
 			})

--- a/les/api.go
+++ b/les/api.go
@@ -453,13 +453,66 @@ func (api *PrivateLespayAPI) Connection(ctx context.Context, remote bool, node s
 	params := tsConnectionParams{requestedCapacity, stayConnected, paymentModule, setCap}
 	enc, _ := rlp.EncodeToBytes(&params)
 	var resEnc []byte
-	fmt.Println("makeCall", remote, node, enc)
 	resEnc, err = api.makeCall(ctx, remote, node, append([]byte{tsConnection}, enc...))
 	if err != nil {
-		fmt.Println("makeCall err", err)
 		return
 	}
 	err = rlp.DecodeBytes(resEnc, &results)
-	fmt.Println("decode err", err)
+	return
+}
+
+func (api *PrivateLespayAPI) Deposit(ctx context.Context, remote bool, node string, paymentModule string, proofOfPayment []byte) (results tsDepositResults, err error) {
+	params := tsDepositParams{paymentModule, proofOfPayment}
+	enc, _ := rlp.EncodeToBytes(&params)
+	var resEnc []byte
+	resEnc, err = api.makeCall(ctx, remote, node, append([]byte{tsDeposit}, enc...))
+	if err != nil {
+		return
+	}
+	err = rlp.DecodeBytes(resEnc, &results)
+	return
+}
+
+func (api *PrivateLespayAPI) BuyTokens(ctx context.Context, remote bool, node string, maxSpend, minReceive uint64, spendAll bool) (results tsBuyTokensResults, err error) {
+	params := tsBuyTokensParams{maxSpend, minReceive, spendAll}
+	enc, _ := rlp.EncodeToBytes(&params)
+	var resEnc []byte
+	resEnc, err = api.makeCall(ctx, remote, node, append([]byte{tsBuyTokens}, enc...))
+	if err != nil {
+		return
+	}
+	err = rlp.DecodeBytes(resEnc, &results)
+	return
+}
+
+func (api *PrivateLespayAPI) GetBalance(ctx context.Context, remote bool, node string) (results tsGetBalanceResults, err error) {
+	var resEnc []byte
+	resEnc, err = api.makeCall(ctx, remote, node, []byte{tsGetBalance})
+	if err != nil {
+		return
+	}
+	err = rlp.DecodeBytes(resEnc, &results)
+	return
+}
+
+func (api *PrivateLespayAPI) Info(ctx context.Context, remote bool, node string) (results tsInfoResults, err error) {
+	var resEnc []byte
+	resEnc, err = api.makeCall(ctx, remote, node, []byte{tsInfo})
+	if err != nil {
+		return
+	}
+	err = rlp.DecodeBytes(resEnc, &results)
+	return
+}
+
+func (api *PrivateLespayAPI) ReceiverInfo(ctx context.Context, remote bool, node string, receiverIDs []string) (results tsReceiverInfoResults, err error) {
+	params := tsReceiverInfoParams(receiverIDs)
+	enc, _ := rlp.EncodeToBytes(&params)
+	var resEnc []byte
+	resEnc, err = api.makeCall(ctx, remote, node, append([]byte{tsReceiverInfo}, enc...))
+	if err != nil {
+		return
+	}
+	err = rlp.DecodeBytes(resEnc, &results)
 	return
 }

--- a/les/balance.go
+++ b/les/balance.go
@@ -17,11 +17,14 @@
 package les
 
 import (
+	"math"
 	"sync"
 	"time"
 
 	"github.com/ethereum/go-ethereum/common/mclock"
 )
+
+const maxBalance = math.MaxInt64
 
 const (
 	balanceCallbackQueue = iota
@@ -99,6 +102,31 @@ func (bt *balanceTracker) balanceToPriority(b balance) int64 {
 		return ^int64(b.pos / bt.capacity)
 	}
 	return int64(b.neg)
+}
+
+func (bt *balanceTracker) posBalanceMissing(targetPriority int64, after time.Duration) uint64 {
+	if targetPriority > 0 {
+		negPrice := uint64(float64(after) * bt.negTimeFactor)
+		if negPrice+bt.balance.neg <= uint64(targetPriority) {
+			return 0
+		}
+		if uint64(targetPriority) > bt.balance.neg && bt.negTimeFactor > 1e-100 {
+			if negTime := time.Duration(float64(uint64(targetPriority)-bt.balance.neg) / bt.negTimeFactor); negTime < after {
+				after -= negTime
+			} else {
+				after = 0
+			}
+		}
+		targetPriority = 0
+	}
+	posRequired := uint64(float64(^targetPriority)*float64(bt.capacity) + float64(after)*bt.timeFactor)
+	if posRequired >= maxBalance {
+		return math.MaxUint64 // target not reachable
+	}
+	if posRequired > bt.balance.pos {
+		return posRequired - bt.balance.pos
+	}
+	return 0
 }
 
 // reducedBalance estimates the reduced balance at a given time in the fututre based

--- a/les/balance.go
+++ b/les/balance.go
@@ -290,12 +290,12 @@ func (bt *balanceTracker) updateAfter(dt time.Duration) {
 }
 
 // requestCost should be called after serving a request for the given peer
-func (bt *balanceTracker) requestCost(cost uint64) {
+func (bt *balanceTracker) requestCost(cost uint64) uint64 {
 	bt.lock.Lock()
 	defer bt.lock.Unlock()
 
 	if bt.stopped {
-		return
+		return 0
 	}
 	now := bt.clock.Now()
 	bt.addBalance(now)
@@ -323,6 +323,7 @@ func (bt *balanceTracker) requestCost(cost uint64) {
 		}
 	}
 	bt.sumReqCost += cost
+	return bt.balance.pos
 }
 
 // getBalance returns the current positive and negative balance

--- a/les/balance.go
+++ b/les/balance.go
@@ -104,7 +104,7 @@ func (bt *balanceTracker) balanceToPriority(b balance) int64 {
 	return int64(b.neg)
 }
 
-func (bt *balanceTracker) posBalanceMissing(targetPriority int64, after time.Duration) uint64 {
+func (bt *balanceTracker) posBalanceMissing(targetPriority int64, targetCapacity uint64, after time.Duration) uint64 {
 	if targetPriority > 0 {
 		negPrice := uint64(float64(after) * bt.negTimeFactor)
 		if negPrice+bt.balance.neg <= uint64(targetPriority) {
@@ -119,7 +119,7 @@ func (bt *balanceTracker) posBalanceMissing(targetPriority int64, after time.Dur
 		}
 		targetPriority = 0
 	}
-	posRequired := uint64(float64(^targetPriority)*float64(bt.capacity) + float64(after)*bt.timeFactor)
+	posRequired := uint64(float64(^targetPriority)*float64(targetCapacity) + float64(after)*bt.timeFactor)
 	if posRequired >= maxBalance {
 		return math.MaxUint64 // target not reachable
 	}

--- a/les/balance_test.go
+++ b/les/balance_test.go
@@ -141,8 +141,8 @@ func TestBalanceToPriority(t *testing.T) {
 		neg      uint64
 		priority int64
 	}{
-		{1000, 0, ^int64(1)},
-		{2000, 0, ^int64(2)}, // Higher balance, lower priority value
+		{1000, 0, -1},
+		{2000, 0, -2}, // Higher balance, lower priority value
 		{0, 0, 0},
 		{0, 1000, 1000},
 	}
@@ -172,16 +172,16 @@ func TestEstimatedPriority(t *testing.T) {
 		reqCost    uint64        // single request cost
 		priority   int64         // expected estimated priority
 	}{
-		{time.Second, time.Second, 0, ^int64(58)},
-		{0, time.Second, 0, ^int64(58)},
+		{time.Second, time.Second, 0, -58},
+		{0, time.Second, 0, -58},
 
 		// 2 seconds time cost, 1 second estimated time cost, 10^9 request cost,
 		// 10^9 estimated request cost per second.
-		{time.Second, time.Second, 1000000000, ^int64(55)},
+		{time.Second, time.Second, 1000000000, -55},
 
 		// 3 seconds time cost, 3 second estimated time cost, 10^9*2 request cost,
 		// 4*10^9 estimated request cost.
-		{time.Second, 3 * time.Second, 1000000000, ^int64(48)},
+		{time.Second, 3 * time.Second, 1000000000, -48},
 
 		// All positive balance is used up
 		{time.Second * 55, 0, 0, 0},
@@ -213,7 +213,7 @@ func TestCallbackChecking(t *testing.T) {
 		priority int64
 		expDiff  time.Duration
 	}{
-		{^int64(500), time.Millisecond * 500},
+		{-500, time.Millisecond * 500},
 		{0, time.Second},
 		{int64(time.Second), 2 * time.Second},
 	}

--- a/les/client.go
+++ b/les/client.go
@@ -48,6 +48,7 @@ import (
 type LightEthereum struct {
 	lesCommons
 
+	srvr       *p2p.Server
 	reqDist    *requestDistributor
 	retriever  *retrieveManager
 	odr        *LesOdr
@@ -206,6 +207,12 @@ func (s *LightEthereum) APIs() []rpc.API {
 			Service:   NewPrivateLightAPI(&s.lesCommons),
 			Public:    false,
 		},
+		{
+			Namespace: "lespay",
+			Version:   "1.0",
+			Service:   NewPrivateLespayAPI(s.lesCommons.peers, s.handler, s.srvr.DiscV5, nil),
+			Public:    false,
+		},
 	}...)
 }
 
@@ -235,6 +242,7 @@ func (s *LightEthereum) Protocols() []p2p.Protocol {
 // light ethereum protocol implementation.
 func (s *LightEthereum) Start(srvr *p2p.Server) error {
 	log.Warn("Light client mode is an experimental feature")
+	s.srvr = srvr
 
 	// Start bloom request workers.
 	s.wg.Add(bloomServiceThreads)

--- a/les/client_handler.go
+++ b/les/client_handler.go
@@ -352,7 +352,7 @@ func (h *clientHandler) handleMsg(p *peer) error {
 	return nil
 }
 
-func (h *clientHandler) sendLespayCommands(p *peer, cmds [][]byte, handler func([][]byte) bool) func() bool {
+func (h *clientHandler) makeLespayCall(p *peer, cmds [][]byte, handler func([][]byte) bool) func() bool {
 	reqID := genReqID()
 	if p.SendLespay(reqID, cmds) != nil {
 		return nil

--- a/les/clientpool.go
+++ b/les/clientpool.go
@@ -187,8 +187,10 @@ func newClientPool(db ethdb.Database, minCap, freeClientCap uint64, clock mclock
 		var stop bool
 		l := len(ids)
 		if l == 1000 {
-			stop = true
 			l--
+			start = ids[l]
+		} else {
+			stop = true
 		}
 		for i := 0; i < l; i++ {
 			pool.disconnectedBalances += pool.ndb.getOrNewPB(ids[i]).value

--- a/les/clientpool.go
+++ b/les/clientpool.go
@@ -594,19 +594,21 @@ func (f *clientPool) setCapacity(id enode.ID, freeID string, capacity uint64, mi
 	if missing != 0 {
 		return missing, capacity, errNoPriority
 	}
-	if setCap && c == nil {
-		return missing, capacity, fmt.Errorf("client %064x is not connected", c.id[:])
-	}
 	// capacity update is possible
-	f.connectedCap += capacity - c.capacity
-	f.updateFullRatio()
-	f.priorityConnected += capacity - c.capacity
-	c.capacity = capacity
-	c.balanceTracker.setCapacity(capacity)
-	f.connectedQueue.Update(c.queueIndex)
-	totalConnectedGauge.Update(int64(f.connectedCap))
-	updatePriceFactors(&c.balanceTracker, c.posFactors, c.negFactors, c.capacity)
-	c.peer.updateCapacity(c.capacity)
+	if setCap {
+		if c == nil {
+			return 0, capacity, fmt.Errorf("client %064x is not connected", c.id[:])
+		}
+		f.connectedCap += capacity - c.capacity
+		f.updateFullRatio()
+		f.priorityConnected += capacity - c.capacity
+		c.capacity = capacity
+		c.balanceTracker.setCapacity(capacity)
+		f.connectedQueue.Update(c.queueIndex)
+		totalConnectedGauge.Update(int64(f.connectedCap))
+		updatePriceFactors(&c.balanceTracker, c.posFactors, c.negFactors, c.capacity)
+		c.peer.updateCapacity(c.capacity)
+	}
 	return 0, capacity, nil
 }
 

--- a/les/clientpool.go
+++ b/les/clientpool.go
@@ -243,7 +243,7 @@ func newClientPool(db ethdb.Database, minCap, freeClientCap uint64, clock mclock
 				pool.tryActivateClients()
 				for _, c := range pool.dropInactivePeers[pool.dropInactiveCounter] {
 					if _, ok := pool.connectedMap[c.id]; ok && !c.active && !c.priority {
-						pool.disconnect(c.peer)
+						pool.disconnectLocked(c.peer)
 					}
 				}
 				delete(pool.dropInactivePeers, pool.dropInactiveCounter)
@@ -406,6 +406,10 @@ func (f *clientPool) disconnect(p clientPeer) {
 	f.lock.Lock()
 	defer f.lock.Unlock()
 
+	f.disconnectLocked(p)
+}
+
+func (f *clientPool) disconnectLocked(p clientPeer) {
 	// Short circuit if client pool is already closed.
 	if f.closed {
 		return

--- a/les/clientpool_test.go
+++ b/les/clientpool_test.go
@@ -89,7 +89,7 @@ func testClientPool(t *testing.T, connLimit, clientCount, paidCount int, randomD
 		disconnFn = func(id enode.ID) {
 			disconnCh <- int(id[0]) + int(id[1])<<8
 		}
-		pool = newClientPool(db, 1, &clock, disconnFn)
+		pool = newClientPool(db, 1, 1, &clock, disconnFn)
 	)
 	pool.disableBias = true
 	pool.setLimits(connLimit, uint64(connLimit))
@@ -172,7 +172,7 @@ func TestConnectPaidClient(t *testing.T) {
 		clock mclock.Simulated
 		db    = rawdb.NewMemoryDatabase()
 	)
-	pool := newClientPool(db, 1, &clock, nil)
+	pool := newClientPool(db, 1, 1, &clock, nil)
 	defer pool.stop()
 	pool.setLimits(10, uint64(10))
 	pool.setDefaultFactors(priceFactors{1, 0, 1}, priceFactors{1, 0, 1})
@@ -190,7 +190,7 @@ func TestConnectPaidClientToSmallPool(t *testing.T) {
 		clock mclock.Simulated
 		db    = rawdb.NewMemoryDatabase()
 	)
-	pool := newClientPool(db, 1, &clock, nil)
+	pool := newClientPool(db, 1, 1, &clock, nil)
 	defer pool.stop()
 	pool.setLimits(10, uint64(10)) // Total capacity limit is 10
 	pool.setDefaultFactors(priceFactors{1, 0, 1}, priceFactors{1, 0, 1})
@@ -210,7 +210,7 @@ func TestConnectPaidClientToFullPool(t *testing.T) {
 		db    = rawdb.NewMemoryDatabase()
 	)
 	removeFn := func(enode.ID) {} // Noop
-	pool := newClientPool(db, 1, &clock, removeFn)
+	pool := newClientPool(db, 1, 1, &clock, removeFn)
 	defer pool.stop()
 	pool.setLimits(10, uint64(10)) // Total capacity limit is 10
 	pool.setDefaultFactors(priceFactors{1, 0, 1}, priceFactors{1, 0, 1})
@@ -237,7 +237,7 @@ func TestPaidClientKickedOut(t *testing.T) {
 		kickedCh = make(chan int, 1)
 	)
 	removeFn := func(id enode.ID) { kickedCh <- int(id[0]) }
-	pool := newClientPool(db, 1, &clock, removeFn)
+	pool := newClientPool(db, 1, 1, &clock, removeFn)
 	defer pool.stop()
 	pool.setLimits(10, uint64(10)) // Total capacity limit is 10
 	pool.setDefaultFactors(priceFactors{1, 0, 1}, priceFactors{1, 0, 1})
@@ -267,7 +267,7 @@ func TestConnectFreeClient(t *testing.T) {
 		clock mclock.Simulated
 		db    = rawdb.NewMemoryDatabase()
 	)
-	pool := newClientPool(db, 1, &clock, nil)
+	pool := newClientPool(db, 1, 1, &clock, nil)
 	defer pool.stop()
 	pool.setLimits(10, uint64(10))
 	pool.setDefaultFactors(priceFactors{1, 0, 1}, priceFactors{1, 0, 1})
@@ -282,7 +282,7 @@ func TestConnectFreeClientToFullPool(t *testing.T) {
 		db    = rawdb.NewMemoryDatabase()
 	)
 	removeFn := func(enode.ID) {} // Noop
-	pool := newClientPool(db, 1, &clock, removeFn)
+	pool := newClientPool(db, 1, 1, &clock, removeFn)
 	defer pool.stop()
 	pool.setLimits(10, uint64(10)) // Total capacity limit is 10
 	pool.setDefaultFactors(priceFactors{1, 0, 1}, priceFactors{1, 0, 1})
@@ -311,7 +311,7 @@ func TestFreeClientKickedOut(t *testing.T) {
 		kicked = make(chan int, 10)
 	)
 	removeFn := func(id enode.ID) { kicked <- int(id[0]) }
-	pool := newClientPool(db, 1, &clock, removeFn)
+	pool := newClientPool(db, 1, 1, &clock, removeFn)
 	defer pool.stop()
 	pool.setLimits(10, uint64(10)) // Total capacity limit is 10
 	pool.setDefaultFactors(priceFactors{1, 0, 1}, priceFactors{1, 0, 1})
@@ -346,7 +346,7 @@ func TestPositiveBalanceCalculation(t *testing.T) {
 		kicked = make(chan int, 10)
 	)
 	removeFn := func(id enode.ID) { kicked <- int(id[0]) } // Noop
-	pool := newClientPool(db, 1, &clock, removeFn)
+	pool := newClientPool(db, 1, 1, &clock, removeFn)
 	defer pool.stop()
 	pool.setLimits(10, uint64(10)) // Total capacity limit is 10
 	pool.setDefaultFactors(priceFactors{1, 0, 1}, priceFactors{1, 0, 1})
@@ -369,7 +369,7 @@ func TestDowngradePriorityClient(t *testing.T) {
 		kicked = make(chan int, 10)
 	)
 	removeFn := func(id enode.ID) { kicked <- int(id[0]) } // Noop
-	pool := newClientPool(db, 1, &clock, removeFn)
+	pool := newClientPool(db, 1, 1, &clock, removeFn)
 	defer pool.stop()
 	pool.setLimits(10, uint64(10)) // Total capacity limit is 10
 	pool.setDefaultFactors(priceFactors{1, 0, 1}, priceFactors{1, 0, 1})
@@ -407,7 +407,7 @@ func TestNegativeBalanceCalculation(t *testing.T) {
 		kicked = make(chan int, 10)
 	)
 	removeFn := func(id enode.ID) { kicked <- int(id[0]) } // Noop
-	pool := newClientPool(db, 1, &clock, removeFn)
+	pool := newClientPool(db, 1, 1, &clock, removeFn)
 	defer pool.stop()
 	pool.setLimits(10, uint64(10)) // Total capacity limit is 10
 	pool.setDefaultFactors(priceFactors{1, 0, 1}, priceFactors{1, 0, 1})

--- a/les/flowcontrol/control.go
+++ b/les/flowcontrol/control.go
@@ -185,6 +185,13 @@ func (node *ClientNode) UpdateParams(params ServerParams) {
 	}
 }
 
+func (node *ClientNode) Params() ServerParams {
+	node.lock.Lock()
+	defer node.lock.Unlock()
+
+	return node.params
+}
+
 // updateParams updates the flow control parameters of the node
 func (node *ClientNode) updateParams(params ServerParams, now mclock.AbsTime) {
 	diff := int64(params.BufLimit - node.params.BufLimit)

--- a/les/handler_test.go
+++ b/les/handler_test.go
@@ -38,17 +38,26 @@ import (
 	"github.com/ethereum/go-ethereum/trie"
 )
 
-func expectResponse(r p2p.MsgReader, msgcode, reqID, bv uint64, data interface{}) error {
+func expectResponse(r p2p.MsgReader, protocol int, msgcode, reqID, bv, cost uint64, data interface{}) error {
 	type resp struct {
-		ReqID, BV uint64
-		Data      interface{}
+		ReqID uint64
+		SF    stateFeedback
+		Data  interface{}
 	}
-	return p2p.ExpectMsg(r, msgcode, resp{reqID, bv, data})
+	sf := stateFeedback{
+		protocolVersion: protocol,
+		stateFeedbackV4: stateFeedbackV4{
+			BV:           bv,
+			RealCost:     cost,
+			TokenBalance: 0,
+		},
+	}
+	return p2p.ExpectMsg(r, msgcode, resp{reqID, sf, data})
 }
 
 // Tests that block headers can be retrieved from a remote chain based on user queries.
-func TestGetBlockHeadersLes2(t *testing.T) { testGetBlockHeaders(t, 2) }
 func TestGetBlockHeadersLes3(t *testing.T) { testGetBlockHeaders(t, 3) }
+func TestGetBlockHeadersLes4(t *testing.T) { testGetBlockHeaders(t, 4) }
 
 func testGetBlockHeaders(t *testing.T, protocol int) {
 	server, tearDown := newServerEnv(t, downloader.MaxHashFetch+15, protocol, nil, false, true, 0)
@@ -170,15 +179,15 @@ func testGetBlockHeaders(t *testing.T, protocol int) {
 
 		cost := server.peer.peer.GetRequestCost(GetBlockHeadersMsg, int(tt.query.Amount))
 		sendRequest(server.peer.app, GetBlockHeadersMsg, reqID, cost, tt.query)
-		if err := expectResponse(server.peer.app, BlockHeadersMsg, reqID, testBufLimit, headers); err != nil {
+		if err := expectResponse(server.peer.app, protocol, BlockHeadersMsg, reqID, testBufLimit, cost, headers); err != nil {
 			t.Errorf("test %d: headers mismatch: %v", i, err)
 		}
 	}
 }
 
 // Tests that block contents can be retrieved from a remote chain based on their hashes.
-func TestGetBlockBodiesLes2(t *testing.T) { testGetBlockBodies(t, 2) }
 func TestGetBlockBodiesLes3(t *testing.T) { testGetBlockBodies(t, 3) }
+func TestGetBlockBodiesLes4(t *testing.T) { testGetBlockBodies(t, 4) }
 
 func testGetBlockBodies(t *testing.T, protocol int) {
 	server, tearDown := newServerEnv(t, downloader.MaxBlockFetch+15, protocol, nil, false, true, 0)
@@ -248,15 +257,15 @@ func testGetBlockBodies(t *testing.T, protocol int) {
 		// Send the hash request and verify the response
 		cost := server.peer.peer.GetRequestCost(GetBlockBodiesMsg, len(hashes))
 		sendRequest(server.peer.app, GetBlockBodiesMsg, reqID, cost, hashes)
-		if err := expectResponse(server.peer.app, BlockBodiesMsg, reqID, testBufLimit, bodies); err != nil {
+		if err := expectResponse(server.peer.app, protocol, BlockBodiesMsg, reqID, testBufLimit, cost, bodies); err != nil {
 			t.Errorf("test %d: bodies mismatch: %v", i, err)
 		}
 	}
 }
 
 // Tests that the contract codes can be retrieved based on account addresses.
-func TestGetCodeLes2(t *testing.T) { testGetCode(t, 2) }
 func TestGetCodeLes3(t *testing.T) { testGetCode(t, 3) }
+func TestGetCodeLes4(t *testing.T) { testGetCode(t, 4) }
 
 func testGetCode(t *testing.T, protocol int) {
 	// Assemble the test environment
@@ -280,14 +289,14 @@ func testGetCode(t *testing.T, protocol int) {
 
 	cost := server.peer.peer.GetRequestCost(GetCodeMsg, len(codereqs))
 	sendRequest(server.peer.app, GetCodeMsg, 42, cost, codereqs)
-	if err := expectResponse(server.peer.app, CodeMsg, 42, testBufLimit, codes); err != nil {
+	if err := expectResponse(server.peer.app, protocol, CodeMsg, 42, testBufLimit, cost, codes); err != nil {
 		t.Errorf("codes mismatch: %v", err)
 	}
 }
 
 // Tests that the stale contract codes can't be retrieved based on account addresses.
-func TestGetStaleCodeLes2(t *testing.T) { testGetStaleCode(t, 2) }
 func TestGetStaleCodeLes3(t *testing.T) { testGetStaleCode(t, 3) }
+func TestGetStaleCodeLes4(t *testing.T) { testGetStaleCode(t, 4) }
 
 func testGetStaleCode(t *testing.T, protocol int) {
 	server, tearDown := newServerEnv(t, core.TriesInMemory+4, protocol, nil, false, true, 0)
@@ -301,7 +310,7 @@ func testGetStaleCode(t *testing.T, protocol int) {
 		}
 		cost := server.peer.peer.GetRequestCost(GetCodeMsg, 1)
 		sendRequest(server.peer.app, GetCodeMsg, 42, cost, []*CodeReq{req})
-		if err := expectResponse(server.peer.app, CodeMsg, 42, testBufLimit, expected); err != nil {
+		if err := expectResponse(server.peer.app, protocol, CodeMsg, 42, testBufLimit, cost, expected); err != nil {
 			t.Errorf("codes mismatch: %v", err)
 		}
 	}
@@ -311,8 +320,8 @@ func testGetStaleCode(t *testing.T, protocol int) {
 }
 
 // Tests that the transaction receipts can be retrieved based on hashes.
-func TestGetReceiptLes2(t *testing.T) { testGetReceipt(t, 2) }
 func TestGetReceiptLes3(t *testing.T) { testGetReceipt(t, 3) }
+func TestGetReceiptLes4(t *testing.T) { testGetReceipt(t, 4) }
 
 func testGetReceipt(t *testing.T, protocol int) {
 	// Assemble the test environment
@@ -333,14 +342,14 @@ func testGetReceipt(t *testing.T, protocol int) {
 	// Send the hash request and verify the response
 	cost := server.peer.peer.GetRequestCost(GetReceiptsMsg, len(hashes))
 	sendRequest(server.peer.app, GetReceiptsMsg, 42, cost, hashes)
-	if err := expectResponse(server.peer.app, ReceiptsMsg, 42, testBufLimit, receipts); err != nil {
+	if err := expectResponse(server.peer.app, protocol, ReceiptsMsg, 42, testBufLimit, cost, receipts); err != nil {
 		t.Errorf("receipts mismatch: %v", err)
 	}
 }
 
 // Tests that trie merkle proofs can be retrieved
-func TestGetProofsLes2(t *testing.T) { testGetProofs(t, 2) }
 func TestGetProofsLes3(t *testing.T) { testGetProofs(t, 3) }
+func TestGetProofsLes4(t *testing.T) { testGetProofs(t, 4) }
 
 func testGetProofs(t *testing.T, protocol int) {
 	// Assemble the test environment
@@ -369,14 +378,14 @@ func testGetProofs(t *testing.T, protocol int) {
 	// Send the proof request and verify the response
 	cost := server.peer.peer.GetRequestCost(GetProofsV2Msg, len(proofreqs))
 	sendRequest(server.peer.app, GetProofsV2Msg, 42, cost, proofreqs)
-	if err := expectResponse(server.peer.app, ProofsV2Msg, 42, testBufLimit, proofsV2.NodeList()); err != nil {
+	if err := expectResponse(server.peer.app, protocol, ProofsV2Msg, 42, testBufLimit, cost, proofsV2.NodeList()); err != nil {
 		t.Errorf("proofs mismatch: %v", err)
 	}
 }
 
 // Tests that the stale contract codes can't be retrieved based on account addresses.
-func TestGetStaleProofLes2(t *testing.T) { testGetStaleProof(t, 2) }
 func TestGetStaleProofLes3(t *testing.T) { testGetStaleProof(t, 3) }
+func TestGetStaleProofLes4(t *testing.T) { testGetStaleProof(t, 4) }
 
 func testGetStaleProof(t *testing.T, protocol int) {
 	server, tearDown := newServerEnv(t, core.TriesInMemory+4, protocol, nil, false, true, 0)
@@ -402,7 +411,7 @@ func testGetStaleProof(t *testing.T, protocol int) {
 			t.Prove(account, 0, proofsV2)
 			expected = proofsV2.NodeList()
 		}
-		if err := expectResponse(server.peer.app, ProofsV2Msg, 42, testBufLimit, expected); err != nil {
+		if err := expectResponse(server.peer.app, protocol, ProofsV2Msg, 42, testBufLimit, cost, expected); err != nil {
 			t.Errorf("codes mismatch: %v", err)
 		}
 	}
@@ -412,8 +421,8 @@ func testGetStaleProof(t *testing.T, protocol int) {
 }
 
 // Tests that CHT proofs can be correctly retrieved.
-func TestGetCHTProofsLes2(t *testing.T) { testGetCHTProofs(t, 2) }
 func TestGetCHTProofsLes3(t *testing.T) { testGetCHTProofs(t, 3) }
+func TestGetCHTProofsLes4(t *testing.T) { testGetCHTProofs(t, 4) }
 
 func testGetCHTProofs(t *testing.T, protocol int) {
 	config := light.TestServerIndexerConfig
@@ -455,13 +464,13 @@ func testGetCHTProofs(t *testing.T, protocol int) {
 	// Send the proof request and verify the response
 	cost := server.peer.peer.GetRequestCost(GetHelperTrieProofsMsg, len(requestsV2))
 	sendRequest(server.peer.app, GetHelperTrieProofsMsg, 42, cost, requestsV2)
-	if err := expectResponse(server.peer.app, HelperTrieProofsMsg, 42, testBufLimit, proofsV2); err != nil {
+	if err := expectResponse(server.peer.app, protocol, HelperTrieProofsMsg, 42, testBufLimit, cost, proofsV2); err != nil {
 		t.Errorf("proofs mismatch: %v", err)
 	}
 }
 
-func TestGetBloombitsProofsLes2(t *testing.T) { testGetBloombitsProofs(t, 2) }
 func TestGetBloombitsProofsLes3(t *testing.T) { testGetBloombitsProofs(t, 3) }
+func TestGetBloombitsProofsLes4(t *testing.T) { testGetBloombitsProofs(t, 4) }
 
 // Tests that bloombits proofs can be correctly retrieved.
 func testGetBloombitsProofs(t *testing.T, protocol int) {
@@ -504,14 +513,14 @@ func testGetBloombitsProofs(t *testing.T, protocol int) {
 		// Send the proof request and verify the response
 		cost := server.peer.peer.GetRequestCost(GetHelperTrieProofsMsg, len(requests))
 		sendRequest(server.peer.app, GetHelperTrieProofsMsg, 42, cost, requests)
-		if err := expectResponse(server.peer.app, HelperTrieProofsMsg, 42, testBufLimit, proofs); err != nil {
+		if err := expectResponse(server.peer.app, protocol, HelperTrieProofsMsg, 42, testBufLimit, cost, proofs); err != nil {
 			t.Errorf("bit %d: proofs mismatch: %v", bit, err)
 		}
 	}
 }
 
-func TestTransactionStatusLes2(t *testing.T) { testTransactionStatus(t, 2) }
 func TestTransactionStatusLes3(t *testing.T) { testTransactionStatus(t, 3) }
+func TestTransactionStatusLes4(t *testing.T) { testTransactionStatus(t, 4) }
 
 func testTransactionStatus(t *testing.T, protocol int) {
 	server, tearDown := newServerEnv(t, 0, protocol, nil, false, true, 0)
@@ -524,14 +533,15 @@ func testTransactionStatus(t *testing.T, protocol int) {
 
 	test := func(tx *types.Transaction, send bool, expStatus light.TxStatus) {
 		reqID++
+		var cost uint64
 		if send {
-			cost := server.peer.peer.GetRequestCost(SendTxV2Msg, 1)
+			cost = server.peer.peer.GetRequestCost(SendTxV2Msg, 1)
 			sendRequest(server.peer.app, SendTxV2Msg, reqID, cost, types.Transactions{tx})
 		} else {
-			cost := server.peer.peer.GetRequestCost(GetTxStatusMsg, 1)
+			cost = server.peer.peer.GetRequestCost(GetTxStatusMsg, 1)
 			sendRequest(server.peer.app, GetTxStatusMsg, reqID, cost, []common.Hash{tx.Hash()})
 		}
-		if err := expectResponse(server.peer.app, TxStatusMsg, reqID, testBufLimit, []light.TxStatus{expStatus}); err != nil {
+		if err := expectResponse(server.peer.app, protocol, TxStatusMsg, reqID, testBufLimit, cost, []light.TxStatus{expStatus}); err != nil {
 			t.Errorf("transaction status mismatch")
 		}
 	}
@@ -606,8 +616,11 @@ func testTransactionStatus(t *testing.T, protocol int) {
 	test(tx2, false, light.TxStatus{Status: core.TxStatusPending})
 }
 
-func TestStopResumeLes3(t *testing.T) {
-	server, tearDown := newServerEnv(t, 0, 3, nil, true, true, testBufLimit/10)
+func TestStopResumeLes3(t *testing.T) { testStopResume(t, 3) }
+func TestStopResumeLes4(t *testing.T) { testStopResume(t, 4) }
+
+func testStopResume(t *testing.T, protocol int) {
+	server, tearDown := newServerEnv(t, 0, protocol, nil, true, true, testBufLimit/10)
 	defer tearDown()
 
 	server.handler.server.costTracker.testing = true
@@ -627,7 +640,7 @@ func TestStopResumeLes3(t *testing.T) {
 		for expBuf >= testCost {
 			req()
 			expBuf -= testCost
-			if err := expectResponse(server.peer.app, BlockHeadersMsg, reqID, expBuf, []*types.Header{header}); err != nil {
+			if err := expectResponse(server.peer.app, protocol, BlockHeadersMsg, reqID, expBuf, testCost, []*types.Header{header}); err != nil {
 				t.Errorf("expected response and failed: %v", err)
 			}
 		}
@@ -646,7 +659,15 @@ func TestStopResumeLes3(t *testing.T) {
 
 		// expect a ResumeMsg with the partially recharged buffer value
 		expBuf += testBufRecharge * wait
-		if err := p2p.ExpectMsg(server.peer.app, ResumeMsg, expBuf); err != nil {
+		sf := stateFeedback{
+			protocolVersion: protocol,
+			stateFeedbackV4: stateFeedbackV4{
+				BV:           expBuf,
+				RealCost:     0,
+				TokenBalance: 0,
+			},
+		}
+		if err := p2p.ExpectMsg(server.peer.app, ResumeMsg, sf); err != nil {
 			t.Errorf("expected ResumeMsg and failed: %v", err)
 		}
 	}

--- a/les/handler_test.go
+++ b/les/handler_test.go
@@ -60,7 +60,7 @@ func TestGetBlockHeadersLes3(t *testing.T) { testGetBlockHeaders(t, 3) }
 func TestGetBlockHeadersLes4(t *testing.T) { testGetBlockHeaders(t, 4) }
 
 func testGetBlockHeaders(t *testing.T, protocol int) {
-	server, tearDown := newServerEnv(t, downloader.MaxHashFetch+15, protocol, nil, false, true, 0)
+	server, tearDown := newServerEnv(t, downloader.MaxHashFetch+15, protocol, nil, false, true, 0, true)
 	defer tearDown()
 
 	bc := server.handler.blockchain
@@ -190,7 +190,7 @@ func TestGetBlockBodiesLes3(t *testing.T) { testGetBlockBodies(t, 3) }
 func TestGetBlockBodiesLes4(t *testing.T) { testGetBlockBodies(t, 4) }
 
 func testGetBlockBodies(t *testing.T, protocol int) {
-	server, tearDown := newServerEnv(t, downloader.MaxBlockFetch+15, protocol, nil, false, true, 0)
+	server, tearDown := newServerEnv(t, downloader.MaxBlockFetch+15, protocol, nil, false, true, 0, true)
 	defer tearDown()
 
 	bc := server.handler.blockchain
@@ -269,7 +269,7 @@ func TestGetCodeLes4(t *testing.T) { testGetCode(t, 4) }
 
 func testGetCode(t *testing.T, protocol int) {
 	// Assemble the test environment
-	server, tearDown := newServerEnv(t, 4, protocol, nil, false, true, 0)
+	server, tearDown := newServerEnv(t, 4, protocol, nil, false, true, 0, true)
 	defer tearDown()
 	bc := server.handler.blockchain
 
@@ -299,7 +299,7 @@ func TestGetStaleCodeLes3(t *testing.T) { testGetStaleCode(t, 3) }
 func TestGetStaleCodeLes4(t *testing.T) { testGetStaleCode(t, 4) }
 
 func testGetStaleCode(t *testing.T, protocol int) {
-	server, tearDown := newServerEnv(t, core.TriesInMemory+4, protocol, nil, false, true, 0)
+	server, tearDown := newServerEnv(t, core.TriesInMemory+4, protocol, nil, false, true, 0, true)
 	defer tearDown()
 	bc := server.handler.blockchain
 
@@ -325,7 +325,7 @@ func TestGetReceiptLes4(t *testing.T) { testGetReceipt(t, 4) }
 
 func testGetReceipt(t *testing.T, protocol int) {
 	// Assemble the test environment
-	server, tearDown := newServerEnv(t, 4, protocol, nil, false, true, 0)
+	server, tearDown := newServerEnv(t, 4, protocol, nil, false, true, 0, true)
 	defer tearDown()
 
 	bc := server.handler.blockchain
@@ -353,7 +353,7 @@ func TestGetProofsLes4(t *testing.T) { testGetProofs(t, 4) }
 
 func testGetProofs(t *testing.T, protocol int) {
 	// Assemble the test environment
-	server, tearDown := newServerEnv(t, 4, protocol, nil, false, true, 0)
+	server, tearDown := newServerEnv(t, 4, protocol, nil, false, true, 0, true)
 	defer tearDown()
 
 	bc := server.handler.blockchain
@@ -388,7 +388,7 @@ func TestGetStaleProofLes3(t *testing.T) { testGetStaleProof(t, 3) }
 func TestGetStaleProofLes4(t *testing.T) { testGetStaleProof(t, 4) }
 
 func testGetStaleProof(t *testing.T, protocol int) {
-	server, tearDown := newServerEnv(t, core.TriesInMemory+4, protocol, nil, false, true, 0)
+	server, tearDown := newServerEnv(t, core.TriesInMemory+4, protocol, nil, false, true, 0, true)
 	defer tearDown()
 	bc := server.handler.blockchain
 
@@ -436,7 +436,7 @@ func testGetCHTProofs(t *testing.T, protocol int) {
 			time.Sleep(10 * time.Millisecond)
 		}
 	}
-	server, tearDown := newServerEnv(t, int(config.ChtSize+config.ChtConfirms), protocol, waitIndexers, false, true, 0)
+	server, tearDown := newServerEnv(t, int(config.ChtSize+config.ChtConfirms), protocol, waitIndexers, false, true, 0, true)
 	defer tearDown()
 
 	bc := server.handler.blockchain
@@ -485,7 +485,7 @@ func testGetBloombitsProofs(t *testing.T, protocol int) {
 			time.Sleep(10 * time.Millisecond)
 		}
 	}
-	server, tearDown := newServerEnv(t, int(config.BloomTrieSize+config.BloomTrieConfirms), protocol, waitIndexers, false, true, 0)
+	server, tearDown := newServerEnv(t, int(config.BloomTrieSize+config.BloomTrieConfirms), protocol, waitIndexers, false, true, 0, true)
 	defer tearDown()
 
 	bc := server.handler.blockchain
@@ -523,7 +523,7 @@ func TestTransactionStatusLes3(t *testing.T) { testTransactionStatus(t, 3) }
 func TestTransactionStatusLes4(t *testing.T) { testTransactionStatus(t, 4) }
 
 func testTransactionStatus(t *testing.T, protocol int) {
-	server, tearDown := newServerEnv(t, 0, protocol, nil, false, true, 0)
+	server, tearDown := newServerEnv(t, 0, protocol, nil, false, true, 0, true)
 	defer tearDown()
 	server.handler.addTxsSync = true
 
@@ -620,7 +620,7 @@ func TestStopResumeLes3(t *testing.T) { testStopResume(t, 3) }
 func TestStopResumeLes4(t *testing.T) { testStopResume(t, 4) }
 
 func testStopResume(t *testing.T, protocol int) {
-	server, tearDown := newServerEnv(t, 0, protocol, nil, true, true, testBufLimit/10)
+	server, tearDown := newServerEnv(t, 0, protocol, nil, true, true, testBufLimit/10, true)
 	defer tearDown()
 
 	server.handler.server.costTracker.testing = true

--- a/les/metrics.go
+++ b/les/metrics.go
@@ -40,6 +40,8 @@ var (
 	miscInTxsTrafficMeter        = metrics.NewRegisteredMeter("les/misc/in/traffic/txs", nil)
 	miscInTxStatusPacketsMeter   = metrics.NewRegisteredMeter("les/misc/in/packets/txStatus", nil)
 	miscInTxStatusTrafficMeter   = metrics.NewRegisteredMeter("les/misc/in/traffic/txStatus", nil)
+	miscInLespayPacketsMeter     = metrics.NewRegisteredMeter("les/misc/in/packets/lespay", nil)
+	miscInLespayTrafficMeter     = metrics.NewRegisteredMeter("les/misc/in/traffic/lespay", nil)
 
 	miscOutPacketsMeter           = metrics.NewRegisteredMeter("les/misc/out/packets/total", nil)
 	miscOutTrafficMeter           = metrics.NewRegisteredMeter("les/misc/out/traffic/total", nil)
@@ -59,6 +61,8 @@ var (
 	miscOutTxsTrafficMeter        = metrics.NewRegisteredMeter("les/misc/out/traffic/txs", nil)
 	miscOutTxStatusPacketsMeter   = metrics.NewRegisteredMeter("les/misc/out/packets/txStatus", nil)
 	miscOutTxStatusTrafficMeter   = metrics.NewRegisteredMeter("les/misc/out/traffic/txStatus", nil)
+	miscOutLespayPacketsMeter     = metrics.NewRegisteredMeter("les/misc/out/packets/lespay", nil)
+	miscOutLespayTrafficMeter     = metrics.NewRegisteredMeter("les/misc/out/traffic/lespay", nil)
 
 	miscServingTimeHeaderTimer     = metrics.NewRegisteredTimer("les/misc/serve/header", nil)
 	miscServingTimeBodyTimer       = metrics.NewRegisteredTimer("les/misc/serve/body", nil)
@@ -68,6 +72,7 @@ var (
 	miscServingTimeHelperTrieTimer = metrics.NewRegisteredTimer("les/misc/serve/helperTrie", nil)
 	miscServingTimeTxTimer         = metrics.NewRegisteredTimer("les/misc/serve/txs", nil)
 	miscServingTimeTxStatusTimer   = metrics.NewRegisteredTimer("les/misc/serve/txStatus", nil)
+	miscServingTimeLespayTimer     = metrics.NewRegisteredTimer("les/misc/serve/lespay", nil)
 
 	connectionTimer       = metrics.NewRegisteredTimer("les/connection/duration", nil)
 	serverConnectionGauge = metrics.NewRegisteredGauge("les/connection/server", nil)

--- a/les/odr_test.go
+++ b/les/odr_test.go
@@ -38,8 +38,8 @@ import (
 
 type odrTestFn func(ctx context.Context, db ethdb.Database, config *params.ChainConfig, bc *core.BlockChain, lc *light.LightChain, bhash common.Hash) []byte
 
-func TestOdrGetBlockLes2(t *testing.T) { testOdr(t, 2, 1, true, odrGetBlock) }
 func TestOdrGetBlockLes3(t *testing.T) { testOdr(t, 3, 1, true, odrGetBlock) }
+func TestOdrGetBlockLes4(t *testing.T) { testOdr(t, 4, 1, true, odrGetBlock) }
 
 func odrGetBlock(ctx context.Context, db ethdb.Database, config *params.ChainConfig, bc *core.BlockChain, lc *light.LightChain, bhash common.Hash) []byte {
 	var block *types.Block
@@ -55,8 +55,8 @@ func odrGetBlock(ctx context.Context, db ethdb.Database, config *params.ChainCon
 	return rlp
 }
 
-func TestOdrGetReceiptsLes2(t *testing.T) { testOdr(t, 2, 1, true, odrGetReceipts) }
 func TestOdrGetReceiptsLes3(t *testing.T) { testOdr(t, 3, 1, true, odrGetReceipts) }
+func TestOdrGetReceiptsLes4(t *testing.T) { testOdr(t, 4, 1, true, odrGetReceipts) }
 
 func odrGetReceipts(ctx context.Context, db ethdb.Database, config *params.ChainConfig, bc *core.BlockChain, lc *light.LightChain, bhash common.Hash) []byte {
 	var receipts types.Receipts
@@ -76,8 +76,8 @@ func odrGetReceipts(ctx context.Context, db ethdb.Database, config *params.Chain
 	return rlp
 }
 
-func TestOdrAccountsLes2(t *testing.T) { testOdr(t, 2, 1, true, odrAccounts) }
 func TestOdrAccountsLes3(t *testing.T) { testOdr(t, 3, 1, true, odrAccounts) }
+func TestOdrAccountsLes4(t *testing.T) { testOdr(t, 4, 1, true, odrAccounts) }
 
 func odrAccounts(ctx context.Context, db ethdb.Database, config *params.ChainConfig, bc *core.BlockChain, lc *light.LightChain, bhash common.Hash) []byte {
 	dummyAddr := common.HexToAddress("1234567812345678123456781234567812345678")
@@ -105,8 +105,8 @@ func odrAccounts(ctx context.Context, db ethdb.Database, config *params.ChainCon
 	return res
 }
 
-func TestOdrContractCallLes2(t *testing.T) { testOdr(t, 2, 2, true, odrContractCall) }
 func TestOdrContractCallLes3(t *testing.T) { testOdr(t, 3, 2, true, odrContractCall) }
+func TestOdrContractCallLes4(t *testing.T) { testOdr(t, 4, 2, true, odrContractCall) }
 
 type callmsg struct {
 	types.Message
@@ -155,8 +155,8 @@ func odrContractCall(ctx context.Context, db ethdb.Database, config *params.Chai
 	return res
 }
 
-func TestOdrTxStatusLes2(t *testing.T) { testOdr(t, 2, 1, false, odrTxStatus) }
 func TestOdrTxStatusLes3(t *testing.T) { testOdr(t, 3, 1, false, odrTxStatus) }
+func TestOdrTxStatusLes4(t *testing.T) { testOdr(t, 4, 1, false, odrTxStatus) }
 
 func odrTxStatus(ctx context.Context, db ethdb.Database, config *params.ChainConfig, bc *core.BlockChain, lc *light.LightChain, bhash common.Hash) []byte {
 	var txs types.Transactions

--- a/les/odr_test.go
+++ b/les/odr_test.go
@@ -236,7 +236,7 @@ func testOdr(t *testing.T, protocol int, expFail uint64, checkCached bool, fn od
 
 	// still expect all retrievals to pass, now data should be cached locally
 	if checkCached {
-		client.handler.backend.peers.Unregister(client.peer.peer.id)
+		client.handler.backend.peers.Disconnect(client.peer.peer.id)
 		time.Sleep(time.Millisecond * 10) // ensure that all peerSetNotify callbacks are executed
 		test(5)
 	}

--- a/les/peer.go
+++ b/les/peer.go
@@ -502,15 +502,15 @@ func (p *peer) SendTxs(reqID, cost uint64, txs rlp.RawValue) error {
 }
 
 // SendLespay sends a set of commands to the service token sale module
-func (p *peer) SendLespay(reqID uint64, cmds [][]byte) error {
-	p.Log().Debug("Sending batch of lespay commands", "size", len(cmds))
-	return sendRequest(p.rw, LespayMsg, reqID, 0, cmds)
+func (p *peer) SendLespay(reqID uint64, cmd []byte) error {
+	p.Log().Debug("Sending batch of lespay commands", "size", len(cmd))
+	return sendRequest(p.rw, LespayMsg, reqID, 0, cmd)
 }
 
 // ReplyLespay sends a set of replies to lespay commands
-func (p *peer) ReplyLespay(reqID uint64, replies [][]byte) error {
-	p.Log().Debug("Sending batch of lespay replies", "size", len(replies))
-	return sendRequest(p.rw, LespayReplyMsg, reqID, 0, replies)
+func (p *peer) ReplyLespay(reqID uint64, reply []byte) error {
+	p.Log().Debug("Sending batch of lespay replies", "size", len(reply))
+	return sendRequest(p.rw, LespayReplyMsg, reqID, 0, reply)
 }
 
 type keyValueEntry struct {

--- a/les/peer.go
+++ b/les/peer.go
@@ -501,6 +501,18 @@ func (p *peer) SendTxs(reqID, cost uint64, txs rlp.RawValue) error {
 	return sendRequest(p.rw, SendTxV2Msg, reqID, cost, txs)
 }
 
+// SendLespay sends a set of commands to the service token sale module
+func (p *peer) SendLespay(reqID uint64, cmds [][]byte) error {
+	p.Log().Debug("Sending batch of lespay commands", "size", len(cmds))
+	return sendRequest(p.rw, LespayMsg, reqID, 0, cmds)
+}
+
+// ReplyLespay sends a set of replies to lespay commands
+func (p *peer) ReplyLespay(reqID uint64, replies [][]byte) error {
+	p.Log().Debug("Sending batch of lespay replies", "size", len(replies))
+	return sendRequest(p.rw, LespayReplyMsg, reqID, 0, replies)
+}
+
 type keyValueEntry struct {
 	Key   string
 	Value rlp.RawValue

--- a/les/peer.go
+++ b/les/peer.go
@@ -101,6 +101,9 @@ type peer struct {
 	responseCount uint64
 	invalidCount  uint32
 
+	active               bool
+	activate, deactivate func()
+
 	poolEntry      *poolEntry
 	hasBlock       func(common.Hash, uint64, bool) bool
 	responseErrors int
@@ -297,12 +300,20 @@ func (p *peer) updateCapacity(cap uint64) {
 	p.responseLock.Lock()
 	defer p.responseLock.Unlock()
 
-	p.fcParams = flowcontrol.ServerParams{MinRecharge: cap, BufLimit: cap * bufLimitRatio}
-	p.fcClient.UpdateParams(p.fcParams)
-	var kvList keyValueList
-	kvList = kvList.add("flowControl/MRR", cap)
-	kvList = kvList.add("flowControl/BL", cap*bufLimitRatio)
-	p.queueSend(func() { p.SendAnnounce(announceData{Update: kvList}) })
+	if !p.active && cap != 0 && p.activate != nil {
+		p.activate()
+	}
+	if cap != 0 || p.version >= lpv4 {
+		p.fcParams = flowcontrol.ServerParams{MinRecharge: cap, BufLimit: cap * bufLimitRatio}
+		p.fcClient.UpdateParams(p.fcParams)
+		var kvList keyValueList
+		kvList = kvList.add("flowControl/BL", cap*bufLimitRatio)
+		kvList = kvList.add("flowControl/MRR", cap)
+		p.queueSend(func() { p.SendAnnounce(announceData{Update: kvList}) })
+	}
+	if p.active && cap == 0 && p.deactivate != nil {
+		p.deactivate()
+	}
 }
 
 func (p *peer) responseID() uint64 {
@@ -628,8 +639,15 @@ func (p *peer) Handshake(td *big.Int, head common.Hash, headNum uint64, genesis 
 			send = send.add("serveRecentState", stateRecent)
 			send = send.add("txRelay", nil)
 		}
-		send = send.add("flowControl/BL", server.defParams.BufLimit)
-		send = send.add("flowControl/MRR", server.defParams.MinRecharge)
+
+		p.active = p.version < lpv4
+		if p.active {
+			p.fcParams = server.defParams
+		} else {
+			p.fcParams = flowcontrol.ServerParams{}
+		}
+		send = send.add("flowControl/BL", p.fcParams.BufLimit)
+		send = send.add("flowControl/MRR", p.fcParams.MinRecharge)
 
 		var costList RequestCostList
 		if server.costTracker.testCostList != nil {
@@ -639,7 +657,6 @@ func (p *peer) Handshake(td *big.Int, head common.Hash, headNum uint64, genesis 
 		}
 		send = send.add("flowControl/MRC", costList)
 		p.fcCosts = costList.decode(ProtocolLengths[uint(p.version)])
-		p.fcParams = server.defParams
 
 		// Add advertised checkpoint and register block height which
 		// client can verify the checkpoint validity.
@@ -710,7 +727,7 @@ func (p *peer) Handshake(td *big.Int, head common.Hash, headNum uint64, genesis 
 				// set default announceType on server side
 				p.announceType = announceTypeSimple
 			}
-			p.fcClient = flowcontrol.NewClientNode(server.fcManager, server.defParams)
+			p.fcClient = flowcontrol.NewClientNode(server.fcManager, p.fcParams)
 		}
 	} else {
 		if recv.get("serveChainSince", &p.chainSince) != nil {
@@ -747,6 +764,7 @@ func (p *peer) Handshake(td *big.Int, head common.Hash, headNum uint64, genesis 
 		p.fcParams = sParams
 		p.fcServer = flowcontrol.NewServerNode(sParams, &mclock.System{})
 		p.fcCosts = MRC.decode(ProtocolLengths[uint(p.version)])
+		p.active = p.paramsUseful()
 
 		recv.get("checkpoint/value", &p.checkpoint)
 		recv.get("checkpoint/registerHeight", &p.checkpointNumber)
@@ -772,10 +790,12 @@ func (p *peer) updateFlowControl(update keyValueMap) {
 	}
 	// If any of the flow control params is nil, refuse to update.
 	var params flowcontrol.ServerParams
+	updated := false
 	if update.get("flowControl/BL", &params.BufLimit) == nil && update.get("flowControl/MRR", &params.MinRecharge) == nil {
 		// todo can light client set a minimal acceptable flow control params?
 		p.fcParams = params
 		p.fcServer.UpdateParams(params)
+		updated = true
 	}
 	var MRC RequestCostList
 	if update.get("flowControl/MRC", &MRC) == nil {
@@ -783,7 +803,16 @@ func (p *peer) updateFlowControl(update keyValueMap) {
 		for code, cost := range costUpdate {
 			p.fcCosts[code] = cost
 		}
+		updated = true
 	}
+	if updated {
+		p.active = p.paramsUseful()
+	}
+}
+
+func (p *peer) paramsUseful() bool {
+	reqRecharge, reqBufLimit := p.fcCosts.reqParams()
+	return p.fcParams.MinRecharge >= reqRecharge && p.fcParams.BufLimit >= reqBufLimit
 }
 
 // String implements fmt.Stringer.
@@ -803,16 +832,17 @@ type peerSetNotify interface {
 // peerSet represents the collection of active peers currently participating in
 // the Light Ethereum sub-protocol.
 type peerSet struct {
-	peers      map[string]*peer
-	lock       sync.RWMutex
-	notifyList []peerSetNotify
-	closed     bool
+	active, inactive map[string]*peer
+	lock             sync.RWMutex
+	notifyList       []peerSetNotify
+	closed           bool
 }
 
 // newPeerSet creates a new peer set to track the active participants.
 func newPeerSet() *peerSet {
 	return &peerSet{
-		peers: make(map[string]*peer),
+		active:   make(map[string]*peer),
+		inactive: make(map[string]*peer),
 	}
 }
 
@@ -820,8 +850,8 @@ func newPeerSet() *peerSet {
 func (ps *peerSet) notify(n peerSetNotify) {
 	ps.lock.Lock()
 	ps.notifyList = append(ps.notifyList, n)
-	peers := make([]*peer, 0, len(ps.peers))
-	for _, p := range ps.peers {
+	peers := make([]*peer, 0, len(ps.active))
+	for _, p := range ps.active {
 		peers = append(peers, p)
 	}
 	ps.lock.Unlock()
@@ -839,11 +869,13 @@ func (ps *peerSet) Register(p *peer) error {
 		ps.lock.Unlock()
 		return errClosed
 	}
-	if _, ok := ps.peers[p.id]; ok {
+	if _, ok := ps.active[p.id]; ok {
 		ps.lock.Unlock()
 		return errAlreadyRegistered
 	}
-	ps.peers[p.id] = p
+	ps.active[p.id] = p
+	delete(ps.inactive, p.id)
+
 	p.sendQueue = newExecQueue(100)
 	peers := make([]peerSetNotify, len(ps.notifyList))
 	copy(peers, ps.notifyList)
@@ -856,14 +888,15 @@ func (ps *peerSet) Register(p *peer) error {
 }
 
 // Unregister removes a remote peer from the active set, disabling any further
-// actions to/from that particular entity. It also initiates disconnection at the networking layer.
-func (ps *peerSet) Unregister(id string) error {
+// actions to/from that particular entity.
+func (ps *peerSet) Unregister(p *peer) error {
 	ps.lock.Lock()
-	if p, ok := ps.peers[id]; !ok {
+	if _, ok := ps.active[p.id]; !ok {
 		ps.lock.Unlock()
 		return errNotRegistered
 	} else {
-		delete(ps.peers, id)
+		delete(ps.active, p.id)
+		ps.inactive[p.id] = p
 		peers := make([]peerSetNotify, len(ps.notifyList))
 		copy(peers, ps.notifyList)
 		ps.lock.Unlock()
@@ -871,22 +904,38 @@ func (ps *peerSet) Unregister(id string) error {
 		for _, n := range peers {
 			n.unregisterPeer(p)
 		}
-
 		p.sendQueue.quit()
-		p.Peer.Disconnect(p2p.DiscUselessPeer)
-
 		return nil
 	}
 }
 
-// AllPeerIDs returns a list of all registered peer IDs
+// Disconnect removes a remote peer from either the active or inactive set and
+// initiates disconnection at the networking layer.
+func (ps *peerSet) Disconnect(id string) error {
+	ps.lock.Lock()
+	p, ok := ps.active[id]
+	if ok {
+		delete(ps.active, id)
+	} else {
+		if p, ok = ps.inactive[id]; !ok {
+			ps.lock.Unlock()
+			return errNotRegistered
+		}
+		delete(ps.inactive, id)
+	}
+	ps.lock.Unlock()
+	p.Peer.Disconnect(p2p.DiscUselessPeer)
+	return nil
+}
+
+// AllPeerIDs returns a list of all active peer IDs
 func (ps *peerSet) AllPeerIDs() []string {
 	ps.lock.RLock()
 	defer ps.lock.RUnlock()
 
-	res := make([]string, len(ps.peers))
+	res := make([]string, len(ps.active))
 	idx := 0
-	for id := range ps.peers {
+	for id := range ps.active {
 		res[idx] = id
 		idx++
 	}
@@ -898,15 +947,18 @@ func (ps *peerSet) Peer(id string) *peer {
 	ps.lock.RLock()
 	defer ps.lock.RUnlock()
 
-	return ps.peers[id]
+	if p, ok := ps.active[id]; ok {
+		return p
+	}
+	return ps.inactive[id]
 }
 
-// Len returns if the current number of peers in the set.
+// Len returns if the current number of peers in the active set.
 func (ps *peerSet) Len() int {
 	ps.lock.RLock()
 	defer ps.lock.RUnlock()
 
-	return len(ps.peers)
+	return len(ps.active)
 }
 
 // BestPeer retrieves the known peer with the currently highest total difficulty.
@@ -918,7 +970,7 @@ func (ps *peerSet) BestPeer() *peer {
 		bestPeer *peer
 		bestTd   *big.Int
 	)
-	for _, p := range ps.peers {
+	for _, p := range ps.active {
 		if td := p.Td(); bestPeer == nil || td.Cmp(bestTd) > 0 {
 			bestPeer, bestTd = p, td
 		}
@@ -926,14 +978,14 @@ func (ps *peerSet) BestPeer() *peer {
 	return bestPeer
 }
 
-// AllPeers returns all peers in a list
+// AllPeers returns all active peers in a list
 func (ps *peerSet) AllPeers() []*peer {
 	ps.lock.RLock()
 	defer ps.lock.RUnlock()
 
-	list := make([]*peer, len(ps.peers))
+	list := make([]*peer, len(ps.active))
 	i := 0
-	for _, peer := range ps.peers {
+	for _, peer := range ps.active {
 		list[i] = peer
 		i++
 	}
@@ -946,7 +998,10 @@ func (ps *peerSet) Close() {
 	ps.lock.Lock()
 	defer ps.lock.Unlock()
 
-	for _, p := range ps.peers {
+	for _, p := range ps.active {
+		p.Disconnect(p2p.DiscQuitting)
+	}
+	for _, p := range ps.inactive {
 		p.Disconnect(p2p.DiscQuitting)
 	}
 	ps.closed = true

--- a/les/protocol.go
+++ b/les/protocol.go
@@ -239,3 +239,28 @@ func (hn *hashOrNumber) DecodeRLP(s *rlp.Stream) error {
 type CodeData []struct {
 	Value []byte
 }
+
+type stateFeedbackV4 struct {
+	BV, RealCost, TokenBalance uint64
+}
+
+type stateFeedback struct {
+	protocolVersion int
+	stateFeedbackV4
+}
+
+func (sf stateFeedback) EncodeRLP(w io.Writer) error {
+	if sf.protocolVersion >= lpv4 {
+		return rlp.Encode(w, sf.stateFeedbackV4)
+	} else {
+		return rlp.Encode(w, sf.BV)
+	}
+}
+
+func (sf *stateFeedback) DecodeRLP(s *rlp.Stream) error {
+	if sf.protocolVersion >= lpv4 {
+		return s.Decode(&sf.stateFeedbackV4)
+	} else {
+		return s.Decode(&sf.BV)
+	}
+}

--- a/les/protocol.go
+++ b/les/protocol.go
@@ -33,17 +33,18 @@ import (
 const (
 	lpv2 = 2
 	lpv3 = 3
+	lpv4 = 4
 )
 
 // Supported versions of the les protocol (first is primary)
 var (
-	ClientProtocolVersions    = []uint{lpv2, lpv3}
-	ServerProtocolVersions    = []uint{lpv2, lpv3}
+	ClientProtocolVersions    = []uint{lpv2, lpv3, lpv4}
+	ServerProtocolVersions    = []uint{lpv2, lpv3, lpv4}
 	AdvertiseProtocolVersions = []uint{lpv2} // clients are searching for the first advertised protocol in the list
 )
 
 // Number of implemented message corresponding to different protocol versions.
-var ProtocolLengths = map[uint]uint64{lpv2: 22, lpv3: 24}
+var ProtocolLengths = map[uint]uint64{lpv2: 22, lpv3: 24, lpv4: 26}
 
 const (
 	NetworkId          = 1
@@ -74,6 +75,9 @@ const (
 	// Protocol messages introduced in LPV3
 	StopMsg   = 0x16
 	ResumeMsg = 0x17
+	// Protocol messages introduced in LPV4
+	LespayMsg      = 0x18
+	LespayReplyMsg = 0x19
 )
 
 type requestInfo struct {

--- a/les/request_test.go
+++ b/les/request_test.go
@@ -36,22 +36,22 @@ func secAddr(addr common.Address) []byte {
 
 type accessTestFn func(db ethdb.Database, bhash common.Hash, number uint64) light.OdrRequest
 
-func TestBlockAccessLes2(t *testing.T) { testAccess(t, 2, tfBlockAccess) }
 func TestBlockAccessLes3(t *testing.T) { testAccess(t, 3, tfBlockAccess) }
+func TestBlockAccessLes4(t *testing.T) { testAccess(t, 4, tfBlockAccess) }
 
 func tfBlockAccess(db ethdb.Database, bhash common.Hash, number uint64) light.OdrRequest {
 	return &light.BlockRequest{Hash: bhash, Number: number}
 }
 
-func TestReceiptsAccessLes2(t *testing.T) { testAccess(t, 2, tfReceiptsAccess) }
 func TestReceiptsAccessLes3(t *testing.T) { testAccess(t, 3, tfReceiptsAccess) }
+func TestReceiptsAccessLes4(t *testing.T) { testAccess(t, 4, tfReceiptsAccess) }
 
 func tfReceiptsAccess(db ethdb.Database, bhash common.Hash, number uint64) light.OdrRequest {
 	return &light.ReceiptsRequest{Hash: bhash, Number: number}
 }
 
-func TestTrieEntryAccessLes2(t *testing.T) { testAccess(t, 2, tfTrieEntryAccess) }
 func TestTrieEntryAccessLes3(t *testing.T) { testAccess(t, 3, tfTrieEntryAccess) }
+func TestTrieEntryAccessLes4(t *testing.T) { testAccess(t, 4, tfTrieEntryAccess) }
 
 func tfTrieEntryAccess(db ethdb.Database, bhash common.Hash, number uint64) light.OdrRequest {
 	if number := rawdb.ReadHeaderNumber(db, bhash); number != nil {
@@ -60,8 +60,8 @@ func tfTrieEntryAccess(db ethdb.Database, bhash common.Hash, number uint64) ligh
 	return nil
 }
 
-func TestCodeAccessLes2(t *testing.T) { testAccess(t, 2, tfCodeAccess) }
 func TestCodeAccessLes3(t *testing.T) { testAccess(t, 3, tfCodeAccess) }
+func TestCodeAccessLes4(t *testing.T) { testAccess(t, 4, tfCodeAccess) }
 
 func tfCodeAccess(db ethdb.Database, bhash common.Hash, num uint64) light.OdrRequest {
 	number := rawdb.ReadHeaderNumber(db, bhash)

--- a/les/retrieve.go
+++ b/les/retrieve.go
@@ -345,7 +345,7 @@ func (r *sentReq) tryRequest() {
 		if hrto {
 			pp.Log().Debug("Request timed out hard")
 			if r.rm.peers != nil {
-				r.rm.peers.Unregister(pp.id)
+				r.rm.peers.Disconnect(pp.id)
 			}
 		}
 

--- a/les/server.go
+++ b/les/server.go
@@ -114,7 +114,7 @@ func NewLesServer(e *eth.Ethereum, config *eth.Config) (*LesServer, error) {
 		srv.maxCapacity = totalRecharge
 	}
 	srv.fcManager.SetCapacityLimits(srv.freeCapacity, srv.maxCapacity, srv.freeCapacity*2)
-	srv.clientPool = newClientPool(srv.chainDb, srv.freeCapacity, mclock.System{}, func(id enode.ID) { go srv.peers.Unregister(peerIdToString(id)) })
+	srv.clientPool = newClientPool(srv.chainDb, srv.minCapacity, srv.freeCapacity, mclock.System{}, func(id enode.ID) { go srv.peers.Unregister(peerIdToString(id)) })
 	srv.clientPool.setDefaultFactors(priceFactors{0, 1, 1}, priceFactors{0, 1, 1})
 
 	checkpoint := srv.latestLocalCheckpoint()

--- a/les/server.go
+++ b/les/server.go
@@ -116,7 +116,7 @@ func NewLesServer(e *eth.Ethereum, config *eth.Config) (*LesServer, error) {
 		srv.maxCapacity = totalRecharge
 	}
 	srv.fcManager.SetCapacityLimits(srv.freeCapacity, srv.maxCapacity, srv.freeCapacity*2)
-	srv.clientPool = newClientPool(srv.chainDb, srv.minCapacity, srv.freeCapacity, mclock.System{}, func(id enode.ID) { go srv.peers.Unregister(peerIdToString(id)) })
+	srv.clientPool = newClientPool(srv.chainDb, srv.minCapacity, srv.freeCapacity, mclock.System{}, func(id enode.ID) { go srv.peers.Disconnect(peerIdToString(id)) })
 	srv.clientPool.setDefaultFactors(priceFactors{0, 1, 1}, priceFactors{0, 1, 1})
 	srv.tokenSale = newTokenSale(srv.clientPool, 0.1)
 

--- a/les/server.go
+++ b/les/server.go
@@ -50,6 +50,7 @@ type LesServer struct {
 	defParams    flowcontrol.ServerParams
 	servingQueue *servingQueue
 	clientPool   *clientPool
+	tokenSale    *tokenSale
 
 	minCapacity, maxCapacity, freeCapacity uint64
 	threadsIdle                            int // Request serving threads count when system is idle.

--- a/les/server.go
+++ b/les/server.go
@@ -118,6 +118,7 @@ func NewLesServer(e *eth.Ethereum, config *eth.Config) (*LesServer, error) {
 	srv.fcManager.SetCapacityLimits(srv.freeCapacity, srv.maxCapacity, srv.freeCapacity*2)
 	srv.clientPool = newClientPool(srv.chainDb, srv.minCapacity, srv.freeCapacity, mclock.System{}, func(id enode.ID) { go srv.peers.Unregister(peerIdToString(id)) })
 	srv.clientPool.setDefaultFactors(priceFactors{0, 1, 1}, priceFactors{0, 1, 1})
+	srv.tokenSale = newTokenSale(srv.clientPool, 0.1)
 
 	checkpoint := srv.latestLocalCheckpoint()
 	if !checkpoint.Empty() {

--- a/les/server.go
+++ b/les/server.go
@@ -149,6 +149,12 @@ func (s *LesServer) APIs() []rpc.API {
 			Service:   NewPrivateDebugAPI(s),
 			Public:    false,
 		},
+		{
+			Namespace: "lespay",
+			Version:   "1.0",
+			Service:   NewPrivateLespayAPI(s.lesCommons.peers, nil, s.srvr.DiscV5, s.tokenSale),
+			Public:    false,
+		},
 	}
 }
 

--- a/les/server.go
+++ b/les/server.go
@@ -176,7 +176,7 @@ func (s *LesServer) Start(srvr *p2p.Server) {
 	go s.capacityManagement()
 
 	if srvr.DiscV5 != nil {
-		srvr.DiscV5.RegisterTalkHandler("les", s.handler.talkRequestHandler)
+		srvr.DiscV5.RegisterTalkHandler("lespay", s.handler.talkRequestHandler)
 		for _, topic := range s.lesTopics {
 			topic := topic
 			go func() {
@@ -195,8 +195,9 @@ func (s *LesServer) Stop() {
 	close(s.closeCh)
 
 	if s.srvr.DiscV5 != nil {
-		s.srvr.DiscV5.RemoveTalkHandler("les")
+		s.srvr.DiscV5.RemoveTalkHandler("lespay")
 	}
+	s.tokenSale.stop()
 
 	// Disconnect existing sessions.
 	// This also closes the gate for any new registrations on the peer set.

--- a/les/server_handler.go
+++ b/les/server_handler.go
@@ -957,5 +957,5 @@ func (h *serverHandler) broadcastHeaders() {
 }
 
 func (h *serverHandler) talkRequestHandler(id enode.ID, addr *net.UDPAddr, payload []byte) ([]byte, bool) {
-	return payload, true
+	return payload, true // dummy handler, just returns the same payload
 }

--- a/les/server_handler.go
+++ b/les/server_handler.go
@@ -981,9 +981,9 @@ func (h *serverHandler) broadcastHeaders() {
 	}
 }
 
-func (h *serverHandler) talkRequestHandler(id enode.ID, addr *net.UDPAddr, payload []byte) ([]byte, bool) {
-	var cmds [][]byte
-	if err := rlp.DecodeBytes(payload, &cmds); err != nil {
+func (h *serverHandler) talkRequestHandler(id enode.ID, addr *net.UDPAddr, payload interface{}) (interface{}, bool) {
+	cmds, ok := payload.([][]byte)
+	if !ok {
 		return nil, false
 	}
 	results := h.server.tokenSale.runCommands(cmds, id, addr.IP.String())

--- a/les/server_handler.go
+++ b/les/server_handler.go
@@ -20,6 +20,7 @@ import (
 	"encoding/binary"
 	"encoding/json"
 	"errors"
+	"net"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -35,6 +36,7 @@ import (
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/metrics"
 	"github.com/ethereum/go-ethereum/p2p"
+	"github.com/ethereum/go-ethereum/p2p/enode"
 	"github.com/ethereum/go-ethereum/rlp"
 	"github.com/ethereum/go-ethereum/trie"
 )
@@ -952,4 +954,8 @@ func (h *serverHandler) broadcastHeaders() {
 			return
 		}
 	}
+}
+
+func (h *serverHandler) talkRequestHandler(id enode.ID, addr *net.UDPAddr, payload rlp.RawValue) (rlp.RawValue, bool) {
+	return payload, true
 }

--- a/les/server_handler.go
+++ b/les/server_handler.go
@@ -956,6 +956,6 @@ func (h *serverHandler) broadcastHeaders() {
 	}
 }
 
-func (h *serverHandler) talkRequestHandler(id enode.ID, addr *net.UDPAddr, payload rlp.RawValue) (rlp.RawValue, bool) {
+func (h *serverHandler) talkRequestHandler(id enode.ID, addr *net.UDPAddr, payload []byte) ([]byte, bool) {
 	return payload, true
 }

--- a/les/server_handler.go
+++ b/les/server_handler.go
@@ -835,21 +835,17 @@ func (h *serverHandler) handleMsg(p *peer, wg *sync.WaitGroup) error {
 		}
 		var req struct {
 			ReqID uint64
-			Cmds  [][]byte
+			Cmd   []byte
 		}
 		if err := msg.Decode(&req); err != nil {
 			clientErrorMeter.Mark(1)
 			return errResp(ErrDecode, "msg %v: %v", msg, err)
 		}
-		replies := h.server.tokenSale.runCommands(req.Cmds, p.ID(), p.freeClientId())
-		p.ReplyLespay(req.ReqID, replies)
+		reply := h.server.tokenSale.runCommand(req.Cmd, p.ID(), p.freeClientId())
+		p.ReplyLespay(req.ReqID, reply)
 		if metrics.EnabledExpensive {
 			miscOutLespayPacketsMeter.Mark(1)
-			var size int64
-			for _, r := range replies {
-				size += int64(len(r))
-			}
-			miscOutLespayTrafficMeter.Mark(size)
+			miscOutLespayTrafficMeter.Mark(int64(len(reply)))
 		}
 
 	default:

--- a/les/server_handler.go
+++ b/les/server_handler.go
@@ -957,5 +957,14 @@ func (h *serverHandler) broadcastHeaders() {
 }
 
 func (h *serverHandler) talkRequestHandler(id enode.ID, addr *net.UDPAddr, payload []byte) ([]byte, bool) {
-	return payload, true // dummy handler, just returns the same payload
+	if h.server.tokenSale == nil {
+		return nil, false
+	}
+	var cmds [][]byte
+	if err := rlp.DecodeBytes(payload, &cmds); err != nil {
+		return nil, false
+	}
+	results := h.server.tokenSale.runCommands(cmds, id, addr.IP.String())
+	res, _ := rlp.EncodeToBytes(&results)
+	return res, true
 }

--- a/les/servingqueue.go
+++ b/les/servingqueue.go
@@ -70,7 +70,7 @@ type runToken chan struct{}
 // start blocks until the task can start and returns true if it is allowed to run.
 // Returning false means that the task should be cancelled.
 func (t *servingTask) start() bool {
-	if t.peer.isFrozen() {
+	if t.peer != nil && t.peer.isFrozen() {
 		return false
 	}
 	t.tokenCh = make(chan runToken, 1)
@@ -289,7 +289,7 @@ func (sq *servingQueue) addTask(task *servingTask) {
 	sq.queuedTime += task.expTime
 	sqServedGauge.Update(int64(sq.recentTime))
 	sqQueuedGauge.Update(int64(sq.queuedTime))
-	if sq.recentTime+sq.queuedTime > sq.burstLimit {
+	if sq.burstLimit != 0 && sq.recentTime+sq.queuedTime > sq.burstLimit {
 		sq.freezePeers()
 	}
 }

--- a/les/test_helper.go
+++ b/les/test_helper.go
@@ -280,7 +280,7 @@ func newTestServerHandler(blocks int, indexers []*core.ChainIndexer, db ethdb.Da
 	}
 	server.costTracker, server.freeCapacity = newCostTracker(db, server.config)
 	server.costTracker.testCostList = testCostList(0) // Disable flow control mechanism.
-	server.clientPool = newClientPool(db, 1, clock, nil)
+	server.clientPool = newClientPool(db, 1, 1, clock, nil)
 	server.clientPool.setLimits(10000, 10000) // Assign enough capacity for clientpool
 	server.handler = newServerHandler(server, simulation.Blockchain(), db, txpool, func() bool { return true })
 	if server.oracle != nil {

--- a/les/test_helper.go
+++ b/les/test_helper.go
@@ -77,10 +77,10 @@ var (
 	processConfirms = big.NewInt(1)
 
 	// The token bucket buffer limit for testing purpose.
-	testBufLimit = uint64(1000000)
+	testBufLimit = uint64(6000)
 
 	// The buffer recharging speed for testing purpose.
-	testBufRecharge = uint64(1000)
+	testBufRecharge = uint64(1)
 )
 
 /*
@@ -393,8 +393,13 @@ func (p *testPeer) handshake(t *testing.T, td *big.Int, head common.Hash, headNu
 	expList = expList.add("serveStateSince", uint64(0))
 	expList = expList.add("serveRecentState", uint64(core.TriesInMemory-4))
 	expList = expList.add("txRelay", nil)
-	expList = expList.add("flowControl/BL", testBufLimit)
-	expList = expList.add("flowControl/MRR", testBufRecharge)
+	if p.peer.version >= lpv4 {
+		expList = expList.add("flowControl/BL", uint64(0))
+		expList = expList.add("flowControl/MRR", uint64(0))
+	} else {
+		expList = expList.add("flowControl/BL", testBufLimit)
+		expList = expList.add("flowControl/MRR", testBufRecharge)
+	}
 	expList = expList.add("flowControl/MRC", costList)
 
 	if err := p2p.ExpectMsg(p.app, StatusMsg, expList); err != nil {
@@ -403,9 +408,16 @@ func (p *testPeer) handshake(t *testing.T, td *big.Int, head common.Hash, headNu
 	if err := p2p.Send(p.app, StatusMsg, sendList); err != nil {
 		t.Fatalf("status send: %v", err)
 	}
-	p.peer.fcParams = flowcontrol.ServerParams{
-		BufLimit:    testBufLimit,
-		MinRecharge: testBufRecharge,
+}
+
+func (p *testPeer) expectCapUpdate(t *testing.T) {
+	if p.peer.version >= lpv4 {
+		var expList keyValueList
+		expList = expList.add("flowControl/BL", testBufLimit)
+		expList = expList.add("flowControl/MRR", testBufRecharge)
+		if err := p2p.ExpectMsg(p.app, AnnounceMsg, announceData{Update: expList}); err != nil {
+			t.Fatalf("status recv: %v", err)
+		}
 	}
 }
 
@@ -436,7 +448,7 @@ type testServer struct {
 	bloomTrieIndexer *core.ChainIndexer
 }
 
-func newServerEnv(t *testing.T, blocks int, protocol int, callback indexerCallback, simClock bool, newPeer bool, testCost uint64) (*testServer, func()) {
+func newServerEnv(t *testing.T, blocks int, protocol int, callback indexerCallback, simClock bool, newPeer bool, testCost uint64, expectCapUpdate bool) (*testServer, func()) {
 	db := rawdb.NewMemoryDatabase()
 	indexers := testIndexers(db, nil, light.TestServerIndexerConfig)
 
@@ -476,6 +488,9 @@ func newServerEnv(t *testing.T, blocks int, protocol int, callback indexerCallba
 		}
 		cIndexer.Close()
 		bIndexer.Close()
+	}
+	if expectCapUpdate {
+		server.peer.expectCapUpdate(t)
 	}
 	return server, teardown
 }

--- a/les/tokensale.go
+++ b/les/tokensale.go
@@ -1,0 +1,409 @@
+// Copyright 2019 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+package les
+
+import (
+	"fmt"
+	"io"
+	"math"
+	"sync"
+	"time"
+
+	"github.com/ethereum/go-ethereum/p2p/enode"
+	"github.com/ethereum/go-ethereum/rlp"
+)
+
+const basePriceTC = time.Hour * 10
+
+type paymentReceiver interface {
+	info() []byte
+	receivePayment(from enode.ID, proofOfPayment, oldMeta []byte) (value uint64, newMeta []byte, err error)
+	requestPayment(from enode.ID, value uint64, meta []byte) uint64
+}
+
+type tokenSale struct {
+	lock                    sync.Mutex
+	clientPool              *clientPool
+	stopCh                  chan struct{}
+	receivers               map[string]paymentReceiver
+	basePrice, minBasePrice float64
+}
+
+func newTokenSale(clientPool *clientPool, minBasePrice float64) *tokenSale {
+	t := &tokenSale{
+		clientPool:   clientPool,
+		receivers:    make(map[string]paymentReceiver),
+		basePrice:    minBasePrice,
+		minBasePrice: minBasePrice,
+		stopCh:       make(chan struct{}),
+	}
+	go func() {
+		for {
+			select {
+			case <-time.After(time.Second * 10):
+				t.lock.Lock()
+				cost, ok := t.tokenCost(1)
+				if cost > t.basePrice*10 || !ok {
+					cost = t.basePrice * 10
+				}
+				t.basePrice += (cost - t.basePrice) * float64(time.Second*10) / float64(basePriceTC)
+				if t.basePrice < minBasePrice {
+					t.basePrice = minBasePrice
+				}
+				t.lock.Unlock()
+			case <-t.stopCh:
+				return
+			}
+		}
+	}()
+	return t
+}
+
+func (t *tokenSale) stop() {
+	close(t.stopCh)
+}
+
+func (t *tokenSale) tokenCost(buyAmount uint64) (float64, bool) {
+	tokenLimit := t.clientPool.totalTokenLimit()
+	tokenAmount := t.clientPool.totalTokenAmount()
+	if tokenAmount+buyAmount >= tokenLimit {
+		return 0, false
+	}
+	r := float64(tokenAmount) / float64(tokenLimit)
+	b := float64(buyAmount) / float64(tokenLimit)
+	var relCost float64
+	if r < 0.5 {
+		if r+b <= 0.5 {
+			relCost = b * (r + r + b)
+			b = 0
+		} else {
+			relCost = (0.5 - r) * (r + 0.5)
+			b = r + b - 0.5
+			r = 0.5
+		}
+	}
+	if b > 0 {
+		l := 1 - r
+		if l < 1e-10 {
+			return 0, false
+		}
+		l = -b / l
+		if l < -1+1e-10 {
+			return 0, false
+		}
+		relCost += -math.Log1p(l) / 2
+
+	}
+	return t.basePrice * float64(tokenLimit) * relCost, true
+}
+
+func (t *tokenSale) tokensFor(maxCost uint64) uint64 {
+	tokenLimit := t.clientPool.totalTokenLimit()
+	tokenAmount := t.clientPool.totalTokenAmount()
+	if tokenLimit <= tokenAmount {
+		return 0
+	}
+	r := float64(tokenAmount) / float64(tokenLimit)
+	c := float64(maxCost) / (t.basePrice * float64(tokenLimit))
+	var relTokens float64
+	if r < 0.5 {
+		relTokens = math.Sqrt(r*r+c) - r
+		if r+relTokens <= 0.5 {
+			c = 0
+		} else {
+			relTokens = 0.5 - r
+			c -= (0.5 - r) * (r + 0.5)
+		}
+	}
+	if c > 0 {
+		relTokens += -math.Expm1(-2*c) * (1 - r)
+	}
+	return uint64(relTokens * float64(tokenLimit))
+}
+
+func (t *tokenSale) connection(id enode.ID, freeID string, requestedCapacity uint64, stayConnected time.Duration, paymentModule []string, setCap bool) (availableCapacity, tokenBalance, tokensMissing, pcBalance, pcMissing uint64, paymentRequired []uint64, err error) {
+	t.lock.Lock()
+	defer t.lock.Unlock()
+
+	tokensMissing, availableCapacity, err = t.clientPool.setCapacityLocked(id, freeID, requestedCapacity, stayConnected, setCap)
+	pb := t.clientPool.getPosBalance(id)
+	tokenBalance = pb.value
+	var meta tokenSaleMeta
+	if err := rlp.DecodeBytes([]byte(pb.meta), &meta); err == nil {
+		pcBalance = meta.pcBalance
+	}
+	if tokensMissing == 0 {
+		return
+	}
+	tokenLimit := t.clientPool.totalTokenLimit()
+	tokenAmount := t.clientPool.totalTokenAmount()
+	if tokenLimit <= tokenAmount || tokenLimit-tokenAmount <= tokensMissing {
+		pcMissing = math.MaxUint64
+	} else {
+		tokensAvailable := tokenLimit - tokenAmount
+		pcr := -math.Log(float64(tokensAvailable-tokensMissing)/float64(tokensAvailable)) * t.basePrice
+		if pcr > 0 {
+			if pcr > maxBalance {
+				pcMissing = math.MaxUint64
+			} else {
+				pcMissing = uint64(pcr)
+				if pcMissing > maxBalance {
+					pcMissing = math.MaxUint64
+				} else {
+					if pcMissing > pcBalance {
+						pcMissing -= pcBalance
+					} else {
+						pcMissing = 0
+					}
+				}
+			}
+		}
+	}
+	if pcMissing == 0 {
+		return
+	}
+	paymentRequired = make([]uint64, len(paymentModule))
+	for i, recID := range paymentModule {
+		if rec, ok := t.receivers[recID]; !ok || pcMissing == math.MaxUint64 {
+			paymentRequired[i] = math.MaxUint64
+		} else {
+			paymentRequired[i] = rec.requestPayment(id, pcMissing, meta.receiverMeta[recID])
+		}
+	}
+	return
+}
+
+func (t *tokenSale) deposit(id enode.ID, paymentModule string, proofOfPayment []byte) (pcValue, pcBalance uint64, err error) {
+	t.lock.Lock()
+	defer t.lock.Unlock()
+
+	pb := t.clientPool.getPosBalance(id)
+	var meta tokenSaleMeta
+	if err := rlp.DecodeBytes([]byte(pb.meta), &meta); err == nil {
+		pcBalance = meta.pcBalance
+	}
+
+	pm := t.receivers[paymentModule]
+	if pm == nil {
+		return 0, pcBalance, fmt.Errorf("Unknown payment receiver '%s'", paymentModule)
+	}
+	pcValue, meta.receiverMeta[paymentModule], err = pm.receivePayment(id, proofOfPayment, meta.receiverMeta[paymentModule])
+	if err != nil {
+		return 0, pcBalance, err
+	}
+	pcBalance += pcValue
+	meta.pcBalance = pcBalance
+	metaEnc, _ := rlp.EncodeToBytes(&meta)
+	t.clientPool.addBalance(id, 0, string(metaEnc))
+	return
+}
+
+func (t *tokenSale) buyTokens(id enode.ID, maxSpend, minReceive uint64, spendAll bool) (pcBalance, tokenBalance, spend, receive uint64, success bool) {
+	t.lock.Lock()
+	defer t.lock.Unlock()
+
+	pb := t.clientPool.getPosBalance(id)
+	tokenBalance = pb.value
+	var meta tokenSaleMeta
+	if err := rlp.DecodeBytes([]byte(pb.meta), &meta); err == nil {
+		pcBalance = meta.pcBalance
+	}
+
+	if maxSpend > pcBalance {
+		maxSpend = pcBalance
+	}
+	if spendAll {
+		spend = maxSpend
+		receive = t.tokensFor(spend)
+		success = receive >= minReceive
+	} else {
+		receive = minReceive
+		if cost, ok := t.tokenCost(receive); ok {
+			spend = uint64(cost)
+		} else {
+			spend = math.MaxUint64
+		}
+		success = spend <= maxSpend
+	}
+	if success {
+		pcBalance -= spend
+		tokenBalance += receive
+		meta.pcBalance = pcBalance
+		metaEnc, _ := rlp.EncodeToBytes(&meta)
+		t.clientPool.addBalance(id, int64(receive), string(metaEnc))
+	}
+	return
+}
+
+func (t *tokenSale) paymentInfo(paymentModule []string) [][]byte {
+	t.lock.Lock()
+	defer t.lock.Unlock()
+
+	res := make([][]byte, len(paymentModule))
+	for i, id := range paymentModule {
+		if rec, ok := t.receivers[id]; ok {
+			res[i] = rec.info()
+		}
+	}
+	return res
+}
+
+type tokenSaleMeta struct {
+	pcBalance    uint64
+	receiverMeta map[string][]byte
+}
+
+type receiverMetaEnc struct {
+	Id   string
+	Meta []byte
+}
+
+type tokenSaleMetaEnc struct {
+	Id        string
+	Version   uint
+	PcBalance uint64
+	Receivers []receiverMetaEnc
+}
+
+// EncodeRLP implements rlp.Encoder
+func (t *tokenSaleMeta) EncodeRLP(w io.Writer) error {
+	receivers := make([]receiverMetaEnc, len(t.receiverMeta))
+	i := 0
+	for id, meta := range t.receiverMeta {
+		receivers[i] = receiverMetaEnc{id, meta}
+		i++
+	}
+	return rlp.Encode(w, tokenSaleMetaEnc{
+		Id:        "tokenSale",
+		Version:   1,
+		PcBalance: t.pcBalance,
+		Receivers: receivers,
+	})
+}
+
+// DecodeRLP implements rlp.Decoder
+func (t *tokenSaleMeta) DecodeRLP(s *rlp.Stream) error {
+	var e tokenSaleMetaEnc
+	if err := s.Decode(&e); err != nil {
+		return err
+	}
+	if e.Id != "tokenSale" || e.Version != 1 {
+		return fmt.Errorf("Unknown balance meta format '%s' version %d", e.Id, e.Version)
+	}
+	t.receiverMeta = make(map[string][]byte)
+	t.pcBalance = e.PcBalance
+	for _, r := range e.Receivers {
+		t.receiverMeta[r.Id] = r.Meta
+	}
+	return nil
+}
+
+const (
+	tsInfo = iota
+	tsDeposit
+	tsBuyTokens
+	tsConnection
+)
+
+/*func (t *tokenSale) connection(id enode.ID, freeID string, requestedCapacity uint64, stayConnected time.Duration, paymentModule []string, setCap bool) (availableCapacity, tokenBalance, tokensMissing, pcBalance, pcMissing uint64, paymentRequired []uint64, err error) {
+func (t *tokenSale) deposit(id enode.ID, paymentModule string, proofOfPayment []byte) (pcValue, pcBalance uint64, err error) {
+func (t *tokenSale) buyTokens(id enode.ID, maxSpend, minReceive uint64, spendAll bool) (pcBalance, tokenBalance, spend, receive uint64, success bool) {
+func (t *tokenSale) paymentInfo(paymentModule []string) map[string][]byte {*/
+
+type (
+	tsDepositParams struct {
+		PaymentModule  string
+		ProofOfPayment []byte
+	}
+	tsDepositResults struct {
+		PcValue, PcBalance uint64
+		Err                string
+	}
+	tsBuyTokensParams struct {
+		MaxSpend, MinReceive uint64
+		SpendAll             bool
+	}
+	tsBuyTokensResults struct {
+		PcBalance, TokenBalance, Spend, Receive uint64
+		Success                                 bool
+	}
+	tsConnectionParams struct {
+		RequestedCapacity, StayConnected uint64
+		PaymentModule                    []string
+		SetCap                           bool
+	}
+	tsConnectionResults struct {
+		AvailableCapacity, TokenBalance, TokensMissing, PcBalance, PcMissing uint64
+		PaymentRequired                                                      []uint64
+		Err                                                                  string
+	}
+)
+
+func (t *tokenSale) runCommand(cmd []byte, id enode.ID, freeID string) []byte {
+	var res []byte
+	switch cmd[0] {
+	case tsInfo:
+		var (
+			params  []string
+			results [][]byte
+		)
+		if err := rlp.DecodeBytes(cmd[1:], &params); err == nil {
+			results = t.paymentInfo(params)
+			res, _ = rlp.EncodeToBytes(&results)
+		}
+	case tsDeposit:
+		var (
+			params  tsDepositParams
+			results tsDepositResults
+		)
+		if err := rlp.DecodeBytes(cmd[1:], &params); err == nil {
+			results.PcValue, results.PcBalance, err = t.deposit(id, params.PaymentModule, params.ProofOfPayment)
+			results.Err = err.Error()
+			res, _ = rlp.EncodeToBytes(&results)
+		}
+	case tsBuyTokens:
+		var (
+			params  tsBuyTokensParams
+			results tsBuyTokensResults
+		)
+		if err := rlp.DecodeBytes(cmd[1:], &params); err == nil {
+			results.PcBalance, results.TokenBalance, results.Spend, results.Receive, results.Success =
+				t.buyTokens(id, params.MaxSpend, params.MinReceive, params.SpendAll)
+			res, _ = rlp.EncodeToBytes(&results)
+		}
+	case tsConnection:
+		var (
+			params  tsConnectionParams
+			results tsConnectionResults
+		)
+		if err := rlp.DecodeBytes(cmd[1:], &params); err == nil {
+			results.AvailableCapacity, results.TokenBalance, results.TokensMissing, results.PcBalance, results.PcMissing, results.PaymentRequired, err =
+				t.connection(id, freeID, params.RequestedCapacity, time.Duration(params.StayConnected)*time.Second, params.PaymentModule, params.SetCap)
+			results.Err = err.Error()
+			res, _ = rlp.EncodeToBytes(&results)
+		}
+	}
+	return res
+}
+
+func (t *tokenSale) runCommands(cmds [][]byte, id enode.ID, freeID string) [][]byte {
+	res := make([][]byte, len(cmds))
+	for i, cmd := range cmds {
+		res[i] = t.runCommand(cmd, id, freeID)
+	}
+	return res
+}

--- a/les/tokensale.go
+++ b/les/tokensale.go
@@ -367,7 +367,9 @@ func (t *tokenSale) runCommand(cmd []byte, id enode.ID, freeID string) []byte {
 		)
 		if err := rlp.DecodeBytes(cmd[1:], &params); err == nil {
 			results.PcValue, results.PcBalance, err = t.deposit(id, params.PaymentModule, params.ProofOfPayment)
-			results.Err = err.Error()
+			if err != nil {
+				results.Err = err.Error()
+			}
 			res, _ = rlp.EncodeToBytes(&results)
 		}
 	case tsBuyTokens:
@@ -388,7 +390,9 @@ func (t *tokenSale) runCommand(cmd []byte, id enode.ID, freeID string) []byte {
 		if err := rlp.DecodeBytes(cmd[1:], &params); err == nil {
 			results.AvailableCapacity, results.TokenBalance, results.TokensMissing, results.PcBalance, results.PcMissing, results.PaymentRequired, err =
 				t.connection(id, freeID, params.RequestedCapacity, time.Duration(params.StayConnected)*time.Second, params.PaymentModule, params.SetCap)
-			results.Err = err.Error()
+			if err != nil {
+				results.Err = err.Error()
+			}
 			res, _ = rlp.EncodeToBytes(&results)
 		}
 	}

--- a/les/tokensale.go
+++ b/les/tokensale.go
@@ -319,11 +319,6 @@ const (
 	tsConnection
 )
 
-/*func (t *tokenSale) connection(id enode.ID, freeID string, requestedCapacity uint64, stayConnected time.Duration, paymentModule []string, setCap bool) (availableCapacity, tokenBalance, tokensMissing, pcBalance, pcMissing uint64, paymentRequired []uint64, err error) {
-func (t *tokenSale) deposit(id enode.ID, paymentModule string, proofOfPayment []byte) (pcValue, pcBalance uint64, err error) {
-func (t *tokenSale) buyTokens(id enode.ID, maxSpend, minReceive uint64, spendAll bool) (pcBalance, tokenBalance, spend, receive uint64, success bool) {
-func (t *tokenSale) paymentInfo(paymentModule []string) map[string][]byte {*/
-
 type (
 	tsDepositParams struct {
 		PaymentModule  string

--- a/les/ulc_test.go
+++ b/les/ulc_test.go
@@ -28,8 +28,8 @@ import (
 	"github.com/ethereum/go-ethereum/p2p/enode"
 )
 
-func TestULCAnnounceThresholdLes2(t *testing.T) { testULCAnnounceThreshold(t, 2) }
 func TestULCAnnounceThresholdLes3(t *testing.T) { testULCAnnounceThreshold(t, 3) }
+func TestULCAnnounceThresholdLes4(t *testing.T) { testULCAnnounceThreshold(t, 4) }
 
 func testULCAnnounceThreshold(t *testing.T, protocol int) {
 	// todo figure out why it takes fetcher so longer to fetcher the announced header.

--- a/les/ulc_test.go
+++ b/les/ulc_test.go
@@ -126,7 +126,7 @@ func connect(server *serverHandler, serverId enode.ID, client *clientHandler, pr
 
 // newServerPeer creates server peer.
 func newServerPeer(t *testing.T, blocks int, protocol int) (*testServer, *enode.Node, func()) {
-	s, teardown := newServerEnv(t, blocks, protocol, nil, false, false, 0)
+	s, teardown := newServerEnv(t, blocks, protocol, nil, false, false, 0, false)
 	key, err := crypto.GenerateKey()
 	if err != nil {
 		t.Fatal("generate key err:", err)

--- a/p2p/discv5/net.go
+++ b/p2p/discv5/net.go
@@ -1372,7 +1372,7 @@ func (q *talkQuery) start(net *Network) bool {
 	if q.remote == net.tab.self {
 		return false
 	}
-	if q.remote.state.canQuery {
+	if q.remote.state == known {
 		net.talkResponseSubLock.Lock()
 		hash := net.conn.send(q.remote, talkRequestPacket, talkRequest{TalkID: []byte(q.talkID), Payload: q.payload})
 		q.key = string(q.remote.sha[:]) + string(hash[:])

--- a/p2p/discv5/net.go
+++ b/p2p/discv5/net.go
@@ -87,8 +87,8 @@ type Network struct {
 }
 
 type (
-	TalkRequestHandler  func(enode.ID, *net.UDPAddr, []byte) ([]byte, bool)
-	TalkResponseHandler func([]byte) bool
+	TalkRequestHandler  func(enode.ID, *net.UDPAddr, interface{}) (interface{}, bool)
+	TalkResponseHandler func(interface{}) bool
 )
 
 // transport is implemented by the UDP transport.
@@ -116,7 +116,7 @@ type findnodeQuery struct {
 type talkQuery struct {
 	remote  *Node
 	talkID  string
-	payload rlp.RawValue
+	payload interface{}
 	key     string
 	handler TalkResponseHandler
 }
@@ -1387,7 +1387,7 @@ func (q *talkQuery) deferQuery() {
 	q.remote.deferQuery(q)
 }
 
-func (net *Network) SendTalkRequest(to *enode.Node, talkID string, payload []byte, handler TalkResponseHandler) func() bool {
+func (net *Network) SendTalkRequest(to *enode.Node, talkID string, payload interface{}, handler TalkResponseHandler) func() bool {
 	var nodeID NodeID
 	copy(nodeID[:], crypto.FromECDSAPub(to.Pubkey())[1:])
 	node := net.nodes[nodeID]

--- a/p2p/discv5/table.go
+++ b/p2p/discv5/table.go
@@ -35,6 +35,7 @@ const (
 	nBuckets   = hashBits + 1 // Number of buckets
 
 	maxFindnodeFailures = 5
+	maxTalkFailures     = 5
 )
 
 type Table struct {

--- a/p2p/discv5/udp.go
+++ b/p2p/discv5/udp.go
@@ -120,11 +120,13 @@ type (
 	}
 
 	talkRequest struct {
-		TalkID, Payload []byte
+		TalkID  []byte
+		Payload interface{}
 	}
 
 	talkResponse struct {
-		ReplyTok, Payload []byte
+		ReplyTok []byte
+		Payload  interface{}
 	}
 
 	rpcNode struct {

--- a/p2p/discv5/udp.go
+++ b/p2p/discv5/udp.go
@@ -120,13 +120,11 @@ type (
 	}
 
 	talkRequest struct {
-		TalkID  []byte
-		Payload rlp.RawValue
+		TalkID, Payload []byte
 	}
 
 	talkResponse struct {
-		ReplyTok []byte
-		Payload  rlp.RawValue
+		ReplyTok, Payload []byte
 	}
 
 	rpcNode struct {

--- a/p2p/discv5/udp.go
+++ b/p2p/discv5/udp.go
@@ -119,6 +119,16 @@ type (
 		Nodes []rpcNode
 	}
 
+	talkRequest struct {
+		TalkID  []byte
+		Payload rlp.RawValue
+	}
+
+	talkResponse struct {
+		ReplyTok []byte
+		Payload  rlp.RawValue
+	}
+
 	rpcNode struct {
 		IP  net.IP // len 4 for IPv4 or 16 for IPv6
 		UDP uint16 // for discovery protocol
@@ -420,6 +430,10 @@ func decodePacket(buffer []byte, pkt *ingressPacket) error {
 		pkt.data = new(topicQuery)
 	case topicNodesPacket:
 		pkt.data = new(topicNodes)
+	case talkRequestPacket:
+		pkt.data = new(talkRequest)
+	case talkResponsePacket:
+		pkt.data = new(talkResponse)
 	default:
 		return fmt.Errorf("unknown packet type: %d", sigdata[0])
 	}

--- a/p2p/enode/node.go
+++ b/p2p/enode/node.go
@@ -217,7 +217,7 @@ func (n ID) MarshalText() ([]byte, error) {
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (n *ID) UnmarshalText(text []byte) error {
-	id, err := parseID(string(text))
+	id, err := ParseID(string(text))
 	if err != nil {
 		return err
 	}
@@ -229,14 +229,14 @@ func (n *ID) UnmarshalText(text []byte) error {
 // The string may be prefixed with 0x.
 // It panics if the string is not a valid ID.
 func HexID(in string) ID {
-	id, err := parseID(in)
+	id, err := ParseID(in)
 	if err != nil {
 		panic(err)
 	}
 	return id
 }
 
-func parseID(in string) (ID, error) {
+func ParseID(in string) (ID, error) {
 	var id ID
 	b, err := hex.DecodeString(strings.TrimPrefix(in, "0x"))
 	if err != nil {


### PR DESCRIPTION
This is a WIP PR for the in-protocol payment logic. Currently implemented features:
- a discv5 extension for protocol negotiation ("talkRequest/talkResponse") and a dummy handler for the "les" domain
- a new clientPool function for calculating the necessary additional amount of token balance in order to fulfill a requested connection/capacity update (the core logic is also deduplicated)

Coming soon:
- new LES/4 and "LESTALK" UDP messages necessary for payment processing and price negotiation
- glue logic for the token sale and payment receiver modules