### PR TITLE
acounts/keystore, cmd/faucet: fix faucet double import, fix twitter url

### DIFF
--- a/accounts/keystore/keystore.go
+++ b/accounts/keystore/keystore.go
@@ -43,6 +43,10 @@ var (
 	ErrLocked  = accounts.NewAuthNeededError("password or unlock")
 	ErrNoMatch = errors.New("no key for given address or file")
 	ErrDecrypt = errors.New("could not decrypt key with given password")
+
+	// ErrAccountAlreadyExists is returned if an account attempted to import is
+	// already present in the keystore.
+	ErrAccountAlreadyExists = errors.New("account alreaady exists")
 )
 
 // KeyStoreType is the reflect type of a keystore backend.
@@ -446,7 +450,7 @@ func (ks *KeyStore) Import(keyJSON []byte, passphrase, newPassphrase string) (ac
 	ks.importMu.Lock()
 	defer ks.importMu.Unlock()
 	if ks.cache.hasAddress(key.Address) {
-		return accounts.Account{}, errors.New("account already exists")
+		return accounts.Account{}, ErrAccountAlreadyExists
 	}
 	return ks.importKey(key, newPassphrase)
 }
@@ -457,7 +461,7 @@ func (ks *KeyStore) ImportECDSA(priv *ecdsa.PrivateKey, passphrase string) (acco
 	ks.importMu.Lock()
 	defer ks.importMu.Unlock()
 	if ks.cache.hasAddress(key.Address) {
-		return accounts.Account{}, errors.New("account already exists")
+		return accounts.Account{}, ErrAccountAlreadyExists
 	}
 	return ks.importKey(key, passphrase)
 }


### PR DESCRIPTION
Twitter swapped their UI to have a React frontend and use an API to retrieve the tweet contents. This broke the faucet because we just scrape to avoid needing an API key. This PR switched over to the non-javascript Twitter site to keep the old functionality going (until they nuke it I guess).

Fixes #21166 