### PR TITLE
core/rawdb: fix datarace in freezer

### DIFF
--- a/core/rawdb/freezer_table_test.go
+++ b/core/rawdb/freezer_table_test.go
@@ -642,7 +642,13 @@ func TestOffset(t *testing.T) {
 // handled already, and the case described above can only (?) happen if an external process/user
 // deletes files from the filesystem.
 
+// TestAppendTruncateParallel is a test to check if the Append/truncate operations
+// are racy. It's disabled, since it's a long-running test which does not fit well
+// in CI.
+// The reason why it's not a regular fuzzer, within tests/fuzzers, is that it is
+// dependent on timing rather than 'clever' input -- there's no determinism.
 func TestAppendTruncateParallel(t *testing.T) {
+	t.Skip()
 	f, err := newCustomTable("./freezer", "tmp", metrics.NilMeter{},
 		metrics.NilMeter{}, metrics.NilGauge{}, 8, true)
 


### PR DESCRIPTION
This PR fixes https://github.com/ethereum/go-ethereum/issues/22714 . 
The Append / truncate operations were racy. When a datafile reaches `2Gb`, a new file is needed. For this operation, we require a writelock, which is not needed in the 99.99% of all cases where the data does fit in the current head-file. 

This transition from readlock to writelock was incorrect, and as the readlock was released, a `truncate` operation could slip in between, and truncate the data. This would have been fine, however, the `Append` operation continued writing as if no truncation had occurred, e.g writing item `5` where item `0` should reside. 

This PR changes the behaviour, so that if when we run into the situation that a new file is needed, it aborts, and retries, this time with a writelock. 

The outcome of the situation described above, running on this PR, would instead be that the `Append` operation exits with a failure. 

The attached testcase, when enabled, finds the (original)  bug pretty quickly. 