### PR TITLE
docs: fix typo in EVM tracing

### DIFF
--- a/docs/_dapp/tracing.md
+++ b/docs/_dapp/tracing.md
@@ -9,7 +9,7 @@ transaction is a contract account with associated EVM (Ethereum Virtual Machine)
 bytecode - beside transferring any Ether - the code will also be executed as part of the
 transaction.
 
-Having code associated with Ethereum accounts permits transactions to do arbitrarilly
+Having code associated with Ethereum accounts permits transactions to do arbitrarily
 complex data storage and enables them to act on the previously stored data by further
 transacting internally with outside accounts and contracts. This creates an intertwined
 ecosystem of contracts, where a single transaction can interact with tens or hundreds of


### PR DESCRIPTION
Sorry, didn't see this when I saw [this other typo](https://github.com/ethereum/go-ethereum/pull/22744).