### PR TITLE
rpc: add subscription to the debug namespace

### DIFF
--- a/rpc/client.go
+++ b/rpc/client.go
@@ -418,6 +418,11 @@ func (c *Client) ShhSubscribe(ctx context.Context, channel interface{}, args ...
 	return c.Subscribe(ctx, "shh", channel, args...)
 }
 
+// DebugSubscribe registers a subscripion under the "debug" namespace.
+func (c *Client) DebugSubscribe(ctx context.Context, channel interface{}, args ...interface{}) (*ClientSubscription, error) {
+	return c.Subscribe(ctx, "debug", channel, args...)
+}
+
 // Subscribe calls the "<namespace>_subscribe" method with the given arguments,
 // registering a subscription. Server notifications for the subscription are
 // sent to the given channel. The element type of the channel must match the


### PR DESCRIPTION
This is a rewrite of #22232: @rjl493456442 correctly pointed out that `ethclient` must be able to connect to any client, and exposing the `debug` namespace there is the wrong thing to do.

However `rpc.Client` is only concerned with Geth and there is value in providing a `debug` namespace equivalent to `EthSubscribe`.