### PR TITLE
core/vm: set stack capacity to 1024 by default

### DIFF
--- a/core/vm/stack.go
+++ b/core/vm/stack.go
@@ -25,7 +25,7 @@ import (
 
 var stackPool = sync.Pool{
 	New: func() interface{} {
-		return &Stack{data: make([]uint256.Int, 0, 16)}
+		return &Stack{data: make([]uint256.Int, 0, 1024)}
 	},
 }
 

--- a/core/vm/stack_test.go
+++ b/core/vm/stack_test.go
@@ -1,0 +1,45 @@
+package vm
+
+import (
+	"testing"
+	"github.com/holiman/uint256"
+	"github.com/ethereum/go-ethereum/params"
+)
+
+func BenchmarkStackPush(b *testing.B) {
+	var (
+		env            = NewEVM(Context{}, nil, params.TestChainConfig, Config{})
+		stack          = newstack()
+		evmInterpreter = NewEVMInterpreter(env, env.vmConfig)
+	)
+
+	env.interpreter = evmInterpreter
+	value := new(uint256.Int).SetUint64(0x1337)
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		stack.push(value)
+	}
+}
+
+func BenchmarkStackPop(b *testing.B) {
+	var (
+		env            = NewEVM(Context{}, nil, params.TestChainConfig, Config{})
+		stack          = newstack()
+		evmInterpreter = NewEVMInterpreter(env, env.vmConfig)
+	)
+
+	env.interpreter = evmInterpreter
+	value := new(uint256.Int).SetUint64(0x1337)
+
+	// TODO how to make sure that b.N is limited to 1024?  why does this crash when the stack is massive?
+
+	for i := 0; i < b.N; i++ {
+		stack.push(value)
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		stack.pop()
+	}
+}

--- a/core/vm/stack_test.go
+++ b/core/vm/stack_test.go
@@ -32,8 +32,6 @@ func BenchmarkStackPop(b *testing.B) {
 	env.interpreter = evmInterpreter
 	value := new(uint256.Int).SetUint64(0x1337)
 
-	// TODO how to make sure that b.N is limited to 1024?  why does this crash when the stack is massive?
-
 	for i := 0; i < b.N; i++ {
 		stack.push(value)
 	}


### PR DESCRIPTION
Also adds benchmarks for push/pop.

benchmarks:

Current default stack capacity:
```
> go test -bench=Stack -benchtime=1024x
goos: linux
goarch: amd64
pkg: github.com/ethereum/go-ethereum/core/vm
BenchmarkStackPush-4   	    1024	        10.7 ns/op
BenchmarkStackPop-4    	    1024	         1.28 ns/op
PASS
ok  	github.com/ethereum/go-ethereum/core/vm	1.861s
```

with default stack capacity of 1024:
```
> go test -bench=Stack -benchtime=1024x
goos: linux
goarch: amd64
pkg: github.com/ethereum/go-ethereum/core/vm
BenchmarkStackPush-4   	    1024	         3.50 ns/op
BenchmarkStackPop-4    	    1024	         1.20 ns/op
PASS
ok  	github.com/ethereum/go-ethereum/core/vm	1.890s
```