### PR TITLE
eth: when triggering a sync, check the head header TD, not block

### DIFF
--- a/eth/handler.go
+++ b/eth/handler.go
@@ -727,8 +727,8 @@ func (pm *ProtocolManager) handleMsg(p *peer) error {
 			// Schedule a sync if above ours. Note, this will not fire a sync for a gap of
 			// a single block (as the true TD is below the propagated block), however this
 			// scenario should easily be covered by the fetcher.
-			currentBlock := pm.blockchain.CurrentBlock()
-			if trueTD.Cmp(pm.blockchain.GetTd(currentBlock.Hash(), currentBlock.NumberU64())) > 0 {
+			currentHeader := pm.blockchain.CurrentHeader()
+			if trueTD.Cmp(pm.blockchain.GetTd(currentHeader.Hash(), currentHeader.Number.Uint64())) > 0 {
 				go pm.synchronise(p)
 			}
 		}

--- a/eth/sync.go
+++ b/eth/sync.go
@@ -189,8 +189,8 @@ func (pm *ProtocolManager) synchronise(peer *peer) {
 		return
 	}
 	// Make sure the peer's TD is higher than our own
-	currentBlock := pm.blockchain.CurrentBlock()
-	td := pm.blockchain.GetTd(currentBlock.Hash(), currentBlock.NumberU64())
+	currentHeader := pm.blockchain.CurrentHeader()
+	td := pm.blockchain.GetTd(currentHeader.Hash(), currentHeader.Number.Uint64())
 
 	pHead, pTd := peer.Head()
 	if pTd.Cmp(td) <= 0 {


### PR DESCRIPTION
This PR fixes a regression introduced in v1.9.0 by the freezer, unfortunately that regression was completely silent and was surfaced only by b9c90c5581934454aa71af5b4b668c37b67d92fc.

The symptom is when a miner is started against an empty database, instantly mines a block, and then fast syncs... crashing. Since the node mined a block, it's current head block is 1, with `hashA`. Fast sync will start and dump a whole lot of data into the freezer/ancient database (including block 1, with `hashB`). Later on, any code that accesses the `currentBlock`, will want data belonging to `hashA`, but the freezer only has data belonging to `hashB`.

The crash is due to the sync code accessing the current block and then it's TD, which is returned as `nil`, since the hash doesn't match (the crash is due to b9c90c5581934454aa71af5b4b668c37b67d92fc actually validating the hash, previously we trusted it blindly).

The fix is to change the sync code to base it's TD retrieval on the head header, instead of the head block. This is actually the correct behavior as throughout fast sync the current block is the genesis, we've been doing it wrong for 4 years. This will also solve the panic because the head header is either the actual one from the ancient db, or if it's newer than the ancient limit then we'll always have it.

Fixes https://github.com/ethereum/go-ethereum/issues/20770, https://github.com/ethereum/go-ethereum/issues/20614