### PR TITLE
cmd/ethkey: speed up test by using weaker scrypt parameters

### DIFF
--- a/cmd/ethkey/generate.go
+++ b/cmd/ethkey/generate.go
@@ -52,6 +52,10 @@ If you want to encrypt an existing private key, it can be specified by setting
 			Name:  "privatekey",
 			Usage: "file containing a raw private key to encrypt",
 		},
+		cli.BoolFlag{
+			Name:  "lightkdf",
+			Usage: "use less secure scrypt parameters",
+		},
 	},
 	Action: func(ctx *cli.Context) error {
 		// Check if keyfile path given and make sure it doesn't already exist.
@@ -91,7 +95,11 @@ If you want to encrypt an existing private key, it can be specified by setting
 
 		// Encrypt key with passphrase.
 		passphrase := promptPassphrase(true)
-		keyjson, err := keystore.EncryptKey(key, passphrase, keystore.StandardScryptN, keystore.StandardScryptP)
+		scryptN, scryptP := keystore.StandardScryptN, keystore.StandardScryptP
+		if ctx.Bool("lightkdf") {
+			scryptN, scryptP = keystore.LightScryptN, keystore.LightScryptP
+		}
+		keyjson, err := keystore.EncryptKey(key, passphrase, scryptN, scryptP)
 		if err != nil {
 			utils.Fatalf("Error encrypting key: %v", err)
 		}

--- a/cmd/ethkey/message_test.go
+++ b/cmd/ethkey/message_test.go
@@ -34,7 +34,7 @@ func TestMessageSignVerify(t *testing.T) {
 	message := "test message"
 
 	// Create the key.
-	generate := runEthkey(t, "generate", keyfile)
+	generate := runEthkey(t, "generate", "--lightkdf", keyfile)
 	generate.Expect(`
 !! Unsupported terminal, password will be echoed.
 Password: {{.InputLine "foobar"}}


### PR DESCRIPTION
This fixes occasional failures of the test under heavy load, i.e. when running many tests in parallel.

Before:

```
=== RUN   TestMessageSignVerify
--- PASS: TestMessageSignVerify (2.78s)
```

After:

```
=== RUN   TestMessageSignVerify
--- PASS: TestMessageSignVerify (0.52s)
```