### PR TITLE
Fix typo on node.Config toml tags

### DIFF
--- a/node/config.go
+++ b/node/config.go
@@ -83,7 +83,7 @@ type Config struct {
 	KeyStoreDir string `toml:",omitempty"`
 
 	// ExternalSigner specifies an external URI for a clef-type signer
-	ExternalSigner string `toml:"omitempty"`
+	ExternalSigner string `toml:",omitempty"`
 
 	// UseLightweightKDF lowers the memory and CPU requirements of the key store
 	// scrypt KDF at the expense of security.


### PR DESCRIPTION
Missing `,` on the config