### PR TITLE
core: add GetBalance method to block generation

### DIFF
--- a/core/chain_makers.go
+++ b/core/chain_makers.go
@@ -111,6 +111,11 @@ func (b *BlockGen) AddTxWithChain(bc *BlockChain, tx *types.Transaction) {
 	b.receipts = append(b.receipts, receipt)
 }
 
+// GetBalance returns the balance of the given address at the generated block.
+func (b *BlockGen) GetBalance(addr common.Address) *big.Int {
+	return b.statedb.GetBalance(addr)
+}
+
 // AddUncheckedTx forcefully adds a transaction to the block without any
 // validation.
 //


### PR DESCRIPTION
This PR adds a `GetBalance()` method to `BlockGen` to allow for more complex transaction generation during chain creation. For example, we will be using the `GetBalance()` method in the [`hivechain` tool](https://github.com/ethereum/hive/tree/master/cmd/hivechain) in order to generate chains with more than 1 transaction per block. 