### PR TITLE
.github: change gitter reference to discord link in issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -2,7 +2,7 @@ Hi there,
 
 Please note that this is an issue tracker reserved for bug reports and feature requests.
 
-For general questions please use the gitter channel or the Ethereum stack exchange at https://ethereum.stackexchange.com.
+For general questions please use [discord](https://discord.gg/nthXNEv) or the Ethereum stack exchange at https://ethereum.stackexchange.com.
 
 #### System information
 


### PR DESCRIPTION
The issue template referred to the obsolete gitter channel. Replace it with Discord.