### PR TITLE
travis, build: own docker builder and hub pusher

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,37 @@ jobs:
       script:
         - go run build/ci.go lint
 
+    # This builder does the Docker Hub build and upload for amd64
+    - stage: build
+      if: type = push
+      os: linux
+      dist: bionic
+      go: 1.16.x
+      env:
+        - docker
+      services:
+        - docker
+      git:
+        submodules: false # avoid cloning ethereum/tests
+      script:
+        - go run build/ci.go docker -upload karalabe/geth-docker-test
+
+    # This builder does the Docker Hub build and upload for arm64
+    - stage: build
+      if: type = push
+      os: linux
+      arch: arm64
+      dist: bionic
+      go: 1.16.x
+      env:
+        - docker
+      services:
+        - docker
+      git:
+        submodules: false # avoid cloning ethereum/tests
+      script:
+        - go run build/ci.go docker -upload karalabe/geth-docker-test
+
     # This builder does the Ubuntu PPA upload
     - stage: build
       if: type = push


### PR DESCRIPTION
Docker stops supporting automated builds on the 18th of June, 2021. This PR replaces that infrastructure with our own local builder via Travis + push to hub directly. This also allows us to do ARM64 builds.

**Note, this PR pushes to my private docker repo for now. We can switch over when we see things are working correctly.**