### PR TITLE
light: goimports -w

### DIFF
--- a/light/postprocess.go
+++ b/light/postprocess.go
@@ -25,7 +25,7 @@ import (
 	"math/big"
 	"time"
 
-	"github.com/deckarep/golang-set"
+	mapset "github.com/deckarep/golang-set"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/bitutil"
 	"github.com/ethereum/go-ethereum/core"


### PR DESCRIPTION
Fixes a lint regression from #19570 