### PR TITLE
rpc: fixed flaky test

### DIFF
--- a/rpc/client_test.go
+++ b/rpc/client_test.go
@@ -593,9 +593,9 @@ func httpTestClient(srv *Server, transport string, fl *flakeyListener) (*Client,
 		fl.Listener = hs.Listener
 		hs.Listener = fl
 	}
-	// Start the server
+	// Start the server.
 	hs.Start()
-	// Wait till the listener was scheduled
+	// Wait till the listener was scheduled.
 	time.Sleep(100 + time.Millisecond)
 	// Connect the client.
 	client, err := Dial(transport + "://" + hs.Listener.Addr().String())

--- a/rpc/client_test.go
+++ b/rpc/client_test.go
@@ -593,8 +593,11 @@ func httpTestClient(srv *Server, transport string, fl *flakeyListener) (*Client,
 		fl.Listener = hs.Listener
 		hs.Listener = fl
 	}
-	// Connect the client.
+	// Start the server
 	hs.Start()
+	// Wait till the listener was scheduled
+	time.Sleep(100 + time.Millisecond)
+	// Connect the client.
 	client, err := Dial(transport + "://" + hs.Listener.Addr().String())
 	if err != nil {
 		panic(err)


### PR DESCRIPTION
I'm not sure if this fixes the flaky test, but my hunch is that the listener routine was not scheduled before the client dials
rel #21922 

