### PR TITLE
cmd/geth, eth, core: snapshot dump + unify with trie dump

### DIFF
--- a/cmd/evm/internal/t8ntool/transition.go
+++ b/cmd/evm/internal/t8ntool/transition.go
@@ -212,14 +212,14 @@ func Main(ctx *cli.Context) error {
 	// Iterate over all the tests, run them and aggregate the results
 
 	// Run the test and aggregate the result
-	state, result, err := prestate.Apply(vmConfig, chainConfig, txs, ctx.Int64(RewardFlag.Name), getTracer)
+	s, result, err := prestate.Apply(vmConfig, chainConfig, txs, ctx.Int64(RewardFlag.Name), getTracer)
 	if err != nil {
 		return err
 	}
 	body, _ := rlp.EncodeToBytes(txs)
 	// Dump the excution result
 	collector := make(Alloc)
-	state.DumpToCollector(collector, false, false, false, nil, -1)
+	s.DumpToCollector(collector, &state.DumpOptions{})
 	return dispatchOutput(ctx, baseDir, result, collector, body)
 
 }

--- a/cmd/evm/internal/t8ntool/transition.go
+++ b/cmd/evm/internal/t8ntool/transition.go
@@ -219,9 +219,8 @@ func Main(ctx *cli.Context) error {
 	body, _ := rlp.EncodeToBytes(txs)
 	// Dump the excution result
 	collector := make(Alloc)
-	s.DumpToCollector(collector, &state.DumpConfig{})
+	s.DumpToCollector(collector, nil)
 	return dispatchOutput(ctx, baseDir, result, collector, body)
-
 }
 
 // txWithKey is a helper-struct, to allow us to use the types.Transaction along with
