### PR TITLE
rpc: add error when call result parameter is not addressable

### DIFF
--- a/rpc/client.go
+++ b/rpc/client.go
@@ -277,7 +277,7 @@ func (c *Client) Call(result interface{}, method string, args ...interface{}) er
 // can also pass nil, in which case the result is ignored.
 func (c *Client) CallContext(ctx context.Context, result interface{}, method string, args ...interface{}) error {
 	if result != nil && reflect.TypeOf(result).Kind() != reflect.Ptr {
-		return fmt.Errorf("Expected nil or pointer for result, got %v", result)
+		return fmt.Errorf("call result parameter must be pointer or nil interface: %v", result)
 	}
 	msg, err := c.newMessage(method, args...)
 	if err != nil {

--- a/rpc/client.go
+++ b/rpc/client.go
@@ -276,6 +276,9 @@ func (c *Client) Call(result interface{}, method string, args ...interface{}) er
 // The result must be a pointer so that package json can unmarshal into it. You
 // can also pass nil, in which case the result is ignored.
 func (c *Client) CallContext(ctx context.Context, result interface{}, method string, args ...interface{}) error {
+	if result != nil && reflect.TypeOf(result).Kind() != reflect.Ptr {
+		return fmt.Errorf("Expected nil or pointer for result, got %v", result)
+	}
 	msg, err := c.newMessage(method, args...)
 	if err != nil {
 		return err

--- a/rpc/client_test.go
+++ b/rpc/client_test.go
@@ -49,6 +49,29 @@ func TestClientRequest(t *testing.T) {
 	}
 }
 
+func TestClientResponseType(t *testing.T) {
+	server := newTestServer()
+	defer server.Stop()
+	client := DialInProc(server)
+	defer client.Close()
+
+	if err := client.Call(nil, "test_echo", "hello", 10, &echoArgs{"world"}); err != nil {
+		t.Errorf("Passing nil as result should be fine, but got an error: %v", err)
+	}
+	var resultVar echoResult
+	if err := client.Call(&resultVar, "test_echo", "hello", 10, &echoArgs{"world"}); err != nil {
+		t.Errorf("Passing reference as result should be fine, but got an error: %v", err)
+	}
+	if resultVar.Int != 10 {
+		t.Errorf("Passing reference should work, but result is: %v", resultVar)
+	}
+	// Note: passing the var, not a ref
+	err := client.Call(resultVar, "test_echo", "hello", 10, &echoArgs{"world"})
+	if err == nil {
+		t.Error("Passing a var as result should be an error")
+	}
+}
+
 func TestClientBatchRequest(t *testing.T) {
 	server := newTestServer()
 	defer server.Stop()

--- a/rpc/client_test.go
+++ b/rpc/client_test.go
@@ -59,12 +59,6 @@ func TestClientResponseType(t *testing.T) {
 		t.Errorf("Passing nil as result should be fine, but got an error: %v", err)
 	}
 	var resultVar echoResult
-	if err := client.Call(&resultVar, "test_echo", "hello", 10, &echoArgs{"world"}); err != nil {
-		t.Errorf("Passing reference as result should be fine, but got an error: %v", err)
-	}
-	if resultVar.Int != 10 {
-		t.Errorf("Passing reference should work, but result is: %v", resultVar)
-	}
 	// Note: passing the var, not a ref
 	err := client.Call(resultVar, "test_echo", "hello", 10, &echoArgs{"world"})
 	if err == nil {


### PR DESCRIPTION
Fixes #20628 