### PR TITLE
node: serve JSON-RPC on all unused HTTP paths

### DIFF
--- a/graphql/graphql_test.go
+++ b/graphql/graphql_test.go
@@ -86,8 +86,7 @@ func TestGraphQLHTTPOnSamePort_GQLRequest_Unsuccessful(t *testing.T) {
 		t.Fatalf("could not read from response body: %v", err)
 	}
 	// make sure the request is not handled successfully
-	assert.Equal(t, 404, resp.StatusCode)
-	assert.Equal(t, "404 page not found\n", string(bodyBytes))
+	assert.True(t, strings.Contains(string(bodyBytes), "invalid request"))
 }
 
 func createNode(t *testing.T, gqlEnabled bool) *node.Node {

--- a/node/rpcstack.go
+++ b/node/rpcstack.go
@@ -184,17 +184,14 @@ func (h *httpServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 	// fall back to JSON-RPC
-	if r.RequestURI == "/" {
-		// Serve JSON-RPC on the root path.
-		ws := h.wsHandler.Load().(*rpcHandler)
-		if ws != nil && isWebsocket(r) {
-			ws.ServeHTTP(w, r)
-			return
-		}
-		if rpc != nil {
-			rpc.ServeHTTP(w, r)
-			return
-		}
+	ws := h.wsHandler.Load().(*rpcHandler)
+	if ws != nil && isWebsocket(r) {
+		ws.ServeHTTP(w, r)
+		return
+	}
+	if rpc != nil {
+		rpc.ServeHTTP(w, r)
+		return
 	}
 	w.WriteHeader(404)
 }

--- a/node/rpcstack_test.go
+++ b/node/rpcstack_test.go
@@ -95,7 +95,7 @@ func TestRPCCall_NotOnRootPath(t *testing.T) {
 	paths := []string{"/", "/testing/test/123", "/testing", ""}
 
 	srv := createAndStartServer(t, httpConfig{}, true, wsConfig{})
-	body :=  bytes.NewReader([]byte(`{"jsonrpc":"2.0","id":1,method":"rpc_modules"}`))
+	body := bytes.NewReader([]byte(`{"jsonrpc":"2.0","id":1,method":"rpc_modules"}`))
 
 	for _, path := range paths {
 		req := createReq(srv, body, path)


### PR DESCRIPTION
This PR fixes an issue where an RPC call that is not on the root path results in a 404 Not Found error. Instead, the request will be pattern-matched against the mux router to see if any registered paths match the request path, and if not, the server will fall back to JSON-RPC. This will allow RPC requests with an additional path to still be served.