### PR TITLE
eth: core/rawdb: p2p/enode: multiple data race fixes

### DIFF
--- a/core/rawdb/freezer_table.go
+++ b/core/rawdb/freezer_table.go
@@ -541,19 +541,22 @@ func (t *freezerTable) getBounds(item uint64) (uint32, uint32, uint32, error) {
 // Retrieve looks up the data offset of an item with the given number and retrieves
 // the raw binary blob from the data file.
 func (t *freezerTable) Retrieve(item uint64) ([]byte, error) {
+	t.lock.RLock()
 	// Ensure the table and the item is accessible
 	if t.index == nil || t.head == nil {
+		t.lock.RUnlock()
 		return nil, errClosed
 	}
 	if atomic.LoadUint64(&t.items) <= item {
+		t.lock.RUnlock()
 		return nil, errOutOfBounds
 	}
 	// Ensure the item was not deleted from the tail either
 	offset := atomic.LoadUint32(&t.itemOffset)
 	if uint64(offset) > item {
+		t.lock.RUnlock()
 		return nil, errOutOfBounds
 	}
-	t.lock.RLock()
 	startOffset, endOffset, filenum, err := t.getBounds(item - uint64(offset))
 	if err != nil {
 		t.lock.RUnlock()

--- a/core/rawdb/freezer_table.go
+++ b/core/rawdb/freezer_table.go
@@ -552,12 +552,11 @@ func (t *freezerTable) Retrieve(item uint64) ([]byte, error) {
 		return nil, errOutOfBounds
 	}
 	// Ensure the item was not deleted from the tail either
-	offset := atomic.LoadUint32(&t.itemOffset)
-	if uint64(offset) > item {
+	if uint64(t.itemOffset) > item {
 		t.lock.RUnlock()
 		return nil, errOutOfBounds
 	}
-	startOffset, endOffset, filenum, err := t.getBounds(item - uint64(offset))
+	startOffset, endOffset, filenum, err := t.getBounds(item - uint64(t.itemOffset))
 	if err != nil {
 		t.lock.RUnlock()
 		return nil, err

--- a/eth/protocol_test.go
+++ b/eth/protocol_test.go
@@ -211,12 +211,12 @@ func TestForkIDSplit(t *testing.T) {
 	peerNoFork = newPeer(64, p2p.NewPeer(enode.ID{1}, "", nil), p2pNoFork, nil)
 	peerProFork = newPeer(64, p2p.NewPeer(enode.ID{2}, "", nil), p2pProFork, nil)
 
-	errc = make(chan error, 2)
-	go func() { errc <- ethNoFork.handle(peerProFork) }()
-	go func() { errc <- ethProFork.handle(peerNoFork) }()
+	errc2 := make(chan error, 2)
+	go func() { errc2 <- ethNoFork.handle(peerProFork) }()
+	go func() { errc2 <- ethProFork.handle(peerNoFork) }()
 
 	select {
-	case err := <-errc:
+	case err := <-errc2:
 		t.Fatalf("homestead nofork <-> profork failed: %v", err)
 	case <-time.After(250 * time.Millisecond):
 		p2pNoFork.Close()
@@ -230,12 +230,12 @@ func TestForkIDSplit(t *testing.T) {
 	peerNoFork = newPeer(64, p2p.NewPeer(enode.ID{1}, "", nil), p2pNoFork, nil)
 	peerProFork = newPeer(64, p2p.NewPeer(enode.ID{2}, "", nil), p2pProFork, nil)
 
-	errc = make(chan error, 2)
-	go func() { errc <- ethNoFork.handle(peerProFork) }()
-	go func() { errc <- ethProFork.handle(peerNoFork) }()
+	errc3 := make(chan error, 2)
+	go func() { errc3 <- ethNoFork.handle(peerProFork) }()
+	go func() { errc3 <- ethProFork.handle(peerNoFork) }()
 
 	select {
-	case err := <-errc:
+	case err := <-errc3:
 		if want := errResp(ErrForkIDRejected, forkid.ErrLocalIncompatibleOrStale.Error()); err.Error() != want.Error() {
 			t.Fatalf("fork ID rejection error mismatch: have %v, want %v", err, want)
 		}

--- a/p2p/enode/iter_test.go
+++ b/p2p/enode/iter_test.go
@@ -268,7 +268,7 @@ func (s *genIter) Node() *Node {
 }
 
 func (s *genIter) Close() {
-	s.index = ^uint32(0)
+	atomic.StoreUint32(&s.index, ^uint32(0))
 }
 
 func testNode(id, seq uint64) *Node {


### PR DESCRIPTION
I found multiple pending data races, they are mostly in tests so very low impact.

`eth:`
Due to the reuse of error channels throughout the tests, the golang race tester complains
to test use `go test -count=1 -run=TestForkIDSplit  ./... -race`

`core/rawdb:` 
closes https://github.com/ethereum/go-ethereum/issues/20420

`p2p/enode:`
fixes a data race between genIter.Next() and genIter.Close()