### PR TITLE
cmd/geth: disable snapshotter in export cmd

### DIFF
--- a/cmd/geth/chaincmd.go
+++ b/cmd/geth/chaincmd.go
@@ -110,6 +110,7 @@ processing will proceed even if an individual RLP-file import failure occurs.`,
 			utils.DataDirFlag,
 			utils.CacheFlag,
 			utils.SyncModeFlag,
+			utils.SnapshotFlag,
 		},
 		Category: "BLOCKCHAIN COMMANDS",
 		Description: `

--- a/cmd/geth/chaincmd.go
+++ b/cmd/geth/chaincmd.go
@@ -110,7 +110,6 @@ processing will proceed even if an individual RLP-file import failure occurs.`,
 			utils.DataDirFlag,
 			utils.CacheFlag,
 			utils.SyncModeFlag,
-			utils.SnapshotFlag,
 		},
 		Category: "BLOCKCHAIN COMMANDS",
 		Description: `
@@ -324,6 +323,9 @@ func exportChain(ctx *cli.Context) error {
 
 	stack, _ := makeConfigNode(ctx)
 	defer stack.Close()
+
+	// Disable snapshotter by default
+	ctx.GlobalSet(utils.SnapshotFlag.Name, "false")
 
 	chain, _ := utils.MakeChain(ctx, stack, true)
 	start := time.Now()


### PR DESCRIPTION
The export command has snapshotter enabled by default even though it's not necessary. This PR disables it.

If I'm not mistaken every command that uses `MakeChain` will have it enabled by default. The 2 other cmds I'm unsure if they need snapshots are `copydb` and `dump` (I'm guessing they do).