### PR TITLE
build: fix GOBIN for gomobile commands

### DIFF
--- a/build/ci.go
+++ b/build/ci.go
@@ -884,11 +884,12 @@ func gomobileTool(subcmd string, args ...string) *exec.Cmd {
 		"PATH=" + GOBIN + string(os.PathListSeparator) + os.Getenv("PATH"),
 	}
 	for _, e := range os.Environ() {
-		if strings.HasPrefix(e, "GOPATH=") || strings.HasPrefix(e, "PATH=") {
+		if strings.HasPrefix(e, "GOPATH=") || strings.HasPrefix(e, "PATH=") || strings.HasPrefix(e, "GOBIN=") {
 			continue
 		}
 		cmd.Env = append(cmd.Env, e)
 	}
+	cmd.Env = append(cmd.Env, "GOBIN="+GOBIN)
 	return cmd
 }
 
@@ -957,7 +958,7 @@ func doXCodeFramework(cmdline []string) {
 
 	if *local {
 		// If we're building locally, use the build folder and stop afterwards
-		bind.Dir, _ = filepath.Abs(GOBIN)
+		bind.Dir = GOBIN
 		build.MustRun(bind)
 		return
 	}


### PR DESCRIPTION
Fixes this issue:

```
~/d/e/s/g/e/go-ethereum >> make ios
env GO111MODULE=on go run build/ci.go xcode --local
/Users/fjl/develop/eth/src/github.com/ethereum/go-ethereum/build/bin
>>> /usr/local/Cellar/go/1.14.4/libexec/bin/go get golang.org/x/mobile/cmd/gomobile golang.org/x/mobile/cmd/gobind
go: found golang.org/x/mobile/cmd/gobind in golang.org/x/mobile v0.0.0-20200721161523-bcce01171201
go: found golang.org/x/mobile/cmd/gomobile in golang.org/x/mobile v0.0.0-20200721161523-bcce01171201
>>> /Users/fjl/develop/eth/src/github.com/ethereum/go-ethereum/build/bin/gomobile init
/Users/fjl/develop/eth/src/github.com/ethereum/go-ethereum/build/bin/gomobile: go install golang.org/x/mobile/cmd/gobind failed: exit status 1
cannot install, GOBIN must be an absolute path

util.go:45: exit status 1
```