### PR TITLE
internal/web3ext: improve eth_getBlockByNumber and eth_getBlockByHash api

### DIFF
--- a/internal/web3ext/web3ext.go
+++ b/internal/web3ext/web3ext.go
@@ -532,12 +532,14 @@ web3._extend({
 		new web3._extend.Method({
 			name: 'getBlockByNumber',
 			call: 'eth_getBlockByNumber',
-			params: 2
+			params: 2,
+			inputFormatter: [web3._extend.formatters.inputBlockNumberFormatter, function (val) { return !!val; }]
 		}),
 		new web3._extend.Method({
 			name: 'getBlockByHash',
 			call: 'eth_getBlockByHash',
-			params: 2
+			params: 2,
+			inputFormatter: [null, function (val) { return !!val; }]
 		}),
 		new web3._extend.Method({
 			name: 'getRawTransaction',


### PR DESCRIPTION
1. let `eth_getBlockByNumber` and `eth_getBlockByNumber` support default value of the second param 
2. format the first param of `eth_getBlockByNumber`

let them have the same behaver as `getBlock` in web3.js