### PR TITLE
ETH API - Estimate gas return data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,4 @@ profile.cov
 /dashboard/assets/package-lock.json
 
 **/yarn-error.log
+/data/

--- a/.gitignore
+++ b/.gitignore
@@ -47,4 +47,3 @@ profile.cov
 /dashboard/assets/package-lock.json
 
 **/yarn-error.log
-/data/

--- a/graphql/graphql.go
+++ b/graphql/graphql.go
@@ -821,15 +821,14 @@ func (b *Block) Call(ctx context.Context, args struct {
 
 func (b *Block) EstimateGas(ctx context.Context, args struct {
 	Data ethapi.CallArgs
-}) (hexutil.Uint64, error) {
+}) (*ethapi.EstimationResult, error) {
 	if b.numberOrHash == nil {
 		_, err := b.resolveHeader(ctx)
 		if err != nil {
-			return hexutil.Uint64(0), err
+			return nil, err
 		}
 	}
-	gas, err := ethapi.DoEstimateGas(ctx, b.backend, args.Data, *b.numberOrHash, b.backend.RPCGasCap())
-	return gas, err
+	return ethapi.DoEstimateGas(ctx, b.backend, args.Data, *b.numberOrHash, b.backend.RPCGasCap())
 }
 
 type Pending struct {
@@ -891,7 +890,7 @@ func (p *Pending) Call(ctx context.Context, args struct {
 
 func (p *Pending) EstimateGas(ctx context.Context, args struct {
 	Data ethapi.CallArgs
-}) (hexutil.Uint64, error) {
+}) (*ethapi.EstimationResult, error) {
 	pendingBlockNr := rpc.BlockNumberOrHashWithNumber(rpc.PendingBlockNumber)
 	return ethapi.DoEstimateGas(ctx, p.backend, args.Data, pendingBlockNr, p.backend.RPCGasCap())
 }

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -1020,7 +1020,7 @@ func DoEstimateGas(ctx context.Context, b Backend, args CallArgs, blockNrOrHash 
 		}
 	}
 	return &EstimationResult{
-		UsedGas:    hexutil.Uint64(hi),
+		GasUsed:    hexutil.Uint64(hi),
 		ReturnData: returnData,
 	}, nil
 }
@@ -1033,7 +1033,7 @@ func (s *PublicBlockChainAPI) EstimateGas(ctx context.Context, args CallArgs) (*
 }
 
 type EstimationResult struct {
-	UsedGas    hexutil.Uint64 `json:"usedGas"`
+	GasUsed    hexutil.Uint64 `json:"usedGas"`
 	ReturnData hexutil.Bytes  `json:"returnData"`
 }
 
@@ -1509,7 +1509,7 @@ func (args *SendTxArgs) setDefaults(ctx context.Context, b Backend) error {
 		if err != nil {
 			return err
 		}
-		args.Gas = &estimated.UsedGas
+		args.Gas = &estimated.GasUsed
 		log.Trace("Estimate gas usage automatically", "gas", args.Gas)
 	}
 	return nil

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -1033,7 +1033,7 @@ func (s *PublicBlockChainAPI) EstimateGas(ctx context.Context, args CallArgs) (*
 }
 
 type EstimationResult struct {
-	GasUsed    hexutil.Uint64 `json:"usedGas"`
+	GasUsed    hexutil.Uint64 `json:"gasUsed"`
 	ReturnData hexutil.Bytes  `json:"returnData"`
 }
 


### PR DESCRIPTION
This PR intends to return transaction data for `eth_estimateGas` method. When transaction required state modification, (not a Solidity view or pure, it can't be execute without a transaction), the estimate endpoint returns the amount of gas needed but omit the returned value.
Sadly this modification required a breaking change in the API in the response format.
In place of: `{ "result": 123456 }`
Returns: `{"result": { "gasUsed": 123456, "returnData": "0x" } }`
ReturnData is typing `Bytes`, the client has to parse it regarding the type of returned value.
I'm not very familiar with the go-ethereum base code, I'm not confident about the way I have done this modification, I run it on live, seems to be ok. Probably I'm not the only one who is annoyed to be able to estimate the transaction but to ignore the returned value.
EIP link: [https://github.com/ethereum/EIPs/pull/2724](https://github.com/ethereum/EIPs/pull/2724)