### PR TITLE
core: fix missing receipt

### DIFF
--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -1680,7 +1680,12 @@ func (bc *BlockChain) insertChain(chain types.Blocks, verifySeals bool) (int, er
 			// as the canonical chain eventually, it needs to be reexecuted for missing
 			// state, but if it's this special case here(skip reexecution) we will lose
 			// the empty receipt entry.
-			rawdb.WriteReceipts(bc.db, block.Hash(), block.NumberU64(), nil)
+			if len(block.Transactions()) == 0 {
+				rawdb.WriteReceipts(bc.db, block.Hash(), block.NumberU64(), nil)
+			} else {
+				log.Error("Please file an issue, skip known block execution without receipt",
+					"hash", block.Hash(), "number", block.NumberU64())
+			}
 			if err := bc.writeKnownBlock(block); err != nil {
 				return it.index, err
 			}


### PR DESCRIPTION
Fixes #20239

It fixes this scenario which may lead to `losing receipts`.

* Running Geth for clique chain(rinkeby, ropsten)
* Crash(without commit the latest state)
* Restart, rewind the `CurrentBlock` to a lower point which has the available relevant state
* Start to sync, import a batch of blocks via `insertSideChain`
* This batch blocks contain some "unknown" blocks, we commit them without "receipts"
* The "sidechain" longer than the "canonical" one, re-insert them for state generation
* But if there is an "empty" block, the first block will also complete this empty one since the state root is same.
* Skip reinsert the "empty" block, we lose the receipt entry

So the issue happens only when we run a clique chain and the block is empty. So the fix can always insert an empty receipt slice whenever we meet this scenario.