### PR TITLE
whisper/whisperv6: decrease pow requirement in tests

### DIFF
--- a/whisper/whisperv6/message_test.go
+++ b/whisper/whisperv6/message_test.go
@@ -36,7 +36,7 @@ func generateMessageParams() (*MessageParams, error) {
 	sz := mrand.Intn(400)
 
 	var p MessageParams
-	p.PoW = 0.01
+	p.PoW = 0.001
 	p.WorkTime = 1
 	p.TTL = uint32(mrand.Intn(1024))
 	p.Payload = make([]byte, sz)


### PR DESCRIPTION
Got this failure on an unrelated PR: 
```
?   	github.com/ethereum/go-ethereum/whisper/shhclient	[no test files]

--- FAIL: TestWatchers (10.55s)

    filter_test.go:627: failed Wrap with seed 1585143261: failed to reach the PoW target, specified pow time (1 seconds) was insufficient.

FAIL
```
So here's a random change that fixes it, but I guess @gballet will have to determine if it also perhaps negatively influences the actual test being performed... ? 

Before this PR:
```
=== RUN   TestWatchers
--- PASS: TestWatchers (5.29s)
```
all whisperv6 tests:
```
ok      github.com/ethereum/go-ethereum/whisper/whisperv6       14.140s
```
After this PR:
```
=== RUN   TestWatchers
--- PASS: TestWatchers (0.70s)
```
All:
```
ok      github.com/ethereum/go-ethereum/whisper/whisperv6       8.309s
```
