### PR TITLE
core/state/snapshot: update generator marker in sync with flushes

### DIFF
--- a/core/blockchain_snapshot_test.go
+++ b/core/blockchain_snapshot_test.go
@@ -675,7 +675,7 @@ func testSnapshot(t *testing.T, tt *snapshotTest) {
 	if _, err := chain.InsertChain(blocks[startPoint:]); err != nil {
 		t.Fatalf("Failed to import canonical chain tail: %v", err)
 	}
-	// Set the flag for writing legacy journal if ncessary
+	// Set the flag for writing legacy journal if necessary
 	if tt.legacy {
 		chain.writeLegacyJournal = true
 	}
@@ -708,7 +708,6 @@ func testSnapshot(t *testing.T, tt *snapshotTest) {
 	} else if tt.gapped > 0 {
 		// Insert blocks without enabling snapshot if gapping is required.
 		chain.Stop()
-
 		gappedBlocks, _ := GenerateChain(params.TestChainConfig, blocks[len(blocks)-1], engine, gendb, tt.gapped, func(i int, b *BlockGen) {})
 
 		// Insert a few more blocks without enabling snapshot
@@ -766,6 +765,7 @@ func testSnapshot(t *testing.T, tt *snapshotTest) {
 		defer chain.Stop()
 	} else {
 		chain.Stop()
+
 		// Restart the chain normally
 		chain, err = NewBlockChain(db, nil, params.AllEthashProtocolChanges, engine, vm.Config{}, nil, nil)
 		if err != nil {

--- a/core/state/snapshot/generate.go
+++ b/core/state/snapshot/generate.go
@@ -19,6 +19,7 @@ package snapshot
 import (
 	"bytes"
 	"encoding/binary"
+	"fmt"
 	"math/big"
 	"time"
 
@@ -116,6 +117,38 @@ func generateSnapshot(diskdb ethdb.KeyValueStore, triedb *trie.Database, cache i
 	return base
 }
 
+// journalProgress persists the generator stats into the database to resume later.
+func journalProgress(db ethdb.KeyValueWriter, marker []byte, stats *generatorStats) {
+	// Write out the generator marker. Note it's a standalone disk layer generator
+	// which is not mixed with journal. It's ok if the generator is persisted while
+	// journal is not.
+	entry := journalGenerator{
+		Done:   marker == nil,
+		Marker: marker,
+	}
+	if stats != nil {
+		entry.Wiping = (stats.wiping != nil)
+		entry.Accounts = stats.accounts
+		entry.Slots = stats.slots
+		entry.Storage = uint64(stats.storage)
+	}
+	blob, err := rlp.EncodeToBytes(entry)
+	if err != nil {
+		panic(err) // Cannot happen, here to catch dev errors
+	}
+	var logstr string
+	switch len(marker) {
+	case 0:
+		logstr = "done"
+	case common.HashLength:
+		logstr = fmt.Sprintf("%#x", marker)
+	default:
+		logstr = fmt.Sprintf("%#x:%#x", marker[:common.HashLength], marker[common.HashLength:])
+	}
+	log.Debug("Journalled generator progress", "progress", logstr)
+	rawdb.WriteSnapshotGenerator(db, blob)
+}
+
 // generate is a background thread that iterates over the state and storage tries,
 // constructing the state snapshot. All the arguments are purely for statistics
 // gethering and logging, since the method surfs the blocks as they arrive, often
@@ -187,11 +220,15 @@ func (dl *diskLayer) generate(stats *generatorStats) {
 		if batch.ValueSize() > ethdb.IdealBatchSize || abort != nil {
 			// Only write and set the marker if we actually did something useful
 			if batch.ValueSize() > 0 {
+				// Ensure the generator entry is in sync with the data
+				marker := accountHash[:]
+				journalProgress(batch, marker, stats)
+
 				batch.Write()
 				batch.Reset()
 
 				dl.lock.Lock()
-				dl.genMarker = accountHash[:]
+				dl.genMarker = marker
 				dl.lock.Unlock()
 			}
 			if abort != nil {
@@ -228,11 +265,15 @@ func (dl *diskLayer) generate(stats *generatorStats) {
 				if batch.ValueSize() > ethdb.IdealBatchSize || abort != nil {
 					// Only write and set the marker if we actually did something useful
 					if batch.ValueSize() > 0 {
+						// Ensure the generator entry is in sync with the data
+						marker := append(accountHash[:], storeIt.Key...)
+						journalProgress(batch, marker, stats)
+
 						batch.Write()
 						batch.Reset()
 
 						dl.lock.Lock()
-						dl.genMarker = append(accountHash[:], storeIt.Key...)
+						dl.genMarker = marker
 						dl.lock.Unlock()
 					}
 					if abort != nil {
@@ -264,6 +305,9 @@ func (dl *diskLayer) generate(stats *generatorStats) {
 	}
 	// Snapshot fully generated, set the marker to nil
 	if batch.ValueSize() > 0 {
+		// Ensure the generator entry is in sync with the data
+		journalProgress(batch, nil, stats)
+
 		batch.Write()
 	}
 	log.Info("Generated state snapshot", "accounts", stats.accounts, "slots", stats.slots,

--- a/core/state/snapshot/snapshot.go
+++ b/core/state/snapshot/snapshot.go
@@ -512,22 +512,8 @@ func diffToDisk(bottom *diffLayer) *diskLayer {
 	// Update the snapshot block marker and write any remainder data
 	rawdb.WriteSnapshotRoot(batch, bottom.root)
 
-	// Write out the generator marker
-	entry := journalGenerator{
-		Done:   base.genMarker == nil,
-		Marker: base.genMarker,
-	}
-	if stats != nil {
-		entry.Wiping = (stats.wiping != nil)
-		entry.Accounts = stats.accounts
-		entry.Slots = stats.slots
-		entry.Storage = uint64(stats.storage)
-	}
-	blob, err := rlp.EncodeToBytes(entry)
-	if err != nil {
-		panic(fmt.Sprintf("Failed to RLP encode generator %v", err))
-	}
-	rawdb.WriteSnapshotGenerator(batch, blob)
+	// Write out the generator progress marker and report
+	journalProgress(batch, base.genMarker, stats)
 
 	// Flush all the updates in the single db operation. Ensure the
 	// disk layer transition is atomic.


### PR DESCRIPTION
This PR fixes a data corruption in the snapshot mechanism if it crashes mid-storage.

The generator works by iterating the state trie and pushing the account/storage leaf data directly to disk. To avoid thrashing the database, the generator accumulates writes into a batch and only flushes to disk after a certain threshold is exceeded. When the generator flushes to disk, it's internal progress marker is also updates so that it knows where to continue from if it's interrupted.

The bug was that the marker was **not** written to disk at the same time as the data batch, rather was kept in memory and only flushed on shutdown. This however means that in case of a crash (or Ctrl+C without waiting for graceful shutdown), if the generator was in progress, then the database would go out of sync, the marker being behind of the data already indexed.

Most of the time this was not noticeable as upon restart, the generator just picked up in it's stale position and reindexed the same data once again. The rare issue however is if the chain progresses before the restart and some of the indexed - but rewound - data slots become deleted. In that case, the generator will not realize that there is junk in the database and will only add the new data, but not delete the stale junk.

The fix is to ensure that every time new snapshot data is pushed to disk, the generator marker is also updated atomically in the same go. From a thrashing perspective this does incur some additional overhead since we need to bump the same database key over and over again on every flush, but it's a price we need to pay.