### PR TITLE
build: use -trimpath flag when building executables

### DIFF
--- a/build/ci.go
+++ b/build/ci.go
@@ -210,11 +210,10 @@ func doInstall(cmdline []string) {
 
 	// Check Go version. People regularly open issues about compilation
 	// failure with outdated Go. This should save them the trouble.
+	// Figure out the minor version number since we can't textually compare (1.10 < 1.9)
+	var minor int
+	fmt.Sscanf(strings.TrimPrefix(runtime.Version(), "go1."), "%d", &minor)
 	if !strings.Contains(runtime.Version(), "devel") {
-		// Figure out the minor version number since we can't textually compare (1.10 < 1.9)
-		var minor int
-		fmt.Sscanf(strings.TrimPrefix(runtime.Version(), "go1."), "%d", &minor)
-
 		if minor < 11 {
 			log.Println("You have Go version", runtime.Version())
 			log.Println("go-ethereum requires at least Go version 1.11 and cannot")
@@ -230,6 +229,9 @@ func doInstall(cmdline []string) {
 
 	if *arch == "" || *arch == runtime.GOARCH {
 		goinstall := goTool("install", buildFlags(env)...)
+		if minor >= 13 {
+			goinstall.Args = append(goinstall.Args, "-trimpath")
+		}
 		if runtime.GOARCH == "arm64" {
 			goinstall.Args = append(goinstall.Args, "-p", "1")
 		}
@@ -241,6 +243,9 @@ func doInstall(cmdline []string) {
 
 	// Seems we are cross compiling, work around forbidden GOBIN
 	goinstall := goToolArch(*arch, *cc, "install", buildFlags(env)...)
+	if minor >= 13 {
+		goinstall.Args = append(goinstall.Args, "-trimpath")
+	}
 	goinstall.Args = append(goinstall.Args, "-v")
 	goinstall.Args = append(goinstall.Args, []string{"-buildmode", "archive"}...)
 	goinstall.Args = append(goinstall.Args, packages...)
@@ -268,14 +273,11 @@ func doInstall(cmdline []string) {
 
 func buildFlags(env build.Environment) (flags []string) {
 	var ld []string
+	ld = append(ld, "-s", "-w")
 	if env.Commit != "" {
 		ld = append(ld, "-X", "main.gitCommit="+env.Commit)
 		ld = append(ld, "-X", "main.gitDate="+env.Date)
 	}
-	if runtime.GOOS == "darwin" {
-		ld = append(ld, "-s")
-	}
-
 	if len(ld) > 0 {
 		flags = append(flags, "-ldflags", strings.Join(ld, " "))
 	}


### PR DESCRIPTION
Disable symbol table and DWARF generation by default.
Trimpath if compiling with Go >= 1.13

On latest release 1.9.17, this reduces build size by 10MB+

Before:
```
$ ls -lh bin/
38M Jul 25 23:01 geth1.9.17_default
```

After:
```
28M Jul 25 23:11 geth1.9.17_patch
```

Trimpath also enhances privacy by stripping the full path of the source code location.

To see what I mean, run this on the binary:
```
strings geth | grep $(whoami)
```
