### PR TITLE
cmd/devp2p: add dns nuke-route53 command

### DIFF
--- a/cmd/devp2p/dns_route53.go
+++ b/cmd/devp2p/dns_route53.go
@@ -228,7 +228,7 @@ func (c *route53Client) computeChanges(name string, records map[string]string, e
 			continue
 		}
 		// Stale entry, nuke it.
-		log.Info(fmt.Sprintf("Deleting %s = %q", path, strings.Join(set.values, "")))
+		log.Info(fmt.Sprintf("Deleting %s = %s", path, strings.Join(set.values, "")))
 		changes = append(changes, newTXTChange("DELETE", path, set.ttl, set.values...))
 	}
 

--- a/cmd/devp2p/dns_route53.go
+++ b/cmd/devp2p/dns_route53.go
@@ -107,22 +107,48 @@ func (c *route53Client) deploy(name string, t *dnsdisc.Tree) error {
 		return err
 	}
 	log.Info(fmt.Sprintf("Found %d TXT records", len(existing)))
-
 	records := t.ToTXT(name)
 	changes := c.computeChanges(name, records, existing)
+
+	// Submit to API.
+	comment := fmt.Sprintf("enrtree update of %s at seq %d", name, t.Seq())
+	return c.submitChanges(changes, comment)
+}
+
+// deleteDomain removes all TXT records of the given domain.
+func (c *route53Client) deleteDomain(name string) error {
+	if err := c.checkZone(name); err != nil {
+		return err
+	}
+
+	// Compute DNS changes.
+	existing, err := c.collectRecords(name)
+	if err != nil {
+		return err
+	}
+	log.Info(fmt.Sprintf("Found %d TXT records", len(existing)))
+	changes := makeDeletionChanges(existing, nil)
+
+	// Submit to API.
+	comment := "enrtree delete of " + name
+	return c.submitChanges(changes, comment)
+}
+
+// submitChanges submits the given DNS changes to Route53.
+func (c *route53Client) submitChanges(changes []types.Change, comment string) error {
 	if len(changes) == 0 {
 		log.Info("No DNS changes needed")
 		return nil
 	}
 
-	// Submit all change batches.
+	var err error
 	batches := splitChanges(changes, route53ChangeSizeLimit, route53ChangeCountLimit)
 	changesToCheck := make([]*route53.ChangeResourceRecordSetsOutput, len(batches))
 	for i, changes := range batches {
 		log.Info(fmt.Sprintf("Submitting %d changes to Route53", len(changes)))
 		batch := &types.ChangeBatch{
 			Changes: changes,
-			Comment: aws.String(fmt.Sprintf("enrtree update %d/%d of %s at seq %d", i+1, len(batches), name, t.Seq())),
+			Comment: aws.String(fmt.Sprintf("%s (%d/%d)", comment, i+1, len(batches))),
 		}
 		req := &route53.ChangeResourceRecordSetsInput{HostedZoneId: &c.zoneID, ChangeBatch: batch}
 		changesToCheck[i], err = c.api.ChangeResourceRecordSets(context.TODO(), req)
@@ -151,7 +177,6 @@ func (c *route53Client) deploy(name string, t *dnsdisc.Tree) error {
 			time.Sleep(30 * time.Second)
 		}
 	}
-
 	return nil
 }
 
@@ -186,7 +211,8 @@ func (c *route53Client) findZoneID(name string) (string, error) {
 	return "", errors.New("can't find zone ID for " + name)
 }
 
