### PR TITLE
mobile: add CallOpts.SetFrom

### DIFF
--- a/mobile/bind.go
+++ b/mobile/bind.go
@@ -69,6 +69,7 @@ func (opts *CallOpts) GetGasLimit() int64 { return 0 /* TODO(karalabe) */ }
 func (opts *CallOpts) SetPending(pending bool)     { opts.opts.Pending = pending }
 func (opts *CallOpts) SetGasLimit(limit int64)     { /* TODO(karalabe) */ }
 func (opts *CallOpts) SetContext(context *Context) { opts.opts.Context = context.context }
+func (opts *CallOpts) SetFrom(addr *Address)       { opts.opts.From = addr.address }
 
 // TransactOpts is the collection of authorization data required to create a
 // valid Ethereum transaction.


### PR DESCRIPTION
This was missing because we forgot to wrap it when bind.CallOpts.From as added.

Fixes: #18034