### PR TITLE
cmd/devp2p: fix error in updating the cursor when collecting route53 records

### DIFF
--- a/cmd/devp2p/dns_route53.go
+++ b/cmd/devp2p/dns_route53.go
@@ -315,8 +315,16 @@ func (c *route53Client) collectRecords(name string) (map[string]recordSet, error
 			break
 		}
 
-		// sets the cursor to the next batch
+		// Set the cursor to the next batc. From the AWS docs:
+		//
+		// To display the next page of results, get the values of NextRecordName,
+		// NextRecordType, and NextRecordIdentifier (if any) from the response. Then submit
+		// another ListResourceRecordSets request, and specify those values for
+		// StartRecordName, StartRecordType, and StartRecordIdentifier.
+
 		req.StartRecordIdentifier = resp.NextRecordIdentifier
+		req.StartRecordName = resp.NextRecordName
+		req.StartRecordType = resp.NextRecordType
 	}
 
 	return existing, nil


### PR DESCRIPTION
This PR fixes a regression introduced in https://github.com/ethereum/go-ethereum/pull/22360, when we updated to the `v2` of the AWS sdk, which causes current crawler to just get the same first `100` results over and over, and get stuck in a loop. 
