### PR TITLE
Typo in curl command, include content-type header

### DIFF
--- a/docs/_interface/Managing-your-accounts.md
+++ b/docs/_interface/Managing-your-accounts.md
@@ -260,7 +260,7 @@ When using the console:
 or via RPC:
 ```
 # Request
-$ curl -X POST --data '{"jsonrpc":"2.0","method":"eth_accounts","params":[],"id":1} http://127.0.0.1:8545'
+$ curl -X POST --data '{"jsonrpc":"2.0","method":"eth_accounts","params":[],"id":1}' -H 'Content-type: application/json' http://127.0.0.1:8545
 
 # Result
 {


### PR DESCRIPTION
Typo: the `'` char was located at the wrong place. 
The`curl` command, without specifying the content-type headers, complains about invalid content type.