### PR TITLE
Fix txpool APIs to get rid of lists-per-nonces

### DIFF
--- a/docs/_interface/Management-APIs.md
+++ b/docs/_interface/Management-APIs.md
@@ -55,7 +55,7 @@ will give all enabled modules including the version number:
 ## Consuming the management APIs
 
 These additional APIs follow the same conventions as the official DApp APIs. Web3 can be
-[extended](https://github.com/ethereum/web3.js/pull/229) and used to consume these additional APIs. 
+[extended](https://github.com/ethereum/web3.js/pull/229) and used to consume these additional APIs.
 
 The different functions are split into multiple smaller logically grouped APIs. Examples are given
 for the [JavaScript console](JavaScript-Console) but
@@ -791,7 +791,7 @@ Usage example, returns the top element of the stack at each CALL opcode only:
 
 ### debug_verbosity
 
-Sets the logging verbosity ceiling. Log messages with level 
+Sets the logging verbosity ceiling. Log messages with level
 up to and including the given level will be printed.
 
 The verbosity of individual packages and source files
@@ -917,7 +917,7 @@ Stop the CPU mining operation.
 
 ### miner_setEtherBase
 
-Sets the etherbase, where mining rewards will go. 
+Sets the etherbase, where mining rewards will go.
 
 | Client  | Method invocation                                           |
 |:-------:|-------------------------------------------------------------|
@@ -936,7 +936,7 @@ Imports the given unencrypted private key (hex string) into the key store,
 encrypting it with the passphrase.
 
 Returns the address of the new account.
- 
+
 | Client    | Method invocation                                                 |
 | :-------: | ----------------------------------------------------------------- |
 | Console   | `personal.importRawKey(keydata, passphrase)`                      |
@@ -963,7 +963,7 @@ in the key store.
 
 Removes the private key with given address from memory.
 The account can no longer be used to send transactions.
- 
+
 | Client    | Method invocation                                        |
 | :-------: | -------------------------------------------------------- |
 | Console   | `personal.lockAccount(address)`                          |
@@ -975,7 +975,7 @@ Generates a new private key and stores it in the key store directory.
 The key file is encrypted with the given passphrase.
 Returns the address of the new account.
 
-At the geth console, `newAccount` will prompt for a passphrase when 
+At the geth console, `newAccount` will prompt for a passphrase when
 it is not supplied as the argument.
 
 | Client    | Method invocation                                       |
@@ -984,11 +984,11 @@ it is not supplied as the argument.
 | RPC       | `{"method": "personal_newAccount", "params": [string]}` |
 
 #### Example
- 
+
 ``` javascript
 > personal.newAccount()
-Passphrase: 
-Repeat passphrase: 
+Passphrase:
+Repeat passphrase:
 "0x5e97870f263700f46aa00d967821199b9bc5a120"
 ```
 
@@ -1012,7 +1012,7 @@ If the unlock duration defaults to 300 seconds. An explicit duration
 of zero seconds unlocks the key until geth exits.
 
 The account can be used with `eth_sign` and `eth_sendTransaction` while it is unlocked.
- 
+
 | Client    | Method invocation                                                          |
 | :-------: | -------------------------------------------------------------------------- |
 | Console   | `personal.unlockAccount(address, passphrase, duration)`                    |
@@ -1023,7 +1023,7 @@ The account can be used with `eth_sign` and `eth_sendTransaction` while it is un
 ``` javascript
 > personal.unlockAccount("0x5e97870f263700f46aa00d967821199b9bc5a120")
 Unlock account 0x5e97870f263700f46aa00d967821199b9bc5a120
-Passphrase: 
+Passphrase:
 true
 ```
 
@@ -1040,7 +1040,7 @@ pass `null` as the passphrase.
 ```
 > personal.unlockAccount("0x5e97870f263700f46aa00d967821199b9bc5a120", null, 30)
 Unlock account 0x5e97870f263700f46aa00d967821199b9bc5a120
-Passphrase: 
+Passphrase:
 true
 ```
 
@@ -1090,7 +1090,7 @@ See ecRecover to verify the signature.
 
 ### personal_ecRecover
 
-`ecRecover` returns the address associated with the private key that was used to calculate the signature in `personal_sign`. 
+`ecRecover` returns the address associated with the private key that was used to calculate the signature in `personal_sign`.
 
 | Client  | Method invocation                                     |
 |:-------:|-------------------------------------------------------|   
@@ -1128,11 +1128,11 @@ Please note, there may be multiple transactions associated with the same account
 happen if the user broadcast mutliple ones with varying gas allowances (or even complerely different
 transactions).
 
-| Client  | Method invocation                                                       |
-|:-------:|-------------------------------------------------------------------------|
-| Go      | `txpool.Content() (map[string]map[string]map[string][]*RPCTransaction)` |
-| Console | `txpool.content`                                                        |
-| RPC     | `{"method": "txpool_content"}`                                          |
+| Client  | Method invocation                                                     |
+|:-------:|-----------------------------------------------------------------------|
+| Go      | `txpool.Content() (map[string]map[string]map[string]*RPCTransaction)` |
+| Console | `txpool.content`                                                      |
+| RPC     | `{"method": "txpool_content"}`                                        |
 
 #### Example
 
@@ -1141,7 +1141,7 @@ transactions).
 {
   pending: {
     0x0216d5032f356960cd3749c31ab34eeff21b3395: {
-      806: [{
+      806: {
         blockHash: "0x0000000000000000000000000000000000000000000000000000000000000000",
         blockNumber: null,
         from: "0x0216d5032f356960cd3749c31ab34eeff21b3395",
@@ -1153,10 +1153,10 @@ transactions).
         to: "0x7f69a91a3cf4be60020fb58b893b7cbb65376db8",
         transactionIndex: null,
         value: "0x19a99f0cf456000"
-      }]
+      }
     },
     0x24d407e5a0b506e1cb2fae163100b5de01f5193c: {
-      34: [{
+      34: {
         blockHash: "0x0000000000000000000000000000000000000000000000000000000000000000",
         blockNumber: null,
         from: "0x24d407e5a0b506e1cb2fae163100b5de01f5193c",
@@ -1168,12 +1168,12 @@ transactions).
         to: "0x7320785200f74861b69c49e4ab32399a71b34f1a",
         transactionIndex: null,
         value: "0x0"
-      }]
+      }
     }
   },
   queued: {
     0x976a3fc5d6f7d259ebfb4cc2ae75115475e9867c: {
-      3: [{
+      3: {
         blockHash: "0x0000000000000000000000000000000000000000000000000000000000000000",
         blockNumber: null,
         from: "0x976a3fc5d6f7d259ebfb4cc2ae75115475e9867c",
@@ -1185,10 +1185,10 @@ transactions).
         to: "0x346fb27de7e7370008f5da379f74dd49f5f2f80f",
         transactionIndex: null,
         value: "0x1f161421c8e0000"
-      }]
+      }
     },
     0x9b11bf0459b0c4b2f87f8cebca4cfc26f294b63a: {
-      2: [{
+      2: {
         blockHash: "0x0000000000000000000000000000000000000000000000000000000000000000",
         blockNumber: null,
         from: "0x9b11bf0459b0c4b2f87f8cebca4cfc26f294b63a",
@@ -1200,8 +1200,8 @@ transactions).
         to: "0x24a461f25ee6a318bdef7f33de634a67bb67ac9d",
         transactionIndex: null,
         value: "0xebec21ee1da40000"
-      }],
-      6: [{
+      },
+      6: {
         blockHash: "0x0000000000000000000000000000000000000000000000000000000000000000",
         blockNumber: null,
         from: "0x9b11bf0459b0c4b2f87f8cebca4cfc26f294b63a",
@@ -1213,19 +1213,7 @@ transactions).
         to: "0x6368f3f8c2b42435d6c136757382e4a59436a681",
         transactionIndex: null,
         value: "0xf9a951af55470000"
-      }, {
-        blockHash: "0x0000000000000000000000000000000000000000000000000000000000000000",
-        blockNumber: null,
-        from: "0x9b11bf0459b0c4b2f87f8cebca4cfc26f294b63a",
-        gas: "0x15f90",
-        gasPrice: "0x4a817c800",
-        hash: "0x60803251d43f072904dc3a2d6a084701cd35b4985790baaf8a8f76696041b272",
-        input: "0x",
-        nonce: "0x6",
-        to: "0x8db7b4e0ecb095fbd01dffa62010801296a9ac78",
-        transactionIndex: null,
-        value: "0xebe866f5f0a06000"
-      }],
+      }
     }
   }
 }
