### PR TITLE
docs/vulnerabilities: vulnerability disclosure docs and json

### DIFF
--- a/docs/vulnerabilities/vulnerabilities.json
+++ b/docs/vulnerabilities/vulnerabilities.json
@@ -1,0 +1,61 @@
+[
+  {
+    "name": "CorruptedDAG",
+    "uid": "GETH-2020-01",
+    "summary": "Mining nodes will generate erroneous PoW on epochs > `385`.",
+    "description": "A mining flaw could cause miners to erroneously calculate PoW, due to an index overflow, if DAG size is exceeding the maximum 32 bit unsigned value.\n\nThis occurred on the ETC chain on 2020-11-06. This is likely to trigger for ETH mainnet around block `11550000`/epoch `385`, slated to occur early January 2021.\n\nThis issue is relevant only for miners, non-mining nodes are unaffected, since non-mining nodes use a smaller verification cache instead of a full DAG.",
+    "links": [
+      "https://github.com/ethereum/go-ethereum/pull/21793",
+      "https://blog.ethereum.org/2020/11/12/geth_security_release/",
+      "https://github.com/ethereum/go-ethereum/commit/567d41d9363706b4b13ce0903804e8acf214af49"
+    ],
+    "introduced": "v1.6.0",
+    "fixed": "v1.9.24",
+    "published": "2020-11-12",
+    "severity": "Medium",
+    "check": "Geth\\/v1\\.(6|7|8)\\..*|Geth\\/v1\\.9\\.2(1|2|3)-.*"
+  },
+  {
+    "name": "GoCrash",
+    "uid": "GETH-2020-02",
+    "summary": "A denial-of-service issue can be used to crash Geth nodes during block processing, due to an underlying bug in Go (CVE-2020-28362) versions < `1.15.5`, or `<1.14.12`",
+    "description": "The DoS issue can be used to crash all Geth nodes during block processing, the effects of which would be that a major part of the Ethereum network went offline.\n\nOutside of Go-Ethereum, the issue is most likely relevant for all forks of Geth (such as TurboGeth or ETC’s core-geth) which is built with versions of Go which contains the vulnerability.",
+    "links": [
+      "https://blog.ethereum.org/2020/11/12/geth_security_release/",
+      "https://groups.google.com/g/golang-announce/c/NpBGTTmKzpM",
+      "https://github.com/golang/go/issues/42552"
+    ],
+    "fixed": "v1.9.24",
+    "published": "2020-11-12",
+    "severity": "Critical",
+    "check": "Geth.*\\/go1\\.(11(.*)|12(.*)|13(.*)|14|14\\.(\\d|10|11|)|15|15\\.[0-4])$"
+  },
+  {
+    "name": "ShallowCopy",
+    "uid": "GETH-2020-03",
+    "summary": "A consensus flaw in Geth, related to `datacopy` precompile",
+    "description": "Geth erroneously performed a 'shallow' copy when the precompiled `datacopy` (at `0x00...04`) was invoked. An attacker could deploy a contract that uses the shallow copy to corrupt the contents of the `RETURNDATA`, thus causing a consensus failure.",
+    "links": [
+      "https://blog.ethereum.org/2020/11/12/geth_security_release/"
+    ],
+    "introduced": "v1.9.7",
+    "fixed": "v1.9.17",
+    "published": "2020-11-12",
+    "severity": "Critical",
+    "check": "Geth\\/v1\\.9\\.(7|8|9|10|11|12|13|14|15|16).*$"
+  },
+  {
+    "name": "GethCrash",
+    "uid": "GETH-2020-04",
+    "summary": "A denial-of-service issue can be used to crash Geth nodes during block processing",
+    "description": "Full details to be disclosed at a later date",
+    "links": [
+      "https://blog.ethereum.org/2020/11/12/geth_security_release/"
+    ],
+    "introduced": "v1.9.16",
+    "fixed": "v1.9.18",
+    "published": "2020-11-12",
+    "severity": "Critical",
+    "check": "Geth\\/v1\\.9.(16|17).*$"
+  }
+]

--- a/docs/vulnerabilities/vulnerabilities.md
+++ b/docs/vulnerabilities/vulnerabilities.md
@@ -11,7 +11,7 @@ Vulnerabilies can typically take two forms:
 2. Vulnerabilies that, if exploited, would harm the Ethereum mainnet. In the case of go-ethereum, examples would be: 
     - Consensus vulnerabilities, which would cause a chain split, 
     - Denial-of-service during block processing, whereby a malicious transaction could cause the geth-portion of the network to crash.  
-    - Denial-of-service via p2p networking, whereby portions of the network could be made inaccessible dur to crashes or resource consumption.
+    - Denial-of-service via p2p networking, whereby portions of the network could be made inaccessible due to crashes or resource consumption.
 
 Historically, vulnerabilities in `geth` predominantly been of the second type, where the health of the network is a concern, rather than individual node operators. 
 
@@ -20,14 +20,12 @@ For vulnerabilities in category `2` above, we reserve the right to silently patc
 ### Why silent patches
 
 In the case of Ethereum, it takes a lot of time (weeks, months) to get node operators to update even to a scheduled hard fork. 
