### PR TITLE
core/vm: use dedicated SLOAD gas constant for EIP-2200

### DIFF
--- a/core/vm/eips.go
+++ b/core/vm/eips.go
@@ -46,9 +46,9 @@ func EnableEIP(eipNum int, jt *JumpTable) error {
 // - Define SELFBALANCE, with cost GasFastStep (5)
 func enable1884(jt *JumpTable) {
 	// Gas cost changes
+	jt[SLOAD].constantGas = params.SloadGasEIP1884
 	jt[BALANCE].constantGas = params.BalanceGasEIP1884
 	jt[EXTCODEHASH].constantGas = params.ExtcodeHashGasEIP1884
-	jt[SLOAD].constantGas = params.SloadGasEIP1884
 
 	// New opcode
 	jt[SELFBALANCE] = operation{
@@ -88,6 +88,6 @@ func opChainID(pc *uint64, interpreter *EVMInterpreter, contract *Contract, memo
 
 // enable2200 applies EIP-2200 (Rebalance net-metered SSTORE)
 func enable2200(jt *JumpTable) {
-	jt[SLOAD].constantGas = params.SloadGasEIP1884
+	jt[SLOAD].constantGas = params.SloadGasEIP2200
 	jt[SSTORE].dynamicGas = gasSStoreEIP2200
 }

--- a/core/vm/eips.go
+++ b/core/vm/eips.go
@@ -88,5 +88,6 @@ func opChainID(pc *uint64, interpreter *EVMInterpreter, contract *Contract, memo
 
 // enable2200 applies EIP-2200 (Rebalance net-metered SSTORE)
 func enable2200(jt *JumpTable) {
+	jt[SLOAD].constantGas = params.SloadGasEIP1884
 	jt[SSTORE].dynamicGas = gasSStoreEIP2200
 }

--- a/params/protocol_params.go
+++ b/params/protocol_params.go
@@ -90,7 +90,7 @@ const (
 	SloadGasFrontier             uint64 = 50
 	SloadGasEIP150               uint64 = 200
 	SloadGasEIP1884              uint64 = 800  // Cost of SLOAD after EIP 1884 (part of Istanbul)
-    SloadGasEIP2200              uint64 = 800  // Cost of SLOAD after EIP 2200 (part of Istanbul)
+	SloadGasEIP2200              uint64 = 800  // Cost of SLOAD after EIP 2200 (part of Istanbul)
 	ExtcodeHashGasConstantinople uint64 = 400  // Cost of EXTCODEHASH (introduced in Constantinople)
 	ExtcodeHashGasEIP1884        uint64 = 700  // Cost of EXTCODEHASH after EIP 1884 (part in Istanbul)
 	SelfdestructGasEIP150        uint64 = 5000 // Cost of SELFDESTRUCT post EIP 150 (Tangerine)

--- a/params/protocol_params.go
+++ b/params/protocol_params.go
@@ -90,6 +90,7 @@ const (
 	SloadGasFrontier             uint64 = 50
 	SloadGasEIP150               uint64 = 200
 	SloadGasEIP1884              uint64 = 800  // Cost of SLOAD after EIP 1884 (part of Istanbul)
+    SloadGasEIP2200              uint64 = 800  // Cost of SLOAD after EIP 2200 (part of Istanbul)
 	ExtcodeHashGasConstantinople uint64 = 400  // Cost of EXTCODEHASH (introduced in Constantinople)
 	ExtcodeHashGasEIP1884        uint64 = 700  // Cost of EXTCODEHASH after EIP 1884 (part in Istanbul)
 	SelfdestructGasEIP150        uint64 = 5000 // Cost of SELFDESTRUCT post EIP 150 (Tangerine)


### PR DESCRIPTION
I was doing some bench marking and analysis surrounding some of the recent EIPs. While tinkering with EIP-1884 I accidentally created a split on a private network between Parity, Besu and Geth, where Parity and Geth forked together with SLOAD_GAS of 200 rather than 800. After investigating, I discovered that EIP-2200 was "technically" incorrectly implemented.

EIP-1884 and EIP-2200 both adjust `SLOAD_GAS` from `200` to `800` - but the current implementation of EIP-2200 assumes that  EIP-1884 is already implemented, and only adjusts `SSTORE`.

This PR adds the EIP-1884 `SLOAD_GAS` changes to EIP-2200.

There is a [Sibling PR](https://github.com/paritytech/parity-ethereum/pull/11474) in Parity