### PR TITLE
eth/protocols, metrics, p2p: add handler performance metrics

### DIFF
--- a/eth/protocols/snap/handler.go
+++ b/eth/protocols/snap/handler.go
@@ -19,12 +19,14 @@ package snap
 import (
 	"bytes"
 	"fmt"
+	"time"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core"
 	"github.com/ethereum/go-ethereum/core/state"
 	"github.com/ethereum/go-ethereum/light"
 	"github.com/ethereum/go-ethereum/log"
+	"github.com/ethereum/go-ethereum/metrics"
 	"github.com/ethereum/go-ethereum/p2p"
 	"github.com/ethereum/go-ethereum/p2p/enode"
 	"github.com/ethereum/go-ethereum/p2p/enr"
@@ -128,6 +130,14 @@ func handleMessage(backend Backend, peer *Peer) error {
 	}
 	defer msg.Discard()
 
+	// Track the emount of time it takes to serve the request and run the handler
+	if metrics.Enabled {
+		h := fmt.Sprintf("%s/%s/%d/%#02x", p2p.HandleHistName, ProtocolName, peer.Version(), msg.Code)
+		defer func(start time.Time) {
+			sampler := func() metrics.Sample { return metrics.NewExpDecaySample(1028, 0.015) }
+			metrics.GetOrRegisterHistogramLazy(h, nil, sampler).Update(time.Since(start).Microseconds())
+		}(time.Now())
+	}
 	// Handle the message depending on its contents
 	switch {
 	case msg.Code == GetAccountRangeMsg:

--- a/metrics/histogram.go
+++ b/metrics/histogram.go
@@ -26,6 +26,15 @@ func GetOrRegisterHistogram(name string, r Registry, s Sample) Histogram {
 	return r.GetOrRegister(name, func() Histogram { return NewHistogram(s) }).(Histogram)
 }
 
+// GetOrRegisterHistogramLazy returns an existing Histogram or constructs and
+// registers a new StandardHistogram.
+func GetOrRegisterHistogramLazy(name string, r Registry, s func() Sample) Histogram {
+	if nil == r {
+		r = DefaultRegistry
+	}
+	return r.GetOrRegister(name, func() Histogram { return NewHistogram(s()) }).(Histogram)
+}
+
 // NewHistogram constructs a new StandardHistogram from a Sample.
 func NewHistogram(s Sample) Histogram {
 	if !Enabled {

--- a/p2p/metrics.go
+++ b/p2p/metrics.go
@@ -25,8 +25,17 @@ import (
 )
 
 const (
+	// ingressMeterName is the prefix of the per-packet inbound metrics.
 	ingressMeterName = "p2p/ingress"
-	egressMeterName  = "p2p/egress"
+
+	// egressMeterName is the prefix of the per-packet outbound metrics.
+	egressMeterName = "p2p/egress"
+
+	// HandleHistName is the prefix of the per-packet serving time histograms.
+	HandleHistName = "p2p/handle"
+
+	// WaitHistName is the prefix of the per-packet (req only) waiting time histograms.
+	WaitHistName = "p2p/wait"
 )
 
 var (


### PR DESCRIPTION
Currently we have no insight into how much time serving specific network requests take. This is a problem because we can't correlate performance issues with network traffic. This PR adds a measurement to all `eth` and `snap` packet handlers to track the latency of handling each packet type in a histogram. Hopefully this will shed some light onto how much time we actually take to serve certain requests and what might influence it.

TL;DR: PR makes colored pixels

![Screenshot from 2021-03-26 14-03-58](https://user-images.githubusercontent.com/129561/112628890-39924000-8e3c-11eb-9c84-6a7f23a6dded.png)
