### PR TITLE
cmd/devp2p/internal/ethtest: lower protocol version to 64

### DIFF
--- a/cmd/devp2p/internal/ethtest/suite.go
+++ b/cmd/devp2p/internal/ethtest/suite.go
@@ -122,7 +122,7 @@ func (c *Conn) statusExchange(t *utesting.T, chain *Chain) Message {
 	}
 	// write status message to client
 	status := Status{
-		ProtocolVersion: 65,
+		ProtocolVersion: 64,
 		NetworkID:       1,
 		TD:              chain.TD(chain.Len()),
 		Head:            chain.blocks[chain.Len()-1].Hash(),


### PR DESCRIPTION
Lower eth protocol version from 65 to 64 to allow openethereum support.