### PR TITLE
tests: disable blockchain tests based on general state tests

### DIFF
--- a/tests/block_test.go
+++ b/tests/block_test.go
@@ -28,7 +28,7 @@ func TestBlockchain(t *testing.T) {
 	// For speedier CI-runs, the line below can be uncommented, so those are skipped.
 	// For now, in hardfork-times (Berlin), we run the tests both as StateTests and
 	// as blockchain tests, since the latter also covers things like receipt root
-	//bt.skipLoad(`^GeneralStateTests/`)
+	bt.skipLoad(`^GeneralStateTests/`)
 
 	// Skip random failures due to selfish mining test
 	bt.skipLoad(`.*bcForgedTest/bcForkUncle\.json`)


### PR DESCRIPTION
Before berlin, I enabled general state tests to run as blockchain tests aswell. I think we can disable that now, and hopefully get green on the arm64-build which currently times out most of the time