### PR TITLE
node: support expressive origin rules in ws.origins

### DIFF
--- a/rpc/websocket.go
+++ b/rpc/websocket.go
@@ -75,14 +75,14 @@ func wsHandshakeValidator(allowedOrigins []string) func(*http.Request) bool {
 			allowAllOrigins = true
 		}
 		if origin != "" {
-			origins.Add(strings.ToLower(origin))
+			origins.Add(origin)
 		}
 	}
 	// allow localhost if no allowedOrigins are specified.
 	if len(origins.ToSlice()) == 0 {
 		origins.Add("http://localhost")
 		if hostname, err := os.Hostname(); err == nil {
-			origins.Add("http://" + strings.ToLower(hostname))
+			origins.Add("http://" + hostname)
 		}
 	}
 	log.Debug(fmt.Sprintf("Allowed origin(s) for WS RPC interface %v", origins.ToSlice()))
@@ -97,7 +97,7 @@ func wsHandshakeValidator(allowedOrigins []string) func(*http.Request) bool {
 		}
 		// Verify origin against whitelist.
 		origin := strings.ToLower(req.Header.Get("Origin"))
-		if allowAllOrigins || origins.Contains(origin) {
+		if allowAllOrigins || originIsAllowed(origins, origin) {
 			return true
 		}
 		log.Warn("Rejected WebSocket connection", "origin", origin)
@@ -118,6 +118,56 @@ func (e wsHandshakeError) Error() string {
 		s += " (HTTP status " + e.status + ")"
 	}
 	return s
+}
+
+func originIsAllowed(allowedOrigins mapset.Set, browserOrigin string) bool {
+	it := allowedOrigins.Iterator()
+	for origin := range it.C {
+		if ruleAllowsOrigin(origin.(string), browserOrigin) {
+			return true
+		}
+	}
+	return false
+}
+
+func ruleAllowsOrigin(allowedOrigin string, browserOrigin string) bool {
+	allowedScheme, allowedHostname, allowedPort, parsedAllowedErr := parseOriginURL(allowedOrigin)
+	browserScheme, browserHostname, browserPort, browserOriginErr := parseOriginURL(browserOrigin)
+	if parsedAllowedErr == nil && browserOriginErr == nil {
+		if allowedScheme != "" && browserScheme != "" && allowedScheme != browserScheme {
+			return false
+		}
+		if allowedHostname != "" && allowedHostname != browserHostname {
+			return false
+		}
+		if allowedPort != "" && browserPort != "" && allowedPort != browserPort {
+			return false
+		}
+		return true
+	} else { // parse error
+		log.Warn("Error parsing Origin URL in comparison for match.", "allowedOrigin", allowedOrigin, "browserOrigin", browserOrigin)
+		return false
+	}
+}
+
+func parseOriginURL(origin string) (string, string, string, error) {
+	parsedURL, parseError := url.Parse(strings.ToLower(origin))
+	var scheme, hostname, port string
+	if parseError == nil {
+		if strings.Contains(origin, "://") {
+			scheme = parsedURL.Scheme
+			hostname = parsedURL.Hostname()
+			port = parsedURL.Port()
+		} else {
+			scheme = ""
+			hostname = parsedURL.Scheme
+			port = parsedURL.Opaque
+			if hostname == "" {
+				hostname = origin
+			}
+		}
+	}
+	return scheme, hostname, port, parseError
 }
 
 // DialWebsocketWithDialer creates a new RPC client that communicates with a JSON-RPC server


### PR DESCRIPTION
Fixes issue: **Browser attack mitigation is overly specific** (converted to PR with potential implementation of suggested fix.)

#### System information

Geth version: Seen in 1.9.10, 1.9.18
OS & Version: Win10

#### Expected behaviour
When using the command line flags `--ws --ws.origins localhost` (along with ws.port and ws.api, dropping the dots for older versions), websocket requests from localhost in the browser will be accepted.  

#### Actual behaviour
Websocket requests from a browser on localhost are rejected, because the browser sets the origin to something like the full string "https://localhost:8540" and [this code](https://github.com/ethereum/go-ethereum/blob/90dedea40fc174c914ef038b8b480c2c0ff031b9/rpc/websocket.go#L100) just naiively checks to see if that exact origin string is in the set of origins permitted by the command-line flag.

#### Steps to reproduce the behaviour
1. Run Geth locally with ws.origins set to something specific, or leave out that flag altogether (in which case the default is a two-element set: `http://localhost, http://myhostnameinlowercase`)
2. Attempt to establish a Websocket connection from a browser, e.g. Chrome 84.0.4147.105 (Official Build) (64-bit) using web3 1.2.11 (`new Web3param.providers.WebsocketProvider(wsURL)`).
3. Observe in the browser console an error "Error during WebSocket handshake: Unexpected response code: 403"
4. Observe in geth logs this warning: "Rejected WebSocket connection            origin=https://localhost:8540"

#### Less secure workaround
Use `--ws.origins "*"` (as folks [are recommending](https://ethereum.stackexchange.com/questions/11527/geth-cant-connected-to-via-websocket)). 

#### More secure workaround
After observing this error, find the Origin string reported in the geth log and add that to the ws.origins command-line flag.

#### Suggested fix
Strip at least the port number and probably also the protocol (e.g. `https://`) from both the browser-populated Origin string and the command-line options or defaults before the call to `Contains`.  The former would be done here and the latter [here](https://github.com/ethereum/go-ethereum/blob/90dedea40fc174c914ef038b8b480c2c0ff031b9/rpc/websocket.go#L78).

#### Side benefits of this implementation
1. This uses a separately maintained and already-imported [URL-parsing library](https://golang.org/pkg/net/url/#URL.Hostname) to avoid possible edge case bugs from any kind of roll-your-own parsing. 
2. Using a helper function instead of just strings.ToLower consolidates all preparation steps in one function for more maintainable consistency, somewhat similar to the benefit of PR #21480.

Collaboration is welcome.