### PR TITLE
p2p: measure packet throughput too, not just bandwidth

### DIFF
--- a/p2p/peer.go
+++ b/p2p/peer.go
@@ -304,6 +304,7 @@ func (p *Peer) handle(msg Msg) error {
 		if metrics.Enabled {
 			m := fmt.Sprintf("%s/%s/%d/%#02x", ingressMeterName, proto.Name, proto.Version, msg.Code-proto.offset)
 			metrics.GetOrRegisterMeter(m, nil).Mark(int64(msg.meterSize))
+			metrics.GetOrRegisterMeter(m+"/packets", nil).Mark(1)
 		}
 		select {
 		case proto.in <- msg:

--- a/p2p/rlpx.go
+++ b/p2p/rlpx.go
@@ -597,6 +597,7 @@ func (rw *rlpxFrameRW) WriteMsg(msg Msg) error {
 	if metrics.Enabled && msg.meterCap.Name != "" { // don't meter non-subprotocol messages
 		m := fmt.Sprintf("%s/%s/%d/%#02x", egressMeterName, msg.meterCap.Name, msg.meterCap.Version, msg.meterCode)
 		metrics.GetOrRegisterMeter(m, nil).Mark(int64(msg.meterSize))
+		metrics.GetOrRegisterMeter(m+"/packets", nil).Mark(1)
 	}
 	// write header
 	headbuf := make([]byte, 32)


### PR DESCRIPTION
This is a backport from the `snap` PR. It enabled P2P network packet frequency metrics too, not just combined bandwidth metrics. The goal is to have an insight into latency issues (e.g. fast sync RTT delays) and detect if something is doing crazy networking even if it's not a particular hit on the total traffic.

TL;DR This PR is the first two columns of:

![Screenshot from 2020-06-22 19-27-32](https://user-images.githubusercontent.com/129561/85509532-dbaba000-b5fe-11ea-806d-5bacde66266a.png)