### PR TITLE
eth: fix transaction announce/broadcast goroutine leak

### DIFF
--- a/eth/peer.go
+++ b/eth/peer.go
@@ -155,9 +155,9 @@ func (p *peer) broadcastBlocks() {
 // node internals and at the same time rate limits queued data.
 func (p *peer) broadcastTransactions() {
 	var (
-		queue []common.Hash      // Queue of hashes to broadcast as full transactions
-		done  chan struct{}      // Non-nil if background broadcaster is running
-		fail  = make(chan error) // Channel used to receive network error
+		queue []common.Hash         // Queue of hashes to broadcast as full transactions
+		done  chan struct{}         // Non-nil if background broadcaster is running
+		fail  = make(chan error, 1) // Channel used to receive network error
 	)
 	for {
 		// If there's no in-flight broadcast running, check if a new one is needed
@@ -217,9 +217,9 @@ func (p *peer) broadcastTransactions() {
 // node internals and at the same time rate limits queued data.
 func (p *peer) announceTransactions() {
 	var (
-		queue []common.Hash      // Queue of hashes to announce as transaction stubs
-		done  chan struct{}      // Non-nil if background announcer is running
-		fail  = make(chan error) // Channel used to receive network error
+		queue []common.Hash         // Queue of hashes to announce as transaction stubs
+		done  chan struct{}         // Non-nil if background announcer is running
+		fail  = make(chan error, 1) // Channel used to receive network error
 	)
 	for {
 		// If there's no in-flight announce running, check if a new one is needed


### PR DESCRIPTION
The `fail` channels in the transaction announcement and broadcast loops were blocking, which meant that any announcement started must be allowed to finish before exiting the broadcaster. This was not the case as a peer drop concurrently closed the peer's termination channel and aborted the send. Depending on the ordering of the event, the outer broadcaster method might have reacted to the `p.term` closure faster, never reading the failure from `fail`.

One way to solve it would be to track any pending requests and only return from the outer method when the goroutine requests finish. This PR takes a simpler approach by converting the `fail` from a blocking channel to a notification one. This way if the sending goroutine is left dangling, it will just write into a noop channel.