### PR TITLE
Update cpu_syscall.go

### DIFF
--- a/metrics/cpu_syscall.go
+++ b/metrics/cpu_syscall.go
@@ -31,5 +31,5 @@ func getProcessCPUTime() int64 {
 		log.Warn("Failed to retrieve CPU time", "err", err)
 		return 0
 	}
-	return (usage.Utime.Sec+usage.Stime.Sec)*100 + int64(usage.Utime.Usec+usage.Stime.Usec)/10000 //nolint:unconvert
+	return int64(usage.Utime.Sec+usage.Stime.Sec)*100 + int64(usage.Utime.Usec+usage.Stime.Usec)/10000 //nolint:unconvert
 }


### PR DESCRIPTION
MINOR ERROR with go1.15: src/github.com/ethereum/go-ethereum/metrics/cpu_syscall.go:34:47: invalid operation: (usage.Utime.Sec + usage.Stime.Sec) * 100 + int64(usage.Utime.Usec + usage.Stime.Usec) / 10000 (mismatched types int32 and int64)