### PR TITLE
node: show websocket url in logs

### DIFF
--- a/node/rpcstack.go
+++ b/node/rpcstack.go
@@ -144,13 +144,15 @@ func (h *httpServer) start() error {
 	h.listener = listener
 	go h.server.Serve(listener)
 
-	// if server is websocket only, return after logging
-	if h.wsAllowed() && !h.rpcAllowed() {
+	if h.wsAllowed() {
 		url := fmt.Sprintf("ws://%v", listener.Addr())
 		if h.wsConfig.prefix != "" {
 			url += h.wsConfig.prefix
 		}
 		h.log.Info("WebSocket enabled", "url", url)
+	}
+	// if server is websocket only, return after logging
+	if !h.rpcAllowed() {
 		return nil
 	}
 	// Log http endpoint.


### PR DESCRIPTION
This PR does two things: 

- ~~If `geth --dev --ws --ws.port 0 --http --http.port 0` is used, then ws and http are both randomized, to different ports.~~
- If `geth --dev --ws --ws.port 9999 --http --http.port 9999`, then it shows in the logs that, yes, websocket is up, even if it's on the same port. 

```
INFO [02-11|10:00:53.477] WebSocket enabled                        url=ws://127.0.0.1:9999
INFO [02-11|10:00:53.477] HTTP server started                      endpoint=127.0.0.1:9999 prefix= cors= vhosts=localhost
```