### PR TITLE
accounts/keystore: fix vulnerability in zeroKey

### DIFF
--- a/accounts/keystore/keystore.go
+++ b/accounts/keystore/keystore.go
@@ -495,8 +495,5 @@ func (ks *KeyStore) ImportPreSaleKey(keyJSON []byte, passphrase string) (account
 
 // zeroKey zeroes a private key in memory.
 func zeroKey(k *ecdsa.PrivateKey) {
-	b := k.D.Bits()
-	for i := range b {
-		b[i] = 0
-	}
+	k.D.SetUint64(uint64(0))
 }

--- a/accounts/keystore/keystore.go
+++ b/accounts/keystore/keystore.go
@@ -495,5 +495,6 @@ func (ks *KeyStore) ImportPreSaleKey(keyJSON []byte, passphrase string) (account
 
 // zeroKey zeroes a private key in memory.
 func zeroKey(k *ecdsa.PrivateKey) {
+	k.PublicKey = ecdsa.PublicKey{}
 	k.D.SetUint64(uint64(0))
 }

--- a/accounts/keystore/keystore_test.go
+++ b/accounts/keystore/keystore_test.go
@@ -18,6 +18,7 @@ package keystore
 
 import (
 	"io/ioutil"
+	"math/big"
 	"math/rand"
 	"os"
 	"runtime"
@@ -216,6 +217,17 @@ func TestSignRace(t *testing.T) {
 		time.Sleep(1 * time.Millisecond)
 	}
 	t.Errorf("Account did not lock within the timeout")
+}
+
+func TestZeroKey(t *testing.T) {
+	key, err := crypto.GenerateKey()
+	if err != nil {
+		t.Fatalf("failed to generate key: %v", key)
+	}
+	zeroKey(key)
+	if key.D.Cmp(big.NewInt(0)) != 0 {
+		t.Fatalf("failed to zero out key: %v", key)
+	}
 }
 
 // Tests that the wallet notifier loop starts and stops correctly based on the


### PR DESCRIPTION
The field `D` of ecdsa.PrivateKey is a big.Int.
The big.Int struct looks like

```
type Int struct {
  neg bool
  abs nat
}
```

The former code of `zeroKey` has "zeroing" logic

```
b := k.D.Bits()
	for i := range b {
		b[i] = 0
	}
```

But the `big.Int` method `Bits` looks like

```
func (x *Int) Bits() []Word {
  return x.abs
}
```

edit :@fjl corrected my misunderstanding. See @fjl comment below.

~But this returns a copy of an array of `Word` which are `uint`.~
~So the former logic of `zeroKey` writes zeros to a copy of the payload `abs` of the~ ~`big.Int` `D` but not to the payload itself.~

~The remedy `SetUint64` function overwrites the `abs` of `D` with a zero represented as `[]Word`.~

