### PR TITLE
Fix preimage race (results in the wrong and missing preimages in the database)

### DIFF
--- a/trie/database.go
+++ b/trie/database.go
@@ -60,7 +60,7 @@ var (
 var secureKeyPrefix = []byte("secure-key-")
 
 // secureKeyLength is the length of the above prefix + 32byte hash.
-const secureKeyLength = 11 + 32
+const secureKeyLength = 0
 
 // Database is an intermediate write layer between the trie data structures and
 // the disk database. The aim is to accumulate trie writes in-memory and only


### PR DESCRIPTION
I have noticed this problem when doing "differential" testing between go-ethereum and turbo-geth RPC apis. On one machine, I was syncing geth 1.9.12 with `--sync mode full --gcmode archive`, on another - turbo-geth with "similar" settings. The RPC methods I had troubles with (when go-ethereum returned wrong results) were:
1. `debug_getModifiedAccountsByHash`
2. `debug_getStorangeRangeAt`

In the case of the `debug_getModifiedAccountsByHash`, go-ethereum's results contained accounts that were not supposed to be in the ranges at all, and also some accounts that were supposed to be there were missing.
In the case of the `debug_getStorageRangeAt`, I got correct set of key hashes, but often incorrect or missing preimages.
Other RPC requests I used were not affected.

After a while I realised that perhaps go-ethereum's database is corrupted and contains wrong preimages. That would explain that other RPC requests I used, which do not employ preimages, were correct. So I looked into the source code and noticed the race. The one in the `trie/database.go` is definitely the one that causes the races (because after fixing it and re-doing the sync, all request results were fine). I am not yet certain whether the fix in `trie/secure_trie.go` is required.

Hope it helps