### PR TITLE
scripts: move oss-fuzz script to go-ethereum

### DIFF
--- a/oss-fuzz.sh
+++ b/oss-fuzz.sh
@@ -1,0 +1,56 @@
+#/bin/bash -eu
+# Copyright 2020 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+# This file is for integration with Google OSS-Fuzz.
+# The following ENV variables are available when executing on OSS-fuzz:
+#
+# /out/         $OUT    Directory to store build artifacts (fuzz targets, dictionaries, options files, seed corpus archives).
+# /src/         $SRC    Directory to checkout source files.
+# /work/        $WORK   Directory to store intermediate files.
+#
+# $CC, $CXX, $CCC       The C and C++ compiler binaries.
+# $CFLAGS, $CXXFLAGS    C and C++ compiler flags.
+# $LIB_FUZZING_ENGINE   C++ compiler argument to link fuzz target against the prebuilt engine library (e.g. libFuzzer).
+
+function compile_fuzzer {
+  path=$SRC/go-ethereum/$1
+  func=$2
+  fuzzer=$3
+  echo "Building $fuzzer"
+  (cd $path && \
+        go-fuzz -func $func -o $WORK/$fuzzer.a . && \
+        echo "First stage built OK" && \
+        $CXX $CXXFLAGS $LIB_FUZZING_ENGINE $WORK/$fuzzer.a -o $OUT/$fuzzer && \
+        echo "Second stage built ok" )
+
+}
+
+compile_fuzzer common/bitutil  Fuzz      fuzzBitutilCompress
+compile_fuzzer crypto/bn256    FuzzAdd   fuzzBn256Add
+compile_fuzzer crypto/bn256    FuzzMul   fuzzBn256Mul
+compile_fuzzer crypto/bn256    FuzzPair  fuzzBn256Pair
+compile_fuzzer core/vm/runtime Fuzz      fuzzVmRuntime
+compile_fuzzer crypto/blake2b  Fuzz      fuzzBlake2b
+compile_fuzzer tests/fuzzers/keystore   Fuzz fuzzKeystore
+compile_fuzzer tests/fuzzers/txfetcher  Fuzz fuzzTxfetcher
+compile_fuzzer tests/fuzzers/rlp        Fuzz fuzzRlp
+compile_fuzzer tests/fuzzers/trie       Fuzz fuzzTrie
+compile_fuzzer tests/fuzzers/stacktrie  Fuzz fuzzStackTrie
+
+# This doesn't work very well @TODO
+#compile_fuzzertests/fuzzers/abi Fuzz fuzzAbi
+


### PR DESCRIPTION
This PR 

1. moves the oss fuzzing configuration/build from oss-fuzz into go-ethereum, making it simpler for us to make changes and updates (it is a prerequisite for a follow-up PR against oss-fuzz to have any effect).

Current script, for reference: https://github.com/google/oss-fuzz/blob/master/projects/go-ethereum/build.sh