### PR TITLE
core/bloombits: fix possible data race caused by inconsistent field protection

### DIFF
--- a/core/bloombits/scheduler.go
+++ b/core/bloombits/scheduler.go
@@ -150,6 +150,7 @@ func (s *scheduler) scheduleDeliveries(pend chan uint64, done chan []byte, quit 
 			// Wait until the request is honoured
 			s.lock.Lock()
 			res := s.responses[idx]
+			cached := res.cached
 			s.lock.Unlock()
 
 			select {
@@ -161,7 +162,7 @@ func (s *scheduler) scheduleDeliveries(pend chan uint64, done chan []byte, quit 
 			select {
 			case <-quit:
 				return
-			case done <- res.cached:
+			case done <- cached:
 			}
 		}
 	}


### PR DESCRIPTION
Fixed inconsistency and also potential data race in core/bloombits/scheduler.go:
`res.cached` is read/written 4 times; 3 out of 4 times it is protected by `s.lock.Lock()`; 1 out of 4 times it is read without a Lock, which is in func `scheduleDeliveries()` on L164.
A data race may happen when `scheduleDeliveries()` and other func like `reset()` are called in parallel.
I think the usage of `res` is not well protected by the lock in `scheduleDeliveries()`. I wonder if we should also protect `res.done`.