### PR TITLE
SECURITY.md: link to release page

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -8,13 +8,10 @@ Please see [Releases](https://github.com/ethereum/go-ethereum/releases). We reco
 
 Audit reports are published in the `docs` folder: https://github.com/ethereum/go-ethereum/tree/master/docs/audits 
 
-
 | Scope | Date | Report Link |
 | ------- | ------- | ----------- |
 | `geth` | 20170425 | [pdf](https://github.com/ethereum/go-ethereum/blob/master/docs/audits/2017-04-25_Geth-audit_Truesec.pdf) |
 | `clef` | 20180914 | [pdf](https://github.com/ethereum/go-ethereum/blob/master/docs/audits/2018-09-14_Clef-audit_NCC.pdf) |
-
-
 
 ## Reporting a Vulnerability
 
@@ -22,12 +19,11 @@ Audit reports are published in the `docs` folder: https://github.com/ethereum/go
 
 To find out how to disclose a vulnerability in Ethereum visit [https://bounty.ethereum.org](https://bounty.ethereum.org) or email bounty@ethereum.org. Please read the [disclosure page](https://github.com/ethereum/go-ethereum/security/advisories?state=published) for more information about publically disclosed security vulnerabilities.
 
-Use the built-in [`geth version-check`](https://geth.ethereum.org/docs/vulnerabilities/vulnerabilities) feature to check whether the software is affected by any known vulnerability. This command will fetch the latest [`vulnerabilities.json`](https://geth.ethereum.org/docs/vulnerabilities/vulnerabilities.json) file which contains known security-relevant vulnerabilities concerning `geth`, and cross-check the data against its own version number.
+Use the built-in `geth version-check` feature to check whether the software is affected by any known vulnerability. This command will fetch the latest [`vulnerabilities.json`](https://geth.ethereum.org/docs/vulnerabilities/vulnerabilities.json) file which contains known security vulnerabilities concerning `geth`, and cross-check the data against its own version number.
 
 The following key may be used to communicate sensitive information to developers.
 
 Fingerprint: `AE96 ED96 9E47 9B00 84F3 E17F E88D 3334 FA5F 6A0A`
-
 
 ```
 -----BEGIN PGP PUBLIC KEY BLOCK-----

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -22,6 +22,8 @@ Audit reports are published in the `docs` folder: https://github.com/ethereum/go
 
 To find out how to disclose a vulnerability in Ethereum visit [https://bounty.ethereum.org](https://bounty.ethereum.org) or email bounty@ethereum.org. Please read the [disclosure page](https://github.com/ethereum/go-ethereum/security/advisories?state=published) for more information about publically disclosed security vulnerabilities.
 
+Use the built-in [`geth version-check`](https://geth.ethereum.org/docs/vulnerabilities/vulnerabilities) feature to check whether the software is affected by any known vulnerability. This command will fetch the latest [`vulnerabilities.json`](https://geth.ethereum.org/docs/vulnerabilities/vulnerabilities.json) file which contains known security-relevant vulnerabilities concerning `geth`, and cross-check the data against it’s own version number.
+
 The following key may be used to communicate sensitive information to developers.
 
 Fingerprint: `AE96 ED96 9E47 9B00 84F3 E17F E88D 3334 FA5F 6A0A`

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,7 +2,7 @@
 
 ## Supported Versions
 
-Please see [Releases](https://github.com/ethereum/go-ethereum/releases). We recommend to use the [most recent released version](https://github.com/ethereum/go-ethereum/releases/latest).
+Please see [Releases](https://github.com/ethereum/go-ethereum/releases). We recommend using the [most recently released version](https://github.com/ethereum/go-ethereum/releases/latest).
 
 ## Audit reports
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,7 +2,7 @@
 
 ## Supported Versions
 
-Please see [Releases](https://github.com/ethereum/go-ethereum/releases). We recommend to use the [most recent released version](https://github.com/ethereum/go-ethereum/releases/latest).  
+Please see [Releases](https://github.com/ethereum/go-ethereum/releases). We recommend to use the [most recent released version](https://github.com/ethereum/go-ethereum/releases/latest).
 
 ## Audit reports
 
@@ -20,7 +20,7 @@ Audit reports are published in the `docs` folder: https://github.com/ethereum/go
 
 **Please do not file a public ticket** mentioning the vulnerability.
 
-To find out how to disclose a vulnerability in Ethereum visit [https://bounty.ethereum.org](https://bounty.ethereum.org) or email bounty@ethereum.org.
+To find out how to disclose a vulnerability in Ethereum visit [https://bounty.ethereum.org](https://bounty.ethereum.org) or email bounty@ethereum.org. Please read the [disclosure page](https://github.com/ethereum/go-ethereum/security/advisories?state=published) for more information about publically disclosed security vulnerabilities.
 
 The following key may be used to communicate sensitive information to developers.
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,7 +2,7 @@
 
 ## Supported Versions
 
-Please see Releases. We recommend to use the most recent released version.  
+Please see [Releases](https://github.com/ethereum/go-ethereum/releases). We recommend to use the [most recent released version](https://github.com/ethereum/go-ethereum/releases/latest).  
 
 ## Audit reports
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -22,7 +22,7 @@ Audit reports are published in the `docs` folder: https://github.com/ethereum/go
 
 To find out how to disclose a vulnerability in Ethereum visit [https://bounty.ethereum.org](https://bounty.ethereum.org) or email bounty@ethereum.org. Please read the [disclosure page](https://github.com/ethereum/go-ethereum/security/advisories?state=published) for more information about publically disclosed security vulnerabilities.
 
-Use the built-in [`geth version-check`](https://geth.ethereum.org/docs/vulnerabilities/vulnerabilities) feature to check whether the software is affected by any known vulnerability. This command will fetch the latest [`vulnerabilities.json`](https://geth.ethereum.org/docs/vulnerabilities/vulnerabilities.json) file which contains known security-relevant vulnerabilities concerning `geth`, and cross-check the data against it’s own version number.
+Use the built-in [`geth version-check`](https://geth.ethereum.org/docs/vulnerabilities/vulnerabilities) feature to check whether the software is affected by any known vulnerability. This command will fetch the latest [`vulnerabilities.json`](https://geth.ethereum.org/docs/vulnerabilities/vulnerabilities.json) file which contains known security-relevant vulnerabilities concerning `geth`, and cross-check the data against its own version number.
 
 The following key may be used to communicate sensitive information to developers.
 


### PR DESCRIPTION
Add links to go-ethereum's GitHub release page.