### PR TITLE
accounts/usbwallet, signer/core: show accounts from ledger legacy derivation paths

### DIFF
--- a/accounts/usbwallet/wallet.go
+++ b/accounts/usbwallet/wallet.go
@@ -368,18 +368,22 @@ func (w *wallet) selfDerive() {
 					w.log.Warn("USB wallet nonce retrieval failed", "err", err)
 					break
 				}
-				// If the next account is empty, stop self-derivation, but add for the last base path
+				// We've just self-derived a new account, start tracking it locally
+				// unless the account was empty.
+				path := make(accounts.DerivationPath, len(nextPaths[i]))
+				copy(path[:], nextPaths[i][:])
 				if balance.Sign() == 0 && nonce == 0 {
 					empty = true
+					// If it indeed was empty, make a log output for it anyway. In the case
+					// of legacy-ledger, the first account on the legacy-path will
+					// be shown to the user, even if we don't actively track it
 					if i < len(nextAddrs)-1 {
+						w.log.Info("Skipping acc, use personal.deriveAccount(<url>,<path>, false) to track",
+							"path", path, "address", nextAddrs[i])
 						break
 					}
 				}
-				// We've just self-derived a new account, start tracking it locally
-				path := make(accounts.DerivationPath, len(nextPaths[i]))
-				copy(path[:], nextPaths[i][:])
 				paths = append(paths, path)
