### PR TITLE
ethapi: estimate gas multiple consecutive calls on the same state

### DIFF
--- a/core/blockchain_test.go
+++ b/core/blockchain_test.go
@@ -994,7 +994,7 @@ func TestLogRebirth(t *testing.T) {
 		genesis       = gspec.MustCommit(db)
 		signer        = types.NewEIP155Signer(gspec.Config.ChainID)
 		engine        = ethash.NewFaker()
-		blockchain, _ = NewBlockChain(db, nil, gspec.Config, engine, vm.Config{}, nil)
+		blockchain, _ = NewBlockChain(db, nil, gspec.Config, engine, vm.Config{}, nil, nil)
 	)
 
 	defer blockchain.Stop()
@@ -1057,7 +1057,7 @@ func TestSideLogRebirth(t *testing.T) {
 		gspec         = &Genesis{Config: params.TestChainConfig, Alloc: GenesisAlloc{addr1: {Balance: big.NewInt(10000000000000)}}}
 		genesis       = gspec.MustCommit(db)
 		signer        = types.NewEIP155Signer(gspec.Config.ChainID)
-		blockchain, _ = NewBlockChain(db, nil, gspec.Config, ethash.NewFaker(), vm.Config{}, nil)
+		blockchain, _ = NewBlockChain(db, nil, gspec.Config, ethash.NewFaker(), vm.Config{}, nil, nil)
 	)
 
 	defer blockchain.Stop()
@@ -2615,7 +2615,7 @@ func TestDeleteRecreateSlots(t *testing.T) {
 	chain, err := NewBlockChain(diskdb, nil, params.TestChainConfig, engine, vm.Config{
 		Debug:  true,
 		Tracer: vm.NewJSONLogger(nil, os.Stdout),
-	}, nil)
+	}, nil, nil)
 	if err != nil {
 		t.Fatalf("failed to create tester chain: %v", err)
 	}
@@ -2695,7 +2695,7 @@ func TestDeleteRecreateAccount(t *testing.T) {
 	chain, err := NewBlockChain(diskdb, nil, params.TestChainConfig, engine, vm.Config{
 		Debug:  true,
 		Tracer: vm.NewJSONLogger(nil, os.Stdout),
-	}, nil)
+	}, nil, nil)
 	if err != nil {
 		t.Fatalf("failed to create tester chain: %v", err)
 	}
@@ -2868,7 +2868,7 @@ func TestDeleteRecreateSlotsAcrossManyBlocks(t *testing.T) {
 	chain, err := NewBlockChain(diskdb, nil, params.TestChainConfig, engine, vm.Config{
 		//Debug:  true,
 		//Tracer: vm.NewJSONLogger(nil, os.Stdout),
-	}, nil)
+	}, nil, nil)
 	if err != nil {
 		t.Fatalf("failed to create tester chain: %v", err)
 	}
@@ -3002,7 +3002,7 @@ func TestInitThenFailCreateContract(t *testing.T) {
 	chain, err := NewBlockChain(diskdb, nil, params.TestChainConfig, engine, vm.Config{
 		//Debug:  true,
 		//Tracer: vm.NewJSONLogger(nil, os.Stdout),
-	}, nil)
+	}, nil, nil)
 	if err != nil {
 		t.Fatalf("failed to create tester chain: %v", err)
 	}

--- a/graphql/graphql.go
+++ b/graphql/graphql.go
@@ -803,7 +803,7 @@ func (b *Block) Call(ctx context.Context, args struct {
 			return nil, err
 		}
 	}
-	result, err := ethapi.DoCall(ctx, b.backend, args.Data, *b.numberOrHash, nil, vm.Config{}, 5*time.Second, b.backend.RPCGasCap())
+	result, _, err := ethapi.DoCall(ctx, b.backend, args.Data, nil, *b.numberOrHash, nil, vm.Config{}, 5*time.Second, b.backend.RPCGasCap())
 	if err != nil {
 		return nil, err
 	}
