### PR TITLE
internal/ethapi: disable sending of non eip155 replay protected tx

### DIFF
--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -199,6 +199,7 @@ var (
 		utils.InsecureUnlockAllowedFlag,
 		utils.RPCGlobalGasCapFlag,
 		utils.RPCGlobalTxFeeCapFlag,
+		utils.AllowUnprotectedTxs,
 	}
 
 	whisperFlags = []cli.Flag{

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -970,7 +970,7 @@ func setHTTP(ctx *cli.Context, cfg *node.Config) {
 	if ctx.GlobalIsSet(HTTPPathPrefixFlag.Name) {
 		cfg.HTTPPathPrefix = ctx.GlobalString(HTTPPathPrefixFlag.Name)
 	}
-	if ctx.GlobalIsSet(HTTPPathPrefixFlag.Name) {
+	if ctx.GlobalIsSet(AllowUnprotectedTxs.Name) {
 		cfg.AllowUnprotectedTxs = ctx.GlobalBool(AllowUnprotectedTxs.Name)
 	}
 }

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -971,9 +971,7 @@ func setHTTP(ctx *cli.Context, cfg *node.Config) {
 		cfg.HTTPPathPrefix = ctx.GlobalString(HTTPPathPrefixFlag.Name)
 	}
 
-	if ctx.GlobalIsSet(AllowUnprotectedTxs.Name) {
-		cfg.UnprotectedAllowed = ctx.GlobalBool(AllowUnprotectedTxs.Name)
-	}
+	cfg.UnprotectedAllowed = ctx.GlobalBool(AllowUnprotectedTxs.Name)
 }
 
 // setGraphQL creates the GraphQL listener interface string from the set

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -593,6 +593,10 @@ var (
 		Name:  "preload",
 		Usage: "Comma separated list of JavaScript files to preload into the console",
 	}
+	AllowUnprotectedTxs = cli.BoolFlag{
+		Name:  "rpc.allow-unprotected-txs",
+		Usage: "Allow for unprotected (non EIP155 signed transactions to be submitted via RPC",
+	}
 
 	// Network Settings
 	MaxPeersFlag = cli.IntFlag{
@@ -965,6 +969,12 @@ func setHTTP(ctx *cli.Context, cfg *node.Config) {
 
 	if ctx.GlobalIsSet(HTTPPathPrefixFlag.Name) {
 		cfg.HTTPPathPrefix = ctx.GlobalString(HTTPPathPrefixFlag.Name)
+	}
+
+	if ctx.GlobalIsSet(AllowUnprotectedTxs.Name) {
+		cfg.EIP155Required = !ctx.GlobalBool(AllowUnprotectedTxs.Name)
+	} else {
+		cfg.EIP155Required = true
 	}
 }
 

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -972,9 +972,7 @@ func setHTTP(ctx *cli.Context, cfg *node.Config) {
 	}
 
 	if ctx.GlobalIsSet(AllowUnprotectedTxs.Name) {
-		cfg.EIP155Required = !ctx.GlobalBool(AllowUnprotectedTxs.Name)
-	} else {
-		cfg.EIP155Required = true
+		cfg.UnprotectedAllowed = ctx.GlobalBool(AllowUnprotectedTxs.Name)
 	}
 }
 

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -970,8 +970,9 @@ func setHTTP(ctx *cli.Context, cfg *node.Config) {
 	if ctx.GlobalIsSet(HTTPPathPrefixFlag.Name) {
 		cfg.HTTPPathPrefix = ctx.GlobalString(HTTPPathPrefixFlag.Name)
 	}
-
-	cfg.UnprotectedAllowed = ctx.GlobalBool(AllowUnprotectedTxs.Name)
+	if ctx.GlobalIsSet(HTTPPathPrefixFlag.Name) {
+		cfg.AllowUnprotectedTxs = ctx.GlobalBool(AllowUnprotectedTxs.Name)
+	}
 }
 
 // setGraphQL creates the GraphQL listener interface string from the set

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -595,7 +595,7 @@ var (
 	}
 	AllowUnprotectedTxs = cli.BoolFlag{
 		Name:  "rpc.allow-unprotected-txs",
-		Usage: "Allow for unprotected (non EIP155 signed transactions to be submitted via RPC",
+		Usage: "Allow for unprotected (non EIP155 signed) transactions to be submitted via RPC",
 	}
 
 	// Network Settings

--- a/eth/api_backend.go
+++ b/eth/api_backend.go
@@ -41,10 +41,10 @@ import (
 
 // EthAPIBackend implements ethapi.Backend for full nodes
 type EthAPIBackend struct {
-	extRPCEnabled      bool
-	unprotectedAllowed bool
-	eth                *Ethereum
-	gpo                *gasprice.Oracle
+	extRPCEnabled       bool
+	allowUnprotectedTxs bool
+	eth                 *Ethereum
+	gpo                 *gasprice.Oracle
 }
 
 // ChainConfig returns the active chain configuration.
@@ -294,7 +294,7 @@ func (b *EthAPIBackend) ExtRPCEnabled() bool {
 }
 
 func (b *EthAPIBackend) UnprotectedAllowed() bool {
-	return b.unprotectedAllowed
+	return b.allowUnprotectedTxs
 }
 
 func (b *EthAPIBackend) RPCGasCap() uint64 {

--- a/eth/api_backend.go
+++ b/eth/api_backend.go
@@ -41,9 +41,10 @@ import (
 
 // EthAPIBackend implements ethapi.Backend for full nodes
 type EthAPIBackend struct {
-	extRPCEnabled bool
-	eth           *Ethereum
-	gpo           *gasprice.Oracle
+	extRPCEnabled  bool
+	eip155Required bool
+	eth            *Ethereum
+	gpo            *gasprice.Oracle
 }
 
 // ChainConfig returns the active chain configuration.
@@ -290,6 +291,10 @@ func (b *EthAPIBackend) AccountManager() *accounts.Manager {
 
 func (b *EthAPIBackend) ExtRPCEnabled() bool {
 	return b.extRPCEnabled
+}
+
+func (b *EthAPIBackend) EIP155Required() bool {
+	return b.eip155Required
 }
 
 func (b *EthAPIBackend) RPCGasCap() uint64 {

--- a/eth/api_backend.go
+++ b/eth/api_backend.go
@@ -41,10 +41,10 @@ import (
 
 // EthAPIBackend implements ethapi.Backend for full nodes
 type EthAPIBackend struct {
-	extRPCEnabled  bool
-	eip155Required bool
-	eth            *Ethereum
-	gpo            *gasprice.Oracle
+	extRPCEnabled      bool
+	unprotectedAllowed bool
+	eth                *Ethereum
+	gpo                *gasprice.Oracle
 }
 
 // ChainConfig returns the active chain configuration.
@@ -293,8 +293,8 @@ func (b *EthAPIBackend) ExtRPCEnabled() bool {
 	return b.extRPCEnabled
 }
 
-func (b *EthAPIBackend) EIP155Required() bool {
-	return b.eip155Required
+func (b *EthAPIBackend) UnprotectedAllowed() bool {
+	return b.unprotectedAllowed
 }
 
 func (b *EthAPIBackend) RPCGasCap() uint64 {

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -222,7 +222,8 @@ func New(stack *node.Node, config *ethconfig.Config) (*Ethereum, error) {
 	eth.miner = miner.New(eth, &config.Miner, chainConfig, eth.EventMux(), eth.engine, eth.isLocalBlock)
 	eth.miner.SetExtra(makeExtraData(config.Miner.ExtraData))
 
-	eth.APIBackend = &EthAPIBackend{stack.Config().ExtRPCEnabled(), stack.Config().UnprotectedAllowed, eth, nil}
+	eth.APIBackend = &EthAPIBackend{stack.Config().ExtRPCEnabled(), stack.Config().AllowUnprotectedTxs, eth, nil}
+	log.Info("Unprotected TXs allowed", "value", eth.APIBackend.allowUnprotectedTxs)
 	gpoParams := config.GPO
 	if gpoParams.Default == nil {
 		gpoParams.Default = config.Miner.GasPrice

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -223,7 +223,9 @@ func New(stack *node.Node, config *ethconfig.Config) (*Ethereum, error) {
 	eth.miner.SetExtra(makeExtraData(config.Miner.ExtraData))
 
 	eth.APIBackend = &EthAPIBackend{stack.Config().ExtRPCEnabled(), stack.Config().AllowUnprotectedTxs, eth, nil}
-	log.Info("Unprotected TXs allowed", "value", eth.APIBackend.allowUnprotectedTxs)
+	if eth.APIBackend.allowUnprotectedTxs {
+		log.Info("Unprotected transactions allowed")
+	}
 	gpoParams := config.GPO
 	if gpoParams.Default == nil {
 		gpoParams.Default = config.Miner.GasPrice

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -222,7 +222,7 @@ func New(stack *node.Node, config *ethconfig.Config) (*Ethereum, error) {
 	eth.miner = miner.New(eth, &config.Miner, chainConfig, eth.EventMux(), eth.engine, eth.isLocalBlock)
 	eth.miner.SetExtra(makeExtraData(config.Miner.ExtraData))
 
-	eth.APIBackend = &EthAPIBackend{stack.Config().ExtRPCEnabled(), eth, nil}
+	eth.APIBackend = &EthAPIBackend{stack.Config().ExtRPCEnabled(), stack.Config().EIP155Required, eth, nil}
 	gpoParams := config.GPO
 	if gpoParams.Default == nil {
 		gpoParams.Default = config.Miner.GasPrice

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -222,7 +222,7 @@ func New(stack *node.Node, config *ethconfig.Config) (*Ethereum, error) {
 	eth.miner = miner.New(eth, &config.Miner, chainConfig, eth.EventMux(), eth.engine, eth.isLocalBlock)
 	eth.miner.SetExtra(makeExtraData(config.Miner.ExtraData))
 
-	eth.APIBackend = &EthAPIBackend{stack.Config().ExtRPCEnabled(), stack.Config().EIP155Required, eth, nil}
+	eth.APIBackend = &EthAPIBackend{stack.Config().ExtRPCEnabled(), stack.Config().UnprotectedAllowed, eth, nil}
 	gpoParams := config.GPO
 	if gpoParams.Default == nil {
 		gpoParams.Default = config.Miner.GasPrice

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -1557,7 +1557,7 @@ func SubmitTransaction(ctx context.Context, b Backend, tx *types.Transaction) (c
 	}
 	// Ensure only eip155 signed transactions are submitted
 	if !tx.Protected() {
-		return common.Hash{}, errors.New("Non-eip155 signed transaction submitted")
+		return common.Hash{}, errors.New("non-eip155 signed transaction submitted")
 	}
 	if err := b.SendTx(ctx, tx); err != nil {
 		return common.Hash{}, err

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -1555,6 +1555,10 @@ func SubmitTransaction(ctx context.Context, b Backend, tx *types.Transaction) (c
 	if err := checkTxFee(tx.GasPrice(), tx.Gas(), b.RPCTxFeeCap()); err != nil {
 		return common.Hash{}, err
 	}
+	// Ensure only eip155 signed transactions are submitted
+	if !tx.Protected() {
+		return common.Hash{}, errors.New("Non-eip155 signed transaction submitted")
+	}
 	if err := b.SendTx(ctx, tx); err != nil {
 		return common.Hash{}, err
 	}

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -1555,8 +1555,8 @@ func SubmitTransaction(ctx context.Context, b Backend, tx *types.Transaction) (c
 	if err := checkTxFee(tx.GasPrice(), tx.Gas(), b.RPCTxFeeCap()); err != nil {
 		return common.Hash{}, err
 	}
-	// Ensure only eip155 signed transactions are submitted
-	if !tx.Protected() {
+	if b.EIP155Required() && !tx.Protected() {
+		// Ensure only eip155 signed transactions are submitted if EIP155Required is set.
 		return common.Hash{}, errors.New("only replay-protected (EIP-155) transactions allowed over RPC")
 	}
 	if err := b.SendTx(ctx, tx); err != nil {

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -1555,7 +1555,7 @@ func SubmitTransaction(ctx context.Context, b Backend, tx *types.Transaction) (c
 	if err := checkTxFee(tx.GasPrice(), tx.Gas(), b.RPCTxFeeCap()); err != nil {
 		return common.Hash{}, err
 	}
-	if b.EIP155Required() && !tx.Protected() {
+	if !b.UnprotectedAllowed() && !tx.Protected() {
 		// Ensure only eip155 signed transactions are submitted if EIP155Required is set.
 		return common.Hash{}, errors.New("only replay-protected (EIP-155) transactions allowed over RPC")
 	}

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -1557,7 +1557,7 @@ func SubmitTransaction(ctx context.Context, b Backend, tx *types.Transaction) (c
 	}
 	// Ensure only eip155 signed transactions are submitted
 	if !tx.Protected() {
-		return common.Hash{}, errors.New("non-eip155 signed transaction submitted")
+		return common.Hash{}, errors.New("only replay-protected (EIP-155) transactions allowed over RPC")
 	}
 	if err := b.SendTx(ctx, tx); err != nil {
 		return common.Hash{}, err

--- a/internal/ethapi/backend.go
+++ b/internal/ethapi/backend.go
@@ -45,9 +45,9 @@ type Backend interface {
 	ChainDb() ethdb.Database
 	AccountManager() *accounts.Manager
 	ExtRPCEnabled() bool
-	RPCGasCap() uint64    // global gas cap for eth_call over rpc: DoS protection
-	RPCTxFeeCap() float64 // global tx fee cap for all transaction related APIs
-	EIP155Required() bool // allows only for EIP155 transactions.
+	RPCGasCap() uint64        // global gas cap for eth_call over rpc: DoS protection
+	RPCTxFeeCap() float64     // global tx fee cap for all transaction related APIs
+	UnprotectedAllowed() bool // allows only for EIP155 transactions.
 
 	// Blockchain API
 	SetHead(number uint64)

--- a/internal/ethapi/backend.go
+++ b/internal/ethapi/backend.go
@@ -47,6 +47,7 @@ type Backend interface {
 	ExtRPCEnabled() bool
 	RPCGasCap() uint64    // global gas cap for eth_call over rpc: DoS protection
 	RPCTxFeeCap() float64 // global tx fee cap for all transaction related APIs
+	EIP155Required() bool // allows only for EIP155 transactions.
 
 	// Blockchain API
 	SetHead(number uint64)

--- a/les/api_backend.go
+++ b/les/api_backend.go
@@ -40,10 +40,10 @@ import (
 )
 
 type LesApiBackend struct {
-	extRPCEnabled  bool
-	eip155Required bool
-	eth            *LightEthereum
-	gpo            *gasprice.Oracle
+	extRPCEnabled      bool
+	unprotectedAllowed bool
+	eth                *LightEthereum
+	gpo                *gasprice.Oracle
 }
 
 func (b *LesApiBackend) ChainConfig() *params.ChainConfig {
@@ -264,8 +264,8 @@ func (b *LesApiBackend) ExtRPCEnabled() bool {
 	return b.extRPCEnabled
 }
 
-func (b *LesApiBackend) EIP155Required() bool {
-	return b.eip155Required
+func (b *LesApiBackend) UnprotectedAllowed() bool {
+	return b.unprotectedAllowed
 }
 
 func (b *LesApiBackend) RPCGasCap() uint64 {

--- a/les/api_backend.go
+++ b/les/api_backend.go
@@ -40,10 +40,10 @@ import (
 )
 
 type LesApiBackend struct {
-	extRPCEnabled      bool
-	unprotectedAllowed bool
-	eth                *LightEthereum
-	gpo                *gasprice.Oracle
+	extRPCEnabled       bool
+	allowUnprotectedTxs bool
+	eth                 *LightEthereum
+	gpo                 *gasprice.Oracle
 }
 
 func (b *LesApiBackend) ChainConfig() *params.ChainConfig {
@@ -265,7 +265,7 @@ func (b *LesApiBackend) ExtRPCEnabled() bool {
 }
 
 func (b *LesApiBackend) UnprotectedAllowed() bool {
-	return b.unprotectedAllowed
+	return b.allowUnprotectedTxs
 }
 
 func (b *LesApiBackend) RPCGasCap() uint64 {

--- a/les/api_backend.go
+++ b/les/api_backend.go
@@ -40,9 +40,10 @@ import (
 )
 
 type LesApiBackend struct {
-	extRPCEnabled bool
-	eth           *LightEthereum
-	gpo           *gasprice.Oracle
+	extRPCEnabled  bool
+	eip155Required bool
+	eth            *LightEthereum
+	gpo            *gasprice.Oracle
 }
 
 func (b *LesApiBackend) ChainConfig() *params.ChainConfig {
@@ -261,6 +262,10 @@ func (b *LesApiBackend) AccountManager() *accounts.Manager {
 
 func (b *LesApiBackend) ExtRPCEnabled() bool {
 	return b.extRPCEnabled
+}
+
+func (b *LesApiBackend) EIP155Required() bool {
+	return b.eip155Required
 }
 
 func (b *LesApiBackend) RPCGasCap() uint64 {

--- a/les/client.go
+++ b/les/client.go
@@ -156,7 +156,7 @@ func New(stack *node.Node, config *ethconfig.Config) (*LightEthereum, error) {
 		rawdb.WriteChainConfig(chainDb, genesisHash, chainConfig)
 	}
 
-	leth.ApiBackend = &LesApiBackend{stack.Config().ExtRPCEnabled(), stack.Config().UnprotectedAllowed, leth, nil}
+	leth.ApiBackend = &LesApiBackend{stack.Config().ExtRPCEnabled(), stack.Config().AllowUnprotectedTxs, leth, nil}
 	gpoParams := config.GPO
 	if gpoParams.Default == nil {
 		gpoParams.Default = config.Miner.GasPrice

--- a/les/client.go
+++ b/les/client.go
@@ -156,7 +156,7 @@ func New(stack *node.Node, config *ethconfig.Config) (*LightEthereum, error) {
 		rawdb.WriteChainConfig(chainDb, genesisHash, chainConfig)
 	}
 
-	leth.ApiBackend = &LesApiBackend{stack.Config().ExtRPCEnabled(), leth, nil}
+	leth.ApiBackend = &LesApiBackend{stack.Config().ExtRPCEnabled(), stack.Config().EIP155Required, leth, nil}
 	gpoParams := config.GPO
 	if gpoParams.Default == nil {
 		gpoParams.Default = config.Miner.GasPrice

--- a/les/client.go
+++ b/les/client.go
@@ -156,7 +156,7 @@ func New(stack *node.Node, config *ethconfig.Config) (*LightEthereum, error) {
 		rawdb.WriteChainConfig(chainDb, genesisHash, chainConfig)
 	}
 
-	leth.ApiBackend = &LesApiBackend{stack.Config().ExtRPCEnabled(), stack.Config().EIP155Required, leth, nil}
+	leth.ApiBackend = &LesApiBackend{stack.Config().ExtRPCEnabled(), stack.Config().UnprotectedAllowed, leth, nil}
 	gpoParams := config.GPO
 	if gpoParams.Default == nil {
 		gpoParams.Default = config.Miner.GasPrice

--- a/node/config.go
+++ b/node/config.go
@@ -192,7 +192,7 @@ type Config struct {
 	trustedNodesWarning    bool
 	oldGethResourceWarning bool
 
-	// Require all transactions to be protected with EIP-155 to prevent replaying on other chains.
+	// UnprotectedAllowed allows non EIP-155 protected transactions to be send over RPC.
 	UnprotectedAllowed bool `toml:",omitempty"`
 }
 

--- a/node/config.go
+++ b/node/config.go
@@ -192,8 +192,8 @@ type Config struct {
 	trustedNodesWarning    bool
 	oldGethResourceWarning bool
 
-	// UnprotectedAllowed allows non EIP-155 protected transactions to be send over RPC.
-	UnprotectedAllowed bool `toml:",omitempty"`
+	// AllowUnprotectedTxs allows non EIP-155 protected transactions to be send over RPC.
+	AllowUnprotectedTxs bool `toml:",omitempty"`
 }
 
 // IPCEndpoint resolves an IPC endpoint based on a configured value, taking into

--- a/node/config.go
+++ b/node/config.go
@@ -193,7 +193,7 @@ type Config struct {
 	oldGethResourceWarning bool
 
 	// Require all transactions to be protected with EIP-155 to prevent replaying on other chains.
-	EIP155Required bool `toml:",omitempty"`
+	UnprotectedAllowed bool `toml:",omitempty"`
 }
 
 // IPCEndpoint resolves an IPC endpoint based on a configured value, taking into

--- a/node/config.go
+++ b/node/config.go
@@ -191,6 +191,9 @@ type Config struct {
 	staticNodesWarning     bool
 	trustedNodesWarning    bool
 	oldGethResourceWarning bool
+
+	// Require all transactions to be protected with EIP-155 to prevent replaying on other chains.
+	EIP155Required bool `toml:",omitempty"`
 }
 
 // IPCEndpoint resolves an IPC endpoint based on a configured value, taking into


### PR DESCRIPTION
This PR prevents users from submitting transactions without EIP-155 enabled.
Replay protection is important so we should gently force our users to use it.

It changes the JSON-RPC API quite significantly, so if you see the "only replay-protected (EIP-155) transactions allowed over RPC" error, you know that you need to update your signer.

To test:
```go
cl, sk := getRealBackend()
fakeTx := types.NewTransaction(0, common.HexToAddress(ADDR), big.NewInt(0), 21000, big.NewInt(1), nil)
noneip, err := types.SignTx(fakeTx, types.HomesteadSigner{}, sk)
if err != nil {
	panic(err)
}
if err := cl.SendTransaction(context.Background(), noneip); err != nil {
	fmt.Println(err) // Prints "only replay-protected (EIP-155) transactions allowed over RPC"
}
eip155, err := types.SignTx(fakeTx, types.NewEIP155Signer(big.NewInt(1337)), sk)
if err != nil {
	panic(err)
}
if err := cl.SendTransaction(context.Background(), eip155); err != nil {
	panic(err)
}
```