### PR TITLE
internal/ethapi: pass in correct vmCfg in DoCall

### DIFF
--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -879,7 +879,7 @@ func DoCall(ctx context.Context, b Backend, args CallArgs, blockNrOrHash rpc.Blo
 
 	// Get a new instance of the EVM.
 	msg := args.ToMessage(globalGasCap)
-	evm, vmError, err := b.GetEVM(ctx, msg, state, header, nil)
+	evm, vmError, err := b.GetEVM(ctx, msg, state, header, &vmCfg)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This PR passes in `vmCfg` into `GetEVM` during DoCall. As it is currently, the `vmCfg` parameter appears to be unused.