### PR TITLE
core/types: reduce allocations in GasPriceCmp

### DIFF
--- a/core/types/transaction.go
+++ b/core/types/transaction.go
@@ -293,7 +293,7 @@ func (tx *Transaction) RawSignatureValues() (v, r, s *big.Int) {
 
 // GasPriceCmp compares the gas prices of two transactions.
 func (tx *Transaction) GasPriceCmp(other *Transaction) int {
-	return tx.inner.gasPrice().Cmp(other.GasPrice())
+	return tx.inner.gasPrice().Cmp(other.inner.gasPrice())
 }
 
 // GasPriceIntCmp compares the gas price of the transaction against the given price.


### PR DESCRIPTION
Current master allocates a lot of unnecessary big integers when comparing gas prices.
Since the tx_list (part of the txpool) relies heavily on comparing transactions by gas price, this does ~1.6% of all allocations unnecessarily. 
This PR directly compares the inner gas prices without creating a new big int in the process
```
Total: 479893007
ROUTINE ======================== github.com/ethereum/go-ethereum/core/types.(*Transaction).GasPrice in github.com/ethereum/go-ethereum/core/types/transaction.go
  10764599   15876467 (flat, cum)  3.31% of Total
         .          .    256:
         .          .    257:// Gas returns the gas limit of the transaction.
         .          .    258:func (tx *Transaction) Gas() uint64 { return tx.inner.gas() }
         .          .    259:
         .          .    260:// GasPrice returns the gas price of the transaction.
  10764599   15876467    261:func (tx *Transaction) GasPrice() *big.Int { return new(big.Int).Set(tx.inner.gasPrice()) }
         .          .    262:
         .          .    263:// Value returns the ether amount of the transaction.
         .          .    264:func (tx *Transaction) Value() *big.Int { return new(big.Int).Set(tx.inner.value()) }
         .          .    265:
         .          .    266:// Nonce returns the sender account nonce of the transaction.
ROUTINE ======================== github.com/ethereum/go-ethereum/core/types.(*Transaction).GasPriceCmp in github.com/ethereum/go-ethereum/core/types/transaction.go
         0    7717050 (flat, cum)  1.61% of Total
         .          .    291:   return tx.inner.rawSignatureValues()
         .          .    292:}
         .          .    293:
         .          .    294:// GasPriceCmp compares the gas prices of two transactions.
         .          .    295:func (tx *Transaction) GasPriceCmp(other *Transaction) int {
         .    7717050    296:   return tx.inner.gasPrice().Cmp(other.GasPrice())
         .          .    297:}
         .          .    298:
         .          .    299:// GasPriceIntCmp compares the gas price of the transaction against the given price.
         .          .    300:func (tx *Transaction) GasPriceIntCmp(other *big.Int) int {
         .          .    301:   return tx.inner.gasPrice().Cmp(other)
```