### PR TITLE
cmd/utils: expand tilde in --jspath

### DIFF
--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -665,10 +665,10 @@ var (
 	}
 
 	// ATM the url is left to the user and deployment to
-	JSpathFlag = cli.StringFlag{
+	JSpathFlag = DirectoryFlag{
 		Name:  "jspath",
 		Usage: "JavaScript root path for `loadScript`",
-		Value: ".",
+		Value: DirectoryString("."),
 	}
 
 	// Gas price oracle settings


### PR DESCRIPTION
closes #22889, replaces #22895