### PR TITLE
core/types: add DynamicFeeTx to TxData implementation list in docs

### DIFF
--- a/core/types/transaction.go
+++ b/core/types/transaction.go
@@ -67,7 +67,7 @@ func NewTx(inner TxData) *Transaction {
 
 // TxData is the underlying data of a transaction.
 //
-// This is implemented by LegacyTx and AccessListTx.
+// This is implemented by DynamicFeeTx, LegacyTx and AccessListTx.
 type TxData interface {
 	txType() byte // returns the type ID
 	copy() TxData // creates a deep copy and initializes all fields


### PR DESCRIPTION
Per the title, update the inline Go documentation to mention that `DynamicFeeTx` implements the `TxData` interface.

@fjl via a Discord chat