### PR TITLE
rlp: fix staticcheck warnings

### DIFF
--- a/rlp/decode.go
+++ b/rlp/decode.go
@@ -29,12 +29,13 @@ import (
 	"sync"
 )
 
-var (
-	// EOL is returned when the end of the current list
-	// has been reached during streaming.
-	EOL = errors.New("rlp: end of list")
+//lint:ignore ST1012 EOL is not an error.
 
-	// Actual Errors
+// EOL is returned when the end of the current list
+// has been reached during streaming.
+var EOL = errors.New("rlp: end of list")
+
+var (
 	ErrExpectedString   = errors.New("rlp: expected String or Byte")
 	ErrExpectedList     = errors.New("rlp: expected List")
 	ErrCanonInt         = errors.New("rlp: non-canonical integer format")

--- a/rlp/decode_test.go
+++ b/rlp/decode_test.go
@@ -354,7 +354,7 @@ type tailUint struct {
 type tailPrivateFields struct {
 	A    uint
 	Tail []uint `rlp:"tail"`
-	x, y bool
+	x, y bool   //lint:ignore U1000 unused fields required for testing purposes.
 }
 
 type nilListUint struct {
@@ -806,9 +806,8 @@ func ExampleDecode() {
 	input, _ := hex.DecodeString("C90A1486666F6F626172")
 
 	type example struct {
-		A, B    uint
-		private uint // private fields are ignored
-		String  string
+		A, B   uint
+		String string
 	}
 
 	var s example

--- a/rlp/decode_test.go
+++ b/rlp/decode_test.go
@@ -818,7 +818,7 @@ func ExampleDecode() {
 		fmt.Printf("Decoded value: %#v\n", s)
 	}
 	// Output:
-	// Decoded value: rlp.example{A:0xa, B:0x14, private:0x0, String:"foobar"}
+	// Decoded value: rlp.example{A:0xa, B:0x14, String:"foobar"}
 }
 
 func ExampleDecode_structTagNil() {


### PR DESCRIPTION
This removes the following warnings:

```
rlp/decode.go:35:2: error var EOL should have name of the form ErrFoo (ST1012)
rlp/decode_test.go:357:2: field x is unused (U1000)
rlp/decode_test.go:357:5: field y is unused (U1000)
rlp/decode_test.go:810:3: field private is unused (U1000)
```