### PR TITLE
cmd/faucet: allow faucet to start if account already exists

### DIFF
--- a/accounts/keystore/keystore.go
+++ b/accounts/keystore/keystore.go
@@ -40,9 +40,10 @@ import (
 )
 
 var (
-	ErrLocked  = accounts.NewAuthNeededError("password or unlock")
-	ErrNoMatch = errors.New("no key for given address or file")
-	ErrDecrypt = errors.New("could not decrypt key with given password")
+	ErrLocked        = accounts.NewAuthNeededError("password or unlock")
+	ErrAlreadyExists = errors.New("account already exists")
+	ErrNoMatch       = errors.New("no key for given address or file")
+	ErrDecrypt       = errors.New("could not decrypt key with given password")
 )
 
 // KeyStoreType is the reflect type of a keystore backend.
@@ -446,7 +447,7 @@ func (ks *KeyStore) Import(keyJSON []byte, passphrase, newPassphrase string) (ac
 	ks.importMu.Lock()
 	defer ks.importMu.Unlock()
 	if ks.cache.hasAddress(key.Address) {
-		return accounts.Account{}, errors.New("account already exists")
+		return accounts.Account{}, ErrAlreadyExists
 	}
 	return ks.importKey(key, newPassphrase)
 }
@@ -457,7 +458,7 @@ func (ks *KeyStore) ImportECDSA(priv *ecdsa.PrivateKey, passphrase string) (acco
 	ks.importMu.Lock()
 	defer ks.importMu.Unlock()
 	if ks.cache.hasAddress(key.Address) {
-		return accounts.Account{}, errors.New("account already exists")
+		return accounts.Account{}, ErrAlreadyExists
 	}
 	return ks.importKey(key, passphrase)
 }

--- a/cmd/faucet/faucet.go
+++ b/cmd/faucet/faucet.go
@@ -170,7 +170,7 @@ func main() {
 		log.Crit("Failed to read account key contents", "file", *accJSONFlag, "err", err)
 	}
 	acc, err := ks.Import(blob, pass, pass)
-	if err != nil {
+	if err != nil && err != keystore.ErrAlreadyExists {
 		log.Crit("Failed to import faucet signer account", "err", err)
 	}
 	ks.Unlock(acc, pass)


### PR DESCRIPTION
Don't fatal if the specified key already exists in keystore (and thus can't be `Import`ed).