### PR TITLE
cmd/geth metrics doesn't work when start with config file

### DIFF
--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -37,7 +37,6 @@ import (
 	"github.com/ethereum/go-ethereum/internal/ethapi"
 	"github.com/ethereum/go-ethereum/internal/flags"
 	"github.com/ethereum/go-ethereum/log"
-	"github.com/ethereum/go-ethereum/metrics"
 	"github.com/ethereum/go-ethereum/node"
 	"gopkg.in/urfave/cli.v1"
 )
@@ -300,11 +299,12 @@ func prepare(ctx *cli.Context) {
 		ctx.GlobalSet(utils.CacheFlag.Name, strconv.Itoa(128))
 	}
 
+	// Maybe we should move this initialization to later
 	// Start metrics export if enabled
-	utils.SetupMetrics(ctx)
+	//utils.SetupMetrics(ctx)
 
 	// Start system runtime metrics collection
-	go metrics.CollectProcessMetrics(3 * time.Second)
+	//go metrics.CollectProcessMetrics(3 * time.Second)
 }
 
 // geth is the main entry point into the system if no special subcommand is ran.


### PR DESCRIPTION
```shell
geth --metrics --metrics.addr 127.0.0.1 dumpconfig  > geth.toml
geth --config geth.toml
```
The setting of metrics doesn't work in this case and I tried to do some changes.