### PR TITLE
cmd/utils: avoid 1Gb alloc in --dev mode

### DIFF
--- a/cmd/geth/genesis_test.go
+++ b/cmd/geth/genesis_test.go
@@ -84,7 +84,7 @@ func TestCustomGenesis(t *testing.T) {
 		runGeth(t, "--datadir", datadir, "init", json).WaitExit()
 
 		// Query the custom genesis block
-		geth := runGeth(t, "--networkid", "1337", "--syncmode=full",
+		geth := runGeth(t, "--networkid", "1337", "--syncmode=full", "--cache", "16",
 			"--datadir", datadir, "--maxpeers", "0", "--port", "0",
 			"--nodiscover", "--nat", "none", "--ipcdisable",
 			"--exec", tt.query, "console")

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -1234,6 +1234,9 @@ func SetNodeConfig(ctx *cli.Context, cfg *node.Config) {
 	if ctx.GlobalIsSet(KeyStoreDirFlag.Name) {
 		cfg.KeyStoreDir = ctx.GlobalString(KeyStoreDirFlag.Name)
 	}
+	if ctx.GlobalIsSet(DeveloperFlag.Name) {
+		cfg.UseLightweightKDF = true
+	}
 	if ctx.GlobalIsSet(LightKDFFlag.Name) {
 		cfg.UseLightweightKDF = ctx.GlobalBool(LightKDFFlag.Name)
 	}
@@ -1647,6 +1650,7 @@ func SetEthConfig(ctx *cli.Context, stack *node.Node, cfg *ethconfig.Config) {
 		if !ctx.GlobalIsSet(NetworkIdFlag.Name) {
 			cfg.NetworkId = 1337
 		}
+		cfg.SyncMode = downloader.FullSync
 		// Create new developer account or reuse existing one
 		var (
 			developer  accounts.Account


### PR DESCRIPTION
Whenever I do `geth --dev` the graphics flicker a bit, indicating that something just consumed a lot of memory (some quirk in qubes, I guess). Turns out that doing `geth --dev` allocates 1.3 Gb. This PR fixes that, which should make it better on the CI runs too, where we sometimes instantiate geth. 

Before (`1304M`)
```
(pprof) top
Showing nodes accounting for 1280MB, 98.11% of 1304.59MB total
Dropped 215 nodes (cum <= 6.52MB)
Showing top 10 nodes out of 31
      flat  flat%   sum%        cum   cum%
     768MB 58.87% 58.87%      768MB 58.87%  golang.org/x/crypto/scrypt.Key
     512MB 39.25% 98.11%      512MB 39.25%  github.com/holiman/bloomfilter/v2.newBits
         0     0% 98.11%      512MB 39.25%  github.com/ethereum/go-ethereum/accounts/keystore.(*KeyStore).NewAccount
         0     0% 98.11%      256MB 19.62%  github.com/ethereum/go-ethereum/accounts/keystore.(*KeyStore).TimedUnlock
         0     0% 98.11%      256MB 19.62%  github.com/ethereum/go-ethereum/accounts/keystore.(*KeyStore).Unlock
         0     0% 98.11%      256MB 19.62%  github.com/ethereum/go-ethereum/accounts/keystore.(*KeyStore).getDecryptedKey
         0     0% 98.11%      512MB 39.25%  github.com/ethereum/go-ethereum/accounts/keystore.DecryptDataV3
         0     0% 98.11%      512MB 39.25%  github.com/ethereum/go-ethereum/accounts/keystore.DecryptKey
         0     0% 98.11%      256MB 19.62%  github.com/ethereum/go-ethereum/accounts/keystore.EncryptDataV3
         0     0% 98.11%      256MB 19.62%  github.com/ethereum/go-ethereum/accounts/keystore.EncryptKey

```
After (`14M`)
```
Showing nodes accounting for 14969.33kB, 100% of 14969.33kB total
Showing top 10 nodes out of 61
      flat  flat%   sum%        cum   cum%
 8194.75kB 54.74% 54.74%  8194.75kB 54.74%  golang.org/x/crypto/scrypt.Key
 4097.37kB 27.37% 82.12%  4097.37kB 27.37%  github.com/syndtr/goleveldb/leveldb/memdb.New
  561.50kB  3.75% 85.87%   561.50kB  3.75%  github.com/ethereum/go-ethereum/miner.newWorker
  561.50kB  3.75% 89.62%   561.50kB  3.75%  golang.org/x/net/html.init
  528.17kB  3.53% 93.15%   528.17kB  3.53%  compress/flate.(*dictDecoder).init (inline)
     514kB  3.43% 96.58%      514kB  3.43%  net/http.init
  512.05kB  3.42%   100%   512.05kB  3.42%  github.com/ethereum/go-ethereum/trie.findChild
         0     0%   100%   528.17kB  3.53%  compress/flate.NewReader
         0     0%   100%   528.17kB  3.53%  compress/gzip.(*Reader).Reset
         0     0%   100%   528.17kB  3.53%  compress/gzip.(*Reader).readHeader
```
