### PR TITLE
p2p: shutdown readLoop on error

### DIFF
--- a/p2p/peer.go
+++ b/p2p/peer.go
@@ -302,6 +302,12 @@ func (p *Peer) readLoop(errc chan<- error) {
 			errc <- err
 			return
 		}
+		// shutdown read loop when node is shutdown
+		select {
+		case <-p.closed:
+			return
+		default:
+		}
 	}
 }
 


### PR DESCRIPTION
Shutting down a node sometimes takes really long. This is because we didn't stop
the read loop when an error occured, thus the wait in peer.go L270 would deadlock.
You can see this in traces where a goroutine hangs there for multiple hours.
The readloop would only terminate if a peer disconnects or an invalid message would
be received not on a write, proto or disc error.

An example trace that stalls because two peers are stalling: https://gist.github.com/MariusVanDerWijden/d4ac18ffae9b99a6373794296e1e8c9b
One stalls for 119 one for 116 minutes.

Basically the shutdown waits until all peers are disconnected via `srv.delpeer`.
The peers shutdown once the `readLoop` and the `pingLoop` are stopped.
The peer can stop the `pingLoop` by closing the `p.closed` channel. The `readLoop` only closes if the peer disconnected or send a junk message. 
I think a peer might prevent another peer from shutting down if they ignored the ping messages and just kept on sending valid messages, but I'm not sure