### PR TITLE
cmd/utils: fix default DNS discovery configuration

### DIFF
--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -1616,7 +1616,7 @@ func setDNSDiscoveryDefaults(cfg *eth.Config, genesis common.Hash) {
 		return // already set through flags/config
 	}
 
-	protocol := "eth"
+	protocol := "all"
 	if cfg.SyncMode == downloader.LightSync {
 		protocol = "les"
 	}


### PR DESCRIPTION
This fixes a regression introduced in #20758.