### PR TITLE
Parallel hashing

### DIFF
--- a/trie/iterator.go
+++ b/trie/iterator.go
@@ -182,7 +182,7 @@ func (it *nodeIterator) LeafBlob() []byte {
 func (it *nodeIterator) LeafProof() [][]byte {
 	if len(it.stack) > 0 {
 		if _, ok := it.stack[len(it.stack)-1].node.(valueNode); ok {
-			hasher := newHasher()
+			hasher := newHasher(false)
 			defer returnHasherToPool(hasher)
 			proofs := make([][]byte, 0, len(it.stack))
 

--- a/trie/proof.go
+++ b/trie/proof.go
@@ -64,7 +64,7 @@ func (t *Trie) Prove(key []byte, fromLevel uint, proofDb ethdb.KeyValueWriter) e
 			panic(fmt.Sprintf("%T: invalid node: %v", tn, tn))
 		}
 	}
-	hasher := newHasher()
+	hasher := newHasher(false)
 	defer returnHasherToPool(hasher)
 
 	for i, n := range nodes {

--- a/trie/secure_trie.go
+++ b/trie/secure_trie.go
@@ -176,7 +176,7 @@ func (t *SecureTrie) NodeIterator(start []byte) NodeIterator {
 // The caller must not hold onto the return value because it will become
 // invalid on the next call to hashKey or secKey.
 func (t *SecureTrie) hashKey(key []byte) []byte {
-	h := newHasher()
+	h := newHasher(false)
 	h.sha.Reset()
 	h.sha.Write(key)
 	buf := h.sha.Sum(t.hashKeyBuf[:0])

--- a/trie/trie.go
+++ b/trie/trie.go
@@ -48,6 +48,14 @@ type LeafCallback func(leaf []byte, parent common.Hash) error
 type Trie struct {
 	db   *Database
 	root node
+	// Keep a track of the number of leafs to commit. This counter is
+	// update for inserts and deletions of leafs, but does not accurately track the number
+	// of nodes
+	dirtyCount int
+	// Keep track of the number leafs which have been inserted since the last
+	// hashing operation. This number will not directly map to the number of
+	// actually unhashed nodes
+	unhashedCount int
 }
 
 // newFlag returns the cache flag value for a newly created node.
@@ -163,6 +171,8 @@ func (t *Trie) Update(key, value []byte) {
 //
 // If a node was not found in the database, a MissingNodeError is returned.
 func (t *Trie) TryUpdate(key, value []byte) error {
+	t.unhashedCount++
+	t.dirtyCount++
 	k := keybytesToHex(key)
 	if len(value) != 0 {
 		_, n, err := t.insert(t.root, nil, k, valueNode(value))
@@ -259,6 +269,8 @@ func (t *Trie) Delete(key []byte) {
 // TryDelete removes any existing value for key from the trie.
 // If a node was not found in the database, a MissingNodeError is returned.
 func (t *Trie) TryDelete(key []byte) error {
+	t.unhashedCount++
+	t.dirtyCount++
 	k := keybytesToHex(key)
 	_, n, err := t.delete(t.root, nil, k)
 	if err != nil {
@@ -405,7 +417,7 @@ func (t *Trie) resolveHash(n hashNode, prefix []byte) (node, error) {
 // Hash returns the root hash of the trie. It does not write to the
 // database and can be used even if the trie doesn't have one.
 func (t *Trie) Hash() common.Hash {
-	hash, cached, _ := t.hashRoot(nil, nil)
+	hash, cached, _ := t.hashRoot(nil)
 	t.root = cached
 	return common.BytesToHash(hash.(hashNode))
 }
@@ -451,17 +463,20 @@ func (t *Trie) Commit(onleaf LeafCallback) (root common.Hash, err error) {
 	if err != nil {
 		return common.Hash{}, err
 	}
+	t.dirtyCount = 0
 	t.root = newRoot
 	return rootHash, nil
 }
 
 // hashRoot calculates the root hash of the given trie
-func (t *Trie) hashRoot(db *Database, onleaf LeafCallback) (node, node, error) {
+func (t *Trie) hashRoot(db *Database) (node, node, error) {
 	if t.root == nil {
 		return hashNode(emptyRoot.Bytes()), nil, nil
 	}
-	h := newHasher()
+	// If the number of changes is below 100, we let one thread handle it
+	h := newHasher(t.unhashedCount >= 100)
 	defer returnHasherToPool(h)
 	hashed, cached := h.hash(t.root, true)
+	t.unhashedCount = 0
 	return hashed, cached, nil
 }


### PR DESCRIPTION
This is a follow-up to https://github.com/ethereum/go-ethereum/pull/20481 , which implements 

- Counting updates to the trie, 
- Paralellizing the hashing operation, if the number of changes exceed 99 items. 

The benchmarks below are against https://github.com/ethereum/go-ethereum/pull/20481

```
[user@work trie]$ benchstat serial_hash.txt paralell_hash.txt 
name                  old time/op    new time/op    delta
Hash-6                  6.56µs ±16%    4.34µs ± 3%  -33.79%  (p=0.016 n=5+4)
HashFixedSize/10-6      63.1µs ± 1%    63.6µs ± 3%     ~     (p=0.310 n=5+5)
HashFixedSize/100-6      295µs ± 1%     257µs ± 1%  -12.74%  (p=0.008 n=5+5)
HashFixedSize/1K-6      3.41ms ± 9%    2.43ms ± 8%  -28.93%  (p=0.008 n=5+5)
HashFixedSize/10K-6     39.3ms ± 7%    28.1ms ± 5%  -28.42%  (p=0.008 n=5+5)
HashFixedSize/100K-6     449ms ±15%     295ms ± 9%  -34.25%  (p=0.008 n=5+5)

name                  old alloc/op   new alloc/op   delta
Hash-6                    911B ± 3%      914B ± 0%     ~     (p=0.135 n=5+5)
HashFixedSize/10-6      12.5kB ± 0%    12.6kB ± 0%   +0.85%  (p=0.008 n=5+5)
HashFixedSize/100-6     58.6kB ± 0%    59.3kB ± 0%   +1.04%  (p=0.008 n=5+5)
HashFixedSize/1K-6       631kB ± 0%     639kB ± 0%   +1.20%  (p=0.008 n=5+5)
HashFixedSize/10K-6     6.57MB ± 0%    6.65MB ± 0%   +1.16%  (p=0.008 n=5+5)
HashFixedSize/100K-6    64.9MB ± 0%    65.5MB ± 0%   +0.95%  (p=0.008 n=5+5)

name                  old allocs/op  new allocs/op  delta
Hash-6                    11.0 ± 0%      12.0 ± 0%   +9.09%  (p=0.008 n=5+5)
HashFixedSize/10-6         162 ± 0%       176 ± 0%   +8.64%  (p=0.008 n=5+5)
HashFixedSize/100-6        786 ± 0%       850 ± 0%   +8.14%  (p=0.008 n=5+5)
HashFixedSize/1K-6       8.15k ± 0%     8.87k ± 0%   +8.81%  (p=0.008 n=5+5)
HashFixedSize/10K-6      83.4k ± 0%     91.1k ± 0%   +9.17%  (p=0.008 n=5+5)
HashFixedSize/100K-6      830k ± 0%      905k ± 0%   +8.96%  (p=0.008 n=5+5)

```

Here are the benchmarks against master: 
```
[user@work trie]$ benchstat hashbefore.txt paralell_hash.txt 
name                  old time/op    new time/op    delta
Hash-6                  7.08µs ±12%    4.34µs ± 3%  -38.69%  (p=0.002 n=10+4)
HashFixedSize/10-6      70.0µs ± 2%    63.6µs ± 3%   -9.19%  (p=0.001 n=10+5)
HashFixedSize/100-6      328µs ± 3%     257µs ± 1%  -21.56%  (p=0.001 n=10+5)
HashFixedSize/1K-6      3.67ms ± 3%    2.43ms ± 8%  -33.81%  (p=0.001 n=9+5)
HashFixedSize/10K-6     43.3ms ± 2%    28.1ms ± 5%  -35.09%  (p=0.001 n=9+5)
HashFixedSize/100K-6     525ms ±12%     295ms ± 9%  -43.76%  (p=0.001 n=10+5)

name                  old alloc/op   new alloc/op   delta
Hash-6                    989B ± 1%      914B ± 0%   -7.54%  (p=0.001 n=10+5)
HashFixedSize/10-6      13.8kB ± 0%    12.6kB ± 0%   -8.50%  (p=0.001 n=10+5)
HashFixedSize/100-6     65.0kB ± 0%    59.3kB ± 0%   -8.90%  (p=0.001 n=10+5)
HashFixedSize/1K-6       695kB ± 0%     639kB ± 0%   -8.14%  (p=0.001 n=10+5)
HashFixedSize/10K-6     7.21MB ± 0%    6.65MB ± 0%   -7.81%  (p=0.001 n=10+5)
HashFixedSize/100K-6    71.3MB ± 0%    65.5MB ± 0%   -8.11%  (p=0.001 n=10+5)

name                  old allocs/op  new allocs/op  delta
Hash-6                    12.0 ± 0%      12.0 ± 0%     ~     (all equal)
HashFixedSize/10-6         182 ± 0%       176 ± 0%   -3.30%  (p=0.000 n=10+5)
HashFixedSize/100-6        886 ± 0%       850 ± 0%   -4.06%  (p=0.000 n=10+5)
HashFixedSize/1K-6       9.16k ± 0%     8.87k ± 0%   -3.14%  (p=0.000 n=8+5)
HashFixedSize/10K-6      93.5k ± 0%     91.1k ± 0%   -2.63%  (p=0.000 n=10+5)
HashFixedSize/100K-6      932k ± 0%      905k ± 0%   -2.89%  (p=0.001 n=10+5)
```

Once the current benchmark run is done, I'll put this one up