### PR TITLE
les: cosmetic rewrite of the arm64 float bug workaround

### DIFF
--- a/les/utils/expiredvalue.go
+++ b/les/utils/expiredvalue.go
@@ -89,7 +89,7 @@ func (e *ExpiredValue) Add(amount int64, logOffset Fixed64) int64 {
 		// This is a temporary fix to circumvent a golang
 		// uint conversion issue on arm64, which needs to
 		// be investigated further. FIXME
-		e.Base = uint64(int64(e.Base) + int64(base))
+		e.Base += uint64(base)
 		return amount
 	}
 	net := int64(-float64(e.Base) / factor)

--- a/les/utils/expiredvalue.go
+++ b/les/utils/expiredvalue.go
@@ -17,7 +17,6 @@
 package utils
 
 import (
-	"fmt"
 	"math"
 	"sync"
 
@@ -89,10 +88,9 @@ func (e *ExpiredValue) Add(amount int64, logOffset Fixed64) int64 {
 	if base >= 0 || uint64(-base) <= e.Base {
 		// This is a temporary fix to circumvent a golang
 		// uint conversion issue on arm64, which needs to
-		// be investigated further. FIXME
-		fmt.Printf("problem: %d %f %d %d %d\n", e.Base, base, uint64(base), int64(e.Base), int64(base))
-		e.Base += uint64(base)
-		fmt.Println(e.Base)
+		// be investigated further. More details at:
+		// https://github.com/golang/go/issues/43047
+		e.Base += uint64(int64(base))
 		return amount
 	}
 	net := int64(-float64(e.Base) / factor)

--- a/les/utils/expiredvalue.go
+++ b/les/utils/expiredvalue.go
@@ -17,6 +17,7 @@
 package utils
 
 import (
+	"fmt"
 	"math"
 	"sync"
 
@@ -89,7 +90,9 @@ func (e *ExpiredValue) Add(amount int64, logOffset Fixed64) int64 {
 		// This is a temporary fix to circumvent a golang
 		// uint conversion issue on arm64, which needs to
 		// be investigated further. FIXME
+		fmt.Printf("problem: %d %f %d %d %d\n", e.Base, base, uint64(base), int64(e.Base), int64(base))
 		e.Base += uint64(base)
+		fmt.Println(e.Base)
 		return amount
 	}
 	net := int64(-float64(e.Base) / factor)


### PR DESCRIPTION
This is a PR meant to check if go 1.15 fixed the floating point conversion error described in https://github.com/ethereum/go-ethereum/issues/20921, disregard for now