### PR TITLE
cmd/geth: added counters to the geth inspect report

### DIFF
--- a/core/rawdb/database.go
+++ b/core/rawdb/database.go
@@ -401,21 +401,6 @@ func InspectDatabase(db ethdb.Database) error {
 	if count, err := db.Ancients(); err == nil {
 		ancients = counter(count)
 	}
-	// Count receipts in ancient db
-	ancientReceipts := counter(0)
-	for blockNumber := uint64(0); blockNumber < uint64(ancients); blockNumber++ {
-		data, err := db.Ancient(freezerReceiptTable, blockNumber)
-		if err != nil {
-			log.Error("Error reading ancient receipts from block", "number", blockNumber, "err", err)
-		} else {
-			ancientReceipts += countReceiptsRLP(data)
-		}
-		if blockNumber%1000 == 0 && time.Since(logged) > 8*time.Second {
-			log.Info("Counting ancient database receipts", "blocknumber", blockNumber, "percentage", ancients.Percentage(blockNumber), "elapsed", common.PrettyDuration(time.Since(start)))
-			logged = time.Now()
-		}
-	}
-	log.Info("Counting ancient database receipts", "blocknumber", uint64(ancients), "percentage", "100", "elapsed", common.PrettyDuration(time.Since(start)))
 	// Display the database statistic.
 	stats := [][]string{
 		{"Key-Value store", "Headers", headers.Size(), headers.Count()},
@@ -436,7 +421,6 @@ func InspectDatabase(db ethdb.Database) error {
 		{"Ancient store", "Headers", ancientHeadersSize.String(), ancients.String()},
 		{"Ancient store", "Bodies", ancientBodiesSize.String(), ancients.String()},
 		{"Ancient store", "Receipt lists", ancientReceiptsSize.String(), ancients.String()},
-		{"Ancient store", "└ counted receipts", "--", ancientReceipts.String()},
 		{"Ancient store", "Difficulties", ancientTdsSize.String(), ancients.String()},
 		{"Ancient store", "Block number->hash", ancientHashesSize.String(), ancients.String()},
 		{"Light client", "CHT trie nodes", chtTrieNodes.Size(), chtTrieNodes.Count()},

--- a/core/rawdb/database.go
+++ b/core/rawdb/database.go
@@ -410,10 +410,11 @@ func InspectDatabase(db ethdb.Database) error {
 			ancientReceipts += countReceiptsRLP(data)
 		}
 		if blockNumber%1000 == 0 && time.Since(logged) > 8*time.Second {
-			log.Info("Counting ancient database receipts", "number", blockNumber, "percentage", ancients.Percentage(blockNumber), "elapsed", common.PrettyDuration(time.Since(start)))
+			log.Info("Counting ancient database receipts", "blocknumber", blockNumber, "percentage", ancients.Percentage(blockNumber), "elapsed", common.PrettyDuration(time.Since(start)))
 			logged = time.Now()
 		}
 	}
+	log.Info("Counting ancient database receipts", "blocknumber", uint64(ancients), "percentage", "100", "elapsed", common.PrettyDuration(time.Since(start)))
 	// Display the database statistic.
 	stats := [][]string{
 		{"Key-Value store", "Headers", headers.Size(), headers.Count()},
@@ -449,6 +450,5 @@ func InspectDatabase(db ethdb.Database) error {
 		log.Error("Database contains unaccounted data", "size", unaccounted.size, "count", unaccounted.count)
 	}
 
-	log.Info("Inspection completed", "elapsed", common.PrettyDuration(time.Since(start)))
 	return nil
 }

--- a/core/rawdb/database.go
+++ b/core/rawdb/database.go
@@ -21,15 +21,16 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"strconv"
 	"sync/atomic"
 	"time"
 
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/ethdb"
 	"github.com/ethereum/go-ethereum/ethdb/leveldb"
 	"github.com/ethereum/go-ethereum/ethdb/memorydb"
 	"github.com/ethereum/go-ethereum/log"
+	"github.com/ethereum/go-ethereum/rlp"
 	"github.com/olekukonko/tablewriter"
 )
 
@@ -239,8 +240,41 @@ func NewLevelDBDatabaseWithFreezer(file string, cache int, handles int, freezer 
 	return frdb, nil
 }
 
-func formatCounter(counter uint64) string {
-	return strconv.FormatUint(counter, 10)
+type counter uint64
+
+func (c counter) String() string {
+	return fmt.Sprintf("%d", c)
+}
+
+// stat stores sizes and count for a parameter
+type stat struct {
+	size  common.StorageSize
+	count counter
+}
+
+// Add size to the stat and increase the counter by 1
+func (s *stat) Add(size common.StorageSize) {
+	s.size += size
+	s.count++
+}
+
+func (s *stat) Size() string {
+	return s.size.String()
+}
+
+func (s *stat) Count() string {
+	return s.count.String()
+}
+
+// countReceiptsRLP counts how many receipts are stored in a RLP raw value
+func countReceiptsRLP(data rlp.RawValue) counter {
+	// Convert the receipts from their storage form to their internal representation
+	storageReceipts := []*types.ReceiptForStorage{}
+	if err := rlp.DecodeBytes(data, &storageReceipts); err != nil {
+		log.Error("Invalid receipt array RLP")
+		return counter(0)
+	}
+	return counter(len(storageReceipts))
 }
 
 // InspectDatabase traverses the entire database and checks the size
@@ -255,56 +289,38 @@ func InspectDatabase(db ethdb.Database) error {
 		logged = time.Now()
 
 		// Key-value store statistics
-		total           common.StorageSize
-		headerSize      common.StorageSize
-		bodySize        common.StorageSize
-		receiptSize     common.StorageSize
-		tdSize          common.StorageSize
-		numHashPairing  common.StorageSize
-		hashNumPairing  common.StorageSize
-		trieSize        common.StorageSize
-		codeSize        common.StorageSize
-		txlookupSize    common.StorageSize
-		accountSnapSize common.StorageSize
-		storageSnapSize common.StorageSize
-		preimageSize    common.StorageSize
-		bloomBitsSize   common.StorageSize
-		cliqueSnapsSize common.StorageSize
+		headers         stat
+		bodies          stat
+		receipts        stat
+		tds             stat
+		numHashPairings stat
+		hashNumPairings stat
+		tries           stat
+		codes           stat
+		txLookups       stat
+		accountSnaps    stat
+		storageSnaps    stat
+		preimages       stat
+		bloomBits       stat
+		cliqueSnaps     stat
 
 		// Ancient store statistics
-		ancientHeaders  common.StorageSize
-		ancientBodies   common.StorageSize
-		ancientReceipts common.StorageSize
-		ancientHashes   common.StorageSize
-		ancientTds      common.StorageSize
+		ancientHeadersSize  common.StorageSize
+		ancientBodiesSize   common.StorageSize
+		ancientReceiptsSize common.StorageSize
+		ancientTdsSize      common.StorageSize
+		ancientHashesSize   common.StorageSize
 
 		// Les statistic
-		chtTrieNodes   common.StorageSize
-		bloomTrieNodes common.StorageSize
+		chtTrieNodes   stat
+		bloomTrieNodes stat
 
 		// Meta- and unaccounted data
-		metadata    common.StorageSize
-		unaccounted common.StorageSize
+		metadata    stat
+		unaccounted stat
 
 		// Totals
-		headerSizeCount      uint64
-		bodySizeCount        uint64
-		receiptSizeCount     uint64
-		tdSizeCount          uint64
-		numHashPairingCount  uint64
-		hashNumPairingCount  uint64
-		trieSizeCount        uint64
-		codeSizeCount        uint64
-		txlookupSizeCount    uint64
-		accountSnapSizeCount uint64
-		storageSnapSizeCount uint64
-		preimageSizeCount    uint64
-		bloomBitsSizeCount   uint64
-		cliqueSnapsSizeCount uint64
-		chtTrieNodesCount    uint64
-		bloomTrieNodesCount  uint64
-		metadataCount        uint64
-		unaccountedCount     uint64
+		total common.StorageSize
 	)
 	// Inspect key-value database first.
 	for it.Next() {
@@ -314,67 +330,49 @@ func InspectDatabase(db ethdb.Database) error {
 		)
 		total += size
 		switch {
-		case bytes.HasPrefix(key, headerPrefix) && bytes.HasSuffix(key, headerTDSuffix):
-			tdSize += size
-			tdSizeCount++
-		case bytes.HasPrefix(key, headerPrefix) && bytes.HasSuffix(key, headerHashSuffix):
-			numHashPairing += size
-			numHashPairingCount++
 		case bytes.HasPrefix(key, headerPrefix) && len(key) == (len(headerPrefix)+8+common.HashLength):
-			headerSize += size
-			headerSizeCount++
-		case bytes.HasPrefix(key, headerNumberPrefix) && len(key) == (len(headerNumberPrefix)+common.HashLength):
-			hashNumPairing += size
-			hashNumPairingCount++
+			headers.Add(size)
 		case bytes.HasPrefix(key, blockBodyPrefix) && len(key) == (len(blockBodyPrefix)+8+common.HashLength):
-			bodySize += size
-			bodySizeCount++
+			bodies.Add(size)
 		case bytes.HasPrefix(key, blockReceiptsPrefix) && len(key) == (len(blockReceiptsPrefix)+8+common.HashLength):
-			receiptSize += size
-			receiptSizeCount++
-		case bytes.HasPrefix(key, txLookupPrefix) && len(key) == (len(txLookupPrefix)+common.HashLength):
-			txlookupSize += size
-			txlookupSizeCount++
-		case bytes.HasPrefix(key, SnapshotAccountPrefix) && len(key) == (len(SnapshotAccountPrefix)+common.HashLength):
-			accountSnapSize += size
-			accountSnapSizeCount++
-		case bytes.HasPrefix(key, SnapshotStoragePrefix) && len(key) == (len(SnapshotStoragePrefix)+2*common.HashLength):
-			storageSnapSize += size
-			storageSnapSizeCount++
-		case bytes.HasPrefix(key, preimagePrefix) && len(key) == (len(preimagePrefix)+common.HashLength):
-			preimageSize += size
-			preimageSizeCount++
-		case bytes.HasPrefix(key, bloomBitsPrefix) && len(key) == (len(bloomBitsPrefix)+10+common.HashLength):
-			bloomBitsSize += size
-			bloomBitsSizeCount++
-		case bytes.HasPrefix(key, []byte("clique-")) && len(key) == 7+common.HashLength:
-			cliqueSnapsSize += size
-			cliqueSnapsSizeCount++
-		case bytes.HasPrefix(key, []byte("cht-")) && len(key) == 4+common.HashLength:
-			chtTrieNodes += size
-			chtTrieNodesCount++
-		case bytes.HasPrefix(key, []byte("blt-")) && len(key) == 4+common.HashLength:
-			bloomTrieNodes += size
-			bloomTrieNodesCount++
-		case bytes.HasPrefix(key, codePrefix) && len(key) == len(codePrefix)+common.HashLength:
-			codeSize += size
-			codeSizeCount++
+			receipts.size += size
+			receipts.count += countReceiptsRLP(it.Value())
+		case bytes.HasPrefix(key, headerPrefix) && bytes.HasSuffix(key, headerTDSuffix):
+			tds.Add(size)
+		case bytes.HasPrefix(key, headerPrefix) && bytes.HasSuffix(key, headerHashSuffix):
+			numHashPairings.Add(size)
+		case bytes.HasPrefix(key, headerNumberPrefix) && len(key) == (len(headerNumberPrefix)+common.HashLength):
+			hashNumPairings.Add(size)
 		case len(key) == common.HashLength:
-			trieSize += size
-			trieSizeCount++
-		default:
+			tries.Add(size)
+		case bytes.HasPrefix(key, codePrefix) && len(key) == len(codePrefix)+common.HashLength:
+			codes.Add(size)
+		case bytes.HasPrefix(key, txLookupPrefix) && len(key) == (len(txLookupPrefix)+common.HashLength):
+			txLookups.Add(size)
+		case bytes.HasPrefix(key, SnapshotAccountPrefix) && len(key) == (len(SnapshotAccountPrefix)+common.HashLength):
+			accountSnaps.Add(size)
+		case bytes.HasPrefix(key, SnapshotStoragePrefix) && len(key) == (len(SnapshotStoragePrefix)+2*common.HashLength):
+			storageSnaps.Add(size)
+		case bytes.HasPrefix(key, preimagePrefix) && len(key) == (len(preimagePrefix)+common.HashLength):
+			preimages.Add(size)
+		case bytes.HasPrefix(key, bloomBitsPrefix) && len(key) == (len(bloomBitsPrefix)+10+common.HashLength):
+			bloomBits.Add(size)
+		case bytes.HasPrefix(key, []byte("clique-")) && len(key) == 7+common.HashLength:
+			cliqueSnaps.Add(size)
+		case bytes.HasPrefix(key, []byte("cht-")) && len(key) == 4+common.HashLength:
+			chtTrieNodes.Add(size)
+		case bytes.HasPrefix(key, []byte("blt-")) && len(key) == 4+common.HashLength:
+			bloomTrieNodes.Add(size)
 			var accounted bool
 			for _, meta := range [][]byte{databaseVerisionKey, headHeaderKey, headBlockKey, headFastBlockKey, fastTrieProgressKey} {
 				if bytes.Equal(key, meta) {
-					metadata += size
-					metadataCount++
+					metadata.Add(size)
 					accounted = true
 					break
 				}
 			}
 			if !accounted {
-				unaccounted += size
-				unaccountedCount++
+				unaccounted.Add(size)
 			}
 		}
 		count += 1
@@ -384,46 +382,67 @@ func InspectDatabase(db ethdb.Database) error {
 		}
 	}
 	// Inspect append-only file store then.
-	ancients := []*common.StorageSize{&ancientHeaders, &ancientBodies, &ancientReceipts, &ancientHashes, &ancientTds}
+	ancientSizes := []*common.StorageSize{&ancientHeadersSize, &ancientBodiesSize, &ancientReceiptsSize, &ancientHashesSize, &ancientTdsSize}
 	for i, category := range []string{freezerHeaderTable, freezerBodiesTable, freezerReceiptTable, freezerHashTable, freezerDifficultyTable} {
 		if size, err := db.AncientSize(category); err == nil {
-			*ancients[i] += common.StorageSize(size)
+			*ancientSizes[i] += common.StorageSize(size)
 			total += common.StorageSize(size)
+		}
+	}
+	// Get number of ancient rows inside the freezer
+	ancients := counter(0)
+	if count, err := db.Ancients(); err == nil {
+		ancients = counter(count)
+	}
+	// Count receipts in ancient db
+	ancientReceipts := counter(0)
+	for blockNumber := uint64(0); blockNumber <= uint64(ancients-1); blockNumber++ {
+		data, err := db.Ancient(freezerReceiptTable, blockNumber)
+		if err != nil {
+			log.Error("Error reading ancient receipts from block", "number", blockNumber, "err", err)
+		} else {
+			ancientReceipts += countReceiptsRLP(data)
+		}
+		if blockNumber%1000 == 0 && time.Since(logged) > 8*time.Second {
+			log.Info("Inspecting ancient database", "number", blockNumber, "elapsed", common.PrettyDuration(time.Since(start)))
+			logged = time.Now()
 		}
 	}
 	// Display the database statistic.
 	stats := [][]string{
-		{"Key-Value store", "Headers", headerSize.String(), formatCounter(headerSizeCount)},
-		{"Key-Value store", "Bodies", bodySize.String(), formatCounter(bodySizeCount)},
-		{"Key-Value store", "Receipts", receiptSize.String(), formatCounter(receiptSizeCount)},
-		{"Key-Value store", "Difficulties", tdSize.String(), formatCounter(tdSizeCount)},
-		{"Key-Value store", "Block number->hash", numHashPairing.String(), formatCounter(numHashPairingCount)},
-		{"Key-Value store", "Block hash->number", hashNumPairing.String(), formatCounter(hashNumPairingCount)},
-		{"Key-Value store", "Transaction index", txlookupSize.String(), formatCounter(txlookupSizeCount)},
-		{"Key-Value store", "Bloombit index", bloomBitsSize.String(), formatCounter(bloomBitsSizeCount)},
-		{"Key-Value store", "Contract codes", codeSize.String(), formatCounter(codeSizeCount)},
-		{"Key-Value store", "Trie nodes", trieSize.String(), formatCounter(trieSizeCount)},
-		{"Key-Value store", "Trie preimages", preimageSize.String(), formatCounter(preimageSizeCount)},
-		{"Key-Value store", "Account snapshot", accountSnapSize.String(), formatCounter(accountSnapSizeCount)},
-		{"Key-Value store", "Storage snapshot", storageSnapSize.String(), formatCounter(storageSnapSizeCount)},
-		{"Key-Value store", "Clique snapshots", cliqueSnapsSize.String(), formatCounter(cliqueSnapsSizeCount)},
-		{"Key-Value store", "Singleton metadata", metadata.String(), formatCounter(metadataCount)},
-		{"Ancient store", "Headers", ancientHeaders.String(), "NA"},
-		{"Ancient store", "Bodies", ancientBodies.String(), "NA"},
-		{"Ancient store", "Receipts", ancientReceipts.String(), "NA"},
-		{"Ancient store", "Difficulties", ancientTds.String(), "NA"},
-		{"Ancient store", "Block number->hash", ancientHashes.String(), "NA"},
-		{"Light client", "CHT trie nodes", chtTrieNodes.String(), formatCounter(chtTrieNodesCount)},
-		{"Light client", "Bloom trie nodes", bloomTrieNodes.String(), formatCounter(bloomTrieNodesCount)},
+		{"Key-Value store", "Headers", headers.Size(), headers.Count()},
+		{"Key-Value store", "Bodies", bodies.Size(), bodies.Count()},
+		{"Key-Value store", "Receipts", receipts.Size(), receipts.Count()},
+		{"Key-Value store", "Difficulties", tds.Size(), tds.Count()},
+		{"Key-Value store", "Block number->hash", numHashPairings.Size(), numHashPairings.Count()},
+		{"Key-Value store", "Block hash->number", hashNumPairings.Size(), hashNumPairings.Count()},
+		{"Key-Value store", "Transaction index", txLookups.Size(), txLookups.Count()},
+		{"Key-Value store", "Bloombit index", bloomBits.Size(), bloomBits.Count()},
+		{"Key-Value store", "Contract codes", codes.Size(), codes.Count()},
+		{"Key-Value store", "Trie nodes", tries.Size(), tries.Count()},
+		{"Key-Value store", "Trie preimages", preimages.Size(), preimages.Count()},
+		{"Key-Value store", "Account snapshot", accountSnaps.Size(), accountSnaps.Count()},
+		{"Key-Value store", "Storage snapshot", storageSnaps.Size(), storageSnaps.Count()},
+		{"Key-Value store", "Clique snapshots", cliqueSnaps.Size(), cliqueSnaps.Count()},
+		{"Key-Value store", "Singleton metadata", metadata.Size(), metadata.Count()},
+		{"Ancient store", "Headers", ancientHeadersSize.String(), ancients.String()},
+		{"Ancient store", "Bodies", ancientBodiesSize.String(), ancients.String()},
+		{"Ancient store", "Receipts", ancientReceiptsSize.String(), ancientReceipts.String()},
+		{"Ancient store", "Difficulties", ancientTdsSize.String(), ancients.String()},
+		{"Ancient store", "Block number->hash", ancientHashesSize.String(), ancients.String()},
+		{"Light client", "CHT trie nodes", chtTrieNodes.Size(), chtTrieNodes.Count()},
+		{"Light client", "Bloom trie nodes", bloomTrieNodes.Size(), bloomTrieNodes.Count()},
 	}
 	table := tablewriter.NewWriter(os.Stdout)
 	table.SetHeader([]string{"Database", "Category", "Size", "Count"})
-	table.SetFooter([]string{"", "Total", total.String(), ""})
+	table.SetFooter([]string{"", "Total", total.String(), " "})
 	table.AppendBulk(stats)
 	table.Render()
 
-	if unaccounted > 0 {
-		log.Error("Database contains unaccounted data", "size", unaccounted, "count", unaccountedCount)
+	if unaccounted.size > 0 {
+		log.Error("Database contains unaccounted data", "size", unaccounted.size, "count", unaccounted.count)
 	}
+
+	log.Info("Inspection completed", "elapsed", common.PrettyDuration(time.Since(start)))
 	return nil
 }

--- a/core/rawdb/database.go
+++ b/core/rawdb/database.go
@@ -25,7 +25,6 @@ import (
 	"time"
 
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/ethdb"
 	"github.com/ethereum/go-ethereum/ethdb/leveldb"
 	"github.com/ethereum/go-ethereum/ethdb/memorydb"
@@ -272,13 +271,16 @@ func (s *stat) Count() string {
 
 // countReceiptsRLP counts how many receipts are stored in a RLP raw value
 func countReceiptsRLP(data rlp.RawValue) counter {
-	// Convert the receipts from their storage form to their internal representation
-	storageReceipts := []*types.ReceiptForStorage{}
-	if err := rlp.DecodeBytes(data, &storageReceipts); err != nil {
-		log.Error("Invalid receipt array RLP")
+	it, err := rlp.NewListIterator(data)
+	if err != nil {
+		log.Warn("Receipt iteration error", "error", err)
 		return counter(0)
 	}
-	return counter(len(storageReceipts))
+	count := counter(0)
+	for it.Next() {
+		count++
+	}
+	return count
 }
 
 // InspectDatabase traverses the entire database and checks the size

--- a/core/rawdb/database.go
+++ b/core/rawdb/database.go
@@ -396,7 +396,7 @@ func InspectDatabase(db ethdb.Database) error {
 	}
 	// Count receipts in ancient db
 	ancientReceipts := counter(0)
-	for blockNumber := uint64(0); blockNumber <= uint64(ancients-1); blockNumber++ {
+	for blockNumber := uint64(0); blockNumber < uint64(ancients); blockNumber++ {
 		data, err := db.Ancient(freezerReceiptTable, blockNumber)
 		if err != nil {
 			log.Error("Error reading ancient receipts from block", "number", blockNumber, "err", err)

--- a/core/rawdb/database.go
+++ b/core/rawdb/database.go
@@ -369,6 +369,7 @@ func InspectDatabase(db ethdb.Database) error {
 			chtTrieNodes.Add(size)
 		case bytes.HasPrefix(key, []byte("blt-")) && len(key) == 4+common.HashLength:
 			bloomTrieNodes.Add(size)
+		default:
 			var accounted bool
 			for _, meta := range [][]byte{databaseVerisionKey, headHeaderKey, headBlockKey, headFastBlockKey, fastTrieProgressKey} {
 				if bytes.Equal(key, meta) {
@@ -381,7 +382,7 @@ func InspectDatabase(db ethdb.Database) error {
 				unaccounted.Add(size)
 			}
 		}
-		count += 1
+		count++
 		if count%1000 == 0 && time.Since(logged) > 8*time.Second {
 			log.Info("Inspecting database", "count", count, "elapsed", common.PrettyDuration(time.Since(start)))
 			logged = time.Now()

--- a/core/rawdb/database.go
+++ b/core/rawdb/database.go
@@ -434,14 +434,15 @@ func InspectDatabase(db ethdb.Database) error {
 		{"Key-Value store", "Singleton metadata", metadata.Size(), metadata.Count()},
 		{"Ancient store", "Headers", ancientHeadersSize.String(), ancients.String()},
 		{"Ancient store", "Bodies", ancientBodiesSize.String(), ancients.String()},
-		{"Ancient store", "Receipts", ancientReceiptsSize.String(), ancientReceipts.String()},
+		{"Ancient store", "Receipt lists", ancientReceiptsSize.String(), ancients.String()},
+		{"Ancient store", "└ counted receipts", "--", ancientReceipts.String()},
 		{"Ancient store", "Difficulties", ancientTdsSize.String(), ancients.String()},
 		{"Ancient store", "Block number->hash", ancientHashesSize.String(), ancients.String()},
 		{"Light client", "CHT trie nodes", chtTrieNodes.Size(), chtTrieNodes.Count()},
 		{"Light client", "Bloom trie nodes", bloomTrieNodes.Size(), bloomTrieNodes.Count()},
 	}
 	table := tablewriter.NewWriter(os.Stdout)
-	table.SetHeader([]string{"Database", "Category", "Size", "Count"})
+	table.SetHeader([]string{"Database", "Category", "Size", "Items"})
 	table.SetFooter([]string{"", "Total", total.String(), " "})
 	table.AppendBulk(stats)
 	table.Render()

--- a/core/rawdb/database.go
+++ b/core/rawdb/database.go
@@ -246,6 +246,10 @@ func (c counter) String() string {
 	return fmt.Sprintf("%d", c)
 }
 
+func (c counter) Percentage(current uint64) string {
+	return fmt.Sprintf("%d", current*100/uint64(c))
+}
+
 // stat stores sizes and count for a parameter
 type stat struct {
 	size  common.StorageSize
@@ -404,7 +408,7 @@ func InspectDatabase(db ethdb.Database) error {
 			ancientReceipts += countReceiptsRLP(data)
 		}
 		if blockNumber%1000 == 0 && time.Since(logged) > 8*time.Second {
-			log.Info("Inspecting ancient database", "number", blockNumber, "elapsed", common.PrettyDuration(time.Since(start)))
+			log.Info("Counting ancient database receipts", "number", blockNumber, "percentage", ancients.Percentage(blockNumber), "elapsed", common.PrettyDuration(time.Since(start)))
 			logged = time.Now()
 		}
 	}


### PR DESCRIPTION
Add counters to the stats from inspect command.

These counters are useful to better understand what's inside LevelDB and they can be useful to better answer some recurrent questions about geth stats like _how many state entries I must download before having a synced full node_? (see https://github.com/ethereum/go-ethereum/issues/14647)

This is a preview of the output, based on a goerli synced full node:

```zsh
❯ ./build/bin/geth --goerli inspect
INFO [08-27|13:51:50.845] Maximum peer count                       ETH=50 LES=0 total=50
INFO [08-27|13:51:50.845] Smartcard socket not found, disabling    err="stat /run/pcscd/pcscd.comm: no such file or directory"
INFO [08-27|13:51:50.848] Set global gas cap                       cap=25000000
INFO [08-27|13:51:50.848] Allocated cache and file handles         database=/home/developer/.ethereum/goerli/geth/chaindata cache=512.00MiB handles=524288
INFO [08-27|13:51:51.094] Opened ancient database                  database=/home/developer/.ethereum/goerli/geth/chaindata/ancient
INFO [08-27|13:51:51.110] Persisted trie from memory database      nodes=361 size=51.17KiB time="866.628µs" gcnodes=0 gcsize=0.00B gctime=0s livenodes=1 livesize=0.00B
INFO [08-27|13:51:51.112] Loaded most recent local header          number=3297447 hash="a32882…d2974c" td=4812390 age=11s
INFO [08-27|13:51:51.112] Loaded most recent local full block      number=3297447 hash="a32882…d2974c" td=4812390 age=11s
INFO [08-27|13:51:51.112] Loaded most recent local fast block      number=3297447 hash="a32882…d2974c" td=4812390 age=11s
INFO [08-27|13:51:51.112] Loaded last fast-sync pivot marker       number=3292045
INFO [08-27|13:51:59.134] Inspecting database                      count=12630000 elapsed=8.000s
INFO [08-27|13:52:07.134] Inspecting database                      count=24366000 elapsed=16.000s
+-----------------+--------------------+------------+----------+
|    DATABASE     |      CATEGORY      |    SIZE    |  COUNT   |
+-----------------+--------------------+------------+----------+
| Key-Value store | Headers            | 13.21 MiB  |    21399 |
| Key-Value store | Bodies             | 40.74 MiB  |    21572 |
| Key-Value store | Receipts           | 37.35 MiB  |    21572 |
| Key-Value store | Difficulties       | 1.03 MiB   |    22038 |
| Key-Value store | Block number->hash | 948.25 KiB |    21131 |
| Key-Value store | Block hash->number | 128.97 MiB |  3298371 |
| Key-Value store | Transaction index  | 10.44 MiB  |   304051 |
| Key-Value store | Bloombit index     | 102.89 MiB |  1646592 |
| Key-Value store | Contract codes     | 97.26 MiB  |    17962 |
| Key-Value store | Trie nodes         | 2.37 GiB   | 24296985 |
| Key-Value store | Trie preimages     | 3.90 MiB   |    54925 |
| Key-Value store | Account snapshot   | 0.00 B     |        0 |
| Key-Value store | Storage snapshot   | 0.00 B     |        0 |
| Key-Value store | Clique snapshots   | 80.15 KiB  |       99 |
| Key-Value store | Singleton metadata | 151.00 B   |        5 |
| Ancient store   | Headers            | 1.04 GiB   | NA       |
| Ancient store   | Bodies             | 1.09 GiB   | NA       |
| Ancient store   | Receipts           | 596.63 MiB | NA       |
| Ancient store   | Difficulties       | 31.21 MiB  | NA       |
| Ancient store   | Block number->hash | 118.75 MiB | NA       |
| Light client    | CHT trie nodes     | 0.00 B     |        0 |
| Light client    | Bloom trie nodes   | 0.00 B     |        0 |
+-----------------+--------------------+------------+----------+
|                         TOTAL        |  5.66 GIB  |           
+-----------------+--------------------+------------+----------+
ERROR[08-27|13:52:10.258] Database contains unaccounted data       size=100.74KiB count=3514
```