### PR TITLE
signer: EIP 712, parse `bytes` and `bytesX` as hex strings + correct padding

### DIFF
--- a/signer/core/signed_data.go
+++ b/signer/core/signed_data.go
@@ -593,10 +593,13 @@ func (typedData *TypedData) EncodePrimitiveValue(encType string, encValue interf
 		if length < 0 || length > 32 {
 			return nil, fmt.Errorf("invalid size on bytes: %d", length)
 		}
-		if byteValue, ok := parseBytes(encValue); !ok {
+		if byteValue, ok := parseBytes(encValue); !ok || len(byteValue) != length {
 			return nil, dataMismatchError(encType, encValue)
 		} else {
-			return math.PaddedBigBytes(new(big.Int).SetBytes(byteValue), 32), nil
+			// Right-pad the bits
+			dst := make([]byte, 32)
+			copy(dst, byteValue)
+			return dst, nil
 		}
 	}
 	if strings.HasPrefix(encType, "int") || strings.HasPrefix(encType, "uint") {

--- a/signer/core/signed_data.go
+++ b/signer/core/signed_data.go
@@ -490,7 +490,10 @@ func parseBytes(encType interface{}) ([]byte, bool) {
 		return []byte(v), true
 	case string:
 		bytes, err := hexutil.Decode(v)
-		return bytes, err == nil
+		if err != nil {
+			return nil, false
+		}
+		return bytes, true
 	default:
 		return nil, false
 	}

--- a/signer/core/signed_data_internal_test.go
+++ b/signer/core/signed_data_internal_test.go
@@ -17,7 +17,7 @@
 package core
 
 import (
-	"fmt"
+	"bytes"
 	"math/big"
 	"testing"
 
@@ -33,6 +33,8 @@ func TestParseBytes(t *testing.T) {
 		{"0x1234", []byte{0x12, 0x34}},
 		{[]byte{12, 34}, []byte{12, 34}},
 		{hexutil.Bytes([]byte{12, 34}), []byte{12, 34}},
+		{"1234", nil},    // not a proper hex-string
+		{"0x01233", nil}, // nibbles should be rejected
 		{"not a hex string", nil},
 		{15, nil},
 		{nil, nil},
@@ -40,15 +42,15 @@ func TestParseBytes(t *testing.T) {
 		out, ok := parseBytes(tt.v)
 		if tt.exp == nil {
 			if ok {
-				t.Errorf("Case %d: expecting !ok, got ok with %v", i, out)
+				t.Errorf("Case %d: expecting !ok, got ok with %x", i, out)
 			}
 			continue
 		}
 		if !ok {
 			t.Errorf("Case %d: expecting ok got !ok", i)
 		}
-		if fmt.Sprintf("%#v", out) != fmt.Sprintf("%#v", tt.exp) {
-			t.Errorf("Case %d: expecting %v got %v", i, tt.exp, out)
+		if !bytes.Equal(out, tt.exp) {
+			t.Errorf("Case %d: expecting %x got %x", i, tt.exp, out)
 		}
 	}
 }

--- a/signer/core/signed_data_internal_test.go
+++ b/signer/core/signed_data_internal_test.go
@@ -41,8 +41,8 @@ func TestParseBytes(t *testing.T) {
 	} {
 		out, ok := parseBytes(tt.v)
 		if tt.exp == nil {
-			if ok {
-				t.Errorf("Case %d: expecting !ok, got ok with %x", i, out)
+			if ok || out != nil {
+				t.Errorf("Case %d: expecting !ok, got ok = %v with out = %x", i, ok, out)
 			}
 			continue
 		}

--- a/signer/core/signed_data_internal_test.go
+++ b/signer/core/signed_data_internal_test.go
@@ -42,6 +42,11 @@ func TestBytesPadding(t *testing.T) {
 			Output: []byte{1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
 		},
 		{
+			Type:   "bytes1",
+			Input:  []byte{1, 2},
+			Output: nil,
+		},
+		{
 			Type:   "bytes7",
 			Input:  []byte{1, 2, 3, 4, 5, 6, 7},
 			Output: []byte{1, 2, 3, 4, 5, 6, 7, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
@@ -51,24 +56,29 @@ func TestBytesPadding(t *testing.T) {
 			Input:  []byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32},
 			Output: []byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32},
 		},
+		{
+			Type:   "bytes32",
+			Input:  []byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33},
+			Output: nil,
+		},
 	}
 
 	d := TypedData{}
-	for _, test := range tests {
+	for i, test := range tests {
 		val, err := d.EncodePrimitiveValue(test.Type, test.Input, 1)
 		if test.Output == nil {
 			if err == nil {
-				t.Errorf("expected error, got nil error with result %v: case %v", val, test)
+				t.Errorf("test %d: expected error, got no error (result %x)", i, val)
 			}
 		} else {
 			if err != nil {
-				t.Errorf("expected nil error, got %v: case %v", err, test)
+				t.Errorf("test %d: expected no error, got %v", i, err)
 			}
 			if len(val) != 32 {
-				t.Errorf("expected len 32, got %v: case %v", len(val), test)
+				t.Errorf("test %d: expected len 32, got %d", i, len(val))
 			}
-			if fmt.Sprint(val) != fmt.Sprint(test.Output) {
-				t.Errorf("expected %x, got %x: case %v", test.Output, val, test)
+			if !bytes.Equal(val, test.Output) {
+				t.Errorf("test %d: expected %x, got %x", i, test.Output, val)
 			}
 		}
 	}
@@ -92,15 +102,15 @@ func TestParseBytes(t *testing.T) {
 		out, ok := parseBytes(tt.v)
 		if tt.exp == nil {
 			if ok || out != nil {
-				t.Errorf("Case %d: expecting !ok, got ok = %v with out = %x", i, ok, out)
+				t.Errorf("test %d: expected !ok, got ok = %v with out = %x", i, ok, out)
 			}
 			continue
 		}
 		if !ok {
-			t.Errorf("Case %d: expecting ok got !ok", i)
+			t.Errorf("test %d: expected ok got !ok", i)
 		}
 		if !bytes.Equal(out, tt.exp) {
-			t.Errorf("Case %d: expecting %x got %x", i, tt.exp, out)
+			t.Errorf("test %d: expected %x got %x", i, tt.exp, out)
 		}
 	}
 }

--- a/signer/core/signed_data_internal_test.go
+++ b/signer/core/signed_data_internal_test.go
@@ -17,9 +17,41 @@
 package core
 
 import (
+	"fmt"
 	"math/big"
 	"testing"
+
+	"github.com/ethereum/go-ethereum/common/hexutil"
 )
+
+func TestParseBytes(t *testing.T) {
+	for i, tt := range []struct {
+		v   interface{}
+		exp []byte
+	}{
+		{"0x", []byte{}},
+		{"0x1234", []byte{0x12, 0x34}},
+		{[]byte{12, 34}, []byte{12, 34}},
+		{hexutil.Bytes([]byte{12, 34}), []byte{12, 34}},
+		{"not a hex string", nil},
+		{15, nil},
+		{nil, nil},
+	} {
+		out, ok := parseBytes(tt.v)
+		if tt.exp == nil {
+			if ok {
+				t.Errorf("Case %d: expecting !ok, got ok with %v", i, out)
+			}
+			continue
+		}
+		if !ok {
+			t.Errorf("Case %d: expecting ok got !ok", i)
+		}
+		if fmt.Sprintf("%#v", out) != fmt.Sprintf("%#v", tt.exp) {
+			t.Errorf("Case %d: expecting %v got %v", i, tt.exp, out)
+		}
+	}
+}
 
 func TestParseInteger(t *testing.T) {
 	for i, tt := range []struct {

--- a/signer/core/signed_data_internal_test.go
+++ b/signer/core/signed_data_internal_test.go
@@ -24,6 +24,56 @@ import (
 	"github.com/ethereum/go-ethereum/common/hexutil"
 )
 
+func TestBytesPadding(t *testing.T) {
+	tests := []struct {
+		Type   string
+		Input  []byte
+		Output []byte // nil => error
+	}{
+		{
+			// Fail on wrong length
+			Type:   "bytes20",
+			Input:  []byte{},
+			Output: nil,
+		},
+		{
+			Type:   "bytes1",
+			Input:  []byte{1},
+			Output: []byte{1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+		},
+		{
+			Type:   "bytes7",
+			Input:  []byte{1, 2, 3, 4, 5, 6, 7},
+			Output: []byte{1, 2, 3, 4, 5, 6, 7, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+		},
+		{
+			Type:   "bytes32",
+			Input:  []byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32},
+			Output: []byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32},
+		},
+	}
+
+	d := TypedData{}
+	for _, test := range tests {
+		val, err := d.EncodePrimitiveValue(test.Type, test.Input, 1)
+		if test.Output == nil {
+			if err == nil {
+				t.Errorf("expected error, got nil error with result %v: case %v", val, test)
+			}
+		} else {
+			if err != nil {
+				t.Errorf("expected nil error, got %v: case %v", err, test)
+			}
+			if len(val) != 32 {
+				t.Errorf("expected len 32, got %v: case %v", len(val), test)
+			}
+			if fmt.Sprint(val) != fmt.Sprint(test.Output) {
+				t.Errorf("expected %x, got %x: case %v", test.Output, val, test)
+			}
+		}
+	}
+}
+
 func TestParseBytes(t *testing.T) {
 	for i, tt := range []struct {
 		v   interface{}


### PR DESCRIPTION
I've come across a lot of input TypedData where bytes and bytesX is encoded as a hex string (`0x...`).

This adds support for parsing those inputs in the `TypedData.EncodePritimitiveValue` method. 

Tests are included.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ethereum/go-ethereum/21307)
<!-- Reviewable:end -->
