### PR TITLE
core: set max tx size down to 2 slots (64KB)

### DIFF
--- a/core/tx_pool.go
+++ b/core/tx_pool.go
@@ -49,7 +49,7 @@ const (
 	// non-trivial consequences: larger transactions are significantly harder and
 	// more expensive to propagate; larger transactions also take more resources
 	// to validate whether they fit into the pool or not.
-	txMaxSize = 4 * txSlotSize // 128KB, don't bump without chunking support
+	txMaxSize = 2 * txSlotSize // 64KB, don't bump without EIP-2464 support
 )
 
 var (


### PR DESCRIPTION
This PR 'cripples' the tx size that was increased by https://github.com/ethereum/go-ethereum/pull/20352 . The reasoning is that we've been seeing some crashes on nodes with many peers, related to tx pools, and would like to wait with bumping the tx size too much until EIP-2464 has been adopted: https://github.com/ethereum/EIPs/issues/2465