### PR TITLE
Localbloom

### DIFF
--- a/core/state/snapshot/difflayer.go
+++ b/core/state/snapshot/difflayer.go
@@ -27,7 +27,7 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/rlp"
-	"github.com/steakknife/bloomfilter"
+	"github.com/holiman/bloomfilter"
 )
 
 var (
@@ -110,7 +110,8 @@ type diffLayer struct {
 	storageList map[common.Hash][]common.Hash          // List of storage slots for iterated retrievals, one per account. Any existing lists are sorted if non-nil
 	storageData map[common.Hash]map[common.Hash][]byte // Keyed storage slots for direct retrival. one per account (nil means deleted)
 
-	diffed *bloomfilter.Filter // Bloom filter tracking all the diffed items up to the disk layer
+	diffed     *bloomfilter.Filter // Bloom filter tracking local diffed items
+	cumulative *bloomfilter.Filter // cumulumative bloom filter -- by default set to nil
 
 	lock sync.RWMutex
 }
@@ -169,34 +170,24 @@ func newDiffLayer(parent snapshot, root common.Hash, destructs map[common.Hash]s
 		accountData: accounts,
 		storageData: storage,
 	}
-	switch parent := parent.(type) {
-	case *diskLayer:
-		dl.rebloom(parent, true)
-	case *diffLayer:
-		dl.rebloom(parent.origin, true)
-	default:
-		panic("unknown parent type")
-	}
+	dl.initBloom()
 	return dl
 }
 
