### PR TITLE
update go mod version to match go build version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/ethereum/go-ethereum
 
-go 1.13
+go 1.15
 
 require (
 	github.com/Azure/azure-storage-blob-go v0.7.0


### PR DESCRIPTION
Updates the go.mod go version to match the [build version](https://github.com/ethereum/go-ethereum/blob/master/.travis.yml)

The changes to go.mod largely affect the default behavior of the GO111MODULE which is moot since the GO111MODULE is specifically specified in all of the commands