### PR TITLE
trie: small optimization of delete in fullNode case

### DIFF
--- a/trie/trie.go
+++ b/trie/trie.go
@@ -405,6 +405,10 @@ func (t *Trie) delete(n node, prefix, key []byte) (bool, node, error) {
 		n.flags = t.newFlag()
 		n.Children[key[0]] = nn
 
+		if nn != nil {
+			// n still contains at least two values and cannot be reduced.
+			return true, n, nil
+		}
 		// Check how many non-nil entries are left after deleting and
 		// reduce the full node to a short node if only one entry is
 		// left. Since n must've contained at least two children

--- a/trie/trie.go
+++ b/trie/trie.go
@@ -405,10 +405,14 @@ func (t *Trie) delete(n node, prefix, key []byte) (bool, node, error) {
 		n.flags = t.newFlag()
 		n.Children[key[0]] = nn
 
+		// Because n is a full node, it must've contained at least two children
+		// before the delete operation. If the new child value is non-nil, n still
+		// has at least two children after the deletion, and cannot be reduced to
+		// a short node.
 		if nn != nil {
-			// n still contains at least two values and cannot be reduced.
 			return true, n, nil
-		}
+		}		
+		// Reduction:
 		// Check how many non-nil entries are left after deleting and
 		// reduce the full node to a short node if only one entry is
 		// left. Since n must've contained at least two children

--- a/trie/trie.go
+++ b/trie/trie.go
@@ -411,7 +411,7 @@ func (t *Trie) delete(n node, prefix, key []byte) (bool, node, error) {
 		// a short node.
 		if nn != nil {
 			return true, n, nil
-		}		
+		}
 		// Reduction:
 		// Check how many non-nil entries are left after deleting and
 		// reduce the full node to a short node if only one entry is


### PR DESCRIPTION
when `nn` is not `nil`, there is no need to check the number of non-nil entries.
Since n must've contained at least two children before deletion, there must be another child node other than `nn`.