### PR TITLE
eth, core: free pointer from slice after popping element from price heap

### DIFF
--- a/core/tx_list.go
+++ b/core/tx_list.go
@@ -431,9 +431,10 @@ func (h *priceHeap) Push(x interface{}) {
 
 func (h *priceHeap) Pop() interface{} {
 	old := *h
-	n := len(old)
-	x := old[n-1]
-	*h = old[0 : n-1]
+	newLen := len(old) - 1
+	x := old[newLen]
+	old[newLen] = nil
+	*h = old[0:newLen]
 	return x
 }
 

--- a/core/tx_list.go
+++ b/core/tx_list.go
@@ -431,10 +431,10 @@ func (h *priceHeap) Push(x interface{}) {
 
 func (h *priceHeap) Pop() interface{} {
 	old := *h
-	newLen := len(old) - 1
-	x := old[newLen]
-	old[newLen] = nil
-	*h = old[0:newLen]
+	n := len(old)
+	x := old[n-1]
+	old[n-1] = nil
+	*h = old[0 : n-1]
 	return x
 }
 


### PR DESCRIPTION
As per the documentation for golang heap, heap Pop can cause a memory leak if the element that is returned is a pointer and is not set to nil. This causes the pointer to be held by the underlying array, such that it cannot be garbage collected.