### PR TITLE
event, p2p/simulations/adapters: use buffered channel to avoid goroutine leak

### DIFF
--- a/event/subscription.go
+++ b/event/subscription.go
@@ -143,7 +143,7 @@ func (s *resubscribeSub) loop() {
 }
 
 func (s *resubscribeSub) subscribe() Subscription {
-	subscribed := make(chan error)
+	subscribed := make(chan error, 1)
 	var sub Subscription
 retry:
 	for {

--- a/event/subscription.go
+++ b/event/subscription.go
@@ -143,9 +143,8 @@ func (s *resubscribeSub) loop() {
 }
 
 func (s *resubscribeSub) subscribe() Subscription {
-	subscribed := make(chan error, 1)
+	subscribed := make(chan error)
 	var sub Subscription
-retry:
 	for {
 		s.lastTry = mclock.Now()
 		ctx, cancel := context.WithCancel(context.Background())
@@ -157,19 +156,19 @@ retry:
 		select {
 		case err := <-subscribed:
 			cancel()
-			if err != nil {
-				// Subscribing failed, wait before launching the next try.
-				if s.backoffWait() {
-					return nil
+			if err == nil {
+				if sub == nil {
+					panic("event: ResubscribeFunc returned nil subscription and no error")
 				}
-				continue retry
+				return sub
 			}
-			if sub == nil {
-				panic("event: ResubscribeFunc returned nil subscription and no error")
+			// Subscribing failed, wait before launching the next try.
+			if s.backoffWait() {
+				return nil // unsubscribed during wait
 			}
-			return sub
 		case <-s.unsub:
 			cancel()
+			<-subscribed // avoid leaking the s.fn goroutine.
 			return nil
 		}
 	}

--- a/event/subscription_test.go
+++ b/event/subscription_test.go
@@ -102,7 +102,7 @@ func TestResubscribe(t *testing.T) {
 func TestResubscribeAbort(t *testing.T) {
 	t.Parallel()
 
-	done := make(chan error)
+	done := make(chan error, 1)
 	sub := Resubscribe(0, func(ctx context.Context) (Subscription, error) {
 		select {
 		case <-ctx.Done():

--- a/p2p/simulations/adapters/exec.go
+++ b/p2p/simulations/adapters/exec.go
@@ -287,7 +287,7 @@ func (n *ExecNode) Stop() error {
 	if err := n.Cmd.Process.Signal(syscall.SIGTERM); err != nil {
 		return n.Cmd.Process.Kill()
 	}
-	waitErr := make(chan error)
+	waitErr := make(chan error, 1)
 	go func() {
 		waitErr <- n.Cmd.Wait()
 	}()


### PR DESCRIPTION
`subscribe()` in event/subscribe.go and `Stop()` in p2p/simulations/adapters/exec.go share a same problem:  some goroutines in these functions will be leaked in certain cases (unsub for `subscribe()`, and timeout for `Stop()`).
In `subscribe()`, the send operation `subscribed <- err` on L115 will be blocked forever when `unsub` is selected. Thus the child goroutine leaks and always occupies the memory.
Adding one buffer to the channel will make the send operation never block the child goroutine,
and it will not change semantic.
The same is true for `Stop()`.
In `Stop()`, although `Kill()` is called on timeout,
I am not sure if the child goroutine will be in the same process or not. Here is the annotation of `Kill()`, in /os/exec.go:
```
// Kill causes the Process to exit immediately. Kill does not wait until
// the Process has actually exited. This only kills the Process itself,
// not any other processes it may have started.
func (p *Process) Kill() error {
    return p.kill()
}
```
