### PR TITLE
accounts/external, signer/core: clef support for 2930-type txs

### DIFF
--- a/accounts/external/backend.go
+++ b/accounts/external/backend.go
@@ -203,14 +203,19 @@ func (api *ExternalSigner) SignTx(account accounts.Account, tx *types.Transactio
 		t := common.NewMixedcaseAddress(*tx.To())
 		to = &t
 	}
+	accessList := tx.AccessList()
 	args := &core.SendTxArgs{
-		Data:     &data,
-		Nonce:    hexutil.Uint64(tx.Nonce()),
-		Value:    hexutil.Big(*tx.Value()),
-		Gas:      hexutil.Uint64(tx.Gas()),
-		GasPrice: hexutil.Big(*tx.GasPrice()),
-		To:       to,
-		From:     common.NewMixedcaseAddress(account.Address),
+		Data:       &data,
+		Nonce:      hexutil.Uint64(tx.Nonce()),
+		Value:      hexutil.Big(*tx.Value()),
+		Gas:        hexutil.Uint64(tx.Gas()),
+		GasPrice:   hexutil.Big(*tx.GasPrice()),
+		To:         to,
+		From:       common.NewMixedcaseAddress(account.Address),
+		AccessList: &accessList,
+	}
+	if tx.ChainId() != nil {
+		args.ChainID = (*hexutil.Big)(tx.ChainId())
 	}
 	var res signTransactionResult
 	if err := api.client.Call(&res, "account_signTransaction", args); err != nil {

--- a/signer/core/api.go
+++ b/signer/core/api.go
@@ -534,6 +534,14 @@ func (api *SignerAPI) SignTransaction(ctx context.Context, args SendTxArgs, meth
 			return nil, err
 		}
 	}
+	if args.ChainID != nil {
+		requestedChainId := (*big.Int)(args.ChainID)
+		if api.chainID.Cmp(requestedChainId) != 0 {
+			log.Error("Signing request with wrong chain id", "requested", requestedChainId, "configured", api.chainID)
+			return nil, fmt.Errorf("requested chainid %d does not match the configuration of the signer",
+				requestedChainId)
+		}
+	}
 	req := SignTxRequest{
 		Transaction: args,
 		Meta:        MetadataFromContext(ctx),

--- a/signer/core/cliui.go
+++ b/signer/core/cliui.go
@@ -118,6 +118,18 @@ func (ui *CommandlineUI) ApproveTx(request *SignTxRequest) (SignTxResponse, erro
 	fmt.Printf("gas:      %v (%v)\n", request.Transaction.Gas, uint64(request.Transaction.Gas))
 	fmt.Printf("gasprice: %v wei\n", request.Transaction.GasPrice.ToInt())
 	fmt.Printf("nonce:    %v (%v)\n", request.Transaction.Nonce, uint64(request.Transaction.Nonce))
+	if chainId := request.Transaction.ChainID; chainId != nil {
+		fmt.Printf("chainid:  %v\n", chainId)
+	}
+	if list := request.Transaction.AccessList; list != nil {
+		fmt.Printf("Accesslist\n")
+		for i, el := range *list {
+			fmt.Printf(" %d. %v\n", i, el.Address)
+			for j, slot := range el.StorageKeys {
+				fmt.Printf("   %d. %v\n", j, slot)
+			}
+		}
+	}
 	if request.Transaction.Data != nil {
 		d := *request.Transaction.Data
 		if len(d) > 0 {


### PR DESCRIPTION
This PR adds support to use clef as a backend for signing 2930 type transcations. 
```
-----------------------
WARN [03-26|14:47:56.832] Served account_signTransaction           reqid=4 t=1.856328178s             err="request denied"
--------- Transaction request-------------
to:    0x8A8eAFb1cf62BfBeb1741769DAE1a9dd47996192
from:     0x8A8eAFb1cf62BfBeb1741769DAE1a9dd47996192 [chksum ok]
value:    1 wei
gas:      0x84d0 (34000)
gasprice: 500 wei
nonce:    0x5 (5)
chainid:  0x796f6c6f763378
Accesslist
 0. 0x8A8eAFb1cf62BfBeb1741769DAE1a9dd47996192
   0. 0x79e6c92a69cc29f3faafb3d3cfe5b6ffaea50d4cecde1c0b03442a56f16f337a
 1. 0x8A8eAFb1cf62BfBeb1741769DAE1a9dd47996192
   0. 0x79e6c92a69cc29f3faafb3d3cfe5b6ffaea50d4cecde1c0b03442a56f16f337a

Request context:
	NA -> NA -> NA

Additional HTTP header data, provided by the external caller:
	User-Agent: ""
	Origin: ""
-------------------------------------------
Approve? [y/N]:
> n
-----------------------
WARN [03-26|14:48:09.235] Served account_signTransaction           reqid=5 t=2.223563371s             err="request denied"
```
However, there is a snag. The `ChainId` is implemented by both legacy and new type transactions, and for the old type, it's derived from the `v`. But when we approve it, it's not yet signed, so a legacy tx looks like this: 
```
--------- Transaction request-------------
to:    0x8A8eAFb1cf62BfBeb1741769DAE1a9dd47996192
from:     0x8A8eAFb1cf62BfBeb1741769DAE1a9dd47996192 [chksum ok]
value:    1 wei
gas:      0x84d0 (34000)
gasprice: 500 wei
nonce:    0x5 (5)
chainid:  0x7fffffffffffffee

Request context:
	NA -> NA -> NA

Additional HTTP header data, provided by the external caller:
	User-Agent: ""
	Origin: ""
-------------------------------------------
Approve? [y/N]:
> n

```
And that's not great. If we have a `types.Transaction`, we don't really know if the `ChainId` represents the "User wants to sign for X" or "This tx is signed for X".  cc @fjl any ideas?
