### PR TITLE
refactor downloader common ancestor span/binary search fns

### DIFF
--- a/eth/downloader/downloader.go
+++ b/eth/downloader/downloader.go
@@ -441,10 +441,18 @@ func (d *Downloader) syncWithPeer(p *peerConnection, hash common.Hash, td *big.I
 	}
 	height := latest.Number.Uint64()
 
-	origin, err := d.findAncestor(p, latest)
-	if err != nil {
-		return err
+	var origin = uint64(0)
+
+	if d.blockchain != nil &&
+		d.blockchain.CurrentHeader() != nil &&
+		d.blockchain.CurrentHeader().Number != nil &&
+		d.blockchain.CurrentHeader().Number.Uint64() > 0 {
+		origin, err = d.findAncestor(p, latest)
+		if err != nil {
+			return err
+		}
 	}
+
 	d.syncStatsLock.Lock()
 	if d.syncStatsChainHeight <= origin || d.syncStatsChainOrigin > origin {
 		d.syncStatsChainOrigin = origin

--- a/eth/downloader/downloader.go
+++ b/eth/downloader/downloader.go
@@ -753,7 +753,7 @@ func (d *Downloader) findAncestor(p *peerConnection, remoteHeader *types.Header)
 	}
 
 	// Only attempt span search if local head is "close" to reported remote
-	if remoteHeight-localHeight < uint64(MaxHeaderFetch) {
+	if remoteHeight-localHeight <= uint64(MaxHeaderFetch) {
 		a, err := d.findAncestorSpanSearch(p, remoteHeight, localHeight, floor)
 		if err == nil {
 			if a > localHeight {

--- a/eth/downloader/downloader.go
+++ b/eth/downloader/downloader.go
@@ -444,10 +444,8 @@ func (d *Downloader) syncWithPeer(p *peerConnection, hash common.Hash, td *big.I
 
 	var origin = uint64(0)
 
-	if d.blockchain != nil &&
-		d.blockchain.CurrentHeader() != nil &&
-		d.blockchain.CurrentHeader().Number != nil &&
-		d.blockchain.CurrentHeader().Number.Uint64() > 0 {
+	if (d.mode != LightSync && d.blockchain.CurrentHeader().Number.Uint64() > 0) ||
+		d.lightchain.CurrentHeader().Number.Uint64() > 0 {
 		origin, err = d.findAncestor(p, latest)
 		if err != nil {
 			return err

--- a/eth/downloader/downloader.go
+++ b/eth/downloader/downloader.go
@@ -20,6 +20,7 @@ package downloader
 import (
 	"errors"
 	"fmt"
+	"math"
 	"math/big"
 	"sync"
 	"sync/atomic"
@@ -753,7 +754,7 @@ func (d *Downloader) findAncestor(p *peerConnection, remoteHeader *types.Header)
 	}
 
 	// Only attempt span search if local head is "close" to reported remote
-	if remoteHeight-localHeight <= uint64(MaxHeaderFetch) {
+	if math.Abs(float64(remoteHeight-localHeight)) <= float64(MaxHeaderFetch) {
 		a, err := d.findAncestorSpanSearch(p, remoteHeight, localHeight, floor)
 		if err == nil {
 			if a > localHeight {

--- a/eth/downloader/downloader.go
+++ b/eth/downloader/downloader.go
@@ -760,7 +760,8 @@ func (d *Downloader) findAncestor(p *peerConnection, remoteHeader *types.Header)
 				a = localHeight
 			}
 			return a, nil
-		} else if err != errNoAncestor {
+		}
+		if err != errNoAncestor {
 			return 0, err
 		}
 	}


### PR DESCRIPTION
- breaks these functions (SpanSearch, BinarySearch) off into their own functions
- only attempt any common ancestor negotiation if we're not at genesis
- try SpanSearch only if we're within `MaxHeaderFetch` range of the peer's reported head
