### PR TITLE
EIP-1559 tx pool support

### DIFF
--- a/core/tx_list.go
+++ b/core/tx_list.go
@@ -287,7 +287,7 @@ func (l *txList) Add(tx *types.Transaction, priceBump uint64) (bool, *types.Tran
 		// Have to ensure that the new gas price is higher than the old gas
 		// price as well as checking the percentage threshold to ensure that
 		// this is accurate for low (Wei-level) gas price replacements
-		if old.GasPriceCmp(tx) >= 0 || tx.GasPriceIntCmp(threshold) < 0 {
+		if old.FeeCapCmp(tx) >= 0 || tx.FeeCapIntCmp(threshold) < 0 {
 			return false, nil
 		}
 	}
@@ -413,8 +413,8 @@ func (h priceHeap) Len() int      { return len(h) }
 func (h priceHeap) Swap(i, j int) { h[i], h[j] = h[j], h[i] }
 
 func (h priceHeap) Less(i, j int) bool {
-	// Sort primarily by price, returning the cheaper one
-	switch h[i].GasPriceCmp(h[j]) {
+	// Sort primarily by fee cap, returning the cheaper one
+	switch h[i].FeeCapCmp(h[j]) {
 	case -1:
 		return true
 	case 1:
@@ -491,7 +491,7 @@ func (l *txPricedList) Cap(threshold *big.Int) types.Transactions {
 			continue
 		}
 		// Stop the discards if we've reached the threshold
-		if cheapest.GasPriceIntCmp(threshold) >= 0 {
+		if cheapest.FeeCapIntCmp(threshold) >= 0 {
 			break
 		}
 		heap.Pop(l.remotes)
@@ -520,7 +520,7 @@ func (l *txPricedList) Underpriced(tx *types.Transaction) bool {
 	// If the remote transaction is even cheaper than the
 	// cheapest one tracked locally, reject it.
 	cheapest := []*types.Transaction(*l.remotes)[0]
-	return cheapest.GasPriceCmp(tx) >= 0
+	return cheapest.FeeCapCmp(tx) >= 0
 }
 
 // Discard finds a number of most underpriced transactions, removes them from the

--- a/core/tx_list.go
+++ b/core/tx_list.go
@@ -534,7 +534,8 @@ func (l *txPricedList) Underpriced(tx *types.Transaction) bool {
 	// If the remote transaction is even cheaper than the
 	// cheapest one tracked locally, reject it.
 	cheapest := []*types.Transaction(*l.remotes)[0]
-	return cheapest.FeeCapCmp(tx) >= 0
+	cmp := cheapest.FeeCapCmp(tx)
+	return cmp > 0 || (cmp == 0 && cheapest.TipCmp(tx) >= 0)
 }
 
 // Discard finds a number of most underpriced transactions, removes them from the

--- a/core/tx_list.go
+++ b/core/tx_list.go
@@ -489,31 +489,6 @@ func (l *txPricedList) Removed(count int) {
 	l.Reheap()
 }
 
-// Cap finds all the transactions below the given price threshold, drops them
-// from the priced list and returns them for further removal from the entire pool.
-//
-// Note: only remote transactions will be considered for eviction.
-// This function should only be used pre-EIP-1559 - it can only cap by fee cap, not tip
-func (l *txPricedList) Cap(threshold *big.Int) types.Transactions {
-	drop := make(types.Transactions, 0, 128) // Remote underpriced transactions to drop
-	for len(*l.remotes) > 0 {
-		// Discard stale transactions if found during cleanup
-		cheapest := (*l.remotes)[0]
-		if l.all.GetRemote(cheapest.Hash()) == nil { // Removed or migrated
-			heap.Pop(l.remotes)
-			l.stales--
-			continue
-		}
-		// Stop the discards if we've reached the threshold
-		if cheapest.FeeCapIntCmp(threshold) >= 0 {
-			break
-		}
-		heap.Pop(l.remotes)
-		drop = append(drop, cheapest)
-	}
-	return drop
-}
-
 // Underpriced checks whether a transaction is cheaper than (or as cheap as) the
 // lowest priced (remote) transaction currently being tracked.
 func (l *txPricedList) Underpriced(tx *types.Transaction) bool {

--- a/core/tx_list.go
+++ b/core/tx_list.go
@@ -280,20 +280,20 @@ func (l *txList) Add(tx *types.Transaction, priceBump uint64) (bool, *types.Tran
 	old := l.txs.Get(tx.Nonce())
 	if old != nil {
 		// thresholdFeeCap = oldFC  * (100 + priceBump) / 100
-		// thresholdTip    = oldTip * (100 + priceBump) / 100
 		a := big.NewInt(100 + int64(priceBump))
 		aFeeCap := new(big.Int).Mul(a, old.FeeCap())
 		aTip := a.Mul(a, old.Tip())
+
+		// thresholdTip    = oldTip * (100 + priceBump) / 100
 		b := big.NewInt(100)
 		thresholdFeeCap := aFeeCap.Div(aFeeCap, b)
 		thresholdTip := aTip.Div(aTip, b)
-		// Have to ensure that the new fee cap and tip are both higher than the old
-		// ones as well as checking the percentage threshold to ensure that
+
+		// Have to ensure that either the new fee cap or tip is higher than the
+		// old ones as well as checking the percentage threshold to ensure that
 		// this is accurate for low (Wei-level) gas price replacements
-		if old.FeeCapCmp(tx) >= 0 || tx.FeeCapIntCmp(thresholdFeeCap) < 0 {
-			return false, nil
-		}
-		if old.TipCmp(tx) >= 0 || tx.TipIntCmp(thresholdTip) < 0 {
+		if (old.FeeCapCmp(tx) >= 0 || tx.FeeCapIntCmp(thresholdFeeCap) < 0) &&
+			(old.TipCmp(tx) >= 0 || tx.TipIntCmp(thresholdTip) < 0) {
 			return false, nil
 		}
 	}

--- a/core/tx_list.go
+++ b/core/tx_list.go
@@ -292,7 +292,7 @@ func (l *txList) Add(tx *types.Transaction, priceBump uint64) (bool, *types.Tran
 		// Have to ensure that either the new fee cap or tip is higher than the
 		// old ones as well as checking the percentage threshold to ensure that
 		// this is accurate for low (Wei-level) gas price replacements
-		if (old.FeeCapCmp(tx) >= 0 || tx.FeeCapIntCmp(thresholdFeeCap) < 0) &&
+		if (old.FeeCapCmp(tx) >= 0 || tx.FeeCapIntCmp(thresholdFeeCap) < 0) ||
 			(old.TipCmp(tx) >= 0 || tx.TipIntCmp(thresholdTip) < 0) {
 			return false, nil
 		}

--- a/core/tx_pool.go
+++ b/core/tx_pool.go
@@ -545,8 +545,8 @@ func (pool *TxPool) validateTx(tx *types.Transaction, local bool) error {
 	if err != nil {
 		return ErrInvalidSender
 	}
-	// Drop non-local transactions under our own minimal accepted gas price
-	if !local && tx.GasPriceIntCmp(pool.gasPrice) < 0 {
+	// Drop non-local transactions under our own minimal accepted gas price or tip
+	if !local && tx.TipIntCmp(pool.gasPrice) < 0 {
 		return ErrUnderpriced
 	}
 	// Ensure the transaction adheres to nonce ordering

--- a/core/tx_pool.go
+++ b/core/tx_pool.go
@@ -233,7 +233,7 @@ type TxPool struct {
 	mu          sync.RWMutex
 
 	istanbul bool // Fork indicator whether we are in the istanbul stage.
-	eip2718  bool // Fork indicator whether we are using EIp-2718 type transactions.
+	eip2718  bool // Fork indicator whether we are using EIP-2718 type transactions.
 	eip1559  bool // Fork indicator whether we are using EIP-1559 type transactions.
 
 	currentState  *state.StateDB // Current state in the blockchain head

--- a/core/tx_pool.go
+++ b/core/tx_pool.go
@@ -435,18 +435,12 @@ func (pool *TxPool) SetGasPrice(price *big.Int) {
 	pool.gasPrice = price
 	// if the min miner fee increased, remove transactions below the new threshold
 	if price.Cmp(old) > 0 {
-		if !pool.eip1559 {
-			for _, tx := range pool.priced.Cap(price) {
-				pool.removeTx(tx.Hash(), false)
-			}
-		} else {
-			// pool.priced is sorted by FeeCap, so we have to iterate through pool.all instead
-			drop := pool.all.RemotesBelowTip(price)
-			for _, tx := range drop {
-				pool.removeTx(tx.Hash(), false)
-			}
-			pool.priced.Removed(len(drop))
+		// pool.priced is sorted by FeeCap, so we have to iterate through pool.all instead
+		drop := pool.all.RemotesBelowTip(price)
+		for _, tx := range drop {
+			pool.removeTx(tx.Hash(), false)
 		}
+		pool.priced.Removed(len(drop))
 	}
 
 	log.Info("Transaction pool miner fee threshold updated", "fee", price)

--- a/core/tx_pool.go
+++ b/core/tx_pool.go
@@ -1222,7 +1222,7 @@ func (pool *TxPool) reset(oldHead, newHead *types.Header) {
 	next := new(big.Int).Add(newHead.Number, big.NewInt(1))
 	pool.istanbul = pool.chainconfig.IsIstanbul(next)
 	pool.eip2718 = pool.chainconfig.IsBerlin(next)
-	pool.eip1559 = pool.chainconfig.IsAleut(next)
+	pool.eip1559 = pool.chainconfig.IsLondon(next)
 
 	// For EIP-1559, adjust the gas limit by the elasticity multiplier
 	if pool.eip1559 {

--- a/core/tx_pool.go
+++ b/core/tx_pool.go
@@ -443,7 +443,7 @@ func (pool *TxPool) SetGasPrice(price *big.Int) {
 		pool.priced.Removed(len(drop))
 	}
 
-	log.Info("Transaction pool miner fee threshold updated", "fee", price)
+	log.Info("Transaction pool price threshold updated", "price", price)
 }
 
 // Nonce returns the next nonce of an account, with all transactions executable

--- a/core/tx_pool.go
+++ b/core/tx_pool.go
@@ -1223,11 +1223,6 @@ func (pool *TxPool) reset(oldHead, newHead *types.Header) {
 	pool.istanbul = pool.chainconfig.IsIstanbul(next)
 	pool.eip2718 = pool.chainconfig.IsBerlin(next)
 	pool.eip1559 = pool.chainconfig.IsLondon(next)
-
-	// For EIP-1559, adjust the gas limit by the elasticity multiplier
-	if pool.eip1559 {
-		pool.currentMaxGas *= params.ElasticityMultiplier
-	}
 }
 
 // promoteExecutables moves transactions that have become processable from the

--- a/core/tx_pool_test.go
+++ b/core/tx_pool_test.go
@@ -347,6 +347,21 @@ func TestTransactionNegativeValue(t *testing.T) {
 	}
 }
 
+func TestTransactionTypeNotSupported(t *testing.T) {
+	t.Parallel()
+
+	pool, key := setupTxPool()
+	defer pool.Stop()
+
+	// cannot use dynamicFeeTransaction() here for now as it uses the Aleut testnet ChainID
+	tx := types.NewDynamicFeeTransaction(pool.chainconfig.ChainID, 0, common.Address{}, big.NewInt(100), 100, big.NewInt(1), big.NewInt(1), nil, nil)
+	tx, _ = types.SignTx(tx, types.NewEIP2718Signer(pool.chainconfig.ChainID), key)
+
+	if err := pool.AddRemote(tx); err != ErrTxTypeNotSupported {
+		t.Error("expected", ErrTxTypeNotSupported, "got", err)
+	}
+}
+
 func TestTransactionChainFork(t *testing.T) {
 	t.Parallel()
 

--- a/core/tx_pool_test.go
+++ b/core/tx_pool_test.go
@@ -87,6 +87,12 @@ func pricedDataTransaction(nonce uint64, gaslimit uint64, gasprice *big.Int, key
 	return tx
 }
 
+func dynamicFeeTransaction(nonce uint64, gaslimit uint64, gasFee *big.Int, tip *big.Int, key *ecdsa.PrivateKey) *types.Transaction {
+	tx := types.NewDynamicFeeTransaction(params.AleutChainConfig.ChainID, nonce, common.Address{}, big.NewInt(100), gaslimit, gasFee, tip, nil, nil)
+	tx, _ = types.SignTx(tx, types.NewEIP2718Signer(params.AleutChainConfig.ChainID), key)
+	return tx
+}
+
 func setupTxPool() (*TxPool, *ecdsa.PrivateKey) {
 	statedb, _ := state.New(common.Hash{}, state.NewDatabase(rawdb.NewMemoryDatabase()), nil)
 	blockchain := &testBlockChain{statedb, 10000000, new(event.Feed)}

--- a/core/tx_pool_test.go
+++ b/core/tx_pool_test.go
@@ -1415,10 +1415,7 @@ func TestTransactionPoolRepricingDynamicFee(t *testing.T) {
 	t.Parallel()
 
 	// Create the pool to test the pricing enforcement with
-	statedb, _ := state.New(common.Hash{}, state.NewDatabase(rawdb.NewMemoryDatabase()), nil)
-	blockchain := &testBlockChain{statedb, 1000000, new(event.Feed)}
-
-	pool := NewTxPool(testTxPoolConfig, params.AleutChainConfig, blockchain)
+	pool, _ := setupTxPoolWithConfig(params.AleutChainConfig)
 	defer pool.Stop()
 
 	// Keep track of transaction events to ensure all executables get announced
@@ -1555,14 +1552,14 @@ func TestTransactionPoolRepricingKeepsLocals(t *testing.T) {
 		pool.currentState.AddBalance(crypto.PubkeyToAddress(keys[i].PublicKey), big.NewInt(1000*1000000))
 	}
 	// Create transaction (both pending and queued) with a linearly growing gasprice
-	for i := uint64(0); i < 250; i++ {
+	for i := uint64(0); i < 500; i++ {
 		// Add pending transaction.
 		pendingTx := pricedTransaction(i, 100000, big.NewInt(int64(i)), keys[2])
 		if err := pool.AddLocal(pendingTx); err != nil {
 			t.Fatal(err)
 		}
 		// Add queued transaction.
-		queuedTx := pricedTransaction(i+251, 100000, big.NewInt(int64(i)), keys[2])
+		queuedTx := pricedTransaction(i+501, 100000, big.NewInt(int64(i)), keys[2])
 		if err := pool.AddLocal(queuedTx); err != nil {
 			t.Fatal(err)
 		}
@@ -1573,13 +1570,13 @@ func TestTransactionPoolRepricingKeepsLocals(t *testing.T) {
 			t.Fatal(err)
 		}
 		// Add queued dynamic fee transaction.
-		queuedTx = dynamicFeeTx(i+251, 100000, big.NewInt(int64(i)+1), big.NewInt(int64(i)), keys[1])
+		queuedTx = dynamicFeeTx(i+501, 100000, big.NewInt(int64(i)+1), big.NewInt(int64(i)), keys[1])
 		if err := pool.AddLocal(queuedTx); err != nil {
 			t.Fatal(err)
 		}
 	}
 	pending, queued := pool.Stats()
-	expPending, expQueued := 500, 500
+	expPending, expQueued := 1000, 1000
 	validate := func() {
 		pending, queued = pool.Stats()
 		if pending != expPending {

--- a/core/types/transaction.go
+++ b/core/types/transaction.go
@@ -315,15 +315,22 @@ func (tx *Transaction) GasPriceIntCmp(other *big.Int) int {
 	return tx.inner.gasPrice().Cmp(other)
 }
 
+// FeeCapCmp compares the fee cap of two transactions.
 func (tx *Transaction) FeeCapCmp(other *Transaction) int {
 	return tx.inner.feeCap().Cmp(other.inner.feeCap())
 }
+
+// FeeCapIntCmp compares the fee cap of the transaction against the given fee cap.
 func (tx *Transaction) FeeCapIntCmp(other *big.Int) int {
 	return tx.inner.feeCap().Cmp(other)
 }
+
+// TipCmp compares the tip of two transactions.
 func (tx *Transaction) TipCmp(other *Transaction) int {
 	return tx.inner.tip().Cmp(other.inner.tip())
 }
+
+// TipIntCmp compares the tip of the transaction against the given tip.
 func (tx *Transaction) TipIntCmp(other *big.Int) int {
 	return tx.inner.tip().Cmp(other)
 }

--- a/core/types/transaction.go
+++ b/core/types/transaction.go
@@ -315,6 +315,19 @@ func (tx *Transaction) GasPriceIntCmp(other *big.Int) int {
 	return tx.inner.gasPrice().Cmp(other)
 }
 
+func (tx *Transaction) FeeCapCmp(other *Transaction) int {
+	return tx.inner.feeCap().Cmp(other.inner.feeCap())
+}
+func (tx *Transaction) FeeCapIntCmp(other *big.Int) int {
+	return tx.inner.feeCap().Cmp(other)
+}
+func (tx *Transaction) TipCmp(other *Transaction) int {
+	return tx.inner.tip().Cmp(other.inner.tip())
+}
+func (tx *Transaction) TipIntCmp(other *big.Int) int {
+	return tx.inner.tip().Cmp(other)
+}
+
 // Hash returns the transaction hash.
 func (tx *Transaction) Hash() common.Hash {
 	if hash := tx.hash.Load(); hash != nil {

--- a/eth/gasprice/gasprice.go
+++ b/eth/gasprice/gasprice.go
@@ -188,7 +188,7 @@ type transactionsByGasPrice []*types.Transaction
 
 func (t transactionsByGasPrice) Len() int           { return len(t) }
 func (t transactionsByGasPrice) Swap(i, j int)      { t[i], t[j] = t[j], t[i] }
-func (t transactionsByGasPrice) Less(i, j int) bool { return t[i].GasPriceCmp(t[j]) < 0 }
+func (t transactionsByGasPrice) Less(i, j int) bool { return t[i].FeeCapCmp(t[j]) < 0 }
 
 // getBlockPrices calculates the lowest transaction gas price in a given block
 // and sends it to the result channel. If the block is empty or all transactions


### PR DESCRIPTION
Note: the consensus-only changes are tracked in https://github.com/ethereum/go-ethereum/pull/22617

The main goal of the tx pool is to decentralize the submission of transactions to the network, it's absence would lead to the centralization of hash power since users would need to communicate their transactions directly with miners. Minority miners would be left out of the majority of transaction transmissions, since users would just broadcast their txs to the major mining pools.

Building a tx pool is easy--building a good one is more challenging. A naive implementation could relay everything it sees. This is clearly susceptible to a number of denial-of-service attacks. To do better, we should think of the tx pool as a rate limiter.

A robust tx pool should only share valid transactions with its peers that have the potential to be included in the near future. Today, clients achieve this by validating incoming transactions. They verify the static aspect of the transaction first and then they verify the contextual validity -- e.g. the transaction's gas price is greater than the client's minimum and is greater than the current lowest paying transaction in the pool.

Gas price is a nice single-dimension quantity that clients can use for contextual validity. EIP-1559 complicates this by introducing two dimensions that a transaction's price to be weighed against. The first is the transaction tip (aka priority fee, miner bribe, etc), the second is the fee cap. The tip refers to the max amount the transaction pays out directly to the miner of the block, while the fee cap refers to the max base fee a transaction is valid under.

The likelihood of a high fee cap transaction being mined in the near future with EIP-1559 is comparable to the likelihood of mining a high gas price transaction in the near future. This makes fee cap a good candidate [[1]] to replace gas price as the contextual validity check, and therefore in this PR we sort the pool by fee cap. If the pool fills up, we can drop transactions with the smallest fee cap first. 

This presents a bit of a danger though -- if the pool is full transactions that have high tips, a high fee cap low tip transaction could displace a high tip transaction. If the high tip transaction had a reasonable fee cap, this would be probably be the wrong behaviour since both transactions could have roughly equal chances of being included, but one is much more lucrative for miners. Realistically, this scenario should almost never happen. Because the chain is expected to be in a steady-state with the base fee oscillating around the gas target, there should only be around a block or twos worth of executable transactions in the tx pool. Therefore, under normal conditions, it will be impossible for an objectively worse transaction to displace a better one.

This result allows use to naively use fee cap as the sole ordering mechanism in the tx pool. In cases where fee cap's are equal, it makes sense to use the tip as tie breaker. This brings us to the implementation of this PR. The following has been implemented:

* sort transactions by fee cap in a min heap, so the minimum value can be found and removed efficiently
* enforce configurable minimum tip (same as min gas price setting)
* either the fee cap or tip must be bumped more than the price bump percentage
* test tx pool set gas price (now min tip)
* test tx pool global limits
* test tx replacement mechanics

[1]: https://hackmd.io/@adietrichs/1559-transaction-sorting-part2