### PR TITLE
accounts/external: convert signature v value to 0/1

### DIFF
--- a/accounts/accounts.go
+++ b/accounts/accounts.go
@@ -129,6 +129,8 @@ type Wallet interface {
 	// about which fields or actions are needed. The user may retry by providing
 	// the needed details via SignHashWithPassphrase, or by other means (e.g. unlock
 	// the account in a keystore).
+	//
+	// This method should return the signature in 'canonical' format, with v 0 or 1
 	SignText(account Account, text []byte) ([]byte, error)
 
 	// SignTextWithPassphrase is identical to Signtext, but also takes a password

--- a/accounts/external/backend.go
+++ b/accounts/external/backend.go
@@ -169,15 +169,20 @@ func (api *ExternalSigner) SignData(account accounts.Account, mimeType string, d
 }
 
 func (api *ExternalSigner) SignText(account accounts.Account, text []byte) ([]byte, error) {
-	var res hexutil.Bytes
+	var signature hexutil.Bytes
 	var signAddress = common.NewMixedcaseAddress(account.Address)
-	if err := api.client.Call(&res, "account_signData",
+	if err := api.client.Call(&signature, "account_signData",
 		accounts.MimetypeTextPlain,
 		&signAddress, // Need to use the pointer here, because of how MarshalJSON is defined
 		hexutil.Encode(text)); err != nil {
 		return nil, err
 	}
-	return res, nil
+	if signature[64] == 27 || signature[64] == 28 {
+		// If clef is used as a backend, it may already have transformed
+		// the signature to ethereum-type signature.
+		signature[64] -= 27 // Transform V from Ethereum-legacy to 0/1
+	}
+	return signature, nil
 }
 
 func (api *ExternalSigner) SignTx(account accounts.Account, tx *types.Transaction, chainID *big.Int) (*types.Transaction, error) {


### PR DESCRIPTION
With this PR, the outputs from `eth.sign` is identical regardless of whether
`clef` is used as backend, or a regular keystore.

Keystore:
```
[user@work go-ethereum]$ build/bin/geth --nodiscover --maxpeers 0 --keystore=~/tmp/fookeys console
```
```
// unlock first
>  eth.sign("0xD38018ac06AE8394C2a0Ed55BfDc3EE76e0Aa55C","")
"0x324b5f7e6be13118848225da6b0c18fd80d2759952ba3d55d15de01bb36d5a0808141daa1b50ea216e99d1cb855446c86462244b63baa610f8d8d77740c09a3c1c"
```
Clef:
```
[user@work go-ethereum]$ build/bin/geth --nodiscover --maxpeers 0 --signer /home/user/.clef/clef.ipc console
```
```
> eth.sign("0xD38018ac06AE8394C2a0Ed55BfDc3EE76e0Aa55C","")
"0x324b5f7e6be13118848225da6b0c18fd80d2759952ba3d55d15de01bb36d5a0808141daa1b50ea216e99d1cb855446c86462244b63baa610f8d8d77740c09a3c1c"
```