### PR TITLE
internal/ethapi: fix encoding of uncle headers and pending blocks

### DIFF
--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -642,7 +642,7 @@ func (s *PublicBlockChainAPI) GetBlockByNumber(ctx context.Context, number rpc.B
 		response, err := s.rpcMarshalBlock(block, true, fullTx)
 		if err == nil && number == rpc.PendingBlockNumber {
 			// Pending blocks need to nil out a few fields
-			for _, field := range []string{"hash", "nonce", "miner"} {
+			for _, field := range []string{"hash", "nonce", "miner", "number"} {
 				response[field] = nil
 			}
 		}
@@ -1088,7 +1088,9 @@ func (s *PublicBlockChainAPI) rpcMarshalBlock(b *types.Block, inclTx bool, fullT
 	if err != nil {
 		return nil, err
 	}
-	fields["totalDifficulty"] = (*hexutil.Big)(s.b.GetTd(b.Hash()))
+	if inclTx {
+		fields["totalDifficulty"] = (*hexutil.Big)(s.b.GetTd(b.Hash()))
+	}
 	return fields, err
 }
 


### PR DESCRIPTION
I have fixed removed the `totalDifficulty` field from API `eth_getUncleByBlockHashAndIndex` as suggested in #19024. Also, I have made a change in block number of `eth_getBlockByNumber("pending")`. Now, block number will be marked `null` because parity also does the same. 

Fixes: #19024 and #19332 
