### PR TITLE
core: add new eip-1559 tx constraints

### DIFF
--- a/core/error.go
+++ b/core/error.go
@@ -72,6 +72,18 @@ var (
 	// current network configuration.
 	ErrTxTypeNotSupported = types.ErrTxTypeNotSupported
 
+	// ErrTipAboveFeeCap is a sanity error to ensure no one is able to specify a
+	// transaction with a tip higher than the total fee cap.
+	ErrTipAboveFeeCap = errors.New("tip higher than fee cap")
+
+	// ErrTipVeryHigh is a sanity error to avoid extremely big numbers specified
+	// in the tip field.
+	ErrTipVeryHigh = errors.New("tip higher than 2^256-1")
+
+	// ErrFeeCapVeryHigh is a sanity error to avoid extremely big numbers specified
+	// in the fee cap field.
+	ErrFeeCapVeryHigh = errors.New("fee cap higher than 2^256-1")
+
 	// ErrFeeCapTooLow is returned if the transaction fee cap is less than the
 	// the base fee of the block.
 	ErrFeeCapTooLow = errors.New("fee cap less than block base fee")

--- a/core/state_processor_test.go
+++ b/core/state_processor_test.go
@@ -66,7 +66,7 @@ func TestStateProcessorErrors(t *testing.T) {
 			Nonce:  nonce,
 			Tip:    tip,
 			FeeCap: feeCap,
-			Gas:    0,
+			Gas:    gasLimit,
 			To:     &to,
 			Value:  big.NewInt(0),
 		}), signer, testKey)
