### PR TITLE
cmd/devp2p: print enode:// URL in enrdump

### DIFF
--- a/cmd/devp2p/enrcmd.go
+++ b/cmd/devp2p/enrcmd.go
@@ -21,6 +21,7 @@ import (
 	"encoding/base64"
 	"encoding/hex"
 	"fmt"
+	"io"
 	"io/ioutil"
 	"net"
 	"os"
@@ -69,27 +70,30 @@ func enrdump(ctx *cli.Context) error {
 	if err != nil {
 		return fmt.Errorf("INVALID: %v", err)
 	}
-	fmt.Print(dumpRecord(r))
-	n, err := parseNode(source)
-	if err != nil {
-		return err
-	}
-	fmt.Printf("URLv4: %v\n", n.URLv4())
+	dumpRecord(os.Stdout, r)
 	return nil
 }
 
 // dumpRecord creates a human-readable description of the given node record.
-func dumpRecord(r *enr.Record) string {
-	out := new(bytes.Buffer)
-	if n, err := enode.New(enode.ValidSchemes, r); err != nil {
+func dumpRecord(out io.Writer, r *enr.Record) {
+	n, err := enode.New(enode.ValidSchemes, r)
+	if err != nil {
 		fmt.Fprintf(out, "INVALID: %v\n", err)
 	} else {
 		fmt.Fprintf(out, "Node ID: %v\n", n.ID())
+		dumpNodeURL(out, n)
 	}
 	kv := r.AppendElements(nil)[1:]
 	fmt.Fprintf(out, "Record has sequence number %d and %d key/value pairs.\n", r.Seq(), len(kv)/2)
 	fmt.Fprint(out, dumpRecordKV(kv, 2))
-	return out.String()
+}
+
+func dumpNodeURL(out io.Writer, n *enode.Node) {
+	var key enode.Secp256k1
+	if n.Load(&key) != nil {
+		return // no secp256k1 public key
+	}
+	fmt.Fprintf(out, "URLv4:   %s\n", n.URLv4())
 }
 
 func dumpRecordKV(kv []interface{}, indent int) string {

--- a/cmd/devp2p/enrcmd.go
+++ b/cmd/devp2p/enrcmd.go
@@ -70,6 +70,11 @@ func enrdump(ctx *cli.Context) error {
 		return fmt.Errorf("INVALID: %v", err)
 	}
 	fmt.Print(dumpRecord(r))
+	n, err := parseNode(source)
+	if err != nil {
+		return err
+	}
+	fmt.Printf("URLv4: %v\n", n.URLv4())
 	return nil
 }
 


### PR DESCRIPTION
Add the last line to what `devp2p enrdump ...` prints:
```
Node ID: 42a31d1a2ab3ad2cf79670255444926a333a3de4259e57d39a387b60b274b982
Record has sequence number 15 and 6 key/value pairs.
  "eth"       c7c68480cb8ad480
  "id"        "v4"
  "ip"        18.211.172.244
  "secp256k1" a10361e8a477bdb61e09fc10f43a0a9a139f72282d04ea8f8b4bf341694cc1abb26f
  "tcp"       30332
  "udp"       30332
URLv4: enode://61e8...3c54fd@18.211.172.244:30302
```