### PR TITLE
rpc: add 'rpc' as always-available module

### DIFF
--- a/rpc/endpoints.go
+++ b/rpc/endpoints.go
@@ -22,18 +22,26 @@ import (
 	"github.com/ethereum/go-ethereum/log"
 )
 
+// availableAPISetBase defines available api modules which are always available.
+var availableAPISetBase = map[string]struct{}{
+	MetadataApi: {},
+}
+
 // checkModuleAvailability check that all names given in modules are actually
 // available API services.
 func checkModuleAvailability(modules []string, apis []API) (bad, available []string) {
-	availableSet := make(map[string]struct{})
+	availableAPISet := make(map[string]struct{})
+	for k, v := range availableAPISetBase {
+		availableAPISet[k] = v
+	}
 	for _, api := range apis {
-		if _, ok := availableSet[api.Namespace]; !ok {
-			availableSet[api.Namespace] = struct{}{}
+		if _, ok := availableAPISet[api.Namespace]; !ok {
+			availableAPISet[api.Namespace] = struct{}{}
 			available = append(available, api.Namespace)
 		}
 	}
 	for _, name := range modules {
-		if _, ok := availableSet[name]; !ok {
+		if _, ok := availableAPISet[name]; !ok {
 			bad = append(bad, name)
 		}
 	}


### PR DESCRIPTION
The MetadataAPI module 'rpc' is registered on
the creation of a new handler.

Signed-off-by: meows <b5c6@protonmail.com>

---

### Fixes

A incorrect error `ERROR[03-16|07:48:24.157] Unavailable modules in HTTP API list     unavailable=[rpc] available="[admin debug web3 eth txpool personal ethash miner net]"` is logged if a user configures `--rpcapi=rpc[|,...]`

```
./build/bin/geth --datadir=/tmp/gethddd --nodiscover --maxpeers=0 --rpc --rpcapi=admin,debug,eth,ethash,miner,net,personal,rpc,txpool,web3
```

```
07e1ff053b63af9b75c446c1a6aa7dbed878727ad2052b376648d46d@127.0.0.1:30303?discport=0"
INFO [03-16|07:48:24.157] IPC endpoint opened                      url=/tmp/gethddd/geth.ipc
ERROR[03-16|07:48:24.157] Unavailable modules in HTTP API list     unavailable=[rpc] available="[admin debug web3 eth txpool personal ethash miner net]"
INFO [03-16|07:48:24.158] HTTP endpoint opened                     url=http://127.0.0.1:8545 cors= vhosts=localhost
```