-If we were to highlight that a release contains important consensus or DoS fixes, there is always a risk of someone trying to beat updaters 
-to the punch line and exploit the vulnerability. We do not strive for "security via obscurity", but delaying a potential attack 
-sufficiently to make the majority of node operators immune may be worth the temporary "hit" to transparency.
+If we were to highlight that a release contains important consensus or DoS fixes, there is always a risk of someone trying to beat 
+node operators to the punch, and exploit the vulnerability. Delaying a potential attack 
+sufficiently to make the majority of node operators immune may be worth the temporary loss of transparency.
 
-The primary goal for the Geth team is the health of the Ethereum network as a whole.
-
-The decision whether or not to publish details about a serious vulnerability boils down to what the 
-fallout would be in both cases and picking the one where the damage is smaller. 
+The primary goal for the Geth team is the health of the Ethereum network as a whole, and the decision whether or not to publish details about a serious vulnerability boils down 
+to minimizing the risk and/or impact of discovery and exploitation. 
 
 At certain times, it's better to remain silent as shown by other projects 
 too such as [Monero](https://www.getmonero.org/2017/05/17/disclosure-of-a-major-bug-in-cryptonote-based-currencies.html), 

--- a/docs/vulnerabilities/vulnerabilities.md
+++ b/docs/vulnerabilities/vulnerabilities.md
@@ -1,0 +1,79 @@
+## Vulnerability disclosures
+
+In the software world, it is expected for security vulnerabilities to be immediately announced, thus giving operators an opportunity to take protective measure against attackers. 
+
+Vulnerabilies can typically take two forms: 
+1. Bugs that, if exploited, would harm the software operator. In the case of go-ethereum, examples of such bugs would be:
+    - A bug that would allow remote reading or writing of OS files, or 
+    - Remote command execution, or
+    - Bugs that would leak cryptographic keys  
+2. Bugs that, if exploited, would harm the Ethereum mainnet. In the case of go-ethereum, such bugs would typically be: 
+    - Consensus vulnerabilities, which would cause a chain split, 
+    - Denial-of-service during block processing, whereby a malicious transaction could cause the geth-portion of the network to crash.  
+    - Denial-of-service via p2p networking, whereby portions of the network could be made inaccessible dur to crashes or resource consumption.
+
+Historically, vulnerabilities in `geth` predominantly been of the second type, where the health of the network is a concern, rather than individual node operators. 
+
+For bugs in category `2` above, we reserve the right to silently patch and ship fixes in new releases. 
+
+### Why silent patches
+
+In the case of Ethereum, it takes a lot of time (weeks, months) to get node operators to update even to a scheduled hard fork. 
+If we were to highlight that a release contains important consensus or DoS fixes, there is always a risk of someone trying to beat updaters 
+to the punch line and exploit the vulnerability. We do not strive for "security via obscurity", but delaying a potential attack 
+sufficiently to make the majority of node operators immune may be worth the temporary "hit" to transparency.
+
+The primary goal for the Geth team is the health of the Ethereum network as a whole.
+
+The decision whether or not to publish details about a serious bug boils down to what the 
+fallout would be in both cases and picking the one where the damage is smaller. 
+
+At certain times, it's better to remain silent as shown by other projects 
+too such as [Monero](https://www.getmonero.org/2017/05/17/disclosure-of-a-major-bug-in-cryptonote-based-currencies.html), 
+[ZCash](https://electriccoin.co/blog/zcash-counterfeiting-vulnerability-successfully-remediated/) and 
+[Bitcoin](https://www.coindesk.com/the-latest-bitcoin-bug-was-so-bad-developers-kept-its-full-details-a-secret).
+
+### Public transparency
+
+As of November 2020, our policy going forward is: 
+
+- If we silently fix and ship a vulnerability in release `X`, then, 
+- After 4-8 weeks, we will disclose that `X` contained a security-fix. 
+- After an additional 4-8 weeks, we will publish the details about the vulnerability.
+
+We hope that this provides sufficient balance between transparency versus the need for secrecy, and aids node operators and downstream projects
+ in keeping up to date with what versions to run on their infrastructure.
+
+In keeping with this policy, we have taken inspiration from [Solidity bug disclosure](https://solidity.readthedocs.io/en/develop/bugs.html) - see below.
+
+## Disclosed vulnerabilities
+
+In this folder, you can find a JSON-formatted list of some of the known security-relevant vulnerabilities concerning `geth`. 
+
+The file itself is hosted in the Github repository, on the `gh-pages`-branch. 
+The list was started in November 2020, and covers mainly `v1.9.7` and forward.
+
+The JSON file of known bugs below is a list of objects, one for each bug, with the following keys:
+
+- `name` 
+  - Unique name given to the bug.
+- `uid` 
+  - Unique identifier of the bug. Format `GETH-<year>-<sequential id>`
+- `summary`
+    - Short description of the bug.
+- `description`
+    - Detailed description of the bug.
+- `links`
+    - List of releavnt URLs with more detailed information (optional).
+- `introduced`
+    - The first published compiler version that contained the bug (optional).
+- `fixed`
+    - The first published compiler version that did not contain the bug anymore.
+- `published`
+    - The date at which the bug became known publicly (optional).
+- `severity`
+    - Severity of the bug: `low`, `medium`, `high`, `critical`. 
+    - Takes into account the severity of impact and likelihood of exploitation.
+- `check`
+    - This field contains a regular expression, which can be used against the reported `web3_clientVersion` of a node. If the check 
+    matches, the node is with a high likelyhood affected by the vulnerability.

--- a/docs/vulnerabilities/vulnerabilities.md
+++ b/docs/vulnerabilities/vulnerabilities.md
@@ -3,18 +3,19 @@
 In the software world, it is expected for security vulnerabilities to be immediately announced, thus giving operators an opportunity to take protective measure against attackers. 
 
 Vulnerabilies can typically take two forms: 
-1. Bugs that, if exploited, would harm the software operator. In the case of go-ethereum, examples of such bugs would be:
+
+1. Vulnerabilies that, if exploited, would harm the software operator. In the case of go-ethereum, examples would be:
     - A bug that would allow remote reading or writing of OS files, or 
     - Remote command execution, or
     - Bugs that would leak cryptographic keys  
-2. Bugs that, if exploited, would harm the Ethereum mainnet. In the case of go-ethereum, such bugs would typically be: 
+2. Vulnerabilies that, if exploited, would harm the Ethereum mainnet. In the case of go-ethereum, examples would be: 
     - Consensus vulnerabilities, which would cause a chain split, 
     - Denial-of-service during block processing, whereby a malicious transaction could cause the geth-portion of the network to crash.  
     - Denial-of-service via p2p networking, whereby portions of the network could be made inaccessible dur to crashes or resource consumption.
 
 Historically, vulnerabilities in `geth` predominantly been of the second type, where the health of the network is a concern, rather than individual node operators. 
 
-For bugs in category `2` above, we reserve the right to silently patch and ship fixes in new releases. 
+For vulnerabilities in category `2` above, we reserve the right to silently patch and ship fixes in new releases. 
 
 ### Why silent patches
 
@@ -25,7 +26,7 @@ sufficiently to make the majority of node operators immune may be worth the temp
 
 The primary goal for the Geth team is the health of the Ethereum network as a whole.
 
-The decision whether or not to publish details about a serious bug boils down to what the 
+The decision whether or not to publish details about a serious vulnerability boils down to what the 
 fallout would be in both cases and picking the one where the damage is smaller. 
 
 At certain times, it's better to remain silent as shown by other projects 
@@ -53,27 +54,27 @@ In this folder, you can find a JSON-formatted list of some of the known security
 The file itself is hosted in the Github repository, on the `gh-pages`-branch. 
 The list was started in November 2020, and covers mainly `v1.9.7` and forward.
 
-The JSON file of known bugs below is a list of objects, one for each bug, with the following keys:
+The JSON file of known vulnerabilities below is a list of objects, one for each vulnerability, with the following keys:
 
 - `name` 
-  - Unique name given to the bug.
+  - Unique name given to the vulnerability.
 - `uid` 
-  - Unique identifier of the bug. Format `GETH-<year>-<sequential id>`
+  - Unique identifier of the vulnerability. Format `GETH-<year>-<sequential id>`
 - `summary`
-    - Short description of the bug.
+  - Short description of the vulnerability.
 - `description`
-    - Detailed description of the bug.
+  - Detailed description of the vulnerability.
 - `links`
-    - List of releavnt URLs with more detailed information (optional).
+  - List of relevant URLs with more detailed information (optional).
 - `introduced`
-    - The first published compiler version that contained the bug (optional).
+  - The first published Geth version that contained the vulnerability (optional).
 - `fixed`
-    - The first published compiler version that did not contain the bug anymore.
+  - The first published Geth version that did not contain the vulnerability anymore.
 - `published`
-    - The date at which the bug became known publicly (optional).
+  - The date at which the vulnerability became known publicly (optional).
 - `severity`
-    - Severity of the bug: `low`, `medium`, `high`, `critical`. 
-    - Takes into account the severity of impact and likelihood of exploitation.
+  - Severity of the vulnerability: `low`, `medium`, `high`, `critical`. 
+  - Takes into account the severity of impact and likelihood of exploitation.
 - `check`
-    - This field contains a regular expression, which can be used against the reported `web3_clientVersion` of a node. If the check 
+  - This field contains a regular expression, which can be used against the reported `web3_clientVersion` of a node. If the check 
     matches, the node is with a high likelyhood affected by the vulnerability.


### PR DESCRIPTION
This PR contains a document describing a proposed disclosure policy, along with a machine-readable json-file with vulnerability disclosures. 

The idea is to publish this on our github pages. After that, 

- We can add some optional geth self-check, e.g. `geth selfcheck` which could check if the node is vulnerable to any known vulnerabilities, 
- We can add checks on https://forkmon.ethdevops.io/, to show information about nodes which suffers from vulnerabilities, 
- We can add information on the download-page, by flagging versions with known vulnerabilities. 

