### PR TITLE
core/state/snapshot: reuse memory data instead of hitting disk

### DIFF
--- a/core/state/snapshot/generate.go
+++ b/core/state/snapshot/generate.go
@@ -435,18 +435,24 @@ func (dl *diskLayer) generateRange(root common.Hash, prefix []byte, kind string,
 		}
 		meter.Mark(1)
 	}
-
-	// We use the snap data to build up a cache which can be used by the
-	// main account trie as a primary lookup when resolving hashes
-	var snapTrieDb *trie.Database
+	// We use the snap data to build up a cache which can be used by the main
+	// account trie as a short-circuit when resolving hashes
 	if len(result.keys) > 0 {
-		snapNodeCache := memorydb.New()
-		snapTrieDb = trie.NewDatabase(snapNodeCache)
-		snapTrie, _ := trie.New(common.Hash{}, snapTrieDb)
+		var (
+			cache   = memorydb.New()
+			triedb  = trie.NewDatabase(cache)
+			trie, _ = trie.New(common.Hash{}, triedb)
+		)
 		for i, key := range result.keys {
-			snapTrie.Update(key, result.vals[i])
+			trie.Update(key, result.vals[i])
 		}
-		snapTrie.Commit(nil)
+		trie.Commit(nil)
+
+		it := cache.NewIterator(nil, nil)
+		for it.Next() {
+			dl.triedb.Seed(common.BytesToHash(it.Key()), common.CopyBytes(it.Value()))
+		}
+		it.Release()
 	}
 	tr := result.tr
 	if tr == nil {
@@ -456,11 +462,9 @@ func (dl *diskLayer) generateRange(root common.Hash, prefix []byte, kind string,
 			return false, nil, errMissingTrie
 		}
 	}
