### PR TITLE
core: make genesis parse baseFee correctly

### DIFF
--- a/core/gen_genesis.go
+++ b/core/gen_genesis.go
@@ -30,7 +30,7 @@ func (g Genesis) MarshalJSON() ([]byte, error) {
 		Number     math.HexOrDecimal64                         `json:"number"`
 		GasUsed    math.HexOrDecimal64                         `json:"gasUsed"`
 		ParentHash common.Hash                                 `json:"parentHash"`
-		BaseFee    *big.Int                                    `json:"baseFee"`
+		BaseFee    *math.HexOrDecimal256                       `json:"baseFee"`
 	}
 	var enc Genesis
 	enc.Config = g.Config
@@ -50,7 +50,7 @@ func (g Genesis) MarshalJSON() ([]byte, error) {
 	enc.Number = math.HexOrDecimal64(g.Number)
 	enc.GasUsed = math.HexOrDecimal64(g.GasUsed)
 	enc.ParentHash = g.ParentHash
-	enc.BaseFee = g.BaseFee
+	enc.BaseFee = (*math.HexOrDecimal256)(g.BaseFee)
 	return json.Marshal(&enc)
 }
 
@@ -69,7 +69,7 @@ func (g *Genesis) UnmarshalJSON(input []byte) error {
 		Number     *math.HexOrDecimal64                        `json:"number"`
 		GasUsed    *math.HexOrDecimal64                        `json:"gasUsed"`
 		ParentHash *common.Hash                                `json:"parentHash"`
-		BaseFee    *big.Int                                    `json:"baseFee"`
+		BaseFee    *math.HexOrDecimal256                       `json:"baseFee"`
 	}
 	var dec Genesis
 	if err := json.Unmarshal(input, &dec); err != nil {
@@ -118,7 +118,7 @@ func (g *Genesis) UnmarshalJSON(input []byte) error {
 		g.ParentHash = *dec.ParentHash
 	}
 	if dec.BaseFee != nil {
-		g.BaseFee = dec.BaseFee
+		g.BaseFee = (*big.Int)(dec.BaseFee)
 	}
 	return nil
 }

--- a/core/genesis.go
+++ b/core/genesis.go
@@ -98,6 +98,7 @@ type genesisSpecMarshaling struct {
 	GasUsed    math.HexOrDecimal64
 	Number     math.HexOrDecimal64
 	Difficulty *math.HexOrDecimal256
+	BaseFee    *math.HexOrDecimal256
 	Alloc      map[common.UnprefixedAddress]GenesisAccount
 }
 


### PR DESCRIPTION
This is needed to parse genesis basefee with hex encoding which is used for consensus-tests in hive