### PR TITLE
travis, appveyor, build, Dockerfile: bump Go to 1.14.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ jobs:
   allow_failures:
     - stage: build
       os: osx
-      go: 1.13.x
+      go: 1.14.x
       env:
         - azure-osx
         - azure-ios
@@ -16,7 +16,7 @@ jobs:
     - stage: lint
       os: linux
       dist: xenial
-      go: 1.13.x
+      go: 1.14.x
       env:
         - lint
       git:
@@ -44,12 +44,22 @@ jobs:
         - go run build/ci.go install
         - go run build/ci.go test -coverage $TEST_PACKAGES
 
+    - stage: build
+      os: linux
+      dist: xenial
+      go: 1.13.x
+      env:
+        - GO111MODULE=on
+      script:
+        - go run build/ci.go install
+        - go run build/ci.go test -coverage $TEST_PACKAGES
+
     # These are the latest Go versions.
     - stage: build
       os: linux
       arch: amd64
       dist: xenial
-      go: 1.13.x
+      go: 1.14.x
       script:
         - go run build/ci.go install
         - go run build/ci.go test -coverage $TEST_PACKAGES
@@ -59,7 +69,7 @@ jobs:
       os: linux
       arch: arm64
       dist: xenial
-      go: 1.13.x
+      go: 1.14.x
       script:
         - go run build/ci.go install
         - go run build/ci.go test -coverage $TEST_PACKAGES
@@ -67,7 +77,7 @@ jobs:
     - stage: build
       os: osx
       osx_image: xcode11.3
-      go: 1.13.x
+      go: 1.14.x
       script:
         - echo "Increase the maximum number of open file descriptors on macOS"
         - NOFILE=20480
@@ -86,7 +96,7 @@ jobs:
       if: type = push
       os: linux
       dist: xenial
-      go: 1.13.x
+      go: 1.14.x
       env:
         - ubuntu-ppa
       git:
@@ -102,7 +112,7 @@ jobs:
             - python-paramiko
       script:
         - echo '|1|7SiYPr9xl3uctzovOTj4gMwAC1M=|t6ReES75Bo/PxlOPJ6/GsGbTrM0= ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEA0aKz5UTUndYgIGG7dQBV+HaeuEZJ2xPHo2DS2iSKvUL4xNMSAY4UguNW+pX56nAQmZKIZZ8MaEvSj6zMEDiq6HFfn5JcTlM80UwlnyKe8B8p7Nk06PPQLrnmQt5fh0HmEcZx+JU9TZsfCHPnX7MNz4ELfZE6cFsclClrKim3BHUIGq//t93DllB+h4O9LHjEUsQ1Sr63irDLSutkLJD6RXchjROXkNirlcNVHH/jwLWR5RcYilNX7S5bIkK8NlWPjsn/8Ua5O7I9/YoE97PpO6i73DTGLh5H9JN/SITwCKBkgSDWUt61uPK3Y11Gty7o2lWsBjhBUm2Y38CBsoGmBw==' >> ~/.ssh/known_hosts
-        - go run build/ci.go debsrc -goversion 1.13.8 -upload ethereum/ethereum -sftp-user geth-ci -signer "Go Ethereum Linux Builder <geth-ci@ethereum.org>"
+        - go run build/ci.go debsrc -goversion 1.14.2 -upload ethereum/ethereum -sftp-user geth-ci -signer "Go Ethereum Linux Builder <geth-ci@ethereum.org>"
 
     # This builder does the Linux Azure uploads
     - stage: build
@@ -110,7 +120,7 @@ jobs:
       os: linux
       dist: xenial
       sudo: required
-      go: 1.13.x
+      go: 1.14.x
       env:
         - azure-linux
       git:
@@ -146,7 +156,7 @@ jobs:
       dist: xenial
       services:
         - docker
-      go: 1.13.x
+      go: 1.14.x
       env:
         - azure-linux-mips
       git:
@@ -192,7 +202,7 @@ jobs:
       git:
         submodules: false # avoid cloning ethereum/tests
       before_install:
-        - curl https://dl.google.com/go/go1.13.8.linux-amd64.tar.gz | tar -xz
+        - curl https://dl.google.com/go/go1.14.2.linux-amd64.tar.gz | tar -xz
         - export PATH=`pwd`/go/bin:$PATH
         - export GOROOT=`pwd`/go
         - export GOPATH=$HOME/go
@@ -210,7 +220,7 @@ jobs:
     - stage: build
       if: type = push
       os: osx
-      go: 1.13.x
+      go: 1.14.x
       env:
         - azure-osx
         - azure-ios
@@ -241,7 +251,7 @@ jobs:
       if: type = cron
       os: linux
       dist: xenial
-      go: 1.13.x
+      go: 1.14.x
       env:
         - azure-purge
       git:

