### PR TITLE
rlp: pool listheads to reduce allocations

### DIFF
--- a/rlp/encode.go
+++ b/rlp/encode.go
@@ -181,12 +181,16 @@ func (w *encbuf) encodeString(b []byte) {
 	}
 }
 
-func (w *encbuf) list() *listhead {
+// list adds a new list header to the header stack. It returns the index
+// of the header. The caller must call listEnd with this index after encoding
+// the content of the list.
+func (w *encbuf) list() int {
 	w.lheads = append(w.lheads, listhead{offset: len(w.str), size: w.lhsize})
-	return &w.lheads[len(w.lheads)-1]
+	return len(w.lheads) - 1
 }
 
-func (w *encbuf) listEnd(lh *listhead) {
+func (w *encbuf) listEnd(index int) {
+	lh := &w.lheads[index]
 	lh.size = w.size() - lh.offset - lh.size
 	if lh.size < 56 {
 		w.lhsize++ // length encoded into kind tag

--- a/rlp/encode.go
+++ b/rlp/encode.go
@@ -137,12 +137,8 @@ var encbufPool = sync.Pool{
 
 func (w *encbuf) reset() {
 	w.lhsize = 0
-	if w.str != nil {
-		w.str = w.str[:0]
-	}
-	if w.lheads != nil {
-		w.lheads = w.lheads[:0]
-	}
+	w.str = w.str[:0]
+	w.lheads = w.lheads[:0]
 }
 
 // encbuf implements io.Writer so it can be passed it into EncodeRLP.

--- a/rlp/encode.go
+++ b/rlp/encode.go
@@ -92,10 +92,10 @@ func EncodeToReader(val interface{}) (size int, r io.Reader, err error) {
 }
 
 type encbuf struct {
-	str     []byte      // string data, contains everything except list headers
-	lheads  []*listhead // all list headers
-	lhsize  int         // sum of sizes of all encoded list headers
-	sizebuf []byte      // 9-byte auxiliary buffer for uint encoding
+	str     []byte     // string data, contains everything except list headers
+	lheads  []listhead // all list headers
+	lhsize  int        // sum of sizes of all encoded list headers
+	sizebuf []byte     // 9-byte auxiliary buffer for uint encoding
 }
 
 type listhead struct {
@@ -182,9 +182,8 @@ func (w *encbuf) encodeString(b []byte) {
 }
 
 func (w *encbuf) list() *listhead {
-	lh := &listhead{offset: len(w.str), size: w.lhsize}
-	w.lheads = append(w.lheads, lh)
-	return lh
+	w.lheads = append(w.lheads, listhead{offset: len(w.str), size: w.lhsize})
+	return &w.lheads[len(w.lheads)-1]
 }
 
 func (w *encbuf) listEnd(lh *listhead) {


### PR DESCRIPTION
In this commit we introduce a pool for listheads which reduces the total allocations from geth during fast sync by ~11%.
This commit has obviously consequences not only for fast sync, fast sync was just the way I benchmarked.

Before this commit:
```
         .          .    184:func (w *encbuf) list() *listhead {
 200805352  200805352    185:lh := &listhead{offset: len(w.str), size: w.lhsize}
     10121      10121    186:w.lheads = append(w.lheads, lh)
         .          .    187:return lh
         .          .    188:}
```
After:
```
         .          .    192:func (w *encbuf) list() *listhead {
         .          .    193:lh := listheadPool.Get().(*listhead)
         .          .    194:lh.offset = len(w.str)
         .          .    195:lh.size = w.lhsize
       706        706    196:w.lheads = append(w.lheads, lh)
         .          .    197:return lh
         .          .    198:}
```