### PR TITLE
correct func name

### DIFF
--- a/core/vm/gas.go
+++ b/core/vm/gas.go
@@ -34,7 +34,7 @@ const (
 //
 // The cost of gas was changed during the homestead price change HF.
 // As part of EIP 150 (TangerineWhistle), the returned gas is gas - base * 63 / 64.
-func callGas(isEip150 bool, availableGas, base uint64, callCost *big.Int) (uint64, error) {
+func calcGas(isEip150 bool, availableGas, base uint64, callCost *big.Int) (uint64, error) {
 	if isEip150 {
 		availableGas = availableGas - base
 		gas := availableGas - availableGas/64


### PR DESCRIPTION
comment typo: `calcGas` should be `callGas`