### PR TITLE
les: protect field access with lock to avoid possible data race

### DIFF
--- a/les/client_handler.go
+++ b/les/client_handler.go
@@ -125,7 +125,10 @@ func (h *clientHandler) handle(p *peer) error {
 		serverConnectionGauge.Update(int64(h.backend.peers.Len()))
 	}()
 
-	h.fetcher.announce(p, p.headInfo)
+	p.lock.RLock()
+	headInfo := p.headInfo
+	p.lock.RUnlock()
+	h.fetcher.announce(p, headInfo)
 
 	// pool entry can be nil during the unit test.
 	if p.poolEntry != nil {


### PR DESCRIPTION
Fixed inconsistency and also potential data race in les/client_handler.go and les/clientpool.go:
e.g. In les/client_handler.go:
`p.headInfo` is read/written 11 times in les/peer.go and les/fetcher.go; 10 out of 11 times it is protected by `q.lock.RLock()/Lock()`; 1 out of 11 times it is read without a Lock, which is in func `handle()` on L128.
A data race may happen when `handle()` and other func like `announce()` are called in parallel.
The fix is to protect the access to `p.headInfo` and save the result to a local variable.
I am not sure if `announce(p, headInfo)` will have an atomicity violation after this fix.

A similar bug is an unprotected access to `f.capLimit` in `setCapacity()` in les/clientpool.go.
I wonder if this function has some special calling guarantee to avoid data race on `f.capLimit`, since all other functions protect the field with `f.lock.Lock()`.

See #20651