### PR TITLE
eth: change chainID method to return chainID from config or error if before EIP-155

### DIFF
--- a/eth/api.go
+++ b/eth/api.go
@@ -68,9 +68,7 @@ func (api *PublicEthereumAPI) Hashrate() hexutil.Uint64 {
 
 // ChainId is the chain id for the current ethereum chain config.
 func (api *PublicEthereumAPI) ChainId() hexutil.Uint64 {
-	chainID := new(big.Int)
-	chainID = api.e.blockchain.Config().ChainID
-	return (hexutil.Uint64)(chainID.Uint64())
+	return (hexutil.Uint64)(api.e.blockchain.Config().ChainID.Uint64())
 }
 
 // IsEIP155 returns whether the current chain is on or past the

--- a/eth/api.go
+++ b/eth/api.go
@@ -66,15 +66,13 @@ func (api *PublicEthereumAPI) Hashrate() hexutil.Uint64 {
 	return hexutil.Uint64(api.e.Miner().HashRate())
 }
 
-// ChainId is the chain id for the current ethereum chain config.
-func (api *PublicEthereumAPI) ChainId() hexutil.Uint64 {
-	return (hexutil.Uint64)(api.e.blockchain.Config().ChainID.Uint64())
-}
-
-// IsEIP155 returns whether the current chain is on or past the
-// EIP-155 replay-protection fork block.
-func (api *PublicEthereumAPI) IsEIP155() bool {
-	return api.e.blockchain.Config().IsEIP155(api.e.blockchain.CurrentBlock().Number())
+// ChainId is the EIP-155 replay-protection chain id for the current ethereum chain config.
+func (api *PublicEthereumAPI) ChainId() (hexutil.Uint64, error) {
+	// if current block is at or past the EIP-155 replay-protection fork block, return chainID from config
+	if config := api.e.blockchain.Config(); config.IsEIP155(api.e.blockchain.CurrentBlock().Number()) {
+		return (hexutil.Uint64)(config.ChainID.Uint64()), nil
+	}
+	return hexutil.Uint64(0), fmt.Errorf("chain not synced beyond EIP-155 replay-protection fork block")
 }
 
 // PublicMinerAPI provides an API to control the miner.

--- a/eth/api.go
+++ b/eth/api.go
@@ -66,18 +66,17 @@ func (api *PublicEthereumAPI) Hashrate() hexutil.Uint64 {
 	return hexutil.Uint64(api.e.Miner().HashRate())
 }
 
-// ChainId is the EIP-155 replay-protection chain id for the current ethereum chain config.
+// ChainId is the chain id for the current ethereum chain config.
 func (api *PublicEthereumAPI) ChainId() hexutil.Uint64 {
 	chainID := new(big.Int)
-	if config := api.e.blockchain.Config(); config.IsEIP155(api.e.blockchain.CurrentBlock().Number()) {
-		chainID = config.ChainID
-	}
+	chainID = api.e.blockchain.Config().ChainID
 	return (hexutil.Uint64)(chainID.Uint64())
 }
 
-// ChainIDFromConfig returns the chain id for the current ethereum chain config.
-func (api *PublicEthereumAPI) ChainIDFromConfig() hexutil.Uint64 {
-	return (hexutil.Uint64)(api.e.blockchain.Config().ChainID.Uint64())
+// IsEIP155 returns whether the current chain is on or past the
+// EIP-155 replay-protection fork block.
+func (api *PublicEthereumAPI) IsEIP155() bool {
+	return api.e.blockchain.Config().IsEIP155(api.e.blockchain.CurrentBlock().Number())
 }
 
 // PublicMinerAPI provides an API to control the miner.

--- a/eth/api.go
+++ b/eth/api.go
@@ -75,6 +75,11 @@ func (api *PublicEthereumAPI) ChainId() hexutil.Uint64 {
 	return (hexutil.Uint64)(chainID.Uint64())
 }
 
+// ChainIDFromConfig returns the chain id for the current ethereum chain config.
+func (api *PublicEthereumAPI) ChainIDFromConfig() hexutil.Uint64 {
+	return (hexutil.Uint64)(api.e.blockchain.Config().ChainID.Uint64())
+}
+
 // PublicMinerAPI provides an API to control the miner.
 // It offers only methods that operate on data that pose no security risk when it is publicly accessible.
 type PublicMinerAPI struct {

--- a/internal/web3ext/web3ext.go
+++ b/internal/web3ext/web3ext.go
@@ -483,11 +483,6 @@ web3._extend({
 			params: 0
 		}),
 		new web3._extend.Method({
-			name: 'isEIP155',
-			call: 'eth_isEIP155',
-			params: 0
-		}),
-		new web3._extend.Method({
 			name: 'sign',
 			call: 'eth_sign',
 			params: 2,

--- a/internal/web3ext/web3ext.go
+++ b/internal/web3ext/web3ext.go
@@ -483,6 +483,11 @@ web3._extend({
 			params: 0
 		}),
 		new web3._extend.Method({
+			name: 'chainIDFromConfig',
+			call: 'eth_chainIDFromConfig',
+			params: 0
+		}),
+		new web3._extend.Method({
 			name: 'sign',
 			call: 'eth_sign',
 			params: 2,

--- a/internal/web3ext/web3ext.go
+++ b/internal/web3ext/web3ext.go
@@ -483,8 +483,8 @@ web3._extend({
 			params: 0
 		}),
 		new web3._extend.Method({
-			name: 'chainIDFromConfig',
-			call: 'eth_chainIDFromConfig',
+			name: 'isEIP155',
+			call: 'eth_isEIP155',
 			params: 0
 		}),
 		new web3._extend.Method({


### PR DESCRIPTION
This PR changes the `chainId()` method of the public eth api to return the eth config's `chainID` regardless of sync status. 

Sync status was previously required by the `chainId()` method in order to return the proper chainID, due to the following condition: 
```go
config.IsEIP155(api.e.blockchain.CurrentBlock().Number())
```
causing the incorrect `chainID` to be returned by the `chainId()` method for both Rinkeby and Ropsten (and private chains).


This PR also adds an `isEIP155()` method to the public ethereum API so one can check if the chain is at or beyond the EIP155 fork block.

closes https://github.com/ethereum/go-ethereum/issues/20894