### PR TITLE
appveyor.yml: use Visual Studio 2019 image

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,13 +1,11 @@
 os: Visual Studio 2019
 
 # Clone directly into GOPATH.
-clone_folder: C:\gopath\src\github.com\ethereum\go-ethereum
 clone_depth: 5
 version: "{branch}.{build}"
 environment:
   global:
     GO111MODULE: on
-    GOPATH: C:\gopath
   matrix:
     - GETH_ARCH: amd64
       PATH: C:\mingw-w64\x86_64-8.1.0-posix-seh-rt_v6-rev0\bin;C:\Program Files (x86)\NSIS\;%PATH%
@@ -15,7 +13,8 @@ environment:
       PATH: C:\mingw-w64\i686-8.1.0-posix-dwarf-rt_v6-rev0\bin;C:\Program Files (x86)\NSIS\;%PATH%
 
 install:
-  - git submodule update --init
+  # - git submodule update --init
+  - dir C:\mingw-w64\x86_64-8.1.0-posix-seh-rt_v6-rev0
   - go version
   - gcc --version
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -23,7 +23,6 @@ environment:
 
 install:
   - git submodule update --init
-  - rmdir C:\go /s /q
   - go version
   - gcc --version
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,20 +13,17 @@ environment:
       MINGW_DIR: i686-8.1.0-posix-dwarf-rt_v6-rev0\mingw32
 
 install:
-  # - git submodule update --init
-  - dir C:\mingw-w64\%MINGW_DIR%
-  - dir C:\mingw-w64\%MINGW_DIR%\bin
+  - git submodule update --init
   - set PATH=C:\mingw-w64\%MINGW_DIR%\bin\;C:\Program Files (x86)\NSIS\;%PATH%
   - go version
   - gcc --version
 
 build_script:
-  - go run build\ci.go install -dlgo
+  - go run build\ci.go install -arch %GETH_ARCH% -dlgo
 
 after_build:
-  - go run build\ci.go archive -type zip -signer WINDOWS_SIGNING_KEY -upload gethstore/builds
-  - go run build\ci.go nsis -signer WINDOWS_SIGNING_KEY -upload gethstore/builds
+  - go run build\ci.go archive -arch %GETH_ARCH% -type zip -signer WINDOWS_SIGNING_KEY -upload gethstore/builds
+  - go run build\ci.go nsis -arch %GETH_ARCH% -signer WINDOWS_SIGNING_KEY -upload gethstore/builds
 
 test_script:
-  - set CGO_ENABLED=1
-  - go run build\ci.go test -coverage
+  - go run build\ci.go test -arch %GETH_ARCH% -coverage

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,4 @@
-os: Visual Studio 2015
+os: Visual Studio 2019
 
 # Clone directly into GOPATH.
 clone_folder: C:\gopath\src\github.com\ethereum\go-ethereum
@@ -24,8 +24,6 @@ environment:
 install:
   - git submodule update --init
   - rmdir C:\go /s /q
-  - appveyor DownloadFile https://dl.google.com/go/go1.15.5.windows-%GETH_ARCH%.zip
-  - 7z x go1.15.5.windows-%GETH_ARCH%.zip -y -oC:\ > NUL
   - go version
   - gcc --version
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,9 +10,10 @@ environment:
     - GETH_ARCH: amd64
       MINGW_DIR: x86_64-8.1.0-posix-seh-rt_v6-rev0\mingw64
     - GETH_ARCH: 386
-      MINGW_DIR: x86_64-8.1.0-posix-seh-rt_v6-rev0\mingw64
+      MINGW_DIR: i686-8.1.0-posix-dwarf-rt_v6-rev0\mingw32
 
 install:
+  - dir C:\mingw-w64\i686-8.1.0-posix-dwarf-rt_v6-rev0
   - git submodule update --init
   - set PATH=C:\mingw-w64\%MINGW_DIR%\bin\;C:\Program Files (x86)\NSIS\;%PATH%
   - go version

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -17,7 +17,7 @@ environment:
 install:
   - git submodule update --init
   - go version
-  - gcc --version
+  # - gcc --version
 
 build_script:
   - go run build\ci.go install -dlgo

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,14 +10,14 @@ environment:
     GOPATH: C:\gopath
   matrix:
     - GETH_ARCH: amd64
-      PATH: C:\Program Files (x86)\NSIS\;%PATH%
+      PATH: C:\mingw-w64\x86_64-8.1.0-posix-seh-rt_v6-rev0\bin;C:\Program Files (x86)\NSIS\;%PATH%
     - GETH_ARCH: 386
-      PATH: C:\Program Files (x86)\NSIS\;%PATH%
+      PATH: C:\mingw-w64\i686-8.1.0-posix-dwarf-rt_v6-rev0\bin;C:\Program Files (x86)\NSIS\;%PATH%
 
 install:
   - git submodule update --init
   - go version
-  # - gcc --version
+  - gcc --version
 
 build_script:
   - go run build\ci.go install -dlgo

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,18 +8,11 @@ environment:
   global:
     GO111MODULE: on
     GOPATH: C:\gopath
