### PR TITLE
les: use eth64 instead of 63

### DIFF
--- a/les/server_handler.go
+++ b/les/server_handler.go
@@ -46,7 +46,7 @@ import (
 const (
 	softResponseLimit = 2 * 1024 * 1024 // Target maximum size of returned blocks, headers or node data.
 	estHeaderRlpSize  = 500             // Approximate size of an RLP encoded block header
-	ethVersion        = 63              // equivalent eth version for the downloader
+	ethVersion        = 64              // equivalent eth version for the downloader
 
 	MaxHeaderFetch           = 192 // Amount of block headers to be fetched per retrieval request
 	MaxBodyFetch             = 32  // Amount of block bodies to be fetched per retrieval request


### PR DESCRIPTION
We're dropping support for `63` with 1.10, so would be good to have this in for the upcoming release