### PR TITLE
internal/ethapi: return revert reason for eth_call

### DIFF
--- a/accounts/abi/bind/backends/simulated.go
+++ b/accounts/abi/bind/backends/simulated.go
@@ -509,13 +509,7 @@ func (b *SimulatedBackend) EstimateGas(ctx context.Context, call ethereum.CallMs
 		if failed {
 			if result != nil && result.Err != vm.ErrOutOfGas {
 				if len(result.Revert()) > 0 {
-					reason, err := abi.UnpackRevert(result.Revert())
-					if err == nil {
-						return 0, &revertError{
-							error:   errors.New("execution reverted"),
-							errData: reason,
-						}
-					}
+					return 0, newRevertError(result)
 				}
 				return 0, result.Err
 			}

--- a/accounts/abi/bind/backends/simulated.go
+++ b/accounts/abi/bind/backends/simulated.go
@@ -361,7 +361,7 @@ func (b *SimulatedBackend) CallContract(ctx context.Context, call ethereum.CallM
 		return nil, err
 	}
 	// If the result contains a revert reason, unpack and return it.
-	if res.Err != nil {
+	if res.Err != nil && len(res.Revert()) > 0 {
 		reason, err := abi.UnpackRevert(res.Revert())
 		if err != nil {
 			return nil, err
@@ -382,7 +382,7 @@ func (b *SimulatedBackend) PendingCallContract(ctx context.Context, call ethereu
 		return nil, err
 	}
 	// If the result contains a revert reason, unpack and return it.
-	if res.Err != nil {
+	if res.Err != nil && len(res.Revert()) > 0 {
 		reason, err := abi.UnpackRevert(res.Revert())
 		if err != nil {
 			return nil, err

--- a/accounts/abi/bind/backends/simulated.go
+++ b/accounts/abi/bind/backends/simulated.go
@@ -352,24 +352,27 @@ func newRevertError(result *core.ExecutionResult) *revertError {
 		err = fmt.Errorf("execution reverted: %v", reason)
 	}
 	return &revertError{
-		error:   err,
-		errData: hexutil.Encode(result.Revert()),
+		error:  err,
+		reason: hexutil.Encode(result.Revert()),
 	}
 }
 
+// revertError is an API error that encompassas an EVM revertal with JSON error
+// code and a binary data blob.
 type revertError struct {
 	error
-	errData interface{} // additional data
+	reason string // revert reason hex encoded
 }
 
-func (e revertError) ErrorCode() int {
-	// revert errors are execution errors.
-	// See: https://github.com/ethereum/wiki/wiki/JSON-RPC-Error-Codes-Improvement-Proposal
+// ErrorCode returns the JSON error code for a revertal.
+// See: https://github.com/ethereum/wiki/wiki/JSON-RPC-Error-Codes-Improvement-Proposal
+func (e *revertError) ErrorCode() int {
 	return 3
 }
 
-func (e revertError) ErrorData() interface{} {
-	return e.errData
+// ErrorData returns the hex encoded revert reason.
+func (e *revertError) ErrorData() interface{} {
+	return e.reason
 }
 
 // CallContract executes a contract call.

--- a/accounts/abi/bind/backends/simulated.go
+++ b/accounts/abi/bind/backends/simulated.go
@@ -352,24 +352,27 @@ func newRevertError(result *core.ExecutionResult) *revertError {
 		err = fmt.Errorf("execution reverted: %v", reason)
 	}
 	return &revertError{
-		error:   err,
-		errData: hexutil.Encode(result.Revert()),
+		error:  err,
+		reason: hexutil.Encode(result.Revert()),
 	}
 }
 
+// revertError is an API error that encompassas an EVM revertal with JSON error
+// code and a binary data blob.
 type revertError struct {
 	error
-	errData interface{} // additional data
+	reason string // revert reason hex encoded
 }
 
-func (e revertError) ErrorCode() int {
-	// revert errors are execution errors.
-	// See: https://github.com/ethereum/wiki/wiki/JSON-RPC-Error-Codes-Improvement-Proposal
+// Core returns the JSON error code for a revertal.
+// See: https://github.com/ethereum/wiki/wiki/JSON-RPC-Error-Codes-Improvement-Proposal
+func (e *revertError) Code() int {
 	return 3
 }
 
-func (e revertError) ErrorData() interface{} {
-	return e.errData
+// Data returns the hex encoded revert reason.
+func (e *revertError) Data() interface{} {
+	return e.reason
 }
 
 // CallContract executes a contract call.

--- a/accounts/abi/bind/backends/simulated.go
+++ b/accounts/abi/bind/backends/simulated.go
@@ -361,7 +361,7 @@ func (b *SimulatedBackend) CallContract(ctx context.Context, call ethereum.CallM
 		return nil, err
 	}
 	// If the result contains a revert reason, try to unpack and return it.
-	if res.Err != nil && len(res.Revert()) > 0 {
+	if len(res.Revert()) > 0 {
 		reason, err := abi.UnpackRevert(res.Revert())
 		if err == nil {
 			return nil, fmt.Errorf("execution reverted: %v", reason)
@@ -381,7 +381,7 @@ func (b *SimulatedBackend) PendingCallContract(ctx context.Context, call ethereu
 		return nil, err
 	}
 	// If the result contains a revert reason, try to unpack and return it.
-	if res.Err != nil && len(res.Revert()) > 0 {
+	if len(res.Revert()) > 0 {
 		reason, err := abi.UnpackRevert(res.Revert())
 		if err == nil {
 			return nil, fmt.Errorf("execution reverted: %v", reason)

--- a/accounts/abi/bind/backends/simulated.go
+++ b/accounts/abi/bind/backends/simulated.go
@@ -352,27 +352,24 @@ func newRevertError(result *core.ExecutionResult) *revertError {
 		err = fmt.Errorf("execution reverted: %v", reason)
 	}
 	return &revertError{
-		error:  err,
-		reason: hexutil.Encode(result.Revert()),
+		error:   err,
+		errData: hexutil.Encode(result.Revert()),
 	}
 }
 
-// revertError is an API error that encompassas an EVM revertal with JSON error
-// code and a binary data blob.
 type revertError struct {
 	error
-	reason string // revert reason hex encoded
+	errData interface{} // additional data
 }
 
-// Core returns the JSON error code for a revertal.
-// See: https://github.com/ethereum/wiki/wiki/JSON-RPC-Error-Codes-Improvement-Proposal
-func (e *revertError) Code() int {
+func (e revertError) ErrorCode() int {
+	// revert errors are execution errors.
+	// See: https://github.com/ethereum/wiki/wiki/JSON-RPC-Error-Codes-Improvement-Proposal
 	return 3
 }
 
-// Data returns the hex encoded revert reason.
-func (e *revertError) Data() interface{} {
-	return e.reason
+func (e revertError) ErrorData() interface{} {
+	return e.errData
 }
 
 // CallContract executes a contract call.

--- a/accounts/abi/bind/backends/simulated.go
+++ b/accounts/abi/bind/backends/simulated.go
@@ -360,6 +360,14 @@ func (b *SimulatedBackend) CallContract(ctx context.Context, call ethereum.CallM
 	if err != nil {
 		return nil, err
 	}
+	// If the result contains a revert reason, unpack and return it.
+	if res.Err != nil {
+		reason, err := abi.UnpackRevert(res.Revert())
+		if err != nil {
+			return nil, err
+		}
+		return nil, fmt.Errorf("execution reverted: %v", reason)
+	}
 	return res.Return(), nil
 }
 
@@ -372,6 +380,14 @@ func (b *SimulatedBackend) PendingCallContract(ctx context.Context, call ethereu
 	res, err := b.callContract(ctx, call, b.pendingBlock, b.pendingState)
 	if err != nil {
 		return nil, err
+	}
+	// If the result contains a revert reason, unpack and return it.
+	if res.Err != nil {
+		reason, err := abi.UnpackRevert(res.Revert())
+		if err != nil {
+			return nil, err
+		}
+		return nil, fmt.Errorf("execution reverted: %v", reason)
 	}
 	return res.Return(), nil
 }

--- a/accounts/abi/bind/backends/simulated.go
+++ b/accounts/abi/bind/backends/simulated.go
@@ -360,15 +360,14 @@ func (b *SimulatedBackend) CallContract(ctx context.Context, call ethereum.CallM
 	if err != nil {
 		return nil, err
 	}
-	// If the result contains a revert reason, unpack and return it.
+	// If the result contains a revert reason, try to unpack and return it.
 	if res.Err != nil && len(res.Revert()) > 0 {
 		reason, err := abi.UnpackRevert(res.Revert())
-		if err != nil {
-			return nil, err
+		if err == nil {
+			return nil, fmt.Errorf("execution reverted: %v", reason)
 		}
-		return nil, fmt.Errorf("execution reverted: %v", reason)
 	}
-	return res.Return(), nil
+	return res.Return(), res.Err
 }
 
 // PendingCallContract executes a contract call on the pending state.
@@ -381,15 +380,14 @@ func (b *SimulatedBackend) PendingCallContract(ctx context.Context, call ethereu
 	if err != nil {
 		return nil, err
 	}
-	// If the result contains a revert reason, unpack and return it.
+	// If the result contains a revert reason, try to unpack and return it.
 	if res.Err != nil && len(res.Revert()) > 0 {
 		reason, err := abi.UnpackRevert(res.Revert())
-		if err != nil {
-			return nil, err
+		if err == nil {
+			return nil, fmt.Errorf("execution reverted: %v", reason)
 		}
-		return nil, fmt.Errorf("execution reverted: %v", reason)
 	}
-	return res.Return(), nil
+	return res.Return(), res.Err
 }
 
 // PendingNonceAt implements PendingStateReader.PendingNonceAt, retrieving

--- a/accounts/abi/bind/backends/simulated.go
+++ b/accounts/abi/bind/backends/simulated.go
@@ -380,8 +380,8 @@ func (b *SimulatedBackend) CallContract(ctx context.Context, call ethereum.CallM
 		reason, err := abi.UnpackRevert(res.Revert())
 		if err == nil {
 			return nil, &revertError{
-				error:   errors.New("execution reverted"),
-				errData: reason,
+				error:   fmt.Errorf("execution reverted: %v", reason),
+				errData: res.Revert(),
 			}
 		}
 	}
@@ -403,8 +403,8 @@ func (b *SimulatedBackend) PendingCallContract(ctx context.Context, call ethereu
 		reason, err := abi.UnpackRevert(res.Revert())
 		if err == nil {
 			return nil, &revertError{
-				error:   errors.New("execution reverted"),
-				errData: reason,
+				error:   fmt.Errorf("execution reverted: %v", reason),
+				errData: res.Revert(),
 			}
 		}
 	}

--- a/accounts/abi/bind/backends/simulated_test.go
+++ b/accounts/abi/bind/backends/simulated_test.go
@@ -415,7 +415,7 @@ func TestSimulatedBackend_EstimateGas(t *testing.T) {
 			GasPrice: big.NewInt(0),
 			Value:    nil,
 			Data:     common.Hex2Bytes("d8b98391"),
-		}, 0, errors.New("execution reverted"), "revert reason"},
+		}, 0, errors.New("execution reverted: revert reason"), "0x08c379a00000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000000d72657665727420726561736f6e00000000000000000000000000000000000000"},
 
 		{"PureRevert", ethereum.CallMsg{
 			From:     addr,

--- a/accounts/abi/bind/backends/simulated_test.go
+++ b/accounts/abi/bind/backends/simulated_test.go
@@ -20,6 +20,7 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"fmt"
 	"math/big"
 	"strings"
 	"testing"
@@ -106,14 +107,18 @@ const deployedCode = `60806040526004361061003b576000357c010000000000000000000000
 // expected return value contains "hello world"
 var expectedReturn = []byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 32, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 11, 104, 101, 108, 108, 111, 32, 119, 111, 114, 108, 100, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}
 
+func simTestBackend(testAddr common.Address) *SimulatedBackend {
+	return NewSimulatedBackend(
+		core.GenesisAlloc{
+			testAddr: {Balance: big.NewInt(10000000000)},
+		}, 10000000,
+	)
+}
+
 func TestNewSimulatedBackend(t *testing.T) {
 	testAddr := crypto.PubkeyToAddress(testKey.PublicKey)
 	expectedBal := big.NewInt(10000000000)
-	sim := NewSimulatedBackend(
-		core.GenesisAlloc{
-			testAddr: {Balance: expectedBal},
-		}, 10000000,
-	)
+	sim := simTestBackend(testAddr)
 	defer sim.Close()
 
 	if sim.config != params.AllEthashProtocolChanges {
@@ -152,11 +157,7 @@ func TestSimulatedBackend_AdjustTime(t *testing.T) {
 func TestSimulatedBackend_BalanceAt(t *testing.T) {
 	testAddr := crypto.PubkeyToAddress(testKey.PublicKey)
 	expectedBal := big.NewInt(10000000000)
-	sim := NewSimulatedBackend(
-		core.GenesisAlloc{
-			testAddr: {Balance: expectedBal},
-		}, 10000000,
-	)
+	sim := simTestBackend(testAddr)
 	defer sim.Close()
 	bgCtx := context.Background()
 
@@ -229,11 +230,7 @@ func TestSimulatedBackend_BlockByNumber(t *testing.T) {
 func TestSimulatedBackend_NonceAt(t *testing.T) {
 	testAddr := crypto.PubkeyToAddress(testKey.PublicKey)
 
-	sim := NewSimulatedBackend(
-		core.GenesisAlloc{
-			testAddr: {Balance: big.NewInt(10000000000)},
-		}, 10000000,
-	)
+	sim := simTestBackend(testAddr)
 	defer sim.Close()
 	bgCtx := context.Background()
 
@@ -283,11 +280,7 @@ func TestSimulatedBackend_NonceAt(t *testing.T) {
 func TestSimulatedBackend_SendTransaction(t *testing.T) {
 	testAddr := crypto.PubkeyToAddress(testKey.PublicKey)
 
-	sim := NewSimulatedBackend(
-		core.GenesisAlloc{
-			testAddr: {Balance: big.NewInt(10000000000)},
-		}, 10000000,
-	)
+	sim := simTestBackend(testAddr)
 	defer sim.Close()
 	bgCtx := context.Background()
 
@@ -546,11 +539,7 @@ func TestSimulatedBackend_EstimateGasWithPrice(t *testing.T) {
 func TestSimulatedBackend_HeaderByHash(t *testing.T) {
 	testAddr := crypto.PubkeyToAddress(testKey.PublicKey)
 
-	sim := NewSimulatedBackend(
-		core.GenesisAlloc{
-			testAddr: {Balance: big.NewInt(10000000000)},
-		}, 10000000,
-	)
+	sim := simTestBackend(testAddr)
 	defer sim.Close()
 	bgCtx := context.Background()
 
@@ -571,11 +560,7 @@ func TestSimulatedBackend_HeaderByHash(t *testing.T) {
 func TestSimulatedBackend_HeaderByNumber(t *testing.T) {
 	testAddr := crypto.PubkeyToAddress(testKey.PublicKey)
 
-	sim := NewSimulatedBackend(
-		core.GenesisAlloc{
-			testAddr: {Balance: big.NewInt(10000000000)},
-		}, 10000000,
-	)
+	sim := simTestBackend(testAddr)
 	defer sim.Close()
 	bgCtx := context.Background()
 
@@ -622,11 +607,7 @@ func TestSimulatedBackend_HeaderByNumber(t *testing.T) {
 func TestSimulatedBackend_TransactionCount(t *testing.T) {
 	testAddr := crypto.PubkeyToAddress(testKey.PublicKey)
 
-	sim := NewSimulatedBackend(
-		core.GenesisAlloc{
-			testAddr: {Balance: big.NewInt(10000000000)},
-		}, 10000000,
-	)
+	sim := simTestBackend(testAddr)
 	defer sim.Close()
 	bgCtx := context.Background()
 	currentBlock, err := sim.BlockByNumber(bgCtx, nil)
@@ -676,11 +657,7 @@ func TestSimulatedBackend_TransactionCount(t *testing.T) {
 func TestSimulatedBackend_TransactionInBlock(t *testing.T) {
 	testAddr := crypto.PubkeyToAddress(testKey.PublicKey)
 
-	sim := NewSimulatedBackend(
-		core.GenesisAlloc{
-			testAddr: {Balance: big.NewInt(10000000000)},
-		}, 10000000,
-	)
+	sim := simTestBackend(testAddr)
 	defer sim.Close()
 	bgCtx := context.Background()
 
@@ -743,11 +720,7 @@ func TestSimulatedBackend_TransactionInBlock(t *testing.T) {
 func TestSimulatedBackend_PendingNonceAt(t *testing.T) {
 	testAddr := crypto.PubkeyToAddress(testKey.PublicKey)
 
-	sim := NewSimulatedBackend(
-		core.GenesisAlloc{
-			testAddr: {Balance: big.NewInt(10000000000)},
-		}, 10000000,
-	)
+	sim := simTestBackend(testAddr)
 	defer sim.Close()
 	bgCtx := context.Background()
 
@@ -809,11 +782,7 @@ func TestSimulatedBackend_PendingNonceAt(t *testing.T) {
 func TestSimulatedBackend_TransactionReceipt(t *testing.T) {
 	testAddr := crypto.PubkeyToAddress(testKey.PublicKey)
 
-	sim := NewSimulatedBackend(
-		core.GenesisAlloc{
-			testAddr: {Balance: big.NewInt(10000000000)},
-		}, 10000000,
-	)
+	sim := simTestBackend(testAddr)
 	defer sim.Close()
 	bgCtx := context.Background()
 
@@ -859,12 +828,7 @@ func TestSimulatedBackend_SuggestGasPrice(t *testing.T) {
 
 func TestSimulatedBackend_PendingCodeAt(t *testing.T) {
 	testAddr := crypto.PubkeyToAddress(testKey.PublicKey)
-	sim := NewSimulatedBackend(
-		core.GenesisAlloc{
-			testAddr: {Balance: big.NewInt(10000000000)},
-		},
-		10000000,
-	)
+	sim := simTestBackend(testAddr)
 	defer sim.Close()
 	bgCtx := context.Background()
 	code, err := sim.CodeAt(bgCtx, testAddr, nil)
@@ -900,12 +864,7 @@ func TestSimulatedBackend_PendingCodeAt(t *testing.T) {
 
 func TestSimulatedBackend_CodeAt(t *testing.T) {
 	testAddr := crypto.PubkeyToAddress(testKey.PublicKey)
-	sim := NewSimulatedBackend(
-		core.GenesisAlloc{
-			testAddr: {Balance: big.NewInt(10000000000)},
-		},
-		10000000,
-	)
+	sim := simTestBackend(testAddr)
 	defer sim.Close()
 	bgCtx := context.Background()
 	code, err := sim.CodeAt(bgCtx, testAddr, nil)
@@ -944,12 +903,7 @@ func TestSimulatedBackend_CodeAt(t *testing.T) {
 //   receipt{status=1 cgas=23949 bloom=00000000004000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000800000000000000000000000000000000000040200000000000000000000000000000000001000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000080000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000 logs=[log: b6818c8064f645cd82d99b59a1a267d6d61117ef [75fd880d39c1daf53b6547ab6cb59451fc6452d27caa90e5b6649dd8293b9eed] 000000000000000000000000376c47978271565f56deb45495afa69e59c16ab200000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000000060000000000000000000000000000000000000000000000000000000000000000158 9ae378b6d4409eada347a5dc0c180f186cb62dc68fcc0f043425eb917335aa28 0 95d429d309bb9d753954195fe2d69bd140b4ae731b9b5b605c34323de162cf00 0]}
 func TestSimulatedBackend_PendingAndCallContract(t *testing.T) {
 	testAddr := crypto.PubkeyToAddress(testKey.PublicKey)
-	sim := NewSimulatedBackend(
-		core.GenesisAlloc{
-			testAddr: {Balance: big.NewInt(10000000000)},
-		},
-		10000000,
-	)
+	sim := simTestBackend(testAddr)
 	defer sim.Close()
 	bgCtx := context.Background()
 
@@ -965,7 +919,7 @@ func TestSimulatedBackend_PendingAndCallContract(t *testing.T) {
 
 	input, err := parsed.Pack("receive", []byte("X"))
 	if err != nil {
-		t.Errorf("could pack receive function on contract: %v", err)
+		t.Errorf("could not pack receive function on contract: %v", err)
 	}
 
 	// make sure you can call the contract in pending state
@@ -1003,5 +957,86 @@ func TestSimulatedBackend_PendingAndCallContract(t *testing.T) {
 
 	if !bytes.Equal(res, expectedReturn) || !strings.Contains(string(res), "hello world") {
 		t.Errorf("response from calling contract was expected to be 'hello world' instead received %v", string(res))
+	}
+}
+
+func TestSimulatedBackend_CallContractRevert(t *testing.T) {
+	testAddr := crypto.PubkeyToAddress(testKey.PublicKey)
+	sim := simTestBackend(testAddr)
+	defer sim.Close()
+	bgCtx := context.Background()
+
+	reverterABI := `[{"inputs": [],"name": "noRevert","outputs": [],"stateMutability": "pure","type": "function"},{"inputs": [],"name": "revertASM","outputs": [],"stateMutability": "pure","type": "function"},{"inputs": [],"name": "revertNoString","outputs": [],"stateMutability": "pure","type": "function"},{"inputs": [],"name": "revertString","outputs": [],"stateMutability": "pure","type": "function"}]`
+	reverterBin := "608060405234801561001057600080fd5b506101d3806100206000396000f3fe608060405234801561001057600080fd5b506004361061004c5760003560e01c80634b409e01146100515780639b340e361461005b5780639bd6103714610065578063b7246fc11461006f575b600080fd5b610059610079565b005b6100636100ca565b005b61006d6100cf565b005b610077610145565b005b60006100c8576040517f08c379a0000000000000000000000000000000000000000000000000000000008152600401808060200182810382526000815260200160200191505060405180910390fd5b565b600080fd5b6000610143576040517f08c379a000000000000000000000000000000000000000000000000000000000815260040180806020018281038252600a8152602001807f736f6d65206572726f720000000000000000000000000000000000000000000081525060200191505060405180910390fd5b565b7f08c379a0000000000000000000000000000000000000000000000000000000006000526020600452600a6024527f736f6d65206572726f720000000000000000000000000000000000000000000060445260646000f3fea2646970667358221220cdd8af0609ec4996b7360c7c780bad5c735740c64b1fffc3445aa12d37f07cb164736f6c63430006070033"
+
+	parsed, err := abi.JSON(strings.NewReader(reverterABI))
+	if err != nil {
+		t.Errorf("could not get code at test addr: %v", err)
+	}
+	contractAuth := bind.NewKeyedTransactor(testKey)
+	addr, _, _, err := bind.DeployContract(contractAuth, parsed, common.FromHex(reverterBin), sim)
+	if err != nil {
+		t.Errorf("could not deploy contract: %v", err)
+	}
+
+	inputs := make(map[string]interface{}, 3)
+	inputs["revertASM"] = nil
+	inputs["revertNoString"] = ""
+	inputs["revertString"] = "some error"
+
+	call := make([]func([]byte) ([]byte, error), 2)
+	call[0] = func(input []byte) ([]byte, error) {
+		return sim.PendingCallContract(bgCtx, ethereum.CallMsg{
+			From: testAddr,
+			To:   &addr,
+			Data: input,
+		})
+	}
+	call[1] = func(input []byte) ([]byte, error) {
+		return sim.CallContract(bgCtx, ethereum.CallMsg{
+			From: testAddr,
+			To:   &addr,
+			Data: input,
+		}, nil)
+	}
+
+	// Run pending calls then commit
+	for _, cl := range call {
+		for key, val := range inputs {
+			input, err := parsed.Pack(key)
+			if err != nil {
+				t.Errorf("could not pack %v function on contract: %v", key, err)
+			}
+
+			res, err := cl(input)
+			if err == nil {
+				t.Errorf("call to %v was not reverted", key)
+			}
+			if res != nil {
+				t.Errorf("result from %v was not nil: %v", key, res)
+			}
+			if val != nil {
+				if err.Error() != fmt.Sprintf("execution reverted: %v", val) {
+					t.Errorf("error was malformed: got %v want %v", err, fmt.Errorf("execution reverted: %v", val))
+				}
+			} else {
+				// revert(0x0,0x0)
+				if err.Error() != "execution reverted" {
+					t.Errorf("error was malformed: got %v want %v", err, "execution reverted")
+				}
+			}
+		}
+		input, err := parsed.Pack("noRevert")
+		if err != nil {
+			t.Errorf("could not pack noRevert function on contract: %v", err)
+		}
+		res, err := cl(input)
+		if err != nil {
+			t.Error("call to noRevert was reverted")
+		}
+		if res == nil {
+			t.Errorf("result from noRevert was nil")
+		}
+		sim.Commit()
 	}
 }

--- a/accounts/abi/bind/backends/simulated_test.go
+++ b/accounts/abi/bind/backends/simulated_test.go
@@ -463,10 +463,10 @@ func TestSimulatedBackend_EstimateGas(t *testing.T) {
 				t.Fatalf("Expect error, want %v, got %v", c.expectError, err)
 			}
 			if c.expectData != nil {
-				if err, ok := err.(*revertError); !ok {
+				if rerr, ok := err.(*revertError); !ok {
 					t.Fatalf("Expect revert error, got %T", err)
-				} else if !reflect.DeepEqual(err.Data(), c.expectData) {
-					t.Fatalf("Error data mismatch, want %v, got %v", c.expectData, err.Data())
+				} else if !reflect.DeepEqual(rerr.ErrorData(), c.expectData) {
+					t.Fatalf("Error data mismatch, want %v, got %v", c.expectData, rerr.ErrorData())
 				}
 			}
 			continue

--- a/accounts/abi/bind/backends/simulated_test.go
+++ b/accounts/abi/bind/backends/simulated_test.go
@@ -463,10 +463,10 @@ func TestSimulatedBackend_EstimateGas(t *testing.T) {
 				t.Fatalf("Expect error, want %v, got %v", c.expectError, err)
 			}
 			if c.expectData != nil {
-				if rerr, ok := err.(*revertError); !ok {
+				if err, ok := err.(*revertError); !ok {
 					t.Fatalf("Expect revert error, got %T", err)
-				} else if !reflect.DeepEqual(rerr.ErrorData(), c.expectData) {
-					t.Fatalf("Error data mismatch, want %v, got %v", c.expectData, rerr.ErrorData())
+				} else if !reflect.DeepEqual(err.Data(), c.expectData) {
+					t.Fatalf("Error data mismatch, want %v, got %v", c.expectData, err.Data())
 				}
 			}
 			continue

--- a/accounts/abi/bind/backends/simulated_test.go
+++ b/accounts/abi/bind/backends/simulated_test.go
@@ -960,6 +960,31 @@ func TestSimulatedBackend_PendingAndCallContract(t *testing.T) {
 	}
 }
 
+// This test is based on the following contract:
+/*
+contract Reverter {
+    function revertString() public pure{
+        require(false, "some error");
+    }
+    function revertNoString() public pure {
+        require(false, "");
+    }
+    function revertASM() public pure {
+        assembly {
+            revert(0x0, 0x0)
+        }
+    }
+    function noRevert() public pure {
+        assembly {
+            // Assembles something that looks like require(false, "some error") but is not reverted
+            mstore(0x0, 0x08c379a000000000000000000000000000000000000000000000000000000000)
+            mstore(0x4, 0x0000000000000000000000000000000000000000000000000000000000000020)
+            mstore(0x24, 0x000000000000000000000000000000000000000000000000000000000000000a)
+            mstore(0x44, 0x736f6d65206572726f7200000000000000000000000000000000000000000000)
+            return(0x0, 0x64)
+        }
+    }
+}*/
 func TestSimulatedBackend_CallContractRevert(t *testing.T) {
 	testAddr := crypto.PubkeyToAddress(testKey.PublicKey)
 	sim := simTestBackend(testAddr)

--- a/accounts/abi/bind/backends/simulated_test.go
+++ b/accounts/abi/bind/backends/simulated_test.go
@@ -463,10 +463,10 @@ func TestSimulatedBackend_EstimateGas(t *testing.T) {
 				t.Fatalf("Expect error, want %v, got %v", c.expectError, err)
 			}
 			if c.expectData != nil {
-				if rerr, ok := err.(*revertError); !ok {
+				if err, ok := err.(*revertError); !ok {
 					t.Fatalf("Expect revert error, got %T", err)
-				} else if !reflect.DeepEqual(rerr.ErrorData(), c.expectData) {
-					t.Fatalf("Error data mismatch, want %v, got %v", c.expectData, rerr.ErrorData())
+				} else if !reflect.DeepEqual(err.ErrorData(), c.expectData) {
+					t.Fatalf("Error data mismatch, want %v, got %v", c.expectData, err.ErrorData())
 				}
 			}
 			continue

--- a/accounts/abi/bind/backends/simulated_test.go
+++ b/accounts/abi/bind/backends/simulated_test.go
@@ -1053,8 +1053,8 @@ func TestSimulatedBackend_CallContractRevert(t *testing.T) {
 				if !ok {
 					t.Errorf("expect revert error")
 				}
-				if !reflect.DeepEqual(rerr.ErrorData(), val) {
-					t.Errorf("error was malformed: got %v want %v", rerr.ErrorData(), val)
+				if rerr.Error() != "execution reverted: "+val.(string) {
+					t.Errorf("error was malformed: got %v want %v", rerr.Error(), val)
 				}
 			} else {
 				// revert(0x0,0x0)

--- a/console/bridge.go
+++ b/console/bridge.go
@@ -435,6 +435,8 @@ func (b *bridge) Send(call jsre.Call) (goja.Value, error) {
 			}
 		case rpc.Error:
 			setError(resp, err.ErrorCode(), err.Error())
+		case rpc.DataError:
+			resp.Set("error", map[string]interface{}{"code": -32603, "message": err.Error(), "data": err.ErrorData()})
 		default:
 			setError(resp, -32603, err.Error())
 		}

--- a/console/bridge.go
+++ b/console/bridge.go
@@ -434,9 +434,11 @@ func (b *bridge) Send(call jsre.Call) (goja.Value, error) {
 				}
 			}
 		case rpc.Error:
-			setError(resp, err.ErrorCode(), err.Error())
-		case rpc.DataError:
-			resp.Set("error", map[string]interface{}{"code": -32603, "message": err.Error(), "data": err.ErrorData()})
+			errMap := map[string]interface{}{"code": err.ErrorCode(), "message": err.Error()}
+			if dataErr, ok := err.(rpc.DataError); ok {
+				errMap["data"] = dataErr.ErrorData()
+			}
+			resp.Set("error", errMap)
 		default:
 			setError(resp, -32603, err.Error())
 		}

--- a/console/bridge.go
+++ b/console/bridge.go
@@ -413,9 +413,7 @@ func (b *bridge) Send(call jsre.Call) (goja.Value, error) {
 		resp.Set("id", req.ID)
 
 		var result json.RawMessage
-		err = b.client.Call(&result, req.Method, req.Params...)
-		switch err := err.(type) {
-		case nil:
+		if err = b.client.Call(&result, req.Method, req.Params...); err == nil {
 			if result == nil {
 				// Special case null because it is decoded as an empty
 				// raw message for some reason.
@@ -433,18 +431,19 @@ func (b *bridge) Send(call jsre.Call) (goja.Value, error) {
 					resp.Set("result", resultVal)
 				}
 			}
-		case rpc.Error:
-			if dataErr, ok := err.(rpc.DataError); ok {
-				setError(resp, err.ErrorCode(), err.Error(), dataErr.ErrorData())
-			} else {
-				setError(resp, err.ErrorCode(), err.Error(), nil)
+		} else {
+			code := -32603
+			var data interface{}
+			if err, ok := err.(rpc.Error); ok {
+				code = err.ErrorCode()
 			}
-		default:
-			setError(resp, -32603, err.Error(), nil)
+			if err, ok := err.(rpc.DataError); ok {
+				data = err.ErrorData()
+			}
+			setError(resp, code, err.Error(), data)
 		}
 		resps = append(resps, resp)
 	}
-
 	// Return the responses either to the callback (if supplied)
 	// or directly as the return value.
 	var result goja.Value

--- a/graphql/graphql.go
+++ b/graphql/graphql.go
@@ -23,7 +23,6 @@ import (
 	"time"
 
 	"github.com/ethereum/go-ethereum"
-	"github.com/ethereum/go-ethereum/accounts/abi"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/core/rawdb"
@@ -812,16 +811,9 @@ func (b *Block) Call(ctx context.Context, args struct {
 	if result.Failed() {
 		status = 0
 	}
-	data := result.Return()
-	// If the result contains a revert reason, try to unpack and return it.
-	if len(result.Revert()) > 0 {
-		reason, err := abi.UnpackRevert(result.Revert())
-		if err == nil {
-			data = []byte(reason)
-		}
-	}
+	//TODO(rjl493456442, MariusVanDerWijden) return revert reason here once the spec supports an error reason.
 	return &CallResult{
-		data:    data,
+		data:    result.Return(),
 		gasUsed: hexutil.Uint64(result.UsedGas),
 		status:  status,
 	}, nil
@@ -889,16 +881,9 @@ func (p *Pending) Call(ctx context.Context, args struct {
 	if result.Failed() {
 		status = 0
 	}
-	data := result.Return()
-	// If the result contains a revert reason, try to unpack and return it.
-	if len(result.Revert()) > 0 {
-		reason, err := abi.UnpackRevert(result.Revert())
-		if err == nil {
-			data = []byte(reason)
-		}
-	}
+	//TODO(rjl493456442, MariusVanDerWijden) return revert reason here once the spec supports an error reason.
 	return &CallResult{
-		data:    data,
+		data:    result.Return(),
 		gasUsed: hexutil.Uint64(result.UsedGas),
 		status:  status,
 	}, nil

--- a/graphql/graphql.go
+++ b/graphql/graphql.go
@@ -813,7 +813,7 @@ func (b *Block) Call(ctx context.Context, args struct {
 	}
 	//TODO(rjl493456442, MariusVanDerWijden) return revert reason here once the spec supports an error reason.
 	return &CallResult{
-		data:    result.Return(),
+		data:    result.ReturnData,
 		gasUsed: hexutil.Uint64(result.UsedGas),
 		status:  status,
 	}, nil
@@ -883,7 +883,7 @@ func (p *Pending) Call(ctx context.Context, args struct {
 	}
 	//TODO(rjl493456442, MariusVanDerWijden) return revert reason here once the spec supports an error reason.
 	return &CallResult{
-		data:    result.Return(),
+		data:    result.ReturnData,
 		gasUsed: hexutil.Uint64(result.UsedGas),
 		status:  status,
 	}, nil

--- a/graphql/graphql.go
+++ b/graphql/graphql.go
@@ -811,7 +811,7 @@ func (b *Block) Call(ctx context.Context, args struct {
 	if result.Failed() {
 		status = 0
 	}
-	//TODO(rjl493456442, MariusVanDerWijden) return revert reason here once the spec supports an error reason.
+
 	return &CallResult{
 		data:    result.ReturnData,
 		gasUsed: hexutil.Uint64(result.UsedGas),
@@ -881,7 +881,7 @@ func (p *Pending) Call(ctx context.Context, args struct {
 	if result.Failed() {
 		status = 0
 	}
-	//TODO(rjl493456442, MariusVanDerWijden) return revert reason here once the spec supports an error reason.
+
 	return &CallResult{
 		data:    result.ReturnData,
 		gasUsed: hexutil.Uint64(result.UsedGas),

--- a/graphql/graphql.go
+++ b/graphql/graphql.go
@@ -23,6 +23,7 @@ import (
 	"time"
 
 	"github.com/ethereum/go-ethereum"
+	"github.com/ethereum/go-ethereum/accounts/abi"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/core/rawdb"
@@ -811,8 +812,16 @@ func (b *Block) Call(ctx context.Context, args struct {
 	if result.Failed() {
 		status = 0
 	}
+	data := result.Return()
+	// If the result contains a revert reason, try to unpack and return it.
+	if len(result.Revert()) > 0 {
+		reason, err := abi.UnpackRevert(result.Revert())
+		if err == nil {
+			data = []byte(reason)
+		}
+	}
 	return &CallResult{
-		data:    result.Return(),
+		data:    data,
 		gasUsed: hexutil.Uint64(result.UsedGas),
 		status:  status,
 	}, nil
@@ -880,8 +889,16 @@ func (p *Pending) Call(ctx context.Context, args struct {
 	if result.Failed() {
 		status = 0
 	}
+	data := result.Return()
+	// If the result contains a revert reason, try to unpack and return it.
+	if len(result.Revert()) > 0 {
+		reason, err := abi.UnpackRevert(result.Revert())
+		if err == nil {
+			data = []byte(reason)
+		}
+	}
 	return &CallResult{
-		data:    result.Return(),
+		data:    data,
 		gasUsed: hexutil.Uint64(result.UsedGas),
 		status:  status,
 	}, nil

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -861,15 +861,14 @@ func DoCall(ctx context.Context, b Backend, args CallArgs, blockNrOrHash rpc.Blo
 	if evm.Cancelled() {
 		return nil, fmt.Errorf("execution aborted (timeout = %v)", timeout)
 	}
-	// If the result contains a revert reason, unpack and return it.
-	if result.Err != nil && len(result.Revert()) > 0 {
-		reason, err := abi.UnpackRevert(result.Revert())
-		if err != nil {
-			return nil, err
+	// If the result contains a revert reason, try to unpack and return it.
+	if res.Err != nil && len(res.Revert()) > 0 {
+		reason, err := abi.UnpackRevert(res.Revert())
+		if err == nil {
+			return nil, fmt.Errorf("execution reverted: %v", reason)
 		}
-		return nil, fmt.Errorf("execution reverted: %v", reason)
 	}
-	return result, err
+	return result, res.Err
 }
 
 // Call executes the given transaction on the state for the given block number.

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -868,7 +868,6 @@ var _ rpc.DataError = (*revertError)(nil)
 
 type revertError struct {
 	err     string      // The error string
-	code    int         // optional error code
 	errData interface{} // additional data
 }
 
@@ -877,7 +876,9 @@ func (e revertError) Error() string {
 }
 
 func (e revertError) ErrorCode() int {
-	return e.code
+	// revert errors are execution errors.
+	// See: https://github.com/ethereum/wiki/wiki/JSON-RPC-Error-Codes-Improvement-Proposal
+	return 3
 }
 
 func (e revertError) ErrorData() interface{} {

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -862,13 +862,13 @@ func DoCall(ctx context.Context, b Backend, args CallArgs, blockNrOrHash rpc.Blo
 		return nil, fmt.Errorf("execution aborted (timeout = %v)", timeout)
 	}
 	// If the result contains a revert reason, try to unpack and return it.
-	if res.Err != nil && len(res.Revert()) > 0 {
-		reason, err := abi.UnpackRevert(res.Revert())
+	if len(result.Revert()) > 0 {
+		reason, err := abi.UnpackRevert(result.Revert())
 		if err == nil {
 			return nil, fmt.Errorf("execution reverted: %v", reason)
 		}
 	}
-	return result, res.Err
+	return result, result.Err
 }
 
 // Call executes the given transaction on the state for the given block number.

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -868,7 +868,7 @@ func DoCall(ctx context.Context, b Backend, args CallArgs, blockNrOrHash rpc.Blo
 			return nil, fmt.Errorf("execution reverted: %v", reason)
 		}
 	}
-	return result, result.Err
+	return result, err
 }
 
 // Call executes the given transaction on the state for the given block number.

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -862,7 +862,7 @@ func DoCall(ctx context.Context, b Backend, args CallArgs, blockNrOrHash rpc.Blo
 		return nil, fmt.Errorf("execution aborted (timeout = %v)", timeout)
 	}
 	// If the result contains a revert reason, unpack and return it.
-	if result.Err != nil {
+	if result.Err != nil && len(result.Revert()) > 0 {
 		reason, err := abi.UnpackRevert(result.Revert())
 		if err != nil {
 			return nil, err

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -861,13 +861,6 @@ func DoCall(ctx context.Context, b Backend, args CallArgs, blockNrOrHash rpc.Blo
 	if evm.Cancelled() {
 		return nil, fmt.Errorf("execution aborted (timeout = %v)", timeout)
 	}
-	// If the result contains a revert reason, try to unpack and return it.
-	if len(result.Revert()) > 0 {
-		reason, err := abi.UnpackRevert(result.Revert())
-		if err == nil {
-			return nil, fmt.Errorf("execution reverted: %v", reason)
-		}
-	}
 	return result, err
 }
 
@@ -885,6 +878,13 @@ func (s *PublicBlockChainAPI) Call(ctx context.Context, args CallArgs, blockNrOr
 	result, err := DoCall(ctx, s.b, args, blockNrOrHash, accounts, vm.Config{}, 5*time.Second, s.b.RPCGasCap())
 	if err != nil {
 		return nil, err
+	}
+	// If the result contains a revert reason, try to unpack and return it.
+	if len(result.Revert()) > 0 {
+		reason, err := abi.UnpackRevert(result.Revert())
+		if err == nil {
+			return nil, fmt.Errorf("execution reverted: %v", reason)
+		}
 	}
 	return result.Return(), nil
 }

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -869,7 +869,7 @@ func DoCall(ctx context.Context, b Backend, args CallArgs, blockNrOrHash rpc.Blo
 		}
 		return nil, fmt.Errorf("execution reverted: %v", reason)
 	}
-	return result, nil
+	return result, err
 }
 
 // Call executes the given transaction on the state for the given block number.

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -868,11 +868,16 @@ var _ rpc.DataError = (*revertError)(nil)
 
 type revertError struct {
 	err     string      // The error string
+	code    int         // optional error code
 	errData interface{} // additional data
 }
 
 func (e revertError) Error() string {
 	return e.err
+}
+
+func (e revertError) ErrorCode() int {
+	return e.code
 }
 
 func (e revertError) ErrorData() interface{} {

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -871,24 +871,27 @@ func newRevertError(result *core.ExecutionResult) *revertError {
 		err = fmt.Errorf("execution reverted: %v", reason)
 	}
 	return &revertError{
-		error:   err,
-		errData: hexutil.Encode(result.Revert()),
+		error:  err,
+		reason: hexutil.Encode(result.Revert()),
 	}
 }
 
+// revertError is an API error that encompassas an EVM revertal with JSON error
+// code and a binary data blob.
 type revertError struct {
 	error
-	errData interface{} // additional data
+	reason string // revert reason hex encoded
 }
 
-func (e revertError) ErrorCode() int {
-	// revert errors are execution errors.
-	// See: https://github.com/ethereum/wiki/wiki/JSON-RPC-Error-Codes-Improvement-Proposal
+// Core returns the JSON error code for a revertal.
+// See: https://github.com/ethereum/wiki/wiki/JSON-RPC-Error-Codes-Improvement-Proposal
+func (e *revertError) Code() int {
 	return 3
 }
 
-func (e revertError) ErrorData() interface{} {
-	return e.errData
+// Data returns the hex encoded revert reason.
+func (e *revertError) Data() interface{} {
+	return e.reason
 }
 
 // Call executes the given transaction on the state for the given block number.

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -871,27 +871,24 @@ func newRevertError(result *core.ExecutionResult) *revertError {
 		err = fmt.Errorf("execution reverted: %v", reason)
 	}
 	return &revertError{
-		error:  err,
-		reason: hexutil.Encode(result.Revert()),
+		error:   err,
+		errData: hexutil.Encode(result.Revert()),
 	}
 }
 
-// revertError is an API error that encompassas an EVM revertal with JSON error
-// code and a binary data blob.
 type revertError struct {
 	error
-	reason string // revert reason hex encoded
+	errData interface{} // additional data
 }
 
-// Core returns the JSON error code for a revertal.
-// See: https://github.com/ethereum/wiki/wiki/JSON-RPC-Error-Codes-Improvement-Proposal
-func (e *revertError) Code() int {
+func (e revertError) ErrorCode() int {
+	// revert errors are execution errors.
+	// See: https://github.com/ethereum/wiki/wiki/JSON-RPC-Error-Codes-Improvement-Proposal
 	return 3
 }
 
-// Data returns the hex encoded revert reason.
-func (e *revertError) Data() interface{} {
-	return e.reason
+func (e revertError) ErrorData() interface{} {
+	return e.errData
 }
 
 // Call executes the given transaction on the state for the given block number.

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -871,24 +871,27 @@ func newRevertError(result *core.ExecutionResult) *revertError {
 		err = fmt.Errorf("execution reverted: %v", reason)
 	}
 	return &revertError{
-		error:   err,
-		errData: hexutil.Encode(result.Revert()),
+		error:  err,
+		reason: hexutil.Encode(result.Revert()),
 	}
 }
 
+// revertError is an API error that encompassas an EVM revertal with JSON error
+// code and a binary data blob.
 type revertError struct {
 	error
-	errData interface{} // additional data
+	reason string // revert reason hex encoded
 }
 
-func (e revertError) ErrorCode() int {
-	// revert errors are execution errors.
-	// See: https://github.com/ethereum/wiki/wiki/JSON-RPC-Error-Codes-Improvement-Proposal
+// ErrorCode returns the JSON error code for a revertal.
+// See: https://github.com/ethereum/wiki/wiki/JSON-RPC-Error-Codes-Improvement-Proposal
+func (e *revertError) ErrorCode() int {
 	return 3
 }
 
-func (e revertError) ErrorData() interface{} {
-	return e.errData
+// ErrorData returns the hex encoded revert reason.
+func (e *revertError) ErrorData() interface{} {
+	return e.reason
 }
 
 // Call executes the given transaction on the state for the given block number.

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -899,8 +899,8 @@ func (s *PublicBlockChainAPI) Call(ctx context.Context, args CallArgs, blockNrOr
 		reason, err := abi.UnpackRevert(result.Revert())
 		if err == nil {
 			return nil, &revertError{
-				error:   errors.New("execution reverted"),
-				errData: reason,
+				error:   fmt.Errorf("execution reverted: %v", reason),
+				errData: result.Revert(),
 			}
 		}
 	}
@@ -1003,8 +1003,8 @@ func DoEstimateGas(ctx context.Context, b Backend, args CallArgs, blockNrOrHash 
 					reason, err := abi.UnpackRevert(result.Revert())
 					if err == nil {
 						return 0, &revertError{
-							error:   errors.New("execution reverted"),
-							errData: reason,
+							error:   fmt.Errorf("execution reverted: %v", reason),
+							errData: result.Revert(),
 						}
 					}
 				}

--- a/rpc/client_test.go
+++ b/rpc/client_test.go
@@ -66,6 +66,33 @@ func TestClientResponseType(t *testing.T) {
 	}
 }
 
+// This test checks that server-returned errors with code and data come out of Client.Call.
+func TestClientErrorData(t *testing.T) {
+	server := newTestServer()
+	defer server.Stop()
+	client := DialInProc(server)
+	defer client.Close()
+
+	var resp interface{}
+	err := client.Call(&resp, "test_returnError")
+	if err == nil {
+		t.Fatal("expected error")
+	}
+
+	// Check code.
+	if e, ok := err.(Error); !ok {
+		t.Fatalf("client did not return rpc.Error, got %#v", e)
+	} else if e.ErrorCode() != (testError{}.ErrorCode()) {
+		t.Fatalf("wrong error code %d, want %d", e.ErrorCode(), testError{}.ErrorCode())
+	}
+	// Check data.
+	if e, ok := err.(DataError); !ok {
+		t.Fatalf("client did not return rpc.DataError, got %#v", e)
+	} else if e.ErrorData() != (testError{}.ErrorData()) {
+		t.Fatalf("wrong error data %#v, want %#v", e.ErrorData(), testError{}.ErrorData())
+	}
+}
+
 func TestClientBatchRequest(t *testing.T) {
 	server := newTestServer()
 	defer server.Stop()

--- a/rpc/errors.go
+++ b/rpc/errors.go
@@ -18,6 +18,15 @@ package rpc
 
 import "fmt"
 
+var (
+	_ Error = new(methodNotFoundError)
+	_ Error = new(subscriptionNotFoundError)
+	_ Error = new(parseError)
+	_ Error = new(invalidRequestError)
+	_ Error = new(invalidMessageError)
+	_ Error = new(invalidParamsError)
+)
+
 const defaultErrorCode = -32000
 
 type methodNotFoundError struct{ method string }

--- a/rpc/errors.go
+++ b/rpc/errors.go
@@ -18,20 +18,27 @@ package rpc
 
 import "fmt"
 
+var (
+	_ ErrorWithCode = new(methodNotFoundError)
+	_ ErrorWithCode = new(subscriptionNotFoundError)
+	_ ErrorWithCode = new(parseError)
+	_ ErrorWithCode = new(invalidRequestError)
+	_ ErrorWithCode = new(invalidMessageError)
+	_ ErrorWithCode = new(invalidParamsError)
+)
+
 const defaultErrorCode = -32000
 
 type methodNotFoundError struct{ method string }
 
-func (e *methodNotFoundError) ErrorCode() int { return -32601 }
-
+func (e *methodNotFoundError) Code() int { return -32601 }
 func (e *methodNotFoundError) Error() string {
 	return fmt.Sprintf("the method %s does not exist/is not available", e.method)
 }
 
 type subscriptionNotFoundError struct{ namespace, subscription string }
 
-func (e *subscriptionNotFoundError) ErrorCode() int { return -32601 }
-
+func (e *subscriptionNotFoundError) Code() int { return -32601 }
 func (e *subscriptionNotFoundError) Error() string {
 	return fmt.Sprintf("no %q subscription in %s namespace", e.subscription, e.namespace)
 }
@@ -39,27 +46,23 @@ func (e *subscriptionNotFoundError) Error() string {
 // Invalid JSON was received by the server.
 type parseError struct{ message string }
 
-func (e *parseError) ErrorCode() int { return -32700 }
-
+func (e *parseError) Code() int     { return -32700 }
 func (e *parseError) Error() string { return e.message }
 
 // received message isn't a valid request
 type invalidRequestError struct{ message string }
 
-func (e *invalidRequestError) ErrorCode() int { return -32600 }
-
+func (e *invalidRequestError) Code() int     { return -32600 }
 func (e *invalidRequestError) Error() string { return e.message }
 
 // received message is invalid
 type invalidMessageError struct{ message string }
 
-func (e *invalidMessageError) ErrorCode() int { return -32700 }
-
+func (e *invalidMessageError) Code() int     { return -32700 }
 func (e *invalidMessageError) Error() string { return e.message }
 
 // unable to decode supplied params, or an invalid number of parameters
 type invalidParamsError struct{ message string }
 
-func (e *invalidParamsError) ErrorCode() int { return -32602 }
-
+func (e *invalidParamsError) Code() int     { return -32602 }
 func (e *invalidParamsError) Error() string { return e.message }

--- a/rpc/errors.go
+++ b/rpc/errors.go
@@ -18,27 +18,20 @@ package rpc
 
 import "fmt"
 
-var (
-	_ ErrorWithCode = new(methodNotFoundError)
-	_ ErrorWithCode = new(subscriptionNotFoundError)
-	_ ErrorWithCode = new(parseError)
-	_ ErrorWithCode = new(invalidRequestError)
-	_ ErrorWithCode = new(invalidMessageError)
-	_ ErrorWithCode = new(invalidParamsError)
-)
-
 const defaultErrorCode = -32000
 
 type methodNotFoundError struct{ method string }
 
-func (e *methodNotFoundError) Code() int { return -32601 }
+func (e *methodNotFoundError) ErrorCode() int { return -32601 }
+
 func (e *methodNotFoundError) Error() string {
 	return fmt.Sprintf("the method %s does not exist/is not available", e.method)
 }
 
 type subscriptionNotFoundError struct{ namespace, subscription string }
 
-func (e *subscriptionNotFoundError) Code() int { return -32601 }
+func (e *subscriptionNotFoundError) ErrorCode() int { return -32601 }
+
 func (e *subscriptionNotFoundError) Error() string {
 	return fmt.Sprintf("no %q subscription in %s namespace", e.subscription, e.namespace)
 }
@@ -46,23 +39,27 @@ func (e *subscriptionNotFoundError) Error() string {
 // Invalid JSON was received by the server.
 type parseError struct{ message string }
 
-func (e *parseError) Code() int     { return -32700 }
+func (e *parseError) ErrorCode() int { return -32700 }
+
 func (e *parseError) Error() string { return e.message }
 
 // received message isn't a valid request
 type invalidRequestError struct{ message string }
 
-func (e *invalidRequestError) Code() int     { return -32600 }
+func (e *invalidRequestError) ErrorCode() int { return -32600 }
+
 func (e *invalidRequestError) Error() string { return e.message }
 
 // received message is invalid
 type invalidMessageError struct{ message string }
 
-func (e *invalidMessageError) Code() int     { return -32700 }
+func (e *invalidMessageError) ErrorCode() int { return -32700 }
+
 func (e *invalidMessageError) Error() string { return e.message }
 
 // unable to decode supplied params, or an invalid number of parameters
 type invalidParamsError struct{ message string }
 
-func (e *invalidParamsError) Code() int     { return -32602 }
+func (e *invalidParamsError) ErrorCode() int { return -32602 }
+
 func (e *invalidParamsError) Error() string { return e.message }

--- a/rpc/handler.go
+++ b/rpc/handler.go
@@ -296,10 +296,16 @@ func (h *handler) handleCallMsg(ctx *callProc, msg *jsonrpcMessage) *jsonrpcMess
 		return nil
 	case msg.isCall():
 		resp := h.handleCall(ctx, msg)
+		var ctx []interface{}
+		ctx = append(ctx, "reqid", idForLog{msg.ID}, "t", time.Since(start))
 		if resp.Error != nil {
-			h.log.Warn("Served "+msg.Method, "reqid", idForLog{msg.ID}, "t", time.Since(start), "err", resp.Error.Message)
+			ctx = append(ctx, "err", resp.Error.Message)
+			if resp.Error.Data != nil {
+				ctx = append(ctx, "errdata", resp.Error.Data)
+			}
+			h.log.Warn("Served "+msg.Method, ctx...)
 		} else {
-			h.log.Debug("Served "+msg.Method, "reqid", idForLog{msg.ID}, "t", time.Since(start))
+			h.log.Debug("Served "+msg.Method, ctx...)
 		}
 		return resp
 	case msg.hasValidID():

--- a/rpc/handler.go
+++ b/rpc/handler.go
@@ -301,7 +301,7 @@ func (h *handler) handleCallMsg(ctx *callProc, msg *jsonrpcMessage) *jsonrpcMess
 		if resp.Error != nil {
 			ctx = append(ctx, "err", resp.Error.Message)
 			if resp.Error.Data != nil {
-				ctx = append(ctx, "errdata", resp.Error.Data)
+				ctx = append(ctx, "data", resp.Error.Data)
 			}
 			h.log.Warn("Served "+msg.Method, ctx...)
 		} else {

--- a/rpc/handler.go
+++ b/rpc/handler.go
@@ -301,7 +301,7 @@ func (h *handler) handleCallMsg(ctx *callProc, msg *jsonrpcMessage) *jsonrpcMess
 		if resp.Error != nil {
 			ctx = append(ctx, "err", resp.Error.Message)
 			if resp.Error.Data != nil {
-				ctx = append(ctx, "data", resp.Error.Data)
+				ctx = append(ctx, "errdata", resp.Error.Data)
 			}
 			h.log.Warn("Served "+msg.Method, ctx...)
 		} else {

--- a/rpc/json.go
+++ b/rpc/json.go
@@ -115,6 +115,10 @@ func errorMessage(err error) *jsonrpcMessage {
 	if ok {
 		msg.Error.Code = ec.ErrorCode()
 	}
+	de, ok := err.(DataError)
+	if ok {
+		msg.Error.Data = de.ErrorData()
+	}
 	return msg
 }
 

--- a/rpc/json.go
+++ b/rpc/json.go
@@ -139,6 +139,10 @@ func (err *jsonError) ErrorCode() int {
 	return err.Code
 }
 
+func (err *jsonError) ErrorData() interface{} {
+	return err.Data
+}
+
 // Conn is a subset of the methods of net.Conn which are sufficient for ServerCodec.
 type Conn interface {
 	io.ReadWriteCloser

--- a/rpc/json.go
+++ b/rpc/json.go
@@ -111,13 +111,13 @@ func errorMessage(err error) *jsonrpcMessage {
 		Code:    defaultErrorCode,
 		Message: err.Error(),
 	}}
-	ec, ok := err.(Error)
+	ec, ok := err.(ErrorWithCode)
 	if ok {
-		msg.Error.Code = ec.ErrorCode()
+		msg.Error.Code = ec.Code()
 	}
-	de, ok := err.(DataError)
+	de, ok := err.(ErrorWithData)
 	if ok {
-		msg.Error.Data = de.ErrorData()
+		msg.Error.Data = de.Data()
 	}
 	return msg
 }
@@ -133,14 +133,6 @@ func (err *jsonError) Error() string {
 		return fmt.Sprintf("json-rpc error %d", err.Code)
 	}
 	return err.Message
-}
-
-func (err *jsonError) ErrorCode() int {
-	return err.Code
-}
-
-func (err *jsonError) ErrorData() interface{} {
-	return err.Data
 }
 
 // Conn is a subset of the methods of net.Conn which are sufficient for ServerCodec.

--- a/rpc/json.go
+++ b/rpc/json.go
@@ -111,13 +111,13 @@ func errorMessage(err error) *jsonrpcMessage {
 		Code:    defaultErrorCode,
 		Message: err.Error(),
 	}}
-	ec, ok := err.(ErrorWithCode)
+	ec, ok := err.(Error)
 	if ok {
-		msg.Error.Code = ec.Code()
+		msg.Error.Code = ec.ErrorCode()
 	}
-	de, ok := err.(ErrorWithData)
+	de, ok := err.(DataError)
 	if ok {
-		msg.Error.Data = de.Data()
+		msg.Error.Data = de.ErrorData()
 	}
 	return msg
 }
@@ -133,6 +133,14 @@ func (err *jsonError) Error() string {
 		return fmt.Sprintf("json-rpc error %d", err.Code)
 	}
 	return err.Message
+}
+
+func (err *jsonError) ErrorCode() int {
+	return err.Code
+}
+
+func (err *jsonError) ErrorData() interface{} {
+	return err.Data
 }
 
 // Conn is a subset of the methods of net.Conn which are sufficient for ServerCodec.

--- a/rpc/server_test.go
+++ b/rpc/server_test.go
@@ -45,7 +45,7 @@ func TestServerRegisterName(t *testing.T) {
 		t.Fatalf("Expected service calc to be registered")
 	}
 
-	wantCallbacks := 8
+	wantCallbacks := 9
 	if len(svc.callbacks) != wantCallbacks {
 		t.Errorf("Expected %d callbacks for service 'service', got %d", wantCallbacks, len(svc.callbacks))
 	}

--- a/rpc/testservice_test.go
+++ b/rpc/testservice_test.go
@@ -63,6 +63,12 @@ type echoResult struct {
 	Args   *echoArgs
 }
 
+type testError struct{}
+
+func (testError) Error() string          { return "testError" }
+func (testError) ErrorCode() int         { return 444 }
+func (testError) ErrorData() interface{} { return "testError data" }
+
 func (s *testService) NoArgsRets() {}
 
 func (s *testService) Echo(str string, i int, args *echoArgs) echoResult {
@@ -97,6 +103,10 @@ func (s *testService) InvalidRets2() (string, string) {
 
 func (s *testService) InvalidRets3() (string, string, error) {
 	return "", "", nil
+}
+
+func (s *testService) ReturnError() error {
+	return testError{}
 }
 
 func (s *testService) CallMeBack(ctx context.Context, method string, args []interface{}) (interface{}, error) {

--- a/rpc/types.go
+++ b/rpc/types.go
@@ -41,6 +41,12 @@ type Error interface {
 	ErrorCode() int // returns the code
 }
 
+// A DataError contains some data in addition to the error message.
+type DataError interface {
+	Error() string          // returns the message
+	ErrorData() interface{} // returns the error data
+}
+
 // ServerCodec implements reading, parsing and writing RPC messages for the server side of
 // a RPC session. Implementations must be go-routine safe since the codec can be called in
 // multiple go-routines concurrently.

--- a/rpc/types.go
+++ b/rpc/types.go
@@ -35,16 +35,14 @@ type API struct {
 	Public    bool        // indication if the methods must be considered safe for public use
 }
 
-// Error wraps RPC errors, which contain an error code in addition to the message.
-type Error interface {
-	Error() string  // returns the message
-	ErrorCode() int // returns the code
+// ErrorWithCode defines an error code in addition to the message.
+type ErrorWithCode interface {
+	Code() int // returns the code
 }
 
-// A DataError contains some data in addition to the error message.
-type DataError interface {
-	Error() string          // returns the message
-	ErrorData() interface{} // returns the error data
+// ErrorWithData defines a data item in addition to the message.
+type ErrorWithData interface {
+	Data() interface{} // returns the error data
 }
 
 // ServerCodec implements reading, parsing and writing RPC messages for the server side of

--- a/rpc/types.go
+++ b/rpc/types.go
@@ -35,14 +35,16 @@ type API struct {
 	Public    bool        // indication if the methods must be considered safe for public use
 }
 
-// ErrorWithCode defines an error code in addition to the message.
-type ErrorWithCode interface {
-	Code() int // returns the code
+// Error wraps RPC errors, which contain an error code in addition to the message.
+type Error interface {
+	Error() string  // returns the message
+	ErrorCode() int // returns the code
 }
 
-// ErrorWithData defines a data item in addition to the message.
-type ErrorWithData interface {
-	Data() interface{} // returns the error data
+// A DataError contains some data in addition to the error message.
+type DataError interface {
+	Error() string          // returns the message
+	ErrorData() interface{} // returns the error data
 }
 
 // ServerCodec implements reading, parsing and writing RPC messages for the server side of


### PR DESCRIPTION
Allows to return the proper revert reason for eth_call.
fixes https://github.com/ethereum/go-ethereum/issues/19027
fixes https://github.com/ethereum/go-ethereum/issues/21150
fixes https://github.com/ethereum/go-ethereum/issues/21082

Outputs: 
```
{
  "jsonrpc": "2.0",
  "id": 1,
  "error": {
    "code": -32000,
    "message": "some error"
  }
}
```