### PR TITLE
snapshot: add Unlock before return/panic

### DIFF
--- a/core/state/snapshot/iterator.go
+++ b/core/state/snapshot/iterator.go
@@ -128,7 +128,6 @@ func (it *diffAccountIterator) Account() []byte {
 			it.layer.lock.RUnlock()
 			return nil
 		}
-		it.layer.lock.RUnlock()
 		panic(fmt.Sprintf("iterator referenced non-existent account: %x", it.curHash))
 	}
 	it.layer.lock.RUnlock()

--- a/core/state/snapshot/iterator.go
+++ b/core/state/snapshot/iterator.go
@@ -125,8 +125,10 @@ func (it *diffAccountIterator) Account() []byte {
 	blob, ok := it.layer.accountData[it.curHash]
 	if !ok {
 		if _, ok := it.layer.destructSet[it.curHash]; ok {
+			it.layer.lock.RUnlock()
 			return nil
 		}
+		it.layer.lock.RUnlock()
 		panic(fmt.Sprintf("iterator referenced non-existent account: %x", it.curHash))
 	}
 	it.layer.lock.RUnlock()

--- a/core/state/snapshot/snapshot.go
+++ b/core/state/snapshot/snapshot.go
@@ -420,6 +420,7 @@ func diffToDisk(bottom *diffLayer) *diskLayer {
 	// Mark the original base as stale as we're going to create a new wrapper
 	base.lock.Lock()
 	if base.stale {
+		base.lock.Unlock()
 		panic("parent disk layer is stale") // we've committed into the same base from two children, boo
 	}
 	base.stale = true

--- a/core/state/snapshot/snapshot.go
+++ b/core/state/snapshot/snapshot.go
@@ -420,7 +420,6 @@ func diffToDisk(bottom *diffLayer) *diskLayer {
 	// Mark the original base as stale as we're going to create a new wrapper
 	base.lock.Lock()
 	if base.stale {
-		base.lock.Unlock()
 		panic("parent disk layer is stale") // we've committed into the same base from two children, boo
 	}
 	base.stale = true


### PR DESCRIPTION
There are two forgetting Unlock bugs fixed in this PR:
1. In `func Account()`,
https://github.com/ethereum/go-ethereum/blob/648b0cb7144feec13391f8e587866e9d47a75548/core/state/snapshot/iterator.go#L124-L132
`it.layer.lock.RUnlock()` is forgot before return and panic.

2. In `func diffToDisk()`,
https://github.com/ethereum/go-ethereum/blob/648b0cb7144feec13391f8e587866e9d47a75548/core/state/snapshot/snapshot.go#L421-L426
`base.lock.Unlock()` is forgot before panic.
 