### PR TITLE
accounts/keystore: add timeout to test to prevent failure on travis

### DIFF
--- a/accounts/keystore/keystore_test.go
+++ b/accounts/keystore/keystore_test.go
@@ -304,6 +304,7 @@ func TestWalletNotifications(t *testing.T) {
 			}
 		}
 	}()
+
 	// Randomly add and remove accounts.
 	var (
 		live       = make(map[common.Address]accounts.Account)
@@ -332,6 +333,7 @@ func TestWalletNotifications(t *testing.T) {
 			wantEvents = append(wantEvents, walletEvent{accounts.WalletEvent{Kind: accounts.WalletDropped}, account})
 		}
 	}
+
 	// Wait for the event collector to get scheduled.
 	time.Sleep(10 * time.Millisecond)
 	// Shut down the event collector and check events.

--- a/accounts/keystore/keystore_test.go
+++ b/accounts/keystore/keystore_test.go
@@ -334,11 +334,11 @@ func TestWalletNotifications(t *testing.T) {
 		}
 	}
 
-	// Wait for the event collector to get scheduled.
-	time.Sleep(10 * time.Millisecond)
 	// Shut down the event collector and check events.
 	sub.Unsubscribe()
-	<-updates
+	for ev := range updates {
+		events = append(events, walletEvent{ev, ev.Wallet.Accounts()[0]})
+	}
 	checkAccounts(t, live, ks.Wallets())
 	checkEvents(t, wantEvents, events)
 }

--- a/accounts/keystore/keystore_test.go
+++ b/accounts/keystore/keystore_test.go
@@ -304,7 +304,6 @@ func TestWalletNotifications(t *testing.T) {
 			}
 		}
 	}()
-
 	// Randomly add and remove accounts.
 	var (
 		live       = make(map[common.Address]accounts.Account)
@@ -333,7 +332,8 @@ func TestWalletNotifications(t *testing.T) {
 			wantEvents = append(wantEvents, walletEvent{accounts.WalletEvent{Kind: accounts.WalletDropped}, account})
 		}
 	}
-
+	// Wait for the event collector to get scheduled.
+	time.Sleep(10 * time.Millisecond)
 	// Shut down the event collector and check events.
 	sub.Unsubscribe()
 	<-updates


### PR DESCRIPTION
The TestWalletNotifications test sporadically fails on travis.
This is because we shutdown the event collection before all events are received.
~~Adding a small timeout (10 milliseconds) allows the collector to be scheduled
and to consume all pending events before we shut it down.~~

ex: https://travis-ci.org/github/ethereum/go-ethereum/jobs/733709675