### PR TITLE
core, trie: speed up some tests with quadratic processing flaw

### DIFF
--- a/core/state/sync_test.go
+++ b/core/state/sync_test.go
@@ -62,7 +62,8 @@ func makeTestState() (Database, common.Hash, []*testAccount) {
 		}
 		if i%5 == 0 {
 			for j := byte(0); j < 5; j++ {
-				obj.SetState(db, crypto.Keccak256Hash([]byte{i, i, i, i, i, j, j}), crypto.Keccak256Hash([]byte{i, i, i, i, i, j, j}))
+				hash := crypto.Keccak256Hash([]byte{i, i, i, i, i, j, j})
+				obj.SetState(db, hash, hash)
 			}
 		}
 		state.updateStateObject(obj)
@@ -447,15 +448,13 @@ func TestIncompleteStateSync(t *testing.T) {
 		batch.Write()
 		for _, result := range results {
 			added = append(added, result.Hash)
-		}
-		// Check that all known sub-tries added so far are complete or missing entirely.
-		for _, hash := range added {
-			if isCode(hash) {
+			// Check that all known sub-tries added so far are complete or missing entirely.
+			if isCode(result.Hash) {
 				continue
 			}
 			// Can't use checkStateConsistency here because subtrie keys may have odd
 			// length and crash in LeafKey.
-			if err := checkTrieConsistency(dstDb, hash); err != nil {
+			if err := checkTrieConsistency(dstDb, result.Hash); err != nil {
 				t.Fatalf("state inconsistent: %v", err)
 			}
 		}

--- a/trie/sync_test.go
+++ b/trie/sync_test.go
@@ -377,7 +377,6 @@ func TestIncompleteSync(t *testing.T) {
 
 	nodes, _, codes := sched.Missing(1)
 	queue := append(append([]common.Hash{}, nodes...), codes...)
-
 	for len(queue) > 0 {
 		// Fetch a batch of trie nodes
 		results := make([]SyncResult, len(queue))
@@ -401,10 +400,8 @@ func TestIncompleteSync(t *testing.T) {
 		batch.Write()
 		for _, result := range results {
 			added = append(added, result.Hash)
-		}
-		// Check that all known sub-tries in the synced trie are complete
-		for _, root := range added {
-			if err := checkTrieConsistency(triedb, root); err != nil {
+			// Check that all known sub-tries in the synced trie are complete
+			if err := checkTrieConsistency(triedb, result.Hash); err != nil {
 				t.Fatalf("trie inconsistent: %v", err)
 			}
 		}


### PR DESCRIPTION
This PR fixes what I _think_ is a flaw in two testcases, and brings down the exec-time from ~40s on my laptop, to ~8s for `trie/TestIncompleteSync`. 

The `checkConsistency` was performed over and over again on the _complete_ set of nodes, not just the recently added. So it had a quadratic runtime, basically. 

@rjl493456442 please correct me if it looks like I misinterpreted the test