### PR TITLE
eth/tracers: handle invalid mem access better

### DIFF
--- a/eth/tracers/tracer.go
+++ b/eth/tracers/tracer.go
@@ -93,6 +93,13 @@ type memoryWrapper struct {
 
 // slice returns the requested range of memory as a byte slice.
 func (mw *memoryWrapper) slice(begin, end int64) []byte {
+	if end == begin {
+		return nil
+	}
+	if end < begin || begin < 0 {
+		log.Warn("Tracer accessed memory incorrectly", "offset", begin, "size", end-begin)
+		return nil
+	}
 	if mw.memory.Len() < int(end) {
 		// TODO(karalabe): We can't js-throw from Go inside duktape inside Go. The Go
 		// runtime goes belly up https://github.com/golang/go/issues/15639.


### PR DESCRIPTION
This is related to https://github.com/ethereum/go-ethereum/issues/18022 . The log showed a lot of errors where `available=96 offset=128 size=0`, that is, a call was made, but zero size was specified, thus memory was not expanded (because zero size memory is always a no-op from expansion perspective). 
This PR changes the `slice` operation on tracer memory to handle that, and additionally the case if size becomes negative. 

This does not fix the root issue of slowness 