### PR TITLE
internal/debug: fix dropped deprecated (legacy) pprof flags

### DIFF
--- a/internal/debug/flags.go
+++ b/internal/debug/flags.go
@@ -155,6 +155,7 @@ var DeprecatedFlags = []cli.Flag{
 var glogger *log.GlogHandler
 
 func init() {
+	Flags = append(Flags, DeprecatedFlags...)
 	glogger = log.NewGlogHandler(log.StreamHandler(os.Stderr, log.TerminalFormat(false)))
 	glogger.Verbosity(log.LvlInfo)
 	log.Root().SetHandler(glogger)
@@ -234,13 +235,26 @@ func Setup(ctx *cli.Context) error {
 		if err := Handler.StartCPUProfile(cpuFile); err != nil {
 			return err
 		}
+	} else if legacyCPUFile := ctx.GlobalString(legacyCpuprofileFlag.Name); legacyCPUFile != "" {
+		log.Warn("The flag --cpuprofile is deprecated and will be removed in the future, please use --pprof.cpuprofile")
+		if err := Handler.StartCPUProfile(legacyCPUFile); err != nil {
+			return err
+		}
 	}
 
 	// pprof server
 	if ctx.GlobalBool(pprofFlag.Name) {
 		listenHost := ctx.GlobalString(pprofAddrFlag.Name)
+		if ctx.GlobalIsSet(legacyPprofAddrFlag.Name) {
+			listenHost = ctx.GlobalString(legacyPprofAddrFlag.Name)
+			log.Warn("The flag --pprofaddr is deprecated and will be removed in the future, please use --pprof.addr")
+		}
 
 		port := ctx.GlobalInt(pprofPortFlag.Name)
+		if ctx.GlobalIsSet(legacyPprofPortFlag.Name) {
+			port = ctx.GlobalInt(legacyPprofPortFlag.Name)
+			log.Warn("The flag --pprofport is deprecated and will be removed in the future, please use --pprof.port")
+		}
 
 		address := fmt.Sprintf("%s:%d", listenHost, port)
 		// This context value ("metrics.addr") represents the utils.MetricsHTTPFlag.Name.


### PR DESCRIPTION
All deprecated pprof flags were dropped, apparently
accidentally.

I noticed this because --debug was unavailable.

Not only were the flag declarations unregistered,
but logical support for pprofport, pprofaddr, and cpuprofile
were missing; this adds support for them.

Date: 2021-04-28 06:33:15-05:00
Signed-off-by: meows <b5c6@protonmail.com>