### PR TITLE
les: move server pool to les/vflux/client

### DIFF
--- a/internal/web3ext/web3ext.go
+++ b/internal/web3ext/web3ext.go
@@ -33,7 +33,7 @@ var Modules = map[string]string{
 	"swarmfs":    SwarmfsJs,
 	"txpool":     TxpoolJs,
 	"les":        LESJs,
-	"lespay":     LESPayJs,
+	"vflux":      VfluxJs,
 }
 
 const ChequebookJs = `
@@ -877,24 +877,24 @@ web3._extend({
 });
 `
 
-const LESPayJs = `
+const VfluxJs = `
 web3._extend({
-	property: 'lespay',
+	property: 'vflux',
 	methods:
 	[
 		new web3._extend.Method({
 			name: 'distribution',
-			call: 'lespay_distribution',
+			call: 'vflux_distribution',
 			params: 2
 		}),
 		new web3._extend.Method({
 			name: 'timeout',
-			call: 'lespay_timeout',
+			call: 'vflux_timeout',
 			params: 2
 		}),
 		new web3._extend.Method({
 			name: 'value',
-			call: 'lespay_value',
+			call: 'vflux_value',
 			params: 2
 		}),
 	],
@@ -902,7 +902,7 @@ web3._extend({
 	[
 		new web3._extend.Property({
 			name: 'requestStats',
-			getter: 'lespay_requestStats'
+			getter: 'vflux_requestStats'
 		}),
 	]
 });

--- a/les/client.go
+++ b/les/client.go
@@ -115,6 +115,7 @@ func New(stack *node.Node, config *ethconfig.Config) (*LightEthereum, error) {
 	}
 
 	leth.serverPool, leth.dialCandidates = vfc.NewServerPool(lesDb, []byte("serverpool:"), leth.valueTracker, time.Second, nil, &mclock.System{}, config.UltraLightServers)
+	leth.serverPool.AddMetrics(suggestedTimeoutGauge, totalValueGauge, serverSelectableGauge, serverConnectedGauge, sessionValueMeter, serverDialedMeter)
 
 	leth.retriever = newRetrieveManager(peers, leth.reqDist, leth.serverPool.GetTimeout)
 	leth.relay = newLesTxRelay(peers, leth.retriever)

--- a/les/client_handler.go
+++ b/les/client_handler.go
@@ -120,7 +120,7 @@ func (h *clientHandler) handle(p *serverPeer) error {
 		return err
 	}
 	if h.backend.serverPool != nil {
-		p.setValueTracker(h.backend.valueTracker, h.backend.serverPool.RegisterNode(p.Node()))
+		p.setValueTracker(h.backend.serverPool.RegisterNode(p.Node()))
 		p.updateVtParams()
 	}
 
@@ -129,7 +129,7 @@ func (h *clientHandler) handle(p *serverPeer) error {
 	connectedAt := mclock.Now()
 	defer func() {
 		if h.backend.serverPool != nil {
-			p.setValueTracker(nil, nil)
+			p.setValueTracker(nil)
 			h.backend.serverPool.UnregisterNode(p.Node())
 		}
 		h.backend.peers.unregister(p.id)

--- a/les/vflux/client/queueiterator_test.go
+++ b/les/vflux/client/queueiterator_test.go
@@ -26,17 +26,6 @@ import (
 	"github.com/ethereum/go-ethereum/p2p/nodestate"
 )
 
-func testNodeID(i int) enode.ID {
-	return enode.ID{42, byte(i % 256), byte(i / 256)}
-}
-
-func testNodeIndex(id enode.ID) int {
-	if id[0] != 42 {
-		return -1
-	}
-	return int(id[1]) + int(id[2])*256
-}
-
 func testNode(i int) *enode.Node {
 	return enode.SignNull(new(enr.Record), testNodeID(i))
 }

--- a/les/vflux/client/serverpool.go
+++ b/les/vflux/client/serverpool.go
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
 
-package les
+package client
 
 import (
 	"errors"
@@ -27,7 +27,6 @@ import (
 	"github.com/ethereum/go-ethereum/common/mclock"
 	"github.com/ethereum/go-ethereum/ethdb"
 	"github.com/ethereum/go-ethereum/les/utils"
-	vfc "github.com/ethereum/go-ethereum/les/vflux/client"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/p2p/enode"
 	"github.com/ethereum/go-ethereum/p2p/enr"
@@ -50,31 +49,31 @@ const (
 	maxQueryFails       = 100                    // number of consecutive UDP query failures before we print a warning
 )
 
-// serverPool provides a node iterator for dial candidates. The output is a mix of newly discovered
+// ServerPool provides a node iterator for dial candidates. The output is a mix of newly discovered
 // nodes, a weighted random selection of known (previously valuable) nodes and trusted/paid nodes.
-type serverPool struct {
+type ServerPool struct {
 	clock    mclock.Clock
 	unixTime func() int64
 	db       ethdb.KeyValueStore
 
 	ns           *nodestate.NodeStateMachine
-	vt           *vfc.ValueTracker
+	vt           *ValueTracker
 	mixer        *enode.FairMix
 	mixSources   []enode.Iterator
 	dialIterator enode.Iterator
 	validSchemes enr.IdentityScheme
 	trustedURLs  []string
-	fillSet      *vfc.FillSet
+	fillSet      *FillSet
 	queryFails   uint32
 
 	timeoutLock      sync.RWMutex
 	timeout          time.Duration
-	timeWeights      vfc.ResponseTimeWeights
+	timeWeights      ResponseTimeWeights
 	timeoutRefreshed mclock.AbsTime
 }
 
 // nodeHistory keeps track of dial costs which determine node weight together with the
-// service value calculated by vfc.ValueTracker.
+// service value calculated by ValueTracker.
 type nodeHistory struct {
 	dialCost                       utils.ExpiredValue
 	redialWaitStart, redialWaitEnd int64 // unix time (seconds)
@@ -91,18 +90,18 @@ type nodeHistoryEnc struct {
 type queryFunc func(*enode.Node) int
 
 var (
-	serverPoolSetup    = &nodestate.Setup{Version: 1}
-	sfHasValue         = serverPoolSetup.NewPersistentFlag("hasValue")
-	sfQueried          = serverPoolSetup.NewFlag("queried")
-	sfCanDial          = serverPoolSetup.NewFlag("canDial")
-	sfDialing          = serverPoolSetup.NewFlag("dialed")
-	sfWaitDialTimeout  = serverPoolSetup.NewFlag("dialTimeout")
-	sfConnected        = serverPoolSetup.NewFlag("connected")
-	sfRedialWait       = serverPoolSetup.NewFlag("redialWait")
-	sfAlwaysConnect    = serverPoolSetup.NewFlag("alwaysConnect")
+	clientSetup        = &nodestate.Setup{Version: 1}
+	sfHasValue         = clientSetup.NewPersistentFlag("hasValue")
+	sfQueried          = clientSetup.NewFlag("queried")
+	sfCanDial          = clientSetup.NewFlag("canDial")
+	sfDialing          = clientSetup.NewFlag("dialed")
+	sfWaitDialTimeout  = clientSetup.NewFlag("dialTimeout")
+	sfConnected        = clientSetup.NewFlag("connected")
+	sfRedialWait       = clientSetup.NewFlag("redialWait")
+	sfAlwaysConnect    = clientSetup.NewFlag("alwaysConnect")
 	sfDisableSelection = nodestate.MergeFlags(sfQueried, sfCanDial, sfDialing, sfConnected, sfRedialWait)
 
-	sfiNodeHistory = serverPoolSetup.NewPersistentField("nodeHistory", reflect.TypeOf(nodeHistory{}),
+	sfiNodeHistory = clientSetup.NewPersistentField("nodeHistory", reflect.TypeOf(nodeHistory{}),
 		func(field interface{}) ([]byte, error) {
 			if n, ok := field.(nodeHistory); ok {
 				ne := nodeHistoryEnc{
@@ -126,25 +125,25 @@ var (
 			return n, err
 		},
 	)
-	sfiNodeWeight     = serverPoolSetup.NewField("nodeWeight", reflect.TypeOf(uint64(0)))
-	sfiConnectedStats = serverPoolSetup.NewField("connectedStats", reflect.TypeOf(vfc.ResponseTimeStats{}))
+	sfiNodeWeight     = clientSetup.NewField("nodeWeight", reflect.TypeOf(uint64(0)))
+	sfiConnectedStats = clientSetup.NewField("connectedStats", reflect.TypeOf(ResponseTimeStats{}))
 )
 
 // newServerPool creates a new server pool
-func newServerPool(db ethdb.KeyValueStore, dbKey []byte, vt *vfc.ValueTracker, mixTimeout time.Duration, query queryFunc, clock mclock.Clock, trustedURLs []string) *serverPool {
-	s := &serverPool{
+func NewServerPool(db ethdb.KeyValueStore, dbKey []byte, vt *ValueTracker, mixTimeout time.Duration, query queryFunc, clock mclock.Clock, trustedURLs []string) (*ServerPool, enode.Iterator) {
+	s := &ServerPool{
 		db:           db,
 		clock:        clock,
 		unixTime:     func() int64 { return time.Now().Unix() },
 		validSchemes: enode.ValidSchemes,
 		trustedURLs:  trustedURLs,
 		vt:           vt,
-		ns:           nodestate.NewNodeStateMachine(db, []byte(string(dbKey)+"ns:"), clock, serverPoolSetup),
+		ns:           nodestate.NewNodeStateMachine(db, []byte(string(dbKey)+"ns:"), clock, clientSetup),
 	}
 	s.recalTimeout()
 	s.mixer = enode.NewFairMix(mixTimeout)
-	knownSelector := vfc.NewWrsIterator(s.ns, sfHasValue, sfDisableSelection, sfiNodeWeight)
-	alwaysConnect := vfc.NewQueueIterator(s.ns, sfAlwaysConnect, sfDisableSelection, true, nil)
+	knownSelector := NewWrsIterator(s.ns, sfHasValue, sfDisableSelection, sfiNodeWeight)
+	alwaysConnect := NewQueueIterator(s.ns, sfAlwaysConnect, sfDisableSelection, true, nil)
 	s.mixSources = append(s.mixSources, knownSelector)
 	s.mixSources = append(s.mixSources, alwaysConnect)
 
@@ -166,14 +165,15 @@ func newServerPool(db ethdb.KeyValueStore, dbKey []byte, vt *vfc.ValueTracker, m
 		}
 	})
 
-	s.ns.AddLogMetrics(sfHasValue, sfDisableSelection, "selectable", nil, nil, serverSelectableGauge)
+	//TODO
+	/*s.ns.AddLogMetrics(sfHasValue, sfDisableSelection, "selectable", nil, nil, serverSelectableGauge)
 	s.ns.AddLogMetrics(sfDialing, nodestate.Flags{}, "dialed", serverDialedMeter, nil, nil)
-	s.ns.AddLogMetrics(sfConnected, nodestate.Flags{}, "connected", nil, nil, serverConnectedGauge)
-	return s
+	s.ns.AddLogMetrics(sfConnected, nodestate.Flags{}, "connected", nil, nil, serverConnectedGauge)*/
+	return s, s.dialIterator
 }
 
-// addSource adds a node discovery source to the server pool (should be called before start)
-func (s *serverPool) addSource(source enode.Iterator) {
+// AddSource adds a node discovery source to the server pool (should be called before start)
+func (s *ServerPool) AddSource(source enode.Iterator) {
 	if source != nil {
 		s.mixSources = append(s.mixSources, source)
 	}
@@ -182,8 +182,8 @@ func (s *serverPool) addSource(source enode.Iterator) {
 // addPreNegFilter installs a node filter mechanism that performs a pre-negotiation query.
 // Nodes that are filtered out and does not appear on the output iterator are put back
 // into redialWait state.
-func (s *serverPool) addPreNegFilter(input enode.Iterator, query queryFunc) enode.Iterator {
-	s.fillSet = vfc.NewFillSet(s.ns, input, sfQueried)
+func (s *ServerPool) addPreNegFilter(input enode.Iterator, query queryFunc) enode.Iterator {
+	s.fillSet = NewFillSet(s.ns, input, sfQueried)
 	s.ns.SubscribeState(sfQueried, func(n *enode.Node, oldState, newState nodestate.Flags) {
 		if newState.Equals(sfQueried) {
 			fails := atomic.LoadUint32(&s.queryFails)
@@ -221,7 +221,7 @@ func (s *serverPool) addPreNegFilter(input enode.Iterator, query queryFunc) enod
 			}()
 		}
 	})
-	return vfc.NewQueueIterator(s.ns, sfCanDial, nodestate.Flags{}, false, func(waiting bool) {
+	return NewQueueIterator(s.ns, sfCanDial, nodestate.Flags{}, false, func(waiting bool) {
 		if waiting {
 			s.fillSet.SetTarget(preNegLimit)
 		} else {
@@ -231,7 +231,7 @@ func (s *serverPool) addPreNegFilter(input enode.Iterator, query queryFunc) enod
 }
 
 // start starts the server pool. Note that NodeStateMachine should be started first.
-func (s *serverPool) start() {
+func (s *ServerPool) Start() {
 	s.ns.Start()
 	for _, iter := range s.mixSources {
 		// add sources to mixer at startup because the mixer instantly tries to read them
@@ -264,7 +264,7 @@ func (s *serverPool) start() {
 }
 
 // stop stops the server pool
-func (s *serverPool) stop() {
+func (s *ServerPool) Stop() {
 	s.dialIterator.Close()
 	if s.fillSet != nil {
 		s.fillSet.Close()
@@ -279,29 +279,27 @@ func (s *serverPool) stop() {
 }
 
 // registerPeer implements serverPeerSubscriber
-func (s *serverPool) registerPeer(p *serverPeer) {
-	s.ns.SetState(p.Node(), sfConnected, sfDialing.Or(sfWaitDialTimeout), 0)
-	nvt := s.vt.Register(p.ID())
-	s.ns.SetField(p.Node(), sfiConnectedStats, nvt.RtStats())
-	p.setValueTracker(s.vt, nvt)
-	p.updateVtParams()
+func (s *ServerPool) RegisterNode(node *enode.Node) *NodeValueTracker {
+	s.ns.SetState(node, sfConnected, sfDialing.Or(sfWaitDialTimeout), 0)
+	nvt := s.vt.Register(node.ID())
+	s.ns.SetField(node, sfiConnectedStats, nvt.RtStats())
+	return nvt
 }
 
 // unregisterPeer implements serverPeerSubscriber
-func (s *serverPool) unregisterPeer(p *serverPeer) {
+func (s *ServerPool) UnregisterNode(node *enode.Node) {
 	s.ns.Operation(func() {
-		s.setRedialWait(p.Node(), dialCost, dialWaitStep)
-		s.ns.SetStateSub(p.Node(), nodestate.Flags{}, sfConnected, 0)
-		s.ns.SetFieldSub(p.Node(), sfiConnectedStats, nil)
+		s.setRedialWait(node, dialCost, dialWaitStep)
+		s.ns.SetStateSub(node, nodestate.Flags{}, sfConnected, 0)
+		s.ns.SetFieldSub(node, sfiConnectedStats, nil)
 	})
-	s.vt.Unregister(p.ID())
-	p.setValueTracker(nil, nil)
+	s.vt.Unregister(node.ID())
 }
 
 // recalTimeout calculates the current recommended timeout. This value is used by
 // the client as a "soft timeout" value. It also affects the service value calculation
 // of individual nodes.
-func (s *serverPool) recalTimeout() {
+func (s *ServerPool) recalTimeout() {
 	// Use cached result if possible, avoid recalculating too frequently.
 	s.timeoutLock.RLock()
 	refreshed := s.timeoutRefreshed
@@ -330,17 +328,18 @@ func (s *serverPool) recalTimeout() {
 	s.timeoutLock.Lock()
 	if s.timeout != timeout {
 		s.timeout = timeout
-		s.timeWeights = vfc.TimeoutWeights(s.timeout)
+		s.timeWeights = TimeoutWeights(s.timeout)
 
-		suggestedTimeoutGauge.Update(int64(s.timeout / time.Millisecond))
-		totalValueGauge.Update(int64(rts.Value(s.timeWeights, s.vt.StatsExpFactor())))
+		//TODO
+		/*suggestedTimeoutGauge.Update(int64(s.timeout / time.Millisecond))
+		totalValueGauge.Update(int64(rts.Value(s.timeWeights, s.vt.StatsExpFactor())))*/
 	}
 	s.timeoutRefreshed = now
 	s.timeoutLock.Unlock()
 }
 
-// getTimeout returns the recommended request timeout.
-func (s *serverPool) getTimeout() time.Duration {
+// GetTimeout returns the recommended request timeout.
+func (s *ServerPool) GetTimeout() time.Duration {
 	s.recalTimeout()
 	s.timeoutLock.RLock()
 	defer s.timeoutLock.RUnlock()
@@ -349,7 +348,7 @@ func (s *serverPool) getTimeout() time.Duration {
 
 // getTimeoutAndWeight returns the recommended request timeout as well as the
 // response time weight which is necessary to calculate service value.
-func (s *serverPool) getTimeoutAndWeight() (time.Duration, vfc.ResponseTimeWeights) {
+func (s *ServerPool) getTimeoutAndWeight() (time.Duration, ResponseTimeWeights) {
 	s.recalTimeout()
 	s.timeoutLock.RLock()
 	defer s.timeoutLock.RUnlock()
@@ -358,7 +357,7 @@ func (s *serverPool) getTimeoutAndWeight() (time.Duration, vfc.ResponseTimeWeigh
 
 // addDialCost adds the given amount of dial cost to the node history and returns the current
 // amount of total dial cost
-func (s *serverPool) addDialCost(n *nodeHistory, amount int64) uint64 {
+func (s *ServerPool) addDialCost(n *nodeHistory, amount int64) uint64 {
 	logOffset := s.vt.StatsExpirer().LogOffset(s.clock.Now())
 	if amount > 0 {
 		n.dialCost.Add(amount, logOffset)
@@ -371,7 +370,7 @@ func (s *serverPool) addDialCost(n *nodeHistory, amount int64) uint64 {
 }
 
 // serviceValue returns the service value accumulated in this session and in total
-func (s *serverPool) serviceValue(node *enode.Node) (sessionValue, totalValue float64) {
+func (s *ServerPool) serviceValue(node *enode.Node) (sessionValue, totalValue float64) {
 	nvt := s.vt.GetNode(node.ID())
 	if nvt == nil {
 		return 0, 0
@@ -381,11 +380,12 @@ func (s *serverPool) serviceValue(node *enode.Node) (sessionValue, totalValue fl
 	expFactor := s.vt.StatsExpFactor()
 
 	totalValue = currentStats.Value(timeWeights, expFactor)
-	if connStats, ok := s.ns.GetField(node, sfiConnectedStats).(vfc.ResponseTimeStats); ok {
+	if connStats, ok := s.ns.GetField(node, sfiConnectedStats).(ResponseTimeStats); ok {
 		diff := currentStats
 		diff.SubStats(&connStats)
 		sessionValue = diff.Value(timeWeights, expFactor)
-		sessionValueMeter.Mark(int64(sessionValue))
+		//TODO
+		//sessionValueMeter.Mark(int64(sessionValue))
 	}
 	return
 }
@@ -393,7 +393,7 @@ func (s *serverPool) serviceValue(node *enode.Node) (sessionValue, totalValue fl
 // updateWeight calculates the node weight and updates the nodeWeight field and the
 // hasValue flag. It also saves the node state if necessary.
 // Note: this function should run inside a NodeStateMachine operation
-func (s *serverPool) updateWeight(node *enode.Node, totalValue float64, totalDialCost uint64) {
+func (s *ServerPool) updateWeight(node *enode.Node, totalValue float64, totalDialCost uint64) {
 	weight := uint64(totalValue * nodeWeightMul / float64(totalDialCost))
 	if weight >= nodeWeightThreshold {
 		s.ns.SetStateSub(node, sfHasValue, nodestate.Flags{}, 0)
@@ -415,7 +415,7 @@ func (s *serverPool) updateWeight(node *enode.Node, totalValue float64, totalDia
 // to the minimum.
 // Note: node weight is also recalculated and updated by this function.
 // Note 2: this function should run inside a NodeStateMachine operation
-func (s *serverPool) setRedialWait(node *enode.Node, addDialCost int64, waitStep float64) {
+func (s *ServerPool) setRedialWait(node *enode.Node, addDialCost int64, waitStep float64) {
 	n, _ := s.ns.GetField(node, sfiNodeHistory).(nodeHistory)
 	sessionValue, totalValue := s.serviceValue(node)
 	totalDialCost := s.addDialCost(&n, addDialCost)
@@ -481,7 +481,7 @@ func (s *serverPool) setRedialWait(node *enode.Node, addDialCost int64, waitStep
 // This function should be called during startup and shutdown only, otherwise setRedialWait
 // will keep the weights updated as the underlying statistics are adjusted.
 // Note: this function should run inside a NodeStateMachine operation
-func (s *serverPool) calculateWeight(node *enode.Node) {
+func (s *ServerPool) calculateWeight(node *enode.Node) {
 	n, _ := s.ns.GetField(node, sfiNodeHistory).(nodeHistory)
 	_, totalValue := s.serviceValue(node)
 	totalDialCost := s.addDialCost(&n, 0)

--- a/les/vflux/client/serverpool_test.go
+++ b/les/vflux/client/serverpool_test.go
@@ -14,10 +14,11 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
 
-package les
+package client
 
 import (
 	"math/rand"
+	"strconv"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -25,8 +26,6 @@ import (
 	"github.com/ethereum/go-ethereum/common/mclock"
 	"github.com/ethereum/go-ethereum/ethdb"
 	"github.com/ethereum/go-ethereum/ethdb/memorydb"
-	vfc "github.com/ethereum/go-ethereum/les/vflux/client"
-	"github.com/ethereum/go-ethereum/p2p"
 	"github.com/ethereum/go-ethereum/p2p/enode"
 	"github.com/ethereum/go-ethereum/p2p/enr"
 )
@@ -50,13 +49,13 @@ func testNodeIndex(id enode.ID) int {
 	return int(id[1]) + int(id[2])*256
 }
 
-type serverPoolTest struct {
+type ServerPoolTest struct {
 	db                   ethdb.KeyValueStore
 	clock                *mclock.Simulated
 	quit                 chan struct{}
 	preNeg, preNegFail   bool
-	vt                   *vfc.ValueTracker
-	sp                   *serverPool
+	vt                   *ValueTracker
+	sp                   *ServerPool
 	input                enode.Iterator
 	testNodes            []spTestNode
 	trusted              []string
@@ -71,15 +70,15 @@ type spTestNode struct {
 	connectCycles, waitCycles int
 	nextConnCycle, totalConn  int
 	connected, service        bool
-	peer                      *serverPeer
+	node                      *enode.Node
 }
 
-func newServerPoolTest(preNeg, preNegFail bool) *serverPoolTest {
+func newServerPoolTest(preNeg, preNegFail bool) *ServerPoolTest {
 	nodes := make([]*enode.Node, spTestNodes)
 	for i := range nodes {
 		nodes[i] = enode.SignNull(&enr.Record{}, testNodeID(i))
 	}
-	return &serverPoolTest{
+	return &ServerPoolTest{
 		clock:      &mclock.Simulated{},
 		db:         memorydb.New(),
 		input:      enode.CycleNodes(nodes),
@@ -89,7 +88,7 @@ func newServerPoolTest(preNeg, preNegFail bool) *serverPoolTest {
 	}
 }
 
-func (s *serverPoolTest) beginWait() {
+func (s *ServerPoolTest) beginWait() {
 	// ensure that dialIterator and the maximal number of pre-neg queries are not all stuck in a waiting state
 	for atomic.AddInt32(&s.waitCount, 1) > preNegLimit {
 		atomic.AddInt32(&s.waitCount, -1)
@@ -97,16 +96,16 @@ func (s *serverPoolTest) beginWait() {
 	}
 }
 
-func (s *serverPoolTest) endWait() {
+func (s *ServerPoolTest) endWait() {
 	atomic.AddInt32(&s.waitCount, -1)
 	atomic.AddInt32(&s.waitEnded, 1)
 }
 
-func (s *serverPoolTest) addTrusted(i int) {
+func (s *ServerPoolTest) addTrusted(i int) {
 	s.trusted = append(s.trusted, enode.SignNull(&enr.Record{}, testNodeID(i)).String())
 }
 
-func (s *serverPoolTest) start() {
+func (s *ServerPoolTest) start() {
 	var testQuery queryFunc
 	if s.preNeg {
 		testQuery = func(node *enode.Node) int {
@@ -144,8 +143,13 @@ func (s *serverPoolTest) start() {
 		}
 	}
 
-	s.vt = vfc.NewValueTracker(s.db, s.clock, requestList, time.Minute, 1/float64(time.Hour), 1/float64(time.Hour*100), 1/float64(time.Hour*1000))
-	s.sp = newServerPool(s.db, []byte("serverpool:"), s.vt, 0, testQuery, s.clock, s.trusted)
+	requestList := make([]RequestInfo, testReqTypes)
+	for i := range requestList {
+		requestList[i] = RequestInfo{Name: "testreq" + strconv.Itoa(i), InitAmount: 1, InitValue: 1}
+	}
+
+	s.vt = NewValueTracker(s.db, s.clock, requestList, time.Minute, 1/float64(time.Hour), 1/float64(time.Hour*100), 1/float64(time.Hour*1000))
+	s.sp = newServerPool(s.db, []byte("ServerPool:"), s.vt, 0, testQuery, s.clock, s.trusted)
 	s.sp.addSource(s.input)
 	s.sp.validSchemes = enode.ValidSchemesForTesting
 	s.sp.unixTime = func() int64 { return int64(s.clock.Now()) / int64(time.Second) }
@@ -170,7 +174,7 @@ func (s *serverPoolTest) start() {
 	}()
 }
 
-func (s *serverPoolTest) stop() {
+func (s *ServerPoolTest) stop() {
 	close(s.quit)
 	s.sp.stop()
 	s.vt.Stop()
@@ -180,21 +184,21 @@ func (s *serverPoolTest) stop() {
 			n.totalConn += s.cycle
 		}
 		n.connected = false
-		n.peer = nil
+		n.node = nil
 		n.nextConnCycle = 0
 	}
 	s.conn, s.servedConn = 0, 0
 }
 
-func (s *serverPoolTest) run() {
+func (s *ServerPoolTest) run() {
 	for count := spTestLength; count > 0; count-- {
 		if dcList := s.disconnect[s.cycle]; dcList != nil {
 			for _, idx := range dcList {
 				n := &s.testNodes[idx]
-				s.sp.unregisterPeer(n.peer)
+				s.sp.UnregisterNode(n.node)
 				n.totalConn += s.cycle
 				n.connected = false
-				n.peer = nil
+				n.node = nil
 				s.conn--
 				if n.service {
 					s.servedConn--
@@ -221,10 +225,10 @@ func (s *serverPoolTest) run() {
 				n.connected = true
 				dc := s.cycle + n.connectCycles
 				s.disconnect[dc] = append(s.disconnect[dc], idx)
-				n.peer = &serverPeer{peerCommons: peerCommons{Peer: p2p.NewPeer(id, "", nil)}}
-				s.sp.registerPeer(n.peer)
+				n.node = dial
+				s.sp.RegisterNode(n.node)
 				if n.service {
-					s.vt.Served(s.vt.GetNode(id), []vfc.ServedRequest{{ReqType: 0, Amount: 100}}, 0)
+					s.vt.Served(s.vt.GetNode(id), []ServedRequest{{ReqType: 0, Amount: 100}}, 0)
 				}
 			}
 		}
@@ -234,7 +238,7 @@ func (s *serverPoolTest) run() {
 	}
 }
 
-func (s *serverPoolTest) setNodes(count, conn, wait int, service, trusted bool) (res []int) {
+func (s *ServerPoolTest) setNodes(count, conn, wait int, service, trusted bool) (res []int) {
 	for ; count > 0; count-- {
 		idx := rand.Intn(spTestNodes)
 		for s.testNodes[idx].connectCycles != 0 || s.testNodes[idx].connected {
@@ -253,11 +257,11 @@ func (s *serverPoolTest) setNodes(count, conn, wait int, service, trusted bool) 
 	return
 }
 
-func (s *serverPoolTest) resetNodes() {
+func (s *ServerPoolTest) resetNodes() {
 	for i, n := range s.testNodes {
 		if n.connected {
 			n.totalConn += s.cycle
-			s.sp.unregisterPeer(n.peer)
+			s.sp.UnregisterNode(n.node)
 		}
 		s.testNodes[i] = spTestNode{totalConn: n.totalConn}
 	}
@@ -266,7 +270,7 @@ func (s *serverPoolTest) resetNodes() {
 	s.trusted = nil
 }
 
-func (s *serverPoolTest) checkNodes(t *testing.T, nodes []int) {
+func (s *ServerPoolTest) checkNodes(t *testing.T, nodes []int) {
 	var sum int
 	for _, idx := range nodes {
 		n := &s.testNodes[idx]

--- a/les/vflux/client/valuetracker_test.go
+++ b/les/vflux/client/valuetracker_test.go
@@ -64,7 +64,7 @@ func TestValueTracker(t *testing.T) {
 			for j := range costList {
 				costList[j] = uint64(baseCost * relPrices[j])
 			}
-			vt.UpdateCosts(nodes[i], costList)
+			nodes[i].UpdateCosts(costList)
 		}
 		for i := range nodes {
 			nodes[i] = vt.Register(enode.ID{byte(i)})
@@ -77,7 +77,7 @@ func TestValueTracker(t *testing.T) {
 				node := rand.Intn(testNodeCount)
 				respTime := time.Duration((rand.Float64() + 1) * float64(time.Second) * float64(node+1) / testNodeCount)
 				totalAmount[reqType] += uint64(reqAmount)
-				vt.Served(nodes[node], []ServedRequest{{uint32(reqType), uint32(reqAmount)}}, respTime)
+				nodes[node].Served([]ServedRequest{{uint32(reqType), uint32(reqAmount)}}, respTime)
 				clock.Run(time.Second)
 			}
 		} else {


### PR DESCRIPTION
This PR moves the server pool into the `les/vflux/client` package where the rest of the peer logic is, leaving package `les` for client functionality and protocol implementation. The value tracker is also created by the server pool. Only the `NodeValueTracker` of individual connected nodes is referenced by `serverPeer` in order to provide service quality feedback for the peer logic.

Replaces https://github.com/ethereum/go-ethereum/pull/22297
Fixes https://github.com/ethereum/go-ethereum/issues/22259

Note: a subsequent PR will move the `clientPool` into `les/vflux/server`, removing all peerset related complexity and all references to `NodeStateMachine` from package `les`.