### PR TITLE
accounts: add blockByNumberNoLock() to avoid double-lock

### DIFF
--- a/accounts/abi/bind/backends/simulated.go
+++ b/accounts/abi/bind/backends/simulated.go
@@ -132,7 +132,7 @@ func (b *SimulatedBackend) stateByBlockNumber(ctx context.Context, blockNumber *
 	if blockNumber == nil || blockNumber.Cmp(b.blockchain.CurrentBlock().Number()) == 0 {
 		return b.blockchain.State()
 	}
-	block, err := b.BlockByNumber(ctx, blockNumber)
+	block, err := b.blockByNumberNoLock(ctx, blockNumber)
 	if err != nil {
 		return nil, err
 	}
@@ -243,6 +243,12 @@ func (b *SimulatedBackend) BlockByNumber(ctx context.Context, number *big.Int) (
 	b.mu.Lock()
 	defer b.mu.Unlock()
 
+	return b.blockByNumberNoLock(ctx, number)
+}
+
+// blockByNumberNoLock retrieves a block from the database by number, caching it
+// (associated with its hash) if found without Lock.
+func (b *SimulatedBackend) blockByNumberNoLock(ctx context.Context, number *big.Int) (*types.Block, error) {
 	if number == nil || number.Cmp(b.pendingBlock.Number()) == 0 {
 		return b.blockchain.CurrentBlock(), nil
 	}

--- a/accounts/abi/bind/backends/simulated.go
+++ b/accounts/abi/bind/backends/simulated.go
@@ -136,7 +136,7 @@ func (b *SimulatedBackend) stateByBlockNumber(ctx context.Context, blockNumber *
 	if err != nil {
 		return nil, err
 	}
-	return b.blockchain.StateAt(block.Hash())
+	return b.blockchain.StateAt(block.Root())
 }
 
 // CodeAt returns the code associated with a certain account in the blockchain.

--- a/accounts/abi/bind/backends/simulated_test.go
+++ b/accounts/abi/bind/backends/simulated_test.go
@@ -268,6 +268,16 @@ func TestSimulatedBackend_NonceAt(t *testing.T) {
 	if newNonce != nonce+uint64(1) {
 		t.Errorf("received incorrect nonce. expected 1, got %v", nonce)
 	}
+	// create some more blocks
+	sim.Commit()
+	// Check that we can get data for an older block/state
+	newNonce, err = sim.NonceAt(bgCtx, testAddr, big.NewInt(1))
+	if err != nil {
+		t.Fatalf("could not get nonce for test addr: %v", err)
+	}
+	if newNonce != nonce+uint64(1) {
+		t.Fatalf("received incorrect nonce. expected 1, got %v", nonce)
+	}
 }
 
 func TestSimulatedBackend_SendTransaction(t *testing.T) {


### PR DESCRIPTION
In accounts/abi/bind/backends/simulated.go,
Four functions `CodeAt()`, `BalanceAt()`, `NonceAt()`, `StorageAt()` call `stateByBlockNumber()`.
https://github.com/ethereum/go-ethereum/blob/1aa83290f5052ce275fc4f36b909a721afe6037a/accounts/abi/bind/backends/simulated.go#L143-L147
But before that, they all hold `b.mu.Lock()`.
Then func `stateByBlockNumber()` calls `b.BlockByNumber()`, where the second `b.mu.Lock()` resides.
https://github.com/ethereum/go-ethereum/blob/1aa83290f5052ce275fc4f36b909a721afe6037a/accounts/abi/bind/backends/simulated.go#L131-L135
https://github.com/ethereum/go-ethereum/blob/1aa83290f5052ce275fc4f36b909a721afe6037a/accounts/abi/bind/backends/simulated.go#L242-L244

The fix is to add a No-Lock version of `BlockByNumber()`: `blockByNumberNoLock()`.
Then we call `blockByNumberNoLock()` instead of `BlockByNumber()` in `stateByBlockNumber()`.