### PR TITLE
tests: get test name from testing.T

### DIFF
--- a/tests/block_test.go
+++ b/tests/block_test.go
@@ -48,10 +48,10 @@ func TestBlockchain(t *testing.T) {
 	// using 4.6 TGas
 	bt.skipLoad(`.*randomStatetest94.json.*`)
 	bt.walk(t, blockTestDir, func(t *testing.T, name string, test *BlockTest) {
-		if err := bt.checkFailure(t, name+"/trie", test.Run(false)); err != nil {
+		if err := bt.checkFailure(t, test.Run(false)); err != nil {
 			t.Errorf("test without snapshotter failed: %v", err)
 		}
-		if err := bt.checkFailure(t, name+"/snap", test.Run(true)); err != nil {
+		if err := bt.checkFailure(t, test.Run(true)); err != nil {
 			t.Errorf("test with snapshotter failed: %v", err)
 		}
 	})

--- a/tests/difficulty_test.go
+++ b/tests/difficulty_test.go
@@ -79,12 +79,12 @@ func TestDifficulty(t *testing.T) {
 	dt.config("difficulty.json", mainnetChainConfig)
 
 	dt.walk(t, difficultyTestDir, func(t *testing.T, name string, test *DifficultyTest) {
-		cfg := dt.findConfig(name)
+		cfg := dt.findConfig(t)
 		if test.ParentDifficulty.Cmp(params.MinimumDifficulty) < 0 {
 			t.Skip("difficulty below minimum")
 			return
 		}
-		if err := dt.checkFailure(t, name, test.Run(cfg)); err != nil {
+		if err := dt.checkFailure(t, test.Run(cfg)); err != nil {
 			t.Error(err)
 		}
 	})

--- a/tests/init_test.go
+++ b/tests/init_test.go
@@ -167,10 +167,9 @@ func (tm *testMatcher) findSkip(name string) (reason string, skipload bool) {
 }
 
 // findConfig returns the chain config matching defined patterns.
-func (tm *testMatcher) findConfig(name string) *params.ChainConfig {
-	// TODO(fjl): name can be derived from testing.T when min Go version is 1.8
+func (tm *testMatcher) findConfig(t *testing.T) *params.ChainConfig {
 	for _, m := range tm.configpat {
-		if m.p.MatchString(name) {
+		if m.p.MatchString(t.Name()) {
 			return &m.config
 		}
 	}
@@ -178,11 +177,10 @@ func (tm *testMatcher) findConfig(name string) *params.ChainConfig {
 }
 
 // checkFailure checks whether a failure is expected.
-func (tm *testMatcher) checkFailure(t *testing.T, name string, err error) error {
-	// TODO(fjl): name can be derived from t when min Go version is 1.8
+func (tm *testMatcher) checkFailure(t *testing.T, err error) error {
 	failReason := ""
 	for _, m := range tm.failpat {
-		if m.p.MatchString(name) {
+		if m.p.MatchString(t.Name()) {
 			failReason = m.reason
 			break
 		}

--- a/tests/rlp_test.go
+++ b/tests/rlp_test.go
@@ -24,7 +24,7 @@ func TestRLP(t *testing.T) {
 	t.Parallel()
 	tm := new(testMatcher)
 	tm.walk(t, rlpTestDir, func(t *testing.T, name string, test *RLPTest) {
-		if err := tm.checkFailure(t, name, test.Run()); err != nil {
+		if err := tm.checkFailure(t, test.Run()); err != nil {
 			t.Error(err)
 		}
 	})

--- a/tests/state_test.go
+++ b/tests/state_test.go
@@ -64,12 +64,11 @@ func TestState(t *testing.T) {
 			for _, subtest := range test.Subtests() {
 				subtest := subtest
 				key := fmt.Sprintf("%s/%d", subtest.Fork, subtest.Index)
-				name := name + "/" + key
 
 				t.Run(key+"/trie", func(t *testing.T) {
 					withTrace(t, test.gasLimit(subtest), func(vmconfig vm.Config) error {
 						_, _, err := test.Run(subtest, vmconfig, false)
-						return st.checkFailure(t, name+"/trie", err)
+						return st.checkFailure(t, err)
 					})
 				})
 				t.Run(key+"/snap", func(t *testing.T) {
@@ -78,7 +77,7 @@ func TestState(t *testing.T) {
 						if _, err := snaps.Journal(statedb.IntermediateRoot(false)); err != nil {
 							return err
 						}
-						return st.checkFailure(t, name+"/snap", err)
+						return st.checkFailure(t, err)
 					})
 				})
 			}
@@ -117,6 +116,6 @@ func withTrace(t *testing.T, gasLimit uint64, test func(vm.Config) error) {
 	} else {
 		t.Log("EVM operation log:\n" + buf.String())
 	}
-	//t.Logf("EVM output: 0x%x", tracer.Output())
-	//t.Logf("EVM error: %v", tracer.Error())
+	// t.Logf("EVM output: 0x%x", tracer.Output())
+	// t.Logf("EVM error: %v", tracer.Error())
 }

--- a/tests/transaction_test.go
+++ b/tests/transaction_test.go
@@ -47,7 +47,7 @@ func TestTransaction(t *testing.T) {
 	txt.skipLoad("^ttValue/TransactionWithHighValueOverflow.json")
 	txt.walk(t, transactionTestDir, func(t *testing.T, name string, test *TransactionTest) {
 		cfg := params.MainnetChainConfig
-		if err := txt.checkFailure(t, name, test.Run(cfg)); err != nil {
+		if err := txt.checkFailure(t, test.Run(cfg)); err != nil {
 			t.Error(err)
 		}
 	})

--- a/tests/vm_test.go
+++ b/tests/vm_test.go
@@ -30,10 +30,10 @@ func TestVM(t *testing.T) {
 
 	vmt.walk(t, vmTestDir, func(t *testing.T, name string, test *VMTest) {
 		withTrace(t, test.json.Exec.GasLimit, func(vmconfig vm.Config) error {
-			return vmt.checkFailure(t, name+"/trie", test.Run(vmconfig, false))
+			return vmt.checkFailure(t, test.Run(vmconfig, false))
 		})
 		withTrace(t, test.json.Exec.GasLimit, func(vmconfig vm.Config) error {
-			return vmt.checkFailure(t, name+"/snap", test.Run(vmconfig, true))
+			return vmt.checkFailure(t, test.Run(vmconfig, true))
 		})
 	})
 }


### PR DESCRIPTION
There were 2 TODOs about that fix after Golang 1.8 release. It's here for 3 years already, so now should be the right time.