### PR TITLE
miner: exit loop when downloader Done or Failed

### DIFF
--- a/miner/miner.go
+++ b/miner/miner.go
@@ -110,14 +110,14 @@ func (miner *Miner) update() {
 				}
 			case downloader.FailedEvent:
 				canStart = true
-				if miningRequested {
+				if miningRequested && !miner.Mining() {
 					miner.SetEtherbase(miner.coinbase)
 					miner.worker.start()
 				}
 			case downloader.DoneEvent:
 				canStart = true
 				downloaderCanStop = false
-				if miningRequested {
+				if miningRequested && !miner.Mining() {
 					miner.SetEtherbase(miner.coinbase)
 					miner.worker.start()
 				}

--- a/miner/miner.go
+++ b/miner/miner.go
@@ -106,6 +106,7 @@ func (miner *Miner) update() {
 					log.Info("Mining aborted due to sync")
 				}
 			case downloader.DoneEvent, downloader.FailedEvent:
+				canStart = true
 				if shouldStart {
 					miner.SetEtherbase(miner.coinbase)
 					miner.worker.start()

--- a/miner/miner.go
+++ b/miner/miner.go
@@ -126,14 +126,11 @@ func (miner *Miner) update() {
 
 	// Handle downloader events while subscription is open.
 	go func() {
-		for {
-			select {
-			case ev := <-downloaderEvents.Chan():
-				if ev == nil {
-					return
-				}
-				handleDownloaderEvents(ev)
+		for ev := range downloaderEvents.Chan() {
+			if ev == nil {
+				return
 			}
+			handleDownloaderEvents(ev)
 		}
 	}()
 

--- a/miner/miner.go
+++ b/miner/miner.go
@@ -111,8 +111,6 @@ func (miner *Miner) update() {
 					miner.SetEtherbase(miner.coinbase)
 					miner.worker.start()
 				}
-				// stop immediately and ignore all further pending events
-				return
 			}
 		case addr := <-miner.startCh:
 			if canStart {

--- a/miner/miner.go
+++ b/miner/miner.go
@@ -111,6 +111,8 @@ func (miner *Miner) update() {
 					miner.SetEtherbase(miner.coinbase)
 					miner.worker.start()
 				}
+				// stop immediately and ignore all further pending events
+				return
 			}
 		case addr := <-miner.startCh:
 			if canStart {

--- a/miner/miner.go
+++ b/miner/miner.go
@@ -124,13 +124,21 @@ func (miner *Miner) update() {
 		}
 	}
 
+	// Handle downloader events while subscription is open.
+	go func() {
+		for {
+			select {
+			case ev := <-downloaderEvents.Chan():
+				if ev == nil {
+					return
+				}
+				handleDownloaderEvents(ev)
+			}
+		}
+	}()
+
 	for {
 		select {
-		case ev := <-downloaderEvents.Chan():
-			if ev == nil {
-				return
-			}
-			handleDownloaderEvents(ev)
 		case addr := <-miner.startCh:
 			if canStart {
 				miner.SetEtherbase(addr)

--- a/miner/miner.go
+++ b/miner/miner.go
@@ -106,7 +106,6 @@ func (miner *Miner) update() {
 					log.Info("Mining aborted due to sync")
 				}
 			case downloader.DoneEvent, downloader.FailedEvent:
-				canStart = true
 				if shouldStart {
 					miner.SetEtherbase(miner.coinbase)
 					miner.worker.start()

--- a/miner/miner_test.go
+++ b/miner/miner_test.go
@@ -89,10 +89,10 @@ func TestMiner(t *testing.T) {
 	// Stop the downloader and wait for the update loop to run
 	mux.Post(downloader.DoneEvent{})
 	waitForMiningState(t, miner, true)
-	// Start the downloader and wait for the update loop to run
+	// Start the downloader, the mining state will not change because the update loop has exited
 	mux.Post(downloader.StartEvent{})
-	waitForMiningState(t, miner, false)
-	// Stop the downloader and wait for the update loop to run
+	waitForMiningState(t, miner, true)
+	// Stop the downloader, the mining state will not change
 	mux.Post(downloader.FailedEvent{})
 	waitForMiningState(t, miner, true)
 }

--- a/miner/miner_test.go
+++ b/miner/miner_test.go
@@ -90,8 +90,13 @@ func TestMiner(t *testing.T) {
 	mux.Post(downloader.DoneEvent{})
 	waitForMiningState(t, miner, true)
 
+	// Subsequent downloader events should not cause the
+	// miner to start or stop. This prevents a security vulnerability
+	// that would allow entities to present fake high blocks that would
+	// stop mining operations by causing a downloader sync
+	// until it was discovered they were invalid, whereon mining would resume.
 	mux.Post(downloader.StartEvent{})
-	waitForMiningState(t, miner, false)
+	waitForMiningState(t, miner, true)
 
 	mux.Post(downloader.FailedEvent{})
 	waitForMiningState(t, miner, true)

--- a/miner/miner_test.go
+++ b/miner/miner_test.go
@@ -104,7 +104,7 @@ func TestMiner(t *testing.T) {
 
 // TestMinerDownloaderFirstFails tests that mining is only
 // permitted to run indefinitely once the downloader sees a DoneEvent (success).
-// With this, a FailEvent should not prohibit mining stopping on a subsequent
+// An initial FailedEvent should allow mining to stop on a subsequent
 // downloader StartEvent.
 func TestMinerDownloaderFirstFails(t *testing.T) {
 	miner, mux := createMiner(t)

--- a/miner/miner_test.go
+++ b/miner/miner_test.go
@@ -89,10 +89,10 @@ func TestMiner(t *testing.T) {
 	// Stop the downloader and wait for the update loop to run
 	mux.Post(downloader.DoneEvent{})
 	waitForMiningState(t, miner, true)
-	// Start the downloader, the mining state will not change because the update loop has exited
+
 	mux.Post(downloader.StartEvent{})
-	waitForMiningState(t, miner, true)
-	// Stop the downloader, the mining state will not change
+	waitForMiningState(t, miner, false)
+
 	mux.Post(downloader.FailedEvent{})
 	waitForMiningState(t, miner, true)
 }
@@ -158,10 +158,10 @@ func waitForMiningState(t *testing.T, m *Miner, mining bool) {
 
 	var state bool
 	for i := 0; i < 100; i++ {
+		time.Sleep(10 * time.Millisecond)
 		if state = m.Mining(); state == mining {
 			return
 		}
-		time.Sleep(10 * time.Millisecond)
 	}
 	t.Fatalf("Mining() == %t, want %t", state, mining)
 }

--- a/miner/miner_test.go
+++ b/miner/miner_test.go
@@ -135,7 +135,29 @@ func TestMinerDownloaderFirstFails(t *testing.T) {
 
 	mux.Post(downloader.FailedEvent{})
 	waitForMiningState(t, miner, true)
+}
 
+func TestMinerStartStopAfterDownloaderEvents(t *testing.T) {
+	miner, mux := createMiner(t)
+
+	miner.Start(common.HexToAddress("0x12345"))
+	waitForMiningState(t, miner, true)
+	// Start the downloader
+	mux.Post(downloader.StartEvent{})
+	waitForMiningState(t, miner, false)
+
+	// Downloader finally succeeds.
+	mux.Post(downloader.DoneEvent{})
+	waitForMiningState(t, miner, true)
+
+	miner.Stop()
+	waitForMiningState(t, miner, false)
+
+	miner.Start(common.HexToAddress("0x678910"))
+	waitForMiningState(t, miner, true)
+
+	miner.Stop()
+	waitForMiningState(t, miner, false)
 }
 
 func TestStartWhileDownload(t *testing.T) {

--- a/miner/miner_test.go
+++ b/miner/miner_test.go
@@ -97,27 +97,6 @@ func TestMiner(t *testing.T) {
 	waitForMiningState(t, miner, true)
 }
 
-// TestMiner_2 shows that TestMiner assertions 'waitForMiningState' are
-// imprecise measurements. The last two assertions use 'false' where the original
-// test uses 'true'. The test passes.
-func TestMiner_2(t *testing.T) {
-	miner, mux := createMiner(t)
-	miner.Start(common.HexToAddress("0x12345"))
-	waitForMiningState(t, miner, true)
-	// Start the downloader
-	mux.Post(downloader.StartEvent{})
-	waitForMiningState(t, miner, false)
-	// Stop the downloader and wait for the update loop to run
-	mux.Post(downloader.DoneEvent{})
-	waitForMiningState(t, miner, true)
-	// Start the downloader, the mining state will not change because the update loop has exited
-	mux.Post(downloader.StartEvent{})
-	waitForMiningState(t, miner, false)
-	// Stop the downloader, the mining state will not change
-	mux.Post(downloader.FailedEvent{})
-	waitForMiningState(t, miner, false)
-}
-
 func TestStartWhileDownload(t *testing.T) {
 	miner, mux := createMiner(t)
 	waitForMiningState(t, miner, false)


### PR DESCRIPTION
Following the logic of the comment at the method,
this fixes a regression introduced at 7cf56d6f064869cb62b1673f9ee437020c595391, which would allow external parties to DoS with blocks, preventing mining progress.


Rel 
- https://github.com/ethereum/go-ethereum/pull/21536
- https://github.com/ethereum/go-ethereum/pull/21547
- https://github.com/etclabscore/core-geth/issues/199

