### PR TITLE
transaction pool optimizations

### DIFF
--- a/core/tx_list.go
+++ b/core/tx_list.go
@@ -99,7 +99,30 @@ func (m *txSortedMap) Forward(threshold uint64) types.Transactions {
 
 // Filter iterates over the list of transactions and removes all of them for which
 // the specified function evaluates to true.
+// Filter, as opposed to 'filter', re-initialises the heap after the operation is done.
+// If you want to do several consecutive filterings, it's therefore better to first
+// do a .filter(func1) followed by .Filter(func2) or reheap()
 func (m *txSortedMap) Filter(filter func(*types.Transaction) bool) types.Transactions {
+	removed := m.filter(filter)
+	// If transactions were removed, the heap and cache are ruined
+	if len(removed) > 0 {
+		m.reheap()
+	}
+	return removed
+}
+
+func (m *txSortedMap) reheap() {
+	*m.index = make([]uint64, 0, len(m.items))
+	for nonce := range m.items {
+		*m.index = append(*m.index, nonce)
+	}
+	heap.Init(m.index)
+	m.cache = nil
+}
+
+// filter is identical to Filter, but **does not** regenerate the heap. This method
+// should only be used if followed immediately by a call to Filter or reheap()
+func (m *txSortedMap) filter(filter func(*types.Transaction) bool) types.Transactions {
 	var removed types.Transactions
 
 	// Collect all the transactions to filter out
@@ -109,14 +132,7 @@ func (m *txSortedMap) Filter(filter func(*types.Transaction) bool) types.Transac
 			delete(m.items, nonce)
 		}
 	}
-	// If transactions were removed, the heap and cache are ruined
 	if len(removed) > 0 {
-		*m.index = make([]uint64, 0, len(m.items))
-		for nonce := range m.items {
-			*m.index = append(*m.index, nonce)
-		}
-		heap.Init(m.index)
-
 		m.cache = nil
 	}
 	return removed
@@ -216,7 +232,7 @@ func (m *txSortedMap) Flatten() types.Transactions {
 	// Copy the cache to prevent accidental modifications
 	cache := m.flatten()
 	txs := make(types.Transactions, len(cache))
-	copy(txs, m.cache)
+	copy(txs, cache)
 	return txs
 }
 
