### PR TITLE
eth: fix error in tracing if reexec is set

### DIFF
--- a/eth/api_tracer.go
+++ b/eth/api_tracer.go
@@ -65,7 +65,7 @@ type TraceConfig struct {
 
 // StdTraceConfig holds extra parameters to standard-json trace functions.
 type StdTraceConfig struct {
-	*vm.LogConfig
+	vm.LogConfig
 	Reexec *uint64
 	TxHash common.Hash
 }
@@ -553,9 +553,7 @@ func (api *PrivateDebugAPI) standardTraceBlockToFile(ctx context.Context, block 
 		txHash    common.Hash
 	)
 	if config != nil {
-		if config.LogConfig != nil {
-			logConfig = *config.LogConfig
-		}
+		logConfig = config.LogConfig
 		txHash = config.TxHash
 	}
 	logConfig.Debug = true
@@ -573,7 +571,7 @@ func (api *PrivateDebugAPI) standardTraceBlockToFile(ctx context.Context, block 
 	// in order to obtain the state.
 	// Therefore, it's perfectly valid to specify `"futureForkBlock": 0`, to enable `futureFork`
 
-	if config != nil && config.LogConfig != nil && config.LogConfig.Overrides != nil {
+	if config != nil && config.Overrides != nil {
 		// Copy the config, to not screw up the main config
 		// Note: the Clique-part is _not_ deep copied
 		chainConfigCopy := new(params.ChainConfig)

--- a/eth/api_tracer.go
+++ b/eth/api_tracer.go
@@ -573,13 +573,13 @@ func (api *PrivateDebugAPI) standardTraceBlockToFile(ctx context.Context, block 
 	// in order to obtain the state.
 	// Therefore, it's perfectly valid to specify `"futureForkBlock": 0`, to enable `futureFork`
 
-	if config != nil && config.Overrides != nil {
+	if config != nil && config.LogConfig != nil && config.LogConfig.Overrides != nil {
 		// Copy the config, to not screw up the main config
 		// Note: the Clique-part is _not_ deep copied
 		chainConfigCopy := new(params.ChainConfig)
 		*chainConfigCopy = *chainConfig
 		chainConfig = chainConfigCopy
-		if yolov2 := config.Overrides.YoloV2Block; yolov2 != nil {
+		if yolov2 := config.LogConfig.Overrides.YoloV2Block; yolov2 != nil {
 			chainConfig.YoloV2Block = yolov2
 			canon = false
 		}


### PR DESCRIPTION
This fixes an error that can be hit when tracing and using e.g. `reexec=100`. Due to an anonymous struct, the `config.Overrides ` can trigger a nil deref since it _actually_ references `config.LogConfig.Overrides`, and ` config.LogConfig` is `nil` if only `reexec` is specified but nothing else. 

Example crash: 
```
INFO [11-11|13:37:27.158] Historical state regenerated             block=11234872 elapsed=50m20.275461793s nodes=1.54GiB preimages=92.71MiB
ERROR[11-11|13:37:27.158] RPC method debug_standardTraceBlockToFile crashed: runtime error: invalid memory address or nil pointer dereference
goroutine 1089318128 [running]:
github.com/ethereum/go-ethereum/rpc.(*callback).call.func1(0xc01538f740, 0x1e, 0xc27acb1d58)
	github.com/ethereum/go-ethereum/rpc/service.go:200 +0xba
panic(0x11a5f00, 0x1bf60f0)
	runtime/panic.go:969 +0x1b9
github.com/ethereum/go-ethereum/eth.(*PrivateDebugAPI).standardTraceBlockToFile(0xc000269790, 0x154e440, 0xc0a32a3000, 0xc0626690e0, 0xc0367ac960, 0xc0626690e0, 0x48581f, 0x11dbb60, 0x121f9a0, 0xc0a32a3000)
	github.com/ethereum/go-ethereum/eth/api_tracer.go:576 +0x33b
github.com/ethereum/go-ethereum/eth.(*PrivateDebugAPI).StandardTraceBlockToFile(0xc000269790, 0x154e440, 0xc0a32a3000, 0x7798a89e71ec2084, 0x9dff2851ce3bbbf1, 0x8f0776b37fcf9eb, 0xf3fb9fbcbcfe4808, 0xc0367ac960, 0x0, 0x0, ...)
	github.com/ethereum/go-ethereum/eth/api_tracer.go:426 +0xb0
reflect.Value.call(0xc000617e80, 0xc00307b610, 0x13, 0x13251c1, 0x4, 0xc0a11a7e60, 0x4, 0x4, 0xc0a11a7e90, 0xc0367ac8d0, ...)
	reflect/value.go:475 +0x8c7
reflect.Value.Call(0xc000617e80, 0xc00307b610, 0x13, 0xc0a11a7e60, 0x4, 0x4, 0x16, 0x10, 0x0)
	reflect/value.go:336 +0xb9
github.com/ethereum/go-ethereum/rpc.(*callback).call(0xc0031bcae0, 0x154e440, 0xc0a32a3000, 0xc01538f740, 0x1e, 0xc0367ac8d0, 0x2, 0x2, 0x0, 0x0, ...)
	github.com/ethereum/go-ethereum/rpc/service.go:206 +0x2c5
github.com/ethereum/go-ethereum/rpc.(*handler).runMethod(0xc069383c20, 0x154e440, 0xc0a32a3000, 0xc08852dab0, 0xc0031bcae0, 0xc0367ac8d0, 0x2, 0x2, 0x2)
	github.com/ethereum/go-ethereum/rpc/handler.go:389 +0x8a
github.com/ethereum/go-ethereum/rpc.(*handler).handleCall(0xc069383c20, 0xc0367ac870, 0xc08852dab0, 0x20300d)
	github.com/ethereum/go-ethereum/rpc/handler.go:337 +0x294
github.com/ethereum/go-ethereum/rpc.(*handler).handleCallMsg(0xc069383c20, 0xc0367ac870, 0xc08852dab0, 0x153dc01)
	github.com/ethereum/go-ethereum/rpc/handler.go:298 +0x1be
github.com/ethereum/go-ethereum/rpc.(*handler).handleMsg.func1(0xc0367ac870)
	github.com/ethereum/go-ethereum/rpc/handler.go:139 +0x46
github.com/ethereum/go-ethereum/rpc.(*handler).startCallProc.func1(0xc069383c20, 0xc0a5cbeba0)
	github.com/ethereum/go-ethereum/rpc/handler.go:226 +0xd2
created by github.com/ethereum/go-ethereum/rpc.(*handler).startCallProc
	github.com/ethereum/go-ethereum/rpc/handler.go:222 +0x66
 
```