### PR TITLE
crypto: faster keccak on Address and Hash

### DIFF
--- a/core/state/database.go
+++ b/core/state/database.go
@@ -65,20 +65,27 @@ type Trie interface {
 	// TODO(fjl): remove this when SecureTrie is removed
 	GetKey([]byte) []byte
 
-	// TryGet returns the value for key stored in the trie. The value bytes must
+	// TryGetHash returns the value for key stored in the trie. The value bytes must
 	// not be modified by the caller. If a node was not found in the database, a
 	// trie.MissingNodeError is returned.
-	TryGet(key []byte) ([]byte, error)
+	TryGetHash(key common.Hash) ([]byte, error)
 
-	// TryUpdate associates key with value in the trie. If value has length zero, any
+	// TryGetAddress is identical to TryGetHash, but uses a common.Address as key,
+	TryGetAddress(key common.Address) ([]byte, error)
+
+	// TryUpdateHash associates key with value in the trie. If value has length zero, any
 	// existing value is deleted from the trie. The value bytes must not be modified
 	// by the caller while they are stored in the trie. If a node was not found in the
 	// database, a trie.MissingNodeError is returned.
-	TryUpdate(key, value []byte) error
+	TryUpdateHash(key common.Hash, value []byte) error
+	// TryUpdateAddress is identical to TryUpdateHash but uses common.Address as key
+	TryUpdateAddress(key common.Address, value []byte) error
 
-	// TryDelete removes any existing value for key from the trie. If a node was not
+	// TryDeleteHash removes any existing value for key from the trie. If a node was not
 	// found in the database, a trie.MissingNodeError is returned.
-	TryDelete(key []byte) error
+	TryDeleteHash(key common.Hash) error
+	// TryDeleteAddress is identical to TryDeleteHash but uses common.Address as key.
+	TryDeleteAddress(key common.Address) error
 
 	// Hash returns the root hash of the trie. It does not write to the database and
 	// can be used even if the trie doesn't have one.

--- a/core/state/state_object.go
+++ b/core/state/state_object.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/crypto/fixed"
 	"github.com/ethereum/go-ethereum/metrics"
 	"github.com/ethereum/go-ethereum/rlp"
 )
