### PR TITLE
cmd/geth: usb is off by default

### DIFF
--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -68,6 +68,7 @@ var (
 		utils.KeyStoreDirFlag,
 		utils.ExternalSignerFlag,
 		utils.NoUSBFlag,
+		utils.USBFlag,
 		utils.SmartCardDaemonPathFlag,
 		utils.EthashCacheDirFlag,
 		utils.EthashCachesInMemoryFlag,

--- a/cmd/geth/usage.go
+++ b/cmd/geth/usage.go
@@ -37,7 +37,7 @@ var AppHelpFlagGroups = []flags.FlagGroup{
 			utils.DataDirFlag,
 			utils.AncientFlag,
 			utils.KeyStoreDirFlag,
-			utils.NoUSBFlag,
+			utils.USBFlag,
 			utils.SmartCardDaemonPathFlag,
 			utils.NetworkIdFlag,
 			utils.GoerliFlag,
@@ -219,6 +219,7 @@ var AppHelpFlagGroups = []flags.FlagGroup{
 	{
 		Name: "ALIASED (deprecated)",
 		Flags: append([]cli.Flag{
+			utils.NoUSBFlag,
 			utils.LegacyRPCEnabledFlag,
 			utils.LegacyRPCListenAddrFlag,
 			utils.LegacyRPCPortFlag,

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -119,7 +119,11 @@ var (
 	}
 	NoUSBFlag = cli.BoolFlag{
 		Name:  "nousb",
-		Usage: "Disables monitoring for and managing USB hardware wallets",
+		Usage: "Disables monitoring for and managing USB hardware wallets (deprecated)",
+	}
+	USBFlag = cli.BoolFlag{
+		Name:  "usb",
+		Usage: "Enable monitoring and management of USB hardware wallets",
 	}
 	SmartCardDaemonPathFlag = cli.StringFlag{
 		Name:  "pcscdpath",
@@ -1225,8 +1229,11 @@ func SetNodeConfig(ctx *cli.Context, cfg *node.Config) {
 	if ctx.GlobalIsSet(LightKDFFlag.Name) {
 		cfg.UseLightweightKDF = ctx.GlobalBool(LightKDFFlag.Name)
 	}
+	if ctx.GlobalIsSet(USBFlag.Name) {
+		cfg.NoUSB = !ctx.GlobalBool(USBFlag.Name)
+	}
 	if ctx.GlobalIsSet(NoUSBFlag.Name) {
-		cfg.NoUSB = ctx.GlobalBool(NoUSBFlag.Name)
+		log.Warn("Option nousb is deprecated and USB is deactivated by default. Use --usb to enable")
 	}
 	if ctx.GlobalIsSet(InsecureUnlockAllowedFlag.Name) {
 		cfg.InsecureUnlockAllowed = ctx.GlobalBool(InsecureUnlockAllowedFlag.Name)


### PR DESCRIPTION
As discussed during standup, this PR turns USB off by default and deprecates `--nousb`. It introduces the inverse option `--usb`.

The goal of this PR is to initiate a removal of the account system from geth and move it into clef, as well as reduce the reliance of geth on C dependencies.