### PR TITLE
core/state/snapshot: fix panic on missing parent

### DIFF
--- a/core/state/snapshot/snapshot.go
+++ b/core/state/snapshot/snapshot.go
@@ -283,11 +283,11 @@ func (t *Tree) Update(blockRoot common.Hash, parentRoot common.Hash, destructs m
 		return errSnapshotCycle
 	}
 	// Generate a new snapshot on top of the parent
-	parent := t.Snapshot(parentRoot).(snapshot)
+	parent := t.Snapshot(parentRoot)
 	if parent == nil {
 		return fmt.Errorf("parent [%#x] snapshot missing", parentRoot)
 	}
-	snap := parent.Update(blockRoot, destructs, accounts, storage)
+	snap := parent.(snapshot).Update(blockRoot, destructs, accounts, storage)
 
 	// Save the new snapshot for later
 	t.lock.Lock()


### PR DESCRIPTION
When building a snapshot on top of a parent, the parent may occasionally be missing (if there are many blocks imported whilst simultaneously mining a new block). In that case, the current code panics because the path that checks for missing parent already makes an interface conversion before `nil` check.

```
panic: interface conversion: interface is nil, not snapshot.snapshot
goroutine 92 [running]:
github.com/ethereum/go-ethereum/core/state/snapshot.(*Tree).Update(0xc02b51d100, 0x1881189dfd6131c7, 0x65806745df63f116, 0xeeb17030c8ccf09f, 0x8be3502ada3d5705, 0xf3286cf6afe5e4da, 0xebc572ab54e816af, 0x6e0e89ca9372a1c2, 0xaa34de51b47e9b97, 0xc087c97ce0, ...)
	github.com/ethereum/go-ethereum/core/state/snapshot/snapshot.go:286 +0xff
github.com/ethereum/go-ethereum/core/state.(*StateDB).Commit(0xc024b59380, 0xc03f27da01, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0)
	github.com/ethereum/go-ethereum/core/state/statedb.go:970 +0x74c
github.com/ethereum/go-ethereum/core.(*BlockChain).writeBlockWithState(0xc0000ab900, 0xc06de0d170, 0xc01aa78680, 0x33, 0x33, 0xc0436bbf00, 0x1a, 0x20, 0xc024b59380, 0xc031685001, ...)
	github.com/ethereum/go-ethereum/core/blockchain.go:1530 +0x76c
github.com/ethereum/go-ethereum/core.(*BlockChain).WriteBlockWithState(0xc0000ab900, 0xc06de0d170, 0xc01aa78680, 0x33, 0x33, 0xc0436bbf00, 0x1a, 0x20, 0xc024b59380, 0x7b4000000d901, ...)
	github.com/ethereum/go-ethereum/core/blockchain.go:1498 +0x111
github.com/ethereum/go-ethereum/miner.(*worker).resultLoop(0xc025218240)
	github.com/ethereum/go-ethereum/miner/worker.go:626 +0x80a
created by github.com/ethereum/go-ethereum/miner.newWorker
	github.com/ethereum/go-ethereum/miner/worker.go:229 +0x585
panic: interface conversion: interface is nil, not snapshot.snapshot
```

The fix is to do the `nil` check first and only afterwards to cast to the `snapshot` interface.