### PR TITLE
eth: don't enforce minimum broadcast, fix broadcast test

### DIFF
--- a/eth/handler.go
+++ b/eth/handler.go
@@ -50,9 +50,6 @@ const (
 	// txChanSize is the size of channel listening to NewTxsEvent.
 	// The number is referenced from the size of tx pool.
 	txChanSize = 4096
-
-	// minimim number of peers to broadcast entire blocks and transactions too.
-	minBroadcastPeers = 4
 )
 
 var (
@@ -830,14 +827,7 @@ func (pm *ProtocolManager) BroadcastBlock(block *types.Block, propagate bool) {
 			return
 		}
 		// Send the block to a subset of our peers
-		transferLen := int(math.Sqrt(float64(len(peers))))
-		if transferLen < minBroadcastPeers {
-			transferLen = minBroadcastPeers
-		}
-		if transferLen > len(peers) {
-			transferLen = len(peers)
-		}
-		transfer := peers[:transferLen]
+		transfer := peers[:int(math.Sqrt(float64(len(peers))))]
 		for _, peer := range transfer {
 			peer.AsyncSendNewBlock(block, td)
 		}
@@ -866,14 +856,7 @@ func (pm *ProtocolManager) BroadcastTransactions(txs types.Transactions, propaga
 			peers := pm.peers.PeersWithoutTx(tx.Hash())
 
 			// Send the block to a subset of our peers
-			transferLen := int(math.Sqrt(float64(len(peers))))
-			if transferLen < minBroadcastPeers {
-				transferLen = minBroadcastPeers
-			}
-			if transferLen > len(peers) {
-				transferLen = len(peers)
-			}
-			transfer := peers[:transferLen]
+			transfer := peers[:int(math.Sqrt(float64(len(peers))))]
 			for _, peer := range transfer {
 				txset[peer] = append(txset[peer], tx.Hash())
 			}


### PR DESCRIPTION
Currently we always propagate a block/transaction to at least 4 peers, even if the square root is less (e.g. if I have 5 peers, I will propagate to 4, not just to 2). As far as I know this was added when there was no announcement mechanism at all (i.e. eth/60).

I think this is misguided:

 * If a node is so unhealthy that it barely has a few connections, there's no point in pushing even more load onto it.
   * Every node will surely broadcast to at least 1 more peer (`sqrt(whatever_gt_1) >= 1`) and the announces will cover any gaps for super degenerate topologies.
 * If a node is healthy, it will **always** happen (when broadcast saturates the network) that most of its peers already sent it a block/tx, so `PeersWithoutBlock` and `PeersWithoutTx` will return a small subset of peers. With the enforced 4 peer propagation, the node will send the block/tx forward to 4 further peers, even if 46 out of 50 peers already know of it, which is pointless.
   * Announces should handle degenerate connections, everything else can still be saturated with `sqrt(whatever)` (since `sqrt(whatever_gt_1) >= 1`, so we will always send the block in its entirety to at least one peer).

The PR also reduces the test time of the BroadcastTest from 18 seconds to 1.