### PR TITLE
crypto/bn256: better comments for u, P and Order

### DIFF
--- a/crypto/bn256/google/constants.go
+++ b/crypto/bn256/google/constants.go
@@ -13,13 +13,14 @@ func bigFromBase10(s string) *big.Int {
 	return n
 }
 
-// u is the BN parameter that determines the prime: 1868033³.
+// u is the BN parameter that determines the prime.
 var u = bigFromBase10("4965661367192848881")
 
-// p is a prime over which we form a basic field: 36u⁴+36u³+24u²+6u+1.
+// P is a prime over which we form a basic field: 36u⁴+36u³+24u²+6u+1.
 var P = bigFromBase10("21888242871839275222246405745257275088696311157297823662689037894645226208583")
 
 // Order is the number of elements in both G₁ and G₂: 36u⁴+36u³+18u²+6u+1.
+// Order - 1 = 2^28 * 3^2 * 13 * 29 * 983 * 11003 * 237073 * 405928799 * 1670836401704629 * 13818364434197438864469338081.
 var Order = bigFromBase10("21888242871839275222246405745257275088548364400416034343698204186575808495617")
 
 // xiToPMinus1Over6 is ξ^((p-1)/6) where ξ = i+9.


### PR DESCRIPTION
Updates the comment for `u`. Previously the comment referred to the bn256 curve. However ethereum uses the alt_bn curve. 
Unfortunately `u` can not be put into a nice form of `u = x^3` as with the `u` used in bn256.

closes https://github.com/ethereum/go-ethereum/issues/21595