### PR TITLE
build: upgrade golangci to 1.22.2

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -6,6 +6,8 @@ run:
   # default is true. Enables skipping of directories:
   #   vendor$, third_party$, testdata$, examples$, Godeps$, builtin$
   skip-dirs-use-default: true
+  skip-files:
+    - core/genesis_alloc.go
 
 linters:
   disable-all: true
@@ -43,3 +45,6 @@ issues:
     - path: core/vm/instructions_test.go
       linters:
         - goconst
+    - path: cmd/faucet/
+      linters:
+        - deadcode

--- a/build/checksums.txt
+++ b/build/checksums.txt
@@ -2,18 +2,18 @@
 
 95dbeab442ee2746b9acf0934c8e2fc26414a0565c008631b04addb8c02e7624  go1.13.4.src.tar.gz
 
-1fcbc9e36f4319eeed02beb8cfd1b3d425ffc2f90ddf09a80f18d5064c51e0cb  golangci-lint-1.21.0-linux-386.tar.gz
-267b4066e67139a38d29499331a002d6a29ad5be7aafc83db3b1e88f1b027f90  golangci-lint-1.21.0-linux-armv6.tar.gz
-a602c1f25f90e46e621019cff0a8cb3f4e1837011f3537f15e730d6a9ebf507b  golangci-lint-1.21.0-freebsd-armv7.tar.gz
-2c861f8dc56b560474aa27cab0c075991628cc01af3451e27ac82f5d10d5106b  golangci-lint-1.21.0-linux-amd64.tar.gz
-a1c39e055280e755acaa906e7abfc20b99a5c28be8af541c57fbc44abbb20dde  golangci-lint-1.21.0-linux-arm64.tar.gz
-a8f8bda8c6a4136acf858091077830b1e83ad5612606cb69d5dced869ce00bd8  golangci-lint-1.21.0-linux-ppc64le.tar.gz
-0a8a8c3bc660ccbca668897ab520f7ee9878f16cc8e4dd24fe46236ceec97ba3  golangci-lint-1.21.0-freebsd-armv6.tar.gz
-699b07f45e216571f54002bcbd83b511c4801464a422162158e299587b095b18  golangci-lint-1.21.0-freebsd-amd64.tar.gz
-980fb4993942154bb5c8129ea3b86de09574fe81b24384ebb58cd7a9d2f04483  golangci-lint-1.21.0-linux-armv7.tar.gz
-f15b689088a47f20d5d3c1d945e9ee7c6238f2b84ea468b5f886cf8713dce62e  golangci-lint-1.21.0-windows-386.zip
-2e40ded7adcf11e59013cb15c24438b15a86526ca241edfcfdf1abd73a5280a8  golangci-lint-1.21.0-windows-amd64.zip
-6052c7cfea4d6dc2fc722f6c12792a5ec087420198db495afffbc22052653bf7  golangci-lint-1.21.0-freebsd-386.tar.gz
-ca00b8eacf9af14a71b908b4149606c762aa5c0eac781e74ca0abedfdfdf6c8c  golangci-lint-1.21.0-linux-s390x.tar.gz
-1365455940c342f95718159d89d66ad2eef19f0846c3e87023e915a3527b929f  golangci-lint-1.21.0-darwin-386.tar.gz
-2b2713ec5007e67883aa501eebb81f22abfab0cf0909134ba90f60a066db3760  golangci-lint-1.21.0-darwin-amd64.tar.gz
+478994633b0f5121a7a8d4f368078093e21014fdc7fb2c0ceeae63668c13c5b6  golangci-lint-1.22.2-freebsd-amd64.tar.gz
+fcf80824c21567eb0871055711bf9bdca91cf9a081122e2a45f1d11fed754600  golangci-lint-1.22.2-darwin-amd64.tar.gz
+cda85c72fc128b2ea0ae05baea7b91172c63aea34064829f65285f1dd536f1e0  golangci-lint-1.22.2-windows-386.zip
+94f04899f620aadc9c1524e5482e415efdbd993fa2b2918c4fec2798f030ac1c  golangci-lint-1.22.2-linux-armv7.tar.gz
+0e72a87d71edde00b6e37e84a99841833ad55fee83e20d21130a7a622b2860bb  golangci-lint-1.22.2-freebsd-386.tar.gz
+86def2f31fe8fd7c05674104ed2a4bef3e44b7132b93c6ad2f52f198b3d01801  golangci-lint-1.22.2-linux-s390x.tar.gz
+b0df4546d36be94e8107733ba290b98dd9b7e41a42d3fb202e87fc7e4ee800c3  golangci-lint-1.22.2-freebsd-armv6.tar.gz
+3d45958dcf6a8d195086d2fced1a21db42a90815dfd156d180efa62dbdda6724  golangci-lint-1.22.2-darwin-386.tar.gz
+7ee29f35c74fab017a454237990c74d984ce3855960f2c10509238992bb781f9  golangci-lint-1.22.2-linux-arm64.tar.gz
+52086ac52a502b68578e58e35d3964f127c16d7a90b9ffcb399a004d055ded51  golangci-lint-1.22.2-linux-386.tar.gz
+c2e4df1fab2ae53762f9baac6041503eeeaa968ce38ea41779f7cb526751c667  golangci-lint-1.22.2-windows-amd64.zip
+109d38cdc89f271392f5a138d6782657157f9f496fd4801956efa2d0428e0cbe  golangci-lint-1.22.2-linux-amd64.tar.gz
+f08aae4868d4828c8f07deb0dcd941a1da695b97e58d15e9f3d1d07dcc7a0c84  golangci-lint-1.22.2-linux-armv6.tar.gz
+37af03d9c144d527cb15c46a07e6a22d3f62b5491e34ad6f3bfe6bb0b0b597d4  golangci-lint-1.22.2-linux-ppc64le.tar.gz
+251a1081d53944f1d5f86216d752837b23079f90605c9d1cc628da1ffcd2e749  golangci-lint-1.22.2-freebsd-armv7.tar.gz

--- a/build/ci.go
+++ b/build/ci.go
@@ -355,7 +355,7 @@ func doLint(cmdline []string) {
 
 // downloadLinter downloads and unpacks golangci-lint.
 func downloadLinter(cachedir string) string {
-	const version = "1.21.0"
+	const version = "1.22.2"
 
 	csdb := build.MustLoadChecksums("build/checksums.txt")
 	base := fmt.Sprintf("golangci-lint-%s-%s-%s", version, runtime.GOOS, runtime.GOARCH)


### PR DESCRIPTION
The `arm64` linter build seems to be broken, and indeed the `arm64` version of `golangci` is not available for this platform. This PR upgrades the ci build to match the latest version, that has support for `arm64`.