### PR TITLE
Update native-accounts.md

### DIFF
--- a/docs/_dapp/native-accounts.md
+++ b/docs/_dapp/native-accounts.md
@@ -83,7 +83,7 @@ recommend placing it either inside your user's home directory or even more locke
 backend applications.
 
 The last two arguments of
-[`accounts.NewManager`](https://godoc.org/github.com/ethereum/go-ethereum/accounts#NewManager)
+[`keystore.NewKeyStore`](https://godoc.org/github.com/ethereum/go-ethereum/accounts/keystore#NewKeyStore)
 are the crypto parameters defining how resource-intensive the keystore encryption should
 be. You can choose between [`accounts.StandardScryptN, accounts.StandardScryptP`,
 `accounts.LightScryptN,


### PR DESCRIPTION
it looks there was a typo in "The last two arguments of...". Pointing to "accounts.NewManager" looks irrelevant, while the context gives a description for "keystore.NewKeyStore" (which I changed with the link). As actually the choosing between [`accounts.StandardScryptN, accounts.StandardScryptP`,`accounts.LightScryptN, accounts.LightScryptP`] occurs in "keystore.NewKeyStore".
Thank you