### PR TITLE
les: fix clientInfo deadlock

### DIFF
--- a/les/api.go
+++ b/les/api.go
@@ -108,7 +108,7 @@ func (api *PrivateLightServerAPI) clientInfo(c *clientInfo, id enode.ID) map[str
 		info["priority"] = pb != 0
 	} else {
 		info["isConnected"] = false
-		pb := api.server.clientPool.getPosBalance(id)
+		pb := api.server.clientPool.ndb.getOrNewPB(id)
 		info["pricing/balance"], info["pricing/balanceMeta"] = pb.value, pb.meta
 		info["priority"] = pb.value != 0
 	}


### PR DESCRIPTION
This PR fixes a deadlock caused by double-locking the clientpool mutex. When requesting info for a disconnected node `getPosBalance` uses the lock and it was called from the callback of `forClients` where the lock is already held.