### PR TITLE
p2p/peer : Fix potential panic when add a p2p service without func Run

### DIFF
--- a/p2p/peer.go
+++ b/p2p/peer.go
@@ -367,6 +367,10 @@ func (p *Peer) startProtocols(writeStart <-chan struct{}, writeErr chan<- error)
 		p.log.Trace(fmt.Sprintf("Starting protocol %s/%d", proto.Name, proto.Version))
 		go func() {
 			defer p.wg.Done()
+			if proto.Run == nil {
+				return
+			}
+
 			err := proto.Run(p, rw)
 			if err == nil {
 				p.log.Trace(fmt.Sprintf("Protocol %s/%d returned", proto.Name, proto.Version))


### PR DESCRIPTION
It will not happen in current p2p protocols. 
It occurs when add a new p2p protocol and without the ```func Run()```