### PR TITLE
rpc: increase max request content length

### DIFF
--- a/rpc/http.go
+++ b/rpc/http.go
@@ -32,7 +32,7 @@ import (
 )
 
 const (
-	maxRequestContentLength = 1024 * 1024 * 5
+	maxRequestContentLength = 1024 * 1024 * 20
 	contentType             = "application/json"
 )
 


### PR DESCRIPTION
In the ropsten network, there are multiple blocks with the size over 3MB (height 599275 - 3.35MB, 599281 - 6.52MB). The current max request content length limit of 5MB does not allow to fetch these blocks using the `eth_getBlock` API call. With the overhead of the hex encoding in the rpc protocol, the maximum block size possible to be fetched is only about 2.5MB.

Fixed by extending the max request content length size to 20MB - with some buffer room, as the working limit would be about 14-15MB.