### PR TITLE
eth/protocols/snap, eth/downloader: don't use bloom filter in snap sync

### DIFF
--- a/eth/downloader/downloader.go
+++ b/eth/downloader/downloader.go
@@ -240,7 +240,7 @@ func New(checkpoint uint64, stateDb ethdb.Database, stateBloom *trie.SyncBloom, 
 		headerProcCh:   make(chan []*types.Header, 1),
 		quitCh:         make(chan struct{}),
 		stateCh:        make(chan dataPack),
-		SnapSyncer:     snap.NewSyncer(stateDb, stateBloom),
+		SnapSyncer:     snap.NewSyncer(stateDb),
 		stateSyncStart: make(chan *stateSync),
 		syncStatsState: stateSyncStats{
 			processed: rawdb.ReadFastTrieProgress(stateDb),

--- a/eth/protocols/snap/sync.go
+++ b/eth/protocols/snap/sync.go
@@ -376,8 +376,7 @@ type SyncPeer interface {
 //   - The peer delivers a stale response after a previous timeout
 //   - The peer delivers a refusal to serve the requested state
 type Syncer struct {
-	db    ethdb.KeyValueStore // Database to store the trie nodes into (and dedup)
-	bloom *trie.SyncBloom     // Bloom filter to deduplicate nodes for state fixup
+	db ethdb.KeyValueStore // Database to store the trie nodes into (and dedup)
 
 	root    common.Hash    // Current state trie root being synced
 	tasks   []*accountTask // Current account task set being synced
@@ -446,10 +445,9 @@ type Syncer struct {
 
 // NewSyncer creates a new snapshot syncer to download the Ethereum state over the
 // snap protocol.
-func NewSyncer(db ethdb.KeyValueStore, bloom *trie.SyncBloom) *Syncer {
+func NewSyncer(db ethdb.KeyValueStore) *Syncer {
 	return &Syncer{
-		db:    db,
-		bloom: bloom,
+		db: db,
 
 		peers:    make(map[string]SyncPeer),
 		peerJoin: new(event.Feed),
@@ -546,7 +544,7 @@ func (s *Syncer) Sync(root common.Hash, cancel chan struct{}) error {
 	s.lock.Lock()
 	s.root = root
 	s.healer = &healTask{
-		scheduler: state.NewStateSync(root, s.db, s.bloom),
+		scheduler: state.NewStateSync(root, s.db, nil),
 		trieTasks: make(map[common.Hash]trie.SyncPath),
 		codeTasks: make(map[common.Hash]struct{}),
 	}
@@ -1660,7 +1658,6 @@ func (s *Syncer) processBytecodeResponse(res *bytecodeResponse) {
 		bytes += common.StorageSize(len(code))
 
 		rawdb.WriteCode(batch, hash, code)
-		s.bloom.Add(hash[:])
 	}
 	if err := batch.Write(); err != nil {
 		log.Crit("Failed to persist bytecodes", "err", err)
@@ -1796,7 +1793,6 @@ func (s *Syncer) processStorageResponse(res *storageResponse) {
 			}
 			// Node is not a boundary, persist to disk
 			batch.Put(it.Key(), it.Value())
-			s.bloom.Add(it.Key())
 
 			bytes += common.StorageSize(common.HashLength + len(it.Value()))
 			nodes++
@@ -1953,7 +1949,6 @@ func (s *Syncer) forwardAccountTask(task *accountTask) {
 		}
 		// Node is neither a boundary, not an incomplete account, persist to disk
 		batch.Put(it.Key(), it.Value())
-		s.bloom.Add(it.Key())
 
 		bytes += common.StorageSize(common.HashLength + len(it.Value()))
 		nodes++

--- a/eth/protocols/snap/sync_test.go
+++ b/eth/protocols/snap/sync_test.go
@@ -525,7 +525,7 @@ func TestSyncBloatedProof(t *testing.T) {
 
 func setupSyncer(peers ...*testPeer) *Syncer {
 	stateDb := rawdb.NewMemoryDatabase()
-	syncer := NewSyncer(stateDb, trie.NewSyncBloom(1, stateDb))
+	syncer := NewSyncer(stateDb)
 	for _, peer := range peers {
 		syncer.Register(peer)
 		peer.remote = syncer


### PR DESCRIPTION
This PR removes the use of a bloom filter during snap sync. Bloom filters are nice, but for snap they don't really help _that_ much. We only ever want to do a bit of light healing on top of mostly correct state. 

In practice, however, if the user restarts the node, it will kick of an entire trie-iteration to filll the bloom filter, which is a bit counterproductive for a feature that was meant to accelerate things by keeping the disk IO down. 


