### PR TITLE
cmd/devp2p/internal/ethtest: add more tx propagation tests

### DIFF
--- a/cmd/devp2p/internal/ethtest/chain.go
+++ b/cmd/devp2p/internal/ethtest/chain.go
@@ -152,6 +152,7 @@ func loadGenesis(genesisFile string) (core.Genesis, error) {
 	return gen, nil
 }
 
+
 func blocksFromFile(chainfile string, gblock *types.Block) ([]*types.Block, error) {
 	// Load chain.rlp.
 	fh, err := os.Open(chainfile)

--- a/cmd/devp2p/internal/ethtest/chain.go
+++ b/cmd/devp2p/internal/ethtest/chain.go
@@ -152,7 +152,6 @@ func loadGenesis(genesisFile string) (core.Genesis, error) {
 	return gen, nil
 }
 
-
 func blocksFromFile(chainfile string, gblock *types.Block) ([]*types.Block, error) {
 	// Load chain.rlp.
 	fh, err := os.Open(chainfile)

--- a/cmd/devp2p/internal/ethtest/suite.go
+++ b/cmd/devp2p/internal/ethtest/suite.go
@@ -140,7 +140,6 @@ func (s *Suite) Eth66Tests() []utesting.Test {
 // a status message with it, and then check to make sure
 // the chain head is correct.
 func (s *Suite) TestStatus(t *utesting.T) {
-	t.Log()
 	conn, err := s.dial()
 	if err != nil {
 		t.Fatalf("could not dial: %v", err)

--- a/cmd/devp2p/internal/ethtest/suite.go
+++ b/cmd/devp2p/internal/ethtest/suite.go
@@ -97,6 +97,8 @@ func (s *Suite) AllEthTests() []utesting.Test {
 		{Name: "TestTransaction_66", Fn: s.TestTransaction_66},
 		{Name: "TestMaliciousTx", Fn: s.TestMaliciousTx},
 		{Name: "TestMaliciousTx_66", Fn: s.TestMaliciousTx_66},
+		{Name: "TestLargeTxRequest_66", Fn: s.TestLargeTxRequest_66},
+		{Name: "TestNewPooledTxs_66", Fn: s.TestNewPooledTxs_66},
 	}
 }
 
@@ -129,6 +131,8 @@ func (s *Suite) Eth66Tests() []utesting.Test {
 		{Name: "TestMaliciousStatus_66", Fn: s.TestMaliciousStatus_66},
 		{Name: "TestTransaction_66", Fn: s.TestTransaction_66},
 		{Name: "TestMaliciousTx_66", Fn: s.TestMaliciousTx_66},
+		{Name: "TestLargeTxRequest_66", Fn: s.TestLargeTxRequest_66},
+		{Name: "TestNewPooledTxs_66", Fn: s.TestNewPooledTxs_66},
 	}
 }
 
@@ -136,6 +140,7 @@ func (s *Suite) Eth66Tests() []utesting.Test {
 // a status message with it, and then check to make sure
 // the chain head is correct.
 func (s *Suite) TestStatus(t *utesting.T) {
+	t.Log()
 	conn, err := s.dial()
 	if err != nil {
 		t.Fatalf("could not dial: %v", err)
@@ -455,7 +460,6 @@ func (s *Suite) testAnnounce(t *utesting.T, sendConn, receiveConn *Conn, blockAn
 }
 
 func (s *Suite) waitAnnounce(t *utesting.T, conn *Conn, blockAnnouncement *NewBlock) {
-	timeout := 20 * time.Second
 	switch msg := conn.ReadAndServe(s.chain, timeout).(type) {
 	case *NewBlock:
 		t.Logf("received NewBlock message: %s", pretty.Sdump(msg.Block))

--- a/cmd/devp2p/internal/ethtest/transaction.go
+++ b/cmd/devp2p/internal/ethtest/transaction.go
@@ -17,7 +17,6 @@
 package ethtest
 
 import (
-	"github.com/ethereum/go-ethereum/params"
 	"math/big"
 	"strings"
 	"time"
@@ -26,6 +25,7 @@ import (
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/internal/utesting"
+	"github.com/ethereum/go-ethereum/params"
 )
 
 //var faucetAddr = common.HexToAddress("0x71562b71999873DB5b286dF957af199Ec94617F7")

--- a/cmd/devp2p/internal/ethtest/transaction.go
+++ b/cmd/devp2p/internal/ethtest/transaction.go
@@ -17,6 +17,9 @@
 package ethtest
 
 import (
+	"github.com/ethereum/go-ethereum/params"
+	"math/big"
+	"strings"
 	"time"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -40,7 +43,9 @@ func sendSuccessfulTxWithConn(t *utesting.T, s *Suite, tx *types.Transaction, se
 	if err := sendConn.Write(&Transactions{tx}); err != nil {
 		t.Fatal(err)
 	}
-	time.Sleep(100 * time.Millisecond)
+	// update last nonce seen
+	nonce = tx.Nonce()
+
 	recvConn := s.setupConnection(t)
 	// Wait for the transaction announcement
 	switch msg := recvConn.ReadAndServe(s.chain, timeout).(type) {
@@ -66,6 +71,60 @@ func sendSuccessfulTxWithConn(t *utesting.T, s *Suite, tx *types.Transaction, se
 	}
 }
 
+var nonce = uint64(99)
+
+func sendMultipleSuccessfulTxs(t *utesting.T, s *Suite, sendConn *Conn, txs []*types.Transaction) {
+	txMsg := Transactions(txs)
+	t.Logf("sending %d txs\n", len(txs))
+
+	recvConn := s.setupConnection(t)
+	defer recvConn.Close()
+
+	// Send the transactions
+	if err := sendConn.Write(&txMsg); err != nil {
+		t.Fatal(err)
+	}
+	// update nonce
+	nonce = txs[len(txs)-1].Nonce()
+	// Wait for the transaction announcement(s) and make sure all sent txs are being propagated
+	recvHashes := make([]common.Hash, 0)
+	// all txs should be announced within 3 announcements
+	for i := 0; i < 3; i++ {
+		switch msg := recvConn.ReadAndServe(s.chain, timeout).(type) {
+		case *Transactions:
+			for _, tx := range *msg {
+				recvHashes = append(recvHashes, tx.Hash())
+			}
+		case *NewPooledTransactionHashes:
+			recvHashes = append(recvHashes, *msg...)
+		default:
+			if !strings.Contains(pretty.Sdump(msg), "i/o timeout") {
+				t.Fatalf("unexpected message while waiting to receive txs: %s", pretty.Sdump(msg))
+			}
+		}
+		// break once all 2000 txs have been received
+		if len(recvHashes) == 2000 {
+			break
+		}
+		if len(recvHashes) > 0 {
+			_, missingTxs := compareReceivedTxs(recvHashes, txs)
+			if len(missingTxs) > 0 {
+				continue
+			} else {
+				t.Logf("successfully received all %d txs", len(txs))
+				return
+			}
+		}
+	}
+	_, missingTxs := compareReceivedTxs(recvHashes, txs)
+	if len(missingTxs) > 0 {
+		for _, missing := range missingTxs {
+			t.Logf("missing tx: %v", missing.Hash())
+		}
+		t.Fatalf("missing %d txs", len(missingTxs))
+	}
+}
+
 func waitForTxPropagation(t *utesting.T, s *Suite, txs []*types.Transaction, recvConn *Conn) {
 	// Wait for another transaction announcement
 	switch msg := recvConn.ReadAndServe(s.chain, time.Second*8).(type) {
@@ -75,7 +134,7 @@ func waitForTxPropagation(t *utesting.T, s *Suite, txs []*types.Transaction, rec
 		for i, recvTx := range *msg {
 			recvTxs[i] = recvTx.Hash()
 		}
-		badTxs := containsTxs(recvTxs, txs)
+		badTxs, _ := compareReceivedTxs(recvTxs, txs)
 		if len(badTxs) > 0 {
 			for _, tx := range badTxs {
 				t.Logf("received bad tx: %v", tx)
@@ -83,7 +142,7 @@ func waitForTxPropagation(t *utesting.T, s *Suite, txs []*types.Transaction, rec
 			t.Fatalf("received %d bad txs", len(badTxs))
 		}
 	case *NewPooledTransactionHashes:
-		badTxs := containsTxs(*msg, txs)
+		badTxs, _ := compareReceivedTxs(*msg, txs)
 		if len(badTxs) > 0 {
 			for _, tx := range badTxs {
 				t.Logf("received bad tx: %v", tx)
@@ -98,18 +157,27 @@ func waitForTxPropagation(t *utesting.T, s *Suite, txs []*types.Transaction, rec
 	}
 }
 
-// containsTxs checks whether the hashes of the received transactions are present in
-// the given set of txs
-func containsTxs(recvTxs []common.Hash, txs []*types.Transaction) []common.Hash {
-	containedTxs := make([]common.Hash, 0)
-	for _, recvTx := range recvTxs {
-		for _, tx := range txs {
-			if recvTx == tx.Hash() {
-				containedTxs = append(containedTxs, recvTx)
-			}
+// compareReceivedTxs compares the received set of txs against the given set of txs,
+// returning both the set received txs that were present within the given txs, and
+// the set of txs that were missing from the set of received txs
+func compareReceivedTxs(recvTxs []common.Hash, txs []*types.Transaction) (present []*types.Transaction, missing []*types.Transaction) {
+	// create a map of the hashes received from node
+	recvHashes := make(map[common.Hash]common.Hash)
+	for _, hash := range recvTxs {
+		recvHashes[hash] = hash
+	}
+
+	// collect present txs and missing txs separately
+	present = make([]*types.Transaction, 0)
+	missing = make([]*types.Transaction, 0)
+	for _, tx := range txs {
+		if _, exists := recvHashes[tx.Hash()]; exists {
+			present = append(present, tx)
+		} else {
+			missing = append(missing, tx)
 		}
 	}
-	return containedTxs
+	return present, missing
 }
 
 func unknownTx(t *utesting.T, s *Suite) *types.Transaction {
@@ -119,7 +187,7 @@ func unknownTx(t *utesting.T, s *Suite) *types.Transaction {
 		to = *tx.To()
 	}
 	txNew := types.NewTransaction(tx.Nonce()+1, to, tx.Value(), tx.Gas(), tx.GasPrice(), tx.Data())
-	return signWithFaucet(t, txNew)
+	return signWithFaucet(t, s.chain.chainConfig, txNew)
 }
 
 func getNextTxFromChain(t *utesting.T, s *Suite) *types.Transaction {
@@ -136,6 +204,30 @@ func getNextTxFromChain(t *utesting.T, s *Suite) *types.Transaction {
 		t.Fatal("could not find transaction")
 	}
 	return tx
+}
+
+func generateTxs(t *utesting.T, s *Suite, numTxs int) (map[common.Hash]common.Hash, []*types.Transaction) {
+	txHashMap := make(map[common.Hash]common.Hash, numTxs)
+	txs := make([]*types.Transaction, numTxs)
+
+	nextTx := getNextTxFromChain(t, s)
+	gas := nextTx.Gas()
+
+	nonce = nonce + 1
+	// generate txs
+	for i := 0; i < numTxs; i++ {
+		tx := generateTx(t, s.chain.chainConfig, nonce, gas)
+		txHashMap[tx.Hash()] = tx.Hash()
+		txs[i] = tx
+		nonce = nonce + 1
+	}
+	return txHashMap, txs
+}
+
+func generateTx(t *utesting.T, chainConfig *params.ChainConfig, nonce uint64, gas uint64) *types.Transaction {
+	var to common.Address
+	tx := types.NewTransaction(nonce, to, big.NewInt(1), gas, big.NewInt(1), []byte{})
+	return signWithFaucet(t, chainConfig, tx)
 }
 
 func getOldTxFromChain(t *utesting.T, s *Suite) *types.Transaction {
@@ -160,7 +252,7 @@ func invalidNonceTx(t *utesting.T, s *Suite) *types.Transaction {
 		to = *tx.To()
 	}
 	txNew := types.NewTransaction(tx.Nonce()-2, to, tx.Value(), tx.Gas(), tx.GasPrice(), tx.Data())
-	return signWithFaucet(t, txNew)
+	return signWithFaucet(t, s.chain.chainConfig, txNew)
 }
 
 func hugeAmount(t *utesting.T, s *Suite) *types.Transaction {
@@ -171,7 +263,7 @@ func hugeAmount(t *utesting.T, s *Suite) *types.Transaction {
 		to = *tx.To()
 	}
 	txNew := types.NewTransaction(tx.Nonce(), to, amount, tx.Gas(), tx.GasPrice(), tx.Data())
-	return signWithFaucet(t, txNew)
+	return signWithFaucet(t, s.chain.chainConfig, txNew)
 }
 
 func hugeGasPrice(t *utesting.T, s *Suite) *types.Transaction {
@@ -182,7 +274,7 @@ func hugeGasPrice(t *utesting.T, s *Suite) *types.Transaction {
 		to = *tx.To()
 	}
 	txNew := types.NewTransaction(tx.Nonce(), to, tx.Value(), tx.Gas(), gasPrice, tx.Data())
-	return signWithFaucet(t, txNew)
+	return signWithFaucet(t, s.chain.chainConfig, txNew)
 }
 
 func hugeData(t *utesting.T, s *Suite) *types.Transaction {
@@ -192,11 +284,11 @@ func hugeData(t *utesting.T, s *Suite) *types.Transaction {
 		to = *tx.To()
 	}
 	txNew := types.NewTransaction(tx.Nonce(), to, tx.Value(), tx.Gas(), tx.GasPrice(), largeBuffer(2))
-	return signWithFaucet(t, txNew)
+	return signWithFaucet(t, s.chain.chainConfig, txNew)
 }
 
-func signWithFaucet(t *utesting.T, tx *types.Transaction) *types.Transaction {
-	signer := types.HomesteadSigner{}
+func signWithFaucet(t *utesting.T, chainConfig *params.ChainConfig, tx *types.Transaction) *types.Transaction {
+	signer := types.LatestSigner(chainConfig)
 	signedTx, err := types.SignTx(tx, signer, faucetKey)
 	if err != nil {
 		t.Fatalf("could not sign tx: %v\n", err)

--- a/cmd/devp2p/internal/ethtest/types.go
+++ b/cmd/devp2p/internal/ethtest/types.go
@@ -120,6 +120,14 @@ type NewPooledTransactionHashes eth.NewPooledTransactionHashesPacket
 
 func (nb NewPooledTransactionHashes) Code() int { return 24 }
 
+type GetPooledTransactions eth.GetPooledTransactionsPacket
+
+func (gpt GetPooledTransactions) Code() int { return 25 }
+
+type PooledTransactions eth.PooledTransactionsPacket
+
+func (pt PooledTransactions) Code() int { return 26 }
+
 // Conn represents an individual connection with a peer
 type Conn struct {
 	*rlpx.Conn
@@ -163,6 +171,10 @@ func (c *Conn) Read() Message {
 		msg = new(Transactions)
 	case (NewPooledTransactionHashes{}).Code():
 		msg = new(NewPooledTransactionHashes)
+	case (GetPooledTransactions{}.Code()):
+		msg = new(GetPooledTransactions)
+	case (PooledTransactions{}.Code()):
+		msg = new(PooledTransactions)
 	default:
 		return errorf("invalid message code: %d", code)
 	}
@@ -241,6 +253,7 @@ func (c *Conn) handshake(t *utesting.T) Message {
 		}
 		return msg
 	default:
+		t.Logf("dump: %s", pretty.Sdump(msg))
 		t.Fatalf("bad handshake: %#v", msg)
 		return nil
 	}

--- a/cmd/devp2p/internal/ethtest/types.go
+++ b/cmd/devp2p/internal/ethtest/types.go
@@ -253,7 +253,6 @@ func (c *Conn) handshake(t *utesting.T) Message {
 		}
 		return msg
 	default:
-		t.Logf("dump: %s", pretty.Sdump(msg))
 		t.Fatalf("bad handshake: %#v", msg)
 		return nil
 	}


### PR DESCRIPTION
This PR adds a large transaction request test to the eth test suite as well as a new pooled tx hashes announcement test. 

It depends on #22698.