### PR TITLE
core/asm: allow numbers in labels

### DIFF
--- a/core/asm/lex_test.go
+++ b/core/asm/lex_test.go
@@ -60,6 +60,14 @@ func TestLexer(t *testing.T) {
 			input:  "0123abc",
 			tokens: []token{{typ: lineStart}, {typ: number, text: "0123"}, {typ: element, text: "abc"}, {typ: eof}},
 		},
+		{
+			input:  "@foo",
+			tokens: []token{{typ: lineStart}, {typ: label, text: "foo"}, {typ: eof}},
+		},
+		{
+			input:  "@label123",
+			tokens: []token{{typ: lineStart}, {typ: label, text: "label123"}, {typ: eof}},
+		},
 	}
 
 	for _, test := range tests {

--- a/core/asm/lexer.go
+++ b/core/asm/lexer.go
@@ -234,7 +234,7 @@ func lexComment(l *lexer) stateFn {
 // the lex text state function to advance the parsing
 // process.
 func lexLabel(l *lexer) stateFn {
-	l.acceptRun(Alpha + "_")
+	l.acceptRun(Alpha + "_" + Numbers)
 
 	l.emit(label)
 


### PR DESCRIPTION
Numbers were already allowed when creating labels, just not when
referencing them.