### PR TITLE
les: remove useless protocol defines

### DIFF
--- a/les/benchmark.go
+++ b/les/benchmark.go
@@ -156,7 +156,7 @@ func (b *benchmarkHelperTrie) request(peer *serverPeer, index int) error {
 		for i := range reqs {
 			key := make([]byte, 8)
 			binary.BigEndian.PutUint64(key[:], uint64(rand.Int63n(int64(b.headNum))))
-			reqs[i] = HelperTrieReq{Type: htCanonical, TrieIdx: b.sectionCount - 1, Key: key, AuxReq: auxHeader}
+			reqs[i] = HelperTrieReq{Type: htCanonical, TrieIdx: b.sectionCount - 1, Key: key, AuxReq: htAuxHeader}
 		}
 	}
 

--- a/les/handler_test.go
+++ b/les/handler_test.go
@@ -443,7 +443,7 @@ func testGetCHTProofs(t *testing.T, protocol int) {
 		Type:    htCanonical,
 		TrieIdx: 0,
 		Key:     key,
-		AuxReq:  auxHeader,
+		AuxReq:  htAuxHeader,
 	}}
 	// Send the proof request and verify the response
 	sendRequest(server.peer.app, GetHelperTrieProofsMsg, 42, requestsV2)

--- a/les/odr_requests.go
+++ b/les/odr_requests.go
@@ -295,10 +295,9 @@ const (
 	htCanonical = iota // Canonical hash trie
 	htBloomBits        // BloomBits trie
 
-	// applicable for all helper trie requests
-	auxRoot = 1
-	// applicable for htCanonical
-	auxHeader = 2
+	// helper trie auxiliary types
+	htAuxNone   = 1 // deprecated number, used in les2/3 previously.
+	htAuxHeader = 2 // applicable for htCanonical, requests for relevant headers
 )
 
 type HelperTrieReq struct {
@@ -339,7 +338,7 @@ func (r *ChtRequest) Request(reqID uint64, peer *serverPeer) error {
 		Type:    htCanonical,
 		TrieIdx: r.ChtNum,
 		Key:     encNum[:],
-		AuxReq:  auxHeader,
+		AuxReq:  htAuxHeader,
 	}
 	return peer.requestHelperTrieProofs(reqID, []HelperTrieReq{req})
 }

--- a/les/odr_requests.go
+++ b/les/odr_requests.go
@@ -296,7 +296,7 @@ const (
 	htBloomBits        // BloomBits trie
 
 	// helper trie auxiliary types
-	htAuxNone   = 1 // deprecated number, used in les2/3 previously.
+	// htAuxNone = 1 ; deprecated number, used in les2/3 previously.
 	htAuxHeader = 2 // applicable for htCanonical, requests for relevant headers
 )
 


### PR DESCRIPTION
This PR has two changes in the les protocol.

- the `auxRoot` is not supported. See https://github.com/ethereum/devp2p/issues/171 for more information
- the empty response will be returned in `GetHelperTrieProofsMsg` request if the merkle proving is failed
   - note, for backward compatibility, the empty merkle proof as well as the request auxiliary data will still be returned in les2/3 protocol no matter the proving is successful or not
   - the proving failure can happen e.g. request the proving for a non-included entry in helper trie(unstable header)