### PR TITLE
internal/ethapi: add defensive check

### DIFF
--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -310,6 +310,9 @@ func (s *PrivateAccountAPI) ImportRawKey(privkey string, password string) (commo
 		return common.Address{}, err
 	}
 	acc, err := ks.ImportECDSA(key, password)
+	if err != nil {
+		return common.Address{}, nil
+	}
 	return acc.Address, err
 }
 


### PR DESCRIPTION
Adding a defensive check to prevent panic. Noted that `ks.ImportECDSA()` doesn't seem return a nil account at this point.