### PR TITLE
eth/protocols, metrics: use resetting histograms for rare packets

### DIFF
--- a/eth/protocols/eth/handler.go
+++ b/eth/protocols/eth/handler.go
@@ -246,7 +246,11 @@ func handleMessage(backend Backend, peer *Peer) error {
 	if metrics.Enabled {
 		h := fmt.Sprintf("%s/%s/%d/%#02x", p2p.HandleHistName, ProtocolName, peer.Version(), msg.Code)
 		defer func(start time.Time) {
-			sampler := func() metrics.Sample { return metrics.NewExpDecaySample(1028, 0.015) }
+			sampler := func() metrics.Sample {
+				return metrics.ResettingSample(
+					metrics.NewExpDecaySample(1028, 0.015),
+				)
+			}
 			metrics.GetOrRegisterHistogramLazy(h, nil, sampler).Update(time.Since(start).Microseconds())
 		}(time.Now())
 	}

--- a/eth/protocols/snap/handler.go
+++ b/eth/protocols/snap/handler.go
@@ -134,7 +134,11 @@ func handleMessage(backend Backend, peer *Peer) error {
 	if metrics.Enabled {
 		h := fmt.Sprintf("%s/%s/%d/%#02x", p2p.HandleHistName, ProtocolName, peer.Version(), msg.Code)
 		defer func(start time.Time) {
-			sampler := func() metrics.Sample { return metrics.NewExpDecaySample(1028, 0.015) }
+			sampler := func() metrics.Sample {
+				return metrics.ResettingSample(
+					metrics.NewExpDecaySample(1028, 0.015),
+				)
+			}
 			metrics.GetOrRegisterHistogramLazy(h, nil, sampler).Update(time.Since(start).Microseconds())
 		}(time.Now())
 	}

--- a/metrics/resetting_sample.go
+++ b/metrics/resetting_sample.go
@@ -1,0 +1,24 @@
+package metrics
+
+// ResettingSample converts an ordinary sample into one that resets whenever its
+// snapshot is retrieved. This will break for multi-monitor systems, but when only
+// a single metric is being pushed out, this ensure that low-frequency events don't
+// skew th charts indefinitely.
+func ResettingSample(sample Sample) Sample {
+	return &resettingSample{
+		Sample: sample,
+	}
+}
+
+// resettingSample is a simple wrapper around a sample that resets it upon the
+// snapshot retrieval.
+type resettingSample struct {
+	Sample
+}
+
+// Snapshot returns a read-only copy of the sample with the original reset.
+func (rs *resettingSample) Snapshot() Sample {
+	s := rs.Sample.Snapshot()
+	rs.Sample.Clear()
+	return s
+}


### PR DESCRIPTION
This PR "fixes" the previous histograms by resetting them upon each pull/push.

The same way as with timers, the metrics library assumes that there's a constant stream of events we monitor. If a metric gets updated very rarely (e.g. eth/64 header request), the chart will be skewed because the metric will report the same value over and over and over ad infinitum (decaying ever so slowly to 0).

This PR uses @nonsense's resetting idea, just for histograms to reset them on retrieval.

![Screenshot from 2021-03-26 16-12-10](https://user-images.githubusercontent.com/129561/112645037-be865500-8e4e-11eb-827a-c96241c7e40a.png)

The diff is visible on the screenshot below. The code was updated to this PR in the middle on the displayed run.