### PR TITLE
core: cache nonces for tx validation

### DIFF
--- a/core/tx_pool.go
+++ b/core/tx_pool.go
@@ -232,6 +232,7 @@ type TxPool struct {
 	eip2718  bool // Fork indicator whether we are using EIP-2718 type transactions.
 
 	currentState  *state.StateDB // Current state in the blockchain head
+	currentNonces *txNoncer      // Current state tracking for nonces
 	pendingNonces *txNoncer      // Pending state tracking virtual nonces
 	currentMaxGas uint64         // Current gas limit for transaction caps
 
@@ -550,7 +551,7 @@ func (pool *TxPool) validateTx(tx *types.Transaction, local bool) error {
 		return ErrUnderpriced
 	}
 	// Ensure the transaction adheres to nonce ordering
-	if pool.currentState.GetNonce(from) > tx.Nonce() {
+	if pool.currentNonces.get(from) > tx.Nonce() {
 		return ErrNonceTooLow
 	}
 	// Transactor should have enough funds to cover the costs
@@ -1194,6 +1195,7 @@ func (pool *TxPool) reset(oldHead, newHead *types.Header) {
 	}
 	pool.currentState = statedb
 	pool.pendingNonces = newTxNoncer(statedb)
+	pool.currentNonces = newTxNoncer(statedb)
 	pool.currentMaxGas = newHead.GasLimit
 
 	// Inject any transactions discarded due to reorgs


### PR DESCRIPTION
Currently a lot of time is spent on validating incoming transactions, especially by getting the current nonce from the state
```
         .          .    547:   // Ensure the transaction adheres to nonce ordering
         .      6.12s    548:   if pool.currentState.GetNonce(from) > tx.Nonce() {
         .          .    549:           return ErrNonceTooLow
         .          .    550:   }
```
This PR introduces caching to the nonces, s.th. they don't have to be retrieved from the current state on every tx.

One potential caveat is that the cache is invalidated on every new head. 
Another one is that the stateDB has it's own caching algorithm.
Still retrieving from stateDB (even from snapshot) has quite a big overhead for simply retrieving a nonce.

Another thing to note is that we can not use the existing TxNoncer (`pendingNonces`) as it is polluted by e.g. promoting transactions or running reorgs