### PR TITLE
accounts: add walletsNoLock to avoid double read lock

### DIFF
--- a/accounts/manager.go
+++ b/accounts/manager.go
@@ -144,7 +144,7 @@ func (am *Manager) Wallets() []Wallet {
 	return am.walletsNoLock()
 }
 
-// Wallets without lock.
+// walletsNoLock returns all registered wallets. Callers must hold am.lock.
 func (am *Manager) walletsNoLock() []Wallet {
 	cpy := make([]Wallet, len(am.wallets))
 	copy(cpy, am.wallets)

--- a/accounts/manager.go
+++ b/accounts/manager.go
@@ -141,6 +141,11 @@ func (am *Manager) Wallets() []Wallet {
 	am.lock.RLock()
 	defer am.lock.RUnlock()
 
+	return am.walletsNoLock()
+}
+
+// Wallets without lock.
+func (am *Manager) walletsNoLock() []Wallet {
 	cpy := make([]Wallet, len(am.wallets))
 	copy(cpy, am.wallets)
 	return cpy
@@ -155,7 +160,7 @@ func (am *Manager) Wallet(url string) (Wallet, error) {
 	if err != nil {
 		return nil, err
 	}
-	for _, wallet := range am.Wallets() {
+	for _, wallet := range am.walletsNoLock() {
 		if wallet.URL() == parsed {
 			return wallet, nil
 		}


### PR DESCRIPTION
As the [https://golang.org/pkg/sync/](https://golang.org/pkg/sync/) says about RLock:
`It should not be used for recursive read locking; a blocked Lock call excludes new readers from acquiring the lock.`
So double read lock should also be avoided.
The first RLock is `am.lock.RLock()` in func `Wallet()`, the second RLock is in its callee func `Wallets()`.
The fix is to add a new func `walletsNoLock()` and let `Wallet()` and `Wallets()` call it.