### PR TITLE
appveyor.yml: use VisualStudio 2019 image

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -23,7 +23,6 @@ environment:
 
 install:
   - git submodule update --init
-  - rmdir C:\go /s /q
   - go version
   - gcc --version
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,24 +7,21 @@ version: "{branch}.{build}"
 environment:
   global:
     GO111MODULE: on
-    GOPATH: C:\gopath
-    CC: C:\mingw-w64\x86_64-8.1.0-posix-seh-rt_v6-rev0\mingw64\bin\gcc.exe
   matrix:
-    # - GETH_ARCH: amd64
-    #   MSYS2_ARCH: x86_64
-    #   MSYS2_BITS: 64
-    #   MSYSTEM: MINGW64
-    #   PATH: C:\msys64\mingw64\bin\;C:\Program Files (x86)\NSIS\;%PATH%
+    - GETH_ARCH: amd64
+      CC: C:\msys64\mingw64\bin\gcc.exe
+      PATH: C:\Program Files (x86)\NSIS\;%PATH%
     - GETH_ARCH: 386
+      CC: C:\msys64\mingw64\bin\gcc.exe
       PATH: C:\Program Files (x86)\NSIS\;%PATH%
 
 install:
   - git submodule update --init
   - go version
-  - C:\mingw-w64\x86_64-8.1.0-posix-seh-rt_v6-rev0\mingw64\bin\gcc.exe --version
+  - %CC% --version
 
 build_script:
-  - go run build\ci.go install -dlgo -arch %GETH_ARCH% -cc C:\mingw-w64\i686-8.1.0-posix-dwarf-rt_v6-rev0\mingw32\bin\gcc.exe
+  - go run build\ci.go install -dlgo -arch %GETH_ARCH%
 
 after_build:
   - go run build\ci.go archive -arch %GETH_ARCH% -type zip -signer WINDOWS_SIGNING_KEY -upload gethstore/builds

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -16,10 +16,11 @@ environment:
     #   MSYSTEM: MINGW64
     #   PATH: C:\msys64\mingw64\bin\;C:\Program Files (x86)\NSIS\;%PATH%
     - GETH_ARCH: 386
-      MSYS2_ARCH: i686
-      MSYS2_BITS: 32
-      MSYSTEM: MINGW32
-      PATH: C:\msys64\mingw32\bin\;C:\Program Files (x86)\NSIS\;%PATH%
+      PATH: C:\Program Files (x86)\NSIS\;%PATH%
+    #   MSYS2_ARCH: i686
+    #   MSYS2_BITS: 32
+    #   MSYSTEM: MINGW32
+
 
 install:
   - git submodule update --init

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -28,7 +28,7 @@ install:
   - gcc --version
 
 build_script:
-  - go run build\ci.go install -dlgo -arch %GETH_ARCH% -cc C:\msys64\mingw32\bin\gcc.exe
+  - go run build\ci.go install -dlgo -arch %GETH_ARCH%
 
 after_build:
   - go run build\ci.go archive -arch %GETH_ARCH% -type zip -signer WINDOWS_SIGNING_KEY -upload gethstore/builds

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,10 +9,10 @@ environment:
     GO111MODULE: on
   matrix:
     - GETH_ARCH: amd64
-      CC: C:\msys64\mingw64\bin\gcc.exe
+      CC: C:\mingw-w64\x86_64-8.1.0-posix-seh-rt_v6-rev0\bin\gcc.exe
       PATH: C:\Program Files (x86)\NSIS\;%PATH%
     - GETH_ARCH: 386
-      CC: C:\msys64\mingw64\bin\gcc.exe
+      CC: C:\msys64\mingw32\bin\gcc.exe
       PATH: C:\Program Files (x86)\NSIS\;%PATH%
 
 install:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -24,17 +24,14 @@ environment:
 install:
   - git submodule update --init
   - go version
-  - dir C:\msys64\mingw32\bin
-  - dir C:\msys64\mingw64\bin
   - gcc --version
 
 build_script:
-  # - go run build\ci.go install -dlgo
+  - go run build\ci.go install -dlgo -arch %GETH_ARCH%
 
 after_build:
