### PR TITLE
[DOCS] fix typo of syncing mode "fast" -> "full"

### DIFF
--- a/docs/_dapp/tracing.md
+++ b/docs/_dapp/tracing.md
@@ -41,7 +41,7 @@ result in different capabilities:
  * An **archive** node retaining **all historical data** can trace arbitrary transactions
    at any point in time. Tracing a single transaction also entails reexecuting all
    preceding transactions in the same block.
- * A **fast synced** node retaining **all historical data** after initial sync can only
+ * A **full synced** node retaining **all historical data** after initial sync can only
    trace transactions from blocks following the initial sync point. Tracing a single
    transaction also entails reexecuting all preceding transactions in the same block.
  * A **fast synced** node retaining only **periodic state data** after initial sync can


### PR DESCRIPTION
This should be an easy typo and can be immediately fixed. Correct me if I'm wrong.