### PR TITLE
core/rawdb: Stop freezer process as part of freezer.Close()

### DIFF
--- a/core/rawdb/database.go
+++ b/core/rawdb/database.go
@@ -41,10 +41,10 @@ type freezerdb struct {
 // the slow ancient tables.
 func (frdb *freezerdb) Close() error {
 	var errs []error
-	if err := frdb.KeyValueStore.Close(); err != nil {
+	if err := frdb.AncientStore.Close(); err != nil {
 		errs = append(errs, err)
 	}
-	if err := frdb.AncientStore.Close(); err != nil {
+	if err := frdb.KeyValueStore.Close(); err != nil {
 		errs = append(errs, err)
 	}
 	if len(errs) != 0 {

--- a/core/rawdb/freezer.go
+++ b/core/rawdb/freezer.go
@@ -277,7 +277,8 @@ func (f *freezer) freeze(db ethdb.KeyValueStore) {
 		hash := ReadHeadBlockHash(nfdb)
 		if hash == (common.Hash{}) {
 			log.Debug("Current full block hash unavailable") // new chain, empty database
-
+			backoff = true
+			continue
 		}
 		number := ReadHeaderNumber(nfdb, hash)
 		switch {

--- a/core/rawdb/freezer.go
+++ b/core/rawdb/freezer.go
@@ -102,7 +102,7 @@ func newFreezer(datadir string, namespace string) (*freezer, error) {
 	freezer := &freezer{
 		tables:       make(map[string]*freezerTable),
 		instanceLock: lock,
-		quit: make(chan struct{}),
+		quit:         make(chan struct{}),
 	}
 	for name, disableSnappy := range freezerNoSnappy {
 		table, err := newTable(datadir, name, readMeter, writeMeter, sizeGauge, disableSnappy)


### PR DESCRIPTION
When you call db.Close(), it was closing the leveldb database first, then closing the freezer, but never stopping the freezer process. This could cause the freezer to attempt to write to leveldb after leveldb had been closed, leading to a crash with a non-zero exit code. 

This can be a problem, for example, when running with the --exitwhensynced flag and checking the exit code to make sure it synced properly. If the freezer process is running when it catches up with the network and shuts down, it can cause a failed error code. This is rare, but we do see it occasionally. The database is generally fine when this happens, but we'd like to avoid a non-zero exit code.

This change adds a quit channel to the freezer, and freezer.Close() will not return until the freezer process has stopped.

Additionally, when you call freezerdb.Close(), it will close the AncientStore before closing leveldb, to ensure that the freezer goroutine will be stopped before leveldb is closed.