### PR TITLE
eth: refactor creation of EthAPIBackend

### DIFF
--- a/eth/backend.go
+++ b/eth/backend.go
@@ -213,12 +213,12 @@ func New(ctx *node.ServiceContext, config *Config) (*Ethereum, error) {
 	eth.miner = miner.New(eth, &config.Miner, chainConfig, eth.EventMux(), eth.engine, eth.isLocalBlock)
 	eth.miner.SetExtra(makeExtraData(config.Miner.ExtraData))
 
-	eth.APIBackend = &EthAPIBackend{ctx.ExtRPCEnabled(), eth, nil}
 	gpoParams := config.GPO
 	if gpoParams.Default == nil {
 		gpoParams.Default = config.Miner.GasPrice
 	}
-	eth.APIBackend.gpo = gasprice.NewOracle(eth.APIBackend, gpoParams)
+
+	eth.APIBackend = &EthAPIBackend{ctx.ExtRPCEnabled(), eth, gasprice.NewOracle(eth.APIBackend, gpoParams)}
 
 	return eth, nil
 }


### PR DESCRIPTION
I was following the code for creating a New ethereum object and I found this part little confusing, like creating first the backend with nil gpo to later set it, if not important just discard. 

Thanks