### PR TITLE
core/rawdb: fix freezer table test error check

### DIFF
--- a/core/rawdb/freezer_table_test.go
+++ b/core/rawdb/freezer_table_test.go
@@ -196,10 +196,8 @@ func TestFreezerRepairDanglingHeadLarge(t *testing.T) {
 			f.Append(uint64(x), data)
 		}
 		// The last item should be there
-		if _, err = f.Retrieve(f.items - 1); err == nil {
-			if err != nil {
-				t.Fatal(err)
-			}
+		if _, err = f.Retrieve(f.items - 1); err != nil {
+			t.Fatal(err)
 		}
 		f.Close()
 	}


### PR DESCRIPTION
Fixes: Condition is always 'false' because 'err' is always 'nil'