### PR TITLE
trie: reduce allocs in insertPreimage

### DIFF
--- a/trie/database.go
+++ b/trie/database.go
@@ -349,14 +349,15 @@ func (db *Database) insert(hash common.Hash, size int, node node) {
 }
 
 // insertPreimage writes a new trie node pre-image to the memory database if it's
-// yet unknown. The method will make a copy of the slice.
+// yet unknown. The method will NOT make a copy of the slice,
+// only use if the preimage will NOT be changed later on.
 //
 // Note, this method assumes that the database's lock is held!
 func (db *Database) insertPreimage(hash common.Hash, preimage []byte) {
 	if _, ok := db.preimages[hash]; ok {
 		return
 	}
-	db.preimages[hash] = common.CopyBytes(preimage)
+	db.preimages[hash] = preimage
 	db.preimagesSize += common.StorageSize(common.HashLength + len(preimage))
 }
 


### PR DESCRIPTION
Currently all preimages are copied twice, once while inserting into the cache and once when we flush the cache to disk.
This PR removes the second copy which reduces allocated memory by quite a bit. 
On my half synced node on goerli the memory allocated at this point was ~190MB.