### PR TITLE
rpc: export jsonError

### DIFF
--- a/rpc/client_test.go
+++ b/rpc/client_test.go
@@ -135,7 +135,7 @@ func TestClientBatchRequest(t *testing.T) {
 			Method: "no_such_method",
 			Args:   []interface{}{1, 2, 3},
 			Result: new(int),
-			Error:  &jsonError{Code: -32601, Message: "the method no_such_method does not exist/is not available"},
+			Error:  &JsonError{Code: -32601, Message: "the method no_such_method does not exist/is not available"},
 		},
 	}
 	if !reflect.DeepEqual(batch, wantResult) {

--- a/rpc/json.go
+++ b/rpc/json.go
@@ -53,7 +53,7 @@ type jsonrpcMessage struct {
 	ID      json.RawMessage `json:"id,omitempty"`
 	Method  string          `json:"method,omitempty"`
 	Params  json.RawMessage `json:"params,omitempty"`
-	Error   *jsonError      `json:"error,omitempty"`
+	Error   *JsonError      `json:"error,omitempty"`
 	Result  json.RawMessage `json:"result,omitempty"`
 }
 
@@ -107,7 +107,7 @@ func (msg *jsonrpcMessage) response(result interface{}) *jsonrpcMessage {
 }
 
 func errorMessage(err error) *jsonrpcMessage {
-	msg := &jsonrpcMessage{Version: vsn, ID: null, Error: &jsonError{
+	msg := &jsonrpcMessage{Version: vsn, ID: null, Error: &JsonError{
 		Code:    defaultErrorCode,
 		Message: err.Error(),
 	}}
@@ -122,24 +122,24 @@ func errorMessage(err error) *jsonrpcMessage {
 	return msg
 }
 
-type jsonError struct {
+type JsonError struct {
 	Code    int         `json:"code"`
 	Message string      `json:"message"`
 	Data    interface{} `json:"data,omitempty"`
 }
 
-func (err *jsonError) Error() string {
+func (err *JsonError) Error() string {
 	if err.Message == "" {
 		return fmt.Sprintf("json-rpc error %d", err.Code)
 	}
 	return err.Message
 }
 
-func (err *jsonError) ErrorCode() int {
+func (err *JsonError) ErrorCode() int {
 	return err.Code
 }
 
-func (err *jsonError) ErrorData() interface{} {
+func (err *JsonError) ErrorData() interface{} {
 	return err.Data
 }
 


### PR DESCRIPTION
use case

```go
package main

import (
	"errors"
	"fmt"

	"github.com/ethereum/go-ethereum/rpc"
)

func main() {
	err := Example()
	if w := (*rpc.JsonError)(nil); errors.As(err, &w) {
		fmt.Printf("JsonError: Code: %d\n", w.Code)
		fmt.Printf("JsonError: Message: %s\n", w.Message)
		fmt.Printf("JsonError: Data: %v\n", w.Data)
	}
}

func Example() error {
	client, err := rpc.Dial("ws://127.0.0.1:8546")
	if err != nil {
		return fmt.Errorf("dial: %w", err)
	}
	defer client.Close()

	var m map[string]interface{}
	if err := client.Call(&m, "unknown_method"); err != nil {
		return fmt.Errorf("call: %w", err)
	}
	return nil
}
```