### PR TITLE
core/types: optimize bloom filters

### DIFF
--- a/core/types/bloom9.go
+++ b/core/types/bloom9.go
@@ -117,11 +117,12 @@ func CreateBloom(receipts Receipts) Bloom {
 
 // LogsBloom returns the bloom bytes for the given logs
 func LogsBloom(logs []*Log) []byte {
+	buf := make([]byte, 6)
 	var bin Bloom
 	for _, log := range logs {
-		bin.Add(log.Address.Bytes())
+		bin.add(log.Address.Bytes(), buf)
 		for _, b := range log.Topics {
-			bin.Add(b[:])
+			bin.add(b[:], buf)
 		}
 	}
 	return bin[:]

--- a/core/types/bloom9_test.go
+++ b/core/types/bloom9_test.go
@@ -17,8 +17,12 @@
 package types
 
 import (
+	"fmt"
 	"math/big"
 	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/crypto"
 )
 
 func TestBloom(t *testing.T) {
@@ -50,32 +54,104 @@ func TestBloom(t *testing.T) {
 	}
 }
 
-/*
-import (
-	"testing"
-
-	"github.com/ethereum/go-ethereum/core/state"
-)
-
-func TestBloom9(t *testing.T) {
-	testCase := []byte("testtest")
-	bin := LogsBloom([]state.Log{
-		{testCase, [][]byte{[]byte("hellohello")}, nil},
-	}).Bytes()
-	res := BloomLookup(bin, testCase)
-
-	if !res {
-		t.Errorf("Bloom lookup failed")
+// TestBloomExtensively does some more thorough tests
+func TestBloomExtensively(t *testing.T) {
+	var exp = common.HexToHash("c8d3ca65cdb4874300a9e39475508f23ed6da09fdbc487f89a2dcf50b09eb263")
+	var b Bloom
+	// Add 100 "random" things
+	for i := 0; i < 100; i++ {
+		data := fmt.Sprintf("xxxxxxxxxx data %d yyyyyyyyyyyyyy", i)
+		//b.Add([]byte(data))
+		b.Add(new(big.Int).SetBytes([]byte(data)))
+	}
+	got := crypto.Keccak256Hash(b.Bytes())
+	if got != exp {
+		t.Errorf("Got %x, exp %x", got, exp)
+	}
+	var b2 Bloom
+	b2.SetBytes(b.Bytes())
+	got2 := crypto.Keccak256Hash(b2.Bytes())
+	if got != got2 {
+		t.Errorf("Got %x, exp %x", got, got2)
 	}
 }
 
-
-func TestAddress(t *testing.T) {
-	block := &Block{}
-	block.Coinbase = common.Hex2Bytes("22341ae42d6dd7384bc8584e50419ea3ac75b83f")
-	fmt.Printf("%x\n", crypto.Keccak256(block.Coinbase))
-
-	bin := CreateBloom(block)
-	fmt.Printf("bin = %x\n", common.LeftPadBytes(bin, 64))
+func BenchmarkBloom9(b *testing.B) {
+	test := []byte("testestestest")
+	for i := 0; i < b.N; i++ {
+		Bloom9(test)
+	}
 }
-*/
+
+func BenchmarkBloom9Lookup(b *testing.B) {
+	toTest := []byte("testtest")
+	bloom := new(Bloom)
+	for i := 0; i < b.N; i++ {
+		bloom.Test(new(big.Int).SetBytes(toTest))
+		//bloom.Test(toTest)
+	}
+}
+
+func BenchmarkCreateBloom(b *testing.B) {
+
+	var txs = Transactions{
+		NewContractCreation(1, big.NewInt(1), 1, big.NewInt(1), nil),
+		NewTransaction(2, common.HexToAddress("0x2"), big.NewInt(2), 2, big.NewInt(2), nil),
+	}
+	var rSmall = Receipts{
+		&Receipt{
+			Status:            ReceiptStatusFailed,
+			CumulativeGasUsed: 1,
+			Logs: []*Log{
+				{Address: common.BytesToAddress([]byte{0x11})},
+				{Address: common.BytesToAddress([]byte{0x01, 0x11})},
+			},
+			TxHash:          txs[0].Hash(),
+			ContractAddress: common.BytesToAddress([]byte{0x01, 0x11, 0x11}),
+			GasUsed:         1,
+		},
+		&Receipt{
+			PostState:         common.Hash{2}.Bytes(),
+			CumulativeGasUsed: 3,
+			Logs: []*Log{
+				{Address: common.BytesToAddress([]byte{0x22})},
+				{Address: common.BytesToAddress([]byte{0x02, 0x22})},
+			},
+			TxHash:          txs[1].Hash(),
+			ContractAddress: common.BytesToAddress([]byte{0x02, 0x22, 0x22}),
+			GasUsed:         2,
+		},
+	}
+
+	var rLarge = make(Receipts, 200)
+	// Fill it with 200 receipts x 2 logs
+	for i := 0; i < 200; i += 2 {
+		copy(rLarge[i:], rSmall)
+	}
+	b.Run("small", func(b *testing.B) {
+		b.ReportAllocs()
+		var bl Bloom
+		for i := 0; i < b.N; i++ {
+			bl = CreateBloom(rSmall)
+		}
+		b.StopTimer()
+		var exp = common.HexToHash("c384c56ece49458a427c67b90fefe979ebf7104795be65dc398b280f24104949")
+		got := crypto.Keccak256Hash(bl.Bytes())
+		if got != exp {
+			b.Errorf("Got %x, exp %x", got, exp)
+		}
+	})
+	b.Run("large", func(b *testing.B) {
+		b.ReportAllocs()
+		var bl Bloom
+		for i := 0; i < b.N; i++ {
+			bl = CreateBloom(rLarge)
+		}
+		b.StopTimer()
+		var exp = common.HexToHash("c384c56ece49458a427c67b90fefe979ebf7104795be65dc398b280f24104949")
+		got := crypto.Keccak256Hash(bl.Bytes())
+		if got != exp {
+			b.Errorf("Got %x, exp %x", got, exp)
+		}
+	})
+}

--- a/core/types/bloom9_test.go
+++ b/core/types/bloom9_test.go
@@ -39,16 +39,16 @@ func TestBloom(t *testing.T) {
 
 	var bloom Bloom
 	for _, data := range positive {
-		bloom.Add(new(big.Int).SetBytes([]byte(data)))
+		bloom.Add([]byte(data))
 	}
 
 	for _, data := range positive {
-		if !bloom.TestBytes([]byte(data)) {
+		if !bloom.Test([]byte(data)) {
 			t.Error("expected", data, "to test true")
 		}
 	}
 	for _, data := range negative {
-		if bloom.TestBytes([]byte(data)) {
+		if bloom.Test([]byte(data)) {
 			t.Error("did not expect", data, "to test true")
 		}
 	}
@@ -61,8 +61,8 @@ func TestBloomExtensively(t *testing.T) {
 	// Add 100 "random" things
 	for i := 0; i < 100; i++ {
 		data := fmt.Sprintf("xxxxxxxxxx data %d yyyyyyyyyyyyyy", i)
-		//b.Add([]byte(data))
-		b.Add(new(big.Int).SetBytes([]byte(data)))
+		b.Add([]byte(data))
+		//b.Add(new(big.Int).SetBytes([]byte(data)))
 	}
 	got := crypto.Keccak256Hash(b.Bytes())
 	if got != exp {
@@ -87,8 +87,7 @@ func BenchmarkBloom9Lookup(b *testing.B) {
 	toTest := []byte("testtest")
 	bloom := new(Bloom)
 	for i := 0; i < b.N; i++ {
-		bloom.Test(new(big.Int).SetBytes(toTest))
-		//bloom.Test(toTest)
+		bloom.Test(toTest)
 	}
 }
 


### PR DESCRIPTION
This supersedes #21616 and closes #18092

The bloom filter was very suboptimal, and more or less broken. 


```
name                 old time/op    new time/op    delta
Bloom9-6               1.41µs ±17%    0.09µs ±10%  -93.75%  (p=0.008 n=5+5)
Bloom9Lookup-6         1.75µs ±15%    0.69µs ± 5%  -60.45%  (p=0.008 n=5+5)
CreateBloom/small-6    7.29µs ± 4%    2.86µs ± 0%  -60.76%  (p=0.016 n=5+4)
CreateBloom/large-6     701µs ±20%     280µs ± 2%  -59.96%  (p=0.008 n=5+5)

name                 old alloc/op   new alloc/op   delta
CreateBloom/small-6    7.50kB ± 0%    0.26kB ± 0%  -96.48%  (p=0.008 n=5+5)
CreateBloom/large-6     676kB ± 0%      26kB ± 0%  -96.21%  (p=0.008 n=5+5)

name                 old allocs/op  new allocs/op  delta
CreateBloom/small-6      58.0 ± 0%       9.0 ± 0%  -84.48%  (p=0.008 n=5+5)
CreateBloom/large-6     5.50k ± 0%     0.80k ± 0%  -85.44%  (p=0.008 n=5+5)
```
