### PR TITLE
README: update min go version to 1.13

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ archives are published at https://geth.ethereum.org/downloads/.
 
 For prerequisites and detailed build instructions please read the [Installation Instructions](https://github.com/ethereum/go-ethereum/wiki/Building-Ethereum) on the wiki.
 
-Building `geth` requires both a Go (version 1.10 or later) and a C compiler. You can install
+Building `geth` requires both a Go (version 1.13 or later) and a C compiler. You can install
 them using your favourite package manager. Once the dependencies are installed, run
 
 ```shell


### PR DESCRIPTION
Currently with 1.10 you cannot build anymore as you get this error:

```
env GO111MODULE=on go run build/ci.go install ./cmd/geth
build/ci.go:61:2: cannot find package "github.com/cespare/cp" in any of:
    /usr/lib/go-1.10/src/github.com/cespare/cp (from $GOROOT)
    /home/ligi/go/src/github.com/cespare/cp (from $GOPATH)
build/ci.go:62:2: use of internal package not allowed
Makefile:16: recipe for target 'geth' failed
make: *** [geth] Error 1
```

so updating the minimum version here