### PR TITLE
eth, eth/downloader,p2p: reserve half peer slots for snap peers during snap sync

### DIFF
--- a/eth/handler.go
+++ b/eth/handler.go
@@ -252,13 +252,10 @@ func (h *handler) runEthPeer(peer *eth.Peer, handler eth.Handler) error {
 	}
 	reject := false // reserved peer slots
 	if atomic.LoadUint32(&h.snapSync) == 1 && !peer.SupportsCap("snap", 1) {
-		// If we are running snap-sync, we want to reserve half the peer slots for
-		// peers supporting the snap protocol
-		// The logic here is; we always allow up to 5 non-snap peers, but after that,
-		// we require snap-peers to fill at least a third of the peer-slots.
-		snapPeers := h.peers.SnapLen()
-		ethPeers := h.peers.Len() - snapPeers // snap-peers are a subset of eth-peers
-		if ethPeers > 5 && ethPeers > 2*snapPeers {
+		// If we are running snap-sync, we want to reserve roughly half the peer
+		// slots for peers supporting the snap protocol.
+		// The logic here is; we only allow up to 5 more non-snap peers than snap-peers.
+		if all, snp := h.peers.Len(), h.peers.SnapLen(); all-snp > snp+5 {
 			reject = true
 		}
 	}

--- a/eth/handler.go
+++ b/eth/handler.go
@@ -255,7 +255,6 @@ func (h *handler) runEthPeer(peer *eth.Peer, handler eth.Handler) error {
 		// If we are running snap-sync, we want to reserve half the peer slots for
 		// peers supporting the snap protocol
 		reserved = h.maxPeers/2 - len(h.peers.snapPeers)
-		log.Info("Non-snap peer restricted", "reserved", reserved, "snap peers", len(h.peers.snapPeers))
 	}
 	if reserved < 0 {
 		reserved = 0

--- a/eth/peerset.go
+++ b/eth/peerset.go
@@ -259,13 +259,22 @@ func (ps *peerSet) ethPeersWithoutTransaction(hash common.Hash) []*ethPeer {
 }
 
 // Len returns if the current number of `eth` peers in the set. Since the `snap`
-// peers are tied to the existnce of an `eth` connection, that will always be a
+// peers are tied to the existence of an `eth` connection, that will always be a
 // subset of `eth`.
 func (ps *peerSet) Len() int {
 	ps.lock.RLock()
 	defer ps.lock.RUnlock()
 
 	return len(ps.ethPeers)
+}
+
+// SnapLen returns if the current number of `snap` peers in the set. Since the `snap`
+// peers are tied to the existence of an `eth` connection, that will always be a
+// subset of `eth`.
+func (ps *peerSet) SnapLen() int {
+	ps.lock.RLock()
+	defer ps.lock.RUnlock()
+	return len(ps.snapPeers)
 }
 
 // ethPeerWithHighestTD retrieves the known peer with the currently highest total

--- a/eth/sync.go
+++ b/eth/sync.go
@@ -329,6 +329,10 @@ func (h *handler) doSync(op *chainSyncOp) error {
 		log.Info("Fast sync complete, auto disabling")
 		atomic.StoreUint32(&h.fastSync, 0)
 	}
+	if atomic.LoadUint32(&h.snapSync) == 1 {
+		log.Info("Snap sync complete, auto disabling")
+		atomic.StoreUint32(&h.snapSync, 0)
+	}
 	// If we've successfully finished a sync cycle and passed any required checkpoint,
 	// enable accepting transactions from the network.
 	head := h.chain.CurrentBlock()

--- a/p2p/peer.go
+++ b/p2p/peer.go
@@ -158,6 +158,16 @@ func (p *Peer) Caps() []Cap {
 	return p.rw.caps
 }
 
+// SupportsCap returns true if the peer supports the given protocol/version
+func (p *Peer) SupportsCap(protocol string, version uint) bool {
+	for _, cap := range p.rw.caps {
+		if cap.Name == protocol {
+			return version <= cap.Version
+		}
+	}
+	return false
+}
+
 // RemoteAddr returns the remote address of the network connection.
 func (p *Peer) RemoteAddr() net.Addr {
 	return p.rw.fd.RemoteAddr()


### PR DESCRIPTION
This PR attempts to reseve half the peer slots for `snap/1` peers, if we're actively trying to perform a snap sync. 

Some caveats
- If we're just running `--snapshot`, but `syncmode=fast`, then it should do nothing
- If we're running `--snapshot`, and`syncmode=snap`, but are done syncing, it should do nothing

