### PR TITLE
miner: set etherbase even if mining isn't possible at the moment

### DIFF
--- a/miner/miner.go
+++ b/miner/miner.go
@@ -128,8 +128,8 @@ func (miner *Miner) update() {
 				events.Unsubscribe()
 			}
 		case addr := <-miner.startCh:
+			miner.SetEtherbase(addr)
 			if canStart {
-				miner.SetEtherbase(addr)
 				miner.worker.start()
 			}
 			shouldStart = true

--- a/miner/miner_test.go
+++ b/miner/miner_test.go
@@ -192,6 +192,28 @@ func TestCloseMiner(t *testing.T) {
 	waitForMiningState(t, miner, false)
 }
 
+// TestMinerSetEtherbase checks that etherbase becomes set even if mining isn't
+// possible at the moment
+func TestMinerSetEtherbase(t *testing.T) {
+	miner, mux := createMiner(t)
+	// Start with a 'bad' mining address
+	miner.Start(common.HexToAddress("0xdead"))
+	waitForMiningState(t, miner, true)
+	// Start the downloader
+	mux.Post(downloader.StartEvent{})
+	waitForMiningState(t, miner, false)
+	// Now user tries to configure proper mining address
+	miner.Start(common.HexToAddress("0x1337"))
+	// Stop the downloader and wait for the update loop to run
+	mux.Post(downloader.DoneEvent{})
+
+	waitForMiningState(t, miner, true)
+	// The miner should now be using the good address
+	if got, exp := miner.coinbase, common.HexToAddress("0x1337"); got != exp {
+		t.Fatalf("Wrong coinbase, got %x expected %x", got, exp)
+	}
+}
+
 // waitForMiningState waits until either
 // * the desired mining state was reached
 // * a timeout was reached which fails the test


### PR DESCRIPTION
When restarting a goerli signer, we got this: 
```
 Oct 14 10:45:54 goerli-aws-eu-west-2-001 geth ERROR[10-14|08:45:54.089] Refusing to mine without etherbase 
```
I think the underlying cause is that the miner had a regression: in case mining wasn't possible (due to sync), the etherbase was not set. This PR fixes it and adds a testcase. 
This could have more severe consequences: if the etherbase is initially set to something, and changed to something else _while sync is in progress_ , the latter 'set' is ignored, and the original is kept. 