### PR TITLE
tests: fix nil pointer panic on failure

### DIFF
--- a/tests/state_test.go
+++ b/tests/state_test.go
@@ -74,8 +74,10 @@ func TestState(t *testing.T) {
 				t.Run(key+"/snap", func(t *testing.T) {
 					withTrace(t, test.gasLimit(subtest), func(vmconfig vm.Config) error {
 						snaps, statedb, err := test.Run(subtest, vmconfig, true)
-						if _, err := snaps.Journal(statedb.IntermediateRoot(false)); err != nil {
-							return err
+						if snaps != nil && statedb != nil {
+							if _, err := snaps.Journal(statedb.IntermediateRoot(false)); err != nil {
+								return err
+							}
 						}
 						return st.checkFailure(t, err)
 					})


### PR DESCRIPTION
This fixes a nil pointer exception if test.Run throws an unexpected error