### PR TITLE
cmd/puppeth: make it possible to have pw-protected keyfiles

### DIFF
--- a/cmd/puppeth/wizard_intro.go
+++ b/cmd/puppeth/wizard_intro.go
@@ -23,7 +23,6 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
-	"sync"
 
 	"github.com/ethereum/go-ethereum/log"
 )
@@ -80,25 +79,17 @@ func (w *wizard) run() {
 	} else if err := json.Unmarshal(blob, &w.conf); err != nil {
 		log.Crit("Previous configuration corrupted", "path", w.conf.path, "err", err)
 	} else {
-		// Dial all previously known servers concurrently
-		var pend sync.WaitGroup
+		// Dial all previously known servers
 		for server, pubkey := range w.conf.Servers {
-			pend.Add(1)
-
-			go func(server string, pubkey []byte) {
-				defer pend.Done()
-
-				log.Info("Dialing previously configured server", "server", server)
-				client, err := dial(server, pubkey)
-				if err != nil {
-					log.Error("Previous server unreachable", "server", server, "err", err)
-				}
-				w.lock.Lock()
-				w.servers[server] = client
-				w.lock.Unlock()
-			}(server, pubkey)
+			log.Info("Dialing previously configured server", "server", server)
+			client, err := dial(server, pubkey)
+			if err != nil {
+				log.Error("Previous server unreachable", "server", server, "err", err)
+			}
+			w.lock.Lock()
+			w.servers[server] = client
+			w.lock.Unlock()
 		}
-		pend.Wait()
 		w.networkStats()
 	}
 	// Basics done, loop ad infinitum about what to do


### PR DESCRIPTION
This PR makes the ssh connection sequential. This is important in the case where user feedback is needed, e.g. when the ssh key is password protected. 

With this PR: 
```
INFO [01-08|11:24:53.385] Administering Ethereum network           name=rinkeby
INFO [01-08|11:24:53.387] Dialing previously configured server     server=karalabe:id_rsa_2017@boot.rinkeby.io
What's the decryption password for /home/user/.ssh/id_rsa_2017? (won't be echoed)
>
INFO [01-08|11:25:00.430] Dialing previously configured server     server=karalabe:id_rsa_2017@web.rinkeby.io
What's the decryption password for /home/user/.ssh/id_rsa_2017? (won't be echoed)
>
INFO [01-08|11:25:06.580] Starting remote server health-check      server=karalabe:id_rsa_2017@web.rinkeby.io
INFO [01-08|11:25:06.580] Starting remote server health-check      server=karalabe:id_rsa_2017@boot.rinkeby.io
```
Without this PR: 
```
What's the decryption password for /home/user/.ssh/id_rsa_2017? (won't be echoed)
>What's the decryption password for /home/user/.ssh/id_rsa_2017? (won't be echoed)
>
```
The health-check-phase is still performed in parallel. 
