### PR TITLE
eth/handler, downloader: don't wait indefinitely for downloader termination

### DIFF
--- a/core/blockchain_insert.go
+++ b/core/blockchain_insert.go
@@ -58,7 +58,7 @@ func (st *insertStats) report(chain []*types.Block, index int, dirty common.Stor
 		context := []interface{}{
 			"blocks", st.processed, "txs", txs, "mgas", float64(st.usedGas) / 1000000,
 			"elapsed", common.PrettyDuration(elapsed), "mgasps", float64(st.usedGas) * 1000 / float64(elapsed),
-			"number", end.Number(), "hash", end.Hash(),
+			"number", end.Number(), "hash", end.Hash(), "remaining", len(chain) - 1 - index,
 		}
 		if timestamp := time.Unix(int64(end.Time()), 0); time.Since(timestamp) > time.Minute {
 			context = append(context, []interface{}{"age", common.PrettyAge(timestamp)}...)


### PR DESCRIPTION
... during shutdown, fixes #21087

This PR implements one of the potential fixes suggested in https://github.com/ethereum/go-ethereum/issues/21087 , namely to only wait a while for lower layers to finish shutting down. 

This issue was kind of a bitch to repro, until I found what the cause was. Once the cause was identified, it's trivial to cause this to happen, e.g. 
```diff
--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -1707,6 +1707,7 @@ func (bc *BlockChain) insertChain(chain types.Blocks, verifySeals bool) (int, er
        }
        // No validation errors for the first block (or chain prefix skipped)
        for ; block != nil && err == nil || err == ErrKnownBlock; block, err = it.next() {
+               time.Sleep(2 * time.Second)
                // If the chain is terminating, stop processing blocks
                if atomic.LoadInt32(&bc.procInterrupt) == 1 {
                        log.Debug("Premature abort during blocks processing")

```
With this PR: 
```
^CINFO [05-15|00:18:18.535] Got interrupt, shutting down... 
INFO [05-15|00:18:18.535] IPC endpoint closed                      url=/home/user/.ethereum/goerli/geth.ipc
INFO [05-15|00:18:23.049] Imported new chain segment               blocks=4 txs=8 mgas=1.341 elapsed=8.069s mgasps=0.166 number=2696271 hash="8ef95a…805ab5" remaining=376 age=5h24s   dirty=171.87KiB
INFO [05-15|00:18:27.871] Looking for peers                        peercount=2 tried=112 static=0
INFO [05-15|00:18:28.535] Protocol manager moving on 
INFO [05-15|00:18:28.536] Ethereum protocol stopped 
INFO [05-15|00:18:28.536] Terminated topic registration            topic=LES2@bf7e331f7f7c1dd2
INFO [05-15|00:18:28.536] Les server stopped 
INFO [05-15|00:18:28.536] Transaction pool stopped 
INFO [05-15|00:18:29.083] Writing cached state to disk             block=2696273 hash="d53e26…cf6573" root="601178…8c7bec"
WARN [05-15|00:18:29.083] Synchronisation failed, retrying         err="content processing canceled (requested)"
INFO [05-15|00:18:29.090] Persisted trie from memory database      nodes=328 size=105.21KiB time=6.535499ms gcnodes=0 gcsize=0.00B gctime=0s livenodes=176 livesize=65.26KiB
INFO [05-15|00:18:29.090] Writing cached state to disk             block=2696272 hash="575d53…a806d7" root="8a97c2…5a72e7"
INFO [05-15|00:18:29.092] Persisted trie from memory database      nodes=64  size=23.68KiB  time=1.513359ms gcnodes=0 gcsize=0.00B gctime=0s livenodes=112 livesize=41.58KiB
INFO [05-15|00:18:29.092] Writing cached state to disk             block=2696146 hash="7b7d3a…410e7d" root="486ffa…1481c0"
INFO [05-15|00:18:29.093] Persisted trie from memory database      nodes=0   size=0.00B     time="9.078µs"  gcnodes=0 gcsize=0.00B gctime=0s livenodes=112 livesize=41.58KiB
INFO [05-15|00:18:29.094] Blockchain stopped 
```
