### PR TITLE
cmd/puppeth: add flags to support non-interactive genesis.json creation

### DIFF
--- a/cmd/puppeth/puppeth.go
+++ b/cmd/puppeth/puppeth.go
@@ -89,7 +89,7 @@ func runWizard(c *cli.Context) error {
 	blocksTime := uint64(c.Int("blocksTime"))
 	sealAccounts := c.String("sealAccounts")
 	preFundedAccounts := c.String("preFundedAccounts")
-        preCmpAddOneWei := c.String("preCmpAddressWithOneWei")
+	preCmpAddOneWei := c.String("preCmpAddressWithOneWei")
 	networkID := c.Uint64("networkID")
 
 	nonInteract := network != "" && consensusType != "" && blocksTime > 0 && sealAccounts != "" && preFundedAccounts != "" && preCmpAddOneWei != "" &&  networkID > 0

--- a/cmd/puppeth/puppeth.go
+++ b/cmd/puppeth/puppeth.go
@@ -42,6 +42,31 @@ func main() {
 			Value: 3,
 			Usage: "log level to emit to the screen",
 		},
+		cli.StringFlag{
+			Name:  "consensusType",
+			Usage: "Which consensus engine to use? (default = null)\n \t\t1. Ethash - proof-of-work\n \t\t2. Clique - proof-of-authority",
+		},
+		cli.IntFlag{
+			Name:  "blocksTime",
+			Usage: "log level to emit to the screen",
+		},
+		cli.StringFlag{
+			Name:  "sealAccounts",
+			Usage: "Which accounts are allowed to seal? (mandatory at least one)",
+		},
+		cli.StringFlag{
+			Name:  "preFundedAccounts",
+			Usage: "Which accounts should be pre-funded? (advisable at least one)",
+		},
+		cli.StringFlag{
+			Name:  "preCmpAddressWithOneWei",
+			Usage: "Should the precompile-addresses (0x1 .. 0xff) be pre-funded with 1 wei?",
+		},
+		cli.Uint64Flag{
+			Name:  "networkID",
+			Value: 0,
+			Usage: "Specify your chain/network ID if you want an explicit one (default = random)",
+		},
 	}
 	app.Before = func(c *cli.Context) error {
 		// Set up the logger to print everything and the random generator
@@ -60,6 +85,15 @@ func runWizard(c *cli.Context) error {
 	if strings.Contains(network, " ") || strings.Contains(network, "-") || strings.ToLower(network) != network {
 		log.Crit("No spaces, hyphens or capital letters allowed in network name")
 	}
-	makeWizard(c.String("network")).run()
+	consensusType := c.String("consensusType")
+	blocksTime := uint64(c.Int("blocksTime"))
+	sealAccounts := c.String("sealAccounts")
+	preFundedAccounts := c.String("preFundedAccounts")
+        preCmpAddOneWei := c.String("preCmpAddressWithOneWei")
+	networkID := c.Uint64("networkID")
+
+	nonInteract := network != "" && consensusType != "" && blocksTime > 0 && sealAccounts != "" && preFundedAccounts != "" && preCmpAddOneWei != "" &&  networkID > 0
+
+	makeWizard(network, consensusType, blocksTime, sealAccounts, preFundedAccounts, preCmpAddOneWei, networkID, nonInteract).run()
 	return nil
 }

--- a/cmd/puppeth/wizard.go
+++ b/cmd/puppeth/wizard.go
@@ -79,7 +79,7 @@ type wizard struct {
 	in   *bufio.Reader // Wrapper around stdin to allow reading user input
 	lock sync.Mutex    // Lock to protect configs during concurrent service discovery
 	consensusType	string
-        blocksTime	uint64
+	blocksTime	uint64
 	sealAccounts	string
 	preFundedAccounts	string
 	preCmpAddOneWei		string

--- a/cmd/puppeth/wizard_genesis.go
+++ b/cmd/puppeth/wizard_genesis.go
@@ -64,7 +64,7 @@ func (w *wizard) makeGenesis() {
 	if w.consensusType != "" {
 		choice = w.consensusType
 		fmt.Println(w.consensusType)
-	}else{
+	} else {
 		choice = w.read()
 	}
 	switch {
@@ -84,7 +84,7 @@ func (w *wizard) makeGenesis() {
 		fmt.Println("How many seconds should blocks take? (default = 15)")
 		if w.blocksTime > 0 {
 			genesis.Config.Clique.Period = w.blocksTime
-		}else{
+		} else {
 			genesis.Config.Clique.Period = uint64(w.readDefaultInt(15))
 		}
 
@@ -133,7 +133,7 @@ func (w *wizard) makeGenesis() {
 				}
 				continue
 			}
-	}else{
+	} else {
 		for {
 			// Read the address of the account to fund
 			if address := w.readAddress(); address != nil {


### PR DESCRIPTION
Add some parameters for puppeth to support non-interactive mode when we want a genesis.json 
usage:
puppeth --consensusType 2 --network test12 --blocksTime 10 --sealAccounts "25Cde39d96684E2a681Ae0289b37AF8E9859ed99, 25Cde39d96684E2a681Ae0289b37AF8E9859ed98, 25Cde39d96684E2a681Ae0289b37AF8E9859ed99" --preFundedAccounts "25Cde39d96684E2a681Ae0289b37AF8E9859ed99, 25Cde39d96684E2a681Ae0289b37AF8E9859ed98, " --networkID 231 --preCmpAddressWithOneWei true