### PR TITLE
core: add skip in AddChildIndexer() to avoid double lock

### DIFF
--- a/core/chain_indexer.go
+++ b/core/chain_indexer.go
@@ -439,6 +439,9 @@ func (c *ChainIndexer) Sections() (uint64, uint64, common.Hash) {
 
 // AddChildIndexer adds a child ChainIndexer that can use the output of this one
 func (c *ChainIndexer) AddChildIndexer(indexer *ChainIndexer) {
+	if c == indexer {
+		return
+	}
 	c.lock.Lock()
 	defer c.lock.Unlock()
 

--- a/core/chain_indexer.go
+++ b/core/chain_indexer.go
@@ -439,8 +439,8 @@ func (c *ChainIndexer) Sections() (uint64, uint64, common.Hash) {
 
 // AddChildIndexer adds a child ChainIndexer that can use the output of this one
 func (c *ChainIndexer) AddChildIndexer(indexer *ChainIndexer) {
-	if c == indexer {
-		return
+	if indexer == c {
+		panic("can't add indexer as a child of itself")
 	}
 	c.lock.Lock()
 	defer c.lock.Unlock()


### PR DESCRIPTION
In core/chain_indexer.go,
The first lock is `c.lock.Lock()` in func `AddChildIndexer()`.
Then the func calls `indexer.newHead()`, where the second lock is called.
If `c == indexer`, then this is a double lock.
https://github.com/ethereum/go-ethereum/blob/1aa83290f5052ce275fc4f36b909a721afe6037a/core/chain_indexer.go#L240-L242

The fix adds a condition before the first lock: if `c == indexer`, then directly returns.
Since `AddChildIndexer()` is a public func, I think it is necessary to add this checking to prevent developers from mistakenly passing `ChainIndexer` itself to the function.
