### PR TITLE
Remove unused read head header accessor

### DIFF
--- a/core/rawdb/accessors_chain.go
+++ b/core/rawdb/accessors_chain.go
@@ -826,19 +826,6 @@ func FindCommonAncestor(db ethdb.Reader, a, b *types.Header) *types.Header {
 	return a
 }
 
-// ReadHeadHeader returns the current canonical head header.
-func ReadHeadHeader(db ethdb.Reader) *types.Header {
-	headHeaderHash := ReadHeadHeaderHash(db)
-	if headHeaderHash == (common.Hash{}) {
-		return nil
-	}
-	headHeaderNumber := ReadHeaderNumber(db, headHeaderHash)
-	if headHeaderNumber == nil {
-		return nil
-	}
-	return ReadHeader(db, headHeaderHash, *headHeaderNumber)
-}
-
 // ReadHeadBlock returns the current canonical head block.
 func ReadHeadBlock(db ethdb.Reader) *types.Block {
 	headBlockHash := ReadHeadBlockHash(db)


### PR DESCRIPTION
This PR removes dead code from `core/rawdb/accessors_chain.go`