### PR TITLE
les: drop the message if the entire p2p connection is stuck

### DIFF
--- a/les/peer.go
+++ b/les/peer.go
@@ -164,24 +164,6 @@ func (p *peerCommons) queueSend(f func()) bool {
 	return p.sendQueue.Queue(f)
 }
 
-// mustQueueSend starts a for loop and retry the caching if failed.
-// If the stopCh is closed, then it returns.
-func (p *peerCommons) mustQueueSend(f func()) {
-	for {
-		// Check whether the stopCh is closed.
-		select {
-		case <-p.closeCh:
-			return
-		default:
-		}
-		// If the function is successfully cached, return.
-		if p.canQueue() && p.queueSend(f) {
-			return
-		}
-		time.Sleep(retrySendCachePeriod)
-	}
-}
-
 // String implements fmt.Stringer.
 func (p *peerCommons) String() string {
 	return fmt.Sprintf("Peer %s [%s]", p.id, fmt.Sprintf("les/%d", p.version))
@@ -899,7 +881,7 @@ func (p *clientPeer) updateCapacity(cap uint64) {
 	var kvList keyValueList
 	kvList = kvList.add("flowControl/MRR", cap)
 	kvList = kvList.add("flowControl/BL", cap*bufLimitRatio)
-	p.mustQueueSend(func() { p.sendAnnounce(announceData{Update: kvList}) })
+	p.queueSend(func() { p.sendAnnounce(announceData{Update: kvList}) })
 }
 
 // freezeClient temporarily puts the client in a frozen state which means all

--- a/les/peer.go
+++ b/les/peer.go
@@ -65,9 +65,6 @@ const (
 
 	// handshakeTimeout is the timeout LES handshake will be treated as failed.
 	handshakeTimeout = 5 * time.Second
-
-	// retrySendCachePeriod is the time interval a caching retry is performed.
-	retrySendCachePeriod = time.Millisecond * 100
 )
 
 const (

--- a/les/server_handler.go
+++ b/les/server_handler.go
@@ -262,7 +262,7 @@ func (h *serverHandler) handleMsg(p *clientPeer, wg *sync.WaitGroup) error {
 			h.server.clientPool.requestCost(p, realCost)
 		}
 		if reply != nil {
-			p.mustQueueSend(func() {
+			p.queueSend(func() {
 				if err := reply.send(bv); err != nil {
 					select {
 					case p.errCh <- err:


### PR DESCRIPTION
Fix the issue like 

```
goroutine 1775696068 [semacquire, 3413 minutes]:
sync.runtime_SemacquireMutex(0xc045c3b744, 0x1065c00, 0x1)
	/usr/local/go/src/runtime/sema.go:71 +0x47
sync.(*Mutex).lockSlow(0xc045c3b740)
	/usr/local/go/src/sync/mutex.go:138 +0xfc
sync.(*Mutex).Lock(...)
	/usr/local/go/src/sync/mutex.go:81
github.com/ethereum/go-ethereum/les.(*serverHandler).handleMsg.func2(0x62888cdf70726b39, 0x1, 0xc064ea2580, 0x8694d)
	/go-ethereum/les/server_handler.go:237 +0x362
github.com/ethereum/go-ethereum/les.(*serverHandler).handleMsg.func4(0xc12a418520, 0xc0e631fd00, 0xc08b1fe588, 0xc1964d37a0, 0xc09f33e330, 0xc0022b67d0, 0xc045c3b680, 0xc0e631fd80, 0x1)
	/go-ethereum/les/server_handler.go:429 +0x265
created by github.com/ethereum/go-ethereum/les.(*serverHandler).handleMsg
	/go-ethereum/les/server_handler.go:410 +0xa39
```