### PR TITLE
core/bloombits: faster generator

### DIFF
--- a/core/bloombits/generator.go
+++ b/core/bloombits/generator.go
@@ -65,18 +65,23 @@ func (b *Generator) AddBloom(index uint, bloom types.Bloom) error {
 	}
 	// Rotate the bloom and insert into our collection
 	byteIndex := b.nextSec / 8
-	bitMask := byte(1) << byte(7-b.nextSec%8)
-
-	for i := 0; i < types.BloomBitLength; i++ {
-		bloomByteIndex := types.BloomByteLength - 1 - i/8
-		bloomBitMask := byte(1) << byte(i%8)
-
-		if (bloom[bloomByteIndex] & bloomBitMask) != 0 {
-			b.blooms[i][byteIndex] |= bitMask
+	bitIndex := byte(7 - b.nextSec%8)
+	for byt := 0; byt < types.BloomByteLength; byt++ {
+		bloomByte := bloom[types.BloomByteLength-1-byt]
+		if bloomByte == 0 {
+			continue
 		}
+		base := 8 * byt
+		b.blooms[base+7][byteIndex] |= ((bloomByte >> 7) & 1) << bitIndex
+		b.blooms[base+6][byteIndex] |= ((bloomByte >> 6) & 1) << bitIndex
+		b.blooms[base+5][byteIndex] |= ((bloomByte >> 5) & 1) << bitIndex
+		b.blooms[base+4][byteIndex] |= ((bloomByte >> 4) & 1) << bitIndex
+		b.blooms[base+3][byteIndex] |= ((bloomByte >> 3) & 1) << bitIndex
+		b.blooms[base+2][byteIndex] |= ((bloomByte >> 2) & 1) << bitIndex
+		b.blooms[base+1][byteIndex] |= ((bloomByte >> 1) & 1) << bitIndex
+		b.blooms[base][byteIndex] |= (bloomByte & 1) << bitIndex
 	}
 	b.nextSec++
-
 	return nil
 }
 

--- a/core/bloombits/generator_test.go
+++ b/core/bloombits/generator_test.go
@@ -58,3 +58,42 @@ func TestGenerator(t *testing.T) {
 		}
 	}
 }
+
+func BenchmarkGenerator(b *testing.B) {
+	var input [types.BloomBitLength][types.BloomByteLength]byte
+	b.Run("empty", func(b *testing.B) {
+		b.ReportAllocs()
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			// Crunch the input through the generator and verify the result
+			gen, err := NewGenerator(types.BloomBitLength)
+			if err != nil {
+				b.Fatalf("failed to create bloombit generator: %v", err)
+			}
+			for j, bloom := range input {
+				if err := gen.AddBloom(uint(j), bloom); err != nil {
+					b.Fatalf("bloom %d: failed to add: %v", i, err)
+				}
+			}
+		}
+	})
+	for i := 0; i < types.BloomBitLength; i++ {
+		rand.Read(input[i][:])
+	}
+	b.Run("random", func(b *testing.B) {
+		b.ReportAllocs()
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			// Crunch the input through the generator and verify the result
+			gen, err := NewGenerator(types.BloomBitLength)
+			if err != nil {
+				b.Fatalf("failed to create bloombit generator: %v", err)
+			}
+			for j, bloom := range input {
+				if err := gen.AddBloom(uint(j), bloom); err != nil {
+					b.Fatalf("bloom %d: failed to add: %v", i, err)
+				}
+			}
+		}
+	})
+}


### PR DESCRIPTION
This PR optimizes the bloombit generator a bit. It unrolls a loop and avoids branching on every potential setting of a bit. 
EDIT: It also performs drastically better when blooms are less saturated

```
name                old time/op    new time/op    delta
Generator/empty-6     7.72ms ± 1%    0.91ms ± 3%  -88.27%  (p=0.000 n=9+8)
Generator/random-6    28.9ms ± 1%    15.2ms ± 1%  -47.44%  (p=0.000 n=9+9)

```
The existing testcase was pretty good. I tested with some intentional (and unintentional) errors, and each one was immediately detected. 