### PR TITLE
eth/fetcher: avoid spurious timer events at startup

### DIFF
--- a/eth/fetcher/block_fetcher.go
+++ b/eth/fetcher/block_fetcher.go
@@ -331,10 +331,11 @@ func (f *BlockFetcher) FilterBodies(peer string, transactions [][]*types.Transac
 // events.
 func (f *BlockFetcher) loop() {
 	// Iterate the block fetching until a quit is requested
-	fetchTimer := time.NewTimer(0)
-	<-fetchTimer.C //clear out the channel
-	
-	completeTimer := time.NewTimer(0)
+	var (
+		fetchTimer = time.NewTimer(0)
+		completeTimer = time.NewTimer(0)
+	)
+	<-fetchTimer.C // clear out the channel	
 	<-completeTimer.C
 	defer fetchTimer.Stop()
 	defer completeTimer.Stop()

--- a/eth/fetcher/block_fetcher.go
+++ b/eth/fetcher/block_fetcher.go
@@ -335,7 +335,7 @@ func (f *BlockFetcher) loop() {
 		fetchTimer    = time.NewTimer(0)
 		completeTimer = time.NewTimer(0)
 	)
-	<-fetchTimer.C // clear out the channel	
+	<-fetchTimer.C // clear out the channel
 	<-completeTimer.C
 	defer fetchTimer.Stop()
 	defer completeTimer.Stop()

--- a/eth/fetcher/block_fetcher.go
+++ b/eth/fetcher/block_fetcher.go
@@ -332,7 +332,7 @@ func (f *BlockFetcher) FilterBodies(peer string, transactions [][]*types.Transac
 func (f *BlockFetcher) loop() {
 	// Iterate the block fetching until a quit is requested
 	var (
-		fetchTimer = time.NewTimer(0)
+		fetchTimer    = time.NewTimer(0)
 		completeTimer = time.NewTimer(0)
 	)
 	<-fetchTimer.C // clear out the channel	

--- a/eth/fetcher/block_fetcher.go
+++ b/eth/fetcher/block_fetcher.go
@@ -332,7 +332,10 @@ func (f *BlockFetcher) FilterBodies(peer string, transactions [][]*types.Transac
 func (f *BlockFetcher) loop() {
 	// Iterate the block fetching until a quit is requested
 	fetchTimer := time.NewTimer(0)
+	<-fetchTimer.C //clear out the channel
+	
 	completeTimer := time.NewTimer(0)
+	<-completeTimer.C
 	defer fetchTimer.Stop()
 	defer completeTimer.Stop()
 


### PR DESCRIPTION
clear out the channel