### PR TITLE
core: insert local transactions first

### DIFF
--- a/core/tx_pool_test.go
+++ b/core/tx_pool_test.go
@@ -1926,7 +1926,7 @@ func BenchmarkLocalInsert(b *testing.B) {
 		remoteKeys = append(remoteKeys, key)
 	}
 	// The reason for picking these numbers is ~4000 txs/s is a reasonable peak value
-	// in the real mainnet. It's valueable to benchmark with these parameters.
+	// in the real mainnet. It's valuable to benchmark with these parameters.
 	locals := make([]*types.Transaction, 50)
 	for i := 0; i < 50; i++ {
 		locals[i] = transaction(uint64(i), 100000, key)

--- a/core/tx_pool_test.go
+++ b/core/tx_pool_test.go
@@ -1914,3 +1914,65 @@ func benchmarkPoolBatchInsert(b *testing.B, size int) {
 		pool.AddRemotes(batch)
 	}
 }
+
+func BenchmarkLocalInsert(b *testing.B) {
+	// Allocate keys for testing
+	key, _ := crypto.GenerateKey()
+	account := crypto.PubkeyToAddress(key.PublicKey)
+
+	var remoteKeys []*ecdsa.PrivateKey
+	for i := 0; i < 4; i++ {
+		key, _ := crypto.GenerateKey()
+		remoteKeys = append(remoteKeys, key)
+	}
+	// The reason for picking these numbers is ~4000 txs/s is a reasonable peak value
+	// in the real mainnet. It's valueable to benchmark with these parameters.
+	locals := make([]*types.Transaction, 50)
+	for i := 0; i < 50; i++ {
+		locals[i] = transaction(uint64(i), 100000, key)
+	}
+	remotes := make([][]*types.Transaction, 4)
+	for i := 0; i < 4; i++ {
+		remotes[i] = make(types.Transactions, 1000)
+		for j := 0; j < 1000; j++ {
+			remotes[i][j] = transaction(uint64(j), 100000, remoteKeys[i])
+		}
+	}
+	// Benchmark importing the transactions into the queue
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		// Assign a high enough balance for testing
+		pool, _ := setupTxPool()
+		pool.currentState.AddBalance(account, big.NewInt(100000000))
+		for i := 0; i < len(remoteKeys); i++ {
+			account := crypto.PubkeyToAddress(remoteKeys[i].PublicKey)
+			pool.currentState.AddBalance(account, big.NewInt(100000000))
+		}
+		// Spin up go-routines to simulate pressure of inserting remote txs
+		done := make(chan struct{})
+		defer close(done)
+
+		for i := 0; i < 4; i++ {
+			go func(keyIndex int) {
+				var index int
+				for {
+					pool.AddRemotes([]*types.Transaction{remotes[keyIndex][index]})
+					index += 1
+					if index >= len(remotes[keyIndex]) {
+						return
+					}
+					select {
+					case <-done:
+						return
+					default:
+					}
+				}
+			}(i)
+		}
+		for i := 0; i < len(locals); i++ {
+			pool.AddLocal(locals[i])
+		}
+		pool.Stop()
+	}
+}

--- a/core/tx_pool_test.go
+++ b/core/tx_pool_test.go
@@ -1884,7 +1884,7 @@ func benchmarkFuturePromotion(b *testing.B, size int) {
 	// Benchmark the speed of pool validation
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		pool.promoteExecutables(nil)
+		pool.promoteExecutables([]common.Address{account})
 	}
 }
 


### PR DESCRIPTION
This PR does a trick to allow local transactions to cut in line for insertion.

<img width="1256" alt="截屏2020-06-04上午10 46 49" src="https://user-images.githubusercontent.com/5959481/83709254-b3a8cc80-a650-11ea-8cc0-d5320c214670.png">

From this chart, we can see the txpool pressure of inserting transactions can be very high(~4000tx/s). In this case, the lock resource can be super busy and is not easy for local users to submit txs quickly.

So this PR offers the feature for inserting locals first.

### Benchmark

This PR offers a benchmark for simulation by insertion tons of remote transactions concurrently and tests the time for inserting 50 local transactions

**Master**

```
goos: linux
goarch: 386
pkg: github.com/ethereum/go-ethereum/core
BenchmarkLocalInsert
BenchmarkLocalInsert-8                21          71377886 ns/op
```

**Exp**

```
goos: linux
goarch: 386
pkg: github.com/ethereum/go-ethereum/core
BenchmarkLocalInsert
BenchmarkLocalInsert-8                38          28283317 ns/op
```

