### PR TITLE
catalyst: check if block exists in assemble-block call with unknown parent-hash

### DIFF
--- a/eth/catalyst/api.go
+++ b/eth/catalyst/api.go
@@ -109,6 +109,11 @@ func (api *consensusAPI) AssembleBlock(params assembleBlockParams) (*executableD
 
 	bc := api.eth.BlockChain()
 	parent := bc.GetBlockByHash(params.ParentHash)
+	if parent == nil {
+		log.Warn("Cannot assemble block with parent hash to unknown block", "parentHash", params.ParentHash)
+		return nil, fmt.Errorf("cannot assemble block with unknown parent %s", params.ParentHash)
+	}
+
 	pool := api.eth.TxPool()
 
 	if parent.Time() >= params.Timestamp {


### PR DESCRIPTION
This adds a simple nil check on the retrieved parent block during the assembleBlock RPC call in catalyst (merge prototype).

Crash (thanks to potuz on discord for finding this):
```
INFO [04-29|08:56:36.015] Producing block                          parentHash=7d555b..bafbe4
ERROR[04-29|08:56:36.015] RPC method consensus_assembleBlock crashed: runtime error: invalid memory address or nil pointer dereference
goroutine 823 [running]:
github.com/ethereum/go-ethereum/rpc.(*callback).call.func1(0xc00012a5b8, 0x17, 0xc0005ebd58)
	/home/heluani/Documents/code/rayonism/mergenet-tutorial/clients/catalyst/rpc/service.go:200 +0xbd
panic(0x11c7600, 0x1c1b520)
	/usr/lib/go/src/runtime/panic.go:965 +0x1b9
github.com/ethereum/go-ethereum/core/types.(*Block).Time(...)
	/home/heluani/Documents/code/rayonism/mergenet-tutorial/clients/catalyst/core/types/block.go:278
github.com/ethereum/go-ethereum/eth/catalyst.(*consensusAPI).AssembleBlock(0xc0001ae018, 0xf83cd151545b557d, 0x16a47c8c41fde4f2, 0x3233f2f5ed318202, 0xe4fbbad77a719efa, 0x608a9ef4, 0x0, 0x0, 0x0)
	/home/heluani/Documents/code/rayonism/mergenet-tutorial/clients/catalyst/eth/catalyst/api.go:114 +0x13a
reflect.Value.call(0xc0001795c0, 0xc0001afde8, 0x13, 0x134c682, 0x4, 0xc000145090, 0x2, 0x3, 0xc0001450a8, 0xc000346ac8, ...)
	/usr/lib/go/src/reflect/value.go:476 +0x8e7
reflect.Value.Call(0xc0001795c0, 0xc0001afde8, 0x13, 0xc000145090, 0x2, 0x3, 0x0, 0x0, 0x11cd320)
	/usr/lib/go/src/reflect/value.go:337 +0xb9
github.com/ethereum/go-ethereum/rpc.(*callback).call(0xc00053b980, 0x157b338, 0xc000148e00, 0xc00012a5b8, 0x17, 0xc000346ac8, 0x1, 0x1, 0x0, 0x0, ...)
	/home/heluani/Documents/code/rayonism/mergenet-tutorial/clients/catalyst/rpc/service.go:206 +0x2c5
github.com/ethereum/go-ethereum/rpc.(*handler).runMethod(0xc00014b830, 0x157b338, 0xc000148e00, 0xc000317730, 0xc00053b980, 0xc000346ac8, 0x1, 0x1, 0x1)
	/home/heluani/Documents/code/rayonism/mergenet-tutorial/clients/catalyst/rpc/handler.go:389 +0x8a
github.com/ethereum/go-ethereum/rpc.(*handler).handleCall(0xc00014b830, 0xc000f45ec0, 0xc000317730, 0x203000)
	/home/heluani/Documents/code/rayonism/mergenet-tutorial/clients/catalyst/rpc/handler.go:337 +0x265
github.com/ethereum/go-ethereum/rpc.(*handler).handleCallMsg(0xc00014b830, 0xc000f45ec0, 0xc000317730, 0x156d601)
	/home/heluani/Documents/code/rayonism/mergenet-tutorial/clients/catalyst/rpc/handler.go:298 +0x1be
github.com/ethereum/go-ethereum/rpc.(*handler).handleMsg.func1(0xc000f45ec0)
	/home/heluani/Documents/code/rayonism/mergenet-tutorial/clients/catalyst/rpc/handler.go:139 +0x46
github.com/ethereum/go-ethereum/rpc.(*handler).startCallProc.func1(0xc00014b830, 0xc000346ab0)
	/home/heluani/Documents/code/rayonism/mergenet-tutorial/clients/catalyst/rpc/handler.go:226 +0xd2
created by github.com/ethereum/go-ethereum/rpc.(*handler).startCallProc
	/home/heluani/Documents/code/rayonism/mergenet-tutorial/clients/catalyst/rpc/handler.go:222 +0x66
```

cc @gballet 

Fix is being tested now.

Edit: force pushed to amend wording in error log and message.