### PR TITLE
build: fix regressions with the -dlgo change

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -55,24 +55,6 @@ jobs:
       script:
         - go run build/ci.go test -coverage $TEST_PACKAGES
 
-    - stage: build
-      os: osx
-      osx_image: xcode11.3
-      go: 1.15.x
-      env:
-        - GO111MODULE=on
-      script:
-        - echo "Increase the maximum number of open file descriptors on macOS"
-        - NOFILE=20480
-        - sudo sysctl -w kern.maxfiles=$NOFILE
-        - sudo sysctl -w kern.maxfilesperproc=$NOFILE
-        - sudo launchctl limit maxfiles $NOFILE $NOFILE
-        - sudo launchctl limit maxfiles
-        - ulimit -S -n $NOFILE
-        - ulimit -n
-        - unset -f cd # workaround for https://github.com/travis-ci/travis-ci/issues/8703
-        - go run build/ci.go test -coverage $TEST_PACKAGES
-
     # This builder does the Ubuntu PPA upload
     - stage: build
       if: type = push

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,65 +13,65 @@ jobs:
 
   include:
     # This builder only tests code linters on latest version of Go
-    # - stage: lint
-    #   os: linux
-    #   dist: xenial
-    #   go: 1.15.x
-    #   env:
-    #     - lint
-    #   git:
-    #     submodules: false # avoid cloning ethereum/tests
-    #   script:
-    #     - go run build/ci.go lint
+    - stage: lint
+      os: linux
+      dist: xenial
+      go: 1.15.x
+      env:
+        - lint
+      git:
+        submodules: false # avoid cloning ethereum/tests
+      script:
+        - go run build/ci.go lint
 
-    # - stage: build
-    #   os: linux
-    #   dist: xenial
-    #   go: 1.14.x
-    #   env:
-    #     - GO111MODULE=on
-    #   script:
-    #     - go run build/ci.go test -coverage $TEST_PACKAGES
+    - stage: build
+      os: linux
+      dist: xenial
+      go: 1.14.x
+      env:
+        - GO111MODULE=on
+      script:
+        - go run build/ci.go test -coverage $TEST_PACKAGES
 
     # These are the latest Go versions.
-    # - stage: build
-    #   os: linux
-    #   arch: amd64
-    #   dist: xenial
-    #   go: 1.15.x
-    #   env:
-    #     - GO111MODULE=on
-    #   script:
-    #     - go run build/ci.go test -coverage $TEST_PACKAGES
+    - stage: build
+      os: linux
+      arch: amd64
+      dist: xenial
+      go: 1.15.x
+      env:
+        - GO111MODULE=on
+      script:
+        - go run build/ci.go test -coverage $TEST_PACKAGES
 
-    # - stage: build
-    #   if: type = pull_request
-    #   os: linux
-    #   arch: arm64
-    #   dist: xenial
-    #   go: 1.15.x
-    #   env:
-    #     - GO111MODULE=on
-    #   script:
-    #     - go run build/ci.go test -coverage $TEST_PACKAGES
+    - stage: build
+      if: type = pull_request
+      os: linux
+      arch: arm64
+      dist: xenial
+      go: 1.15.x
+      env:
+        - GO111MODULE=on
+      script:
+        - go run build/ci.go test -coverage $TEST_PACKAGES
 
-    # - stage: build
-    #   os: osx
-    #   osx_image: xcode11.3
-    #   go: 1.15.x
-    #   env:
-    #     - GO111MODULE=on
-    #   script:
-    #     - echo "Increase the maximum number of open file descriptors on macOS"
-    #     - NOFILE=20480
-    #     - sudo sysctl -w kern.maxfiles=$NOFILE
-    #     - sudo sysctl -w kern.maxfilesperproc=$NOFILE
-    #     - sudo launchctl limit maxfiles $NOFILE $NOFILE
-    #     - sudo launchctl limit maxfiles
-    #     - ulimit -S -n $NOFILE
-    #     - ulimit -n
-    #     - unset -f cd # workaround for https://github.com/travis-ci/travis-ci/issues/8703
-    #     - go run build/ci.go test -coverage $TEST_PACKAGES
+    - stage: build
+      os: osx
+      osx_image: xcode11.3
+      go: 1.15.x
+      env:
+        - GO111MODULE=on
+      script:
+        - echo "Increase the maximum number of open file descriptors on macOS"
+        - NOFILE=20480
+        - sudo sysctl -w kern.maxfiles=$NOFILE
+        - sudo sysctl -w kern.maxfilesperproc=$NOFILE
+        - sudo launchctl limit maxfiles $NOFILE $NOFILE
+        - sudo launchctl limit maxfiles
+        - ulimit -S -n $NOFILE
+        - ulimit -n
+        - unset -f cd # workaround for https://github.com/travis-ci/travis-ci/issues/8703
+        - go run build/ci.go test -coverage $TEST_PACKAGES
 
     # This builder does the Ubuntu PPA upload
     - stage: build
