### PR TITLE
build: fix windows installer build for NSIS v3.05

### DIFF
--- a/build/nsis.envvarupdate.nsh
+++ b/build/nsis.envvarupdate.nsh
@@ -43,7 +43,7 @@
   !ifndef Un${StrFuncName}_INCLUDED
     ${Un${StrFuncName}}
   !endif
-  !define un.${StrFuncName} "${Un${StrFuncName}}"
+  !define un.${StrFuncName} '${Un${StrFuncName}}'
 !macroend
 
 !insertmacro _IncludeStrFunction StrTok


### PR DESCRIPTION
With the update to a newer AppVeyor build image, creating the Windows
installer no longer worked because of a string quoting error in
EnvVarUpdate.nsh. This applies the fix recommended
in https://stackoverflow.com/questions/62081765.

I have tested this, and the resulting installer/uninstaller works.