### PR TITLE
core/state/snapshot: faster snapshot generation

### DIFF
--- a/cmd/geth/snapshot.go
+++ b/cmd/geth/snapshot.go
@@ -205,10 +205,10 @@ func verifyState(ctx *cli.Context) error {
 		}
 	}
 	if err := snaptree.Verify(root); err != nil {
-		log.Error("Failed to verfiy state", "error", err)
+		log.Error("Failed to verfiy state", "root", root, "error", err)
 		return err
 	}
-	log.Info("Verified the state")
+	log.Info("Verified the state", "root", root)
 	return nil
 }
 

--- a/cmd/geth/snapshot.go
+++ b/cmd/geth/snapshot.go
@@ -155,7 +155,7 @@ func pruneState(ctx *cli.Context) error {
 	chaindb := utils.MakeChainDatabase(ctx, stack, false)
 	pruner, err := pruner.NewPruner(chaindb, stack.ResolvePath(""), stack.ResolvePath(config.Eth.TrieCleanCacheJournal), ctx.GlobalUint64(utils.BloomFilterSizeFlag.Name))
 	if err != nil {
-		log.Error("Failed to open snapshot tree", "error", err)
+		log.Error("Failed to open snapshot tree", "err", err)
 		return err
 	}
 	if ctx.NArg() > 1 {
@@ -166,12 +166,12 @@ func pruneState(ctx *cli.Context) error {
 	if ctx.NArg() == 1 {
 		targetRoot, err = parseRoot(ctx.Args()[0])
 		if err != nil {
-			log.Error("Failed to resolve state root", "error", err)
+			log.Error("Failed to resolve state root", "err", err)
 			return err
 		}
 	}
 	if err = pruner.Prune(targetRoot); err != nil {
-		log.Error("Failed to prune state", "error", err)
+		log.Error("Failed to prune state", "err", err)
 		return err
 	}
 	return nil
@@ -189,7 +189,7 @@ func verifyState(ctx *cli.Context) error {
 	}
 	snaptree, err := snapshot.New(chaindb, trie.NewDatabase(chaindb), 256, headBlock.Root(), false, false, false)
 	if err != nil {
-		log.Error("Failed to open snapshot tree", "error", err)
+		log.Error("Failed to open snapshot tree", "err", err)
 		return err
 	}
 	if ctx.NArg() > 1 {
@@ -200,12 +200,12 @@ func verifyState(ctx *cli.Context) error {
 	if ctx.NArg() == 1 {
 		root, err = parseRoot(ctx.Args()[0])
 		if err != nil {
-			log.Error("Failed to resolve state root", "error", err)
+			log.Error("Failed to resolve state root", "err", err)
 			return err
 		}
 	}
 	if err := snaptree.Verify(root); err != nil {
-		log.Error("Failed to verfiy state", "root", root, "error", err)
+		log.Error("Failed to verfiy state", "root", root, "err", err)
 		return err
 	}
 	log.Info("Verified the state", "root", root)
@@ -236,7 +236,7 @@ func traverseState(ctx *cli.Context) error {
 	if ctx.NArg() == 1 {
 		root, err = parseRoot(ctx.Args()[0])
 		if err != nil {
-			log.Error("Failed to resolve state root", "error", err)
+			log.Error("Failed to resolve state root", "err", err)
 			return err
 		}
 		log.Info("Start traversing the state", "root", root)
@@ -247,7 +247,7 @@ func traverseState(ctx *cli.Context) error {
 	triedb := trie.NewDatabase(chaindb)
 	t, err := trie.NewSecure(root, triedb)
 	if err != nil {
-		log.Error("Failed to open trie", "root", root, "error", err)
+		log.Error("Failed to open trie", "root", root, "err", err)
 		return err
 	}
 	var (
@@ -262,13 +262,13 @@ func traverseState(ctx *cli.Context) error {
 		accounts += 1
 		var acc state.Account
 		if err := rlp.DecodeBytes(accIter.Value, &acc); err != nil {
-			log.Error("Invalid account encountered during traversal", "error", err)
+			log.Error("Invalid account encountered during traversal", "err", err)
 			return err
 		}
 		if acc.Root != emptyRoot {
 			storageTrie, err := trie.NewSecure(acc.Root, triedb)
 			if err != nil {
-				log.Error("Failed to open storage trie", "root", acc.Root, "error", err)
+				log.Error("Failed to open storage trie", "root", acc.Root, "err", err)
 				return err
 			}
 			storageIter := trie.NewIterator(storageTrie.NodeIterator(nil))
@@ -276,7 +276,7 @@ func traverseState(ctx *cli.Context) error {
 				slots += 1
 			}
 			if storageIter.Err != nil {
-				log.Error("Failed to traverse storage trie", "root", acc.Root, "error", storageIter.Err)
+				log.Error("Failed to traverse storage trie", "root", acc.Root, "err", storageIter.Err)
 				return storageIter.Err
 			}
 		}
@@ -294,7 +294,7 @@ func traverseState(ctx *cli.Context) error {
 		}
 	}
 	if accIter.Err != nil {
-		log.Error("Failed to traverse state trie", "root", root, "error", accIter.Err)
+		log.Error("Failed to traverse state trie", "root", root, "err", accIter.Err)
 		return accIter.Err
 	}
 	log.Info("State is complete", "accounts", accounts, "slots", slots, "codes", codes, "elapsed", common.PrettyDuration(time.Since(start)))
@@ -326,7 +326,7 @@ func traverseRawState(ctx *cli.Context) error {
 	if ctx.NArg() == 1 {
 		root, err = parseRoot(ctx.Args()[0])
 		if err != nil {
-			log.Error("Failed to resolve state root", "error", err)
+			log.Error("Failed to resolve state root", "err", err)
 			return err
 		}
 		log.Info("Start traversing the state", "root", root)
@@ -337,7 +337,7 @@ func traverseRawState(ctx *cli.Context) error {
 	triedb := trie.NewDatabase(chaindb)
 	t, err := trie.NewSecure(root, triedb)
 	if err != nil {
-		log.Error("Failed to open trie", "root", root, "error", err)
+		log.Error("Failed to open trie", "root", root, "err", err)
 		return err
 	}
 	var (
@@ -368,13 +368,13 @@ func traverseRawState(ctx *cli.Context) error {
 			accounts += 1
 			var acc state.Account
 			if err := rlp.DecodeBytes(accIter.LeafBlob(), &acc); err != nil {
-				log.Error("Invalid account encountered during traversal", "error", err)
+				log.Error("Invalid account encountered during traversal", "err", err)
 				return errors.New("invalid account")
 			}
 			if acc.Root != emptyRoot {
 				storageTrie, err := trie.NewSecure(acc.Root, triedb)
 				if err != nil {
-					log.Error("Failed to open storage trie", "root", acc.Root, "error", err)
+					log.Error("Failed to open storage trie", "root", acc.Root, "err", err)
 					return errors.New("missing storage trie")
 				}
 				storageIter := storageTrie.NodeIterator(nil)
@@ -397,7 +397,7 @@ func traverseRawState(ctx *cli.Context) error {
 					}
 				}
 				if storageIter.Error() != nil {
-					log.Error("Failed to traverse storage trie", "root", acc.Root, "error", storageIter.Error())
+					log.Error("Failed to traverse storage trie", "root", acc.Root, "err", storageIter.Error())
 					return storageIter.Error()
 				}
 			}
@@ -416,7 +416,7 @@ func traverseRawState(ctx *cli.Context) error {
 		}
 	}
 	if accIter.Error() != nil {
-		log.Error("Failed to traverse state trie", "root", root, "error", accIter.Error())
+		log.Error("Failed to traverse state trie", "root", root, "err", accIter.Error())
 		return accIter.Error()
 	}
 	log.Info("State is complete", "nodes", nodes, "accounts", accounts, "slots", slots, "codes", codes, "elapsed", common.PrettyDuration(time.Since(start)))

--- a/core/state/snapshot/conversion.go
+++ b/core/state/snapshot/conversion.go
@@ -322,7 +322,7 @@ func generateTrieRoot(db ethdb.KeyValueWriter, it Iterator, account common.Hash,
 						return
 					}
 					if !bytes.Equal(account.Root, subroot.Bytes()) {
-						results <- fmt.Errorf("invalid subroot(%x), want %x, got %x", it.Hash(), account.Root, subroot)
+						results <- fmt.Errorf("invalid subroot(%x), want %x, got %x", hash, account.Root, subroot)
 						return
 					}
 					results <- nil

--- a/core/state/snapshot/conversion.go
+++ b/core/state/snapshot/conversion.go
@@ -322,7 +322,7 @@ func generateTrieRoot(db ethdb.KeyValueWriter, it Iterator, account common.Hash,
 						return
 					}
 					if !bytes.Equal(account.Root, subroot.Bytes()) {
-						results <- fmt.Errorf("invalid subroot(%x), want %x, got %x", hash, account.Root, subroot)
+						results <- fmt.Errorf("invalid subroot(path %x), want %x, have %x", hash, account.Root, subroot)
 						return
 					}
 					results <- nil

--- a/core/state/snapshot/generate.go
+++ b/core/state/snapshot/generate.go
@@ -434,7 +434,7 @@ func (dl *diskLayer) generate(stats *generatorStats) {
 						return nil
 					}
 					storeOrigin = increseKey(last)
-					if bytes.Equal(storeOrigin, common.Hash{}.Bytes()) {
+					if storeOrigin == nil {
 						return nil // special case, the last is 0xffffffff...fff
 					}
 				}
@@ -456,7 +456,7 @@ func (dl *diskLayer) generate(stats *generatorStats) {
 			break
 		}
 		accOrigin = increseKey(last)
-		if bytes.Equal(accOrigin, common.Hash{}.Bytes()) {
+		if accOrigin == nil {
 			break // special case, the last is 0xffffffff...fff
 		}
 	}
@@ -480,12 +480,14 @@ func (dl *diskLayer) generate(stats *generatorStats) {
 	abort <- nil
 }
 
+// increseKey increase the input key by one bit. Return nil if the entire
+// addition operation overflows,
 func increseKey(key []byte) []byte {
 	for i := len(key) - 1; i >= 0; i-- {
 		key[i]++
 		if key[i] != 0x0 {
-			break
+			return key
 		}
 	}
-	return key
+	return nil
 }

--- a/core/state/snapshot/generate.go
+++ b/core/state/snapshot/generate.go
@@ -287,9 +287,10 @@ func (dl *diskLayer) proveRange(root common.Hash, tr *trie.Trie, prefix []byte, 
 	}
 	// Range prover says the trie still has some elements on the right side but
 	// the database is exhausted, then data loss is detected.
-	if cont && len(keys) < max {
-		return &proofResult{keys: keys, vals: vals, cont: false, proofErr: errors.New("data loss in the state range")}, nil
-	}
+	// TODO: Investigate if this is needed (the assumption is that it's not needed)
+	//if cont && len(keys) < max {
+	//return &proofResult{keys: keys, vals: vals, cont: true, proofErr: nil}, nil
+	//}
 	return &proofResult{keys: keys, vals: vals, cont: cont, proofErr: nil}, nil
 }
 

--- a/core/state/snapshot/generate.go
+++ b/core/state/snapshot/generate.go
@@ -388,6 +388,9 @@ func (dl *diskLayer) genRange(root common.Hash, prefix []byte, kind string, orig
 		} else {
 			// The "stale state" is actually not stale, skip it
 			untouched += 1
+			if err := onState(iter.Key, iter.Value, false, false); err != nil {
+				return false, nil, err
+			}
 		}
 		kvkeys = kvkeys[1:]
 		kvvals = kvvals[1:]

--- a/core/state/snapshot/generate.go
+++ b/core/state/snapshot/generate.go
@@ -336,8 +336,7 @@ func (dl *diskLayer) generate(stats *generatorStats) {
 			// Flush out the batch anyway no matter it's empty or not.
 			// It's possible that all the states are recovered and the
 			// generation indeed makes progress.
-			marker := currentLocation
-			journalProgress(batch, marker, stats)
+			journalProgress(batch, currentLocation, stats)
 
 			if err := batch.Write(); err != nil {
 				return err
@@ -345,16 +344,16 @@ func (dl *diskLayer) generate(stats *generatorStats) {
 			batch.Reset()
 
 			dl.lock.Lock()
-			dl.genMarker = marker
+			dl.genMarker = currentLocation
 			dl.lock.Unlock()
 
 			if abort != nil {
-				stats.Log("Aborting state snapshot generation", dl.root, marker)
+				stats.Log("Aborting state snapshot generation", dl.root, currentLocation)
 				return errors.New("aborted")
 			}
 		}
 		if time.Since(logged) > 8*time.Second {
-			stats.Log("Generating state snapshot", dl.root, marker)
+			stats.Log("Generating state snapshot", dl.root, currentLocation)
 			logged = time.Now()
 		}
 		return nil

--- a/core/state/snapshot/generate.go
+++ b/core/state/snapshot/generate.go
@@ -241,8 +241,7 @@ func (dl *diskLayer) proveRange(root common.Hash, prefix []byte, kind string, or
 	for iter.Next() {
 		key := iter.Key()
 		if len(key) != len(prefix)+common.HashLength {
-			// TODO! Why is this check neeed?
-			panic("remove this panic later on")
+			continue
 		}
 		if len(keys) == max {
 			aborted = true
@@ -422,7 +421,7 @@ func (dl *diskLayer) genRange(root common.Hash, prefix []byte, kind string, orig
 	}
 	logger.Debug("Regenerated state range", "root", root, "last", hexutil.Encode(last),
 		"count", count, "created", created, "updated", updated, "deleted", deleted, "untouched", untouched)
-	return !aborted, last, nil // The entire trie is exhausted
+	return !aborted, last, nil
 }
 
 // generate is a background thread that iterates over the state and storage tries,

--- a/core/state/snapshot/generate.go
+++ b/core/state/snapshot/generate.go
@@ -316,9 +316,10 @@ func (dl *diskLayer) generate(stats *generatorStats) {
 	)
 	if len(dl.genMarker) > 0 { // []byte{} is the start, use nil for that
 		accMarker = dl.genMarker[:common.HashLength]
-	}
-	if len(dl.genMarker) == 2*common.HashLength {
-		accountRange = 1 // We already fall into the storage generation last time, only pick one account
+
+		// Always reset the initial account range as 1 whenever recover
+		// from the interruption.
+		accountRange = 1
 	}
 	var (
 		batch     = dl.diskdb.NewBatch()

--- a/core/state/snapshot/generate.go
+++ b/core/state/snapshot/generate.go
@@ -209,9 +209,6 @@ func (result *proofResult) last() []byte {
 // forEach iterates all the visited elements and applies the given callback on them.
 // The iteration is aborted if the callback returns non-nil error.
 func (result *proofResult) forEach(callback func(key []byte, val []byte) error) error {
-	if callback == nil {
-		return nil
-	}
 	for i := 0; i < len(result.keys); i++ {
 		key, val := result.keys[i], result.vals[i]
 		if err := callback(key, val); err != nil {
@@ -255,7 +252,7 @@ func (dl *diskLayer) proveRange(root common.Hash, prefix []byte, kind string, or
 		}
 		val, err := valueConvertFn(iter.Value())
 		if err != nil {
-			// Sepcial case, the state data is corrupted(invalid slim-format account),
+			// Special case, the state data is corrupted (invalid slim-format account),
 			// don't abort the entire procedure directly. Instead, let the fallback
 			// generation to heal the invalid data.
 			//

--- a/core/state/snapshot/generate.go
+++ b/core/state/snapshot/generate.go
@@ -189,8 +189,11 @@ func (dl *diskLayer) proveRange(root common.Hash, tr *trie.SecureTrie, prefix []
 		count int
 		last  []byte
 		proof = rawdb.NewMemoryDatabase()
-		iter  = dl.diskdb.NewIterator(prefix, origin)
 	)
+
+	iter := dl.diskdb.NewIterator(prefix, origin)
+	defer iter.Release()
+
 	for iter.Next() && count < max {
 		key := iter.Key()
 		if len(key) != len(prefix)+common.HashLength {
@@ -269,7 +272,7 @@ func (dl *diskLayer) genRange(root common.Hash, prefix []byte, kind string, orig
 		return exhausted, last, nil
 	}
 	snapFailedRangeProofMeter.Mark(1)
-	log.Debug("Detected outdated state range", "kind", kind, "prefix", prefix, "origin", origin, "last", last)
+	log.Debug("Detected outdated state range", "kind", kind, "prefix", prefix, "origin", origin, "last", last, "error", err)
 
 	// The verifcation is failed, the flat state in this range cannot match the
 	// merkle trie. Alternatively, use the fallback generation mechanism to regenerate

--- a/core/state/snapshot/generate.go
+++ b/core/state/snapshot/generate.go
@@ -184,7 +184,7 @@ func journalProgress(db ethdb.KeyValueWriter, marker []byte, stats *generatorSta
 // The iteration start point will be assigned if the iterator is restored from
 // the last interruption. Max will be assigned in order to limit the maximum
 // amount of data involved in each iteration.
-func (dl *diskLayer) proveRange(root common.Hash, tr *trie.SecureTrie, prefix []byte, kind string, origin []byte, max int, valueConvertFn func([]byte) ([]byte, error)) ([][]byte, [][]byte, []byte, bool, error) {
+func (dl *diskLayer) proveRange(root common.Hash, tr *trie.Trie, prefix []byte, kind string, origin []byte, max int, valueConvertFn func([]byte) ([]byte, error)) ([][]byte, [][]byte, []byte, bool, error) {
 	var (
 		keys  [][]byte
 		vals  [][]byte
@@ -248,7 +248,7 @@ func (dl *diskLayer) proveRange(root common.Hash, tr *trie.SecureTrie, prefix []
 // either verify the correctness of existing state through rangeproof and skip
 // generation, or iterate trie to regenerate state on demand.
 func (dl *diskLayer) genRange(root common.Hash, prefix []byte, kind string, origin []byte, max int, stats *generatorStats, onState func(key []byte, val []byte, regen bool) error, valueConvertFn func([]byte) ([]byte, error)) (bool, []byte, error) {
-	tr, err := trie.NewSecure(root, dl.triedb)
+	tr, err := trie.New(root, dl.triedb)
 	if err != nil {
 		stats.Log("Trie missing, state snapshotting paused", root, dl.genMarker)
 		return false, nil, errors.New("trie is missing")

--- a/core/state/snapshot/generate.go
+++ b/core/state/snapshot/generate.go
@@ -245,6 +245,7 @@ func (dl *diskLayer) proveRange(root common.Hash, prefix []byte, kind string, or
 		}
 		if len(keys) == max {
 			aborted = true
+			break
 		}
 		keys = append(keys, common.CopyBytes(key[len(prefix):]))
 
@@ -341,7 +342,7 @@ func (dl *diskLayer) genRange(root common.Hash, prefix []byte, kind string, orig
 		}
 		return !result.cont, last, nil
 	}
-	logger.Debug("Detected outdated state range", "last", hexutil.Encode(last), "error", err)
+	logger.Debug("Detected outdated state range", "last", hexutil.Encode(last), "error", result.proofErr)
 	snapFailedRangeProofMeter.Mark(1)
 
 	// Special case, the entire trie is missing. In the original trie scheme,
@@ -420,7 +421,7 @@ func (dl *diskLayer) genRange(root common.Hash, prefix []byte, kind string, orig
 		deleted += 1
 	}
 	logger.Debug("Regenerated state range", "root", root, "last", hexutil.Encode(last),
-		"count", count, "created", created, "updated", updated, "deleted", deleted, "untouched", untouched)
+		"count", count, "created", created, "updated", updated, "untouched", untouched, "deleted", deleted)
 	return !aborted, last, nil
 }
 

--- a/core/state/snapshot/generate.go
+++ b/core/state/snapshot/generate.go
@@ -371,8 +371,7 @@ func (dl *diskLayer) genRange(root common.Hash, prefix []byte, kind string, orig
 		untouched = 0 // states already correct
 	)
 	for iter.Next() {
-		if count == max {
-			// Don't keep iterating indefinitely
+		if last != nil && bytes.Compare(iter.Key, last) > 0 {
 			aborted = true
 			break
 		}
@@ -404,7 +403,6 @@ func (dl *diskLayer) genRange(root common.Hash, prefix []byte, kind string, orig
 		if err := onState(iter.Key, iter.Value, write, false); err != nil {
 			return false, nil, err
 		}
-		last = common.CopyBytes(iter.Key)
 	}
 	if iter.Err != nil {
 		return false, nil, iter.Err

--- a/core/state/snapshot/generate.go
+++ b/core/state/snapshot/generate.go
@@ -263,6 +263,12 @@ func (dl *diskLayer) proveRange(root common.Hash, prefix []byte, kind string, or
 		if len(key) != len(prefix)+common.HashLength {
 			continue
 		}
+		if len(keys) == max {
+			// Break if we've reached the max size, and signal that we're not
+			// done yet.
+			diskMore = true
+			break
+		}
 		keys = append(keys, common.CopyBytes(key[len(prefix):]))
 
 		if valueConvertFn == nil {
@@ -280,12 +286,6 @@ func (dl *diskLayer) proveRange(root common.Hash, prefix []byte, kind string, or
 			} else {
 				vals = append(vals, val)
 			}
-		}
-		// A trick is applied here, whenever the maximum items are reached,
-		// also check the database iterator is exhausted or not.
-		if len(keys) == max {
-			diskMore = iter.Next()
-			break
 		}
 	}
 	// Update metrics for database iteration and merkle proving

--- a/core/state/snapshot/generate.go
+++ b/core/state/snapshot/generate.go
@@ -391,6 +391,7 @@ func (dl *diskLayer) genRange(root common.Hash, prefix []byte, kind string, orig
 				kvkeys = kvkeys[1:]
 				kvvals = kvvals[1:]
 				deleted += 1
+				continue
 			} else if cmp == 0 {
 				// the snapshot key can be overwritten
 				if write = !bytes.Equal(kvvals[0], iter.Value); write {

--- a/core/state/snapshot/generate.go
+++ b/core/state/snapshot/generate.go
@@ -332,7 +332,7 @@ func (dl *diskLayer) genRange(root common.Hash, prefix []byte, kind string, orig
 	// The range prover says the range is correct, skip trie iteration
 	if result.valid() {
 		snapSuccessfulRangeProofMeter.Mark(1)
-		logger.Debug("Proved state range", "last", hexutil.Encode(last))
+		logger.Trace("Proved state range", "last", hexutil.Encode(last))
 
 		// The verification is passed, process each state with the given
 		// callback function. If this state represents a contract, the
@@ -342,7 +342,7 @@ func (dl *diskLayer) genRange(root common.Hash, prefix []byte, kind string, orig
 		}
 		return !result.hasMoreElems, last, nil
 	}
-	logger.Debug("Detected outdated state range", "last", hexutil.Encode(last), "error", result.proofErr)
+	logger.Trace("Detected outdated state range", "last", hexutil.Encode(last), "error", result.proofErr)
 	snapFailedRangeProofMeter.Mark(1)
 
 	// Special case, the entire trie is missing. In the original trie scheme,
@@ -384,6 +384,7 @@ func (dl *diskLayer) genRange(root common.Hash, prefix []byte, kind string, orig
 		count += 1
 
 		write := true
+		created++
 		for len(kvkeys) > 0 {
 			if cmp := bytes.Compare(kvkeys[0], iter.Key); cmp < 0 {
 				// delete the key
@@ -396,6 +397,7 @@ func (dl *diskLayer) genRange(root common.Hash, prefix []byte, kind string, orig
 				continue
 			} else if cmp == 0 {
 				// the snapshot key can be overwritten
+				created--
 				if write = !bytes.Equal(kvvals[0], iter.Value); write {
 					updated++
 				} else {

--- a/core/state/snapshot/generate.go
+++ b/core/state/snapshot/generate.go
@@ -475,10 +475,10 @@ func (dl *diskLayer) genRange(root common.Hash, prefix []byte, kind string, orig
 	// Update metrics for counting trie iteration
 	if kind == "storage" {
 		storageTrieRead += time.Since(start) - internal
-		snapStorageSnapReadTimer.Update(int64(storageTrieRead))
+		snapStorageTrieReadTimer.Update(int64(storageTrieRead))
 	} else {
 		accountTrieRead += time.Since(start) - internal
-		snapAccountSnapReadTimer.Update(int64(accountTrieRead))
+		snapAccountTrieReadTimer.Update(int64(accountTrieRead))
 	}
 	logger.Debug("Regenerated state range", "root", root, "last", hexutil.Encode(last),
 		"count", count, "created", created, "updated", updated, "untouched", untouched, "deleted", deleted)

--- a/core/state/snapshot/generate.go
+++ b/core/state/snapshot/generate.go
@@ -207,7 +207,7 @@ func journalProgress(db ethdb.KeyValueWriter, marker []byte, stats *generatorSta
 }
 
 // proofResult contains the output of range proving which can be used
-// for further processing no matter it's successful or not.
+// for further processing regardless if it is successful or not.
 type proofResult struct {
 	keys     [][]byte   // The key set of all elements being iterated, even proving is failed
 	vals     [][]byte   // The val set of all elements being iterated, even proving is failed
@@ -222,7 +222,7 @@ func (result *proofResult) valid() bool {
 	return result.proofErr == nil
 }
 
-// last returns the last verified element key no matter the range proof is
+// last returns the last verified element key regardless of whether the range proof is
 // successful or not. Nil is returned if nothing involved in the proving.
 func (result *proofResult) last() []byte {
 	var last []byte
@@ -244,7 +244,7 @@ func (result *proofResult) forEach(callback func(key []byte, val []byte) error) 
 	return nil
 }
 
-// proveRange proves the state segment with particular prefix is "valid".
+// proveRange proves the snapshot segment with particular prefix is "valid".
 // The iteration start point will be assigned if the iterator is restored from
 // the last interruption. Max will be assigned in order to limit the maximum
 // amount of data involved in each iteration.
@@ -346,7 +346,7 @@ func (dl *diskLayer) proveRange(stats *generatorStats, root common.Hash, prefix 
 			return &proofResult{keys: keys, vals: vals, diskMore: diskMore, trieMore: false, proofErr: err, tr: tr}, nil
 		}
 	}
-	// Verify the state segment with range prover, ensure that all flat states
+	// Verify the snapshot segment with range prover, ensure that all flat states
 	// in this range correspond to merkle trie.
 	_, _, _, cont, err := trie.VerifyRangeProof(root, origin, last, keys, vals, proof)
 	return &proofResult{keys: keys, vals: vals, diskMore: diskMore, trieMore: cont, proofErr: err, tr: tr}, nil

--- a/core/state/snapshot/generate.go
+++ b/core/state/snapshot/generate.go
@@ -144,6 +144,16 @@ func (gs *generatorStats) Log(msg string, root common.Hash, marker []byte) {
 	log.Info(msg, ctx...)
 }
 
+// ClearSnapshotMarker sets the snapshot marker to zero, meaning that snapshots
+// are not usable.
+func ClearSnapshotMarker(diskdb ethdb.KeyValueStore) {
+	batch := diskdb.NewBatch()
+	journalProgress(batch, []byte{}, nil)
+	if err := batch.Write(); err != nil {
+		log.Crit("Failed to write initialized state marker", "err", err)
+	}
+}
+
 // generateSnapshot regenerates a brand new snapshot based on an existing state
 // database and head block asynchronously. The snapshot is returned immediately
 // and generation is continued in the background until done.

--- a/core/state/snapshot/generate.go
+++ b/core/state/snapshot/generate.go
@@ -297,6 +297,7 @@ func (dl *diskLayer) proveRange(stats *generatorStats, root common.Hash, prefix 
 				// Here append the original value to ensure that the number of key and
 				// value are the same.
 				vals = append(vals, common.CopyBytes(iter.Value()))
+				log.Error("Failed to convert account state data", "err", err)
 			} else {
 				vals = append(vals, val)
 			}

--- a/core/state/snapshot/generate_test.go
+++ b/core/state/snapshot/generate_test.go
@@ -453,18 +453,22 @@ func TestGenerateWithExtraAccounts(t *testing.T) {
 		val, _ := rlp.EncodeToBytes(acc)
 		accTrie.Update([]byte("acc-1"), val) // 0x9250573b9c18c664139f3b6a7a8081b7d8f8916a8fcc5d94feec6c29f5fd4e9e
 		// Identical in the snap
-		rawdb.WriteAccountSnapshot(diskdb, hashData([]byte("acc-1")), val)
-		rawdb.WriteStorageSnapshot(diskdb, hashData([]byte("acc-1")), hashData([]byte("key-1")), []byte("val-1"))
-		rawdb.WriteStorageSnapshot(diskdb, hashData([]byte("acc-1")), hashData([]byte("key-2")), []byte("val-2"))
-		rawdb.WriteStorageSnapshot(diskdb, hashData([]byte("acc-1")), hashData([]byte("key-3")), []byte("val-3"))
+		key := hashData([]byte("acc-1"))
+		rawdb.WriteAccountSnapshot(diskdb, key, val)
+		rawdb.WriteStorageSnapshot(diskdb, key, hashData([]byte("key-1")), []byte("val-1"))
+		rawdb.WriteStorageSnapshot(diskdb, key, hashData([]byte("key-2")), []byte("val-2"))
+		rawdb.WriteStorageSnapshot(diskdb, key, hashData([]byte("key-3")), []byte("val-3"))
+		rawdb.WriteStorageSnapshot(diskdb, key, hashData([]byte("key-4")), []byte("val-4"))
+		rawdb.WriteStorageSnapshot(diskdb, key, hashData([]byte("key-5")), []byte("val-5"))
 	}
 	{ // Account two exists only in the snapshot
 		acc := &Account{Balance: big.NewInt(1), Root: stTrie.Hash().Bytes(), CodeHash: emptyCode.Bytes()}
 		val, _ := rlp.EncodeToBytes(acc)
-		rawdb.WriteAccountSnapshot(diskdb, hashData([]byte("acc-2")), val)
-		rawdb.WriteStorageSnapshot(diskdb, hashData([]byte("acc-2")), hashData([]byte("b-key-1")), []byte("b-val-1"))
-		rawdb.WriteStorageSnapshot(diskdb, hashData([]byte("acc-2")), hashData([]byte("b-key-2")), []byte("b-val-2"))
-		rawdb.WriteStorageSnapshot(diskdb, hashData([]byte("acc-2")), hashData([]byte("b-key-3")), []byte("b-val-3"))
+		key := hashData([]byte("acc-2"))
+		rawdb.WriteAccountSnapshot(diskdb, key, val)
+		rawdb.WriteStorageSnapshot(diskdb, key, hashData([]byte("b-key-1")), []byte("b-val-1"))
+		rawdb.WriteStorageSnapshot(diskdb, key, hashData([]byte("b-key-2")), []byte("b-val-2"))
+		rawdb.WriteStorageSnapshot(diskdb, key, hashData([]byte("b-key-3")), []byte("b-val-3"))
 	}
 	root, _ := accTrie.Commit(nil)
 	t.Logf("root: %x", root)
@@ -495,7 +499,7 @@ func TestGenerateWithManyExtraAccounts(t *testing.T) {
 	var (
 		diskdb = memorydb.New()
 		triedb = trie.NewDatabase(diskdb)
-		stTrie = getStorageTrie(5, triedb)
+		stTrie = getStorageTrie(3, triedb)
 	)
 	accTrie, _ := trie.NewSecure(common.Hash{}, triedb)
 	{ // Account one in the trie
@@ -503,10 +507,11 @@ func TestGenerateWithManyExtraAccounts(t *testing.T) {
 		val, _ := rlp.EncodeToBytes(acc)
 		accTrie.Update([]byte("acc-1"), val) // 0x9250573b9c18c664139f3b6a7a8081b7d8f8916a8fcc5d94feec6c29f5fd4e9e
 		// Identical in the snap
-		rawdb.WriteAccountSnapshot(diskdb, hashData([]byte("acc-1")), val)
-		rawdb.WriteStorageSnapshot(diskdb, hashData([]byte("acc-1")), hashData([]byte("key-1")), []byte("val-1"))
-		rawdb.WriteStorageSnapshot(diskdb, hashData([]byte("acc-1")), hashData([]byte("key-2")), []byte("val-2"))
-		rawdb.WriteStorageSnapshot(diskdb, hashData([]byte("acc-1")), hashData([]byte("key-3")), []byte("val-3"))
+		key := hashData([]byte("acc-1"))
+		rawdb.WriteAccountSnapshot(diskdb, key, val)
+		rawdb.WriteStorageSnapshot(diskdb, key, hashData([]byte("key-1")), []byte("val-1"))
+		rawdb.WriteStorageSnapshot(diskdb, key, hashData([]byte("key-2")), []byte("val-2"))
+		rawdb.WriteStorageSnapshot(diskdb, key, hashData([]byte("key-3")), []byte("val-3"))
 	}
 	{ // 100 accounts exist only in snapshot
 		for i := 0; i < 100; i++ {

--- a/core/state/snapshot/generate_test.go
+++ b/core/state/snapshot/generate_test.go
@@ -175,7 +175,9 @@ func checkSnapRoot(t *testing.T, snap *diskLayer, trieRoot common.Hash) {
 // - the contract(non-empty storage) misses some storage slots
 // - the contract(non-empty storage) has wrong storage slots
 func TestGenerateExistentStateWithWrongStorage(t *testing.T) {
-	log.Root().SetHandler(log.LvlFilterHandler(log.LvlTrace, log.StreamHandler(os.Stderr, log.TerminalFormat(true))))
+	if false {
+		log.Root().SetHandler(log.LvlFilterHandler(log.LvlTrace, log.StreamHandler(os.Stderr, log.TerminalFormat(true))))
+	}
 
 	// We can't use statedb to make a test trie (circular dependency), so make
 	// a fake one manually. We're going with a small account trie of 3 accounts,

--- a/core/state/snapshot/generate_test.go
+++ b/core/state/snapshot/generate_test.go
@@ -235,7 +235,6 @@ func TestGenerateExistentStateWithWrongStorage(t *testing.T) {
 		acc := &Account{Balance: big.NewInt(3), Root: stTrie.Hash().Bytes(), CodeHash: emptyCode.Bytes()}
 		val, _ := rlp.EncodeToBytes(acc)
 		accTrie.Update([]byte("acc-5"), val)
-		val, _ = rlp.EncodeToBytes(acc)
 		rawdb.WriteAccountSnapshot(diskdb, hashData([]byte("acc-5")), val)
 		rawdb.WriteStorageSnapshot(diskdb, hashData([]byte("acc-5")), hashData([]byte("key-1")), []byte("badval-1"))
 		rawdb.WriteStorageSnapshot(diskdb, hashData([]byte("acc-5")), hashData([]byte("key-2")), []byte("badval-2"))

--- a/core/state/snapshot/generate_test.go
+++ b/core/state/snapshot/generate_test.go
@@ -667,7 +667,9 @@ func TestGenerateWithManyExtraAccounts(t *testing.T) {
 // But in the database, we still have the stale storage slots 0x04, 0x05. They are not iterated yet, but the procedure is finished.
 func TestGenerateWithExtraBeforeAndAfter(t *testing.T) {
 	accountCheckRange = 3
-	log.Root().SetHandler(log.LvlFilterHandler(log.LvlTrace, log.StreamHandler(os.Stderr, log.TerminalFormat(true))))
+	if false {
+		enableLogging()
+	}
 	var (
 		diskdb = memorydb.New()
 		triedb = trie.NewDatabase(diskdb)
@@ -711,7 +713,9 @@ func TestGenerateWithExtraBeforeAndAfter(t *testing.T) {
 // in the snapshot database, which cannot be parsed back to an account
 func TestGenerateWithMalformedSnapdata(t *testing.T) {
 	accountCheckRange = 3
-	log.Root().SetHandler(log.LvlFilterHandler(log.LvlTrace, log.StreamHandler(os.Stderr, log.TerminalFormat(true))))
+	if false {
+		enableLogging()
+	}
 	var (
 		diskdb = memorydb.New()
 		triedb = trie.NewDatabase(diskdb)

--- a/core/state/snapshot/generate_test.go
+++ b/core/state/snapshot/generate_test.go
@@ -492,6 +492,10 @@ func TestGenerateWithExtraAccounts(t *testing.T) {
 	root, _ := accTrie.Commit(nil)
 	t.Logf("root: %x", root)
 	triedb.Commit(root, false, nil)
+	// To verify the test: If we now inspect the snap db, there should exist extraneous storage items
+	if data := rawdb.ReadStorageSnapshot(diskdb, hashData([]byte("acc-2")), hashData([]byte("b-key-1"))); data == nil {
+		t.Fatalf("expected snap storage to exist")
+	}
 
 	snap := generateSnapshot(diskdb, triedb, 16, root)
 	select {
@@ -564,10 +568,6 @@ func TestGenerateWithManyExtraAccounts(t *testing.T) {
 	stop := make(chan *generatorStats)
 	snap.genAbort <- stop
 	<-stop
-	// If we now inspect the snap db, there should exist no extraneous storage items
-	if data := rawdb.ReadStorageSnapshot(diskdb, hashData([]byte("acc-2")), hashData([]byte("b-key-1"))); data != nil {
-		t.Fatalf("expected slot to be removed, got %v", string(data))
-	}
 }
 
 // Tests this case
@@ -619,10 +619,6 @@ func TestGenerateWithExtraBeforeAndAfter(t *testing.T) {
 	stop := make(chan *generatorStats)
 	snap.genAbort <- stop
 	<-stop
-	// If we now inspect the snap db, there should exist no extraneous storage items
-	if data := rawdb.ReadStorageSnapshot(diskdb, hashData([]byte("acc-2")), hashData([]byte("b-key-1"))); data != nil {
-		t.Fatalf("expected slot to be removed, got %v", string(data))
-	}
 }
 
 // TestGenerateWithMalformedSnapdata tests what happes if we have some junk

--- a/core/state/snapshot/generate_test.go
+++ b/core/state/snapshot/generate_test.go
@@ -168,8 +168,11 @@ func checkSnapRoot(t *testing.T, snap *diskLayer, trieRoot common.Hash) {
 }
 
 // Tests that snapshot generation with existent flat state, where the flat state contains
-// some errors
-func TestGenerateExistentStateWithExtraStorage(t *testing.T) {
+// some errors:
+// - the contract with empty storage root but has storage entries in the disk
+// - the contract(non-empty storage) misses some storage slots
+// - the contract(non-empty storage) has wrong storage slots
+func TestGenerateExistentStateWithWrongStorage(t *testing.T) {
 	//log.Root().SetHandler(log.LvlFilterHandler(log.LvlInfo, log.StreamHandler(os.Stderr, log.TerminalFormat(true))))
 
 	// We can't use statedb to make a test trie (circular dependency), so make
@@ -187,37 +190,56 @@ func TestGenerateExistentStateWithExtraStorage(t *testing.T) {
 
 	accTrie, _ := trie.NewSecure(common.Hash{}, triedb)
 
-	{ // Account one
+	{ // Account one, miss storage slots in the end(key-3)
 		acc := &Account{Balance: big.NewInt(1), Root: stTrie.Hash().Bytes(), CodeHash: emptyCode.Bytes()}
 		val, _ := rlp.EncodeToBytes(acc)
-		accTrie.Update([]byte("acc-1"), val) // 0x9250573b9c18c664139f3b6a7a8081b7d8f8916a8fcc5d94feec6c29f5fd4e9e
+		accTrie.Update([]byte("acc-1"), val)
 		rawdb.WriteAccountSnapshot(diskdb, hashData([]byte("acc-1")), val)
 		rawdb.WriteStorageSnapshot(diskdb, hashData([]byte("acc-1")), hashData([]byte("key-1")), []byte("val-1"))
 		rawdb.WriteStorageSnapshot(diskdb, hashData([]byte("acc-1")), hashData([]byte("key-2")), []byte("val-2"))
-		rawdb.WriteStorageSnapshot(diskdb, hashData([]byte("acc-1")), hashData([]byte("key-3")), []byte("val-3"))
 	}
-	{ // Account two
+	{ // Account two, miss storage slots in the beginning(key-1)
+		acc := &Account{Balance: big.NewInt(1), Root: stTrie.Hash().Bytes(), CodeHash: emptyCode.Bytes()}
+		val, _ := rlp.EncodeToBytes(acc)
+		accTrie.Update([]byte("acc-2"), val)
+		rawdb.WriteAccountSnapshot(diskdb, hashData([]byte("acc-2")), val)
+		rawdb.WriteStorageSnapshot(diskdb, hashData([]byte("acc-2")), hashData([]byte("key-2")), []byte("val-2"))
+		rawdb.WriteStorageSnapshot(diskdb, hashData([]byte("acc-2")), hashData([]byte("key-3")), []byte("val-3"))
+	}
+	{ // Account three
 		// The storage root is emptyHash, but the flat db has some storage values. This can happen
 		// if the storage was unset during sync
 		acc := &Account{Balance: big.NewInt(2), Root: emptyRoot.Bytes(), CodeHash: emptyCode.Bytes()}
 		val, _ := rlp.EncodeToBytes(acc)
-		accTrie.Update([]byte("acc-2"), val) // 0x65145f923027566669a1ae5ccac66f945b55ff6eaeb17d2ea8e048b7d381f2d7
-		diskdb.Put(hashData([]byte("acc-2")).Bytes(), val)
-		rawdb.WriteAccountSnapshot(diskdb, hashData([]byte("acc-2")), val)
-		rawdb.WriteStorageSnapshot(diskdb, hashData([]byte("acc-2")), hashData([]byte("key-1")), []byte("val-1"))
+		accTrie.Update([]byte("acc-3"), val)
+		diskdb.Put(hashData([]byte("acc-3")).Bytes(), val)
+		rawdb.WriteAccountSnapshot(diskdb, hashData([]byte("acc-3")), val)
+		rawdb.WriteStorageSnapshot(diskdb, hashData([]byte("acc-3")), hashData([]byte("key-1")), []byte("val-1"))
 	}
 
-	{ // Account three
+	{ // Account four
 		// This account changed codehash
 		acc := &Account{Balance: big.NewInt(3), Root: stTrie.Hash().Bytes(), CodeHash: emptyCode.Bytes()}
 		val, _ := rlp.EncodeToBytes(acc)
-		accTrie.Update([]byte("acc-3"), val) // 0x50815097425d000edfc8b3a4a13e175fc2bdcfee8bdfbf2d1ff61041d3c235b2
+		accTrie.Update([]byte("acc-4"), val)
 		acc.CodeHash = hashData([]byte("codez")).Bytes()
 		val, _ = rlp.EncodeToBytes(acc)
-		rawdb.WriteAccountSnapshot(diskdb, hashData([]byte("acc-3")), val)
-		rawdb.WriteStorageSnapshot(diskdb, hashData([]byte("acc-3")), hashData([]byte("key-1")), []byte("val-1"))
-		rawdb.WriteStorageSnapshot(diskdb, hashData([]byte("acc-3")), hashData([]byte("key-2")), []byte("val-2"))
-		rawdb.WriteStorageSnapshot(diskdb, hashData([]byte("acc-3")), hashData([]byte("key-3")), []byte("val-3"))
+		rawdb.WriteAccountSnapshot(diskdb, hashData([]byte("acc-4")), val)
+		rawdb.WriteStorageSnapshot(diskdb, hashData([]byte("acc-4")), hashData([]byte("key-1")), []byte("val-1"))
+		rawdb.WriteStorageSnapshot(diskdb, hashData([]byte("acc-4")), hashData([]byte("key-2")), []byte("val-2"))
+		rawdb.WriteStorageSnapshot(diskdb, hashData([]byte("acc-4")), hashData([]byte("key-3")), []byte("val-3"))
+	}
+
+	{ // Account five
+		// This account has the wrong storage slot
+		acc := &Account{Balance: big.NewInt(3), Root: stTrie.Hash().Bytes(), CodeHash: emptyCode.Bytes()}
+		val, _ := rlp.EncodeToBytes(acc)
+		accTrie.Update([]byte("acc-5"), val)
+		val, _ = rlp.EncodeToBytes(acc)
+		rawdb.WriteAccountSnapshot(diskdb, hashData([]byte("acc-5")), val)
+		rawdb.WriteStorageSnapshot(diskdb, hashData([]byte("acc-5")), hashData([]byte("key-1")), []byte("badval-1"))
+		rawdb.WriteStorageSnapshot(diskdb, hashData([]byte("acc-5")), hashData([]byte("key-2")), []byte("badval-2"))
+		rawdb.WriteStorageSnapshot(diskdb, hashData([]byte("acc-5")), hashData([]byte("key-3")), []byte("badval-3"))
 	}
 
 	root, _ := accTrie.Commit(nil) // Root: 0xe3712f1a226f3782caca78ca770ccc19ee000552813a9f59d479f8611db9b1fd

--- a/core/state/snapshot/generate_test.go
+++ b/core/state/snapshot/generate_test.go
@@ -518,7 +518,7 @@ func enableLogging() {
 
 // Tests that snapshot generation when an extra account with storage exists in the snap state.
 func TestGenerateWithManyExtraAccounts(t *testing.T) {
-	if true {
+	if false {
 		enableLogging()
 	}
 	var (

--- a/core/state/snapshot/snapshot.go
+++ b/core/state/snapshot/snapshot.go
@@ -662,8 +662,9 @@ func (t *Tree) Rebuild(root common.Hash) {
 		case *diskLayer:
 			// If the base layer is generating, abort it and save
 			if layer.genAbort != nil {
-				abort := make(chan *generatorStats, 1) // Discard the stats
+				abort := make(chan *generatorStats)
 				layer.genAbort <- abort
+				<-abort
 			}
 			// Layer should be inactive now, mark it as stale
 			layer.lock.Lock()

--- a/core/state/snapshot/snapshot.go
+++ b/core/state/snapshot/snapshot.go
@@ -662,7 +662,7 @@ func (t *Tree) Rebuild(root common.Hash) {
 		case *diskLayer:
 			// If the base layer is generating, abort it and save
 			if layer.genAbort != nil {
-				abort := make(chan *generatorStats)
+				abort := make(chan *generatorStats, 1) // Discard the stats
 				layer.genAbort <- abort
 			}
 			// Layer should be inactive now, mark it as stale

--- a/core/state/snapshot/wipe.go
+++ b/core/state/snapshot/wipe.go
@@ -85,6 +85,8 @@ func wipeContent(db ethdb.KeyValueStore) error {
 // wipeKeyRange deletes a range of keys from the database starting with prefix
 // and having a specific total key length. The start and limit is optional for
 // specifying a particular key range for deletion.
+//
+// Origin is included for wiping and limit is excluded if they are specified.
 func wipeKeyRange(db ethdb.KeyValueStore, kind string, prefix []byte, origin []byte, limit []byte, keylen int, meter metrics.Meter, report bool) error {
 	// Batch deletions together to avoid holding an iterator for too long
 	var (

--- a/core/state/statedb.go
+++ b/core/state/statedb.go
@@ -948,7 +948,7 @@ func (s *StateDB) Commit(deleteEmptyObjects bool) (common.Hash, error) {
 	// The onleaf func is called _serially_, so we can reuse the same account
 	// for unmarshalling every time.
 	var account Account
-	root, err := s.trie.Commit(func(path []byte, leaf []byte, parent common.Hash) error {
+	root, err := s.trie.Commit(func(_ [][]byte, _ []byte, leaf []byte, parent common.Hash) error {
 		if err := rlp.DecodeBytes(leaf, &account); err != nil {
 			return nil
 		}

--- a/core/state/sync.go
+++ b/core/state/sync.go
@@ -26,17 +26,31 @@ import (
 )
 
 // NewStateSync create a new state trie download scheduler.
-func NewStateSync(root common.Hash, database ethdb.KeyValueReader, bloom *trie.SyncBloom) *trie.Sync {
+func NewStateSync(root common.Hash, database ethdb.KeyValueReader, bloom *trie.SyncBloom, onLeaf func(path []byte, leaf []byte) error) *trie.Sync {
+	// Register the storage slot callback if the external callback is specified.
+	var onSlot func(path []byte, leaf []byte, parent common.Hash) error
+	if onLeaf != nil {
+		onSlot = func(path []byte, leaf []byte, parent common.Hash) error {
+			return onLeaf(path, leaf)
+		}
+	}
+	// Register the account callback to connect the state trie and the storage
+	// trie belongs to the contract.
 	var syncer *trie.Sync
-	callback := func(path []byte, leaf []byte, parent common.Hash) error {
+	onAccount := func(path []byte, leaf []byte, parent common.Hash) error {
+		if onLeaf != nil {
+			if err := onLeaf(path, leaf); err != nil {
+				return err
+			}
+		}
 		var obj Account
 		if err := rlp.Decode(bytes.NewReader(leaf), &obj); err != nil {
 			return err
 		}
-		syncer.AddSubTrie(obj.Root, path, parent, nil)
+		syncer.AddSubTrie(obj.Root, path, parent, onSlot)
 		syncer.AddCodeEntry(common.BytesToHash(obj.CodeHash), path, parent)
 		return nil
 	}
-	syncer = trie.NewSync(root, database, callback, bloom)
+	syncer = trie.NewSync(root, database, onAccount, bloom)
 	return syncer
 }

--- a/core/state/sync.go
+++ b/core/state/sync.go
@@ -26,20 +26,20 @@ import (
 )
 
 // NewStateSync create a new state trie download scheduler.
-func NewStateSync(root common.Hash, database ethdb.KeyValueReader, bloom *trie.SyncBloom, onLeaf func(path []byte, leaf []byte) error) *trie.Sync {
+func NewStateSync(root common.Hash, database ethdb.KeyValueReader, bloom *trie.SyncBloom, onLeaf func(paths [][]byte, leaf []byte) error) *trie.Sync {
 	// Register the storage slot callback if the external callback is specified.
-	var onSlot func(path []byte, leaf []byte, parent common.Hash) error
+	var onSlot func(paths [][]byte, hexpath []byte, leaf []byte, parent common.Hash) error
 	if onLeaf != nil {
-		onSlot = func(path []byte, leaf []byte, parent common.Hash) error {
-			return onLeaf(path, leaf)
+		onSlot = func(paths [][]byte, hexpath []byte, leaf []byte, parent common.Hash) error {
+			return onLeaf(paths, leaf)
 		}
 	}
 	// Register the account callback to connect the state trie and the storage
 	// trie belongs to the contract.
 	var syncer *trie.Sync
-	onAccount := func(path []byte, leaf []byte, parent common.Hash) error {
+	onAccount := func(paths [][]byte, hexpath []byte, leaf []byte, parent common.Hash) error {
 		if onLeaf != nil {
-			if err := onLeaf(path, leaf); err != nil {
+			if err := onLeaf(paths, leaf); err != nil {
 				return err
 			}
 		}
@@ -47,8 +47,8 @@ func NewStateSync(root common.Hash, database ethdb.KeyValueReader, bloom *trie.S
 		if err := rlp.Decode(bytes.NewReader(leaf), &obj); err != nil {
 			return err
 		}
-		syncer.AddSubTrie(obj.Root, path, parent, onSlot)
-		syncer.AddCodeEntry(common.BytesToHash(obj.CodeHash), path, parent)
+		syncer.AddSubTrie(obj.Root, hexpath, parent, onSlot)
+		syncer.AddCodeEntry(common.BytesToHash(obj.CodeHash), hexpath, parent)
 		return nil
 	}
 	syncer = trie.NewSync(root, database, onAccount, bloom)

--- a/core/state/sync_test.go
+++ b/core/state/sync_test.go
@@ -133,7 +133,7 @@ func checkStateConsistency(db ethdb.Database, root common.Hash) error {
 // Tests that an empty state is not scheduled for syncing.
 func TestEmptyStateSync(t *testing.T) {
 	empty := common.HexToHash("56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421")
-	sync := NewStateSync(empty, rawdb.NewMemoryDatabase(), trie.NewSyncBloom(1, memorydb.New()))
+	sync := NewStateSync(empty, rawdb.NewMemoryDatabase(), trie.NewSyncBloom(1, memorydb.New()), nil)
 	if nodes, paths, codes := sync.Missing(1); len(nodes) != 0 || len(paths) != 0 || len(codes) != 0 {
 		t.Errorf(" content requested for empty state: %v, %v, %v", nodes, paths, codes)
 	}
@@ -170,7 +170,7 @@ func testIterativeStateSync(t *testing.T, count int, commit bool, bypath bool) {
 
 	// Create a destination state and sync with the scheduler
 	dstDb := rawdb.NewMemoryDatabase()
-	sched := NewStateSync(srcRoot, dstDb, trie.NewSyncBloom(1, dstDb))
+	sched := NewStateSync(srcRoot, dstDb, trie.NewSyncBloom(1, dstDb), nil)
 
 	nodes, paths, codes := sched.Missing(count)
 	var (
@@ -249,7 +249,7 @@ func TestIterativeDelayedStateSync(t *testing.T) {
 
 	// Create a destination state and sync with the scheduler
 	dstDb := rawdb.NewMemoryDatabase()
-	sched := NewStateSync(srcRoot, dstDb, trie.NewSyncBloom(1, dstDb))
+	sched := NewStateSync(srcRoot, dstDb, trie.NewSyncBloom(1, dstDb), nil)
 
 	nodes, _, codes := sched.Missing(0)
 	queue := append(append([]common.Hash{}, nodes...), codes...)
@@ -297,7 +297,7 @@ func testIterativeRandomStateSync(t *testing.T, count int) {
 
 	// Create a destination state and sync with the scheduler
 	dstDb := rawdb.NewMemoryDatabase()
-	sched := NewStateSync(srcRoot, dstDb, trie.NewSyncBloom(1, dstDb))
+	sched := NewStateSync(srcRoot, dstDb, trie.NewSyncBloom(1, dstDb), nil)
 
 	queue := make(map[common.Hash]struct{})
 	nodes, _, codes := sched.Missing(count)
@@ -347,7 +347,7 @@ func TestIterativeRandomDelayedStateSync(t *testing.T) {
 
 	// Create a destination state and sync with the scheduler
 	dstDb := rawdb.NewMemoryDatabase()
-	sched := NewStateSync(srcRoot, dstDb, trie.NewSyncBloom(1, dstDb))
+	sched := NewStateSync(srcRoot, dstDb, trie.NewSyncBloom(1, dstDb), nil)
 
 	queue := make(map[common.Hash]struct{})
 	nodes, _, codes := sched.Missing(0)
@@ -414,7 +414,7 @@ func TestIncompleteStateSync(t *testing.T) {
 
 	// Create a destination state and sync with the scheduler
 	dstDb := rawdb.NewMemoryDatabase()
-	sched := NewStateSync(srcRoot, dstDb, trie.NewSyncBloom(1, dstDb))
+	sched := NewStateSync(srcRoot, dstDb, trie.NewSyncBloom(1, dstDb), nil)
 
 	var added []common.Hash
 

--- a/eth/downloader/statesync.go
+++ b/eth/downloader/statesync.go
@@ -298,7 +298,7 @@ func newStateSync(d *Downloader, root common.Hash) *stateSync {
 	return &stateSync{
 		d:         d,
 		root:      root,
-		sched:     state.NewStateSync(root, d.stateDB, d.stateBloom),
+		sched:     state.NewStateSync(root, d.stateDB, d.stateBloom, nil),
 		keccak:    sha3.NewLegacyKeccak256().(crypto.KeccakState),
 		trieTasks: make(map[common.Hash]*trieTask),
 		codeTasks: make(map[common.Hash]*codeTask),

--- a/eth/protocols/snap/sync.go
+++ b/eth/protocols/snap/sync.go
@@ -567,6 +567,11 @@ func (s *Syncer) Sync(root common.Hash, cancel chan struct{}) error {
 		log.Debug("Snapshot sync already completed")
 		return nil
 	}
+	// If sync is still not finished, we need to ensure that any marker is wiped.
+	// Otherwise, it may happen that requests for e.g. genesis-data is delivered
+	// from the snapshot data, instead of from the trie
+	snapshot.ClearSnapshotMarker(s.db)
+
 	defer func() { // Persist any progress, independent of failure
 		for _, task := range s.tasks {
 			s.forwardAccountTask(task)

--- a/eth/protocols/snap/sync.go
+++ b/eth/protocols/snap/sync.go
@@ -2695,9 +2695,9 @@ func (s *Syncer) reportHealProgress(force bool) {
 	var (
 		trienode = fmt.Sprintf("%d@%v", s.trienodeHealSynced, s.trienodeHealBytes.TerminalString())
 		bytecode = fmt.Sprintf("%d@%v", s.bytecodeHealSynced, s.bytecodeHealBytes.TerminalString())
+		accounts = fmt.Sprintf("%d@%v", s.accountHealed, s.accountHealedBytes.TerminalString())
+		storage  = fmt.Sprintf("%d@%v", s.storageHealed, s.storageHealedBytes.TerminalString())
 	)
-	log.Info("State heal in progress", "nodes", trienode, "codes", bytecode,
-		"accounts", s.accountHealed, "account size", s.accountHealedBytes,
-		"storages", s.storageHealed, "storage size", s.storageHealedBytes,
-		"pending", s.healer.scheduler.Pending())
+	log.Info("State heal in progress", "accounts", accounts, "slots", storage,
+		"codes", bytecode, "nodes", trienode, "pending", s.healer.scheduler.Pending())
 }

--- a/eth/protocols/snap/sync.go
+++ b/eth/protocols/snap/sync.go
@@ -2697,5 +2697,7 @@ func (s *Syncer) reportHealProgress(force bool) {
 		bytecode = fmt.Sprintf("%d@%v", s.bytecodeHealSynced, s.bytecodeHealBytes.TerminalString())
 	)
 	log.Info("State heal in progress", "nodes", trienode, "codes", bytecode,
-		"accounts", s.accountHealed, "bytes", s.accountHealedBytes, "storages", s.storageHealed, "bytes", s.storageHealedBytes, "pending", s.healer.scheduler.Pending())
+		"accounts", s.accountHealed, "account size", s.accountHealedBytes,
+		"storages", s.storageHealed, "storage size", s.storageHealedBytes,
+		"pending", s.healer.scheduler.Pending())
 }

--- a/eth/protocols/snap/sync.go
+++ b/eth/protocols/snap/sync.go
@@ -2609,9 +2609,14 @@ func (s *Syncer) onHealByteCodes(peer SyncPeer, id uint64, bytecodes [][]byte) e
 // Note it's not concurrent safe, please handle the concurrent issue outside.
 func (s *Syncer) onHealState(paths [][]byte, value []byte) error {
 	if len(paths) == 1 {
-		rawdb.WriteAccountSnapshot(s.stateWriter, common.BytesToHash(paths[0]), value)
+		var account state.Account
+		if err := rlp.DecodeBytes(value, &account); err != nil {
+			return nil
+		}
+		blob := snapshot.SlimAccountRLP(account.Nonce, account.Balance, account.Root, account.CodeHash)
+		rawdb.WriteAccountSnapshot(s.stateWriter, common.BytesToHash(paths[0]), blob)
 		s.accountHealed += 1
-		s.accountHealedBytes += common.StorageSize(1 + common.HashLength + len(value))
+		s.accountHealedBytes += common.StorageSize(1 + common.HashLength + len(blob))
 	}
 	if len(paths) == 2 {
 		rawdb.WriteStorageSnapshot(s.stateWriter, common.BytesToHash(paths[0]), common.BytesToHash(paths[1]), value)

--- a/eth/protocols/snap/sync.go
+++ b/eth/protocols/snap/sync.go
@@ -2611,21 +2611,25 @@ func (s *Syncer) onHealState(paths [][]byte, value []byte) error {
 	if len(paths) == 1 {
 		var account state.Account
 		if err := rlp.DecodeBytes(value, &account); err != nil {
+			log.Info("Failed to decode account", "error", err) // DEBUG LOG, REMOVE IT
 			return nil
 		}
 		blob := snapshot.SlimAccountRLP(account.Nonce, account.Balance, account.Root, account.CodeHash)
 		rawdb.WriteAccountSnapshot(s.stateWriter, common.BytesToHash(paths[0]), blob)
 		s.accountHealed += 1
 		s.accountHealedBytes += common.StorageSize(1 + common.HashLength + len(blob))
+		log.Info("Heal state account", "hash", paths[0]) // DEBUG LOG, REMOVE IT
 	}
 	if len(paths) == 2 {
 		rawdb.WriteStorageSnapshot(s.stateWriter, common.BytesToHash(paths[0]), common.BytesToHash(paths[1]), value)
 		s.storageHealed += 1
 		s.storageHealedBytes += common.StorageSize(1 + 2*common.HashLength + len(value))
+		log.Info("Heal state storage", "account", paths[0], "hash", paths[1]) // DEBUG LOG, REMOVE IT
 	}
 	if s.stateWriter.ValueSize() > ethdb.IdealBatchSize {
 		s.stateWriter.Write() // It's fine to ignore the error here
 		s.stateWriter.Reset()
+		log.Info("Flush state heal writer") // DEBUG LOG, REMOVE IT
 	}
 	return nil
 }

--- a/eth/protocols/snap/sync.go
+++ b/eth/protocols/snap/sync.go
@@ -436,6 +436,12 @@ type Syncer struct {
 	bytecodeHealDups   uint64             // Number of bytecodes already processed
 	bytecodeHealNops   uint64             // Number of bytecodes not requested
 
+	stateWriter        ethdb.Batch        // Shared batch writer used for persisting raw states
+	accountHealed      uint64             // Number of accounts downloaded during the healing stage
+	accountHealedBytes common.StorageSize // Number of raw account bytes persisted to disk during the healing stage
+	storageHealed      uint64             // Number of storage slots downloaded during the healing stage
+	storageHealedBytes common.StorageSize // Number of raw storage bytes persisted to disk during the healing stage
+
 	startTime time.Time // Time instance when snapshot sync started
 	logTime   time.Time // Time instance when status was last reported
 
@@ -477,6 +483,7 @@ func NewSyncer(db ethdb.KeyValueStore) *Syncer {
 		bytecodeHealReqFails: make(chan *bytecodeHealRequest),
 		trienodeHealResps:    make(chan *trienodeHealResponse),
 		bytecodeHealResps:    make(chan *bytecodeHealResponse),
+		stateWriter:          db.NewBatch(),
 	}
 }
 
@@ -544,7 +551,7 @@ func (s *Syncer) Sync(root common.Hash, cancel chan struct{}) error {
 	s.lock.Lock()
 	s.root = root
 	s.healer = &healTask{
-		scheduler: state.NewStateSync(root, s.db, nil),
+		scheduler: state.NewStateSync(root, s.db, nil, s.onHealState),
 		trieTasks: make(map[common.Hash]trie.SyncPath),
 		codeTasks: make(map[common.Hash]struct{}),
 	}
@@ -569,6 +576,14 @@ func (s *Syncer) Sync(root common.Hash, cancel chan struct{}) error {
 	}()
 
 	log.Debug("Starting snapshot sync cycle", "root", root)
+
+	// Flush out the last committed raw states
+	defer func() {
+		if s.stateWriter.ValueSize() > 0 {
+			s.stateWriter.Write()
+			s.stateWriter.Reset()
+		}
+	}()
 	defer s.report(true)
 
 	// Whether sync completed or not, disregard any future packets
@@ -1853,75 +1868,6 @@ func (s *Syncer) processStorageResponse(res *storageResponse) {
 	// task assigners to pick up and fill.
 }
 
-// stateWriter is a database batch replayer that takes a batch of write operations
-// and extract the flat states from them. The target flat states will be persisted
-// blindly and can be fixed by the generator later.
-type stateWriter struct {
-	db            ethdb.KeyValueWriter
-	res           *trienodeHealResponse
-	accountMarker map[common.Hash]int
-	storageMarker map[common.Hash]int
-
-	accountSynced uint64             // Number of accounts persisted
-	accountBytes  common.StorageSize // Number of account bytes persisted to disk
-	storageSynced uint64             // Number of storage slots persisted
-	storageBytes  common.StorageSize // Number of storage bytes persisted to disk
-}
-
-func newStateWriter(db ethdb.KeyValueWriter, res *trienodeHealResponse) *stateWriter {
-	var (
-		accountMarker = make(map[common.Hash]int)
-		storageMarker = make(map[common.Hash]int)
-	)
-	for i, path := range res.paths {
-		if len(path) == 1 && len(path[0]) == common.HashLength {
-			accountMarker[res.hashes[i]] = i
-		}
-		if len(path) == 2 && len(path[1]) == common.HashLength {
-			storageMarker[res.hashes[i]] = i
-		}
-	}
-	return &stateWriter{
-		db:            db,
-		res:           res,
-		accountMarker: accountMarker,
-		storageMarker: storageMarker,
-	}
-}
-
-// Put reacts to database writes and implements flat state persistence.
-func (w *stateWriter) Put(key []byte, val []byte) error {
-	if len(key) != common.HashLength {
-		return nil
-	}
-	hash := common.BytesToHash(key)
-	if index, ok := w.accountMarker[hash]; ok {
-		rawdb.WriteAccountSnapshot(w.db, common.BytesToHash(w.res.paths[index][0]), w.res.nodes[index])
-		w.accountSynced += 1
-		w.accountBytes += common.StorageSize(1 + common.HashLength + len(w.res.nodes[index]))
-	}
-	if index, ok := w.storageMarker[hash]; ok {
-		rawdb.WriteStorageSnapshot(w.db, common.BytesToHash(w.res.paths[index][0]), common.BytesToHash(w.res.paths[index][1]), w.res.nodes[index])
-		w.storageSynced += 1
-		w.storageBytes += common.StorageSize(1 + 2*common.HashLength + len(w.res.nodes[index]))
-	}
-	return nil
-}
-
-func (w *stateWriter) Delete(key []byte) error {
-	panic("not implemented")
-}
-
-func (w *stateWriter) log() (ret []interface{}) {
-	if w.accountSynced > 0 {
-		ret = append(ret, "accounts", w.accountSynced, "bytes", w.accountBytes)
-	}
-	if w.storageSynced > 0 {
-		ret = append(ret, "storages", w.storageSynced, "bytes", w.storageBytes)
-	}
-	return ret
-}
-
 // processTrienodeHealResponse integrates an already validated trienode response
 // into the healer tasks.
 func (s *Syncer) processTrienodeHealResponse(res *trienodeHealResponse) {
@@ -1955,18 +1901,7 @@ func (s *Syncer) processTrienodeHealResponse(res *trienodeHealResponse) {
 	if err := batch.Write(); err != nil {
 		log.Crit("Failed to persist healing data", "err", err)
 	}
-	stateWriter := newStateWriter(s.db, res)
-	if err := batch.Replay(stateWriter); err != nil {
-		log.Crit("Failed to replay the committed batch", "err", err)
-	}
-	ctx := []interface{}{
-		"type", "trienodes",
-		"bytes", common.StorageSize(batch.ValueSize()),
-	}
-	if logs := stateWriter.log(); logs != nil {
-		ctx = append(ctx, logs...)
-	}
-	log.Info("Persisted set of healing data", ctx...)
+	log.Debug("Persisted set of healing data", "type", "trienodes", "bytes", common.StorageSize(batch.ValueSize()))
 }
 
 // processBytecodeHealResponse integrates an already validated bytecode response
@@ -2668,6 +2603,28 @@ func (s *Syncer) onHealByteCodes(peer SyncPeer, id uint64, bytecodes [][]byte) e
 	return nil
 }
 
+// onHealState is a callback method to invoke when a flat state(account
+// or storage slot) is downloded during the healing stage. The flat states
+// can be persisted blindly and can be fixed later in the generation stage.
+// Note it's not concurrent safe, please handle the concurrent issue outside.
+func (s *Syncer) onHealState(path []byte, value []byte) error {
+	if len(path) == common.HashLength {
+		rawdb.WriteAccountSnapshot(s.stateWriter, common.BytesToHash(path), value)
+		s.accountHealed += 1
+		s.accountHealedBytes += common.StorageSize(1 + common.HashLength + len(value))
+	}
+	if len(path) == 2*common.HashLength {
+		rawdb.WriteStorageSnapshot(s.stateWriter, common.BytesToHash(path[:common.HashLength]), common.BytesToHash(path[common.HashLength:]), value)
+		s.storageHealed += 1
+		s.storageHealedBytes += common.StorageSize(1 + 2*common.HashLength + len(value))
+	}
+	if s.stateWriter.ValueSize() > ethdb.IdealBatchSize {
+		s.stateWriter.Write() // It's fine to ignore the error here
+		s.stateWriter.Reset()
+	}
+	return nil
+}
+
 // hashSpace is the total size of the 256 bit hash space for accounts.
 var hashSpace = new(big.Int).Exp(common.Big2, common.Big256, nil)
 
@@ -2733,5 +2690,5 @@ func (s *Syncer) reportHealProgress(force bool) {
 		bytecode = fmt.Sprintf("%d@%v", s.bytecodeHealSynced, s.bytecodeHealBytes.TerminalString())
 	)
 	log.Info("State heal in progress", "nodes", trienode, "codes", bytecode,
-		"pending", s.healer.scheduler.Pending())
+		"accounts", s.accountHealed, "bytes", s.accountHealedBytes, "storages", s.storageHealed, "bytes", s.storageHealedBytes, "pending", s.healer.scheduler.Pending())
 }

--- a/eth/protocols/snap/sync.go
+++ b/eth/protocols/snap/sync.go
@@ -2607,14 +2607,14 @@ func (s *Syncer) onHealByteCodes(peer SyncPeer, id uint64, bytecodes [][]byte) e
 // or storage slot) is downloded during the healing stage. The flat states
 // can be persisted blindly and can be fixed later in the generation stage.
 // Note it's not concurrent safe, please handle the concurrent issue outside.
-func (s *Syncer) onHealState(path []byte, value []byte) error {
-	if len(path) == common.HashLength {
-		rawdb.WriteAccountSnapshot(s.stateWriter, common.BytesToHash(path), value)
+func (s *Syncer) onHealState(paths [][]byte, value []byte) error {
+	if len(paths) == 1 {
+		rawdb.WriteAccountSnapshot(s.stateWriter, common.BytesToHash(paths[0]), value)
 		s.accountHealed += 1
 		s.accountHealedBytes += common.StorageSize(1 + common.HashLength + len(value))
 	}
-	if len(path) == 2*common.HashLength {
-		rawdb.WriteStorageSnapshot(s.stateWriter, common.BytesToHash(path[:common.HashLength]), common.BytesToHash(path[common.HashLength:]), value)
+	if len(paths) == 2 {
+		rawdb.WriteStorageSnapshot(s.stateWriter, common.BytesToHash(paths[0]), common.BytesToHash(paths[1]), value)
 		s.storageHealed += 1
 		s.storageHealedBytes += common.StorageSize(1 + 2*common.HashLength + len(value))
 	}

--- a/eth/protocols/snap/sync.go
+++ b/eth/protocols/snap/sync.go
@@ -2611,25 +2611,21 @@ func (s *Syncer) onHealState(paths [][]byte, value []byte) error {
 	if len(paths) == 1 {
 		var account state.Account
 		if err := rlp.DecodeBytes(value, &account); err != nil {
-			log.Info("Failed to decode account", "error", err) // DEBUG LOG, REMOVE IT
 			return nil
 		}
 		blob := snapshot.SlimAccountRLP(account.Nonce, account.Balance, account.Root, account.CodeHash)
 		rawdb.WriteAccountSnapshot(s.stateWriter, common.BytesToHash(paths[0]), blob)
 		s.accountHealed += 1
 		s.accountHealedBytes += common.StorageSize(1 + common.HashLength + len(blob))
-		log.Info("Heal state account", "hash", paths[0]) // DEBUG LOG, REMOVE IT
 	}
 	if len(paths) == 2 {
 		rawdb.WriteStorageSnapshot(s.stateWriter, common.BytesToHash(paths[0]), common.BytesToHash(paths[1]), value)
 		s.storageHealed += 1
 		s.storageHealedBytes += common.StorageSize(1 + 2*common.HashLength + len(value))
-		log.Info("Heal state storage", "account", paths[0], "hash", paths[1]) // DEBUG LOG, REMOVE IT
 	}
 	if s.stateWriter.ValueSize() > ethdb.IdealBatchSize {
 		s.stateWriter.Write() // It's fine to ignore the error here
 		s.stateWriter.Reset()
-		log.Info("Flush state heal writer") // DEBUG LOG, REMOVE IT
 	}
 	return nil
 }

--- a/eth/protocols/snap/sync.go
+++ b/eth/protocols/snap/sync.go
@@ -1891,6 +1891,9 @@ func newStateWriter(db ethdb.KeyValueWriter, res *trienodeHealResponse) *stateWr
 
 // Put reacts to database writes and implements flat state persistence.
 func (w *stateWriter) Put(key []byte, val []byte) error {
+	if len(key) != common.HashLength {
+		return nil
+	}
 	hash := common.BytesToHash(key)
 	if index, ok := w.accountMarker[hash]; ok {
 		rawdb.WriteAccountSnapshot(w.db, common.BytesToHash(w.res.paths[index][0]), w.res.nodes[index])
@@ -1914,7 +1917,7 @@ func (w *stateWriter) log() (ret []interface{}) {
 		ret = append(ret, "accounts", w.accountSynced, "bytes", w.accountBytes)
 	}
 	if w.storageSynced > 0 {
-		ret = append(ret, "storages", w.storageSynced, "bytes", w.storageSynced)
+		ret = append(ret, "storages", w.storageSynced, "bytes", w.storageBytes)
 	}
 	return ret
 }
@@ -1956,7 +1959,14 @@ func (s *Syncer) processTrienodeHealResponse(res *trienodeHealResponse) {
 	if err := batch.Replay(stateWriter); err != nil {
 		log.Crit("Failed to replay the committed batch", "err", err)
 	}
-	log.Info("Persisted set of healing data", "type", "trienodes", "bytes", common.StorageSize(batch.ValueSize()), stateWriter.log())
+	ctx := []interface{}{
+		"type", "trienodes",
+		"bytes", common.StorageSize(batch.ValueSize()),
+	}
+	if logs := stateWriter.log(); logs != nil {
+		ctx = append(ctx, logs...)
+	}
+	log.Info("Persisted set of healing data", ctx...)
 }
 
 // processBytecodeHealResponse integrates an already validated bytecode response

--- a/eth/protocols/snap/sync.go
+++ b/eth/protocols/snap/sync.go
@@ -2010,9 +2010,6 @@ func (s *Syncer) forwardAccountTask(task *accountTask) {
 	// outdated during the sync, but it can be fixed later during the
 	// snapshot generation.
 	for i, hash := range res.hashes {
-		if task.needCode[i] || task.needState[i] {
-			break
-		}
 		blob := snapshot.SlimAccountRLP(res.accounts[i].Nonce, res.accounts[i].Balance, res.accounts[i].Root, res.accounts[i].CodeHash)
 		rawdb.WriteAccountSnapshot(batch, hash, blob)
 		bytes += common.StorageSize(1 + common.HashLength + len(blob))

--- a/trie/committer.go
+++ b/trie/committer.go
@@ -220,13 +220,13 @@ func (c *committer) commitLoop(db *Database) {
 			switch n := n.(type) {
 			case *shortNode:
 				if child, ok := n.Val.(valueNode); ok {
-					c.onleaf(nil, child, hash)
+					c.onleaf(nil, nil, child, hash)
 				}
 			case *fullNode:
 				// For children in range [0, 15], it's impossible
 				// to contain valuenode. Only check the 17th child.
 				if n.Children[16] != nil {
-					c.onleaf(nil, n.Children[16].(valueNode), hash)
+					c.onleaf(nil, nil, n.Children[16].(valueNode), hash)
 				}
 			}
 		}

--- a/trie/sync.go
+++ b/trie/sync.go
@@ -398,7 +398,14 @@ func (s *Sync) children(req *request, object node) ([]*request, error) {
 		// Notify any external watcher of a new key/value node
 		if req.callback != nil {
 			if node, ok := (child.node).(valueNode); ok {
-				if err := req.callback(child.path, node, req.hash); err != nil {
+				var paths [][]byte
+				if len(child.path) == 2*common.HashLength {
+					paths = append(paths, hexToKeybytes(child.path))
+				} else if len(child.path) == 4*common.HashLength {
+					paths = append(paths, hexToKeybytes(child.path[:2*common.HashLength]))
+					paths = append(paths, hexToKeybytes(child.path[2*common.HashLength:]))
+				}
+				if err := req.callback(paths, child.path, node, req.hash); err != nil {
 					return nil, err
 				}
 			}

--- a/trie/trie.go
+++ b/trie/trie.go
@@ -37,9 +37,20 @@ var (
 )
 
 // LeafCallback is a callback type invoked when a trie operation reaches a leaf
-// node. It's used by state sync and commit to allow handling external references
-// between account and storage tries.
-type LeafCallback func(path []byte, leaf []byte, parent common.Hash) error
+// node.
+//
+// The paths is a path tuple identifying a particular trie node either in a single
+// trie (account) or a layered trie (account -> storage). Each path in the tuple
+// is in the raw format(32 bytes).
+//
+// The hexpath is a composite hexary path identifying the trie node. All the key
+// bytes are converted to the hexary nibbles and composited with the parent path
+// if the trie node is in a layered trie.
+//
+// It's used by state sync and commit to allow handling external references
+// between account and storage tries. And also it's used in the state healing
+// for extracting the raw states(leaf nodes) with corresponding paths.
+type LeafCallback func(paths [][]byte, hexpath []byte, leaf []byte, parent common.Hash) error
 
 // Trie is a Merkle Patricia Trie.
 // The zero value is an empty trie with no database.

--- a/trie/trie_test.go
+++ b/trie/trie_test.go
@@ -569,7 +569,7 @@ func BenchmarkCommitAfterHash(b *testing.B) {
 		benchmarkCommitAfterHash(b, nil)
 	})
 	var a account
-	onleaf := func(path []byte, leaf []byte, parent common.Hash) error {
+	onleaf := func(paths [][]byte, hexpath []byte, leaf []byte, parent common.Hash) error {
 		rlp.DecodeBytes(leaf, &a)
 		return nil
 	}


### PR DESCRIPTION
This PR improves snapshot generation (post-snap-sync) by orders of magnitude. 

## How snapshot generation works now


When doing a snap sync, we download 'slices' of the trie, individually verified, and use these slices to fill our trie. 
The slices of accounts/storage themselves are forgotten. 

After this is done, we iterate the entire account trie, and every storage trie, to reconstruct the snapshot database. 
This process takes hundreds of hours, and the disk IO is extreme during this process. 


## With this PR

This PR implements the basic idea described here: https://gist.github.com/rjl493456442/85832a0c760f2bafe2a69e33efe68c60 . 

For starters, it stores the snapshots into the database. The account (and storage) data do not actually match up to whatever
root we'll eventually wind up on, but that's for later. 

After the snap sync is done, we start generating the snapshot, as before. But this time, we have some (potentially stale) data already laying there. 

We proceed in batches (ranges). In this PR, the range-size for accounts is `200`, and the range-size for storage is `1024`.

For any given range, we do 
- Ask the snapshot db for that range (e.g. give me 200 accounts starting from `0x00..`. 
- We then check if that range can be _proven_ against the main account trie. 
  - If that is OK, then we know the entire account-set in that range is correct. We then have to still check the storage of each of those. 
  - If the check is not ok, then we have some iteration to do. We iterate the trie over that range, and for each leaf: 
   - If the leaf key/value is identical to the snap-data, leave it (`untouched`) (but also check the storage)
   - If the leaf key is identical, but value differs, update the data (`updated`) (and check the storage)
   - If the key did not exist, write it to the snapshot (`created`). (and check the storage). 
  - And once the iteration is done, we remove any straggling elements that were in the snapshot. 

The same algo is used for storage tries. The idea being that most 99% of all ranges are fine, and that out of the ranges which are not fine, most individual elements are fine. 
This improves the IO performance of generation by orders of magnitude. 


Some other optimizations: 
- For small storage tries (smaller than `1024`), where we can load the entire range into memory, we can do the verification against the expected `root` 
using the `stackTrie`. Just feed everything in there, and have it spit out the root, which we can then compare. This means that we don't have to resolve
the trie for that storage root _at all_. 

Experimental results (mainnet)
```
INFO [03-17|20:43:10.408] Generated state snapshot                 accounts=122184516 slots=422055852 storage=42.15GiB   elapsed=6h48m25.947s
```
During the process, it read `1.5TB` from disk/leveldb (same same). It wrote `22GB` in the first 15 minutes (compaction?), and ended up totalling `24Gb` leveldb writes, `35Gb` disk writes.