### PR TITLE
Set PetersburgBlock as optional when checking Fork order

### DIFF
--- a/params/config.go
+++ b/params/config.go
@@ -473,7 +473,7 @@ func (c *ChainConfig) CheckConfigForkOrder() error {
 		{name: "eip158Block", block: c.EIP158Block},
 		{name: "byzantiumBlock", block: c.ByzantiumBlock},
 		{name: "constantinopleBlock", block: c.ConstantinopleBlock},
-		{name: "petersburgBlock", block: c.PetersburgBlock},
+		{name: "petersburgBlock", block: c.PetersburgBlock, optional: true},
 		{name: "istanbulBlock", block: c.IstanbulBlock},
 		{name: "muirGlacierBlock", block: c.MuirGlacierBlock, optional: true},
 		{name: "yoloV1Block", block: c.YoloV1Block},


### PR DESCRIPTION
`PetersburgBlock`, if not explicitly set, is assumed to be active depending on whether `ConstantinopleBlock` is [active](https://github.com/ethereum/go-ethereum/blob/54add4255064f722b33fe1c13e46db0b875fe325/params/config.go#L419-L424). However, when checking fork ordering, PetersburgBlock is treated mandatory. In private chains which are running 1.8.27 with ConstantinopleBlock active, migration to 1.9 fails because PetersburgBlock is not explicitly set (even the [gas calculation](https://github.com/ethereum/go-ethereum/blob/54add4255064f722b33fe1c13e46db0b875fe325/core/vm/gas_table.go#L101-L104) works as though Petersburg block is set). This PR sets PetersburgBlock to `optional` to reflect the treatment of the fork across the rest of the code. The main benefit of this change is that private chains which set the Constantinople fork and are running with Geth `1.8.27` can upgrade to Geth 1.9.x and apply the `Istanbul` fork after upgrade.

I discussed this with @holiman on Discord, creating a PR as follow up to the discussion.