### PR TITLE
cmd/devp2p: add support for -limit option in nodeset filter command

### DIFF
--- a/cmd/devp2p/README.md
+++ b/cmd/devp2p/README.md
@@ -48,6 +48,11 @@ set to standard output. The following filters are supported:
 - `-les-server` filters nodes by LES server support
 - `-snap` filters nodes by snap protocol support
 
+For example, given a node set in `nodes.json`, you could create a filtered set containing
+up to 20 eth mainnet nodes which also support snap sync using this command:
+
+    devp2p nodeset filter nodes.json -eth-network mainnet -snap -limit 20
+
 ### Discovery v4 Utilities
 
 The `devp2p discv4 ...` command family deals with the [Node Discovery v4][discv4]

--- a/cmd/devp2p/README.md
+++ b/cmd/devp2p/README.md
@@ -30,6 +30,24 @@ Run `devp2p dns to-route53 <directory>` to publish a tree to Amazon Route53.
 
 You can find more information about these commands in the [DNS Discovery Setup Guide][dns-tutorial].
 
+### Node Set Utilities
+
+There are several commands for working with JSON node set files. These files are generated
+by the discovery crawlers and DNS client commands. Node sets also used as the input of the
+DNS deployer commands.
+
+Run `devp2p nodeset info <nodes.json>` to display statistics of a node set.
+
+Run `devp2p nodeset filter <nodes.json> <filter flags...>` to write a new, filtered node
+set to standard output. The following filters are supported:
+
+- `-limit <N>` limits the output set to N entries, taking the top N nodes by score
+- `-ip <CIDR>` filters nodes by IP subnet
+- `-min-age <duration>` filters nodes by 'first seen' time
+- `-eth-network <mainnet/rinkeby/goerli/ropsten>` filters nodes by "eth" ENR entry
+- `-les-server` filters nodes by LES server support
+- `-snap` filters nodes by snap protocol support
+
 ### Discovery v4 Utilities
 
 The `devp2p discv4 ...` command family deals with the [Node Discovery v4][discv4]
@@ -94,7 +112,7 @@ To run the eth protocol test suite against your implementation, the node needs t
 geth --datadir <datadir> --nodiscover --nat=none --networkid 19763 --verbosity 5
 ```
 
-Then, run the following command, replacing `<enode>` with the enode of the geth node: 
+Then, run the following command, replacing `<enode>` with the enode of the geth node:
  ```
  devp2p rlpx eth-test <enode> cmd/devp2p/internal/ethtest/testdata/chain.rlp cmd/devp2p/internal/ethtest/testdata/genesis.json
 ```
@@ -103,7 +121,7 @@ Repeat the above process (re-initialising the node) in order to run the Eth Prot
 
 #### Eth66 Test Suite
 
-The Eth66 test suite is also a conformance test suite for the eth 66 protocol version specifically. 
+The Eth66 test suite is also a conformance test suite for the eth 66 protocol version specifically.
 To run the eth66 protocol test suite, initialize a geth node as described above and run the following command,
 replacing `<enode>` with the enode of the geth node:
 

--- a/cmd/devp2p/nodesetcmd.go
+++ b/cmd/devp2p/nodesetcmd.go
@@ -114,16 +114,15 @@ func nodesetFilter(ctx *cli.Context) error {
 	}
 
 	// Load nodes and apply filters.
-	// If -limit is set, get the top n nodes first.
 	ns := loadNodesJSON(ctx.Args().First())
-	if limit >= 0 {
-		ns = ns.topN(limit)
-	}
 	result := make(nodeSet)
 	for id, n := range ns {
 		if filter(n) {
 			result[id] = n
 		}
+	}
+	if limit >= 0 {
+		result = result.topN(limit)
 	}
 	writeNodesJSON("-", result)
 	return nil

--- a/cmd/devp2p/nodesetcmd.go
+++ b/cmd/devp2p/nodesetcmd.go
@@ -100,13 +100,11 @@ func nodesetFilter(ctx *cli.Context) error {
 	if ctx.NArg() < 1 {
 		return fmt.Errorf("need nodes file as argument")
 	}
-
 	// Parse -limit.
 	limit, err := parseFilterLimit(ctx.Args().Tail())
 	if err != nil {
 		return err
 	}
-
 	// Parse the filters.
 	filter, err := andFilter(ctx.Args().Tail())
 	if err != nil {


### PR DESCRIPTION
The new -limit option makes the filter operate on top N nodes by score.