### PR TITLE
node, cmd/clef: report actual port used for http rpc

### DIFF
--- a/cmd/clef/main.go
+++ b/cmd/clef/main.go
@@ -545,7 +545,7 @@ func signer(c *cli.Context) error {
 		if err != nil {
 			utils.Fatalf("Could not start RPC api: %v", err)
 		}
-		extapiURL = fmt.Sprintf("http://%v", listener.Addr())
+		extapiURL = fmt.Sprintf("http://%v/", listener.Addr())
 		log.Info("HTTP endpoint opened", "url", extapiURL)
 
 		defer func() {

--- a/cmd/clef/main.go
+++ b/cmd/clef/main.go
@@ -545,12 +545,12 @@ func signer(c *cli.Context) error {
 		if err != nil {
 			utils.Fatalf("Could not start RPC api: %v", err)
 		}
-		extapiURL = fmt.Sprintf("http://%s", httpEndpoint)
+		extapiURL = fmt.Sprintf("http://%v", listener.Addr())
 		log.Info("HTTP endpoint opened", "url", extapiURL)
 
 		defer func() {
 			listener.Close()
-			log.Info("HTTP endpoint closed", "url", httpEndpoint)
+			log.Info("HTTP endpoint closed", "url", extapiURL)
 		}()
 	}
 	if !c.GlobalBool(utils.IPCDisabledFlag.Name) {

--- a/node/node.go
+++ b/node/node.go
@@ -368,7 +368,9 @@ func (n *Node) startHTTP(endpoint string, apis []rpc.API, modules []string, cors
 	if err != nil {
 		return err
 	}
-	n.log.Info("HTTP endpoint opened", "url", fmt.Sprintf("http://%s", endpoint), "cors", strings.Join(cors, ","), "vhosts", strings.Join(vhosts, ","))
+	n.log.Info("HTTP endpoint opened", "url", fmt.Sprintf("http://%v/", listener.Addr()),
+		"cors", strings.Join(cors, ","),
+		"vhosts", strings.Join(vhosts, ","))
 	// All listeners booted successfully
 	n.httpEndpoint = endpoint
 	n.httpListener = listener
@@ -380,10 +382,10 @@ func (n *Node) startHTTP(endpoint string, apis []rpc.API, modules []string, cors
 // stopHTTP terminates the HTTP RPC endpoint.
 func (n *Node) stopHTTP() {
 	if n.httpListener != nil {
+		url := fmt.Sprintf("http://%v", n.httpListener.Addr())
 		n.httpListener.Close()
 		n.httpListener = nil
-
-		n.log.Info("HTTP endpoint closed", "url", fmt.Sprintf("http://%s", n.httpEndpoint))
+		n.log.Info("HTTP endpoint closed", "url", url)
 	}
 	if n.httpHandler != nil {
 		n.httpHandler.Stop()

--- a/node/node.go
+++ b/node/node.go
@@ -382,7 +382,7 @@ func (n *Node) startHTTP(endpoint string, apis []rpc.API, modules []string, cors
 // stopHTTP terminates the HTTP RPC endpoint.
 func (n *Node) stopHTTP() {
 	if n.httpListener != nil {
-		url := fmt.Sprintf("http://%v", n.httpListener.Addr())
+		url := fmt.Sprintf("http://%v/", n.httpListener.Addr())
 		n.httpListener.Close()
 		n.httpListener = nil
 		n.log.Info("HTTP endpoint closed", "url", url)


### PR DESCRIPTION
This PR fixes and issue where, if you specify `--rpcport=0`, you get
```
HTTP endpoint opened                     url=http://127.0.0.1:0 cors= vhosts=localhost
```
Port `0` means "hey OS, please give me a free port". We should output the actual
port given to us by the OS in this case.

With this PR:

## geth
```
INFO [03-20|10:11:00.749] IPC endpoint opened                      url=/tmp/geth.ipc
INFO [03-20|10:11:00.749] HTTP endpoint opened                     url=http://127.0.0.1:43157/ cors= vhosts=localhost
...
INFO [03-20|10:11:02.546] HTTP endpoint closed                     url=http://127.0.0.1:43157
INFO [03-20|10:11:02.546] IPC endpoint closed                      url=/tmp/geth.ipc
```

## clef

```
DEBUG[03-20|10:10:16.333] HTTP registered                          namespace=account
INFO [03-20|10:10:16.333] HTTP endpoint opened                     url=http://127.0.0.1:39755
...
INFO [03-20|10:10:19.130] IPC endpoint closed                      url=/home/user/.clef/clef.ipc
INFO [03-20|10:10:19.130] HTTP endpoint closed                     url=http://127.0.0.1:39755
```