### PR TITLE
accounts/abi/bind/backends: remove unused assignment

### DIFF
--- a/accounts/abi/bind/backends/simulated_test.go
+++ b/accounts/abi/bind/backends/simulated_test.go
@@ -72,7 +72,7 @@ func TestSimulatedBackend(t *testing.T) {
 	}
 
 	sim.Commit()
-	tx, isPending, err = sim.TransactionByHash(context.Background(), txHash)
+	_, isPending, err = sim.TransactionByHash(context.Background(), txHash)
 	if err != nil {
 		t.Fatalf("error getting transaction with hash: %v", txHash.String())
 	}


### PR DESCRIPTION
This fixes a staticcheck warning:

```
accounts/abi/bind/backends/simulated_test.go:75:2: this value of tx is never used (SA4006)
```