### PR TITLE
consensus/ethash: fix the percentage progress report

### DIFF
--- a/consensus/ethash/algorithm.go
+++ b/consensus/ethash/algorithm.go
@@ -295,7 +295,7 @@ func generateDataset(dest []uint32, epoch uint64, cache []uint32) {
 	var pend sync.WaitGroup
 	pend.Add(threads)
 
-	var progress uint32
+	var progress uint64
 	for i := 0; i < threads; i++ {
 		go func(id int) {
 			defer pend.Done()
@@ -311,7 +311,7 @@ func generateDataset(dest []uint32, epoch uint64, cache []uint32) {
 				limit = uint32(size / hashBytes)
 			}
 			// Calculate the dataset segment
-			percent := uint32(size / hashBytes / 100)
+			percent := size / hashBytes / 100
 			for index := first; index < limit; index++ {
 				item := generateDatasetItem(cache, index, keccak512)
 				if swapped {
@@ -319,8 +319,8 @@ func generateDataset(dest []uint32, epoch uint64, cache []uint32) {
 				}
 				copy(dataset[index*hashBytes:], item)
 
-				if status := atomic.AddUint32(&progress, 1); status%percent == 0 {
-					logger.Info("Generating DAG in progress", "percentage", uint64(status*100)/(size/hashBytes), "elapsed", common.PrettyDuration(time.Since(start)))
+				if status := atomic.AddUint64(&progress, 1); status%percent == 0 {
+					logger.Info("Generating DAG in progress", "percentage", (status*100)/(size/hashBytes), "elapsed", common.PrettyDuration(time.Since(start)))
 				}
 			}
 		}(i)


### PR DESCRIPTION
This is a follow-up to https://github.com/ethereum/go-ethereum/pull/21793 , fixing the percentage progress report. 

Before this PR (with the actual work skipped, hence the quick speeds): 
```
[user@work go-ethereum]$ ./build/bin/geth makedag 22000000 ./dag
INFO [11-09|11:43:21.019] Generating ethash verification cache     epoch=733 percentage=69 elapsed=3.000s
INFO [11-09|11:43:22.444] Generated ethash verification cache      epoch=733 elapsed=4.425s
INFO [11-09|11:43:22.503] Generating DAG in progress               epoch=733 percentage=0  elapsed=58.463ms
INFO [11-09|11:43:22.565] Generating DAG in progress               epoch=733 percentage=1  elapsed=120.784ms
INFO [11-09|11:43:22.633] Generating DAG in progress               epoch=733 percentage=2  elapsed=188.635ms
INFO [11-09|11:43:22.685] Generating DAG in progress               epoch=733 percentage=3  elapsed=240.863ms
INFO [11-09|11:43:22.746] Generating DAG in progress               epoch=733 percentage=4  elapsed=301.516ms
INFO [11-09|11:43:22.807] Generating DAG in progress               epoch=733 percentage=5  elapsed=363.052ms
INFO [11-09|11:43:22.857] Generating DAG in progress               epoch=733 percentage=6  elapsed=412.736ms
INFO [11-09|11:43:23.025] Generating DAG in progress               epoch=733 percentage=7  elapsed=581.315ms
INFO [11-09|11:43:23.260] Generating DAG in progress               epoch=733 percentage=8  elapsed=815.848ms
INFO [11-09|11:43:23.505] Generating DAG in progress               epoch=733 percentage=9  elapsed=1.061s
INFO [11-09|11:43:23.756] Generating DAG in progress               epoch=733 percentage=10 elapsed=1.311s
INFO [11-09|11:43:24.010] Generating DAG in progress               epoch=733 percentage=11 elapsed=1.565s
INFO [11-09|11:43:24.320] Generating DAG in progress               epoch=733 percentage=12 elapsed=1.876s
INFO [11-09|11:43:24.539] Generating DAG in progress               epoch=733 percentage=13 elapsed=2.095s
INFO [11-09|11:43:24.740] Generating DAG in progress               epoch=733 percentage=14 elapsed=2.295s
INFO [11-09|11:43:24.959] Generating DAG in progress               epoch=733 percentage=15 elapsed=2.514s
INFO [11-09|11:43:25.219] Generating DAG in progress               epoch=733 percentage=16 elapsed=2.774s
INFO [11-09|11:43:25.442] Generating DAG in progress               epoch=733 percentage=17 elapsed=2.997s
INFO [11-09|11:43:25.659] Generating DAG in progress               epoch=733 percentage=18 elapsed=3.214s
INFO [11-09|11:43:25.891] Generating DAG in progress               epoch=733 percentage=19 elapsed=3.446s
INFO [11-09|11:43:26.097] Generating DAG in progress               epoch=733 percentage=20 elapsed=3.652s
INFO [11-09|11:43:26.295] Generating DAG in progress               epoch=733 percentage=21 elapsed=3.851s
INFO [11-09|11:43:26.529] Generating DAG in progress               epoch=733 percentage=22 elapsed=4.084s
INFO [11-09|11:43:26.760] Generating DAG in progress               epoch=733 percentage=23 elapsed=4.316s
INFO [11-09|11:43:26.941] Generating DAG in progress               epoch=733 percentage=24 elapsed=4.496s
INFO [11-09|11:43:27.174] Generating DAG in progress               epoch=733 percentage=25 elapsed=4.729s
INFO [11-09|11:43:27.396] Generating DAG in progress               epoch=733 percentage=26 elapsed=4.952s
INFO [11-09|11:43:27.631] Generating DAG in progress               epoch=733 percentage=27 elapsed=5.186s
INFO [11-09|11:43:27.844] Generating DAG in progress               epoch=733 percentage=28 elapsed=5.400s
INFO [11-09|11:43:28.029] Generating DAG in progress               epoch=733 percentage=29 elapsed=5.584s
INFO [11-09|11:43:28.244] Generating DAG in progress               epoch=733 percentage=30 elapsed=5.799s
INFO [11-09|11:43:28.467] Generating DAG in progress               epoch=733 percentage=31 elapsed=6.022s
INFO [11-09|11:43:28.666] Generating DAG in progress               epoch=733 percentage=32 elapsed=6.221s
INFO [11-09|11:43:28.891] Generating DAG in progress               epoch=733 percentage=33 elapsed=6.447s
INFO [11-09|11:43:29.121] Generating DAG in progress               epoch=733 percentage=34 elapsed=6.677s
INFO [11-09|11:43:29.343] Generating DAG in progress               epoch=733 percentage=35 elapsed=6.899s
INFO [11-09|11:43:29.568] Generating DAG in progress               epoch=733 percentage=36 elapsed=7.124s
INFO [11-09|11:43:29.759] Generating DAG in progress               epoch=733 percentage=37 elapsed=7.315s
INFO [11-09|11:43:29.997] Generating DAG in progress               epoch=733 percentage=0  elapsed=7.553s
INFO [11-09|11:43:30.231] Generating DAG in progress               epoch=733 percentage=1  elapsed=7.787s
```
After this PR: 

```
user@work go-ethereum]$ ./build/bin/geth makedag 22000000 ./dag
INFO [11-09|11:46:00.840] Generating ethash verification cache     epoch=733 percentage=70 elapsed=3.010s
INFO [11-09|11:46:02.247] Generated ethash verification cache      epoch=733 elapsed=4.417s
INFO [11-09|11:46:02.295] Generating DAG in progress               epoch=733 percentage=0  elapsed=47.872ms
INFO [11-09|11:46:02.356] Generating DAG in progress               epoch=733 percentage=1  elapsed=109.047ms
INFO [11-09|11:46:02.421] Generating DAG in progress               epoch=733 percentage=2  elapsed=173.629ms
INFO [11-09|11:46:02.478] Generating DAG in progress               epoch=733 percentage=3  elapsed=230.638ms
INFO [11-09|11:46:02.526] Generating DAG in progress               epoch=733 percentage=4  elapsed=279.418ms
INFO [11-09|11:46:02.602] Generating DAG in progress               epoch=733 percentage=5  elapsed=355.418ms
INFO [11-09|11:46:02.651] Generating DAG in progress               epoch=733 percentage=6  elapsed=403.904ms
INFO [11-09|11:46:02.705] Generating DAG in progress               epoch=733 percentage=7  elapsed=458.408ms
INFO [11-09|11:46:02.836] Generating DAG in progress               epoch=733 percentage=8  elapsed=588.958ms
INFO [11-09|11:46:02.996] Generating DAG in progress               epoch=733 percentage=9  elapsed=749.486ms
INFO [11-09|11:46:03.176] Generating DAG in progress               epoch=733 percentage=10 elapsed=928.616ms
INFO [11-09|11:46:03.350] Generating DAG in progress               epoch=733 percentage=11 elapsed=1.102s
INFO [11-09|11:46:03.534] Generating DAG in progress               epoch=733 percentage=12 elapsed=1.287s
INFO [11-09|11:46:03.715] Generating DAG in progress               epoch=733 percentage=13 elapsed=1.468s
INFO [11-09|11:46:03.911] Generating DAG in progress               epoch=733 percentage=14 elapsed=1.664s
INFO [11-09|11:46:04.112] Generating DAG in progress               epoch=733 percentage=15 elapsed=1.865s
INFO [11-09|11:46:04.318] Generating DAG in progress               epoch=733 percentage=16 elapsed=2.071s
INFO [11-09|11:46:04.534] Generating DAG in progress               epoch=733 percentage=17 elapsed=2.286s
INFO [11-09|11:46:04.761] Generating DAG in progress               epoch=733 percentage=18 elapsed=2.513s
INFO [11-09|11:46:05.020] Generating DAG in progress               epoch=733 percentage=19 elapsed=2.772s
INFO [11-09|11:46:05.289] Generating DAG in progress               epoch=733 percentage=20 elapsed=3.041s
INFO [11-09|11:46:05.611] Generating DAG in progress               epoch=733 percentage=21 elapsed=3.364s
INFO [11-09|11:46:05.869] Generating DAG in progress               epoch=733 percentage=22 elapsed=3.622s
INFO [11-09|11:46:06.082] Generating DAG in progress               epoch=733 percentage=23 elapsed=3.834s
INFO [11-09|11:46:06.293] Generating DAG in progress               epoch=733 percentage=24 elapsed=4.045s
INFO [11-09|11:46:06.505] Generating DAG in progress               epoch=733 percentage=25 elapsed=4.258s
INFO [11-09|11:46:06.723] Generating DAG in progress               epoch=733 percentage=26 elapsed=4.475s
INFO [11-09|11:46:06.944] Generating DAG in progress               epoch=733 percentage=27 elapsed=4.697s
INFO [11-09|11:46:07.170] Generating DAG in progress               epoch=733 percentage=28 elapsed=4.922s
INFO [11-09|11:46:07.381] Generating DAG in progress               epoch=733 percentage=29 elapsed=5.134s
INFO [11-09|11:46:07.591] Generating DAG in progress               epoch=733 percentage=30 elapsed=5.344s
INFO [11-09|11:46:07.806] Generating DAG in progress               epoch=733 percentage=31 elapsed=5.558s
INFO [11-09|11:46:08.022] Generating DAG in progress               epoch=733 percentage=32 elapsed=5.774s
INFO [11-09|11:46:08.237] Generating DAG in progress               epoch=733 percentage=33 elapsed=5.990s
INFO [11-09|11:46:08.455] Generating DAG in progress               epoch=733 percentage=34 elapsed=6.208s
INFO [11-09|11:46:08.673] Generating DAG in progress               epoch=733 percentage=35 elapsed=6.426s
INFO [11-09|11:46:08.895] Generating DAG in progress               epoch=733 percentage=36 elapsed=6.648s
INFO [11-09|11:46:09.110] Generating DAG in progress               epoch=733 percentage=37 elapsed=6.862s
INFO [11-09|11:46:09.323] Generating DAG in progress               epoch=733 percentage=38 elapsed=7.076s
INFO [11-09|11:46:09.537] Generating DAG in progress               epoch=733 percentage=39 elapsed=7.290s
INFO [11-09|11:46:09.754] Generating DAG in progress               epoch=733 percentage=40 elapsed=7.506s
INFO [11-09|11:46:09.971] Generating DAG in progress               epoch=733 percentage=41 elapsed=7.724s
INFO [11-09|11:46:10.190] Generating DAG in progress               epoch=733 percentage=42 elapsed=7.943s
INFO [11-09|11:46:10.403] Generating DAG in progress               epoch=733 percentage=43 elapsed=8.155s
INFO [11-09|11:46:10.624] Generating DAG in progress               epoch=733 percentage=44 elapsed=8.377s
INFO [11-09|11:46:10.854] Generating DAG in progress               epoch=733 percentage=45 elapsed=8.606s
INFO [11-09|11:46:11.082] Generating DAG in progress               epoch=733 percentage=46 elapsed=8.834s
INFO [11-09|11:46:11.305] Generating DAG in progress               epoch=733 percentage=47 elapsed=9.057s
INFO [11-09|11:46:11.531] Generating DAG in progress               epoch=733 percentage=48 elapsed=9.284s
INFO [11-09|11:46:11.828] Generating DAG in progress               epoch=733 percentage=49 elapsed=9.581s
INFO [11-09|11:46:12.749] Generating DAG in progress               epoch=733 percentage=50 elapsed=10.502s
INFO [11-09|11:46:13.224] Generating DAG in progress               epoch=733 percentage=51 elapsed=10.977s
INFO [11-09|11:46:13.763] Generating DAG in progress               epoch=733 percentage=52 elapsed=11.516s
INFO [11-09|11:46:14.049] Generating DAG in progress               epoch=733 percentage=53 elapsed=11.801s
INFO [11-09|11:46:14.290] Generating DAG in progress               epoch=733 percentage=54 elapsed=12.042s
INFO [11-09|11:46:14.509] Generating DAG in progress               epoch=733 percentage=55 elapsed=12.262s
INFO [11-09|11:46:14.736] Generating DAG in progress               epoch=733 percentage=56 elapsed=12.488s
INFO [11-09|11:46:14.976] Generating DAG in progress               epoch=733 percentage=57 elapsed=12.729s
INFO [11-09|11:46:15.228] Generating DAG in progress               epoch=733 percentage=58 elapsed=12.981s
INFO [11-09|11:46:15.513] Generating DAG in progress               epoch=733 percentage=59 elapsed=13.266s
INFO [11-09|11:46:15.742] Generating DAG in progress               epoch=733 percentage=60 elapsed=13.495s
INFO [11-09|11:46:16.021] Generating DAG in progress               epoch=733 percentage=61 elapsed=13.773s
INFO [11-09|11:46:16.287] Generating DAG in progress               epoch=733 percentage=62 elapsed=14.040s
INFO [11-09|11:46:16.543] Generating DAG in progress               epoch=733 percentage=63 elapsed=14.295s
INFO [11-09|11:46:16.825] Generating DAG in progress               epoch=733 percentage=64 elapsed=14.578s
INFO [11-09|11:46:17.141] Generating DAG in progress               epoch=733 percentage=65 elapsed=14.893s
INFO [11-09|11:46:17.644] Generating DAG in progress               epoch=733 percentage=66 elapsed=15.396s
INFO [11-09|11:46:17.878] Generating DAG in progress               epoch=733 percentage=67 elapsed=15.630s
INFO [11-09|11:46:18.119] Generating DAG in progress               epoch=733 percentage=68 elapsed=15.871s
INFO [11-09|11:46:18.363] Generating DAG in progress               epoch=733 percentage=69 elapsed=16.116s
INFO [11-09|11:46:18.605] Generating DAG in progress               epoch=733 percentage=70 elapsed=16.358s
INFO [11-09|11:46:18.857] Generating DAG in progress               epoch=733 percentage=71 elapsed=16.610s
INFO [11-09|11:46:19.103] Generating DAG in progress               epoch=733 percentage=72 elapsed=16.855s
INFO [11-09|11:46:19.341] Generating DAG in progress               epoch=733 percentage=73 elapsed=17.093s
INFO [11-09|11:46:19.559] Generating DAG in progress               epoch=733 percentage=74 elapsed=17.311s
INFO [11-09|11:46:19.762] Generating DAG in progress               epoch=733 percentage=75 elapsed=17.514s
INFO [11-09|11:46:19.964] Generating DAG in progress               epoch=733 percentage=76 elapsed=17.716s
INFO [11-09|11:46:20.164] Generating DAG in progress               epoch=733 percentage=77 elapsed=17.916s
INFO [11-09|11:46:20.350] Generating DAG in progress               epoch=733 percentage=78 elapsed=18.102s
INFO [11-09|11:46:20.540] Generating DAG in progress               epoch=733 percentage=79 elapsed=18.293s
INFO [11-09|11:46:20.728] Generating DAG in progress               epoch=733 percentage=80 elapsed=18.480s
INFO [11-09|11:46:20.920] Generating DAG in progress               epoch=733 percentage=81 elapsed=18.673s
INFO [11-09|11:46:21.114] Generating DAG in progress               epoch=733 percentage=82 elapsed=18.867s
INFO [11-09|11:46:21.299] Generating DAG in progress               epoch=733 percentage=83 elapsed=19.051s
INFO [11-09|11:46:21.481] Generating DAG in progress               epoch=733 percentage=84 elapsed=19.234s
INFO [11-09|11:46:21.674] Generating DAG in progress               epoch=733 percentage=85 elapsed=19.427s
INFO [11-09|11:46:21.879] Generating DAG in progress               epoch=733 percentage=86 elapsed=19.632s
INFO [11-09|11:46:22.126] Generating DAG in progress               epoch=733 percentage=87 elapsed=19.878s
INFO [11-09|11:46:22.384] Generating DAG in progress               epoch=733 percentage=88 elapsed=20.136s
INFO [11-09|11:46:22.618] Generating DAG in progress               epoch=733 percentage=89 elapsed=20.371s
INFO [11-09|11:46:23.025] Generating DAG in progress               epoch=733 percentage=90 elapsed=20.778s
INFO [11-09|11:46:23.326] Generating DAG in progress               epoch=733 percentage=91 elapsed=21.078s
INFO [11-09|11:46:23.593] Generating DAG in progress               epoch=733 percentage=92 elapsed=21.346s
INFO [11-09|11:46:23.860] Generating DAG in progress               epoch=733 percentage=93 elapsed=21.612s
INFO [11-09|11:46:24.114] Generating DAG in progress               epoch=733 percentage=94 elapsed=21.867s
INFO [11-09|11:46:24.375] Generating DAG in progress               epoch=733 percentage=95 elapsed=22.127s
INFO [11-09|11:46:24.609] Generating DAG in progress               epoch=733 percentage=96 elapsed=22.362s
INFO [11-09|11:46:24.839] Generating DAG in progress               epoch=733 percentage=97 elapsed=22.592s
INFO [11-09|11:46:25.089] Generating DAG in progress               epoch=733 percentage=98 elapsed=22.842s
INFO [11-09|11:46:25.366] Generating DAG in progress               epoch=733 percentage=99 elapsed=23.119s
INFO [11-09|11:46:25.369] Generated ethash verification cache      epoch=733 elapsed=23.120s
```