### PR TITLE
trie: fix range prover

### DIFF
--- a/trie/proof.go
+++ b/trie/proof.go
@@ -216,7 +216,7 @@ func proofToPath(rootHash common.Hash, root node, key []byte, proofDb ethdb.KeyV
 //
 // Note we have the assumption here the given boundary keys are different
 // and right is larger than left.
-func unsetInternal(n node, left []byte, right []byte) error {
+func unsetInternal(n node, left []byte, right []byte) (bool, error) {
 	left, right = keybytesToHex(left), keybytesToHex(right)
 
 	// Step down to the fork point. There are two scenarios can happen:
@@ -278,58 +278,55 @@ findFork:
 		// - left proof points to the shortnode, but right proof is greater
 		// - right proof points to the shortnode, but left proof is less
 		if shortForkLeft == -1 && shortForkRight == -1 {
-			return errors.New("empty range")
+			return false, errors.New("empty range")
 		}
 		if shortForkLeft == 1 && shortForkRight == 1 {
-			return errors.New("empty range")
+			return false, errors.New("empty range")
 		}
 		if shortForkLeft != 0 && shortForkRight != 0 {
 			// The fork point is root node, unset the entire trie
 			if parent == nil {
-				n = nil
-				return nil
+				return true, nil
 			}
 			parent.(*fullNode).Children[left[pos-1]] = nil
-			return nil
+			return false, nil
 		}
 		// Only one proof points to non-existent key.
 		if shortForkRight != 0 {
 			if _, ok := rn.Val.(valueNode); ok {
 				// The fork point is root node, unset the entire trie
 				if parent == nil {
-					n = nil
-					return nil
+					return true, nil
 				}
 				parent.(*fullNode).Children[left[pos-1]] = nil
-				return nil
+				return false, nil
 			}
-			return unset(rn, rn.Val, left[pos:], len(rn.Key), false)
+			return false, unset(rn, rn.Val, left[pos:], len(rn.Key), false)
 		}
 		if shortForkLeft != 0 {
 			if _, ok := rn.Val.(valueNode); ok {
 				// The fork point is root node, unset the entire trie
 				if parent == nil {
-					n = nil
-					return nil
+					return true, nil
 				}
 				parent.(*fullNode).Children[right[pos-1]] = nil
-				return nil
+				return false, nil
 			}
-			return unset(rn, rn.Val, right[pos:], len(rn.Key), true)
+			return false, unset(rn, rn.Val, right[pos:], len(rn.Key), true)
 		}
-		return nil
+		return false, nil
 	case *fullNode:
 		// unset all internal nodes in the forkpoint
 		for i := left[pos] + 1; i < right[pos]; i++ {
 			rn.Children[i] = nil
 		}
 		if err := unset(rn, rn.Children[left[pos]], left[pos:], 1, false); err != nil {
-			return err
+			return false, err
 		}
 		if err := unset(rn, rn.Children[right[pos]], right[pos:], 1, true); err != nil {
-			return err
+			return false, err
 		}
-		return nil
+		return false, nil
 	default:
 		panic(fmt.Sprintf("%T: invalid node: %v", n, n))
 	}
@@ -573,7 +570,8 @@ func VerifyRangeProof(rootHash common.Hash, firstKey []byte, lastKey []byte, key
 	}
 	// Remove all internal references. All the removed parts should
 	// be re-filled(or re-constructed) by the given leaves range.
-	if err := unsetInternal(root, firstKey, lastKey); err != nil {
+	empty, err := unsetInternal(root, firstKey, lastKey)
+	if err != nil {
 		return nil, nil, nil, false, err
 	}
 	// Rebuild the trie with the leaf stream, the shape of trie
@@ -583,6 +581,9 @@ func VerifyRangeProof(rootHash common.Hash, firstKey []byte, lastKey []byte, key
 		triedb = NewDatabase(diskdb)
 	)
 	tr := &Trie{root: root, db: triedb}
+	if empty {
+		tr.root = nil
+	}
 	for index, key := range keys {
 		tr.TryUpdate(key, values[index])
 	}

--- a/trie/proof.go
+++ b/trie/proof.go
@@ -284,21 +284,34 @@ findFork:
 			return errors.New("empty range")
 		}
 		if shortForkLeft != 0 && shortForkRight != 0 {
+			// The fork point is root node, unset the entire trie
+			if parent == nil {
+				n = nil
+				return nil
+			}
 			parent.(*fullNode).Children[left[pos-1]] = nil
 			return nil
 		}
 		// Only one proof points to non-existent key.
 		if shortForkRight != 0 {
-			// Unset left proof's path
 			if _, ok := rn.Val.(valueNode); ok {
+				// The fork point is root node, unset the entire trie
+				if parent == nil {
+					n = nil
+					return nil
+				}
 				parent.(*fullNode).Children[left[pos-1]] = nil
 				return nil
 			}
 			return unset(rn, rn.Val, left[pos:], len(rn.Key), false)
 		}
 		if shortForkLeft != 0 {
-			// Unset right proof's path.
 			if _, ok := rn.Val.(valueNode); ok {
+				// The fork point is root node, unset the entire trie
+				if parent == nil {
+					n = nil
+					return nil
+				}
 				parent.(*fullNode).Children[right[pos-1]] = nil
 				return nil
 			}

--- a/trie/proof_test.go
+++ b/trie/proof_test.go
@@ -384,6 +384,25 @@ func TestOneElementRangeProof(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Expected no error, got %v", err)
 	}
+
+	// Test the mini trie with only a single element.
+	tinyTrie := new(Trie)
+	entry := &kv{randBytes(32), randBytes(20), false}
+	tinyTrie.Update(entry.k, entry.v)
+
+	first = common.HexToHash("0x0000000000000000000000000000000000000000000000000000000000000000").Bytes()
+	last = entry.k
+	proof = memorydb.New()
+	if err := tinyTrie.Prove(first, 0, proof); err != nil {
+		t.Fatalf("Failed to prove the first node %v", err)
+	}
+	if err := tinyTrie.Prove(last, 0, proof); err != nil {
+		t.Fatalf("Failed to prove the last node %v", err)
+	}
+	_, _, _, _, err = VerifyRangeProof(tinyTrie.Hash(), first, last, [][]byte{entry.k}, [][]byte{entry.v}, proof)
+	if err != nil {
+		t.Fatalf("Expected no error, got %v", err)
+	}
 }
 
 // TestAllElementsProof tests the range proof with all elements.


### PR DESCRIPTION
Fixes the issue described https://github.com/ethereum/go-ethereum/pull/22179#issuecomment-763672300


It's a special case that the trie only has a single trie node and the range proof only contains a single element.

```
TRACE[01-20|15:53:31.702] Fetching range of accounts               id=nice-a reqid=4037200794235010051 root="c2661f…b0463a" origin="000000…000000" limit="0fffff…ffffff" bytes=512.00KiB
TRACE[01-20|15:53:31.702] Delivering range of accounts             id=nice-a reqid=4037200794235010051 hashes=1 accounts=1 proofs=1 bytes=210.00B
panic: interface conversion: trie.node is nil, not *trie.fullNode

goroutine 20 [running]:
github.com/ethereum/go-ethereum/trie.unsetInternal(0xa5c2a0, 0xc00007ed70, 0xc00002b9a0, 0x41, 0x41, 0xc00002b9f0, 0x41, 0x41, 0x20, 0xa5c1a0)
	/home/user/go/src/github.com/ethereum/go-ethereum/trie/proof.go:302 +0xd65
github.com/ethereum/go-ethereum/trie.VerifyRangeProof(0x6657bd231f66c2, 0x723c83101df021d9, 0xea1a61864a975b5e, 0x3a46b00c81ac76fa, 0xc00014a630, 0x20, 0x20, 0xc000352400, 0x20, 0x20, ...)
	/home/user/go/src/github.com/ethereum/go-ethereum/trie/proof.go:563 +0x7e5
github.com/ethereum/go-ethereum/eth/protocols/snap.(*Syncer).OnAccounts(0xc000147b00, 0xa62960, 0xc00016a3f0, 0x380704bb7b4d7c03, 0xc0003522a0, 0x1, 0x1, 0xc00034c140, 0x1, 0x1, ...)
	/home/user/go/src/github.com/ethereum/go-ethereum/eth/protocols/snap/sync.go:2033 +0x876
github.com/ethereum/go-ethereum/eth/protocols/snap.defaultAccountRequestHandler(0xc00016a3f0, 0x380704bb7b4d7c03, 0x6657bd231f66c2, 0x723c83101df021d9, 0xea1a61864a975b5e, 0x3a46b00c81ac76fa, 0x0, 0x0, 0x0, 0x0, ...)
	/home/user/go/src/github.com/ethereum/go-ethereum/eth/protocols/snap/sync_test.go:220 +0x11b
created by github.com/ethereum/go-ethereum/eth/protocols/snap.(*testPeer).RequestAccountRange
	/home/user/go/src/github.com/ethereum/go-ethereum/eth/protocols/snap/sync_test.go:162 +0x365
```