### PR TITLE
graphql: add transaction signature values

### DIFF
--- a/graphql/graphql.go
+++ b/graphql/graphql.go
@@ -314,33 +314,33 @@ func (t *Transaction) Logs(ctx context.Context) (*[]*Log, error) {
 	return &ret, nil
 }
 
-func (t *Transaction) R(ctx context.Context) (hexutil.Big, error){
-	tx, err:= t.resolve(ctx)
-	if err!= nil || tx == nil{
+func (t *Transaction) R(ctx context.Context) (hexutil.Big, error) {
+	tx, err := t.resolve(ctx)
+	if err != nil || tx == nil {
 		return hexutil.Big{}, err
 	}
-	r,_,_ := tx.RawSignatureValues()
-	return hexutil.Big(*r),nil
+	r, _, _ := tx.RawSignatureValues()
+	return hexutil.Big(*r), nil
 }
 
-
-func (t *Transaction) S(ctx context.Context) (hexutil.Big, error){
-        tx, err:= t.resolve(ctx)
-        if err!= nil || tx == nil{
-                return hexutil.Big{}, err
-        }
-        _,s,_ := tx.RawSignatureValues()
-        return hexutil.Big(*s),nil
+func (t *Transaction) S(ctx context.Context) (hexutil.Big, error) {
+	tx, err := t.resolve(ctx)
+	if err != nil || tx == nil {
+		return hexutil.Big{}, err
+	}
+	_, s, _ := tx.RawSignatureValues()
+	return hexutil.Big(*s), nil
 }
 
-func (t *Transaction) V(ctx context.Context) (hexutil.Big, error){
-        tx, err:= t.resolve(ctx)
-        if err!= nil || tx == nil{
-                return hexutil.Big{}, err
-        }
-        _,_,v := tx.RawSignatureValues()
-        return hexutil.Big(*v),nil
+func (t *Transaction) V(ctx context.Context) (hexutil.Big, error) {
+	tx, err := t.resolve(ctx)
+	if err != nil || tx == nil {
+		return hexutil.Big{}, err
+	}
+	_, _, v := tx.RawSignatureValues()
+	return hexutil.Big(*v), nil
 }
+
 type BlockType int
 
 // Block represents an Ethereum block.

--- a/graphql/graphql.go
+++ b/graphql/graphql.go
@@ -314,6 +314,33 @@ func (t *Transaction) Logs(ctx context.Context) (*[]*Log, error) {
 	return &ret, nil
 }
 
+func (t *Transaction) R(ctx context.Context) (hexutil.Big, error){
+	tx, err:= t.resolve(ctx)
+	if err!= nil || tx == nil{
+		return hexutil.Big{}, err
+	}
+	r,_,_ := tx.RawSignatureValues()
+	return hexutil.Big(*r),nil
+}
+
+
+func (t *Transaction) S(ctx context.Context) (hexutil.Big, error){
+        tx, err:= t.resolve(ctx)
+        if err!= nil || tx == nil{
+                return hexutil.Big{}, err
+        }
+        _,s,_ := tx.RawSignatureValues()
+        return hexutil.Big(*s),nil
+}
+
+func (t *Transaction) V(ctx context.Context) (hexutil.Big, error){
+        tx, err:= t.resolve(ctx)
+        if err!= nil || tx == nil{
+                return hexutil.Big{}, err
+        }
+        _,_,v := tx.RawSignatureValues()
+        return hexutil.Big(*v),nil
+}
 type BlockType int
 
 // Block represents an Ethereum block.

--- a/graphql/graphql.go
+++ b/graphql/graphql.go
@@ -319,7 +319,7 @@ func (t *Transaction) R(ctx context.Context) (hexutil.Big, error) {
 	if err != nil || tx == nil {
 		return hexutil.Big{}, err
 	}
-	r, _, _ := tx.RawSignatureValues()
+	_, r, _ := tx.RawSignatureValues()
 	return hexutil.Big(*r), nil
 }
 
@@ -328,7 +328,7 @@ func (t *Transaction) S(ctx context.Context) (hexutil.Big, error) {
 	if err != nil || tx == nil {
 		return hexutil.Big{}, err
 	}
-	_, s, _ := tx.RawSignatureValues()
+	_, _, s := tx.RawSignatureValues()
 	return hexutil.Big(*s), nil
 }
 
@@ -337,7 +337,7 @@ func (t *Transaction) V(ctx context.Context) (hexutil.Big, error) {
 	if err != nil || tx == nil {
 		return hexutil.Big{}, err
 	}
-	_, _, v := tx.RawSignatureValues()
+	v, _, _ := tx.RawSignatureValues()
 	return hexutil.Big(*v), nil
 }
 

--- a/graphql/schema.go
+++ b/graphql/schema.go
@@ -115,6 +115,9 @@ const schema string = `
         # Logs is a list of log entries emitted by this transaction. If the
         # transaction has not yet been mined, this field will be null.
         logs: [Log!]
+	r: BigInt!
+	s: BigInt!
+	v: BigInt!
     }
 
     # BlockFilterCriteria encapsulates log filter criteria for a filter applied

--- a/graphql/schema.go
+++ b/graphql/schema.go
@@ -115,9 +115,9 @@ const schema string = `
         # Logs is a list of log entries emitted by this transaction. If the
         # transaction has not yet been mined, this field will be null.
         logs: [Log!]
-	r: BigInt!
-	s: BigInt!
-	v: BigInt!
+        r: BigInt!
+        s: BigInt!
+        v: BigInt!
     }
 
     # BlockFilterCriteria encapsulates log filter criteria for a filter applied


### PR DESCRIPTION
The feature update allows the graphql api endpoint to retrieve transaction signature R,S,V parameters. 