### PR TITLE
cmd/faucet: switch Facebook auth over to mobile site

### DIFF
--- a/cmd/faucet/faucet.go
+++ b/cmd/faucet/faucet.go
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with go-ethereum. If not, see <http://www.gnu.org/licenses/>.
 
-// faucet is a Ether faucet backed by a light client.
+// faucet is an Ether faucet backed by a light client.
 package main
 
 //go:generate go-bindata -nometadata -o website.go faucet.html
@@ -847,7 +847,13 @@ func authFacebook(url string) (string, string, common.Address, error) {
 	// Facebook's Graph API isn't really friendly with direct links. Still, we don't
 	// want to do ask read permissions from users, so just load the public posts and
 	// scrape it for the Ethereum address and profile URL.
-	res, err := http.Get(url)
+	//
+	// Facebook recently changed their desktop webpage to use AJAX for loading post
+	// content, so switch over to the mobile site for now. Will probably end up having
+	// to use the API eventually.
+	crawl := strings.Replace(url, "www.facebook.com", "m.facebook.com", 1)
+
+	res, err := http.Get(crawl)
 	if err != nil {
 		return "", "", common.Address{}, err
 	}

--- a/cmd/faucet/faucet_test.go
+++ b/cmd/faucet/faucet_test.go
@@ -1,0 +1,43 @@
+// Copyright 2021 The go-ethereum Authors
+// This file is part of go-ethereum.
+//
+// go-ethereum is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// go-ethereum is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with go-ethereum. If not, see <http://www.gnu.org/licenses/>.
+
+package main
+
+import (
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+)
+
+func TestFacebook(t *testing.T) {
+	for _, tt := range []struct {
+		url  string
+		want common.Address
+	}{
+		{
+			"https://www.facebook.com/fooz.gazonk/posts/2837228539847129",
+			common.HexToAddress("0xDeadDeaDDeaDbEefbEeFbEEfBeeFBeefBeeFbEEF"),
+		},
+	} {
+		_, _, gotAddress, err := authFacebook(tt.url)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if gotAddress != tt.want {
+			t.Fatalf("address wrong, have %v want %v", gotAddress, tt.want)
+		}
+	}
+}


### PR DESCRIPTION
The full website uses AJAX. Switch over to the mobile site for scraping the infos.