### PR TITLE
eth/protocols/snap: lower abortion and resumption logs to debug

### DIFF
--- a/eth/protocols/snap/sync.go
+++ b/eth/protocols/snap/sync.go
@@ -1595,7 +1595,7 @@ func (s *Syncer) processAccountResponse(res *accountResponse) {
 				// is interrupted and resumed later. However, *do* update the
 				// previous root hash.
 				if subtasks, ok := res.task.SubTasks[res.hashes[i]]; ok {
-					log.Error("Resuming large storage retrieval", "account", res.hashes[i], "root", account.Root)
+					log.Debug("Resuming large storage retrieval", "account", res.hashes[i], "root", account.Root)
 					for _, subtask := range subtasks {
 						subtask.root = account.Root
 					}
@@ -1614,7 +1614,7 @@ func (s *Syncer) processAccountResponse(res *accountResponse) {
 	// now we have to live with that.
 	for hash := range res.task.SubTasks {
 		if _, ok := resumed[hash]; !ok {
-			log.Error("Aborting suspended storage retrieval", "account", hash)
+			log.Debug("Aborting suspended storage retrieval", "account", hash)
 			delete(res.task.SubTasks, hash)
 		}
 	}


### PR DESCRIPTION
I accidentally left the snap sync resumption logs on Error to see what's going on without the noise. This PR lowers it back down to debug.