### PR TITLE
les: clean up resources during test

### DIFF
--- a/les/server.go
+++ b/les/server.go
@@ -212,17 +212,25 @@ func (s *LesServer) Stop() error {
 	close(s.closeCh)
 
 	s.clientPool.Stop()
-	s.serverset.close()
+	if s.serverset != nil {
+		s.serverset.close()
+	}
 	s.peers.close()
 	s.fcManager.Stop()
 	s.costTracker.stop()
 	s.handler.stop()
 	s.servingQueue.stop()
-	s.vfluxServer.Stop()
+	if s.vfluxServer != nil {
+		s.vfluxServer.Stop()
+	}
 
 	// Note, bloom trie indexer is closed by parent bloombits indexer.
-	s.chtIndexer.Close()
-	s.lesDb.Close()
+	if s.chtIndexer != nil {
+		s.chtIndexer.Close()
+	}
+	if s.lesDb != nil {
+		s.lesDb.Close()
+	}
 	s.wg.Wait()
 	log.Info("Les server stopped")
 

--- a/les/test_helper.go
+++ b/les/test_helper.go
@@ -189,7 +189,7 @@ func testIndexers(db ethdb.Database, odr light.OdrBackend, config *light.Indexer
 	return indexers[:]
 }
 
-func newTestClientHandler(backend *backends.SimulatedBackend, odr *LesOdr, indexers []*core.ChainIndexer, db ethdb.Database, peers *serverPeerSet, ulcServers []string, ulcFraction int) *clientHandler {
+func newTestClientHandler(backend *backends.SimulatedBackend, odr *LesOdr, indexers []*core.ChainIndexer, db ethdb.Database, peers *serverPeerSet, ulcServers []string, ulcFraction int) (*clientHandler, func()) {
 	var (
 		evmux  = new(event.TypeMux)
 		engine = ethash.NewFaker()
@@ -245,10 +245,12 @@ func newTestClientHandler(backend *backends.SimulatedBackend, odr *LesOdr, index
 		client.oracle.Start(backend)
 	}
 	client.handler.start()
-	return client.handler
+	return client.handler, func() {
+		client.handler.stop()
+	}
 }
 
-func newTestServerHandler(blocks int, indexers []*core.ChainIndexer, db ethdb.Database, clock mclock.Clock) (*serverHandler, *backends.SimulatedBackend) {
+func newTestServerHandler(blocks int, indexers []*core.ChainIndexer, db ethdb.Database, clock mclock.Clock) (*serverHandler, *backends.SimulatedBackend, func()) {
 	var (
 		gspec = core.Genesis{
 			Config:   params.AllEthashProtocolChanges,
@@ -314,7 +316,8 @@ func newTestServerHandler(blocks int, indexers []*core.ChainIndexer, db ethdb.Da
 	}
 	server.servingQueue.setThreads(4)
 	server.handler.start()
-	return server.handler, simulation
+	closer := func() { server.Stop() }
+	return server.handler, simulation, closer
 }
 
 func alwaysTrueFn() bool {
@@ -600,8 +603,8 @@ func newClientServerEnv(t *testing.T, config testnetConfig) (*testServer, *testC
 	ccIndexer, cbIndexer, cbtIndexer := cIndexers[0], cIndexers[1], cIndexers[2]
 	odr.SetIndexers(ccIndexer, cbIndexer, cbtIndexer)
 
-	server, b := newTestServerHandler(config.blocks, sindexers, sdb, clock)
-	client := newTestClientHandler(b, odr, cIndexers, cdb, speers, config.ulcServers, config.ulcFraction)
+	server, b, serverClose := newTestServerHandler(config.blocks, sindexers, sdb, clock)
+	client, clientClose := newTestClientHandler(b, odr, cIndexers, cdb, speers, config.ulcServers, config.ulcFraction)
 
 	scIndexer.Start(server.blockchain)
 	sbIndexer.Start(server.blockchain)
@@ -658,7 +661,10 @@ func newClientServerEnv(t *testing.T, config testnetConfig) (*testServer, *testC
 		cbIndexer.Close()
 		scIndexer.Close()
 		sbIndexer.Close()
+		dist.close()
+		serverClose()
 		b.Close()
+		clientClose()
 	}
 	return s, c, teardown
 }


### PR DESCRIPTION
The tests fail a lot, e..g on appveyor. Example: https://ci.appveyor.com/project/ethereum/go-ethereum/builds/38784182/job/5so0ap0l4d3al810 

It appears that a _lot_ of goroutines are leaked. Just by running `TestReceiptsAccessLes3`, I got the dump below after doing the teardown. 

THe changes in this PR might be doable more nicely, but I'm not really that well versed about how les works under the hood, so I just made the simplest changes I could find which "fixed" it. 

```
GOROOT=/usr/local/go #gosetup
GOPATH=/home/user/go #gosetup
/usr/local/go/bin/go test -c -o /tmp/___TestReceiptsAccessLes3_in_github_com_ethereum_go_ethereum_les github.com/ethereum/go-ethereum/les #gosetup
/usr/local/go/bin/go tool test2json -t /tmp/___TestReceiptsAccessLes3_in_github_com_ethereum_go_ethereum_les -test.v -test.run ^\QTestReceiptsAccessLes3\E$
=== RUN   TestReceiptsAccessLes3
goroutine 48 [running]:
runtime/pprof.writeGoroutineStacks(0x129e600, 0xc00064cf00, 0xc00016f170, 0xc000355db0)
	/usr/local/go/src/runtime/pprof/pprof.go:693 +0x9f
runtime/pprof.writeGoroutine(0x129e600, 0xc00064cf00, 0x2, 0x203000, 0x0)
	/usr/local/go/src/runtime/pprof/pprof.go:682 +0x45
runtime/pprof.(*Profile).WriteTo(0x186abc0, 0x129e600, 0xc00064cf00, 0x2, 0x0, 0x0)
	/usr/local/go/src/runtime/pprof/pprof.go:331 +0x3f2
github.com/ethereum/go-ethereum/les.testAccess(0xc00011d800, 0x3, 0x11966a0)
	/home/user/go/src/github.com/ethereum/go-ethereum/les/request_test.go:127 +0x2f5
github.com/ethereum/go-ethereum/les.TestReceiptsAccessLes3(0xc00011d800)
	/home/user/go/src/github.com/ethereum/go-ethereum/les/request_test.go:51 +0x45
testing.tRunner(0xc00011d800, 0x11964d0)
	/usr/local/go/src/testing/testing.go:1123 +0xef
created by testing.(*T).Run
	/usr/local/go/src/testing/testing.go:1168 +0x2b3

goroutine 1 [chan receive]:
testing.(*T).Run(0xc00011d800, 0x10ec987, 0x16, 0x11964d0, 0x49ef01)
	/usr/local/go/src/testing/testing.go:1169 +0x2da
testing.runTests.func1(0xc00011d680)
	/usr/local/go/src/testing/testing.go:1439 +0x78
testing.tRunner(0xc00011d680, 0xc0001b3d40)
	/usr/local/go/src/testing/testing.go:1123 +0xef
testing.runTests(0xc0004486a0, 0x1878460, 0x56, 0x56, 0x0, 0x0, 0x0, 0xde8e46)
	/usr/local/go/src/testing/testing.go:1437 +0x2fe
testing.(*M).Run(0xc000140c80, 0x0)
	/usr/local/go/src/testing/testing.go:1345 +0x1eb
github.com/ethereum/go-ethereum/les.TestMain(0xc000140c80)
	/home/user/go/src/github.com/ethereum/go-ethereum/les/api_test.go:60 +0x155
main.main()
	_testmain.go:215 +0x165

goroutine 36 [chan receive]:
github.com/ethereum/go-ethereum/core.(*txSenderCacher).cache(0xc0001966c0)
	/home/user/go/src/github.com/ethereum/go-ethereum/core/tx_cacher.go:63 +0x97
created by github.com/ethereum/go-ethereum/core.newTxSenderCacher
	/home/user/go/src/github.com/ethereum/go-ethereum/core/tx_cacher.go:55 +0x9f

goroutine 37 [chan receive]:
github.com/ethereum/go-ethereum/core.(*txSenderCacher).cache(0xc0001966c0)
	/home/user/go/src/github.com/ethereum/go-ethereum/core/tx_cacher.go:63 +0x97
created by github.com/ethereum/go-ethereum/core.newTxSenderCacher
	/home/user/go/src/github.com/ethereum/go-ethereum/core/tx_cacher.go:55 +0x9f

goroutine 38 [chan receive]:
github.com/ethereum/go-ethereum/core.(*txSenderCacher).cache(0xc0001966c0)
	/home/user/go/src/github.com/ethereum/go-ethereum/core/tx_cacher.go:63 +0x97
created by github.com/ethereum/go-ethereum/core.newTxSenderCacher
	/home/user/go/src/github.com/ethereum/go-ethereum/core/tx_cacher.go:55 +0x9f

goroutine 39 [chan receive]:
github.com/ethereum/go-ethereum/core.(*txSenderCacher).cache(0xc0001966c0)
	/home/user/go/src/github.com/ethereum/go-ethereum/core/tx_cacher.go:63 +0x97
created by github.com/ethereum/go-ethereum/core.newTxSenderCacher
	/home/user/go/src/github.com/ethereum/go-ethereum/core/tx_cacher.go:55 +0x9f

goroutine 40 [chan receive]:
github.com/ethereum/go-ethereum/core.(*txSenderCacher).cache(0xc0001966c0)
	/home/user/go/src/github.com/ethereum/go-ethereum/core/tx_cacher.go:63 +0x97
created by github.com/ethereum/go-ethereum/core.newTxSenderCacher
	/home/user/go/src/github.com/ethereum/go-ethereum/core/tx_cacher.go:55 +0x9f

goroutine 41 [chan receive]:
github.com/ethereum/go-ethereum/core.(*txSenderCacher).cache(0xc0001966c0)
	/home/user/go/src/github.com/ethereum/go-ethereum/core/tx_cacher.go:63 +0x97
created by github.com/ethereum/go-ethereum/core.newTxSenderCacher
	/home/user/go/src/github.com/ethereum/go-ethereum/core/tx_cacher.go:55 +0x9f

goroutine 42 [chan receive]:
github.com/ethereum/go-ethereum/metrics.(*meterArbiter).tick(0x197c2e0)
	/home/user/go/src/github.com/ethereum/go-ethereum/metrics/meter.go:290 +0x7d
created by github.com/ethereum/go-ethereum/metrics.NewMeterForced
	/home/user/go/src/github.com/ethereum/go-ethereum/metrics/meter.go:71 +0x105

goroutine 43 [select]:
github.com/ethereum/go-ethereum/consensus/ethash.(*remoteSealer).loop(0xc0001480f0)
	/home/user/go/src/github.com/ethereum/go-ethereum/consensus/ethash/sealer.go:278 +0x25c
created by github.com/ethereum/go-ethereum/consensus/ethash.startRemoteSealer
	/home/user/go/src/github.com/ethereum/go-ethereum/consensus/ethash/sealer.go:262 +0x2b2

goroutine 47 [chan receive]:
github.com/rjeczalik/notify.(*nonrecursiveTree).internal(0xc000119d40, 0xc000119ce0)
	/home/user/go/pkg/mod/github.com/rjeczalik/notify@v0.9.1/tree_nonrecursive.go:81 +0x58
created by github.com/rjeczalik/notify.newNonrecursiveTree
	/home/user/go/pkg/mod/github.com/rjeczalik/notify@v0.9.1/tree_nonrecursive.go:30 +0x111

goroutine 46 [chan receive]:
github.com/rjeczalik/notify.(*nonrecursiveTree).dispatch(0xc000119d40, 0xc000119c80)
	/home/user/go/pkg/mod/github.com/rjeczalik/notify@v0.9.1/tree_nonrecursive.go:36 +0xb6
created by github.com/rjeczalik/notify.newNonrecursiveTree
	/home/user/go/pkg/mod/github.com/rjeczalik/notify@v0.9.1/tree_nonrecursive.go:29 +0xe5

goroutine 49 [select]:
github.com/ethereum/go-ethereum/les.(*requestDistributor).loop(0xc000255b20)
	/home/user/go/src/github.com/ethereum/go-ethereum/les/distributor.go:128 +0x34e
created by github.com/ethereum/go-ethereum/les.newRequestDistributor
	/home/user/go/src/github.com/ethereum/go-ethereum/les/distributor.go:89 +0x14c

goroutine 118 [select]:
github.com/ethereum/go-ethereum/les.(*servingQueue).queueLoop(0xc00016f3b0)
	/home/user/go/src/github.com/ethereum/go-ethereum/les/servingqueue.go:323 +0x385
created by github.com/ethereum/go-ethereum/les.newServingQueue
	/home/user/go/src/github.com/ethereum/go-ethereum/les/servingqueue.go:139 +0x2fd

goroutine 119 [select]:
github.com/ethereum/go-ethereum/les.(*servingQueue).threadCountLoop(0xc00016f3b0)
	/home/user/go/src/github.com/ethereum/go-ethereum/les/servingqueue.go:354 +0x245
created by github.com/ethereum/go-ethereum/les.newServingQueue
	/home/user/go/src/github.com/ethereum/go-ethereum/les/servingqueue.go:140 +0x31f

goroutine 120 [select]:
github.com/ethereum/go-ethereum/les/flowcontrol.NewClientManager.func2(0xc0000d8630)
	/home/user/go/src/github.com/ethereum/go-ethereum/les/flowcontrol/manager.go:121 +0xdf
created by github.com/ethereum/go-ethereum/les/flowcontrol.NewClientManager
	/home/user/go/src/github.com/ethereum/go-ethereum/les/flowcontrol/manager.go:118 +0x205

goroutine 121 [select]:
github.com/ethereum/go-ethereum/les.(*costTracker).gfLoop.func1(0xc000102ea8, 0xc00016f5f0, 0xc000102e98, 0xc000102ec8, 0xc000102eb0, 0xc000102eb8, 0x0, 0xc000102ec0, 0xc000102ea0)
	/home/user/go/src/github.com/ethereum/go-ethereum/les/costtracker.go:275 +0x1c8
created by github.com/ethereum/go-ethereum/les.(*costTracker).gfLoop
	/home/user/go/src/github.com/ethereum/go-ethereum/les/costtracker.go:264 +0x25c

goroutine 122 [select]:
github.com/ethereum/go-ethereum/les/vflux/server.(*nodeDB).expirer(0xc00007cf00)
	/home/user/go/src/github.com/ethereum/go-ethereum/les/vflux/server/clientdb.go:214 +0xe5
created by github.com/ethereum/go-ethereum/les/vflux/server.newNodeDB
	/home/user/go/src/github.com/ethereum/go-ethereum/les/vflux/server/clientdb.go:79 +0x145

goroutine 123 [select]:
github.com/ethereum/go-ethereum/les/vflux/server.newBalanceTracker.func4(0x12bb760, 0x19b1e28, 0xc0004f8a80, 0x12b3d60, 0xc00082c2a0, 0x12b3d60, 0xc00082c2d0)
	/home/user/go/src/github.com/ethereum/go-ethereum/les/vflux/server/balance_tracker.go:129 +0x175
created by github.com/ethereum/go-ethereum/les/vflux/server.newBalanceTracker
	/home/user/go/src/github.com/ethereum/go-ethereum/les/vflux/server/balance_tracker.go:127 +0x3fc

goroutine 124 [select]:
github.com/ethereum/go-ethereum/les.(*serverHandler).broadcastLoop(0xc00007d380)
	/home/user/go/src/github.com/ethereum/go-ethereum/les/server_handler.go:418 +0x1a5
created by github.com/ethereum/go-ethereum/les.(*serverHandler).start
	/home/user/go/src/github.com/ethereum/go-ethereum/les/server_handler.go:92 +0x5c

goroutine 126 [select]:
github.com/ethereum/go-ethereum/eth/downloader.(*Downloader).qosTuner(0xc000707680)
	/home/user/go/src/github.com/ethereum/go-ethereum/eth/downloader/downloader.go:2040 +0x36d
created by github.com/ethereum/go-ethereum/eth/downloader.New
	/home/user/go/src/github.com/ethereum/go-ethereum/eth/downloader/downloader.go:251 +0x493

goroutine 68 [select]:
github.com/ethereum/go-ethereum/les.(*servingQueue).threadController(0xc00016f3b0)
	/home/user/go/src/github.com/ethereum/go-ethereum/les/servingqueue.go:164 +0x12c
created by github.com/ethereum/go-ethereum/les.(*servingQueue).threadCountLoop
	/home/user/go/src/github.com/ethereum/go-ethereum/les/servingqueue.go:341 +0x74

goroutine 69 [select]:
github.com/ethereum/go-ethereum/les.(*servingQueue).threadController(0xc00016f3b0)
	/home/user/go/src/github.com/ethereum/go-ethereum/les/servingqueue.go:164 +0x12c
created by github.com/ethereum/go-ethereum/les.(*servingQueue).threadCountLoop
	/home/user/go/src/github.com/ethereum/go-ethereum/les/servingqueue.go:341 +0x74

goroutine 70 [select]:
github.com/ethereum/go-ethereum/les.(*servingQueue).threadController(0xc00016f3b0)
	/home/user/go/src/github.com/ethereum/go-ethereum/les/servingqueue.go:164 +0x12c
created by github.com/ethereum/go-ethereum/les.(*servingQueue).threadCountLoop
	/home/user/go/src/github.com/ethereum/go-ethereum/les/servingqueue.go:341 +0x74

goroutine 71 [select]:
github.com/ethereum/go-ethereum/les.(*servingQueue).threadController(0xc00016f3b0)
	/home/user/go/src/github.com/ethereum/go-ethereum/les/servingqueue.go:164 +0x12c
created by github.com/ethereum/go-ethereum/les.(*servingQueue).threadCountLoop
	/home/user/go/src/github.com/ethereum/go-ethereum/les/servingqueue.go:341 +0x74

goroutine 127 [select]:
github.com/ethereum/go-ethereum/eth/downloader.(*Downloader).stateFetcher(0xc000707680)
	/home/user/go/src/github.com/ethereum/go-ethereum/eth/downloader/statesync.go:83 +0x106
created by github.com/ethereum/go-ethereum/eth/downloader.New
	/home/user/go/src/github.com/ethereum/go-ethereum/eth/downloader/downloader.go:252 +0x4b5

goroutine 128 [select]:
github.com/ethereum/go-ethereum/eth/fetcher.(*BlockFetcher).loop(0xc0002b5880)
	/home/user/go/src/github.com/ethereum/go-ethereum/eth/fetcher/block_fetcher.go:379 +0x7ca
created by github.com/ethereum/go-ethereum/eth/fetcher.(*BlockFetcher).Start
	/home/user/go/src/github.com/ethereum/go-ethereum/eth/fetcher/block_fetcher.go:231 +0x3f

goroutine 129 [select]:
github.com/ethereum/go-ethereum/les.(*lightFetcher).mainloop(0xc0000d9ce0)
	/home/user/go/src/github.com/ethereum/go-ethereum/les/fetcher.go:304 +0x4e5
created by github.com/ethereum/go-ethereum/les.(*lightFetcher).start
	/home/user/go/src/github.com/ethereum/go-ethereum/les/fetcher.go:200 +0x71

--- PASS: TestReceiptsAccessLes3 (0.12s)
PASS

Process finished with exit code 0

```
After this PR, the corresponding stack dump is : 
```
GOROOT=/usr/local/go #gosetup
GOPATH=/home/user/go #gosetup
/usr/local/go/bin/go test -c -o /tmp/___TestReceiptsAccessLes3_in_github_com_ethereum_go_ethereum_les github.com/ethereum/go-ethereum/les #gosetup
/usr/local/go/bin/go tool test2json -t /tmp/___TestReceiptsAccessLes3_in_github_com_ethereum_go_ethereum_les -test.v -test.run ^\QTestReceiptsAccessLes3\E$
=== RUN   TestReceiptsAccessLes3
goroutine 6 [running]:
runtime/pprof.writeGoroutineStacks(0x129e720, 0xc0007450e0, 0x3f, 0xeb)
	/usr/local/go/src/runtime/pprof/pprof.go:693 +0x9f
runtime/pprof.writeGoroutine(0x129e720, 0xc0007450e0, 0x2, 0x203000, 0x0)
	/usr/local/go/src/runtime/pprof/pprof.go:682 +0x45
runtime/pprof.(*Profile).WriteTo(0x186bbc0, 0x129e720, 0xc0007450e0, 0x2, 0x0, 0x0)
	/usr/local/go/src/runtime/pprof/pprof.go:331 +0x3f2
github.com/ethereum/go-ethereum/les.testAccess(0xc000111200, 0x3, 0x11967a0)
	/home/user/go/src/github.com/ethereum/go-ethereum/les/request_test.go:127 +0x2f5
github.com/ethereum/go-ethereum/les.TestReceiptsAccessLes3(0xc000111200)
	/home/user/go/src/github.com/ethereum/go-ethereum/les/request_test.go:51 +0x45
testing.tRunner(0xc000111200, 0x11965d0)
	/usr/local/go/src/testing/testing.go:1123 +0xef
created by testing.(*T).Run
	/usr/local/go/src/testing/testing.go:1168 +0x2b3

goroutine 1 [chan receive]:
testing.(*T).Run(0xc000111200, 0x10eca87, 0x16, 0x11965d0, 0x49ef01)
	/usr/local/go/src/testing/testing.go:1169 +0x2da
testing.runTests.func1(0xc000111080)
	/usr/local/go/src/testing/testing.go:1439 +0x78
testing.tRunner(0xc000111080, 0xc0005f5d40)
	/usr/local/go/src/testing/testing.go:1123 +0xef
testing.runTests(0xc000126860, 0x1879460, 0x56, 0x56, 0x0, 0x0, 0x0, 0xde8e46)
	/usr/local/go/src/testing/testing.go:1437 +0x2fe
testing.(*M).Run(0xc000124200, 0x0)
	/usr/local/go/src/testing/testing.go:1345 +0x1eb
github.com/ethereum/go-ethereum/les.TestMain(0xc000124200)
	/home/user/go/src/github.com/ethereum/go-ethereum/les/api_test.go:60 +0x155
main.main()
	_testmain.go:215 +0x165

goroutine 21 [chan receive]:
github.com/ethereum/go-ethereum/core.(*txSenderCacher).cache(0xc0001b2ca0)
	/home/user/go/src/github.com/ethereum/go-ethereum/core/tx_cacher.go:63 +0x97
created by github.com/ethereum/go-ethereum/core.newTxSenderCacher
	/home/user/go/src/github.com/ethereum/go-ethereum/core/tx_cacher.go:55 +0x9f

goroutine 22 [chan receive]:
github.com/ethereum/go-ethereum/core.(*txSenderCacher).cache(0xc0001b2ca0)
	/home/user/go/src/github.com/ethereum/go-ethereum/core/tx_cacher.go:63 +0x97
created by github.com/ethereum/go-ethereum/core.newTxSenderCacher
	/home/user/go/src/github.com/ethereum/go-ethereum/core/tx_cacher.go:55 +0x9f

goroutine 23 [chan receive]:
github.com/ethereum/go-ethereum/core.(*txSenderCacher).cache(0xc0001b2ca0)
	/home/user/go/src/github.com/ethereum/go-ethereum/core/tx_cacher.go:63 +0x97
created by github.com/ethereum/go-ethereum/core.newTxSenderCacher
	/home/user/go/src/github.com/ethereum/go-ethereum/core/tx_cacher.go:55 +0x9f

goroutine 24 [chan receive]:
github.com/ethereum/go-ethereum/core.(*txSenderCacher).cache(0xc0001b2ca0)
	/home/user/go/src/github.com/ethereum/go-ethereum/core/tx_cacher.go:63 +0x97
created by github.com/ethereum/go-ethereum/core.newTxSenderCacher
	/home/user/go/src/github.com/ethereum/go-ethereum/core/tx_cacher.go:55 +0x9f

goroutine 25 [chan receive]:
github.com/ethereum/go-ethereum/core.(*txSenderCacher).cache(0xc0001b2ca0)
	/home/user/go/src/github.com/ethereum/go-ethereum/core/tx_cacher.go:63 +0x97
created by github.com/ethereum/go-ethereum/core.newTxSenderCacher
	/home/user/go/src/github.com/ethereum/go-ethereum/core/tx_cacher.go:55 +0x9f

goroutine 26 [chan receive]:
github.com/ethereum/go-ethereum/core.(*txSenderCacher).cache(0xc0001b2ca0)
	/home/user/go/src/github.com/ethereum/go-ethereum/core/tx_cacher.go:63 +0x97
created by github.com/ethereum/go-ethereum/core.newTxSenderCacher
	/home/user/go/src/github.com/ethereum/go-ethereum/core/tx_cacher.go:55 +0x9f

goroutine 27 [chan receive]:
github.com/ethereum/go-ethereum/metrics.(*meterArbiter).tick(0x197d2e0)
	/home/user/go/src/github.com/ethereum/go-ethereum/metrics/meter.go:290 +0x7d
created by github.com/ethereum/go-ethereum/metrics.NewMeterForced
	/home/user/go/src/github.com/ethereum/go-ethereum/metrics/meter.go:71 +0x105

goroutine 28 [select]:
github.com/ethereum/go-ethereum/consensus/ethash.(*remoteSealer).loop(0xc0001920f0)
	/home/user/go/src/github.com/ethereum/go-ethereum/consensus/ethash/sealer.go:278 +0x25c
created by github.com/ethereum/go-ethereum/consensus/ethash.startRemoteSealer
	/home/user/go/src/github.com/ethereum/go-ethereum/consensus/ethash/sealer.go:262 +0x2b2

goroutine 35 [chan receive]:
github.com/rjeczalik/notify.(*nonrecursiveTree).dispatch(0xc00010c720, 0xc00010c660)
	/home/user/go/pkg/mod/github.com/rjeczalik/notify@v0.9.1/tree_nonrecursive.go:36 +0xb6
created by github.com/rjeczalik/notify.newNonrecursiveTree
	/home/user/go/pkg/mod/github.com/rjeczalik/notify@v0.9.1/tree_nonrecursive.go:29 +0xe5

goroutine 36 [chan receive]:
github.com/rjeczalik/notify.(*nonrecursiveTree).internal(0xc00010c720, 0xc00010c6c0)
	/home/user/go/pkg/mod/github.com/rjeczalik/notify@v0.9.1/tree_nonrecursive.go:81 +0x58
created by github.com/rjeczalik/notify.newNonrecursiveTree
	/home/user/go/pkg/mod/github.com/rjeczalik/notify@v0.9.1/tree_nonrecursive.go:30 +0x111

goroutine 115 [select]:
github.com/ethereum/go-ethereum/eth/downloader.(*Downloader).qosTuner(0xc000786d20)
	/home/user/go/src/github.com/ethereum/go-ethereum/eth/downloader/downloader.go:2040 +0x36d
created by github.com/ethereum/go-ethereum/eth/downloader.New
	/home/user/go/src/github.com/ethereum/go-ethereum/eth/downloader/downloader.go:251 +0x493

goroutine 116 [select]:
github.com/ethereum/go-ethereum/eth/downloader.(*Downloader).stateFetcher(0xc000786d20)
	/home/user/go/src/github.com/ethereum/go-ethereum/eth/downloader/statesync.go:83 +0x106
created by github.com/ethereum/go-ethereum/eth/downloader.New
	/home/user/go/src/github.com/ethereum/go-ethereum/eth/downloader/downloader.go:252 +0x4b5

goroutine 117 [select]:
github.com/ethereum/go-ethereum/eth/fetcher.(*BlockFetcher).loop(0xc0003d5260)
	/home/user/go/src/github.com/ethereum/go-ethereum/eth/fetcher/block_fetcher.go:379 +0x7ca
created by github.com/ethereum/go-ethereum/eth/fetcher.(*BlockFetcher).Start
	/home/user/go/src/github.com/ethereum/go-ethereum/eth/fetcher/block_fetcher.go:231 +0x3f

goroutine 118 [select]:
github.com/ethereum/go-ethereum/les.(*lightFetcher).mainloop(0xc0000d9810)
	/home/user/go/src/github.com/ethereum/go-ethereum/les/fetcher.go:304 +0x4e5
created by github.com/ethereum/go-ethereum/les.(*lightFetcher).start
	/home/user/go/src/github.com/ethereum/go-ethereum/les/fetcher.go:200 +0x71

--- PASS: TestReceiptsAccessLes3 (0.08s)
PASS

Process finished with exit code 0
```
