### PR TITLE
eth/downloader: fix peer idleness tracking when restarting statesync

### DIFF
--- a/eth/downloader/statesync.go
+++ b/eth/downloader/statesync.go
@@ -99,7 +99,9 @@ func (d *Downloader) runStateSync(s *stateSync) *stateSync {
 		finished []*stateReq                  // Completed or failed requests
 		timeout  = make(chan *stateReq)       // Timed out active requests
 	)
+
 	// Run the state sync.
+	log.Trace("State sync starting", "root", s.root)
 	go s.run()
 	defer s.Cancel()
 
@@ -210,6 +212,8 @@ func (d *Downloader) runStateSync(s *stateSync) *stateSync {
 // will time out. This is to ensure that when the next stateSync starts working, all peers
 // are marked as idle and de facto _are_ idle.
 func (d *Downloader) spindownStateSync(active map[string]*stateReq, finished []*stateReq, timeout chan *stateReq, peerDrop chan *peerConnection) {
+	log.Trace("State sync spinning down", "active", len(active), "finished", len(finished))
+
 	for len(active) > 0 {
 		var (
 			req    *stateReq


### PR DESCRIPTION
When we restart a statesync, we simply let the old one die, and start a new one. 
In one deferred statement, while the old one is exiting, we mark all active (peers where we have an outstanding request that we're waiting for) as 'idle'. 
The effect of marking it immediately as 'idle' is that the new statesync immediately schedules something for it. Now, in most cases, the peer will actually send something back. When these two conditions are met: 
- The new sync has scheduled a new request, and 
- The previous request is delivered, 
Then we will look at the data, and tag it as 'unexpected'. The (stale) delivery will start the cycle again, since we set it to 'idle' once more, and the whole thing will repeat. Sometimes, when this error occurs, tasks will be rescheduled to other peers, and the deliveries become marked as 'duplicate'. 

This fix is a bit hacky, and I tried a few variants, but it's not easy to get right. Here are some variants I tested: 

1. Within the deferred function, spin of a new goroutine that does the sleep + setIdle. Problem: Although this sets the peer idle, it does not trigger an activity in the new syncer. Thus, if we have only one peer, the statesync will never "wake up". 
2. Make the `runStateSync` method both take and return `sync, active`, and let the new syncer continue on the old 'active'. Problem: I'm not sure this is correct. If we move to a new pivot root, then we don't want to continue on the old state-trie, which I felt _might_ happen if we do this. Also, I'm fairly certain that this solution would not handle timeouts properly.   
