### PR TITLE
eth/downloader: fix possible data race by inconsistent field protection

### DIFF
--- a/eth/downloader/queue.go
+++ b/eth/downloader/queue.go
@@ -564,26 +564,29 @@ func (q *queue) reserveHeaders(p *peerConnection, count int, taskPool map[common
 
 // CancelHeaders aborts a fetch request, returning all pending skeleton indexes to the queue.
 func (q *queue) CancelHeaders(request *fetchRequest) {
+	q.lock.Lock()
+	defer q.lock.Unlock()
 	q.cancel(request, q.headerTaskQueue, q.headerPendPool)
 }
 
 // CancelBodies aborts a body fetch request, returning all pending headers to the
 // task queue.
 func (q *queue) CancelBodies(request *fetchRequest) {
+	q.lock.Lock()
+	defer q.lock.Unlock()
 	q.cancel(request, q.blockTaskQueue, q.blockPendPool)
 }
 
 // CancelReceipts aborts a body fetch request, returning all pending headers to
 // the task queue.
 func (q *queue) CancelReceipts(request *fetchRequest) {
+	q.lock.Lock()
+	defer q.lock.Unlock()
 	q.cancel(request, q.receiptTaskQueue, q.receiptPendPool)
 }
 
 // Cancel aborts a fetch request, returning all pending hashes to the task queue.
 func (q *queue) cancel(request *fetchRequest, taskQueue *prque.Prque, pendPool map[string]*fetchRequest) {
-	q.lock.Lock()
-	defer q.lock.Unlock()
-
 	if request.From > 0 {
 		taskQueue.Push(request.From, -int64(request.From))
 	}


### PR DESCRIPTION
Fixed inconsistency and also potential data race in eth/downloader/queue.go:
e.g. In eth/downloader/queue.go:
`q.receiptPendPool` is read/written 10 times; 9 out of 10 times it is protected by q.lock.Lock(); 1 out of 10 times it is read without a Lock, which is in func CancelReceipts() on L579.
A data race may happen when `CancelReceipts()` and other func like `Revoke()` are called in parallel.
The fix is to move lock from func `cancel()` to its caller `CancelReceipts()`.
The other bugs and fixes are similar.
Note that there is an FP for eth/downloader/peer.go in PR [20650](https://github.com/ethereum/go-ethereum/pull/20650). I remove the changes in peer.go and start a new PR here.