### PR TITLE
cmd/devp2p/internal/ethtest: add 'large announcement' tests

### DIFF
--- a/cmd/devp2p/internal/ethtest/large.go
+++ b/cmd/devp2p/internal/ethtest/large.go
@@ -45,7 +45,7 @@ func largeBuffer(megabytes int) []byte {
 func largeString(megabytes int) string {
 	buf := make([]byte, megabytes*1024*1024)
 	rand.Read(buf)
-	return string(hexutil.Encode(buf))
+	return hexutil.Encode(buf)
 }
 
 func largeBlock() *types.Block {

--- a/cmd/devp2p/internal/ethtest/large.go
+++ b/cmd/devp2p/internal/ethtest/large.go
@@ -1,0 +1,80 @@
+// Copyright 2020 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+package ethtest
+
+import (
+	"crypto/rand"
+	"math/big"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/ethereum/go-ethereum/core/types"
+)
+
+// largeNumber returns a very large big.Int.
+func largeNumber(megabytes int) *big.Int {
+	buf := make([]byte, megabytes*1024*1024)
+	rand.Read(buf)
+	bigint := new(big.Int)
+	bigint.SetBytes(buf)
+	return bigint
+}
+
+// largeBuffer returns a very large buffer.
+func largeBuffer(megabytes int) []byte {
+	buf := make([]byte, megabytes*1024*1024)
+	rand.Read(buf)
+	return buf
+}
+
+// largeString returns a very large string.
+func largeString(megabytes int) string {
+	buf := make([]byte, megabytes*1024*1024)
+	rand.Read(buf)
+	return string(hexutil.Encode(buf))
+}
+
+func largeBlock() *types.Block {
+	return types.NewBlockWithHeader(largeHeader())
+}
+
+// Returns a random hash
+func randHash() common.Hash {
+	var h common.Hash
+	rand.Read(h[:])
+	return h
+}
+
+func largeHeader() *types.Header {
+	return &types.Header{
+		MixDigest:   randHash(),
+		ReceiptHash: randHash(),
+		TxHash:      randHash(),
+		Nonce:       types.BlockNonce{},
+		Extra:       []byte{},
+		Bloom:       types.Bloom{},
+		GasUsed:     0,
+		Coinbase:    common.Address{},
+		GasLimit:    0,
+		UncleHash:   randHash(),
+		Time:        1337,
+		ParentHash:  randHash(),
+		Root:        randHash(),
+		Number:      largeNumber(2),
+		Difficulty:  largeNumber(2),
+	}
+}

--- a/cmd/devp2p/internal/ethtest/suite.go
+++ b/cmd/devp2p/internal/ethtest/suite.go
@@ -309,10 +309,10 @@ func (s *Suite) TestLargeAnnounce(t *utesting.T) {
 	}
 }
 
-func (s *Suite) testDisconnect(t *utesting.T, conn *Conn, msg Message) {
+func (s *Suite) testDisconnect(t *utesting.T, conn *Conn, msg Message) error {
 	// Announce the block.
 	if err := conn.Write(msg); err != nil {
-		t.Fatalf("could not write to connection: %v", err)
+		return fmt.Errorf("could not write to connection: %v", err)
 	}
 	time.Sleep(100 * time.Millisecond)
 	// check that the peer disconnected
@@ -320,8 +320,10 @@ func (s *Suite) testDisconnect(t *utesting.T, conn *Conn, msg Message) {
 	switch msg := conn.ReadAndServe(s.chain, timeout).(type) {
 	case *Disconnect:
 		return
+	case *Error:
+		return
 	default:
-		t.Fatalf("unexpected: %s", pretty.Sdump(msg))
+		return fmt.Errorf("unexpected: %s", pretty.Sdump(msg))
 	}
 }
 

--- a/cmd/devp2p/internal/ethtest/suite.go
+++ b/cmd/devp2p/internal/ethtest/suite.go
@@ -323,9 +323,8 @@ func (s *Suite) testAnnounce(t *utesting.T, sendConn, receiveConn *Conn, blockAn
 }
 
 func (s *Suite) waitAnnounce(t *utesting.T, conn *Conn, blockAnnouncement *NewBlock) {
-	// Wait for the announcement.
 	timeout := 20 * time.Second
-	switch msg := receiveConn.ReadAndServe(s.chain, timeout).(type) {
+	switch msg := conn.ReadAndServe(s.chain, timeout).(type) {
 	case *NewBlock:
 		t.Logf("received NewBlock message: %s", pretty.Sdump(msg.Block))
 		assert.Equal(t,

--- a/cmd/devp2p/internal/ethtest/types.go
+++ b/cmd/devp2p/internal/ethtest/types.go
@@ -304,7 +304,7 @@ func (c *Conn) negotiateEthProtocol(caps []p2p.Cap) {
 
 // statusExchange performs a `Status` message exchange with the given
 // node.
-func (c *Conn) statusExchange(t *utesting.T, chain *Chain) Message {
+func (c *Conn) statusExchange(t *utesting.T, chain *Chain, status *Status) Message {
 	defer c.SetDeadline(time.Time{})
 	c.SetDeadline(time.Now().Add(20 * time.Second))
 
@@ -338,16 +338,19 @@ loop:
 	if c.ethProtocolVersion == 0 {
 		t.Fatalf("eth protocol version must be set in Conn")
 	}
-	// write status message to client
-	status := Status{
-		ProtocolVersion: uint32(c.ethProtocolVersion),
-		NetworkID:       chain.chainConfig.ChainID.Uint64(),
-		TD:              chain.TD(chain.Len()),
-		Head:            chain.blocks[chain.Len()-1].Hash(),
-		Genesis:         chain.blocks[0].Hash(),
-		ForkID:          chain.ForkID(),
+	if status == nil {
+		// write status message to client
+		status = &Status{
+			ProtocolVersion: uint32(c.ethProtocolVersion),
+			NetworkID:       chain.chainConfig.ChainID.Uint64(),
+			TD:              chain.TD(chain.Len()),
+			Head:            chain.blocks[chain.Len()-1].Hash(),
+			Genesis:         chain.blocks[0].Hash(),
+			ForkID:          chain.ForkID(),
+		}
 	}
-	if err := c.Write(status); err != nil {
+
+	if err := c.Write(*status); err != nil {
 		t.Fatalf("could not write to connection: %v", err)
 	}
 
@@ -382,7 +385,7 @@ func (c *Conn) waitForBlock(block *types.Block) error {
 func (c *Conn) waitForMessage(msg Message) error {
 	defer c.SetReadDeadline(time.Time{})
 
-	timeout := 20 * time.Second
+	timeout := 10 * time.Second
 	deadline := time.Now().Add(timeout)
 	c.SetReadDeadline(deadline)
 	t := time.NewTimer(timeout)

--- a/cmd/devp2p/internal/ethtest/types.go
+++ b/cmd/devp2p/internal/ethtest/types.go
@@ -377,3 +377,25 @@ func (c *Conn) waitForBlock(block *types.Block) error {
 		}
 	}
 }
+
+// waitForMessage waits for a certain message type.
+func (c *Conn) waitForMessage(msg Message) error {
+	defer c.SetReadDeadline(time.Time{})
+
+	timeout := 20 * time.Second
+	deadline := time.Now().Add(timeout)
+	c.SetReadDeadline(deadline)
+	t := time.NewTimer(timeout)
+	for {
+		msg := c.Read()
+		if msg.Code() == msg.Code() {
+			return nil
+		}
+		select {
+		case <-t.C:
+			return fmt.Errorf("no message received within timeout")
+		default:
+			time.Sleep(100 * time.Millisecond)
+		}
+	}
+}

--- a/cmd/devp2p/internal/ethtest/types.go
+++ b/cmd/devp2p/internal/ethtest/types.go
@@ -380,25 +380,3 @@ func (c *Conn) waitForBlock(block *types.Block) error {
 		}
 	}
 }
-
-// waitForMessage waits for a certain message type.
-func (c *Conn) waitForMessage(msg Message) error {
-	defer c.SetReadDeadline(time.Time{})
-
-	timeout := 10 * time.Second
-	deadline := time.Now().Add(timeout)
-	c.SetReadDeadline(deadline)
-	t := time.NewTimer(timeout)
-	for {
-		msg := c.Read()
-		if msg.Code() == msg.Code() {
-			return nil
-		}
-		select {
-		case <-t.C:
-			return fmt.Errorf("no message received within timeout")
-		default:
-			time.Sleep(100 * time.Millisecond)
-		}
-	}
-}


### PR DESCRIPTION
In these tests we create large announcements (announcements with numbers of ~ 2mb), and send them to the CuT

## To test:
Prepare your geth node:
```
rm -rf build/datadir/
geth --http --http.port 8546 --nodiscover --datadir ./build/datadir init cmd/devp2p/internal/ethtest/testdata/genesis.json
geth --http --http.port 8546 --nodiscover --datadir ./build/datadir import cmd/devp2p/internal/ethtest/testdata/halfchain.rlp.gz
geth --http --http.port 8546 --nodiscover --datadir ./build/datadir --nat=none --networkid 19763 --verbosity 5 
```
Run the tests:
```
./devp2p rlpx eth-test enode://d789f40e3ebb0d7f80f52ef1c6a81c2b773c8b163d982ec4216041843046b0316f9c25c374be4703db7c17660601784cc5e4fb7c6f5b29ded81ff2ec651486fa@127.0.0.1:30303 internal/ethtest/testdata/fullchain.rlp.gz internal/ethtest/testdata/genesis.json
```