### PR TITLE
eth, cmd/utils: make snap discovery use eth dataset with enr-filter

### DIFF
--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -1692,7 +1692,7 @@ func SetDNSDiscoveryDefaults(cfg *ethconfig.Config, genesis common.Hash) {
 		cfg.EthDiscoveryURLs = []string{url}
 	}
 	if cfg.SyncMode == downloader.SnapSync {
-		if url := params.KnownDNSNetwork(genesis, "snap"); url != "" {
+		if url := params.KnownDNSNetwork(genesis, protocol); url != "" {
 			cfg.SnapDiscoveryURLs = []string{url}
 		}
 	}


### PR DESCRIPTION
This PR makes the `snap` discovery use the same dns-backed ENR tree as the `eth` protocol (e.g. `all.mainnet.ethdisco.net` instead of `snap.mainnet.ethdisco.net`), and then apply a filter to filter out the ones we want. 

The DNS crawler had to impose some limits, as we were going out of the DNS entry limit on route53, so snap are limited to `500` right now, so this change should bump the number of discoverable snap peers by quite a lot, since most eth-peers are also serving snap. 