### PR TITLE
travis: drop Go 1.13 builders as it's not supported any more

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,16 +27,6 @@ jobs:
     - stage: build
       os: linux
       dist: xenial
-      go: 1.13.x
-      env:
-        - GO111MODULE=on
-      script:
-        - go run build/ci.go install
-        - go run build/ci.go test -coverage $TEST_PACKAGES
-
-    - stage: build
-      os: linux
-      dist: xenial
       go: 1.14.x
       env:
         - GO111MODULE=on


### PR DESCRIPTION
Go 1.13 is not officially supported any more, stop wasting CI resources on it.