### PR TITLE
[DOCS] add note about unicode BOM in password files

### DIFF
--- a/docs/_interface/Command-Line-Options.md
+++ b/docs/_interface/Command-Line-Options.md
@@ -101,7 +101,7 @@ PERFORMANCE TUNING OPTIONS:
 
 ACCOUNT OPTIONS:
   --unlock value                      Comma separated list of accounts to unlock
-  --password value                    Password file to use for non-interactive password input.
+  --password value                    Password file to use for non-interactive password input
   --signer value                      External signer (url or path to ipc file)
   --allow-insecure-unlock             Allow insecure account unlocking when account-related RPCs are exposed by http
 

--- a/docs/_interface/Command-Line-Options.md
+++ b/docs/_interface/Command-Line-Options.md
@@ -101,7 +101,7 @@ PERFORMANCE TUNING OPTIONS:
 
 ACCOUNT OPTIONS:
   --unlock value                      Comma separated list of accounts to unlock
-  --password value                    Password file to use for non-interactive password input
+  --password value                    Password file to use for non-interactive password input. Note this will not work for password files formatted with Byte Order Marks etc. as included by default with Windows text files; see https://github.com/ethereum/go-ethereum/issues/19905 for a workaround and updates.
   --signer value                      External signer (url or path to ipc file)
   --allow-insecure-unlock             Allow insecure account unlocking when account-related RPCs are exposed by http
 

--- a/docs/_interface/Command-Line-Options.md
+++ b/docs/_interface/Command-Line-Options.md
@@ -101,7 +101,7 @@ PERFORMANCE TUNING OPTIONS:
 
 ACCOUNT OPTIONS:
   --unlock value                      Comma separated list of accounts to unlock
-  --password value                    Password file to use for non-interactive password input. Note this will not work for password files formatted with Byte Order Marks etc. as included by default with Windows text files; see https://github.com/ethereum/go-ethereum/issues/19905 for a workaround and updates.
+  --password value                    Password file to use for non-interactive password input.
   --signer value                      External signer (url or path to ipc file)
   --allow-insecure-unlock             Allow insecure account unlocking when account-related RPCs are exposed by http
 

--- a/docs/_interface/FAQ.md
+++ b/docs/_interface/FAQ.md
@@ -59,3 +59,10 @@ Not only is storing the data very suboptimal, but due to the 200 modification / 
 **A:** Unfortunately not. Doing a fast sync on an HDD will take more time than you're willing to wait with the current data schema. Even if you do wait it out, an HDD will not be able to keep up with the read/write requirements of transaction processing on mainnet.
 
 You however should be able to run a light client on an HDD with minimal impact on system resources. If you wish to run a full node however, an SSD is your only option.
+
+
+---
+
+**Q: When I try to use the --password command line flag, I get the error "Could not decrypt key with given passphrase" but the password is correct. Why does this error appear?**
+
+**A:** Especially if the password file was created on Windows, it may have a Byte Order Mark or other special encoding that the go-ethereum client doesn't currently recognize.  You can change this behavior with a PowerShell command like `echo "mypasswordhere" | out-file test.txt -encoding ASCII`.  Additional details and/or any updates on more robust handling are at https://github.com/ethereum/go-ethereum/issues/19905.

--- a/docs/_interface/FAQ.md
+++ b/docs/_interface/FAQ.md
@@ -65,4 +65,4 @@ You however should be able to run a light client on an HDD with minimal impact o
 
 **Q: When I try to use the --password command line flag, I get the error "Could not decrypt key with given passphrase" but the password is correct. Why does this error appear?**
 
-**A:** Especially if the password file was created on Windows, it may have a Byte Order Mark or other special encoding that the go-ethereum client doesn't currently recognize.  You can change this behavior with a PowerShell command like `echo "mypasswordhere" | out-file test.txt -encoding ASCII`.  Additional details and/or any updates on more robust handling are at https://github.com/ethereum/go-ethereum/issues/19905.
+**A:** Especially if the password file was created on Windows, it may have a Byte Order Mark or other special encoding that the go-ethereum client doesn't currently recognize.  You can change this behavior with a PowerShell command like `echo "mypasswordhere" | out-file test.txt -encoding ASCII`.  Additional details and/or any updates on more robust handling are at <https://github.com/ethereum/go-ethereum/issues/19905>.


### PR DESCRIPTION
This doesn't fix the underlying issue, but does make it easier to find a workaround and any indications of progress towards a more robust handling of password files.  Documentation was [requested](https://github.com/ethereum/go-ethereum/issues/19905#issuecomment-520755645) in the issue discussion.

Note: This is not against the `master` branch because that branch lacks the modified documentation files.