### PR TITLE
core/vm/runtime: remove duplicate line

### DIFF
--- a/core/vm/runtime/runtime.go
+++ b/core/vm/runtime/runtime.go
@@ -118,7 +118,6 @@ func Execute(code, input []byte, cfg *Config) ([]byte, *state.StateDB, error) {
 		cfg.State.AddAddressToAccessList(address)
 		for _, addr := range vmenv.ActivePrecompiles() {
 			cfg.State.AddAddressToAccessList(addr)
-			cfg.State.AddAddressToAccessList(addr)
 		}
 	}
 	cfg.State.CreateAccount(address)


### PR DESCRIPTION
This line is duplicated, though it doesn't cause any issues. 
You can check the actual discussion with @holiman [here](https://github.com/ethereum/go-ethereum/pull/21509#discussion_r535541122).