### PR TITLE
cmd/geth: handle memfixes on 32bit arch with large RAM

### DIFF
--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -314,6 +314,10 @@ func prepare(ctx *cli.Context) {
 	// Check https://github.com/elastic/gosigar#supported-platforms
 	if runtime.GOOS != "openbsd" {
 		if err := mem.Get(); err == nil {
+			if 32<<(^uintptr(0)>>63) == 32 && mem.Total > 2*1024*1024*1024 {
+				log.Warn("Lowering memory allowance on 32bit arch", "available", mem.Total/1024/1024, "addressable", 2*1024)
+				mem.Total = 2 * 1024 * 1024 * 1024
+			}
 			allowance := int(mem.Total / 1024 / 1024 / 3)
 			if cache := ctx.GlobalInt(utils.CacheFlag.Name); cache > allowance {
 				log.Warn("Sanitizing cache to Go's GC limits", "provided", cache, "updated", allowance)


### PR DESCRIPTION
If a 32bit Geth is ran on a system with a lot of RAM (e.g. AppVeyor 32bit test), Geth will bump the memory request to 4GB, which will cause an OOM since we cannot address that much. This PR adds a fine tuning so that if we're on a 32 bit platform (or rather have 32 bit pointers), then we cap the memory Geth will use accordingly.

I'm unsure what the correct value is. The theoretical max in 4GB RAM, Windows I know only allows about 3 to be used.