### PR TITLE
core: fix indexer unit test

### DIFF
--- a/core/chain_indexer_test.go
+++ b/core/chain_indexer_test.go
@@ -203,7 +203,7 @@ func (b *testChainIndexBackend) assertBlocks(headNum, failNum uint64) (uint64, b
 }
 
 func (b *testChainIndexBackend) reorg(headNum uint64) uint64 {
-	firstChanged := headNum / b.indexer.sectionSize
+	firstChanged := (headNum + 1) / b.indexer.sectionSize
 	if firstChanged < b.stored {
 		b.stored = firstChanged
 	}


### PR DESCRIPTION
This PR fixes unit tests of chain indexers.

In #19748 we fix an issue in chain indexer when it tries to run reorg. The change is the given `head` in `newHead` function is the `common ancestor` of new head header and previous head header. So `head` is still considered valid. The change merged is using `known := (head + 1) / c.sectionSize` to calculate the section index which need to be reverted instead of using `head/c.sectionSize`.

But we don't change the unit test, this PR just follow the original merged change.

Fixes #20497 