### PR TITLE
cmd/geth: fixed parallelized tests

### DIFF
--- a/cmd/geth/accountcmd_test.go
+++ b/cmd/geth/accountcmd_test.go
@@ -102,6 +102,7 @@ func TestAccountImport(t *testing.T) {
 		},
 	}
 	for _, test := range tests {
+		test := test
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
 			importAccountWithExpect(t, test.key, test.output)


### PR DESCRIPTION
Two tests in our codebase use the `t.Parallel()` in an unsafe way which results in only the last test in a test table being executed.
For example master prouduces:
```
=== RUN   TestDeliverHeadersHang
=== PAUSE TestDeliverHeadersHang
=== CONT  TestDeliverHeadersHang
=== RUN   TestDeliverHeadersHang/protocol_63_mode_full
=== PAUSE TestDeliverHeadersHang/protocol_63_mode_full
=== RUN   TestDeliverHeadersHang/protocol_63_mode_fast
=== PAUSE TestDeliverHeadersHang/protocol_63_mode_fast
=== RUN   TestDeliverHeadersHang/protocol_64_mode_full
=== PAUSE TestDeliverHeadersHang/protocol_64_mode_full
=== RUN   TestDeliverHeadersHang/protocol_64_mode_fast
=== PAUSE TestDeliverHeadersHang/protocol_64_mode_fast
=== RUN   TestDeliverHeadersHang/protocol_64_mode_light
=== PAUSE TestDeliverHeadersHang/protocol_64_mode_light
=== RUN   TestDeliverHeadersHang/protocol_65_mode_full
=== PAUSE TestDeliverHeadersHang/protocol_65_mode_full
=== RUN   TestDeliverHeadersHang/protocol_65_mode_fast
=== PAUSE TestDeliverHeadersHang/protocol_65_mode_fast
=== RUN   TestDeliverHeadersHang/protocol_65_mode_light
=== PAUSE TestDeliverHeadersHang/protocol_65_mode_light
=== CONT  TestDeliverHeadersHang/protocol_63_mode_full
65=== CONT  TestDeliverHeadersHang/protocol_65_mode_full
65=== CONT  TestDeliverHeadersHang/protocol_65_mode_light
65=== CONT  TestDeliverHeadersHang/protocol_64_mode_fast
65=== CONT  TestDeliverHeadersHang/protocol_64_mode_light
65=== CONT  TestDeliverHeadersHang/protocol_65_mode_fast
65=== CONT  TestDeliverHeadersHang/protocol_64_mode_full
65=== CONT  TestDeliverHeadersHang/protocol_63_mode_fast
65
``` 
while this branch produces:
```
=== RUN   TestDeliverHeadersHang
=== PAUSE TestDeliverHeadersHang
=== CONT  TestDeliverHeadersHang
=== RUN   TestDeliverHeadersHang/protocol_63_mode_full
=== PAUSE TestDeliverHeadersHang/protocol_63_mode_full
=== RUN   TestDeliverHeadersHang/protocol_63_mode_fast
=== PAUSE TestDeliverHeadersHang/protocol_63_mode_fast
=== RUN   TestDeliverHeadersHang/protocol_64_mode_full
=== PAUSE TestDeliverHeadersHang/protocol_64_mode_full
=== RUN   TestDeliverHeadersHang/protocol_64_mode_fast
=== PAUSE TestDeliverHeadersHang/protocol_64_mode_fast
=== RUN   TestDeliverHeadersHang/protocol_64_mode_light
=== PAUSE TestDeliverHeadersHang/protocol_64_mode_light
=== RUN   TestDeliverHeadersHang/protocol_65_mode_full
=== PAUSE TestDeliverHeadersHang/protocol_65_mode_full
=== RUN   TestDeliverHeadersHang/protocol_65_mode_fast
=== PAUSE TestDeliverHeadersHang/protocol_65_mode_fast
=== RUN   TestDeliverHeadersHang/protocol_65_mode_light
=== PAUSE TestDeliverHeadersHang/protocol_65_mode_light
=== CONT  TestDeliverHeadersHang/protocol_63_mode_full
63=== CONT  TestDeliverHeadersHang/protocol_65_mode_light
65=== CONT  TestDeliverHeadersHang/protocol_64_mode_light
64=== CONT  TestDeliverHeadersHang/protocol_65_mode_fast
65=== CONT  TestDeliverHeadersHang/protocol_65_mode_full
65=== CONT  TestDeliverHeadersHang/protocol_64_mode_full
64=== CONT  TestDeliverHeadersHang/protocol_64_mode_fast
64=== CONT  TestDeliverHeadersHang/protocol_63_mode_fast
63
```
When printing out the tested protocol.

See also: https://gist.github.com/posener/92a55c4cd441fc5e5e85f27bca008721