### PR TITLE
cmd/geth retesteth: add ethash mining support for retesteth

### DIFF
--- a/cmd/geth/retesteth.go
+++ b/cmd/geth/retesteth.go
@@ -548,6 +548,13 @@ func (api *RetestethAPI) mineBlock() error {
 	if err != nil {
 		return err
 	}
+	resultCh := make(chan *types.Block, 1)
+	stopCh := make(chan struct{})
+	err = api.engine.Seal(api.blockchain, block, resultCh, stopCh)
+	if err != nil {
+		return err
+	}
+	block = <-resultCh
 	return api.importBlock(block)
 }
 


### PR DESCRIPTION
This is a work in progress, not ready for merge yet. 
@winsvega , could you give this one a spin and see if it 1) works, and 2) does not break the existing retesteth mining? 
