### PR TITLE
cmd/geth: fix bad genesis test

### DIFF
--- a/cmd/geth/genesis_test.go
+++ b/cmd/geth/genesis_test.go
@@ -28,22 +28,6 @@ var customGenesisTests = []struct {
 	query   string
 	result  string
 }{
-	// Plain genesis file without anything extra
-	{
-		genesis: `{
-			"alloc"      : {},
-			"coinbase"   : "0x0000000000000000000000000000000000000000",
-			"difficulty" : "0x20000",
-			"extraData"  : "",
-			"gasLimit"   : "0x2fefd8",
-			"nonce"      : "0x0000000000000042",
-			"mixhash"    : "0x0000000000000000000000000000000000000000000000000000000000000000",
-			"parentHash" : "0x0000000000000000000000000000000000000000000000000000000000000000",
-			"timestamp"  : "0x00"
-		}`,
-		query:  "eth.getBlock(0).nonce",
-		result: "0x0000000000000042",
-	},
 	// Genesis file with an empty chain configuration (ensure missing fields work)
 	{
 		genesis: `{
@@ -52,14 +36,14 @@ var customGenesisTests = []struct {
 			"difficulty" : "0x20000",
 			"extraData"  : "",
 			"gasLimit"   : "0x2fefd8",
-			"nonce"      : "0x0000000000000042",
+			"nonce"      : "0x0000000000001338",
 			"mixhash"    : "0x0000000000000000000000000000000000000000000000000000000000000000",
 			"parentHash" : "0x0000000000000000000000000000000000000000000000000000000000000000",
 			"timestamp"  : "0x00",
 			"config"     : {}
 		}`,
 		query:  "eth.getBlock(0).nonce",
-		result: "0x0000000000000042",
+		result: "0x0000000000001338",
 	},
 	// Genesis file with specific chain configurations
 	{
@@ -69,7 +53,7 @@ var customGenesisTests = []struct {
 			"difficulty" : "0x20000",
 			"extraData"  : "",
 			"gasLimit"   : "0x2fefd8",
-			"nonce"      : "0x0000000000000042",
+			"nonce"      : "0x0000000000001339",
 			"mixhash"    : "0x0000000000000000000000000000000000000000000000000000000000000000",
 			"parentHash" : "0x0000000000000000000000000000000000000000000000000000000000000000",
 			"timestamp"  : "0x00",
@@ -80,7 +64,7 @@ var customGenesisTests = []struct {
 			}
 		}`,
 		query:  "eth.getBlock(0).nonce",
-		result: "0x0000000000000042",
+		result: "0x0000000000001339",
 	},
 }
 
@@ -97,10 +81,10 @@ func TestCustomGenesis(t *testing.T) {
 		if err := ioutil.WriteFile(json, []byte(tt.genesis), 0600); err != nil {
 			t.Fatalf("test %d: failed to write genesis file: %v", i, err)
 		}
-		runGeth(t, "--datadir", datadir, "init", json).WaitExit()
+		runGeth(t, "--nousb", "--datadir", datadir, "init", json).WaitExit()
 
 		// Query the custom genesis block
-		geth := runGeth(t,
+		geth := runGeth(t, "--nousb",
 			"--datadir", datadir, "--maxpeers", "0", "--port", "0",
 			"--nodiscover", "--nat", "none", "--ipcdisable",
 			"--exec", tt.query, "console")


### PR DESCRIPTION
This PR fixes the genesis tests that were flaky. 
The tests spat out 
```
  test_cmd.go:250: (stderr) Fatal: Failed to write genesis block: genesis has no chain configuration
```
The first test should have failed ever since https://github.com/ethereum/go-ethereum/commit/37dd9086ec491900311fc39837f4a62ef5fd3a4a, three years ago. 

However,  _after_  a test unsuccessfully did a `geth init` (thus, not writing the genesis successfully) the test continued, and started geth, -- which then used the _default_ init-config: the mainnet. 

And the tests passed, because the query checked the genesis nonce. And the testcases were using the same nonce as mainnet does. Doh!

Tests are now changed to use other nonces. I also removed the first test, since we also have a _different_ test to ensure that we reject genesis:es without configs: https://github.com/ethereum/go-ethereum/blob/master/core/genesis_test.go#L68