### PR TITLE
core/state/snapshot: avoid copybytes for stacktrie

### DIFF
--- a/core/state/snapshot/generate.go
+++ b/core/state/snapshot/generate.go
@@ -317,7 +317,7 @@ func (dl *diskLayer) proveRange(stats *generatorStats, root common.Hash, prefix 
 	if origin == nil && !diskMore {
 		stackTr := trie.NewStackTrie(nil)
 		for i, key := range keys {
-			stackTr.TryUpdate(key, common.CopyBytes(vals[i]))
+			stackTr.TryUpdate(key, vals[i])
 		}
 		if gotRoot := stackTr.Hash(); gotRoot != root {
 			return &proofResult{

--- a/trie/trie_test.go
+++ b/trie/trie_test.go
@@ -830,8 +830,8 @@ func TestCommitSequenceStackTrie(t *testing.T) {
 				val = make([]byte, 1+prng.Intn(1024))
 			}
 			prng.Read(val)
-			trie.TryUpdate(key, common.CopyBytes(val))
-			stTrie.TryUpdate(key, common.CopyBytes(val))
+			trie.TryUpdate(key, val)
+			stTrie.TryUpdate(key, val)
 		}
 		// Flush trie -> database
 		root, _ := trie.Commit(nil)


### PR DESCRIPTION
Follow-up to https://github.com/ethereum/go-ethereum/pull/22673 , this PR avoid some copying for things going into the Stacktrie