### PR TITLE
trie: fix flaw in stacktrie pool reuse

### DIFF
--- a/trie/stacktrie.go
+++ b/trie/stacktrie.go
@@ -113,7 +113,7 @@ func (st *StackTrie) Update(key, value []byte) {
 func (st *StackTrie) Reset() {
 	st.db = nil
 	st.key = st.key[:0]
-	st.val = st.val[:0]
+	st.val = nil
 	for i := range st.children {
 		st.children[i] = nil
 	}


### PR DESCRIPTION
This PR fixes an issue found by @rjl493456442 , where stacktrie can become corrupted if used in parallel. This happens since the `child` is returned _before_ the rlp-encoding (https://github.com/ethereum/go-ethereum/blob/45a46b82218536ffe20d635d7f2c6ff30ce46379/trie/stacktrie.go#L313)  is finished, when a fullnode is processed: https://github.com/ethereum/go-ethereum/blob/45a46b82218536ffe20d635d7f2c6ff30ce46379/trie/stacktrie.go#L307 

A paralell stacktrie may write into the same underlying slice, right before the rlp-encoding has begun. 
This PR fixes that by not reusing the `val` slice