### PR TITLE
common,crypto: move fuzzers out of core

### DIFF
--- a/oss-fuzz.sh
+++ b/oss-fuzz.sh
@@ -26,37 +26,80 @@
 # $CFLAGS, $CXXFLAGS    C and C++ compiler flags.
 # $LIB_FUZZING_ENGINE   C++ compiler argument to link fuzz target against the prebuilt engine library (e.g. libFuzzer).
 
+# This sets the -coverpgk for the coverage report when the corpus is executed through go test
+coverpkg="github.com/ethereum/go-ethereum/..."
+
+function coverbuild {
+  path=$1
+  function=$2
+  fuzzer=$3
+  tags=""
+
+  if [[ $#  -eq 4 ]]; then
+    tags="-tags $4"
+  fi
+  cd $path
+  fuzzed_package=`pwd | rev | cut -d'/' -f 1 | rev`
+  cp $GOPATH/ossfuzz_coverage_runner.go ./"${function,,}"_test.go
+  sed -i -e 's/FuzzFunction/'$function'/' ./"${function,,}"_test.go
+  sed -i -e 's/mypackagebeingfuzzed/'$fuzzed_package'/' ./"${function,,}"_test.go
+  sed -i -e 's/TestFuzzCorpus/Test'$function'Corpus/' ./"${function,,}"_test.go
+
+cat << DOG > $OUT/$fuzzer
+#/bin/sh
+
+  cd $OUT/$path
+  go test -run Test${function}Corpus -v $tags -coverprofile \$1 -coverpkg $coverpkg
+
+DOG
+
+  chmod +x $OUT/$fuzzer
+  #echo "Built script $OUT/$fuzzer"
+  #cat $OUT/$fuzzer
+  cd -
+}
+
 function compile_fuzzer {
-  path=$SRC/go-ethereum/$1
+  # Inputs:
+  # $1: The package to fuzz, within go-ethereum
+  # $2: The name of the fuzzing function
+  # $3: The name to give to the final fuzzing-binary
+
+  path=$GOPATH/src/github.com/ethereum/go-ethereum/$1
   func=$2
   fuzzer=$3
-  corpusfile="${path}/testdata/${fuzzer}_seed_corpus.zip"
-  echo "Building $fuzzer (expecting corpus at $corpusfile)"
-  (cd $path && \
-        go-fuzz -func $func -o $WORK/$fuzzer.a . && \
-        echo "First stage built OK" && \
-        $CXX $CXXFLAGS $LIB_FUZZING_ENGINE $WORK/$fuzzer.a -o $OUT/$fuzzer && \
-        echo "Second stage built ok" )
 
-        ## Check if there exists a seed corpus file
-        if [ -f $corpusfile ]
-        then
-          cp $corpusfile $OUT/
-          echo "Found seed corpus: $corpusfile"
-        fi
+  echo "Building $fuzzer"
+
+  # Do a coverage-build or a regular build
+  if [[ $SANITIZER = *coverage* ]]; then
+    coverbuild $path $func $fuzzer $coverpkg
+  else
+    (cd $path && \
+        go-fuzz -func $func -o $WORK/$fuzzer.a . && \
+        $CXX $CXXFLAGS $LIB_FUZZING_ENGINE $WORK/$fuzzer.a -o $OUT/$fuzzer)
+  fi
+
+  ## Check if there exists a seed corpus file
+  corpusfile="${path}/testdata/${fuzzer}_seed_corpus.zip"
+  if [ -f $corpusfile ]
+  then
+    cp $corpusfile $OUT/
+    echo "Found seed corpus: $corpusfile"
+  fi
 }
 
 compile_fuzzer tests/fuzzers/bitutil  Fuzz      fuzzBitutilCompress
 compile_fuzzer tests/fuzzers/bn256    FuzzAdd   fuzzBn256Add
 compile_fuzzer tests/fuzzers/bn256    FuzzMul   fuzzBn256Mul
 compile_fuzzer tests/fuzzers/bn256    FuzzPair  fuzzBn256Pair
-compile_fuzzer tests/fuzzers/runtime Fuzz      fuzzVmRuntime
+compile_fuzzer tests/fuzzers/runtime  Fuzz      fuzzVmRuntime
 compile_fuzzer tests/fuzzers/keystore   Fuzz fuzzKeystore
 compile_fuzzer tests/fuzzers/txfetcher  Fuzz fuzzTxfetcher
 compile_fuzzer tests/fuzzers/rlp        Fuzz fuzzRlp
 compile_fuzzer tests/fuzzers/trie       Fuzz fuzzTrie
 compile_fuzzer tests/fuzzers/stacktrie  Fuzz fuzzStackTrie
-compile_fuzzer tests/fuzzers/difficulty  Fuzz fuzzDifficulty
+compile_fuzzer tests/fuzzers/difficulty Fuzz fuzzDifficulty
 
 compile_fuzzer tests/fuzzers/bls12381  FuzzG1Add fuzz_g1_add
 compile_fuzzer tests/fuzzers/bls12381  FuzzG1Mul fuzz_g1_mul

--- a/oss-fuzz.sh
+++ b/oss-fuzz.sh
@@ -46,10 +46,10 @@ function compile_fuzzer {
         fi
 }
 
-compile_fuzzer common/bitutil  Fuzz      fuzzBitutilCompress
-compile_fuzzer crypto/bn256    FuzzAdd   fuzzBn256Add
-compile_fuzzer crypto/bn256    FuzzMul   fuzzBn256Mul
-compile_fuzzer crypto/bn256    FuzzPair  fuzzBn256Pair
+compile_fuzzer tests/fuzzers/bitutil  Fuzz      fuzzBitutilCompress
+compile_fuzzer tests/fuzzers/bn256    FuzzAdd   fuzzBn256Add
+compile_fuzzer tests/fuzzers/bn256    FuzzMul   fuzzBn256Mul
+compile_fuzzer tests/fuzzers/bn256    FuzzPair  fuzzBn256Pair
 compile_fuzzer core/vm/runtime Fuzz      fuzzVmRuntime
 compile_fuzzer crypto/blake2b  Fuzz      fuzzBlake2b
 compile_fuzzer tests/fuzzers/keystore   Fuzz fuzzKeystore

--- a/oss-fuzz.sh
+++ b/oss-fuzz.sh
@@ -50,8 +50,7 @@ compile_fuzzer tests/fuzzers/bitutil  Fuzz      fuzzBitutilCompress
 compile_fuzzer tests/fuzzers/bn256    FuzzAdd   fuzzBn256Add
 compile_fuzzer tests/fuzzers/bn256    FuzzMul   fuzzBn256Mul
 compile_fuzzer tests/fuzzers/bn256    FuzzPair  fuzzBn256Pair
-compile_fuzzer core/vm/runtime Fuzz      fuzzVmRuntime
-compile_fuzzer crypto/blake2b  Fuzz      fuzzBlake2b
+compile_fuzzer tests/fuzzers/runtime Fuzz      fuzzVmRuntime
 compile_fuzzer tests/fuzzers/keystore   Fuzz fuzzKeystore
 compile_fuzzer tests/fuzzers/txfetcher  Fuzz fuzzTxfetcher
 compile_fuzzer tests/fuzzers/rlp        Fuzz fuzzRlp
@@ -68,6 +67,10 @@ compile_fuzzer tests/fuzzers/bls12381  FuzzG2MultiExp fuzz_g2_multiexp
 compile_fuzzer tests/fuzzers/bls12381  FuzzPairing fuzz_pairing
 compile_fuzzer tests/fuzzers/bls12381  FuzzMapG1 fuzz_map_g1
 compile_fuzzer tests/fuzzers/bls12381  FuzzMapG2 fuzz_map_g2
+
+#TODO: move this to tests/fuzzers, if possible
+compile_fuzzer crypto/blake2b  Fuzz      fuzzBlake2b
+
 
 # This doesn't work very well @TODO
 #compile_fuzzertests/fuzzers/abi Fuzz fuzzAbi

--- a/tests/fuzzers/bitutil/compress_fuzz.go
+++ b/tests/fuzzers/bitutil/compress_fuzz.go
@@ -14,11 +14,13 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
 
-// +build gofuzz
-
 package bitutil
 
-import "bytes"
+import (
+	"bytes"
+
+	"github.com/ethereum/go-ethereum/common/bitutil"
+)
 
 // Fuzz implements a go-fuzz fuzzer method to test various encoding method
 // invocations.
@@ -35,7 +37,7 @@ func Fuzz(data []byte) int {
 // fuzzEncode implements a go-fuzz fuzzer method to test the bitset encoding and
 // decoding algorithm.
 func fuzzEncode(data []byte) int {
-	proc, _ := bitsetDecodeBytes(bitsetEncodeBytes(data), len(data))
+	proc, _ := bitutil.DecompressBytes(bitutil.CompressBytes(data), len(data))
 	if !bytes.Equal(data, proc) {
 		panic("content mismatch")
 	}
@@ -45,11 +47,11 @@ func fuzzEncode(data []byte) int {
 // fuzzDecode implements a go-fuzz fuzzer method to test the bit decoding and
 // reencoding algorithm.
 func fuzzDecode(data []byte) int {
-	blob, err := bitsetDecodeBytes(data, 1024)
+	blob, err := bitutil.DecompressBytes(data, 1024)
 	if err != nil {
 		return 0
 	}
-	if comp := bitsetEncodeBytes(blob); !bytes.Equal(comp, data) {
+	if comp := bitutil.CompressBytes(blob); !bytes.Equal(comp, data) {
 		panic("content mismatch")
 	}
 	return 1

--- a/tests/fuzzers/bn256/bn256_fuzz.go
+++ b/tests/fuzzers/bn256/bn256_fuzz.go
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be found
 // in the LICENSE file.
 
-// +build gofuzz
-
 package bn256
 
 import (
@@ -24,7 +22,7 @@ func getG1Points(input io.Reader) (*cloudflare.G1, *google.G1) {
 	}
 	xg := new(google.G1)
 	if _, err := xg.Unmarshal(xc.Marshal()); err != nil {
-		panic(fmt.Sprintf("Could not marshal cloudflare -> google:", err))
+		panic(fmt.Sprintf("Could not marshal cloudflare -> google: %v", err))
 	}
 	return xc, xg
 }
@@ -37,7 +35,7 @@ func getG2Points(input io.Reader) (*cloudflare.G2, *google.G2) {
 	}
 	xg := new(google.G2)
 	if _, err := xg.Unmarshal(xc.Marshal()); err != nil {
-		panic(fmt.Sprintf("Could not marshal cloudflare -> google:", err))
+		panic(fmt.Sprintf("Could not marshal cloudflare -> google: %v", err))
 	}
 	return xc, xg
 }

--- a/tests/fuzzers/runtime/runtime_fuzz.go
+++ b/tests/fuzzers/runtime/runtime_fuzz.go
@@ -14,23 +14,23 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
 
-// +build gofuzz
-
 package runtime
+
+import (
+	"github.com/ethereum/go-ethereum/core/vm/runtime"
+)
 
 // Fuzz is the basic entry point for the go-fuzz tool
 //
 // This returns 1 for valid parsable/runable code, 0
 // for invalid opcode.
 func Fuzz(input []byte) int {
-	_, _, err := Execute(input, input, &Config{
-		GasLimit: 3000000,
+	_, _, err := runtime.Execute(input, input, &runtime.Config{
+		GasLimit: 12000000,
 	})
-
 	// invalid opcode
 	if err != nil && len(err.Error()) > 6 && string(err.Error()[:7]) == "invalid" {
 		return 0
 	}
-
 	return 1
 }

--- a/tests/fuzzers/runtime/runtime_fuzz.go
+++ b/tests/fuzzers/runtime/runtime_fuzz.go
@@ -29,7 +29,7 @@ func Fuzz(input []byte) int {
 		GasLimit: 12000000,
 	})
 	// invalid opcode
-	if err != nil && len(err.Error()) > 6 && string(err.Error()[:7]) == "invalid" {
+	if err != nil && len(err.Error()) > 6 && err.Error()[:7] == "invalid" {
 		return 0
 	}
 	return 1


### PR DESCRIPTION
This is one step towards getting coverage reports, a'la https://github.com/google/oss-fuzz/issues/4847 . 
A couple of our fuzzers reside within the go-ethereum core codebase. This is fine, except that in order to not include them in regular builds, they've been tagged with `// +build gofuzz`, to only be included in the fuzzed images. 

However, the coverage reports are based on runinng regular `go test ... ` on a testcase which simply feeds the corpus through the `Fuzz` function. And the `Fuzz` function is not visible in that case, since the build-tag is not active when not running via `go-fuzz`. 

So a better approach is to move the fuzzers into `tests/`, and remove the build tag. 
We still have some other cases where it's more difficult to move them, since the fuzzing relies on un-exported fields (blake2b), but this is a start.