### PR TITLE
cmd/abigen: Sanitize vyper's combined json names

### DIFF
--- a/cmd/abigen/main.go
+++ b/cmd/abigen/main.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
+	"path/filepath"
 	"regexp"
 	"strings"
 
@@ -204,7 +205,8 @@ func abigen(c *cli.Context) error {
 				// Sanitize the combined json names to match the
 				// format expected by solidity.
 				if !strings.Contains(n, ":") {
-					name = abi.ToCamelCase(strings.TrimSuffix(name, ".vy"))
+					// Remove extra path components
+					name = abi.ToCamelCase(strings.TrimSuffix(filepath.Base(name), ".vy"))
 				}
 				contracts[name] = contract
 			}


### PR DESCRIPTION
This is a fix for #20418 

Solidity has a `combined_json` output with the following schema:

```
{
 "filename:contractname": { ... }
 ...
}
```

In the case of vyper, it's only:


```
{
 "filename": { ... }
 ...
}
```

This PR sanitizes the output if such a case is detected. I will also open an issue in the vyper repo.