### PR TITLE
cmd/faucet: protect f.reqs with Rlock to prevent data race

### DIFF
--- a/cmd/faucet/faucet.go
+++ b/cmd/faucet/faucet.go
@@ -360,6 +360,7 @@ func (f *faucet) apiHandler(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 	// Send over the initial stats and the latest header
+	f.lock.RLock()
 	if err = send(conn, map[string]interface{}{
 		"funds":    new(big.Int).Div(balance, ether),
 		"funded":   nonce,
@@ -367,8 +368,10 @@ func (f *faucet) apiHandler(w http.ResponseWriter, r *http.Request) {
 		"requests": f.reqs,
 	}, 3*time.Second); err != nil {
 		log.Warn("Failed to send initial stats to client", "err", err)
+		f.lock.RUnlock()
 		return
 	}
+	f.lock.RUnlock()
 	if err = send(conn, head, 3*time.Second); err != nil {
 		log.Warn("Failed to send initial header to client", "err", err)
 		return

--- a/cmd/faucet/faucet.go
+++ b/cmd/faucet/faucet.go
@@ -361,17 +361,17 @@ func (f *faucet) apiHandler(w http.ResponseWriter, r *http.Request) {
 	}
 	// Send over the initial stats and the latest header
 	f.lock.RLock()
+	reqs := f.reqs
+	f.lock.RUnlock()
 	if err = send(conn, map[string]interface{}{
 		"funds":    new(big.Int).Div(balance, ether),
 		"funded":   nonce,
 		"peers":    f.stack.Server().PeerCount(),
-		"requests": f.reqs,
+		"requests": reqs,
 	}, 3*time.Second); err != nil {
 		log.Warn("Failed to send initial stats to client", "err", err)
-		f.lock.RUnlock()
 		return
 	}
-	f.lock.RUnlock()
 	if err = send(conn, head, 3*time.Second); err != nil {
 		log.Warn("Failed to send initial header to client", "err", err)
 		return


### PR DESCRIPTION
In cmd/faucet/faucet.go,
`f.reqs` is protected by `f.lock.Lock()` or `f.lock.Rlock()` at five places.
The only place where it is not protected is on L367 in func `apiHandler()`.
This may cause data race when `apiHandler()` and other func like `refresh()` where `f.reqs` is written to are called in parallel.
The fix is to use `f.lock.Rlock()` to protect `f.reqs`.
