### PR TITLE
rpc: increase the number of subscriptions in storm test

### DIFF
--- a/rpc/client_test.go
+++ b/rpc/client_test.go
@@ -427,7 +427,7 @@ func TestClientNotificationStorm(t *testing.T) {
 	}
 
 	doTest(8000, false)
-	doTest(23000, true)
+	doTest(24000, true)
 }
 
 func TestClientSetHeader(t *testing.T) {


### PR DESCRIPTION
Fixes #22314.

The `TestClientNotificationStorm` test checks that a storm of client notification subscriptions is detected and an error is returned. For whatever reason, FreeBSD seems to handle the storm a tiny bit better than other systems, and therefore no error is raised. Bumping the number of requests by 1000 causes the expected buffer flood and an error is correctly reported.