### PR TITLE
tests/fuzzers: add nodestatemachine fuzzer (wip)

### DIFF
--- a/tests/fuzzers/nodestatemachine/debug/main.go
+++ b/tests/fuzzers/nodestatemachine/debug/main.go
@@ -1,0 +1,41 @@
+// Copyright 2020 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+package main
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+
+	"github.com/ethereum/go-ethereum/tests/fuzzers/nodestatemachine"
+)
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintf(os.Stderr, "Usage: debug <file>\n")
+		fmt.Fprintf(os.Stderr, "Example\n")
+		fmt.Fprintf(os.Stderr, "	$ debug ../crashers/4bbef6857c733a87ecf6fd8b9e7238f65eb9862a\n")
+		os.Exit(1)
+	}
+	crasher := os.Args[1]
+	data, err := ioutil.ReadFile(crasher)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error loading crasher %v: %v", crasher, err)
+		os.Exit(1)
+	}
+	nodestatemachine.Fuzz(data)
+}

--- a/tests/fuzzers/nodestatemachine/nodestatemachine-fuzzer.go
+++ b/tests/fuzzers/nodestatemachine/nodestatemachine-fuzzer.go
@@ -1,0 +1,203 @@
+package nodestatemachine
+
+import (
+	"bytes"
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"github.com/ethereum/go-ethereum/common/mclock"
+	"github.com/ethereum/go-ethereum/core/rawdb"
+	"github.com/ethereum/go-ethereum/p2p/enode"
+	"github.com/ethereum/go-ethereum/p2p/enr"
+	"github.com/ethereum/go-ethereum/p2p/nodestate"
+	"github.com/ethereum/go-ethereum/rlp"
+	"io"
+	"reflect"
+	"time"
+)
+
+// The function must return
+// 1 if the fuzzer should increase priority of the
+//    given input during subsequent fuzzing (for example, the input is lexically
+//    correct and was parsed successfully);
+// -1 if the input must not be added to corpus even if gives new coverage; and
+// 0  otherwise
+// other values are reserved for future use.
+func Fuzz(data []byte) int {
+	f := fuzzer{
+		input:     bytes.NewReader(data),
+		exhausted: false,
+	}
+	return f.fuzz()
+}
+
+type dummyIdentity enode.ID
+
+func (id dummyIdentity) Verify(r *enr.Record, sig []byte) error { return nil }
+func (id dummyIdentity) NodeAddr(r *enr.Record) []byte          { return id[:] }
+
+func testNode(b byte) *enode.Node {
+	r := &enr.Record{}
+	r.SetSig(dummyIdentity{b}, []byte{42})
+	n, _ := enode.New(dummyIdentity{b}, r)
+	return n
+}
+func uint64FieldEnc(field interface{}) ([]byte, error) {
+	if u, ok := field.(uint64); ok {
+		enc, err := rlp.EncodeToBytes(&u)
+		return enc, err
+	}
+	return nil, errors.New("invalid field type")
+}
+
+func uint64FieldDec(enc []byte) (interface{}, error) {
+	var u uint64
+	err := rlp.DecodeBytes(enc, &u)
+	return u, err
+}
+
+func stringFieldEnc(field interface{}) ([]byte, error) {
+	if s, ok := field.(string); ok {
+		return []byte(s), nil
+	}
+	return nil, errors.New("invalid field type")
+}
+
+func stringFieldDec(enc []byte) (interface{}, error) {
+	return string(enc), nil
+}
+
+
+func testSetup(flagPersist []bool, fieldType []reflect.Type) (*nodestate.Setup, []nodestate.Flags, []nodestate.Field) {
+	setup := &nodestate.Setup{}
+	flags := make([]nodestate.Flags, len(flagPersist))
+	for i, persist := range flagPersist {
+		if persist {
+			flags[i] = setup.NewPersistentFlag(fmt.Sprintf("flag-%d", i))
+		} else {
+			flags[i] = setup.NewFlag(fmt.Sprintf("flag-%d", i))
+		}
+	}
+	fields := make([]nodestate.Field, len(fieldType))
+	for i, ftype := range fieldType {
+		switch ftype {
+		case reflect.TypeOf(uint64(0)):
+			fields[i] = setup.NewPersistentField(fmt.Sprintf("field-%d", i), ftype, uint64FieldEnc, uint64FieldDec)
+		case reflect.TypeOf(""):
+			fields[i] = setup.NewPersistentField(fmt.Sprintf("field-%d", i), ftype, stringFieldEnc, stringFieldDec)
+		default:
+			fields[i] = setup.NewField(fmt.Sprintf("field-%d", i), ftype)
+		}
+	}
+	return setup, flags, fields
+}
+
+type fuzzer struct {
+	input     io.Reader
+	exhausted bool
+	debugging bool
+	enodes    []*enode.Node
+	setup *nodestate.Setup
+}
+
+func (f *fuzzer) read(size int) []byte {
+	out := make([]byte, size)
+	if _, err := f.input.Read(out); err != nil {
+		f.exhausted = true
+	}
+	return out
+}
+
+func (f *fuzzer) readSlice(min, max int) []byte {
+	var a uint16
+	binary.Read(f.input, binary.LittleEndian, &a)
+	size := min + int(a)%(max-min)
+	out := make([]byte, size)
+	if _, err := f.input.Read(out); err != nil {
+		f.exhausted = true
+	}
+	return out
+}
+
+func (f *fuzzer) randomBytes(maxlen int) []byte {
+	return f.readSlice(0, maxlen)
+}
+
+func (f *fuzzer) randomByte() byte {
+	d := f.read(1)
+	return d[0]
+}
+func (f *fuzzer) randomBool() bool {
+	d := f.read(1)
+	return d[0]&1 == 1
+}
+
+func (f *fuzzer) randomInt(max int) int {
+	var a uint16
+	if err := binary.Read(f.input, binary.LittleEndian, &a); err != nil {
+		f.exhausted = true
+	}
+	return int(a % uint16(max))
+}
+
+func (f *fuzzer) randomEnode() *enode.Node {
+	// 50% chance of using an old enode
+	if existing := len(f.enodes); existing > 0 && f.randomBool() {
+		index := f.randomInt(existing - 1)
+		return f.enodes[index]
+	}
+	// Create a new one
+	node := testNode(f.randomByte())
+	f.enodes = append(f.enodes, node)
+	return node
+}
+
+func (f *fuzzer) randomField() nodestate.Field {
+	return f.setup.NewField(string(f.randomBytes(100)), reflect.TypeOf("") )
+}
+
+func (f *fuzzer) randomFlags() nodestate.Flags {
+	return f.setup.NewFlag(string(f.randomBytes(100)))
+}
+
+func (f *fuzzer) randomDuration(maxTime time.Duration) time.Duration {
+	var a uint64
+	if err := binary.Read(f.input, binary.LittleEndian, &a); err != nil {
+		f.exhausted = true
+	}
+	a = a % uint64(maxTime)
+	return time.Duration(a)
+}
+
+func (f *fuzzer) fuzz() int {
+	mdb, clock := rawdb.NewMemoryDatabase(), &mclock.Simulated{}
+	s, _, _ := testSetup([]bool{false, false, false, false}, nil)
+	f.setup =s
+	ns := nodestate.NewNodeStateMachine(mdb, []byte("-ns"), clock, s)
+	ns.Start()
+	steps := 0
+	for !f.exhausted {
+		switch f.randomInt(6) {
+		case 0:
+			ns.SetFieldSub(f.randomEnode(), f.randomField(), f.randomBytes(5))
+		case 1:
+			ns.SetField(f.randomEnode(), f.randomField(), f.randomBytes(4))
+		case 2:
+			ns.AddTimeout(f.randomEnode(), f.randomFlags(), f.randomDuration(200*time.Millisecond))
+		case 3:
+			ns.Operation(func() {
+				time.Sleep(f.randomDuration(200 * time.Millisecond))
+			})
+		case 4:
+			ns.Persist(f.randomEnode())
+		case 5:
+			ns.Stop()
+		}
+		steps++
+	}
+	if steps > 2 {
+		return 1
+	}
+	return 0
+
+}

