### PR TITLE
ethclient: added createAccessList

### DIFF
--- a/ethclient/ethclient.go
+++ b/ethclient/ethclient.go
@@ -515,6 +515,20 @@ func (ec *Client) EstimateGas(ctx context.Context, msg ethereum.CallMsg) (uint64
 	return uint64(hex), nil
 }
 
+// CreateAccessList tries to create an access list for a specific transaction.
+func (ec *Client) CreateAccessList(ctx context.Context, msg ethereum.CallMsg) (*types.AccessList, uint64, string, error) {
+	type accessListResult struct {
+		Accesslist *types.AccessList `json:"accessList"`
+		Error      string            `json:"error,omitempty"`
+		GasUsed    hexutil.Uint64    `json:"gasUsed"`
+	}
+	var result accessListResult
+	if err := ec.c.CallContext(ctx, &result, "eth_createAccessList", toCallArg(msg)); err != nil {
+		return nil, 0, "", err
+	}
+	return result.Accesslist, uint64(result.GasUsed), result.Error, nil
+}
+
 // SendTransaction injects a signed transaction into the pending pool for execution.
 //
 // If the transaction was a contract creation use the TransactionReceipt method to get the

--- a/ethclient/ethclient.go
+++ b/ethclient/ethclient.go
@@ -515,7 +515,8 @@ func (ec *Client) EstimateGas(ctx context.Context, msg ethereum.CallMsg) (uint64
 	return uint64(hex), nil
 }
 
-// CreateAccessList tries to create an access list for a specific transaction.
+// CreateAccessList tries to create an access list for a specific transaction based on the
+// current pending state of the blockchain.
 func (ec *Client) CreateAccessList(ctx context.Context, msg ethereum.CallMsg) (*types.AccessList, uint64, string, error) {
 	type accessListResult struct {
 		Accesslist *types.AccessList `json:"accessList"`

--- a/ethclient/ethclient_test.go
+++ b/ethclient/ethclient_test.go
@@ -622,12 +622,7 @@ func testAccessList(t *testing.T, client *rpc.Client) {
 	if len(*al) != 1 || al.StorageKeys() != 1 {
 		t.Fatalf("unexpected length of accesslist: %v", len(*al))
 	}
-	/*
-		accessList: [{
-			address: "0x3A220f351252089D385b29beca14e27F204c296A",
-			storageKeys: ["0x0000000000000000000000000000000000000000000000000000000000000081"]
-		}],
-	*/
+	// address changes between calls, so we can't test for it
 	if (*al)[0].Address == common.HexToAddress("0x0") {
 		t.Fatalf("unexpected address: %v", (*al)[0].Address)
 	}

--- a/ethclient/ethclient_test.go
+++ b/ethclient/ethclient_test.go
@@ -622,7 +622,7 @@ func testAccessList(t *testing.T, client *rpc.Client) {
 	if len(*al) != 1 || al.StorageKeys() != 1 {
 		t.Fatalf("unexpected length of accesslist: %v", len(*al))
 	}
-	// address changes between calls, so we can't test for it
+	// address changes between calls, so we can't test for it.
 	if (*al)[0].Address == common.HexToAddress("0x0") {
 		t.Fatalf("unexpected address: %v", (*al)[0].Address)
 	}


### PR DESCRIPTION
This PR adds the `eth_createAccessList` rpc call to the ethclient.