### PR TITLE
eth: fix potential deadlock of pub/sub module

### DIFF
--- a/eth/filters/filter_system.go
+++ b/eth/filters/filter_system.go
@@ -174,6 +174,17 @@ func (sub *Subscription) Unsubscribe() {
 		// this ensures that the manager won't use the event channel which
 		// will probably be closed by the client asap after this method returns.
 		<-sub.Err()
+
+	drainLoop:
+		for {
+			select {
+			case <-sub.f.logs:
+			case <-sub.f.hashes:
+			case <-sub.f.headers:
+			default:
+				break drainLoop
+			}
+		}
 	})
 }
 


### PR DESCRIPTION
### Description

Fix the potential deadlock of pub/sub module which may cause the chain halt. 

More detail in https://github.com/ethereum/go-ethereum/issues/22131

### Rationale

The deadlock dependency is:

Routine A: `NewPendingTransactionFilter` want to lock `filtersMu` to consume hashes;
Routine B: `eventLoop` is waiting Routine A to consume hashes so that it can push new hash to channel.
Routine C: `Unsubscribe` is holding lock f`iltersMu`, but it is waiting for Routine B to consume `uninstall` channel.

### Changes
There is no need to fetch lock on `NewPendingTransactionFilter` routine, so just loose the logic.

And fix the potential risk that `Unsubscribe` routine does not drain all the `hash`, `header` and `log`. 