### PR TITLE
downloader: allow at-floor common ancestors

### DIFF
--- a/eth/downloader/downloader.go
+++ b/eth/downloader/downloader.go
@@ -814,7 +814,7 @@ func (d *Downloader) findAncestor(p *peerConnection, remoteHeader *types.Header)
 	}
 	// If the head fetch already found an ancestor, return
 	if hash != (common.Hash{}) {
-		if int64(number) <= floor {
+		if int64(number) < floor {
 			p.log.Warn("Ancestor below allowance", "number", number, "hash", hash, "allowance", floor)
 			return 0, errInvalidAncestor
 		}
@@ -893,7 +893,7 @@ func (d *Downloader) findAncestor(p *peerConnection, remoteHeader *types.Header)
 		}
 	}
 	// Ensure valid ancestry and return
-	if int64(start) <= floor {
+	if int64(start) < floor {
 		p.log.Warn("Ancestor below allowance", "number", start, "hash", hash, "allowance", floor)
 		return 0, errInvalidAncestor
 	}

--- a/eth/downloader/downloader_test.go
+++ b/eth/downloader/downloader_test.go
@@ -683,8 +683,8 @@ func testBoundedForkedSync(t *testing.T, protocol int, mode SyncMode) {
 	assertOwnChain(t, tester, chainA.len())
 
 	// Synchronise with the second peer and ensure that the fork is rejected to being too old
-	if err := tester.sync("rewriter", nil, mode); err != errInvalidAncestor {
-		t.Fatalf("sync failure mismatch: have %v, want %v", err, errInvalidAncestor)
+	if err := tester.sync("rewriter", nil, mode); err != errInvalidChain {
+		t.Fatalf("sync failure mismatch: have %v, want %v", err, errInvalidChain)
 	}
 }
 
@@ -717,8 +717,8 @@ func testBoundedHeavyForkedSync(t *testing.T, protocol int, mode SyncMode) {
 	assertOwnChain(t, tester, chainA.len())
 
 	// Synchronise with the second peer and ensure that the fork is rejected to being too old
-	if err := tester.sync("heavy-rewriter", nil, mode); err != errInvalidAncestor {
-		t.Fatalf("sync failure mismatch: have %v, want %v", err, errInvalidAncestor)
+	if err := tester.sync("heavy-rewriter", nil, mode); err != errInvalidChain {
+		t.Fatalf("sync failure mismatch: have %v, want %v", err, errInvalidChain)
 	}
 }
 


### PR DESCRIPTION
I was seeing logs that seemed a little strange to me, like below, where geth was dropping peers with common ancestors _at_ the `local - maxForkAncestry=`__`floor`__ height.

```
WARN [05-26|12:03:04.420] Ancestor below allowance                 peer=5ed95f530fa3a22f number=10374213 hash="000000…000000" allowance=10374213
WARN [05-26|12:03:06.537] Ancestor below allowance                 peer=caa60bff46c9af6f number=10374214 hash="000000…000000" allowance=10374214
WARN [05-26|12:07:23.664] Ancestor below allowance                 peer=17c9b12cc635e028 number=10374232 hash="000000…000000" allowance=10374232
WARN [05-26|12:08:16.442] Ancestor below allowance                 peer=b68f78d37eb4969f number=10374233 hash="000000…000000" allowance=10374233
WARN [05-26|12:11:33.612] Ancestor below allowance                 peer=596ba8ce636ce66a number=10374242 hash="000000…000000" allowance=10374242
WARN [05-26|12:11:59.311] Ancestor below allowance                 peer=caa60bff46c9af6f number=10374242 hash="000000…000000" allowance=10374242
WARN [05-26|12:12:16.996] Ancestor below allowance                 peer=596ba8ce636ce66a number=10374243 hash="000000…000000" allowance=10374243
WARN [05-26|12:14:02.252] Ancestor below allowance                 peer=8e0933d8d44ea192 number=10374250 hash="000000…000000" allowance=10374250
WARN [05-26|12:14:04.845] Ancestor below allowance                 peer=9efb8b5c696f49ce number=10374250 hash="000000…000000" allowance=10374250
WARN [05-26|12:14:09.445] Ancestor below allowance                 peer=ff4075b6eb686d01 number=10374250 hash="000000…000000" allowance=10374250
WARN [05-26|12:14:32.119] Ancestor below allowance                 peer=ef387cf6e82f1cb7 number=10374250 hash="000000…000000" allowance=10374250
WARN [05-26|12:15:22.371] Ancestor below allowance                 peer=a21229182f495487 number=10374251 hash="000000…000000" allowance=10374251
WARN [05-26|12:15:43.180] Ancestor below allowance                 peer=1cdbc3b2caeafc90 number=10374253 hash="000000…000000" allowance=10374253
WARN [05-26|12:15:52.322] Ancestor below allowance                 peer=ac7bf025c6d8bbd9 number=10374253 hash="000000…000000" allowance=10374253
WARN [05-26|12:15:52.549] Ancestor below allowance                 peer=5ed95f530fa3a22f number=10374253 hash="000000…000000" allowance=10374253
WARN [05-26|12:16:13.737] Ancestor below allowance                 peer=4dc523d87212135b number=10374253 hash="000000…000000" allowance=10374253
```

I'm not 100% sure about this since the expected errors modified in the test seem a little weird, but wanted to at least run it by for review, since it seems to make geth behave as I would expect, and since @holiman it seems like you might be thinking about the downloader this week.