### PR TITLE
internal/ethapi: default gas to maxgascap, not max int64

### DIFF
--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -749,7 +749,10 @@ func (args *CallArgs) ToMessage(globalGasCap uint64) types.Message {
 	}
 
 	// Set default gas & gas price if none were set
-	gas := uint64(math.MaxUint64 / 2)
+	gas := globalGasCap
+	if gas == 0 {
+		gas = uint64(math.MaxUint64 / 2)
+	}
 	if args.Gas != nil {
 		gas = uint64(*args.Gas)
 	}


### PR DESCRIPTION
This PR fixes an error introduced with default rpc gascap, which is very noticable if a LES-server is run. 
Example output, with some extra info in the warnings: 
```
 Jul 01 23:23:51 bootnode-aws-eu-west-1-001 geth WARN [07-01|21:23:51.229] Caller gas above allowance[1], capping requested=9223372036854775807 cap=25000000 to=0x9a9070028361F7AAbeB3f2F2Dc07F82C4a98A02a data=0x4d6a304c from=0x0000000000000000000000000000000000000000
Jul 01 23:23:51 bootnode-aws-eu-west-1-001 geth WARN [07-01|21:23:51.246] Caller gas above allowance[1], capping requested=9223372036854775807 cap=25000000 to=0x9a9070028361F7AAbeB3f2F2Dc07F82C4a98A02a data=0x4d6a304c from=0x0000000000000000000000000000000000000000
Jul 01 23:23:51 bootnode-aws-eu-west-1-001 geth WARN [07-01|21:23:51.267] Caller gas above allowance[1], capping requested=9223372036854775807 cap=25000000 to=0x9a9070028361F7AAbeB3f2F2Dc07F82C4a98A02a data=0x4d6a304c from=0x0000000000000000000000000000000000000000
Jul 01 23:23:51 bootnode-aws-eu-west-1-001 geth WARN [07-01|21:23:51.306] Caller gas above allowance[1], capping requested=9223372036854775807 cap=25000000 to=0x9a9070028361F7AAbeB3f2F2Dc07F82C4a98A02a data=0x4d6a304c from=0x0000000000000000000000000000000000000000
Jul 01 23:23:51 bootnode-aws-eu-west-1-001 geth WARN [07-01|21:23:51.326] Caller gas above allowance[1], capping requested=9223372036854775807 cap=25000000 to=0x9a9070028361F7AAbeB3f2F2Dc07F82C4a98A02a data=0x4d6a304c from=0x0000000000000000000000000000000000000000
Jul 01 23:23:51 bootnode-aws-eu-west-1-001 geth WARN [07-01|21:23:51.341] Caller gas above allowance[1], capping requested=9223372036854775807 cap=25000000 to=0x9a9070028361F7AAbeB3f2F2Dc07F82C4a98A02a data=0x4d6a304c from=0x0000000000000000000000000000000000000000
Jul 01 23:23:51 bootnode-aws-eu-west-1-001 geth WARN [07-01|21:23:51.350] Caller gas above allowance[1], capping requested=9223372036854775807 cap=25000000 to=0x9a9070028361F7AAbeB3f2F2Dc07F82C4a98A02a data=0x4d6a304c from=0x0000000000000000000000000000000000000000
Jul 01 23:23:51 bootnode-aws-eu-west-1-001 geth WARN [07-01|21:23:51.400] Caller gas above allowance[1], capping requested=9223372036854775807 cap=25000000 to=0x9a9070028361F7AAbeB3f2F2Dc07F82C4a98A02a data=0x4d6a304c from=0x0000000000000000000000000000000000000000
Jul 01 23:23:51 bootnode-aws-eu-west-1-001 geth WARN [07-01|21:23:51.436] Caller gas above allowance[1], capping requested=9223372036854775807 cap=25000000 to=0x9a9070028361F7AAbeB3f2F2Dc07F82C4a98A02a data=0x4d6a304c from=0x0000000000000000000000000000000000000000
Jul 01 23:23:51 bootnode-aws-eu-west-1-001 geth WARN [07-01|21:23:51.437] Caller gas above allowance[1], capping requested=9223372036854775807 cap=25000000 to=0x9a9070028361F7AAbeB3f2F2Dc07F82C4a98A02a data=0x4d6a304c from=0x0000000000000000000000000000000000000000
Jul 01 23:23:51 bootnode-aws-eu-west-1-001 geth WARN [07-01|21:23:51.444] Caller gas above allowance[1], capping requested=9223372036854775807 cap=25000000 to=0x9a9070028361F7AAbeB3f2F2Dc07F82C4a98A02a data=0x4d6a304c from=0x0000000000000000000000000000000000000000
Jul 01 23:23:51 bootnode-aws-eu-west-1-001 geth WARN [07-01|21:23:51.497] Caller gas above allowance[1], capping requested=9223372036854775807 cap=25000000 to=0x9a9070028361F7AAbeB3f2F2Dc07F82C4a98A02a data=0x4d6a304c from=0x0000000000000000000000000000000000000000
```
These calls correspond to the contract `CheckpointOracle`, method `GetLatestCheckpoint() `. It looks a bit odd that we're calling this thing 10+times per second. 

This PR changes the default gas used when no gas is specified, to be `rpggascap` instead of `uint64(math.MaxUint64 / 2)`, so this PR prevents the logs from being filled with the output above. 

Sidenote: we should cache/memoize the oracle info, so we don't have to do an ethCall every time we do a handshake with a LES peer. 