### PR TITLE
cmd/faucet: fix nonce-gap problem

### DIFF
--- a/cmd/faucet/faucet.go
+++ b/cmd/faucet/faucet.go
@@ -648,8 +648,8 @@ func (f *faucet) loop() {
 
 		case <-f.update:
 			// Pending requests updated, stream to clients
-			reqData, _ := json.Marshal(map[string]interface{}{"requests": f.reqs})
 			f.lock.RLock()
+			reqData, _ := json.Marshal(map[string]interface{}{"requests": f.reqs})
 			for _, conn := range f.conns {
 				if err := sendMarshalled(conn, reqData, time.Second); err != nil {
 					log.Warn("Failed to send requests to client", "err", err)

--- a/cmd/faucet/faucet.go
+++ b/cmd/faucet/faucet.go
@@ -578,8 +578,13 @@ func (f *faucet) refresh(head *types.Header) error {
 	f.lock.Lock()
 	f.head, f.balance = head, balance
 	f.price, f.nonce = price, nonce
-	for i := len(f.reqs) - 1; f.reqs[i].Tx.Nonce() < f.nonce; i-- {
-		f.reqs = f.reqs[:i]
+	// The requests are ordered as [txN, txN-1, .. txN-M]
+	for i := len(f.reqs) - 1; i > 0; i-- {
+		if f.reqs[i].Tx.Nonce() < f.nonce {
+			f.reqs = f.reqs[:i]
+			continue
+		}
+		break
 	}
 	f.lock.Unlock()
 

--- a/cmd/faucet/faucet.go
+++ b/cmd/faucet/faucet.go
@@ -615,11 +615,15 @@ func (f *faucet) loop() {
 			// Faucet state retrieved, update locally and send to clients
 			f.lock.RLock()
 			log.Info("Updated faucet state", "number", head.Number, "hash", head.Hash(), "age", common.PrettyAge(timestamp), "balance", f.balance, "nonce", f.nonce, "price", f.price)
+
+			balance := new(big.Int).Div(f.balance, ether)
+			peers := f.stack.Server().PeerCount()
+
 			for _, conn := range f.conns {
 				if err := send(conn, map[string]interface{}{
-					"funds":    new(big.Int).Div(f.balance, ether),
+					"funds":    balance,
 					"funded":   f.nonce,
-					"peers":    f.stack.Server().PeerCount(),
+					"peers":    peers,
 					"requests": f.reqs,
 				}, time.Second); err != nil {
 					log.Warn("Failed to send stats to client", "err", err)

--- a/cmd/faucet/faucet.html
+++ b/cmd/faucet/faucet.html
@@ -177,7 +177,7 @@
 						}
 						// Iterate over our entire local collection and re-render the funding table
 						var content = "";
-						for (var i=0; i<requests.length; i++) {
+						for (var i=requests.length-1; i >= 0; i--) {
 							var done    = requests[i].time == "";
 							var elapsed = moment().unix()-moment(requests[i].time).unix();
 


### PR DESCRIPTION
The faucet sometimes croaks. When a client connects to the faucet, quite a lot of data is shipped.

![faucet](https://user-images.githubusercontent.com/142290/103932783-a726ae00-5122-11eb-8702-936384f11cd2.png)

Every 15s or so, `~56Kb` of request-data is sent, and `1.5Kb` block data is sent. In the example here, half a megabyte in 2.5 minutes. 

And this is for every individual user who has the page open in a tab -- so 100 concurrent users means the server has a lot of work to do. This PR reuses the encoded json messages that goes out to the clients, to make things a little bit speedier. 


Caveat: I haven't tested it...
