### PR TITLE
les: log disconnect reason when light server is not synced

### DIFF
--- a/les/server_handler.go
+++ b/les/server_handler.go
@@ -128,7 +128,7 @@ func (h *serverHandler) handle(p *peer) error {
 	}
 	// Reject light clients if server is not synced.
 	if !h.synced() {
-		p.Log().Debug("Not synced Light Ethereum rejecting", p)
+		p.Log().Debug("Light server not synced, so it's rejecting client", p)
 		return p2p.DiscRequested
 	}
 	defer p.fcClient.Disconnect()

--- a/les/server_handler.go
+++ b/les/server_handler.go
@@ -128,6 +128,7 @@ func (h *serverHandler) handle(p *peer) error {
 	}
 	// Reject light clients if server is not synced.
 	if !h.synced() {
+		p.Log().Debug("Not synced Light Ethereum rejecting", p)
 		return p2p.DiscRequested
 	}
 	defer p.fcClient.Disconnect()

--- a/les/server_handler.go
+++ b/les/server_handler.go
@@ -128,7 +128,7 @@ func (h *serverHandler) handle(p *peer) error {
 	}
 	// Reject light clients if server is not synced.
 	if !h.synced() {
-		p.Log().Debug("Light server not synced, so it's rejecting client", p)
+		p.Log().Debug("Light server not synced, rejecting peer")
 		return p2p.DiscRequested
 	}
 	defer p.fcClient.Disconnect()


### PR DESCRIPTION
When the light server disconnects due to not being synced, it gives no reason for that. Provide that reason in a debug log message.