### PR TITLE
p2p/nodestate: ensure correct callback order

### DIFF
--- a/les/lespay/client/fillset_test.go
+++ b/les/lespay/client/fillset_test.go
@@ -102,7 +102,7 @@ func TestFillSet(t *testing.T) {
 	expNotWaiting()
 	// remove all previosly set flags
 	ns.ForEach(sfTest1, nodestate.Flags{}, func(node *enode.Node, state nodestate.Flags) {
-		ns.SetStateSub(node, nodestate.Flags{}, sfTest1, 0)
+		ns.SetState(node, nodestate.Flags{}, sfTest1, 0)
 	})
 	// now expect FillSet to fill the set up again with 10 new nodes
 	expWaiting(10, true)

--- a/les/lespay/client/fillset_test.go
+++ b/les/lespay/client/fillset_test.go
@@ -102,7 +102,7 @@ func TestFillSet(t *testing.T) {
 	expNotWaiting()
 	// remove all previosly set flags
 	ns.ForEach(sfTest1, nodestate.Flags{}, func(node *enode.Node, state nodestate.Flags) {
-		ns.SetState(node, nodestate.Flags{}, sfTest1, 0)
+		ns.SetStateSub(node, nodestate.Flags{}, sfTest1, 0)
 	})
 	// now expect FillSet to fill the set up again with 10 new nodes
 	expWaiting(10, true)

--- a/les/serverpool.go
+++ b/les/serverpool.go
@@ -166,7 +166,7 @@ func newServerPool(db ethdb.KeyValueStore, dbKey []byte, vt *lpc.ValueTracker, d
 		if oldState.Equals(sfWaitDialTimeout) && newState.IsEmpty() {
 			// dial timeout, no connection
 			s.setRedialWait(n, dialCost, dialWaitStep)
-			s.ns.SetState(n, nodestate.Flags{}, sfDialing, 0)
+			s.ns.SetStateSub(n, nodestate.Flags{}, sfDialing, 0)
 		}
 	})
 
@@ -193,10 +193,10 @@ func (s *serverPool) addPreNegFilter(input enode.Iterator, query queryFunc) enod
 			if rand.Intn(maxQueryFails*2) < int(fails) {
 				// skip pre-negotiation with increasing chance, max 50%
 				// this ensures that the client can operate even if UDP is not working at all
-				s.ns.SetState(n, sfCanDial, nodestate.Flags{}, time.Second*10)
+				s.ns.SetStateSub(n, sfCanDial, nodestate.Flags{}, time.Second*10)
 				// set canDial before resetting queried so that FillSet will not read more
 				// candidates unnecessarily
-				s.ns.SetState(n, nodestate.Flags{}, sfQueried, 0)
+				s.ns.SetStateSub(n, nodestate.Flags{}, sfQueried, 0)
 				return
 			}
 			go func() {
@@ -206,12 +206,15 @@ func (s *serverPool) addPreNegFilter(input enode.Iterator, query queryFunc) enod
 				} else {
 					atomic.StoreUint32(&s.queryFails, 0)
 				}
-				if q == 1 {
-					s.ns.SetState(n, sfCanDial, nodestate.Flags{}, time.Second*10)
-				} else {
-					s.setRedialWait(n, queryCost, queryWaitStep)
-				}
-				s.ns.SetState(n, nodestate.Flags{}, sfQueried, 0)
+				s.ns.Operation(func() {
+					// we are no longer running in the operation that the callback belongs to, start a new one because of setRedialWait
+					if q == 1 {
+						s.ns.SetStateSub(n, sfCanDial, nodestate.Flags{}, time.Second*10)
+					} else {
+						s.setRedialWait(n, queryCost, queryWaitStep)
+					}
+					s.ns.SetStateSub(n, nodestate.Flags{}, sfQueried, 0)
+				})
 			}()
 		}
 	})
@@ -250,7 +253,7 @@ func (s *serverPool) start() {
 				// waiting time then the system clock was probably adjusted
 				wait = lastWait
 			}
-			s.ns.SetState(node, sfRedialWait, nodestate.Flags{}, time.Duration(wait)*time.Second)
+			s.ns.SetStateSub(node, sfRedialWait, nodestate.Flags{}, time.Duration(wait)*time.Second)
 		}
 	})
 }
