### PR TITLE
les: refactor serverPeerSet

### DIFF
--- a/les/client.go
+++ b/les/client.go
@@ -300,7 +300,8 @@ func (s *LightEthereum) Start() error {
 	}
 	s.serverPool.addSource(discovery)
 	s.ns.Start()
-	s.serverPool.start()
+	s.peers.open()       // start accepting connections
+	s.serverPool.start() // start dialing peers
 	// Start bloom request workers.
 	s.wg.Add(bloomServiceThreads)
 	s.startBloomHandlers(params.BloomBitsBlocksClient)

--- a/les/client.go
+++ b/les/client.go
@@ -51,7 +51,7 @@ import (
 var (
 	clientSetup       = &nodestate.Setup{Version: 1}
 	serverPeerField   = clientSetup.NewField("serverPeer", reflect.TypeOf(&serverPeer{}))
-	valueTrackerSetup = lpc.NewValueTrackerSetup(clientSetup)
+	valueTrackerSetup = vfc.NewValueTrackerSetup(clientSetup)
 )
 
 func init() {
@@ -104,7 +104,7 @@ func New(stack *node.Node, config *ethconfig.Config) (*LightEthereum, error) {
 	}
 	log.Info("Initialised chain configuration", "config", chainConfig)
 
-	ns := nodestate.NewNodeStateMachine(lespayDb, []byte("ns:"), &mclock.System{}, clientSetup)
+	ns := nodestate.NewNodeStateMachine(lesDb, []byte("ns:"), &mclock.System{}, clientSetup)
 	peers := newServerPeerSet(ns)
 	leth := &LightEthereum{
 		lesCommons: lesCommons{

--- a/les/odr_test.go
+++ b/les/odr_test.go
@@ -228,20 +228,20 @@ func testOdr(t *testing.T, protocol int, expFail uint64, checkCached bool, fn od
 	}
 
 	// expect retrievals to fail (except genesis block) without a les peer
-	client.handler.backend.peers.lock.Lock()
+	client.peer.speer.lock.Lock()
 	client.peer.speer.hasBlockHook = func(common.Hash, uint64, bool) bool { return false }
-	client.handler.backend.peers.lock.Unlock()
+	client.peer.speer.lock.Unlock()
 	test(expFail)
 
 	// expect all retrievals to pass
-	client.handler.backend.peers.lock.Lock()
+	client.peer.speer.lock.Lock()
 	client.peer.speer.hasBlockHook = func(common.Hash, uint64, bool) bool { return true }
-	client.handler.backend.peers.lock.Unlock()
+	client.peer.speer.lock.Unlock()
 	test(5)
 
 	// still expect all retrievals to pass, now data should be cached locally
 	if checkCached {
-		client.handler.backend.peers.unregister(client.peer.speer.id)
+		client.handler.removePeer(client.peer.speer.ID())
 		time.Sleep(time.Millisecond * 10) // ensure that all peerSetNotify callbacks are executed
 		test(5)
 	}

--- a/les/peer_test.go
+++ b/les/peer_test.go
@@ -58,6 +58,7 @@ func TestPeerSubscription(t *testing.T) {
 	sub := newTestServerPeerSub()
 	peers.subscribe(sub)
 	ns.Start()
+	peers.open()
 	defer ns.Stop()
 
 	checkIds := func(expect []string) {

--- a/les/retrieve.go
+++ b/les/retrieve.go
@@ -341,7 +341,7 @@ func (r *sentReq) tryRequest() {
 		if hrto && ok {
 			pp.Log().Debug("Request timed out hard")
 			if r.rm.peers != nil {
-				r.rm.peers.unregister(pp.id)
+				r.rm.peers.unregister(pp.ID())
 			}
 		}
 	}()

--- a/les/serverpool.go
+++ b/les/serverpool.go
@@ -166,7 +166,7 @@ func newServerPool(ns *nodestate.NodeStateMachine, db ethdb.KeyValueStore, vt *v
 
 	s.ns.SubscribeField(valueTrackerSetup.ValueTrackerField, func(node *enode.Node, state nodestate.Flags, oldValue, newValue interface{}) {
 		if newValue != nil {
-			nvt := newValue.(*lpc.NodeValueTracker)
+			nvt := newValue.(*vfc.NodeValueTracker)
 			s.ns.SetStateSub(node, sfConnected, sfDialing.Or(sfWaitDialTimeout), 0)
 			s.ns.SetFieldSub(node, sfiConnectedStats, nvt.RtStats())
 			p := s.ns.GetField(node, serverPeerField).(*serverPeer)

--- a/les/serverpool.go
+++ b/les/serverpool.go
@@ -91,18 +91,17 @@ type nodeHistoryEnc struct {
 type queryFunc func(*enode.Node) int
 
 var (
-	serverPoolSetup    = &nodestate.Setup{Version: 1}
-	sfHasValue         = serverPoolSetup.NewPersistentFlag("hasValue")
-	sfQueried          = serverPoolSetup.NewFlag("queried")
-	sfCanDial          = serverPoolSetup.NewFlag("canDial")
-	sfDialing          = serverPoolSetup.NewFlag("dialed")
-	sfWaitDialTimeout  = serverPoolSetup.NewFlag("dialTimeout")
-	sfConnected        = serverPoolSetup.NewFlag("connected")
-	sfRedialWait       = serverPoolSetup.NewFlag("redialWait")
-	sfAlwaysConnect    = serverPoolSetup.NewFlag("alwaysConnect")
+	sfHasValue         = clientSetup.NewPersistentFlag("hasValue")
+	sfQueried          = clientSetup.NewFlag("queried")
+	sfCanDial          = clientSetup.NewFlag("canDial")
+	sfDialing          = clientSetup.NewFlag("dialed")
+	sfWaitDialTimeout  = clientSetup.NewFlag("dialTimeout")
+	sfConnected        = clientSetup.NewFlag("connected")
+	sfRedialWait       = clientSetup.NewFlag("redialWait")
+	sfAlwaysConnect    = clientSetup.NewFlag("alwaysConnect")
 	sfDisableSelection = nodestate.MergeFlags(sfQueried, sfCanDial, sfDialing, sfConnected, sfRedialWait)
 
-	sfiNodeHistory = serverPoolSetup.NewPersistentField("nodeHistory", reflect.TypeOf(nodeHistory{}),
+	sfiNodeHistory = clientSetup.NewPersistentField("nodeHistory", reflect.TypeOf(nodeHistory{}),
 		func(field interface{}) ([]byte, error) {
 			if n, ok := field.(nodeHistory); ok {
 				ne := nodeHistoryEnc{
@@ -126,12 +125,12 @@ var (
 			return n, err
 		},
 	)
-	sfiNodeWeight     = serverPoolSetup.NewField("nodeWeight", reflect.TypeOf(uint64(0)))
-	sfiConnectedStats = serverPoolSetup.NewField("connectedStats", reflect.TypeOf(vfc.ResponseTimeStats{}))
+	sfiNodeWeight     = clientSetup.NewField("nodeWeight", reflect.TypeOf(uint64(0)))
+	sfiConnectedStats = clientSetup.NewField("connectedStats", reflect.TypeOf(vfc.ResponseTimeStats{}))
 )
 
 // newServerPool creates a new server pool
-func newServerPool(db ethdb.KeyValueStore, dbKey []byte, vt *vfc.ValueTracker, mixTimeout time.Duration, query queryFunc, clock mclock.Clock, trustedURLs []string) *serverPool {
+func newServerPool(ns *nodestate.NodeStateMachine, db ethdb.KeyValueStore, vt *vfc.ValueTracker, mixTimeout time.Duration, query queryFunc, clock mclock.Clock, trustedURLs []string) *serverPool {
 	s := &serverPool{
 		db:           db,
 		clock:        clock,
@@ -139,9 +138,8 @@ func newServerPool(db ethdb.KeyValueStore, dbKey []byte, vt *vfc.ValueTracker, m
 		validSchemes: enode.ValidSchemes,
 		trustedURLs:  trustedURLs,
 		vt:           vt,
-		ns:           nodestate.NewNodeStateMachine(db, []byte(string(dbKey)+"ns:"), clock, serverPoolSetup),
+		ns:           ns,
 	}
-	s.recalTimeout()
 	s.mixer = enode.NewFairMix(mixTimeout)
 	knownSelector := vfc.NewWrsIterator(s.ns, sfHasValue, sfDisableSelection, sfiNodeWeight)
 	alwaysConnect := vfc.NewQueueIterator(s.ns, sfAlwaysConnect, sfDisableSelection, true, nil)
@@ -163,6 +161,24 @@ func newServerPool(db ethdb.KeyValueStore, dbKey []byte, vt *vfc.ValueTracker, m
 			// dial timeout, no connection
 			s.setRedialWait(n, dialCost, dialWaitStep)
 			s.ns.SetStateSub(n, nodestate.Flags{}, sfDialing, 0)
+		}
+	})
+
+	s.ns.SubscribeField(valueTrackerSetup.ValueTrackerField, func(node *enode.Node, state nodestate.Flags, oldValue, newValue interface{}) {
+		if newValue != nil {
+			nvt := newValue.(*lpc.NodeValueTracker)
+			s.ns.SetStateSub(node, sfConnected, sfDialing.Or(sfWaitDialTimeout), 0)
+			s.ns.SetFieldSub(node, sfiConnectedStats, nvt.RtStats())
+			p := s.ns.GetField(node, serverPeerField).(*serverPeer)
+			p.setValueTracker(s.vt, nvt)
+			p.updateVtParams()
+		} else {
+			s.setRedialWait(node, dialCost, dialWaitStep)
+			s.ns.SetStateSub(node, nodestate.Flags{}, sfConnected, 0)
+			s.ns.SetFieldSub(node, sfiConnectedStats, nil)
+			if p, ok := s.ns.GetField(node, serverPeerField).(*serverPeer); ok {
+				p.setValueTracker(nil, nil)
+			}
 		}
 	})
 
@@ -232,7 +248,7 @@ func (s *serverPool) addPreNegFilter(input enode.Iterator, query queryFunc) enod
 
 // start starts the server pool. Note that NodeStateMachine should be started first.
 func (s *serverPool) start() {
-	s.ns.Start()
+	s.recalTimeout()
 	for _, iter := range s.mixSources {
 		// add sources to mixer at startup because the mixer instantly tries to read them
 		// which should only happen after NodeStateMachine has been started
@@ -275,27 +291,6 @@ func (s *serverPool) stop() {
 			s.calculateWeight(n)
 		})
 	})
-	s.ns.Stop()
-}
-
-// registerPeer implements serverPeerSubscriber
-func (s *serverPool) registerPeer(p *serverPeer) {
-	s.ns.SetState(p.Node(), sfConnected, sfDialing.Or(sfWaitDialTimeout), 0)
-	nvt := s.vt.Register(p.ID())
-	s.ns.SetField(p.Node(), sfiConnectedStats, nvt.RtStats())
-	p.setValueTracker(s.vt, nvt)
-	p.updateVtParams()
-}
-
-// unregisterPeer implements serverPeerSubscriber
-func (s *serverPool) unregisterPeer(p *serverPeer) {
-	s.ns.Operation(func() {
-		s.setRedialWait(p.Node(), dialCost, dialWaitStep)
-		s.ns.SetStateSub(p.Node(), nodestate.Flags{}, sfConnected, 0)
-		s.ns.SetFieldSub(p.Node(), sfiConnectedStats, nil)
-	})
-	s.vt.Unregister(p.ID())
-	p.setValueTracker(nil, nil)
 }
 
 // recalTimeout calculates the current recommended timeout. This value is used by

--- a/les/serverpool_test.go
+++ b/les/serverpool_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/ethereum/go-ethereum/p2p"
 	"github.com/ethereum/go-ethereum/p2p/enode"
 	"github.com/ethereum/go-ethereum/p2p/enr"
+	"github.com/ethereum/go-ethereum/p2p/nodestate"
 )
 
 const (
@@ -51,6 +52,7 @@ func testNodeIndex(id enode.ID) int {
 }
 
 type serverPoolTest struct {
+	ns                   *nodestate.NodeStateMachine
 	db                   ethdb.KeyValueStore
 	clock                *mclock.Simulated
 	quit                 chan struct{}
@@ -79,7 +81,7 @@ func newServerPoolTest(preNeg, preNegFail bool) *serverPoolTest {
 	for i := range nodes {
 		nodes[i] = enode.SignNull(&enr.Record{}, testNodeID(i))
 	}
-	return &serverPoolTest{
+	st := &serverPoolTest{
 		clock:      &mclock.Simulated{},
 		db:         memorydb.New(),
 		input:      enode.CycleNodes(nodes),
@@ -87,6 +89,7 @@ func newServerPoolTest(preNeg, preNegFail bool) *serverPoolTest {
 		preNeg:     preNeg,
 		preNegFail: preNegFail,
 	}
+	return st
 }
 
 func (s *serverPoolTest) beginWait() {
@@ -107,6 +110,7 @@ func (s *serverPoolTest) addTrusted(i int) {
 }
 
 func (s *serverPoolTest) start() {
+	s.ns = nodestate.NewNodeStateMachine(s.db, []byte("ns:"), s.clock, clientSetup)
 	var testQuery queryFunc
 	if s.preNeg {
 		testQuery = func(node *enode.Node) int {
@@ -144,12 +148,13 @@ func (s *serverPoolTest) start() {
 		}
 	}
 
-	s.vt = vfc.NewValueTracker(s.db, s.clock, requestList, time.Minute, 1/float64(time.Hour), 1/float64(time.Hour*100), 1/float64(time.Hour*1000))
-	s.sp = newServerPool(s.db, []byte("serverpool:"), s.vt, 0, testQuery, s.clock, s.trusted)
+	s.vt = vfc.NewValueTracker(s.ns, valueTrackerSetup, s.db, s.clock, requestList, time.Minute, 1/float64(time.Hour), 1/float64(time.Hour*100), 1/float64(time.Hour*1000))
+	s.sp = newServerPool(s.ns, s.db, s.vt, 0, testQuery, s.clock, s.trusted)
 	s.sp.addSource(s.input)
 	s.sp.validSchemes = enode.ValidSchemesForTesting
 	s.sp.unixTime = func() int64 { return int64(s.clock.Now()) / int64(time.Second) }
 	s.disconnect = make(map[int][]int)
+	s.ns.Start()
 	s.sp.start()
 	s.quit = make(chan struct{})
 	go func() {
@@ -184,6 +189,7 @@ func (s *serverPoolTest) stop() {
 		n.nextConnCycle = 0
 	}
 	s.conn, s.servedConn = 0, 0
+	s.ns.Stop()
 }
 
 func (s *serverPoolTest) run() {
@@ -191,7 +197,7 @@ func (s *serverPoolTest) run() {
 		if dcList := s.disconnect[s.cycle]; dcList != nil {
 			for _, idx := range dcList {
 				n := &s.testNodes[idx]
-				s.sp.unregisterPeer(n.peer)
+				s.ns.SetField(n.peer.Node(), serverPeerField, nil)
 				n.totalConn += s.cycle
 				n.connected = false
 				n.peer = nil
@@ -222,7 +228,7 @@ func (s *serverPoolTest) run() {
 				dc := s.cycle + n.connectCycles
 				s.disconnect[dc] = append(s.disconnect[dc], idx)
 				n.peer = &serverPeer{peerCommons: peerCommons{Peer: p2p.NewPeer(id, "", nil)}}
-				s.sp.registerPeer(n.peer)
+				s.ns.SetField(n.peer.Node(), serverPeerField, n.peer)
 				if n.service {
 					s.vt.Served(s.vt.GetNode(id), []vfc.ServedRequest{{ReqType: 0, Amount: 100}}, 0)
 				}
@@ -257,7 +263,7 @@ func (s *serverPoolTest) resetNodes() {
 	for i, n := range s.testNodes {
 		if n.connected {
 			n.totalConn += s.cycle
-			s.sp.unregisterPeer(n.peer)
+			s.ns.SetField(n.peer.Node(), serverPeerField, nil)
 		}
 		s.testNodes[i] = spTestNode{totalConn: n.totalConn}
 	}

--- a/les/sync.go
+++ b/les/sync.go
@@ -169,7 +169,7 @@ func (h *clientHandler) synchronise(peer *serverPeer) {
 		if mode == checkpointSync {
 			if err := h.validateCheckpoint(peer); err != nil {
 				log.Debug("Failed to validate checkpoint", "reason", err)
-				h.removePeer(peer.id)
+				h.removePeer(peer.ID())
 				return
 			}
 			h.backend.blockchain.AddTrustedCheckpoint(checkpoint)
@@ -187,7 +187,7 @@ func (h *clientHandler) synchronise(peer *serverPeer) {
 		defer cancel()
 		if !checkpoint.Empty() && !h.backend.blockchain.SyncCheckpoint(ctx, checkpoint) {
 			log.Debug("Sync checkpoint failed")
-			h.removePeer(peer.id)
+			h.removePeer(peer.ID())
 			return
 		}
 	}

--- a/les/test_helper.go
+++ b/les/test_helper.go
@@ -538,6 +538,7 @@ func newClientServerEnv(t *testing.T, blocks int, protocol int, callback indexer
 	client := newTestClientHandler(b, odr, cIndexers, cdb, speers, ulcServers, ulcFraction)
 
 	ns.Start()
+	speers.open()
 	scIndexer.Start(server.blockchain)
 	sbIndexer.Start(server.blockchain)
 	ccIndexer.Start(client.backend.blockchain)


### PR DESCRIPTION
This PR removes the old serverPeerSet and uses NodeStateMachine to realize the peer set logic of clients, similarly to what has already been done with clientPeerSet. This change makes the code more consistent by removing multiple custom peer maps used by different mechanisms. It also allows further client side feature improvements (mostly related to incentivization).
The NodeStateMachine is also extended with another ForEach iterator that iterates on nodes having a certain field set.
Replaces https://github.com/ethereum/go-ethereum/pull/22221