### PR TITLE
eth/protocols/snap: snap sync testing

### DIFF
--- a/eth/downloader/downloader.go
+++ b/eth/downloader/downloader.go
@@ -298,7 +298,7 @@ func (d *Downloader) RegisterPeer(id string, version uint, peer Peer) error {
 		// Tests use short IDs, don't choke on them
 		logger = log.New("peer", id)
 	} else {
-		logger = log.New("peer", id[:16])
+		logger = log.New("peer", id[:8])
 	}
 	logger.Trace("Registering sync peer")
 	if err := d.peers.Register(newPeerConnection(id, version, peer, logger)); err != nil {
@@ -325,7 +325,7 @@ func (d *Downloader) UnregisterPeer(id string) error {
 		// Tests use short IDs, don't choke on them
 		logger = log.New("peer", id)
 	} else {
-		logger = log.New("peer", id[:16])
+		logger = log.New("peer", id[:8])
 	}
 	logger.Trace("Unregistering sync peer")
 	if err := d.peers.Unregister(id); err != nil {

--- a/eth/protocols/snap/peer.go
+++ b/eth/protocols/snap/peer.go
@@ -22,6 +22,17 @@ import (
 	"github.com/ethereum/go-ethereum/p2p"
 )
 
+// PeerIF exists so we can mock peers in testing, and not deal with
+// the actual protocol marshalling
+type PeerIF interface {
+	ID() string
+	RequestAccountRange(id uint64, root, origin, limit common.Hash, bytes uint64) error
+	RequestStorageRanges(id uint64, root common.Hash, accounts []common.Hash, origin, limit []byte, bytes uint64) error
+	RequestByteCodes(id uint64, hashes []common.Hash, bytes uint64) error
+	RequestTrieNodes(id uint64, root common.Hash, paths []TrieNodePathSet, bytes uint64) error
+	Log() log.Logger
+}
+
 // Peer is a collection of relevant information we have about a `snap` peer.
 type Peer struct {
 	id string // Unique ID for the peer, cached

--- a/eth/protocols/snap/peer.go
+++ b/eth/protocols/snap/peer.go
@@ -22,17 +22,6 @@ import (
 	"github.com/ethereum/go-ethereum/p2p"
 )
 
-// PeerIF exists so we can mock peers in testing, and not deal with
-// the actual protocol marshalling
-type PeerIF interface {
-	ID() string
-	RequestAccountRange(id uint64, root, origin, limit common.Hash, bytes uint64) error
-	RequestStorageRanges(id uint64, root common.Hash, accounts []common.Hash, origin, limit []byte, bytes uint64) error
-	RequestByteCodes(id uint64, hashes []common.Hash, bytes uint64) error
-	RequestTrieNodes(id uint64, root common.Hash, paths []TrieNodePathSet, bytes uint64) error
-	Log() log.Logger
-}
-
 // Peer is a collection of relevant information we have about a `snap` peer.
 type Peer struct {
 	id string // Unique ID for the peer, cached
@@ -65,6 +54,11 @@ func (p *Peer) ID() string {
 // Version retrieves the peer's negoatiated `snap` protocol version.
 func (p *Peer) Version() uint {
 	return p.version
+}
+
+// Log overrides the P2P logget with the higher level one containing only the id.
+func (p *Peer) Log() log.Logger {
+	return p.logger
 }
 
 // RequestAccountRange fetches a batch of accounts rooted in a specific account

--- a/eth/protocols/snap/protocol.go
+++ b/eth/protocols/snap/protocol.go
@@ -61,6 +61,7 @@ var (
 	errDecode         = errors.New("invalid message")
 	errInvalidMsgCode = errors.New("invalid message code")
 	errBadRequest     = errors.New("bad request")
+	errCancelled      = errors.New("sync cancelled")
 )
 
 // Packet represents a p2p message in the `snap` protocol.

--- a/eth/protocols/snap/sync.go
+++ b/eth/protocols/snap/sync.go
@@ -2392,6 +2392,8 @@ func (s *Syncer) OnTrieNodes(peer PeerIF, id uint64, trienodes [][]byte) error {
 		}
 		// We've either ran out of hashes, or got unrequested data
 		logger.Warn("Unexpected healing trienodes", "count", len(trienodes)-i)
+		// Signal this request as failed, and ready for rescheduling
+		s.scheduleRevertTrienodeHealRequest(req)
 		return errors.New("unexpected healing trienode")
 	}
 	// Response validated, send it to the scheduler for filling
@@ -2484,6 +2486,8 @@ func (s *Syncer) onHealByteCodes(peer PeerIF, id uint64, bytecodes [][]byte) err
 		}
 		// We've either ran out of hashes, or got unrequested data
 		logger.Warn("Unexpected healing bytecodes", "count", len(bytecodes)-i)
+		// Signal this request as failed, and ready for rescheduling
+		s.scheduleRevertBytecodeHealRequest(req)
 		return errors.New("unexpected healing bytecode")
 	}
 	// Response validated, send it to the scheduler for filling

--- a/eth/protocols/snap/sync.go
+++ b/eth/protocols/snap/sync.go
@@ -2103,7 +2103,11 @@ func (s *Syncer) onByteCodes(peer PeerIF, id uint64, bytecodes [][]byte) error {
 
 	// Clean up the request timeout timer, we'll see how to proceed further based
 	// on the actual delivered content
-	req.timeout.Stop()
+	if !req.timeout.Stop() {
+		// The timeout is already triggered, and this request will be reverted+rescheduled
+		s.lock.Unlock()
+		return nil
+	}
 
 	// Response is valid, but check if peer is signalling that it does not have
 	// the requested data. For bytecode range queries that means the peer is not

--- a/eth/protocols/snap/sync.go
+++ b/eth/protocols/snap/sync.go
@@ -1537,7 +1537,7 @@ func (s *Syncer) processAccountResponse(res *accountResponse) {
 			break
 		}
 	}
-	// Itereate over all the accounts and assemble which ones need further sub-
+	// Iterate over all the accounts and assemble which ones need further sub-
 	// filling before the entire account range can be persisted.
 	res.task.needCode = make([]bool, len(res.accounts))
 	res.task.needState = make([]bool, len(res.accounts))
@@ -1581,7 +1581,7 @@ func (s *Syncer) processAccountResponse(res *accountResponse) {
 		}
 	}
 	// Delete any subtasks that have been aborted but not resumed. This may undo
-	// some progress if a newpeer gives us less accounts than an old one, but for
+	// some progress if a new peer gives us less accounts than an old one, but for
 	// now we have to live with that.
 	for hash := range res.task.SubTasks {
 		if _, ok := resumed[hash]; !ok {

--- a/eth/protocols/snap/sync.go
+++ b/eth/protocols/snap/sync.go
@@ -2262,6 +2262,7 @@ func (s *Syncer) OnStorage(peer PeerIF, id uint64, hashes [][]common.Hash, slots
 			dbs[i], tries[i], _, _, err = trie.VerifyRangeProof(req.roots[i], nil, nil, keys, slots[i], nil)
 			if err != nil {
 				logger.Warn("Storage slots failed proof", "err", err)
+				s.scheduleRevertStorageRequest(req)
 				return err
 			}
 		} else {
@@ -2276,6 +2277,7 @@ func (s *Syncer) OnStorage(peer PeerIF, id uint64, hashes [][]common.Hash, slots
 			dbs[i], tries[i], notary, cont, err = trie.VerifyRangeProof(req.roots[i], req.origin[:], end, keys, slots[i], proofdb)
 			if err != nil {
 				logger.Warn("Storage range failed proof", "err", err)
+				s.scheduleRevertStorageRequest(req)
 				return err
 			}
 		}

--- a/eth/protocols/snap/sync.go
+++ b/eth/protocols/snap/sync.go
@@ -1978,7 +1978,11 @@ func (s *Syncer) OnAccounts(peer PeerIF, id uint64, hashes []common.Hash, accoun
 
 	// Clean up the request timeout timer, we'll see how to proceed further based
 	// on the actual delivered content
-	req.timeout.Stop()
+	if !req.timeout.Stop(){
+		// The timeout is already triggered, and this request will be reverted+rescheduled
+		s.lock.Unlock()
+		return nil
+	}
 
 	// Response is valid, but check if peer is signalling that it does not have
 	// the requested data. For account range queries that means the state being
@@ -2199,7 +2203,11 @@ func (s *Syncer) OnStorage(peer PeerIF, id uint64, hashes [][]common.Hash, slots
 
 	// Clean up the request timeout timer, we'll see how to proceed further based
 	// on the actual delivered content
-	req.timeout.Stop()
+	if !req.timeout.Stop(){
+		// The timeout is already triggered, and this request will be reverted+rescheduled
+		s.lock.Unlock()
+		return nil
+	}
 
 	// Reject the response if the hash sets and slot sets don't match, or if the
 	// peer sent more data than requested.
@@ -2336,7 +2344,11 @@ func (s *Syncer) OnTrieNodes(peer PeerIF, id uint64, trienodes [][]byte) error {
 
 	// Clean up the request timeout timer, we'll see how to proceed further based
 	// on the actual delivered content
-	req.timeout.Stop()
+	if !req.timeout.Stop(){
+		// The timeout is already triggered, and this request will be reverted+rescheduled
+		s.lock.Unlock()
+		return nil
+	}
 
 	// Response is valid, but check if peer is signalling that it does not have
 	// the requested data. For bytecode range queries that means the peer is not
@@ -2424,7 +2436,11 @@ func (s *Syncer) onHealByteCodes(peer PeerIF, id uint64, bytecodes [][]byte) err
 
 	// Clean up the request timeout timer, we'll see how to proceed further based
 	// on the actual delivered content
-	req.timeout.Stop()
+	if !req.timeout.Stop(){
+		// The timeout is already triggered, and this request will be reverted+rescheduled
+		s.lock.Unlock()
+		return nil
+	}
 
 	// Response is valid, but check if peer is signalling that it does not have
 	// the requested data. For bytecode range queries that means the peer is not

--- a/eth/protocols/snap/sync.go
+++ b/eth/protocols/snap/sync.go
@@ -1703,6 +1703,7 @@ func (s *Syncer) processStorageResponse(res *storageResponse) {
 				continue
 			}
 			acc := res.mainTask.res.accounts[j]
+
 			// If the packet contains multiple contract storage slots, all
 			// but the last are surely complete. The last contract may be
 			// chunked, so check it's continuation flag.

--- a/eth/protocols/snap/sync.go
+++ b/eth/protocols/snap/sync.go
@@ -73,10 +73,6 @@ const (
 	// waste bandwidth.
 	maxTrieRequestCount = 512
 
-	// requestTimeout is the maximum time a peer is allowed to spend on serving
-	// a single network request.
-	requestTimeout = 10 * time.Second // TODO(karalabe): Make it dynamic ala fast-sync?
-
 	// accountConcurrency is the number of chunks to split the account trie into
 	// to allow concurrent retrievals.
 	accountConcurrency = 16
@@ -84,6 +80,12 @@ const (
 	// storageConcurrency is the number of chunks to split the a large contract
 	// storage trie into to allow concurrent retrievals.
 	storageConcurrency = 16
+)
+
+var (
+	// requestTimeout is the maximum time a peer is allowed to spend on serving
+	// a single network request.
+	requestTimeout = 10 * time.Second // TODO(karalabe): Make it dynamic ala fast-sync?
 )
 
 // accountRequest tracks a pending account range request to ensure responses are

--- a/eth/protocols/snap/sync.go
+++ b/eth/protocols/snap/sync.go
@@ -2018,6 +2018,8 @@ func (s *Syncer) OnAccounts(peer PeerIF, id uint64, hashes []common.Hash, accoun
 	db, tr, notary, cont, err := trie.VerifyRangeProof(root, req.origin[:], end, keys, accounts, proofdb)
 	if err != nil {
 		logger.Warn("Account range failed proof", "err", err)
+		// Signal this request as failed, and ready for rescheduling
+		s.scheduleRevertAccountRequest(req)
 		return err
 	}
 	// Partial trie reconstructed, send it to the scheduler for storage filling

--- a/eth/protocols/snap/sync.go
+++ b/eth/protocols/snap/sync.go
@@ -583,7 +583,7 @@ func (s *Syncer) Sync(root common.Hash, cancel chan struct{}) error {
 		case id := <-peerDrop:
 			s.revertRequests(id)
 		case <-cancel:
-			return nil
+			return errCancelled
 
 		case req := <-s.accountReqFails:
 			s.revertAccountRequest(req)
@@ -1978,7 +1978,7 @@ func (s *Syncer) OnAccounts(peer PeerIF, id uint64, hashes []common.Hash, accoun
 
 	// Clean up the request timeout timer, we'll see how to proceed further based
 	// on the actual delivered content
-	if !req.timeout.Stop(){
+	if !req.timeout.Stop() {
 		// The timeout is already triggered, and this request will be reverted+rescheduled
 		s.lock.Unlock()
 		return nil
@@ -2203,7 +2203,7 @@ func (s *Syncer) OnStorage(peer PeerIF, id uint64, hashes [][]common.Hash, slots
 
 	// Clean up the request timeout timer, we'll see how to proceed further based
 	// on the actual delivered content
-	if !req.timeout.Stop(){
+	if !req.timeout.Stop() {
 		// The timeout is already triggered, and this request will be reverted+rescheduled
 		s.lock.Unlock()
 		return nil
@@ -2344,7 +2344,7 @@ func (s *Syncer) OnTrieNodes(peer PeerIF, id uint64, trienodes [][]byte) error {
 
 	// Clean up the request timeout timer, we'll see how to proceed further based
 	// on the actual delivered content
-	if !req.timeout.Stop(){
+	if !req.timeout.Stop() {
 		// The timeout is already triggered, and this request will be reverted+rescheduled
 		s.lock.Unlock()
 		return nil
@@ -2436,7 +2436,7 @@ func (s *Syncer) onHealByteCodes(peer PeerIF, id uint64, bytecodes [][]byte) err
 
 	// Clean up the request timeout timer, we'll see how to proceed further based
 	// on the actual delivered content
-	if !req.timeout.Stop(){
+	if !req.timeout.Stop() {
 		// The timeout is already triggered, and this request will be reverted+rescheduled
 		s.lock.Unlock()
 		return nil

--- a/eth/protocols/snap/sync_test.go
+++ b/eth/protocols/snap/sync_test.go
@@ -22,7 +22,6 @@ import (
 	"encoding/binary"
 	"fmt"
 	"math/big"
-	"os"
 	"sort"
 	"testing"
 	"time"
@@ -143,8 +142,8 @@ func newTestPeer(id string, t *testing.T, cancelCh chan struct{}) *testPeer {
 		codeRequestHandler:    defaultCodeReqeustHandler,
 		cancelCh:              cancelCh,
 	}
-	stdoutHandler := log.StreamHandler(os.Stdout, log.TerminalFormat(true))
-	peer.logger.SetHandler(stdoutHandler)
+	//stderrHandler := log.StreamHandler(os.Stderr, log.TerminalFormat(true))
+	//peer.logger.SetHandler(stderrHandler)
 	return peer
 
 }
@@ -874,7 +873,6 @@ func TestSyncNoStorageAndOneCodeCappedPeer(t *testing.T) {
 // TestSyncWithStorageAndOneCappedPeer tests sync using accounts + storage, where one peer is
 // consistently returning very small results
 func TestSyncWithStorageAndOneCappedPeer(t *testing.T) {
-	log.Root().SetHandler(log.LvlFilterHandler(log.LvlTrace, log.StreamHandler(os.Stderr, log.TerminalFormat(true))))
 	cancel := make(chan struct{})
 
 	sourceAccountTrie, elems, storageTries, storageElems := makeAccountTrieWithStorage(300, 1000, false)

--- a/eth/protocols/snap/sync_test.go
+++ b/eth/protocols/snap/sync_test.go
@@ -744,7 +744,7 @@ func checkStall(t *testing.T, cancel chan struct{}) chan struct{} {
 	testDone := make(chan struct{})
 	go func() {
 		select {
-		case <-time.After(15 * time.Second):
+		case <-time.After(time.Minute): // TODO(karalabe): Make tests smaller, this is too much
 			t.Log("Sync stalled")
 			close(cancel)
 		case <-testDone:

--- a/eth/protocols/snap/sync_test.go
+++ b/eth/protocols/snap/sync_test.go
@@ -110,6 +110,11 @@ func BenchmarkHashing(b *testing.B) {
 	})
 }
 
+type storageHandlerFunc func(t *testPeer, requestId uint64, root common.Hash, accounts []common.Hash, origin, limit []byte, max uint64) error
+type accountHandlerFunc func(t *testPeer, requestId uint64, root common.Hash, origin common.Hash, cap uint64) error
+type trieHandlerFunc func(t *testPeer, requestId uint64, root common.Hash, paths []TrieNodePathSet, cap uint64) error
+type codeHandlerFunc func(t *testPeer, id uint64, hashes []common.Hash, max uint64) error
+
 type testPeer struct {
 	id            string
 	test          *testing.T
@@ -120,10 +125,10 @@ type testPeer struct {
 	storageTries  map[common.Hash]*trie.Trie
 	storageValues map[common.Hash]entrySlice
 
-	accountRequestHandler func(t *testPeer, requestId uint64, root common.Hash, origin common.Hash, cap uint64) error
-	storageRequestHandler func(t *testPeer, requestId uint64, root common.Hash, accounts []common.Hash, origin, limit []byte, max uint64) error
-	trieRequestHandler    func(t *testPeer, requestId uint64, root common.Hash, paths []TrieNodePathSet, cap uint64) error
-	codeRequestHandler    func(t *testPeer, id uint64, hashes []common.Hash, max uint64) error
+	accountRequestHandler accountHandlerFunc
+	storageRequestHandler storageHandlerFunc
+	trieRequestHandler    trieHandlerFunc
+	codeRequestHandler    codeHandlerFunc
 	cancelCh              chan struct{}
 }
 
@@ -152,28 +157,31 @@ func (t *testPeer) Log() log.Logger {
 	return t.log
 }
 
-func (t *testPeer) RequestAccountRange(id uint64, root, origin, limit common.Hash, cap uint64) error {
-	t.Log().Info("<- AccRangeReq", "id", id, "root", root, "origin", origin, "limit", limit, "max", cap)
-	go t.accountRequestHandler(t, id, root, origin, cap)
+func (t *testPeer) RequestAccountRange(id uint64, root, origin, limit common.Hash, bytes uint64) error {
+	t.log.Trace("Fetching range of accounts", "reqid", id, "root", root, "origin", origin, "limit", limit, "bytes", common.StorageSize(bytes))
+	go t.accountRequestHandler(t, id, root, origin, bytes)
 	return nil
 }
 
-func (t *testPeer) RequestTrieNodes(id uint64, root common.Hash, paths []TrieNodePathSet, cap uint64) error {
-	t.Log().Info("<- TrieNodeReq", "id", id, "root", root, "paths", len(paths), "limit", cap)
-	go t.trieRequestHandler(t, id, root, paths, cap)
+func (t *testPeer) RequestTrieNodes(id uint64, root common.Hash, paths []TrieNodePathSet, bytes uint64) error {
+	t.log.Trace("Fetching set of trie nodes", "reqid", id, "root", root, "pathsets", len(paths), "bytes", common.StorageSize(bytes))
+	go t.trieRequestHandler(t, id, root, paths, bytes)
 	return nil
 }
 
-func (t *testPeer) RequestStorageRanges(id uint64, root common.Hash, accounts []common.Hash, origin, limit []byte, max uint64) error {
-	t.Log().Info("<- StorRangeReq", "id", id, "root", root, "account[0]", accounts[0],
-		"origin", fmt.Sprintf("%x", origin), "limit", fmt.Sprintf("%x", limit), "max", max)
-	go t.storageRequestHandler(t, id, root, accounts, origin, limit, max)
+func (t *testPeer) RequestStorageRanges(id uint64, root common.Hash, accounts []common.Hash, origin, limit []byte, bytes uint64) error {
+	if len(accounts) == 1 && origin != nil {
+		t.log.Trace("Fetching range of large storage slots", "reqid", id, "root", root, "account", accounts[0], "origin", common.BytesToHash(origin), "limit", common.BytesToHash(limit), "bytes", common.StorageSize(bytes))
+	} else {
+		t.log.Trace("Fetching ranges of small storage slots", "reqid", id, "root", root, "accounts", len(accounts), "first", accounts[0], "bytes", common.StorageSize(bytes))
+	}
+	go t.storageRequestHandler(t, id, root, accounts, origin, limit, bytes)
 	return nil
 }
 
-func (t *testPeer) RequestByteCodes(id uint64, hashes []common.Hash, max uint64) error {
-	t.Log().Info("<- CodeReq", "id", id, "#hashes", len(hashes), "max", max)
-	go t.codeRequestHandler(t, id, hashes, max)
+func (t *testPeer) RequestByteCodes(id uint64, hashes []common.Hash, bytes uint64) error {
+	t.log.Trace("Fetching set of byte codes", "reqid", id, "hashes", len(hashes), "bytes", common.StorageSize(bytes))
+	go t.codeRequestHandler(t, id, hashes, bytes)
 	return nil
 }
 
@@ -207,13 +215,20 @@ func defaultTrieRequestHandler(t *testPeer, requestId uint64, root common.Hash, 
 }
 
 // defaultAccountRequestHandler is a well-behaving handler for AccountRangeRequests
-func defaultAccountRequestHandler(t *testPeer, requestId uint64, root common.Hash, origin common.Hash, cap uint64) error {
-	var (
-		proofs [][]byte
-		keys   []common.Hash
-		vals   [][]byte
-		size   uint64
-	)
+func defaultAccountRequestHandler(t *testPeer, id uint64, root common.Hash, origin common.Hash, cap uint64) error {
+	keys, vals, proofs := createAccountRequestResponse(t, root, origin, cap)
+	if err := t.remote.OnAccounts(t, id, keys, vals, proofs); err != nil {
+		t.log.Error("remote error on delivery", "error", err)
+		t.test.Errorf("Remote side rejected our delivery: %v", err)
+		t.remote.Unregister(t.id)
+		t.cancelCh <- struct{}{}
+		return err
+	}
+	return nil
+}
+
+func createAccountRequestResponse(t *testPeer, root common.Hash, origin common.Hash, cap uint64) (keys []common.Hash, vals [][]byte, proofs [][]byte) {
+	var size uint64
 	for _, entry := range t.accountValues {
 		if size > cap {
 			break
@@ -242,19 +257,26 @@ func defaultAccountRequestHandler(t *testPeer, requestId uint64, root common.Has
 	for _, blob := range proof.NodeList() {
 		proofs = append(proofs, blob)
 	}
-	if err := t.remote.OnAccounts(t, requestId, keys, vals, proofs); err != nil {
-		t.log.Error("remote error on delivery", "error", err)
-		t.test.Errorf("Remote side rejected our delivery: %v", err)
-		t.cancelCh <- struct{}{}
-		return err
-	}
-	return nil
+	return keys, vals, proofs
 }
 
 // defaultStorageRequestHandler is a well-behaving storage request handler
 func defaultStorageRequestHandler(t *testPeer, requestId uint64, root common.Hash, accounts []common.Hash, bOrigin, bLimit []byte, max uint64) error {
 	hashes, slots, proofs := createStorageRequestResponse(t, root, accounts, bOrigin, bLimit, max)
 	if err := t.remote.OnStorage(t, requestId, hashes, slots, proofs); err != nil {
+		t.log.Error("remote error on delivery", "error", err)
+		t.test.Errorf("Remote side rejected our delivery: %v", err)
+		t.cancelCh <- struct{}{}
+	}
+	return nil
+}
+
+func defaultCodeReqeustHandler(t *testPeer, id uint64, hashes []common.Hash, max uint64) error {
+	var bytecodes [][]byte
+	for _, h := range hashes {
+		bytecodes = append(bytecodes, getCode(h))
+	}
+	if err := t.remote.OnByteCodes(t, id, bytecodes); err != nil {
 		t.log.Error("remote error on delivery", "error", err)
 		t.test.Errorf("Remote side rejected our delivery: %v", err)
 		t.cancelCh <- struct{}{}
@@ -278,7 +300,6 @@ func createStorageRequestResponse(t *testPeer, root common.Hash, accounts []comm
 	var limitExceeded bool
 	var incomplete bool
 	for _, account := range accounts {
-		t.Log().Info("Adding account", "account", account.Hex())
 
 		var keys []common.Hash
 		var vals [][]byte
@@ -295,7 +316,6 @@ func createStorageRequestResponse(t *testPeer, root common.Hash, accounts []comm
 			vals = append(vals, entry.v)
 			size += uint64(32 + len(entry.v))
 			if bytes.Compare(entry.k, limit[:]) >= 0 {
-				t.Log().Info("key outside of limit", "limit", fmt.Sprintf("%x", limit), "key", fmt.Sprintf("%x", entry.k))
 				limitExceeded = true
 			}
 			if size > max {
@@ -333,10 +353,6 @@ func createStorageRequestResponse(t *testPeer, root common.Hash, accounts []comm
 	return hashes, slots, proofs
 }
 
-func defaultCodeReqeustHandler(t *testPeer, id uint64, hashes []common.Hash, max uint64) error {
-	panic("TODO implement me")
-}
-
 // emptyRequestAccountRangeFn is a rejects AccountRangeRequests
 func emptyRequestAccountRangeFn(t *testPeer, requestId uint64, root common.Hash, origin common.Hash, cap uint64) error {
 	var proofs [][]byte
@@ -372,9 +388,36 @@ func nonResponsiveStorageRequestHandler(t *testPeer, requestId uint64, root comm
 	return nil
 }
 
-func emptyCodeRequestHandler(t *testPeer, id uint64, hashes []common.Hash, max uint64) error {
+//func emptyCodeRequestHandler(t *testPeer, id uint64, hashes []common.Hash, max uint64) error {
+//	var bytecodes [][]byte
+//	t.remote.OnByteCodes(t, id, bytecodes)
+//	return nil
+//}
+
+func corruptCodeReqeustHandler(t *testPeer, id uint64, hashes []common.Hash, max uint64) error {
 	var bytecodes [][]byte
-	t.remote.OnByteCodes(t, id, bytecodes)
+	for _, h := range hashes {
+		// Send back the hashes
+		bytecodes = append(bytecodes, h[:])
+	}
+	if err := t.remote.OnByteCodes(t, id, bytecodes); err != nil {
+		t.log.Error("remote error on delivery", "error", err)
+		// Mimic the real-life handler, which drops a peer on errors
+		t.remote.Unregister(t.id)
+	}
+	return nil
+}
+
+func cappedCodeReqeustHandler(t *testPeer, id uint64, hashes []common.Hash, max uint64) error {
+	var bytecodes [][]byte
+	for _, h := range hashes[:1] {
+		bytecodes = append(bytecodes, getCode(h))
+	}
+	if err := t.remote.OnByteCodes(t, id, bytecodes); err != nil {
+		t.log.Error("remote error on delivery", "error", err)
+		// Mimic the real-life handler, which drops a peer on errors
+		t.remote.Unregister(t.id)
+	}
 	return nil
 }
 
@@ -387,8 +430,21 @@ func starvingAccountRequestHandler(t *testPeer, requestId uint64, root common.Ha
 	return defaultAccountRequestHandler(t, requestId, root, origin, 500)
 }
 
-func misdeliveringAccountRequestHandler(t *testPeer, requestId uint64, root common.Hash, origin common.Hash, cap uint64) error {
-	return defaultAccountRequestHandler(t, requestId-1, root, origin, 500)
+//func misdeliveringAccountRequestHandler(t *testPeer, requestId uint64, root common.Hash, origin common.Hash, cap uint64) error {
+//	return defaultAccountRequestHandler(t, requestId-1, root, origin, 500)
+//}
+
+func corruptAccountRequestHandler(t *testPeer, requestId uint64, root common.Hash, origin common.Hash, cap uint64) error {
+	hashes, accounts, proofs := createAccountRequestResponse(t, root, origin, cap)
+	if len(proofs) > 0 {
+		proofs = proofs[1:]
+	}
+	if err := t.remote.OnAccounts(t, requestId, hashes, accounts, proofs); err != nil {
+		t.log.Info("remote error on delivery (as expected)", "error", err)
+		// Mimic the real-life handler, which drops a peer on errors
+		t.remote.Unregister(t.id)
+	}
+	return nil
 }
 
 // corruptStorageRequestHandler doesn't provide good proofs
@@ -399,43 +455,24 @@ func corruptStorageRequestHandler(t *testPeer, requestId uint64, root common.Has
 	}
 	if err := t.remote.OnStorage(t, requestId, hashes, slots, proofs); err != nil {
 		t.log.Info("remote error on delivery (as expected)", "error", err)
+		// Mimic the real-life handler, which drops a peer on errors
+		t.remote.Unregister(t.id)
 	}
 	return nil
 }
 
-// TestSync tests a basic sync
-func TestSync(t *testing.T) {
-	trieBackend := trie.NewDatabase(rawdb.NewMemoryDatabase())
-
-	sourceAccountTrie, elems := makeAccountTrieNoStorage(trieBackend, 100)
-	cancel := make(chan struct{})
-	source := newTestPeer("source", t, cancel)
-	source.accountTrie = sourceAccountTrie
-	source.accountValues = elems
-	syncer := setupSyncer(source)
-	if err := syncer.Sync(sourceAccountTrie.Hash(), cancel); err != nil {
-		t.Fatalf("sync failed: %v", err)
+func noProofStorageRequestHandler(t *testPeer, requestId uint64, root common.Hash, accounts []common.Hash, origin, limit []byte, max uint64) error {
+	hashes, slots, _ := createStorageRequestResponse(t, root, accounts, origin, limit, max)
+	if err := t.remote.OnStorage(t, requestId, hashes, slots, nil); err != nil {
+		t.log.Info("remote error on delivery (as expected)", "error", err)
+		// Mimic the real-life handler, which drops a peer on errors
+		t.remote.Unregister(t.id)
 	}
-}
-
-// TestSyncWithStorage tests  basic sync using accounts + storage
-func TestSyncWithStorage(t *testing.T) {
-	trieBackend := trie.NewDatabase(rawdb.NewMemoryDatabase())
-	sourceAccountTrie, elems, storageTries, storageElems := makeAccountTrieWithStorage(trieBackend, 3, 3000)
-	cancel := make(chan struct{})
-	source := newTestPeer("source", t, cancel)
-	source.accountTrie = sourceAccountTrie
-	source.accountValues = elems
-	source.storageTries = storageTries
-	source.storageValues = storageElems
-	syncer := setupSyncer(source)
-	if err := syncer.Sync(sourceAccountTrie.Hash(), cancel); err != nil {
-		t.Fatalf("sync failed: %v", err)
-	}
+	return nil
 }
 
 // TestSyncBloatedProof tests a scenario where we provide only _one_ value, but
-// also ship the entire trie inside the proof. If the attack is successfull,
+// also ship the entire trie inside the proof. If the attack is successful,
 // the remote side does not do any follow-up requests
 func TestSyncBloatedProof(t *testing.T) {
 	trieBackend := trie.NewDatabase(rawdb.NewMemoryDatabase())
@@ -499,20 +536,86 @@ func setupSyncer(peers ...*testPeer) *Syncer {
 	return syncer
 }
 
+// TestSync tests a basic sync with one peer
+func TestSync(t *testing.T) {
+	cancel := make(chan struct{})
+	sourceAccountTrie, elems := makeAccountTrieNoStorage(trie.NewDatabase(rawdb.NewMemoryDatabase()), 100)
+
+	mkSource := func(name string) *testPeer {
+		source := newTestPeer(name, t, cancel)
+		source.accountTrie = sourceAccountTrie
+		source.accountValues = elems
+		return source
+	}
+
+	syncer := setupSyncer(mkSource("sourceA"))
+	if err := syncer.Sync(sourceAccountTrie.Hash(), cancel); err != nil {
+		t.Fatalf("sync failed: %v", err)
+	}
+}
+
+// TestSyncTinyTriePanic tests a basic sync with one peer, and a tiny trie. This caused a
+// panic within the prover
+func TestSyncTinyTriePanic(t *testing.T) {
+	cancel := make(chan struct{})
+
+	sourceAccountTrie, elems, storageTries, storageElems := makeAccountTrieWithStorage(1, 1, false)
+
+	mkSource := func(name string, slow bool) *testPeer {
+		source := newTestPeer(name, t, cancel)
+		source.accountTrie = sourceAccountTrie
+		source.accountValues = elems
+		source.storageTries = storageTries
+		source.storageValues = storageElems
+
+		if slow {
+			source.storageRequestHandler = starvingStorageRequestHandler
+		}
+		return source
+	}
+
+	syncer := setupSyncer(
+		mkSource("nice-a", false),
+	)
+	done := checkStall(t, cancel)
+	if err := syncer.Sync(sourceAccountTrie.Hash(), cancel); err != nil {
+		t.Fatalf("sync failed: %v", err)
+	}
+	close(done)
+}
+
 // TestMultiSync tests a basic sync with multiple peers
 func TestMultiSync(t *testing.T) {
 	cancel := make(chan struct{})
 	sourceAccountTrie, elems := makeAccountTrieNoStorage(trie.NewDatabase(rawdb.NewMemoryDatabase()), 100)
 
-	sourceA := newTestPeer("sourceA", t, cancel)
-	sourceA.accountTrie = sourceAccountTrie
-	sourceA.accountValues = elems
+	mkSource := func(name string) *testPeer {
+		source := newTestPeer(name, t, cancel)
+		source.accountTrie = sourceAccountTrie
+		source.accountValues = elems
+		return source
+	}
 
-	sourceB := newTestPeer("sourceB", t, cancel)
-	sourceB.accountTrie = sourceAccountTrie
-	sourceB.accountValues = elems
+	syncer := setupSyncer(mkSource("sourceA"), mkSource("sourceB"))
+	if err := syncer.Sync(sourceAccountTrie.Hash(), cancel); err != nil {
+		t.Fatalf("sync failed: %v", err)
+	}
+}
 
-	syncer := setupSyncer(sourceA, sourceB)
+// TestSyncWithStorage tests  basic sync using accounts + storage + code
+func TestSyncWithStorage(t *testing.T) {
+	cancel := make(chan struct{})
+	sourceAccountTrie, elems, storageTries, storageElems := makeAccountTrieWithStorage(3, 3000, true)
+
+	mkSource := func(name string) *testPeer {
+		source := newTestPeer(name, t, cancel)
+		source.accountTrie = sourceAccountTrie
+		source.accountValues = elems
+		source.storageTries = storageTries
+		source.storageValues = storageElems
+		return source
+	}
+	syncer := setupSyncer(mkSource("sourceA"))
 	if err := syncer.Sync(sourceAccountTrie.Hash(), cancel); err != nil {
 		t.Fatalf("sync failed: %v", err)
 	}
@@ -522,8 +625,7 @@ func TestMultiSync(t *testing.T) {
 func TestMultiSyncManyUseless(t *testing.T) {
 	cancel := make(chan struct{})
 
-	trieBackend := trie.NewDatabase(rawdb.NewMemoryDatabase())
-	sourceAccountTrie, elems, storageTries, storageElems := makeAccountTrieWithStorage(trieBackend, 100, 3000)
+	sourceAccountTrie, elems, storageTries, storageElems := makeAccountTrieWithStorage(100, 3000, true)
 
 	mkSource := func(name string, a, b, c bool) *testPeer {
 		source := newTestPeer(name, t, cancel)
@@ -567,8 +669,7 @@ func TestMultiSyncManyUselessWithLowTimeout(t *testing.T) {
 	}()
 	cancel := make(chan struct{})
 
-	trieBackend := trie.NewDatabase(rawdb.NewMemoryDatabase())
-	sourceAccountTrie, elems, storageTries, storageElems := makeAccountTrieWithStorage(trieBackend, 100, 3000)
+	sourceAccountTrie, elems, storageTries, storageElems := makeAccountTrieWithStorage(100, 3000, true)
 
 	mkSource := func(name string, a, b, c bool) *testPeer {
 		source := newTestPeer(name, t, cancel)
@@ -602,10 +703,16 @@ func TestMultiSyncManyUselessWithLowTimeout(t *testing.T) {
 
 // TestMultiSyncManyUnresponsive contains one good peer, and many which doesn't respond at all
 func TestMultiSyncManyUnresponsive(t *testing.T) {
+	// We're setting the timeout to very low, to make the test run a bit faster
+	old := requestTimeout
+	requestTimeout = 1 * time.Millisecond
+	defer func() {
+		requestTimeout = old
+	}()
+
 	cancel := make(chan struct{})
 
-	trieBackend := trie.NewDatabase(rawdb.NewMemoryDatabase())
-	sourceAccountTrie, elems, storageTries, storageElems := makeAccountTrieWithStorage(trieBackend, 100, 3000)
+	sourceAccountTrie, elems, storageTries, storageElems := makeAccountTrieWithStorage(100, 3000, true)
 
 	mkSource := func(name string, a, b, c bool) *testPeer {
 		source := newTestPeer(name, t, cancel)
@@ -637,13 +744,26 @@ func TestMultiSyncManyUnresponsive(t *testing.T) {
 	}
 }
 
+func checkStall(t *testing.T, cancel chan (struct{})) chan struct{} {
+	testDone := make(chan (struct{}))
+	go func() {
+		select {
+		case <-time.After(5 * time.Second):
+			t.Log("Sync stalled")
+			cancel <- struct{}{}
+		case <-testDone:
+			return
+		}
+	}()
+	return testDone
+}
+
 // TestSyncNoStorageAndOneCappedPeer tests sync using accounts and no storage, where one peer is
 // consistently returning very small results
 func TestSyncNoStorageAndOneCappedPeer(t *testing.T) {
 	cancel := make(chan struct{})
 
-	trieBackend := trie.NewDatabase(rawdb.NewMemoryDatabase())
-	sourceAccountTrie, elems := makeAccountTrieNoStorage(trieBackend, 3000)
+	sourceAccountTrie, elems := makeAccountTrieNoStorage(trie.NewDatabase(rawdb.NewMemoryDatabase()), 3000)
 
 	mkSource := func(name string, slow bool) *testPeer {
 		source := newTestPeer(name, t, cancel)
@@ -662,25 +782,115 @@ func TestSyncNoStorageAndOneCappedPeer(t *testing.T) {
 		mkSource("nice-c", false),
 		mkSource("capped", true),
 	)
-	go func() {
-		select {
-		case <-time.After(5 * time.Second):
-			t.Log("Sync stalled")
-			cancel <- struct{}{}
-		}
-	}()
+	done := checkStall(t, cancel)
 	if err := syncer.Sync(sourceAccountTrie.Hash(), cancel); err != nil {
 		t.Fatalf("sync failed: %v", err)
+	}
+	close(done)
+}
+
+// TestSyncNoStorageAndOneCodeCorruptPeer has one peer which doesn't deliver
+// code requests properly.
+func TestSyncNoStorageAndOneCodeCorruptPeer(t *testing.T) {
+	cancel := make(chan struct{})
+
+	sourceAccountTrie, elems := makeAccountTrieNoStorage(
+		trie.NewDatabase(rawdb.NewMemoryDatabase()), 3000)
+
+	mkSource := func(name string, codeFn codeHandlerFunc) *testPeer {
+		source := newTestPeer(name, t, cancel)
+		source.accountTrie = sourceAccountTrie
+		source.accountValues = elems
+		source.codeRequestHandler = codeFn
+		return source
+	}
+	// One is capped, one is corrupt. If we don't use a capped one, there's a 50%
+	// chance that the full set of codes requested are sent only to the
+	// non-corrupt peer, which delivers everything in one go, and makes the
+	// test moot
+	syncer := setupSyncer(
+		mkSource("capped", cappedCodeReqeustHandler),
+		mkSource("corrupt", corruptCodeReqeustHandler),
+	)
+	done := checkStall(t, cancel)
+	if err := syncer.Sync(sourceAccountTrie.Hash(), cancel); err != nil {
+		t.Fatalf("sync failed: %v", err)
+	}
+	close(done)
+}
+
+func TestSyncNoStorageAndOneAccountCorruptPeer(t *testing.T) {
+	cancel := make(chan struct{})
+
+	sourceAccountTrie, elems := makeAccountTrieNoStorage(trie.NewDatabase(rawdb.NewMemoryDatabase()), 3000)
+
+	mkSource := func(name string, accFn accountHandlerFunc) *testPeer {
+		source := newTestPeer(name, t, cancel)
+		source.accountTrie = sourceAccountTrie
+		source.accountValues = elems
+		source.accountRequestHandler = accFn
+		return source
+	}
+	// One is capped, one is corrupt. If we don't use a capped one, there's a 50%
+	// chance that the full set of codes requested are sent only to the
+	// non-corrupt peer, which delivers everything in one go, and makes the
+	// test moot
+	syncer := setupSyncer(
+		mkSource("capped", defaultAccountRequestHandler),
+		mkSource("corrupt", corruptAccountRequestHandler),
+	)
+	done := checkStall(t, cancel)
+	if err := syncer.Sync(sourceAccountTrie.Hash(), cancel); err != nil {
+		t.Fatalf("sync failed: %v", err)
+	}
+	close(done)
+}
+
+// TestSyncNoStorageAndOneCodeCappedPeer has one peer which delivers code hashes
+// one by one
+func TestSyncNoStorageAndOneCodeCappedPeer(t *testing.T) {
+	cancel := make(chan struct{})
+
+	sourceAccountTrie, elems := makeAccountTrieNoStorage(trie.NewDatabase(rawdb.NewMemoryDatabase()), 3000)
+
+	mkSource := func(name string, codeFn codeHandlerFunc) *testPeer {
+		source := newTestPeer(name, t, cancel)
+		source.accountTrie = sourceAccountTrie
+		source.accountValues = elems
+		source.codeRequestHandler = codeFn
+		return source
+	}
+	// Count how many times it's invoked. Remember, there are only 8 unique hashes,
+	// so it shouldn't be more than that
+	var counter int
+	syncer := setupSyncer(
+		mkSource("capped", func(t *testPeer, id uint64, hashes []common.Hash, max uint64) error {
+			counter++
+			return cappedCodeReqeustHandler(t, id, hashes, max)
+		}),
+	)
+	done := checkStall(t, cancel)
+	if err := syncer.Sync(sourceAccountTrie.Hash(), cancel); err != nil {
+		t.Fatalf("sync failed: %v", err)
+	}
+	close(done)
+	// There are only 8 unique hashes, and 3K accounts. However, the code
+	// deduplication is per request batch. If it were a perfect global dedup,
+	// we would expect only 8 requests. If there were no dedup, there would be
+	// 3k requests.
+	// We expect somewhere below 100 requests for these 8 unique hashes.
+	if threshold := 100; counter > threshold {
+		t.Fatalf("Error, expected < %d invocations, got %d", threshold, counter)
 	}
 }
 
 // TestSyncWithStorageAndOneCappedPeer tests sync using accounts + storage, where one peer is
 // consistently returning very small results
 func TestSyncWithStorageAndOneCappedPeer(t *testing.T) {
+	log.Root().SetHandler(log.LvlFilterHandler(log.LvlTrace, log.StreamHandler(os.Stderr, log.TerminalFormat(true))))
 	cancel := make(chan struct{})
 
-	trieBackend := trie.NewDatabase(rawdb.NewMemoryDatabase())
-	sourceAccountTrie, elems, storageTries, storageElems := makeAccountTrieWithStorage(trieBackend, 100, 3000)
+	sourceAccountTrie, elems, storageTries, storageElems := makeAccountTrieWithStorage(300, 1000, false)
 
 	mkSource := func(name string, slow bool) *testPeer {
 		source := newTestPeer(name, t, cancel)
@@ -697,20 +907,13 @@ func TestSyncWithStorageAndOneCappedPeer(t *testing.T) {
 
 	syncer := setupSyncer(
 		mkSource("nice-a", false),
-		//mkSource("nice-b", false),
-		//mkSource("nice-c", false),
 		mkSource("slow", true),
 	)
-	go func() {
-		select {
-		case <-time.After(5 * time.Second):
-			t.Errorf("Sync stalled")
-			cancel <- struct{}{}
-		}
-	}()
+	done := checkStall(t, cancel)
 	if err := syncer.Sync(sourceAccountTrie.Hash(), cancel); err != nil {
 		t.Fatalf("sync failed: %v", err)
 	}
+	close(done)
 }
 
 // TestSyncWithStorageAndCorruptPeer tests sync using accounts + storage, where one peer is
@@ -718,38 +921,57 @@ func TestSyncWithStorageAndOneCappedPeer(t *testing.T) {
 func TestSyncWithStorageAndCorruptPeer(t *testing.T) {
 	cancel := make(chan struct{})
 
-	trieBackend := trie.NewDatabase(rawdb.NewMemoryDatabase())
-	sourceAccountTrie, elems, storageTries, storageElems := makeAccountTrieWithStorage(trieBackend, 100, 3000)
+	sourceAccountTrie, elems, storageTries, storageElems := makeAccountTrieWithStorage(100, 3000, true)
 
-	mkSource := func(name string, corrupt bool) *testPeer {
+	mkSource := func(name string, handler storageHandlerFunc) *testPeer {
 		source := newTestPeer(name, t, cancel)
 		source.accountTrie = sourceAccountTrie
 		source.accountValues = elems
 		source.storageTries = storageTries
 		source.storageValues = storageElems
-
-		if corrupt {
-			source.storageRequestHandler = corruptStorageRequestHandler
-		}
+		source.storageRequestHandler = handler
 		return source
 	}
 
 	syncer := setupSyncer(
-		mkSource("nice-a", false),
-		mkSource("nice-b", false),
-		mkSource("nice-c", false),
-		mkSource("corrupt", true),
+		mkSource("nice-a", defaultStorageRequestHandler),
+		mkSource("nice-b", defaultStorageRequestHandler),
+		mkSource("nice-c", defaultStorageRequestHandler),
+		mkSource("corrupt", corruptStorageRequestHandler),
 	)
-	go func() {
-		select {
-		case <-time.After(5 * time.Second):
-			t.Errorf("Sync stalled")
-			cancel <- struct{}{}
-		}
-	}()
+	done := checkStall(t, cancel)
 	if err := syncer.Sync(sourceAccountTrie.Hash(), cancel); err != nil {
 		t.Fatalf("sync failed: %v", err)
 	}
+	close(done)
+}
+
+func TestSyncWithStorageAndNonProvingPeer(t *testing.T) {
+	cancel := make(chan struct{})
+
+	sourceAccountTrie, elems, storageTries, storageElems := makeAccountTrieWithStorage(100, 3000, true)
+
+	mkSource := func(name string, handler storageHandlerFunc) *testPeer {
+		source := newTestPeer(name, t, cancel)
+		source.accountTrie = sourceAccountTrie
+		source.accountValues = elems
+		source.storageTries = storageTries
+		source.storageValues = storageElems
+		source.storageRequestHandler = handler
+		return source
+	}
+
+	syncer := setupSyncer(
+		mkSource("nice-a", defaultStorageRequestHandler),
+		mkSource("nice-b", defaultStorageRequestHandler),
+		mkSource("nice-c", defaultStorageRequestHandler),
+		mkSource("corrupt", noProofStorageRequestHandler),
+	)
+	done := checkStall(t, cancel)
+	if err := syncer.Sync(sourceAccountTrie.Hash(), cancel); err != nil {
+		t.Fatalf("sync failed: %v", err)
+	}
+	close(done)
 }
 
 type kv struct {
@@ -773,7 +995,7 @@ func makeAccountTrieNoStorage(db *trie.Database, n int) (*trie.Trie, entrySlice)
 			Nonce:    i,
 			Balance:  big.NewInt(int64(i)),
 			Root:     emptyRoot,
-			CodeHash: emptyCode[:],
+			CodeHash: getACodeHash(i),
 		})
 		key := key32(i)
 		elem := &kv{key, value, false}
@@ -792,11 +1014,44 @@ func key32(i uint64) []byte {
 	return key
 }
 
+var (
+	codehashes = []common.Hash{
+		crypto.Keccak256Hash([]byte{0}),
+		crypto.Keccak256Hash([]byte{1}),
+		crypto.Keccak256Hash([]byte{2}),
+		crypto.Keccak256Hash([]byte{3}),
+		crypto.Keccak256Hash([]byte{4}),
+		crypto.Keccak256Hash([]byte{5}),
+		crypto.Keccak256Hash([]byte{6}),
+		crypto.Keccak256Hash([]byte{7}),
+	}
+)
+
+// getACodeHash returns a pseudo-random code hash
+func getACodeHash(i uint64) []byte {
+	h := codehashes[int(i)%len(codehashes)]
+	return h[:]
+}
+
+// convenience function to lookup the code from the code hash
+func getCode(hash common.Hash) []byte {
+	if hash == emptyCode {
+		return nil
+	}
+	for i, h := range codehashes {
+		if h == hash {
+			return []byte{byte(i)}
+		}
+	}
+	return nil
+}
+
 // makeAccountTrieWithStorage spits out a trie, along with the leafs
-func makeAccountTrieWithStorage(db *trie.Database, accounts, slots int) (*trie.Trie, entrySlice,
+func makeAccountTrieWithStorage(accounts, slots int, code bool) (*trie.Trie, entrySlice,
 	map[common.Hash]*trie.Trie, map[common.Hash]entrySlice) {
 
 	var (
+		db             = trie.NewDatabase(rawdb.NewMemoryDatabase())
 		accTrie, _     = trie.New(common.Hash{}, db)
 		entries        entrySlice
 		storageTries   = make(map[common.Hash]*trie.Trie)
@@ -809,11 +1064,15 @@ func makeAccountTrieWithStorage(db *trie.Database, accounts, slots int) (*trie.T
 	// Create n accounts in the trie
 	for i := uint64(1); i <= uint64(accounts); i++ {
 		key := key32(i)
+		codehash := emptyCode[:]
+		if code {
+			codehash = getACodeHash(i)
+		}
 		value, _ := rlp.EncodeToBytes(state.Account{
 			Nonce:    i,
 			Balance:  big.NewInt(int64(i)),
 			Root:     stRoot,
-			CodeHash: emptyCode[:],
+			CodeHash: codehash,
 		})
 		elem := &kv{key, value, false}
 		accTrie.Update(elem.k, elem.v)
@@ -822,6 +1081,7 @@ func makeAccountTrieWithStorage(db *trie.Database, accounts, slots int) (*trie.T
 		storageTries[common.BytesToHash(key)] = stTrie
 		storageEntries[common.BytesToHash(key)] = stEntries
 	}
+	sort.Sort(entries)
 	stTrie.Commit(nil)
 	accTrie.Commit(nil)
 	return accTrie, entries, storageTries, storageEntries

--- a/eth/protocols/snap/sync_test.go
+++ b/eth/protocols/snap/sync_test.go
@@ -38,6 +38,8 @@ import (
 )
 
 func TestHashing(t *testing.T) {
+	t.Parallel()
+
 	var bytecodes = make([][]byte, 10)
 	for i := 0; i < len(bytecodes); i++ {
 		buf := make([]byte, 100)
@@ -469,6 +471,8 @@ func noProofStorageRequestHandler(t *testPeer, requestId uint64, root common.Has
 // also ship the entire trie inside the proof. If the attack is successful,
 // the remote side does not do any follow-up requests
 func TestSyncBloatedProof(t *testing.T) {
+	t.Parallel()
+
 	sourceAccountTrie, elems := makeAccountTrieNoStorage(100)
 	cancel := make(chan struct{})
 	source := newTestPeer("source", t, cancel)
@@ -531,6 +535,8 @@ func setupSyncer(peers ...*testPeer) *Syncer {
 
 // TestSync tests a basic sync with one peer
 func TestSync(t *testing.T) {
+	t.Parallel()
+
 	cancel := make(chan struct{})
 	sourceAccountTrie, elems := makeAccountTrieNoStorage(100)
 
@@ -550,6 +556,8 @@ func TestSync(t *testing.T) {
 // TestSyncTinyTriePanic tests a basic sync with one peer, and a tiny trie. This caused a
 // panic within the prover
 func TestSyncTinyTriePanic(t *testing.T) {
+	t.Parallel()
+
 	cancel := make(chan struct{})
 
 	sourceAccountTrie, elems := makeAccountTrieNoStorage(1)
@@ -573,6 +581,8 @@ func TestSyncTinyTriePanic(t *testing.T) {
 
 // TestMultiSync tests a basic sync with multiple peers
 func TestMultiSync(t *testing.T) {
+	t.Parallel()
+
 	cancel := make(chan struct{})
 	sourceAccountTrie, elems := makeAccountTrieNoStorage(100)
 
@@ -591,6 +601,8 @@ func TestMultiSync(t *testing.T) {
 
 // TestSyncWithStorage tests  basic sync using accounts + storage + code
 func TestSyncWithStorage(t *testing.T) {
+	t.Parallel()
+
 	cancel := make(chan struct{})
 	sourceAccountTrie, elems, storageTries, storageElems := makeAccountTrieWithStorage(3, 3000, true)
 
@@ -610,6 +622,8 @@ func TestSyncWithStorage(t *testing.T) {
 
 // TestMultiSyncManyUseless contains one good peer, and many which doesn't return anything valuable at all
 func TestMultiSyncManyUseless(t *testing.T) {
+	t.Parallel()
+
 	cancel := make(chan struct{})
 
 	sourceAccountTrie, elems, storageTries, storageElems := makeAccountTrieWithStorage(100, 3000, true)
@@ -649,11 +663,9 @@ func TestMultiSyncManyUselessWithLowTimeout(t *testing.T) {
 	// We're setting the timeout to very low, to increase the chance of the timeout
 	// being triggered. This was previously a cause of panic, when a response
 	// arrived simultaneously as a timeout was triggered.
-	old := requestTimeout
-	requestTimeout = 1 * time.Millisecond
-	defer func() {
-		requestTimeout = old
-	}()
+	defer func(old time.Duration) { requestTimeout = old }(requestTimeout)
+	requestTimeout = time.Millisecond
+
 	cancel := make(chan struct{})
 
 	sourceAccountTrie, elems, storageTries, storageElems := makeAccountTrieWithStorage(100, 3000, true)
@@ -691,11 +703,8 @@ func TestMultiSyncManyUselessWithLowTimeout(t *testing.T) {
 // TestMultiSyncManyUnresponsive contains one good peer, and many which doesn't respond at all
 func TestMultiSyncManyUnresponsive(t *testing.T) {
 	// We're setting the timeout to very low, to make the test run a bit faster
-	old := requestTimeout
-	requestTimeout = 1 * time.Millisecond
-	defer func() {
-		requestTimeout = old
-	}()
+	defer func(old time.Duration) { requestTimeout = old }(requestTimeout)
+	requestTimeout = time.Millisecond
 
 	cancel := make(chan struct{})
 
@@ -731,13 +740,13 @@ func TestMultiSyncManyUnresponsive(t *testing.T) {
 	}
 }
 
-func checkStall(t *testing.T, cancel chan (struct{})) chan struct{} {
-	testDone := make(chan (struct{}))
+func checkStall(t *testing.T, cancel chan struct{}) chan struct{} {
+	testDone := make(chan struct{})
 	go func() {
 		select {
 		case <-time.After(5 * time.Second):
 			t.Log("Sync stalled")
-			cancel <- struct{}{}
+			close(cancel)
 		case <-testDone:
 			return
 		}
@@ -748,6 +757,8 @@ func checkStall(t *testing.T, cancel chan (struct{})) chan struct{} {
 // TestSyncNoStorageAndOneCappedPeer tests sync using accounts and no storage, where one peer is
 // consistently returning very small results
 func TestSyncNoStorageAndOneCappedPeer(t *testing.T) {
+	t.Parallel()
+
 	cancel := make(chan struct{})
 
 	sourceAccountTrie, elems := makeAccountTrieNoStorage(3000)
@@ -779,6 +790,8 @@ func TestSyncNoStorageAndOneCappedPeer(t *testing.T) {
 // TestSyncNoStorageAndOneCodeCorruptPeer has one peer which doesn't deliver
 // code requests properly.
 func TestSyncNoStorageAndOneCodeCorruptPeer(t *testing.T) {
+	t.Parallel()
+
 	cancel := make(chan struct{})
 
 	sourceAccountTrie, elems := makeAccountTrieNoStorage(3000)
@@ -806,6 +819,8 @@ func TestSyncNoStorageAndOneCodeCorruptPeer(t *testing.T) {
 }
 
 func TestSyncNoStorageAndOneAccountCorruptPeer(t *testing.T) {
+	t.Parallel()
+
 	cancel := make(chan struct{})
 
 	sourceAccountTrie, elems := makeAccountTrieNoStorage(3000)
@@ -835,6 +850,8 @@ func TestSyncNoStorageAndOneAccountCorruptPeer(t *testing.T) {
 // TestSyncNoStorageAndOneCodeCappedPeer has one peer which delivers code hashes
 // one by one
 func TestSyncNoStorageAndOneCodeCappedPeer(t *testing.T) {
+	t.Parallel()
+
 	cancel := make(chan struct{})
 
 	sourceAccountTrie, elems := makeAccountTrieNoStorage(3000)
@@ -873,6 +890,8 @@ func TestSyncNoStorageAndOneCodeCappedPeer(t *testing.T) {
 // TestSyncWithStorageAndOneCappedPeer tests sync using accounts + storage, where one peer is
 // consistently returning very small results
 func TestSyncWithStorageAndOneCappedPeer(t *testing.T) {
+	t.Parallel()
+
 	cancel := make(chan struct{})
 
 	sourceAccountTrie, elems, storageTries, storageElems := makeAccountTrieWithStorage(300, 1000, false)
@@ -904,6 +923,8 @@ func TestSyncWithStorageAndOneCappedPeer(t *testing.T) {
 // TestSyncWithStorageAndCorruptPeer tests sync using accounts + storage, where one peer is
 // sometimes sending bad proofs
 func TestSyncWithStorageAndCorruptPeer(t *testing.T) {
+	t.Parallel()
+
 	cancel := make(chan struct{})
 
 	sourceAccountTrie, elems, storageTries, storageElems := makeAccountTrieWithStorage(100, 3000, true)
@@ -932,6 +953,8 @@ func TestSyncWithStorageAndCorruptPeer(t *testing.T) {
 }
 
 func TestSyncWithStorageAndNonProvingPeer(t *testing.T) {
+	t.Parallel()
+
 	cancel := make(chan struct{})
 
 	sourceAccountTrie, elems, storageTries, storageElems := makeAccountTrieWithStorage(100, 3000, true)
@@ -993,7 +1016,7 @@ var (
 // getACodeHash returns a pseudo-random code hash
 func getACodeHash(i uint64) []byte {
 	h := codehashes[int(i)%len(codehashes)]
-	return h[:]
+	return common.CopyBytes(h[:])
 }
 
 // convenience function to lookup the code from the code hash

--- a/eth/protocols/snap/sync_test.go
+++ b/eth/protocols/snap/sync_test.go
@@ -17,11 +17,24 @@
 package snap
 
 import (
+	"bytes"
 	"crypto/rand"
+	"encoding/binary"
 	"fmt"
+	"math/big"
+	"os"
+	"sort"
 	"testing"
+	"time"
 
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/rawdb"
+	"github.com/ethereum/go-ethereum/core/state"
 	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/light"
+	"github.com/ethereum/go-ethereum/log"
+	"github.com/ethereum/go-ethereum/rlp"
+	"github.com/ethereum/go-ethereum/trie"
 	"golang.org/x/crypto/sha3"
 )
 
@@ -95,4 +108,649 @@ func BenchmarkHashing(b *testing.B) {
 			new()
 		}
 	})
+}
+
+type testPeer struct {
+	id            string
+	test          *testing.T
+	remote        *Syncer
+	log           log.Logger
+	accountTrie   *trie.Trie
+	accountValues entrySlice
+	storageTries  map[common.Hash]*trie.Trie
+	storageValues map[common.Hash]entrySlice
+
+	accountRequestHandler func(t *testPeer, requestId uint64, root common.Hash, origin common.Hash, cap uint64) error
+	storageRequestHandler func(t *testPeer, requestId uint64, root common.Hash, accounts []common.Hash, origin, limit []byte, max uint64) error
+	trieRequestHandler    func(t *testPeer, requestId uint64, root common.Hash, paths []TrieNodePathSet, cap uint64) error
+	codeRequestHandler    func(t *testPeer, id uint64, hashes []common.Hash, max uint64) error
+	cancelCh              chan struct{}
+}
+
+func newTestPeer(id string, t *testing.T, cancelCh chan struct{}) *testPeer {
+	peer := &testPeer{
+		id:                    id,
+		test:                  t,
+		log:                   log.New("id", id),
+		accountRequestHandler: defaultAccountRequestHandler,
+		trieRequestHandler:    defaultTrieRequestHandler,
+		storageRequestHandler: defaultStorageRequestHandler,
+		codeRequestHandler:    defaultCodeReqeustHandler,
+		cancelCh:              cancelCh,
+	}
+	stdoutHandler := log.StreamHandler(os.Stdout, log.TerminalFormat(true))
+	peer.log.SetHandler(stdoutHandler)
+	return peer
+
+}
+
+func (t *testPeer) ID() string {
+	return t.id
+}
+
+func (t *testPeer) Log() log.Logger {
+	return t.log
+}
+
+func (t *testPeer) RequestAccountRange(id uint64, root, origin, limit common.Hash, cap uint64) error {
+	t.Log().Info("<- AccRangeReq", "id", id, "root", root, "origin", origin, "limit", limit, "max", cap)
+	go t.accountRequestHandler(t, id, root, origin, cap)
+	return nil
+}
+
+func (t *testPeer) RequestTrieNodes(id uint64, root common.Hash, paths []TrieNodePathSet, cap uint64) error {
+	t.Log().Info("<- TrieNodeReq", "id", id, "root", root, "paths", len(paths), "limit", cap)
+	go t.trieRequestHandler(t, id, root, paths, cap)
+	return nil
+}
+
+func (t *testPeer) RequestStorageRanges(id uint64, root common.Hash, accounts []common.Hash, origin, limit []byte, max uint64) error {
+	t.Log().Info("<- StorRangeReq", "id", id, "root", root, "account[0]", accounts[0],
+		"origin", fmt.Sprintf("%x", origin), "limit", fmt.Sprintf("%x", limit), "max", max)
+	go t.storageRequestHandler(t, id, root, accounts, origin, limit, max)
+	return nil
+}
+
+func (t *testPeer) RequestByteCodes(id uint64, hashes []common.Hash, max uint64) error {
+	t.Log().Info("<- CodeReq", "id", id, "#hashes", len(hashes), "max", max)
+	go t.codeRequestHandler(t, id, hashes, max)
+	return nil
+}
+
+// defaultTrieRequestHandler is a well-behaving handler for trie healing requests
+func defaultTrieRequestHandler(t *testPeer, requestId uint64, root common.Hash, paths []TrieNodePathSet, cap uint64) error {
+	// Pass the response
+	var nodes [][]byte
+	for _, pathset := range paths {
+		switch len(pathset) {
+		case 1:
+			blob, _, err := t.accountTrie.TryGetNode(pathset[0])
+			if err != nil {
+				t.Log().Info("Error handling req", "error", err)
+				break
+			}
+			nodes = append(nodes, blob)
+		default:
+			account := t.storageTries[(common.BytesToHash(pathset[0]))]
+			for _, path := range pathset[1:] {
+				blob, _, err := account.TryGetNode(path)
+				if err != nil {
+					t.Log().Info("Error handling req", "error", err)
+					break
+				}
+				nodes = append(nodes, blob)
+			}
+		}
+	}
+	t.remote.OnTrieNodes(t, requestId, nodes)
+	return nil
+}
+
+// defaultAccountRequestHandler is a well-behaving handler for AccountRangeRequests
+func defaultAccountRequestHandler(t *testPeer, requestId uint64, root common.Hash, origin common.Hash, cap uint64) error {
+	var (
+		proofs [][]byte
+		keys   []common.Hash
+		vals   [][]byte
+		size   uint64
+	)
+	for _, entry := range t.accountValues {
+		if size > cap {
+			break
+		}
+		if bytes.Compare(origin[:], entry.k) <= 0 {
+			keys = append(keys, common.BytesToHash(entry.k))
+			vals = append(vals, entry.v)
+			size += uint64(32 + len(entry.v))
+		}
+	}
+	// Unless we send the entire trie, we need to supply proofs
+	// Actually, we need to supply proofs either way! This seems tob be an implementation
+	// quirk in go-ethereum
+	proof := light.NewNodeSet()
+	if err := t.accountTrie.Prove(origin[:], 0, proof); err != nil {
+		t.log.Error("Could not prove inexistence of origin", "origin", origin,
+			"error", err)
+	}
+	if len(keys) > 0 {
+		lastK := (keys[len(keys)-1])[:]
+		if err := t.accountTrie.Prove(lastK, 0, proof); err != nil {
+			t.log.Error("Could not prove last item",
+				"error", err)
+		}
+	}
+	for _, blob := range proof.NodeList() {
+		proofs = append(proofs, blob)
+	}
+	if err := t.remote.OnAccounts(t, requestId, keys, vals, proofs); err != nil {
+		t.log.Error("remote error on delivery", "error", err)
+		t.test.Errorf("Remote side rejected our delivery: %v", err)
+		t.cancelCh <- struct{}{}
+		return err
+	}
+	return nil
+}
+
+// defaultStorageRequestHandler is a well-behaving storage request handler
+func defaultStorageRequestHandler(t *testPeer, requestId uint64, root common.Hash, accounts []common.Hash, bOrigin, bLimit []byte, max uint64) error {
+	hashes, slots, proofs := createStorageRequestResponse(t, root, accounts, bOrigin, bLimit, max)
+	if err := t.remote.OnStorage(t, requestId, hashes, slots, proofs); err != nil {
+		t.log.Error("remote error on delivery", "error", err)
+		t.test.Errorf("Remote side rejected our delivery: %v", err)
+		t.cancelCh <- struct{}{}
+	}
+	return nil
+}
+
+func createStorageRequestResponse(t *testPeer, root common.Hash, accounts []common.Hash, bOrigin, bLimit []byte, max uint64) (hashes [][]common.Hash, slots [][][]byte, proofs [][]byte) {
+	var (
+		size  uint64
+		limit = common.HexToHash("0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff")
+	)
+	if len(bLimit) > 0 {
+		limit = common.BytesToHash(bLimit)
+	}
+	var origin common.Hash
+	if len(bOrigin) > 0 {
+		origin = common.BytesToHash(bOrigin)
+	}
+
+	var limitExceeded bool
+	var incomplete bool
+	for _, account := range accounts {
+		t.Log().Info("Adding account", "account", account.Hex())
+
+		var keys []common.Hash
+		var vals [][]byte
+		for _, entry := range t.storageValues[account] {
+			if limitExceeded {
+				incomplete = true
+				break
+			}
+			if bytes.Compare(entry.k, origin[:]) < 0 {
+				incomplete = true
+				continue
+			}
+			keys = append(keys, common.BytesToHash(entry.k))
+			vals = append(vals, entry.v)
+			size += uint64(32 + len(entry.v))
+			if bytes.Compare(entry.k, limit[:]) >= 0 {
+				t.Log().Info("key outside of limit", "limit", fmt.Sprintf("%x", limit), "key", fmt.Sprintf("%x", entry.k))
+				limitExceeded = true
+			}
+			if size > max {
+				limitExceeded = true
+			}
+		}
+		hashes = append(hashes, keys)
+		slots = append(slots, vals)
+
+		if incomplete {
+			// If we're aborting, we need to prove the first and last item
+			// This terminates the response (and thus the loop)
+			proof := light.NewNodeSet()
+			stTrie := t.storageTries[account]
+
+			// Here's a potential gotcha: when constructing the proof, we cannot
+			// use the 'origin' slice directly, but must use the full 32-byte
+			// hash form.
+			if err := stTrie.Prove(origin[:], 0, proof); err != nil {
+				t.log.Error("Could not prove inexistence of origin", "origin", origin,
+					"error", err)
+			}
+			if len(keys) > 0 {
+				lastK := (keys[len(keys)-1])[:]
+				if err := stTrie.Prove(lastK, 0, proof); err != nil {
+					t.log.Error("Could not prove last item", "error", err)
+				}
+			}
+			for _, blob := range proof.NodeList() {
+				proofs = append(proofs, blob)
+			}
+			break
+		}
+	}
+	return hashes, slots, proofs
+}
+
+func defaultCodeReqeustHandler(t *testPeer, id uint64, hashes []common.Hash, max uint64) error {
+	panic("TODO implement me")
+}
+
+// emptyRequestAccountRangeFn is a rejects AccountRangeRequests
+func emptyRequestAccountRangeFn(t *testPeer, requestId uint64, root common.Hash, origin common.Hash, cap uint64) error {
+	var proofs [][]byte
+	var keys []common.Hash
+	var vals [][]byte
+	t.remote.OnAccounts(t, requestId, keys, vals, proofs)
+	return nil
+}
+
+func emptyTrieRequestHandler(t *testPeer, requestId uint64, root common.Hash, paths []TrieNodePathSet, cap uint64) error {
+	var nodes [][]byte
+	t.remote.OnTrieNodes(t, requestId, nodes)
+	return nil
+}
+
+func emptyStorageRequestHandler(t *testPeer, requestId uint64, root common.Hash, accounts []common.Hash, origin, limit []byte, max uint64) error {
+	var hashes [][]common.Hash
+	var slots [][][]byte
+	var proofs [][]byte
+	t.remote.OnStorage(t, requestId, hashes, slots, proofs)
+	return nil
+}
+
+func emptyCodeRequestHandler(t *testPeer, id uint64, hashes []common.Hash, max uint64) error {
+	var bytecodes [][]byte
+	t.remote.OnByteCodes(t, id, bytecodes)
+	return nil
+}
+
+// starvingStorageRequestHandler is somewhat well-behaving storage handler, but it caps the returned results to be very small
+func starvingStorageRequestHandler(t *testPeer, requestId uint64, root common.Hash, accounts []common.Hash, origin, limit []byte, max uint64) error {
+	return defaultStorageRequestHandler(t, requestId, root, accounts, origin, limit, 500)
+}
+
+func starvingAccountRequestHandler(t *testPeer, requestId uint64, root common.Hash, origin common.Hash, cap uint64) error {
+	return defaultAccountRequestHandler(t, requestId, root, origin, 500)
+}
+
+// corruptStorageRequestHandler doesn't provide good proofs
+func corruptStorageRequestHandler(t *testPeer, requestId uint64, root common.Hash, accounts []common.Hash, origin, limit []byte, max uint64) error {
+	hashes, slots, proofs := createStorageRequestResponse(t, root, accounts, origin, limit, max)
+	if len(proofs) > 0 {
+		proofs = proofs[1:]
+	}
+	if err := t.remote.OnStorage(t, requestId, hashes, slots, proofs); err != nil {
+		t.log.Info("remote error on delivery (as expected)", "error", err)
+	}
+	return nil
+}
+
+// TestSync tests a basic sync
+func TestSync(t *testing.T) {
+	trieBackend := trie.NewDatabase(rawdb.NewMemoryDatabase())
+
+	sourceAccountTrie, elems := makeAccountTrieNoStorage(trieBackend, 100)
+	cancel := make(chan struct{})
+	source := newTestPeer("source", t, cancel)
+	source.accountTrie = sourceAccountTrie
+	source.accountValues = elems
+	syncer := setupSyncer(source)
+	if err := syncer.Sync(sourceAccountTrie.Hash(), cancel); err != nil {
+		t.Fatalf("sync failed: %v", err)
+	}
+}
+
+// TestSyncWithStorage tests  basic sync using accounts + storage
+func TestSyncWithStorage(t *testing.T) {
+	trieBackend := trie.NewDatabase(rawdb.NewMemoryDatabase())
+	sourceAccountTrie, elems, storageTries, storageElems := makeAccountTrieWithStorage(trieBackend, 3, 3000)
+	cancel := make(chan struct{})
+	source := newTestPeer("source", t, cancel)
+	source.accountTrie = sourceAccountTrie
+	source.accountValues = elems
+	source.storageTries = storageTries
+	source.storageValues = storageElems
+	syncer := setupSyncer(source)
+	if err := syncer.Sync(sourceAccountTrie.Hash(), cancel); err != nil {
+		t.Fatalf("sync failed: %v", err)
+	}
+}
+
+// TestSyncBloatedProof tests a scenario where we provide only _one_ value, but
+// also ship the entire trie inside the proof. If the attack is successfull,
+// the remote side does not do any follow-up requests
+func TestSyncBloatedProof(t *testing.T) {
+	trieBackend := trie.NewDatabase(rawdb.NewMemoryDatabase())
+	sourceAccountTrie, elems := makeAccountTrieNoStorage(trieBackend, 100)
+	cancel := make(chan struct{})
+	source := newTestPeer("source", t, cancel)
+	source.accountTrie = sourceAccountTrie
+	source.accountValues = elems
+
+	source.accountRequestHandler = func(t *testPeer, requestId uint64, root common.Hash, origin common.Hash, cap uint64) error {
+		var proofs [][]byte
+		var keys []common.Hash
+		var vals [][]byte
+
+		// The values
+		for _, entry := range t.accountValues {
+			if bytes.Compare(origin[:], entry.k) <= 0 {
+				keys = append(keys, common.BytesToHash(entry.k))
+				vals = append(vals, entry.v)
+			}
+		}
+		// The proofs
+		proof := light.NewNodeSet()
+		if err := t.accountTrie.Prove(origin[:], 0, proof); err != nil {
+			t.log.Error("Could not prove origin", "origin", origin, "error", err)
+		}
+		// The bloat: add proof of every single element
+		for _, entry := range t.accountValues {
+			if err := t.accountTrie.Prove(entry.k, 0, proof); err != nil {
+				t.log.Error("Could not prove item", "error", err)
+			}
+		}
+		// And remove one item from the elements
+		if len(keys) > 2 {
+			keys = append(keys[:1], keys[2:]...)
+			vals = append(vals[:1], vals[2:]...)
+		}
+		for _, blob := range proof.NodeList() {
+			proofs = append(proofs, blob)
+		}
+		if err := t.remote.OnAccounts(t, requestId, keys, vals, proofs); err != nil {
+			t.log.Error("remote error on delivery", "error", err)
+			// This is actually correct, signal to exit the test successfully
+			t.cancelCh <- struct{}{}
+		}
+		return nil
+	}
+	syncer := setupSyncer(source)
+	if err := syncer.Sync(sourceAccountTrie.Hash(), cancel); err != nil {
+		t.Logf("sync failed: %v", err)
+	} else {
+		// TODO @karalabe, @holiman:
+		// A cancel, which aborts the sync before completion, should probably
+		// return an error from Sync(..) ?
+		t.Fatal("No error returned from incomplete/cancelled sync")
+	}
+}
+
+func setupSyncer(peers ...*testPeer) *Syncer {
+	stateDb := rawdb.NewMemoryDatabase()
+	syncer := NewSyncer(stateDb, trie.NewSyncBloom(1, stateDb))
+	for _, peer := range peers {
+		syncer.Register(peer)
+		peer.remote = syncer
+	}
+	return syncer
+}
+
+// TestMultiSync tests a basic sync with multiple peers
+func TestMultiSync(t *testing.T) {
+	cancel := make(chan struct{})
+	sourceAccountTrie, elems := makeAccountTrieNoStorage(trie.NewDatabase(rawdb.NewMemoryDatabase()), 100)
+
+	sourceA := newTestPeer("sourceA", t, cancel)
+	sourceA.accountTrie = sourceAccountTrie
+	sourceA.accountValues = elems
+
+	sourceB := newTestPeer("sourceB", t, cancel)
+	sourceB.accountTrie = sourceAccountTrie
+	sourceB.accountValues = elems
+
+	syncer := setupSyncer(sourceA, sourceB)
+	if err := syncer.Sync(sourceAccountTrie.Hash(), cancel); err != nil {
+		t.Fatalf("sync failed: %v", err)
+	}
+}
+
+// TestMultiSyncManyUseless contains one good peer, and many which doesn't return anything valuable at all
+func TestMultiSyncManyUseless(t *testing.T) {
+	cancel := make(chan struct{})
+
+	trieBackend := trie.NewDatabase(rawdb.NewMemoryDatabase())
+	sourceAccountTrie, elems, storageTries, storageElems := makeAccountTrieWithStorage(trieBackend, 100, 3000)
+
+	mkSource := func(name string, a, b, c bool) *testPeer {
+		source := newTestPeer(name, t, cancel)
+		source.accountTrie = sourceAccountTrie
+		source.accountValues = elems
+		source.storageTries = storageTries
+		source.storageValues = storageElems
+
+		if !a {
+			source.accountRequestHandler = emptyRequestAccountRangeFn
+		}
+		if !b {
+			source.storageRequestHandler = emptyStorageRequestHandler
+		}
+		if !c {
+			source.trieRequestHandler = emptyTrieRequestHandler
+		}
+		return source
+	}
+
+	syncer := setupSyncer(
+		mkSource("full", true, true, true),
+		mkSource("noAccounts", false, true, true),
+		mkSource("noStorage", true, false, true),
+		mkSource("noTrie", true, true, false),
+	)
+	if err := syncer.Sync(sourceAccountTrie.Hash(), cancel); err != nil {
+		t.Fatalf("sync failed: %v", err)
+	}
+}
+
+// TestSyncNoStorageAndOneCappedPeer tests sync using accounts and no storage, where one peer is
+// consistently returning very small results
+func TestSyncNoStorageAndOneCappedPeer(t *testing.T) {
+	cancel := make(chan struct{})
+
+	trieBackend := trie.NewDatabase(rawdb.NewMemoryDatabase())
+	sourceAccountTrie, elems := makeAccountTrieNoStorage(trieBackend, 3000)
+
+	mkSource := func(name string, slow bool) *testPeer {
+		source := newTestPeer(name, t, cancel)
+		source.accountTrie = sourceAccountTrie
+		source.accountValues = elems
+
+		if slow {
+			source.accountRequestHandler = starvingAccountRequestHandler
+		}
+		return source
+	}
+
+	syncer := setupSyncer(
+		mkSource("nice-a", false),
+		mkSource("nice-b", false),
+		mkSource("nice-c", false),
+		mkSource("capped", true),
+	)
+	go func() {
+		select {
+		case <-time.After(5 * time.Second):
+			t.Errorf("Sync stalled")
+			cancel <- struct{}{}
+		}
+	}()
+	if err := syncer.Sync(sourceAccountTrie.Hash(), cancel); err != nil {
+		t.Fatalf("sync failed: %v", err)
+	}
+}
+
+// TestSyncWithStorageAndOneCappedPeer tests sync using accounts + storage, where one peer is
+// consistently returning very small results
+func TestSyncWithStorageAndOneCappedPeer(t *testing.T) {
+	cancel := make(chan struct{})
+
+	trieBackend := trie.NewDatabase(rawdb.NewMemoryDatabase())
+	sourceAccountTrie, elems, storageTries, storageElems := makeAccountTrieWithStorage(trieBackend, 100, 3000)
+
+	mkSource := func(name string, slow bool) *testPeer {
+		source := newTestPeer(name, t, cancel)
+		source.accountTrie = sourceAccountTrie
+		source.accountValues = elems
+		source.storageTries = storageTries
+		source.storageValues = storageElems
+
+		if slow {
+			source.storageRequestHandler = starvingStorageRequestHandler
+		}
+		return source
+	}
+
+	syncer := setupSyncer(
+		mkSource("nice-a", false),
+		//mkSource("nice-b", false),
+		//mkSource("nice-c", false),
+		mkSource("slow", true),
+	)
+	go func() {
+		select {
+		case <-time.After(5 * time.Second):
+			t.Errorf("Sync stalled")
+			cancel <- struct{}{}
+		}
+	}()
+	if err := syncer.Sync(sourceAccountTrie.Hash(), cancel); err != nil {
+		t.Fatalf("sync failed: %v", err)
+	}
+}
+
+// TestSyncWithStorageAndCorruptPeer tests sync using accounts + storage, where one peer is
+// sometimes sending bad proofs
+func TestSyncWithStorageAndCorruptPeer(t *testing.T) {
+	cancel := make(chan struct{})
+
+	trieBackend := trie.NewDatabase(rawdb.NewMemoryDatabase())
+	sourceAccountTrie, elems, storageTries, storageElems := makeAccountTrieWithStorage(trieBackend, 100, 3000)
+
+	mkSource := func(name string, corrupt bool) *testPeer {
+		source := newTestPeer(name, t, cancel)
+		source.accountTrie = sourceAccountTrie
+		source.accountValues = elems
+		source.storageTries = storageTries
+		source.storageValues = storageElems
+
+		if corrupt {
+			source.storageRequestHandler = corruptStorageRequestHandler
+		}
+		return source
+	}
+
+	syncer := setupSyncer(
+		mkSource("nice-a", false),
+		mkSource("nice-b", false),
+		mkSource("nice-c", false),
+		mkSource("corrupt", true),
+	)
+	go func() {
+		select {
+		case <-time.After(5 * time.Second):
+			t.Errorf("Sync stalled")
+			cancel <- struct{}{}
+		}
+	}()
+	if err := syncer.Sync(sourceAccountTrie.Hash(), cancel); err != nil {
+		t.Fatalf("sync failed: %v", err)
+	}
+}
+
+type kv struct {
+	k, v []byte
+	t    bool
+}
+
+// Some helpers for sorting
+type entrySlice []*kv
+
+func (p entrySlice) Len() int           { return len(p) }
+func (p entrySlice) Less(i, j int) bool { return bytes.Compare(p[i].k, p[j].k) < 0 }
+func (p entrySlice) Swap(i, j int)      { p[i], p[j] = p[j], p[i] }
+
+// makeAccountTrieNoStorage spits out a trie, along with the leafs
+func makeAccountTrieNoStorage(db *trie.Database, n int) (*trie.Trie, entrySlice) {
+	accTrie, _ := trie.New(common.Hash{}, db)
+	var entries entrySlice
+	for i := uint64(0); i < uint64(n); i++ {
+		value, _ := rlp.EncodeToBytes(state.Account{
+			Nonce:    i,
+			Balance:  big.NewInt(int64(i)),
+			Root:     emptyRoot,
+			CodeHash: emptyCode[:],
+		})
+		key := key32(i)
+		elem := &kv{key, value, false}
+		accTrie.Update(elem.k, elem.v)
+		entries = append(entries, elem)
+	}
+	sort.Sort(entries)
+	// Push to disk layer
+	accTrie.Commit(nil)
+	return accTrie, entries
+}
+
+func key32(i uint64) []byte {
+	key := make([]byte, 32)
+	binary.LittleEndian.PutUint64(key, i)
+	return key
+}
+
+// makeAccountTrieWithStorage spits out a trie, along with the leafs
+func makeAccountTrieWithStorage(db *trie.Database, accounts, slots int) (*trie.Trie, entrySlice,
+	map[common.Hash]*trie.Trie, map[common.Hash]entrySlice) {
+
+	var (
+		accTrie, _     = trie.New(common.Hash{}, db)
+		entries        entrySlice
+		storageTries   = make(map[common.Hash]*trie.Trie)
+		storageEntries = make(map[common.Hash]entrySlice)
+	)
+
+	// Make a storage trie which we reuse for the whole lot
+	stTrie, stEntries := makeStorageTrie(slots, db)
+	stRoot := stTrie.Hash()
+	// Create n accounts in the trie
+	for i := uint64(1); i <= uint64(accounts); i++ {
+		key := key32(i)
+		value, _ := rlp.EncodeToBytes(state.Account{
+			Nonce:    i,
+			Balance:  big.NewInt(int64(i)),
+			Root:     stRoot,
+			CodeHash: emptyCode[:],
+		})
+		elem := &kv{key, value, false}
+		accTrie.Update(elem.k, elem.v)
+		entries = append(entries, elem)
+		// we reuse the same one for all accounts
+		storageTries[common.BytesToHash(key)] = stTrie
+		storageEntries[common.BytesToHash(key)] = stEntries
+	}
+	stTrie.Commit(nil)
+	accTrie.Commit(nil)
+	return accTrie, entries, storageTries, storageEntries
+}
+
+// makeStorageTrie fills a storage trie with n items, returning the
+// not-yet-committed trie and the sorted entries
+func makeStorageTrie(n int, db *trie.Database) (*trie.Trie, entrySlice) {
+	trie, _ := trie.New(common.Hash{}, db)
+	var entries entrySlice
+	for i := uint64(1); i <= uint64(n); i++ {
+		// store 'i' at slot 'i'
+		slotValue := key32(i)
+		rlpSlotValue, _ := rlp.EncodeToBytes(common.TrimLeftZeroes(slotValue[:]))
+
+		slotKey := key32(i)
+		key := crypto.Keccak256Hash(slotKey[:])
+
+		elem := &kv{key[:], rlpSlotValue, false}
+		trie.Update(elem.k, elem.v)
+		entries = append(entries, elem)
+	}
+	sort.Sort(entries)
+	return trie, entries
 }


### PR DESCRIPTION
This is a work in progress - the tests now just hang, which isn't ideal. However, the tests do enable some fairly deep testing of the snap protocol, and the reason I rebased it again and am working on it, is to see if it can be used to trigger https://github.com/ethereum/go-ethereum/issues/22172. 

Also, in general, I think it would be good to have these kinds of fairly high-level protocol tests. 