### PR TITLE
log: close log file before calling truncate on windows

### DIFF
--- a/log/handler.go
+++ b/log/handler.go
@@ -125,7 +125,14 @@ func prepFile(path string) (*countingWriter, error) {
 		return nil, err
 	}
 	ns := fi.Size() - cut
-	if err = f.Truncate(ns); err != nil {
+	if err := f.Close(); err != nil {
+		return nil, err
+	}
+	if err = os.Truncate(path, ns); err != nil {
+		return nil, err
+	}
+	f, err = os.OpenFile(path, os.O_RDWR|os.O_APPEND, 0600)
+	if err != nil {
 		return nil, err
 	}
 	return &countingWriter{w: f, count: uint(ns)}, nil


### PR DESCRIPTION
   If you truncate an open file in Windows, access is denied.
   how about close the file before truncation?