### PR TITLE
eth: add `debug_removePendingTransaction` RPC method

### DIFF
--- a/core/tx_pool.go
+++ b/core/tx_pool.go
@@ -876,6 +876,15 @@ func (pool *TxPool) Has(hash common.Hash) bool {
 	return pool.all.Get(hash) != nil
 }
 
+// RemoveTx publicizes the removeTx method since the API method txpool_removeTx
+// needs to allow public access to internal `removeTx()`
+func (pool *TxPool) RemoveTx(hash common.Hash) *types.Transaction {
+	tx := pool.Get(hash)
+	pool.removeTx(hash, true)
+
+	return tx
+}
+
 // removeTx removes a single transaction from the queue, moving all subsequent
 // transactions back to the future queue.
 func (pool *TxPool) removeTx(hash common.Hash, outofbound bool) {

--- a/eth/api.go
+++ b/eth/api.go
@@ -533,3 +533,9 @@ func (api *PrivateDebugAPI) getModifiedAccounts(startBlock, endBlock *types.Bloc
 	}
 	return dirty, nil
 }
+
+// RemovePendingTransaction removes a transaction from the txpool.
+// It returns the transaction removed, if any.
+func (api *PrivateDebugAPI) RemovePendingTransaction(hash common.Hash) (*types.Transaction, error) {
+	return api.eth.txPool.RemoveTx(hash), nil
+}

--- a/internal/web3ext/web3ext.go
+++ b/internal/web3ext/web3ext.go
@@ -468,6 +468,11 @@ web3._extend({
 			call: 'debug_freezeClient',
 			params: 1,
 		}),
+		new web3._extend.Method({
+ 			name: 'removePendingTransaction',
+ 			call: 'debug_removePendingTransaction',
+ 			params: 1
+ 		}),
 	],
 	properties: []
 });


### PR DESCRIPTION
Adds an analogue of `parity_removeTransaction` RPC method
Name was chosen to match https://github.com/etclabscore/core-geth/pull/203 (posted rationale there also).
Related issue: https://github.com/ethereum/go-ethereum/issues/18389

Request example:
```
curl --location --request POST 'http://localhost:8545' \
--header 'Content-Type: application/json' \
--data-raw '{
   "method":"debug_removePendingTransaction",
   "params":["0x42fdd01035f651164c78bddbf3e94cecdc07f6cc11c7f5e45337ae9ed8bc885e"],
   "id": 1,
   "jsonrpc": "2.0"
}'
```

Response example:
```
{
    "jsonrpc": "2.0",
    "id": 1,
    "result": {
        "nonce": "0x70f6",
        "gasPrice": "0x12a05f200",
        "gas": "0x7a120",
        "to": "0x4d77b31e5876fc91000551a4026f4c0c305dcaed",
        "value": "0x0",
        "input": "0x202ee0ed0000000000000000000000000000000000000000000000000000000000002100000000000000000000000000000000000000000000000000000000000035f361",
        "v": "0x2d",
        "r": "0x9dda18c69611ff74f3cd8dfae38f603dbeb38752eb611392508edac72b4b64f2",
        "s": "0x5969d313c75372195a2a55beacfaf1280bf411cf36728c93dfd84c4bb0936039",
        "hash": "0x42fdd01035f651164c78bddbf3e94cecdc07f6cc11c7f5e45337ae9ed8bc885e"
    }
}
```