### PR TITLE
core/rawdb: don't use os.exit on chain iterator failures

### DIFF
--- a/core/rawdb/chain_iterator.go
+++ b/core/rawdb/chain_iterator.go
@@ -50,7 +50,8 @@ func InitDatabaseFromFreezer(db ethdb.Database) {
 		// freezerdb return N items (e.g up to 1000 items per go)
 		// That would require an API change in Ancients though
 		if h, err := db.Ancient(freezerHashTable, i); err != nil {
-			log.Crit("Failed to init database from freezer", "err", err)
+			log.Error("Failed to init database from freezer", "err", err)
+			return
 		} else {
 			hash = common.BytesToHash(h)
 		}
@@ -58,7 +59,8 @@ func InitDatabaseFromFreezer(db ethdb.Database) {
 		// If enough data was accumulated in memory or we're at the last block, dump to disk
 		if batch.ValueSize() > ethdb.IdealBatchSize {
 			if err := batch.Write(); err != nil {
-				log.Crit("Failed to write data to db", "err", err)
+				log.Error("Failed to write data to db", "err", err)
+				return
 			}
 			batch.Reset()
 		}
@@ -69,7 +71,8 @@ func InitDatabaseFromFreezer(db ethdb.Database) {
 		}
 	}
 	if err := batch.Write(); err != nil {
-		log.Crit("Failed to write data to db", "err", err)
+		log.Error("Failed to write data to db", "err", err)
+		return
 	}
 	batch.Reset()
 
@@ -214,7 +217,7 @@ func indexTransactions(db ethdb.Database, from uint64, to uint64, interrupt chan
 			if batch.ValueSize() > ethdb.IdealBatchSize {
 				WriteTxIndexTail(batch, lastNum) // Also write the tail here
 				if err := batch.Write(); err != nil {
-					log.Crit("Failed writing batch to db", "error", err)
+					log.Error("Failed writing batch to db", "error", err)
 					return
 				}
 				batch.Reset()
@@ -231,7 +234,7 @@ func indexTransactions(db ethdb.Database, from uint64, to uint64, interrupt chan
 	// be flushed anyway.
 	WriteTxIndexTail(batch, lastNum)
 	if err := batch.Write(); err != nil {
-		log.Crit("Failed writing batch to db", "error", err)
+		log.Error("Failed writing batch to db", "error", err)
 		return
 	}
 	select {
@@ -305,7 +308,7 @@ func unindexTransactions(db ethdb.Database, from uint64, to uint64, interrupt ch
 			if blocks%1000 == 0 {
 				WriteTxIndexTail(batch, nextNum)
 				if err := batch.Write(); err != nil {
-					log.Crit("Failed writing batch to db", "error", err)
+					log.Error("Failed writing batch to db", "error", err)
 					return
 				}
 				batch.Reset()
@@ -322,7 +325,7 @@ func unindexTransactions(db ethdb.Database, from uint64, to uint64, interrupt ch
 	// be flushed anyway.
 	WriteTxIndexTail(batch, nextNum)
 	if err := batch.Write(); err != nil {
-		log.Crit("Failed writing batch to db", "error", err)
+		log.Error("Failed writing batch to db", "error", err)
 		return
 	}
 	select {

--- a/core/rawdb/chain_iterator.go
+++ b/core/rawdb/chain_iterator.go
@@ -50,8 +50,7 @@ func InitDatabaseFromFreezer(db ethdb.Database) {
 		// freezerdb return N items (e.g up to 1000 items per go)
 		// That would require an API change in Ancients though
 		if h, err := db.Ancient(freezerHashTable, i); err != nil {
-			log.Error("Failed to init database from freezer", "err", err)
-			return
+			log.Crit("Failed to init database from freezer", "err", err)
 		} else {
 			hash = common.BytesToHash(h)
 		}


### PR DESCRIPTION
If you close (`ctrl-c`) the node while tx indexing/unindexing is ongoing, the indexing dies because the db is closed. This is mostly fine, but it's not good behaviour: the indexer does a `log.Crit`, which calls `os.Exit` under the hood. Since the db is already closed, we probably are mostly done and it's fine, but there could be other stuff we want to do before exiting, e..g closing filenhandles for the ancients, or whatever. 
This PR changes the `Crit` to `Error`. 
Example of hitting this behaviour: 
```
INFO [10-08|18:39:42.493] Imported new chain segment               blocks=23 txs=2910 mgas=258.929 elapsed=4.016s      mgasps=64.466 number=11016528 hash="c92c79…597853" age=2m55s     dirty=91.10MiB
INFO [10-08|18:39:42.494] Imported new block headers               count=2    elapsed=7.426s      number=11016530 hash="36fa33…ad7be8" age=2m29s
INFO [10-08|18:39:42.494] Upgrading chain index                    type=bloombits                                percentage=99
INFO [10-08|18:39:42.517] Downloader queue stats                   receiptTasks=0     blockTasks=0     itemSize=171.33KiB throttle=383
INFO [10-08|18:39:43.494] Unindexing transactions                  blocks=1160 txs=181191 total=72017 elapsed=1.000s
INFO [10-08|18:39:44.628] Imported new chain segment               blocks=2    txs=339    mgas=23.729  elapsed=2.111s      mgasps=11.240 number=11016530 hash="36fa33…ad7be8" age=2m31s     dirty=94.22MiB
INFO [10-08|18:39:44.628] Fast sync complete, auto disabling
INFO [10-08|18:39:49.221] Imported new chain segment               blocks=2    txs=306    mgas=23.514  elapsed=2.887s      mgasps=8.144  number=11016532 hash="c6bcf8…151d89" age=2m25s     dirty=97.08MiB
INFO [10-08|18:39:50.961] Upgrading chain index                    type=bloombits                                percentage=99
INFO [10-08|18:39:52.901] Unindexing transactions                  blocks=7000 txs=1126733 total=72017 elapsed=10.406s
^CINFO [10-08|18:39:53.479] Got interrupt, shutting down...
INFO [10-08|18:39:53.481] IPC endpoint closed                      url=/datadrive/geth-repro-copy/geth.ipc
INFO [10-08|18:39:54.535] Ethereum protocol stopped
INFO [10-08|18:39:54.617] Transaction pool stopped
INFO [10-08|18:39:54.617] Writing cached state to disk             block=11016534 hash="fea4a7…81ad30" root="7aacfe…3b47d1"
INFO [10-08|18:40:01.547] Unindexing transactions                  blocks=14000 txs=2336848 total=72017 elapsed=19.052s
INFO [10-08|18:40:02.502] Looking for peers                        peercount=0 tried=54 static=0
INFO [10-08|18:40:09.658] Unindexing transactions                  blocks=21000 txs=3480033 total=72017 elapsed=27.164s
INFO [10-08|18:40:12.503] Looking for peers                        peercount=0 tried=56 static=0
INFO [10-08|18:40:17.659] Unindexing transactions                  blocks=28127 txs=4618458 total=72017 elapsed=35.164s
INFO [10-08|18:40:21.373] Persisted trie from memory database      nodes=99376 size=30.91MiB   time=26.75583775s gcnodes=0 gcsize=0.00B gctime=0s livenodes=124927 livesize=47.82MiB
INFO [10-08|18:40:21.375] Writing cached state to disk             block=11016533 hash="fac076…71b30a" root="e52fe5…2f6c7d"
INFO [10-08|18:40:21.429] Persisted trie from memory database      nodes=2183  size=872.92KiB  time=54.913889ms  gcnodes=0 gcsize=0.00B gctime=0s livenodes=122744 livesize=46.97MiB
INFO [10-08|18:40:21.431] Writing cached state to disk             block=11016407 hash="4e6d41…c18da5" root="f29e2e…989e56"
INFO [10-08|18:40:21.431] Persisted trie from memory database      nodes=0     size=0.00B      time="6.375µs"    gcnodes=0 gcsize=0.00B gctime=0s livenodes=122744 livesize=46.97MiB
INFO [10-08|18:40:21.784] Writing clean trie cache to disk         path=/datadrive/geth-repro-copy/geth/triecache threads=8
INFO [10-08|18:40:21.818] Persisted the clean trie cache           path=/datadrive/geth-repro-copy/geth/triecache elapsed=34.045ms
INFO [10-08|18:40:21.818] Blockchain stopped
WARN [10-08|18:40:22.543] tx iteration error                       error="unexpected EOF"
WARN [10-08|18:40:22.543] tx iteration error                       error="unexpected EOF"
WARN [10-08|18:40:22.543] tx iteration error                       error="unexpected EOF"
WARN [10-08|18:40:22.543] tx iteration error                       error="unexpected EOF"
WARN [10-08|18:40:22.543] tx iteration error                       error="unexpected EOF"
WARN [10-08|18:40:22.543] tx iteration error                       error="unexpected EOF"
WARN [10-08|18:40:22.543] tx iteration error                       error="unexpected EOF"
WARN [10-08|18:40:22.543] tx iteration error                       error="unexpected EOF"
CRIT [10-08|18:40:22.543] Failed writing batch to db               error="leveldb: closed"
```