### PR TITLE
cmd/utils: implement configurable developer (--dev) account options

### DIFF
--- a/cmd/geth/usage.go
+++ b/cmd/geth/usage.go
@@ -103,9 +103,6 @@ var AppHelpFlagGroups = []flagGroup{
 		Flags: []cli.Flag{
 			utils.DeveloperFlag,
 			utils.DeveloperPeriodFlag,
-			utils.KeyStoreDirFlag,
-			utils.PasswordFileFlag,
-			utils.MinerEtherbaseFlag,
 		},
 	},
 	{

--- a/cmd/geth/usage.go
+++ b/cmd/geth/usage.go
@@ -103,6 +103,9 @@ var AppHelpFlagGroups = []flagGroup{
 		Flags: []cli.Flag{
 			utils.DeveloperFlag,
 			utils.DeveloperPeriodFlag,
+			utils.KeyStoreDirFlag,
+			utils.PasswordFileFlag,
+			utils.MinerEtherbaseFlag,
 		},
 	},
 	{

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -1638,18 +1638,28 @@ func SetEthConfig(ctx *cli.Context, stack *node.Node, cfg *eth.Config) {
 		}
 		// Create new developer account or reuse existing one
 		var (
-			developer accounts.Account
-			err       error
+			developer  accounts.Account
+			passphrase string
+			err        error
 		)
-		if accs := ks.Accounts(); len(accs) > 0 {
+		if list := MakePasswordList(ctx); len(list) > 0 {
+			// Just take the first value. Although the function returns a possible multiple values and
+			// some usages iterate through them as attempts, that doesn't make sense in this setting,
+			// when we're definitely concerned with only one account.
+			passphrase = list[0]
+		}
+		// setEtherbase has been called above, configuring the miner address from command line flags.
+		if cfg.Miner.Etherbase != (common.Address{}) {
+			developer = accounts.Account{Address: cfg.Miner.Etherbase}
+		} else if accs := ks.Accounts(); len(accs) > 0 {
 			developer = ks.Accounts()[0]
 		} else {
-			developer, err = ks.NewAccount("")
+			developer, err = ks.NewAccount(passphrase)
 			if err != nil {
 				Fatalf("Failed to create developer account: %v", err)
 			}
 		}
-		if err := ks.Unlock(developer, ""); err != nil {
+		if err := ks.Unlock(developer, passphrase); err != nil {
 			Fatalf("Failed to unlock developer account: %v", err)
 		}
 		log.Info("Using developer account", "address", developer.Address)


### PR DESCRIPTION
Prior to this change --dev (developer) mode
generated one account with an empty password,
irrespective of existing --password and --miner.etherbase
options.

This change makes --dev mode compatible with these
existing flags.

--dev mode may now be used in conjunction with
--password and --miner.etherbase flags to configure
the developer faucet using an existing keystore or
in creating a new account.

---

```sh
> cat demo-dev-ks.sh 
#!/usr/bin/env bash

set -x

rm -rf ./ks
mkdir ks
echo "mypassphrase" > pass.txt
./build/bin/geth --keystore=./ks --password=./pass.txt account new
./build/bin/geth --keystore=./ks --password=./pass.txt account new
./build/bin/geth --keystore=./ks --password=./pass.txt account new

# Take the _middle_ address, where normally --dev would default to the first (or last?).
addr=$(cat ./ks/* | jq -r '.address' | tail -2 | head -1)
./build/bin/geth --dev --dev.period=1 --keystore=./ks --password=./pass.txt --miner.etherbase="$addr" --exec 'exit' console

> ./demo-dev-ks.sh
+ rm -rf ./ks
+ mkdir ks
+ echo mypassphrase
+ ./build/bin/geth --keystore=./ks --password=./pass.txt account new
INFO [07-07|08:29:44.270] Maximum peer count                       ETH=50 LES=0 total=50
INFO [07-07|08:29:44.270] Smartcard socket not found, disabling    err="stat /run/pcscd/pcscd.comm: no such file or directory"

Your new key was generated

Public address of the key:   0xBADf17be3d483D06B2DcBCA1d60457cD89fd0a1a
Path of the secret key file: /home/ia/go/src/github.com/ethereum/go-ethereum/ks/UTC--2020-07-07T13-29-44.270890139Z--badf17be3d483d06b2dcbca1d60457cd89fd0a1a

- You can share your public address with anyone. Others need it to interact with you.
- You must NEVER share the secret key with anyone! The key controls access to your funds!
- You must BACKUP your key file! Without the key, it's impossible to access account funds!
- You must REMEMBER your password! Without the password, it's impossible to decrypt the key!

+ ./build/bin/geth --keystore=./ks --password=./pass.txt account new
INFO [07-07|08:29:45.595] Maximum peer count                       ETH=50 LES=0 total=50
INFO [07-07|08:29:45.595] Smartcard socket not found, disabling    err="stat /run/pcscd/pcscd.comm: no such file or directory"

Your new key was generated

Public address of the key:   0x5F038071f11ab6566E5994617fB705140e222D6D
Path of the secret key file: /home/ia/go/src/github.com/ethereum/go-ethereum/ks/UTC--2020-07-07T13-29-45.595832831Z--5f038071f11ab6566e5994617fb705140e222d6d

- You can share your public address with anyone. Others need it to interact with you.
- You must NEVER share the secret key with anyone! The key controls access to your funds!
- You must BACKUP your key file! Without the key, it's impossible to access account funds!
- You must REMEMBER your password! Without the password, it's impossible to decrypt the key!

+ ./build/bin/geth --keystore=./ks --password=./pass.txt account new
INFO [07-07|08:29:46.937] Maximum peer count                       ETH=50 LES=0 total=50
INFO [07-07|08:29:46.937] Smartcard socket not found, disabling    err="stat /run/pcscd/pcscd.comm: no such file or directory"

Your new key was generated

Public address of the key:   0x5F5CfB9F81FA7Bcd86147034582d6766072ec96f
Path of the secret key file: /home/ia/go/src/github.com/ethereum/go-ethereum/ks/UTC--2020-07-07T13-29-46.937960824Z--5f5cfb9f81fa7bcd86147034582d6766072ec96f

- You can share your public address with anyone. Others need it to interact with you.
- You must NEVER share the secret key with anyone! The key controls access to your funds!
- You must BACKUP your key file! Without the key, it's impossible to access account funds!
- You must REMEMBER your password! Without the password, it's impossible to decrypt the key!

++ cat ./ks/UTC--2020-07-07T13-29-44.270890139Z--badf17be3d483d06b2dcbca1d60457cd89fd0a1a ./ks/UTC--2020-07-07T13-29-45.595832831Z--5f038071f11ab6566e5994617fb705140e222d6d ./ks/UTC--2020-07-07T13-29-46.937960824Z--5f5cfb9f81fa7bcd86147034582d6766072ec96f
++ jq -r .address
++ tail -2
++ head -1
+ addr=5f038071f11ab6566e5994617fb705140e222d6d
+ ./build/bin/geth --dev --dev.period=1 --keystore=./ks --password=./pass.txt --miner.etherbase=5f038071f11ab6566e5994617fb705140e222d6d --exec exit console
INFO [07-07|08:29:48.268] Starting Geth in ephemeral dev mode... 
INFO [07-07|08:29:48.269] Maximum peer count                       ETH=50 LES=0 total=50
INFO [07-07|08:29:48.269] Smartcard socket not found, disabling    err="stat /run/pcscd/pcscd.comm: no such file or directory"
INFO [07-07|08:29:48.270] Set global gas cap                       cap=25000000
INFO [07-07|08:29:48.899] Using developer account                  address=0x5F038071f11ab6566E5994617fB705140e222D6D
INFO [07-07|08:29:48.899] Starting peer-to-peer node               instance=Geth/v1.9.16-unstable-e5871b92-20200707/linux-amd64/go1.14.3
INFO [07-07|08:29:48.899] Allocated trie memory caches             clean=256.00MiB dirty=256.00MiB
INFO [07-07|08:29:48.899] Writing custom genesis block 
INFO [07-07|08:29:48.900] Persisted trie from memory database      nodes=11 size=1.66KiB time="29.577µs" gcnodes=0 gcsize=0.00B gctime=0s livenodes=1 livesize=0.00B
INFO [07-07|08:29:48.900] Initialised chain configuration          config="{ChainID: 1337 Homestead: 0 DAO: <nil> DAOSupport: false EIP150: 0 EIP155: 0 EIP158: 0 Byzantium: 0 Constantinople: 0 Petersburg: 0 Istanbul: 0, Muir Glacier: <nil>, YOLO v1: <nil>, Engine: clique}"
INFO [07-07|08:29:48.900] Initialising Ethereum protocol           versions="[65 64 63]" network=1337 dbversion=<nil>
WARN [07-07|08:29:48.900] Upgrade blockchain database version      from=<nil> to=7
INFO [07-07|08:29:48.900] Loaded most recent local header          number=0 hash="ba7e2e…b71f7c" td=1 age=51y3mo13h
INFO [07-07|08:29:48.900] Loaded most recent local full block      number=0 hash="ba7e2e…b71f7c" td=1 age=51y3mo13h
INFO [07-07|08:29:48.900] Loaded most recent local fast block      number=0 hash="ba7e2e…b71f7c" td=1 age=51y3mo13h
INFO [07-07|08:29:48.906] Allocated fast sync bloom                size=512.00MiB
INFO [07-07|08:29:48.907] Stored checkpoint snapshot to disk       number=0 hash="ba7e2e…b71f7c"
INFO [07-07|08:29:48.908] started whisper v.6.0 
INFO [07-07|08:29:48.908] New local node record                    seq=1 id=6a823af52791d1b6 ip=127.0.0.1 udp=0 tcp=39337
INFO [07-07|08:29:48.909] Started P2P networking                   self="enode://023fe62cf3531c53ece7f872d841a51784493ca3fc18cdcdf352f684f9743d64746cce02c3c83ecf04fc1fcd2fcd66878f45cc3bb2a98737fb8ca120ca1820c6@127.0.0.1:39337?discport=0"
INFO [07-07|08:29:48.909] IPC endpoint opened                      url=/tmp/geth.ipc
INFO [07-07|08:29:48.910] Transaction pool price threshold updated price=1000000000
INFO [07-07|08:29:48.910] Transaction pool price threshold updated price=1
INFO [07-07|08:29:48.910] Commit new mining work                   number=1 sealhash="f20c05…cdd34e" uncles=0 txs=0 gas=0 fees=0 elapsed="114.39µs"
INFO [07-07|08:29:48.910] Successfully sealed new block            number=1 sealhash="f20c05…cdd34e" hash="aa8ad9…bd9916" elapsed="469.841µs"
INFO [07-07|08:29:48.910] 🔨 mined potential block                  number=1 hash="aa8ad9…bd9916"
INFO [07-07|08:29:48.911] Commit new mining work                   number=2 sealhash="60b74a…2e12d7" uncles=0 txs=0 gas=0 fees=0 elapsed="333.98µs"
INFO [07-07|08:29:48.911] Initialized fast sync bloom              items=11 errorrate=0.000 elapsed=4.559ms
INFO [07-07|08:29:48.916] Mapped network port                      proto=tcp extport=39337 intport=39337 interface=NAT-PMP(192.168.0.1)
ReferenceError: exit is not defined
	at <eval>:1:1(0)

INFO [07-07|08:29:48.940] IPC endpoint closed                      url=/tmp/geth.ipc
INFO [07-07|08:29:48.940] Ethereum protocol stopped 
INFO [07-07|08:29:48.940] Transaction pool stopped 
INFO [07-07|08:29:48.940] Writing cached state to disk             block=1 hash="aa8ad9…bd9916" root="c5e561…807777"
INFO [07-07|08:29:48.940] Persisted trie from memory database      nodes=0  size=0.00B     time="2.647µs"  gcnodes=0 gcsize=0.00B gctime=0s livenodes=1 livesize=0.00B
INFO [07-07|08:29:48.940] Blockchain stopped 
INFO [07-07|08:29:48.940] whisper stopped 


