### PR TITLE
core/state: copy the snap when copying the state

### DIFF
--- a/core/state/statedb.go
+++ b/core/state/statedb.go
@@ -735,24 +735,24 @@ func (s *StateDB) Copy() *StateDB {
 		// and force the miner to operate trie-backed only
 		state.snaps = s.snaps
 		state.snap = s.snap
-		// TODO: Should we copy or make new (empty) ones here?
-		// If we copy, we need to ensure concurrency safety.
-		// If we don't copy, we run the risk of consensus breaking.
-		// In theory, as the state is copied, it's still 'fresh', and these
-		// should be empty.
-		//
-		// It might be good to check the size first, and if any are non-zero,
-		// simply avoid copying over the snap
+		// deep copy needed
 		state.snapDestructs = make(map[common.Hash]struct{})
-		state.snapAccounts = make(map[common.Hash][]byte)
-		state.snapStorage = make(map[common.Hash]map[common.Hash][]byte)
-		if len(s.snapAccounts)+len(s.snapDestructs)+len(s.snapStorage) != 0 {
-			panic("Oy vey!")
+		for k, v := range s.snapDestructs {
+			state.snapDestructs[k] = v
 		}
-
+		state.snapAccounts = make(map[common.Hash][]byte)
+		for k, v := range s.snapAccounts {
+			state.snapAccounts[k] = v
+		}
+		state.snapStorage = make(map[common.Hash]map[common.Hash][]byte)
+		for k, v := range s.snapStorage {
+			temp := make(map[common.Hash][]byte)
+			for kk, vv := range v {
+				temp[kk] = vv
+			}
+			state.snapStorage[k] = temp
+		}
 	}
-
-	state.snaps = s.snaps
 	return state
 }
 


### PR DESCRIPTION
This PR attempts to fix an issue that was found on YoloV3, where the sealer does not deliver on the `snap/1` protocol. The reason for this, is that the `state` which the miner operates on does not have access to the `snap`, and thus is forced to use the trie-backend for reading and cannot write updates to the snapshot tree 

On mainnet, that would be bad, because whenever a miner mines a block, it would cause a gap in the snapshot tree, making the miner fall out of sync with the snapshot and essentially nuking the snapshot functionality. Perhaps also going into regenerate-mode again and again. 

This PR is a hacky first attempt to fix it. It does address the issue, but perhaps not optimally so, and there's an open question how we should handle the case where the `snapDestructs` are non-empty (if that could ever happen?). 

To repro this case, I used a tiny private clique network and sync between two nodes locally. I can provide the files to repro it if anyone wants to give it a spin. 
 