### PR TITLE
[DOCS] add note about HTTP attach in getting started guide

### DIFF
--- a/docs/_getting-started/index.md
+++ b/docs/_getting-started/index.md
@@ -77,7 +77,9 @@ terminal and using the following command to open a JavaScript console:
 ```shell
 geth attach
 ```
-If you get the error 'unable to attach to remote geth', try including the path to localhost as shown below:
+
+If you get the error 'unable to attach to remote geth', try connecting via HTTP as shown below:
+
 ```shell
 geth attach http://127.0.0.1:8545
 ```

--- a/docs/_getting-started/index.md
+++ b/docs/_getting-started/index.md
@@ -77,6 +77,10 @@ terminal and using the following command to open a JavaScript console:
 ```shell
 geth attach
 ```
+If you get the error 'unable to attach to remote geth', try including the path to localhost as shown below:
+```shell
+geth attach http://127.0.0.1:8545
+```
 
 In the console you can issue any of the Geth commands, for example, to list all the
 accounts on the node, use:


### PR DESCRIPTION
Adding an alternative command since some people are unable to connect with 'geth attach' command by itself.