### PR TITLE
ethclient: fix error handling for header test

### DIFF
--- a/ethclient/ethclient_test.go
+++ b/ethclient/ethclient_test.go
@@ -288,8 +288,9 @@ func testHeader(t *testing.T, chain []*types.Block, client *rpc.Client) {
 			want:  chain[1].Header(),
 		},
 		"future_block": {
-			block: big.NewInt(1000000000),
-			want:  nil,
+			block:   big.NewInt(1000000000),
+			want:    nil,
+			wantErr: ethereum.NotFound,
 		},
 	}
 	for name, tt := range tests {
@@ -299,10 +300,10 @@ func testHeader(t *testing.T, chain []*types.Block, client *rpc.Client) {
 			defer cancel()
 
 			got, err := ec.HeaderByNumber(ctx, tt.block)
-			if tt.wantErr != nil && (err == nil || err.Error() != tt.wantErr.Error()) {
+			if !errors.Is(err, tt.wantErr) {
 				t.Fatalf("HeaderByNumber(%v) error = %q, want %q", tt.block, err, tt.wantErr)
 			}
-			if got != nil && got.Number.Sign() == 0 {
+			if got != nil && got.Number != nil && got.Number.Sign() == 0 {
 				got.Number = big.NewInt(0) // hack to make DeepEqual work
 			}
 			if !reflect.DeepEqual(got, tt.want) {


### PR DESCRIPTION
The `wantErr` field was disused, and the error
returned by ec.HeaderByNumber was not properly
tested.

This simplifies the error checking using
`errors.Is` and asserts that getting an expected
missing header returns `ethereum.NotFound`.

Also adds a nil check condition for header.Number
before using big.Int's Sign method.

Date: 2021-03-17 07:57:26-05:00
Signed-off-by: meows <b5c6@protonmail.com>