### PR TITLE
[Tracer] Handle Empty Contract Deployment Transactions

### DIFF
--- a/core/vm/interpreter.go
+++ b/core/vm/interpreter.go
@@ -155,11 +155,6 @@ func (in *EVMInterpreter) Run(contract *Contract, input []byte, readOnly bool) (
 	// as every returning call will return new data anyway.
 	in.returnData = nil
 
-	// Don't bother with the execution if there's no code.
-	if len(contract.Code) == 0 {
-		return nil, nil
-	}
-
 	var (
 		op          OpCode             // current opcode
 		mem         = NewMemory()      // bound memory
@@ -182,6 +177,20 @@ func (in *EVMInterpreter) Run(contract *Contract, input []byte, readOnly bool) (
 		logged  bool   // deferred Tracer should ignore already logged steps
 		res     []byte // result of the opcode execution function
 	)
+
+	// Don't bother with the execution if there's no code.
+	if len(contract.Code) == 0 {
+		if in.cfg.Debug {
+			// Even if there's nothing to execute, we need to invoke CaptureState here because the
+			// tracer assumes StateDB is populated when GetResult is invoked.
+			//
+			// If a transaction only contains an contract deployment with no code and we don't set CaptureState here, the
+			// tracer will panic if any db-related methods are invoked.
+			in.cfg.Tracer.CaptureState(in.evm, pcCopy, op, gasCopy, cost, mem, stack, returns, in.returnData, contract, in.evm.depth, nil)
+		}
+		return nil, nil
+	}
+
 	// Don't move this deferrred function, it's placed before the capturestate-deferred method,
 	// so that it get's executed _after_: the capturestate needs the stacks before
 	// they are returned to the pools


### PR DESCRIPTION
Related: https://github.com/ava-labs/coreth/pull/98

### Problem
When invoking `debug_traceTransaction` with the [default Blockscout tracing script](https://github.com/poanetwork/blockscout/blob/master/apps/ethereum_jsonrpc/priv/js/ethereum_jsonrpc/geth/debug_traceTransaction/tracer.js), I noticed that the `Tracer` panics if called on a transaction that created a contract with no code. There is an example of such a transaction on the Avalanche testnet [here](https://testnet.avascan.info/blockchain/c/tx/0xc0f33007b76c2d8675cdc34e979b94f3aab4778572be0b185115bbd4686f6a17).

### Root Cause
The root cause of this issue is that the `Tracer.dbWrapper.db` is not populated when [`Tracer.GetResult`](https://github.com/ethereum/go-ethereum/blob/e74bd587f730fcdb5a9b625390da8aa85a2cbbc8/eth/tracers/tracer.go#L656) is called [at the end of `traceTx`](https://github.com/ethereum/go-ethereum/blob/eb21c652c0a9d8f651efc0251cc5797a3328d863/eth/tracers/api.go#L779). Specifically, note that [`GetResult` calls `result(ctx, db)`](https://github.com/ethereum/go-ethereum/blob/e74bd587f730fcdb5a9b625390da8aa85a2cbbc8/eth/tracers/tracer.go#L655-L659) and that the attached script attempts to [access the code of any created contract](https://github.com/poanetwork/blockscout/blob/b9b3088d7f27643bc6f5f0cfa9c7ed76ed71f8ee/apps/ethereum_jsonrpc/priv/js/ethereum_jsonrpc/geth/debug_traceTransaction/tracer.js#L348) from the provided db (which panics [here](https://github.com/ethereum/go-ethereum/blob/e74bd587f730fcdb5a9b625390da8aa85a2cbbc8/eth/tracers/tracer.go#L214) as no `dbWrapper.db` was ever set).