### PR TITLE
p2p/discover: slow down lookups on empty table

### DIFF
--- a/p2p/discover/lookup.go
+++ b/p2p/discover/lookup.go
@@ -111,7 +111,7 @@ func (it *lookup) startQueries() bool {
 		// for the table to fill in this case, but there is no good mechanism for that
 		// yet.
 		if len(closest.entries) == 0 {
-			time.Sleep(1 * time.Second)
+			it.slowdown()
 		}
 		it.queries = 1
 		it.replyCh <- closest.entries
@@ -129,6 +129,15 @@ func (it *lookup) startQueries() bool {
 	}
 	// The lookup ends when no more nodes can be asked.
 	return it.queries > 0
+}
+
+func (it *lookup) slowdown() {
+	sleep := time.NewTimer(1 * time.Second)
+	defer sleep.Stop()
+	select {
+	case <-sleep.C:
+	case <-it.tab.closeReq:
+	}
 }
 
 func (it *lookup) query(n *node, reply chan<- []*node) {

--- a/p2p/discover/lookup.go
+++ b/p2p/discover/lookup.go
@@ -18,6 +18,7 @@ package discover
 
 import (
 	"context"
+	"time"
 
 	"github.com/ethereum/go-ethereum/p2p/enode"
 )
@@ -106,6 +107,12 @@ func (it *lookup) startQueries() bool {
 		it.tab.mutex.Lock()
 		closest := it.tab.closest(it.result.target, bucketSize, false)
 		it.tab.mutex.Unlock()
+		// Avoid finishing the lookup too quickly if table is empty. It'd be better to wait
+		// for the table to fill in this case, but there is no good mechanism for that
+		// yet.
+		if len(closest.entries) == 0 {
+			time.Sleep(1 * time.Second)
+		}
 		it.queries = 1
 		it.replyCh <- closest.entries
 		return true


### PR DESCRIPTION
This is a hotfix for an issue where peer discovery would busy-wait in the lookup
iterator when the node is offline for a while.