### PR TITLE
core, light: add unlock before Reset to avoid double lock

### DIFF
--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -329,6 +329,8 @@ func (bc *BlockChain) loadLastState() error {
 	if head == (common.Hash{}) {
 		// Corrupt or empty database, init from scratch
 		log.Warn("Empty database, resetting chain")
+		bc.chainmu.Unlock()
+		defer bc.chainmu.Lock()
 		return bc.Reset()
 	}
 	// Make sure the entire head block is available
@@ -336,6 +338,8 @@ func (bc *BlockChain) loadLastState() error {
 	if currentBlock == nil {
 		// Corrupt or empty database, init from scratch
 		log.Warn("Head block missing, resetting chain", "hash", head)
+		bc.chainmu.Unlock()
+		defer bc.chainmu.Lock()
 		return bc.Reset()
 	}
 	// Make sure the state associated with the block is available

--- a/light/lightchain.go
+++ b/light/lightchain.go
@@ -153,7 +153,9 @@ func (lc *LightChain) HeaderChain() *core.HeaderChain {
 func (lc *LightChain) loadLastState() error {
 	if head := rawdb.ReadHeadHeaderHash(lc.chainDb); head == (common.Hash{}) {
 		// Corrupt or empty database, init from scratch
+		lc.chainmu.Unlock()
 		lc.Reset()
+		lc.chainmu.Lock()
 	} else {
 		if header := lc.GetHeaderByHash(head); header != nil {
 			lc.hc.SetCurrentHeader(header)


### PR DESCRIPTION
In core/blockchain.go: 
The first lock is in func `SetHead()`, the second lock is in func `Reset()`.
https://github.com/ethereum/go-ethereum/blob/8045504abf64a865be4b1dbc780b796a9f5d11cc/core/blockchain.go#L394
https://github.com/ethereum/go-ethereum/blob/8045504abf64a865be4b1dbc780b796a9f5d11cc/core/blockchain.go#L469
https://github.com/ethereum/go-ethereum/blob/8045504abf64a865be4b1dbc780b796a9f5d11cc/core/blockchain.go#L332
https://github.com/ethereum/go-ethereum/blob/8045504abf64a865be4b1dbc780b796a9f5d11cc/core/blockchain.go#L536-L538
https://github.com/ethereum/go-ethereum/blob/8045504abf64a865be4b1dbc780b796a9f5d11cc/core/blockchain.go#L542-L548
In `ResetWithGenesisBlock()`, the recursively called `SetHead()` contains the second lock.
`ResetWithGenesisBlock()` itself also directly calls the second lock.
My original fix is to add unlock before `Reset()`. But this may introduce atomicity violations. And developers think this is too risky.
So I decide to add No-Lock version resetWithGenesisBlockNoLock() and setHeadNoLock() and replace the original version in `SetHead()`.

Similar bugs and fix apply to light/lightchain.go