### PR TITLE
cmd/devp2p: add flag for AWS region

### DIFF
--- a/cmd/devp2p/dns_route53.go
+++ b/cmd/devp2p/dns_route53.go
@@ -59,6 +59,11 @@ var (
 		Name:  "zone-id",
 		Usage: "Route53 Zone ID",
 	}
+	route53RegionFlag = cli.StringFlag{
+		Name:  "aws-region",
+		Usage: "AWS Region",
+		Value: "eu-central-1",
+	}
 )
 
 type route53Client struct {
@@ -76,13 +81,14 @@ func newRoute53Client(ctx *cli.Context) *route53Client {
 	akey := ctx.String(route53AccessKeyFlag.Name)
 	asec := ctx.String(route53AccessSecretFlag.Name)
 	if akey == "" || asec == "" {
-		exit(fmt.Errorf("need Route53 Access Key ID and secret proceed"))
+		exit(fmt.Errorf("need Route53 Access Key ID and secret to proceed"))
 	}
 	creds := aws.NewCredentialsCache(credentials.NewStaticCredentialsProvider(akey, asec, ""))
 	cfg, err := config.LoadDefaultConfig(context.Background(), config.WithCredentialsProvider(creds))
 	if err != nil {
 		exit(fmt.Errorf("can't initialize AWS configuration: %v", err))
 	}
+	cfg.Region = ctx.String(route53RegionFlag.Name)
 	return &route53Client{
 		api:    route53.NewFromConfig(cfg),
 		zoneID: ctx.String(route53ZoneIDFlag.Name),

--- a/cmd/devp2p/dnscmd.go
+++ b/cmd/devp2p/dnscmd.go
@@ -77,7 +77,12 @@ var (
 		Usage:     "Deploy DNS TXT records to Amazon Route53",
 		ArgsUsage: "<tree-directory>",
 		Action:    dnsToRoute53,
-		Flags:     []cli.Flag{route53AccessKeyFlag, route53AccessSecretFlag, route53ZoneIDFlag},
+		Flags: []cli.Flag{
+			route53AccessKeyFlag,
+			route53AccessSecretFlag,
+			route53ZoneIDFlag,
+			route53RegionFlag,
+		},
 	}
 )
 


### PR DESCRIPTION
AWS SDK v2 requires setting the region explicity.