### PR TITLE
core/vm: improve jumpdest lookup

### DIFF
--- a/core/vm/contract.go
+++ b/core/vm/contract.go
@@ -92,25 +92,28 @@ func (c *Contract) validJumpdest(dest *big.Int) bool {
 	if OpCode(c.Code[udest]) != JUMPDEST {
 		return false
 	}
-	// Do we have a contract hash already?
+	// Do we have it locally already?
+	if c.analysis != nil {
+		return c.analysis.codeSegment(udest)
+	}
+	// If we have the code hash (but no analysis), we should look into the
+	// parent analysis map and see if the analysis has been made previously
 	if c.CodeHash != (common.Hash{}) {
-		// Does parent context have the analysis?
 		analysis, exist := c.jumpdests[c.CodeHash]
 		if !exist {
 			// Do the analysis and save in parent context
-			// We do not need to store it in c.analysis
 			analysis = codeBitmap(c.Code)
 			c.jumpdests[c.CodeHash] = analysis
 		}
+		// Also stash it in current contract for faster access
+		c.analysis = analysis
 		return analysis.codeSegment(udest)
 	}
 	// We don't have the code hash, most likely a piece of initcode not already
 	// in state trie. In that case, we do an analysis, and save it locally, so
 	// we don't have to recalculate it for every JUMP instruction in the execution
 	// However, we don't save it within the parent context
-	if c.analysis == nil {
-		c.analysis = codeBitmap(c.Code)
-	}
+	c.analysis = codeBitmap(c.Code)
 	return c.analysis.codeSegment(udest)
 }
 


### PR DESCRIPTION
This PR changes how jumpdest analysis is stored: previously, an analysis bitmap was always stored by _either_ by hash in a map, _or_ as a member on the `contract` itself (if it was initcode). 

With this PR, we store it on the object itself, which saves us a map lookup, which actually makes a difference if a lot of looping is done.  

This change was originally part of https://github.com/ethereum/go-ethereum/pull/20787, but since it's not related to `uint256`, we decided to make it a separate PR instead. 



```
name          old time/op    new time/op    delta
SimpleLoop-6     201ms ± 2%     172ms ± 2%  -14.24%  (p=0.000 n=9+8)

name          old alloc/op   new alloc/op   delta
SimpleLoop-6    52.0kB ± 0%    52.0kB ± 0%     ~     (p=1.000 n=10+10)

name          old allocs/op  new allocs/op  delta
SimpleLoop-6       114 ± 0%       115 ± 1%     ~     (p=1.000 n=10+10)
```