### PR TITLE
cmd/geth: add db-command to inspect freezer index (ref #22111)

### DIFF
--- a/cmd/geth/dbcmd.go
+++ b/cmd/geth/dbcmd.go
@@ -480,7 +480,7 @@ func freezerInspect(ctx *cli.Context) error {
 	kind := ctx.Args().Get(0)
 	if noSnap, ok := rawdb.FreezerNoSnappy[kind]; !ok {
 		var options []string
-		for opt, _ := range rawdb.FreezerNoSnappy {
+		for opt := range rawdb.FreezerNoSnappy {
 			options = append(options, opt)
 		}
 		sort.Strings(options)

--- a/cmd/geth/dbcmd.go
+++ b/cmd/geth/dbcmd.go
@@ -60,6 +60,7 @@ Remove blockchain and state databases`,
 			dbDeleteCmd,
 			dbPutCmd,
 			dbGetSlotsCmd,
+			dbDumpFreezerIndex,
 		},
 	}
 	dbInspectCmd = cli.Command{
@@ -176,6 +177,22 @@ WARNING: This is a low-level operation which may cause database corruption!`,
 			utils.YoloV3Flag,
 		},
 		Description: "This command looks up the specified database key from the database.",
+	}
+	dbDumpFreezerIndex = cli.Command{
+		Action:    utils.MigrateFlags(freezerInspect),
+		Name:      "freezer-index",
+		Usage:     "Dump out the index of a given freezer type",
+		ArgsUsage: "<type> <start (int)> <end (int)>",
+		Flags: []cli.Flag{
+			utils.DataDirFlag,
+			utils.SyncModeFlag,
+			utils.MainnetFlag,
+			utils.RopstenFlag,
+			utils.RinkebyFlag,
+			utils.GoerliFlag,
+			utils.YoloV3Flag,
+		},
+		Description: "This command displays information about the freezer index.",
 	}
 )
 
@@ -448,4 +465,47 @@ func dbDumpTrie(ctx *cli.Context) error {
 		count++
 	}
 	return it.Err
+}
+
+func freezerInspect(ctx *cli.Context) error {
+	var (
+		start, end    int64
+		disableSnappy bool
+		err           error
+	)
+	if ctx.NArg() < 3 {
+		return fmt.Errorf("required arguments: %v", ctx.Command.ArgsUsage)
+	}
+	kind := ctx.Args().Get(0)
+	kinds := map[string]bool{
+		"headers":  false,
+		"hashes":   true,
+		"bodies":   false,
+		"receipts": false,
+		"diffs":    true,
+	}
+	if noSnap, ok := kinds[kind]; !ok {
+		return fmt.Errorf("Could read freezer-type: one of 'headers', 'hashes', "+
+			"'bodies','receipts' or 'diffs': %v", kind)
+	} else {
+		disableSnappy = noSnap
+	}
+	if start, err = strconv.ParseInt(ctx.Args().Get(1), 10, 64); err != nil {
+		log.Info("Could read start-param", "error", err)
+		return err
+	}
+	if end, err = strconv.ParseInt(ctx.Args().Get(2), 10, 64); err != nil {
+		log.Info("Could read end-param", "error", err)
+		return err
+	}
+	stack, _ := makeConfigNode(ctx)
+	defer stack.Close()
+	path := filepath.Join(stack.ResolvePath("chaindata"), "ancient")
+	log.Info("Opening freezer", "location", path, "name", kind)
+	if f, err := rawdb.NewFreezerTable(path, kind, disableSnappy); err != nil {
+		return err
+	} else {
+		f.DumpIndex(start, end)
+	}
+	return nil
 }

--- a/cmd/geth/dbcmd.go
+++ b/cmd/geth/dbcmd.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sort"
 	"strconv"
 	"time"
 
@@ -477,16 +478,13 @@ func freezerInspect(ctx *cli.Context) error {
 		return fmt.Errorf("required arguments: %v", ctx.Command.ArgsUsage)
 	}
 	kind := ctx.Args().Get(0)
