### PR TITLE
core/rawdb | remove unused math

### DIFF
--- a/core/rawdb/chain_iterator.go
+++ b/core/rawdb/chain_iterator.go
@@ -17,7 +17,6 @@
 package rawdb
 
 import (
-	"math"
 	"runtime"
 	"sync/atomic"
 	"time"


### PR DESCRIPTION
```
core/rawdb/chain_iterator.go:20:2: imported and not used: "math"
```