### PR TITLE
eth, les: add new config "syncFromCheckpoint"

### DIFF
--- a/eth/config.go
+++ b/eth/config.go
@@ -127,11 +127,12 @@ type Config struct {
 	Whitelist map[uint64]common.Hash `toml:"-"`
 
 	// Light client options
-	LightServ    int  `toml:",omitempty"` // Maximum percentage of time allowed for serving LES requests
-	LightIngress int  `toml:",omitempty"` // Incoming bandwidth limit for light servers
-	LightEgress  int  `toml:",omitempty"` // Outgoing bandwidth limit for light servers
-	LightPeers   int  `toml:",omitempty"` // Maximum number of LES client peers
-	LightNoPrune bool `toml:",omitempty"` // Whether to disable light chain pruning
+	LightServ          int  `toml:",omitempty"` // Maximum percentage of time allowed for serving LES requests
+	LightIngress       int  `toml:",omitempty"` // Incoming bandwidth limit for light servers
+	LightEgress        int  `toml:",omitempty"` // Outgoing bandwidth limit for light servers
+	LightPeers         int  `toml:",omitempty"` // Maximum number of LES client peers
+	LightNoPrune       bool `toml:",omitempty"` // Whether to disable light chain pruning
+	SyncFromCheckpoint bool `toml:",omitempty"` // Whether to sync the header chain from the configured checkpoint
 
 	// Ultra Light client options
 	UltraLightServers      []string `toml:",omitempty"` // List of trusted ultra light servers

--- a/eth/gen_config.go
+++ b/eth/gen_config.go
@@ -21,6 +21,7 @@ func (c Config) MarshalTOML() (interface{}, error) {
 		NetworkId               uint64
 		SyncMode                downloader.SyncMode
 		EthDiscoveryURLs        []string
+		SnapDiscoveryURLs       []string
 		NoPruning               bool
 		NoPrefetch              bool
 		TxLookupLimit           uint64                 `toml:",omitempty"`
@@ -30,6 +31,7 @@ func (c Config) MarshalTOML() (interface{}, error) {
 		LightEgress             int                    `toml:",omitempty"`
 		LightPeers              int                    `toml:",omitempty"`
 		LightNoPrune            bool                   `toml:",omitempty"`
+		SyncFromCheckpoint      bool                   `toml:",omitempty"`
 		UltraLightServers       []string               `toml:",omitempty"`
 		UltraLightFraction      int                    `toml:",omitempty"`
 		UltraLightOnlyAnnounce  bool                   `toml:",omitempty"`
@@ -62,6 +64,7 @@ func (c Config) MarshalTOML() (interface{}, error) {
 	enc.NetworkId = c.NetworkId
 	enc.SyncMode = c.SyncMode
 	enc.EthDiscoveryURLs = c.EthDiscoveryURLs
+	enc.SnapDiscoveryURLs = c.SnapDiscoveryURLs
 	enc.NoPruning = c.NoPruning
 	enc.NoPrefetch = c.NoPrefetch
 	enc.TxLookupLimit = c.TxLookupLimit
@@ -71,6 +74,7 @@ func (c Config) MarshalTOML() (interface{}, error) {
 	enc.LightEgress = c.LightEgress
 	enc.LightPeers = c.LightPeers
 	enc.LightNoPrune = c.LightNoPrune
+	enc.SyncFromCheckpoint = c.SyncFromCheckpoint
 	enc.UltraLightServers = c.UltraLightServers
 	enc.UltraLightFraction = c.UltraLightFraction
 	enc.UltraLightOnlyAnnounce = c.UltraLightOnlyAnnounce
@@ -107,6 +111,7 @@ func (c *Config) UnmarshalTOML(unmarshal func(interface{}) error) error {
 		NetworkId               *uint64
 		SyncMode                *downloader.SyncMode
 		EthDiscoveryURLs        []string
+		SnapDiscoveryURLs       []string
 		NoPruning               *bool
 		NoPrefetch              *bool
 		TxLookupLimit           *uint64                `toml:",omitempty"`
@@ -116,6 +121,7 @@ func (c *Config) UnmarshalTOML(unmarshal func(interface{}) error) error {
 		LightEgress             *int                   `toml:",omitempty"`
 		LightPeers              *int                   `toml:",omitempty"`
 		LightNoPrune            *bool                  `toml:",omitempty"`
+		SyncFromCheckpoint      *bool                  `toml:",omitempty"`
 		UltraLightServers       []string               `toml:",omitempty"`
 		UltraLightFraction      *int                   `toml:",omitempty"`
 		UltraLightOnlyAnnounce  *bool                  `toml:",omitempty"`
@@ -159,6 +165,9 @@ func (c *Config) UnmarshalTOML(unmarshal func(interface{}) error) error {
 	if dec.EthDiscoveryURLs != nil {
 		c.EthDiscoveryURLs = dec.EthDiscoveryURLs
 	}
+	if dec.SnapDiscoveryURLs != nil {
+		c.SnapDiscoveryURLs = dec.SnapDiscoveryURLs
+	}
 	if dec.NoPruning != nil {
 		c.NoPruning = *dec.NoPruning
 	}
@@ -185,6 +194,9 @@ func (c *Config) UnmarshalTOML(unmarshal func(interface{}) error) error {
 	}
 	if dec.LightNoPrune != nil {
 		c.LightNoPrune = *dec.LightNoPrune
+	}
+	if dec.SyncFromCheckpoint != nil {
+		c.SyncFromCheckpoint = *dec.SyncFromCheckpoint
 	}
 	if dec.UltraLightServers != nil {
 		c.UltraLightServers = dec.UltraLightServers

--- a/les/client_handler.go
+++ b/les/client_handler.go
@@ -44,9 +44,12 @@ type clientHandler struct {
 	downloader *downloader.Downloader
 	backend    *LightEthereum
 
-	closeCh  chan struct{}
-	wg       sync.WaitGroup // WaitGroup used to track all connected peers.
-	syncDone func()         // Test hooks when syncing is done.
+	closeCh chan struct{}
+	wg      sync.WaitGroup // WaitGroup used to track all connected peers.
+
+	// Hooks used in the testing
+	syncStart func(header *types.Header) // Hook called when the syncing is started
+	syncEnd   func(header *types.Header) // Hook called when the syncing is done
 }
 
 func newClientHandler(ulcServers []string, ulcFraction int, checkpoint *params.TrustedCheckpoint, backend *LightEthereum) *clientHandler {

--- a/les/commons.go
+++ b/les/commons.go
@@ -157,17 +157,17 @@ func (c *lesCommons) setupOracle(node *node.Node, genesis common.Hash, ethconfig
 		config = params.CheckpointOracles[genesis]
 	}
 	if config == nil {
-		log.Info("Checkpoint registrar is not enabled")
+		log.Info("Checkpoint oracle is not enabled")
 		return nil
 	}
 	if config.Address == (common.Address{}) || uint64(len(config.Signers)) < config.Threshold {
-		log.Warn("Invalid checkpoint registrar config")
+		log.Warn("Invalid checkpoint oracle config")
 		return nil
 	}
 	oracle := checkpointoracle.New(config, c.localCheckpoint)
 	rpcClient, _ := node.Attach()
 	client := ethclient.NewClient(rpcClient)
 	oracle.Start(client)
-	log.Info("Configured checkpoint registrar", "address", config.Address, "signers", len(config.Signers), "threshold", config.Threshold)
+	log.Info("Configured checkpoint oracle", "address", config.Address, "signers", len(config.Signers), "threshold", config.Threshold)
 	return oracle
 }

--- a/les/sync.go
+++ b/les/sync.go
@@ -19,6 +19,7 @@ package les
 import (
 	"context"
 	"errors"
+	"github.com/ethereum/go-ethereum/params"
 	"time"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -98,22 +99,33 @@ func (h *clientHandler) synchronise(peer *serverPeer) {
 	if currentTd != nil && peer.Td().Cmp(currentTd) < 0 {
 		return
 	}
-	// Recap the checkpoint.
-	//
-	// The light client may be connected to several different versions of the server.
-	// (1) Old version server which can not provide stable checkpoint in the handshake packet.
-	//     => Use hardcoded checkpoint or empty checkpoint
-	// (2) New version server but simple checkpoint syncing is not enabled(e.g. mainnet, new testnet or private network)
-	//     => Use hardcoded checkpoint or empty checkpoint
-	// (3) New version server but the provided stable checkpoint is even lower than the hardcoded one.
-	//     => Use hardcoded checkpoint
+	// Recap the checkpoint. The light client may be connected to several different
+	// versions of the server.
+	// (1) Old version server which can not provide stable checkpoint in the
+	//     handshake packet.
+	//     => Use local checkpoint or empty checkpoint
+	// (2) New version server but simple checkpoint syncing is not enabled
+	//     (e.g. mainnet, new testnet or private network)
+	//     => Use local checkpoint or empty checkpoint
+	// (3) New version server but the provided stable checkpoint is even lower
+	//     than the local one.
+	//     => Use local checkpoint
 	// (4) New version server with valid and higher stable checkpoint
 	//     => Use provided checkpoint
-	var checkpoint = &peer.checkpoint
-	var hardcoded bool
+	var (
+		local      bool
+		checkpoint = &peer.checkpoint
+	)
 	if h.checkpoint != nil && h.checkpoint.SectionIndex >= peer.checkpoint.SectionIndex {
-		checkpoint = h.checkpoint // Use the hardcoded one.
-		hardcoded = true
+		local, checkpoint = true, h.checkpoint
+	}
+	// Replace the checkpoint with locally configured one If it's required by
+	// users. Nil checkpoint means synchronization from the scratch.
+	if h.backend.config.SyncFromCheckpoint {
+		local, checkpoint = true, h.backend.config.Checkpoint
+		if h.backend.config.Checkpoint == nil {
+			checkpoint = &params.TrustedCheckpoint{}
+		}
 	}
 	// Determine whether we should run checkpoint syncing or normal light syncing.
 	//
@@ -121,7 +133,7 @@ func (h *clientHandler) synchronise(peer *serverPeer) {
 	//
 	// 1. The checkpoint is empty
 	// 2. The latest head block of the local chain is above the checkpoint.
-	// 3. The checkpoint is hardcoded(recap with local hardcoded checkpoint)
+	// 3. The checkpoint is local(recap with local local checkpoint)
 	// 4. For some networks the checkpoint syncing is not activated.
 	mode := checkpointSync
 	switch {
@@ -131,7 +143,7 @@ func (h *clientHandler) synchronise(peer *serverPeer) {
 	case latest.Number.Uint64() >= (checkpoint.SectionIndex+1)*h.backend.iConfig.ChtSize-1:
 		mode = lightSync
 		log.Debug("Disable checkpoint syncing", "reason", "local chain beyond the checkpoint")
-	case hardcoded:
+	case local:
 		mode = legacyCheckpointSync
 		log.Debug("Disable checkpoint syncing", "reason", "checkpoint is hardcoded")
 	case h.backend.oracle == nil || !h.backend.oracle.IsRunning():
@@ -143,12 +155,14 @@ func (h *clientHandler) synchronise(peer *serverPeer) {
 		}
 		log.Debug("Disable checkpoint syncing", "reason", "checkpoint syncing is not activated")
 	}
+
 	// Notify testing framework if syncing has completed(for testing purpose).
 	defer func() {
-		if h.syncDone != nil {
-			h.syncDone()
+		if h.syncEnd != nil {
+			h.syncEnd(h.backend.blockchain.CurrentHeader())
 		}
 	}()
+
 	start := time.Now()
 	if mode == checkpointSync || mode == legacyCheckpointSync {
 		// Validate the advertised checkpoint
@@ -176,6 +190,10 @@ func (h *clientHandler) synchronise(peer *serverPeer) {
 			h.removePeer(peer.id)
 			return
 		}
+	}
+
+	if h.syncStart != nil {
+		h.syncStart(h.backend.blockchain.CurrentHeader())
 	}
 	// Fetch the remaining block headers based on the current chain header.
 	if err := h.downloader.Synchronise(peer.id, peer.Head(), peer.Td(), downloader.LightSync); err != nil {

--- a/les/sync.go
+++ b/les/sync.go
@@ -19,7 +19,6 @@ package les
 import (
 	"context"
 	"errors"
-	"github.com/ethereum/go-ethereum/params"
 	"time"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -27,6 +26,7 @@ import (
 	"github.com/ethereum/go-ethereum/eth/downloader"
 	"github.com/ethereum/go-ethereum/light"
 	"github.com/ethereum/go-ethereum/log"
+	"github.com/ethereum/go-ethereum/params"
 )
 
 var errInvalidCheckpoint = errors.New("invalid advertised checkpoint")
@@ -133,7 +133,7 @@ func (h *clientHandler) synchronise(peer *serverPeer) {
 	//
 	// 1. The checkpoint is empty
 	// 2. The latest head block of the local chain is above the checkpoint.
-	// 3. The checkpoint is local(recap with local local checkpoint)
+	// 3. The checkpoint is local(replaced with local checkpoint)
 	// 4. For some networks the checkpoint syncing is not activated.
 	mode := checkpointSync
 	switch {

--- a/les/test_helper.go
+++ b/les/test_helper.go
@@ -541,7 +541,7 @@ func newClientServerEnv(t *testing.T, blocks int, protocol int, callback indexer
 	)
 	if connect {
 		done := make(chan struct{})
-		client.syncDone = func() { close(done) }
+		client.syncEnd = func(_ *types.Header) { close(done) }
 		cpeer, speer, err = newTestPeerPair("peer", protocol, server, client)
 		if err != nil {
 			t.Fatalf("Failed to connect testing peers %v", err)


### PR DESCRIPTION
This PR introduces a new config field `SyncFromCheckpoint` for light client. 

In some special scenarios, it's required to start synchronization from some arbitrary checkpoint or even from the scratch. So this PR offers this flexibility to users so that the synchronization start point can be configured.

There are two relevant configs: `SyncFromCheckpoint` and `Checkpoint`.
- If the `SyncFromCheckpoint` is true, the light client will try to sync from the specified checkpoint.
- If the `Checkpoint` is not configured, then the light client will sync from the scratch(from the latest header if the database is not empty)

Additional notes: these two configs are not visible in the CLI flags but only accessable in the config file.

Example Usage:

```
[Eth]
SyncFromCheckpoint = true

[Eth.Checkpoint]
SectionIndex = 100
SectionHead = "0xabc"
CHTRoot = "0xabc"
BloomRoot = "0xabc"
```

PS. Historical checkpoint can be retrieved from the synced full node or light client via `les_getCheckpoint` API.

Fixes
#21786
#21337
