### PR TITLE
les: remove invalid use of t.Fatal in TestHandshake

### DIFF
--- a/les/peer_test.go
+++ b/les/peer_test.go
@@ -18,6 +18,7 @@ package les
 
 import (
 	"crypto/rand"
+	"errors"
 	"math/big"
 	"reflect"
 	"sort"
@@ -121,10 +122,10 @@ func TestHandshake(t *testing.T) {
 			var reqType uint64
 			err := recv.get("announceType", &reqType)
 			if err != nil {
-				t.Fatal(err)
+				return err
 			}
 			if reqType != announceTypeSigned {
-				t.Fatal("Expected announceTypeSigned")
+				return errors.New("Expected announceTypeSigned")
 			}
 			return nil
 		})


### PR DESCRIPTION
Similar to PR #20961
`testing.Fatal()/FailNow()/SkipNow()/...` can only be used in test goroutine.
`t.Fatal()/Fatalf()/FailNow()` "[must be called from the goroutine running the test or benchmark function, not from other goroutines created during the test.](https://golang.org/pkg/testing/#T.FailNow)"

The fix directly returns `err` to replace the `t.Fatal()` in the child goroutine of test. 
`err` will be passed to `errCh2` and the test goroutine will receive it and call `t.Fatal()`.