### PR TITLE
tests/fuzzers: fix false positive in bitutil fuzzer

### DIFF
--- a/tests/fuzzers/bitutil/compress_fuzz.go
+++ b/tests/fuzzers/bitutil/compress_fuzz.go
@@ -51,7 +51,19 @@ func fuzzDecode(data []byte) int {
 	if err != nil {
 		return 0
 	}
-	if comp := bitutil.CompressBytes(blob); !bytes.Equal(comp, data) {
+	// re-compress it (it's OK if the re-compressed differs from the
+	// original - the first input may not have been compressed at all)
+	comp := bitutil.CompressBytes(blob)
+	if len(comp) > len(blob) {
+		// After compression, it must be smaller or equal
+		panic("bad compression")
+	}
+	// But decompressing it once again should work
+	decomp, err := bitutil.DecompressBytes(data, 1024)
+	if err != nil {
+		panic(err)
+	}
+	if !bytes.Equal(decomp, blob) {
 		panic("content mismatch")
 	}
 	return 1


### PR DESCRIPTION
This PR fixes a false positive reported by oss-fuzz. The fuzzer took the input as 'compressed' data, and expected unpack + pack to yield the same result. 
However, un-compressed data at size `1024` can be interpreted as "compressed (but not really)", and thus there's no change when decompressing it. When we compress it again, however, it becomes _actually_ compressed. 