### PR TITLE
[FIXED ERROR] CAPITALIZATION of Ethereum. Please merge!

### DIFF
--- a/node/api.go
+++ b/node/api.go
@@ -1,18 +1,18 @@
-// Copyright 2015 The go-ethereum Authors
-// This file is part of the go-ethereum library.
+// Copyright 2015 The go-Ethereum Authors
+// This file is part of the go-Ethereum library.
 //
-// The go-ethereum library is free software: you can redistribute it and/or modify
+// The go-Ethereum library is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Lesser General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
 //
-// The go-ethereum library is distributed in the hope that it will be useful,
+// The go-Ethereum library is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU Lesser General Public License for more details.
 //
 // You should have received a copy of the GNU Lesser General Public License
-// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+// along with the go-Ethereum library. If not, see <http://www.gnu.org/licenses/>.
 
 package node
 
@@ -321,7 +321,7 @@ func (s *publicWeb3API) ClientVersion() string {
 	return s.stack.Server().Name
 }
 
-// Sha3 applies the ethereum sha3 implementation on the input.
+// Sha3 applies the Ethereum sha3 implementation on the input.
 // It assumes the input is hex encoded.
 func (s *publicWeb3API) Sha3(input hexutil.Bytes) hexutil.Bytes {
 	return crypto.Keccak256(input)


### PR DESCRIPTION
Please-
This fixes the capitalization from "ethereum" to "Ethereum." The way it is supposed to be to give the RESPECT it deserves. PLEASE MERGE I WANT TO BE PART OF HISTORY!!!!!