### PR TITLE
ethapi: add `txpool_contentHashes` RPC method

### DIFF
--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -130,6 +130,27 @@ func (s *PublicTxPoolAPI) Content() map[string]map[string]map[string]*RPCTransac
 	return content
 }
 
+func (s *PublicTxPoolAPI) Hashes() map[string][]common.Hash {
+	hashes := map[string][]common.Hash{}
+	pending, queue := s.b.TxPoolContent()
+
+	// Flatten the pending transactions
+	for _, txs := range pending {
+		for _, tx := range txs {
+			hashes["pending"] = append(hashes["pending"], tx.Hash())
+		}
+
+	}
+	// Flatten the queued transactions
+	for _, txs := range queue {
+		for _, tx := range txs {
+			hashes["queued"] = append(hashes["queued"], tx.Hash())
+		}
+	}
+
+	return hashes
+}
+
 // Status returns the number of pending and queued transaction in the pool.
 func (s *PublicTxPoolAPI) Status() map[string]hexutil.Uint {
 	pending, queue := s.b.Stats()


### PR DESCRIPTION
PR adds `txpool_contentHashes` RPC method as a lightweight alternative to existing `txpool_content`. The method is pretty useful for applications intensively working with memory pool content since it reduces a response time (up to ~2 seconds), decreases geth CPU usage and network I/O (don't have accurate numbers for last two but can do benchmarking if needed).

Request example:
```
curl --location --request GET 'http://localhost:8545' \
--header 'Content-Type: application/json' \
--data-raw '{
    "method": "txpool_contentHashes",
    "jsonrpc": "2.0",
    "id": 1,
    "params": []
}'
```

Response example:

```
{
    "jsonrpc": "2.0",
    "id": 1,
    "result": [
        "0x65088a14d4f5effb9b0702b25eff7c4c33acbb29e3cf23a79dac02eb8cb9f265",
        "0x0605beec5e217d6db46bf437b275d49e28498a2498908b8bd3924795239e3268",
        "0x5c0695c6a4e6a915f01d2baf8c0a89332187c7690b239a19370ca6f176560ad1",
        "0x1552b0cf8fd8282c6765704d2ea14de21b24d036da5327774f1e4fa9737aeb3d",
        ...
    ]
}
```