### PR TITLE
accounts/keystore: fix race-condition in Import/ImportECDSA

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ archives are published at https://geth.ethereum.org/downloads/.
 
 For prerequisites and detailed build instructions please read the [Installation Instructions](https://github.com/ethereum/go-ethereum/wiki/Building-Ethereum) on the wiki.
 
-Building `geth` requires both a Go (version 1.10 or later) and a C compiler. You can install
+Building `geth` requires both a Go (version 1.13 or later) and a C compiler. You can install
 them using your favourite package manager. Once the dependencies are installed, run
 
 ```shell

--- a/accounts/keystore/keystore.go
+++ b/accounts/keystore/keystore.go
@@ -24,7 +24,6 @@ import (
 	"crypto/ecdsa"
 	crand "crypto/rand"
 	"errors"
-	"fmt"
 	"math/big"
 	"os"
 	"path/filepath"
@@ -447,7 +446,7 @@ func (ks *KeyStore) Import(keyJSON []byte, passphrase, newPassphrase string) (ac
 	ks.importMu.Lock()
 	defer ks.importMu.Unlock()
 	if ks.cache.hasAddress(key.Address) {
-		return accounts.Account{}, fmt.Errorf("account already exists")
+		return accounts.Account{}, errors.New("account already exists")
 	}
 	return ks.importKey(key, newPassphrase)
 }
@@ -458,7 +457,7 @@ func (ks *KeyStore) ImportECDSA(priv *ecdsa.PrivateKey, passphrase string) (acco
 	ks.importMu.Lock()
 	defer ks.importMu.Unlock()
 	if ks.cache.hasAddress(key.Address) {
-		return accounts.Account{}, fmt.Errorf("account already exists")
+		return accounts.Account{}, errors.New("account already exists")
 	}
 	return ks.importKey(key, passphrase)
 }

--- a/accounts/keystore/keystore.go
+++ b/accounts/keystore/keystore.go
@@ -67,8 +67,8 @@ type KeyStore struct {
 	updateScope event.SubscriptionScope // Subscription scope tracking current live listeners
 	updating    bool                    // Whether the event notification loop is running
 
-	mu    sync.RWMutex
-	impMu sync.RWMutex // Import Mutex locks the import to prevent two insertions from racing
+	mu       sync.RWMutex
+	importMu sync.RWMutex // Import Mutex locks the import to prevent two insertions from racing
 }
 
 type unlocked struct {
@@ -444,8 +444,8 @@ func (ks *KeyStore) Import(keyJSON []byte, passphrase, newPassphrase string) (ac
 	if err != nil {
 		return accounts.Account{}, err
 	}
-	ks.impMu.Lock()
-	defer ks.impMu.Unlock()
+	ks.importMu.Lock()
+	defer ks.importMu.Unlock()
 	if ks.cache.hasAddress(key.Address) {
 		return accounts.Account{}, fmt.Errorf("account already exists")
 	}
@@ -455,8 +455,8 @@ func (ks *KeyStore) Import(keyJSON []byte, passphrase, newPassphrase string) (ac
 // ImportECDSA stores the given key into the key directory, encrypting it with the passphrase.
 func (ks *KeyStore) ImportECDSA(priv *ecdsa.PrivateKey, passphrase string) (accounts.Account, error) {
 	key := newKeyFromECDSA(priv)
-	ks.impMu.Lock()
-	defer ks.impMu.Unlock()
+	ks.importMu.Lock()
+	defer ks.importMu.Unlock()
 	if ks.cache.hasAddress(key.Address) {
 		return accounts.Account{}, fmt.Errorf("account already exists")
 	}

--- a/accounts/keystore/keystore_test.go
+++ b/accounts/keystore/keystore_test.go
@@ -23,11 +23,14 @@ import (
 	"runtime"
 	"sort"
 	"strings"
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/ethereum/go-ethereum/accounts"
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/event"
 )
 
@@ -336,6 +339,83 @@ func TestWalletNotifications(t *testing.T) {
 	<-updates
 	checkAccounts(t, live, ks.Wallets())
 	checkEvents(t, wantEvents, events)
+}
+
+// TestImportExport tests the import functionality of a keystore.
+func TestImportECDSA(t *testing.T) {
+	dir, ks := tmpKeyStore(t, true)
+	defer os.RemoveAll(dir)
+	key, err := crypto.GenerateKey()
+	if err != nil {
+		t.Fatalf("failed to generate key: %v", key)
+	}
+	if _, err = ks.ImportECDSA(key, "old"); err != nil {
+		t.Errorf("importing failed: %v", err)
+	}
+	if _, err = ks.ImportECDSA(key, "old"); err == nil {
+		t.Errorf("importing same key twice succeded")
+	}
+	if _, err = ks.ImportECDSA(key, "new"); err == nil {
+		t.Errorf("importing same key twice succeded")
+	}
+}
+
+// TestImportECDSA tests the import and export functionality of a keystore.
+func TestImportExport(t *testing.T) {
+	dir, ks := tmpKeyStore(t, true)
+	defer os.RemoveAll(dir)
+	acc, err := ks.NewAccount("old")
+	if err != nil {
+		t.Fatalf("failed to create account: %v", acc)
+	}
+	json, err := ks.Export(acc, "old", "new")
+	if err != nil {
+		t.Fatalf("failed to export account: %v", acc)
+	}
+	dir2, ks2 := tmpKeyStore(t, true)
+	defer os.RemoveAll(dir2)
+	if _, err = ks2.Import(json, "old", "old"); err == nil {
+		t.Errorf("importing with invalid password succeeded")
+	}
+	if _, err = ks2.Import(json, "new", "new"); err != nil {
+		t.Errorf("importing failed: %v", err)
+	}
+	if _, err = ks2.Import(json, "new", "new"); err == nil {
+		t.Errorf("importing a key twice succeeded")
+	}
+}
+
+// TestImportRace tests the keystore on races.
+// This test should fail under -race if importing races.
+func TestImportRace(t *testing.T) {
+	dir, ks := tmpKeyStore(t, true)
+	defer os.RemoveAll(dir)
+	acc, err := ks.NewAccount("old")
+	if err != nil {
+		t.Fatalf("failed to create account: %v", acc)
+	}
+	json, err := ks.Export(acc, "old", "new")
+	if err != nil {
+		t.Fatalf("failed to export account: %v", acc)
+	}
+	dir2, ks2 := tmpKeyStore(t, true)
+	defer os.RemoveAll(dir2)
+	var atom uint32
+	var wg sync.WaitGroup
+	wg.Add(2)
+	for i := 0; i < 2; i++ {
+		go func() {
+			defer wg.Done()
+			if _, err := ks2.Import(json, "new", "new"); err != nil {
+				atomic.AddUint32(&atom, 1)
+			}
+
+		}()
+	}
+	wg.Wait()
+	if atom != 1 {
+		t.Errorf("Import is racy")
+	}
 }
 
 // checkAccounts checks that all known live accounts are present in the wallet list.

--- a/accounts/keystore/keystore_test.go
+++ b/accounts/keystore/keystore_test.go
@@ -377,12 +377,17 @@ func TestImportExport(t *testing.T) {
 	if _, err = ks2.Import(json, "old", "old"); err == nil {
 		t.Errorf("importing with invalid password succeeded")
 	}
-	if _, err = ks2.Import(json, "new", "new"); err != nil {
+	acc2, err := ks2.Import(json, "new", "new")
+	if err != nil {
 		t.Errorf("importing failed: %v", err)
+	}
+	if acc.Address != acc2.Address {
+		t.Error("imported account does not match exported account")
 	}
 	if _, err = ks2.Import(json, "new", "new"); err == nil {
 		t.Errorf("importing a key twice succeeded")
 	}
+
 }
 
 // TestImportRace tests the keystore on races.

--- a/accounts/keystore/keystore_test.go
+++ b/accounts/keystore/keystore_test.go
@@ -353,10 +353,10 @@ func TestImportECDSA(t *testing.T) {
 		t.Errorf("importing failed: %v", err)
 	}
 	if _, err = ks.ImportECDSA(key, "old"); err == nil {
-		t.Errorf("importing same key twice succeded")
+		t.Errorf("importing same key twice succeeded")
 	}
 	if _, err = ks.ImportECDSA(key, "new"); err == nil {
-		t.Errorf("importing same key twice succeded")
+		t.Errorf("importing same key twice succeeded")
 	}
 }
 

--- a/cmd/geth/accountcmd_test.go
+++ b/cmd/geth/accountcmd_test.go
@@ -89,18 +89,23 @@ Path of the secret key file: .*UTC--.+--[0-9a-f]{40}
 }
 
 func TestAccountImport(t *testing.T) {
-	tests := []struct{ key, output string }{
+	tests := []struct{ name, key, output string }{
 		{
+			name:   "correct account",
 			key:    "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
 			output: "Address: {fcad0b19bb29d4674531d6f115237e16afce377c}\n",
 		},
 		{
+			name:   "invalid character",
 			key:    "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef1",
 			output: "Fatal: Failed to load the private key: invalid character '1' at end of key file\n",
 		},
 	}
 	for _, test := range tests {
-		importAccountWithExpect(t, test.key, test.output)
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			importAccountWithExpect(t, test.key, test.output)
+		})
 	}
 }
 


### PR DESCRIPTION
Calling keystore.Import or keystore.ImportECDSA might result in a race.
If they are called in parallel, they both check whether a key is already in the keystore.
The keystore is empty so both threads insert their key into the keystore.
This however results in a keystore that contains a key twice.

I personally do not like the additionally mutex in the structure, but I currently don't see another way to do this.

additional: Tests for exporting/importing keys


closes https://github.com/ethereum/go-ethereum/issues/19575#event-3230244782