### PR TITLE
cmd/devp2p: add node filter for snap + fix arg error

### DIFF
--- a/cmd/devp2p/nodesetcmd.go
+++ b/cmd/devp2p/nodesetcmd.go
@@ -95,6 +95,7 @@ var filterFlags = map[string]nodeFilterC{
 	"-min-age":     {1, minAgeFilter},
 	"-eth-network": {1, ethFilter},
 	"-les-server":  {0, lesFilter},
+	"-snap":        {0, snapFilter},
 }
 
 func parseFilters(args []string) ([]nodeFilter, error) {
@@ -104,15 +105,15 @@ func parseFilters(args []string) ([]nodeFilter, error) {
 		if !ok {
 			return nil, fmt.Errorf("invalid filter %q", args[0])
 		}
-		if len(args) < fc.narg {
-			return nil, fmt.Errorf("filter %q wants %d arguments, have %d", args[0], fc.narg, len(args))
+		if len(args)-1 < fc.narg {
+			return nil, fmt.Errorf("filter %q wants %d arguments, have %d", args[0], fc.narg, len(args)-1)
 		}
-		filter, err := fc.fn(args[1:])
+		filter, err := fc.fn(args[1 : 1+fc.narg])
 		if err != nil {
 			return nil, fmt.Errorf("%s: %v", args[0], err)
 		}
 		filters = append(filters, filter)
-		args = args[fc.narg+1:]
+		args = args[1+fc.narg:]
 	}
 	return filters, nil
 }
@@ -188,6 +189,16 @@ func lesFilter(args []string) (nodeFilter, error) {
 			_ []rlp.RawValue `rlp:"tail"`
 		}
 		return n.N.Load(enr.WithEntry("les", &les)) == nil
+	}
+	return f, nil
+}
+
+func snapFilter(args []string) (nodeFilter, error) {
+	f := func(n nodeJSON) bool {
+		var snap struct {
+			_ []rlp.RawValue `rlp:"tail"`
+		}
+		return n.N.Load(enr.WithEntry("snap", &snap)) == nil
 	}
 	return f, nil
 }


### PR DESCRIPTION
This PR adds a filter to filter out snap peers from a set of nodes. 

```
 go run .  nodeset filter nodes.json -eth-network mainnet -snap | jq ".[] | .record" 
"enr:-KO4QE8DeESXiEKUDzeg4P1Eu4xR1kLCPSIJgGD6LQnya-0acIB3OFK-PhvubvESpbttKpkT3YfFSIuVy4Cha6v12vCBuYNldGjHxoTgKemRgIJpZIJ2NIJpcIRoKtkZg2xlc8CJc2VjcDI1NmsxoQNdbXzSDW2ku4Oh0oyttdQJtk7fMUwDNd9ljBpU4yx8SoRzbmFwwIN0Y3CCdl-DdWRwgnZf"
"enr:-KS4QDu27qjyNzpZxiWJ3QKh1XLOSiF1knJ_CzETUzIekDKtWCThgZ1DpnjopgyhdEpxRWgdmDPNX8kgINer330qYWOCAQqDZXRox8aE4CnpkYCCaWSCdjSCaXCEI570l4NsZXPAiXNlY3AyNTZrMaECJ5lE2NzUKN_6p0NvJcoMpDrhnnvPlKj7fRZBZR-S0SGEc25hcMCDdGNwgnZfg3VkcIJ2Xw"
"enr:-KO4QKv24uhwkS612lV6JLStvQw50hHLpY7X3T2-IycGyAbZJMxKhB0Q4QiwEnAOKvzgp3j8Nv5g6h70IwQHk-aZiOWBhINldGjHxoTgKemRgIJpZIJ2NIJpcIQ056Vsg2xlc8CJc2VjcDI1NmsxoQJxUXH1BQirqIrs0SUK85KkWjMK-R17kHAcQ2thjIaqoYRzbmFwwIN0Y3CCdl-DdWRwgnZf"
"enr:-KK4QDlbre2EY4rlIxGdjAq67kU-StBB5IxSESUaSfN_Y22IHpVbs6k9Ud7FymZfh70cr3OsuMY7RiMeRRdDuzUhtkV5g2V0aMfGhOAp6ZGAgmlkgnY0gmlwhBKKbEODbGVzwIlzZWNwMjU2azGhAthgoB-XIteAUWGdHiNRq6P0P5Q_bwBxjRubqkEBkyofhHNuYXDAg3RjcIJ2X4N1ZHCCdl8"

```
Also fixes a crash that happened if `devp2p nodeset filter nodes.json -eth-network` was invoked (missing an arg)