### PR TITLE
core/state/snapshot: implement disk iterator seek

### DIFF
--- a/cmd/utils/cmd.go
+++ b/cmd/utils/cmd.go
@@ -301,7 +301,7 @@ func ExportPreimages(db ethdb.Database, fn string) error {
 		defer writer.(*gzip.Writer).Close()
 	}
 	// Iterate over the preimages and export them
-	it := db.NewIteratorWith([]byte("secure-key-"), nil)
+	it := db.NewIterator([]byte("secure-key-"), nil)
 	defer it.Release()
 
 	for it.Next() {

--- a/cmd/utils/cmd.go
+++ b/cmd/utils/cmd.go
@@ -301,7 +301,7 @@ func ExportPreimages(db ethdb.Database, fn string) error {
 		defer writer.(*gzip.Writer).Close()
 	}
 	// Iterate over the preimages and export them
-	it := db.NewIteratorWithPrefix([]byte("secure-key-"))
+	it := db.NewIteratorWith([]byte("secure-key-"), nil)
 	defer it.Release()
 
 	for it.Next() {

--- a/common/bytes.go
+++ b/common/bytes.go
@@ -145,3 +145,14 @@ func TrimLeftZeroes(s []byte) []byte {
 	}
 	return s[idx:]
 }
+
+// TrimRightZeroes returns a subslice of s without trailing zeroes
+func TrimRightZeroes(s []byte) []byte {
+	idx := len(s)
+	for ; idx > 0; idx-- {
+		if s[idx-1] != 0 {
+			break
+		}
+	}
+	return s[:idx]
+}

--- a/common/bytes_test.go
+++ b/common/bytes_test.go
@@ -105,3 +105,22 @@ func TestNoPrefixShortHexOddLength(t *testing.T) {
 		t.Errorf("Expected %x got %x", expected, result)
 	}
 }
+
+func TestTrimRightZeroes(t *testing.T) {
+	tests := []struct {
+		arr []byte
+		exp []byte
+	}{
+		{FromHex("0x00ffff00ff0000"), FromHex("0x00ffff00ff")},
+		{FromHex("0x00000000000000"), []byte{}},
+		{FromHex("0xff"), FromHex("0xff")},
+		{[]byte{}, []byte{}},
+		{FromHex("0x00ffffffffffff"), FromHex("0x00ffffffffffff")},
+	}
+	for i, test := range tests {
+		got := TrimRightZeroes(test.arr)
+		if !bytes.Equal(got, test.exp) {
+			t.Errorf("test %d, got %x exp %x", i, got, test.exp)
+		}
+	}
+}

