### PR TITLE
accounts/abi: make GetType public again

### DIFF
--- a/accounts/abi/error.go
+++ b/accounts/abi/error.go
@@ -39,11 +39,11 @@ func formatSliceString(kind reflect.Kind, sliceSize int) string {
 // type in t.
 func sliceTypeCheck(t Type, val reflect.Value) error {
 	if val.Kind() != reflect.Slice && val.Kind() != reflect.Array {
-		return typeErr(formatSliceString(t.getType().Kind(), t.Size), val.Type())
+		return typeErr(formatSliceString(t.GetType().Kind(), t.Size), val.Type())
 	}
 
 	if t.T == ArrayTy && val.Len() != t.Size {
-		return typeErr(formatSliceString(t.Elem.getType().Kind(), t.Size), formatSliceString(val.Type().Elem().Kind(), val.Len()))
+		return typeErr(formatSliceString(t.Elem.GetType().Kind(), t.Size), formatSliceString(val.Type().Elem().Kind(), val.Len()))
 	}
 
 	if t.Elem.T == SliceTy || t.Elem.T == ArrayTy {
@@ -52,8 +52,8 @@ func sliceTypeCheck(t Type, val reflect.Value) error {
 		}
 	}
 
-	if elemKind := val.Type().Elem().Kind(); elemKind != t.Elem.getType().Kind() {
-		return typeErr(formatSliceString(t.Elem.getType().Kind(), t.Size), val.Type())
+	if elemKind := val.Type().Elem().Kind(); elemKind != t.Elem.GetType().Kind() {
+		return typeErr(formatSliceString(t.Elem.GetType().Kind(), t.Size), val.Type())
 	}
 	return nil
 }
@@ -66,10 +66,10 @@ func typeCheck(t Type, value reflect.Value) error {
 	}
 
 	// Check base type validity. Element types will be checked later on.
-	if t.getType().Kind() != value.Kind() {
-		return typeErr(t.getType().Kind(), value.Kind())
+	if t.GetType().Kind() != value.Kind() {
+		return typeErr(t.GetType().Kind(), value.Kind())
 	} else if t.T == FixedBytesTy && t.Size != value.Len() {
-		return typeErr(t.getType(), value.Type())
+		return typeErr(t.GetType(), value.Type())
 	} else {
 		return nil
 	}

--- a/accounts/abi/type.go
+++ b/accounts/abi/type.go
@@ -214,6 +214,7 @@ func NewType(t string, internalType string, components []ArgumentMarshaling) (ty
 	return
 }
 
+// GetType returns the reflection type of the ABI type.
 func (t Type) GetType() reflect.Type {
 	switch t.T {
 	case IntTy:

--- a/accounts/abi/type.go
+++ b/accounts/abi/type.go
@@ -176,7 +176,7 @@ func NewType(t string, internalType string, components []ArgumentMarshaling) (ty
 			overloadedNames[fieldName] = fieldName
 			fields = append(fields, reflect.StructField{
 				Name: fieldName, // reflect.StructOf will panic for any exported field.
-				Type: cType.getType(),
+				Type: cType.GetType(),
 				Tag:  reflect.StructTag("json:\"" + c.Name + "\""),
 			})
 			elems = append(elems, &cType)
@@ -214,7 +214,7 @@ func NewType(t string, internalType string, components []ArgumentMarshaling) (ty
 	return
 }
 
-func (t Type) getType() reflect.Type {
+func (t Type) GetType() reflect.Type {
 	switch t.T {
 	case IntTy:
 		return reflectIntType(false, t.Size)
@@ -225,9 +225,9 @@ func (t Type) getType() reflect.Type {
 	case StringTy:
 		return reflect.TypeOf("")
 	case SliceTy:
-		return reflect.SliceOf(t.Elem.getType())
+		return reflect.SliceOf(t.Elem.GetType())
 	case ArrayTy:
-		return reflect.ArrayOf(t.Size, t.Elem.getType())
+		return reflect.ArrayOf(t.Size, t.Elem.GetType())
 	case TupleTy:
 		return t.TupleType
 	case AddressTy:

--- a/accounts/abi/unpack.go
+++ b/accounts/abi/unpack.go
@@ -110,7 +110,7 @@ func ReadFixedBytes(t Type, word []byte) (interface{}, error) {
 		return nil, fmt.Errorf("abi: invalid type in call to make fixed byte array")
 	}
 	// convert
-	array := reflect.New(t.getType()).Elem()
+	array := reflect.New(t.GetType()).Elem()
 
 	reflect.Copy(array, reflect.ValueOf(word[0:t.Size]))
 	return array.Interface(), nil
@@ -131,10 +131,10 @@ func forEachUnpack(t Type, output []byte, start, size int) (interface{}, error) 
 
 	if t.T == SliceTy {
 		// declare our slice
-		refSlice = reflect.MakeSlice(t.getType(), size, size)
+		refSlice = reflect.MakeSlice(t.GetType(), size, size)
 	} else if t.T == ArrayTy {
 		// declare our array
-		refSlice = reflect.New(t.getType()).Elem()
+		refSlice = reflect.New(t.GetType()).Elem()
 	} else {
 		return nil, fmt.Errorf("abi: invalid type in array/slice unpacking stage")
 	}
@@ -158,7 +158,7 @@ func forEachUnpack(t Type, output []byte, start, size int) (interface{}, error) 
 }
 
 func forTupleUnpack(t Type, output []byte) (interface{}, error) {
-	retval := reflect.New(t.getType()).Elem()
+	retval := reflect.New(t.GetType()).Elem()
 	virtualArgs := 0
 	for index, elem := range t.TupleElems {
 		marshalledValue, err := toGoType((index+virtualArgs)*32, *elem, output)


### PR DESCRIPTION
Change the private `abi.Type.getType()` method to public.

The `abi.Type.Type` field has been made private in 1.9.14 as the `getType()` method. This breaks some code including the project we were working on which relies on it quite heavily. As this change is keeping backward compatibility and a simple change, I think it is worth it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ethereum/go-ethereum/21157)
<!-- Reviewable:end -->
