### PR TITLE
accounts/usbwallet: fix ledger version check

### DIFF
--- a/accounts/usbwallet/ledger.go
+++ b/accounts/usbwallet/ledger.go
@@ -162,7 +162,7 @@ func (w *ledgerDriver) SignTx(path accounts.DerivationPath, tx *types.Transactio
 		return common.Address{}, nil, accounts.ErrWalletClosed
 	}
 	// Ensure the wallet is capable of signing the given transaction
-	if chainID != nil && w.version[0] <= 1 && w.version[2] <= 2 {
+	if chainID != nil && w.version[0] <= 1 && w.version[1] <= 0 && w.version[2] <= 2 {
 		//lint:ignore ST1005 brand name displayed on the console
 		return common.Address{}, nil, fmt.Errorf("Ledger v%d.%d.%d doesn't support signing this transaction, please update to v1.0.3 at least", w.version[0], w.version[1], w.version[2])
 	}


### PR DESCRIPTION
After upgrading the Ledger Ethereum app to v1.4.0 the other day, I was no longer able to sign transactions with my Ledger using clef - the error message returned by clef was:
```
Ledger v1.4.0 doesn't support signing this transaction, please update to v1.0.3 at least
```
The version check logic did not take into account the second digit (i.e. the '4' in v1.4.0) - this one line patch corrects this.