### PR TITLE
core: fix potential race in chainIndexerTest

### DIFF
--- a/core/chain_indexer_test.go
+++ b/core/chain_indexer_test.go
@@ -18,6 +18,7 @@ package core
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"math/big"
 	"math/rand"
@@ -224,7 +225,10 @@ func (b *testChainIndexBackend) Process(ctx context.Context, header *types.Heade
 	//t.processCh <- header.Number.Uint64()
 	select {
 	case <-time.After(10 * time.Second):
-		b.t.Fatal("Unexpected call to Process")
+		b.t.Error("Unexpected call to Process")
+		// Can't use Fatal since this is not the test's goroutine.
+		// Returning error stops the chainIndexer's updateLoop
+		return errors.New("Unexpected call to Process")
 	case b.processCh <- header.Number.Uint64():
 	}
 	return nil


### PR DESCRIPTION
Fixes #22318

I managed to reproduce the issue by commenting out this [line](https://github.com/ethereum/go-ethereum/blob/6ec15610443b28eabf665199f1dc5be2b3e3f7cb/core/chain_indexer_test.go#L228) to make [both](https://github.com/ethereum/go-ethereum/blob/6ec15610443b28eabf665199f1dc5be2b3e3f7cb/core/chain_indexer_test.go#L226) [timeouts](https://github.com/ethereum/go-ethereum/blob/6ec15610443b28eabf665199f1dc5be2b3e3f7cb/core/chain_indexer_test.go#L188). I think the problem is that as Peter pointed out `t.Fatal` is being called from a goroutine which is not the test's main routine. So I tried to stop `ChainIndexer.updateLoop` gracefully.