### PR TITLE
[DRAFT] internal/ethapi: added debug_burnedETH to query burned ether due to 1559

### DIFF
--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -1949,10 +1949,10 @@ func (api *PrivateDebugAPI) SetHead(number hexutil.Uint64) {
 	api.b.SetHead(uint64(number))
 }
 
-// BurnedETH returns the amount of burned ether for a specific
+// Burned returns the amount of burned ether for a specific
 // range of blocks under eip-1559.
 // The returned value is in denoted in Wei.
-func (api *PrivateDebugAPI) BurnedETH(start, end *hexutil.Uint64) (*hexutil.Big, error) {
+func (api *PrivateDebugAPI) Burned(start, end *hexutil.Uint64) (*hexutil.Big, error) {
 	burned := big.NewInt(0)
 	startBlock := 0
 	endBlock := int(api.b.CurrentHeader().Number.Int64())
@@ -1966,13 +1966,13 @@ func (api *PrivateDebugAPI) BurnedETH(start, end *hexutil.Uint64) (*hexutil.Big,
 		return (*hexutil.Big)(burned), errors.New("invalid range specified, start > end")
 	}
 	for i := startBlock; i < endBlock; i++ {
-		block, err := api.b.BlockByNumber(context.Background(), rpc.BlockNumber(i))
+		header, err := api.b.HeaderByNumber(context.Background(), rpc.BlockNumber(i))
 		if err != nil {
 			return (*hexutil.Big)(burned), err
 		}
-		txs := len(block.Transactions())
-		if basefee := block.Header().BaseFee; basefee != nil && basefee.Cmp(common.Big0) != 0 {
-			burnedBlock := new(big.Int).Mul(basefee, big.NewInt(int64(txs)))
+
+		if basefee := header.BaseFee; basefee != nil && basefee.Cmp(common.Big0) != 0 {
+			burnedBlock := new(big.Int).Mul(basefee, big.NewInt(int64(header.GasUsed)))
 			burned = new(big.Int).Add(burned, burnedBlock)
 		}
 	}

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -1972,8 +1972,8 @@ func (api *PrivateDebugAPI) Burned(start, end *hexutil.Uint64) (*hexutil.Big, er
 		}
 
 		if basefee := header.BaseFee; basefee != nil && basefee.Cmp(common.Big0) != 0 {
-			burnedBlock := new(big.Int).Mul(basefee, big.NewInt(int64(header.GasUsed)))
-			burned = new(big.Int).Add(burned, burnedBlock)
+			gasUsed := big.NewInt(int64(header.GasUsed))
+			burned.Add(burned, gasUsed.Mul(gasUsed, basefee))
 		}
 	}
 	return (*hexutil.Big)(burned), nil

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -1965,7 +1965,7 @@ func (api *PrivateDebugAPI) Burned(start, end *hexutil.Uint64) (*hexutil.Big, er
 	if startBlock > endBlock {
 		return (*hexutil.Big)(burned), errors.New("invalid range specified, start > end")
 	}
-	for i := startBlock; i < endBlock; i++ {
+	for i := startBlock; i <= endBlock; i++ {
 		header, err := api.b.HeaderByNumber(context.Background(), rpc.BlockNumber(i))
 		if err != nil {
 			return (*hexutil.Big)(burned), err

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -1949,6 +1949,36 @@ func (api *PrivateDebugAPI) SetHead(number hexutil.Uint64) {
 	api.b.SetHead(uint64(number))
 }
 
+// BurnedETH returns the amount of burned ether for a specific
+// range of blocks under eip-1559.
+// The returned value is in denoted in Wei.
+func (api *PrivateDebugAPI) BurnedETH(start, end *hexutil.Uint64) (*hexutil.Big, error) {
+	burned := big.NewInt(0)
+	startBlock := 0
+	endBlock := int(api.b.CurrentHeader().Number.Int64())
+	if start != nil {
+		startBlock = int(*start)
+	}
+	if end != nil {
+		endBlock = int(*end)
+	}
+	if startBlock > endBlock {
+		return (*hexutil.Big)(burned), errors.New("invalid range specified, start > end")
+	}
+	for i := startBlock; i < endBlock; i++ {
+		block, err := api.b.BlockByNumber(context.Background(), rpc.BlockNumber(i))
+		if err != nil {
+			return (*hexutil.Big)(burned), err
+		}
+		txs := len(block.Transactions())
+		if basefee := block.Header().BaseFee; basefee != nil && basefee.Cmp(common.Big0) != 0 {
+			burnedBlock := new(big.Int).Mul(basefee, big.NewInt(int64(txs)))
+			burned = new(big.Int).Add(burned, burnedBlock)
+		}
+	}
+	return (*hexutil.Big)(burned), nil
+}
+
 // PublicNetAPI offers network related RPC methods
 type PublicNetAPI struct {
 	net            *p2p.Server

--- a/internal/web3ext/web3ext.go
+++ b/internal/web3ext/web3ext.go
@@ -269,6 +269,12 @@ web3._extend({
 			params: 1
 		}),
 		new web3._extend.Method({
+			name: 'burnedETH',
+			call: 'debug_burnedETH',
+			params: 2,
+			inputFormatter: [null, null],
+		}),
+		new web3._extend.Method({
 			name: 'seedHash',
 			call: 'debug_seedHash',
 			params: 1

--- a/internal/web3ext/web3ext.go
+++ b/internal/web3ext/web3ext.go
@@ -269,8 +269,8 @@ web3._extend({
 			params: 1
 		}),
 		new web3._extend.Method({
-			name: 'burnedETH',
-			call: 'debug_burnedETH',
+			name: 'burned',
+			call: 'debug_burned',
 			params: 2,
 			inputFormatter: [null, null],
 		}),

--- a/internal/web3ext/web3ext.go
+++ b/internal/web3ext/web3ext.go
@@ -275,6 +275,12 @@ web3._extend({
 			inputFormatter: [null, null],
 		}),
 		new web3._extend.Method({
+			name: 'getBlockReward',
+			call: 'debug_getBlockReward',
+			params: 1,
+			inputFormatter: [null],
+		}),
+		new web3._extend.Method({
 			name: 'seedHash',
 			call: 'debug_seedHash',
 			params: 1


### PR DESCRIPTION
This PR implements a new RPC call to query how much ether (in wei) has been burned in a certain range of blocks.
If no blocks are specified, the call calculates from genesis to current head. 
This call is pretty resource intensive so it should be used with caution.
I am not sure if this even something that we want to have long time in the code base, but it allows us to easily see the basefee on testnets, so its cool for testing of 1559

```
> debug.burnedETH()
"0x3bdac1c6c5a2d2"
> debug.burnedETH("0x0", "0x9BF6")
"0x3bdac1c6c5a2d2"
```