### PR TITLE
eth/tracer: Wasm tracer

### DIFF
--- a/eth/api_tracer.go
+++ b/eth/api_tracer.go
@@ -784,7 +784,7 @@ func (api *PrivateDebugAPI) traceTx(ctx context.Context, message core.Message, v
 		deadlineCtx, cancel := context.WithTimeout(ctx, timeout)
 		go func() {
 			<-deadlineCtx.Done()
-			tracer.(*tracers.Tracer).Stop(errors.New("execution timeout"))
+			tracer.(tracers.Tracer).Stop(errors.New("execution timeout"))
 		}()
 		defer cancel()
 
@@ -816,7 +816,7 @@ func (api *PrivateDebugAPI) traceTx(ctx context.Context, message core.Message, v
 			StructLogs:  ethapi.FormatLogs(tracer.StructLogs()),
 		}, nil
 
-	case *tracers.Tracer:
+	case tracers.Tracer:
 		return tracer.GetResult()
 
 	default:

--- a/eth/tracers/tracer.go
+++ b/eth/tracers/tracer.go
@@ -366,7 +366,7 @@ func checkWasm(code string) bool {
 func newWasm(code string) (Tracer, error) {
 	tracer := &WasmTracer{code: code, resultIndex: -1, stepIndex: -1, faultIndex: -1, initIndex: -1}
 	module, err := wasm.ReadModule(bytes.NewReader([]byte(code)), func(name string) (*wasm.Module, error) {
-		if name == "tracer" {
+		if name == "env" { // "tracer"{
 			tracerModule := wasm.NewModule()
 			tracerModule.Types = &wasm.SectionTypes{
 				Entries: []wasm.FunctionSig{
@@ -447,7 +447,7 @@ func newWasm(code string) (Tracer, error) {
 
 	tracer.module = module
 
-	// TODO check all the exports and get their indices
+	// Find the index for all required exports
 	for name, export := range module.Export.Entries {
 		switch name {
 		case "init":

--- a/eth/tracers/tracer.go
+++ b/eth/tracers/tracer.go
@@ -293,6 +293,7 @@ type Tracer interface {
 	CaptureFault(env *vm.EVM, pc uint64, op vm.OpCode, gas, cost uint64, memory *vm.Memory, stack *vm.Stack, rStack *vm.ReturnStack, contract *vm.Contract, depth int, err error) error
 	CaptureEnd(output []byte, gasUsed uint64, t time.Duration, err error) error
 	GetResult() (json.RawMessage, error)
+	Stop(error)
 }
 
 // Tracer provides an implementation of Tracer that evaluates a Javascript
@@ -358,7 +359,7 @@ func checkWasm(code string) bool {
 }
 
 func newWasm(code string) (Tracer, error) {
-	module, err := wasm.ReadModule(bytes.NewReader([]byte(code)), func(name string) (*Module, error) {
+	module, err := wasm.ReadModule(bytes.NewReader([]byte(code)), func(name string) (*wasm.Module, error) {
 		if name == "tracer" {
 			tracerModule := wasm.NewModule()
 			tracerModule.Types = &wasm.SectionTypes{
@@ -801,4 +802,7 @@ func (wt *WasmTracer) GetResult() (json.RawMessage, error) {
 		return nil, errors.New("expected get_result to return []byte")
 	}
 	return json.RawMessage(result), execErr
+}
+
+func (wt *WasmTracer) Stop(err error) {
 }

--- a/eth/tracers/tracer_test.go
+++ b/eth/tracers/tracer_test.go
@@ -113,24 +113,31 @@ func TestTracing(t *testing.T) {
 
 // wasmTraceCode is the []byte-serialized compiled WASM output of the
 // following C code:
-// #define WASM_EXPORT __attribute__((visibility("default")))
+//#define WASM_EXPORT __attribute__((visibility("default")))
 //
-// static int count = 0;
+//static unsigned long count = 0;
+//extern void write_result(void *ptr, unsigned long length);
 //
-// WASM_EXPORT
-// void step() {
-//   count++;
-// }
+//WASM_EXPORT
+//void init() {
+//	count = 0;
+//}
 //
-// WASM_EXPORT
-// void fault() {
-// }
+//WASM_EXPORT
+//void step() {
+//	count++;
+//}
 //
-// WASM_EXPORT
-// unsigned char *result() {
-//   return &count;
-// }
-var wasmTraceCode []byte = []byte{0, 97, 115, 109, 1, 0, 0, 0, 1, 8, 2, 96, 0, 0, 96, 0, 1, 127, 3, 5, 4, 0, 0, 0, 1, 4, 5, 1, 112, 1, 1, 1, 5, 3, 1, 0, 2, 6, 21, 3, 127, 1, 65, 144, 136, 4, 11, 127, 0, 65, 144, 136, 4, 11, 127, 0, 65, 132, 8, 11, 7, 61, 6, 4, 115, 116, 101, 112, 0, 1, 5, 102, 97, 117, 108, 116, 0, 2, 6, 114, 101, 115, 117, 108, 116, 0, 3, 6, 109, 101, 109, 111, 114, 121, 2, 0, 11, 95, 95, 104, 101, 97, 112, 95, 98, 97, 115, 101, 3, 1, 10, 95, 95, 100, 97, 116, 97, 95, 101, 110, 100, 3, 2, 10, 31, 4, 2, 0, 11, 17, 0, 65, 0, 65, 0, 40, 2, 128, 8, 65, 1, 106, 54, 2, 128, 8, 11, 2, 0, 11, 5, 0, 65, 128, 8, 11, 11, 11, 1, 0, 65, 128, 8, 11, 4, 0, 0, 0, 0, 0, 59, 4, 110, 97, 109, 101, 1, 41, 4, 0, 17, 95, 95, 119, 97, 115, 109, 95, 99, 97, 108, 108, 95, 99, 116, 111, 114, 115, 1, 4, 115, 116, 101, 112, 2, 5, 102, 97, 117, 108, 116, 3, 6, 114, 101, 115, 117, 108, 116, 2, 9, 4, 0, 0, 1, 0, 2, 0, 3, 0}
+//WASM_EXPORT
+//	void fault() {
+//}
+//
+//WASM_EXPORT
+//int result() {
+//	write_result(&count, sizeof(count));
+//	return 0;
+//}
+var wasmTraceCode []byte = []byte{0, 97, 115, 109, 1, 0, 0, 0, 1, 13, 3, 96, 2, 127, 127, 0, 96, 0, 0, 96, 0, 1, 127, 2, 20, 1, 3, 101, 110, 118, 12, 119, 114, 105, 116, 101, 95, 114, 101, 115, 117, 108, 116, 0, 0, 3, 5, 4, 1, 1, 1, 2, 4, 5, 1, 112, 1, 1, 1, 5, 3, 1, 0, 2, 6, 8, 1, 127, 1, 65, 144, 136, 4, 11, 7, 41, 5, 4, 105, 110, 105, 116, 0, 1, 4, 115, 116, 101, 112, 0, 2, 5, 102, 97, 117, 108, 116, 0, 3, 6, 114, 101, 115, 117, 108, 116, 0, 4, 6, 109, 101, 109, 111, 114, 121, 2, 0, 10, 45, 4, 10, 0, 65, 0, 65, 0, 54, 2, 128, 8, 11, 17, 0, 65, 0, 65, 0, 40, 2, 128, 8, 65, 1, 106, 54, 2, 128, 8, 11, 2, 0, 11, 11, 0, 65, 128, 8, 65, 4, 16, 0, 65, 0, 11, 11, 11, 1, 0, 65, 128, 8, 11, 4, 0, 0, 0, 0, 0, 66, 4, 110, 97, 109, 101, 1, 42, 5, 0, 12, 119, 114, 105, 116, 101, 95, 114, 101, 115, 117, 108, 116, 1, 4, 105, 110, 105, 116, 2, 4, 115, 116, 101, 112, 3, 5, 102, 97, 117, 108, 116, 4, 6, 114, 101, 115, 117, 108, 116, 2, 15, 5, 0, 2, 0, 0, 1, 0, 1, 0, 2, 0, 3, 0, 4, 0}
 
 func TestWasmTracing(t *testing.T) {
 	tracer, err := New(string(wasmTraceCode))
@@ -142,8 +149,29 @@ func TestWasmTracing(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !bytes.Equal(ret, []byte("3")) {
-		t.Errorf("Expected return value to be 3, got %s", string(ret))
+	if !bytes.Equal(ret, []byte{3,0,0, 0}) {
+		t.Errorf("Expected return value to be 0x03000000, got %#x", ret)
+	}
+}
+
+func TestWasmTracingCallInit(t *testing.T) {
+	tracer, err := New(string(wasmTraceCode))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var ret []byte
+	_, err = runTrace(tracer)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ret, err = runTrace(tracer)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !bytes.Equal(ret, []byte{3,0,0, 0}) {
+		t.Errorf("Expected return value to be 0x03000000, got %#x", ret)
 	}
 }
 

--- a/eth/tracers/tracer_test.go
+++ b/eth/tracers/tracer_test.go
@@ -50,7 +50,7 @@ type dummyStatedb struct {
 
 func (*dummyStatedb) GetRefund() uint64 { return 1337 }
 
-func runTrace(tracer *Tracer) (json.RawMessage, error) {
+func runTrace(tracer Tracer) (json.RawMessage, error) {
 	env := vm.NewEVM(vm.Context{BlockNumber: big.NewInt(1)}, &dummyStatedb{}, params.TestChainConfig, vm.Config{Debug: true, Tracer: tracer})
 
 	contract := vm.NewContract(account{}, account{}, big.NewInt(0), 10000)

--- a/eth/tracers/tracer_test.go
+++ b/eth/tracers/tracer_test.go
@@ -111,6 +111,42 @@ func TestTracing(t *testing.T) {
 	}
 }
 
+// wasmTraceCode is the []byte-serialized compiled WASM output of the
+// following C code:
+// #define WASM_EXPORT __attribute__((visibility("default")))
+//
+// static int count = 0;
+//
+// WASM_EXPORT
+// void step() {
+//   count++;
+// }
+//
+// WASM_EXPORT
+// void fault() {
+// }
+//
+// WASM_EXPORT
+// unsigned char *result() {
+//   return &count;
+// }
+var wasmTraceCode []byte = []byte{0, 97, 115, 109, 1, 0, 0, 0, 1, 8, 2, 96, 0, 0, 96, 0, 1, 127, 3, 5, 4, 0, 0, 0, 1, 4, 5, 1, 112, 1, 1, 1, 5, 3, 1, 0, 2, 6, 21, 3, 127, 1, 65, 144, 136, 4, 11, 127, 0, 65, 144, 136, 4, 11, 127, 0, 65, 132, 8, 11, 7, 61, 6, 4, 115, 116, 101, 112, 0, 1, 5, 102, 97, 117, 108, 116, 0, 2, 6, 114, 101, 115, 117, 108, 116, 0, 3, 6, 109, 101, 109, 111, 114, 121, 2, 0, 11, 95, 95, 104, 101, 97, 112, 95, 98, 97, 115, 101, 3, 1, 10, 95, 95, 100, 97, 116, 97, 95, 101, 110, 100, 3, 2, 10, 31, 4, 2, 0, 11, 17, 0, 65, 0, 65, 0, 40, 2, 128, 8, 65, 1, 106, 54, 2, 128, 8, 11, 2, 0, 11, 5, 0, 65, 128, 8, 11, 11, 11, 1, 0, 65, 128, 8, 11, 4, 0, 0, 0, 0, 0, 59, 4, 110, 97, 109, 101, 1, 41, 4, 0, 17, 95, 95, 119, 97, 115, 109, 95, 99, 97, 108, 108, 95, 99, 116, 111, 114, 115, 1, 4, 115, 116, 101, 112, 2, 5, 102, 97, 117, 108, 116, 3, 6, 114, 101, 115, 117, 108, 116, 2, 9, 4, 0, 0, 1, 0, 2, 0, 3, 0}
+
+func TestWasmTracing(t *testing.T) {
+	tracer, err := New(string(wasmTraceCode))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ret, err := runTrace(tracer)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(ret, []byte("3")) {
+		t.Errorf("Expected return value to be 3, got %s", string(ret))
+	}
+}
+
 func TestStack(t *testing.T) {
 	tracer, err := New("{depths: [], step: function(log) { this.depths.push(log.stack.length()); }, fault: function() {}, result: function() { return this.depths; }}")
 	if err != nil {

--- a/eth/tracers/tracer_test.go
+++ b/eth/tracers/tracer_test.go
@@ -149,7 +149,7 @@ func TestWasmTracing(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !bytes.Equal(ret, []byte{3,0,0, 0}) {
+	if !bytes.Equal(ret, []byte{3, 0, 0, 0}) {
 		t.Errorf("Expected return value to be 0x03000000, got %#x", ret)
 	}
 }
@@ -165,12 +165,16 @@ func TestWasmTracingCallInit(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	// TODO(gballet) CaptureStart isn't called by runTrace, so fake
+	// the call so as not to rebuild a full-fledged environment at
+	// this stage.
+	tracer.CaptureStart(common.Address{}, common.Address{}, false, nil, 0, big.NewInt(0))
 	ret, err = runTrace(tracer)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	if !bytes.Equal(ret, []byte{3,0,0, 0}) {
+	if !bytes.Equal(ret, []byte{3, 0, 0, 0}) {
 		t.Errorf("Expected return value to be 0x03000000, got %#x", ret)
 	}
 }

--- a/eth/tracers/tracers.go
+++ b/eth/tracers/tracers.go
@@ -24,8 +24,9 @@ import (
 	"github.com/ethereum/go-ethereum/eth/tracers/internal/tracers"
 )
 
-// all contains all the built in JavaScript tracers by name.
-var all = make(map[string]string)
+// allJs contains allJs the built in JavaScript tracers by name.
+var allJs = make(map[string]string)
+var allWasm = make(map[string]string)
 
 // camel converts a snake cased input string into a camel cased output.
 func camel(str string) string {
@@ -39,15 +40,23 @@ func camel(str string) string {
 // init retrieves the JavaScript transaction tracers included in go-ethereum.
 func init() {
 	for _, file := range tracers.AssetNames() {
-		name := camel(strings.TrimSuffix(file, ".js"))
-		all[name] = string(tracers.MustAsset(file))
+		if strings.HasSuffix(file, ".js") {
+			name := camel(strings.TrimSuffix(file, ".js"))
+			allJs[name] = string(tracers.MustAsset(file))
+		} else {
+			name := camel(strings.TrimSuffix(file, ".wasm"))
+			allWasm[name] = string(tracers.MustAsset(file))
+		}
 	}
 }
 
-// tracer retrieves a specific JavaScript tracer by name.
-func tracer(name string) (string, bool) {
-	if tracer, ok := all[name]; ok {
-		return tracer, true
+// tracer retrieves a specific JavaScript or Wasm tracer by name.
+func tracer(name string) (string, bool, bool) {
+	if tracer, ok := allJs[name]; ok {
+		return tracer, false, true
 	}
-	return "", false
+	if tracer, ok := allWasm[name]; ok {
+		return tracer, true, true
+	}
+	return "", false, false
 }

--- a/go.mod
+++ b/go.mod
@@ -19,10 +19,11 @@ require (
 	github.com/docker/docker v1.4.2-0.20180625184442-8e610b2b55bf
 	github.com/dop251/goja v0.0.0-20200721192441-a695b0cdd498
 	github.com/dvyukov/go-fuzz v0.0.0-20200318091601-be3528f3a813 // indirect
-	github.com/edsrzf/mmap-go v0.0.0-20160512033002-935e0e8a636c
+	github.com/edsrzf/mmap-go v1.0.0
 	github.com/fatih/color v1.3.0
 	github.com/fjl/memsize v0.0.0-20180418122429-ca190fb6ffbc
 	github.com/gballet/go-libpcsclite v0.0.0-20190607065134-2772fd86a8ff
+	github.com/go-interpreter/wagon v0.6.0 // indirect
 	github.com/go-ole/go-ole v1.2.1 // indirect
 	github.com/go-sourcemap/sourcemap v2.1.2+incompatible // indirect
 	github.com/go-stack/stack v1.8.0

--- a/go.mod
+++ b/go.mod
@@ -23,7 +23,7 @@ require (
 	github.com/fatih/color v1.3.0
 	github.com/fjl/memsize v0.0.0-20180418122429-ca190fb6ffbc
 	github.com/gballet/go-libpcsclite v0.0.0-20190607065134-2772fd86a8ff
-	github.com/go-interpreter/wagon v0.6.0 // indirect
+	github.com/go-interpreter/wagon v0.6.0
 	github.com/go-ole/go-ole v1.2.1 // indirect
 	github.com/go-sourcemap/sourcemap v2.1.2+incompatible // indirect
 	github.com/go-stack/stack v1.8.0

--- a/go.sum
+++ b/go.sum
@@ -63,6 +63,7 @@ github.com/dvyukov/go-fuzz v0.0.0-20200318091601-be3528f3a813 h1:NgO45/5mBLRVfiX
 github.com/dvyukov/go-fuzz v0.0.0-20200318091601-be3528f3a813/go.mod h1:11Gm+ccJnvAhCNLlf5+cS9KjtbaD5I5zaZpFMsTHWTw=
 github.com/edsrzf/mmap-go v0.0.0-20160512033002-935e0e8a636c h1:JHHhtb9XWJrGNMcrVP6vyzO4dusgi/HnceHTgxSejUM=
 github.com/edsrzf/mmap-go v0.0.0-20160512033002-935e0e8a636c/go.mod h1:YO35OhQPt3KJa3ryjFM5Bs14WD66h8eGKpfaBNrHW5M=
+github.com/edsrzf/mmap-go v1.0.0 h1:CEBF7HpRnUCSJgGUb5h1Gm7e3VkmVDrR8lvWVLtrOFw=
 github.com/edsrzf/mmap-go v1.0.0/go.mod h1:YO35OhQPt3KJa3ryjFM5Bs14WD66h8eGKpfaBNrHW5M=
 github.com/fatih/color v1.3.0 h1:YehCCcyeQ6Km0D6+IapqPinWBK6y+0eB5umvZXK9WPs=
 github.com/fatih/color v1.3.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
@@ -209,6 +210,7 @@ github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJy
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/syndtr/goleveldb v1.0.1-0.20200815110645-5c35d600f0ca h1:Ld/zXl5t4+D69SiV4JoN7kkfvJdOWlPpfxrzxpLMoUk=
 github.com/syndtr/goleveldb v1.0.1-0.20200815110645-5c35d600f0ca/go.mod h1:u2MKkTVTVJWe5D1rCvame8WqhBd88EuIwODJZ1VHCPM=
+github.com/twitchyliquid64/golang-asm v0.0.0-20190126203739-365674df15fc h1:RTUQlKzoZZVG3umWNzOYeFecQLIh+dbxXvJp1zPQJTI=
 github.com/twitchyliquid64/golang-asm v0.0.0-20190126203739-365674df15fc/go.mod h1:NoCfSFWosfqMqmmD7hApkirIK9ozpHjxRnRxs1l413A=
 github.com/tyler-smith/go-bip39 v1.0.1-0.20181017060643-dbb3b84ba2ef h1:wHSqTBrZW24CsNJDfeh9Ex6Pm0Rcpc7qrgKBiL44vF4=
 github.com/tyler-smith/go-bip39 v1.0.1-0.20181017060643-dbb3b84ba2ef/go.mod h1:sJ5fKU0s6JVwZjjcUEX2zFOnvq0ASQ2K9Zr6cf67kNs=

--- a/go.sum
+++ b/go.sum
@@ -63,6 +63,7 @@ github.com/dvyukov/go-fuzz v0.0.0-20200318091601-be3528f3a813 h1:NgO45/5mBLRVfiX
 github.com/dvyukov/go-fuzz v0.0.0-20200318091601-be3528f3a813/go.mod h1:11Gm+ccJnvAhCNLlf5+cS9KjtbaD5I5zaZpFMsTHWTw=
 github.com/edsrzf/mmap-go v0.0.0-20160512033002-935e0e8a636c h1:JHHhtb9XWJrGNMcrVP6vyzO4dusgi/HnceHTgxSejUM=
 github.com/edsrzf/mmap-go v0.0.0-20160512033002-935e0e8a636c/go.mod h1:YO35OhQPt3KJa3ryjFM5Bs14WD66h8eGKpfaBNrHW5M=
+github.com/edsrzf/mmap-go v1.0.0/go.mod h1:YO35OhQPt3KJa3ryjFM5Bs14WD66h8eGKpfaBNrHW5M=
 github.com/fatih/color v1.3.0 h1:YehCCcyeQ6Km0D6+IapqPinWBK6y+0eB5umvZXK9WPs=
 github.com/fatih/color v1.3.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
 github.com/fjl/memsize v0.0.0-20180418122429-ca190fb6ffbc h1:jtW8jbpkO4YirRSyepBOH8E+2HEw6/hKkBvFPwhUN8c=
@@ -73,6 +74,8 @@ github.com/fsnotify/fsnotify v1.4.9 h1:hsms1Qyu0jgnwNXIxa+/V/PDsU6CfLf6CNO8H7IWo
 github.com/fsnotify/fsnotify v1.4.9/go.mod h1:znqG4EE+3YCdAaPaxE2ZRY/06pZUdp0tY4IgpuI1SZQ=
 github.com/gballet/go-libpcsclite v0.0.0-20190607065134-2772fd86a8ff h1:tY80oXqGNY4FhTFhk+o9oFHGINQ/+vhlm8HFzi6znCI=
 github.com/gballet/go-libpcsclite v0.0.0-20190607065134-2772fd86a8ff/go.mod h1:x7DCsMOv1taUwEWCzT4cmDeAkigA5/QCwUodaVOe8Ww=
+github.com/go-interpreter/wagon v0.6.0 h1:BBxDxjiJiHgw9EdkYXAWs8NHhwnazZ5P2EWBW5hFNWw=
+github.com/go-interpreter/wagon v0.6.0/go.mod h1:5+b/MBYkclRZngKF5s6qrgWxSLgE9F5dFdO1hAueZLc=
 github.com/go-kit/kit v0.8.0 h1:Wz+5lgoB0kkuqLEc6NVmwRknTKP6dTGbSqvhZtBI/j0=
 github.com/go-kit/kit v0.8.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2as=
 github.com/go-logfmt/logfmt v0.3.0 h1:8HUsc87TaSWLKwrnumgC8/YconD2fJQsRJAsWaPg2ic=
@@ -206,6 +209,7 @@ github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJy
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/syndtr/goleveldb v1.0.1-0.20200815110645-5c35d600f0ca h1:Ld/zXl5t4+D69SiV4JoN7kkfvJdOWlPpfxrzxpLMoUk=
 github.com/syndtr/goleveldb v1.0.1-0.20200815110645-5c35d600f0ca/go.mod h1:u2MKkTVTVJWe5D1rCvame8WqhBd88EuIwODJZ1VHCPM=
+github.com/twitchyliquid64/golang-asm v0.0.0-20190126203739-365674df15fc/go.mod h1:NoCfSFWosfqMqmmD7hApkirIK9ozpHjxRnRxs1l413A=
 github.com/tyler-smith/go-bip39 v1.0.1-0.20181017060643-dbb3b84ba2ef h1:wHSqTBrZW24CsNJDfeh9Ex6Pm0Rcpc7qrgKBiL44vF4=
 github.com/tyler-smith/go-bip39 v1.0.1-0.20181017060643-dbb3b84ba2ef/go.mod h1:sJ5fKU0s6JVwZjjcUEX2zFOnvq0ASQ2K9Zr6cf67kNs=
 github.com/urfave/cli v1.22.1/go.mod h1:Gos4lmkARVdJ6EkW0WaNv/tZAAMe9V7XWyB60NtXRu0=
@@ -227,6 +231,7 @@ golang.org/x/sync v0.0.0-20181108010431-42b317875d0f/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sys v0.0.0-20180909124046-d0be0721c37e/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20181107165924-66b7b1311ac8/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
+golang.org/x/sys v0.0.0-20190306220234-b354f8bf4d9e/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190904154756-749cb33beabd/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191005200804-aed5e4c7ecf9/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=


### PR DESCRIPTION
As discussed back in February, this introduces support for tracing code written in WASM. The medium-term goal is to replace javascript tracers entirely and get rid of the cgo constraint introduced by duktape.

This is a draft PR because I would like to collect feedback before I go ahead and implement all objects.
