### PR TITLE
eth/ethconfig: bump the RPC gas cap to 50M, since 1559 exceeds 25

### DIFF
--- a/eth/ethconfig/config.go
+++ b/eth/ethconfig/config.go
@@ -85,7 +85,7 @@ var Defaults = Config{
 		Recommit: 3 * time.Second,
 	},
 	TxPool:      core.DefaultTxPoolConfig,
-	RPCGasCap:   25000000,
+	RPCGasCap:   50000000,
 	GPO:         FullNodeGPO,
 	RPCTxFeeCap: 1, // 1 ether
 }


### PR DESCRIPTION
Make sure we don't limit the gas estimation to below the actual block size.