### PR TITLE
ethclient: add BlockNumber method

### DIFF
--- a/ethclient/ethclient.go
+++ b/ethclient/ethclient.go
@@ -88,6 +88,13 @@ func (ec *Client) BlockByNumber(ctx context.Context, number *big.Int) (*types.Bl
 	return ec.getBlock(ctx, "eth_getBlockByNumber", toBlockNumArg(number), true)
 }
 
+// BlockNumber returns the most recent block number
+func (ec *Client) BlockNumber(ctx context.Context) (uint64, error) {
+	var result hexutil.Uint64
+	err := ec.c.CallContext(ctx, &result, "eth_getBlockNumber", nil)
+	return uint64(result), err
+}
+
 type rpcBlock struct {
 	Hash         common.Hash      `json:"hash"`
 	Transactions []rpcTransaction `json:"transactions"`


### PR DESCRIPTION
This adds a new client method `BlockNumber` to fetch the most recent block number off the chain