### PR TITLE
Rough feature PoC: speedtests

### DIFF
--- a/eth/backend.go
+++ b/eth/backend.go
@@ -118,6 +118,7 @@ func New(stack *node.Node, config *Config) (*Ethereum, error) {
 	if err != nil {
 		return nil, err
 	}
+	SpeedTest(chainDb)
 	chainConfig, genesisHash, genesisErr := core.SetupGenesisBlock(chainDb, config.Genesis)
 	if _, ok := genesisErr.(*params.ConfigCompatError); genesisErr != nil && !ok {
 		return nil, genesisErr

--- a/eth/speedtest.go
+++ b/eth/speedtest.go
@@ -1,0 +1,23 @@
+package eth
+
+import (
+	"github.com/ethereum/go-ethereum/ethdb"
+	"github.com/ethereum/go-ethereum/log"
+	mrand "math/rand"
+	"time"
+)
+
+func SpeedTest(db ethdb.Database) {
+	var (
+		count = uint64(0)
+		key   = make([]byte, 32)
+		t0    = time.Now()
+	)
+	for time.Since(t0) < 1*time.Second {
+		mrand.Read(key)
+		db.Get(key)
+		count++
+	}
+	duration := uint64(time.Now().Sub(t0))
+	log.Info("Speed test performed", "r/s", float64(uint64(time.Second)*count)/float64(duration))
+}

--- a/eth/speedtest.go
+++ b/eth/speedtest.go
@@ -13,7 +13,7 @@ func SpeedTest(db ethdb.Database) {
 		key   = make([]byte, 32)
 		t0    = time.Now()
 	)
-	for time.Since(t0) < 1*time.Second {
+	for time.Since(t0) < 2*time.Second {
 		mrand.Read(key)
 		db.Get(key)
 		count++


### PR DESCRIPTION
Sometimes, user report that `geth` is slow. It's very hard to get to the bottom of that, since it may be 

- a legitimate bug, which has caused a regression and e..g locks or suboptimal handling of things, 
- that the disk is unsuitalbe (e.g. due to SSD deterioratoin), 
- that the file system is unsuitable ( e.g. zfs set up with snapshotting)

We sometimes ask people to run benchmarks, something like `sudo hdparm -Tt /dev/sda` (for read/write) or `dd if=/dev/zero of=/tmp/output conv=fdatasync bs=384k count=1k; rm -f /tmp/output` (for write). However, these commands are not cross-platofrm, and does not really tell us much about how the "geth workload" operates. 

This PR adds a little speedcheck, which does _random reads_ from leveldb. Thus, each read is expected to hit empty air, forcing the following events: 

- Leveldb cache misses, 
- OS filesystem cache misses, 
- Disk read

The read-speed is the bottleneck in many cases. For example, towards the end of a fast-sync, there is a very heavy read  pressure to check existence of trie nodes before scheduling for fetching from peers, which slows down the processing of state responses. 

If users run a little 1-second benchmark during boot, we may be better able to pinpoint issues stemming from "outside of geth"

Examples:

`65M` ropsten chaindata, laptop with SSD:
```
INFO [08-16|17:12:40.200] Allocated cache and file handles         database=/home/user/.ethereum/testnet/geth/chaindata cache=512.00MiB handles=262144
INFO [08-16|17:12:40.228] Opened ancient database                  database=/home/user/.ethereum/testnet/geth/chaindata/ancient
INFO [08-16|17:12:41.229] Speed test performed                     r/s=360873.079
```
`419Mb` goerli chaindata, same laptop: 
```
INFO [08-16|17:30:56.684] Speed test performed                     r/s=146207.721
```

`1.6G` chaindata on same laptop: :
```
INFO [08-16|17:13:55.162] Allocated cache and file handles         database=/home/user/.ethereum/geth/chaindata cache=1.26GiB handles=262144
INFO [08-16|17:13:55.215] Opened ancient database                  database=/home/user/.ethereum/geth/chaindata/ancient
INFO [08-16|17:13:56.219] Speed test performed                     r/s=53835.621
```


Do we want something like this?