### PR TITLE
core/state: construct access list from current state

### DIFF
--- a/core/state/journal.go
+++ b/core/state/journal.go
@@ -138,6 +138,9 @@ type (
 		address *common.Address
 		slot    *common.Hash
 	}
+	accessListDeleteAccountChange struct {
+		address *common.Address
+	}
 )
 
 func (ch createObjectChange) revert(s *StateDB) {
@@ -265,5 +268,13 @@ func (ch accessListAddSlotChange) revert(s *StateDB) {
 }
 
 func (ch accessListAddSlotChange) dirtied() *common.Address {
+	return nil
+}
+
+func (ch accessListDeleteAccountChange) revert(s *StateDB) {
+	s.accessList.AddAddress(*ch.address)
+}
+
+func (ch accessListDeleteAccountChange) dirtied() *common.Address {
 	return nil
 }

--- a/core/state/journal.go
+++ b/core/state/journal.go
@@ -138,9 +138,6 @@ type (
 		address *common.Address
 		slot    *common.Hash
 	}
-	accessListDeleteAccountChange struct {
-		address *common.Address
-	}
 )
 
 func (ch createObjectChange) revert(s *StateDB) {
@@ -260,14 +257,6 @@ func (ch accessListAddAccountChange) revert(s *StateDB) {
 }
 
 func (ch accessListAddAccountChange) dirtied() *common.Address {
-	return nil
-}
-
-func (ch accessListDeleteAccountChange) revert(s *StateDB) {
-	s.accessList.AddAddress(*ch.address)
-}
-
-func (ch accessListDeleteAccountChange) dirtied() *common.Address {
 	return nil
 }
 

--- a/core/state/journal.go
+++ b/core/state/journal.go
@@ -138,6 +138,9 @@ type (
 		address *common.Address
 		slot    *common.Hash
 	}
+	accessListDeleteAccountChange struct {
+		address *common.Address
+	}
 )
 
 func (ch createObjectChange) revert(s *StateDB) {
@@ -257,6 +260,14 @@ func (ch accessListAddAccountChange) revert(s *StateDB) {
 }
 
 func (ch accessListAddAccountChange) dirtied() *common.Address {
+	return nil
+}
+
+func (ch accessListDeleteAccountChange) revert(s *StateDB) {
+	s.accessList.AddAddress(*ch.address)
+}
+
+func (ch accessListDeleteAccountChange) dirtied() *common.Address {
 	return nil
 }
 

--- a/core/state/statedb.go
+++ b/core/state/statedb.go
@@ -1073,10 +1073,10 @@ func (s *StateDB) CurrentAccessList() *types.AccessList {
 	acl := make([]types.AccessTuple, 0, len(list.addresses))
 	for addr, idx := range list.addresses {
 		var tuple types.AccessTuple
-		tuple.Address = &addr
-		keys := make([]*common.Hash, 0, len(list.slots[idx]))
-		for key, _ := range list.slots[idx] {
-			keys = append(keys, &key)
+		tuple.Address = addr
+		keys := make([]common.Hash, 0, len(list.slots[idx]))
+		for key := range list.slots[idx] {
+			keys = append(keys, key)
 		}
 		tuple.StorageKeys = keys
 		acl = append(acl, tuple)
@@ -1090,11 +1090,11 @@ func (s *StateDB) AccessList() *types.AccessList {
 	acl := make([]types.AccessTuple, 0, len(s.journal.dirties))
 	for addr := range s.journal.dirties {
 		var tuple types.AccessTuple
-		tuple.Address = &addr
+		tuple.Address = addr
 		obj := s.stateObjects[addr]
-		keys := make([]*common.Hash, 0, len(obj.dirtyStorage))
+		keys := make([]common.Hash, 0, len(obj.dirtyStorage))
 		for slots := range obj.dirtyStorage {
-			keys = append(keys, &slots)
+			keys = append(keys, slots)
 		}
 		tuple.StorageKeys = keys
 		acl = append(acl, tuple)

--- a/core/state/statedb.go
+++ b/core/state/statedb.go
@@ -1034,27 +1034,6 @@ func (s *StateDB) AddSlotToAccessList(addr common.Address, slot common.Hash) {
 	}
 }
 
-// UnprepareAccessList unprepares the access list of the statedb.
-// It reverts the preparation steps from EIP-2929
-// - Delete sender from access list (2929)
-// - Delete receiver from access list (2929)
-// - Delete precompiles from access list (2929)
-func (s *StateDB) UnprepareAccessList(sender common.Address, dst *common.Address, precompiles []common.Address) {
-	s.DeleteAddressFromAccessList(sender)
-	if dst != nil {
-		s.DeleteAddressFromAccessList(*dst)
-	}
-	for _, addr := range precompiles {
-		s.DeleteAddressFromAccessList(addr)
-	}
-}
-
-// DeleteAddressFromAccessList deletes the given address from the access list
-func (s *StateDB) DeleteAddressFromAccessList(addr common.Address) {
-	s.accessList.DeleteAddress(addr)
-	s.journal.append(accessListDeleteAccountChange{&addr})
-}
-
 // AddressInAccessList returns true if the given address is in the access list.
 func (s *StateDB) AddressInAccessList(addr common.Address) bool {
 	return s.accessList.ContainsAddress(addr)
@@ -1063,26 +1042,6 @@ func (s *StateDB) AddressInAccessList(addr common.Address) bool {
 // SlotInAccessList returns true if the given (address, slot)-tuple is in the access list.
 func (s *StateDB) SlotInAccessList(addr common.Address, slot common.Hash) (addressPresent bool, slotPresent bool) {
 	return s.accessList.Contains(addr, slot)
-}
-
-// CurrentAccessList returns the current access list for the StateDB.
-// If the precompiles, sender and receiver are to be removed from the access list,
-// a prior call to `UnprepareAccessList` is required.
-func (s *StateDB) CurrentAccessList() *types.AccessList {
-	list := s.accessList.Copy()
-	acl := make([]types.AccessTuple, 0, len(list.addresses))
-	for addr, idx := range list.addresses {
-		var tuple types.AccessTuple
-		tuple.Address = addr
-		keys := make([]common.Hash, 0, len(list.slots[idx]))
-		for key := range list.slots[idx] {
-			keys = append(keys, key)
-		}
-		tuple.StorageKeys = keys
-		acl = append(acl, tuple)
-	}
-	cast := types.AccessList(acl)
-	return &cast
 }
 
 // AccessList returns a list of dirty slots and addresses

--- a/core/state/statedb.go
+++ b/core/state/statedb.go
@@ -1043,3 +1043,20 @@ func (s *StateDB) AddressInAccessList(addr common.Address) bool {
 func (s *StateDB) SlotInAccessList(addr common.Address, slot common.Hash) (addressPresent bool, slotPresent bool) {
 	return s.accessList.Contains(addr, slot)
 }
+
+func (s *StateDB) AccessList() *types.AccessList {
+	list := s.accessList.Copy()
+	acl := make([]types.AccessTuple, 0, len(list.addresses))
+	for addr, idx := range list.addresses {
+		var tuple types.AccessTuple
+		tuple.Address = &addr
+		keys := make([]*common.Hash, 0, len(list.slots[idx]))
+		for key, _ := range list.slots[idx] {
+			tuple.StorageKeys = append(tuple.StorageKeys, &key)
+		}
+		tuple.StorageKeys = keys
+		acl = append(acl, tuple)
+	}
+	cast := types.AccessList(acl)
+	return &cast
+}

--- a/core/state/statedb.go
+++ b/core/state/statedb.go
@@ -1034,6 +1034,27 @@ func (s *StateDB) AddSlotToAccessList(addr common.Address, slot common.Hash) {
 	}
 }
 
+// UnprepareAccessList unprepares an access list.
+// It reverts the preparation steps from EIP-2929
+// - Delete sender from access list (2929)
+// - Delete receiver from access list (2929)
+// - Delete precompiles from access list (2929)
+func (s *StateDB) UnprepareAccessList(sender common.Address, dst *common.Address, precompiles []common.Address) {
+	s.DeleteAddressFromAccessList(sender)
+	if dst != nil {
+		s.DeleteAddressFromAccessList(*dst)
+	}
+	for _, addr := range precompiles {
+		s.DeleteAddressFromAccessList(addr)
+	}
+}
+
+// DeleteAddressFromAccessList deletes the given address from the access list
+func (s *StateDB) DeleteAddressFromAccessList(addr common.Address) {
+	s.accessList.DeleteAddress(addr)
+	s.journal.append(accessListDeleteAccountChange{&addr})
+}
+
 // AddressInAccessList returns true if the given address is in the access list.
 func (s *StateDB) AddressInAccessList(addr common.Address) bool {
 	return s.accessList.ContainsAddress(addr)
@@ -1044,18 +1065,23 @@ func (s *StateDB) SlotInAccessList(addr common.Address, slot common.Hash) (addre
 	return s.accessList.Contains(addr, slot)
 }
 
-// AccessList returns a list of dirty slots and addresses
+// AccessList returns the current access list for the StateDB.
+// If the precompiles, sender and receiver are to be removed from the access list,
+// a prior call to `UnprepareAccessList` is required.
 func (s *StateDB) AccessList() *types.AccessList {
-	acl := make([]types.AccessTuple, 0, len(s.journal.dirties))
-	for addr := range s.journal.dirties {
+	list := s.accessList.Copy()
+	acl := make([]types.AccessTuple, 0, len(list.addresses))
+	for addr, idx := range list.addresses {
 		var tuple types.AccessTuple
 		tuple.Address = addr
-		obj := s.stateObjects[addr]
-		keys := make([]common.Hash, 0, len(obj.dirtyStorage))
-		for slots := range obj.dirtyStorage {
-			keys = append(keys, slots)
+		// addresses without slots are saved as -1
+		if idx > 0 {
+			keys := make([]common.Hash, 0, len(list.slots[idx]))
+			for key := range list.slots[idx] {
+				keys = append(keys, key)
+			}
+			tuple.StorageKeys = keys
 		}
-		tuple.StorageKeys = keys
 		acl = append(acl, tuple)
 	}
 	cast := types.AccessList(acl)

--- a/core/vm/interface.go
+++ b/core/vm/interface.go
@@ -58,6 +58,7 @@ type StateDB interface {
 	Empty(common.Address) bool
 
 	PrepareAccessList(sender common.Address, dest *common.Address, precompiles []common.Address, txAccesses types.AccessList)
+	UnprepareAccessList(sender common.Address, dest *common.Address, precompiles []common.Address)
 	AddressInAccessList(addr common.Address) bool
 	SlotInAccessList(addr common.Address, slot common.Hash) (addressOk bool, slotOk bool)
 	// AddAddressToAccessList adds the given address to the access list. This operation is safe to perform

--- a/core/vm/interface.go
+++ b/core/vm/interface.go
@@ -74,6 +74,8 @@ type StateDB interface {
 	AddPreimage(common.Hash, []byte)
 
 	ForEachStorage(common.Address, func(common.Hash, common.Hash) bool) error
+
+	AccessList() *types.AccessList
 }
 
 // CallContext provides a basic interface for the EVM calling conventions. The EVM

--- a/eth/api.go
+++ b/eth/api.go
@@ -543,3 +543,8 @@ func (api *PrivateDebugAPI) getModifiedAccounts(startBlock, endBlock *types.Bloc
 	}
 	return dirty, nil
 }
+
+func (api *PublicDebugAPI) CreateAccessList(block *types.Block, reexec uint64, tx *types.Transaction) (*types.AccessList, error) {
+	ctx := context.Background()
+	return api.eth.APIBackend.AccessList(ctx, block, reexec, tx)
+}

--- a/eth/api_backend.go
+++ b/eth/api_backend.go
@@ -364,7 +364,7 @@ func (b *EthAPIBackend) AccessList(ctx context.Context, block *types.Block, reex
 	// Not yet the searched for transaction, execute on top of the current state
 	vmenv := vm.NewEVM(context, txContext, statedb, b.eth.blockchain.Config(), vm.Config{})
 	if _, err := core.ApplyMessage(vmenv, msg, new(core.GasPool).AddGas(tx.Gas())); err != nil {
-		return nil, fmt.Errorf("failed to apply transaction: %v", tx.Hash(), err)
+		return nil, fmt.Errorf("failed to apply transaction: %v err: %v", tx.Hash(), err)
 	}
 
 	return vmenv.StateDB.AccessList(), nil

--- a/eth/api_backend.go
+++ b/eth/api_backend.go
@@ -346,6 +346,9 @@ func (b *EthAPIBackend) StateAtTransaction(ctx context.Context, block *types.Blo
 }
 
 func (b *EthAPIBackend) AccessList(ctx context.Context, block *types.Block, reexec uint64, tx *types.Transaction) (*types.AccessList, error) {
+	if block == nil {
+		block = b.CurrentBlock()
+	}
 	statedb, release, err := b.eth.stateAtBlock(block, reexec)
 	defer release()
 	if err != nil {
@@ -363,6 +366,6 @@ func (b *EthAPIBackend) AccessList(ctx context.Context, block *types.Block, reex
 	if _, err := core.ApplyMessage(vmenv, msg, new(core.GasPool).AddGas(tx.Gas())); err != nil {
 		return nil, fmt.Errorf("failed to apply transaction: %v", tx.Hash(), err)
 	}
-	statedb.UnprepareAccessList(msg.From(), msg.To(), vmenv.ActivePrecompiles())
-	return statedb.AccessList(), nil
+
+	return vmenv.StateDB.AccessList(), nil
 }

--- a/eth/api_backend.go
+++ b/eth/api_backend.go
@@ -378,6 +378,7 @@ func (b *EthAPIBackend) AccessList(ctx context.Context, block *types.Block, reex
 			return nil, fmt.Errorf("failed to apply transaction: %v err: %v", args.ToTransaction().Hash(), err)
 		}
 		if res.UsedGas == gas {
+			vmenv.StateDB.UnprepareAccessList(args.From, args.To, vmenv.ActivePrecompiles())
 			return vmenv.StateDB.AccessList(), nil
 		}
 		accessList = vmenv.StateDB.AccessList()

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -358,11 +358,11 @@ func (s *PrivateAccountAPI) signTransaction(ctx context.Context, args *SendTxArg
 		return nil, err
 	}
 	// Set some sanity defaults and terminate on failure
-	if err := args.setDefaults(ctx, s.b); err != nil {
+	if err := args.SetDefaults(ctx, s.b); err != nil {
 		return nil, err
 	}
 	// Assemble the transaction and sign with the wallet
-	tx := args.toTransaction()
+	tx := args.ToTransaction()
 
 	return wallet.SignTxWithPassphrase(account, passwd, tx, s.b.ChainConfig().ChainID)
 }
@@ -1501,8 +1501,8 @@ type SendTxArgs struct {
 	ChainID    *hexutil.Big      `json:"chainId,omitempty"`
 }
 
-// setDefaults fills in default values for unspecified tx fields.
-func (args *SendTxArgs) setDefaults(ctx context.Context, b Backend) error {
+// SetDefaults fills in default values for unspecified tx fields.
+func (args *SendTxArgs) SetDefaults(ctx context.Context, b Backend) error {
 	if args.GasPrice == nil {
 		price, err := b.SuggestPrice(ctx)
 		if err != nil {
@@ -1567,9 +1567,9 @@ func (args *SendTxArgs) setDefaults(ctx context.Context, b Backend) error {
 	return nil
 }
 
-// toTransaction converts the arguments to a transaction.
+// ToTransaction converts the arguments to a transaction.
 // This assumes that setDefaults has been called.
-func (args *SendTxArgs) toTransaction() *types.Transaction {
+func (args *SendTxArgs) ToTransaction() *types.Transaction {
 	var input []byte
 	if args.Input != nil {
 		input = *args.Input
@@ -1651,11 +1651,11 @@ func (s *PublicTransactionPoolAPI) SendTransaction(ctx context.Context, args Sen
 	}
 
 	// Set some sanity defaults and terminate on failure
-	if err := args.setDefaults(ctx, s.b); err != nil {
+	if err := args.SetDefaults(ctx, s.b); err != nil {
 		return common.Hash{}, err
 	}
 	// Assemble the transaction and sign with the wallet
-	tx := args.toTransaction()
+	tx := args.ToTransaction()
 
 	signed, err := wallet.SignTx(account, tx, s.b.ChainConfig().ChainID)
 	if err != nil {
@@ -1668,11 +1668,11 @@ func (s *PublicTransactionPoolAPI) SendTransaction(ctx context.Context, args Sen
 // and returns it to the caller for further processing (signing + broadcast)
 func (s *PublicTransactionPoolAPI) FillTransaction(ctx context.Context, args SendTxArgs) (*SignTransactionResult, error) {
 	// Set some sanity defaults and terminate on failure
-	if err := args.setDefaults(ctx, s.b); err != nil {
+	if err := args.SetDefaults(ctx, s.b); err != nil {
 		return nil, err
 	}
 	// Assemble the transaction and obtain rlp
-	tx := args.toTransaction()
+	tx := args.ToTransaction()
 	data, err := tx.MarshalBinary()
 	if err != nil {
 		return nil, err
@@ -1734,14 +1734,14 @@ func (s *PublicTransactionPoolAPI) SignTransaction(ctx context.Context, args Sen
 	if args.Nonce == nil {
 		return nil, fmt.Errorf("nonce not specified")
 	}
-	if err := args.setDefaults(ctx, s.b); err != nil {
+	if err := args.SetDefaults(ctx, s.b); err != nil {
 		return nil, err
 	}
 	// Before actually sign the transaction, ensure the transaction fee is reasonable.
 	if err := checkTxFee(args.GasPrice.ToInt(), uint64(*args.Gas), s.b.RPCTxFeeCap()); err != nil {
 		return nil, err
 	}
-	tx, err := s.sign(args.From, args.toTransaction())
+	tx, err := s.sign(args.From, args.ToTransaction())
 	if err != nil {
 		return nil, err
 	}
@@ -1781,10 +1781,10 @@ func (s *PublicTransactionPoolAPI) Resend(ctx context.Context, sendArgs SendTxAr
 	if sendArgs.Nonce == nil {
 		return common.Hash{}, fmt.Errorf("missing transaction nonce in transaction spec")
 	}
-	if err := sendArgs.setDefaults(ctx, s.b); err != nil {
+	if err := sendArgs.SetDefaults(ctx, s.b); err != nil {
 		return common.Hash{}, err
 	}
-	matchTx := sendArgs.toTransaction()
+	matchTx := sendArgs.ToTransaction()
 
 	// Before replacing the old transaction, ensure the _new_ transaction fee is reasonable.
 	var price = matchTx.GasPrice()
@@ -1814,7 +1814,7 @@ func (s *PublicTransactionPoolAPI) Resend(ctx context.Context, sendArgs SendTxAr
 			if gasLimit != nil && *gasLimit != 0 {
 				sendArgs.Gas = gasLimit
 			}
-			signedTx, err := s.sign(sendArgs.From, sendArgs.toTransaction())
+			signedTx, err := s.sign(sendArgs.From, sendArgs.ToTransaction())
 			if err != nil {
 				return common.Hash{}, err
 			}

--- a/internal/web3ext/web3ext.go
+++ b/internal/web3ext/web3ext.go
@@ -474,7 +474,7 @@ web3._extend({
 			name: 'createAccessList',
 			call: 'debug_createAccessList',
 			params: 3,
-			inputFormatter: [web3._extend.formatters.inputBlockNumberFormatter, null, web3._extend.formatters.inputTransactionFormatter],
+			inputFormatter: [web3._extend.formatters.inputBlockNumberFormatter, null, null],
 		}),
 	],
 	properties: []

--- a/internal/web3ext/web3ext.go
+++ b/internal/web3ext/web3ext.go
@@ -470,6 +470,12 @@ web3._extend({
 			call: 'debug_freezeClient',
 			params: 1,
 		}),
+		new web3._extend.Method({
+			name: 'createAccessList',
+			call: 'debug_createAccessList',
+			params: 3,
+			inputFormatter: [web3._extend.formatters.inputBlockNumberFormatter, null, web3._extend.formatters.inputTransactionFormatter],
+		}),
 	],
 	properties: []
 });


### PR DESCRIPTION
Implement access list helpers on top of https://github.com/ethereum/go-ethereum/pull/21502 and https://github.com/ethereum/go-ethereum/pull/22290

TODO:

- [x] Implement access list generator
- [x] Rebase when #21502 is merged
- [x] Rebase when #22290 is merged
- [x] Remove unnecessary functions

Usage:
```
> debug.createAccessList("pending", 0, {"from": "0xe840410a7f7a9ecb9010e781cae90b9bb8cbece4", "to":   "0xebe8efa441b9302a0d7eaecc277c09d20d684540", "gas":  "0x1bd7c","data": "0xd459fc46000000000000000000000000000000000000000000000000000000000046c650dbb5e8cb2bac4d2ed0b1e6475d37361157738801c494ca482f96527eb48f9eec488c2eba92d31baeccfb6968fad5c21a3df93181b43b4cf253b4d572b64172ef000000000000000000000000000000000000000000000000000000000000008c00000000000000000000000000000000000000000000000000000000000000e0000000000000000000000000000000000000000000000000000000000000014000000000000000000000000000000000000000000000000000000000000001a00000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000001c000000000000000000000000000000000000000000000000000000000000001c0000000000000000000000000000000000000000000000000000000000000002b85c0c828d7a98633b4e1b65eac0c017502da909420aeade9a280675013df36bdc71cffdf420cef3d24ba4b3f9b980bfbb26bd5e2dcf7795b3519a3fd22ffbb2000000000000000000000000000000000000000000000000000000000000000238fb6606dc2b5e42d00c653372c153da8560de77bd9afaba94b4ab6e4aa11d565d858c761320dbf23a94018d843772349bd9d92301b0ca9ca983a22d86a70628"})
[{
    address: "0x0000000000000000000000000000000000000007",
    storageKeys: null
}, {
    address: "0x0000000000000000000000000000000000000005",
    storageKeys: null
}, {
    address: "0x0000000000000000000000000000000000000008",
    storageKeys: null
}, {
    address: "0x0000000000000000000000000000000000000001",
    storageKeys: null
}, {
    address: "0x0000000000000000000000000000000000000003",
    storageKeys: null
}, {
    address: "0x0000000000000000000000000000000000000002",
    storageKeys: null
}, {
    address: "0xebe8efa441b9302a0d7eaecc277c09d20d684540",
    storageKeys: null
}, {
    address: "0xe840410a7f7a9ecb9010e781cae90b9bb8cbece4",
    storageKeys: null
}, {
    address: "0x0000000000000000000000000000000000000004",
    storageKeys: null
}, {
    address: "0x0000000000000000000000000000000000000006",
    storageKeys: null
}, {
    address: "0x0000000000000000000000000000000000000009",
    storageKeys: null
}]
```

Edit: the above output was from before the access list was unprepared.
```
> debug.createAccessList("pending", 0, {"from": "0x067dc07d4df2bda13d5a1ea9efced4c129974350", "to":   "0xebe8efa441b9302a0d7eaecc277c09d20d684540", "gas":  "0x1bd7c","data": "0xd459fc46000000000000000000000000000000000000000000000000000000000046c650dbb5e8cb2bac4d2ed0b1e6475d37361157738801c494ca482f96527eb48f9eec488c2eba92d31baeccfb6968fad5c21a3df93181b43b4cf253b4d572b64172ef000000000000000000000000000000000000000000000000000000000000008c00000000000000000000000000000000000000000000000000000000000000e0000000000000000000000000000000000000000000000000000000000000014000000000000000000000000000000000000000000000000000000000000001a00000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000001c000000000000000000000000000000000000000000000000000000000000001c0000000000000000000000000000000000000000000000000000000000000002b85c0c828d7a98633b4e1b65eac0c017502da909420aeade9a280675013df36bdc71cffdf420cef3d24ba4b3f9b980bfbb26bd5e2dcf7795b3519a3fd22ffbb2000000000000000000000000000000000000000000000000000000000000000238fb6606dc2b5e42d00c653372c153da8560de77bd9afaba94b4ab6e4aa11d565d858c761320dbf23a94018d843772349bd9d92301b0ca9ca983a22d86a70628"})
[]
```