### PR TITLE
EIP-1559 RPC changes

### DIFF
--- a/core/bench_test.go
+++ b/core/bench_test.go
@@ -112,7 +112,7 @@ func genTxRing(naccounts int) func(int, *BlockGen) {
 	from := 0
 	return func(i int, gen *BlockGen) {
 		block := gen.PrevBlock(i - 1)
-		gas := CalcGasLimit(block, block.GasLimit(), block.GasLimit())
+		gas := block.GasLimit()
 		for {
 			gas -= params.TxGas
 			if gas < params.TxGas {

--- a/core/block_validator.go
+++ b/core/block_validator.go
@@ -140,28 +140,24 @@ func CalcGasLimit(parentGasUsed, parentGasLimit, gasFloor, gasCeil uint64) uint6
 }
 
 // CalcGasLimit1559 calculates the next block gas limit under 1559 rules.
-func CalcGasLimit1559(parentGasUsed, parentGasLimit, gasFloor, gasCeil uint64) uint64 {
+func CalcGasLimit1559(parentGasLimit, desiredLimit uint64) uint64 {
 	delta := parentGasLimit/params.GasLimitBoundDivisor - 1
 	limit := parentGasLimit
-	if parentGasUsed > parentGasLimit/2 {
-		// Bump it
-		limit += delta
-	} else if parentGasUsed < parentGasLimit/2 {
-		limit -= delta
-	}
-	if limit < params.MinGasLimit {
-		limit = params.MinGasLimit
+	if desiredLimit < params.MinGasLimit {
+		desiredLimit = params.MinGasLimit
 	}
 	// If we're outside our allowed gas range, we try to hone towards them
-	if limit < gasFloor {
+	if limit < desiredLimit {
 		limit = parentGasLimit + delta
-		if limit > gasFloor {
-			limit = gasFloor
+		if limit > desiredLimit {
+			limit = desiredLimit
 		}
-	} else if limit > gasCeil {
+		return limit
+	}
+	if limit > desiredLimit {
 		limit = parentGasLimit - delta
-		if limit < gasCeil {
-			limit = gasCeil
+		if limit < desiredLimit {
+			limit = desiredLimit
 		}
 	}
 	return limit

--- a/core/block_validator.go
+++ b/core/block_validator.go
@@ -106,12 +106,12 @@ func (v *BlockValidator) ValidateState(block *types.Block, statedb *state.StateD
 // to keep the baseline gas above the provided floor, and increase it towards the
 // ceil if the blocks are full. If the ceil is exceeded, it will always decrease
 // the gas allowance.
-func CalcGasLimit(parent *types.Block, gasFloor, gasCeil uint64) uint64 {
+func CalcGasLimit(parentGasUsed, parentGasLimit, gasFloor, gasCeil uint64) uint64 {
 	// contrib = (parentGasUsed * 3 / 2) / 1024
-	contrib := (parent.GasUsed() + parent.GasUsed()/2) / params.GasLimitBoundDivisor
+	contrib := (parentGasUsed + parentGasUsed/2) / params.GasLimitBoundDivisor
 
 	// decay = parentGasLimit / 1024 -1
-	decay := parent.GasLimit()/params.GasLimitBoundDivisor - 1
+	decay := parentGasLimit/params.GasLimitBoundDivisor - 1
 
 	/*
 		strategy: gasLimit of block-to-mine is set based on parent's
@@ -120,18 +120,18 @@ func CalcGasLimit(parent *types.Block, gasFloor, gasCeil uint64) uint64 {
 		at that usage) the amount increased/decreased depends on how far away
 		from parentGasLimit * (2/3) parentGasUsed is.
 	*/
-	limit := parent.GasLimit() - decay + contrib
+	limit := parentGasLimit - decay + contrib
 	if limit < params.MinGasLimit {
 		limit = params.MinGasLimit
 	}
 	// If we're outside our allowed gas range, we try to hone towards them
 	if limit < gasFloor {
-		limit = parent.GasLimit() + decay
+		limit = parentGasLimit + decay
 		if limit > gasFloor {
 			limit = gasFloor
 		}
 	} else if limit > gasCeil {
-		limit = parent.GasLimit() - decay
+		limit = parentGasLimit - decay
 		if limit < gasCeil {
 			limit = gasCeil
 		}

--- a/core/block_validator.go
+++ b/core/block_validator.go
@@ -138,3 +138,31 @@ func CalcGasLimit(parentGasUsed, parentGasLimit, gasFloor, gasCeil uint64) uint6
 	}
 	return limit
 }
+
+// CalcGasLimit1559 calculates the next block gas limit under 1559 rules.
+func CalcGasLimit1559(parentGasUsed, parentGasLimit, gasFloor, gasCeil uint64) uint64 {
+	delta := parentGasLimit/params.GasLimitBoundDivisor - 1
+	limit := parentGasLimit
+	if parentGasUsed > parentGasLimit/2 {
+		// Bump it
+		limit += delta
+	} else if parentGasUsed < parentGasLimit/2 {
+		limit -= delta
+	}
+	if limit < params.MinGasLimit {
+		limit = params.MinGasLimit
+	}
+	// If we're outside our allowed gas range, we try to hone towards them
+	if limit < gasFloor {
+		limit = parentGasLimit + delta
+		if limit > gasFloor {
+			limit = gasFloor
+		}
+	} else if limit > gasCeil {
+		limit = parentGasLimit - delta
+		if limit < gasCeil {
+			limit = gasCeil
+		}
+	}
+	return limit
+}

--- a/core/block_validator_test.go
+++ b/core/block_validator_test.go
@@ -197,3 +197,36 @@ func testHeaderConcurrentAbortion(t *testing.T, threads int) {
 		t.Errorf("verification count too large: have %d, want below %d", verified, 2*threads)
 	}
 }
+
+func TestCalcGasLimit1559(t *testing.T) {
+
+	for i, tc := range []struct {
+		pGasLimit uint64
+		max       uint64
+		min       uint64
+	}{
+		{20000000, 20019530, 19980470},
+		{40000000, 40039061, 39960939},
+	} {
+		// Increase
+		if have, want := CalcGasLimit1559(tc.pGasLimit, 2*tc.pGasLimit), tc.max; have != want {
+			t.Errorf("test %d: have %d want <%d", i, have, want)
+		}
+		// Decrease
+		if have, want := CalcGasLimit1559(tc.pGasLimit, 0), tc.min; have != want {
+			t.Errorf("test %d: have %d want >%d", i, have, want)
+		}
+		// Small decrease
+		if have, want := CalcGasLimit1559(tc.pGasLimit, tc.pGasLimit-1), tc.pGasLimit-1; have != want {
+			t.Errorf("test %d: have %d want %d", i, have, want)
+		}
+		// Small increase
+		if have, want := CalcGasLimit1559(tc.pGasLimit, tc.pGasLimit+1), tc.pGasLimit+1; have != want {
+			t.Errorf("test %d: have %d want %d", i, have, want)
+		}
+		// No change
+		if have, want := CalcGasLimit1559(tc.pGasLimit, tc.pGasLimit), tc.pGasLimit; have != want {
+			t.Errorf("test %d: have %d want %d", i, have, want)
+		}
+	}
+}

--- a/core/chain_makers.go
+++ b/core/chain_makers.go
@@ -263,7 +263,7 @@ func makeHeader(chain consensus.ChainReader, parent *types.Block, state *state.S
 			Difficulty: parent.Difficulty(),
 			UncleHash:  parent.UncleHash(),
 		}),
-		GasLimit: CalcGasLimit(parent, parent.GasLimit(), parent.GasLimit()),
+		GasLimit: parent.GasLimit(),
 		Number:   new(big.Int).Add(parent.Number(), common.Big1),
 		Time:     time,
 	}

--- a/core/state_processor_test.go
+++ b/core/state_processor_test.go
@@ -208,7 +208,7 @@ func GenerateBadBlock(parent *types.Block, engine consensus.Engine, txs types.Tr
 			Difficulty: parent.Difficulty(),
 			UncleHash:  parent.UncleHash(),
 		}),
-		GasLimit:  CalcGasLimit(parent, parent.GasLimit(), parent.GasLimit()),
+		GasLimit:  parent.GasLimit(),
 		Number:    new(big.Int).Add(parent.Number(), common.Big1),
 		Time:      parent.Time() + 10,
 		UncleHash: types.EmptyUncleHash,

--- a/core/tx_list.go
+++ b/core/tx_list.go
@@ -287,7 +287,7 @@ func (l *txList) Add(tx *types.Transaction, priceBump uint64) (bool, *types.Tran
 		// Have to ensure that the new gas price is higher than the old gas
 		// price as well as checking the percentage threshold to ensure that
 		// this is accurate for low (Wei-level) gas price replacements
-		if old.GasPriceCmp(tx) >= 0 || tx.GasPriceIntCmp(threshold) < 0 {
+		if old.FeeCapCmp(tx) >= 0 || tx.FeeCapIntCmp(threshold) < 0 {
 			return false, nil
 		}
 	}
@@ -413,8 +413,8 @@ func (h priceHeap) Len() int      { return len(h) }
 func (h priceHeap) Swap(i, j int) { h[i], h[j] = h[j], h[i] }
 
 func (h priceHeap) Less(i, j int) bool {
-	// Sort primarily by price, returning the cheaper one
-	switch h[i].GasPriceCmp(h[j]) {
+	// Sort primarily by fee cap, returning the cheaper one
+	switch h[i].FeeCapCmp(h[j]) {
 	case -1:
 		return true
 	case 1:
@@ -491,7 +491,7 @@ func (l *txPricedList) Cap(threshold *big.Int) types.Transactions {
 			continue
 		}
 		// Stop the discards if we've reached the threshold
-		if cheapest.GasPriceIntCmp(threshold) >= 0 {
+		if cheapest.FeeCapIntCmp(threshold) >= 0 {
 			break
 		}
 		heap.Pop(l.remotes)
@@ -520,7 +520,7 @@ func (l *txPricedList) Underpriced(tx *types.Transaction) bool {
 	// If the remote transaction is even cheaper than the
 	// cheapest one tracked locally, reject it.
 	cheapest := []*types.Transaction(*l.remotes)[0]
-	return cheapest.GasPriceCmp(tx) >= 0
+	return cheapest.FeeCapCmp(tx) >= 0
 }
 
 // Discard finds a number of most underpriced transactions, removes them from the

--- a/core/tx_list.go
+++ b/core/tx_list.go
@@ -534,7 +534,8 @@ func (l *txPricedList) Underpriced(tx *types.Transaction) bool {
 	// If the remote transaction is even cheaper than the
 	// cheapest one tracked locally, reject it.
 	cheapest := []*types.Transaction(*l.remotes)[0]
-	return cheapest.FeeCapCmp(tx) >= 0
+	cmp := cheapest.FeeCapCmp(tx)
+	return cmp > 0 || (cmp == 0 && cheapest.TipCmp(tx) >= 0)
 }
 
 // Discard finds a number of most underpriced transactions, removes them from the

--- a/core/tx_list.go
+++ b/core/tx_list.go
@@ -489,31 +489,6 @@ func (l *txPricedList) Removed(count int) {
 	l.Reheap()
 }
 
-// Cap finds all the transactions below the given price threshold, drops them
-// from the priced list and returns them for further removal from the entire pool.
-//
-// Note: only remote transactions will be considered for eviction.
-// This function should only be used pre-EIP-1559 - it can only cap by fee cap, not tip
-func (l *txPricedList) Cap(threshold *big.Int) types.Transactions {
-	drop := make(types.Transactions, 0, 128) // Remote underpriced transactions to drop
-	for len(*l.remotes) > 0 {
-		// Discard stale transactions if found during cleanup
-		cheapest := (*l.remotes)[0]
-		if l.all.GetRemote(cheapest.Hash()) == nil { // Removed or migrated
-			heap.Pop(l.remotes)
-			l.stales--
-			continue
-		}
-		// Stop the discards if we've reached the threshold
-		if cheapest.FeeCapIntCmp(threshold) >= 0 {
-			break
-		}
-		heap.Pop(l.remotes)
-		drop = append(drop, cheapest)
-	}
-	return drop
-}
-
 // Underpriced checks whether a transaction is cheaper than (or as cheap as) the
 // lowest priced (remote) transaction currently being tracked.
 func (l *txPricedList) Underpriced(tx *types.Transaction) bool {

--- a/core/tx_list.go
+++ b/core/tx_list.go
@@ -280,20 +280,20 @@ func (l *txList) Add(tx *types.Transaction, priceBump uint64) (bool, *types.Tran
 	old := l.txs.Get(tx.Nonce())
 	if old != nil {
 		// thresholdFeeCap = oldFC  * (100 + priceBump) / 100
-		// thresholdTip    = oldTip * (100 + priceBump) / 100
 		a := big.NewInt(100 + int64(priceBump))
 		aFeeCap := new(big.Int).Mul(a, old.FeeCap())
 		aTip := a.Mul(a, old.Tip())
+
+		// thresholdTip    = oldTip * (100 + priceBump) / 100
 		b := big.NewInt(100)
 		thresholdFeeCap := aFeeCap.Div(aFeeCap, b)
 		thresholdTip := aTip.Div(aTip, b)
-		// Have to ensure that the new fee cap and tip are both higher than the old
-		// ones as well as checking the percentage threshold to ensure that
+
+		// Have to ensure that either the new fee cap or tip is higher than the
+		// old ones as well as checking the percentage threshold to ensure that
 		// this is accurate for low (Wei-level) gas price replacements
-		if old.FeeCapCmp(tx) >= 0 || tx.FeeCapIntCmp(thresholdFeeCap) < 0 {
-			return false, nil
-		}
-		if old.TipCmp(tx) >= 0 || tx.TipIntCmp(thresholdTip) < 0 {
+		if (old.FeeCapCmp(tx) >= 0 || tx.FeeCapIntCmp(thresholdFeeCap) < 0) &&
+			(old.TipCmp(tx) >= 0 || tx.TipIntCmp(thresholdTip) < 0) {
 			return false, nil
 		}
 	}

--- a/core/tx_list.go
+++ b/core/tx_list.go
@@ -292,7 +292,7 @@ func (l *txList) Add(tx *types.Transaction, priceBump uint64) (bool, *types.Tran
 		// Have to ensure that either the new fee cap or tip is higher than the
 		// old ones as well as checking the percentage threshold to ensure that
 		// this is accurate for low (Wei-level) gas price replacements
-		if (old.FeeCapCmp(tx) >= 0 || tx.FeeCapIntCmp(thresholdFeeCap) < 0) &&
+		if (old.FeeCapCmp(tx) >= 0 || tx.FeeCapIntCmp(thresholdFeeCap) < 0) ||
 			(old.TipCmp(tx) >= 0 || tx.TipIntCmp(thresholdTip) < 0) {
 			return false, nil
 		}

--- a/core/tx_pool.go
+++ b/core/tx_pool.go
@@ -545,8 +545,8 @@ func (pool *TxPool) validateTx(tx *types.Transaction, local bool) error {
 	if err != nil {
 		return ErrInvalidSender
 	}
-	// Drop non-local transactions under our own minimal accepted gas price
-	if !local && tx.GasPriceIntCmp(pool.gasPrice) < 0 {
+	// Drop non-local transactions under our own minimal accepted gas price or tip
+	if !local && tx.TipIntCmp(pool.gasPrice) < 0 {
 		return ErrUnderpriced
 	}
 	// Ensure the transaction adheres to nonce ordering

--- a/core/tx_pool.go
+++ b/core/tx_pool.go
@@ -233,7 +233,7 @@ type TxPool struct {
 	mu          sync.RWMutex
 
 	istanbul bool // Fork indicator whether we are in the istanbul stage.
-	eip2718  bool // Fork indicator whether we are using EIp-2718 type transactions.
+	eip2718  bool // Fork indicator whether we are using EIP-2718 type transactions.
 	eip1559  bool // Fork indicator whether we are using EIP-1559 type transactions.
 
 	currentState  *state.StateDB // Current state in the blockchain head

--- a/core/tx_pool.go
+++ b/core/tx_pool.go
@@ -435,18 +435,12 @@ func (pool *TxPool) SetGasPrice(price *big.Int) {
 	pool.gasPrice = price
 	// if the min miner fee increased, remove transactions below the new threshold
 	if price.Cmp(old) > 0 {
-		if !pool.eip1559 {
-			for _, tx := range pool.priced.Cap(price) {
-				pool.removeTx(tx.Hash(), false)
-			}
-		} else {
-			// pool.priced is sorted by FeeCap, so we have to iterate through pool.all instead
-			drop := pool.all.RemotesBelowTip(price)
-			for _, tx := range drop {
-				pool.removeTx(tx.Hash(), false)
-			}
-			pool.priced.Removed(len(drop))
+		// pool.priced is sorted by FeeCap, so we have to iterate through pool.all instead
+		drop := pool.all.RemotesBelowTip(price)
+		for _, tx := range drop {
+			pool.removeTx(tx.Hash(), false)
 		}
+		pool.priced.Removed(len(drop))
 	}
 
 	log.Info("Transaction pool miner fee threshold updated", "fee", price)

--- a/core/tx_pool.go
+++ b/core/tx_pool.go
@@ -1222,7 +1222,7 @@ func (pool *TxPool) reset(oldHead, newHead *types.Header) {
 	next := new(big.Int).Add(newHead.Number, big.NewInt(1))
 	pool.istanbul = pool.chainconfig.IsIstanbul(next)
 	pool.eip2718 = pool.chainconfig.IsBerlin(next)
-	pool.eip1559 = pool.chainconfig.IsAleut(next)
+	pool.eip1559 = pool.chainconfig.IsLondon(next)
 
 	// For EIP-1559, adjust the gas limit by the elasticity multiplier
 	if pool.eip1559 {

--- a/core/tx_pool.go
+++ b/core/tx_pool.go
@@ -443,7 +443,7 @@ func (pool *TxPool) SetGasPrice(price *big.Int) {
 		pool.priced.Removed(len(drop))
 	}
 
-	log.Info("Transaction pool miner fee threshold updated", "fee", price)
+	log.Info("Transaction pool price threshold updated", "price", price)
 }
 
 // Nonce returns the next nonce of an account, with all transactions executable

--- a/core/tx_pool.go
+++ b/core/tx_pool.go
@@ -1223,11 +1223,6 @@ func (pool *TxPool) reset(oldHead, newHead *types.Header) {
 	pool.istanbul = pool.chainconfig.IsIstanbul(next)
 	pool.eip2718 = pool.chainconfig.IsBerlin(next)
 	pool.eip1559 = pool.chainconfig.IsLondon(next)
-
-	// For EIP-1559, adjust the gas limit by the elasticity multiplier
-	if pool.eip1559 {
-		pool.currentMaxGas *= params.ElasticityMultiplier
-	}
 }
 
 // promoteExecutables moves transactions that have become processable from the

--- a/core/tx_pool_test.go
+++ b/core/tx_pool_test.go
@@ -347,6 +347,21 @@ func TestTransactionNegativeValue(t *testing.T) {
 	}
 }
 
+func TestTransactionTypeNotSupported(t *testing.T) {
+	t.Parallel()
+
+	pool, key := setupTxPool()
+	defer pool.Stop()
+
+	// cannot use dynamicFeeTransaction() here for now as it uses the Aleut testnet ChainID
+	tx := types.NewDynamicFeeTransaction(pool.chainconfig.ChainID, 0, common.Address{}, big.NewInt(100), 100, big.NewInt(1), big.NewInt(1), nil, nil)
+	tx, _ = types.SignTx(tx, types.NewEIP2718Signer(pool.chainconfig.ChainID), key)
+
+	if err := pool.AddRemote(tx); err != ErrTxTypeNotSupported {
+		t.Error("expected", ErrTxTypeNotSupported, "got", err)
+	}
+}
+
 func TestTransactionChainFork(t *testing.T) {
 	t.Parallel()
 

--- a/core/tx_pool_test.go
+++ b/core/tx_pool_test.go
@@ -87,6 +87,12 @@ func pricedDataTransaction(nonce uint64, gaslimit uint64, gasprice *big.Int, key
 	return tx
 }
 
+func dynamicFeeTransaction(nonce uint64, gaslimit uint64, gasFee *big.Int, tip *big.Int, key *ecdsa.PrivateKey) *types.Transaction {
+	tx := types.NewDynamicFeeTransaction(params.AleutChainConfig.ChainID, nonce, common.Address{}, big.NewInt(100), gaslimit, gasFee, tip, nil, nil)
+	tx, _ = types.SignTx(tx, types.NewEIP2718Signer(params.AleutChainConfig.ChainID), key)
+	return tx
+}
+
 func setupTxPool() (*TxPool, *ecdsa.PrivateKey) {
 	statedb, _ := state.New(common.Hash{}, state.NewDatabase(rawdb.NewMemoryDatabase()), nil)
 	blockchain := &testBlockChain{statedb, 10000000, new(event.Feed)}

--- a/core/tx_pool_test.go
+++ b/core/tx_pool_test.go
@@ -1415,10 +1415,7 @@ func TestTransactionPoolRepricingDynamicFee(t *testing.T) {
 	t.Parallel()
 
 	// Create the pool to test the pricing enforcement with
-	statedb, _ := state.New(common.Hash{}, state.NewDatabase(rawdb.NewMemoryDatabase()), nil)
-	blockchain := &testBlockChain{statedb, 1000000, new(event.Feed)}
-
-	pool := NewTxPool(testTxPoolConfig, params.AleutChainConfig, blockchain)
+	pool, _ := setupTxPoolWithConfig(params.AleutChainConfig)
 	defer pool.Stop()
 
 	// Keep track of transaction events to ensure all executables get announced
@@ -1555,14 +1552,14 @@ func TestTransactionPoolRepricingKeepsLocals(t *testing.T) {
 		pool.currentState.AddBalance(crypto.PubkeyToAddress(keys[i].PublicKey), big.NewInt(1000*1000000))
 	}
 	// Create transaction (both pending and queued) with a linearly growing gasprice
-	for i := uint64(0); i < 250; i++ {
+	for i := uint64(0); i < 500; i++ {
 		// Add pending transaction.
 		pendingTx := pricedTransaction(i, 100000, big.NewInt(int64(i)), keys[2])
 		if err := pool.AddLocal(pendingTx); err != nil {
 			t.Fatal(err)
 		}
 		// Add queued transaction.
-		queuedTx := pricedTransaction(i+251, 100000, big.NewInt(int64(i)), keys[2])
+		queuedTx := pricedTransaction(i+501, 100000, big.NewInt(int64(i)), keys[2])
 		if err := pool.AddLocal(queuedTx); err != nil {
 			t.Fatal(err)
 		}
@@ -1573,13 +1570,13 @@ func TestTransactionPoolRepricingKeepsLocals(t *testing.T) {
 			t.Fatal(err)
 		}
 		// Add queued dynamic fee transaction.
-		queuedTx = dynamicFeeTx(i+251, 100000, big.NewInt(int64(i)+1), big.NewInt(int64(i)), keys[1])
+		queuedTx = dynamicFeeTx(i+501, 100000, big.NewInt(int64(i)+1), big.NewInt(int64(i)), keys[1])
 		if err := pool.AddLocal(queuedTx); err != nil {
 			t.Fatal(err)
 		}
 	}
 	pending, queued := pool.Stats()
-	expPending, expQueued := 500, 500
+	expPending, expQueued := 1000, 1000
 	validate := func() {
 		pending, queued = pool.Stats()
 		if pending != expPending {

--- a/core/types/block.go
+++ b/core/types/block.go
@@ -84,7 +84,7 @@ type Header struct {
 	Nonce       BlockNonce     `json:"nonce"`
 
 	// BaseFee was added by EIP-1559 and is ignored in legacy headers.
-	BaseFee *big.Int `json:"baseFee" rlp:"optional"`
+	BaseFee *big.Int `json:"baseFeePerGas" rlp:"optional"`
 }
 
 // field type overrides for gencodec

--- a/core/types/gen_header_json.go
+++ b/core/types/gen_header_json.go
@@ -31,6 +31,7 @@ func (h Header) MarshalJSON() ([]byte, error) {
 		Extra       hexutil.Bytes  `json:"extraData"        gencodec:"required"`
 		MixDigest   common.Hash    `json:"mixHash"`
 		Nonce       BlockNonce     `json:"nonce"`
+		BaseFee     *hexutil.Big   `json:"baseFeePerGas" rlp:"optional"`
 		Hash        common.Hash    `json:"hash"`
 	}
 	var enc Header
@@ -49,6 +50,7 @@ func (h Header) MarshalJSON() ([]byte, error) {
 	enc.Extra = h.Extra
 	enc.MixDigest = h.MixDigest
 	enc.Nonce = h.Nonce
+	enc.BaseFee = (*hexutil.Big)(h.BaseFee)
 	enc.Hash = h.Hash()
 	return json.Marshal(&enc)
 }
@@ -71,6 +73,7 @@ func (h *Header) UnmarshalJSON(input []byte) error {
 		Extra       *hexutil.Bytes  `json:"extraData"        gencodec:"required"`
 		MixDigest   *common.Hash    `json:"mixHash"`
 		Nonce       *BlockNonce     `json:"nonce"`
+		BaseFee     *hexutil.Big    `json:"baseFeePerGas" rlp:"optional"`
 	}
 	var dec Header
 	if err := json.Unmarshal(input, &dec); err != nil {
@@ -133,6 +136,9 @@ func (h *Header) UnmarshalJSON(input []byte) error {
 	}
 	if dec.Nonce != nil {
 		h.Nonce = *dec.Nonce
+	}
+	if dec.BaseFee != nil {
+		h.BaseFee = (*big.Int)(dec.BaseFee)
 	}
 	return nil
 }

--- a/core/types/transaction.go
+++ b/core/types/transaction.go
@@ -450,27 +450,27 @@ func NewTxWithMinerFee(tx *Transaction, baseFee *big.Int) *TxWithMinerFee {
 	}
 }
 
-// TxByPriceAndTime implements both the sort and the heap interface, making it useful
+// TxByMinerFeeAndTime implements both the sort and the heap interface, making it useful
 // for all at once sorting as well as individually adding and removing elements.
-type TxByPriceAndTime Transactions
+type TxByMinerFeeAndTime []*TxWithMinerFee
 
-func (s TxByPriceAndTime) Len() int { return len(s) }
-func (s TxByPriceAndTime) Less(i, j int) bool {
+func (s TxByMinerFeeAndTime) Len() int { return len(s) }
+func (s TxByMinerFeeAndTime) Less(i, j int) bool {
 	// If the prices are equal, use the time the transaction was first seen for
 	// deterministic sorting
-	cmp := s[i].GasPrice().Cmp(s[j].GasPrice())
+	cmp := s[i].minerFee.Cmp(s[j].minerFee)
 	if cmp == 0 {
-		return s[i].time.Before(s[j].time)
+		return s[i].tx.time.Before(s[j].tx.time)
 	}
 	return cmp > 0
 }
-func (s TxByPriceAndTime) Swap(i, j int) { s[i], s[j] = s[j], s[i] }
+func (s TxByMinerFeeAndTime) Swap(i, j int) { s[i], s[j] = s[j], s[i] }
 
-func (s *TxByPriceAndTime) Push(x interface{}) {
-	*s = append(*s, x.(*Transaction))
+func (s *TxByMinerFeeAndTime) Push(x interface{}) {
+	*s = append(*s, x.(*TxWithMinerFee))
 }
 
-func (s *TxByPriceAndTime) Pop() interface{} {
+func (s *TxByMinerFeeAndTime) Pop() interface{} {
 	old := *s
 	n := len(old)
 	x := old[n-1]
@@ -478,65 +478,69 @@ func (s *TxByPriceAndTime) Pop() interface{} {
 	return x
 }
 
-// TransactionsByPriceAndNonce represents a set of transactions that can return
+// TransactionsByMinerFeeAndNonce represents a set of transactions that can return
 // transactions in a profit-maximizing sorted order, while supporting removing
 // entire batches of transactions for non-executable accounts.
-type TransactionsByPriceAndNonce struct {
-	txs    map[common.Address]Transactions // Per account nonce-sorted list of transactions
-	heads  TxByPriceAndTime                // Next transaction for each unique account (price heap)
-	signer Signer                          // Signer for the set of transactions
+type TransactionsByMinerFeeAndNonce struct {
+	txs     map[common.Address]Transactions // Per account nonce-sorted list of transactions
+	heads   TxByMinerFeeAndTime             // Next transaction for each unique account (price heap)
+	signer  Signer                          // Signer for the set of transactions
+	baseFee *big.Int                        // Current base fee
 }
 
-// NewTransactionsByPriceAndNonce creates a transaction set that can retrieve
+// NewTransactionsByMinerFeeAndNonce creates a transaction set that can retrieve
 // price sorted transactions in a nonce-honouring way.
 //
 // Note, the input map is reowned so the caller should not interact any more with
 // if after providing it to the constructor.
-func NewTransactionsByPriceAndNonce(signer Signer, txs map[common.Address]Transactions) *TransactionsByPriceAndNonce {
+func NewTransactionsByMinerFeeAndNonce(signer Signer, txs map[common.Address]Transactions, baseFee *big.Int) *TransactionsByMinerFeeAndNonce {
 	// Initialize a price and received time based heap with the head transactions
-	heads := make(TxByPriceAndTime, 0, len(txs))
+	heads := make(TxByMinerFeeAndTime, 0, len(txs))
 	for from, accTxs := range txs {
-		// Ensure the sender address is from the signer
-		if acc, _ := Sender(signer, accTxs[0]); acc != from {
+		wrapped := NewTxWithMinerFee(accTxs[0], baseFee)
+		if wrapped == nil {
 			delete(txs, from)
 			continue
 		}
-		heads = append(heads, accTxs[0])
+		heads = append(heads, wrapped)
 		txs[from] = accTxs[1:]
 	}
 	heap.Init(&heads)
 
 	// Assemble and return the transaction set
-	return &TransactionsByPriceAndNonce{
-		txs:    txs,
-		heads:  heads,
-		signer: signer,
+	return &TransactionsByMinerFeeAndNonce{
+		txs:     txs,
+		heads:   heads,
+		signer:  signer,
+		baseFee: baseFee,
 	}
 }
 
 // Peek returns the next transaction by price.
-func (t *TransactionsByPriceAndNonce) Peek() *Transaction {
+func (t *TransactionsByMinerFeeAndNonce) Peek() *Transaction {
 	if len(t.heads) == 0 {
 		return nil
 	}
-	return t.heads[0]
+	return t.heads[0].tx
 }
 
 // Shift replaces the current best head with the next one from the same account.
-func (t *TransactionsByPriceAndNonce) Shift() {
-	acc, _ := Sender(t.signer, t.heads[0])
+func (t *TransactionsByMinerFeeAndNonce) Shift() {
+	acc, _ := Sender(t.signer, t.heads[0].tx)
 	if txs, ok := t.txs[acc]; ok && len(txs) > 0 {
-		t.heads[0], t.txs[acc] = txs[0], txs[1:]
-		heap.Fix(&t.heads, 0)
-	} else {
-		heap.Pop(&t.heads)
+		if wrapped := NewTxWithMinerFee(txs[0], t.baseFee); wrapped != nil {
+			t.heads[0], t.txs[acc] = wrapped, txs[1:]
+			heap.Fix(&t.heads, 0)
+			return
+		}
 	}
+	heap.Pop(&t.heads)
 }
 
 // Pop removes the best transaction, *not* replacing it with the next one from
 // the same account. This should be used when a transaction cannot be executed
 // and hence all subsequent ones should be discarded from the same account.
-func (t *TransactionsByPriceAndNonce) Pop() {
+func (t *TransactionsByMinerFeeAndNonce) Pop() {
 	heap.Pop(&t.heads)
 }
 

--- a/core/types/transaction.go
+++ b/core/types/transaction.go
@@ -493,7 +493,7 @@ type TransactionsByMinerFeeAndNonce struct {
 //
 // Note, the input map is reowned so the caller should not interact any more with
 // if after providing it to the constructor.
-func NewTransactionsByMinerFeeAndNonce(signer Signer, txs map[common.Address]Transactions, baseFee *big.Int) *TransactionsByMinerFeeAndNonce {
+func NewTransactionsByPriceAndNonce(signer Signer, txs map[common.Address]Transactions, baseFee *big.Int) *TransactionsByMinerFeeAndNonce {
 	// Initialize a price and received time based heap with the head transactions
 	heads := make(TxByMinerFeeAndTime, 0, len(txs))
 	for from, accTxs := range txs {

--- a/core/types/transaction.go
+++ b/core/types/transaction.go
@@ -501,8 +501,10 @@ func NewTransactionsByPriceAndNonce(signer Signer, txs map[common.Address]Transa
 	// Initialize a price and received time based heap with the head transactions
 	heads := make(TxByPriceAndTime, 0, len(txs))
 	for from, accTxs := range txs {
+		acc, _ := Sender(signer, accTxs[0])
 		wrapped, err := NewTxWithMinerFee(accTxs[0], baseFee)
-		if err != nil {
+		// Remove transaction if sender doesn't match from, or if wrapping fails.
+		if acc != from || err != nil {
 			delete(txs, from)
 			continue
 		}

--- a/core/types/transaction.go
+++ b/core/types/transaction.go
@@ -315,15 +315,22 @@ func (tx *Transaction) GasPriceIntCmp(other *big.Int) int {
 	return tx.inner.gasPrice().Cmp(other)
 }
 
+// FeeCapCmp compares the fee cap of two transactions.
 func (tx *Transaction) FeeCapCmp(other *Transaction) int {
 	return tx.inner.feeCap().Cmp(other.inner.feeCap())
 }
+
+// FeeCapIntCmp compares the fee cap of the transaction against the given fee cap.
 func (tx *Transaction) FeeCapIntCmp(other *big.Int) int {
 	return tx.inner.feeCap().Cmp(other)
 }
+
+// TipCmp compares the tip of two transactions.
 func (tx *Transaction) TipCmp(other *Transaction) int {
 	return tx.inner.tip().Cmp(other.inner.tip())
 }
+
+// TipIntCmp compares the tip of the transaction against the given tip.
 func (tx *Transaction) TipIntCmp(other *big.Int) int {
 	return tx.inner.tip().Cmp(other)
 }

--- a/core/types/transaction.go
+++ b/core/types/transaction.go
@@ -315,6 +315,19 @@ func (tx *Transaction) GasPriceIntCmp(other *big.Int) int {
 	return tx.inner.gasPrice().Cmp(other)
 }
 
+func (tx *Transaction) FeeCapCmp(other *Transaction) int {
+	return tx.inner.feeCap().Cmp(other.inner.feeCap())
+}
+func (tx *Transaction) FeeCapIntCmp(other *big.Int) int {
+	return tx.inner.feeCap().Cmp(other)
+}
+func (tx *Transaction) TipCmp(other *Transaction) int {
+	return tx.inner.tip().Cmp(other.inner.tip())
+}
+func (tx *Transaction) TipIntCmp(other *big.Int) int {
+	return tx.inner.tip().Cmp(other)
+}
+
 // Hash returns the transaction hash.
 func (tx *Transaction) Hash() common.Hash {
 	if hash := tx.hash.Load(); hash != nil {

--- a/core/types/transaction_test.go
+++ b/core/types/transaction_test.go
@@ -279,7 +279,7 @@ func TestTransactionPriceNonceSort(t *testing.T) {
 		}
 	}
 	// Sort the transactions and cross check the nonce ordering
-	txset := NewTransactionsByPriceAndNonce(signer, groups)
+	txset := NewTransactionsByMinerFeeAndNonce(signer, groups, nil)
 
 	txs := Transactions{}
 	for tx := txset.Peek(); tx != nil; tx = txset.Peek() {
@@ -331,7 +331,7 @@ func TestTransactionTimeSort(t *testing.T) {
 		groups[addr] = append(groups[addr], tx)
 	}
 	// Sort the transactions and cross check the nonce ordering
-	txset := NewTransactionsByPriceAndNonce(signer, groups)
+	txset := NewTransactionsByMinerFeeAndNonce(signer, groups, nil)
 
 	txs := Transactions{}
 	for tx := txset.Peek(); tx != nil; tx = txset.Peek() {

--- a/core/types/transaction_test.go
+++ b/core/types/transaction_test.go
@@ -278,7 +278,7 @@ func testTransactionPriceNonceSort(t *testing.T, baseFee *big.Int) {
 	for i := 0; i < len(keys); i++ {
 		keys[i], _ = crypto.GenerateKey()
 	}
-	signer := NewEIP2930Signer(big.NewInt(0))
+	signer := LatestSignerForChainID(common.Big1)
 
 	// Generate a batch of transactions with overlapping values, but shifted nonces
 	groups := map[common.Address]Transactions{}
@@ -312,7 +312,10 @@ func testTransactionPriceNonceSort(t *testing.T, baseFee *big.Int) {
 					count = i
 				}
 			}
-			tx, _ = SignTx(tx, signer, key)
+			tx, err := SignTx(tx, signer, key)
+			if err != nil {
+				t.Fatalf("failed to sign tx: %s", err)
+			}
 			groups[addr] = append(groups[addr], tx)
 		}
 		expectedCount += count

--- a/core/types/transaction_test.go
+++ b/core/types/transaction_test.go
@@ -22,6 +22,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"math/big"
+	"math/rand"
 	"reflect"
 	"testing"
 	"time"
@@ -258,36 +259,74 @@ func TestRecipientNormal(t *testing.T) {
 	}
 }
 
+func TestTransactionPriceNonceSortLegacy(t *testing.T) {
+	testTransactionPriceNonceSort(t, nil)
+}
+
+func TestTransactionPriceNonceSort1559(t *testing.T) {
+	testTransactionPriceNonceSort(t, big.NewInt(0))
+	testTransactionPriceNonceSort(t, big.NewInt(5))
+	testTransactionPriceNonceSort(t, big.NewInt(50))
+}
+
 // Tests that transactions can be correctly sorted according to their price in
 // decreasing order, but at the same time with increasing nonces when issued by
 // the same account.
-func TestTransactionPriceNonceSort(t *testing.T) {
+func testTransactionPriceNonceSort(t *testing.T, baseFee *big.Int) {
 	// Generate a batch of accounts to start with
 	keys := make([]*ecdsa.PrivateKey, 25)
 	for i := 0; i < len(keys); i++ {
 		keys[i], _ = crypto.GenerateKey()
 	}
-	signer := HomesteadSigner{}
+	signer := NewEIP2930Signer(big.NewInt(0))
 
 	// Generate a batch of transactions with overlapping values, but shifted nonces
 	groups := map[common.Address]Transactions{}
+	expectedCount := 0
 	for start, key := range keys {
 		addr := crypto.PubkeyToAddress(key.PublicKey)
+		count := 25
 		for i := 0; i < 25; i++ {
-			tx, _ := SignTx(NewTransaction(uint64(start+i), common.Address{}, big.NewInt(100), 100, big.NewInt(int64(start+i)), nil), signer, key)
+			var tx *Transaction
+			feeCap := rand.Intn(50)
+			if baseFee == nil {
+				tx = NewTx(&LegacyTx{
+					Nonce:    uint64(start + i),
+					To:       &common.Address{},
+					Value:    big.NewInt(100),
+					Gas:      100,
+					GasPrice: big.NewInt(int64(feeCap)),
+					Data:     nil,
+				})
+			} else {
+				tx = NewTx(&DynamicFeeTx{
+					Nonce:  uint64(start + i),
+					To:     &common.Address{},
+					Value:  big.NewInt(100),
+					Gas:    100,
+					FeeCap: big.NewInt(int64(feeCap)),
+					Tip:    big.NewInt(int64(rand.Intn(feeCap + 1))),
+					Data:   nil,
+				})
+				if count == 25 && int64(feeCap) < baseFee.Int64() {
+					count = i
+				}
+			}
+			tx, _ = SignTx(tx, signer, key)
 			groups[addr] = append(groups[addr], tx)
 		}
+		expectedCount += count
 	}
 	// Sort the transactions and cross check the nonce ordering
-	txset := NewTransactionsByPriceAndNonce(signer, groups, nil)
+	txset := NewTransactionsByPriceAndNonce(signer, groups, baseFee)
 
 	txs := Transactions{}
 	for tx := txset.Peek(); tx != nil; tx = txset.Peek() {
 		txs = append(txs, tx)
 		txset.Shift()
 	}
-	if len(txs) != 25*25 {
-		t.Errorf("expected %d transactions, found %d", 25*25, len(txs))
+	if len(txs) != expectedCount {
+		t.Errorf("expected %d transactions, found %d", expectedCount, len(txs))
 	}
 	for i, txi := range txs {
 		fromi, _ := Sender(signer, txi)
@@ -303,7 +342,12 @@ func TestTransactionPriceNonceSort(t *testing.T) {
 		if i+1 < len(txs) {
 			next := txs[i+1]
 			fromNext, _ := Sender(signer, next)
-			if fromi != fromNext && txi.GasPrice().Cmp(next.GasPrice()) < 0 {
+			tip, err := txi.EffectiveTip(baseFee)
+			nextTip, nextErr := next.EffectiveTip(baseFee)
+			if err != nil || nextErr != nil {
+				t.Errorf("error calculating effective tip")
+			}
+			if fromi != fromNext && tip.Cmp(nextTip) < 0 {
 				t.Errorf("invalid gasprice ordering: tx #%d (A=%x P=%v) < tx #%d (A=%x P=%v)", i, fromi[:4], txi.GasPrice(), i+1, fromNext[:4], next.GasPrice())
 			}
 		}

--- a/core/types/transaction_test.go
+++ b/core/types/transaction_test.go
@@ -279,7 +279,7 @@ func TestTransactionPriceNonceSort(t *testing.T) {
 		}
 	}
 	// Sort the transactions and cross check the nonce ordering
-	txset := NewTransactionsByMinerFeeAndNonce(signer, groups, nil)
+	txset := NewTransactionsByPriceAndNonce(signer, groups, nil)
 
 	txs := Transactions{}
 	for tx := txset.Peek(); tx != nil; tx = txset.Peek() {
@@ -331,7 +331,7 @@ func TestTransactionTimeSort(t *testing.T) {
 		groups[addr] = append(groups[addr], tx)
 	}
 	// Sort the transactions and cross check the nonce ordering
-	txset := NewTransactionsByMinerFeeAndNonce(signer, groups, nil)
+	txset := NewTransactionsByPriceAndNonce(signer, groups, nil)
 
 	txs := Transactions{}
 	for tx := txset.Peek(); tx != nil; tx = txset.Peek() {

--- a/eth/api_backend.go
+++ b/eth/api_backend.go
@@ -276,7 +276,15 @@ func (b *EthAPIBackend) Downloader() *downloader.Downloader {
 }
 
 func (b *EthAPIBackend) SuggestPrice(ctx context.Context) (*big.Int, error) {
-	return b.gpo.SuggestPrice(ctx)
+	return b.gpo.SuggestPrice(ctx, false)
+}
+
+func (b *EthAPIBackend) SuggestTip(ctx context.Context) (*big.Int, error) {
+	return b.gpo.SuggestPrice(ctx, true)
+}
+
+func (b *EthAPIBackend) SuggestFeeCap(ctx context.Context) (*big.Int, error) {
+	return new(big.Int).Mul(b.CurrentBlock().BaseFee(), common.Big2), nil
 }
 
 func (b *EthAPIBackend) ChainDb() ethdb.Database {

--- a/eth/catalyst/api.go
+++ b/eth/catalyst/api.go
@@ -155,7 +155,7 @@ func (api *consensusAPI) AssembleBlock(params assembleBlockParams) (*executableD
 
 	var (
 		signer       = types.MakeSigner(bc.Config(), header.Number)
-		txHeap       = types.NewTransactionsByPriceAndNonce(signer, pending)
+		txHeap       = types.NewTransactionsByPriceAndNonce(signer, pending, nil)
 		transactions []*types.Transaction
 	)
 	for {

--- a/eth/gasprice/gasprice.go
+++ b/eth/gasprice/gasprice.go
@@ -194,8 +194,6 @@ type SortableTxs interface {
 
 type transactionsByGasPrice []*types.Transaction
 
-func makeTxsByGasPrice(txs []*types.Transaction) SortableTxs { return transactionsByGasPrice(txs) }
-
 func (t transactionsByGasPrice) Len() int                                { return len(t) }
 func (t transactionsByGasPrice) Swap(i, j int)                           { t[i], t[j] = t[j], t[i] }
 func (t transactionsByGasPrice) Less(i, j int) bool                      { return t[i].GasPriceCmp(t[j]) < 0 }
@@ -203,8 +201,6 @@ func (t transactionsByGasPrice) GasPrice(i int) *big.Int                 { retur
 func (t transactionsByGasPrice) EffectiveTip(i int, b *big.Int) *big.Int { return nil }
 
 type transactionsByTip []*types.Transaction
-
-func makeTxsByTip(txs []*types.Transaction) SortableTxs { return transactionsByGasPrice(txs) }
 
 func (t transactionsByTip) Len() int                { return len(t) }
 func (t transactionsByTip) Swap(i, j int)           { t[i], t[j] = t[j], t[i] }

--- a/eth/gasprice/gasprice.go
+++ b/eth/gasprice/gasprice.go
@@ -103,9 +103,9 @@ func NewOracle(backend OracleBackend, params Config) *Oracle {
 	}
 }
 
-// SuggestPrice returns a gasprice so that newly created transaction can
-// have a very high chance to be included in the following blocks.
-func (gpo *Oracle) SuggestPrice(ctx context.Context) (*big.Int, error) {
+// SuggestPrice returns a gasprice or tip so that newly created transaction
+// can have a very high chance to be included in the following blocks.
+func (gpo *Oracle) SuggestPrice(ctx context.Context, tip bool) (*big.Int, error) {
 	head, _ := gpo.backend.HeaderByNumber(ctx, rpc.LatestBlockNumber)
 	headHash := head.Hash()
 
@@ -129,12 +129,12 @@ func (gpo *Oracle) SuggestPrice(ctx context.Context) (*big.Int, error) {
 	var (
 		sent, exp int
 		number    = head.Number.Uint64()
-		result    = make(chan getBlockPricesResult, gpo.checkBlocks)
+		result    = make(chan results, gpo.checkBlocks)
 		quit      = make(chan struct{})
 		txPrices  []*big.Int
 	)
 	for sent < gpo.checkBlocks && number > 0 {
-		go gpo.getBlockPrices(ctx, types.MakeSigner(gpo.backend.ChainConfig(), big.NewInt(int64(number))), number, sampleNumber, gpo.ignorePrice, result, quit)
+		go gpo.getBlockValues(ctx, tip, types.MakeSigner(gpo.backend.ChainConfig(), big.NewInt(int64(number))), number, sampleNumber, gpo.ignorePrice, result, quit)
 		sent++
 		exp++
 		number--
@@ -150,19 +150,19 @@ func (gpo *Oracle) SuggestPrice(ctx context.Context) (*big.Int, error) {
 		// - The block is empty
 		// - All the transactions included are sent by the miner itself.
 		// In these cases, use the latest calculated price for samping.
-		if len(res.prices) == 0 {
-			res.prices = []*big.Int{lastPrice}
+		if len(res.values) == 0 {
+			res.values = []*big.Int{lastPrice}
 		}
 		// Besides, in order to collect enough data for sampling, if nothing
 		// meaningful returned, try to query more blocks. But the maximum
 		// is 2*checkBlocks.
-		if len(res.prices) == 1 && len(txPrices)+1+exp < gpo.checkBlocks*2 && number > 0 {
-			go gpo.getBlockPrices(ctx, types.MakeSigner(gpo.backend.ChainConfig(), big.NewInt(int64(number))), number, sampleNumber, gpo.ignorePrice, result, quit)
+		if len(res.values) == 1 && len(txPrices)+1+exp < gpo.checkBlocks*2 && number > 0 {
+			go gpo.getBlockValues(ctx, tip, types.MakeSigner(gpo.backend.ChainConfig(), big.NewInt(int64(number))), number, sampleNumber, gpo.ignorePrice, result, quit)
 			sent++
 			exp++
 			number--
 		}
-		txPrices = append(txPrices, res.prices...)
+		txPrices = append(txPrices, res.values...)
 	}
 	price := lastPrice
 	if len(txPrices) > 0 {
@@ -179,26 +179,53 @@ func (gpo *Oracle) SuggestPrice(ctx context.Context) (*big.Int, error) {
 	return price, nil
 }
 
-type getBlockPricesResult struct {
-	prices []*big.Int
+type results struct {
+	values []*big.Int
 	err    error
+}
+
+type SortableTxs interface {
+	Len() int
+	Less(i, j int) bool
+	Swap(i, j int)
+	GasPrice(int) *big.Int
+	EffectiveTip(int, *big.Int) *big.Int
 }
 
 type transactionsByGasPrice []*types.Transaction
 
-func (t transactionsByGasPrice) Len() int           { return len(t) }
-func (t transactionsByGasPrice) Swap(i, j int)      { t[i], t[j] = t[j], t[i] }
-func (t transactionsByGasPrice) Less(i, j int) bool { return t[i].FeeCapCmp(t[j]) < 0 }
+func makeTxsByGasPrice(txs []*types.Transaction) SortableTxs { return transactionsByGasPrice(txs) }
+
+func (t transactionsByGasPrice) Len() int                                { return len(t) }
+func (t transactionsByGasPrice) Swap(i, j int)                           { t[i], t[j] = t[j], t[i] }
+func (t transactionsByGasPrice) Less(i, j int) bool                      { return t[i].GasPriceCmp(t[j]) < 0 }
+func (t transactionsByGasPrice) GasPrice(i int) *big.Int                 { return t[i].GasPrice() }
+func (t transactionsByGasPrice) EffectiveTip(i int, b *big.Int) *big.Int { return nil }
+
+type transactionsByTip []*types.Transaction
+
+func makeTxsByTip(txs []*types.Transaction) SortableTxs { return transactionsByGasPrice(txs) }
+
+func (t transactionsByTip) Len() int                { return len(t) }
+func (t transactionsByTip) Swap(i, j int)           { t[i], t[j] = t[j], t[i] }
+func (t transactionsByTip) Less(i, j int) bool      { return t[i].GasPriceCmp(t[j]) < 0 }
+func (t transactionsByTip) GasPrice(i int) *big.Int { return nil }
+func (t transactionsByTip) EffectiveTip(i int, b *big.Int) *big.Int {
+	// It's okay to discard the error because a tx would never be accepted into
+	// a block with an invalid effective tip.
+	et, _ := t[i].EffectiveTip(b)
+	return et
+}
 
 // getBlockPrices calculates the lowest transaction gas price in a given block
 // and sends it to the result channel. If the block is empty or all transactions
 // are sent by the miner itself(it doesn't make any sense to include this kind of
 // transaction prices for sampling), nil gasprice is returned.
-func (gpo *Oracle) getBlockPrices(ctx context.Context, signer types.Signer, blockNum uint64, limit int, ignoreUnder *big.Int, result chan getBlockPricesResult, quit chan struct{}) {
+func (gpo *Oracle) getBlockValues(ctx context.Context, tip bool, signer types.Signer, blockNum uint64, limit int, ignoreUnder *big.Int, result chan results, quit chan struct{}) {
 	block, err := gpo.backend.BlockByNumber(ctx, rpc.BlockNumber(blockNum))
 	if block == nil {
 		select {
-		case result <- getBlockPricesResult{nil, err}:
+		case result <- results{nil, err}:
 		case <-quit:
 		}
 		return
@@ -206,23 +233,33 @@ func (gpo *Oracle) getBlockPrices(ctx context.Context, signer types.Signer, bloc
 	blockTxs := block.Transactions()
 	txs := make([]*types.Transaction, len(blockTxs))
 	copy(txs, blockTxs)
-	sort.Sort(transactionsByGasPrice(txs))
+
+	if tip {
+		sort.Sort(transactionsByTip(txs))
+	} else {
+		sort.Sort(transactionsByGasPrice(txs))
+	}
 
 	var prices []*big.Int
-	for _, tx := range txs {
-		if ignoreUnder != nil && tx.GasPriceIntCmp(ignoreUnder) == -1 {
+	for i := range txs {
+		if ignoreUnder != nil && txs[i].TipIntCmp(ignoreUnder) == -1 {
 			continue
 		}
-		sender, err := types.Sender(signer, tx)
+		sender, err := types.Sender(signer, txs[i])
 		if err == nil && sender != block.Coinbase() {
-			prices = append(prices, tx.GasPrice())
+			if tip {
+				et, _ := txs[i].EffectiveTip(block.BaseFee())
+				prices = append(prices, et)
+			} else {
+				prices = append(prices, txs[i].GasPrice())
+			}
 			if len(prices) >= limit {
 				break
 			}
 		}
 	}
 	select {
-	case result <- getBlockPricesResult{prices, nil}:
+	case result <- results{prices, nil}:
 	case <-quit:
 	}
 }

--- a/eth/gasprice/gasprice.go
+++ b/eth/gasprice/gasprice.go
@@ -188,7 +188,7 @@ type transactionsByGasPrice []*types.Transaction
 
 func (t transactionsByGasPrice) Len() int           { return len(t) }
 func (t transactionsByGasPrice) Swap(i, j int)      { t[i], t[j] = t[j], t[i] }
-func (t transactionsByGasPrice) Less(i, j int) bool { return t[i].GasPriceCmp(t[j]) < 0 }
+func (t transactionsByGasPrice) Less(i, j int) bool { return t[i].FeeCapCmp(t[j]) < 0 }
 
 // getBlockPrices calculates the lowest transaction gas price in a given block
 // and sends it to the result channel. If the block is empty or all transactions

--- a/eth/tracers/api.go
+++ b/eth/tracers/api.go
@@ -762,7 +762,7 @@ func (api *API) TraceCall(ctx context.Context, args ethapi.CallArgs, blockNrOrHa
 		}
 	}
 	// Execute the trace
-	msg := args.ToMessage(api.backend.RPCGasCap())
+	msg := args.ToMessage(api.backend.RPCGasCap(), block.BaseFee())
 	vmctx := core.NewEVMBlockContext(block.Header(), api.chainContext(ctx), nil)
 
 	var traceConfig *TraceConfig

--- a/go.mod
+++ b/go.mod
@@ -23,6 +23,7 @@ require (
 	github.com/dop251/goja v0.0.0-20200721192441-a695b0cdd498
 	github.com/edsrzf/mmap-go v1.0.0
 	github.com/fatih/color v1.7.0
+	github.com/fjl/gencodec v0.0.0-20191126094850-e283372f291f // indirect
 	github.com/fjl/memsize v0.0.0-20190710130421-bcb5799ab5e5
 	github.com/gballet/go-libpcsclite v0.0.0-20190607065134-2772fd86a8ff
 	github.com/go-ole/go-ole v1.2.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -128,12 +128,16 @@ github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.m
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
 github.com/fatih/color v1.7.0 h1:DkWD4oS2D8LGGgTQ6IvwJJXSL5Vp2ffcQg58nFV38Ys=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
+github.com/fjl/gencodec v0.0.0-20191126094850-e283372f291f h1:Y/gg/utVetS+WS6htAKCTDralkm/8hLIIUAtLFdbdQ8=
+github.com/fjl/gencodec v0.0.0-20191126094850-e283372f291f/go.mod h1:q+7Z5oyy8cvKF3TakcuihvQvBHFTnXjB+7UP1e2Q+1o=
 github.com/fjl/memsize v0.0.0-20190710130421-bcb5799ab5e5 h1:FtmdgXiUlNeRsoNMFlKLDt+S+6hbjVMEW6RGQ7aUf7c=
 github.com/fjl/memsize v0.0.0-20190710130421-bcb5799ab5e5/go.mod h1:VvhXpOYNQvB+uIk2RvXzuaQtkQJzzIx6lSBe1xv7hi0=
 github.com/fogleman/gg v1.2.1-0.20190220221249-0403632d5b90/go.mod h1:R/bRT+9gY/C5z7JzPU0zXsXHKM4/ayA+zqcVNZzPa1k=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/fsnotify/fsnotify v1.4.9 h1:hsms1Qyu0jgnwNXIxa+/V/PDsU6CfLf6CNO8H7IWoS4=
 github.com/fsnotify/fsnotify v1.4.9/go.mod h1:znqG4EE+3YCdAaPaxE2ZRY/06pZUdp0tY4IgpuI1SZQ=
+github.com/garslo/gogen v0.0.0-20170306192744-1d203ffc1f61 h1:IZqZOB2fydHte3kUgxrzK5E1fW7RQGeDwE8F/ZZnUYc=
+github.com/garslo/gogen v0.0.0-20170306192744-1d203ffc1f61/go.mod h1:Q0X6pkwTILDlzrGEckF6HKjXe48EgsY/l7K7vhY4MW8=
 github.com/gballet/go-libpcsclite v0.0.0-20190607065134-2772fd86a8ff h1:tY80oXqGNY4FhTFhk+o9oFHGINQ/+vhlm8HFzi6znCI=
 github.com/gballet/go-libpcsclite v0.0.0-20190607065134-2772fd86a8ff/go.mod h1:x7DCsMOv1taUwEWCzT4cmDeAkigA5/QCwUodaVOe8Ww=
 github.com/glycerine/go-unsnap-stream v0.0.0-20180323001048-9f0cb55181dd/go.mod h1:/20jfyN9Y5QPEAprSgKAUr+glWDY39ZiUEAYOEv5dsE=
@@ -263,6 +267,7 @@ github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORN
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
+github.com/kylelemons/godebug v0.0.0-20170224010052-a616ab194758/go.mod h1:B69LEHPfb2qLo0BaaOLcbitczOKLWTsrBG9LczfCD4k=
 github.com/kylelemons/godebug v1.1.0 h1:RPNrshWIDI6G2gRW9EHilWtl7Z6Sb1BR0xunSBf0SNc=
 github.com/kylelemons/godebug v1.1.0/go.mod h1:9/0rRGxNHcop5bhtWyNeEfOS8JIWk580+fNqagV/RAw=
 github.com/leanovate/gopter v0.2.9 h1:fQjYxZaynp97ozCzfOyOuAGOU4aU/z37zf/tOujFk7c=
@@ -298,6 +303,7 @@ github.com/olekukonko/tablewriter v0.0.5 h1:P2Ga83D34wi1o9J6Wh1mRuqd4mF/x/lgBS7N
 github.com/olekukonko/tablewriter v0.0.5/go.mod h1:hPp6KlRPjbx+hW8ykQs1w3UBbZlj6HuIJcUGPhkA7kY=
 github.com/onsi/ginkgo v1.6.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v1.7.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
+github.com/onsi/ginkgo v1.10.3/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v1.12.1/go.mod h1:zj2OWP4+oCPe1qIXoGWkgMRwljMUYCdkwsT2108oapk=
 github.com/onsi/ginkgo v1.14.0 h1:2mOpI4JVVPBN+WQRa0WKH2eXR+Ey+uK4n7Zj0aYpIQA=
 github.com/onsi/ginkgo v1.14.0/go.mod h1:iSB4RoI2tjJc9BBv4NKIKWKya62Rps+oPG/Lv9klQyY=
@@ -420,6 +426,7 @@ golang.org/x/mod v0.0.0-20190513183733-4bf6d317e70e/go.mod h1:mXi4GBBbnImb6dmsKG
 golang.org/x/mod v0.1.0/go.mod h1:0QHyrYULN0/3qlju5TqG8bIK38QM8yzMo5ekMj3DlcY=
 golang.org/x/mod v0.1.1-0.20191105210325-c90efee705ee/go.mod h1:QqPTAvyqsEbceGzBzNggFXnrqF1CaUcvgkdR5Ot7KZg=
 golang.org/x/mod v0.3.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
+golang.org/x/mod v0.4.2 h1:Gz96sIWK3OalVv/I/qNygP42zyoKp3xptRVCWRFEBvo=
 golang.org/x/mod v0.4.2/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/net v0.0.0-20180724234803-3673e40ba225/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180826012351-8a410e7b638d/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
@@ -521,9 +528,11 @@ golang.org/x/tools v0.0.0-20191113191852-77e3bb0ad9e7/go.mod h1:b+2E5dAYhXwXZwtn
 golang.org/x/tools v0.0.0-20191115202509-3a792d9c32b2/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20191119224855-298f0cb1881e/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20191125144606-a911d9008d1f/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
+golang.org/x/tools v0.0.0-20191126055441-b0650ceb63d9/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20191216173652-a0e659d51361/go.mod h1:TB2adYChydJhpapKDTa4BR/hXlZSLoq2Wpct/0txZ28=
 golang.org/x/tools v0.0.0-20191227053925-7b8e75db28f4/go.mod h1:TB2adYChydJhpapKDTa4BR/hXlZSLoq2Wpct/0txZ28=
 golang.org/x/tools v0.0.0-20200108203644-89082a384178/go.mod h1:TB2adYChydJhpapKDTa4BR/hXlZSLoq2Wpct/0txZ28=
+golang.org/x/tools v0.1.0 h1:po9/4sTYwZU9lPhi1tOrb4hCv3qrhiQ77LZfGa2OjwY=
 golang.org/x/tools v0.1.0/go.mod h1:xkSsbof2nBLbhDlRMhhhyNLN/zl3eTqcnHD5viDpcZ0=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -1137,7 +1137,7 @@ func FormatLogs(logs []vm.StructLog) []StructLogRes {
 
 // RPCMarshalHeader converts the given header to the RPC output .
 func RPCMarshalHeader(head *types.Header) map[string]interface{} {
-	return map[string]interface{}{
+	result := map[string]interface{}{
 		"number":           (*hexutil.Big)(head.Number),
 		"hash":             head.Hash(),
 		"parentHash":       head.ParentHash,
@@ -1156,6 +1156,12 @@ func RPCMarshalHeader(head *types.Header) map[string]interface{} {
 		"transactionsRoot": head.TxHash,
 		"receiptsRoot":     head.ReceiptHash,
 	}
+
+	if head.BaseFee != nil {
+		result["baseFee"] = (*hexutil.Big)(head.BaseFee)
+	}
+
+	return result
 }
 
 // RPCMarshalBlock converts the given block to the RPC output which depends on fullTx. If inclTx is true transactions are

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -1228,6 +1228,8 @@ type RPCTransaction struct {
 	From             common.Address    `json:"from"`
 	Gas              hexutil.Uint64    `json:"gas"`
 	GasPrice         *hexutil.Big      `json:"gasPrice"`
+	FeeCap           *hexutil.Big      `json:"feeCap,omitempty"`
+	Tip              *hexutil.Big      `json:"tip,omitempty"`
 	Hash             common.Hash       `json:"hash"`
 	Input            hexutil.Bytes     `json:"input"`
 	Nonce            hexutil.Uint64    `json:"nonce"`
@@ -1244,7 +1246,7 @@ type RPCTransaction struct {
 
 // newRPCTransaction returns a transaction that will serialize to the RPC
 // representation, with the given location metadata set (if available).
-func newRPCTransaction(tx *types.Transaction, blockHash common.Hash, blockNumber uint64, index uint64) *RPCTransaction {
+func newRPCTransaction(tx *types.Transaction, blockHash common.Hash, blockNumber uint64, index uint64, baseFee *big.Int) *RPCTransaction {
 	// Determine the signer. For replay-protected transactions, use the most permissive
 	// signer, because we assume that signers are backwards-compatible with old
 	// transactions. For non-protected transactions, the homestead signer signer is used
@@ -1277,17 +1279,32 @@ func newRPCTransaction(tx *types.Transaction, blockHash common.Hash, blockNumber
 		result.BlockNumber = (*hexutil.Big)(new(big.Int).SetUint64(blockNumber))
 		result.TransactionIndex = (*hexutil.Uint64)(&index)
 	}
-	if tx.Type() != types.LegacyTxType {
+	switch tx.Type() {
+	case types.AccessListTxType:
 		al := tx.AccessList()
 		result.Accesses = &al
 		result.ChainID = (*hexutil.Big)(tx.ChainId())
+	case types.DynamicFeeTxType:
+		al := tx.AccessList()
+		result.Accesses = &al
+		result.ChainID = (*hexutil.Big)(tx.ChainId())
+		result.FeeCap = (*hexutil.Big)(tx.FeeCap())
+		result.Tip = (*hexutil.Big)(tx.Tip())
+		// if the transaction has been mined, compute the effective gas price
+		if baseFee != nil && blockHash != (common.Hash{}) {
+			// price = min(tip, feeCap - baseFee) + baseFee
+			price := math.BigMin(new(big.Int).Add(tx.Tip(), baseFee), tx.FeeCap())
+			result.GasPrice = (*hexutil.Big)(price)
+		} else {
+			result.GasPrice = nil
+		}
 	}
 	return result
 }
 
 // newRPCPendingTransaction returns a pending transaction that will serialize to the RPC representation
 func newRPCPendingTransaction(tx *types.Transaction) *RPCTransaction {
-	return newRPCTransaction(tx, common.Hash{}, 0, 0)
+	return newRPCTransaction(tx, common.Hash{}, 0, 0, nil)
 }
 
 // newRPCTransactionFromBlockIndex returns a transaction that will serialize to the RPC representation.
@@ -1296,7 +1313,7 @@ func newRPCTransactionFromBlockIndex(b *types.Block, index uint64) *RPCTransacti
 	if index >= uint64(len(txs)) {
 		return nil
 	}
-	return newRPCTransaction(txs[index], b.Hash(), b.NumberU64(), index)
+	return newRPCTransaction(txs[index], b.Hash(), b.NumberU64(), index, b.BaseFee())
 }
 
 // newRPCRawTransactionFromBlockIndex returns the bytes of a transaction given a block and a transaction index.
@@ -1511,7 +1528,11 @@ func (s *PublicTransactionPoolAPI) GetTransactionByHash(ctx context.Context, has
 		return nil, err
 	}
 	if tx != nil {
-		return newRPCTransaction(tx, blockHash, blockNumber, index), nil
+		block, err := s.b.BlockByHash(ctx, blockHash)
+		if err != nil {
+			return nil, err
+		}
+		return newRPCTransaction(tx, blockHash, blockNumber, index, block.BaseFee()), nil
 	}
 	// No finalized transaction, try to retrieve it from the pool
 	if tx := s.b.GetPoolTransaction(hash); tx != nil {

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -1669,13 +1669,6 @@ type SendTxArgs struct {
 // setDefaults fills in default values for unspecified tx fields.
 func (args *SendTxArgs) setDefaults(ctx context.Context, b Backend) error {
 	if b.ChainConfig().IsLondon(b.CurrentBlock().Number()) && args.GasPrice == nil {
-		if args.FeeCap == nil {
-			feeCap, err := b.SuggestFeeCap(ctx)
-			if err != nil {
-				return err
-			}
-			args.FeeCap = (*hexutil.Big)(feeCap)
-		}
 		if args.Tip == nil {
 			tip, err := b.SuggestTip(ctx)
 			if err != nil {
@@ -1683,6 +1676,15 @@ func (args *SendTxArgs) setDefaults(ctx context.Context, b Backend) error {
 			}
 			args.Tip = (*hexutil.Big)(tip)
 		}
+		if args.FeeCap == nil {
+			feeCap, err := b.SuggestFeeCap(ctx)
+			if err != nil {
+				return err
+			}
+			args.FeeCap = (*hexutil.Big)(feeCap)
+		}
+		// Don't let tip exceed feeCap.
+		args.FeeCap = (*hexutil.Big)(math.BigMax(args.FeeCap.ToInt(), args.Tip.ToInt()))
 	} else {
 		if args.GasPrice == nil {
 			price, err := b.SuggestPrice(ctx)

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -757,8 +757,8 @@ type CallArgs struct {
 	To         *common.Address   `json:"to"`
 	Gas        *hexutil.Uint64   `json:"gas"`
 	GasPrice   *hexutil.Big      `json:"gasPrice"`
-	FeeCap     *hexutil.Big      `json:"feeCap"`
-	Tip        *hexutil.Big      `json:"tip"`
+	FeeCap     *hexutil.Big      `json:"maxFeePerGas"`
+	Tip        *hexutil.Big      `json:"maxPriorityFeePerGas"`
 	Value      *hexutil.Big      `json:"value"`
 	Data       *hexutil.Bytes    `json:"data"`
 	AccessList *types.AccessList `json:"accessList"`
@@ -1250,8 +1250,8 @@ type RPCTransaction struct {
 	From             common.Address    `json:"from"`
 	Gas              hexutil.Uint64    `json:"gas"`
 	GasPrice         *hexutil.Big      `json:"gasPrice"`
-	FeeCap           *hexutil.Big      `json:"feeCap,omitempty"`
-	Tip              *hexutil.Big      `json:"tip,omitempty"`
+	FeeCap           *hexutil.Big      `json:"maxFeePerGas,omitempty"`
+	Tip              *hexutil.Big      `json:"maxPriorityFeePerGas,omitempty"`
 	Hash             common.Hash       `json:"hash"`
 	Input            hexutil.Bytes     `json:"input"`
 	Nonce            hexutil.Uint64    `json:"nonce"`
@@ -1652,8 +1652,8 @@ type SendTxArgs struct {
 	To       *common.Address `json:"to"`
 	Gas      *hexutil.Uint64 `json:"gas"`
 	GasPrice *hexutil.Big    `json:"gasPrice"`
-	FeeCap   *hexutil.Big    `json:"feeCap"`
-	Tip      *hexutil.Big    `json:"tip"`
+	FeeCap   *hexutil.Big    `json:"maxFeePerGas"`
+	Tip      *hexutil.Big    `json:"maxPriorityFeePerGas"`
 	Value    *hexutil.Big    `json:"value"`
 	Nonce    *hexutil.Uint64 `json:"nonce"`
 	// We accept "data" and "input" for backwards-compatibility reasons. "input" is the

--- a/internal/ethapi/backend.go
+++ b/internal/ethapi/backend.go
@@ -42,6 +42,8 @@ type Backend interface {
 	// General Ethereum API
 	Downloader() *downloader.Downloader
 	SuggestPrice(ctx context.Context) (*big.Int, error)
+	SuggestTip(ctx context.Context) (*big.Int, error)
+	SuggestFeeCap(ctx context.Context) (*big.Int, error)
 	ChainDb() ethdb.Database
 	AccountManager() *accounts.Manager
 	ExtRPCEnabled() bool

--- a/les/api_backend.go
+++ b/les/api_backend.go
@@ -252,7 +252,15 @@ func (b *LesApiBackend) ProtocolVersion() int {
 }
 
 func (b *LesApiBackend) SuggestPrice(ctx context.Context) (*big.Int, error) {
-	return b.gpo.SuggestPrice(ctx)
+	return b.gpo.SuggestPrice(ctx, false)
+}
+
+func (b *LesApiBackend) SuggestTip(ctx context.Context) (*big.Int, error) {
+	return b.gpo.SuggestPrice(ctx, true)
+}
+
+func (b *LesApiBackend) SuggestFeeCap(ctx context.Context) (*big.Int, error) {
+	return new(big.Int).Mul(b.CurrentBlock().BaseFee(), common.Big2), nil
 }
 
 func (b *LesApiBackend) ChainDb() ethdb.Database {

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -499,7 +499,7 @@ func (w *worker) mainLoop() {
 					acc, _ := types.Sender(w.current.signer, tx)
 					txs[acc] = append(txs[acc], tx)
 				}
-				txset := types.NewTransactionsByMinerFeeAndNonce(w.current.signer, txs, w.current.header.BaseFee)
+				txset := types.NewTransactionsByPriceAndNonce(w.current.signer, txs, w.current.header.BaseFee)
 				tcount := w.current.tcount
 				w.commitTransactions(txset, coinbase, nil)
 				// Only update the snapshot if any new transactons were added
@@ -983,13 +983,13 @@ func (w *worker) commitNewWork(interrupt *int32, noempty bool, timestamp int64) 
 		}
 	}
 	if len(localTxs) > 0 {
-		txs := types.NewTransactionsByMinerFeeAndNonce(w.current.signer, localTxs, header.BaseFee)
+		txs := types.NewTransactionsByPriceAndNonce(w.current.signer, localTxs, header.BaseFee)
 		if w.commitTransactions(txs, w.coinbase, interrupt) {
 			return
 		}
 	}
 	if len(remoteTxs) > 0 {
-		txs := types.NewTransactionsByMinerFeeAndNonce(w.current.signer, remoteTxs, header.BaseFee)
+		txs := types.NewTransactionsByPriceAndNonce(w.current.signer, remoteTxs, header.BaseFee)
 		if w.commitTransactions(txs, w.coinbase, interrupt) {
 			return
 		}

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -499,7 +499,7 @@ func (w *worker) mainLoop() {
 					acc, _ := types.Sender(w.current.signer, tx)
 					txs[acc] = append(txs[acc], tx)
 				}
-				txset := types.NewTransactionsByPriceAndNonce(w.current.signer, txs)
+				txset := types.NewTransactionsByMinerFeeAndNonce(w.current.signer, txs, nil)
 				tcount := w.current.tcount
 				w.commitTransactions(txset, coinbase, nil)
 				// Only update the snapshot if any new transactons were added
@@ -747,7 +747,7 @@ func (w *worker) commitTransaction(tx *types.Transaction, coinbase common.Addres
 	return receipt.Logs, nil
 }
 
-func (w *worker) commitTransactions(txs *types.TransactionsByPriceAndNonce, coinbase common.Address, interrupt *int32) bool {
+func (w *worker) commitTransactions(txs *types.TransactionsByMinerFeeAndNonce, coinbase common.Address, interrupt *int32) bool {
 	// Short circuit if current is nil
 	if w.current == nil {
 		return true
@@ -973,13 +973,13 @@ func (w *worker) commitNewWork(interrupt *int32, noempty bool, timestamp int64) 
 		}
 	}
 	if len(localTxs) > 0 {
-		txs := types.NewTransactionsByPriceAndNonce(w.current.signer, localTxs)
+		txs := types.NewTransactionsByMinerFeeAndNonce(w.current.signer, localTxs, nil)
 		if w.commitTransactions(txs, w.coinbase, interrupt) {
 			return
 		}
 	}
 	if len(remoteTxs) > 0 {
-		txs := types.NewTransactionsByPriceAndNonce(w.current.signer, remoteTxs)
+		txs := types.NewTransactionsByMinerFeeAndNonce(w.current.signer, remoteTxs, nil)
 		if w.commitTransactions(txs, w.coinbase, interrupt) {
 			return
 		}

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -1051,13 +1051,7 @@ func (w *worker) postSideBlock(event core.ChainSideEvent) {
 func totalFees(block *types.Block, receipts []*types.Receipt) *big.Float {
 	feesWei := new(big.Int)
 	for i, tx := range block.Transactions() {
-		minerFee := tx.Tip()
-		if block.BaseFee() != nil {
-			maxMinerFee := (&big.Int{}).Sub(tx.FeeCap(), block.BaseFee())
-			if maxMinerFee.Cmp(minerFee) < 0 {
-				minerFee = maxMinerFee
-			}
-		}
+		minerFee, _ := tx.EffectiveTip(block.BaseFee())
 		feesWei.Add(feesWei, new(big.Int).Mul(new(big.Int).SetUint64(receipts[i].GasUsed), minerFee))
 	}
 	return new(big.Float).Quo(new(big.Float).SetInt(feesWei), new(big.Float).SetInt(big.NewInt(params.Ether)))

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -747,7 +747,7 @@ func (w *worker) commitTransaction(tx *types.Transaction, coinbase common.Addres
 	return receipt.Logs, nil
 }
 
-func (w *worker) commitTransactions(txs *types.TransactionsByMinerFeeAndNonce, coinbase common.Address, interrupt *int32) bool {
+func (w *worker) commitTransactions(txs *types.TransactionsByPriceAndNonce, coinbase common.Address, interrupt *int32) bool {
 	// Short circuit if current is nil
 	if w.current == nil {
 		return true
@@ -889,10 +889,8 @@ func (w *worker) commitNewWork(interrupt *int32, noempty bool, timestamp int64) 
 		Time:       uint64(timestamp),
 	}
 	// Set baseFee if we are on an EIP-1559 chain
-	if w.chain.Config().IsAleut(parent.Number()) {
-		header.BaseFee = misc.CalcBaseFee(parent.Header())
-	} else if w.chain.Config().IsAleut(header.Number) {
-		header.BaseFee = new(big.Int).SetUint64(params.InitialBaseFee)
+	if w.chainConfig.IsAleut(header.Number) {
+		header.BaseFee = misc.CalcBaseFee(w.chainConfig, parent.Header())
 	}
 	// Only set the coinbase if our consensus engine is running (avoid spurious block rewards)
 	if w.isRunning() {

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -754,7 +754,7 @@ func (w *worker) commitTransactions(txs *types.TransactionsByPriceAndNonce, coin
 	}
 
 	gasLimit := w.current.header.GasLimit
-	if w.chain.Config().IsAleut(w.current.header.Number) {
+	if w.chain.Config().IsLondon(w.current.header.Number) {
 		gasLimit *= params.ElasticityMultiplier
 	}
 	if w.current.gasPool == nil {
@@ -889,7 +889,7 @@ func (w *worker) commitNewWork(interrupt *int32, noempty bool, timestamp int64) 
 		Time:       uint64(timestamp),
 	}
 	// Set baseFee if we are on an EIP-1559 chain
-	if w.chainConfig.IsAleut(header.Number) {
+	if w.chainConfig.IsLondon(header.Number) {
 		header.BaseFee = misc.CalcBaseFee(w.chainConfig, parent.Header())
 	}
 	// Only set the coinbase if our consensus engine is running (avoid spurious block rewards)

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -881,17 +881,16 @@ func (w *worker) commitNewWork(interrupt *int32, noempty bool, timestamp int64) 
 	header := &types.Header{
 		ParentHash: parent.Hash(),
 		Number:     num.Add(num, common.Big1),
-		GasLimit:   core.CalcGasLimit(parent, w.config.GasFloor, w.config.GasCeil),
+		GasLimit:   core.CalcGasLimit(parent.GasUsed(), parent.GasLimit(), w.config.GasFloor, w.config.GasCeil),
 		Extra:      w.extra,
 		Time:       uint64(timestamp),
 	}
 	// Set baseFee and GasLimit if we are on an EIP-1559 chain
 	if w.chainConfig.IsLondon(header.Number) {
 		header.BaseFee = misc.CalcBaseFee(w.chainConfig, parent.Header())
-		parentHeader := parent.Header()
-		parentHeader.GasLimit = parent.GasLimit() / params.ElasticityMultiplier
-		parent = types.NewBlockWithHeader(parentHeader)
-		header.GasLimit = core.CalcGasLimit(parent, w.config.GasFloor, w.config.GasCeil) * params.ElasticityMultiplier
+		parentGasTarget := parent.GasLimit() / params.ElasticityMultiplier
+		header.GasLimit = core.CalcGasLimit(parent.GasUsed(), parentGasTarget, w.config.GasFloor,
+			w.config.GasCeil) * params.ElasticityMultiplier
 	}
 	// Only set the coinbase if our consensus engine is running (avoid spurious block rewards)
 	if w.isRunning() {

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -889,14 +889,11 @@ func (w *worker) commitNewWork(interrupt *int32, noempty bool, timestamp int64) 
 	if w.chainConfig.IsLondon(header.Number) {
 		header.BaseFee = misc.CalcBaseFee(w.chainConfig, parent.Header())
 		parentGasLimit := parent.GasLimit()
-		parentGasTarget := parentGasLimit / params.ElasticityMultiplier
 		if !w.chainConfig.IsLondon(parent.Number()) {
 			// Bump by 2x
 			parentGasLimit = parent.GasLimit() * params.ElasticityMultiplier
-			parentGasTarget = parent.GasLimit()
 		}
-		header.GasLimit = core.CalcGasLimit1559(parent.GasUsed(), parentGasTarget, w.config.GasFloor,
-			w.config.GasCeil)
+		header.GasLimit = core.CalcGasLimit1559(parentGasLimit, w.config.GasCeil)
 	}
 	// Only set the coinbase if our consensus engine is running (avoid spurious block rewards)
 	if w.isRunning() {

--- a/miner/worker_test.go
+++ b/miner/worker_test.go
@@ -182,10 +182,11 @@ func (b *testWorkerBackend) newRandomUncle() *types.Block {
 
 func (b *testWorkerBackend) newRandomTx(creation bool) *types.Transaction {
 	var tx *types.Transaction
+	gasPrice := big.NewInt(10 * params.InitialBaseFee)
 	if creation {
-		tx, _ = types.SignTx(types.NewContractCreation(b.txPool.Nonce(testBankAddress), big.NewInt(0), testGas, nil, common.FromHex(testCode)), types.HomesteadSigner{}, testBankKey)
+		tx, _ = types.SignTx(types.NewContractCreation(b.txPool.Nonce(testBankAddress), big.NewInt(0), testGas, gasPrice, common.FromHex(testCode)), types.HomesteadSigner{}, testBankKey)
 	} else {
-		tx, _ = types.SignTx(types.NewTransaction(b.txPool.Nonce(testBankAddress), testUserAddress, big.NewInt(1000), params.TxGas, nil, nil), types.HomesteadSigner{}, testBankKey)
+		tx, _ = types.SignTx(types.NewTransaction(b.txPool.Nonce(testBankAddress), testUserAddress, big.NewInt(1000), params.TxGas, gasPrice, nil), types.HomesteadSigner{}, testBankKey)
 	}
 	return tx
 }
@@ -221,6 +222,7 @@ func testGenerateBlockAndImport(t *testing.T, isClique bool) {
 		engine = ethash.NewFaker()
 	}
 
+	chainConfig.AleutBlock = big.NewInt(0)
 	w, b := newTestWorker(t, chainConfig, engine, db, 0)
 	defer w.close()
 

--- a/miner/worker_test.go
+++ b/miner/worker_test.go
@@ -222,7 +222,7 @@ func testGenerateBlockAndImport(t *testing.T, isClique bool) {
 		engine = ethash.NewFaker()
 	}
 
-	chainConfig.AleutBlock = big.NewInt(0)
+	chainConfig.LondonBlock = big.NewInt(0)
 	w, b := newTestWorker(t, chainConfig, engine, db, 0)
 	defer w.close()
 


### PR DESCRIPTION
This branch contains EIP-1559 specific changes to the RPC, specifically:
* eth_gasPrice
* dynamicFeeTx can be displayed in RPC response
* effectiveGasPrice is computed on-the-fly for eth_getTransaction*
* add baseFee to RPC headers

A few things that haven't been addressed yet:
* eth_estimateGas does not account for dynamicFeeTxs effective gas price vs. EOA balance
* gas price oracle does not gracefully handle 1559 fork, it naively finds the median gas price of the previous `n` blocks