### PR TITLE
rpc, internal/ethapi: default rpc gascap at 25M + better error message

### DIFF
--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -1566,13 +1566,13 @@ func SetEthConfig(ctx *cli.Context, stack *node.Node, cfg *eth.Config) {
 	if ctx.GlobalIsSet(RPCGlobalGasCap.Name) {
 		cfg.RPCGasCap = ctx.GlobalUint64(RPCGlobalGasCap.Name)
 	}
-	if ctx.GlobalIsSet(RPCGlobalTxFeeCap.Name) {
-		cfg.RPCTxFeeCap = ctx.GlobalFloat64(RPCGlobalTxFeeCap.Name)
-	}
-	if cap := cfg.RPCGasCap; cap != 0 {
-		log.Info("Set global gas cap", "cap", cap)
+	if cfg.RPCGasCap != 0 {
+		log.Info("Set global gas cap", "cap", cfg.RPCGasCap)
 	} else {
 		log.Info("Global gas cap disabled")
+	}
+	if ctx.GlobalIsSet(RPCGlobalTxFeeCap.Name) {
+		cfg.RPCTxFeeCap = ctx.GlobalFloat64(RPCGlobalTxFeeCap.Name)
 	}
 	if ctx.GlobalIsSet(DNSDiscoveryFlag.Name) {
 		urls := ctx.GlobalString(DNSDiscoveryFlag.Name)

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -477,7 +477,7 @@ var (
 	RPCGlobalGasCap = cli.Uint64Flag{
 		Name:  "rpc.gascap",
 		Usage: "Sets a cap on gas that can be used in eth_call/estimateGas (0=infinite)",
-		Value: eth.DefaultConfig.RPCGasCap.Uint64(),
+		Value: eth.DefaultConfig.RPCGasCap,
 	}
 	RPCGlobalTxFeeCap = cli.Float64Flag{
 		Name:  "rpc.txfeecap",
@@ -1564,12 +1564,12 @@ func SetEthConfig(ctx *cli.Context, stack *node.Node, cfg *eth.Config) {
 		cfg.EVMInterpreter = ctx.GlobalString(EVMInterpreterFlag.Name)
 	}
 	if ctx.GlobalIsSet(RPCGlobalGasCap.Name) {
-		cfg.RPCGasCap = new(big.Int).SetUint64(ctx.GlobalUint64(RPCGlobalGasCap.Name))
+		cfg.RPCGasCap = ctx.GlobalUint64(RPCGlobalGasCap.Name)
 	}
 	if ctx.GlobalIsSet(RPCGlobalTxFeeCap.Name) {
 		cfg.RPCTxFeeCap = ctx.GlobalFloat64(RPCGlobalTxFeeCap.Name)
 	}
-	if cap := cfg.RPCGasCap; cap != nil && cap.Uint64() != 0 {
+	if cap := cfg.RPCGasCap; cap != 0 {
 		log.Info("Set global gas cap", "cap", cap)
 	} else {
 		log.Info("Global gas cap disabled")

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -476,7 +476,8 @@ var (
 	}
 	RPCGlobalGasCap = cli.Uint64Flag{
 		Name:  "rpc.gascap",
-		Usage: "Sets a cap on gas that can be used in eth_call/estimateGas",
+		Usage: "Sets a cap on gas that can be used in eth_call/estimateGas (0=infinite)",
+		Value: eth.DefaultConfig.RPCGasCap.Uint64(),
 	}
 	RPCGlobalTxFeeCap = cli.Float64Flag{
 		Name:  "rpc.txfeecap",
@@ -1567,6 +1568,11 @@ func SetEthConfig(ctx *cli.Context, stack *node.Node, cfg *eth.Config) {
 	}
 	if ctx.GlobalIsSet(RPCGlobalTxFeeCap.Name) {
 		cfg.RPCTxFeeCap = ctx.GlobalFloat64(RPCGlobalTxFeeCap.Name)
+	}
+	if cap := cfg.RPCGasCap; cap != nil && cap.Uint64() != 0 {
+		log.Info("Set global gas cap", "cap", cap)
+	} else {
+		log.Info("Global gas cap disabled")
 	}
 	if ctx.GlobalIsSet(DNSDiscoveryFlag.Name) {
 		urls := ctx.GlobalString(DNSDiscoveryFlag.Name)

--- a/core/tx_pool_test.go
+++ b/core/tx_pool_test.go
@@ -18,6 +18,7 @@ package core
 
 import (
 	"crypto/ecdsa"
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"math/big"
@@ -245,7 +246,7 @@ func TestInvalidTransactions(t *testing.T) {
 
 	balance := new(big.Int).Add(tx.Value(), new(big.Int).Mul(new(big.Int).SetUint64(tx.Gas()), tx.GasPrice()))
 	pool.currentState.AddBalance(from, balance)
-	if err := pool.AddRemote(tx); err != ErrIntrinsicGas {
+	if err := pool.AddRemote(tx); !errors.Is(ErrIntrinsicGas){
 		t.Error("expected", ErrIntrinsicGas, "got", err)
 	}
 

--- a/core/tx_pool_test.go
+++ b/core/tx_pool_test.go
@@ -246,7 +246,7 @@ func TestInvalidTransactions(t *testing.T) {
 
 	balance := new(big.Int).Add(tx.Value(), new(big.Int).Mul(new(big.Int).SetUint64(tx.Gas()), tx.GasPrice()))
 	pool.currentState.AddBalance(from, balance)
-	if err := pool.AddRemote(tx); !errors.Is(ErrIntrinsicGas){
+	if err := pool.AddRemote(tx); !errors.Is(err, ErrIntrinsicGas) {
 		t.Error("expected", ErrIntrinsicGas, "got", err)
 	}
 

--- a/eth/api_backend.go
+++ b/eth/api_backend.go
@@ -290,7 +290,10 @@ func (b *EthAPIBackend) ExtRPCEnabled() bool {
 }
 
 func (b *EthAPIBackend) RPCGasCap() *big.Int {
-	return b.eth.config.RPCGasCap
+	if cap := b.eth.config.RPCGasCap; cap != nil && cap.Uint64() != 0{
+		return cap
+	}
+	return nil
 }
 
 func (b *EthAPIBackend) RPCTxFeeCap() float64 {

--- a/eth/api_backend.go
+++ b/eth/api_backend.go
@@ -289,11 +289,8 @@ func (b *EthAPIBackend) ExtRPCEnabled() bool {
 	return b.extRPCEnabled
 }
 
-func (b *EthAPIBackend) RPCGasCap() *big.Int {
-	if cap := b.eth.config.RPCGasCap; cap != nil && cap.Uint64() != 0{
-		return cap
-	}
-	return nil
+func (b *EthAPIBackend) RPCGasCap() uint64 {
+	return b.eth.config.RPCGasCap
 }
 
 func (b *EthAPIBackend) RPCTxFeeCap() float64 {

--- a/eth/config.go
+++ b/eth/config.go
@@ -59,7 +59,8 @@ var DefaultConfig = Config{
 		GasPrice: big.NewInt(params.GWei),
 		Recommit: 3 * time.Second,
 	},
-	TxPool: core.DefaultTxPoolConfig,
+	TxPool:    core.DefaultTxPoolConfig,
+	RPCGasCap: big.NewInt(50000000),
 	GPO: gasprice.Config{
 		Blocks:     20,
 		Percentile: 60,

--- a/eth/config.go
+++ b/eth/config.go
@@ -60,7 +60,7 @@ var DefaultConfig = Config{
 		Recommit: 3 * time.Second,
 	},
 	TxPool:    core.DefaultTxPoolConfig,
-	RPCGasCap: big.NewInt(50000000),
+	RPCGasCap: 50000000,
 	GPO: gasprice.Config{
 		Blocks:     20,
 		Percentile: 60,
@@ -159,7 +159,7 @@ type Config struct {
 	EVMInterpreter string
 
 	// RPCGasCap is the global gas cap for eth-call variants.
-	RPCGasCap *big.Int `toml:",omitempty"`
+	RPCGasCap uint64 `toml:",omitempty"`
 
 	// RPCTxFeeCap is the global transaction fee(price * gaslimit) cap for
 	// send-transction variants. The unit is ether.

--- a/eth/config.go
+++ b/eth/config.go
@@ -60,7 +60,7 @@ var DefaultConfig = Config{
 		Recommit: 3 * time.Second,
 	},
 	TxPool:    core.DefaultTxPoolConfig,
-	RPCGasCap: 50000000,
+	RPCGasCap: 25000000,
 	GPO: gasprice.Config{
 		Blocks:     20,
 		Percentile: 60,

--- a/eth/gen_config.go
+++ b/eth/gen_config.go
@@ -3,7 +3,6 @@
 package eth
 
 import (
-	"math/big"
 	"time"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -49,7 +48,7 @@ func (c Config) MarshalTOML() (interface{}, error) {
 		DocRoot                 string `toml:"-"`
 		EWASMInterpreter        string
 		EVMInterpreter          string
-		RPCGasCap               *big.Int                       `toml:",omitempty"`
+		RPCGasCap               uint64                         `toml:",omitempty"`
 		RPCTxFeeCap             float64                        `toml:",omitempty"`
 		Checkpoint              *params.TrustedCheckpoint      `toml:",omitempty"`
 		CheckpointOracle        *params.CheckpointOracleConfig `toml:",omitempty"`
@@ -127,7 +126,7 @@ func (c *Config) UnmarshalTOML(unmarshal func(interface{}) error) error {
 		DocRoot                 *string `toml:"-"`
 		EWASMInterpreter        *string
 		EVMInterpreter          *string
-		RPCGasCap               *big.Int                       `toml:",omitempty"`
+		RPCGasCap               *uint64                        `toml:",omitempty"`
 		RPCTxFeeCap             *float64                       `toml:",omitempty"`
 		Checkpoint              *params.TrustedCheckpoint      `toml:",omitempty"`
 		CheckpointOracle        *params.CheckpointOracleConfig `toml:",omitempty"`
@@ -230,7 +229,7 @@ func (c *Config) UnmarshalTOML(unmarshal func(interface{}) error) error {
 		c.EVMInterpreter = *dec.EVMInterpreter
 	}
 	if dec.RPCGasCap != nil {
-		c.RPCGasCap = dec.RPCGasCap
+		c.RPCGasCap = *dec.RPCGasCap
 	}
 	if dec.RPCTxFeeCap != nil {
 		c.RPCTxFeeCap = *dec.RPCTxFeeCap

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -741,7 +741,7 @@ type CallArgs struct {
 }
 
 // ToMessage converts CallArgs to the Message type used by the core evm
-func (args *CallArgs) ToMessage(globalGasCap *big.Int) types.Message {
+func (args *CallArgs) ToMessage(globalGasCap uint64) types.Message {
 	// Set sender address or use zero address if none specified.
 	var addr common.Address
 	if args.From != nil {
@@ -753,9 +753,9 @@ func (args *CallArgs) ToMessage(globalGasCap *big.Int) types.Message {
 	if args.Gas != nil {
 		gas = uint64(*args.Gas)
 	}
-	if globalGasCap != nil && globalGasCap.Uint64() < gas {
+	if globalGasCap != 0 && globalGasCap < gas {
 		log.Warn("Caller gas above allowance, capping", "requested", gas, "cap", globalGasCap)
-		gas = globalGasCap.Uint64()
+		gas = globalGasCap
 	}
 	gasPrice := new(big.Int)
 	if args.GasPrice != nil {
@@ -790,7 +790,7 @@ type account struct {
 	StateDiff *map[common.Hash]common.Hash `json:"stateDiff"`
 }
 
-func DoCall(ctx context.Context, b Backend, args CallArgs, blockNrOrHash rpc.BlockNumberOrHash, overrides map[common.Address]account, vmCfg vm.Config, timeout time.Duration, globalGasCap *big.Int) (*core.ExecutionResult, error) {
+func DoCall(ctx context.Context, b Backend, args CallArgs, blockNrOrHash rpc.BlockNumberOrHash, overrides map[common.Address]account, vmCfg vm.Config, timeout time.Duration, globalGasCap uint64) (*core.ExecutionResult, error) {
 	defer func(start time.Time) { log.Debug("Executing EVM call finished", "runtime", time.Since(start)) }(time.Now())
 
 	state, header, err := b.StateAndHeaderByNumberOrHash(ctx, blockNrOrHash)
@@ -919,7 +919,7 @@ func (s *PublicBlockChainAPI) Call(ctx context.Context, args CallArgs, blockNrOr
 	return result.Return(), result.Err
 }
 
-func DoEstimateGas(ctx context.Context, b Backend, args CallArgs, blockNrOrHash rpc.BlockNumberOrHash, gasCap *big.Int) (hexutil.Uint64, error) {
+func DoEstimateGas(ctx context.Context, b Backend, args CallArgs, blockNrOrHash rpc.BlockNumberOrHash, gasCap uint64) (hexutil.Uint64, error) {
 	// Binary search the gas requirement, as it may be higher than the amount used
 	var (
 		lo  uint64 = params.TxGas - 1
@@ -967,9 +967,9 @@ func DoEstimateGas(ctx context.Context, b Backend, args CallArgs, blockNrOrHash 
 		}
 	}
 	// Recap the highest gas allowance with specified gascap.
-	if gasCap != nil && hi > gasCap.Uint64() {
+	if gasCap != 0 && hi > gasCap {
 		log.Warn("Caller gas above allowance, capping", "requested", hi, "cap", gasCap)
-		hi = gasCap.Uint64()
+		hi = gasCap
 	}
 	cap = hi
 

--- a/internal/ethapi/backend.go
+++ b/internal/ethapi/backend.go
@@ -45,8 +45,8 @@ type Backend interface {
 	ChainDb() ethdb.Database
 	AccountManager() *accounts.Manager
 	ExtRPCEnabled() bool
-	RPCGasCap() *big.Int  // global gas cap for eth_call over rpc: DoS protection
 	RPCTxFeeCap() float64 // global tx fee cap for all transaction related APIs
+	RPCGasCap() uint64    // global gas cap for eth_call over rpc: DoS protection
 
 	// Blockchain API
 	SetHead(number uint64)

--- a/les/api_backend.go
+++ b/les/api_backend.go
@@ -259,7 +259,10 @@ func (b *LesApiBackend) ExtRPCEnabled() bool {
 }
 
 func (b *LesApiBackend) RPCGasCap() *big.Int {
-	return b.eth.config.RPCGasCap
+	if cap := b.eth.config.RPCGasCap; cap != nil && cap.Uint64() != 0 {
+		return cap
+	}
+	return nil
 }
 
 func (b *LesApiBackend) RPCTxFeeCap() float64 {

--- a/les/api_backend.go
+++ b/les/api_backend.go
@@ -258,11 +258,8 @@ func (b *LesApiBackend) ExtRPCEnabled() bool {
 	return b.extRPCEnabled
 }
 
-func (b *LesApiBackend) RPCGasCap() *big.Int {
-	if cap := b.eth.config.RPCGasCap; cap != nil && cap.Uint64() != 0 {
-		return cap
-	}
-	return nil
+func (b *LesApiBackend) RPCGasCap() uint64 {
+	return b.eth.config.RPCGasCap
 }
 
 func (b *LesApiBackend) RPCTxFeeCap() float64 {


### PR DESCRIPTION
This PR does two things: 

1. make geth use a default rpc gascap of ~~`50M`~~ `25M` gas. To disable it, it needs to be set explicitly to zero. 
2. Make the error message returned to RPC caller friendlier. If the server caps the gas, making something fail, we previously returned e.g. "intrinsic gas too low" (without telling the caller that it's because we capped it). Now we also say what gas was _actually_ used during execution, in that particular case. 

## examples


Explicitly set the gas cap:
`build/bin/geth --dev --rpc.gascap 1 --rpc`:
```
[user@work go-ethereum]$ curl -X POST -H "Content-Type: application/json" --data '{"jsonrpc":"2.0","method":"eth_call","params":[{"from": "0x0000000000000000000000000000000000000001", "to":"0x0000000000000000000000000000000000000002", "gas":"0x2000"},"latest"],"id":67}' http://localhost:8545
{"jsonrpc":"2.0","id":67,"error":{"code":-32000,"message":"err: intrinsic gas too low (supplied gas 1)"}}
```

Disable the gascap:
` build/bin/geth --dev --rpc.gascap 0 --rpc `
```
[user@work go-ethereum]$ curl -X POST -H "Content-Type: application/json" --data '{"jsonrpc":"2.0","method":"eth_call","params":[{"from": "0x0000000000000000000000000000000000000001", "to":"0x0000000000000000000000000000000000000002", "gas":"0x2000"},"latest"],"id":67}' http://localhost:8545
{"jsonrpc":"2.0","id":67,"error":{"code":-32000,"message":"err: intrinsic gas too low (supplied gas 8192)"}}
[user@work go-ethereum]$ curl -X POST -H "Content-Type: application/json" --data '{"jsonrpc":"2.0","method":"eth_call","params":[{"from": "0x0000000000000000000000000000000000000001", "to":"0x0000000000000000000000000000000000000002", "gas":"0x2001"},"latest"],"id":67}' http://localhost:8545
{"jsonrpc":"2.0","id":67,"error":{"code":-32000,"message":"err: intrinsic gas too low (supplied gas 8193)"}}
```

Default the gascap:

```
build/bin/geth --dev  --rpc
...
INFO [06-17|12:24:20.423] Set global gas cap                       cap=50000000
```
```
[user@work go-ethereum]$ curl -X POST -H "Content-Type: application/json" --data '{"jsonrpc":"2.0","method":"eth_call","params":[{"from": "0x0000000000000000000000000000000000000001", "to":"0x0000000000000000000000000000000000000002", "gas":"0x202201"},"latest"],"id":67}' http://localhost:8545
{"jsonrpc":"2.0","id":67,"result":"0xe3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"}
```
```
 build/bin/geth --dev  dumpconfig
 ...
[Eth]
NetworkId = 1337
SyncMode = "fast"
DiscoveryURLs = []
NoPruning = false
NoPrefetch = false
LightPeers = 100
UltraLightFraction = 75
DatabaseCache = 512
DatabaseFreezer = ""
TrieCleanCache = 256
TrieDirtyCache = 256
TrieTimeout = 3600000000000
EnablePreimageRecording = false
EWASMInterpreter = ""
EVMInterpreter = ""
RPCGasCap = 50000000
```
