### PR TITLE
accounts, signer: fix Ledger Live account derivation path (clef)

### DIFF
--- a/accounts/hd.go
+++ b/accounts/hd.go
@@ -150,3 +150,31 @@ func (path *DerivationPath) UnmarshalJSON(b []byte) error {
 	*path, err = ParseDerivationPath(dp)
 	return err
 }
+
+// DefaultIterator creates a BIP-32 path iterator, which progresses by increasing the last component:
+// i.e. m/44'/60'/0'/0/0, m/44'/60'/0'/0/1, m/44'/60'/0'/0/2, ... m/44'/60'/0'/0/N.
+func DefaultIterator(base DerivationPath) func() DerivationPath {
+	path := make(DerivationPath, len(base))
+	copy(path[:], base[:])
+	// Set it back by one, so the first call gives the first result
+	path[len(path)-1]--
+	return func() DerivationPath {
+		path[len(path)-1]++
+		return path
+	}
+}
+
+// LedgerLiveIterator creates a bip44 path iterator for Ledger Live.
+// Ledger Live increments the third component rather than the fifth component
+// i.e. m/44'/60'/0'/0/0, m/44'/60'/1'/0/0, m/44'/60'/2'/0/0, ... m/44'/60'/N'/0/0.
+func LedgerLiveIterator(base DerivationPath) func() DerivationPath {
+	path := make(DerivationPath, len(base))
+	copy(path[:], base[:])
+	// Set it back by one, so the first call gives the first result
+	path[2]--
+	return func() DerivationPath {
+		// ledgerLivePathIterator iterates on the third component
+		path[2]++
+		return path
+	}
+}

--- a/accounts/hd_test.go
+++ b/accounts/hd_test.go
@@ -17,6 +17,7 @@
 package accounts
 
 import (
+	"fmt"
 	"reflect"
 	"testing"
 )
@@ -76,4 +77,42 @@ func TestHDPathParsing(t *testing.T) {
 			t.Errorf("test %d: nil path and error: %v", i, err)
 		}
 	}
+}
+
+func testDerive(t *testing.T, next func() DerivationPath, expected []string) {
+	t.Helper()
+	for i, want := range expected {
+		if have := next(); fmt.Sprintf("%v", have) != want {
+			t.Errorf("step %d, have %v, want %v", i, have, want)
+		}
+	}
+}
+
+func TestHdPathIteration(t *testing.T) {
+	testDerive(t, DefaultIterator(DefaultBaseDerivationPath),
+		[]string{
+			"m/44'/60'/0'/0/0", "m/44'/60'/0'/0/1",
+			"m/44'/60'/0'/0/2", "m/44'/60'/0'/0/3",
+			"m/44'/60'/0'/0/4", "m/44'/60'/0'/0/5",
+			"m/44'/60'/0'/0/6", "m/44'/60'/0'/0/7",
+			"m/44'/60'/0'/0/8", "m/44'/60'/0'/0/9",
+		})
+
+	testDerive(t, DefaultIterator(LegacyLedgerBaseDerivationPath),
+		[]string{
+			"m/44'/60'/0'/0", "m/44'/60'/0'/1",
+			"m/44'/60'/0'/2", "m/44'/60'/0'/3",
+			"m/44'/60'/0'/4", "m/44'/60'/0'/5",
+			"m/44'/60'/0'/6", "m/44'/60'/0'/7",
+			"m/44'/60'/0'/8", "m/44'/60'/0'/9",
+		})
+
+	testDerive(t, LedgerLiveIterator(DefaultBaseDerivationPath),
+		[]string{
+			"m/44'/60'/0'/0/0", "m/44'/60'/1'/0/0",
+			"m/44'/60'/2'/0/0", "m/44'/60'/3'/0/0",
+			"m/44'/60'/4'/0/0", "m/44'/60'/5'/0/0",
+			"m/44'/60'/6'/0/0", "m/44'/60'/7'/0/0",
+			"m/44'/60'/8'/0/0", "m/44'/60'/9'/0/0",
+		})
 }

