### PR TITLE
internal/web3ext: fix clique console apis to work on missing arguments

### DIFF
--- a/internal/web3ext/web3ext.go
+++ b/internal/web3ext/web3ext.go
@@ -74,7 +74,7 @@ web3._extend({
 			name: 'getSnapshot',
 			call: 'clique_getSnapshot',
 			params: 1,
-			inputFormatter: [web3._extend.utils.fromDecimal]
+			inputFormatter: [web3._extend.formatters.inputBlockNumberFormatter]
 		}),
 		new web3._extend.Method({
 			name: 'getSnapshotAtHash',
@@ -85,7 +85,7 @@ web3._extend({
 			name: 'getSigners',
 			call: 'clique_getSigners',
 			params: 1,
-			inputFormatter: [web3._extend.utils.fromDecimal]
+			inputFormatter: [web3._extend.formatters.inputBlockNumberFormatter]
 		}),
 		new web3._extend.Method({
 			name: 'getSignersAtHash',


### PR DESCRIPTION
Fixes a tiny regression introduced by https://github.com/ethereum/go-ethereum/pull/20318, which caused the `clique` API calls in the console to not accept empty arguments (or `'latest`) any more (I mean, it accepted, but defaulted to block 0, instead of the chain head).

Fixes https://github.com/ethereum/go-ethereum/issues/20772