### PR TITLE
Allow setting PetersburgBlock before chain head

### DIFF
--- a/params/config.go
+++ b/params/config.go
@@ -528,7 +528,11 @@ func (c *ChainConfig) checkCompatible(newcfg *ChainConfig, head *big.Int) *Confi
 		return newCompatError("Constantinople fork block", c.ConstantinopleBlock, newcfg.ConstantinopleBlock)
 	}
 	if isForkIncompatible(c.PetersburgBlock, newcfg.PetersburgBlock, head) {
-		return newCompatError("Petersburg fork block", c.PetersburgBlock, newcfg.PetersburgBlock)
+		// the only case where we allow Petersburg to be set in the past is if it is equal to Constantinople
+		// mainly to satisfy fork ordering requirements which state that Petersburg fork be set if Constantinople fork is set
+		if isForkIncompatible(c.ConstantinopleBlock, newcfg.PetersburgBlock, head) {
+			return newCompatError("Petersburg fork block", c.PetersburgBlock, newcfg.PetersburgBlock)
+		}
 	}
 	if isForkIncompatible(c.IstanbulBlock, newcfg.IstanbulBlock, head) {
 		return newCompatError("Istanbul fork block", c.IstanbulBlock, newcfg.IstanbulBlock)

--- a/params/config_test.go
+++ b/params/config_test.go
@@ -76,6 +76,17 @@ func TestCheckCompatible(t *testing.T) {
 			head:    40,
 			wantErr: nil,
 		},
+		{
+			stored: &ChainConfig{ConstantinopleBlock: big.NewInt(30)},
+			new:    &ChainConfig{ConstantinopleBlock: big.NewInt(30), PetersburgBlock: big.NewInt(31)},
+			head:   40,
+			wantErr: &ConfigCompatError{
+				What:         "Petersburg fork block",
+				StoredConfig: nil,
+				NewConfig:    big.NewInt(31),
+				RewindTo:     30,
+			},
+		},
 	}
 
 	for _, test := range tests {

--- a/params/config_test.go
+++ b/params/config_test.go
@@ -70,6 +70,12 @@ func TestCheckCompatible(t *testing.T) {
 				RewindTo:     9,
 			},
 		},
+		{
+			stored:  &ChainConfig{ConstantinopleBlock: big.NewInt(30)},
+			new:     &ChainConfig{ConstantinopleBlock: big.NewInt(30), PetersburgBlock: big.NewInt(30)},
+			head:    40,
+			wantErr: nil,
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
...if it is at the same block as ConstantinopleBlock

This is to enable private chains running on older Geth release `1.8.27` with `Constantinople` fork enabled (but not `Petersburg`) to apply `Petersburg` retroactively when upgrading to Geth 1.9.

Reference comments in another PR that was raised originally: https://github.com/ethereum/go-ethereum/pull/21447