### PR TITLE
cmd/geth: import command exit with status code 1 if import returns error

### DIFF
--- a/cmd/geth/chaincmd.go
+++ b/cmd/geth/chaincmd.go
@@ -299,13 +299,17 @@ func importChain(ctx *cli.Context) error {
 	// Import the chain
 	start := time.Now()
 
+	var importErr error
+
 	if len(ctx.Args()) == 1 {
 		if err := utils.ImportChain(chain, ctx.Args().First()); err != nil {
+			importErr = err
 			log.Error("Import error", "err", err)
 		}
 	} else {
 		for _, arg := range ctx.Args() {
 			if err := utils.ImportChain(chain, arg); err != nil {
+				importErr = err
 				log.Error("Import error", "file", arg, "err", err)
 			}
 		}
@@ -358,7 +362,7 @@ func importChain(ctx *cli.Context) error {
 		utils.Fatalf("Failed to read database iostats: %v", err)
 	}
 	fmt.Println(ioStats)
-	return nil
+	return importErr
 }
 
 func exportChain(ctx *cli.Context) error {


### PR DESCRIPTION
The import command should not return a 0 status
code if the import finishes prematurely because
of an import error.

Returning the error causes the program to exit with 1
if the err is non nil.

In case multiple errors are encountered during the import of >1 files, the last is returned (although it doesn't make much of a difference, it just becomes the final error printed on exit).