### PR TITLE
ethdb: use latest leveldb

### DIFF
--- a/ethdb/leveldb/leveldb.go
+++ b/ethdb/leveldb/leveldb.go
@@ -100,7 +100,8 @@ func New(file string, cache int, handles int, namespace string) (*Database, erro
 	// Open the db and recover any potential corruptions
 	db, err := leveldb.OpenFile(file, &opt.Options{
 		OpenFilesCacheCapacity: handles,
-		MetadataCacheCapacity:  cache / 2 * opt.MiB,
+		MetadataCacheCapacity:  cache / 4 * opt.MiB,
+		BlockCacheCapacity:     cache / 4 * opt.MiB,
 		WriteBuffer:            cache / 4 * opt.MiB, // Two of these are used internally
 		Filter:                 filter.NewBloomFilter(10),
 		DisableSeeksCompaction: true,
@@ -425,10 +426,10 @@ func (db *Database) meter(refresh time.Duration) {
 			merr = err
 			continue
 		}
-		if dataCacheHit + dataDiskHit != 0 {
+		if dataCacheHit+dataDiskHit != 0 {
 			db.dataCacheHitRateGauge.Update(int64(100 * dataCacheHit / (dataCacheHit + dataDiskHit)))
 		}
-		if metaCacheHit + metaDiskHit != 0 {
+		if metaCacheHit+metaDiskHit != 0 {
 			db.metaCacheHitRateGauge.Update(int64(100 * metaCacheHit / (metaCacheHit + metaDiskHit)))
 		}
 
@@ -443,7 +444,7 @@ func (db *Database) meter(refresh time.Duration) {
 			merr = err
 			continue
 		}
-		if filterHit + filterMiss != 0 {
+		if filterHit+filterMiss != 0 {
 			db.falsePositiveRateGauge.Update(int64(100 * filterMiss / (filterHit + filterMiss)))
 		}
 

--- a/ethdb/leveldb/leveldb.go
+++ b/ethdb/leveldb/leveldb.go
@@ -425,8 +425,12 @@ func (db *Database) meter(refresh time.Duration) {
 			merr = err
 			continue
 		}
-		db.dataCacheHitRateGauge.Update(int64(100 * dataCacheHit / (dataCacheHit + dataDiskHit)))
-		db.metaCacheHitRateGauge.Update(int64(100 * metaCacheHit / (metaCacheHit + metaDiskHit)))
+		if dataCacheHit + dataDiskHit != 0 {
+			db.dataCacheHitRateGauge.Update(int64(100 * dataCacheHit / (dataCacheHit + dataDiskHit)))
+		}
+		if metaCacheHit + metaDiskHit != 0 {
+			db.metaCacheHitRateGauge.Update(int64(100 * metaCacheHit / (metaCacheHit + metaDiskHit)))
+		}
 
 		filterStats, err := db.db.GetProperty("leveldb.filterstats")
 		if err != nil {
@@ -439,7 +443,9 @@ func (db *Database) meter(refresh time.Duration) {
 			merr = err
 			continue
 		}
-		db.falsePositiveRateGauge.Update(int64(100 * filterMiss / (filterHit + filterMiss)))
+		if filterHit + filterMiss != 0 {
+			db.falsePositiveRateGauge.Update(int64(100 * filterMiss / (filterHit + filterMiss)))
+		}
 
 		// Sleep a bit, then repeat the stats collection
 		select {

--- a/go.mod
+++ b/go.mod
@@ -68,3 +68,5 @@ require (
 	gopkg.in/urfave/cli.v1 v1.20.0
 	gotest.tools v2.2.0+incompatible // indirect
 )
+
+replace github.com/syndtr/goleveldb => github.com/rjl493456442/goleveldb v0.0.0-20200528054212-1bee18ccef73

--- a/go.sum
+++ b/go.sum
@@ -162,6 +162,10 @@ github.com/prometheus/tsdb v0.6.2-0.20190402121629-4f204dcbc150 h1:ZeU+auZj1iNzN
 github.com/prometheus/tsdb v0.6.2-0.20190402121629-4f204dcbc150/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40TwIPHuXU=
 github.com/rjeczalik/notify v0.9.1 h1:CLCKso/QK1snAlnhNR/CNvNiFU2saUtjV0bx3EwNeCE=
 github.com/rjeczalik/notify v0.9.1/go.mod h1:rKwnCoCGeuQnwBtTSPL9Dad03Vh2n40ePRrjvIXnJho=
+github.com/rjl493456442/goleveldb v0.0.0-20200528050746-82428547339b h1:kff6gFtvs1jeo6KNGpznJCAR52cXXd/v4M4x2AnPNqU=
+github.com/rjl493456442/goleveldb v0.0.0-20200528050746-82428547339b/go.mod h1:9OrXJhf154huy1nPWmuSrkgjPUtUNhA+Zmy+6AESzuA=
+github.com/rjl493456442/goleveldb v0.0.0-20200528054212-1bee18ccef73 h1:07SH5mFoWA+KfReQlcTE9wQuubB16VEgGfWkAOTwFm0=
+github.com/rjl493456442/goleveldb v0.0.0-20200528054212-1bee18ccef73/go.mod h1:9OrXJhf154huy1nPWmuSrkgjPUtUNhA+Zmy+6AESzuA=
 github.com/rs/cors v0.0.0-20160617231935-a62a804a8a00 h1:8DPul/X0IT/1TNMIxoKLwdemEOBBHDC/K4EB16Cw5WE=
 github.com/rs/cors v0.0.0-20160617231935-a62a804a8a00/go.mod h1:gFx+x8UowdsKA9AchylcLynDq+nNFfI8FkUZdN/jGCU=
 github.com/rs/xhandler v0.0.0-20160618193221-ed27b6fd6521 h1:3hxavr+IHMsQBrYUPQM5v0CgENFktkkbg1sfpgM3h20=


### PR DESCRIPTION
This PR replaces the upstream leveldb with a patched one. See the leveldb PR here https://github.com/syndtr/goleveldb/pull/323

The main goal of this PR is benchmarking. 