### PR TITLE
eth: increase timeout to fix a spurious travis test failure

### DIFF
--- a/eth/handler_test.go
+++ b/eth/handler_test.go
@@ -608,7 +608,7 @@ func testBroadcastBlock(t *testing.T, totalPeers, broadcastExpected int) {
 			}
 		}(peer)
 	}
-	timeout := time.After(time.Second)
+	timeout := time.After(2 * time.Second)
 	var receivedCount int
 outer:
 	for {


### PR DESCRIPTION
Failure https://travis-ci.org/ethereum/go-ethereum/jobs/636889602#L710 : 
```
ok  	github.com/ethereum/go-ethereum/crypto/ecies	0.061s	coverage: 75.9% of statements
ok  	github.com/ethereum/go-ethereum/crypto/secp256k1	1.472s	coverage: 30.6% of statements
--- FAIL: TestBroadcastBlock (7.12s)
    handler_test.go:634: block broadcast to 3 peers, expected 4
FAIL
coverage: 28.0% of statements
FAIL	github.com/ethereum/go-ethereum/eth	17.103s
ok  	github.com/ethereum/go-ethereum/eth/downloader	41.391s	coverage: 78.3% of statements
```
This might fix it, at least make it less common