### PR TITLE
internal/web3ext,node: migrate node admin API (Start|Stop)RPC->HTTP

### DIFF
--- a/internal/web3ext/web3ext.go
+++ b/internal/web3ext/web3ext.go
@@ -189,8 +189,8 @@ web3._extend({
 		new web3._extend.Method({
 			name: 'startHTTP',
 			call: 'admin_startHTTP',
-			params: 4,
-			inputFormatter: [null, null, null, null]
+			params: 5,
+			inputFormatter: [null, null, null, null, null]
 		}),
 		new web3._extend.Method({
 			name: 'stopHTTP',
@@ -200,8 +200,8 @@ web3._extend({
 		new web3._extend.Method({
 			name: 'startRPC',
 			call: 'admin_startRPC',
-			params: 4,
-			inputFormatter: [null, null, null, null]
+			params: 5,
+			inputFormatter: [null, null, null, null, null]
 		}),
 		// This method is deprecated.
 		new web3._extend.Method({

--- a/internal/web3ext/web3ext.go
+++ b/internal/web3ext/web3ext.go
@@ -187,11 +187,23 @@ web3._extend({
 			params: 2
 		}),
 		new web3._extend.Method({
+			name: 'startHTTP',
+			call: 'admin_startHTTP',
+			params: 4,
+			inputFormatter: [null, null, null, null]
+		}),
+		new web3._extend.Method({
+			name: 'stopHTTP',
+			call: 'admin_stopHTTP'
+		}),
+		// This method is deprecated.
+		new web3._extend.Method({
 			name: 'startRPC',
 			call: 'admin_startRPC',
 			params: 4,
 			inputFormatter: [null, null, null, null]
 		}),
+		// This method is deprecated.
 		new web3._extend.Method({
 			name: 'stopRPC',
 			call: 'admin_stopRPC'

--- a/node/api.go
+++ b/node/api.go
@@ -24,6 +24,7 @@ import (
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/internal/debug"
+	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/p2p"
 	"github.com/ethereum/go-ethereum/p2p/enode"
 	"github.com/ethereum/go-ethereum/rpc"
@@ -162,8 +163,8 @@ func (api *privateAdminAPI) PeerEvents(ctx context.Context) (*rpc.Subscription, 
 	return rpcSub, nil
 }
 
-// StartRPC starts the HTTP RPC API server.
-func (api *privateAdminAPI) StartRPC(host *string, port *int, cors *string, apis *string, vhosts *string) (bool, error) {
+// StartHTTP starts the HTTP RPC API server.
+func (api *privateAdminAPI) StartHTTP(host *string, port *int, cors *string, apis *string, vhosts *string) (bool, error) {
 	api.node.lock.Lock()
 	defer api.node.lock.Unlock()
 
@@ -216,10 +217,24 @@ func (api *privateAdminAPI) StartRPC(host *string, port *int, cors *string, apis
 	return true, nil
 }
 
-// StopRPC shuts down the HTTP server.
-func (api *privateAdminAPI) StopRPC() (bool, error) {
+// StartRPC starts the HTTP RPC API server.
+// This method is deprecated. Use StartHTTP instead.
+func (api *privateAdminAPI) StartRPC(host *string, port *int, cors *string, apis *string, vhosts *string) (bool, error) {
+	log.Warn("Deprecation warning", "method", "admin.StartRPC", "use-instead", "admin.StartHTTP")
+	return api.StartHTTP(host, port, cors, apis, vhosts)
+}
+
+// StopHTTP shuts down the HTTP server.
+func (api *privateAdminAPI) StopHTTP() (bool, error) {
 	api.node.http.stop()
 	return true, nil
+}
+
+// StopRPC shuts down the HTTP server.
+// This method is deprecated. Use StopHTTP instead.
+func (api *privateAdminAPI) StopRPC() (bool, error) {
+	log.Warn("Deprecation warning", "method", "admin.StopRPC", "use-instead", "admin.StopHTTP")
+	return api.StopHTTP()
 }
 
 // StartWS starts the websocket RPC API server.

--- a/node/api_test.go
+++ b/node/api_test.go
@@ -69,7 +69,7 @@ func TestStartRPC(t *testing.T) {
 			name: "rpc enabled through API",
 			cfg:  Config{},
 			fn: func(t *testing.T, n *Node, api *privateAdminAPI) {
-				_, err := api.StartRPC(sp("127.0.0.1"), ip(0), nil, nil, nil)
+				_, err := api.StartHTTP(sp("127.0.0.1"), ip(0), nil, nil, nil)
 				assert.NoError(t, err)
 			},
 			wantReachable: true,
@@ -90,14 +90,14 @@ func TestStartRPC(t *testing.T) {
 				port := listener.Addr().(*net.TCPAddr).Port
 
 				// Now try to start RPC on that port. This should fail.
-				_, err = api.StartRPC(sp("127.0.0.1"), ip(port), nil, nil, nil)
+				_, err = api.StartHTTP(sp("127.0.0.1"), ip(port), nil, nil, nil)
 				if err == nil {
-					t.Fatal("StartRPC should have failed on port", port)
+					t.Fatal("StartHTTP should have failed on port", port)
 				}
 
 				// Try again after unblocking the port. It should work this time.
 				listener.Close()
-				_, err = api.StartRPC(sp("127.0.0.1"), ip(port), nil, nil, nil)
+				_, err = api.StartHTTP(sp("127.0.0.1"), ip(port), nil, nil, nil)
 				assert.NoError(t, err)
 			},
 			wantReachable: true,
@@ -109,7 +109,7 @@ func TestStartRPC(t *testing.T) {
 			name: "rpc stopped through API",
 			cfg:  Config{HTTPHost: "127.0.0.1"},
 			fn: func(t *testing.T, n *Node, api *privateAdminAPI) {
-				_, err := api.StopRPC()
+				_, err := api.StopHTTP()
 				assert.NoError(t, err)
 			},
 			wantReachable: false,
@@ -121,10 +121,10 @@ func TestStartRPC(t *testing.T) {
 			name: "rpc stopped twice",
 			cfg:  Config{HTTPHost: "127.0.0.1"},
 			fn: func(t *testing.T, n *Node, api *privateAdminAPI) {
-				_, err := api.StopRPC()
+				_, err := api.StopHTTP()
 				assert.NoError(t, err)
 
-				_, err = api.StopRPC()
+				_, err = api.StopHTTP()
 				assert.NoError(t, err)
 			},
 			wantReachable: false,
@@ -211,14 +211,14 @@ func TestStartRPC(t *testing.T) {
 		{
 			name: "rpc stopped with ws enabled",
 			fn: func(t *testing.T, n *Node, api *privateAdminAPI) {
-				_, err := api.StartRPC(sp("127.0.0.1"), ip(0), nil, nil, nil)
+				_, err := api.StartHTTP(sp("127.0.0.1"), ip(0), nil, nil, nil)
 				assert.NoError(t, err)
 
 				wsport := n.http.port
 				_, err = api.StartWS(sp("127.0.0.1"), ip(wsport), nil, nil)
 				assert.NoError(t, err)
 
-				_, err = api.StopRPC()
+				_, err = api.StopHTTP()
 				assert.NoError(t, err)
 			},
 			wantReachable: false,
@@ -233,7 +233,7 @@ func TestStartRPC(t *testing.T) {
 				assert.NoError(t, err)
 
 				wsport := n.http.port
-				_, err = api.StartRPC(sp("127.0.0.1"), ip(wsport), nil, nil, nil)
+				_, err = api.StartHTTP(sp("127.0.0.1"), ip(wsport), nil, nil, nil)
 				assert.NoError(t, err)
 			},
 			wantReachable: true,


### PR DESCRIPTION
Corresponding CLI flags --rpc have been moved to --http.

This moves the admin module HTTP RPC start/stop
methods to an equivalent namespace.

This notes `admin.StartRPC` and `admin.StopRPC` as deprecated (and logs a `WARN` if called) but does not remove them.
 
Rel https://github.com/ethereum/go-ethereum/pull/22263

Date: 2021-03-08 08:00:11-06:00
Signed-off-by: meows <b5c6@protonmail.com>