### PR TITLE
eth/protocols/eth, les: avoid Raw() when decoding HashOrNumber

### DIFF
--- a/eth/protocols/eth/protocol.go
+++ b/eth/protocols/eth/protocol.go
@@ -156,10 +156,9 @@ func (hn *HashOrNumber) EncodeRLP(w io.Writer) error {
 // into either a block hash or a block number.
 func (hn *HashOrNumber) DecodeRLP(s *rlp.Stream) error {
 	_, size, err := s.Kind()
-	if err != nil {
-		return err
-	}
 	switch {
+	case err != nil:
+		return err
 	case size == 32:
 		hn.Number = 0
 		return s.Decode(&hn.Hash)

--- a/eth/protocols/eth/protocol.go
+++ b/eth/protocols/eth/protocol.go
@@ -155,19 +155,20 @@ func (hn *HashOrNumber) EncodeRLP(w io.Writer) error {
 // DecodeRLP is a specialized decoder for HashOrNumber to decode the contents
 // into either a block hash or a block number.
 func (hn *HashOrNumber) DecodeRLP(s *rlp.Stream) error {
-	_, size, _ := s.Kind()
-	origin, err := s.Raw()
-	if err == nil {
-		switch {
-		case size == 32:
-			err = rlp.DecodeBytes(origin, &hn.Hash)
-		case size <= 8:
-			err = rlp.DecodeBytes(origin, &hn.Number)
-		default:
-			err = fmt.Errorf("invalid input size %d for origin", size)
-		}
+	_, size, err := s.Kind()
+	if err != nil {
+		return err
 	}
-	return err
+	switch {
+	case size == 32:
+		hn.Number = 0
+		return s.Decode(&hn.Hash)
+	case size <= 8:
+		hn.Hash = common.Hash{}
+		return s.Decode(&hn.Number)
+	default:
+		return fmt.Errorf("invalid input size %d for origin", size)
+	}
 }
 
 // BlockHeadersPacket represents a block header response.

--- a/les/protocol.go
+++ b/les/protocol.go
@@ -308,10 +308,9 @@ func (hn *hashOrNumber) EncodeRLP(w io.Writer) error {
 // into either a block hash or a block number.
 func (hn *hashOrNumber) DecodeRLP(s *rlp.Stream) error {
 	_, size, err := s.Kind()
-	if err != nil {
-		return err
-	}
 	switch {
+	case err != nil:
+		return err
 	case size == 32:
 		hn.Number = 0
 		return s.Decode(&hn.Hash)

--- a/les/protocol.go
+++ b/les/protocol.go
@@ -307,19 +307,20 @@ func (hn *hashOrNumber) EncodeRLP(w io.Writer) error {
 // DecodeRLP is a specialized decoder for hashOrNumber to decode the contents
 // into either a block hash or a block number.
 func (hn *hashOrNumber) DecodeRLP(s *rlp.Stream) error {
-	_, size, _ := s.Kind()
-	origin, err := s.Raw()
-	if err == nil {
-		switch {
-		case size == 32:
-			err = rlp.DecodeBytes(origin, &hn.Hash)
-		case size <= 8:
-			err = rlp.DecodeBytes(origin, &hn.Number)
-		default:
-			err = fmt.Errorf("invalid input size %d for origin", size)
-		}
+	_, size, err := s.Kind()
+	if err != nil {
+		return err
 	}
-	return err
+	switch {
+	case size == 32:
+		hn.Number = 0
+		return s.Decode(&hn.Hash)
+	case size <= 8:
+		hn.Hash = common.Hash{}
+		return s.Decode(&hn.Number)
+	default:
+		return fmt.Errorf("invalid input size %d for origin", size)
+	}
 }
 
 // CodeData is the network response packet for a node data retrieval.


### PR DESCRIPTION
Getting the raw value is not necessary to decode this type, and
decoding it directly from the stream is faster.