### PR TITLE
ethdb/leveldb: use timer instead of time.After

### DIFF
--- a/ethdb/leveldb/leveldb.go
+++ b/ethdb/leveldb/leveldb.go
@@ -248,6 +248,9 @@ func (db *Database) meter(refresh time.Duration) {
 		merr error
 	)
 
+	timer := time.NewTimer(refresh)
+	defer timer.Stop()
+
 	// Iterate ad infinitum and collect the stats
 	for i := 1; errc == nil && merr == nil; i++ {
 		// Retrieve the database stats
@@ -399,7 +402,8 @@ func (db *Database) meter(refresh time.Duration) {
 		select {
 		case errc = <-db.quitChan:
 			// Quit requesting, stop hammering the database
-		case <-time.After(refresh):
+		case <-timer.C:
+			timer.Reset(refresh)
 			// Timeout, gather a new set of stats
 		}
 	}


### PR DESCRIPTION
I think it should be a litter better use ```timer``` than ```time.After``` in long term loops.