### PR TITLE
Rename unused function with typo

### DIFF
--- a/common/debug.go
+++ b/common/debug.go
@@ -37,8 +37,8 @@ func Report(extra ...interface{}) {
 	fmt.Fprintln(os.Stderr, "#### BUG! PLEASE REPORT ####")
 }
 
-// PrintDepricationWarning prinst the given string in a box using fmt.Println.
-func PrintDepricationWarning(str string) {
+// PrintDeprecationWarning prints the given string in a box using fmt.Println.
+func PrintDeprecationWarning(str string) {
 	line := strings.Repeat("#", len(str)+4)
 	emptyLine := strings.Repeat(" ", len(str))
 	fmt.Printf(`


### PR DESCRIPTION
This function is not used in the code base, so probably safe to do rename, or remove in its entirety, but I'm assuming the logic from the original creator still applies so rename probably better.