### PR TITLE
core/types: remove BlockBy sorting code

### DIFF
--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -23,6 +23,7 @@ import (
 	"io"
 	"math/big"
 	mrand "math/rand"
+	"sort"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -855,8 +856,9 @@ func (bc *BlockChain) procFutureBlocks() {
 		}
 	}
 	if len(blocks) > 0 {
-		types.BlockBy(types.Number).Sort(blocks)
-
+		sort.Slice(blocks, func(i, j int) bool {
+			return blocks[i].NumberU64() < blocks[j].NumberU64()
+		})
 		// Insert one by one as chain insertion needs contiguous ancestry between blocks
 		for i := range blocks {
 			bc.InsertChain(blocks[i : i+1])

--- a/core/types/block.go
+++ b/core/types/block.go
@@ -23,7 +23,6 @@ import (
 	"io"
 	"math/big"
 	"reflect"
-	"sort"
 	"sync/atomic"
 	"time"
 
@@ -394,26 +393,3 @@ func (b *Block) Hash() common.Hash {
 }
 
 type Blocks []*Block
-
-type BlockBy func(b1, b2 *Block) bool
-
-func (self BlockBy) Sort(blocks Blocks) {
-	bs := blockSorter{
-		blocks: blocks,
-		by:     self,
-	}
-	sort.Sort(bs)
-}
-
-type blockSorter struct {
-	blocks Blocks
-	by     func(b1, b2 *Block) bool
-}
-
-func (self blockSorter) Len() int { return len(self.blocks) }
-func (self blockSorter) Swap(i, j int) {
-	self.blocks[i], self.blocks[j] = self.blocks[j], self.blocks[i]
-}
-func (self blockSorter) Less(i, j int) bool { return self.by(self.blocks[i], self.blocks[j]) }
-
-func Number(b1, b2 *Block) bool { return b1.header.Number.Cmp(b2.header.Number) < 0 }


### PR DESCRIPTION
This was only used in one place. This code predates sort.Slice, and converting
the call site to sort.Slice is less code.

This fixes the following staticcheck warnings:

```
core/types/block.go:400:7: receiver name should be a reflection of its identity; don't use generic names such as "this" or "self" (ST1006)
core/types/block.go:413:7: receiver name should be a reflection of its identity; don't use generic names such as "this" or "self" (ST1006)
core/types/block.go:414:7: receiver name should be a reflection of its identity; don't use generic names such as "this" or "self" (ST1006)
core/types/block.go:417:7: receiver name should be a reflection of its identity; don't use generic names such as "this" or "self" (ST1006)
```
