### PR TITLE
travis, build: add support for multi-arch docker images

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,38 @@ jobs:
       script:
         - go run build/ci.go lint
 
-    # This builder does the Docker Hub build and upload for amd64
+    # These builders create the Docker sub-images for multi-arch push
+    - stage: prebuild
+      if: type = push
+      os: linux
+      arch: amd64
+      dist: bionic
+      go: 1.16.x
+      env:
+        - docker
+      services:
+        - docker
+      git:
+        submodules: false # avoid cloning ethereum/tests
+      script:
+        - go run build/ci.go docker -image -upload karalabe/geth-docker-test
+
+    - stage: prebuild
+      if: type = push
+      os: linux
+      arch: arm64
+      dist: bionic
+      go: 1.16.x
+      env:
+        - docker
+      services:
+        - docker
+      git:
+        submodules: false # avoid cloning ethereum/tests
+      script:
+        - go run build/ci.go docker -image -upload karalabe/geth-docker-test
+
+    # This builder does the Docker Hub multi-arch image
     - stage: build
       if: type = push
       os: linux
@@ -36,8 +67,10 @@ jobs:
         - docker
       git:
         submodules: false # avoid cloning ethereum/tests
+      before_install:
+        - export DOCKER_CLI_EXPERIMENTAL=enabled
       script:
-        - go run build/ci.go docker -upload karalabe/geth-docker-test
+        - go run build/ci.go docker -manifest amd64,arm64 -upload karalabe/geth-docker-test
 
     # This builder does the Ubuntu PPA upload
     - stage: build


### PR DESCRIPTION
This PR enabled building individual architecture specific docker images, pushing them to Docker hub and then linking them together in a later build step.