### PR TITLE
graphql: fix spurious travis failure

### DIFF
--- a/graphql/graphql_test.go
+++ b/graphql/graphql_test.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"math/big"
+	"math/rand"
 	"net/http"
 	"strings"
 	"testing"
@@ -131,7 +132,7 @@ func TestGraphQLBlockSerialization(t *testing.T) {
 			code: 200,
 		},
 	} {
-		resp, err := http.Post(fmt.Sprintf("http://%s/graphql", "127.0.0.1:9393"), "application/json", strings.NewReader(tt.body))
+		resp, err := http.Post(fmt.Sprintf("http://127.0.0.1:%d/graphql", stack.Config().HTTPPort), "application/json", strings.NewReader(tt.body))
 		if err != nil {
 			t.Fatalf("could not post: %v", err)
 		}
@@ -156,7 +157,7 @@ func TestGraphQLHTTPOnSamePort_GQLRequest_Unsuccessful(t *testing.T) {
 		t.Fatalf("could not start node: %v", err)
 	}
 	body := strings.NewReader(`{"query": "{block{number}}","variables": null}`)
-	resp, err := http.Post(fmt.Sprintf("http://%s/graphql", "127.0.0.1:9393"), "application/json", body)
+	resp, err := http.Post(fmt.Sprintf("http://127.0.0.1:%d/graphql", stack.Config().HTTPPort), "application/json", body)
 	if err != nil {
 		t.Fatalf("could not post: %v", err)
 	}
@@ -174,12 +175,16 @@ func TestGraphQLHTTPOnSamePort_GQLRequest_Unsuccessful(t *testing.T) {
 	}
 }
 
+// createnode starts a node, with the http/ws port being randomized between
+// 9300 and 9399. If a port is reused (without a proper delay between tests),
+// there may be spurious errors, particularly it seems to happen on go 1.14.x.
 func createNode(t *testing.T, gqlEnabled bool) *node.Node {
+	port := 9300 + rand.Intn(100)
 	stack, err := node.New(&node.Config{
 		HTTPHost: "127.0.0.1",
-		HTTPPort: 9393,
+		HTTPPort: port,
 		WSHost:   "127.0.0.1",
-		WSPort:   9393,
+		WSPort:   port,
 	})
 	if err != nil {
 		t.Fatalf("could not create node: %v", err)
@@ -187,7 +192,7 @@ func createNode(t *testing.T, gqlEnabled bool) *node.Node {
 	if !gqlEnabled {
 		return stack
 	}
-	createGQLService(t, stack, "127.0.0.1:9393")
+	createGQLService(t, stack, fmt.Sprintf("127.0.0.1:%d", port))
 	return stack
 }
 


### PR DESCRIPTION
In go `1.14`, the graphql tests runs really fast: 
```
go test . -run TestGraphQLHTTPOnSamePort_GQLRequest_Unsuccessful -v  --count 20
=== RUN   TestGraphQLHTTPOnSamePort_GQLRequest_Unsuccessful
--- PASS: TestGraphQLHTTPOnSamePort_GQLRequest_Unsuccessful (0.00s)
=== RUN   TestGraphQLHTTPOnSamePort_GQLRequest_Unsuccessful
--- PASS: TestGraphQLHTTPOnSamePort_GQLRequest_Unsuccessful (0.00s)
=== RUN   TestGraphQLHTTPOnSamePort_GQLRequest_Unsuccessful
--- PASS: TestGraphQLHTTPOnSamePort_GQLRequest_Unsuccessful (0.00s)
=== RUN   TestGraphQLHTTPOnSamePort_GQLRequest_Unsuccessful
--- PASS: TestGraphQLHTTPOnSamePort_GQLRequest_Unsuccessful (0.00s)
=== RUN   TestGraphQLHTTPOnSamePort_GQLRequest_Unsuccessful
--- PASS: TestGraphQLHTTPOnSamePort_GQLRequest_Unsuccessful (0.00s)
=== RUN   TestGraphQLHTTPOnSamePort_GQLRequest_Unsuccessful
--- PASS: TestGraphQLHTTPOnSamePort_GQLRequest_Unsuccessful (0.00s)
=== RUN   TestGraphQLHTTPOnSamePort_GQLRequest_Unsuccessful
--- PASS: TestGraphQLHTTPOnSamePort_GQLRequest_Unsuccessful (0.00s)
=== RUN   TestGraphQLHTTPOnSamePort_GQLRequest_Unsuccessful
--- PASS: TestGraphQLHTTPOnSamePort_GQLRequest_Unsuccessful (0.00s)
=== RUN   TestGraphQLHTTPOnSamePort_GQLRequest_Unsuccessful
--- PASS: TestGraphQLHTTPOnSamePort_GQLRequest_Unsuccessful (0.00s)
```
But sometimes they fail:
```
=== RUN   TestGraphQLHTTPOnSamePort_GQLRequest_Unsuccessful
    TestGraphQLHTTPOnSamePort_GQLRequest_Unsuccessful: graphql_test.go:161: could not post: Post "http://127.0.0.1:9393/graphql": EOF
```

In go `1.15`, they run slow. But 
```
go test . -run TestGraphQLHTTPOnSamePort_GQLRequest_Unsuccessful -v  --count 20
=== RUN   TestGraphQLHTTPOnSamePort_GQLRequest_Unsuccessful
--- PASS: TestGraphQLHTTPOnSamePort_GQLRequest_Unsuccessful (0.53s)
=== RUN   TestGraphQLHTTPOnSamePort_GQLRequest_Unsuccessful
--- PASS: TestGraphQLHTTPOnSamePort_GQLRequest_Unsuccessful (0.58s)
=== RUN   TestGraphQLHTTPOnSamePort_GQLRequest_Unsuccessful
--- PASS: TestGraphQLHTTPOnSamePort_GQLRequest_Unsuccessful (0.51s)
=== RUN   TestGraphQLHTTPOnSamePort_GQLRequest_Unsuccessful
--- PASS: TestGraphQLHTTPOnSamePort_GQLRequest_Unsuccessful (0.50s)
=== RUN   TestGraphQLHTTPOnSamePort_GQLRequest_Unsuccessful
--- PASS: TestGraphQLHTTPOnSamePort_GQLRequest_Unsuccessful (0.51s)
=== RUN   TestGraphQLHTTPOnSamePort_GQLRequest_Unsuccessful
--- PASS: TestGraphQLHTTPOnSamePort_GQLRequest_Unsuccessful (0.50s)
=== RUN   TestGraphQLHTTPOnSamePort_GQLRequest_Unsuccessful
--- PASS: TestGraphQLHTTPOnSamePort_GQLRequest_Unsuccessful (0.56s)
```
But they don't spuriously fail!

So the delay seems to be working. What is the delay? The delay is improved in this commit: https://github.com/golang/go/commit/f0c9ae5452832f0f9e4dfa38f756ae9137577482 , and digging into the back-story a bit, it can be surmised that there's a race between closing connecttions, and that there may be active connections that get bit by it. It seems that `1.14` suffers from this. Maybe a straggling 'close' or 'reset' is still on the network when the next connection is made. 

Whatever the reason, it seems that a working fix is to not use the same port every time, but randomize it a bit. With this PR, I no longer trigger the error on go `1.14`. 