### PR TITLE
accounts/external: fetch external accounts

### DIFF
--- a/accounts/external/backend.go
+++ b/accounts/external/backend.go
@@ -131,6 +131,12 @@ func (api *ExternalSigner) Accounts() []accounts.Account {
 func (api *ExternalSigner) Contains(account accounts.Account) bool {
 	api.cacheMu.RLock()
 	defer api.cacheMu.RUnlock()
+	if api.cache == nil {
+		// If we haven't already fetched the accounts, it's time to do so now
+		api.cacheMu.RUnlock()
+		api.Accounts()
+		api.cacheMu.RLock()
+	}
 	for _, a := range api.cache {
 		if a.Address == account.Address && (account.URL == (accounts.URL{}) || account.URL == api.URL()) {
 			return true


### PR DESCRIPTION
This PR fills the account-cache from an externals signer, if that hasn't already been done. Fixes #20995
Bug repro below (but I only include the results for this PR): 

gethsign.json:
```json
 cat gethsign.json
{
  "jsonrpc": "2.0",
  "method": "eth_sign",
  "params": [ "0xD38018ac06AE8394C2a0Ed55BfDc3EE76e0Aa55C", ""],
  "id": 67
}
```

Start `clef` with: `build/bin/clef --keystore ~/tmp/fookeys`
Start `geth` with `build/bin/geth --nodiscover --maxpeers 0 --signer /home/user/.clef/clef.ipc`

Then send a request (without having touched the console) : `cat gethsign.json | nc -U /home/user/.ethereum/geth.ipc`

Clef output:
```
-------- List Account request--------------
A request has been made to list all accounts.
You can select which accounts the caller can see
  [x] 0xD38018ac06AE8394C2a0Ed55BfDc3EE76e0Aa55C
    URL: keystore:///home/user/tmp/fookeys/UTC--2020-04-28T11-50-33.375837463Z--d38018ac06ae8394c2a0ed55bfdc3ee76e0aa55c
-------------------------------------------
Request context:
	NA -> NA -> NA

Additional HTTP header data, provided by the external caller:
	User-Agent: ""
	Origin: ""
Approve? [y/N]:
> y

... followed by sign text ...
```
Eventually, the response:
```
[user@work clef]$ cat gethsign.json | nc -U /home/user/.ethereum/geth.ipc
{"jsonrpc":"2.0","id":67,"result":"0x324b5f7e6be13118848225da6b0c18fd80d2759952ba3d55d15de01bb36d5a0808141daa1b50ea216e99d1cb855446c86462244b63baa610f8d8d77740c09a3c37"}

```