### PR TITLE
core/state/snapshot: don't create storage list for non-existing accounts

### DIFF
--- a/core/state/snapshot/difflayer.go
+++ b/core/state/snapshot/difflayer.go
@@ -526,6 +526,11 @@ func (dl *diffLayer) StorageList(accountHash common.Hash) ([]common.Hash, bool) 
 	// If an old list already exists, return it
 	dl.lock.RLock()
 	_, destructed := dl.destructSet[accountHash]
+	if _, ok := dl.storageData[accountHash]; !ok {
+		// Account not tracked by this layer
+		dl.lock.RUnlock()
+		return nil, destructed
+	}
 	if list, exist := dl.storageList[accountHash]; exist {
 		dl.lock.RUnlock()
 		return list, destructed // The list might be nil


### PR DESCRIPTION
The storage iterator caches sorted slots into the diff layer when iterating. There was a tiny omission where we didn't check whether an account is referenced by a layer at all or not, rather always created the sorted slots. This meant that we ended up creating sorted empty lists for every account in the state.