### PR TITLE
[DOCS] fix --miner.etherbase flag

### DIFF
--- a/docs/_interface/Private-Network.md
+++ b/docs/_interface/Private-Network.md
@@ -291,8 +291,8 @@ create a stable stream of blocks at regular intervals. To start a Geth instance 
 mining, run it with all the usual flags and add the following to configure mining:
 
 ```shell
-geth <other-flags> --mine --miner.threads=1 --etherbase=0x0000000000000000000000000000000000000000
+geth <other-flags> --mine --miner.threads=1 --miner.etherbase=0x0000000000000000000000000000000000000000
 ```
 
 This will start mining bocks and transactions on a single CPU thread, crediting all block
-rewards to the account specified by `--etherbase`.
+rewards to the account specified by `--miner.etherbase`.


### PR DESCRIPTION
The `--etherbase` parameter seems to be named `--miner.etherbase` now.