### PR TITLE
[WIP] graphql: gas-related queries use `Long` instead of hex string

### DIFF
--- a/graphql/graphql.go
+++ b/graphql/graphql.go
@@ -43,10 +43,6 @@ var (
 
 type Long uint64
 
-func (b Long) String() string {
-	return string(b)
-}
-
 // ImplementsGraphQLType returns true if Long implements the provided GraphQL type.
 func (b Long) ImplementsGraphQLType(name string) bool { return name == "Long" }
 
@@ -445,7 +441,7 @@ func (b *Block) resolveReceipts(ctx context.Context) ([]*types.Receipt, error) {
 func (b *Block) Number(ctx context.Context) (Long, error) {
 	header, err := b.resolveHeader(ctx)
 	if err != nil {
-		return 0, err
+		return Long(0), err
 	}
 
 	return Long(header.Number.Uint64()), nil

--- a/graphql/graphql.go
+++ b/graphql/graphql.go
@@ -41,7 +41,7 @@ var (
 	errBlockInvariant = errors.New("block objects must be instantiated with at least one of num or hash")
 )
 
-type Long uint64
+type Long int64
 
 // ImplementsGraphQLType returns true if Long implements the provided GraphQL type.
 func (b Long) ImplementsGraphQLType(name string) bool { return name == "Long" }
@@ -51,10 +51,20 @@ func (b *Long) UnmarshalGraphQL(input interface{}) error {
 	var err error
 	switch input := input.(type) {
 	case string:
-		value, err := strconv.ParseUint(input, 10, 64)
+		// uncomment to support hex values
+		//if strings.HasPrefix(input, "0x") {
+		//	// apply leniency and support hex representations of longs.
+		//	value, err := hexutil.DecodeUint64(input)
+		//	*b = Long(value)
+		//	return err
+		//} else {
+		value, err := strconv.ParseInt(input, 10, 64)
 		*b = Long(value)
 		return err
+		//}
 	case int32:
+		*b = Long(input)
+	case int64:
 		*b = Long(input)
 	default:
 		err = fmt.Errorf("unexpected type %T for Long", input)
@@ -925,7 +935,7 @@ type Resolver struct {
 }
 
 func (r *Resolver) Block(ctx context.Context, args struct {
-	Number *int64
+	Number *Long
 	Hash   *common.Hash
 }) (*Block, error) {
 	var block *Block

--- a/graphql/graphql.go
+++ b/graphql/graphql.go
@@ -301,21 +301,21 @@ func (t *Transaction) Status(ctx context.Context) (*hexutil.Uint64, error) {
 	return &ret, nil
 }
 
-func (t *Transaction) GasUsed(ctx context.Context) (*hexutil.Uint64, error) {
+func (t *Transaction) GasUsed(ctx context.Context) (*Long, error) {
 	receipt, err := t.getReceipt(ctx)
 	if err != nil || receipt == nil {
 		return nil, err
 	}
-	ret := hexutil.Uint64(receipt.GasUsed)
+	ret := Long(receipt.GasUsed)
 	return &ret, nil
 }
 
-func (t *Transaction) CumulativeGasUsed(ctx context.Context) (*hexutil.Uint64, error) {
+func (t *Transaction) CumulativeGasUsed(ctx context.Context) (*Long, error) {
 	receipt, err := t.getReceipt(ctx)
 	if err != nil || receipt == nil {
 		return nil, err
 	}
-	ret := hexutil.Uint64(receipt.CumulativeGasUsed)
+	ret := Long(receipt.CumulativeGasUsed)
 	return &ret, nil
 }
 
@@ -811,7 +811,7 @@ type CallData struct {
 // CallResult encapsulates the result of an invocation of the `call` accessor.
 type CallResult struct {
 	data    hexutil.Bytes  // The return data from the call
-	gasUsed hexutil.Uint64 // The amount of gas used
+	gasUsed Long // The amount of gas used
 	status  hexutil.Uint64 // The return status of the call - 0 for failure or 1 for success.
 }
 
@@ -819,7 +819,7 @@ func (c *CallResult) Data() hexutil.Bytes {
 	return c.data
 }
 
-func (c *CallResult) GasUsed() hexutil.Uint64 {
+func (c *CallResult) GasUsed() Long {
 	return c.gasUsed
 }
 
@@ -847,22 +847,22 @@ func (b *Block) Call(ctx context.Context, args struct {
 
 	return &CallResult{
 		data:    result.ReturnData,
-		gasUsed: hexutil.Uint64(result.UsedGas),
+		gasUsed: Long(result.UsedGas),
 		status:  status,
 	}, nil
 }
 
 func (b *Block) EstimateGas(ctx context.Context, args struct {
 	Data ethapi.CallArgs
-}) (hexutil.Uint64, error) {
+}) (Long, error) {
 	if b.numberOrHash == nil {
 		_, err := b.resolveHeader(ctx)
 		if err != nil {
-			return hexutil.Uint64(0), err
+			return 0, err
 		}
 	}
 	gas, err := ethapi.DoEstimateGas(ctx, b.backend, args.Data, *b.numberOrHash, b.backend.RPCGasCap())
-	return gas, err
+	return Long(gas), err
 }
 
 type Pending struct {
@@ -917,16 +917,17 @@ func (p *Pending) Call(ctx context.Context, args struct {
 
 	return &CallResult{
 		data:    result.ReturnData,
-		gasUsed: hexutil.Uint64(result.UsedGas),
+		gasUsed: Long(result.UsedGas),
 		status:  status,
 	}, nil
 }
 
 func (p *Pending) EstimateGas(ctx context.Context, args struct {
 	Data ethapi.CallArgs
-}) (hexutil.Uint64, error) {
+}) (Long, error) {
 	pendingBlockNr := rpc.BlockNumberOrHashWithNumber(rpc.PendingBlockNumber)
-	return ethapi.DoEstimateGas(ctx, p.backend, args.Data, pendingBlockNr, p.backend.RPCGasCap())
+	gas, err := ethapi.DoEstimateGas(ctx, p.backend, args.Data, pendingBlockNr, p.backend.RPCGasCap())
+	return Long(gas), err
 }
 
 // Resolver is the top-level object in the GraphQL hierarchy.

--- a/graphql/graphql.go
+++ b/graphql/graphql.go
@@ -441,7 +441,7 @@ func (b *Block) resolveReceipts(ctx context.Context) ([]*types.Receipt, error) {
 func (b *Block) Number(ctx context.Context) (Long, error) {
 	header, err := b.resolveHeader(ctx)
 	if err != nil {
-		return Long(0), err
+		return 0, err
 	}
 
 	return Long(header.Number.Uint64()), nil

--- a/graphql/graphql.go
+++ b/graphql/graphql.go
@@ -925,7 +925,7 @@ type Resolver struct {
 }
 
 func (r *Resolver) Block(ctx context.Context, args struct {
-	Number *Long
+	Number *int64
 	Hash   *common.Hash
 }) (*Block, error) {
 	var block *Block

--- a/graphql/graphql.go
+++ b/graphql/graphql.go
@@ -41,7 +41,11 @@ var (
 	errBlockInvariant = errors.New("block objects must be instantiated with at least one of num or hash")
 )
 
-type Long int64
+type Long uint64
+
+func (b Long) String() string {
+	return string(b)
+}
 
 // ImplementsGraphQLType returns true if Long implements the provided GraphQL type.
 func (b Long) ImplementsGraphQLType(name string) bool { return name == "Long" }
@@ -51,20 +55,10 @@ func (b *Long) UnmarshalGraphQL(input interface{}) error {
 	var err error
 	switch input := input.(type) {
 	case string:
-		// uncomment to support hex values
-		//if strings.HasPrefix(input, "0x") {
-		//	// apply leniency and support hex representations of longs.
-		//	value, err := hexutil.DecodeUint64(input)
-		//	*b = Long(value)
-		//	return err
-		//} else {
-		value, err := strconv.ParseInt(input, 10, 64)
+		value, err := strconv.ParseUint(input, 10, 64)
 		*b = Long(value)
 		return err
-		//}
 	case int32:
-		*b = Long(input)
-	case int64:
 		*b = Long(input)
 	default:
 		err = fmt.Errorf("unexpected type %T for Long", input)

--- a/graphql/graphql_test.go
+++ b/graphql/graphql_test.go
@@ -29,7 +29,6 @@ import (
 	"github.com/ethereum/go-ethereum/core"
 	"github.com/ethereum/go-ethereum/eth"
 	"github.com/ethereum/go-ethereum/node"
-	"github.com/ethereum/go-ethereum/params"
 )
 
 func TestBuildSchema(t *testing.T) {
@@ -139,56 +138,6 @@ func TestGraphQLBlockSerialization(t *testing.T) {
 	assert.Equal(t, expected, string(bodyBytes))
 }
 
-// Tests that a graphQL request is successfully handled when graphql is enabled on the specified endpoint
-func TestGraphQLBlockSerialization(t *testing.T) {
-	stack := createNode(t, true)
-	defer stack.Close()
-	// start node
-	if err := stack.Start(); err != nil {
-		t.Fatalf("could not start node: %v", err)
-	}
-	// create http request
-	body := strings.NewReader("{\"query\": \"{block{number,gasUsed,gasLimit}}\",\"variables\": null}")
-	gqlReq, err := http.NewRequest(http.MethodGet, fmt.Sprintf("http://%s/graphql", "127.0.0.1:9393"), body)
-	if err != nil {
-		t.Error("could not issue new http request ", err)
-	}
-	gqlReq.Header.Set("Content-Type", "application/json")
-	// read from response
-	resp := doHTTPRequest(t, gqlReq)
-	bodyBytes, err := ioutil.ReadAll(resp.Body)
-	if err != nil {
-		t.Fatalf("could not read from response body: %v", err)
-	}
-	expected := "{\"data\":{\"block\":{\"number\":0,\"gasUsed\":0,\"gasLimit\":11500000}}}"
-	assert.Equal(t, expected, string(bodyBytes))
-}
-
-// Tests that a graphQL request with a stringified block number returns an error.
-func TestGraphQLBlockSerializationZeroString(t *testing.T) {
-	stack := createNode(t, true)
-	defer stack.Close()
-	// start node
-	if err := stack.Start(); err != nil {
-		t.Fatalf("could not start node: %v", err)
-	}
-	// create http request
-	body := strings.NewReader(`{"query": "{block(number:\"0\"){number,gasUsed,gasLimit}}","variables": null}`)
-	gqlReq, err := http.NewRequest(http.MethodGet, fmt.Sprintf("http://%s/graphql", "127.0.0.1:9393"), body)
-	if err != nil {
-		t.Error("could not issue new http request ", err)
-	}
-	gqlReq.Header.Set("Content-Type", "application/json")
-	// read from response
-	resp := doHTTPRequest(t, gqlReq)
-	bodyBytes, err := ioutil.ReadAll(resp.Body)
-	if err != nil {
-		t.Fatalf("could not read from response body: %v", err)
-	}
-	expected := "{\"errors\":[{\"message\":\"could not unmarshal \\\"0\\\" (string) into int64: incompatible type\"}],\"data\":{}}"
-	assert.Equal(t, expected, string(bodyBytes))
-}
-
 // Tests that a graphQL request is not handled successfully when graphql is not enabled on the specified endpoint
 func TestGraphQLHTTPOnSamePort_GQLRequest_Unsuccessful(t *testing.T) {
 	stack := createNode(t, false)
@@ -198,9 +147,7 @@ func TestGraphQLHTTPOnSamePort_GQLRequest_Unsuccessful(t *testing.T) {
 	}
 	body := strings.NewReader(`{"query": "{block{number}}","variables": null}`)
 	resp, err := http.Post(fmt.Sprintf("http://%s/graphql", "127.0.0.1:9393"), "application/json", body)
-	if err != nil {
-		t.Fatalf("could not post: %v", err)
-	}
+
 	bodyBytes, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		t.Fatalf("could not read from response body: %v", err)

--- a/graphql/graphql_test.go
+++ b/graphql/graphql_test.go
@@ -143,7 +143,9 @@ func TestGraphQLHTTPOnSamePort_GQLRequest_Unsuccessful(t *testing.T) {
 	}
 	body := strings.NewReader(`{"query": "{block{number}}","variables": null}`)
 	resp, err := http.Post(fmt.Sprintf("http://%s/graphql", "127.0.0.1:9393"), "application/json", body)
-
+	if err != nil {
+		t.Fatalf("could not post: %v", err)
+	}
 	bodyBytes, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		t.Fatalf("could not read from response body: %v", err)

--- a/graphql/graphql_test.go
+++ b/graphql/graphql_test.go
@@ -135,6 +135,31 @@ func TestGraphQLBlockSerialization(t *testing.T) {
 	}
 }
 
+// Tests that a graphQL request is successfully handled when graphql is enabled on the specified endpoint
+func TestGraphQLBlockSerialization(t *testing.T) {
+	stack := createNode(t, true)
+	defer stack.Close()
+	// start node
+	if err := stack.Start(); err != nil {
+		t.Fatalf("could not start node: %v", err)
+	}
+	// create http request
+	body := strings.NewReader("{\"query\": \"{block{number,gasUsed,gasLimit}}\",\"variables\": null}")
+	gqlReq, err := http.NewRequest(http.MethodGet, fmt.Sprintf("http://%s/graphql", "127.0.0.1:9393"), body)
+	if err != nil {
+		t.Error("could not issue new http request ", err)
+	}
+	gqlReq.Header.Set("Content-Type", "application/json")
+	// read from response
+	resp := doHTTPRequest(t, gqlReq)
+	bodyBytes, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("could not read from response body: %v", err)
+	}
+	expected := "{\"data\":{\"block\":{\"number\":\"0x0\",\"gasUsed\":0,\"gasLimit\":5000}}}"
+	assert.Equal(t, expected, string(bodyBytes))
+}
+
 // Tests that a graphQL request is not handled successfully when graphql is not enabled on the specified endpoint
 func TestGraphQLHTTPOnSamePort_GQLRequest_Unsuccessful(t *testing.T) {
 	stack := createNode(t, false)

--- a/graphql/graphql_test.go
+++ b/graphql/graphql_test.go
@@ -132,10 +132,6 @@ func TestGraphQLBlockSerialization(t *testing.T) {
 			t.Errorf("testcase %d %s,\nwrong statuscode, have: %v, want: %v", i, tt.body, resp.StatusCode, tt.code)
 		}
 	}
-
-	expected := "{\"data\":{\"block\":{\"number\":0}}}"
-	assert.Equal(t, 200, resp.StatusCode)
-	assert.Equal(t, expected, string(bodyBytes))
 }
 
 // Tests that a graphQL request is not handled successfully when graphql is not enabled on the specified endpoint

--- a/graphql/graphql_test.go
+++ b/graphql/graphql_test.go
@@ -133,6 +133,10 @@ func TestGraphQLBlockSerialization(t *testing.T) {
 			t.Errorf("testcase %d %s,\nwrong statuscode, have: %v, want: %v", i, tt.body, resp.StatusCode, tt.code)
 		}
 	}
+
+	expected := "{\"data\":{\"block\":{\"number\":0}}}"
+	assert.Equal(t, 200, resp.StatusCode)
+	assert.Equal(t, expected, string(bodyBytes))
 }
 
 // Tests that a graphQL request is successfully handled when graphql is enabled on the specified endpoint
@@ -156,7 +160,7 @@ func TestGraphQLBlockSerialization(t *testing.T) {
 	if err != nil {
 		t.Fatalf("could not read from response body: %v", err)
 	}
-	expected := "{\"data\":{\"block\":{\"number\":\"0x0\",\"gasUsed\":0,\"gasLimit\":5000}}}"
+	expected := "{\"data\":{\"block\":{\"number\":0,\"gasUsed\":0,\"gasLimit\":11500000}}}"
 	assert.Equal(t, expected, string(bodyBytes))
 }
 

--- a/graphql/graphql_test.go
+++ b/graphql/graphql_test.go
@@ -18,6 +18,7 @@ package graphql
 
 import (
 	"fmt"
+	"github.com/ethereum/go-ethereum/params"
 	"io/ioutil"
 	"math/big"
 	"net/http"

--- a/graphql/graphql_test.go
+++ b/graphql/graphql_test.go
@@ -18,7 +18,6 @@ package graphql
 
 import (
 	"fmt"
-	"github.com/ethereum/go-ethereum/params"
 	"io/ioutil"
 	"math/big"
 	"net/http"
@@ -30,6 +29,7 @@ import (
 	"github.com/ethereum/go-ethereum/core"
 	"github.com/ethereum/go-ethereum/eth"
 	"github.com/ethereum/go-ethereum/node"
+	"github.com/ethereum/go-ethereum/params"
 )
 
 func TestBuildSchema(t *testing.T) {


### PR DESCRIPTION
- `estimateGas`
- `cumulativeGas`