### PR TITLE
accounts/abi: fix staticcheck warnings

### DIFF
--- a/accounts/abi/abi_test.go
+++ b/accounts/abi/abi_test.go
@@ -927,7 +927,7 @@ func TestABI_MethodById(t *testing.T) {
 		}
 		b := fmt.Sprintf("%v", m2)
 		if a != b {
-			t.Errorf("Method %v (id %v) not 'findable' by id in ABI", name, common.ToHex(m.ID()))
+			t.Errorf("Method %v (id %x) not 'findable' by id in ABI", name, m.ID())
 		}
 	}
 	// Also test empty

--- a/accounts/abi/event_test.go
+++ b/accounts/abi/event_test.go
@@ -173,7 +173,6 @@ func TestEventTupleUnpack(t *testing.T) {
 	type EventTransferWithTag struct {
 		// this is valid because `value` is not exportable,
 		// so value is only unmarshalled into `Value1`.
-		value  *big.Int
 		Value1 *big.Int `abi:"value"`
 	}
 
@@ -352,40 +351,6 @@ func unpackTestEventData(dest interface{}, hexData string, jsonEvent []byte, ass
 	assert.NoError(json.Unmarshal(jsonEvent, &e), "Should be able to unmarshal event ABI")
 	a := ABI{Events: map[string]Event{"e": e}}
 	return a.Unpack(dest, "e", data)
-}
-
-/*
-Taken from
-https://github.com/ethereum/go-ethereum/pull/15568
-*/
-
-type testResult struct {
-	Values [2]*big.Int
-	Value1 *big.Int
-	Value2 *big.Int
-}
-
-type testCase struct {
-	definition string
-	want       testResult
-}
-
-func (tc testCase) encoded(intType, arrayType Type) []byte {
-	var b bytes.Buffer
-	if tc.want.Value1 != nil {
-		val, _ := intType.pack(reflect.ValueOf(tc.want.Value1))
-		b.Write(val)
-	}
-
-	if !reflect.DeepEqual(tc.want.Values, [2]*big.Int{nil, nil}) {
-		val, _ := arrayType.pack(reflect.ValueOf(tc.want.Values))
-		b.Write(val)
-	}
-	if tc.want.Value2 != nil {
-		val, _ := intType.pack(reflect.ValueOf(tc.want.Value2))
-		b.Write(val)
-	}
-	return b.Bytes()
 }
 
 // TestEventUnpackIndexed verifies that indexed field will be skipped by event decoder.

--- a/accounts/abi/event_test.go
+++ b/accounts/abi/event_test.go
@@ -173,6 +173,7 @@ func TestEventTupleUnpack(t *testing.T) {
 	type EventTransferWithTag struct {
 		// this is valid because `value` is not exportable,
 		// so value is only unmarshalled into `Value1`.
+		value  *big.Int //lint:ignore U1000 unused field is part of test
 		Value1 *big.Int `abi:"value"`
 	}
 


### PR DESCRIPTION
This fixes the following warnings:

```
accounts/abi/abi_test.go:930:68: common.ToHex is deprecated: use hexutil.Encode instead.  (SA1019)
accounts/abi/event_test.go:176:3: field value is unused (U1000)
accounts/abi/event_test.go:362:6: type testResult is unused (U1000)
accounts/abi/event_test.go:368:6: type testCase is unused (U1000)
```