### PR TITLE
cmd/utils, eth/ethconfig: unindex txs older than ~1 year

### DIFF
--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -212,10 +212,10 @@ var (
 		Name:  "snapshot",
 		Usage: `Enables snapshot-database mode (default = enable)`,
 	}
-	TxLookupLimitFlag = cli.Int64Flag{
+	TxLookupLimitFlag = cli.Uint64Flag{
 		Name:  "txlookuplimit",
-		Usage: "Number of recent blocks to maintain transactions index by-hash for (default = index all blocks)",
-		Value: 0,
+		Usage: "Number of recent blocks to maintain transactions index for (default = about one year, 0 = entire chain)",
+		Value: ethconfig.Defaults.TxLookupLimit,
 	}
 	LightKDFFlag = cli.BoolFlag{
 		Name:  "lightkdf",

--- a/eth/ethconfig/config.go
+++ b/eth/ethconfig/config.go
@@ -66,6 +66,7 @@ var Defaults = Config{
 		DatasetsLockMmap: false,
 	},
 	NetworkId:               1,
+	TxLookupLimit:           2350000,
 	LightPeers:              100,
 	UltraLightFraction:      75,
 	DatabaseCache:           512,


### PR DESCRIPTION
https://twitter.com/peter_szilagyi/status/1358767100995784704 .

This PR changes the default number of indexed transaction from infinite to the most recent 1 year (assuming block times of around 13-14s).

The reasoning behind this change is that currently on mainnet there are over 1 billion transactions. Just tracking the `hash->blocknum` mapping weighs 33GB on the database (requires SSD speeds due to the hash keying) and represents 3/5th of the database entry count, which makes trie operations and compactions exceedingly expensive.

Without any form of pruning, the transaction index dataset grows indefinitely. We must bite the bullet and have normal full nodes retain meaningful history, but not indefinite.

Operators still wishing to index all transactions since genesis can run geth with `--txlookuplimit=0`. The index can be reconstructed even if it was pruned, so no data is lost. The index is not needed for network health, it's just a local acceleration structure.-