### PR TITLE
Fix comment on read head block

### DIFF
--- a/core/rawdb/accessors_chain.go
+++ b/core/rawdb/accessors_chain.go
@@ -839,7 +839,7 @@ func ReadHeadHeader(db ethdb.Reader) *types.Header {
 	return ReadHeader(db, headHeaderHash, *headHeaderNumber)
 }
 
-// ReadHeadHeader returns the current canonical head block.
+// ReadHeadBlock returns the current canonical head block.
 func ReadHeadBlock(db ethdb.Reader) *types.Block {
 	headBlockHash := ReadHeadBlockHash(db)
 	if headBlockHash == (common.Hash{}) {


### PR DESCRIPTION
This PR fixes a comment on ReadHeadBlock.

The function above `ReadHeadHeader` also appears to be unused throughout the rest of the repo. Is there any reason for keeping it? If not, I can add removing it to this PR.