### PR TITLE
eth, les: handle nil-subscriptions

### DIFF
--- a/eth/discovery.go
+++ b/eth/discovery.go
@@ -43,7 +43,9 @@ func (e ethEntry) ENRKey() string {
 func (eth *Ethereum) startEthEntryUpdate(ln *enode.LocalNode) {
 	var newHead = make(chan core.ChainHeadEvent, 10)
 	sub := eth.blockchain.SubscribeChainHeadEvent(newHead)
-
+	if sub == nil {
+		return
+	}
 	go func() {
 		defer sub.Unsubscribe()
 		for {

--- a/les/server.go
+++ b/les/server.go
@@ -229,6 +229,9 @@ func (s *LesServer) capacityManagement() {
 
 	processCh := make(chan bool, 100)
 	sub := s.handler.blockchain.SubscribeBlockProcessingEvent(processCh)
+	if sub == nil {
+		return
+	}
 	defer sub.Unsubscribe()
 
 	totalRechargeCh := make(chan uint64, 100)

--- a/les/server_handler.go
+++ b/les/server_handler.go
@@ -911,8 +911,12 @@ func (h *serverHandler) broadcastHeaders() {
 
 	headCh := make(chan core.ChainHeadEvent, 10)
 	headSub := h.blockchain.SubscribeChainHeadEvent(headCh)
+	if headSub == nil {
+		// headSub can be nil, if the blockchain (and bc.scope)is Stop():ed very quickly, which
+		// can happen during tests. In that case, we're done here
+		return
+	}
 	defer headSub.Unsubscribe()
-
 	var (
 		lastHead *types.Header
 		lastTd   = common.Big0


### PR DESCRIPTION
This PR fixes an error happening from time to time on travis, example: https://travis-ci.org/github/ethereum/go-ethereum/jobs/720927357#L895  . 

The `bc.SubscribeXX` methods calls `bc.scope.Track(..`. 

>  If the scope is closed, Track returns nil.

Therefore, when we do very brief testing-runs on travis, it may happen that we close the scope before these goroutines actually start working. This was already properly handled in one place

https://github.com/ethereum/go-ethereum/blob/1b5a867eec711d83abfda18f7083f0c64a50f8b2/core/blockchain.go#L2282


 but not the rest. 