### PR TITLE
internal/ethapi: add optional parameter blockNrOrHash to estimateGas

### DIFF
--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -1051,9 +1051,12 @@ func DoEstimateGas(ctx context.Context, b Backend, args CallArgs, blockNrOrHash 
 
 // EstimateGas returns an estimate of the amount of gas needed to execute the
 // given transaction against the current pending block.
-func (s *PublicBlockChainAPI) EstimateGas(ctx context.Context, args CallArgs) (hexutil.Uint64, error) {
-	blockNrOrHash := rpc.BlockNumberOrHashWithNumber(rpc.PendingBlockNumber)
-	return DoEstimateGas(ctx, s.b, args, blockNrOrHash, s.b.RPCGasCap())
+func (s *PublicBlockChainAPI) EstimateGas(ctx context.Context, args CallArgs, blockNrOrHash *rpc.BlockNumberOrHash) (hexutil.Uint64, error) {
+	bNrOrHash := rpc.BlockNumberOrHashWithNumber(rpc.PendingBlockNumber)
+	if blockNrOrHash != nil {
+		bNrOrHash = *blockNrOrHash
+	}
+	return DoEstimateGas(ctx, s.b, args, bNrOrHash, s.b.RPCGasCap())
 }
 
 // ExecutionResult groups all structured logs emitted by the EVM


### PR DESCRIPTION
This PR adds an optional parameter to EstimateGas to be in lne with the json-rpc specification.
Now you can choose to estimate your gas usage based on the pending block or the latest block, which ever might suite you best.

The JSON RPC spec of this API is

eth_estimateGas
Generates and returns an estimate of how much gas is necessary to allow the transaction to complete.

**Parameters**
**1. Object** - The transaction call object
`from`: DATA, 20 Bytes - The address the transaction is sent from.
`to`: DATA, 20 Bytes - (optional) The address the transaction is directed to.
`gas`: QUANTITY - (optional) Integer of the gas provided for the transaction execution. eth_call consumes zero gas, but this parameter may be needed by some executions.
`gasPrice`: QUANTITY - (optional) Integer of the gasPrice used for each paid gas
`value`: QUANTITY - (optional) Integer of the value sent with this transaction
`data`: DATA - (optional) Hash of the method signature and encoded parameters. For details see Ethereum Contract ABI

**2. Block number**
QUANTITY|TAG - (optional) integer block number, or the string "latest", "earliest" or "pending", see the default block parameter


Curl Example:
```
curl -H "Content-Type: application/json" -X POST  localhost:8545 --data '{"jsonrpc":"2.0","method":"eth_estimateGas","params":[{"from":"0x64CF3E7FC95B608C51bF3E3003b993bc55B56D15"}, "latest"],"id":1}'
```

closes https://github.com/ethereum/go-ethereum/issues/2586