### PR TITLE
accounts/abi/bind: fixed erroneous filtering of negative ints

### DIFF
--- a/accounts/abi/bind/topics.go
+++ b/accounts/abi/bind/topics.go
@@ -49,17 +49,13 @@ func makeTopics(query ...[]interface{}) ([][]common.Hash, error) {
 					topic[common.HashLength-1] = 1
 				}
 			case int8:
-				blob := big.NewInt(int64(rule)).Bytes()
-				copy(topic[common.HashLength-len(blob):], blob)
+				copy(topic[:], genIntType(int64(rule), 1))
 			case int16:
-				blob := big.NewInt(int64(rule)).Bytes()
-				copy(topic[common.HashLength-len(blob):], blob)
+				copy(topic[:], genIntType(int64(rule), 2))
 			case int32:
-				blob := big.NewInt(int64(rule)).Bytes()
-				copy(topic[common.HashLength-len(blob):], blob)
+				copy(topic[:], genIntType(int64(rule), 4))
 			case int64:
-				blob := big.NewInt(rule).Bytes()
-				copy(topic[common.HashLength-len(blob):], blob)
+				copy(topic[:], genIntType(rule, 8))
 			case uint8:
 				blob := new(big.Int).SetUint64(uint64(rule)).Bytes()
 				copy(topic[common.HashLength-len(blob):], blob)
@@ -101,6 +97,19 @@ func makeTopics(query ...[]interface{}) ([][]common.Hash, error) {
 		}
 	}
 	return topics, nil
+}
+
+func genIntType(rule int64, size int) []byte {
+	var topic [common.HashLength]byte
+	if rule < 0 {
+		// if a rule is negative, we need to put it into two's complement.
+		// extended to common.Hashlength bytes.
+		topic = [common.HashLength]byte{255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255}
+	}
+	for i := 0; i < size; i++ {
+		topic[common.HashLength-i-1] = byte(rule >> (i * 8))
+	}
+	return topic[:]
 }
 
 // parseTopics converts the indexed topic fields into actual log field values.

--- a/accounts/abi/bind/topics.go
+++ b/accounts/abi/bind/topics.go
@@ -106,8 +106,7 @@ func genIntType(rule int64, size uint) []byte {
 		// extended to common.Hashlength bytes.
 		topic = [common.HashLength]byte{255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255}
 	}
