### PR TITLE
cmd, core/state: implement state pruner

### DIFF
--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -248,8 +248,8 @@ func init() {
 		retestethCommand,
 		// See cmd/utils/flags_legacy.go
 		utils.ShowDeprecated,
-		// See pruner.go
-		pruningCommand,
+		// See snapshot.go
+		snapshotCommand,
 	}
 	sort.Sort(cli.CommandsByName(app.Commands))
 

--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -248,6 +248,8 @@ func init() {
 		retestethCommand,
 		// See cmd/utils/flags_legacy.go
 		utils.ShowDeprecated,
+		// See pruner.go
+		pruningCommand,
 	}
 	sort.Sort(cli.CommandsByName(app.Commands))
 

--- a/cmd/geth/pruner.go
+++ b/cmd/geth/pruner.go
@@ -1,0 +1,99 @@
+// Copyright 2020 The go-ethereum Authors
+// This file is part of go-ethereum.
+//
+// go-ethereum is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// go-ethereum is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with go-ethereum. If not, see <http://www.gnu.org/licenses/>.
+
+package main
+
+import (
+	"fmt"
+
+	"github.com/ethereum/go-ethereum/cmd/utils"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/state/pruner"
+	cli "gopkg.in/urfave/cli.v1"
+)
+
+var (
+	pruningCommand = cli.Command{
+		Name:        "prune",
+		Usage:       "Prune ethereum historical or stale data",
+		ArgsUsage:   "",
+		Category:    "MISCELLANEOUS COMMANDS",
+		Description: "",
+		Subcommands: []cli.Command{
+			{
+				Name:      "state",
+				Usage:     "Prune stale ethereum state data",
+				ArgsUsage: "<root>",
+				Action:    utils.MigrateFlags(pruneState),
+				Category:  "MISCELLANEOUS COMMANDS",
+				Flags: []cli.Flag{
+					utils.DataDirFlag,
+					utils.RopstenFlag,
+					utils.RinkebyFlag,
+					utils.GoerliFlag,
+					utils.LegacyTestnetFlag,
+				},
+				Description: `
+geth prune state <state-root>
+will prune historical state data with the help of state snapshot.
+All trie nodes which not belong to the state snapshot will be delete
+from the database.
+`,
+			},
+			{
+				Name:      "chain",
+				Usage:     "Prune historical ethereum chain data",
+				ArgsUsage: "",
+				Action:    utils.MigrateFlags(pruneChain),
+				Category:  "MISCELLANEOUS COMMANDS",
+				Flags: []cli.Flag{
+					utils.DataDirFlag,
+				},
+				Description: ``,
+			},
+		},
+	}
+)
+
+func pruneState(ctx *cli.Context) error {
+	stack, _ := makeFullNode(ctx)
+	defer stack.Close()
+
+	chain, chaindb := utils.MakeChain(ctx, stack, true)
+	defer chaindb.Close()
+
+	pruner, err := pruner.NewPruner(chaindb, chain.CurrentBlock().Root(), stack.ResolvePath(""))
+	fmt.Println(stack.ResolvePath(""))
+	if err != nil {
+		utils.Fatalf("Failed to open snapshot tree %v", err)
+	}
+	if ctx.NArg() > 1 {
+		utils.Fatalf("too many arguments given")
+	}
+	var root common.Hash
+	if ctx.NArg() == 1 {
+		root = common.HexToHash(ctx.Args()[0])
+	}
+	err = pruner.Prune(root)
+	if err != nil {
+		utils.Fatalf("Failed to prune state", "error", err)
+	}
+	return nil
+}
+
+func pruneChain(ctx *cli.Context) error {
+	return nil
+}