@@ -303,7 +302,7 @@ func (g Alloc) OnAccount(addr common.Address, dumpAccount state.DumpAccount) {
 		}
 	}
 	genesisAccount := core.GenesisAccount{
-		Code:    common.FromHex(dumpAccount.Code),
+		Code:    dumpAccount.Code,
 		Storage: storage,
 		Balance: balance,
 		Nonce:   dumpAccount.Nonce,

--- a/cmd/evm/internal/t8ntool/transition.go
+++ b/cmd/evm/internal/t8ntool/transition.go
@@ -219,7 +219,7 @@ func Main(ctx *cli.Context) error {
 	body, _ := rlp.EncodeToBytes(txs)
 	// Dump the excution result
 	collector := make(Alloc)
-	s.DumpToCollector(collector, &state.DumpOptions{})
+	s.DumpToCollector(collector, &state.DumpConfig{})
 	return dispatchOutput(ctx, baseDir, result, collector, body)
 
 }

--- a/cmd/evm/runner.go
+++ b/cmd/evm/runner.go
@@ -270,7 +270,7 @@ func runCmd(ctx *cli.Context) error {
 	if ctx.GlobalBool(DumpFlag.Name) {
 		statedb.Commit(true)
 		statedb.IntermediateRoot(true)
-		fmt.Println(string(statedb.Dump(false, false, true)))
+		fmt.Println(string(statedb.Dump(&state.DumpOptions{})))
 	}
 
 	if memProfilePath := ctx.GlobalString(MemProfileFlag.Name); memProfilePath != "" {

--- a/cmd/evm/runner.go
+++ b/cmd/evm/runner.go
@@ -270,7 +270,7 @@ func runCmd(ctx *cli.Context) error {
 	if ctx.GlobalBool(DumpFlag.Name) {
 		statedb.Commit(true)
 		statedb.IntermediateRoot(true)
-		fmt.Println(string(statedb.Dump(&state.DumpOptions{})))
+		fmt.Println(string(statedb.Dump(&state.DumpConfig{})))
 	}
 
 	if memProfilePath := ctx.GlobalString(MemProfileFlag.Name); memProfilePath != "" {

--- a/cmd/evm/runner.go
+++ b/cmd/evm/runner.go
@@ -270,7 +270,7 @@ func runCmd(ctx *cli.Context) error {
 	if ctx.GlobalBool(DumpFlag.Name) {
 		statedb.Commit(true)
 		statedb.IntermediateRoot(true)
-		fmt.Println(string(statedb.Dump(&state.DumpConfig{})))
+		fmt.Println(string(statedb.Dump(nil)))
 	}
 
 	if memProfilePath := ctx.GlobalString(MemProfileFlag.Name); memProfilePath != "" {

--- a/cmd/evm/staterunner.go
+++ b/cmd/evm/staterunner.go
@@ -107,7 +107,7 @@ func stateTestCmd(ctx *cli.Context) error {
 				// Test failed, mark as so and dump any state to aid debugging
 				result.Pass, result.Error = false, err.Error()
 				if ctx.GlobalBool(DumpFlag.Name) && s != nil {
-					dump := s.RawDump(&state.DumpOptions{})
+					dump := s.RawDump(&state.DumpConfig{})
 					result.State = &dump
 				}
 			}

--- a/cmd/evm/staterunner.go
+++ b/cmd/evm/staterunner.go
@@ -98,16 +98,16 @@ func stateTestCmd(ctx *cli.Context) error {
 		for _, st := range test.Subtests() {
 			// Run the test and aggregate the result
 			result := &StatetestResult{Name: key, Fork: st.Fork, Pass: true}
-			_, state, err := test.Run(st, cfg, false)
+			_, s, err := test.Run(st, cfg, false)
 			// print state root for evmlab tracing
-			if ctx.GlobalBool(MachineFlag.Name) && state != nil {
-				fmt.Fprintf(os.Stderr, "{\"stateRoot\": \"%x\"}\n", state.IntermediateRoot(false))
+			if ctx.GlobalBool(MachineFlag.Name) && s != nil {
+				fmt.Fprintf(os.Stderr, "{\"stateRoot\": \"%x\"}\n", s.IntermediateRoot(false))
 			}
 			if err != nil {
 				// Test failed, mark as so and dump any state to aid debugging
 				result.Pass, result.Error = false, err.Error()
-				if ctx.GlobalBool(DumpFlag.Name) && state != nil {
-					dump := state.RawDump(false, false, true)
+				if ctx.GlobalBool(DumpFlag.Name) && s != nil {
+					dump := s.RawDump(&state.DumpOptions{})
 					result.State = &dump
 				}
 			}

--- a/cmd/evm/staterunner.go
+++ b/cmd/evm/staterunner.go
@@ -107,7 +107,7 @@ func stateTestCmd(ctx *cli.Context) error {
 				// Test failed, mark as so and dump any state to aid debugging
 				result.Pass, result.Error = false, err.Error()
 				if ctx.GlobalBool(DumpFlag.Name) && s != nil {
-					dump := s.RawDump(&state.DumpConfig{})
+					dump := s.RawDump(nil)
 					result.State = &dump
 				}
 			}

--- a/cmd/geth/chaincmd.go
+++ b/cmd/geth/chaincmd.go
@@ -431,12 +431,9 @@ func parseDumpConfig(ctx *cli.Context, stack *node.Node) (*state.DumpConfig, eth
 		Start:             start.Bytes(),
 		Max:               ctx.Uint64(utils.DumpLimitFlag.Name),
 	}
-	log.Info("Dump options", "block", header.Number,
-		"hash", header.Hash().Hex(),
-		"code", !conf.SkipCode,
-		"storage", !conf.SkipStorage,
-		"start", hexutil.Encode(conf.Start),
-		"limit", conf.Max)
+	log.Info("State dump configured", "block", header.Number, "hash", header.Hash().Hex(),
+		"skipcode", conf.SkipCode, "skipstorage", conf.SkipStorage,
+		"start", hexutil.Encode(conf.Start), "limit", conf.Max)
 	return conf, db, header.Root, nil
 }
 

--- a/cmd/geth/chaincmd.go
+++ b/cmd/geth/chaincmd.go
@@ -20,7 +20,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/ethereum/go-ethereum/common/hexutil"
 	"os"
 	"runtime"
 	"strconv"
@@ -29,6 +28,7 @@ import (
 
 	"github.com/ethereum/go-ethereum/cmd/utils"
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/core"
 	"github.com/ethereum/go-ethereum/core/rawdb"
 	"github.com/ethereum/go-ethereum/core/state"

--- a/cmd/geth/snapshot.go
+++ b/cmd/geth/snapshot.go
@@ -18,7 +18,9 @@ package main
 
 import (
 	"bytes"
+	"encoding/json"
 	"errors"
+	"os"
 	"time"
 
 	"github.com/ethereum/go-ethereum/cmd/utils"
@@ -142,6 +144,30 @@ verification. The default checking target is the HEAD state. It's basically iden
 to traverse-state, but the check granularity is smaller. 
 
 It's also usable without snapshot enabled.
+`,
+			},
+			{
+				Name:      "dump",
+				Usage:     "Dump a specific block from storage (same as 'geth dump' but using snapshots)",
+				ArgsUsage: "[? <blockHash> | <blockNum>]",
+				Action:    utils.MigrateFlags(dumpState),
+				Category:  "MISCELLANEOUS COMMANDS",
+				Flags: []cli.Flag{
+					utils.DataDirFlag,
+					utils.AncientFlag,
+					utils.RopstenFlag,
+					utils.RinkebyFlag,
+					utils.GoerliFlag,
+					utils.ExcludeCodeFlag,
+					utils.ExcludeStorageFlag,
+					utils.StartKeyFlag,
+				},
+				Description: `
+This command is semantically equivalent to 'geth dump', but uses the snapshots
+as the backend data source, making this command a lot faster. 
+
+The argument is interpreted as block number or hash. If none is provided, the latest
+block is used.
 `,
 			},
 		},
@@ -429,4 +455,68 @@ func parseRoot(input string) (common.Hash, error) {
 		return h, err
 	}
 	return h, nil
+}
+
+func dumpState(ctx *cli.Context) error {
+	stack, _ := makeConfigNode(ctx)
+	defer stack.Close()
+
+	opts, db, root, err := parseDumpOptions(ctx, stack)
+	if err != nil {
+		return err
+	}
+	snaptree, err := snapshot.New(db, trie.NewDatabase(db), 256, root, false, false, false)
+	if err != nil {
+		return err
+	}
+	accIt, err := snaptree.AccountIterator(root, common.BytesToHash(opts.Start))
+	if err != nil {
+		return err
+	}
+	defer accIt.Release()
+	log.Info("Snapshot iteration started", "root", root)
+	var (
+		start    = time.Now()
+		logged   = time.Now()
+		accounts uint64
+	)
+	enc := json.NewEncoder(os.Stdout)
+	enc.Encode(struct {
+		Root common.Hash `json:"root"`
+	}{root})
+	for accIt.Next() {
+		account, err := snapshot.FullAccount(accIt.Account())
+		if err != nil {
+			return err
+		}
+		da := &state.DumpAccount{
+			Balance:   account.Balance.String(),
+			Nonce:     account.Nonce,
+			Root:      common.Bytes2Hex(account.Root),
+			CodeHash:  common.Bytes2Hex(account.CodeHash),
+			SecureKey: accIt.Hash().Bytes(),
+		}
+		if !opts.SkipCode && !bytes.Equal(account.CodeHash, emptyCode) {
+			da.Code = common.Bytes2Hex(rawdb.ReadCode(db, common.BytesToHash(account.CodeHash)))
+		}
+		if !opts.SkipStorage {
+			stIt, err := snaptree.StorageIterator(root, accIt.Hash(), common.Hash{})
+			if err != nil {
+				return err
+			}
+			for stIt.Next() {
+				da.Storage[stIt.Hash()] = common.Bytes2Hex(stIt.Slot())
+			}
+		}
+		enc.Encode(da)
+		accounts++
+		if time.Since(logged) > 10*time.Second {
+			log.Info("Snapshot iteration in progress", "at", accIt.Hash(), "accounts", accounts,
+				"elapsed", common.PrettyDuration(time.Since(start)))
+			logged = time.Now()
+		}
+	}
+	log.Info("Snapshot iteration complete", "accounts", accounts,
+		"elapsed", common.PrettyDuration(time.Since(start)))
+	return nil
 }

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -184,7 +184,7 @@ var (
 		Name:  "exitwhensynced",
 		Usage: "Exits after block synchronisation completes",
 	}
-	IterativeOutputFlag = cli.BoolFlag{
+	IterativeOutputFlag = cli.BoolTFlag{
 		Name:  "iterative",
 		Usage: "Print streaming JSON iteratively, delimited by newlines",
 	}
@@ -199,6 +199,11 @@ var (
 	ExcludeCodeFlag = cli.BoolFlag{
 		Name:  "nocode",
 		Usage: "Exclude contract code (save db lookups)",
+	}
+	StartKeyFlag = cli.StringFlag{
+		Name:  "start",
+		Usage: "Start position",
+		Value: "0x00",
 	}
 	defaultSyncMode = ethconfig.Defaults.SyncMode
 	SyncModeFlag    = TextMarshalerFlag{

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -202,8 +202,13 @@ var (
 	}
 	StartKeyFlag = cli.StringFlag{
 		Name:  "start",
-		Usage: "Start position",
-		Value: "0x00",
+		Usage: "Start position. Either a hash or address",
+		Value: "0x0000000000000000000000000000000000000000000000000000000000000000",
+	}
+	DumpLimitFlag = cli.Uint64Flag{
+		Name:  "limit",
+		Usage: "Max number of elements (0 = no limit)",
+		Value: 0,
 	}
 	defaultSyncMode = ethconfig.Defaults.SyncMode
 	SyncModeFlag    = TextMarshalerFlag{

--- a/core/state/state_test.go
+++ b/core/state/state_test.go
@@ -57,7 +57,7 @@ func TestDump(t *testing.T) {
 	s.state.Commit(false)
 
 	// check that DumpToCollector contains the state objects that are in trie
-	got := string(s.state.Dump(&DumpOptions{}))
+	got := string(s.state.Dump(&DumpConfig{}))
 	want := `{
     "root": "71edff0130dd2385947095001c73d9e28d862fc286fca2b922ca6f6f3cddfdd2",
     "accounts": {

--- a/core/state/state_test.go
+++ b/core/state/state_test.go
@@ -57,7 +57,7 @@ func TestDump(t *testing.T) {
 	s.state.Commit(false)
 
 	// check that DumpToCollector contains the state objects that are in trie
-	got := string(s.state.Dump(false, false, true))
+	got := string(s.state.Dump(&DumpOptions{}))
 	want := `{
     "root": "71edff0130dd2385947095001c73d9e28d862fc286fca2b922ca6f6f3cddfdd2",
     "accounts": {
@@ -65,20 +65,23 @@ func TestDump(t *testing.T) {
             "balance": "22",
             "nonce": 0,
             "root": "56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421",
-            "codeHash": "c5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470"
+            "codeHash": "c5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
+            "key": "0x1468288056310c82aa4c01a7e12a10f8111a0560e72b700555479031b86c357d"
         },
         "0x0000000000000000000000000000000000000002": {
             "balance": "44",
             "nonce": 0,
             "root": "56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421",
-            "codeHash": "c5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470"
+            "codeHash": "c5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
+            "key": "0xd52688a8f926c816ca1e079067caba944f158e764817b83fc43594370ca9cf62"
         },
         "0x0000000000000000000000000000000000000102": {
             "balance": "0",
             "nonce": 0,
             "root": "56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421",
             "codeHash": "87874902497a5bb968da31a2998d8f22e949d1ef6214bcdedd8bae24cca4b9e3",
-            "code": "03030303030303"
+            "code": "03030303030303",
+            "key": "0xa17eacbc25cda025e81db9c5c62868822c73ce097cee2a63e33a2e41268358a1"
         }
     }
 }`

--- a/core/state/state_test.go
+++ b/core/state/state_test.go
@@ -57,30 +57,30 @@ func TestDump(t *testing.T) {
 	s.state.Commit(false)
 
 	// check that DumpToCollector contains the state objects that are in trie
-	got := string(s.state.Dump(&DumpConfig{}))
+	got := string(s.state.Dump(nil))
 	want := `{
     "root": "71edff0130dd2385947095001c73d9e28d862fc286fca2b922ca6f6f3cddfdd2",
     "accounts": {
         "0x0000000000000000000000000000000000000001": {
             "balance": "22",
             "nonce": 0,
-            "root": "56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421",
-            "codeHash": "c5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
+            "root": "0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421",
+            "codeHash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
             "key": "0x1468288056310c82aa4c01a7e12a10f8111a0560e72b700555479031b86c357d"
         },
         "0x0000000000000000000000000000000000000002": {
             "balance": "44",
             "nonce": 0,
-            "root": "56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421",
-            "codeHash": "c5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
+            "root": "0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421",
+            "codeHash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
             "key": "0xd52688a8f926c816ca1e079067caba944f158e764817b83fc43594370ca9cf62"
         },
         "0x0000000000000000000000000000000000000102": {
             "balance": "0",
             "nonce": 0,
-            "root": "56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421",
-            "codeHash": "87874902497a5bb968da31a2998d8f22e949d1ef6214bcdedd8bae24cca4b9e3",
-            "code": "03030303030303",
+            "root": "0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421",
+            "codeHash": "0x87874902497a5bb968da31a2998d8f22e949d1ef6214bcdedd8bae24cca4b9e3",
+            "code": "0x03030303030303",
             "key": "0xa17eacbc25cda025e81db9c5c62868822c73ce097cee2a63e33a2e41268358a1"
         }
     }

--- a/eth/api.go
+++ b/eth/api.go
@@ -264,12 +264,17 @@ func NewPublicDebugAPI(eth *Ethereum) *PublicDebugAPI {
 
 // DumpBlock retrieves the entire state of the database at a given block.
 func (api *PublicDebugAPI) DumpBlock(blockNr rpc.BlockNumber) (state.Dump, error) {
+	opts := &state.DumpOptions{
+		OnlyWithAddresses: true,
+		Start:             nil,
+		Max:               AccountRangeMaxResults, // Sanity limit over RPC
+	}
 	if blockNr == rpc.PendingBlockNumber {
 		// If we're dumping the pending state, we need to request
 		// both the pending block as well as the pending state from
 		// the miner and operate on those
 		_, stateDb := api.eth.miner.Pending()
-		return stateDb.RawDump(false, false, true), nil
+		return stateDb.RawDump(opts), nil
 	}
 	var block *types.Block
 	if blockNr == rpc.LatestBlockNumber {
@@ -284,7 +289,7 @@ func (api *PublicDebugAPI) DumpBlock(blockNr rpc.BlockNumber) (state.Dump, error
 	if err != nil {
 		return state.Dump{}, err
 	}
-	return stateDb.RawDump(false, false, true), nil
+	return stateDb.RawDump(opts), nil
 }
 
 // PrivateDebugAPI is the collection of Ethereum full node APIs exposed over
@@ -386,10 +391,17 @@ func (api *PublicDebugAPI) AccountRange(blockNrOrHash rpc.BlockNumberOrHash, sta
 		return state.IteratorDump{}, errors.New("either block number or block hash must be specified")
 	}
 
-	if maxResults > AccountRangeMaxResults || maxResults <= 0 {
-		maxResults = AccountRangeMaxResults
+	opts := &state.DumpOptions{
+		SkipCode:          nocode,
+		SkipStorage:       nostorage,
+		OnlyWithAddresses: !incompletes,
+		Start:             start,
+		Max:               uint64(maxResults),
 	}
-	return stateDb.IteratorDump(nocode, nostorage, incompletes, start, maxResults), nil
+	if maxResults > AccountRangeMaxResults || maxResults <= 0 {
+		opts.Max = AccountRangeMaxResults
+	}
+	return stateDb.IteratorDump(opts), nil
 }
 
 // StorageRangeResult is the result of a debug_storageRangeAt API call.

--- a/eth/api.go
+++ b/eth/api.go
@@ -264,7 +264,7 @@ func NewPublicDebugAPI(eth *Ethereum) *PublicDebugAPI {
 
 // DumpBlock retrieves the entire state of the database at a given block.
 func (api *PublicDebugAPI) DumpBlock(blockNr rpc.BlockNumber) (state.Dump, error) {
-	opts := &state.DumpOptions{
+	opts := &state.DumpConfig{
 		OnlyWithAddresses: true,
 		Start:             nil,
 		Max:               AccountRangeMaxResults, // Sanity limit over RPC
@@ -391,7 +391,7 @@ func (api *PublicDebugAPI) AccountRange(blockNrOrHash rpc.BlockNumberOrHash, sta
 		return state.IteratorDump{}, errors.New("either block number or block hash must be specified")
 	}
 
-	opts := &state.DumpOptions{
+	opts := &state.DumpConfig{
 		SkipCode:          nocode,
 		SkipStorage:       nostorage,
 		OnlyWithAddresses: !incompletes,

--- a/eth/api.go
+++ b/eth/api.go
@@ -266,7 +266,6 @@ func NewPublicDebugAPI(eth *Ethereum) *PublicDebugAPI {
 func (api *PublicDebugAPI) DumpBlock(blockNr rpc.BlockNumber) (state.Dump, error) {
 	opts := &state.DumpConfig{
 		OnlyWithAddresses: true,
-		Start:             nil,
 		Max:               AccountRangeMaxResults, // Sanity limit over RPC
 	}
 	if blockNr == rpc.PendingBlockNumber {

--- a/eth/api_test.go
+++ b/eth/api_test.go
@@ -34,7 +34,7 @@ import (
 var dumper = spew.ConfigState{Indent: "    "}
 
 func accountRangeTest(t *testing.T, trie *state.Trie, statedb *state.StateDB, start common.Hash, requestedNum int, expectedNum int) state.IteratorDump {
-	result := statedb.IteratorDump(&state.DumpOptions{
+	result := statedb.IteratorDump(&state.DumpConfig{
 		SkipCode:          true,
 		SkipStorage:       true,
 		OnlyWithAddresses: false,
@@ -142,7 +142,7 @@ func TestEmptyAccountRange(t *testing.T) {
 	)
 	st.Commit(true)
 	st.IntermediateRoot(true)
-	results := st.IteratorDump(&state.DumpOptions{
+	results := st.IteratorDump(&state.DumpConfig{
 		SkipCode:          true,
 		SkipStorage:       true,
 		OnlyWithAddresses: true,

--- a/eth/api_test.go
+++ b/eth/api_test.go
@@ -34,7 +34,13 @@ import (
 var dumper = spew.ConfigState{Indent: "    "}
 
 func accountRangeTest(t *testing.T, trie *state.Trie, statedb *state.StateDB, start common.Hash, requestedNum int, expectedNum int) state.IteratorDump {
-	result := statedb.IteratorDump(true, true, false, start.Bytes(), requestedNum)
+	result := statedb.IteratorDump(&state.DumpOptions{
+		SkipCode:          true,
+		SkipStorage:       true,
+		OnlyWithAddresses: false,
+		Start:             start.Bytes(),
+		Max:               uint64(requestedNum),
+	})
 
 	if len(result.Accounts) != expectedNum {
 		t.Fatalf("expected %d results, got %d", expectedNum, len(result.Accounts))
@@ -131,12 +137,17 @@ func TestEmptyAccountRange(t *testing.T) {
 	t.Parallel()
 
 	var (
-		statedb  = state.NewDatabase(rawdb.NewMemoryDatabase())
-		state, _ = state.New(common.Hash{}, statedb, nil)
+		statedb = state.NewDatabase(rawdb.NewMemoryDatabase())
+		st, _   = state.New(common.Hash{}, statedb, nil)
 	)
-	state.Commit(true)
-	state.IntermediateRoot(true)
-	results := state.IteratorDump(true, true, true, (common.Hash{}).Bytes(), AccountRangeMaxResults)
+	st.Commit(true)
+	st.IntermediateRoot(true)
+	results := st.IteratorDump(&state.DumpOptions{
+		SkipCode:          true,
+		SkipStorage:       true,
+		OnlyWithAddresses: true,
+		Max:               uint64(AccountRangeMaxResults),
+	})
 	if bytes.Equal(results.Next, (common.Hash{}).Bytes()) {
 		t.Fatalf("Empty results should not return a second page")
 	}


### PR DESCRIPTION
Supersedes https://github.com/ethereum/go-ethereum/pull/22787

This PR adds support for doing dumps from the snapshot. This is useful for two purposes: 
- For general chain investigations, it's faster to dump data using the snapshot than iterating the trie. 
- For checking the trie against the snapshot, it's possible to dump out parts of the state from either, and compare the two. 

There are a few differences, however. 
- For snapshot dump, I haven't added the conversion from hashed form to preimages. Mostly because since we don't (by default) store preimages any longer, I don't think it makes sense to do an extra db lookup for every hash. However, I didn't remove the address lookup from the trie dump, to not destroy something.
- For snapshot dump, it only ever does iterative (`jsonlines`, not `json`) output. 
- For trie dump, I changed the default to be iterative
- Both commands now take a `start`
- Both commands defaults to latest block if no args are given
- Also added progress reporting on both

Opening this in draft, will test it a bit more, add some performance numbers. 

## Examples:

Trie dump:  
```
[user@work go-ethereum]$ ./build/bin/geth --ropsten  dump --start 0xfe6a58207750197f48cb90864096850259845c2c8e90c74433325c0b144bf8bb
INFO [05-01|20:24:33.872] Maximum peer count                       ETH=50 LES=0 total=50
WARN [05-01|20:24:33.872] Using the deprecated `testnet` datadir. Future versions will store the Ropsten chain in `ropsten`. 
INFO [05-01|20:24:33.872] Smartcard socket not found, disabling    err="stat /run/pcscd/pcscd.comm: no such file or directory"
INFO [05-01|20:24:33.873] Set global gas cap                       cap=25,000,000
INFO [05-01|20:24:33.873] Allocated cache and file handles         database=/home/user/.ethereum/ropsten/geth/chaindata cache=512.00MiB handles=262,144 readonly=true
INFO [05-01|20:24:33.912] Opened ancient database                  database=/home/user/.ethereum/ropsten/geth/chaindata/ancient readonly=true
INFO [05-01|20:24:33.913] Dump options                             block=0 hash=0x41941023680923e0fe4d74a34bdac8141f2540e3ae90623718e47d66d1ca4a2d code=true storage=true start=0xfe6a58207750197f48cb90864096850259845c2c8e90c74433325c0b144bf8bb
{"root":"0x217b0bbcfb72e2d57e28f33cb361b9983513177755dc3f33ce3e7022ed62b77b"}
{"balance":"0","nonce":0,"root":"56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421","codeHash":"c5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470","address":"0x000000000000000000000000000000000000007f","key":"0xfe6a58207750197f48cb90864096850259845c2c8e90c74433325c0b144bf8bb"}
{"balance":"0","nonce":0,"root":"56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421","codeHash":"c5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470","address":"0x000000000000000000000000000000000000000d","key":"0xfffa0eae268038cfa984647a1d0635beb86eda9fb7b500688f3189520cfa9ee5"}
INFO [05-01|20:24:33.913] Trie iteration complete                  accounts=2 elapsed="215.961µs"
```
Snapshot dump: 
```
[user@work go-ethereum]$ ./build/bin/geth --ropsten  snapshot dump --start 0xfe6a58207750197f48cb90864096850259845c2c8e90c74433325c0b144bf8bb
INFO [05-01|20:25:02.252] Maximum peer count                       ETH=50 LES=0 total=50
WARN [05-01|20:25:02.253] Using the deprecated `testnet` datadir. Future versions will store the Ropsten chain in `ropsten`. 
INFO [05-01|20:25:02.253] Smartcard socket not found, disabling    err="stat /run/pcscd/pcscd.comm: no such file or directory"
INFO [05-01|20:25:02.253] Set global gas cap                       cap=25,000,000
INFO [05-01|20:25:02.253] Allocated cache and file handles         database=/home/user/.ethereum/ropsten/geth/chaindata cache=512.00MiB handles=262,144 readonly=true
INFO [05-01|20:25:02.272] Opened ancient database                  database=/home/user/.ethereum/ropsten/geth/chaindata/ancient readonly=true
INFO [05-01|20:25:02.272] Dump options                             block=0 hash=0x41941023680923e0fe4d74a34bdac8141f2540e3ae90623718e47d66d1ca4a2d code=true storage=true start=0xfe6a58207750197f48cb90864096850259845c2c8e90c74433325c0b144bf8bb
INFO [05-01|20:25:02.272] Snapshot iteration started               root=217b0b..62b77b
{"root":"0x217b0bbcfb72e2d57e28f33cb361b9983513177755dc3f33ce3e7022ed62b77b"}
{"balance":"0","nonce":0,"root":"56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421","codeHash":"c5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470","key":"0xfe6a58207750197f48cb90864096850259845c2c8e90c74433325c0b144bf8bb"}
{"balance":"0","nonce":0,"root":"56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421","codeHash":"c5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470","key":"0xfffa0eae268038cfa984647a1d0635beb86eda9fb7b500688f3189520cfa9ee5"}
INFO [05-01|20:25:02.273] Snapshot iteration complete              accounts=2 elapsed="161.081µs"

``` 