### PR TITLE
core: define and test chain reparation cornercases

### DIFF
--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -303,8 +303,8 @@ func NewBlockChain(db ethdb.Database, cacheConfig *CacheConfig, chainConfig *par
 			for i := low + 1; i <= bc.CurrentHeader().Number.Uint64(); i++ {
 				hashes = append(hashes, rawdb.ReadCanonicalHash(bc.db, i))
 			}
+			log.Warn("Truncating ancient chain", "from", previous, "to", low)
 			bc.Rollback(hashes)
-			log.Warn("Truncate ancient chain", "from", previous, "to", low)
 		}
 	}
 	// Check the current state of the block hashes and make sure that we do not have any of the bad blocks in our chain
@@ -485,10 +485,9 @@ func (bc *BlockChain) SetHead(head uint64) error {
 		if num+1 <= frozen {
 			// Truncate all relative data(header, total difficulty, body, receipt
 			// and canonical hash) from ancient store.
-			if err := bc.db.TruncateAncients(num + 1); err != nil {
+			if err := bc.truncateAncient(num + 1); err != nil {
 				log.Crit("Failed to truncate ancient data", "number", num, "err", err)
 			}
-
 			// Remove the hash <-> number mapping from the active store.
 			rawdb.DeleteHeaderNumber(db, hash)
 		} else {

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -284,38 +284,7 @@ func NewBlockChain(db ethdb.Database, cacheConfig *CacheConfig, chainConfig *par
 	// the head block (ethash cache or clique voting snapshot). Might as well do
 	// it in advance.
 	bc.engine.VerifyHeader(bc, bc.CurrentHeader(), true)
-	/*
-		// Ensure that the head block is above the freezer limit
-		if frozen, err := bc.db.Ancients(); err == nil && frozen > 0 {
-			var (
-				needRewind bool
-				low        uint64
-			)
-			// The head full block may be rolled back to a very low height due to
-			// blockchain repair. If the head full block is even lower than the ancient
-			// chain, truncate the ancient store.
-			fullBlock := bc.CurrentBlock()
-			if fullBlock != nil && fullBlock != bc.genesisBlock && fullBlock.NumberU64() < frozen-1 {
-				needRewind = true
-				low = fullBlock.NumberU64()
-			}
-			// In fast sync, it may happen that ancient data has been written to the
-			// ancient store, but the LastFastBlock has not been updated, truncate the
-			// extra data here.
-			fastBlock := bc.CurrentFastBlock()
-			if fastBlock != nil && fastBlock.NumberU64() < frozen-1 {
-				needRewind = true
-				if fastBlock.NumberU64() < low || low == 0 {
-					low = fastBlock.NumberU64()
-				}
-			}
-			if needRewind {
-				log.Warn("Truncating ancient chain", "from", bc.CurrentHeader().Number.Uint64(), "to", low)
-				if err := bc.SetHead(low); err != nil {
-					return nil, err
-				}
-			}
-		}*/
+
 	// Check the current state of the block hashes and make sure that we do not have any of the bad blocks in our chain
 	for hash := range BadHashes {
 		if header := bc.GetHeaderByHash(hash); header != nil {

--- a/core/blockchain_repair_test.go
+++ b/core/blockchain_repair_test.go
@@ -35,7 +35,7 @@ import (
 )
 
 // Tests a recovery for a short canonical chain where a recent block was already
-// comitted to disk and then the process crashed. In this case we expect the full
+// committed to disk and then the process crashed. In this case we expect the full
 // chain to be rolled back to the committed block, but the chain data itself left
 // in the database for replaying.
 func TestShortRepair(t *testing.T) {
@@ -72,7 +72,7 @@ func TestShortRepair(t *testing.T) {
 }
 
 // Tests a recovery for a short canonical chain where the fast sync pivot point was
-// already comitted, after which the process crashed. In this case we expect the full
+// already committed, after which the process crashed. In this case we expect the full
 // chain to be rolled back to the committed block, but the chain data itself left in
 // the database for replaying.
 func TestShortFastSyncedRepair(t *testing.T) {
@@ -109,7 +109,7 @@ func TestShortFastSyncedRepair(t *testing.T) {
 }
 
 // Tests a recovery for a short canonical chain where the fast sync pivot point was
-// not yet comitted, but the process crashed. In this case we expect the chain to
+// not yet committed, but the process crashed. In this case we expect the chain to
 // detect that it was fast syncing and not delete anything, since we can just pick
 // up directly where we left off.
 func TestShortFastSyncingRepair(t *testing.T) {
@@ -146,8 +146,8 @@ func TestShortFastSyncingRepair(t *testing.T) {
 }
 
 // Tests a recovery for a short canonical chain and a shorter side chain, where a
-// recent block was already comitted to disk and then the process crashed. In this
-// test scenario the side chain is below the commited block. In this case we expect
+// recent block was already committed to disk and then the process crashed. In this
+// test scenario the side chain is below the committed block. In this case we expect
 // the canonical chain to be rolled back to the committed block, but the chain data
 // itself left in the database for replaying.
 func TestShortOldForkedRepair(t *testing.T) {
@@ -186,8 +186,8 @@ func TestShortOldForkedRepair(t *testing.T) {
 }
 
 // Tests a recovery for a short canonical chain and a shorter side chain, where
-// the fast sync pivot point was already comitted to disk and then the process
-// crashed. In this test scenario the side chain is below the commited block. In
+// the fast sync pivot point was already committed to disk and then the process
+// crashed. In this test scenario the side chain is below the committed block. In
 // this case we expect the canonical chain to be rolled back to the committed block,
 // but the chain data itself left in the database for replaying.
 func TestShortOldForkedFastSyncedRepair(t *testing.T) {
@@ -226,8 +226,8 @@ func TestShortOldForkedFastSyncedRepair(t *testing.T) {
 }
 
 // Tests a recovery for a short canonical chain and a shorter side chain, where
-// the fast sync pivot point was not yet comitted, but the process crashed. In this
-// test scenario the side chain is below the commited block. In this case we expect
+// the fast sync pivot point was not yet committed, but the process crashed. In this
+// test scenario the side chain is below the committed block. In this case we expect
 // the chain to detect that it was fast syncing and not delete anything, since we
 // can just pick up directly where we left off.
 func TestShortOldForkedFastSyncingRepair(t *testing.T) {
@@ -266,8 +266,8 @@ func TestShortOldForkedFastSyncingRepair(t *testing.T) {
 }
 
 // Tests a recovery for a short canonical chain and a shorter side chain, where a
-// recent block was already comitted to disk and then the process crashed. In this
-// test scenario the side chain reaches above the commited block. In this case we
+// recent block was already committed to disk and then the process crashed. In this
+// test scenario the side chain reaches above the committed block. In this case we
 // expect the canonical chain to be rolled back to the committed block, but the
 // chain data itself left in the database for replaying.
 func TestShortNewlyForkedRepair(t *testing.T) {
@@ -306,8 +306,8 @@ func TestShortNewlyForkedRepair(t *testing.T) {
 }
 
 // Tests a recovery for a short canonical chain and a shorter side chain, where
-// the fast sync pivot point was already comitted to disk and then the process
-// crashed. In this test scenario the side chain reaches above the commited block.
+// the fast sync pivot point was already committed to disk and then the process
+// crashed. In this test scenario the side chain reaches above the committed block.
 // In this case we expect the canonical chain to be rolled back to the committed
 // block, but the chain data itself left in the database for replaying.
 func TestShortNewlyForkedFastSyncedRepair(t *testing.T) {
@@ -346,8 +346,8 @@ func TestShortNewlyForkedFastSyncedRepair(t *testing.T) {
 }
 
 // Tests a recovery for a short canonical chain and a shorter side chain, where
-// the fast sync pivot point was not yet comitted, but the process crashed. In
-// this test scenario the side chain reaches above the commited block. In this
+// the fast sync pivot point was not yet committed, but the process crashed. In
+// this test scenario the side chain reaches above the committed block. In this
 // case we expect the chain to detect that it was fast syncing and not delete
 // anything, since we can just pick up directly where we left off.
 func TestShortNewlyForkedFastSyncingRepair(t *testing.T) {
@@ -386,7 +386,7 @@ func TestShortNewlyForkedFastSyncingRepair(t *testing.T) {
 }
 
 // Tests a recovery for a short canonical chain and a longer side chain, where a
-// recent block was already comitted to disk and then the process crashed. In this
+// recent block was already committed to disk and then the process crashed. In this
 // case we expect the canonical chain to be rolled back to the committed block, but
 // the chain data itself left in the database for replaying.
 func TestShortReorgedRepair(t *testing.T) {
@@ -425,7 +425,7 @@ func TestShortReorgedRepair(t *testing.T) {
 }
 
 // Tests a recovery for a short canonical chain and a longer side chain, where
-// the fast sync pivot point was already comitted to disk and then the process
+// the fast sync pivot point was already committed to disk and then the process
 // crashed. In this case we expect the canonical chain to be rolled back to the
 // committed block, but the chain data itself left in the database for replaying.
 func TestShortReorgedFastSyncedRepair(t *testing.T) {
@@ -464,7 +464,7 @@ func TestShortReorgedFastSyncedRepair(t *testing.T) {
 }
 
 // Tests a recovery for a short canonical chain and a longer side chain, where
-// the fast sync pivot point was not yet comitted, but the process crashed. In
+// the fast sync pivot point was not yet committed, but the process crashed. In
 // this case we expect the chain to detect that it was fast syncing and not delete
 // anything, since we can just pick up directly where we left off.
 func TestShortReorgedFastSyncingRepair(t *testing.T) {
@@ -503,7 +503,7 @@ func TestShortReorgedFastSyncingRepair(t *testing.T) {
 }
 
 // Tests a recovery for a long canonical chain with frozen blocks where a recent
-// block - newer than the ancient limit - was already comitted to disk and then
+// block - newer than the ancient limit - was already committed to disk and then
 // the process crashed. In this case we expect the chain to be rolled back to the
 // committed block, with everything afterwads kept as fast sync data.
 func TestLongShallowRepair(t *testing.T) {
@@ -545,7 +545,7 @@ func TestLongShallowRepair(t *testing.T) {
 }
 
 // Tests a recovery for a long canonical chain with frozen blocks where a recent
-// block - older than the ancient limit - was already comitted to disk and then
+// block - older than the ancient limit - was already committed to disk and then
 // the process crashed. In this case we expect the chain to be rolled back to the
 // committed block, with everything afterwads deleted.
 func TestLongDeepRepair(t *testing.T) {
@@ -586,7 +586,7 @@ func TestLongDeepRepair(t *testing.T) {
 }
 
 // Tests a recovery for a long canonical chain with frozen blocks where the fast
-// sync pivot point - newer than the ancient limit - was already comitted, after
+// sync pivot point - newer than the ancient limit - was already committed, after
 // which the process crashed. In this case we expect the chain to be rolled back
 // to the committed block, with everything afterwads kept as fast sync data.
 func TestLongFastSyncedShallowRepair(t *testing.T) {
@@ -628,7 +628,7 @@ func TestLongFastSyncedShallowRepair(t *testing.T) {
 }
 
 // Tests a recovery for a long canonical chain with frozen blocks where the fast
-// sync pivot point - older than the ancient limit - was already comitted, after
+// sync pivot point - older than the ancient limit - was already committed, after
 // which the process crashed. In this case we expect the chain to be rolled back
 // to the committed block, with everything afterwads deleted.
 func TestLongFastSyncedDeepRepair(t *testing.T) {
@@ -669,7 +669,7 @@ func TestLongFastSyncedDeepRepair(t *testing.T) {
 }
 
 // Tests a recovery for a long canonical chain with frozen blocks where the fast
-// sync pivot point - older than the ancient limit - was not yet comitted, but the
+// sync pivot point - older than the ancient limit - was not yet committed, but the
 // process crashed. In this case we expect the chain to detect that it was fast
 // syncing and not delete anything, since we can just pick up directly where we
 // left off.
@@ -712,7 +712,7 @@ func TestLongFastSyncingShallowRepair(t *testing.T) {
 }
 
 // Tests a recovery for a long canonical chain with frozen blocks where the fast
-// sync pivot point - newer than the ancient limit - was not yet comitted, but the
+// sync pivot point - newer than the ancient limit - was not yet committed, but the
 // process crashed. In this case we expect the chain to detect that it was fast
 // syncing and not delete anything, since we can just pick up directly where we
 // left off.
@@ -756,8 +756,8 @@ func TestLongFastSyncingDeepRepair(t *testing.T) {
 
 // Tests a recovery for a long canonical chain with frozen blocks and a shorter
 // side chain, where a recent block - newer than the ancient limit - was already
-// comitted to disk and then the process crashed. In this test scenario the side
-// chain is below the commited block. In this case we expect the chain to be
+// committed to disk and then the process crashed. In this test scenario the side
+// chain is below the committed block. In this case we expect the chain to be
 // rolled back to the committed block, with everything afterwads kept as fast
 // sync data; the side chain completely nuked by the freezer.
 func TestLongOldForkedShallowRepair(t *testing.T) {
@@ -801,8 +801,8 @@ func TestLongOldForkedShallowRepair(t *testing.T) {
 
 // Tests a recovery for a long canonical chain with frozen blocks and a shorter
 // side chain, where a recent block - older than the ancient limit - was already
-// comitted to disk and then the process crashed. In this test scenario the side
-// chain is below the commited block. In this case we expect the canonical chain
+// committed to disk and then the process crashed. In this test scenario the side
+// chain is below the committed block. In this case we expect the canonical chain
 // to be rolled back to the committed block, with everything afterwads deleted;
 // the side chain completely nuked by the freezer.
 func TestLongOldForkedDeepRepair(t *testing.T) {
@@ -845,8 +845,8 @@ func TestLongOldForkedDeepRepair(t *testing.T) {
 
 // Tests a recovery for a long canonical chain with frozen blocks and a shorter
 // side chain, where the fast sync pivot point - newer than the ancient limit -
-// was already comitted to disk and then the process crashed. In this test scenario
-// the side chain is below the commited block. In this case we expect the chain
+// was already committed to disk and then the process crashed. In this test scenario
+// the side chain is below the committed block. In this case we expect the chain
 // to be rolled back to the committed block, with everything afterwads kept as
 // fast sync data; the side chain completely nuked by the freezer.
 func TestLongOldForkedFastSyncedShallowRepair(t *testing.T) {
@@ -890,8 +890,8 @@ func TestLongOldForkedFastSyncedShallowRepair(t *testing.T) {
 
 // Tests a recovery for a long canonical chain with frozen blocks and a shorter
 // side chain, where the fast sync pivot point - older than the ancient limit -
-// was already comitted to disk and then the process crashed. In this test scenario
-// the side chain is below the commited block. In this case we expect the canonical
+// was already committed to disk and then the process crashed. In this test scenario
+// the side chain is below the committed block. In this case we expect the canonical
 // chain to be rolled back to the committed block, with everything afterwads deleted;
 // the side chain completely nuked by the freezer.
 func TestLongOldForkedFastSyncedDeepRepair(t *testing.T) {
@@ -934,8 +934,8 @@ func TestLongOldForkedFastSyncedDeepRepair(t *testing.T) {
 
 // Tests a recovery for a long canonical chain with frozen blocks and a shorter
 // side chain, where the fast sync pivot point - older than the ancient limit -
-// was not yet comitted, but the process crashed. In this test scenario the side
-// chain is below the commited block. In this case we expect the chain to detect
+// was not yet committed, but the process crashed. In this test scenario the side
+// chain is below the committed block. In this case we expect the chain to detect
 // that it was fast syncing and not delete anything. The side chain is completely
 // nuked by the freezer.
 func TestLongOldForkedFastSyncingShallowRepair(t *testing.T) {
@@ -979,8 +979,8 @@ func TestLongOldForkedFastSyncingShallowRepair(t *testing.T) {
 
 // Tests a recovery for a long canonical chain with frozen blocks and a shorter
 // side chain, where the fast sync pivot point - older than the ancient limit -
-// was not yet comitted, but the process crashed. In this test scenario the side
-// chain is below the commited block. In this case we expect the chain to detect
+// was not yet committed, but the process crashed. In this test scenario the side
+// chain is below the committed block. In this case we expect the chain to detect
 // that it was fast syncing and not delete anything. The side chain is completely
 // nuked by the freezer.
 func TestLongOldForkedFastSyncingDeepRepair(t *testing.T) {
@@ -1024,8 +1024,8 @@ func TestLongOldForkedFastSyncingDeepRepair(t *testing.T) {
 
 // Tests a recovery for a long canonical chain with frozen blocks and a shorter
 // side chain, where a recent block - newer than the ancient limit - was already
-// comitted to disk and then the process crashed. In this test scenario the side
-// chain is above the commited block. In this case we expect the chain to be
+// committed to disk and then the process crashed. In this test scenario the side
+// chain is above the committed block. In this case we expect the chain to be
 // rolled back to the committed block, with everything afterwads kept as fast
 // sync data; the side chain completely nuked by the freezer.
 func TestLongNewerForkedShallowRepair(t *testing.T) {
@@ -1069,8 +1069,8 @@ func TestLongNewerForkedShallowRepair(t *testing.T) {
 
 // Tests a recovery for a long canonical chain with frozen blocks and a shorter
 // side chain, where a recent block - older than the ancient limit - was already
-// comitted to disk and then the process crashed. In this test scenario the side
-// chain is above the commited block. In this case we expect the canonical chain
+// committed to disk and then the process crashed. In this test scenario the side
+// chain is above the committed block. In this case we expect the canonical chain
 // to be rolled back to the committed block, with everything afterwads deleted;
 // the side chain completely nuked by the freezer.
 func TestLongNewerForkedDeepRepair(t *testing.T) {
@@ -1113,8 +1113,8 @@ func TestLongNewerForkedDeepRepair(t *testing.T) {
 
 // Tests a recovery for a long canonical chain with frozen blocks and a shorter
 // side chain, where the fast sync pivot point - newer than the ancient limit -
-// was already comitted to disk and then the process crashed. In this test scenario
-// the side chain is above the commited block. In this case we expect the chain
+// was already committed to disk and then the process crashed. In this test scenario
+// the side chain is above the committed block. In this case we expect the chain
 // to be rolled back to the committed block, with everything afterwads kept as fast
 // sync data; the side chain completely nuked by the freezer.
 func TestLongNewerForkedFastSyncedShallowRepair(t *testing.T) {
@@ -1158,8 +1158,8 @@ func TestLongNewerForkedFastSyncedShallowRepair(t *testing.T) {
 
 // Tests a recovery for a long canonical chain with frozen blocks and a shorter
 // side chain, where the fast sync pivot point - older than the ancient limit -
-// was already comitted to disk and then the process crashed. In this test scenario
-// the side chain is above the commited block. In this case we expect the canonical
+// was already committed to disk and then the process crashed. In this test scenario
+// the side chain is above the committed block. In this case we expect the canonical
 // chain to be rolled back to the committed block, with everything afterwads deleted;
 // the side chain completely nuked by the freezer.
 func TestLongNewerForkedFastSyncedDeepRepair(t *testing.T) {
@@ -1202,8 +1202,8 @@ func TestLongNewerForkedFastSyncedDeepRepair(t *testing.T) {
 
 // Tests a recovery for a long canonical chain with frozen blocks and a shorter
 // side chain, where the fast sync pivot point - older than the ancient limit -
-// was not yet comitted, but the process crashed. In this test scenario the side
-// chain is above the commited block. In this case we expect the chain to detect
+// was not yet committed, but the process crashed. In this test scenario the side
+// chain is above the committed block. In this case we expect the chain to detect
 // that it was fast syncing and not delete anything. The side chain is completely
 // nuked by the freezer.
 func TestLongNewerForkedFastSyncingShallowRepair(t *testing.T) {
@@ -1247,8 +1247,8 @@ func TestLongNewerForkedFastSyncingShallowRepair(t *testing.T) {
 
 // Tests a recovery for a long canonical chain with frozen blocks and a shorter
 // side chain, where the fast sync pivot point - older than the ancient limit -
-// was not yet comitted, but the process crashed. In this test scenario the side
-// chain is above the commited block. In this case we expect the chain to detect
+// was not yet committed, but the process crashed. In this test scenario the side
+// chain is above the committed block. In this case we expect the chain to detect
 // that it was fast syncing and not delete anything. The side chain is completely
 // nuked by the freezer.
 func TestLongNewerForkedFastSyncingDeepRepair(t *testing.T) {
@@ -1291,7 +1291,7 @@ func TestLongNewerForkedFastSyncingDeepRepair(t *testing.T) {
 }
 
 // Tests a recovery for a long canonical chain with frozen blocks and a longer side
-// chain, where a recent block - newer than the ancient limit - was already comitted
+// chain, where a recent block - newer than the ancient limit - was already committed
 // to disk and then the process crashed. In this case we expect the chain to be
 // rolled back to the committed block, with everything afterwads kept as fast sync
 // data. The side chain completely nuked by the freezer.
@@ -1335,7 +1335,7 @@ func TestLongReorgedShallowRepair(t *testing.T) {
 }
 
 // Tests a recovery for a long canonical chain with frozen blocks and a longer side
-// chain, where a recent block - older than the ancient limit - was already comitted
+// chain, where a recent block - older than the ancient limit - was already committed
 // to disk and then the process crashed. In this case we expect the canonical chains
 // to be rolled back to the committed block, with everything afterwads deleted. The
 // side chain completely nuked by the freezer.
@@ -1379,7 +1379,7 @@ func TestLongReorgedDeepRepair(t *testing.T) {
 
 // Tests a recovery for a long canonical chain with frozen blocks and a longer
 // side chain, where the fast sync pivot point - newer than the ancient limit -
-// was already comitted to disk and then the process crashed. In this case we
+// was already committed to disk and then the process crashed. In this case we
 // expect the chain to be rolled back to the committed block, with everything
 // afterwads kept as fast sync data. The side chain completely nuked by the
 // freezer.
@@ -1424,7 +1424,7 @@ func TestLongReorgedFastSyncedShallowRepair(t *testing.T) {
 
 // Tests a recovery for a long canonical chain with frozen blocks and a longer
 // side chain, where the fast sync pivot point - older than the ancient limit -
-// was already comitted to disk and then the process crashed. In this case we
+// was already committed to disk and then the process crashed. In this case we
 // expect the canonical chains to be rolled back to the committed block, with
 // everything afterwads deleted. The side chain completely nuked by the freezer.
 func TestLongReorgedFastSyncedDeepRepair(t *testing.T) {
@@ -1467,7 +1467,7 @@ func TestLongReorgedFastSyncedDeepRepair(t *testing.T) {
 
 // Tests a recovery for a long canonical chain with frozen blocks and a longer
 // side chain, where the fast sync pivot point - newer than the ancient limit -
-// was not yet comitted, but the process crashed. In this case we expect the
+// was not yet committed, but the process crashed. In this case we expect the
 // chain to detect that it was fast syncing and not delete anything, since we
 // can just pick up directly where we left off.
 func TestLongReorgedFastSyncingShallowRepair(t *testing.T) {
@@ -1511,7 +1511,7 @@ func TestLongReorgedFastSyncingShallowRepair(t *testing.T) {
 
 // Tests a recovery for a long canonical chain with frozen blocks and a longer
 // side chain, where the fast sync pivot point - older than the ancient limit -
-// was not yet comitted, but the process crashed. In this case we expect the
+// was not yet committed, but the process crashed. In this case we expect the
 // chain to detect that it was fast syncing and not delete anything, since we
 // can just pick up directly where we left off.
 func TestLongReorgedFastSyncingDeepRepair(t *testing.T) {

--- a/core/blockchain_rollback_test.go
+++ b/core/blockchain_rollback_test.go
@@ -1,0 +1,432 @@
+// Copyright 2020 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+package core
+
+import (
+	"fmt"
+	"io/ioutil"
+	"math/big"
+	"os"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/consensus/ethash"
+	"github.com/ethereum/go-ethereum/core/rawdb"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/core/vm"
+	"github.com/ethereum/go-ethereum/params"
+)
+
+// Tests that abnormal program termination (i.e.crash) and restart doesn't leave
+// the database in some strange state with gaps in the chain, nor with block data
+// dangling in the future.
+//
+// The expected behavior in case of missing head state is to delete all blocks and
+// related data up until the first block for which we do have the state, or if we
+// exceed the fast sync pivot point to stop there and reenable fast sync.
+//
+// Note, the trigger condition needs to be the current full block, not the current
+// head header, as fast sync is allowed to go further with headers.
+
+// Tests a recovery for a short canonical chain where a recent block was already
+// comitted to disk and then the process crashed. In this case we expect the chain
+// to be rolled back to the committed block, with everything afterwads deleted.
+func TestShortRepair(t *testing.T) {
+	testRepair(t, 8, 0, 16, 4, 0, 4, 0)
+}
+
+// Tests a recovery for a short canonical chain where the fast sync pivot point was
+// already comitted, after which the process crashed. In this case we expect the
+// chain to behave like in full sync mode, rolling back to the committed block,
+// with everything afterwads deleted.
+func TestShortFastSyncedRepair(t *testing.T) {
+	testRepair(t, 8, 0, 16, 4, 4, 4, 0)
+}
+
+// Tests a recovery for a short canonical chain where the fast sync pivot point was
+// not yet comitted, but the process crashed. In this case we expect the chain to
+// detect that it was fast syncing and not delete anything, since we can just pick
+// up directly where we left off.
+func TestShortFastSyncingRepair(t *testing.T) {
+	testRepair(t, 8, 0, 16, 0, 4, 8, 0)
+}
+
+// Tests a recovery for a short canonical chain and a shorter side chain, where a
+// recent block was already comitted to disk and then the process crashed. In this
+// test scenario the side chain is below the commited block. In this case we expect
+// the canonical chain to be rolled back to the committed block, with everything
+// afterwads deleted; but the side chain left alone as it was shorter.
+func TestShortOldForkedRepair(t *testing.T) {
+	testRepair(t, 8, 3, 16, 4, 0, 4, 3)
+}
+
+// Tests a recovery for a short canonical chain and a shorter side chain, where
+// the fast sync pivot point was already comitted to disk and then the process
+// crashed. In this test scenario the side chain is below the commited block. In
+// this case we expect the canonical chain to be rolled back to the committed block,
+// with everything afterwads deleted; but the side chain left alone as it was shorter.
+func TestShortOldForkedFastSyncedRepair(t *testing.T) {
+	testRepair(t, 8, 3, 16, 4, 4, 4, 3)
+}
+
+// Tests a recovery for a short canonical chain and a shorter side chain, where
+// the fast sync pivot point was not yet comitted, but the process crashed. In this
+// test scenario the side chain is below the commited block. In this case we expect
+// the chain to detect that it was fast syncing and not delete anything, since we
+// can just pick up directly where we left off.
+func TestShortOldForkedFastSyncingRepair(t *testing.T) {
+	testRepair(t, 8, 3, 16, 0, 4, 8, 3)
+}
+
+// Tests a recovery for a short canonical chain and a shorter side chain, where a
+// recent block was already comitted to disk and then the process crashed. In this
+// test scenario the side chain reaches above the commited block. In this case we
+// expect both canonical and side chains to be rolled back to the committed block,
+// with everything afterwads deleted.
+//
+// The side chain could be left to be if the fork point was before the new head
+// we are deleting to, but it would be exceedingly hard to detect that case and
+// properly handle it, so we'll trade extra work in exchange for simpler code.
+func TestShortNewlyForkedRepair(t *testing.T) {
+	testRepair(t, 8, 6, 16, 4, 0, 4, 4)
+}
+
+// Tests a recovery for a short canonical chain and a shorter side chain, where
+// the fast sync pivot point was already comitted to disk and then the process
+// crashed. In this test scenario the side chain reaches above the commited block.
+// In this case we expect both canonical and side chains to be rolled back to the
+// committed block, with everything afterwads deleted.
+//
+// The side chain could be left to be if the fork point was before the new head
+// we are deleting to, but it would be exceedingly hard to detect that case and
+// properly handle it, so we'll trade extra work in exchange for simpler code.
+func TestShortNewlyForkedFastSyncedRepair(t *testing.T) {
+	testRepair(t, 8, 6, 16, 4, 4, 4, 4)
+}
+
+// Tests a recovery for a short canonical chain and a shorter side chain, where
+// the fast sync pivot point was not yet comitted, but the process crashed. In
+// this test scenario the side chain reaches above the commited block. In this
+// case we expect the chain to detect that it was fast syncing and not delete
+// anything, since we can just pick up directly where we left off.
+func TestShortNewlyForkedFastSyncingRepair(t *testing.T) {
+	testRepair(t, 8, 6, 16, 0, 4, 8, 6)
+}
+
+// Tests a recovery for a short canonical chain and a longer side chain, where a
+// recent block was already comitted to disk and then the process crashed. In this
+// case we expect both canonical and side chains to be rolled back to the committed
+// block, with everything afterwads deleted.
+//
+// The side chain could be left to be if the fork point was before the new head
+// we are deleting to, but it would be exceedingly hard to detect that case and
+// properly handle it, so we'll trade extra work in exchange for simpler code.
+func TestShortReorgedRepair(t *testing.T) {
+	testRepair(t, 8, 10, 16, 4, 0, 4, 4)
+}
+
+// Tests a recovery for a short canonical chain and a longer side chain, where
+// the fast sync pivot point was already comitted to disk and then the process
+// crashed. In this case we expect both canonical and side chains to be rolled
+// back to the committed block, with everything afterwads deleted.
+//
+// The side chain could be left to be if the fork point was before the new head
+// we are deleting to, but it would be exceedingly hard to detect that case and
+// properly handle it, so we'll trade extra work in exchange for simpler code.
+func TestShortReorgedFastSyncedRepair(t *testing.T) {
+	testRepair(t, 8, 10, 16, 4, 4, 4, 4)
+}
+
+// Tests a recovery for a short canonical chain and a longer side chain, where
+// the fast sync pivot point was not yet comitted, but the process crashed. In
+// this case we expect the chain to detect that it was fast syncing and not delete
+// anything, since we can just pick up directly where we left off.
+func TestShortReorgedFastSyncingRepair(t *testing.T) {
+	testRepair(t, 8, 10, 16, 0, 4, 8, 10)
+}
+
+// Tests a recovery for a long canonical chain with frozen blocks where a recent
+// block - older than the ancient limit - was already comitted to disk and then
+// the process crashed. In this case we expect the chain to be rolled back to the
+// committed block, with everything afterwads deleted.
+func TestLongRepair(t *testing.T) {
+	testRepair(t, 24, 0, 16, 4, 0, 4, 0)
+}
+
+// Tests a recovery for a long canonical chain with frozen blocks where the fast
+// sync pivot point - older than the ancient limit - was already comitted, after
+// which the process crashed. In this case we expect the chain to behave like in
+// full sync mode, rolling back to the committed block, with everything afterwads
+// deleted.
+func TestLongFastSyncedRepair(t *testing.T) {
+	testRepair(t, 24, 0, 16, 4, 4, 4, 0)
+}
+
+// Tests a recovery for a long canonical chain with frozen blocks where the fast
+// sync pivot point - older than the ancient limit - was not yet comitted, but the
+// process crashed. In this case we expect the chain to detect that it was fast
+// syncing and not delete anything, since we can just pick up directly where we
+// left off.
+func TestLongFastSyncingRepair(t *testing.T) {
+	testRepair(t, 24, 0, 16, 0, 4, 24, 0)
+}
+
+// Tests a recovery for a long canonical chain with frozen blocks and a shorter
+// side chain, where a recent block - older than the ancient limit - was already
+// comitted to disk and then the process crashed. In this test scenario the side
+// chain is below the commited block. In this case we expect the canonical chain
+// to be rolled back to the committed block, with everything afterwads deleted;
+// the side chain completely nuked by the freezer.
+func TestLongOldForkedRepair(t *testing.T) {
+	testRepair(t, 24, 3, 16, 4, 0, 4, 0)
+}
+
+// Tests a recovery for a long canonical chain with frozen blocks and a shorter
+// side chain, where the fast sync pivot point - older than the ancient limit -
+// was already comitted to disk and then the process crashed. In this test scenario
+// the side chain is below the commited block. In this case we expect the canonical
+// chain to be rolled back to the committed block, with everything afterwads deleted;
+// the side chain completely nuked by the freezer.
+func TestLongOldForkedFastSyncedRepair(t *testing.T) {
+	testRepair(t, 24, 3, 16, 4, 4, 4, 0)
+}
+
+// Tests a recovery for a long canonical chain with frozen blocks and a shorter
+// side chain, where the fast sync pivot point - older than the ancient limit -
+// was not yet comitted, but the process crashed. In this test scenario the side
+// chain is below the commited block. In this case we expect the chain to detect
+// that it was fast syncing and not delete anything. The side chin is completely
+// nuked by the freezer.
+func TestLongOldForkedFastSyncingRepair(t *testing.T) {
+	testRepair(t, 24, 3, 16, 0, 4, 24, 0)
+}
+
+// Tests a recovery for a long canonical chain with frozen blocks and a shorter
+// side chain, where a recent block - older than the ancient limit - was already
+// comitted to disk and then the process crashed. In this test scenario the side
+// chain is abo e the commited block. In this case we expect the canonical chain
+// to be rolled back to the committed block, with everything afterwads deleted;
+// the side chain completely nuked by the freezer.
+func TestLongNewerForkedRepair(t *testing.T) {
+	testRepair(t, 24, 12, 16, 4, 0, 4, 0)
+}
+
+// Tests a recovery for a long canonical chain with frozen blocks and a shorter
+// side chain, where the fast sync pivot point - older than the ancient limit -
+// was already comitted to disk and then the process crashed. In this test scenario
+// the side chain is abo e the commited block. In this case we expect the canonical
+// chain to be rolled back to the committed block, with everything afterwads deleted;
+// the side chain completely nuked by the freezer.
+func TestLongNewerForkedFastSyncedRepair(t *testing.T) {
+	testRepair(t, 24, 12, 16, 4, 4, 4, 0)
+}
+
+// Tests a recovery for a long canonical chain with frozen blocks and a shorter
+// side chain, where the fast sync pivot point - older than the ancient limit -
+// was not yet comitted, but the process crashed. In this test scenario the side
+// chain is abo e the commited block. In this case we expect the chain to detect
+// that it was fast syncing and not delete anything. The side chain is completely
+// nuked by the freezer.
+func TestLongNewerForkedFastSyncingRepair(t *testing.T) {
+	testRepair(t, 24, 12, 16, 0, 4, 24, 0)
+}
+
+// Tests a recovery for a long canonical chain with frozen blocks and a longer side
+// chain, where a recent block - older than the ancient limit - was already comitted
+// to disk and then the process crashed. In this case we expect the canonical chains
+// to be rolled back to the committed block, with everything afterwads deleted. The
+// side chain completely nuked by the freezer.
+//
+// The side chain could be left to be if the fork point was before the new head
+// we are deleting to, but it would be exceedingly hard to detect that case and
+// properly handle it, so we'll trade extra work in exchange for simpler code.
+func TestLongReorgedRepair(t *testing.T) {
+	testRepair(t, 24, 26, 16, 4, 0, 4, 0)
+}
+
+// Tests a recovery for a long canonical chain with frozen blocks and a longer
+// side chain, where the fast sync pivot point - older than the ancient limit -
+// was already comitted to disk and then the process crashed. In this case we
+// expect the canonical chains to be rolled back to the committed block, with
+// everything afterwads deleted. The side chain completely nuked by the freezer.
+//
+// The side chain could be left to be if the fork point was before the new head
+// we are deleting to, but it would be exceedingly hard to detect that case and
+// properly handle it, so we'll trade extra work in exchange for simpler code.
+func TestLongReorgedFastSyncedRepair(t *testing.T) {
+	testRepair(t, 24, 26, 16, 4, 4, 4, 0)
+}
+
+// Tests a recovery for a long canonical chain with frozen blocks and a longer
+// side chain, where the fast sync pivot point - older than the ancient limit -
+// was not yet comitted, but the process crashed. In this case we expect the
+// chain to detect that it was fast syncing and not delete anything, since we
+// can just pick up directly where we left off.
+func TestLongReorgedFastSyncingRepair(t *testing.T) {
+	testRepair(t, 24, 26, 16, 0, 4, 24, 26)
+}
+
+func testRepair(t *testing.T, canonchain int, sidechain int, freeze uint64, commit int, pivot int, canonretain int, sideretain int) {
+	//log.Root().SetHandler(log.LvlFilterHandler(log.LvlTrace, log.StreamHandler(os.Stderr, log.TerminalFormat(true))))
+
+	// Create a temporary persistent database
+	datadir, err := ioutil.TempDir("", "")
+	if err != nil {
+		t.Fatalf("Failed to create temporary datadir: %v", err)
+	}
+	os.RemoveAll(datadir)
+
+	db, err := rawdb.NewLevelDBDatabaseWithFreezer(datadir, 0, 0, datadir, "")
+	if err != nil {
+		t.Fatalf("Failed to create persistent database: %v", err)
+	}
+	defer db.Close() // Might double close, should be fine
+
+	// Initialize a fresh chain
+	var (
+		genesis = new(Genesis).MustCommit(db)
+		engine  = ethash.NewFullFaker()
+	)
+	chain, err := NewBlockChain(db, nil, params.AllEthashProtocolChanges, engine, vm.Config{}, nil, nil)
+	if err != nil {
+		t.Fatalf("Failed to create chain: %v", err)
+	}
+	// If sidechain blocks are needed, make a light chain and import it
+	var sideblocks types.Blocks
+	if sidechain > 0 {
+		sideblocks, _ = GenerateChain(params.TestChainConfig, genesis, engine, rawdb.NewMemoryDatabase(), sidechain, func(i int, b *BlockGen) {
+			b.SetCoinbase(common.Address{0x01})
+		})
+		if _, err := chain.InsertChain(sideblocks); err != nil {
+			t.Fatalf("Failed to import side chain: %v", err)
+		}
+	}
+	canonblocks, _ := GenerateChain(params.TestChainConfig, genesis, engine, rawdb.NewMemoryDatabase(), canonchain, func(i int, b *BlockGen) {
+		b.SetCoinbase(common.Address{0x02})
+		b.SetDifficulty(big.NewInt(1000000))
+	})
+	if _, err := chain.InsertChain(canonblocks[:commit]); err != nil {
+		t.Fatalf("Failed to import canonical chain start: %v", err)
+	}
+	if commit > 0 {
+		chain.stateCache.TrieDB().Commit(canonblocks[commit-1].Root(), true, nil)
+	}
+	if _, err := chain.InsertChain(canonblocks[commit:]); err != nil {
+		t.Fatalf("Failed to import canonical chain tail: %v", err)
+	}
+	if sidechain > 0 {
+		fmt.Println(sideblocks[sidechain-1].Hash(), canonblocks[canonchain-1].Hash())
+		fmt.Println(chain.CurrentBlock().Hash())
+	}
+	// Force run a freeze cycle
+	type freezer interface {
+		Freeze(threshold uint64)
+	}
+	db.(freezer).Freeze(freeze)
+
+	// Pull the plug on the database, simulating a hard crash
+	db.Close()
+
+	// Start a new blockchain back up and see where the repait leads us
+	db, err = rawdb.NewLevelDBDatabaseWithFreezer(datadir, 0, 0, datadir, "")
+	if err != nil {
+		t.Fatalf("Failed to reopen persistent database: %v", err)
+	}
+	defer db.Close()
+
+	chain, err = NewBlockChain(db, nil, params.AllEthashProtocolChanges, engine, vm.Config{}, nil, nil)
+	if err != nil {
+		t.Fatalf("Failed to recreate chain: %v", err)
+	}
+	defer chain.Stop()
+
+	// Iterate over all the remaining blocks and ensure there are no gaps
+	verifyNoGaps(t, chain, canonblocks)
+	verifyNoGaps(t, chain, sideblocks)
+	verifyCutoff(t, chain, canonblocks, canonretain)
+	verifyCutoff(t, chain, sideblocks, sideretain)
+}
+
+// verifyNoGaps checks that there are no gaps after the initial set of blocks in
+// the database and errors if found.
+func verifyNoGaps(t *testing.T, chain *BlockChain, inserted types.Blocks) {
+	t.Helper()
+
+	var end uint64
+	for i := uint64(0); i <= uint64(len(inserted)); i++ {
+		header := chain.GetHeaderByNumber(i)
+		if header == nil && end == 0 {
+			end = i
+		}
+		if header != nil && end > 0 {
+			t.Errorf("Header gap between #%d-#%d", end, i-1)
+			end = 0 // Reset for further gap detection
+		}
+	}
+	end = 0
+	for i := uint64(0); i <= uint64(len(inserted)); i++ {
+		block := chain.GetBlockByNumber(i)
+		if block == nil && end == 0 {
+			end = i
+		}
+		if block != nil && end > 0 {
+			t.Errorf("Block gap between #%d-#%d", end, i-1)
+			end = 0 // Reset for further gap detection
+		}
+	}
+	end = 0
+	for i := uint64(1); i <= uint64(len(inserted)); i++ {
+		receipts := chain.GetReceiptsByHash(inserted[i-1].Hash())
+		if receipts == nil && end == 0 {
+			end = i
+		}
+		if receipts != nil && end > 0 {
+			t.Errorf("Receipt gap between #%d-#%d", end, i-1)
+			end = 0 // Reset for further gap detection
+		}
+	}
+}
+
+// verifyCutoff checks that there are no chain data available in the chain after
+// the specified limit, but that it is available before.
+func verifyCutoff(t *testing.T, chain *BlockChain, inserted types.Blocks, head int) {
+	t.Helper()
+
+	for i := 1; i <= len(inserted); i++ {
+		if i <= head {
+			if header := chain.GetHeader(inserted[i-1].Hash(), uint64(i)); header == nil {
+				t.Errorf("Header   #%2d [%x...] missing before cap %d", inserted[i-1].Number(), inserted[i-1].Hash().Bytes()[:3], head)
+			}
+			if block := chain.GetBlock(inserted[i-1].Hash(), uint64(i)); block == nil {
+				t.Errorf("Block    #%2d [%x...] missing before cap %d", inserted[i-1].Number(), inserted[i-1].Hash().Bytes()[:3], head)
+			}
+			if receipts := chain.GetReceiptsByHash(inserted[i-1].Hash()); receipts == nil {
+				t.Errorf("Receipts #%2d [%x...] missing before cap %d", inserted[i-1].Number(), inserted[i-1].Hash().Bytes()[:3], head)
+			}
+		} else {
+			if header := chain.GetHeader(inserted[i-1].Hash(), uint64(i)); header != nil {
+				t.Errorf("Header   #%2d [%x...] present after cap %d", inserted[i-1].Number(), inserted[i-1].Hash().Bytes()[:3], head)
+			}
+			if block := chain.GetBlock(inserted[i-1].Hash(), uint64(i)); block != nil {
+				t.Errorf("Block    #%2d [%x...] present after cap %d", inserted[i-1].Number(), inserted[i-1].Hash().Bytes()[:3], head)
+			}
+			if receipts := chain.GetReceiptsByHash(inserted[i-1].Hash()); receipts != nil {
+				t.Errorf("Receipts #%2d [%x...] present after cap %d", inserted[i-1].Number(), inserted[i-1].Hash().Bytes()[:3], head)
+			}
+		}
+	}
+}

--- a/core/blockchain_sethead_test.go
+++ b/core/blockchain_sethead_test.go
@@ -20,9 +20,11 @@
 package core
 
 import (
+	"fmt"
 	"io/ioutil"
 	"math/big"
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -33,102 +35,317 @@ import (
 	"github.com/ethereum/go-ethereum/params"
 )
 
-// setHeadTest is a test case for chain rollback upon user request.
-type setHeadTest struct {
-	canonicalBlocks int    // Number of blocks to generate for the canonical chain (heavier)
-	sidechainBlocks int    // Number of blocks to generate for the side chain (lighter)
-	freezeThreshold uint64 // Block number until which to move things into the freezer
-	commitBlock     uint64 // Block number for which to commit the state to disk
-	pivotBlock      uint64 // Pivot block number in case of fast sync
+// rewindTest is a test case for chain rollback upon user request.
+type rewindTest struct {
+	canonicalBlocks int     // Number of blocks to generate for the canonical chain (heavier)
+	sidechainBlocks int     // Number of blocks to generate for the side chain (lighter)
+	freezeThreshold uint64  // Block number until which to move things into the freezer
+	commitBlock     uint64  // Block number for which to commit the state to disk
+	pivotBlock      *uint64 // Pivot block number in case of fast sync
 
 	setheadBlock       uint64 // Block number to set head back to
-	expCanonicalBlocks int    // Number of canonical blocks expected to remain in the database
-	expSidechainBlocks int    // Number of sidechain blocks expected to remain in the database
+	expCanonicalBlocks int    // Number of canonical blocks expected to remain in the database (excl. genesis)
+	expSidechainBlocks int    // Number of sidechain blocks expected to remain in the database (excl. genesis)
+	expFrozen          int    // Number of canonical blocks expected to be in the freezer (incl. genesis)
+	expHeadHeader      uint64 // Block number of the expected head header
+	expHeadFastBlock   uint64 // Block number of the expected head fast sync block
+	expHeadBlock       uint64 // Block number of the expected head full block
+}
+
+func (tt *rewindTest) dump(crash bool) string {
+	buffer := new(strings.Builder)
+
+	fmt.Fprint(buffer, "Chain:\n  G")
+	for i := 0; i < tt.canonicalBlocks; i++ {
+		fmt.Fprintf(buffer, "->C%d", i+1)
+	}
+	fmt.Fprint(buffer, " (HEAD)\n")
+	if tt.sidechainBlocks > 0 {
+		fmt.Fprintf(buffer, "  └")
+		for i := 0; i < tt.sidechainBlocks; i++ {
+			fmt.Fprintf(buffer, "->S%d", i+1)
+		}
+		fmt.Fprintf(buffer, "\n")
+	}
+	fmt.Fprintf(buffer, "\n")
+
+	if tt.canonicalBlocks > int(tt.freezeThreshold) {
+		fmt.Fprint(buffer, "Frozen:\n  G")
+		for i := 0; i < tt.canonicalBlocks-int(tt.freezeThreshold); i++ {
+			fmt.Fprintf(buffer, "->C%d", i+1)
+		}
+		fmt.Fprintf(buffer, "\n\n")
+	} else {
+		fmt.Fprintf(buffer, "Frozen: none\n")
+	}
+	fmt.Fprintf(buffer, "Commit: G")
+	if tt.commitBlock > 0 {
+		fmt.Fprintf(buffer, ", C%d", tt.commitBlock)
+	}
+	fmt.Fprint(buffer, "\n")
+
+	if tt.pivotBlock == nil {
+		fmt.Fprintf(buffer, "Pivot : none\n")
+	} else {
+		fmt.Fprintf(buffer, "Pivot : C%d\n", *tt.pivotBlock)
+	}
+	if crash {
+		fmt.Fprintf(buffer, "\nCRASH\n\n")
+	} else {
+		fmt.Fprintf(buffer, "\nSetHead(%d)\n\n", tt.setheadBlock)
+	}
+	fmt.Fprintf(buffer, "------------------------------\n\n")
+
+	if tt.expFrozen > 0 {
+		fmt.Fprint(buffer, "Expected in freezer:\n  G")
+		for i := 0; i < tt.expFrozen-1; i++ {
+			fmt.Fprintf(buffer, "->C%d", i+1)
+		}
+		fmt.Fprintf(buffer, "\n\n")
+	}
+	if tt.expFrozen > 0 {
+		if tt.expFrozen >= tt.expCanonicalBlocks {
+			fmt.Fprintf(buffer, "Expected in leveldb: none\n")
+		} else {
+			fmt.Fprintf(buffer, "Expected in leveldb:\n  C%d)", tt.expFrozen-1)
+			for i := tt.expFrozen - 1; i < tt.expCanonicalBlocks; i++ {
+				fmt.Fprintf(buffer, "->C%d", i+1)
+			}
+			fmt.Fprint(buffer, "\n")
+			if tt.expSidechainBlocks > tt.expFrozen {
+				fmt.Fprintf(buffer, "  └")
+				for i := tt.expFrozen - 1; i < tt.expSidechainBlocks; i++ {
+					fmt.Fprintf(buffer, "->S%d", i+1)
+				}
+				fmt.Fprintf(buffer, "\n")
+			}
+		}
+	} else {
+		fmt.Fprint(buffer, "Expected in leveldb:\n  G")
+		for i := tt.expFrozen; i < tt.expCanonicalBlocks; i++ {
+			fmt.Fprintf(buffer, "->C%d", i+1)
+		}
+		fmt.Fprint(buffer, "\n")
+		if tt.expSidechainBlocks > tt.expFrozen {
+			fmt.Fprintf(buffer, "  └")
+			for i := tt.expFrozen; i < tt.expSidechainBlocks; i++ {
+				fmt.Fprintf(buffer, "->S%d", i+1)
+			}
+			fmt.Fprintf(buffer, "\n")
+		}
+	}
+	fmt.Fprintf(buffer, "\n")
+	fmt.Fprintf(buffer, "Expected head header    : C%d\n", tt.expHeadHeader)
+	fmt.Fprintf(buffer, "Expected head fast block: C%d\n", tt.expHeadFastBlock)
+	if tt.expHeadBlock == 0 {
+		fmt.Fprintf(buffer, "Expected head block     : G\n")
+	} else {
+		fmt.Fprintf(buffer, "Expected head block     : C%d\n", tt.expHeadBlock)
+	}
+	return buffer.String()
 }
 
 // Tests a sethead for a short canonical chain where a recent block was already
-// comitted to disk and then the sethead called. In this case we expect the chain
-// to be rolled back to the committed block, with everything afterwads deleted.
+// comitted to disk and then the sethead called. In this case we expect the full
+// chain to be rolled back to the committed block. Everything above the sethead
+// point should be deleted. In between the committed block and the requested head
+// the data can remain as "fast sync" data to avoid redownloading it.
 func TestShortSetHead(t *testing.T) {
-	testSetHead(t, &setHeadTest{
+	// Chain:
+	//   G->C1->C2->C3->C4->C5->C6->C7->C8 (HEAD)
+	//
+	// Frozen: none
+	// Commit: G, C4
+	// Pivot : none
+	//
+	// SetHead(7)
+	//
+	// ------------------------------
+	//
+	// Expected in leveldb:
+	//   G->C1->C2->C3->C4->C5->C6->C7
+	//
+	// Expected head header    : C7
+	// Expected head fast block: C7
+	// Expected head block     : C4
+	testSetHead(t, &rewindTest{
 		canonicalBlocks:    8,
 		sidechainBlocks:    0,
 		freezeThreshold:    16,
 		commitBlock:        4,
-		pivotBlock:         0,
+		pivotBlock:         nil,
 		setheadBlock:       7,
-		expCanonicalBlocks: 4,
+		expCanonicalBlocks: 7,
 		expSidechainBlocks: 0,
+		expFrozen:          0,
+		expHeadHeader:      7,
+		expHeadFastBlock:   7,
+		expHeadBlock:       4,
 	})
 }
 
 // Tests a sethead for a short canonical chain where the fast sync pivot point was
 // already comitted, after which sethead was called. In this case we expect the
-// chain to behave like in full sync mode, rolling back to the committed block,
-// with everything afterwads deleted.
+// chain to behave like in full sync mode, rolling back to the committed block
+// Everything above the sethead point should be deleted. In between the committed
+// block and the requested head the data can remain as "fast sync" data to avoid
+// redownloading it.
 func TestShortFastSyncedSetHead(t *testing.T) {
-	testSetHead(t, &setHeadTest{
+	// Chain:
+	//   G->C1->C2->C3->C4->C5->C6->C7->C8 (HEAD)
+	//
+	// Frozen: none
+	// Commit: G, C4
+	// Pivot : C4
+	//
+	// SetHead(7)
+	//
+	// ------------------------------
+	//
+	// Expected in leveldb:
+	//   G->C1->C2->C3->C4->C5->C6->C7
+	//
+	// Expected head header    : C7
+	// Expected head fast block: C7
+	// Expected head block     : C4
+	testSetHead(t, &rewindTest{
 		canonicalBlocks:    8,
 		sidechainBlocks:    0,
 		freezeThreshold:    16,
 		commitBlock:        4,
-		pivotBlock:         4,
+		pivotBlock:         uint64ptr(4),
 		setheadBlock:       7,
-		expCanonicalBlocks: 4,
+		expCanonicalBlocks: 7,
 		expSidechainBlocks: 0,
+		expFrozen:          0,
+		expHeadHeader:      7,
+		expHeadFastBlock:   7,
+		expHeadBlock:       4,
 	})
 }
 
 // Tests a sethead for a short canonical chain where the fast sync pivot point was
 // not yet comitted, but sethead was called. In this case we expect the chain to
 // detect that it was fast syncing and delete everything from the new head, since
-// we can just pick up fast syncing from there.
+// we can just pick up fast syncing from there. The head full block should be set
+// to the genesis.
 func TestShortFastSyncingSetHead(t *testing.T) {
-	testSetHead(t, &setHeadTest{
+	// Chain:
+	//   G->C1->C2->C3->C4->C5->C6->C7->C8 (HEAD)
+	//
+	// Frozen: none
+	// Commit: G
+	// Pivot : C4
+	//
+	// SetHead(7)
+	//
+	// ------------------------------
+	//
+	// Expected in leveldb:
+	//   G->C1->C2->C3->C4->C5->C6->C7
+	//
+	// Expected head header    : C7
+	// Expected head fast block: C7
+	// Expected head block     : G
+	testSetHead(t, &rewindTest{
 		canonicalBlocks:    8,
 		sidechainBlocks:    0,
 		freezeThreshold:    16,
 		commitBlock:        0,
-		pivotBlock:         4,
+		pivotBlock:         uint64ptr(4),
 		setheadBlock:       7,
 		expCanonicalBlocks: 7,
 		expSidechainBlocks: 0,
+		expFrozen:          0,
+		expHeadHeader:      7,
+		expHeadFastBlock:   7,
+		expHeadBlock:       0,
 	})
 }
 
 // Tests a sethead for a short canonical chain and a shorter side chain, where a
 // recent block was already comitted to disk and then sethead was called. In this
 // test scenario the side chain is below the commited block. In this case we expect
-// the canonical chain to be rolled back to the committed block, with everything
-// afterwads deleted; but the side chain left alone as it was shorter.
+// the canonical full chain to be rolled back to the committed block. Everything
+// above the sethead point should be deleted. In between the committed block and
+// the requested head the data can remain as "fast sync" data to avoid redownloading
+// it. The side chain should be left alone as it was shorter.
 func TestShortOldForkedSetHead(t *testing.T) {
-	testSetHead(t, &setHeadTest{
+	// Chain:
+	//   G->C1->C2->C3->C4->C5->C6->C7->C8 (HEAD)
+	//   └->S1->S2->S3
+	//
+	// Frozen: none
+	// Commit: G, C4
+	// Pivot : none
+	//
+	// SetHead(7)
+	//
+	// ------------------------------
+	//
+	// Expected in leveldb:
+	//   G->C1->C2->C3->C4->C5->C6->C7
+	//   └->S1->S2->S3
+	//
+	// Expected head header    : C7
+	// Expected head fast block: C7
+	// Expected head block     : C4
+	testSetHead(t, &rewindTest{
 		canonicalBlocks:    8,
 		sidechainBlocks:    3,
 		freezeThreshold:    16,
 		commitBlock:        4,
-		pivotBlock:         0,
+		pivotBlock:         nil,
 		setheadBlock:       7,
-		expCanonicalBlocks: 4,
+		expCanonicalBlocks: 7,
 		expSidechainBlocks: 3,
+		expFrozen:          0,
+		expHeadHeader:      7,
+		expHeadFastBlock:   7,
+		expHeadBlock:       4,
 	})
 }
 
 // Tests a sethead for a short canonical chain and a shorter side chain, where
 // the fast sync pivot point was already comitted to disk and then sethead was
 // called. In this test scenario the side chain is below the commited block. In
-// this case we expect the canonical chain to be rolled back to the committed block,
-// with everything afterwads deleted; but the side chain left alone as it was shorter.
+// this case we expect the canonical full chain to be rolled back to the committed
+// block. Everything above the sethead point should be deleted. In between the
+// committed block and the requested head the data can remain as "fast sync" data
+// to avoid redownloading it. The side chain should be left alone as it was shorter.
 func TestShortOldForkedFastSyncedSetHead(t *testing.T) {
-	testSetHead(t, &setHeadTest{
+	// Chain:
+	//   G->C1->C2->C3->C4->C5->C6->C7->C8 (HEAD)
+	//   └->S1->S2->S3
+	//
+	// Frozen: none
+	// Commit: G, C4
+	// Pivot : C4
+	//
+	// SetHead(7)
+	//
+	// ------------------------------
+	//
+	// Expected in leveldb:
+	//   G->C1->C2->C3->C4->C5->C6->C7
+	//   └->S1->S2->S3
+	//
+	// Expected head header    : C7
+	// Expected head fast block: C7
+	// Expected head block     : C4
+	testSetHead(t, &rewindTest{
 		canonicalBlocks:    8,
 		sidechainBlocks:    3,
 		freezeThreshold:    16,
 		commitBlock:        4,
-		pivotBlock:         4,
+		pivotBlock:         uint64ptr(4),
 		setheadBlock:       7,
-		expCanonicalBlocks: 4,
+		expCanonicalBlocks: 7,
 		expSidechainBlocks: 3,
+		expFrozen:          0,
+		expHeadHeader:      7,
+		expHeadFastBlock:   7,
+		expHeadBlock:       4,
 	})
 }
 
@@ -136,61 +353,134 @@ func TestShortOldForkedFastSyncedSetHead(t *testing.T) {
 // the fast sync pivot point was not yet comitted, but sethead was called. In this
 // test scenario the side chain is below the commited block. In this case we expect
 // the chain to detect that it was fast syncing and delete everything from the new
-// head, since we can just pick up fast syncing from there.
+// head, since we can just pick up fast syncing from there. The head full block
+// should be set to the genesis.
 func TestShortOldForkedFastSyncingSetHead(t *testing.T) {
-	testSetHead(t, &setHeadTest{
+	// Chain:
+	//   G->C1->C2->C3->C4->C5->C6->C7->C8 (HEAD)
+	//   └->S1->S2->S3
+	//
+	// Frozen: none
+	// Commit: G
+	// Pivot : C4
+	//
+	// SetHead(7)
+	//
+	// ------------------------------
+	//
+	// Expected in leveldb:
+	//   G->C1->C2->C3->C4->C5->C6->C7
+	//   └->S1->S2->S3
+	//
+	// Expected head header    : C7
+	// Expected head fast block: C7
+	// Expected head block     : G
+	testSetHead(t, &rewindTest{
 		canonicalBlocks:    8,
 		sidechainBlocks:    3,
 		freezeThreshold:    16,
 		commitBlock:        0,
-		pivotBlock:         4,
+		pivotBlock:         uint64ptr(4),
 		setheadBlock:       7,
 		expCanonicalBlocks: 7,
 		expSidechainBlocks: 3,
+		expFrozen:          0,
+		expHeadHeader:      7,
+		expHeadFastBlock:   7,
+		expHeadBlock:       0,
 	})
 }
 
 // Tests a sethead for a short canonical chain and a shorter side chain, where a
 // recent block was already comitted to disk and then sethead was called. In this
 // test scenario the side chain reaches above the commited block. In this case we
-// expect both canonical and side chains to be rolled back to the committed block,
-// with everything afterwads deleted.
+// expect the canonical full chain to be rolled back to the committed block. All
+// data above the sethead point should be deleted. In between the committed block
+// and the requested head the data can remain as "fast sync" data to avoid having
+// to redownload it. The side chain should be truncated to the head set.
 //
 // The side chain could be left to be if the fork point was before the new head
 // we are deleting to, but it would be exceedingly hard to detect that case and
 // properly handle it, so we'll trade extra work in exchange for simpler code.
 func TestShortNewlyForkedSetHead(t *testing.T) {
-	testSetHead(t, &setHeadTest{
-		canonicalBlocks:    8,
-		sidechainBlocks:    6,
+	// Chain:
+	//   G->C1->C2->C3->C4->C5->C6->C7->C8->C9->C10 (HEAD)
+	//   └->S1->S2->S3->S4->S5->S6->S7->S8
+	//
+	// Frozen: none
+	// Commit: G, C4
+	// Pivot : none
+	//
+	// SetHead(7)
+	//
+	// ------------------------------
+	//
+	// Expected in leveldb:
+	//   G->C1->C2->C3->C4->C5->C6->C7
+	//   └->S1->S2->S3->S4->S5->S6->S7
+	//
+	// Expected head header    : C7
+	// Expected head fast block: C7
+	// Expected head block     : C4
+	testSetHead(t, &rewindTest{
+		canonicalBlocks:    10,
+		sidechainBlocks:    8,
 		freezeThreshold:    16,
 		commitBlock:        4,
-		pivotBlock:         0,
+		pivotBlock:         nil,
 		setheadBlock:       7,
-		expCanonicalBlocks: 4,
-		expSidechainBlocks: 4,
+		expCanonicalBlocks: 7,
+		expSidechainBlocks: 7,
+		expFrozen:          0,
+		expHeadHeader:      7,
+		expHeadFastBlock:   7,
+		expHeadBlock:       4,
 	})
 }
 
 // Tests a sethead for a short canonical chain and a shorter side chain, where
 // the fast sync pivot point was already comitted to disk and then sethead was
-// called. In this test scenario the side chain reaches above the commited block.
-// In this case we expect both canonical and side chains to be rolled back to the
-// committed block, with everything afterwads deleted.
+// called. In this case we expect the canonical full chain to be rolled back to
+// between the committed block and the requested head the data can remain as
+// "fast sync" data to avoid having to redownload it. The side chain should be
+// truncated to the head set.
 //
 // The side chain could be left to be if the fork point was before the new head
 // we are deleting to, but it would be exceedingly hard to detect that case and
 // properly handle it, so we'll trade extra work in exchange for simpler code.
 func TestShortNewlyForkedFastSyncedSetHead(t *testing.T) {
-	testSetHead(t, &setHeadTest{
-		canonicalBlocks:    8,
-		sidechainBlocks:    6,
+	// Chain:
+	//   G->C1->C2->C3->C4->C5->C6->C7->C8->C9->C10 (HEAD)
+	//   └->S1->S2->S3->S4->S5->S6->S7->S8
+	//
+	// Frozen: none
+	// Commit: G, C4
+	// Pivot : C4
+	//
+	// SetHead(7)
+	//
+	// ------------------------------
+	//
+	// Expected in leveldb:
+	//   G->C1->C2->C3->C4->C5->C6->C7
+	//   └->S1->S2->S3->S4->S5->S6->S7
+	//
+	// Expected head header    : C7
+	// Expected head fast block: C7
+	// Expected head block     : C4
+	testSetHead(t, &rewindTest{
+		canonicalBlocks:    10,
+		sidechainBlocks:    8,
 		freezeThreshold:    16,
 		commitBlock:        4,
-		pivotBlock:         4,
+		pivotBlock:         uint64ptr(4),
 		setheadBlock:       7,
-		expCanonicalBlocks: 4,
-		expSidechainBlocks: 4,
+		expCanonicalBlocks: 7,
+		expSidechainBlocks: 7,
+		expFrozen:          0,
+		expHeadHeader:      7,
+		expHeadFastBlock:   7,
+		expHeadBlock:       4,
 	})
 }
 
@@ -205,57 +495,131 @@ func TestShortNewlyForkedFastSyncedSetHead(t *testing.T) {
 // we are deleting to, but it would be exceedingly hard to detect that case and
 // properly handle it, so we'll trade extra work in exchange for simpler code.
 func TestShortNewlyForkedFastSyncingSetHead(t *testing.T) {
-	testSetHead(t, &setHeadTest{
-		canonicalBlocks:    8,
-		sidechainBlocks:    6,
+	// Chain:
+	//   G->C1->C2->C3->C4->C5->C6->C7->C8->C9->C10 (HEAD)
+	//   └->S1->S2->S3->S4->S5->S6->S7->S8
+	//
+	// Frozen: none
+	// Commit: G
+	// Pivot : C4
+	//
+	// SetHead(7)
+	//
+	// ------------------------------
+	//
+	// Expected in leveldb:
+	//   G->C1->C2->C3->C4->C5->C6->C7
+	//   └->S1->S2->S3->S4->S5->S6->S7
+	//
+	// Expected head header    : C7
+	// Expected head fast block: C7
+	// Expected head block     : G
+	testSetHead(t, &rewindTest{
+		canonicalBlocks:    10,
+		sidechainBlocks:    8,
 		freezeThreshold:    16,
 		commitBlock:        0,
-		pivotBlock:         4,
-		setheadBlock:       5,
-		expCanonicalBlocks: 5,
-		expSidechainBlocks: 5,
+		pivotBlock:         uint64ptr(4),
+		setheadBlock:       7,
+		expCanonicalBlocks: 7,
+		expSidechainBlocks: 7,
+		expFrozen:          0,
+		expHeadHeader:      7,
+		expHeadFastBlock:   7,
+		expHeadBlock:       0,
 	})
 }
 
 // Tests a sethead for a short canonical chain and a longer side chain, where a
 // recent block was already comitted to disk and then sethead was called. In this
-// case we expect both canonical and side chains to be rolled back to the committed
-// block, with everything afterwads deleted.
+// case we expect the canonical full chain to be rolled back to the committed block.
+// All data above the sethead point should be deleted. In between the committed
+// block and the requested head the data can remain as "fast sync" data to avoid
+// having to redownload it. The side chain should be truncated to the head set.
 //
 // The side chain could be left to be if the fork point was before the new head
 // we are deleting to, but it would be exceedingly hard to detect that case and
 // properly handle it, so we'll trade extra work in exchange for simpler code.
 func TestShortReorgedSetHead(t *testing.T) {
-	testSetHead(t, &setHeadTest{
+	// Chain:
+	//   G->C1->C2->C3->C4->C5->C6->C7->C8 (HEAD)
+	//   └->S1->S2->S3->S4->S5->S6->S7->S8->S9->S10
+	//
+	// Frozen: none
+	// Commit: G, C4
+	// Pivot : none
+	//
+	// SetHead(7)
+	//
+	// ------------------------------
+	//
+	// Expected in leveldb:
+	//   G->C1->C2->C3->C4->C5->C6->C7
+	//   └->S1->S2->S3->S4->S5->S6->S7
+	//
+	// Expected head header    : C7
+	// Expected head fast block: C7
+	// Expected head block     : C4
+	testSetHead(t, &rewindTest{
 		canonicalBlocks:    8,
 		sidechainBlocks:    10,
 		freezeThreshold:    16,
 		commitBlock:        4,
-		pivotBlock:         0,
+		pivotBlock:         nil,
 		setheadBlock:       7,
-		expCanonicalBlocks: 4,
-		expSidechainBlocks: 4,
+		expCanonicalBlocks: 7,
+		expSidechainBlocks: 7,
+		expFrozen:          0,
+		expHeadHeader:      7,
+		expHeadFastBlock:   7,
+		expHeadBlock:       4,
 	})
 }
 
 // Tests a sethead for a short canonical chain and a longer side chain, where
 // the fast sync pivot point was already comitted to disk and then sethead was
-// called. In this case we expect both canonical and side chains to be rolled
-// back to the committed block, with everything afterwads deleted.
+// called. In this case we expect the canonical full chain to be rolled back to
+// the committed block. All data above the sethead point should be deleted. In
+// between the committed block and the requested head the data can remain as
+// "fast sync" data to avoid having to redownload it. The side chain should be
+// truncated to the head set.
 //
 // The side chain could be left to be if the fork point was before the new head
 // we are deleting to, but it would be exceedingly hard to detect that case and
 // properly handle it, so we'll trade extra work in exchange for simpler code.
 func TestShortReorgedFastSyncedSetHead(t *testing.T) {
-	testSetHead(t, &setHeadTest{
+	// Chain:
+	//   G->C1->C2->C3->C4->C5->C6->C7->C8 (HEAD)
+	//   └->S1->S2->S3->S4->S5->S6->S7->S8->S9->S10
+	//
+	// Frozen: none
+	// Commit: G, C4
+	// Pivot : C4
+	//
+	// SetHead(7)
+	//
+	// ------------------------------
+	//
+	// Expected in leveldb:
+	//   G->C1->C2->C3->C4->C5->C6->C7
+	//   └->S1->S2->S3->S4->S5->S6->S7
+	//
+	// Expected head header    : C7
+	// Expected head fast block: C7
+	// Expected head block     : C4
+	testSetHead(t, &rewindTest{
 		canonicalBlocks:    8,
 		sidechainBlocks:    10,
 		freezeThreshold:    16,
 		commitBlock:        4,
-		pivotBlock:         4,
+		pivotBlock:         uint64ptr(4),
 		setheadBlock:       7,
-		expCanonicalBlocks: 4,
-		expSidechainBlocks: 4,
+		expCanonicalBlocks: 7,
+		expSidechainBlocks: 7,
+		expFrozen:          0,
+		expHeadHeader:      7,
+		expHeadFastBlock:   7,
+		expHeadBlock:       4,
 	})
 }
 
@@ -269,50 +633,258 @@ func TestShortReorgedFastSyncedSetHead(t *testing.T) {
 // we are deleting to, but it would be exceedingly hard to detect that case and
 // properly handle it, so we'll trade extra work in exchange for simpler code.
 func TestShortReorgedFastSyncingSetHead(t *testing.T) {
-	testSetHead(t, &setHeadTest{
+	// Chain:
+	//   G->C1->C2->C3->C4->C5->C6->C7->C8 (HEAD)
+	//   └->S1->S2->S3->S4->S5->S6->S7->S8->S9->S10
+	//
+	// Frozen: none
+	// Commit: G
+	// Pivot : C4
+	//
+	// SetHead(7)
+	//
+	// ------------------------------
+	//
+	// Expected in leveldb:
+	//   G->C1->C2->C3->C4->C5->C6->C7
+	//   └->S1->S2->S3->S4->S5->S6->S7
+	//
+	// Expected head header    : C7
+	// Expected head fast block: C7
+	// Expected head block     : G
+	testSetHead(t, &rewindTest{
 		canonicalBlocks:    8,
 		sidechainBlocks:    10,
 		freezeThreshold:    16,
 		commitBlock:        0,
-		pivotBlock:         4,
+		pivotBlock:         uint64ptr(4),
 		setheadBlock:       7,
 		expCanonicalBlocks: 7,
 		expSidechainBlocks: 7,
+		expFrozen:          0,
+		expHeadHeader:      7,
+		expHeadFastBlock:   7,
+		expHeadBlock:       0,
+	})
+}
+
+// Tests a sethead for a long canonical chain with frozen blocks where a recent
+// block - newer than the ancient limit - was already comitted to disk and then
+// sethead was called. In this case we expect the full chain to be rolled back
+// to the committed block. Everything above the sethead point should be deleted.
+// In between the committed block and the requested head the data can remain as
+// "fast sync" data to avoid redownloading it.
+func TestLongShallowSetHead(t *testing.T) {
+	// Chain:
+	//   G->C1->C2->C3->C4->C5->C6->C7->C8->C9->C10->C11->C12->C13->C14->C15->C16->C17->C18 (HEAD)
+	//
+	// Frozen:
+	//   G->C1->C2
+	//
+	// Commit: G, C4
+	// Pivot : none
+	//
+	// SetHead(6)
+	//
+	// ------------------------------
+	//
+	// Expected in freezer:
+	//   G->C1->C2
+	//
+	// Expected in leveldb:
+	//   C2)->C3->C4->C5->C6
+	//
+	// Expected head header    : C6
+	// Expected head fast block: C6
+	// Expected head block     : C4
+	testSetHead(t, &rewindTest{
+		canonicalBlocks:    18,
+		sidechainBlocks:    0,
+		freezeThreshold:    16,
+		commitBlock:        4,
+		pivotBlock:         nil,
+		setheadBlock:       6,
+		expCanonicalBlocks: 6,
+		expSidechainBlocks: 0,
+		expFrozen:          3,
+		expHeadHeader:      6,
+		expHeadFastBlock:   6,
+		expHeadBlock:       4,
 	})
 }
 
 // Tests a sethead for a long canonical chain with frozen blocks where a recent
 // block - older than the ancient limit - was already comitted to disk and then
-// sethead was called. In this case we expect the chain to be rolled back to the
-// committed block, with everything afterwads deleted.
-func TestLongSetHead(t *testing.T) {
-	testSetHead(t, &setHeadTest{
+// sethead was called. In this case we expect the full chain to be rolled back
+// to the committed block. Since the ancient limit was underflown, everything
+// needs to be deleted onwards to avoid creating a gap.
+func TestLongDeepSetHead(t *testing.T) {
+	// Chain:
+	//   G->C1->C2->C3->C4->C5->C6->C7->C8->C9->C10->C11->C12->C13->C14->C15->C16->C17->C18->C19->C20->C21->C22->C23->C24 (HEAD)
+	//
+	// Frozen:
+	//   G->C1->C2->C3->C4->C5->C6->C7->C8
+	//
+	// Commit: G, C4
+	// Pivot : none
+	//
+	// SetHead(6)
+	//
+	// ------------------------------
+	//
+	// Expected in freezer:
+	//   G->C1->C2->C3->C4
+	//
+	// Expected in leveldb: none
+	//
+	// Expected head header    : C4
+	// Expected head fast block: C4
+	// Expected head block     : C4
+	testSetHead(t, &rewindTest{
 		canonicalBlocks:    24,
 		sidechainBlocks:    0,
 		freezeThreshold:    16,
 		commitBlock:        4,
-		pivotBlock:         0,
+		pivotBlock:         nil,
 		setheadBlock:       6,
 		expCanonicalBlocks: 4,
 		expSidechainBlocks: 0,
+		expFrozen:          5,
+		expHeadHeader:      4,
+		expHeadFastBlock:   4,
+		expHeadBlock:       4,
+	})
+}
+
+// Tests a sethead for a long canonical chain with frozen blocks where the fast
+// sync pivot point - newer than the ancient limit - was already comitted, after
+// which sethead was called. In this case we expect the full chain to be rolled
+// back to the committed block. Everything above the sethead point should be
+// deleted. In between the committed block and the requested head the data can
+// remain as "fast sync" data to avoid redownloading it.
+func TestLongFastSyncedShallowSetHead(t *testing.T) {
+	// Chain:
+	//   G->C1->C2->C3->C4->C5->C6->C7->C8->C9->C10->C11->C12->C13->C14->C15->C16->C17->C18 (HEAD)
+	//
+	// Frozen:
+	//   G->C1->C2
+	//
+	// Commit: G, C4
+	// Pivot : C4
+	//
+	// SetHead(6)
+	//
+	// ------------------------------
+	//
+	// Expected in freezer:
+	//   G->C1->C2
+	//
+	// Expected in leveldb:
+	//   C2)->C3->C4->C5->C6
+	//
+	// Expected head header    : C6
+	// Expected head fast block: C6
+	// Expected head block     : C4
+	testSetHead(t, &rewindTest{
+		canonicalBlocks:    18,
+		sidechainBlocks:    0,
+		freezeThreshold:    16,
+		commitBlock:        4,
+		pivotBlock:         uint64ptr(4),
+		setheadBlock:       6,
+		expCanonicalBlocks: 6,
+		expSidechainBlocks: 0,
+		expFrozen:          3,
+		expHeadHeader:      6,
+		expHeadFastBlock:   6,
+		expHeadBlock:       4,
 	})
 }
 
 // Tests a sethead for a long canonical chain with frozen blocks where the fast
 // sync pivot point - older than the ancient limit - was already comitted, after
-// which sethead was called. In this case we expect the chain to behave like in
-// full sync mode, rolling back to the committed block, with everything afterwads
-// deleted.
-func TestLongFastSyncedSetHead(t *testing.T) {
-	testSetHead(t, &setHeadTest{
+// which sethead was called. In this case we expect the full chain to be rolled
+// back to the committed block. Since the ancient limit was underflown, everything
+// needs to be deleted onwards to avoid creating a gap.
+func TestLongFastSyncedDeepSetHead(t *testing.T) {
+	// Chain:
+	//   G->C1->C2->C3->C4->C5->C6->C7->C8->C9->C10->C11->C12->C13->C14->C15->C16->C17->C18->C19->C20->C21->C22->C23->C24 (HEAD)
+	//
+	// Frozen:
+	//   G->C1->C2->C3->C4->C5->C6->C7->C8
+	//
+	// Commit: G, C4
+	// Pivot : C4
+	//
+	// SetHead(6)
+	//
+	// ------------------------------
+	//
+	// Expected in freezer:
+	//   G->C1->C2->C3->C4
+	//
+	// Expected in leveldb: none
+	//
+	// Expected head header    : C4
+	// Expected head fast block: C4
+	// Expected head block     : C4
+	testSetHead(t, &rewindTest{
 		canonicalBlocks:    24,
 		sidechainBlocks:    0,
 		freezeThreshold:    16,
 		commitBlock:        4,
-		pivotBlock:         4,
+		pivotBlock:         uint64ptr(4),
 		setheadBlock:       6,
 		expCanonicalBlocks: 4,
 		expSidechainBlocks: 0,
+		expFrozen:          5,
+		expHeadHeader:      4,
+		expHeadFastBlock:   4,
+		expHeadBlock:       4,
+	})
+}
+
+// Tests a sethead for a long canonical chain with frozen blocks where the fast
+// sync pivot point - newer than the ancient limit - was not yet comitted, but
+// sethead was called. In this case we expect the chain to detect that it was fast
+// syncing and delete everything from the new head, since we can just pick up fast
+// syncing from there.
+func TestLongFastSyncingShallowSetHead(t *testing.T) {
+	// Chain:
+	//   G->C1->C2->C3->C4->C5->C6->C7->C8->C9->C10->C11->C12->C13->C14->C15->C16->C17->C18 (HEAD)
+	//
+	// Frozen:
+	//   G->C1->C2
+	//
+	// Commit: G
+	// Pivot : C4
+	//
+	// SetHead(6)
+	//
+	// ------------------------------
+	//
+	// Expected in freezer:
+	//   G->C1->C2
+	//
+	// Expected in leveldb:
+	//   C2)->C3->C4->C5->C6
+	//
+	// Expected head header    : C6
+	// Expected head fast block: C6
+	// Expected head block     : G
+	testSetHead(t, &rewindTest{
+		canonicalBlocks:    18,
+		sidechainBlocks:    0,
+		freezeThreshold:    16,
+		commitBlock:        0,
+		pivotBlock:         uint64ptr(4),
+		setheadBlock:       6,
+		expCanonicalBlocks: 6,
+		expSidechainBlocks: 0,
+		expFrozen:          3,
+		expHeadHeader:      6,
+		expHeadFastBlock:   6,
+		expHeadBlock:       0,
 	})
 }
 
@@ -321,35 +893,181 @@ func TestLongFastSyncedSetHead(t *testing.T) {
 // sethead was called. In this case we expect the chain to detect that it was fast
 // syncing and delete everything from the new head, since we can just pick up fast
 // syncing from there.
-func TestLongFastSyncingSetHead(t *testing.T) {
-	testSetHead(t, &setHeadTest{
+func TestLongFastSyncingDeepSetHead(t *testing.T) {
+	// Chain:
+	//   G->C1->C2->C3->C4->C5->C6->C7->C8->C9->C10->C11->C12->C13->C14->C15->C16->C17->C18->C19->C20->C21->C22->C23->C24 (HEAD)
+	//
+	// Frozen:
+	//   G->C1->C2->C3->C4->C5->C6->C7->C8
+	//
+	// Commit: G
+	// Pivot : C4
+	//
+	// SetHead(6)
+	//
+	// ------------------------------
+	//
+	// Expected in freezer:
+	//   G->C1->C2->C3->C4->C5->C6
+	//
+	// Expected in leveldb: none
+	//
+	// Expected head header    : C6
+	// Expected head fast block: C6
+	// Expected head block     : G
+	testSetHead(t, &rewindTest{
 		canonicalBlocks:    24,
 		sidechainBlocks:    0,
 		freezeThreshold:    16,
 		commitBlock:        0,
-		pivotBlock:         4,
+		pivotBlock:         uint64ptr(4),
 		setheadBlock:       6,
 		expCanonicalBlocks: 6,
 		expSidechainBlocks: 0,
+		expFrozen:          7,
+		expHeadHeader:      6,
+		expHeadFastBlock:   6,
+		expHeadBlock:       0,
 	})
 }
 
-// Tests a sethead for a long canonical chain with frozen blocks and a shorter
-// side chain, where a recent block - older than the ancient limit - was already
-// comitted to disk and then sethead was called. In this test scenario the side
-// chain is below the commited block. In this case we expect the canonical chain
-// to be rolled back to the committed block, with everything afterwads deleted;
-// the side chain completely nuked by the freezer.
-func TestLongOldForkedSetHead(t *testing.T) {
-	testSetHead(t, &setHeadTest{
+// Tests a sethead for a long canonical chain with frozen blocks and a shorter side
+// chain, where a recent block - newer than the ancient limit - was already comitted
+// to disk and then sethead was called. In this case we expect the canonical full
+// chain to be rolled back to the committed block. Everything above the sethead point
+// should be deleted. In between the committed block and the requested head the data
+// can remain as "fast sync" data to avoid redownloading it. The side chain is nuked
+// by the freezer.
+func TestLongOldForkedShallowSetHead(t *testing.T) {
+	// Chain:
+	//   G->C1->C2->C3->C4->C5->C6->C7->C8->C9->C10->C11->C12->C13->C14->C15->C16->C17->C18 (HEAD)
+	//   └->S1->S2->S3
+	//
+	// Frozen:
+	//   G->C1->C2
+	//
+	// Commit: G, C4
+	// Pivot : none
+	//
+	// SetHead(6)
+	//
+	// ------------------------------
+	//
+	// Expected in freezer:
+	//   G->C1->C2
+	//
+	// Expected in leveldb:
+	//   C2)->C3->C4->C5->C6
+	//
+	// Expected head header    : C6
+	// Expected head fast block: C6
+	// Expected head block     : C4
+	testSetHead(t, &rewindTest{
+		canonicalBlocks:    18,
+		sidechainBlocks:    3,
+		freezeThreshold:    16,
+		commitBlock:        4,
+		pivotBlock:         nil,
+		setheadBlock:       6,
+		expCanonicalBlocks: 6,
+		expSidechainBlocks: 0,
+		expFrozen:          3,
+		expHeadHeader:      6,
+		expHeadFastBlock:   6,
+		expHeadBlock:       4,
+	})
+}
+
+// Tests a sethead for a long canonical chain with frozen blocks and a shorter side
+// chain, where a recent block - older than the ancient limit - was already comitted
+// to disk and then sethead was called. In this case we expect the canonical full
+// chain to be rolled back to the committed block. Since the ancient limit was
+// underflown, everything needs to be deleted onwards to avoid creating a gap. The
+// side chain is nuked by the freezer.
+func TestLongOldForkedDeepSetHead(t *testing.T) {
+	// Chain:
+	//   G->C1->C2->C3->C4->C5->C6->C7->C8->C9->C10->C11->C12->C13->C14->C15->C16->C17->C18->C19->C20->C21->C22->C23->C24 (HEAD)
+	//   └->S1->S2->S3
+	//
+	// Frozen:
+	//   G->C1->C2->C3->C4->C5->C6->C7->C8
+	//
+	// Commit: G, C4
+	// Pivot : none
+	//
+	// SetHead(6)
+	//
+	// ------------------------------
+	//
+	// Expected in freezer:
+	//   G->C1->C2->C3->C4
+	//
+	// Expected in leveldb: none
+	//
+	// Expected head header    : C4
+	// Expected head fast block: C4
+	// Expected head block     : C4
+	testSetHead(t, &rewindTest{
 		canonicalBlocks:    24,
 		sidechainBlocks:    3,
 		freezeThreshold:    16,
 		commitBlock:        4,
-		pivotBlock:         0,
+		pivotBlock:         nil,
 		setheadBlock:       6,
 		expCanonicalBlocks: 4,
 		expSidechainBlocks: 0,
+		expFrozen:          5,
+		expHeadHeader:      4,
+		expHeadFastBlock:   4,
+		expHeadBlock:       4,
+	})
+}
+
+// Tests a sethead for a long canonical chain with frozen blocks and a shorter
+// side chain, where the fast sync pivot point - newer than the ancient limit -
+// was already comitted to disk and then sethead was called. In this test scenario
+// the side chain is below the commited block. In this case we expect the canonical
+// full chain to be rolled back to the committed block. Everything above the
+// sethead point should be deleted. In between the committed block and the
+// requested head the data can remain as "fast sync" data to avoid redownloading
+// it. The side chain is nuked by the freezer.
+func TestLongOldForkedFastSyncedShallowSetHead(t *testing.T) {
+	// Chain:
+	//   G->C1->C2->C3->C4->C5->C6->C7->C8->C9->C10->C11->C12->C13->C14->C15->C16->C17->C18 (HEAD)
+	//   └->S1->S2->S3
+	//
+	// Frozen:
+	//   G->C1->C2
+	//
+	// Commit: G, C4
+	// Pivot : C4
+	//
+	// SetHead(6)
+	//
+	// ------------------------------
+	//
+	// Expected in freezer:
+	//   G->C1->C2
+	//
+	// Expected in leveldb:
+	//   C2)->C3->C4->C5->C6
+	//
+	// Expected head header    : C6
+	// Expected head fast block: C6
+	// Expected head block     : C4
+	testSetHead(t, &rewindTest{
+		canonicalBlocks:    18,
+		sidechainBlocks:    3,
+		freezeThreshold:    16,
+		commitBlock:        4,
+		pivotBlock:         uint64ptr(4),
+		setheadBlock:       6,
+		expCanonicalBlocks: 6,
+		expSidechainBlocks: 0,
+		expFrozen:          3,
+		expHeadHeader:      6,
+		expHeadFastBlock:   6,
+		expHeadBlock:       4,
 	})
 }
 
@@ -357,18 +1075,92 @@ func TestLongOldForkedSetHead(t *testing.T) {
 // side chain, where the fast sync pivot point - older than the ancient limit -
 // was already comitted to disk and then sethead was called. In this test scenario
 // the side chain is below the commited block. In this case we expect the canonical
-// chain to be rolled back to the committed block, with everything afterwads deleted;
-// the side chain completely nuked by the freezer.
-func TestLongOldForkedFastSyncedSetHead(t *testing.T) {
-	testSetHead(t, &setHeadTest{
+// full chain to be rolled back to the committed block. Since the ancient limit was
+// underflown, everything needs to be deleted onwards to avoid creating a gap. The
+// side chain is nuked by the freezer.
+func TestLongOldForkedFastSyncedDeepSetHead(t *testing.T) {
+	// Chain:
+	//   G->C1->C2->C3->C4->C5->C6->C7->C8->C9->C10->C11->C12->C13->C14->C15->C16->C17->C18->C19->C20->C21->C22->C23->C24 (HEAD)
+	//   └->S1->S2->S3
+	//
+	// Frozen:
+	//   G->C1->C2->C3->C4->C5->C6->C7->C8
+	//
+	// Commit: G, C4
+	// Pivot : C4
+	//
+	// SetHead(6)
+	//
+	// ------------------------------
+	//
+	// Expected in freezer:
+	//   G->C1->C2->C3->C4->C5->C6
+	//
+	// Expected in leveldb: none
+	//
+	// Expected head header    : C6
+	// Expected head fast block: C6
+	// Expected head block     : C4
+	testSetHead(t, &rewindTest{
 		canonicalBlocks:    24,
 		sidechainBlocks:    3,
 		freezeThreshold:    16,
 		commitBlock:        4,
-		pivotBlock:         4,
+		pivotBlock:         uint64ptr(4),
 		setheadBlock:       6,
 		expCanonicalBlocks: 4,
 		expSidechainBlocks: 0,
+		expFrozen:          5,
+		expHeadHeader:      4,
+		expHeadFastBlock:   4,
+		expHeadBlock:       4,
+	})
+}
+
+// Tests a sethead for a long canonical chain with frozen blocks and a shorter
+// side chain, where the fast sync pivot point - newer than the ancient limit -
+// was not yet comitted, but sethead was called. In this test scenario the side
+// chain is below the commited block. In this case we expect the chain to detect
+// that it was fast syncing and delete everything from the new head, since we can
+// just pick up fast syncing from there. The side chain is completely nuked by the
+// freezer.
+func TestLongOldForkedFastSyncingShallowSetHead(t *testing.T) {
+	// Chain:
+	//   G->C1->C2->C3->C4->C5->C6->C7->C8->C9->C10->C11->C12->C13->C14->C15->C16->C17->C18 (HEAD)
+	//   └->S1->S2->S3
+	//
+	// Frozen:
+	//   G->C1->C2
+	//
+	// Commit: G
+	// Pivot : C4
+	//
+	// SetHead(6)
+	//
+	// ------------------------------
+	//
+	// Expected in freezer:
+	//   G->C1->C2
+	//
+	// Expected in leveldb:
+	//   C2)->C3->C4->C5->C6
+	//
+	// Expected head header    : C6
+	// Expected head fast block: C6
+	// Expected head block     : G
+	testSetHead(t, &rewindTest{
+		canonicalBlocks:    18,
+		sidechainBlocks:    3,
+		freezeThreshold:    16,
+		commitBlock:        0,
+		pivotBlock:         uint64ptr(4),
+		setheadBlock:       6,
+		expCanonicalBlocks: 6,
+		expSidechainBlocks: 0,
+		expFrozen:          3,
+		expHeadHeader:      6,
+		expHeadFastBlock:   6,
+		expHeadBlock:       0,
 	})
 }
 
@@ -377,120 +1169,533 @@ func TestLongOldForkedFastSyncedSetHead(t *testing.T) {
 // was not yet comitted, but sethead was called. In this test scenario the side
 // chain is below the commited block. In this case we expect the chain to detect
 // that it was fast syncing and delete everything from the new head, since we can
-// just pick up fast syncing from there. The side chin is completely nuked by the
+// just pick up fast syncing from there. The side chain is completely nuked by the
 // freezer.
-func TestLongOldForkedFastSyncingSetHead(t *testing.T) {
-	testSetHead(t, &setHeadTest{
+func TestLongOldForkedFastSyncingDeepSetHead(t *testing.T) {
+	// Chain:
+	//   G->C1->C2->C3->C4->C5->C6->C7->C8->C9->C10->C11->C12->C13->C14->C15->C16->C17->C18->C19->C20->C21->C22->C23->C24 (HEAD)
+	//   └->S1->S2->S3
+	//
+	// Frozen:
+	//   G->C1->C2->C3->C4->C5->C6->C7->C8
+	//
+	// Commit: G
+	// Pivot : C4
+	//
+	// SetHead(6)
+	//
+	// ------------------------------
+	//
+	// Expected in freezer:
+	//   G->C1->C2->C3->C4->C5->C6
+	//
+	// Expected in leveldb: none
+	//
+	// Expected head header    : C6
+	// Expected head fast block: C6
+	// Expected head block     : G
+	testSetHead(t, &rewindTest{
 		canonicalBlocks:    24,
 		sidechainBlocks:    3,
 		freezeThreshold:    16,
 		commitBlock:        0,
-		pivotBlock:         4,
+		pivotBlock:         uint64ptr(4),
 		setheadBlock:       6,
 		expCanonicalBlocks: 6,
 		expSidechainBlocks: 0,
+		expFrozen:          7,
+		expHeadHeader:      6,
+		expHeadFastBlock:   6,
+		expHeadBlock:       0,
+	})
+}
+
+// Tests a sethead for a long canonical chain with frozen blocks and a shorter
+// side chain, where a recent block - newer than the ancient limit - was already
+// comitted to disk and then sethead was called. In this test scenario the side
+// chain is above the commited block. In this case the freezer will delete the
+// sidechain since it's dangling, reverting to TestLongShallowSetHead.
+func TestLongNewerForkedShallowSetHead(t *testing.T) {
+	// Chain:
+	//   G->C1->C2->C3->C4->C5->C6->C7->C8->C9->C10->C11->C12->C13->C14->C15->C16->C17->C18 (HEAD)
+	//   └->S1->S2->S3->S4->S5->S6->S7->S8->S9->S10->S11->S12
+	//
+	// Frozen:
+	//   G->C1->C2
+	//
+	// Commit: G, C4
+	// Pivot : none
+	//
+	// SetHead(6)
+	//
+	// ------------------------------
+	//
+	// Expected in freezer:
+	//   G->C1->C2
+	//
+	// Expected in leveldb:
+	//   C2)->C3->C4->C5->C6
+	//
+	// Expected head header    : C6
+	// Expected head fast block: C6
+	// Expected head block     : C4
+	testSetHead(t, &rewindTest{
+		canonicalBlocks:    18,
+		sidechainBlocks:    12,
+		freezeThreshold:    16,
+		commitBlock:        4,
+		pivotBlock:         nil,
+		setheadBlock:       6,
+		expCanonicalBlocks: 6,
+		expSidechainBlocks: 0,
+		expFrozen:          3,
+		expHeadHeader:      6,
+		expHeadFastBlock:   6,
+		expHeadBlock:       4,
 	})
 }
 
 // Tests a sethead for a long canonical chain with frozen blocks and a shorter
 // side chain, where a recent block - older than the ancient limit - was already
 // comitted to disk and then sethead was called. In this test scenario the side
-// chain is above the commited block. In this case we expect the canonical chain
-// to be rolled back to the committed block, with everything afterwads deleted;
-// the side chain completely nuked by the freezer.
-func TestLongNewerForkedSetHead(t *testing.T) {
-	testSetHead(t, &setHeadTest{
+// chain is above the commited block. In this case the freezer will delete the
+// sidechain since it's dangling, reverting to TestLongDeepSetHead.
+func TestLongNewerForkedDeepSetHead(t *testing.T) {
+	// Chain:
+	//   G->C1->C2->C3->C4->C5->C6->C7->C8->C9->C10->C11->C12->C13->C14->C15->C16->C17->C18->C19->C20->C21->C22->C23->C24 (HEAD)
+	//   └->S1->S2->S3->S4->S5->S6->S7->S8->S9->S10->S11->S12
+	//
+	// Frozen:
+	//   G->C1->C2->C3->C4->C5->C6->C7->C8
+	//
+	// Commit: G, C4
+	// Pivot : none
+	//
+	// SetHead(6)
+	//
+	// ------------------------------
+	//
+	// Expected in freezer:
+	//   G->C1->C2->C3->C4
+	//
+	// Expected in leveldb: none
+	//
+	// Expected head header    : C4
+	// Expected head fast block: C4
+	// Expected head block     : C4
+	testSetHead(t, &rewindTest{
 		canonicalBlocks:    24,
 		sidechainBlocks:    12,
 		freezeThreshold:    16,
 		commitBlock:        4,
-		pivotBlock:         0,
+		pivotBlock:         nil,
 		setheadBlock:       6,
 		expCanonicalBlocks: 4,
 		expSidechainBlocks: 0,
+		expFrozen:          5,
+		expHeadHeader:      4,
+		expHeadFastBlock:   4,
+		expHeadBlock:       4,
+	})
+}
+
+// Tests a sethead for a long canonical chain with frozen blocks and a shorter
+// side chain, where the fast sync pivot point - newer than the ancient limit -
+// was already comitted to disk and then sethead was called. In this test scenario
+// the side chain is above the commited block. In this case the freezer will delete
+// the sidechain since it's dangling, reverting to TestLongFastSyncedShallowSetHead.
+func TestLongNewerForkedFastSyncedShallowSetHead(t *testing.T) {
+	// Chain:
+	//   G->C1->C2->C3->C4->C5->C6->C7->C8->C9->C10->C11->C12->C13->C14->C15->C16->C17->C18 (HEAD)
+	//   └->S1->S2->S3->S4->S5->S6->S7->S8->S9->S10->S11->S12
+	//
+	// Frozen:
+	//   G->C1->C2
+	//
+	// Commit: G, C4
+	// Pivot : C4
+	//
+	// SetHead(6)
+	//
+	// ------------------------------
+	//
+	// Expected in freezer:
+	//   G->C1->C2
+	//
+	// Expected in leveldb:
+	//   C2)->C3->C4->C5->C6
+	//
+	// Expected head header    : C6
+	// Expected head fast block: C6
+	// Expected head block     : C4
+	testSetHead(t, &rewindTest{
+		canonicalBlocks:    18,
+		sidechainBlocks:    12,
+		freezeThreshold:    16,
+		commitBlock:        4,
+		pivotBlock:         uint64ptr(4),
+		setheadBlock:       6,
+		expCanonicalBlocks: 6,
+		expSidechainBlocks: 0,
+		expFrozen:          3,
+		expHeadHeader:      6,
+		expHeadFastBlock:   6,
+		expHeadBlock:       4,
 	})
 }
 
 // Tests a sethead for a long canonical chain with frozen blocks and a shorter
 // side chain, where the fast sync pivot point - older than the ancient limit -
 // was already comitted to disk and then sethead was called. In this test scenario
-// the side chain is above the commited block. In this case we expect the canonical
-// chain to be rolled back to the committed block, with everything afterwads deleted;
-// the side chain completely nuked by the freezer.
-func TestLongNewerForkedFastSyncedSetHead(t *testing.T) {
-	testSetHead(t, &setHeadTest{
+// the side chain is above the commited block. In this case the freezer will delete
+// the sidechain since it's dangling, reverting to TestLongFastSyncedDeepSetHead.
+func TestLongNewerForkedFastSyncedDeepSetHead(t *testing.T) {
+	// Chain:
+	//   G->C1->C2->C3->C4->C5->C6->C7->C8->C9->C10->C11->C12->C13->C14->C15->C16->C17->C18->C19->C20->C21->C22->C23->C24 (HEAD)
+	//   └->S1->S2->S3->S4->S5->S6->S7->S8->S9->S10->S11->S12
+	//
+	// Frozen:
+	//   G->C1->C2->C3->C4->C5->C6->C7->C8
+	//
+	// Commit: G, C4
+	// Pivot : C4
+	//
+	// SetHead(6)
+	//
+	// ------------------------------
+	//
+	// Expected in freezer:
+	//   G->C1->C2->C3->C4
+	//
+	// Expected in leveldb: none
+	//
+	// Expected head header    : C4
+	// Expected head fast block: C4
+	// Expected head block     : C
+	testSetHead(t, &rewindTest{
 		canonicalBlocks:    24,
 		sidechainBlocks:    12,
 		freezeThreshold:    16,
 		commitBlock:        4,
-		pivotBlock:         4,
+		pivotBlock:         uint64ptr(4),
 		setheadBlock:       6,
 		expCanonicalBlocks: 4,
 		expSidechainBlocks: 0,
+		expFrozen:          5,
+		expHeadHeader:      4,
+		expHeadFastBlock:   4,
+		expHeadBlock:       4,
+	})
+}
+
+// Tests a sethead for a long canonical chain with frozen blocks and a shorter
+// side chain, where the fast sync pivot point - newer than the ancient limit -
+// was not yet comitted, but sethead was called. In this test scenario the side
+// chain is above the commited block. In this case the freezer will delete the
+// sidechain since it's dangling, reverting to TestLongFastSyncinghallowSetHead.
+func TestLongNewerForkedFastSyncingShallowSetHead(t *testing.T) {
+	// Chain:
+	//   G->C1->C2->C3->C4->C5->C6->C7->C8->C9->C10->C11->C12->C13->C14->C15->C16->C17->C18 (HEAD)
+	//   └->S1->S2->S3->S4->S5->S6->S7->S8->S9->S10->S11->S12
+	//
+	// Frozen:
+	//   G->C1->C2
+	//
+	// Commit: G
+	// Pivot : C4
+	//
+	// SetHead(6)
+	//
+	// ------------------------------
+	//
+	// Expected in freezer:
+	//   G->C1->C2
+	//
+	// Expected in leveldb:
+	//   C2)->C3->C4->C5->C6
+	//
+	// Expected head header    : C6
+	// Expected head fast block: C6
+	// Expected head block     : G
+	testSetHead(t, &rewindTest{
+		canonicalBlocks:    18,
+		sidechainBlocks:    12,
+		freezeThreshold:    16,
+		commitBlock:        0,
+		pivotBlock:         uint64ptr(4),
+		setheadBlock:       6,
+		expCanonicalBlocks: 6,
+		expSidechainBlocks: 0,
+		expFrozen:          3,
+		expHeadHeader:      6,
+		expHeadFastBlock:   6,
+		expHeadBlock:       0,
 	})
 }
 
 // Tests a sethead for a long canonical chain with frozen blocks and a shorter
 // side chain, where the fast sync pivot point - older than the ancient limit -
 // was not yet comitted, but sethead was called. In this test scenario the side
-// chain is above the commited block. In this case we expect the chain to detect
-// that it was fast syncing and delete everything from the new head, since we can
-// just pick up fast syncing from there. The side chain is completely nuked by
-// the freezer.
-func TestLongNewerForkedFastSyncingSetHead(t *testing.T) {
-	testSetHead(t, &setHeadTest{
+// chain is above the commited block. In this case the freezer will delete the
+// sidechain since it's dangling, reverting to TestLongFastSyncingDeepSetHead.
+func TestLongNewerForkedFastSyncingDeepSetHead(t *testing.T) {
+	// Chain:
+	//   G->C1->C2->C3->C4->C5->C6->C7->C8->C9->C10->C11->C12->C13->C14->C15->C16->C17->C18->C19->C20->C21->C22->C23->C24 (HEAD)
+	//   └->S1->S2->S3->S4->S5->S6->S7->S8->S9->S10->S11->S12
+	//
+	// Frozen:
+	//   G->C1->C2->C3->C4->C5->C6->C7->C8
+	//
+	// Commit: G
+	// Pivot : C4
+	//
+	// SetHead(6)
+	//
+	// ------------------------------
+	//
+	// Expected in freezer:
+	//   G->C1->C2->C3->C4->C5->C6
+	//
+	// Expected in leveldb: none
+	//
+	// Expected head header    : C6
+	// Expected head fast block: C6
+	// Expected head block     : G
+	testSetHead(t, &rewindTest{
 		canonicalBlocks:    24,
 		sidechainBlocks:    12,
 		freezeThreshold:    16,
 		commitBlock:        0,
-		pivotBlock:         4,
+		pivotBlock:         uint64ptr(4),
 		setheadBlock:       6,
 		expCanonicalBlocks: 6,
 		expSidechainBlocks: 0,
+		expFrozen:          7,
+		expHeadHeader:      6,
+		expHeadFastBlock:   6,
+		expHeadBlock:       0,
+	})
+}
+
+// Tests a sethead for a long canonical chain with frozen blocks and a longer side
+// chain, where a recent block - newer than the ancient limit - was already comitted
+// to disk and then sethead was called. In this case the freezer will delete the
+// sidechain since it's dangling, reverting to TestLongShallowSetHead.
+func TestLongReorgedShallowSetHead(t *testing.T) {
+	// Chain:
+	//   G->C1->C2->C3->C4->C5->C6->C7->C8->C9->C10->C11->C12->C13->C14->C15->C16->C17->C18 (HEAD)
+	//   └->S1->S2->S3->S4->S5->S6->S7->S8->S9->S10->S11->S12->S13->S14->S15->S16->S17->S18->S19->S20->S21->S22->S23->S24->S25->S26
+	//
+	// Frozen:
+	//   G->C1->C2
+	//
+	// Commit: G, C4
+	// Pivot : none
+	//
+	// SetHead(6)
+	//
+	// ------------------------------
+	//
+	// Expected in freezer:
+	//   G->C1->C2
+	//
+	// Expected in leveldb:
+	//   C2)->C3->C4->C5->C6
+	//
+	// Expected head header    : C6
+	// Expected head fast block: C6
+	// Expected head block     : C4
+	testSetHead(t, &rewindTest{
+		canonicalBlocks:    18,
+		sidechainBlocks:    26,
+		freezeThreshold:    16,
+		commitBlock:        4,
+		pivotBlock:         nil,
+		setheadBlock:       6,
+		expCanonicalBlocks: 6,
+		expSidechainBlocks: 0,
+		expFrozen:          3,
+		expHeadHeader:      6,
+		expHeadFastBlock:   6,
+		expHeadBlock:       4,
 	})
 }
 
 // Tests a sethead for a long canonical chain with frozen blocks and a longer side
 // chain, where a recent block - older than the ancient limit - was already comitted
-// to disk and then sethead was called. In this case we expect the canonical chains
-// to be rolled back to the committed block, with everything afterwads deleted. The
-// side chain completely nuked by the freezer.
-//
-// The side chain could be left to be if the fork point was before the new head
-// we are deleting to, but it would be exceedingly hard to detect that case and
-// properly handle it, so we'll trade extra work in exchange for simpler code.
-func TestLongReorgedSetHead(t *testing.T) {
-	testSetHead(t, &setHeadTest{
+// to disk and then sethead was called. In this case the freezer will delete the
+// sidechain since it's dangling, reverting to TestLongDeepSetHead.
+func TestLongReorgedDeepSetHead(t *testing.T) {
+	// Chain:
+	//   G->C1->C2->C3->C4->C5->C6->C7->C8->C9->C10->C11->C12->C13->C14->C15->C16->C17->C18->C19->C20->C21->C22->C23->C24 (HEAD)
+	//   └->S1->S2->S3->S4->S5->S6->S7->S8->S9->S10->S11->S12->S13->S14->S15->S16->S17->S18->S19->S20->S21->S22->S23->S24->S25->S26
+	//
+	// Frozen:
+	//   G->C1->C2->C3->C4->C5->C6->C7->C8
+	//
+	// Commit: G, C4
+	// Pivot : none
+	//
+	// SetHead(6)
+	//
+	// ------------------------------
+	//
+	// Expected in freezer:
+	//   G->C1->C2->C3->C4
+	//
+	// Expected in leveldb: none
+	//
+	// Expected head header    : C4
+	// Expected head fast block: C4
+	// Expected head block     : C4
+	testSetHead(t, &rewindTest{
 		canonicalBlocks:    24,
 		sidechainBlocks:    26,
 		freezeThreshold:    16,
 		commitBlock:        4,
-		pivotBlock:         0,
+		pivotBlock:         nil,
 		setheadBlock:       6,
 		expCanonicalBlocks: 4,
 		expSidechainBlocks: 0,
+		expFrozen:          5,
+		expHeadHeader:      4,
+		expHeadFastBlock:   4,
+		expHeadBlock:       4,
+	})
+}
+
+// Tests a sethead for a long canonical chain with frozen blocks and a longer
+// side chain, where the fast sync pivot point - newer than the ancient limit -
+// was already comitted to disk and then sethead was called. In this case the
+// freezer will delete the sidechain since it's dangling, reverting to
+// TestLongFastSyncedShallowSetHead.
+func TestLongReorgedFastSyncedShallowSetHead(t *testing.T) {
+	// Chain:
+	//   G->C1->C2->C3->C4->C5->C6->C7->C8->C9->C10->C11->C12->C13->C14->C15->C16->C17->C18 (HEAD)
+	//   └->S1->S2->S3->S4->S5->S6->S7->S8->S9->S10->S11->S12->S13->S14->S15->S16->S17->S18->S19->S20->S21->S22->S23->S24->S25->S26
+	//
+	// Frozen:
+	//   G->C1->C2
+	//
+	// Commit: G, C4
+	// Pivot : C4
+	//
+	// SetHead(6)
+	//
+	// ------------------------------
+	//
+	// Expected in freezer:
+	//   G->C1->C2
+	//
+	// Expected in leveldb:
+	//   C2)->C3->C4->C5->C6
+	//
+	// Expected head header    : C6
+	// Expected head fast block: C6
+	// Expected head block     : C4
+	testSetHead(t, &rewindTest{
+		canonicalBlocks:    18,
+		sidechainBlocks:    26,
+		freezeThreshold:    16,
+		commitBlock:        4,
+		pivotBlock:         uint64ptr(4),
+		setheadBlock:       6,
+		expCanonicalBlocks: 6,
+		expSidechainBlocks: 0,
+		expFrozen:          3,
+		expHeadHeader:      6,
+		expHeadFastBlock:   6,
+		expHeadBlock:       4,
 	})
 }
 
 // Tests a sethead for a long canonical chain with frozen blocks and a longer
 // side chain, where the fast sync pivot point - older than the ancient limit -
-// was already comitted to disk and then sethead was called. In this case we
-// expect the canonical chains to be rolled back to the committed block, with
-// everything afterwads deleted. The side chain completely nuked by the freezer.
-//
-// The side chain could be left to be if the fork point was before the new head
-// we are deleting to, but it would be exceedingly hard to detect that case and
-// properly handle it, so we'll trade extra work in exchange for simpler code.
-func TestLongReorgedFastSyncedSetHead(t *testing.T) {
-	testSetHead(t, &setHeadTest{
+// was already comitted to disk and then sethead was called. In this case the
+// freezer will delete the sidechain since it's dangling, reverting to
+// TestLongFastSyncedDeepSetHead.
+func TestLongReorgedFastSyncedDeepSetHead(t *testing.T) {
+	// Chain:
+	//   G->C1->C2->C3->C4->C5->C6->C7->C8->C9->C10->C11->C12->C13->C14->C15->C16->C17->C18->C19->C20->C21->C22->C23->C24 (HEAD)
+	//   └->S1->S2->S3->S4->S5->S6->S7->S8->S9->S10->S11->S12->S13->S14->S15->S16->S17->S18->S19->S20->S21->S22->S23->S24->S25->S26
+	//
+	// Frozen:
+	//   G->C1->C2->C3->C4->C5->C6->C7->C8
+	//
+	// Commit: G, C4
+	// Pivot : C4
+	//
+	// SetHead(6)
+	//
+	// ------------------------------
+	//
+	// Expected in freezer:
+	//   G->C1->C2->C3->C4
+	//
+	// Expected in leveldb: none
+	//
+	// Expected head header    : C4
+	// Expected head fast block: C4
+	// Expected head block     : C4
+	testSetHead(t, &rewindTest{
 		canonicalBlocks:    24,
 		sidechainBlocks:    26,
 		freezeThreshold:    16,
 		commitBlock:        4,
-		pivotBlock:         4,
+		pivotBlock:         uint64ptr(4),
 		setheadBlock:       6,
 		expCanonicalBlocks: 4,
 		expSidechainBlocks: 0,
+		expFrozen:          5,
+		expHeadHeader:      4,
+		expHeadFastBlock:   4,
+		expHeadBlock:       4,
+	})
+}
+
+// Tests a sethead for a long canonical chain with frozen blocks and a longer
+// side chain, where the fast sync pivot point - newer than the ancient limit -
+// was not yet comitted, but sethead was called. In this case we expect the
+// chain to detect that it was fast syncing and delete everything from the new
+// head, since we can just pick up fast syncing from there. The side chain is
+// completely nuked by the freezer.
+func TestLongReorgedFastSyncingShallowSetHead(t *testing.T) {
+	// Chain:
+	//   G->C1->C2->C3->C4->C5->C6->C7->C8->C9->C10->C11->C12->C13->C14->C15->C16->C17->C18 (HEAD)
+	//   └->S1->S2->S3->S4->S5->S6->S7->S8->S9->S10->S11->S12->S13->S14->S15->S16->S17->S18->S19->S20->S21->S22->S23->S24->S25->S26
+	//
+	// Frozen:
+	//   G->C1->C2
+	//
+	// Commit: G
+	// Pivot : C4
+	//
+	// SetHead(6)
+	//
+	// ------------------------------
+	//
+	// Expected in freezer:
+	//   G->C1->C2
+	//
+	// Expected in leveldb:
+	//   C2)->C3->C4->C5->C6
+	//
+	// Expected head header    : C6
+	// Expected head fast block: C6
+	// Expected head block     : G
+	testSetHead(t, &rewindTest{
+		canonicalBlocks:    18,
+		sidechainBlocks:    26,
+		freezeThreshold:    16,
+		commitBlock:        0,
+		pivotBlock:         uint64ptr(4),
+		setheadBlock:       6,
+		expCanonicalBlocks: 6,
+		expSidechainBlocks: 0,
+		expFrozen:          3,
+		expHeadHeader:      6,
+		expHeadFastBlock:   6,
+		expHeadBlock:       0,
 	})
 }
 
@@ -500,21 +1705,49 @@ func TestLongReorgedFastSyncedSetHead(t *testing.T) {
 // chain to detect that it was fast syncing and delete everything from the new
 // head, since we can just pick up fast syncing from there. The side chain is
 // completely nuked by the freezer.
-func TestLongReorgedFastSyncingSetHead(t *testing.T) {
-	testSetHead(t, &setHeadTest{
+func TestLongReorgedFastSyncingDeepSetHead(t *testing.T) {
+	// Chain:
+	//   G->C1->C2->C3->C4->C5->C6->C7->C8->C9->C10->C11->C12->C13->C14->C15->C16->C17->C18->C19->C20->C21->C22->C23->C24 (HEAD)
+	//   └->S1->S2->S3->S4->S5->S6->S7->S8->S9->S10->S11->S12->S13->S14->S15->S16->S17->S18->S19->S20->S21->S22->S23->S24->S25->S26
+	//
+	// Frozen:
+	//   G->C1->C2->C3->C4->C5->C6->C7->C8
+	//
+	// Commit: G
+	// Pivot : C4
+	//
+	// SetHead(6)
+	//
+	// ------------------------------
+	//
+	// Expected in freezer:
+	//   G->C1->C2->C3->C4->C5->C6
+	//
+	// Expected in leveldb: none
+	//
+	// Expected head header    : C6
+	// Expected head fast block: C6
+	// Expected head block     : G
+	testSetHead(t, &rewindTest{
 		canonicalBlocks:    24,
 		sidechainBlocks:    26,
 		freezeThreshold:    16,
 		commitBlock:        0,
-		pivotBlock:         4,
+		pivotBlock:         uint64ptr(4),
 		setheadBlock:       6,
 		expCanonicalBlocks: 6,
 		expSidechainBlocks: 0,
+		expFrozen:          7,
+		expHeadHeader:      6,
+		expHeadFastBlock:   6,
+		expHeadBlock:       0,
 	})
 }
 
-func testSetHead(t *testing.T, tt *setHeadTest) {
+func testSetHead(t *testing.T, tt *rewindTest) {
+	// It's hard to follow the test case, visualize the input
 	//log.Root().SetHandler(log.LvlFilterHandler(log.LvlTrace, log.StreamHandler(os.Stderr, log.TerminalFormat(true))))
+	//fmt.Println(tt.dump(false))
 
 	// Create a temporary persistent database
 	datadir, err := ioutil.TempDir("", "")
@@ -561,12 +1794,24 @@ func testSetHead(t *testing.T, tt *setHeadTest) {
 	if _, err := chain.InsertChain(canonblocks[tt.commitBlock:]); err != nil {
 		t.Fatalf("Failed to import canonical chain tail: %v", err)
 	}
+	// Manually dereference anything not comitted to not have to work with 128+ tries
+	for _, block := range sideblocks {
+		chain.stateCache.TrieDB().Dereference(block.Root())
+	}
+	for _, block := range canonblocks {
+		chain.stateCache.TrieDB().Dereference(block.Root())
+	}
 	// Force run a freeze cycle
 	type freezer interface {
 		Freeze(threshold uint64)
+		Ancients() (uint64, error)
 	}
 	db.(freezer).Freeze(tt.freezeThreshold)
 
+	// Set the simulated pivot block
+	if tt.pivotBlock != nil {
+		rawdb.WriteLastPivotNumber(db, *tt.pivotBlock)
+	}
 	// Set the head of the chain back to the requested number
 	chain.SetHead(tt.setheadBlock)
 
@@ -575,4 +1820,130 @@ func testSetHead(t *testing.T, tt *setHeadTest) {
 	verifyNoGaps(t, chain, false, sideblocks)
 	verifyCutoff(t, chain, true, canonblocks, tt.expCanonicalBlocks)
 	verifyCutoff(t, chain, false, sideblocks, tt.expSidechainBlocks)
+
+	if head := chain.CurrentHeader(); head.Number.Uint64() != tt.expHeadHeader {
+		t.Errorf("Head header mismatch: have %d, want %d", head.Number, tt.expHeadHeader)
+	}
+	if head := chain.CurrentFastBlock(); head.NumberU64() != tt.expHeadFastBlock {
+		t.Errorf("Head fast block mismatch: have %d, want %d", head.NumberU64(), tt.expHeadFastBlock)
+	}
+	if head := chain.CurrentBlock(); head.NumberU64() != tt.expHeadBlock {
+		t.Errorf("Head block mismatch: have %d, want %d", head.NumberU64(), tt.expHeadBlock)
+	}
+	if frozen, err := db.(freezer).Ancients(); err != nil {
+		t.Errorf("Failed to retrieve ancient count: %v\n", err)
+	} else if int(frozen) != tt.expFrozen {
+		t.Errorf("Frozen block count mismatch: have %d, want %d", frozen, tt.expFrozen)
+	}
+}
+
+// verifyNoGaps checks that there are no gaps after the initial set of blocks in
+// the database and errors if found.
+func verifyNoGaps(t *testing.T, chain *BlockChain, canonical bool, inserted types.Blocks) {
+	t.Helper()
+
+	var end uint64
+	for i := uint64(0); i <= uint64(len(inserted)); i++ {
+		header := chain.GetHeaderByNumber(i)
+		if header == nil && end == 0 {
+			end = i
+		}
+		if header != nil && end > 0 {
+			if canonical {
+				t.Errorf("Canonical header gap between #%d-#%d", end, i-1)
+			} else {
+				t.Errorf("Sidechain header gap between #%d-#%d", end, i-1)
+			}
+			end = 0 // Reset for further gap detection
+		}
+	}
+	end = 0
+	for i := uint64(0); i <= uint64(len(inserted)); i++ {
+		block := chain.GetBlockByNumber(i)
+		if block == nil && end == 0 {
+			end = i
+		}
+		if block != nil && end > 0 {
+			if canonical {
+				t.Errorf("Canonical block gap between #%d-#%d", end, i-1)
+			} else {
+				t.Errorf("Sidechain block gap between #%d-#%d", end, i-1)
+			}
+			end = 0 // Reset for further gap detection
+		}
+	}
+	end = 0
+	for i := uint64(1); i <= uint64(len(inserted)); i++ {
+		receipts := chain.GetReceiptsByHash(inserted[i-1].Hash())
+		if receipts == nil && end == 0 {
+			end = i
+		}
+		if receipts != nil && end > 0 {
+			if canonical {
+				t.Errorf("Canonical receipt gap between #%d-#%d", end, i-1)
+			} else {
+				t.Errorf("Sidechain receipt gap between #%d-#%d", end, i-1)
+			}
+			end = 0 // Reset for further gap detection
+		}
+	}
+}
+
+// verifyCutoff checks that there are no chain data available in the chain after
+// the specified limit, but that it is available before.
+func verifyCutoff(t *testing.T, chain *BlockChain, canonical bool, inserted types.Blocks, head int) {
+	t.Helper()
+
+	for i := 1; i <= len(inserted); i++ {
+		if i <= head {
+			if header := chain.GetHeader(inserted[i-1].Hash(), uint64(i)); header == nil {
+				if canonical {
+					t.Errorf("Canonical header   #%2d [%x...] missing before cap %d", inserted[i-1].Number(), inserted[i-1].Hash().Bytes()[:3], head)
+				} else {
+					t.Errorf("Sidechain header   #%2d [%x...] missing before cap %d", inserted[i-1].Number(), inserted[i-1].Hash().Bytes()[:3], head)
+				}
+			}
+			if block := chain.GetBlock(inserted[i-1].Hash(), uint64(i)); block == nil {
+				if canonical {
+					t.Errorf("Canonical block    #%2d [%x...] missing before cap %d", inserted[i-1].Number(), inserted[i-1].Hash().Bytes()[:3], head)
+				} else {
+					t.Errorf("Sidechain block    #%2d [%x...] missing before cap %d", inserted[i-1].Number(), inserted[i-1].Hash().Bytes()[:3], head)
+				}
+			}
+			if receipts := chain.GetReceiptsByHash(inserted[i-1].Hash()); receipts == nil {
+				if canonical {
+					t.Errorf("Canonical receipts #%2d [%x...] missing before cap %d", inserted[i-1].Number(), inserted[i-1].Hash().Bytes()[:3], head)
+				} else {
+					t.Errorf("Sidechain receipts #%2d [%x...] missing before cap %d", inserted[i-1].Number(), inserted[i-1].Hash().Bytes()[:3], head)
+				}
+			}
+		} else {
+			if header := chain.GetHeader(inserted[i-1].Hash(), uint64(i)); header != nil {
+				if canonical {
+					t.Errorf("Canonical header   #%2d [%x...] present after cap %d", inserted[i-1].Number(), inserted[i-1].Hash().Bytes()[:3], head)
+				} else {
+					t.Errorf("Sidechain header   #%2d [%x...] present after cap %d", inserted[i-1].Number(), inserted[i-1].Hash().Bytes()[:3], head)
+				}
+			}
+			if block := chain.GetBlock(inserted[i-1].Hash(), uint64(i)); block != nil {
+				if canonical {
+					t.Errorf("Canonical block    #%2d [%x...] present after cap %d", inserted[i-1].Number(), inserted[i-1].Hash().Bytes()[:3], head)
+				} else {
+					t.Errorf("Sidechain block    #%2d [%x...] present after cap %d", inserted[i-1].Number(), inserted[i-1].Hash().Bytes()[:3], head)
+				}
+			}
+			if receipts := chain.GetReceiptsByHash(inserted[i-1].Hash()); receipts != nil {
+				if canonical {
+					t.Errorf("Canonical receipts #%2d [%x...] present after cap %d", inserted[i-1].Number(), inserted[i-1].Hash().Bytes()[:3], head)
+				} else {
+					t.Errorf("Sidechain receipts #%2d [%x...] present after cap %d", inserted[i-1].Number(), inserted[i-1].Hash().Bytes()[:3], head)
+				}
+			}
+		}
+	}
+}
+
+// uint64ptr is a weird helper to allow 1-line constant pointer creation.
+func uint64ptr(n uint64) *uint64 {
+	return &n
 }

--- a/core/blockchain_sethead_test.go
+++ b/core/blockchain_sethead_test.go
@@ -146,7 +146,7 @@ func (tt *rewindTest) dump(crash bool) string {
 }
 
 // Tests a sethead for a short canonical chain where a recent block was already
-// comitted to disk and then the sethead called. In this case we expect the full
+// committed to disk and then the sethead called. In this case we expect the full
 // chain to be rolled back to the committed block. Everything above the sethead
 // point should be deleted. In between the committed block and the requested head
 // the data can remain as "fast sync" data to avoid redownloading it.
@@ -185,7 +185,7 @@ func TestShortSetHead(t *testing.T) {
 }
 
 // Tests a sethead for a short canonical chain where the fast sync pivot point was
-// already comitted, after which sethead was called. In this case we expect the
+// already committed, after which sethead was called. In this case we expect the
 // chain to behave like in full sync mode, rolling back to the committed block
 // Everything above the sethead point should be deleted. In between the committed
 // block and the requested head the data can remain as "fast sync" data to avoid
@@ -225,7 +225,7 @@ func TestShortFastSyncedSetHead(t *testing.T) {
 }
 
 // Tests a sethead for a short canonical chain where the fast sync pivot point was
-// not yet comitted, but sethead was called. In this case we expect the chain to
+// not yet committed, but sethead was called. In this case we expect the chain to
 // detect that it was fast syncing and delete everything from the new head, since
 // we can just pick up fast syncing from there. The head full block should be set
 // to the genesis.
@@ -264,8 +264,8 @@ func TestShortFastSyncingSetHead(t *testing.T) {
 }
 
 // Tests a sethead for a short canonical chain and a shorter side chain, where a
-// recent block was already comitted to disk and then sethead was called. In this
-// test scenario the side chain is below the commited block. In this case we expect
+// recent block was already committed to disk and then sethead was called. In this
+// test scenario the side chain is below the committed block. In this case we expect
 // the canonical full chain to be rolled back to the committed block. Everything
 // above the sethead point should be deleted. In between the committed block and
 // the requested head the data can remain as "fast sync" data to avoid redownloading
@@ -307,8 +307,8 @@ func TestShortOldForkedSetHead(t *testing.T) {
 }
 
 // Tests a sethead for a short canonical chain and a shorter side chain, where
-// the fast sync pivot point was already comitted to disk and then sethead was
-// called. In this test scenario the side chain is below the commited block. In
+// the fast sync pivot point was already committed to disk and then sethead was
+// called. In this test scenario the side chain is below the committed block. In
 // this case we expect the canonical full chain to be rolled back to the committed
 // block. Everything above the sethead point should be deleted. In between the
 // committed block and the requested head the data can remain as "fast sync" data
@@ -350,8 +350,8 @@ func TestShortOldForkedFastSyncedSetHead(t *testing.T) {
 }
 
 // Tests a sethead for a short canonical chain and a shorter side chain, where
-// the fast sync pivot point was not yet comitted, but sethead was called. In this
-// test scenario the side chain is below the commited block. In this case we expect
+// the fast sync pivot point was not yet committed, but sethead was called. In this
+// test scenario the side chain is below the committed block. In this case we expect
 // the chain to detect that it was fast syncing and delete everything from the new
 // head, since we can just pick up fast syncing from there. The head full block
 // should be set to the genesis.
@@ -392,8 +392,8 @@ func TestShortOldForkedFastSyncingSetHead(t *testing.T) {
 }
 
 // Tests a sethead for a short canonical chain and a shorter side chain, where a
-// recent block was already comitted to disk and then sethead was called. In this
-// test scenario the side chain reaches above the commited block. In this case we
+// recent block was already committed to disk and then sethead was called. In this
+// test scenario the side chain reaches above the committed block. In this case we
 // expect the canonical full chain to be rolled back to the committed block. All
 // data above the sethead point should be deleted. In between the committed block
 // and the requested head the data can remain as "fast sync" data to avoid having
@@ -439,7 +439,7 @@ func TestShortNewlyForkedSetHead(t *testing.T) {
 }
 
 // Tests a sethead for a short canonical chain and a shorter side chain, where
-// the fast sync pivot point was already comitted to disk and then sethead was
+// the fast sync pivot point was already committed to disk and then sethead was
 // called. In this case we expect the canonical full chain to be rolled back to
 // between the committed block and the requested head the data can remain as
 // "fast sync" data to avoid having to redownload it. The side chain should be
@@ -485,8 +485,8 @@ func TestShortNewlyForkedFastSyncedSetHead(t *testing.T) {
 }
 
 // Tests a sethead for a short canonical chain and a shorter side chain, where
-// the fast sync pivot point was not yet comitted, but sethead was called. In
-// this test scenario the side chain reaches above the commited block. In this
+// the fast sync pivot point was not yet committed, but sethead was called. In
+// this test scenario the side chain reaches above the committed block. In this
 // case we expect the chain to detect that it was fast syncing and delete
 // everything from the new head, since we can just pick up fast syncing from
 // there.
@@ -531,7 +531,7 @@ func TestShortNewlyForkedFastSyncingSetHead(t *testing.T) {
 }
 
 // Tests a sethead for a short canonical chain and a longer side chain, where a
-// recent block was already comitted to disk and then sethead was called. In this
+// recent block was already committed to disk and then sethead was called. In this
 // case we expect the canonical full chain to be rolled back to the committed block.
 // All data above the sethead point should be deleted. In between the committed
 // block and the requested head the data can remain as "fast sync" data to avoid
@@ -577,7 +577,7 @@ func TestShortReorgedSetHead(t *testing.T) {
 }
 
 // Tests a sethead for a short canonical chain and a longer side chain, where
-// the fast sync pivot point was already comitted to disk and then sethead was
+// the fast sync pivot point was already committed to disk and then sethead was
 // called. In this case we expect the canonical full chain to be rolled back to
 // the committed block. All data above the sethead point should be deleted. In
 // between the committed block and the requested head the data can remain as
@@ -624,7 +624,7 @@ func TestShortReorgedFastSyncedSetHead(t *testing.T) {
 }
 
 // Tests a sethead for a short canonical chain and a longer side chain, where
-// the fast sync pivot point was not yet comitted, but sethead was called. In
+// the fast sync pivot point was not yet committed, but sethead was called. In
 // this case we expect the chain to detect that it was fast syncing and delete
 // everything from the new head, since we can just pick up fast syncing from
 // there.
@@ -669,7 +669,7 @@ func TestShortReorgedFastSyncingSetHead(t *testing.T) {
 }
 
 // Tests a sethead for a long canonical chain with frozen blocks where a recent
-// block - newer than the ancient limit - was already comitted to disk and then
+// block - newer than the ancient limit - was already committed to disk and then
 // sethead was called. In this case we expect the full chain to be rolled back
 // to the committed block. Everything above the sethead point should be deleted.
 // In between the committed block and the requested head the data can remain as
@@ -714,7 +714,7 @@ func TestLongShallowSetHead(t *testing.T) {
 }
 
 // Tests a sethead for a long canonical chain with frozen blocks where a recent
-// block - older than the ancient limit - was already comitted to disk and then
+// block - older than the ancient limit - was already committed to disk and then
 // sethead was called. In this case we expect the full chain to be rolled back
 // to the committed block. Since the ancient limit was underflown, everything
 // needs to be deleted onwards to avoid creating a gap.
@@ -757,7 +757,7 @@ func TestLongDeepSetHead(t *testing.T) {
 }
 
 // Tests a sethead for a long canonical chain with frozen blocks where the fast
-// sync pivot point - newer than the ancient limit - was already comitted, after
+// sync pivot point - newer than the ancient limit - was already committed, after
 // which sethead was called. In this case we expect the full chain to be rolled
 // back to the committed block. Everything above the sethead point should be
 // deleted. In between the committed block and the requested head the data can
@@ -802,7 +802,7 @@ func TestLongFastSyncedShallowSetHead(t *testing.T) {
 }
 
 // Tests a sethead for a long canonical chain with frozen blocks where the fast
-// sync pivot point - older than the ancient limit - was already comitted, after
+// sync pivot point - older than the ancient limit - was already committed, after
 // which sethead was called. In this case we expect the full chain to be rolled
 // back to the committed block. Since the ancient limit was underflown, everything
 // needs to be deleted onwards to avoid creating a gap.
@@ -845,7 +845,7 @@ func TestLongFastSyncedDeepSetHead(t *testing.T) {
 }
 
 // Tests a sethead for a long canonical chain with frozen blocks where the fast
-// sync pivot point - newer than the ancient limit - was not yet comitted, but
+// sync pivot point - newer than the ancient limit - was not yet committed, but
 // sethead was called. In this case we expect the chain to detect that it was fast
 // syncing and delete everything from the new head, since we can just pick up fast
 // syncing from there.
@@ -889,7 +889,7 @@ func TestLongFastSyncingShallowSetHead(t *testing.T) {
 }
 
 // Tests a sethead for a long canonical chain with frozen blocks where the fast
-// sync pivot point - older than the ancient limit - was not yet comitted, but
+// sync pivot point - older than the ancient limit - was not yet committed, but
 // sethead was called. In this case we expect the chain to detect that it was fast
 // syncing and delete everything from the new head, since we can just pick up fast
 // syncing from there.
@@ -932,7 +932,7 @@ func TestLongFastSyncingDeepSetHead(t *testing.T) {
 }
 
 // Tests a sethead for a long canonical chain with frozen blocks and a shorter side
-// chain, where a recent block - newer than the ancient limit - was already comitted
+// chain, where a recent block - newer than the ancient limit - was already committed
 // to disk and then sethead was called. In this case we expect the canonical full
 // chain to be rolled back to the committed block. Everything above the sethead point
 // should be deleted. In between the committed block and the requested head the data
@@ -979,7 +979,7 @@ func TestLongOldForkedShallowSetHead(t *testing.T) {
 }
 
 // Tests a sethead for a long canonical chain with frozen blocks and a shorter side
-// chain, where a recent block - older than the ancient limit - was already comitted
+// chain, where a recent block - older than the ancient limit - was already committed
 // to disk and then sethead was called. In this case we expect the canonical full
 // chain to be rolled back to the committed block. Since the ancient limit was
 // underflown, everything needs to be deleted onwards to avoid creating a gap. The
@@ -1025,8 +1025,8 @@ func TestLongOldForkedDeepSetHead(t *testing.T) {
 
 // Tests a sethead for a long canonical chain with frozen blocks and a shorter
 // side chain, where the fast sync pivot point - newer than the ancient limit -
-// was already comitted to disk and then sethead was called. In this test scenario
-// the side chain is below the commited block. In this case we expect the canonical
+// was already committed to disk and then sethead was called. In this test scenario
+// the side chain is below the committed block. In this case we expect the canonical
 // full chain to be rolled back to the committed block. Everything above the
 // sethead point should be deleted. In between the committed block and the
 // requested head the data can remain as "fast sync" data to avoid redownloading
@@ -1073,8 +1073,8 @@ func TestLongOldForkedFastSyncedShallowSetHead(t *testing.T) {
 
 // Tests a sethead for a long canonical chain with frozen blocks and a shorter
 // side chain, where the fast sync pivot point - older than the ancient limit -
-// was already comitted to disk and then sethead was called. In this test scenario
-// the side chain is below the commited block. In this case we expect the canonical
+// was already committed to disk and then sethead was called. In this test scenario
+// the side chain is below the committed block. In this case we expect the canonical
 // full chain to be rolled back to the committed block. Since the ancient limit was
 // underflown, everything needs to be deleted onwards to avoid creating a gap. The
 // side chain is nuked by the freezer.
@@ -1119,8 +1119,8 @@ func TestLongOldForkedFastSyncedDeepSetHead(t *testing.T) {
 
 // Tests a sethead for a long canonical chain with frozen blocks and a shorter
 // side chain, where the fast sync pivot point - newer than the ancient limit -
-// was not yet comitted, but sethead was called. In this test scenario the side
-// chain is below the commited block. In this case we expect the chain to detect
+// was not yet committed, but sethead was called. In this test scenario the side
+// chain is below the committed block. In this case we expect the chain to detect
 // that it was fast syncing and delete everything from the new head, since we can
 // just pick up fast syncing from there. The side chain is completely nuked by the
 // freezer.
@@ -1166,8 +1166,8 @@ func TestLongOldForkedFastSyncingShallowSetHead(t *testing.T) {
 
 // Tests a sethead for a long canonical chain with frozen blocks and a shorter
 // side chain, where the fast sync pivot point - older than the ancient limit -
-// was not yet comitted, but sethead was called. In this test scenario the side
-// chain is below the commited block. In this case we expect the chain to detect
+// was not yet committed, but sethead was called. In this test scenario the side
+// chain is below the committed block. In this case we expect the chain to detect
 // that it was fast syncing and delete everything from the new head, since we can
 // just pick up fast syncing from there. The side chain is completely nuked by the
 // freezer.
@@ -1212,8 +1212,8 @@ func TestLongOldForkedFastSyncingDeepSetHead(t *testing.T) {
 
 // Tests a sethead for a long canonical chain with frozen blocks and a shorter
 // side chain, where a recent block - newer than the ancient limit - was already
-// comitted to disk and then sethead was called. In this test scenario the side
-// chain is above the commited block. In this case the freezer will delete the
+// committed to disk and then sethead was called. In this test scenario the side
+// chain is above the committed block. In this case the freezer will delete the
 // sidechain since it's dangling, reverting to TestLongShallowSetHead.
 func TestLongNewerForkedShallowSetHead(t *testing.T) {
 	// Chain:
@@ -1257,8 +1257,8 @@ func TestLongNewerForkedShallowSetHead(t *testing.T) {
 
 // Tests a sethead for a long canonical chain with frozen blocks and a shorter
 // side chain, where a recent block - older than the ancient limit - was already
-// comitted to disk and then sethead was called. In this test scenario the side
-// chain is above the commited block. In this case the freezer will delete the
+// committed to disk and then sethead was called. In this test scenario the side
+// chain is above the committed block. In this case the freezer will delete the
 // sidechain since it's dangling, reverting to TestLongDeepSetHead.
 func TestLongNewerForkedDeepSetHead(t *testing.T) {
 	// Chain:
@@ -1301,8 +1301,8 @@ func TestLongNewerForkedDeepSetHead(t *testing.T) {
 
 // Tests a sethead for a long canonical chain with frozen blocks and a shorter
 // side chain, where the fast sync pivot point - newer than the ancient limit -
-// was already comitted to disk and then sethead was called. In this test scenario
-// the side chain is above the commited block. In this case the freezer will delete
+// was already committed to disk and then sethead was called. In this test scenario
+// the side chain is above the committed block. In this case the freezer will delete
 // the sidechain since it's dangling, reverting to TestLongFastSyncedShallowSetHead.
 func TestLongNewerForkedFastSyncedShallowSetHead(t *testing.T) {
 	// Chain:
@@ -1346,8 +1346,8 @@ func TestLongNewerForkedFastSyncedShallowSetHead(t *testing.T) {
 
 // Tests a sethead for a long canonical chain with frozen blocks and a shorter
 // side chain, where the fast sync pivot point - older than the ancient limit -
-// was already comitted to disk and then sethead was called. In this test scenario
-// the side chain is above the commited block. In this case the freezer will delete
+// was already committed to disk and then sethead was called. In this test scenario
+// the side chain is above the committed block. In this case the freezer will delete
 // the sidechain since it's dangling, reverting to TestLongFastSyncedDeepSetHead.
 func TestLongNewerForkedFastSyncedDeepSetHead(t *testing.T) {
 	// Chain:
@@ -1390,8 +1390,8 @@ func TestLongNewerForkedFastSyncedDeepSetHead(t *testing.T) {
 
 // Tests a sethead for a long canonical chain with frozen blocks and a shorter
 // side chain, where the fast sync pivot point - newer than the ancient limit -
-// was not yet comitted, but sethead was called. In this test scenario the side
-// chain is above the commited block. In this case the freezer will delete the
+// was not yet committed, but sethead was called. In this test scenario the side
+// chain is above the committed block. In this case the freezer will delete the
 // sidechain since it's dangling, reverting to TestLongFastSyncinghallowSetHead.
 func TestLongNewerForkedFastSyncingShallowSetHead(t *testing.T) {
 	// Chain:
@@ -1435,8 +1435,8 @@ func TestLongNewerForkedFastSyncingShallowSetHead(t *testing.T) {
 
 // Tests a sethead for a long canonical chain with frozen blocks and a shorter
 // side chain, where the fast sync pivot point - older than the ancient limit -
-// was not yet comitted, but sethead was called. In this test scenario the side
-// chain is above the commited block. In this case the freezer will delete the
+// was not yet committed, but sethead was called. In this test scenario the side
+// chain is above the committed block. In this case the freezer will delete the
 // sidechain since it's dangling, reverting to TestLongFastSyncingDeepSetHead.
 func TestLongNewerForkedFastSyncingDeepSetHead(t *testing.T) {
 	// Chain:
@@ -1478,7 +1478,7 @@ func TestLongNewerForkedFastSyncingDeepSetHead(t *testing.T) {
 }
 
 // Tests a sethead for a long canonical chain with frozen blocks and a longer side
-// chain, where a recent block - newer than the ancient limit - was already comitted
+// chain, where a recent block - newer than the ancient limit - was already committed
 // to disk and then sethead was called. In this case the freezer will delete the
 // sidechain since it's dangling, reverting to TestLongShallowSetHead.
 func TestLongReorgedShallowSetHead(t *testing.T) {
@@ -1522,7 +1522,7 @@ func TestLongReorgedShallowSetHead(t *testing.T) {
 }
 
 // Tests a sethead for a long canonical chain with frozen blocks and a longer side
-// chain, where a recent block - older than the ancient limit - was already comitted
+// chain, where a recent block - older than the ancient limit - was already committed
 // to disk and then sethead was called. In this case the freezer will delete the
 // sidechain since it's dangling, reverting to TestLongDeepSetHead.
 func TestLongReorgedDeepSetHead(t *testing.T) {
@@ -1566,7 +1566,7 @@ func TestLongReorgedDeepSetHead(t *testing.T) {
 
 // Tests a sethead for a long canonical chain with frozen blocks and a longer
 // side chain, where the fast sync pivot point - newer than the ancient limit -
-// was already comitted to disk and then sethead was called. In this case the
+// was already committed to disk and then sethead was called. In this case the
 // freezer will delete the sidechain since it's dangling, reverting to
 // TestLongFastSyncedShallowSetHead.
 func TestLongReorgedFastSyncedShallowSetHead(t *testing.T) {
@@ -1611,7 +1611,7 @@ func TestLongReorgedFastSyncedShallowSetHead(t *testing.T) {
 
 // Tests a sethead for a long canonical chain with frozen blocks and a longer
 // side chain, where the fast sync pivot point - older than the ancient limit -
-// was already comitted to disk and then sethead was called. In this case the
+// was already committed to disk and then sethead was called. In this case the
 // freezer will delete the sidechain since it's dangling, reverting to
 // TestLongFastSyncedDeepSetHead.
 func TestLongReorgedFastSyncedDeepSetHead(t *testing.T) {
@@ -1655,7 +1655,7 @@ func TestLongReorgedFastSyncedDeepSetHead(t *testing.T) {
 
 // Tests a sethead for a long canonical chain with frozen blocks and a longer
 // side chain, where the fast sync pivot point - newer than the ancient limit -
-// was not yet comitted, but sethead was called. In this case we expect the
+// was not yet committed, but sethead was called. In this case we expect the
 // chain to detect that it was fast syncing and delete everything from the new
 // head, since we can just pick up fast syncing from there. The side chain is
 // completely nuked by the freezer.
@@ -1701,7 +1701,7 @@ func TestLongReorgedFastSyncingShallowSetHead(t *testing.T) {
 
 // Tests a sethead for a long canonical chain with frozen blocks and a longer
 // side chain, where the fast sync pivot point - older than the ancient limit -
-// was not yet comitted, but sethead was called. In this case we expect the
+// was not yet committed, but sethead was called. In this case we expect the
 // chain to detect that it was fast syncing and delete everything from the new
 // head, since we can just pick up fast syncing from there. The side chain is
 // completely nuked by the freezer.
@@ -1794,7 +1794,7 @@ func testSetHead(t *testing.T, tt *rewindTest) {
 	if _, err := chain.InsertChain(canonblocks[tt.commitBlock:]); err != nil {
 		t.Fatalf("Failed to import canonical chain tail: %v", err)
 	}
-	// Manually dereference anything not comitted to not have to work with 128+ tries
+	// Manually dereference anything not committed to not have to work with 128+ tries
 	for _, block := range sideblocks {
 		chain.stateCache.TrieDB().Dereference(block.Root())
 	}

--- a/core/blockchain_sethead_test.go
+++ b/core/blockchain_sethead_test.go
@@ -1,0 +1,578 @@
+// Copyright 2020 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+// Tests that setting the chain head backwards doesn't leave the database in some
+// strange state with gaps in the chain, nor with block data dangling in the future.
+
+package core
+
+import (
+	"io/ioutil"
+	"math/big"
+	"os"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/consensus/ethash"
+	"github.com/ethereum/go-ethereum/core/rawdb"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/core/vm"
+	"github.com/ethereum/go-ethereum/params"
+)
+
+// setHeadTest is a test case for chain rollback upon user request.
+type setHeadTest struct {
+	canonicalBlocks int    // Number of blocks to generate for the canonical chain (heavier)
+	sidechainBlocks int    // Number of blocks to generate for the side chain (lighter)
+	freezeThreshold uint64 // Block number until which to move things into the freezer
+	commitBlock     uint64 // Block number for which to commit the state to disk
+	pivotBlock      uint64 // Pivot block number in case of fast sync
+
+	setheadBlock       uint64 // Block number to set head back to
+	expCanonicalBlocks int    // Number of canonical blocks expected to remain in the database
+	expSidechainBlocks int    // Number of sidechain blocks expected to remain in the database
+}
+
+// Tests a sethead for a short canonical chain where a recent block was already
+// comitted to disk and then the sethead called. In this case we expect the chain
+// to be rolled back to the committed block, with everything afterwads deleted.
+func TestShortSetHead(t *testing.T) {
+	testSetHead(t, &setHeadTest{
+		canonicalBlocks:    8,
+		sidechainBlocks:    0,
+		freezeThreshold:    16,
+		commitBlock:        4,
+		pivotBlock:         0,
+		setheadBlock:       7,
+		expCanonicalBlocks: 4,
+		expSidechainBlocks: 0,
+	})
+}
+
+// Tests a sethead for a short canonical chain where the fast sync pivot point was
+// already comitted, after which sethead was called. In this case we expect the
+// chain to behave like in full sync mode, rolling back to the committed block,
+// with everything afterwads deleted.
+func TestShortFastSyncedSetHead(t *testing.T) {
+	testSetHead(t, &setHeadTest{
+		canonicalBlocks:    8,
+		sidechainBlocks:    0,
+		freezeThreshold:    16,
+		commitBlock:        4,
+		pivotBlock:         4,
+		setheadBlock:       7,
+		expCanonicalBlocks: 4,
+		expSidechainBlocks: 0,
+	})
+}
+
+// Tests a sethead for a short canonical chain where the fast sync pivot point was
+// not yet comitted, but sethead was called. In this case we expect the chain to
+// detect that it was fast syncing and delete everything from the new head, since
+// we can just pick up fast syncing from there.
+func TestShortFastSyncingSetHead(t *testing.T) {
+	testSetHead(t, &setHeadTest{
+		canonicalBlocks:    8,
+		sidechainBlocks:    0,
+		freezeThreshold:    16,
+		commitBlock:        0,
+		pivotBlock:         4,
+		setheadBlock:       7,
+		expCanonicalBlocks: 7,
+		expSidechainBlocks: 0,
+	})
+}
+
+// Tests a sethead for a short canonical chain and a shorter side chain, where a
+// recent block was already comitted to disk and then sethead was called. In this
+// test scenario the side chain is below the commited block. In this case we expect
+// the canonical chain to be rolled back to the committed block, with everything
+// afterwads deleted; but the side chain left alone as it was shorter.
+func TestShortOldForkedSetHead(t *testing.T) {
+	testSetHead(t, &setHeadTest{
+		canonicalBlocks:    8,
+		sidechainBlocks:    3,
+		freezeThreshold:    16,
+		commitBlock:        4,
+		pivotBlock:         0,
+		setheadBlock:       7,
+		expCanonicalBlocks: 4,
+		expSidechainBlocks: 3,
+	})
+}
+
+// Tests a sethead for a short canonical chain and a shorter side chain, where
+// the fast sync pivot point was already comitted to disk and then sethead was
+// called. In this test scenario the side chain is below the commited block. In
+// this case we expect the canonical chain to be rolled back to the committed block,
+// with everything afterwads deleted; but the side chain left alone as it was shorter.
+func TestShortOldForkedFastSyncedSetHead(t *testing.T) {
+	testSetHead(t, &setHeadTest{
+		canonicalBlocks:    8,
+		sidechainBlocks:    3,
+		freezeThreshold:    16,
+		commitBlock:        4,
+		pivotBlock:         4,
+		setheadBlock:       7,
+		expCanonicalBlocks: 4,
+		expSidechainBlocks: 3,
+	})
+}
+
+// Tests a sethead for a short canonical chain and a shorter side chain, where
+// the fast sync pivot point was not yet comitted, but sethead was called. In this
+// test scenario the side chain is below the commited block. In this case we expect
+// the chain to detect that it was fast syncing and delete everything from the new
+// head, since we can just pick up fast syncing from there.
+func TestShortOldForkedFastSyncingSetHead(t *testing.T) {
+	testSetHead(t, &setHeadTest{
+		canonicalBlocks:    8,
+		sidechainBlocks:    3,
+		freezeThreshold:    16,
+		commitBlock:        0,
+		pivotBlock:         4,
+		setheadBlock:       7,
+		expCanonicalBlocks: 7,
+		expSidechainBlocks: 3,
+	})
+}
+
+// Tests a sethead for a short canonical chain and a shorter side chain, where a
+// recent block was already comitted to disk and then sethead was called. In this
+// test scenario the side chain reaches above the commited block. In this case we
+// expect both canonical and side chains to be rolled back to the committed block,
+// with everything afterwads deleted.
+//
+// The side chain could be left to be if the fork point was before the new head
+// we are deleting to, but it would be exceedingly hard to detect that case and
+// properly handle it, so we'll trade extra work in exchange for simpler code.
+func TestShortNewlyForkedSetHead(t *testing.T) {
+	testSetHead(t, &setHeadTest{
+		canonicalBlocks:    8,
+		sidechainBlocks:    6,
+		freezeThreshold:    16,
+		commitBlock:        4,
+		pivotBlock:         0,
+		setheadBlock:       7,
+		expCanonicalBlocks: 4,
+		expSidechainBlocks: 4,
+	})
+}
+
+// Tests a sethead for a short canonical chain and a shorter side chain, where
+// the fast sync pivot point was already comitted to disk and then sethead was
+// called. In this test scenario the side chain reaches above the commited block.
+// In this case we expect both canonical and side chains to be rolled back to the
+// committed block, with everything afterwads deleted.
+//
+// The side chain could be left to be if the fork point was before the new head
+// we are deleting to, but it would be exceedingly hard to detect that case and
+// properly handle it, so we'll trade extra work in exchange for simpler code.
+func TestShortNewlyForkedFastSyncedSetHead(t *testing.T) {
+	testSetHead(t, &setHeadTest{
+		canonicalBlocks:    8,
+		sidechainBlocks:    6,
+		freezeThreshold:    16,
+		commitBlock:        4,
+		pivotBlock:         4,
+		setheadBlock:       7,
+		expCanonicalBlocks: 4,
+		expSidechainBlocks: 4,
+	})
+}
+
+// Tests a sethead for a short canonical chain and a shorter side chain, where
+// the fast sync pivot point was not yet comitted, but sethead was called. In
+// this test scenario the side chain reaches above the commited block. In this
+// case we expect the chain to detect that it was fast syncing and delete
+// everything from the new head, since we can just pick up fast syncing from
+// there.
+//
+// The side chain could be left to be if the fork point was before the new head
+// we are deleting to, but it would be exceedingly hard to detect that case and
+// properly handle it, so we'll trade extra work in exchange for simpler code.
+func TestShortNewlyForkedFastSyncingSetHead(t *testing.T) {
+	testSetHead(t, &setHeadTest{
+		canonicalBlocks:    8,
+		sidechainBlocks:    6,
+		freezeThreshold:    16,
+		commitBlock:        0,
+		pivotBlock:         4,
+		setheadBlock:       5,
+		expCanonicalBlocks: 5,
+		expSidechainBlocks: 5,
+	})
+}
+
+// Tests a sethead for a short canonical chain and a longer side chain, where a
+// recent block was already comitted to disk and then sethead was called. In this
+// case we expect both canonical and side chains to be rolled back to the committed
+// block, with everything afterwads deleted.
+//
+// The side chain could be left to be if the fork point was before the new head
+// we are deleting to, but it would be exceedingly hard to detect that case and
+// properly handle it, so we'll trade extra work in exchange for simpler code.
+func TestShortReorgedSetHead(t *testing.T) {
+	testSetHead(t, &setHeadTest{
+		canonicalBlocks:    8,
+		sidechainBlocks:    10,
+		freezeThreshold:    16,
+		commitBlock:        4,
+		pivotBlock:         0,
+		setheadBlock:       7,
+		expCanonicalBlocks: 4,
+		expSidechainBlocks: 4,
+	})
+}
+
+// Tests a sethead for a short canonical chain and a longer side chain, where
+// the fast sync pivot point was already comitted to disk and then sethead was
+// called. In this case we expect both canonical and side chains to be rolled
+// back to the committed block, with everything afterwads deleted.
+//
+// The side chain could be left to be if the fork point was before the new head
+// we are deleting to, but it would be exceedingly hard to detect that case and
+// properly handle it, so we'll trade extra work in exchange for simpler code.
+func TestShortReorgedFastSyncedSetHead(t *testing.T) {
+	testSetHead(t, &setHeadTest{
+		canonicalBlocks:    8,
+		sidechainBlocks:    10,
+		freezeThreshold:    16,
+		commitBlock:        4,
+		pivotBlock:         4,
+		setheadBlock:       7,
+		expCanonicalBlocks: 4,
+		expSidechainBlocks: 4,
+	})
+}
+
+// Tests a sethead for a short canonical chain and a longer side chain, where
+// the fast sync pivot point was not yet comitted, but sethead was called. In
+// this case we expect the chain to detect that it was fast syncing and delete
+// everything from the new head, since we can just pick up fast syncing from
+// there.
+//
+// The side chain could be left to be if the fork point was before the new head
+// we are deleting to, but it would be exceedingly hard to detect that case and
+// properly handle it, so we'll trade extra work in exchange for simpler code.
+func TestShortReorgedFastSyncingSetHead(t *testing.T) {
+	testSetHead(t, &setHeadTest{
+		canonicalBlocks:    8,
+		sidechainBlocks:    10,
+		freezeThreshold:    16,
+		commitBlock:        0,
+		pivotBlock:         4,
+		setheadBlock:       7,
+		expCanonicalBlocks: 7,
+		expSidechainBlocks: 7,
+	})
+}
+
+// Tests a sethead for a long canonical chain with frozen blocks where a recent
+// block - older than the ancient limit - was already comitted to disk and then
+// sethead was called. In this case we expect the chain to be rolled back to the
+// committed block, with everything afterwads deleted.
+func TestLongSetHead(t *testing.T) {
+	testSetHead(t, &setHeadTest{
+		canonicalBlocks:    24,
+		sidechainBlocks:    0,
+		freezeThreshold:    16,
+		commitBlock:        4,
+		pivotBlock:         0,
+		setheadBlock:       6,
+		expCanonicalBlocks: 4,
+		expSidechainBlocks: 0,
+	})
+}
+
+// Tests a sethead for a long canonical chain with frozen blocks where the fast
+// sync pivot point - older than the ancient limit - was already comitted, after
+// which sethead was called. In this case we expect the chain to behave like in
+// full sync mode, rolling back to the committed block, with everything afterwads
+// deleted.
+func TestLongFastSyncedSetHead(t *testing.T) {
+	testSetHead(t, &setHeadTest{
+		canonicalBlocks:    24,
+		sidechainBlocks:    0,
+		freezeThreshold:    16,
+		commitBlock:        4,
+		pivotBlock:         4,
+		setheadBlock:       6,
+		expCanonicalBlocks: 4,
+		expSidechainBlocks: 0,
+	})
+}
+
+// Tests a sethead for a long canonical chain with frozen blocks where the fast
+// sync pivot point - older than the ancient limit - was not yet comitted, but
+// sethead was called. In this case we expect the chain to detect that it was fast
+// syncing and delete everything from the new head, since we can just pick up fast
+// syncing from there.
+func TestLongFastSyncingSetHead(t *testing.T) {
+	testSetHead(t, &setHeadTest{
+		canonicalBlocks:    24,
+		sidechainBlocks:    0,
+		freezeThreshold:    16,
+		commitBlock:        0,
+		pivotBlock:         4,
+		setheadBlock:       6,
+		expCanonicalBlocks: 6,
+		expSidechainBlocks: 0,
+	})
+}
+
+// Tests a sethead for a long canonical chain with frozen blocks and a shorter
+// side chain, where a recent block - older than the ancient limit - was already
+// comitted to disk and then sethead was called. In this test scenario the side
+// chain is below the commited block. In this case we expect the canonical chain
+// to be rolled back to the committed block, with everything afterwads deleted;
+// the side chain completely nuked by the freezer.
+func TestLongOldForkedSetHead(t *testing.T) {
+	testSetHead(t, &setHeadTest{
+		canonicalBlocks:    24,
+		sidechainBlocks:    3,
+		freezeThreshold:    16,
+		commitBlock:        4,
+		pivotBlock:         0,
+		setheadBlock:       6,
+		expCanonicalBlocks: 4,
+		expSidechainBlocks: 0,
+	})
+}
+
+// Tests a sethead for a long canonical chain with frozen blocks and a shorter
+// side chain, where the fast sync pivot point - older than the ancient limit -
+// was already comitted to disk and then sethead was called. In this test scenario
+// the side chain is below the commited block. In this case we expect the canonical
+// chain to be rolled back to the committed block, with everything afterwads deleted;
+// the side chain completely nuked by the freezer.
+func TestLongOldForkedFastSyncedSetHead(t *testing.T) {
+	testSetHead(t, &setHeadTest{
+		canonicalBlocks:    24,
+		sidechainBlocks:    3,
+		freezeThreshold:    16,
+		commitBlock:        4,
+		pivotBlock:         4,
+		setheadBlock:       6,
+		expCanonicalBlocks: 4,
+		expSidechainBlocks: 0,
+	})
+}
+
+// Tests a sethead for a long canonical chain with frozen blocks and a shorter
+// side chain, where the fast sync pivot point - older than the ancient limit -
+// was not yet comitted, but sethead was called. In this test scenario the side
+// chain is below the commited block. In this case we expect the chain to detect
+// that it was fast syncing and delete everything from the new head, since we can
+// just pick up fast syncing from there. The side chin is completely nuked by the
+// freezer.
+func TestLongOldForkedFastSyncingSetHead(t *testing.T) {
+	testSetHead(t, &setHeadTest{
+		canonicalBlocks:    24,
+		sidechainBlocks:    3,
+		freezeThreshold:    16,
+		commitBlock:        0,
+		pivotBlock:         4,
+		setheadBlock:       6,
+		expCanonicalBlocks: 6,
+		expSidechainBlocks: 0,
+	})
+}
+
+// Tests a sethead for a long canonical chain with frozen blocks and a shorter
+// side chain, where a recent block - older than the ancient limit - was already
+// comitted to disk and then sethead was called. In this test scenario the side
+// chain is above the commited block. In this case we expect the canonical chain
+// to be rolled back to the committed block, with everything afterwads deleted;
+// the side chain completely nuked by the freezer.
+func TestLongNewerForkedSetHead(t *testing.T) {
+	testSetHead(t, &setHeadTest{
+		canonicalBlocks:    24,
+		sidechainBlocks:    12,
+		freezeThreshold:    16,
+		commitBlock:        4,
+		pivotBlock:         0,
+		setheadBlock:       6,
+		expCanonicalBlocks: 4,
+		expSidechainBlocks: 0,
+	})
+}
+
+// Tests a sethead for a long canonical chain with frozen blocks and a shorter
+// side chain, where the fast sync pivot point - older than the ancient limit -
+// was already comitted to disk and then sethead was called. In this test scenario
+// the side chain is above the commited block. In this case we expect the canonical
+// chain to be rolled back to the committed block, with everything afterwads deleted;
+// the side chain completely nuked by the freezer.
+func TestLongNewerForkedFastSyncedSetHead(t *testing.T) {
+	testSetHead(t, &setHeadTest{
+		canonicalBlocks:    24,
+		sidechainBlocks:    12,
+		freezeThreshold:    16,
+		commitBlock:        4,
+		pivotBlock:         4,
+		setheadBlock:       6,
+		expCanonicalBlocks: 4,
+		expSidechainBlocks: 0,
+	})
+}
+
+// Tests a sethead for a long canonical chain with frozen blocks and a shorter
+// side chain, where the fast sync pivot point - older than the ancient limit -
+// was not yet comitted, but sethead was called. In this test scenario the side
+// chain is above the commited block. In this case we expect the chain to detect
+// that it was fast syncing and delete everything from the new head, since we can
+// just pick up fast syncing from there. The side chain is completely nuked by
+// the freezer.
+func TestLongNewerForkedFastSyncingSetHead(t *testing.T) {
+	testSetHead(t, &setHeadTest{
+		canonicalBlocks:    24,
+		sidechainBlocks:    12,
+		freezeThreshold:    16,
+		commitBlock:        0,
+		pivotBlock:         4,
+		setheadBlock:       6,
+		expCanonicalBlocks: 6,
+		expSidechainBlocks: 0,
+	})
+}
+
+// Tests a sethead for a long canonical chain with frozen blocks and a longer side
+// chain, where a recent block - older than the ancient limit - was already comitted
+// to disk and then sethead was called. In this case we expect the canonical chains
+// to be rolled back to the committed block, with everything afterwads deleted. The
+// side chain completely nuked by the freezer.
+//
+// The side chain could be left to be if the fork point was before the new head
+// we are deleting to, but it would be exceedingly hard to detect that case and
+// properly handle it, so we'll trade extra work in exchange for simpler code.
+func TestLongReorgedSetHead(t *testing.T) {
+	testSetHead(t, &setHeadTest{
+		canonicalBlocks:    24,
+		sidechainBlocks:    26,
+		freezeThreshold:    16,
+		commitBlock:        4,
+		pivotBlock:         0,
+		setheadBlock:       6,
+		expCanonicalBlocks: 4,
+		expSidechainBlocks: 0,
+	})
+}
+
+// Tests a sethead for a long canonical chain with frozen blocks and a longer
+// side chain, where the fast sync pivot point - older than the ancient limit -
+// was already comitted to disk and then sethead was called. In this case we
+// expect the canonical chains to be rolled back to the committed block, with
+// everything afterwads deleted. The side chain completely nuked by the freezer.
+//
+// The side chain could be left to be if the fork point was before the new head
+// we are deleting to, but it would be exceedingly hard to detect that case and
+// properly handle it, so we'll trade extra work in exchange for simpler code.
+func TestLongReorgedFastSyncedSetHead(t *testing.T) {
+	testSetHead(t, &setHeadTest{
+		canonicalBlocks:    24,
+		sidechainBlocks:    26,
+		freezeThreshold:    16,
+		commitBlock:        4,
+		pivotBlock:         4,
+		setheadBlock:       6,
+		expCanonicalBlocks: 4,
+		expSidechainBlocks: 0,
+	})
+}
+
+// Tests a sethead for a long canonical chain with frozen blocks and a longer
+// side chain, where the fast sync pivot point - older than the ancient limit -
+// was not yet comitted, but sethead was called. In this case we expect the
+// chain to detect that it was fast syncing and delete everything from the new
+// head, since we can just pick up fast syncing from there. The side chain is
+// completely nuked by the freezer.
+func TestLongReorgedFastSyncingSetHead(t *testing.T) {
+	testSetHead(t, &setHeadTest{
+		canonicalBlocks:    24,
+		sidechainBlocks:    26,
+		freezeThreshold:    16,
+		commitBlock:        0,
+		pivotBlock:         4,
+		setheadBlock:       6,
+		expCanonicalBlocks: 6,
+		expSidechainBlocks: 0,
+	})
+}
+
+func testSetHead(t *testing.T, tt *setHeadTest) {
+	//log.Root().SetHandler(log.LvlFilterHandler(log.LvlTrace, log.StreamHandler(os.Stderr, log.TerminalFormat(true))))
+
+	// Create a temporary persistent database
+	datadir, err := ioutil.TempDir("", "")
+	if err != nil {
+		t.Fatalf("Failed to create temporary datadir: %v", err)
+	}
+	os.RemoveAll(datadir)
+
+	db, err := rawdb.NewLevelDBDatabaseWithFreezer(datadir, 0, 0, datadir, "")
+	if err != nil {
+		t.Fatalf("Failed to create persistent database: %v", err)
+	}
+	defer db.Close()
+
+	// Initialize a fresh chain
+	var (
+		genesis = new(Genesis).MustCommit(db)
+		engine  = ethash.NewFullFaker()
+	)
+	chain, err := NewBlockChain(db, nil, params.AllEthashProtocolChanges, engine, vm.Config{}, nil, nil)
+	if err != nil {
+		t.Fatalf("Failed to create chain: %v", err)
+	}
+	// If sidechain blocks are needed, make a light chain and import it
+	var sideblocks types.Blocks
+	if tt.sidechainBlocks > 0 {
+		sideblocks, _ = GenerateChain(params.TestChainConfig, genesis, engine, rawdb.NewMemoryDatabase(), tt.sidechainBlocks, func(i int, b *BlockGen) {
+			b.SetCoinbase(common.Address{0x01})
+		})
+		if _, err := chain.InsertChain(sideblocks); err != nil {
+			t.Fatalf("Failed to import side chain: %v", err)
+		}
+	}
+	canonblocks, _ := GenerateChain(params.TestChainConfig, genesis, engine, rawdb.NewMemoryDatabase(), tt.canonicalBlocks, func(i int, b *BlockGen) {
+		b.SetCoinbase(common.Address{0x02})
+		b.SetDifficulty(big.NewInt(1000000))
+	})
+	if _, err := chain.InsertChain(canonblocks[:tt.commitBlock]); err != nil {
+		t.Fatalf("Failed to import canonical chain start: %v", err)
+	}
+	if tt.commitBlock > 0 {
+		chain.stateCache.TrieDB().Commit(canonblocks[tt.commitBlock-1].Root(), true, nil)
+	}
+	if _, err := chain.InsertChain(canonblocks[tt.commitBlock:]); err != nil {
+		t.Fatalf("Failed to import canonical chain tail: %v", err)
+	}
+	// Force run a freeze cycle
+	type freezer interface {
+		Freeze(threshold uint64)
+	}
+	db.(freezer).Freeze(tt.freezeThreshold)
+
+	// Set the head of the chain back to the requested number
+	chain.SetHead(tt.setheadBlock)
+
+	// Iterate over all the remaining blocks and ensure there are no gaps
+	verifyNoGaps(t, chain, true, canonblocks)
+	verifyNoGaps(t, chain, false, sideblocks)
+	verifyCutoff(t, chain, true, canonblocks, tt.expCanonicalBlocks)
+	verifyCutoff(t, chain, false, sideblocks, tt.expSidechainBlocks)
+}

--- a/core/blockchain_test.go
+++ b/core/blockchain_test.go
@@ -731,12 +731,12 @@ func TestLightVsFastVsFullChainHeads(t *testing.T) {
 		return db, func() { os.RemoveAll(dir) }
 	}
 	// Configure a subchain to roll back
-	remove := []common.Hash{}
-	for _, block := range blocks[height/2:] {
-		remove = append(remove, block.Hash())
-	}
+	remove := blocks[height/2].NumberU64()
+
 	// Create a small assertion method to check the three heads
 	assert := func(t *testing.T, kind string, chain *BlockChain, header uint64, fast uint64, block uint64) {
+		t.Helper()
+
 		if num := chain.CurrentBlock().NumberU64(); num != block {
 			t.Errorf("%s head block mismatch: have #%v, want #%v", kind, num, block)
 		}
@@ -750,14 +750,18 @@ func TestLightVsFastVsFullChainHeads(t *testing.T) {
 	// Import the chain as an archive node and ensure all pointers are updated
 	archiveDb, delfn := makeDb()
 	defer delfn()
-	archive, _ := NewBlockChain(archiveDb, nil, gspec.Config, ethash.NewFaker(), vm.Config{}, nil, nil)
+
+	archiveCaching := *defaultCacheConfig
+	archiveCaching.TrieDirtyDisabled = true
+
+	archive, _ := NewBlockChain(archiveDb, &archiveCaching, gspec.Config, ethash.NewFaker(), vm.Config{}, nil, nil)
 	if n, err := archive.InsertChain(blocks); err != nil {
 		t.Fatalf("failed to process block %d: %v", n, err)
 	}
 	defer archive.Stop()
 
 	assert(t, "archive", archive, height, height, height)
-	archive.Rollback(remove)
+	archive.SetHead(remove - 1)
 	assert(t, "archive", archive, height/2, height/2, height/2)
 
 	// Import the chain as a non-archive node and ensure all pointers are updated
@@ -777,7 +781,7 @@ func TestLightVsFastVsFullChainHeads(t *testing.T) {
 		t.Fatalf("failed to insert receipt %d: %v", n, err)
 	}
 	assert(t, "fast", fast, height, height, 0)
-	fast.Rollback(remove)
+	fast.SetHead(remove - 1)
 	assert(t, "fast", fast, height/2, height/2, 0)
 
 	// Import the chain as a ancient-first node and ensure all pointers are updated
@@ -793,12 +797,12 @@ func TestLightVsFastVsFullChainHeads(t *testing.T) {
 		t.Fatalf("failed to insert receipt %d: %v", n, err)
 	}
 	assert(t, "ancient", ancient, height, height, 0)
-	ancient.Rollback(remove)
-	assert(t, "ancient", ancient, height/2, height/2, 0)
-	if frozen, err := ancientDb.Ancients(); err != nil || frozen != height/2+1 {
-		t.Fatalf("failed to truncate ancient store, want %v, have %v", height/2+1, frozen)
-	}
+	ancient.SetHead(remove - 1)
+	assert(t, "ancient", ancient, 0, 0, 0)
 
+	if frozen, err := ancientDb.Ancients(); err != nil || frozen != 1 {
+		t.Fatalf("failed to truncate ancient store, want %v, have %v", 1, frozen)
+	}
 	// Import the chain as a light node and ensure all pointers are updated
 	lightDb, delfn := makeDb()
 	defer delfn()
@@ -809,7 +813,7 @@ func TestLightVsFastVsFullChainHeads(t *testing.T) {
 	defer light.Stop()
 
 	assert(t, "light", light, height, 0, 0)
-	light.Rollback(remove)
+	light.SetHead(remove - 1)
 	assert(t, "light", light, height/2, 0, 0)
 }
 
@@ -1617,8 +1621,8 @@ func TestBlockchainRecovery(t *testing.T) {
 	if num := ancient.CurrentFastBlock().NumberU64(); num != midBlock.NumberU64() {
 		t.Errorf("head fast-block mismatch: have #%v, want #%v", num, midBlock.NumberU64())
 	}
-	if num := ancient.CurrentHeader().Number.Uint64(); num != midBlock.NumberU64() {
-		t.Errorf("head header mismatch: have #%v, want #%v", num, midBlock.NumberU64())
+	if num := ancient.CurrentHeader().Number.Uint64(); num != blocks[len(blocks)-1].NumberU64() {
+		t.Errorf("head header mismatch: have #%v, want #%v", num, blocks[len(blocks)-1].NumberU64())
 	}
 }
 
@@ -1912,11 +1916,9 @@ func testInsertKnownChainData(t *testing.T, typ string) {
 	asserter(t, blocks[len(blocks)-1])
 
 	// Import a long canonical chain with some known data as prefix.
-	var rollback []common.Hash
-	for i := len(blocks) / 2; i < len(blocks); i++ {
-		rollback = append(rollback, blocks[i].Hash())
-	}
-	chain.Rollback(rollback)
+	rollback := blocks[len(blocks)/2].NumberU64()
+
+	chain.SetHead(rollback - 1)
 	if err := inserter(append(blocks, blocks2...), append(receipts, receipts2...)); err != nil {
 		t.Fatalf("failed to insert chain data: %v", err)
 	}
@@ -1936,11 +1938,7 @@ func testInsertKnownChainData(t *testing.T, typ string) {
 	asserter(t, blocks3[len(blocks3)-1])
 
 	// Rollback the heavier chain and re-insert the longer chain again
-	for i := 0; i < len(blocks3); i++ {
-		rollback = append(rollback, blocks3[i].Hash())
-	}
-	chain.Rollback(rollback)
-
+	chain.SetHead(rollback - 1)
 	if err := inserter(append(blocks, blocks2...), append(receipts, receipts2...)); err != nil {
 		t.Fatalf("failed to insert chain data: %v", err)
 	}

--- a/core/blockchain_test.go
+++ b/core/blockchain_test.go
@@ -1589,6 +1589,7 @@ func TestBlockchainRecovery(t *testing.T) {
 		t.Fatalf("failed to create temp freezer dir: %v", err)
 	}
 	defer os.Remove(frdir)
+
 	ancientDb, err := rawdb.NewDatabaseWithFreezer(rawdb.NewMemoryDatabase(), frdir, "")
 	if err != nil {
 		t.Fatalf("failed to create temp freezer db: %v", err)
@@ -1606,6 +1607,7 @@ func TestBlockchainRecovery(t *testing.T) {
 	if n, err := ancient.InsertReceiptChain(blocks, receipts, uint64(3*len(blocks)/4)); err != nil {
 		t.Fatalf("failed to insert receipt %d: %v", n, err)
 	}
+	rawdb.WriteLastPivotNumber(ancientDb, blocks[len(blocks)-1].NumberU64()) // Force fast sync behavior
 	ancient.Stop()
 
 	// Destroy head fast block manually
@@ -1621,8 +1623,8 @@ func TestBlockchainRecovery(t *testing.T) {
 	if num := ancient.CurrentFastBlock().NumberU64(); num != midBlock.NumberU64() {
 		t.Errorf("head fast-block mismatch: have #%v, want #%v", num, midBlock.NumberU64())
 	}
-	if num := ancient.CurrentHeader().Number.Uint64(); num != blocks[len(blocks)-1].NumberU64() {
-		t.Errorf("head header mismatch: have #%v, want #%v", num, blocks[len(blocks)-1].NumberU64())
+	if num := ancient.CurrentHeader().Number.Uint64(); num != midBlock.NumberU64() {
+		t.Errorf("head header mismatch: have #%v, want #%v", num, midBlock.NumberU64())
 	}
 }
 

--- a/core/headerchain.go
+++ b/core/headerchain.go
@@ -488,8 +488,10 @@ func (hc *HeaderChain) SetCurrentHeader(head *types.Header) {
 
 type (
 	// UpdateHeadBlocksCallback is a callback function that is called by SetHead
-	// before head header is updated.
-	UpdateHeadBlocksCallback func(ethdb.KeyValueWriter, *types.Header)
+	// before head header is updated. The method will return the actual block it
+	// updated the head to (missing state) and a flag if setHead should continue
+	// rewinding till that forcefully (exceeded ancient limits)
+	UpdateHeadBlocksCallback func(ethdb.KeyValueWriter, *types.Header) (uint64, bool)
 
 	// DeleteBlockContentCallback is a callback function that is called by SetHead
 	// before each header is deleted.
@@ -502,9 +504,10 @@ func (hc *HeaderChain) SetHead(head uint64, updateFn UpdateHeadBlocksCallback, d
 	var (
 		parentHash common.Hash
 		batch      = hc.chainDb.NewBatch()
+		origin     = true
 	)
 	for hdr := hc.CurrentHeader(); hdr != nil && hdr.Number.Uint64() > head; hdr = hc.CurrentHeader() {
-		hash, num := hdr.Hash(), hdr.Number.Uint64()
+		num := hdr.Number.Uint64()
 
 		// Rewind block chain to new head.
 		parent := hc.GetHeader(hdr.ParentHash, num-1)
@@ -522,7 +525,11 @@ func (hc *HeaderChain) SetHead(head uint64, updateFn UpdateHeadBlocksCallback, d
 		// Update head first(head fast block, head full block) before deleting the data.
 		markerBatch := hc.chainDb.NewBatch()
 		if updateFn != nil {
-			updateFn(markerBatch, parent)
+			newHead, force := updateFn(markerBatch, parent)
+			if force && newHead < head {
+				log.Warn("Force rewiding till ancient limit", "head", newHead)
+				head = newHead
+			}
 		}
 		// Update head header then.
 		rawdb.WriteHeadHeaderHash(markerBatch, parentHash)
@@ -533,14 +540,34 @@ func (hc *HeaderChain) SetHead(head uint64, updateFn UpdateHeadBlocksCallback, d
 		hc.currentHeaderHash = parentHash
 		headHeaderGauge.Update(parent.Number.Int64())
 
-		// Remove the relative data from the database.
-		if delFn != nil {
-			delFn(batch, hash, num)
+		// If this is the first iteration, wipe any leftover data upwards too so
+		// we don't end up with dangling daps in the database
+		var nums []uint64
+		if origin {
+			for n := num + 1; len(rawdb.ReadAllHashes(hc.chainDb, n)) > 0; n++ {
+				nums = append([]uint64{n}, nums...) // suboptimal, but we don't really expect this path
+			}
+			origin = false
 		}
-		// Rewind header chain to new head.
-		rawdb.DeleteHeader(batch, hash, num)
-		rawdb.DeleteTd(batch, hash, num)
-		rawdb.DeleteCanonicalHash(batch, num)
+		nums = append(nums, num)
+
+		// Remove the related data from the database on all sidechains
+		for _, num := range nums {
+			// Gather all the side fork hashes
+			hashes := rawdb.ReadAllHashes(hc.chainDb, num)
+			if len(hashes) == 0 {
+				// No hashes in the database whatsoever, probably frozen already
+				hashes = append(hashes, hdr.Hash())
+			}
+			for _, hash := range hashes {
+				if delFn != nil {
+					delFn(batch, hash, num)
+				}
+				rawdb.DeleteHeader(batch, hash, num)
+				rawdb.DeleteTd(batch, hash, num)
+			}
+			rawdb.DeleteCanonicalHash(batch, num)
+		}
 	}
 	// Flush all accumulated deletions.
 	if err := batch.Write(); err != nil {

--- a/core/headerchain.go
+++ b/core/headerchain.go
@@ -527,7 +527,7 @@ func (hc *HeaderChain) SetHead(head uint64, updateFn UpdateHeadBlocksCallback, d
 		if updateFn != nil {
 			newHead, force := updateFn(markerBatch, parent)
 			if force && newHead < head {
-				log.Warn("Force rewiding till ancient limit", "head", newHead)
+				log.Warn("Force rewinding till ancient limit", "head", newHead)
 				head = newHead
 			}
 		}

--- a/core/headerchain.go
+++ b/core/headerchain.go
@@ -512,10 +512,11 @@ func (hc *HeaderChain) SetHead(head uint64, updateFn UpdateHeadBlocksCallback, d
 			parent = hc.genesisHeader
 		}
 		parentHash = hdr.ParentHash
+
 		// Notably, since geth has the possibility for setting the head to a low
 		// height which is even lower than ancient head.
 		// In order to ensure that the head is always no higher than the data in
-		// the database(ancient store or active store), we need to update head
+		// the database (ancient store or active store), we need to update head
 		// first then remove the relative data from the database.
 		//
 		// Update head first(head fast block, head full block) before deleting the data.

--- a/core/rawdb/accessors_chain.go
+++ b/core/rawdb/accessors_chain.go
@@ -187,6 +187,32 @@ func WriteHeadFastBlockHash(db ethdb.KeyValueWriter, hash common.Hash) {
 	}
 }
 
+// ReadLastPivotNumber retrieves the number of the last pivot block. If the node
+// full synced, the last pivot will always be nil.
+func ReadLastPivotNumber(db ethdb.KeyValueReader) *uint64 {
+	data, _ := db.Get(lastPivotKey)
+	if len(data) == 0 {
+		return nil
+	}
+	var pivot uint64
+	if err := rlp.DecodeBytes(data, &pivot); err != nil {
+		log.Error("Invalid pivot block number in database", "err", err)
+		return nil
+	}
+	return &pivot
+}
+
+// WriteLastPivotNumber stores the number of the last pivot block.
+func WriteLastPivotNumber(db ethdb.KeyValueWriter, pivot uint64) {
+	enc, err := rlp.EncodeToBytes(pivot)
+	if err != nil {
+		log.Crit("Failed to encode pivot block number", "err", err)
+	}
+	if err := db.Put(lastPivotKey, enc); err != nil {
+		log.Crit("Failed to store pivot block number", "err", err)
+	}
+}
+
 // ReadFastTrieProgress retrieves the number of tries nodes fast synced to allow
 // reporting correct numbers across restarts.
 func ReadFastTrieProgress(db ethdb.KeyValueReader) uint64 {

--- a/core/rawdb/schema.go
+++ b/core/rawdb/schema.go
@@ -38,6 +38,9 @@ var (
 	// headFastBlockKey tracks the latest known incomplete block's hash during fast sync.
 	headFastBlockKey = []byte("LastFast")
 
+	// lastPivotKey tracks the last pivot block used by fast sync (to reenable on sethead).
+	lastPivotKey = []byte("LastPivot")
+
 	// fastTrieProgressKey tracks the number of trie entries imported during fast sync.
 	fastTrieProgressKey = []byte("TrieSync")
 

--- a/eth/downloader/downloader.go
+++ b/eth/downloader/downloader.go
@@ -176,8 +176,8 @@ type LightChain interface {
 	// InsertHeaderChain inserts a batch of headers into the local chain.
 	InsertHeaderChain([]*types.Header, int) (int, error)
 
-	// Rollback removes a few recently added elements from the local chain.
-	Rollback([]common.Hash)
+	// SetHead rewinds the local chain to a new head.
+	SetHead(uint64) error
 }
 
 // BlockChain encapsulates functions required to sync a (full or fast) blockchain.
@@ -469,6 +469,9 @@ func (d *Downloader) syncWithPeer(p *peerConnection, hash common.Hash, td *big.I
 			if pivot <= origin {
 				origin = pivot - 1
 			}
+			// Write out the pivot into the database so a rollback beyond it will
+			// reenable fast sync
+			rawdb.WriteLastPivotNumber(d.stateDB, pivot)
 		}
 	}
 	d.committed = 1
@@ -496,6 +499,7 @@ func (d *Downloader) syncWithPeer(p *peerConnection, hash common.Hash, td *big.I
 			d.ancientLimit = height - fullMaxForkAncestry - 1
 		}
 		frozen, _ := d.stateDB.Ancients() // Ignore the error here since light client can also hit here.
+
 		// If a part of blockchain data has already been written into active store,
 		// disable the ancient style insertion explicitly.
 		if origin >= frozen && frozen != 0 {
@@ -506,11 +510,9 @@ func (d *Downloader) syncWithPeer(p *peerConnection, hash common.Hash, td *big.I
 		}
 		// Rewind the ancient store and blockchain if reorg happens.
 		if origin+1 < frozen {
-			var hashes []common.Hash
-			for i := origin + 1; i < d.lightchain.CurrentHeader().Number.Uint64(); i++ {
-				hashes = append(hashes, rawdb.ReadCanonicalHash(d.stateDB, i))
+			if err := d.lightchain.SetHead(origin + 1); err != nil {
+				return err
 			}
-			d.lightchain.Rollback(hashes)
 		}
 	}
 	// Initiate the sync using a concurrent header and content retrieval algorithm
@@ -1382,35 +1384,32 @@ func (d *Downloader) fetchParts(deliveryCh chan dataPack, deliver func(dataPack)
 func (d *Downloader) processHeaders(origin uint64, pivot uint64, td *big.Int) error {
 	// Keep a count of uncertain headers to roll back
 	var (
-		rollback    []*types.Header
+		rollback    uint64 // Zero means no rollback (fine as you can't unroll the genesis)
 		rollbackErr error
 		mode        = d.getMode()
 	)
 	defer func() {
-		if len(rollback) > 0 {
-			// Flatten the headers and roll them back
-			hashes := make([]common.Hash, len(rollback))
-			for i, header := range rollback {
-				hashes[i] = header.Hash()
-			}
+		if rollback > 0 {
 			lastHeader, lastFastBlock, lastBlock := d.lightchain.CurrentHeader().Number, common.Big0, common.Big0
 			if mode != LightSync {
 				lastFastBlock = d.blockchain.CurrentFastBlock().Number()
 				lastBlock = d.blockchain.CurrentBlock().Number()
 			}
-			d.lightchain.Rollback(hashes)
+			if err := d.lightchain.SetHead(rollback - 1); err != nil { // -1 to target the parent of the first uncertain block
+				// We're already unwinding the stack, only print the error to make it more visible
+				log.Error("Failed to roll back chain segment", "head", rollback-1, "err", err)
+			}
 			curFastBlock, curBlock := common.Big0, common.Big0
 			if mode != LightSync {
 				curFastBlock = d.blockchain.CurrentFastBlock().Number()
 				curBlock = d.blockchain.CurrentBlock().Number()
 			}
-			log.Warn("Rolled back headers", "count", len(hashes),
+			log.Warn("Rolled back chain segment",
 				"header", fmt.Sprintf("%d->%d", lastHeader, d.lightchain.CurrentHeader().Number),
 				"fast", fmt.Sprintf("%d->%d", lastFastBlock, curFastBlock),
 				"block", fmt.Sprintf("%d->%d", lastBlock, curBlock), "reason", rollbackErr)
 		}
 	}()
-
 	// Wait for batches of headers to process
 	gotHeaders := false
 
@@ -1462,7 +1461,7 @@ func (d *Downloader) processHeaders(origin uint64, pivot uint64, td *big.Int) er
 					}
 				}
 				// Disable any rollback and return
-				rollback = nil
+				rollback = 0
 				return nil
 			}
 			// Otherwise split the chunk of headers into batches and process them
@@ -1481,15 +1480,9 @@ func (d *Downloader) processHeaders(origin uint64, pivot uint64, td *big.Int) er
 					limit = len(headers)
 				}
 				chunk := headers[:limit]
+
 				// In case of header only syncing, validate the chunk immediately
 				if mode == FastSync || mode == LightSync {
-					// Collect the yet unknown headers to mark them as uncertain
-					unknown := make([]*types.Header, 0, len(chunk))
-					for _, header := range chunk {
-						if !d.lightchain.HasHeader(header.Hash(), header.Number.Uint64()) {
-							unknown = append(unknown, header)
-						}
-					}
 					// If we're importing pure headers, verify based on their recentness
 					frequency := fsHeaderCheckFrequency
 					if chunk[len(chunk)-1].Number.Uint64()+uint64(fsHeaderForceVerify) > pivot {
@@ -1497,17 +1490,18 @@ func (d *Downloader) processHeaders(origin uint64, pivot uint64, td *big.Int) er
 					}
 					if n, err := d.lightchain.InsertHeaderChain(chunk, frequency); err != nil {
 						rollbackErr = err
-						// If some headers were inserted, add them too to the rollback list
-						if n > 0 {
-							rollback = append(rollback, chunk[:n]...)
+
+						// If some headers were inserted, track them as uncertain
+						if n > 0 && rollback == 0 {
+							rollback = chunk[0].Number.Uint64()
 						}
 						log.Debug("Invalid header encountered", "number", chunk[n].Number, "hash", chunk[n].Hash(), "parent", chunk[n].ParentHash, "err", err)
 						return fmt.Errorf("%w: %v", errInvalidChain, err)
 					}
-					// All verifications passed, store newly found uncertain headers
-					rollback = append(rollback, unknown...)
-					if len(rollback) > fsHeaderSafetyNet {
-						rollback = append(rollback[:0], rollback[len(rollback)-fsHeaderSafetyNet:]...)
+					// All verifications passed, track all headers within the alloted limits
+					head := chunk[len(chunk)-1].Number.Uint64()
+					if head-rollback > uint64(fsHeaderSafetyNet) {
+						rollback = head - uint64(fsHeaderSafetyNet)
 					}
 				}
 				// Unless we're doing light chains, schedule the headers for associated content retrieval

--- a/eth/downloader/downloader.go
+++ b/eth/downloader/downloader.go
@@ -1607,6 +1607,7 @@ func (d *Downloader) processFastSyncContent(latest *types.Header) error {
 		}
 	}
 	go closeOnErr(sync)
+
 	// Figure out the ideal pivot block. Note, that this goalpost may move if the
 	// sync takes long enough for the chain head to move significantly.
 	pivot := uint64(0)
@@ -1648,6 +1649,10 @@ func (d *Downloader) processFastSyncContent(latest *types.Header) error {
 			if height := latest.Number.Uint64(); height > pivot+2*uint64(fsMinFullBlocks) {
 				log.Warn("Pivot became stale, moving", "old", pivot, "new", height-uint64(fsMinFullBlocks))
 				pivot = height - uint64(fsMinFullBlocks)
+
+				// Write out the pivot into the database so a rollback beyond it will
+				// reenable fast sync
+				rawdb.WriteLastPivotNumber(d.stateDB, pivot)
 			}
 		}
 		P, beforeP, afterP := splitAroundPivot(pivot, results)

--- a/trie/sync.go
+++ b/trie/sync.go
@@ -99,7 +99,7 @@ func (s *Sync) AddSubTrie(root common.Hash, depth int, parent common.Hash, callb
 	if _, ok := s.membatch.batch[root]; ok {
 		return
 	}
-	if s.bloom.Contains(root[:]) {
+	if s.bloom == nil || s.bloom.Contains(root[:]) {
 		// Bloom filter says this might be a duplicate, double check
 		blob, _ := s.database.Get(root[:])
 		if local, err := decodeNode(root[:], blob); local != nil && err == nil {
@@ -138,7 +138,7 @@ func (s *Sync) AddRawEntry(hash common.Hash, depth int, parent common.Hash) {
 	if _, ok := s.membatch.batch[hash]; ok {
 		return
 	}
-	if s.bloom.Contains(hash[:]) {
+	if s.bloom == nil || s.bloom.Contains(hash[:]) {
 		// Bloom filter says this might be a duplicate, double check
 		if ok, _ := s.database.Has(hash[:]); ok {
 			return
@@ -300,7 +300,7 @@ func (s *Sync) children(req *request, object node) ([]*request, error) {
 			if _, ok := s.membatch.batch[hash]; ok {
 				continue
 			}
-			if s.bloom.Contains(node) {
+			if s.bloom == nil || s.bloom.Contains(node) {
 				// Bloom filter says this might be a duplicate, double check
 				if ok, _ := s.database.Has(node); ok {
 					continue


### PR DESCRIPTION
This PR is a major tech debt repayment. Over the years we kept hacking in various logic into Geth as to what happens when some blocks need to be deleted (fast sync rollback, crash recovery, user sethead). Fast sync rollbacks worked fine since their use was limited. Crash recovery generally worked ok, unless you underflown into the freezer. SetHead was a Russian roulette.

This PR bites the bullet and sorts this issue out by writing up a gigantic test suite with all the possible state combinations from which Geth might want to rewind it's chain and what the expected result is. The PR also unifies the 3 different rollback methods (which just for the fun of it used one another), and rather makes a single `SetHead` that works for every use case. The PR ended up fixing a significant number of bugs - which only triggered on crashes or manual sethead calls.

Fixes:

- https://github.com/ethereum/go-ethereum/pull/20745
- https://github.com/ethereum/go-ethereum/pull/20235
- https://github.com/ethereum/go-ethereum/issues/20224
- https://github.com/ethereum/go-ethereum/issues/20238