### PR TITLE
rlp: handle case of normal EOF in Stream.readFull()

### DIFF
--- a/rlp/decode.go
+++ b/rlp/decode.go
@@ -952,7 +952,13 @@ func (s *Stream) readFull(buf []byte) (err error) {
 		n += nn
 	}
 	if err == io.EOF {
-		err = io.ErrUnexpectedEOF
+		if n < len(buf) {
+			err = io.ErrUnexpectedEOF
+		} else {
+			// Readers are allowed to give EOF even though the read succeeded.
+			// In such cases, we discard the EOF, like io.ReadFull() does.
+			err = nil
+		}
 	}
 	return err
 }

--- a/rlp/decode_test.go
+++ b/rlp/decode_test.go
@@ -665,6 +665,26 @@ func TestDecodeWithByteReader(t *testing.T) {
 	})
 }
 
+func testDecodeWithEncReader(t *testing.T, n int) {
+	s := strings.Repeat("0", n)
+	_, r, _ := EncodeToReader(s)
+	var decoded string
+	err := Decode(r, &decoded)
+	if err != nil {
+		t.Errorf("Unexpected decode error with n=%v: %v", n, err)
+	}
+	if decoded != s {
+		t.Errorf("Decode mismatch with n=%v", n)
+	}
+}
+
+// This is a regression test checking that decoding from encReader
+// works for RLP values of size 8192 bytes or more.
+func TestDecodeWithEncReader(t *testing.T) {
+	testDecodeWithEncReader(t, 8188) // length with header is 8191
+	testDecodeWithEncReader(t, 8189) // length with header is 8192
+}
+
 // plainReader reads from a byte slice but does not
 // implement ReadByte. It is also not recognized by the
 // size validation. This is useful to test how the decoder


### PR DESCRIPTION
@fjl (since you appear a lot in the rlp git history): This fixes a bug resulting from the combination of three factors:

1. `encReader.Read()` returning `EOF` when a successful read (i.e. where `len(b)` bytes were read) reaches the end.  This, in itself, is not a bug, since the docs for `io.Reader` say returning EOF in such cases is allowed (but not required). See https://github.com/ethereum/go-ethereum/blob/1489c3f4942aa50bb97659d800e9c2840f285dfc/rlp/encode.go#L271-L280
2. `Stream.readFull()` giving `ErrUnexpectedEOF` when it gets an `EOF`, even if the read was successful (i.e. if `len(buff)` bytes were read). See https://github.com/ethereum/go-ethereum/blob/1489c3f4942aa50bb97659d800e9c2840f285dfc/rlp/decode.go#L954-L956
3. An inconsistency in `bufio.Reader.Read()` in whether or not it passes on the error from its underlying reader if the number of bytes read is non-zero.  Namely, if the buffer is empty and the amount to read is greater than the buffer size (4096 bytes by default), the resulting EOF will be passed on, but otherwise the read will return nil for its error and the EOF from the underlying reader would only be returned on the next call to `.Read()`.  See https://github.com/golang/go/blob/5faf941df067b33485edb9cd2e880869e7feb6a3/src/bufio/bufio.go#L221 and https://github.com/golang/go/blob/5faf941df067b33485edb9cd2e880869e7feb6a3/src/bufio/bufio.go#L231-L242.

The result of this is that if you encode a large value using `rlp.EncodeToReader`, you can then get an error leading to failure in decoding.  I've added a test in this PR which fails without the fix.  Specifically, it fails when the message is 8192 bytes or greater, but passes if it's less (which has to do with the specific reads done during decoding).  If you'd rather use a different sort of test, I'd be happy to change it.

The PR fixes this bug by making `Stream.readFull()` tolerate the EOF error if we read the number of bytes we were supposed to, bringing its behavior more in line with what is done in `io.ReadFull()` (https://github.com/golang/go/blob/5faf941df067b33485edb9cd2e880869e7feb6a3/src/io/io.go#L314-L348).

A different way to fix this would have been to modify `encReader()` to not return `EOF` in such cases.