### PR TITLE
metrics: make flawed test less flawed

### DIFF
--- a/metrics/timer_test.go
+++ b/metrics/timer_test.go
@@ -45,10 +45,23 @@ func TestTimerStop(t *testing.T) {
 }
 
 func TestTimerFunc(t *testing.T) {
-	tm := NewTimer()
-	tm.Time(func() { time.Sleep(50e6) })
-	if max := tm.Max(); 35e6 > max || max > 145e6 {
-		t.Errorf("tm.Max(): 35e6 > %v || %v > 145e6\n", max, max)
+	var (
+		tm         = NewTimer()
+		testStart  = time.Now()
+		actualTime time.Duration
+	)
+	tm.Time(func() {
+		time.Sleep(50 * time.Millisecond)
+		actualTime = time.Since(testStart)
+	})
+	var (
+		drift    = time.Millisecond * 2
+		measured = time.Duration(tm.Max())
+		ceil     = actualTime + drift
+		floor    = actualTime - drift
+	)
+	if measured > ceil || measured < floor {
+		t.Errorf("tm.Max(): %v > %v || %v > %v\n", measured, ceil, measured, floor)
 	}
 }
 


### PR DESCRIPTION
This test failed if the desired 50 milliseconds becomes either

1. below 35 ms, or
2. above 145 ms

Example:
```

--- FAIL: TestTimerFunc (0.15s)

    timer_test.go:51: tm.Max(): 35e6 > 151151814 || 151151814 > 145e6

FAIL
```

The test failed due to what appers to be fluctuations in `time.Sleep`, which is
_not_ the actual method under test (native to golang)

This change modifies it so we compare the metered Max to the actual time instead
of the desired time.

I'm not 100% sure if this test is actually a test worth having, nor if my changes
screw with what we're trying to test here.