-	kinds := map[string]bool{
-		"headers":  false,
-		"hashes":   true,
-		"bodies":   false,
-		"receipts": false,
-		"diffs":    true,
-	}
-	if noSnap, ok := kinds[kind]; !ok {
-		return fmt.Errorf("Could read freezer-type: one of 'headers', 'hashes', "+
-			"'bodies','receipts' or 'diffs': %v", kind)
+	if noSnap, ok := rawdb.FreezerNoSnappy[kind]; !ok {
+		var options []string
+		for opt, _ := range rawdb.FreezerNoSnappy {
+			options = append(options, opt)
+		}
+		sort.Strings(options)
+		return fmt.Errorf("Could read freezer-type '%v'. Available options: %v", kind, options)
 	} else {
 		disableSnappy = noSnap
 	}
@@ -495,7 +493,7 @@ func freezerInspect(ctx *cli.Context) error {
 		return err
 	}
 	if end, err = strconv.ParseInt(ctx.Args().Get(2), 10, 64); err != nil {
-		log.Info("Could read end-param", "error", err)
+		log.Info("Could read count param", "error", err)
 		return err
 	}
 	stack, _ := makeConfigNode(ctx)

--- a/core/rawdb/freezer.go
+++ b/core/rawdb/freezer.go
@@ -118,7 +118,7 @@ func newFreezer(datadir string, namespace string, readonly bool) (*freezer, erro
 		trigger:      make(chan chan struct{}),
 		quit:         make(chan struct{}),
 	}
-	for name, disableSnappy := range freezerNoSnappy {
+	for name, disableSnappy := range FreezerNoSnappy {
 		table, err := newTable(datadir, name, readMeter, writeMeter, sizeGauge, disableSnappy)
 		if err != nil {
 			for _, table := range freezer.tables {

--- a/core/rawdb/freezer_table.go
+++ b/core/rawdb/freezer_table.go
@@ -636,25 +636,24 @@ func (t *freezerTable) Sync() error {
 	return t.head.Sync()
 }
 
-// printIndex is a debug print utility function for testing
-func (t *freezerTable) printIndex() {
+// DumpIndex is a debug print utility function, mainly for testing. It can also
+// be used to analyse a live freezer table index.
+func (t *freezerTable) DumpIndex(start, stop int64) {
 	buf := make([]byte, indexEntrySize)
 
-	fmt.Printf("|-----------------|\n")
-	fmt.Printf("| fileno | offset |\n")
-	fmt.Printf("|--------+--------|\n")
+	fmt.Printf("| number | fileno | offset |\n")
+	fmt.Printf("|--------|--------|--------|\n")
 
-	for i := uint64(0); ; i++ {
+	for i := uint64(start); ; i++ {
 		if _, err := t.index.ReadAt(buf, int64(i*indexEntrySize)); err != nil {
 			break
 		}
 		var entry indexEntry
 		entry.unmarshalBinary(buf)
-		fmt.Printf("|  %03d   |  %03d   | \n", entry.filenum, entry.offset)
-		if i > 100 {
-			fmt.Printf(" ... \n")
+		fmt.Printf("|  %03d   |  %03d   |  %03d   | \n", i, entry.filenum, entry.offset)
+		if stop > 0 && i >= uint64(stop) {
 			break
 		}
 	}
-	fmt.Printf("|-----------------|\n")
+	fmt.Printf("|--------------------------|\n")
 }

--- a/core/rawdb/freezer_table_test.go
+++ b/core/rawdb/freezer_table_test.go
@@ -525,7 +525,7 @@ func TestOffset(t *testing.T) {
 
 		f.Append(4, getChunk(20, 0xbb))
 		f.Append(5, getChunk(20, 0xaa))
-		f.printIndex()
+		f.DumpIndex(0, 100)
 		f.Close()
 	}
 	// Now crop it.
@@ -572,7 +572,7 @@ func TestOffset(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		f.printIndex()
+		f.DumpIndex(0, 100)
 		// It should allow writing item 6
 		f.Append(numDeleted+2, getChunk(20, 0x99))
 

--- a/core/rawdb/schema.go
+++ b/core/rawdb/schema.go
@@ -114,9 +114,9 @@ const (
 	freezerDifficultyTable = "diffs"
 )
 
-// freezerNoSnappy configures whether compression is disabled for the ancient-tables.
+// FreezerNoSnappy configures whether compression is disabled for the ancient-tables.
 // Hashes and difficulties don't compress well.
-var freezerNoSnappy = map[string]bool{
+var FreezerNoSnappy = map[string]bool{
 	freezerHeaderTable:     false,
 	freezerHashTable:       true,
 	freezerBodiesTable:     false,


### PR DESCRIPTION
This PR makes it easier to inspect the freezer index, which could be useful to investigate things like #22111

```
geth --yolov3 db freezer-index diffs  214043 214056
INFO [04-08|13:52:42.921] Maximum peer count                       ETH=50 LES=0 total=50
INFO [04-08|13:52:42.921] Smartcard socket not found, disabling    err="stat /run/pcscd/pcscd.comm: no such file or directory"
INFO [04-08|13:52:42.922] Set global gas cap                       cap=25000000
INFO [04-08|13:52:42.922] Opening freezer                          location=/home/user/.ethereum/yolo-v3/geth/chaindata/ancient name=diffs
| number | fileno | offset |
|--------|--------|--------|
|  214043   |  000   |  823212   | 
|  214044   |  000   |  823216   | 
|  214045   |  000   |  823220   | 
|  214046   |  000   |  823224   | 
|  214047   |  000   |  823228   | 
|  214048   |  000   |  823232   | 
|  214049   |  000   |  823236   | 
|  214050   |  000   |  823240   | 
|  214051   |  000   |  823244   | 
|  214052   |  000   |  823248   | 
|  214053   |  000   |  823252   | 
|  214054   |  000   |  823256   | 
|  214055   |  000   |  823260   | 
|  214056   |  000   |  823264   | 
|--------------------------|
```