### PR TITLE
cmd/ethkey: support --passwordfile in generate command

### DIFF
--- a/cmd/ethkey/changepassword.go
+++ b/cmd/ethkey/changepassword.go
@@ -51,7 +51,7 @@ Change the password of a keyfile.`,
 		}
 
 		// Decrypt key with passphrase.
-		passphrase := getPassphrase(ctx)
+		passphrase := getPassphrase(ctx, false)
 		key, err := keystore.DecryptKey(keyjson, passphrase)
 		if err != nil {
 			utils.Fatalf("Error decrypting key: %v", err)

--- a/cmd/ethkey/generate.go
+++ b/cmd/ethkey/generate.go
@@ -94,7 +94,12 @@ If you want to encrypt an existing private key, it can be specified by setting
 		}
 
 		// Encrypt key with passphrase.
-		passphrase := promptPassphrase(true)
+		var passphrase string
+		if file := ctx.String(passphraseFlag.Name); file != "" {
+			passphrase = getPassphrase(ctx)
+		} else {
+			passphrase = promptPassphrase(true)
+		}
 		scryptN, scryptP := keystore.StandardScryptN, keystore.StandardScryptP
 		if ctx.Bool("lightkdf") {
 			scryptN, scryptP = keystore.LightScryptN, keystore.LightScryptP

--- a/cmd/ethkey/generate.go
+++ b/cmd/ethkey/generate.go
@@ -95,7 +95,6 @@ If you want to encrypt an existing private key, it can be specified by setting
 
 		// Encrypt key with passphrase.
 		passphrase := getPassphrase(ctx, true)
-
 		scryptN, scryptP := keystore.StandardScryptN, keystore.StandardScryptP
 		if ctx.Bool("lightkdf") {
 			scryptN, scryptP = keystore.LightScryptN, keystore.LightScryptP

--- a/cmd/ethkey/generate.go
+++ b/cmd/ethkey/generate.go
@@ -94,12 +94,8 @@ If you want to encrypt an existing private key, it can be specified by setting
 		}
 
 		// Encrypt key with passphrase.
-		var passphrase string
-		if file := ctx.String(passphraseFlag.Name); file != "" {
-			passphrase = getPassphrase(ctx)
-		} else {
-			passphrase = promptPassphrase(true)
-		}
+		passphrase := getPassphrase(ctx, true)
+
 		scryptN, scryptP := keystore.StandardScryptN, keystore.StandardScryptP
 		if ctx.Bool("lightkdf") {
 			scryptN, scryptP = keystore.LightScryptN, keystore.LightScryptP

--- a/cmd/ethkey/inspect.go
+++ b/cmd/ethkey/inspect.go
@@ -60,7 +60,7 @@ make sure to use this feature with great caution!`,
 		}
 
 		// Decrypt key with passphrase.
-		passphrase := getPassphrase(ctx)
+		passphrase := getPassphrase(ctx, false)
 		key, err := keystore.DecryptKey(keyjson, passphrase)
 		if err != nil {
 			utils.Fatalf("Error decrypting key: %v", err)

--- a/cmd/ethkey/message.go
+++ b/cmd/ethkey/message.go
@@ -62,7 +62,7 @@ To sign a message contained in a file, use the --msgfile flag.
 		}
 
 		// Decrypt key with passphrase.
-		passphrase := getPassphrase(ctx)
+		passphrase := getPassphrase(ctx, false)
 		key, err := keystore.DecryptKey(keyjson, passphrase)
 		if err != nil {
 			utils.Fatalf("Error decrypting key: %v", err)

--- a/cmd/ethkey/utils.go
+++ b/cmd/ethkey/utils.go
@@ -52,7 +52,7 @@ func promptPassphrase(confirmation bool) string {
 // getPassphrase obtains a passphrase given by the user.  It first checks the
 // --passfile command line flag and ultimately prompts the user for a
 // passphrase.
-func getPassphrase(ctx *cli.Context) string {
+func getPassphrase(ctx *cli.Context, confirmation bool) string {
 	// Look for the --passwordfile flag.
 	passphraseFile := ctx.String(passphraseFlag.Name)
 	if passphraseFile != "" {
@@ -65,7 +65,7 @@ func getPassphrase(ctx *cli.Context) string {
 	}
 
 	// Otherwise prompt the user for the passphrase.
-	return promptPassphrase(false)
+	return promptPassphrase(confirmation)
 }
 
 // signHash is a helper function that calculates a hash for the given message


### PR DESCRIPTION
Add the `--passwordfile` flag to the `ethkey generate` keyfile command, the `--passwordfile` is used to make the command non-interactive, e.g.`ethkey generate --privatekey privatekey --passwordfile password.txt`