### PR TITLE
p2p: don't use peer.Name in warn messages

### DIFF
--- a/eth/handler.go
+++ b/eth/handler.go
@@ -349,7 +349,7 @@ func (pm *ProtocolManager) handle(p *peer) error {
 		}
 		// Start a timer to disconnect if the peer doesn't reply in time
 		p.syncDrop = time.AfterFunc(syncChallengeTimeout, func() {
-			p.Log().Warn("Checkpoint challenge timed out, dropping", "addr", p.RemoteAddr(), "type", p.Name())
+			p.Log().Warn("Checkpoint challenge timed out, dropping", "addr", p.RemoteAddr())
 			pm.removePeer(p.id)
 		})
 		// Make sure it's cleaned up if the peer dies off
@@ -498,7 +498,7 @@ func (pm *ProtocolManager) handleMsg(p *peer) error {
 			// eclipse attacks. Unsynced nodes are welcome to connect after we're done
 			// joining the network
 			if atomic.LoadUint32(&pm.fastSync) == 1 {
-				p.Log().Warn("Dropping unsynced node during fast sync", "addr", p.RemoteAddr(), "type", p.Name())
+				p.Log().Warn("Dropping unsynced node during fast sync", "addr", p.RemoteAddr())
 				return errors.New("unsynced node cannot serve fast sync")
 			}
 		}

--- a/p2p/peer.go
+++ b/p2p/peer.go
@@ -140,7 +140,7 @@ func (p *Peer) Node() *enode.Node {
 
 // Name returns the node name that the remote node advertised.
 func (p *Peer) Name() string {
-	return p.LocalAddr().String()
+	return p.rw.name
 }
 
 // Caps returns the capabilities (supported subprotocols) of the remote peer.

--- a/p2p/peer.go
+++ b/p2p/peer.go
@@ -140,7 +140,7 @@ func (p *Peer) Node() *enode.Node {
 
 // Name returns the node name that the remote node advertised.
 func (p *Peer) Name() string {
-	return p.rw.name
+	return p.LocalAddr().String()
 }
 
 // Caps returns the capabilities (supported subprotocols) of the remote peer.


### PR DESCRIPTION
We currently use the name (which can be freely set by the peer) in several log messages.
This enables malicious actors to write spam into your geth log.
This pr reduces the usage of peer.Name() to log messages which are not shown by default

rel: https://github.com/ethereum/go-ethereum/issues/21687