-
 	var (
 		trieMore       bool
-		nodeIt         = tr.NodeIterator(origin)
-		iter           = trie.NewIterator(nodeIt)
+		iter           = trie.NewIterator(tr.NodeIterator(origin))
 		kvkeys, kvvals = result.keys, result.vals
 
 		// counters
@@ -474,7 +478,6 @@ func (dl *diskLayer) generateRange(root common.Hash, prefix []byte, kind string,
 		start    = time.Now()
 		internal time.Duration
 	)
-	nodeIt.AddResolver(snapTrieDb)
 	for iter.Next() {
 		if last != nil && bytes.Compare(iter.Key, last) > 0 {
 			trieMore = true

--- a/trie/database.go
+++ b/trie/database.go
@@ -893,3 +893,15 @@ func (db *Database) SaveCachePeriodically(dir string, interval time.Duration, st
 		}
 	}
 }
+
+// Seed can be used to inject a single trie node into the clean cache. Its main
+// purpose is to allow operating on trie nodes that are known to be on disk, but
+// if they are available in RAM too (generated from snapshot), instead of loading
+// again from persistent storage (expensive), rather inject into the cache to be
+// loaded from there (cheap).
+func (db *Database) Seed(key common.Hash, val []byte) {
+	db.lock.RLock()
+	defer db.lock.RUnlock()
+
+	db.cleans.Set(key[:], val)
+}

--- a/trie/iterator.go
+++ b/trie/iterator.go
@@ -102,6 +102,8 @@ type NodeIterator interface {
 	// iterator is not positioned at a leaf. Callers must not retain references
 	// to the value after calling Next.
 	LeafProof() [][]byte
+
+	AddResolver(*Database)
 }
 
 // nodeIteratorState represents the iteration state at one particular node of the
@@ -115,10 +117,15 @@ type nodeIteratorState struct {
 }
 
 type nodeIterator struct {
-	trie  *Trie                // Trie being iterated
-	stack []*nodeIteratorState // Hierarchy of trie nodes persisting the iteration state
-	path  []byte               // Path to the current node
-	err   error                // Failure set in case of an internal error in the iterator
+	trie            *Trie                // Trie being iterated
+	stack           []*nodeIteratorState // Hierarchy of trie nodes persisting the iteration state
+	path            []byte               // Path to the current node
+	err             error                // Failure set in case of an internal error in the iterator
+	primaryResolver *Database
+}
+
+func (it *nodeIterator) AddResolver(db *Database) {
+	it.primaryResolver = db
 }
 
 // errIteratorEnd is stored in nodeIterator.err when iteration is done.
@@ -264,7 +271,7 @@ func (it *nodeIterator) peek(descend bool) (*nodeIteratorState, *int, []byte, er
 		if root != emptyRoot {
 			state.hash = root
 		}
-		err := state.resolve(it.trie, nil)
+		err := state.resolve(it, nil)
 		return state, nil, nil, err
 	}
 	if !descend {
@@ -281,7 +288,7 @@ func (it *nodeIterator) peek(descend bool) (*nodeIteratorState, *int, []byte, er
 		}
 		state, path, ok := it.nextChild(parent, ancestor)
 		if ok {
-			if err := state.resolve(it.trie, path); err != nil {
+			if err := state.resolve(it, path); err != nil {
 				return parent, &parent.index, path, err
 			}
 			return state, &parent.index, path, nil
@@ -292,9 +299,19 @@ func (it *nodeIterator) peek(descend bool) (*nodeIteratorState, *int, []byte, er
 	return nil, nil, nil, errIteratorEnd
 }
 
-func (st *nodeIteratorState) resolve(tr *Trie, path []byte) error {
+func (it *nodeIterator) resolveHash(hash hashNode, path []byte) (node, error) {
+	if it.primaryResolver != nil {
+		if resolved := it.primaryResolver.node(common.BytesToHash(hash)); resolved != nil {
+			return resolved, nil
+		}
+	}
+	resolved, err := it.trie.resolveHash(hash, path)
+	return resolved, err
+}
+
+func (st *nodeIteratorState) resolve(it *nodeIterator, path []byte) error {
 	if hash, ok := st.node.(hashNode); ok {
-		resolved, err := tr.resolveHash(hash, path)
+		resolved, err := it.resolveHash(hash, path)
 		if err != nil {
 			return err
 		}
@@ -420,6 +437,10 @@ func (it *differenceIterator) Path() []byte {
 	return it.b.Path()
 }
 
+func (it *differenceIterator) AddResolver(db *Database) {
+	panic("Not implemented")
+}
+
 func (it *differenceIterator) Next(bool) bool {
 	// Invariants:
 	// - We always advance at least one element in b.
@@ -525,6 +546,10 @@ func (it *unionIterator) LeafProof() [][]byte {
 
 func (it *unionIterator) Path() []byte {
 	return (*it.items)[0].Path()
+}
+
+func (it *unionIterator) AddResolver(db *Database) {
+	panic("Not implemented")
 }
 
 // Next returns the next node in the union of tries being iterated over.

--- a/trie/iterator.go
+++ b/trie/iterator.go
@@ -102,8 +102,6 @@ type NodeIterator interface {
 	// iterator is not positioned at a leaf. Callers must not retain references
 	// to the value after calling Next.
 	LeafProof() [][]byte
-
-	AddResolver(*Database)
 }
 
 // nodeIteratorState represents the iteration state at one particular node of the
@@ -117,15 +115,10 @@ type nodeIteratorState struct {
 }
 
 type nodeIterator struct {
-	trie            *Trie                // Trie being iterated
-	stack           []*nodeIteratorState // Hierarchy of trie nodes persisting the iteration state
-	path            []byte               // Path to the current node
-	err             error                // Failure set in case of an internal error in the iterator
-	primaryResolver *Database
-}
-
-func (it *nodeIterator) AddResolver(db *Database) {
-	it.primaryResolver = db
+	trie  *Trie                // Trie being iterated
+	stack []*nodeIteratorState // Hierarchy of trie nodes persisting the iteration state
+	path  []byte               // Path to the current node
+	err   error                // Failure set in case of an internal error in the iterator
 }
 
 // errIteratorEnd is stored in nodeIterator.err when iteration is done.
@@ -271,7 +264,7 @@ func (it *nodeIterator) peek(descend bool) (*nodeIteratorState, *int, []byte, er
 		if root != emptyRoot {
 			state.hash = root
 		}
-		err := state.resolve(it, nil)
+		err := state.resolve(it.trie, nil)
 		return state, nil, nil, err
 	}
 	if !descend {
@@ -288,7 +281,7 @@ func (it *nodeIterator) peek(descend bool) (*nodeIteratorState, *int, []byte, er
 		}
 		state, path, ok := it.nextChild(parent, ancestor)
 		if ok {
-			if err := state.resolve(it, path); err != nil {
+			if err := state.resolve(it.trie, path); err != nil {
 				return parent, &parent.index, path, err
 			}
 			return state, &parent.index, path, nil
@@ -299,19 +292,9 @@ func (it *nodeIterator) peek(descend bool) (*nodeIteratorState, *int, []byte, er
 	return nil, nil, nil, errIteratorEnd
 }
 
-func (it *nodeIterator) resolveHash(hash hashNode, path []byte) (node, error) {
-	if it.primaryResolver != nil {
-		if resolved := it.primaryResolver.node(common.BytesToHash(hash)); resolved != nil {
-			return resolved, nil
-		}
-	}
-	resolved, err := it.trie.resolveHash(hash, path)
-	return resolved, err
-}
-
-func (st *nodeIteratorState) resolve(it *nodeIterator, path []byte) error {
+func (st *nodeIteratorState) resolve(tr *Trie, path []byte) error {
 	if hash, ok := st.node.(hashNode); ok {
-		resolved, err := it.resolveHash(hash, path)
+		resolved, err := tr.resolveHash(hash, path)
 		if err != nil {
 			return err
 		}
@@ -437,10 +420,6 @@ func (it *differenceIterator) Path() []byte {
 	return it.b.Path()
 }
 
-func (it *differenceIterator) AddResolver(db *Database) {
-	panic("Not implemented")
-}
-
 func (it *differenceIterator) Next(bool) bool {
 	// Invariants:
 	// - We always advance at least one element in b.
@@ -546,10 +525,6 @@ func (it *unionIterator) LeafProof() [][]byte {
 
 func (it *unionIterator) Path() []byte {
 	return (*it.items)[0].Path()
-}
-
-func (it *unionIterator) AddResolver(db *Database) {
-	panic("Not implemented")
 }
 
 // Next returns the next node in the union of tries being iterated over.


### PR DESCRIPTION
Alternative implementation for https://github.com/ethereum/go-ethereum/pull/22667, which in theory does the same thing reusing the read/clean cache, instead of introducing a new mechanism. Needs to be benchmarked / verified though.