### PR TITLE
common: remove usage of deprecated function

### DIFF
--- a/common/bytes.go
+++ b/common/bytes.go
@@ -17,7 +17,11 @@
 // Package common contains various helper functions.
 package common
 
-import "encoding/hex"
+import (
+	"encoding/hex"
+
+	"github.com/ethereum/go-ethereum/common/hexutil"
+)
 
 // ToHex returns the hex representation of b, prefixed with '0x'.
 // For empty slices, the return value is "0x0".
@@ -35,7 +39,7 @@ func ToHex(b []byte) string {
 func ToHexArray(b [][]byte) []string {
 	r := make([]string, len(b))
 	for i := range b {
-		r[i] = ToHex(b[i])
+		r[i] = hexutil.Encode(b[i])
 	}
 	return r
 }

--- a/common/bytes.go
+++ b/common/bytes.go
@@ -19,30 +19,7 @@ package common
 
 import (
 	"encoding/hex"
-
-	"github.com/ethereum/go-ethereum/common/hexutil"
 )
-
-// ToHex returns the hex representation of b, prefixed with '0x'.
-// For empty slices, the return value is "0x0".
-//
-// Deprecated: use hexutil.Encode instead.
-func ToHex(b []byte) string {
-	hex := Bytes2Hex(b)
-	if len(hex) == 0 {
-		hex = "0"
-	}
-	return "0x" + hex
-}
-
-// ToHexArray creates a array of hex-string based on []byte
-func ToHexArray(b [][]byte) []string {
-	r := make([]string, len(b))
-	for i := range b {
-		r[i] = hexutil.Encode(b[i])
-	}
-	return r
-}
 
 // FromHex returns the bytes represented by the hexadecimal string s.
 // s may be prefixed with "0x".

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -592,6 +592,15 @@ func (s *PublicBlockChainAPI) GetProof(ctx context.Context, address common.Addre
 		codeHash = crypto.Keccak256Hash(nil)
 	}
 
+	// toHexArray creates a array of hex-string based on []byte
+	toHexArray := func(b [][]byte) []string {
+		r := make([]string, len(b))
+		for i := range b {
+			r[i] = hexutil.Encode(b[i])
+		}
+		return r
+	}
+
 	// create the proof for the storageKeys
 	for i, key := range storageKeys {
 		if storageTrie != nil {
@@ -599,7 +608,7 @@ func (s *PublicBlockChainAPI) GetProof(ctx context.Context, address common.Addre
 			if storageError != nil {
 				return nil, storageError
 			}
-			storageProof[i] = StorageResult{key, (*hexutil.Big)(state.GetState(address, common.HexToHash(key)).Big()), common.ToHexArray(proof)}
+			storageProof[i] = StorageResult{key, (*hexutil.Big)(state.GetState(address, common.HexToHash(key)).Big()), toHexArray(proof)}
 		} else {
 			storageProof[i] = StorageResult{key, &hexutil.Big{}, []string{}}
 		}
@@ -613,7 +622,7 @@ func (s *PublicBlockChainAPI) GetProof(ctx context.Context, address common.Addre
 
 	return &AccountResult{
 		Address:      address,
-		AccountProof: common.ToHexArray(accountProof),
+		AccountProof: toHexArray(accountProof),
 		Balance:      (*hexutil.Big)(state.GetBalance(address)),
 		CodeHash:     codeHash,
 		Nonce:        hexutil.Uint64(state.GetNonce(address)),

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -592,15 +592,6 @@ func (s *PublicBlockChainAPI) GetProof(ctx context.Context, address common.Addre
 		codeHash = crypto.Keccak256Hash(nil)
 	}
 
-	// toHexArray creates a array of hex-string based on []byte
-	toHexArray := func(b [][]byte) []string {
-		r := make([]string, len(b))
-		for i := range b {
-			r[i] = hexutil.Encode(b[i])
-		}
-		return r
-	}
-
 	// create the proof for the storageKeys
 	for i, key := range storageKeys {
 		if storageTrie != nil {
@@ -608,7 +599,7 @@ func (s *PublicBlockChainAPI) GetProof(ctx context.Context, address common.Addre
 			if storageError != nil {
 				return nil, storageError
 			}
-			storageProof[i] = StorageResult{key, (*hexutil.Big)(state.GetState(address, common.HexToHash(key)).Big()), toHexArray(proof)}
+			storageProof[i] = StorageResult{key, (*hexutil.Big)(state.GetState(address, common.HexToHash(key)).Big()), toHexSlice(proof)}
 		} else {
 			storageProof[i] = StorageResult{key, &hexutil.Big{}, []string{}}
 		}
@@ -622,7 +613,7 @@ func (s *PublicBlockChainAPI) GetProof(ctx context.Context, address common.Addre
 
 	return &AccountResult{
 		Address:      address,
-		AccountProof: toHexArray(accountProof),
+		AccountProof: toHexSlice(accountProof),
 		Balance:      (*hexutil.Big)(state.GetBalance(address)),
 		CodeHash:     codeHash,
 		Nonce:        hexutil.Uint64(state.GetNonce(address)),
@@ -1945,4 +1936,13 @@ func checkTxFee(gasPrice *big.Int, gas uint64, cap float64) error {
 		return fmt.Errorf("tx fee (%.2f ether) exceeds the configured cap (%.2f ether)", feeFloat, cap)
 	}
 	return nil
+}
+
+// toHexSlice creates a slice of hex-strings based on []byte.
+func toHexSlice(b [][]byte) []string {
+	r := make([]string, len(b))
+	for i := range b {
+		r[i] = hexutil.Encode(b[i])
+	}
+	return r
 }


### PR DESCRIPTION
This changes the default behaviour of ToHexArray and with it the behaviour of eth_getProof.
Previously we encoded an empty slice as 0, now the empty slice is encoded as 0x.

~~Also it introduces the hexutil package into common so it might not be so good after all~~