### PR TITLE
p2p/nat: skip TestUPNP in non-CI envs if discover fails

### DIFF
--- a/p2p/nat/natupnp_test.go
+++ b/p2p/nat/natupnp_test.go
@@ -21,6 +21,7 @@ import (
 	"io"
 	"net"
 	"net/http"
+	"os"
 	"runtime"
 	"strings"
 	"testing"
@@ -162,7 +163,11 @@ func TestUPNP_DDWRT(t *testing.T) {
 	// Attempt to discover the fake device.
 	discovered := discoverUPnP()
 	if discovered == nil {
-		t.Fatalf("not discovered")
+		if os.Getenv("CI") != "" {
+			t.Fatalf("not discovered")
+		} else {
+			t.Skipf("UPnP not discovered (known issue, see https://github.com/ethereum/go-ethereum/issues/21476)")
+		}
 	}
 	upnp, _ := discovered.(*upnp)
 	if upnp.service != "IGDv1-IP1" {


### PR DESCRIPTION
Addressing the issue from https://github.com/ethereum/go-ethereum/issues/21476.

This issue is pretty annoying for me; I don't want to accept failure as the normal development test status. 

This proposed patch causes the offending test to `Skip` if it would otherwise fail _and_ the environment has an empty `CI` env var value (suggesting the environment is _not_ CI). As far as I know, all CI environments set this value, eg:
- https://circleci.com/docs/2.0/env-vars/#built-in-environment-variables (`CI=true`)
- https://docs.travis-ci.com/user/environment-variables/#default-environment-variables (`CI=true`)


