### PR TITLE
internal/debug: rename flags in log namespace, fix some pprof flags

### DIFF
--- a/internal/debug/flags.go
+++ b/internal/debug/flags.go
@@ -211,9 +211,24 @@ func Setup(ctx *cli.Context) error {
 	log.Root().SetHandler(glogger)
 
 	// profiling, tracing
-	runtime.MemProfileRate = ctx.GlobalInt(memprofilerateFlag.Name)
+	runtime.MemProfileRate = memprofilerateFlag.Value
+	if ctx.GlobalIsSet(legacyMemprofilerateFlag.Name) {
+		runtime.MemProfileRate = ctx.GlobalInt(legacyMemprofilerateFlag.Name)
+		log.Warn("The flag --memprofilerate is deprecated and will be removed in the future, please use --pprof.memprofilerate")
+	}
+	if ctx.GlobalIsSet(memprofilerateFlag.Name) {
+		runtime.MemProfileRate = ctx.GlobalInt(memprofilerateFlag.Name)
+	}
 
-	Handler.SetBlockProfileRate(ctx.GlobalInt(blockprofilerateFlag.Name))
+	blockProfileRate := blockprofilerateFlag.Value
+	if ctx.GlobalIsSet(legacyBlockprofilerateFlag.Name) {
+		blockProfileRate = ctx.GlobalInt(legacyBlockprofilerateFlag.Name)
+		log.Warn("The flag --blockprofilerate is deprecated and will be removed in the future, please use --pprof.blockprofilerate")
+	}
+	if ctx.GlobalIsSet(blockprofilerateFlag.Name) {
+		blockProfileRate = ctx.GlobalInt(blockprofilerateFlag.Name)
+	}
+	Handler.SetBlockProfileRate(blockProfileRate)
 
 	if traceFile := ctx.GlobalString(traceFlag.Name); traceFile != "" {
 		if err := Handler.StartGoTrace(traceFile); err != nil {

--- a/internal/debug/flags.go
+++ b/internal/debug/flags.go
@@ -37,7 +37,7 @@ var Memsize memsizeui.Handler
 
 var (
 	verbosityFlag = cli.IntFlag{
-		Name:  "verbosity",
+		Name:  "log.verbosity",
 		Usage: "Logging verbosity: 0=silent, 1=error, 2=warn, 3=info, 4=debug, 5=detail",
 		Value: 3,
 	}
@@ -46,17 +46,17 @@ var (
 		Usage: "Format logs with JSON",
 	}
 	vmoduleFlag = cli.StringFlag{
-		Name:  "vmodule",
+		Name:  "log.vmodule",
 		Usage: "Per-module verbosity: comma-separated list of <pattern>=<level> (e.g. eth/*=5,p2p=4)",
 		Value: "",
 	}
 	backtraceAtFlag = cli.StringFlag{
-		Name:  "backtrace",
+		Name:  "log.backtrace",
 		Usage: "Request a stack trace at a specific logging statement (e.g. \"block.go:271\")",
 		Value: "",
 	}
 	debugFlag = cli.BoolFlag{
-		Name:  "debug",
+		Name:  "log.debug",
 		Usage: "Prepends log messages with call-site location (file and line number)",
 	}
 	pprofFlag = cli.BoolFlag{
@@ -90,6 +90,50 @@ var (
 		Name:  "trace",
 		Usage: "Write execution trace to the given file",
 	}
+	// (Deprecated April 2020)
+	legacyPprofPortFlag = cli.IntFlag{
+		Name:  "pprofport",
+		Usage: "pprof HTTP server listening port (deprecated, use --pprof.port)",
+		Value: 6060,
+	}
+	legacyPprofAddrFlag = cli.StringFlag{
+		Name:  "pprofaddr",
+		Usage: "pprof HTTP server listening interface (deprecated, use --pprof.addr)",
+		Value: "127.0.0.1",
+	}
+	legacyMemprofilerateFlag = cli.IntFlag{
+		Name:  "memprofilerate",
+		Usage: "Turn on memory profiling with the given rate (deprecated, use --pprof.memprofilerate)",
+		Value: runtime.MemProfileRate,
+	}
+	legacyBlockprofilerateFlag = cli.IntFlag{
+		Name:  "blockprofilerate",
+		Usage: "Turn on block profiling with the given rate (deprecated, use --pprof.blockprofilerate)",
+	}
+	legacyCpuprofileFlag = cli.StringFlag{
+		Name:  "cpuprofile",
+		Usage: "Write CPU profile to the given file (deprecated, use --pprof.cpuprofile)",
+	}
+	// (Deprecated February 2021)
+	legacyVerbosityFlag = cli.IntFlag{
+		Name:  "verbosity",
+		Usage: "Logging verbosity: 0=silent, 1=error, 2=warn, 3=info, 4=debug, 5=detail (deprecated, use --log.verbosity)",
+		Value: 3,
+	}
+	legacyVmoduleFlag = cli.StringFlag{
+		Name:  "vmodule",
+		Usage: "Per-module verbosity: comma-separated list of <pattern>=<level> (e.g. eth/*=5,p2p=4) (deprecated, use --log.vmodule)",
+		Value: "",
+	}
+	legacyBacktraceAtFlag = cli.StringFlag{
+		Name:  "backtrace",
+		Usage: "Request a stack trace at a specific logging statement (e.g. \"block.go:271\") (deprecated, use --log.backtrace)",
+		Value: "",
+	}
+	legacyDebugFlag = cli.BoolFlag{
+		Name:  "debug",
+		Usage: "Prepends log messages with call-site location (file and line number) (deprecated, use --log.debug)",
+	}
 )
 
 // Flags holds all command-line flags required for debugging.
@@ -99,9 +143,14 @@ var Flags = []cli.Flag{
 	blockprofilerateFlag, cpuprofileFlag, traceFlag,
 }
 
-var (
-	glogger *log.GlogHandler
-)
+var DeprecatedFlags = []cli.Flag{
+	legacyPprofPortFlag, legacyPprofAddrFlag, legacyMemprofilerateFlag,
+	legacyBlockprofilerateFlag, legacyCpuprofileFlag,
+	legacyVerbosityFlag, legacyVmoduleFlag, legacyBacktraceAtFlag,
+	legacyDebugFlag,
+}
+
+var glogger *log.GlogHandler
 
 func init() {
 	glogger = log.NewGlogHandler(log.StreamHandler(os.Stderr, log.TerminalFormat(false)))
@@ -124,11 +173,41 @@ func Setup(ctx *cli.Context) error {
 		ostream = log.StreamHandler(output, log.TerminalFormat(usecolor))
 	}
 	glogger.SetHandler(ostream)
+
 	// logging
-	log.PrintOrigins(ctx.GlobalBool(debugFlag.Name))
-	glogger.Verbosity(log.Lvl(ctx.GlobalInt(verbosityFlag.Name)))
-	glogger.Vmodule(ctx.GlobalString(vmoduleFlag.Name))
-	glogger.BacktraceAt(ctx.GlobalString(backtraceAtFlag.Name))
+	if ctx.GlobalIsSet(legacyDebugFlag.Name) {
+		log.PrintOrigins(ctx.GlobalBool(legacyDebugFlag.Name))
+		log.Warn("The flag --debug is deprecated and will be removed in the future, please use --log.debug")
+	}
+	if ctx.GlobalIsSet(debugFlag.Name) {
+		log.PrintOrigins(ctx.GlobalBool(debugFlag.Name))
+	}
+
+	// Default verbosity is set in init()
+	if ctx.GlobalIsSet(legacyVerbosityFlag.Name) {
+		glogger.Verbosity(log.Lvl(ctx.GlobalInt(legacyVerbosityFlag.Name)))
+		log.Warn("The flag --verbosity is deprecated and will be removed in the future, please use --log.verbosity")
+	}
+	if ctx.GlobalIsSet(verbosityFlag.Name) {
+		glogger.Verbosity(log.Lvl(ctx.GlobalInt(verbosityFlag.Name)))
+	}
+
+	if vmodule := ctx.GlobalString(legacyVmoduleFlag.Name); vmodule != "" {
+		glogger.Vmodule(vmodule)
+		log.Warn("The flag --vmodule is deprecated and will be removed in the future, please use --log.vmodule")
+	}
+	if vmodule := ctx.GlobalString(vmoduleFlag.Name); vmodule != "" {
+		glogger.Vmodule(vmodule)
+	}
+
+	if backtrace := ctx.GlobalString(legacyBacktraceAtFlag.Name); backtrace != "" {
+		glogger.BacktraceAt(backtrace)
+		log.Warn("The flag --backtrace is deprecated and will be removed in the future, please use --log.backtrace")
+	}
+	if backtrace := ctx.GlobalString(backtraceAtFlag.Name); backtrace != "" {
+		glogger.BacktraceAt(backtrace)
+	}
+
 	log.Root().SetHandler(glogger)
 
 	// profiling, tracing

--- a/internal/debug/flags.go
+++ b/internal/debug/flags.go
@@ -175,38 +175,45 @@ func Setup(ctx *cli.Context) error {
 	glogger.SetHandler(ostream)
 
 	// logging
+	debug := ctx.GlobalBool(debugFlag.Name)
 	if ctx.GlobalIsSet(legacyDebugFlag.Name) {
-		log.PrintOrigins(ctx.GlobalBool(legacyDebugFlag.Name))
+		debug = ctx.GlobalBool(legacyDebugFlag.Name)
 		log.Warn("The flag --debug is deprecated and will be removed in the future, please use --log.debug")
 	}
 	if ctx.GlobalIsSet(debugFlag.Name) {
-		log.PrintOrigins(ctx.GlobalBool(debugFlag.Name))
+		debug = ctx.GlobalBool(debugFlag.Name)
 	}
+	log.PrintOrigins(debug)
 
-	// Default verbosity is set in init()
+	verbosity := ctx.GlobalInt(verbosityFlag.Name)
 	if ctx.GlobalIsSet(legacyVerbosityFlag.Name) {
-		glogger.Verbosity(log.Lvl(ctx.GlobalInt(legacyVerbosityFlag.Name)))
+		verbosity = ctx.GlobalInt(legacyVerbosityFlag.Name)
 		log.Warn("The flag --verbosity is deprecated and will be removed in the future, please use --log.verbosity")
 	}
 	if ctx.GlobalIsSet(verbosityFlag.Name) {
-		glogger.Verbosity(log.Lvl(ctx.GlobalInt(verbosityFlag.Name)))
+		verbosity = ctx.GlobalInt(verbosityFlag.Name)
 	}
+	glogger.Verbosity(log.Lvl(verbosity))
 
-	if vmodule := ctx.GlobalString(legacyVmoduleFlag.Name); vmodule != "" {
-		glogger.Vmodule(vmodule)
+	vmodule := ctx.GlobalString(vmoduleFlag.Name)
+	if v := ctx.GlobalString(legacyVmoduleFlag.Name); v != "" {
+		vmodule = v
 		log.Warn("The flag --vmodule is deprecated and will be removed in the future, please use --log.vmodule")
 	}
-	if vmodule := ctx.GlobalString(vmoduleFlag.Name); vmodule != "" {
-		glogger.Vmodule(vmodule)
+	if v := ctx.GlobalString(vmoduleFlag.Name); v != "" {
+		vmodule = v
 	}
+	glogger.Vmodule(vmodule)
 
-	if backtrace := ctx.GlobalString(legacyBacktraceAtFlag.Name); backtrace != "" {
-		glogger.BacktraceAt(backtrace)
+	backtrace := ctx.GlobalString(backtraceAtFlag.Name)
+	if b := ctx.GlobalString(legacyBacktraceAtFlag.Name); b != "" {
+		backtrace = b
 		log.Warn("The flag --backtrace is deprecated and will be removed in the future, please use --log.backtrace")
 	}
-	if backtrace := ctx.GlobalString(backtraceAtFlag.Name); backtrace != "" {
-		glogger.BacktraceAt(backtrace)
+	if b := ctx.GlobalString(backtraceAtFlag.Name); b != "" {
+		backtrace = b
 	}
+	glogger.BacktraceAt(backtrace)
 
 	log.Root().SetHandler(glogger)
 


### PR DESCRIPTION
This PR moves the flags `--debug`, `--backtrace` to the `log` namespace (i.e. `--log.backtrace`, etc.). It keeps the previous ones but marks them as deprecated. In case both the current and deprecated flags are passed, the deprecated has lower precedence.

I noticed that the `--memprofilerate` and `--blockprofilerate` are right now ineffective (they're always overridden even if `--pprof.memprofilerate` is not set). This is also fixed.