@@ -144,27 +144,33 @@ func TestStateProcessorErrors(t *testing.T) {
 			},
 			{ // ErrFeeCapTooLow
 				txs: []*types.Transaction{
-					mkDynamicTx(0, common.Address{}, params.TxGas-1000, big.NewInt(0), big.NewInt(0)),
+					mkDynamicTx(0, common.Address{}, params.TxGas, big.NewInt(0), big.NewInt(0)),
 				},
-				want: "could not apply tx 0 [0x21e9b9015150fc7f6bd5059890a5e1727f2452df285e8a84f4ca61a74c159ded]: fee cap less than block base fee: address 0x71562b71999873DB5b286dF957af199Ec94617F7, feeCap: 0 baseFee: 875000000",
+				want: "could not apply tx 0 [0xc4ab868fef0c82ae0387b742aee87907f2d0fc528fc6ea0a021459fb0fc4a4a8]: fee cap less than block base fee: address 0x71562b71999873DB5b286dF957af199Ec94617F7, feeCap: 0 baseFee: 875000000",
 			},
 			{ // ErrTipVeryHigh
 				txs: []*types.Transaction{
-					mkDynamicTx(0, common.Address{}, params.TxGas-1000, veryBigNumber, big.NewInt(1)),
+					mkDynamicTx(0, common.Address{}, params.TxGas, veryBigNumber, big.NewInt(1)),
 				},
-				want: "could not apply tx 0 [0xf1d416d1f548bb9ea84cdd8d1c6ad370caa8f670b831dd8048f71d52e43c5e2b]: tip higher than 2^256-1: address 0x71562b71999873DB5b286dF957af199Ec94617F7, tip byte length: 38",
+				want: "could not apply tx 0 [0x56a98c4e7714c63ebd41e56c7ab399e237a690b68139f2a9e3bfeab01ade8473]: tip higher than 2^256-1: address 0x71562b71999873DB5b286dF957af199Ec94617F7, tip byte length: 38",
 			},
 			{ // ErrFeeCapVeryHigh
 				txs: []*types.Transaction{
-					mkDynamicTx(0, common.Address{}, params.TxGas-1000, big.NewInt(1), veryBigNumber),
+					mkDynamicTx(0, common.Address{}, params.TxGas, big.NewInt(1), veryBigNumber),
 				},
-				want: "could not apply tx 0 [0x6d1cba2357c510a18eee03894057c3acaad2db6624080467da3e3a3ba84ec7ca]: fee cap higher than 2^256-1: address 0x71562b71999873DB5b286dF957af199Ec94617F7, feeCap byte length: 38",
+				want: "could not apply tx 0 [0x41dcd104694d9ed0cd2a7957707483939eae5f57d8de625f56e75b88a7709ac0]: fee cap higher than 2^256-1: address 0x71562b71999873DB5b286dF957af199Ec94617F7, feeCap byte length: 38",
 			},
 			{ // ErrTipAboveFeeCap
 				txs: []*types.Transaction{
-					mkDynamicTx(0, common.Address{}, params.TxGas-1000, big.NewInt(2), big.NewInt(1)),
+					mkDynamicTx(0, common.Address{}, params.TxGas, big.NewInt(2), big.NewInt(1)),
 				},
-				want: "could not apply tx 0 [0xa7ef91f7636e56676ba73f16e14e74d5556d3def48819a77217962580b19339f]: tip higher than fee cap: address 0x71562b71999873DB5b286dF957af199Ec94617F7, tip: 1, feeCap: 2",
+				want: "could not apply tx 0 [0xf987a31ff0c71895780a7612f965a0c8b056deb54e020bb44fa478092f14c9b4]: tip higher than fee cap: address 0x71562b71999873DB5b286dF957af199Ec94617F7, tip: 1, feeCap: 2",
+			},
+			{ // ErrInsufficientFunds
+				txs: []*types.Transaction{
+					mkDynamicTx(0, common.Address{}, params.TxGas, big.NewInt(1), big.NewInt(1000000000000000000)),
+				},
+				want: "could not apply tx 0 [0xbe93a7a024ea94e4156851ceab721dd300abd8509a6fa4216a58152982619973]: insufficient funds for gas * price + value: address 0x71562b71999873DB5b286dF957af199Ec94617F7 have 1000000000000000000 want 21000000000000000000000",
 			},
 		} {
 			block := GenerateBadBlock(genesis, ethash.NewFaker(), tt.txs, gspec.Config)
@@ -214,7 +220,7 @@ func TestStateProcessorErrors(t *testing.T) {
 				txs: []*types.Transaction{
 					mkDynamicTx(0, common.Address{}, params.TxGas-1000, big.NewInt(0), big.NewInt(0)),
 				},
-				want: "could not apply tx 0 [0x21e9b9015150fc7f6bd5059890a5e1727f2452df285e8a84f4ca61a74c159ded]: transaction type not supported",
+				want: "could not apply tx 0 [0x88626ac0d53cb65308f2416103c62bb1f18b805573d4f96a3640bbbfff13c14f]: transaction type not supported",
 			},
 		} {
 			block := GenerateBadBlock(genesis, ethash.NewFaker(), tt.txs, gspec.Config)

--- a/core/state_processor_test.go
+++ b/core/state_processor_test.go
@@ -152,13 +152,13 @@ func TestStateProcessorErrors(t *testing.T) {
 				txs: []*types.Transaction{
 					mkDynamicTx(0, common.Address{}, params.TxGas, veryBigNumber, big.NewInt(1)),
 				},
-				want: "could not apply tx 0 [0x56a98c4e7714c63ebd41e56c7ab399e237a690b68139f2a9e3bfeab01ade8473]: tip higher than 2^256-1: address 0x71562b71999873DB5b286dF957af199Ec94617F7, tip byte length: 38",
+				want: "could not apply tx 0 [0x56a98c4e7714c63ebd41e56c7ab399e237a690b68139f2a9e3bfeab01ade8473]: tip higher than 2^256-1: address 0x71562b71999873DB5b286dF957af199Ec94617F7, tip bit length: 301",
 			},
 			{ // ErrFeeCapVeryHigh
 				txs: []*types.Transaction{
 					mkDynamicTx(0, common.Address{}, params.TxGas, big.NewInt(1), veryBigNumber),
 				},
-				want: "could not apply tx 0 [0x41dcd104694d9ed0cd2a7957707483939eae5f57d8de625f56e75b88a7709ac0]: fee cap higher than 2^256-1: address 0x71562b71999873DB5b286dF957af199Ec94617F7, feeCap byte length: 38",
+				want: "could not apply tx 0 [0x41dcd104694d9ed0cd2a7957707483939eae5f57d8de625f56e75b88a7709ac0]: fee cap higher than 2^256-1: address 0x71562b71999873DB5b286dF957af199Ec94617F7, feeCap bit length: 301",
 			},
 			{ // ErrTipAboveFeeCap
 				txs: []*types.Transaction{

--- a/core/state_transition.go
+++ b/core/state_transition.go
@@ -187,14 +187,14 @@ func (st *StateTransition) to() common.Address {
 }
 
 func (st *StateTransition) buyGas() error {
-	mgval := new(big.Int).Mul(new(big.Int).SetUint64(st.msg.Gas()), st.gasPrice)
-	var balanceReq *big.Int
+	mgval := new(big.Int).SetUint64(st.msg.Gas())
+	mgval = mgval.Mul(mgval, st.gasPrice)
+	balanceCheck := mgval
 	if st.feeCap != nil {
-		balanceReq = new(big.Int).Mul(new(big.Int).SetUint64(st.msg.Gas()), st.feeCap)
-	} else {
-		balanceReq = mgval
+		balanceCheck = new(big.Int).SetUint64(st.msg.Gas())
+		balanceCheck = balanceCheck.Mul(balanceCheck, st.feeCap)
 	}
-	if have, want := st.state.GetBalance(st.msg.From()), balanceReq; have.Cmp(want) < 0 {
+	if have, want := st.state.GetBalance(st.msg.From()), balanceCheck; have.Cmp(want) < 0 {
 		return fmt.Errorf("%w: address %v have %v want %v", ErrInsufficientFunds, st.msg.From().Hex(), have, want)
 	}
 	if err := st.gp.SubGas(st.msg.Gas()); err != nil {

--- a/core/state_transition.go
+++ b/core/state_transition.go
@@ -188,7 +188,12 @@ func (st *StateTransition) to() common.Address {
 
 func (st *StateTransition) buyGas() error {
 	mgval := new(big.Int).Mul(new(big.Int).SetUint64(st.msg.Gas()), st.gasPrice)
-	balanceReq := new(big.Int).Mul(new(big.Int).SetUint64(st.msg.Gas()), st.feeCap)
+	var balanceReq *big.Int
+	if st.feeCap != nil {
+		balanceReq = new(big.Int).Mul(new(big.Int).SetUint64(st.msg.Gas()), st.feeCap)
+	} else {
+		balanceReq = mgval
+	}
 	if have, want := st.state.GetBalance(st.msg.From()), balanceReq; have.Cmp(want) < 0 {
 		return fmt.Errorf("%w: address %v have %v want %v", ErrInsufficientFunds, st.msg.From().Hex(), have, want)
 	}

--- a/core/state_transition.go
+++ b/core/state_transition.go
@@ -188,7 +188,8 @@ func (st *StateTransition) to() common.Address {
 
 func (st *StateTransition) buyGas() error {
 	mgval := new(big.Int).Mul(new(big.Int).SetUint64(st.msg.Gas()), st.gasPrice)
-	if have, want := st.state.GetBalance(st.msg.From()), mgval; have.Cmp(want) < 0 {
+	balanceReq := new(big.Int).Mul(new(big.Int).SetUint64(st.msg.Gas()), st.feeCap)
+	if have, want := st.state.GetBalance(st.msg.From()), balanceReq; have.Cmp(want) < 0 {
 		return fmt.Errorf("%w: address %v have %v want %v", ErrInsufficientFunds, st.msg.From().Hex(), have, want)
 	}
 	if err := st.gp.SubGas(st.msg.Gas()); err != nil {

--- a/core/state_transition.go
+++ b/core/state_transition.go
@@ -216,12 +216,12 @@ func (st *StateTransition) preCheck() error {
 	}
 	// Make sure that transaction feeCap is greater than the baseFee (post london)
 	if st.evm.ChainConfig().IsLondon(st.evm.Context.BlockNumber) {
-		if l := len(st.feeCap.Bytes()); l > 32 {
-			return fmt.Errorf("%w: address %v, feeCap byte length: %d", ErrFeeCapVeryHigh,
+		if l := st.feeCap.BitLen(); l > 256 {
+			return fmt.Errorf("%w: address %v, feeCap bit length: %d", ErrFeeCapVeryHigh,
 				st.msg.From().Hex(), l)
 		}
-		if l := len(st.tip.Bytes()); l > 32 {
-			return fmt.Errorf("%w: address %v, tip byte length: %d", ErrTipVeryHigh,
+		if l := st.tip.BitLen(); l > 256 {
+			return fmt.Errorf("%w: address %v, tip bit length: %d", ErrTipVeryHigh,
 				st.msg.From().Hex(), l)
 		}
 		if st.feeCap.Cmp(st.tip) < 0 {

--- a/core/tx_pool.go
+++ b/core/tx_pool.go
@@ -556,10 +556,10 @@ func (pool *TxPool) validateTx(tx *types.Transaction, local bool) error {
 		return ErrGasLimit
 	}
 	// Sanity check for extremely large numbers
-	if len(tx.FeeCap().Bytes()) > 32 {
+	if tx.FeeCap().BitLen() > 256 {
 		return ErrFeeCapVeryHigh
 	}
-	if len(tx.Tip().Bytes()) > 32 {
+	if tx.Tip().BitLen() > 256 {
 		return ErrTipVeryHigh
 	}
 	// Ensure feeCap is less than or equal to tip.

--- a/core/tx_pool.go
+++ b/core/tx_pool.go
@@ -83,10 +83,6 @@ var (
 	// than some meaningful limit a user might use. This is not a consensus error
 	// making the transaction invalid, rather a DOS protection.
 	ErrOversizedData = errors.New("oversized data")
-
-	// ErrTipAboveFeeCap is a sanity error to ensure no one is able to specify a
-	// transaction with a tip higher than the total fee cap.
-	ErrTipAboveFeeCap = errors.New("tip higher than fee cap")
 )
 
 var (
@@ -558,6 +554,13 @@ func (pool *TxPool) validateTx(tx *types.Transaction, local bool) error {
 	// Ensure the transaction doesn't exceed the current block limit gas.
 	if pool.currentMaxGas < tx.Gas() {
 		return ErrGasLimit
+	}
+	// Sanity check for extremely large numbers
+	if len(tx.FeeCap().Bytes()) > 32 {
+		return ErrFeeCapVeryHigh
+	}
+	if len(tx.Tip().Bytes()) > 32 {
+		return ErrTipVeryHigh
 	}
 	// Ensure feeCap is less than or equal to tip.
 	if tx.FeeCapIntCmp(tx.Tip()) < 0 {

--- a/core/tx_pool_test.go
+++ b/core/tx_pool_test.go
@@ -395,6 +395,26 @@ func TestTransactionTipAboveFeeCap(t *testing.T) {
 	}
 }
 
+func TestTransactionVeryHighValues(t *testing.T) {
+	t.Parallel()
+
+	pool, key := setupTxPoolWithConfig(eip1559Config)
+	defer pool.Stop()
+
+	veryBigNumber := big.NewInt(1)
+	veryBigNumber.Lsh(veryBigNumber, 300)
+
+	tx := dynamicFeeTx(0, 100, big.NewInt(1), veryBigNumber, key)
+	if err := pool.AddRemote(tx); err != ErrTipVeryHigh {
+		t.Error("expected", ErrTipVeryHigh, "got", err)
+	}
+
+	tx2 := dynamicFeeTx(0, 100, veryBigNumber, big.NewInt(1), key)
+	if err := pool.AddRemote(tx2); err != ErrFeeCapVeryHigh {
+		t.Error("expected", ErrFeeCapVeryHigh, "got", err)
+	}
+}
+
 func TestTransactionChainFork(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
This PR adds the new consensus constraints of EIP-1559 transactions as specified here:
https://github.com/ethereum/EIPs/pull/3594
Note: the same sanity checks are performed first during tx pool validation even though the previously existing filters would filter out the same transactions. This way the same error types can be returned by the pool and by consensus.