### PR TITLE
core: Use maxQueuedTxAnns for to limit the number of transactions announced

### DIFF
--- a/eth/peer.go
+++ b/eth/peer.go
@@ -262,7 +262,7 @@ func (p *peer) announceTransactions(removePeer func(string)) {
 			queue = append(queue, hashes...)
 			if len(queue) > maxQueuedTxAnns {
 				// Fancy copy and resize to ensure buffer doesn't grow indefinitely
-				queue = queue[:copy(queue, queue[len(queue)-maxQueuedTxs:])]
+				queue = queue[:copy(queue, queue[len(queue)-maxQueuedTxAnns:])]
 			}
 
 		case <-done:


### PR DESCRIPTION
The wrong variable was used for limiting maxQueuedTxAnns. At the moment this was fine because both have the same value.