### PR TITLE
tests: fixed eip1559 tx on non-eip1559 network

### DIFF
--- a/tests/state_test_util.go
+++ b/tests/state_test_util.go
@@ -328,6 +328,9 @@ func (tx *stTransaction) toMessage(ps stPostState, baseFee *big.Int) (core.Messa
 		gasPrice = math.BigMin(new(big.Int).Add(tx.MaxPriorityFeePerGas, baseFee),
 			tx.MaxFeePerGas)
 	}
+	if gasPrice == nil {
+		return nil, fmt.Errorf("no gas price provided")
+	}
 
 	msg := types.NewMessage(from, to, tx.Nonce, value, gasLimit, gasPrice,
 		tx.MaxFeePerGas, tx.MaxPriorityFeePerGas, data, accessList, true)


### PR DESCRIPTION
During normal execution, this is checked by `Sender()` in `tx.AsMessage` as the sender recovery will reject a transaction that was signed for a eip-1559 network as `transaction type not supported`