### PR TITLE
cmd: add ancient datadir flag to snapshot subcommands

### DIFF
--- a/cmd/geth/snapshot.go
+++ b/cmd/geth/snapshot.go
@@ -57,6 +57,7 @@ var (
 				Category:  "MISCELLANEOUS COMMANDS",
 				Flags: []cli.Flag{
 					utils.DataDirFlag,
+					utils.AncientFlag,
 					utils.RopstenFlag,
 					utils.RinkebyFlag,
 					utils.GoerliFlag,
@@ -86,6 +87,7 @@ the trie clean cache with default directory will be deleted.
 				Category:  "MISCELLANEOUS COMMANDS",
 				Flags: []cli.Flag{
 					utils.DataDirFlag,
+					utils.AncientFlag,
 					utils.RopstenFlag,
 					utils.RinkebyFlag,
 					utils.GoerliFlag,
@@ -105,6 +107,7 @@ In other words, this command does the snapshot to trie conversion.
 				Category:  "MISCELLANEOUS COMMANDS",
 				Flags: []cli.Flag{
 					utils.DataDirFlag,
+					utils.AncientFlag,
 					utils.RopstenFlag,
 					utils.RinkebyFlag,
 					utils.GoerliFlag,
@@ -126,6 +129,7 @@ It's also usable without snapshot enabled.
 				Category:  "MISCELLANEOUS COMMANDS",
 				Flags: []cli.Flag{
 					utils.DataDirFlag,
+					utils.AncientFlag,
 					utils.RopstenFlag,
 					utils.RinkebyFlag,
 					utils.GoerliFlag,


### PR DESCRIPTION
When syncing with an non-default ancient data directory, the `snapshot` sub-commands aren't usable because Geth can't open the database. This PR adds the missing `--database.ancient` flags to the `snapshot` sub-commands