### PR TITLE
core/state/snapshot: reuse memory data instead of hitting disk when generating

### DIFF
--- a/trie/iterator.go
+++ b/trie/iterator.go
@@ -114,7 +114,7 @@ type NodeIterator interface {
 	//
 	// Before adding a similar mechanism to any other place in Geth, consider
 	// making trie.Database an interface and wrapping at that level. It's a huge
-	// refactor, but it could be worth it if another occurance arises.
+	// refactor, but it could be worth it if another occurrence arises.
 	AddResolver(ethdb.KeyValueStore)
 }
 

--- a/trie/iterator.go
+++ b/trie/iterator.go
@@ -102,6 +102,8 @@ type NodeIterator interface {
 	// iterator is not positioned at a leaf. Callers must not retain references
 	// to the value after calling Next.
 	LeafProof() [][]byte
+
+	AddResolver(*Database)
 }
 
 // nodeIteratorState represents the iteration state at one particular node of the
@@ -115,10 +117,15 @@ type nodeIteratorState struct {
 }
 
 type nodeIterator struct {
-	trie  *Trie                // Trie being iterated
-	stack []*nodeIteratorState // Hierarchy of trie nodes persisting the iteration state
-	path  []byte               // Path to the current node
-	err   error                // Failure set in case of an internal error in the iterator
+	trie            *Trie                // Trie being iterated
+	stack           []*nodeIteratorState // Hierarchy of trie nodes persisting the iteration state
+	path            []byte               // Path to the current node
+	err             error                // Failure set in case of an internal error in the iterator
+	primaryResolver *Database
+}
+
+func (it *nodeIterator) AddResolver(db *Database) {
+	it.primaryResolver = db
 }
 
 // errIteratorEnd is stored in nodeIterator.err when iteration is done.
@@ -262,7 +269,7 @@ func (it *nodeIterator) init() (*nodeIteratorState, error) {
 	if root != emptyRoot {
 		state.hash = root
 	}
-	return state, state.resolve(it.trie, nil)
+	return state, state.resolve(it, nil)
 }
 
 // peek creates the next state of the iterator.
@@ -286,7 +293,7 @@ func (it *nodeIterator) peek(descend bool) (*nodeIteratorState, *int, []byte, er
 		}
 		state, path, ok := it.nextChild(parent, ancestor)
 		if ok {
-			if err := state.resolve(it.trie, path); err != nil {
+			if err := state.resolve(it, path); err != nil {
 				return parent, &parent.index, path, err
 			}
 			return state, &parent.index, path, nil
@@ -319,7 +326,7 @@ func (it *nodeIterator) peekSeek(seekKey []byte) (*nodeIteratorState, *int, []by
 		}
 		state, path, ok := it.nextChildAt(parent, ancestor, seekKey)
 		if ok {
-			if err := state.resolve(it.trie, path); err != nil {
+			if err := state.resolve(it, path); err != nil {
 				return parent, &parent.index, path, err
 			}
 			return state, &parent.index, path, nil
@@ -330,9 +337,19 @@ func (it *nodeIterator) peekSeek(seekKey []byte) (*nodeIteratorState, *int, []by
 	return nil, nil, nil, errIteratorEnd
 }
 
-func (st *nodeIteratorState) resolve(tr *Trie, path []byte) error {
+func (it *nodeIterator) resolveHash(hash hashNode, path []byte) (node, error) {
+	if it.primaryResolver != nil {
+		if resolved := it.primaryResolver.node(common.BytesToHash(hash)); resolved != nil {
+			return resolved, nil
+		}
+	}
+	resolved, err := it.trie.resolveHash(hash, path)
+	return resolved, err
+}
+
+func (st *nodeIteratorState) resolve(it *nodeIterator, path []byte) error {
 	if hash, ok := st.node.(hashNode); ok {
-		resolved, err := tr.resolveHash(hash, path)
+		resolved, err := it.resolveHash(hash, path)
 		if err != nil {
 			return err
 		}
@@ -517,6 +534,10 @@ func (it *differenceIterator) Path() []byte {
 	return it.b.Path()
 }
 
+func (it *differenceIterator) AddResolver(db *Database) {
+	panic("Not implemented")
+}
+
 func (it *differenceIterator) Next(bool) bool {
 	// Invariants:
 	// - We always advance at least one element in b.
@@ -622,6 +643,10 @@ func (it *unionIterator) LeafProof() [][]byte {
 
 func (it *unionIterator) Path() []byte {
 	return (*it.items)[0].Path()
+}
+
+func (it *unionIterator) AddResolver(db *Database) {
+	panic("Not implemented")
 }
 
 // Next returns the next node in the union of tries being iterated over.


### PR DESCRIPTION
This PR is a successor to https://github.com/rjl493456442/go-ethereum/pull/6 (some charts can be found there). 

This PR attempts to minimize the number of disk reads when doing the snapshot generation. 

When we have a slice of snapshot values which do not match the trie data, we currently iterate the disk to retrieve the canonical data.

What this PR does, is commit the (incorrect) snapshot data to a trie, which will be 99% correct. When iterating the trie, we then use the snapshot-trie-database for resolving hashes. By doing so, we can read 99% of the leaves the from the memory db instead of resolving from disk.

It can also be implemented differently (this was my third variation). Other variants which also "work"

- Use a differenceIterator, to walk only the nodes which are on disk and not in memory. The drawback with this (otherwise pretty clean) approach is that it needs two walks: one to find out what needs to be added from trie to snapshot, another (reverse direction) which figures out what needs to be deleted. It could be solved by writing a new difference-iterator which spits out "addition" or "deletion", if we prefer that approach. 
- Use a relay-database, which implements ethdb.KeyValueStore. And then shove all nodes into a memorydb, and have the relaydb use the memdb as primary and diskdb as secondary, and plug it into a new trie.Database as backend. It's pretty clunky, and does not get to use any of the `cleans` cache in the existing trie.Database.

The upside of this particular way to implement it is that most of the modifications are performed in the node iterator, and does not touch the trie database.

This approach can probably be further polished/optimized if we retain the trie used by the prover, instead of rebuilding it once again -- but this PR focuses on the disk access part, not so much on getting the cpu cycles down