### PR TITLE
p2p: recover from potential panics

### DIFF
--- a/p2p/peer.go
+++ b/p2p/peer.go
@@ -266,6 +266,11 @@ func (p *Peer) pingLoop() {
 }
 
 func (p *Peer) readLoop(errc chan<- error) {
+	defer func() {
+		if r := recover(); r != nil {
+			p.log.Error("ReadLoop for peer panic'd: %v", r)
+		}
+	}()
 	defer p.wg.Done()
 	for {
 		msg, err := p.rw.ReadMsg()

--- a/p2p/peer_test.go
+++ b/p2p/peer_test.go
@@ -140,6 +140,29 @@ func TestPeerProtoReadMsg(t *testing.T) {
 	}
 }
 
+func BenchmarkPeerProtoReadMsg(b *testing.B) {
+	rounds := b.N
+	proto := Protocol{
+		Name:   "a",
+		Length: 5,
+		Run: func(peer *Peer, rw MsgReadWriter) error {
+			for i := 0; i < rounds; i++ {
+				if err := ExpectMsg(rw, 3, []uint{uint(i)}); err != nil {
+					b.Error(err)
+				}
+			}
+			return nil
+		},
+	}
+
+	closer, rw, _, _ := testPeer([]Protocol{proto})
+	defer closer()
+
+	for i := 0; i < rounds; i++ {
+		Send(rw, baseProtocolLength+3, []uint{uint(i)})
+	}
+}
+
 func TestPeerProtoEncodeMsg(t *testing.T) {
 	proto := Protocol{
 		Name:   "a",


### PR DESCRIPTION
DON'T MERGE
```
master:
BenchmarkPeerProtoReadMsg-16    	   26704	     45878 ns/op	   40764 B/op	      59 allocs/op
```
```
p2p_recover
BenchmarkPeerProtoReadMsg-16    	   26688	     46185 ns/op	   40764 B/op	      59 allocs/op
```
~1% perf difference