-  # - go run build\ci.go archive -type zip -signer WINDOWS_SIGNING_KEY -upload gethstore/builds
-  # - go run build\ci.go nsis -signer WINDOWS_SIGNING_KEY -upload gethstore/builds
+  - go run build\ci.go archive -arch %GETH_ARCH% -type zip -signer WINDOWS_SIGNING_KEY -upload gethstore/builds
+  - go run build\ci.go nsis -arch %GETH_ARCH% -signer WINDOWS_SIGNING_KEY -upload gethstore/builds
 
 test_script:
-  # - set CGO_ENABLED=1
-  # - go run build\ci.go test -dlgo -coverage
+  - go run build\ci.go test -dlgo -arch %GETH_ARCH% -coverage

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -36,4 +36,4 @@ after_build:
 
 test_script:
   - set CGO_ENABLED=1
-  - go run build\ci.go test -coverage
+  - go run build\ci.go test -dlgo -coverage

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -16,7 +16,7 @@ environment:
     #   MSYSTEM: MINGW64
     #   PATH: C:\msys64\mingw64\bin\;C:\Program Files (x86)\NSIS\;%PATH%
     - GETH_ARCH: 386
-      PATH: C:\Program Files (x86)\NSIS\;%PATH%
+      PATH: C:\msys64\mingw64\bin\;C:\Program Files (x86)\NSIS\;%PATH%
     #   MSYS2_ARCH: i686
     #   MSYS2_BITS: 32
     #   MSYSTEM: MINGW32

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -24,15 +24,17 @@ environment:
 install:
   - git submodule update --init
   - go version
+  - dir C:\msys64\mingw32\bin
+  - dir C:\msys64\mingw64\bin
   - gcc --version
 
 build_script:
-  - go run build\ci.go install -dlgo
+  # - go run build\ci.go install -dlgo
 
 after_build:
-  - go run build\ci.go archive -type zip -signer WINDOWS_SIGNING_KEY -upload gethstore/builds
-  - go run build\ci.go nsis -signer WINDOWS_SIGNING_KEY -upload gethstore/builds
+  # - go run build\ci.go archive -type zip -signer WINDOWS_SIGNING_KEY -upload gethstore/builds
+  # - go run build\ci.go nsis -signer WINDOWS_SIGNING_KEY -upload gethstore/builds
 
 test_script:
-  - set CGO_ENABLED=1
-  - go run build\ci.go test -dlgo -coverage
+  # - set CGO_ENABLED=1
+  # - go run build\ci.go test -dlgo -coverage

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -18,7 +18,7 @@ environment:
 install:
   - git submodule update --init
   - go version
-  - %CC% --version
+  - "%CC% --version"
 
 build_script:
   - go run build\ci.go install -dlgo -arch %GETH_ARCH%

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,11 +10,11 @@ environment:
     GOPATH: C:\gopath
     CC: gcc.exe
   matrix:
-    - GETH_ARCH: amd64
-      MSYS2_ARCH: x86_64
-      MSYS2_BITS: 64
-      MSYSTEM: MINGW64
-      PATH: C:\msys64\mingw64\bin\;C:\Program Files (x86)\NSIS\;%PATH%
+    # - GETH_ARCH: amd64
+    #   MSYS2_ARCH: x86_64
+    #   MSYS2_BITS: 64
+    #   MSYSTEM: MINGW64
+    #   PATH: C:\msys64\mingw64\bin\;C:\Program Files (x86)\NSIS\;%PATH%
     - GETH_ARCH: 386
       MSYS2_ARCH: i686
       MSYS2_BITS: 32
@@ -27,7 +27,7 @@ install:
   - gcc --version
 
 build_script:
-  - go run build\ci.go install -dlgo -arch %GETH_ARCH%
+  - go run build\ci.go install -dlgo -arch %GETH_ARCH% -cc C:\msys64\mingw32\bin\gcc.exe
 
 after_build:
   - go run build\ci.go archive -arch %GETH_ARCH% -type zip -signer WINDOWS_SIGNING_KEY -upload gethstore/builds

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,11 +9,11 @@ environment:
     GO111MODULE: on
   matrix:
     - GETH_ARCH: amd64
