### PR TITLE
all: fix goroutine leaks in unit tests by adding 1-elem channel buffer

### DIFF
--- a/common/mclock/simclock_test.go
+++ b/common/mclock/simclock_test.go
@@ -96,7 +96,7 @@ func TestSimulatedSleep(t *testing.T) {
 	var (
 		c       Simulated
 		timeout = 1 * time.Hour
-		done    = make(chan AbsTime)
+		done    = make(chan AbsTime, 1)
 	)
 	go func() {
 		c.Sleep(timeout)

--- a/eth/handler_test.go
+++ b/eth/handler_test.go
@@ -677,7 +677,7 @@ func TestBroadcastMalformedBlock(t *testing.T) {
 	malformedEverything.TxHash[0]++
 
 	// Keep listening to broadcasts and notify if any arrives
-	notify := make(chan struct{})
+	notify := make(chan struct{}, 1)
 	go func() {
 		if _, err := sink.app.ReadMsg(); err == nil {
 			notify <- struct{}{}

--- a/p2p/server_test.go
+++ b/p2p/server_test.go
@@ -131,7 +131,7 @@ func TestServerDial(t *testing.T) {
 		t.Fatalf("could not setup listener: %v", err)
 	}
 	defer listener.Close()
-	accepted := make(chan net.Conn)
+	accepted := make(chan net.Conn, 1)
 	go func() {
 		conn, err := listener.Accept()
 		if err != nil {
@@ -670,7 +670,7 @@ func TestServerInboundThrottle(t *testing.T) {
 	conn.Close()
 
 	// Dial again. This time the server should close the connection immediately.
-	connClosed := make(chan struct{})
+	connClosed := make(chan struct{}, 1)
 	conn, err = net.DialTimeout("tcp", srv.ListenAddr, timeout)
 	if err != nil {
 		t.Fatalf("could not dial: %v", err)

--- a/rpc/client_test.go
+++ b/rpc/client_test.go
@@ -297,7 +297,7 @@ func TestClientSubscribeClose(t *testing.T) {
 
 	var (
 		nc   = make(chan int)
-		errc = make(chan error)
+		errc = make(chan error, 1)
 		sub  *ClientSubscription
 		err  error
 	)


### PR DESCRIPTION
In server_test.go,
Goroutine may leak because sending to `accept` is blocked on L141 when `select` on L156 selects timeout on L204. Although `t.Error()` is called in this case, it won't stop the leaking, because "[Calling FailNow does not stop those other goroutines.](https://golang.org/pkg/testing/#T.FailNow)". The fix is to replace the unbuffered channel with a buffered channel (buffer size 1), and the semantic is not changed.
There are 5 bugs following the same pattern and fix in #20663.