### PR TITLE
les: allow either full enode strings or raw hex ids in the API

### DIFF
--- a/les/api.go
+++ b/les/api.go
@@ -49,6 +49,18 @@ func NewPrivateLightServerAPI(server *LesServer) *PrivateLightServerAPI {
 	}
 }
 
+// parseNode parses either an enode address a raw hex node id
+func parseNode(node string) (enode.ID, error) {
+	if id, err := enode.ParseID(node); err == nil {
+		return id, nil
+	}
+	if node, err := enode.Parse(enode.ValidSchemes, node); err == nil {
+		return node.ID(), nil
+	} else {
+		return enode.ID{}, err
+	}
+}
+
 // ServerInfo returns global server parameters
 func (api *PrivateLightServerAPI) ServerInfo() map[string]interface{} {
 	res := make(map[string]interface{})
@@ -59,7 +71,14 @@ func (api *PrivateLightServerAPI) ServerInfo() map[string]interface{} {
 }
 
 // ClientInfo returns information about clients listed in the ids list or matching the given tags
-func (api *PrivateLightServerAPI) ClientInfo(ids []enode.ID) map[enode.ID]map[string]interface{} {
+func (api *PrivateLightServerAPI) ClientInfo(nodes []string) map[enode.ID]map[string]interface{} {
+	var ids []enode.ID
+	for _, node := range nodes {
+		if id, err := parseNode(node); err == nil {
+			ids = append(ids, id)
+		}
+	}
+
 	res := make(map[enode.ID]map[string]interface{})
 	api.server.clientPool.forClients(ids, func(client *clientInfo) {
 		res[client.node.ID()] = api.clientInfo(client)
@@ -159,8 +178,18 @@ func (api *PrivateLightServerAPI) setParams(params map[string]interface{}, clien
 
 // SetClientParams sets client parameters for all clients listed in the ids list
 // or all connected clients if the list is empty
-func (api *PrivateLightServerAPI) SetClientParams(ids []enode.ID, params map[string]interface{}) error {
-	var err error
+func (api *PrivateLightServerAPI) SetClientParams(nodes []string, params map[string]interface{}) error {
+	var (
+		ids []enode.ID
+		err error
+	)
+	for _, node := range nodes {
+		if id, err := parseNode(node); err != nil {
+			return err
+		} else {
+			ids = append(ids, id)
+		}
+	}
 	api.server.clientPool.forClients(ids, func(client *clientInfo) {
 		if client.connected {
 			posFactors, negFactors := client.balance.GetPriceFactors()
@@ -201,7 +230,11 @@ func (api *PrivateLightServerAPI) SetConnectedBias(bias time.Duration) error {
 
 // AddBalance adds the given amount to the balance of a client if possible and returns
 // the balance before and after the operation
-func (api *PrivateLightServerAPI) AddBalance(id enode.ID, amount int64) (balance [2]uint64, err error) {
+func (api *PrivateLightServerAPI) AddBalance(node string, amount int64) (balance [2]uint64, err error) {
+	var id enode.ID
+	if id, err = parseNode(node); err != nil {
+		return
+	}
 	api.server.clientPool.forClients([]enode.ID{id}, func(c *clientInfo) {
 		balance[0], balance[1], err = c.balance.AddBalance(amount)
 	})
@@ -297,8 +330,14 @@ func NewPrivateDebugAPI(server *LesServer) *PrivateDebugAPI {
 }
 
 // FreezeClient forces a temporary client freeze which normally happens when the server is overloaded
-func (api *PrivateDebugAPI) FreezeClient(id enode.ID) error {
-	var err error
+func (api *PrivateDebugAPI) FreezeClient(node string) error {
+	var (
+		id  enode.ID
+		err error
+	)
+	if id, err = parseNode(node); err != nil {
+		return err
+	}
 	api.server.clientPool.forClients([]enode.ID{id}, func(c *clientInfo) {
 		if c.connected {
 			c.peer.freeze()


### PR DESCRIPTION
This PR improves the LES priority API functions by accepting both raw hex node IDs (like before) and full enode strings.

Now each of the following forms are accepted:
```
les.addBalance("8d3797578a393adbe77af76c6d0f6fee8c4d402d235ad9fa93f8f20eb9bc0dad", 10000000000000)
les.addBalance("0x8d3797578a393adbe77af76c6d0f6fee8c4d402d235ad9fa93f8f20eb9bc0dad", 10000000000000)
les.addBalance("enode://4f3fb4e87c51057126d79ea0473bb7432b056456737e77e9977c5a72268b31a42dcaf2b7f0c03bc656fb0b8da093490c22cdc972494c9801f0858e5a903c693b@127.0.0.1:37214", 10000000000000)
```