### PR TITLE
crypto/secp256k1: add workaround for go mod vendor

### DIFF
--- a/crypto/secp256k1/dummy.go
+++ b/crypto/secp256k1/dummy.go
@@ -1,0 +1,13 @@
+// +build dummy
+
+// Package c contains only a C file.
+//
+// This Go file is part of a workaround for `go mod vendor`.
+// Please see the file dummy.go at the root of the module for more information.
+package secp256k1
+
+import (
+	_ "github.com/ethereum/go-ethereum/crypto/secp256k1/libsecp256k1/include"
+	_ "github.com/ethereum/go-ethereum/crypto/secp256k1/libsecp256k1/src"
+	_ "github.com/ethereum/go-ethereum/crypto/secp256k1/libsecp256k1/src/modules/recovery"
+)

--- a/crypto/secp256k1/dummy.go
+++ b/crypto/secp256k1/dummy.go
@@ -1,9 +1,16 @@
 // +build dummy
 
-// Package c contains only a C file.
+// This file is part of a workaround for `go mod vendor` which won't vendor
+// C files if there's no Go file in the same directory.
+// This would prevent the crypto/secp256k1/libsecp256k1/include/secp256k1.h file to be vendored.
 //
-// This Go file is part of a workaround for `go mod vendor`.
-// Please see the file dummy.go at the root of the module for more information.
+// This Go file imports the c directory where there is another dummy.go file which
+// is the second part of this workaround.
+//
+// These two files combined make it so `go mod vendor` behaves correctly.
+//
+// See this issue for reference: https://github.com/golang/go/issues/26366
+
 package secp256k1
 
 import (

--- a/crypto/secp256k1/libsecp256k1/contrib/dummy.go
+++ b/crypto/secp256k1/libsecp256k1/contrib/dummy.go
@@ -1,0 +1,7 @@
+// +build dummy
+
+// Package c contains only a C file.
+//
+// This Go file is part of a workaround for `go mod vendor`.
+// Please see the file dummy.go at the root of the module for more information.
+package contrib

--- a/crypto/secp256k1/libsecp256k1/contrib/dummy.go
+++ b/crypto/secp256k1/libsecp256k1/contrib/dummy.go
@@ -3,5 +3,5 @@
 // Package c contains only a C file.
 //
 // This Go file is part of a workaround for `go mod vendor`.
-// Please see the file dummy.go at the root of the module for more information.
+// Please see the file crypto/secp256k1/dummy.go for more information.
 package contrib

--- a/crypto/secp256k1/libsecp256k1/dummy.go
+++ b/crypto/secp256k1/libsecp256k1/dummy.go
@@ -1,0 +1,7 @@
+// +build dummy
+
+// Package c contains only a C file.
+//
+// This Go file is part of a workaround for `go mod vendor`.
+// Please see the file dummy.go at the root of the module for more information.
+package libsecp256k1

--- a/crypto/secp256k1/libsecp256k1/dummy.go
+++ b/crypto/secp256k1/libsecp256k1/dummy.go
@@ -3,5 +3,5 @@
 // Package c contains only a C file.
 //
 // This Go file is part of a workaround for `go mod vendor`.
-// Please see the file dummy.go at the root of the module for more information.
+// Please see the file crypto/secp256k1/dummy.go for more information.
 package libsecp256k1

--- a/crypto/secp256k1/libsecp256k1/include/dummy.go
+++ b/crypto/secp256k1/libsecp256k1/include/dummy.go
@@ -1,0 +1,7 @@
+// +build dummy
+
+// Package c contains only a C file.
+//
+// This Go file is part of a workaround for `go mod vendor`.
+// Please see the file dummy.go at the root of the module for more information.
+package include

--- a/crypto/secp256k1/libsecp256k1/include/dummy.go
+++ b/crypto/secp256k1/libsecp256k1/include/dummy.go
@@ -3,5 +3,5 @@
 // Package c contains only a C file.
 //
 // This Go file is part of a workaround for `go mod vendor`.
-// Please see the file dummy.go at the root of the module for more information.
+// Please see the file crypto/secp256k1/dummy.go for more information.
 package include

--- a/crypto/secp256k1/libsecp256k1/src/dummy.go
+++ b/crypto/secp256k1/libsecp256k1/src/dummy.go
@@ -1,0 +1,7 @@
+// +build dummy
+
+// Package c contains only a C file.
+//
+// This Go file is part of a workaround for `go mod vendor`.
+// Please see the file dummy.go at the root of the module for more information.
+package src

--- a/crypto/secp256k1/libsecp256k1/src/dummy.go
+++ b/crypto/secp256k1/libsecp256k1/src/dummy.go
@@ -3,5 +3,5 @@
 // Package c contains only a C file.
 //
 // This Go file is part of a workaround for `go mod vendor`.
-// Please see the file dummy.go at the root of the module for more information.
+// Please see the file crypto/secp256k1/dummy.go for more information.
 package src

--- a/crypto/secp256k1/libsecp256k1/src/modules/dummy.go
+++ b/crypto/secp256k1/libsecp256k1/src/modules/dummy.go
@@ -1,0 +1,7 @@
+// +build dummy
+
+// Package c contains only a C file.
+//
+// This Go file is part of a workaround for `go mod vendor`.
+// Please see the file dummy.go at the root of the module for more information.
+package module

--- a/crypto/secp256k1/libsecp256k1/src/modules/dummy.go
+++ b/crypto/secp256k1/libsecp256k1/src/modules/dummy.go
@@ -3,5 +3,5 @@
 // Package c contains only a C file.
 //
 // This Go file is part of a workaround for `go mod vendor`.
-// Please see the file dummy.go at the root of the module for more information.
+// Please see the file crypto/secp256k1/dummy.go for more information.
 package module

--- a/crypto/secp256k1/libsecp256k1/src/modules/ecdh/dummy.go
+++ b/crypto/secp256k1/libsecp256k1/src/modules/ecdh/dummy.go
@@ -1,0 +1,7 @@
+// +build dummy
+
+// Package c contains only a C file.
+//
+// This Go file is part of a workaround for `go mod vendor`.
+// Please see the file dummy.go at the root of the module for more information.
+package ecdh

--- a/crypto/secp256k1/libsecp256k1/src/modules/ecdh/dummy.go
+++ b/crypto/secp256k1/libsecp256k1/src/modules/ecdh/dummy.go
@@ -3,5 +3,5 @@
 // Package c contains only a C file.
 //
 // This Go file is part of a workaround for `go mod vendor`.
-// Please see the file dummy.go at the root of the module for more information.
+// Please see the file crypto/secp256k1/dummy.go for more information.
 package ecdh

--- a/crypto/secp256k1/libsecp256k1/src/modules/recovery/dummy.go
+++ b/crypto/secp256k1/libsecp256k1/src/modules/recovery/dummy.go
@@ -1,0 +1,7 @@
+// +build dummy
+
+// Package c contains only a C file.
+//
+// This Go file is part of a workaround for `go mod vendor`.
+// Please see the file dummy.go at the root of the module for more information.
+package recovery

--- a/crypto/secp256k1/libsecp256k1/src/modules/recovery/dummy.go
+++ b/crypto/secp256k1/libsecp256k1/src/modules/recovery/dummy.go
@@ -3,5 +3,5 @@
 // Package c contains only a C file.
 //
 // This Go file is part of a workaround for `go mod vendor`.
-// Please see the file dummy.go at the root of the module for more information.
+// Please see the file crypto/secp256k1/dummy.go for more information.
 package recovery


### PR DESCRIPTION
Go won't vendor C files if there are no Go files present in the directory. Workaround is to add dummy Go files.

Approach from: crawshaw/sqlite#88

Fixes: ethereum/go-ethereum#20232