-
 				account := accounts.Account{
 					Address: nextAddrs[i],
 					URL:     accounts.URL{Scheme: w.url.Scheme, Path: fmt.Sprintf("%s/%s", w.url.Path, path)},

--- a/accounts/usbwallet/wallet.go
+++ b/accounts/usbwallet/wallet.go
@@ -378,7 +378,7 @@ func (w *wallet) selfDerive() {
 					// of legacy-ledger, the first account on the legacy-path will
 					// be shown to the user, even if we don't actively track it
 					if i < len(nextAddrs)-1 {
-						w.log.Info("Skipping acc, use personal.deriveAccount(<url>,<path>, false) to track",
+						w.log.Info("Skipping trakcking first account on legacy path, use personal.deriveAccount(<url>,<path>, false) to track",
 							"path", path, "address", nextAddrs[i])
 						break
 					}

--- a/signer/core/api.go
+++ b/signer/core/api.go
@@ -346,19 +346,28 @@ func (api *SignerAPI) startUSBListener() {
 			case accounts.WalletOpened:
 				status, _ := event.Wallet.Status()
 				log.Info("New wallet appeared", "url", event.Wallet.URL(), "status", status)
+				var derive = func(numToDerive int, base accounts.DerivationPath) {
+					// Derive first N accounts, hardcoded for now
+					var nextPath = make(accounts.DerivationPath, len(base))
+					copy(nextPath[:], base[:])
 
-				// Derive first N accounts, hardcoded for now
-				var nextPath = make(accounts.DerivationPath, len(accounts.DefaultBaseDerivationPath))
-				copy(nextPath[:], accounts.DefaultBaseDerivationPath[:])
-
-				for i := 0; i < numberOfAccountsToDerive; i++ {
-					acc, err := event.Wallet.Derive(nextPath, true)
-					if err != nil {
-						log.Warn("account derivation failed", "error", err)
-					} else {
-						log.Info("derived account", "address", acc.Address)
+					for i := 0; i < numToDerive; i++ {
+						acc, err := event.Wallet.Derive(nextPath, true)
+						if err != nil {
+							log.Warn("account derivation failed", "error", err)
+						} else {
+							log.Info("derived account", "address", acc.Address, "path", nextPath)
+						}
+						nextPath[len(nextPath)-1]++
 					}
-					nextPath[len(nextPath)-1]++
+				}
+				if event.Wallet.URL().Scheme == "ledger" {
+					log.Info("Deriving ledger default paths")
+					derive(numberOfAccountsToDerive/2, accounts.DefaultBaseDerivationPath)
+					log.Info("Deriving ledger legacy paths")
+					derive(numberOfAccountsToDerive/2, accounts.LegacyLedgerBaseDerivationPath)
+				} else {
+					derive(numberOfAccountsToDerive, accounts.DefaultBaseDerivationPath)
 				}
 			case accounts.WalletDropped:
 				log.Info("Old wallet dropped", "url", event.Wallet.URL())

--- a/signer/core/api.go
+++ b/signer/core/api.go
@@ -356,7 +356,7 @@ func (api *SignerAPI) startUSBListener() {
 						if err != nil {
 							log.Warn("Account derivation failed", "error", err)
 						} else {
-							log.Info("derived account", "address", acc.Address, "path", nextPath)
+							log.Info("Derived account", "address", acc.Address, "path", nextPath)
 						}
 						nextPath[len(nextPath)-1]++
 					}

--- a/signer/core/api.go
+++ b/signer/core/api.go
@@ -354,7 +354,7 @@ func (api *SignerAPI) startUSBListener() {
 					for i := 0; i < numToDerive; i++ {
 						acc, err := event.Wallet.Derive(nextPath, true)
 						if err != nil {
-							log.Warn("account derivation failed", "error", err)
+							log.Warn("Account derivation failed", "error", err)
 						} else {
 							log.Info("derived account", "address", acc.Address, "path", nextPath)
 						}


### PR DESCRIPTION


The derivation path used by ledger was changed, at some point, from being on the form 
`m/44'/60'/0'/0` into `m/44'/60'/0'/0/0`. 
This was also changed in geth, and the self-derivation added in https://github.com/ethereum/go-ethereum/pull/19438 was clever enough 
to use a chainreader: if it found that accounts on the old path were non-zero, then it kept deriving them. 

However, that doesn't work well in an offline-ish mode, or in conjunction with `clef`. 
This PR modifies it so that 
- For `geth`, the first will-be-skipped account is displayed in the log, so the user can more easily manually add/use the account.
- For `clef`, instead of deriving `10` default paths, we import `5` default and `5` legacy.
 

geth output:
```
> INFO [09-04|19:36:47.421] New wallet appeared                      url=ledger://0001:0004:00         status="Ethereum app v1.0.10 online"

> eth.accounts
INFO [09-04|19:36:53.707] Skipping acc, use personal.deriveAccount(<url>,<path>, false) to track url=ledger://0001:0004:00         path=m/44'/60'/0'/0 address=0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
INFO [09-04|19:36:53.987] USB wallet discovered new account        url=ledger://0001:0004:00         address=0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb path=m/44'/60'/0'/0/0 balance=0 nonce=0
["..., "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"]
> INFO [09-04|19:36:55.034] Initializing fast sync bloom             items=428129 errorrate=0.000 elapsed=8.001s
INFO [09-04|19:36:55.123] Initialized fast sync bloom              items=470567 errorrate=0.000 elapsed=8.090s

```

Clef output: 

```
INFO [09-04|19:41:20.762] New wallet appeared                      url=ledger://0001:0004:00     status="Ethereum app v1.0.10 online"
INFO [09-04|19:41:20.762] Deriving ledger default paths 
DEBUG[09-04|19:41:20.762] USB wallet health-check started          url=ledger://0001:0004:00
DEBUG[09-04|19:41:20.762] USB wallet self-derivation started       url=ledger://0001:0004:00
INFO [09-04|19:41:21.044] derived account                          address=0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb path=m/44'/60'/0'/0/0
INFO [09-04|19:41:21.332] derived account                          address=0xb111111111111111111111111111111111111111 path=m/44'/60'/0'/0/1
INFO [09-04|19:41:21.613] derived account                          address=0xb222222222222222222222222222222222222222 path=m/44'/60'/0'/0/2
INFO [09-04|19:41:21.898] derived account                          address=0xb333333333333333333333333333333333333333 path=m/44'/60'/0'/0/3
INFO [09-04|19:41:22.180] derived account                          address=0xb444444444444444444444444444444444444444 path=m/44'/60'/0'/0/4
INFO [09-04|19:41:22.180] Deriving ledger legacy paths 
INFO [09-04|19:41:22.379] derived account                          address=0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa path=m/44'/60'/0'/0
INFO [09-04|19:41:22.577] derived account                          address=0xa111111111111111111111111111111111111111 path=m/44'/60'/0'/1
INFO [09-04|19:41:22.775] derived account                          address=0xa222222222222222222222222222222222222222 path=m/44'/60'/0'/2
INFO [09-04|19:41:22.977] derived account                          address=0xa333333333333333333333333333333333333333 path=m/44'/60'/0'/3
INFO [09-04|19:41:23.176] derived account                          address=0xa444444444444444444444444444444444444444 path=m/44'/60'/0'/4

```