### PR TITLE
p2p/discovery: support small networks.

### DIFF
--- a/p2p/discover/lookup.go
+++ b/p2p/discover/lookup.go
@@ -147,7 +147,7 @@ func (it *lookup) query(n *node, reply chan<- []*node) {
 		// Avoid recording failures on shutdown.
 		reply <- nil
 		return
-	} else if len(r) == 0 {
+	} else if len(r) == 0 && err != nil {
 		fails++
 		it.tab.db.UpdateFindFails(n.ID(), n.IP(), fails)
 		it.tab.log.Trace("Findnode failed", "id", n.ID(), "failcount", fails, "results", len(r), "err", err)


### PR DESCRIPTION
Fix neighbor discovery to work with small networks by allowing NEIGHBOR messages with 0 nodes. 