### PR TITLE
eth/tracers, internal/ethapi: fix typos causing lint issue

### DIFF
--- a/eth/tracers/api_test.go
+++ b/eth/tracers/api_test.go
@@ -372,7 +372,7 @@ func TestOverridenTraceCall(t *testing.T) {
 			expectErr: core.ErrInsufficientFundsForTransfer,
 			expect:    nil,
 		},
-		// Sucessful simple contract call
+		// Successful simple contract call
 		//
 		// // SPDX-License-Identifier: GPL-3.0
 		//

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -817,7 +817,7 @@ type OverrideAccount struct {
 	StateDiff *map[common.Hash]common.Hash `json:"stateDiff"`
 }
 
-// StateOverride is the collection of overriden accounts.
+// StateOverride is the collection of overridden accounts.
 type StateOverride map[common.Address]OverrideAccount
 
 // Apply overrides the fields of specified accounts into the given state.


### PR DESCRIPTION
This PR fixes two typos.