### PR TITLE
metrics: replace gosigar with gopsutil

### DIFF
--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -27,7 +27,7 @@ import (
 	"strings"
 	"time"
 
-	gopsutil "github.com/renaynay/gopsutil/mem"
+	gopsutil "github.com/shirou/gopsutil/mem"
 
 	"github.com/ethereum/go-ethereum/accounts"
 	"github.com/ethereum/go-ethereum/accounts/keystore"

--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -27,7 +27,6 @@ import (
 	"strings"
 	"time"
 
-	gopsutil "github.com/shirou/gopsutil/mem"
 	"github.com/ethereum/go-ethereum/accounts"
 	"github.com/ethereum/go-ethereum/accounts/keystore"
 	"github.com/ethereum/go-ethereum/cmd/utils"
@@ -41,6 +40,7 @@ import (
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/metrics"
 	"github.com/ethereum/go-ethereum/node"
+	gopsutil "github.com/shirou/gopsutil/mem"
 	cli "gopkg.in/urfave/cli.v1"
 )
 

--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -27,7 +27,7 @@ import (
 	"strings"
 	"time"
 
-	gopsutil "github.com/shirou/gopsutil/mem"
+	gopsutil "github.com/renaynay/gopsutil/mem"
 
 	"github.com/ethereum/go-ethereum/accounts"
 	"github.com/ethereum/go-ethereum/accounts/keystore"

--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -311,18 +311,16 @@ func prepare(ctx *cli.Context) {
 		ctx.GlobalSet(utils.CacheFlag.Name, strconv.Itoa(128))
 	}
 	// Cap the cache allowance and tune the garbage collector
-	if runtime.GOOS != "openbsd" {
-		mem, err := gopsutil.VirtualMemory()
-		if err == nil {
-			if 32<<(^uintptr(0)>>63) == 32 && mem.Total > 2*1024*1024*1024 {
-				log.Warn("Lowering memory allowance on 32bit arch", "available", mem.Total/1024/1024, "addressable", 2*1024)
-				mem.Total = 2 * 1024 * 1024 * 1024
-			}
-			allowance := int(mem.Total / 1024 / 1024 / 3)
-			if cache := ctx.GlobalInt(utils.CacheFlag.Name); cache > allowance {
-				log.Warn("Sanitizing cache to Go's GC limits", "provided", cache, "updated", allowance)
-				ctx.GlobalSet(utils.CacheFlag.Name, strconv.Itoa(allowance))
-			}
+	mem, err := gopsutil.VirtualMemory()
+	if err == nil {
+		if 32<<(^uintptr(0)>>63) == 32 && mem.Total > 2*1024*1024*1024 {
+			log.Warn("Lowering memory allowance on 32bit arch", "available", mem.Total/1024/1024, "addressable", 2*1024)
+			mem.Total = 2 * 1024 * 1024 * 1024
+		}
+		allowance := int(mem.Total / 1024 / 1024 / 3)
+		if cache := ctx.GlobalInt(utils.CacheFlag.Name); cache > allowance {
+			log.Warn("Sanitizing cache to Go's GC limits", "provided", cache, "updated", allowance)
+			ctx.GlobalSet(utils.CacheFlag.Name, strconv.Itoa(allowance))
 		}
 	}
 	// Ensure Go's GC ignores the database cache for trigger percentage

--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -28,7 +28,8 @@ import (
 	"strings"
 	"time"
 
-	"github.com/elastic/gosigar"
+	gopsutil "github.com/shirou/gopsutil/mem"
+
 	"github.com/ethereum/go-ethereum/accounts"
 	"github.com/ethereum/go-ethereum/accounts/keystore"
 	"github.com/ethereum/go-ethereum/cmd/utils"
@@ -310,11 +311,9 @@ func prepare(ctx *cli.Context) {
 		ctx.GlobalSet(utils.CacheFlag.Name, strconv.Itoa(128))
 	}
 	// Cap the cache allowance and tune the garbage collector
-	var mem gosigar.Mem
-	// Workaround until OpenBSD support lands into gosigar
-	// Check https://github.com/elastic/gosigar#supported-platforms
 	if runtime.GOOS != "openbsd" {
-		if err := mem.Get(); err == nil {
+		mem, err := gopsutil.VirtualMemory()
+		if err == nil {
 			if 32<<(^uintptr(0)>>63) == 32 && mem.Total > 2*1024*1024*1024 {
 				log.Warn("Lowering memory allowance on 32bit arch", "available", mem.Total/1024/1024, "addressable", 2*1024)
 				mem.Total = 2 * 1024 * 1024 * 1024

--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -28,7 +28,6 @@ import (
 	"time"
 
 	gopsutil "github.com/shirou/gopsutil/mem"
-
 	"github.com/ethereum/go-ethereum/accounts"
 	"github.com/ethereum/go-ethereum/accounts/keystore"
 	"github.com/ethereum/go-ethereum/cmd/utils"

--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -21,7 +21,6 @@ import (
 	"fmt"
 	"math"
 	"os"
-	"runtime"
 	godebug "runtime/debug"
 	"sort"
 	"strconv"

--- a/go.mod
+++ b/go.mod
@@ -46,10 +46,11 @@ require (
 	github.com/pborman/uuid v0.0.0-20170112150404-1b00554d8222
 	github.com/peterh/liner v1.1.1-0.20190123174540-a2c9a5303de7
 	github.com/prometheus/tsdb v0.6.2-0.20190402121629-4f204dcbc150
+	github.com/renaynay/gopsutil v2.20.4+incompatible
 	github.com/rjeczalik/notify v0.9.1
 	github.com/rs/cors v0.0.0-20160617231935-a62a804a8a00
 	github.com/rs/xhandler v0.0.0-20160618193221-ed27b6fd6521 // indirect
-	github.com/shirou/gopsutil v2.20.4+incompatible
+	github.com/shirou/gopsutil v2.20.4+incompatible // indirect
 	github.com/status-im/keycard-go v0.0.0-20190316090335-8537d3370df4
 	github.com/steakknife/bloomfilter v0.0.0-20180922174646-6819c0d2a570
 	github.com/steakknife/hamming v0.0.0-20180906055917-c99c65617cd3 // indirect

--- a/go.mod
+++ b/go.mod
@@ -46,7 +46,7 @@ require (
 	github.com/pborman/uuid v0.0.0-20170112150404-1b00554d8222
 	github.com/peterh/liner v1.1.1-0.20190123174540-a2c9a5303de7
 	github.com/prometheus/tsdb v0.6.2-0.20190402121629-4f204dcbc150
-	github.com/renaynay/gopsutil v2.20.4+incompatible
+	github.com/renaynay/gopsutil v2.20.5-0.20200527171923-18b0077b21cd+incompatible
 	github.com/rjeczalik/notify v0.9.1
 	github.com/rs/cors v0.0.0-20160617231935-a62a804a8a00
 	github.com/rs/xhandler v0.0.0-20160618193221-ed27b6fd6521 // indirect

--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,6 @@ require (
 	github.com/docker/docker v1.4.2-0.20180625184442-8e610b2b55bf
 	github.com/dop251/goja v0.0.0-20200219165308-d1232e640a87
 	github.com/edsrzf/mmap-go v0.0.0-20160512033002-935e0e8a636c
-	github.com/elastic/gosigar v0.8.1-0.20180330100440-37f05ff46ffa
 	github.com/fatih/color v1.3.0
 	github.com/fjl/memsize v0.0.0-20180418122429-ca190fb6ffbc
 	github.com/gballet/go-libpcsclite v0.0.0-20190607065134-2772fd86a8ff
@@ -50,6 +49,7 @@ require (
 	github.com/rjeczalik/notify v0.9.1
 	github.com/rs/cors v0.0.0-20160617231935-a62a804a8a00
 	github.com/rs/xhandler v0.0.0-20160618193221-ed27b6fd6521 // indirect
+	github.com/shirou/gopsutil v2.20.4+incompatible
 	github.com/status-im/keycard-go v0.0.0-20190316090335-8537d3370df4
 	github.com/steakknife/bloomfilter v0.0.0-20180922174646-6819c0d2a570
 	github.com/steakknife/hamming v0.0.0-20180906055917-c99c65617cd3 // indirect

--- a/go.mod
+++ b/go.mod
@@ -46,11 +46,10 @@ require (
 	github.com/pborman/uuid v0.0.0-20170112150404-1b00554d8222
 	github.com/peterh/liner v1.1.1-0.20190123174540-a2c9a5303de7
 	github.com/prometheus/tsdb v0.6.2-0.20190402121629-4f204dcbc150
-	github.com/renaynay/gopsutil v2.20.5-0.20200527171923-18b0077b21cd+incompatible
 	github.com/rjeczalik/notify v0.9.1
 	github.com/rs/cors v0.0.0-20160617231935-a62a804a8a00
 	github.com/rs/xhandler v0.0.0-20160618193221-ed27b6fd6521 // indirect
-	github.com/shirou/gopsutil v2.20.4+incompatible // indirect
+	github.com/shirou/gopsutil v2.20.5-0.20200531151128-663af789c085+incompatible
 	github.com/status-im/keycard-go v0.0.0-20190316090335-8537d3370df4
 	github.com/steakknife/bloomfilter v0.0.0-20180922174646-6819c0d2a570
 	github.com/steakknife/hamming v0.0.0-20180906055917-c99c65617cd3 // indirect

--- a/go.sum
+++ b/go.sum
@@ -61,8 +61,6 @@ github.com/dop251/goja v0.0.0-20200219165308-d1232e640a87 h1:OMbqMXf9OAXzH1dDH82
 github.com/dop251/goja v0.0.0-20200219165308-d1232e640a87/go.mod h1:Mw6PkjjMXWbTj+nnj4s3QPXq1jaT0s5pC0iFD4+BOAA=
 github.com/edsrzf/mmap-go v0.0.0-20160512033002-935e0e8a636c h1:JHHhtb9XWJrGNMcrVP6vyzO4dusgi/HnceHTgxSejUM=
 github.com/edsrzf/mmap-go v0.0.0-20160512033002-935e0e8a636c/go.mod h1:YO35OhQPt3KJa3ryjFM5Bs14WD66h8eGKpfaBNrHW5M=
-github.com/elastic/gosigar v0.8.1-0.20180330100440-37f05ff46ffa h1:XKAhUk/dtp+CV0VO6mhG2V7jA9vbcGcnYF/Ay9NjZrY=
-github.com/elastic/gosigar v0.8.1-0.20180330100440-37f05ff46ffa/go.mod h1:cdorVVzy1fhmEqmtgqkoE3bYtCfSCkVyjTyCIo22xvs=
 github.com/fatih/color v1.3.0 h1:YehCCcyeQ6Km0D6+IapqPinWBK6y+0eB5umvZXK9WPs=
 github.com/fatih/color v1.3.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
 github.com/fjl/memsize v0.0.0-20180418122429-ca190fb6ffbc h1:jtW8jbpkO4YirRSyepBOH8E+2HEw6/hKkBvFPwhUN8c=
@@ -167,6 +165,8 @@ github.com/rs/cors v0.0.0-20160617231935-a62a804a8a00/go.mod h1:gFx+x8UowdsKA9Ac
 github.com/rs/xhandler v0.0.0-20160618193221-ed27b6fd6521 h1:3hxavr+IHMsQBrYUPQM5v0CgENFktkkbg1sfpgM3h20=
 github.com/rs/xhandler v0.0.0-20160618193221-ed27b6fd6521/go.mod h1:RvLn4FgxWubrpZHtQLnOf6EwhN2hEMusxZOhcW9H3UQ=
 github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
+github.com/shirou/gopsutil v2.20.4+incompatible h1:cMT4rxS55zx9NVUnCkrmXCsEB/RNfG9SwHY9evtX8Ng=
+github.com/shirou/gopsutil v2.20.4+incompatible/go.mod h1:5b4v6he4MtMOwMlS0TUMTu2PcXUg8+E1lC7eC3UO/RA=
 github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
 github.com/status-im/keycard-go v0.0.0-20190316090335-8537d3370df4 h1:Gb2Tyox57NRNuZ2d3rmvB3pcmbu7O1RS3m8WRx7ilrg=

--- a/go.sum
+++ b/go.sum
@@ -165,8 +165,6 @@ github.com/rs/cors v0.0.0-20160617231935-a62a804a8a00/go.mod h1:gFx+x8UowdsKA9Ac
 github.com/rs/xhandler v0.0.0-20160618193221-ed27b6fd6521 h1:3hxavr+IHMsQBrYUPQM5v0CgENFktkkbg1sfpgM3h20=
 github.com/rs/xhandler v0.0.0-20160618193221-ed27b6fd6521/go.mod h1:RvLn4FgxWubrpZHtQLnOf6EwhN2hEMusxZOhcW9H3UQ=
 github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
-github.com/shirou/gopsutil v2.20.4+incompatible h1:cMT4rxS55zx9NVUnCkrmXCsEB/RNfG9SwHY9evtX8Ng=
-github.com/shirou/gopsutil v2.20.4+incompatible/go.mod h1:5b4v6he4MtMOwMlS0TUMTu2PcXUg8+E1lC7eC3UO/RA=
 github.com/shirou/gopsutil v2.20.5-0.20200531151128-663af789c085+incompatible h1:+gAR1bMhuoQnZMTWFIvp7ukynULPsteLzG+siZKLtD8=
 github.com/shirou/gopsutil v2.20.5-0.20200531151128-663af789c085+incompatible/go.mod h1:5b4v6he4MtMOwMlS0TUMTu2PcXUg8+E1lC7eC3UO/RA=
 github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=

--- a/go.sum
+++ b/go.sum
@@ -158,10 +158,6 @@ github.com/prometheus/common v0.0.0-20181113130724-41aa239b4cce/go.mod h1:daVV7q
 github.com/prometheus/procfs v0.0.0-20181005140218-185b4288413d/go.mod h1:c3At6R/oaqEKCNdg8wHV1ftS6bRYblBhIjjI8uT2IGk=
 github.com/prometheus/tsdb v0.6.2-0.20190402121629-4f204dcbc150 h1:ZeU+auZj1iNzN8iVhff6M38Mfu73FQiJve/GEXYJBjE=
 github.com/prometheus/tsdb v0.6.2-0.20190402121629-4f204dcbc150/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40TwIPHuXU=
-github.com/renaynay/gopsutil v2.20.4+incompatible h1:SlhB60Fo709MH5n7PkXteHFFdMCKxF2TZe1dkJZKwsQ=
-github.com/renaynay/gopsutil v2.20.4+incompatible/go.mod h1:gMFmW+jZnHvgVoc3HJbE/yeHgzr46LWWtXG7qA/Z3x8=
-github.com/renaynay/gopsutil v2.20.5-0.20200527171923-18b0077b21cd+incompatible h1:XGThPFqjcw/Tmqhgr1o6zQkUfN5G8aIEdLLmIu9zcLM=
-github.com/renaynay/gopsutil v2.20.5-0.20200527171923-18b0077b21cd+incompatible/go.mod h1:gMFmW+jZnHvgVoc3HJbE/yeHgzr46LWWtXG7qA/Z3x8=
 github.com/rjeczalik/notify v0.9.1 h1:CLCKso/QK1snAlnhNR/CNvNiFU2saUtjV0bx3EwNeCE=
 github.com/rjeczalik/notify v0.9.1/go.mod h1:rKwnCoCGeuQnwBtTSPL9Dad03Vh2n40ePRrjvIXnJho=
 github.com/rs/cors v0.0.0-20160617231935-a62a804a8a00 h1:8DPul/X0IT/1TNMIxoKLwdemEOBBHDC/K4EB16Cw5WE=
@@ -171,6 +167,8 @@ github.com/rs/xhandler v0.0.0-20160618193221-ed27b6fd6521/go.mod h1:RvLn4FgxWubr
 github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/shirou/gopsutil v2.20.4+incompatible h1:cMT4rxS55zx9NVUnCkrmXCsEB/RNfG9SwHY9evtX8Ng=
 github.com/shirou/gopsutil v2.20.4+incompatible/go.mod h1:5b4v6he4MtMOwMlS0TUMTu2PcXUg8+E1lC7eC3UO/RA=
+github.com/shirou/gopsutil v2.20.5-0.20200531151128-663af789c085+incompatible h1:+gAR1bMhuoQnZMTWFIvp7ukynULPsteLzG+siZKLtD8=
+github.com/shirou/gopsutil v2.20.5-0.20200531151128-663af789c085+incompatible/go.mod h1:5b4v6he4MtMOwMlS0TUMTu2PcXUg8+E1lC7eC3UO/RA=
 github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
 github.com/status-im/keycard-go v0.0.0-20190316090335-8537d3370df4 h1:Gb2Tyox57NRNuZ2d3rmvB3pcmbu7O1RS3m8WRx7ilrg=

--- a/go.sum
+++ b/go.sum
@@ -160,6 +160,8 @@ github.com/prometheus/tsdb v0.6.2-0.20190402121629-4f204dcbc150 h1:ZeU+auZj1iNzN
 github.com/prometheus/tsdb v0.6.2-0.20190402121629-4f204dcbc150/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40TwIPHuXU=
 github.com/renaynay/gopsutil v2.20.4+incompatible h1:SlhB60Fo709MH5n7PkXteHFFdMCKxF2TZe1dkJZKwsQ=
 github.com/renaynay/gopsutil v2.20.4+incompatible/go.mod h1:gMFmW+jZnHvgVoc3HJbE/yeHgzr46LWWtXG7qA/Z3x8=
+github.com/renaynay/gopsutil v2.20.5-0.20200527171923-18b0077b21cd+incompatible h1:XGThPFqjcw/Tmqhgr1o6zQkUfN5G8aIEdLLmIu9zcLM=
+github.com/renaynay/gopsutil v2.20.5-0.20200527171923-18b0077b21cd+incompatible/go.mod h1:gMFmW+jZnHvgVoc3HJbE/yeHgzr46LWWtXG7qA/Z3x8=
 github.com/rjeczalik/notify v0.9.1 h1:CLCKso/QK1snAlnhNR/CNvNiFU2saUtjV0bx3EwNeCE=
 github.com/rjeczalik/notify v0.9.1/go.mod h1:rKwnCoCGeuQnwBtTSPL9Dad03Vh2n40ePRrjvIXnJho=
 github.com/rs/cors v0.0.0-20160617231935-a62a804a8a00 h1:8DPul/X0IT/1TNMIxoKLwdemEOBBHDC/K4EB16Cw5WE=

--- a/go.sum
+++ b/go.sum
@@ -158,6 +158,8 @@ github.com/prometheus/common v0.0.0-20181113130724-41aa239b4cce/go.mod h1:daVV7q
 github.com/prometheus/procfs v0.0.0-20181005140218-185b4288413d/go.mod h1:c3At6R/oaqEKCNdg8wHV1ftS6bRYblBhIjjI8uT2IGk=
 github.com/prometheus/tsdb v0.6.2-0.20190402121629-4f204dcbc150 h1:ZeU+auZj1iNzN8iVhff6M38Mfu73FQiJve/GEXYJBjE=
 github.com/prometheus/tsdb v0.6.2-0.20190402121629-4f204dcbc150/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40TwIPHuXU=
+github.com/renaynay/gopsutil v2.20.4+incompatible h1:SlhB60Fo709MH5n7PkXteHFFdMCKxF2TZe1dkJZKwsQ=
+github.com/renaynay/gopsutil v2.20.4+incompatible/go.mod h1:gMFmW+jZnHvgVoc3HJbE/yeHgzr46LWWtXG7qA/Z3x8=
 github.com/rjeczalik/notify v0.9.1 h1:CLCKso/QK1snAlnhNR/CNvNiFU2saUtjV0bx3EwNeCE=
 github.com/rjeczalik/notify v0.9.1/go.mod h1:rKwnCoCGeuQnwBtTSPL9Dad03Vh2n40ePRrjvIXnJho=
 github.com/rs/cors v0.0.0-20160617231935-a62a804a8a00 h1:8DPul/X0IT/1TNMIxoKLwdemEOBBHDC/K4EB16Cw5WE=

--- a/metrics/cpu_enabled.go
+++ b/metrics/cpu_enabled.go
@@ -33,7 +33,7 @@ func ReadCPUStats(stats *CPUStats) {
 	}
 	// requesting all cpu times will always return an array with only one time stats entry
 	timeStat := timeStats[0]
-	stats.GlobalTime = int64((timeStat.User + timeStat.Nice + timeStat.System) * 128)
-	stats.GlobalWait = int64((timeStat.Iowait) * 128)
+	stats.GlobalTime = int64((timeStat.User + timeStat.Nice + timeStat.System))
+	stats.GlobalWait = int64((timeStat.Iowait))
 	stats.LocalTime = getProcessCPUTime()
 }

--- a/metrics/cpu_enabled.go
+++ b/metrics/cpu_enabled.go
@@ -20,7 +20,7 @@ package metrics
 
 import (
 	"github.com/ethereum/go-ethereum/log"
-	"github.com/shirou/gopsutil/cpu"
+	"github.com/renaynay/gopsutil/cpu"
 )
 
 // ReadCPUStats retrieves the current CPU stats.

--- a/metrics/cpu_enabled.go
+++ b/metrics/cpu_enabled.go
@@ -33,7 +33,7 @@ func ReadCPUStats(stats *CPUStats) {
 	}
 	// requesting all cpu times will always return an array with only one time stats entry
 	timeStat := timeStats[0]
-	stats.GlobalTime = int64((timeStat.User + timeStat.Nice + timeStat.System)*128)
-	stats.GlobalWait = int64((timeStat.Iowait)*128)
+	stats.GlobalTime = int64((timeStat.User + timeStat.Nice + timeStat.System) * 128)
+	stats.GlobalWait = int64((timeStat.Iowait) * 128)
 	stats.LocalTime = getProcessCPUTime()
 }

--- a/metrics/cpu_enabled.go
+++ b/metrics/cpu_enabled.go
@@ -18,19 +18,22 @@
 
 package metrics
 
-import "github.com/shirou/gopsutil/cpu"
+import (
+	"github.com/ethereum/go-ethereum/log"
+	"github.com/shirou/gopsutil/cpu"
+)
 
 // ReadCPUStats retrieves the current CPU stats.
 func ReadCPUStats(stats *CPUStats) {
 	// passing false to request all cpu times
 	timeStats, err := cpu.Times(false)
 	if err != nil {
-		return // TODO is it okay to just return if cpu.Times errors out? Or should it be a fatal error
+		log.Error("Could not read cpu stats", "err", err)
+		return
 	}
 	// requesting all cpu times will always return an array with only one time stats entry
 	timeStat := timeStats[0]
-
-	stats.GlobalTime = int64(timeStat.User + timeStat.Nice + timeStat.System)
-	stats.GlobalWait = int64(timeStat.Iowait)
+	stats.GlobalTime = int64((timeStat.User + timeStat.Nice + timeStat.System)*128)
+	stats.GlobalWait = int64((timeStat.Iowait)*128)
 	stats.LocalTime = getProcessCPUTime()
 }

--- a/metrics/cpu_enabled.go
+++ b/metrics/cpu_enabled.go
@@ -18,14 +18,19 @@
 
 package metrics
 
-import "github.com/elastic/gosigar"
+import "github.com/shirou/gopsutil/cpu"
 
 // ReadCPUStats retrieves the current CPU stats.
 func ReadCPUStats(stats *CPUStats) {
-	global := gosigar.Cpu{}
-	global.Get()
+	// passing false to request all cpu times
+	timeStats, err := cpu.Times(false)
+	if err != nil {
+		return // TODO is it okay to just return if cpu.Times errors out? Or should it be a fatal error
+	}
+	// requesting all cpu times will always return an array with only one time stats entry
+	timeStat := timeStats[0]
 
-	stats.GlobalTime = int64(global.User + global.Nice + global.Sys)
-	stats.GlobalWait = int64(global.Wait)
+	stats.GlobalTime = int64(timeStat.User + timeStat.Nice + timeStat.System)
+	stats.GlobalWait = int64(timeStat.Iowait)
 	stats.LocalTime = getProcessCPUTime()
 }

--- a/metrics/cpu_enabled.go
+++ b/metrics/cpu_enabled.go
@@ -33,7 +33,7 @@ func ReadCPUStats(stats *CPUStats) {
 	}
 	// requesting all cpu times will always return an array with only one time stats entry
 	timeStat := timeStats[0]
-	stats.GlobalTime = int64((timeStat.User + timeStat.Nice + timeStat.System))
-	stats.GlobalWait = int64((timeStat.Iowait))
+	stats.GlobalTime = int64((timeStat.User + timeStat.Nice + timeStat.System) * cpu.ClocksPerSec)
+	stats.GlobalWait = int64((timeStat.Iowait) * cpu.ClocksPerSec)
 	stats.LocalTime = getProcessCPUTime()
 }

--- a/metrics/cpu_enabled.go
+++ b/metrics/cpu_enabled.go
@@ -20,7 +20,7 @@ package metrics
 
 import (
 	"github.com/ethereum/go-ethereum/log"
-	"github.com/renaynay/gopsutil/cpu"
+	"github.com/shirou/gopsutil/cpu"
 )
 
 // ReadCPUStats retrieves the current CPU stats.


### PR DESCRIPTION
This PR removes any use of the [`gosigar`](https://github.com/elastic/gosigar) library in geth and replaces it with [`gopsutil`](https://github.com/shirou/gopsutil) as `gosigar` is relatively unmaintained and presented a couple issues: 
* building geth with cgo disabled on Darwin would exit with the following errors: 
```bash
# github.com/elastic/gosigar
../../../../pkg/mod/github.com/elastic/gosigar@v0.10.5/concrete_sigar.go:20:11: cpuUsage.Get undefined (type Cpu has no field or method Get)
../../../../pkg/mod/github.com/elastic/gosigar@v0.10.5/concrete_sigar.go:30:13: cpuUsage.Get undefined (type Cpu has no field or method Get)
../../../../pkg/mod/github.com/elastic/gosigar@v0.10.5/concrete_sigar.go:49:10: l.Get undefined (type LoadAverage has no field or method Get)
../../../../pkg/mod/github.com/elastic/gosigar@v0.10.5/concrete_sigar.go:55:10: m.Get undefined (type Mem has no field or method Get)
../../../../pkg/mod/github.com/elastic/gosigar@v0.10.5/concrete_sigar.go:61:10: s.Get undefined (type Swap has no field or method Get)
../../../../pkg/mod/github.com/elastic/gosigar@v0.10.5/concrete_sigar.go:67:10: p.Get undefined (type HugeTLBPages has no field or method Get)
../../../../pkg/mod/github.com/elastic/gosigar@v0.10.5/concrete_sigar.go:79:11: fd.Get undefined (type FDUsage has no field or method Get)
../../../../pkg/mod/github.com/elastic/gosigar@v0.10.5/sigar_darwin_amd64.go:11:12: undefined: sysctlbyname
```
* `gosigar` [did not fully support](https://github.com/elastic/gosigar#supported-platforms) openbsd

This PR would solve for the issue mentioned in #20829. 