### PR TITLE
Add missing Capture functions to CallCode, DelegateCall, StaticCall

### DIFF
--- a/core/vm/evm.go
+++ b/core/vm/evm.go
@@ -301,7 +301,7 @@ func (evm *EVM) CallCode(caller ContractRef, addr common.Address, input []byte, 
 	var snapshot = evm.StateDB.Snapshot()
 
 	// Capture the tracer start/end events in debug mode
-	if evm.vmConfig.Debug && evm.depth == 0 {
+	if evm.vmConfig.Debug  {
 		evm.vmConfig.Tracer.CaptureStart(caller.Address(), addr, false, input, gas, value)
 		defer func(startGas uint64, startTime time.Time) { // Lazy evaluation of the parameters
 			evm.vmConfig.Tracer.CaptureEnd(ret, startGas-gas, time.Since(startTime), err)
@@ -345,7 +345,7 @@ func (evm *EVM) DelegateCall(caller ContractRef, addr common.Address, input []by
 	var snapshot = evm.StateDB.Snapshot()
 
 	// Capture the tracer start/end events in debug mode
-	if evm.vmConfig.Debug && evm.depth == 0 {
+	if evm.vmConfig.Debug {
 		evm.vmConfig.Tracer.CaptureStart(caller.Address(), addr, false, input, gas, big.NewInt(0))
 		defer func(startGas uint64, startTime time.Time) { // Lazy evaluation of the parameters
 			evm.vmConfig.Tracer.CaptureEnd(ret, startGas-gas, time.Since(startTime), err)
@@ -398,7 +398,7 @@ func (evm *EVM) StaticCall(caller ContractRef, addr common.Address, input []byte
 	evm.StateDB.AddBalance(addr, big0)
 
 	// Capture the tracer start/end events in debug mode
-	if evm.vmConfig.Debug && evm.depth == 0 {
+	if evm.vmConfig.Debug {
 		evm.vmConfig.Tracer.CaptureStart(caller.Address(), addr, false, input, gas, big.NewInt(0))
 		defer func(startGas uint64, startTime time.Time) { // Lazy evaluation of the parameters
 			evm.vmConfig.Tracer.CaptureEnd(ret, startGas-gas, time.Since(startTime), err)


### PR DESCRIPTION
This is a port to Geth of a fix I'm preparing for TurboGeth, in case it's of interest here too.

It works as expected in TurboGeth, but I haven't run it in Geth.

Also, lines 349 and 402 set value=0. Let me know if it should be something different.