### PR TITLE
eth/downloader: only roll back light sync if not fully validating

### DIFF
--- a/eth/downloader/downloader_test.go
+++ b/eth/downloader/downloader_test.go
@@ -1020,10 +1020,9 @@ func testShiftedHeaderAttack(t *testing.T, protocol int, mode SyncMode) {
 // Tests that upon detecting an invalid header, the recent ones are rolled back
 // for various failure scenarios. Afterwards a full sync is attempted to make
 // sure no state was corrupted.
-func TestInvalidHeaderRollback63Fast(t *testing.T)  { testInvalidHeaderRollback(t, 63, FastSync) }
-func TestInvalidHeaderRollback64Fast(t *testing.T)  { testInvalidHeaderRollback(t, 64, FastSync) }
-func TestInvalidHeaderRollback65Fast(t *testing.T)  { testInvalidHeaderRollback(t, 65, FastSync) }
-func TestInvalidHeaderRollback65Light(t *testing.T) { testInvalidHeaderRollback(t, 65, LightSync) }
+func TestInvalidHeaderRollback63Fast(t *testing.T) { testInvalidHeaderRollback(t, 63, FastSync) }
+func TestInvalidHeaderRollback64Fast(t *testing.T) { testInvalidHeaderRollback(t, 64, FastSync) }
+func TestInvalidHeaderRollback65Fast(t *testing.T) { testInvalidHeaderRollback(t, 65, FastSync) }
 
 func testInvalidHeaderRollback(t *testing.T, protocol int, mode SyncMode) {
 	t.Parallel()


### PR DESCRIPTION
Fixes https://github.com/ethereum/go-ethereum/issues/21505.

There is a notion of rollbacks during fast sync, where recent blocks that might not be clean are deleted from the database on a sync failure. This is needed to avoid attacks on fast sync since we're not running transactions.

For light sync however, rollbacks are pointless because there's no batch of full blocks imported on top to validate them. As long as the PoW checks out, light clients will take the node's word for it.

This PR disables the rollback mechanism for light syncs, which was causing crashes in the light txpool due to deleting headers that it imported before. Interestingly, the issue was that the rollback mechanism wasn't disabled after initial sync (opposed to fast sync switching to full sync).