### PR TITLE
eth/tracers: do the JSON serialization via .js to capture C faults

### DIFF
--- a/eth/tracers/tracer_test.go
+++ b/eth/tracers/tracer_test.go
@@ -78,7 +78,7 @@ func runTrace(tracer *Tracer, vmctx *vmContext) (json.RawMessage, error) {
 }
 
 func TestTracer(t *testing.T) {
-	execTracer := func(code string) []byte {
+	execTracer := func(code string) ([]byte, string) {
 		t.Helper()
 		ctx := &vmContext{blockCtx: vm.BlockContext{BlockNumber: big.NewInt(1)}, txCtx: vm.TxContext{GasPrice: big.NewInt(100000)}}
 		tracer, err := New(code, ctx.txCtx)
@@ -87,13 +87,14 @@ func TestTracer(t *testing.T) {
 		}
 		ret, err := runTrace(tracer, ctx)
 		if err != nil {
-			t.Fatal(err)
+			return nil, err.Error() // Stringify to allow comparison without nil checks
 		}
-		return ret
+		return ret, ""
 	}
 	for i, tt := range []struct {
 		code string
 		want string
+		fail string
 	}{
 		{ // tests that we don't panic on bad arguments to memory access
 			code: "{depths: [], step: function(log) { this.depths.push(log.memory.slice(-1,-2)); }, fault: function() {}, result: function() { return this.depths; }}",
@@ -116,10 +117,13 @@ func TestTracer(t *testing.T) {
 		}, { // tests intrinsic gas
 			code: "{depths: [], step: function() {}, fault: function() {}, result: function(ctx) { return ctx.gasPrice+'.'+ctx.gasUsed+'.'+ctx.intrinsicGas; }}",
 			want: `"100000.6.21000"`,
+		}, { // tests too deep object / serialization crash
+			code: "{step: function() {}, fault: function() {}, result: function() { var o={}; var x=o; for (var i=0; i<1000; i++){	o.foo={}; o=o.foo; } return x; }}",
+			fail: "RangeError: json encode recursion limit    in server-side tracer function 'result'",
 		},
 	} {
-		if have := execTracer(tt.code); tt.want != string(have) {
-			t.Errorf("testcase %d: expected return value to be %s got %s\n\tcode: %v", i, tt.want, string(have), tt.code)
+		if have, err := execTracer(tt.code); tt.want != string(have) || tt.fail != err {
+			t.Errorf("testcase %d: expected return value to be '%s' got '%s', error to be '%s' got '%s'\n\tcode: %v", i, tt.want, string(have), tt.fail, err, tt.code)
 		}
 	}
 }


### PR DESCRIPTION
Supersedes https://github.com/ethereum/go-ethereum/pull/22725.

Duktape's JSON serializer has some hard coded depth limits, currently set at 1000. Any object deeper than that fails to serialize, resulting in a C++ exception. Unfortunately Go can't catch that exception, so the tracer (along with Geth) panics.

Duktape itself has a `duk_safe_call` method, the purpose of which is exactly to allow catching these exceptions in client code that would otherwise be unable to do, however the wrapper in go-duktape did a dumb C wrapping which makes this method unusable from Go (i.e. `fn` can't be meaningfully filled since we don't have access to the `duk_xxx` methods):

```go
func (d *Context) SafeCall(fn, args *[0]byte, nargs, nrets int) int {
	return int(C.duk_safe_call(
		d.duk_context,
		fn,
		unsafe.Pointer(&args),
		C.duk_idx_t(nargs),
		C.duk_idx_t(nrets),
	))
}
```

Our last option is to use the JavaScript `JSON.stringify` method to do the flattening. This still uses the C code underneath, so it is equally as fast, but it also does the C++ exception handling, so it's also safe. Duktape is also weird, so this PR also gets weird.

Duktape can only call functions and methods on objects that are already in its heap/stack. Getting the `JSON.stringify` method on there turned out to be strangely funky. Currently the best idea I had was to push a `(JSON.stringify)` evaluation onto the .js stack, which when evaluated will push the actual method we want to call onto the stack (and not the string of it). Then I can call this method to do the real work. This whole dance needs to be special cased to be only done when calling `result`, since whereas `JsonEncode` was always fast, this extra .js object conversion is very slow, so we can't afford to do it once per step.