### PR TITLE
core/vm: avoid map lookups for accessing jumpdest analysis

### DIFF
--- a/core/vm/contract.go
+++ b/core/vm/contract.go
@@ -112,7 +112,13 @@ func (c *Contract) validJumpSubdest(udest uint64) bool {
 // isCode returns true if the provided PC location is an actual opcode, as
 // opposed to a data-segment following a PUSHN operation.
 func (c *Contract) isCode(udest uint64) bool {
+	// Do we already have an analysis laying around?
+	if c.analysis != nil {
+		return c.analysis.codeSegment(udest)
+	}
 	// Do we have a contract hash already?
+	// If we do have a hash, that means it's a 'regular' contract. For regular
+	// contracts ( not temporary initcode), we store the analysis in a map
 	if c.CodeHash != (common.Hash{}) {
 		// Does parent context have the analysis?
 		analysis, exist := c.jumpdests[c.CodeHash]


### PR DESCRIPTION
This change was actually introduced in https://github.com/ethereum/go-ethereum/pull/21123/files , but was lost when subroutines were introduced in https://github.com/ethereum/go-ethereum/commit/cd57d5cd38ef692de8fbedaa56598b4e9fbfbabc#diff-6eafc1c0af4b6eeba491f9b4d56c12b4 . 