### PR TITLE
metrics/influxdb: don't push empty histograms, no measurement != 0

### DIFF
--- a/metrics/influxdb/influxdb.go
+++ b/metrics/influxdb/influxdb.go
@@ -162,26 +162,29 @@ func (r *reporter) send() error {
 			})
 		case metrics.Histogram:
 			ms := metric.Snapshot()
-			ps := ms.Percentiles([]float64{0.5, 0.75, 0.95, 0.99, 0.999, 0.9999})
-			pts = append(pts, client.Point{
-				Measurement: fmt.Sprintf("%s%s.histogram", namespace, name),
-				Tags:        r.tags,
-				Fields: map[string]interface{}{
-					"count":    ms.Count(),
-					"max":      ms.Max(),
-					"mean":     ms.Mean(),
-					"min":      ms.Min(),
-					"stddev":   ms.StdDev(),
-					"variance": ms.Variance(),
-					"p50":      ps[0],
-					"p75":      ps[1],
-					"p95":      ps[2],
-					"p99":      ps[3],
-					"p999":     ps[4],
-					"p9999":    ps[5],
-				},
-				Time: now,
-			})
+
+			if ms.Count() > 0 {
+				ps := ms.Percentiles([]float64{0.5, 0.75, 0.95, 0.99, 0.999, 0.9999})
+				pts = append(pts, client.Point{
+					Measurement: fmt.Sprintf("%s%s.histogram", namespace, name),
+					Tags:        r.tags,
+					Fields: map[string]interface{}{
+						"count":    ms.Count(),
+						"max":      ms.Max(),
+						"mean":     ms.Mean(),
+						"min":      ms.Min(),
+						"stddev":   ms.StdDev(),
+						"variance": ms.Variance(),
+						"p50":      ps[0],
+						"p75":      ps[1],
+						"p95":      ps[2],
+						"p99":      ps[3],
+						"p999":     ps[4],
+						"p9999":    ps[5],
+					},
+					Time: now,
+				})
+			}
 		case metrics.Meter:
 			ms := metric.Snapshot()
 			pts = append(pts, client.Point{


### PR DESCRIPTION
Our InfluxDB reporter always pushed the content of a histogram, even if it was empty. This is problematic, because no measurements results in a reported value of 0 for all percentiles. This PR stops reporting 0 values if no measurements are made.