### PR TITLE
graphql: change receipt status to decimal instead of hex

### DIFF
--- a/graphql/graphql.go
+++ b/graphql/graphql.go
@@ -810,9 +810,9 @@ type CallData struct {
 
 // CallResult encapsulates the result of an invocation of the `call` accessor.
 type CallResult struct {
-	data    hexutil.Bytes  // The return data from the call
-	gasUsed Long           // The amount of gas used
-	status  Long // The return status of the call - 0 for failure or 1 for success.
+	data    hexutil.Bytes // The return data from the call
+	gasUsed Long          // The amount of gas used
+	status  Long          // The return status of the call - 0 for failure or 1 for success.
 }
 
 func (c *CallResult) Data() hexutil.Bytes {
@@ -842,7 +842,7 @@ func (b *Block) Call(ctx context.Context, args struct {
 	}
 	status := Long(1)
 	if result.Failed() {
-		status = Long(0) // TODO is this unnecessary
+		status = 0
 	}
 
 	return &CallResult{

--- a/graphql/graphql.go
+++ b/graphql/graphql.go
@@ -292,12 +292,12 @@ func (t *Transaction) getReceipt(ctx context.Context) (*types.Receipt, error) {
 	return receipts[t.index], nil
 }
 
-func (t *Transaction) Status(ctx context.Context) (*hexutil.Uint64, error) {
+func (t *Transaction) Status(ctx context.Context) (*Long, error) {
 	receipt, err := t.getReceipt(ctx)
 	if err != nil || receipt == nil {
 		return nil, err
 	}
-	ret := hexutil.Uint64(receipt.Status)
+	ret := Long(receipt.Status)
 	return &ret, nil
 }
 
@@ -812,7 +812,7 @@ type CallData struct {
 type CallResult struct {
 	data    hexutil.Bytes  // The return data from the call
 	gasUsed Long           // The amount of gas used
-	status  hexutil.Uint64 // The return status of the call - 0 for failure or 1 for success.
+	status  Long // The return status of the call - 0 for failure or 1 for success.
 }
 
 func (c *CallResult) Data() hexutil.Bytes {
@@ -823,7 +823,7 @@ func (c *CallResult) GasUsed() Long {
 	return c.gasUsed
 }
 
-func (c *CallResult) Status() hexutil.Uint64 {
+func (c *CallResult) Status() Long {
 	return c.status
 }
 
@@ -840,9 +840,9 @@ func (b *Block) Call(ctx context.Context, args struct {
 	if err != nil {
 		return nil, err
 	}
-	status := hexutil.Uint64(1)
+	status := Long(1)
 	if result.Failed() {
-		status = 0
+		status = Long(0) // TODO is this unnecessary
 	}
 
 	return &CallResult{
@@ -910,9 +910,9 @@ func (p *Pending) Call(ctx context.Context, args struct {
 	if err != nil {
 		return nil, err
 	}
-	status := hexutil.Uint64(1)
+	status := Long(1)
 	if result.Failed() {
-		status = 0
+		status = Long(0) // TODO is this necessary
 	}
 
 	return &CallResult{

--- a/graphql/graphql.go
+++ b/graphql/graphql.go
@@ -912,7 +912,7 @@ func (p *Pending) Call(ctx context.Context, args struct {
 	}
 	status := Long(1)
 	if result.Failed() {
-		status = Long(0) // TODO is this necessary
+		status = 0
 	}
 
 	return &CallResult{

--- a/graphql/graphql_test.go
+++ b/graphql/graphql_test.go
@@ -130,6 +130,12 @@ func TestGraphQLBlockSerialization(t *testing.T) {
 			want: `{"data":{"block":{"estimateGas":53000}}}`,
 			code: 200,
 		},
+		// should return `status` as decimal
+		{
+			body: `{"query": "{block {number call (data : {from : \"0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b\", to: \"0x6295ee1b4f6dd65047762f924ecd367c17eabf8f\", data :\"0x12a7b914\"}){data status}}}"}`,
+			want: `{"data":{"block":{"number":10,"call":{"data":"0x","status":1}}}}`,
+			code: 200,
+		},
 	} {
 		resp, err := http.Post(fmt.Sprintf("%s/graphql", stack.HTTPEndpoint()), "application/json", strings.NewReader(tt.body))
 		if err != nil {


### PR DESCRIPTION
This PR fixes the `Status` field to be decimal instead of a hex string, as called for by the [spec](https://eips.ethereum.org/EIPS/eip-1767).