### PR TITLE
internal/ethapi: return non-null "number" for pending block

### DIFF
--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -642,7 +642,7 @@ func (s *PublicBlockChainAPI) GetBlockByNumber(ctx context.Context, number rpc.B
 		response, err := s.rpcMarshalBlock(block, true, fullTx)
 		if err == nil && number == rpc.PendingBlockNumber {
 			// Pending blocks need to nil out a few fields
-			for _, field := range []string{"hash", "nonce", "miner", "number"} {
+			for _, field := range []string{"hash", "nonce", "miner"} {
 				response[field] = nil
 			}
 		}


### PR DESCRIPTION
…block

Ref: https://github.com/ethereum/go-ethereum/pull/20460 

Fixes: https://github.com/ethereum/go-ethereum/issues/20587 , https://github.com/ethereum/web3.py/issues/1572 