### PR TITLE
eth: skip transaction announcer goroutine on eth<65

### DIFF
--- a/eth/peer.go
+++ b/eth/peer.go
@@ -720,8 +720,9 @@ func (ps *peerSet) Register(p *peer) error {
 
 	go p.broadcastBlocks()
 	go p.broadcastTransactions()
-	go p.announceTransactions()
-
+	if p.version >= eth65 {
+		go p.announceTransactions()
+	}
 	return nil
 }
 


### PR DESCRIPTION
Since implementing tx announcement, we've spun up a goroutine even for `eth<65` peers. Whilst they are harmless, they make debugging goroutine leaks hard as they fill up the stack traces with noise. This PR just doesn't spin them up n the first place. The shutdown is fine as there's no individual tracking and the async announce sends are already properly limited to `eth65+`.