### PR TITLE
whisper/whisperv6: fix peer time.Ticker leak

### DIFF
--- a/whisper/whisperv6/peer.go
+++ b/whisper/whisperv6/peer.go
@@ -146,7 +146,9 @@ func (peer *Peer) handshake() error {
 func (peer *Peer) update() {
 	// Start the tickers for the updates
 	expire := time.NewTicker(expirationCycle)
+	defer expire.Stop()
 	transmit := time.NewTicker(transmissionCycle)
+	defer transmit.Stop()
 
 	// Loop and transmit until termination is requested
 	for {


### PR DESCRIPTION
This PR fixes Whisper module, Ticker leak caused when Peer node is disconnected