### PR TITLE
Snapshotter: Improve updates

### DIFF
--- a/common/types.go
+++ b/common/types.go
@@ -368,3 +368,11 @@ func (ma *MixedcaseAddress) ValidChecksum() bool {
 func (ma *MixedcaseAddress) Original() string {
 	return ma.original
 }
+
+type TriePrefetcher interface {
+	Pause()
+	Reset(number uint64, root Hash)
+	PrefetchAddress(addr Address)
+	PrefetchStorage(root Hash, slots []Hash)
+	Close()
+}

--- a/core/state/database.go
+++ b/core/state/database.go
@@ -121,12 +121,20 @@ type cachingDB struct {
 
 // OpenTrie opens the main account trie at a specific root hash.
 func (db *cachingDB) OpenTrie(root common.Hash) (Trie, error) {
-	return trie.NewSecure(root, db.db)
+	tr, err := trie.NewSecure(root, db.db)
+	if err != nil {
+		return nil, err
+	}
+	return tr, nil
 }
 
 // OpenStorageTrie opens the storage trie of an account.
 func (db *cachingDB) OpenStorageTrie(addrHash, root common.Hash) (Trie, error) {
-	return trie.NewSecure(root, db.db)
+	tr, err := trie.NewSecure(root, db.db)
+	if err != nil {
+		return nil, err
+	}
+	return tr, nil
 }
 
 // CopyTrie returns an independent copy of the given trie.

--- a/core/state/state_object.go
+++ b/core/state/state_object.go
@@ -325,6 +325,7 @@ func (s *stateObject) updateTrie(db Database) Trie {
 	var storage map[common.Hash][]byte
 	// Insert all the pending updates into the trie
 	tr := s.getTrie(db)
+	hasher := s.db.hasher
 	for key, value := range s.pendingStorage {
 		// Skip noop changes, persist actual changes
 		if value == s.originStorage[key] {
@@ -349,7 +350,7 @@ func (s *stateObject) updateTrie(db Database) Trie {
 					s.db.snapStorage[s.addrHash] = storage
 				}
 			}
-			storage[crypto.Keccak256Hash(key[:])] = v // v will be nil if value is 0x00
+			storage[crypto.HashData(hasher, key[:])] = v // v will be nil if value is 0x00
 		}
 	}
 	if len(s.pendingStorage) > 0 {

--- a/core/state/state_object.go
+++ b/core/state/state_object.go
@@ -197,12 +197,24 @@ func (s *stateObject) GetCommittedState(db Database, key common.Hash) common.Has
 	}
 	// If no live objects are available, attempt to use snapshots
 	var (
-		enc []byte
-		err error
+		enc   []byte
+		err   error
+		meter *time.Duration
 	)
+	readStart := time.Now()
+	if metrics.EnabledExpensive {
+		// If the snap is 'under construction', the first lookup may fail. If that
+		// happens, we don't want to double-count the time elapsed. Thus this
+		// dance with the metering.
+		defer func() {
+			if meter != nil {
+				*meter += time.Since(readStart)
+			}
+		}()
+	}
 	if s.db.snap != nil {
 		if metrics.EnabledExpensive {
-			defer func(start time.Time) { s.db.SnapshotStorageReads += time.Since(start) }(time.Now())
+			meter = &s.db.SnapshotStorageReads
 		}
 		// If the object was destructed in *this* block (and potentially resurrected),
 		// the storage has been cleared out, and we should *not* consult the previous
@@ -217,8 +229,14 @@ func (s *stateObject) GetCommittedState(db Database, key common.Hash) common.Has
 	}
 	// If snapshot unavailable or reading from it failed, load from the database
 	if s.db.snap == nil || err != nil {
+		if meter != nil {
+			// If we already spent time checking the snapshot, account for it
+			// and reset the readStart
+			*meter += time.Since(readStart)
+			readStart = time.Now()
+		}
 		if metrics.EnabledExpensive {
-			defer func(start time.Time) { s.db.StorageReads += time.Since(start) }(time.Now())
+			meter = &s.db.StorageReads
 		}
 		if enc, err = s.getTrie(db).TryGet(key[:]); err != nil {
 			s.setError(err)

--- a/core/trie_prefetcher.go
+++ b/core/trie_prefetcher.go
@@ -1,0 +1,182 @@
+// Copyright 2020 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+package core
+
+import (
+	"sync/atomic"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/state"
+	"github.com/ethereum/go-ethereum/log"
+	"github.com/ethereum/go-ethereum/metrics"
+)
+
+var (
+	triePrefetchFetchMeter = metrics.NewRegisteredMeter("trie/prefetch/fetch", nil)
+	triePrefetchSkipMeter  = metrics.NewRegisteredMeter("trie/prefetch/skip", nil)
+	triePrefetchDropMeter  = metrics.NewRegisteredMeter("trie/prefetch/drop", nil)
+)
+
+// triePrefetcher is an active prefetcher, which receives accounts or storage
+// items on two channels, and does trie-loading of the items.
+// The goal is to get as much useful content into the caches as possible
+type triePrefetcher struct {
+	cmdCh   chan (command)
+	abortCh chan (struct{})
+	db      state.Database
+	stale   uint64
+}
+
+func newTriePrefetcher(db state.Database) *triePrefetcher {
+	return &triePrefetcher{
+		cmdCh:   make(chan command, 200),
+		abortCh: make(chan struct{}),
+		db:      db,
+	}
+}
+
+type command struct {
+	root    *common.Hash
+	address *common.Address
+	slots   []common.Hash
+}
+
+func (p *triePrefetcher) loop() {
+	var (
+		tr          state.Trie
+		err         error
+		currentRoot common.Hash
+		// Some tracking of performance
+		skipped int64
+		fetched int64
+	)
+	for {
+		select {
+		case cmd := <-p.cmdCh:
+			// New roots are sent synchoronously
+			if cmd.root != nil && cmd.slots == nil {
+				// Update metrics at new block events
+				triePrefetchFetchMeter.Mark(fetched)
+				fetched = 0
+				triePrefetchSkipMeter.Mark(skipped)
+				skipped = 0
+				// New root and number
+				currentRoot = *cmd.root
+				tr, err = p.db.OpenTrie(currentRoot)
+				if err != nil {
+					log.Warn("trie prefetcher failed opening trie", "root", currentRoot, "err", err)
+				}
+				// Open for business again
+				atomic.StoreUint64(&p.stale, 0)
+				continue
+			}
+			// Don't get stuck precaching on old blocks
+			if atomic.LoadUint64(&p.stale) == 1 {
+				if nSlots := len(cmd.slots); nSlots > 0 {
+					skipped += int64(nSlots)
+				} else {
+					skipped++
+				}
+				// Keep reading until we're in step with the chain
+				continue
+			}
+			// It's either storage slots or an account
+			if cmd.slots != nil {
+				storageTrie, err := p.db.OpenTrie(*cmd.root)
+				if err != nil {
+					log.Warn("trie prefetcher failed opening storage trie", "root", *cmd.root, "err", err)
+					skipped += int64(len(cmd.slots))
+					continue
+				}
+				for i, key := range cmd.slots {
+					storageTrie.TryGet(key[:])
+					fetched++
+					// Abort if we fall behind
+					if atomic.LoadUint64(&p.stale) == 1 {
+						skipped += int64(len(cmd.slots[i:]))
+						break
+					}
+				}
+			} else { // an account
+				if tr == nil {
+					skipped++
+					continue
+				}
+				// We're in sync with the chain, do preloading
+				if cmd.address != nil {
+					fetched++
+					addr := *cmd.address
+					tr.TryGet(addr[:])
+				}
+			}
+		case <-p.abortCh:
+			return
+		}
+	}
+}
+
+// Close stops the prefetcher
+func (p *triePrefetcher) Close() {
+	p.abortCh <- struct{}{}
+}
+
+// Reset prevent the prefetcher from entering a state where it is
+// behind the actual block processing.
+// It causes any existing (stale) work to be ignored, and the prefetcher will skip ahead
+// to current tasks
+func (p *triePrefetcher) Reset(number uint64, root common.Hash) {
+	// Set staleness
+	atomic.StoreUint64(&p.stale, 1)
+	// Do a synced send, so we're sure it punches through any old (now stale) commands
+	cmd := command{
+		root: &root,
+	}
+	p.cmdCh <- cmd
+}
+
+func (p *triePrefetcher) Pause() {
+	// Set staleness
+	atomic.StoreUint64(&p.stale, 1)
+}
+
+// PrefetchAddress adds an address for prefetching
+func (p *triePrefetcher) PrefetchAddress(addr common.Address) {
+	cmd := command{
+		address: &addr,
+	}
+	// We do an async send here, to not cause the caller to block
+	select {
+	case p.cmdCh <- cmd:
+	default:
+		triePrefetchDropMeter.Mark(1)
+	}
+}
+
+// PrefetchStorage adds a storage root and a set of keys for prefetching
+func (p *triePrefetcher) PrefetchStorage(root common.Hash, slots []common.Hash) {
+	cmd := command{
+		root:  &root,
+		slots: slots,
+	}
+	// We do an async send here, to not cause the caller to block
+	select {
+	case p.cmdCh <- cmd:
+	default:
+		triePrefetchDropMeter.Mark(int64(len(slots)))
+	}
+
+}

--- a/crypto/crypto_test.go
+++ b/crypto/crypto_test.go
@@ -42,6 +42,13 @@ func TestKeccak256Hash(t *testing.T) {
 	checkhash(t, "Sha3-256-array", func(in []byte) []byte { h := Keccak256Hash(in); return h[:] }, msg, exp)
 }
 
+func TestKeccak256Hasher(t *testing.T) {
+	msg := []byte("abc")
+	exp, _ := hex.DecodeString("4e03657aea45a94fc7d47ba826c8d667c0d1e6e33a64a036ec44f58fa12d6c45")
+	hasher := NewKeccakHasher()
+	checkhash(t, "Sha3-256-array", func(in []byte) []byte { h := HashData(hasher, in); return h[:] }, msg, exp)
+}
+
 func TestToECDSAErrors(t *testing.T) {
 	if _, err := HexToECDSA("0000000000000000000000000000000000000000000000000000000000000000"); err == nil {
 		t.Fatal("HexToECDSA should've returned error")


### PR DESCRIPTION
This PR was originally opened against the `snapshot-5` branch over at @karalabe as https://github.com/karalabe/go-ethereum/pull/27 . That PR contains some graphs from running it. 

### Background: 

When we execute block `n` , we execute transactions serially. 
After tx 1, we call `Finalize`, which puts the address for each pending object into `pending`. 
Similarly, we for each of those, we call `obj.Finalize`, which does a similar thing for each modified `slot`. 

### Idea

So, during finalize, we also send each `addr` off onto a channel (non-blocking). And on that channel, there's a little 
precacher-thread which loads it from the trie and warms up the cache. 

So the snapshotter allows us to parallelize the trie-reads instead of doing it serially. At the end of the block, when we finally reach the update-phase, the trie caches will be prepopulated already, and the update will be quick.  
 