### PR TITLE
p2p/enode: prevent data race in sliceIter

### DIFF
--- a/p2p/enode/iter.go
+++ b/p2p/enode/iter.go
@@ -88,6 +88,8 @@ func (it *sliceIter) Next() bool {
 }
 
 func (it *sliceIter) Node() *Node {
+	it.mu.Lock()
+	defer it.mu.Unlock()
 	if len(it.nodes) == 0 {
 		return nil
 	}


### PR DESCRIPTION
currently Node() has a data race with Next()

<details><summary>Stack Trace</summary>
<p>

```
==================
WARNING: DATA RACE
Write at 0x00c0001e3748 by goroutine 94:
  github.com/ethereum/go-ethereum/p2p/enode.(*sliceIter).Close()
      /home/asdf/go/src/github.com/ethereum/go-ethereum/p2p/enode/iter.go:101 +0x85
  github.com/ethereum/go-ethereum/p2p/enode.(*FairMix).Close()
      /home/asdf/go/src/github.com/ethereum/go-ethereum/p2p/enode/iter.go:191 +0x124
  github.com/ethereum/go-ethereum/p2p/enode.TestFairMixEmpty()
      /home/asdf/go/src/github.com/ethereum/go-ethereum/p2p/enode/iter_test.go:155 +0x38a
  testing.tRunner()
      /snap/go/4762/src/testing/testing.go:909 +0x199

Previous read at 0x00c0001e3748 by goroutine 15:
  github.com/ethereum/go-ethereum/p2p/enode.(*sliceIter).Node()
      /home/asdf/go/src/github.com/ethereum/go-ethereum/p2p/enode/iter.go:91 +0x47
  github.com/ethereum/go-ethereum/p2p/enode.(*FairMix).runSource()
      /home/asdf/go/src/github.com/ethereum/go-ethereum/p2p/enode/iter.go:278 +0x13a

Goroutine 94 (running) created at:
  testing.(*T).Run()
      /snap/go/4762/src/testing/testing.go:960 +0x651
  testing.runTests.func1()
      /snap/go/4762/src/testing/testing.go:1202 +0xa6
  testing.tRunner()
      /snap/go/4762/src/testing/testing.go:909 +0x199
  testing.runTests()
      /snap/go/4762/src/testing/testing.go:1200 +0x521
  testing.(*M).Run()
      /snap/go/4762/src/testing/testing.go:1117 +0x2ff
  main.main()
      _testmain.go:102 +0x223

Goroutine 15 (running) created at:
  github.com/ethereum/go-ethereum/p2p/enode.(*FairMix).AddSource()
      /home/asdf/go/src/github.com/ethereum/go-ethereum/p2p/enode/iter.go:178 +0x2f1
  github.com/ethereum/go-ethereum/p2p/enode.TestFairMixEmpty()
      /home/asdf/go/src/github.com/ethereum/go-ethereum/p2p/enode/iter_test.go:151 +0x34d
  testing.tRunner()
      /snap/go/4762/src/testing/testing.go:909 +0x199
==================
--- FAIL: TestFairMixEmpty (0.00s)
    testing.go:853: race detected during execution of test
FAIL

```

</p>
</details>