### PR TITLE
rpc: dont log an error if user configures --rpcapi=rpc...

### DIFF
--- a/rpc/endpoints.go
+++ b/rpc/endpoints.go
@@ -23,7 +23,7 @@ import (
 )
 
 // checkModuleAvailability check that all names given in modules are actually
-// available API services.
+// available API services. It assumes that the special snowflake "rpc" module is always available.
 func checkModuleAvailability(modules []string, apis []API) (bad, available []string) {
 	availableSet := make(map[string]struct{})
 	for _, api := range apis {
@@ -33,7 +33,7 @@ func checkModuleAvailability(modules []string, apis []API) (bad, available []str
 		}
 	}
 	for _, name := range modules {
-		if _, ok := availableSet[name]; !ok {
+		if _, ok := availableSet[name]; !ok && name != MetadataApi {
 			bad = append(bad, name)
 		}
 	}

--- a/rpc/endpoints.go
+++ b/rpc/endpoints.go
@@ -22,8 +22,9 @@ import (
 	"github.com/ethereum/go-ethereum/log"
 )
 
-// checkModuleAvailability check that all names given in modules are actually
-// available API services. It assumes that the special snowflake "rpc" module is always available.
+// checkModuleAvailability checks that all names given in modules are actually
+// available API services. It assumes that the MetadataApi module ("rpc") is always available;
+// the registration of this "rpc" module happens in NewServer() and is thus common to all endpoints.
 func checkModuleAvailability(modules []string, apis []API) (bad, available []string) {
 	availableSet := make(map[string]struct{})
 	for _, api := range apis {


### PR DESCRIPTION
Follow up to https://github.com/ethereum/go-ethereum/pull/20771

> Since its always available, why would a user specify it explicitly?
> https://github.com/ethereum/go-ethereum/pull/20771#issuecomment-599978739

I don't know... because they can? Should they know otherwise that the module is always available? Doesn't seem to be mentioned at all in https://geth.ethereum.org/docs/rpc/server. 

> I think we should just tell people that it's always available and not specify it. 
> https://github.com/ethereum/go-ethereum/pull/20771#issuecomment-599979900

Documentation would be helpful.

---

This just prevents a false negative `ERROR` warning when, for some unknown reason, a user attempts to turn on the module `rpc` even though it's already going to be on.

