### PR TITLE
cmd/devp2p: fix flakey tests in CI

### DIFF
--- a/cmd/devp2p/internal/ethtest/eth66_suite.go
+++ b/cmd/devp2p/internal/ethtest/eth66_suite.go
@@ -217,17 +217,7 @@ func (s *Suite) TestLargeAnnounce_66(t *utesting.T) {
 		sendConn.Close()
 	}
 	// Test the last block as a valid block
-	sendConn, receiveConn := s.setupConnection66(t), s.setupConnection66(t)
-	defer sendConn.Close()
-	defer receiveConn.Close()
-
-	s.testAnnounce66(t, sendConn, receiveConn, blocks[3])
-	// wait for client to update its chain
-	if err := receiveConn.waitForBlock66(s.fullChain.blocks[nextBlock]); err != nil {
-		t.Fatal(err)
-	}
-	// update test suite chain
-	s.chain.blocks = append(s.chain.blocks, s.fullChain.blocks[nextBlock])
+	s.sendNextBlock66(t)
 }
 
 func (s *Suite) TestOldAnnounce_66(t *utesting.T) {

--- a/cmd/devp2p/internal/ethtest/eth66_suite.go
+++ b/cmd/devp2p/internal/ethtest/eth66_suite.go
@@ -222,12 +222,12 @@ func (s *Suite) TestLargeAnnounce_66(t *utesting.T) {
 	defer receiveConn.Close()
 
 	s.testAnnounce66(t, sendConn, receiveConn, blocks[3])
-	// update test suite chain
-	s.chain.blocks = append(s.chain.blocks, s.fullChain.blocks[nextBlock])
 	// wait for client to update its chain
 	if err := receiveConn.waitForBlock66(s.fullChain.blocks[nextBlock]); err != nil {
 		t.Fatal(err)
 	}
+	// update test suite chain
+	s.chain.blocks = append(s.chain.blocks, s.fullChain.blocks[nextBlock])
 }
 
 func (s *Suite) TestOldAnnounce_66(t *utesting.T) {

--- a/cmd/devp2p/internal/ethtest/eth66_suiteHelpers.go
+++ b/cmd/devp2p/internal/ethtest/eth66_suiteHelpers.go
@@ -320,7 +320,7 @@ func (s *Suite) sendNextBlock66(t *utesting.T) {
 	// send announcement and wait for node to request the header
 	s.testAnnounce66(t, sendConn, receiveConn, blockAnnouncement)
 	// wait for client to update its chain
-	if err := receiveConn.waitForBlock66(s.chain.Head()); err != nil {
+	if err := receiveConn.waitForBlock66(s.fullChain.blocks[nextBlock]); err != nil {
 		t.Fatal(err)
 	}
 	// update test suite chain

--- a/cmd/devp2p/internal/ethtest/eth66_suiteHelpers.go
+++ b/cmd/devp2p/internal/ethtest/eth66_suiteHelpers.go
@@ -319,10 +319,10 @@ func (s *Suite) sendNextBlock66(t *utesting.T) {
 	}
 	// send announcement and wait for node to request the header
 	s.testAnnounce66(t, sendConn, receiveConn, blockAnnouncement)
-	// update test suite chain
-	s.chain.blocks = append(s.chain.blocks, s.fullChain.blocks[nextBlock])
 	// wait for client to update its chain
 	if err := receiveConn.waitForBlock66(s.chain.Head()); err != nil {
 		t.Fatal(err)
 	}
+	// update test suite chain
+	s.chain.blocks = append(s.chain.blocks, s.fullChain.blocks[nextBlock])
 }

--- a/cmd/devp2p/internal/ethtest/eth66_suiteHelpers.go
+++ b/cmd/devp2p/internal/ethtest/eth66_suiteHelpers.go
@@ -229,8 +229,7 @@ func (s *Suite) waitAnnounce66(t *utesting.T, conn *Conn, blockAnnouncement *New
 func (c *Conn) waitForBlock66(block *types.Block) error {
 	defer c.SetReadDeadline(time.Time{})
 
-	timeout := time.Now().Add(20 * time.Second)
-	c.SetReadDeadline(timeout)
+	c.SetReadDeadline(time.Now().Add(20 * time.Second))
 	for {
 		req := eth.GetBlockHeadersPacket66{
 			RequestId: 54,

--- a/cmd/devp2p/internal/ethtest/eth66_suiteHelpers.go
+++ b/cmd/devp2p/internal/ethtest/eth66_suiteHelpers.go
@@ -256,8 +256,10 @@ func (c *Conn) waitForBlock66(block *types.Block) error {
 			if reqID != req.RequestId {
 				return fmt.Errorf("request ID mismatch: wanted %d, got %d", req.RequestId, reqID)
 			}
-			if len(msg) > 0 {
-				return nil
+			for _, header := range msg {
+				if header.Number.Uint64() == block.NumberU64() {
+					return nil
+				}
 			}
 			time.Sleep(100 * time.Millisecond)
 		case *NewPooledTransactionHashes:

--- a/cmd/devp2p/internal/ethtest/eth66_suiteHelpers.go
+++ b/cmd/devp2p/internal/ethtest/eth66_suiteHelpers.go
@@ -230,6 +230,10 @@ func (c *Conn) waitForBlock66(block *types.Block) error {
 	defer c.SetReadDeadline(time.Time{})
 
 	c.SetReadDeadline(time.Now().Add(20 * time.Second))
+	// note: if the node has not yet imported the block, it will respond
+	// to the GetBlockHeaders request with an empty BlockHeaders response,
+	// so the GetBlockHeaders request must be sent again until the BlockHeaders
+	// response contains the desired header.
 	for {
 		req := eth.GetBlockHeadersPacket66{
 			RequestId: 54,

--- a/cmd/devp2p/internal/ethtest/suite.go
+++ b/cmd/devp2p/internal/ethtest/suite.go
@@ -277,7 +277,7 @@ func (s *Suite) sendNextBlock(t *utesting.T) {
 	// send announcement and wait for node to request the header
 	s.testAnnounce(t, sendConn, receiveConn, blockAnnouncement)
 	// wait for client to update its chain
-	if err := receiveConn.waitForBlock(s.chain.Head()); err != nil {
+	if err := receiveConn.waitForBlock(s.fullChain.blocks[nextBlock]); err != nil {
 		t.Fatal(err)
 	}
 	// update test suite chain

--- a/cmd/devp2p/internal/ethtest/suite.go
+++ b/cmd/devp2p/internal/ethtest/suite.go
@@ -400,18 +400,7 @@ func (s *Suite) TestLargeAnnounce(t *utesting.T) {
 		sendConn.Close()
 	}
 	// Test the last block as a valid block
-	sendConn := s.setupConnection(t)
-	receiveConn := s.setupConnection(t)
-	defer sendConn.Close()
-	defer receiveConn.Close()
-
-	s.testAnnounce(t, sendConn, receiveConn, blocks[3])
-	// wait for client to update its chain
-	if err := receiveConn.waitForBlock(s.fullChain.blocks[nextBlock]); err != nil {
-		t.Fatal(err)
-	}
-	// update test suite chain
-	s.chain.blocks = append(s.chain.blocks, s.fullChain.blocks[nextBlock])
+	s.sendNextBlock(t)
 }
 
 func (s *Suite) TestOldAnnounce(t *utesting.T) {

--- a/cmd/devp2p/internal/ethtest/suite_test.go
+++ b/cmd/devp2p/internal/ethtest/suite_test.go
@@ -52,7 +52,6 @@ func TestEthSuite(t *testing.T) {
 				t.Fatal()
 			}
 		})
-		time.Sleep(100 * time.Millisecond)
 	}
 }
 

--- a/cmd/devp2p/internal/ethtest/suite_test.go
+++ b/cmd/devp2p/internal/ethtest/suite_test.go
@@ -52,6 +52,7 @@ func TestEthSuite(t *testing.T) {
 				t.Fatal()
 			}
 		})
+		time.Sleep(100 * time.Millisecond)
 	}
 }
 

--- a/cmd/devp2p/internal/ethtest/types.go
+++ b/cmd/devp2p/internal/ethtest/types.go
@@ -335,6 +335,10 @@ func (c *Conn) waitForBlock(block *types.Block) error {
 	defer c.SetReadDeadline(time.Time{})
 
 	c.SetReadDeadline(time.Now().Add(20 * time.Second))
+	// note: if the node has not yet imported the block, it will respond
+	// to the GetBlockHeaders request with an empty BlockHeaders response,
+	// so the GetBlockHeaders request must be sent again until the BlockHeaders
+	// response contains the desired header.
 	for {
 		req := &GetBlockHeaders{Origin: eth.HashOrNumber{Hash: block.Hash()}, Amount: 1}
 		if err := c.Write(req); err != nil {


### PR DESCRIPTION
This PR fixes a couple of issues in the eth test suite that caused flakiness when run in the CI. 

It depends on #22754 getting merged.