### PR TITLE
les: make clientPool.connectedBias configurable

### DIFF
--- a/les/api.go
+++ b/les/api.go
@@ -202,6 +202,18 @@ func (api *PrivateLightServerAPI) SetDefaultParams(params map[string]interface{}
 	return err
 }
 
+// SetConnectedBias set the connection bias, which is applied to already connected clients
+// So that already connected client won't be kicked out very soon and we can ensure all
+// connected clients can have enough time to request or sync some data.
+// When the input parameter `bias` < 0 (illegal), return error.
+func (api *PrivateLightServerAPI) SetConnectedBias(bias time.Duration) error {
+	if bias < time.Duration(0) {
+		return fmt.Errorf("bias illegal: %v less than 0", bias)
+	}
+	api.server.clientPool.setConnectedBias(bias)
+	return nil
+}
+
 // Benchmark runs a request performance benchmark with a given set of measurement setups
 // in multiple passes specified by passCount. The measurement time for each setup in each
 // pass is specified in milliseconds by length.

--- a/les/clientpool_test.go
+++ b/les/clientpool_test.go
@@ -91,7 +91,7 @@ func testClientPool(t *testing.T, connLimit, clientCount, paidCount int, randomD
 		}
 		pool = newClientPool(db, 1, &clock, disconnFn)
 	)
-	pool.disableBias = true
+	pool.setConnectedBias(0)
 	pool.setLimits(connLimit, uint64(connLimit))
 	pool.setDefaultFactors(priceFactors{1, 0, 1}, priceFactors{1, 0, 1})
 
@@ -248,7 +248,7 @@ func TestPaidClientKickedOut(t *testing.T) {
 		clock.Run(time.Millisecond)
 	}
 	clock.Run(time.Second)
-	clock.Run(connectedBias)
+	clock.Run(defaultConnectedBias)
 	if !pool.connect(poolTestPeer(11), 0) {
 		t.Fatalf("Free client should be accectped")
 	}


### PR DESCRIPTION
In les/clientpool.go:
1. line 53
```go
connectedBias = time.Minute * 3
```
2. line 97
```go
disableBias       bool           // Disable connection bias(used in testing)
```
3. line 282
```go
bias := connectedBias
if f.disableBias {
	bias = 0
}
```

Obviously, we can combine the two into one. Here are some explanation:
1.  `time.Duration(0)` means disabled connection bias, other duration means abled connection bias. 
2.  Expose LES api `SetConnectedBias` for configuring the value.
3.  Bias less than zero is illegal.

By this way, the code implements the configuration API elegantly.

*For test:*
```shell
go test -v ./les/
```
Thanks for your review!
