### PR TITLE
build: raise test timeout back to 10 mins

### DIFF
--- a/build/ci.go
+++ b/build/ci.go
@@ -325,7 +325,7 @@ func doTest(cmdline []string) {
 	// Test a single package at a time. CI builders are slow
 	// and some tests run into timeouts under load.
 	gotest := goTool("test", buildFlags(env)...)
-	gotest.Args = append(gotest.Args, "-p", "1", "-timeout", "5m")
+	gotest.Args = append(gotest.Args, "-p", "1")
 	if *coverage {
 		gotest.Args = append(gotest.Args, "-covermode=atomic", "-cover")
 	}


### PR DESCRIPTION
The consensus test suite is getting eerily close to the 5 minute runtime mark. It also exceeds that on AppVeyor, so this PR bumps the limit back to the default 10 mins.