### PR TITLE
p2p/dnsdisc: fix flaw in dns size calculation

### DIFF
--- a/p2p/dnsdisc/tree.go
+++ b/p2p/dnsdisc/tree.go
@@ -113,10 +113,41 @@ func (t *Tree) Nodes() []*enode.Node {
 	return nodes
 }
 
+/*
+We want to keep the UDP size below 512 bytes. The UDP size is roughly:
+UDP length = 8 + UDP payload length ( 229 )
+UPD Payload length:
+ - dns.id 2
+ - dns.flags 2
+ - dns.count.queries 2
+ - dns.count.answers 2
+ - dns.count.auth_rr 2
+ - dns.count.add_rr 2
+ - queries (query-size + 6)
+ - answers :
+ 	- dns.resp.name 2
+ 	- dns.resp.type 2
+ 	- dns.resp.class 2
+ 	- dns.resp.ttl 4
+ 	- dns.resp.len 2
+ 	- dns.txt.length 1
+ 	- dns.txt resp_data_size
+
+So the total size is roughly a fixed overhead of `39`, and the size of the
+query (domain name) and response.
+The query size is, for example, FVY6INQ6LZ33WLCHO3BPR3FH6Y.snap.mainnet.ethdisco.net (52)
+
+We also have some static data in the response, such as `enrtree-branch:`, and potentially
+splitting the response up with `" "`, leaving us with a size of roughly `400` that we need
+to stay below.
+
+The number `370` is used to have some margin for extra overhead (for example, the dns query
+may be larger - more subdomains).
+*/
 const (
-	hashAbbrev    = 16
-	maxChildren   = 300 / hashAbbrev * (13 / 8)
-	minHashLength = 12
+	hashAbbrevSize = 1 + 16*13/8          // Size of an encoded hash (plus comma)
+	maxChildren    = 370 / hashAbbrevSize // 13 children
+	minHashLength  = 12
 )
 
 // MakeTree creates a tree containing the given nodes and links.


### PR DESCRIPTION
Fixes https://github.com/ethereum/go-ethereum/issues/22532 

The calculation for maxChildren was wrong:
```
300 / 16 * (13 / 8) == 30
```
Should have been
```
300 / (16 * (13 / 8)) == 11
```
After fixing this, I also bumped `300` a bit, so instead of `11` we land at `13` as the max. 