### PR TITLE
rpc: reset writeConn when conn is closed on readErr

### DIFF
--- a/rpc/client.go
+++ b/rpc/client.go
@@ -555,6 +555,7 @@ func (c *Client) dispatch(codec ServerCodec) {
 			conn.handler.log.Debug("RPC connection read error", "err", err)
 			conn.close(err, lastOp)
 			reading = false
+			c.writeConn = nil
 
 		// Reconnect:
 		case newcodec := <-c.reconnected:


### PR DESCRIPTION
### Behavior

When running geth with external signer (Clef), if Clef is restarted, the first call to Clef always fail but the subsequent calls work fine.

### Analysis & Fix

In `rpc/client.go`, when any error like `EOF` is sent to `readErr` channel, `conn` will be closed but `c.writeConn` is not set to nil. If a new request comes after `conn` is closed, it must fail once before it will try to reconnect. This fix is to set `c.writeConn = nil` when `readErr` is received and `conn` is closed.