### PR TITLE
core/tx_pool: fix off-by-one error

### DIFF
--- a/core/tx_pool.go
+++ b/core/tx_pool.go
@@ -817,6 +817,7 @@ func (pool *TxPool) addTxs(txs []*types.Transaction, local, sync bool) []error {
 			nilSlot++
 		}
 		errs[nilSlot] = err
+		nilSlot++
 	}
 	// Reorg the pool internals if needed and return
 	done := pool.requestPromoteExecutables(dirtyAddrs)


### PR DESCRIPTION
As reported by Hwanjo Heo, there is an off-by-one error when blending the new-errors into the error-slice in the txpool. 