### PR TITLE
consensus/ethash: use 64bit indexes for the DAG generation

### DIFF
--- a/consensus/ethash/algorithm.go
+++ b/consensus/ethash/algorithm.go
@@ -304,11 +304,11 @@ func generateDataset(dest []uint32, epoch uint64, cache []uint32) {
 			keccak512 := makeHasher(sha3.NewLegacyKeccak512())
 
 			// Calculate the data segment this thread should generate
-			batch := uint64((size + hashBytes*uint64(threads) - 1) / (hashBytes * uint64(threads)))
+			batch := (size + hashBytes*uint64(threads) - 1) / (hashBytes * uint64(threads))
 			first := uint64(id) * batch
 			limit := first + batch
-			if limit > uint64(size/hashBytes) {
-				limit = uint64(size / hashBytes)
+			if limit > size/hashBytes {
+				limit = size / hashBytes
 			}
 			// Calculate the dataset segment
 			percent := uint32(size / hashBytes / 100)

--- a/consensus/ethash/algorithm.go
+++ b/consensus/ethash/algorithm.go
@@ -304,16 +304,16 @@ func generateDataset(dest []uint32, epoch uint64, cache []uint32) {
 			keccak512 := makeHasher(sha3.NewLegacyKeccak512())
 
 			// Calculate the data segment this thread should generate
-			batch := uint32((size + hashBytes*uint64(threads) - 1) / (hashBytes * uint64(threads)))
-			first := uint32(id) * batch
+			batch := uint64((size + hashBytes*uint64(threads) - 1) / (hashBytes * uint64(threads)))
+			first := uint64(id) * batch
 			limit := first + batch
-			if limit > uint32(size/hashBytes) {
-				limit = uint32(size / hashBytes)
+			if limit > uint64(size/hashBytes) {
+				limit = uint64(size / hashBytes)
 			}
 			// Calculate the dataset segment
 			percent := uint32(size / hashBytes / 100)
 			for index := first; index < limit; index++ {
-				item := generateDatasetItem(cache, index, keccak512)
+				item := generateDatasetItem(cache, uint32(index), keccak512)
 				if swapped {
 					swap(item)
 				}


### PR DESCRIPTION
If DAG size is exceeding the maximum 32 bit unsigned value, the DAG generation will produce incorrect results due to an index overflow. This PR converts all index calculations to 64 bit, which implicitly also fixes the addressing overflow.