--- a/core/rawdb/accessors_chain.go
+++ b/core/rawdb/accessors_chain.go
@@ -69,7 +69,7 @@ func ReadAllHashes(db ethdb.Iteratee, number uint64) []common.Hash {
 	prefix := headerKeyPrefix(number)
 
 	hashes := make([]common.Hash, 0, 1)
-	it := db.NewIteratorWith(prefix, nil)
+	it := db.NewIterator(prefix, nil)
 	defer it.Release()
 
 	for it.Next() {

--- a/core/rawdb/accessors_chain.go
+++ b/core/rawdb/accessors_chain.go
@@ -69,7 +69,7 @@ func ReadAllHashes(db ethdb.Iteratee, number uint64) []common.Hash {
 	prefix := headerKeyPrefix(number)
 
 	hashes := make([]common.Hash, 0, 1)
-	it := db.NewIteratorWithPrefix(prefix)
+	it := db.NewIteratorWith(prefix, nil)
 	defer it.Release()
 
 	for it.Next() {

--- a/core/rawdb/accessors_snapshot.go
+++ b/core/rawdb/accessors_snapshot.go
@@ -93,7 +93,7 @@ func DeleteStorageSnapshot(db ethdb.KeyValueWriter, accountHash, storageHash com
 // IterateStorageSnapshots returns an iterator for walking the entire storage
 // space of a specific account.
 func IterateStorageSnapshots(db ethdb.Iteratee, accountHash common.Hash) ethdb.Iterator {
-	return db.NewIteratorWithPrefix(storageSnapshotsKey(accountHash))
+	return db.NewIteratorWith(storageSnapshotsKey(accountHash), nil)
 }
 
 // ReadSnapshotJournal retrieves the serialized in-memory diff layers saved at

--- a/core/rawdb/accessors_snapshot.go
+++ b/core/rawdb/accessors_snapshot.go
@@ -93,7 +93,7 @@ func DeleteStorageSnapshot(db ethdb.KeyValueWriter, accountHash, storageHash com
 // IterateStorageSnapshots returns an iterator for walking the entire storage
 // space of a specific account.
 func IterateStorageSnapshots(db ethdb.Iteratee, accountHash common.Hash) ethdb.Iterator {
-	return db.NewIteratorWith(storageSnapshotsKey(accountHash), nil)
+	return db.NewIterator(storageSnapshotsKey(accountHash), nil)
 }
 
 // ReadSnapshotJournal retrieves the serialized in-memory diff layers saved at

--- a/core/rawdb/database.go
+++ b/core/rawdb/database.go
@@ -221,7 +221,7 @@ func NewLevelDBDatabaseWithFreezer(file string, cache int, handles int, freezer 
 // InspectDatabase traverses the entire database and checks the size
 // of all different categories of data.
 func InspectDatabase(db ethdb.Database) error {
-	it := db.NewIterator()
+	it := db.NewIterator(nil, nil)
 	defer it.Release()
 
 	var (

--- a/core/rawdb/table.go
+++ b/core/rawdb/table.go
@@ -113,17 +113,21 @@ func (t *table) NewIterator() ethdb.Iterator {
 // database content starting at a particular initial key (or after, if it does
 // not exist).
 func (t *table) NewIteratorWithStart(start []byte) ethdb.Iterator {
-	iter := t.db.NewIteratorWithStart(append([]byte(t.prefix), start...))
-	return &tableIterator{
-		iter:   iter,
-		prefix: t.prefix,
-	}
+	return t.NewIteratorWith(nil, start)
 }
 
 // NewIteratorWithPrefix creates a binary-alphabetical iterator over a subset
 // of database content with a particular key prefix.
 func (t *table) NewIteratorWithPrefix(prefix []byte) ethdb.Iterator {
-	iter := t.db.NewIteratorWithPrefix(append([]byte(t.prefix), prefix...))
+	return t.NewIteratorWith(prefix, nil)
+}
+
+// NewIteratorWith creates a binary-alphabetical iterator over a subset
+// of database content with a particular key prefix, starting at a particular
+// initial key (or after, if it does not exist).
+func (t *table) NewIteratorWith(prefix []byte, start []byte) ethdb.Iterator {
+	innerPrefix := append([]byte(t.prefix), prefix...)
+	iter := t.db.NewIteratorWith(innerPrefix, start)
 	return &tableIterator{
 		iter:   iter,
 		prefix: t.prefix,

--- a/core/rawdb/table.go
+++ b/core/rawdb/table.go
@@ -106,20 +106,7 @@ func (t *table) Delete(key []byte) error {
 // NewIterator creates a binary-alphabetical iterator over the entire keyspace
 // contained within the database.
 func (t *table) NewIterator() ethdb.Iterator {
-	return t.NewIteratorWithPrefix(nil)
-}
-
-// NewIteratorWithStart creates a binary-alphabetical iterator over a subset of
-// database content starting at a particular initial key (or after, if it does
-// not exist).
-func (t *table) NewIteratorWithStart(start []byte) ethdb.Iterator {
-	return t.NewIteratorWith(nil, start)
-}
-
-// NewIteratorWithPrefix creates a binary-alphabetical iterator over a subset
-// of database content with a particular key prefix.
-func (t *table) NewIteratorWithPrefix(prefix []byte) ethdb.Iterator {
-	return t.NewIteratorWith(prefix, nil)
+	return t.NewIteratorWith(nil, nil)
 }
 
 // NewIteratorWith creates a binary-alphabetical iterator over a subset

--- a/core/rawdb/table.go
+++ b/core/rawdb/table.go
@@ -103,18 +103,12 @@ func (t *table) Delete(key []byte) error {
 	return t.db.Delete(append([]byte(t.prefix), key...))
 }
 
-// NewIterator creates a binary-alphabetical iterator over the entire keyspace
-// contained within the database.
-func (t *table) NewIterator() ethdb.Iterator {
-	return t.NewIteratorWith(nil, nil)
-}
-
-// NewIteratorWith creates a binary-alphabetical iterator over a subset
+// NewIterator creates a binary-alphabetical iterator over a subset
 // of database content with a particular key prefix, starting at a particular
 // initial key (or after, if it does not exist).
-func (t *table) NewIteratorWith(prefix []byte, start []byte) ethdb.Iterator {
+func (t *table) NewIterator(prefix []byte, start []byte) ethdb.Iterator {
 	innerPrefix := append([]byte(t.prefix), prefix...)
-	iter := t.db.NewIteratorWith(innerPrefix, start)
+	iter := t.db.NewIterator(innerPrefix, start)
 	return &tableIterator{
 		iter:   iter,
 		prefix: t.prefix,

--- a/core/rawdb/table_test.go
+++ b/core/rawdb/table_test.go
@@ -19,6 +19,8 @@ package rawdb
 import (
 	"bytes"
 	"testing"
+
+	"github.com/ethereum/go-ethereum/ethdb"
 )
 
 func TestTableDatabase(t *testing.T)            { testTableDatabase(t, "prefix") }
@@ -96,49 +98,31 @@ func testTableDatabase(t *testing.T, prefix string) {
 		}
 	}
 
+	check := func(iter ethdb.Iterator, expCount, index int) {
+		count := 0
+		for iter.Next() {
+			key, value := iter.Key(), iter.Value()
+			if !bytes.Equal(key, entries[index].key) {
+				t.Fatalf("Key mismatch: want=%v, got=%v", entries[index].key, key)
+			}
+			if !bytes.Equal(value, entries[index].value) {
+				t.Fatalf("Value mismatch: want=%v, got=%v", entries[index].value, value)
+			}
+			index += 1
+			count++
+		}
+		if count != expCount {
+			t.Fatalf("Wrong number of elems, exp %d got %d", expCount, count)
+		}
+		iter.Release()
+	}
 	// Test iterators
-	iter := db.NewIterator()
-	var index int
-	for iter.Next() {
-		key, value := iter.Key(), iter.Value()
-		if !bytes.Equal(key, entries[index].key) {
-			t.Fatalf("Key mismatch: want=%v, got=%v", entries[index].key, key)
-		}
-		if !bytes.Equal(value, entries[index].value) {
-			t.Fatalf("Value mismatch: want=%v, got=%v", entries[index].value, value)
-		}
-		index += 1
-	}
-	iter.Release()
-
+	check(db.NewIterator(), 6, 0)
 	// Test iterators with prefix
-	iter = db.NewIteratorWithPrefix([]byte{0xff, 0xff})
-	index = 3
-	for iter.Next() {
-		key, value := iter.Key(), iter.Value()
-		if !bytes.Equal(key, entries[index].key) {
-			t.Fatalf("Key mismatch: want=%v, got=%v", entries[index].key, key)
-		}
-		if !bytes.Equal(value, entries[index].value) {
-			t.Fatalf("Value mismatch: want=%v, got=%v", entries[index].value, value)
-		}
-		index += 1
-	}
-	iter.Release()
-
+	check(db.NewIteratorWith([]byte{0xff, 0xff}, nil), 3, 3)
 	// Test iterators with start point
-	//iter = db.NewIteratorWithStart([]byte{0xff, 0xff, 0x02})
-	iter = db.NewIteratorWith(nil,[]byte{0xff, 0xff, 0x02})
-	index = 4
-	for iter.Next() {
-		key, value := iter.Key(), iter.Value()
-		if !bytes.Equal(key, entries[index].key) {
-			t.Fatalf("Key mismatch: want=%v, got=%v", entries[index].key, key)
-		}
-		if !bytes.Equal(value, entries[index].value) {
-			t.Fatalf("Value mismatch: want=%v, got=%v", entries[index].value, value)
-		}
-		index += 1
-	}
-	iter.Release()
+	check(db.NewIteratorWith(nil, []byte{0xff, 0xff, 0x02}), 2, 4)
+	// Test iterators with prefix and start point
+	check(db.NewIteratorWith([]byte{0xee}, nil), 0, 0)
+	check(db.NewIteratorWith(nil, []byte{0x00}), 6, 0)
 }

--- a/core/rawdb/table_test.go
+++ b/core/rawdb/table_test.go
@@ -117,12 +117,12 @@ func testTableDatabase(t *testing.T, prefix string) {
 		iter.Release()
 	}
 	// Test iterators
-	check(db.NewIterator(), 6, 0)
+	check(db.NewIterator(nil, nil), 6, 0)
 	// Test iterators with prefix
-	check(db.NewIteratorWith([]byte{0xff, 0xff}, nil), 3, 3)
+	check(db.NewIterator([]byte{0xff, 0xff}, nil), 3, 3)
 	// Test iterators with start point
-	check(db.NewIteratorWith(nil, []byte{0xff, 0xff, 0x02}), 2, 4)
+	check(db.NewIterator(nil, []byte{0xff, 0xff, 0x02}), 2, 4)
 	// Test iterators with prefix and start point
-	check(db.NewIteratorWith([]byte{0xee}, nil), 0, 0)
-	check(db.NewIteratorWith(nil, []byte{0x00}), 6, 0)
+	check(db.NewIterator([]byte{0xee}, nil), 0, 0)
+	check(db.NewIterator(nil, []byte{0x00}), 6, 0)
 }

--- a/core/rawdb/table_test.go
+++ b/core/rawdb/table_test.go
@@ -127,7 +127,8 @@ func testTableDatabase(t *testing.T, prefix string) {
 	iter.Release()
 
 	// Test iterators with start point
-	iter = db.NewIteratorWithStart([]byte{0xff, 0xff, 0x02})
+	//iter = db.NewIteratorWithStart([]byte{0xff, 0xff, 0x02})
+	iter = db.NewIteratorWith(nil,[]byte{0xff, 0xff, 0x02})
 	index = 4
 	for iter.Next() {
 		key, value := iter.Key(), iter.Value()

--- a/core/state/iterator_test.go
+++ b/core/state/iterator_test.go
@@ -51,7 +51,7 @@ func TestNodeIteratorCoverage(t *testing.T) {
 			t.Errorf("state entry not reported %x", hash)
 		}
 	}
-	it := db.TrieDB().DiskDB().(ethdb.Database).NewIterator()
+	it := db.TrieDB().DiskDB().(ethdb.Database).NewIterator(nil, nil)
 	for it.Next() {
 		key := it.Key()
 		if bytes.HasPrefix(key, []byte("secure-key-")) {

--- a/core/state/snapshot/disklayer_test.go
+++ b/core/state/snapshot/disklayer_test.go
@@ -18,7 +18,6 @@ package snapshot
 
 import (
 	"bytes"
-	"github.com/ethereum/go-ethereum/ethdb/leveldb"
 	"io/ioutil"
 	"testing"
 
@@ -26,6 +25,7 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/rawdb"
 	"github.com/ethereum/go-ethereum/ethdb"
+	"github.com/ethereum/go-ethereum/ethdb/leveldb"
 	"github.com/ethereum/go-ethereum/ethdb/memorydb"
 )
 
@@ -454,9 +454,9 @@ func tempDB() (ethdb.Database, error) {
 func TestDiskSeek(t *testing.T) {
 	// Create some accounts in the disk layer
 	//db := memorydb.New()
-	db ,err := tempDB()
+	db, err := tempDB()
 	if err != nil {
-		t.Fatal( err)
+		t.Fatal(err)
 	}
 	// Fill even keys [0,2,4...]
 	for i := 0; i < 0xff; i += 2 {

--- a/core/state/snapshot/disklayer_test.go
+++ b/core/state/snapshot/disklayer_test.go
@@ -19,6 +19,7 @@ package snapshot
 import (
 	"bytes"
 	"io/ioutil"
+	"os"
 	"testing"
 
 	"github.com/VictoriaMetrics/fastcache"
@@ -438,25 +439,20 @@ func TestDiskMidAccountPartialMerge(t *testing.T) {
 	// TODO(@karalabe) ?
 }
 
-func tempDB() (ethdb.Database, error) {
-	dir, err := ioutil.TempDir("", "disklayer-test")
-	if err != nil {
-		return nil, err
-	}
-	diskdb, err := leveldb.New(dir, 256, 0, "")
-	if err != nil {
-		return nil, err
-	}
-	return rawdb.NewDatabase(diskdb), nil
-}
-
 // TestDiskSeek tests that seek-operations work on the disk layer
 func TestDiskSeek(t *testing.T) {
 	// Create some accounts in the disk layer
-	//db := memorydb.New()
-	db, err := tempDB()
-	if err != nil {
+	var db ethdb.Database
+
+	if dir, err := ioutil.TempDir("", "disklayer-test"); err != nil {
 		t.Fatal(err)
+	} else {
+		defer os.RemoveAll(dir)
+		diskdb, err := leveldb.New(dir, 256, 0, "")
+		if err != nil {
+			t.Fatal(err)
+		}
+		db = rawdb.NewDatabase(diskdb)
 	}
 	// Fill even keys [0,2,4...]
 	for i := 0; i < 0xff; i += 2 {

--- a/core/state/snapshot/iterator.go
+++ b/core/state/snapshot/iterator.go
@@ -148,10 +148,10 @@ type diskAccountIterator struct {
 
 // AccountIterator creates an account iterator over a disk layer.
 func (dl *diskLayer) AccountIterator(seek common.Hash) AccountIterator {
-	// TODO: Fix seek position, or remove seek parameter
+	pos := append(rawdb.SnapshotAccountPrefix, common.TrimRightZeroes(seek[:])...)
 	return &diskAccountIterator{
 		layer: dl,
-		it:    dl.diskdb.NewIteratorWithPrefix(rawdb.SnapshotAccountPrefix),
+		it:    dl.diskdb.NewIteratorWithPrefix(pos),
 	}
 }
 

--- a/core/state/snapshot/iterator.go
+++ b/core/state/snapshot/iterator.go
@@ -151,7 +151,7 @@ func (dl *diskLayer) AccountIterator(seek common.Hash) AccountIterator {
 	pos := common.TrimRightZeroes(seek[:])
 	return &diskAccountIterator{
 		layer: dl,
-		it:    dl.diskdb.NewIteratorWith(rawdb.SnapshotAccountPrefix, pos),
+		it:    dl.diskdb.NewIterator(rawdb.SnapshotAccountPrefix, pos),
 	}
 }
 

--- a/core/state/snapshot/iterator.go
+++ b/core/state/snapshot/iterator.go
@@ -148,10 +148,10 @@ type diskAccountIterator struct {
 
 // AccountIterator creates an account iterator over a disk layer.
 func (dl *diskLayer) AccountIterator(seek common.Hash) AccountIterator {
-	pos := append(rawdb.SnapshotAccountPrefix, common.TrimRightZeroes(seek[:])...)
+	pos := common.TrimRightZeroes(seek[:])
 	return &diskAccountIterator{
 		layer: dl,
-		it:    dl.diskdb.NewIteratorWithPrefix(pos),
+		it:    dl.diskdb.NewIteratorWith(rawdb.SnapshotAccountPrefix, pos),
 	}
 }
 

--- a/core/state/snapshot/wipe.go
+++ b/core/state/snapshot/wipe.go
@@ -92,7 +92,7 @@ func wipeKeyRange(db ethdb.KeyValueStore, kind string, prefix []byte, keylen int
 	// Iterate over the key-range and delete all of them
 	start, logged := time.Now(), time.Now()
 
-	it := db.NewIteratorWithStart(prefix)
+	it := db.NewIteratorWith(prefix, nil)
 	for it.Next() {
 		// Skip any keys with the correct prefix but wrong lenth (trie nodes)
 		key := it.Key()
@@ -113,7 +113,8 @@ func wipeKeyRange(db ethdb.KeyValueStore, kind string, prefix []byte, keylen int
 				return err
 			}
 			batch.Reset()
-			it = db.NewIteratorWithStart(key)
+			seekPos := bytes.Trim(key, prefix)
+			it = db.NewIteratorWith(prefix, seekPos)
 
 			if time.Since(logged) > 8*time.Second {
 				log.Info("Deleting state snapshot leftovers", "kind", kind, "wiped", items, "elapsed", common.PrettyDuration(time.Since(start)))

--- a/core/state/snapshot/wipe.go
+++ b/core/state/snapshot/wipe.go
@@ -113,7 +113,7 @@ func wipeKeyRange(db ethdb.KeyValueStore, kind string, prefix []byte, keylen int
 				return err
 			}
 			batch.Reset()
-			seekPos := bytes.Trim(key, prefix)
+			seekPos := key[len(prefix):]
 			it = db.NewIteratorWith(prefix, seekPos)
 
 			if time.Since(logged) > 8*time.Second {

--- a/core/state/snapshot/wipe.go
+++ b/core/state/snapshot/wipe.go
@@ -92,7 +92,7 @@ func wipeKeyRange(db ethdb.KeyValueStore, kind string, prefix []byte, keylen int
 	// Iterate over the key-range and delete all of them
 	start, logged := time.Now(), time.Now()
 
-	it := db.NewIteratorWith(prefix, nil)
+	it := db.NewIterator(prefix, nil)
 	for it.Next() {
 		// Skip any keys with the correct prefix but wrong lenth (trie nodes)
 		key := it.Key()
@@ -114,7 +114,7 @@ func wipeKeyRange(db ethdb.KeyValueStore, kind string, prefix []byte, keylen int
 			}
 			batch.Reset()
 			seekPos := key[len(prefix):]
-			it = db.NewIteratorWith(prefix, seekPos)
+			it = db.NewIterator(prefix, seekPos)
 
 			if time.Since(logged) > 8*time.Second {
 				log.Info("Deleting state snapshot leftovers", "kind", kind, "wiped", items, "elapsed", common.PrettyDuration(time.Since(start)))

--- a/core/state/snapshot/wipe_test.go
+++ b/core/state/snapshot/wipe_test.go
@@ -60,7 +60,7 @@ func TestWipe(t *testing.T) {
 	// Sanity check that all the keys are present
 	var items int
 
-	it := db.NewIteratorWithPrefix(rawdb.SnapshotAccountPrefix)
+	it := db.NewIteratorWith(rawdb.SnapshotAccountPrefix, nil)
 	defer it.Release()
 
 	for it.Next() {
@@ -69,7 +69,7 @@ func TestWipe(t *testing.T) {
 			items++
 		}
 	}
-	it = db.NewIteratorWithPrefix(rawdb.SnapshotStoragePrefix)
+	it = db.NewIteratorWith(rawdb.SnapshotStoragePrefix, nil)
 	defer it.Release()
 
 	for it.Next() {
@@ -88,7 +88,7 @@ func TestWipe(t *testing.T) {
 	<-wipeSnapshot(db, true)
 
 	// Iterate over the database end ensure no snapshot information remains
-	it = db.NewIteratorWithPrefix(rawdb.SnapshotAccountPrefix)
+	it = db.NewIteratorWith(rawdb.SnapshotAccountPrefix, nil)
 	defer it.Release()
 
 	for it.Next() {
@@ -97,7 +97,7 @@ func TestWipe(t *testing.T) {
 			t.Errorf("snapshot entry remained after wipe: %x", key)
 		}
 	}
-	it = db.NewIteratorWithPrefix(rawdb.SnapshotStoragePrefix)
+	it = db.NewIteratorWith(rawdb.SnapshotStoragePrefix, nil)
 	defer it.Release()
 
 	for it.Next() {

--- a/core/state/snapshot/wipe_test.go
+++ b/core/state/snapshot/wipe_test.go
@@ -60,7 +60,7 @@ func TestWipe(t *testing.T) {
 	// Sanity check that all the keys are present
 	var items int
 
-	it := db.NewIteratorWith(rawdb.SnapshotAccountPrefix, nil)
+	it := db.NewIterator(rawdb.SnapshotAccountPrefix, nil)
 	defer it.Release()
 
 	for it.Next() {
@@ -69,7 +69,7 @@ func TestWipe(t *testing.T) {
 			items++
 		}
 	}
-	it = db.NewIteratorWith(rawdb.SnapshotStoragePrefix, nil)
+	it = db.NewIterator(rawdb.SnapshotStoragePrefix, nil)
 	defer it.Release()
 
 	for it.Next() {
@@ -88,7 +88,7 @@ func TestWipe(t *testing.T) {
 	<-wipeSnapshot(db, true)
 
 	// Iterate over the database end ensure no snapshot information remains
-	it = db.NewIteratorWith(rawdb.SnapshotAccountPrefix, nil)
+	it = db.NewIterator(rawdb.SnapshotAccountPrefix, nil)
 	defer it.Release()
 
 	for it.Next() {
@@ -97,7 +97,7 @@ func TestWipe(t *testing.T) {
 			t.Errorf("snapshot entry remained after wipe: %x", key)
 		}
 	}
-	it = db.NewIteratorWith(rawdb.SnapshotStoragePrefix, nil)
+	it = db.NewIterator(rawdb.SnapshotStoragePrefix, nil)
 	defer it.Release()
 
 	for it.Next() {
@@ -112,7 +112,7 @@ func TestWipe(t *testing.T) {
 	// Iterate over the database and ensure miscellaneous items are present
 	items = 0
 
-	it = db.NewIterator()
+	it = db.NewIterator(nil, nil)
 	defer it.Release()
 
 	for it.Next() {

--- a/core/state/statedb_test.go
+++ b/core/state/statedb_test.go
@@ -60,7 +60,7 @@ func TestUpdateLeaks(t *testing.T) {
 	}
 
 	// Ensure that no data was leaked into the database
-	it := db.NewIterator()
+	it := db.NewIterator(nil, nil)
 	for it.Next() {
 		t.Errorf("State leaked into database: %x -> %x", it.Key(), it.Value())
 	}
@@ -118,7 +118,7 @@ func TestIntermediateLeaks(t *testing.T) {
 		t.Errorf("can not commit trie %v to persistent database", finalRoot.Hex())
 	}
 
-	it := finalDb.NewIterator()
+	it := finalDb.NewIterator(nil, nil)
 	for it.Next() {
 		key, fvalue := it.Key(), it.Value()
 		tvalue, err := transDb.Get(key)
@@ -131,7 +131,7 @@ func TestIntermediateLeaks(t *testing.T) {
 	}
 	it.Release()
 
-	it = transDb.NewIterator()
+	it = transDb.NewIterator(nil, nil)
 	for it.Next() {
 		key, tvalue := it.Key(), it.Value()
 		fvalue, err := finalDb.Get(key)

--- a/eth/filters/bench_test.go
+++ b/eth/filters/bench_test.go
@@ -147,7 +147,7 @@ var bloomBitsPrefix = []byte("bloomBits-")
 
 func clearBloomBits(db ethdb.Database) {
 	fmt.Println("Clearing bloombits data...")
-	it := db.NewIteratorWith(bloomBitsPrefix, nil)
+	it := db.NewIterator(bloomBitsPrefix, nil)
 	for it.Next() {
 		db.Delete(it.Key())
 	}

--- a/eth/filters/bench_test.go
+++ b/eth/filters/bench_test.go
@@ -147,7 +147,7 @@ var bloomBitsPrefix = []byte("bloomBits-")
 
 func clearBloomBits(db ethdb.Database) {
 	fmt.Println("Clearing bloombits data...")
-	it := db.NewIteratorWithPrefix(bloomBitsPrefix)
+	it := db.NewIteratorWith(bloomBitsPrefix, nil)
 	for it.Next() {
 		db.Delete(it.Key())
 	}

--- a/eth/handler_test.go
+++ b/eth/handler_test.go
@@ -317,7 +317,7 @@ func testGetNodeData(t *testing.T, protocol int) {
 	// Fetch for now the entire chain db
 	hashes := []common.Hash{}
 
-	it := db.NewIterator()
+	it := db.NewIterator(nil, nil)
 	for it.Next() {
 		if key := it.Key(); len(key) == common.HashLength {
 			hashes = append(hashes, common.BytesToHash(key))

--- a/ethdb/dbtest/testsuite.go
+++ b/ethdb/dbtest/testsuite.go
@@ -104,7 +104,7 @@ func TestDatabaseSuite(t *testing.T, New func() ethdb.KeyValueStore) {
 				}
 			}
 			// Iterate over the database with the given configs and verify the results
-			it, idx := db.NewIteratorWith([]byte(tt.prefix), []byte(tt.start)), 0
+			it, idx := db.NewIterator([]byte(tt.prefix), []byte(tt.start)), 0
 			for it.Next() {
 				if len(tt.order) <= idx {
 					t.Errorf("test %d: prefix=%q more items than expected: checking idx=%d (key %q), expecting len=%d", i, tt.prefix, idx, it.Key(), len(tt.order))
@@ -142,7 +142,7 @@ func TestDatabaseSuite(t *testing.T, New func() ethdb.KeyValueStore) {
 		}
 
 		{
-			it := db.NewIterator()
+			it := db.NewIterator(nil, nil)
 			got, want := iterateKeys(it), keys
 			if err := it.Error(); err != nil {
 				t.Fatal(err)
@@ -153,7 +153,7 @@ func TestDatabaseSuite(t *testing.T, New func() ethdb.KeyValueStore) {
 		}
 
 		{
-			it := db.NewIteratorWith([]byte("1"), nil)
+			it := db.NewIterator([]byte("1"), nil)
 			got, want := iterateKeys(it), []string{"1", "10", "11", "12"}
 			if err := it.Error(); err != nil {
 				t.Fatal(err)
@@ -164,7 +164,7 @@ func TestDatabaseSuite(t *testing.T, New func() ethdb.KeyValueStore) {
 		}
 
 		{
-			it := db.NewIteratorWith([]byte("5"), nil)
+			it := db.NewIterator([]byte("5"), nil)
 			got, want := iterateKeys(it), []string{}
 			if err := it.Error(); err != nil {
 				t.Fatal(err)
@@ -175,7 +175,7 @@ func TestDatabaseSuite(t *testing.T, New func() ethdb.KeyValueStore) {
 		}
 
 		{
-			it := db.NewIteratorWith(nil, []byte("2"))
+			it := db.NewIterator(nil, []byte("2"))
 			got, want := iterateKeys(it), []string{"2", "20", "21", "22", "3", "4", "6"}
 			if err := it.Error(); err != nil {
 				t.Fatal(err)
@@ -186,7 +186,7 @@ func TestDatabaseSuite(t *testing.T, New func() ethdb.KeyValueStore) {
 		}
 
 		{
-			it := db.NewIteratorWith(nil, []byte("5"))
+			it := db.NewIterator(nil, []byte("5"))
 			got, want := iterateKeys(it), []string{"6"}
 			if err := it.Error(); err != nil {
 				t.Fatal(err)
@@ -259,7 +259,7 @@ func TestDatabaseSuite(t *testing.T, New func() ethdb.KeyValueStore) {
 		}
 
 		{
-			it := db.NewIterator()
+			it := db.NewIterator(nil, nil)
 			if got, want := iterateKeys(it), []string{"1", "2", "3", "4"}; !reflect.DeepEqual(got, want) {
 				t.Errorf("got: %s; want: %s", got, want)
 			}
@@ -279,7 +279,7 @@ func TestDatabaseSuite(t *testing.T, New func() ethdb.KeyValueStore) {
 		}
 
 		{
-			it := db.NewIterator()
+			it := db.NewIterator(nil, nil)
 			if got, want := iterateKeys(it), []string{"2", "3", "4", "5", "6"}; !reflect.DeepEqual(got, want) {
 				t.Errorf("got: %s; want: %s", got, want)
 			}
@@ -307,7 +307,7 @@ func TestDatabaseSuite(t *testing.T, New func() ethdb.KeyValueStore) {
 			t.Fatal(err)
 		}
 
-		it := db.NewIterator()
+		it := db.NewIterator(nil, nil)
 		if got := iterateKeys(it); !reflect.DeepEqual(got, want) {
 			t.Errorf("got: %s; want: %s", got, want)
 		}

--- a/ethdb/dbtest/testsuite.go
+++ b/ethdb/dbtest/testsuite.go
@@ -32,31 +32,32 @@ func TestDatabaseSuite(t *testing.T, New func() ethdb.KeyValueStore) {
 		tests := []struct {
 			content map[string]string
 			prefix  string
+			start string
 			order   []string
 		}{
 			// Empty databases should be iterable
-			{map[string]string{}, "", nil},
-			{map[string]string{}, "non-existent-prefix", nil},
+			{map[string]string{}, "","", nil},
+			{map[string]string{}, "non-existent-prefix","", nil},
 
 			// Single-item databases should be iterable
-			{map[string]string{"key": "val"}, "", []string{"key"}},
-			{map[string]string{"key": "val"}, "k", []string{"key"}},
-			{map[string]string{"key": "val"}, "l", nil},
+			{map[string]string{"key": "val"}, "","", []string{"key"}},
+			{map[string]string{"key": "val"}, "k","", []string{"key"}},
+			{map[string]string{"key": "val"}, "l","", nil},
 
 			// Multi-item databases should be fully iterable
 			{
 				map[string]string{"k1": "v1", "k5": "v5", "k2": "v2", "k4": "v4", "k3": "v3"},
-				"",
+				"","",
 				[]string{"k1", "k2", "k3", "k4", "k5"},
 			},
 			{
 				map[string]string{"k1": "v1", "k5": "v5", "k2": "v2", "k4": "v4", "k3": "v3"},
-				"k",
+				"k","",
 				[]string{"k1", "k2", "k3", "k4", "k5"},
 			},
 			{
 				map[string]string{"k1": "v1", "k5": "v5", "k2": "v2", "k4": "v4", "k3": "v3"},
-				"l",
+				"l","",
 				nil,
 			},
 			// Multi-item databases should be prefix-iterable
@@ -65,7 +66,7 @@ func TestDatabaseSuite(t *testing.T, New func() ethdb.KeyValueStore) {
 					"ka1": "va1", "ka5": "va5", "ka2": "va2", "ka4": "va4", "ka3": "va3",
 					"kb1": "vb1", "kb5": "vb5", "kb2": "vb2", "kb4": "vb4", "kb3": "vb3",
 				},
-				"ka",
+				"ka","",
 				[]string{"ka1", "ka2", "ka3", "ka4", "ka5"},
 			},
 			{
@@ -73,7 +74,24 @@ func TestDatabaseSuite(t *testing.T, New func() ethdb.KeyValueStore) {
 					"ka1": "va1", "ka5": "va5", "ka2": "va2", "ka4": "va4", "ka3": "va3",
 					"kb1": "vb1", "kb5": "vb5", "kb2": "vb2", "kb4": "vb4", "kb3": "vb3",
 				},
-				"kc",
+				"kc","",
+				nil,
+			},
+			// Multi-item databases should be prefix-iterable with start position
+			{
+				map[string]string{
+					"ka1": "va1", "ka5": "va5", "ka2": "va2", "ka4": "va4", "ka3": "va3",
+					"kb1": "vb1", "kb5": "vb5", "kb2": "vb2", "kb4": "vb4", "kb3": "vb3",
+				},
+				"ka","3",
+				[]string{"ka3", "ka4", "ka5"},
+			},
+			{
+				map[string]string{
+					"ka1": "va1", "ka5": "va5", "ka2": "va2", "ka4": "va4", "ka3": "va3",
+					"kb1": "vb1", "kb5": "vb5", "kb2": "vb2", "kb4": "vb4", "kb3": "vb3",
+				},
+				"ka","8",
 				nil,
 			},
 		}
@@ -86,7 +104,7 @@ func TestDatabaseSuite(t *testing.T, New func() ethdb.KeyValueStore) {
 				}
 			}
 			// Iterate over the database with the given configs and verify the results
-			it, idx := db.NewIteratorWithPrefix([]byte(tt.prefix)), 0
+			it, idx := db.NewIteratorWith([]byte(tt.prefix), []byte(tt.start)), 0
 			for it.Next() {
 				if len(tt.order) <= idx {
 					t.Errorf("test %d: prefix=%q more items than expected: checking idx=%d (key %q), expecting len=%d", i, tt.prefix, idx, it.Key(), len(tt.order))

--- a/ethdb/dbtest/testsuite.go
+++ b/ethdb/dbtest/testsuite.go
@@ -32,32 +32,32 @@ func TestDatabaseSuite(t *testing.T, New func() ethdb.KeyValueStore) {
 		tests := []struct {
 			content map[string]string
 			prefix  string
-			start string
+			start   string
 			order   []string
 		}{
 			// Empty databases should be iterable
-			{map[string]string{}, "","", nil},
-			{map[string]string{}, "non-existent-prefix","", nil},
+			{map[string]string{}, "", "", nil},
+			{map[string]string{}, "non-existent-prefix", "", nil},
 
 			// Single-item databases should be iterable
-			{map[string]string{"key": "val"}, "","", []string{"key"}},
-			{map[string]string{"key": "val"}, "k","", []string{"key"}},
-			{map[string]string{"key": "val"}, "l","", nil},
+			{map[string]string{"key": "val"}, "", "", []string{"key"}},
+			{map[string]string{"key": "val"}, "k", "", []string{"key"}},
+			{map[string]string{"key": "val"}, "l", "", nil},
 
 			// Multi-item databases should be fully iterable
 			{
 				map[string]string{"k1": "v1", "k5": "v5", "k2": "v2", "k4": "v4", "k3": "v3"},
-				"","",
+				"", "",
 				[]string{"k1", "k2", "k3", "k4", "k5"},
 			},
 			{
 				map[string]string{"k1": "v1", "k5": "v5", "k2": "v2", "k4": "v4", "k3": "v3"},
-				"k","",
+				"k", "",
 				[]string{"k1", "k2", "k3", "k4", "k5"},
 			},
 			{
 				map[string]string{"k1": "v1", "k5": "v5", "k2": "v2", "k4": "v4", "k3": "v3"},
-				"l","",
+				"l", "",
 				nil,
 			},
 			// Multi-item databases should be prefix-iterable
@@ -66,7 +66,7 @@ func TestDatabaseSuite(t *testing.T, New func() ethdb.KeyValueStore) {
 					"ka1": "va1", "ka5": "va5", "ka2": "va2", "ka4": "va4", "ka3": "va3",
 					"kb1": "vb1", "kb5": "vb5", "kb2": "vb2", "kb4": "vb4", "kb3": "vb3",
 				},
-				"ka","",
+				"ka", "",
 				[]string{"ka1", "ka2", "ka3", "ka4", "ka5"},
 			},
 			{
@@ -74,7 +74,7 @@ func TestDatabaseSuite(t *testing.T, New func() ethdb.KeyValueStore) {
 					"ka1": "va1", "ka5": "va5", "ka2": "va2", "ka4": "va4", "ka3": "va3",
 					"kb1": "vb1", "kb5": "vb5", "kb2": "vb2", "kb4": "vb4", "kb3": "vb3",
 				},
-				"kc","",
+				"kc", "",
 				nil,
 			},
 			// Multi-item databases should be prefix-iterable with start position
@@ -83,7 +83,7 @@ func TestDatabaseSuite(t *testing.T, New func() ethdb.KeyValueStore) {
 					"ka1": "va1", "ka5": "va5", "ka2": "va2", "ka4": "va4", "ka3": "va3",
 					"kb1": "vb1", "kb5": "vb5", "kb2": "vb2", "kb4": "vb4", "kb3": "vb3",
 				},
-				"ka","3",
+				"ka", "3",
 				[]string{"ka3", "ka4", "ka5"},
 			},
 			{
@@ -91,7 +91,7 @@ func TestDatabaseSuite(t *testing.T, New func() ethdb.KeyValueStore) {
 					"ka1": "va1", "ka5": "va5", "ka2": "va2", "ka4": "va4", "ka3": "va3",
 					"kb1": "vb1", "kb5": "vb5", "kb2": "vb2", "kb4": "vb4", "kb3": "vb3",
 				},
-				"ka","8",
+				"ka", "8",
 				nil,
 			},
 		}
@@ -147,57 +147,52 @@ func TestDatabaseSuite(t *testing.T, New func() ethdb.KeyValueStore) {
 			if err := it.Error(); err != nil {
 				t.Fatal(err)
 			}
-			it.Release()
 			if !reflect.DeepEqual(got, want) {
 				t.Errorf("Iterator: got: %s; want: %s", got, want)
 			}
 		}
 
 		{
-			it := db.NewIteratorWithPrefix([]byte("1"))
+			it := db.NewIteratorWith([]byte("1"), nil)
 			got, want := iterateKeys(it), []string{"1", "10", "11", "12"}
 			if err := it.Error(); err != nil {
 				t.Fatal(err)
 			}
-			it.Release()
 			if !reflect.DeepEqual(got, want) {
-				t.Errorf("IteratorWithPrefix(1): got: %s; want: %s", got, want)
+				t.Errorf("IteratorWith(1,nil): got: %s; want: %s", got, want)
 			}
 		}
 
 		{
-			it := db.NewIteratorWithPrefix([]byte("5"))
+			it := db.NewIteratorWith([]byte("5"), nil)
 			got, want := iterateKeys(it), []string{}
 			if err := it.Error(); err != nil {
 				t.Fatal(err)
 			}
-			it.Release()
 			if !reflect.DeepEqual(got, want) {
-				t.Errorf("IteratorWithPrefix(1): got: %s; want: %s", got, want)
+				t.Errorf("IteratorWith(5,nil): got: %s; want: %s", got, want)
 			}
 		}
 
 		{
-			it := db.NewIteratorWithStart([]byte("2"))
+			it := db.NewIteratorWith(nil, []byte("2"))
 			got, want := iterateKeys(it), []string{"2", "20", "21", "22", "3", "4", "6"}
 			if err := it.Error(); err != nil {
 				t.Fatal(err)
 			}
-			it.Release()
 			if !reflect.DeepEqual(got, want) {
-				t.Errorf("IteratorWithStart(2): got: %s; want: %s", got, want)
+				t.Errorf("IteratorWith(nil,2): got: %s; want: %s", got, want)
 			}
 		}
 
 		{
-			it := db.NewIteratorWithStart([]byte("5"))
+			it := db.NewIteratorWith(nil, []byte("5"))
 			got, want := iterateKeys(it), []string{"6"}
 			if err := it.Error(); err != nil {
 				t.Fatal(err)
 			}
-			it.Release()
 			if !reflect.DeepEqual(got, want) {
-				t.Errorf("IteratorWithStart(2): got: %s; want: %s", got, want)
+				t.Errorf("IteratorWith(nil,5): got: %s; want: %s", got, want)
 			}
 		}
 	})
@@ -268,7 +263,6 @@ func TestDatabaseSuite(t *testing.T, New func() ethdb.KeyValueStore) {
 			if got, want := iterateKeys(it), []string{"1", "2", "3", "4"}; !reflect.DeepEqual(got, want) {
 				t.Errorf("got: %s; want: %s", got, want)
 			}
-			it.Release()
 		}
 
 		b.Reset()
@@ -289,7 +283,6 @@ func TestDatabaseSuite(t *testing.T, New func() ethdb.KeyValueStore) {
 			if got, want := iterateKeys(it), []string{"2", "3", "4", "5", "6"}; !reflect.DeepEqual(got, want) {
 				t.Errorf("got: %s; want: %s", got, want)
 			}
-			it.Release()
 		}
 	})
 
@@ -318,7 +311,6 @@ func TestDatabaseSuite(t *testing.T, New func() ethdb.KeyValueStore) {
 		if got := iterateKeys(it); !reflect.DeepEqual(got, want) {
 			t.Errorf("got: %s; want: %s", got, want)
 		}
-		it.Release()
 	})
 
 }
@@ -329,5 +321,6 @@ func iterateKeys(it ethdb.Iterator) []string {
 		keys = append(keys, string(it.Key()))
 	}
 	sort.Strings(keys)
+	it.Release()
 	return keys
 }

--- a/ethdb/iterator.go
+++ b/ethdb/iterator.go
@@ -51,12 +51,8 @@ type Iterator interface {
 
 // Iteratee wraps the NewIterator methods of a backing data store.
 type Iteratee interface {
-	// NewIterator creates a binary-alphabetical iterator over the entire keyspace
-	// contained within the key-value database.
-	NewIterator() Iterator
-
-	// NewIteratorWith creates a binary-alphabetical iterator over a subset
+	// NewIterator creates a binary-alphabetical iterator over a subset
 	// of database content with a particular key prefix, starting at a particular
 	// initial key (or after, if it does not exist).
-	NewIteratorWith(prefix []byte, start []byte) Iterator
+	NewIterator(prefix []byte, start []byte) Iterator
 }

--- a/ethdb/iterator.go
+++ b/ethdb/iterator.go
@@ -63,4 +63,9 @@ type Iteratee interface {
 	// NewIteratorWithPrefix creates a binary-alphabetical iterator over a subset
 	// of database content with a particular key prefix.
 	NewIteratorWithPrefix(prefix []byte) Iterator
+
+	// NewIteratorWithPrefix creates a binary-alphabetical iterator over a subset
+	// of database content with a particular key prefix, starting at a particular
+	//initial key (or after, if it does not exist).
+	NewIteratorWith(prefix []byte, start []byte) Iterator
 }

--- a/ethdb/iterator.go
+++ b/ethdb/iterator.go
@@ -54,5 +54,8 @@ type Iteratee interface {
 	// NewIterator creates a binary-alphabetical iterator over a subset
 	// of database content with a particular key prefix, starting at a particular
 	// initial key (or after, if it does not exist).
+	//
+	// Note: This method assumes that the prefix is NOT part of the start, so there's
+	// no need for the caller to prepend the prefix to the start
 	NewIterator(prefix []byte, start []byte) Iterator
 }

--- a/ethdb/iterator.go
+++ b/ethdb/iterator.go
@@ -55,17 +55,8 @@ type Iteratee interface {
 	// contained within the key-value database.
 	NewIterator() Iterator
 
-	// NewIteratorWithStart creates a binary-alphabetical iterator over a subset of
-	// database content starting at a particular initial key (or after, if it does
-	// not exist).
-	NewIteratorWithStart(start []byte) Iterator
-
-	// NewIteratorWithPrefix creates a binary-alphabetical iterator over a subset
-	// of database content with a particular key prefix.
-	NewIteratorWithPrefix(prefix []byte) Iterator
-
-	// NewIteratorWithPrefix creates a binary-alphabetical iterator over a subset
+	// NewIteratorWith creates a binary-alphabetical iterator over a subset
 	// of database content with a particular key prefix, starting at a particular
-	//initial key (or after, if it does not exist).
+	// initial key (or after, if it does not exist).
 	NewIteratorWith(prefix []byte, start []byte) Iterator
 }

--- a/ethdb/leveldb/leveldb.go
+++ b/ethdb/leveldb/leveldb.go
@@ -187,7 +187,7 @@ func (db *Database) NewBatch() ethdb.Batch {
 // of database content with a particular key prefix, starting at a particular
 // initial key (or after, if it does not exist).
 func (db *Database) NewIterator(prefix []byte, start []byte) ethdb.Iterator {
-	return db.db.NewIterator(BytesPrefixRange(prefix, start), nil)
+	return db.db.NewIterator(bytesPrefixRange(prefix, start), nil)
 }
 
 // Stat returns a particular internal stat of the database.
@@ -477,10 +477,10 @@ func (r *replayer) Delete(key []byte) {
 	r.failure = r.writer.Delete(key)
 }
 
-// BytesPrefixRange returns key range that satisfy
+// bytesPrefixRange returns key range that satisfy
 // - the given prefix, and
 // - the given seek position
-func BytesPrefixRange(prefix, start []byte) *util.Range {
+func bytesPrefixRange(prefix, start []byte) *util.Range {
 	r := util.BytesPrefix(prefix)
 	r.Start = append(r.Start, start...)
 	return r

--- a/ethdb/leveldb/leveldb.go
+++ b/ethdb/leveldb/leveldb.go
@@ -183,16 +183,10 @@ func (db *Database) NewBatch() ethdb.Batch {
 	}
 }
 
-// NewIterator creates a binary-alphabetical iterator over the entire keyspace
-// contained within the leveldb database.
-func (db *Database) NewIterator() ethdb.Iterator {
-	return db.db.NewIterator(new(util.Range), nil)
-}
-
-// NewIteratorWith creates a binary-alphabetical iterator over a subset
+// NewIterator creates a binary-alphabetical iterator over a subset
 // of database content with a particular key prefix, starting at a particular
 // initial key (or after, if it does not exist).
-func (db *Database) NewIteratorWith(prefix []byte, start []byte) ethdb.Iterator {
+func (db *Database) NewIterator(prefix []byte, start []byte) ethdb.Iterator {
 	return db.db.NewIterator(BytesPrefixRange(prefix, start), nil)
 }
 

--- a/ethdb/leveldb/leveldb.go
+++ b/ethdb/leveldb/leveldb.go
@@ -189,19 +189,6 @@ func (db *Database) NewIterator() ethdb.Iterator {
 	return db.db.NewIterator(new(util.Range), nil)
 }
 
-// NewIteratorWithStart creates a binary-alphabetical iterator over a subset of
-// database content starting at a particular initial key (or after, if it does
-// not exist).
-func (db *Database) NewIteratorWithStart(start []byte) ethdb.Iterator {
-	return db.db.NewIterator(&util.Range{Start: start}, nil)
-}
-
-// NewIteratorWithPrefix creates a binary-alphabetical iterator over a subset
-// of database content with a particular key prefix.
-func (db *Database) NewIteratorWithPrefix(prefix []byte) ethdb.Iterator {
-	return db.db.NewIterator(util.BytesPrefix(prefix), nil)
-}
-
 // NewIteratorWith creates a binary-alphabetical iterator over a subset
 // of database content with a particular key prefix, starting at a particular
 // initial key (or after, if it does not exist).

--- a/ethdb/leveldb/leveldb.go
+++ b/ethdb/leveldb/leveldb.go
@@ -202,6 +202,13 @@ func (db *Database) NewIteratorWithPrefix(prefix []byte) ethdb.Iterator {
 	return db.db.NewIterator(util.BytesPrefix(prefix), nil)
 }
 
+// NewIteratorWith creates a binary-alphabetical iterator over a subset
+// of database content with a particular key prefix, starting at a particular
+// initial key (or after, if it does not exist).
+func (db *Database) NewIteratorWith(prefix []byte, start []byte) ethdb.Iterator {
+	return db.db.NewIterator(BytesPrefixRange(prefix, start), nil)
+}
+
 // Stat returns a particular internal stat of the database.
 func (db *Database) Stat(property string) (string, error) {
 	return db.db.GetProperty(property)
@@ -487,4 +494,13 @@ func (r *replayer) Delete(key []byte) {
 		return
 	}
 	r.failure = r.writer.Delete(key)
+}
+
+// BytesPrefixRange returns key range that satisfy
+// - the given prefix, and
+// - the given seek position
+func BytesPrefixRange(prefix, start []byte) *util.Range {
+	r := util.BytesPrefix(prefix)
+	r.Start = append(r.Start, start...)
+	return r
 }

--- a/ethdb/memorydb/memorydb.go
+++ b/ethdb/memorydb/memorydb.go
@@ -132,20 +132,7 @@ func (db *Database) NewBatch() ethdb.Batch {
 // NewIterator creates a binary-alphabetical iterator over the entire keyspace
 // contained within the memory database.
 func (db *Database) NewIterator() ethdb.Iterator {
-	return db.NewIteratorWithStart(nil)
-}
-
-// NewIteratorWithStart creates a binary-alphabetical iterator over a subset of
-// database content starting at a particular initial key (or after, if it does
-// not exist).
-func (db *Database) NewIteratorWithStart(start []byte) ethdb.Iterator {
-	return db.NewIteratorWith(nil, start)
-}
-
-// NewIteratorWithPrefix creates a binary-alphabetical iterator over a subset
-// of database content with a particular key prefix.
-func (db *Database) NewIteratorWithPrefix(prefix []byte) ethdb.Iterator {
-	return db.NewIteratorWith(prefix, nil)
+	return db.NewIteratorWith(nil, nil)
 }
 
 // NewIteratorWith creates a binary-alphabetical iterator over a subset

--- a/ethdb/memorydb/memorydb.go
+++ b/ethdb/memorydb/memorydb.go
@@ -132,8 +132,6 @@ func (db *Database) NewBatch() ethdb.Batch {
 // NewIterator creates a binary-alphabetical iterator over a subset
 // of database content with a particular key prefix, starting at a particular
 // initial key (or after, if it does not exist).
-// Note: This method assumes that the prefix is NOT part of the start, so there's
-// no need for the caller to prepend the prefix to the start
 func (db *Database) NewIterator(prefix []byte, start []byte) ethdb.Iterator {
 	db.lock.RLock()
 	defer db.lock.RUnlock()

--- a/ethdb/memorydb/memorydb.go
+++ b/ethdb/memorydb/memorydb.go
@@ -129,18 +129,12 @@ func (db *Database) NewBatch() ethdb.Batch {
 	}
 }
 
-// NewIterator creates a binary-alphabetical iterator over the entire keyspace
-// contained within the memory database.
-func (db *Database) NewIterator() ethdb.Iterator {
-	return db.NewIteratorWith(nil, nil)
-}
-
-// NewIteratorWith creates a binary-alphabetical iterator over a subset
+// NewIterator creates a binary-alphabetical iterator over a subset
 // of database content with a particular key prefix, starting at a particular
 // initial key (or after, if it does not exist).
 // Note: This method assumes that the prefix is NOT part of the start, so there's
 // no need for the caller to prepend the prefix to the start
-func (db *Database) NewIteratorWith(prefix []byte, start []byte) ethdb.Iterator {
+func (db *Database) NewIterator(prefix []byte, start []byte) ethdb.Iterator {
 	db.lock.RLock()
 	defer db.lock.RUnlock()
 

--- a/les/clientpool.go
+++ b/les/clientpool.go
@@ -770,7 +770,7 @@ func (db *nodeDB) getPosBalanceIDs(start, stop enode.ID, maxCount int) (result [
 		return
 	}
 	prefix := db.getPrefix(false)
-	it := db.db.NewIteratorWith(prefix, start.Bytes())
+	it := db.db.NewIterator(prefix, start.Bytes())
 	defer it.Release()
 	for i := len(stop[:]) - 1; i >= 0; i-- {
 		stop[i]--
@@ -851,7 +851,7 @@ func (db *nodeDB) expireNodes() {
 		start   = time.Now()
 		prefix  = db.getPrefix(true)
 	)
-	iter := db.db.NewIteratorWith(prefix, nil)
+	iter := db.db.NewIterator(prefix, nil)
 	for iter.Next() {
 		visited += 1
 		var balance negBalance

--- a/les/clientpool.go
+++ b/les/clientpool.go
@@ -691,6 +691,14 @@ func (db *nodeDB) close() {
 	close(db.closeCh)
 }
 
+func (db *nodeDB) getPrefix(neg bool) []byte {
+	prefix := positiveBalancePrefix
+	if neg {
+		prefix = negativeBalancePrefix
+	}
+	return append(db.verbuf[:], prefix...)
+}
+
 func (db *nodeDB) key(id []byte, neg bool) []byte {
 	prefix := positiveBalancePrefix
 	if neg {
@@ -761,7 +769,8 @@ func (db *nodeDB) getPosBalanceIDs(start, stop enode.ID, maxCount int) (result [
 	if maxCount <= 0 {
 		return
 	}
-	it := db.db.NewIteratorWithStart(db.key(start.Bytes(), false))
+	prefix := db.getPrefix(false)
+	it := db.db.NewIteratorWith(prefix, start.Bytes())
 	defer it.Release()
 	for i := len(stop[:]) - 1; i >= 0; i-- {
 		stop[i]--

--- a/les/clientpool.go
+++ b/les/clientpool.go
@@ -849,8 +849,9 @@ func (db *nodeDB) expireNodes() {
 		visited int
 		deleted int
 		start   = time.Now()
+		prefix  = db.getPrefix(true)
 	)
-	iter := db.db.NewIteratorWithPrefix(append(db.verbuf[:], negativeBalancePrefix...))
+	iter := db.db.NewIteratorWith(prefix, nil)
 	for iter.Next() {
 		visited += 1
 		var balance negBalance

--- a/trie/iterator_test.go
+++ b/trie/iterator_test.go
@@ -120,7 +120,7 @@ func TestNodeIteratorCoverage(t *testing.T) {
 			}
 		}
 	}
-	it := db.diskdb.NewIterator()
+	it := db.diskdb.NewIterator(nil, nil)
 	for it.Next() {
 		key := it.Key()
 		if _, ok := hashes[common.BytesToHash(key)]; !ok {
@@ -312,7 +312,7 @@ func testIteratorContinueAfterError(t *testing.T, memonly bool) {
 	if memonly {
 		memKeys = triedb.Nodes()
 	} else {
-		it := diskdb.NewIterator()
+		it := diskdb.NewIterator(nil, nil)
 		for it.Next() {
 			diskKeys = append(diskKeys, it.Key())
 		}

--- a/trie/proof_test.go
+++ b/trie/proof_test.go
@@ -106,7 +106,7 @@ func TestBadProof(t *testing.T) {
 			if proof == nil {
 				t.Fatalf("prover %d: nil proof", i)
 			}
-			it := proof.NewIterator()
+			it := proof.NewIterator(nil, nil)
 			for i, d := 0, mrand.Intn(proof.Len()); i <= d; i++ {
 				it.Next()
 			}

--- a/trie/sync_bloom.go
+++ b/trie/sync_bloom.go
@@ -116,7 +116,7 @@ func (b *SyncBloom) init(database ethdb.Iteratee) {
 			key := common.CopyBytes(it.Key())
 
 			it.Release()
-			it = database.NewIteratorWithStart(key)
+			it = database.NewIteratorWith(nil, key)
 
 			log.Info("Initializing fast sync bloom", "items", b.bloom.N(), "errorrate", b.errorRate(), "elapsed", common.PrettyDuration(time.Since(start)))
 			swap = time.Now()

--- a/trie/sync_bloom.go
+++ b/trie/sync_bloom.go
@@ -99,7 +99,7 @@ func (b *SyncBloom) init(database ethdb.Iteratee) {
 	// Note, this is fine, because everything inserted into leveldb by fast sync is
 	// also pushed into the bloom directly, so we're not missing anything when the
 	// iterator is swapped out for a new one.
-	it := database.NewIterator()
+	it := database.NewIterator(nil, nil)
 
 	var (
 		start = time.Now()
@@ -116,7 +116,7 @@ func (b *SyncBloom) init(database ethdb.Iteratee) {
 			key := common.CopyBytes(it.Key())
 
 			it.Release()
-			it = database.NewIteratorWith(nil, key)
+			it = database.NewIterator(nil, key)
 
 			log.Info("Initializing fast sync bloom", "items", b.bloom.N(), "errorrate", b.errorRate(), "elapsed", common.PrettyDuration(time.Since(start)))
 			swap = time.Now()


### PR DESCRIPTION
This PR changes the way the Iteratee interface is defined. Previously, we had
```
NewIteratorWithPrefix(prefix []byte)
NewIteratorWithStart(start []byte)
```
But no good way to get a prefixed iterator with a given start position. As that was missing, a lot of code made one of two mistakes: 

1. Use `NewIteratorWithStart( prefix ++ start)`. This solution is wrong; consider the prefix `0x0a` and start `0x00`. The returned iterator would also return e.g `0x0b`, as it is after `a` in the keyspace. 
2. Use `NewIteratorWithPrefix( prefix ++ start)`. This is also wrong. Consider the prefix `0x0a` and start `0x01`. This iterator would miss a key at `0x0a02`, since `0x0a01` is not a prefix to `0x0a02`. 

I replaced both of these with 
```
NewIteratorWith(prefix, start []byte)
```
