### PR TITLE
ethclient, web3ext: rerouted net_version to eth_chainID

### DIFF
--- a/ethclient/ethclient.go
+++ b/ethclient/ethclient.go
@@ -339,15 +339,7 @@ func (ec *Client) SubscribeNewHead(ctx context.Context, ch chan<- *types.Header)
 
 // NetworkID returns the network ID (also known as the chain ID) for this chain.
 func (ec *Client) NetworkID(ctx context.Context) (*big.Int, error) {
-	version := new(big.Int)
-	var ver string
-	if err := ec.c.CallContext(ctx, &ver, "net_version"); err != nil {
-		return nil, err
-	}
-	if _, ok := version.SetString(ver, 10); !ok {
-		return nil, fmt.Errorf("invalid net_version result %q", ver)
-	}
-	return version, nil
+	return ec.ChainID(ctx)
 }
 
 // BalanceAt returns the wei balance of the given account.

--- a/internal/web3ext/web3ext.go
+++ b/internal/web3ext/web3ext.go
@@ -633,7 +633,7 @@ web3._extend({
 	properties: [
 		new web3._extend.Property({
 			name: 'version',
-			getter: 'net_version'
+			getter: 'eth_chainId'
 		}),
 	]
 });


### PR DESCRIPTION
TODO
* check if it still works if `eth` is disabled but `net` is enabled

rel: https://github.com/ethereum/go-ethereum/issues/22034