### PR TITLE
core/state: abort commit if errors have occurred

### DIFF
--- a/core/state/statedb.go
+++ b/core/state/statedb.go
@@ -804,6 +804,9 @@ func (s *StateDB) clearJournalAndRefund() {
 
 // Commit writes the state to the underlying in-memory trie database.
 func (s *StateDB) Commit(deleteEmptyObjects bool) (common.Hash, error) {
+	if s.dbErr != nil {
+		return common.Hash{}, fmt.Errorf("commit aborted due to earlier error: %v", s.dbErr)
+	}
 	// Finalize any pending changes and merge everything into the tries
 	s.IntermediateRoot(deleteEmptyObjects)
 


### PR DESCRIPTION
We should abort committing/writing to the trie if we have had a previous error while loading stuff 