-// rebloom discards the layer's current bloom and rebuilds it from scratch based
-// on the parent's and the local diffs.
-func (dl *diffLayer) rebloom(origin *diskLayer, creation bool) {
+// initBloom builds the layer's bloom and calculates memory consumption
+func (dl *diffLayer) initBloom() {
 	dl.lock.Lock()
 	defer dl.lock.Unlock()
 
 	defer func(start time.Time) {
 		snapshotBloomIndexTimer.Update(time.Since(start))
 	}(time.Now())
-
-	// Inject the new origin that triggered the rebloom
-	dl.origin = origin
-
 	// Retrieve the parent bloom or create a fresh empty one
+	// We need to use the same keys as the parent bloom if we want to be able
+	// to make union later
 	if parent, ok := dl.parent.(*diffLayer); ok {
 		parent.lock.RLock()
-		dl.diffed, _ = parent.diffed.Copy()
+		dl.diffed, _ = parent.diffed.NewCompatible()
 		parent.lock.RUnlock()
 	} else {
 		dl.diffed, _ = bloomfilter.New(uint64(bloomSize), uint64(bloomFuncs))
@@ -218,9 +209,7 @@ func (dl *diffLayer) rebloom(origin *diskLayer, creation bool) {
 		nHashes++
 	}
 	dl.memory = dataSize + nHashes*uint64(common.HashLength)
-	if creation {
-		snapshotDirtyAccountWriteMeter.Mark(int64(dataSize))
-	}
+	snapshotDirtyAccountWriteMeter.Mark(int64(dataSize))
 
 	dataSize, nHashes = uint64(0), uint64(0)
 	for accountHash, slots := range dl.storageData {
@@ -235,16 +224,39 @@ func (dl *diffLayer) rebloom(origin *diskLayer, creation bool) {
 		}
 	}
 	dl.memory += dataSize + nHashes*uint64(common.HashLength)
-	if creation {
-		snapshotDirtyStorageWriteMeter.Mark(int64(dataSize))
+	snapshotDirtyStorageWriteMeter.Mark(int64(dataSize))
+}
+
+// Prepare prepares the difflayer for execution, and creates the cumulative
+// bloom
+func (dl *diffLayer) Prepare(origin *diskLayer) {
+	dl.lock.Lock()
+	dl.cumulative, _ = dl.diffed.Copy()
+	layer := dl
+	for {
+		if parent, ok := layer.parent.(*diffLayer); ok {
+			parent.lock.RLock()
+			dl.cumulative.UnionInPlace(parent.diffed)
+			parent.lock.RUnlock()
+			layer = parent
+		} else {
+			break
+		}
 	}
+	dl.origin = origin
+	dl.lock.Unlock()
 	// Calculate the current false positive rate and update the error rate meter.
-	// This is a bit cheating because subsequent layers will overwrite it, but it
-	// should be fine, we're only interested in ballpark figures.
-	k := float64(dl.diffed.K())
-	n := float64(dl.diffed.N())
-	m := float64(dl.diffed.M())
+	k := float64(dl.cumulative.K())
+	n := float64(dl.cumulative.N())
+	m := float64(dl.cumulative.M())
 	snapshotBloomErrorGauge.Update(math.Pow(1.0-math.Exp((-k)*(n+0.5)/(m-1)), k))
+
+}
+
+func (dl *diffLayer) Release() {
+	dl.lock.Lock()
+	dl.cumulative = nil
+	dl.lock.Unlock()
 }
 
 // Root returns the root hash for which this snapshot was made.
@@ -286,9 +298,9 @@ func (dl *diffLayer) AccountRLP(hash common.Hash) ([]byte, error) {
 	// Check the bloom filter first whether there's even a point in reaching into
 	// all the maps in all the layers below
 	dl.lock.RLock()
-	hit := dl.diffed.Contains(accountBloomHasher(hash))
+	hit := dl.cumulative.Contains(accountBloomHasher(hash))
 	if !hit {
-		hit = dl.diffed.Contains(destructBloomHasher(hash))
+		hit = dl.cumulative.Contains(destructBloomHasher(hash))
 	}
 	dl.lock.RUnlock()
 
@@ -346,9 +358,9 @@ func (dl *diffLayer) Storage(accountHash, storageHash common.Hash) ([]byte, erro
 	// Check the bloom filter first whether there's even a point in reaching into
 	// all the maps in all the layers below
 	dl.lock.RLock()
-	hit := dl.diffed.Contains(storageBloomHasher{accountHash, storageHash})
+	hit := dl.cumulative.Contains(storageBloomHasher{accountHash, storageHash})
 	if !hit {
-		hit = dl.diffed.Contains(destructBloomHasher(accountHash))
+		hit = dl.cumulative.Contains(destructBloomHasher(accountHash))
 	}
 	dl.lock.RUnlock()
 
@@ -457,6 +469,7 @@ func (dl *diffLayer) flatten() snapshot {
 		parent.storageData[accountHash] = comboData
 	}
 	// Return the combo parent
+	parent.diffed.UnionInPlace(dl.diffed)
 	return &diffLayer{
 		parent:      parent.parent,
 		origin:      parent.origin,
@@ -465,7 +478,7 @@ func (dl *diffLayer) flatten() snapshot {
 		accountData: parent.accountData,
 		storageData: parent.storageData,
 		storageList: make(map[common.Hash][]common.Hash),
-		diffed:      dl.diffed,
+		diffed:      parent.diffed,
 		memory:      parent.memory + dl.memory,
 	}
 }

--- a/core/state/snapshot/disklayer.go
+++ b/core/state/snapshot/disklayer.go
@@ -166,4 +166,3 @@ func (dl *diskLayer) Update(blockHash common.Hash, destructs map[common.Hash]str
 }
 
 func (dl *diskLayer) Prepare(*diskLayer) {}
-func (dl *diskLayer) Release()           {}

--- a/core/state/snapshot/disklayer.go
+++ b/core/state/snapshot/disklayer.go
@@ -164,3 +164,6 @@ func (dl *diskLayer) Storage(accountHash, storageHash common.Hash) ([]byte, erro
 func (dl *diskLayer) Update(blockHash common.Hash, destructs map[common.Hash]struct{}, accounts map[common.Hash][]byte, storage map[common.Hash]map[common.Hash][]byte) *diffLayer {
 	return newDiffLayer(dl, blockHash, destructs, accounts, storage)
 }
+
+func (dl *diskLayer) Prepare(*diskLayer) {}
+func (dl *diskLayer) Release()           {}

--- a/core/state/snapshot/snapshot.go
+++ b/core/state/snapshot/snapshot.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	"sync"
 	"sync/atomic"
+	"time"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/rawdb"
@@ -65,8 +66,9 @@ var (
 	snapshotFlushStorageItemMeter = metrics.NewRegisteredMeter("state/snapshot/flush/storage/item", nil)
 	snapshotFlushStorageSizeMeter = metrics.NewRegisteredMeter("state/snapshot/flush/storage/size", nil)
 
-	snapshotBloomIndexTimer = metrics.NewRegisteredResettingTimer("state/snapshot/bloom/index", nil)
-	snapshotBloomErrorGauge = metrics.NewRegisteredGaugeFloat64("state/snapshot/bloom/error", nil)
+	snapshotBloomPrepareTimer = metrics.NewRegisteredResettingTimer("state/snapshot/bloom/prepare", nil)
+	snapshotBloomIndexTimer   = metrics.NewRegisteredResettingTimer("state/snapshot/bloom/index", nil)
+	snapshotBloomErrorGauge   = metrics.NewRegisteredGaugeFloat64("state/snapshot/bloom/error", nil)
 
 	snapshotBloomAccountTrueHitMeter  = metrics.NewRegisteredMeter("state/snapshot/bloom/account/truehit", nil)
 	snapshotBloomAccountFalseHitMeter = metrics.NewRegisteredMeter("state/snapshot/bloom/account/falsehit", nil)
@@ -107,7 +109,6 @@ type Snapshot interface {
 	// Storage directly retrieves the storage data associated with a particular hash,
 	// within a particular account.
 	Storage(accountHash, storageHash common.Hash) ([]byte, error)
-	Release()
 }
 
 // snapshot is the internal version of the snapshot data layer that supports some
@@ -219,6 +220,9 @@ func (t *Tree) waitBuild() {
 }
 
 func (t *Tree) PrepareSnapshot(blockRoot common.Hash) Snapshot {
+	defer func(start time.Time) {
+		snapshotBloomPrepareTimer.Update(time.Since(start))
+	}(time.Now())
 	t.lock.RLock()
 	defer t.lock.RUnlock()
 	if snap := t.layers[blockRoot]; snap != nil {
@@ -324,9 +328,6 @@ func (t *Tree) Cap(root common.Hash, layers int) error {
 	default:
 		// Many layers requested to be retained, cap normally
 		persisted = t.cap(diff, layers)
-		if persisted != nil {
-			t.diskLayer = persisted
-		}
 	}
 	// Remove any layer that is stale or links into a stale layer
 	children := make(map[common.Hash][]common.Hash)
@@ -349,7 +350,21 @@ func (t *Tree) Cap(root common.Hash, layers int) error {
 			remove(root)
 		}
 	}
-	// If the disk layer was modified, regenerate all the cummulative blooms
+	// If the disk layer was modified, wipe all the cumulative blooms
+	if persisted != nil {
+		// Update ref
+		t.diskLayer = persisted
+		var wipeCumulative func(root common.Hash)
+		wipeCumulative = func(root common.Hash) {
+			if diff, ok := t.layers[root].(*diffLayer); ok {
+				diff.cumulative = nil
+			}
+			for _, child := range children[root] {
+				wipeCumulative(child)
+			}
+		}
+		wipeCumulative(persisted.root)
+	}
 	return nil
 }
 

--- a/core/state/snapshot/snapshot.go
+++ b/core/state/snapshot/snapshot.go
@@ -332,7 +332,7 @@ func (t *Tree) Cap(root common.Hash, layers int) error {
 		var rebloom func(root common.Hash)
 		rebloom = func(root common.Hash) {
 			if diff, ok := t.layers[root].(*diffLayer); ok {
-				diff.rebloom(persisted)
+				diff.rebloom(persisted, false)
 			}
 			for _, child := range children[root] {
 				rebloom(child)

--- a/core/state/state_object.go
+++ b/core/state/state_object.go
@@ -329,17 +329,12 @@ func (s *stateObject) updateTrie(db Database) Trie {
 			// lazy load storage
 			if storage == nil {
 				// Retrieve the old storage map, if available
-				s.db.snapLock.RLock()
 				storage = s.db.snapStorage[s.addrHash]
-				s.db.snapLock.RUnlock()
 
 				// If no old storage map was available, create a new one
 				if storage == nil {
 					storage = make(map[common.Hash][]byte)
-
-					s.db.snapLock.Lock()
 					s.db.snapStorage[s.addrHash] = storage
-					s.db.snapLock.Unlock()
 				}
 			}
 			storage[crypto.Keccak256Hash(key[:])] = v // v will be nil if value is 0x00

--- a/core/state/state_object_test.go
+++ b/core/state/state_object_test.go
@@ -18,6 +18,8 @@ package state
 
 import (
 	"bytes"
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/rlp"
 	"testing"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -42,5 +44,21 @@ func BenchmarkCutCustomTrim(b *testing.B) {
 	value := common.HexToHash("0x01")
 	for i := 0; i < b.N; i++ {
 		common.TrimLeftZeroes(value[:])
+	}
+}
+
+// BenchmarkHashKey-6   	 1221526	       975 ns/op
+func BenchmarkHashKey(b *testing.B) {
+	key := common.HexToHash("0x01")
+	for i := 0; i < b.N; i++ {
+		crypto.Keccak256Hash(key[:])
+	}
+}
+
+//BenchmarkEncodeValue-6   	 4843382	       219 ns/op
+func BenchmarkEncodeValue(b *testing.B) {
+	value := common.HexToHash("0x01")
+	for i := 0; i < b.N; i++ {
+		rlp.EncodeToBytes(common.TrimLeftZeroes(value[:]))
 	}
 }

--- a/core/state/statedb.go
+++ b/core/state/statedb.go
@@ -866,7 +866,6 @@ func (s *StateDB) Commit(deleteEmptyObjects bool) (common.Hash, error) {
 				log.Warn("Failed to cap snapshot tree", "root", root, "layers", 127, "err", err)
 			}
 		}
-		s.snap.Release()
 		s.snap, s.snapDestructs, s.snapAccounts, s.snapStorage = nil, nil, nil, nil
 	}
 	return root, err

--- a/core/state/statedb.go
+++ b/core/state/statedb.go
@@ -359,6 +359,7 @@ func (s *StateDB) StorageTrie(addr common.Address) Trie {
 	}
 	cpy := stateObject.deepCopy(s)
 	cpy.updateTrie(s.db)
+	// Explicitly load the trie
 	return cpy.getTrie(s.db)
 }
 
@@ -806,7 +807,6 @@ func (s *StateDB) clearJournalAndRefund() {
 func (s *StateDB) Commit(deleteEmptyObjects bool) (common.Hash, error) {
 	// Finalize any pending changes and merge everything into the tries
 	s.IntermediateRoot(deleteEmptyObjects)
-
 	// Commit objects to the trie, measuring the elapsed time
 	for addr := range s.stateObjectsDirty {
 		if obj := s.stateObjects[addr]; !obj.deleted {

--- a/core/state/statedb.go
+++ b/core/state/statedb.go
@@ -855,11 +855,12 @@ func (s *StateDB) Commit(deleteEmptyObjects bool) (common.Hash, error) {
 		}
 		// Only update if there's a state transition (skip empty Clique blocks)
 		if parent := s.snap.Root(); parent != root {
+			// We cap first, leaving space for the one we're about to add
+			if err := s.snaps.Cap(root, 127-1); err != nil { // Persistent layer is 128th, the last available trie
+				log.Warn("Failed to cap snapshot tree", "root", root, "layers", 127-1, "err", err)
+			}
 			if err := s.snaps.Update(root, parent, s.snapDestructs, s.snapAccounts, s.snapStorage); err != nil {
 				log.Warn("Failed to update snapshot tree", "from", parent, "to", root, "err", err)
-			}
-			if err := s.snaps.Cap(root, 127); err != nil { // Persistent layer is 128th, the last available trie
-				log.Warn("Failed to cap snapshot tree", "root", root, "layers", 127, "err", err)
 			}
 		}
 		s.snap, s.snapDestructs, s.snapAccounts, s.snapStorage = nil, nil, nil, nil

--- a/go.mod
+++ b/go.mod
@@ -33,7 +33,7 @@ require (
 	github.com/gorilla/websocket v1.4.1-0.20190629185528-ae1634f6a989
 	github.com/graph-gophers/graphql-go v0.0.0-20191115155744-f33e81362277
 	github.com/hashicorp/golang-lru v0.0.0-20160813221303-0a025b7e63ad
-	github.com/holiman/bloomfilter v0.0.0-20191206152701-e4d21e6716c9
+	github.com/holiman/bloomfilter v0.0.0-20191211091059-3e24bf2f1d8e
 	github.com/huin/goupnp v0.0.0-20161224104101-679507af18f3
 	github.com/influxdata/influxdb v1.2.3-0.20180221223340-01288bdb0883
 	github.com/jackpal/go-nat-pmp v1.0.2-0.20160603034137-1fa385a6f458

--- a/go.mod
+++ b/go.mod
@@ -33,6 +33,7 @@ require (
 	github.com/gorilla/websocket v1.4.1-0.20190629185528-ae1634f6a989
 	github.com/graph-gophers/graphql-go v0.0.0-20191115155744-f33e81362277
 	github.com/hashicorp/golang-lru v0.0.0-20160813221303-0a025b7e63ad
+	github.com/holiman/bloomfilter v0.0.0-20191204204232-5fc8e9365fc2
 	github.com/huin/goupnp v0.0.0-20161224104101-679507af18f3
 	github.com/influxdata/influxdb v1.2.3-0.20180221223340-01288bdb0883
 	github.com/jackpal/go-nat-pmp v1.0.2-0.20160603034137-1fa385a6f458
@@ -57,6 +58,7 @@ require (
 	github.com/stretchr/testify v1.4.0
 	github.com/syndtr/goleveldb v1.0.1-0.20190923125748-758128399b1d
 	github.com/tyler-smith/go-bip39 v1.0.1-0.20181017060643-dbb3b84ba2ef
+	github.com/umbracle/fastrlp v0.0.0-20191017143648-86584926e68c
 	github.com/wsddn/go-ecdh v0.0.0-20161211032359-48726bab9208
 	golang.org/x/crypto v0.0.0-20200311171314-f7b00557c8c4
 	golang.org/x/net v0.0.0-20200301022130-244492dfa37a // indirect

--- a/go.mod
+++ b/go.mod
@@ -33,7 +33,7 @@ require (
 	github.com/gorilla/websocket v1.4.1-0.20190629185528-ae1634f6a989
 	github.com/graph-gophers/graphql-go v0.0.0-20191115155744-f33e81362277
 	github.com/hashicorp/golang-lru v0.0.0-20160813221303-0a025b7e63ad
-	github.com/holiman/bloomfilter v0.0.0-20191204204232-5fc8e9365fc2
+	github.com/holiman/bloomfilter v0.0.0-20191206152701-e4d21e6716c9
 	github.com/huin/goupnp v0.0.0-20161224104101-679507af18f3
 	github.com/influxdata/influxdb v1.2.3-0.20180221223340-01288bdb0883
 	github.com/jackpal/go-nat-pmp v1.0.2-0.20160603034137-1fa385a6f458
@@ -58,7 +58,6 @@ require (
 	github.com/stretchr/testify v1.4.0
 	github.com/syndtr/goleveldb v1.0.1-0.20190923125748-758128399b1d
 	github.com/tyler-smith/go-bip39 v1.0.1-0.20181017060643-dbb3b84ba2ef
-	github.com/umbracle/fastrlp v0.0.0-20191017143648-86584926e68c
 	github.com/wsddn/go-ecdh v0.0.0-20161211032359-48726bab9208
 	golang.org/x/crypto v0.0.0-20200311171314-f7b00557c8c4
 	golang.org/x/net v0.0.0-20200301022130-244492dfa37a // indirect

--- a/go.sum
+++ b/go.sum
@@ -99,6 +99,8 @@ github.com/graph-gophers/graphql-go v0.0.0-20191115155744-f33e81362277 h1:E0whKx
 github.com/graph-gophers/graphql-go v0.0.0-20191115155744-f33e81362277/go.mod h1:9CQHMSxwO4MprSdzoIEobiHpoLtHm77vfxsvsIN5Vuc=
 github.com/hashicorp/golang-lru v0.0.0-20160813221303-0a025b7e63ad h1:eMxs9EL0PvIGS9TTtxg4R+JxuPGav82J8rA+GFnY7po=
 github.com/hashicorp/golang-lru v0.0.0-20160813221303-0a025b7e63ad/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
+github.com/holiman/bloomfilter v0.0.0-20191204204232-5fc8e9365fc2 h1:W++/MG1xoR0V8YM2H47YC/G/DnZKODb0TmxY/GBcEac=
+github.com/holiman/bloomfilter v0.0.0-20191204204232-5fc8e9365fc2/go.mod h1:+E92jn6hSglI3YfM9VLe+w2tHKtSL9l83iBiZS7/4Lw=
 github.com/hpcloud/tail v1.0.0 h1:nfCOvKYfkgYP8hkirhJocXT2+zOD8yUNjXaWfTlyFKI=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
 github.com/huin/goupnp v0.0.0-20161224104101-679507af18f3 h1:DqD8eigqlUm0+znmx7zhL0xvTW3+e1jCekJMfBUADWI=
@@ -189,6 +191,8 @@ github.com/syndtr/goleveldb v1.0.1-0.20190923125748-758128399b1d h1:gZZadD8H+fF+
 github.com/syndtr/goleveldb v1.0.1-0.20190923125748-758128399b1d/go.mod h1:9OrXJhf154huy1nPWmuSrkgjPUtUNhA+Zmy+6AESzuA=
 github.com/tyler-smith/go-bip39 v1.0.1-0.20181017060643-dbb3b84ba2ef h1:wHSqTBrZW24CsNJDfeh9Ex6Pm0Rcpc7qrgKBiL44vF4=
 github.com/tyler-smith/go-bip39 v1.0.1-0.20181017060643-dbb3b84ba2ef/go.mod h1:sJ5fKU0s6JVwZjjcUEX2zFOnvq0ASQ2K9Zr6cf67kNs=
+github.com/umbracle/fastrlp v0.0.0-20191017143648-86584926e68c h1:KCbyOp0afQzDTGARP+qj9HpZVk79WQaQtAO+4kMy/E4=
+github.com/umbracle/fastrlp v0.0.0-20191017143648-86584926e68c/go.mod h1:TBFAIaLMusGh1X7Pd3trJTjLsOmNErpPV9/J7BY9lSA=
 github.com/urfave/cli v1.22.1/go.mod h1:Gos4lmkARVdJ6EkW0WaNv/tZAAMe9V7XWyB60NtXRu0=
 github.com/wsddn/go-ecdh v0.0.0-20161211032359-48726bab9208 h1:1cngl9mPEoITZG8s8cVcUy5CeIBYhEESkOB7m6Gmkrk=
 github.com/wsddn/go-ecdh v0.0.0-20161211032359-48726bab9208/go.mod h1:IotVbo4F+mw0EzQ08zFqg7pK3FebNXpaMsRy2RT+Ees=

--- a/go.sum
+++ b/go.sum
@@ -99,8 +99,8 @@ github.com/graph-gophers/graphql-go v0.0.0-20191115155744-f33e81362277 h1:E0whKx
 github.com/graph-gophers/graphql-go v0.0.0-20191115155744-f33e81362277/go.mod h1:9CQHMSxwO4MprSdzoIEobiHpoLtHm77vfxsvsIN5Vuc=
 github.com/hashicorp/golang-lru v0.0.0-20160813221303-0a025b7e63ad h1:eMxs9EL0PvIGS9TTtxg4R+JxuPGav82J8rA+GFnY7po=
 github.com/hashicorp/golang-lru v0.0.0-20160813221303-0a025b7e63ad/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
-github.com/holiman/bloomfilter v0.0.0-20191206152701-e4d21e6716c9 h1:8FJHmfDjj0LRfpyJYRC8gQl4NO9Pl3TOOkkImi59bOk=
-github.com/holiman/bloomfilter v0.0.0-20191206152701-e4d21e6716c9/go.mod h1:+E92jn6hSglI3YfM9VLe+w2tHKtSL9l83iBiZS7/4Lw=
+github.com/holiman/bloomfilter v0.0.0-20191211091059-3e24bf2f1d8e h1:+9n746lrjamJzr9i9c0O6DyMQ7bqvq9EK3WR7OnaKss=
+github.com/holiman/bloomfilter v0.0.0-20191211091059-3e24bf2f1d8e/go.mod h1:+E92jn6hSglI3YfM9VLe+w2tHKtSL9l83iBiZS7/4Lw=
 github.com/hpcloud/tail v1.0.0 h1:nfCOvKYfkgYP8hkirhJocXT2+zOD8yUNjXaWfTlyFKI=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
 github.com/huin/goupnp v0.0.0-20161224104101-679507af18f3 h1:DqD8eigqlUm0+znmx7zhL0xvTW3+e1jCekJMfBUADWI=

--- a/go.sum
+++ b/go.sum
@@ -99,8 +99,8 @@ github.com/graph-gophers/graphql-go v0.0.0-20191115155744-f33e81362277 h1:E0whKx
 github.com/graph-gophers/graphql-go v0.0.0-20191115155744-f33e81362277/go.mod h1:9CQHMSxwO4MprSdzoIEobiHpoLtHm77vfxsvsIN5Vuc=
 github.com/hashicorp/golang-lru v0.0.0-20160813221303-0a025b7e63ad h1:eMxs9EL0PvIGS9TTtxg4R+JxuPGav82J8rA+GFnY7po=
 github.com/hashicorp/golang-lru v0.0.0-20160813221303-0a025b7e63ad/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
-github.com/holiman/bloomfilter v0.0.0-20191204204232-5fc8e9365fc2 h1:W++/MG1xoR0V8YM2H47YC/G/DnZKODb0TmxY/GBcEac=
-github.com/holiman/bloomfilter v0.0.0-20191204204232-5fc8e9365fc2/go.mod h1:+E92jn6hSglI3YfM9VLe+w2tHKtSL9l83iBiZS7/4Lw=
+github.com/holiman/bloomfilter v0.0.0-20191206152701-e4d21e6716c9 h1:8FJHmfDjj0LRfpyJYRC8gQl4NO9Pl3TOOkkImi59bOk=
+github.com/holiman/bloomfilter v0.0.0-20191206152701-e4d21e6716c9/go.mod h1:+E92jn6hSglI3YfM9VLe+w2tHKtSL9l83iBiZS7/4Lw=
 github.com/hpcloud/tail v1.0.0 h1:nfCOvKYfkgYP8hkirhJocXT2+zOD8yUNjXaWfTlyFKI=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
 github.com/huin/goupnp v0.0.0-20161224104101-679507af18f3 h1:DqD8eigqlUm0+znmx7zhL0xvTW3+e1jCekJMfBUADWI=
@@ -191,8 +191,6 @@ github.com/syndtr/goleveldb v1.0.1-0.20190923125748-758128399b1d h1:gZZadD8H+fF+
 github.com/syndtr/goleveldb v1.0.1-0.20190923125748-758128399b1d/go.mod h1:9OrXJhf154huy1nPWmuSrkgjPUtUNhA+Zmy+6AESzuA=
 github.com/tyler-smith/go-bip39 v1.0.1-0.20181017060643-dbb3b84ba2ef h1:wHSqTBrZW24CsNJDfeh9Ex6Pm0Rcpc7qrgKBiL44vF4=
 github.com/tyler-smith/go-bip39 v1.0.1-0.20181017060643-dbb3b84ba2ef/go.mod h1:sJ5fKU0s6JVwZjjcUEX2zFOnvq0ASQ2K9Zr6cf67kNs=
-github.com/umbracle/fastrlp v0.0.0-20191017143648-86584926e68c h1:KCbyOp0afQzDTGARP+qj9HpZVk79WQaQtAO+4kMy/E4=
-github.com/umbracle/fastrlp v0.0.0-20191017143648-86584926e68c/go.mod h1:TBFAIaLMusGh1X7Pd3trJTjLsOmNErpPV9/J7BY9lSA=
 github.com/urfave/cli v1.22.1/go.mod h1:Gos4lmkARVdJ6EkW0WaNv/tZAAMe9V7XWyB60NtXRu0=
 github.com/wsddn/go-ecdh v0.0.0-20161211032359-48726bab9208 h1:1cngl9mPEoITZG8s8cVcUy5CeIBYhEESkOB7m6Gmkrk=
 github.com/wsddn/go-ecdh v0.0.0-20161211032359-48726bab9208/go.mod h1:IotVbo4F+mw0EzQ08zFqg7pK3FebNXpaMsRy2RT+Ees=


### PR DESCRIPTION
Supersedes https://github.com/karalabe/go-ethereum/pull/25. Work in progress. 

The latest cumulative bloom is retained by the layer that was executed on. When the child layer is pushed on top, and is executed on, then it will use the parent cumulative to build a new, and nuke the parent's cumulative.

This way, we still have 128 local blooms, plus a couple of cumulative blooms. Whenever there's a diffToDisk, we wipe all cumulative blooms.

This way, we keep the benefit of not having to iterate over all data a lot, have pretty up-to-date cumulative blooms, and increase the memory requirements a little bit.

I think this should not take a penalty on 1-block reorgs, since 'commit' does not "pull" the bloom from parent to child -- that happens only when we execute on top of child.