### PR TITLE
abi/bind: add an option to dry run a transaction

### DIFF
--- a/accounts/abi/bind/base.go
+++ b/accounts/abi/bind/base.go
@@ -55,7 +55,7 @@ type TransactOpts struct {
 
 	Context context.Context // Network context to support cancellation and timeouts (nil = no timeout)
 
-	DryRun bool // Do all transact steps but do not send the transaction
+	NoSend bool // Do all transact steps but do not send the transaction
 }
 
 // FilterOpts is the collection of options to fine tune filtering for events
@@ -262,7 +262,7 @@ func (c *BoundContract) transact(opts *TransactOpts, contract *common.Address, i
 	if err != nil {
 		return nil, err
 	}
-	if opts.DryRun {
+	if opts.NoSend {
 		return signedTx, nil
 	}
 	if err := c.transactor.SendTransaction(ensureContext(opts.Context), signedTx); err != nil {

--- a/accounts/abi/bind/base.go
+++ b/accounts/abi/bind/base.go
@@ -263,7 +263,6 @@ func (c *BoundContract) transact(opts *TransactOpts, contract *common.Address, i
 		return nil, err
 	}
 	if opts.DryRun {
-		fmt.Println ( "dryrun")
 		return signedTx, nil
 	}
 	if err := c.transactor.SendTransaction(ensureContext(opts.Context), signedTx); err != nil {

--- a/accounts/abi/bind/base.go
+++ b/accounts/abi/bind/base.go
@@ -54,6 +54,8 @@ type TransactOpts struct {
 	GasLimit uint64   // Gas limit to set for the transaction execution (0 = estimate)
 
 	Context context.Context // Network context to support cancellation and timeouts (nil = no timeout)
+
+	DryRun bool // Do all transact steps but do not send the transaction
 }
 
 // FilterOpts is the collection of options to fine tune filtering for events
@@ -259,6 +261,10 @@ func (c *BoundContract) transact(opts *TransactOpts, contract *common.Address, i
 	signedTx, err := opts.Signer(opts.From, rawTx)
 	if err != nil {
 		return nil, err
+	}
+	if opts.DryRun {
+		fmt.Println ( "dryrun")
+		return signedTx, nil
 	}
 	if err := c.transactor.SendTransaction(ensureContext(opts.Context), signedTx); err != nil {
 		return nil, err


### PR DESCRIPTION
Adding the DryRun option to bind.TransactOpts will cause transact to return before sending the transaction. Allows checking signatures and cost.