### PR TITLE
cmd/devp2p: add eth protocol test suite

### DIFF
--- a/cmd/devp2p/internal/ethtest/chain.go
+++ b/cmd/devp2p/internal/ethtest/chain.go
@@ -48,7 +48,7 @@ func (c *Chain) TD(height int) *big.Int { // TODO later on channge scheme so tha
 
 // ForkID gets the fork id of the chain.
 func (c *Chain) ForkID() forkid.ID {
-	return forkid.NewStaticID(c.chainConfig, c.blocks[0].Hash(), uint64(c.Len()))
+	return forkid.NewID(c.chainConfig, c.blocks[0].Hash(), uint64(c.Len()))
 }
 
 // Shorten returns a copy chain of a desired height from the imported

--- a/cmd/devp2p/internal/ethtest/chain.go
+++ b/cmd/devp2p/internal/ethtest/chain.go
@@ -4,16 +4,17 @@ import (
 	"compress/gzip"
 	"encoding/json"
 	"fmt"
-	"github.com/ethereum/go-ethereum/core"
-	"github.com/ethereum/go-ethereum/core/forkid"
-	"github.com/ethereum/go-ethereum/core/types"
-	"github.com/ethereum/go-ethereum/params"
-	"github.com/ethereum/go-ethereum/rlp"
 	"io"
 	"io/ioutil"
 	"math/big"
 	"os"
 	"strings"
+
+	"github.com/ethereum/go-ethereum/core"
+	"github.com/ethereum/go-ethereum/core/forkid"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/params"
+	"github.com/ethereum/go-ethereum/rlp"
 )
 
 type Chain struct {
@@ -27,7 +28,6 @@ func (c *Chain) WriteTo(writer io.Writer) error {
 			return err
 		}
 	}
-
 
 	return nil
 }
@@ -58,7 +58,7 @@ func (c *Chain) Shorten(height int) *Chain {
 
 	config := *c.chainConfig
 	return &Chain{
-		blocks: blocks,
+		blocks:      blocks,
 		chainConfig: &config,
 	}
 }

--- a/cmd/devp2p/internal/ethtest/chain.go
+++ b/cmd/devp2p/internal/ethtest/chain.go
@@ -1,0 +1,113 @@
+package ethtest
+
+import (
+	"compress/gzip"
+	"encoding/json"
+	"fmt"
+	"github.com/ethereum/go-ethereum/core"
+	"github.com/ethereum/go-ethereum/core/forkid"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/params"
+	"github.com/ethereum/go-ethereum/rlp"
+	"io"
+	"io/ioutil"
+	"math/big"
+	"os"
+	"strings"
+)
+
+type Chain struct {
+	blocks      []*types.Block
+	chainConfig *params.ChainConfig
+}
+
+func (c *Chain) WriteTo(writer io.Writer) error {
+	for _, block := range c.blocks {
+		if err := rlp.Encode(writer, block); err != nil {
+			return err
+		}
+	}
+
+
+	return nil
+}
+
+// Len returns the length of the chain.
+func (c *Chain) Len() int {
+	return len(c.blocks)
+}
+
+// TD calculates the total difficulty of the chain.
+func (c *Chain) TD(height int) *big.Int { // TODO later on channge scheme so that the height is included in range
+	sum := big.NewInt(0)
+	for _, block := range c.blocks[:height] {
+		sum.Add(sum, block.Difficulty())
+	}
+	return sum
+}
+
+// ForkID gets the fork id of the chain.
+func (c *Chain) ForkID() forkid.ID {
+	return forkid.NewStaticID(c.chainConfig, c.blocks[0].Hash(), uint64(c.Len()))
+}
+
+// Shorten returns a copy chain of a desired height from the imported
+func (c *Chain) Shorten(height int) *Chain {
+	blocks := make([]*types.Block, height)
+	copy(blocks, c.blocks[:height])
+
+	config := *c.chainConfig
+	return &Chain{
+		blocks: blocks,
+		chainConfig: &config,
+	}
+}
+
+// Head returns the chain head.
+func (c *Chain) Head() *types.Block {
+	return c.blocks[c.Len()-1]
+}
+
+// loadChain takes the given chain.rlp file, and decodes and returns
+// the blocks from the file.
+func loadChain(chainfile string, genesis string) (*Chain, error) {
+	// Open the file handle and potentially unwrap the gzip stream
+	fh, err := os.Open(chainfile)
+	if err != nil {
+		return nil, err
+	}
+	defer fh.Close()
+
+	var reader io.Reader = fh
+	if strings.HasSuffix(chainfile, ".gz") {
+		if reader, err = gzip.NewReader(reader); err != nil {
+			return nil, err
+		}
+	}
+	stream := rlp.NewStream(reader, 0)
+	var blocks []*types.Block
+	for i := 0; ; i++ {
+		var b types.Block
+		if err := stream.Decode(&b); err == io.EOF {
+			break
+		} else if err != nil {
+			return nil, fmt.Errorf("at block %d: %v", i, err)
+		}
+		blocks = append(blocks, &b)
+	}
+
+	// Open the file handle and potentially unwrap the gzip stream
+	chainConfig, err := ioutil.ReadFile(genesis)
+	if err != nil {
+		return nil, err
+	}
+	var gen core.Genesis
+	if err := json.Unmarshal(chainConfig, &gen); err != nil {
+		return nil, err
+	}
+
+	return &Chain{
+		blocks:      blocks,
+		chainConfig: gen.Config,
+	}, nil
+}