-// computeChanges creates DNS changes for the given record.
+// computeChanges creates DNS changes for the given set of DNS discovery records.
+// The 'existing' arg is the set of records that already exist on Route53.
 func (c *route53Client) computeChanges(name string, records map[string]string, existing map[string]recordSet) []types.Change {
 	// Convert all names to lowercase.
 	lrecords := make(map[string]string, len(records))
@@ -223,16 +249,23 @@ func (c *route53Client) computeChanges(name string, records map[string]string, e
 	}
 
 	// Iterate over the old records and delete anything stale.
-	for path, set := range existing {
-		if _, ok := records[path]; ok {
+	changes = append(changes, makeDeletionChanges(existing, records)...)
+
+	// Ensure changes are in the correct order.
+	sortChanges(changes)
+	return changes
+}
+
+// makeDeletionChanges creates record changes which delete all records not contained in 'keep'.
+func makeDeletionChanges(records map[string]recordSet, keep map[string]string) []types.Change {
+	var changes []types.Change
+	for path, set := range records {
+		if _, ok := keep[path]; ok {
 			continue
 		}
-		// Stale entry, nuke it.
 		log.Info(fmt.Sprintf("Deleting %s = %s", path, strings.Join(set.values, "")))
 		changes = append(changes, newTXTChange("DELETE", path, set.ttl, set.values...))
 	}
-
-	sortChanges(changes)
 	return changes
 }
 

--- a/cmd/devp2p/dnscmd.go
+++ b/cmd/devp2p/dnscmd.go
@@ -43,6 +43,7 @@ var (
 			dnsTXTCommand,
 			dnsCloudflareCommand,
 			dnsRoute53Command,
+			dnsRoute53NukeCommand,
 		},
 	}
 	dnsSyncCommand = cli.Command{
@@ -77,6 +78,18 @@ var (
 		Usage:     "Deploy DNS TXT records to Amazon Route53",
 		ArgsUsage: "<tree-directory>",
 		Action:    dnsToRoute53,
+		Flags: []cli.Flag{
+			route53AccessKeyFlag,
+			route53AccessSecretFlag,
+			route53ZoneIDFlag,
+			route53RegionFlag,
+		},
+	}
+	dnsRoute53NukeCommand = cli.Command{
+		Name:      "nuke-route53",
+		Usage:     "Deletes DNS TXT records of a subdomain on Amazon Route53",
+		ArgsUsage: "<domain>",
+		Action:    dnsNukeRoute53,
 		Flags: []cli.Flag{
 			route53AccessKeyFlag,
 			route53AccessSecretFlag,
@@ -174,6 +187,9 @@ func dnsSign(ctx *cli.Context) error {
 	return nil
 }
 
+// directoryName returns the directory name of the given path.
+// For example, when dir is "foo/bar", it returns "bar".
+// When dir is ".", and the working directory is "example/foo", it returns "foo".
 func directoryName(dir string) string {
 	abs, err := filepath.Abs(dir)
 	if err != nil {
@@ -182,7 +198,7 @@ func directoryName(dir string) string {
 	return filepath.Base(abs)
 }
 
-// dnsToTXT peforms dnsTXTCommand.
+// dnsToTXT performs dnsTXTCommand.
 func dnsToTXT(ctx *cli.Context) error {
 	if ctx.NArg() < 1 {
 		return fmt.Errorf("need tree definition directory as argument")
@@ -199,9 +215,9 @@ func dnsToTXT(ctx *cli.Context) error {
 	return nil
 }
 
-// dnsToCloudflare peforms dnsCloudflareCommand.
+// dnsToCloudflare performs dnsCloudflareCommand.
 func dnsToCloudflare(ctx *cli.Context) error {
-	if ctx.NArg() < 1 {
+	if ctx.NArg() != 1 {
 		return fmt.Errorf("need tree definition directory as argument")
 	}
 	domain, t, err := loadTreeDefinitionForExport(ctx.Args().Get(0))
@@ -212,9 +228,9 @@ func dnsToCloudflare(ctx *cli.Context) error {
 	return client.deploy(domain, t)
 }
 
-// dnsToRoute53 peforms dnsRoute53Command.
+// dnsToRoute53 performs dnsRoute53Command.
 func dnsToRoute53(ctx *cli.Context) error {
-	if ctx.NArg() < 1 {
+	if ctx.NArg() != 1 {
 		return fmt.Errorf("need tree definition directory as argument")
 	}
 	domain, t, err := loadTreeDefinitionForExport(ctx.Args().Get(0))
@@ -223,6 +239,15 @@ func dnsToRoute53(ctx *cli.Context) error {
 	}
 	client := newRoute53Client(ctx)
 	return client.deploy(domain, t)
+}
+
+// dnsNukeRoute53 performs dnsRoute53NukeCommand.
+func dnsNukeRoute53(ctx *cli.Context) error {
+	if ctx.NArg() != 1 {
+		return fmt.Errorf("need domain name as argument")
+	}
+	client := newRoute53Client(ctx)
+	return client.deleteDomain(ctx.Args().First())
 }
 
 // loadSigningKey loads a private key in Ethereum keystore format.


### PR DESCRIPTION
This adds a tool to delete all TXT records of a name on Route53.