### PR TITLE
core: single end logging in json logger

### DIFF
--- a/core/vm/logger_json.go
+++ b/core/vm/logger_json.go
@@ -87,8 +87,9 @@ func (l *JSONLogger) CaptureEnd(output []byte, gasUsed uint64, t time.Duration, 
 		Time    time.Duration       `json:"time"`
 		Err     string              `json:"error,omitempty"`
 	}
+	var errMsg string
 	if err != nil {
-		l.encoder.Encode(endLog{common.Bytes2Hex(output), math.HexOrDecimal64(gasUsed), t, err.Error()})
+		errMsg = err.Error()
 	}
-	l.encoder.Encode(endLog{common.Bytes2Hex(output), math.HexOrDecimal64(gasUsed), t, ""})
+	l.encoder.Encode(endLog{common.Bytes2Hex(output), math.HexOrDecimal64(gasUsed), t, errMsg})
 }


### PR DESCRIPTION
While trying FuzzyVM on the recent `go-ethereum` master (`37b5595456e7049e3ed487c41564281de52e00ab`) I got an incorrect output.

Got:
```
./evm --json --nomemory statetest ~/github.com/MariusVanDerWijden/FuzzyVM/interesting_inputs/BenchTest-16.json
{"pc":0,"op":127,"gas":"0xb6c2b8","gasCost":"0x3","memory":"0x","memSize":0,"stack":[],"returnStack":null,"returnData":"0x","depth":1,"refund":0,"opName":"PUSH32","error":""}
{"pc":33,"op":99,"gas":"0xb6c2b5","gasCost":"0x3","memory":"0x","memSize":0,"stack":["0x564b34a33ecd1af05fe6923d6de71870997d38ef60155c325957214c4259d74b"],"returnStack":null,"returnData":"0x","depth":1,"refund":0,"opName":"PUSH4","error":""}
{"pc":38,"op":82,"gas":"0xb6c2b2","gasCost":"0x4268fec1b10","memory":"0x","memSize":0,"stack":["0x564b34a33ecd1af05fe6923d6de71870997d38ef60155c325957214c4259d74b","0x5c325957"],"returnStack":null,"returnData":"0x","depth":1,"refund":0,"opName":"MSTORE","error":"out of gas"}
{"output":"","gasUsed":"0xb6c2b8","time":180880,"error":"out of gas"}
{"output":"","gasUsed":"0xb6c2b8","time":180880}
{"stateRoot": "437973ecce685dc890492b71c035a103098a5dce5e4c42944dec7456a1ce564f"}
[
  {
    "name": "BenchTest-16",
    "pass": true,
    "fork": "Istanbul"
  }
]
```

Expected:
```
./evm --json --nomemory statetest ~/github.com/MariusVanDerWijden/FuzzyVM/interesting_inputs/BenchTest-16.json
{"pc":0,"op":127,"gas":"0xb6c2b8","gasCost":"0x3","memory":"0x","memSize":0,"stack":[],"returnStack":null,"returnData":"0x","depth":1,"refund":0,"opName":"PUSH32","error":""}
{"pc":33,"op":99,"gas":"0xb6c2b5","gasCost":"0x3","memory":"0x","memSize":0,"stack":["0x564b34a33ecd1af05fe6923d6de71870997d38ef60155c325957214c4259d74b"],"returnStack":null,"returnData":"0x","depth":1,"refund":0,"opName":"PUSH4","error":""}
{"pc":38,"op":82,"gas":"0xb6c2b2","gasCost":"0x4268fec1b10","memory":"0x","memSize":0,"stack":["0x564b34a33ecd1af05fe6923d6de71870997d38ef60155c325957214c4259d74b","0x5c325957"],"returnStack":null,"returnData":"0x","depth":1,"refund":0,"opName":"MSTORE","error":"out of gas"}
{"output":"","gasUsed":"0xb6c2b8","time":180880,"error":"out of gas"}
{"stateRoot": "437973ecce685dc890492b71c035a103098a5dce5e4c42944dec7456a1ce564f"}
[
  {
    "name": "BenchTest-16",
    "pass": true,
    "fork": "Istanbul"
  }
]
```

The second line in the output is redundant:
```
{"output":"","gasUsed":"0xb6c2b8","time":180880,"error":"out of gas"}
{"output":"","gasUsed":"0xb6c2b8","time":180880}
```