### PR TITLE
core/state: avoid escape analysis fault when accessing cached state

### DIFF
--- a/core/state/state_object.go
+++ b/core/state/state_object.go
@@ -213,14 +213,14 @@ func (s *stateObject) GetCommittedState(db Database, key common.Hash) common.Has
 		if _, destructed := s.db.snapDestructs[s.addrHash]; destructed {
 			return common.Hash{}
 		}
-		enc, err = s.db.snap.Storage(s.addrHash, crypto.Keccak256Hash(key[:]))
+		enc, err = s.db.snap.Storage(s.addrHash, crypto.Keccak256Hash(key.Bytes()))
 	}
 	// If snapshot unavailable or reading from it failed, load from the database
 	if s.db.snap == nil || err != nil {
 		if metrics.EnabledExpensive {
 			defer func(start time.Time) { s.db.StorageReads += time.Since(start) }(time.Now())
 		}
-		if enc, err = s.getTrie(db).TryGet(key[:]); err != nil {
+		if enc, err = s.getTrie(db).TryGet(key.Bytes()); err != nil {
 			s.setError(err)
 			return common.Hash{}
 		}

--- a/core/state/statedb.go
+++ b/core/state/statedb.go
@@ -513,7 +513,7 @@ func (s *StateDB) getDeletedStateObject(addr common.Address) *stateObject {
 			defer func(start time.Time) { s.SnapshotAccountReads += time.Since(start) }(time.Now())
 		}
 		var acc *snapshot.Account
-		if acc, err = s.snap.Account(crypto.Keccak256Hash(addr[:])); err == nil {
+		if acc, err = s.snap.Account(crypto.Keccak256Hash(addr.Bytes())); err == nil {
 			if acc == nil {
 				return nil
 			}
@@ -532,9 +532,9 @@ func (s *StateDB) getDeletedStateObject(addr common.Address) *stateObject {
 		if metrics.EnabledExpensive {
 			defer func(start time.Time) { s.AccountReads += time.Since(start) }(time.Now())
 		}
-		enc, err := s.trie.TryGet(addr[:])
+		enc, err := s.trie.TryGet(addr.Bytes())
 		if err != nil {
-			s.setError(fmt.Errorf("getDeleteStateObject (%x) error: %v", addr[:], err))
+			s.setError(fmt.Errorf("getDeleteStateObject (%x) error: %v", addr.Bytes(), err))
 			return nil
 		}
 		if len(enc) == 0 {


### PR DESCRIPTION
Apparently Go's escape analysis is not the brightest tool in the shed. If a method gets a hash/account as a method argument, and the internal `[]byte` representation is accessed within the method via `[:]`, escape analysis faults and the argument will be copied. Within the `state` package, this means that even if we access already cached objects, the method will do an extra allocation because the non-cached path used `[:]`. By changing those invocations into `.Bytes()`, escape faults happen only at those call sites and we avoid the copying the arguments for most cases.

Running the SnailTracer benchmark drives this PR home.

Master:
```
EVM gas used:    1615266220
allocations:     300194
allocated bytes: 134674020
```

PR:
```
EVM gas used:    1615266220
allocations:     2195
allocated bytes: 125135964
```

CC @AlexeyAkhunov, you might be interested in pulling this in.