### PR TITLE
metrics: disable CPU stats (gosigar) on Darwing when nocgo is passed

### DIFF
--- a/metrics/cpu_darwin_cgo.go
+++ b/metrics/cpu_darwin_cgo.go
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
 
-// +build !ios,!darwin
+// +build darwin,cgo
 
 package metrics
 

--- a/metrics/cpu_disabled.go
+++ b/metrics/cpu_disabled.go
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
 
-// +build ios
+// +build ios darwin,!cgo
 
 package metrics
 

--- a/metrics/cpu_enabled.go
+++ b/metrics/cpu_enabled.go
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
 
-// +build darwin,cgo dragonfly freebsd linux nacl netbsd openbsd solaris windows
+// +build darwin,cgo dragonfly freebsd linux nacl netbsd openbsd solaris windows arm64
 
 package metrics
 

--- a/metrics/cpu_enabled.go
+++ b/metrics/cpu_enabled.go
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
 
-// +build !ios
+// +build darwin,cgo dragonfly freebsd linux nacl netbsd openbsd solaris windows
 
 package metrics
 


### PR DESCRIPTION
As the title suggests disables gosigar on darwin when CGO is disabled.

This is because the build fails with the following error when CGO is disabled:
```
../../../../pkg/mod/github.com/elastic/gosigar@v0.10.5/concrete_sigar.go:20:11: cpuUsage.Get undefined (type Cpu has no field or method Get)
../../../../pkg/mod/github.com/elastic/gosigar@v0.10.5/concrete_sigar.go:30:13: cpuUsage.Get undefined (type Cpu has no field or method Get)
../../../../pkg/mod/github.com/elastic/gosigar@v0.10.5/concrete_sigar.go:49:10: l.Get undefined (type LoadAverage has no field or method Get)
../../../../pkg/mod/github.com/elastic/gosigar@v0.10.5/concrete_sigar.go:55:10: m.Get undefined (type Mem has no field or method Get)
../../../../pkg/mod/github.com/elastic/gosigar@v0.10.5/concrete_sigar.go:61:10: s.Get undefined (type Swap has no field or method Get)
../../../../pkg/mod/github.com/elastic/gosigar@v0.10.5/concrete_sigar.go:67:10: p.Get undefined (type HugeTLBPages has no field or method Get)
../../../../pkg/mod/github.com/elastic/gosigar@v0.10.5/concrete_sigar.go:79:11: fd.Get undefined (type FDUsage has no field or method Get)
../../../../pkg/mod/github.com/elastic/gosigar@v0.10.5/sigar_darwin_amd64.go:11:12: undefined: sysctlbyname
```