### PR TITLE
core,les: headerchain import in batches

### DIFF
--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -2438,12 +2438,7 @@ func (bc *BlockChain) InsertHeaderChain(chain []*types.Header, checkFreq int) (i
 
 	bc.wg.Add(1)
 	defer bc.wg.Done()
-
-	whFunc := func(header *types.Header) error {
-		_, err := bc.hc.WriteHeader(header)
-		return err
-	}
-	return bc.hc.InsertHeaderChain(chain, whFunc, start)
+	return bc.hc.InsertHeaderChain(chain, nil, start)
 }
 
 // CurrentHeader retrieves the current head header of the canonical chain. The

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -2438,7 +2438,8 @@ func (bc *BlockChain) InsertHeaderChain(chain []*types.Header, checkFreq int) (i
 
 	bc.wg.Add(1)
 	defer bc.wg.Done()
-	return bc.hc.InsertHeaderChain(chain, nil, start)
+	_, err := bc.hc.InsertHeaderChain(chain, start)
+	return 0, err
 }
 
 // CurrentHeader retrieves the current head header of the canonical chain. The

--- a/core/headerchain.go
+++ b/core/headerchain.go
@@ -198,7 +198,9 @@ func (hc *HeaderChain) WriteHeaders(headers []*types.Header, postWriteFn PostWri
 		}
 		lastHeader, lastHash, lastNumber, ptd = header, hash, number, externTd
 	}
