### PR TITLE
ethstats: overwrite old errors

### DIFF
--- a/ethstats/ethstats.go
+++ b/ethstats/ethstats.go
@@ -256,11 +256,11 @@ func (s *Service) loop() {
 			header.Set("origin", "http://localhost")
 			for _, url := range urls {
 				c, _, e := dialer.Dial(url, header)
-				if e == nil {
+				err = e
+				if err == nil {
 					conn = newConnectionWrapper(c)
 					break
 				}
-				err = e
 			}
 			if err != nil {
 				log.Warn("Stats server unreachable", "err", err)
@@ -275,7 +275,6 @@ func (s *Service) loop() {
 				continue
 			}
 			go s.readLoop(conn)
-
 			// Send the initial stats so our node looks decent from the get go
 			if err = s.report(conn); err != nil {
 				log.Warn("Initial stats report failed", "err", err)


### PR DESCRIPTION
Tiny change, fixes a corner-case in ethstats. If there are multiple URLs, and the first one(s) fail, but a later one works, the first error will prevail and prevent the connection from being established. 