### PR TITLE
cmd/utils: don't crash on nonexistent datadir

### DIFF
--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -1628,7 +1628,7 @@ func SetEthConfig(ctx *cli.Context, stack *node.Node, cfg *ethconfig.Config) {
 		if ctx.GlobalIsSet(DataDirFlag.Name) {
 			// Check if we have an already initialized chain and fall back to
 			// that if so. Otherwise we need to generate a new genesis spec.
-			chaindb := MakeChainDatabase(ctx, stack, true)
+			chaindb := MakeChainDatabase(ctx, stack, false) // TODO (MariusVanDerWijden) make this read only
 			if rawdb.ReadCanonicalHash(chaindb, 0) != (common.Hash{}) {
 				cfg.Genesis = nil // fallback to db content
 			}


### PR DESCRIPTION
closes https://github.com/ethereum/go-ethereum/issues/22720

Problem is that if the datadir is opened read only and does not exist, the `leveldb.New` command will fail.
Previous behavior was to create the datadir if non-existent.
This PR restores previous behavior