### PR TITLE
Separate build stages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,16 @@
 language: go
 go_import_path: github.com/ethereum/go-ethereum
 sudo: false
+
+stages:
+  - lint
+  - test
+  - deploy
+  - clean-up
+
 jobs:
   include:
-        # This builder only tests code linters on latest version of Go
+    # This builder only tests code linters on latest version of Go
     - stage: lint
       os: linux
       dist: xenial
@@ -15,7 +22,7 @@ jobs:
       script:
         - go run build/ci.go lint
 
-    - stage: build
+    - stage: test
       os: linux
       dist: xenial
       go: 1.11.x
@@ -25,7 +32,7 @@ jobs:
         - go run build/ci.go install
         - go run build/ci.go test -coverage $TEST_PACKAGES
 
-    - stage: build
+    - stage: test
       os: linux
       dist: xenial
       go: 1.12.x
@@ -36,7 +43,7 @@ jobs:
         - go run build/ci.go test -coverage $TEST_PACKAGES
 
     # These are the latest Go versions.
-    - stage: build
+    - stage: test
       os: linux
       arch: amd64
       dist: xenial
@@ -45,7 +52,7 @@ jobs:
         - go run build/ci.go install
         - go run build/ci.go test -coverage $TEST_PACKAGES
 
-    - stage: build
+    - stage: test
       if: type = pull_request
       os: linux
       arch: arm64
@@ -55,7 +62,7 @@ jobs:
         - go run build/ci.go install
         - go run build/ci.go test -coverage $TEST_PACKAGES
 
-    - stage: build
+    - stage: test
       os: osx
       osx_image: xcode11.3
       go: 1.13.x
@@ -73,7 +80,7 @@ jobs:
         - go run build/ci.go test -coverage $TEST_PACKAGES
 
     # This builder does the Ubuntu PPA upload
-    - stage: build
+    - stage: deploy
       if: type = push
       os: linux
       dist: xenial
@@ -96,7 +103,7 @@ jobs:
         - go run build/ci.go debsrc -goversion 1.13.8 -upload ethereum/ethereum -sftp-user geth-ci -signer "Go Ethereum Linux Builder <geth-ci@ethereum.org>"
 
     # This builder does the Linux Azure uploads
-    - stage: build
+    - stage: deploy
       if: type = push
       os: linux
       dist: xenial
@@ -131,7 +138,7 @@ jobs:
         - go run build/ci.go archive -arch arm64 -type tar -signer LINUX_SIGNING_KEY -upload gethstore/builds
 
     # This builder does the Linux Azure MIPS xgo uploads
-    - stage: build
+    - stage: deploy
       if: type = push
       os: linux
       dist: xenial
@@ -160,7 +167,7 @@ jobs:
         - go run build/ci.go archive -arch mips64le -type tar -signer LINUX_SIGNING_KEY -upload gethstore/builds
 
     # This builder does the Android Maven and Azure uploads
-    - stage: build
+    - stage: deploy
       if: type = push
       os: linux
       dist: xenial
@@ -198,7 +205,7 @@ jobs:
         - go run build/ci.go aar -signer ANDROID_SIGNING_KEY -deploy https://oss.sonatype.org -upload gethstore/builds
 
     # This builder does the OSX Azure, iOS CocoaPods and iOS Azure uploads
-    - stage: build
+    - stage: deploy
       if: type = push
       os: osx
       go: 1.13.x
@@ -228,7 +235,7 @@ jobs:
         - go run build/ci.go xcode -signer IOS_SIGNING_KEY -deploy trunk -upload gethstore/builds
 
     # This builder does the Azure archive purges to avoid accumulating junk
-    - stage: build
+    - stage: clean-up
       if: type = cron
       os: linux
       dist: xenial


### PR DESCRIPTION
It makes it easier to see if it failed in a test or during a deploy. Also a preliminary step to handle flaky tests.
Before:  deployment is independent of test failures, if one test fails, the other jobs still do a deployment.
After this PR: if something fails in the test stage, deployment doesn't take place