### PR TITLE
core: test.Fatal() can only be used in test goroutine instead of its child

### DIFF
--- a/core/blockchain_test.go
+++ b/core/blockchain_test.go
@@ -993,14 +993,27 @@ func TestLogRebirth(t *testing.T) {
 		signer      = types.NewEIP155Signer(gspec.Config.ChainID)
 		newLogCh    = make(chan bool)
 		removeLogCh = make(chan bool)
+		errMsgCh    = make(chan string, 5) // Receive error message from validateLogEvent
 	)
+
+	defer func() {
+		n := 5 // 5 is the number of times validateLogEvent is used to create new goroutines
+		for i := 0; i < n; i++ {
+			if msg := <-errMsgCh; msg != "" {
+				t.Fatal(msg)
+			}
+		}
+	}()
 
 	// validateLogEvent checks whether the received logs number is equal with expected.
 	validateLogEvent := func(sink interface{}, result chan bool, expect int) {
 		chanval := reflect.ValueOf(sink)
 		chantyp := chanval.Type()
 		if chantyp.Kind() != reflect.Chan || chantyp.ChanDir()&reflect.RecvDir == 0 {
-			t.Fatalf("invalid channel, given type %v", chantyp)
+			errMsgCh <- fmt.Sprintf("invalid channel, given type %v", chantyp)
+			return
+		} else {
+			errMsgCh <- ""
 		}
 		cnt := 0
 		var recv []reflect.Value


### PR DESCRIPTION
`testing.Fatal()/FailNow()/SkipNow()/...` can only be used in test goroutine.
`t.Fatal()/Fatalf()/FailNow()` "[must be called from the goroutine running the test or benchmark function, not from other goroutines created during the test.](https://golang.org/pkg/testing/#T.FailNow)"
The fix adds a channel receiving err message from child goroutine `validateLogEvent()` and only calls `Fatal()` in test goroutine. Note that 5 is the number of the `go validateLogEvent(...)` in this test function.