### PR TITLE
core/state/snapshot: fix trie generator reporter

### DIFF
--- a/core/state/snapshot/conversion.go
+++ b/core/state/snapshot/conversion.go
@@ -102,12 +102,8 @@ func (stat *generateStats) progress(accounts, slots uint64, curAccount common.Ha
 
 	stat.accounts += accounts
 	stat.slots += slots
-	if curAccount != (common.Hash{}) {
-		stat.curAccount = curAccount
-	}
-	if curSlot != (common.Hash{}) {
-		stat.curSlot = curSlot
-	}
+	stat.curAccount = curAccount
+	stat.curSlot = curSlot
 }
 
 // report prints the cumulative progress statistic smartly.

--- a/go.sum
+++ b/go.sum
@@ -208,6 +208,7 @@ golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5h
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200302150141-5c8b2ff67527 h1:uYVVQ9WP/Ds2ROhcaGPeIdVq0RIXVLwsHlnvJ+cT1So=
 golang.org/x/sys v0.0.0-20200302150141-5c8b2ff67527/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd h1:xhmwyvizuTgC2qz7ZlMluP20uW+C3Rm0FD/WLDX8884=
 golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.2 h1:tW2bmiBqwgJj/UpqtC8EpXEZVYOwU0yG4iWbprSVAcs=


### PR DESCRIPTION
This PR fixes an issue in the trie-generator reporter.

Whenever any progress statistic is recorded, we should
update the reporter status atomically even the current
slot hash is empty(it's a valid use case. e.g. last time we
record progress data is in account storage, then 

"curAccount" = "A", "curSlot" = "S0" is recorded. However
this time we are in the state trie, then we should update 
the status to `curAccount` = "B", "curSlot" = "EMPTY"