### PR TITLE
metrics | ReadCPUStats redeclared in this block (compile)

### DIFF
--- a/metrics/cpu_disabled.go
+++ b/metrics/cpu_disabled.go
@@ -20,4 +20,3 @@ package metrics
 
 // ReadCPUStats retrieves the current CPU stats. Internally this uses `gosigar`,
 // which is not supported on the platforms in this file.
-func ReadCPUStats(stats *CPUStats) {}


### PR DESCRIPTION
```
ReadCPUStats redeclared in this block (compile)
```
both in ```cpu_enable.go``` and ```cpu_disable.go```