### PR TITLE
common/mclock: remove dependency on github.com/aristanetworks/goarista

### DIFF
--- a/common/mclock/mclock.go
+++ b/common/mclock/mclock.go
@@ -20,15 +20,19 @@ package mclock
 import (
 	"time"
 
-	"github.com/aristanetworks/goarista/monotime"
+	_ "unsafe" // for go:linkname
 )
 
+//go:noescape
+//go:linkname nanotime runtime.nanotime
+func nanotime() int64
+
 // AbsTime represents absolute monotonic time.
-type AbsTime time.Duration
+type AbsTime int64
 
 // Now returns the current absolute monotonic time.
 func Now() AbsTime {
-	return AbsTime(monotime.Now())
+	return AbsTime(nanotime())
 }
 
 // Add returns t + d as absolute time.
@@ -74,7 +78,7 @@ type System struct{}
 
 // Now returns the current monotonic time.
 func (c System) Now() AbsTime {
-	return AbsTime(monotime.Now())
+	return Now()
 }
 
 // Sleep blocks for the given duration.

--- a/common/mclock/mclock.s
+++ b/common/mclock/mclock.s
@@ -1,0 +1,1 @@
+// This file exists in order to be able to use go:linkname.

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,6 @@ require (
 	github.com/Azure/go-autorest/autorest/adal v0.8.0 // indirect
 	github.com/StackExchange/wmi v0.0.0-20180116203802-5d049714c4a6 // indirect
 	github.com/VictoriaMetrics/fastcache v1.5.7
-	github.com/aristanetworks/goarista v0.0.0-20170210015632-ea17b1a17847
 	github.com/aws/aws-sdk-go v1.25.48
 	github.com/btcsuite/btcd v0.0.0-20171128150713-2e60448ffcc6
 	github.com/cespare/cp v0.1.0

--- a/go.sum
+++ b/go.sum
@@ -29,8 +29,6 @@ github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuy
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/allegro/bigcache v1.2.1-0.20190218064605-e24eb225f156 h1:eMwmnE/GDgah4HI848JfFxHt+iPb26b4zyfspmqY0/8=
 github.com/allegro/bigcache v1.2.1-0.20190218064605-e24eb225f156/go.mod h1:Cb/ax3seSYIx7SuZdm2G2xzfwmv3TPSk2ucNfQESPXM=
-github.com/aristanetworks/goarista v0.0.0-20170210015632-ea17b1a17847 h1:rtI0fD4oG/8eVokGVPYJEW1F88p1ZNgXiEIs9thEE4A=
-github.com/aristanetworks/goarista v0.0.0-20170210015632-ea17b1a17847/go.mod h1:D/tb0zPVXnP7fmsLZjtdUhSsumbK/ij54UXjjVgMGxQ=
 github.com/aws/aws-sdk-go v1.25.48 h1:J82DYDGZHOKHdhx6hD24Tm30c2C3GchYGfN0mf9iKUk=
 github.com/aws/aws-sdk-go v1.25.48/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN924inxo=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=


### PR DESCRIPTION
It takes three lines of code to get to runtime.nanotime, no need to pull a dependency for that.