### PR TITLE
metrics: disable CPU stats (gosigar) on iOS

### DIFF
--- a/metrics/cpu_disabled.go
+++ b/metrics/cpu_disabled.go
@@ -1,4 +1,4 @@
-// Copyright 2018 The go-ethereum Authors
+// Copyright 2020 The go-ethereum Authors
 // This file is part of the go-ethereum library.
 //
 // The go-ethereum library is free software: you can redistribute it and/or modify
@@ -14,11 +14,10 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
 
+// +build ios
+
 package metrics
 
-// CPUStats is the system and process CPU stats.
-type CPUStats struct {
-	GlobalTime int64 // Time spent by the CPU working on all processes
-	GlobalWait int64 // Time spent by waiting on disk for all processes
-	LocalTime  int64 // Time spent by the CPU working on this process
-}
+// ReadCPUStats retrieves the current CPU stats. Internally this uses `gosigar`,
+// which is not supported on the platforms in this file.
+func ReadCPUStats(stats *CPUStats) {}

--- a/metrics/cpu_enabled.go
+++ b/metrics/cpu_enabled.go
@@ -1,4 +1,4 @@
-// Copyright 2018 The go-ethereum Authors
+// Copyright 2020 The go-ethereum Authors
 // This file is part of the go-ethereum library.
 //
 // The go-ethereum library is free software: you can redistribute it and/or modify
@@ -14,11 +14,18 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
 
+// +build !ios
+
 package metrics
 
-// CPUStats is the system and process CPU stats.
-type CPUStats struct {
-	GlobalTime int64 // Time spent by the CPU working on all processes
-	GlobalWait int64 // Time spent by waiting on disk for all processes
-	LocalTime  int64 // Time spent by the CPU working on this process
+import "github.com/elastic/gosigar"
+
+// ReadCPUStats retrieves the current CPU stats.
+func ReadCPUStats(stats *CPUStats) {
+	global := gosigar.Cpu{}
+	global.Get()
+
+	stats.GlobalTime = int64(global.User + global.Nice + global.Sys)
+	stats.GlobalWait = int64(global.Wait)
+	stats.LocalTime = getProcessCPUTime()
 }


### PR DESCRIPTION
Fix https://github.com/ethereum/go-ethereum/issues/20814.

It doesn't make much sense to do monitoring on mobile platforms. Instead of trying to fix `gosigar` to run on iOS, we can just disable CPU metrics on iOS altogether.