### PR TITLE
core: avoid double-lock in tx_pool_test

### DIFF
--- a/core/tx_pool_test.go
+++ b/core/tx_pool_test.go
@@ -117,7 +117,7 @@ func validateTxPoolInternals(pool *TxPool) error {
 				last = nonce
 			}
 		}
-		if nonce := pool.Nonce(addr); nonce != last+1 {
+		if nonce := pool.pendingNonces.get(addr); nonce != last+1 {
 			return fmt.Errorf("pending nonce mismatch: have %v, want %v", nonce, last+1)
 		}
 	}


### PR DESCRIPTION
As the [https://golang.org/pkg/sync/](https://golang.org/pkg/sync/) says about RLock:
`It should not be used for recursive read locking; a blocked Lock call excludes new readers from acquiring the lock.`
So double read lock should also be avoided.
In core/tx_pool_test.go,
func `validateTxPoolInternals()` calls `pool.mu.RLock()`.
https://github.com/ethereum/go-ethereum/blob/1aa83290f5052ce275fc4f36b909a721afe6037a/core/tx_pool_test.go#L99-L101
Then it calls `pool.Nonce()`, where the second `pool.mu.RLock()` resides.
https://github.com/ethereum/go-ethereum/blob/1aa83290f5052ce275fc4f36b909a721afe6037a/core/tx_pool_test.go#L120
https://github.com/ethereum/go-ethereum/blob/1aa83290f5052ce275fc4f36b909a721afe6037a/core/tx_pool.go#L429-L431
The fix is to use the code inside `Nonce()` directly without locking.