### PR TITLE
trie: make stacktrie not mutate input values

### DIFF
--- a/trie/stacktrie.go
+++ b/trie/stacktrie.go
@@ -346,8 +346,7 @@ func (st *StackTrie) hash() {
 			panic(err)
 		}
 	case emptyNode:
-		st.val = st.val[:0]
-		st.val = append(st.val, emptyRoot[:]...)
+		st.val = emptyRoot.Bytes()
 		st.key = st.key[:0]
 		st.nodeType = hashedNode
 		return
@@ -357,17 +356,12 @@ func (st *StackTrie) hash() {
 	st.key = st.key[:0]
 	st.nodeType = hashedNode
 	if len(h.tmp) < 32 {
-		st.val = st.val[:0]
-		st.val = append(st.val, h.tmp...)
+		st.val = common.CopyBytes(h.tmp)
 		return
 	}
-	// Going to write the hash to the 'val'. Need to ensure it's properly sized first
-	// Typically, 'branchNode's will have no 'val', and require this allocation
-	if required := 32 - len(st.val); required > 0 {
-		buf := make([]byte, required)
-		st.val = append(st.val, buf...)
-	}
-	st.val = st.val[:32]
+	// Write the hash to the 'val'. We allocate a new val here to not mutate
+	// input values
+	st.val = make([]byte, 32)
 	h.sha.Reset()
 	h.sha.Write(h.tmp)
 	h.sha.Read(st.val)


### PR DESCRIPTION
The stacktrie is a bit un-untuitive, API-wise: it mutates input values. 

This is dangerous, and easy to get wrong if the calling code 'forgets' this quirk, so this PR fixes that behaviour. The first commit provides a testcase, and the second commit provides a fix. Naturally, the fix has an overhead. 

With this PR:
```
name                       old time/op    new time/op    delta
DeriveSha200/std_trie-6       715µs ±13%     722µs ± 7%     ~     (p=0.841 n=5+5)
DeriveSha200/stack_trie-6     453µs ±13%     449µs ± 2%     ~     (p=0.690 n=5+5)

name                       old alloc/op   new alloc/op   delta
DeriveSha200/std_trie-6       273kB ± 0%     273kB ± 0%     ~     (p=0.548 n=5+5)
DeriveSha200/stack_trie-6    52.5kB ± 0%    58.5kB ± 0%  +11.24%  (p=0.016 n=4+5)

name                       old allocs/op  new allocs/op  delta
DeriveSha200/std_trie-6       2.66k ± 0%     2.66k ± 0%     ~     (all equal)
DeriveSha200/stack_trie-6     1.07k ± 0%     1.25k ± 0%  +17.20%  (p=0.008 n=5+5)
```
Alternative fix:
```diff
index a198eb204b..6ba309cb41 100644
--- a/trie/stacktrie.go
+++ b/trie/stacktrie.go
@@ -99,7 +99,7 @@ func (st *StackTrie) TryUpdate(key, value []byte) error {
 	if len(value) == 0 {
 		panic("deletion not supported")
 	}
-	st.insert(k[:len(k)-1], value)
+	st.insert(k[:len(k)-1], common.CopyBytes(value))
 	return nil
 }
 ```
With alternative fix: 
```
name                       old time/op    new time/op    delta
DeriveSha200/std_trie-6       715µs ±13%     715µs ± 8%     ~     (p=1.000 n=5+5)
DeriveSha200/stack_trie-6     453µs ±13%     469µs ± 8%     ~     (p=0.310 n=5+5)

name                       old alloc/op   new alloc/op   delta
DeriveSha200/std_trie-6       273kB ± 0%     273kB ± 0%     ~     (p=0.690 n=5+5)
DeriveSha200/stack_trie-6    52.5kB ± 0%    75.0kB ± 0%  +42.77%  (p=0.016 n=4+5)

name                       old allocs/op  new allocs/op  delta
DeriveSha200/std_trie-6       2.66k ± 0%     2.66k ± 0%     ~     (all equal)
DeriveSha200/stack_trie-6     1.07k ± 0%     1.27k ± 0%  +18.69%  (p=0.008 n=5+5)
```

With this PR in, though, we can make some other improvements to not always copy data on input. However, it should be noted that the stacktrie still needs the caller to _not_ mutate the data from the outside, so we cannot remove e.g. example https://github.com/ethereum/go-ethereum/blob/master/core/types/hashing.go#L80:L83 (btw -- the ordinary trie behaves the same way, you're not allowed to mutate input values from the callsite)
```
func encodeForDerive(list DerivableList, i int, buf *bytes.Buffer) []byte {
	buf.Reset()
	list.EncodeIndex(i, buf)
	// It's really unfortunate that we need to do perform this copy.
	// StackTrie holds onto the values until Hash is called, so the values
	// written to it must not alias.
	return common.CopyBytes(buf.Bytes())
}
```