### PR TITLE
ethapi: don't crash when keystore-specific methods are called but external signer used

### DIFF
--- a/console/console.go
+++ b/console/console.go
@@ -39,7 +39,8 @@ import (
 )
 
 var (
-	passwordRegexp = regexp.MustCompile(`personal.[nus]`)
+	// u: unlock, s: signXX, sendXX, n: newAccount, i: importXX
+	passwordRegexp = regexp.MustCompile(`personal.[nusi]`)
 	onlyWhitespace = regexp.MustCompile(`^\s*$`)
 	exit           = regexp.MustCompile(`^\s*exit\s*;*\s*$`)
 )


### PR DESCRIPTION
This PR is an alternative to https://github.com/ethereum/go-ethereum/pull/21267 . 

It also fixes a flaw in our regexp which failed to prevent `personal.importRawKey` from winding up in the console history. 


Fixes https://github.com/ethereum/go-ethereum/issues/21266

Tests: 
```
> personal.importRawKey("49a7b37aa6f6645917e7b807e9d1c00d4fa71f18343b0d4122a4d2df64dd6fee", "aa")
WARN [06-30|20:34:44.763] Served personal_importRawKey             reqid=9 t="222.009µs" err="local keystore not used"
Error: local keystore not used
	at web3.js:6347:37(47)
	at web3.js:5081:62(37)
	at <eval>:1:22(5)

> personal.unlockAccount("0x8a8eafb1cf62bfbeb1741769dae1a9dd47996192","")
WARN [06-30|20:35:13.851] Served personal_unlockAccount            reqid=10 t="250.828µs" err="local keystore not used"
GoError: Error: local keystore not used at web3.js:6347:37(47)
	at native
	at <eval>:1:69(4)

> personal.newAccount("aa")
WARN [06-30|20:35:43.945] Served personal_newAccount               reqid=11 t="140.912µs" err="local keystore not used"
GoError: Error: local keystore not used at web3.js:6347:37(47)
	at native
	at <eval>:1:21(3)

> personal.lockAccount("0x8a8eafb1cf62bfbeb1741769dae1a9dd47996192")
false
```