### PR TITLE
core/state: fix panic in state dumping

### DIFF
--- a/core/state/dump.go
+++ b/core/state/dump.go
@@ -138,7 +138,7 @@ func (s *StateDB) DumpToCollector(c DumpCollector, excludeCode, excludeStorage, 
 			account.SecureKey = it.Key
 		}
 		addr := common.BytesToAddress(addrBytes)
-		obj := newObject(nil, addr, data)
+		obj := newObject(s, addr, data)
 		if !excludeCode {
 			account.Code = common.Bytes2Hex(obj.Code(s.db))
 		}


### PR DESCRIPTION
@winsvega reported a [crash](http://retesteth.ethdevops.io/results/log//2021-01-24-1611447623-t8ntool.txt) found via retesteth, introduced in commit #ddadc3d2 . 

Repro:
`alloc.json`: 

```json
{
  "a94f5374fce5edbc8e2a8697c15331677e6ebf0b": {
    "balance": "0x5ffd4878be161d74",
    "code": "0x",
    "nonce": "0xac",
    "storage": {
      "0x0a": "0x01"
    }
  },
  "0x8a8eafb1cf62bfbeb1741769dae1a9dd47996192":{
    "balance": "0xfeedbead",
    "nonce" : "0x00"
  }
}
```
WIthout this PR: 
```
./evm t8n --input.alloc=./alloc.json --input.txs=./testdata/1/txs.json --input.env=./testdata/1/env.json --output.alloc=stdout
INFO [01-24|13:33:13.295] rejected tx                              index=1 hash="0557ba…18d673" from=0x8A8eAFb1cf62BfBeb1741769DAE1a9dd47996192 error="nonce too low: address 0x8A8eAFb1cf62BfBeb1741769DAE1a9dd47996192, tx: 0 state: 1"
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x10 pc=0x83167e]

goroutine 1 [running]:
github.com/ethereum/go-ethereum/core/state.(*stateObject).getTrie(0xc0001fe690, 0x1052be0, 0xc00021aa60, 0x0, 0x0)
	/home/user/go/src/github.com/ethereum/go-ethereum/core/state/state_object.go:162 +0x2fe
github.com/ethereum/go-ethereum/core/state.(*StateDB).DumpToCollector(0xc0003f1040, 0x1045340, 0xc00001b9b0, 0x0, 0x0, 0x0, 0x0, 0xffffffffffffffff, 0x0, 0x0, ...)
	/home/user/go/src/github.com/ethereum/go-ethereum/core/state/dump.go:147 +0x745
github.com/ethereum/go-ethereum/cmd/evm/internal/t8ntool.Main(0xc00015e580, 0x0, 0x0)
	/home/user/go/src/github.com/ethereum/go-ethereum/cmd/evm/internal/t8ntool/transition.go:211 +0x1125
gopkg.in/urfave/cli%2ev1.HandleAction(0xda2c40, 0xf64d98, 0xc00015e580, 0xc0004a3700, 0x0)
	/home/user/go/pkg/mod/gopkg.in/urfave/cli.v1@v1.20.0/app.go:490 +0x82
gopkg.in/urfave/cli%2ev1.Command.Run(0xefbcf4, 0xa, 0x0, 0x0, 0x1542e00, 0x1, 0x1, 0xf12b95, 0x20, 0x0, ...)
	/home/user/go/pkg/mod/gopkg.in/urfave/cli.v1@v1.20.0/command.go:210 +0x9fb
gopkg.in/urfave/cli%2ev1.(*App).Run(0xc0003f0340, 0xc000138120, 0x6, 0x6, 0x0, 0x0)
	/home/user/go/pkg/mod/gopkg.in/urfave/cli.v1@v1.20.0/app.go:255 +0x768
main.main()
	/home/user/go/src/github.com/ethereum/go-ethereum/cmd/evm/main.go:200 +0x55
```
With this PR 
```
 go build . && ./evm t8n --input.alloc=./alloc.json --input.txs=./testdata/1/txs.json --input.env=./testdata/1/env.json --output.alloc=stdout

INFO [01-24|13:31:54.160] rejected tx                              index=1 hash="0557ba…18d673" from=0x8A8eAFb1cf62BfBeb1741769DAE1a9dd47996192 error="nonce too low: address 0x8A8eAFb1cf62BfBeb1741769DAE1a9dd47996192, tx: 0 state: 1"
{
 "alloc": {
  "0x8a8eafb1cf62bfbeb1741769dae1a9dd47996192": {
   "balance": "0xfeed1a9d",
   "nonce": "0x1"
  },
  "0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b": {
   "storage": {
    "0x000000000000000000000000000000000000000000000000000000000000000a": "0x0000000000000000000000000000000000000000000000000000000000000001"
   },
   "balance": "0x5ffd4878be161d74",
   "nonce": "0xac"
  },
  "0xc94f5374fce5edbc8e2a8697c15331677e6ebf0b": {
   "balance": "0xa410"
  }
 }
}
```