### PR TITLE
common: change deprecated function to active

### DIFF
--- a/common/bytes.go
+++ b/common/bytes.go
@@ -21,8 +21,6 @@ import "encoding/hex"
 
 // ToHex returns the hex representation of b, prefixed with '0x'.
 // For empty slices, the return value is "0x0".
-//
-// Deprecated: use hexutil.Encode instead.
 func ToHex(b []byte) string {
 	hex := Bytes2Hex(b)
 	if len(hex) == 0 {


### PR DESCRIPTION
This function can not deprecated. 
It's can not replace by `hexutil.Encode`. they have different efforts as #21610 said.
So I think we'd better to remove the `deprecated` comment.