### PR TITLE
cmd/evm: accept --input for disasm command

### DIFF
--- a/cmd/evm/disasm.go
+++ b/cmd/evm/disasm.go
@@ -34,17 +34,22 @@ var disasmCommand = cli.Command{
 }
 
 func disasmCmd(ctx *cli.Context) error {
-	if len(ctx.Args().First()) == 0 {
-		return errors.New("filename required")
+	var in string
+	switch {
+	case len(ctx.Args().First()) > 0:
+		fn := ctx.Args().First()
+		input, err := ioutil.ReadFile(fn)
+		if err != nil {
+			return err
+		}
+		in = string(input)
+	case ctx.GlobalIsSet(InputFlag.Name):
+		in = ctx.GlobalString(InputFlag.Name)
+	default:
+		return errors.New("Missing filename or --input value")
 	}
 
-	fn := ctx.Args().First()
-	in, err := ioutil.ReadFile(fn)
-	if err != nil {
-		return err
-	}
-
-	code := strings.TrimSpace(string(in))
+	code := strings.TrimSpace(in)
 	fmt.Printf("%v\n", code)
 	return asm.PrintDisassembled(code)
 }


### PR DESCRIPTION
Even though the `evm` utility has `--input value` as a global option, the `disasm` subcommand does not use it. This PR enables the usage of the `--input` switch as an input method.