### PR TITLE
core, txpool: less allocations when handling transactions

### DIFF
--- a/common/math/integer.go
+++ b/common/math/integer.go
@@ -18,6 +18,7 @@ package math
 
 import (
 	"fmt"
+	"math/bits"
 	"strconv"
 )
 
@@ -87,13 +88,12 @@ func SafeSub(x, y uint64) (uint64, bool) {
 
 // SafeAdd returns the result and whether overflow occurred.
 func SafeAdd(x, y uint64) (uint64, bool) {
-	return x + y, y > MaxUint64-x
+	sum, carry := bits.Add64(x, y, 0)
+	return sum, carry != 0
 }
 
 // SafeMul returns multiplication result and whether overflow occurred.
 func SafeMul(x, y uint64) (uint64, bool) {
-	if x == 0 || y == 0 {
-		return 0, false
-	}
-	return x * y, y > MaxUint64/x
+	hi, lo := bits.Mul64(x, y)
+	return lo, hi != 0
 }

--- a/core/tx_list.go
+++ b/core/tx_list.go
@@ -223,17 +223,16 @@ type txList struct {
 	strict bool         // Whether nonces are strictly continuous or not
 	txs    *txSortedMap // Heap indexed sorted hash map of the transactions
 
-	costcap *big.Int // Price of the highest costing transaction (reset only if exceeds balance)
-	gascap  uint64   // Gas limit of the highest spending transaction (reset only if exceeds block limit)
+	costcap uint64 // Price of the highest costing transaction (reset only if exceeds balance)
+	gascap  uint64 // Gas limit of the highest spending transaction (reset only if exceeds block limit)
 }
 
 // newTxList create a new transaction list for maintaining nonce-indexable fast,
 // gapped, sortable transaction lists.
 func newTxList(strict bool) *txList {
 	return &txList{
-		strict:  strict,
-		txs:     newTxSortedMap(),
-		costcap: new(big.Int),
+		strict: strict,
+		txs:    newTxSortedMap(),
 	}
 }
 
@@ -260,9 +259,14 @@ func (l *txList) Add(tx *types.Transaction, priceBump uint64) (bool, *types.Tran
 			return false, nil
 		}
 	}
+	cost, overflow := tx.Cost()
+	if overflow {
+		log.Warn("transaction cost overflown, txHash: %v txCost: %v", tx.Hash(), cost)
+	}
+
 	// Otherwise overwrite the old transaction with the current one
 	l.txs.Put(tx)
