### PR TITLE
eth: increase default max gas price to 1000 GWei

### DIFF
--- a/eth/gasprice/gasprice.go
+++ b/eth/gasprice/gasprice.go
@@ -31,7 +31,7 @@ import (
 
 const sampleNumber = 3 // Number of transactions sampled in a block
 
-var DefaultMaxPrice = big.NewInt(500 * params.GWei)
+var DefaultMaxPrice = big.NewInt(1000 * params.GWei)
 
 type Config struct {
 	Blocks     int


### PR DESCRIPTION
GasPrice was more than 500 GWei in some moments last month and all clients which use default options had incorrect gas price prediction.