@@ -827,7 +827,7 @@ func (b *Block) EstimateGas(ctx context.Context, args struct {
 			return hexutil.Uint64(0), err
 		}
 	}
-	gas, err := ethapi.DoEstimateGas(ctx, b.backend, args.Data, *b.numberOrHash, b.backend.RPCGasCap())
+	gas, _, err := ethapi.DoEstimateGas(ctx, b.backend, args.Data, nil, *b.numberOrHash, b.backend.RPCGasCap())
 	return gas, err
 }
 
@@ -872,7 +872,7 @@ func (p *Pending) Call(ctx context.Context, args struct {
 	Data ethapi.CallArgs
 }) (*CallResult, error) {
 	pendingBlockNr := rpc.BlockNumberOrHashWithNumber(rpc.PendingBlockNumber)
-	result, err := ethapi.DoCall(ctx, p.backend, args.Data, pendingBlockNr, nil, vm.Config{}, 5*time.Second, p.backend.RPCGasCap())
+	result, _, err := ethapi.DoCall(ctx, p.backend, args.Data, nil, pendingBlockNr, nil, vm.Config{}, 5*time.Second, p.backend.RPCGasCap())
 	if err != nil {
 		return nil, err
 	}
@@ -891,7 +891,8 @@ func (p *Pending) EstimateGas(ctx context.Context, args struct {
 	Data ethapi.CallArgs
 }) (hexutil.Uint64, error) {
 	pendingBlockNr := rpc.BlockNumberOrHashWithNumber(rpc.PendingBlockNumber)
-	return ethapi.DoEstimateGas(ctx, p.backend, args.Data, pendingBlockNr, p.backend.RPCGasCap())
+	gas, _, err := ethapi.DoEstimateGas(ctx, p.backend, args.Data, nil, pendingBlockNr, p.backend.RPCGasCap())
+	return gas, err
 }
 
 // Resolver is the top-level object in the GraphQL hierarchy.

--- a/graphql/graphql.go
+++ b/graphql/graphql.go
@@ -895,20 +895,6 @@ func (p *Pending) EstimateGas(ctx context.Context, args struct {
 	return gas, err
 }
 
-func (p *Pending) EstimateGases(ctx context.Context, args struct {
-	Data *[]ethapi.CallArgs
-}) (*[]hexutil.Uint64, error) {
-	ret := make([]hexutil.Uint64, 0, len(*args.Data))
-	for _, call := range *args.Data {
-		estimatedGas, err := ethapi.DoEstimateGas(ctx, p.backend, call, rpc.PendingBlockNumber)
-		if err != nil {
-			return &ret, nil
-		}
-		ret = append(ret, estimatedGas)
-	}
-	return &ret, nil
-}
-
 // Resolver is the top-level object in the GraphQL hierarchy.
 type Resolver struct {
 	backend ethapi.Backend

--- a/graphql/schema.go
+++ b/graphql/schema.go
@@ -292,7 +292,6 @@ const schema string = `
       # EstimateGas estimates the amount of gas that will be required for
       # successful execution of a transaction for the pending state.
       estimateGas(data: CallData!): Long!
-      estimateGases(data: [CallData!]): [Long!]
     }
 
     type Query {

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -1044,7 +1044,6 @@ func (s *PublicBlockChainAPI) EstimateGas(ctx context.Context, argsInterface int
 		json.Unmarshal(marshalled, &callArgs)
 		return callArgs
 	}
-	log.Info(fmt.Sprintf("%T", argsInterface))
 	switch args := argsInterface.(type) {
 	case map[string]interface{}:
 		gas, _, err = DoEstimateGas(ctx, s.b, getCallArgs(args), stateData, blockNrOrHash, s.b.RPCGasCap())
@@ -1060,7 +1059,7 @@ func (s *PublicBlockChainAPI) EstimateGas(ctx context.Context, argsInterface int
 		}
 		return returnVals, nil
 	default:
-		return nil, estimateGasError{error: fmt.Sprintf("unknown input")}
+		return nil, estimateGasError{error: "unknown input"}
 	}
 }
 

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -1046,13 +1046,15 @@ func (s *PublicBlockChainAPI) EstimateGasList(ctx context.Context, argsList []Ca
 		gas       hexutil.Uint64
 		err       error
 		stateData *PreviousState
+		gasCap    = s.b.RPCGasCap()
 	)
 	returnVals := make([]hexutil.Uint64, len(argsList))
 	for idx, args := range argsList {
-		gas, stateData, err = DoEstimateGas(ctx, s.b, args, stateData, blockNrOrHash, s.b.RPCGasCap())
+		gas, stateData, err = DoEstimateGas(ctx, s.b, args, stateData, blockNrOrHash, gasCap)
 		if err != nil {
 			return nil, err
 		}
+		gasCap.Sub(gasCap, new(big.Int).SetUint64(uint64(gas)))
 		returnVals[idx] = gas
 	}
 	return returnVals, nil

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -1038,6 +1038,8 @@ func (s *PublicBlockChainAPI) EstimateGas(ctx context.Context, args CallArgs) (h
 	return gas, err
 }
 
+// EstimateGasList returns an estimate of the amount of gas needed to execute list of
+// given transactions against the current pending block.
 func (s *PublicBlockChainAPI) EstimateGasList(ctx context.Context, argsList []CallArgs) ([]hexutil.Uint64, error) {
 	blockNrOrHash := rpc.BlockNumberOrHashWithNumber(rpc.PendingBlockNumber)
 	var (

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -799,6 +799,9 @@ type PreviousState struct {
 
 func DoCall(ctx context.Context, b Backend, args CallArgs, prevState *PreviousState, blockNrOrHash rpc.BlockNumberOrHash, overrides map[common.Address]account, vmCfg vm.Config, timeout time.Duration, globalGasCap *big.Int) (*core.ExecutionResult, *PreviousState, error) {
 	defer func(start time.Time) { log.Debug("Executing EVM call finished", "runtime", time.Since(start)) }(time.Now())
+	if prevState == nil {
+		prevState = &PreviousState{}
+	}
 	if (prevState.header != nil && prevState.header == nil) || (prevState.header == nil && prevState.header != nil) {
 		return nil, nil, fmt.Errorf("both header and state must be set to use previous staate")
 	}
@@ -1035,9 +1038,6 @@ func (s *PublicBlockChainAPI) EstimateGas(ctx context.Context, argsInterface int
 		err       error
 		stateData *PreviousState
 	)
-	if stateData == nil {
-		stateData = &PreviousState{}
-	}
 	getCallArgs := func(inter map[string]interface{}) CallArgs {
 		marshalled, _ := json.Marshal(inter)
 		callArgs := CallArgs{}


### PR DESCRIPTION
There are multiple occasions where you have to estimate the gas limit in a sequential order, meaning estimate should take state changes made by previous calls into consideration. Current `eth_estimateGas` creates a copy of the pending state on each call. Because of this, it is not possible to send out multiple txs that depends on each other at the same time.
Good example will be DEXs which requires tokens to be `approve(spender, amount)` before executing the trade. Currently some DEXs maintains a gas limit map since the gas limit cannot be estimated using `eth_estimateGas` without having the tokens approved.
At MEW we have to guess the gas limit for batch transactions where we will guess extreme amounts just to be on the safe side and this adds txs that are set with unnecessarily higher gas limits to the pending pool.

This PR will let users estimate gas on the same state. Also it is backwards compatible with current ethereum rpc standard. 
`{"jsonrpc":"2.0","method":"eth_estimateGasList","params":[[{call0-0}, {call0-1}, {call0-2}]],"id":1}`

```
{
  "id":1,
  "jsonrpc": "2.0",
  "result": ["0xvalue0-0", "0xvalue0-1", "0xvalue0-2"]
}
```
in this case `call0`s depends on previous call to be executed on the state.

backwards compatible
`{"jsonrpc":"2.0","method":"eth_estimateGas","params":[{call1-0}],"id":1}`

```
{
  "id":1,
  "jsonrpc": "2.0",
  "result": "0xvalue1-0"
}
```
