### PR TITLE
cmd/geth/retesteth: use canon head instead of keeping alternate count

### DIFF
--- a/cmd/geth/retesteth.go
+++ b/cmd/geth/retesteth.go
@@ -110,7 +110,6 @@ type RetestethAPI struct {
 	genesisHash   common.Hash
 	engine        *NoRewardEngine
 	blockchain    *core.BlockChain
-	blockNumber   uint64
 	txMap         map[common.Address]map[uint64]*types.Transaction // Sender -> Nonce -> Transaction
 	txSenders     map[common.Address]struct{}                      // Set of transaction senders
 	blockInterval uint64
@@ -411,7 +410,6 @@ func (api *RetestethAPI) SetChainParams(ctx context.Context, chainParams ChainPa
 	api.engine = engine
 	api.blockchain = blockchain
 	api.db = state.NewDatabase(api.ethDb)
-	api.blockNumber = 0
 	api.txMap = make(map[common.Address]map[uint64]*types.Transaction)
 	api.txSenders = make(map[common.Address]struct{})
 	api.blockInterval = 0
@@ -424,7 +422,7 @@ func (api *RetestethAPI) SendRawTransaction(ctx context.Context, rawTx hexutil.B
 		// Return nil is not by mistake - some tests include sending transaction where gasLimit overflows uint64
 		return common.Hash{}, nil
 	}
-	signer := types.MakeSigner(api.chainConfig, big.NewInt(int64(api.blockNumber)))
+	signer := types.MakeSigner(api.chainConfig, big.NewInt(int64(api.currentNumber())))
 	sender, err := types.Sender(signer, tx)
 	if err != nil {
 		return common.Hash{}, err
@@ -450,9 +448,17 @@ func (api *RetestethAPI) MineBlocks(ctx context.Context, number uint64) (bool, e
 	return true, nil
 }
 
+func (api *RetestethAPI) currentNumber() uint64 {
+	if current := api.blockchain.CurrentBlock(); current != nil {
+		return current.NumberU64()
+	}
+	return 0
+}
+
 func (api *RetestethAPI) mineBlock() error {
-	parentHash := rawdb.ReadCanonicalHash(api.ethDb, api.blockNumber)
-	parent := rawdb.ReadBlock(api.ethDb, parentHash, api.blockNumber)
+	number := api.currentNumber()
+	parentHash := rawdb.ReadCanonicalHash(api.ethDb, number)
+	parent := rawdb.ReadBlock(api.ethDb, parentHash, number)
 	var timestamp uint64
 	if api.blockInterval == 0 {
 		timestamp = uint64(time.Now().Unix())
@@ -462,7 +468,7 @@ func (api *RetestethAPI) mineBlock() error {
 	gasLimit := core.CalcGasLimit(parent, 9223372036854775807, 9223372036854775807)
 	header := &types.Header{
 		ParentHash: parent.Hash(),
-		Number:     big.NewInt(int64(api.blockNumber + 1)),
+		Number:     big.NewInt(int64(number + 1)),
 		GasLimit:   gasLimit,
 		Extra:      api.extraData,
 		Time:       timestamp,
@@ -548,8 +554,7 @@ func (api *RetestethAPI) importBlock(block *types.Block) error {
 	if _, err := api.blockchain.InsertChain([]*types.Block{block}); err != nil {
 		return err
 	}
-	api.blockNumber = block.NumberU64()
-	fmt.Printf("Imported block %d\n", block.NumberU64())
+	fmt.Printf("Imported block %d,  head is %d\n", block.NumberU64(), api.currentNumber())
 	return nil
 }
 
@@ -574,7 +579,6 @@ func (api *RetestethAPI) RewindToBlock(ctx context.Context, newHead uint64) (boo
 	if err := api.blockchain.SetHead(newHead); err != nil {
 		return false, err
 	}
-	api.blockNumber = newHead
 	return true, nil
 }
 
@@ -594,8 +598,7 @@ func (api *RetestethAPI) GetLogHash(ctx context.Context, txHash common.Hash) (co
 }
 
 func (api *RetestethAPI) BlockNumber(ctx context.Context) (uint64, error) {
-	//fmt.Printf("BlockNumber, response: %d\n", api.blockNumber)
-	return api.blockNumber, nil
+	return api.currentNumber(), nil
 }
 
 func (api *RetestethAPI) GetBlockByNumber(ctx context.Context, blockNr math.HexOrDecimal64, fullTx bool) (map[string]interface{}, error) {


### PR DESCRIPTION
Retesteth was kind of illogical, when blocks were imported `[1,2,3a,4,3b]`, it thought that `3b` was the canon head (since Importblocks does not return an error if a side-block is imported). 

This PR removes the separate blockNumber counter from the API, and uses the actual current head from `blockchain` when needed. 

Requested by @winsvega , PTAL if this fixes your issues. 