@@ -1246,11 +1234,11 @@ Please note, there may be multiple transactions associated with the same account
 happen if the user broadcast mutliple ones with varying gas allowances (or even complerely different
 transactions).
 
-| Client  | Method invocation                                              |
-|:-------:|----------------------------------------------------------------|
-| Go      | `txpool.Inspect() (map[string]map[string]map[string][]string)` |
-| Console | `txpool.inspect`                                               |
-| RPC     | `{"method": "txpool_inspect"}`                                 |
+| Client  | Method invocation                                            |
+|:-------:|--------------------------------------------------------------|
+| Go      | `txpool.Inspect() (map[string]map[string]map[string]string)` |
+| Console | `txpool.inspect`                                             |
+| RPC     | `{"method": "txpool_inspect"}`                               |
 
 #### Example
 
@@ -1259,49 +1247,49 @@ transactions).
 {
   pending: {
     0x26588a9301b0428d95e6fc3a5024fce8bec12d51: {
-      31813: ["0x3375ee30428b2a71c428afa5e89e427905f95f7e: 0 wei + 500000 × 20000000000 gas"]
+      31813: "0x3375ee30428b2a71c428afa5e89e427905f95f7e: 0 wei + 500000 × 20000000000 gas"
     },
     0x2a65aca4d5fc5b5c859090a6c34d164135398226: {
-      563662: ["0x958c1fa64b34db746925c6f8a3dd81128e40355e: 1051546810000000000 wei + 90000 × 20000000000 gas"],
-      563663: ["0x77517b1491a0299a44d668473411676f94e97e34: 1051190740000000000 wei + 90000 × 20000000000 gas"],
-      563664: ["0x3e2a7fe169c8f8eee251bb00d9fb6d304ce07d3a: 1050828950000000000 wei + 90000 × 20000000000 gas"],
-      563665: ["0xaf6c4695da477f8c663ea2d8b768ad82cb6a8522: 1050544770000000000 wei + 90000 × 20000000000 gas"],
-      563666: ["0x139b148094c50f4d20b01caf21b85edb711574db: 1048598530000000000 wei + 90000 × 20000000000 gas"],
-      563667: ["0x48b3bd66770b0d1eecefce090dafee36257538ae: 1048367260000000000 wei + 90000 × 20000000000 gas"],
-      563668: ["0x468569500925d53e06dd0993014ad166fd7dd381: 1048126690000000000 wei + 90000 × 20000000000 gas"],
-      563669: ["0x3dcb4c90477a4b8ff7190b79b524773cbe3be661: 1047965690000000000 wei + 90000 × 20000000000 gas"],
-      563670: ["0x6dfef5bc94b031407ffe71ae8076ca0fbf190963: 1047859050000000000 wei + 90000 × 20000000000 gas"]
+      563662: "0x958c1fa64b34db746925c6f8a3dd81128e40355e: 1051546810000000000 wei + 90000 × 20000000000 gas",
+      563663: "0x77517b1491a0299a44d668473411676f94e97e34: 1051190740000000000 wei + 90000 × 20000000000 gas",
+      563664: "0x3e2a7fe169c8f8eee251bb00d9fb6d304ce07d3a: 1050828950000000000 wei + 90000 × 20000000000 gas",
+      563665: "0xaf6c4695da477f8c663ea2d8b768ad82cb6a8522: 1050544770000000000 wei + 90000 × 20000000000 gas",
+      563666: "0x139b148094c50f4d20b01caf21b85edb711574db: 1048598530000000000 wei + 90000 × 20000000000 gas",
+      563667: "0x48b3bd66770b0d1eecefce090dafee36257538ae: 1048367260000000000 wei + 90000 × 20000000000 gas",
+      563668: "0x468569500925d53e06dd0993014ad166fd7dd381: 1048126690000000000 wei + 90000 × 20000000000 gas",
+      563669: "0x3dcb4c90477a4b8ff7190b79b524773cbe3be661: 1047965690000000000 wei + 90000 × 20000000000 gas",
+      563670: "0x6dfef5bc94b031407ffe71ae8076ca0fbf190963: 1047859050000000000 wei + 90000 × 20000000000 gas"
     },
     0x9174e688d7de157c5c0583df424eaab2676ac162: {
-      3: ["0xbb9bc244d798123fde783fcc1c72d3bb8c189413: 30000000000000000000 wei + 85000 × 21000000000 gas"]
+      3: "0xbb9bc244d798123fde783fcc1c72d3bb8c189413: 30000000000000000000 wei + 85000 × 21000000000 gas"
     },
     0xb18f9d01323e150096650ab989cfecd39d757aec: {
-      777: ["0xcd79c72690750f079ae6ab6ccd7e7aedc03c7720: 0 wei + 1000000 × 20000000000 gas"]
+      777: "0xcd79c72690750f079ae6ab6ccd7e7aedc03c7720: 0 wei + 1000000 × 20000000000 gas"
     },
     0xb2916c870cf66967b6510b76c07e9d13a5d23514: {
-      2: ["0x576f25199d60982a8f31a8dff4da8acb982e6aba: 26000000000000000000 wei + 90000 × 20000000000 gas"]
+      2: "0x576f25199d60982a8f31a8dff4da8acb982e6aba: 26000000000000000000 wei + 90000 × 20000000000 gas"
     },
     0xbc0ca4f217e052753614d6b019948824d0d8688b: {
-      0: ["0x2910543af39aba0cd09dbb2d50200b3e800a63d2: 1000000000000000000 wei + 50000 × 1171602790622 gas"]
+      0: "0x2910543af39aba0cd09dbb2d50200b3e800a63d2: 1000000000000000000 wei + 50000 × 1171602790622 gas"
     },
     0xea674fdde714fd979de3edf0f56aa9716b898ec8: {
-      70148: ["0xe39c55ead9f997f7fa20ebe40fb4649943d7db66: 1000767667434026200 wei + 90000 × 20000000000 gas"]
+      70148: "0xe39c55ead9f997f7fa20ebe40fb4649943d7db66: 1000767667434026200 wei + 90000 × 20000000000 gas"
     }
   },
   queued: {
     0x0f6000de1578619320aba5e392706b131fb1de6f: {
-      6: ["0x8383534d0bcd0186d326c993031311c0ac0d9b2d: 9000000000000000000 wei + 21000 × 20000000000 gas"]
+      6: "0x8383534d0bcd0186d326c993031311c0ac0d9b2d: 9000000000000000000 wei + 21000 × 20000000000 gas"
     },
     0x5b30608c678e1ac464a8994c3b33e5cdf3497112: {
-      6: ["0x9773547e27f8303c87089dc42d9288aa2b9d8f06: 50000000000000000000 wei + 90000 × 50000000000 gas"]
+      6: "0x9773547e27f8303c87089dc42d9288aa2b9d8f06: 50000000000000000000 wei + 90000 × 50000000000 gas"
     },
     0x976a3fc5d6f7d259ebfb4cc2ae75115475e9867c: {
-      3: ["0x346fb27de7e7370008f5da379f74dd49f5f2f80f: 140000000000000000 wei + 90000 × 20000000000 gas"]
+      3: "0x346fb27de7e7370008f5da379f74dd49f5f2f80f: 140000000000000000 wei + 90000 × 20000000000 gas"
     },
     0x9b11bf0459b0c4b2f87f8cebca4cfc26f294b63a: {
-      2: ["0x24a461f25ee6a318bdef7f33de634a67bb67ac9d: 17000000000000000000 wei + 90000 × 50000000000 gas"],
-      6: ["0x6368f3f8c2b42435d6c136757382e4a59436a681: 17990000000000000000 wei + 90000 × 20000000000 gas", "0x8db7b4e0ecb095fbd01dffa62010801296a9ac78: 16998950000000000000 wei + 90000 × 20000000000 gas"],
-      7: ["0x6368f3f8c2b42435d6c136757382e4a59436a681: 17900000000000000000 wei + 90000 × 20000000000 gas"]
+      2: "0x24a461f25ee6a318bdef7f33de634a67bb67ac9d: 17000000000000000000 wei + 90000 × 50000000000 gas",
+      6: "0x6368f3f8c2b42435d6c136757382e4a59436a681: 17990000000000000000 wei + 90000 × 20000000000 gas",
+      7: "0x6368f3f8c2b42435d6c136757382e4a59436a681: 17900000000000000000 wei + 90000 × 20000000000 gas"
     }
   }
 }


### PR DESCRIPTION
A very long time ago we changed the txpool to only maintain 1 transaction per account per nonce. We've never updated the docs accordingly.