### PR TITLE
Fix potential nil pointer error from blockNrOrHash in AccountRange

### DIFF
--- a/eth/api.go
+++ b/eth/api.go
@@ -389,6 +389,8 @@ func (api *PublicDebugAPI) AccountRange(blockNrOrHash rpc.BlockNumberOrHash, sta
 		if err != nil {
 			return state.IteratorDump{}, err
 		}
+	} else {
+		return state.IteratorDump{}, fmt.Errorf("must specify either block number or block hash")
 	}
 
 	if maxResults > AccountRangeMaxResults || maxResults <= 0 {

--- a/eth/api.go
+++ b/eth/api.go
@@ -390,7 +390,7 @@ func (api *PublicDebugAPI) AccountRange(blockNrOrHash rpc.BlockNumberOrHash, sta
 			return state.IteratorDump{}, err
 		}
 	} else {
-		return state.IteratorDump{}, fmt.Errorf("must specify either block number or block hash")
+		return state.IteratorDump{}, errors.New("either block number or block hash must be specified")
 	}
 
 	if maxResults > AccountRangeMaxResults || maxResults <= 0 {


### PR DESCRIPTION
If neither block number nor hash is specified by the call to AccountRange, then both the if and else if branches will be skipped over, such that stateDb will be nil when IteratorDump is called in the return statement.

It appears that the unmarshaller for BlockNumberOrHash does not guarantee that one of the two must be valid.