### PR TITLE
internal/ethapi: re-add net_version RPC method

### DIFF
--- a/eth/backend.go
+++ b/eth/backend.go
@@ -230,7 +230,7 @@ func New(stack *node.Node, config *Config) (*Ethereum, error) {
 		return nil, err
 	}
 	// Start the RPC service
-	eth.netRPCService = ethapi.NewPublicNetAPI(eth.p2pServer)
+	eth.netRPCService = ethapi.NewPublicNetAPI(eth.p2pServer, config.NetworkId)
 
 	// Register the backend on the node
 	stack.RegisterAPIs(eth.APIs())

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -1900,12 +1900,13 @@ func (api *PrivateDebugAPI) SetHead(number hexutil.Uint64) {
 
 // PublicNetAPI offers network related RPC methods
 type PublicNetAPI struct {
-	net *p2p.Server
+	net            *p2p.Server
+	networkVersion uint64
 }
 
 // NewPublicNetAPI creates a new net API instance.
-func NewPublicNetAPI(net *p2p.Server) *PublicNetAPI {
-	return &PublicNetAPI{net}
+func NewPublicNetAPI(net *p2p.Server, networkVersion uint64) *PublicNetAPI {
+	return &PublicNetAPI{net, networkVersion}
 }
 
 // Listening returns an indication if the node is listening for network connections.
@@ -1916,6 +1917,11 @@ func (s *PublicNetAPI) Listening() bool {
 // PeerCount returns the number of connected peers
 func (s *PublicNetAPI) PeerCount() hexutil.Uint {
 	return hexutil.Uint(s.net.PeerCount())
+}
+
+// Version returns the current ethereum protocol version.
+func (s *PublicNetAPI) Version() string {
+	return fmt.Sprintf("%d", s.networkVersion)
 }
 
 // checkTxFee is an internal function used to check whether the fee of

--- a/les/client.go
+++ b/les/client.go
@@ -171,7 +171,7 @@ func New(stack *node.Node, config *eth.Config) (*LightEthereum, error) {
 		leth.blockchain.DisableCheckFreq()
 	}
 
-	leth.netRPCService = ethapi.NewPublicNetAPI(leth.p2pServer)
+	leth.netRPCService = ethapi.NewPublicNetAPI(leth.p2pServer, leth.config.NetworkId)
 
 	// Register the backend on the node
 	stack.RegisterAPIs(leth.APIs())


### PR DESCRIPTION
During the snap and eth refactor, the net_version rpc call was falsely deprecated.
This reenables the net_version RPC handler as most eth2 nodes and other software
depends on it.

closes https://github.com/ethereum/go-ethereum/issues/22059
closes https://github.com/ethereum/go-ethereum/issues/22057
closes https://github.com/ethereum/go-ethereum/issues/22034