### PR TITLE
node: keep rpc interface open longer during shutdown process

### DIFF
--- a/node/node.go
+++ b/node/node.go
@@ -285,8 +285,6 @@ func containsLifecycle(lfs []Lifecycle, l Lifecycle) bool {
 // stopServices terminates running services, RPC and p2p networking.
 // It is the inverse of Start.
 func (n *Node) stopServices(running []Lifecycle) error {
-	n.stopRPC()
-
 	// Stop running lifecycles in reverse order.
 	failure := &StopError{Services: make(map[reflect.Type]error)}
 	for i := len(running) - 1; i >= 0; i-- {
@@ -294,9 +292,9 @@ func (n *Node) stopServices(running []Lifecycle) error {
 			failure.Services[reflect.TypeOf(running[i])] = err
 		}
 	}
-
 	// Stop p2p networking.
 	n.server.Stop()
+	n.stopRPC()
 
 	if len(failure.Services) > 0 {
 		return failure


### PR DESCRIPTION
This PR keeps the RPC capabilities open during the shutdown process, instead of closing those as the first thing. Closes https://github.com/ethereum/go-ethereum/issues/22971 . 

This is also good from another perspective: we've had problems from time to time with shutdown stalls, which can be a bit tricky to get to the bottom with. This change makes it so that we can still access `debug.stacks()` even after shutdown is ongoing. 

As for testing, I added a 1-minute delay before the `n.stopRPC()` call, and in that time made some calls to e.g. `eth.getBlock("latest")`. That seemed to work fine, even though the blockchain was already closed. I suspect some other calls may be borked if the blockchain is closed, but not sure. 

Putting it up for discussion. 