### PR TITLE
cmd/geth: fixes db unavailability for chain commands

### DIFF
--- a/cmd/geth/chaincmd.go
+++ b/cmd/geth/chaincmd.go
@@ -239,7 +239,7 @@ func initGenesis(ctx *cli.Context) error {
 	if err := json.NewDecoder(file).Decode(genesis); err != nil {
 		utils.Fatalf("invalid genesis file: %v", err)
 	}
-	// Make the bare-minimum node to avoid unnecessary service start-up
+
 	stack, _ := makeConfigNode(ctx)
 	defer stack.Close()
 	// Open an initialise both full and light databases
@@ -406,7 +406,7 @@ func importPreimages(ctx *cli.Context) error {
 	if len(ctx.Args()) < 1 {
 		utils.Fatalf("This command requires an argument.")
 	}
-	// Make the bare-minimum node to avoid unnecessary service start-up
+
 	stack, _ := makeConfigNode(ctx)
 	defer stack.Close()
 
@@ -425,7 +425,7 @@ func exportPreimages(ctx *cli.Context) error {
 	if len(ctx.Args()) < 1 {
 		utils.Fatalf("This command requires an argument.")
 	}
-	// Make the bare-minimum node to avoid unnecessary service start-up
+
 	stack, _ := makeConfigNode(ctx)
 	defer stack.Close()
 
@@ -447,7 +447,7 @@ func copyDb(ctx *cli.Context) error {
 	if len(ctx.Args()) < 2 {
 		utils.Fatalf("Source ancient chain directory path argument missing")
 	}
-	// Make the bare-minimum node to avoid unnecessary service start-up
+
 	stack, _ := makeConfigNode(ctx)
 	defer stack.Close()
 	// Initialize a new chain for the running node to sync into
@@ -496,7 +496,6 @@ func copyDb(ctx *cli.Context) error {
 }
 
 func removeDB(ctx *cli.Context) error {
-	// Make the bare-minimum node to avoid unnecessary service start-up
 	stack, config := makeConfigNode(ctx)
 
 	// Remove the full node state database
@@ -557,7 +556,6 @@ func confirmAndRemoveDB(database string, kind string) {
 }
 
 func dump(ctx *cli.Context) error {
-	// Make the bare-minimum node to avoid unnecessary service start-up
 	stack, _ := makeConfigNode(ctx)
 	defer stack.Close()
 
@@ -597,7 +595,6 @@ func dump(ctx *cli.Context) error {
 }
 
 func inspect(ctx *cli.Context) error {
-	// Make the bare-minimum node to avoid unnecessary service start-up
 	node, _ := makeConfigNode(ctx)
 	defer node.Close()
 

--- a/cmd/geth/chaincmd.go
+++ b/cmd/geth/chaincmd.go
@@ -239,11 +239,10 @@ func initGenesis(ctx *cli.Context) error {
 	if err := json.NewDecoder(file).Decode(genesis); err != nil {
 		utils.Fatalf("invalid genesis file: %v", err)
 	}
-
-	// Open an initialise both full and light databases
+	// Make the bare-minimum node to avoid unnecessary service start-up
 	stack, _ := makeConfigNode(ctx)
 	defer stack.Close()
-
+	// Open an initialise both full and light databases
 	for _, name := range []string{"chaindata", "lightchaindata"} {
 		chaindb, err := stack.OpenDatabase(name, 0, 0, "")
 		if err != nil {
@@ -407,6 +406,7 @@ func importPreimages(ctx *cli.Context) error {
 	if len(ctx.Args()) < 1 {
 		utils.Fatalf("This command requires an argument.")
 	}
+	// Make the bare-minimum node to avoid unnecessary service start-up
 	stack, _ := makeConfigNode(ctx)
 	defer stack.Close()
 
@@ -425,6 +425,7 @@ func exportPreimages(ctx *cli.Context) error {
 	if len(ctx.Args()) < 1 {
 		utils.Fatalf("This command requires an argument.")
 	}
+	// Make the bare-minimum node to avoid unnecessary service start-up
 	stack, _ := makeConfigNode(ctx)
 	defer stack.Close()
 
@@ -446,10 +447,10 @@ func copyDb(ctx *cli.Context) error {
 	if len(ctx.Args()) < 2 {
 		utils.Fatalf("Source ancient chain directory path argument missing")
 	}
-	// Initialize a new chain for the running node to sync into
+	// Make the bare-minimum node to avoid unnecessary service start-up
 	stack, _ := makeConfigNode(ctx)
 	defer stack.Close()
-
+	// Initialize a new chain for the running node to sync into
 	chain, chainDb := utils.MakeChain(ctx, stack, false)
 	syncMode := *utils.GlobalTextMarshaler(ctx, utils.SyncModeFlag.Name).(*downloader.SyncMode)
 
@@ -495,6 +496,7 @@ func copyDb(ctx *cli.Context) error {
 }
 
 func removeDB(ctx *cli.Context) error {
+	// Make the bare-minimum node to avoid unnecessary service start-up
 	stack, config := makeConfigNode(ctx)
 
 	// Remove the full node state database
@@ -555,6 +557,7 @@ func confirmAndRemoveDB(database string, kind string) {
 }
 
 func dump(ctx *cli.Context) error {
+	// Make the bare-minimum node to avoid unnecessary service start-up
 	stack, _ := makeConfigNode(ctx)
 	defer stack.Close()
 
@@ -594,6 +597,7 @@ func dump(ctx *cli.Context) error {
 }
 
 func inspect(ctx *cli.Context) error {
+	// Make the bare-minimum node to avoid unnecessary service start-up
 	node, _ := makeConfigNode(ctx)
 	defer node.Close()
 

--- a/cmd/geth/chaincmd.go
+++ b/cmd/geth/chaincmd.go
@@ -239,10 +239,10 @@ func initGenesis(ctx *cli.Context) error {
 	if err := json.NewDecoder(file).Decode(genesis); err != nil {
 		utils.Fatalf("invalid genesis file: %v", err)
 	}
-
+	// Open and initialise both full and light databases
 	stack, _ := makeConfigNode(ctx)
 	defer stack.Close()
-	// Open an initialise both full and light databases
+
 	for _, name := range []string{"chaindata", "lightchaindata"} {
 		chaindb, err := stack.OpenDatabase(name, 0, 0, "")
 		if err != nil {
@@ -447,10 +447,10 @@ func copyDb(ctx *cli.Context) error {
 	if len(ctx.Args()) < 2 {
 		utils.Fatalf("Source ancient chain directory path argument missing")
 	}
-
+	// Initialize a new chain for the running node to sync into
 	stack, _ := makeConfigNode(ctx)
 	defer stack.Close()
-	// Initialize a new chain for the running node to sync into
+
 	chain, chainDb := utils.MakeChain(ctx, stack, false)
 	syncMode := *utils.GlobalTextMarshaler(ctx, utils.SyncModeFlag.Name).(*downloader.SyncMode)
 

--- a/cmd/geth/chaincmd.go
+++ b/cmd/geth/chaincmd.go
@@ -407,7 +407,7 @@ func importPreimages(ctx *cli.Context) error {
 	if len(ctx.Args()) < 1 {
 		utils.Fatalf("This command requires an argument.")
 	}
-	stack, _ := makeFullNode(ctx)
+	stack, _ := makeConfigNode(ctx)
 	defer stack.Close()
 
 	db := utils.MakeChainDatabase(ctx, stack)
@@ -425,7 +425,7 @@ func exportPreimages(ctx *cli.Context) error {
 	if len(ctx.Args()) < 1 {
 		utils.Fatalf("This command requires an argument.")
 	}
-	stack, _ := makeFullNode(ctx)
+	stack, _ := makeConfigNode(ctx)
 	defer stack.Close()
 
 	db := utils.MakeChainDatabase(ctx, stack)
@@ -447,7 +447,7 @@ func copyDb(ctx *cli.Context) error {
 		utils.Fatalf("Source ancient chain directory path argument missing")
 	}
 	// Initialize a new chain for the running node to sync into
-	stack, _ := makeFullNode(ctx)
+	stack, _ := makeConfigNode(ctx)
 	defer stack.Close()
 
 	chain, chainDb := utils.MakeChain(ctx, stack, false)
@@ -555,7 +555,7 @@ func confirmAndRemoveDB(database string, kind string) {
 }
 
 func dump(ctx *cli.Context) error {
-	stack, _ := makeFullNode(ctx)
+	stack, _ := makeConfigNode(ctx)
 	defer stack.Close()
 
 	chain, chainDb := utils.MakeChain(ctx, stack, true)

--- a/cmd/geth/config.go
+++ b/cmd/geth/config.go
@@ -105,6 +105,7 @@ func defaultNodeConfig() node.Config {
 	return cfg
 }
 
+// makeConfigNode loads geth configuration and creates a blank node instance.
 func makeConfigNode(ctx *cli.Context) (*node.Node, gethConfig) {
 	// Load defaults.
 	cfg := gethConfig{
@@ -145,6 +146,7 @@ func enableWhisper(ctx *cli.Context) bool {
 	return false
 }
 
+// makeFullNode loads geth configuration and creates the Ethereum backend.
 func makeFullNode(ctx *cli.Context) (*node.Node, ethapi.Backend) {
 	stack, cfg := makeConfigNode(ctx)
 


### PR DESCRIPTION
Related to #21412, fixes database unavailability issues stemming from the eth service and <chain command> trying to open node's DB simultaneously. 