### PR TITLE
mobile: added constructor for big int

### DIFF
--- a/mobile/big.go
+++ b/mobile/big.go
@@ -38,7 +38,7 @@ func NewBigInt(x int64) *BigInt {
 // NewBigIntFromString allocates and returns a new BigInt set to x
 // interpreted in the provided base.
 func NewBigIntFromString(x string, base int) *BigInt {
-	b, success := big.NewInt(0).SetString(x, base)
+	b, success := new(big.Int).SetString(x, base)
 	if !success {
 		return nil
 	}

--- a/mobile/big.go
+++ b/mobile/big.go
@@ -35,6 +35,16 @@ func NewBigInt(x int64) *BigInt {
 	return &BigInt{big.NewInt(x)}
 }
 
+// NewBigIntFromString allocates and returns a new BigInt set to x
+// interpreted in the provided base.
+func NewBigIntFromString(x string, base int) *BigInt {
+	b, success := big.NewInt(0).SetString(x, base)
+	if !success {
+		return nil
+	}
+	return &BigInt{b}
+}
+
 // GetBytes returns the absolute value of x as a big-endian byte slice.
 func (bi *BigInt) GetBytes() []byte {
 	return bi.bigint.Bytes()


### PR DESCRIPTION
closes https://github.com/ethereum/go-ethereum/issues/16364

Usage:
```java
BigInt b = new BigInt("1234", 10);
log(b.toString());
```