### PR TITLE
core/state/snapshot: add generation logs to storage too

### DIFF
--- a/core/state/snapshot/generate.go
+++ b/core/state/snapshot/generate.go
@@ -281,6 +281,10 @@ func (dl *diskLayer) generate(stats *generatorStats) {
 						abort <- stats
 						return
 					}
+					if time.Since(logged) > 8*time.Second {
+						stats.Log("Generating state snapshot", dl.root, append(accountHash[:], storeIt.Key...))
+						logged = time.Now()
+					}
 				}
 			}
 			if err := storeIt.Err; err != nil {


### PR DESCRIPTION
Currently the snapshot generator only logs every 8 seconds while it's processing the account trie (possibly a regression, I surely know it logged for storage tries too at one time). The generator however does not log while it's crunching through a storage trie.

If the node is receiving blocks, this is fine, because every block interrupts the generator and will resume it afterwards, forcing a log anyway. However, if no blocks are arriving (e.g. benchmarking with networking disabled), the generator will not print anything until it gets done with a contract. With contracts weighting gigabytes on mainnet, that amounts to hours of potential "no log" scenarios, which is not a good UX.

This PR adds a log back so that the generator will log if it was crunching a storage trie for too long too.