@@ -264,7 +280,11 @@ func (l *txList) Add(tx *types.Transaction, priceBump uint64) (bool, *types.Tran
 	// If there's an older better transaction, abort
 	old := l.txs.Get(tx.Nonce())
 	if old != nil {
-		threshold := new(big.Int).Div(new(big.Int).Mul(old.GasPrice(), big.NewInt(100+int64(priceBump))), big.NewInt(100))
+		// threshold = oldGP * (100 + priceBump) / 100
+		a := big.NewInt(100 + int64(priceBump))
+		a = a.Mul(a, old.GasPrice())
+		b := big.NewInt(100)
+		threshold := a.Div(a, b)
 		// Have to ensure that the new gas price is higher than the old gas
 		// price as well as checking the percentage threshold to ensure that
 		// this is accurate for low (Wei-level) gas price replacements
@@ -312,18 +332,21 @@ func (l *txList) Filter(costLimit *big.Int, gasLimit uint64) (types.Transactions
 		return tx.Gas() > gasLimit || tx.Cost().Cmp(costLimit) > 0
 	})
 
-	// If the list was strict, filter anything above the lowest nonce
+	if len(removed) == 0 {
+		return nil, nil
+	}
 	var invalids types.Transactions
-
-	if l.strict && len(removed) > 0 {
+	// If the list was strict, filter anything above the lowest nonce
+	if l.strict {
 		lowest := uint64(math.MaxUint64)
 		for _, tx := range removed {
 			if nonce := tx.Nonce(); lowest > nonce {
 				lowest = nonce
 			}
 		}
-		invalids = l.txs.Filter(func(tx *types.Transaction) bool { return tx.Nonce() > lowest })
+		invalids = l.txs.filter(func(tx *types.Transaction) bool { return tx.Nonce() > lowest })
 	}
+	l.txs.reheap()
 	return removed, invalids
 }
 
@@ -515,8 +538,29 @@ func (l *txPricedList) Underpriced(tx *types.Transaction, local *accountSet) boo
 // Discard finds a number of most underpriced transactions, removes them from the
 // priced list and returns them for further removal from the entire pool.
 func (l *txPricedList) Discard(slots int, local *accountSet) types.Transactions {
-	drop := make(types.Transactions, 0, slots) // Remote underpriced transactions to drop
-	save := make(types.Transactions, 0, 64)    // Local underpriced transactions to keep
+	// If we have some local accountset, those will not be discarded
+	if !local.empty() {
+		// In case the list is filled to the brim with 'local' txs, we do this
+		// little check to avoid unpacking / repacking the heap later on, which
+		// is very expensive
+		discardable := 0
+		for _, tx := range *l.items {
+			if !local.containsTx(tx) {
+				discardable++
+			}
+			if discardable >= slots {
+				break
+			}
+		}
+		if slots > discardable {
+			slots = discardable
+		}
+	}
+	if slots == 0 {
+		return nil
+	}
+	drop := make(types.Transactions, 0, slots)               // Remote underpriced transactions to drop
+	save := make(types.Transactions, 0, len(*l.items)-slots) // Local underpriced transactions to keep
 
 	for len(*l.items) > 0 && slots > 0 {
 		// Discard stale transactions if found during cleanup

--- a/core/tx_pool.go
+++ b/core/tx_pool.go
@@ -1059,8 +1059,8 @@ func (pool *TxPool) runReorg(done chan struct{}, reset *txpoolResetRequest, dirt
 
 	// Update all accounts to the latest known pending nonce
 	for addr, list := range pool.pending {
-		txs := list.Flatten() // Heavy but will be cached and is needed by the miner anyway
-		pool.pendingNonces.set(addr, txs[len(txs)-1].Nonce()+1)
+		highestPending := list.LastElement()
+		pool.pendingNonces.set(addr, highestPending.Nonce()+1)
 	}
 	pool.mu.Unlock()
 

--- a/core/tx_pool.go
+++ b/core/tx_pool.go
@@ -1457,6 +1457,10 @@ func (as *accountSet) contains(addr common.Address) bool {
 	return exist
 }
 
+func (as *accountSet) empty() bool {
+	return len(as.accounts) == 0
+}
+
 // containsTx checks if the sender of a given tx is within the set. If the sender
 // cannot be derived, this method returns false.
 func (as *accountSet) containsTx(tx *types.Transaction) bool {

--- a/core/tx_pool_test.go
+++ b/core/tx_pool_test.go
@@ -1890,11 +1890,15 @@ func benchmarkFuturePromotion(b *testing.B, size int) {
 }
 
 // Benchmarks the speed of batched transaction insertion.
-func BenchmarkPoolBatchInsert100(b *testing.B)   { benchmarkPoolBatchInsert(b, 100) }
-func BenchmarkPoolBatchInsert1000(b *testing.B)  { benchmarkPoolBatchInsert(b, 1000) }
-func BenchmarkPoolBatchInsert10000(b *testing.B) { benchmarkPoolBatchInsert(b, 10000) }
+func BenchmarkPoolBatchInsert100(b *testing.B)   { benchmarkPoolBatchInsert(b, 100, false) }
+func BenchmarkPoolBatchInsert1000(b *testing.B)  { benchmarkPoolBatchInsert(b, 1000, false) }
+func BenchmarkPoolBatchInsert10000(b *testing.B) { benchmarkPoolBatchInsert(b, 10000, false) }
 
-func benchmarkPoolBatchInsert(b *testing.B, size int) {
+func BenchmarkPoolBatchLocalInsert100(b *testing.B)   { benchmarkPoolBatchInsert(b, 100, true) }
+func BenchmarkPoolBatchLocalInsert1000(b *testing.B)  { benchmarkPoolBatchInsert(b, 1000, true) }
+func BenchmarkPoolBatchLocalInsert10000(b *testing.B) { benchmarkPoolBatchInsert(b, 10000, true) }
+
+func benchmarkPoolBatchInsert(b *testing.B, size int, local bool) {
 	// Generate a batch of transactions to enqueue into the pool
 	pool, key := setupTxPool()
 	defer pool.Stop()
@@ -1912,6 +1916,10 @@ func benchmarkPoolBatchInsert(b *testing.B, size int) {
 	// Benchmark importing the transactions into the queue
 	b.ResetTimer()
 	for _, batch := range batches {
-		pool.AddRemotes(batch)
+		if local {
+			pool.AddLocals(batch)
+		} else {
+			pool.AddRemotes(batch)
+		}
 	}
 }


### PR DESCRIPTION
This PR contains some of the commits from the (now reverted) https://github.com/ethereum/go-ethereum/pull/21232 , leaving out the erroneous conversions to `uint64`

```
[user@work core]$ benchstat pool.before pool.after 
name                         old time/op    new time/op    delta
PoolBatchInsert100-6           8.52ms ± 2%    8.50ms ± 2%     ~     (p=1.000 n=5+5)
PoolBatchInsert1000-6          99.2ms ± 1%   101.3ms ± 2%     ~     (p=0.190 n=4+5)
PoolBatchInsert10000-6          1.17s ± 9%     1.17s ±12%     ~     (p=1.000 n=5+5)
PoolBatchLocalInsert100-6       350ms ± 5%      31ms ± 3%  -91.20%  (p=0.008 n=5+5)
PoolBatchLocalInsert1000-6      5.15s ± 8%     0.40s ± 2%  -92.19%  (p=0.016 n=5+4)
PoolBatchLocalInsert10000-6     36.5s ± 2%      3.0s ± 4%  -91.84%  (p=0.036 n=3+5)

name                         old alloc/op   new alloc/op   delta
PoolBatchInsert100-6            293kB ± 0%     264kB ± 0%   -9.71%  (p=0.008 n=5+5)
PoolBatchInsert1000-6          2.63MB ± 0%    2.60MB ± 0%   -1.31%  (p=0.016 n=5+4)
PoolBatchInsert10000-6         22.7MB ± 0%    22.7MB ± 0%   -0.13%  (p=0.008 n=5+5)
PoolBatchLocalInsert100-6      14.7MB ± 0%     0.3MB ± 0%  -97.80%  (p=0.008 n=5+5)
PoolBatchLocalInsert1000-6      205MB ± 8%       3MB ± 0%  -98.71%  (p=0.016 n=5+4)
PoolBatchLocalInsert10000-6    1.46GB ± 0%    0.03GB ± 0%  -98.17%  (p=0.036 n=3+5)

name                         old allocs/op  new allocs/op  delta
PoolBatchInsert100-6            3.78k ± 0%     3.78k ± 0%     ~     (p=0.190 n=5+5)
PoolBatchInsert1000-6           37.8k ± 0%     37.8k ± 0%   -0.16%  (p=0.000 n=5+4)
PoolBatchInsert10000-6           339k ± 0%      339k ± 0%     ~     (p=0.548 n=5+5)
PoolBatchLocalInsert100-6       4.54k ± 0%     3.90k ± 0%  -14.15%  (p=0.016 n=5+4)
PoolBatchLocalInsert1000-6      46.2k ± 1%     38.2k ± 0%  -17.19%  (p=0.008 n=5+5)
PoolBatchLocalInsert10000-6      445k ± 0%      381k ± 0%  -14.36%  (p=0.036 n=3+5)
```