### PR TITLE
Add conditions for bytes32 at isPrimitiveTypeValid

### DIFF
--- a/signer/core/signed_data.go
+++ b/signer/core/signed_data.go
@@ -923,7 +923,9 @@ func isPrimitiveTypeValid(primitiveType string) bool {
 		primitiveType == "bytes30" ||
 		primitiveType == "bytes30[]" ||
 		primitiveType == "bytes31" ||
-		primitiveType == "bytes31[]" {
+		primitiveType == "bytes31[]" ||
+		primitiveType == "bytes32" ||
+		primitiveType == "bytes32[]" {
 		return true
 	}
 	if primitiveType == "int" ||


### PR DESCRIPTION
Hi,

This PR is for accepting `bytes32` of TypedData, especially TypedDataMessage in it.
I got the following error when I use `bytes32` in the message data of EIP712.
```
unknown type 'bytes32'
```
I just added `bytes32` check conditions into `isPrimitiveTypeValid`.