### PR TITLE
eth/protocols/snap: try to prevent requests timing out

### DIFF
--- a/eth/protocols/snap/sync.go
+++ b/eth/protocols/snap/sync.go
@@ -85,7 +85,7 @@ const (
 var (
 	// requestTimeout is the maximum time a peer is allowed to spend on serving
 	// a single network request.
-	requestTimeout = 10 * time.Second // TODO(karalabe): Make it dynamic ala fast-sync?
+	requestTimeout = 15 * time.Second // TODO(karalabe): Make it dynamic ala fast-sync?
 )
 
 // ErrCancelled is returned from snap syncing if the operation was prematurely


### PR DESCRIPTION
This PR increases the static timeout on snap messages from `10` to `15` seconds, and also adds an internal timeout for serving trie nodes, whereby it will abort after `5` seconds and return the results to the remote side.  