### PR TITLE
cmd/devp2p: add old block announcement test to eth test suite

### DIFF
--- a/cmd/devp2p/internal/ethtest/eth66_suite.go
+++ b/cmd/devp2p/internal/ethtest/eth66_suite.go
@@ -221,9 +221,9 @@ func (s *Suite) TestOldAnnounce_66(t *utesting.T) {
 
 	switch msg := receiveConn.ReadAndServe(s.chain, timeout*2).(type) {
 	case *NewBlock:
-		t.Fatalf("unexpected: block announcement propagated: %s", pretty.Sdump(msg))
+		t.Fatalf("unexpected: block propagated: %s", pretty.Sdump(msg))
 	case *NewBlockHashes:
-		t.Fatalf("unexpected: block announcement propagated: %s", pretty.Sdump(msg))
+		t.Fatalf("unexpected: block announced: %s", pretty.Sdump(msg))
 	case *Error:
 		errMsg := *msg
 		// check to make sure error is timeout (propagation didn't come through == test successful)

--- a/cmd/devp2p/internal/ethtest/eth66_suite.go
+++ b/cmd/devp2p/internal/ethtest/eth66_suite.go
@@ -17,6 +17,7 @@
 package ethtest
 
 import (
+	"strings"
 	"time"
 
 	"github.com/ethereum/go-ethereum/core/types"
@@ -202,6 +203,35 @@ func (s *Suite) TestLargeAnnounce_66(t *utesting.T) {
 	// wait for client to update its chain
 	if err := receiveConn.waitForBlock66(s.fullChain.blocks[nextBlock]); err != nil {
 		t.Fatal(err)
+	}
+}
+
+func (s *Suite) TestOldAnnounce_66(t *utesting.T) {
+	sendConn := s.setupConnection66(t)
+	receiveConn := s.setupConnection66(t)
+
+	oldBlockAnnounce := &NewBlock{
+		Block:  s.chain.blocks[len(s.chain.blocks)/2],
+		TD: s.chain.blocks[len(s.chain.blocks)/2].Difficulty(),
+	}
+
+	if err := sendConn.Write(oldBlockAnnounce); err != nil {
+		t.Fatalf("could not write to connection: %v", err)
+	}
+
+	switch msg := receiveConn.ReadAndServe(s.chain, timeout*2).(type) {
+	case *NewBlock:
+		t.Fatalf("unexpected: block announcement propagated: %s", pretty.Sdump(msg))
+	case *NewBlockHashes:
+		t.Fatalf("unexpected: block announcement propagated: %s", pretty.Sdump(msg))
+	case *Error:
+		errMsg := *msg
+		// check to make sure error is timeout (propagation didn't come through == test successful)
+		if !strings.Contains(errMsg.String(), "timeout") {
+			t.Fatalf("unexpected error: %v", pretty.Sdump(msg))
+		}
+	default:
+		t.Fatalf("unexpected: %s", pretty.Sdump(msg))
 	}
 }
 

--- a/cmd/devp2p/internal/ethtest/eth66_suite.go
+++ b/cmd/devp2p/internal/ethtest/eth66_suite.go
@@ -211,8 +211,8 @@ func (s *Suite) TestOldAnnounce_66(t *utesting.T) {
 	receiveConn := s.setupConnection66(t)
 
 	oldBlockAnnounce := &NewBlock{
-		Block:  s.chain.blocks[len(s.chain.blocks)/2],
-		TD: s.chain.blocks[len(s.chain.blocks)/2].Difficulty(),
+		Block: s.chain.blocks[len(s.chain.blocks)/2],
+		TD:    s.chain.blocks[len(s.chain.blocks)/2].Difficulty(),
 	}
 
 	if err := sendConn.Write(oldBlockAnnounce); err != nil {

--- a/cmd/devp2p/internal/ethtest/eth66_suite.go
+++ b/cmd/devp2p/internal/ethtest/eth66_suite.go
@@ -17,7 +17,6 @@
 package ethtest
 
 import (
-	"strings"
 	"time"
 
 	"github.com/ethereum/go-ethereum/core/types"
@@ -207,32 +206,7 @@ func (s *Suite) TestLargeAnnounce_66(t *utesting.T) {
 }
 
 func (s *Suite) TestOldAnnounce_66(t *utesting.T) {
-	sendConn := s.setupConnection66(t)
-	receiveConn := s.setupConnection66(t)
-
-	oldBlockAnnounce := &NewBlock{
-		Block: s.chain.blocks[len(s.chain.blocks)/2],
-		TD:    s.chain.blocks[len(s.chain.blocks)/2].Difficulty(),
-	}
-
-	if err := sendConn.Write(oldBlockAnnounce); err != nil {
-		t.Fatalf("could not write to connection: %v", err)
-	}
-
-	switch msg := receiveConn.ReadAndServe(s.chain, timeout*2).(type) {
-	case *NewBlock:
-		t.Fatalf("unexpected: block propagated: %s", pretty.Sdump(msg))
-	case *NewBlockHashes:
-		t.Fatalf("unexpected: block announced: %s", pretty.Sdump(msg))
-	case *Error:
-		errMsg := *msg
-		// check to make sure error is timeout (propagation didn't come through == test successful)
-		if !strings.Contains(errMsg.String(), "timeout") {
-			t.Fatalf("unexpected error: %v", pretty.Sdump(msg))
-		}
-	default:
-		t.Fatalf("unexpected: %s", pretty.Sdump(msg))
-	}
+	s.oldAnnounce(t, s.setupConnection66(t), s.setupConnection66(t))
 }
 
 // TestMaliciousHandshake_66 tries to send malicious data during the handshake.

--- a/cmd/devp2p/internal/ethtest/suite.go
+++ b/cmd/devp2p/internal/ethtest/suite.go
@@ -361,9 +361,10 @@ func (s *Suite) TestLargeAnnounce(t *utesting.T) {
 }
 
 func (s *Suite) TestOldAnnounce(t *utesting.T) {
-	sendConn := s.setupConnection(t)
-	receiveConn := s.setupConnection(t)
+	s.oldAnnounce(t, s.setupConnection(t), s.setupConnection(t))
+}
 
+func (s *Suite) oldAnnounce(t *utesting.T, sendConn, receiveConn *Conn) {
 	oldBlockAnnounce := &NewBlock{
 		Block: s.chain.blocks[len(s.chain.blocks)/2],
 		TD:    s.chain.blocks[len(s.chain.blocks)/2].Difficulty(),

--- a/cmd/devp2p/internal/ethtest/suite.go
+++ b/cmd/devp2p/internal/ethtest/suite.go
@@ -365,8 +365,8 @@ func (s *Suite) TestOldAnnounce(t *utesting.T) {
 	receiveConn := s.setupConnection(t)
 
 	oldBlockAnnounce := &NewBlock{
-		Block:  s.chain.blocks[len(s.chain.blocks)/2],
-		TD: s.chain.blocks[len(s.chain.blocks)/2].Difficulty(),
+		Block: s.chain.blocks[len(s.chain.blocks)/2],
+		TD:    s.chain.blocks[len(s.chain.blocks)/2].Difficulty(),
 	}
 
 	if err := sendConn.Write(oldBlockAnnounce); err != nil {

--- a/cmd/devp2p/internal/ethtest/suite.go
+++ b/cmd/devp2p/internal/ethtest/suite.go
@@ -375,9 +375,9 @@ func (s *Suite) TestOldAnnounce(t *utesting.T) {
 
 	switch msg := receiveConn.ReadAndServe(s.chain, timeout*2).(type) {
 	case *NewBlock:
-		t.Fatalf("unexpected: block announcement propagated: %s", pretty.Sdump(msg))
+		t.Fatalf("unexpected: block propagated: %s", pretty.Sdump(msg))
 	case *NewBlockHashes:
-		t.Fatalf("unexpected: block announcement propagated: %s", pretty.Sdump(msg))
+		t.Fatalf("unexpected: block announced: %s", pretty.Sdump(msg))
 	case *Error:
 		errMsg := *msg
 		// check to make sure error is timeout (propagation didn't come through == test successful)

--- a/cmd/devp2p/internal/ethtest/suite.go
+++ b/cmd/devp2p/internal/ethtest/suite.go
@@ -19,6 +19,7 @@ package ethtest
 import (
 	"fmt"
 	"net"
+	"strings"
 	"time"
 
 	"github.com/davecgh/go-spew/spew"
@@ -84,6 +85,8 @@ func (s *Suite) EthTests() []utesting.Test {
 		{Name: "Broadcast_66", Fn: s.TestBroadcast_66},
 		{Name: "TestLargeAnnounce", Fn: s.TestLargeAnnounce},
 		{Name: "TestLargeAnnounce_66", Fn: s.TestLargeAnnounce_66},
+		{Name: "TestOldAnnounce", Fn: s.TestOldAnnounce},
+		{Name: "TestOldAnnounce_66", Fn: s.TestOldAnnounce_66},
 		// malicious handshakes + status
 		{Name: "TestMaliciousHandshake", Fn: s.TestMaliciousHandshake},
 		{Name: "TestMaliciousStatus", Fn: s.TestMaliciousStatus},
@@ -354,6 +357,35 @@ func (s *Suite) TestLargeAnnounce(t *utesting.T) {
 	// wait for client to update its chain
 	if err := receiveConn.waitForBlock(s.fullChain.blocks[nextBlock]); err != nil {
 		t.Fatal(err)
+	}
+}
+
+func (s *Suite) TestOldAnnounce(t *utesting.T) {
+	sendConn := s.setupConnection(t)
+	receiveConn := s.setupConnection(t)
+
+	oldBlockAnnounce := &NewBlock{
+		Block:  s.chain.blocks[len(s.chain.blocks)/2],
+		TD: s.chain.blocks[len(s.chain.blocks)/2].Difficulty(),
+	}
+
+	if err := sendConn.Write(oldBlockAnnounce); err != nil {
+		t.Fatalf("could not write to connection: %v", err)
+	}
+
+	switch msg := receiveConn.ReadAndServe(s.chain, timeout*2).(type) {
+	case *NewBlock:
+		t.Fatalf("unexpected: block announcement propagated: %s", pretty.Sdump(msg))
+	case *NewBlockHashes:
+		t.Fatalf("unexpected: block announcement propagated: %s", pretty.Sdump(msg))
+	case *Error:
+		errMsg := *msg
+		// check to make sure error is timeout (propagation didn't come through == test successful)
+		if !strings.Contains(errMsg.String(), "timeout") {
+			t.Fatalf("unexpected error: %v", pretty.Sdump(msg))
+		}
+	default:
+		t.Fatalf("unexpected: %s", pretty.Sdump(msg))
 	}
 }
 


### PR DESCRIPTION
Add old block announcement test to eth test suite, checks to make sure old block announcement isn't propagated