### PR TITLE
common/hexutil: improve GraphQL error messages

### DIFF
--- a/common/hexutil/json.go
+++ b/common/hexutil/json.go
@@ -86,7 +86,7 @@ func (b *Bytes) UnmarshalGraphQL(input interface{}) error {
 		}
 		*b = data
 	default:
-		err = fmt.Errorf("Unexpected type for Bytes: %v", input)
+		err = fmt.Errorf("unexpected type %T for Bytes", input)
 	}
 	return err
 }
@@ -220,7 +220,7 @@ func (b *Big) UnmarshalGraphQL(input interface{}) error {
 		num.SetInt64(int64(input))
 		*b = Big(num)
 	default:
-		err = fmt.Errorf("Unexpected type for BigInt: %v", input)
+		err = fmt.Errorf("unexpected type %T for BigInt", input)
 	}
 	return err
 }
@@ -284,7 +284,7 @@ func (b *Uint64) UnmarshalGraphQL(input interface{}) error {
 	case int32:
 		*b = Uint64(input)
 	default:
-		err = fmt.Errorf("Unexpected type for Long: %v", input)
+		err = fmt.Errorf("unexpected type %T for Long", input)
 	}
 	return err
 }


### PR DESCRIPTION
This fixes the following staticcheck warnings:

```
common/hexutil/json.go:89:19: error strings should not be capitalized (ST1005)
common/hexutil/json.go:223:19: error strings should not be capitalized (ST1005)
common/hexutil/json.go:287:19: error strings should not be capitalized (ST1005)
```