### PR TITLE
console: don't exit on ctrl-c, only on ctrl-d

### DIFF
--- a/cmd/geth/consolecmd_test.go
+++ b/cmd/geth/consolecmd_test.go
@@ -66,6 +66,7 @@ at block: 0 ({{niltime}})
  datadir: {{.Datadir}}
  modules: {{apis}}
 
+To exit, press ctrl-d
 > {{.InputLine "exit"}}
 `)
 	geth.ExpectExit()
@@ -159,6 +160,7 @@ at block: 0 ({{niltime}}){{if ipc}}
  datadir: {{datadir}}{{end}}
  modules: {{apis}}
 
+To exit, press ctrl-d
 > {{.InputLine "exit" }}
 `)
 	attach.ExpectExit()

--- a/console/console.go
+++ b/console/console.go
@@ -345,7 +345,6 @@ func (c *Console) Interactive() {
 		prompt           = c.prompt             // the current prompt line (used for multi-line inputs)
 		indents          = 0                    // the current number of input indents (used for multi-line inputs)
 		input            = ""                   // the current user input
-		interruptCounter = 0                    // keeps track of interrupts, killing the console if pressed twice in a row
 		inputLine        = make(chan string, 1) // receives user input
 		inputErr         = make(chan error, 1)  // receives liner errors
 		requestLine      = make(chan string)    // requests a line of input
@@ -373,12 +372,10 @@ func (c *Console) Interactive() {
 			return
 
 		case err := <-inputErr:
-			if err == liner.ErrPromptAborted && interruptCounter < 1 {
+			if err == liner.ErrPromptAborted {
 				// When prompting for multi-line input, the first Ctrl-C resets
 				// the multi-line state.
 				prompt, indents, input = c.prompt, 0, ""
-				interruptCounter++
-				fmt.Fprintln(c.printer, "(To exit, press ^C again or ^D or type exit)")
 				continue
 			}
 			return
@@ -412,8 +409,6 @@ func (c *Console) Interactive() {
 				c.Evaluate(input)
 				input = ""
 			}
-
-			interruptCounter = 0
 		}
 	}
 }

--- a/console/console.go
+++ b/console/console.go
@@ -324,6 +324,7 @@ func (c *Console) Welcome() {
 		sort.Strings(modules)
 		message += " modules: " + strings.Join(modules, " ") + "\n"
 	}
+	message += "\nTo exit, press ctrl-d"
 	fmt.Fprintln(c.printer, message)
 }
 

--- a/console/console.go
+++ b/console/console.go
@@ -342,13 +342,13 @@ func (c *Console) Evaluate(statement string) {
 // the configured user prompter.
 func (c *Console) Interactive() {
 	var (
-		prompt           = c.prompt             // the current prompt line (used for multi-line inputs)
-		indents          = 0                    // the current number of input indents (used for multi-line inputs)
-		input            = ""                   // the current user input
-		inputLine        = make(chan string, 1) // receives user input
-		inputErr         = make(chan error, 1)  // receives liner errors
-		requestLine      = make(chan string)    // requests a line of input
-		interrupt        = make(chan os.Signal, 1)
+		prompt      = c.prompt             // the current prompt line (used for multi-line inputs)
+		indents     = 0                    // the current number of input indents (used for multi-line inputs)
+		input       = ""                   // the current user input
+		inputLine   = make(chan string, 1) // receives user input
+		inputErr    = make(chan error, 1)  // receives liner errors
+		requestLine = make(chan string)    // requests a line of input
+		interrupt   = make(chan os.Signal, 1)
 	)
 
 	// Monitor Ctrl-C. While liner does turn on the relevant terminal mode bits to avoid


### PR DESCRIPTION
This PR adds an interrupt counter to the local console so that one `^C` will cause the console to be cleared, but two `^C`s in a row will cause console termination.