### PR TITLE
core/state: add more verbosity to panic

### DIFF
--- a/core/state/statedb.go
+++ b/core/state/statedb.go
@@ -204,7 +204,7 @@ func (s *StateDB) AddRefund(gas uint64) {
 func (s *StateDB) SubRefund(gas uint64) {
 	s.journal.append(refundChange{prev: s.refund})
 	if gas > s.refund {
-		panic("Refund counter below zero")
+		panic(fmt.Sprintf("Refund counter below zero (gas: %d > refund: %d)", gas, s.refund))
 	}
 	s.refund -= gas
 }


### PR DESCRIPTION
This PR adds some more verbosity to a `panic` that occurred in https://github.com/ethereum/go-ethereum/issues/20539 . Makes no sense not to be as verbose as possible on panics. 