### PR TITLE
core/state/snapshot: fix leaking goroutines during state tests execution

### DIFF
--- a/core/state/snapshot/generate.go
+++ b/core/state/snapshot/generate.go
@@ -257,6 +257,9 @@ func (dl *diskLayer) generate(stats *generatorStats) {
 	dl.lock.Unlock()
 
 	// Someone will be looking for us, wait it out
-	abort := <-dl.genAbort
-	abort <- nil
+	select {
+	case abort := <-dl.genAbort:
+		abort <- nil
+	default:
+	}
 }


### PR DESCRIPTION
When the state tests are executed, we leak goroutines like there's no tomorrow, because we try to send on a channel where nobody is listening. This "fixes" it, but I'm not quite sure if it breaks anything else in the process... 