### PR TITLE
eth: fix shutdown regression to abort downloads, not just cancel

### DIFF
--- a/eth/downloader/downloader.go
+++ b/eth/downloader/downloader.go
@@ -557,6 +557,8 @@ func (d *Downloader) spawnSync(fetchers []func() error) error {
 func (d *Downloader) cancel() {
 	// Close the current cancel channel
 	d.cancelLock.Lock()
+	defer d.cancelLock.Unlock()
+
 	if d.cancelCh != nil {
 		select {
 		case <-d.cancelCh:
@@ -565,7 +567,6 @@ func (d *Downloader) cancel() {
 			close(d.cancelCh)
 		}
 	}
-	d.cancelLock.Unlock()
 }
 
 // Cancel aborts all of the operations and waits for all download goroutines to

--- a/eth/sync.go
+++ b/eth/sync.go
@@ -222,7 +222,7 @@ func (cs *chainSyncer) loop() {
 
 		case <-cs.pm.quitSync:
 			if cs.doneCh != nil {
-				cs.pm.downloader.Cancel()
+				cs.pm.downloader.Terminate() // Double term is fine, Cancel would block until queue is emptied
 				<-cs.doneCh
 			}
 			return


### PR DESCRIPTION
Fixes https://github.com/ethereum/go-ethereum/issues/20975

I still managed to hang it once, but not general, so there might be something still in there, but at least most hangs are fixed.