### PR TITLE
cmd/devp2p, eth/protocols: earlier sanity check + fix flakey test

### DIFF
--- a/cmd/devp2p/internal/ethtest/eth66_suite.go
+++ b/cmd/devp2p/internal/ethtest/eth66_suite.go
@@ -483,8 +483,8 @@ func (s *Suite) TestNewPooledTxs_66(t *utesting.T) {
 				t.Fatalf("unexpected number of txs requested: wanted %d, got %d", len(hashes), len(msg))
 			}
 			return
-		case *NewPooledTransactionHashes:
-			// ignore propagated txs from old tests
+		case *NewPooledTransactionHashes, *NewBlock, *NewBlockHashes:
+			// ignore propagated txs and blocks from old tests
 			continue
 		default:
 			t.Fatalf("unexpected %s", pretty.Sdump(msg))

--- a/cmd/devp2p/internal/ethtest/large.go
+++ b/cmd/devp2p/internal/ethtest/large.go
@@ -70,7 +70,7 @@ func largeHeader() *types.Header {
 		GasUsed:     0,
 		Coinbase:    common.Address{},
 		GasLimit:    0,
-		UncleHash:   randHash(),
+		UncleHash:   types.EmptyUncleHash,
 		Time:        1337,
 		ParentHash:  randHash(),
 		Root:        randHash(),

--- a/cmd/devp2p/internal/ethtest/suite_test.go
+++ b/cmd/devp2p/internal/ethtest/suite_test.go
@@ -19,6 +19,7 @@ package ethtest
 import (
 	"os"
 	"testing"
+	"time"
 
 	"github.com/ethereum/go-ethereum/eth"
 	"github.com/ethereum/go-ethereum/eth/ethconfig"
@@ -87,8 +88,15 @@ func setupGeth(stack *node.Node) error {
 	}
 
 	backend, err := eth.New(stack, &ethconfig.Config{
-		Genesis:   &chain.genesis,
-		NetworkId: chain.genesis.Config.ChainID.Uint64(), // 19763
+		Genesis:                 &chain.genesis,
+		NetworkId:               chain.genesis.Config.ChainID.Uint64(), // 19763
+		DatabaseCache:           10,
+		TrieCleanCache:          10,
+		TrieCleanCacheJournal:   "",
+		TrieCleanCacheRejournal: 60 * time.Minute,
+		TrieDirtyCache:          16,
+		TrieTimeout:             60 * time.Minute,
+		SnapshotCache:           10,
 	})
 	if err != nil {
 		return err

--- a/eth/protocols/eth/handlers.go
+++ b/eth/protocols/eth/handlers.go
@@ -292,6 +292,9 @@ func handleNewBlock(backend Backend, msg Decoder, peer *Peer) error {
 	if err := msg.Decode(ann); err != nil {
 		return fmt.Errorf("%w: message %v: %v", errDecode, msg, err)
 	}
+	if err := ann.sanityCheck(); err != nil {
+		return err
+	}
 	if hash := types.CalcUncleHash(ann.Block.Uncles()); hash != ann.Block.UncleHash() {
 		log.Warn("Propagated block has invalid uncles", "have", hash, "exp", ann.Block.UncleHash())
 		return nil // TODO(karalabe): return error eventually, but wait a few releases
@@ -299,9 +302,6 @@ func handleNewBlock(backend Backend, msg Decoder, peer *Peer) error {
 	if hash := types.DeriveSha(ann.Block.Transactions(), trie.NewStackTrie(nil)); hash != ann.Block.TxHash() {
 		log.Warn("Propagated block has invalid body", "have", hash, "exp", ann.Block.TxHash())
 		return nil // TODO(karalabe): return error eventually, but wait a few releases
-	}
-	if err := ann.sanityCheck(); err != nil {
-		return err
 	}
 	ann.Block.ReceivedAt = msg.Time()
 	ann.Block.ReceivedFrom = peer


### PR DESCRIPTION
This PR fixes a flaky test:
```
not ok 1 TestNewPooledTxs_66
# received NewBlock message: (*types.Block)({
```
Which I think is due to spurious block broadcasts, you never quite know when a node might decide to send you one. 

Also, it moves the announcement sanity check earlier, and configure the blockchain a bit making the log output smaller (to stop the node from having to do gc after every block import)
