### PR TITLE
trie: avoid rlp-encoding when trie hash is already available

### DIFF
--- a/trie/hasher.go
+++ b/trie/hasher.go
@@ -165,20 +165,20 @@ func (h *hasher) store(n node, db *Database, force bool) (node, error) {
 	if _, isHash := n.(hashNode); n == nil || isHash {
 		return n, nil
 	}
-	// Generate the RLP encoding of the node
-	h.tmp.Reset()
-	if err := rlp.Encode(&h.tmp, n); err != nil {
-		panic("encode error: " + err.Error())
-	}
-	if len(h.tmp) < 32 && !force {
-		return n, nil // Nodes smaller than 32 bytes are stored inside their parent
-	}
-	// Larger nodes are replaced by their hash and stored in the database.
+	// We might already have the hash
 	hash, _ := n.cache()
 	if hash == nil {
+		// Generate the RLP encoding of the node
+		h.tmp.Reset()
+		if err := rlp.Encode(&h.tmp, n); err != nil {
+			panic("encode error: " + err.Error())
+		}
+		if len(h.tmp) < 32 && !force {
+			return n, nil // Nodes smaller than 32 bytes are stored inside their parent
+		}
+		// Larger nodes are replaced by their hash and stored in the database.
 		hash = h.makeHashNode(h.tmp)
 	}
-
 	if db != nil {
 		// We are pooling the trie nodes into an intermediate memory cache
 		hash := common.BytesToHash(hash)


### PR DESCRIPTION
I'm not sure this is correct, of if I'm missing some quirky edgecase, but what this PR does, is attempt to improve on the scenario where we first `Hash` the trie and later `Commit` it. 

That typically happens on every block, since we call `IntermediateStateRoot` after applying the block rewards, and that does `Hash` internally. We need to hash it to get the state root, and we need that in order to validate against the header. 
If everything checks out, we then `Commit`. Now, the `Commit` is clever enough not to re-hash everything since it already has the hashes cached for all nodes. However, we _do_ rlp-encode everything the second time around, which this PR skips if we have the `hash` cached. 

Turns out that saves us `20%` processing time:

```
[user@work trie]$ benchstat before.txt after.txt 
name               old time/op    new time/op    delta
CommitAfterHash-6    5.08µs ±12%    3.99µs ±21%  -21.33%  (p=0.000 n=20+18)

name               old alloc/op   new alloc/op   delta
CommitAfterHash-6    1.79kB ± 1%    1.65kB ± 1%   -7.67%  (p=0.000 n=18+17)

name               old allocs/op  new allocs/op  delta
CommitAfterHash-6      11.0 ± 0%      10.0 ± 0%   -9.09%  (p=0.000 n=20+20)
```