### PR TITLE
Closes #20582. Non-executable transactions should not be evicted.

### DIFF
--- a/core/tx_pool.go
+++ b/core/tx_pool.go
@@ -232,12 +232,12 @@ type TxPool struct {
 	locals  *accountSet // Set of local transaction to exempt from eviction rules
 	journal *txJournal  // Journal of local transaction to back up to disk
 
-	pending   map[common.Address]*txList   // All currently processable transactions
-	queue     map[common.Address]*txList   // Queued but non-processable transactions
-	beats     map[common.Address]time.Time // Last heartbeat from each known account
-	queued_ts map[common.Hash]time.Time    // Timestamp for when queued transactions were added
-	all       *txLookup                    // All transactions to allow lookups
-	priced    *txPricedList                // All transactions sorted by price
+	pending  map[common.Address]*txList   // All currently processable transactions
+	queue    map[common.Address]*txList   // Queued but non-processable transactions
+	beats    map[common.Address]time.Time // Last heartbeat from each known account
+	queuedTs map[common.Hash]time.Time    // Timestamp for when queued transactions were added
+	all      *txLookup                    // All transactions to allow lookups
+	priced   *txPricedList                // All transactions sorted by price
 
 	chainHeadCh     chan ChainHeadEvent
 	chainHeadSub    event.Subscription
@@ -268,7 +268,7 @@ func NewTxPool(config TxPoolConfig, chainconfig *params.ChainConfig, chain block
 		pending:         make(map[common.Address]*txList),
 		queue:           make(map[common.Address]*txList),
 		beats:           make(map[common.Address]time.Time),
-		queued_ts:       make(map[common.Hash]time.Time),
+		queuedTs:        make(map[common.Hash]time.Time),
 		all:             newTxLookup(),
 		chainHeadCh:     make(chan ChainHeadEvent, chainHeadChanSize),
 		reqResetCh:      make(chan *txpoolResetRequest),
@@ -366,7 +366,7 @@ func (pool *TxPool) loop() {
 				// Any non-locals old enough should be removed
 				if time.Since(pool.beats[addr]) > pool.config.Lifetime {
 					for _, tx := range pool.queue[addr].Flatten() {
-						if time.Since(pool.queued_ts[tx.Hash()]) > pool.config.Lifetime {
+						if time.Since(pool.queuedTs[tx.Hash()]) > pool.config.Lifetime {
 							queuedEvictionMeter.Mark(1)
 							pool.removeTx(tx.Hash(), true)
 						}
@@ -668,17 +668,17 @@ func (pool *TxPool) enqueueTx(hash common.Hash, tx *types.Transaction) (bool, er
 		old_hash := old.Hash()
 		pool.all.Remove(old_hash)
 		pool.priced.Removed(1)
-		delete(pool.queued_ts, old_hash)
+		delete(pool.queuedTs, old_hash)
 		queuedReplaceMeter.Mark(1)
 	} else {
 		// Nothing was replaced, bump the queued counter
 		queuedGauge.Inc(1)
-		pool.queued_ts[hash] = time.Now()
+		pool.queuedTs[hash] = time.Now()
 	}
 	if pool.all.Get(hash) == nil {
 		pool.all.Add(tx)
 		pool.priced.Put(tx)
-		pool.queued_ts[hash] = time.Now()
+		pool.queuedTs[hash] = time.Now()
 	}
 	return old != nil, nil
 }
@@ -711,7 +711,7 @@ func (pool *TxPool) promoteTx(addr common.Address, hash common.Hash, tx *types.T
 		// An older transaction was better, discard this
 		pool.all.Remove(hash)
 		pool.priced.Removed(1)
-		delete(pool.queued_ts, hash)
+		delete(pool.queuedTs, hash)
 		pendingDiscardMeter.Mark(1)
 		return false
 	}
@@ -731,7 +731,7 @@ func (pool *TxPool) promoteTx(addr common.Address, hash common.Hash, tx *types.T
 	}
 	// Set the potentially new pending nonce and notify any subsystems of the new tx
 	pool.beats[addr] = time.Now()
-	delete(pool.queued_ts, hash)
+	delete(pool.queuedTs, hash)
 	pool.pendingNonces.set(addr, tx.Nonce()+1)
 
 	return true
@@ -923,7 +923,7 @@ func (pool *TxPool) removeTx(hash common.Hash, outofbound bool) {
 		if removed, _ := future.Remove(tx); removed {
 			// Reduce the queued counter
 			queuedGauge.Dec(1)
-			delete(pool.queued_ts, hash)
+			delete(pool.queuedTs, hash)
 		}
 		if future.Empty() {
 			delete(pool.queue, addr)
@@ -1202,7 +1202,7 @@ func (pool *TxPool) promoteExecutables(accounts []common.Address) []*types.Trans
 		for _, tx := range forwards {
 			hash := tx.Hash()
 			pool.all.Remove(hash)
-			delete(pool.queued_ts, hash)
+			delete(pool.queuedTs, hash)
 		}
 		log.Trace("Removed old queued transactions", "count", len(forwards))
 		// Drop all transactions that are too costly (low balance or out of gas)
@@ -1210,7 +1210,7 @@ func (pool *TxPool) promoteExecutables(accounts []common.Address) []*types.Trans
 		for _, tx := range drops {
 			hash := tx.Hash()
 			pool.all.Remove(hash)
-			delete(pool.queued_ts, hash)
+			delete(pool.queuedTs, hash)
 		}
 		log.Trace("Removed unpayable queued transactions", "count", len(drops))
 		queuedNofundsMeter.Mark(int64(len(drops)))
@@ -1233,7 +1233,7 @@ func (pool *TxPool) promoteExecutables(accounts []common.Address) []*types.Trans
 			for _, tx := range caps {
 				hash := tx.Hash()
 				pool.all.Remove(hash)
-				delete(pool.queued_ts, hash)
+				delete(pool.queuedTs, hash)
 				log.Trace("Removed cap-exceeding queued transaction", "hash", hash)
 			}
 			queuedRateLimitMeter.Mark(int64(len(caps)))

--- a/core/tx_pool_test.go
+++ b/core/tx_pool_test.go
@@ -109,8 +109,8 @@ func validateTxPoolInternals(pool *TxPool) error {
 	if priced := pool.priced.items.Len() - pool.priced.stales; priced != pending+queued {
 		return fmt.Errorf("total priced transaction count %d != %d pending + %d queued", priced, pending, queued)
 	}
-	if queued != len(pool.queued_ts) {
-		return fmt.Errorf("total queued transaction count %d != %d queued_ts length", queued, len(pool.queued_ts))
+	if queued != len(pool.queuedTs) {
+		return fmt.Errorf("total queued transaction count %d != %d queuedTs length", queued, len(pool.queuedTs))
 	}
 
 	// Ensure the next nonce to assign is the correct one


### PR DESCRIPTION
Closes #20582.

# Description
Queued transactions should not be evicted until after `evictionInterval` has passed. Successful promotion of transactions via `promoteExecutables`, pending replacement via `add(...)`, or insertion into the queue via `enqueueTx` should update the last heartbeat. The heartbeat is no longer removed when the `pending` list is emptied or after a minute has passed in the future queue.

Tests are expanded to ensure queued transactions are not removed before the `evictionInterval` duration has passed. Additionally, tests are expanded to ensure a reset or emptied pending list does not clear out the heart beat.

Logging is expanded to detect evictions as a method to prevent/monitor issues in the future.

# Monitoring Before & After
We see a **5x reduction** in queue evictions and the queue is able to reach capacity. Previously, I was seeing 5 tx/s evicted from the queue, that has been reduced to 1 tx/s evicted. Additionally, the queue is able to grow to its limit, from ~500 to 1024 in the case of my config.

**Before**:
![image](https://user-images.githubusercontent.com/7415822/82740082-58531200-9d13-11ea-8665-cf0d83478321.png)
![image](https://user-images.githubusercontent.com/7415822/82740084-6739c480-9d13-11ea-854e-94eda4b2f0f6.png)

**After**:
![image](https://user-images.githubusercontent.com/7415822/82740087-73258680-9d13-11ea-9598-cc29580033a5.png)
![image](https://user-images.githubusercontent.com/7415822/82740092-7caeee80-9d13-11ea-816e-ca0fa22bb782.png)

# Questions
There could be a case for removing heartbeat updates on pending replaced and in promote executables, however, it seems optimal to keep the queue fresh when new activity is seen and to manage ordering appropriately on truncation.