--- a/.travis.yml
+++ b/.travis.yml
@@ -60,6 +60,8 @@ jobs:
       arch: amd64
       dist: xenial
       go: 1.14.x
+      env:
+        - GO111MODULE=on
       script:
         - go run build/ci.go install
         - go run build/ci.go test -coverage $TEST_PACKAGES
@@ -70,6 +72,8 @@ jobs:
       arch: arm64
       dist: xenial
       go: 1.14.x
+      env:
+        - GO111MODULE=on
       script:
         - go run build/ci.go install
         - go run build/ci.go test -coverage $TEST_PACKAGES
@@ -78,6 +82,8 @@ jobs:
       os: osx
       osx_image: xcode11.3
       go: 1.14.x
+      env:
+        - GO111MODULE=on
       script:
         - echo "Increase the maximum number of open file descriptors on macOS"
         - NOFILE=20480
@@ -99,6 +105,7 @@ jobs:
       go: 1.14.x
       env:
         - ubuntu-ppa
+        - GO111MODULE=on
       git:
         submodules: false # avoid cloning ethereum/tests
       addons:
@@ -123,6 +130,7 @@ jobs:
       go: 1.14.x
       env:
         - azure-linux
+        - GO111MODULE=on
       git:
         submodules: false # avoid cloning ethereum/tests
       addons:
@@ -159,6 +167,7 @@ jobs:
       go: 1.14.x
       env:
         - azure-linux-mips
+        - GO111MODULE=on
       git:
         submodules: false # avoid cloning ethereum/tests
       script:
@@ -199,6 +208,7 @@ jobs:
       env:
         - azure-android
         - maven-android
+        - GO111MODULE=on
       git:
         submodules: false # avoid cloning ethereum/tests
       before_install:
@@ -225,6 +235,7 @@ jobs:
         - azure-osx
         - azure-ios
         - cocoapods-ios
+        - GO111MODULE=on
       git:
         submodules: false # avoid cloning ethereum/tests
       script:
@@ -254,6 +265,7 @@ jobs:
       go: 1.14.x
       env:
         - azure-purge
+        - GO111MODULE=on
       git:
         submodules: false # avoid cloning ethereum/tests
       script:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build Geth in a stock Go builder container
-FROM golang:1.13-alpine as builder
+FROM golang:1.14-alpine as builder
 
 RUN apk add --no-cache make gcc musl-dev linux-headers git
 

--- a/Dockerfile.alltools
+++ b/Dockerfile.alltools
@@ -1,5 +1,5 @@
 # Build Geth in a stock Go builder container
-FROM golang:1.13-alpine as builder
+FROM golang:1.14-alpine as builder
 
 RUN apk add --no-cache make gcc musl-dev linux-headers git
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -23,8 +23,8 @@ environment:
 install:
   - git submodule update --init
   - rmdir C:\go /s /q
-  - appveyor DownloadFile https://dl.google.com/go/go1.13.8.windows-%GETH_ARCH%.zip
-  - 7z x go1.13.8.windows-%GETH_ARCH%.zip -y -oC:\ > NUL
+  - appveyor DownloadFile https://dl.google.com/go/go1.14.2.windows-%GETH_ARCH%.zip
+  - 7z x go1.14.2.windows-%GETH_ARCH%.zip -y -oC:\ > NUL
   - go version
   - gcc --version
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,6 +6,7 @@ clone_depth: 5
 version: "{branch}.{build}"
 environment:
   global:
+    GO111MODULE: on
     GOPATH: C:\gopath
     CC: gcc.exe
   matrix:

--- a/build/checksums.txt
+++ b/build/checksums.txt
@@ -1,6 +1,6 @@
 # This file contains sha256 checksums of optional build dependencies.
 
-b13bf04633d4d8cf53226ebeaace8d4d2fd07ae6fa676d0844a688339debec34  go1.13.8.src.tar.gz
+98de84e69726a66da7b4e58eac41b99cbe274d7e8906eeb8a5b7eb0aadee7f7c  go1.14.2.src.tar.gz
 
 aeaa5498682246b87d0b77ece283897348ea03d98e816760a074058bfca60b2a  golangci-lint-1.24.0-windows-amd64.zip
 7e854a70d449fe77b7a91583ec88c8603eb3bf96c45d52797dc4ba3f2f278dbe  golangci-lint-1.24.0-darwin-386.tar.gz


### PR DESCRIPTION
Fixes https://github.com/ethereum/go-ethereum/issues/20734, both upstream issues have been patched, first in Go 1.14.1 and the second in Go 1.14.2.

---

I've pushed a second commit that adds `GO111MODULE=on` to travis and appveyor. These are a bit of a bummers, but Go 1.14 still defaults to `auto` on module support, which reverts to GOPATH mode if running in a gopath, which is baad https://github.com/golang/go/issues/38196