### PR TITLE
consensus/ethash: fix usage of *reflect.SliceHeader

### DIFF
--- a/consensus/ethash/algorithm.go
+++ b/consensus/ethash/algorithm.go
@@ -151,10 +151,10 @@ func generateCache(dest []uint32, epoch uint64, seed []byte) {
 		logFn("Generated ethash verification cache", "elapsed", common.PrettyDuration(elapsed))
 	}()
 	// Convert our destination slice to a byte buffer
-	header := *(*reflect.SliceHeader)(unsafe.Pointer(&dest))
+	header := (*reflect.SliceHeader)(unsafe.Pointer(&dest))
 	header.Len *= 4
 	header.Cap *= 4
-	cache := *(*[]byte)(unsafe.Pointer(&header))
+	cache := *(*[]byte)(unsafe.Pointer(header))
 
 	// Calculate the number of theoretical rows (we'll store in one buffer nonetheless)
 	size := uint64(len(cache))

--- a/consensus/ethash/algorithm.go
+++ b/consensus/ethash/algorithm.go
@@ -151,10 +151,13 @@ func generateCache(dest []uint32, epoch uint64, seed []byte) {
 		logFn("Generated ethash verification cache", "elapsed", common.PrettyDuration(elapsed))
 	}()
 	// Convert our destination slice to a byte buffer
-	header := (*reflect.SliceHeader)(unsafe.Pointer(&dest))
-	header.Len *= 4
-	header.Cap *= 4
-	cache := *(*[]byte)(unsafe.Pointer(header))
+	var cache []byte
+	cacheHdr := (*reflect.SliceHeader)(unsafe.Pointer(&cache))
+	dstHdr := (*reflect.SliceHeader)(unsafe.Pointer(&dest))
+	cacheHdr.Data = dstHdr.Data
+	cacheHdr.Len = dstHdr.Len * 4
+	cacheHdr.Cap = dstHdr.Cap * 4
+	cache = *(*[]byte)(unsafe.Pointer(cacheHdr))
 
 	// Calculate the number of theoretical rows (we'll store in one buffer nonetheless)
 	size := uint64(len(cache))

--- a/consensus/ethash/algorithm.go
+++ b/consensus/ethash/algorithm.go
@@ -157,7 +157,6 @@ func generateCache(dest []uint32, epoch uint64, seed []byte) {
 	cacheHdr.Data = dstHdr.Data
 	cacheHdr.Len = dstHdr.Len * 4
 	cacheHdr.Cap = dstHdr.Cap * 4
-	cache = *(*[]byte)(unsafe.Pointer(cacheHdr))
 
 	// Calculate the number of theoretical rows (we'll store in one buffer nonetheless)
 	size := uint64(len(cache))

--- a/consensus/ethash/algorithm.go
+++ b/consensus/ethash/algorithm.go
@@ -285,10 +285,12 @@ func generateDataset(dest []uint32, epoch uint64, cache []uint32) {
 	swapped := !isLittleEndian()
 
 	// Convert our destination slice to a byte buffer
-	header := *(*reflect.SliceHeader)(unsafe.Pointer(&dest))
-	header.Len *= 4
-	header.Cap *= 4
-	dataset := *(*[]byte)(unsafe.Pointer(&header))
+	var dataset []byte
+	datasetHdr := (*reflect.SliceHeader)(unsafe.Pointer(&dataset))
+	destHdr := (*reflect.SliceHeader)(unsafe.Pointer(&dest))
+	datasetHdr.Data = destHdr.Data
+	datasetHdr.Len = destHdr.Len * 4
+	datasetHdr.Cap = destHdr.Cap * 4
 
 	// Generate the dataset on many goroutines since it takes a while
 	threads := runtime.NumCPU()


### PR DESCRIPTION
I ran into a weird issue when fuzzing github.com/prysmaticlabs/prysm, reported here: https://github.com/golang/go/issues/40397.

Some of the feedback I received from @mdempsky was:

> It's only safe to use *reflect.SliceHeader as a pointer to an actual slice-typed variable. You should never have a value or variable of type reflect.SliceHeader.

So I've fixed that issue in this PR.
