### PR TITLE
build: keep geth-sources.jar build result for JavaDoc

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,8 @@ android:
 	$(GORUN) build/ci.go aar --local
 	@echo "Done building."
 	@echo "Import \"$(GOBIN)/geth.aar\" to use the library."
-
+	@echo "Import \"$(GOBIN)/geth-sources.jar\" to add javadocs"
+	@echo "For more info see https://stackoverflow.com/questions/20994336/android-studio-how-to-attach-javadoc"
 ios:
 	$(GORUN) build/ci.go xcode --local
 	@echo "Done building."

--- a/Makefile
+++ b/Makefile
@@ -26,6 +26,7 @@ android:
 	@echo "Import \"$(GOBIN)/geth.aar\" to use the library."
 	@echo "Import \"$(GOBIN)/geth-sources.jar\" to add javadocs"
 	@echo "For more info see https://stackoverflow.com/questions/20994336/android-studio-how-to-attach-javadoc"
+	
 ios:
 	$(GORUN) build/ci.go xcode --local
 	@echo "Done building."

--- a/build/ci.go
+++ b/build/ci.go
@@ -836,6 +836,7 @@ func doAndroidArchive(cmdline []string) {
 	if *local {
 		// If we're building locally, copy bundle to build dir and skip Maven
 		os.Rename("geth.aar", filepath.Join(GOBIN, "geth.aar"))
+		os.Rename("geth-sources.jar", filepath.Join(GOBIN, "geth-sources.jar"))
 		return
 	}
 	meta := newMavenMetadata(env)


### PR DESCRIPTION
closes https://github.com/ethereum/go-ethereum/issues/16127
closes https://github.com/ethereum/go-ethereum/issues/20941

Build the .aar and -sources.jar locally using `make android` and include them in your project.
See https://stackoverflow.com/questions/20994336/android-studio-how-to-attach-javadoc