### PR TITLE
cmd/faucet: delete old keystore when importing new faucet key

### DIFF
--- a/accounts/keystore/keystore.go
+++ b/accounts/keystore/keystore.go
@@ -449,19 +449,25 @@ func (ks *KeyStore) Import(keyJSON []byte, passphrase, newPassphrase string) (ac
 	}
 	ks.importMu.Lock()
 	defer ks.importMu.Unlock()
+
 	if ks.cache.hasAddress(key.Address) {
-		return accounts.Account{}, ErrAccountAlreadyExists
+		return accounts.Account{
+			Address: key.Address,
+		}, ErrAccountAlreadyExists
 	}
 	return ks.importKey(key, newPassphrase)
 }
 
 // ImportECDSA stores the given key into the key directory, encrypting it with the passphrase.
 func (ks *KeyStore) ImportECDSA(priv *ecdsa.PrivateKey, passphrase string) (accounts.Account, error) {
-	key := newKeyFromECDSA(priv)
 	ks.importMu.Lock()
 	defer ks.importMu.Unlock()
+
+	key := newKeyFromECDSA(priv)
 	if ks.cache.hasAddress(key.Address) {
-		return accounts.Account{}, ErrAccountAlreadyExists
+		return accounts.Account{
+			Address: key.Address,
+		}, ErrAccountAlreadyExists
 	}
 	return ks.importKey(key, passphrase)
 }

--- a/cmd/faucet/faucet.go
+++ b/cmd/faucet/faucet.go
@@ -162,7 +162,6 @@ func main() {
 	if blob, err = ioutil.ReadFile(*accPassFlag); err != nil {
 		log.Crit("Failed to read account password contents", "file", *accPassFlag, "err", err)
 	}
-	// Delete trailing newline in password
 	pass := strings.TrimSuffix(string(blob), "\n")
 
 	ks := keystore.NewKeyStore(filepath.Join(os.Getenv("HOME"), ".faucet", "keys"), keystore.StandardScryptN, keystore.StandardScryptP)
@@ -173,8 +172,9 @@ func main() {
 	if err != nil && err != keystore.ErrAccountAlreadyExists {
 		log.Crit("Failed to import faucet signer account", "err", err)
 	}
-	ks.Unlock(acc, pass)
-
+	if err := ks.Unlock(acc, pass); err != nil {
+		log.Crit("Failed to unlock faucet signer account", "err", err)
+	}
 	// Assemble and start the faucet light service
 	faucet, err := newFaucet(genesis, *ethPortFlag, enodes, *netFlag, *statsFlag, ks, website.Bytes())
 	if err != nil {


### PR DESCRIPTION
Fixes https://github.com/ethereum/go-ethereum/issues/21166 again.

This PR modified the account import so that if an old account already exists, it at least tells us what the address is. The URL we're not able to return if there are multiple old accounts existing. Maybe in that case we should error out with an even fancier issue, but that's getting even more messy that we currently are.

If there's only one previously existing account, then keystore operations will still succeed without the URL, so that should be fine-ish. This whole scenario is a bit messy tbh.