### PR TITLE
doc: clarify abigen alias flag usage

### DIFF
--- a/cmd/abigen/main.go
+++ b/cmd/abigen/main.go
@@ -96,7 +96,7 @@ var (
 	}
 	aliasFlag = cli.StringFlag{
 		Name:  "alias",
-		Usage: "Comma separated aliases for function and event renaming, e.g. foo=bar",
+		Usage: "Comma separated aliases for function and event renaming, e.g. foo=_foo, bar=_bar",
 	}
 )
 

--- a/cmd/abigen/main.go
+++ b/cmd/abigen/main.go
@@ -96,7 +96,7 @@ var (
 	}
 	aliasFlag = cli.StringFlag{
 		Name:  "alias",
-		Usage: "Comma separated aliases for function and event renaming, e.g. foo=_foo, bar=_bar",
+		Usage: "Comma separated aliases for function and event renaming, e.g. original1=alias1, original2=alias2",
 	}
 )
 


### PR DESCRIPTION
update the `abigen --alias` flag help info, give an example to make it more clear

related issue: https://github.com/ethereum/go-ethereum/issues/21846
closes: https://github.com/ethereum/go-ethereum/issues/21846