### PR TITLE
les: rework arm64's undefined workaround

### DIFF
--- a/les/utils/expiredvalue.go
+++ b/les/utils/expiredvalue.go
@@ -86,11 +86,15 @@ func (e *ExpiredValue) Add(amount int64, logOffset Fixed64) int64 {
 		e.Exp = integer
 	}
 	if base >= 0 || uint64(-base) <= e.Base {
-		// This is a temporary fix to circumvent a golang
-		// uint conversion issue on arm64, which needs to
-		// be investigated further. More details at:
+		// The conversion from negative float64 to
+		// uint64 is undefined in golang, and doesn't
+		// work with ARMv8. More details at:
 		// https://github.com/golang/go/issues/43047
-		e.Base += uint64(int64(base))
+		if base >= 0 {
+			e.Base += uint64(base)
+		} else {
+			e.Base -= uint64(-base)
+		}
 		return amount
 	}
 	net := int64(-float64(e.Base) / factor)


### PR DESCRIPTION
The previous fix  #21960 converted the float to an intermediate signed int, before attempting the uint conversion. Although this works, this doesn't guarantee that other architectures will work the same.