### PR TITLE
core/vm: evm fix panic

### DIFF
--- a/core/vm/runtime/env.go
+++ b/core/vm/runtime/env.go
@@ -35,6 +35,7 @@ func NewEnv(cfg *Config) *vm.EVM {
 		Time:        cfg.Time,
 		Difficulty:  cfg.Difficulty,
 		GasLimit:    cfg.GasLimit,
+		BaseFee:     cfg.BaseFee,
 	}
 
 	return vm.NewEVM(blockContext, txContext, cfg.State, cfg.ChainConfig, cfg.EVMConfig)

--- a/core/vm/runtime/runtime.go
+++ b/core/vm/runtime/runtime.go
@@ -67,7 +67,7 @@ func setDefaults(cfg *Config) {
 			IstanbulBlock:       new(big.Int),
 			MuirGlacierBlock:    new(big.Int),
 			BerlinBlock:         new(big.Int),
-			LondonBlock:         nil,
+			LondonBlock:         new(big.Int),
 		}
 	}
 
@@ -95,7 +95,7 @@ func setDefaults(cfg *Config) {
 		}
 	}
 	if cfg.BaseFee == nil {
-		cfg.BaseFee = new(big.Int)
+		cfg.BaseFee = big.NewInt(params.InitialBaseFee)
 	}
 }
 

--- a/core/vm/runtime/runtime.go
+++ b/core/vm/runtime/runtime.go
@@ -43,6 +43,7 @@ type Config struct {
 	Value       *big.Int
 	Debug       bool
 	EVMConfig   vm.Config
+	BaseFee     *big.Int
 
 	State     *state.StateDB
 	GetHashFn func(n uint64) common.Hash
@@ -92,6 +93,9 @@ func setDefaults(cfg *Config) {
 		cfg.GetHashFn = func(n uint64) common.Hash {
 			return common.BytesToHash(crypto.Keccak256([]byte(new(big.Int).SetUint64(n).String())))
 		}
+	}
+	if cfg.BaseFee == nil {
+		cfg.BaseFee = new(big.Int)
 	}
 }
 


### PR DESCRIPTION
Without this PR: 
```
[user@work evm]$ ./evm --json --code 0x48 run
{"pc":0,"op":72,"gas":"0x2540be400","gasCost":"0x2","memory":"0x","memSize":0,"stack":[],"returnStack":null,"returnData":"0x","depth":1,"refund":0,"opName":"BASEFEE","error":""}
{"output":"","gasUsed":"0x0","time":277726}
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x10 pc=0x608dcb]

goroutine 1 [running]:
math/big.(*Int).Bits(...)
        /usr/local/go/src/math/big/int.go:87
github.com/holiman/uint256.(*Int).SetFromBig(0xc00018b670, 0x0, 0x0)
        /home/user/go/pkg/mod/github.com/holiman/uint256@v1.2.0/conversion.go:102 +0x4b
github.com/holiman/uint256.FromBig(...)
        /home/user/go/pkg/mod/github.com/holiman/uint256@v1.2.0/conversion.go:50
github.com/ethereum/go-ethereum/core/vm.opBaseFee(0xc0000368f0, 0xc0006c0900, 0xc00000e4e0, 0x42af48, 0x2540be400, 0x2, 0xc00000e4e0, 0x0)
        /home/user/go/src/github.com/ethereum/go-ethereum/core/vm/eips.go:173 +0x5e
github.com/ethereum/go-ethereum/core/vm.(*EVMInterpreter).Run(0xc0006c0900, 0xc0000dc180, 0x12d9f40, 0x0, 0x0, 0xc00003a300, 0x0, 0x0, 0x0, 0x0, ...)
        /home/user/go/src/github.com/ethereum/go-ethereum/core/vm/interpreter.go:286 +0x534
github.com/ethereum/go-ethereum/core/vm.run(0xc000697500, 0xc0000dc180, 0x12d9f40, 0x0, 0x0, 0xe41ccf56fa3b6a00, 0x0, 0x0, 0x0, 0x0, ...)
        /home/user/go/src/github.com/ethereum/go-ethereum/core/vm/evm.go:73 +0x224
github.com/ethereum/go-ethereum/core/vm.(*EVM).Call(0xc000697500, 0xdc05a0, 0xc0006bc000, 0x0, 0x6563657200000000, 0xc072657669, 0x12d9f40, 0x0, 0x0, 0x2540be400, ...)
        /home/user/go/src/github.com/ethereum/go-ethereum/core/vm/evm.go:259 +0x6cb
github.com/ethereum/go-ethereum/core/vm/runtime.Call(0x0, 0x6563657200000000, 0x72657669, 0x12d9f40, 0x0, 0x0, 0xc0006c0000, 0xc8926ae909, 0xc614285, 0xc614285012a7260, ...)
        /home/user/go/src/github.com/ethereum/go-ethereum/core/vm/runtime/runtime.go:179 +0x258
main.runCmd.func2(0xc02a61a48c614285, 0x3532582, 0x12a67e0, 0x0, 0x0, 0x0)
        /home/user/go/src/github.com/ethereum/go-ethereum/cmd/evm/runner.go:263 +0x7d
main.timedExec(0xc00069c100, 0xc000091900, 0x5, 0x72657600, 0xc0000368a8, 0x1, 0x8, 0xc0000f64e0, 0x0, 0x0, ...)
        /home/user/go/src/github.com/ethereum/go-ethereum/cmd/evm/runner.go:96 +0x464
main.runCmd(0xc00069c160, 0x0, 0x0)
        /home/user/go/src/github.com/ethereum/go-ethereum/cmd/evm/runner.go:268 +0xfc5
gopkg.in/urfave/cli%2ev1.HandleAction(0xba3fc0, 0xd14d28, 0xc00069c160, 0xc000092d00, 0x0)
        /home/user/go/pkg/mod/gopkg.in/urfave/cli.v1@v1.20.0/app.go:490 +0x82
gopkg.in/urfave/cli%2ev1.Command.Run(0xcabe78, 0x3, 0x0, 0x0, 0x0, 0x0, 0x0, 0xcbeeae, 0x18, 0x0, ...)
        /home/user/go/pkg/mod/gopkg.in/urfave/cli.v1@v1.20.0/command.go:210 +0x9bb
gopkg.in/urfave/cli%2ev1.(*App).Run(0xc0000f61a0, 0xc000138000, 0x5, 0x5, 0x0, 0x0)
        /home/user/go/pkg/mod/gopkg.in/urfave/cli.v1@v1.20.0/app.go:255 +0x768
main.main()
        /home/user/go/src/github.com/ethereum/go-ethereum/cmd/evm/main.go:201 +0x55

```
With this PR: 
```
[user@work evm]$ ./evm --json --code 0x48 run
{"pc":0,"op":72,"gas":"0x2540be400","gasCost":"0x2","memory":"0x","memSize":0,"stack":[],"returnStack":null,"returnData":"0x","depth":1,"refund":0,"opName":"BASEFEE","error":""}
{"pc":1,"op":0,"gas":"0x2540be3fe","gasCost":"0x0","memory":"0x","memSize":0,"stack":["0x0"],"returnStack":null,"returnData":"0x","depth":1,"refund":0,"opName":"STOP","error":""}
{"output":"","gasUsed":"0x2","time":269783}
```