### PR TITLE
eth: check totaldifficulty in read status

### DIFF
--- a/eth/peer.go
+++ b/eth/peer.go
@@ -625,6 +625,11 @@ func (p *peer) Handshake(network uint64, td *big.Int, head common.Hash, genesis 
 	default:
 		panic(fmt.Sprintf("unsupported eth protocol version: %d", p.version))
 	}
+	// TD at mainnet block #7753254 is 76 bits. If it becomes 100 million times
+	// larger, it will still fit within 100 bits
+	if tdlen := p.td.BitLen(); tdlen > 100 {
+		return fmt.Errorf("too large block TD: bitlen %d", tdlen)
+	}
 	return nil
 }
 


### PR DESCRIPTION
Perform the same check on total difficulty during the handshake that we already do if we receive a block
see `eth/protocol.go:208`

Without this check it is possible to fill the log of nodes started with log level Debug with multiple MB of logs as the total difficulty gets logged. Also we are otherwise going to start the sync process (which fails of course) but nevertheless we can assume peers that advertise such large total difficulty to be bogus