### PR TITLE
rpc: support dial http with context

### DIFF
--- a/rpc/client.go
+++ b/rpc/client.go
@@ -173,7 +173,7 @@ func DialContext(ctx context.Context, rawurl string) (*Client, error) {
 	}
 	switch u.Scheme {
 	case "http", "https":
-		return DialHTTP(rawurl)
+		return DialHTTP(ctx, rawurl)
 	case "ws", "wss":
 		return DialWebsocket(ctx, rawurl, "")
 	case "stdio":

--- a/rpc/http.go
+++ b/rpc/http.go
@@ -106,7 +106,7 @@ var DefaultHTTPTimeouts = HTTPTimeouts{
 
 // DialHTTPWithClient creates a new RPC client that connects to an RPC server over HTTP
 // using the provided HTTP Client.
-func DialHTTPWithClient(endpoint string, client *http.Client) (*Client, error) {
+func DialHTTPWithClient(ctx context.Context, endpoint string, client *http.Client) (*Client, error) {
 	req, err := http.NewRequest(http.MethodPost, endpoint, nil)
 	if err != nil {
 		return nil, err
@@ -114,15 +114,14 @@ func DialHTTPWithClient(endpoint string, client *http.Client) (*Client, error) {
 	req.Header.Set("Content-Type", contentType)
 	req.Header.Set("Accept", contentType)
 
-	initctx := context.Background()
-	return newClient(initctx, func(context.Context) (ServerCodec, error) {
+	return newClient(ctx, func(context.Context) (ServerCodec, error) {
 		return &httpConn{client: client, req: req, closeCh: make(chan interface{})}, nil
 	})
 }
 
 // DialHTTP creates a new RPC client that connects to an RPC server over HTTP.
-func DialHTTP(endpoint string) (*Client, error) {
-	return DialHTTPWithClient(endpoint, new(http.Client))
+func DialHTTP(ctx context.Context, endpoint string) (*Client, error) {
+	return DialHTTPWithClient(ctx, endpoint, new(http.Client))
 }
 
 func (c *Client) sendHTTP(ctx context.Context, op *requestOp, msg interface{}) error {


### PR DESCRIPTION
Make `DialHTTP` consistent with other dials' methods by passing the context along.

`ctx` can carry additional information that are useful when dialing.