### PR TITLE
rpc: check module availability at startup

### DIFF
--- a/cmd/geth/config.go
+++ b/cmd/geth/config.go
@@ -99,8 +99,8 @@ func defaultNodeConfig() node.Config {
 	cfg := node.DefaultConfig
 	cfg.Name = clientIdentifier
 	cfg.Version = params.VersionWithCommit(gitCommit, gitDate)
-	cfg.HTTPModules = append(cfg.HTTPModules, "eth", "shh")
-	cfg.WSModules = append(cfg.WSModules, "eth", "shh")
+	cfg.HTTPModules = append(cfg.HTTPModules, "eth")
+	cfg.WSModules = append(cfg.WSModules, "eth")
 	cfg.IPCPath = "geth.ipc"
 	return cfg
 }

--- a/rpc/endpoints.go
+++ b/rpc/endpoints.go
@@ -18,7 +18,6 @@ package rpc
 
 import (
 	"net"
-	"strings"
 
 	"github.com/ethereum/go-ethereum/log"
 )
@@ -33,8 +32,7 @@ func mustAvailableModule(module string, apis []API) {
 			return
 		}
 	}
-	log.Crit("invalid api module", "module", module, "available", func() string {
-		available := []string{}
+	log.Crit("invalid api module", "module", module, "available", func() (available []string) {
 	outer:
 		for _, api := range apis {
 			// Only include unique api names
@@ -45,7 +43,7 @@ func mustAvailableModule(module string, apis []API) {
 			}
 			available = append(available, api.Namespace)
 		}
-		return strings.Join(available, ",")
+		return
 	}())
 }
 

--- a/rpc/endpoints.go
+++ b/rpc/endpoints.go
@@ -23,34 +23,42 @@ import (
 	"github.com/ethereum/go-ethereum/log"
 )
 
+// mustAvailableModule enforces that requested api modules (eg. via --rpcapi) are actually
+// available API services. If an invalid module is given (ie API "foo" wanted which does not exist),
+// then log.Crit is used to cause program to exit, logging the invalid module and a list of available
+// API service names.
+func mustAvailableModule(module string, apis []API) {
+	apiExists := false
+	for _, api := range apis {
+		if module == api.Namespace {
+			apiExists = true
+			break
+		}
+	}
+	if !apiExists {
+		log.Crit("invalid api module", "module", module, "available", func() string {
+			available := []string{}
+		outer:
+			for _, api := range apis {
+				// Only include unique api names
+				for _, av := range available {
+					if av == api.Namespace {
+						continue outer
+					}
+				}
+				available = append(available, api.Namespace)
+			}
+			return strings.Join(available, ",")
+		}())
+	}
+}
+
 // StartHTTPEndpoint starts the HTTP RPC endpoint, configured with cors/vhosts/modules
 func StartHTTPEndpoint(endpoint string, apis []API, modules []string, cors []string, vhosts []string, timeouts HTTPTimeouts) (net.Listener, *Server, error) {
 	// Generate the whitelist based on the allowed modules
 	whitelist := make(map[string]bool)
 	for _, module := range modules {
-		apiExists := false
-		for _, api := range apis {
-			if module == api.Namespace {
-				apiExists = true
-				break
-			}
-		}
-		if !apiExists {
-			log.Crit("invalid api module", "module", module, "available", func() string {
-				available := []string{}
-				outer:
-				for _, api := range apis {
-					// Only include unique api names
-					for _, av := range available {
-						if av == api.Namespace {
-							continue outer
-						}
-					}
-					available = append(available, api.Namespace)
-				}
-				return strings.Join(available, ",")
-			}())
-		}
+		mustAvailableModule(module, apis)
 		whitelist[module] = true
 	}
 	// Register all the APIs exposed by the services
@@ -81,6 +89,7 @@ func StartWSEndpoint(endpoint string, apis []API, modules []string, wsOrigins []
 	// Generate the whitelist based on the allowed modules
 	whitelist := make(map[string]bool)
 	for _, module := range modules {
+		mustAvailableModule(module, apis)
 		whitelist[module] = true
 	}
 	// Register all the APIs exposed by the services

--- a/rpc/endpoints.go
+++ b/rpc/endpoints.go
@@ -23,11 +23,11 @@ import (
 	"github.com/ethereum/go-ethereum/log"
 )
 
-// isModuleAvailable enforces that requested api modules (eg. via --rpcapi) are actually
+// checkModuleAvailable check that requested api modules (eg. via --rpcapi) are actually
 // available API services. If an invalid module is given (ie API "foo" wanted which does not exist),
-// then log.Crit is used to cause program to exit, logging the invalid module and a list of available
+// then an error is returned including the invalid module and a list of available
 // API service names.
-func isModuleAvailable(module string, apis []API) (err error) {
+func checkModuleAvailable(module string, apis []API) (err error) {
 	for _, api := range apis {
 		if module == api.Namespace {
 			return nil
@@ -57,7 +57,7 @@ func StartHTTPEndpoint(endpoint string, apis []API, modules []string, cors []str
 	for _, module := range modules {
 
 		// Ensure the requested module is actually available.
-		if err := isModuleAvailable(module, apis); err != nil {
+		if err := checkModuleAvailable(module, apis); err != nil {
 			return nil, nil, err
 		}
 		whitelist[module] = true
@@ -92,7 +92,7 @@ func StartWSEndpoint(endpoint string, apis []API, modules []string, wsOrigins []
 	for _, module := range modules {
 
 		// Ensure the requested module is actually available.
-		if err := isModuleAvailable(module, apis); err != nil {
+		if err := checkModuleAvailable(module, apis); err != nil {
 			return nil, nil, err
 		}
 		whitelist[module] = true

--- a/rpc/endpoints.go
+++ b/rpc/endpoints.go
@@ -18,6 +18,7 @@ package rpc
 
 import (
 	"net"
+	"strings"
 
 	"github.com/ethereum/go-ethereum/log"
 )
@@ -27,6 +28,29 @@ func StartHTTPEndpoint(endpoint string, apis []API, modules []string, cors []str
 	// Generate the whitelist based on the allowed modules
 	whitelist := make(map[string]bool)
 	for _, module := range modules {
+		apiExists := false
+		for _, api := range apis {
+			if module == api.Namespace {
+				apiExists = true
+				break
+			}
+		}
+		if !apiExists {
+			log.Crit("invalid api module", "module", module, "available", func() string {
+				available := []string{}
+				outer:
+				for _, api := range apis {
+					// Only include unique api names
+					for _, av := range available {
+						if av == api.Namespace {
+							continue outer
+						}
+					}
+					available = append(available, api.Namespace)
+				}
+				return strings.Join(available, ",")
+			}())
+		}
 		whitelist[module] = true
 	}
 	// Register all the APIs exposed by the services

--- a/rpc/endpoints.go
+++ b/rpc/endpoints.go
@@ -28,29 +28,25 @@ import (
 // then log.Crit is used to cause program to exit, logging the invalid module and a list of available
 // API service names.
 func mustAvailableModule(module string, apis []API) {
-	apiExists := false
 	for _, api := range apis {
 		if module == api.Namespace {
-			apiExists = true
-			break
+			return
 		}
 	}
-	if !apiExists {
-		log.Crit("invalid api module", "module", module, "available", func() string {
-			available := []string{}
-		outer:
-			for _, api := range apis {
-				// Only include unique api names
-				for _, av := range available {
-					if av == api.Namespace {
-						continue outer
-					}
+	log.Crit("invalid api module", "module", module, "available", func() string {
+		available := []string{}
+	outer:
+		for _, api := range apis {
+			// Only include unique api names
+			for _, av := range available {
+				if av == api.Namespace {
+					continue outer
 				}
-				available = append(available, api.Namespace)
 			}
-			return strings.Join(available, ",")
-		}())
-	}
+			available = append(available, api.Namespace)
+		}
+		return strings.Join(available, ",")
+	}())
 }
 
 // StartHTTPEndpoint starts the HTTP RPC endpoint, configured with cors/vhosts/modules


### PR DESCRIPTION
```text
$ geth --rpc --rpcapi foo
...
Fatal: Error starting protocol stack: invalid API "foo" in whitelist (available: admin, debug, web3, eth, txpool, personal, ethash, net, les)
```

Resubmit of #20468 
Fixes #20467