### PR TITLE
core: sort txs at the same gas price by sender address

### DIFF
--- a/common/types.go
+++ b/common/types.go
@@ -203,6 +203,9 @@ func IsHexAddress(s string) bool {
 // Bytes gets the string representation of the underlying address.
 func (a Address) Bytes() []byte { return a[:] }
 
+// Big converts an address to a big.Int.
+func (a Address) Big() *big.Int { return new(big.Int).SetBytes(a[:]) }
+
 // Hash converts an address to a hash by left-padding it with zeros.
 func (a Address) Hash() Hash { return BytesToHash(a[:]) }
 


### PR DESCRIPTION
This PR changes the sorting of pool transactions with the same gas price.

Previously transactions were sorted randomly (due to the way go maps work).
Now they are sorted by their sender address in ascending order (using the Big representation of the sender address).

This is supposed to remove the incentive for spamming transactions to backrun a tx (#21350).

----
Potential cons of this solution:
* Bots will premine sender accounts potentially leading to state bloat and leaving dust accounts.
* Bots might be incentivized to fill blocks with spam to give them time to fund a new account.