### PR TITLE
graphql: fix transaction API

### DIFF
--- a/graphql/graphql.go
+++ b/graphql/graphql.go
@@ -29,7 +29,6 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/common/math"
-	"github.com/ethereum/go-ethereum/core/rawdb"
 	"github.com/ethereum/go-ethereum/core/state"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/eth/filters"
@@ -94,7 +93,11 @@ func (a *Account) Balance(ctx context.Context) (hexutil.Big, error) {
 	if err != nil {
 		return hexutil.Big{}, err
 	}
-	return hexutil.Big(*state.GetBalance(a.address)), nil
+	balance := state.GetBalance(a.address)
+	if balance == nil {
+		return hexutil.Big{}, fmt.Errorf("failed to load balance %x", a.address)
+	}
+	return hexutil.Big(*balance), nil
 }
 
 func (a *Account) TransactionCount(ctx context.Context) (hexutil.Uint64, error) {
@@ -179,8 +182,9 @@ type Transaction struct {
 // resolve returns the internal transaction object, fetching it if needed.
 func (t *Transaction) resolve(ctx context.Context) (*types.Transaction, error) {
 	if t.tx == nil {
-		tx, blockHash, _, index := rawdb.ReadTransaction(t.backend.ChainDb(), t.hash)
-		if tx != nil {
+		// Try to return an already finalized transaction
+		tx, blockHash, _, index, err := t.backend.GetTransaction(ctx, t.hash)
+		if err == nil && tx != nil {
 			t.tx = tx
 			blockNrOrHash := rpc.BlockNumberOrHashWithHash(blockHash, false)
 			t.block = &Block{
@@ -188,9 +192,10 @@ func (t *Transaction) resolve(ctx context.Context) (*types.Transaction, error) {
 				numberOrHash: &blockNrOrHash,
 			}
 			t.index = index
-		} else {
-			t.tx = t.backend.GetPoolTransaction(t.hash)
+			return t.tx, nil
 		}
+		// No finalized transaction, try to retrieve it from the pool
+		t.tx = t.backend.GetPoolTransaction(t.hash)
 	}
 	return t.tx, nil
 }
@@ -270,6 +275,9 @@ func (t *Transaction) Value(ctx context.Context) (hexutil.Big, error) {
 	tx, err := t.resolve(ctx)
 	if err != nil || tx == nil {
 		return hexutil.Big{}, err
+	}
+	if tx.Value() == nil {
+		return hexutil.Big{}, fmt.Errorf("invalid transaction value %x", t.hash)
 	}
 	return hexutil.Big(*tx.Value()), nil
 }
@@ -706,7 +714,11 @@ func (b *Block) TotalDifficulty(ctx context.Context) (hexutil.Big, error) {
 		}
 		h = header.Hash()
 	}
-	return hexutil.Big(*b.backend.GetTd(ctx, h)), nil
+	td := b.backend.GetTd(ctx, h)
+	if td == nil {
+		return hexutil.Big{}, fmt.Errorf("total difficulty not found %x", b.hash)
+	}
+	return hexutil.Big(*td), nil
 }
 
 // BlockNumberArgs encapsulates arguments to accessors that specify a block number.


### PR DESCRIPTION
This PR fixes the GraphQL transaction API. Previously it will only look up the transaction index in the database so it doesn't work for light client.