### PR TITLE
p2p/dnsdisc: fix hot-spin when all trees are empty

### DIFF
--- a/p2p/dnsdisc/client.go
+++ b/p2p/dnsdisc/client.go
@@ -238,10 +238,10 @@ func (it *randomIterator) Node() *enode.Node {
 
 // Close closes the iterator.
 func (it *randomIterator) Close() {
+	it.cancelFn()
+
 	it.mu.Lock()
 	defer it.mu.Unlock()
-
-	it.cancelFn()
 	it.trees = nil
 }
 

--- a/p2p/dnsdisc/client.go
+++ b/p2p/dnsdisc/client.go
@@ -338,18 +338,18 @@ func (it *randomIterator) syncableTrees() (canSync bool, trees []*clientTree) {
 
 // waitForRootUpdates waits for the closest scheduled root check time on the given trees.
 func (it *randomIterator) waitForRootUpdates(trees []*clientTree) bool {
-	var checkTree string
-	var nextCheck = mclock.AbsTime(-1)
+	var minTree *clientTree
+	var nextCheck mclock.AbsTime
 	for _, ct := range trees {
 		check := ct.nextScheduledRootCheck()
-		if nextCheck == -1 || check < nextCheck {
+		if minTree == nil || check < nextCheck {
+			minTree = ct
 			nextCheck = check
-			checkTree = ct.loc.domain
 		}
 	}
 
 	sleep := nextCheck.Sub(it.c.clock.Now())
-	it.c.cfg.Logger.Debug("DNS iterator waiting for root updates", "sleep", sleep, "tree", checkTree)
+	it.c.cfg.Logger.Debug("DNS iterator waiting for root updates", "sleep", sleep, "tree", minTree.loc.domain)
 	timeout := it.c.clock.NewTimer(sleep)
 	defer timeout.Stop()
 	select {

--- a/p2p/dnsdisc/client.go
+++ b/p2p/dnsdisc/client.go
@@ -291,9 +291,6 @@ func (it *randomIterator) pickTree() *clientTree {
 		it.rebuildTrees()
 		it.lc.changed = false
 	}
-	if len(it.trees) == 0 {
-		return nil
-	}
 
 	for {
 		// Find trees that might still have pending items to sync.
@@ -302,9 +299,11 @@ func (it *randomIterator) pickTree() *clientTree {
 		if len(syncable) > 0 {
 			return syncable[rand.Intn(len(syncable))]
 		}
-		// The client tried all trees, and no sync action can be performed on any of them.
-		// The only meaningful thing to do now is waiting for any root record to get
-		// updated.
+		if len(disabled) == 0 {
+			return nil // Iterator was closed.
+		}
+		// No sync action can be performed on any tree right now. The only meaningful
+		// thing to do is waiting for any root record to get updated.
 		if !it.waitForRootUpdates(disabled) {
 			return nil // Iterator was closed.
 		}

--- a/p2p/dnsdisc/client.go
+++ b/p2p/dnsdisc/client.go
@@ -325,13 +325,13 @@ func (it *randomIterator) syncableTrees() (syncable, disabled []*clientTree) {
 
 // waitForRootUpdates waits for the closest scheduled root check time on the given trees.
 func (it *randomIterator) waitForRootUpdates(trees []*clientTree) bool {
+	var checkTree string
 	var nextCheck = mclock.AbsTime(-1)
-	var checkTree *clientTree
 	for _, ct := range trees {
 		check := ct.nextScheduledRootCheck()
 		if nextCheck == -1 || check < nextCheck {
 			nextCheck = check
-			checkTree = ct
+			checkTree = ct.loc.domain
 		}
 	}
 

--- a/p2p/dnsdisc/client.go
+++ b/p2p/dnsdisc/client.go
@@ -216,10 +216,9 @@ type randomIterator struct {
 	cancelFn context.CancelFunc
 	c        *Client
 
-	mu       sync.Mutex
-	trees    map[string]*clientTree // all trees
-	rootWait map[string]*clientTree // trees waiting for root change
-	lc       linkCache              // tracks tree dependencies
+	mu    sync.Mutex
+	trees map[string]*clientTree // all trees
+	lc    linkCache              // tracks tree dependencies
 }
 
 func (c *Client) newRandomIterator() *randomIterator {

--- a/p2p/dnsdisc/client_test.go
+++ b/p2p/dnsdisc/client_test.go
@@ -246,7 +246,7 @@ func TestIteratorEmptyTree(t *testing.T) {
 	)
 	c.clock = clock
 	tree1, url := makeTestTree("n", nil, nil)
-	tree2, url := makeTestTree("n", nodes, nil)
+	tree2, _ := makeTestTree("n", nodes, nil)
 	resolver.add(tree1.ToTXT("n"))
 
 	// Start the iterator.

--- a/p2p/dnsdisc/client_test.go
+++ b/p2p/dnsdisc/client_test.go
@@ -261,13 +261,16 @@ func TestIteratorEmptyTree(t *testing.T) {
 		node <- it.Node()
 	}()
 
-	// Wait for it to get stuck in slowdownRollover, then modify the root.
+	// Wait for the client to get stuck in waitForRootUpdates.
 	clock.WaitForTimers(1)
+
+	// Now update the root.
 	resolver.add(tree2.ToTXT("n"))
 
+	// Wait for it to pick up the root change.
 	timeout := time.After(5 * time.Second)
 	for {
-		clock.Run(1 * time.Second)
+		clock.Run(20 * time.Second)
 		select {
 		case n := <-node:
 			if n.ID() != nodes[0].ID() {

--- a/p2p/dnsdisc/client_test.go
+++ b/p2p/dnsdisc/client_test.go
@@ -22,7 +22,6 @@ import (
 	"errors"
 	"math/rand"
 	"reflect"
-	"runtime"
 	"testing"
 	"time"
 
@@ -268,20 +267,14 @@ func TestIteratorEmptyTree(t *testing.T) {
 	resolver.add(tree2.ToTXT("n"))
 
 	// Wait for it to pick up the root change.
-	timeout := time.After(5 * time.Second)
-	for {
-		clock.Run(20 * time.Second)
-		select {
-		case n := <-node:
-			if n.ID() != nodes[0].ID() {
-				t.Fatalf("wrong node returned")
-			}
-			return
-		case <-timeout:
-			t.Fatal("it.Next() did not unblock within 5s of real time")
-		default:
-			runtime.Gosched()
+	clock.Run(c.cfg.RecheckInterval)
+	select {
+	case n := <-node:
+		if n.ID() != nodes[0].ID() {
+			t.Fatalf("wrong node returned")
 		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("it.Next() did not unblock within 5s of real time")
 	}
 }
 

--- a/p2p/dnsdisc/sync.go
+++ b/p2p/dnsdisc/sync.go
@@ -25,9 +25,9 @@ import (
 	"github.com/ethereum/go-ethereum/p2p/enode"
 )
 
-const (
-	rootRecheckFailCount = 5 // update root if this many leaf requests fail
-)
+// This is the number of consecutive leaf requests that may fail before
+// we consider re-resolving the tree root.
+const rootRecheckFailCount = 5
 
 // clientTree is a full tree being synced.
 type clientTree struct {
@@ -89,11 +89,20 @@ func (ct *clientTree) syncRandom(ctx context.Context) (n *enode.Node, err error)
 	ct.gcLinks()
 
 	// Sync next random entry in ENR tree. Once every node has been visited, we simply
-	// start over. This is fine because entries are cached.
+	// start over. This is fine because entries are cached internally by the client LRU
+	// also by DNS resolvers.
 	if ct.enrs.done() {
 		ct.enrs = newSubtreeSync(ct.c, ct.loc, ct.root.eroot, false)
 	}
 	return ct.syncNextRandomENR(ctx)
+}
+
+// canSyncRandom checks if any meaningful action can be performed by syncRandom.
+func (ct *clientTree) canSyncRandom() bool {
+	// Note: the check for non-zero leaf count is very important here.
+	// If we're done syncing all nodes, and no leaves were found, the tree
+	// is empty and we can't use it for sync.
+	return ct.rootUpdateDue() || !ct.links.done() || !ct.enrs.done() || ct.enrs.leaves != 0
 }
 
 // gcLinks removes outdated links from the global link cache. GC runs once
@@ -184,8 +193,12 @@ func (ct *clientTree) updateRoot(ctx context.Context) error {
 // rootUpdateDue returns true when a root update is needed.
 func (ct *clientTree) rootUpdateDue() bool {
 	tooManyFailures := ct.leafFailCount > rootRecheckFailCount
-	scheduledCheck := ct.c.clock.Now().Sub(ct.lastRootCheck) > ct.c.cfg.RecheckInterval
+	scheduledCheck := ct.c.clock.Now() >= ct.nextScheduledRootCheck()
 	return ct.root == nil || tooManyFailures || scheduledCheck
+}
+
+func (ct *clientTree) nextScheduledRootCheck() mclock.AbsTime {
+	return ct.lastRootCheck.Add(ct.c.cfg.RecheckInterval)
 }
 
 // slowdownRootUpdate applies a delay to root resolution if is tried
@@ -218,10 +231,11 @@ type subtreeSync struct {
 	root    string
 	missing []string // missing tree node hashes
 	link    bool     // true if this sync is for the link tree
+	leaves  int      // counter of synced leaves
 }
 
 func newSubtreeSync(c *Client, loc *linkEntry, root string, link bool) *subtreeSync {
-	return &subtreeSync{c, loc, root, []string{root}, link}
+	return &subtreeSync{c, loc, root, []string{root}, link, 0}
 }
 
 func (ts *subtreeSync) done() bool {
@@ -253,10 +267,12 @@ func (ts *subtreeSync) resolveNext(ctx context.Context, hash string) (entry, err
 		if ts.link {
 			return nil, errENRInLinkTree
 		}
+		ts.leaves++
 	case *linkEntry:
 		if !ts.link {
 			return nil, errLinkInENRTree
 		}
+		ts.leaves++
 	case *branchEntry:
 		ts.missing = append(ts.missing, e.children...)
 	}


### PR DESCRIPTION
In the random sync algorithm used by the DNS node iterator, we first pick a random
tree and then perform one sync action on that tree. This happens in a loop until any
node is found. If no trees contain any nodes, the iterator will enter a hot loop spinning
at 100% CPU.

The fix is complicated. The iterator now checks if a meaningful sync action can
be performed on any tree. If there is nothing to do, it waits for the next root record
recheck time to arrive and then tries again.

Fixes #22306 