### PR TITLE
core/state/snapshot: fix flaky tests

### DIFF
--- a/core/state/snapshot/generate_test.go
+++ b/core/state/snapshot/generate_test.go
@@ -71,7 +71,7 @@ func TestGeneration(t *testing.T) {
 	case <-snap.genPending:
 		// Snapshot generation succeeded
 
-	case <-time.After(250 * time.Millisecond):
+	case <-time.After(3 * time.Second):
 		t.Errorf("Snapshot generation failed")
 	}
 	checkSnapRoot(t, snap, root)
@@ -136,7 +136,7 @@ func TestGenerateExistentState(t *testing.T) {
 	case <-snap.genPending:
 		// Snapshot generation succeeded
 
-	case <-time.After(250 * time.Millisecond):
+	case <-time.After(3 * time.Second):
 		t.Errorf("Snapshot generation failed")
 	}
 	checkSnapRoot(t, snap, root)
@@ -309,7 +309,7 @@ func TestGenerateExistentStateWithWrongStorage(t *testing.T) {
 	case <-snap.genPending:
 		// Snapshot generation succeeded
 
-	case <-time.After(250 * time.Millisecond):
+	case <-time.After(3 * time.Second):
 		t.Errorf("Snapshot generation failed")
 	}
 	checkSnapRoot(t, snap, root)
@@ -361,7 +361,7 @@ func TestGenerateExistentStateWithWrongAccounts(t *testing.T) {
 	case <-snap.genPending:
 		// Snapshot generation succeeded
 
-	case <-time.After(250 * time.Millisecond):
+	case <-time.After(3 * time.Second):
 		t.Errorf("Snapshot generation failed")
 	}
 	checkSnapRoot(t, snap, root)
@@ -406,7 +406,7 @@ func TestGenerateCorruptAccountTrie(t *testing.T) {
 		// Snapshot generation succeeded
 		t.Errorf("Snapshot generated against corrupt account trie")
 
-	case <-time.After(250 * time.Millisecond):
+	case <-time.After(3 * time.Second):
 		// Not generated fast enough, hopefully blocked inside on missing trie node fail
 	}
 	// Signal abortion to the generator and wait for it to tear down
@@ -466,7 +466,7 @@ func TestGenerateMissingStorageTrie(t *testing.T) {
 		// Snapshot generation succeeded
 		t.Errorf("Snapshot generated against corrupt storage trie")
 
-	case <-time.After(250 * time.Millisecond):
+	case <-time.After(3 * time.Second):
 		// Not generated fast enough, hopefully blocked inside on missing trie node fail
 	}
 	// Signal abortion to the generator and wait for it to tear down
@@ -525,7 +525,7 @@ func TestGenerateCorruptStorageTrie(t *testing.T) {
 		// Snapshot generation succeeded
 		t.Errorf("Snapshot generated against corrupt storage trie")
 
-	case <-time.After(250 * time.Millisecond):
+	case <-time.After(3 * time.Second):
 		// Not generated fast enough, hopefully blocked inside on missing trie node fail
 	}
 	// Signal abortion to the generator and wait for it to tear down
@@ -588,7 +588,7 @@ func TestGenerateWithExtraAccounts(t *testing.T) {
 	case <-snap.genPending:
 		// Snapshot generation succeeded
 
-	case <-time.After(250 * time.Millisecond):
+	case <-time.After(3 * time.Second):
 		t.Errorf("Snapshot generation failed")
 	}
 	checkSnapRoot(t, snap, root)
@@ -646,7 +646,7 @@ func TestGenerateWithManyExtraAccounts(t *testing.T) {
 	case <-snap.genPending:
 		// Snapshot generation succeeded
 
-	case <-time.After(250 * time.Millisecond):
+	case <-time.After(3 * time.Second):
 		t.Errorf("Snapshot generation failed")
 	}
 	checkSnapRoot(t, snap, root)
@@ -699,7 +699,7 @@ func TestGenerateWithExtraBeforeAndAfter(t *testing.T) {
 	case <-snap.genPending:
 		// Snapshot generation succeeded
 
-	case <-time.After(250 * time.Millisecond):
+	case <-time.After(3 * time.Second):
 		t.Errorf("Snapshot generation failed")
 	}
 	checkSnapRoot(t, snap, root)
@@ -743,7 +743,7 @@ func TestGenerateWithMalformedSnapdata(t *testing.T) {
 	case <-snap.genPending:
 		// Snapshot generation succeeded
 
-	case <-time.After(250 * time.Millisecond):
+	case <-time.After(3 * time.Second):
 		t.Errorf("Snapshot generation failed")
 	}
 	checkSnapRoot(t, snap, root)
@@ -775,7 +775,7 @@ func TestGenerateFromEmptySnap(t *testing.T) {
 	case <-snap.genPending:
 		// Snapshot generation succeeded
 
-	case <-time.After(1 * time.Second):
+	case <-time.After(3 * time.Second):
 		t.Errorf("Snapshot generation failed")
 	}
 	checkSnapRoot(t, snap, root)
@@ -822,7 +822,7 @@ func TestGenerateWithIncompleteStorage(t *testing.T) {
 	case <-snap.genPending:
 		// Snapshot generation succeeded
 
-	case <-time.After(250 * time.Millisecond):
+	case <-time.After(3 * time.Second):
 		t.Errorf("Snapshot generation failed")
 	}
 	checkSnapRoot(t, snap, root)

--- a/core/state/snapshot/generate_test.go
+++ b/core/state/snapshot/generate_test.go
@@ -406,7 +406,7 @@ func TestGenerateCorruptAccountTrie(t *testing.T) {
 		// Snapshot generation succeeded
 		t.Errorf("Snapshot generated against corrupt account trie")
 
-	case <-time.After(3 * time.Second):
+	case <-time.After(time.Second):
 		// Not generated fast enough, hopefully blocked inside on missing trie node fail
 	}
 	// Signal abortion to the generator and wait for it to tear down
@@ -466,7 +466,7 @@ func TestGenerateMissingStorageTrie(t *testing.T) {
 		// Snapshot generation succeeded
 		t.Errorf("Snapshot generated against corrupt storage trie")
 
-	case <-time.After(3 * time.Second):
+	case <-time.After(time.Second):
 		// Not generated fast enough, hopefully blocked inside on missing trie node fail
 	}
 	// Signal abortion to the generator and wait for it to tear down
@@ -525,7 +525,7 @@ func TestGenerateCorruptStorageTrie(t *testing.T) {
 		// Snapshot generation succeeded
 		t.Errorf("Snapshot generated against corrupt storage trie")
 
-	case <-time.After(3 * time.Second):
+	case <-time.After(time.Second):
 		// Not generated fast enough, hopefully blocked inside on missing trie node fail
 	}
 	// Signal abortion to the generator and wait for it to tear down


### PR DESCRIPTION
This PR fixes some flaky tests due to short wait time.

```
/var/folders/11/1thmg8jd64jc4v8x9qp8pvpr0000gn/T/go-stress-20210526T144842-803955729
--- FAIL: TestGenerateWithManyExtraAccounts (0.29s)
    generate_test.go:641: root: 34b118351a8a35bdf2632fe90ec25160fad17f4cac4401dd110e4d7001a88e0c
    generate_test.go:650: Snapshot generation failed
    generate_test.go:652: invalid subroot(path 29184934297fb4f590f1e3937ee6d183d064bd994c805fe0aef390ff95881040), want 56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421, have ddefcd9376dd029653ef384bd2f0a126bb755fe84fdcc9e7cf421ba454f2bc67
FAIL
```