### PR TITLE
p2p: ensure Server.loop is ticking even if discovery hangs

### DIFF
--- a/p2p/server.go
+++ b/p2p/server.go
@@ -650,9 +650,12 @@ func (srv *Server) run(dialstate dialer) {
 		inboundCount = 0
 		trusted      = make(map[enode.ID]bool, len(srv.TrustedNodes))
 		taskdone     = make(chan task, maxActiveDialTasks)
+		tick         = time.NewTicker(30 * time.Second)
 		runningTasks []task
 		queuedTasks  []task // tasks that can't run yet
 	)
+	defer tick.Stop()
+
 	// Put trusted nodes into a map to speed up checks.
 	// Trusted peers are loaded on startup or added via AddTrustedPeer RPC.
 	for _, n := range srv.TrustedNodes {
@@ -694,6 +697,9 @@ running:
 		scheduleTasks()
 
 		select {
+		case <-tick.C:
+			// This is just here to ensure the dial scheduler runs occasionally.
+
 		case <-srv.quit:
 			// The server was stopped. Run the cleanup logic.
 			break running


### PR DESCRIPTION
This is a temporary fix for a problem which started happening when the
dialer was changed to read nodes from an enode.Iterator. Before the
iterator change, discovery queries would always return within a couple
seconds even if there was no Internet access. Since the iterator won't
return unless a node is actually found, discoverTask can take much
longer. This means that the 'emergency connect' logic might not execute
in time, leading to a stuck node.