### PR TITLE
eth/handler: more reliable announcements

### DIFF
--- a/eth/fetcher/block_fetcher.go
+++ b/eth/fetcher/block_fetcher.go
@@ -374,6 +374,7 @@ func (f *BlockFetcher) loop() {
 			} else {
 				f.importBlocks(op.origin, op.block)
 			}
+			height = f.chainHeight()
 		}
 		// Wait for an outside event to occur
 		select {
@@ -798,15 +799,35 @@ func (f *BlockFetcher) importBlocks(peer string, block *types.Block) {
 			return
 		}
 		// Quickly validate the header and propagate the block if it passes
+		var announce bool
 		switch err := f.verifyHeader(block.Header()); err {
 		case nil:
 			// All ok, quickly propagate to our peers
 			blockBroadcastOutTimer.UpdateSince(block.ReceivedAt)
 			go f.broadcastBlock(block, true)
-
+			announce = true
 		case consensus.ErrFutureBlock:
-			// Weird future block, don't fail, but neither propagate
-
+			// Future block, don't fail, but neither propagate.
+			//
+			// Import it to the chain (it will internally be scheduled for later),
+			// but by default, don't announce it.
+			// If we do announce it, it will be marked as 'known' by the peer, but since it's
+			// not actually present in our chain, it the actual announcement will be
+			// skipped (see BroadcastBlock in eth/handler.go)
+			//
+			// This has a fairly high risk of happening on Clique-networks, where the
+			// Clique engine is a lot stricter about 'future' blocks -- ethash allows
+			// up to 15s "drift".
+			//
+			// To handle the Clique case better, we can handle some slack here:
+			// wait up to 2 seconds before trying to import + announce the block.
+			announce = false
+			if diff := int64(block.Header().Time) - time.Now().Unix(); diff > 0 && diff <= 2 {
+				// Less than two second, let's wait and then try to import
+				log.Info("Waiting before import + announce", "seconds", diff)
+				time.Sleep(time.Duration(diff) * time.Second)
+				announce = true
+			}
 		default:
 			// Something went very wrong, drop the peer
 			log.Debug("Propagated block verification failed", "peer", peer, "number", block.Number(), "hash", hash, "err", err)
@@ -818,10 +839,11 @@ func (f *BlockFetcher) importBlocks(peer string, block *types.Block) {
 			log.Debug("Propagated block import failed", "peer", peer, "number", block.Number(), "hash", hash, "err", err)
 			return
 		}
-		// If import succeeded, broadcast the block
-		blockAnnounceOutTimer.UpdateSince(block.ReceivedAt)
-		go f.broadcastBlock(block, false)
-
+		if announce {
+			// If import succeeded, broadcast the block
+			blockAnnounceOutTimer.UpdateSince(block.ReceivedAt)
+			go f.broadcastBlock(block, false)
+		}
 		// Invoke the testing hook if needed
 		if f.importedHook != nil {
 			f.importedHook(nil, block)

--- a/eth/handler.go
+++ b/eth/handler.go
@@ -450,7 +450,9 @@ func (h *handler) BroadcastBlock(block *types.Block, propagate bool) {
 		for _, peer := range transfer {
 			peer.AsyncSendNewBlock(block, td)
 		}
-		log.Trace("Propagated block", "hash", hash, "recipients", len(transfer), "duration", common.PrettyDuration(time.Since(block.ReceivedAt)))
+		if len(transfer) > 0 {
+			log.Debug("Propagated block", "number", block.NumberU64(), "hash", hash, "recipients", len(transfer), "duration", common.PrettyDuration(time.Since(block.ReceivedAt)))
+		}
 		return
 	}
 	// Otherwise if the block is indeed in out own chain, announce it
@@ -458,7 +460,11 @@ func (h *handler) BroadcastBlock(block *types.Block, propagate bool) {
 		for _, peer := range peers {
 			peer.AsyncSendNewBlockHash(block)
 		}
-		log.Trace("Announced block", "hash", hash, "recipients", len(peers), "duration", common.PrettyDuration(time.Since(block.ReceivedAt)))
+		if len(peers) > 0 {
+			log.Debug("Announced block", "number", block.NumberU64(), "hash", hash, "recipients", len(peers), "duration", common.PrettyDuration(time.Since(block.ReceivedAt)))
+		}
+	}else{
+		log.Debug("Block neither announced nor propagated","number", block.NumberU64(), "hash", hash)
 	}
 }
 


### PR DESCRIPTION
This is based on  to https://github.com/ethereum/go-ethereum/pull/22241, but could really be applied on `master` aswell. While working on `eth66`, where I used one 'relayer' and one 'isolated' node which spoke only to the relayer, I noticed that block import did not happen one by one, but rather in batches whenever it got 'far enough' behind. 

After diving deep into it, I concluded that the problem was: 

- When a `relayer` gets a block via broadcast, but the block is `1 second ` future from `Now`, the block 
  -  was _not_ broadcast
  - It was _attempted_ to import (but blockchain would schedule it for import a little while later)
  - Was sent to the notification-framework
    - Which also marks the `hash` as known at `isolated`. 
    - However, right before sending the announcement, we check if we have it in chain (we don't want to announce non-canon blocks). This check failed, and we therefore neither broadcast nor announce the block.
  - If we have multiple peers, like `relayer` does, he gets the same block a split second later, and it gets imported properly. 
  - This time, it's not announced to `isolated`, since he's already marked as having it. 

This all leads to `isolated` missing out on announcements. 

There are several ways to handle this, and I tried a few, end eventually settled on performing a small wait (up to 2 seconds) in the block fetcher, if it notices that a given block is indeed future, but the timestamp is `<=2s` from now. At that point, we're already executing in a goroutine, and sleeping + doing successfull import there prevents the hash from being sent to the `done` channel prematurely.  

Anyway, the whole point of this particular PR is the last commit. With that, my two goerli-on-eth66 nodes work fine with eachother, progressing in lock-step block by block

This PR also fixes what I _think_ is an oversight during `queue` processing in the fetcher -- but maybe it was intentional and I have just overlooked some aspect. 


EDIT: The fix I made, eventually, is just a band-aid on a broken thing. I think a more correct fix would be to have two separate paths: broadcasts done as now, and announcements triggered/sent based on a subscription of imported blocks. That way, we would be guaranteed that regardless of how the block is imported (via fetcher or via `procFutureBlocks`), the block would be announced, and at the time of the announcement, the block is fully imported)