### PR TITLE
github: Add new style of issue-templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -1,8 +1,10 @@
-Hi there,
-
-Please note that this is an issue tracker reserved for bug reports and feature requests.
-
-For general questions please use [discord](https://discord.gg/nthXNEv) or the Ethereum stack exchange at https://ethereum.stackexchange.com.
+---
+name: Report a bug
+about: Something with go-ethereum is not working as expected
+title: ''
+labels: 'type:bug'
+assignees: ''
+---
 
 #### System information
 

--- a/.github/ISSUE_TEMPLATE/feature.md
+++ b/.github/ISSUE_TEMPLATE/feature.md
@@ -1,0 +1,17 @@
+---
+name: Request a feature
+about: Report a missing feature - e.g. as a step before submitting a PR
+title: ''
+labels: 'type:feature'
+assignees: ''
+---
+
+# Rationale
+
+Why should this feature exist?
+What are the use-cases?
+
+# Implementation
+
+Do you have ideas regarding the implementation of this feature?
+Are you willing to implement this feature?

--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -1,0 +1,9 @@
+---
+name: Ask a question
+about: Something is unclear
+title: ''
+labels: 'type:docs'
+assignees: ''
+---
+
+This should only be used in very rare cases e.g. if you are not 100% sure if something is a bug or asking a question that leads to improving the documentation. For general questions please use [discord](https://discord.gg/nthXNEv) or the Ethereum stack exchange at https://ethereum.stackexchange.com.

--- a/.github/ISSUE_TEMPLATE/vulnerability.md
+++ b/.github/ISSUE_TEMPLATE/vulnerability.md
@@ -1,0 +1,13 @@
+---
+name: Report a vulnerability
+about: There is a bug in go-ethereum that can be exploited
+title: ''
+labels: 'type:security'
+assignees: ''
+---
+
+Please do not submit these in this public issue tracker!
+
+To find out how to disclose a vulnerability in Ethereum visit https://bounty.ethereum.org or email bounty@ethereum.org.
+
+Please read [Reporting a vulnerability](https://github.com/ethereum/go-ethereum/security/policy#reporting-a-vulnerability) for more information.


### PR DESCRIPTION
Removes this warning:

![Selection_293](https://user-images.githubusercontent.com/111600/99961265-60594080-2d8e-11eb-9ce8-c1dc1b25d9b8.png)

Also might guide some people that might not be aware to https://bounty.ethereum.org in case of a vulnerability.
And sets some labels automatically.

closes #20024