### PR TITLE
WIP: accounts/abi/bind Added Is{{.Type}} to template

### DIFF
--- a/accounts/abi/bind/base.go
+++ b/accounts/abi/bind/base.go
@@ -25,7 +25,6 @@ import (
 	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/accounts/abi"
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/event"
@@ -121,8 +120,8 @@ func DeployContract(opts *TransactOpts, abi abi.ABI, bytecode []byte, backend Co
 	return c.address, tx, c, nil
 }
 
-// CheckContract checks whether the deployed contract at the given address matches the provided binary
-func CheckContract(opts *CheckOpts, bytecode string, backend ContractBackend) (bool, error) {
+// CheckContract checks whether the deployed contract at the given address matches the provided code hash
+func CheckContract(opts *CheckOpts, codeHash string, backend ContractBackend) (bool, error) {
 	if opts == nil {
 		return false, errors.New("Invalid CheckOpts provided")
 	}
@@ -131,7 +130,8 @@ func CheckContract(opts *CheckOpts, bytecode string, backend ContractBackend) (b
 		return false, err
 	}
 
-	return bytecode == hexutil.Encode(code), nil
+	gotHash := common.Bytes2Hex(crypto.Keccak256([]byte(common.Bytes2Hex(code))))
+	return codeHash == "0x"+gotHash, nil
 }
 
 // Call invokes the (constant) contract method with params as input values and

--- a/accounts/abi/bind/bind.go
+++ b/accounts/abi/bind/bind.go
@@ -31,6 +31,8 @@ import (
 	"unicode"
 
 	"github.com/ethereum/go-ethereum/accounts/abi"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/log"
 )
 
@@ -173,10 +175,11 @@ func Bind(types []string, abis []string, bytecodes []string, fsigs []map[string]
 		inputBin := strings.TrimPrefix(strings.TrimSpace(bytecodes[i]), "0x")
 		outputBin := strings.SplitAfter(inputBin, "6080604052")
 		contracts[types[i]] = &tmplContract{
-			Type:        capitalise(types[i]),
-			InputABI:    strings.Replace(strippedABI, "\"", "\\\"", -1),
-			InputBin:    inputBin,
-			OutputBin:   outputBin[len(outputBin)-1],
+			Type:     capitalise(types[i]),
+			InputABI: strings.Replace(strippedABI, "\"", "\\\"", -1),
+			InputBin: inputBin,
+			// CodeHash is the hash of the last segment of the outputBin.
+			CodeHash:    common.Bytes2Hex(crypto.Keccak256([]byte("6080604052" + outputBin[len(outputBin)-1]))),
 			Constructor: evmABI.Constructor,
 			Calls:       calls,
 			Transacts:   transacts,

--- a/accounts/abi/bind/bind.go
+++ b/accounts/abi/bind/bind.go
@@ -170,10 +170,13 @@ func Bind(types []string, abis []string, bytecodes []string, fsigs []map[string]
 			return "", errors.New("java binding for tuple arguments is not supported yet")
 		}
 
+		inputBin := strings.TrimPrefix(strings.TrimSpace(bytecodes[i]), "0x")
+		outputBin := strings.SplitAfter(inputBin, "6080604052")
 		contracts[types[i]] = &tmplContract{
 			Type:        capitalise(types[i]),
 			InputABI:    strings.Replace(strippedABI, "\"", "\\\"", -1),
-			InputBin:    strings.TrimPrefix(strings.TrimSpace(bytecodes[i]), "0x"),
+			InputBin:    inputBin,
+			OutputBin:   outputBin[len(outputBin)-1],
 			Constructor: evmABI.Constructor,
 			Calls:       calls,
 			Transacts:   transacts,

--- a/accounts/abi/bind/bind_test.go
+++ b/accounts/abi/bind/bind_test.go
@@ -287,6 +287,7 @@ var bindTests = []struct {
 		[]string{`[{"constant":true,"inputs":[],"name":"transactString","outputs":[{"name":"","type":"string"}],"type":"function"},{"constant":true,"inputs":[],"name":"deployString","outputs":[{"name":"","type":"string"}],"type":"function"},{"constant":false,"inputs":[{"name":"str","type":"string"}],"name":"transact","outputs":[],"type":"function"},{"inputs":[{"name":"str","type":"string"}],"type":"constructor"}]`},
 		`
 			"math/big"
+			"context"
 
 			"github.com/ethereum/go-ethereum/accounts/abi/bind"
 			"github.com/ethereum/go-ethereum/accounts/abi/bind/backends"
@@ -321,6 +322,30 @@ var bindTests = []struct {
 				t.Fatalf("Failed to retrieve transact string: %v", err)
 			} else if str != "Transact string" {
 				t.Fatalf("Transact string mismatch: have '%s', want 'Transact string'", str)
+			}
+			
+			// Check that IsInteractor works 
+			addr, _, _, _ := DeployInteractor(auth, sim, "Deploy string")
+			checkopts := bind.CheckOpts{
+				Address:     addr,
+				BlockNumber: nil,
+				Context:     context.Background(),
+			}
+			is, err := IsInteractor(&checkopts, sim); 
+			if err != nil {
+				t.Fatalf("Failed to check IsInteractor: %v", err)
+			}
+			if is {
+				t.Fatalf("IsInteractor should produce false if contract is not deployed")
+			}
+			// Commit the deployment
+			sim.Commit()
+			is, err = IsInteractor(&checkopts, sim); 
+			if err != nil {
+				t.Fatalf("Failed to check IsInteractor: %v", err)
+			}
+			if !is {
+				t.Fatalf("IsInteractor should be true for a valid contract")
 			}
 		`,
 		nil,

--- a/accounts/abi/bind/template.go
+++ b/accounts/abi/bind/template.go
@@ -31,7 +31,7 @@ type tmplContract struct {
 	Type        string                 // Type name of the main contract binding
 	InputABI    string                 // JSON ABI used as the input to generate the binding from
 	InputBin    string                 // Optional EVM bytecode used to deploy code from
-	OutputBin   string                 // Optional EVM bytecode as will be produced by deploying this contract
+	CodeHash    string                 // Optional Hash of the EVM bytecode as deployed on chain
 	FuncSigs    map[string]string      // Optional map: string signature -> 4-byte signature
 	Constructor abi.Method             // Contract constructor for deploy parametrization
 	Calls       map[string]*tmplMethod // Contract calls that only read state data
@@ -153,13 +153,13 @@ var (
 		}
 	{{end}}
 
-	{{if .OutputBin}}
-		// {{.Type}}OnChainBin is the compiled bytecode of the contract as deployed on-chain.
-		var {{.Type}}OnChainBin = "0x{{.OutputBin}}"
+	{{if .CodeHash}}
+		// {{.Type}}CodeHash is the hash of the bytecode as deployed on-chain.
+		var {{.Type}}CodeHash = "0x{{.CodeHash}}"
 
 		// Is{{.Type}} checks whether a contract at this address is an instance of {{.Type}}.
 		func Is{{.Type}} (checkOpts *bind.CheckOpts, backend bind.ContractBackend) (bool, error) {
-		  return bind.CheckContract(checkOpts, {{.Type}}OnChainBin, backend)
+		  return bind.CheckContract(checkOpts, {{.Type}}CodeHash, backend)
 		}
 	{{end}}
 

--- a/accounts/abi/bind/template.go
+++ b/accounts/abi/bind/template.go
@@ -30,7 +30,8 @@ type tmplData struct {
 type tmplContract struct {
 	Type        string                 // Type name of the main contract binding
 	InputABI    string                 // JSON ABI used as the input to generate the binding from
-	InputBin    string                 // Optional EVM bytecode used to denetare deploy code from
+	InputBin    string                 // Optional EVM bytecode used to deploy code from
+	OutputBin   string                 // Optional EVM bytecode as will be produced by deploying this contract
 	FuncSigs    map[string]string      // Optional map: string signature -> 4-byte signature
 	Constructor abi.Method             // Contract constructor for deploy parametrization
 	Calls       map[string]*tmplMethod // Contract calls that only read state data
@@ -149,6 +150,16 @@ var (
 		    return common.Address{}, nil, nil, err
 		  }
 		  return address, tx, &{{.Type}}{ {{.Type}}Caller: {{.Type}}Caller{contract: contract}, {{.Type}}Transactor: {{.Type}}Transactor{contract: contract}, {{.Type}}Filterer: {{.Type}}Filterer{contract: contract} }, nil
+		}
+	{{end}}
+
+	{{if .OutputBin}}
+		// {{.Type}}OnChainBin is the compiled bytecode of the contract as deployed on-chain.
+		var {{.Type}}OnChainBin = "0x{{.OutputBin}}"
+
+		// Is{{.Type}} checks whether a contract at this address is an instance of {{.Type}}.
+		func Is{{.Type}} (checkOpts *bind.CheckOpts, backend bind.ContractBackend) (bool, error) {
+		  return bind.CheckContract(checkOpts, {{.Type}}OnChainBin, backend)
 		}
 	{{end}}
 


### PR DESCRIPTION
Now users can call IsContract() and provide a on-chain address.
Internally the code checks if the bytecode at the provided address matches the on-chain code of the contract (without the constructor code).