### PR TITLE
core: more efficient nonce-update in txpool

### DIFF
--- a/core/tx_noncer.go
+++ b/core/tx_noncer.go
@@ -77,3 +77,11 @@ func (txn *txNoncer) setIfLower(addr common.Address, nonce uint64) {
 	}
 	txn.nonces[addr] = nonce
 }
+
+// resetAll sets the nonces for all accounts to the given map.
+func (txn *txNoncer) resetAll(all map[common.Address]uint64) {
+	txn.lock.Lock()
+	defer txn.lock.Unlock()
+
+	txn.nonces = all
+}

--- a/core/tx_noncer.go
+++ b/core/tx_noncer.go
@@ -78,8 +78,8 @@ func (txn *txNoncer) setIfLower(addr common.Address, nonce uint64) {
 	txn.nonces[addr] = nonce
 }
 
-// resetAll sets the nonces for all accounts to the given map.
-func (txn *txNoncer) resetAll(all map[common.Address]uint64) {
+// setAll sets the nonces for all accounts to the given map.
+func (txn *txNoncer) setAll(all map[common.Address]uint64) {
 	txn.lock.Lock()
 	defer txn.lock.Unlock()
 

--- a/core/tx_pool.go
+++ b/core/tx_pool.go
@@ -1183,12 +1183,12 @@ func (pool *TxPool) runReorg(done chan struct{}, reset *txpoolResetRequest, dirt
 			pool.priced.SetBaseFee(pendingBaseFee)
 		}
 		// Update all accounts to the latest known pending nonce
-		nonces := make(map[common.Address]uint64)
+		nonces := make(map[common.Address]uint64, len(pool.pending))
 		for addr, list := range pool.pending {
 			highestPending := list.LastElement()
 			nonces[addr] = highestPending.Nonce() + 1
 		}
-		pool.pendingNonces.resetAll(nonces)
+		pool.pendingNonces.setAll(nonces)
 	}
 	// Ensure pool.queue and pool.pending sizes stay within the configured limits.
 	pool.truncatePending()

--- a/core/tx_pool.go
+++ b/core/tx_pool.go
@@ -1182,16 +1182,18 @@ func (pool *TxPool) runReorg(done chan struct{}, reset *txpoolResetRequest, dirt
 			pendingBaseFee := misc.CalcBaseFee(pool.chainconfig, reset.newHead)
 			pool.priced.SetBaseFee(pendingBaseFee)
 		}
+		// Update all accounts to the latest known pending nonce
+		nonces := make(map[common.Address]uint64)
+		for addr, list := range pool.pending {
+			highestPending := list.LastElement()
+			nonces[addr] = highestPending.Nonce() + 1
+		}
+		pool.pendingNonces.resetAll(nonces)
 	}
 	// Ensure pool.queue and pool.pending sizes stay within the configured limits.
 	pool.truncatePending()
 	pool.truncateQueue()
 
-	// Update all accounts to the latest known pending nonce
-	for addr, list := range pool.pending {
-		highestPending := list.LastElement()
-		pool.pendingNonces.set(addr, highestPending.Nonce()+1)
-	}
 	dropBetweenReorgHistogram.Update(int64(pool.changesSinceReorg))
 	pool.changesSinceReorg = 0 // Reset change counter
 	pool.mu.Unlock()

--- a/core/tx_pool_test.go
+++ b/core/tx_pool_test.go
@@ -2546,7 +2546,7 @@ func BenchmarkPoolMultiAccountBatchInsert(b *testing.B) {
 	// Generate a batch of transactions to enqueue into the pool
 	pool, _ := setupTxPool()
 	defer pool.Stop()
-
+	b.ReportAllocs()
 	batches := make(types.Transactions, b.N)
 	for i := 0; i < b.N; i++ {
 		key, _ := crypto.GenerateKey()

--- a/core/tx_pool_test.go
+++ b/core/tx_pool_test.go
@@ -2540,3 +2540,24 @@ func BenchmarkInsertRemoteWithAllLocals(b *testing.B) {
 		pool.Stop()
 	}
 }
+
+// Benchmarks the speed of batch transaction insertion in case of multiple accounts.
+func BenchmarkPoolMultiAccountBatchInsert(b *testing.B) {
+	// Generate a batch of transactions to enqueue into the pool
+	pool, _ := setupTxPool()
+	defer pool.Stop()
+
+	batches := make(types.Transactions, b.N)
+	for i := 0; i < b.N; i++ {
+		key, _ := crypto.GenerateKey()
+		account := crypto.PubkeyToAddress(key.PublicKey)
+		pool.currentState.AddBalance(account, big.NewInt(1000000))
+		tx := transaction(uint64(0), 100000, key)
+		batches[i] = tx
+	}
+	// Benchmark importing the transactions into the queue
+	b.ResetTimer()
+	for _, tx := range batches {
+		pool.AddRemotesSync([]*types.Transaction{tx})
+	}
+}


### PR DESCRIPTION
This PR supersedes https://github.com/ethereum/go-ethereum/pull/21164  by @WeiLoy . The original PR was based off a fork of geth but on `master` , and I was not able to push the rebased + fixed version onto a `master` branch. 

I believe that the original implementation by @WeiLoy was correct, but it had been a bit bitrotted, the PR is quite old. 
Here are the benchmarks compared to current master: 
```
benchstat before.txt after3.txt 
name                           old time/op  new time/op  delta
PoolMultiAccountBatchInsert-6   993µs ±11%   281µs ± 7%  -71.72%  (p=0.008 n=5+5)
```