@@ -279,9 +282,11 @@ func (s *serverPool) registerPeer(p *serverPeer) {
 
 // unregisterPeer implements serverPeerSubscriber
 func (s *serverPool) unregisterPeer(p *serverPeer) {
-	s.setRedialWait(p.Node(), dialCost, dialWaitStep)
-	s.ns.SetState(p.Node(), nodestate.Flags{}, sfConnected, 0)
-	s.ns.SetField(p.Node(), sfiConnectedStats, nil)
+	s.ns.Operation(func() {
+		s.setRedialWait(p.Node(), dialCost, dialWaitStep)
+		s.ns.SetStateSub(p.Node(), nodestate.Flags{}, sfConnected, 0)
+		s.ns.SetFieldSub(p.Node(), sfiConnectedStats, nil)
+	})
 	s.vt.Unregister(p.ID())
 	p.setValueTracker(nil, nil)
 }
@@ -380,14 +385,15 @@ func (s *serverPool) serviceValue(node *enode.Node) (sessionValue, totalValue fl
 
 // updateWeight calculates the node weight and updates the nodeWeight field and the
 // hasValue flag. It also saves the node state if necessary.
+// Note: this function should run inside a NodeStateMachine operation
 func (s *serverPool) updateWeight(node *enode.Node, totalValue float64, totalDialCost uint64) {
 	weight := uint64(totalValue * nodeWeightMul / float64(totalDialCost))
 	if weight >= nodeWeightThreshold {
-		s.ns.SetState(node, sfHasValue, nodestate.Flags{}, 0)
-		s.ns.SetField(node, sfiNodeWeight, weight)
+		s.ns.SetStateSub(node, sfHasValue, nodestate.Flags{}, 0)
+		s.ns.SetFieldSub(node, sfiNodeWeight, weight)
 	} else {
-		s.ns.SetState(node, nodestate.Flags{}, sfHasValue, 0)
-		s.ns.SetField(node, sfiNodeWeight, nil)
+		s.ns.SetStateSub(node, nodestate.Flags{}, sfHasValue, 0)
+		s.ns.SetFieldSub(node, sfiNodeWeight, nil)
 	}
 	s.ns.Persist(node) // saved if node history or hasValue changed
 }
@@ -400,6 +406,7 @@ func (s *serverPool) updateWeight(node *enode.Node, totalValue float64, totalDia
 // a significant amount of service value again its waiting time is quickly reduced or reset
 // to the minimum.
 // Note: node weight is also recalculated and updated by this function.
+// Note 2: this function should run inside a NodeStateMachine operation
 func (s *serverPool) setRedialWait(node *enode.Node, addDialCost int64, waitStep float64) {
 	n, _ := s.ns.GetField(node, sfiNodeHistory).(nodeHistory)
 	sessionValue, totalValue := s.serviceValue(node)
@@ -450,21 +457,22 @@ func (s *serverPool) setRedialWait(node *enode.Node, addDialCost int64, waitStep
 	if wait < waitThreshold {
 		n.redialWaitStart = unixTime
 		n.redialWaitEnd = unixTime + int64(nextTimeout)
-		s.ns.SetField(node, sfiNodeHistory, n)
-		s.ns.SetState(node, sfRedialWait, nodestate.Flags{}, wait)
+		s.ns.SetFieldSub(node, sfiNodeHistory, n)
+		s.ns.SetStateSub(node, sfRedialWait, nodestate.Flags{}, wait)
 		s.updateWeight(node, totalValue, totalDialCost)
 	} else {
 		// discard known node statistics if waiting time is very long because the node
 		// hasn't been responsive for a very long time
-		s.ns.SetField(node, sfiNodeHistory, nil)
-		s.ns.SetField(node, sfiNodeWeight, nil)
-		s.ns.SetState(node, nodestate.Flags{}, sfHasValue, 0)
+		s.ns.SetFieldSub(node, sfiNodeHistory, nil)
+		s.ns.SetFieldSub(node, sfiNodeWeight, nil)
+		s.ns.SetStateSub(node, nodestate.Flags{}, sfHasValue, 0)
 	}
 }
 
 // calculateWeight calculates and sets the node weight without altering the node history.
 // This function should be called during startup and shutdown only, otherwise setRedialWait
 // will keep the weights updated as the underlying statistics are adjusted.
+// Note: this function should run inside a NodeStateMachine operation
 func (s *serverPool) calculateWeight(node *enode.Node) {
 	n, _ := s.ns.GetField(node, sfiNodeHistory).(nodeHistory)
 	_, totalValue := s.serviceValue(node)

--- a/les/serverpool.go
+++ b/les/serverpool.go
@@ -398,6 +398,7 @@ func (s *serverPool) updateWeight(node *enode.Node, totalValue float64, totalDia
 	} else {
 		s.ns.SetStateSub(node, nodestate.Flags{}, sfHasValue, 0)
 		s.ns.SetFieldSub(node, sfiNodeWeight, nil)
+		s.ns.SetFieldSub(node, sfiNodeHistory, nil)
 	}
 	s.ns.Persist(node) // saved if node history or hasValue changed
 }

--- a/p2p/nodestate/nodestate.go
+++ b/p2p/nodestate/nodestate.go
@@ -18,7 +18,6 @@ package nodestate
 
 import (
 	"errors"
-	"fmt"
 	"reflect"
 	"sync"
 	"time"
@@ -32,8 +31,6 @@ import (
 	"github.com/ethereum/go-ethereum/p2p/enr"
 	"github.com/ethereum/go-ethereum/rlp"
 )
-
-const debugPrints = false
 
 type (
 	// NodeStateMachine connects different system components operating on subsets of
@@ -633,9 +630,6 @@ func (ns *NodeStateMachine) SetState(n *enode.Node, setFlags, resetFlags Flags, 
 	}
 	oldState := node.state
 	newState := (node.state & (^reset)) | set
-	if debugPrints {
-		fmt.Println("SetState", n.ID(), "old", Flags{oldState, ns.setup}, "new", Flags{newState, ns.setup}, "set", setFlags, "reset", resetFlags, "timeout", timeout)
-	}
 	changed := oldState ^ newState
 	node.state = newState
 
@@ -675,9 +669,6 @@ func (ns *NodeStateMachine) SetState(n *enode.Node, setFlags, resetFlags Flags, 
 		for i, v := range node.fields {
 			if v == nil {
 				continue
-			}
-			if debugPrints {
-				fmt.Println("discardField", n.ID(), ns.setup.fields[i].name, v)
 			}
 			f := ns.fields[i]
 			if len(f.subs) > 0 {
@@ -788,9 +779,6 @@ func (ns *NodeStateMachine) addTimeout(n *enode.Node, mask bitMask, timeout time
 	ns.removeTimeouts(node, mask)
 	t := &nodeStateTimeout{mask: mask}
 	t.timer = ns.clock.AfterFunc(timeout, func() {
-		if debugPrints {
-			fmt.Println("timeout", n.ID(), Flags{mask, ns.setup})
-		}
 		ns.SetState(n, Flags{}, Flags{mask: t.mask, setup: ns.setup}, 0, nil)
 	})
 	node.timeouts = append(node.timeouts, t)
@@ -860,9 +848,6 @@ func (ns *NodeStateMachine) SetField(n *enode.Node, field Field, value interface
 		return errors.New("invalid field type")
 	}
 	oldValue := node.fields[fieldIndex]
-	if debugPrints {
-		fmt.Println("SetField", n.ID(), Flags{node.state, ns.setup}, field.setup.fields[field.index].name, oldValue, value)
-	}
 	if value == oldValue {
 		ns.lock.Unlock()
 		return nil

--- a/p2p/nodestate/nodestate.go
+++ b/p2p/nodestate/nodestate.go
@@ -688,7 +688,6 @@ func (ns *NodeStateMachine) setState(n *enode.Node, setFlags, resetFlags Flags, 
 		}
 	}
 	ns.opPending = append(ns.opPending, callback)
-	return
 }
 
 // opCheck checks whether an operation is active

--- a/p2p/nodestate/nodestate.go
+++ b/p2p/nodestate/nodestate.go
@@ -916,11 +916,12 @@ func (ns *NodeStateMachine) setField(n *enode.Node, field Field, value interface
 }
 
 // ForEach calls the callback for each node having all of the required and none of the
-// disabled flags set
+// disabled flags set.
+// Note that this callback is not an operation callback but ForEach can be called from an
+// Operation callback or Operation can also be called from a ForEach callback if necessary.
 func (ns *NodeStateMachine) ForEach(requireFlags, disableFlags Flags, cb func(n *enode.Node, state Flags)) {
 	ns.lock.Lock()
 	ns.checkStarted()
-	ns.opStart()
 	type callback struct {
 		node  *enode.Node
 		state bitMask
@@ -936,9 +937,6 @@ func (ns *NodeStateMachine) ForEach(requireFlags, disableFlags Flags, cb func(n 
 	for _, c := range callbacks {
 		cb(c.node, Flags{mask: c.state, setup: ns.setup})
 	}
-	ns.lock.Lock()
-	ns.opFinish()
-	ns.lock.Unlock()
 }
 
 // GetNode returns the enode currently associated with the given ID

--- a/p2p/nodestate/nodestate.go
+++ b/p2p/nodestate/nodestate.go
@@ -698,7 +698,7 @@ func (ns *NodeStateMachine) opCheck() {
 }
 
 func (ns *NodeStateMachine) opStart() {
-	if ns.opFlag {
+	for ns.opFlag {
 		ns.opWait.Wait()
 	}
 	ns.opFlag = true
@@ -721,6 +721,16 @@ func (ns *NodeStateMachine) opEnd() {
 	ns.pending = nil
 	ns.opFlag = false
 	ns.opWait.Signal()
+}
+
+func (ns *NodeStateMachine) Operation(fn func()) {
+	ns.lock.Lock()
+	ns.opStart()
+	ns.lock.Unlock()
+	fn()
+	ns.lock.Lock()
+	ns.opEnd()
+	ns.lock.Unlock()
 }
 
 // offlineCallbacks calls state update callbacks at startup or shutdown

--- a/p2p/nodestate/nodestate_test.go
+++ b/p2p/nodestate/nodestate_test.go
@@ -70,15 +70,15 @@ func TestCallback(t *testing.T) {
 	set0 := make(chan struct{}, 1)
 	set1 := make(chan struct{}, 1)
 	set2 := make(chan struct{}, 1)
-	ns.SubscribeState(flags[0], func(n *enode.Node, oldState, newState Flags, caller *Caller) { set0 <- struct{}{} })
-	ns.SubscribeState(flags[1], func(n *enode.Node, oldState, newState Flags, caller *Caller) { set1 <- struct{}{} })
-	ns.SubscribeState(flags[2], func(n *enode.Node, oldState, newState Flags, caller *Caller) { set2 <- struct{}{} })
+	ns.SubscribeState(flags[0], func(n *enode.Node, oldState, newState Flags) { set0 <- struct{}{} })
+	ns.SubscribeState(flags[1], func(n *enode.Node, oldState, newState Flags) { set1 <- struct{}{} })
+	ns.SubscribeState(flags[2], func(n *enode.Node, oldState, newState Flags) { set2 <- struct{}{} })
 
 	ns.Start()
 
-	ns.SetState(testNode(1), flags[0], Flags{}, 0, nil)
-	ns.SetState(testNode(1), flags[1], Flags{}, time.Second, nil)
-	ns.SetState(testNode(1), flags[2], Flags{}, 2*time.Second, nil)
+	ns.SetState(testNode(1), flags[0], Flags{}, 0)
+	ns.SetState(testNode(1), flags[1], Flags{}, time.Second)
+	ns.SetState(testNode(1), flags[2], Flags{}, 2*time.Second)
 
 	for i := 0; i < 3; i++ {
 		select {
@@ -104,11 +104,11 @@ func TestPersistentFlags(t *testing.T) {
 
 	ns.Start()
 
-	ns.SetState(testNode(1), flags[0], Flags{}, time.Second, nil) // state with timeout should not be saved
-	ns.SetState(testNode(2), flags[1], Flags{}, 0, nil)
-	ns.SetState(testNode(3), flags[2], Flags{}, 0, nil)
-	ns.SetState(testNode(4), flags[3], Flags{}, 0, nil)
-	ns.SetState(testNode(5), flags[0], Flags{}, 0, nil)
+	ns.SetState(testNode(1), flags[0], Flags{}, time.Second) // state with timeout should not be saved
+	ns.SetState(testNode(2), flags[1], Flags{}, 0)
+	ns.SetState(testNode(3), flags[2], Flags{}, 0)
+	ns.SetState(testNode(4), flags[3], Flags{}, 0)
+	ns.SetState(testNode(5), flags[0], Flags{}, 0)
 	ns.Persist(testNode(5))
 	select {
 	case <-saveNode:
@@ -145,19 +145,19 @@ func TestSetField(t *testing.T) {
 	ns.Start()
 
 	// Set field before setting state
-	ns.SetField(testNode(1), fields[0], "hello world", nil)
+	ns.SetField(testNode(1), fields[0], "hello world")
 	field := ns.GetField(testNode(1), fields[0])
 	if field != nil {
 		t.Fatalf("Field shouldn't be set before setting states")
 	}
 	// Set field after setting state
-	ns.SetState(testNode(1), flags[0], Flags{}, 0, nil)
-	ns.SetField(testNode(1), fields[0], "hello world", nil)
+	ns.SetState(testNode(1), flags[0], Flags{}, 0)
+	ns.SetField(testNode(1), fields[0], "hello world")
 	field = ns.GetField(testNode(1), fields[0])
 	if field == nil {
 		t.Fatalf("Field should be set after setting states")
 	}
-	if err := ns.SetField(testNode(1), fields[0], 123, nil); err == nil {
+	if err := ns.SetField(testNode(1), fields[0], 123); err == nil {
 		t.Fatalf("Invalid field should be rejected")
 	}
 	// Dirty node should be written back
@@ -177,10 +177,10 @@ func TestUnsetField(t *testing.T) {
 
 	ns.Start()
 
-	ns.SetState(testNode(1), flags[0], Flags{}, time.Second, nil)
-	ns.SetField(testNode(1), fields[0], "hello world", nil)
+	ns.SetState(testNode(1), flags[0], Flags{}, time.Second)
+	ns.SetField(testNode(1), fields[0], "hello world")
 
-	ns.SetState(testNode(1), Flags{}, flags[0], 0, nil)
+	ns.SetState(testNode(1), Flags{}, flags[0], 0)
 	if field := ns.GetField(testNode(1), fields[0]); field != nil {
 		t.Fatalf("Field should be unset")
 	}
@@ -194,7 +194,7 @@ func TestSetState(t *testing.T) {
 
 	type change struct{ old, new Flags }
 	set := make(chan change, 1)
-	ns.SubscribeState(flags[0].Or(flags[1]), func(n *enode.Node, oldState, newState Flags, caller *Caller) {
+	ns.SubscribeState(flags[0].Or(flags[1]), func(n *enode.Node, oldState, newState Flags) {
 		set <- change{
 			old: oldState,
 			new: newState,
@@ -224,25 +224,25 @@ func TestSetState(t *testing.T) {
 			return
 		}
 	}
-	ns.SetState(testNode(1), flags[0], Flags{}, 0, nil)
+	ns.SetState(testNode(1), flags[0], Flags{}, 0)
 	check(Flags{}, flags[0], true)
 
-	ns.SetState(testNode(1), flags[1], Flags{}, 0, nil)
+	ns.SetState(testNode(1), flags[1], Flags{}, 0)
 	check(flags[0], flags[0].Or(flags[1]), true)
 
-	ns.SetState(testNode(1), flags[2], Flags{}, 0, nil)
+	ns.SetState(testNode(1), flags[2], Flags{}, 0)
 	check(Flags{}, Flags{}, false)
 
-	ns.SetState(testNode(1), Flags{}, flags[0], 0, nil)
+	ns.SetState(testNode(1), Flags{}, flags[0], 0)
 	check(flags[0].Or(flags[1]), flags[1], true)
 
-	ns.SetState(testNode(1), Flags{}, flags[1], 0, nil)
+	ns.SetState(testNode(1), Flags{}, flags[1], 0)
 	check(flags[1], Flags{}, true)
 
-	ns.SetState(testNode(1), Flags{}, flags[2], 0, nil)
+	ns.SetState(testNode(1), Flags{}, flags[2], 0)
 	check(Flags{}, Flags{}, false)
 
-	ns.SetState(testNode(1), flags[0].Or(flags[1]), Flags{}, time.Second, nil)
+	ns.SetState(testNode(1), flags[0].Or(flags[1]), Flags{}, time.Second)
 	check(Flags{}, flags[0].Or(flags[1]), true)
 	clock.Run(time.Second)
 	check(flags[0].Or(flags[1]), Flags{}, true)
@@ -282,9 +282,9 @@ func TestPersistentFields(t *testing.T) {
 	ns := NewNodeStateMachine(mdb, []byte("-ns"), clock, s)
 
 	ns.Start()
-	ns.SetState(testNode(1), flags[0], Flags{}, 0, nil)
-	ns.SetField(testNode(1), fields[0], uint64(100), nil)
-	ns.SetField(testNode(1), fields[1], "hello world", nil)
+	ns.SetState(testNode(1), flags[0], Flags{}, 0)
+	ns.SetField(testNode(1), fields[0], uint64(100))
+	ns.SetField(testNode(1), fields[1], "hello world")
 	ns.Stop()
 
 	ns2 := NewNodeStateMachine(mdb, []byte("-ns"), clock, s)
@@ -317,7 +317,7 @@ func TestFieldSub(t *testing.T) {
 		lastState                  Flags
 		lastOldValue, lastNewValue interface{}
 	)
-	ns.SubscribeField(fields[0], func(n *enode.Node, state Flags, oldValue, newValue interface{}, caller *Caller) {
+	ns.SubscribeField(fields[0], func(n *enode.Node, state Flags, oldValue, newValue interface{}) {
 		lastState, lastOldValue, lastNewValue = state, oldValue, newValue
 	})
 	check := func(state Flags, oldValue, newValue interface{}) {
@@ -326,19 +326,19 @@ func TestFieldSub(t *testing.T) {
 		}
 	}
 	ns.Start()
-	ns.SetState(testNode(1), flags[0], Flags{}, 0, nil)
-	ns.SetField(testNode(1), fields[0], uint64(100), nil)
+	ns.SetState(testNode(1), flags[0], Flags{}, 0)
+	ns.SetField(testNode(1), fields[0], uint64(100))
 	check(flags[0], nil, uint64(100))
 	ns.Stop()
 	check(s.OfflineFlag(), uint64(100), nil)
 
 	ns2 := NewNodeStateMachine(mdb, []byte("-ns"), clock, s)
-	ns2.SubscribeField(fields[0], func(n *enode.Node, state Flags, oldValue, newValue interface{}, caller *Caller) {
+	ns2.SubscribeField(fields[0], func(n *enode.Node, state Flags, oldValue, newValue interface{}) {
 		lastState, lastOldValue, lastNewValue = state, oldValue, newValue
 	})
 	ns2.Start()
 	check(s.OfflineFlag(), nil, uint64(100))
-	ns2.SetState(testNode(1), Flags{}, flags[0], 0, nil)
+	ns2.SetState(testNode(1), Flags{}, flags[0], 0)
 	check(Flags{}, uint64(100), nil)
 	ns2.Stop()
 }
@@ -351,7 +351,7 @@ func TestDuplicatedFlags(t *testing.T) {
 
 	type change struct{ old, new Flags }
 	set := make(chan change, 1)
-	ns.SubscribeState(flags[0], func(n *enode.Node, oldState, newState Flags, caller *Caller) {
+	ns.SubscribeState(flags[0], func(n *enode.Node, oldState, newState Flags) {
 		set <- change{oldState, newState}
 	})
 
@@ -379,9 +379,9 @@ func TestDuplicatedFlags(t *testing.T) {
 			return
 		}
 	}
-	ns.SetState(testNode(1), flags[0], Flags{}, time.Second, nil)
+	ns.SetState(testNode(1), flags[0], Flags{}, time.Second)
 	check(Flags{}, flags[0], true)
-	ns.SetState(testNode(1), flags[0], Flags{}, 2*time.Second, nil) // extend the timeout to 2s
+	ns.SetState(testNode(1), flags[0], Flags{}, 2*time.Second) // extend the timeout to 2s
 	check(Flags{}, flags[0], false)
 
 	clock.Run(2 * time.Second)
@@ -394,19 +394,19 @@ func TestCallbackOrder(t *testing.T) {
 	s, flags, _ := testSetup([]bool{false, false, false, false}, nil)
 	ns := NewNodeStateMachine(mdb, []byte("-ns"), clock, s)
 
-	ns.SubscribeState(flags[0], func(n *enode.Node, oldState, newState Flags, caller *Caller) {
+	ns.SubscribeState(flags[0], func(n *enode.Node, oldState, newState Flags) {
 		if newState.Equals(flags[0]) {
-			ns.SetState(n, flags[1], Flags{}, 0, caller)
-			ns.SetState(n, flags[2], Flags{}, 0, caller)
+			ns.SetStateSub(n, flags[1], Flags{}, 0)
+			ns.SetStateSub(n, flags[2], Flags{}, 0)
 		}
 	})
-	ns.SubscribeState(flags[1], func(n *enode.Node, oldState, newState Flags, caller *Caller) {
+	ns.SubscribeState(flags[1], func(n *enode.Node, oldState, newState Flags) {
 		if newState.Equals(flags[1]) {
-			ns.SetState(n, flags[3], Flags{}, 0, caller)
+			ns.SetStateSub(n, flags[3], Flags{}, 0)
 		}
 	})
 	lastState := Flags{}
-	ns.SubscribeState(MergeFlags(flags[1], flags[2], flags[3]), func(n *enode.Node, oldState, newState Flags, caller *Caller) {
+	ns.SubscribeState(MergeFlags(flags[1], flags[2], flags[3]), func(n *enode.Node, oldState, newState Flags) {
 		if !oldState.Equals(lastState) {
 			t.Fatalf("Wrong callback order")
 		}
@@ -416,5 +416,5 @@ func TestCallbackOrder(t *testing.T) {
 	ns.Start()
 	defer ns.Stop()
 
-	ns.SetState(testNode(1), flags[0], Flags{}, 0, nil)
+	ns.SetState(testNode(1), flags[0], Flags{}, 0)
 }

--- a/p2p/nodestate/nodestate_test.go
+++ b/p2p/nodestate/nodestate_test.go
@@ -147,8 +147,13 @@ func TestSetField(t *testing.T) {
 	// Set field before setting state
 	ns.SetField(testNode(1), fields[0], "hello world")
 	field := ns.GetField(testNode(1), fields[0])
+	if field == nil {
+		t.Fatalf("Field should be set before setting states")
+	}
+	ns.SetField(testNode(1), fields[0], nil)
+	field = ns.GetField(testNode(1), fields[0])
 	if field != nil {
-		t.Fatalf("Field shouldn't be set before setting states")
+		t.Fatalf("Field should be unset")
 	}
 	// Set field after setting state
 	ns.SetState(testNode(1), flags[0], Flags{}, 0)
@@ -166,23 +171,6 @@ func TestSetField(t *testing.T) {
 	case <-saveNode:
 	case <-time.After(time.Second):
 		t.Fatalf("Timeout")
-	}
-}
-
-func TestUnsetField(t *testing.T) {
-	mdb, clock := rawdb.NewMemoryDatabase(), &mclock.Simulated{}
-
-	s, flags, fields := testSetup([]bool{false}, []reflect.Type{reflect.TypeOf("")})
-	ns := NewNodeStateMachine(mdb, []byte("-ns"), clock, s)
-
-	ns.Start()
-
-	ns.SetState(testNode(1), flags[0], Flags{}, time.Second)
-	ns.SetField(testNode(1), fields[0], "hello world")
-
-	ns.SetState(testNode(1), Flags{}, flags[0], 0)
-	if field := ns.GetField(testNode(1), fields[0]); field != nil {
-		t.Fatalf("Field should be unset")
 	}
 }
 
@@ -339,6 +327,7 @@ func TestFieldSub(t *testing.T) {
 	ns2.Start()
 	check(s.OfflineFlag(), nil, uint64(100))
 	ns2.SetState(testNode(1), Flags{}, flags[0], 0)
+	ns2.SetField(testNode(1), fields[0], nil)
 	check(Flags{}, uint64(100), nil)
 	ns2.Stop()
 }


### PR DESCRIPTION
This PR adds an extra guarantee to NodeStateMachine: it ensures that all immediate effects of a certain change are processed before any subsequent effects of any of the immediate effects on the same node. In the original version, if a cascaded change caused a subscription callback to be called multiple times for the same node then these calls might have happened in a wrong chronological order.

For example:
- a subscription to `flag0` changes `flag1` and `flag2`
- a subscription to `flag1` changes `flag3`
- a subscription to `flag1`, `flag2` and `flag3` was called in the following order:
	- `[flag1]` -> `[flag1, flag3]`
	- `[]` -> `[flag1]`
	- `[flag1, flag3]` -> `[flag1, flag2, flag3]`

This happened because the tree of changes was traversed in a "depth-first order". Now it is traversed in a "breadth-first order"; each node has a FIFO queue for pending callbacks and each triggered subscription callback is added to the end of the list. The already existing guarantees are retained; no `SetState` or `SetField` returns until the callback queue of the node is empty again. Just like before, it is the responsibility of the state machine design to ensure that infinite state loops are not possible. Multiple changes affecting the same node can still happen simultaneously; in this case the changes can be interleaved in the FIFO of the node but the correct order is still guaranteed.

A new unit test is also added to verify callback order in the above scenario.