### PR TITLE
les: remove transaction propagation limits

### DIFF
--- a/les/txrelay.go
+++ b/les/txrelay.go
@@ -25,13 +25,8 @@ import (
 	"github.com/ethereum/go-ethereum/rlp"
 )
 
-type ltrInfo struct {
-	tx     *types.Transaction
-	sentTo map[*serverPeer]struct{}
-}
-
 type lesTxRelay struct {
-	txSent       map[common.Hash]*ltrInfo
+	txSent       map[common.Hash]*types.Transaction
 	txPending    map[common.Hash]struct{}
 	peerList     []*serverPeer
 	peerStartPos int
@@ -43,7 +38,7 @@ type lesTxRelay struct {
 
 func newLesTxRelay(ps *serverPeerSet, retriever *retrieveManager) *lesTxRelay {
 	r := &lesTxRelay{
-		txSent:    make(map[common.Hash]*ltrInfo),
+		txSent:    make(map[common.Hash]*types.Transaction),
 		txPending: make(map[common.Hash]struct{}),
 		retriever: retriever,
 		stop:      make(chan struct{}),
@@ -80,8 +75,7 @@ func (ltrx *lesTxRelay) unregisterPeer(p *serverPeer) {
 	}
 }
 
-// send sends a list of transactions to at most a given number of peers at
-// once, never resending any particular transaction to the same peer twice
+// send sends a list of transactions to at most a given number of peers.
 func (ltrx *lesTxRelay) send(txs types.Transactions, count int) {
 	sendTo := make(map[*serverPeer]types.Transactions)
 
@@ -92,26 +86,18 @@ func (ltrx *lesTxRelay) send(txs types.Transactions, count int) {
 
 	for _, tx := range txs {
 		hash := tx.Hash()
-		ltr, ok := ltrx.txSent[hash]
+		_, ok := ltrx.txSent[hash]
 		if !ok {
-			ltr = &ltrInfo{
-				tx:     tx,
-				sentTo: make(map[*serverPeer]struct{}),
-			}
-			ltrx.txSent[hash] = ltr
+			ltrx.txSent[hash] = tx
 			ltrx.txPending[hash] = struct{}{}
 		}
-
 		if len(ltrx.peerList) > 0 {
 			cnt := count
 			pos := ltrx.peerStartPos
 			for {
 				peer := ltrx.peerList[pos]
-				if _, ok := ltr.sentTo[peer]; !ok {
-					sendTo[peer] = append(sendTo[peer], tx)
-					ltr.sentTo[peer] = struct{}{}
-					cnt--
-				}
+				sendTo[peer] = append(sendTo[peer], tx)
+				cnt--
 				if cnt == 0 {
 					break // sent it to the desired number of peers
 				}
@@ -174,7 +160,7 @@ func (ltrx *lesTxRelay) NewHead(head common.Hash, mined []common.Hash, rollback 
 		txs := make(types.Transactions, len(ltrx.txPending))
 		i := 0
 		for hash := range ltrx.txPending {
-			txs[i] = ltrx.txSent[hash].tx
+			txs[i] = ltrx.txSent[hash]
 			i++
 		}
 		ltrx.send(txs, 1)


### PR DESCRIPTION
This PR removes the restriction in the transaction propagation. 

Previously, the transaction will only be sent to the specific peer for one time. This approach is not robust enough, espeically when the peerset is small. Round-of-robin is enough for distributing the transaction to the network.

In this PR, the propagation logic is simplied a lot. Whenever the light client tries to broadcast transactions, it just picks a few peers with Round-of-robin algo.