### PR TITLE
feat: adds example

### DIFF
--- a/docs/_install-and-build/Backup--restore.md
+++ b/docs/_install-and-build/Backup--restore.md
@@ -63,3 +63,5 @@ _See https://github.com/ethereum/wiki/wiki/Blockchain-import-export for more inf
 
 
 And finally: **REMEMBER YOUR PASSWORD** and **BACKUP YOUR KEYSTORE**
+
+[Example](https://github.com/ethereum/go-ethereum/issues/2773#issuecomment-814715389)


### PR DESCRIPTION
* Adds example link to the doc
* The documentation does not provide example of how does geth import and export is done.
* I have added an example on [geth export does not work](https://github.com/ethereum/go-ethereum/issues/2773), and the same has been added as an Example link in the documentation s.t. the future developers who will come across this problem will have an example to refer and it will be easier for them to understand.