@@ -99,7 +99,7 @@ jobs:
 
     # This builder does the Linux Azure uploads
     - stage: build
-      # if: type = push
+      if: type = push
       os: linux
       dist: xenial
       sudo: required
@@ -135,7 +135,7 @@ jobs:
 
     # This builder does the Linux Azure MIPS xgo uploads
     - stage: build
-      # if: type = push
+      if: type = push
       os: linux
       dist: xenial
       services:

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,65 +13,65 @@ jobs:
 
   include:
     # This builder only tests code linters on latest version of Go
-    - stage: lint
-      os: linux
-      dist: xenial
-      go: 1.15.x
-      env:
-        - lint
-      git:
-        submodules: false # avoid cloning ethereum/tests
-      script:
-        - go run build/ci.go lint
+    # - stage: lint
+    #   os: linux
+    #   dist: xenial
+    #   go: 1.15.x
+    #   env:
+    #     - lint
+    #   git:
+    #     submodules: false # avoid cloning ethereum/tests
+    #   script:
+    #     - go run build/ci.go lint
 
-    - stage: build
-      os: linux
-      dist: xenial
-      go: 1.14.x
-      env:
-        - GO111MODULE=on
-      script:
-        - go run build/ci.go test -coverage $TEST_PACKAGES
+    # - stage: build
+    #   os: linux
+    #   dist: xenial
+    #   go: 1.14.x
+    #   env:
+    #     - GO111MODULE=on
+    #   script:
+    #     - go run build/ci.go test -coverage $TEST_PACKAGES
 
     # These are the latest Go versions.
-    - stage: build
-      os: linux
-      arch: amd64
-      dist: xenial
-      go: 1.15.x
-      env:
-        - GO111MODULE=on
-      script:
-        - go run build/ci.go test -coverage $TEST_PACKAGES
+    # - stage: build
+    #   os: linux
+    #   arch: amd64
+    #   dist: xenial
+    #   go: 1.15.x
+    #   env:
+    #     - GO111MODULE=on
+    #   script:
+    #     - go run build/ci.go test -coverage $TEST_PACKAGES
 
-    - stage: build
-      if: type = pull_request
-      os: linux
-      arch: arm64
-      dist: xenial
-      go: 1.15.x
-      env:
-        - GO111MODULE=on
-      script:
-        - go run build/ci.go test -coverage $TEST_PACKAGES
+    # - stage: build
+    #   if: type = pull_request
+    #   os: linux
+    #   arch: arm64
+    #   dist: xenial
+    #   go: 1.15.x
+    #   env:
+    #     - GO111MODULE=on
+    #   script:
+    #     - go run build/ci.go test -coverage $TEST_PACKAGES
 
-    - stage: build
-      os: osx
-      osx_image: xcode11.3
-      go: 1.15.x
-      env:
-        - GO111MODULE=on
-      script:
-        - echo "Increase the maximum number of open file descriptors on macOS"
-        - NOFILE=20480
-        - sudo sysctl -w kern.maxfiles=$NOFILE
-        - sudo sysctl -w kern.maxfilesperproc=$NOFILE
-        - sudo launchctl limit maxfiles $NOFILE $NOFILE
-        - sudo launchctl limit maxfiles
-        - ulimit -S -n $NOFILE
-        - ulimit -n
-        - unset -f cd # workaround for https://github.com/travis-ci/travis-ci/issues/8703
-        - go run build/ci.go test -coverage $TEST_PACKAGES
+    # - stage: build
+    #   os: osx
+    #   osx_image: xcode11.3
+    #   go: 1.15.x
+    #   env:
+    #     - GO111MODULE=on
+    #   script:
+    #     - echo "Increase the maximum number of open file descriptors on macOS"
+    #     - NOFILE=20480
+    #     - sudo sysctl -w kern.maxfiles=$NOFILE
+    #     - sudo sysctl -w kern.maxfilesperproc=$NOFILE
+    #     - sudo launchctl limit maxfiles $NOFILE $NOFILE
+    #     - sudo launchctl limit maxfiles
+    #     - ulimit -S -n $NOFILE
+    #     - ulimit -n
+    #     - unset -f cd # workaround for https://github.com/travis-ci/travis-ci/issues/8703
+    #     - go run build/ci.go test -coverage $TEST_PACKAGES
 
     # This builder does the Ubuntu PPA upload
     - stage: build
