### PR TITLE
event: resubscribe with error handler

### DIFF
--- a/event/subscription.go
+++ b/event/subscription.go
@@ -95,12 +95,9 @@ func (s *funcSub) Err() <-chan error {
 // Resubscribe applies backoff between calls to fn. The time between calls is adapted
 // based on the error rate, but will never exceed backoffMax.
 func Resubscribe(backoffMax time.Duration, fn ResubscribeFunc) Subscription {
-	return ResubscribeWithErrFunc(
-		backoffMax,
-		func(ctx context.Context, _ error) (Subscription, error) {
-			return fn(ctx)
-		},
-	)
+	return ResubscribeErr(backoffMax, func(ctx context.Context, _ error) (Subscription, error) {
+		return fn(ctx)
+	})
 }
 
 // A ResubscribeFunc attempts to establish a subscription.

--- a/event/subscription.go
+++ b/event/subscription.go
@@ -106,13 +106,18 @@ func Resubscribe(backoffMax time.Duration, fn ResubscribeFunc) Subscription {
 // A ResubscribeFunc attempts to establish a subscription.
 type ResubscribeFunc func(context.Context) (Subscription, error)
 
-// ResubscribeWithErrFunc does exactly the same as the original `Resubscribe`
-// function but uses a resubscribe function allowing to hook into the error
-// returned by previous subscription.
-func ResubscribeWithErrFunc(
-	backoffMax time.Duration,
-	fn ResubscribeErrFunc,
-) Subscription {
+// ResubscribeErr calls fn repeatedly to keep a subscription established. When the
+// subscription is established, ResubscribeErr waits for it to fail and calls fn again. This
+// process repeats until Unsubscribe is called or the active subscription ends
+// successfully.
+//
+// The difference between Resubscribe and ResubscribeErr is that with ResubscribeErr,
+// the error of the failing subscription is available to the callback for logging
+// purposes.
+//
+// ResubscribeErr applies backoff between calls to fn. The time between calls is adapted
+// based on the error rate, but will never exceed backoffMax.
+func ResubscribeErr(backoffMax time.Duration, fn ResubscribeErrFunc) Subscription {
 	s := &resubscribeSub{
 		waitTime:   backoffMax / 10,
 		backoffMax: backoffMax,


### PR DESCRIPTION
Added a possibility to pass a custom callback function which will be invoked on subscription error.

This change will allow clients to receive the original subscription error and perform some additional actions like logging to make debugging easier.