### PR TITLE
cmd/geth: fix cache variable with config files

### DIFF
--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -295,7 +295,7 @@ func prepare(ctx *cli.Context) {
 		}
 	}
 
-	// Ue Cache value provided by config file (if present)
+	// Use Cache value provided by config file (if present)
 	if cfg.Node.Cache != 0 {
 		ctx.GlobalSet(utils.CacheFlag.Name, strconv.Itoa(cfg.Node.Cache))
 	}

--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -295,7 +295,7 @@ func prepare(ctx *cli.Context) {
 		}
 	}
 
-	// Cache value is set in the config file
+	// Ue Cache value provided by config file (if present)
 	if cfg.Node.Cache != 0 {
 		ctx.GlobalSet(utils.CacheFlag.Name, strconv.Itoa(cfg.Node.Cache))
 	}

--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -286,6 +286,20 @@ func prepare(ctx *cli.Context) {
 	case !ctx.GlobalIsSet(utils.NetworkIdFlag.Name):
 		log.Info("Starting Geth on Ethereum mainnet...")
 	}
+
+	// Load the config file early to check the Cache configuration value
+	cfg := gethConfig{}
+	if file := ctx.GlobalString(configFileFlag.Name); file != "" {
+		if err := loadConfig(file, &cfg); err != nil {
+			utils.Fatalf("%v", err)
+		}
+	}
+
+	// Cache value is set in the config file
+	if cfg.Node.Cache != 0 {
+		ctx.GlobalSet(utils.CacheFlag.Name, strconv.Itoa(cfg.Node.Cache))
+	}
+
 	// If we're a full node on mainnet without --cache specified, bump default cache allowance
 	if ctx.GlobalString(utils.SyncModeFlag.Name) != "light" && !ctx.GlobalIsSet(utils.CacheFlag.Name) && !ctx.GlobalIsSet(utils.NetworkIdFlag.Name) {
 		// Make sure we're not on any supported preconfigured testnet either

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -1218,6 +1218,9 @@ func SetNodeConfig(ctx *cli.Context, cfg *node.Config) {
 	if ctx.GlobalIsSet(InsecureUnlockAllowedFlag.Name) {
 		cfg.InsecureUnlockAllowed = ctx.GlobalBool(InsecureUnlockAllowedFlag.Name)
 	}
+	if ctx.GlobalIsSet(CacheFlag.Name) {
+		cfg.Cache = ctx.GlobalInt(CacheFlag.Name)
+	}
 }
 
 func setSmartCard(ctx *cli.Context, cfg *node.Config) {

--- a/node/config.go
+++ b/node/config.go
@@ -194,6 +194,10 @@ type Config struct {
 
 	// AllowUnprotectedTxs allows non EIP-155 protected transactions to be send over RPC.
 	AllowUnprotectedTxs bool `toml:",omitempty"`
+
+	// Cache sets global cache values used for Go garbage collection.
+	// If set will also override database cache values
+	Cache int `toml:",omitempty"`
 }
 
 // IPCEndpoint resolves an IPC endpoint based on a configured value, taking into


### PR DESCRIPTION
_main:_ Sample config file for cache value to allow setting Go GC cache values though a config file
_node:_ Add new configuration variable "Cache"
_utils:_ Set configuration value based on command line parameter
 
When Geth detects it is operating on the mainnet it will bump up cache values. This happens before the configuration file is parsed so the value is unable to be set by the config file and must be set via a command line parameter.

This patch adds a new configuration variable allowing this cache value to be set. In order to read this value, the config file must be parsed early to detect the presence of this value.
 
Fixes #21090