### PR TITLE
trie/proof.go "VerifyProof" doesn't check whether the hash is correct

### DIFF
--- a/trie/proof.go
+++ b/trie/proof.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/ethdb"
 	"github.com/ethereum/go-ethereum/ethdb/memorydb"
 	"github.com/ethereum/go-ethereum/log"
@@ -110,6 +111,10 @@ func VerifyProof(rootHash common.Hash, key []byte, proofDb ethdb.KeyValueReader)
 		buf, _ := proofDb.Get(wantHash[:])
 		if buf == nil {
 			return nil, fmt.Errorf("proof node %d (hash %064x) missing", i, wantHash)
+		}
+		bufHash := crypto.Keccak256(buf)
+		if !bytes.Equal(wantHash[:], bufHash) {
+			return nil, fmt.Errorf("fake proof node %d: (want hash %064x, final hash %064x)", i, wantHash, bufHash)
 		}
 		n, err := decodeNode(wantHash[:], buf)
 		if err != nil {

--- a/trie/proof.go
+++ b/trie/proof.go
@@ -22,7 +22,6 @@ import (
 	"fmt"
 
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/ethdb"
 	"github.com/ethereum/go-ethereum/ethdb/memorydb"
 	"github.com/ethereum/go-ethereum/log"
@@ -107,12 +106,14 @@ func (t *SecureTrie) Prove(key []byte, fromLevel uint, proofDb ethdb.KeyValueWri
 func VerifyProof(rootHash common.Hash, key []byte, proofDb ethdb.KeyValueReader) (value []byte, err error) {
 	key = keybytesToHex(key)
 	wantHash := rootHash
+	hasher := newHasher(false)
+	defer returnHasherToPool(hasher)
 	for i := 0; ; i++ {
 		buf, _ := proofDb.Get(wantHash[:])
 		if buf == nil {
 			return nil, fmt.Errorf("proof node %d (hash %064x) missing", i, wantHash)
 		}
-		bufHash := crypto.Keccak256(buf)
+		bufHash := hasher.hashData(buf)
 		if !bytes.Equal(wantHash[:], bufHash) {
 			return nil, fmt.Errorf("fake proof node %d: (want hash %064x, final hash %064x)", i, wantHash, bufHash)
 		}

--- a/trie/proof_test.go
+++ b/trie/proof_test.go
@@ -65,7 +65,7 @@ func makeBadProver(trie *Trie) func(key []byte) *memorydb.Database {
 		if it := NewIterator(trie.NodeIterator(key)); it.Next() && bytes.Equal(key, it.Key) {
 			for _, p := range it.Prove() {
 				last = crypto.Keccak256(p)
-				proof.Put(crypto.Keccak256(p), p)
+				proof.Put(last, p)
 			}
 			// make a wrong final value
 			p, _ := proof.Get(last)


### PR DESCRIPTION
If an attacker just change the value of `proofDb`, `VerifyProof` can't detect the problem.