### PR TITLE
"Downloader queue stats" is now provided once per minute

### DIFF
--- a/eth/downloader/queue.go
+++ b/eth/downloader/queue.go
@@ -385,7 +385,7 @@ func (q *queue) Results(block bool) []*fetchResult {
 		q.lastStatLog = time.Now()
 		info := q.Stats()
 		info = append(info, "throttle", throttleThreshold)
-		log.Info("Downloader queue stats", info...)
+		log.Debug("Downloader queue stats", info...)
 	}
 	return results
 }

--- a/eth/downloader/queue.go
+++ b/eth/downloader/queue.go
@@ -381,11 +381,11 @@ func (q *queue) Results(block bool) []*fetchResult {
 	throttleThreshold = q.resultCache.SetThrottleThreshold(throttleThreshold)
 
 	// Log some info at certain times
-	if time.Since(q.lastStatLog) > 10*time.Second {
+	if time.Since(q.lastStatLog) > 60*time.Second {
 		q.lastStatLog = time.Now()
 		info := q.Stats()
 		info = append(info, "throttle", throttleThreshold)
-		log.Debug("Downloader queue stats", info...)
+		log.Info("Downloader queue stats", info...)
 	}
 	return results
 }


### PR DESCRIPTION
I think this info is more a DEBUG related information then an INFO, and it is for me a little bit annoying to have that so often during syncronization. If it must remains an INFO, maybe it can be slow down to a print every 5-10 minutes or so.