### PR TITLE
eth: check propagated block malformation on receiption

### DIFF
--- a/eth/handler.go
+++ b/eth/handler.go
@@ -687,6 +687,14 @@ func (pm *ProtocolManager) handleMsg(p *peer) error {
 		if err := msg.Decode(&request); err != nil {
 			return errResp(ErrDecode, "%v: %v", msg, err)
 		}
+		if hash := types.CalcUncleHash(request.Block.Uncles()); hash != request.Block.UncleHash() {
+			log.Warn("Propagated block has invalid uncles", "have", hash, "exp", request.Block.UncleHash())
+			break // TODO(karalabe): return error eventually, but wait a few releases
+		}
+		if hash := types.DeriveSha(request.Block.Transactions()); hash != request.Block.TxHash() {
+			log.Warn("Propagated block has invalid body", "have", hash, "exp", request.Block.TxHash())
+			break // TODO(karalabe): return error eventually, but wait a few releases
+		}
 		if err := request.sanityCheck(); err != nil {
 			return err
 		}


### PR DESCRIPTION
Malformed blocks are detected and rejected by the chain inserter. If however a malformed block is broadcast to us, we only do PoW checks and quickly forward it to keep latency down. This is unfortunate, because PoW does not protect against a bad body, so every new valid PoW is an opportunity to propagate a (one!) malformed block through the network.

This PR fixes it by moving a malformation detection into block receiption (propagation is the only place where an entire block is transmitted in assembled form, the rest of the protocol already uses split headers/bodies). Long term if we rework block propagation to be smarter, even this one instance can be dropped.

The PR currently just silently discards these blocks, but long term we want to drop the offending peer altogether for protocol violation. The reason we don't do this now is not to nuke the network apart if someone attempts this malformed propagation again.

