### PR TITLE
p2p/nodestate: fix deadlock

### DIFF
--- a/p2p/nodestate/nodestate.go
+++ b/p2p/nodestate/nodestate.go
@@ -725,7 +725,7 @@ func (ns *NodeStateMachine) opFinish() {
 	}
 	ns.opPending = nil
 	ns.opFlag = false
-	ns.opWait.Signal()
+	ns.opWait.Broadcast()
 }
 
 // Operation calls the given function as an operation callback. This allows the caller


### PR DESCRIPTION
This PR fixes a deadlock reported here: https://github.com/ethereum/go-ethereum/issues/21925

The cause is that many operations may be pending, but if the close happens, only one of them gets awoken and exits, the others remain waiting for a signal that never comes. 

Here's a pretty crappy test that hangs on `master` but works fine with this patch, and demonstrates this behaviour. It needs to be fixed up to be less chronistic (channel-based?) if we want to get the test in also: 
```golang
func TestDeadlock(t *testing.T) {

	mdb, clock := rawdb.NewMemoryDatabase(), &mclock.Simulated{}

	s, _, _ := testSetup([]bool{false, false, false, false}, nil)
	ns := NewNodeStateMachine(mdb, []byte("-ns"), clock, s)
	ns.Start()
	startedCh := make(chan bool)
	// some operation takes a lot of time
	go func() {
		err := ns.Operation(func() {
			close(startedCh)
			fmt.Printf("Long running op started\n")
			// Wait here until someone signals us to go ahead
			time.Sleep(1 * time.Second)
			//<- aChan
			fmt.Printf("Long running op ended\n")
		})
		if err != nil {
			t.Fatalf("error in test: %v", err)
		}
	}()
	<-startedCh
	var wg sync.WaitGroup
	// The long-running op is now executing.
	// While that's happening, four other guys wants to do sometihng
	wg.Add(4)
	for i := 0; i < 4; i++ {
		go func(i int) {
			fmt.Printf("Calling setfield (id %d)\n", i)
			ns.SetField(testNode(byte(i)), Field{}, nil)
			fmt.Printf("Ok, exiting now (id %d)\n", i)
			wg.Done()
		}(i)
	}
	// We stop the node machine
	fmt.Printf("Stopping the node machine\n")
	ns.Stop()
	fmt.Printf("Node machine stopped\n")
	wg.Wait()
	fmt.Printf("all done\n")
}
```