--- a/cmd/geth/snapshot.go
+++ b/cmd/geth/snapshot.go
@@ -130,10 +130,10 @@ func pruneState(ctx *cli.Context) error {
 }
 
 func verifyState(ctx *cli.Context) error {
-	stack := makeFullNode(ctx)
+	stack, _ := makeFullNode(ctx)
 	defer stack.Close()
 
-	chain, chaindb := utils.MakeChain(ctx, stack)
+	chain, chaindb := utils.MakeChain(ctx, stack, true)
 	defer chaindb.Close()
 
 	snaptree, err := snapshot.New(chaindb, trie.NewDatabase(chaindb), 256, chain.CurrentBlock().Root(), false, false)
@@ -172,10 +172,10 @@ func traverseState(ctx *cli.Context) error {
 	glogger.Verbosity(log.LvlInfo)
 	log.Root().SetHandler(glogger)
 
-	stack := makeFullNode(ctx)
+	stack, _ := makeFullNode(ctx)
 	defer stack.Close()
 
-	_, chaindb := utils.MakeChain(ctx, stack)
+	_, chaindb := utils.MakeChain(ctx, stack, true)
 	defer chaindb.Close()
 
 	if ctx.NArg() > 1 {

--- a/cmd/geth/snapshot.go
+++ b/cmd/geth/snapshot.go
@@ -105,7 +105,7 @@ node is missing. This command can be used for trie integrity verification.
 )
 
 func pruneState(ctx *cli.Context) error {
-	stack, _ := makeFullNode(ctx)
+	stack, _ := makeConfigNode(ctx)
 	defer stack.Close()
 
 	chain, chaindb := utils.MakeChain(ctx, stack, true)
@@ -130,7 +130,7 @@ func pruneState(ctx *cli.Context) error {
 }
 
 func verifyState(ctx *cli.Context) error {
-	stack, _ := makeFullNode(ctx)
+	stack, _ := makeConfigNode(ctx)
 	defer stack.Close()
 
 	chain, chaindb := utils.MakeChain(ctx, stack, true)
@@ -172,7 +172,7 @@ func traverseState(ctx *cli.Context) error {
 	glogger.Verbosity(log.LvlInfo)
 	log.Root().SetHandler(glogger)
 
-	stack, _ := makeFullNode(ctx)
+	stack, _ := makeConfigNode(ctx)
 	defer stack.Close()
 
 	_, chaindb := utils.MakeChain(ctx, stack, true)

--- a/cmd/geth/snapshot.go
+++ b/cmd/geth/snapshot.go
@@ -17,12 +17,20 @@
 package main
 
 import (
+	"bytes"
 	"fmt"
+	"math/big"
+	"os"
+	"time"
 
 	"github.com/ethereum/go-ethereum/cmd/utils"
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/rawdb"
 	"github.com/ethereum/go-ethereum/core/state/pruner"
 	"github.com/ethereum/go-ethereum/core/state/snapshot"
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/log"
+	"github.com/ethereum/go-ethereum/rlp"
 	"github.com/ethereum/go-ethereum/trie"
 	cli "gopkg.in/urfave/cli.v1"
 )
@@ -71,6 +79,25 @@ will be deleted from the database.
 geth snapshot verify-state <state-root>
 will traverse the whole accounts and storages set based on the specified
 snapshot and recalculate the root hash of state for verification.
+`,
+			},
+			{
+				Name:      "traverse-state",
+				Usage:     "Traverse the state with given root hash for verification",
+				ArgsUsage: "<root>",
+				Action:    utils.MigrateFlags(traverseState),
+				Category:  "MISCELLANEOUS COMMANDS",
+				Flags: []cli.Flag{
+					utils.DataDirFlag,
+					utils.RopstenFlag,
+					utils.RinkebyFlag,
+					utils.GoerliFlag,
+					utils.LegacyTestnetFlag,
+				},
+				Description: `
+geth snapshot traverse-state <state-root>
+will traverse the whole trie from the given root and will abort if any referenced
+node is missing. This command can be used for trie integrity verification.
 `,
 			},
 		},
@@ -126,5 +153,89 @@ func verifyState(ctx *cli.Context) error {
 	} else {
 		fmt.Println("Verified the state")
 	}
+	return nil
+}
+
+var (
+	// emptyRoot is the known root hash of an empty trie.
+	emptyRoot = common.HexToHash("56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421")
+
+	// emptyCode is the known hash of the empty EVM bytecode.
+	emptyCode = crypto.Keccak256(nil)
+)
+
+// traverseState is a helper function used for pruning verification.
+// Basically it just iterates the trie, ensure all nodes and assoicated
+// contract codes are present.
+func traverseState(ctx *cli.Context) error {
+	glogger := log.NewGlogHandler(log.StreamHandler(os.Stderr, log.TerminalFormat(true)))
+	glogger.Verbosity(log.LvlInfo)
+	log.Root().SetHandler(glogger)
+
+	stack := makeFullNode(ctx)
+	defer stack.Close()
+
+	_, chaindb := utils.MakeChain(ctx, stack)
+	defer chaindb.Close()
+
+	if ctx.NArg() > 1 {
+		log.Crit("Too many arguments given")
+	}
+	var root = rawdb.ReadSnapshotRoot(chaindb)
+	if ctx.NArg() == 1 {
+		root = common.HexToHash(ctx.Args()[0])
+	}
+	t, err := trie.NewSecure(root, trie.NewDatabase(chaindb))
+	if err != nil {
+		log.Crit("Failed to open trie", "root", root, "error", err)
+	}
+	var (
+		accounts   int
+		slots      int
+		codes      int
+		lastReport time.Time
+		start      = time.Now()
+	)
+	accIter := trie.NewIterator(t.NodeIterator(nil))
+	for accIter.Next() {
+		accounts += 1
+		var acc struct {
+			Nonce    uint64
+			Balance  *big.Int
+			Root     common.Hash
+			CodeHash []byte
+		}
+		if err := rlp.DecodeBytes(accIter.Value, &acc); err != nil {
+			log.Crit("Invalid account encountered during traversal", "error", err)
+		}
+		if acc.Root != emptyRoot {
+			storageTrie, err := trie.NewSecure(acc.Root, trie.NewDatabase(chaindb))
+			if err != nil {
+				log.Crit("Failed to open storage trie", "root", acc.Root, "error", err)
+			}
+			storageIter := trie.NewIterator(storageTrie.NodeIterator(nil))
+			for storageIter.Next() {
+				slots += 1
+			}
+			if storageIter.Err != nil {
+				log.Crit("Failed to traverse storage trie", "root", acc.Root, "error", storageIter.Err)
+			}
+		}
+		if !bytes.Equal(acc.CodeHash, emptyCode) {
+			has, _ := chaindb.Has(acc.CodeHash)
+			if !has {
+				log.Crit("Code is missing", "account", common.BytesToHash(accIter.Key))
+			}
+			codes += 1
+		}
+		if time.Since(lastReport) > time.Second*8 {
+			log.Info("Traversing state", "accounts", accounts, "slots", slots, "codes", codes, "elapsed", common.PrettyDuration(time.Since(start)))
+			lastReport = time.Now()
+		}
+	}
+	if accIter.Err != nil {
+		log.Crit("Failed to traverse state trie", "root", root, "error", accIter.Err)
+	}
+	log.Info("State is complete", "accounts", accounts, "slots", slots, "codes", codes, "elapsed", common.PrettyDuration(time.Since(start)))
 	return nil
 }

--- a/cmd/geth/snapshot.go
+++ b/cmd/geth/snapshot.go
@@ -17,8 +17,6 @@
 package main
 
 import (
-	"fmt"
-
 	"github.com/ethereum/go-ethereum/cmd/utils"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/state/pruner"
@@ -26,16 +24,16 @@ import (
 )
 
 var (
-	pruningCommand = cli.Command{
-		Name:        "prune",
-		Usage:       "Prune ethereum historical or stale data",
+	snapshotCommand = cli.Command{
+		Name:        "snapshot",
+		Usage:       "A command collection which based on the snapshot",
 		ArgsUsage:   "",
 		Category:    "MISCELLANEOUS COMMANDS",
 		Description: "",
 		Subcommands: []cli.Command{
 			{
-				Name:      "state",
-				Usage:     "Prune stale ethereum state data",
+				Name:      "prune-state",
+				Usage:     "Prune stale ethereum state data based on snapshot",
 				ArgsUsage: "<root>",
 				Action:    utils.MigrateFlags(pruneState),
 				Category:  "MISCELLANEOUS COMMANDS",
@@ -47,22 +45,11 @@ var (
 					utils.LegacyTestnetFlag,
 				},
 				Description: `
-geth prune state <state-root>
+geth snapshot prune-state <state-root>
 will prune historical state data with the help of state snapshot.
 All trie nodes which not belong to the state snapshot will be delete
 from the database.
 `,
-			},
-			{
-				Name:      "chain",
-				Usage:     "Prune historical ethereum chain data",
-				ArgsUsage: "",
-				Action:    utils.MigrateFlags(pruneChain),
-				Category:  "MISCELLANEOUS COMMANDS",
-				Flags: []cli.Flag{
-					utils.DataDirFlag,
-				},
-				Description: ``,
 			},
 		},
 	}
@@ -76,7 +63,6 @@ func pruneState(ctx *cli.Context) error {
 	defer chaindb.Close()
 
 	pruner, err := pruner.NewPruner(chaindb, chain.CurrentBlock().Root(), stack.ResolvePath(""))
-	fmt.Println(stack.ResolvePath(""))
 	if err != nil {
 		utils.Fatalf("Failed to open snapshot tree %v", err)
 	}
@@ -91,9 +77,5 @@ func pruneState(ctx *cli.Context) error {
 	if err != nil {
 		utils.Fatalf("Failed to prune state", "error", err)
 	}
-	return nil
-}
-
-func pruneChain(ctx *cli.Context) error {
 	return nil
 }

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -339,7 +339,7 @@ func NewBlockChain(db ethdb.Database, cacheConfig *CacheConfig, chainConfig *par
 	}
 	// Load any existing snapshot, regenerating it if loading failed
 	if bc.cacheConfig.SnapshotLimit > 0 {
-		bc.snaps = snapshot.New(bc.db, bc.stateCache.TrieDB(), bc.cacheConfig.SnapshotLimit, bc.CurrentBlock().Root(), !bc.cacheConfig.SnapshotWait)
+		bc.snaps, _ = snapshot.New(bc.db, bc.stateCache.TrieDB(), bc.cacheConfig.SnapshotLimit, bc.CurrentBlock().Root(), !bc.cacheConfig.SnapshotWait, true)
 	}
 	// Take ownership of this particular state
 	go bc.update()

--- a/core/genesis.go
+++ b/core/genesis.go
@@ -171,7 +171,6 @@ func SetupGenesisBlock(db ethdb.Database, genesis *Genesis) (*params.ChainConfig
 		}
 		return genesis.Config, block.Hash(), nil
 	}
-
 	// We have the genesis block in database(perhaps in ancient database)
 	// but the corresponding state is missing.
 	header := rawdb.ReadHeader(db, stored, 0)
@@ -190,7 +189,6 @@ func SetupGenesisBlock(db ethdb.Database, genesis *Genesis) (*params.ChainConfig
 		}
 		return genesis.Config, block.Hash(), nil
 	}
-
 	// Check whether the genesis block is already written.
 	if genesis != nil {
 		hash := genesis.ToBlock(nil).Hash()
@@ -198,7 +196,6 @@ func SetupGenesisBlock(db ethdb.Database, genesis *Genesis) (*params.ChainConfig
 			return genesis.Config, hash, &GenesisMismatchError{stored, hash}
 		}
 	}
-
 	// Get the existing chain configuration.
 	newcfg := genesis.configOrDefault(stored)
 	if err := newcfg.CheckConfigForkOrder(); err != nil {
@@ -216,7 +213,6 @@ func SetupGenesisBlock(db ethdb.Database, genesis *Genesis) (*params.ChainConfig
 	if genesis == nil && stored != params.MainnetGenesisHash {
 		return storedcfg, stored, nil
 	}
-
 	// Check config compatibility and write the config. Compatibility errors
 	// are returned to the caller unless we're already at block zero.
 	height := rawdb.ReadHeaderNumber(db, rawdb.ReadHeadHeaderHash(db))

--- a/core/rawdb/database.go
+++ b/core/rawdb/database.go
@@ -347,15 +347,24 @@ func InspectDatabase(db ethdb.Database) error {
 			preimages.Add(size)
 		case bytes.HasPrefix(key, bloomBitsPrefix) && len(key) == (len(bloomBitsPrefix)+10+common.HashLength):
 			bloomBits.Add(size)
+		case bytes.HasPrefix(key, BloomBitsIndexPrefix):
+			bloomBits.Add(size)
 		case bytes.HasPrefix(key, []byte("clique-")) && len(key) == 7+common.HashLength:
 			cliqueSnaps.Add(size)
-		case bytes.HasPrefix(key, []byte("cht-")) && len(key) == 4+common.HashLength:
+		case bytes.HasPrefix(key, []byte("cht-")) ||
+			bytes.HasPrefix(key, []byte("chtIndexV2-")) ||
+			bytes.HasPrefix(key, []byte("chtRootV2-")): // Canonical hash trie
 			chtTrieNodes.Add(size)
-		case bytes.HasPrefix(key, []byte("blt-")) && len(key) == 4+common.HashLength:
+		case bytes.HasPrefix(key, []byte("blt-")) ||
+			bytes.HasPrefix(key, []byte("bltIndex-")) ||
+			bytes.HasPrefix(key, []byte("bltRoot-")): // Bloomtrie sub
 			bloomTrieNodes.Add(size)
 		default:
 			var accounted bool
-			for _, meta := range [][]byte{databaseVerisionKey, headHeaderKey, headBlockKey, headFastBlockKey, fastTrieProgressKey} {
+			for _, meta := range [][]byte{
+				databaseVerisionKey, headHeaderKey, headBlockKey, headFastBlockKey,
+				fastTrieProgressKey, snapshotRootKey, snapshotJournalKey,
+			} {
 				if bytes.Equal(key, meta) {
 					metadata.Add(size)
 					accounted = true

--- a/core/rawdb/file_unix.go
+++ b/core/rawdb/file_unix.go
@@ -1,0 +1,62 @@
+// Copyright 2020 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+// +build darwin dragonfly freebsd linux netbsd openbsd
+
+package rawdb
+
+import (
+	"os"
+	"syscall"
+)
+
+func rename(oldpath, newpath string) error {
+	return os.Rename(oldpath, newpath)
+}
+
+func isErrInvalid(err error) bool {
+	if err == os.ErrInvalid {
+		return true
+	}
+	// Go < 1.8
+	if syserr, ok := err.(*os.SyscallError); ok && syserr.Err == syscall.EINVAL {
+		return true
+	}
+	// Go >= 1.8 returns *os.PathError instead
+	if patherr, ok := err.(*os.PathError); ok && patherr.Err == syscall.EINVAL {
+		return true
+	}
+	return false
+}
+
+func syncDir(name string) error {
+	// As per fsync manpage, Linux seems to expect fsync on directory, however
+	// some system don't support this, so we will ignore syscall.EINVAL.
+	//
+	// From fsync(2):
+	//   Calling fsync() does not necessarily ensure that the entry in the
+	//   directory containing the file has also reached disk. For that an
+	//   explicit fsync() on a file descriptor for the directory is also needed.
+	f, err := os.Open(name)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	if err := f.Sync(); err != nil && !isErrInvalid(err) {
+		return err
+	}
+	return nil
+}

--- a/core/rawdb/file_windows.go
+++ b/core/rawdb/file_windows.go
@@ -1,0 +1,46 @@
+// Copyright (c) 2013, Suryandaru Triandana <syndtr@gmail.com>
+// All rights reserved.
+//
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package rawdb
+
+import (
+	"syscall"
+	"unsafe"
+)
+
+var (
+	modkernel32     = syscall.NewLazyDLL("kernel32.dll")
+	procMoveFileExW = modkernel32.NewProc("MoveFileExW")
+)
+
+const (
+	_MOVEFILE_REPLACE_EXISTING = 1
+)
+
+func moveFileEx(from *uint16, to *uint16, flags uint32) error {
+	r1, _, e1 := syscall.Syscall(procMoveFileExW.Addr(), 3, uintptr(unsafe.Pointer(from)), uintptr(unsafe.Pointer(to)), uintptr(flags))
+	if r1 == 0 {
+		if e1 != 0 {
+			return error(e1)
+		}
+		return syscall.EINVAL
+	}
+	return nil
+}
+
+func rename(oldpath, newpath string) error {
+	from, err := syscall.UTF16PtrFromString(oldpath)
+	if err != nil {
+		return err
+	}
+	to, err := syscall.UTF16PtrFromString(newpath)
+	if err != nil {
+		return err
+	}
+	return moveFileEx(from, to, _MOVEFILE_REPLACE_EXISTING)
+}
+
+func syncDir(name string) error { return nil }

--- a/core/rawdb/flatdb.go
+++ b/core/rawdb/flatdb.go
@@ -1,0 +1,466 @@
+// Copyright 2020 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+package rawdb
+
+import (
+	"encoding/binary"
+	"errors"
+	"io"
+	"os"
+	"path/filepath"
+	"sync"
+
+	"github.com/ethereum/go-ethereum/ethdb"
+)
+
+const (
+	temporaryName = "tmp.db"
+	syncedName    = "flat.db"
+	indexName     = "flat.index"
+	bufferGrowRec = 3000
+	chunkSize     = 4 * 1024 * 1024
+)
+
+var (
+	ErrReadOnly     = errors.New("read only")
+	ErrWriteOnly    = errors.New("write only")
+	ErrWriteFailure = errors.New("write failure")
+	ErrReadFailure  = errors.New("read failure")
+	ErrEmptyEntry   = errors.New("empty entry")
+)
+
+// FlatDatabase is the "database" based on the raw file. It implements the
+// ethdb.KeyValueStore interfaces which can act as the kv database in some
+// special scenarios which don't require random read but only write appendly
+// and iteration(with writing order).
+//
+// All items stored in the flatDB will be marshalled in this format:
+//
+//   +------------+-----+--------------+-------+
+//   | Key Length | Key | Value Length | Value |
+//   +------------+-----+--------------+-------+
+//
+// The flatDB can only be opened for read only mode(iteration) or write only
+// mode. Each write operation will append the blob into the file with or without
+// sync operation. But in order to make the flat database readable, it should
+// call Commit after all write opts and after that the db is not writable.
+type FlatDatabase struct {
+	lock      sync.Mutex
+	path      string   // The directory for the flat database
+	data      *os.File // File descriptor for the flat database.
+	index     *os.File // File descriptor for the indexes.
+	read      bool     // Indicator whether the db is read or write mode
+	buff      []byte   // Auxiliary buffer for storing uncommitted data
+	items     int      // Auxiliary number for counting uncommitted data
+	iterating bool     // Indicator whether the db is iterating. Concurrent iteration is not supported
+	offset    uint64   // Global offset of entry in the file
+}
+
+func NewFlatDatabase(path string, read bool) (*FlatDatabase, error) {
+	if err := os.MkdirAll(path, 0755); err != nil {
+		return nil, err
+	}
+	var (
+		data  *os.File
+		index *os.File
+		err   error
+	)
+	if read {
+		data, err = os.OpenFile(filepath.Join(path, syncedName), os.O_RDONLY, 0644)
+		if err != nil {
+			return nil, err
+		}
+		index, err = os.OpenFile(filepath.Join(path, indexName), os.O_RDONLY, 0644)
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		data, err = os.OpenFile(filepath.Join(path, temporaryName), os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0644)
+		if err != nil {
+			return nil, err
+		}
+		index, err = os.OpenFile(filepath.Join(path, indexName), os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0644)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return &FlatDatabase{
+		path:  path,
+		data:  data,
+		index: index,
+		read:  read,
+	}, nil
+}
+
+// Has retrieves if a key is present in the flat data store.
+func (db *FlatDatabase) Has(key []byte) (bool, error) { panic("not supported") }
+
+// Get retrieves the given key if it's present in the flat data store.
+func (db *FlatDatabase) Get(key []byte) ([]byte, error) { panic("not supported") }
+
+// Delete removes the key from the key-value data store.
+func (db *FlatDatabase) Delete(key []byte) error { panic("not supported") }
+
+// Stat returns a particular internal stat of the database.
+func (db *FlatDatabase) Stat(property string) (string, error) { panic("not supported") }
+
+// Compact flattens the underlying data store for the given key range. In essence,
+// deleted and overwritten versions are discarded, and the data is rearranged to
+// reduce the cost of operations needed to access them.
+//
+// A nil start is treated as a key before all keys in the data store; a nil limit
+// is treated as a key after all keys in the data store. If both is nil then it
+// will compact entire data store.
+func (db *FlatDatabase) Compact(start []byte, limit []byte) error { panic("not supported") }
+
+// Put inserts the given value into the key-value data store.
+func (db *FlatDatabase) Put(key []byte, value []byte) error {
+	if len(key) == 0 || len(value) == 0 {
+		return ErrEmptyEntry
+	}
+	db.lock.Lock()
+	defer db.lock.Unlock()
+
+	if db.read {
+		return ErrReadOnly
+	}
+	n := 2*binary.MaxVarintLen32 + len(key) + len(value)
+	db.grow(n)
+	offset, previous := len(db.buff), len(db.buff)
+	db.buff = db.buff[:offset+n]
+	offset += binary.PutUvarint(db.buff[offset:], uint64(len(key)))
+	offset += copy(db.buff[offset:], key)
+	offset += binary.PutUvarint(db.buff[offset:], uint64(len(value)))
+	offset += copy(db.buff[offset:], value)
+	db.buff = db.buff[:offset]
+	db.items += 1
+	db.offset += uint64(offset) - uint64(previous)
+	return db.writeChunk(false)
+}
+
+func (db *FlatDatabase) grow(n int) {
+	o := len(db.buff)
+	if cap(db.buff)-o < n {
+		div := 1
+		if db.items > bufferGrowRec {
+			div = db.items / bufferGrowRec
+		}
+		ndata := make([]byte, o, o+n+o/div)
+		copy(ndata, db.buff)
+		db.buff = ndata
+	}
+}
+
+func (db *FlatDatabase) writeChunk(force bool) error {
+	if len(db.buff) < chunkSize && !force {
+		return nil
+	}
+	// Step one, flush data
+	n, err := db.data.Write(db.buff)
+	if err != nil {
+		return err
+	}
+	if n != len(db.buff) {
+		return ErrWriteFailure
+	}
+	db.buff = db.buff[:0]
+	db.items = 0
+
+	// Step two, flush chunk offset
+	var local [8]byte
+	binary.BigEndian.PutUint64(local[:], db.offset)
+	n, err = db.index.Write(local[:])
+	if err != nil {
+		return err
+	}
+	if n != 8 {
+		return ErrWriteFailure
+	}
+	return nil
+}
+
+func (db *FlatDatabase) readChunk() error {
+	// Step one, read chunk size
+	var local [8]byte
+	n, err := db.index.Read(local[:])
+	if err != nil {
+		return err // may return EOF
+	}
+	if n != 8 {
+		return ErrReadFailure
+	}
+	offset := binary.BigEndian.Uint64(local[:])
+	size := int(offset - db.offset)
+	db.offset = offset
+
+	db.grow(size)
+	db.buff = db.buff[:size]
+	n, err = db.data.Read(db.buff)
+	if err != nil {
+		return err // may return EOF
+	}
+	if n != size {
+		return ErrReadFailure
+	}
+	return nil
+}
+
+// Commit flushs all in-memory data into the disk and switchs the db to read mode.
+func (db *FlatDatabase) Commit() error {
+	db.lock.Lock()
+	defer db.lock.Unlock()
+
+	if err := db.closeNoLock(); err != nil {
+		return err
+	}
+	if err := rename(filepath.Join(db.path, temporaryName), filepath.Join(db.path, syncedName)); err != nil {
+		return err
+	}
+	if err := syncDir(db.path); err != nil {
+		return err
+	}
+	db.read = true
+	db.offset = 0
+
+	// Reopen the files in read-only mode
+	var err error
+	db.data, err = os.OpenFile(filepath.Join(db.path, syncedName), os.O_RDONLY, 0644)
+	if err != nil {
+		return err
+	}
+	db.index, err = os.OpenFile(filepath.Join(db.path, indexName), os.O_RDONLY, 0644)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func (db *FlatDatabase) closeNoLock() error {
+	if err := db.writeChunk(true); err != nil {
+		return err
+	}
+	if err := db.data.Sync(); err != nil {
+		return err
+	}
+	if err := db.index.Sync(); err != nil {
+		return err
+	}
+	if err := db.data.Close(); err != nil {
+		return err
+	}
+	if err := db.index.Close(); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (db *FlatDatabase) Close() error {
+	db.lock.Lock()
+	defer db.lock.Unlock()
+
+	return db.closeNoLock()
+}
+
+// NewBatch creates a write-only database that buffers changes to its host db
+// until a final write is called.
+func (db *FlatDatabase) NewBatch() ethdb.Batch {
+	return &flatBatch{db: db}
+}
+
+type flatBatch struct {
+	db      *FlatDatabase
+	keys    [][]byte
+	vals    [][]byte
+	keysize int
+	valsize int
+	lock    sync.RWMutex
+}
+
+// Put inserts the given value into the key-value data store.
+func (fb *flatBatch) Put(key []byte, value []byte) error {
+	fb.lock.Lock()
+	defer fb.lock.Unlock()
+
+	fb.keys = append(fb.keys, key)
+	fb.vals = append(fb.vals, value)
+	fb.keysize += len(key)
+	fb.valsize += len(value)
+	return nil
+}
+
+// Delete removes the key from the key-value data store.
+func (fb *flatBatch) Delete(key []byte) error { panic("not supported") }
+
+// ValueSize retrieves the amount of data queued up for writing.
+func (fb *flatBatch) ValueSize() int {
+	fb.lock.RLock()
+	defer fb.lock.RUnlock()
+
+	return fb.valsize
+}
+
+// Write flushes any accumulated data to disk.
+func (fb *flatBatch) Write() error {
+	fb.lock.Lock()
+	defer fb.lock.Unlock()
+
+	for i := 0; i < len(fb.keys); i++ {
+		if err := fb.db.Put(fb.keys[i], fb.vals[i]); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// Reset resets the batch for reuse.
+func (fb *flatBatch) Reset() {
+	fb.lock.Lock()
+	defer fb.lock.Unlock()
+
+	fb.keysize, fb.valsize = 0, 0
+	fb.keys = fb.keys[:0]
+	fb.vals = fb.vals[:0]
+}
+
+// Replay replays the batch contents.
+func (fb *flatBatch) Replay(w ethdb.KeyValueWriter) error {
+	fb.lock.Lock()
+	defer fb.lock.Unlock()
+
+	for i := 0; i < len(fb.keys); i++ {
+		if err := w.Put(fb.keys[i], fb.vals[i]); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// NewIterator creates a iterator over the **whole** database with first-in-first-out
+// order. The passed `prefix` and `start` is useless, just only to follow the interface.
+//
+// If there already exists a un-released iterator, the nil will be returned since
+// iteration concurrently is not supported by flatdb.
+func (db *FlatDatabase) NewIterator(prefix []byte, start []byte) ethdb.Iterator {
+	db.lock.Lock()
+	defer db.lock.Unlock()
+
+	if db.iterating {
+		return nil
+	}
+	db.iterating = true
+	db.data.Seek(0, 0)
+	db.index.Seek(0, 0)
+	db.offset = 0
+	db.buff = db.buff[:0]
+	return &flatIterator{db: db}
+}
+
+// flatIterator is the iterator used to itearate the whole db.
+type flatIterator struct {
+	db  *FlatDatabase
+	key []byte
+	val []byte
+	err error
+	eof bool
+}
+
+// Next moves the iterator to the next key/value pair. It returns whether the
+// iterator is exhausted.
+func (iter *flatIterator) Next() bool {
+	if len(iter.db.buff) == 0 && !iter.eof {
+		if err := iter.db.readChunk(); err != nil {
+			if err == io.EOF {
+				iter.eof = true
+				return false
+			} else {
+				iter.err = err
+				return false
+			}
+		}
+	}
+	var offset int
+	x, n := binary.Uvarint(iter.db.buff)
+	offset += n
+	if n <= 0 {
+		return false
+	}
+	key := iter.db.buff[offset : offset+int(x)]
+	offset += int(x)
+	x, n = binary.Uvarint(iter.db.buff[offset:])
+	offset += n
+	if n <= 0 {
+		return false
+	}
+	val := iter.db.buff[offset : offset+int(x)]
+	offset += int(x)
+
+	iter.key = key
+	iter.val = val
+	iter.db.buff = iter.db.buff[offset:]
+	return true
+}
+
+// Error returns any accumulated error. Exhausting all the key/value pairs
+// is not considered to be an error.
+func (iter *flatIterator) Error() error {
+	return iter.err
+}
+
+// Key returns the key of the current key/value pair, or nil if done. The caller
+// should not modify the contents of the returned slice, and its contents may
+// change on the next call to Next.
+func (iter *flatIterator) Key() []byte {
+	return iter.key
+}
+
+// Value returns the value of the current key/value pair, or nil if done. The
+// caller should not modify the contents of the returned slice, and its contents
+// may change on the next call to Next.
+func (iter *flatIterator) Value() []byte {
+	return iter.val
+}
+
+// Release releases associated resources. Release should always succeed and can
+// be called multiple times without causing error.
+func (iter *flatIterator) Release() {
+	iter.db.iterating = false
+}
+
+// HasAncient returns an indicator whether the specified data exists in the
+// ancient store.
+func (db *FlatDatabase) HasAncient(kind string, number uint64) (bool, error) { panic("not supported") }
+
+// Ancient retrieves an ancient binary blob from the append-only immutable files.
+func (db *FlatDatabase) Ancient(kind string, number uint64) ([]byte, error) { panic("not supported") }
+
+// Ancients returns the ancient item numbers in the ancient store.
+func (db *FlatDatabase) Ancients() (uint64, error) { panic("not supported") }
+
+// AncientSize returns the ancient size of the specified category.
+func (db *FlatDatabase) AncientSize(kind string) (uint64, error) { panic("not supported") }
+
+// AppendAncient injects all binary blobs belong to block at the end of the
+// append-only immutable table files.
+func (db *FlatDatabase) AppendAncient(number uint64, hash, header, body, receipt, td []byte) error {
+	panic("not supported")
+}
+
+// TruncateAncients discards all but the first n ancient data from the ancient store.
+func (db *FlatDatabase) TruncateAncients(n uint64) error { panic("not supported") }
+
+// Sync flushes all in-memory ancient store data to disk.
+func (db *FlatDatabase) Sync() error { panic("not supported") }

--- a/core/rawdb/flatdb.go
+++ b/core/rawdb/flatdb.go
@@ -148,6 +148,10 @@ func (db *FlatDatabase) Put(key []byte, value []byte) error {
 	offset += copy(db.buff[offset:], value)
 	db.buff = db.buff[:offset]
 	db.items += 1
+
+	// db.offset is monotonic increasing in "WRITE" mode which
+	// indicates the offset of the last written entry in GLOBAL
+	// view. So everytime only the diff is added.
 	db.offset += uint64(offset) - uint64(previous)
 	return db.writeChunk(false)
 }

--- a/core/rawdb/flatdb_test.go
+++ b/core/rawdb/flatdb_test.go
@@ -1,0 +1,199 @@
+// Copyright 2020 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+package rawdb
+
+import (
+	"bytes"
+	"crypto/rand"
+	"io/ioutil"
+	"os"
+	"sync"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/ethdb"
+)
+
+type flatDBTester struct {
+	dir string
+	db  *FlatDatabase
+}
+
+func newFlatDBTester(read bool) *flatDBTester {
+	dir, _ := ioutil.TempDir("", "")
+	db, err := NewFlatDatabase(dir, read)
+	if err != nil {
+		return nil
+	}
+	return &flatDBTester{
+		dir: dir,
+		db:  db,
+	}
+}
+
+func (tester *flatDBTester) teardown() {
+	if tester.dir != "" {
+		os.RemoveAll(tester.dir)
+	}
+}
+
+func (tester *flatDBTester) Put(key, value []byte) {
+	tester.db.Put(key, value)
+}
+
+func (tester *flatDBTester) Iterate() ethdb.Iterator {
+	return tester.db.NewIterator(nil, nil)
+}
+
+func (tester *flatDBTester) Commit() {
+	tester.db.Commit()
+}
+
+func (tester *flatDBTester) checkIteration(t *testing.T, keys [][]byte, vals [][]byte) {
+	iter := tester.Iterate()
+	var index int
+	for iter.Next() {
+		if index >= len(keys) {
+			t.Fatalf("Extra entry found")
+		}
+		if index >= len(vals) {
+			t.Fatalf("Extra entry found")
+		}
+		if !bytes.Equal(iter.Key(), keys[index]) {
+			t.Fatalf("Entry key mismatch %v -> %v", keys[index], iter.Key())
+		}
+		if !bytes.Equal(iter.Value(), vals[index]) {
+			t.Fatalf("Entry value mismatch %v -> %v", vals[index], iter.Value())
+		}
+		index += 1
+	}
+	if iter.Error() != nil {
+		t.Fatalf("Iteration error %v", iter.Error())
+	}
+	iter.Release()
+}
+
+func newTestCases(size int) ([][]byte, [][]byte) {
+	var (
+		keys [][]byte
+		vals [][]byte
+		kbuf [20]byte
+		vbuf [32]byte
+	)
+	for i := 0; i < size; i++ {
+		rand.Read(kbuf[:])
+		keys = append(keys, common.CopyBytes(kbuf[:]))
+
+		rand.Read(vbuf[:])
+		vals = append(vals, common.CopyBytes(vbuf[:]))
+	}
+	return keys, vals
+}
+
+func TestReadNonExistentDB(t *testing.T) {
+	tester := newFlatDBTester(true)
+	if tester != nil {
+		t.Fatalf("Expect the error for opening the non-existent db")
+	}
+}
+
+func TestReadConcurrently(t *testing.T) {
+	tester := newFlatDBTester(false)
+	if tester == nil {
+		t.Fatalf("Failed to init tester")
+	}
+	defer tester.teardown()
+
+	iter := tester.Iterate()
+	if iter == nil {
+		t.Fatalf("Failed to obtain iterator")
+	}
+	if iter := tester.Iterate(); iter != nil {
+		t.Fatalf("Concurrent iteration is not allowed")
+	}
+	iter.Release()
+	if iter := tester.Iterate(); iter == nil {
+		t.Fatalf("Failed to obtain iterator")
+	}
+}
+
+func TestFlatDatabase(t *testing.T) {
+	tester := newFlatDBTester(false)
+	if tester == nil {
+		t.Fatalf("Failed to init tester")
+	}
+	defer tester.teardown()
+
+	keys, vals := newTestCases(1024 * 1024)
+	for i := 0; i < len(keys); i++ {
+		tester.Put(keys[i], vals[i])
+	}
+	tester.Commit()
+	tester.checkIteration(t, keys, vals)
+	tester.checkIteration(t, keys, vals) // Check twice
+}
+
+func TestFlatDatabaseBatchWrite(t *testing.T) {
+	tester := newFlatDBTester(false)
+	if tester == nil {
+		t.Fatalf("Failed to init tester")
+	}
+	defer tester.teardown()
+
+	keys, vals := newTestCases(1024 * 1024)
+	batch := tester.db.NewBatch()
+	for i := 0; i < len(keys); i++ {
+		batch.Put(keys[i], vals[i])
+		if batch.ValueSize() > 1024 {
+			batch.Write()
+			batch.Reset()
+		}
+	}
+	batch.Write()
+
+	tester.Commit()
+	tester.checkIteration(t, keys, vals)
+}
+
+func TestFlatDatabaseConcurrentWrite(t *testing.T) {
+	tester := newFlatDBTester(false)
+	if tester == nil {
+		t.Fatalf("Failed to init tester")
+	}
+	defer tester.teardown()
+
+	var wg sync.WaitGroup
+	writer := func() {
+		defer wg.Done()
+		keys, vals := newTestCases(1024 * 1024)
+		batch := tester.db.NewBatch()
+		for i := 0; i < len(keys); i++ {
+			batch.Put(keys[i], vals[i])
+			if batch.ValueSize() > 1024 {
+				batch.Write()
+				batch.Reset()
+			}
+		}
+		batch.Write()
+	}
+	wg.Add(2)
+	go writer()
+	go writer()
+
+	wg.Wait()
+	tester.Commit()
+}

--- a/core/rawdb/flatdb_test.go
+++ b/core/rawdb/flatdb_test.go
@@ -85,6 +85,10 @@ func (tester *flatDBTester) checkIteration(t *testing.T, keys [][]byte, vals [][
 		t.Fatalf("Iteration error %v", iter.Error())
 	}
 	iter.Release()
+
+	if index != len(keys) {
+		t.Fatalf("Missing entries, want %d, got %d", len(keys), index)
+	}
 }
 
 func newTestCases(size int) ([][]byte, [][]byte) {

--- a/core/state/pruner/pruner.go
+++ b/core/state/pruner/pruner.go
@@ -97,7 +97,7 @@ func (p *Pruner) Prune(root common.Hash) error {
 	}
 	// Extract all node refs belong to the genesis. We have to keep the
 	// genesis all the time.
-	marker, err := extractGenesis(p.db, p.snaptree)
+	marker, err := extractGenesis(p.db)
 	if err != nil {
 		return err
 	}
@@ -266,7 +266,7 @@ func RecoverTemporaryDatabase(homedir string, db ethdb.Database) error {
 
 // extractGenesis loads the genesis state and creates the nodes marker.
 // So that it can be used as an present indicator for all genesis trie nodes.
-func extractGenesis(db ethdb.Database, snaptree *snapshot.Tree) (map[common.Hash]struct{}, error) {
+func extractGenesis(db ethdb.Database) (map[common.Hash]struct{}, error) {
 	genesisHash := rawdb.ReadCanonicalHash(db, 0)
 	if genesisHash == (common.Hash{}) {
 		return nil, errors.New("missing genesis hash")

--- a/core/state/pruner/pruner.go
+++ b/core/state/pruner/pruner.go
@@ -127,7 +127,7 @@ func (p *Pruner) Prune(root common.Hash) error {
 				}
 			} else {
 				if _, ok := marker[common.BytesToHash(key)]; ok {
-					continue // Genesis state trie node
+					continue // Genesis state trie node or legacy contract code
 				}
 			}
 			size += common.StorageSize(len(key) + len(iter.Value()))

--- a/core/state/pruner/pruner.go
+++ b/core/state/pruner/pruner.go
@@ -283,11 +283,11 @@ func extractGenesis(db ethdb.Database, snaptree *snapshot.Tree) (map[common.Hash
 	accIter := t.NodeIterator(nil)
 	for accIter.Next(true) {
 		node := accIter.Hash()
-		if node == (common.Hash{}) {
-			continue
-		}
-		marker[node] = struct{}{}
 
+		// Embeded nodes don't have hash.
+		if node != (common.Hash{}) {
+			marker[node] = struct{}{}
+		}
 		// If it's a leaf node, yes we are touching an account,
 		// dig into the storage trie further.
 		if accIter.Leaf() {

--- a/core/state/pruner/pruner.go
+++ b/core/state/pruner/pruner.go
@@ -1,0 +1,239 @@
+// Copyright 2020 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+package pruner
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/rawdb"
+	"github.com/ethereum/go-ethereum/core/state/snapshot"
+	"github.com/ethereum/go-ethereum/ethdb"
+	"github.com/ethereum/go-ethereum/log"
+	"github.com/ethereum/go-ethereum/trie"
+)
+
+// temporaryStateDatabase is the directory name of temporary database for pruning usage.
+const temporaryStateDatabase = "pruning.tmp"
+
+type Pruner struct {
+	db, tmpdb ethdb.Database
+	homedir   string
+	snaptree  *snapshot.Tree
+}
+
+// NewPruner creates the pruner instance.
+func NewPruner(db ethdb.Database, root common.Hash, homedir string) (*Pruner, error) {
+	snaptree, err := snapshot.New(db, trie.NewDatabase(db), 256, root, false, false)
+	if err != nil {
+		return nil, err // The relevant snapshot(s) might not exist
+	}
+	tmpdb, err := openTemporaryDatabase(homedir)
+	if err != nil {
+		return nil, err
+	}
+	return &Pruner{
+		db:       db,
+		tmpdb:    tmpdb,
+		homedir:  homedir,
+		snaptree: snaptree,
+	}, nil
+}
+
+// Prune deletes all historical state nodes except the nodes belong to the
+// specified state version. If user doesn't specify the state version, use
+// the persisted snapshot disk layer as the target.
+func (p *Pruner) Prune(root common.Hash) error {
+	// If the target state root is not specified, use the oldest layer
+	// (disk layer). Fresh new layer as the target is not recommended,
+	// since it might be non-canonical.
+	if root == (common.Hash{}) {
+		root = rawdb.ReadSnapshotRoot(p.db)
+		if root == (common.Hash{}) {
+			return errors.New("no target state specified")
+		}
+	}
+	// Traverse the target state, re-construct the whole state trie and
+	// commit to the given temporary database.
+	if err := snapshot.CommitAndVerifyState(p.snaptree, root, p.db, p.tmpdb); err != nil {
+		return err
+	}
+	if err := markComplete(p.tmpdb); err != nil {
+		return err
+	}
+	// Delete all old trie nodes in the disk(it's safe since we already commit
+	// a complete trie to the temporary db, any crash happens we can recover
+	// a complete state from it).
+	var (
+		count  int
+		size   common.StorageSize
+		start  = time.Now()
+		logged = time.Now()
+		batch  = p.db.NewBatch()
+		iter   = p.db.NewIterator(nil, nil)
+	)
+	defer iter.Release()
+	for iter.Next() {
+		key := iter.Key()
+
+		// Note all entries with 32byte length key(trie nodes,
+		// contract codes) are deleted here.
+		if len(key) == common.HashLength {
+			size += common.StorageSize(len(key) + len(iter.Value()))
+			batch.Delete(key)
+
+			if batch.ValueSize() >= ethdb.IdealBatchSize {
+				batch.Write()
+				batch.Reset()
+			}
+			count += 1
+			if count%1000 == 0 && time.Since(logged) > 8*time.Second {
+				log.Info("Pruning state data", "count", count, "size", size, "elapsed", common.PrettyDuration(time.Since(start)))
+				logged = time.Now()
+			}
+		}
+	}
+	if batch.ValueSize() > 0 {
+		batch.Write()
+		batch.Reset()
+	}
+	log.Info("Pruned state data", "count", count, "size", size, "elapsed", common.PrettyDuration(time.Since(start)))
+
+	// Migrate the state from the temporary db to main one.
+	committed, err := migrateState(p.db, p.tmpdb, p.homedir)
+	if err != nil {
+		return err
+	}
+	// Start compactions, will remove the deleted data from the disk immediately.
+	cstart := time.Now()
+	log.Info("Start compacting the database")
+	if err := p.db.Compact(nil, nil); err != nil {
+		log.Error("Failed to compact the whole database", "error", err)
+	}
+	log.Info("Compacted the whole database", "elapsed", common.PrettyDuration(time.Since(cstart)))
+	log.Info("Successfully prune the state", "committed", committed, "pruned", size, "released", size-committed, "elasped", common.PrettyDuration(time.Since(start)))
+	return nil
+}
+
+// openTemporaryDatabase opens the temporary state database under the given
+// instance directory.
+func openTemporaryDatabase(homedir string) (ethdb.Database, error) {
+	dir := filepath.Join(homedir, temporaryStateDatabase)
+	if _, err := os.Stat(dir); !os.IsNotExist(err) {
+		return nil, fmt.Errorf("temporary state database is occupied: %v", err)
+	}
+	return rawdb.NewLevelDBDatabase(dir, 256, 256, "pruning/tmp")
+}
+
+// wipeTemporaryDatabase closes the db handler and wipes the data from the disk.
+func wipeTemporaryDatabase(homedir string, db ethdb.Database) {
+	db.Close()
+	os.RemoveAll(filepath.Join(homedir, temporaryStateDatabase))
+}
+
+// migrateState moves all states in temporary database to main db.
+// Wipe the whole temporary db if success.
+func migrateState(db, tmpdb ethdb.Database, homedir string) (common.StorageSize, error) {
+	var (
+		count  int
+		size   common.StorageSize
+		start  = time.Now()
+		logged = time.Now()
+		batch  = db.NewBatch()
+		iter   = tmpdb.NewIterator(nil, nil)
+	)
+	defer iter.Release()
+
+	if !isComplete(tmpdb) {
+		return size, errors.New("incomplete state")
+	}
+	for iter.Next() {
+		key := iter.Key()
+		if bytes.Equal(key, stateMarker) {
+			continue
+		}
+		// Note all entries with 32byte length key(trie nodes,
+		// contract codes are migrated here).
+		if len(key) != common.HashLength {
+			panic("invalid entry in database")
+		}
+		size += common.StorageSize(len(key) + len(iter.Value()))
+		batch.Put(key, iter.Value())
+
+		if batch.ValueSize() >= ethdb.IdealBatchSize {
+			batch.Write()
+			batch.Reset()
+		}
+		count += 1
+		if count%1000 == 0 && time.Since(logged) > 8*time.Second {
+			log.Info("Migrating state data", "count", count, "size", size, "elapsed", common.PrettyDuration(time.Since(start)))
+			logged = time.Now()
+		}
+	}
+	if batch.ValueSize() > 0 {
+		batch.Write()
+		batch.Reset()
+	}
+	log.Info("Migrated state data", "count", count, "size", size, "elapsed", common.PrettyDuration(time.Since(start)))
+	wipeTemporaryDatabase(homedir, tmpdb)
+	return size, nil
+}
+
+// RecoverTemporaryDatabase migrates all state data from temporary database to
+// given main db. If the state database is broken, then interrupt the migration.
+//
+// This function is used in this case: user tries to prune state data, but after
+// creating the state backup, the system exits(maually or crashed). Next time
+// before launching the system, the backup state should be merged into main db.
+func RecoverTemporaryDatabase(homedir string, db ethdb.Database) error {
+	dir := filepath.Join(homedir, temporaryStateDatabase)
+	if _, err := os.Stat(dir); os.IsNotExist(err) {
+		return nil // nothing to recover
+	}
+	recoverdb, err := rawdb.NewLevelDBDatabase(dir, 256, 256, "pruning/tmp")
+	if err != nil {
+		return err
+	}
+	if _, err := migrateState(db, recoverdb, homedir); err != nil {
+		return err
+	}
+	return nil
+}
+
+// stateMarker is the key of special state integrity indicator
+var stateMarker = []byte("StateComplete")
+
+// markComplete writes a special marker into the database to represent
+// the whole state in the database is complete. Note it should be called
+// when all state nodes are committed.
+func markComplete(db ethdb.Database) error {
+	return db.Put(stateMarker, []byte{0x01})
+}
+
+// isComplete reads the special state integrity marker from the disk.
+func isComplete(db ethdb.Database) bool {
+	blob, err := db.Get(stateMarker)
+	if err != nil {
+		return false
+	}
+	return len(blob) != 0
+}

--- a/core/state/snapshot/conversion.go
+++ b/core/state/snapshot/conversion.go
@@ -338,10 +338,20 @@ func stdGenerate(db ethdb.Database, in chan trieKV, out chan common.Hash) {
 	for leaf := range in {
 		t.TryUpdate(leaf.key[:], leaf.value)
 	}
-	root := t.Hash()
-	if commit {
-		t.Commit(nil)
-		triedb.Commit(root, false, nil)
+	var (
+		err  error
+		root common.Hash
+	)
+	if !commit {
+		root = t.Hash()
+	} else {
+		root, err = t.Commit(nil)
+		if err != nil {
+			panic(err)
+		}
+		if err := triedb.Commit(root, false); err != nil {
+			panic(err)
+		}
 	}
 	out <- root
 }

--- a/core/state/snapshot/conversion.go
+++ b/core/state/snapshot/conversion.go
@@ -106,7 +106,7 @@ func CommitAndVerifyState(snaptree *Tree, root common.Hash, db, commitdb ethdb.D
 	}
 	defer acctIt.Release()
 
-	got, err := generateTrieRoot(commitdb, acctIt, common.Hash{}, stdGenerate, func(commitdb ethdb.Database, accountHash, codeHash common.Hash, stat *generateStats) (common.Hash, error) {
+	got, err := generateTrieRoot(commitdb, acctIt, common.Hash{}, stackTrieGenerate, func(commitdb ethdb.Database, accountHash, codeHash common.Hash, stat *generateStats) (common.Hash, error) {
 		// Migrate the code first, commit the contract code into the tmp db.
 		if codeHash != emptyCode {
 			code := rawdb.ReadCode(db, codeHash)
@@ -122,7 +122,7 @@ func CommitAndVerifyState(snaptree *Tree, root common.Hash, db, commitdb ethdb.D
 		}
 		defer storageIt.Release()
 
-		hash, err := generateTrieRoot(commitdb, storageIt, accountHash, stdGenerate, nil, stat, false)
+		hash, err := generateTrieRoot(commitdb, storageIt, accountHash, stackTrieGenerate, nil, stat, false)
 		if err != nil {
 			return common.Hash{}, err
 		}
@@ -346,6 +346,21 @@ func stdGenerate(db ethdb.Database, in chan trieKV, out chan common.Hash) {
 		if err := triedb.Commit(root, false, nil); err != nil {
 			panic(err)
 		}
+	}
+	out <- root
+}
+
+func stackTrieGenerate(db ethdb.Database, in chan trieKV, out chan common.Hash) {
+	commit := db != nil
+	t := trie.NewStackTrie(db)
+	for leaf := range in {
+		t.TryUpdate(leaf.key[:], leaf.value)
+	}
+	var root common.Hash
+	if !commit {
+		root = t.Hash()
+	} else {
+		root = t.Commit(db)
 	}
 	out <- root
 }

--- a/core/state/snapshot/conversion.go
+++ b/core/state/snapshot/conversion.go
@@ -475,16 +475,15 @@ func stdGenerate(db ethdb.Database, in chan trieKV, out chan common.Hash) {
 }
 
 func stackTrieGenerate(db ethdb.Database, in chan trieKV, out chan common.Hash) {
-	commit := db != nil
 	t := trie.NewStackTrie(db)
 	for leaf := range in {
 		t.TryUpdate(leaf.key[:], leaf.value)
 	}
 	var root common.Hash
-	if !commit {
+	if db == nil {
 		root = t.Hash()
 	} else {
-		root = t.Commit(db)
+		root, _ = t.Commit()
 	}
 	out <- root
 }

--- a/core/state/snapshot/conversion.go
+++ b/core/state/snapshot/conversion.go
@@ -284,7 +284,7 @@ func runSubTasks(in chan subTask, out chan error, stop chan struct{}) {
 			}
 		case <-stop:
 			// Drain all cached tasks first
-			drain:
+		drain:
 			for {
 				select {
 				case task := <-in:

--- a/core/state/snapshot/conversion.go
+++ b/core/state/snapshot/conversion.go
@@ -227,7 +227,7 @@ type subTask struct {
 }
 
 // runSubTasks is a helper function of generateTrieRoot. If generateTrieRoot has
-// the callback for all leaves, all sub-tasks can be accumulated and executed here.
+// the callback for leaves, all sub-tasks can be accumulated and executed here.
 // If any sub-task failed, a signal will be throw back very soon.
 //
 // Note we expect the out channel has at least 1 slot available so that sending won't
@@ -343,7 +343,13 @@ func generateTrieRoot(db ethdb.Database, it Iterator, account common.Hash, gener
 		}()
 	}
 	// stop is a helper function to shutdown the background threads
-	// and return the re-generated trie hash.
+	// and return the re-generated trie hash. There are three scenarios
+	// for calling this function:
+	// (a) the failure already occurs when processing the sub-task(e.g.
+	//   the storage root is not matched).
+	// (b) the failure already occurs when iterating the state trie.
+	// (c) there is no failure yet.
+	// In case (a) we won't fetch the sub-failure again.
 	stop := func(success bool, subFailed bool) (common.Hash, bool) {
 		close(in)
 		if subStop != nil {

--- a/core/state/snapshot/conversion.go
+++ b/core/state/snapshot/conversion.go
@@ -349,7 +349,7 @@ func stdGenerate(db ethdb.Database, in chan trieKV, out chan common.Hash) {
 		if err != nil {
 			panic(err)
 		}
-		if err := triedb.Commit(root, false); err != nil {
+		if err := triedb.Commit(root, false, nil); err != nil {
 			panic(err)
 		}
 	}

--- a/core/state/snapshot/conversion.go
+++ b/core/state/snapshot/conversion.go
@@ -342,7 +342,7 @@ func generateTrieRoot(db ethdb.Database, it Iterator, account common.Hash, gener
 	// and return the re-generated trie hash. There are three scenarios
 	// for calling this function:
 	// (a) the failure already occurs when processing the sub-task(e.g.
-	//   the storage root is not matched).
+	//     the storage root is not matched).
 	// (b) the failure already occurs when iterating the state trie.
 	// (c) there is no failure yet.
 	// In case (a) we won't fetch the sub-failure again.

--- a/core/state/snapshot/conversion.go
+++ b/core/state/snapshot/conversion.go
@@ -109,17 +109,11 @@ func CommitAndVerifyState(snaptree *Tree, root common.Hash, db, commitdb ethdb.D
 	got, err := generateTrieRoot(commitdb, acctIt, common.Hash{}, stdGenerate, func(commitdb ethdb.Database, accountHash, codeHash common.Hash, stat *generateStats) (common.Hash, error) {
 		// Migrate the code first, commit the contract code into the tmp db.
 		if codeHash != emptyCode {
-			// todo the notion of contract code should be integrated into snapshot.
-			code, err := db.Get(codeHash.Bytes())
-			if err != nil {
-				return common.Hash{}, err
-			}
+			code := rawdb.ReadCode(db, codeHash)
 			if len(code) == 0 {
 				return common.Hash{}, errors.New("failed to migrate contract code")
 			}
-			if err := commitdb.Put(codeHash.Bytes(), code); err != nil {
-				return common.Hash{}, err
-			}
+			rawdb.WriteCode(commitdb, codeHash, code)
 		}
 		// Then migrate all storage trie nodes into the tmp db.
 		storageIt, err := snaptree.StorageIterator(root, accountHash, common.Hash{})

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -20,6 +20,7 @@ package eth
 import (
 	"errors"
 	"fmt"
+	"github.com/ethereum/go-ethereum/core/state/pruner"
 	"math/big"
 	"runtime"
 	"sync"
@@ -124,6 +125,9 @@ func New(stack *node.Node, config *Config) (*Ethereum, error) {
 	}
 	log.Info("Initialised chain configuration", "config", chainConfig)
 
+	if err := pruner.RecoverTemporaryDatabase(stack.ResolvePath(""), chainDb); err != nil {
+		log.Error("Failed to recover state", "error", err)
+	}
 	eth := &Ethereum{
 		config:            config,
 		chainDb:           chainDb,

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -20,7 +20,6 @@ package eth
 import (
 	"errors"
 	"fmt"
-	"github.com/ethereum/go-ethereum/core/state/pruner"
 	"math/big"
 	"runtime"
 	"sync"
@@ -35,6 +34,7 @@ import (
 	"github.com/ethereum/go-ethereum/core"
 	"github.com/ethereum/go-ethereum/core/bloombits"
 	"github.com/ethereum/go-ethereum/core/rawdb"
+	"github.com/ethereum/go-ethereum/core/state/pruner"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/core/vm"
 	"github.com/ethereum/go-ethereum/eth/downloader"

--- a/go.mod
+++ b/go.mod
@@ -58,6 +58,7 @@ require (
 	github.com/stretchr/testify v1.4.0
 	github.com/syndtr/goleveldb v1.0.1-0.20200815110645-5c35d600f0ca
 	github.com/tyler-smith/go-bip39 v1.0.1-0.20181017060643-dbb3b84ba2ef
+	github.com/urfave/cli v1.22.1
 	github.com/wsddn/go-ecdh v0.0.0-20161211032359-48726bab9208
 	golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9
 	golang.org/x/mobile v0.0.0-20200801112145-973feb4309de // indirect

--- a/go.sum
+++ b/go.sum
@@ -45,6 +45,7 @@ github.com/cespare/xxhash/v2 v2.1.1 h1:6MnRN8NT7+YBpUIWxHtefFZOKTAPgGjpQSxqLNn0+
 github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/cloudflare/cloudflare-go v0.10.2-0.20190916151808-a80f83b9add9 h1:J82+/8rub3qSy0HxEnoYD8cs+HDlHWYrqYXe2Vqxluk=
 github.com/cloudflare/cloudflare-go v0.10.2-0.20190916151808-a80f83b9add9/go.mod h1:1MxXX1Ux4x6mqPmjkUgTP1CdXIBXKX7T+Jk9Gxrmx+U=
+github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d h1:U+s90UTSYgptZMwQh2aRr3LuazLJIa+Pg3Kc1ylSYVY=
 github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
@@ -189,6 +190,7 @@ github.com/rs/cors v0.0.0-20160617231935-a62a804a8a00 h1:8DPul/X0IT/1TNMIxoKLwde
 github.com/rs/cors v0.0.0-20160617231935-a62a804a8a00/go.mod h1:gFx+x8UowdsKA9AchylcLynDq+nNFfI8FkUZdN/jGCU=
 github.com/rs/xhandler v0.0.0-20160618193221-ed27b6fd6521 h1:3hxavr+IHMsQBrYUPQM5v0CgENFktkkbg1sfpgM3h20=
 github.com/rs/xhandler v0.0.0-20160618193221-ed27b6fd6521/go.mod h1:RvLn4FgxWubrpZHtQLnOf6EwhN2hEMusxZOhcW9H3UQ=
+github.com/russross/blackfriday/v2 v2.0.1 h1:lPqVAte+HuHNfhJ/0LC98ESWRz8afy9tM/0RK8m9o+Q=
 github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/shirou/gopsutil v2.20.5+incompatible h1:tYH07UPoQt0OCQdgWWMgYHy3/a9bcxNpBIysykNIP7I=
 github.com/shirou/gopsutil v2.20.5+incompatible/go.mod h1:5b4v6he4MtMOwMlS0TUMTu2PcXUg8+E1lC7eC3UO/RA=
@@ -203,7 +205,6 @@ github.com/steakknife/hamming v0.0.0-20180906055917-c99c65617cd3/go.mod h1:hpGUW
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
-github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJyk=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/syndtr/goleveldb v1.0.1-0.20200815110645-5c35d600f0ca h1:Ld/zXl5t4+D69SiV4JoN7kkfvJdOWlPpfxrzxpLMoUk=
 github.com/syndtr/goleveldb v1.0.1-0.20200815110645-5c35d600f0ca/go.mod h1:u2MKkTVTVJWe5D1rCvame8WqhBd88EuIwODJZ1VHCPM=
@@ -280,15 +281,11 @@ google.golang.org/protobuf v1.23.0 h1:4MY060fB1DLGMB/7MBTLnwQUY6+F09GEiz6SsrNqyz
 google.golang.org/protobuf v1.23.0/go.mod h1:EGpADcykh3NcUnDUJcl1+ZksZNG86OlYog2l/sGQquU=
 gopkg.in/alecthomas/kingpin.v2 v2.2.6/go.mod h1:FMv+mEhP44yOT+4EoQTLFTRgOQ1FBLkstjWtayDeSgw=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
-gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 h1:qIbj1fsPNlZgppZ+VLlY7N33q108Sa+fhmuc+sWQYwY=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
-gopkg.in/fsnotify.v1 v1.4.7 h1:xOHLXZwVvI9hhs+cLKq5+I5onOuwQLhQwiu63xxlHs4=
 gopkg.in/fsnotify.v1 v1.4.7/go.mod h1:Tz8NjZHkW78fSQdbUxIjBTcgA1z1m8ZHf0WmKUhAMys=
-gopkg.in/natefinch/npipe.v2 v2.0.0-20160621034901-c1b8fa8bdcce h1:+JknDZhAj8YMt7GC73Ei8pv4MzjDUNPHgQWJdtMAaDU=
 gopkg.in/natefinch/npipe.v2 v2.0.0-20160621034901-c1b8fa8bdcce/go.mod h1:5AcXVHNjg+BDxry382+8OKon8SEWiKktQR07RKPsv1c=
 gopkg.in/olebedev/go-duktape.v3 v3.0.0-20200619000410-60c24ae608a6 h1:a6cXbcDDUkSBlpnkWV1bJ+vv3mOgQEltEJ2rPxroVu0=
 gopkg.in/olebedev/go-duktape.v3 v3.0.0-20200619000410-60c24ae608a6/go.mod h1:uAJfkITjFhyEEuUfm7bsmCZRbW5WRq8s9EY8HZ6hCns=
-gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 h1:uRGJdciOHaEIrze2W8Q3AKkepLTh2hOroT7a+7czfdQ=
 gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7/go.mod h1:dt/ZhP58zS4L8KSrWDmTeBkI65Dw0HsyUHuEVlX15mw=
 gopkg.in/urfave/cli.v1 v1.20.0 h1:NdAVW6RYxDif9DhDHaAortIu956m2c0v+09AZBPTbE0=
 gopkg.in/urfave/cli.v1 v1.20.0/go.mod h1:vuBzUtMdQeixQj8LVd+/98pzhxNGQoyuPBlsXHOQNO0=

--- a/go.sum
+++ b/go.sum
@@ -205,6 +205,7 @@ github.com/steakknife/hamming v0.0.0-20180906055917-c99c65617cd3/go.mod h1:hpGUW
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
+github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJyk=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/syndtr/goleveldb v1.0.1-0.20200815110645-5c35d600f0ca h1:Ld/zXl5t4+D69SiV4JoN7kkfvJdOWlPpfxrzxpLMoUk=
 github.com/syndtr/goleveldb v1.0.1-0.20200815110645-5c35d600f0ca/go.mod h1:u2MKkTVTVJWe5D1rCvame8WqhBd88EuIwODJZ1VHCPM=

--- a/tests/state_test_util.go
+++ b/tests/state_test_util.go
@@ -225,7 +225,7 @@ func MakePreState(db ethdb.Database, accounts core.GenesisAlloc, snapshotter boo
 
 	var snaps *snapshot.Tree
 	if snapshotter {
-		snaps = snapshot.New(db, sdb.TrieDB(), 1, root, false)
+		snaps, _ = snapshot.New(db, sdb.TrieDB(), 1, root, false, true)
 	}
 	statedb, _ = state.New(root, sdb, snaps)
 	return snaps, statedb


### PR DESCRIPTION
This PR offers two commands `geth snapshot prune-state` and `geth snapshot verify-state`.
All these two commands require a live snapshot. If you want to use it, generate the snapshot 
first with `--snapshot` enabled.

### State pruner

It's a very simple state pruner. The idea is quite straightforward. Whenever we have a live snapshot, we can re-generate the whole state trie from it. Users can pick a specific version snapshot for state regeneration and then wipe all other trie nodes for pruning.

The procedure of pruning can be the following steps:

* Generate the state trie of a specific snapshot
* Commit all trie nodes as well as the account codes to a file-based temporary database
* Iterate the main database, delete all state data(includes the account codes), **but the genesis state should be kept**.
* Compact the whole main db to release disk space
* Migrate all data from the temporary database to main one

These following scenarios can happen:
* Before we regenerate the state trie, the system exits: In this case, the temporary database is incomplete and will be deleted when the system launches next time.
* After we regenerate the state trie, the system exits: In this case, the temporary database is complete. And the more important thing is: we may already prune state data from the main database. So when the system launches next time, the temporary database will be migrated to the main db and wipe it.

Something important:
* The whole pruning procedure can take a very long time(e.g. 7 minutes on goerli)

### State verifier

Verifier is a simple tool to verify whether the regenerated state trie hash is equal with the original one. Now it's mainly used for testing.

### What's more?

Except these two commands, we can offer more functionalities based on the snapshot. One idea is the snapshot can be used to generate arbitrary range trie nodes. If so, we can use it for state repairing. Whenever we hit the `trie node missing` error, we can just regenerate it instead of throwing out the whole db.
