### PR TITLE
cmd/devp2p: tweak DNS TTLs

### DIFF
--- a/cmd/devp2p/dnscmd.go
+++ b/cmd/devp2p/dnscmd.go
@@ -97,8 +97,8 @@ var (
 )
 
 const (
-	rootTTL     = 1
-	treeNodeTTL = 2147483647
+	rootTTL     = 30 * 60              // 30 min
+	treeNodeTTL = 2 * 7 * 24 * 60 * 60 // 2 weeks
 )
 
 // dnsSync performs dnsSyncCommand.

--- a/cmd/devp2p/dnscmd.go
+++ b/cmd/devp2p/dnscmd.go
@@ -98,7 +98,7 @@ var (
 
 const (
 	rootTTL     = 30 * 60              // 30 min
-	treeNodeTTL = 2 * 7 * 24 * 60 * 60 // 2 weeks
+	treeNodeTTL = 4 * 7 * 24 * 60 * 60 // 4 weeks
 )
 
 // dnsSync performs dnsSyncCommand.


### PR DESCRIPTION
This increases the TTL on tree root records to enable some caching.
It also decreases the TTL on the leaves to a saner value.