@@ -120,7 +121,7 @@ func newObject(db *StateDB, address common.Address, data Account) *stateObject {
 	return &stateObject{
 		db:             db,
 		address:        address,
-		addrHash:       crypto.Keccak256Hash(address[:]),
+		addrHash:       fixed.LegacyKeccak20(address),
 		data:           data,
 		originStorage:  make(Storage),
 		pendingStorage: make(Storage),
@@ -213,7 +214,7 @@ func (s *stateObject) GetCommittedState(db Database, key common.Hash) common.Has
 		if _, destructed := s.db.snapDestructs[s.addrHash]; destructed {
 			return common.Hash{}
 		}
-		enc, err = s.db.snap.Storage(s.addrHash, crypto.Keccak256Hash(key.Bytes()))
+		enc, err = s.db.snap.Storage(s.addrHash, fixed.LegacyKeccak32(key))
 	}
 	// If snapshot unavailable or reading from it failed, load from the database
 	if s.db.snap == nil || err != nil {
@@ -332,7 +333,7 @@ func (s *stateObject) updateTrie(db Database) Trie {
 		}
 		// If state snapshotting is active, cache the data til commit
 		if storage != nil {
-			storage[crypto.Keccak256Hash(key[:])] = v // v will be nil if value is 0x00
+			storage[fixed.LegacyKeccak32(key)] = v // v will be nil if value is 0x00
 		}
 	}
 	if len(s.pendingStorage) > 0 {

--- a/core/state/state_object.go
+++ b/core/state/state_object.go
@@ -221,7 +221,7 @@ func (s *stateObject) GetCommittedState(db Database, key common.Hash) common.Has
 		if metrics.EnabledExpensive {
 			defer func(start time.Time) { s.db.StorageReads += time.Since(start) }(time.Now())
 		}
-		if enc, err = s.getTrie(db).TryGet(key.Bytes()); err != nil {
+		if enc, err = s.getTrie(db).TryGetHash(key); err != nil {
 			s.setError(err)
 			return common.Hash{}
 		}
@@ -325,11 +325,11 @@ func (s *stateObject) updateTrie(db Database) Trie {
 
 		var v []byte
 		if (value == common.Hash{}) {
-			s.setError(tr.TryDelete(key[:]))
+			s.setError(tr.TryDeleteHash(key))
 		} else {
 			// Encoding []byte cannot fail, ok to ignore the error.
 			v, _ = rlp.EncodeToBytes(common.TrimLeftZeroes(value[:]))
-			s.setError(tr.TryUpdate(key[:], v))
+			s.setError(tr.TryUpdateHash(key, v))
 		}
 		// If state snapshotting is active, cache the data til commit
 		if storage != nil {

--- a/core/state/statedb.go
+++ b/core/state/statedb.go
@@ -29,6 +29,7 @@ import (
 	"github.com/ethereum/go-ethereum/core/state/snapshot"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/crypto/fixed"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/metrics"
 	"github.com/ethereum/go-ethereum/rlp"
@@ -316,7 +317,7 @@ func (s *StateDB) GetState(addr common.Address, hash common.Hash) common.Hash {
 
 // GetProof returns the Merkle proof for a given account.
 func (s *StateDB) GetProof(addr common.Address) ([][]byte, error) {
-	return s.GetProofByHash(crypto.Keccak256Hash(addr.Bytes()))
+	return s.GetProofByHash(fixed.LegacyKeccak20(addr))
 }
 
 // GetProofByHash returns the Merkle proof for a given account.
@@ -532,7 +533,7 @@ func (s *StateDB) getDeletedStateObject(addr common.Address) *stateObject {
 			defer func(start time.Time) { s.SnapshotAccountReads += time.Since(start) }(time.Now())
 		}
 		var acc *snapshot.Account
-		if acc, err = s.snap.Account(crypto.Keccak256Hash(addr.Bytes())); err == nil {
+		if acc, err = s.snap.Account(fixed.LegacyKeccak20(addr)); err == nil {
 			if acc == nil {
 				return nil
 			}

--- a/core/state/statedb.go
+++ b/core/state/statedb.go
@@ -478,7 +478,7 @@ func (s *StateDB) updateStateObject(obj *stateObject) {
 	if err != nil {
 		panic(fmt.Errorf("can't encode object at %x: %v", addr[:], err))
 	}
-	if err = s.trie.TryUpdate(addr[:], data); err != nil {
+	if err = s.trie.TryUpdateAddress(addr, data); err != nil {
 		s.setError(fmt.Errorf("updateStateObject (%x) error: %v", addr[:], err))
 	}
 
@@ -499,7 +499,7 @@ func (s *StateDB) deleteStateObject(obj *stateObject) {
 	}
 	// Delete the account from the trie
 	addr := obj.Address()
-	if err := s.trie.TryDelete(addr[:]); err != nil {
+	if err := s.trie.TryDeleteAddress(addr); err != nil {
 		s.setError(fmt.Errorf("deleteStateObject (%x) error: %v", addr[:], err))
 	}
 }
@@ -556,7 +556,7 @@ func (s *StateDB) getDeletedStateObject(addr common.Address) *stateObject {
 		if metrics.EnabledExpensive {
 			defer func(start time.Time) { s.AccountReads += time.Since(start) }(time.Now())
 		}
-		enc, err := s.trie.TryGet(addr.Bytes())
+		enc, err := s.trie.TryGetAddress(addr)
 		if err != nil {
 			s.setError(fmt.Errorf("getDeleteStateObject (%x) error: %v", addr.Bytes(), err))
 			return nil

--- a/crypto/fixed/fixed.go
+++ b/crypto/fixed/fixed.go
@@ -1,0 +1,77 @@
+package fixed
+
+// LegacyKeccak20 calculates the LegacyKeccak256 hash of data
+func LegacyKeccak20(data [20]byte) [32]byte {
+	var a [25]uint64
+	// Pad and permute in one go
+	a[16] = 0x8000000000000000
+	a[2] = 1<<32 | uint64(data[19])<<24 | uint64(data[18])<<16 | uint64(data[17])<<8 | uint64(data[16])
+	a[1] = uint64(data[15])<<56 | uint64(data[14])<<48 | uint64(data[13])<<40 | uint64(data[12])<<32 |
+		uint64(data[11])<<24 | uint64(data[10])<<16 | uint64(data[9])<<8 | uint64(data[8])
+	a[0] = uint64(data[7])<<56 | uint64(data[6])<<48 | uint64(data[5])<<40 | uint64(data[4])<<32 |
+		uint64(data[3])<<24 | uint64(data[2])<<16 | uint64(data[1])<<8 | uint64(data[0])
+	// Hash it
+	keccakF1600(&a)
+	// Convert back to bytes, and return
+	var buf [32]byte
+	/*
+		It is possible (the golang lib version does it) to use an unaligned copy here,
+		but it is platform specific.
+		Since it's a pretty small slice we're dealing with, we're a generic method instead.
+		The 'cost' of using the generic version is ~5%, 454ns instead of 430ns.
+
+		ab := (*[136]uint8)(unsafe.Pointer(&a[0]))
+		copy(buf[:], ab[:])
+	*/
+	for i := 0; i < 4; i++ {
+		buf[8*i+7] = byte(a[i] >> 56)
+		buf[8*i+6] = byte(a[i] >> 48)
+		buf[8*i+5] = byte(a[i] >> 40)
+		buf[8*i+4] = byte(a[i] >> 32)
+		buf[8*i+3] = byte(a[i] >> 24)
+		buf[8*i+2] = byte(a[i] >> 16)
+		buf[8*i+1] = byte(a[i] >> 8)
+		buf[8*i] = byte(a[i])
+	}
+	return buf
+}
+
+// LegacyKeccak32 calculates the LegacyKeccak256 hash of data
+func LegacyKeccak32(data [32]byte) [32]byte {
+	var a [25]uint64
+	// Pad and permute in one go
+	a[16] = 0x8000000000000000
+	a[4] = 1
+	a[3] = uint64(data[31])<<56 | uint64(data[30])<<48 | uint64(data[29])<<40 | uint64(data[28])<<32 |
+		uint64(data[27])<<24 | uint64(data[26])<<16 | uint64(data[25])<<8 | uint64(data[24])
+	a[2] = uint64(data[23])<<56 | uint64(data[22])<<48 | uint64(data[21])<<40 | uint64(data[20])<<32 |
+		uint64(data[19])<<24 | uint64(data[18])<<16 | uint64(data[17])<<8 | uint64(data[16])
+	a[1] = uint64(data[15])<<56 | uint64(data[14])<<48 | uint64(data[13])<<40 | uint64(data[12])<<32 |
+		uint64(data[11])<<24 | uint64(data[10])<<16 | uint64(data[9])<<8 | uint64(data[8])
+	a[0] = uint64(data[7])<<56 | uint64(data[6])<<48 | uint64(data[5])<<40 | uint64(data[4])<<32 |
+		uint64(data[3])<<24 | uint64(data[2])<<16 | uint64(data[1])<<8 | uint64(data[0])
+	// Hash it
+	keccakF1600(&a)
+	// Convert back to bytes, and return
+	var buf [32]byte
+	/*
+		It is possible (the golang lib version does it) to use an unaligned copy here,
+		but it is platform specific.
+		Since it's a pretty small slice we're dealing with, we're a generic method instead.
+		The 'cost' of using the generic version is ~5%, 454ns instead of 430ns.
+
+		ab := (*[136]uint8)(unsafe.Pointer(&a[0]))
+		copy(buf[:], ab[:])
+	*/
+	for i := 0; i < 4; i++ {
+		buf[8*i+7] = byte(a[i] >> 56)
+		buf[8*i+6] = byte(a[i] >> 48)
+		buf[8*i+5] = byte(a[i] >> 40)
+		buf[8*i+4] = byte(a[i] >> 32)
+		buf[8*i+3] = byte(a[i] >> 24)
+		buf[8*i+2] = byte(a[i] >> 16)
+		buf[8*i+1] = byte(a[i] >> 8)
+		buf[8*i] = byte(a[i])
+	}
+	return buf
+}

--- a/crypto/fixed/keccakf.go
+++ b/crypto/fixed/keccakf.go
@@ -1,0 +1,414 @@
+// This file is copied from golang/x/crypto/sha3/keccakf.go
+
+// Copyright 2014 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+//  +build !amd64 appengine gccgo
+
+package fixed
+
+// rc stores the round constants for use in the ι step.
+var rc = [24]uint64{
+	0x0000000000000001,
+	0x0000000000008082,
+	0x800000000000808A,
+	0x8000000080008000,
+	0x000000000000808B,
+	0x0000000080000001,
+	0x8000000080008081,
+	0x8000000000008009,
+	0x000000000000008A,
+	0x0000000000000088,
+	0x0000000080008009,
+	0x000000008000000A,
+	0x000000008000808B,
+	0x800000000000008B,
+	0x8000000000008089,
+	0x8000000000008003,
+	0x8000000000008002,
+	0x8000000000000080,
+	0x000000000000800A,
+	0x800000008000000A,
+	0x8000000080008081,
+	0x8000000000008080,
+	0x0000000080000001,
+	0x8000000080008008,
+}
+
+// keccakF1600 applies the Keccak permutation to a 1600b-wide
+// state represented as a slice of 25 uint64s.
+func keccakF1600(a *[25]uint64) {
+	// Implementation translated from Keccak-inplace.c
+	// in the keccak reference code.
+	var t, bc0, bc1, bc2, bc3, bc4, d0, d1, d2, d3, d4 uint64
+
+	for i := 0; i < 24; i += 4 {
+		// Combines the 5 steps in each round into 2 steps.
+		// Unrolls 4 rounds per loop and spreads some steps across rounds.
+
+		// Round 1
+		bc0 = a[0] ^ a[5] ^ a[10] ^ a[15] ^ a[20]
+		bc1 = a[1] ^ a[6] ^ a[11] ^ a[16] ^ a[21]
+		bc2 = a[2] ^ a[7] ^ a[12] ^ a[17] ^ a[22]
+		bc3 = a[3] ^ a[8] ^ a[13] ^ a[18] ^ a[23]
+		bc4 = a[4] ^ a[9] ^ a[14] ^ a[19] ^ a[24]
+		d0 = bc4 ^ (bc1<<1 | bc1>>63)
+		d1 = bc0 ^ (bc2<<1 | bc2>>63)
+		d2 = bc1 ^ (bc3<<1 | bc3>>63)
+		d3 = bc2 ^ (bc4<<1 | bc4>>63)
+		d4 = bc3 ^ (bc0<<1 | bc0>>63)
+
+		bc0 = a[0] ^ d0
+		t = a[6] ^ d1
+		bc1 = t<<44 | t>>(64-44)
+		t = a[12] ^ d2
+		bc2 = t<<43 | t>>(64-43)
+		t = a[18] ^ d3
+		bc3 = t<<21 | t>>(64-21)
+		t = a[24] ^ d4
+		bc4 = t<<14 | t>>(64-14)
+		a[0] = bc0 ^ (bc2 &^ bc1) ^ rc[i]
+		a[6] = bc1 ^ (bc3 &^ bc2)
+		a[12] = bc2 ^ (bc4 &^ bc3)
+		a[18] = bc3 ^ (bc0 &^ bc4)
+		a[24] = bc4 ^ (bc1 &^ bc0)
+
+		t = a[10] ^ d0
+		bc2 = t<<3 | t>>(64-3)
+		t = a[16] ^ d1
+		bc3 = t<<45 | t>>(64-45)
+		t = a[22] ^ d2
+		bc4 = t<<61 | t>>(64-61)
+		t = a[3] ^ d3
+		bc0 = t<<28 | t>>(64-28)
+		t = a[9] ^ d4
+		bc1 = t<<20 | t>>(64-20)
+		a[10] = bc0 ^ (bc2 &^ bc1)
+		a[16] = bc1 ^ (bc3 &^ bc2)
+		a[22] = bc2 ^ (bc4 &^ bc3)
+		a[3] = bc3 ^ (bc0 &^ bc4)
+		a[9] = bc4 ^ (bc1 &^ bc0)
+
+		t = a[20] ^ d0
+		bc4 = t<<18 | t>>(64-18)
+		t = a[1] ^ d1
+		bc0 = t<<1 | t>>(64-1)
+		t = a[7] ^ d2
+		bc1 = t<<6 | t>>(64-6)
+		t = a[13] ^ d3
+		bc2 = t<<25 | t>>(64-25)
+		t = a[19] ^ d4
+		bc3 = t<<8 | t>>(64-8)
+		a[20] = bc0 ^ (bc2 &^ bc1)
+		a[1] = bc1 ^ (bc3 &^ bc2)
+		a[7] = bc2 ^ (bc4 &^ bc3)
+		a[13] = bc3 ^ (bc0 &^ bc4)
+		a[19] = bc4 ^ (bc1 &^ bc0)
+
+		t = a[5] ^ d0
+		bc1 = t<<36 | t>>(64-36)
+		t = a[11] ^ d1
+		bc2 = t<<10 | t>>(64-10)
+		t = a[17] ^ d2
+		bc3 = t<<15 | t>>(64-15)
+		t = a[23] ^ d3
+		bc4 = t<<56 | t>>(64-56)
+		t = a[4] ^ d4
+		bc0 = t<<27 | t>>(64-27)
+		a[5] = bc0 ^ (bc2 &^ bc1)
+		a[11] = bc1 ^ (bc3 &^ bc2)
+		a[17] = bc2 ^ (bc4 &^ bc3)
+		a[23] = bc3 ^ (bc0 &^ bc4)
+		a[4] = bc4 ^ (bc1 &^ bc0)
+
+		t = a[15] ^ d0
+		bc3 = t<<41 | t>>(64-41)
+		t = a[21] ^ d1
+		bc4 = t<<2 | t>>(64-2)
+		t = a[2] ^ d2
+		bc0 = t<<62 | t>>(64-62)
+		t = a[8] ^ d3
+		bc1 = t<<55 | t>>(64-55)
+		t = a[14] ^ d4
+		bc2 = t<<39 | t>>(64-39)
+		a[15] = bc0 ^ (bc2 &^ bc1)
+		a[21] = bc1 ^ (bc3 &^ bc2)
+		a[2] = bc2 ^ (bc4 &^ bc3)
+		a[8] = bc3 ^ (bc0 &^ bc4)
+		a[14] = bc4 ^ (bc1 &^ bc0)
+
+		// Round 2
+		bc0 = a[0] ^ a[5] ^ a[10] ^ a[15] ^ a[20]
+		bc1 = a[1] ^ a[6] ^ a[11] ^ a[16] ^ a[21]
+		bc2 = a[2] ^ a[7] ^ a[12] ^ a[17] ^ a[22]
+		bc3 = a[3] ^ a[8] ^ a[13] ^ a[18] ^ a[23]
+		bc4 = a[4] ^ a[9] ^ a[14] ^ a[19] ^ a[24]
+		d0 = bc4 ^ (bc1<<1 | bc1>>63)
+		d1 = bc0 ^ (bc2<<1 | bc2>>63)
+		d2 = bc1 ^ (bc3<<1 | bc3>>63)
+		d3 = bc2 ^ (bc4<<1 | bc4>>63)
+		d4 = bc3 ^ (bc0<<1 | bc0>>63)
+
+		bc0 = a[0] ^ d0
+		t = a[16] ^ d1
+		bc1 = t<<44 | t>>(64-44)
+		t = a[7] ^ d2
+		bc2 = t<<43 | t>>(64-43)
+		t = a[23] ^ d3
+		bc3 = t<<21 | t>>(64-21)
+		t = a[14] ^ d4
+		bc4 = t<<14 | t>>(64-14)
+		a[0] = bc0 ^ (bc2 &^ bc1) ^ rc[i+1]
+		a[16] = bc1 ^ (bc3 &^ bc2)
+		a[7] = bc2 ^ (bc4 &^ bc3)
+		a[23] = bc3 ^ (bc0 &^ bc4)
+		a[14] = bc4 ^ (bc1 &^ bc0)
+
+		t = a[20] ^ d0
+		bc2 = t<<3 | t>>(64-3)
+		t = a[11] ^ d1
+		bc3 = t<<45 | t>>(64-45)
+		t = a[2] ^ d2
+		bc4 = t<<61 | t>>(64-61)
+		t = a[18] ^ d3
+		bc0 = t<<28 | t>>(64-28)
+		t = a[9] ^ d4
+		bc1 = t<<20 | t>>(64-20)
+		a[20] = bc0 ^ (bc2 &^ bc1)
+		a[11] = bc1 ^ (bc3 &^ bc2)
+		a[2] = bc2 ^ (bc4 &^ bc3)
+		a[18] = bc3 ^ (bc0 &^ bc4)
+		a[9] = bc4 ^ (bc1 &^ bc0)
+
+		t = a[15] ^ d0
+		bc4 = t<<18 | t>>(64-18)
+		t = a[6] ^ d1
+		bc0 = t<<1 | t>>(64-1)
+		t = a[22] ^ d2
+		bc1 = t<<6 | t>>(64-6)
+		t = a[13] ^ d3
+		bc2 = t<<25 | t>>(64-25)
+		t = a[4] ^ d4
+		bc3 = t<<8 | t>>(64-8)
+		a[15] = bc0 ^ (bc2 &^ bc1)
+		a[6] = bc1 ^ (bc3 &^ bc2)
+		a[22] = bc2 ^ (bc4 &^ bc3)
+		a[13] = bc3 ^ (bc0 &^ bc4)
+		a[4] = bc4 ^ (bc1 &^ bc0)
+
+		t = a[10] ^ d0
+		bc1 = t<<36 | t>>(64-36)
+		t = a[1] ^ d1
+		bc2 = t<<10 | t>>(64-10)
+		t = a[17] ^ d2
+		bc3 = t<<15 | t>>(64-15)
+		t = a[8] ^ d3
+		bc4 = t<<56 | t>>(64-56)
+		t = a[24] ^ d4
+		bc0 = t<<27 | t>>(64-27)
+		a[10] = bc0 ^ (bc2 &^ bc1)
+		a[1] = bc1 ^ (bc3 &^ bc2)
+		a[17] = bc2 ^ (bc4 &^ bc3)
+		a[8] = bc3 ^ (bc0 &^ bc4)
+		a[24] = bc4 ^ (bc1 &^ bc0)
+
+		t = a[5] ^ d0
+		bc3 = t<<41 | t>>(64-41)
+		t = a[21] ^ d1
+		bc4 = t<<2 | t>>(64-2)
+		t = a[12] ^ d2
+		bc0 = t<<62 | t>>(64-62)
+		t = a[3] ^ d3
+		bc1 = t<<55 | t>>(64-55)
+		t = a[19] ^ d4
+		bc2 = t<<39 | t>>(64-39)
+		a[5] = bc0 ^ (bc2 &^ bc1)
+		a[21] = bc1 ^ (bc3 &^ bc2)
+		a[12] = bc2 ^ (bc4 &^ bc3)
+		a[3] = bc3 ^ (bc0 &^ bc4)
+		a[19] = bc4 ^ (bc1 &^ bc0)
+
+		// Round 3
+		bc0 = a[0] ^ a[5] ^ a[10] ^ a[15] ^ a[20]
+		bc1 = a[1] ^ a[6] ^ a[11] ^ a[16] ^ a[21]
+		bc2 = a[2] ^ a[7] ^ a[12] ^ a[17] ^ a[22]
+		bc3 = a[3] ^ a[8] ^ a[13] ^ a[18] ^ a[23]
+		bc4 = a[4] ^ a[9] ^ a[14] ^ a[19] ^ a[24]
+		d0 = bc4 ^ (bc1<<1 | bc1>>63)
+		d1 = bc0 ^ (bc2<<1 | bc2>>63)
+		d2 = bc1 ^ (bc3<<1 | bc3>>63)
+		d3 = bc2 ^ (bc4<<1 | bc4>>63)
+		d4 = bc3 ^ (bc0<<1 | bc0>>63)
+
+		bc0 = a[0] ^ d0
+		t = a[11] ^ d1
+		bc1 = t<<44 | t>>(64-44)
+		t = a[22] ^ d2
+		bc2 = t<<43 | t>>(64-43)
+		t = a[8] ^ d3
+		bc3 = t<<21 | t>>(64-21)
+		t = a[19] ^ d4
+		bc4 = t<<14 | t>>(64-14)
+		a[0] = bc0 ^ (bc2 &^ bc1) ^ rc[i+2]
+		a[11] = bc1 ^ (bc3 &^ bc2)
+		a[22] = bc2 ^ (bc4 &^ bc3)
+		a[8] = bc3 ^ (bc0 &^ bc4)
+		a[19] = bc4 ^ (bc1 &^ bc0)
+
+		t = a[15] ^ d0
+		bc2 = t<<3 | t>>(64-3)
+		t = a[1] ^ d1
+		bc3 = t<<45 | t>>(64-45)
+		t = a[12] ^ d2
+		bc4 = t<<61 | t>>(64-61)
+		t = a[23] ^ d3
+		bc0 = t<<28 | t>>(64-28)
+		t = a[9] ^ d4
+		bc1 = t<<20 | t>>(64-20)
+		a[15] = bc0 ^ (bc2 &^ bc1)
+		a[1] = bc1 ^ (bc3 &^ bc2)
+		a[12] = bc2 ^ (bc4 &^ bc3)
+		a[23] = bc3 ^ (bc0 &^ bc4)
+		a[9] = bc4 ^ (bc1 &^ bc0)
+
+		t = a[5] ^ d0
+		bc4 = t<<18 | t>>(64-18)
+		t = a[16] ^ d1
+		bc0 = t<<1 | t>>(64-1)
+		t = a[2] ^ d2
+		bc1 = t<<6 | t>>(64-6)
+		t = a[13] ^ d3
+		bc2 = t<<25 | t>>(64-25)
+		t = a[24] ^ d4
+		bc3 = t<<8 | t>>(64-8)
+		a[5] = bc0 ^ (bc2 &^ bc1)
+		a[16] = bc1 ^ (bc3 &^ bc2)
+		a[2] = bc2 ^ (bc4 &^ bc3)
+		a[13] = bc3 ^ (bc0 &^ bc4)
+		a[24] = bc4 ^ (bc1 &^ bc0)
+
+		t = a[20] ^ d0
+		bc1 = t<<36 | t>>(64-36)
+		t = a[6] ^ d1
+		bc2 = t<<10 | t>>(64-10)
+		t = a[17] ^ d2
+		bc3 = t<<15 | t>>(64-15)
+		t = a[3] ^ d3
+		bc4 = t<<56 | t>>(64-56)
+		t = a[14] ^ d4
+		bc0 = t<<27 | t>>(64-27)
+		a[20] = bc0 ^ (bc2 &^ bc1)
+		a[6] = bc1 ^ (bc3 &^ bc2)
+		a[17] = bc2 ^ (bc4 &^ bc3)
+		a[3] = bc3 ^ (bc0 &^ bc4)
+		a[14] = bc4 ^ (bc1 &^ bc0)
+
+		t = a[10] ^ d0
+		bc3 = t<<41 | t>>(64-41)
+		t = a[21] ^ d1
+		bc4 = t<<2 | t>>(64-2)
+		t = a[7] ^ d2
+		bc0 = t<<62 | t>>(64-62)
+		t = a[18] ^ d3
+		bc1 = t<<55 | t>>(64-55)
+		t = a[4] ^ d4
+		bc2 = t<<39 | t>>(64-39)
+		a[10] = bc0 ^ (bc2 &^ bc1)
+		a[21] = bc1 ^ (bc3 &^ bc2)
+		a[7] = bc2 ^ (bc4 &^ bc3)
+		a[18] = bc3 ^ (bc0 &^ bc4)
+		a[4] = bc4 ^ (bc1 &^ bc0)
+
+		// Round 4
+		bc0 = a[0] ^ a[5] ^ a[10] ^ a[15] ^ a[20]
+		bc1 = a[1] ^ a[6] ^ a[11] ^ a[16] ^ a[21]
+		bc2 = a[2] ^ a[7] ^ a[12] ^ a[17] ^ a[22]
+		bc3 = a[3] ^ a[8] ^ a[13] ^ a[18] ^ a[23]
+		bc4 = a[4] ^ a[9] ^ a[14] ^ a[19] ^ a[24]
+		d0 = bc4 ^ (bc1<<1 | bc1>>63)
+		d1 = bc0 ^ (bc2<<1 | bc2>>63)
+		d2 = bc1 ^ (bc3<<1 | bc3>>63)
+		d3 = bc2 ^ (bc4<<1 | bc4>>63)
+		d4 = bc3 ^ (bc0<<1 | bc0>>63)
+
+		bc0 = a[0] ^ d0
+		t = a[1] ^ d1
+		bc1 = t<<44 | t>>(64-44)
+		t = a[2] ^ d2
+		bc2 = t<<43 | t>>(64-43)
+		t = a[3] ^ d3
+		bc3 = t<<21 | t>>(64-21)
+		t = a[4] ^ d4
+		bc4 = t<<14 | t>>(64-14)
+		a[0] = bc0 ^ (bc2 &^ bc1) ^ rc[i+3]
+		a[1] = bc1 ^ (bc3 &^ bc2)
+		a[2] = bc2 ^ (bc4 &^ bc3)
+		a[3] = bc3 ^ (bc0 &^ bc4)
+		a[4] = bc4 ^ (bc1 &^ bc0)
+
+		t = a[5] ^ d0
+		bc2 = t<<3 | t>>(64-3)
+		t = a[6] ^ d1
+		bc3 = t<<45 | t>>(64-45)
+		t = a[7] ^ d2
+		bc4 = t<<61 | t>>(64-61)
+		t = a[8] ^ d3
+		bc0 = t<<28 | t>>(64-28)
+		t = a[9] ^ d4
+		bc1 = t<<20 | t>>(64-20)
+		a[5] = bc0 ^ (bc2 &^ bc1)
+		a[6] = bc1 ^ (bc3 &^ bc2)
+		a[7] = bc2 ^ (bc4 &^ bc3)
+		a[8] = bc3 ^ (bc0 &^ bc4)
+		a[9] = bc4 ^ (bc1 &^ bc0)
+
+		t = a[10] ^ d0
+		bc4 = t<<18 | t>>(64-18)
+		t = a[11] ^ d1
+		bc0 = t<<1 | t>>(64-1)
+		t = a[12] ^ d2
+		bc1 = t<<6 | t>>(64-6)
+		t = a[13] ^ d3
+		bc2 = t<<25 | t>>(64-25)
+		t = a[14] ^ d4
+		bc3 = t<<8 | t>>(64-8)
+		a[10] = bc0 ^ (bc2 &^ bc1)
+		a[11] = bc1 ^ (bc3 &^ bc2)
+		a[12] = bc2 ^ (bc4 &^ bc3)
+		a[13] = bc3 ^ (bc0 &^ bc4)
+		a[14] = bc4 ^ (bc1 &^ bc0)
+
+		t = a[15] ^ d0
+		bc1 = t<<36 | t>>(64-36)
+		t = a[16] ^ d1
+		bc2 = t<<10 | t>>(64-10)
+		t = a[17] ^ d2
+		bc3 = t<<15 | t>>(64-15)
+		t = a[18] ^ d3
+		bc4 = t<<56 | t>>(64-56)
+		t = a[19] ^ d4
+		bc0 = t<<27 | t>>(64-27)
+		a[15] = bc0 ^ (bc2 &^ bc1)
+		a[16] = bc1 ^ (bc3 &^ bc2)
+		a[17] = bc2 ^ (bc4 &^ bc3)
+		a[18] = bc3 ^ (bc0 &^ bc4)
+		a[19] = bc4 ^ (bc1 &^ bc0)
+
+		t = a[20] ^ d0
+		bc3 = t<<41 | t>>(64-41)
+		t = a[21] ^ d1
+		bc4 = t<<2 | t>>(64-2)
+		t = a[22] ^ d2
+		bc0 = t<<62 | t>>(64-62)
+		t = a[23] ^ d3
+		bc1 = t<<55 | t>>(64-55)
+		t = a[24] ^ d4
+		bc2 = t<<39 | t>>(64-39)
+		a[20] = bc0 ^ (bc2 &^ bc1)
+		a[21] = bc1 ^ (bc3 &^ bc2)
+		a[22] = bc2 ^ (bc4 &^ bc3)
+		a[23] = bc3 ^ (bc0 &^ bc4)
+		a[24] = bc4 ^ (bc1 &^ bc0)
+	}
+}

--- a/crypto/fixed/keccakf.go
+++ b/crypto/fixed/keccakf.go
@@ -1,10 +1,9 @@
 // This file is copied from golang/x/crypto/sha3/keccakf.go
-
 // Copyright 2014 The Go Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-//  +build !amd64 appengine gccgo
+//  +build !amd64 purego !gc
 
 package fixed
 

--- a/crypto/fixed/keccakf_amd64.go
+++ b/crypto/fixed/keccakf_amd64.go
@@ -1,0 +1,15 @@
+// This file is copied from golang/x/crypto/sha3/keccakf_amd64.go
+
+// Copyright 2015 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// +build amd64,!appengine,!gccgo
+
+package fixed
+
+// This function is implemented in keccakf_amd64.s.
+
+//go:noescape
+
+func keccakF1600(a *[25]uint64)

--- a/crypto/fixed/keccakf_amd64.go
+++ b/crypto/fixed/keccakf_amd64.go
@@ -4,7 +4,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-// +build amd64,!appengine,!gccgo
+// +build amd64,!purego,gc
 
 package fixed
 

--- a/crypto/fixed/keccakf_amd64.go
+++ b/crypto/fixed/keccakf_amd64.go
@@ -12,4 +12,4 @@ package fixed
 
 //go:noescape
 
-func keccakF1600(a *[25]uint64)
+func keccakF1600(state *[25]uint64)

--- a/crypto/fixed/keccakf_amd64.s
+++ b/crypto/fixed/keccakf_amd64.s
@@ -1,0 +1,392 @@
+// This file is copied from golang/x/crypto/sha3/keccakf_amd64.s
+
+// Copyright 2015 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// +build amd64,!appengine,!gccgo
+
+// This code was translated into a form compatible with 6a from the public
+// domain sources at https://github.com/gvanas/KeccakCodePackage
+
+// Offsets in state
+#define _ba  (0*8)
+#define _be  (1*8)
+#define _bi  (2*8)
+#define _bo  (3*8)
+#define _bu  (4*8)
+#define _ga  (5*8)
+#define _ge  (6*8)
+#define _gi  (7*8)
+#define _go  (8*8)
+#define _gu  (9*8)
+#define _ka (10*8)
+#define _ke (11*8)
+#define _ki (12*8)
+#define _ko (13*8)
+#define _ku (14*8)
+#define _ma (15*8)
+#define _me (16*8)
+#define _mi (17*8)
+#define _mo (18*8)
+#define _mu (19*8)
+#define _sa (20*8)
+#define _se (21*8)
+#define _si (22*8)
+#define _so (23*8)
+#define _su (24*8)
+
+// Temporary registers
+#define rT1  AX
+
+// Round vars
+#define rpState DI
+#define rpStack SP
+
+#define rDa BX
+#define rDe CX
+#define rDi DX
+#define rDo R8
+#define rDu R9
+
+#define rBa R10
+#define rBe R11
+#define rBi R12
+#define rBo R13
+#define rBu R14
+
+#define rCa SI
+#define rCe BP
+#define rCi rBi
+#define rCo rBo
+#define rCu R15
+
+#define MOVQ_RBI_RCE MOVQ rBi, rCe
+#define XORQ_RT1_RCA XORQ rT1, rCa
+#define XORQ_RT1_RCE XORQ rT1, rCe
+#define XORQ_RBA_RCU XORQ rBa, rCu
+#define XORQ_RBE_RCU XORQ rBe, rCu
+#define XORQ_RDU_RCU XORQ rDu, rCu
+#define XORQ_RDA_RCA XORQ rDa, rCa
+#define XORQ_RDE_RCE XORQ rDe, rCe
+
+#define mKeccakRound(iState, oState, rc, B_RBI_RCE, G_RT1_RCA, G_RT1_RCE, G_RBA_RCU, K_RT1_RCA, K_RT1_RCE, K_RBA_RCU, M_RT1_RCA, M_RT1_RCE, M_RBE_RCU, S_RDU_RCU, S_RDA_RCA, S_RDE_RCE) \
+	/* Prepare round */    \
+	MOVQ rCe, rDa;         \
+	ROLQ $1, rDa;          \
+	                       \
+	MOVQ _bi(iState), rCi; \
+	XORQ _gi(iState), rDi; \
+	XORQ rCu, rDa;         \
+	XORQ _ki(iState), rCi; \
+	XORQ _mi(iState), rDi; \
+	XORQ rDi, rCi;         \
+	                       \
+	MOVQ rCi, rDe;         \
+	ROLQ $1, rDe;          \
+	                       \
+	MOVQ _bo(iState), rCo; \
+	XORQ _go(iState), rDo; \
+	XORQ rCa, rDe;         \
+	XORQ _ko(iState), rCo; \
+	XORQ _mo(iState), rDo; \
+	XORQ rDo, rCo;         \
+	                       \
+	MOVQ rCo, rDi;         \
+	ROLQ $1, rDi;          \
+	                       \
+	MOVQ rCu, rDo;         \
+	XORQ rCe, rDi;         \
+	ROLQ $1, rDo;          \
+	                       \
+	MOVQ rCa, rDu;         \
+	XORQ rCi, rDo;         \
+	ROLQ $1, rDu;          \
+	                       \
+	/* Result b */         \
+	MOVQ _ba(iState), rBa; \
+	MOVQ _ge(iState), rBe; \
+	XORQ rCo, rDu;         \
+	MOVQ _ki(iState), rBi; \
+	MOVQ _mo(iState), rBo; \
+	MOVQ _su(iState), rBu; \
+	XORQ rDe, rBe;         \
+	ROLQ $44, rBe;         \
+	XORQ rDi, rBi;         \
+	XORQ rDa, rBa;         \
+	ROLQ $43, rBi;         \
+	                       \
+	MOVQ rBe, rCa;         \
+	MOVQ rc, rT1;          \
+	ORQ  rBi, rCa;         \
+	XORQ rBa, rT1;         \
+	XORQ rT1, rCa;         \
+	MOVQ rCa, _ba(oState); \
+	                       \
+	XORQ rDu, rBu;         \
+	ROLQ $14, rBu;         \
+	MOVQ rBa, rCu;         \
+	ANDQ rBe, rCu;         \
+	XORQ rBu, rCu;         \
+	MOVQ rCu, _bu(oState); \
+	                       \
+	XORQ rDo, rBo;         \
+	ROLQ $21, rBo;         \
+	MOVQ rBo, rT1;         \
+	ANDQ rBu, rT1;         \
+	XORQ rBi, rT1;         \
+	MOVQ rT1, _bi(oState); \
+	                       \
+	NOTQ rBi;              \
+	ORQ  rBa, rBu;         \
+	ORQ  rBo, rBi;         \
+	XORQ rBo, rBu;         \
+	XORQ rBe, rBi;         \
+	MOVQ rBu, _bo(oState); \
+	MOVQ rBi, _be(oState); \
+	B_RBI_RCE;             \
+	                       \
+	/* Result g */         \
+	MOVQ _gu(iState), rBe; \
+	XORQ rDu, rBe;         \
+	MOVQ _ka(iState), rBi; \
+	ROLQ $20, rBe;         \
+	XORQ rDa, rBi;         \
+	ROLQ $3, rBi;          \
+	MOVQ _bo(iState), rBa; \
+	MOVQ rBe, rT1;         \
+	ORQ  rBi, rT1;         \
+	XORQ rDo, rBa;         \
+	MOVQ _me(iState), rBo; \
+	MOVQ _si(iState), rBu; \
+	ROLQ $28, rBa;         \
+	XORQ rBa, rT1;         \
+	MOVQ rT1, _ga(oState); \
+	G_RT1_RCA;             \
+	                       \
+	XORQ rDe, rBo;         \
+	ROLQ $45, rBo;         \
+	MOVQ rBi, rT1;         \
+	ANDQ rBo, rT1;         \
+	XORQ rBe, rT1;         \
+	MOVQ rT1, _ge(oState); \
+	G_RT1_RCE;             \
+	                       \
+	XORQ rDi, rBu;         \
+	ROLQ $61, rBu;         \
+	MOVQ rBu, rT1;         \
+	ORQ  rBa, rT1;         \
+	XORQ rBo, rT1;         \
+	MOVQ rT1, _go(oState); \
+	                       \
+	ANDQ rBe, rBa;         \
+	XORQ rBu, rBa;         \
+	MOVQ rBa, _gu(oState); \
+	NOTQ rBu;              \
+	G_RBA_RCU;             \
+	                       \
+	ORQ  rBu, rBo;         \
+	XORQ rBi, rBo;         \
+	MOVQ rBo, _gi(oState); \
+	                       \
+	/* Result k */         \
+	MOVQ _be(iState), rBa; \
+	MOVQ _gi(iState), rBe; \
+	MOVQ _ko(iState), rBi; \
+	MOVQ _mu(iState), rBo; \
+	MOVQ _sa(iState), rBu; \
+	XORQ rDi, rBe;         \
+	ROLQ $6, rBe;          \
+	XORQ rDo, rBi;         \
+	ROLQ $25, rBi;         \
+	MOVQ rBe, rT1;         \
+	ORQ  rBi, rT1;         \
+	XORQ rDe, rBa;         \
+	ROLQ $1, rBa;          \
+	XORQ rBa, rT1;         \
+	MOVQ rT1, _ka(oState); \
+	K_RT1_RCA;             \
+	                       \
+	XORQ rDu, rBo;         \
+	ROLQ $8, rBo;          \
+	MOVQ rBi, rT1;         \
+	ANDQ rBo, rT1;         \
+	XORQ rBe, rT1;         \
+	MOVQ rT1, _ke(oState); \
+	K_RT1_RCE;             \
+	                       \
+	XORQ rDa, rBu;         \
+	ROLQ $18, rBu;         \
+	NOTQ rBo;              \
+	MOVQ rBo, rT1;         \
+	ANDQ rBu, rT1;         \
+	XORQ rBi, rT1;         \
+	MOVQ rT1, _ki(oState); \
+	                       \
+	MOVQ rBu, rT1;         \
+	ORQ  rBa, rT1;         \
+	XORQ rBo, rT1;         \
+	MOVQ rT1, _ko(oState); \
+	                       \
+	ANDQ rBe, rBa;         \
+	XORQ rBu, rBa;         \
+	MOVQ rBa, _ku(oState); \
+	K_RBA_RCU;             \
+	                       \
+	/* Result m */         \
+	MOVQ _ga(iState), rBe; \
+	XORQ rDa, rBe;         \
+	MOVQ _ke(iState), rBi; \
+	ROLQ $36, rBe;         \
+	XORQ rDe, rBi;         \
+	MOVQ _bu(iState), rBa; \
+	ROLQ $10, rBi;         \
+	MOVQ rBe, rT1;         \
+	MOVQ _mi(iState), rBo; \
+	ANDQ rBi, rT1;         \
+	XORQ rDu, rBa;         \
+	MOVQ _so(iState), rBu; \
+	ROLQ $27, rBa;         \
+	XORQ rBa, rT1;         \
+	MOVQ rT1, _ma(oState); \
+	M_RT1_RCA;             \
+	                       \
+	XORQ rDi, rBo;         \
+	ROLQ $15, rBo;         \
+	MOVQ rBi, rT1;         \
+	ORQ  rBo, rT1;         \
+	XORQ rBe, rT1;         \
+	MOVQ rT1, _me(oState); \
+	M_RT1_RCE;             \
+	                       \
+	XORQ rDo, rBu;         \
+	ROLQ $56, rBu;         \
+	NOTQ rBo;              \
+	MOVQ rBo, rT1;         \
+	ORQ  rBu, rT1;         \
+	XORQ rBi, rT1;         \
+	MOVQ rT1, _mi(oState); \
+	                       \
+	ORQ  rBa, rBe;         \
+	XORQ rBu, rBe;         \
+	MOVQ rBe, _mu(oState); \
+	                       \
+	ANDQ rBa, rBu;         \
+	XORQ rBo, rBu;         \
+	MOVQ rBu, _mo(oState); \
+	M_RBE_RCU;             \
+	                       \
+	/* Result s */         \
+	MOVQ _bi(iState), rBa; \
+	MOVQ _go(iState), rBe; \
+	MOVQ _ku(iState), rBi; \
+	XORQ rDi, rBa;         \
+	MOVQ _ma(iState), rBo; \
+	ROLQ $62, rBa;         \
+	XORQ rDo, rBe;         \
+	MOVQ _se(iState), rBu; \
+	ROLQ $55, rBe;         \
+	                       \
+	XORQ rDu, rBi;         \
+	MOVQ rBa, rDu;         \
+	XORQ rDe, rBu;         \
+	ROLQ $2, rBu;          \
+	ANDQ rBe, rDu;         \
+	XORQ rBu, rDu;         \
+	MOVQ rDu, _su(oState); \
+	                       \
+	ROLQ $39, rBi;         \
+	S_RDU_RCU;             \
+	NOTQ rBe;              \
+	XORQ rDa, rBo;         \
+	MOVQ rBe, rDa;         \
+	ANDQ rBi, rDa;         \
+	XORQ rBa, rDa;         \
+	MOVQ rDa, _sa(oState); \
+	S_RDA_RCA;             \
+	                       \
+	ROLQ $41, rBo;         \
+	MOVQ rBi, rDe;         \
+	ORQ  rBo, rDe;         \
+	XORQ rBe, rDe;         \
+	MOVQ rDe, _se(oState); \
+	S_RDE_RCE;             \
+	                       \
+	MOVQ rBo, rDi;         \
+	MOVQ rBu, rDo;         \
+	ANDQ rBu, rDi;         \
+	ORQ  rBa, rDo;         \
+	XORQ rBi, rDi;         \
+	XORQ rBo, rDo;         \
+	MOVQ rDi, _si(oState); \
+	MOVQ rDo, _so(oState)  \
+
+// func keccakF1600(state *[25]uint64)
+TEXT ·keccakF1600(SB), 0, $200-8
+	MOVQ state+0(FP), rpState
+
+	// Convert the user state into an internal state
+	NOTQ _be(rpState)
+	NOTQ _bi(rpState)
+	NOTQ _go(rpState)
+	NOTQ _ki(rpState)
+	NOTQ _mi(rpState)
+	NOTQ _sa(rpState)
+
+	// Execute the KeccakF permutation
+	MOVQ _ba(rpState), rCa
+	MOVQ _be(rpState), rCe
+	MOVQ _bu(rpState), rCu
+
+	XORQ _ga(rpState), rCa
+	XORQ _ge(rpState), rCe
+	XORQ _gu(rpState), rCu
+
+	XORQ _ka(rpState), rCa
+	XORQ _ke(rpState), rCe
+	XORQ _ku(rpState), rCu
+
+	XORQ _ma(rpState), rCa
+	XORQ _me(rpState), rCe
+	XORQ _mu(rpState), rCu
+
+	XORQ _sa(rpState), rCa
+	XORQ _se(rpState), rCe
+	MOVQ _si(rpState), rDi
+	MOVQ _so(rpState), rDo
+	XORQ _su(rpState), rCu
+
+	mKeccakRound(rpState, rpStack, $0x0000000000000001, MOVQ_RBI_RCE, XORQ_RT1_RCA, XORQ_RT1_RCE, XORQ_RBA_RCU, XORQ_RT1_RCA, XORQ_RT1_RCE, XORQ_RBA_RCU, XORQ_RT1_RCA, XORQ_RT1_RCE, XORQ_RBE_RCU, XORQ_RDU_RCU, XORQ_RDA_RCA, XORQ_RDE_RCE)
+	mKeccakRound(rpStack, rpState, $0x0000000000008082, MOVQ_RBI_RCE, XORQ_RT1_RCA, XORQ_RT1_RCE, XORQ_RBA_RCU, XORQ_RT1_RCA, XORQ_RT1_RCE, XORQ_RBA_RCU, XORQ_RT1_RCA, XORQ_RT1_RCE, XORQ_RBE_RCU, XORQ_RDU_RCU, XORQ_RDA_RCA, XORQ_RDE_RCE)
+	mKeccakRound(rpState, rpStack, $0x800000000000808a, MOVQ_RBI_RCE, XORQ_RT1_RCA, XORQ_RT1_RCE, XORQ_RBA_RCU, XORQ_RT1_RCA, XORQ_RT1_RCE, XORQ_RBA_RCU, XORQ_RT1_RCA, XORQ_RT1_RCE, XORQ_RBE_RCU, XORQ_RDU_RCU, XORQ_RDA_RCA, XORQ_RDE_RCE)
+	mKeccakRound(rpStack, rpState, $0x8000000080008000, MOVQ_RBI_RCE, XORQ_RT1_RCA, XORQ_RT1_RCE, XORQ_RBA_RCU, XORQ_RT1_RCA, XORQ_RT1_RCE, XORQ_RBA_RCU, XORQ_RT1_RCA, XORQ_RT1_RCE, XORQ_RBE_RCU, XORQ_RDU_RCU, XORQ_RDA_RCA, XORQ_RDE_RCE)
+	mKeccakRound(rpState, rpStack, $0x000000000000808b, MOVQ_RBI_RCE, XORQ_RT1_RCA, XORQ_RT1_RCE, XORQ_RBA_RCU, XORQ_RT1_RCA, XORQ_RT1_RCE, XORQ_RBA_RCU, XORQ_RT1_RCA, XORQ_RT1_RCE, XORQ_RBE_RCU, XORQ_RDU_RCU, XORQ_RDA_RCA, XORQ_RDE_RCE)
+	mKeccakRound(rpStack, rpState, $0x0000000080000001, MOVQ_RBI_RCE, XORQ_RT1_RCA, XORQ_RT1_RCE, XORQ_RBA_RCU, XORQ_RT1_RCA, XORQ_RT1_RCE, XORQ_RBA_RCU, XORQ_RT1_RCA, XORQ_RT1_RCE, XORQ_RBE_RCU, XORQ_RDU_RCU, XORQ_RDA_RCA, XORQ_RDE_RCE)
+	mKeccakRound(rpState, rpStack, $0x8000000080008081, MOVQ_RBI_RCE, XORQ_RT1_RCA, XORQ_RT1_RCE, XORQ_RBA_RCU, XORQ_RT1_RCA, XORQ_RT1_RCE, XORQ_RBA_RCU, XORQ_RT1_RCA, XORQ_RT1_RCE, XORQ_RBE_RCU, XORQ_RDU_RCU, XORQ_RDA_RCA, XORQ_RDE_RCE)
+	mKeccakRound(rpStack, rpState, $0x8000000000008009, MOVQ_RBI_RCE, XORQ_RT1_RCA, XORQ_RT1_RCE, XORQ_RBA_RCU, XORQ_RT1_RCA, XORQ_RT1_RCE, XORQ_RBA_RCU, XORQ_RT1_RCA, XORQ_RT1_RCE, XORQ_RBE_RCU, XORQ_RDU_RCU, XORQ_RDA_RCA, XORQ_RDE_RCE)
+	mKeccakRound(rpState, rpStack, $0x000000000000008a, MOVQ_RBI_RCE, XORQ_RT1_RCA, XORQ_RT1_RCE, XORQ_RBA_RCU, XORQ_RT1_RCA, XORQ_RT1_RCE, XORQ_RBA_RCU, XORQ_RT1_RCA, XORQ_RT1_RCE, XORQ_RBE_RCU, XORQ_RDU_RCU, XORQ_RDA_RCA, XORQ_RDE_RCE)
+	mKeccakRound(rpStack, rpState, $0x0000000000000088, MOVQ_RBI_RCE, XORQ_RT1_RCA, XORQ_RT1_RCE, XORQ_RBA_RCU, XORQ_RT1_RCA, XORQ_RT1_RCE, XORQ_RBA_RCU, XORQ_RT1_RCA, XORQ_RT1_RCE, XORQ_RBE_RCU, XORQ_RDU_RCU, XORQ_RDA_RCA, XORQ_RDE_RCE)
+	mKeccakRound(rpState, rpStack, $0x0000000080008009, MOVQ_RBI_RCE, XORQ_RT1_RCA, XORQ_RT1_RCE, XORQ_RBA_RCU, XORQ_RT1_RCA, XORQ_RT1_RCE, XORQ_RBA_RCU, XORQ_RT1_RCA, XORQ_RT1_RCE, XORQ_RBE_RCU, XORQ_RDU_RCU, XORQ_RDA_RCA, XORQ_RDE_RCE)
+	mKeccakRound(rpStack, rpState, $0x000000008000000a, MOVQ_RBI_RCE, XORQ_RT1_RCA, XORQ_RT1_RCE, XORQ_RBA_RCU, XORQ_RT1_RCA, XORQ_RT1_RCE, XORQ_RBA_RCU, XORQ_RT1_RCA, XORQ_RT1_RCE, XORQ_RBE_RCU, XORQ_RDU_RCU, XORQ_RDA_RCA, XORQ_RDE_RCE)
+	mKeccakRound(rpState, rpStack, $0x000000008000808b, MOVQ_RBI_RCE, XORQ_RT1_RCA, XORQ_RT1_RCE, XORQ_RBA_RCU, XORQ_RT1_RCA, XORQ_RT1_RCE, XORQ_RBA_RCU, XORQ_RT1_RCA, XORQ_RT1_RCE, XORQ_RBE_RCU, XORQ_RDU_RCU, XORQ_RDA_RCA, XORQ_RDE_RCE)
+	mKeccakRound(rpStack, rpState, $0x800000000000008b, MOVQ_RBI_RCE, XORQ_RT1_RCA, XORQ_RT1_RCE, XORQ_RBA_RCU, XORQ_RT1_RCA, XORQ_RT1_RCE, XORQ_RBA_RCU, XORQ_RT1_RCA, XORQ_RT1_RCE, XORQ_RBE_RCU, XORQ_RDU_RCU, XORQ_RDA_RCA, XORQ_RDE_RCE)
+	mKeccakRound(rpState, rpStack, $0x8000000000008089, MOVQ_RBI_RCE, XORQ_RT1_RCA, XORQ_RT1_RCE, XORQ_RBA_RCU, XORQ_RT1_RCA, XORQ_RT1_RCE, XORQ_RBA_RCU, XORQ_RT1_RCA, XORQ_RT1_RCE, XORQ_RBE_RCU, XORQ_RDU_RCU, XORQ_RDA_RCA, XORQ_RDE_RCE)
+	mKeccakRound(rpStack, rpState, $0x8000000000008003, MOVQ_RBI_RCE, XORQ_RT1_RCA, XORQ_RT1_RCE, XORQ_RBA_RCU, XORQ_RT1_RCA, XORQ_RT1_RCE, XORQ_RBA_RCU, XORQ_RT1_RCA, XORQ_RT1_RCE, XORQ_RBE_RCU, XORQ_RDU_RCU, XORQ_RDA_RCA, XORQ_RDE_RCE)
+	mKeccakRound(rpState, rpStack, $0x8000000000008002, MOVQ_RBI_RCE, XORQ_RT1_RCA, XORQ_RT1_RCE, XORQ_RBA_RCU, XORQ_RT1_RCA, XORQ_RT1_RCE, XORQ_RBA_RCU, XORQ_RT1_RCA, XORQ_RT1_RCE, XORQ_RBE_RCU, XORQ_RDU_RCU, XORQ_RDA_RCA, XORQ_RDE_RCE)
+	mKeccakRound(rpStack, rpState, $0x8000000000000080, MOVQ_RBI_RCE, XORQ_RT1_RCA, XORQ_RT1_RCE, XORQ_RBA_RCU, XORQ_RT1_RCA, XORQ_RT1_RCE, XORQ_RBA_RCU, XORQ_RT1_RCA, XORQ_RT1_RCE, XORQ_RBE_RCU, XORQ_RDU_RCU, XORQ_RDA_RCA, XORQ_RDE_RCE)
+	mKeccakRound(rpState, rpStack, $0x000000000000800a, MOVQ_RBI_RCE, XORQ_RT1_RCA, XORQ_RT1_RCE, XORQ_RBA_RCU, XORQ_RT1_RCA, XORQ_RT1_RCE, XORQ_RBA_RCU, XORQ_RT1_RCA, XORQ_RT1_RCE, XORQ_RBE_RCU, XORQ_RDU_RCU, XORQ_RDA_RCA, XORQ_RDE_RCE)
+	mKeccakRound(rpStack, rpState, $0x800000008000000a, MOVQ_RBI_RCE, XORQ_RT1_RCA, XORQ_RT1_RCE, XORQ_RBA_RCU, XORQ_RT1_RCA, XORQ_RT1_RCE, XORQ_RBA_RCU, XORQ_RT1_RCA, XORQ_RT1_RCE, XORQ_RBE_RCU, XORQ_RDU_RCU, XORQ_RDA_RCA, XORQ_RDE_RCE)
+	mKeccakRound(rpState, rpStack, $0x8000000080008081, MOVQ_RBI_RCE, XORQ_RT1_RCA, XORQ_RT1_RCE, XORQ_RBA_RCU, XORQ_RT1_RCA, XORQ_RT1_RCE, XORQ_RBA_RCU, XORQ_RT1_RCA, XORQ_RT1_RCE, XORQ_RBE_RCU, XORQ_RDU_RCU, XORQ_RDA_RCA, XORQ_RDE_RCE)
+	mKeccakRound(rpStack, rpState, $0x8000000000008080, MOVQ_RBI_RCE, XORQ_RT1_RCA, XORQ_RT1_RCE, XORQ_RBA_RCU, XORQ_RT1_RCA, XORQ_RT1_RCE, XORQ_RBA_RCU, XORQ_RT1_RCA, XORQ_RT1_RCE, XORQ_RBE_RCU, XORQ_RDU_RCU, XORQ_RDA_RCA, XORQ_RDE_RCE)
+	mKeccakRound(rpState, rpStack, $0x0000000080000001, MOVQ_RBI_RCE, XORQ_RT1_RCA, XORQ_RT1_RCE, XORQ_RBA_RCU, XORQ_RT1_RCA, XORQ_RT1_RCE, XORQ_RBA_RCU, XORQ_RT1_RCA, XORQ_RT1_RCE, XORQ_RBE_RCU, XORQ_RDU_RCU, XORQ_RDA_RCA, XORQ_RDE_RCE)
+	mKeccakRound(rpStack, rpState, $0x8000000080008008, NOP, NOP, NOP, NOP, NOP, NOP, NOP, NOP, NOP, NOP, NOP, NOP, NOP)
+
+	// Revert the internal state to the user state
+	NOTQ _be(rpState)
+	NOTQ _bi(rpState)
+	NOTQ _go(rpState)
+	NOTQ _ki(rpState)
+	NOTQ _mi(rpState)
+	NOTQ _sa(rpState)
+
+	RET

--- a/crypto/fixed/keccakf_amd64.s
+++ b/crypto/fixed/keccakf_amd64.s
@@ -4,7 +4,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-// +build amd64,!appengine,!gccgo
+// +build amd64,!purego,gc
 
 // This code was translated into a form compatible with 6a from the public
 // domain sources at https://github.com/gvanas/KeccakCodePackage

--- a/light/trie.go
+++ b/light/trie.go
@@ -101,7 +101,7 @@ type odrTrie struct {
 	trie *trie.Trie
 }
 
-func (t *odrTrie) TryGet(key []byte) ([]byte, error) {
+func (t *odrTrie) tryGet(key []byte) ([]byte, error) {
 	key = crypto.Keccak256(key)
 	var res []byte
 	err := t.do(key, func() (err error) {
@@ -111,6 +111,16 @@ func (t *odrTrie) TryGet(key []byte) ([]byte, error) {
 	return res, err
 }
 
+// TryGetHash implements state.Trie interface
+func (t *odrTrie) TryGetHash(key common.Hash) ([]byte, error) {
+	return t.tryGet(key.Bytes())
+}
+
+// TryGetAddress implements state.Trie interface
+func (t *odrTrie) TryGetAddress(key common.Address) ([]byte, error) {
+	return t.tryGet(key.Bytes())
+}
+
 func (t *odrTrie) TryUpdate(key, value []byte) error {
 	key = crypto.Keccak256(key)
 	return t.do(key, func() error {
@@ -118,11 +128,31 @@ func (t *odrTrie) TryUpdate(key, value []byte) error {
 	})
 }
 
+// TryUpdateHash implements state.Trie interface
+func (t *odrTrie) TryUpdateHash(key common.Hash, value []byte) error {
+	return t.TryUpdate(key.Bytes(), value)
+}
+
+// TryUpdateAddress implements state.Trie interface
+func (t *odrTrie) TryUpdateAddress(key common.Address, value []byte) error {
+	return t.TryUpdate(key.Bytes(), value)
+}
+
 func (t *odrTrie) TryDelete(key []byte) error {
 	key = crypto.Keccak256(key)
 	return t.do(key, func() error {
 		return t.trie.TryDelete(key)
 	})
+}
+
+// TryDeleteHash implements state.Trie interface
+func (t *odrTrie) TryDeleteHash(key common.Hash) error {
+	return t.TryDelete(key.Bytes())
+}
+
+// TryDeleteAddress implements state.Trie interface
+func (t *odrTrie) TryDeleteAddress(key common.Address) error {
+	return t.TryDelete(key.Bytes())
 }
 
 func (t *odrTrie) Commit(onleaf trie.LeafCallback) (common.Hash, error) {

--- a/trie/errors.go
+++ b/trie/errors.go
@@ -22,7 +22,7 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 )
 
-// MissingNodeError is returned by the trie functions (TryGet, TryUpdate, TryDelete)
+// MissingNodeError is returned by the trie functions (TryUpdateXXX, TryDeleteXXX)
 // in the case where a trie node is not present in the local database. It contains
 // information necessary for retrieving the missing node.
 type MissingNodeError struct {


### PR DESCRIPTION
This is a bit of an experiment, which turned out pretty nicely. 
This PR makes it possible to do keccak hashes of `[20]byte` and `[32]byte` (i.e: `Address` and `Hash`) 2-3x faster and without any allocs:
```
[user@work crypto]$ go test . -run - -bench KeccakHash
goos: linux
goarch: amd64
pkg: github.com/ethereum/go-ethereum/crypto
BenchmarkKeccakHash/generic-20-6                 1363515               976 ns/op             480 B/op          2 allocs/op
BenchmarkKeccakHash/fixed-20-6                   2680185               473 ns/op               0 B/op          0 allocs/op
BenchmarkKeccakHash/generic-32-6                  808141              1263 ns/op             480 B/op          2 allocs/op
BenchmarkKeccakHash/fixed-32-6                   2611064               448 ns/op               0 B/op          0 allocs/op
```
So far, this PR isnt' actually used anywhere, but we have a few places in the code where we do these operations. I'll integrate it into those places and convert the draft into an actual PR. 