### PR TITLE
cmd/faucet: disable flaky facebook test

### DIFF
--- a/cmd/faucet/faucet_test.go
+++ b/cmd/faucet/faucet_test.go
@@ -23,6 +23,8 @@ import (
 )
 
 func TestFacebook(t *testing.T) {
+	// TODO: Remove facebook auth or implement facebook api, which seems to require an API key
+	t.Skipf("The facebook access is flaky, needs to be reimplemented or removed")
 	for _, tt := range []struct {
 		url  string
 		want common.Address


### PR DESCRIPTION
This disables the facebook-test, which fails very often on CI. See https://github.com/ethereum/go-ethereum/pull/22985 