### PR TITLE
cmd/utils: use preconfigured testnet flags instead of networkid

### DIFF
--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -128,7 +128,7 @@ var (
 	}
 	NetworkIdFlag = cli.Uint64Flag{
 		Name:  "networkid",
-		Usage: "Network identifier (integer, 1=Frontier, 3=Ropsten, 4=Rinkeby, 5=Görli)",
+		Usage: "Network identifier (integer, 1=Frontier, 3=Ropsten, 4=Rinkeby, 5=Görli), (for testnets: use --goerli, --ropsten, --rinkeby instead)",
 		Value: eth.DefaultConfig.NetworkId,
 	}
 	GoerliFlag = cli.BoolFlag{

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -128,7 +128,7 @@ var (
 	}
 	NetworkIdFlag = cli.Uint64Flag{
 		Name:  "networkid",
-		Usage: "Explicitly set network id (integer)(For testnets: use --goerli, --ropsten, --rinkeby instead)",
+		Usage: "Explicitly set network id (integer)(For testnets: use --ropsten, --rinkeby, --goerli instead)",
 		Value: eth.DefaultConfig.NetworkId,
 	}
 	GoerliFlag = cli.BoolFlag{

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -128,7 +128,7 @@ var (
 	}
 	NetworkIdFlag = cli.Uint64Flag{
 		Name:  "networkid",
-		Usage: "Network identifier (integer, 1=Frontier, 3=Ropsten, 4=Rinkeby, 5=Görli), (for testnets: use --goerli, --ropsten, --rinkeby instead)",
+		Usage: "Explicitly set network id (integer)(For testnets: use --goerli, --ropsten, --rinkeby instead)",
 		Value: eth.DefaultConfig.NetworkId,
 	}
 	GoerliFlag = cli.BoolFlag{


### PR DESCRIPTION
closes https://github.com/ethereum/go-ethereum/issues/21560