### PR TITLE
eth: add missing eth_getHashrate() method

### DIFF
--- a/eth/api.go
+++ b/eth/api.go
@@ -66,6 +66,11 @@ func (api *PublicEthereumAPI) Hashrate() hexutil.Uint64 {
 	return hexutil.Uint64(api.e.Miner().HashRate())
 }
 
+// GetHashrate returns the POW hashrate
+func (api *PublicEthereumAPI) GetHashrate() hexutil.Uint64 {
+	return api.Hashrate()
+}
+
 // ChainId is the EIP-155 replay-protection chain id for the current ethereum chain config.
 func (api *PublicEthereumAPI) ChainId() hexutil.Uint64 {
 	chainID := new(big.Int)


### PR DESCRIPTION
The RPC method `eth_getHashrate()` returns `undefined`, where one would expect that it would return a numeric value like fellow methods `miner_getHashrate()` and `ethash_getHashrate()`, as well as the property value `eth_hashrate`.

This is happening because the `ethash/*API` is registered under both `eth_` and `ethash_` namespaces for backwards compatibility reasons: https://github.com/ethereum/go-ethereum/blob/master/consensus/ethash/ethash.go#L655, and the method is not yet implemented under the `eth_` receiver.

```
> eth
{
  accounts: ["0x48de97512c606b3cd1d2787f69530587a59b550f"],
  blockNumber: 0,
  coinbase: "0x48de97512c606b3cd1d2787f69530587a59b550f",
  compile: {
    lll: function(),
    serpent: function(),
    solidity: function()
  },
  defaultAccount: undefined,
  defaultBlock: "latest",
  gasPrice: 1000000000,
  hashrate: 0,
  mining: false,
  pendingTransactions: [],
  protocolVersion: "0x41",
  syncing: {
    currentBlock: 913456,
    highestBlock: 7575483,
    knownStates: 1781791,
    pulledStates: 1769535,
    startingBlock: 13
  },
  call: function(),
  chainId: function(),
  contract: function(abi),
  estimateGas: function(),
  fillTransaction: function(),
  filter: function(options, callback, filterCreationErrorCallback),
  getAccounts: function(callback),
  getBalance: function(),
  getBlock: function(),
  getBlockByHash: function(),
  getBlockByNumber: function(),
  getBlockNumber: function(callback),
  getBlockTransactionCount: function(),
  getBlockUncleCount: function(),
  getCode: function(),
  getCoinbase: function(callback),
  getCompilers: function(),
  getGasPrice: function(callback),
  getHashrate: function(callback),
  getHeaderByHash: function(),
  getHeaderByNumber: function(),
  getMining: function(callback),
  getPendingTransactions: function(callback),
  getProof: function(),
  getProtocolVersion: function(callback),
  getRawTransaction: function(),
  getRawTransactionFromBlock: function(),
  getStorageAt: function(),
  getSyncing: function(callback),
  getTransaction: function(),
  getTransactionCount: function(),
  getTransactionFromBlock: function(),
  getTransactionReceipt: function(),
  getUncle: function(),
  getWork: function(),
  iban: function(iban),
  icapNamereg: function(),
  isSyncing: function(callback),
  namereg: function(),
  resend: function(),
  sendIBANTransaction: function(),
  sendRawTransaction: function(),
  sendTransaction: function(),
  sign: function(),
  signTransaction: function(),
  submitTransaction: function(),
  submitWork: function()
}
> ethash
{
  getHashrate: function(),
  getWork: function(),
  submitHashRate: function(),
  submitWork: function()
}
> miner
{
  getHashrate: function(),
  setEtherbase: function(),
  setExtra: function(),
  setGasPrice: function(),
  setRecommitInterval: function(),
  start: function(),
  stop: function()
}
> console.log(Date(), web3.version.node, eth.getHashrate(), eth.hashrate, ethash.getHashrate(), miner.getHashrate());

Mon Mar 23 2020 11:19:23 GMT-0500 (CDT) Geth/v1.9.13-unstable-0734c4b8/linux-amd64/go1.13.5 undefined 0 0 0
null
```