### PR TITLE
core, params: make DeveloperGenesisBlock thread safe

### DIFF
--- a/core/genesis.go
+++ b/core/genesis.go
@@ -415,7 +415,10 @@ func DefaultCalaverasGenesisBlock() *Genesis {
 func DeveloperGenesisBlock(period uint64, faucet common.Address) *Genesis {
 	// Override the default period to the user requested one
 	config := *params.AllCliqueProtocolChanges
-	config.Clique.Period = period
+	config.Clique = &params.CliqueConfig{
+		Period: period,
+		Epoch:  config.Clique.Epoch,
+	}
 
 	// Assemble and return the genesis with the precompiles and faucet pre-funded
 	return &Genesis{


### PR DESCRIPTION
`DeveloperGenesisBlock` is currently not thread safe, since it creates a shallow copy of the `CliqueConfig` and modifies the `Period` value of it.  

This MR:  
Adds a `Copy()` function to `CliqueConfig` and uses it in DeveloperGenesisBlock to avoid overwriting `params.AllCliqueProtocolChanges.Clique.Period`.
This change makes `DeveloperGenesisBlock` thread safe.