-	if cost := tx.Cost(); l.costcap.Cmp(cost) < 0 {
+	if l.costcap < cost {
 		l.costcap = cost
 	}
 	if gas := tx.Gas(); l.gascap < gas {
@@ -287,16 +291,16 @@ func (l *txList) Forward(threshold uint64) types.Transactions {
 // a point in calculating all the costs or if the balance covers all. If the threshold
 // is lower than the costgas cap, the caps will be reset to a new high after removing
 // the newly invalidated transactions.
-func (l *txList) Filter(costLimit *big.Int, gasLimit uint64) (types.Transactions, types.Transactions) {
+func (l *txList) Filter(costLimit uint64, gasLimit uint64) (types.Transactions, types.Transactions) {
 	// If all transactions are below the threshold, short circuit
-	if l.costcap.Cmp(costLimit) <= 0 && l.gascap <= gasLimit {
+	if l.costcap <= costLimit && l.gascap <= gasLimit {
 		return nil, nil
 	}
-	l.costcap = new(big.Int).Set(costLimit) // Lower the caps to the thresholds
+	l.costcap = costLimit // Lower the caps to the thresholds
 	l.gascap = gasLimit
 
 	// Filter out all the transactions above the account's funds
-	removed := l.txs.Filter(func(tx *types.Transaction) bool { return tx.Cost().Cmp(costLimit) > 0 || tx.Gas() > gasLimit })
+	removed := l.txs.Filter(func(tx *types.Transaction) bool { cost, _ := tx.Cost(); return cost > costLimit || tx.Gas() > gasLimit })
 
 	// If the list was strict, filter anything above the lowest nonce
 	var invalids types.Transactions

--- a/core/tx_list.go
+++ b/core/tx_list.go
@@ -224,7 +224,7 @@ func (m *txSortedMap) Flatten() types.Transactions {
 // transaction with the highest nonce
 func (m *txSortedMap) LastElement() *types.Transaction {
 	cache := m.flatten()
-	return cache[len(m.cache)-1]
+	return cache[len(cache)-1]
 }
 
 // txList is a "list" of transactions belonging to an account, sorted by account

--- a/core/tx_list_test.go
+++ b/core/tx_list_test.go
@@ -50,20 +50,22 @@ func TestStrictTxListAdd(t *testing.T) {
 	}
 }
 
-func BenchmarkTxListAdd(t *testing.B) {
+func BenchmarkTxListAdd(b *testing.B) {
 	// Generate a list of transactions to insert
 	key, _ := crypto.GenerateKey()
 
-	txs := make(types.Transactions, 100000)
+	txs := make(types.Transactions, 2000)
 	for i := 0; i < len(txs); i++ {
 		txs[i] = transaction(uint64(i), 0, key)
 	}
 	// Insert the transactions in a random order
-	list := newTxList(true)
+	b.ResetTimer()
 	priceLimit := DefaultTxPoolConfig.PriceLimit
-	t.ResetTimer()
-	for _, v := range rand.Perm(len(txs)) {
-		list.Add(txs[v], DefaultTxPoolConfig.PriceBump)
-		list.Filter(priceLimit, DefaultTxPoolConfig.PriceBump)
+	for i := 0 ; i < b.N; i++{
+		list := newTxList(true)
+		for _, v := range rand.Perm(len(txs)) {
+			list.Add(txs[v], DefaultTxPoolConfig.PriceBump)
+			list.Filter(priceLimit, DefaultTxPoolConfig.PriceBump)
+		}
 	}
 }

--- a/core/tx_list_test.go
+++ b/core/tx_list_test.go
@@ -17,7 +17,6 @@
 package core
 
 import (
-	"math/big"
 	"math/rand"
 	"testing"
 
@@ -61,7 +60,7 @@ func BenchmarkTxListAdd(t *testing.B) {
 	}
 	// Insert the transactions in a random order
 	list := newTxList(true)
-	priceLimit := big.NewInt(int64(DefaultTxPoolConfig.PriceLimit))
+	priceLimit := DefaultTxPoolConfig.PriceLimit
 	t.ResetTimer()
 	for _, v := range rand.Perm(len(txs)) {
 		list.Add(txs[v], DefaultTxPoolConfig.PriceBump)

--- a/core/tx_list_test.go
+++ b/core/tx_list_test.go
@@ -61,7 +61,7 @@ func BenchmarkTxListAdd(b *testing.B) {
 	// Insert the transactions in a random order
 	b.ResetTimer()
 	priceLimit := DefaultTxPoolConfig.PriceLimit
-	for i := 0 ; i < b.N; i++{
+	for i := 0; i < b.N; i++ {
 		list := newTxList(true)
 		for _, v := range rand.Perm(len(txs)) {
 			list.Add(txs[v], DefaultTxPoolConfig.PriceBump)

--- a/core/tx_pool.go
+++ b/core/tx_pool.go
@@ -1461,6 +1461,10 @@ func (as *accountSet) contains(addr common.Address) bool {
 	return exist
 }
 
+func (as *accountSet) empty() bool {
+	return len(as.accounts) == 0
+}
+
 // containsTx checks if the sender of a given tx is within the set. If the sender
 // cannot be derived, this method returns false.
 func (as *accountSet) containsTx(tx *types.Transaction) bool {

--- a/core/tx_pool_test.go
+++ b/core/tx_pool_test.go
@@ -1889,11 +1889,15 @@ func benchmarkFuturePromotion(b *testing.B, size int) {
 }
 
 // Benchmarks the speed of batched transaction insertion.
-func BenchmarkPoolBatchInsert100(b *testing.B)   { benchmarkPoolBatchInsert(b, 100) }
-func BenchmarkPoolBatchInsert1000(b *testing.B)  { benchmarkPoolBatchInsert(b, 1000) }
-func BenchmarkPoolBatchInsert10000(b *testing.B) { benchmarkPoolBatchInsert(b, 10000) }
+func BenchmarkPoolBatchInsert100(b *testing.B)   { benchmarkPoolBatchInsert(b, 100, false) }
+func BenchmarkPoolBatchInsert1000(b *testing.B)  { benchmarkPoolBatchInsert(b, 1000, false) }
+func BenchmarkPoolBatchInsert10000(b *testing.B) { benchmarkPoolBatchInsert(b, 10000, false) }
 
-func benchmarkPoolBatchInsert(b *testing.B, size int) {
+func BenchmarkPoolBatchLocalInsert100(b *testing.B)   { benchmarkPoolBatchInsert(b, 100, true) }
+func BenchmarkPoolBatchLocalInsert1000(b *testing.B)  { benchmarkPoolBatchInsert(b, 1000, true) }
+func BenchmarkPoolBatchLocalInsert10000(b *testing.B) { benchmarkPoolBatchInsert(b, 10000, true) }
+
+func benchmarkPoolBatchInsert(b *testing.B, size int, local bool) {
 	// Generate a batch of transactions to enqueue into the pool
 	pool, key := setupTxPool()
 	defer pool.Stop()
@@ -1911,6 +1915,10 @@ func benchmarkPoolBatchInsert(b *testing.B, size int) {
 	// Benchmark importing the transactions into the queue
 	b.ResetTimer()
 	for _, batch := range batches {
-		pool.AddRemotes(batch)
+		if local {
+			pool.AddLocals(batch)
+		} else {
+			pool.AddRemotes(batch)
+		}
 	}
 }


### PR DESCRIPTION
```
BenchmarkPendingDemotion100-16       	 6804576	       173 ns/op	       0 B/op	       0 allocs/op
BenchmarkPendingDemotion1000-16      	 6309848	       174 ns/op	       0 B/op	       0 allocs/op
BenchmarkPendingDemotion10000-16     	 7006021	       176 ns/op	       0 B/op	       0 allocs/op
BenchmarkFuturePromotion100-16       	358416355	         3.38 ns/op	       0 B/op	       0 allocs/op
BenchmarkFuturePromotion1000-16      	365451259	         3.37 ns/op	       0 B/op	       0 allocs/op
BenchmarkFuturePromotion10000-16     	377171361	         3.33 ns/op	       0 B/op	       0 allocs/op
BenchmarkPoolBatchInsert100-16       	      38	  27382746 ns/op	  607269 B/op	    8177 allocs/op
BenchmarkPoolBatchInsert1000-16      	       5	 259864088 ns/op	 5861854 B/op	   83225 allocs/op
BenchmarkPoolBatchInsert10000-16     	       1	2085832352 ns/op	51360392 B/op	  690243 allocs/op
BenchmarkPoolBatchInsert100000-16    	       1	17361944530 ns/op	445913240 B/op	 5550197 allocs/op
```
Master
```
BenchmarkPendingDemotion100-16      	 5902473	       183 ns/op	       0 B/op	       0 allocs/op
BenchmarkPendingDemotion1000-16     	 6397833	       178 ns/op	       0 B/op	       0 allocs/op
BenchmarkPendingDemotion10000-16    	 6575794	       176 ns/op	       0 B/op	       0 allocs/op
BenchmarkFuturePromotion100-16      	389451097	         2.96 ns/op	       0 B/op	       0 allocs/op
BenchmarkFuturePromotion1000-16     	371748506	         2.96 ns/op	       0 B/op	       0 allocs/op
BenchmarkFuturePromotion10000-16    	404261654	         3.01 ns/op	       0 B/op	       0 allocs/op
BenchmarkPoolBatchInsert100-16      	      39	  27335098 ns/op	  633578 B/op	    9082 allocs/op
BenchmarkPoolBatchInsert1000-16     	       6	 216564796 ns/op	 6051392 B/op	   94093 allocs/op
BenchmarkPoolBatchInsert10000-16    	       1	2149670407 ns/op	53134952 B/op	  750930 allocs/op
```