### PR TITLE
cmd/geth: add ability to get/put raw db values

### DIFF
--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -246,6 +246,8 @@ func init() {
 		licenseCommand,
 		// See config.go
 		dumpConfigCommand,
+		dbGetCommand,
+		dbPutCommand,
 		// See cmd/utils/flags_legacy.go
 		utils.ShowDeprecated,
 	}


### PR DESCRIPTION
This PR is a bit experimental, and provides ability to modify the database contents. It's for being able to inspect, and potentially salvage, problems like reported in https://github.com/ethereum/go-ethereum/issues/21990 . 
Example usage: 

Putting a value
```
[user@work go-ethereum]$ ./build/bin/geth db.put 0x1337 0xdeadc0de
INFO [12-10|11:02:19.555] Maximum peer count                       ETH=50 LES=0 total=50
INFO [12-10|11:02:19.555] Smartcard socket not found, disabling    err="stat /run/pcscd/pcscd.comm: no such file or directory"
...
..
INFO [12-10|11:02:19.598] Opened ancient database                  database=/home/user/.ethereum/geth/chaindata/ancient
INFO [12-10|11:02:19.599] Freezer shutting down
```
Reading it:
```
[user@work go-ethereum]$ ./build/bin/geth db.get 0x1337
INFO [12-10|11:02:27.926] Maximum peer count                       ETH=50 LES=0 total=50
...
INFO [12-10|11:02:27.953] Opened ancient database                  database=/home/user/.ethereum/geth/chaindata/ancient
key 1337:
        deadc0de
INFO [12-10|11:02:27.955] Freezer shutting down
```
Overwriting it:
```
[user@work go-ethereum]$ ./build/bin/geth db.put 0x1337 0xcafebabe
INFO [12-10|11:02:36.959] Maximum peer count                       ETH=50 LES=0 total=50
...
INFO [12-10|11:02:36.987] Opened ancient database                  database=/home/user/.ethereum/geth/chaindata/ancient
Previous value:
deadc0de
INFO [12-10|11:02:36.988] Freezer shutting down
```