### PR TITLE
core/rawdb: db inspect move 'config' and 'shutdown' into 'meta data'

### DIFF
--- a/core/rawdb/database.go
+++ b/core/rawdb/database.go
@@ -318,7 +318,6 @@ func InspectDatabase(db ethdb.Database, keyPrefix, keyStart []byte) error {
 		// Meta- and unaccounted data
 		metadata     stat
 		unaccounted  stat
-		shutdownInfo stat
 
 		// Totals
 		total common.StorageSize
@@ -355,6 +354,8 @@ func InspectDatabase(db ethdb.Database, keyPrefix, keyStart []byte) error {
 			storageSnaps.Add(size)
 		case bytes.HasPrefix(key, preimagePrefix) && len(key) == (len(preimagePrefix)+common.HashLength):
 			preimages.Add(size)
+		case bytes.HasPrefix(key, configPrefix) && len(key) == (len(configPrefix)+common.HashLength):
+			metadata.Add(size)
 		case bytes.HasPrefix(key, bloomBitsPrefix) && len(key) == (len(bloomBitsPrefix)+10+common.HashLength):
 			bloomBits.Add(size)
 		case bytes.HasPrefix(key, BloomBitsIndexPrefix):
@@ -369,8 +370,6 @@ func InspectDatabase(db ethdb.Database, keyPrefix, keyStart []byte) error {
 			bytes.HasPrefix(key, []byte("bltIndex-")) ||
 			bytes.HasPrefix(key, []byte("bltRoot-")): // Bloomtrie sub
 			bloomTrieNodes.Add(size)
-		case bytes.Equal(key, uncleanShutdownKey):
-			shutdownInfo.Add(size)
 		default:
 			var accounted bool
 			for _, meta := range [][]byte{
@@ -425,7 +424,6 @@ func InspectDatabase(db ethdb.Database, keyPrefix, keyStart []byte) error {
 		{"Key-Value store", "Storage snapshot", storageSnaps.Size(), storageSnaps.Count()},
 		{"Key-Value store", "Clique snapshots", cliqueSnaps.Size(), cliqueSnaps.Count()},
 		{"Key-Value store", "Singleton metadata", metadata.Size(), metadata.Count()},
-		{"Key-Value store", "Shutdown metadata", shutdownInfo.Size(), shutdownInfo.Count()},
 		{"Ancient store", "Headers", ancientHeadersSize.String(), ancients.String()},
 		{"Ancient store", "Bodies", ancientBodiesSize.String(), ancients.String()},
 		{"Ancient store", "Receipt lists", ancientReceiptsSize.String(), ancients.String()},

--- a/core/rawdb/database.go
+++ b/core/rawdb/database.go
@@ -316,8 +316,8 @@ func InspectDatabase(db ethdb.Database, keyPrefix, keyStart []byte) error {
 		bloomTrieNodes stat
 
 		// Meta- and unaccounted data
-		metadata     stat
-		unaccounted  stat
+		metadata    stat
+		unaccounted stat
 
 		// Totals
 		total common.StorageSize


### PR DESCRIPTION
Avoid the error message of Database contains `unaccounted data`
![image](https://user-images.githubusercontent.com/35091674/120314017-59972180-c30d-11eb-8434-29c56758611f.png)