### PR TITLE
core: reduce allocs for gas price comparison

### DIFF
--- a/core/tx_list.go
+++ b/core/tx_list.go
@@ -256,7 +256,7 @@ func (l *txList) Add(tx *types.Transaction, priceBump uint64) (bool, *types.Tran
 		// Have to ensure that the new gas price is higher than the old gas
 		// price as well as checking the percentage threshold to ensure that
 		// this is accurate for low (Wei-level) gas price replacements
-		if old.GasPrice().Cmp(tx.GasPrice()) >= 0 || threshold.Cmp(tx.GasPrice()) > 0 {
+		if old.CmpGasPrice(tx) >= 0 || threshold.Cmp(tx.GasPrice()) > 0 {
 			return false, nil
 		}
 	}
@@ -372,7 +372,7 @@ func (h priceHeap) Swap(i, j int) { h[i], h[j] = h[j], h[i] }
 
 func (h priceHeap) Less(i, j int) bool {
 	// Sort primarily by price, returning the cheaper one
-	switch h[i].GasPrice().Cmp(h[j].GasPrice()) {
+	switch h[i].CmpGasPrice(h[j]) {
 	case -1:
 		return true
 	case 1:
@@ -489,7 +489,7 @@ func (l *txPricedList) Underpriced(tx *types.Transaction, local *accountSet) boo
 		return false
 	}
 	cheapest := []*types.Transaction(*l.items)[0]
-	return cheapest.GasPrice().Cmp(tx.GasPrice()) >= 0
+	return cheapest.CmpGasPrice(tx) >= 0
 }
 
 // Discard finds a number of most underpriced transactions, removes them from the

--- a/core/tx_list.go
+++ b/core/tx_list.go
@@ -256,7 +256,7 @@ func (l *txList) Add(tx *types.Transaction, priceBump uint64) (bool, *types.Tran
 		// Have to ensure that the new gas price is higher than the old gas
 		// price as well as checking the percentage threshold to ensure that
 		// this is accurate for low (Wei-level) gas price replacements
-		if old.CmpGasPrice(tx) >= 0 || threshold.Cmp(tx.GasPrice()) > 0 {
+		if old.CmpGasPrice(tx) >= 0 || tx.CmpGasPriceInt(threshold) <= 0 {
 			return false, nil
 		}
 	}
@@ -449,7 +449,7 @@ func (l *txPricedList) Cap(threshold *big.Int, local *accountSet) types.Transact
 			continue
 		}
 		// Stop the discards if we've reached the threshold
-		if tx.GasPrice().Cmp(threshold) >= 0 {
+		if tx.CmpGasPriceInt(threshold) >= 0 {
 			save = append(save, tx)
 			break
 		}

--- a/core/tx_list_test.go
+++ b/core/tx_list_test.go
@@ -17,6 +17,7 @@
 package core
 
 import (
+	"math/big"
 	"math/rand"
 	"testing"
 
@@ -47,5 +48,23 @@ func TestStrictTxListAdd(t *testing.T) {
 		if list.txs.items[tx.Nonce()] != tx {
 			t.Errorf("item %d: transaction mismatch: have %v, want %v", i, list.txs.items[tx.Nonce()], tx)
 		}
+	}
+}
+
+func BenchmarkTxListAdd(t *testing.B) {
+	// Generate a list of transactions to insert
+	key, _ := crypto.GenerateKey()
+
+	txs := make(types.Transactions, 100000)
+	for i := 0; i < len(txs); i++ {
+		txs[i] = transaction(uint64(i), 0, key)
+	}
+	// Insert the transactions in a random order
+	list := newTxList(true)
+	priceLimit := big.NewInt(0).SetUint64(DefaultTxPoolConfig.PriceLimit)
+	t.ResetTimer()
+	for _, v := range rand.Perm(len(txs)) {
+		list.Add(txs[v], DefaultTxPoolConfig.PriceBump)
+		list.Filter(priceLimit, DefaultTxPoolConfig.PriceBump)
 	}
 }

--- a/core/tx_pool.go
+++ b/core/tx_pool.go
@@ -534,7 +534,7 @@ func (pool *TxPool) validateTx(tx *types.Transaction, local bool) error {
 	}
 	// Drop non-local transactions under our own minimal accepted gas price
 	local = local || pool.locals.contains(from) // account may be local even if the transaction arrived from the network
-	if !local && pool.gasPrice.Cmp(tx.GasPrice()) > 0 {
+	if !local && tx.CmpGasPriceInt(pool.gasPrice) <= 0 {
 		return ErrUnderpriced
 	}
 	// Ensure the transaction adheres to nonce ordering

--- a/core/types/transaction.go
+++ b/core/types/transaction.go
@@ -183,6 +183,10 @@ func (tx *Transaction) CmpGasPrice(other *Transaction) int {
 	return tx.data.Price.Cmp(other.data.Price)
 }
 
+func (tx *Transaction) CmpGasPriceInt(other *big.Int) int {
+	return tx.data.Price.Cmp(other)
+}
+
 // To returns the recipient address of the transaction.
 // It returns nil if the transaction is a contract creation.
 func (tx *Transaction) To() *common.Address {

--- a/core/types/transaction.go
+++ b/core/types/transaction.go
@@ -179,6 +179,10 @@ func (tx *Transaction) Value() *big.Int    { return new(big.Int).Set(tx.data.Amo
 func (tx *Transaction) Nonce() uint64      { return tx.data.AccountNonce }
 func (tx *Transaction) CheckNonce() bool   { return true }
 
+func (tx *Transaction) CmpGasPrice(other *Transaction) int {
+	return tx.data.Price.Cmp(other.data.Price)
+}
+
 // To returns the recipient address of the transaction.
 // It returns nil if the transaction is a contract creation.
 func (tx *Transaction) To() *common.Address {

--- a/eth/gasprice/gasprice.go
+++ b/eth/gasprice/gasprice.go
@@ -156,7 +156,7 @@ type transactionsByGasPrice []*types.Transaction
 
 func (t transactionsByGasPrice) Len() int           { return len(t) }
 func (t transactionsByGasPrice) Swap(i, j int)      { t[i], t[j] = t[j], t[i] }
-func (t transactionsByGasPrice) Less(i, j int) bool { return t[i].GasPrice().Cmp(t[j].GasPrice()) < 0 }
+func (t transactionsByGasPrice) Less(i, j int) bool { return t[i].CmpGasPrice(t[j]) < 0 }
 
 // getBlockPrices calculates the lowest transaction gas price in a given block
 // and sends it to the result channel. If the block is empty, price is nil.


### PR DESCRIPTION
This change reduces the allocations needed for comparing different transactions to each other.
A call to `tx.GasPrice()` copies the gas price as it has to be safe against modifications. For comparing and ordering different transactions we don't need these guarantees.

Benchmarks:
```
BenchmarkPendingDemotion100-16      	 6019682	       180 ns/op	       0 B/op	       0 allocs/op
BenchmarkPendingDemotion1000-16     	 5997415	       178 ns/op	       0 B/op	       0 allocs/op
BenchmarkPendingDemotion10000-16    	 5680364	       186 ns/op	       0 B/op	       0 allocs/op
BenchmarkFuturePromotion100-16      	393596380	         2.92 ns/op	       0 B/op	       0 allocs/op
BenchmarkFuturePromotion1000-16     	431979504	         2.73 ns/op	       0 B/op	       0 allocs/op
BenchmarkFuturePromotion10000-16    	438367808	         2.81 ns/op	       0 B/op	       0 allocs/op
BenchmarkPoolBatchInsert100-16      	      39	  26932436 ns/op	  618046 B/op	    7095 allocs/op
BenchmarkPoolBatchInsert1000-16     	       5	 245582982 ns/op	 5960881 B/op	   71495 allocs/op
BenchmarkPoolBatchInsert10000-16    	       1	2055617384 ns/op	52212896 B/op	  634693 allocs/op
```
Current master:
```
BenchmarkPendingDemotion100-16      	 5902473	       183 ns/op	       0 B/op	       0 allocs/op
BenchmarkPendingDemotion1000-16     	 6397833	       178 ns/op	       0 B/op	       0 allocs/op
BenchmarkPendingDemotion10000-16    	 6575794	       176 ns/op	       0 B/op	       0 allocs/op
BenchmarkFuturePromotion100-16      	389451097	         2.96 ns/op	       0 B/op	       0 allocs/op
BenchmarkFuturePromotion1000-16     	371748506	         2.96 ns/op	       0 B/op	       0 allocs/op
BenchmarkFuturePromotion10000-16    	404261654	         3.01 ns/op	       0 B/op	       0 allocs/op
BenchmarkPoolBatchInsert100-16      	      39	  27335098 ns/op	  633578 B/op	    9082 allocs/op
BenchmarkPoolBatchInsert1000-16     	       6	 216564796 ns/op	 6051392 B/op	   94093 allocs/op
BenchmarkPoolBatchInsert10000-16    	       1	2149670407 ns/op	53134952 B/op	  750930 allocs/op
```

And I've added the following benchmark:
```
BenchmarkPoolBatchInsert100000-16    	       1	17350467173 ns/op	453254664 B/op	 5584792 allocs/op
```
Current master:
```
BenchmarkPoolBatchInsert100000-16    	       1	17616720136 ns/op	455629784 B/op	 5881079 allocs/op
```