### PR TITLE
miner: replace use of 'self' as receiver name

### DIFF
--- a/miner/miner.go
+++ b/miner/miner.go
@@ -202,6 +202,6 @@ func (miner *Miner) DisablePreseal() {
 
 // SubscribePendingLogs starts delivering logs from pending transactions
 // to the given channel.
-func (self *Miner) SubscribePendingLogs(ch chan<- []*types.Log) event.Subscription {
-	return self.worker.pendingLogsFeed.Subscribe(ch)
+func (miner *Miner) SubscribePendingLogs(ch chan<- []*types.Log) event.Subscription {
+	return miner.worker.pendingLogsFeed.Subscribe(ch)
 }


### PR DESCRIPTION
```
receiver name should be a reflection of its identity; don't use generic names such as "this" or "self" (ST1006)
```