### PR TITLE
trie: db insertions + leaf callback parallelism

### DIFF
--- a/trie/database.go
+++ b/trie/database.go
@@ -314,24 +314,24 @@ func (db *Database) InsertBlob(hash common.Hash, blob []byte) {
 	db.lock.Lock()
 	defer db.lock.Unlock()
 
-	db.insert(hash, blob, rawNode(blob))
+	db.insert(hash, len(blob), rawNode(blob))
 }
 
 // insert inserts a collapsed trie node into the memory database. This method is
 // a more generic version of InsertBlob, supporting both raw blob insertions as
-// well ex trie node insertions. The blob must always be specified to allow proper
+// well ex trie node insertions. The blob size must be specified to allow proper
 // size tracking.
-func (db *Database) insert(hash common.Hash, blob []byte, node node) {
+func (db *Database) insert(hash common.Hash, size int, node node) {
 	// If the node's already cached, skip
 	if _, ok := db.dirties[hash]; ok {
 		return
 	}
-	memcacheDirtyWriteMeter.Mark(int64(len(blob)))
+	memcacheDirtyWriteMeter.Mark(int64(size))
 
 	// Create the cached entry for this node
 	entry := &cachedNode{
 		node:      simplifyNode(node),
-		size:      uint16(len(blob)),
+		size:      uint16(size),
 		flushPrev: db.newest,
 	}
 	for _, child := range entry.childs() {

--- a/trie/hasher.go
+++ b/trie/hasher.go
@@ -184,7 +184,7 @@ func (h *hasher) store(n node, db *Database, force bool) (node, error) {
 		hash := common.BytesToHash(hash)
 
 		db.lock.Lock()
-		db.insert(hash, h.tmp, n)
+		db.insert(hash, len(h.tmp), n)
 		db.lock.Unlock()
 
 		// Track external references from account->storage trie

--- a/trie/trie_test.go
+++ b/trie/trie_test.go
@@ -568,6 +568,18 @@ func benchmarkCommitAfterHash(b *testing.B, onleaf LeafCallback) {
 	trie.Commit(onleaf)
 }
 
+func TestCommitAfterHash(t *testing.T) {
+	// Create a realistic account trie to hash
+	addresses, accounts := makeAccounts(1000)
+	trie := newEmpty()
+	for i := 0; i < len(addresses); i++ {
+		trie.Update(crypto.Keccak256(addresses[i][:]), accounts[i])
+	}
+	// Insert the accounts into the trie and hash it
+	trie.Hash()
+	trie.Commit(nil)
+}
+
 func makeAccounts(size int) (addresses [][20]byte, accounts [][]byte) {
 	// Make the random benchmark deterministic
 	random := rand.New(rand.NewSource(0))
@@ -637,7 +649,7 @@ func benchmarkCommitAfterHashFixedSize(b *testing.B, addresses [][20]byte, accou
 	// Insert the accounts into the trie and hash it
 	trie.Hash()
 	b.StartTimer()
-	trie.Commit()
+	trie.Commit(nil)
 	b.StopTimer()
 }
 

--- a/trie/trie_test.go
+++ b/trie/trie_test.go
@@ -637,7 +637,7 @@ func benchmarkCommitAfterHashFixedSize(b *testing.B, addresses [][20]byte, accou
 	// Insert the accounts into the trie and hash it
 	trie.Hash()
 	b.StartTimer()
-	trie.Commit(nil)
+	trie.Commit()
 	b.StopTimer()
 }
 


### PR DESCRIPTION
When we do `Commit` on the trie when parents-of-leafs are encountered, we do two things: 

1. call `db.insert`, which can be a fairly heavy operation, and 
2. call the `onleaf` function for the leafs. This can also be somewhat heavy. 

This PR splits this up, so that we can have one dedicated goroutine which handles the insertion and callbacks, and the main trie-walker can concentrate on iterating the trie. 

Since the order of events (inserts and callback invocation) is unchanged by this PR, I don't think this has any buggy side-effects.

Here are the benchmark results: 
```
name                           old time/op    new time/op    delta
CommitAfterHash/no-onleaf-6      5.10µs ±14%    4.28µs ± 8%  -16.06%  (p=0.000 n=10+9)
CommitAfterHash/with-onleaf-6    6.77µs ±19%    5.44µs ±18%  -19.71%  (p=0.000 n=10+10)

name                           old alloc/op   new alloc/op   delta
CommitAfterHash/no-onleaf-6      1.79kB ± 3%    1.94kB ± 5%   +8.65%  (p=0.000 n=10+10)
CommitAfterHash/with-onleaf-6    2.18kB ± 2%    2.22kB ± 2%   +1.81%  (p=0.004 n=10+10)

name                           old allocs/op  new allocs/op  delta
CommitAfterHash/no-onleaf-6        11.0 ± 0%      13.0 ± 0%  +18.18%  (p=0.000 n=10+10)
CommitAfterHash/with-onleaf-6      18.3 ± 4%      20.0 ± 0%   +9.29%  (p=0.000 n=10+10)

```
As can be expected, if there's an `onleaf` function provided, the gains are higher `20%`, compared to `16%` if there is no `onleaf`. 
The benchmarks are pretty synthetic, though, and I imagine that there is a lot more work done in the `insert` section on a live node. 

This PR should work pretty nicely even pre-byzantium, I'd guess. 

The actual implementation can surely be cleaned up a bit, particularly the hack in `trie.go` could be made a bit more elegant. 