### PR TITLE
ethdb/leveldb : timer instead of sleep and sync close meter routine of leveldb

### DIFF
--- a/ethdb/leveldb/leveldb.go
+++ b/ethdb/leveldb/leveldb.go
@@ -75,8 +75,8 @@ type Database struct {
 	nonlevel0CompGauge metrics.Gauge // Gauge for tracking the number of table compaction in non0 level
 	seekCompGauge      metrics.Gauge // Gauge for tracking the number of table compaction caused by read opt
 
-	quitLock sync.Mutex      // Mutex protecting the quit channel access
-	quitChan chan chan error // Quit channel to stop the metrics collection before closing the database
+	quitLock sync.Mutex    // Mutex protecting the quit channel access
+	quitChan chan struct{} // Quit channel to stop the metrics collection before closing the database
 
 	log log.Logger // Contextual logger tracking the database path
 
@@ -115,7 +115,7 @@ func New(file string, cache int, handles int, namespace string) (*Database, erro
 		fn:       file,
 		db:       db,
 		log:      logger,
-		quitChan: make(chan chan error),
+		quitChan: make(chan struct{}),
 	}
 	ldb.compTimeMeter = metrics.NewRegisteredMeter(namespace+"compact/time", nil)
 	ldb.compReadMeter = metrics.NewRegisteredMeter(namespace+"compact/input", nil)

--- a/ethdb/leveldb/leveldb.go
+++ b/ethdb/leveldb/leveldb.go
@@ -235,15 +235,16 @@ func (db *Database) meter(refresh time.Duration) {
 	for i := 0; i < 2; i++ {
 		compactions[i] = make([]float64, 4)
 	}
-	// Create storage for iostats.
-	var iostats [2]float64
 
-	// Create storage and warning log tracer for write delay.
 	var (
+		// Create storage for iostats.
+		iostats [2]float64
+		// Create storage and warning log tracer for write delay.
 		delaystats      [2]int64
 		lastWritePaused time.Time
+
+		timer = time.NewTimer(refresh)
 	)
-	timer := time.NewTimer(refresh)
 	defer timer.Stop()
 
 	// Iterate ad infinitum and collect the stats

--- a/ethdb/leveldb/leveldb.go
+++ b/ethdb/leveldb/leveldb.go
@@ -384,6 +384,7 @@ func (db *Database) meter(refresh time.Duration) {
 		// Sleep a bit, then repeat the stats collection
 		select {
 		case <-db.quitChan:
+			log.Info("Leveldb meter already quit")
 			return
 			// Quit requesting, stop hammering the database
 		case <-timer.C:


### PR DESCRIPTION
1. use timer instead of sleep in loops
2. make sure the meter go routine always finish closing