### PR TITLE
core/state: make GetCodeSize mirror GetCode implementation wise

### DIFF
--- a/core/state/statedb.go
+++ b/core/state/statedb.go
@@ -18,7 +18,6 @@
 package state
 
 import (
-	"bytes"
 	"errors"
 	"fmt"
 	"math/big"
@@ -289,20 +288,10 @@ func (s *StateDB) GetCode(addr common.Address) []byte {
 
 func (s *StateDB) GetCodeSize(addr common.Address) int {
 	stateObject := s.getStateObject(addr)
-	if stateObject == nil {
-		return 0
+	if stateObject != nil {
+		return stateObject.CodeSize(s.db)
 	}
-	if stateObject.code != nil {
-		return len(stateObject.code)
-	}
-	if bytes.Equal(stateObject.CodeHash(), emptyCode[:]) {
-		return 0
-	}
-	size, err := s.db.ContractCodeSize(stateObject.addrHash, common.BytesToHash(stateObject.CodeHash()))
-	if err != nil {
-		s.setError(fmt.Errorf("GetCodeSize (%x) error: %v", addr[:], err))
-	}
-	return size
+	return 0
 }
 
 func (s *StateDB) GetCodeHash(addr common.Address) common.Hash {


### PR DESCRIPTION
Functionally this is a noop change, but code readability wise it moves the special case handling of GetCode and GetCodeSize side by side to avoid the same logic being scattered across two files.