### PR TITLE
go.mod: remove golang.org/x/sync

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -59,7 +59,6 @@ require (
 	github.com/wsddn/go-ecdh v0.0.0-20161211032359-48726bab9208
 	golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9
 	golang.org/x/net v0.0.0-20200822124328-c89045814202 // indirect
-	golang.org/x/sync v0.0.0-20181108010431-42b317875d0f
 	golang.org/x/sys v0.0.0-20200824131525-c12d262b63d8
 	golang.org/x/text v0.3.3
 	golang.org/x/time v0.0.0-20190308202827-9d24e82272b4


### PR DESCRIPTION
golang.org/x/sync is not used in this module.

Run `go mod tidy`