### PR TITLE
eth/downloader: removed unnecessary invalid chain error check

### DIFF
--- a/eth/downloader/queue.go
+++ b/eth/downloader/queue.go
@@ -893,9 +893,6 @@ func (q *queue) deliver(id string, taskPool map[common.Hash]*types.Header,
 		return accepted, nil
 	}
 	// If none of the data was good, it's a stale delivery
-	if errors.Is(failure, errInvalidChain) {
-		return accepted, failure
-	}
 	if accepted > 0 {
 		return accepted, fmt.Errorf("partial failure: %v", failure)
 	}


### PR DESCRIPTION
In downloader queue update (#21263), the invalid chain error assignment is removed. 
So, the invalid chain error checking is not necessary anymore.