-      CC: C:\mingw-w64\x86_64-8.1.0-posix-seh-rt_v6-rev0\bin\gcc.exe
-      PATH: C:\Program Files (x86)\NSIS\;%PATH%
+      CC: C:\msys64\mingw64\bin\gcc.exe
+      PATH: C:\msys64\mingw64\bin;C:\Program Files (x86)\NSIS\;%PATH%
     - GETH_ARCH: 386
       CC: C:\msys64\mingw32\bin\gcc.exe
-      PATH: C:\Program Files (x86)\NSIS\;%PATH%
+      PATH: C:\msys64\mingw32\bin;C:\Program Files (x86)\NSIS\;%PATH%
 
 install:
   - git submodule update --init

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -28,7 +28,7 @@ install:
   - gcc --version
 
 build_script:
-  - go run build\ci.go install -dlgo -arch %GETH_ARCH%
+  - go run build\ci.go install -dlgo -arch %GETH_ARCH% -cc C:\msys64\mingw32\bin\gcc.exe
 
 after_build:
   - go run build\ci.go archive -arch %GETH_ARCH% -type zip -signer WINDOWS_SIGNING_KEY -upload gethstore/builds

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,4 @@
-os: Visual Studio 2015
+os: Visual Studio 2019
 
 # Clone directly into GOPATH.
 clone_folder: C:\gopath\src\github.com\ethereum\go-ethereum
@@ -24,8 +24,6 @@ environment:
 install:
   - git submodule update --init
   - rmdir C:\go /s /q
-  - appveyor DownloadFile https://dl.google.com/go/go1.16.windows-%GETH_ARCH%.zip
-  - 7z x go1.16.windows-%GETH_ARCH%.zip -y -oC:\ > NUL
   - go version
   - gcc --version
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,7 +8,7 @@ environment:
   global:
     GO111MODULE: on
     GOPATH: C:\gopath
-    CC: gcc.exe
+    CC: C:\mingw-w64\x86_64-8.1.0-posix-seh-rt_v6-rev0\mingw64\bin\gcc.exe
   matrix:
     # - GETH_ARCH: amd64
     #   MSYS2_ARCH: x86_64
@@ -16,19 +16,15 @@ environment:
     #   MSYSTEM: MINGW64
     #   PATH: C:\msys64\mingw64\bin\;C:\Program Files (x86)\NSIS\;%PATH%
     - GETH_ARCH: 386
-      PATH: C:\msys64\mingw64\bin\;C:\Program Files (x86)\NSIS\;%PATH%
-    #   MSYS2_ARCH: i686
-    #   MSYS2_BITS: 32
-    #   MSYSTEM: MINGW32
-
+      PATH: C:\Program Files (x86)\NSIS\;%PATH%
 
 install:
   - git submodule update --init
   - go version
-  - gcc --version
+  - C:\mingw-w64\x86_64-8.1.0-posix-seh-rt_v6-rev0\mingw64\bin\gcc.exe --version
 
 build_script:
-  - go run build\ci.go install -dlgo -arch %GETH_ARCH% -cc C:\msys64\mingw32\bin\gcc.exe
+  - go run build\ci.go install -dlgo -arch %GETH_ARCH% -cc C:\mingw-w64\i686-8.1.0-posix-dwarf-rt_v6-rev0\mingw32\bin\gcc.exe
 
 after_build:
   - go run build\ci.go archive -arch %GETH_ARCH% -type zip -signer WINDOWS_SIGNING_KEY -upload gethstore/builds

