### PR TITLE
eth/protocols/snap: use storage batch, not account batch in st task

### DIFF
--- a/eth/protocols/snap/sync.go
+++ b/eth/protocols/snap/sync.go
@@ -690,7 +690,7 @@ func (s *Syncer) loadSyncStatus() {
 								s.storageBytes += common.StorageSize(len(key) + len(value))
 							},
 						}
-						subtask.genTrie = trie.NewStackTrie(task.genBatch)
+						subtask.genTrie = trie.NewStackTrie(subtask.genBatch)
 					}
 				}
 			}


### PR DESCRIPTION
When large contract sync was interrupted and resumed, recreating the task set the account batch into the storage trie stack tries, causing those to never be flushed, rather just pushed into until the contract completed.