### PR TITLE
consensus/ethash: increase seal timeout for tests

### DIFF
--- a/consensus/ethash/ethash_test.go
+++ b/consensus/ethash/ethash_test.go
@@ -49,7 +49,7 @@ func TestTestMode(t *testing.T) {
 		if err := ethash.VerifySeal(nil, header); err != nil {
 			t.Fatalf("unexpected verification error: %v", err)
 		}
-	case <-time.NewTimer(2 * time.Second).C:
+	case <-time.NewTimer(4 * time.Second).C:
 		t.Error("sealing result timeout")
 	}
 }


### PR DESCRIPTION
It seems that the 2 second timeout is not enough for travis
```
--- FAIL: TestTestMode (2.00s)
    ethash_test.go:53: sealing result timeout
FAIL
coverage: 70.2% of statements
FAIL	github.com/ethereum/go-ethereum/consensus/ethash	11.261s
```
https://travis-ci.com/github/ethereum/go-ethereum/jobs/457951964
https://travis-ci.com/github/ethereum/go-ethereum/jobs/469377305
https://travis-ci.com/github/ethereum/go-ethereum/jobs/469031088