### PR TITLE
internal/ethapi: restore eth_protocolVersion method

### DIFF
--- a/eth/backend.go
+++ b/eth/backend.go
@@ -310,9 +310,20 @@ func (s *Ethereum) APIs() []rpc.API {
 	// Append any APIs exposed explicitly by the consensus engine
 	apis = append(apis, s.engine.APIs(s.BlockChain())...)
 
+	// Retrieve network protocol version if available
+	var protocolVersion uint
+	if len(s.p2pServer.Config.Protocols) > 0 {
+		protocolVersion = s.p2pServer.Config.Protocols[0].Version
+	}
+
 	// Append all the local APIs and return
 	return append(apis, []rpc.API{
 		{
+			Namespace: "eth",
+			Version:   "1.0",
+			Service:   ethapi.NewPublicEthereumAPI(s.APIBackend, protocolVersion),
+			Public:    true,
+		}, {
 			Namespace: "eth",
 			Version:   "1.0",
 			Service:   NewPublicEthereumAPI(s),

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -50,12 +50,13 @@ import (
 // PublicEthereumAPI provides an API to access Ethereum related information.
 // It offers only methods that operate on public data that is freely available to anyone.
 type PublicEthereumAPI struct {
-	b Backend
+	b               Backend
+	protocolVersion uint
 }
 
 // NewPublicEthereumAPI creates a new Ethereum protocol API.
-func NewPublicEthereumAPI(b Backend) *PublicEthereumAPI {
-	return &PublicEthereumAPI{b}
+func NewPublicEthereumAPI(b Backend, protocolVersion uint) *PublicEthereumAPI {
+	return &PublicEthereumAPI{b, protocolVersion}
 }
 
 // GasPrice returns a suggestion for a gas price.
@@ -86,6 +87,11 @@ func (s *PublicEthereumAPI) Syncing() (interface{}, error) {
 		"pulledStates":  hexutil.Uint64(progress.PulledStates),
 		"knownStates":   hexutil.Uint64(progress.KnownStates),
 	}, nil
+}
+
+// ProtocolVersion returns the current Ethereum protocol version this node supports
+func (s *PublicEthereumAPI) ProtocolVersion() hexutil.Uint {
+	return hexutil.Uint(s.protocolVersion)
 }
 
 // PublicTxPoolAPI offers and API for the transaction pool. It only operates on data that is non confidential.

--- a/internal/ethapi/backend.go
+++ b/internal/ethapi/backend.go
@@ -91,46 +91,40 @@ type Backend interface {
 
 func GetAPIs(apiBackend Backend) []rpc.API {
 	nonceLock := new(AddrLocker)
-	return []rpc.API{
-		{
-			Namespace: "eth",
-			Version:   "1.0",
-			Service:   NewPublicEthereumAPI(apiBackend),
-			Public:    true,
-		}, {
-			Namespace: "eth",
-			Version:   "1.0",
-			Service:   NewPublicBlockChainAPI(apiBackend),
-			Public:    true,
-		}, {
-			Namespace: "eth",
-			Version:   "1.0",
-			Service:   NewPublicTransactionPoolAPI(apiBackend, nonceLock),
-			Public:    true,
-		}, {
-			Namespace: "txpool",
-			Version:   "1.0",
-			Service:   NewPublicTxPoolAPI(apiBackend),
-			Public:    true,
-		}, {
-			Namespace: "debug",
-			Version:   "1.0",
-			Service:   NewPublicDebugAPI(apiBackend),
-			Public:    true,
-		}, {
-			Namespace: "debug",
-			Version:   "1.0",
-			Service:   NewPrivateDebugAPI(apiBackend),
-		}, {
-			Namespace: "eth",
-			Version:   "1.0",
-			Service:   NewPublicAccountAPI(apiBackend.AccountManager()),
-			Public:    true,
-		}, {
-			Namespace: "personal",
-			Version:   "1.0",
-			Service:   NewPrivateAccountAPI(apiBackend, nonceLock),
-			Public:    false,
-		},
+	return []rpc.API{{
+		Namespace: "eth",
+		Version:   "1.0",
+		Service:   NewPublicBlockChainAPI(apiBackend),
+		Public:    true,
+	}, {
+		Namespace: "eth",
+		Version:   "1.0",
+		Service:   NewPublicTransactionPoolAPI(apiBackend, nonceLock),
+		Public:    true,
+	}, {
+		Namespace: "txpool",
+		Version:   "1.0",
+		Service:   NewPublicTxPoolAPI(apiBackend),
+		Public:    true,
+	}, {
+		Namespace: "debug",
+		Version:   "1.0",
+		Service:   NewPublicDebugAPI(apiBackend),
+		Public:    true,
+	}, {
+		Namespace: "debug",
+		Version:   "1.0",
+		Service:   NewPrivateDebugAPI(apiBackend),
+	}, {
+		Namespace: "eth",
+		Version:   "1.0",
+		Service:   NewPublicAccountAPI(apiBackend.AccountManager()),
+		Public:    true,
+	}, {
+		Namespace: "personal",
+		Version:   "1.0",
+		Service:   NewPrivateAccountAPI(apiBackend, nonceLock),
+		Public:    false,
+	},
 	}
 }

--- a/les/client.go
+++ b/les/client.go
@@ -238,8 +238,17 @@ func (s *LightDummyAPI) Mining() bool {
 func (s *LightEthereum) APIs() []rpc.API {
 	apis := ethapi.GetAPIs(s.ApiBackend)
 	apis = append(apis, s.engine.APIs(s.BlockChain().HeaderChain())...)
+	var protocolVersion uint
+	if len(s.p2pServer.Config.Protocols) > 0 {
+		protocolVersion = s.p2pServer.Config.Protocols[0].Version
+	}
 	return append(apis, []rpc.API{
 		{
+			Namespace: "eth",
+			Version:   "1.0",
+			Service:   ethapi.NewPublicEthereumAPI(s.ApiBackend, protocolVersion),
+			Public:    true,
+		}, {
 			Namespace: "eth",
 			Version:   "1.0",
 			Service:   &LightDummyAPI{},


### PR DESCRIPTION
restores the `eth_protocolVersion` RPC call which was broken due to a regression
during the snap refactor.