### PR TITLE
params: remove dependency on crypto

### DIFF
--- a/params/config.go
+++ b/params/config.go
@@ -22,7 +22,7 @@ import (
 	"math/big"
 
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/crypto"
+	"golang.org/x/crypto/sha3"
 )
 
 // Genesis hashes to enforce below configs on.
@@ -278,12 +278,17 @@ func (c *TrustedCheckpoint) HashEqual(hash common.Hash) bool {
 
 // Hash returns the hash of checkpoint's four key fields(index, sectionHead, chtRoot and bloomTrieRoot).
 func (c *TrustedCheckpoint) Hash() common.Hash {
-	buf := make([]byte, 8+3*common.HashLength)
-	binary.BigEndian.PutUint64(buf, c.SectionIndex)
-	copy(buf[8:], c.SectionHead.Bytes())
-	copy(buf[8+common.HashLength:], c.CHTRoot.Bytes())
-	copy(buf[8+2*common.HashLength:], c.BloomRoot.Bytes())
-	return crypto.Keccak256Hash(buf)
+	var sectionIndex [8]byte
+	binary.BigEndian.PutUint64(sectionIndex[:], c.SectionIndex)
+
+	w := sha3.NewLegacyKeccak256()
+	w.Write(sectionIndex[:])
+	w.Write(c.CHTRoot[:])
+	w.Write(c.BloomRoot[:])
+
+	var h common.Hash
+	w.Sum(h[:0])
+	return h
 }
 
 // Empty returns an indicator whether the checkpoint is regarded as empty.

--- a/params/config.go
+++ b/params/config.go
@@ -283,6 +283,7 @@ func (c *TrustedCheckpoint) Hash() common.Hash {
 
 	w := sha3.NewLegacyKeccak256()
 	w.Write(sectionIndex[:])
+	w.Write(c.SectionHead[:])
 	w.Write(c.CHTRoot[:])
 	w.Write(c.BloomRoot[:])
 


### PR DESCRIPTION
Package params should not depend on package crypto because building
crypto requires cgo.

Since build/ci.go needs package params to get the go-ethereum version
number, C code must be compiled in order to run the build tool, which is
annoying for certain cross-compilation setups.