### PR TITLE
method handler crashing for new account and import raw key apis

### DIFF
--- a/accounts/accounts.go
+++ b/accounts/accounts.go
@@ -151,6 +151,12 @@ type Wallet interface {
 
 	// SignTxWithPassphrase is identical to SignTx, but also takes a password
 	SignTxWithPassphrase(account Account, passphrase string, tx *types.Transaction, chainID *big.Int) (*types.Transaction, error)
+
+	// LockAccount locks the account
+	LockAccount(account Account) (bool, error)
+
+	// UnLockAccount unlocks the account with given password for the given duration
+	UnlockAccount(account Account, password string, duration *uint64) (bool, error)
 }
 
 // Backend is a "wallet provider" that may contain a batch of accounts they can

--- a/accounts/external/backend.go
+++ b/accounts/external/backend.go
@@ -225,6 +225,14 @@ func (api *ExternalSigner) SignDataWithPassphrase(account accounts.Account, pass
 	return nil, fmt.Errorf("password-operations not supported on external signers")
 }
 
+func (api *ExternalSigner) LockAccount(account accounts.Account) (bool, error) {
+	return false, fmt.Errorf("operation not supported on external signers")
+}
+
+func (api *ExternalSigner) UnlockAccount(account accounts.Account, password string, duration *uint64) (bool, error) {
+	return false, fmt.Errorf("operation not supported on external signers")
+}
+
 func (api *ExternalSigner) listAccounts() ([]common.Address, error) {
 	var res []common.Address
 	if err := api.client.Call(&res, "account_list"); err != nil {

--- a/accounts/scwallet/hub.go
+++ b/accounts/scwallet/hub.go
@@ -45,7 +45,7 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/event"
 	"github.com/ethereum/go-ethereum/log"
-	pcsc "github.com/gballet/go-libpcsclite"
+	"github.com/gballet/go-libpcsclite"
 )
 
 // Scheme is the URI prefix for smartcard wallets.

--- a/accounts/scwallet/wallet.go
+++ b/accounts/scwallet/wallet.go
@@ -762,6 +762,14 @@ func (w *Wallet) SignTxWithPassphrase(account accounts.Account, passphrase strin
 	return w.SignTx(account, tx, chainID)
 }
 
+func (w *Wallet) LockAccount(account accounts.Account) (bool, error) {
+	return false, fmt.Errorf("operation not supported")
+}
+
+func (w *Wallet) UnlockAccount(account accounts.Account, password string, duration *uint64) (bool, error) {
+	return false, fmt.Errorf("operation not supported")
+}
+
 // findAccountPath returns the derivation path for the provided account.
 // It first checks for the address in the list of pinned accounts, and if it is
 // not found, attempts to parse the derivation path from the account's URL.

--- a/accounts/usbwallet/wallet.go
+++ b/accounts/usbwallet/wallet.go
@@ -593,3 +593,11 @@ func (w *wallet) SignTextWithPassphrase(account accounts.Account, passphrase str
 func (w *wallet) SignTxWithPassphrase(account accounts.Account, passphrase string, tx *types.Transaction, chainID *big.Int) (*types.Transaction, error) {
 	return w.SignTx(account, tx, chainID)
 }
+
+func(w *wallet) LockAccount(account accounts.Account) (bool, error) {
+	return false, fmt.Errorf("operation not supported")
+}
+
+func(w *wallet) UnlockAccount(account accounts.Account, password string, duration *uint64) (bool, error) {
+	return false, fmt.Errorf("operation not supported")
+}


### PR DESCRIPTION
**System Information**
```
➜  7nodes git:(geth-1.9.7) ✗ geth version
Geth
Version: 1.9.16-unstable
Git Commit: 02cea2330d6b4822b43a7fbaeacc12ddc8e8b1db
Git Commit Date: 20200626
Architecture: amd64
Protocol Versions: [65 64 63]
Go Version: go1.13.8
Operating System: darwin
GOPATH=
GOROOT=/usr/local/Cellar/go@1.13/1.13.8/libexec
```
**Expected Behaviour**
When running geth with clef, executing personal.importKey or personal.newAccount at geth js console should return appropriate error message.

Actual behaviour
Executing personal.importKey or personal.newAccount at geth js console returns method handler crashed error.
```
Welcome to the Geth JavaScript console!

instance: Geth/v1.9.16-unstable-02cea233-20200626/darwin-amd64/go1.13.8
coinbase: 0x46b8ce2e9d3e7a0eb653d574afa506087997461e
at block: 9 (Sat Jun 27 2020 09:16:01 GMT+0800 (+08))
 datadir: 
 modules: admin:1.0 debug:1.0 eth:1.0 miner:1.0 net:1.0 personal:1.0 rpc:1.0 txpool:1.0 web3:1.0

> personal.importRawKey("<<_keyValue_>>", "")
Error: method handler crashed
	at web3.js:6347:37(47)
	at web3.js:5081:62(37)
	at <eval>:1:22(5)

> personal.newAccount()
Passphrase:
Repeat passphrase:
GoError: Error: method handler crashed at web3.js:6347:37(47)
	at native
	at <eval>:1:1(2)
Steps to reproduce the behaviour
```
fixes #21266 