### PR TITLE
trie: improve range proof

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -202,6 +202,8 @@ golang.org/x/sys v0.0.0-20180909124046-d0be0721c37e/go.mod h1:STP8DvDyc/dI5b8T5h
 golang.org/x/sys v0.0.0-20181107165924-66b7b1311ac8/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20200302150141-5c8b2ff67527 h1:uYVVQ9WP/Ds2ROhcaGPeIdVq0RIXVLwsHlnvJ+cT1So=
+golang.org/x/sys v0.0.0-20200302150141-5c8b2ff67527/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd h1:xhmwyvizuTgC2qz7ZlMluP20uW+C3Rm0FD/WLDX8884=
 golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=

--- a/trie/proof.go
+++ b/trie/proof.go
@@ -167,7 +167,7 @@ func proofToPath(rootHash common.Hash, root node, key []byte, proofDb ethdb.KeyV
 		switch cld := child.(type) {
 		case nil:
 			// The trie doesn't contain the key. It's possible
-			// the proof is an non-existing proof, but at least
+			// the proof is a non-existing proof, but at least
 			// we can prove all resolved nodes are correct, it's
 			// enough for us to prove range.
 			if allowNonExistent {
@@ -355,7 +355,7 @@ func unset(parent node, child node, key []byte, pos int, removeLeft bool) error 
 //   range should be all the leaves in the trie.
 //
 // - Zero element proof(left edge proof should be a non-existent proof). In this
-//   case if there are still some other leaves available in the right side, then
+//   case if there are still some other leaves available on the right side, then
 //   an error will be returned.
 //
 // - One element proof. In this case no matter the left edge proof is a non-existent

--- a/trie/proof.go
+++ b/trie/proof.go
@@ -364,8 +364,8 @@ func VerifyRangeProof(rootHash common.Hash, firstKey []byte, keys [][]byte, valu
 	if len(keys) != len(values) {
 		return fmt.Errorf("inconsistent proof data, keys: %d, values: %d", len(keys), len(values))
 	}
-	// Speical case, there is no edge proof at all. Then the
-	// given range is expected to be the whole set in the trie.
+	// Special case, there is no edge proof at all. The given range is expected
+	// to be the whole leaf-set in the trie.
 	if firstProof == nil && lastProof == nil {
 		emptytrie, err := New(common.Hash{}, NewDatabase(memorydb.New()))
 		if err != nil {
@@ -375,15 +375,14 @@ func VerifyRangeProof(rootHash common.Hash, firstKey []byte, keys [][]byte, valu
 			emptytrie.TryUpdate(key, values[index])
 		}
 		if emptytrie.Hash() != rootHash {
-			return fmt.Errorf("invalid proof, wanthash %x, got %x", rootHash, emptytrie.Hash())
+			return fmt.Errorf("invalid proof, want hash %x, got %x", rootHash, emptytrie.Hash())
 		}
 		return nil
 	}
-	// Special case, there is a provided non-existent proof and
-	// zero leaf, it means no more leaf we can get in the trie.
+	// Special case, there is a provided non-existence proof and zero key/value
+	// pairs, meaning there are no more accounts / slots in the trie.
 	if len(keys) == 0 {
-		// Recover the non-existent proof to a path, ensure there
-		// is nothing left
+		// Recover the non-existent proof to a path, ensure there is nothing left
 		root, err := proofToPath(rootHash, nil, firstKey, firstProof, true)
 		if err != nil {
 			return err
@@ -454,7 +453,7 @@ func VerifyRangeProof(rootHash common.Hash, firstKey []byte, keys [][]byte, valu
 		newtrie.TryUpdate(key, values[index])
 	}
 	if newtrie.Hash() != rootHash {
-		return fmt.Errorf("invalid proof, wanthash %x, got %x", rootHash, newtrie.Hash())
+		return fmt.Errorf("invalid proof, want hash %x, got %x", rootHash, newtrie.Hash())
 	}
 	return nil
 }

--- a/trie/proof_test.go
+++ b/trie/proof_test.go
@@ -473,6 +473,39 @@ func TestGappedRangeProof(t *testing.T) {
 	}
 }
 
+// TestSingleSideRangeProof tests the range starts from zero.
+func TestSingleSideRangeProof(t *testing.T) {
+	trie := new(Trie)
+	var entries entrySlice
+	for i := 0; i < 4096; i++ {
+		value := &kv{randBytes(32), randBytes(20), false}
+		trie.Update(value.k, value.v)
+		entries = append(entries, value)
+	}
+	sort.Sort(entries)
+
+	var cases = []int{0, 1, 50, 100, 1000, 2000, len(entries) - 1}
+	for _, pos := range cases {
+		firstProof, lastProof := memorydb.New(), memorydb.New()
+		if err := trie.Prove(common.Hash{}.Bytes(), 0, firstProof); err != nil {
+			t.Fatalf("Failed to prove the first node %v", err)
+		}
+		if err := trie.Prove(entries[pos].k, 0, lastProof); err != nil {
+			t.Fatalf("Failed to prove the first node %v", err)
+		}
+		k := make([][]byte, 0)
+		v := make([][]byte, 0)
+		for i := 0; i <= pos; i++ {
+			k = append(k, entries[i].k)
+			v = append(v, entries[i].v)
+		}
+		err := VerifyRangeProof(trie.Hash(), common.Hash{}.Bytes(), k, v, firstProof, lastProof)
+		if err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
+	}
+}
+
 // mutateByte changes one byte in b.
 func mutateByte(b []byte) {
 	for r := mrand.Intn(len(b)); ; {

--- a/trie/proof_test.go
+++ b/trie/proof_test.go
@@ -130,7 +130,7 @@ func TestRangeProof(t *testing.T) {
 			keys = append(keys, entries[i].k)
 			vals = append(vals, entries[i].v)
 		}
-		err := VerifyRangeProof(trie.Hash(), keys, vals, firstProof, lastProof)
+		err := VerifyRangeProof(trie.Hash(), keys[0], keys, vals, firstProof, lastProof)
 		if err != nil {
 			t.Fatalf("Case %d(%d->%d) expect no error, got %v", i, start, end-1, err)
 		}
@@ -208,7 +208,7 @@ func TestBadRangeProof(t *testing.T) {
 			index = mrand.Intn(end - start)
 			vals[index] = nil
 		}
-		err := VerifyRangeProof(trie.Hash(), keys, vals, firstProof, lastProof)
+		err := VerifyRangeProof(trie.Hash(), keys[0], keys, vals, firstProof, lastProof)
 		if err == nil {
 			t.Fatalf("%d Case %d index %d range: (%d->%d) expect error, got nil", i, testcase, index, start, end-1)
 		}
@@ -242,7 +242,7 @@ func TestGappedRangeProof(t *testing.T) {
 		keys = append(keys, entries[i].k)
 		vals = append(vals, entries[i].v)
 	}
-	err := VerifyRangeProof(trie.Hash(), keys, vals, firstProof, lastProof)
+	err := VerifyRangeProof(trie.Hash(), keys[0], keys, vals, firstProof, lastProof)
 	if err == nil {
 		t.Fatal("expect error, got nil")
 	}
@@ -379,7 +379,7 @@ func benchmarkVerifyRangeProof(b *testing.B, size int) {
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		err := VerifyRangeProof(trie.Hash(), keys, values, firstProof, lastProof)
+		err := VerifyRangeProof(trie.Hash(), keys[0], keys, values, firstProof, lastProof)
 		if err != nil {
 			b.Fatalf("Case %d(%d->%d) expect no error, got %v", i, start, end-1, err)
 		}

--- a/trie/proof_test.go
+++ b/trie/proof_test.go
@@ -155,8 +155,8 @@ func (p entrySlice) Len() int           { return len(p) }
 func (p entrySlice) Less(i, j int) bool { return bytes.Compare(p[i].k, p[j].k) < 0 }
 func (p entrySlice) Swap(i, j int)      { p[i], p[j] = p[j], p[i] }
 
-// TestRangeProof tests normal range proof with both edge proofs as the
-// existent proof. The test cases are generated randomly.
+// TestRangeProof tests normal range proof with both edge proofs
+// as the existent proof. The test cases are generated randomly.
 func TestRangeProof(t *testing.T) {
 	trie, vals := randomTrie(4096)
 	var entries entrySlice
@@ -190,8 +190,8 @@ func TestRangeProof(t *testing.T) {
 	}
 }
 
-// TestRangeProof tests normal range proof with the first edge proof as the
-// non-existent proof. The test cases are generated randomly.
+// TestRangeProof tests normal range proof with the first edge proof
+// as the non-existent proof. The test cases are generated randomly.
 func TestRangeProofWithNonExistentProof(t *testing.T) {
 	trie, vals := randomTrie(4096)
 	var entries entrySlice
@@ -232,7 +232,7 @@ func TestRangeProofWithNonExistentProof(t *testing.T) {
 
 // TestRangeProofWithInvalidNonExistentProof tests such scenarios:
 // - The last edge proof is an non-existent proof
-// - There exist the gap between the first leaf and first non-existent proof
+// - There exists a gap between the first element and the left edge proof
 func TestRangeProofWithInvalidNonExistentProof(t *testing.T) {
 	trie, vals := randomTrie(4096)
 	var entries entrySlice
@@ -328,7 +328,7 @@ func TestOneElementRangeProof(t *testing.T) {
 }
 
 // TestEmptyRangeProof tests the range proof with "no" element.
-// The first edge proof must be an non-existent proof.
+// The first edge proof must be a non-existent proof.
 func TestEmptyRangeProof(t *testing.T) {
 	trie, vals := randomTrie(4096)
 	var entries entrySlice

--- a/trie/proof_test.go
+++ b/trie/proof_test.go
@@ -98,6 +98,57 @@ func TestOneElementProof(t *testing.T) {
 	}
 }
 
+func TestBadProof(t *testing.T) {
+	trie, vals := randomTrie(800)
+	root := trie.Hash()
+	for i, prover := range makeProvers(trie) {
+		for _, kv := range vals {
+			proof := prover(kv.k)
+			if proof == nil {
+				t.Fatalf("prover %d: nil proof", i)
+			}
+			it := proof.NewIterator(nil, nil)
+			for i, d := 0, mrand.Intn(proof.Len()); i <= d; i++ {
+				it.Next()
+			}
+			key := it.Key()
+			val, _ := proof.Get(key)
+			proof.Delete(key)
+			it.Release()
+
+			mutateByte(val)
+			proof.Put(crypto.Keccak256(val), val)
+
+			if _, err := VerifyProof(root, kv.k, proof); err == nil {
+				t.Fatalf("prover %d: expected proof to fail for key %x", i, kv.k)
+			}
+		}
+	}
+}
+
+// Tests that missing keys can also be proven. The test explicitly uses a single
+// entry trie and checks for missing keys both before and after the single entry.
+func TestMissingKeyProof(t *testing.T) {
+	trie := new(Trie)
+	updateString(trie, "k", "v")
+
+	for i, key := range []string{"a", "j", "l", "z"} {
+		proof := memorydb.New()
+		trie.Prove([]byte(key), 0, proof)
+
+		if proof.Len() != 1 {
+			t.Errorf("test %d: proof should have one element", i)
+		}
+		val, err := VerifyProof(trie.Hash(), []byte(key), proof)
+		if err != nil {
+			t.Fatalf("test %d: failed to verify proof: %v\nraw proof: %x", i, err, proof)
+		}
+		if val != nil {
+			t.Fatalf("test %d: verified value mismatch: have %x, want nil", i, val)
+		}
+	}
+}
+
 type entrySlice []*kv
 
 func (p entrySlice) Len() int           { return len(p) }
@@ -134,6 +185,138 @@ func TestRangeProof(t *testing.T) {
 		if err != nil {
 			t.Fatalf("Case %d(%d->%d) expect no error, got %v", i, start, end-1, err)
 		}
+	}
+}
+
+func TestRangeProofWithNonExistentProof(t *testing.T) {
+	trie, vals := randomTrie(4096)
+	var entries entrySlice
+	for _, kv := range vals {
+		entries = append(entries, kv)
+	}
+	sort.Sort(entries)
+	for i := 0; i < 500; i++ {
+		start := mrand.Intn(len(entries))
+		end := mrand.Intn(len(entries)-start) + start
+		if start == end {
+			continue
+		}
+		firstProof, lastProof := memorydb.New(), memorydb.New()
+
+		first := decreseKey(common.CopyBytes(entries[start].k))
+		if start != 0 && bytes.Equal(first, entries[start-1].k) {
+			continue
+		}
+		if err := trie.Prove(first, 0, firstProof); err != nil {
+			t.Fatalf("Failed to prove the first node %v", err)
+		}
+		if err := trie.Prove(entries[end-1].k, 0, lastProof); err != nil {
+			t.Fatalf("Failed to prove the last node %v", err)
+		}
+		var keys [][]byte
+		var vals [][]byte
+		for i := start; i < end; i++ {
+			keys = append(keys, entries[i].k)
+			vals = append(vals, entries[i].v)
+		}
+		err := VerifyRangeProof(trie.Hash(), first, keys, vals, firstProof, lastProof)
+		if err != nil {
+			t.Fatalf("Case %d(%d->%d) expect no error, got %v", i, start, end-1, err)
+		}
+	}
+}
+
+// TestRangeProofWithInvalidNonExistentProof tests such scenarios:
+// - The last edge proof is an non-existent proof
+// - There exist the gap between the first leaf and first non-existent proof
+func TestRangeProofWithInvalidNonExistentProof(t *testing.T) {
+	trie, vals := randomTrie(4096)
+	var entries entrySlice
+	for _, kv := range vals {
+		entries = append(entries, kv)
+	}
+	sort.Sort(entries)
+
+	// Case 1
+	start, end := 100, 200
+	first, last := decreseKey(common.CopyBytes(entries[start].k)), increseKey(common.CopyBytes(entries[end].k))
+	firstProof, lastProof := memorydb.New(), memorydb.New()
+	if err := trie.Prove(first, 0, firstProof); err != nil {
+		t.Fatalf("Failed to prove the first node %v", err)
+	}
+	if err := trie.Prove(last, 0, lastProof); err != nil {
+		t.Fatalf("Failed to prove the last node %v", err)
+	}
+	var k [][]byte
+	var v [][]byte
+	for i := start; i < end; i++ {
+		k = append(k, entries[i].k)
+		v = append(v, entries[i].v)
+	}
+	err := VerifyRangeProof(trie.Hash(), first, k, v, firstProof, lastProof)
+	if err == nil {
+		t.Fatalf("Expected to detect the error, got nil")
+	}
+
+	// Case 2
+	start, end = 100, 200
+	first = decreseKey(common.CopyBytes(entries[start].k))
+
+	firstProof, lastProof = memorydb.New(), memorydb.New()
+	if err := trie.Prove(first, 0, firstProof); err != nil {
+		t.Fatalf("Failed to prove the first node %v", err)
+	}
+	if err := trie.Prove(entries[end-1].k, 0, lastProof); err != nil {
+		t.Fatalf("Failed to prove the last node %v", err)
+	}
+	start = 105 // Gap created
+	k = make([][]byte, 0)
+	v = make([][]byte, 0)
+	for i := start; i < end; i++ {
+		k = append(k, entries[i].k)
+		v = append(v, entries[i].v)
+	}
+	err = VerifyRangeProof(trie.Hash(), first, k, v, firstProof, lastProof)
+	if err == nil {
+		t.Fatalf("Expected to detect the error, got nil")
+	}
+}
+
+func TestOneElementRangeProof(t *testing.T) {
+	trie, vals := randomTrie(4096)
+	var entries entrySlice
+	for _, kv := range vals {
+		entries = append(entries, kv)
+	}
+	sort.Sort(entries)
+
+	// One element with existent edge proof
+	start := 1000
+	firstProof, lastProof := memorydb.New(), memorydb.New()
+	if err := trie.Prove(entries[start].k, 0, firstProof); err != nil {
+		t.Fatalf("Failed to prove the first node %v", err)
+	}
+	if err := trie.Prove(entries[start].k, 0, lastProof); err != nil {
+		t.Fatalf("Failed to prove the last node %v", err)
+	}
+	err := VerifyRangeProof(trie.Hash(), entries[start].k, [][]byte{entries[start].k}, [][]byte{entries[start].v}, firstProof, lastProof)
+	if err != nil {
+		t.Fatalf("Expected no error, got %v", err)
+	}
+
+	// One element with non-existent edge proof
+	start = 1000
+	first := decreseKey(common.CopyBytes(entries[start].k))
+	firstProof, lastProof = memorydb.New(), memorydb.New()
+	if err := trie.Prove(first, 0, firstProof); err != nil {
+		t.Fatalf("Failed to prove the first node %v", err)
+	}
+	if err := trie.Prove(entries[start].k, 0, lastProof); err != nil {
+		t.Fatalf("Failed to prove the last node %v", err)
+	}
+	err = VerifyRangeProof(trie.Hash(), first, [][]byte{entries[start].k}, [][]byte{entries[start].v}, firstProof, lastProof)
+	if err != nil {
+		t.Fatalf("Expected no error, got %v", err)
 	}
 }
 
@@ -248,57 +431,6 @@ func TestGappedRangeProof(t *testing.T) {
 	}
 }
 
-func TestBadProof(t *testing.T) {
-	trie, vals := randomTrie(800)
-	root := trie.Hash()
-	for i, prover := range makeProvers(trie) {
-		for _, kv := range vals {
-			proof := prover(kv.k)
-			if proof == nil {
-				t.Fatalf("prover %d: nil proof", i)
-			}
-			it := proof.NewIterator(nil, nil)
-			for i, d := 0, mrand.Intn(proof.Len()); i <= d; i++ {
-				it.Next()
-			}
-			key := it.Key()
-			val, _ := proof.Get(key)
-			proof.Delete(key)
-			it.Release()
-
-			mutateByte(val)
-			proof.Put(crypto.Keccak256(val), val)
-
-			if _, err := VerifyProof(root, kv.k, proof); err == nil {
-				t.Fatalf("prover %d: expected proof to fail for key %x", i, kv.k)
-			}
-		}
-	}
-}
-
-// Tests that missing keys can also be proven. The test explicitly uses a single
-// entry trie and checks for missing keys both before and after the single entry.
-func TestMissingKeyProof(t *testing.T) {
-	trie := new(Trie)
-	updateString(trie, "k", "v")
-
-	for i, key := range []string{"a", "j", "l", "z"} {
-		proof := memorydb.New()
-		trie.Prove([]byte(key), 0, proof)
-
-		if proof.Len() != 1 {
-			t.Errorf("test %d: proof should have one element", i)
-		}
-		val, err := VerifyProof(trie.Hash(), []byte(key), proof)
-		if err != nil {
-			t.Fatalf("test %d: failed to verify proof: %v\nraw proof: %x", i, err, proof)
-		}
-		if val != nil {
-			t.Fatalf("test %d: verified value mismatch: have %x, want nil", i, val)
-		}
-	}
-}
-
 // mutateByte changes one byte in b.
 func mutateByte(b []byte) {
 	for r := mrand.Intn(len(b)); ; {
@@ -308,6 +440,26 @@ func mutateByte(b []byte) {
 			break
 		}
 	}
+}
+
+func increseKey(key []byte) []byte {
+	for i := len(key) - 1; i >= 0; i-- {
+		key[i]++
+		if key[i] != 0x0 {
+			break
+		}
+	}
+	return key
+}
+
+func decreseKey(key []byte) []byte {
+	for i := len(key) - 1; i >= 0; i-- {
+		key[i]--
+		if key[i] != 0xff {
+			break
+		}
+	}
+	return key
 }
 
 func BenchmarkProve(b *testing.B) {


### PR DESCRIPTION
In this PR, range proof is improved.

Originally we only allow range proof with two existent edge proofs. 
However in the real use cases, it's quite common that the first edge
proof might point to a non-existent node. So in this PR, non-existent
left edge proof is allowed.

Besides, there are a few corner cases handled:
- The range is empty, and the left edge proof is a non-existent proof. In this case 
   the function will verify whether there still exist some leaves on the right side. If
   so, then return the error.
- The range only has one element, no matter the left edge proof is existent one or not
- The range has all the elements, the edge proofs can be nil