### PR TITLE
miner: Fix race conditions on start and stop

### DIFF
--- a/miner/miner.go
+++ b/miner/miner.go
@@ -101,12 +101,7 @@ func (miner *Miner) update() {
 				// ensure calls to Start do not start the miner before sync is
 				// finished.
 
-				// We need to lock over setting canStart, checking Mining and
-				// the call to stop, to prevent the race condition where a
-				// prior concurrent call to Start which has passed all its
-				// checks then calls start after stop is called here. Resulting
-				// in the miner starting immediately after this call to stop
-				// whilst canstart is set to false.
+				// Prevent a race between this and Start/Stop
 				miner.mu.Lock()
 				miner.syncing = true
 				if miner.Mining() {
@@ -119,11 +114,7 @@ func (miner *Miner) update() {
 				// to start, we also unset the flag preventing calls to Start
 				// from starting the miner.
 
-				// We need to lock over both the check on shouldStart and the
-				// call to start, to prevent the race condition where a
-				// concurrent call to Stop occurs between the check of
-				// shouldStart and the call to start resulting in the miner
-				// being started after Stop has been called.
+				// Prevent a race between this and Start/Stop
 				miner.mu.Lock()
 				miner.syncing = false
 				if miner.shouldStart {


### PR DESCRIPTION
The Miner update method reacted to events from the downloader to start and stop the miner, but it lacked synchronisation over the checks to see if the miner was running or should run and the actions to start and stop
the miner.

This meant that you could end up in a situation where the miner would restart after a call to Stop and could also end up with the miner running during syncing.


Restarting after a call to `Stop`:
If we imagine there are 2 go-routines and one is handling a downloader done event and is about to execute line 108 of miner.go,  in the meantime a call to`Stop` is made and completes in a different goroutine, then the goroutine handling the downloader event continues and starts the miner.
https://github.com/ethereum/go-ethereum/blob/93da0cf8a19bac578c9bc7da08093a062a676fa3/miner/miner.go#L105-L112

https://github.com/ethereum/go-ethereum/blob/93da0cf8a19bac578c9bc7da08093a062a676fa3/miner/miner.go#L133-L136


Running while syncing:
If we imagine one goroutine is processing `Start` and is about to execute line 130 of miner.go, meanwhile a download start event is fully processed, `canStart` is set to 0 but no other action is taken because the miner is not running. Then the goroutine executing `Start` resumes and starts the miner even though `canStart` is 0 and the downloader is syncing.

https://github.com/ethereum/go-ethereum/blob/93da0cf8a19bac578c9bc7da08093a062a676fa3/miner/miner.go#L122-L131

https://github.com/ethereum/go-ethereum/blob/93da0cf8a19bac578c9bc7da08093a062a676fa3/miner/miner.go#L98-L104

The solution in these cases is to synchronise over both the check on the state and the action taken so that the check and action happen as one atomic block.