-    CC: gcc.exe
   matrix:
     - GETH_ARCH: amd64
-      MSYS2_ARCH: x86_64
-      MSYS2_BITS: 64
-      MSYSTEM: MINGW64
-      PATH: C:\msys64\mingw64\bin\;C:\Program Files (x86)\NSIS\;%PATH%
+      PATH: C:\Program Files (x86)\NSIS\;%PATH%
     - GETH_ARCH: 386
-      MSYS2_ARCH: i686
-      MSYS2_BITS: 32
-      MSYSTEM: MINGW32
-      PATH: C:\msys64\mingw32\bin\;C:\Program Files (x86)\NSIS\;%PATH%
+      PATH: C:\Program Files (x86)\NSIS\;%PATH%
 
 install:
   - git submodule update --init

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,14 +10,14 @@ environment:
     - GETH_ARCH: amd64
       MINGW_DIR: x86_64-8.1.0-posix-seh-rt_v6-rev0\mingw64
     - GETH_ARCH: 386
-      MINGW_DIR: i686-8.1.0-posix-dwarf-rt_v6-rev0\mingw32
-      CFLAGS: -m32
+      MINGW_DIR: x86_64-8.1.0-posix-seh-rt_v6-rev0\mingw64
 
 install:
   - git submodule update --init
   - set PATH=C:\mingw-w64\%MINGW_DIR%\bin\;C:\Program Files (x86)\NSIS\;%PATH%
   - go version
   - gcc --version
+  - g++ -v
 
 build_script:
   - go run build\ci.go install -arch %GETH_ARCH% -dlgo

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,6 +11,7 @@ environment:
       MINGW_DIR: x86_64-8.1.0-posix-seh-rt_v6-rev0\mingw64
     - GETH_ARCH: 386
       MINGW_DIR: i686-8.1.0-posix-dwarf-rt_v6-rev0\mingw32
+      CFLAGS: -m32
 
 install:
   - git submodule update --init

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,13 +8,15 @@ environment:
     GO111MODULE: on
   matrix:
     - GETH_ARCH: amd64
-      PATH: C:\mingw-w64\x86_64-8.1.0-posix-seh-rt_v6-rev0\bin;C:\Program Files (x86)\NSIS\;%PATH%
+      MINGW_DIR: x86_64-8.1.0-posix-seh-rt_v6-rev0
     - GETH_ARCH: 386
-      PATH: C:\mingw-w64\i686-8.1.0-posix-dwarf-rt_v6-rev0\bin;C:\Program Files (x86)\NSIS\;%PATH%
+      MINGW_DIR: i686-8.1.0-posix-dwarf-rt_v6-rev0
 
 install:
   # - git submodule update --init
-  - dir C:\mingw-w64\x86_64-8.1.0-posix-seh-rt_v6-rev0
+  - dir C:\mingw-w64\%MINGW_DIR%\mingw64
+  - dir C:\mingw-w64\%MINGW_DIR%\mingw64\bin
+  - set PATH=C:\mingw-w64\%MINGW_DIR%\mingw64\bin\;C:\Program Files (x86)\NSIS\;%PATH%
   - go version
   - gcc --version
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,12 +13,10 @@ environment:
       MINGW_DIR: i686-8.1.0-posix-dwarf-rt_v6-rev0\mingw32
 
 install:
-  - echo %CC%
   - git submodule update --init
   - set PATH=C:\mingw-w64\%MINGW_DIR%\bin\;C:\Program Files (x86)\NSIS\;%PATH%
   - go version
   - gcc --version
-  - g++ -v
 
 build_script:
   - go run build\ci.go install -arch %GETH_ARCH% -dlgo

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,7 +13,7 @@ environment:
       MINGW_DIR: i686-8.1.0-posix-dwarf-rt_v6-rev0\mingw32
 
 install:
-  - dir C:\mingw-w64\i686-8.1.0-posix-dwarf-rt_v6-rev0
+  - echo %CC%
   - git submodule update --init
   - set PATH=C:\mingw-w64\%MINGW_DIR%\bin\;C:\Program Files (x86)\NSIS\;%PATH%
   - go version
@@ -28,4 +28,4 @@ after_build:
   - go run build\ci.go nsis -arch %GETH_ARCH% -signer WINDOWS_SIGNING_KEY -upload gethstore/builds
 
 test_script:
-  - go run build\ci.go test -arch %GETH_ARCH% -coverage
+  - go run build\ci.go test -coverage

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,15 +8,15 @@ environment:
     GO111MODULE: on
   matrix:
     - GETH_ARCH: amd64
-      MINGW_DIR: x86_64-8.1.0-posix-seh-rt_v6-rev0
+      MINGW_DIR: x86_64-8.1.0-posix-seh-rt_v6-rev0\mingw64
     - GETH_ARCH: 386
-      MINGW_DIR: i686-8.1.0-posix-dwarf-rt_v6-rev0
+      MINGW_DIR: i686-8.1.0-posix-dwarf-rt_v6-rev0\mingw32
 
 install:
   # - git submodule update --init
