### PR TITLE
eth/downloader: allow all timers to exit

### DIFF
--- a/eth/downloader/statesync.go
+++ b/eth/downloader/statesync.go
@@ -197,12 +197,7 @@ func (d *Downloader) runStateSync(s *stateSync) *stateSync {
 			}
 			// Start a timer to notify the sync loop if the peer stalled.
 			req.timer = time.AfterFunc(req.timeout, func() {
-				select {
-				case timeout <- req:
-				case <-s.done:
-					// Prevent leaking of timer goroutines in the unlikely case where a
-					// timer is fired just before exiting runStateSync.
-				}
+				timeout <- req
 			})
 			active[req.peer.id] = req
 		}
@@ -214,7 +209,6 @@ func (d *Downloader) runStateSync(s *stateSync) *stateSync {
 // are marked as idle and de facto _are_ idle.
 func (d *Downloader) spindownStateSync(active map[string]*stateReq, finished []*stateReq, timeout chan *stateReq, peerDrop chan *peerConnection) {
 	log.Trace("State sync spinning down", "active", len(active), "finished", len(finished))
-
 	for len(active) > 0 {
 		var (
 			req    *stateReq


### PR DESCRIPTION
There's an issue in statesync, which can cause the `spindown` to become blocked. Example trace: 
```
goroutine 61 [select, 25 minutes]:
github.com/ethereum/go-ethereum/eth/downloader.(*Downloader).spindownStateSync(0xc003576000, 0xc011a80c88, 0xc050990000, 0xf3, 0x100, 0xc15126c3c0, 0xc0ee278ae0)
        github.com/ethereum/go-ethereum/eth/downloader/statesync.go:226 +0x298
github.com/ethereum/go-ethereum/eth/downloader.(*Downloader).runStateSync(0xc003576000, 0xc125033f40, 0x0)
        github.com/ethereum/go-ethereum/eth/downloader/statesync.go:131 +0x1002
github.com/ethereum/go-ethereum/eth/downloader.(*Downloader).stateFetcher(0xc003576000)
        github.com/ethereum/go-ethereum/eth/downloader/statesync.go:85 +0x47
created by github.com/ethereum/go-ethereum/eth/downloader.New
        github.com/ethereum/go-ethereum/eth/downloader/downloader.go:244 +0x433
```

The spindown path is  via 
```golang
        case <-s.done:
            d.spindownStateSync(active, finished, timeout, peerDrop)
            return nil
```
And, is `s.done` is closed, that means the timers may or may not fire at all. This PR removes the `s.done`-check from the timer func, so it always triggers. 