### PR TITLE
accounts/abi/bind: call ensureContext on every context

### DIFF
--- a/accounts/abi/bind/base.go
+++ b/accounts/abi/bind/base.go
@@ -229,13 +229,13 @@ func (c *BoundContract) transact(opts *TransactOpts, contract *common.Address, i
 	if opts.GasPrice != nil && (opts.GasFeeCap != nil || opts.GasTipCap != nil) {
 		return nil, errors.New("both gasPrice and (maxFeePerGas or maxPriorityFeePerGas) specified")
 	}
-	head, err := c.transactor.HeaderByNumber(opts.Context, nil)
+	head, err := c.transactor.HeaderByNumber(ensureContext(opts.Context), nil)
 	if err != nil {
 		return nil, err
 	}
 	if head.BaseFee != nil && opts.GasPrice == nil {
 		if opts.GasTipCap == nil {
-			tip, err := c.transactor.SuggestGasTipCap(opts.Context)
+			tip, err := c.transactor.SuggestGasTipCap(ensureContext(opts.Context))
 			if err != nil {
 				return nil, err
 			}
@@ -256,7 +256,7 @@ func (c *BoundContract) transact(opts *TransactOpts, contract *common.Address, i
 			return nil, errors.New("maxFeePerGas or maxPriorityFeePerGas specified but london is not active yet")
 		}
 		if opts.GasPrice == nil {
-			price, err := c.transactor.SuggestGasTipCap(opts.Context)
+			price, err := c.transactor.SuggestGasTipCap(ensureContext(opts.Context))
 			if err != nil {
 				return nil, err
 			}


### PR DESCRIPTION
`ensureContext` was called for every other context in the `transact` method.
Without it, `net/http` fails with an error `net/http: nil Context` if the user does not provide a context.