### PR TITLE
build: added maven upload function

### DIFF
--- a/build/ci.go
+++ b/build/ci.go
@@ -865,16 +865,17 @@ func doAndroidArchive(cmdline []string) {
 		if err != nil {
 			log.Fatal(err)
 		}
-		dir := "./"
+		buildDir := "build"
 		build.MustRunCommand("mvn", "gpg:sign-and-deploy-file", "-e", "-X",
-			"-settings=build/mvn.settings", "-Durl=file:///"+dir, "-DrepositoryId=ossrh",
+			"-settings=build/mvn.settings", "-Durl=file:///"+buildDir, "-DrepositoryId=ossrh",
 			"-Dgpg.keyname="+keyID,
 			"-DpomFile="+meta.Package+".pom", "-Dfile="+meta.Package+".aar")
 
 		profileID := "1234" // TODO (MariusVanDerWijden) get these configuration parameters
 		repositoryID := "1234"
 		// Upload the artifacts to Maven Central
-		uploadToMaven(deploy, profileID, repositoryID, dir)
+		uploadDir := buildDir + "/org/ethereum/geth/" + meta.Package
+		uploadToMaven(deploy, profileID, repositoryID, uploadDir)
 	}
 }
 


### PR DESCRIPTION
WIP to fix the upload of android artifacts to nexus. closes #20922 

The PR creates a new directory under `build/org/ethereum/geth/1.9.14-SNAPSHOT`
which contains the following files 
```
geth-1.9.14-20200423.105903-1.aar
geth-1.9.14-20200423.105903-1.aar.md5
geth-1.9.14-20200423.105903-1.aar.sha1
geth-1.9.14-20200423.105903-1.pom
geth-1.9.14-20200423.105903-1.pom.md5
geth-1.9.14-20200423.105903-1.pom.sha1
geth-1.9.14-SNAPSHOT.aar.asc
geth-1.9.14-SNAPSHOT.aar.asc.md5
geth-1.9.14-SNAPSHOT.aar.asc.sha1
geth-1.9.14-SNAPSHOT.pom.asc
geth-1.9.14-SNAPSHOT.pom.asc.md5
geth-1.9.14-SNAPSHOT.pom.asc.sha1
maven-metadata.xml
maven-metadata.xml.md5
maven-metadata.xml.sha1
```

and uploads them using curl