### PR TITLE
internal/web3ext: add debug_accountRange

### DIFF
--- a/internal/web3ext/web3ext.go
+++ b/internal/web3ext/web3ext.go
@@ -228,6 +228,11 @@ web3._extend({
 	property: 'debug',
 	methods: [
 		new web3._extend.Method({
+			name: 'accountRange',
+			call: 'debug_accountRange',
+			params: 2
+		}),
+		new web3._extend.Method({
 			name: 'printBlock',
 			call: 'debug_printBlock',
 			params: 1


### PR DESCRIPTION
Add `debug_accountRange` to web3ext so that it can be accessed in geth console.