### PR TITLE
eth/downloader: fix spuriously failing tests

### DIFF
--- a/miner/worker_test.go
+++ b/miner/worker_test.go
@@ -285,9 +285,7 @@ func testEmptyWork(t *testing.T, chainConfig *params.ChainConfig, engine consens
 	}
 	w.skipSealHook = func(task *task) bool { return true }
 	w.fullTaskHook = func() {
-		// Arch64 unit tests are running in a VM on travis, they must
-		// be given more time to execute.
-		time.Sleep(time.Second)
+		time.Sleep(100 * time.Millisecond)
 	}
 	w.start() // Start mining!
 	for i := 0; i < 2; i += 1 {


### PR DESCRIPTION
This PR fixes a test that was sometimes failing on travis, example
```
    downloader_test.go:686: failed to synchronise blocks: retrieved hash chain is invalid: InsertHeaderChain: unknown parent at first position, parent of number 577
```
I was able to repro it by inserting the following: 
```
func (dl *downloadTester) InsertHeaderChain(headers []*types.Header, checkFreq int) (i int, err error) {
    time.Sleep(500 * time.Millisecond)
        ...
```
It turns out that since we don't have checkpoints, the remote head determined the ancient-limit. So things were written directly to ancients, however, since the insertion of headers vs receipts was a bit racy, it sometimes happened that receipts were written before the next batch of headers arrive.  

When the next batch of headers arrived, we failed to check ancients for the parent, and we had also had deleted the `td` for those headers, while shoving them over to ancients. 