--- a/build/ci.go
+++ b/build/ci.go
@@ -50,7 +50,6 @@ import (
 	"log"
 	"os"
 	"os/exec"
-	"path"
 	"path/filepath"
 	"regexp"
 	"runtime"
@@ -271,21 +270,24 @@ func doInstall(cmdline []string) {
 	// Show packages during build.
 	gobuild.Args = append(gobuild.Args, "-v")
 
-	// Now we choose what we're even building.
-	// Default: collect all 'main' packages in cmd/ and build those.
-	packages := flag.Args()
-	if len(packages) == 0 {
-		packages = build.FindMainPackages("./cmd")
-	}
+	gobuild.Args = append(gobuild.Args, "-x", "runtime/cgo")
+	build.MustRun(&exec.Cmd{Path: gobuild.Path, Args: gobuild.Args, Env: gobuild.Env})
 
-	// Do the build!
-	for _, pkg := range packages {
-		args := make([]string, len(gobuild.Args))
-		copy(args, gobuild.Args)
-		args = append(args, "-o", executablePath(path.Base(pkg)))
-		args = append(args, pkg)
-		build.MustRun(&exec.Cmd{Path: gobuild.Path, Args: args, Env: gobuild.Env})
-	}
+	// // Now we choose what we're even building.
+	// // Default: collect all 'main' packages in cmd/ and build those.
+	// packages := flag.Args()
+	// if len(packages) == 0 {
+	// 	packages = build.FindMainPackages("./cmd")
+	// }
+	//
+	// // Do the build!
+	// for _, pkg := range packages {
+	// 	args := make([]string, len(gobuild.Args))
+	// 	copy(args, gobuild.Args)
+	// 	args = append(args, "-o", executablePath(path.Base(pkg)))
+	// 	args = append(args, pkg)
+	// 	build.MustRun(&exec.Cmd{Path: gobuild.Path, Args: args, Env: gobuild.Env})
+	// }
 }
 
 // buildFlags returns the go tool flags for building.

--- a/build/ci.go
+++ b/build/ci.go
@@ -250,6 +250,11 @@ func doInstall(cmdline []string) {
 		gobuild.Env = append(gobuild.Env, "CC="+os.Getenv("CC"))
 	}
 
+	// Configure MinGW.
+	if runtime.GOOS == "windows" {
+		gobuild.Env = append(gobuild.Env, "MSYS2_ARCH=i686", "MSYS2_BITS=32", "MSYSTEM=mingw32")
+	}
+
 	// arm64 CI builders are memory-constrained and can't handle concurrent builds,
 	// better disable it. This check isn't the best, it should probably
 	// check for something in env instead.

--- a/build/ci.go
+++ b/build/ci.go
@@ -336,6 +336,7 @@ func goToolSetEnv(cmd *exec.Cmd) {
 func doTest(cmdline []string) {
 	var (
 		dlgo     = flag.Bool("dlgo", false, "Download Go and build with it")
+		arch     = flag.String("arch", "", "Run tests for given architecture")
 		coverage = flag.Bool("coverage", false, "Whether to record code coverage")
 		verbose  = flag.Bool("v", false, "Whether to log verbosely")
 	)
@@ -358,6 +359,12 @@ func doTest(cmdline []string) {
 		cachedir := filepath.Join("build", "cache")
 		goroot := downloadGo(runtime.GOARCH, runtime.GOOS, cachedir)
 		gotest = localGoTool(goroot, "test", buildFlags(env)...)
+	}
+
+	// Configure environment for cross build.
+	if *arch != "" || *arch != runtime.GOARCH {
+		gotest.Env = append(gotest.Env, "CGO_ENABLED=1")
+		gotest.Env = append(gotest.Env, "GOARCH="+*arch)
 	}
 
 	// Test a single package at a time. CI builders are slow

--- a/build/ci.go
+++ b/build/ci.go
@@ -357,7 +357,7 @@ func doTest(cmdline []string) {
 		// installed version is too old and cannot be upgraded easily.
 		cachedir := filepath.Join("build", "cache")
 		goroot := downloadGo(runtime.GOARCH, runtime.GOOS, cachedir)
-		gotest = localGoTool(goroot, "build", buildFlags(env)...)
+		gotest = localGoTool(goroot, "test", buildFlags(env)...)
 	}
 
 	// Test a single package at a time. CI builders are slow

--- a/build/ci.go
+++ b/build/ci.go
@@ -366,6 +366,9 @@ func doTest(cmdline []string) {
 		gotest.Env = append(gotest.Env, "CGO_ENABLED=1")
 		gotest.Env = append(gotest.Env, "GOARCH="+*arch)
 	}
+	if os.Getenv("CC") != "" {
+		gotest.Env = append(gotest.Env, "CC="+os.Getenv("CC"))
+	}
 
 	// Test a single package at a time. CI builders are slow
 	// and some tests run into timeouts under load.

--- a/build/ci.go
+++ b/build/ci.go
@@ -250,9 +250,6 @@ func doInstall(cmdline []string) {
 		gobuild.Env = append(gobuild.Env, "CC="+os.Getenv("CC"))
 	}
 
-	// Show commands.
-	gobuild.Args = append(gobuild.Args, "-x")
-
 	// arm64 CI builders are memory-constrained and can't handle concurrent builds,
 	// better disable it. This check isn't the best, it should probably
 	// check for something in env instead.

--- a/build/ci.go
+++ b/build/ci.go
@@ -609,6 +609,15 @@ func downloadGoSources(cachedir string) string {
 // downloadGo downloads the Go binary distribution and unpacks it into a temporary
 // directory. It returns the GOROOT of the unpacked toolchain.
 func downloadGo(goarch, goos, cachedir string) string {
+	// Shortcut: if the Go version that runs this script matches the
+	// requested version exactly, there is no need to download anything.
+	activeGo := strings.TrimPrefix(runtime.Version(), "go")
+	if activeGo == dlgoVersion && goos == runtime.GOOS && goarch == runtime.GOARCH {
+		fmt.Printf("-dlgo version matches active Go version %s, skipping download.\n", activeGo)
+		return runtime.GOROOT()
+	}
+
+	// For Arm architecture, GOARCH includes ISA version.
 	if goarch == "arm" {
 		goarch = "armv6l"
 	}

--- a/build/ci.go
+++ b/build/ci.go
@@ -250,6 +250,9 @@ func doInstall(cmdline []string) {
 		gobuild.Env = append(gobuild.Env, "CC="+os.Getenv("CC"))
 	}
 
+	// Show commands.
+	gobuild.Args = append(gobuild.Args, "-x")
+
 	// arm64 CI builders are memory-constrained and can't handle concurrent builds,
 	// better disable it. This check isn't the best, it should probably
 	// check for something in env instead.

--- a/build/ci.go
+++ b/build/ci.go
@@ -613,7 +613,7 @@ func downloadGo(goarch, goos, cachedir string) string {
 	// requested version exactly, there is no need to download anything.
 	activeGo := strings.TrimPrefix(runtime.Version(), "go")
 	if activeGo == dlgoVersion && goos == runtime.GOOS && goarch == runtime.GOARCH {
-		fmt.Printf("-dlgo version matches active Go version %s, skipping download.\n", activeGo)
+		log.Printf("-dlgo version matches active Go version %s, skipping download.", activeGo)
 		return runtime.GOROOT()
 	}
 

--- a/params/config.go
+++ b/params/config.go
@@ -22,7 +22,7 @@ import (
 	"math/big"
 
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/crypto"
+	"golang.org/x/crypto/sha3"
 )
 
 // Genesis hashes to enforce below configs on.
@@ -278,12 +278,17 @@ func (c *TrustedCheckpoint) HashEqual(hash common.Hash) bool {
 
 // Hash returns the hash of checkpoint's four key fields(index, sectionHead, chtRoot and bloomTrieRoot).
 func (c *TrustedCheckpoint) Hash() common.Hash {
-	buf := make([]byte, 8+3*common.HashLength)
-	binary.BigEndian.PutUint64(buf, c.SectionIndex)
-	copy(buf[8:], c.SectionHead.Bytes())
-	copy(buf[8+common.HashLength:], c.CHTRoot.Bytes())
-	copy(buf[8+2*common.HashLength:], c.BloomRoot.Bytes())
-	return crypto.Keccak256Hash(buf)
+	var sectionIndex [8]byte
+	binary.BigEndian.PutUint64(sectionIndex[:], c.SectionIndex)
+
+	w := sha3.NewLegacyKeccak256()
+	w.Write(sectionIndex[:])
+	w.Write(c.CHTRoot[:])
+	w.Write(c.BloomRoot[:])
+
+	var h common.Hash
+	w.Sum(h[:0])
+	return h
 }
 
 // Empty returns an indicator whether the checkpoint is regarded as empty.


### PR DESCRIPTION
This upgrades the build environment to a newer image, which has a more
recent Go version installed by default. Since the included Go is recent
enough to run build/ci.go directly, it is no longer necessary to download it
using the appveyor tool.

Also includes some other useful changes in build/ci.go: 

- It is now possible to use -dlgo for running tests.
- The download is skipped if the active version matches the -dlgo version.
- Tests can now be run for another architecture. This is also useful on darwin/arm64
   because the system still supports running darwin/amd64 software using Rosetta 2.