### PR TITLE
Fix queue slicing

### DIFF
--- a/eth/protocols/eth/broadcast.go
+++ b/eth/protocols/eth/broadcast.go
@@ -179,7 +179,7 @@ func (p *Peer) announceTransactions() {
 			queue = append(queue, hashes...)
 			if len(queue) > maxQueuedTxAnns {
 				// Fancy copy and resize to ensure buffer doesn't grow indefinitely
-				queue = queue[:copy(queue, queue[len(queue)-maxQueuedTxs:])]
+				queue = queue[:copy(queue, queue[len(queue)-maxQueuedTxAnns:])]
 			}
 
 		case <-done:


### PR DESCRIPTION
This seems to be a bug. Usually the two values are the same but when they are not this can cause a negative starting position. It looks like this was copied from above but the variable name was not changed.