### PR TITLE
cmd/utils: disable caching preimages by default

### DIFF
--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -401,9 +401,9 @@ var (
 		Name:  "cache.noprefetch",
 		Usage: "Disable heuristic state prefetch during block import (less CPU and disk IO, more time waiting for data)",
 	}
-	CachePreimagesFlag = cli.BoolTFlag{
+	CachePreimagesFlag = cli.BoolFlag{
 		Name:  "cache.preimages",
-		Usage: "Enable recording the SHA3/keccak preimages of trie keys (default: true)",
+		Usage: "Enable recording the SHA3/keccak preimages of trie keys",
 	}
 	// Miner settings
 	MiningEnabledFlag = cli.BoolFlag{


### PR DESCRIPTION
This PR is another feature flip for 1.10, disabling the collection of trie preimages by default. These are only used by Remix debugging and there's no reason to have everyone track them. It shaves off about 5GB of a mainnet node. Note, existing data will not be cleaned from disk.