-	batch.Write()
+	if err := batch.Write(); err != nil {
+		log.Crit("Failed to write headers", "error", err)
+	}
 	batch.Reset()
 	var (
 		head    = hc.CurrentHeader().Number.Uint64()
@@ -293,7 +295,7 @@ func (hc *HeaderChain) WriteHeaders(headers []*types.Header, postWriteFn PostWri
 
 // PostWriteCallback is a callback function for inserting headers,
 // which is called once, with the last successfully imported header in the batch.
-// The raeson for having it is:
+// The reason for having it is:
 // In light-chain mode, status should be processed and light chain events sent,
 // whereas in a non-light mode this is not necessary since chain events are sent after inserting blocks.
 type PostWriteCallback func(header *types.Header, status WriteStatus)

--- a/core/headerchain.go
+++ b/core/headerchain.go
@@ -166,7 +166,16 @@ func (hc *HeaderChain) writeHeaders(headers []*types.Header) (result *headerWrit
 
 	batch := hc.chainDb.NewBatch()
 	for i, header := range headers {
-		hash, number := header.Hash(), header.Number.Uint64()
+		var hash common.Hash
+		// The headers have already been validated at this point, so we already
+		// know that it's a contiguous chain, where
+		// headers[i].Hash() == headers[i+1].ParentHash
+		if i < len(headers)-1 {
+			hash = headers[i+1].ParentHash
+		} else {
+			hash = header.Hash()
+		}
+		number := header.Number.Uint64()
 		newTD.Add(newTD, header.Difficulty)
 
 		// If the header is already known, skip it, otherwise store

--- a/core/headerchain.go
+++ b/core/headerchain.go
@@ -145,7 +145,7 @@ type headerWriteResult struct {
 // without the real blocks. Hence, writing headers directly should only be done
 // in two scenarios: pure-header mode of operation (light clients), or properly
 // separated header/block phases (non-archive clients).
-func (hc *HeaderChain) WriteHeaders(headers []*types.Header, postWriteFn PostWriteCallback) (result *headerWriteResult, err error) {
+func (hc *HeaderChain) writeHeaders(headers []*types.Header, postWriteFn PostWriteCallback) (result *headerWriteResult, err error) {
 	if len(headers) == 0 {
 		return &headerWriteResult{}, nil
 	}
@@ -358,7 +358,7 @@ func (hc *HeaderChain) InsertHeaderChain(chain []*types.Header, postWriteFn Post
 	if hc.procInterrupt() {
 		return 0, errors.New("aborted")
 	}
-	res, err := hc.WriteHeaders(chain, postWriteFn)
+	res, err := hc.writeHeaders(chain, postWriteFn)
 	// Report some public statistics so the user has a clue what's going on
 	context := []interface{}{
 		"count", res.imported,

--- a/core/headerchain.go
+++ b/core/headerchain.go
@@ -312,6 +312,10 @@ func (hc *HeaderChain) ValidateHeaderChain(chain []*types.Header, checkFreq int)
 		if BadHashes[parentHash] {
 			return i - 1, ErrBlacklistedHash
 		}
+		// If it's the last header in the cunk, we need to check it too
+		if i == len(chain)-1 && BadHashes[chain[i].Hash()] {
+			return i, ErrBlacklistedHash
+		}
 	}
 
 	// Generate the list of seal verification requests, and start the parallel verifier

--- a/core/headerchain.go
+++ b/core/headerchain.go
@@ -299,13 +299,18 @@ func (hc *HeaderChain) writeHeaders(headers []*types.Header) (result *headerWrit
 func (hc *HeaderChain) ValidateHeaderChain(chain []*types.Header, checkFreq int) (int, error) {
 	// Do a sanity check that the provided chain is actually ordered and linked
 	for i := 1; i < len(chain); i++ {
-		if chain[i].Number.Uint64() != chain[i-1].Number.Uint64()+1 || chain[i].ParentHash != chain[i-1].Hash() {
+		parentHash := chain[i-1].Hash()
+		if chain[i].Number.Uint64() != chain[i-1].Number.Uint64()+1 || chain[i].ParentHash != parentHash {
 			// Chain broke ancestry, log a message (programming error) and skip insertion
 			log.Error("Non contiguous header insert", "number", chain[i].Number, "hash", chain[i].Hash(),
-				"parent", chain[i].ParentHash, "prevnumber", chain[i-1].Number, "prevhash", chain[i-1].Hash())
+				"parent", chain[i].ParentHash, "prevnumber", chain[i-1].Number, "prevhash", parentHash)
 
 			return 0, fmt.Errorf("non contiguous insert: item %d is #%d [%x…], item %d is #%d [%x…] (parent [%x…])", i-1, chain[i-1].Number,
-				chain[i-1].Hash().Bytes()[:4], i, chain[i].Number, chain[i].Hash().Bytes()[:4], chain[i].ParentHash[:4])
+				parentHash.Bytes()[:4], i, chain[i].Number, chain[i].Hash().Bytes()[:4], chain[i].ParentHash[:4])
+		}
+		// If the header is a banned one, straight out abort
+		if BadHashes[parentHash] {
+			return i - 1, ErrBlacklistedHash
 		}
 	}
 
@@ -328,15 +333,11 @@ func (hc *HeaderChain) ValidateHeaderChain(chain []*types.Header, checkFreq int)
 	defer close(abort)
 
 	// Iterate over the headers and ensure they all check out
-	for i, header := range chain {
+	for i := range chain {
 		// If the chain is terminating, stop processing blocks
 		if hc.procInterrupt() {
 			log.Debug("Premature abort during headers verification")
 			return 0, errors.New("aborted")
-		}
-		// If the header is a banned one, straight out abort
-		if BadHashes[header.Hash()] {
-			return i, ErrBlacklistedHash
 		}
 		// Otherwise wait for headers checks and ensure they pass
 		if err := <-results; err != nil {

--- a/core/headerchain_test.go
+++ b/core/headerchain_test.go
@@ -1,0 +1,146 @@
+// Copyright 2020 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+package core
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/ethereum/go-ethereum/consensus"
+	"github.com/ethereum/go-ethereum/consensus/ethash"
+	"github.com/ethereum/go-ethereum/core/rawdb"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/log"
+	"github.com/ethereum/go-ethereum/params"
+)
+
+func verifyUnbrokenCanonchain(hc *HeaderChain) error {
+	h := hc.CurrentHeader()
+	for {
+		canonHash := rawdb.ReadCanonicalHash(hc.chainDb, h.Number.Uint64())
+		if exp := h.Hash(); canonHash != exp {
+			return fmt.Errorf("Canon hash chain broken, block %d got %x, expected %x",
+				h.Number, canonHash[:8], exp[:8])
+		}
+		// Verify that we have the TD
+		if td := rawdb.ReadTd(hc.chainDb, canonHash, h.Number.Uint64()); td == nil {
+			return fmt.Errorf("Canon TD missing at block %d", h.Number)
+		}
+		if h.Number.Uint64() == 0 {
+			break
+		}
+		h = hc.GetHeader(h.ParentHash, h.Number.Uint64()-1)
+	}
+	return nil
+}
+
+func testInsert(t *testing.T, hc *HeaderChain, chain []*types.Header, expInsert, expCanon, expSide int) error {
+	t.Helper()
+	gotInsert, gotCanon, gotSide := 0, 0, 0
+
+	_, err := hc.InsertHeaderChain(chain, func(header *types.Header) error {
+		status, err := hc.WriteHeader(header)
+		if err != nil{
+			return err
+		}
+		gotInsert++
+		switch status {
+		case CanonStatTy:
+			gotCanon++
+		default:
+			gotSide++
+		}
+		return nil
+
+	}, time.Now())
+
+	if gotInsert != expInsert {
+		t.Errorf("wrong number of callback invocations, got %d, exp %d", gotInsert, expInsert)
+	}
+	if gotCanon != expCanon {
+		t.Errorf("wrong number of canon headers, got %d, exp %d", gotCanon, expCanon)
+	}
+	if gotSide != expSide {
+		t.Errorf("wrong number of side headers, got %d, exp %d", gotSide, expSide)
+	}
+	// Always verify that the header chain is unbroken
+	if err := verifyUnbrokenCanonchain(hc); err != nil {
+		t.Fatal(err)
+		return err
+	}
+	return err
+}
+
+func TestHeaderInsertion(t *testing.T) {
+	var (
+		db      = rawdb.NewMemoryDatabase()
+		genesis = new(Genesis).MustCommit(db)
+	)
+
+	hc, err := NewHeaderChain(db, params.AllEthashProtocolChanges, ethash.NewFaker(), func() bool { return false })
+	if err != nil {
+		t.Fatal(err)
+	}
+	// chain A: G->A1->A2...A128
+	chainA := makeHeaderChain(genesis.Header(), 128, ethash.NewFaker(), db, 10)
+	// chain B: G->A1->B2...B128
+	chainB := makeHeaderChain(chainA[0], 128, ethash.NewFaker(), db, 10)
+	log.Root().SetHandler(log.StdoutHandler)
+
+	// Inserting 64 headers on an empty chain, expecting
+	// 64 callbacks, 64 canon-status, 0 sidestatus,
+	if err := testInsert(t, hc, chainA[:64], 64, 64, 0); err != nil {
+		t.Fatal(err)
+	}
+
+	// Inserting 64 indentical headers, expecting
+	// 0 callbacks, 0 canon-status, 0 sidestatus,
+	if err := testInsert(t, hc, chainA[:64], 0, 0, 0); err != nil {
+		t.Fatal(err)
+	}
+	// Inserting the same some old, some new headers
+	// 32 callbacks, 32 canon, 0 side
+	if err := testInsert(t, hc, chainA[32:96], 32, 32, 0); err != nil {
+		t.Fatal(err)
+	}
+	// Inserting side blocks, but not overtaking the canon chain
+	if err := testInsert(t, hc, chainB[0:32], 32, 0, 32); err != nil {
+		t.Fatal(err)
+	}
+	// Inserting more side blocks, but we don't have the parent
+	if err := testInsert(t, hc, chainB[34:36], 0, 0, 0); !errors.Is(err, consensus.ErrUnknownAncestor) {
+		t.Fatal(fmt.Errorf("Expected %v, got %v", consensus.ErrUnknownAncestor, err))
+	}
+	// Inserting more sideblocks, overtaking the canon chain
+	if err := testInsert(t, hc, chainB[32:97], 65, 65, 0); err != nil {
+		t.Fatal(err)
+	}
+	// Inserting more A-headers, taking back the canonicality
+	if err := testInsert(t, hc, chainA[90:100], 4, 4, 0); err != nil {
+		t.Fatal(err)
+	}
+	// And B becomes canon again
+	if err := testInsert(t, hc, chainB[97:107], 10, 10, 0); err != nil {
+		t.Fatal(err)
+	}
+	// And B becomes even longer
+	if err := testInsert(t, hc, chainB[107:128], 21, 21, 0); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/core/headerchain_test.go
+++ b/core/headerchain_test.go
@@ -98,23 +98,23 @@ func TestHeaderInsertion(t *testing.T) {
 	log.Root().SetHandler(log.StdoutHandler)
 
 	// Inserting 64 headers on an empty chain, expecting
-	// 64 callbacks, 64 canon-status, 0 sidestatus,
-	if err := testInsert(t, hc, chainA[:64], 64, 64, 0); err != nil {
+	// 1 callbacks, 1 canon-status, 0 sidestatus,
+	if err := testInsert(t, hc, chainA[:64], 1, 1, 0); err != nil {
 		t.Fatal(err)
 	}
 
-	// Inserting 64 inentical headers, expecting
+	// Inserting 64 identical headers, expecting
 	// 0 callbacks, 0 canon-status, 0 sidestatus,
 	if err := testInsert(t, hc, chainA[:64], 0, 0, 0); err != nil {
 		t.Fatal(err)
 	}
 	// Inserting the same some old, some new headers
-	// 32 callbacks, 32 canon, 0 side
-	if err := testInsert(t, hc, chainA[32:96], 32, 32, 0); err != nil {
+	// 1 callbacks, 1 canon, 0 side
+	if err := testInsert(t, hc, chainA[32:96], 1, 1, 0); err != nil {
 		t.Fatal(err)
 	}
 	// Inserting side blocks, but not overtaking the canon chain
-	if err := testInsert(t, hc, chainB[0:32], 32, 0, 32); err != nil {
+	if err := testInsert(t, hc, chainB[0:32], 1, 0, 1); err != nil {
 		t.Fatal(err)
 	}
 	// Inserting more side blocks, but we don't have the parent
@@ -122,19 +122,19 @@ func TestHeaderInsertion(t *testing.T) {
 		t.Fatal(fmt.Errorf("Expected %v, got %v", consensus.ErrUnknownAncestor, err))
 	}
 	// Inserting more sideblocks, overtaking the canon chain
-	if err := testInsert(t, hc, chainB[32:97], 65, 65, 0); err != nil {
+	if err := testInsert(t, hc, chainB[32:97], 1, 1, 0); err != nil {
 		t.Fatal(err)
 	}
 	// Inserting more A-headers, taking back the canonicality
-	if err := testInsert(t, hc, chainA[90:100], 4, 4, 0); err != nil {
+	if err := testInsert(t, hc, chainA[90:100], 1, 1, 0); err != nil {
 		t.Fatal(err)
 	}
 	// And B becomes canon again
-	if err := testInsert(t, hc, chainB[97:107], 10, 10, 0); err != nil {
+	if err := testInsert(t, hc, chainB[97:107], 1, 1, 0); err != nil {
 		t.Fatal(err)
 	}
 	// And B becomes even longer
-	if err := testInsert(t, hc, chainB[107:128], 21, 21, 0); err != nil {
+	if err := testInsert(t, hc, chainB[107:128], 1, 1, 0); err != nil {
 		t.Fatal(err)
 	}
 }

--- a/core/headerchain_test.go
+++ b/core/headerchain_test.go
@@ -54,11 +54,7 @@ func testInsert(t *testing.T, hc *HeaderChain, chain []*types.Header, expInsert,
 	t.Helper()
 	gotInsert, gotCanon, gotSide := 0, 0, 0
 
-	_, err := hc.InsertHeaderChain(chain, func(header *types.Header) error {
-		status, err := hc.WriteHeader(header)
-		if err != nil{
-			return err
-		}
+	_, err := hc.InsertHeaderChain(chain, func(header *types.Header, status WriteStatus) {
 		gotInsert++
 		switch status {
 		case CanonStatTy:
@@ -66,8 +62,6 @@ func testInsert(t *testing.T, hc *HeaderChain, chain []*types.Header, expInsert,
 		default:
 			gotSide++
 		}
-		return nil
-
 	}, time.Now())
 
 	if gotInsert != expInsert {
@@ -109,7 +103,7 @@ func TestHeaderInsertion(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// Inserting 64 indentical headers, expecting
+	// Inserting 64 inentical headers, expecting
 	// 0 callbacks, 0 canon-status, 0 sidestatus,
 	if err := testInsert(t, hc, chainA[:64], 0, 0, 0); err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
This PR is a rewrite of https://github.com/ethereum/go-ethereum/pull/19456. It does a couple of things. 
The first commit contains a testcase for how the headerchain behaves in certain aspects. Running that on a non -modified master, yields a few errors; 
```
=== RUN   TestHeaderInsertion
t=2020-08-21T09:32:13+0200 lvl=info msg="Imported new block headers" count=64 elapsed=1.470ms number=64 hash=0xf2036d795873749f13e0abb674f7001813c8fc2593cf5cc3779a89094a54359d age=51y4mo2w
t=2020-08-21T09:32:13+0200 lvl=info msg="Imported new block headers" count=0  elapsed="234.946µs" number=64 hash=0xf2036d795873749f13e0abb674f7001813c8fc2593cf5cc3779a89094a54359d age=51y4mo2w ignored=64
t=2020-08-21T09:32:13+0200 lvl=info msg="Imported new block headers" count=32 elapsed="782.077µs" number=96 hash=0x364526c1f837d1213d070d18a9d45d45b2d321be533c5f9e6332fc46a0d196bb age=51y4mo2w ignored=32
t=2020-08-21T09:32:13+0200 lvl=info msg="Imported new block headers" count=32 elapsed=2.185ms     number=33 hash=0x45393823b215807f104c45f761fc91dcba061594bf01ea7ca519722764e6def0 age=51y4mo2w
t=2020-08-21T09:32:13+0200 lvl=info msg="Imported new block headers" count=65 elapsed=1.027ms     number=98 hash=0xb6b62e17d4aabd16a56d1cfa70ca17ab7f894ada6dc47bf35e4934d36c645ffa age=51y4mo2w
    TestHeaderInsertion: headerchain_test.go:131: wrong number of canon headers, got 3, exp 65
    TestHeaderInsertion: headerchain_test.go:131: wrong number of side headers, got 62, exp 0
t=2020-08-21T09:32:13+0200 lvl=info msg="Imported new block headers" count=4  elapsed="185.013µs" number=100 hash=0x37a6d6b1a0e40f90a432532a0128bc42dd2f30754f813274c25aaa25bc62b299 age=51y4mo2w ignored=6
    TestHeaderInsertion: headerchain_test.go:135: wrong number of canon headers, got 3, exp 4
    TestHeaderInsertion: headerchain_test.go:135: wrong number of side headers, got 1, exp 0
t=2020-08-21T09:32:13+0200 lvl=info msg="Imported new block headers" count=10 elapsed="506.449µs" number=108 hash=0x211509f70aff3490c63d8ce75e6268a37c0f48c5a27a526a726ace2f6d5bafe9 age=51y4mo2w
    TestHeaderInsertion: headerchain_test.go:139: wrong number of canon headers, got 8, exp 10
    TestHeaderInsertion: headerchain_test.go:139: wrong number of side headers, got 2, exp 0
t=2020-08-21T09:32:13+0200 lvl=info msg="Imported new block headers" count=21 elapsed="389.356µs" number=129 hash=0xa42cd0f3769e083d833431d1141c8ea5e8be146f16b900165b273192908c5126 age=51y4mo2w
--- FAIL: TestHeaderInsertion (0.05s)
```

Currently, on master: 
- If `n` headers are imported in a batch, and become the new canon chain, then the first part of the chain gets counted as 'side', and only the later blocks are counted as 'canon'. This behaviour changes with this PR, and all (previously unknown) headers are flagged as 'canon'. This really only matters for lightchain, I think. 

The benefits of writing headers in batches is that we can do a lot less readback of written data, particularly when it comes to 
 - reading the canonicality-status. On `master`, every single header in the batch of `2048` headers cause a check to see if a canon block has already been written for that number. 
 - This PR instead does it only for the first of those 2048, and skips it altogether if the current head is the de-facto parent of the batch. 

The PR changes how writes are done - previously writes were done inside a callback. This is no longer needed, but instead a post-write callback has been added for the benefit of the light client.  