### PR TITLE
Allow to compile client to webassembly

### DIFF
--- a/accounts/abi/bind/auth.go
+++ b/accounts/abi/bind/auth.go
@@ -14,6 +14,8 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
 
+// +build !js
+
 package bind
 
 import (

--- a/metrics/cpu_disabled.go
+++ b/metrics/cpu_disabled.go
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
 
-// +build ios
+// +build ios js
 
 package metrics
 

--- a/metrics/cpu_enabled.go
+++ b/metrics/cpu_enabled.go
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
 
-// +build !ios
+// +build !ios,!js
 
 package metrics
 

--- a/metrics/cpu_no_syscall.go
+++ b/metrics/cpu_no_syscall.go
@@ -14,6 +14,8 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
 
+// +build windows js
+
 package metrics
 
 // getProcessCPUTime returns 0 on Windows as there is no system call to resolve

--- a/metrics/cpu_syscall.go
+++ b/metrics/cpu_syscall.go
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
 
-// +build !windows
+// +build !windows,!js
 
 package metrics
 


### PR DESCRIPTION
We try to use ethereum contract in webassembly but it was failing due to
some symbols missing. To fix this I disabled compilation of some modules
for js tag.