### PR TITLE
core/state: fix eta calculation on pruning

### DIFF
--- a/core/state/pruner/pruner.go
+++ b/core/state/pruner/pruner.go
@@ -155,7 +155,7 @@ func prune(maindb ethdb.Database, stateBloom *stateBloom, middleStateRoots map[c
 			if done := binary.BigEndian.Uint64(key[:8]); done > 0 {
 				var (
 					left  = math.MaxUint64 - binary.BigEndian.Uint64(key[:8])
-					speed = done/uint64(time.Since(start)/time.Millisecond+1) + 1 // +1s to avoid division by zero
+					speed = done/uint64(time.Since(pstart)/time.Millisecond+1) + 1 // +1s to avoid division by zero
 				)
 				eta = time.Duration(left/speed) * time.Millisecond
 			}


### PR DESCRIPTION
```
root@mon02:/datadrive# docker run -v /datadrive:/datadir -it ethereum/client-go  --datadir=/datadir/geth  snapshot prune-state                                                                  ...  
INFO [02-26|12:40:18.730] Iterating state snapshot                 accounts=0 slots=0 elapsed="118.987µs"
INFO [02-26|12:40:26.730] Iterating state snapshot                 accounts=126708 slots=186080 elapsed=8.000s      eta=2h5m46.954s

INFO [02-26|14:00:38.239] Iterated snapshot                        accounts=119817571 slots=414421589 elapsed=1h20m19.509s
INFO [02-26|14:00:59.508] Writing state bloom to disk              name=/datadir/geth/geth/statebloom.0xef2542a6cd3a64ca7188de8d682a3fad85c9e9e732df20a4d99da177263a7fa4.bf.gz
INFO [02-26|14:03:32.428] State bloom filter committed             name=/datadir/geth/geth/statebloom.0xef2542a6cd3a64ca7188de8d682a3fad85c9e9e732df20a4d99da177263a7fa4.bf.gz
INFO [02-26|14:03:40.428] Pruning state data                       nodes=837506 size=218.19MiB elapsed=8.000s       eta=208h26m17.558s
...
INFO [02-26|14:12:37.865] Pruning state data                       nodes=47986709 size=12.22GiB  elapsed=9m5.437s     eta=2h31m5.014s
...
INFO [02-26|14:39:12.435] Pruning state data                       nodes=126099024 size=32.11GiB  elapsed=35m40.006s   eta=22.854s
INFO [02-26|14:39:15.933] Pruned state data                        nodes=126503269 size=32.21GiB  elapsed=35m43.504s
INFO [02-26|14:39:15.933] Compacting database                      range=0x00-0x10 elapsed="3.017µs"

```
^ it's a bit overly pessimistic when estimating the pruning -time, obviously. ETA `208h`, finishes pruning in `35m`. 

I think this PR fixes it. 