### PR TITLE
bug: fix dir path in geth attach for yolov2 network

### DIFF
--- a/cmd/geth/consolecmd.go
+++ b/cmd/geth/consolecmd.go
@@ -137,7 +137,7 @@ func remoteConsole(ctx *cli.Context) error {
 			} else if ctx.GlobalBool(utils.GoerliFlag.Name) {
 				path = filepath.Join(path, "goerli")
 			} else if ctx.GlobalBool(utils.YoloV2Flag.Name) {
-				path = filepath.Join(path, "yolo-v1")
+				path = filepath.Join(path, "yolo-v2")
 			}
 		}
 		endpoint = fmt.Sprintf("%s/geth.ipc", path)


### PR DESCRIPTION
Closes #21748 by correcting the datadir path used in the `geth attach` command with the `--yolov2` flag 