### PR TITLE
go.mod: goja update

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/deckarep/golang-set v0.0.0-20180603214616-504e848d77ea
 	github.com/dlclark/regexp2 v1.2.0 // indirect
 	github.com/docker/docker v1.4.2-0.20180625184442-8e610b2b55bf
-	github.com/dop251/goja v0.0.0-20200219165308-d1232e640a87
+	github.com/dop251/goja v0.0.0-20200721192441-a695b0cdd498
 	github.com/edsrzf/mmap-go v0.0.0-20160512033002-935e0e8a636c
 	github.com/fatih/color v1.3.0
 	github.com/fjl/memsize v0.0.0-20180418122429-ca190fb6ffbc

--- a/go.sum
+++ b/go.sum
@@ -57,8 +57,8 @@ github.com/dlclark/regexp2 v1.2.0 h1:8sAhBGEM0dRWogWqWyQeIJnxjWO6oIjl8FKqREDsGfk
 github.com/dlclark/regexp2 v1.2.0/go.mod h1:2pZnwuY/m+8K6iRw6wQdMtk+rH5tNGR1i55kozfMjCc=
 github.com/docker/docker v1.4.2-0.20180625184442-8e610b2b55bf h1:sh8rkQZavChcmakYiSlqu2425CHyFXLZZnvm7PDpU8M=
 github.com/docker/docker v1.4.2-0.20180625184442-8e610b2b55bf/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
-github.com/dop251/goja v0.0.0-20200219165308-d1232e640a87 h1:OMbqMXf9OAXzH1dDH82mQMrddBE8LIIwDtxeK4wE1/A=
-github.com/dop251/goja v0.0.0-20200219165308-d1232e640a87/go.mod h1:Mw6PkjjMXWbTj+nnj4s3QPXq1jaT0s5pC0iFD4+BOAA=
+github.com/dop251/goja v0.0.0-20200721192441-a695b0cdd498 h1:Y9vTBSsV4hSwPSj4bacAU/eSnV3dAxVpepaghAdhGoQ=
+github.com/dop251/goja v0.0.0-20200721192441-a695b0cdd498/go.mod h1:Mw6PkjjMXWbTj+nnj4s3QPXq1jaT0s5pC0iFD4+BOAA=
 github.com/edsrzf/mmap-go v0.0.0-20160512033002-935e0e8a636c h1:JHHhtb9XWJrGNMcrVP6vyzO4dusgi/HnceHTgxSejUM=
 github.com/edsrzf/mmap-go v0.0.0-20160512033002-935e0e8a636c/go.mod h1:YO35OhQPt3KJa3ryjFM5Bs14WD66h8eGKpfaBNrHW5M=
 github.com/fatih/color v1.3.0 h1:YehCCcyeQ6Km0D6+IapqPinWBK6y+0eB5umvZXK9WPs=


### PR DESCRIPTION
1. Initialise Function.prototype also when it's being set or deleted. Fixes https://github.com/dop251/goja/commit/3d32615791671be7e2cfb6f08f7872d8de0961c5
2. Made nested structs addressable if possible. Closes https://github.com/dop251/goja/commit/ebfbf88ae3f7b4d3929fad07fdaf3001cbcf209a
3. Fixed objectGoSliceReflect.getStr() and delete(). https://github.com/dop251/goja/commit/c3769ba23d73e45c74bd7cfa22029bd09714d4cf
4. [fea] add push support for goslice_reflect object https://github.com/dop251/goja/commit/794ceddc9009ebc03e7cc178973f3288a589cdce
5. Use strings.Trim instead of regex to trim unicodeString https://github.com/dop251/goja/commit/7bb4acfa4c6ef02f47bdac4f7dc3d5ef5dec4ac5
6. Array.prototype.sort(): correctly handle float return value https://github.com/dop251/goja/commit/2de61b11743de9f3facae532af6bf7401e600651
7. Fixed iterator stack leak when returning from the loop body https://github.com/dop251/goja/commit/77e84ffb8c65af72e4a3bc53c31328265eac7c81
8. Set correct 'this' when calling member functions within a 'with' block https://github.com/dop251/goja/commit/e92122c4a4c83a4180c7bc3c18e68057c6a6fc16
9. Fixed stack leak on empty catch block https://github.com/dop251/goja/commit/bfd59704b500581bf75771f79cc2579741cf3d2c
10. fix JSON.parse with reviver https://github.com/dop251/goja/commit/9025f726e64af3340940761f084ecc1b8cd71ffd