### PR TITLE
core: make internal handling of txs maintain tx ordering

### DIFF
--- a/core/tx_pool.go
+++ b/core/tx_pool.go
@@ -1113,6 +1113,7 @@ func (pool *TxPool) runReorg(done chan struct{}, reset *txpoolResetRequest, dirt
 		for _, set := range events {
 			txs = append(txs, set.Flatten()...)
 		}
+		sort.Sort(types.TxByPriceAndTime(txs))
 		pool.txFeed.Send(NewTxsEvent{txs})
 	}
 }

--- a/core/tx_pool_test.go
+++ b/core/tx_pool_test.go
@@ -24,6 +24,7 @@ import (
 	"math/big"
 	"math/rand"
 	"os"
+	"sort"
 	"testing"
 	"time"
 
@@ -137,6 +138,10 @@ func validateEvents(events chan NewTxsEvent, count int) error {
 		select {
 		case ev := <-events:
 			received = append(received, ev.Txs...)
+			// Check that they are properly ordered in each batch
+			if !sort.IsSorted(types.TxByPriceAndTime(ev.Txs)) {
+				return fmt.Errorf("feed transcations not sorted")
+			}
 		case <-time.After(time.Second):
 			return fmt.Errorf("event #%d not fired", len(received))
 		}


### PR DESCRIPTION
This PR makes the internal transaction propagation events for new transactions maintain ordering by price and time. The idea behind this is to ensue that time-ordering is maintained when we announce/broadcast transactions to peers. 

Currently, we track when a transaction was received from the network. However, when we send transactions to a peer, then the order becomes random.

The current behaviour means that txs are coming into the node, pass through the pool and bubbles back out in random order, and are relayed to a node that ends up being the miner, and which point the price/time priority has been lost. This may be a cause for some remaining transaction spam. 