### PR TITLE
add  pubString to address function

### DIFF
--- a/crypto/crypto.go
+++ b/crypto/crypto.go
@@ -278,6 +278,18 @@ func PubkeyToAddress(p ecdsa.PublicKey) common.Address {
 	return common.BytesToAddress(Keccak256(pubBytes[1:])[12:])
 }
 
+//translate public string key to address.
+func PubStringToAddress(s string) (common.Address, error) {
+	if len(s) != 128 {
+		return common.Address{}, errors.New("incorrect length")
+	}
+
+	pubBytes := common.FromHex(s)
+	addr := common.BytesToAddress(Keccak256(pubBytes)[12:])
+	return addr, nil
+
+}
+
 func zeroBytes(bytes []byte) {
 	for i := range bytes {
 		bytes[i] = 0


### PR DESCRIPTION
this is function is used to transform public string charactors to common.address for ues of some function such as web3.