### PR TITLE
all: replace RWMutex with Mutex in places where RLock is not used

### DIFF
--- a/accounts/keystore/file_cache.go
+++ b/accounts/keystore/file_cache.go
@@ -32,7 +32,7 @@ import (
 type fileCache struct {
 	all     mapset.Set // Set of all files from the keystore folder
 	lastMod time.Time  // Last time instance when a file was modified
-	mu      sync.RWMutex
+	mu      sync.Mutex
 }
 
 // scan performs a new scan on the given directory, compares against the already

--- a/core/chain_indexer.go
+++ b/core/chain_indexer.go
@@ -94,7 +94,7 @@ type ChainIndexer struct {
 	throttling time.Duration // Disk throttling to prevent a heavy upgrade from hogging resources
 
 	log  log.Logger
-	lock sync.RWMutex
+	lock sync.Mutex
 }
 
 // NewChainIndexer creates a new chain indexer to do background processing on

--- a/eth/downloader/downloader.go
+++ b/eth/downloader/downloader.go
@@ -153,7 +153,7 @@ type Downloader struct {
 	cancelWg   sync.WaitGroup // Make sure all fetcher goroutines have exited.
 
 	quitCh   chan struct{} // Quit channel to signal termination
-	quitLock sync.RWMutex  // Lock to prevent double closes
+	quitLock sync.Mutex    // Lock to prevent double closes
 
 	// Testing hooks
 	syncInitHook     func(uint64, uint64)  // Method to call upon initiating a new sync run

--- a/eth/downloader/downloader_test.go
+++ b/eth/downloader/downloader_test.go
@@ -411,7 +411,6 @@ func (dl *downloadTester) dropPeer(id string) {
 type downloadTesterPeer struct {
 	dl            *downloadTester
 	id            string
-	lock          sync.RWMutex
 	chain         *testChain
 	missingStates map[common.Hash]bool // State entries that fast sync should not return
 }
@@ -1601,7 +1600,7 @@ func TestRemoteHeaderRequestSpan(t *testing.T) {
 		{15000, 13006,
 			[]int{14823, 14839, 14855, 14871, 14887, 14903, 14919, 14935, 14951, 14967, 14983, 14999},
 		},
-		//Remote is pretty close to us. We don't have to fetch as many
+		// Remote is pretty close to us. We don't have to fetch as many
 		{1200, 1150,
 			[]int{1149, 1154, 1159, 1164, 1169, 1174, 1179, 1184, 1189, 1194, 1199},
 		},

--- a/eth/helper_test.go
+++ b/eth/helper_test.go
@@ -94,7 +94,7 @@ type testTxPool struct {
 	pool   map[common.Hash]*types.Transaction // Hash map of collected transactions
 	added  chan<- []*types.Transaction        // Notification channel for new transactions
 
-	lock sync.Mutex // Protects the transaction pool
+	lock sync.RWMutex // Protects the transaction pool
 }
 
 // Has returns an indicator whether txpool has a transaction

--- a/eth/helper_test.go
+++ b/eth/helper_test.go
@@ -94,7 +94,7 @@ type testTxPool struct {
 	pool   map[common.Hash]*types.Transaction // Hash map of collected transactions
 	added  chan<- []*types.Transaction        // Notification channel for new transactions
 
-	lock sync.RWMutex // Protects the transaction pool
+	lock sync.Mutex // Protects the transaction pool
 }
 
 // Has returns an indicator whether txpool has a transaction

--- a/les/txrelay.go
+++ b/les/txrelay.go
@@ -35,7 +35,7 @@ type lesTxRelay struct {
 	txPending    map[common.Hash]struct{}
 	peerList     []*serverPeer
 	peerStartPos int
-	lock         sync.RWMutex
+	lock         sync.Mutex
 	stop         chan struct{}
 
 	retriever *retrieveManager

--- a/miner/unconfirmed.go
+++ b/miner/unconfirmed.go
@@ -50,7 +50,7 @@ type unconfirmedBlocks struct {
 	chain  chainRetriever // Blockchain to verify canonical status through
 	depth  uint           // Depth after which to discard previous blocks
 	blocks *ring.Ring     // Block infos to allow canonical chain cross checks
-	lock   sync.RWMutex   // Protects the fields from concurrent access
+	lock   sync.Mutex     // Protects the fields from concurrent access
 }
 
 // newUnconfirmedBlocks returns new data structure to track currently unconfirmed blocks.


### PR DESCRIPTION
These RWMutex are not use `RLock()`, they are only use `Lock()`, so replace them with `Mutex`