-	var i uint
-	for i = 0; i < size; i++ {
+	for i := uint(0); i < size; i++ {
 		topic[common.HashLength-i-1] = byte(rule >> (i * 8))
 	}
 	return topic[:]

--- a/accounts/abi/bind/topics.go
+++ b/accounts/abi/bind/topics.go
@@ -99,14 +99,15 @@ func makeTopics(query ...[]interface{}) ([][]common.Hash, error) {
 	return topics, nil
 }
 
-func genIntType(rule int64, size int) []byte {
+func genIntType(rule int64, size uint) []byte {
 	var topic [common.HashLength]byte
 	if rule < 0 {
 		// if a rule is negative, we need to put it into two's complement.
 		// extended to common.Hashlength bytes.
 		topic = [common.HashLength]byte{255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255}
 	}
-	for i := 0; i < size; i++ {
+	var i uint
+	for i = 0; i < size; i++ {
 		topic[common.HashLength-i-1] = byte(rule >> (i * 8))
 	}
 	return topic[:]

--- a/accounts/abi/bind/topics_test.go
+++ b/accounts/abi/bind/topics_test.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/ethereum/go-ethereum/accounts/abi"
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/crypto"
 )
 
 func TestMakeTopics(t *testing.T) {
@@ -39,6 +40,80 @@ func TestMakeTopics(t *testing.T) {
 			"support fixed byte types, right padded to 32 bytes",
 			args{[][]interface{}{{[5]byte{1, 2, 3, 4, 5}}}},
 			[][]common.Hash{{common.Hash{1, 2, 3, 4, 5}}},
+			false,
+		},
+		{
+			"support common hash types in topics",
+			args{[][]interface{}{{common.Hash{1, 2, 3, 4, 5}}}},
+			[][]common.Hash{{common.Hash{1, 2, 3, 4, 5}}},
+			false,
+		},
+		{
+			"support address types in topics",
+			args{[][]interface{}{{common.Address{1, 2, 3, 4, 5}}}},
+			[][]common.Hash{{common.Hash{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 2, 3, 4, 5}}},
+			false,
+		},
+		{
+			"support *big.Int types in topics",
+			args{[][]interface{}{{big.NewInt(1).Lsh(big.NewInt(2), 254)}}},
+			[][]common.Hash{{common.Hash{128}}},
+			false,
+		},
+		{
+			"support boolean types in topics",
+			args{[][]interface{}{
+				{true},
+				{false},
+			}},
+			[][]common.Hash{
+				{common.Hash{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1}},
+				{common.Hash{0}},
+			},
+			false,
+		},
+		{
+			"support int/uint(8/16/32/64) types in topics",
+			args{[][]interface{}{
+				{int8(-2)},
+				{int16(-3)},
+				{int32(-4)},
+				{int64(-5)},
+				{int8(1)},
+				{int16(256)},
+				{int32(65536)},
+				{int64(4294967296)},
+				{uint8(1)},
+				{uint16(256)},
+				{uint32(65536)},
+				{uint64(4294967296)},
+			}},
+			[][]common.Hash{
+				{common.Hash{255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 254}},
+				{common.Hash{255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 253}},
+				{common.Hash{255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 252}},
+				{common.Hash{255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 251}},
+				{common.Hash{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1}},
+				{common.Hash{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0}},
+				{common.Hash{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0}},
+				{common.Hash{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0}},
+				{common.Hash{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1}},
+				{common.Hash{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0}},
+				{common.Hash{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0}},
+				{common.Hash{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0}},
+			},
+			false,
+		},
+		{
+			"support string types in topics",
+			args{[][]interface{}{{"hello world"}}},
+			[][]common.Hash{{crypto.Keccak256Hash([]byte("hello world"))}},
+			false,
+		},
+		{
+			"support byte slice types in topics",
+			args{[][]interface{}{{[]byte{1, 2, 3}}}},
+			[][]common.Hash{{crypto.Keccak256Hash([]byte{1, 2, 3})}},
 			false,
 		},
 	}


### PR DESCRIPTION
Setting up filters/subscriptions for negative values was broken.
Following solidity code could not be properly queried for:
```
pragma solidity >=0.4.22 <0.7.0;


contract Eventer {
   
    event TestInt8(int8 indexed out1, int8 indexed out2);
    event AnonEvent(address, address);
    
    function getEvent() public {
        // set to 2,3 for functioning filter
        emit TestInt8(-2, -3);
    }
```
Go test code:
```
func TestNegativeEvent(t *testing.T) {
	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
	defer cancel()
	backend, sk := getSimBackend()
	transactor := bind.NewKeyedTransactor(sk)
	_, _, eventer, err := DeployEventer(transactor, backend)
	assert.NoError(t, err)

	tx, err := eventer.GetEvent(transactor)
	backend.Commit()
	assert.NoError(t, err)
	receipt, err := bind.WaitMined(ctx, backend, tx)
	assert.NoError(t, err)
	assert.True(t, receipt.Status != types.ReceiptStatusFailed)

	// filter for events
	opts := bind.FilterOpts{
		Start:   0,
		Context: ctx,
		End:     nil,
	}
	// Set to 2,3 for functioning filter
	iter, err := eventer.FilterTestInt8(&opts, []int8{-2}, []int8{-3})
	assert.NoError(t, err)
	if iter.Next() {
		t.Log(iter.Event.Out1)
		t.Log(iter.Event.Out2)
		t.Log(iter.Event.Raw)
		t.Log(iter.Next())
		t.Error("Successful if it hits this error")
	}
	t.Error("Unsuccessful")
}
```
