### PR TITLE
cmd/geth: add dbstats command

### DIFF
--- a/cmd/geth/chaincmd.go
+++ b/cmd/geth/chaincmd.go
@@ -34,6 +34,7 @@ import (
 	"github.com/ethereum/go-ethereum/core/state"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/eth/downloader"
+	"github.com/ethereum/go-ethereum/ethdb/leveldb"
 	"github.com/ethereum/go-ethereum/event"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/metrics"
@@ -216,6 +217,20 @@ Use "ethereum dump 0" to dump the genesis block.`,
 			utils.YoloV2Flag,
 			utils.LegacyTestnetFlag,
 			utils.SyncModeFlag,
+		},
+		Category: "BLOCKCHAIN COMMANDS",
+	}
+	statDbCommand = cli.Command{
+		Action:    utils.MigrateFlags(statDb),
+		Name:      "dbstats",
+		Usage:     "Print stats about the leveldb database",
+		ArgsUsage: " ",
+		Flags: []cli.Flag{
+			utils.DataDirFlag,
+			utils.CacheFlag,
+			utils.RopstenFlag,
+			utils.RinkebyFlag,
+			utils.GoerliFlag,
 		},
 		Category: "BLOCKCHAIN COMMANDS",
 	}
@@ -604,6 +619,23 @@ func inspect(ctx *cli.Context) error {
 	defer chainDb.Close()
 
 	return rawdb.InspectDatabase(chainDb)
+}
+
+func statDb(ctx *cli.Context) error {
+	stack, _ := makeConfigNode(ctx)
+	defer stack.Close()
+	path := stack.ResolvePath("chaindata")
+	db, err := leveldb.New(path, 1024, 1000, "")
+	if err != nil {
+		return err
+	}
+	log.Info("Checking stats")
+	stats, err := db.Stat("leveldb.stats")
+	if err != nil {
+		return err
+	}
+	fmt.Println(stats)
+	return nil
 }
 
 // hashish returns true for strings that look like hashes.

--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -231,6 +231,7 @@ func init() {
 		dumpCommand,
 		dumpGenesisCommand,
 		inspectCommand,
+		statDbCommand,
 		// See accountcmd.go:
 		accountCommand,
 		walletCommand,

--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -232,6 +232,7 @@ func init() {
 		dumpGenesisCommand,
 		inspectCommand,
 		statDbCommand,
+		compactDbCommand,
 		// See accountcmd.go:
 		accountCommand,
 		walletCommand,


### PR DESCRIPTION
Small wip/poc PR that makes it possible to dump out the leveldb statistics. Might be useful for analyzing errors, e.g https://github.com/ethereum/go-ethereum/issues/21809 and https://github.com/syndtr/goleveldb/issues/346

Usage examples: 
```
[user@work go-ethereum]$ ./build/bin/geth --goerli dbstats
INFO [11-22|10:26:23.066] Maximum peer count                       ETH=50 LES=0 total=50
INFO [11-22|10:26:23.066] Smartcard socket not found, disabling    err="stat /run/pcscd/pcscd.comm: no such file or directory"
ERROR[11-22|10:26:23.077] Failed to enumerate USB devices          hub=ledger vendor=11415 failcount=1 err="failed to initialize libusb: libusb: unknown error [code -99]"
ERROR[11-22|10:26:23.077] Failed to enumerate USB devices          hub=trezor vendor=21324 failcount=1 err="failed to initialize libusb: libusb: unknown error [code -99]"
ERROR[11-22|10:26:23.077] Failed to enumerate USB devices          hub=trezor vendor=4617  failcount=1 err="failed to initialize libusb: libusb: unknown error [code -99]"
ERROR[11-22|10:26:23.077] Failed to enumerate USB devices          hub=ledger vendor=11415 failcount=2 err="failed to initialize libusb: libusb: unknown error [code -99]"
ERROR[11-22|10:26:23.077] Failed to enumerate USB devices          hub=trezor vendor=21324 failcount=2 err="failed to initialize libusb: libusb: unknown error [code -99]"
ERROR[11-22|10:26:23.077] Failed to enumerate USB devices          hub=trezor vendor=4617  failcount=2 err="failed to initialize libusb: libusb: unknown error [code -99]"
INFO [11-22|10:26:23.078] Set global gas cap                       cap=25000000
INFO [11-22|10:26:23.078] Allocated cache and file handles         database=/home/user/.ethereum/goerli/geth/chaindata cache=1024.00MiB handles=1000
INFO [11-22|10:26:23.120] Checking stats 
Compactions
 Level |   Tables   |    Size(MB)   |    Time(sec)  |    Read(MB)   |   Write(MB)
-------+------------+---------------+---------------+---------------+---------------
   1   |         22 |      42.68468 |       0.00000 |       0.00000 |       0.00000
-------+------------+---------------+---------------+---------------+---------------
 Total |         22 |      42.68468 |       0.00000 |       0.00000 |       0.00000

```
```
[user@work go-ethereum]$ ./build/bin/geth --nousb dbstats
INFO [11-22|10:28:21.239] Maximum peer count                       ETH=50 LES=0 total=50
INFO [11-22|10:28:21.239] Smartcard socket not found, disabling    err="stat /run/pcscd/pcscd.comm: no such file or directory"
INFO [11-22|10:28:21.240] Set global gas cap                       cap=25000000
INFO [11-22|10:28:21.240] Allocated cache and file handles         database=/home/user/.ethereum/geth/chaindata cache=1024.00MiB handles=1000
INFO [11-22|10:28:21.278] Checking stats 
Compactions
 Level |   Tables   |    Size(MB)   |    Time(sec)  |    Read(MB)   |   Write(MB)
-------+------------+---------------+---------------+---------------+---------------
   0   |          2 |       0.00097 |       0.00000 |       0.00000 |       0.00000
   3   |        322 |     644.93655 |       0.00000 |       0.00000 |       0.00000
-------+------------+---------------+---------------+---------------+---------------
 Total |        324 |     644.93752 |       0.00000 |       0.00000 |       0.00000

[user@work go-ethereum]$ 
```
