### PR TITLE
core/state: avoid statedb.dbErr due to emptyCode

### DIFF
--- a/core/state/statedb.go
+++ b/core/state/statedb.go
@@ -18,6 +18,7 @@
 package state
 
 import (
+	"bytes"
 	"errors"
 	"fmt"
 	"math/big"
@@ -294,9 +295,12 @@ func (s *StateDB) GetCodeSize(addr common.Address) int {
 	if stateObject.code != nil {
 		return len(stateObject.code)
 	}
+	if bytes.Equal(stateObject.CodeHash(), emptyCode[:]) {
+		return 0
+	}
 	size, err := s.db.ContractCodeSize(stateObject.addrHash, common.BytesToHash(stateObject.CodeHash()))
 	if err != nil {
-		s.setError(err)
+		s.setError(fmt.Errorf("GetCodeSize (%x) error: %v", addr[:], err))
 	}
 	return size
 }
@@ -465,7 +469,9 @@ func (s *StateDB) updateStateObject(obj *stateObject) {
 	if err != nil {
 		panic(fmt.Errorf("can't encode object at %x: %v", addr[:], err))
 	}
-	s.setError(s.trie.TryUpdate(addr[:], data))
+	if err = s.trie.TryUpdate(addr[:], data); err != nil {
+		s.setError(fmt.Errorf("updateStateObject (%x) error: %v", addr[:], err))
+	}
 
 	// If state snapshotting is active, cache the data til commit. Note, this
 	// update mechanism is not symmetric to the deletion, because whereas it is
@@ -484,7 +490,9 @@ func (s *StateDB) deleteStateObject(obj *stateObject) {
 	}
 	// Delete the account from the trie
 	addr := obj.Address()
-	s.setError(s.trie.TryDelete(addr[:]))
+	if err := s.trie.TryDelete(addr[:]); err != nil {
+		s.setError(fmt.Errorf("deleteStateObject (%x) error: %v", addr[:], err))
+	}
 }
 
 // getStateObject retrieves a state object given by the address, returning nil if
@@ -537,7 +545,7 @@ func (s *StateDB) getDeletedStateObject(addr common.Address) *stateObject {
 		}
 		enc, err := s.trie.TryGet(addr[:])
 		if len(enc) == 0 {
-			s.setError(err)
+			s.setError(fmt.Errorf("getDeleteStateObject (%x) error: %v", addr[:], err))
 			return nil
 		}
 		if err := rlp.DecodeBytes(enc, &data); err != nil {

--- a/core/state/statedb.go
+++ b/core/state/statedb.go
@@ -548,7 +548,7 @@ func (s *StateDB) getDeletedStateObject(addr common.Address) *stateObject {
 			s.setError(fmt.Errorf("getDeleteStateObject (%x) error: %v", addr[:], err))
 			return nil
 		}
-		if len(enc) == 0{
+		if len(enc) == 0 {
 			return nil
 		}
 		if err := rlp.DecodeBytes(enc, &data); err != nil {

--- a/core/state/statedb.go
+++ b/core/state/statedb.go
@@ -544,8 +544,11 @@ func (s *StateDB) getDeletedStateObject(addr common.Address) *stateObject {
 			defer func(start time.Time) { s.AccountReads += time.Since(start) }(time.Now())
 		}
 		enc, err := s.trie.TryGet(addr[:])
-		if len(enc) == 0 {
+		if err != nil {
 			s.setError(fmt.Errorf("getDeleteStateObject (%x) error: %v", addr[:], err))
+			return nil
+		}
+		if len(enc) == 0{
 			return nil
 		}
 		if err := rlp.DecodeBytes(enc, &data); err != nil {


### PR DESCRIPTION
The PR https://github.com/ethereum/go-ethereum/pull/21039 introduced a regression, apparently because we did not have a shortcut for the emptycodehash when called from e.g. `EXTCODEHASH`. This caused an internal db error every time it was invoked on an account without code. 

Previously, we silently ignored that, but with the changes in #21039, we suddenly started caring about it, and thus rejected blocks/peers. 