### PR TITLE
unmergeable: benchmarking

### DIFF
--- a/core/vm/contracts.go
+++ b/core/vm/contracts.go
@@ -205,6 +205,7 @@ func (c *dataCopy) Run(in []byte) ([]byte, error) {
 type bigModExp struct{}
 
 var (
+	big0      = big.NewInt(0)
 	big1      = big.NewInt(1)
 	big4      = big.NewInt(4)
 	big8      = big.NewInt(8)

--- a/core/vm/contracts.go
+++ b/core/vm/contracts.go
@@ -102,12 +102,18 @@ var PrecompiledContractsYoloV1 = map[common.Address]PrecompiledContract{
 }
 
 // RunPrecompiledContract runs and evaluates the output of a precompiled contract.
-func RunPrecompiledContract(p PrecompiledContract, input []byte, contract *Contract) (ret []byte, err error) {
-	gas := p.RequiredGas(input)
-	if contract.UseGas(gas) {
-		return p.Run(input)
+// It returns
+// - the returned bytes,
+// - the _remaining_ gas,
+// - any error that occurred
+func RunPrecompiledContract(p PrecompiledContract, input []byte, suppliedGas uint64) (ret []byte, remainingGas uint64, err error) {
+	gasCost := p.RequiredGas(input)
+	if suppliedGas < gasCost {
+		return nil, 0, ErrOutOfGas
 	}
-	return nil, ErrOutOfGas
+	suppliedGas -= gasCost
+	output, err := p.Run(input)
+	return output, suppliedGas, err
 }
 
 // ECRECOVER implemented as a native contract.

--- a/core/vm/contracts.go
+++ b/core/vm/contracts.go
@@ -187,10 +187,12 @@ type dataCopy struct{}
 // This method does not require any overflow checking as the input size gas costs
 // required for anything significant is so high it's impossible to pay for.
 func (c *dataCopy) RequiredGas(input []byte) uint64 {
+	return 0
 	return uint64(len(input)+31)/32*params.IdentityPerWordGas + params.IdentityBaseGas
 }
 func (c *dataCopy) Run(in []byte) ([]byte, error) {
-	return in, nil
+	return nil, nil
+	//return in, nil
 }
 
 // bigModExp implements a native big integer exponential modular operation.

--- a/core/vm/evm.go
+++ b/core/vm/evm.go
@@ -354,16 +354,15 @@ func (evm *EVM) StaticCall(caller ContractRef, addr common.Address, input []byte
 	// This doesn't matter on Mainnet, where all empties are gone at the time of Byzantium,
 	// but is the correct thing to do and matters on other networks, in tests, and potential
 	// future scenarios
-	evm.StateDB.AddBalance(addr, big.NewInt(0))
+	evm.StateDB.AddBalance(addr, big0)
 
 	if p, isPrecompile := evm.precompile(addr); isPrecompile {
-		 return RunPrecompiledContract(p, input, gas)
+		return RunPrecompiledContract(p, input, gas)
 	}
 	// Initialise a new contract and set the code that is to be used by the EVM.
 	// The contract is a scoped environment for this execution context only.
 	contract := NewContract(caller, to, new(big.Int), gas)
 	contract.SetCallCode(&addr, evm.StateDB.GetCodeHash(addr), evm.StateDB.GetCode(addr))
-
 
 	// When an error was returned by the EVM or when setting the creation code
 	// above we revert to the snapshot and consume any gas remaining. Additionally

--- a/core/vm/runtime/runtime.go
+++ b/core/vm/runtime/runtime.go
@@ -52,13 +52,20 @@ type Config struct {
 func setDefaults(cfg *Config) {
 	if cfg.ChainConfig == nil {
 		cfg.ChainConfig = &params.ChainConfig{
-			ChainID:        big.NewInt(1),
-			HomesteadBlock: new(big.Int),
-			DAOForkBlock:   new(big.Int),
-			DAOForkSupport: false,
-			EIP150Block:    new(big.Int),
-			EIP155Block:    new(big.Int),
-			EIP158Block:    new(big.Int),
+			ChainID:             big.NewInt(1),
+			HomesteadBlock:      new(big.Int),
+			DAOForkBlock:        new(big.Int),
+			DAOForkSupport:      false,
+			EIP150Block:         new(big.Int),
+			EIP150Hash:          common.Hash{},
+			EIP155Block:         new(big.Int),
+			EIP158Block:         new(big.Int),
+			ByzantiumBlock:      new(big.Int),
+			ConstantinopleBlock: new(big.Int),
+			PetersburgBlock:     new(big.Int),
+			IstanbulBlock:       new(big.Int),
+			MuirGlacierBlock:    new(big.Int),
+			YoloV1Block:         nil,
 		}
 	}
 

--- a/core/vm/runtime/runtime_test.go
+++ b/core/vm/runtime/runtime_test.go
@@ -582,6 +582,7 @@ func benchmarkNonModifyingCode(gas uint64, code []byte, name string, b *testing.
 	//cfg.State.CreateAccount(cfg.Origin)
 	// set the receiver's (the executing contract) code for execution.
 	cfg.State.SetCode(destination, code)
+	vmenv.Call(sender, destination, nil, gas, cfg.Value)
 
 	b.Run(name, func(b *testing.B) {
 		b.ReportAllocs()

--- a/core/vm/runtime/runtime_test.go
+++ b/core/vm/runtime/runtime_test.go
@@ -321,34 +321,6 @@ func TestBlockhash(t *testing.T) {
 	}
 }
 
-// BenchmarkSimpleLoop test a pretty simple loop which loops
-// 1M (1 048 575) times.
-// Takes about 200 ms
-func BenchmarkSimpleLoop(b *testing.B) {
-	// 0xfffff = 1048575 loops
-	code := []byte{
-		byte(vm.PUSH3), 0x0f, 0xff, 0xff,
-		byte(vm.JUMPDEST), //  [ count ]
-		byte(vm.PUSH1), 1, // [count, 1]
-		byte(vm.SWAP1),    // [1, count]
-		byte(vm.SUB),      // [ count -1 ]
-		byte(vm.DUP1),     //  [ count -1 , count-1]
-		byte(vm.PUSH1), 4, // [count-1, count -1, label]
-		byte(vm.JUMPI), // [ 0 ]
-		byte(vm.STOP),
-	}
-	//tracer := vm.NewJSONLogger(nil, os.Stdout)
-	//Execute(code, nil, &Config{
-	//	EVMConfig: vm.Config{
-	//		Debug:  true,
-	//		Tracer: tracer,
-	//	}})
-
-	for i := 0; i < b.N; i++ {
-		Execute(code, nil, nil)
-	}
-}
-
 type stepCounter struct {
 	inner *vm.JSONLogger
 	steps int
@@ -592,4 +564,78 @@ func DisabledTestEipExampleCases(t *testing.T) {
 		prettyPrint("In this example, the code 'walks' into a subroutine, which is not "+
 			"allowed, and causes an error", code)
 	}
+}
+
+// benchmarkNonModifyingCode benchmarks code, but if the code modifies the
+// state, this should not be used, since it does not reset the state between runs.
+func benchmarkNonModifyingCode(gas uint64, code []byte, name string, b *testing.B) {
+	cfg := new(Config)
+	setDefaults(cfg)
+	cfg.State, _ = state.New(common.Hash{}, state.NewDatabase(rawdb.NewMemoryDatabase()), nil)
+	cfg.GasLimit = gas
+	var (
+		destination = common.BytesToAddress([]byte("contract"))
+		vmenv       = NewEnv(cfg)
+		sender      = vm.AccountRef(cfg.Origin)
+	)
+	cfg.State.CreateAccount(destination)
+	//cfg.State.CreateAccount(cfg.Origin)
+	// set the receiver's (the executing contract) code for execution.
+	cfg.State.SetCode(destination, code)
+
+	b.Run(name, func(b *testing.B) {
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			vmenv.Call(sender, destination, nil, gas, cfg.Value)
+		}
+	})
+}
+
+// BenchmarkSimpleLoop test a pretty simple loop which loops until OOG
+// 55 ms
+func BenchmarkSimpleLoop(b *testing.B) {
+
+	precompileCallerCode := []byte{
+		byte(vm.JUMPDEST), //  [ count ]
+		// push args for the call
+		byte(vm.PUSH1), 0, // out size
+		byte(vm.DUP1),       // out offset
+		byte(vm.DUP1),       // out insize
+		byte(vm.DUP1),       // in offset
+		byte(vm.PUSH1), 0x4, // address of identity
+		byte(vm.GAS), // gas
+		byte(vm.STATICCALL),
+		byte(vm.POP),      // pop return value
+		byte(vm.PUSH1), 0, // jumpdestination
+		byte(vm.JUMP),
+	}
+
+	loopingCode := []byte{
+		byte(vm.JUMPDEST), //  [ count ]
+		// push args for the call
+		byte(vm.PUSH1), 0, // out size
+		byte(vm.DUP1),       // out offset
+		byte(vm.DUP1),       // out insize
+		byte(vm.DUP1),       // in offset
+		byte(vm.PUSH1), 0x4, // address of identity
+		byte(vm.GAS), // gas
+
+		byte(vm.POP),byte(vm.POP),byte(vm.POP),byte(vm.POP),byte(vm.POP),byte(vm.POP),
+		byte(vm.PUSH1), 0, // jumpdestination
+		byte(vm.JUMP),
+	}
+
+	//tracer := vm.NewJSONLogger(nil, os.Stdout)
+	//Execute(loopingCode, nil, &Config{
+	//	EVMConfig: vm.Config{
+	//		Debug:  true,
+	//		Tracer: tracer,
+	//	}})
+	// 100M gas
+	benchmarkNonModifyingCode(100000000, precompileCallerCode, "identity-precompile-100M", b)
+	benchmarkNonModifyingCode(100000000, loopingCode, "loop-100M", b)
+
+
+	//benchmarkNonModifyingCode(10000000, precompileCallerCode, "identity-precompile-10M", b)
+	//benchmarkNonModifyingCode(10000000, loopingCode, "loop-10M", b)
 }

--- a/core/vm/runtime/runtime_test.go
+++ b/core/vm/runtime/runtime_test.go
@@ -632,10 +632,10 @@ func BenchmarkSimpleLoop(b *testing.B) {
 	//		Tracer: tracer,
 	//	}})
 	// 100M gas
-	benchmarkNonModifyingCode(100000000, precompileCallerCode, "identity-precompile-100M", b)
-	benchmarkNonModifyingCode(100000000, loopingCode, "loop-100M", b)
+	//benchmarkNonModifyingCode(100000000, precompileCallerCode, "identity-precompile-100M", b)
+	//benchmarkNonModifyingCode(100000000, loopingCode, "loop-100M", b)
 
 
-	//benchmarkNonModifyingCode(10000000, precompileCallerCode, "identity-precompile-10M", b)
-	//benchmarkNonModifyingCode(10000000, loopingCode, "loop-10M", b)
+	benchmarkNonModifyingCode(10000000, precompileCallerCode, "identity-precompile-10M", b)
+	benchmarkNonModifyingCode(10000000, loopingCode, "loop-10M", b)
 }

--- a/core/vm/runtime/runtime_test.go
+++ b/core/vm/runtime/runtime_test.go
@@ -632,8 +632,8 @@ func BenchmarkSimpleLoop(b *testing.B) {
 	//		Tracer: tracer,
 	//	}})
 	// 100M gas
-	//benchmarkNonModifyingCode(100000000, precompileCallerCode, "identity-precompile-100M", b)
-	//benchmarkNonModifyingCode(100000000, loopingCode, "loop-100M", b)
+	benchmarkNonModifyingCode(100000000, precompileCallerCode, "identity-precompile-100M", b)
+	benchmarkNonModifyingCode(100000000, loopingCode, "loop-100M", b)
 
 
 	benchmarkNonModifyingCode(10000000, precompileCallerCode, "identity-precompile-10M", b)

--- a/params/protocol_params.go
+++ b/params/protocol_params.go
@@ -81,7 +81,7 @@ const (
 
 	// These have been changed during the course of the chain
 	CallGasFrontier              uint64 = 40  // Once per CALL operation & message call transaction.
-	CallGasEIP150                uint64 = 100 // Static portion of gas for CALL-derivates after EIP 150 (Tangerine)
+	CallGasEIP150                uint64 = 40 // Static portion of gas for CALL-derivates after EIP 150 (Tangerine)
 	BalanceGasFrontier           uint64 = 20  // The cost of a BALANCE operation
 	BalanceGasEIP150             uint64 = 400 // The cost of a BALANCE operation after Tangerine
 	BalanceGasEIP1884            uint64 = 700 // The cost of a BALANCE operation after EIP 1884 (part of Istanbul)

--- a/params/protocol_params.go
+++ b/params/protocol_params.go
@@ -81,7 +81,7 @@ const (
 
 	// These have been changed during the course of the chain
 	CallGasFrontier              uint64 = 40  // Once per CALL operation & message call transaction.
-	CallGasEIP150                uint64 = 700 // Static portion of gas for CALL-derivates after EIP 150 (Tangerine)
+	CallGasEIP150                uint64 = 100 // Static portion of gas for CALL-derivates after EIP 150 (Tangerine)
 	BalanceGasFrontier           uint64 = 20  // The cost of a BALANCE operation
 	BalanceGasEIP150             uint64 = 400 // The cost of a BALANCE operation after Tangerine
 	BalanceGasEIP1884            uint64 = 700 // The cost of a BALANCE operation after EIP 1884 (part of Istanbul)


### PR DESCRIPTION
This is not actually a PR, but an analysis of the cost of calling precompiles, due to EIP-2046 to lower the cost of calling precompiles.

It's based on benchmarking the following two loops, which both loops until `OOG`:

## `prog1`

Code which calls the `identity` precompile with zero arguments:
```
		byte(vm.JUMPDEST), //  [ count ]
		// push args for the call
		byte(vm.PUSH1), 0, // out size
		byte(vm.DUP1),       // out offset
		byte(vm.DUP1),       // out insize
		byte(vm.DUP1),       // in offset
		byte(vm.PUSH1), 0x4, // address of identity
		byte(vm.GAS), // gas
		byte(vm.STATICCALL),
		byte(vm.POP),      // pop return value
		byte(vm.PUSH1), 0, // jumpdestination
		byte(vm.JUMP),
```

## `prog2`

And code which doesn't do the call, but instead just pops the arguments off the stack:
```
		byte(vm.JUMPDEST), //  [ count ]
		// push args for the call
		byte(vm.PUSH1), 0, // out size
		byte(vm.DUP1),       // out offset
		byte(vm.DUP1),       // out insize
		byte(vm.DUP1),       // in offset
		byte(vm.PUSH1), 0x4, // address of identity
		byte(vm.GAS), // gas

		byte(vm.POP),byte(vm.POP),byte(vm.POP),byte(vm.POP),byte(vm.POP),byte(vm.POP),
		byte(vm.PUSH1), 0, // jumpdestination
		byte(vm.JUMP),

```
## Current

With the current cost of `700`, the `prog1` is obviously a lot faster, burning through
`100M` gas in `120ms` as opposed to `730ms`:
```
BenchmarkSimpleLoop/identity-precompile-100M-6         	       9	 120120165 ns/op	42914516 B/op	  670317 allocs/op
BenchmarkSimpleLoop/loop-100M-6                        	       2	 732444458 ns/op	   14044 B/op	      42 allocs/op
```

With the proposed `40` gas:
```
BenchmarkSimpleLoop/identity-precompile-100M-6         	       1	1404082804 ns/op	593559048 B/op	 5814130 allocs/op
BenchmarkSimpleLoop/loop-100M-6                        	       2	 657346380 ns/op	   14044 B/op	      42 allocs/op
```
It's actually a factor `2` too slow. This means that we lowered the gas too much!

Testing with `100` gives a pretty close match:
```diff
--- a/params/protocol_params.go
+++ b/params/protocol_params.go
@@ -81,7 +81,7 @@ const (

        // These have been changed during the course of the chain
        CallGasFrontier              uint64 = 40  // Once per CALL operation & message call transaction.
-       CallGasEIP150                uint64 = 700 // Static portion of gas for CALL-derivates after EIP 150 (Tangerine)
+       CallGasEIP150                uint64 = 100 // Static portion of gas for CALL-derivates after EIP 150 (Tangerine)
        BalanceGasFrontier           uint64 = 20  // The cost of a BALANCE operation
        BalanceGasEIP150             uint64 = 400 // The cost of a BALANCE operation after Tangerine
        BalanceGasEIP1884            uint64 = 700 // The cost of a BALANCE operation after EIP 1884 (part of Istanbul)
```

This gives a pretty good match:

```
BenchmarkSimpleLoop/identity-precompile-100M-6         	       2	 617293453 ns/op	219197308 B/op	 3424734 allocs/op
BenchmarkSimpleLoop/loop-100M-6                        	       2	 677941768 ns/op	   14044 B/op	      42 allocs/op
```

Note though, that this includes a cost of `15 + 1` for the call to identity -- the cost of the input. So, let's try
with that cost set to zero, and the precompile doing _nothing_.

```diff
--- a/core/vm/contracts.go
+++ b/core/vm/contracts.go
@@ -187,10 +187,12 @@ type dataCopy struct{}
 // This method does not require any overflow checking as the input size gas costs
 // required for anything significant is so high it's impossible to pay for.
 func (c *dataCopy) RequiredGas(input []byte) uint64 {
+       return 0
        return uint64(len(input)+31)/32*params.IdentityPerWordGas + params.IdentityBaseGas
 }
 func (c *dataCopy) Run(in []byte) ([]byte, error) {
-       return in, nil
+       return nil, nil
+       //return in, nil
 }

```
This makes the match even better:

```
BenchmarkSimpleLoop/identity-precompile-100M
BenchmarkSimpleLoop/identity-precompile-100M-6         	       2	 674733768 ns/op	244293824 B/op	 3816870 allocs/op
BenchmarkSimpleLoop/loop-100M
BenchmarkSimpleLoop/loop-100M-6                        	       2	 666473308 ns/op	   13508 B/op	      41 allocs/op
```

So for go-ethereum, the most 'correct' value, with the current implementation, seems to be a cost of `100` for calling a precmpile.
