### PR TITLE
cmd/devp2p/internal/ethtest: return request ID in BlockHeaders response

### DIFF
--- a/cmd/devp2p/internal/ethtest/eth66_suiteHelpers.go
+++ b/cmd/devp2p/internal/ethtest/eth66_suiteHelpers.go
@@ -141,8 +141,11 @@ func (c *Conn) readAndServe66(chain *Chain, timeout time.Duration) (uint64, Mess
 			if err != nil {
 				return 0, errorf("could not get headers for inbound header request: %v", err)
 			}
-
-			if err := c.Write(headers); err != nil {
+			resp := &eth.BlockHeadersPacket66{
+				RequestId:          reqID,
+				BlockHeadersPacket: eth.BlockHeadersPacket(headers),
+			}
+			if err := c.write66(resp, BlockHeaders{}.Code()); err != nil {
 				return 0, errorf("could not write to connection: %v", err)
 			}
 		default:


### PR DESCRIPTION
This PR fixes an issue with the eth66 test suite where, during a `readAndServe` when the test is manually responding to `GetBlockHeader` requests, it now responds with a `BlockHeaders` eth66 packet that includes the inbound request ID. 