### PR TITLE
eth/downloader: fix possible data race caused by inconsistent field protection

### DIFF
--- a/eth/downloader/peer.go
+++ b/eth/downloader/peer.go
@@ -226,6 +226,8 @@ func (p *peerConnection) FetchNodeData(hashes []common.Hash) error {
 // requests. Its estimated header retrieval throughput is updated with that measured
 // just now.
 func (p *peerConnection) SetHeadersIdle(delivered int) {
+	p.lock.Lock()
+	defer p.lock.Unlock()
 	p.setIdle(p.headerStarted, delivered, &p.headerThroughput, &p.headerIdle)
 }
 
@@ -233,6 +235,8 @@ func (p *peerConnection) SetHeadersIdle(delivered int) {
 // requests. Its estimated body retrieval throughput is updated with that measured
 // just now.
 func (p *peerConnection) SetBodiesIdle(delivered int) {
+	p.lock.Lock()
+	defer p.lock.Unlock()
 	p.setIdle(p.blockStarted, delivered, &p.blockThroughput, &p.blockIdle)
 }
 
@@ -240,6 +244,8 @@ func (p *peerConnection) SetBodiesIdle(delivered int) {
 // retrieval requests. Its estimated receipt retrieval throughput is updated
 // with that measured just now.
 func (p *peerConnection) SetReceiptsIdle(delivered int) {
+	p.lock.Lock()
+	defer p.lock.Unlock()
 	p.setIdle(p.receiptStarted, delivered, &p.receiptThroughput, &p.receiptIdle)
 }
 
@@ -247,6 +253,8 @@ func (p *peerConnection) SetReceiptsIdle(delivered int) {
 // data retrieval requests. Its estimated state retrieval throughput is updated
 // with that measured just now.
 func (p *peerConnection) SetNodeDataIdle(delivered int) {
+	p.lock.Lock()
+	defer p.lock.Unlock()
 	p.setIdle(p.stateStarted, delivered, &p.stateThroughput, &p.stateIdle)
 }
 
@@ -255,9 +263,6 @@ func (p *peerConnection) SetNodeDataIdle(delivered int) {
 func (p *peerConnection) setIdle(started time.Time, delivered int, throughput *float64, idle *int32) {
 	// Irrelevant of the scaling, make sure the peer ends up idle
 	defer atomic.StoreInt32(idle, 0)
-
-	p.lock.Lock()
-	defer p.lock.Unlock()
 
 	// If nothing was delivered (hard timeout / unavailable data), reduce throughput to minimum
 	if delivered == 0 {

--- a/eth/downloader/queue.go
+++ b/eth/downloader/queue.go
@@ -564,26 +564,29 @@ func (q *queue) reserveHeaders(p *peerConnection, count int, taskPool map[common
 
 // CancelHeaders aborts a fetch request, returning all pending skeleton indexes to the queue.
 func (q *queue) CancelHeaders(request *fetchRequest) {
+	q.lock.Lock()
+	defer q.lock.Unlock()
 	q.cancel(request, q.headerTaskQueue, q.headerPendPool)
 }
 
 // CancelBodies aborts a body fetch request, returning all pending headers to the
 // task queue.
 func (q *queue) CancelBodies(request *fetchRequest) {
+	q.lock.Lock()
+	defer q.lock.Unlock()
 	q.cancel(request, q.blockTaskQueue, q.blockPendPool)
 }
 
 // CancelReceipts aborts a body fetch request, returning all pending headers to
 // the task queue.
 func (q *queue) CancelReceipts(request *fetchRequest) {
+	q.lock.Lock()
+	defer q.lock.Unlock()
 	q.cancel(request, q.receiptTaskQueue, q.receiptPendPool)
 }
 
 // Cancel aborts a fetch request, returning all pending hashes to the task queue.
 func (q *queue) cancel(request *fetchRequest, taskQueue *prque.Prque, pendPool map[string]*fetchRequest) {
-	q.lock.Lock()
-	defer q.lock.Unlock()
-
 	if request.From > 0 {
 		taskQueue.Push(request.From, -int64(request.From))
 	}


### PR DESCRIPTION
Fixed inconsistency and also potential data race in eth/downloader/peer.go and eth/downloader/queue.go:
e.g. In eth/downloader/queue.go:
`q.receiptPendPool` is read/written 10 times; 9 out of 10 times it is protected by q.lock.Lock(); 1 out of 10 times it is read without a Lock, which is in func CancelReceipts() on L579.
A data race may happen when `CancelReceipts()` and other func like `Revoke()` are called in parallel.
The fix is to move lock from func `cancel()` to its caller `CancelReceipts()`.
The other bugs and fixes are similar.
