### PR TITLE
core/vm, core/state: proof of concept code chunking implementation

### DIFF
--- a/core/state/journal.go
+++ b/core/state/journal.go
@@ -138,6 +138,10 @@ type (
 		address *common.Address
 		slot    *common.Hash
 	}
+	accessListAddChunkChange struct {
+		address *common.Address
+		chunk   uint16
+	}
 )
 
 func (ch createObjectChange) revert(s *StateDB) {
@@ -265,5 +269,14 @@ func (ch accessListAddSlotChange) revert(s *StateDB) {
 }
 
 func (ch accessListAddSlotChange) dirtied() *common.Address {
+	return nil
+}
+
+func (ch accessListAddChunkChange) revert(s *StateDB) {
+	// TODO implement this
+	//s.accessList.DeleteSlot(*ch.address, *ch.slot)
+}
+
+func (ch accessListAddChunkChange) dirtied() *common.Address {
 	return nil
 }

--- a/core/state/statedb.go
+++ b/core/state/statedb.go
@@ -1043,3 +1043,11 @@ func (s *StateDB) AddressInAccessList(addr common.Address) bool {
 func (s *StateDB) SlotInAccessList(addr common.Address, slot common.Hash) (addressPresent bool, slotPresent bool) {
 	return s.accessList.Contains(addr, slot)
 }
+
+func (s *StateDB) AddCodeChunkToAccessList(addr common.Address, chunk uint16) bool {
+	if s.accessList.AddCodeChunk(addr, chunk) {
+		s.journal.append(accessListAddChunkChange{&addr, chunk})
+		return true
+	}
+	return false
+}

--- a/core/vm/interface.go
+++ b/core/vm/interface.go
@@ -67,6 +67,8 @@ type StateDB interface {
 	// even if the feature/fork is not active yet
 	AddSlotToAccessList(addr common.Address, slot common.Hash)
 
+	AddCodeChunkToAccessList(addr common.Address, chunk uint16) bool
+
 	RevertToSnapshot(int)
 	Snapshot() int
 


### PR DESCRIPTION
This is a proof of concept implementation of [code chunking](https://notes.ethereum.org/@vbuterin/code_chunk_gas_cost), a prototype EIP by @vbuterin . 

> Add a gas cost charge for accessing each individual “chunk” (contiguous 31-byte segment) of code, to bound the maximum witness size of a block.

The implementation is not clean, but _I think_ it is correct. The main drawback that I encountered was that for `EXTCODECOPY`, we need to load the code before determining the cost of accessing the chunks, since we do not have the codesize available until we do. It's also a quirky, since normally the gas calculators do not have access to the `pc`, so cannot determine the (new) dynamic cost for `PUSH` operations -- and therefore I added a special clause within the runloop, which adds a performance hit to all operations. 

All in all, this EIP does not fit super-well into the current EVM model, and I think we'd need to restructure things a bit for a production-ready implementation. I just implemented this so @vbuterin can experiment and/or do some analysis of how it behaves. 


### Case 1

This code segment spans chunk 0 and 1

Bytecode: 
```
0x6001805080508050805080508050805080508050805080508050805080508050805000
```
Operations: 
```
PUSH1 0x01, DUP1, POP, DUP1, POP, DUP1, POP, DUP1, POP, DUP1, POP, DUP1, POP, DUP1, POP, DUP1, POP, DUP1, POP, DUP1, POP, DUP1, POP, DUP1, POP, DUP1, POP, DUP1, POP, DUP1, POP, DUP1, POP, STOP
```

From: `0x0000000000000000000000000000000000000000`
To: `0x000000000000000000000000636F6E7472616374`
Data: `0x`
Gas: `18446744073709551615`
Value `0` wei

|  Pc   |      Op     | Cost |   Stack   |   RStack  |  Refund |
|-------|-------------|------|-----------|-----------|---------|
|    0  |      PUSH1  |  353 |        [] |         0 |
|    2  |       DUP1  |    3 |     [0x1] |         0 |
|    3  |        POP  |    2 | [0x1,0x1] |         0 |
|    4  |       DUP1  |    3 |     [0x1] |         0 |
|    5  |        POP  |    2 | [0x1,0x1] |         0 |
|    6  |       DUP1  |    3 |     [0x1] |         0 |
|    7  |        POP  |    2 | [0x1,0x1] |         0 |
|    8  |       DUP1  |    3 |     [0x1] |         0 |
|    9  |        POP  |    2 | [0x1,0x1] |         0 |
|   10  |       DUP1  |    3 |     [0x1] |         0 |
|   11  |        POP  |    2 | [0x1,0x1] |         0 |
|   12  |       DUP1  |    3 |     [0x1] |         0 |
|   13  |        POP  |    2 | [0x1,0x1] |         0 |
|   14  |       DUP1  |    3 |     [0x1] |         0 |
|   15  |        POP  |    2 | [0x1,0x1] |         0 |
|   16  |       DUP1  |    3 |     [0x1] |         0 |
|   17  |        POP  |    2 | [0x1,0x1] |         0 |
|   18  |       DUP1  |    3 |     [0x1] |         0 |
|   19  |        POP  |    2 | [0x1,0x1] |         0 |
|   20  |       DUP1  |    3 |     [0x1] |         0 |
|   21  |        POP  |    2 | [0x1,0x1] |         0 |
|   22  |       DUP1  |    3 |     [0x1] |         0 |
|   23  |        POP  |    2 | [0x1,0x1] |         0 |
|   24  |       DUP1  |    3 |     [0x1] |         0 |
|   25  |        POP  |    2 | [0x1,0x1] |         0 |
|   26  |       DUP1  |    3 |     [0x1] |         0 |
|   27  |        POP  |    2 | [0x1,0x1] |         0 |
|   28  |       DUP1  |    3 |     [0x1] |         0 |
|   29  |        POP  |    2 | [0x1,0x1] |         0 |
|   30  |       DUP1  |    3 |     [0x1] |         0 |
|   31  |        POP  |  352 | [0x1,0x1] |         0 |
|   32  |       DUP1  |    3 |     [0x1] |         0 |
|   33  |        POP  |    2 | [0x1,0x1] |         0 |
|   34  |       STOP  |    0 |     [0x1] |         0 |

Output: `0x`
Consumed gas: `783`
Error: `<nil>`
### Case 2

This code jumps from chunk 0 to chunk 2

Bytecode: 
```
0x603e5600000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000005b0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000
```
Operations: 
```
PUSH1 0x3e, JUMP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, JUMPDEST, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP
```

From: `0x0000000000000000000000000000000000000000`
To: `0x000000000000000000000000636F6E7472616374`
Data: `0x`
Gas: `18446744073709551615`
Value `0` wei

|  Pc   |      Op     | Cost |   Stack   |   RStack  |  Refund |
|-------|-------------|------|-----------|-----------|---------|
|    0  |      PUSH1  |  353 |        [] |         0 |
|    2  |       JUMP  |    8 |    [0x3e] |         0 |
|   62  |   JUMPDEST  |  351 |        [] |         0 |
|   63  |       STOP  |    0 |        [] |         0 |

Output: `0x`
Consumed gas: `712`
Error: `<nil>`
### Case 3

This code jumps from chunk 0 to chunk 2 and back to 0

Bytecode: 
```
0x603e565b000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000005b6003560000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000
```
Operations: 
```
PUSH1 0x3e, JUMP, JUMPDEST, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, JUMPDEST, PUSH1 0x03, JUMP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP
```

From: `0x0000000000000000000000000000000000000000`
To: `0x000000000000000000000000636F6E7472616374`
Data: `0x`
Gas: `18446744073709551615`
Value `0` wei

|  Pc   |      Op     | Cost |   Stack   |   RStack  |  Refund |
|-------|-------------|------|-----------|-----------|---------|
|    0  |      PUSH1  |  353 |        [] |         0 |
|    2  |       JUMP  |    8 |    [0x3e] |         0 |
|   62  |   JUMPDEST  |  351 |        [] |         0 |
|   63  |      PUSH1  |    3 |        [] |         0 |
|   65  |       JUMP  |    8 |     [0x3] |         0 |
|    3  |   JUMPDEST  |    1 |        [] |         0 |
|    4  |       STOP  |    0 |        [] |         0 |

Output: `0x`
Consumed gas: `724`
Error: `<nil>`
### Case 4

This code has pushdata crossing from chunk 0 to chunk 2

Bytecode: 
```
0x7f00000000000000000000000000000000000000000000000000000000000000005b00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000
```
Operations: 
```
PUSH32 0x0000000000000000000000000000000000000000000000000000000000000000, JUMPDEST, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP
```

From: `0x0000000000000000000000000000000000000000`
To: `0x000000000000000000000000636F6E7472616374`
Data: `0x`
Gas: `18446744073709551615`
Value `0` wei

|  Pc   |      Op     | Cost |   Stack   |   RStack  |  Refund |
|-------|-------------|------|-----------|-----------|---------|
|    0  |     PUSH32  |  703 |        [] |         0 |
|   33  |   JUMPDEST  |    1 |     [0x0] |         0 |
|   34  |       STOP  |    0 |     [0x0] |         0 |

Output: `0x`
Consumed gas: `704`
Error: `<nil>`
### Case 5

This code jumps from chunk 0 to chunk 1, then walks into chunk 2

Bytecode: 
```
0x7d0000000000000000000000000000000000000000000000000000000000005b000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000
```
Operations: 
```
PUSH30 0x000000000000000000000000000000000000000000000000000000000000, JUMPDEST, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP
```

From: `0x0000000000000000000000000000000000000000`
To: `0x000000000000000000000000636F6E7472616374`
Data: `0x`
Gas: `18446744073709551615`
Value `0` wei

|  Pc   |      Op     | Cost |   Stack   |   RStack  |  Refund |
|-------|-------------|------|-----------|-----------|---------|
|    0  |     PUSH30  |  353 |        [] |         0 |
|   31  |   JUMPDEST  |  351 |     [0x0] |         0 |
|   32  |       STOP  |    0 |     [0x0] |         0 |

Output: `0x`
Consumed gas: `704`
Error: `<nil>`
### Case 6

This code jumps from chunk 0 to chunk 1, then walks into chunk 2

Bytecode: 
```
0x600000000000000000000000000000000000000000000000000000000000005b000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000
```
Operations: 
```
PUSH1 0x00, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, JUMPDEST, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP
```

From: `0x0000000000000000000000000000000000000000`
To: `0x000000000000000000000000636F6E7472616374`
Data: `0x`
Gas: `18446744073709551615`
Value `0` wei

|  Pc   |      Op     | Cost |   Stack   |   RStack  |  Refund |
|-------|-------------|------|-----------|-----------|---------|
|    0  |      PUSH1  |  353 |        [] |         0 |
|    2  |       STOP  |    0 |     [0x0] |         0 |

Output: `0x`
Consumed gas: `353`
Error: `<nil>`
### Case 7

This does 0-length codecopy

Bytecode: 
```
0x6000606460003900000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000
```
Operations: 
```
PUSH1 0x00, PUSH1 0x64, PUSH1 0x00, CODECOPY, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP
```

From: `0x0000000000000000000000000000000000000000`
To: `0x000000000000000000000000636F6E7472616374`
Data: `0x`
Gas: `18446744073709551615`
Value `0` wei

|  Pc   |      Op     | Cost |   Stack   |   RStack  |  Refund |
|-------|-------------|------|-----------|-----------|---------|
|    0  |      PUSH1  |  353 |        [] |         0 |
|    2  |      PUSH1  |    3 |     [0x0] |         0 |
|    4  |      PUSH1  |    3 |[0x0,0x64] |         0 |
|    6  |   CODECOPY  |    3 |[0x0,0x64,0x0] |         0 |
|    7  |       STOP  |    0 |        [] |         0 |

Output: `0x`
Consumed gas: `362`
Error: `<nil>`
### Case 8

This does 1-length codecopy

Bytecode: 
```
0x6001606460003900000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000
```
Operations: 
```
PUSH1 0x01, PUSH1 0x64, PUSH1 0x00, CODECOPY, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP
```

From: `0x0000000000000000000000000000000000000000`
To: `0x000000000000000000000000636F6E7472616374`
Data: `0x`
Gas: `18446744073709551615`
Value `0` wei

|  Pc   |      Op     | Cost |   Stack   |   RStack  |  Refund |
|-------|-------------|------|-----------|-----------|---------|
|    0  |      PUSH1  |  353 |        [] |         0 |
|    2  |      PUSH1  |    3 |     [0x1] |         0 |
|    4  |      PUSH1  |    3 |[0x1,0x64] |         0 |
|    6  |   CODECOPY  |  359 |[0x1,0x64,0x0] |         0 |
|    7  |       STOP  |    0 |        [] |         0 |

Output: `0x`
Consumed gas: `718`
Error: `<nil>`
### Case 9

This does a codecopy where the end exceeds the code size (code size 128)

Bytecode: 
```
0x60ff606460003900000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000
```
Operations: 
```
PUSH1 0xff, PUSH1 0x64, PUSH1 0x00, CODECOPY, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP
```

From: `0x0000000000000000000000000000000000000000`
To: `0x000000000000000000000000636F6E7472616374`
Data: `0x`
Gas: `18446744073709551615`
Value `0` wei

|  Pc   |      Op     | Cost |   Stack   |   RStack  |  Refund |
|-------|-------------|------|-----------|-----------|---------|
|    0  |      PUSH1  |  353 |        [] |         0 |
|    2  |      PUSH1  |    3 |    [0xff] |         0 |
|    4  |      PUSH1  |    3 |[0xff,0x64] |         0 |
|    6  |   CODECOPY  |  751 |[0xff,0x64,0x0] |         0 |
|    7  |       STOP  |    0 |        [] |         0 |

Output: `0x`
Consumed gas: `1110`
Error: `<nil>`
### Case 10

This does a codecopy fully outside the code size (code size 128)

Bytecode: 
```
0x60ff60ff60003900000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000
```
Operations: 
```
PUSH1 0xff, PUSH1 0xff, PUSH1 0x00, CODECOPY, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP, STOP
```

From: `0x0000000000000000000000000000000000000000`
To: `0x000000000000000000000000636F6E7472616374`
Data: `0x`
Gas: `18446744073709551615`
Value `0` wei

|  Pc   |      Op     | Cost |   Stack   |   RStack  |  Refund |
|-------|-------------|------|-----------|-----------|---------|
|    0  |      PUSH1  |  353 |        [] |         0 |
|    2  |      PUSH1  |    3 |    [0xff] |         0 |
|    4  |      PUSH1  |    3 |[0xff,0xff] |         0 |
|    6  |   CODECOPY  |   51 |[0xff,0xff,0x0] |         0 |
|    7  |       STOP  |    0 |        [] |         0 |

Output: `0x`
Consumed gas: `410`
Error: `<nil>`
--- PASS: TestCodeChunking (0.00s)
PASS

Process finished with the exit code 0
