### PR TITLE
core/rawdb: wait for background freezing to exit when closing freezer

### DIFF
--- a/core/rawdb/database.go
+++ b/core/rawdb/database.go
@@ -197,7 +197,11 @@ func NewDatabaseWithFreezer(db ethdb.KeyValueStore, freezer string, namespace st
 	}
 	// Freezer is consistent with the key-value database, permit combining the two
 	if !frdb.readonly {
-		go frdb.freeze(db)
+		frdb.wg.Add(1)
+		go func() {
+			frdb.freeze(db)
+			frdb.wg.Done()
+		}()
 	}
 	return &freezerdb{
 		KeyValueStore: db,


### PR DESCRIPTION
I revisited  #20986, which contains some fixes regarding the shutdown of the background freezer. That PR is now stale, and some of the changes are already applied. 

One remaining feature from that PR is to use a waitgroup to ensure that the shutdown takes effect, before proceeding to close the tables and eventually the database. If this is not performed, it may happen that the database is closed, which makes the freezer hit a `log.Crit`, causing an ungraceful termination. 

This PR adds a waitgroup to the `freezer` to fix that behaviour. 
Supersedes  #20986