### PR TITLE
Clean up use of trie.NewSecure

### DIFF
--- a/core/state/database.go
+++ b/core/state/database.go
@@ -129,20 +129,12 @@ type cachingDB struct {
 
 // OpenTrie opens the main account trie at a specific root hash.
 func (db *cachingDB) OpenTrie(root common.Hash) (Trie, error) {
-	tr, err := trie.NewSecure(root, db.db)
-	if err != nil {
-		return nil, err
-	}
-	return tr, nil
+	return trie.NewSecure(root, db.db)
 }
 
 // OpenStorageTrie opens the storage trie of an account.
 func (db *cachingDB) OpenStorageTrie(addrHash, root common.Hash) (Trie, error) {
-	tr, err := trie.NewSecure(root, db.db)
-	if err != nil {
-		return nil, err
-	}
-	return tr, nil
+	return trie.NewSecure(root, db.db)
 }
 
 // CopyTrie returns an independent copy of the given trie.

--- a/core/state/snapshot/generate_test.go
+++ b/core/state/snapshot/generate_test.go
@@ -382,7 +382,10 @@ func TestGenerateCorruptAccountTrie(t *testing.T) {
 		diskdb = memorydb.New()
 		triedb = trie.NewDatabase(diskdb)
 	)
-	tr, _ := trie.NewSecure(common.Hash{}, triedb)
+	tr, err := trie.NewSecure(common.Hash{}, triedb)
+	if err != nil {
+		t.Errorf("Failed to create new secure trie due to %s", err)
+	}
 	acc := &Account{Balance: big.NewInt(1), Root: emptyRoot.Bytes(), CodeHash: emptyCode.Bytes()}
 	val, _ := rlp.EncodeToBytes(acc)
 	tr.Update([]byte("acc-1"), val) // 0xc7a30f39aff471c95d8a837497ad0e49b65be475cc0953540f80cfcdbdcd9074
@@ -426,13 +429,19 @@ func TestGenerateMissingStorageTrie(t *testing.T) {
 		diskdb = memorydb.New()
 		triedb = trie.NewDatabase(diskdb)
 	)
-	stTrie, _ := trie.NewSecure(common.Hash{}, triedb)
+	stTrie, err := trie.NewSecure(common.Hash{}, triedb)
+	if err != nil {
+		t.Errorf("Failed to create new secure trie due to %s", err)
+	}
 	stTrie.Update([]byte("key-1"), []byte("val-1")) // 0x1314700b81afc49f94db3623ef1df38f3ed18b73a1b7ea2f6c095118cf6118a0
 	stTrie.Update([]byte("key-2"), []byte("val-2")) // 0x18a0f4d79cff4459642dd7604f303886ad9d77c30cf3d7d7cedb3a693ab6d371
 	stTrie.Update([]byte("key-3"), []byte("val-3")) // 0x51c71a47af0695957647fb68766d0becee77e953df17c29b3c2f25436f055c78
 	stTrie.Commit(nil)                              // Root: 0xddefcd9376dd029653ef384bd2f0a126bb755fe84fdcc9e7cf421ba454f2bc67
 
-	accTrie, _ := trie.NewSecure(common.Hash{}, triedb)
+	accTrie, err := trie.NewSecure(common.Hash{}, triedb)
+	if err != nil {
+		t.Errorf("Failed to create new secure trie due to %s", err)
+	}
 	acc := &Account{Balance: big.NewInt(1), Root: stTrie.Hash().Bytes(), CodeHash: emptyCode.Bytes()}
 	val, _ := rlp.EncodeToBytes(acc)
 	accTrie.Update([]byte("acc-1"), val) // 0x9250573b9c18c664139f3b6a7a8081b7d8f8916a8fcc5d94feec6c29f5fd4e9e
@@ -485,13 +494,19 @@ func TestGenerateCorruptStorageTrie(t *testing.T) {
 		diskdb = memorydb.New()
 		triedb = trie.NewDatabase(diskdb)
 	)
-	stTrie, _ := trie.NewSecure(common.Hash{}, triedb)
+	stTrie, err := trie.NewSecure(common.Hash{}, triedb)
+	if err != nil {
+		t.Errorf("Failed to create new secure trie due to %s", err)
+	}
 	stTrie.Update([]byte("key-1"), []byte("val-1")) // 0x1314700b81afc49f94db3623ef1df38f3ed18b73a1b7ea2f6c095118cf6118a0
 	stTrie.Update([]byte("key-2"), []byte("val-2")) // 0x18a0f4d79cff4459642dd7604f303886ad9d77c30cf3d7d7cedb3a693ab6d371
 	stTrie.Update([]byte("key-3"), []byte("val-3")) // 0x51c71a47af0695957647fb68766d0becee77e953df17c29b3c2f25436f055c78
 	stTrie.Commit(nil)                              // Root: 0xddefcd9376dd029653ef384bd2f0a126bb755fe84fdcc9e7cf421ba454f2bc67
 
-	accTrie, _ := trie.NewSecure(common.Hash{}, triedb)
+	accTrie, err := trie.NewSecure(common.Hash{}, triedb)
+	if err != nil {
+		t.Errorf("Failed to create new secure trie due to %s", err)
+	}
 	acc := &Account{Balance: big.NewInt(1), Root: stTrie.Hash().Bytes(), CodeHash: emptyCode.Bytes()}
 	val, _ := rlp.EncodeToBytes(acc)
 	accTrie.Update([]byte("acc-1"), val) // 0x9250573b9c18c664139f3b6a7a8081b7d8f8916a8fcc5d94feec6c29f5fd4e9e

--- a/trie/iterator_test.go
+++ b/trie/iterator_test.go
@@ -101,7 +101,7 @@ func TestIteratorLargeData(t *testing.T) {
 // Tests that the node iterator indeed walks over the entire database contents.
 func TestNodeIteratorCoverage(t *testing.T) {
 	// Create some arbitrary test trie to iterate
-	db, trie, _ := makeTestTrie()
+	db, trie, _ := makeTestTrie(t)
 
 	// Gather all the node hashes found by the iterator
 	hashes := make(map[common.Hash]struct{})

--- a/trie/secure_trie_test.go
+++ b/trie/secure_trie_test.go
@@ -27,16 +27,22 @@ import (
 	"github.com/ethereum/go-ethereum/ethdb/memorydb"
 )
 
-func newEmptySecure() *SecureTrie {
-	trie, _ := NewSecure(common.Hash{}, NewDatabase(memorydb.New()))
+func newEmptySecure(t *testing.T) *SecureTrie {
+	trie, err := NewSecure(common.Hash{}, NewDatabase(memorydb.New()))
+	if err != nil {
+		t.Errorf("Failed to create new secure trie due to %s", err)
+	}
 	return trie
 }
 
 // makeTestSecureTrie creates a large enough secure trie for testing.
-func makeTestSecureTrie() (*Database, *SecureTrie, map[string][]byte) {
+func makeTestSecureTrie(t *testing.T) (*Database, *SecureTrie, map[string][]byte) {
 	// Create an empty trie
 	triedb := NewDatabase(memorydb.New())
-	trie, _ := NewSecure(common.Hash{}, triedb)
+	trie, err := NewSecure(common.Hash{}, triedb)
+	if err != nil {
+		t.Errorf("Failed to create new secure trie due to %s", err)
+	}
 
 	// Fill it with some arbitrary data
 	content := make(map[string][]byte)
@@ -64,7 +70,7 @@ func makeTestSecureTrie() (*Database, *SecureTrie, map[string][]byte) {
 }
 
 func TestSecureDelete(t *testing.T) {
-	trie := newEmptySecure()
+	trie := newEmptySecure(t)
 	vals := []struct{ k, v string }{
 		{"do", "verb"},
 		{"ether", "wookiedoo"},
@@ -90,7 +96,7 @@ func TestSecureDelete(t *testing.T) {
 }
 
 func TestSecureGetKey(t *testing.T) {
-	trie := newEmptySecure()
+	trie := newEmptySecure(t)
 	trie.Update([]byte("foo"), []byte("bar"))
 
 	key := []byte("foo")
@@ -107,7 +113,7 @@ func TestSecureGetKey(t *testing.T) {
 
 func TestSecureTrieConcurrency(t *testing.T) {
 	// Create an initial trie and copy if for concurrent access
-	_, trie, _ := makeTestSecureTrie()
+	_, trie, _ := makeTestSecureTrie(t)
 
 	threads := runtime.NumCPU()
 	tries := make([]*SecureTrie, threads)

--- a/trie/sync_test.go
+++ b/trie/sync_test.go
@@ -26,10 +26,13 @@ import (
 )
 
 // makeTestTrie create a sample test trie to test node-wise reconstruction.
-func makeTestTrie() (*Database, *SecureTrie, map[string][]byte) {
+func makeTestTrie(t *testing.T) (*Database, *SecureTrie, map[string][]byte) {
 	// Create an empty trie
 	triedb := NewDatabase(memorydb.New())
-	trie, _ := NewSecure(common.Hash{}, triedb)
+	trie, err := NewSecure(common.Hash{}, triedb)
+	if err != nil {
+		t.Errorf("Failed to create new secure trie due to %s", err)
+	}
 
 	// Fill it with some arbitrary data
 	content := make(map[string][]byte)
@@ -111,7 +114,7 @@ func TestIterativeSyncBatchedByPath(t *testing.T)    { testIterativeSync(t, 100,
 
 func testIterativeSync(t *testing.T, count int, bypath bool) {
 	// Create a random trie to copy
-	srcDb, srcTrie, srcData := makeTestTrie()
+	srcDb, srcTrie, srcData := makeTestTrie(t)
 
 	// Create a destination trie and sync with the scheduler
 	diskdb := memorydb.New()
@@ -172,7 +175,7 @@ func testIterativeSync(t *testing.T, count int, bypath bool) {
 // partial results are returned, and the others sent only later.
 func TestIterativeDelayedSync(t *testing.T) {
 	// Create a random trie to copy
-	srcDb, srcTrie, srcData := makeTestTrie()
+	srcDb, srcTrie, srcData := makeTestTrie(t)
 
 	// Create a destination trie and sync with the scheduler
 	diskdb := memorydb.New()
@@ -218,7 +221,7 @@ func TestIterativeRandomSyncBatched(t *testing.T)    { testIterativeRandomSync(t
 
 func testIterativeRandomSync(t *testing.T, count int) {
 	// Create a random trie to copy
-	srcDb, srcTrie, srcData := makeTestTrie()
+	srcDb, srcTrie, srcData := makeTestTrie(t)
 
 	// Create a destination trie and sync with the scheduler
 	diskdb := memorydb.New()
@@ -266,7 +269,7 @@ func testIterativeRandomSync(t *testing.T, count int) {
 // partial results are returned (Even those randomly), others sent only later.
 func TestIterativeRandomDelayedSync(t *testing.T) {
 	// Create a random trie to copy
-	srcDb, srcTrie, srcData := makeTestTrie()
+	srcDb, srcTrie, srcData := makeTestTrie(t)
 
 	// Create a destination trie and sync with the scheduler
 	diskdb := memorydb.New()
@@ -319,7 +322,7 @@ func TestIterativeRandomDelayedSync(t *testing.T) {
 // have such references.
 func TestDuplicateAvoidanceSync(t *testing.T) {
 	// Create a random trie to copy
-	srcDb, srcTrie, srcData := makeTestTrie()
+	srcDb, srcTrie, srcData := makeTestTrie(t)
 
 	// Create a destination trie and sync with the scheduler
 	diskdb := memorydb.New()
@@ -366,7 +369,7 @@ func TestDuplicateAvoidanceSync(t *testing.T) {
 // the database.
 func TestIncompleteSync(t *testing.T) {
 	// Create a random trie to copy
-	srcDb, srcTrie, _ := makeTestTrie()
+	srcDb, srcTrie, _ := makeTestTrie(t)
 
 	// Create a destination trie and sync with the scheduler
 	diskdb := memorydb.New()
@@ -426,7 +429,7 @@ func TestIncompleteSync(t *testing.T) {
 // depth.
 func TestSyncOrdering(t *testing.T) {
 	// Create a random trie to copy
-	srcDb, srcTrie, srcData := makeTestTrie()
+	srcDb, srcTrie, srcData := makeTestTrie(t)
 
 	// Create a destination trie and sync with the scheduler, tracking the requests
 	diskdb := memorydb.New()


### PR DESCRIPTION
This PR replaces unnecessary error handling in `core/state/database.go` to return the trie and error directly from `trie.NewSecure(root, db.db)` and additionally adds error handling throughout the tests if either of the changed functions ever returns an error.