### PR TITLE
core: bump txpool tx max size to 128KB

### DIFF
--- a/core/tx_pool.go
+++ b/core/tx_pool.go
@@ -48,7 +48,7 @@ const (
 	// non-trivial consequences: larger transactions are significantly harder and
 	// more expensive to propagate; larger transactions also take more resources
 	// to validate whether they fit into the pool or not.
-	txMaxSize = 2 * txSlotSize // 64KB, don't bump without EIP-2464 support
+	txMaxSize = 4 * txSlotSize // 128KB
 )
 
 var (


### PR DESCRIPTION
As the title says. 
cc  @GuthL