### PR TITLE
accounts/abi: template: set events Raw field in Parse methods

### DIFF
--- a/accounts/abi/bind/template.go
+++ b/accounts/abi/bind/template.go
@@ -541,6 +541,7 @@ var (
 			if err := _{{$contract.Type}}.contract.UnpackLog(event, "{{.Original.Name}}", log); err != nil {
 				return nil, err
 			}
+			event.Raw = log
 			return event, nil
 		}
 


### PR DESCRIPTION
The Raw field is not set in Parse* methods.
It is set everywhere else in the template code.
This PR sets it.