### PR TITLE
eth/downloaded: fixed datarace between synchronize and Progress

### DIFF
--- a/eth/downloader/downloader.go
+++ b/eth/downloader/downloader.go
@@ -416,7 +416,9 @@ func (d *Downloader) synchronise(id string, hash common.Hash, td *big.Int, mode 
 	defer d.Cancel() // No matter what, we can't leave the cancel channel open
 
 	// Set the requested sync mode, unless it's forbidden
+	d.syncStatsLock.Lock()
 	d.mode = mode
+	d.syncStatsLock.Unlock()
 
 	// Retrieve the origin peer and initiate the downloading process
 	p := d.peers.Peer(id)


### PR DESCRIPTION
This fixes a race condition between `Progress()` and `synchronize()`.
See: https://github.com/ethereum/go-ethereum/issues/21196
