### PR TITLE
p2p/enode: update code comment

### DIFF
--- a/p2p/enode/urlv4.go
+++ b/p2p/enode/urlv4.go
@@ -59,7 +59,7 @@ func MustParseV4(rawurl string) *Node {
 //
 // For complete nodes, the node ID is encoded in the username portion
 // of the URL, separated from the host by an @ sign. The hostname can
-// only be given as an IP addressor or using DNS domain name.
+// only be given as an IP address or using DNS domain name.
 // The port in the host name section is the TCP listening port. If the
 // TCP and UDP (discovery) ports differ, the UDP port is specified as
 // query parameter "discport".

--- a/p2p/enode/urlv4.go
+++ b/p2p/enode/urlv4.go
@@ -59,7 +59,7 @@ func MustParseV4(rawurl string) *Node {
 //
 // For complete nodes, the node ID is encoded in the username portion
 // of the URL, separated from the host by an @ sign. The hostname can
-// only be given as an IP address, DNS domain names are not allowed.
+// only be given as an IP addressor or using DNS domain name.
 // The port in the host name section is the TCP listening port. If the
 // TCP and UDP (discovery) ports differ, the UDP port is specified as
 // query parameter "discport".


### PR DESCRIPTION
p2p/enode: update code comment

Since commit b90cdbaa79cfe438aab0f1389d35980f3d38ec84 it's possible to specify enode Url using domain name, but under code comment it still mentionned that only IP Address is allow.