-  - dir C:\mingw-w64\%MINGW_DIR%\mingw64
-  - dir C:\mingw-w64\%MINGW_DIR%\mingw64\bin
-  - set PATH=C:\mingw-w64\%MINGW_DIR%\mingw64\bin\;C:\Program Files (x86)\NSIS\;%PATH%
+  - dir C:\mingw-w64\%MINGW_DIR%
+  - dir C:\mingw-w64\%MINGW_DIR%\bin
+  - set PATH=C:\mingw-w64\%MINGW_DIR%\bin\;C:\Program Files (x86)\NSIS\;%PATH%
   - go version
   - gcc --version
 

--- a/build/ci.go
+++ b/build/ci.go
@@ -250,6 +250,11 @@ func doInstall(cmdline []string) {
 		gobuild.Env = append(gobuild.Env, "CC="+os.Getenv("CC"))
 	}
 
+	// Add -m32 for windows.
+	if runtime.GOOS == "windows" && *arch == "386" {
+		gobuild.Env = append(gobuild.Env, "CGO_CFLAGS=-m32")
+	}
+
 	// arm64 CI builders are memory-constrained and can't handle concurrent builds,
 	// better disable it. This check isn't the best, it should probably
 	// check for something in env instead.

--- a/build/ci.go
+++ b/build/ci.go
@@ -269,7 +269,7 @@ func doInstall(cmdline []string) {
 	gobuild.Args = append(gobuild.Args, "-trimpath")
 
 	// Show packages during build.
-	gobuild.Args = append(gobuild.Args, "-v")
+	gobuild.Args = append(gobuild.Args, "-v", "-x")
 
 	// Now we choose what we're even building.
 	// Default: collect all 'main' packages in cmd/ and build those.

--- a/build/ci.go
+++ b/build/ci.go
@@ -250,11 +250,6 @@ func doInstall(cmdline []string) {
 		gobuild.Env = append(gobuild.Env, "CC="+os.Getenv("CC"))
 	}
 
-	// Add -m32 for windows.
-	if runtime.GOOS == "windows" && *arch == "386" {
-		gobuild.Env = append(gobuild.Env, "CGO_CFLAGS=-m32")
-	}
-
 	// arm64 CI builders are memory-constrained and can't handle concurrent builds,
 	// better disable it. This check isn't the best, it should probably
 	// check for something in env instead.
@@ -269,7 +264,7 @@ func doInstall(cmdline []string) {
 	gobuild.Args = append(gobuild.Args, "-trimpath")
 
 	// Show packages during build.
-	gobuild.Args = append(gobuild.Args, "-v", "-x")
+	gobuild.Args = append(gobuild.Args, "-v")
 
 	// Now we choose what we're even building.
 	// Default: collect all 'main' packages in cmd/ and build those.

--- a/params/config.go
+++ b/params/config.go
@@ -22,7 +22,7 @@ import (
 	"math/big"
 
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/crypto"
+	"golang.org/x/crypto/sha3"
 )
 
 // Genesis hashes to enforce below configs on.
@@ -274,12 +274,17 @@ func (c *TrustedCheckpoint) HashEqual(hash common.Hash) bool {
 
 // Hash returns the hash of checkpoint's four key fields(index, sectionHead, chtRoot and bloomTrieRoot).
 func (c *TrustedCheckpoint) Hash() common.Hash {
-	buf := make([]byte, 8+3*common.HashLength)
-	binary.BigEndian.PutUint64(buf, c.SectionIndex)
-	copy(buf[8:], c.SectionHead.Bytes())
-	copy(buf[8+common.HashLength:], c.CHTRoot.Bytes())
-	copy(buf[8+2*common.HashLength:], c.BloomRoot.Bytes())
-	return crypto.Keccak256Hash(buf)
+	sectionIndex := make([]byte, 8)
+	binary.BigEndian.PutUint64(sectionIndex, c.SectionIndex)
+
+	w := sha3.NewLegacyKeccak256()
+	w.Write(buf)
+	w.Write(c.CHTRoot[:])
+	w.Write(c.BloomRoot[:])
+
+	var h common.Hash
+	w.Sum(h[:0])
+	return h
 }
 
 // Empty returns an indicator whether the checkpoint is regarded as empty.

--- a/params/config.go
+++ b/params/config.go
@@ -274,11 +274,11 @@ func (c *TrustedCheckpoint) HashEqual(hash common.Hash) bool {
 
 // Hash returns the hash of checkpoint's four key fields(index, sectionHead, chtRoot and bloomTrieRoot).
 func (c *TrustedCheckpoint) Hash() common.Hash {
-	sectionIndex := make([]byte, 8)
-	binary.BigEndian.PutUint64(sectionIndex, c.SectionIndex)
+	var sectionIndex [8]byte
+	binary.BigEndian.PutUint64(sectionIndex[:], c.SectionIndex)
 
 	w := sha3.NewLegacyKeccak256()
-	w.Write(buf)
+	w.Write(sectionIndex[:])
 	w.Write(c.CHTRoot[:])
 	w.Write(c.BloomRoot[:])
 


### PR DESCRIPTION
This build image includes Go 1.15. This means we can remove the
unauthenticated download and just rely on -dlgo instead.