### PR TITLE
p2p/discv5: unset pingEcho on pong timeout

### DIFF
--- a/p2p/discv5/net.go
+++ b/p2p/discv5/net.go
@@ -1037,6 +1037,9 @@ func (net *Network) handle(n *Node, ev nodeEvent, pkt *ingressPacket) error {
 			net.db.ensureExpirer()
 		}
 	}
+	if ev == pongTimeout {
+		n.pingEcho = nil // clean up if pongtimeout
+	}
 	if n.state == nil {
 		n.state = unknown //???
 	}


### PR DESCRIPTION
https://github.com/ethereum/go-ethereum/blob/b8dd0890b3dbc5d3c1b71a0f5de026b46993a851/p2p/discv5/net.go#L1100-L1110

Function `ping` will check the pending `pingEcho` before sending the ping request, current code has the issue of a lot of nodes stuck in `verifyinit` state (does not fallback to `unknown` state) which will lead to the node will have a lot of `deferredQueries` and can not be consumed then lead to the situation of `discv5` package consumes a lot of memory.