### PR TITLE
event: fix inconsistency in Lock and Unlock

### DIFF
--- a/event/event.go
+++ b/event/event.go
@@ -104,6 +104,7 @@ func (mux *TypeMux) Post(ev interface{}) error {
 // Stop blocks until all current deliveries have finished.
 func (mux *TypeMux) Stop() {
 	mux.mutex.Lock()
+	defer mux.mutex.Unlock()
 	for _, subs := range mux.subm {
 		for _, sub := range subs {
 			sub.closewait()
@@ -111,11 +112,11 @@ func (mux *TypeMux) Stop() {
 	}
 	mux.subm = nil
 	mux.stopped = true
-	mux.mutex.Unlock()
 }
 
 func (mux *TypeMux) del(s *TypeMuxSubscription) {
 	mux.mutex.Lock()
+	defer mux.mutex.Unlock()
 	for typ, subs := range mux.subm {
 		if pos := find(subs, s); pos >= 0 {
 			if len(subs) == 1 {
@@ -125,7 +126,6 @@ func (mux *TypeMux) del(s *TypeMuxSubscription) {
 			}
 		}
 	}
-	mux.mutex.Unlock()
 }
 
 func find(slice []*TypeMuxSubscription, item *TypeMuxSubscription) int {

--- a/event/event.go
+++ b/event/event.go
@@ -125,7 +125,7 @@ func (mux *TypeMux) del(s *TypeMuxSubscription) {
 			}
 		}
 	}
-	s.mux.mutex.Unlock()
+	mux.mutex.Unlock()
 }
 
 func find(slice []*TypeMuxSubscription, item *TypeMuxSubscription) int {


### PR DESCRIPTION
Function [`del()`](https://github.com/BurtonQin/go-ethereum/blob/255e927d0b31dab9e9b339672349b01d8eb3cc17/event/event.go#L117-L129) locks on `mux.mutex` but unlocks on `s.mux.mutex.Unlock()`. `s` comes from the input parameter.

The only caller of del() is [`Unsubscribe()`](https://github.com/BurtonQin/go-ethereum/blob/255e927d0b31dab9e9b339672349b01d8eb3cc17/event/event.go#L179), where the same `s` is provided as the input in `s.mux.del(s)`.

I think we cannot depend on the input to guarantee the consistency of Lock and Unlock.
Can we change `del()` to use the same mutex for `Unlock` and `Lock`, following other functions like [`Subscribe()`](https://github.com/BurtonQin/go-ethereum/blob/255e927d0b31dab9e9b339672349b01d8eb3cc17/event/event.go#L56) and [`Stop()`](https://github.com/BurtonQin/go-ethereum/blob/255e927d0b31dab9e9b339672349b01d8eb3cc17/event/event.go#L114)?
Or this code is for some special purpose?





