### PR TITLE
remove duplicate preparation of blockHash in statedb

### DIFF
--- a/core/state/statedb.go
+++ b/core/state/statedb.go
@@ -715,6 +715,13 @@ func (s *StateDB) Prepare(thash, bhash common.Hash, ti int) {
 	s.bhash = bhash
 	s.txIndex = ti
 }
+func (s *StateDB) PrepareTransaction(thash, ti int) {
+	s.thash = thash
+	s.txIndex = ti
+}
+func (s *StateDB) PrepareBlock(bhash common.Hash) {
+	s.bhash = bhash
+}
 
 func (s *StateDB) clearJournalAndRefund() {
 	if len(s.journal.entries) > 0 {

--- a/core/state_prefetcher.go
+++ b/core/state_prefetcher.go
@@ -53,6 +53,8 @@ func (p *statePrefetcher) Prefetch(block *types.Block, statedb *state.StateDB, c
 		header  = block.Header()
 		gaspool = new(GasPool).AddGas(block.GasLimit())
 	)
+	// Prepare the block hash which is used when the EVM emits new state logs
+	statedb.PrepareBlock(block.Hash())
 	// Iterate over and process the individual transactions
 	for i, tx := range block.Transactions() {
 		// If block precaching was interrupted, abort
@@ -60,7 +62,7 @@ func (p *statePrefetcher) Prefetch(block *types.Block, statedb *state.StateDB, c
 			return
 		}
 		// Block precaching permitted to continue, execute the transaction
-		statedb.Prepare(tx.Hash(), block.Hash(), i)
+		statedb.PrepareTransaction(tx.Hash(), i)
 		if err := precacheTransaction(p.config, p.bc, nil, gaspool, statedb, header, tx, cfg); err != nil {
 			return // Ugh, something went horribly wrong, bail out
 		}

--- a/core/state_processor.go
+++ b/core/state_processor.go
@@ -65,9 +65,11 @@ func (p *StateProcessor) Process(block *types.Block, statedb *state.StateDB, cfg
 	if p.config.DAOForkSupport && p.config.DAOForkBlock != nil && p.config.DAOForkBlock.Cmp(block.Number()) == 0 {
 		misc.ApplyDAOHardFork(statedb)
 	}
+	// Prepare the block hash which is used when the EVM emits new state logs
+	statedb.PrepareBlock(block.Hash())
 	// Iterate over and process the individual transactions
 	for i, tx := range block.Transactions() {
-		statedb.Prepare(tx.Hash(), block.Hash(), i)
+		statedb.PrepareTransaction(tx.Hash(), i)
 		receipt, err := ApplyTransaction(p.config, p.bc, nil, gp, statedb, header, tx, usedGas, cfg)
 		if err != nil {
 			return nil, nil, 0, err


### PR DESCRIPTION
Before execute the transaction, the statedb need to prepare the parameters for the EVM logs (blockHash, txHash, txIndex).
In the current version, the blockHash is prepared when iterating the transaction, resulting in duplicate preparation of the blockHash.

In this commit, I divide the function of statedb.Prepare() into statedb.PrepareBlock(blockHash) and statedb.PrepareTransaction(txHash, txIndex) to avoid that.