@@ -99,7 +99,7 @@ jobs:
 
     # This builder does the Linux Azure uploads
     - stage: build
-      if: type = push
+      # if: type = push
       os: linux
       dist: xenial
       sudo: required
@@ -135,7 +135,7 @@ jobs:
 
     # This builder does the Linux Azure MIPS xgo uploads
     - stage: build
-      if: type = push
+      # if: type = push
       os: linux
       dist: xenial
       services:

--- a/.travis.yml
+++ b/.travis.yml
@@ -99,7 +99,7 @@ jobs:
 
     # This builder does the Linux Azure uploads
     - stage: build
-      # if: type = push
+      if: type = push
       os: linux
       dist: xenial
       sudo: required
@@ -165,7 +165,7 @@ jobs:
 
     # This builder does the Android Maven and Azure uploads
     - stage: build
-      if: type = push
+      # if: type = push
       os: linux
       dist: xenial
       addons:

--- a/.travis.yml
+++ b/.travis.yml
@@ -99,7 +99,7 @@ jobs:
 
     # This builder does the Linux Azure uploads
     - stage: build
-      if: type = push
+      # if: type = push
       os: linux
       dist: xenial
       sudo: required
@@ -165,7 +165,7 @@ jobs:
 
     # This builder does the Android Maven and Azure uploads
     - stage: build
-      # if: type = push
+      if: type = push
       os: linux
       dist: xenial
       addons:

--- a/build/ci.go
+++ b/build/ci.go
@@ -318,6 +318,7 @@ func localGoTool(goroot string, subcmd string, args ...string) *exec.Cmd {
 
 // goToolSetEnv forwards the build environment to the go tool.
 func goToolSetEnv(cmd *exec.Cmd) {
+	cmd.Env = append(cmd.Env, "GOBIN="+GOBIN)
 	for _, e := range os.Environ() {
 		if strings.HasPrefix(e, "GOBIN=") || strings.HasPrefix(e, "CC=") {
 			continue

--- a/build/ci.go
+++ b/build/ci.go
@@ -514,7 +514,7 @@ func doDebianSource(cmdline []string) {
 	gobundle := downloadGoSources(*cachedir)
 
 	// Download all the dependencies needed to build the sources and run the ci script
-	srcdepfetch := goTool("install", "-n", "./...")
+	srcdepfetch := goTool("mod", "download")
 	srcdepfetch.Env = append(os.Environ(), "GOPATH="+filepath.Join(*workdir, "modgopath"))
 	build.MustRun(srcdepfetch)
 

--- a/build/ci.go
+++ b/build/ci.go
@@ -259,6 +259,9 @@ func doInstall(cmdline []string) {
 	// Put the default settings in.
 	gobuild.Args = append(gobuild.Args, buildFlags(env)...)
 
+	// We use -trimpath to avoid leaking local paths into the built executables.
+	gobuild.Args = append(gobuild.Args, "-trimpath")
+
 	// Show packages during build.
 	gobuild.Args = append(gobuild.Args, "-v")
 
@@ -294,8 +297,6 @@ func buildFlags(env build.Environment) (flags []string) {
 	if len(ld) > 0 {
 		flags = append(flags, "-ldflags", strings.Join(ld, " "))
 	}
-	// We use -trimpath to avoid leaking local paths into the built executables.
-	flags = append(flags, "-trimpath")
 	return flags
 }
 

--- a/build/ci.go
+++ b/build/ci.go
@@ -243,7 +243,7 @@ func doInstall(cmdline []string) {
 	}
 
 	// Configure C compiler.
-	if *cc == "" {
+	if *cc != "" {
 		gobuild.Env = append(gobuild.Env, "CC="+*cc)
 	} else if os.Getenv("CC") != "" {
 		gobuild.Env = append(gobuild.Env, "CC="+os.Getenv("CC"))


### PR DESCRIPTION
This fixes cross-build and mobile framework failures.
It also disables the mac test builder because it was failing
all the time in hard to understand ways and we can't afford
it anymore under Travis CI's new pricing.