### PR TITLE
eth/downloader, eth/handler: utilize sync bloom for getNodeData

### DIFF
--- a/eth/downloader/downloader.go
+++ b/eth/downloader/downloader.go
@@ -283,6 +283,15 @@ func (d *Downloader) Synchronising() bool {
 	return atomic.LoadInt32(&d.synchronising) > 0
 }
 
+// SyncBloomContains tests if the syncbloom filter contains the given hash:
+//   - false: the bloom definitely does not contain hash
+//   - true:  the bloom maybe contains hash
+//
+// While the bloom is being initialized (or is closed), all queries will return true.
+func (d *Downloader) SyncBloomContains(hash []byte) bool {
+	return d.stateBloom.Contains(hash)
+}
+
 // RegisterPeer injects a new download peer into the set of block source to be
 // used for fetching hashes and blocks from.
 func (d *Downloader) RegisterPeer(id string, version int, peer Peer) error {

--- a/eth/downloader/downloader.go
+++ b/eth/downloader/downloader.go
@@ -289,7 +289,7 @@ func (d *Downloader) Synchronising() bool {
 //
 // While the bloom is being initialized (or is closed), all queries will return true.
 func (d *Downloader) SyncBloomContains(hash []byte) bool {
-	return d.stateBloom.Contains(hash)
+	return d.stateBloom == nil || d.stateBloom.Contains(hash)
 }
 
 // RegisterPeer injects a new download peer into the set of block source to be

--- a/eth/handler.go
+++ b/eth/handler.go
@@ -610,6 +610,10 @@ func (pm *ProtocolManager) handleMsg(p *peer) error {
 			// Retrieve the requested state entry, stopping if enough was found
 			// todo now the code and trienode is mixed in the protocol level,
 			// separate these two types.
+			if !pm.downloader.SyncBloomContains(hash[:]) {
+				// Only lookup the trie node if there's chance that we actually have it
+				continue
+			}
 			entry, err := pm.blockchain.TrieNode(hash)
 			if len(entry) == 0 || err != nil {
 				// Read the contract code with prefix only to save unnecessary lookups.

--- a/trie/sync_bloom.go
+++ b/trie/sync_bloom.go
@@ -186,6 +186,9 @@ func (b *SyncBloom) Add(hash []byte) {
 // While the bloom is being initialized, any query will return true.
 func (b *SyncBloom) Contains(hash []byte) bool {
 	bloomTestMeter.Mark(1)
+	if b == nil {
+		return true
+	}
 	if atomic.LoadUint32(&b.inited) == 0 {
 		// We didn't load all the trie nodes from the previous run of Geth yet. As
 		// such, we can't say for sure if a hash is not present for anything. Until

--- a/trie/sync_bloom.go
+++ b/trie/sync_bloom.go
@@ -186,9 +186,6 @@ func (b *SyncBloom) Add(hash []byte) {
 // While the bloom is being initialized, any query will return true.
 func (b *SyncBloom) Contains(hash []byte) bool {
 	bloomTestMeter.Mark(1)
-	if b == nil {
-		return true
-	}
 	if atomic.LoadUint32(&b.inited) == 0 {
 		// We didn't load all the trie nodes from the previous run of Geth yet. As
 		// such, we can't say for sure if a hash is not present for anything. Until


### PR DESCRIPTION
This PR is an experiment. While syncing, there's an immense read-pressure on the filesystem, especially when the node has a lot of peers. 
The read-preesure comes from
- processing children of state-responses. For each `state`, it needs to lookup if the child hashes exist. 
- processing `getNodeData` from peers. Each peer may have up to send up to `384` outstanding lookups. These are handled sequentially in the eth/handler.go. 

This PR uses the `stateBloom` filter that's already used by the sync, to avoid lookups to disk in the cases where we do not have the hash. Judging from some of the graphs, it looks like non-existing lookups account for ~50% of all `getNodeData` lookups (the number _will_ vary wildly based on how far along the sync process is)