### PR TITLE
p2p/discv5: bootnodes URLs using domain name

### DIFF
--- a/p2p/discv5/node.go
+++ b/p2p/discv5/node.go
@@ -106,7 +106,10 @@ func (n *Node) String() string {
 	return u.String()
 }
 
-var incompleteNodeURL = regexp.MustCompile("(?i)^(?:enode://)?([0-9a-f]+)$")
+var (
+	incompleteNodeURL = regexp.MustCompile("(?i)^(?:enode://)?([0-9a-f]+)$")
+	lookupIPFunc      = net.LookupIP
+)
 
 // ParseNode parses a node designator.
 //
@@ -168,7 +171,11 @@ func parseComplete(rawurl string) (*Node, error) {
 		return nil, fmt.Errorf("invalid host: %v", err)
 	}
 	if ip = net.ParseIP(host); ip == nil {
-		return nil, errors.New("invalid IP address")
+		ips, err := lookupIPFunc(u.Hostname())
+		if err != nil {
+			return nil, errors.New("no such host")
+		}
+		ip = ips[0]
 	}
 	// Ensure the IP is 4 bytes long for IPv4 addresses.
 	if ipv4 := ip.To4(); ipv4 != nil {


### PR DESCRIPTION
Since commit b90cdbaa79cfe438aab0f1389d35980f3d38ec84 enode url is able to manage domain name under URL,
But it still not the case for bootnodes parameter (invalid IP Address error) this change enable it.