### PR TITLE
crypto/bn256: fix bn256Mul fuzzer to not hang on large input

### DIFF
--- a/crypto/bn256/bn256_fuzz.go
+++ b/crypto/bn256/bn256_fuzz.go
@@ -81,7 +81,7 @@ func FuzzMul(data []byte) int {
 		return 0
 	}
 	if remaining > 128 {
-		// The evm only every uses 32 byte integers, we need to cap this otherwise
+		// The evm only ever uses 32 byte integers, we need to cap this otherwise
 		// we run into slow exec. A 236Kb byte integer cause oss-fuzz to report it as slow.
 		// 128 bytes should be fine though
 		return 0

--- a/crypto/bn256/bn256_fuzz.go
+++ b/crypto/bn256/bn256_fuzz.go
@@ -80,6 +80,12 @@ func FuzzMul(data []byte) int {
 	if remaining == 0 {
 		return 0
 	}
+	if remaining > 128 {
+		// The evm only every uses 32 byte integers, we need to cap this otherwise
+		// we run into slow exec. A 236Kb byte integer cause oss-fuzz to report it as slow.
+		// 128 bytes should be fine though
+		return 0
+	}
 	buf := make([]byte, remaining)
 	input.Read(buf)
 


### PR DESCRIPTION
The bn256 multiplication was unbounded, which caused the oss-fuzz executor to multiply for 30 seconds before exiting. Let's avoid that