### PR TITLE
p2p/discover: remove use of shared hash instance for key derivation

### DIFF
--- a/p2p/discover/v5_encoding.go
+++ b/p2p/discover/v5_encoding.go
@@ -383,7 +383,7 @@ func (c *wireCodec) deriveKeys(n1, n2 enode.ID, priv *ecdsa.PrivateKey, pub *ecd
 	info := []byte("discovery v5 key agreement")
 	info = append(info, n1[:]...)
 	info = append(info, n2[:]...)
-	kdf := hkdf.New(c.sha256reset, eph, challenge.IDNonce[:], info)
+	kdf := hkdf.New(sha256.New, eph, challenge.IDNonce[:], info)
 	sec := handshakeSecrets{
 		writeKey:    make([]byte, aesKeySize),
 		readKey:     make([]byte, aesKeySize),


### PR DESCRIPTION
For some reason, using the shared hash causes a cryptographic
incompatibility when using Go 1.15. I noticed this during the
development of Discovery v5.1 when I added test vector verification.

This is a temporary fix. There is nothing wrong with it, it's just a
tiny bit slower than before.