### PR TITLE
crypto/secp256k1: enable 128-bit int code and endomorphism optimization

### DIFF
--- a/crypto/secp256k1/secp256.go
+++ b/crypto/secp256k1/secp256.go
@@ -18,6 +18,7 @@ package secp256k1
 #  define USE_SCALAR_8X32
 #endif
 
+#define USE_ENDOMORPHISM
 #define USE_NUM_NONE
 #define USE_FIELD_INV_BUILTIN
 #define USE_SCALAR_INV_BUILTIN

--- a/crypto/secp256k1/secp256.go
+++ b/crypto/secp256k1/secp256.go
@@ -8,10 +8,18 @@ package secp256k1
 /*
 #cgo CFLAGS: -I./libsecp256k1
 #cgo CFLAGS: -I./libsecp256k1/src/
+
+#ifdef __SIZEOF_INT128__
+#  define HAVE___INT128
+#  define USE_FIELD_5X52
+#  define USE_SCALAR_4X64
+#else
+#  define USE_FIELD_10X26
+#  define USE_SCALAR_8X32
+#endif
+
 #define USE_NUM_NONE
-#define USE_FIELD_10X26
 #define USE_FIELD_INV_BUILTIN
-#define USE_SCALAR_8X32
 #define USE_SCALAR_INV_BUILTIN
 #define NDEBUG
 #include "./libsecp256k1/src/secp256k1.c"


### PR DESCRIPTION
Just the 128bit int change:

```
name       old time/op  new time/op  delta
pkg:github.com/ethereum/go-ethereum/crypto/secp256k1 goos:darwin goarch:amd64
Sign-8      114µs ± 1%    67µs ± 8%  -41.64%  (p=0.000 n=9+10)
Recover-8   203µs ± 2%   115µs ± 1%  -43.59%  (p=0.000 n=9+7)
```

Just the endomorphism change:

```
name       old time/op  new time/op  delta
pkg:github.com/ethereum/go-ethereum/crypto/secp256k1 goos:darwin goarch:amd64
Sign-8                 114µs ± 1%   112µs ± 1%   -1.71%  (p=0.000 n=9+9)
Recover-8              203µs ± 2%   156µs ± 2%  -23.25%  (p=0.000 n=9+10)
```

Both changes:

```
name       old time/op  new time/op  delta
pkg:github.com/ethereum/go-ethereum/crypto/secp256k1 goos:darwin goarch:amd64
Sign-8      114µs ± 1%    63µs ± 7%  -44.66%  (p=0.000 n=9+10)
Recover-8   203µs ± 2%    88µs ± 2%  -56.97%  (p=0.000 n=9+10)
```

This is similar to https://github.com/ledgerwatch/turbo-geth/pull/600 but avoids the library update.
Ref https://github.com/ethereum/go-ethereum/issues/21179
