### PR TITLE
console, internal/jsre: use goja

### DIFF
--- a/cmd/geth/consolecmd_test.go
+++ b/cmd/geth/consolecmd_test.go
@@ -139,7 +139,9 @@ func testAttachWelcome(t *testing.T, geth *testgeth, endpoint, apis string) {
 	attach.SetTemplateFunc("gover", runtime.Version)
 	attach.SetTemplateFunc("gethver", func() string { return params.VersionWithCommit("", "") })
 	attach.SetTemplateFunc("etherbase", func() string { return geth.Etherbase })
-	attach.SetTemplateFunc("niltime", func() string { return time.Unix(0, 0).Format(time.RFC1123) })
+	attach.SetTemplateFunc("niltime", func() string {
+		return time.Unix(0, 0).Format("Mon Jan 02 2006 15:04:05 GMT-0700 (MST)")
+	})
 	attach.SetTemplateFunc("ipc", func() bool { return strings.HasPrefix(endpoint, "ipc") })
 	attach.SetTemplateFunc("datadir", func() string { return geth.Datadir })
 	attach.SetTemplateFunc("apis", func() string { return apis })

--- a/cmd/geth/consolecmd_test.go
+++ b/cmd/geth/consolecmd_test.go
@@ -51,7 +51,9 @@ func TestConsoleWelcome(t *testing.T) {
 	geth.SetTemplateFunc("goarch", func() string { return runtime.GOARCH })
 	geth.SetTemplateFunc("gover", runtime.Version)
 	geth.SetTemplateFunc("gethver", func() string { return params.VersionWithCommit("", "") })
-	geth.SetTemplateFunc("niltime", func() string { return time.Unix(0, 0).Format(time.RFC1123) })
+	geth.SetTemplateFunc("niltime", func() string {
+		return time.Unix(0, 0).Format("Mon Jan 02 2006 15:04:05 GMT-0700 (MST)")
+	})
 	geth.SetTemplateFunc("apis", func() string { return ipcAPIs })
 
 	// Verify the actual welcome message to the required template

--- a/console/bridge.go
+++ b/console/bridge.go
@@ -20,37 +20,58 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"reflect"
 	"strings"
 	"time"
 
+	"github.com/dop251/goja"
 	"github.com/ethereum/go-ethereum/accounts/scwallet"
 	"github.com/ethereum/go-ethereum/accounts/usbwallet"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/rpc"
-	"github.com/robertkrimen/otto"
 )
 
 // bridge is a collection of JavaScript utility methods to bride the .js runtime
 // environment and the Go RPC connection backing the remote method calls.
 type bridge struct {
-	client   *rpc.Client  // RPC client to execute Ethereum requests through
-	prompter UserPrompter // Input prompter to allow interactive user feedback
-	printer  io.Writer    // Output writer to serialize any display strings to
+	client   *rpc.Client   // RPC client to execute Ethereum requests through
+	prompter UserPrompter  // Input prompter to allow interactive user feedback
+	printer  io.Writer     // Output writer to serialize any display strings to
+	runtime  *goja.Runtime // Pointer to the JS runtime
 }
 
 // newBridge creates a new JavaScript wrapper around an RPC client.
-func newBridge(client *rpc.Client, prompter UserPrompter, printer io.Writer) *bridge {
+func newBridge(client *rpc.Client, prompter UserPrompter, printer io.Writer, runtime *goja.Runtime) *bridge {
 	return &bridge{
 		client:   client,
 		prompter: prompter,
 		printer:  printer,
+		runtime:  runtime,
 	}
+}
+
+// IsNumber returns `true` if input value `v` is a number.
+func IsNumber(v goja.Value) bool {
+	switch v.ExportType().Kind() {
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		return true
+	default:
+		return false
+	}
+}
+
+func getJeth(r *goja.Runtime) *goja.Object {
+	jethObj := r.Get("jeth")
+	if jethObj == nil {
+		panic(r.ToValue("jeth object does not exist"))
+	}
+	return jethObj.ToObject(r)
 }
 
 // NewAccount is a wrapper around the personal.newAccount RPC method that uses a
 // non-echoing password prompt to acquire the passphrase and executes the original
 // RPC method (saved in jeth.newAccount) with it to actually execute the RPC call.
-func (b *bridge) NewAccount(call otto.FunctionCall) (response otto.Value) {
+func (b *bridge) NewAccount(call goja.FunctionCall) (response goja.Value) {
 	var (
 		password string
 		confirm  string
@@ -58,50 +79,58 @@ func (b *bridge) NewAccount(call otto.FunctionCall) (response otto.Value) {
 	)
 	switch {
 	// No password was specified, prompt the user for it
-	case len(call.ArgumentList) == 0:
-		if password, err = b.prompter.PromptPassword("Password: "); err != nil {
-			throwJSException(err.Error())
+	case len(call.Arguments) == 0:
+		if password, err = b.prompter.PromptPassword("Passphrase: "); err != nil {
+			throwJSException(b.runtime, err.Error())
 		}
-		if confirm, err = b.prompter.PromptPassword("Repeat password: "); err != nil {
-			throwJSException(err.Error())
+		if confirm, err = b.prompter.PromptPassword("Repeat passphrase: "); err != nil {
+			throwJSException(b.runtime, err.Error())
 		}
 		if password != confirm {
-			throwJSException("passwords don't match!")
+			throwJSException(b.runtime, "passwords don't match!")
 		}
 
 	// A single string password was specified, use that
-	case len(call.ArgumentList) == 1 && call.Argument(0).IsString():
-		password, _ = call.Argument(0).ToString()
+	case len(call.Arguments) == 1 && call.Argument(0).ToString() != nil:
+		password = call.Argument(0).ToString().String()
 
 	// Otherwise fail with some error
 	default:
-		throwJSException("expected 0 or 1 string argument")
+		throwJSException(b.runtime, "expected 0 or 1 string argument")
 	}
 	// Password acquired, execute the call and return
-	ret, err := call.Otto.Call("jeth.newAccount", nil, password)
+	newAccount, callable := goja.AssertFunction(getJeth(b.runtime).Get("newAccount"))
+	if !callable {
+		panic(b.runtime.ToValue("jeth.newAccount isn't callable"))
+	}
+	ret, err := newAccount(goja.Null(), b.runtime.ToValue(password))
 	if err != nil {
-		throwJSException(err.Error())
+		throwJSException(b.runtime, err.Error())
 	}
 	return ret
 }
 
 // OpenWallet is a wrapper around personal.openWallet which can interpret and
 // react to certain error messages, such as the Trezor PIN matrix request.
-func (b *bridge) OpenWallet(call otto.FunctionCall) (response otto.Value) {
+func (b *bridge) OpenWallet(call goja.FunctionCall) (response goja.Value) {
 	// Make sure we have a wallet specified to open
-	if !call.Argument(0).IsString() {
-		throwJSException("first argument must be the wallet URL to open")
+	if call.Argument(0).ToObject(b.runtime).ClassName() != "String" {
+		throwJSException(b.runtime, b.runtime.ToValue("first argument must be the wallet URL to open"))
 	}
 	wallet := call.Argument(0)
 
-	var passwd otto.Value
-	if call.Argument(1).IsUndefined() || call.Argument(1).IsNull() {
-		passwd, _ = otto.ToValue("")
+	var passwd goja.Value
+	if goja.IsUndefined(call.Argument(1)) || goja.IsNull(call.Argument(1)) {
+		passwd = b.runtime.ToValue("")
 	} else {
 		passwd = call.Argument(1)
 	}
 	// Open the wallet and return if successful in itself
-	val, err := call.Otto.Call("jeth.openWallet", nil, wallet, passwd)
+	openWallet, callable := goja.AssertFunction(getJeth(b.runtime).Get("openWallet"))
+	if !callable {
+		throwJSException(b.runtime, b.runtime.ToValue("jeth.openWallet is not callable"))
+	}
+	val, err := openWallet(goja.Null(), wallet, passwd)
 	if err == nil {
 		return val
 	}
@@ -115,28 +144,28 @@ func (b *bridge) OpenWallet(call otto.FunctionCall) (response otto.Value) {
 		}
 		val, err = b.readPassphraseAndReopenWallet(call)
 		if err != nil {
-			throwJSException(err.Error())
+			throwJSException(b.runtime, err.Error())
 		}
 
 	case strings.HasSuffix(err.Error(), scwallet.ErrPairingPasswordNeeded.Error()):
 		// PUK input requested, fetch from the user and call open again
 		if input, err := b.prompter.PromptPassword("Please enter the pairing password: "); err != nil {
-			throwJSException(err.Error())
+			throwJSException(b.runtime, err.Error())
 		} else {
-			passwd, _ = otto.ToValue(input)
+			passwd = b.runtime.ToValue(input)
 		}
-		if val, err = call.Otto.Call("jeth.openWallet", nil, wallet, passwd); err != nil {
+		if val, err = openWallet(goja.Null(), wallet, passwd); err != nil {
 			if !strings.HasSuffix(err.Error(), scwallet.ErrPINNeeded.Error()) {
-				throwJSException(err.Error())
+				throwJSException(b.runtime, err.Error())
 			} else {
 				// PIN input requested, fetch from the user and call open again
 				if input, err := b.prompter.PromptPassword("Please enter current PIN: "); err != nil {
-					throwJSException(err.Error())
+					throwJSException(b.runtime, err.Error())
 				} else {
-					passwd, _ = otto.ToValue(input)
+					passwd = b.runtime.ToValue(input)
 				}
-				if val, err = call.Otto.Call("jeth.openWallet", nil, wallet, passwd); err != nil {
-					throwJSException(err.Error())
+				if val, err = openWallet(goja.Null(), wallet, passwd); err != nil {
+					throwJSException(b.runtime, err.Error())
 				}
 			}
 		}
@@ -145,51 +174,55 @@ func (b *bridge) OpenWallet(call otto.FunctionCall) (response otto.Value) {
 		// PIN unblock requested, fetch PUK and new PIN from the user
 		var pukpin string
 		if input, err := b.prompter.PromptPassword("Please enter current PUK: "); err != nil {
-			throwJSException(err.Error())
+			throwJSException(b.runtime, err.Error())
 		} else {
 			pukpin = input
 		}
 		if input, err := b.prompter.PromptPassword("Please enter new PIN: "); err != nil {
-			throwJSException(err.Error())
+			throwJSException(b.runtime, err.Error())
 		} else {
 			pukpin += input
 		}
-		passwd, _ = otto.ToValue(pukpin)
-		if val, err = call.Otto.Call("jeth.openWallet", nil, wallet, passwd); err != nil {
-			throwJSException(err.Error())
+		passwd = b.runtime.ToValue(pukpin)
+		if val, err = openWallet(goja.Null(), wallet, passwd); err != nil {
+			throwJSException(b.runtime, err.Error())
 		}
 
 	case strings.HasSuffix(err.Error(), scwallet.ErrPINNeeded.Error()):
 		// PIN input requested, fetch from the user and call open again
 		if input, err := b.prompter.PromptPassword("Please enter current PIN: "); err != nil {
-			throwJSException(err.Error())
+			throwJSException(b.runtime, err.Error())
 		} else {
-			passwd, _ = otto.ToValue(input)
+			passwd = b.runtime.ToValue(input)
 		}
-		if val, err = call.Otto.Call("jeth.openWallet", nil, wallet, passwd); err != nil {
-			throwJSException(err.Error())
+		if val, err = openWallet(goja.Null(), wallet, passwd); err != nil {
+			throwJSException(b.runtime, err.Error())
 		}
 
 	default:
 		// Unknown error occurred, drop to the user
-		throwJSException(err.Error())
+		throwJSException(b.runtime, err.Error())
 	}
 	return val
 }
 
-func (b *bridge) readPassphraseAndReopenWallet(call otto.FunctionCall) (otto.Value, error) {
-	var passwd otto.Value
+func (b *bridge) readPassphraseAndReopenWallet(call goja.FunctionCall) (goja.Value, error) {
+	var passwd goja.Value
 	wallet := call.Argument(0)
-	if input, err := b.prompter.PromptPassword("Please enter your password: "); err != nil {
-		throwJSException(err.Error())
+	if input, err := b.prompter.PromptPassword("Please enter your passphrase: "); err != nil {
+		throwJSException(b.runtime, err.Error())
 	} else {
-		passwd, _ = otto.ToValue(input)
+		passwd = b.runtime.ToValue(input)
 	}
-	return call.Otto.Call("jeth.openWallet", nil, wallet, passwd)
+	openWallet, callable := goja.AssertFunction(getJeth(b.runtime).Get("openWallet"))
+	if !callable {
+		return nil, fmt.Errorf("jeth.openWallet is not callable")
+	}
+	return openWallet(goja.Null(), wallet, passwd)
 }
 
-func (b *bridge) readPinAndReopenWallet(call otto.FunctionCall) (otto.Value, error) {
-	var passwd otto.Value
+func (b *bridge) readPinAndReopenWallet(call goja.FunctionCall) (goja.Value, error) {
+	var passwd goja.Value
 	wallet := call.Argument(0)
 	// Trezor PIN matrix input requested, display the matrix to the user and fetch the data
 	fmt.Fprintf(b.printer, "Look at the device for number positions\n\n")
@@ -200,52 +233,60 @@ func (b *bridge) readPinAndReopenWallet(call otto.FunctionCall) (otto.Value, err
 	fmt.Fprintf(b.printer, "1 | 2 | 3\n\n")
 
 	if input, err := b.prompter.PromptPassword("Please enter current PIN: "); err != nil {
-		throwJSException(err.Error())
+		throwJSException(b.runtime, err.Error())
 	} else {
-		passwd, _ = otto.ToValue(input)
+		passwd = b.runtime.ToValue(input)
 	}
-	return call.Otto.Call("jeth.openWallet", nil, wallet, passwd)
+	openWallet, callable := goja.AssertFunction(getJeth(b.runtime).Get("openWallet"))
+	if !callable {
+		return nil, fmt.Errorf("jeth.openWallet is not callable")
+	}
+	return openWallet(goja.Null(), wallet, passwd)
 }
 
 // UnlockAccount is a wrapper around the personal.unlockAccount RPC method that
 // uses a non-echoing password prompt to acquire the passphrase and executes the
 // original RPC method (saved in jeth.unlockAccount) with it to actually execute
 // the RPC call.
-func (b *bridge) UnlockAccount(call otto.FunctionCall) (response otto.Value) {
+func (b *bridge) UnlockAccount(call goja.FunctionCall) (response goja.Value) {
 	// Make sure we have an account specified to unlock
-	if !call.Argument(0).IsString() {
-		throwJSException("first argument must be the account to unlock")
+	if call.Argument(0).ExportType().Kind() != reflect.String {
+		throwJSException(b.runtime, "first argument must be the account to unlock")
 	}
 	account := call.Argument(0)
 
 	// If password is not given or is the null value, prompt the user for it
-	var passwd otto.Value
+	var passwd goja.Value
 
-	if call.Argument(1).IsUndefined() || call.Argument(1).IsNull() {
+	if goja.IsUndefined(call.Argument(1)) || goja.IsNull(call.Argument(1)) {
 		fmt.Fprintf(b.printer, "Unlock account %s\n", account)
-		if input, err := b.prompter.PromptPassword("Password: "); err != nil {
-			throwJSException(err.Error())
+		if input, err := b.prompter.PromptPassword("Passphrase: "); err != nil {
+			throwJSException(b.runtime, err.Error())
 		} else {
-			passwd, _ = otto.ToValue(input)
+			passwd = b.runtime.ToValue(input)
 		}
 	} else {
-		if !call.Argument(1).IsString() {
-			throwJSException("password must be a string")
+		if call.Argument(1).ExportType().Kind() != reflect.String {
+			throwJSException(b.runtime, "password must be a string")
 		}
 		passwd = call.Argument(1)
 	}
 	// Third argument is the duration how long the account must be unlocked.
-	duration := otto.NullValue()
-	if call.Argument(2).IsDefined() && !call.Argument(2).IsNull() {
-		if !call.Argument(2).IsNumber() {
-			throwJSException("unlock duration must be a number")
+	duration := goja.Null()
+	if !goja.IsUndefined(call.Argument(2)) && !goja.IsNull(call.Argument(2)) {
+		if !IsNumber(call.Argument(2)) {
+			throwJSException(b.runtime, "unlock duration must be a number")
 		}
 		duration = call.Argument(2)
 	}
 	// Send the request to the backend and return
-	val, err := call.Otto.Call("jeth.unlockAccount", nil, account, passwd, duration)
+	unlockAccount, callable := goja.AssertFunction(getJeth(b.runtime).Get("unlockAccount"))
+	if !callable {
+		throwJSException(b.runtime, "jeth.unlockAccount is not callable")
+	}
+	val, err := unlockAccount(goja.Null(), account, passwd, duration)
 	if err != nil {
-		throwJSException(err.Error())
+		throwJSException(b.runtime, err.Error())
 	}
 	return val
 }
@@ -253,89 +294,98 @@ func (b *bridge) UnlockAccount(call otto.FunctionCall) (response otto.Value) {
 // Sign is a wrapper around the personal.sign RPC method that uses a non-echoing password
 // prompt to acquire the passphrase and executes the original RPC method (saved in
 // jeth.sign) with it to actually execute the RPC call.
-func (b *bridge) Sign(call otto.FunctionCall) (response otto.Value) {
+func (b *bridge) Sign(call goja.FunctionCall) (response goja.Value) {
 	var (
 		message = call.Argument(0)
 		account = call.Argument(1)
 		passwd  = call.Argument(2)
 	)
 
-	if !message.IsString() {
-		throwJSException("first argument must be the message to sign")
+	if message.ExportType().Kind() != reflect.String {
+		throwJSException(b.runtime, "first argument must be the message to sign")
 	}
-	if !account.IsString() {
-		throwJSException("second argument must be the account to sign with")
+	if account.ExportType().Kind() != reflect.String {
+		throwJSException(b.runtime, "second argument must be the account to sign with")
 	}
 
 	// if the password is not given or null ask the user and ensure password is a string
-	if passwd.IsUndefined() || passwd.IsNull() {
+	if goja.IsUndefined(passwd) || goja.IsNull(passwd) {
 		fmt.Fprintf(b.printer, "Give password for account %s\n", account)
 		if input, err := b.prompter.PromptPassword("Password: "); err != nil {
-			throwJSException(err.Error())
+			throwJSException(b.runtime, err.Error())
 		} else {
-			passwd, _ = otto.ToValue(input)
+			passwd = b.runtime.ToValue(input)
 		}
 	}
-	if !passwd.IsString() {
-		throwJSException("third argument must be the password to unlock the account")
+	if passwd.ExportType().Kind() != reflect.String {
+		throwJSException(b.runtime, "third argument must be the password to unlock the account")
 	}
 
 	// Send the request to the backend and return
-	val, err := call.Otto.Call("jeth.sign", nil, message, account, passwd)
+	sign, callable := goja.AssertFunction(getJeth(b.runtime).Get("unlockAccount"))
+	if !callable {
+		throwJSException(b.runtime, "jeth.unlockAccount is not callable")
+	}
+	val, err := sign(goja.Null(), message, account, passwd)
 	if err != nil {
-		throwJSException(err.Error())
+		throwJSException(b.runtime, err.Error())
 	}
 	return val
 }
 
 // Sleep will block the console for the specified number of seconds.
-func (b *bridge) Sleep(call otto.FunctionCall) (response otto.Value) {
-	if call.Argument(0).IsNumber() {
-		sleep, _ := call.Argument(0).ToInteger()
+func (b *bridge) Sleep(call goja.FunctionCall) (response goja.Value) {
+	if IsNumber(call.Argument(0)) {
+		sleep := call.Argument(0).ToInteger()
 		time.Sleep(time.Duration(sleep) * time.Second)
-		return otto.TrueValue()
+		return b.runtime.ToValue(true)
 	}
-	return throwJSException("usage: sleep(<number of seconds>)")
+	return throwJSException(b.runtime, "usage: sleep(<number of seconds>)")
 }
 
 // SleepBlocks will block the console for a specified number of new blocks optionally
 // until the given timeout is reached.
-func (b *bridge) SleepBlocks(call otto.FunctionCall) (response otto.Value) {
+func (b *bridge) SleepBlocks(call goja.FunctionCall) (response goja.Value) {
 	var (
 		blocks = int64(0)
 		sleep  = int64(9999999999999999) // indefinitely
 	)
 	// Parse the input parameters for the sleep
-	nArgs := len(call.ArgumentList)
+	nArgs := len(call.Arguments)
 	if nArgs == 0 {
-		throwJSException("usage: sleepBlocks(<n blocks>[, max sleep in seconds])")
+		throwJSException(b.runtime, "usage: sleepBlocks(<n blocks>[, max sleep in seconds])")
 	}
 	if nArgs >= 1 {
-		if call.Argument(0).IsNumber() {
-			blocks, _ = call.Argument(0).ToInteger()
+		if IsNumber(call.Argument(0)) {
+			blocks = call.Argument(0).ToInteger()
+
 		} else {
-			throwJSException("expected number as first argument")
+			throwJSException(b.runtime, "expected number as first argument")
 		}
 	}
 	if nArgs >= 2 {
-		if call.Argument(1).IsNumber() {
-			sleep, _ = call.Argument(1).ToInteger()
+		if IsNumber(call.Argument(1)) {
+			sleep = call.Argument(1).ToInteger()
 		} else {
-			throwJSException("expected number as second argument")
+			throwJSException(b.runtime, "expected number as second argument")
 		}
 	}
 	// go through the console, this will allow web3 to call the appropriate
 	// callbacks if a delayed response or notification is received.
 	blockNumber := func() int64 {
-		result, err := call.Otto.Run("eth.blockNumber")
-		if err != nil {
-			throwJSException(err.Error())
+		blockNumber, isFunc := goja.AssertFunction(b.runtime.Get("eth.blockNumber"))
+		if !isFunc {
+			throwJSException(b.runtime, "eth.blockNumber isn't a function")
 		}
-		block, err := result.ToInteger()
+		block, err := blockNumber(goja.Null())
 		if err != nil {
-			throwJSException(err.Error())
+			throwJSException(b.runtime, err.Error())
 		}
-		return block
+		// XXX This will return 0 if blockNumber isn't an Integer. This is
+		// actually consistent with the current behavior (block number is 0
+		// until the sync is done) but not safe enough.
+		return block.ToInteger()
+
 	}
 	// Poll the current block number until either it ot a timeout is reached
 	targetBlockNr := blockNumber() + blocks
@@ -343,11 +393,11 @@ func (b *bridge) SleepBlocks(call otto.FunctionCall) (response otto.Value) {
 
 	for time.Now().Before(deadline) {
 		if blockNumber() >= targetBlockNr {
-			return otto.TrueValue()
+			return b.runtime.ToValue(true)
 		}
 		time.Sleep(time.Second)
 	}
-	return otto.FalseValue()
+	return b.runtime.ToValue(false)
 }
 
 type jsonrpcCall struct {
@@ -357,15 +407,14 @@ type jsonrpcCall struct {
 }
 
 // Send implements the web3 provider "send" method.
-func (b *bridge) Send(call otto.FunctionCall) (response otto.Value) {
+func (b *bridge) Send(call goja.FunctionCall) (response goja.Value) {
 	// Remarshal the request into a Go value.
-	JSON, _ := call.Otto.Object("JSON")
-	reqVal, err := JSON.Call("stringify", call.Argument(0))
+	reqVal, err := call.Argument(0).ToObject(b.runtime).MarshalJSON()
 	if err != nil {
-		throwJSException(err.Error())
+		throwJSException(b.runtime, err.Error())
 	}
 	var (
-		rawReq = reqVal.String()
+		rawReq = string(reqVal)
 		dec    = json.NewDecoder(strings.NewReader(rawReq))
 		reqs   []jsonrpcCall
 		batch  bool
@@ -381,9 +430,10 @@ func (b *bridge) Send(call otto.FunctionCall) (response otto.Value) {
 	}
 
 	// Execute the requests.
-	resps, _ := call.Otto.Object("new Array()")
+	var resps []*goja.Object
 	for _, req := range reqs {
-		resp, _ := call.Otto.Object(`({"jsonrpc":"2.0"})`)
+		v, _ := b.runtime.RunString(`({"jsonrpc":"2.0"})`)
+		resp := v.ToObject(b.runtime)
 		resp.Set("id", req.ID)
 		var result json.RawMessage
 		err = b.client.Call(&result, req.Method, req.Params...)
@@ -392,9 +442,15 @@ func (b *bridge) Send(call otto.FunctionCall) (response otto.Value) {
 			if result == nil {
 				// Special case null because it is decoded as an empty
 				// raw message for some reason.
-				resp.Set("result", otto.NullValue())
+				resp.Set("result", goja.Null())
 			} else {
-				resultVal, err := JSON.Call("parse", string(result))
+				JSON := b.runtime.Get("JSON").ToObject(b.runtime)
+				parse, callable := goja.AssertFunction(JSON.Get("parse"))
+				if !callable {
+					panic("JSON.parse isn't a function")
+				}
+
+				resultVal, err := parse(goja.Null(), b.runtime.ToValue(string(result)))
 				if err != nil {
 					setError(resp, -32603, err.Error())
 				} else {
@@ -406,33 +462,29 @@ func (b *bridge) Send(call otto.FunctionCall) (response otto.Value) {
 		default:
 			setError(resp, -32603, err.Error())
 		}
-		resps.Call("push", resp)
+		resps = append(resps, resp)
 	}
 
 	// Return the responses either to the callback (if supplied)
 	// or directly as the return value.
 	if batch {
-		response = resps.Value()
+		response = b.runtime.ToValue(resps)
 	} else {
-		response, _ = resps.Get("0")
+		response = resps[0]
 	}
-	if fn := call.Argument(1); fn.Class() == "Function" {
-		fn.Call(otto.NullValue(), otto.NullValue(), response)
-		return otto.UndefinedValue()
+	if fn, isFunc := goja.AssertFunction(call.Argument(1)); isFunc {
+		fn(goja.Null(), goja.Null(), response)
+		return goja.Undefined()
 	}
 	return response
 }
 
-func setError(resp *otto.Object, code int, msg string) {
+func setError(resp *goja.Object, code int, msg string) {
 	resp.Set("error", map[string]interface{}{"code": code, "message": msg})
 }
 
-// throwJSException panics on an otto.Value. The Otto VM will recover from the
+// throwJSException panics on an goja.Value. The Goja VM will recover from the
 // Go panic and throw msg as a JavaScript error.
-func throwJSException(msg interface{}) otto.Value {
-	val, err := otto.ToValue(msg)
-	if err != nil {
-		log.Error("Failed to serialize JavaScript exception", "exception", msg, "err", err)
-	}
-	panic(val)
+func throwJSException(runtime *goja.Runtime, msg interface{}) goja.Value {
+	panic(runtime.ToValue(msg))
 }

--- a/console/bridge.go
+++ b/console/bridge.go
@@ -27,7 +27,6 @@ import (
 	"github.com/dop251/goja"
 	"github.com/ethereum/go-ethereum/accounts/scwallet"
 	"github.com/ethereum/go-ethereum/accounts/usbwallet"
-	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/rpc"
 )
 

--- a/console/console.go
+++ b/console/console.go
@@ -28,12 +28,12 @@ import (
 	"strings"
 	"syscall"
 
+	"github.com/dop251/goja"
 	"github.com/ethereum/go-ethereum/internal/jsre"
 	"github.com/ethereum/go-ethereum/internal/web3ext"
 	"github.com/ethereum/go-ethereum/rpc"
 	"github.com/mattn/go-colorable"
 	"github.com/peterh/liner"
-	"github.com/robertkrimen/otto"
 )
 
 var (
@@ -64,13 +64,14 @@ type Config struct {
 // JavaScript console attached to a running node via an external or in-process RPC
 // client.
 type Console struct {
-	client   *rpc.Client  // RPC client to execute Ethereum requests through
-	jsre     *jsre.JSRE   // JavaScript runtime environment running the interpreter
-	prompt   string       // Input prompt prefix string
-	prompter UserPrompter // Input prompter to allow interactive user feedback
-	histPath string       // Absolute path to the console scrollback history
-	history  []string     // Scroll history maintained by the console
-	printer  io.Writer    // Output writer to serialize any display strings to
+	client   *rpc.Client   // RPC client to execute Ethereum requests through
+	jsre     *jsre.JSRE    // JavaScript runtime environment running the interpreter
+	prompt   string        // Input prompt prefix string
+	prompter UserPrompter  // Input prompter to allow interactive user feedback
+	histPath string        // Absolute path to the console scrollback history
+	history  []string      // Scroll history maintained by the console
+	printer  io.Writer     // Output writer to serialize any display strings to
+	runtime  *goja.Runtime // The javascript runtime
 }
 
 // New initializes a JavaScript interpreted runtime environment and sets defaults
@@ -86,10 +87,15 @@ func New(config Config) (*Console, error) {
 	if config.Printer == nil {
 		config.Printer = colorable.NewColorableStdout()
 	}
+
+	// Create the JS runtime
+	runtime := goja.New()
+
 	// Initialize the console and return
 	console := &Console{
+		runtime:  runtime,
 		client:   config.Client,
-		jsre:     jsre.New(config.DocRoot, config.Printer),
+		jsre:     jsre.New(config.DocRoot, config.Printer, runtime),
 		prompt:   config.Prompt,
 		prompter: config.Prompter,
 		printer:  config.Printer,
@@ -108,22 +114,31 @@ func New(config Config) (*Console, error) {
 // the console's JavaScript namespaces based on the exposed modules.
 func (c *Console) init(preload []string) error {
 	// Initialize the JavaScript <-> Go RPC bridge
-	bridge := newBridge(c.client, c.prompter, c.printer)
-	c.jsre.Set("jeth", struct{}{})
+	bridge := newBridge(c.client, c.prompter, c.printer, c.runtime)
+	c.jsre.Run("jeth = {};")
+	c.jsre.Run("console = {};")
 
-	jethObj, _ := c.jsre.Get("jeth")
-	jethObj.Object().Set("send", bridge.Send)
-	jethObj.Object().Set("sendAsync", bridge.Send)
+	jethObj := c.jsre.Get("jeth").ToObject(c.runtime)
+	if err := jethObj.Set("send", bridge.Send); err != nil {
+		panic(err)
+	}
+	if err := jethObj.Set("sendAsync", bridge.Send); err != nil {
+		panic(err)
+	}
 
-	consoleObj, _ := c.jsre.Get("console")
-	consoleObj.Object().Set("log", c.consoleOutput)
-	consoleObj.Object().Set("error", c.consoleOutput)
+	consoleObj := c.runtime.Get("console").ToObject(c.runtime)
+	if err := consoleObj.Set("log", c.consoleOutput); err != nil {
+		panic(err)
+	}
+	if err := consoleObj.Set("error", c.consoleOutput); err != nil {
+		panic(err)
+	}
 
 	// Load all the internal utility JavaScript libraries
-	if err := c.jsre.Compile("bignumber.js", jsre.BignumberJs); err != nil {
+	if err := c.jsre.Compile("bignumber.js", string(jsre.BignumberJs)); err != nil {
 		return fmt.Errorf("bignumber.js: %v", err)
 	}
-	if err := c.jsre.Compile("web3.js", jsre.Web3Js); err != nil {
+	if err := c.jsre.Compile("web3.js", string(jsre.Web3Js)); err != nil {
 		return fmt.Errorf("web3.js: %v", err)
 	}
 	if _, err := c.jsre.Run("var Web3 = require('web3');"); err != nil {
@@ -148,7 +163,7 @@ func (c *Console) init(preload []string) error {
 				return fmt.Errorf("%s.js: %v", api, err)
 			}
 			flatten += fmt.Sprintf("var %s = web3.%s; ", api, api)
-		} else if obj, err := c.jsre.Run("web3." + api); err == nil && obj.IsObject() {
+		} else if obj, err := c.jsre.Run("web3." + api); err == nil && obj.ToObject(c.runtime) != nil {
 			// Enable web3.js built-in extension if available.
 			flatten += fmt.Sprintf("var %s = web3.%s; ", api, api)
 		}
@@ -162,16 +177,16 @@ func (c *Console) init(preload []string) error {
 	// If the console is in interactive mode, instrument password related methods to query the user
 	if c.prompter != nil {
 		// Retrieve the account management object to instrument
-		personal, err := c.jsre.Get("personal")
-		if err != nil {
-			return err
+		personal := c.jsre.Get("personal")
+		if personal == nil {
+			return fmt.Errorf("Could not find personal")
 		}
 		// Override the openWallet, unlockAccount, newAccount and sign methods since
 		// these require user interaction. Assign these method in the Console the
 		// original web3 callbacks. These will be called by the jeth.* methods after
 		// they got the password from the user and send the original web3 request to
 		// the backend.
-		if obj := personal.Object(); obj != nil { // make sure the personal api is enabled over the interface
+		if obj := personal.ToObject(c.runtime); obj != nil { // make sure the personal api is enabled over the interface
 			if _, err = c.jsre.Run(`jeth.openWallet = personal.openWallet;`); err != nil {
 				return fmt.Errorf("personal.openWallet: %v", err)
 			}
@@ -191,11 +206,11 @@ func (c *Console) init(preload []string) error {
 		}
 	}
 	// The admin.sleep and admin.sleepBlocks are offered by the console and not by the RPC layer.
-	admin, err := c.jsre.Get("admin")
-	if err != nil {
-		return err
+	admin := c.jsre.Get("admin")
+	if admin == nil {
+		return fmt.Errorf("Could not find admin")
 	}
-	if obj := admin.Object(); obj != nil { // make sure the admin api is enabled over the interface
+	if obj := admin.ToObject(c.runtime); obj != nil { // make sure the admin api is enabled over the interface
 		obj.Set("sleepBlocks", bridge.SleepBlocks)
 		obj.Set("sleep", bridge.Sleep)
 		obj.Set("clearHistory", c.clearHistory)
@@ -204,8 +219,8 @@ func (c *Console) init(preload []string) error {
 	for _, path := range preload {
 		if err := c.jsre.Exec(path); err != nil {
 			failure := err.Error()
-			if ottoErr, ok := err.(*otto.Error); ok {
-				failure = ottoErr.String()
+			if gojaErr, ok := err.(*goja.Exception); ok {
+				failure = gojaErr.String()
 			}
 			return fmt.Errorf("%s: %v", path, failure)
 		}
@@ -235,13 +250,13 @@ func (c *Console) clearHistory() {
 
 // consoleOutput is an override for the console.log and console.error methods to
 // stream the output into the configured output stream instead of stdout.
-func (c *Console) consoleOutput(call otto.FunctionCall) otto.Value {
+func (c *Console) consoleOutput(call goja.FunctionCall) goja.Value {
 	var output []string
-	for _, argument := range call.ArgumentList {
+	for _, argument := range call.Arguments {
 		output = append(output, fmt.Sprintf("%v", argument))
 	}
 	fmt.Fprintln(c.printer, strings.Join(output, " "))
-	return otto.Value{}
+	return goja.Null()
 }
 
 // AutoCompleteInput is a pre-assembled word completer to be used by the user

--- a/console/console.go
+++ b/console/console.go
@@ -30,6 +30,7 @@ import (
 
 	"github.com/dop251/goja"
 	"github.com/ethereum/go-ethereum/internal/jsre"
+	"github.com/ethereum/go-ethereum/internal/jsre/deps"
 	"github.com/ethereum/go-ethereum/internal/web3ext"
 	"github.com/ethereum/go-ethereum/rpc"
 	"github.com/mattn/go-colorable"
@@ -181,10 +182,12 @@ func (c *Console) initConsoleObject() {
 }
 
 func (c *Console) initWeb3(bridge *bridge) error {
-	if err := c.jsre.Compile("bignumber.js", string(jsre.BignumberJs)); err != nil {
+	bnJS := string(deps.MustAsset("bignumber.js"))
+	web3JS := string(deps.MustAsset("web3.js"))
+	if err := c.jsre.Compile("bignumber.js", bnJS); err != nil {
 		return fmt.Errorf("bignumber.js: %v", err)
 	}
-	if err := c.jsre.Compile("web3.js", string(jsre.Web3Js)); err != nil {
+	if err := c.jsre.Compile("web3.js", web3JS); err != nil {
 		return fmt.Errorf("web3.js: %v", err)
 	}
 	if _, err := c.jsre.Run("var Web3 = require('web3');"); err != nil {

--- a/console/console.go
+++ b/console/console.go
@@ -206,14 +206,14 @@ func (c *Console) init(preload []string) error {
 		}
 	}
 	// The admin.sleep and admin.sleepBlocks are offered by the console and not by the RPC layer.
-	admin := c.jsre.Get("admin")
-	if admin == nil {
-		return fmt.Errorf("could not find admin")
-	}
-	if obj := admin.ToObject(c.runtime); obj != nil { // make sure the admin api is enabled over the interface
-		obj.Set("sleepBlocks", bridge.SleepBlocks)
-		obj.Set("sleep", bridge.Sleep)
-		obj.Set("clearHistory", c.clearHistory)
+	admin := c.jsre.Get("admin") // Could be `nil`
+	if admin != nil {
+		// make sure the admin api is enabled over the interface
+		if obj := admin.ToObject(c.runtime); obj != nil {
+			obj.Set("sleepBlocks", bridge.SleepBlocks)
+			obj.Set("sleep", bridge.Sleep)
+			obj.Set("clearHistory", c.clearHistory)
+		}
 	}
 	// Preload any JavaScript files before starting the console
 	for _, path := range preload {

--- a/console/console.go
+++ b/console/console.go
@@ -179,7 +179,7 @@ func (c *Console) init(preload []string) error {
 		// Retrieve the account management object to instrument
 		personal := c.jsre.Get("personal")
 		if personal == nil {
-			return fmt.Errorf("Could not find personal")
+			return fmt.Errorf("could not find personal")
 		}
 		// Override the openWallet, unlockAccount, newAccount and sign methods since
 		// these require user interaction. Assign these method in the Console the
@@ -208,7 +208,7 @@ func (c *Console) init(preload []string) error {
 	// The admin.sleep and admin.sleepBlocks are offered by the console and not by the RPC layer.
 	admin := c.jsre.Get("admin")
 	if admin == nil {
-		return fmt.Errorf("Could not find admin")
+		return fmt.Errorf("could not find admin")
 	}
 	if obj := admin.ToObject(c.runtime); obj != nil { // make sure the admin api is enabled over the interface
 		obj.Set("sleepBlocks", bridge.SleepBlocks)

--- a/console/console.go
+++ b/console/console.go
@@ -119,20 +119,12 @@ func (c *Console) init(preload []string) error {
 	c.jsre.Run("console = {};")
 
 	jethObj := c.jsre.Get("jeth").ToObject(c.runtime)
-	if err := jethObj.Set("send", bridge.Send); err != nil {
-		panic(err)
-	}
-	if err := jethObj.Set("sendAsync", bridge.Send); err != nil {
-		panic(err)
-	}
+	jethObj.Set("send", bridge.Send)
+	jethObj.Set("sendAsync", bridge.Send)
 
 	consoleObj := c.runtime.Get("console").ToObject(c.runtime)
-	if err := consoleObj.Set("log", c.consoleOutput); err != nil {
-		panic(err)
-	}
-	if err := consoleObj.Set("error", c.consoleOutput); err != nil {
-		panic(err)
-	}
+	consoleObj.Set("log", c.consoleOutput)
+	consoleObj.Set("error", c.consoleOutput)
 
 	// Load all the internal utility JavaScript libraries
 	if err := c.jsre.Compile("bignumber.js", string(jsre.BignumberJs)); err != nil {

--- a/console/console.go
+++ b/console/console.go
@@ -205,7 +205,7 @@ func (c *Console) initExtensions() error {
 	// Apply aliases.
 	c.jsre.Do(func(vm *goja.Runtime) {
 		web3 := getObject(vm, "web3")
-		for name, _ := range aliases {
+		for name := range aliases {
 			if v := web3.Get(name); v != nil {
 				vm.Set(name, v)
 			}

--- a/console/console_test.go
+++ b/console/console_test.go
@@ -289,7 +289,7 @@ func TestPrettyError(t *testing.T) {
 	defer tester.Close(t)
 	tester.console.Evaluate("throw 'hello'")
 
-	want := jsre.ErrorColor("hello") + "\n"
+	want := jsre.ErrorColor("hello") + "\n\tat <eval>:1:7(1)\n\n"
 	if output := tester.output.String(); output != want {
 		t.Fatalf("pretty error mismatch: have %s, want %s", output, want)
 	}

--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/deckarep/golang-set v0.0.0-20180603214616-504e848d77ea
 	github.com/dlclark/regexp2 v1.2.0 // indirect
 	github.com/docker/docker v1.4.2-0.20180625184442-8e610b2b55bf
-	github.com/dop251/goja v0.0.0-20191203121440-007eef3bc40f
+	github.com/dop251/goja v0.0.0-20200106141417-aaec0e7bde29
 	github.com/edsrzf/mmap-go v0.0.0-20160512033002-935e0e8a636c
 	github.com/elastic/gosigar v0.8.1-0.20180330100440-37f05ff46ffa
 	github.com/fatih/color v1.3.0

--- a/go.mod
+++ b/go.mod
@@ -16,13 +16,16 @@ require (
 	github.com/cloudflare/cloudflare-go v0.10.2-0.20190916151808-a80f83b9add9
 	github.com/davecgh/go-spew v1.1.1
 	github.com/deckarep/golang-set v0.0.0-20180603214616-504e848d77ea
+	github.com/dlclark/regexp2 v1.2.0 // indirect
 	github.com/docker/docker v1.4.2-0.20180625184442-8e610b2b55bf
+	github.com/dop251/goja v0.0.0-20191203121440-007eef3bc40f // indirect
 	github.com/edsrzf/mmap-go v0.0.0-20160512033002-935e0e8a636c
 	github.com/elastic/gosigar v0.8.1-0.20180330100440-37f05ff46ffa
 	github.com/fatih/color v1.3.0
 	github.com/fjl/memsize v0.0.0-20180418122429-ca190fb6ffbc
 	github.com/gballet/go-libpcsclite v0.0.0-20190607065134-2772fd86a8ff
 	github.com/go-ole/go-ole v1.2.1 // indirect
+	github.com/go-sourcemap/sourcemap v2.1.2+incompatible // indirect
 	github.com/go-stack/stack v1.8.0
 	github.com/golang/protobuf v1.3.2-0.20190517061210-b285ee9cfc6c
 	github.com/golang/snappy v0.0.1

--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/deckarep/golang-set v0.0.0-20180603214616-504e848d77ea
 	github.com/dlclark/regexp2 v1.2.0 // indirect
 	github.com/docker/docker v1.4.2-0.20180625184442-8e610b2b55bf
-	github.com/dop251/goja v0.0.0-20191203121440-007eef3bc40f // indirect
+	github.com/dop251/goja v0.0.0-20191203121440-007eef3bc40f
 	github.com/edsrzf/mmap-go v0.0.0-20160512033002-935e0e8a636c
 	github.com/elastic/gosigar v0.8.1-0.20180330100440-37f05ff46ffa
 	github.com/fatih/color v1.3.0

--- a/go.sum
+++ b/go.sum
@@ -63,6 +63,8 @@ github.com/docker/docker v1.4.2-0.20180625184442-8e610b2b55bf h1:sh8rkQZavChcmak
 github.com/docker/docker v1.4.2-0.20180625184442-8e610b2b55bf/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
 github.com/dop251/goja v0.0.0-20191203121440-007eef3bc40f h1:vtCDQseO/Sbu5IZSoc2uzZ7CkSoai7OtpcwGFK5FlyE=
 github.com/dop251/goja v0.0.0-20191203121440-007eef3bc40f/go.mod h1:Mw6PkjjMXWbTj+nnj4s3QPXq1jaT0s5pC0iFD4+BOAA=
+github.com/dop251/goja v0.0.0-20200106141417-aaec0e7bde29 h1:Ewd9K+mC725sITA12QQHRqWj78NU4t7EhlFVVgdlzJg=
+github.com/dop251/goja v0.0.0-20200106141417-aaec0e7bde29/go.mod h1:Mw6PkjjMXWbTj+nnj4s3QPXq1jaT0s5pC0iFD4+BOAA=
 github.com/edsrzf/mmap-go v0.0.0-20160512033002-935e0e8a636c h1:JHHhtb9XWJrGNMcrVP6vyzO4dusgi/HnceHTgxSejUM=
 github.com/edsrzf/mmap-go v0.0.0-20160512033002-935e0e8a636c/go.mod h1:YO35OhQPt3KJa3ryjFM5Bs14WD66h8eGKpfaBNrHW5M=
 github.com/elastic/gosigar v0.8.1-0.20180330100440-37f05ff46ffa h1:XKAhUk/dtp+CV0VO6mhG2V7jA9vbcGcnYF/Ay9NjZrY=

--- a/go.sum
+++ b/go.sum
@@ -57,8 +57,12 @@ github.com/deckarep/golang-set v0.0.0-20180603214616-504e848d77ea/go.mod h1:93vs
 github.com/dgrijalva/jwt-go v3.2.0+incompatible h1:7qlOGliEKZXTDg6OTjfoBKDXWrumCAMpl/TFQ4/5kLM=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/dgryski/go-sip13 v0.0.0-20181026042036-e10d5fee7954/go.mod h1:vAd38F8PWV+bWy6jNmig1y/TA+kYO4g3RSRF0IAv0no=
+github.com/dlclark/regexp2 v1.2.0 h1:8sAhBGEM0dRWogWqWyQeIJnxjWO6oIjl8FKqREDsGfk=
+github.com/dlclark/regexp2 v1.2.0/go.mod h1:2pZnwuY/m+8K6iRw6wQdMtk+rH5tNGR1i55kozfMjCc=
 github.com/docker/docker v1.4.2-0.20180625184442-8e610b2b55bf h1:sh8rkQZavChcmakYiSlqu2425CHyFXLZZnvm7PDpU8M=
 github.com/docker/docker v1.4.2-0.20180625184442-8e610b2b55bf/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
+github.com/dop251/goja v0.0.0-20191203121440-007eef3bc40f h1:vtCDQseO/Sbu5IZSoc2uzZ7CkSoai7OtpcwGFK5FlyE=
+github.com/dop251/goja v0.0.0-20191203121440-007eef3bc40f/go.mod h1:Mw6PkjjMXWbTj+nnj4s3QPXq1jaT0s5pC0iFD4+BOAA=
 github.com/edsrzf/mmap-go v0.0.0-20160512033002-935e0e8a636c h1:JHHhtb9XWJrGNMcrVP6vyzO4dusgi/HnceHTgxSejUM=
 github.com/edsrzf/mmap-go v0.0.0-20160512033002-935e0e8a636c/go.mod h1:YO35OhQPt3KJa3ryjFM5Bs14WD66h8eGKpfaBNrHW5M=
 github.com/elastic/gosigar v0.8.1-0.20180330100440-37f05ff46ffa h1:XKAhUk/dtp+CV0VO6mhG2V7jA9vbcGcnYF/Ay9NjZrY=
@@ -77,6 +81,8 @@ github.com/go-logfmt/logfmt v0.3.0 h1:8HUsc87TaSWLKwrnumgC8/YconD2fJQsRJAsWaPg2i
 github.com/go-logfmt/logfmt v0.3.0/go.mod h1:Qt1PoO58o5twSAckw1HlFXLmHsOX5/0LbT9GBnD5lWE=
 github.com/go-ole/go-ole v1.2.1 h1:2lOsA72HgjxAuMlKpFiCbHTvu44PIVkZ5hqm3RSdI/E=
 github.com/go-ole/go-ole v1.2.1/go.mod h1:7FAglXiTm7HKlQRDeOQ6ZNUHidzCWXuZWq/1dTyBNF8=
+github.com/go-sourcemap/sourcemap v2.1.2+incompatible h1:0b/xya7BKGhXuqFESKM4oIiRo9WOt2ebz7KxfreD6ug=
+github.com/go-sourcemap/sourcemap v2.1.2+incompatible/go.mod h1:F8jJfvm2KbVjc5NqelyYJmf/v5J0dwNLS2mL4sNA1Jg=
 github.com/go-stack/stack v1.8.0 h1:5SgMzNM5HxrEjV0ww2lTmX6E2Izsfxas4+YHWRs3Lsk=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
 github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=

--- a/internal/jsre/completion_test.go
+++ b/internal/jsre/completion_test.go
@@ -42,6 +42,10 @@ func TestCompleteKeywords(t *testing.T) {
 		want  []string
 	}{
 		{
+			input: "St",
+			want:  []string{"String"},
+		},
+		{
 			input: "x",
 			want:  []string{"x."},
 		},

--- a/internal/jsre/completion_test.go
+++ b/internal/jsre/completion_test.go
@@ -20,10 +20,12 @@ import (
 	"os"
 	"reflect"
 	"testing"
+
+	"github.com/dop251/goja"
 )
 
 func TestCompleteKeywords(t *testing.T) {
-	re := New("", os.Stdout)
+	re := New("", os.Stdout, goja.New())
 	re.Run(`
 		function theClass() {
 			this.foo = 3;

--- a/internal/jsre/completion_test.go
+++ b/internal/jsre/completion_test.go
@@ -20,12 +20,10 @@ import (
 	"os"
 	"reflect"
 	"testing"
-
-	"github.com/dop251/goja"
 )
 
 func TestCompleteKeywords(t *testing.T) {
-	re := New("", os.Stdout, goja.New())
+	re := New("", os.Stdout)
 	re.Run(`
 		function theClass() {
 			this.foo = 3;

--- a/internal/jsre/jsre.go
+++ b/internal/jsre/jsre.go
@@ -28,12 +28,6 @@ import (
 
 	"github.com/dop251/goja"
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/internal/jsre/deps"
-)
-
-var (
-	BignumberJs = deps.MustAsset("bignumber.js")
-	Web3Js      = deps.MustAsset("web3.js")
 )
 
 // JSRE is a JS runtime environment embedding the goja interpreter.

--- a/internal/jsre/jsre.go
+++ b/internal/jsre/jsre.go
@@ -26,9 +26,9 @@ import (
 	"math/rand"
 	"time"
 
+	"github.com/dop251/goja"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/internal/jsre/deps"
-	"github.com/robertkrimen/otto"
 )
 
 var (
@@ -37,7 +37,7 @@ var (
 )
 
 /*
-JSRE is a generic JS runtime environment embedding the otto JS interpreter.
+JSRE is a generic JS runtime environment embedding the goja JS interpreter.
 It provides some helper functions to
 - load code from files
 - run code snippets
@@ -50,6 +50,7 @@ type JSRE struct {
 	evalQueue     chan *evalReq
 	stopEventLoop chan bool
 	closed        chan struct{}
+	vm            *goja.Runtime
 }
 
 // jsTimer is a single timer instance with a callback function
@@ -57,23 +58,24 @@ type jsTimer struct {
 	timer    *time.Timer
 	duration time.Duration
 	interval bool
-	call     otto.FunctionCall
+	call     goja.FunctionCall
 }
 
 // evalReq is a serialized vm execution request processed by runEventLoop.
 type evalReq struct {
-	fn   func(vm *otto.Otto)
+	fn   func(vm *goja.Runtime)
 	done chan bool
 }
 
 // runtime must be stopped with Stop() after use and cannot be used after stopping
-func New(assetPath string, output io.Writer) *JSRE {
+func New(assetPath string, output io.Writer, vm *goja.Runtime) *JSRE {
 	re := &JSRE{
 		assetPath:     assetPath,
 		output:        output,
 		closed:        make(chan struct{}),
 		evalQueue:     make(chan *evalReq),
 		stopEventLoop: make(chan bool),
+		vm:            vm,
 	}
 	go re.runEventLoop()
 	re.Set("loadScript", re.loadScript)
@@ -99,21 +101,20 @@ func randomSource() *rand.Rand {
 // serialized way and calls timer callback functions at the appropriate time.
 
 // Exported functions always access the vm through the event queue. You can
-// call the functions of the otto vm directly to circumvent the queue. These
+// call the functions of the goja vm directly to circumvent the queue. These
 // functions should be used if and only if running a routine that was already
 // called from JS through an RPC call.
 func (re *JSRE) runEventLoop() {
 	defer close(re.closed)
 
-	vm := otto.New()
 	r := randomSource()
-	vm.SetRandomSource(r.Float64)
+	re.vm.SetRandSource(r.Float64)
 
 	registry := map[*jsTimer]*jsTimer{}
 	ready := make(chan *jsTimer)
 
-	newTimer := func(call otto.FunctionCall, interval bool) (*jsTimer, otto.Value) {
-		delay, _ := call.Argument(1).ToInteger()
+	newTimer := func(call goja.FunctionCall, interval bool) (*jsTimer, goja.Value) {
+		delay := call.Argument(1).ToInteger()
 		if 0 >= delay {
 			delay = 1
 		}
@@ -128,47 +129,43 @@ func (re *JSRE) runEventLoop() {
 			ready <- timer
 		})
 
-		value, err := call.Otto.ToValue(timer)
-		if err != nil {
-			panic(err)
-		}
-		return timer, value
+		return timer, re.vm.ToValue(timer)
 	}
 
-	setTimeout := func(call otto.FunctionCall) otto.Value {
+	setTimeout := func(call goja.FunctionCall) goja.Value {
 		_, value := newTimer(call, false)
 		return value
 	}
 
-	setInterval := func(call otto.FunctionCall) otto.Value {
+	setInterval := func(call goja.FunctionCall) goja.Value {
 		_, value := newTimer(call, true)
 		return value
 	}
 
-	clearTimeout := func(call otto.FunctionCall) otto.Value {
-		timer, _ := call.Argument(0).Export()
+	clearTimeout := func(call goja.FunctionCall) goja.Value {
+		timer := call.Argument(0).Export()
 		if timer, ok := timer.(*jsTimer); ok {
 			timer.timer.Stop()
 			delete(registry, timer)
 		}
-		return otto.UndefinedValue()
+		return goja.Undefined()
 	}
-	vm.Set("_setTimeout", setTimeout)
-	vm.Set("_setInterval", setInterval)
-	vm.Run(`var setTimeout = function(args) {
+	re.vm.Set("_setTimeout", setTimeout)
+	re.vm.Set("_setInterval", setInterval)
+	re.vm.RunString(`var setTimeout = function(args) {
 		if (arguments.length < 1) {
 			throw TypeError("Failed to execute 'setTimeout': 1 argument required, but only 0 present.");
 		}
 		return _setTimeout.apply(this, arguments);
 	}`)
-	vm.Run(`var setInterval = function(args) {
+	re.vm.RunString(`var setInterval = function(args) {
 		if (arguments.length < 1) {
 			throw TypeError("Failed to execute 'setInterval': 1 argument required, but only 0 present.");
 		}
 		return _setInterval.apply(this, arguments);
 	}`)
-	vm.Set("clearTimeout", clearTimeout)
-	vm.Set("clearInterval", clearTimeout)
+	re.vm.Set("clearTimeout", clearTimeout)
+	re.vm.Set("clearInterval", clearTimeout)
 
 	var waitForCallbacks bool
 
@@ -178,8 +175,8 @@ loop:
 		case timer := <-ready:
 			// execute callback, remove/reschedule the timer
 			var arguments []interface{}
-			if len(timer.call.ArgumentList) > 2 {
-				tmp := timer.call.ArgumentList[2:]
+			if len(timer.call.Arguments) > 2 {
+				tmp := timer.call.Arguments[2:]
 				arguments = make([]interface{}, 2+len(tmp))
 				for i, value := range tmp {
 					arguments[i+2] = value
@@ -187,11 +184,12 @@ loop:
 			} else {
 				arguments = make([]interface{}, 1)
 			}
-			arguments[0] = timer.call.ArgumentList[0]
-			_, err := vm.Call(`Function.call.call`, nil, arguments...)
-			if err != nil {
-				fmt.Println("js error:", err, arguments)
+			arguments[0] = timer.call.Arguments[0]
+			call, isFunc := goja.AssertFunction(timer.call.Arguments[0])
+			if !isFunc {
+				panic(re.vm.ToValue("js error: timer/timeout callback is not a function"))
 			}
+			call(goja.Null(), timer.call.Arguments...)
 
 			_, inreg := registry[timer] // when clearInterval is called from within the callback don't reset it
 			if timer.interval && inreg {
@@ -204,7 +202,7 @@ loop:
 			}
 		case req := <-re.evalQueue:
 			// run the code, send the result back
-			req.fn(vm)
+			req.fn(re.vm)
 			close(req.done)
 			if waitForCallbacks && (len(registry) == 0) {
 				break loop
@@ -223,7 +221,7 @@ loop:
 }
 
 // Do executes the given function on the JS event loop.
-func (re *JSRE) Do(fn func(*otto.Otto)) {
+func (re *JSRE) Do(fn func(*goja.Runtime)) {
 	done := make(chan bool)
 	req := &evalReq{fn, done}
 	re.evalQueue <- req
@@ -246,13 +244,13 @@ func (re *JSRE) Exec(file string) error {
 	if err != nil {
 		return err
 	}
-	var script *otto.Script
-	re.Do(func(vm *otto.Otto) {
-		script, err = vm.Compile(file, code)
+	var script *goja.Program
+	re.Do(func(vm *goja.Runtime) {
+		script, err = goja.Compile(file, string(code), false)
 		if err != nil {
 			return
 		}
-		_, err = vm.Run(script)
+		_, err = vm.RunProgram(script)
 	})
 	return err
 }
@@ -264,43 +262,38 @@ func (re *JSRE) Bind(name string, v interface{}) error {
 }
 
 // Run runs a piece of JS code.
-func (re *JSRE) Run(code string) (v otto.Value, err error) {
-	re.Do(func(vm *otto.Otto) { v, err = vm.Run(code) })
+func (re *JSRE) Run(code string) (v goja.Value, err error) {
+	re.Do(func(vm *goja.Runtime) { v, err = vm.RunString(code) })
 	return v, err
 }
 
 // Get returns the value of a variable in the JS environment.
-func (re *JSRE) Get(ns string) (v otto.Value, err error) {
-	re.Do(func(vm *otto.Otto) { v, err = vm.Get(ns) })
-	return v, err
+func (re *JSRE) Get(ns string) (v goja.Value) {
+	re.Do(func(vm *goja.Runtime) { v = vm.Get(ns) })
+	return v
 }
 
 // Set assigns value v to a variable in the JS environment.
 func (re *JSRE) Set(ns string, v interface{}) (err error) {
-	re.Do(func(vm *otto.Otto) { err = vm.Set(ns, v) })
+	re.Do(func(vm *goja.Runtime) { vm.Set(ns, v) })
 	return err
 }
 
 // loadScript executes a JS script from inside the currently executing JS code.
-func (re *JSRE) loadScript(call otto.FunctionCall) otto.Value {
-	file, err := call.Argument(0).ToString()
-	if err != nil {
-		// TODO: throw exception
-		return otto.FalseValue()
-	}
+func (re *JSRE) loadScript(call goja.FunctionCall) goja.Value {
+	file := call.Argument(0).ToString().String()
 	file = common.AbsolutePath(re.assetPath, file)
 	source, err := ioutil.ReadFile(file)
 	if err != nil {
-		// TODO: throw exception
-		return otto.FalseValue()
+		// Panicking with a goja.Value arg will cause a JS exception
+		// in the caller.
+		panic(re.vm.ToValue(fmt.Sprintf("Could not read file %s: %v", file, err)))
 	}
-	if _, err := compileAndRun(call.Otto, file, source); err != nil {
-		// TODO: throw exception
-		fmt.Println("err:", err)
-		return otto.FalseValue()
+	value, err := compileAndRun(re.vm, file, string(source))
+	if err != nil {
+		panic(re.vm.ToValue(fmt.Sprintf("Error while compiling or running script: %v", err)))
 	}
-	// TODO: return evaluation result
-	return otto.TrueValue()
+	return value
 }
 
 // Evaluate executes code and pretty prints the result to the specified output
@@ -308,8 +301,8 @@ func (re *JSRE) loadScript(call otto.FunctionCall) otto.Value {
 func (re *JSRE) Evaluate(code string, w io.Writer) error {
 	var fail error
 
-	re.Do(func(vm *otto.Otto) {
-		val, err := vm.Run(code)
+	re.Do(func(vm *goja.Runtime) {
+		val, err := vm.RunString(code)
 		if err != nil {
 			prettyError(vm, err, w)
 		} else {
@@ -321,15 +314,15 @@ func (re *JSRE) Evaluate(code string, w io.Writer) error {
 }
 
 // Compile compiles and then runs a piece of JS code.
-func (re *JSRE) Compile(filename string, src interface{}) (err error) {
-	re.Do(func(vm *otto.Otto) { _, err = compileAndRun(vm, filename, src) })
+func (re *JSRE) Compile(filename string, src string) (err error) {
+	re.Do(func(vm *goja.Runtime) { _, err = compileAndRun(vm, filename, src) })
 	return err
 }
 
-func compileAndRun(vm *otto.Otto, filename string, src interface{}) (otto.Value, error) {
-	script, err := vm.Compile(filename, src)
+func compileAndRun(vm *goja.Runtime, filename string, src string) (goja.Value, error) {
+	script, err := goja.Compile(filename, src, false)
 	if err != nil {
-		return otto.Value{}, err
+		return goja.Null(), err
 	}
-	return vm.Run(script)
+	return vm.RunProgram(script)
 }

--- a/internal/jsre/jsre_test.go
+++ b/internal/jsre/jsre_test.go
@@ -50,7 +50,7 @@ func newWithTestJS(t *testing.T, testjs string) (*JSRE, string) {
 			t.Fatal("cannot create test.js:", err)
 		}
 	}
-	jsre := New(dir, os.Stdout, goja.New())
+	jsre := New(dir, os.Stdout)
 	return jsre, dir
 }
 
@@ -102,10 +102,10 @@ func TestNatto(t *testing.T) {
 }
 
 func TestBind(t *testing.T) {
-	jsre := New("", os.Stdout, goja.New())
+	jsre := New("", os.Stdout)
 	defer jsre.Stop(false)
 
-	jsre.Bind("no", &testNativeObjectBinding{vm: jsre.vm})
+	jsre.Set("no", &testNativeObjectBinding{vm: jsre.vm})
 
 	_, err := jsre.Run(`no.TestMethod("testMsg")`)
 	if err != nil {

--- a/internal/jsre/jsre_test.go
+++ b/internal/jsre/jsre_test.go
@@ -20,25 +20,24 @@ import (
 	"io/ioutil"
 	"os"
 	"path"
+	"reflect"
 	"testing"
 	"time"
 
-	"github.com/robertkrimen/otto"
+	"github.com/dop251/goja"
 )
 
-type testNativeObjectBinding struct{}
+type testNativeObjectBinding struct {
+	vm *goja.Runtime
+}
 
 type msg struct {
 	Msg string
 }
 
-func (no *testNativeObjectBinding) TestMethod(call otto.FunctionCall) otto.Value {
-	m, err := call.Argument(0).ToString()
-	if err != nil {
-		return otto.UndefinedValue()
-	}
-	v, _ := call.Otto.ToValue(&msg{m})
-	return v
+func (no *testNativeObjectBinding) TestMethod(call goja.FunctionCall) goja.Value {
+	m := call.Argument(0).ToString().String()
+	return no.vm.ToValue(&msg{m})
 }
 
 func newWithTestJS(t *testing.T, testjs string) (*JSRE, string) {
@@ -51,7 +50,8 @@ func newWithTestJS(t *testing.T, testjs string) (*JSRE, string) {
 			t.Fatal("cannot create test.js:", err)
 		}
 	}
-	return New(dir, os.Stdout), dir
+	jsre := New(dir, os.Stdout, goja.New())
+	return jsre, dir
 }
 
 func TestExec(t *testing.T) {
@@ -66,11 +66,11 @@ func TestExec(t *testing.T) {
 	if err != nil {
 		t.Errorf("expected no error, got %v", err)
 	}
-	if !val.IsString() {
+	if val.ExportType().Kind() != reflect.String {
 		t.Errorf("expected string value, got %v", val)
 	}
 	exp := "testMsg"
-	got, _ := val.ToString()
+	got := val.ToString().String()
 	if exp != got {
 		t.Errorf("expected '%v', got '%v'", exp, got)
 	}
@@ -90,11 +90,11 @@ func TestNatto(t *testing.T) {
 	if err != nil {
 		t.Errorf("expected no error, got %v", err)
 	}
-	if !val.IsString() {
+	if val.ExportType().Kind() != reflect.String {
 		t.Errorf("expected string value, got %v", val)
 	}
 	exp := "testMsg"
-	got, _ := val.ToString()
+	got := val.ToString().String()
 	if exp != got {
 		t.Errorf("expected '%v', got '%v'", exp, got)
 	}
@@ -102,10 +102,10 @@ func TestNatto(t *testing.T) {
 }
 
 func TestBind(t *testing.T) {
-	jsre := New("", os.Stdout)
+	jsre := New("", os.Stdout, goja.New())
 	defer jsre.Stop(false)
 
-	jsre.Bind("no", &testNativeObjectBinding{})
+	jsre.Bind("no", &testNativeObjectBinding{vm: jsre.vm})
 
 	_, err := jsre.Run(`no.TestMethod("testMsg")`)
 	if err != nil {
@@ -125,11 +125,11 @@ func TestLoadScript(t *testing.T) {
 	if err != nil {
 		t.Errorf("expected no error, got %v", err)
 	}
-	if !val.IsString() {
+	if val.ExportType().Kind() != reflect.String {
 		t.Errorf("expected string value, got %v", val)
 	}
 	exp := "testMsg"
-	got, _ := val.ToString()
+	got := val.ToString().String()
 	if exp != got {
 		t.Errorf("expected '%v', got '%v'", exp, got)
 	}

--- a/internal/jsre/pretty.go
+++ b/internal/jsre/pretty.go
@@ -19,12 +19,13 @@ package jsre
 import (
 	"fmt"
 	"io"
+	"reflect"
 	"sort"
 	"strconv"
 	"strings"
 
+	"github.com/dop251/goja"
 	"github.com/fatih/color"
-	"github.com/robertkrimen/otto"
 )
 
 const (
@@ -52,29 +53,29 @@ var boringKeys = map[string]bool{
 }
 
 // prettyPrint writes value to standard output.
-func prettyPrint(vm *otto.Otto, value otto.Value, w io.Writer) {
+func prettyPrint(vm *goja.Runtime, value goja.Value, w io.Writer) {
 	ppctx{vm: vm, w: w}.printValue(value, 0, false)
 }
 
 // prettyError writes err to standard output.
-func prettyError(vm *otto.Otto, err error, w io.Writer) {
+func prettyError(vm *goja.Runtime, err error, w io.Writer) {
 	failure := err.Error()
-	if ottoErr, ok := err.(*otto.Error); ok {
-		failure = ottoErr.String()
+	if gojaErr, ok := err.(*goja.Exception); ok {
+		failure = gojaErr.String()
 	}
 	fmt.Fprint(w, ErrorColor("%s", failure))
 }
 
-func (re *JSRE) prettyPrintJS(call otto.FunctionCall) otto.Value {
-	for _, v := range call.ArgumentList {
-		prettyPrint(call.Otto, v, re.output)
+func (re *JSRE) prettyPrintJS(call goja.FunctionCall) goja.Value {
+	for _, v := range call.Arguments {
+		prettyPrint(re.vm, v, re.output)
 		fmt.Fprintln(re.output)
 	}
-	return otto.UndefinedValue()
+	return goja.Undefined()
 }
 
 type ppctx struct {
-	vm *otto.Otto
+	vm *goja.Runtime
 	w  io.Writer
 }
 
@@ -82,35 +83,54 @@ func (ctx ppctx) indent(level int) string {
 	return strings.Repeat(indentString, level)
 }
 
-func (ctx ppctx) printValue(v otto.Value, level int, inArray bool) {
+func (ctx ppctx) printValue(v goja.Value, level int, inArray bool) {
 	switch {
-	case v.IsObject():
-		ctx.printObject(v.Object(), level, inArray)
-	case v.IsNull():
+	case goja.IsNull(v):
 		fmt.Fprint(ctx.w, SpecialColor("null"))
-	case v.IsUndefined():
+	case goja.IsUndefined(v):
 		fmt.Fprint(ctx.w, SpecialColor("undefined"))
-	case v.IsString():
-		s, _ := v.ToString()
-		fmt.Fprint(ctx.w, StringColor("%q", s))
-	case v.IsBoolean():
-		b, _ := v.ToBoolean()
-		fmt.Fprint(ctx.w, SpecialColor("%t", b))
-	case v.IsNaN():
+	case goja.IsNaN(v):
 		fmt.Fprint(ctx.w, NumberColor("NaN"))
-	case v.IsNumber():
-		s, _ := v.ToString()
-		fmt.Fprint(ctx.w, NumberColor("%s", s))
 	default:
-		fmt.Fprint(ctx.w, "<unprintable>")
+		switch v.ExportType().Kind() {
+		case reflect.String:
+			s := v.ToString().String()
+			fmt.Fprint(ctx.w, StringColor("%q", s))
+		case reflect.Bool:
+			b := v.ToBoolean()
+			fmt.Fprint(ctx.w, SpecialColor("%t", b))
+		case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+			s := v.ToString().String()
+			fmt.Fprint(ctx.w, NumberColor("%s", s))
+		default:
+			if obj, ok := v.(*goja.Object); ok {
+				ctx.printObject(obj, level, inArray)
+			} else {
+				fmt.Fprint(ctx.w, "<unprintable>")
+			}
+		}
 	}
 }
 
-func (ctx ppctx) printObject(obj *otto.Object, level int, inArray bool) {
-	switch obj.Class() {
+// SafeGet attempt to get the value associated to `key`, and
+// catches the panic that goja creates if an error occurs in
+// key.
+func SafeGet(obj *goja.Object, key string) (ret goja.Value) {
+	defer func() {
+		if r := recover(); r != nil {
+			ret = goja.Undefined()
+		}
+	}()
+	ret = obj.Get(key)
+
+	return ret
+}
+
+func (ctx ppctx) printObject(obj *goja.Object, level int, inArray bool) {
+	switch obj.ClassName() {
 	case "Array", "GoArray":
-		lv, _ := obj.Get("length")
-		len, _ := lv.ToInteger()
+		lv := obj.Get("length")
+		len := lv.ToInteger()
 		if len == 0 {
 			fmt.Fprintf(ctx.w, "[]")
 			return
@@ -121,8 +141,8 @@ func (ctx ppctx) printObject(obj *otto.Object, level int, inArray bool) {
 		}
 		fmt.Fprint(ctx.w, "[")
 		for i := int64(0); i < len; i++ {
-			el, err := obj.Get(strconv.FormatInt(i, 10))
-			if err == nil {
+			el := obj.Get(strconv.FormatInt(i, 10))
+			if el != nil {
 				ctx.printValue(el, level+1, true)
 			}
 			if i < len-1 {
@@ -149,7 +169,7 @@ func (ctx ppctx) printObject(obj *otto.Object, level int, inArray bool) {
 		}
 		fmt.Fprintln(ctx.w, "{")
 		for i, k := range keys {
-			v, _ := obj.Get(k)
+			v := SafeGet(obj, k)
 			fmt.Fprintf(ctx.w, "%s%s: ", ctx.indent(level+1), k)
 			ctx.printValue(v, level+1, false)
 			if i < len(keys)-1 {
@@ -163,29 +183,25 @@ func (ctx ppctx) printObject(obj *otto.Object, level int, inArray bool) {
 		fmt.Fprintf(ctx.w, "%s}", ctx.indent(level))
 
 	case "Function":
-		// Use toString() to display the argument list if possible.
-		if robj, err := obj.Call("toString"); err != nil {
-			fmt.Fprint(ctx.w, FunctionColor("function()"))
-		} else {
-			desc := strings.Trim(strings.Split(robj.String(), "{")[0], " \t\n")
-			desc = strings.Replace(desc, " (", "(", 1)
-			fmt.Fprint(ctx.w, FunctionColor("%s", desc))
-		}
+		robj := obj.ToString()
+		desc := strings.Trim(strings.Split(robj.String(), "{")[0], " \t\n")
+		desc = strings.Replace(desc, " (", "(", 1)
+		fmt.Fprint(ctx.w, FunctionColor("%s", desc))
 
 	case "RegExp":
 		fmt.Fprint(ctx.w, StringColor("%s", toString(obj)))
 
 	default:
-		if v, _ := obj.Get("toString"); v.IsFunction() && level <= maxPrettyPrintLevel {
-			s, _ := obj.Call("toString")
-			fmt.Fprintf(ctx.w, "<%s %s>", obj.Class(), s.String())
+		if level <= maxPrettyPrintLevel {
+			s := obj.ToString().String()
+			fmt.Fprintf(ctx.w, "<%s %s>", obj.ClassName(), s)
 		} else {
-			fmt.Fprintf(ctx.w, "<%s>", obj.Class())
+			fmt.Fprintf(ctx.w, "<%s>", obj.ClassName())
 		}
 	}
 }
 
-func (ctx ppctx) fields(obj *otto.Object) []string {
+func (ctx ppctx) fields(obj *goja.Object) []string {
 	var (
 		vals, methods []string
 		seen          = make(map[string]bool)
@@ -195,11 +211,22 @@ func (ctx ppctx) fields(obj *otto.Object) []string {
 			return
 		}
 		seen[k] = true
-		if v, _ := obj.Get(k); v.IsFunction() {
-			methods = append(methods, k)
-		} else {
+
+		key := SafeGet(obj, k)
+		if key == nil {
+			// The value corresponding to that key could not be found
+			// (typically because it is backed by an RPC call that is
+			// not supported by this instance.  Add it to the list of
+			// values so that it appears as `undefined` to the user.
 			vals = append(vals, k)
+		} else {
+			if _, callable := goja.AssertFunction(key); callable {
+				methods = append(methods, k)
+			} else {
+				vals = append(vals, k)
+			}
 		}
+
 	}
 	iterOwnAndConstructorKeys(ctx.vm, obj, add)
 	sort.Strings(vals)
@@ -207,13 +234,13 @@ func (ctx ppctx) fields(obj *otto.Object) []string {
 	return append(vals, methods...)
 }
 
-func iterOwnAndConstructorKeys(vm *otto.Otto, obj *otto.Object, f func(string)) {
+func iterOwnAndConstructorKeys(vm *goja.Runtime, obj *goja.Object, f func(string)) {
 	seen := make(map[string]bool)
 	iterOwnKeys(vm, obj, func(prop string) {
 		seen[prop] = true
 		f(prop)
 	})
-	if cp := constructorPrototype(obj); cp != nil {
+	if cp := constructorPrototype(vm, obj); cp != nil {
 		iterOwnKeys(vm, cp, func(prop string) {
 			if !seen[prop] {
 				f(prop)
@@ -222,10 +249,17 @@ func iterOwnAndConstructorKeys(vm *otto.Otto, obj *otto.Object, f func(string)) 
 	}
 }
 
-func iterOwnKeys(vm *otto.Otto, obj *otto.Object, f func(string)) {
-	Object, _ := vm.Object("Object")
-	rv, _ := Object.Call("getOwnPropertyNames", obj.Value())
-	gv, _ := rv.Export()
+func iterOwnKeys(vm *goja.Runtime, obj *goja.Object, f func(string)) {
+	Object := vm.Get("Object").ToObject(vm)
+	getOwnPropertyNames, isFunc := goja.AssertFunction(Object.Get("getOwnPropertyNames"))
+	if !isFunc {
+		panic(vm.ToValue("Object.getOwnPropertyNames isn't a function"))
+	}
+	rv, err := getOwnPropertyNames(goja.Null(), obj)
+	if err != nil {
+		panic(vm.ToValue(fmt.Sprintf("Error getting object properties: %v", err)))
+	}
+	gv := rv.Export()
 	switch gv := gv.(type) {
 	case []interface{}:
 		for _, v := range gv {
@@ -240,32 +274,35 @@ func iterOwnKeys(vm *otto.Otto, obj *otto.Object, f func(string)) {
 	}
 }
 
-func (ctx ppctx) isBigNumber(v *otto.Object) bool {
+func (ctx ppctx) isBigNumber(v *goja.Object) bool {
 	// Handle numbers with custom constructor.
-	if v, _ := v.Get("constructor"); v.Object() != nil {
-		if strings.HasPrefix(toString(v.Object()), "function BigNumber") {
+	if obj := v.Get("constructor").ToObject(ctx.vm); obj != nil {
+		if strings.HasPrefix(toString(obj), "function BigNumber") {
 			return true
 		}
 	}
 	// Handle default constructor.
-	BigNumber, _ := ctx.vm.Object("BigNumber.prototype")
+	BigNumber := ctx.vm.Get("BigNumber").ToObject(ctx.vm)
 	if BigNumber == nil {
 		return false
 	}
-	bv, _ := BigNumber.Call("isPrototypeOf", v)
-	b, _ := bv.ToBoolean()
-	return b
+	prototype := BigNumber.Get("prototype").ToObject(ctx.vm)
+	isPrototypeOf, callable := goja.AssertFunction(prototype.Get("isPrototypeOf"))
+	if !callable {
+		return false
+	}
+	bv, _ := isPrototypeOf(prototype, v)
+	return bv.ToBoolean()
 }
 
-func toString(obj *otto.Object) string {
-	s, _ := obj.Call("toString")
-	return s.String()
+func toString(obj *goja.Object) string {
+	return obj.ToString().String()
 }
 
-func constructorPrototype(obj *otto.Object) *otto.Object {
-	if v, _ := obj.Get("constructor"); v.Object() != nil {
-		if v, _ = v.Object().Get("prototype"); v.Object() != nil {
-			return v.Object()
+func constructorPrototype(vm *goja.Runtime, obj *goja.Object) *goja.Object {
+	if v := obj.Get("constructor"); v != nil {
+		if v := v.ToObject(vm).Get("prototype"); v != nil {
+			return v.ToObject(vm)
 		}
 	}
 	return nil


### PR DESCRIPTION
As #19761 was becoming too complex and also really hard to rebase, I have decided to break the switch into several sub-PR to make it easier to review.

This is the first PR, in which only the console is switched to goja. The signer still uses otto and the tracer still uses duktape.

Closes #14649