### PR TITLE
les: update checktime even if check fails

### DIFF
--- a/les/checkpointoracle/oracle.go
+++ b/les/checkpointoracle/oracle.go
@@ -93,8 +93,11 @@ func (oracle *CheckpointOracle) StableCheckpoint() (*params.TrustedCheckpoint, u
 	// Look it up properly
 	// Retrieve the latest checkpoint from the contract, abort if empty
 	latest, hash, height, err := oracle.contract.Contract().GetLatestCheckpoint(nil)
+	oracle.lastCheckTime = time.Now()
 	if err != nil || (latest == 0 && hash == [32]byte{}) {
-		return nil, 0
+		oracle.lastCheckPointHeight = 0
+		oracle.lastCheckPoint = nil
+		return oracle.lastCheckPoint, oracle.lastCheckPointHeight
 	}
 	local := oracle.getLocal(latest)
 
@@ -106,10 +109,9 @@ func (oracle *CheckpointOracle) StableCheckpoint() (*params.TrustedCheckpoint, u
 	//
 	// In both cases, no stable checkpoint will be returned.
 	if local.HashEqual(hash) {
-		oracle.lastCheckTime = time.Now()
 		oracle.lastCheckPointHeight = height.Uint64()
 		oracle.lastCheckPoint = &local
-		return &local, height.Uint64()
+		return oracle.lastCheckPoint, oracle.lastCheckPointHeight
 	}
 	return nil, 0
 }


### PR DESCRIPTION
Whenever a les-client connected to a server, the server internally did an RPC-call on each handshake. This was quite resource intensive, and was fixed  in https://github.com/ethereum/go-ethereum/pull/21285  which prevented it from doing so more than once per minute. 
However, the PR was a bit lacking -- if the call failed, which might be the case during syncing, the fix actually made the situation worse. Not only did it still do RPC request for each handshake, the added lock also forces those rpc requests to be made serially. 

This PR addresses that. 