### PR TITLE
eth/downloader: fix data race around the ancientlimit

### DIFF
--- a/eth/downloader/downloader.go
+++ b/eth/downloader/downloader.go
@@ -515,6 +515,8 @@ func (d *Downloader) syncWithPeer(p *peerConnection, hash common.Hash, td *big.I
 			d.ancientLimit = d.checkpoint
 		} else if height > fullMaxForkAncestry+1 {
 			d.ancientLimit = height - fullMaxForkAncestry - 1
+		} else {
+			d.ancientLimit = 0
 		}
 		frozen, _ := d.stateDB.Ancients() // Ignore the error here since light client can also hit here.
 

--- a/eth/downloader/downloader.go
+++ b/eth/downloader/downloader.go
@@ -606,9 +606,6 @@ func (d *Downloader) cancel() {
 func (d *Downloader) Cancel() {
 	d.cancel()
 	d.cancelWg.Wait()
-
-	d.ancientLimit = 0
-	log.Debug("Reset ancient limit to zero")
 }
 
 // Terminate interrupts the downloader, canceling all pending operations.


### PR DESCRIPTION
Fixes #21557

`AncientLimit` in downloader is only used in `FAST SYNC`. However, during the fast sync setup, we will reassign the value anyway. So cleanup is meaningless and can cause data race. So this PR removes the cleanup logic.