### PR TITLE
metrics/prometheus: define TYPE once, add tests

### DIFF
--- a/metrics/prometheus/collector.go
+++ b/metrics/prometheus/collector.go
@@ -39,7 +39,7 @@ type collector struct {
 	buff *bytes.Buffer
 }
 
-// newCollector createa a new Prometheus metric aggregator.
+// newCollector creates a new Prometheus metric aggregator.
 func newCollector() *collector {
 	return &collector{
 		buff: &bytes.Buffer{},

--- a/metrics/prometheus/collector.go
+++ b/metrics/prometheus/collector.go
@@ -30,7 +30,7 @@ var (
 	typeCounterTpl         = "# TYPE %s counter\n"
 	typeSummaryTpl         = "# TYPE %s summary\n"
 	keyValueTpl            = "%s %v\n\n"
-	keyQuantileTagValueTpl = "%s {quantile=\"%s\"} %v\n\n"
+	keyQuantileTagValueTpl = "%s {quantile=\"%s\"} %v\n"
 )
 
 // collector is a collection of byte buffers that aggregate Prometheus reports
@@ -62,9 +62,11 @@ func (c *collector) addHistogram(name string, m metrics.Histogram) {
 	pv := []float64{0.5, 0.75, 0.95, 0.99, 0.999, 0.9999}
 	ps := m.Percentiles(pv)
 	c.writeSummaryCounter(name, m.Count())
+	c.buff.WriteString(fmt.Sprintf(typeSummaryTpl, mutateKey(name)))
 	for i := range pv {
 		c.writeSummaryPercentile(name, strconv.FormatFloat(pv[i], 'f', -1, 64), ps[i])
 	}
+	c.buff.WriteRune('\n')
 }
 
 func (c *collector) addMeter(name string, m metrics.Meter) {
@@ -75,9 +77,11 @@ func (c *collector) addTimer(name string, m metrics.Timer) {
 	pv := []float64{0.5, 0.75, 0.95, 0.99, 0.999, 0.9999}
 	ps := m.Percentiles(pv)
 	c.writeSummaryCounter(name, m.Count())
+	c.buff.WriteString(fmt.Sprintf(typeSummaryTpl, mutateKey(name)))
 	for i := range pv {
 		c.writeSummaryPercentile(name, strconv.FormatFloat(pv[i], 'f', -1, 64), ps[i])
 	}
+	c.buff.WriteRune('\n')
 }
 
 func (c *collector) addResettingTimer(name string, m metrics.ResettingTimer) {
@@ -87,9 +91,11 @@ func (c *collector) addResettingTimer(name string, m metrics.ResettingTimer) {
 	ps := m.Percentiles([]float64{50, 95, 99})
 	val := m.Values()
 	c.writeSummaryCounter(name, len(val))
+	c.buff.WriteString(fmt.Sprintf(typeSummaryTpl, mutateKey(name)))
 	c.writeSummaryPercentile(name, "0.50", ps[0])
 	c.writeSummaryPercentile(name, "0.95", ps[1])
 	c.writeSummaryPercentile(name, "0.99", ps[2])
+	c.buff.WriteRune('\n')
 }
 
 func (c *collector) writeGaugeCounter(name string, value interface{}) {
@@ -106,7 +112,6 @@ func (c *collector) writeSummaryCounter(name string, value interface{}) {
 
 func (c *collector) writeSummaryPercentile(name, p string, value interface{}) {
 	name = mutateKey(name)
-	c.buff.WriteString(fmt.Sprintf(typeSummaryTpl, name))
 	c.buff.WriteString(fmt.Sprintf(keyQuantileTagValueTpl, name, p, value))
 }
 

--- a/metrics/prometheus/collector_test.go
+++ b/metrics/prometheus/collector_test.go
@@ -1,0 +1,110 @@
+package prometheus
+
+import (
+	"os"
+	"testing"
+	"time"
+
+	"github.com/ethereum/go-ethereum/metrics"
+)
+
+func TestMain(m *testing.M) {
+	metrics.Enabled = true
+	os.Exit(m.Run())
+}
+
+func TestCollector(t *testing.T) {
+	c := newCollector()
+
+	counter := metrics.NewCounter()
+	counter.Inc(12345)
+	c.addCounter("test/counter", counter)
+
+	gauge := metrics.NewGauge()
+	gauge.Update(23456)
+	c.addGauge("test/gauge", gauge)
+
+	gaugeFloat64 := metrics.NewGaugeFloat64()
+	gaugeFloat64.Update(34567.89)
+	c.addGaugeFloat64("test/gauge_float64", gaugeFloat64)
+
+	histogram := metrics.NewHistogram(&metrics.NilSample{})
+	c.addHistogram("test/histogram", histogram)
+
+	meter := metrics.NewMeter()
+	defer meter.Stop()
+	meter.Mark(9999999)
+	c.addMeter("test/meter", meter)
+
+	timer := metrics.NewTimer()
+	defer timer.Stop()
+	timer.Update(20 * time.Millisecond)
+	timer.Update(21 * time.Millisecond)
+	timer.Update(22 * time.Millisecond)
+	timer.Update(120 * time.Millisecond)
+	timer.Update(23 * time.Millisecond)
+	timer.Update(24 * time.Millisecond)
+	c.addTimer("test/timer", timer)
+
+	resettingTimer := metrics.NewResettingTimer()
+	resettingTimer.Update(10 * time.Millisecond)
+	resettingTimer.Update(11 * time.Millisecond)
+	resettingTimer.Update(12 * time.Millisecond)
+	resettingTimer.Update(120 * time.Millisecond)
+	resettingTimer.Update(13 * time.Millisecond)
+	resettingTimer.Update(14 * time.Millisecond)
+	c.addResettingTimer("test/resetting_timer", resettingTimer.Snapshot())
+
+	emptyResettingTimer := metrics.NewResettingTimer().Snapshot()
+	c.addResettingTimer("test/empty_resetting_timer", emptyResettingTimer)
+
+	const expectedOutput = `# TYPE test_counter gauge
+test_counter 12345
+
+# TYPE test_gauge gauge
+test_gauge 23456
+
+# TYPE test_gauge_float64 gauge
+test_gauge_float64 34567.89
+
+# TYPE test_histogram_count counter
+test_histogram_count 0
+
+# TYPE test_histogram summary
+test_histogram {quantile="0.5"} 0
+test_histogram {quantile="0.75"} 0
+test_histogram {quantile="0.95"} 0
+test_histogram {quantile="0.99"} 0
+test_histogram {quantile="0.999"} 0
+test_histogram {quantile="0.9999"} 0
+
+# TYPE test_meter gauge
+test_meter 9999999
+
+# TYPE test_timer_count counter
+test_timer_count 6
+
+# TYPE test_timer summary
+test_timer {quantile="0.5"} 2.25e+07
+test_timer {quantile="0.75"} 4.8e+07
+test_timer {quantile="0.95"} 1.2e+08
+test_timer {quantile="0.99"} 1.2e+08
+test_timer {quantile="0.999"} 1.2e+08
+test_timer {quantile="0.9999"} 1.2e+08
+
+# TYPE test_resetting_timer_count counter
+test_resetting_timer_count 6
+
+# TYPE test_resetting_timer summary
+test_resetting_timer {quantile="0.50"} 12000000
+test_resetting_timer {quantile="0.95"} 120000000
+test_resetting_timer {quantile="0.99"} 120000000
+
+`
+	exp := c.buff.String()
+	if exp != expectedOutput {
+		t.Log("Expected Output:\n", expectedOutput)
+		t.Log("Actual Output:\n", exp)
+		t.Fatal("unexpected collector output")
+	}
+}


### PR DESCRIPTION
## Problem

The integrated Prometheus exporter generates output considered invalid by the `expfmt` parser of the Prometheus common library (v0.9.1):  https://pkg.go.dev/github.com/prometheus/common@v0.9.1

The output at latest master (0b63915430e5921722004345228c5239a8784d6b) looks like this for histograms.
```
# TYPE test_histogram summary
test_histogram {quantile="0.5"} 0

# TYPE test_histogram summary
test_histogram {quantile="0.75"} 0

# TYPE test_histogram summary
test_histogram {quantile="0.95"} 0
```

Applications dependent on `expfmt` package will fail to decode go-ethereum metrics.
This is an error trace seen in the latest InfluxDB 2.0 beta.
```
error	Unable to gather	{"log_id": "0MjOKNZG000", "error": "reading text format failed: text format parsing error in line 4: second TYPE line for metric name \"test_histogram\", or TYPE reported after samples"}
```

The behavior can be traced back to the following check, where parsing is aborted when a type definition is encountered a second time.

https://github.com/prometheus/common/blob/e8215224146358493faab0295ce364cd386223b9/expfmt/text_parse.go#L499-L502

## Fix

A minor change is introduced for histogram-like metrics, defining the type for histogram statistics only once. 

```
# TYPE test_histogram summary
test_histogram {quantile="0.5"} 0
test_histogram {quantile="0.75"} 0
test_histogram {quantile="0.95"} 0
```

Additionally, a test with 100% coverage of `prometheus/metrics/collector.go` is introduced.

It might make sense to parse the generated metrics using prometheus/common/expfmt in the same test, but I didn't want to add another dependency just for that.