### PR TITLE
internal/web3ext: improve some web3 apis

### DIFF
--- a/internal/web3ext/web3ext.go
+++ b/internal/web3ext/web3ext.go
@@ -237,7 +237,8 @@ web3._extend({
 		new web3._extend.Method({
 			name: 'printBlock',
 			call: 'debug_printBlock',
-			params: 1
+			params: 1,
+			outputFormatter: console.log
 		}),
 		new web3._extend.Method({
 			name: 'getBlockRlp',
@@ -248,7 +249,7 @@ web3._extend({
 			name: 'testSignCliqueBlock',
 			call: 'debug_testSignCliqueBlock',
 			params: 2,
-			inputFormatters: [web3._extend.formatters.inputAddressFormatter, null],
+			inputFormatter: [web3._extend.formatters.inputAddressFormatter, null],
 		}),
 		new web3._extend.Method({
 			name: 'setHead',
@@ -263,7 +264,8 @@ web3._extend({
 		new web3._extend.Method({
 			name: 'dumpBlock',
 			call: 'debug_dumpBlock',
-			params: 1
+			params: 1,
+			inputFormatter: [web3._extend.formatters.inputAddressFormatter]
 		}),
 		new web3._extend.Method({
 			name: 'chaindbProperty',
@@ -415,7 +417,7 @@ web3._extend({
 			name: 'traceBlockByNumber',
 			call: 'debug_traceBlockByNumber',
 			params: 2,
-			inputFormatter: [null, null]
+			inputFormatter: [web3._extend.formatters.inputBlockNumberFormatter, null]
 		}),
 		new web3._extend.Method({
 			name: 'traceBlockByHash',
@@ -522,7 +524,8 @@ web3._extend({
 		new web3._extend.Method({
 			name: 'getHeaderByNumber',
 			call: 'eth_getHeaderByNumber',
-			params: 1
+			params: 1,
+			inputFormatter: [web3._extend.formatters.inputBlockNumberFormatter]
 		}),
 		new web3._extend.Method({
 			name: 'getHeaderByHash',

--- a/internal/web3ext/web3ext.go
+++ b/internal/web3ext/web3ext.go
@@ -265,7 +265,7 @@ web3._extend({
 			name: 'dumpBlock',
 			call: 'debug_dumpBlock',
 			params: 1,
-			inputFormatter: [web3._extend.formatters.inputAddressFormatter]
+			inputFormatter: [web3._extend.formatters.inputBlockNumberFormatter]
 		}),
 		new web3._extend.Method({
 			name: 'chaindbProperty',


### PR DESCRIPTION
this PR improves some api and fix a bug:
1. improve some param's input format, let them support `Number`. 
2. fix a tiny typo:  `inputFormatters `->`inputFormatter`
3. improve `debug_printBlock ` output.

before change, the `debug_printBlock` output: 
```
> debug.printBlock(2)
"(*types.Block)(0xc0000beea0)({\n header: (*types.Header)(0xc0010706c0)({\n  ParentHash: (common.Hash) (len=32 cap=32) 0x6ccfac8baea9c2829d9e302403c4a3523504fe088ee3a860e6ee4536d0c92888,\n  UncleHash: (common.Hash) (len=32 cap=32) 0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347,\n
......
```

after change: 
```
> debug.printBlock(2)
(*types.Block)(0xc041222000)({
 header: (*types.Header)(0xc04121e480)({
  ParentHash: (common.Hash) (len=32 cap=32) 0x6ccfac8baea9c2829d9e302403c4a3523504fe088ee3a860e6ee4536d0c92888,
  UncleHash: (common.Hash) (len=32 cap=32) 0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347,
......
```