### PR TITLE
les: implement les4 and UDP extension for token sale

### DIFF
--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -101,6 +101,7 @@ var (
 		utils.UltraLightServersFlag,
 		utils.UltraLightFractionFlag,
 		utils.UltraLightOnlyAnnounceFlag,
+		utils.LespayTestModuleFlag,
 		utils.WhitelistFlag,
 		utils.CacheFlag,
 		utils.CacheDatabaseFlag,

--- a/cmd/geth/usage.go
+++ b/cmd/geth/usage.go
@@ -94,6 +94,7 @@ var AppHelpFlagGroups = []flagGroup{
 			utils.UltraLightServersFlag,
 			utils.UltraLightFractionFlag,
 			utils.UltraLightOnlyAnnounceFlag,
+			utils.LespayTestModuleFlag,
 		},
 	},
 	{

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -272,6 +272,10 @@ var (
 		Usage: "Maximum number of light clients to serve, or light servers to attach to",
 		Value: eth.DefaultConfig.LightPeers,
 	}
+	LespayTestModuleFlag = cli.BoolFlag{
+		Name:  "lespay.testmodule",
+		Usage: "Enable dummy payment module (for testing only)",
+	}
 	UltraLightServersFlag = cli.StringFlag{
 		Name:  "ulc.servers",
 		Usage: "List of trusted ultra-light servers",
@@ -1008,6 +1012,9 @@ func setLes(ctx *cli.Context, cfg *eth.Config) {
 	}
 	if ctx.GlobalIsSet(UltraLightOnlyAnnounceFlag.Name) {
 		cfg.UltraLightOnlyAnnounce = ctx.GlobalBool(UltraLightOnlyAnnounceFlag.Name)
+	}
+	if ctx.GlobalIsSet(LespayTestModuleFlag.Name) {
+		cfg.LespayTestModule = true
 	}
 }
 

--- a/eth/config.go
+++ b/eth/config.go
@@ -116,6 +116,9 @@ type Config struct {
 	UltraLightFraction     int      `toml:",omitempty"` // Percentage of trusted servers to accept an announcement
 	UltraLightOnlyAnnounce bool     `toml:",omitempty"` // Whether to only announce headers, or also serve them
 
+	// Light client payment options
+	LespayTestModule bool
+
 	// Database options
 	SkipBcVersionCheck bool `toml:"-"`
 	DatabaseHandles    int  `toml:"-"`

--- a/eth/gen_config.go
+++ b/eth/gen_config.go
@@ -32,6 +32,7 @@ func (c Config) MarshalTOML() (interface{}, error) {
 		UltraLightServers       []string               `toml:",omitempty"`
 		UltraLightFraction      int                    `toml:",omitempty"`
 		UltraLightOnlyAnnounce  bool                   `toml:",omitempty"`
+		LespayTestModule        bool                   `toml:"-"`
 		SkipBcVersionCheck      bool                   `toml:"-"`
 		DatabaseHandles         int                    `toml:"-"`
 		DatabaseCache           int
@@ -68,6 +69,7 @@ func (c Config) MarshalTOML() (interface{}, error) {
 	enc.UltraLightServers = c.UltraLightServers
 	enc.UltraLightFraction = c.UltraLightFraction
 	enc.UltraLightOnlyAnnounce = c.UltraLightOnlyAnnounce
+	enc.LespayTestModule = c.LespayTestModule
 	enc.SkipBcVersionCheck = c.SkipBcVersionCheck
 	enc.DatabaseHandles = c.DatabaseHandles
 	enc.DatabaseCache = c.DatabaseCache
@@ -108,6 +110,7 @@ func (c *Config) UnmarshalTOML(unmarshal func(interface{}) error) error {
 		UltraLightServers       []string               `toml:",omitempty"`
 		UltraLightFraction      *int                   `toml:",omitempty"`
 		UltraLightOnlyAnnounce  *bool                  `toml:",omitempty"`
+		LespayTestModule        *bool                  `toml:"-"`
 		SkipBcVersionCheck      *bool                  `toml:"-"`
 		DatabaseHandles         *int                   `toml:"-"`
 		DatabaseCache           *int
@@ -174,6 +177,9 @@ func (c *Config) UnmarshalTOML(unmarshal func(interface{}) error) error {
 	}
 	if dec.UltraLightOnlyAnnounce != nil {
 		c.UltraLightOnlyAnnounce = *dec.UltraLightOnlyAnnounce
+	}
+	if dec.LespayTestModule != nil {
+		c.LespayTestModule = *dec.LespayTestModule
 	}
 	if dec.SkipBcVersionCheck != nil {
 		c.SkipBcVersionCheck = *dec.SkipBcVersionCheck

--- a/internal/web3ext/web3ext.go
+++ b/internal/web3ext/web3ext.go
@@ -33,6 +33,7 @@ var Modules = map[string]string{
 	"swarmfs":    SwarmfsJs,
 	"txpool":     TxpoolJs,
 	"les":        LESJs,
+	"lespay":     LESPAYJs,
 }
 
 const ChequebookJs = `
@@ -853,6 +854,53 @@ web3._extend({
 			name: 'serverInfo',
 			getter: 'les_serverInfo'
 		}),
+	]
+});
+`
+
+const LESPAYJs = `
+web3._extend({
+	property: 'lespay',
+	methods:
+	[
+		new web3._extend.Method({
+			name: 'connection',
+			call: 'lespay_connection',
+			params: 6
+		}),
+		new web3._extend.Method({
+			name: 'deposit',
+			call: 'lespay_deposit',
+			params: 4
+		}),
+		new web3._extend.Method({
+			name: 'buyTokens',
+			call: 'lespay_buyTokens',
+			params: 6
+		}),
+		new web3._extend.Method({
+			name: 'buyTokens',
+			call: 'lespay_sellTokens',
+			params: 6
+		}),
+		new web3._extend.Method({
+			name: 'getBalance',
+			call: 'lespay_getBalance',
+			params: 2
+		}),
+		new web3._extend.Method({
+			name: 'info',
+			call: 'lespay_info',
+			params: 2
+		}),
+		new web3._extend.Method({
+			name: 'receiverInfo',
+			call: 'lespay_receiverInfo',
+			params: 3
+		}),
+	],
+	properties:
+	[
 	]
 });
 `

--- a/les/api.go
+++ b/les/api.go
@@ -104,12 +104,16 @@ func (api *PrivateLightServerAPI) clientInfo(c *clientInfo, id enode.ID) map[str
 		info["capacity"] = c.capacity
 		pb, nb := c.balanceTracker.getBalance(now)
 		info["pricing/balance"], info["pricing/negBalance"] = pb, nb
-		info["pricing/balanceMeta"] = c.balanceMetaInfo
+
+		cb := api.server.clientPool.ndb.getCurrencyBalance(id)
+		info["pricing/currency"] = cb.amount
 		info["priority"] = pb.base != 0
 	} else {
 		info["isConnected"] = false
-		pb := api.server.clientPool.ndb.getOrNewPB(id)
-		info["pricing/balance"], info["pricing/balanceMeta"] = pb.value, pb.meta
+		pb := api.server.clientPool.ndb.getOrNewBalance(id.Bytes(), false)
+
+		cb := api.server.clientPool.ndb.getCurrencyBalance(id)
+		info["pricing/balance"], info["pricing/currency"] = pb.value, cb.amount
 		info["priority"] = pb.value.base != 0
 	}
 	return info
@@ -150,7 +154,7 @@ func (api *PrivateLightServerAPI) setParams(params map[string]interface{}, clien
 			setFactor(&negFactors.requestFactor)
 		case !defParams && name == "capacity":
 			if capacity, ok := value.(float64); ok && uint64(capacity) >= api.server.minCapacity {
-				_, _, err = api.server.clientPool.setCapacity(client.id, client.freeID, uint64(capacity), 0, true)
+				_, _, err = api.server.clientPool.setCapacity(client.id, client.address, uint64(capacity), 0, true)
 				// Don't have to call factor update explicitly. It's already done
 				// in setCapacity function.
 			} else {
@@ -172,8 +176,8 @@ func (api *PrivateLightServerAPI) setParams(params map[string]interface{}, clien
 
 // AddBalance updates the balance of a client (either overwrites it or adds to it).
 // It also updates the balance meta info string.
-func (api *PrivateLightServerAPI) AddBalance(id enode.ID, value int64, meta string) ([2]uint64, error) {
-	oldBalance, newBalance, err := api.server.clientPool.addBalance(id, value, meta)
+func (api *PrivateLightServerAPI) AddBalance(id enode.ID, value int64) ([2]uint64, error) {
+	oldBalance, newBalance, err := api.server.clientPool.addBalance(id, value)
 	return [2]uint64{oldBalance, newBalance}, err
 }
 
@@ -184,7 +188,7 @@ func (api *PrivateLightServerAPI) SetClientParams(ids []enode.ID, params map[str
 		if client != nil {
 			update, err := api.setParams(params, client, nil, nil)
 			if update {
-				updatePriceFactors(&client.balanceTracker, client.posFactors, client.negFactors, client.capacity)
+				updatePriceFactors(&client.balanceTracker, client.posFactors, client.negFactors)
 			}
 			return err
 		} else {

--- a/les/balance_test.go
+++ b/les/balance_test.go
@@ -25,11 +25,11 @@ import (
 
 type zeroExpCtrl struct{}
 
-func (z zeroExpCtrl) posExpiration(mclock.AbsTime) uint64 {
+func (z zeroExpCtrl) posExpiration(mclock.AbsTime) fixed64 {
 	return 0
 }
 
-func (z zeroExpCtrl) negExpiration(mclock.AbsTime) uint64 {
+func (z zeroExpCtrl) negExpiration(mclock.AbsTime) fixed64 {
 	return 0
 }
 
@@ -70,8 +70,7 @@ func TestBalanceTimeCost(t *testing.T) {
 	)
 	tracker.init(clock, 1000)
 	defer tracker.stop(clock.Now())
-	tracker.setFactors(false, 1, 1)
-	tracker.setFactors(true, 1, 1)
+	tracker.setFactors(priceFactors{1, 0, 1}, priceFactors{1, 0, 1})
 
 	tracker.setBalance(expval(uint64(time.Minute)), expval(0)) // 1 minute time allowance
 
@@ -114,8 +113,7 @@ func TestBalanceReqCost(t *testing.T) {
 	)
 	tracker.init(clock, 1000)
 	defer tracker.stop(clock.Now())
-	tracker.setFactors(false, 1, 1)
-	tracker.setFactors(true, 1, 1)
+	tracker.setFactors(priceFactors{1, 0, 1}, priceFactors{1, 0, 1})
 
 	tracker.setBalance(expval(uint64(time.Minute)), expval(0)) // 1 minute time serving time allowance
 	var inputs = []struct {
@@ -146,8 +144,7 @@ func TestBalanceToPriority(t *testing.T) {
 	)
 	tracker.init(clock, 1000) // cap = 1000
 	defer tracker.stop(clock.Now())
-	tracker.setFactors(false, 1, 1)
-	tracker.setFactors(true, 1, 1)
+	tracker.setFactors(priceFactors{1, 0, 1}, priceFactors{1, 0, 1})
 
 	var inputs = []struct {
 		pos      uint64
@@ -175,8 +172,7 @@ func TestEstimatedPriority(t *testing.T) {
 	)
 	tracker.init(clock, 1000000000) // cap = 1000,000,000
 	defer tracker.stop(clock.Now())
-	tracker.setFactors(false, 1, 1)
-	tracker.setFactors(true, 1, 1)
+	tracker.setFactors(priceFactors{1, 0, 1}, priceFactors{1, 0, 1})
 
 	tracker.setBalance(expval(uint64(time.Minute)), expval(0))
 	var inputs = []struct {
@@ -219,8 +215,7 @@ func TestCallbackChecking(t *testing.T) {
 	)
 	tracker.init(clock, 1000000) // cap = 1000,000
 	defer tracker.stop(clock.Now())
-	tracker.setFactors(false, 1, 1)
-	tracker.setFactors(true, 1, 1)
+	tracker.setFactors(priceFactors{1, 0, 1}, priceFactors{1, 0, 1})
 
 	var inputs = []struct {
 		priority int64
@@ -246,8 +241,7 @@ func TestCallback(t *testing.T) {
 	)
 	tracker.init(clock, 1000) // cap = 1000
 	defer tracker.stop(clock.Now())
-	tracker.setFactors(false, 1, 1)
-	tracker.setFactors(true, 1, 1)
+	tracker.setFactors(priceFactors{1, 0, 1}, priceFactors{1, 0, 1})
 
 	callCh := make(chan struct{}, 1)
 	tracker.setBalance(expval(uint64(time.Minute)), expval(0))

--- a/les/client.go
+++ b/les/client.go
@@ -50,6 +50,7 @@ type LightEthereum struct {
 	lesCommons
 
 	peers      *serverPeerSet
+	srvr       *p2p.Server
 	reqDist    *requestDistributor
 	retriever  *retrieveManager
 	odr        *LesOdr
@@ -208,6 +209,12 @@ func (s *LightEthereum) APIs() []rpc.API {
 			Service:   NewPrivateLightAPI(&s.lesCommons),
 			Public:    false,
 		},
+		{
+			Namespace: "lespay",
+			Version:   "1.0",
+			Service:   NewPrivateLespayAPI(s.lesCommons.peers, s.handler, s.srvr.DiscV5, nil),
+			Public:    false,
+		},
 	}...)
 }
 
@@ -237,6 +244,7 @@ func (s *LightEthereum) Protocols() []p2p.Protocol {
 // light ethereum protocol implementation.
 func (s *LightEthereum) Start(srvr *p2p.Server) error {
 	log.Warn("Light client mode is an experimental feature")
+	s.srvr = srvr
 
 	// Start bloom request workers.
 	s.wg.Add(bloomServiceThreads)

--- a/les/client.go
+++ b/les/client.go
@@ -212,7 +212,7 @@ func (s *LightEthereum) APIs() []rpc.API {
 		{
 			Namespace: "lespay",
 			Version:   "1.0",
-			Service:   NewPrivateLespayAPI(s.lesCommons.peers, s.handler, s.srvr.DiscV5, nil),
+			Service:   NewPrivateLespayAPI(nil, s.peers, s.handler, s.srvr.DiscV5, nil),
 			Public:    false,
 		},
 	}...)

--- a/les/client_handler.go
+++ b/les/client_handler.go
@@ -40,6 +40,9 @@ type clientHandler struct {
 	downloader *downloader.Downloader
 	backend    *LightEthereum
 
+	lespayReplyHandlers map[uint64]func([]byte, uint) bool
+	lespayReplyLock     sync.Mutex
+
 	closeCh  chan struct{}
 	wg       sync.WaitGroup // WaitGroup used to track all connected peers.
 	syncDone func()         // Test hooks when syncing is done.
@@ -47,9 +50,10 @@ type clientHandler struct {
 
 func newClientHandler(ulcServers []string, ulcFraction int, checkpoint *params.TrustedCheckpoint, backend *LightEthereum) *clientHandler {
 	handler := &clientHandler{
-		checkpoint: checkpoint,
-		backend:    backend,
-		closeCh:    make(chan struct{}),
+		checkpoint:          checkpoint,
+		backend:             backend,
+		closeCh:             make(chan struct{}),
+		lespayReplyHandlers: make(map[uint64]func([]byte, uint) bool),
 	}
 	if ulcServers != nil {
 		ulc, err := newULC(ulcServers, ulcFraction)
@@ -112,28 +116,48 @@ func (h *clientHandler) handle(p *serverPeer) error {
 		p.Log().Debug("Light Ethereum handshake failed", "err", err)
 		return err
 	}
-	// Register the peer locally
-	if err := h.backend.peers.register(p); err != nil {
-		p.Log().Error("Light Ethereum peer registration failed", "err", err)
-		return err
-	}
-	serverConnectionGauge.Update(int64(h.backend.peers.len()))
 
-	connectedAt := mclock.Now()
-	defer func() {
-		h.backend.peers.unregister(p.id)
+	var (
+		connectedAt mclock.AbsTime
+		lastActive  bool
+	)
+	activate := func() {
+		// Register the peer locally
+		if err := h.backend.peers.register(p); err != nil {
+			p.Log().Error("Light Ethereum peer registration failed", "err", err)
+			return
+		}
+		serverConnectionGauge.Update(int64(h.backend.peers.len()))
+		connectedAt = mclock.Now()
+		h.fetcher.announce(p, &announceData{Hash: p.headInfo.Hash, Number: p.headInfo.Number, Td: p.headInfo.Td})
+		lastActive = true
+	}
+	deactivate := func() {
+		h.backend.peers.unregister(p)
 		connectionTimer.Update(time.Duration(mclock.Now() - connectedAt))
 		serverConnectionGauge.Update(int64(h.backend.peers.len()))
+		lastActive = false
+	}
+	defer func() {
+		if lastActive {
+			deactivate()
+		}
+		h.backend.peers.disconnect(p.id)
 	}()
-
-	h.fetcher.announce(p, &announceData{Hash: p.headInfo.Hash, Number: p.headInfo.Number, Td: p.headInfo.Td})
 
 	// pool entry can be nil during the unit test.
 	if p.poolEntry != nil {
 		h.backend.serverPool.registered(p.poolEntry)
 	}
+
 	// Spawn a main loop to handle all incoming messages.
 	for {
+		if p.active && !lastActive {
+			activate()
+		}
+		if !p.active && lastActive {
+			deactivate()
+		}
 		if err := h.handleMsg(p); err != nil {
 			p.Log().Debug("Light Ethereum message handling failed", "err", err)
 			p.fcServer.DumpLogs()
@@ -157,7 +181,10 @@ func (h *clientHandler) handleMsg(p *serverPeer) error {
 	}
 	defer msg.Discard()
 
-	var deliverMsg *Msg
+	var (
+		deliverMsg    *Msg
+		responseError bool
+	)
 
 	// Handle the message depending on its contents
 	switch msg.Code {
@@ -193,13 +220,15 @@ func (h *clientHandler) handleMsg(p *serverPeer) error {
 	case BlockHeadersMsg:
 		p.Log().Trace("Received block header response message")
 		var resp struct {
-			ReqID, BV uint64
-			Headers   []*types.Header
+			ReqID   uint64
+			SF      stateFeedback
+			Headers []*types.Header
 		}
+		resp.SF.protocolVersion = p.version
 		if err := msg.Decode(&resp); err != nil {
 			return errResp(ErrDecode, "msg %v: %v", msg, err)
 		}
-		p.fcServer.ReceivedReply(resp.ReqID, resp.BV)
+		p.fcServer.ReceivedReply(resp.ReqID, resp.SF.BV)
 		if h.fetcher.requestedID(resp.ReqID) {
 			h.fetcher.deliverHeaders(p, resp.ReqID, resp.Headers)
 		} else {
@@ -210,13 +239,15 @@ func (h *clientHandler) handleMsg(p *serverPeer) error {
 	case BlockBodiesMsg:
 		p.Log().Trace("Received block bodies response")
 		var resp struct {
-			ReqID, BV uint64
-			Data      []*types.Body
+			ReqID uint64
+			SF    stateFeedback
+			Data  []*types.Body
 		}
+		resp.SF.protocolVersion = p.version
 		if err := msg.Decode(&resp); err != nil {
 			return errResp(ErrDecode, "msg %v: %v", msg, err)
 		}
-		p.fcServer.ReceivedReply(resp.ReqID, resp.BV)
+		p.fcServer.ReceivedReply(resp.ReqID, resp.SF.BV)
 		deliverMsg = &Msg{
 			MsgType: MsgBlockBodies,
 			ReqID:   resp.ReqID,
@@ -225,13 +256,15 @@ func (h *clientHandler) handleMsg(p *serverPeer) error {
 	case CodeMsg:
 		p.Log().Trace("Received code response")
 		var resp struct {
-			ReqID, BV uint64
-			Data      [][]byte
+			ReqID uint64
+			SF    stateFeedback
+			Data  [][]byte
 		}
+		resp.SF.protocolVersion = p.version
 		if err := msg.Decode(&resp); err != nil {
 			return errResp(ErrDecode, "msg %v: %v", msg, err)
 		}
-		p.fcServer.ReceivedReply(resp.ReqID, resp.BV)
+		p.fcServer.ReceivedReply(resp.ReqID, resp.SF.BV)
 		deliverMsg = &Msg{
 			MsgType: MsgCode,
 			ReqID:   resp.ReqID,
@@ -240,13 +273,15 @@ func (h *clientHandler) handleMsg(p *serverPeer) error {
 	case ReceiptsMsg:
 		p.Log().Trace("Received receipts response")
 		var resp struct {
-			ReqID, BV uint64
-			Receipts  []types.Receipts
+			ReqID    uint64
+			SF       stateFeedback
+			Receipts []types.Receipts
 		}
+		resp.SF.protocolVersion = p.version
 		if err := msg.Decode(&resp); err != nil {
 			return errResp(ErrDecode, "msg %v: %v", msg, err)
 		}
-		p.fcServer.ReceivedReply(resp.ReqID, resp.BV)
+		p.fcServer.ReceivedReply(resp.ReqID, resp.SF.BV)
 		deliverMsg = &Msg{
 			MsgType: MsgReceipts,
 			ReqID:   resp.ReqID,
@@ -255,13 +290,15 @@ func (h *clientHandler) handleMsg(p *serverPeer) error {
 	case ProofsV2Msg:
 		p.Log().Trace("Received les/2 proofs response")
 		var resp struct {
-			ReqID, BV uint64
-			Data      light.NodeList
+			ReqID uint64
+			SF    stateFeedback
+			Data  light.NodeList
 		}
+		resp.SF.protocolVersion = p.version
 		if err := msg.Decode(&resp); err != nil {
 			return errResp(ErrDecode, "msg %v: %v", msg, err)
 		}
-		p.fcServer.ReceivedReply(resp.ReqID, resp.BV)
+		p.fcServer.ReceivedReply(resp.ReqID, resp.SF.BV)
 		deliverMsg = &Msg{
 			MsgType: MsgProofsV2,
 			ReqID:   resp.ReqID,
@@ -270,13 +307,15 @@ func (h *clientHandler) handleMsg(p *serverPeer) error {
 	case HelperTrieProofsMsg:
 		p.Log().Trace("Received helper trie proof response")
 		var resp struct {
-			ReqID, BV uint64
-			Data      HelperTrieResps
+			ReqID uint64
+			SF    stateFeedback
+			Data  HelperTrieResps
 		}
+		resp.SF.protocolVersion = p.version
 		if err := msg.Decode(&resp); err != nil {
 			return errResp(ErrDecode, "msg %v: %v", msg, err)
 		}
-		p.fcServer.ReceivedReply(resp.ReqID, resp.BV)
+		p.fcServer.ReceivedReply(resp.ReqID, resp.SF.BV)
 		deliverMsg = &Msg{
 			MsgType: MsgHelperTrieProofs,
 			ReqID:   resp.ReqID,
@@ -285,13 +324,15 @@ func (h *clientHandler) handleMsg(p *serverPeer) error {
 	case TxStatusMsg:
 		p.Log().Trace("Received tx status response")
 		var resp struct {
-			ReqID, BV uint64
-			Status    []light.TxStatus
+			ReqID  uint64
+			SF     stateFeedback
+			Status []light.TxStatus
 		}
+		resp.SF.protocolVersion = p.version
 		if err := msg.Decode(&resp); err != nil {
 			return errResp(ErrDecode, "msg %v: %v", msg, err)
 		}
-		p.fcServer.ReceivedReply(resp.ReqID, resp.BV)
+		p.fcServer.ReceivedReply(resp.ReqID, resp.SF.BV)
 		deliverMsg = &Msg{
 			MsgType: MsgTxStatus,
 			ReqID:   resp.ReqID,
@@ -302,13 +343,32 @@ func (h *clientHandler) handleMsg(p *serverPeer) error {
 		h.backend.retriever.frozen(p)
 		p.Log().Debug("Service stopped")
 	case ResumeMsg:
-		var bv uint64
-		if err := msg.Decode(&bv); err != nil {
+		var sf stateFeedback
+		sf.protocolVersion = p.version
+		if err := msg.Decode(&sf); err != nil {
 			return errResp(ErrDecode, "msg %v: %v", msg, err)
 		}
-		p.fcServer.ResumeFreeze(bv)
+		p.fcServer.ResumeFreeze(sf.BV)
 		p.unfreeze()
 		p.Log().Debug("Service resumed")
+	case LespayReplyMsg:
+		p.Log().Trace("Received tx status response")
+		var resp struct {
+			ReqID uint64
+			Reply lespayReply
+		}
+		if err := msg.Decode(&resp); err != nil {
+			return errResp(ErrDecode, "msg %v: %v", msg, err)
+		}
+		h.lespayReplyLock.Lock()
+		if handler := h.lespayReplyHandlers[resp.ReqID]; handler != nil {
+			delete(h.lespayReplyHandlers, resp.ReqID)
+			responseError = !handler(resp.Reply.Reply, resp.Reply.Delay)
+		} else {
+			responseError = true
+		}
+		h.lespayReplyLock.Unlock()
+
 	default:
 		p.Log().Trace("Received invalid message", "code", msg.Code)
 		return errResp(ErrInvalidMsgCode, "%v", msg.Code)
@@ -316,17 +376,48 @@ func (h *clientHandler) handleMsg(p *serverPeer) error {
 	// Deliver the received response to retriever.
 	if deliverMsg != nil {
 		if err := h.backend.retriever.deliver(p, deliverMsg); err != nil {
-			p.errCount++
-			if p.errCount > maxResponseErrors {
-				return err
-			}
+			responseError = true
+		}
+	}
+	if responseError {
+		p.errCount++
+		if p.errCount > maxResponseErrors {
+			return err
 		}
 	}
 	return nil
 }
 
+// makeLespayCall sends a lespay command through an LES connection and registers
+// a response handler. It returns a cancel function that removes the response
+// handler and calls it with a nil parameter if the response has not arrived yet.
+func (h *clientHandler) makeLespayCall(p *peer, cmd []byte, handler func([]byte, uint) bool) func() bool {
+	reqID := genReqID()
+	h.lespayReplyLock.Lock()
+	h.lespayReplyHandlers[reqID] = handler
+	h.lespayReplyLock.Unlock()
+	if p.SendLespay(reqID, cmd) != nil {
+		h.lespayReplyLock.Lock()
+		delete(h.lespayReplyHandlers, reqID)
+		h.lespayReplyLock.Unlock()
+		return nil
+	}
+	return func() bool {
+		h.lespayReplyLock.Lock()
+		cancel := h.lespayReplyHandlers[reqID] != nil
+		if cancel {
+			delete(h.lespayReplyHandlers, reqID)
+		}
+		h.lespayReplyLock.Unlock()
+		if cancel {
+			handler(nil, 0)
+		}
+		return cancel
+	}
+}
+
 func (h *clientHandler) removePeer(id string) {
-	h.backend.peers.unregister(id)
+	h.backend.peers.disconnect(id)
 }
 
 type peerConnection struct {

--- a/les/client_handler.go
+++ b/les/client_handler.go
@@ -391,12 +391,12 @@ func (h *clientHandler) handleMsg(p *serverPeer) error {
 // makeLespayCall sends a lespay command through an LES connection and registers
 // a response handler. It returns a cancel function that removes the response
 // handler and calls it with a nil parameter if the response has not arrived yet.
-func (h *clientHandler) makeLespayCall(p *peer, cmd []byte, handler func([]byte, uint) bool) func() bool {
+func (h *clientHandler) makeLespayCall(p *serverPeer, cmd []byte, handler func([]byte, uint) bool) func() bool {
 	reqID := genReqID()
 	h.lespayReplyLock.Lock()
 	h.lespayReplyHandlers[reqID] = handler
 	h.lespayReplyLock.Unlock()
-	if p.SendLespay(reqID, cmd) != nil {
+	if p.sendLespay(reqID, cmd) != nil {
 		h.lespayReplyLock.Lock()
 		delete(h.lespayReplyHandlers, reqID)
 		h.lespayReplyLock.Unlock()

--- a/les/clientdb.go
+++ b/les/clientdb.go
@@ -1,0 +1,278 @@
+// Copyright 2020 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+package les
+
+import (
+	"bytes"
+	"encoding/binary"
+	"io"
+	"time"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/mclock"
+	"github.com/ethereum/go-ethereum/core/rawdb"
+	"github.com/ethereum/go-ethereum/ethdb"
+	"github.com/ethereum/go-ethereum/log"
+	"github.com/ethereum/go-ethereum/p2p/enode"
+	"github.com/ethereum/go-ethereum/rlp"
+	lru "github.com/hashicorp/golang-lru"
+)
+
+const balanceCacheLimit = 8192 // the maximum number of cached items in service token balance queue
+
+// tokenBalance is a wrapper of expiredValue which represents the service token
+// balance of clients. The balance value will decay exponentially over time and
+// can be deleted when the amount is small enough.
+type tokenBalance struct {
+	value expiredValue
+}
+
+// EncodeRLP implements rlp.Encoder
+func (b *tokenBalance) EncodeRLP(w io.Writer) error {
+	return rlp.Encode(w, []interface{}{b.value.base, b.value.exp})
+}
+
+// DecodeRLP implements rlp.Decoder
+func (b *tokenBalance) DecodeRLP(s *rlp.Stream) error {
+	var entry struct {
+		Base, Exp uint64
+	}
+	if err := s.Decode(&entry); err != nil {
+		return err
+	}
+	b.value = expiredValue{base: entry.Base, exp: entry.Exp}
+	return nil
+}
+
+// currencyBalance represents the client's currency balance.
+type currencyBalance struct {
+	amount uint64
+	typ    string
+}
+
+// EncodeRLP implements rlp.Encoder
+func (b *currencyBalance) EncodeRLP(w io.Writer) error {
+	return rlp.Encode(w, []interface{}{b.amount, b.typ})
+}
+
+// DecodeRLP implements rlp.Decoder
+func (b *currencyBalance) DecodeRLP(s *rlp.Stream) error {
+	var entry struct {
+		Amount uint64
+		Type   string
+	}
+	if err := s.Decode(&entry); err != nil {
+		return err
+	}
+	b.amount, b.typ = entry.Amount, entry.Type
+	return nil
+}
+
+const (
+	// nodeDBVersion is the version identifier of the node data in db
+	//
+	// Changelog:
+	// * Replace `lastTotal` with `meta` in positive balance: version 0=>1
+	// * Rework balance, add currency balance: version 1=>2
+	nodeDBVersion = 2
+
+	// dbCleanupCycle is the cycle of db for useless data cleanup
+	dbCleanupCycle = time.Hour
+)
+
+var (
+	posBalancePrefix = []byte("pb:")         // dbVersion(uint16 big endian) + posBalancePrefix + id -> positive balance
+	negBalancePrefix = []byte("nb:")         // dbVersion(uint16 big endian) + negBalancePrefix + ip -> negative balance
+	curBalancePrefix = []byte("cb:")         // dbVersion(uint16 big endian) + curBalancePrefix + id -> currency balance
+	expirationKey    = []byte("expiration:") // dbVersion(uint16 big endian) + expirationKey -> posExp, negExp
+)
+
+type nodeDB struct {
+	db            ethdb.Database
+	cache         *lru.Cache
+	clock         mclock.Clock
+	closeCh       chan struct{}
+	evictCallBack func(mclock.AbsTime, bool, tokenBalance) bool // Callback to determine whether the balance can be evicted.
+	cleanupHook   func()                                        // Test hook used for testing
+}
+
+func newNodeDB(db ethdb.Database, clock mclock.Clock) *nodeDB {
+	var buff [2]byte
+	binary.BigEndian.PutUint16(buff[:], uint16(nodeDBVersion))
+
+	cache, _ := lru.New(balanceCacheLimit)
+	ndb := &nodeDB{
+		db:      rawdb.NewTable(db, string(buff[:])),
+		cache:   cache,
+		clock:   clock,
+		closeCh: make(chan struct{}),
+	}
+	go ndb.expirer()
+	return ndb
+}
+
+func (db *nodeDB) close() {
+	close(db.closeCh)
+}
+
+func (db *nodeDB) key(id []byte, neg bool) []byte {
+	prefix := posBalancePrefix
+	if neg {
+		prefix = negBalancePrefix
+	}
+	return append(prefix, id...)
+}
+
+func (db *nodeDB) getExpiration() (fixed64, fixed64) {
+	blob, err := db.db.Get(expirationKey)
+	if err != nil || len(blob) != 16 {
+		return 0, 0
+	}
+	return fixed64(binary.BigEndian.Uint64(blob[:8])), fixed64(binary.BigEndian.Uint64(blob[8:16]))
+}
+
+func (db *nodeDB) setExpiration(pos, neg fixed64) {
+	var buff [16]byte
+	binary.BigEndian.PutUint64(buff[:8], uint64(pos))
+	binary.BigEndian.PutUint64(buff[8:16], uint64(neg))
+	db.db.Put(expirationKey, buff[:16])
+}
+
+func (db *nodeDB) getCurrencyBalance(id enode.ID) currencyBalance {
+	var b currencyBalance
+	enc, err := db.db.Get(append(curBalancePrefix, id.Bytes()...))
+	if err != nil || len(enc) == 0 {
+		return b
+	}
+	if err := rlp.DecodeBytes(enc, &b); err != nil {
+		log.Crit("Failed to decode positive balance", "err", err)
+	}
+	return b
+}
+
+func (db *nodeDB) setCurrencyBalance(id enode.ID, b currencyBalance) {
+	enc, err := rlp.EncodeToBytes(&(b))
+	if err != nil {
+		log.Crit("Failed to encode currency balance", "err", err)
+	}
+	db.db.Put(append(curBalancePrefix, id.Bytes()...), enc)
+}
+
+func (db *nodeDB) getOrNewBalance(id []byte, neg bool) tokenBalance {
+	key := db.key(id, neg)
+	item, exist := db.cache.Get(string(key))
+	if exist {
+		return item.(tokenBalance)
+	}
+	var b tokenBalance
+	enc, err := db.db.Get(key)
+	if err != nil || len(enc) == 0 {
+		return b
+	}
+	if err := rlp.DecodeBytes(enc, &b); err != nil {
+		log.Crit("Failed to decode positive balance", "err", err)
+	}
+	db.cache.Add(string(key), b)
+	return b
+}
+
+func (db *nodeDB) setBalance(id []byte, neg bool, b tokenBalance) {
+	key := db.key(id, neg)
+	enc, err := rlp.EncodeToBytes(&(b))
+	if err != nil {
+		log.Crit("Failed to encode positive balance", "err", err)
+	}
+	db.db.Put(key, enc)
+	db.cache.Add(string(key), b)
+}
+
+func (db *nodeDB) delBalance(id []byte, neg bool) {
+	key := db.key(id, neg)
+	db.db.Delete(key)
+	db.cache.Remove(string(key))
+}
+
+// getPosBalanceIDs returns a lexicographically ordered list of IDs of accounts
+// with a positive balance
+func (db *nodeDB) getPosBalanceIDs(start, stop enode.ID, maxCount int) (result []enode.ID) {
+	if maxCount <= 0 {
+		return
+	}
+	it := db.db.NewIteratorWithStart(db.key(start.Bytes(), false))
+	defer it.Release()
+	for i := len(stop[:]) - 1; i >= 0; i-- {
+		stop[i]--
+		if stop[i] != 255 {
+			break
+		}
+	}
+	stopKey := db.key(stop.Bytes(), false)
+	keyLen := len(stopKey)
+
+	for it.Next() {
+		var id enode.ID
+		if len(it.Key()) != keyLen || bytes.Compare(it.Key(), stopKey) == 1 {
+			return
+		}
+		copy(id[:], it.Key()[keyLen-len(id):])
+		result = append(result, id)
+		if len(result) == maxCount {
+			return
+		}
+	}
+	return
+}
+
+func (db *nodeDB) expirer() {
+	for {
+		select {
+		case <-db.clock.After(dbCleanupCycle):
+			db.expireNodes()
+		case <-db.closeCh:
+			return
+		}
+	}
+}
+
+// expireNodes iterates the whole node db and checks whether the
+// token balances can deleted.
+func (db *nodeDB) expireNodes() {
+	var (
+		visited int
+		deleted int
+		start   = time.Now()
+	)
+	for index, prefix := range [][]byte{posBalancePrefix, negBalancePrefix} {
+		iter := db.db.NewIteratorWithPrefix(prefix)
+		for iter.Next() {
+			visited += 1
+			var balance tokenBalance
+			if err := rlp.DecodeBytes(iter.Value(), &balance); err != nil {
+				log.Crit("Failed to decode negative balance", "err", err)
+			}
+			if db.evictCallBack != nil && db.evictCallBack(db.clock.Now(), index != 0, balance) {
+				deleted += 1
+				db.db.Delete(iter.Key())
+			}
+		}
+	}
+	// Invoke testing hook if it's not nil.
+	if db.cleanupHook != nil {
+		db.cleanupHook()
+	}
+	log.Debug("Expire nodes", "visited", visited, "deleted", deleted, "elapsed", common.PrettyDuration(time.Since(start)))
+}

--- a/les/clientdb_test.go
+++ b/les/clientdb_test.go
@@ -1,0 +1,139 @@
+// Copyright 2020 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+package les
+
+import (
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/ethereum/go-ethereum/common/mclock"
+	"github.com/ethereum/go-ethereum/core/rawdb"
+	"github.com/ethereum/go-ethereum/p2p/enode"
+)
+
+func TestNodeDB(t *testing.T) {
+	ndb := newNodeDB(rawdb.NewMemoryDatabase(), mclock.System{})
+	defer ndb.close()
+
+	var cases = []struct {
+		id       enode.ID
+		ip       string
+		balance  tokenBalance
+		positive bool
+	}{
+		{enode.ID{0x00, 0x01, 0x02}, "", tokenBalance{value: expval(100)}, true},
+		{enode.ID{0x00, 0x01, 0x02}, "", tokenBalance{value: expval(200)}, true},
+		{enode.ID{}, "127.0.0.1", tokenBalance{value: expval(100)}, false},
+		{enode.ID{}, "127.0.0.1", tokenBalance{value: expval(200)}, false},
+	}
+	for _, c := range cases {
+		if c.positive {
+			ndb.setBalance(c.id.Bytes(), false, c.balance)
+			if pb := ndb.getOrNewBalance(c.id.Bytes(), false); !reflect.DeepEqual(pb, c.balance) {
+				t.Fatalf("Positive balance mismatch, want %v, got %v", c.balance, pb)
+			}
+		} else {
+			ndb.setBalance([]byte(c.ip), true, c.balance)
+			if nb := ndb.getOrNewBalance([]byte(c.ip), true); !reflect.DeepEqual(nb, c.balance) {
+				t.Fatalf("Negative balance mismatch, want %v, got %v", c.balance, nb)
+			}
+		}
+	}
+	for _, c := range cases {
+		if c.positive {
+			ndb.delBalance(c.id.Bytes(), false)
+			if pb := ndb.getOrNewBalance(c.id.Bytes(), false); !reflect.DeepEqual(pb, tokenBalance{}) {
+				t.Fatalf("Positive balance mismatch, want %v, got %v", tokenBalance{}, pb)
+			}
+		} else {
+			ndb.delBalance([]byte(c.ip), true)
+			if nb := ndb.getOrNewBalance([]byte(c.ip), true); !reflect.DeepEqual(nb, tokenBalance{}) {
+				t.Fatalf("Negative balance mismatch, want %v, got %v", tokenBalance{}, nb)
+			}
+		}
+	}
+	posExp, negExp := fixed64(1000), fixed64(2000)
+	ndb.setExpiration(posExp, negExp)
+	if pos, neg := ndb.getExpiration(); pos != posExp || neg != negExp {
+		t.Fatalf("Expiration mismatch, want %v / %v, got %v / %v", posExp, negExp, pos, neg)
+	}
+	curBalance := currencyBalance{typ: "ETH", amount: 10000}
+	ndb.setCurrencyBalance(enode.ID{0x01, 0x02}, curBalance)
+	if got := ndb.getCurrencyBalance(enode.ID{0x01, 0x02}); !reflect.DeepEqual(got, curBalance) {
+		t.Fatalf("Currency balance mismatch, want %v, got %v", curBalance, got)
+	}
+}
+
+func TestNodeDBExpiration(t *testing.T) {
+	var (
+		iterated int
+		done     = make(chan struct{}, 1)
+	)
+	callback := func(now mclock.AbsTime, neg bool, b tokenBalance) bool {
+		iterated += 1
+		return true
+	}
+	clock := &mclock.Simulated{}
+	ndb := newNodeDB(rawdb.NewMemoryDatabase(), clock)
+	defer ndb.close()
+	ndb.evictCallBack = callback
+	ndb.cleanupHook = func() { done <- struct{}{} }
+
+	var cases = []struct {
+		id      []byte
+		neg     bool
+		balance tokenBalance
+	}{
+		{[]byte{0x01, 0x02}, false, tokenBalance{value: expval(1)}},
+		{[]byte{0x03, 0x04}, false, tokenBalance{value: expval(1)}},
+		{[]byte{0x05, 0x06}, false, tokenBalance{value: expval(1)}},
+		{[]byte{0x07, 0x08}, false, tokenBalance{value: expval(1)}},
+
+		{[]byte("127.0.0.1"), true, tokenBalance{value: expval(1)}},
+		{[]byte("127.0.0.2"), true, tokenBalance{value: expval(1)}},
+		{[]byte("127.0.0.3"), true, tokenBalance{value: expval(1)}},
+		{[]byte("127.0.0.4"), true, tokenBalance{value: expval(1)}},
+	}
+	for _, c := range cases {
+		ndb.setBalance(c.id, c.neg, c.balance)
+	}
+	clock.WaitForTimers(1)
+	clock.Run(time.Hour + time.Minute)
+	select {
+	case <-done:
+	case <-time.NewTimer(time.Second).C:
+		t.Fatalf("timeout")
+	}
+	if iterated != 8 {
+		t.Fatalf("Failed to evict useless balances, want %v, got %d", 8, iterated)
+	}
+
+	for _, c := range cases {
+		ndb.setBalance(c.id, c.neg, c.balance)
+	}
+	clock.WaitForTimers(1)
+	clock.Run(time.Hour + time.Minute)
+	select {
+	case <-done:
+	case <-time.NewTimer(time.Second).C:
+		t.Fatalf("timeout")
+	}
+	if iterated != 16 {
+		t.Fatalf("Failed to evict useless balances, want %v, got %d", 16, iterated)
+	}
+}

--- a/les/clientpool.go
+++ b/les/clientpool.go
@@ -123,7 +123,7 @@ type clientPoolPeer interface {
 	ID() enode.ID
 	freeClientId() string
 	updateCapacity(uint64)
-	freezeClient()
+	freeze()
 }
 
 // clientInfo represents a connected client
@@ -500,7 +500,7 @@ func (f *clientPool) disconnect(p clientPoolPeer) {
 }
 
 // drop deactivates the peer if necessary and drops it from the inactive queue
-func (f *clientPool) drop(p clientPeer, kicked bool) {
+func (f *clientPool) drop(p clientPoolPeer, kicked bool) {
 	// Short circuit if client pool is already closed.
 	if f.closed {
 		return

--- a/les/clientpool.go
+++ b/les/clientpool.go
@@ -226,9 +226,11 @@ func newClientPool(db ethdb.Database, minCap, freeClientCap uint64, clock mclock
 		for {
 			select {
 			case <-clock.After(persistExpirationRefresh):
+				pool.lock.Lock()
 				now := pool.clock.Now()
 				posExp := pool.posExpiration(now)
 				negExp := pool.negExpiration(now)
+				pool.lock.Unlock()
 				pool.ndb.setExpiration(posExp, negExp)
 			case <-pool.stopCh:
 				return

--- a/les/clientpool_test.go
+++ b/les/clientpool_test.go
@@ -56,29 +56,34 @@ func TestClientPoolL100C300P20(t *testing.T) {
 
 const testClientPoolTicks = 100000
 
-type poolTestPeer int
-
-func (i poolTestPeer) ID() enode.ID {
-	return enode.ID{byte(i % 256), byte(i >> 8)}
+type poolTestPeer struct {
+	index     int
+	disconnCh chan int
+	cap       uint64
 }
 
-func (i poolTestPeer) freeClientId() string {
+func newPoolTestPeer(i int, disconnCh chan int) *poolTestPeer {
+	return &poolTestPeer{index: i, disconnCh: disconnCh}
+}
+
+func (i *poolTestPeer) ID() enode.ID {
+	return enode.ID{byte(i.index % 256), byte(i.index >> 8)}
+}
+
+func (i *poolTestPeer) freeClientId() string {
 	return fmt.Sprintf("addr #%d", i)
 }
 
-func (i poolTestPeer) updateCapacity(uint64) {}
-
-type poolTestPeerWithCap struct {
-	poolTestPeer
-
-	cap uint64
+func (i *poolTestPeer) updateCapacity(cap uint64) {
+	i.cap = cap
+	if cap == 0 && i.disconnCh != nil {
+		i.disconnCh <- i.index
+	}
 }
 
-func (i *poolTestPeerWithCap) updateCapacity(cap uint64) { i.cap = cap }
+func (i *poolTestPeer) freezeClient() {}
 
-func (i poolTestPeer) freezeClient() {}
-
-func testClientPool(t *testing.T, connLimit, clientCount, paidCount int, randomDisconnect bool) {
+func testClientPool(t *testing.T, activeLimit, clientCount, paidCount int, randomDisconnect bool) {
 	rand.Seed(time.Now().UnixNano())
 	var (
 		clock     mclock.Simulated
@@ -89,15 +94,16 @@ func testClientPool(t *testing.T, connLimit, clientCount, paidCount int, randomD
 		disconnFn = func(id enode.ID) {
 			disconnCh <- int(id[0]) + int(id[1])<<8
 		}
-		pool = newClientPool(db, 1, &clock, disconnFn)
+		pool = newClientPool(db, 1, 1, &clock, disconnFn)
 	)
+
 	pool.disableBias = true
-	pool.setLimits(connLimit, uint64(connLimit))
+	pool.setLimits(activeLimit, uint64(activeLimit))
 	pool.setDefaultFactors(priceFactors{1, 0, 1}, priceFactors{1, 0, 1})
 
 	// pool should accept new peers up to its connected limit
-	for i := 0; i < connLimit; i++ {
-		if pool.connect(poolTestPeer(i), 0) {
+	for i := 0; i < activeLimit; i++ {
+		if cap, _ := pool.connect(newPoolTestPeer(i, disconnCh), 0); cap != 0 {
 			connected[i] = true
 		} else {
 			t.Fatalf("Test peer #%d rejected", i)
@@ -111,28 +117,30 @@ func testClientPool(t *testing.T, connLimit, clientCount, paidCount int, randomD
 			// give a positive balance to some of the peers
 			amount := testClientPoolTicks / 2 * int64(time.Second) // enough for half of the simulation period
 			for i := 0; i < paidCount; i++ {
-				pool.addBalance(poolTestPeer(i).ID(), amount, "")
+				pool.addBalance(newPoolTestPeer(i, disconnCh).ID(), amount, "")
 			}
 		}
 
 		i := rand.Intn(clientCount)
 		if connected[i] {
 			if randomDisconnect {
-				pool.disconnect(poolTestPeer(i))
+				pool.disconnect(newPoolTestPeer(i, disconnCh))
 				connected[i] = false
 				connTicks[i] += tickCounter
 			}
 		} else {
-			if pool.connect(poolTestPeer(i), 0) {
+			if cap, _ := pool.connect(newPoolTestPeer(i, disconnCh), 0); cap != 0 {
 				connected[i] = true
 				connTicks[i] -= tickCounter
+			} else {
+				pool.disconnect(newPoolTestPeer(i, disconnCh))
 			}
 		}
 	pollDisconnects:
 		for {
 			select {
 			case i := <-disconnCh:
-				pool.disconnect(poolTestPeer(i))
+				pool.disconnect(newPoolTestPeer(i, disconnCh))
 				if connected[i] {
 					connTicks[i] += tickCounter
 					connected[i] = false
@@ -143,10 +151,10 @@ func testClientPool(t *testing.T, connLimit, clientCount, paidCount int, randomD
 		}
 	}
 
-	expTicks := testClientPoolTicks/2*connLimit/clientCount + testClientPoolTicks/2*(connLimit-paidCount)/(clientCount-paidCount)
+	expTicks := testClientPoolTicks/2*activeLimit/clientCount + testClientPoolTicks/2*(activeLimit-paidCount)/(clientCount-paidCount)
 	expMin := expTicks - expTicks/5
 	expMax := expTicks + expTicks/5
-	paidTicks := testClientPoolTicks/2*connLimit/clientCount + testClientPoolTicks/2
+	paidTicks := testClientPoolTicks/2*activeLimit/clientCount + testClientPoolTicks/2
 	paidMin := paidTicks - paidTicks/5
 	paidMax := paidTicks + paidTicks/5
 
@@ -172,15 +180,15 @@ func TestConnectPaidClient(t *testing.T) {
 		clock mclock.Simulated
 		db    = rawdb.NewMemoryDatabase()
 	)
-	pool := newClientPool(db, 1, &clock, nil)
+	pool := newClientPool(db, 1, 1, &clock, nil)
 	defer pool.stop()
 	pool.setLimits(10, uint64(10))
 	pool.setDefaultFactors(priceFactors{1, 0, 1}, priceFactors{1, 0, 1})
 
 	// Add balance for an external client and mark it as paid client
-	pool.addBalance(poolTestPeer(0).ID(), 1000, "")
+	pool.addBalance(newPoolTestPeer(0, nil).ID(), 1000, "")
 
-	if !pool.connect(poolTestPeer(0), 10) {
+	if cap, _ := pool.connect(newPoolTestPeer(0, nil), 10); cap == 0 {
 		t.Fatalf("Failed to connect paid client")
 	}
 }
@@ -190,16 +198,16 @@ func TestConnectPaidClientToSmallPool(t *testing.T) {
 		clock mclock.Simulated
 		db    = rawdb.NewMemoryDatabase()
 	)
-	pool := newClientPool(db, 1, &clock, nil)
+	pool := newClientPool(db, 1, 1, &clock, nil)
 	defer pool.stop()
 	pool.setLimits(10, uint64(10)) // Total capacity limit is 10
 	pool.setDefaultFactors(priceFactors{1, 0, 1}, priceFactors{1, 0, 1})
 
 	// Add balance for an external client and mark it as paid client
-	pool.addBalance(poolTestPeer(0).ID(), 1000, "")
+	pool.addBalance(newPoolTestPeer(0, nil).ID(), 1000, "")
 
 	// Connect a fat paid client to pool, should reject it.
-	if pool.connect(poolTestPeer(0), 100) {
+	if cap, _ := pool.connect(newPoolTestPeer(0, nil), 100); cap != 0 {
 		t.Fatalf("Connected fat paid client, should reject it")
 	}
 }
@@ -210,23 +218,23 @@ func TestConnectPaidClientToFullPool(t *testing.T) {
 		db    = rawdb.NewMemoryDatabase()
 	)
 	removeFn := func(enode.ID) {} // Noop
-	pool := newClientPool(db, 1, &clock, removeFn)
+	pool := newClientPool(db, 1, 1, &clock, removeFn)
 	defer pool.stop()
 	pool.setLimits(10, uint64(10)) // Total capacity limit is 10
 	pool.setDefaultFactors(priceFactors{1, 0, 1}, priceFactors{1, 0, 1})
 
 	for i := 0; i < 10; i++ {
-		pool.addBalance(poolTestPeer(i).ID(), 1000000000, "")
-		pool.connect(poolTestPeer(i), 1)
+		pool.addBalance(newPoolTestPeer(i, nil).ID(), 1000000000, "")
+		pool.connect(newPoolTestPeer(i, nil), 1)
 	}
-	pool.addBalance(poolTestPeer(11).ID(), 1000, "") // Add low balance to new paid client
-	if pool.connect(poolTestPeer(11), 1) {
+	pool.addBalance(newPoolTestPeer(11, nil).ID(), 1000, "") // Add low balance to new paid client
+	if cap, _ := pool.connect(newPoolTestPeer(11, nil), 1); cap != 0 {
 		t.Fatalf("Low balance paid client should be rejected")
 	}
 	clock.Run(time.Second)
-	pool.addBalance(poolTestPeer(12).ID(), 1000000000*60*3, "") // Add high balance to new paid client
-	if !pool.connect(poolTestPeer(12), 1) {
-		t.Fatalf("High balance paid client should be accpected")
+	pool.addBalance(newPoolTestPeer(12, nil).ID(), 1000000000*60*3+1, "") // Add high balance to new paid client
+	if cap, _ := pool.connect(newPoolTestPeer(12, nil), 1); cap == 0 {
+		t.Fatalf("High balance paid client should be accepted")
 	}
 }
 
@@ -237,19 +245,19 @@ func TestPaidClientKickedOut(t *testing.T) {
 		kickedCh = make(chan int, 1)
 	)
 	removeFn := func(id enode.ID) { kickedCh <- int(id[0]) }
-	pool := newClientPool(db, 1, &clock, removeFn)
+	pool := newClientPool(db, 1, 1, &clock, removeFn)
 	defer pool.stop()
 	pool.setLimits(10, uint64(10)) // Total capacity limit is 10
 	pool.setDefaultFactors(priceFactors{1, 0, 1}, priceFactors{1, 0, 1})
 
 	for i := 0; i < 10; i++ {
-		pool.addBalance(poolTestPeer(i).ID(), 1000000000, "") // 1 second allowance
-		pool.connect(poolTestPeer(i), 1)
+		pool.addBalance(newPoolTestPeer(i, kickedCh).ID(), 1000000000, "") // 1 second allowance
+		pool.connect(newPoolTestPeer(i, kickedCh), 1)
 		clock.Run(time.Millisecond)
 	}
 	clock.Run(time.Second)
-	clock.Run(connectedBias)
-	if !pool.connect(poolTestPeer(11), 0) {
+	clock.Run(activeBias)
+	if cap, _ := pool.connect(newPoolTestPeer(11, kickedCh), 0); cap == 0 {
 		t.Fatalf("Free client should be accectped")
 	}
 	select {
@@ -267,11 +275,11 @@ func TestConnectFreeClient(t *testing.T) {
 		clock mclock.Simulated
 		db    = rawdb.NewMemoryDatabase()
 	)
-	pool := newClientPool(db, 1, &clock, nil)
+	pool := newClientPool(db, 1, 1, &clock, nil)
 	defer pool.stop()
 	pool.setLimits(10, uint64(10))
 	pool.setDefaultFactors(priceFactors{1, 0, 1}, priceFactors{1, 0, 1})
-	if !pool.connect(poolTestPeer(0), 10) {
+	if cap, _ := pool.connect(newPoolTestPeer(0, nil), 10); cap == 0 {
 		t.Fatalf("Failed to connect free client")
 	}
 }
@@ -282,24 +290,24 @@ func TestConnectFreeClientToFullPool(t *testing.T) {
 		db    = rawdb.NewMemoryDatabase()
 	)
 	removeFn := func(enode.ID) {} // Noop
-	pool := newClientPool(db, 1, &clock, removeFn)
+	pool := newClientPool(db, 1, 1, &clock, removeFn)
 	defer pool.stop()
 	pool.setLimits(10, uint64(10)) // Total capacity limit is 10
 	pool.setDefaultFactors(priceFactors{1, 0, 1}, priceFactors{1, 0, 1})
 
 	for i := 0; i < 10; i++ {
-		pool.connect(poolTestPeer(i), 1)
+		pool.connect(newPoolTestPeer(i, nil), 1)
 	}
-	if pool.connect(poolTestPeer(11), 1) {
+	if cap, _ := pool.connect(newPoolTestPeer(11, nil), 1); cap != 0 {
 		t.Fatalf("New free client should be rejected")
 	}
 	clock.Run(time.Minute)
-	if pool.connect(poolTestPeer(12), 1) {
+	if cap, _ := pool.connect(newPoolTestPeer(12, nil), 1); cap != 0 {
 		t.Fatalf("New free client should be rejected")
 	}
 	clock.Run(time.Millisecond)
 	clock.Run(4 * time.Minute)
-	if !pool.connect(poolTestPeer(13), 1) {
+	if cap, _ := pool.connect(newPoolTestPeer(13, nil), 1); cap == 0 {
 		t.Fatalf("Old client connects more than 5min should be kicked")
 	}
 }
@@ -311,21 +319,22 @@ func TestFreeClientKickedOut(t *testing.T) {
 		kicked = make(chan int, 10)
 	)
 	removeFn := func(id enode.ID) { kicked <- int(id[0]) }
-	pool := newClientPool(db, 1, &clock, removeFn)
+	pool := newClientPool(db, 1, 1, &clock, removeFn)
 	defer pool.stop()
 	pool.setLimits(10, uint64(10)) // Total capacity limit is 10
 	pool.setDefaultFactors(priceFactors{1, 0, 1}, priceFactors{1, 0, 1})
 
 	for i := 0; i < 10; i++ {
-		pool.connect(poolTestPeer(i), 1)
+		pool.connect(newPoolTestPeer(i, kicked), 1)
 		clock.Run(time.Millisecond)
 	}
-	if pool.connect(poolTestPeer(10), 1) {
+	if cap, _ := pool.connect(newPoolTestPeer(10, kicked), 1); cap != 0 {
 		t.Fatalf("New free client should be rejected")
 	}
+	pool.disconnect(newPoolTestPeer(10, kicked))
 	clock.Run(5 * time.Minute)
 	for i := 0; i < 10; i++ {
-		pool.connect(poolTestPeer(i+10), 1)
+		pool.connect(newPoolTestPeer(i+10, kicked), 1)
 	}
 	for i := 0; i < 10; i++ {
 		select {
@@ -346,18 +355,18 @@ func TestPositiveBalanceCalculation(t *testing.T) {
 		kicked = make(chan int, 10)
 	)
 	removeFn := func(id enode.ID) { kicked <- int(id[0]) } // Noop
-	pool := newClientPool(db, 1, &clock, removeFn)
+	pool := newClientPool(db, 1, 1, &clock, removeFn)
 	defer pool.stop()
 	pool.setLimits(10, uint64(10)) // Total capacity limit is 10
 	pool.setDefaultFactors(priceFactors{1, 0, 1}, priceFactors{1, 0, 1})
 
-	pool.addBalance(poolTestPeer(0).ID(), int64(time.Minute*3), "")
-	pool.connect(poolTestPeer(0), 10)
+	pool.addBalance(newPoolTestPeer(0, kicked).ID(), int64(time.Minute*3), "")
+	pool.connect(newPoolTestPeer(0, kicked), 10)
 	clock.Run(time.Minute)
 
-	pool.disconnect(poolTestPeer(0))
-	pb := pool.ndb.getOrNewPB(poolTestPeer(0).ID())
-	if pb.value != uint64(time.Minute*2) {
+	pool.disconnect(newPoolTestPeer(0, kicked))
+	pb := pool.ndb.getOrNewPB(newPoolTestPeer(0, kicked).ID())
+	if pb.value != expval(uint64(time.Minute*2)) {
 		t.Fatalf("Positive balance mismatch, want %v, got %v", uint64(time.Minute*2), pb.value)
 	}
 }
@@ -369,16 +378,14 @@ func TestDowngradePriorityClient(t *testing.T) {
 		kicked = make(chan int, 10)
 	)
 	removeFn := func(id enode.ID) { kicked <- int(id[0]) } // Noop
-	pool := newClientPool(db, 1, &clock, removeFn)
+	pool := newClientPool(db, 1, 1, &clock, removeFn)
 	defer pool.stop()
 	pool.setLimits(10, uint64(10)) // Total capacity limit is 10
 	pool.setDefaultFactors(priceFactors{1, 0, 1}, priceFactors{1, 0, 1})
 
-	p := &poolTestPeerWithCap{
-		poolTestPeer: poolTestPeer(0),
-	}
+	p := newPoolTestPeer(0, kicked)
 	pool.addBalance(p.ID(), int64(time.Minute), "")
-	pool.connect(p, 10)
+	p.cap, _ = pool.connect(p, 10)
 	if p.cap != 10 {
 		t.Fatalf("The capcacity of priority peer hasn't been updated, got: %d", p.cap)
 	}
@@ -388,53 +395,51 @@ func TestDowngradePriorityClient(t *testing.T) {
 	if p.cap != 1 {
 		t.Fatalf("The capcacity of peer should be downgraded, got: %d", p.cap)
 	}
-	pb := pool.ndb.getOrNewPB(poolTestPeer(0).ID())
-	if pb.value != 0 {
+	pb := pool.ndb.getOrNewPB(newPoolTestPeer(0, kicked).ID())
+	if pb.value.base != 0 {
 		t.Fatalf("Positive balance mismatch, want %v, got %v", 0, pb.value)
 	}
 
-	pool.addBalance(poolTestPeer(0).ID(), int64(time.Minute), "")
-	pb = pool.ndb.getOrNewPB(poolTestPeer(0).ID())
-	if pb.value != uint64(time.Minute) {
+	pool.addBalance(newPoolTestPeer(0, kicked).ID(), int64(time.Minute), "")
+	pb = pool.ndb.getOrNewPB(newPoolTestPeer(0, kicked).ID())
+	if pb.value != expval(uint64(time.Minute)) {
 		t.Fatalf("Positive balance mismatch, want %v, got %v", uint64(time.Minute), pb.value)
 	}
 }
 
 func TestNegativeBalanceCalculation(t *testing.T) {
 	var (
-		clock  mclock.Simulated
-		db     = rawdb.NewMemoryDatabase()
-		kicked = make(chan int, 10)
+		clock mclock.Simulated
+		db    = rawdb.NewMemoryDatabase()
 	)
-	removeFn := func(id enode.ID) { kicked <- int(id[0]) } // Noop
-	pool := newClientPool(db, 1, &clock, removeFn)
+	pool := newClientPool(db, 1, 1, &clock, nil)
 	defer pool.stop()
 	pool.setLimits(10, uint64(10)) // Total capacity limit is 10
 	pool.setDefaultFactors(priceFactors{1, 0, 1}, priceFactors{1, 0, 1})
 
 	for i := 0; i < 10; i++ {
-		pool.connect(poolTestPeer(i), 1)
+		pool.connect(newPoolTestPeer(i, nil), 1)
 	}
-	clock.Run(time.Second)
+	clock.Run(time.Millisecond * 999)
 
 	for i := 0; i < 10; i++ {
-		pool.disconnect(poolTestPeer(i))
-		nb := pool.ndb.getOrNewNB(poolTestPeer(i).freeClientId())
+		pool.disconnect(newPoolTestPeer(i, nil))
+		nb := pool.ndb.getOrNewNB(newPoolTestPeer(i, nil).freeClientId())
 		if nb.logValue != 0 {
 			t.Fatalf("Short connection shouldn't be recorded")
 		}
 	}
 
 	for i := 0; i < 10; i++ {
-		pool.connect(poolTestPeer(i), 1)
+		pool.connect(newPoolTestPeer(i, nil), 1)
 	}
 	clock.Run(time.Minute)
 	for i := 0; i < 10; i++ {
-		pool.disconnect(poolTestPeer(i))
-		nb := pool.ndb.getOrNewNB(poolTestPeer(i).freeClientId())
-		nb.logValue -= pool.logOffset(clock.Now())
-		nb.logValue /= fixedPointMultiplier
-		if nb.logValue != int64(math.Log(float64(time.Minute/time.Second))) {
+		pool.disconnect(newPoolTestPeer(i, nil))
+		nb := pool.ndb.getOrNewNB(newPoolTestPeer(i, nil).freeClientId())
+		nb.logValue -= pool.negExpiration(clock.Now())
+		nb.logValue = uint64(float64(nb.logValue) / logMultiplier)
+		if nb.logValue != uint64(math.Log(float64(time.Minute/time.Second))) {
 			t.Fatalf("Negative balance mismatch, want %v, got %v", int64(math.Log(float64(time.Minute/time.Second))), nb.logValue)
 		}
 	}
@@ -453,8 +458,8 @@ func TestNodeDB(t *testing.T) {
 		balance  interface{}
 		positive bool
 	}{
-		{enode.ID{0x00, 0x01, 0x02}, "", posBalance{value: 100}, true},
-		{enode.ID{0x00, 0x01, 0x02}, "", posBalance{value: 200}, true},
+		{enode.ID{0x00, 0x01, 0x02}, "", posBalance{value: expval(100)}, true},
+		{enode.ID{0x00, 0x01, 0x02}, "", posBalance{value: expval(200)}, true},
 		{enode.ID{}, "127.0.0.1", negBalance{logValue: 10}, false},
 		{enode.ID{}, "127.0.0.1", negBalance{logValue: 20}, false},
 	}
@@ -484,9 +489,9 @@ func TestNodeDB(t *testing.T) {
 			}
 		}
 	}
-	ndb.setCumulativeTime(100)
-	if ndb.getCumulativeTime() != 100 {
-		t.Fatalf("Cumulative time mismatch, want %v, got %v", 100, ndb.getCumulativeTime())
+	ndb.setExpiration(100, 200)
+	if pos, neg := ndb.getExpiration(); pos != 100 || neg != 200 {
+		t.Fatalf("Expiration mismatch, want %v / %v, got %v / %v", 100, 200, pos, neg)
 	}
 }
 
@@ -539,5 +544,85 @@ func TestNodeDBExpiration(t *testing.T) {
 	}
 	if iterated != 8 {
 		t.Fatalf("Failed to evict useless negative balances, want %v, got %d", 4, iterated)
+	}
+}
+
+func TestInactiveClient(t *testing.T) {
+	var (
+		clock mclock.Simulated
+		db    = rawdb.NewMemoryDatabase()
+	)
+	pool := newClientPool(db, 1, 1, &clock, nil)
+	defer pool.stop()
+	pool.setLimits(2, uint64(2)) // Total capacity limit is 10
+
+	p1 := newPoolTestPeer(1, nil)
+	p2 := newPoolTestPeer(2, nil)
+	p3 := newPoolTestPeer(3, nil)
+	pool.addBalance(p1.ID(), 1000, "")
+	pool.addBalance(p3.ID(), 2000, "")
+	// p1: 1000  p2: 0  p3: 2000
+	p1.cap, _ = pool.connect(p1, 1)
+	if p1.cap != 1 {
+		t.Fatalf("Failed to connect peer #1")
+	}
+	p2.cap, _ = pool.connect(p2, 1)
+	if p2.cap != 1 {
+		t.Fatalf("Failed to connect peer #2")
+	}
+	p3.cap, _ = pool.connect(p3, 1)
+	if p3.cap != 1 {
+		t.Fatalf("Failed to connect peer #3")
+	}
+	if p2.cap != 0 {
+		t.Fatalf("Failed to deactivate peer #2")
+	}
+	pool.addBalance(p2.ID(), 3000, "")
+	// p1: 1000  p2: 3000  p3: 2000
+	if p2.cap != 1 {
+		t.Fatalf("Failed to activate peer #2")
+	}
+	if p1.cap != 0 {
+		t.Fatalf("Failed to deactivate peer #1")
+	}
+	pool.addBalance(p2.ID(), -2500, "")
+	// p1: 1000  p2: 500  p3: 2000
+	if p1.cap != 1 {
+		t.Fatalf("Failed to activate peer #1")
+	}
+	if p2.cap != 0 {
+		t.Fatalf("Failed to deactivate peer #2")
+	}
+	pool.setDefaultFactors(priceFactors{1e-9, 0, 0}, priceFactors{1e-9, 0, 0})
+	p4 := newPoolTestPeer(4, nil)
+	pool.addBalance(p4.ID(), 1500, "")
+	// p1: 1000  p2: 500  p3: 2000  p4: 1500
+	p4.cap, _ = pool.connect(p4, 1)
+	if p4.cap != 1 {
+		t.Fatalf("Failed to activate peer #4")
+	}
+	if p1.cap != 0 {
+		t.Fatalf("Failed to deactivate peer #1")
+	}
+	clock.Run(time.Second * 600)
+	// manually trigger a check to avoid a long real-time wait
+	pool.lock.Lock()
+	pool.tryActivateClients()
+	pool.lock.Unlock()
+	// p1: 1000  p2: 500  p3: 2000  p4: 900
+	if p1.cap != 1 {
+		t.Fatalf("Failed to activate peer #1")
+	}
+	if p4.cap != 0 {
+		t.Fatalf("Failed to deactivate peer #4")
+	}
+	pool.disconnect(p2)
+	pool.disconnect(p4)
+	pool.addBalance(p1.ID(), -1000, "")
+	if p1.cap != 1 {
+		t.Fatalf("Should not deactivate peer #1")
+	}
+	if p2.cap != 0 {
+		t.Fatalf("Should not activate peer #2")
 	}
 }

--- a/les/clientpool_test.go
+++ b/les/clientpool_test.go
@@ -81,7 +81,7 @@ func (i *poolTestPeer) updateCapacity(cap uint64) {
 	}
 }
 
-func (i *poolTestPeer) freezeClient() {}
+func (i *poolTestPeer) freeze() {}
 
 func testClientPool(t *testing.T, activeLimit, clientCount, paidCount int, randomDisconnect bool) {
 	rand.Seed(time.Now().UnixNano())

--- a/les/clientpool_test.go
+++ b/les/clientpool_test.go
@@ -17,11 +17,8 @@
 package les
 
 import (
-	"bytes"
 	"fmt"
-	"math"
 	"math/rand"
-	"reflect"
 	"testing"
 	"time"
 
@@ -117,7 +114,7 @@ func testClientPool(t *testing.T, activeLimit, clientCount, paidCount int, rando
 			// give a positive balance to some of the peers
 			amount := testClientPoolTicks / 2 * int64(time.Second) // enough for half of the simulation period
 			for i := 0; i < paidCount; i++ {
-				pool.addBalance(newPoolTestPeer(i, disconnCh).ID(), amount, "")
+				pool.addBalance(newPoolTestPeer(i, disconnCh).ID(), amount)
 			}
 		}
 
@@ -186,7 +183,7 @@ func TestConnectPaidClient(t *testing.T) {
 	pool.setDefaultFactors(priceFactors{1, 0, 1}, priceFactors{1, 0, 1})
 
 	// Add balance for an external client and mark it as paid client
-	pool.addBalance(newPoolTestPeer(0, nil).ID(), 1000, "")
+	pool.addBalance(newPoolTestPeer(0, nil).ID(), 1000)
 
 	if cap, _ := pool.connect(newPoolTestPeer(0, nil), 10); cap == 0 {
 		t.Fatalf("Failed to connect paid client")
@@ -204,7 +201,7 @@ func TestConnectPaidClientToSmallPool(t *testing.T) {
 	pool.setDefaultFactors(priceFactors{1, 0, 1}, priceFactors{1, 0, 1})
 
 	// Add balance for an external client and mark it as paid client
-	pool.addBalance(newPoolTestPeer(0, nil).ID(), 1000, "")
+	pool.addBalance(newPoolTestPeer(0, nil).ID(), 1000)
 
 	// Connect a fat paid client to pool, should reject it.
 	if cap, _ := pool.connect(newPoolTestPeer(0, nil), 100); cap != 0 {
@@ -224,15 +221,15 @@ func TestConnectPaidClientToFullPool(t *testing.T) {
 	pool.setDefaultFactors(priceFactors{1, 0, 1}, priceFactors{1, 0, 1})
 
 	for i := 0; i < 10; i++ {
-		pool.addBalance(newPoolTestPeer(i, nil).ID(), 1000000000, "")
+		pool.addBalance(newPoolTestPeer(i, nil).ID(), int64(time.Second))
 		pool.connect(newPoolTestPeer(i, nil), 1)
 	}
-	pool.addBalance(newPoolTestPeer(11, nil).ID(), 1000, "") // Add low balance to new paid client
+	pool.addBalance(newPoolTestPeer(11, nil).ID(), 1000) // Add low balance to new paid client
 	if cap, _ := pool.connect(newPoolTestPeer(11, nil), 1); cap != 0 {
 		t.Fatalf("Low balance paid client should be rejected")
 	}
 	clock.Run(time.Second)
-	pool.addBalance(newPoolTestPeer(12, nil).ID(), 1000000000*60*3+1, "") // Add high balance to new paid client
+	pool.addBalance(newPoolTestPeer(12, nil).ID(), int64(time.Minute*5)) // Add high balance to new paid client
 	if cap, _ := pool.connect(newPoolTestPeer(12, nil), 1); cap == 0 {
 		t.Fatalf("High balance paid client should be accepted")
 	}
@@ -251,7 +248,7 @@ func TestPaidClientKickedOut(t *testing.T) {
 	pool.setDefaultFactors(priceFactors{1, 0, 1}, priceFactors{1, 0, 1})
 
 	for i := 0; i < 10; i++ {
-		pool.addBalance(newPoolTestPeer(i, kickedCh).ID(), 1000000000, "") // 1 second allowance
+		pool.addBalance(newPoolTestPeer(i, kickedCh).ID(), 1000000000) // 1 second allowance
 		pool.connect(newPoolTestPeer(i, kickedCh), 1)
 		clock.Run(time.Millisecond)
 	}
@@ -360,12 +357,12 @@ func TestPositiveBalanceCalculation(t *testing.T) {
 	pool.setLimits(10, uint64(10)) // Total capacity limit is 10
 	pool.setDefaultFactors(priceFactors{1, 0, 1}, priceFactors{1, 0, 1})
 
-	pool.addBalance(newPoolTestPeer(0, kicked).ID(), int64(time.Minute*3), "")
+	pool.addBalance(newPoolTestPeer(0, kicked).ID(), int64(time.Minute*3))
 	pool.connect(newPoolTestPeer(0, kicked), 10)
 	clock.Run(time.Minute)
 
 	pool.disconnect(newPoolTestPeer(0, kicked))
-	pb := pool.ndb.getOrNewPB(newPoolTestPeer(0, kicked).ID())
+	pb := pool.ndb.getOrNewBalance(newPoolTestPeer(0, kicked).ID().Bytes(), false)
 	if pb.value != expval(uint64(time.Minute*2)) {
 		t.Fatalf("Positive balance mismatch, want %v, got %v", uint64(time.Minute*2), pb.value)
 	}
@@ -384,7 +381,7 @@ func TestDowngradePriorityClient(t *testing.T) {
 	pool.setDefaultFactors(priceFactors{1, 0, 1}, priceFactors{1, 0, 1})
 
 	p := newPoolTestPeer(0, kicked)
-	pool.addBalance(p.ID(), int64(time.Minute), "")
+	pool.addBalance(p.ID(), int64(time.Minute))
 	p.cap, _ = pool.connect(p, 10)
 	if p.cap != 10 {
 		t.Fatalf("The capcacity of priority peer hasn't been updated, got: %d", p.cap)
@@ -395,13 +392,13 @@ func TestDowngradePriorityClient(t *testing.T) {
 	if p.cap != 1 {
 		t.Fatalf("The capcacity of peer should be downgraded, got: %d", p.cap)
 	}
-	pb := pool.ndb.getOrNewPB(newPoolTestPeer(0, kicked).ID())
+	pb := pool.ndb.getOrNewBalance(newPoolTestPeer(0, kicked).ID().Bytes(), false)
 	if pb.value.base != 0 {
 		t.Fatalf("Positive balance mismatch, want %v, got %v", 0, pb.value)
 	}
 
-	pool.addBalance(newPoolTestPeer(0, kicked).ID(), int64(time.Minute), "")
-	pb = pool.ndb.getOrNewPB(newPoolTestPeer(0, kicked).ID())
+	pool.addBalance(newPoolTestPeer(0, kicked).ID(), int64(time.Minute))
+	pb = pool.ndb.getOrNewBalance(newPoolTestPeer(0, kicked).ID().Bytes(), false)
 	if pb.value != expval(uint64(time.Minute)) {
 		t.Fatalf("Positive balance mismatch, want %v, got %v", uint64(time.Minute), pb.value)
 	}
@@ -420,130 +417,26 @@ func TestNegativeBalanceCalculation(t *testing.T) {
 	for i := 0; i < 10; i++ {
 		pool.connect(newPoolTestPeer(i, nil), 1)
 	}
-	clock.Run(time.Millisecond * 999)
+	clock.Run(time.Second)
 
 	for i := 0; i < 10; i++ {
 		pool.disconnect(newPoolTestPeer(i, nil))
-		nb := pool.ndb.getOrNewNB(newPoolTestPeer(i, nil).freeClientId())
-		if nb.logValue != 0 {
+		nb := pool.ndb.getOrNewBalance([]byte(newPoolTestPeer(i, nil).freeClientId()), true)
+		if nb.value.base != 0 {
 			t.Fatalf("Short connection shouldn't be recorded")
 		}
 	}
-
 	for i := 0; i < 10; i++ {
 		pool.connect(newPoolTestPeer(i, nil), 1)
 	}
 	clock.Run(time.Minute)
 	for i := 0; i < 10; i++ {
 		pool.disconnect(newPoolTestPeer(i, nil))
-		nb := pool.ndb.getOrNewNB(newPoolTestPeer(i, nil).freeClientId())
-		nb.logValue -= pool.negExpiration(clock.Now())
-		nb.logValue = uint64(float64(nb.logValue) / logMultiplier)
-		if nb.logValue != uint64(math.Log(float64(time.Minute/time.Second))) {
-			t.Fatalf("Negative balance mismatch, want %v, got %v", int64(math.Log(float64(time.Minute/time.Second))), nb.logValue)
+		nb := pool.ndb.getOrNewBalance([]byte(newPoolTestPeer(i, nil).freeClientId()), true)
+		value := nb.value.value(pool.negExpiration(clock.Now()))
+		if value != uint64(time.Minute) {
+			t.Fatalf("Negative balance mismatch, want %v, got %v", time.Minute, value)
 		}
-	}
-}
-
-func TestNodeDB(t *testing.T) {
-	ndb := newNodeDB(rawdb.NewMemoryDatabase(), mclock.System{})
-	defer ndb.close()
-
-	if !bytes.Equal(ndb.verbuf[:], []byte{0x00, nodeDBVersion}) {
-		t.Fatalf("version buffer mismatch, want %v, got %v", []byte{0x00, nodeDBVersion}, ndb.verbuf)
-	}
-	var cases = []struct {
-		id       enode.ID
-		ip       string
-		balance  interface{}
-		positive bool
-	}{
-		{enode.ID{0x00, 0x01, 0x02}, "", posBalance{value: expval(100)}, true},
-		{enode.ID{0x00, 0x01, 0x02}, "", posBalance{value: expval(200)}, true},
-		{enode.ID{}, "127.0.0.1", negBalance{logValue: 10}, false},
-		{enode.ID{}, "127.0.0.1", negBalance{logValue: 20}, false},
-	}
-	for _, c := range cases {
-		if c.positive {
-			ndb.setPB(c.id, c.balance.(posBalance))
-			if pb := ndb.getOrNewPB(c.id); !reflect.DeepEqual(pb, c.balance.(posBalance)) {
-				t.Fatalf("Positive balance mismatch, want %v, got %v", c.balance.(posBalance), pb)
-			}
-		} else {
-			ndb.setNB(c.ip, c.balance.(negBalance))
-			if nb := ndb.getOrNewNB(c.ip); !reflect.DeepEqual(nb, c.balance.(negBalance)) {
-				t.Fatalf("Negative balance mismatch, want %v, got %v", c.balance.(negBalance), nb)
-			}
-		}
-	}
-	for _, c := range cases {
-		if c.positive {
-			ndb.delPB(c.id)
-			if pb := ndb.getOrNewPB(c.id); !reflect.DeepEqual(pb, posBalance{}) {
-				t.Fatalf("Positive balance mismatch, want %v, got %v", posBalance{}, pb)
-			}
-		} else {
-			ndb.delNB(c.ip)
-			if nb := ndb.getOrNewNB(c.ip); !reflect.DeepEqual(nb, negBalance{}) {
-				t.Fatalf("Negative balance mismatch, want %v, got %v", negBalance{}, nb)
-			}
-		}
-	}
-	ndb.setExpiration(100, 200)
-	if pos, neg := ndb.getExpiration(); pos != 100 || neg != 200 {
-		t.Fatalf("Expiration mismatch, want %v / %v, got %v / %v", 100, 200, pos, neg)
-	}
-}
-
-func TestNodeDBExpiration(t *testing.T) {
-	var (
-		iterated int
-		done     = make(chan struct{}, 1)
-	)
-	callback := func(now mclock.AbsTime, b negBalance) bool {
-		iterated += 1
-		return true
-	}
-	clock := &mclock.Simulated{}
-	ndb := newNodeDB(rawdb.NewMemoryDatabase(), clock)
-	defer ndb.close()
-	ndb.nbEvictCallBack = callback
-	ndb.cleanupHook = func() { done <- struct{}{} }
-
-	var cases = []struct {
-		ip      string
-		balance negBalance
-	}{
-		{"127.0.0.1", negBalance{logValue: 1}},
-		{"127.0.0.2", negBalance{logValue: 1}},
-		{"127.0.0.3", negBalance{logValue: 1}},
-		{"127.0.0.4", negBalance{logValue: 1}},
-	}
-	for _, c := range cases {
-		ndb.setNB(c.ip, c.balance)
-	}
-	clock.WaitForTimers(1)
-	clock.Run(time.Hour + time.Minute)
-	select {
-	case <-done:
-	case <-time.NewTimer(time.Second).C:
-		t.Fatalf("timeout")
-	}
-	if iterated != 4 {
-		t.Fatalf("Failed to evict useless negative balances, want %v, got %d", 4, iterated)
-	}
-	clock.WaitForTimers(1)
-	for _, c := range cases {
-		ndb.setNB(c.ip, c.balance)
-	}
-	clock.Run(time.Hour + time.Minute)
-	select {
-	case <-done:
-	case <-time.NewTimer(time.Second).C:
-		t.Fatalf("timeout")
-	}
-	if iterated != 8 {
-		t.Fatalf("Failed to evict useless negative balances, want %v, got %d", 4, iterated)
 	}
 }
 
@@ -559,8 +452,8 @@ func TestInactiveClient(t *testing.T) {
 	p1 := newPoolTestPeer(1, nil)
 	p2 := newPoolTestPeer(2, nil)
 	p3 := newPoolTestPeer(3, nil)
-	pool.addBalance(p1.ID(), 1000, "")
-	pool.addBalance(p3.ID(), 2000, "")
+	pool.addBalance(p1.ID(), 1000)
+	pool.addBalance(p3.ID(), 2000)
 	// p1: 1000  p2: 0  p3: 2000
 	p1.cap, _ = pool.connect(p1, 1)
 	if p1.cap != 1 {
@@ -577,7 +470,7 @@ func TestInactiveClient(t *testing.T) {
 	if p2.cap != 0 {
 		t.Fatalf("Failed to deactivate peer #2")
 	}
-	pool.addBalance(p2.ID(), 3000, "")
+	pool.addBalance(p2.ID(), 3000)
 	// p1: 1000  p2: 3000  p3: 2000
 	if p2.cap != 1 {
 		t.Fatalf("Failed to activate peer #2")
@@ -585,7 +478,7 @@ func TestInactiveClient(t *testing.T) {
 	if p1.cap != 0 {
 		t.Fatalf("Failed to deactivate peer #1")
 	}
-	pool.addBalance(p2.ID(), -2500, "")
+	pool.addBalance(p2.ID(), -2500)
 	// p1: 1000  p2: 500  p3: 2000
 	if p1.cap != 1 {
 		t.Fatalf("Failed to activate peer #1")
@@ -595,7 +488,7 @@ func TestInactiveClient(t *testing.T) {
 	}
 	pool.setDefaultFactors(priceFactors{1e-9, 0, 0}, priceFactors{1e-9, 0, 0})
 	p4 := newPoolTestPeer(4, nil)
-	pool.addBalance(p4.ID(), 1500, "")
+	pool.addBalance(p4.ID(), 1500)
 	// p1: 1000  p2: 500  p3: 2000  p4: 1500
 	p4.cap, _ = pool.connect(p4, 1)
 	if p4.cap != 1 {
@@ -618,7 +511,7 @@ func TestInactiveClient(t *testing.T) {
 	}
 	pool.disconnect(p2)
 	pool.disconnect(p4)
-	pool.addBalance(p1.ID(), -1000, "")
+	pool.addBalance(p1.ID(), -1000)
 	if p1.cap != 1 {
 		t.Fatalf("Should not deactivate peer #1")
 	}

--- a/les/expiredvalue.go
+++ b/les/expiredvalue.go
@@ -1,0 +1,128 @@
+// Copyright 2020 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+package les
+
+import "math"
+
+// expiredValue is a scalar value that is continuously expired (decreased
+// exponentially) based on the provided logarithmic expiration offset value.
+//
+// The formula for value calculation is: base*2^(exp-logOffset). In order to
+// simplify the calculation of expiredValue, its value is expressed in the form
+// of an exponent with a base of 2.
+//
+// Also here is a trick to reduce a lot of calculations. In theory, when a value X
+// decays over time and then a new value Y is added, the final result should be
+// X*2^(exp-logOffset)+Y. However it's very hard to represent in memory.
+// So the trick is using the idea of inflation instead of exponential decay. At this
+// moment the temporary value becomes: X*2^exp+Y*2^logOffset_1, apply the exponential
+// decay when we actually want to calculate the value.
+//
+// e.g.
+// t0: V = 100
+// t1: add 30, inflationary value is: 100 + 30/0.3, 0.3 is the decay coefficient
+// t2: get value, decay coefficient is 0.2 now, final result is: 200*0.2 = 40
+type expiredValue struct {
+	base, exp uint64
+}
+
+// value calculates the value at the given moment.
+func (e expiredValue) value(logOffset fixed64) uint64 {
+	offset := uint64ToFixed64(e.exp) - logOffset
+	return uint64(float64(e.base) * offset.pow2Fixed())
+}
+
+// add adds a signed value at the given moment
+func (e *expiredValue) add(amount int64, logOffset fixed64) int64 {
+	integer, frac := logOffset.toUint64(), logOffset.fraction()
+	factor := frac.pow2Fixed()
+	base := factor * float64(amount)
+	if integer < e.exp {
+		base /= math.Pow(2, float64(e.exp-integer))
+	}
+	if integer > e.exp {
+		e.base >>= (integer - e.exp)
+		e.exp = integer
+	}
+	if base >= 0 || uint64(-base) <= e.base {
+		e.base += uint64(base)
+		return amount
+	}
+	net := int64(-float64(e.base) / factor)
+	e.base = 0
+	return net
+}
+
+// addExp adds another expiredValue
+func (e *expiredValue) addExp(a expiredValue) {
+	if e.exp > a.exp {
+		a.base >>= (e.exp - a.exp)
+	}
+	if e.exp < a.exp {
+		e.base >>= (a.exp - e.exp)
+		e.exp = a.exp
+	}
+	e.base += a.base
+}
+
+// subExp subtracts another expiredValue
+func (e *expiredValue) subExp(a expiredValue) {
+	if e.exp > a.exp {
+		a.base >>= (e.exp - a.exp)
+	}
+	if e.exp < a.exp {
+		e.base >>= (a.exp - e.exp)
+		e.exp = a.exp
+	}
+	if e.base > a.base {
+		e.base -= a.base
+	} else {
+		e.base = 0
+	}
+}
+
+// fixedFactor is the factor used by fixed64
+const fixedFactor = 0x1000000
+
+// fixed64 is a float64 wrapper that uses integer arithmetic
+// to avoid precision loss in floating-point arithmetic.
+type fixed64 int64
+
+// uint64ToFixed64 converts uint64 integer to fixed64 format.
+func uint64ToFixed64(f uint64) fixed64 {
+	return fixed64(f * fixedFactor)
+}
+
+// float64ToFixed64 converts float64 to fixed64 format.
+func float64ToFixed64(f float64) fixed64 {
+	return fixed64(f * fixedFactor)
+}
+
+// toUint64 converts fixed64 format to uint64.
+func (f64 fixed64) toUint64() uint64 {
+	return uint64(f64) / fixedFactor
+}
+
+// fraction returns the fraction of the fixed64.
+func (f64 fixed64) fraction() fixed64 {
+	return f64 % fixedFactor
+}
+
+// pow2Fixed returns the 2 based pow of the fixed value.
+func (f64 fixed64) pow2Fixed() float64 {
+	return math.Pow(2, float64(f64)/fixedFactor)
+}

--- a/les/expiredvalue.go
+++ b/les/expiredvalue.go
@@ -43,13 +43,13 @@ type expiredValue struct {
 // value calculates the value at the given moment.
 func (e expiredValue) value(logOffset fixed64) uint64 {
 	offset := uint64ToFixed64(e.exp) - logOffset
-	return uint64(float64(e.base) * offset.pow2Fixed())
+	return uint64(float64(e.base) * offset.pow2())
 }
 
 // add adds a signed value at the given moment
 func (e *expiredValue) add(amount int64, logOffset fixed64) int64 {
 	integer, frac := logOffset.toUint64(), logOffset.fraction()
-	factor := frac.pow2Fixed()
+	factor := frac.pow2()
 	base := factor * float64(amount)
 	if integer < e.exp {
 		base /= math.Pow(2, float64(e.exp-integer))
@@ -95,11 +95,10 @@ func (e *expiredValue) subExp(a expiredValue) {
 	}
 }
 
-// fixedFactor is the factor used by fixed64
+// fixedFactor is the fixed point multiplier factor used by fixed64.
 const fixedFactor = 0x1000000
 
-// fixed64 is a float64 wrapper that uses integer arithmetic
-// to avoid precision loss in floating-point arithmetic.
+// fixed64 implements 64-bit fixed point arithmetic functions.
 type fixed64 int64
 
 // uint64ToFixed64 converts uint64 integer to fixed64 format.
@@ -117,12 +116,14 @@ func (f64 fixed64) toUint64() uint64 {
 	return uint64(f64) / fixedFactor
 }
 
-// fraction returns the fraction of the fixed64.
+// fraction returns the fractional part of a fixed64 value.
 func (f64 fixed64) fraction() fixed64 {
 	return f64 % fixedFactor
 }
 
-// pow2Fixed returns the 2 based pow of the fixed value.
-func (f64 fixed64) pow2Fixed() float64 {
-	return math.Pow(2, float64(f64)/fixedFactor)
+var fixedLogFactor = math.Log(2) / float64(fixedFactor)
+
+// pow2Fixed returns the base 2 power of the fixed point value.
+func (f64 fixed64) pow2() float64 {
+	return math.Exp(float64(f64) * fixedLogFactor)
 }

--- a/les/expiredvalue_test.go
+++ b/les/expiredvalue_test.go
@@ -1,0 +1,116 @@
+// Copyright 2020 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+package les
+
+import "testing"
+
+func TestValueExpiration(t *testing.T) {
+	var cases = []struct {
+		input      expiredValue
+		timeOffset fixed64
+		expect     uint64
+	}{
+		{expiredValue{base: 128, exp: 0}, uint64ToFixed64(0), 128},
+		{expiredValue{base: 128, exp: 0}, uint64ToFixed64(1), 64},
+		{expiredValue{base: 128, exp: 0}, uint64ToFixed64(2), 32},
+		{expiredValue{base: 128, exp: 2}, uint64ToFixed64(2), 128},
+		{expiredValue{base: 128, exp: 2}, uint64ToFixed64(3), 64},
+	}
+	for _, c := range cases {
+		if got := c.input.value(c.timeOffset); got != c.expect {
+			t.Fatalf("Value mismatch, want=%d, got=%d", c.expect, got)
+		}
+	}
+}
+
+func TestValueAddition(t *testing.T) {
+	var cases = []struct {
+		input      expiredValue
+		addend     int64
+		timeOffset fixed64
+		expect     uint64
+		expectNet  int64
+	}{
+		// Addition
+		{expiredValue{base: 128, exp: 0}, 128, uint64ToFixed64(0), 256, 128},
+		{expiredValue{base: 128, exp: 2}, 128, uint64ToFixed64(0), 640, 128},
+
+		// Addition with offset
+		{expiredValue{base: 128, exp: 0}, 128, uint64ToFixed64(1), 192, 128},
+		{expiredValue{base: 128, exp: 2}, 128, uint64ToFixed64(1), 384, 128},
+		{expiredValue{base: 128, exp: 2}, 128, uint64ToFixed64(3), 192, 128},
+
+		// Subtraction
+		{expiredValue{base: 128, exp: 0}, -64, uint64ToFixed64(0), 64, -64},
+		{expiredValue{base: 128, exp: 0}, -128, uint64ToFixed64(0), 0, -128},
+		{expiredValue{base: 128, exp: 0}, -192, uint64ToFixed64(0), 0, -128},
+
+		// Subtraction with offset
+		{expiredValue{base: 128, exp: 0}, -64, uint64ToFixed64(1), 0, -64},
+		{expiredValue{base: 128, exp: 0}, -128, uint64ToFixed64(1), 0, -64},
+		{expiredValue{base: 128, exp: 2}, -128, uint64ToFixed64(1), 128, -128},
+		{expiredValue{base: 128, exp: 2}, -128, uint64ToFixed64(2), 0, -128},
+	}
+	for _, c := range cases {
+		if net := c.input.add(c.addend, c.timeOffset); net != c.expectNet {
+			t.Fatalf("Net amount mismatch, want=%d, got=%d", c.expectNet, net)
+		}
+		if got := c.input.value(c.timeOffset); got != c.expect {
+			t.Fatalf("Value mismatch, want=%d, got=%d", c.expect, got)
+		}
+	}
+}
+
+func TestExpiredValueAddition(t *testing.T) {
+	var cases = []struct {
+		input      expiredValue
+		another    expiredValue
+		timeOffset fixed64
+		expect     uint64
+	}{
+		{expiredValue{base: 128, exp: 0}, expiredValue{base: 128, exp: 0}, uint64ToFixed64(0), 256},
+		{expiredValue{base: 128, exp: 1}, expiredValue{base: 128, exp: 0}, uint64ToFixed64(0), 384},
+		{expiredValue{base: 128, exp: 0}, expiredValue{base: 128, exp: 1}, uint64ToFixed64(0), 384},
+		{expiredValue{base: 128, exp: 0}, expiredValue{base: 128, exp: 0}, uint64ToFixed64(1), 128},
+	}
+	for _, c := range cases {
+		c.input.addExp(c.another)
+		if got := c.input.value(c.timeOffset); got != c.expect {
+			t.Fatalf("Value mismatch, want=%d, got=%d", c.expect, got)
+		}
+	}
+}
+
+func TestExpiredValueSubtraction(t *testing.T) {
+	var cases = []struct {
+		input      expiredValue
+		another    expiredValue
+		timeOffset fixed64
+		expect     uint64
+	}{
+		{expiredValue{base: 128, exp: 0}, expiredValue{base: 128, exp: 0}, uint64ToFixed64(0), 0},
+		{expiredValue{base: 128, exp: 0}, expiredValue{base: 128, exp: 1}, uint64ToFixed64(0), 0},
+		{expiredValue{base: 128, exp: 1}, expiredValue{base: 128, exp: 0}, uint64ToFixed64(0), 128},
+		{expiredValue{base: 128, exp: 1}, expiredValue{base: 128, exp: 0}, uint64ToFixed64(1), 64},
+	}
+	for _, c := range cases {
+		c.input.subExp(c.another)
+		if got := c.input.value(c.timeOffset); got != c.expect {
+			t.Fatalf("Value mismatch, want=%d, got=%d", c.expect, got)
+		}
+	}
+}

--- a/les/flowcontrol/control.go
+++ b/les/flowcontrol/control.go
@@ -185,6 +185,14 @@ func (node *ClientNode) UpdateParams(params ServerParams) {
 	}
 }
 
+// Params returns the current server parameters
+func (node *ClientNode) Params() ServerParams {
+	node.lock.Lock()
+	defer node.lock.Unlock()
+
+	return node.params
+}
+
 // updateParams updates the flow control parameters of the node
 func (node *ClientNode) updateParams(params ServerParams, now mclock.AbsTime) {
 	diff := int64(params.BufLimit - node.params.BufLimit)

--- a/les/handler_test.go
+++ b/les/handler_test.go
@@ -177,7 +177,7 @@ func testGetBlockHeaders(t *testing.T, protocol int) {
 		// Send the hash request and verify the response
 		reqID++
 
-		cost := server.peer.peer.GetRequestCost(GetBlockHeadersMsg, int(tt.query.Amount))
+		cost := server.peer.speer.getRequestCost(GetBlockHeadersMsg, int(tt.query.Amount))
 		sendRequest(server.peer.app, GetBlockHeadersMsg, reqID, tt.query)
 		if err := expectResponse(server.peer.app, protocol, BlockHeadersMsg, reqID, testBufLimit, cost, headers); err != nil {
 			t.Errorf("test %d: headers mismatch: %v", i, err)
@@ -255,7 +255,7 @@ func testGetBlockBodies(t *testing.T, protocol int) {
 		reqID++
 
 		// Send the hash request and verify the response
-		cost := server.peer.peer.GetRequestCost(GetBlockBodiesMsg, len(hashes))
+		cost := server.peer.speer.getRequestCost(GetBlockBodiesMsg, len(hashes))
 		sendRequest(server.peer.app, GetBlockBodiesMsg, reqID, hashes)
 		if err := expectResponse(server.peer.app, protocol, BlockBodiesMsg, reqID, testBufLimit, cost, bodies); err != nil {
 			t.Errorf("test %d: bodies mismatch: %v", i, err)
@@ -287,7 +287,7 @@ func testGetCode(t *testing.T, protocol int) {
 		}
 	}
 
-	cost := server.peer.peer.GetRequestCost(GetCodeMsg, len(codereqs))
+	cost := server.peer.speer.getRequestCost(GetCodeMsg, len(codereqs))
 	sendRequest(server.peer.app, GetCodeMsg, 42, codereqs)
 	if err := expectResponse(server.peer.app, protocol, CodeMsg, 42, testBufLimit, cost, codes); err != nil {
 		t.Errorf("codes mismatch: %v", err)
@@ -308,7 +308,7 @@ func testGetStaleCode(t *testing.T, protocol int) {
 			BHash:  bc.GetHeaderByNumber(number).Hash(),
 			AccKey: crypto.Keccak256(testContractAddr[:]),
 		}
-		cost := server.peer.peer.GetRequestCost(GetCodeMsg, 1)
+		cost := server.peer.speer.getRequestCost(GetCodeMsg, 1)
 		sendRequest(server.peer.app, GetCodeMsg, 42, []*CodeReq{req})
 		if err := expectResponse(server.peer.app, protocol, CodeMsg, 42, testBufLimit, cost, expected); err != nil {
 			t.Errorf("codes mismatch: %v", err)
@@ -340,7 +340,7 @@ func testGetReceipt(t *testing.T, protocol int) {
 		receipts = append(receipts, rawdb.ReadRawReceipts(server.db, block.Hash(), block.NumberU64()))
 	}
 	// Send the hash request and verify the response
-	cost := server.peer.peer.GetRequestCost(GetReceiptsMsg, len(hashes))
+	cost := server.peer.speer.getRequestCost(GetReceiptsMsg, len(hashes))
 	sendRequest(server.peer.app, GetReceiptsMsg, 42, hashes)
 	if err := expectResponse(server.peer.app, protocol, ReceiptsMsg, 42, testBufLimit, cost, receipts); err != nil {
 		t.Errorf("receipts mismatch: %v", err)
@@ -376,7 +376,7 @@ func testGetProofs(t *testing.T, protocol int) {
 		}
 	}
 	// Send the proof request and verify the response
-	cost := server.peer.peer.GetRequestCost(GetProofsV2Msg, len(proofreqs))
+	cost := server.peer.speer.getRequestCost(GetProofsV2Msg, len(proofreqs))
 	sendRequest(server.peer.app, GetProofsV2Msg, 42, proofreqs)
 	if err := expectResponse(server.peer.app, protocol, ProofsV2Msg, 42, testBufLimit, cost, proofsV2.NodeList()); err != nil {
 		t.Errorf("proofs mismatch: %v", err)
@@ -410,6 +410,7 @@ func testGetStaleProof(t *testing.T, protocol int) {
 			t.Prove(account, 0, proofsV2)
 			expected = proofsV2.NodeList()
 		}
+		cost := server.peer.speer.getRequestCost(GetProofsV2Msg, 1)
 		if err := expectResponse(server.peer.app, protocol, ProofsV2Msg, 42, testBufLimit, cost, expected); err != nil {
 			t.Errorf("codes mismatch: %v", err)
 		}
@@ -461,7 +462,7 @@ func testGetCHTProofs(t *testing.T, protocol int) {
 		AuxReq:  auxHeader,
 	}}
 	// Send the proof request and verify the response
-	cost := server.peer.peer.GetRequestCost(GetHelperTrieProofsMsg, len(requestsV2))
+	cost := server.peer.speer.getRequestCost(GetHelperTrieProofsMsg, len(requestsV2))
 	sendRequest(server.peer.app, GetHelperTrieProofsMsg, 42, requestsV2)
 	if err := expectResponse(server.peer.app, protocol, HelperTrieProofsMsg, 42, testBufLimit, cost, proofsV2); err != nil {
 		t.Errorf("proofs mismatch: %v", err)
@@ -510,7 +511,7 @@ func testGetBloombitsProofs(t *testing.T, protocol int) {
 		trie.Prove(key, 0, &proofs.Proofs)
 
 		// Send the proof request and verify the response
-		cost := server.peer.peer.GetRequestCost(GetHelperTrieProofsMsg, len(requests))
+		cost := server.peer.speer.getRequestCost(GetHelperTrieProofsMsg, len(requests))
 		sendRequest(server.peer.app, GetHelperTrieProofsMsg, 42, requests)
 		if err := expectResponse(server.peer.app, protocol, HelperTrieProofsMsg, 42, testBufLimit, cost, proofs); err != nil {
 			t.Errorf("bit %d: proofs mismatch: %v", bit, err)
@@ -534,10 +535,10 @@ func testTransactionStatus(t *testing.T, protocol int) {
 		reqID++
 		var cost uint64
 		if send {
-			cost = server.peer.peer.GetRequestCost(SendTxV2Msg, 1)
+			cost = server.peer.speer.getRequestCost(SendTxV2Msg, 1)
 			sendRequest(server.peer.app, SendTxV2Msg, reqID, types.Transactions{tx})
 		} else {
-			cost = server.peer.peer.GetRequestCost(GetTxStatusMsg, 1)
+			cost = server.peer.speer.getRequestCost(GetTxStatusMsg, 1)
 			sendRequest(server.peer.app, GetTxStatusMsg, reqID, []common.Hash{tx.Hash()})
 		}
 		if err := expectResponse(server.peer.app, protocol, TxStatusMsg, reqID, testBufLimit, cost, []light.TxStatus{expStatus}); err != nil {

--- a/les/metrics.go
+++ b/les/metrics.go
@@ -40,6 +40,8 @@ var (
 	miscInTxsTrafficMeter        = metrics.NewRegisteredMeter("les/misc/in/traffic/txs", nil)
 	miscInTxStatusPacketsMeter   = metrics.NewRegisteredMeter("les/misc/in/packets/txStatus", nil)
 	miscInTxStatusTrafficMeter   = metrics.NewRegisteredMeter("les/misc/in/traffic/txStatus", nil)
+	miscInLespayPacketsMeter     = metrics.NewRegisteredMeter("les/misc/in/packets/lespay", nil)
+	miscInLespayTrafficMeter     = metrics.NewRegisteredMeter("les/misc/in/traffic/lespay", nil)
 
 	miscOutPacketsMeter           = metrics.NewRegisteredMeter("les/misc/out/packets/total", nil)
 	miscOutTrafficMeter           = metrics.NewRegisteredMeter("les/misc/out/traffic/total", nil)
@@ -59,6 +61,8 @@ var (
 	miscOutTxsTrafficMeter        = metrics.NewRegisteredMeter("les/misc/out/traffic/txs", nil)
 	miscOutTxStatusPacketsMeter   = metrics.NewRegisteredMeter("les/misc/out/packets/txStatus", nil)
 	miscOutTxStatusTrafficMeter   = metrics.NewRegisteredMeter("les/misc/out/traffic/txStatus", nil)
+	miscOutLespayPacketsMeter     = metrics.NewRegisteredMeter("les/misc/out/packets/lespay", nil)
+	miscOutLespayTrafficMeter     = metrics.NewRegisteredMeter("les/misc/out/traffic/lespay", nil)
 
 	miscServingTimeHeaderTimer     = metrics.NewRegisteredTimer("les/misc/serve/header", nil)
 	miscServingTimeBodyTimer       = metrics.NewRegisteredTimer("les/misc/serve/body", nil)
@@ -68,6 +72,7 @@ var (
 	miscServingTimeHelperTrieTimer = metrics.NewRegisteredTimer("les/misc/serve/helperTrie", nil)
 	miscServingTimeTxTimer         = metrics.NewRegisteredTimer("les/misc/serve/txs", nil)
 	miscServingTimeTxStatusTimer   = metrics.NewRegisteredTimer("les/misc/serve/txStatus", nil)
+	miscServingTimeLespayTimer     = metrics.NewRegisteredTimer("les/misc/serve/lespay", nil)
 
 	connectionTimer       = metrics.NewRegisteredTimer("les/connection/duration", nil)
 	serverConnectionGauge = metrics.NewRegisteredGauge("les/connection/server", nil)

--- a/les/odr_test.go
+++ b/les/odr_test.go
@@ -38,8 +38,8 @@ import (
 
 type odrTestFn func(ctx context.Context, db ethdb.Database, config *params.ChainConfig, bc *core.BlockChain, lc *light.LightChain, bhash common.Hash) []byte
 
-func TestOdrGetBlockLes2(t *testing.T) { testOdr(t, 2, 1, true, odrGetBlock) }
 func TestOdrGetBlockLes3(t *testing.T) { testOdr(t, 3, 1, true, odrGetBlock) }
+func TestOdrGetBlockLes4(t *testing.T) { testOdr(t, 4, 1, true, odrGetBlock) }
 
 func odrGetBlock(ctx context.Context, db ethdb.Database, config *params.ChainConfig, bc *core.BlockChain, lc *light.LightChain, bhash common.Hash) []byte {
 	var block *types.Block
@@ -55,8 +55,8 @@ func odrGetBlock(ctx context.Context, db ethdb.Database, config *params.ChainCon
 	return rlp
 }
 
-func TestOdrGetReceiptsLes2(t *testing.T) { testOdr(t, 2, 1, true, odrGetReceipts) }
 func TestOdrGetReceiptsLes3(t *testing.T) { testOdr(t, 3, 1, true, odrGetReceipts) }
+func TestOdrGetReceiptsLes4(t *testing.T) { testOdr(t, 4, 1, true, odrGetReceipts) }
 
 func odrGetReceipts(ctx context.Context, db ethdb.Database, config *params.ChainConfig, bc *core.BlockChain, lc *light.LightChain, bhash common.Hash) []byte {
 	var receipts types.Receipts
@@ -76,8 +76,8 @@ func odrGetReceipts(ctx context.Context, db ethdb.Database, config *params.Chain
 	return rlp
 }
 
-func TestOdrAccountsLes2(t *testing.T) { testOdr(t, 2, 1, true, odrAccounts) }
 func TestOdrAccountsLes3(t *testing.T) { testOdr(t, 3, 1, true, odrAccounts) }
+func TestOdrAccountsLes4(t *testing.T) { testOdr(t, 4, 1, true, odrAccounts) }
 
 func odrAccounts(ctx context.Context, db ethdb.Database, config *params.ChainConfig, bc *core.BlockChain, lc *light.LightChain, bhash common.Hash) []byte {
 	dummyAddr := common.HexToAddress("1234567812345678123456781234567812345678")
@@ -105,8 +105,8 @@ func odrAccounts(ctx context.Context, db ethdb.Database, config *params.ChainCon
 	return res
 }
 
-func TestOdrContractCallLes2(t *testing.T) { testOdr(t, 2, 2, true, odrContractCall) }
 func TestOdrContractCallLes3(t *testing.T) { testOdr(t, 3, 2, true, odrContractCall) }
+func TestOdrContractCallLes4(t *testing.T) { testOdr(t, 4, 2, true, odrContractCall) }
 
 type callmsg struct {
 	types.Message
@@ -155,8 +155,8 @@ func odrContractCall(ctx context.Context, db ethdb.Database, config *params.Chai
 	return res
 }
 
-func TestOdrTxStatusLes2(t *testing.T) { testOdr(t, 2, 1, false, odrTxStatus) }
 func TestOdrTxStatusLes3(t *testing.T) { testOdr(t, 3, 1, false, odrTxStatus) }
+func TestOdrTxStatusLes4(t *testing.T) { testOdr(t, 4, 1, false, odrTxStatus) }
 
 func odrTxStatus(ctx context.Context, db ethdb.Database, config *params.ChainConfig, bc *core.BlockChain, lc *light.LightChain, bhash common.Hash) []byte {
 	var txs types.Transactions
@@ -236,7 +236,7 @@ func testOdr(t *testing.T, protocol int, expFail uint64, checkCached bool, fn od
 
 	// still expect all retrievals to pass, now data should be cached locally
 	if checkCached {
-		client.handler.backend.peers.unregister(client.peer.speer.id)
+		client.handler.backend.peers.disconnect(client.peer.speer.id)
 		time.Sleep(time.Millisecond * 10) // ensure that all peerSetNotify callbacks are executed
 		test(5)
 	}

--- a/les/peer.go
+++ b/les/peer.go
@@ -634,6 +634,7 @@ func (p *serverPeer) Handshake(td *big.Int, head common.Hash, headNum uint64, ge
 		p.fcParams = sParams
 		p.fcServer = flowcontrol.NewServerNode(sParams, &mclock.System{})
 		p.fcCosts = MRC.decode(ProtocolLengths[uint(p.version)])
+		p.active = p.paramsUseful()
 
 		recv.get("checkpoint/value", &p.checkpoint)
 		recv.get("checkpoint/registerHeight", &p.checkpointNumber)

--- a/les/peer_test.go
+++ b/les/peer_test.go
@@ -85,7 +85,7 @@ func TestPeerSubscription(t *testing.T) {
 	checkIds([]string{peer.id})
 	checkPeers(sub.regCh)
 
-	peers.unregister(peer.id)
+	peers.unregister(peer)
 	checkIds([]string{})
 	checkPeers(sub.unregCh)
 }

--- a/les/request_test.go
+++ b/les/request_test.go
@@ -36,22 +36,22 @@ func secAddr(addr common.Address) []byte {
 
 type accessTestFn func(db ethdb.Database, bhash common.Hash, number uint64) light.OdrRequest
 
-func TestBlockAccessLes2(t *testing.T) { testAccess(t, 2, tfBlockAccess) }
 func TestBlockAccessLes3(t *testing.T) { testAccess(t, 3, tfBlockAccess) }
+func TestBlockAccessLes4(t *testing.T) { testAccess(t, 4, tfBlockAccess) }
 
 func tfBlockAccess(db ethdb.Database, bhash common.Hash, number uint64) light.OdrRequest {
 	return &light.BlockRequest{Hash: bhash, Number: number}
 }
 
-func TestReceiptsAccessLes2(t *testing.T) { testAccess(t, 2, tfReceiptsAccess) }
 func TestReceiptsAccessLes3(t *testing.T) { testAccess(t, 3, tfReceiptsAccess) }
+func TestReceiptsAccessLes4(t *testing.T) { testAccess(t, 4, tfReceiptsAccess) }
 
 func tfReceiptsAccess(db ethdb.Database, bhash common.Hash, number uint64) light.OdrRequest {
 	return &light.ReceiptsRequest{Hash: bhash, Number: number}
 }
 
-func TestTrieEntryAccessLes2(t *testing.T) { testAccess(t, 2, tfTrieEntryAccess) }
 func TestTrieEntryAccessLes3(t *testing.T) { testAccess(t, 3, tfTrieEntryAccess) }
+func TestTrieEntryAccessLes4(t *testing.T) { testAccess(t, 4, tfTrieEntryAccess) }
 
 func tfTrieEntryAccess(db ethdb.Database, bhash common.Hash, number uint64) light.OdrRequest {
 	if number := rawdb.ReadHeaderNumber(db, bhash); number != nil {
@@ -60,8 +60,8 @@ func tfTrieEntryAccess(db ethdb.Database, bhash common.Hash, number uint64) ligh
 	return nil
 }
 
-func TestCodeAccessLes2(t *testing.T) { testAccess(t, 2, tfCodeAccess) }
 func TestCodeAccessLes3(t *testing.T) { testAccess(t, 3, tfCodeAccess) }
+func TestCodeAccessLes4(t *testing.T) { testAccess(t, 4, tfCodeAccess) }
 
 func tfCodeAccess(db ethdb.Database, bhash common.Hash, num uint64) light.OdrRequest {
 	number := rawdb.ReadHeaderNumber(db, bhash)

--- a/les/retrieve.go
+++ b/les/retrieve.go
@@ -345,7 +345,7 @@ func (r *sentReq) tryRequest() {
 		if hrto {
 			pp.Log().Debug("Request timed out hard")
 			if r.rm.peers != nil {
-				r.rm.peers.unregister(pp.id)
+				r.rm.peers.disconnect(pp.id)
 			}
 		}
 

--- a/les/server.go
+++ b/les/server.go
@@ -158,7 +158,7 @@ func (s *LesServer) APIs() []rpc.API {
 		{
 			Namespace: "lespay",
 			Version:   "1.0",
-			Service:   NewPrivateLespayAPI(s.lesCommons.peers, nil, s.srvr.DiscV5, s.tokenSale),
+			Service:   NewPrivateLespayAPI(s.peers, nil, nil, s.srvr.DiscV5, s.tokenSale),
 			Public:    false,
 		},
 	}

--- a/les/server.go
+++ b/les/server.go
@@ -44,6 +44,7 @@ type LesServer struct {
 	handler     *serverHandler
 	lesTopics   []discv5.Topic
 	privateKey  *ecdsa.PrivateKey
+	srvr        *p2p.Server
 
 	// Flow control and capacity management
 	fcManager    *flowcontrol.ClientManager
@@ -51,6 +52,7 @@ type LesServer struct {
 	defParams    flowcontrol.ServerParams
 	servingQueue *servingQueue
 	clientPool   *clientPool
+	tokenSale    *tokenSale
 
 	minCapacity, maxCapacity, freeCapacity uint64
 	threadsIdle                            int // Request serving threads count when system is idle.
@@ -116,8 +118,13 @@ func NewLesServer(e *eth.Ethereum, config *eth.Config) (*LesServer, error) {
 		srv.maxCapacity = totalRecharge
 	}
 	srv.fcManager.SetCapacityLimits(srv.freeCapacity, srv.maxCapacity, srv.freeCapacity*2)
-	srv.clientPool = newClientPool(srv.chainDb, srv.freeCapacity, mclock.System{}, func(id enode.ID) { go srv.peers.unregister(peerIdToString(id)) })
+	srv.clientPool = newClientPool(srv.chainDb, srv.minCapacity, srv.freeCapacity, mclock.System{}, func(id enode.ID) { go srv.peers.disconnect(peerIdToString(id)) })
 	srv.clientPool.setDefaultFactors(priceFactors{0, 1, 1}, priceFactors{0, 1, 1})
+	srv.tokenSale = newTokenSale(srv.clientPool, 0.1, 100)
+	if config.LespayTestModule {
+		srv.tokenSale.addReceiver("test", testReceiver{})
+		srv.clientPool.setExpirationTCs(defaultPosExpTC, defaultNegExpTC)
+	}
 
 	checkpoint := srv.latestLocalCheckpoint()
 	if !checkpoint.Empty() {
@@ -148,6 +155,12 @@ func (s *LesServer) APIs() []rpc.API {
 			Service:   NewPrivateDebugAPI(s),
 			Public:    false,
 		},
+		{
+			Namespace: "lespay",
+			Version:   "1.0",
+			Service:   NewPrivateLespayAPI(s.lesCommons.peers, nil, s.srvr.DiscV5, s.tokenSale),
+			Public:    false,
+		},
 	}
 }
 
@@ -167,6 +180,7 @@ func (s *LesServer) Protocols() []p2p.Protocol {
 
 // Start starts the LES server
 func (s *LesServer) Start(srvr *p2p.Server) {
+	s.srvr = srvr
 	s.privateKey = srvr.PrivateKey
 	s.handler.start()
 
@@ -174,6 +188,7 @@ func (s *LesServer) Start(srvr *p2p.Server) {
 	go s.capacityManagement()
 
 	if srvr.DiscV5 != nil {
+		srvr.DiscV5.RegisterTalkHandler("lespay", s.handler.talkRequestHandler)
 		for _, topic := range s.lesTopics {
 			topic := topic
 			go func() {
@@ -190,6 +205,11 @@ func (s *LesServer) Start(srvr *p2p.Server) {
 // Stop stops the LES service
 func (s *LesServer) Stop() {
 	close(s.closeCh)
+
+	if s.srvr.DiscV5 != nil {
+		s.srvr.DiscV5.RemoveTalkHandler("lespay")
+	}
+	s.tokenSale.stop()
 
 	// Disconnect existing sessions.
 	// This also closes the gate for any new registrations on the peer set.

--- a/les/servingqueue.go
+++ b/les/servingqueue.go
@@ -70,7 +70,7 @@ type runToken chan struct{}
 // start blocks until the task can start and returns true if it is allowed to run.
 // Returning false means that the task should be cancelled.
 func (t *servingTask) start() bool {
-	if t.peer.isFrozen() {
+	if t.peer != nil && t.peer.isFrozen() {
 		return false
 	}
 	t.tokenCh = make(chan runToken, 1)
@@ -289,7 +289,7 @@ func (sq *servingQueue) addTask(task *servingTask) {
 	sq.queuedTime += task.expTime
 	sqServedGauge.Update(int64(sq.recentTime))
 	sqQueuedGauge.Update(int64(sq.queuedTime))
-	if sq.recentTime+sq.queuedTime > sq.burstLimit {
+	if sq.burstLimit != 0 && sq.recentTime+sq.queuedTime > sq.burstLimit {
 		sq.freezePeers()
 	}
 }

--- a/les/test_helper.go
+++ b/les/test_helper.go
@@ -78,10 +78,10 @@ var (
 	processConfirms = big.NewInt(1)
 
 	// The token bucket buffer limit for testing purpose.
-	testBufLimit = uint64(1000000)
+	testBufLimit = uint64(6000)
 
 	// The buffer recharging speed for testing purpose.
-	testBufRecharge = uint64(1000)
+	testBufRecharge = uint64(1)
 )
 
 /*
@@ -281,7 +281,7 @@ func newTestServerHandler(blocks int, indexers []*core.ChainIndexer, db ethdb.Da
 	}
 	server.costTracker, server.freeCapacity = newCostTracker(db, server.config)
 	server.costTracker.testCostList = testCostList(0) // Disable flow control mechanism.
-	server.clientPool = newClientPool(db, 1, clock, nil)
+	server.clientPool = newClientPool(db, 1, 1, clock, nil)
 	server.clientPool.setLimits(10000, 10000) // Assign enough capacity for clientpool
 	server.handler = newServerHandler(server, simulation.Blockchain(), db, txpool, func() bool { return true })
 	if server.oracle != nil {
@@ -395,8 +395,13 @@ func (p *testPeer) handshake(t *testing.T, td *big.Int, head common.Hash, headNu
 	expList = expList.add("serveStateSince", uint64(0))
 	expList = expList.add("serveRecentState", uint64(core.TriesInMemory-4))
 	expList = expList.add("txRelay", nil)
-	expList = expList.add("flowControl/BL", testBufLimit)
-	expList = expList.add("flowControl/MRR", testBufRecharge)
+	if p.peer.version >= lpv4 {
+		expList = expList.add("flowControl/BL", uint64(0))
+		expList = expList.add("flowControl/MRR", uint64(0))
+	} else {
+		expList = expList.add("flowControl/BL", testBufLimit)
+		expList = expList.add("flowControl/MRR", testBufRecharge)
+	}
 	expList = expList.add("flowControl/MRC", costList)
 
 	if err := p2p.ExpectMsg(p.app, StatusMsg, expList); err != nil {
@@ -408,6 +413,16 @@ func (p *testPeer) handshake(t *testing.T, td *big.Int, head common.Hash, headNu
 	p.cpeer.fcParams = flowcontrol.ServerParams{
 		BufLimit:    testBufLimit,
 		MinRecharge: testBufRecharge,
+}
+
+func (p *testPeer) expectCapUpdate(t *testing.T) {
+	if p.peer.version >= lpv4 {
+		var expList keyValueList
+		expList = expList.add("flowControl/BL", testBufLimit)
+		expList = expList.add("flowControl/MRR", testBufRecharge)
+		if err := p2p.ExpectMsg(p.app, AnnounceMsg, announceData{Update: expList}); err != nil {
+			t.Fatalf("status recv: %v", err)
+		}
 	}
 }
 
@@ -438,7 +453,7 @@ type testServer struct {
 	bloomTrieIndexer *core.ChainIndexer
 }
 
-func newServerEnv(t *testing.T, blocks int, protocol int, callback indexerCallback, simClock bool, newPeer bool, testCost uint64) (*testServer, func()) {
+func newServerEnv(t *testing.T, blocks int, protocol int, callback indexerCallback, simClock bool, newPeer bool, testCost uint64, expectCapUpdate bool) (*testServer, func()) {
 	db := rawdb.NewMemoryDatabase()
 	indexers := testIndexers(db, nil, light.TestServerIndexerConfig)
 
@@ -479,6 +494,9 @@ func newServerEnv(t *testing.T, blocks int, protocol int, callback indexerCallba
 		}
 		cIndexer.Close()
 		bIndexer.Close()
+	}
+	if expectCapUpdate {
+		server.peer.expectCapUpdate(t)
 	}
 	return server, teardown
 }

--- a/les/test_helper.go
+++ b/les/test_helper.go
@@ -412,10 +412,6 @@ func (p *testPeer) handshake(t *testing.T, td *big.Int, head common.Hash, headNu
 	if err := p2p.Send(p.app, StatusMsg, sendList); err != nil {
 		t.Fatalf("status send: %v", err)
 	}
-	p.cpeer.fcParams = flowcontrol.ServerParams{
-		BufLimit:    testBufLimit,
-		MinRecharge: testBufRecharge,
-	}
 }
 
 func (p *testPeer) expectCapUpdate(t *testing.T) {

--- a/les/tokensale.go
+++ b/les/tokensale.go
@@ -1,0 +1,870 @@
+// Copyright 2019 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+package les
+
+import (
+	"encoding/binary"
+	"fmt"
+	"io"
+	"math"
+	"strconv"
+	"sync"
+	"time"
+
+	"github.com/ethereum/go-ethereum/common/mclock"
+	"github.com/ethereum/go-ethereum/p2p/enode"
+	"github.com/ethereum/go-ethereum/rlp"
+)
+
+const (
+	basePriceTC       = time.Hour * 10  // time constant for controlling the base price
+	tokenSellMaxRatio = 0.9             // total amount/supply limit ratio over which selling price does not increase further
+	tsMinDelay        = time.Second * 5 // minimum recommended delay for sending the next command
+	tsMaxBurst        = 16              // maximum commands processed in a row before the recommended delay has elapsed
+)
+
+// paymentReceiver processes incoming payments and can be implemented using different
+// payment technologies
+type paymentReceiver interface {
+	info() keyValueList
+	receivePayment(from enode.ID, proofOfPayment, oldMeta []byte) (value uint64, newMeta []byte, err error)
+	requestPayment(from enode.ID, value uint64, meta []byte) uint64
+}
+
+// tokenSale handles client balance deposits, conversion to and from service tokens
+// and granting connections and capacity changes through a set of commands called "lespay".
+type tokenSale struct {
+	lock                              sync.Mutex
+	clientPool                        *clientPool
+	stopCh                            chan struct{}
+	receivers                         map[string]paymentReceiver
+	receiverNames                     []string
+	basePrice, minBasePrice           float64
+	totalTokenLimit, totalTokenAmount func() uint64
+
+	qlock                            sync.Mutex
+	sq                               *servingQueue
+	sources                          map[string]*cmdSource
+	delayFactorZero, delayFactorLast mclock.AbsTime
+	tsProcessDelay, tsTargetPeriod   time.Duration
+}
+
+// newTokenSale creates a new token sale module instance
+func newTokenSale(clientPool *clientPool, minBasePrice float64, talkSpeed int) *tokenSale {
+	t := &tokenSale{
+		clientPool:       clientPool,
+		receivers:        make(map[string]paymentReceiver),
+		basePrice:        minBasePrice,
+		minBasePrice:     minBasePrice,
+		totalTokenLimit:  clientPool.totalTokenLimit,
+		totalTokenAmount: clientPool.totalTokenAmount,
+		stopCh:           make(chan struct{}),
+		sq:               newServingQueue(0, 0),
+		sources:          make(map[string]*cmdSource),
+		delayFactorZero:  mclock.Now(),
+		delayFactorLast:  mclock.Now(),
+		tsProcessDelay:   time.Second / time.Duration(talkSpeed),
+		tsTargetPeriod:   5 * time.Second / time.Duration(talkSpeed),
+	}
+	t.sq.setThreads(1)
+	go func() {
+		cleanupCounter := 0
+		for {
+			select {
+			case <-time.After(time.Second * 10):
+				t.lock.Lock()
+				cost, ok := t.tokenPrice(1, true)
+				if cost > t.basePrice*10 || !ok {
+					cost = t.basePrice * 10
+				}
+				t.basePrice += (cost - t.basePrice) * float64(time.Second*10) / float64(basePriceTC)
+				if t.basePrice < minBasePrice {
+					t.basePrice = minBasePrice
+				}
+				t.lock.Unlock()
+
+				cleanupCounter++
+				if cleanupCounter == 100 {
+					t.sourceMapCleanup()
+					cleanupCounter = 0
+				}
+			case <-t.stopCh:
+				return
+			}
+		}
+	}()
+	return t
+}
+
+type (
+	// cmdSource represents a source where lespay commands can come from.
+	// It can be either an LES connected peer or a UDP address.
+	cmdSource struct {
+		ch           chan lespayCmd
+		delayUntil   mclock.AbsTime
+		burstCounter int
+	}
+	// lespayCmd represents a single lespay command, including the source it came
+	// from and the callback that is going to process the results.
+	lespayCmd struct {
+		cmd    []byte
+		id     enode.ID
+		freeID string
+		send   func([]byte, uint)
+	}
+)
+
+// priority returns the processing priority for the next command coming from the given
+// source. Commands sent before the previously recommended delay has elapsed have a
+// lower priority. It also checks whether the number of commands consecutively sent
+// before the delay has elapsed exceeds maxBurst and rejects the command instantly if
+// necessary.
+func (c *cmdSource) priority() (int64, bool) {
+	dt := c.delayUntil - mclock.Now()
+	if dt <= 0 {
+		c.burstCounter = 0
+		return 0, true
+	}
+	if c.burstCounter >= tsMaxBurst {
+		return 0, false
+	}
+	c.burstCounter++
+	return -int64(dt), true
+}
+
+// addDelay adds the given amount to the recommended delay
+func (c *cmdSource) addDelay(now mclock.AbsTime, delay time.Duration) uint {
+	dt := time.Duration(c.delayUntil - now)
+	if dt <= 0 {
+		dt = 0
+	}
+	dt += delay
+	if dt < tsMinDelay {
+		dt = tsMinDelay
+	}
+	c.delayUntil = now + mclock.AbsTime(dt)
+	return uint((dt + time.Second - 1) / time.Second)
+}
+
+// delayFactor calculates the amount added to the recommended delay after processing
+// a single command
+func (t *tokenSale) delayFactor(now mclock.AbsTime) time.Duration {
+	if now > t.delayFactorZero {
+		t.delayFactorZero = now
+	}
+	t.delayFactorZero += mclock.AbsTime(t.tsTargetPeriod) + t.delayFactorLast - now
+	t.delayFactorLast = now
+	if now >= t.delayFactorZero {
+		return 0
+	} else {
+		return time.Duration(t.delayFactorZero-now) / 4
+	}
+}
+
+// sourceMapCleanup removes unnecessary entries from the command source map
+func (t *tokenSale) sourceMapCleanup() {
+	t.qlock.Lock()
+	defer t.qlock.Unlock()
+
+	now := mclock.Now()
+	for src, s := range t.sources {
+		if s.delayUntil < now {
+			delete(t.sources, src)
+		}
+	}
+}
+
+// queueCommand schedules a lespay command (encapsulated in a lespayCmd) for execution
+func (t *tokenSale) queueCommand(src string, cmd lespayCmd) bool {
+	t.qlock.Lock()
+	defer t.qlock.Unlock()
+
+	s := t.sources[src]
+	if s == nil {
+		s = &cmdSource{}
+		t.sources[src] = s
+	}
+	if s.ch != nil {
+		select {
+		case s.ch <- cmd:
+			return true
+		default:
+			return false
+		}
+	}
+	s.ch = make(chan lespayCmd, 16)
+	s.ch <- cmd
+
+	go func() {
+	loop:
+		for {
+			select {
+			case cmd := <-s.ch:
+				t.qlock.Lock()
+				pri, ok := s.priority()
+				t.qlock.Unlock()
+				if ok {
+					task := t.sq.newTask(nil, 0, pri)
+					if !task.start() {
+						break loop
+					}
+					reply := t.runCommand(cmd.cmd, cmd.id, cmd.freeID)
+					t.qlock.Lock()
+					now := mclock.Now()
+					delay := s.addDelay(now, t.delayFactor(now))
+					t.qlock.Unlock()
+					cmd.send(reply, delay)
+					time.Sleep(t.tsProcessDelay)
+					task.done()
+				} else {
+					cmd.send(nil, 0)
+				}
+			default:
+				break loop
+			}
+			t.qlock.Lock()
+			s.ch = nil
+			t.qlock.Unlock()
+		}
+	}()
+	return true
+}
+
+// stop stops the token sale module
+func (t *tokenSale) stop() {
+	close(t.stopCh)
+	t.sq.stop()
+}
+
+// addReceiver adds a new payment receiver module
+func (t *tokenSale) addReceiver(id string, r paymentReceiver) {
+	t.lock.Lock()
+	defer t.lock.Unlock()
+
+	t.receivers[id] = r
+	t.receiverNames = append(t.receiverNames, id)
+}
+
+// tokenPrice returns the PC units required to buy the specified amount of service
+// tokens or the PC units received when selling the given amount of tokens.
+// Returns false if not possible.
+//
+// Note: the price of each token unit depends on the current amount of existing tokens
+// and the total token limit, first raising from 0 to basePrice linearly, then tends to
+// infinity as tokenAmount approaches tokenLimit.
+//
+// if 0 <= tokenAmount <= tokenLimit/2:
+//   tokenPrice = basePrice*tokenAmount/(tokenLimit/2)
+// if tokenLimit/2 <= tokenAmount < tokenLimit:
+//   tokenPrice = basePrice*tokenLimit/2/(tokenLimit-tokenAmount)
+//
+// The price of multiple tokens is calculated as an integral based on the above formula.
+func (t *tokenSale) tokenPrice(buySellAmount uint64, buy bool) (float64, bool) {
+	tokenLimit := t.totalTokenLimit()
+	tokenAmount := t.totalTokenAmount()
+	if buy {
+		if tokenAmount+buySellAmount >= tokenLimit {
+			return 0, false
+		}
+	} else {
+		maxAmount := uint64(float64(tokenLimit) * tokenSellMaxRatio)
+		if tokenAmount > maxAmount {
+			tokenAmount = maxAmount
+		}
+		if tokenAmount < buySellAmount {
+			buySellAmount = tokenAmount
+		}
+		tokenAmount -= buySellAmount
+	}
+	r := float64(tokenAmount) / float64(tokenLimit)
+	b := float64(buySellAmount) / float64(tokenLimit)
+	var relPrice float64
+	if r < 0.5 {
+		// first purchased token is in the linear range
+		if r+b <= 0.5 {
+			// all purchased tokens are in the linear range
+			relPrice = b * (r + r + b)
+			b = 0
+		} else {
+			// some purchased tokens are in the 1/x range, calculate linear price
+			// update starting point and amount left to buy in the 1/x range
+			relPrice = (0.5 - r) * (r + 0.5)
+			b = r + b - 0.5
+			r = 0.5
+		}
+	}
+	if b > 0 {
+		// some purchased tokens are in the 1/x range
+		l := 1 - r
+		if l < 1e-10 {
+			return 0, false
+		}
+		l = -b / l
+		if l < -1+1e-10 {
+			return 0, false
+		}
+		relPrice += -math.Log1p(l) / 2
+	}
+	return t.basePrice * float64(tokenLimit) * relPrice, true
+}
+
+// tokenBuyAmount returns the service token amount currently available for the given
+// sum of PC units
+func (t *tokenSale) tokenBuyAmount(price float64) uint64 {
+	tokenLimit := t.totalTokenLimit()
+	tokenAmount := t.totalTokenAmount()
+	if tokenLimit <= tokenAmount {
+		return 0
+	}
+	r := float64(tokenAmount) / float64(tokenLimit)
+	c := price / (t.basePrice * float64(tokenLimit))
+	var relTokens float64
+	if r < 0.5 {
+		// first purchased token is in the linear range
+		relTokens = math.Sqrt(r*r+c) - r
+		if r+relTokens <= 0.5 {
+			// all purchased tokens are in the linear range, no more to spend
+			c = 0
+		} else {
+			// some purchased tokens are in the 1/x range, calculate linear amount
+			// update starting point and available funds left to buy in the 1/x range
+			relTokens = 0.5 - r
+			c -= (0.5 - r) * (r + 0.5)
+			r = 0.5
+		}
+	}
+	if c > 0 {
+		relTokens -= math.Expm1(-2*c) * (1 - r)
+	}
+	return uint64(relTokens * float64(tokenLimit))
+}
+
+// tokenSellAmount returns the service token amount that needs to be sold in order
+// to receive the given sum of PC units. Returns false if not possible.
+func (t *tokenSale) tokenSellAmount(price float64) (uint64, bool) {
+	tokenLimit := t.totalTokenLimit()
+	tokenAmount := t.totalTokenAmount()
+	r := float64(tokenAmount) / float64(tokenLimit)
+	if r > tokenSellMaxRatio {
+		r = tokenSellMaxRatio
+	}
+	c := price / (t.basePrice * float64(tokenLimit))
+	var relTokens float64
+	if r > 0.5 {
+		// first sold token is in the 1/x range
+		relTokens = math.Expm1(2*c) * (1 - r)
+		if r-relTokens >= 0.5 || 1-r < 1e-10 {
+			// all sold tokens are in the 1/x range, no more to sell
+			c = 0
+		} else {
+			// some sold tokens are in the linear range, calculate price in 1/x range
+			// update starting point and remaining price to sell for in the linear range
+			relTokens = r - 0.5
+			c -= math.Log1p(relTokens/(1-r)) / 2
+			r = 0.5
+		}
+	}
+	if c > 0 {
+		// some sold tokens are in the linear range
+		if x := r*r - c; x >= 0 {
+			relTokens += r - math.Sqrt(x)
+		} else {
+			return 0, false
+		}
+	}
+	return uint64(relTokens * float64(tokenLimit)), true
+}
+
+// connection checks whether it is possible with the current balance levels to establish
+// requested connection or capacity change and then stay connected for the given amount
+// of time. If it is possible and setCap is also true then the client is activated of the
+// capacity change is performed. If not then returns how many tokens are missing and how
+// much that would currently cost using the specified payment module(s).
+func (t *tokenSale) connection(id enode.ID, freeID string, requestedCapacity uint64, stayConnected time.Duration, paymentModule []string, setCap bool) (availableCapacity, tokenBalance, tokensMissing, pcBalance, pcMissing uint64, paymentRequired []uint64, err error) {
+	t.lock.Lock()
+	defer t.lock.Unlock()
+
+	tokensMissing, availableCapacity, err = t.clientPool.setCapacityLocked(id, freeID, requestedCapacity, stayConnected, setCap)
+	pb := t.clientPool.getPosBalance(id)
+	tokenBalance = pb.value.value(t.clientPool.posExpiration(mclock.Now()))
+	var meta tokenSaleMeta
+	if err := rlp.DecodeBytes([]byte(pb.meta), &meta); err == nil {
+		pcBalance = meta.pcBalance
+	}
+	if tokensMissing == 0 {
+		return
+	}
+	tokenLimit := t.clientPool.totalTokenLimit()
+	tokenAmount := t.clientPool.totalTokenAmount()
+	if tokenLimit <= tokenAmount || tokenLimit-tokenAmount <= tokensMissing {
+		pcMissing = math.MaxUint64
+	} else {
+		tokensAvailable := tokenLimit - tokenAmount
+		pcr := -math.Log(float64(tokensAvailable-tokensMissing)/float64(tokensAvailable)) * t.basePrice
+		if pcr > 0 {
+			if pcr > maxBalance {
+				pcMissing = math.MaxUint64
+			} else {
+				pcMissing = uint64(pcr)
+				if pcMissing > maxBalance {
+					pcMissing = math.MaxUint64
+				} else {
+					if pcMissing > pcBalance {
+						pcMissing -= pcBalance
+					} else {
+						pcMissing = 0
+					}
+				}
+			}
+		}
+	}
+	if pcMissing == 0 {
+		return
+	}
+	paymentRequired = make([]uint64, len(paymentModule))
+	for i, recID := range paymentModule {
+		if rec, ok := t.receivers[recID]; !ok || pcMissing == math.MaxUint64 {
+			paymentRequired[i] = math.MaxUint64
+		} else {
+			paymentRequired[i] = rec.requestPayment(id, pcMissing, meta.receiverMeta[recID])
+		}
+	}
+	return
+}
+
+// deposit credits a payment on the sender's account using the specified payment module
+func (t *tokenSale) deposit(id enode.ID, paymentModule string, proofOfPayment []byte) (pcValue, pcBalance uint64, err error) {
+	t.lock.Lock()
+	defer t.lock.Unlock()
+
+	pb := t.clientPool.getPosBalance(id)
+	var meta tokenSaleMeta
+	if err := rlp.DecodeBytes([]byte(pb.meta), &meta); err == nil {
+		pcBalance = meta.pcBalance
+	}
+
+	pm := t.receivers[paymentModule]
+	if pm == nil {
+		return 0, pcBalance, fmt.Errorf("Unknown payment receiver '%s'", paymentModule)
+	}
+	pcValue, meta.receiverMeta[paymentModule], err = pm.receivePayment(id, proofOfPayment, meta.receiverMeta[paymentModule])
+	if err != nil {
+		return 0, pcBalance, err
+	}
+	pcBalance += pcValue
+	meta.pcBalance = pcBalance
+	metaEnc, _ := rlp.EncodeToBytes(&meta)
+	t.clientPool.addBalance(id, 0, string(metaEnc))
+	return
+}
+
+// buyTokens tries to convert the permanent balance (nominated in the server's preferred
+// currency, PC) to service tokens. If spendAll is true then it sells the maxSpend amount
+// of PC coins if the received service token amount is at least minReceive. If spendAll is
+// false then is buys minReceive amount of tokens if it does not cost more than maxSpend
+// amount of PC coins.
+// if relative is true then maxSpend and minReceive are specified relative to their current
+// balances. In this case maxSpend represents the amount under which the PC balance should
+// not go and minReceive represents the amount the service token balance should reach.
+// This mode is useful when actual conversion is intended to happen and the sender has to
+// retry the command after not receiving a reply previously. In this case the sender cannot
+// be sure whether the conversion has already happened or not. If relative is true then it
+// is impossible to do a conversion twice. In exchange the sender needs to know its current
+// balances (which it probably does if it has made a previous call to just ask the current price).
+func (t *tokenSale) buyTokens(id enode.ID, maxSpend, minReceive uint64, relative, spendAll bool) (pcBalance, tokenBalance, spend, receive uint64, success bool) {
+	t.lock.Lock()
+	defer t.lock.Unlock()
+
+	pb := t.clientPool.getPosBalance(id)
+	tokenBalance = pb.value.value(t.clientPool.posExpiration(mclock.Now()))
+	var meta tokenSaleMeta
+	if err := rlp.DecodeBytes([]byte(pb.meta), &meta); err == nil {
+		pcBalance = meta.pcBalance
+	}
+	if relative {
+		if pcBalance > maxSpend {
+			maxSpend = pcBalance - maxSpend
+		} else {
+			maxSpend = 0
+		}
+		if minReceive > tokenBalance {
+			minReceive -= tokenBalance
+		} else {
+			minReceive = 0
+		}
+	}
+
+	if maxSpend > pcBalance {
+		maxSpend = pcBalance
+	}
+	if spendAll {
+		spend = maxSpend
+		receive = t.tokenBuyAmount(float64(spend))
+		success = receive >= minReceive
+	} else {
+		receive = minReceive
+		if cost, ok := t.tokenPrice(receive, true); ok {
+			spend = uint64(cost) + 1 // ensure that we don't sell small amounts for free
+		} else {
+			spend = math.MaxUint64
+		}
+		success = spend <= maxSpend
+	}
+	if success {
+		pcBalance -= spend
+		tokenBalance += receive
+		meta.pcBalance = pcBalance
+		metaEnc, _ := rlp.EncodeToBytes(&meta)
+		t.clientPool.addBalance(id, int64(receive), string(metaEnc))
+	}
+	return
+}
+
+// sellTokens tries to convert service tokens to permanent balance (nominated in the server's
+// preferred currency, PC). Parameters work similarly to buyTokens.
+func (t *tokenSale) sellTokens(id enode.ID, maxSell, minRefund uint64, relative, sellAll bool) (pcBalance, tokenBalance, sell, refund uint64, success bool) {
+	t.lock.Lock()
+	defer t.lock.Unlock()
+
+	pb := t.clientPool.getPosBalance(id)
+	tokenBalance = pb.value.value(t.clientPool.posExpiration(mclock.Now()))
+	var meta tokenSaleMeta
+	if err := rlp.DecodeBytes([]byte(pb.meta), &meta); err == nil {
+		pcBalance = meta.pcBalance
+	}
+	if relative {
+		if pcBalance < minRefund {
+			minRefund -= pcBalance
+		} else {
+			minRefund = 0
+		}
+		if maxSell < tokenBalance {
+			maxSell = tokenBalance - maxSell
+		} else {
+			maxSell = 0
+		}
+	}
+
+	if maxSell > tokenBalance {
+		maxSell = tokenBalance
+	}
+	if sellAll {
+		sell = maxSell
+		if r, ok := t.tokenPrice(sell, false); ok {
+			refund = uint64(r)
+			success = refund >= minRefund
+		}
+	} else {
+		refund = minRefund
+		if s, ok := t.tokenSellAmount(float64(refund)); ok {
+			sell = s + 1 // ensure that we don't sell small amounts for free
+		} else {
+			sell = math.MaxUint64
+		}
+		success = sell <= maxSell
+	}
+	if success {
+		pcBalance += refund
+		tokenBalance -= sell
+		meta.pcBalance = pcBalance
+		metaEnc, _ := rlp.EncodeToBytes(&meta)
+		t.clientPool.addBalance(id, -int64(sell), string(metaEnc))
+	}
+	return
+}
+
+// getBalance returns the current PC balance and service token balance
+func (t *tokenSale) getBalance(id enode.ID) (pcBalance, tokenBalance uint64) {
+	t.lock.Lock()
+	defer t.lock.Unlock()
+
+	pb := t.clientPool.getPosBalance(id)
+	tokenBalance = pb.value.value(t.clientPool.posExpiration(mclock.Now()))
+	var meta tokenSaleMeta
+	if err := rlp.DecodeBytes([]byte(pb.meta), &meta); err == nil {
+		pcBalance = meta.pcBalance
+	}
+	return
+}
+
+// info returns general information about the server, including version info of the
+// lespay command set, supported payment modules and token expiration time constant
+func (t *tokenSale) info() (version, compatible uint, info keyValueList, receivers []string) {
+	t.lock.Lock()
+	defer t.lock.Unlock()
+
+	exp, _ := t.clientPool.getExpirationTCs()
+	info = info.add("tokenExpiration", strconv.FormatUint(exp, 10))
+	return 1, 1, info, t.receiverNames
+}
+
+// receiverInfo returns information about the specified payment receiver(s) if supported
+func (t *tokenSale) receiverInfo(receiverIDs []string) []keyValueList {
+	t.lock.Lock()
+	defer t.lock.Unlock()
+
+	res := make([]keyValueList, len(receiverIDs))
+	for i, id := range receiverIDs {
+		if rec, ok := t.receivers[id]; ok {
+			res[i] = rec.info()
+		}
+	}
+	return res
+}
+
+// tokenSaleMeta is the "meta" field used by the lespay token sale module. It is
+// attached to token balances and it includes the permanent balance of the client
+// nominated in the server's preferred currency and the meta fields provided by
+// the used payment receivers.
+type tokenSaleMeta struct {
+	pcBalance    uint64
+	receiverMeta map[string][]byte
+}
+
+// receiverMetaEnc is used for easy RLP encoding/decoding
+type receiverMetaEnc struct {
+	Id   string
+	Meta []byte
+}
+
+// tokenSaleMetaEnc is used for easy RLP encoding/decoding
+type tokenSaleMetaEnc struct {
+	Id        string
+	Version   uint
+	PcBalance uint64
+	Receivers []receiverMetaEnc
+}
+
+// EncodeRLP implements rlp.Encoder
+func (t *tokenSaleMeta) EncodeRLP(w io.Writer) error {
+	receivers := make([]receiverMetaEnc, len(t.receiverMeta))
+	i := 0
+	for id, meta := range t.receiverMeta {
+		receivers[i] = receiverMetaEnc{id, meta}
+		i++
+	}
+	return rlp.Encode(w, tokenSaleMetaEnc{
+		Id:        "tokenSale",
+		Version:   1,
+		PcBalance: t.pcBalance,
+		Receivers: receivers,
+	})
+}
+
+// DecodeRLP implements rlp.Decoder
+func (t *tokenSaleMeta) DecodeRLP(s *rlp.Stream) error {
+	if t.receiverMeta == nil {
+		t.receiverMeta = make(map[string][]byte)
+	}
+	var e tokenSaleMetaEnc
+	if err := s.Decode(&e); err != nil {
+		return err
+	}
+	if e.Id != "tokenSale" || e.Version != 1 {
+		return fmt.Errorf("Unknown balance meta format '%s' version %d", e.Id, e.Version)
+	}
+	t.receiverMeta = make(map[string][]byte)
+	t.pcBalance = e.PcBalance
+	for _, r := range e.Receivers {
+		t.receiverMeta[r.Id] = r.Meta
+	}
+	return nil
+}
+
+const (
+	tsInfo = iota
+	tsReceiverInfo
+	tsGetBalance
+	tsDeposit
+	tsBuyTokens
+	tsSellTokens
+	tsConnection
+)
+
+type (
+	tsInfoResults struct {
+		Version, Compatible uint
+		Info                keyValueList
+		Receivers           []string
+	}
+	tsInfoApiResults struct {
+		Version, Compatible uint
+		Info                keyValueMapDecoded
+		Receivers           []string
+	}
+	tsReceiverInfoParams     []string
+	tsReceiverInfoResults    []keyValueList
+	tsReceiverInfoApiResults []keyValueMapDecoded
+	tsGetBalanceResults      struct {
+		PcBalance, TokenBalance uint64
+	}
+	tsDepositParams struct {
+		PaymentModule  string
+		ProofOfPayment []byte
+	}
+	tsDepositResults struct {
+		PcValue, PcBalance uint64
+		Err                string
+	}
+	tsBuyTokensParams struct {
+		MaxSpend, MinReceive uint64
+		Relative, SpendAll   bool
+	}
+	tsBuyTokensResults struct {
+		PcBalance, TokenBalance, Spend, Receive uint64
+		Success                                 bool
+	}
+	tsSellTokensParams struct {
+		MaxSell, MinRefund uint64
+		Relative, SellAll  bool
+	}
+	tsSellTokensResults struct {
+		PcBalance, TokenBalance, Sell, Refund uint64
+		Success                               bool
+	}
+	tsConnectionParams struct {
+		RequestedCapacity, StayConnected uint64
+		PaymentModule                    []string
+		SetCap                           bool
+	}
+	tsConnectionResults struct {
+		AvailableCapacity, TokenBalance, TokensMissing, PcBalance, PcMissing uint64
+		PaymentRequired                                                      []uint64
+		Err                                                                  string
+	}
+)
+
+// runCommand runs an encoded lespay command and returns the encoded results
+func (t *tokenSale) runCommand(cmd []byte, id enode.ID, freeID string) []byte {
+	var res []byte
+	switch cmd[0] {
+	case tsInfo:
+		var results tsInfoResults
+		if len(cmd) == 1 {
+			results.Version, results.Compatible, results.Info, results.Receivers = t.info()
+			res, _ = rlp.EncodeToBytes(&results)
+		}
+	case tsReceiverInfo:
+		var (
+			params  tsReceiverInfoParams
+			results tsReceiverInfoResults
+		)
+		if err := rlp.DecodeBytes(cmd[1:], &params); err == nil {
+			results = t.receiverInfo(params)
+			res, _ = rlp.EncodeToBytes(&results)
+		}
+	case tsGetBalance:
+		var results tsGetBalanceResults
+		if len(cmd) == 1 {
+			results.PcBalance, results.TokenBalance = t.getBalance(id)
+			res, _ = rlp.EncodeToBytes(&results)
+		}
+	case tsDeposit:
+		var (
+			params  tsDepositParams
+			results tsDepositResults
+		)
+		if err := rlp.DecodeBytes(cmd[1:], &params); err == nil {
+			results.PcValue, results.PcBalance, err = t.deposit(id, params.PaymentModule, params.ProofOfPayment)
+			if err != nil {
+				results.Err = err.Error()
+			}
+			res, _ = rlp.EncodeToBytes(&results)
+		}
+	case tsBuyTokens:
+		var (
+			params  tsBuyTokensParams
+			results tsBuyTokensResults
+		)
+		if err := rlp.DecodeBytes(cmd[1:], &params); err == nil {
+			results.PcBalance, results.TokenBalance, results.Spend, results.Receive, results.Success =
+				t.buyTokens(id, params.MaxSpend, params.MinReceive, params.Relative, params.SpendAll)
+			res, _ = rlp.EncodeToBytes(&results)
+		}
+	case tsSellTokens:
+		var (
+			params  tsSellTokensParams
+			results tsSellTokensResults
+		)
+		if err := rlp.DecodeBytes(cmd[1:], &params); err == nil {
+			results.PcBalance, results.TokenBalance, results.Sell, results.Refund, results.Success =
+				t.sellTokens(id, params.MaxSell, params.MinRefund, params.Relative, params.SellAll)
+			res, _ = rlp.EncodeToBytes(&results)
+		}
+	case tsConnection:
+		var (
+			params  tsConnectionParams
+			results tsConnectionResults
+		)
+		if err := rlp.DecodeBytes(cmd[1:], &params); err == nil {
+			results.AvailableCapacity, results.TokenBalance, results.TokensMissing, results.PcBalance, results.PcMissing, results.PaymentRequired, err =
+				t.connection(id, freeID, params.RequestedCapacity, time.Duration(params.StayConnected)*time.Second, params.PaymentModule, params.SetCap)
+			if err != nil {
+				results.Err = err.Error()
+			}
+			res, _ = rlp.EncodeToBytes(&results)
+		}
+	}
+	return res
+}
+
+type keyValueMapDecoded map[string]interface{}
+
+// DecodeRLP implements rlp.Decoder
+func (k *keyValueMapDecoded) DecodeRLP(s *rlp.Stream) error {
+	var list keyValueList
+	if err := s.Decode(&list); err != nil {
+		return err
+	}
+	*k = make(keyValueMapDecoded)
+	for _, item := range list {
+		var s string
+		if err := rlp.DecodeBytes(item.Value, &s); err != nil {
+			return err
+		}
+		(*k)[item.Key] = s
+	}
+	return nil
+}
+
+// testReceiver implements paymentReceiver. It should only be used for testing.
+type testReceiver struct{}
+
+func (t testReceiver) info() keyValueList {
+	var info keyValueList
+	info = info.add("description", "Test payment receiver")
+	info = info.add("version", "1.0.0")
+	return info
+}
+
+// receivePayment implements paymentReceiver. proofOfPayment is a base 10 ascii number
+// which is credited to the sender's account without any further conditions.
+func (t testReceiver) receivePayment(from enode.ID, proofOfPayment, oldMeta []byte) (value uint64, newMeta []byte, err error) {
+	if len(proofOfPayment) > 8 {
+		err = fmt.Errorf("proof of payment is too long; max 8 bytes long big endian integer expected")
+		return
+	}
+	var b [8]byte
+	copy(b[8-len(proofOfPayment):], proofOfPayment)
+	value = binary.BigEndian.Uint64(b[:])
+	return
+}
+
+// requestPayment implements paymentReceiver
+func (t testReceiver) requestPayment(from enode.ID, value uint64, meta []byte) uint64 {
+	return value
+}

--- a/les/tokensale_test.go
+++ b/les/tokensale_test.go
@@ -1,0 +1,157 @@
+// Copyright 2020 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+package les
+
+import (
+	"math/rand"
+	"testing"
+)
+
+func TestTokenPriceCalculation(t *testing.T) {
+	var totalLimit, totalAmount uint64
+	ts := &tokenSale{
+		basePrice:        1,
+		totalTokenLimit:  func() uint64 { return totalLimit },
+		totalTokenAmount: func() uint64 { return totalAmount },
+	}
+	totalLimit = 1000000000000
+	maxDiff := int64(totalLimit / 1000000)
+	// inaccuracy increases around both ends of the allowed token range
+	min := totalLimit / 100
+	max := uint64(float64(totalLimit) * tokenSellMaxRatio)
+	for count := 0; count < 100000; count++ {
+		start := min + uint64(rand.Int63n(int64(max-min)))
+		stop := min + uint64(rand.Int63n(int64(max-min)))
+		if start > stop {
+			start, stop = stop, start
+		}
+		// buy (start-stop) tokens in two steps
+		mid := start + uint64(rand.Int63n(int64(stop-start+1)))
+		totalAmount = start
+		cost, ok := ts.tokenPrice(mid-start, true)
+		if !ok {
+			t.Fatalf("Failed to buy tokens")
+		}
+		totalAmount = mid
+		cost2, ok := ts.tokenPrice(stop-mid, true)
+		if !ok {
+			t.Fatalf("Failed to buy tokens")
+		}
+		cost += cost2
+
+		// sell the same amount of tokens in two steps
+		mid = start + uint64(rand.Int63n(int64(stop-start+1)))
+		totalAmount = stop
+		refund, ok := ts.tokenPrice(stop-mid, false)
+		if !ok {
+			t.Fatalf("Failed to sell tokens")
+		}
+		totalAmount = mid
+		refund2, ok := ts.tokenPrice(mid-start, false)
+		if !ok {
+			t.Fatalf("Failed to sell tokens")
+		}
+		refund += refund2
+		ratio := (refund + 1) / (cost + 1)
+		if ratio < 0.999999 || ratio > 1.000001 {
+			t.Fatalf("Token selling price does not match buy cost")
+		}
+
+		// buy tokens for the previously calculated price in two steps
+		pcost := cost * rand.Float64()
+		totalAmount = start
+		totalAmount += ts.tokenBuyAmount(pcost)
+		totalAmount += ts.tokenBuyAmount(cost - pcost)
+
+		diff := int64(totalAmount - stop)
+		if diff > maxDiff || diff < -maxDiff {
+			t.Fatalf("Bought token amount mismatch")
+		}
+
+		// sell tokens for the previously calculated price in two steps
+		pcost = cost * rand.Float64()
+		totalAmount = stop
+		soldAmount, ok := ts.tokenSellAmount(pcost)
+		if !ok {
+			t.Fatalf("Failed to sell tokens")
+		}
+		totalAmount -= soldAmount
+		soldAmount, ok = ts.tokenSellAmount(cost - pcost)
+		if !ok {
+			t.Fatalf("Failed to sell tokens")
+		}
+		totalAmount -= soldAmount
+
+		diff = int64(totalAmount - start)
+		if diff > maxDiff || diff < -maxDiff {
+			t.Fatalf("Sold token amount mismatch")
+		}
+	}
+}
+
+func TestSingleTokenPrice(t *testing.T) {
+	var totalLimit, totalAmount uint64
+	ts := &tokenSale{
+		basePrice:        1,
+		totalTokenLimit:  func() uint64 { return totalLimit },
+		totalTokenAmount: func() uint64 { return totalAmount },
+	}
+	totalLimit = 1000000000000
+	buyLimit := uint64(float64(totalLimit) * tokenSellMaxRatio)
+	for count := 0; count < 10000; count++ {
+		totalAmount = uint64(rand.Int63n(int64(buyLimit)))
+		relAmount := float64(totalAmount) / float64(totalLimit)
+		var expPrice, maxDiff float64
+		if relAmount < 0.5 {
+			expPrice = relAmount * 2
+			maxDiff = 0.001
+		} else {
+			expPrice = 0.5 / (1 - relAmount)
+			maxDiff = 0.001 * expPrice
+		}
+		price, ok := ts.tokenPrice(1, true)
+		if !ok {
+			t.Fatalf("Failed to buy tokens")
+		}
+		if price < expPrice-maxDiff || price > expPrice+maxDiff {
+			t.Fatalf("Token price mismatch")
+		}
+
+		price, ok = ts.tokenPrice(1, false)
+		if !ok {
+			t.Fatalf("Failed to sell tokens")
+		}
+		if price < expPrice-maxDiff || price > expPrice+maxDiff {
+			t.Fatalf("Token price mismatch")
+		}
+
+		if relAmount > 0.01 {
+			amount := ts.tokenBuyAmount(expPrice * 100)
+			if amount < 99 || amount > 101 {
+				t.Fatalf("Bought token amount mismatch")
+			}
+
+			amount, ok = ts.tokenSellAmount(expPrice * 100)
+			if !ok {
+				t.Fatalf("Failed to sell tokens")
+			}
+			if amount < 99 || amount > 101 {
+				t.Fatalf("Sold token amount mismatch")
+			}
+		}
+	}
+}

--- a/les/ulc_test.go
+++ b/les/ulc_test.go
@@ -28,8 +28,8 @@ import (
 	"github.com/ethereum/go-ethereum/p2p/enode"
 )
 
-func TestULCAnnounceThresholdLes2(t *testing.T) { testULCAnnounceThreshold(t, 2) }
 func TestULCAnnounceThresholdLes3(t *testing.T) { testULCAnnounceThreshold(t, 3) }
+func TestULCAnnounceThresholdLes4(t *testing.T) { testULCAnnounceThreshold(t, 4) }
 
 func testULCAnnounceThreshold(t *testing.T, protocol int) {
 	// todo figure out why it takes fetcher so longer to fetcher the announced header.
@@ -124,9 +124,9 @@ func connect(server *serverHandler, serverId enode.ID, client *clientHandler, pr
 	return peer1, peer2, nil
 }
 
-// newTestServerPeer creates server peer.
+// newServerPeer creates server peer.
 func newTestServerPeer(t *testing.T, blocks int, protocol int) (*testServer, *enode.Node, func()) {
-	s, teardown := newServerEnv(t, blocks, protocol, nil, false, false, 0)
+	s, teardown := newServerEnv(t, blocks, protocol, nil, false, false, 0, false)
 	key, err := crypto.GenerateKey()
 	if err != nil {
 		t.Fatal("generate key err:", err)

--- a/p2p/discv5/table.go
+++ b/p2p/discv5/table.go
@@ -35,6 +35,7 @@ const (
 	nBuckets   = hashBits + 1 // Number of buckets
 
 	maxFindnodeFailures = 5
+	maxTalkFailures     = 5
 )
 
 type Table struct {

--- a/p2p/discv5/udp.go
+++ b/p2p/discv5/udp.go
@@ -119,6 +119,17 @@ type (
 		Nodes []rpcNode
 	}
 
+	talkRequest struct {
+		TalkID  []byte
+		Payload interface{}
+	}
+
+	talkResponse struct {
+		ReplyTok []byte
+		Delay    uint
+		Payload  interface{}
+	}
+
 	rpcNode struct {
 		IP  net.IP // len 4 for IPv4 or 16 for IPv6
 		UDP uint16 // for discovery protocol
@@ -420,6 +431,10 @@ func decodePacket(buffer []byte, pkt *ingressPacket) error {
 		pkt.data = new(topicQuery)
 	case topicNodesPacket:
 		pkt.data = new(topicNodes)
+	case talkRequestPacket:
+		pkt.data = new(talkRequest)
+	case talkResponsePacket:
+		pkt.data = new(talkResponse)
 	default:
 		return fmt.Errorf("unknown packet type: %d", sigdata[0])
 	}

--- a/p2p/enode/node.go
+++ b/p2p/enode/node.go
@@ -217,7 +217,7 @@ func (n ID) MarshalText() ([]byte, error) {
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (n *ID) UnmarshalText(text []byte) error {
-	id, err := parseID(string(text))
+	id, err := ParseID(string(text))
 	if err != nil {
 		return err
 	}
@@ -229,14 +229,14 @@ func (n *ID) UnmarshalText(text []byte) error {
 // The string may be prefixed with 0x.
 // It panics if the string is not a valid ID.
 func HexID(in string) ID {
-	id, err := parseID(in)
+	id, err := ParseID(in)
 	if err != nil {
 		panic(err)
 	}
 	return id
 }
 
-func parseID(in string) (ID, error) {
+func ParseID(in string) (ID, error) {
 	var id ID
 	b, err := hex.DecodeString(strings.TrimPrefix(in, "0x"))
 	if err != nil {


### PR DESCRIPTION
This PR implements
- a new module called `tokenSale` that provides functions (`lesPay` commands) for depositing funds, buying/selling service tokens, querying prices, balances and connection availability
	- payment channel implementation is not part of this PR, payment receiver is a replaceable module (a dummy `testReceiver` is included)
	- clients now have a balance in the server's preferred currency (`pcBalance`) in addition to the already existing service token balance
	- conversion is possible with a dynamically adjusted rate; service tokens are usually held for a short term only 
	- a very simple rate limiter logic for `lesPay` commands protects from DoS attacks while the "recommended delay" feedback makes it easy for clients to behave nicely while still being as efficient as possible
- expiring service token model: like negative balances, now positive service token balances are also decreased exponentially
	- expiration only happens when the `clientPool` is not filled with priority clients and therefore all service tokens are spendable (kind of a "spendability fee")
	- `balanceTracker` and the token balance database now use `expiredValue` which handles exponential decrease without regular updating
	- total existing token amount is limited, the limit is adjusted dynamically based on the availability of free service
	- prices are changed according to the existing token amount to limit ratio
	- this ensures that free service is usually available and tokens are usually all spendable
- improvements to the `clientPool`:
	- connected clients can be active or inactive, the latter means zero capacity, no request serving but keeping the TCP/IP connection
	- if a higher priority client is connected the lower priority one is not kicked out instantly but deactivated first
	- clients with a positive balance can stay connected as inactive for as long as necessary, free clients are still kicked out after 5-10 seconds
	- inactive clients are waiting in a queue and are automatically reactivated if possible
	- this behavior fits the expiring service token model and the new server pool logic better because token-holding clients want to spend their tokens whenever possible
	- the extra complexity introduced by inactive clients in `clientPool` will be made up for with a simpler `serverPool` logic
- `les/4` protocol extension with `LespayMsg` and `LespayReplyMsg` to provide access to the `lesPay` commands in-protocol
	- zero-capacity connection is also allowed by `les/4` so earlier clients are still dropped instantly
- UDP `talkRequest` and `talkResponse` packets are added to `discv5` which is used by LES to make `lesPay` also accessible through UDP when not connected
	- connection pre-negotiation and price queries are much cheaper this way
- `PrivateLespayAPI` provides user access to the `lesPay` commands on either the local or a remote server