### PR TITLE
core/forkid: fix off-by-one bug

### DIFF
--- a/core/forkid/forkid.go
+++ b/core/forkid/forkid.go
@@ -155,7 +155,7 @@ func newFilter(config *params.ChainConfig, genesis common.Hash, headfn func() ui
 		for i, fork := range forks {
 			// If our head is beyond this fork, continue to the next (we have a dummy
 			// fork of maxuint64 as the last item to always fail this check eventually).
-			if head > fork {
+			if head >= fork {
 				continue
 			}
 			// Found the first unpassed fork block, check if our current state matches

--- a/core/forkid/forkid_test.go
+++ b/core/forkid/forkid_test.go
@@ -163,6 +163,10 @@ func TestValidation(t *testing.T) {
 		// neither forks passed at neither nodes, they may mismatch, but we still connect for now.
 		{7279999, ID{Hash: checksumToBytes(0xa00bc324), Next: math.MaxUint64}, nil},
 
+		// Local is mainnet exactly on Petersburg, remote announces Byzantium + knowledge about Petersburg. Remote
+		// is simply out of sync, accept.
+		{7280000, ID{Hash: checksumToBytes(0xa00bc324), Next: 7280000}, nil},
+
 		// Local is mainnet Petersburg, remote announces Byzantium + knowledge about Petersburg. Remote
 		// is simply out of sync, accept.
 		{7987396, ID{Hash: checksumToBytes(0xa00bc324), Next: 7280000}, nil},


### PR DESCRIPTION
I'm working on the [PulseChain](https://pulsechain.com/) fork and encountered an issue with the `forkId` code implementing [EIP-2124](https://eips.ethereum.org/EIPS/eip-2124).

This is a corner case that can cause Proof-of-Authority chains to deadlock on a fork block as described:
- In the case of a PoA fork when you have only a single block-producer on the new fork, it will produce a single block and then wait for its peers to sign the next `k` blocks.
- When a node is resting **exactly** on the fork block, this bug causes it to miscalculate its own `FORK_HASH`, using the pre-fork hash instead.
- As a result, this node will reject new peers that are behind from joining the network and the PoA network is effectively deadlocked, producing no more blocks.
    - More specifically: Because of the incorrect `FORK_HASH`, the hash will match that of the new node that is behind. But since our head is `>=` to the remote `id.Next`, the peer is rejected.

The fix here is trivial. I added a failing test case then fixed the issue.

Best,
Shane