### PR TITLE
event: add missing unlock before panic

### DIFF
--- a/event/feed.go
+++ b/event/feed.go
@@ -138,6 +138,7 @@ func (f *Feed) Send(value interface{}) (nsent int) {
 
 	if !f.typecheck(rvalue.Type()) {
 		f.sendLock <- struct{}{}
+		f.mu.Unlock()
 		panic(feedTypeError{op: "Send", got: rvalue.Type(), want: f.etype})
 	}
 	f.mu.Unlock()


### PR DESCRIPTION
In event/feed.go,
func `Send()`, `f.mu.Lock()` is on L135,
and `f.mu.Unlock()` is on L143.
However, there is a panic on L141.
If the panic is executed, f.mu will still be locked even after recovery.
The fix is to add `f.mu.Unlock()` before panic.