### PR TITLE
main,utils,node,rpc: --ipc.chmod flag enabling configurable octal permissions for ipc path

### DIFF
--- a/cmd/clef/main.go
+++ b/cmd/clef/main.go
@@ -33,6 +33,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"sort"
+	"strconv"
 	"strings"
 	"time"
 
@@ -239,6 +240,7 @@ var AppHelpFlagGroups = []flags.FlagGroup{
 			utils.HTTPVirtualHostsFlag,
 			utils.IPCDisabledFlag,
 			utils.IPCPathFlag,
+			utils.IPCChmodFlag,
 			utils.HTTPEnabledFlag,
 			rpcPortFlag,
 			signerSecretFlag,
@@ -703,7 +705,12 @@ func signer(c *cli.Context) error {
 	if !c.GlobalBool(utils.IPCDisabledFlag.Name) {
 		givenPath := c.GlobalString(utils.IPCPathFlag.Name)
 		ipcapiURL = ipcEndpoint(filepath.Join(givenPath, "clef.ipc"), configDir)
-		listener, _, err := rpc.StartIPCEndpoint(ipcapiURL, rpcAPI)
+		givenMode := c.GlobalString(utils.IPCChmodFlag.Name)
+		parsedMode, err := strconv.ParseUint(givenMode, 8, 32)
+		if err != nil {
+			utils.Fatalf("Could not parse IPC file mode: %v", err)
+		}
+		listener, _, err := rpc.StartIPCEndpoint(ipcapiURL, os.FileMode(parsedMode), rpcAPI)
 		if err != nil {
 			utils.Fatalf("Could not start IPC api: %v", err)
 		}

--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -186,6 +186,7 @@ var (
 		utils.LegacyWSAllowedOriginsFlag,
 		utils.IPCDisabledFlag,
 		utils.IPCPathFlag,
+		utils.IPCChmodFlag,
 		utils.InsecureUnlockAllowedFlag,
 		utils.RPCGlobalGasCap,
 		utils.RPCGlobalTxFeeCap,

--- a/cmd/geth/usage.go
+++ b/cmd/geth/usage.go
@@ -128,6 +128,7 @@ var AppHelpFlagGroups = []flags.FlagGroup{
 		Flags: []cli.Flag{
 			utils.IPCDisabledFlag,
 			utils.IPCPathFlag,
+			utils.IPCChmodFlag,
 			utils.HTTPEnabledFlag,
 			utils.HTTPListenAddrFlag,
 			utils.HTTPPortFlag,

--- a/node/config.go
+++ b/node/config.go
@@ -104,6 +104,9 @@ type Config struct {
 	// relative), then that specific path is enforced. An empty path disables IPC.
 	IPCPath string
 
+	// IPCMode is the octal file permissions for the IPC endpoint. Default is 0600.
+	IPCMode os.FileMode
+
 	// HTTPHost is the host interface on which to start the HTTP RPC server. If this
 	// field is empty, no HTTP API endpoint will be started.
 	HTTPHost string
@@ -216,6 +219,14 @@ func (c *Config) IPCEndpoint() string {
 		return filepath.Join(c.DataDir, c.IPCPath)
 	}
 	return c.IPCPath
+}
+
+// IPCChmod returns the configuration ipc file mode or default 0600 (-rw-------).
+func (c *Config) IPCChmod() os.FileMode {
+	if c.IPCMode == 0 {
+		return os.FileMode(0600)
+	}
+	return c.IPCMode
 }
 
 // NodeDB returns the path to the discovery node database.

--- a/rpc/client_test.go
+++ b/rpc/client_test.go
@@ -573,7 +573,7 @@ func ipcTestClient(srv *Server, fl *flakeyListener) (*Client, net.Listener) {
 	} else {
 		endpoint = os.TempDir() + "/" + endpoint
 	}
-	l, err := ipcListen(endpoint)
+	l, err := ipcListen(endpoint, 0600)
 	if err != nil {
 		panic(err)
 	}

--- a/rpc/endpoints.go
+++ b/rpc/endpoints.go
@@ -18,12 +18,13 @@ package rpc
 
 import (
 	"net"
+	"os"
 
 	"github.com/ethereum/go-ethereum/log"
 )
 
 // StartIPCEndpoint starts an IPC endpoint.
-func StartIPCEndpoint(ipcEndpoint string, apis []API) (net.Listener, *Server, error) {
+func StartIPCEndpoint(ipcEndpoint string, ipcMode os.FileMode, apis []API) (net.Listener, *Server, error) {
 	// Register all the APIs exposed by the services.
 	handler := NewServer()
 	for _, api := range apis {
@@ -33,7 +34,7 @@ func StartIPCEndpoint(ipcEndpoint string, apis []API) (net.Listener, *Server, er
 		log.Debug("IPC registered", "namespace", api.Namespace)
 	}
 	// All APIs registered, start the IPC listener.
-	listener, err := ipcListen(ipcEndpoint)
+	listener, err := ipcListen(ipcEndpoint, ipcMode)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/rpc/ipc_unix.go
+++ b/rpc/ipc_unix.go
@@ -29,7 +29,7 @@ import (
 )
 
 // ipcListen will create a Unix socket on the given endpoint.
-func ipcListen(endpoint string) (net.Listener, error) {
+func ipcListen(endpoint string, mode os.FileMode) (net.Listener, error) {
 	if len(endpoint) > int(max_path_size) {
 		log.Warn(fmt.Sprintf("The ipc endpoint is longer than %d characters. ", max_path_size),
 			"endpoint", endpoint)
@@ -44,7 +44,7 @@ func ipcListen(endpoint string) (net.Listener, error) {
 	if err != nil {
 		return nil, err
 	}
-	os.Chmod(endpoint, 0600)
+	os.Chmod(endpoint, mode)
 	return l, nil
 }
 


### PR DESCRIPTION
OpenEthereum has a flag for configuring the IPC permissions, and I've found myself wanting this in geth more than once. I often run geth under one user and want to access the socket RPC API under another, which isn't allowed with the current hardcoded `0600` (owner:r+w only) permissions. This saves having to add an extra step around the process runner(s) to open modify the permissions after geth starts up.

The default of `0600` is unchanged.
 
The related usage text from OpenEthereum:

```txt
API and Console Options – IPC:
    [...]
    --ipc-chmod=[NUM]
        Specify octal value for ipc socket permissions (unix/bsd only) (default: 660)
```

Note that behavior is 'unique' on Windows, although
behavior there is unmodified, and at the users decision
(only owner r/w is set).  From the Go `os.Chmod` comment:

```go
// Chmod changes the mode of the named file to mode.
// If the file is a symbolic link, it changes the mode of the link's target.
// If there is an error, it will be of type *PathError.
//
// A different subset of the mode bits are used, depending on the
// operating system.
//
// On Unix, the mode's permission bits, ModeSetuid, ModeSetgid, and
// ModeSticky are used.
//
// On Windows, only the 0200 bit (owner writable) of mode is used; it
// controls whether the file's read-only attribute is set or cleared.
// The other bits are currently unused. For compatibility with Go 1.12
// and earlier, use a non-zero mode. Use mode 0400 for a read-only
// file and 0600 for a readable+writable file.
//
// On Plan 9, the mode's permission bits, ModeAppend, ModeExclusive,
// and ModeTemporary are used.
func Chmod(name string, mode FileMode) error { return chmod(name, mode) }
```