### PR TITLE
eth/protocols/snap: lower the packet size to avoid overloading link

### DIFF
--- a/eth/protocols/snap/sync.go
+++ b/eth/protocols/snap/sync.go
@@ -52,7 +52,7 @@ var (
 
 const (
 	// maxRequestSize is the maximum number of bytes to request from a remote peer.
-	maxRequestSize = 512 * 1024
+	maxRequestSize = 128 * 1024
 
 	// maxStorageSetRequestCount is the maximum number of contracts to request the
 	// storage of in a single query. If this number is too low, we're not filling
@@ -74,7 +74,7 @@ const (
 	// a single query. If this number is too low, we're not filling responses fully
 	// and waste round trip times. If it's too high, we're capping responses and
 	// waste bandwidth.
-	maxTrieRequestCount = 512
+	maxTrieRequestCount = 256
 )
 
 var (


### PR DESCRIPTION
Originally `snap` sync used fairly large packet sizes to minimize the healing phase due to chunking. With the optimization that fed contiguous snapshot chunks to generate trie nodes merged, the healing phase is mostly independent of how large packets are, so we can reduce them to something a bit more reasonable.

Ideally we want dynamic sizes, but that's for the next release.