--- a/cmd/devp2p/internal/ethtest/suite.go
+++ b/cmd/devp2p/internal/ethtest/suite.go
@@ -41,8 +41,8 @@ func (c *Conn) Read() Message {
 	switch int(code) {
 	case (Hello{}).Code():
 		msg = new(Hello)
-	case (Disc{}).Code():
-		msg = new(Disc)
+	case (Disconnect{}).Code():
+		msg = new(Disconnect)
 	case (Status{}).Code():
 		msg = new(Status)
 	case (GetBlockHeaders{}).Code():

--- a/cmd/devp2p/internal/ethtest/suite.go
+++ b/cmd/devp2p/internal/ethtest/suite.go
@@ -239,15 +239,13 @@ func (s *Suite) TestGetBlockHeaders(t *utesting.T) {
 		t.Fatalf("could not write to connection: %v", err)
 	}
 
-	msg := conn.Read()
-	switch msg.Code() {
-	case 20:
-		headers, ok := msg.(*BlockHeaders)
-		if !ok {
-			t.Fatalf("message %v does not match code %d", msg, msg.Code())
-		}
+	switch msg := conn.Read().(type) {
+	case *BlockHeaders:
+		headers := msg
 		for _, header := range *headers {
-			t.Logf("\nHEADER FOR BLOCK NUMBER %d: %+v\n", header.Number, header) // TODO eventually check against our own data
+			num := header.Number.Uint64()
+			assert.Equal(t, s.chain.blocks[int(num)].Header(), header)
+			t.Logf("\nHEADER FOR BLOCK NUMBER %d: %+v\n", header.Number, header)
 		}
 	default:
 		t.Fatalf("error: %v", msg)
@@ -270,13 +268,9 @@ func (s *Suite) TestGetBlockBodies(t *utesting.T) {
 		t.Fatalf("could not write to connection: %v", err)
 	}
 
-	msg := conn.Read()
-	switch msg.Code() {
-	case 22:
-		bodies, ok := msg.(*BlockBodies)
-		if !ok {
-			t.Fatalf("message %v does not match code %d", msg, msg.Code()) // TODO eventually check against our own data
-		}
+	switch msg := conn.Read().(type) {
+	case *BlockBodies:
+		bodies := msg
 		for _, body := range *bodies {
 			t.Logf("\nBODY: %+v\n", body)
 		}

--- a/cmd/devp2p/internal/ethtest/suite.go
+++ b/cmd/devp2p/internal/ethtest/suite.go
@@ -206,8 +206,12 @@ func (s *Suite) TestStatus(t *utesting.T) {
 	// get protoHandshake
 	conn.handshake(t)
 	// get status
-	msg := conn.statusExchange(t, s.chain) // todo make this a switch
-	t.Logf("%+v\n", msg)
+	switch msg := conn.statusExchange(t, s.chain).(type) {
+	case *Status:
+		t.Logf("%+v\n", msg)
+	default:
+		t.Fatalf("error: %v", msg)
+	}
 }
 
 // TestGetBlockHeaders tests whether the given node can respond to
@@ -221,7 +225,7 @@ func (s *Suite) TestGetBlockHeaders(t *utesting.T) {
 	conn.handshake(t)
 	conn.statusExchange(t, s.chain)
 
-	// get block headers // TODO eventually make this customizable with CL args (take from a file)?
+	// get block headers
 	req := &GetBlockHeaders{
 		Origin: hashOrNumber{
 			Hash: s.chain.blocks[1].Hash(),
@@ -246,7 +250,7 @@ func (s *Suite) TestGetBlockHeaders(t *utesting.T) {
 			t.Logf("\nHEADER FOR BLOCK NUMBER %d: %+v\n", header.Number, header) // TODO eventually check against our own data
 		}
 	default:
-		t.Fatalf("error reading message: %v", msg)
+		t.Fatalf("error: %v", msg)
 	}
 }
 
@@ -277,11 +281,12 @@ func (s *Suite) TestGetBlockBodies(t *utesting.T) {
 			t.Logf("\nBODY: %+v\n", body)
 		}
 	default:
-		t.Fatalf("error reading message: %v", msg)
+		t.Fatalf("error: %v", msg)
 	}
 }
 
-// TestBroadcast // TODO how to make sure this is compatible with the imported blockchain of the node?
+// TestBroadcast tests whether a block announcement is correctly
+// propagated to the given node's peer(s).
 func (s *Suite) TestBroadcast(t *utesting.T) {
 	// create conn to send block announcement
 	sendConn, err := s.dial()

--- a/cmd/devp2p/internal/ethtest/suite.go
+++ b/cmd/devp2p/internal/ethtest/suite.go
@@ -174,24 +174,11 @@ func NewSuite(dest *enode.Node, chainfile string, genesisfile string) *Suite {
 
 func (s *Suite) AllTests() []utesting.Test {
 	return []utesting.Test{
-		{Name: "Ping", Fn: s.TestPing},
 		{Name: "Status", Fn: s.TestStatus},
 		{Name: "GetBlockHeaders", Fn: s.TestGetBlockHeaders},
 		{Name: "Broadcast", Fn: s.TestBroadcast},
 		{Name: "GetBlockBodies", Fn: s.TestGetBlockBodies},
 	}
-}
-
-// TestPing attempts to exchange `HELLO` messages
-// with the given node.
-func (s *Suite) TestPing(t *utesting.T) {
-	conn, err := s.dial()
-	if err != nil {
-		t.Fatalf("could not dial: %v", err)
-	}
-	// get protoHandshake
-	msg := conn.handshake(t)
-	t.Logf("%+v\n", msg)
 }
 
 // TestStatus attempts to connect to the given node and exchange

--- a/cmd/devp2p/internal/ethtest/suite.go
+++ b/cmd/devp2p/internal/ethtest/suite.go
@@ -3,18 +3,18 @@ package ethtest
 import (
 	"crypto/ecdsa"
 	"fmt"
-	"github.com/ethereum/go-ethereum/core/types"
-	"github.com/ethereum/go-ethereum/rlp"
+	"net"
+	"reflect"
 	"time"
 
+	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/internal/utesting"
 	"github.com/ethereum/go-ethereum/p2p"
 	"github.com/ethereum/go-ethereum/p2p/enode"
 	"github.com/ethereum/go-ethereum/p2p/rlpx"
+	"github.com/ethereum/go-ethereum/rlp"
 	"github.com/stretchr/testify/assert"
-	"net"
-	"reflect"
 )
 
 // Suite represents a structure used to test the eth
@@ -84,7 +84,7 @@ func (c *Conn) handshake(t *utesting.T) Message {
 	pub0 := crypto.FromECDSAPub(&c.ourKey.PublicKey)[1:]
 	ourHandshake := &Hello{
 		Version: 3,
-		Caps:    []p2p.Cap{{"eth", 64}, {"eth", 65}},
+		Caps:    []p2p.Cap{{Name: "eth", Version: 64}, {Name: "eth", Version: 65}},
 		ID:      pub0,
 	}
 	if err := c.Write(ourHandshake); err != nil {
@@ -129,8 +129,7 @@ func (c *Conn) statusExchange(t *utesting.T, chain *Chain) Message {
 		Genesis:         chain.blocks[0].Hash(),
 		ForkID:          chain.ForkID(),
 	}
-	if err := c.Write(status)
-		err != nil {
+	if err := c.Write(status); err != nil {
 		t.Fatalf("could not write to connection: %v", err)
 	}
 
@@ -151,7 +150,7 @@ func (c *Conn) waitForBlock(block *types.Block) error {
 			if len(*msg) > 0 {
 				return nil
 			}
-			time.Sleep(100*time.Millisecond)
+			time.Sleep(100 * time.Millisecond)
 		default:
 			return fmt.Errorf("invalid message: %v", msg)
 		}
@@ -175,11 +174,11 @@ func NewSuite(dest *enode.Node, chainfile string, genesisfile string) *Suite {
 
 func (s *Suite) AllTests() []utesting.Test {
 	return []utesting.Test{
-		{"Ping", s.TestPing},
-		{"Status", s.TestStatus},
-		{"GetBlockHeaders", s.TestGetBlockHeaders},
-		{"Broadcast", s.TestBroadcast},
-		{"GetBlockBodies", s.TestGetBlockBodies},
+		{Name: "Ping", Fn: s.TestPing},
+		{Name: "Status", Fn: s.TestStatus},
+		{Name: "GetBlockHeaders", Fn: s.TestGetBlockHeaders},
+		{Name: "Broadcast", Fn: s.TestBroadcast},
+		{Name: "GetBlockBodies", Fn: s.TestGetBlockBodies},
 	}
 }
 

--- a/cmd/devp2p/internal/ethtest/suite.go
+++ b/cmd/devp2p/internal/ethtest/suite.go
@@ -1,0 +1,304 @@
+package ethtest
+
+import (
+	"crypto/ecdsa"
+	"fmt"
+	"github.com/ethereum/go-ethereum/core/types"
+	"time"
+
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/internal/utesting"
+	"github.com/ethereum/go-ethereum/p2p"
+	"github.com/ethereum/go-ethereum/p2p/enode"
+	"github.com/ethereum/go-ethereum/p2p/rlpx"
+	"github.com/stretchr/testify/assert"
+	"net"
+	"reflect"
+)
+
+// Suite represents a structure used to test the eth
+// protocol of a node(s).
+type Suite struct {
+	Dest *enode.Node
+
+	chain     *Chain
+	fullChain *Chain
+}
+
+type Conn struct {
+	*rlpx.Conn
+	ourKey *ecdsa.PrivateKey
+}
+
+// handshake checks to make sure a `HELLO` is received.
+func (c *Conn) handshake(t *utesting.T) Message {
+	// write protoHandshake to client
+	pub0 := crypto.FromECDSAPub(&c.ourKey.PublicKey)[1:]
+	ourHandshake := &Hello{
+		Version: 3,
+		Caps:    []p2p.Cap{{"eth", 64}, {"eth", 65}},
+		ID:      pub0,
+	}
+	if err := Write(c.Conn, ourHandshake); err != nil {
+		t.Fatalf("could not write to connection: %v", err)
+	}
+	// read protoHandshake from client
+	switch msg := Read(c.Conn).(type) {
+	case *Hello:
+		return msg
+	default:
+		t.Fatalf("bad handshake: %v", msg)
+		return nil
+	}
+}
+
+// statusExchange performs a `Status` message exchange with the given
+// node.
+func (c *Conn) statusExchange(t *utesting.T, chain *Chain) Message {
+	// read status message from client
+	var message Message
+	switch msg := Read(c.Conn).(type) {
+	case *Status:
+		if msg.Head != chain.blocks[chain.Len()-1].Hash() {
+			t.Fatalf("wrong head in status: %v", msg.Head)
+		}
+		if msg.TD.Cmp(chain.TD(chain.Len())) != 0 {
+			t.Fatalf("wrong TD in status: %v", msg.TD)
+		}
+		if !reflect.DeepEqual(msg.ForkID, chain.ForkID()) {
+			t.Fatalf("wrong fork ID in status: %v", msg.ForkID)
+		}
+		message = msg
+	default:
+		t.Fatalf("bad status message: %v", msg)
+	}
+	// write status message to client
+	status := Status{
+		ProtocolVersion: 65,
+		NetworkID:       1,
+		TD:              chain.TD(chain.Len()),
+		Head:            chain.blocks[chain.Len()-1].Hash(),
+		Genesis:         chain.blocks[0].Hash(),
+		ForkID:          chain.ForkID(),
+	}
+	if err := Write(c.Conn, status)
+		err != nil {
+		t.Fatalf("could not write to connection: %v", err)
+	}
+
+	return message
+}
+
+// waitForBlock waits for confirmation from the client that it has
+// imported the given block.
+func (c *Conn) waitForBlock(block *types.Block) error {
+	for {
+		req := &GetBlockHeaders{Origin: hashOrNumber{Hash: block.Hash()}, Amount: 1}
+		if err := Write(c.Conn, req); err != nil {
+			return err
+		}
+
+		switch msg := Read(c.Conn).(type) {
+		case *BlockHeaders:
+			if len(*msg) > 0 {
+				return nil
+			}
+			time.Sleep(100*time.Millisecond)
+		default:
+			return fmt.Errorf("invalid message: %v", msg)
+		}
+	}
+}
+
+// NewSuite creates and returns a new eth-test suite that can
+// be used to test the given node against the given blockchain
+// data.
+func NewSuite(dest *enode.Node, chainfile string, genesisfile string) *Suite {
+	chain, err := loadChain(chainfile, genesisfile)
+	if err != nil {
+		panic(err)
+	}
+	return &Suite{
+		Dest:      dest,
+		chain:     chain.Shorten(1000),
+		fullChain: chain,
+	}
+}
+
+func (s *Suite) AllTests() []utesting.Test {
+	return []utesting.Test{
+		{"Ping", s.TestPing},
+		{"Status", s.TestStatus},
+		{"GetBlockHeaders", s.TestGetBlockHeaders},
+		{"Broadcast", s.TestBroadcast},
+		{"GetBlockBodies", s.TestGetBlockBodies},
+	}
+}
+
+// TestPing attempts to exchange `HELLO` messages
+// with the given node.
+func (s *Suite) TestPing(t *utesting.T) {
+	conn, err := s.dial()
+	if err != nil {
+		t.Fatalf("could not dial: %v", err)
+	}
+	// get protoHandshake
+	msg := conn.handshake(t)
+	t.Logf("%+v\n", msg)
+}
+
+// TestStatus attempts to connect to the given node and exchange
+// a status message with it, and then check to make sure
+// the chain head is correct.
+func (s *Suite) TestStatus(t *utesting.T) {
+	conn, err := s.dial()
+	if err != nil {
+		t.Fatalf("could not dial: %v", err)
+	}
+	// get protoHandshake
+	conn.handshake(t)
+	// get status
+	msg := conn.statusExchange(t, s.chain) // todo make this a switch
+	t.Logf("%+v\n", msg)
+}
+
+// TestGetBlockHeaders tests whether the given node can respond to
+// a `GetBlockHeaders` request and that the response is accurate.
+func (s *Suite) TestGetBlockHeaders(t *utesting.T) {
+	conn, err := s.dial()
+	if err != nil {
+		t.Fatalf("could not dial: %v", err)
+	}
+
+	conn.handshake(t)
+	conn.statusExchange(t, s.chain)
+
+	// get block headers // TODO eventually make this customizable with CL args (take from a file)?
+	req := &GetBlockHeaders{
+		Origin: hashOrNumber{
+			Hash: s.chain.blocks[1].Hash(),
+		},
+		Amount:  2,
+		Skip:    1,
+		Reverse: false,
+	}
+
+	if err := Write(conn.Conn, req); err != nil {
+		t.Fatalf("could not write to connection: %v", err)
+	}
+
+	msg := Read(conn.Conn)
+	switch msg.Code() {
+	case 20:
+		headers, ok := msg.(*BlockHeaders)
+		if !ok {
+			t.Fatalf("message %v does not match code %d", msg, msg.Code())
+		}
+		for _, header := range *headers {
+			t.Logf("\nHEADER FOR BLOCK NUMBER %d: %+v\n", header.Number, header) // TODO eventually check against our own data
+		}
+	default:
+		t.Fatalf("error reading message: %v", msg)
+	}
+}
+
+// TestGetBlockBodies tests whether the given node can respond to
+// a `GetBlockBodies` request and that the response is accurate.
+func (s *Suite) TestGetBlockBodies(t *utesting.T) {
+	conn, err := s.dial()
+	if err != nil {
+		t.Fatalf("could not dial: %v", err)
+	}
+
+	conn.handshake(t)
+	conn.statusExchange(t, s.chain)
+	// create block bodies request
+	req := &GetBlockBodies{s.chain.blocks[54].Hash(), s.chain.blocks[75].Hash()}
+	if err := Write(conn.Conn, req); err != nil {
+		t.Fatalf("could not write to connection: %v", err)
+	}
+
+	msg := Read(conn.Conn)
+	switch msg.Code() {
+	case 22:
+		bodies, ok := msg.(*BlockBodies)
+		if !ok {
+			t.Fatalf("message %v does not match code %d", msg, msg.Code()) // TODO eventually check against our own data
+		}
+		for _, body := range *bodies {
+			t.Logf("\nBODY: %+v\n", body)
+		}
+	default:
+		t.Fatalf("error reading message: %v", msg)
+	}
+}
+
+// TestBroadcast // TODO how to make sure this is compatible with the imported blockchain of the node?
+func (s *Suite) TestBroadcast(t *utesting.T) {
+	// create conn to send block announcement
+	sendConn, err := s.dial()
+	if err != nil {
+		t.Fatalf("could not dial: %v", err)
+	}
+	// create conn to receive block announcement
+	receiveConn, err := s.dial()
+	if err != nil {
+		t.Fatalf("could not dial: %v", err)
+	}
+
+	sendConn.handshake(t)
+	receiveConn.handshake(t)
+
+	sendConn.statusExchange(t, s.chain)
+	receiveConn.statusExchange(t, s.chain)
+
+	// sendConn sends the block announcement
+	blockAnnouncement := &NewBlock{
+		Block: s.fullChain.blocks[1000],
+		TD:    s.fullChain.TD(1001),
+	}
+	if err := Write(sendConn.Conn, blockAnnouncement); err != nil {
+		t.Fatalf("could not write to connection: %v", err)
+	}
+
+	switch msg := Read(receiveConn.Conn).(type) {
+	case *NewBlock:
+		assert.Equal(t, blockAnnouncement.Block.Header(), msg.Block.Header(),
+			"wrong block header in announcement")
+		assert.Equal(t, blockAnnouncement.TD, msg.TD,
+			"wrong TD in announcement")
+	case *NewBlockHashes:
+		hashes := *msg
+		assert.Equal(t, blockAnnouncement.Block.Hash(), hashes[0].Hash,
+			"wrong block hash in announcement")
+	default:
+		t.Fatal(msg)
+	}
+	// update test suite chain
+	s.chain.blocks = append(s.chain.blocks, s.fullChain.blocks[1000])
+	// wait for client to update its chain
+	if err := receiveConn.waitForBlock(s.chain.Head()); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// dial attempts to dial the given node and perform a handshake,
+// returning the created Conn if successful.
+func (s *Suite) dial() (*Conn, error) {
+	var conn Conn
+
+	fd, err := net.Dial("tcp", fmt.Sprintf("%v:%d", s.Dest.IP(), s.Dest.TCP()))
+	if err != nil {
+		return nil, err
+	}
+	conn.Conn = rlpx.NewConn(fd, s.Dest.Pubkey())
+
+	// do encHandshake
+	conn.ourKey, _ = crypto.GenerateKey()
+	_, err = conn.Handshake(conn.ourKey)
+	if err != nil {
+		return nil, err
+	}
+
+	return &conn, nil
+}

--- a/cmd/devp2p/internal/ethtest/types.go
+++ b/cmd/devp2p/internal/ethtest/types.go
@@ -1,0 +1,178 @@
+package ethtest
+
+import (
+"fmt"
+"github.com/ethereum/go-ethereum/common"
+"github.com/ethereum/go-ethereum/core/forkid"
+"github.com/ethereum/go-ethereum/core/types"
+"github.com/ethereum/go-ethereum/p2p"
+"github.com/ethereum/go-ethereum/p2p/rlpx"
+"github.com/ethereum/go-ethereum/rlp"
+"io"
+"math/big"
+)
+
+type Message interface {
+	Code() int
+	//Protocol() int // TODO
+}
+
+func Read(conn *rlpx.Conn) Message {
+	code, rawData, err := conn.Read()
+	if err != nil {
+		return &Error{fmt.Errorf("could not read from connection: %v", err)}
+	}
+
+	var msg Message
+	switch int(code) {
+	case (Hello{}).Code():
+		msg = new(Hello)
+	case (Disc{}).Code():
+		msg = new(Disc)
+	case (Status{}).Code():
+		msg = new(Status)
+	case (GetBlockHeaders{}).Code():
+		msg = new(GetBlockHeaders)
+	case (BlockHeaders{}).Code():
+		msg = new(BlockHeaders)
+	case (GetBlockBodies{}).Code():
+		msg = new(GetBlockBodies)
+	case (BlockBodies{}).Code():
+		msg = new(BlockBodies)
+	case (NewBlock{}).Code():
+		msg = new(NewBlock)
+	case (NewBlockHashes{}).Code():
+		msg = new(NewBlockHashes)
+	default:
+		return &Error{fmt.Errorf("invalid message code: %d", code)}
+	}
+
+	if err := rlp.DecodeBytes(rawData, msg); err != nil {
+		return &Error{fmt.Errorf("could not rlp decode message: %v", err)}
+	}
+
+	return msg
+}
+
+func Write(conn *rlpx.Conn, msg Message) error { // TODO eventually put this method on the Conn
+	size, payload, err := rlp.EncodeToReader(msg)
+	if err != nil {
+		return err
+	}
+	_, err = conn.WriteMsg(uint64(msg.Code()), uint32(size), payload)
+	return err
+}
+
+type Error struct {
+	err error
+}
+
+func (e *Error) Unwrap() error { return e.err }
+func (e *Error) Error() string { return e.err.Error() }
+func (e *Error) Code() int     { return -1 }
+
+// Hello is the RLP structure of the protocol handshake.
+type Hello struct {
+	Version    uint64
+	Name       string
+	Caps       []p2p.Cap
+	ListenPort uint64
+	ID         []byte // secp256k1 public key
+
+	// Ignore additional fields (for forward compatibility).
+	Rest []rlp.RawValue `rlp:"tail"`
+}
+
+func (h Hello) Code() int { return 0x00 }
+
+type Disc struct {
+	Reason p2p.DiscReason
+}
+
+func (d Disc) Code() int { return 0x01 }
+
+// Status is the network packet for the status message for eth/64 and later.
+type Status struct {
+	ProtocolVersion uint32
+	NetworkID       uint64
+	TD              *big.Int
+	Head            common.Hash
+	Genesis         common.Hash
+	ForkID          forkid.ID
+}
+
+func (s Status) Code() int { return 16 }
+
+//func (sd *statusData) Protocol() int {
+//
+//}
+
+// NewBlockHashes is the network packet for the block announcements.
+type NewBlockHashes []struct {
+	Hash   common.Hash // Hash of one particular block being announced
+	Number uint64      // Number of one particular block being announced
+}
+func (nbh NewBlockHashes) Code() int { return 17 }
+
+// NewBlock is the network packet for the block propagation message.
+type NewBlock struct {
+	Block *types.Block
+	TD    *big.Int
+}
+func (nb NewBlock) Code() int { return 23 }
+
+// GetBlockHeaders represents a block header query.
+type GetBlockHeaders struct {
+	Origin  hashOrNumber // Block from which to retrieve headers
+	Amount  uint64       // Maximum number of headers to retrieve
+	Skip    uint64       // Blocks to skip between consecutive headers
+	Reverse bool         // Query direction (false = rising towards latest, true = falling towards genesis)
+}
+func (g GetBlockHeaders) Code() int { return 19 }
+
+type BlockHeaders []*types.Header
+func (bh BlockHeaders) Code() int { return 20 }
+
+// HashOrNumber is a combined field for specifying an origin block.
+type hashOrNumber struct {
+	Hash   common.Hash // Block hash from which to retrieve headers (excludes Number)
+	Number uint64      // Block hash from which to retrieve headers (excludes Hash)
+}
+
+// EncodeRLP is a specialized encoder for hashOrNumber to encode only one of the
+// two contained union fields.
+func (hn *hashOrNumber) EncodeRLP(w io.Writer) error {
+	if hn.Hash == (common.Hash{}) {
+		return rlp.Encode(w, hn.Number)
+	}
+	if hn.Number != 0 {
+		return fmt.Errorf("both origin hash (%x) and number (%d) provided", hn.Hash, hn.Number)
+	}
+	return rlp.Encode(w, hn.Hash)
+}
+
+// DecodeRLP is a specialized decoder for hashOrNumber to decode the contents
+// into either a block hash or a block number.
+func (hn *hashOrNumber) DecodeRLP(s *rlp.Stream) error {
+	_, size, _ := s.Kind()
+	origin, err := s.Raw()
+	if err == nil {
+		switch {
+		case size == 32:
+			err = rlp.DecodeBytes(origin, &hn.Hash)
+		case size <= 8:
+			err = rlp.DecodeBytes(origin, &hn.Number)
+		default:
+			err = fmt.Errorf("invalid input size %d for origin", size)
+		}
+	}
+	return err
+}
+
+// GetBlockBodies represents a GetBlockBodies request
+type GetBlockBodies []common.Hash
+func (gbb GetBlockBodies) Code() int { return 21 }
+
+// BlockBodies is the network packet for block content distribution.
+type BlockBodies []*types.Body
+func (bb BlockBodies) Code() int { return 22 }

--- a/cmd/devp2p/internal/ethtest/types.go
+++ b/cmd/devp2p/internal/ethtest/types.go
@@ -38,11 +38,12 @@ type Hello struct {
 
 func (h Hello) Code() int { return 0x00 }
 
-type Disc struct {
+// Disconnect is the RLP structure for a disconnect message.
+type Disconnect struct {
 	Reason p2p.DiscReason
 }
 
-func (d Disc) Code() int { return 0x01 }
+func (d Disconnect) Code() int { return 0x01 }
 
 // Status is the network packet for the status message for eth/64 and later.
 type Status struct {
@@ -55,10 +56,6 @@ type Status struct {
 }
 
 func (s Status) Code() int { return 16 }
-
-//func (sd *statusData) Protocol() int {
-//
-//}
 
 // NewBlockHashes is the network packet for the block announcements.
 type NewBlockHashes []struct {

--- a/cmd/devp2p/internal/ethtest/types.go
+++ b/cmd/devp2p/internal/ethtest/types.go
@@ -1,66 +1,18 @@
 package ethtest
 
 import (
-"fmt"
-"github.com/ethereum/go-ethereum/common"
-"github.com/ethereum/go-ethereum/core/forkid"
-"github.com/ethereum/go-ethereum/core/types"
-"github.com/ethereum/go-ethereum/p2p"
-"github.com/ethereum/go-ethereum/p2p/rlpx"
-"github.com/ethereum/go-ethereum/rlp"
-"io"
-"math/big"
+	"fmt"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/forkid"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/p2p"
+	"github.com/ethereum/go-ethereum/rlp"
+	"io"
+	"math/big"
 )
 
 type Message interface {
 	Code() int
-	//Protocol() int // TODO
-}
-
-func Read(conn *rlpx.Conn) Message {
-	code, rawData, err := conn.Read()
-	if err != nil {
-		return &Error{fmt.Errorf("could not read from connection: %v", err)}
-	}
-
-	var msg Message
-	switch int(code) {
-	case (Hello{}).Code():
-		msg = new(Hello)
-	case (Disc{}).Code():
-		msg = new(Disc)
-	case (Status{}).Code():
-		msg = new(Status)
-	case (GetBlockHeaders{}).Code():
-		msg = new(GetBlockHeaders)
-	case (BlockHeaders{}).Code():
-		msg = new(BlockHeaders)
-	case (GetBlockBodies{}).Code():
-		msg = new(GetBlockBodies)
-	case (BlockBodies{}).Code():
-		msg = new(BlockBodies)
-	case (NewBlock{}).Code():
-		msg = new(NewBlock)
-	case (NewBlockHashes{}).Code():
-		msg = new(NewBlockHashes)
-	default:
-		return &Error{fmt.Errorf("invalid message code: %d", code)}
-	}
-
-	if err := rlp.DecodeBytes(rawData, msg); err != nil {
-		return &Error{fmt.Errorf("could not rlp decode message: %v", err)}
-	}
-
-	return msg
-}
-
-func Write(conn *rlpx.Conn, msg Message) error { // TODO eventually put this method on the Conn
-	size, payload, err := rlp.EncodeToReader(msg)
-	if err != nil {
-		return err
-	}
-	_, err = conn.WriteMsg(uint64(msg.Code()), uint32(size), payload)
-	return err
 }
 
 type Error struct {

--- a/cmd/devp2p/internal/ethtest/types.go
+++ b/cmd/devp2p/internal/ethtest/types.go
@@ -2,13 +2,14 @@ package ethtest
 
 import (
 	"fmt"
+	"io"
+	"math/big"
+
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/forkid"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/p2p"
 	"github.com/ethereum/go-ethereum/rlp"
-	"io"
-	"math/big"
 )
 
 type Message interface {
@@ -64,6 +65,7 @@ type NewBlockHashes []struct {
 	Hash   common.Hash // Hash of one particular block being announced
 	Number uint64      // Number of one particular block being announced
 }
+
 func (nbh NewBlockHashes) Code() int { return 17 }
 
 // NewBlock is the network packet for the block propagation message.
@@ -71,6 +73,7 @@ type NewBlock struct {
 	Block *types.Block
 	TD    *big.Int
 }
+
 func (nb NewBlock) Code() int { return 23 }
 
 // GetBlockHeaders represents a block header query.
@@ -80,9 +83,11 @@ type GetBlockHeaders struct {
 	Skip    uint64       // Blocks to skip between consecutive headers
 	Reverse bool         // Query direction (false = rising towards latest, true = falling towards genesis)
 }
+
 func (g GetBlockHeaders) Code() int { return 19 }
 
 type BlockHeaders []*types.Header
+
 func (bh BlockHeaders) Code() int { return 20 }
 
 // HashOrNumber is a combined field for specifying an origin block.
@@ -123,8 +128,10 @@ func (hn *hashOrNumber) DecodeRLP(s *rlp.Stream) error {
 
 // GetBlockBodies represents a GetBlockBodies request
 type GetBlockBodies []common.Hash
+
 func (gbb GetBlockBodies) Code() int { return 21 }
 
 // BlockBodies is the network packet for block content distribution.
 type BlockBodies []*types.Body
+
 func (bb BlockBodies) Code() int { return 22 }

--- a/cmd/devp2p/main.go
+++ b/cmd/devp2p/main.go
@@ -81,7 +81,7 @@ func commandHasFlag(ctx *cli.Context, flag cli.Flag) bool {
 
 // getNodeArg handles the common case of a single node descriptor argument.
 func getNodeArg(ctx *cli.Context) *enode.Node {
-	if ctx.NArg() != 1 {
+	if ctx.NArg() < 1 {
 		exit("missing node as command-line argument")
 	}
 	n, err := parseNode(ctx.Args()[0])

--- a/cmd/devp2p/rlpxcmd.go
+++ b/cmd/devp2p/rlpxcmd.go
@@ -18,6 +18,9 @@ package main
 
 import (
 	"fmt"
+	"net"
+	"os"
+
 	"github.com/ethereum/go-ethereum/cmd/devp2p/internal/ethtest"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/internal/utesting"
@@ -25,8 +28,6 @@ import (
 	"github.com/ethereum/go-ethereum/p2p/rlpx"
 	"github.com/ethereum/go-ethereum/rlp"
 	"gopkg.in/urfave/cli.v1"
-	"net"
-	"os"
 )
 
 var (
@@ -39,16 +40,16 @@ var (
 		},
 	}
 	rlpxPingCommand = cli.Command{
-		Name: "ping",
-		Usage: "ping <node>",
+		Name:   "ping",
+		Usage:  "ping <node>",
 		Action: rlpxPing,
 	}
 	rlpxEthTestCommand = cli.Command{
-		Name:   "eth-test",
-		Usage:  "Runs tests against a node",
+		Name:      "eth-test",
+		Usage:     "Runs tests against a node",
 		ArgsUsage: "<node> <path_to_chain.rlp_file>",
-		Action: rlpxEthTest,
-		Flags:  []cli.Flag{testPatternFlag},
+		Action:    rlpxEthTest,
+		Flags:     []cli.Flag{testPatternFlag},
 	}
 )
 

--- a/cmd/devp2p/rlpxcmd.go
+++ b/cmd/devp2p/rlpxcmd.go
@@ -29,9 +29,6 @@ import (
 	"os"
 )
 
-// TODO TO TEST:
-// TODO: - GETBLOCKHEADERS, GETBLOCKBODIES, 2 CONN BLOCK PROPAGATION TEST
-
 var (
 	rlpxCommand = cli.Command{
 		Name:  "rlpx",
@@ -49,7 +46,7 @@ var (
 	rlpxEthTestCommand = cli.Command{
 		Name:   "eth-test",
 		Usage:  "Runs tests against a node",
-		ArgsUsage: "<node> <path_to_chain.rlp_file>", // TODO maybe better?
+		ArgsUsage: "<node> <path_to_chain.rlp_file>",
 		Action: rlpxEthTest,
 		Flags:  []cli.Flag{testPatternFlag},
 	}
@@ -67,7 +64,7 @@ func rlpxPing(ctx *cli.Context) error {
 	if err != nil {
 		return err
 	}
-	code, data, err := conn.Read()
+	code, data, _, err := conn.Read()
 	if err != nil {
 		return err
 	}

--- a/cmd/devp2p/rlpxcmd.go
+++ b/cmd/devp2p/rlpxcmd.go
@@ -18,15 +18,19 @@ package main
 
 import (
 	"fmt"
-	"net"
-
-	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/ethereum/go-ethereum/cmd/devp2p/internal/ethtest"
 	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/internal/utesting"
 	"github.com/ethereum/go-ethereum/p2p"
 	"github.com/ethereum/go-ethereum/p2p/rlpx"
 	"github.com/ethereum/go-ethereum/rlp"
 	"gopkg.in/urfave/cli.v1"
+	"net"
+	"os"
 )
+
+// TODO TO TEST:
+// TODO: - GETBLOCKHEADERS, GETBLOCKBODIES, 2 CONN BLOCK PROPAGATION TEST
 
 var (
 	rlpxCommand = cli.Command{
@@ -34,38 +38,42 @@ var (
 		Usage: "RLPx Commands",
 		Subcommands: []cli.Command{
 			rlpxPingCommand,
+			rlpxEthTestCommand,
 		},
 	}
 	rlpxPingCommand = cli.Command{
-		Name:      "ping",
-		Usage:     "Perform a RLPx handshake",
-		ArgsUsage: "<node>",
-		Action:    rlpxPing,
+		Name: "ping",
+		Usage: "ping <node>",
+		Action: rlpxPing,
+	}
+	rlpxEthTestCommand = cli.Command{
+		Name:   "eth-test",
+		Usage:  "Runs tests against a node",
+		ArgsUsage: "<node> <path_to_chain.rlp_file>", // TODO maybe better?
+		Action: rlpxEthTest,
+		Flags:  []cli.Flag{testPatternFlag},
 	}
 )
 
 func rlpxPing(ctx *cli.Context) error {
 	n := getNodeArg(ctx)
-
 	fd, err := net.Dial("tcp", fmt.Sprintf("%v:%d", n.IP(), n.TCP()))
 	if err != nil {
 		return err
 	}
 	conn := rlpx.NewConn(fd, n.Pubkey())
-
 	ourKey, _ := crypto.GenerateKey()
 	_, err = conn.Handshake(ourKey)
 	if err != nil {
 		return err
 	}
-
-	code, data, _, err := conn.Read()
+	code, data, err := conn.Read()
 	if err != nil {
 		return err
 	}
 	switch code {
 	case 0:
-		var h devp2pHandshake
+		var h ethtest.Hello
 		if err := rlp.DecodeBytes(data, &h); err != nil {
 			return fmt.Errorf("invalid handshake: %v", err)
 		}
@@ -82,13 +90,22 @@ func rlpxPing(ctx *cli.Context) error {
 	return nil
 }
 
-// devp2pHandshake is the RLP structure of the devp2p protocol handshake.
-type devp2pHandshake struct {
-	Version    uint64
-	Name       string
-	Caps       []p2p.Cap
-	ListenPort uint64
-	ID         hexutil.Bytes // secp256k1 public key
-	// Ignore additional fields (for forward compatibility).
-	Rest []rlp.RawValue `rlp:"tail"`
+func rlpxEthTest(ctx *cli.Context) error {
+	if ctx.NArg() < 3 {
+		exit("missing path to chain.rlp as command-line argument")
+	}
+
+	suite := ethtest.NewSuite(getNodeArg(ctx), ctx.Args()[1], ctx.Args()[2])
+
+	// Filter and run test cases.
+	tests := suite.AllTests()
+	if ctx.IsSet(testPatternFlag.Name) {
+		tests = utesting.MatchTests(tests, ctx.String(testPatternFlag.Name))
+	}
+	results := utesting.RunTests(tests, os.Stdout)
+	if fails := utesting.CountFailures(results); fails > 0 {
+		return fmt.Errorf("%v of %v tests passed.", len(tests)-fails, len(tests))
+	}
+	fmt.Printf("all tests passed\n")
+	return nil
 }

--- a/core/forkid/forkid.go
+++ b/core/forkid/forkid.go
@@ -67,17 +67,17 @@ type Filter func(id ID) error
 
 // NewID calculates the Ethereum fork ID from the chain config and head.
 func NewID(chain Blockchain) ID {
-	return newID(
+	return NewStaticID(
 		chain.Config(),
 		chain.Genesis().Hash(),
 		chain.CurrentHeader().Number.Uint64(),
 	)
 }
 
-// newID is the internal version of NewID, which takes extracted values as its
+// NewStaticID is the internal version of NewID, which takes extracted values as its
 // arguments instead of a chain. The reason is to allow testing the IDs without
 // having to simulate an entire blockchain.
-func newID(config *params.ChainConfig, genesis common.Hash, head uint64) ID {
+func NewStaticID(config *params.ChainConfig, genesis common.Hash, head uint64) ID {
 	// Calculate the starting checksum from the genesis hash
 	hash := crc32.ChecksumIEEE(genesis[:])
 

--- a/core/forkid/forkid.go
+++ b/core/forkid/forkid.go
@@ -65,19 +65,8 @@ type ID struct {
 // Filter is a fork id filter to validate a remotely advertised ID.
 type Filter func(id ID) error
 
-// NewID calculates the Ethereum fork ID from the chain config and head.
-func NewID(chain Blockchain) ID {
-	return NewStaticID(
-		chain.Config(),
-		chain.Genesis().Hash(),
-		chain.CurrentHeader().Number.Uint64(),
-	)
-}
-
-// NewStaticID is the internal version of NewID, which takes extracted values as its
-// arguments instead of a chain. The reason is to allow testing the IDs without
-// having to simulate an entire blockchain.
-func NewStaticID(config *params.ChainConfig, genesis common.Hash, head uint64) ID {
+// NewID calculates the Ethereum fork ID from the chain config, genesis hash, and head.
+func NewID(config *params.ChainConfig, genesis common.Hash, head uint64) ID {
 	// Calculate the starting checksum from the genesis hash
 	hash := crc32.ChecksumIEEE(genesis[:])
 

--- a/core/forkid/forkid_test.go
+++ b/core/forkid/forkid_test.go
@@ -118,7 +118,7 @@ func TestCreation(t *testing.T) {
 	}
 	for i, tt := range tests {
 		for j, ttt := range tt.cases {
-			if have := newID(tt.config, tt.genesis, ttt.head); have != ttt.want {
+			if have := NewStaticID(tt.config, tt.genesis, ttt.head); have != ttt.want {
 				t.Errorf("test %d, case %d: fork ID mismatch: have %x, want %x", i, j, have, ttt.want)
 			}
 		}

--- a/core/forkid/forkid_test.go
+++ b/core/forkid/forkid_test.go
@@ -118,7 +118,7 @@ func TestCreation(t *testing.T) {
 	}
 	for i, tt := range tests {
 		for j, ttt := range tt.cases {
-			if have := NewStaticID(tt.config, tt.genesis, ttt.head); have != ttt.want {
+			if have := NewID(tt.config, tt.genesis, ttt.head); have != ttt.want {
 				t.Errorf("test %d, case %d: fork ID mismatch: have %x, want %x", i, j, have, ttt.want)
 			}
 		}

--- a/eth/discovery.go
+++ b/eth/discovery.go
@@ -60,12 +60,8 @@ func (eth *Ethereum) startEthEntryUpdate(ln *enode.LocalNode) {
 }
 
 func (eth *Ethereum) currentEthEntry() *ethEntry {
-	return &ethEntry{ForkID:
-		forkid.NewID(
-			eth.blockchain.Config(),
-			eth.blockchain.Genesis().Hash(),
-			eth.blockchain.CurrentHeader().Number.Uint64()),
-	}
+	return &ethEntry{ForkID: forkid.NewID(eth.blockchain.Config(), eth.blockchain.Genesis().Hash(),
+		eth.blockchain.CurrentHeader().Number.Uint64())}
 }
 
 // setupDiscovery creates the node discovery source for the eth protocol.

--- a/eth/discovery.go
+++ b/eth/discovery.go
@@ -60,7 +60,12 @@ func (eth *Ethereum) startEthEntryUpdate(ln *enode.LocalNode) {
 }
 
 func (eth *Ethereum) currentEthEntry() *ethEntry {
-	return &ethEntry{ForkID: forkid.NewID(eth.blockchain)}
+	return &ethEntry{ForkID:
+		forkid.NewID(
+			eth.blockchain.Config(),
+			eth.blockchain.Genesis().Hash(),
+			eth.blockchain.CurrentHeader().Number.Uint64()),
+	}
 }
 
 // setupDiscovery creates the node discovery source for the eth protocol.

--- a/eth/handler.go
+++ b/eth/handler.go
@@ -319,7 +319,8 @@ func (pm *ProtocolManager) handle(p *peer) error {
 		number  = head.Number.Uint64()
 		td      = pm.blockchain.GetTd(hash, number)
 	)
-	if err := p.Handshake(pm.networkID, td, hash, genesis.Hash(), forkid.NewID(pm.blockchain), pm.forkFilter); err != nil {
+	forkID := forkid.NewID(pm.blockchain.Config(), pm.blockchain.Genesis().Hash(), pm.blockchain.CurrentHeader().Number.Uint64())
+	if err := p.Handshake(pm.networkID, td, hash, genesis.Hash(), forkID, pm.forkFilter); err != nil {
 		p.Log().Debug("Ethereum handshake failed", "err", err)
 		return err
 	}

--- a/eth/helper_test.go
+++ b/eth/helper_test.go
@@ -185,7 +185,8 @@ func newTestPeer(name string, version int, pm *ProtocolManager, shake bool) (*te
 			head    = pm.blockchain.CurrentHeader()
 			td      = pm.blockchain.GetTd(head.Hash(), head.Number.Uint64())
 		)
-		tp.handshake(nil, td, head.Hash(), genesis.Hash(), forkid.NewID(pm.blockchain), forkid.NewFilter(pm.blockchain))
+		forkID := forkid.NewID(pm.blockchain.Config(), pm.blockchain.Genesis().Hash(), pm.blockchain.CurrentHeader().Number.Uint64())
+		tp.handshake(nil, td, head.Hash(), genesis.Hash(), forkID, forkid.NewFilter(pm.blockchain))
 	}
 	return tp, errc
 }

--- a/eth/protocol_test.go
+++ b/eth/protocol_test.go
@@ -104,7 +104,7 @@ func TestStatusMsgErrors64(t *testing.T) {
 		genesis = pm.blockchain.Genesis()
 		head    = pm.blockchain.CurrentHeader()
 		td      = pm.blockchain.GetTd(head.Hash(), head.Number.Uint64())
-		forkID  = forkid.NewID(pm.blockchain)
+		forkID  = forkid.NewID(pm.blockchain.Config(), pm.blockchain.Genesis().Hash(), pm.blockchain.CurrentHeader().Number.Uint64())
 	)
 	defer pm.Stop()
 


### PR DESCRIPTION
This PR adds a test framework for the eth protocol, with the following basic tests: 

- `GetBlockBodies`
- `GetBlockHeaders`
- `Status`
- `Ping`
- and a block propagation test `Broadcast`
