### PR TITLE
cmd/puppeth: specify working directory for nodejs 15

### DIFF
--- a/cmd/puppeth/module_dashboard.go
+++ b/cmd/puppeth/module_dashboard.go
@@ -518,6 +518,8 @@ var dashboardMascot = []byte("\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR\x00\x00\x01s\x
 var dashboardDockerfile = `
 FROM mhart/alpine-node:latest
 
+WORKDIR /usr/app
+
 RUN \
 	npm install connect serve-static && \
 	\


### PR DESCRIPTION
So basically with nodejs 15, if no WORKDIR is specified, NPM is executed in the root of the container

closes https://github.com/ethereum/go-ethereum/issues/22439
see also https://stackoverflow.com/questions/57534295/npm-err-tracker-idealtree-already-exists-while-creating-the-docker-image-for