### PR TITLE
node: add log message when boot is aborted

### DIFF
--- a/node/node.go
+++ b/node/node.go
@@ -241,6 +241,7 @@ func (n *Node) Start() error {
 			service.Stop()
 		}
 		running.Stop()
+		n.log.Error("Aborting startup", "error", err)
 		return err
 	}
 	// Finish initializing the startup


### PR DESCRIPTION
This PR adds a diagnostic log message to figure out why #20642 doesn't work. 

```
[user@work go-ethereum]$ ./build/bin/geth --rpc --rpcapi foo,baz
...
ERROR[02-13|10:33:47.837] Failed to enumerate USB devices          hub=trezor vendor=4617  failcount=3 err="failed to initialize libusb: libusb: unknown error [code -99]"
ERROR[02-13|10:33:47.837] Failed to enumerate USB devices          hub=trezor vendor=21324 failcount=3 err="failed to initialize libusb: libusb: unknown error [code -99]"
ERROR[02-13|10:33:49.237] Aborting startup                         error="invalid API \"foo\" in whitelist (available: admin, debug, web3, eth, txpool, personal, ethash, miner, net)"
```