### PR TITLE
tests/fuzzers/stacktrie: prevent false positives

### DIFF
--- a/tests/fuzzers/stacktrie/trie_fuzzer.go
+++ b/tests/fuzzers/stacktrie/trie_fuzzer.go
@@ -158,6 +158,15 @@ func (f *fuzzer) fuzz() int {
 			// thus 'deletion' which is not supported on stacktrie
 			break
 		}
+		found := false
+		for _, val := range vals {
+			if bytes.Equal(val.k, k) {
+				found = true
+			}
+		}
+		if found {
+			continue
+		}
 		vals = append(vals, kv{k: k, v: v})
 		trieA.Update(k, v)
 		useful = true


### PR DESCRIPTION
The stacktrie (other than the normal trie) does not like inserting the same key twice. 
Currently the fuzzer does exactly this. 
This PR fixes that by ignoring duplicate keys. 

Another maybe better idea is to sort the keys first and then go through them once and remove all duplicates cc @holiman 