--- a/tests/fuzzers/nodestatemachine/nodestatemachine-fuzzer.go
+++ b/tests/fuzzers/nodestatemachine/nodestatemachine-fuzzer.go
@@ -179,7 +179,9 @@ func (f *fuzzer) fuzz() int {
 	for !f.exhausted {
 		switch f.randomInt(6) {
 		case 0:
-			ns.SetFieldSub(f.randomEnode(), f.randomField(), f.randomBytes(5))
+			ns.SetField(f.randomEnode(), f.randomField(), f.randomBytes(4))
+			// The one below panics easily,
+			//ns.SetFieldSub(f.randomEnode(), f.randomField(), f.randomBytes(5))
 		case 1:
 			ns.SetField(f.randomEnode(), f.randomField(), f.randomBytes(4))
 		case 2:

--- a/tests/fuzzers/nodestatemachine/nodestatemachine-fuzzer.go
+++ b/tests/fuzzers/nodestatemachine/nodestatemachine-fuzzer.go
@@ -180,7 +180,7 @@ func (f *fuzzer) fuzz() int {
 	var stopped bool
 	steps := 0
 	for !f.exhausted {
-		switch f.randomInt(6) {
+		switch f.randomInt(9) {
 		case 0:
 			ns.SetField(f.randomEnode(), f.randomField(), f.randomBytes(4))
 			// The one below panics easily,
@@ -191,7 +191,7 @@ func (f *fuzzer) fuzz() int {
 			ns.AddTimeout(f.randomEnode(), f.randomFlags(), f.randomDuration(200*time.Millisecond))
 		case 3:
 			ns.Operation(func() {
-				time.Sleep(f.randomDuration(200 * time.Millisecond))
+				//time.Sleep(f.randomDuration(200 * time.Millisecond))
 			})
 		case 4:
 			ns.Persist(f.randomEnode())
@@ -200,6 +200,12 @@ func (f *fuzzer) fuzz() int {
 				ns.Stop()
 			}
 			stopped = true
+		case 6:
+			ns.ForEach(f.randomFlags(), f.randomFlags(), func(n *enode.Node, state nodestate.Flags) {})
+		case 7:
+			ns.Persist(f.randomEnode())
+		case 8:
+			ns.GetNode(f.randomEnode().ID())
 		}
 		steps++
 	}


### PR DESCRIPTION
This is a work in progress of a fuzzer for the node state machine. 

It basically panics immediately, on 
```
panic: Operation has not started

goroutine 1 [running]:
github.com/ethereum/go-ethereum/p2p/nodestate.(*NodeStateMachine).opCheck(...)
	/home/user/go/src/github.com/ethereum/go-ethereum/p2p/nodestate/nodestate.go:696
github.com/ethereum/go-ethereum/p2p/nodestate.(*NodeStateMachine).SetFieldSub(0xc000158000, 0xc000150e70, 0x0, 0xc0001123c0, 0x6e6b20, 0xc00000d700, 0x0, 0x0)
	/home/user/go/src/github.com/ethereum/go-ethereum/p2p/nodestate/nodestate.go:879 +0x18f
github.com/ethereum/go-ethereum/tests/fuzzers/nodestatemachine.(*fuzzer).fuzz(0xc000053e60, 0xc000029710)
	/home/user/go/src/github.com/ethereum/go-ethereum/tests/fuzzers/nodestatemachine/nodestatemachine-fuzzer.go:182 +0x5e5
github.com/ethereum/go-ethereum/tests/fuzzers/nodestatemachine.Fuzz(0x753187e82000, 0x0, 0x0, 0x4)
	/home/user/go/src/github.com/ethereum/go-ethereum/tests/fuzzers/nodestatemachine/nodestatemachine-fuzzer.go:31 +0xd7
go-fuzz-dep.Main(0xc000053f70, 0x1, 0x1)
	go-fuzz-dep/main.go:36 +0x1b8
main.main()
	github.com/ethereum/go-ethereum/tests/fuzzers/nodestatemachine/go.fuzz.main/main.go:15 +0x52
exit status 2
```
So apparently the nodestatemachine has a built-in tendency to `panic`, if it's not used correctly. I think that seems a bit dangerous to do on our production codebase. 

The fuzzer needs to be improved to be actually useful, but it's a first stab. I don't really know the internals of the nodestate machine, but it would be neat if calling the exposed methods does not panic as easily. 
