### PR TITLE
accounts/abi: implement abi.encodePacked

### DIFF
--- a/accounts/abi/encodepacked.go
+++ b/accounts/abi/encodepacked.go
@@ -10,10 +10,15 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 )
 
-// EncodePacked implements the non-standard encoding available in solidity.
+// SolidityEncodePacked implements the non-standard encoding available in solidity.
 // Since encoding is ambigious there is no decoding function.
-// See
-func EncodePacked(args []Type, values []interface{}) ([]byte, error) {
+//
+// Using EncodePacked to pack data before hashing or signing is generally unsafe because
+// the following arguments produce the same output.
+// abi.SolidityEncodePacked([]Type{String,String}, []interface{}{"hello", "world01"})
+// abi.SolidityEncodePacked([]Type{String,String}, []interface{}{"helloworld", "01"})
+// '0x68656c6c6f776f726c643031'
+func SolidityEncodePacked(args []Type, values []interface{}) ([]byte, error) {
 	enc := make([]byte, 0)
 	var index int
 	for _, arg := range args {

--- a/accounts/abi/encodepacked.go
+++ b/accounts/abi/encodepacked.go
@@ -1,0 +1,90 @@
+package abi
+
+import (
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"math/big"
+	"reflect"
+
+	"github.com/ethereum/go-ethereum/common"
+)
+
+// EncodePacked implements the non-standard encoding available in solidity.
+// Since encoding is ambigious there is no decoding function.
+// See
+func EncodePacked(args []Type, values []interface{}) ([]byte, error) {
+	enc := make([]byte, 0)
+	for idx, arg := range args {
+		switch arg.T {
+		case TupleTy:
+			return []byte{}, errors.New("Not implemented")
+		case ArrayTy, SliceTy:
+		default:
+			packed, err := encodePackElement(arg, reflect.ValueOf(values[idx]))
+			if err != nil {
+				return []byte{}, err
+			}
+			enc = append(enc, packed...)
+		}
+	}
+	return enc, nil
+}
+
+func encodePackElement(t Type, value reflect.Value) ([]byte, error) {
+	value = indirect(value)
+
+	switch t.T {
+	case IntTy, UintTy:
+		return encodePackedNum(t, value), nil
+	case StringTy:
+		return encodePackedByteSlice(t, []byte(value.String())), nil
+	case AddressTy, FixedBytesTy:
+		if value.Kind() == reflect.Array {
+			value = mustArrayToByteSlice(value)
+		}
+
+		return encodePackedByteSlice(t, value.Bytes()), nil
+	case BoolTy:
+		if value.Bool() {
+			return []byte{1}, nil
+		}
+		return []byte{0}, nil
+	case BytesTy:
+		if value.Kind() == reflect.Array {
+			value = mustArrayToByteSlice(value)
+		}
+		if value.Type() != reflect.TypeOf([]byte{}) {
+			return []byte{}, errors.New("Bytes type is neither slice nor array")
+		}
+		return encodePackedByteSlice(t, value.Bytes()), nil
+	default:
+		return []byte{}, fmt.Errorf("Could not encode pack element, unknown type: %v", t.T)
+	}
+}
+
+func encodePackedNum(t Type, value reflect.Value) []byte {
+	bytes := make([]byte, 8)
+	switch kind := value.Kind(); kind {
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+		binary.BigEndian.PutUint64(bytes, value.Uint())
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		binary.BigEndian.PutUint64(bytes, uint64(value.Int()))
+	case reflect.Ptr:
+		big := new(big.Int).Set(value.Interface().(*big.Int))
+		bytes = big.Bytes()
+	default:
+		panic("abi: fatal error")
+	}
+	return encodePackedByteSlice(t, bytes)
+}
+
+func encodePackedByteSlice(t Type, value []byte) []byte {
+	size := t.Size / 8
+	// If size is not set in the type, use the length of the value to pad
+	if size == 0 {
+		size = len(value)
+	}
+	padded := common.LeftPadBytes(value, size)
+	return padded[len(padded)-size:]
+}

--- a/accounts/abi/encodepacked_test.go
+++ b/accounts/abi/encodepacked_test.go
@@ -1,0 +1,38 @@
+package abi
+
+import (
+	"bytes"
+	"fmt"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+)
+
+func TestEncodePackedExample(t *testing.T) {
+	// Test example from docs.soliditylang.org
+	// int16(-1), bytes1(0x42), uint16(0x03), string("Hello, world!")
+	int16T, _ := NewType("int16", "", nil)
+	bytes1T, _ := NewType("bytes1", "", nil)
+	want := common.Hex2Bytes("ffff42000348656c6c6f2c20776f726c6421")
+	fmt.Print(want)
+
+	types := []Type{
+		int16T,
+		bytes1T,
+		Uint16,
+		String,
+	}
+	values := []interface{}{
+		int16(-1),
+		[]byte{0x42},
+		uint16(0x03),
+		"Hello, world!",
+	}
+	encoded, err := EncodePacked(types, values)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(encoded, want) {
+		t.Errorf("Could not properly encode using EncodePacked: got %v, want %v", encoded, want)
+	}
+}

--- a/accounts/abi/encodepacked_test.go
+++ b/accounts/abi/encodepacked_test.go
@@ -2,37 +2,89 @@ package abi
 
 import (
 	"bytes"
-	"fmt"
 	"testing"
 
 	"github.com/ethereum/go-ethereum/common"
 )
 
-func TestEncodePackedExample(t *testing.T) {
-	// Test example from docs.soliditylang.org
-	// int16(-1), bytes1(0x42), uint16(0x03), string("Hello, world!")
+func TestEncodePacked(t *testing.T) {
+
+	Uint8ArrT, _ := NewType("uint8[3]", "", nil)
 	int16T, _ := NewType("int16", "", nil)
 	bytes1T, _ := NewType("bytes1", "", nil)
-	want := common.Hex2Bytes("ffff42000348656c6c6f2c20776f726c6421")
-	fmt.Print(want)
+	bytesT, _ := NewType("bytes", "", nil)
 
-	types := []Type{
-		int16T,
-		bytes1T,
-		Uint16,
-		String,
+	type test struct {
+		name    string
+		encoded string
+		types   []Type
+		values  []interface{}
 	}
-	values := []interface{}{
-		int16(-1),
-		[]byte{0x42},
-		uint16(0x03),
-		"Hello, world!",
+
+	tests := []test{
+		{
+			// Test example from docs.soliditylang.org
+			// int16(-1), bytes1(0x42), uint16(0x03), string("Hello, world!")
+			name:    "TestSolidityExample",
+			encoded: "ffff42000348656c6c6f2c20776f726c6421",
+			types: []Type{
+				int16T,
+				bytes1T,
+				Uint16,
+				String,
+			},
+			values: []interface{}{
+				int16(-1),
+				[]byte{0x42},
+				uint16(0x03),
+				"Hello, world!",
+			},
+		},
+		{
+			name: "TestArray",
+			encoded: "0000000000000000000000000000000000000000000000000000000000000001" +
+				"0000000000000000000000000000000000000000000000000000000000000002" +
+				"0000000000000000000000000000000000000000000000000000000000000042" +
+				"41414141" +
+				"42424242",
+			types: []Type{
+				Uint8ArrT,
+				String,
+				String,
+			},
+			values: []interface{}{
+				uint8(0x1),
+				uint8(0x2),
+				uint8(0x42),
+				"AAAA",
+				"BBBB",
+			},
+		},
+		{
+			name:    "TestBytesBool",
+			encoded: "414141410100",
+			types: []Type{
+				bytesT,
+				Bool,
+				Bool,
+			},
+			values: []interface{}{
+				[]byte{0x41, 0x41, 0x41, 0x41},
+				true,
+				false,
+			},
+		},
 	}
-	encoded, err := EncodePacked(types, values)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if !bytes.Equal(encoded, want) {
-		t.Errorf("Could not properly encode using EncodePacked: got %v, want %v", encoded, want)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			want := common.Hex2Bytes(tt.encoded)
+			encoded, err := EncodePacked(tt.types, tt.values)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !bytes.Equal(encoded, want) {
+				t.Errorf("Could not properly encode using EncodePacked: got %v, want %v", encoded, want)
+			}
+		})
 	}
 }

--- a/accounts/abi/encodepacked_test.go
+++ b/accounts/abi/encodepacked_test.go
@@ -78,7 +78,7 @@ func TestEncodePacked(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			want := common.Hex2Bytes(tt.encoded)
-			encoded, err := EncodePacked(tt.types, tt.values)
+			encoded, err := SolidityEncodePacked(tt.types, tt.values)
 			if err != nil {
 				t.Fatal(err)
 			}


### PR DESCRIPTION
This PR implements the `abi.EncodePacked` function a non-standard encoding function available in solidity.
Doc: https://docs.soliditylang.org/en/latest/abi-spec.html#non-standard-packed-mode
Some behaviour around arrays are guesstimates based on evaluations did with solidity.

rel: https://github.com/ethereum/go-ethereum/issues/22257