### PR TITLE
internal: get pending and queued transaction by address

### DIFF
--- a/core/tx_pool.go
+++ b/core/tx_pool.go
@@ -499,11 +499,11 @@ func (pool *TxPool) ContentFrom(addr common.Address) (types.Transactions, types.
 	pool.mu.RLock()
 	defer pool.mu.RUnlock()
 
-	pending := types.Transactions{}
+	var pending types.Transactions
 	if list, ok := pool.pending[addr]; ok {
 		pending = list.Flatten()
 	}
-	queued := types.Transactions{}
+	var queued types.Transactions
 	if list, ok := pool.queue[addr]; ok {
 		queued = list.Flatten()
 	}

--- a/core/tx_pool.go
+++ b/core/tx_pool.go
@@ -493,6 +493,23 @@ func (pool *TxPool) Content() (map[common.Address]types.Transactions, map[common
 	return pending, queued
 }
 
+// ContentFrom retrieves the data content of the transaction pool, returning the
+// pending as well as queued transactions of this address, grouped by nonce.
+func (pool *TxPool) ContentFrom(addr common.Address) (types.Transactions, types.Transactions) {
+	pool.mu.RLock()
+	defer pool.mu.RUnlock()
+
+	pending := types.Transactions{}
+	if list, ok := pool.pending[addr]; ok {
+		pending = list.Flatten()
+	}
+	queued := types.Transactions{}
+	if list, ok := pool.queue[addr]; ok {
+		queued = list.Flatten()
+	}
+	return pending, queued
+}
+
 // Pending retrieves all currently processable transactions, grouped by origin
 // account and sorted by nonce. The returned transaction set is a copy and can be
 // freely modified by calling code.

--- a/eth/api_backend.go
+++ b/eth/api_backend.go
@@ -263,6 +263,10 @@ func (b *EthAPIBackend) TxPoolContent() (map[common.Address]types.Transactions, 
 	return b.eth.TxPool().Content()
 }
 
+func (b *EthAPIBackend) TxPoolContentFrom(addr common.Address) (types.Transactions, types.Transactions) {
+	return b.eth.TxPool().ContentFrom(addr)
+}
+
 func (b *EthAPIBackend) TxPool() *core.TxPool {
 	return b.eth.TxPool()
 }

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -141,6 +141,29 @@ func (s *PublicTxPoolAPI) Content() map[string]map[string]map[string]*RPCTransac
 	return content
 }
 
+// ContentFrom returns the transactions contained within the transaction pool.
+func (s *PublicTxPoolAPI) ContentFrom(addr common.Address) map[string]map[string]*RPCTransaction {
+	content := make(map[string]map[string]*RPCTransaction, 2)
+	pending, queue := s.b.TxPoolContentFrom(addr)
+	curHeader := s.b.CurrentHeader()
+
+	// Build the pending transactions
+	dump := make(map[string]*RPCTransaction, len(pending))
+	for _, tx := range pending {
+		dump[fmt.Sprintf("%d", tx.Nonce())] = newRPCPendingTransaction(tx, curHeader, s.b.ChainConfig())
+	}
+	content["pending"] = dump
+
+	// Build the queued transactions
+	dump = make(map[string]*RPCTransaction, len(queue))
+	for _, tx := range queue {
+		dump[fmt.Sprintf("%d", tx.Nonce())] = newRPCPendingTransaction(tx, curHeader, s.b.ChainConfig())
+	}
+	content["queued"] = dump
+
+	return content
+}
+
 // Status returns the number of pending and queued transaction in the pool.
 func (s *PublicTxPoolAPI) Status() map[string]hexutil.Uint {
 	pending, queue := s.b.Stats()

--- a/internal/ethapi/backend.go
+++ b/internal/ethapi/backend.go
@@ -76,6 +76,7 @@ type Backend interface {
 	GetPoolNonce(ctx context.Context, addr common.Address) (uint64, error)
 	Stats() (pending int, queued int)
 	TxPoolContent() (map[common.Address]types.Transactions, map[common.Address]types.Transactions)
+	TxPoolContentFrom(addr common.Address) (types.Transactions, types.Transactions)
 	SubscribeNewTxsEvent(chan<- core.NewTxsEvent) event.Subscription
 
 	// Filter API

--- a/internal/web3ext/web3ext.go
+++ b/internal/web3ext/web3ext.go
@@ -798,6 +798,11 @@ web3._extend({
 				return status;
 			}
 		}),
+		new web3._extend.Method({
+			name: 'contentFrom',
+			call: 'txpool_contentFrom',
+			params: 1,
+		}),
 	]
 });
 `

--- a/les/api_backend.go
+++ b/les/api_backend.go
@@ -212,6 +212,10 @@ func (b *LesApiBackend) TxPoolContent() (map[common.Address]types.Transactions, 
 	return b.eth.txPool.Content()
 }
 
+func (b *LesApiBackend) TxPoolContentFrom(addr common.Address) (types.Transactions, types.Transactions) {
+	return b.eth.txPool.ContentFrom(addr)
+}
+
 func (b *LesApiBackend) SubscribeNewTxsEvent(ch chan<- core.NewTxsEvent) event.Subscription {
 	return b.eth.txPool.SubscribeNewTxsEvent(ch)
 }

--- a/light/txpool.go
+++ b/light/txpool.go
@@ -512,7 +512,7 @@ func (pool *TxPool) ContentFrom(addr common.Address) (types.Transactions, types.
 	defer pool.mu.RUnlock()
 
 	// Retrieve the pending transactions and sort by nonce
-	pending := types.Transactions{}
+	var pending types.Transactions
 	for _, tx := range pool.pending {
 		account, _ := types.Sender(pool.signer, tx)
 		if account != addr {

--- a/light/txpool.go
+++ b/light/txpool.go
@@ -505,6 +505,25 @@ func (pool *TxPool) Content() (map[common.Address]types.Transactions, map[common
 	return pending, queued
 }
 
+// ContentFrom retrieves the data content of the transaction pool, returning the
+// pending as well as queued transactions of this address, grouped by nonce.
+func (pool *TxPool) ContentFrom(addr common.Address) (types.Transactions, types.Transactions) {
+	pool.mu.RLock()
+	defer pool.mu.RUnlock()
+
+	// Retrieve the pending transactions and sort by nonce
+	pending := types.Transactions{}
+	for _, tx := range pool.pending {
+		account, _ := types.Sender(pool.signer, tx)
+		if account != addr {
+			continue
+		}
+		pending = append(pending, tx)
+	}
+	// There are no queued transactions in a light pool, just return an empty map
+	return pending, types.Transactions{}
+}
+
 // RemoveTransactions removes all given transactions from the pool.
 func (pool *TxPool) RemoveTransactions(txs types.Transactions) {
 	pool.mu.Lock()


### PR DESCRIPTION
We can call Content() to get `all` pending and queued transactions, but the response is really large... 
This pull request implements an API to filter the pending/queued transactions by an address.