### PR TITLE
tests/fuzzers: fix goroutine leak in les fuzzer

### DIFF
--- a/les/server_requests.go
+++ b/les/server_requests.go
@@ -206,8 +206,8 @@ func handleGetBlockHeaders(msg Decoder) (serveRequestFn, uint64, uint64, error) 
 					next    = current + r.Query.Skip + 1
 				)
 				if next <= current {
-					infos, _ := json.MarshalIndent(p.Peer.Info(), "", "  ")
-					p.Log().Warn("GetBlockHeaders skip overflow attack", "current", current, "skip", r.Query.Skip, "next", next, "attacker", infos)
+					infos, _ := json.Marshal(p.Peer.Info())
+					p.Log().Warn("GetBlockHeaders skip overflow attack", "current", current, "skip", r.Query.Skip, "next", next, "attacker", string(infos))
 					unknown = true
 				} else {
 					if header := bc.GetHeaderByNumber(next); header != nil {

--- a/les/test_helper.go
+++ b/les/test_helper.go
@@ -661,6 +661,10 @@ func newClientServerEnv(t *testing.T, config testnetConfig) (*testServer, *testC
 	return s, c, teardown
 }
 
-func NewFuzzerPeer(version int) *clientPeer {
-	return newClientPeer(version, 0, p2p.NewPeer(enode.ID{}, "", nil), nil)
+// NewFuzzerPeer creates a client peer for test purposes, and also returns
+// a function to close the peer: this is needed to avoid goroutine leaks in the
+// exec queue.
+func NewFuzzerPeer(version int) (p *clientPeer, closer func()) {
+	p = newClientPeer(version, 0, p2p.NewPeer(enode.ID{}, "", nil), nil)
+	return p, func() { p.peerCommons.close() }
 }

--- a/tests/fuzzers/les/les-fuzzer.go
+++ b/tests/fuzzers/les/les-fuzzer.go
@@ -261,18 +261,18 @@ func (d dummyMsg) Decode(val interface{}) error {
 }
 
 func (f *fuzzer) doFuzz(msgCode uint64, packet interface{}) {
-	version := f.randomInt(3) + 2 // [LES2, LES3, LES4]
-	peer := l.NewFuzzerPeer(version)
 	enc, err := rlp.EncodeToBytes(packet)
 	if err != nil {
 		panic(err)
 	}
+	version := f.randomInt(3) + 2 // [LES2, LES3, LES4]
+	peer, closeFn := l.NewFuzzerPeer(version)
+	defer closeFn()
 	fn, _, _, err := l.Les3[msgCode].Handle(dummyMsg{enc})
 	if err != nil {
 		panic(err)
 	}
 	fn(f, peer, func() bool { return true })
-
 }
 
 func Fuzz(input []byte) int {


### PR DESCRIPTION
The oss-fuzz fuzzer has been reporting some failing testcases for les. They're all spurious, and cannot reliably be reproduced. However, running them showed that there was a goroutine leak: the tests created a lot of new clients, which started an exec queue that was never torn down. 

This PR fixes the goroutine leak, and also a log message which was erroneously formatted. 

`
WARN [03-08|10:35:15.880] GetBlockHeaders skip overflow attack     id=0000000000000000 conn= current=0 skip=18446744073709551615 next=0 attacker="[123 10 32 32 34 101 110 111 100 101 34 58 32 34 101 110 111 100 101 58 47 47 110 117 108 108 46 48 48 48 48 48 48 48 48 48 48 48 48 48 48 48 48 48 48 48 48 48 48 48 48 48 48 48 48 48 48 48 48 48 48 48 48 48 48 48 48 48 48 48 48 48 48 48 48 48 48 48 48 48 48 48 48 48 48 48 48 48 48 48 48 34 44 10 32 32 34 105 100 34 58 32 34 48 48 48 48 48 48 48 48 48 48 48 48 48 48 48 48 48 48 48 48 48 48 48 48 48 48 48 48 48 48 48 48 48 48 48 48 48 48 48 48 48 48 48 48 48 48 48 48 48 48 48 48 48 48 48 48 48 48 48 48 48 48 48 48 34 44 10 32 32 34 110 97 109 101 34 58 32 34 34 44 10 32 32 34 99 97 112 115 34 58 32 110 117 108 108 44 10 32 32 34 110 101 116 119 111 114 107 34 58 32 123 10 32 32 32 32 34 108 111 99 97 108 65 100 100 114 101 115 115 34 58 32 34 112 105 112 101 34 44 10 32 32 32 32 34 114 101 109 111 116 101 65 100 100 114 101 115 115 34 58 32 34 112 105 112 101 34 44 10 32 32 32 32 34 105 110 98 111 117 110 100 34 58 32 102 97 108 115 101 44 10 32 32 32 32 34 116 114 117 115 116 101 100 34 58 32 102 97 108 115 101 44 10 32 32 32 32 34 115 116 97 116 105 99 34 58 32 102 97 108 115 101 10 32 32 125 44 10 32 32 34 112 114 111 116 111 99 111 108 115 34 58 32 123 125 10 125]"
`
vs
`
WARN [03-08|10:35:59.406] GetBlockHeaders skip overflow attack     id=0000000000000000 conn= current=0   skip=18446744073709551615 next=0   attacker="{\n  \"enode\": \"enode://null.0000000000000000000000000000000000000000000000000000000000000000\",\n  \"id\": \"0000000000000000000000000000000000000000000000000000000000000000\",\n  \"name\": \"\",\n  \"caps\": null,\n  \"network\": {\n    \"localAddress\": \"pipe\",\n    \"remoteAddress\": \"pipe\",\n    \"inbound\": false,\n    \"trusted\": false,\n    \"static\": false\n  },\n  \"protocols\": {}\n}"
`