--- a/signer/core/api.go
+++ b/signer/core/api.go
@@ -322,74 +322,65 @@ func (api *SignerAPI) openTrezor(url accounts.URL) {
 
 // startUSBListener starts a listener for USB events, for hardware wallet interaction
 func (api *SignerAPI) startUSBListener() {
-	events := make(chan accounts.WalletEvent, 16)
+	eventCh := make(chan accounts.WalletEvent, 16)
 	am := api.am
-	am.Subscribe(events)
-	go func() {
+	am.Subscribe(eventCh)
+	// Open any wallets already attached
+	for _, wallet := range am.Wallets() {
+		if err := wallet.Open(""); err != nil {
+			log.Warn("Failed to open wallet", "url", wallet.URL(), "err", err)
+			if err == usbwallet.ErrTrezorPINNeeded {
+				go api.openTrezor(wallet.URL())
+			}
+		}
+	}
+	go api.derivationLoop(eventCh)
+}
 
-		// Open any wallets already attached
-		for _, wallet := range am.Wallets() {
-			if err := wallet.Open(""); err != nil {
-				log.Warn("Failed to open wallet", "url", wallet.URL(), "err", err)
+// derivationLoop listens for wallet events
+func (api *SignerAPI) derivationLoop(events chan accounts.WalletEvent) {
+	// Listen for wallet event till termination
+	for event := range events {
+		switch event.Kind {
+		case accounts.WalletArrived:
+			if err := event.Wallet.Open(""); err != nil {
+				log.Warn("New wallet appeared, failed to open", "url", event.Wallet.URL(), "err", err)
 				if err == usbwallet.ErrTrezorPINNeeded {
-					go api.openTrezor(wallet.URL())
+					go api.openTrezor(event.Wallet.URL())
 				}
 			}
-		}
-		// Listen for wallet event till termination
-		for event := range events {
-			switch event.Kind {
-			case accounts.WalletArrived:
-				if err := event.Wallet.Open(""); err != nil {
-					log.Warn("New wallet appeared, failed to open", "url", event.Wallet.URL(), "err", err)
-					if err == usbwallet.ErrTrezorPINNeeded {
-						go api.openTrezor(event.Wallet.URL())
+		case accounts.WalletOpened:
+			status, _ := event.Wallet.Status()
+			log.Info("New wallet appeared", "url", event.Wallet.URL(), "status", status)
+			var derive = func(limit int, next func() accounts.DerivationPath) {
+				// Derive first N accounts, hardcoded for now
+				for i := 0; i < limit; i++ {
+					path := next()
+					if acc, err := event.Wallet.Derive(path, true); err != nil {
+						log.Warn("Account derivation failed", "error", err)
+					} else {
+						log.Info("Derived account", "address", acc.Address, "path", path)
 					}
 				}
-			case accounts.WalletOpened:
-				status, _ := event.Wallet.Status()
-				log.Info("New wallet appeared", "url", event.Wallet.URL(), "status", status)
-				var derive = func(numToDerive int, base accounts.DerivationPath, incrOffset int, skipBase bool) {
-					// Derive first N accounts, hardcoded for now
-					if incrOffset < -len(base) || incrOffset >= len(base) {
-						log.Warn("Account derivation failed, increment level out of range", "base", base, "baseLen", len(base), "incrOffset", incrOffset)
-						return
-					}
-					var nextPath = make(accounts.DerivationPath, len(base))
-					copy(nextPath[:], base[:])
-					if incrOffset < 0 {
-						incrOffset += len(nextPath)
-					}
-					if skipBase {
-						numToDerive--
-						nextPath[incrOffset]++
-					}
-					for i := 0; i < numToDerive; i++ {
-						acc, err := event.Wallet.Derive(nextPath, true)
-						if err != nil {
-							log.Warn("Account derivation failed", "error", err)
-						} else {
-							log.Info("Derived account", "address", acc.Address, "path", nextPath)
-						}
-						nextPath[incrOffset]++
-					}
-				}
-				log.Info("Deriving default paths")
-				derive(numberOfAccountsToDerive, accounts.DefaultBaseDerivationPath, -1, false)
-				if event.Wallet.URL().Scheme == "ledger" {
-					log.Info("Deriving ledger legacy paths")
-					derive(numberOfAccountsToDerive, accounts.LegacyLedgerBaseDerivationPath, -1, false)
-
-					// note we skip the first account here as it was already included above
-					log.Info("Deriving ledger live paths")
-					derive(numberOfAccountsToDerive, accounts.DefaultBaseDerivationPath, 2, true)
-				}
-			case accounts.WalletDropped:
-				log.Info("Old wallet dropped", "url", event.Wallet.URL())
-				event.Wallet.Close()
 			}
+			log.Info("Deriving default paths")
+			derive(numberOfAccountsToDerive, accounts.DefaultIterator(accounts.DefaultBaseDerivationPath))
+			if event.Wallet.URL().Scheme == "ledger" {
+				log.Info("Deriving ledger legacy paths")
+				derive(numberOfAccountsToDerive, accounts.DefaultIterator(accounts.LegacyLedgerBaseDerivationPath))
+				log.Info("Deriving ledger live paths")
+				// For ledger live, since it's based off the same (DefaultBaseDerivationPath)
+				// as one we've already used, we need to step it forward one step to avoid
+				// hitting the same path again
+				nextFn := accounts.LedgerLiveIterator(accounts.DefaultBaseDerivationPath)
+				nextFn()
+				derive(numberOfAccountsToDerive, nextFn)
+			}
+		case accounts.WalletDropped:
+			log.Info("Old wallet dropped", "url", event.Wallet.URL())
+			event.Wallet.Close()
 		}
-	}()
+	}
 }
 
 // List returns the set of wallet this signer manages. Each wallet can contain


### PR DESCRIPTION
Existing code in clef enumerated Ledger Live accounts by starting with m/60' are enumerated by starting at `m/44'/60'/0'/0/0` and then incrementing the last component to `m/44'/60'/0'/0/1`, `m/44'/60'/0'/0/2`, ... `m/44'/60'/0'/0/N`.

However this failed to find any account after the first one as Ledger Live increments the third component rather than the fifth component i.e. `m/44'/60'/0'/0/0`, `m/44'/60'/1'/0/0`, `m/44'/60'/2'/0/0`, ... `m/44'/60'/N'/0/0`.

This patch corrects Ledger Live account derivation but leaves the existing derivation for Ledger Legacy and non-Ledger devices.

Additionally, this patch increases enumeration depth to ten accounts each for Ledger Legacy and Ledger Live - in my case, I currently use six accounts on Ledger Live and the existing limit of five each for legacy and live failed to find all my accounts.

For the signer clef which has no access to the blockchain, I think it would be reasonable to provide a command line option or configuration parameter to specify legacy vs. live account path derviation and number of accounts to iterate, though this would be a larger functional enhancement.

I have also not looked at account derivation code in geth outside of clef which may or may not have a similar issue with Ledger Live derivation paths.

Note this relates to issue #21592 insofar as I have been trying to use clef with a Ledger Nano and nucypher.