### PR TITLE
travis: allow cocoapods deploy to fail

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,17 @@ language: go
 go_import_path: github.com/ethereum/go-ethereum
 sudo: false
 jobs:
+  allow_failures:
+    - stage: build
+      os: osx
+      go: 1.13.x
+      env:
+        - azure-osx
+        - azure-ios
+        - cocoapods-ios
+
   include:
-        # This builder only tests code linters on latest version of Go
+    # This builder only tests code linters on latest version of Go
     - stage: lint
       os: linux
       dist: xenial


### PR DESCRIPTION
If cocoapod build/deploy fails (which it always does now), the job is displayed as failing, but the whole build is considered passed, like [this build](https://travis-ci.org/github/adamschmideg/go-ethereum/builds/668380425)