### PR TITLE
eth/downloader: fix rollback issue on short chains

### DIFF
--- a/eth/downloader/downloader.go
+++ b/eth/downloader/downloader.go
@@ -1502,6 +1502,8 @@ func (d *Downloader) processHeaders(origin uint64, pivot uint64, td *big.Int) er
 					head := chunk[len(chunk)-1].Number.Uint64()
 					if head-rollback > uint64(fsHeaderSafetyNet) {
 						rollback = head - uint64(fsHeaderSafetyNet)
+					} else {
+						rollback = 1
 					}
 				}
 				// Unless we're doing light chains, schedule the headers for associated content retrieval


### PR DESCRIPTION
In https://github.com/ethereum/go-ethereum/commit/8cbdc8638fd28693f84d7bdbbdd587e8c57f6383#diff-c2fa15e758e986688c646459d8970a50R1501-R1504 , the rollback mechanism was changed, from beign a slice of hashes to being a number. 
The change also cause a regression, if the number is smaller than `fsHeaderSafetyNet`, then the rollback will be `0`, and the `sethead` won't happen. This causes some spurious test failures, 

```
[user@work go-ethereum]$ go test ./eth/downloader/ -run InvalidHeaderRollback 
--- FAIL: TestInvalidHeaderRollback63Fast (2.39s)
    downloader_test.go:1047: rollback head mismatch: have 384, want at most 192
--- FAIL: TestInvalidHeaderRollback65Light (3.23s)
    downloader_test.go:1047: rollback head mismatch: have 960, want at most 192
FAIL
FAIL    github.com/ethereum/go-ethereum/eth/downloader  6.513s
```