### PR TITLE
accounts/abi/bind: generate java structs

### DIFF
--- a/accounts/abi/bind/bind.go
+++ b/accounts/abi/bind/bind.go
@@ -22,7 +22,6 @@ package bind
 
 import (
 	"bytes"
-	"errors"
 	"fmt"
 	"go/format"
 	"regexp"
@@ -164,10 +163,6 @@ func Bind(types []string, abis []string, bytecodes []string, fsigs []map[string]
 		}
 		if evmABI.HasReceive() {
 			receive = &tmplMethod{Original: evmABI.Receive}
-		}
-		// There is no easy way to pass arbitrary java objects to the Go side.
-		if len(structs) > 0 && lang == LangJava {
-			return "", errors.New("java binding for tuple arguments is not supported yet")
 		}
 
 		contracts[types[i]] = &tmplContract{

--- a/accounts/abi/bind/bind_test.go
+++ b/accounts/abi/bind/bind_test.go
@@ -2150,7 +2150,7 @@ public class Test {
 			for _, line := range lines {
 				if strings.TrimSpace(line) != "" {
 					lines[index] = line
-					index += 1
+					index++
 				}
 			}
 			lines = lines[:index]
@@ -2160,6 +2160,17 @@ public class Test {
 		expect := removeEmptys(c.expected)
 		if binding != expect {
 			t.Fatalf("test %d: generated binding mismatch, has %s, want %s", i, binding, c.expected)
+		}
+	}
+}
+
+// Tests binding the bindTests succeeds (does not execute test cases, only checks binding errors)
+func TestGenerateBindingingJava(t *testing.T) {
+	// Generate the test suite for all the contracts
+	for _, tt := range bindTests {
+		_, err := Bind([]string{tt.name}, tt.abi, tt.bytecode, nil, "bindtest", LangJava, nil, tt.aliases)
+		if err != nil {
+			t.Fatalf("test %s: failed to generate binding: %v", tt.name, err)
 		}
 	}
 }

--- a/accounts/abi/bind/bind_test.go
+++ b/accounts/abi/bind/bind_test.go
@@ -2168,9 +2168,13 @@ public class Test {
 func TestGenerateBindingingJava(t *testing.T) {
 	// Generate the test suite for all the contracts
 	for _, tt := range bindTests {
-		_, err := Bind([]string{tt.name}, tt.abi, tt.bytecode, nil, "bindtest", LangJava, nil, tt.aliases)
+		bind, err := Bind([]string{tt.name}, tt.abi, tt.bytecode, nil, "bindtest", LangJava, nil, tt.aliases)
 		if err != nil {
 			t.Fatalf("test %s: failed to generate binding: %v", tt.name, err)
 		}
+		if err := ioutil.WriteFile("/home/matematik/j-bindings/"+tt.name, []byte(bind), 0600); err != nil {
+			t.Fatal(err)
+		}
+
 	}
 }

--- a/accounts/abi/bind/template.go
+++ b/accounts/abi/bind/template.go
@@ -613,6 +613,14 @@ import java.util.*;
 		this(Geth.bindContract(address, ABI, client));
 	}
 
+	{{range $structs}}
+	// {{capitalise .Name}} is an auto generated low-level Java binding around an user-defined struct.
+	public class {{capitalise .Name}} {
+		{{range $index, $item := .Fields}}public {{$item.Type}} {{if ne .Name ""}}{{.Name}}{{else}}Return{{$index}}{{end}};
+		{{end}}
+	}
+	{{end}}
+
 	{{range .Calls}}
 	{{if gt (len .Normalized.Outputs) 1}}
 	// {{capitalise .Normalized.Name}}Results is the output of a call to {{.Normalized.Name}}.

--- a/mobile/interface.go
+++ b/mobile/interface.go
@@ -116,8 +116,9 @@ func (i *Interface) SetUint64s(bigints *BigInts) {
 	}
 	i.object = &ints
 }
-func (i *Interface) SetBigInt(bigint *BigInt)    { i.object = &bigint.bigint }
-func (i *Interface) SetBigInts(bigints *BigInts) { i.object = &bigints.bigints }
+func (i *Interface) SetBigInt(bigint *BigInt)         { i.object = &bigint.bigint }
+func (i *Interface) SetBigInts(bigints *BigInts)      { i.object = &bigints.bigints }
+func (i *Interface) SetInterfaces(ifaces *Interfaces) { i.object = &ifaces.objects }
 
 func (i *Interface) SetDefaultBool()      { i.object = new(bool) }
 func (i *Interface) SetDefaultBools()     { i.object = new([]bool) }
@@ -238,8 +239,9 @@ func (i *Interface) GetUint64s() *BigInts {
 	}
 	return bigints
 }
-func (i *Interface) GetBigInt() *BigInt   { return &BigInt{*i.object.(**big.Int)} }
-func (i *Interface) GetBigInts() *BigInts { return &BigInts{*i.object.(*[]*big.Int)} }
+func (i *Interface) GetBigInt() *BigInt         { return &BigInt{*i.object.(**big.Int)} }
+func (i *Interface) GetBigInts() *BigInts       { return &BigInts{*i.object.(*[]*big.Int)} }
+func (i *Interface) GetInterfaces() *Interfaces { return &Interfaces{*i.object.(*[]interface{})} }
 
 // Interfaces is a slices of wrapped generic objects.
 type Interfaces struct {
@@ -256,7 +258,7 @@ func (i *Interfaces) Size() int {
 	return len(i.objects)
 }
 
-// Get returns the bigint at the given index from the slice.
+// Get returns the interface at the given index from the slice.
 // Notably the returned value can be changed without affecting the
 // interfaces itself.
 func (i *Interfaces) Get(index int) (iface *Interface, _ error) {
@@ -266,11 +268,17 @@ func (i *Interfaces) Get(index int) (iface *Interface, _ error) {
 	return &Interface{object: i.objects[index]}, nil
 }
 
-// Set sets the big int at the given index in the slice.
+// Set sets the interface at the given index in the slice.
 func (i *Interfaces) Set(index int, object *Interface) error {
 	if index < 0 || index >= len(i.objects) {
 		return errors.New("index out of bounds")
 	}
 	i.objects[index] = object.object
 	return nil
+}
+
+func (i *Interfaces) SetInterfaces(index int, objects *Interfaces) error {
+	var in Interface
+	in.SetInterfaces(objects)
+	return i.Set(index, &in)
 }


### PR DESCRIPTION
This commit enables struct generation for contracts on java.
It will generate for the TUPLE contract the following:
```
// TupleP is an auto generated low-level Java binding around an user-defined struct.
	public class TupleP {
		public BigInt x;
		public BigInt y;
	}

	// TupleQ is an auto generated low-level Java binding around an user-defined struct.
	public class TupleQ {
		public BigInt x;
		public BigInt y;
	}

	// TupleS is an auto generated low-level Java binding around an user-defined struct.
	public class TupleS {
		public BigInt a;
		public BigInts b;
		public TupleT[] c;
	}

	// TupleT is an auto generated low-level Java binding around an user-defined struct.
	public class TupleT {
		public BigInt x;
		public BigInt y;
	}

	// Func1Results is the output of a call to func1.
	public class Func1Results {
		public TupleS Return0;
		public TupleT[][] Return1;
		public TupleT[][] Return2;
		public TupleS[] Return3;
		public BigInts Return4;
	}
```