### PR TITLE
Updated call_tracer to be more descriptive

### DIFF
--- a/eth/tracers/internal/tracers/call_tracer.js
+++ b/eth/tracers/internal/tracers/call_tracer.js
@@ -61,7 +61,14 @@
 			if (this.callstack[left-1].calls === undefined) {
 				this.callstack[left-1].calls = [];
 			}
-			this.callstack[left-1].calls.push({type: op});
+			this.callstack[left-1].calls.push({
+				type:    op,
+				from:    toHex(log.contract.getAddress()),
+				to:      toHex(toAddress(log.stack.peek(0).toString(16))),
+				gasIn:   log.getGas(),
+				gasCost: log.getCost(),
+				value:   '0x' + db.getBalance(log.contract.getAddress()).toString(16)
+			});
 			return
 		}
 		// If a new method invocation is being done, add to the call stack


### PR DESCRIPTION
Added the fields `to`, `from` and `value` to the tracer when the op is `SELFDESTRUCT`. This lets us figure out how much ETH was self destructed and helps with accounting. 

Example of trace before:
```
{
   "type":"CREATE",
   "from":"0x874b54a8bd152966d63f706bae1ffeb0411921e5",
   "to":"0xf191a640b0bfeb316cf3df5961896d502445414d",
   "value":"0x1",
   "gas":"0x3c0c4",
   "gasUsed":"0x7533",
   "input":"0x60fdff61000080610011600039610011565b6000f3",
   "output":"0x",
   "time":"79.869µs",
   "calls":[
      {
         "type":"SELFDESTRUCT"
      }
   ]
}
```

Example of trace after:
```
{
   "type":"CREATE",
   "from":"0x874b54a8bd152966d63f706bae1ffeb0411921e5",
   "to":"0xf191a640b0bfeb316cf3df5961896d502445414d",
   "value":"0x1",
   "gas":"0x3c0c4",
   "gasUsed":"0x7533",
   "input":"0x60fdff61000080610011600039610011565b6000f3",
   "output":"0x",
   "time":"2.660798ms",
   "calls":[
      {
         "type":"SELFDESTRUCT",
         "from":"0xf191a640b0bfeb316cf3df5961896d502445414d",
         "to":"0x00000000000000000000000000000000000000fd",
         "value":"0x1"
      }
   ]
}
```