### PR TITLE
crypto: improve error messages in LoadECDSA

### DIFF
--- a/cmd/geth/accountcmd_test.go
+++ b/cmd/geth/accountcmd_test.go
@@ -93,8 +93,8 @@ func TestAccountImport(t *testing.T) {
 	bytes64 := "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
 	success := "Address: {fcad0b19bb29d4674531d6f115237e16afce377c}\n"
 	failureTemplate := "Fatal: Failed to load the private key: expected 64 bytes, got %v\n"
-	tests := []struct{
-		key string
+	tests := []struct {
+		key    string
 		result string
 	}{
 		{key: bytes64, result: success},

--- a/cmd/geth/accountcmd_test.go
+++ b/cmd/geth/accountcmd_test.go
@@ -17,7 +17,6 @@
 package main
 
 import (
-	"fmt"
 	"io/ioutil"
 	"path/filepath"
 	"runtime"
@@ -90,32 +89,29 @@ Path of the secret key file: .*UTC--.+--[0-9a-f]{40}
 }
 
 func TestAccountImport(t *testing.T) {
-	success := "Address: {fcad0b19bb29d4674531d6f115237e16afce377c}\n"
-	failureTemplate := "Fatal: Failed to load the private key: expected 64 bytes, got %v\n"
-	tests := []struct {
-		key    string
-		result string
-	}{
-		{key: "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef", result: success},
-		{key: "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef\n", result: success},
-		{key: "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef\r\n", result: success},
-		{key: "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef1", result: fmt.Sprintf(failureTemplate, 65)},
-		{key: "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdefx", result: fmt.Sprintf(failureTemplate, 65)},
-		{key: "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef\n\n\n", result: fmt.Sprintf(failureTemplate, 67)},
+	tests := []struct{ key, output string }{
+		{
+			key:    "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+			output: "Address: {fcad0b19bb29d4674531d6f115237e16afce377c}\n",
+		},
+		{
+			key:    "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef1",
+			output: "Fatal: Failed to load the private key: invalid character '1' at end of key file\n",
+		},
 	}
 	for _, test := range tests {
-		importAccountWithExpect(t, test.key, test.result)
+		importAccountWithExpect(t, test.key, test.output)
 	}
 }
 
 func importAccountWithExpect(t *testing.T, key string, expected string) {
 	dir := tmpdir(t)
 	keyfile := filepath.Join(dir, "key.prv")
-	if err := ioutil.WriteFile(keyfile, []byte(key), 0644); err != nil {
+	if err := ioutil.WriteFile(keyfile, []byte(key), 0600); err != nil {
 		t.Error(err)
 	}
 	passwordFile := filepath.Join(dir, "password.txt")
-	if err := ioutil.WriteFile(passwordFile, []byte("foobar"), 0644); err != nil {
+	if err := ioutil.WriteFile(passwordFile, []byte("foobar"), 0600); err != nil {
 		t.Error(err)
 	}
 	geth := runGeth(t, "account", "import", keyfile, "-password", passwordFile)

--- a/cmd/geth/accountcmd_test.go
+++ b/cmd/geth/accountcmd_test.go
@@ -90,19 +90,18 @@ Path of the secret key file: .*UTC--.+--[0-9a-f]{40}
 }
 
 func TestAccountImport(t *testing.T) {
-	bytes64 := "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
 	success := "Address: {fcad0b19bb29d4674531d6f115237e16afce377c}\n"
 	failureTemplate := "Fatal: Failed to load the private key: expected 64 bytes, got %v\n"
 	tests := []struct {
 		key    string
 		result string
 	}{
-		{key: bytes64, result: success},
-		{key: bytes64 + "\n", result: success},
-		{key: bytes64 + "\r\n", result: success},
-		{key: bytes64 + "1", result: fmt.Sprintf(failureTemplate, 65)},
-		{key: bytes64 + "x", result: fmt.Sprintf(failureTemplate, 65)},
-		{key: bytes64 + "\n\n\n", result: fmt.Sprintf(failureTemplate, 67)},
+		{key: "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef", result: success},
+		{key: "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef\n", result: success},
+		{key: "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef\r\n", result: success},
+		{key: "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef1", result: fmt.Sprintf(failureTemplate, 65)},
+		{key: "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdefx", result: fmt.Sprintf(failureTemplate, 65)},
+		{key: "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef\n\n\n", result: fmt.Sprintf(failureTemplate, 67)},
 	}
 	for _, test := range tests {
 		importAccountWithExpect(t, test.key, test.result)

--- a/cmd/geth/accountcmd_test.go
+++ b/cmd/geth/accountcmd_test.go
@@ -128,7 +128,7 @@ func TestAccountImportTooShort(t *testing.T) {
 	geth := runGeth(t, "account", "import", keyfile)
 	defer geth.ExpectExit()
 	geth.Expect(`
-Fatal: Failed to load the private key: expected 64 hexa characters, got 40
+Fatal: Failed to load the private key: expected 64 bytes, got 40
 `)
 }
 

--- a/crypto/crypto.go
+++ b/crypto/crypto.go
@@ -25,6 +25,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"math/big"
+	"os"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/math"
@@ -164,12 +165,17 @@ func HexToECDSA(hexkey string) (*ecdsa.PrivateKey, error) {
 
 // LoadECDSA loads a secp256k1 private key from the given file.
 func LoadECDSA(file string) (*ecdsa.PrivateKey, error) {
-	buf, err := ioutil.ReadFile(file)
+	stat, err := os.Stat(file)
 	if err != nil {
 		return nil, err
 	}
-	if len(buf) != 64 {
-		return nil, fmt.Errorf("expected 64 hexa characters, got %v", len(buf))
+	size := stat.Size()
+	if size != 64 {
+		return nil, fmt.Errorf("expected 64 hexa characters, got %v", size)
+	}
+	buf, err := ioutil.ReadFile(file)
+	if err != nil {
+		return nil, err
 	}
 
 	key, err := hex.DecodeString(string(buf))

--- a/crypto/crypto.go
+++ b/crypto/crypto.go
@@ -23,12 +23,13 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
+	"io/ioutil"
+	"math/big"
+
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/math"
 	"github.com/ethereum/go-ethereum/rlp"
 	"golang.org/x/crypto/sha3"
-	"io/ioutil"
-	"math/big"
 )
 
 //SignatureLength indicates the byte length required to carry a signature with recovery id.

--- a/crypto/crypto.go
+++ b/crypto/crypto.go
@@ -168,7 +168,7 @@ func LoadECDSA(file string) (*ecdsa.PrivateKey, error) {
 		return nil, err
 	}
 	if len(buf) != 64 {
-		return nil, errors.New(fmt.Sprintf("expected 64 hexa characters, got %v", len(buf)))
+		return nil, fmt.Errorf("expected 64 hexa characters, got %v", len(buf))
 	}
 
 	key, err := hex.DecodeString(string(buf))

--- a/crypto/crypto.go
+++ b/crypto/crypto.go
@@ -23,15 +23,12 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
-	"io"
-	"io/ioutil"
-	"math/big"
-	"os"
-
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/math"
 	"github.com/ethereum/go-ethereum/rlp"
 	"golang.org/x/crypto/sha3"
+	"io/ioutil"
+	"math/big"
 )
 
 //SignatureLength indicates the byte length required to carry a signature with recovery id.
@@ -166,14 +163,12 @@ func HexToECDSA(hexkey string) (*ecdsa.PrivateKey, error) {
 
 // LoadECDSA loads a secp256k1 private key from the given file.
 func LoadECDSA(file string) (*ecdsa.PrivateKey, error) {
-	buf := make([]byte, 64)
-	fd, err := os.Open(file)
+	buf, err := ioutil.ReadFile(file)
 	if err != nil {
 		return nil, err
 	}
-	defer fd.Close()
-	if _, err := io.ReadFull(fd, buf); err != nil {
-		return nil, err
+	if len(buf) != 64 {
+		return nil, errors.New(fmt.Sprintf("expected 64 hexa characters, got %v", len(buf)))
 	}
 
 	key, err := hex.DecodeString(string(buf))

--- a/crypto/crypto.go
+++ b/crypto/crypto.go
@@ -17,13 +17,14 @@
 package crypto
 
 import (
-	"bytes"
+	"bufio"
 	"crypto/ecdsa"
 	"crypto/elliptic"
 	"crypto/rand"
 	"encoding/hex"
 	"errors"
 	"fmt"
+	"io"
 	"io/ioutil"
 	"math/big"
 	"os"
@@ -158,37 +159,67 @@ func FromECDSAPub(pub *ecdsa.PublicKey) []byte {
 // HexToECDSA parses a secp256k1 private key.
 func HexToECDSA(hexkey string) (*ecdsa.PrivateKey, error) {
 	b, err := hex.DecodeString(hexkey)
-	if err != nil {
-		return nil, errors.New("invalid hex string")
+	if byteErr, ok := err.(hex.InvalidByteError); ok {
+		return nil, fmt.Errorf("invalid hex character %q in private key", byte(byteErr))
+	} else if err != nil {
+		return nil, errors.New("invalid hex data for private key")
 	}
 	return ToECDSA(b)
 }
 
 // LoadECDSA loads a secp256k1 private key from the given file.
 func LoadECDSA(file string) (*ecdsa.PrivateKey, error) {
-	stat, err := os.Stat(file)
+	fd, err := os.Open(file)
 	if err != nil {
 		return nil, err
 	}
-	size := stat.Size()
-	// Allow two extra chars for possible line ending to be checked later
-	if size < 64 || size > 66 {
-		return nil, fmt.Errorf("expected 64 bytes, got %v", size)
-	}
-	buf, err := ioutil.ReadFile(file)
+	defer fd.Close()
+
+	r := bufio.NewReader(fd)
+	buf := make([]byte, 64)
+	n, err := readASCII(buf, r)
 	if err != nil {
 		return nil, err
+	} else if n != len(buf) {
+		return nil, fmt.Errorf("key file too short, want 64 hex characters")
 	}
-	buf = bytes.TrimSpace(buf)
-	if len(buf) != 64 {
-		return nil, fmt.Errorf("expected 64 bytes, got %v", len(buf))
+	if err := checkKeyFileEnd(r); err != nil {
+		return nil, err
 	}
 
-	key, err := hex.DecodeString(string(buf))
-	if err != nil {
-		return nil, err
+	return HexToECDSA(string(buf))
+}
+
+// readASCII reads into 'buf', stopping when the buffer is full or
+// when a non-printable control character is encountered.
+func readASCII(buf []byte, r *bufio.Reader) (n int, err error) {
+	for ; n < len(buf); n++ {
+		buf[n], err = r.ReadByte()
+		switch {
+		case err == io.EOF || buf[n] < '!':
+			return n, nil
+		case err != nil:
+			return n, err
+		}
 	}
-	return ToECDSA(key)
+	return n, nil
+}
+
+// checkKeyFileEnd skips over additional newlines at the end of a key file.
+func checkKeyFileEnd(r *bufio.Reader) error {
+	for i := 0; ; i++ {
+		b, err := r.ReadByte()
+		switch {
+		case err == io.EOF:
+			return nil
+		case err != nil:
+			return err
+		case b != '\n' && b != '\r':
+			return fmt.Errorf("invalid character %q at end of key file", b)
+		case i >= 2:
+			return errors.New("key file too long, want 64 hex characters")
+		}
+	}
 }
 
 // SaveECDSA saves a secp256k1 private key to the given file with
@@ -198,6 +229,7 @@ func SaveECDSA(file string, key *ecdsa.PrivateKey) error {
 	return ioutil.WriteFile(file, []byte(k), 0600)
 }
 
+// GenerateKey generates a new private key.
 func GenerateKey() (*ecdsa.PrivateKey, error) {
 	return ecdsa.GenerateKey(S256(), rand.Reader)
 }

--- a/crypto/crypto.go
+++ b/crypto/crypto.go
@@ -170,15 +170,23 @@ func LoadECDSA(file string) (*ecdsa.PrivateKey, error) {
 		return nil, err
 	}
 	size := stat.Size()
-	if size != 64 {
+	// Allow two extra chars for possible line ending to be checked later
+	if size < 64 || size > 66 {
 		return nil, fmt.Errorf("expected 64 bytes, got %v", size)
 	}
 	buf, err := ioutil.ReadFile(file)
 	if err != nil {
 		return nil, err
 	}
+	// Check line ending
+	maybeLineEnding := buf[64:]
+	for _, ch := range maybeLineEnding {
+		if ch != '\n' && ch != '\r' {
+			return nil, fmt.Errorf("expected 64 bytes, got %v", size)
+		}
+	}
 
-	key, err := hex.DecodeString(string(buf))
+	key, err := hex.DecodeString(string(buf[:64]))
 	if err != nil {
 		return nil, err
 	}

--- a/crypto/crypto.go
+++ b/crypto/crypto.go
@@ -17,6 +17,7 @@
 package crypto
 
 import (
+	"bytes"
 	"crypto/ecdsa"
 	"crypto/elliptic"
 	"crypto/rand"
@@ -178,15 +179,12 @@ func LoadECDSA(file string) (*ecdsa.PrivateKey, error) {
 	if err != nil {
 		return nil, err
 	}
-	// Check line ending
-	maybeLineEnding := buf[64:]
-	for _, ch := range maybeLineEnding {
-		if ch != '\n' && ch != '\r' {
-			return nil, fmt.Errorf("expected 64 bytes, got %v", size)
-		}
+	buf = bytes.TrimSpace(buf)
+	if len(buf) != 64 {
+		return nil, fmt.Errorf("expected 64 bytes, got %v", len(buf))
 	}
 
-	key, err := hex.DecodeString(string(buf[:64]))
+	key, err := hex.DecodeString(string(buf))
 	if err != nil {
 		return nil, err
 	}

--- a/crypto/crypto.go
+++ b/crypto/crypto.go
@@ -171,7 +171,7 @@ func LoadECDSA(file string) (*ecdsa.PrivateKey, error) {
 	}
 	size := stat.Size()
 	if size != 64 {
-		return nil, fmt.Errorf("expected 64 hexa characters, got %v", size)
+		return nil, fmt.Errorf("expected 64 bytes, got %v", size)
 	}
 	buf, err := ioutil.ReadFile(file)
 	if err != nil {

--- a/crypto/crypto_test.go
+++ b/crypto/crypto_test.go
@@ -139,39 +139,82 @@ func TestNewContractAddress(t *testing.T) {
 	checkAddr(t, common.HexToAddress("c9ddedf451bc62ce88bf9292afb13df35b670699"), caddr2)
 }
 
-func TestLoadECDSAFile(t *testing.T) {
-	keyBytes := common.FromHex(testPrivHex)
-	fileName0 := "test_key0"
-	fileName1 := "test_key1"
-	checkKey := func(k *ecdsa.PrivateKey) {
-		checkAddr(t, PubkeyToAddress(k.PublicKey), common.HexToAddress(testAddrHex))
-		loadedKeyBytes := FromECDSA(k)
-		if !bytes.Equal(loadedKeyBytes, keyBytes) {
-			t.Fatalf("private key mismatch: want: %x have: %x", keyBytes, loadedKeyBytes)
+func TestLoadECDSA(t *testing.T) {
+	tests := []struct {
+		input string
+		err   string
+	}{
+		// good
+		{input: "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"},
+		{input: "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef\n"},
+		{input: "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef\n\r"},
+		{input: "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef\r\n"},
+		{input: "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef\n\n"},
+		{input: "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef\n\r"},
+		// bad
+		{
+			input: "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcde",
+			err:   "key file too short, want 64 hex characters",
+		},
+		{
+			input: "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcde\n",
+			err:   "key file too short, want 64 hex characters",
+		},
+		{
+			input: "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdeX",
+			err:   "invalid hex character 'X' in private key",
+		},
+		{
+			input: "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdefX",
+			err:   "invalid character 'X' at end of key file",
+		},
+		{
+			input: "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef\n\n\n",
+			err:   "key file too long, want 64 hex characters",
+		},
+	}
+
+	for _, test := range tests {
+		f, err := ioutil.TempFile("", "loadecdsa_test.*.txt")
+		if err != nil {
+			t.Fatal(err)
+		}
+		filename := f.Name()
+		f.WriteString(test.input)
+		f.Close()
+
+		_, err = LoadECDSA(filename)
+		switch {
+		case err != nil && test.err == "":
+			t.Fatalf("unexpected error for input %q:\n  %v", test.input, err)
+		case err != nil && err.Error() != test.err:
+			t.Fatalf("wrong error for input %q:\n  %v", test.input, err)
+		case err == nil && test.err != "":
+			t.Fatalf("LoadECDSA did not return error for input %q", test.input)
 		}
 	}
+}
 
-	ioutil.WriteFile(fileName0, []byte(testPrivHex), 0600)
-	defer os.Remove(fileName0)
-
-	key0, err := LoadECDSA(fileName0)
+func TestSaveECDSA(t *testing.T) {
+	f, err := ioutil.TempFile("", "saveecdsa_test.*.txt")
 	if err != nil {
 		t.Fatal(err)
 	}
-	checkKey(key0)
+	file := f.Name()
+	f.Close()
+	defer os.Remove(file)
 
-	// again, this time with SaveECDSA instead of manual save:
-	err = SaveECDSA(fileName1, key0)
+	key, _ := HexToECDSA(testPrivHex)
+	if err := SaveECDSA(file, key); err != nil {
+		t.Fatal(err)
+	}
+	loaded, err := LoadECDSA(file)
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer os.Remove(fileName1)
-
-	key1, err := LoadECDSA(fileName1)
-	if err != nil {
-		t.Fatal(err)
+	if !reflect.DeepEqual(key, loaded) {
+		t.Fatal("loaded key not equal to saved key")
 	}
-	checkKey(key1)
 }
 
 func TestValidateSignatureValues(t *testing.T) {


### PR DESCRIPTION
Invoking `geth account import key.prv`

Old error message: `Failed to load the private key: unexpected EOF`
New error message: `Failed to load the private key: key file too short, want 64 hex characters`

Note: it was OK to provide a longer key than expected. Now it's an error too.