### PR TITLE
[Experiment] rework state database scheme

### DIFF
--- a/cmd/geth/snapshot.go
+++ b/cmd/geth/snapshot.go
@@ -293,7 +293,7 @@ func traverseState(ctx *cli.Context) error {
 			return err
 		}
 		if acc.Root != emptyRoot {
-			storageTrie, err := trie.NewSecure(acc.Root, triedb)
+			storageTrie, err := trie.NewSecureWithOwner(common.BytesToHash(accIter.Key), acc.Root, triedb)
 			if err != nil {
 				log.Error("Failed to open storage trie", "root", acc.Root, "err", err)
 				return err
@@ -383,7 +383,7 @@ func traverseRawState(ctx *cli.Context) error {
 		if node != (common.Hash{}) {
 			// Check the present for non-empty hash node(embedded node doesn't
 			// have their own hash).
-			blob := rawdb.ReadTrieNode(chaindb, node)
+			blob := rawdb.ReadTrieNode(chaindb, accIter.ComposedKey())
 			if len(blob) == 0 {
 				log.Error("Missing trie node(account)", "hash", node)
 				return errors.New("missing account")
@@ -412,7 +412,7 @@ func traverseRawState(ctx *cli.Context) error {
 					// Check the present for non-empty hash node(embedded node doesn't
 					// have their own hash).
 					if node != (common.Hash{}) {
-						blob := rawdb.ReadTrieNode(chaindb, node)
+						blob := rawdb.ReadTrieNode(chaindb, storageIter.ComposedKey())
 						if len(blob) == 0 {
 							log.Error("Missing trie node(storage)", "hash", node)
 							return errors.New("missing storage")

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -965,7 +965,7 @@ func (bc *BlockChain) GetUnclesInChain(block *types.Block, length int) []*types.
 // TrieNode retrieves a blob of data associated with a trie node
 // either from ephemeral in-memory cache, or from persistent storage.
 func (bc *BlockChain) TrieNode(hash common.Hash) ([]byte, error) {
-	return bc.stateCache.TrieDB().Node(hash)
+	return nil, errors.New("not found")
 }
 
 // ContractCode retrieves a blob of data associated with a contract hash
@@ -1485,7 +1485,7 @@ func (bc *BlockChain) writeBlockWithState(block *types.Block, receipts []*types.
 		}
 	} else {
 		// Full but not archive node, do proper garbage collection
-		triedb.Reference(root, common.Hash{}) // metadata reference to keep trie alive
+		triedb.Reference(common.Hash{}, root, common.Hash{}, nil) // metadata reference to keep trie alive
 		bc.triegc.Push(root, -int64(block.NumberU64()))
 
 		if current := block.NumberU64(); current > TriesInMemory {

--- a/core/blockchain_test.go
+++ b/core/blockchain_test.go
@@ -1551,7 +1551,7 @@ func TestLargeReorgTrieGC(t *testing.T) {
 		t.Fatalf("failed to insert original chain: %v", err)
 	}
 	// Ensure that the state associated with the forking point is pruned away
-	if node, _ := chain.stateCache.TrieDB().Node(shared[len(shared)-1].Root()); node != nil {
+	if node, _ := chain.stateCache.TrieDB().Node(common.Hash{}, nil, shared[len(shared)-1].Root()); node != nil {
 		t.Fatalf("common-but-old ancestor still cache")
 	}
 	// Import the competitor chain without exceeding the canonical's TD and ensure
@@ -1560,7 +1560,7 @@ func TestLargeReorgTrieGC(t *testing.T) {
 		t.Fatalf("failed to insert competitor chain: %v", err)
 	}
 	for i, block := range competitor[:len(competitor)-2] {
-		if node, _ := chain.stateCache.TrieDB().Node(block.Root()); node != nil {
+		if node, _ := chain.stateCache.TrieDB().Node(common.Hash{}, nil, block.Root()); node != nil {
 			t.Fatalf("competitor %d: low TD chain became processed", i)
 		}
 	}
@@ -1570,7 +1570,7 @@ func TestLargeReorgTrieGC(t *testing.T) {
 		t.Fatalf("failed to finalize competitor chain: %v", err)
 	}
 	for i, block := range competitor[:len(competitor)-TriesInMemory] {
-		if node, _ := chain.stateCache.TrieDB().Node(block.Root()); node != nil {
+		if node, _ := chain.stateCache.TrieDB().Node(common.Hash{}, nil, block.Root()); node != nil {
 			t.Fatalf("competitor %d: competing chain state missing", i)
 		}
 	}

--- a/core/rawdb/accessors_state.go
+++ b/core/rawdb/accessors_state.go
@@ -76,21 +76,21 @@ func DeleteCode(db ethdb.KeyValueWriter, hash common.Hash) {
 }
 
 // ReadTrieNode retrieves the trie node of the provided hash.
-func ReadTrieNode(db ethdb.KeyValueReader, hash common.Hash) []byte {
-	data, _ := db.Get(hash.Bytes())
+func ReadTrieNode(db ethdb.KeyValueReader, key []byte) []byte {
+	data, _ := db.Get(trieNodeKey(key))
 	return data
 }
 
 // WriteTrieNode writes the provided trie node database.
-func WriteTrieNode(db ethdb.KeyValueWriter, hash common.Hash, node []byte) {
-	if err := db.Put(hash.Bytes(), node); err != nil {
+func WriteTrieNode(db ethdb.KeyValueWriter, key []byte, node []byte) {
+	if err := db.Put(trieNodeKey(key), node); err != nil {
 		log.Crit("Failed to store trie node", "err", err)
 	}
 }
 
 // DeleteTrieNode deletes the specified trie node from the database.
-func DeleteTrieNode(db ethdb.KeyValueWriter, hash common.Hash) {
-	if err := db.Delete(hash.Bytes()); err != nil {
+func DeleteTrieNode(db ethdb.KeyValueWriter, key []byte) {
+	if err := db.Delete(trieNodeKey(key)); err != nil {
 		log.Crit("Failed to delete trie node", "err", err)
 	}
 }

--- a/core/rawdb/database.go
+++ b/core/rawdb/database.go
@@ -343,7 +343,7 @@ func InspectDatabase(db ethdb.Database, keyPrefix, keyStart []byte) error {
 			numHashPairings.Add(size)
 		case bytes.HasPrefix(key, headerNumberPrefix) && len(key) == (len(headerNumberPrefix)+common.HashLength):
 			hashNumPairings.Add(size)
-		case len(key) == common.HashLength:
+		case bytes.HasPrefix(key, TrieNodePrefix) && len(key) >= common.HashLength+len(TrieNodePrefix):
 			tries.Add(size)
 		case bytes.HasPrefix(key, CodePrefix) && len(key) == len(CodePrefix)+common.HashLength:
 			codes.Add(size)

--- a/core/rawdb/schema.go
+++ b/core/rawdb/schema.go
@@ -89,6 +89,7 @@ var (
 	SnapshotAccountPrefix = []byte("a") // SnapshotAccountPrefix + account hash -> account trie value
 	SnapshotStoragePrefix = []byte("o") // SnapshotStoragePrefix + account hash + storage hash -> storage trie value
 	CodePrefix            = []byte("c") // CodePrefix + code hash -> account code
+	TrieNodePrefix        = []byte("w") // TrieNodePrefix + node path + node hash -> trie node
 
 	preimagePrefix = []byte("secure-key-")      // preimagePrefix + hash -> preimage
 	configPrefix   = []byte("ethereum-config-") // config prefix for the db
@@ -222,6 +223,20 @@ func codeKey(hash common.Hash) []byte {
 func IsCodeKey(key []byte) (bool, []byte) {
 	if bytes.HasPrefix(key, CodePrefix) && len(key) == common.HashLength+len(CodePrefix) {
 		return true, key[len(CodePrefix):]
+	}
+	return false, nil
+}
+
+// trieNodeKey = TrieNodePrefix + encoded node key
+func trieNodeKey(key []byte) []byte {
+	return append(TrieNodePrefix, key...)
+}
+
+// IsTrieNodeKey reports whether the given byte slice is the key of trie node.
+// if so return the raw encoded trie key as well.
+func IsTrieNodeKey(key []byte) (bool, []byte) {
+	if bytes.HasPrefix(key, TrieNodePrefix) && len(key) > common.HashLength+len(TrieNodePrefix) {
+		return true, key[len(TrieNodePrefix):]
 	}
 	return false, nil
 }

--- a/core/state/database.go
+++ b/core/state/database.go
@@ -138,7 +138,7 @@ func (db *cachingDB) OpenTrie(root common.Hash) (Trie, error) {
 
 // OpenStorageTrie opens the storage trie of an account.
 func (db *cachingDB) OpenStorageTrie(addrHash, root common.Hash) (Trie, error) {
-	tr, err := trie.NewSecure(root, db.db)
+	tr, err := trie.NewSecureWithOwner(addrHash, root, db.db)
 	if err != nil {
 		return nil, err
 	}

--- a/core/state/iterator_test.go
+++ b/core/state/iterator_test.go
@@ -17,53 +17,49 @@
 package state
 
 import (
-	"bytes"
 	"testing"
-
-	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/ethdb"
 )
 
 // Tests that the node iterator indeed walks over the entire database contents.
 func TestNodeIteratorCoverage(t *testing.T) {
-	// Create some arbitrary test state to iterate
-	db, root, _ := makeTestState()
-	db.TrieDB().Commit(root, false, nil)
-
-	state, err := New(root, db, nil)
-	if err != nil {
-		t.Fatalf("failed to create state trie at %x: %v", root, err)
-	}
-	// Gather all the node hashes found by the iterator
-	hashes := make(map[common.Hash]struct{})
-	for it := NewNodeIterator(state); it.Next(); {
-		if it.Hash != (common.Hash{}) {
-			hashes[it.Hash] = struct{}{}
-		}
-	}
-	// Cross check the iterated hashes and the database/nodepool content
-	for hash := range hashes {
-		if _, err = db.TrieDB().Node(hash); err != nil {
-			_, err = db.ContractCode(common.Hash{}, hash)
-		}
-		if err != nil {
-			t.Errorf("failed to retrieve reported node %x", hash)
-		}
-	}
-	for _, hash := range db.TrieDB().Nodes() {
-		if _, ok := hashes[hash]; !ok {
-			t.Errorf("state entry not reported %x", hash)
-		}
-	}
-	it := db.TrieDB().DiskDB().(ethdb.Database).NewIterator(nil, nil)
-	for it.Next() {
-		key := it.Key()
-		if bytes.HasPrefix(key, []byte("secure-key-")) {
-			continue
-		}
-		if _, ok := hashes[common.BytesToHash(key)]; !ok {
-			t.Errorf("state entry not reported %x", key)
-		}
-	}
-	it.Release()
+	//// Create some arbitrary test state to iterate
+	//db, root, _ := makeTestState()
+	//db.TrieDB().Commit(root, false, nil)
+	//
+	//state, err := New(root, db, nil)
+	//if err != nil {
+	//	t.Fatalf("failed to create state trie at %x: %v", root, err)
+	//}
+	//// Gather all the node hashes found by the iterator
+	//hashes := make(map[string]struct{})
+	//for it := NewNodeIterator(state); it.Next(); {
+	//	if it.Hash != (common.Hash{}) {
+	//		hashes[it.Hash] = struct{}{}
+	//	}
+	//}
+	//// Cross check the iterated hashes and the database/nodepool content
+	//for hash := range hashes {
+	//	if _, err = db.TrieDB().Node(common.Hash{}, nil, hash); err != nil { // todo
+	//		_, err = db.ContractCode(common.Hash{}, hash)
+	//	}
+	//	if err != nil {
+	//		t.Errorf("failed to retrieve reported node %x", hash)
+	//	}
+	//}
+	//for _, hash := range db.TrieDB().Nodes() {
+	//	if _, ok := hashes[hash]; !ok {
+	//		t.Errorf("state entry not reported %x", hash)
+	//	}
+	//}
+	//it := db.TrieDB().DiskDB().(ethdb.Database).NewIterator(nil, nil)
+	//for it.Next() {
+	//	key := it.Key()
+	//	if bytes.HasPrefix(key, []byte("secure-key-")) {
+	//		continue
+	//	}
+	//	if _, ok := hashes[common.BytesToHash(key)]; !ok {
+	//		t.Errorf("state entry not reported %x", key)
+	//	}
+	//}
+	//it.Release()
 }

--- a/core/state/pruner/pruner.go
+++ b/core/state/pruner/pruner.go
@@ -113,7 +113,7 @@ func NewPruner(db ethdb.Database, datadir, trieCachePath string, bloomSize uint6
 	}, nil
 }
 
-func prune(snaptree *snapshot.Tree, root common.Hash, maindb ethdb.Database, stateBloom *stateBloom, bloomPath string, middleStateRoots map[common.Hash]struct{}, start time.Time) error {
+func prune(snaptree *snapshot.Tree, root common.Hash, maindb ethdb.Database, stateBloom *stateBloom, bloomPath string, middleStateRoots map[common.Hash]bool, start time.Time) error {
 	// Delete all stale trie nodes in the disk. With the help of state bloom
 	// the trie nodes(and codes) belong to the active state will be filtered
 	// out. A very small part of stale tries will also be filtered because of
@@ -134,21 +134,27 @@ func prune(snaptree *snapshot.Tree, root common.Hash, maindb ethdb.Database, sta
 
 		// All state entries don't belong to specific state and genesis are deleted here
 		// - trie node
-		// - legacy contract code
-		// - new-scheme contract code
+		// - contract code
+		var checkKey []byte
 		isCode, codeKey := rawdb.IsCodeKey(key)
-		if len(key) == common.HashLength || isCode {
-			checkKey := key
-			if isCode {
-				checkKey = codeKey
-			}
-			if _, exist := middleStateRoots[common.BytesToHash(checkKey)]; exist {
-				log.Debug("Forcibly delete the middle state roots", "hash", common.BytesToHash(checkKey))
-			} else {
-				if ok, err := stateBloom.Contain(checkKey); err != nil {
-					return err
-				} else if ok {
-					continue
+		if isCode {
+			checkKey = codeKey
+		}
+		isNode, nodeKey := rawdb.IsTrieNodeKey(key)
+		if isNode {
+			checkKey = nodeKey
+		}
+		if checkKey != nil {
+			if isNode {
+				owner, _, hash := trie.DecodeNodeKey(checkKey)
+				if owner == (common.Hash{}) && middleStateRoots[hash] {
+					log.Debug("Forcibly delete the middle state roots", "hash", common.BytesToHash(checkKey))
+				} else {
+					if ok, err := stateBloom.Contain(checkKey); err != nil {
+						return err
+					} else if ok {
+						continue
+					}
 				}
 			}
 			count += 1
@@ -266,7 +272,7 @@ func (p *Pruner) Prune(root common.Hash) error {
 	// Ensure the root is really present. The weak assumption
 	// is the presence of root can indicate the presence of the
 	// entire trie.
-	if blob := rawdb.ReadTrieNode(p.db, root); len(blob) == 0 {
+	if blob := rawdb.ReadTrieNode(p.db, trie.TrieRootKey(common.Hash{}, root)); len(blob) == 0 {
 		// The special case is for clique based networks(rinkeby, goerli
 		// and some other private networks), it's possible that two
 		// consecutive blocks will have same root. In this case snapshot
@@ -280,7 +286,7 @@ func (p *Pruner) Prune(root common.Hash) error {
 		// as the pruning target.
 		var found bool
 		for i := len(layers) - 2; i >= 2; i-- {
-			if blob := rawdb.ReadTrieNode(p.db, layers[i].Root()); len(blob) != 0 {
+			if blob := rawdb.ReadTrieNode(p.db, trie.TrieRootKey(common.Hash{}, root)); len(blob) != 0 {
 				root = layers[i].Root()
 				found = true
 				log.Info("Selecting middle-layer as the pruning target", "root", root, "depth", i)
@@ -308,12 +314,12 @@ func (p *Pruner) Prune(root common.Hash) error {
 
 	// All the state roots of the middle layer should be forcibly pruned,
 	// otherwise the dangling state will be left.
-	middleRoots := make(map[common.Hash]struct{})
+	middleRoots := make(map[common.Hash]bool)
 	for _, layer := range layers {
 		if layer.Root() == root {
 			break
 		}
-		middleRoots[layer.Root()] = struct{}{}
+		middleRoots[layer.Root()] = true
 	}
 	// Traverse the target state, re-construct the whole state trie and
 	// commit to the given bloom filter.
@@ -384,14 +390,14 @@ func RecoverPruning(datadir string, db ethdb.Database, trieCachePath string) err
 	var (
 		found       bool
 		layers      = snaptree.Snapshots(headBlock.Root(), 128, true)
-		middleRoots = make(map[common.Hash]struct{})
+		middleRoots = make(map[common.Hash]bool)
 	)
 	for _, layer := range layers {
 		if layer.Root() == stateBloomRoot {
 			found = true
 			break
 		}
-		middleRoots[layer.Root()] = struct{}{}
+		middleRoots[layer.Root()] = true
 	}
 	if !found {
 		log.Error("Pruning target state is not existent")
@@ -421,7 +427,7 @@ func extractGenesis(db ethdb.Database, stateBloom *stateBloom) error {
 
 		// Embedded nodes don't have hash.
 		if hash != (common.Hash{}) {
-			stateBloom.Put(hash.Bytes(), nil)
+			stateBloom.Put(accIter.ComposedKey(), nil)
 		}
 		// If it's a leaf node, yes we are touching an account,
 		// dig into the storage trie further.
@@ -431,7 +437,7 @@ func extractGenesis(db ethdb.Database, stateBloom *stateBloom) error {
 				return err
 			}
 			if acc.Root != emptyRoot {
-				storageTrie, err := trie.NewSecure(acc.Root, trie.NewDatabase(db))
+				storageTrie, err := trie.NewSecureWithOwner(common.BytesToHash(accIter.LeafKey()), acc.Root, trie.NewDatabase(db))
 				if err != nil {
 					return err
 				}
@@ -439,7 +445,7 @@ func extractGenesis(db ethdb.Database, stateBloom *stateBloom) error {
 				for storageIter.Next(true) {
 					hash := storageIter.Hash()
 					if hash != (common.Hash{}) {
-						stateBloom.Put(hash.Bytes(), nil)
+						stateBloom.Put(storageIter.ComposedKey(), nil)
 					}
 				}
 				if storageIter.Error() != nil {

--- a/core/state/snapshot/conversion.go
+++ b/core/state/snapshot/conversion.go
@@ -43,7 +43,7 @@ type trieKV struct {
 type (
 	// trieGeneratorFn is the interface of trie generation which can
 	// be implemented by different trie algorithm.
-	trieGeneratorFn func(db ethdb.KeyValueWriter, in chan (trieKV), out chan (common.Hash))
+	trieGeneratorFn func(db ethdb.KeyValueWriter, owner common.Hash, in chan (trieKV), out chan (common.Hash))
 
 	// leafCallbackFn is the callback invoked at the leaves of the trie,
 	// returns the subtrie root with the specified subtrie identifier.
@@ -253,7 +253,7 @@ func generateTrieRoot(db ethdb.KeyValueWriter, it Iterator, account common.Hash,
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
-		generatorFn(db, in, out)
+		generatorFn(db, account, in, out)
 	}()
 	// Spin up a go-routine for progress logging
 	if report && stats != nil {
@@ -360,8 +360,8 @@ func generateTrieRoot(db ethdb.KeyValueWriter, it Iterator, account common.Hash,
 	return stop(nil)
 }
 
-func stackTrieGenerate(db ethdb.KeyValueWriter, in chan trieKV, out chan common.Hash) {
-	t := trie.NewStackTrie(db)
+func stackTrieGenerate(db ethdb.KeyValueWriter, owner common.Hash, in chan trieKV, out chan common.Hash) {
+	t := trie.NewStackTrieWithOwner(db, owner)
 	for leaf := range in {
 		t.TryUpdate(leaf.key[:], leaf.value)
 	}

--- a/core/state/snapshot/generate.go
+++ b/core/state/snapshot/generate.go
@@ -248,7 +248,7 @@ func (result *proofResult) forEach(callback func(key []byte, val []byte) error) 
 //
 // The proof result will be returned if the range proving is finished, otherwise
 // the error will be returned to abort the entire procedure.
-func (dl *diskLayer) proveRange(stats *generatorStats, root common.Hash, prefix []byte, kind string, origin []byte, max int, valueConvertFn func([]byte) ([]byte, error)) (*proofResult, error) {
+func (dl *diskLayer) proveRange(stats *generatorStats, owner common.Hash, root common.Hash, prefix []byte, kind string, origin []byte, max int, valueConvertFn func([]byte) ([]byte, error)) (*proofResult, error) {
 	var (
 		keys     [][]byte
 		vals     [][]byte
@@ -306,7 +306,7 @@ func (dl *diskLayer) proveRange(stats *generatorStats, root common.Hash, prefix 
 
 	// The snap state is exhausted, pass the entire key/val set for verification
 	if origin == nil && !diskMore {
-		stackTr := trie.NewStackTrie(nil)
+		stackTr := trie.NewStackTrieWithOwner(nil, owner)
 		for i, key := range keys {
 			stackTr.TryUpdate(key, vals[i])
 		}
@@ -320,7 +320,7 @@ func (dl *diskLayer) proveRange(stats *generatorStats, root common.Hash, prefix 
 		return &proofResult{keys: keys, vals: vals}, nil
 	}
 	// Snap state is chunked, generate edge proofs for verification.
-	tr, err := trie.New(root, dl.triedb)
+	tr, err := trie.NewWithOwner(owner, root, dl.triedb)
 	if err != nil {
 		stats.Log("Trie missing, state snapshotting paused", dl.root, dl.genMarker)
 		return nil, errMissingTrie
@@ -381,9 +381,9 @@ type onStateCallback func(key []byte, val []byte, write bool, delete bool) error
 // generateRange generates the state segment with particular prefix. Generation can
 // either verify the correctness of existing state through rangeproof and skip
 // generation, or iterate trie to regenerate state on demand.
-func (dl *diskLayer) generateRange(root common.Hash, prefix []byte, kind string, origin []byte, max int, stats *generatorStats, onState onStateCallback, valueConvertFn func([]byte) ([]byte, error)) (bool, []byte, error) {
+func (dl *diskLayer) generateRange(owner common.Hash, root common.Hash, prefix []byte, kind string, origin []byte, max int, stats *generatorStats, onState onStateCallback, valueConvertFn func([]byte) ([]byte, error)) (bool, []byte, error) {
 	// Use range prover to check the validity of the flat state in the range
-	result, err := dl.proveRange(stats, root, prefix, kind, origin, max, valueConvertFn)
+	result, err := dl.proveRange(stats, owner, root, prefix, kind, origin, max, valueConvertFn)
 	if err != nil {
 		return false, nil, err
 	}
@@ -432,7 +432,7 @@ func (dl *diskLayer) generateRange(root common.Hash, prefix []byte, kind string,
 	if len(result.keys) > 0 {
 		snapNodeCache = memorydb.New()
 		snapTrieDb := trie.NewDatabase(snapNodeCache)
-		snapTrie, _ := trie.New(common.Hash{}, snapTrieDb)
+		snapTrie, _ := trie.NewWithOwner(owner, common.Hash{}, snapTrieDb)
 		for i, key := range result.keys {
 			snapTrie.Update(key, result.vals[i])
 		}
@@ -441,7 +441,7 @@ func (dl *diskLayer) generateRange(root common.Hash, prefix []byte, kind string,
 	}
 	tr := result.tr
 	if tr == nil {
-		tr, err = trie.New(root, dl.triedb)
+		tr, err = trie.NewWithOwner(owner, root, dl.triedb)
 		if err != nil {
 			stats.Log("Trie missing, state snapshotting paused", dl.root, dl.genMarker)
 			return false, nil, errMissingTrie
@@ -686,7 +686,7 @@ func (dl *diskLayer) generate(stats *generatorStats) {
 			}
 			var storeOrigin = common.CopyBytes(storeMarker)
 			for {
-				exhausted, last, err := dl.generateRange(acc.Root, append(rawdb.SnapshotStoragePrefix, accountHash.Bytes()...), "storage", storeOrigin, storageCheckRange, stats, onStorage, nil)
+				exhausted, last, err := dl.generateRange(accountHash, acc.Root, append(rawdb.SnapshotStoragePrefix, accountHash.Bytes()...), "storage", storeOrigin, storageCheckRange, stats, onStorage, nil)
 				if err != nil {
 					return err
 				}
@@ -705,7 +705,7 @@ func (dl *diskLayer) generate(stats *generatorStats) {
 
 	// Global loop for regerating the entire state trie + all layered storage tries.
 	for {
-		exhausted, last, err := dl.generateRange(dl.root, rawdb.SnapshotAccountPrefix, "account", accOrigin, accountRange, stats, onAccount, FullAccountRLP)
+		exhausted, last, err := dl.generateRange(common.Hash{}, dl.root, rawdb.SnapshotAccountPrefix, "account", accOrigin, accountRange, stats, onAccount, FullAccountRLP)
 		// The procedure it aborted, either by external signal or internal error
 		if err != nil {
 			if abort == nil { // aborted by internal error, wait the signal

--- a/core/state/snapshot/generate_test.go
+++ b/core/state/snapshot/generate_test.go
@@ -17,6 +17,7 @@
 package snapshot
 
 import (
+	"bytes"
 	"fmt"
 	"math/big"
 	"os"
@@ -33,54 +34,6 @@ import (
 	"golang.org/x/crypto/sha3"
 )
 
-// Tests that snapshot generation from an empty database.
-func TestGeneration(t *testing.T) {
-	// We can't use statedb to make a test trie (circular dependency), so make
-	// a fake one manually. We're going with a small account trie of 3 accounts,
-	// two of which also has the same 3-slot storage trie attached.
-	var (
-		diskdb = memorydb.New()
-		triedb = trie.NewDatabase(diskdb)
-	)
-	stTrie, _ := trie.NewSecure(common.Hash{}, triedb)
-	stTrie.Update([]byte("key-1"), []byte("val-1")) // 0x1314700b81afc49f94db3623ef1df38f3ed18b73a1b7ea2f6c095118cf6118a0
-	stTrie.Update([]byte("key-2"), []byte("val-2")) // 0x18a0f4d79cff4459642dd7604f303886ad9d77c30cf3d7d7cedb3a693ab6d371
-	stTrie.Update([]byte("key-3"), []byte("val-3")) // 0x51c71a47af0695957647fb68766d0becee77e953df17c29b3c2f25436f055c78
-	stTrie.Commit(nil)                              // Root: 0xddefcd9376dd029653ef384bd2f0a126bb755fe84fdcc9e7cf421ba454f2bc67
-
-	accTrie, _ := trie.NewSecure(common.Hash{}, triedb)
-	acc := &Account{Balance: big.NewInt(1), Root: stTrie.Hash().Bytes(), CodeHash: emptyCode.Bytes()}
-	val, _ := rlp.EncodeToBytes(acc)
-	accTrie.Update([]byte("acc-1"), val) // 0x9250573b9c18c664139f3b6a7a8081b7d8f8916a8fcc5d94feec6c29f5fd4e9e
-
-	acc = &Account{Balance: big.NewInt(2), Root: emptyRoot.Bytes(), CodeHash: emptyCode.Bytes()}
-	val, _ = rlp.EncodeToBytes(acc)
-	accTrie.Update([]byte("acc-2"), val) // 0x65145f923027566669a1ae5ccac66f945b55ff6eaeb17d2ea8e048b7d381f2d7
-
-	acc = &Account{Balance: big.NewInt(3), Root: stTrie.Hash().Bytes(), CodeHash: emptyCode.Bytes()}
-	val, _ = rlp.EncodeToBytes(acc)
-	accTrie.Update([]byte("acc-3"), val) // 0x50815097425d000edfc8b3a4a13e175fc2bdcfee8bdfbf2d1ff61041d3c235b2
-	root, _ := accTrie.Commit(nil)       // Root: 0xe3712f1a226f3782caca78ca770ccc19ee000552813a9f59d479f8611db9b1fd
-	triedb.Commit(root, false, nil)
-
-	if have, want := root, common.HexToHash("0xe3712f1a226f3782caca78ca770ccc19ee000552813a9f59d479f8611db9b1fd"); have != want {
-		t.Fatalf("have %#x want %#x", have, want)
-	}
-	snap := generateSnapshot(diskdb, triedb, 16, root)
-	select {
-	case <-snap.genPending:
-		// Snapshot generation succeeded
-
-	case <-time.After(3 * time.Second):
-		t.Errorf("Snapshot generation failed")
-	}
-	checkSnapRoot(t, snap, root)
-	// Signal abortion to the generator and wait for it to tear down
-	stop := make(chan *generatorStats)
-	snap.genAbort <- stop
-	<-stop
-}
-
 func hashData(input []byte) common.Hash {
 	var hasher = sha3.NewLegacyKeccak256()
 	var hash common.Hash
@@ -90,48 +43,25 @@ func hashData(input []byte) common.Hash {
 	return hash
 }
 
-// Tests that snapshot generation with existent flat state.
-func TestGenerateExistentState(t *testing.T) {
+// Tests that snapshot generation from an empty database.
+func TestGeneration(t *testing.T) {
 	// We can't use statedb to make a test trie (circular dependency), so make
 	// a fake one manually. We're going with a small account trie of 3 accounts,
 	// two of which also has the same 3-slot storage trie attached.
-	var (
-		diskdb = memorydb.New()
-		triedb = trie.NewDatabase(diskdb)
-	)
-	stTrie, _ := trie.NewSecure(common.Hash{}, triedb)
-	stTrie.Update([]byte("key-1"), []byte("val-1")) // 0x1314700b81afc49f94db3623ef1df38f3ed18b73a1b7ea2f6c095118cf6118a0
-	stTrie.Update([]byte("key-2"), []byte("val-2")) // 0x18a0f4d79cff4459642dd7604f303886ad9d77c30cf3d7d7cedb3a693ab6d371
-	stTrie.Update([]byte("key-3"), []byte("val-3")) // 0x51c71a47af0695957647fb68766d0becee77e953df17c29b3c2f25436f055c78
-	stTrie.Commit(nil)                              // Root: 0xddefcd9376dd029653ef384bd2f0a126bb755fe84fdcc9e7cf421ba454f2bc67
+	var helper = newHelper()
+	stRoot := helper.makeStorageTrie(common.Hash{}, []string{"key-1", "key-2", "key-3"}, []string{"val-1", "val-2", "val-3"}, false)
 
-	accTrie, _ := trie.NewSecure(common.Hash{}, triedb)
-	acc := &Account{Balance: big.NewInt(1), Root: stTrie.Hash().Bytes(), CodeHash: emptyCode.Bytes()}
-	val, _ := rlp.EncodeToBytes(acc)
-	accTrie.Update([]byte("acc-1"), val) // 0x9250573b9c18c664139f3b6a7a8081b7d8f8916a8fcc5d94feec6c29f5fd4e9e
-	rawdb.WriteAccountSnapshot(diskdb, hashData([]byte("acc-1")), val)
-	rawdb.WriteStorageSnapshot(diskdb, hashData([]byte("acc-1")), hashData([]byte("key-1")), []byte("val-1"))
-	rawdb.WriteStorageSnapshot(diskdb, hashData([]byte("acc-1")), hashData([]byte("key-2")), []byte("val-2"))
-	rawdb.WriteStorageSnapshot(diskdb, hashData([]byte("acc-1")), hashData([]byte("key-3")), []byte("val-3"))
+	helper.addTrieAccount("acc-1", &Account{Balance: big.NewInt(1), Root: stRoot, CodeHash: emptyCode.Bytes()})
+	helper.addTrieAccount("acc-2", &Account{Balance: big.NewInt(2), Root: emptyRoot.Bytes(), CodeHash: emptyCode.Bytes()})
+	helper.addTrieAccount("acc-3", &Account{Balance: big.NewInt(3), Root: stRoot, CodeHash: emptyCode.Bytes()})
 
-	acc = &Account{Balance: big.NewInt(2), Root: emptyRoot.Bytes(), CodeHash: emptyCode.Bytes()}
-	val, _ = rlp.EncodeToBytes(acc)
-	accTrie.Update([]byte("acc-2"), val) // 0x65145f923027566669a1ae5ccac66f945b55ff6eaeb17d2ea8e048b7d381f2d7
-	diskdb.Put(hashData([]byte("acc-2")).Bytes(), val)
-	rawdb.WriteAccountSnapshot(diskdb, hashData([]byte("acc-2")), val)
+	helper.makeStorageTrie(hashData([]byte("acc-1")), []string{"key-1", "key-2", "key-3"}, []string{"val-1", "val-2", "val-3"}, true)
+	helper.makeStorageTrie(hashData([]byte("acc-3")), []string{"key-1", "key-2", "key-3"}, []string{"val-1", "val-2", "val-3"}, true)
 
-	acc = &Account{Balance: big.NewInt(3), Root: stTrie.Hash().Bytes(), CodeHash: emptyCode.Bytes()}
-	val, _ = rlp.EncodeToBytes(acc)
-	accTrie.Update([]byte("acc-3"), val) // 0x50815097425d000edfc8b3a4a13e175fc2bdcfee8bdfbf2d1ff61041d3c235b2
-	rawdb.WriteAccountSnapshot(diskdb, hashData([]byte("acc-3")), val)
-	rawdb.WriteStorageSnapshot(diskdb, hashData([]byte("acc-3")), hashData([]byte("key-1")), []byte("val-1"))
-	rawdb.WriteStorageSnapshot(diskdb, hashData([]byte("acc-3")), hashData([]byte("key-2")), []byte("val-2"))
-	rawdb.WriteStorageSnapshot(diskdb, hashData([]byte("acc-3")), hashData([]byte("key-3")), []byte("val-3"))
-
-	root, _ := accTrie.Commit(nil) // Root: 0xe3712f1a226f3782caca78ca770ccc19ee000552813a9f59d479f8611db9b1fd
-	triedb.Commit(root, false, nil)
-
-	snap := generateSnapshot(diskdb, triedb, 16, root)
+	root, snap := helper.Generate()
+	if have, want := root, common.HexToHash("0xe3712f1a226f3782caca78ca770ccc19ee000552813a9f59d479f8611db9b1fd"); have != want {
+		t.Fatalf("have %#x want %#x", have, want)
+	}
 	select {
 	case <-snap.genPending:
 		// Snapshot generation succeeded
@@ -140,6 +70,43 @@ func TestGenerateExistentState(t *testing.T) {
 		t.Errorf("Snapshot generation failed")
 	}
 	checkSnapRoot(t, snap, root)
+
+	// Signal abortion to the generator and wait for it to tear down
+	stop := make(chan *generatorStats)
+	snap.genAbort <- stop
+	<-stop
+}
+
+// Tests that snapshot generation with existent flat state.
+func TestGenerateExistentState(t *testing.T) {
+	// We can't use statedb to make a test trie (circular dependency), so make
+	// a fake one manually. We're going with a small account trie of 3 accounts,
+	// two of which also has the same 3-slot storage trie attached.
+	var helper = newHelper()
+
+	stRoot := helper.makeStorageTrie(hashData([]byte("acc-1")), []string{"key-1", "key-2", "key-3"}, []string{"val-1", "val-2", "val-3"}, true)
+	helper.addTrieAccount("acc-1", &Account{Balance: big.NewInt(1), Root: stRoot, CodeHash: emptyCode.Bytes()})
+	helper.addSnapAccount("acc-1", &Account{Balance: big.NewInt(1), Root: stRoot, CodeHash: emptyCode.Bytes()})
+	helper.addSnapStorage("acc-1", []string{"key-1", "key-2", "key-3"}, []string{"val-1", "val-2", "val-3"})
+
+	helper.addTrieAccount("acc-2", &Account{Balance: big.NewInt(2), Root: emptyRoot.Bytes(), CodeHash: emptyCode.Bytes()})
+	helper.addSnapAccount("acc-2", &Account{Balance: big.NewInt(2), Root: emptyRoot.Bytes(), CodeHash: emptyCode.Bytes()})
+
+	stRoot = helper.makeStorageTrie(hashData([]byte("acc-3")), []string{"key-1", "key-2", "key-3"}, []string{"val-1", "val-2", "val-3"}, true)
+	helper.addTrieAccount("acc-3", &Account{Balance: big.NewInt(3), Root: stRoot, CodeHash: emptyCode.Bytes()})
+	helper.addSnapAccount("acc-3", &Account{Balance: big.NewInt(3), Root: stRoot, CodeHash: emptyCode.Bytes()})
+	helper.addSnapStorage("acc-3", []string{"key-1", "key-2", "key-3"}, []string{"val-1", "val-2", "val-3"})
+
+	root, snap := helper.Generate()
+	select {
+	case <-snap.genPending:
+		// Snapshot generation succeeded
+
+	case <-time.After(3 * time.Second):
+		t.Errorf("Snapshot generation failed")
+	}
+	checkSnapRoot(t, snap, root)
+
 	// Signal abortion to the generator and wait for it to tear down
 	stop := make(chan *generatorStats)
 	snap.genAbort <- stop
@@ -210,12 +177,17 @@ func (t *testHelper) addSnapStorage(accKey string, keys []string, vals []string)
 	}
 }
 
-func (t *testHelper) makeStorageTrie(keys []string, vals []string) []byte {
-	stTrie, _ := trie.NewSecure(common.Hash{}, t.triedb)
+func (t *testHelper) makeStorageTrie(owner common.Hash, keys []string, vals []string, commit bool) []byte {
+	stTrie, _ := trie.NewSecureWithOwner(owner, common.Hash{}, t.triedb)
 	for i, k := range keys {
 		stTrie.Update([]byte(k), []byte(vals[i]))
 	}
-	root, _ := stTrie.Commit(nil)
+	var root common.Hash
+	if commit {
+		root, _ = stTrie.Commit(nil)
+	} else {
+		root = stTrie.Hash()
+	}
 	return root.Bytes()
 }
 
@@ -244,7 +216,7 @@ func (t *testHelper) Generate() (common.Hash, *diskLayer) {
 //   - extra slots in the end
 func TestGenerateExistentStateWithWrongStorage(t *testing.T) {
 	helper := newHelper()
-	stRoot := helper.makeStorageTrie([]string{"key-1", "key-2", "key-3"}, []string{"val-1", "val-2", "val-3"})
+	stRoot := helper.makeStorageTrie(hashData([]byte("acc-2")), []string{"key-1", "key-2", "key-3"}, []string{"val-1", "val-2", "val-3"}, true)
 
 	// Account one, empty root but non-empty database
 	helper.addAccount("acc-1", &Account{Balance: big.NewInt(1), Root: emptyRoot.Bytes(), CodeHash: emptyCode.Bytes()})
@@ -256,14 +228,17 @@ func TestGenerateExistentStateWithWrongStorage(t *testing.T) {
 	// Miss slots
 	{
 		// Account three, non empty root but misses slots in the beginning
+		helper.makeStorageTrie(hashData([]byte("acc-3")), []string{"key-1", "key-2", "key-3"}, []string{"val-1", "val-2", "val-3"}, true)
 		helper.addAccount("acc-3", &Account{Balance: big.NewInt(1), Root: stRoot, CodeHash: emptyCode.Bytes()})
 		helper.addSnapStorage("acc-3", []string{"key-2", "key-3"}, []string{"val-2", "val-3"})
 
 		// Account four, non empty root but misses slots in the middle
+		helper.makeStorageTrie(hashData([]byte("acc-4")), []string{"key-1", "key-2", "key-3"}, []string{"val-1", "val-2", "val-3"}, true)
 		helper.addAccount("acc-4", &Account{Balance: big.NewInt(1), Root: stRoot, CodeHash: emptyCode.Bytes()})
 		helper.addSnapStorage("acc-4", []string{"key-1", "key-3"}, []string{"val-1", "val-3"})
 
 		// Account five, non empty root but misses slots in the end
+		helper.makeStorageTrie(hashData([]byte("acc-5")), []string{"key-1", "key-2", "key-3"}, []string{"val-1", "val-2", "val-3"}, true)
 		helper.addAccount("acc-5", &Account{Balance: big.NewInt(1), Root: stRoot, CodeHash: emptyCode.Bytes()})
 		helper.addSnapStorage("acc-5", []string{"key-1", "key-2"}, []string{"val-1", "val-2"})
 	}
@@ -271,18 +246,22 @@ func TestGenerateExistentStateWithWrongStorage(t *testing.T) {
 	// Wrong storage slots
 	{
 		// Account six, non empty root but wrong slots in the beginning
+		helper.makeStorageTrie(hashData([]byte("acc-6")), []string{"key-1", "key-2", "key-3"}, []string{"val-1", "val-2", "val-3"}, true)
 		helper.addAccount("acc-6", &Account{Balance: big.NewInt(1), Root: stRoot, CodeHash: emptyCode.Bytes()})
 		helper.addSnapStorage("acc-6", []string{"key-1", "key-2", "key-3"}, []string{"badval-1", "val-2", "val-3"})
 
 		// Account seven, non empty root but wrong slots in the middle
+		helper.makeStorageTrie(hashData([]byte("acc-7")), []string{"key-1", "key-2", "key-3"}, []string{"val-1", "val-2", "val-3"}, true)
 		helper.addAccount("acc-7", &Account{Balance: big.NewInt(1), Root: stRoot, CodeHash: emptyCode.Bytes()})
 		helper.addSnapStorage("acc-7", []string{"key-1", "key-2", "key-3"}, []string{"val-1", "badval-2", "val-3"})
 
 		// Account eight, non empty root but wrong slots in the end
+		helper.makeStorageTrie(hashData([]byte("acc-8")), []string{"key-1", "key-2", "key-3"}, []string{"val-1", "val-2", "val-3"}, true)
 		helper.addAccount("acc-8", &Account{Balance: big.NewInt(1), Root: stRoot, CodeHash: emptyCode.Bytes()})
 		helper.addSnapStorage("acc-8", []string{"key-1", "key-2", "key-3"}, []string{"val-1", "val-2", "badval-3"})
 
 		// Account 9, non empty root but rotated slots
+		helper.makeStorageTrie(hashData([]byte("acc-9")), []string{"key-1", "key-2", "key-3"}, []string{"val-1", "val-2", "val-3"}, true)
 		helper.addAccount("acc-9", &Account{Balance: big.NewInt(1), Root: stRoot, CodeHash: emptyCode.Bytes()})
 		helper.addSnapStorage("acc-9", []string{"key-1", "key-2", "key-3"}, []string{"val-1", "val-3", "val-2"})
 	}
@@ -290,14 +269,17 @@ func TestGenerateExistentStateWithWrongStorage(t *testing.T) {
 	// Extra storage slots
 	{
 		// Account 10, non empty root but extra slots in the beginning
+		helper.makeStorageTrie(hashData([]byte("acc-10")), []string{"key-1", "key-2", "key-3"}, []string{"val-1", "val-2", "val-3"}, true)
 		helper.addAccount("acc-10", &Account{Balance: big.NewInt(1), Root: stRoot, CodeHash: emptyCode.Bytes()})
 		helper.addSnapStorage("acc-10", []string{"key-0", "key-1", "key-2", "key-3"}, []string{"val-0", "val-1", "val-2", "val-3"})
 
 		// Account 11, non empty root but extra slots in the middle
+		helper.makeStorageTrie(hashData([]byte("acc-11")), []string{"key-1", "key-2", "key-3"}, []string{"val-1", "val-2", "val-3"}, true)
 		helper.addAccount("acc-11", &Account{Balance: big.NewInt(1), Root: stRoot, CodeHash: emptyCode.Bytes()})
 		helper.addSnapStorage("acc-11", []string{"key-1", "key-2", "key-2-1", "key-3"}, []string{"val-1", "val-2", "val-2-1", "val-3"})
 
 		// Account 12, non empty root but extra slots in the end
+		helper.makeStorageTrie(hashData([]byte("acc-12")), []string{"key-1", "key-2", "key-3"}, []string{"val-1", "val-2", "val-3"}, true)
 		helper.addAccount("acc-12", &Account{Balance: big.NewInt(1), Root: stRoot, CodeHash: emptyCode.Bytes()})
 		helper.addSnapStorage("acc-12", []string{"key-1", "key-2", "key-3", "key-4"}, []string{"val-1", "val-2", "val-3", "val-4"})
 	}
@@ -326,7 +308,12 @@ func TestGenerateExistentStateWithWrongStorage(t *testing.T) {
 // - extra accounts
 func TestGenerateExistentStateWithWrongAccounts(t *testing.T) {
 	helper := newHelper()
-	stRoot := helper.makeStorageTrie([]string{"key-1", "key-2", "key-3"}, []string{"val-1", "val-2", "val-3"})
+
+	stRoot := helper.makeStorageTrie(hashData([]byte("acc-1")), []string{"key-1", "key-2", "key-3"}, []string{"val-1", "val-2", "val-3"}, true)
+	stRoot = helper.makeStorageTrie(hashData([]byte("acc-2")), []string{"key-1", "key-2", "key-3"}, []string{"val-1", "val-2", "val-3"}, true)
+	stRoot = helper.makeStorageTrie(hashData([]byte("acc-3")), []string{"key-1", "key-2", "key-3"}, []string{"val-1", "val-2", "val-3"}, true)
+	stRoot = helper.makeStorageTrie(hashData([]byte("acc-4")), []string{"key-1", "key-2", "key-3"}, []string{"val-1", "val-2", "val-3"}, true)
+	stRoot = helper.makeStorageTrie(hashData([]byte("acc-6")), []string{"key-1", "key-2", "key-3"}, []string{"val-1", "val-2", "val-3"}, true)
 
 	// Trie accounts [acc-1, acc-2, acc-3, acc-4, acc-6]
 	// Extra accounts [acc-0, acc-5, acc-7]
@@ -378,29 +365,24 @@ func TestGenerateCorruptAccountTrie(t *testing.T) {
 	// We can't use statedb to make a test trie (circular dependency), so make
 	// a fake one manually. We're going with a small account trie of 3 accounts,
 	// without any storage slots to keep the test smaller.
-	var (
-		diskdb = memorydb.New()
-		triedb = trie.NewDatabase(diskdb)
-	)
-	tr, _ := trie.NewSecure(common.Hash{}, triedb)
-	acc := &Account{Balance: big.NewInt(1), Root: emptyRoot.Bytes(), CodeHash: emptyCode.Bytes()}
-	val, _ := rlp.EncodeToBytes(acc)
-	tr.Update([]byte("acc-1"), val) // 0xc7a30f39aff471c95d8a837497ad0e49b65be475cc0953540f80cfcdbdcd9074
+	helper := newHelper()
 
-	acc = &Account{Balance: big.NewInt(2), Root: emptyRoot.Bytes(), CodeHash: emptyCode.Bytes()}
-	val, _ = rlp.EncodeToBytes(acc)
-	tr.Update([]byte("acc-2"), val) // 0x65145f923027566669a1ae5ccac66f945b55ff6eaeb17d2ea8e048b7d381f2d7
-
-	acc = &Account{Balance: big.NewInt(3), Root: emptyRoot.Bytes(), CodeHash: emptyCode.Bytes()}
-	val, _ = rlp.EncodeToBytes(acc)
-	tr.Update([]byte("acc-3"), val) // 0x19ead688e907b0fab07176120dceec244a72aff2f0aa51e8b827584e378772f4
-	tr.Commit(nil)                  // Root: 0xa04693ea110a31037fb5ee814308a6f1d76bdab0b11676bdf4541d2de55ba978
+	helper.addTrieAccount("acc-1", &Account{Balance: big.NewInt(1), Root: emptyRoot.Bytes(), CodeHash: emptyCode.Bytes()}) // 0xc7a30f39aff471c95d8a837497ad0e49b65be475cc0953540f80cfcdbdcd9074
+	helper.addTrieAccount("acc-2", &Account{Balance: big.NewInt(2), Root: emptyRoot.Bytes(), CodeHash: emptyCode.Bytes()}) // 0x65145f923027566669a1ae5ccac66f945b55ff6eaeb17d2ea8e048b7d381f2d7
+	helper.addTrieAccount("acc-3", &Account{Balance: big.NewInt(3), Root: emptyRoot.Bytes(), CodeHash: emptyCode.Bytes()}) // 0x19ead688e907b0fab07176120dceec244a72aff2f0aa51e8b827584e378772f4
 
 	// Delete an account trie leaf and ensure the generator chokes
-	triedb.Commit(common.HexToHash("0xa04693ea110a31037fb5ee814308a6f1d76bdab0b11676bdf4541d2de55ba978"), false, nil)
-	diskdb.Delete(common.HexToHash("0x65145f923027566669a1ae5ccac66f945b55ff6eaeb17d2ea8e048b7d381f2d7").Bytes())
+	helper.accTrie.Commit(nil) // Root: 0xa04693ea110a31037fb5ee814308a6f1d76bdab0b11676bdf4541d2de55ba978
 
-	snap := generateSnapshot(diskdb, triedb, 16, common.HexToHash("0xa04693ea110a31037fb5ee814308a6f1d76bdab0b11676bdf4541d2de55ba978"))
+	var deletionKey []byte
+	helper.triedb.Commit(common.HexToHash("0xa04693ea110a31037fb5ee814308a6f1d76bdab0b11676bdf4541d2de55ba978"), false, func(key []byte) {
+		if deletionKey == nil && len(key) > common.HashLength {
+			deletionKey = append([]byte{}, key...)
+		}
+	})
+	rawdb.DeleteTrieNode(helper.diskdb, deletionKey)
+
+	snap := generateSnapshot(helper.diskdb, helper.triedb, 16, common.HexToHash("0xa04693ea110a31037fb5ee814308a6f1d76bdab0b11676bdf4541d2de55ba978"))
 	select {
 	case <-snap.genPending:
 		// Snapshot generation succeeded
@@ -422,45 +404,54 @@ func TestGenerateMissingStorageTrie(t *testing.T) {
 	// We can't use statedb to make a test trie (circular dependency), so make
 	// a fake one manually. We're going with a small account trie of 3 accounts,
 	// two of which also has the same 3-slot storage trie attached.
+	var helper = newHelper()
+
+	accOneHash := hashData([]byte("acc-1"))
+	accThreeHash := hashData([]byte("acc-3"))
+
+	stRoot := helper.makeStorageTrie(accOneHash, []string{"key-1", "key-2", "key-3"}, []string{"val-1", "val-2", "val-3"}, true)
+	helper.addTrieAccount("acc-1", &Account{Balance: big.NewInt(1), Root: stRoot, CodeHash: emptyCode.Bytes()})            // 0x9250573b9c18c664139f3b6a7a8081b7d8f8916a8fcc5d94feec6c29f5fd4e9e
+	helper.addTrieAccount("acc-2", &Account{Balance: big.NewInt(2), Root: emptyRoot.Bytes(), CodeHash: emptyCode.Bytes()}) // 0x65145f923027566669a1ae5ccac66f945b55ff6eaeb17d2ea8e048b7d381f2d7
+	stRoot = helper.makeStorageTrie(accThreeHash, []string{"key-1", "key-2", "key-3"}, []string{"val-1", "val-2", "val-3"}, true)
+	helper.addTrieAccount("acc-3", &Account{Balance: big.NewInt(3), Root: stRoot, CodeHash: emptyCode.Bytes()}) // 0x50815097425d000edfc8b3a4a13e175fc2bdcfee8bdfbf2d1ff61041d3c235b2
+
 	var (
-		diskdb = memorydb.New()
-		triedb = trie.NewDatabase(diskdb)
+		accOnePath   []byte
+		accThreePath []byte
 	)
-	stTrie, _ := trie.NewSecure(common.Hash{}, triedb)
-	stTrie.Update([]byte("key-1"), []byte("val-1")) // 0x1314700b81afc49f94db3623ef1df38f3ed18b73a1b7ea2f6c095118cf6118a0
-	stTrie.Update([]byte("key-2"), []byte("val-2")) // 0x18a0f4d79cff4459642dd7604f303886ad9d77c30cf3d7d7cedb3a693ab6d371
-	stTrie.Update([]byte("key-3"), []byte("val-3")) // 0x51c71a47af0695957647fb68766d0becee77e953df17c29b3c2f25436f055c78
-	stTrie.Commit(nil)                              // Root: 0xddefcd9376dd029653ef384bd2f0a126bb755fe84fdcc9e7cf421ba454f2bc67
-
-	accTrie, _ := trie.NewSecure(common.Hash{}, triedb)
-	acc := &Account{Balance: big.NewInt(1), Root: stTrie.Hash().Bytes(), CodeHash: emptyCode.Bytes()}
-	val, _ := rlp.EncodeToBytes(acc)
-	accTrie.Update([]byte("acc-1"), val) // 0x9250573b9c18c664139f3b6a7a8081b7d8f8916a8fcc5d94feec6c29f5fd4e9e
-
-	acc = &Account{Balance: big.NewInt(2), Root: emptyRoot.Bytes(), CodeHash: emptyCode.Bytes()}
-	val, _ = rlp.EncodeToBytes(acc)
-	accTrie.Update([]byte("acc-2"), val) // 0x65145f923027566669a1ae5ccac66f945b55ff6eaeb17d2ea8e048b7d381f2d7
-
-	acc = &Account{Balance: big.NewInt(3), Root: stTrie.Hash().Bytes(), CodeHash: emptyCode.Bytes()}
-	val, _ = rlp.EncodeToBytes(acc)
-	accTrie.Update([]byte("acc-3"), val) // 0x50815097425d000edfc8b3a4a13e175fc2bdcfee8bdfbf2d1ff61041d3c235b2
-	accTrie.Commit(nil)                  // Root: 0xe3712f1a226f3782caca78ca770ccc19ee000552813a9f59d479f8611db9b1fd
+	helper.accTrie.Commit(func(keys [][]byte, path []byte, leaf []byte, parent common.Hash, parentPath []byte) error {
+		if common.BytesToHash(keys[0]) == accOneHash {
+			accOnePath = append([]byte{}, parentPath...)
+		}
+		if common.BytesToHash(keys[0]) == accThreeHash {
+			accThreePath = append([]byte{}, parentPath...)
+		}
+		return nil
+	}) // Root: 0xe3712f1a226f3782caca78ca770ccc19ee000552813a9f59d479f8611db9b1fd
 
 	// We can only corrupt the disk database, so flush the tries out
-	triedb.Reference(
+	helper.triedb.Reference(
+		accOneHash,
 		common.HexToHash("0xddefcd9376dd029653ef384bd2f0a126bb755fe84fdcc9e7cf421ba454f2bc67"),
 		common.HexToHash("0x9250573b9c18c664139f3b6a7a8081b7d8f8916a8fcc5d94feec6c29f5fd4e9e"),
+		accOnePath,
 	)
-	triedb.Reference(
+	helper.triedb.Reference(
+		accThreeHash,
 		common.HexToHash("0xddefcd9376dd029653ef384bd2f0a126bb755fe84fdcc9e7cf421ba454f2bc67"),
 		common.HexToHash("0x50815097425d000edfc8b3a4a13e175fc2bdcfee8bdfbf2d1ff61041d3c235b2"),
+		accThreePath,
 	)
-	triedb.Commit(common.HexToHash("0xe3712f1a226f3782caca78ca770ccc19ee000552813a9f59d479f8611db9b1fd"), false, nil)
-
+	var deletionKey []byte
+	helper.triedb.Commit(common.HexToHash("0xe3712f1a226f3782caca78ca770ccc19ee000552813a9f59d479f8611db9b1fd"), false, func(key []byte) {
+		if bytes.Contains(key, stRoot) {
+			deletionKey = append([]byte{}, key...)
+		}
+	})
 	// Delete a storage trie root and ensure the generator chokes
-	diskdb.Delete(common.HexToHash("0xddefcd9376dd029653ef384bd2f0a126bb755fe84fdcc9e7cf421ba454f2bc67").Bytes())
+	rawdb.DeleteTrieNode(helper.diskdb, deletionKey)
 
-	snap := generateSnapshot(diskdb, triedb, 16, common.HexToHash("0xe3712f1a226f3782caca78ca770ccc19ee000552813a9f59d479f8611db9b1fd"))
+	snap := generateSnapshot(helper.diskdb, helper.triedb, 16, common.HexToHash("0xe3712f1a226f3782caca78ca770ccc19ee000552813a9f59d479f8611db9b1fd"))
 	select {
 	case <-snap.genPending:
 		// Snapshot generation succeeded
@@ -481,45 +472,54 @@ func TestGenerateCorruptStorageTrie(t *testing.T) {
 	// We can't use statedb to make a test trie (circular dependency), so make
 	// a fake one manually. We're going with a small account trie of 3 accounts,
 	// two of which also has the same 3-slot storage trie attached.
+	var helper = newHelper()
+
+	accOneHash := hashData([]byte("acc-1"))
+	accThreeHash := hashData([]byte("acc-3"))
+
+	stRoot := helper.makeStorageTrie(accOneHash, []string{"key-1", "key-2", "key-3"}, []string{"val-1", "val-2", "val-3"}, true)
+	helper.addTrieAccount("acc-1", &Account{Balance: big.NewInt(1), Root: stRoot, CodeHash: emptyCode.Bytes()})            // 0x9250573b9c18c664139f3b6a7a8081b7d8f8916a8fcc5d94feec6c29f5fd4e9e
+	helper.addTrieAccount("acc-2", &Account{Balance: big.NewInt(2), Root: emptyRoot.Bytes(), CodeHash: emptyCode.Bytes()}) // 0x65145f923027566669a1ae5ccac66f945b55ff6eaeb17d2ea8e048b7d381f2d7
+	stRoot = helper.makeStorageTrie(accThreeHash, []string{"key-1", "key-2", "key-3"}, []string{"val-1", "val-2", "val-3"}, true)
+	helper.addTrieAccount("acc-3", &Account{Balance: big.NewInt(3), Root: stRoot, CodeHash: emptyCode.Bytes()}) // 0x50815097425d000edfc8b3a4a13e175fc2bdcfee8bdfbf2d1ff61041d3c235b2
+
 	var (
-		diskdb = memorydb.New()
-		triedb = trie.NewDatabase(diskdb)
+		accOnePath   []byte
+		accThreePath []byte
 	)
-	stTrie, _ := trie.NewSecure(common.Hash{}, triedb)
-	stTrie.Update([]byte("key-1"), []byte("val-1")) // 0x1314700b81afc49f94db3623ef1df38f3ed18b73a1b7ea2f6c095118cf6118a0
-	stTrie.Update([]byte("key-2"), []byte("val-2")) // 0x18a0f4d79cff4459642dd7604f303886ad9d77c30cf3d7d7cedb3a693ab6d371
-	stTrie.Update([]byte("key-3"), []byte("val-3")) // 0x51c71a47af0695957647fb68766d0becee77e953df17c29b3c2f25436f055c78
-	stTrie.Commit(nil)                              // Root: 0xddefcd9376dd029653ef384bd2f0a126bb755fe84fdcc9e7cf421ba454f2bc67
-
-	accTrie, _ := trie.NewSecure(common.Hash{}, triedb)
-	acc := &Account{Balance: big.NewInt(1), Root: stTrie.Hash().Bytes(), CodeHash: emptyCode.Bytes()}
-	val, _ := rlp.EncodeToBytes(acc)
-	accTrie.Update([]byte("acc-1"), val) // 0x9250573b9c18c664139f3b6a7a8081b7d8f8916a8fcc5d94feec6c29f5fd4e9e
-
-	acc = &Account{Balance: big.NewInt(2), Root: emptyRoot.Bytes(), CodeHash: emptyCode.Bytes()}
-	val, _ = rlp.EncodeToBytes(acc)
-	accTrie.Update([]byte("acc-2"), val) // 0x65145f923027566669a1ae5ccac66f945b55ff6eaeb17d2ea8e048b7d381f2d7
-
-	acc = &Account{Balance: big.NewInt(3), Root: stTrie.Hash().Bytes(), CodeHash: emptyCode.Bytes()}
-	val, _ = rlp.EncodeToBytes(acc)
-	accTrie.Update([]byte("acc-3"), val) // 0x50815097425d000edfc8b3a4a13e175fc2bdcfee8bdfbf2d1ff61041d3c235b2
-	accTrie.Commit(nil)                  // Root: 0xe3712f1a226f3782caca78ca770ccc19ee000552813a9f59d479f8611db9b1fd
+	helper.accTrie.Commit(func(keys [][]byte, path []byte, leaf []byte, parent common.Hash, parentPath []byte) error {
+		if common.BytesToHash(keys[0]) == accOneHash {
+			accOnePath = append([]byte{}, parentPath...)
+		}
+		if common.BytesToHash(keys[0]) == accThreeHash {
+			accThreePath = append([]byte{}, parentPath...)
+		}
+		return nil
+	}) // Root: 0xe3712f1a226f3782caca78ca770ccc19ee000552813a9f59d479f8611db9b1fd
 
 	// We can only corrupt the disk database, so flush the tries out
-	triedb.Reference(
+	helper.triedb.Reference(
+		accOneHash,
 		common.HexToHash("0xddefcd9376dd029653ef384bd2f0a126bb755fe84fdcc9e7cf421ba454f2bc67"),
 		common.HexToHash("0x9250573b9c18c664139f3b6a7a8081b7d8f8916a8fcc5d94feec6c29f5fd4e9e"),
+		accOnePath,
 	)
-	triedb.Reference(
+	helper.triedb.Reference(
+		accThreeHash,
 		common.HexToHash("0xddefcd9376dd029653ef384bd2f0a126bb755fe84fdcc9e7cf421ba454f2bc67"),
 		common.HexToHash("0x50815097425d000edfc8b3a4a13e175fc2bdcfee8bdfbf2d1ff61041d3c235b2"),
+		accThreePath,
 	)
-	triedb.Commit(common.HexToHash("0xe3712f1a226f3782caca78ca770ccc19ee000552813a9f59d479f8611db9b1fd"), false, nil)
-
+	var deletionKey []byte
+	helper.triedb.Commit(common.HexToHash("0xe3712f1a226f3782caca78ca770ccc19ee000552813a9f59d479f8611db9b1fd"), false, func(key []byte) {
+		if deletionKey == nil && bytes.Contains(key, common.Hex2Bytes("0x18a0f4d79cff4459642dd7604f303886ad9d77c30cf3d7d7cedb3a693ab6d371")) {
+			deletionKey = append([]byte{}, key...)
+		}
+	})
 	// Delete a storage trie leaf and ensure the generator chokes
-	diskdb.Delete(common.HexToHash("0x18a0f4d79cff4459642dd7604f303886ad9d77c30cf3d7d7cedb3a693ab6d371").Bytes())
+	rawdb.DeleteTrieNode(helper.diskdb, deletionKey)
 
-	snap := generateSnapshot(diskdb, triedb, 16, common.HexToHash("0xe3712f1a226f3782caca78ca770ccc19ee000552813a9f59d479f8611db9b1fd"))
+	snap := generateSnapshot(helper.diskdb, helper.triedb, 16, common.HexToHash("0xe3712f1a226f3782caca78ca770ccc19ee000552813a9f59d479f8611db9b1fd"))
 	select {
 	case <-snap.genPending:
 		// Snapshot generation succeeded
@@ -534,8 +534,8 @@ func TestGenerateCorruptStorageTrie(t *testing.T) {
 	<-stop
 }
 
-func getStorageTrie(n int, triedb *trie.Database) *trie.SecureTrie {
-	stTrie, _ := trie.NewSecure(common.Hash{}, triedb)
+func getStorageTrie(owner common.Hash, n int, triedb *trie.Database) *trie.SecureTrie {
+	stTrie, _ := trie.NewSecureWithOwner(owner, common.Hash{}, triedb)
 	for i := 0; i < n; i++ {
 		k := fmt.Sprintf("key-%d", i)
 		v := fmt.Sprintf("val-%d", i)
@@ -550,13 +550,15 @@ func TestGenerateWithExtraAccounts(t *testing.T) {
 	var (
 		diskdb = memorydb.New()
 		triedb = trie.NewDatabase(diskdb)
-		stTrie = getStorageTrie(5, triedb)
 	)
 	accTrie, _ := trie.NewSecure(common.Hash{}, triedb)
-	{ // Account one in the trie
+	{
+		// Account one in the trie
+		stTrie := getStorageTrie(hashData([]byte("acc-1")), 5, triedb)
 		acc := &Account{Balance: big.NewInt(1), Root: stTrie.Hash().Bytes(), CodeHash: emptyCode.Bytes()}
 		val, _ := rlp.EncodeToBytes(acc)
 		accTrie.Update([]byte("acc-1"), val) // 0x9250573b9c18c664139f3b6a7a8081b7d8f8916a8fcc5d94feec6c29f5fd4e9e
+
 		// Identical in the snap
 		key := hashData([]byte("acc-1"))
 		rawdb.WriteAccountSnapshot(diskdb, key, val)
@@ -567,6 +569,7 @@ func TestGenerateWithExtraAccounts(t *testing.T) {
 		rawdb.WriteStorageSnapshot(diskdb, key, hashData([]byte("key-5")), []byte("val-5"))
 	}
 	{ // Account two exists only in the snapshot
+		stTrie := getStorageTrie(hashData([]byte("acc-2")), 5, triedb)
 		acc := &Account{Balance: big.NewInt(1), Root: stTrie.Hash().Bytes(), CodeHash: emptyCode.Bytes()}
 		val, _ := rlp.EncodeToBytes(acc)
 		key := hashData([]byte("acc-2"))
@@ -578,11 +581,11 @@ func TestGenerateWithExtraAccounts(t *testing.T) {
 	root, _ := accTrie.Commit(nil)
 	t.Logf("root: %x", root)
 	triedb.Commit(root, false, nil)
+
 	// To verify the test: If we now inspect the snap db, there should exist extraneous storage items
 	if data := rawdb.ReadStorageSnapshot(diskdb, hashData([]byte("acc-2")), hashData([]byte("b-key-1"))); data == nil {
 		t.Fatalf("expected snap storage to exist")
 	}
-
 	snap := generateSnapshot(diskdb, triedb, 16, root)
 	select {
 	case <-snap.genPending:
@@ -592,6 +595,7 @@ func TestGenerateWithExtraAccounts(t *testing.T) {
 		t.Errorf("Snapshot generation failed")
 	}
 	checkSnapRoot(t, snap, root)
+
 	// Signal abortion to the generator and wait for it to tear down
 	stop := make(chan *generatorStats)
 	snap.genAbort <- stop
@@ -614,10 +618,11 @@ func TestGenerateWithManyExtraAccounts(t *testing.T) {
 	var (
 		diskdb = memorydb.New()
 		triedb = trie.NewDatabase(diskdb)
-		stTrie = getStorageTrie(3, triedb)
 	)
 	accTrie, _ := trie.NewSecure(common.Hash{}, triedb)
-	{ // Account one in the trie
+	{
+		// Account one in the trie
+		stTrie := getStorageTrie(hashData([]byte("acc-1")), 3, triedb)
 		acc := &Account{Balance: big.NewInt(1), Root: stTrie.Hash().Bytes(), CodeHash: emptyCode.Bytes()}
 		val, _ := rlp.EncodeToBytes(acc)
 		accTrie.Update([]byte("acc-1"), val) // 0x9250573b9c18c664139f3b6a7a8081b7d8f8916a8fcc5d94feec6c29f5fd4e9e
@@ -628,7 +633,8 @@ func TestGenerateWithManyExtraAccounts(t *testing.T) {
 		rawdb.WriteStorageSnapshot(diskdb, key, hashData([]byte("key-2")), []byte("val-2"))
 		rawdb.WriteStorageSnapshot(diskdb, key, hashData([]byte("key-3")), []byte("val-3"))
 	}
-	{ // 100 accounts exist only in snapshot
+	{
+		// 100 accounts exist only in snapshot
 		for i := 0; i < 1000; i++ {
 			//acc := &Account{Balance: big.NewInt(int64(i)), Root: stTrie.Hash().Bytes(), CodeHash: emptyCode.Bytes()}
 			acc := &Account{Balance: big.NewInt(int64(i)), Root: emptyRoot.Bytes(), CodeHash: emptyCode.Bytes()}
@@ -762,9 +768,9 @@ func TestGenerateFromEmptySnap(t *testing.T) {
 	accountCheckRange = 10
 	storageCheckRange = 20
 	helper := newHelper()
-	stRoot := helper.makeStorageTrie([]string{"key-1", "key-2", "key-3"}, []string{"val-1", "val-2", "val-3"})
 	// Add 1K accounts to the trie
 	for i := 0; i < 400; i++ {
+		stRoot := helper.makeStorageTrie(hashData([]byte(fmt.Sprintf("acc-%d", i))), []string{"key-1", "key-2", "key-3"}, []string{"val-1", "val-2", "val-3"}, true)
 		helper.addTrieAccount(fmt.Sprintf("acc-%d", i),
 			&Account{Balance: big.NewInt(1), Root: stRoot, CodeHash: emptyCode.Bytes()})
 	}
@@ -797,12 +803,12 @@ func TestGenerateWithIncompleteStorage(t *testing.T) {
 	helper := newHelper()
 	stKeys := []string{"1", "2", "3", "4", "5", "6", "7", "8"}
 	stVals := []string{"v1", "v2", "v3", "v4", "v5", "v6", "v7", "v8"}
-	stRoot := helper.makeStorageTrie(stKeys, stVals)
 	// We add 8 accounts, each one is missing exactly one of the storage slots. This means
 	// we don't have to order the keys and figure out exactly which hash-key winds up
 	// on the sensitive spots at the boundaries
 	for i := 0; i < 8; i++ {
 		accKey := fmt.Sprintf("acc-%d", i)
+		stRoot := helper.makeStorageTrie(hashData([]byte(accKey)), stKeys, stVals, true)
 		helper.addAccount(accKey, &Account{Balance: big.NewInt(int64(i)), Root: stRoot, CodeHash: emptyCode.Bytes()})
 		var moddedKeys []string
 		var moddedVals []string

--- a/core/state/snapshot/journal.go
+++ b/core/state/snapshot/journal.go
@@ -172,6 +172,7 @@ func loadSnapshot(diskdb ethdb.KeyValueStore, triedb *trie.Database, cache int, 
 	}
 	// Everything loaded correctly, resume any suspended operations
 	if !generator.Done {
+		fmt.Println(">>>>>>>>>>>>>")
 		// Whether or not wiping was in progress, load any generator progress too
 		base.genMarker = generator.Marker
 		if base.genMarker == nil {

--- a/core/state/snapshot/snapshot.go
+++ b/core/state/snapshot/snapshot.go
@@ -183,6 +183,7 @@ func New(diskdb ethdb.KeyValueStore, triedb *trie.Database, cache int, root comm
 		layers: make(map[common.Hash]snapshot),
 	}
 	if !async {
+		fmt.Println("wait")
 		defer snap.waitBuild()
 	}
 	// Attempt to load a previously persisted snapshot and rebuild one if failed

--- a/core/state/state_object.go
+++ b/core/state/state_object.go
@@ -162,7 +162,7 @@ func (s *stateObject) getTrie(db Database) Trie {
 		if s.data.Root != emptyRoot && s.db.prefetcher != nil {
 			// When the miner is creating the pending state, there is no
 			// prefetcher
-			s.trie = s.db.prefetcher.trie(s.data.Root)
+			s.trie = s.db.prefetcher.trie(s.addrHash, s.data.Root)
 		}
 		if s.trie == nil {
 			var err error
@@ -318,7 +318,7 @@ func (s *stateObject) finalise(prefetch bool) {
 		}
 	}
 	if s.db.prefetcher != nil && prefetch && len(slotsToPrefetch) > 0 && s.data.Root != emptyRoot {
-		s.db.prefetcher.prefetch(s.data.Root, slotsToPrefetch)
+		s.db.prefetcher.prefetch(s.addrHash, s.data.Root, slotsToPrefetch)
 	}
 	if len(s.dirtyStorage) > 0 {
 		s.dirtyStorage = make(Storage)
@@ -373,7 +373,7 @@ func (s *stateObject) updateTrie(db Database) Trie {
 		usedStorage = append(usedStorage, common.CopyBytes(key[:])) // Copy needed for closure
 	}
 	if s.db.prefetcher != nil {
-		s.db.prefetcher.used(s.data.Root, usedStorage)
+		s.db.prefetcher.used(s.addrHash, s.data.Root, usedStorage)
 	}
 	if len(s.pendingStorage) > 0 {
 		s.pendingStorage = make(Storage)

--- a/core/state/statedb.go
+++ b/core/state/statedb.go
@@ -825,7 +825,7 @@ func (s *StateDB) Finalise(deleteEmptyObjects bool) {
 		addressesToPrefetch = append(addressesToPrefetch, common.CopyBytes(addr[:])) // Copy needed for closure
 	}
 	if s.prefetcher != nil && len(addressesToPrefetch) > 0 {
-		s.prefetcher.prefetch(s.originalRoot, addressesToPrefetch)
+		s.prefetcher.prefetch(common.Hash{}, s.originalRoot, addressesToPrefetch)
 	}
 	// Invalidate journal because reverting across transactions is not allowed.
 	s.clearJournalAndRefund()
@@ -866,7 +866,7 @@ func (s *StateDB) IntermediateRoot(deleteEmptyObjects bool) common.Hash {
 	// _untouched_. We can check with the prefetcher, if it can give us a trie
 	// which has the same root, but also has some content loaded into it.
 	if prefetcher != nil {
-		if trie := prefetcher.trie(s.originalRoot); trie != nil {
+		if trie := prefetcher.trie(common.Hash{}, s.originalRoot); trie != nil {
 			s.trie = trie
 		}
 	}
@@ -880,7 +880,7 @@ func (s *StateDB) IntermediateRoot(deleteEmptyObjects bool) common.Hash {
 		usedAddrs = append(usedAddrs, common.CopyBytes(addr[:])) // Copy needed for closure
 	}
 	if prefetcher != nil {
-		prefetcher.used(s.originalRoot, usedAddrs)
+		prefetcher.used(common.Hash{}, s.originalRoot, usedAddrs)
 	}
 	if len(s.stateObjectsPending) > 0 {
 		s.stateObjectsPending = make(map[common.Address]struct{})
@@ -948,12 +948,13 @@ func (s *StateDB) Commit(deleteEmptyObjects bool) (common.Hash, error) {
 	// The onleaf func is called _serially_, so we can reuse the same account
 	// for unmarshalling every time.
 	var account Account
-	root, err := s.trie.Commit(func(_ [][]byte, _ []byte, leaf []byte, parent common.Hash) error {
+	root, err := s.trie.Commit(func(keys [][]byte, path []byte, leaf []byte, parent common.Hash, parentPath []byte) error {
 		if err := rlp.DecodeBytes(leaf, &account); err != nil {
 			return nil
 		}
 		if account.Root != emptyRoot {
-			s.db.TrieDB().Reference(account.Root, parent)
+			owner := common.BytesToHash(keys[0])
+			s.db.TrieDB().Reference(owner, account.Root, parent, parentPath)
 		}
 		return nil
 	})

--- a/core/state/sync.go
+++ b/core/state/sync.go
@@ -26,20 +26,20 @@ import (
 )
 
 // NewStateSync create a new state trie download scheduler.
-func NewStateSync(root common.Hash, database ethdb.KeyValueReader, bloom *trie.SyncBloom, onLeaf func(paths [][]byte, leaf []byte) error) *trie.Sync {
+func NewStateSync(root common.Hash, database ethdb.KeyValueReader, bloom *trie.SyncBloom, onLeaf func(keys [][]byte, leaf []byte) error) *trie.Sync {
 	// Register the storage slot callback if the external callback is specified.
-	var onSlot func(paths [][]byte, hexpath []byte, leaf []byte, parent common.Hash) error
+	var onSlot func(keys [][]byte, path []byte, leaf []byte, parent common.Hash, parentPath []byte) error
 	if onLeaf != nil {
-		onSlot = func(paths [][]byte, hexpath []byte, leaf []byte, parent common.Hash) error {
-			return onLeaf(paths, leaf)
+		onSlot = func(keys [][]byte, path []byte, leaf []byte, parent common.Hash, parentPath []byte) error {
+			return onLeaf(keys, leaf)
 		}
 	}
 	// Register the account callback to connect the state trie and the storage
 	// trie belongs to the contract.
 	var syncer *trie.Sync
-	onAccount := func(paths [][]byte, hexpath []byte, leaf []byte, parent common.Hash) error {
+	onAccount := func(keys [][]byte, path []byte, leaf []byte, parent common.Hash, parentPath []byte) error {
 		if onLeaf != nil {
-			if err := onLeaf(paths, leaf); err != nil {
+			if err := onLeaf(keys, leaf); err != nil {
 				return err
 			}
 		}
@@ -47,8 +47,8 @@ func NewStateSync(root common.Hash, database ethdb.KeyValueReader, bloom *trie.S
 		if err := rlp.Decode(bytes.NewReader(leaf), &obj); err != nil {
 			return err
 		}
-		syncer.AddSubTrie(obj.Root, hexpath, parent, onSlot)
-		syncer.AddCodeEntry(common.BytesToHash(obj.CodeHash), hexpath, parent)
+		syncer.AddSubTrie(obj.Root, path, parent, parentPath, onSlot)
+		syncer.AddCodeEntry(common.BytesToHash(obj.CodeHash), path, parent, parentPath)
 		return nil
 	}
 	syncer = trie.NewSync(root, database, onAccount, bloom)

--- a/core/state/sync_test.go
+++ b/core/state/sync_test.go
@@ -116,10 +116,6 @@ func checkTrieConsistency(db ethdb.Database, root common.Hash) error {
 
 // checkStateConsistency checks that all data of a state root is present.
 func checkStateConsistency(db ethdb.Database, root common.Hash) error {
-	// Create and iterate a state trie rooted in a sub-node
-	if _, err := db.Get(root.Bytes()); err != nil {
-		return nil // Consider a non existent state consistent.
-	}
 	state, err := New(root, NewDatabase(db), nil)
 	if err != nil {
 		return err
@@ -134,7 +130,7 @@ func checkStateConsistency(db ethdb.Database, root common.Hash) error {
 func TestEmptyStateSync(t *testing.T) {
 	empty := common.HexToHash("56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421")
 	sync := NewStateSync(empty, rawdb.NewMemoryDatabase(), trie.NewSyncBloom(1, memorydb.New()), nil)
-	if nodes, paths, codes := sync.Missing(1); len(nodes) != 0 || len(paths) != 0 || len(codes) != 0 {
+	if keys, nodes, paths, codes := sync.Missing(1); len(keys) != 0 || len(nodes) != 0 || len(paths) != 0 || len(codes) != 0 {
 		t.Errorf(" content requested for empty state: %v, %v, %v", nodes, paths, codes)
 	}
 }
@@ -160,6 +156,14 @@ func TestIterativeStateSyncBatchedByPath(t *testing.T) {
 	testIterativeStateSync(t, 100, false, true)
 }
 
+// stateElement represents the element in the state trie(bytecode or trie node).
+type stateElement struct {
+	key  string
+	hash common.Hash
+	path trie.NodePath
+	code common.Hash
+}
+
 func testIterativeStateSync(t *testing.T, count int, commit bool, bypath bool) {
 	// Create a random state to copy
 	srcDb, srcRoot, srcAccounts := makeTestState()
@@ -172,54 +176,73 @@ func testIterativeStateSync(t *testing.T, count int, commit bool, bypath bool) {
 	dstDb := rawdb.NewMemoryDatabase()
 	sched := NewStateSync(srcRoot, dstDb, trie.NewSyncBloom(1, dstDb), nil)
 
-	nodes, paths, codes := sched.Missing(count)
+	keys, nodes, paths, codes := sched.Missing(count)
 	var (
-		hashQueue []common.Hash
-		pathQueue []trie.SyncPath
+		nodeElements []stateElement
+		codeElements []stateElement
 	)
-	if !bypath {
-		hashQueue = append(append(hashQueue[:0], nodes...), codes...)
-	} else {
-		hashQueue = append(hashQueue[:0], codes...)
-		pathQueue = append(pathQueue[:0], paths...)
+	for i := 0; i < len(keys); i++ {
+		nodeElements = append(nodeElements, stateElement{
+			key:  keys[i],
+			hash: nodes[i],
+			path: paths[i],
+		})
 	}
-	for len(hashQueue)+len(pathQueue) > 0 {
-		results := make([]trie.SyncResult, len(hashQueue)+len(pathQueue))
-		for i, hash := range hashQueue {
-			data, err := srcDb.TrieDB().Node(hash)
+	for i := 0; i < len(codes); i++ {
+		codeElements = append(codeElements, stateElement{
+			code: codes[i],
+		})
+	}
+	for len(nodeElements)+len(codeElements) > 0 {
+		var (
+			nodeResults = make([]trie.NodeSyncResult, len(nodeElements))
+			codeResults = make([]trie.CodeSyncResult, len(codeElements))
+		)
+		for i, element := range codeElements {
+			data, err := srcDb.ContractCode(common.Hash{}, element.code)
 			if err != nil {
-				data, err = srcDb.ContractCode(common.Hash{}, hash)
+				t.Fatalf("failed to retrieve contract bytecode for hash %x", element.code)
 			}
-			if err != nil {
-				t.Fatalf("failed to retrieve node data for hash %x", hash)
-			}
-			results[i] = trie.SyncResult{Hash: hash, Data: data}
+			codeResults[i] = trie.CodeSyncResult{Hash: element.code, Data: data}
 		}
-		for i, path := range pathQueue {
-			if len(path) == 1 {
-				data, _, err := srcTrie.TryGetNode(path[0])
-				if err != nil {
-					t.Fatalf("failed to retrieve node data for path %x: %v", path, err)
+		for i, node := range nodeElements {
+			if bypath {
+				if len(node.path) == 1 {
+					data, _, err := srcTrie.TryGetNode(node.path[0])
+					if err != nil {
+						t.Fatalf("failed to retrieve node data for path %x: %v", node.path[0], err)
+					}
+					nodeResults[i] = trie.NodeSyncResult{Key: node.key, Data: data}
+				} else {
+					var acc Account
+					if err := rlp.DecodeBytes(srcTrie.Get(node.path[0]), &acc); err != nil {
+						t.Fatalf("failed to decode account on path %x: %v", node.path[0], err)
+					}
+					stTrie, err := trie.NewWithOwner(common.BytesToHash(node.path[0]), acc.Root, srcDb.TrieDB())
+					if err != nil {
+						t.Fatalf("failed to retriev storage trie for path %x: %v", node.path[1], err)
+					}
+					data, _, err := stTrie.TryGetNode(node.path[1])
+					if err != nil {
+						t.Fatalf("failed to retrieve node data for path %x: %v", node.path[1], err)
+					}
+					nodeResults[i] = trie.NodeSyncResult{Key: node.key, Data: data}
 				}
-				results[len(hashQueue)+i] = trie.SyncResult{Hash: crypto.Keccak256Hash(data), Data: data}
 			} else {
-				var acc Account
-				if err := rlp.DecodeBytes(srcTrie.Get(path[0]), &acc); err != nil {
-					t.Fatalf("failed to decode account on path %x: %v", path, err)
-				}
-				stTrie, err := trie.New(acc.Root, srcDb.TrieDB())
+				data, err := srcDb.TrieDB().NodeByKey([]byte(node.key))
 				if err != nil {
-					t.Fatalf("failed to retriev storage trie for path %x: %v", path, err)
+					t.Fatalf("failed to retrieve node data for key %v", []byte(node.key))
 				}
-				data, _, err := stTrie.TryGetNode(path[1])
-				if err != nil {
-					t.Fatalf("failed to retrieve node data for path %x: %v", path, err)
-				}
-				results[len(hashQueue)+i] = trie.SyncResult{Hash: crypto.Keccak256Hash(data), Data: data}
+				nodeResults[i] = trie.NodeSyncResult{Key: node.key, Data: data}
 			}
 		}
-		for _, result := range results {
-			if err := sched.Process(result); err != nil {
+		for _, result := range codeResults {
+			if err := sched.ProcessCode(result); err != nil {
+				t.Errorf("failed to process result %v", err)
+			}
+		}
+		for _, result := range nodeResults {
+			if err := sched.ProcessNode(result); err != nil {
 				t.Errorf("failed to process result %v", err)
 			}
 		}
@@ -229,12 +252,20 @@ func testIterativeStateSync(t *testing.T, count int, commit bool, bypath bool) {
 		}
 		batch.Write()
 
-		nodes, paths, codes = sched.Missing(count)
-		if !bypath {
-			hashQueue = append(append(hashQueue[:0], nodes...), codes...)
-		} else {
-			hashQueue = append(hashQueue[:0], codes...)
-			pathQueue = append(pathQueue[:0], paths...)
+		keys, nodes, paths, codes = sched.Missing(count)
+		nodeElements = nodeElements[:0]
+		for i := 0; i < len(keys); i++ {
+			nodeElements = append(nodeElements, stateElement{
+				key:  keys[i],
+				hash: nodes[i],
+				path: paths[i],
+			})
+		}
+		codeElements = codeElements[:0]
+		for i := 0; i < len(codes); i++ {
+			codeElements = append(codeElements, stateElement{
+				code: codes[i],
+			})
 		}
 	}
 	// Cross check that the two states are in sync
@@ -251,26 +282,59 @@ func TestIterativeDelayedStateSync(t *testing.T) {
 	dstDb := rawdb.NewMemoryDatabase()
 	sched := NewStateSync(srcRoot, dstDb, trie.NewSyncBloom(1, dstDb), nil)
 
-	nodes, _, codes := sched.Missing(0)
-	queue := append(append([]common.Hash{}, nodes...), codes...)
+	var (
+		nodeElements []stateElement
+		codeElements []stateElement
+	)
+	keys, nodes, paths, codes := sched.Missing(0)
+	for i := 0; i < len(keys); i++ {
+		nodeElements = append(nodeElements, stateElement{
+			key:  keys[i],
+			hash: nodes[i],
+			path: paths[i],
+		})
+	}
+	for i := 0; i < len(codes); i++ {
+		codeElements = append(codeElements, stateElement{
+			code: codes[i],
+		})
+	}
 
-	for len(queue) > 0 {
+	for len(nodeElements)+len(codeElements) > 0 {
 		// Sync only half of the scheduled nodes
-		results := make([]trie.SyncResult, len(queue)/2+1)
-		for i, hash := range queue[:len(results)] {
-			data, err := srcDb.TrieDB().Node(hash)
-			if err != nil {
-				data, err = srcDb.ContractCode(common.Hash{}, hash)
+		var nodeProcessd int
+		var codeProcessd int
+		if len(codeElements) > 0 {
+			codeResults := make([]trie.CodeSyncResult, len(codeElements)/2+1)
+			for i, element := range codeElements[:len(codeResults)] {
+				data, err := srcDb.ContractCode(common.Hash{}, element.code)
+				if err != nil {
+					t.Fatalf("failed to retrieve contract bytecode for %x", element.code)
+				}
+				codeResults[i] = trie.CodeSyncResult{Hash: element.code, Data: data}
 			}
-			if err != nil {
-				t.Fatalf("failed to retrieve node data for %x", hash)
+			for _, result := range codeResults {
+				if err := sched.ProcessCode(result); err != nil {
+					t.Fatalf("failed to process result %v", err)
+				}
 			}
-			results[i] = trie.SyncResult{Hash: hash, Data: data}
+			codeProcessd = len(codeResults)
 		}
-		for _, result := range results {
-			if err := sched.Process(result); err != nil {
-				t.Fatalf("failed to process result %v", err)
+		if len(nodeElements) > 0 {
+			nodeResults := make([]trie.NodeSyncResult, len(nodeElements)/2+1)
+			for i, element := range nodeElements[:len(nodeResults)] {
+				data, err := srcDb.TrieDB().NodeByKey([]byte(element.key))
+				if err != nil {
+					t.Fatalf("failed to retrieve contract bytecode for %x", element.code)
+				}
+				nodeResults[i] = trie.NodeSyncResult{Key: element.key, Data: data}
 			}
+			for _, result := range nodeResults {
+				if err := sched.ProcessNode(result); err != nil {
+					t.Fatalf("failed to process result %v", err)
+				}
+			}
+			nodeProcessd = len(nodeResults)
 		}
 		batch := dstDb.NewBatch()
 		if err := sched.Commit(batch); err != nil {
@@ -278,8 +342,21 @@ func TestIterativeDelayedStateSync(t *testing.T) {
 		}
 		batch.Write()
 
-		nodes, _, codes = sched.Missing(0)
-		queue = append(append(queue[len(results):], nodes...), codes...)
+		keys, nodes, paths, codes = sched.Missing(0)
+		nodeElements = nodeElements[nodeProcessd:]
+		for i := 0; i < len(keys); i++ {
+			nodeElements = append(nodeElements, stateElement{
+				key:  keys[i],
+				hash: nodes[i],
+				path: paths[i],
+			})
+		}
+		codeElements = codeElements[codeProcessd:]
+		for i := 0; i < len(codes); i++ {
+			codeElements = append(codeElements, stateElement{
+				code: codes[i],
+			})
+		}
 	}
 	// Cross check that the two states are in sync
 	checkStateAccounts(t, dstDb, srcRoot, srcAccounts)
@@ -299,40 +376,70 @@ func testIterativeRandomStateSync(t *testing.T, count int) {
 	dstDb := rawdb.NewMemoryDatabase()
 	sched := NewStateSync(srcRoot, dstDb, trie.NewSyncBloom(1, dstDb), nil)
 
-	queue := make(map[common.Hash]struct{})
-	nodes, _, codes := sched.Missing(count)
-	for _, hash := range append(nodes, codes...) {
-		queue[hash] = struct{}{}
+	nodeQueue := make(map[string]stateElement)
+	codeQueue := make(map[common.Hash]struct{})
+	keys, nodes, paths, codes := sched.Missing(count)
+	for i, key := range keys {
+		nodeQueue[key] = stateElement{
+			key:  key,
+			hash: nodes[i],
+			path: paths[i],
+		}
 	}
-	for len(queue) > 0 {
+	for _, hash := range codes {
+		codeQueue[hash] = struct{}{}
+	}
+	for len(nodeQueue)+len(codeQueue) > 0 {
 		// Fetch all the queued nodes in a random order
-		results := make([]trie.SyncResult, 0, len(queue))
-		for hash := range queue {
-			data, err := srcDb.TrieDB().Node(hash)
-			if err != nil {
-				data, err = srcDb.ContractCode(common.Hash{}, hash)
+		if len(codeQueue) > 0 {
+			results := make([]trie.CodeSyncResult, 0, len(codeQueue))
+			for hash := range codeQueue {
+				data, err := srcDb.ContractCode(common.Hash{}, hash)
+				if err != nil {
+					t.Fatalf("failed to retrieve node data for %x", hash)
+				}
+				results = append(results, trie.CodeSyncResult{Hash: hash, Data: data})
 			}
-			if err != nil {
-				t.Fatalf("failed to retrieve node data for %x", hash)
+			for _, result := range results {
+				if err := sched.ProcessCode(result); err != nil {
+					t.Fatalf("failed to process result %v", err)
+				}
 			}
-			results = append(results, trie.SyncResult{Hash: hash, Data: data})
+		}
+		if len(nodeQueue) > 0 {
+			results := make([]trie.NodeSyncResult, 0, len(nodeQueue))
+			for key, element := range nodeQueue {
+				data, err := srcDb.TrieDB().NodeByKey([]byte(key))
+				if err != nil {
+					t.Fatalf("failed to retrieve node data for %x %v %v", element.hash, []byte(element.key), element.path)
+				}
+				results = append(results, trie.NodeSyncResult{Key: key, Data: data})
+			}
+			for _, result := range results {
+				if err := sched.ProcessNode(result); err != nil {
+					t.Fatalf("failed to process result %v", err)
+				}
+			}
 		}
 		// Feed the retrieved results back and queue new tasks
-		for _, result := range results {
-			if err := sched.Process(result); err != nil {
-				t.Fatalf("failed to process result %v", err)
-			}
-		}
 		batch := dstDb.NewBatch()
 		if err := sched.Commit(batch); err != nil {
 			t.Fatalf("failed to commit data: %v", err)
 		}
 		batch.Write()
 
-		queue = make(map[common.Hash]struct{})
-		nodes, _, codes = sched.Missing(count)
-		for _, hash := range append(nodes, codes...) {
-			queue[hash] = struct{}{}
+		nodeQueue = make(map[string]stateElement)
+		codeQueue = make(map[common.Hash]struct{})
+		keys, nodes, paths, codes := sched.Missing(count)
+		for i, key := range keys {
+			nodeQueue[key] = stateElement{
+				key:  key,
+				hash: nodes[i],
+				path: paths[i],
+			}
+		}
+		for _, hash := range codes {
+			codeQueue[hash] = struct{}{}
 		}
 	}
 	// Cross check that the two states are in sync
@@ -349,34 +456,62 @@ func TestIterativeRandomDelayedStateSync(t *testing.T) {
 	dstDb := rawdb.NewMemoryDatabase()
 	sched := NewStateSync(srcRoot, dstDb, trie.NewSyncBloom(1, dstDb), nil)
 
-	queue := make(map[common.Hash]struct{})
-	nodes, _, codes := sched.Missing(0)
-	for _, hash := range append(nodes, codes...) {
-		queue[hash] = struct{}{}
+	nodeQueue := make(map[string]stateElement)
+	codeQueue := make(map[common.Hash]struct{})
+	keys, nodes, paths, codes := sched.Missing(0)
+	for i, key := range keys {
+		nodeQueue[key] = stateElement{
+			key:  key,
+			hash: nodes[i],
+			path: paths[i],
+		}
 	}
-	for len(queue) > 0 {
+	for _, hash := range codes {
+		codeQueue[hash] = struct{}{}
+	}
+	for len(nodeQueue)+len(codeQueue) > 0 {
 		// Sync only half of the scheduled nodes, even those in random order
-		results := make([]trie.SyncResult, 0, len(queue)/2+1)
-		for hash := range queue {
-			delete(queue, hash)
+		if len(codeQueue) > 0 {
+			results := make([]trie.CodeSyncResult, 0, len(codeQueue)/2+1)
+			for hash := range codeQueue {
+				delete(codeQueue, hash)
 
-			data, err := srcDb.TrieDB().Node(hash)
-			if err != nil {
-				data, err = srcDb.ContractCode(common.Hash{}, hash)
-			}
-			if err != nil {
-				t.Fatalf("failed to retrieve node data for %x", hash)
-			}
-			results = append(results, trie.SyncResult{Hash: hash, Data: data})
+				data, err := srcDb.ContractCode(common.Hash{}, hash)
+				if err != nil {
+					t.Fatalf("failed to retrieve node data for %x", hash)
+				}
+				results = append(results, trie.CodeSyncResult{Hash: hash, Data: data})
 
-			if len(results) >= cap(results) {
-				break
+				if len(results) >= cap(results) {
+					break
+				}
+			}
+			for _, result := range results {
+				if err := sched.ProcessCode(result); err != nil {
+					t.Fatalf("failed to process result %v", err)
+				}
 			}
 		}
-		// Feed the retrieved results back and queue new tasks
-		for _, result := range results {
-			if err := sched.Process(result); err != nil {
-				t.Fatalf("failed to process result %v", err)
+		if len(nodeQueue) > 0 {
+			results := make([]trie.NodeSyncResult, 0, len(nodeQueue)/2+1)
+			for key, element := range nodeQueue {
+				delete(nodeQueue, key)
+
+				data, err := srcDb.TrieDB().NodeByKey([]byte(key))
+				if err != nil {
+					t.Fatalf("failed to retrieve node data for %x", element.hash)
+				}
+				results = append(results, trie.NodeSyncResult{Key: key, Data: data})
+
+				if len(results) >= cap(results) {
+					break
+				}
+			}
+			// Feed the retrieved results back and queue new tasks
+			for _, result := range results {
+				if err := sched.ProcessNode(result); err != nil {
+					t.Fatalf("failed to process result %v", err)
+				}
 			}
 		}
 		batch := dstDb.NewBatch()
@@ -384,12 +519,17 @@ func TestIterativeRandomDelayedStateSync(t *testing.T) {
 			t.Fatalf("failed to commit data: %v", err)
 		}
 		batch.Write()
-		for _, result := range results {
-			delete(queue, result.Hash)
+
+		keys, nodes, paths, codes := sched.Missing(0)
+		for i, key := range keys {
+			nodeQueue[key] = stateElement{
+				key:  key,
+				hash: nodes[i],
+				path: paths[i],
+			}
 		}
-		nodes, _, codes = sched.Missing(0)
-		for _, hash := range append(nodes, codes...) {
-			queue[hash] = struct{}{}
+		for _, hash := range codes {
+			codeQueue[hash] = struct{}{}
 		}
 	}
 	// Cross check that the two states are in sync
@@ -416,28 +556,62 @@ func TestIncompleteStateSync(t *testing.T) {
 	dstDb := rawdb.NewMemoryDatabase()
 	sched := NewStateSync(srcRoot, dstDb, trie.NewSyncBloom(1, dstDb), nil)
 
-	var added []common.Hash
-
-	nodes, _, codes := sched.Missing(1)
-	queue := append(append([]common.Hash{}, nodes...), codes...)
-
-	for len(queue) > 0 {
-		// Fetch a batch of state nodes
-		results := make([]trie.SyncResult, len(queue))
-		for i, hash := range queue {
-			data, err := srcDb.TrieDB().Node(hash)
-			if err != nil {
-				data, err = srcDb.ContractCode(common.Hash{}, hash)
-			}
-			if err != nil {
-				t.Fatalf("failed to retrieve node data for %x", hash)
-			}
-			results[i] = trie.SyncResult{Hash: hash, Data: data}
+	var (
+		addedCodes []common.Hash
+		addedNodes []string
+	)
+	nodeQueue := make(map[string]stateElement)
+	codeQueue := make(map[common.Hash]struct{})
+	keys, nodes, paths, codes := sched.Missing(1)
+	for i, key := range keys {
+		nodeQueue[key] = stateElement{
+			key:  key,
+			hash: nodes[i],
+			path: paths[i],
 		}
-		// Process each of the state nodes
-		for _, result := range results {
-			if err := sched.Process(result); err != nil {
-				t.Fatalf("failed to process result %v", err)
+	}
+	for _, hash := range codes {
+		codeQueue[hash] = struct{}{}
+	}
+	for len(nodeQueue)+len(codeQueue) > 0 {
+		// Fetch a batch of state nodes
+		if len(codeQueue) > 0 {
+			results := make([]trie.CodeSyncResult, 0, len(codeQueue))
+			for hash := range codeQueue {
+				data, err := srcDb.ContractCode(common.Hash{}, hash)
+				if err != nil {
+					t.Fatalf("failed to retrieve node data for %x", hash)
+				}
+				results = append(results, trie.CodeSyncResult{Hash: hash, Data: data})
+				addedCodes = append(addedCodes, hash)
+			}
+			// Process each of the state nodes
+			for _, result := range results {
+				if err := sched.ProcessCode(result); err != nil {
+					t.Fatalf("failed to process result %v", err)
+				}
+			}
+		}
+		var nodehashes []common.Hash
+		if len(nodeQueue) > 0 {
+			results := make([]trie.NodeSyncResult, 0, len(nodeQueue))
+			for key, element := range nodeQueue {
+				data, err := srcDb.TrieDB().NodeByKey([]byte(element.key))
+				if err != nil {
+					t.Fatalf("failed to retrieve node data for %x", element.hash)
+				}
+				results = append(results, trie.NodeSyncResult{Key: key, Data: data})
+
+				if element.hash != srcRoot {
+					addedNodes = append(addedNodes, element.key)
+				}
+				nodehashes = append(nodehashes, element.hash)
+			}
+			// Process each of the state nodes
+			for _, result := range results {
+				if err := sched.ProcessNode(result); err != nil {
+					t.Fatalf("failed to process result %v", err)
+				}
 			}
 		}
 		batch := dstDb.NewBatch()
@@ -445,43 +619,44 @@ func TestIncompleteStateSync(t *testing.T) {
 			t.Fatalf("failed to commit data: %v", err)
 		}
 		batch.Write()
-		for _, result := range results {
-			added = append(added, result.Hash)
-			// Check that all known sub-tries added so far are complete or missing entirely.
-			if _, ok := isCode[result.Hash]; ok {
-				continue
-			}
+
+		for _, root := range nodehashes {
 			// Can't use checkStateConsistency here because subtrie keys may have odd
 			// length and crash in LeafKey.
-			if err := checkTrieConsistency(dstDb, result.Hash); err != nil {
+			if err := checkTrieConsistency(dstDb, root); err != nil {
 				t.Fatalf("state inconsistent: %v", err)
 			}
 		}
 		// Fetch the next batch to retrieve
-		nodes, _, codes = sched.Missing(1)
-		queue = append(append(queue[:0], nodes...), codes...)
+		nodeQueue = make(map[string]stateElement)
+		codeQueue = make(map[common.Hash]struct{})
+		keys, nodes, paths, codes := sched.Missing(1)
+		for i, key := range keys {
+			nodeQueue[key] = stateElement{
+				key:  key,
+				hash: nodes[i],
+				path: paths[i],
+			}
+		}
+		for _, hash := range codes {
+			codeQueue[hash] = struct{}{}
+		}
 	}
 	// Sanity check that removing any node from the database is detected
-	for _, node := range added[1:] {
-		var (
-			key     = node.Bytes()
-			_, code = isCode[node]
-			val     []byte
-		)
-		if code {
-			val = rawdb.ReadCode(dstDb, node)
-			rawdb.DeleteCode(dstDb, node)
-		} else {
-			val = rawdb.ReadTrieNode(dstDb, node)
-			rawdb.DeleteTrieNode(dstDb, node)
+	for _, node := range addedCodes {
+		val := rawdb.ReadCode(dstDb, node)
+		rawdb.DeleteCode(dstDb, node)
+		if err := checkStateConsistency(dstDb, srcRoot); err == nil {
+			t.Errorf("trie inconsistency not caught, missing: %x", node)
 		}
-		if err := checkStateConsistency(dstDb, added[0]); err == nil {
-			t.Fatalf("trie inconsistency not caught, missing: %x", key)
+		rawdb.WriteCode(dstDb, node, val)
+	}
+	for _, node := range addedNodes {
+		var val = rawdb.ReadTrieNode(dstDb, []byte(node))
+		rawdb.DeleteTrieNode(dstDb, []byte(node))
+		if err := checkStateConsistency(dstDb, srcRoot); err == nil {
+			t.Errorf("trie inconsistency not caught, missing: %v", node)
 		}
-		if code {
-			rawdb.WriteCode(dstDb, node, val)
-		} else {
-			rawdb.WriteTrieNode(dstDb, node, val)
-		}
+		rawdb.WriteTrieNode(dstDb, []byte(node), val)
 	}
 }

--- a/core/state/trie_prefetcher.go
+++ b/core/state/trie_prefetcher.go
@@ -35,10 +35,10 @@ var (
 //
 // Note, the prefetcher's API is not thread safe.
 type triePrefetcher struct {
-	db       Database                    // Database to fetch trie nodes through
-	root     common.Hash                 // Root hash of theaccount trie for metrics
-	fetches  map[common.Hash]Trie        // Partially or fully fetcher tries
-	fetchers map[common.Hash]*subfetcher // Subfetchers for each trie
+	db       Database               // Database to fetch trie nodes through
+	root     common.Hash            // Root hash of the account trie for metrics
+	fetches  map[string]Trie        // Partially or fully fetcher tries
+	fetchers map[string]*subfetcher // Subfetchers for each trie
 
 	deliveryMissMeter metrics.Meter
 	accountLoadMeter  metrics.Meter
@@ -57,7 +57,7 @@ func newTriePrefetcher(db Database, root common.Hash, namespace string) *triePre
 	p := &triePrefetcher{
 		db:       db,
 		root:     root,
-		fetchers: make(map[common.Hash]*subfetcher), // Active prefetchers use the fetchers map
+		fetchers: make(map[string]*subfetcher), // Active prefetchers use the fetchers map
 
 		deliveryMissMeter: metrics.GetOrRegisterMeter(prefix+"/deliverymiss", nil),
 		accountLoadMeter:  metrics.GetOrRegisterMeter(prefix+"/account/load", nil),
@@ -79,7 +79,7 @@ func (p *triePrefetcher) close() {
 		fetcher.abort() // safe to do multiple times
 
 		if metrics.Enabled {
-			if fetcher.root == p.root {
+			if fetcher.root == p.root && fetcher.owner == (common.Hash{}) {
 				p.accountLoadMeter.Mark(int64(len(fetcher.seen)))
 				p.accountDupMeter.Mark(int64(fetcher.dups))
 				p.accountSkipMeter.Mark(int64(len(fetcher.tasks)))
@@ -112,7 +112,7 @@ func (p *triePrefetcher) copy() *triePrefetcher {
 	copy := &triePrefetcher{
 		db:      p.db,
 		root:    p.root,
-		fetches: make(map[common.Hash]Trie), // Active prefetchers use the fetches map
+		fetches: make(map[string]Trie), // Active prefetchers use the fetches map
 
 		deliveryMissMeter: p.deliveryMissMeter,
 		accountLoadMeter:  p.accountLoadMeter,
@@ -132,33 +132,35 @@ func (p *triePrefetcher) copy() *triePrefetcher {
 		return copy
 	}
 	// Otherwise we're copying an active fetcher, retrieve the current states
-	for root, fetcher := range p.fetchers {
-		copy.fetches[root] = fetcher.peek()
+	for id, fetcher := range p.fetchers {
+		copy.fetches[id] = fetcher.peek()
 	}
 	return copy
 }
 
 // prefetch schedules a batch of trie items to prefetch.
-func (p *triePrefetcher) prefetch(root common.Hash, keys [][]byte) {
+func (p *triePrefetcher) prefetch(owner common.Hash, root common.Hash, keys [][]byte) {
 	// If the prefetcher is an inactive one, bail out
 	if p.fetches != nil {
 		return
 	}
 	// Active fetcher, schedule the retrievals
-	fetcher := p.fetchers[root]
+	id := p.trieID(owner, root)
+	fetcher := p.fetchers[id]
 	if fetcher == nil {
-		fetcher = newSubfetcher(p.db, root)
-		p.fetchers[root] = fetcher
+		fetcher = newSubfetcher(p.db, owner, root)
+		p.fetchers[id] = fetcher
 	}
 	fetcher.schedule(keys)
 }
 
 // trie returns the trie matching the root hash, or nil if the prefetcher doesn't
 // have it.
-func (p *triePrefetcher) trie(root common.Hash) Trie {
+func (p *triePrefetcher) trie(owner common.Hash, root common.Hash) Trie {
 	// If the prefetcher is inactive, return from existing deep copies
+	id := p.trieID(owner, root)
 	if p.fetches != nil {
-		trie := p.fetches[root]
+		trie := p.fetches[id]
 		if trie == nil {
 			p.deliveryMissMeter.Mark(1)
 			return nil
@@ -166,7 +168,7 @@ func (p *triePrefetcher) trie(root common.Hash) Trie {
 		return p.db.CopyTrie(trie)
 	}
 	// Otherwise the prefetcher is active, bail if no trie was prefetched for this root
-	fetcher := p.fetchers[root]
+	fetcher := p.fetchers[id]
 	if fetcher == nil {
 		p.deliveryMissMeter.Mark(1)
 		return nil
@@ -185,10 +187,15 @@ func (p *triePrefetcher) trie(root common.Hash) Trie {
 
 // used marks a batch of state items used to allow creating statistics as to
 // how useful or wasteful the prefetcher is.
-func (p *triePrefetcher) used(root common.Hash, used [][]byte) {
-	if fetcher := p.fetchers[root]; fetcher != nil {
+func (p *triePrefetcher) used(owner common.Hash, root common.Hash, used [][]byte) {
+	if fetcher := p.fetchers[p.trieID(owner, root)]; fetcher != nil {
 		fetcher.used = used
 	}
+}
+
+// trieID returns an unique trie identifier consists the trie owner and root hash.
+func (p *triePrefetcher) trieID(owner common.Hash, root common.Hash) string {
+	return string(append(owner.Bytes(), root.Bytes()...))
 }
 
 // subfetcher is a trie fetcher goroutine responsible for pulling entries for a
@@ -196,9 +203,10 @@ func (p *triePrefetcher) used(root common.Hash, used [][]byte) {
 // main prefetcher is paused and either all requested items are processed or if
 // the trie being worked on is retrieved from the prefetcher.
 type subfetcher struct {
-	db   Database    // Database to load trie nodes through
-	root common.Hash // Root hash of the trie to prefetch
-	trie Trie        // Trie being populated with nodes
+	db    Database    // Database to load trie nodes through
+	owner common.Hash // Owner of the trie, usually account hash
+	root  common.Hash // Root hash of the trie to prefetch
+	trie  Trie        // Trie being populated with nodes
 
 	tasks [][]byte   // Items queued up for retrieval
 	lock  sync.Mutex // Lock protecting the task queue
@@ -215,15 +223,16 @@ type subfetcher struct {
 
 // newSubfetcher creates a goroutine to prefetch state items belonging to a
 // particular root hash.
-func newSubfetcher(db Database, root common.Hash) *subfetcher {
+func newSubfetcher(db Database, owner common.Hash, root common.Hash) *subfetcher {
 	sf := &subfetcher{
-		db:   db,
-		root: root,
-		wake: make(chan struct{}, 1),
-		stop: make(chan struct{}),
-		term: make(chan struct{}),
-		copy: make(chan chan Trie),
-		seen: make(map[string]struct{}),
+		db:    db,
+		owner: owner,
+		root:  root,
+		wake:  make(chan struct{}, 1),
+		stop:  make(chan struct{}),
+		term:  make(chan struct{}),
+		copy:  make(chan chan Trie),
+		seen:  make(map[string]struct{}),
 	}
 	go sf.loop()
 	return sf
@@ -279,13 +288,21 @@ func (sf *subfetcher) loop() {
 	defer close(sf.term)
 
 	// Start by opening the trie and stop processing if it fails
-	trie, err := sf.db.OpenTrie(sf.root)
-	if err != nil {
-		log.Warn("Trie prefetcher failed opening trie", "root", sf.root, "err", err)
-		return
+	if sf.owner == (common.Hash{}) {
+		trie, err := sf.db.OpenTrie(sf.root)
+		if err != nil {
+			log.Warn("Trie prefetcher failed opening trie", "root", sf.root, "err", err)
+			return
+		}
+		sf.trie = trie
+	} else {
+		trie, err := sf.db.OpenStorageTrie(sf.owner, sf.root)
+		if err != nil {
+			log.Warn("Trie prefetcher failed opening trie", "root", sf.root, "err", err)
+			return
+		}
+		sf.trie = trie
 	}
-	sf.trie = trie
-
 	// Trie opened successfully, keep prefetching items
 	for {
 		select {

--- a/eth/downloader/statesync.go
+++ b/eth/downloader/statesync.go
@@ -35,7 +35,7 @@ import (
 // a single data retrieval network packet.
 type stateReq struct {
 	nItems    uint16                    // Number of items requested for download (max is 384, so uint16 is sufficient)
-	trieTasks map[common.Hash]*trieTask // Trie node download tasks to track previous attempts
+	trieTasks map[string]*trieTask      // Trie node download tasks to track previous attempts
 	codeTasks map[common.Hash]*codeTask // Byte code download tasks to track previous attempts
 	timeout   time.Duration             // Maximum round trip time for this to complete
 	timer     *time.Timer               // Timer to fire when the RTT timeout expires
@@ -264,7 +264,7 @@ type stateSync struct {
 	sched  *trie.Sync         // State trie sync scheduler defining the tasks
 	keccak crypto.KeccakState // Keccak256 hasher to verify deliveries with
 
-	trieTasks map[common.Hash]*trieTask // Set of trie node tasks currently queued for retrieval
+	trieTasks map[string]*trieTask      // Set of trie node tasks currently queued for retrieval
 	codeTasks map[common.Hash]*codeTask // Set of byte code tasks currently queued for retrieval
 
 	numUncommitted   int
@@ -282,6 +282,7 @@ type stateSync struct {
 // trieTask represents a single trie node download task, containing a set of
 // peers already attempted retrieval from to detect stalled syncs and abort.
 type trieTask struct {
+	hash     common.Hash
 	path     [][]byte
 	attempts map[string]struct{}
 }
@@ -300,7 +301,7 @@ func newStateSync(d *Downloader, root common.Hash) *stateSync {
 		root:      root,
 		sched:     state.NewStateSync(root, d.stateDB, d.stateBloom, nil),
 		keccak:    sha3.NewLegacyKeccak256().(crypto.KeccakState),
-		trieTasks: make(map[common.Hash]*trieTask),
+		trieTasks: make(map[string]*trieTask),
 		codeTasks: make(map[common.Hash]*codeTask),
 		deliver:   make(chan *stateReq),
 		cancel:    make(chan struct{}),
@@ -453,12 +454,13 @@ func (s *stateSync) assignTasks() {
 
 // fillTasks fills the given request object with a maximum of n state download
 // tasks to send to the remote peer.
-func (s *stateSync) fillTasks(n int, req *stateReq) (nodes []common.Hash, paths []trie.SyncPath, codes []common.Hash) {
+func (s *stateSync) fillTasks(n int, req *stateReq) (nodes []common.Hash, paths []trie.NodePath, codes []common.Hash) {
 	// Refill available tasks from the scheduler.
 	if fill := n - (len(s.trieTasks) + len(s.codeTasks)); fill > 0 {
-		nodes, paths, codes := s.sched.Missing(fill)
-		for i, hash := range nodes {
-			s.trieTasks[hash] = &trieTask{
+		keys, hashes, paths, codes := s.sched.Missing(fill)
+		for i, key := range keys {
+			s.trieTasks[key] = &trieTask{
+				hash:     hashes[i],
 				path:     paths[i],
 				attempts: make(map[string]struct{}),
 			}
@@ -472,10 +474,10 @@ func (s *stateSync) fillTasks(n int, req *stateReq) (nodes []common.Hash, paths 
 	// Find tasks that haven't been tried with the request's peer. Prefer code
 	// over trie nodes as those can be written to disk and forgotten about.
 	nodes = make([]common.Hash, 0, n)
-	paths = make([]trie.SyncPath, 0, n)
+	paths = make([]trie.NodePath, 0, n)
 	codes = make([]common.Hash, 0, n)
 
-	req.trieTasks = make(map[common.Hash]*trieTask, n)
+	req.trieTasks = make(map[string]*trieTask, n)
 	req.codeTasks = make(map[common.Hash]*codeTask, n)
 
 	for hash, t := range s.codeTasks {
@@ -493,7 +495,7 @@ func (s *stateSync) fillTasks(n int, req *stateReq) (nodes []common.Hash, paths 
 		req.codeTasks[hash] = t
 		delete(s.codeTasks, hash)
 	}
-	for hash, t := range s.trieTasks {
+	for key, t := range s.trieTasks {
 		// Stop when we've gathered enough requests
 		if len(nodes)+len(codes) == n {
 			break
@@ -505,11 +507,11 @@ func (s *stateSync) fillTasks(n int, req *stateReq) (nodes []common.Hash, paths 
 		// Assign the request to this peer
 		t.attempts[req.peer.id] = struct{}{}
 
-		nodes = append(nodes, hash)
+		nodes = append(nodes, t.hash)
 		paths = append(paths, t.path)
 
-		req.trieTasks[hash] = t
-		delete(s.trieTasks, hash)
+		req.trieTasks[key] = t
+		delete(s.trieTasks, key)
 	}
 	req.nItems = uint16(len(nodes) + len(codes))
 	return nodes, paths, codes
@@ -531,7 +533,7 @@ func (s *stateSync) process(req *stateReq) (int, error) {
 
 	// Iterate over all the delivered data and inject one-by-one into the trie
 	for _, blob := range req.response {
-		hash, err := s.processNodeData(blob)
+		hash, err := s.processNodeData(req.trieTasks, req.codeTasks, blob)
 		switch err {
 		case nil:
 			s.numUncommitted++
@@ -544,13 +546,10 @@ func (s *stateSync) process(req *stateReq) (int, error) {
 		default:
 			return successful, fmt.Errorf("invalid state node %s: %v", hash.TerminalString(), err)
 		}
-		// Delete from both queues (one delivery is enough for the syncer)
-		delete(req.trieTasks, hash)
-		delete(req.codeTasks, hash)
 	}
 	// Put unfulfilled tasks back into the retry queue
 	npeers := s.d.peers.Len()
-	for hash, task := range req.trieTasks {
+	for key, task := range req.trieTasks {
 		// If the node did deliver something, missing items may be due to a protocol
 		// limit or a previous timeout + delayed delivery. Both cases should permit
 		// the node to retry the missing items (to avoid single-peer stalls).
@@ -560,10 +559,10 @@ func (s *stateSync) process(req *stateReq) (int, error) {
 		// If we've requested the node too many times already, it may be a malicious
 		// sync where nobody has the right data. Abort.
 		if len(task.attempts) >= npeers {
-			return successful, fmt.Errorf("trie node %s failed with all peers (%d tries, %d peers)", hash.TerminalString(), len(task.attempts), npeers)
+			return successful, fmt.Errorf("trie node %s failed with all peers (%d tries, %d peers)", task.hash.TerminalString(), len(task.attempts), npeers)
 		}
 		// Missing item, place into the retry queue.
-		s.trieTasks[hash] = task
+		s.trieTasks[key] = task
 	}
 	for hash, task := range req.codeTasks {
 		// If the node did deliver something, missing items may be due to a protocol
@@ -586,13 +585,35 @@ func (s *stateSync) process(req *stateReq) (int, error) {
 // processNodeData tries to inject a trie node data blob delivered from a remote
 // peer into the state trie, returning whether anything useful was written or any
 // error occurred.
-func (s *stateSync) processNodeData(blob []byte) (common.Hash, error) {
-	res := trie.SyncResult{Data: blob}
+//
+// If multiple requests correspond to the same hash, this method will inject the
+// blob as a result for the first one only, leaving the remaining duplicates to
+// be fetched again.
+func (s *stateSync) processNodeData(nodeTasks map[string]*trieTask, codeTasks map[common.Hash]*codeTask, blob []byte) (common.Hash, error) {
+	var hash common.Hash
 	s.keccak.Reset()
 	s.keccak.Write(blob)
-	s.keccak.Read(res.Hash[:])
-	err := s.sched.Process(res)
-	return res.Hash, err
+	s.keccak.Read(hash[:])
+
+	if _, present := codeTasks[hash]; present {
+		err := s.sched.ProcessCode(trie.CodeSyncResult{
+			Hash: hash,
+			Data: blob,
+		})
+		delete(codeTasks, hash)
+		return hash, err
+	}
+	for key, task := range nodeTasks {
+		if task.hash == hash {
+			err := s.sched.ProcessNode(trie.NodeSyncResult{
+				Key:  key,
+				Data: blob,
+			})
+			delete(nodeTasks, key)
+			return hash, err
+		}
+	}
+	return common.Hash{}, trie.ErrNotRequested
 }
 
 // updateStats bumps the various state sync progress counters and displays a log

--- a/eth/protocols/snap/handler.go
+++ b/eth/protocols/snap/handler.go
@@ -323,7 +323,7 @@ func handleMessage(backend Backend, peer *Peer) error {
 				if err := rlp.DecodeBytes(accTrie.Get(account[:]), &acc); err != nil {
 					return p2p.Send(peer.rw, StorageRangesMsg, &StorageRangesPacket{ID: req.ID})
 				}
-				stTrie, err := trie.New(acc.Root, backend.Chain().StateCache().TrieDB())
+				stTrie, err := trie.NewWithOwner(account, acc.Root, backend.Chain().StateCache().TrieDB())
 				if err != nil {
 					return p2p.Send(peer.rw, StorageRangesMsg, &StorageRangesPacket{ID: req.ID})
 				}
@@ -472,7 +472,7 @@ func handleMessage(backend Backend, peer *Peer) error {
 				if err != nil {
 					break
 				}
-				stTrie, err := trie.NewSecure(common.BytesToHash(account.Root), triedb)
+				stTrie, err := trie.NewSecureWithOwner(common.BytesToHash(pathset[0]), common.BytesToHash(account.Root), triedb)
 				loads++ // always account database reads, even for failures
 				if err != nil {
 					break

--- a/eth/protocols/snap/range_test.go
+++ b/eth/protocols/snap/range_test.go
@@ -53,7 +53,7 @@ func TestHashRanges(t *testing.T) {
 			head:   common.HexToHash("0x2000000000000000000000000000000000000000000000000000000000000000"),
 			chunks: 2,
 			starts: []common.Hash{
-				common.Hash{},
+				{},
 				common.HexToHash("0x9000000000000000000000000000000000000000000000000000000000000000"),
 			},
 			ends: []common.Hash{

--- a/eth/protocols/snap/sync.go
+++ b/eth/protocols/snap/sync.go
@@ -229,8 +229,9 @@ type trienodeHealRequest struct {
 	timeout *time.Timer                // Timer to track delivery timeout
 	stale   chan struct{}              // Channel to signal the request was dropped
 
+	keys   []string        // Trie node keys for identifing trie node
 	hashes []common.Hash   // Trie node hashes to validate responses
-	paths  []trie.SyncPath // Trie node paths requested for rescheduling
+	paths  []trie.NodePath // Trie node paths requested for rescheduling
 
 	task *healTask // Task which this request is filling (only access fields through the runloop!!)
 }
@@ -239,8 +240,9 @@ type trienodeHealRequest struct {
 type trienodeHealResponse struct {
 	task *healTask // Task which this request is filling
 
+	keys   []string        // List of trie node identifiers
 	hashes []common.Hash   // Hashes of the trie nodes to avoid double hashing
-	paths  []trie.SyncPath // Trie node paths requested for rescheduling missing ones
+	paths  []trie.NodePath // Trie node paths requested for rescheduling missing ones
 	nodes  [][]byte        // Actual trie nodes to store into the database (nil = missing)
 }
 
@@ -316,12 +318,18 @@ type storageTask struct {
 	done bool // Flag whether the task can be removed
 }
 
+// nodeMeta is the descriptor of a trie node for retrieval
+type nodeMeta struct {
+	path trie.NodePath
+	hash common.Hash
+}
+
 // healTask represents the sync task for healing the snap-synced chunk boundaries.
 type healTask struct {
 	scheduler *trie.Sync // State trie sync scheduler defining the tasks
 
-	trieTasks map[common.Hash]trie.SyncPath // Set of trie node tasks currently queued for retrieval
-	codeTasks map[common.Hash]struct{}      // Set of byte code tasks currently queued for retrieval
+	trieTasks map[string]nodeMeta      // Set of trie node tasks currently queued for retrieval
+	codeTasks map[common.Hash]struct{} // Set of byte code tasks currently queued for retrieval
 }
 
 // syncProgress is a database entry to allow suspending and resuming a snapshot state
@@ -543,7 +551,7 @@ func (s *Syncer) Sync(root common.Hash, cancel chan struct{}) error {
 	s.root = root
 	s.healer = &healTask{
 		scheduler: state.NewStateSync(root, s.db, nil, s.onHealState),
-		trieTasks: make(map[common.Hash]trie.SyncPath),
+		trieTasks: make(map[string]nodeMeta),
 		codeTasks: make(map[common.Hash]struct{}),
 	}
 	s.statelessPeers = make(map[string]struct{})
@@ -689,7 +697,7 @@ func (s *Syncer) loadSyncStatus() {
 				}
 				task.genTrie = trie.NewStackTrie(task.genBatch)
 
-				for _, subtasks := range task.SubTasks {
+				for accountHash, subtasks := range task.SubTasks {
 					for _, subtask := range subtasks {
 						subtask.genBatch = ethdb.HookedBatch{
 							Batch: s.db.NewBatch(),
@@ -697,7 +705,7 @@ func (s *Syncer) loadSyncStatus() {
 								s.storageBytes += common.StorageSize(len(key) + len(value))
 							},
 						}
-						subtask.genTrie = trie.NewStackTrie(subtask.genBatch)
+						subtask.genTrie = trie.NewStackTrieWithOwner(subtask.genBatch, accountHash)
 					}
 				}
 			}
@@ -1242,9 +1250,9 @@ func (s *Syncer) assignTrienodeHealTasks(success chan *trienodeHealResponse, fai
 			want = maxTrieRequestCount + maxCodeRequestCount
 		)
 		if have < want {
-			nodes, paths, codes := s.healer.scheduler.Missing(want - have)
-			for i, hash := range nodes {
-				s.healer.trieTasks[hash] = paths[i]
+			keys, hashes, paths, codes := s.healer.scheduler.Missing(want - have)
+			for i, key := range keys {
+				s.healer.trieTasks[key] = nodeMeta{hash: hashes[i], path: paths[i]}
 			}
 			for _, hash := range codes {
 				s.healer.codeTasks[hash] = struct{}{}
@@ -1284,18 +1292,20 @@ func (s *Syncer) assignTrienodeHealTasks(success chan *trienodeHealResponse, fai
 			cap = maxTrieRequestCount
 		}
 		var (
+			keys     = make([]string, 0, cap)
 			hashes   = make([]common.Hash, 0, cap)
-			paths    = make([]trie.SyncPath, 0, cap)
+			paths    = make([]trie.NodePath, 0, cap)
 			pathsets = make([]TrieNodePathSet, 0, cap)
 		)
-		for hash, pathset := range s.healer.trieTasks {
-			delete(s.healer.trieTasks, hash)
+		for key, meta := range s.healer.trieTasks {
+			delete(s.healer.trieTasks, key)
 
-			hashes = append(hashes, hash)
-			paths = append(paths, pathset)
-			pathsets = append(pathsets, [][]byte(pathset)) // TODO(karalabe): group requests by account hash
+			keys = append(keys, key)
+			hashes = append(hashes, meta.hash)
+			paths = append(paths, meta.path)
+			pathsets = append(pathsets, [][]byte(meta.path)) // TODO(karalabe): group requests by account hash
 
-			if len(hashes) >= cap {
+			if len(keys) >= cap {
 				break
 			}
 		}
@@ -1307,6 +1317,7 @@ func (s *Syncer) assignTrienodeHealTasks(success chan *trienodeHealResponse, fai
 			revert:  fail,
 			cancel:  cancel,
 			stale:   make(chan struct{}),
+			keys:    keys,
 			hashes:  hashes,
 			paths:   paths,
 			task:    s.healer,
@@ -1366,9 +1377,9 @@ func (s *Syncer) assignBytecodeHealTasks(success chan *bytecodeHealResponse, fai
 			want = maxTrieRequestCount + maxCodeRequestCount
 		)
 		if have < want {
-			nodes, paths, codes := s.healer.scheduler.Missing(want - have)
-			for i, hash := range nodes {
-				s.healer.trieTasks[hash] = paths[i]
+			keys, hashes, paths, codes := s.healer.scheduler.Missing(want - have)
+			for i, key := range keys {
+				s.healer.trieTasks[key] = nodeMeta{hash: hashes[i], path: paths[i]}
 			}
 			for _, hash := range codes {
 				s.healer.codeTasks[hash] = struct{}{}
@@ -1666,8 +1677,8 @@ func (s *Syncer) revertTrienodeHealRequest(req *trienodeHealRequest) {
 	// If there's a timeout timer still running, abort it and mark the trie node
 	// retrievals as not-pending, ready for resheduling
 	req.timeout.Stop()
-	for i, hash := range req.hashes {
-		req.task.trieTasks[hash] = req.paths[i]
+	for i, key := range req.keys {
+		req.task.trieTasks[key] = nodeMeta{path: req.paths[i], hash: req.hashes[i]}
 	}
 }
 
@@ -1760,7 +1771,8 @@ func (s *Syncer) processAccountResponse(res *accountResponse) {
 		}
 		// Check if the account is a contract with an unknown storage trie
 		if account.Root != emptyRoot {
-			if node, err := s.db.Get(account.Root[:]); err != nil || node == nil {
+			blob := rawdb.ReadTrieNode(s.db, trie.TrieRootKey(res.hashes[i], account.Root))
+			if len(blob) == 0 {
 				// If there was a previous large state retrieval in progress,
 				// don't restart it from scratch. This happens if a sync cycle
 				// is interrupted and resumed later. However, *do* update the
@@ -1932,7 +1944,7 @@ func (s *Syncer) processStorageResponse(res *storageResponse) {
 						Last:     r.End(),
 						root:     acc.Root,
 						genBatch: batch,
-						genTrie:  trie.NewStackTrie(batch),
+						genTrie:  trie.NewStackTrieWithOwner(batch, account),
 					})
 					for r.Next() {
 						batch := ethdb.HookedBatch{
@@ -1946,7 +1958,7 @@ func (s *Syncer) processStorageResponse(res *storageResponse) {
 							Last:     r.End(),
 							root:     acc.Root,
 							genBatch: batch,
-							genTrie:  trie.NewStackTrie(batch),
+							genTrie:  trie.NewStackTrieWithOwner(batch, account),
 						})
 					}
 					for _, task := range tasks {
@@ -1991,7 +2003,7 @@ func (s *Syncer) processStorageResponse(res *storageResponse) {
 		slots += len(res.hashes[i])
 
 		if i < len(res.hashes)-1 || res.subTask == nil {
-			tr := trie.NewStackTrie(batch)
+			tr := trie.NewStackTrieWithOwner(batch, account)
 			for j := 0; j < len(res.hashes[i]); j++ {
 				tr.Update(res.hashes[i][j][:], res.slots[i][j])
 			}
@@ -2057,14 +2069,14 @@ func (s *Syncer) processTrienodeHealResponse(res *trienodeHealResponse) {
 
 		// If the trie node was not delivered, reschedule it
 		if node == nil {
-			res.task.trieTasks[hash] = res.paths[i]
+			res.task.trieTasks[res.keys[i]] = nodeMeta{path: res.paths[i], hash: res.hashes[i]}
 			continue
 		}
 		// Push the trie node into the state syncer
 		s.trienodeHealSynced++
 		s.trienodeHealBytes += common.StorageSize(len(node))
 
-		err := s.healer.scheduler.Process(trie.SyncResult{Hash: hash, Data: node})
+		err := s.healer.scheduler.ProcessNode(trie.NodeSyncResult{Key: res.keys[i], Data: node})
 		switch err {
 		case nil:
 		case trie.ErrAlreadyProcessed:
@@ -2100,7 +2112,7 @@ func (s *Syncer) processBytecodeHealResponse(res *bytecodeHealResponse) {
 		s.bytecodeHealSynced++
 		s.bytecodeHealBytes += common.StorageSize(len(node))
 
-		err := s.healer.scheduler.Process(trie.SyncResult{Hash: hash, Data: node})
+		err := s.healer.scheduler.ProcessCode(trie.CodeSyncResult{Hash: hash, Data: node})
 		switch err {
 		case nil:
 		case trie.ErrAlreadyProcessed:
@@ -2627,6 +2639,7 @@ func (s *Syncer) OnTrieNodes(peer SyncPeer, id uint64, trienodes [][]byte) error
 	}
 	// Response validated, send it to the scheduler for filling
 	response := &trienodeHealResponse{
+		keys:   req.keys,
 		task:   req.task,
 		hashes: req.hashes,
 		paths:  req.paths,

--- a/eth/protocols/snap/sync_test.go
+++ b/eth/protocols/snap/sync_test.go
@@ -1603,7 +1603,7 @@ func verifyTrie(db ethdb.KeyValueStore, root common.Hash, t *testing.T) {
 		}
 		accounts++
 		if acc.Root != emptyRoot {
-			storeTrie, err := trie.NewSecure(acc.Root, triedb)
+			storeTrie, err := trie.NewSecureWithOwner(common.BytesToHash(accIt.Key), acc.Root, triedb)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/eth/state_accessor.go
+++ b/eth/state_accessor.go
@@ -125,7 +125,7 @@ func (eth *Ethereum) stateAtBlock(block *types.Block, reexec uint64, base *state
 		if err != nil {
 			return nil, fmt.Errorf("state reset after block %d failed: %v", current.NumberU64(), err)
 		}
-		database.TrieDB().Reference(root, common.Hash{})
+		database.TrieDB().Reference(common.Hash{}, root, common.Hash{}, nil)
 		if parent != (common.Hash{}) {
 			database.TrieDB().Dereference(parent)
 		}

--- a/eth/tracers/api.go
+++ b/eth/tracers/api.go
@@ -351,7 +351,7 @@ func (api *API) traceChain(ctx context.Context, start, end *types.Block, config 
 			}
 			if statedb.Database().TrieDB() != nil {
 				// Hold the reference for tracer, will be released at the final stage
-				statedb.Database().TrieDB().Reference(block.Root(), common.Hash{})
+				statedb.Database().TrieDB().Reference(common.Hash{}, block.Root(), common.Hash{}, nil)
 
 				// Release the parent state because it's already held by the tracer
 				if parent != (common.Hash{}) {

--- a/light/trie.go
+++ b/light/trie.go
@@ -227,6 +227,14 @@ func (it *nodeIterator) do(fn func() error) {
 	}
 }
 
+func (it *nodeIterator) Owner() common.Hash {
+	return it.t.trie.Owner()
+}
+
+func (it *nodeIterator) ComposedKey() []byte {
+	panic("not implemented")
+}
+
 func (it *nodeIterator) Error() error {
 	if it.err != nil {
 		return it.err

--- a/trie/database.go
+++ b/trie/database.go
@@ -58,6 +58,10 @@ var (
 	memcacheCommitSizeMeter  = metrics.NewRegisteredMeter("trie/memcache/commit/size", nil)
 )
 
+// metaRoot is the identifier of the global memcache root that anchors the block
+// accounts tries for garbage collection.
+const metaRoot = ""
+
 // Database is an intermediate write layer between the trie data structures and
 // the disk database. The aim is to accumulate trie writes in-memory and only
 // periodically flush a couple tries to disk, garbage collecting the remainder.
@@ -69,10 +73,10 @@ var (
 type Database struct {
 	diskdb ethdb.KeyValueStore // Persistent storage for matured trie nodes
 
-	cleans  *fastcache.Cache            // GC friendly memory cache of clean node RLPs
-	dirties map[common.Hash]*cachedNode // Data and references relationships of dirty trie nodes
-	oldest  common.Hash                 // Oldest tracked node, flush-list head
-	newest  common.Hash                 // Newest tracked node, flush-list tail
+	cleans  *fastcache.Cache       // GC friendly memory cache of clean node RLPs
+	dirties map[string]*cachedNode // Data and references relationships of dirty trie nodes
+	oldest  string                 // Oldest tracked node, flush-list head
+	newest  string                 // Newest tracked node, flush-list tail
 
 	preimages map[common.Hash][]byte // Preimages of nodes from the secure trie
 
@@ -89,19 +93,6 @@ type Database struct {
 	preimagesSize common.StorageSize // Storage size of the preimages cache
 
 	lock sync.RWMutex
-}
-
-// rawNode is a simple binary blob used to differentiate between collapsed trie
-// nodes and already encoded RLP binary blobs (while at the same time store them
-// in the same cache fields).
-type rawNode []byte
-
-func (n rawNode) cache() (hashNode, bool)   { panic("this should never end up in a live trie") }
-func (n rawNode) fstring(ind string) string { panic("this should never end up in a live trie") }
-
-func (n rawNode) EncodeRLP(w io.Writer) error {
-	_, err := w.Write(n)
-	return err
 }
 
 // rawFullNode represents only the useful data content of a full node, with the
@@ -126,8 +117,8 @@ func (n rawFullNode) EncodeRLP(w io.Writer) error {
 }
 
 // rawShortNode represents only the useful data content of a short node, with the
-// caches and flags stripped out to minimize its data storage. This type honors
-// the same RLP encoding as the original parent.
+// caches and flags stripped out to minimize its data storage. The key of the node
+// is in hexary format and needs compact conversion for RLP encoding.
 type rawShortNode struct {
 	Key []byte
 	Val node
@@ -135,18 +126,52 @@ type rawShortNode struct {
 
 func (n rawShortNode) cache() (hashNode, bool)   { panic("this should never end up in a live trie") }
 func (n rawShortNode) fstring(ind string) string { panic("this should never end up in a live trie") }
+func (n rawShortNode) EncodeRLP(w io.Writer) error {
+	return rlp.Encode(w, shortNode{
+		Key: hexToCompact(n.Key),
+		Val: n.Val,
+	})
+}
 
 // cachedNode is all the information we know about a single cached trie node
 // in the memory database write layer.
 type cachedNode struct {
-	node node   // Cached collapsed trie node, or raw rlp data
+	node node   // Cached collapsed trie node
 	size uint16 // Byte size of the useful cached data
 
-	parents  uint32                 // Number of live nodes referencing this one
-	children map[common.Hash]uint16 // External children referenced by this node
+	parents  uint32            // Number of live nodes referencing this one
+	children map[string]uint16 // External children referenced by this node
 
-	flushPrev common.Hash // Previous node in the flush-list
-	flushNext common.Hash // Next node in the flush-list
+	flushPrev string // Previous node in the flush-list
+	flushNext string // Next node in the flush-list
+}
+
+// iterateRefs walks the embedded children of the cached node, tracking the
+// internal path and invoking the provided callback on all hash nodes.
+func (n *cachedNode) iterateRefs(path []byte, onHashNode func([]byte, common.Hash) error) error {
+	return iterateRefs(n.node, path, onHashNode)
+}
+
+// iterateRefs traverses the node hierarchy of a cached node and invokes the
+// provided callback on all hash nodes.
+func iterateRefs(n node, path []byte, onHashNode func([]byte, common.Hash) error) error {
+	switch n := n.(type) {
+	case *rawShortNode:
+		return iterateRefs(n.Val, append(path, n.Key...), onHashNode)
+	case rawFullNode:
+		for i := 0; i < 16; i++ {
+			if err := iterateRefs(n[i], append(path, byte(i)), onHashNode); err != nil {
+				return err
+			}
+		}
+		return nil
+	case hashNode:
+		return onHashNode(path, common.BytesToHash(n))
+	case valueNode, nil:
+		return nil
+	default:
+		panic(fmt.Sprintf("unknown node type: %T", n))
+	}
 }
 
 // cachedNodeSize is the raw size of a cachedNode data structure without any
@@ -158,12 +183,8 @@ var cachedNodeSize = int(reflect.TypeOf(cachedNode{}).Size())
 // reference map.
 const cachedNodeChildrenSize = 48
 
-// rlp returns the raw rlp encoded blob of the cached trie node, either directly
-// from the cache, or by regenerating it from the collapsed node.
+// rlp returns the raw rlp encoded blob of the cached trie node.
 func (n *cachedNode) rlp() []byte {
-	if node, ok := n.node.(rawNode); ok {
-		return node
-	}
 	blob, err := rlp.EncodeToBytes(n.node)
 	if err != nil {
 		panic(err)
@@ -171,43 +192,9 @@ func (n *cachedNode) rlp() []byte {
 	return blob
 }
 
-// obj returns the decoded and expanded trie node, either directly from the cache,
-// or by regenerating it from the rlp encoded blob.
+// obj returns the decoded and expanded trie node.
 func (n *cachedNode) obj(hash common.Hash) node {
-	if node, ok := n.node.(rawNode); ok {
-		return mustDecodeNode(hash[:], node)
-	}
 	return expandNode(hash[:], n.node)
-}
-
-// forChilds invokes the callback for all the tracked children of this node,
-// both the implicit ones from inside the node as well as the explicit ones
-// from outside the node.
-func (n *cachedNode) forChilds(onChild func(hash common.Hash)) {
-	for child := range n.children {
-		onChild(child)
-	}
-	if _, ok := n.node.(rawNode); !ok {
-		forGatherChildren(n.node, onChild)
-	}
-}
-
-// forGatherChildren traverses the node hierarchy of a collapsed storage node and
-// invokes the callback for all the hashnode children.
-func forGatherChildren(n node, onChild func(hash common.Hash)) {
-	switch n := n.(type) {
-	case *rawShortNode:
-		forGatherChildren(n.Val, onChild)
-	case rawFullNode:
-		for i := 0; i < 16; i++ {
-			forGatherChildren(n[i], onChild)
-		}
-	case hashNode:
-		onChild(common.BytesToHash(n))
-	case valueNode, nil, rawNode:
-	default:
-		panic(fmt.Sprintf("unknown node type: %T", n))
-	}
 }
 
 // simplifyNode traverses the hierarchy of an expanded memory node and discards
@@ -216,7 +203,7 @@ func simplifyNode(n node) node {
 	switch n := n.(type) {
 	case *shortNode:
 		// Short nodes discard the flags and cascade
-		return &rawShortNode{Key: n.Key, Val: simplifyNode(n.Val)}
+		return &rawShortNode{Key: compactToHex(n.Key), Val: simplifyNode(n.Val)}
 
 	case *fullNode:
 		// Full nodes discard the flags and cascade
@@ -228,7 +215,7 @@ func simplifyNode(n node) node {
 		}
 		return node
 
-	case valueNode, hashNode, rawNode:
+	case valueNode, hashNode:
 		return n
 
 	default:
@@ -243,7 +230,7 @@ func expandNode(hash hashNode, n node) node {
 	case *rawShortNode:
 		// Short nodes need key and child expansion
 		return &shortNode{
-			Key: compactToHex(n.Key),
+			Key: n.Key,
 			Val: expandNode(nil, n.Val),
 			flags: nodeFlag{
 				hash: hash,
@@ -301,8 +288,8 @@ func NewDatabaseWithConfig(diskdb ethdb.KeyValueStore, config *Config) *Database
 	db := &Database{
 		diskdb: diskdb,
 		cleans: cleans,
-		dirties: map[common.Hash]*cachedNode{{}: {
-			children: make(map[common.Hash]uint16),
+		dirties: map[string]*cachedNode{"": {
+			children: make(map[string]uint16),
 		}},
 	}
 	if config == nil || config.Preimages { // TODO(karalabe): Flip to default off in the future
@@ -320,9 +307,10 @@ func (db *Database) DiskDB() ethdb.KeyValueStore {
 // The blob size must be specified to allow proper size tracking.
 // All nodes inserted by this function will be reference tracked
 // and in theory should only used for **trie nodes** insertion.
-func (db *Database) insert(hash common.Hash, size int, node node) {
+func (db *Database) insert(owner common.Hash, path []byte, hash common.Hash, size int, node node) {
 	// If the node's already cached, skip
-	if _, ok := db.dirties[hash]; ok {
+	key := string(EncodeNodeKey(owner, path, hash))
+	if _, ok := db.dirties[key]; ok {
 		return
 	}
 	memcacheDirtyWriteMeter.Mark(int64(size))
@@ -333,18 +321,21 @@ func (db *Database) insert(hash common.Hash, size int, node node) {
 		size:      uint16(size),
 		flushPrev: db.newest,
 	}
-	entry.forChilds(func(child common.Hash) {
-		if c := db.dirties[child]; c != nil {
+	entry.iterateRefs(path, func(childPath []byte, child common.Hash) error {
+		byteKey := EncodeNodeKey(owner, childPath, child)
+		key := string(byteKey)
+		if c := db.dirties[key]; c != nil {
 			c.parents++
 		}
+		return nil
 	})
-	db.dirties[hash] = entry
+	db.dirties[key] = entry
 
 	// Update the flush-list endpoints
-	if db.oldest == (common.Hash{}) {
-		db.oldest, db.newest = hash, hash
+	if db.oldest == metaRoot {
+		db.oldest, db.newest = key, key
 	} else {
-		db.dirties[db.newest].flushNext, db.newest = hash, hash
+		db.dirties[db.newest].flushNext, db.newest = key, key
 	}
 	db.dirtiesSize += common.StorageSize(common.HashLength + entry.size)
 }
@@ -369,18 +360,20 @@ func (db *Database) insertPreimage(hash common.Hash, preimage []byte) {
 
 // node retrieves a cached trie node from memory, or returns nil if none can be
 // found in the memory cache.
-func (db *Database) node(hash common.Hash) node {
+func (db *Database) node(owner common.Hash, path []byte, hash common.Hash) node {
 	// Retrieve the node from the clean cache if available
+	byteKey := EncodeNodeKey(owner, path, hash)
 	if db.cleans != nil {
-		if enc := db.cleans.Get(nil, hash[:]); enc != nil {
+		if enc := db.cleans.Get(nil, byteKey); enc != nil {
 			memcacheCleanHitMeter.Mark(1)
 			memcacheCleanReadMeter.Mark(int64(len(enc)))
 			return mustDecodeNode(hash[:], enc)
 		}
 	}
 	// Retrieve the node from the dirty cache if available
+	key := string(byteKey)
 	db.lock.RLock()
-	dirty := db.dirties[hash]
+	dirty := db.dirties[key]
 	db.lock.RUnlock()
 
 	if dirty != nil {
@@ -391,36 +384,33 @@ func (db *Database) node(hash common.Hash) node {
 	memcacheDirtyMissMeter.Mark(1)
 
 	// Content unavailable in memory, attempt to retrieve from disk
-	enc, err := db.diskdb.Get(hash[:])
-	if err != nil || enc == nil {
+	enc := rawdb.ReadTrieNode(db.diskdb, byteKey)
+	if enc == nil {
 		return nil
 	}
 	if db.cleans != nil {
-		db.cleans.Set(hash[:], enc)
+		db.cleans.Set(byteKey, enc)
 		memcacheCleanMissMeter.Mark(1)
 		memcacheCleanWriteMeter.Mark(int64(len(enc)))
 	}
 	return mustDecodeNode(hash[:], enc)
 }
 
-// Node retrieves an encoded cached trie node from memory. If it cannot be found
+// NodeByKey retrieves an encoded cached trie node from memory. If it cannot be found
 // cached, the method queries the persistent database for the content.
-func (db *Database) Node(hash common.Hash) ([]byte, error) {
-	// It doesn't make sense to retrieve the metaroot
-	if hash == (common.Hash{}) {
-		return nil, errors.New("not found")
-	}
+func (db *Database) NodeByKey(byteKey []byte) ([]byte, error) {
 	// Retrieve the node from the clean cache if available
 	if db.cleans != nil {
-		if enc := db.cleans.Get(nil, hash[:]); enc != nil {
+		if enc := db.cleans.Get(nil, byteKey); enc != nil {
 			memcacheCleanHitMeter.Mark(1)
 			memcacheCleanReadMeter.Mark(int64(len(enc)))
 			return enc, nil
 		}
 	}
 	// Retrieve the node from the dirty cache if available
+	key := string(byteKey)
 	db.lock.RLock()
-	dirty := db.dirties[hash]
+	dirty := db.dirties[key]
 	db.lock.RUnlock()
 
 	if dirty != nil {
@@ -431,16 +421,26 @@ func (db *Database) Node(hash common.Hash) ([]byte, error) {
 	memcacheDirtyMissMeter.Mark(1)
 
 	// Content unavailable in memory, attempt to retrieve from disk
-	enc := rawdb.ReadTrieNode(db.diskdb, hash)
+	enc := rawdb.ReadTrieNode(db.diskdb, byteKey)
 	if len(enc) != 0 {
 		if db.cleans != nil {
-			db.cleans.Set(hash[:], enc)
+			db.cleans.Set(byteKey, enc)
 			memcacheCleanMissMeter.Mark(1)
 			memcacheCleanWriteMeter.Mark(int64(len(enc)))
 		}
 		return enc, nil
 	}
 	return nil, errors.New("not found")
+}
+
+// Node retrieves an encoded cached trie node from memory. If it cannot be found
+// cached, the method queries the persistent database for the content.
+func (db *Database) Node(owner common.Hash, path []byte, hash common.Hash) ([]byte, error) {
+	// It doesn't make sense to retrieve the metaroot
+	if hash == (common.Hash{}) {
+		return nil, errors.New("not found")
+	}
+	return db.NodeByKey(EncodeNodeKey(owner, path, hash))
 }
 
 // preimage retrieves a cached trie node pre-image from memory. If it cannot be
@@ -464,47 +464,49 @@ func (db *Database) preimage(hash common.Hash) []byte {
 // Nodes retrieves the hashes of all the nodes cached within the memory database.
 // This method is extremely expensive and should only be used to validate internal
 // states in test code.
-func (db *Database) Nodes() []common.Hash {
+func (db *Database) Nodes() []string {
 	db.lock.RLock()
 	defer db.lock.RUnlock()
 
-	var hashes = make([]common.Hash, 0, len(db.dirties))
-	for hash := range db.dirties {
-		if hash != (common.Hash{}) { // Special case for "root" references/nodes
-			hashes = append(hashes, hash)
+	var keys = make([]string, 0, len(db.dirties))
+	for key := range db.dirties {
+		if key != metaRoot { // Special case for "root" references/nodes
+			keys = append(keys, key)
 		}
 	}
-	return hashes
+	return keys
 }
 
 // Reference adds a new reference from a parent node to a child node.
 // This function is used to add reference between internal trie node
 // and external node(e.g. storage trie root), all internal trie nodes
 // are referenced together by database itself.
-func (db *Database) Reference(child common.Hash, parent common.Hash) {
+func (db *Database) Reference(owner common.Hash, child common.Hash, parent common.Hash, parentPath []byte) {
 	db.lock.Lock()
 	defer db.lock.Unlock()
 
-	db.reference(child, parent)
+	db.reference(owner, child, parent, parentPath)
 }
 
 // reference is the private locked version of Reference.
-func (db *Database) reference(child common.Hash, parent common.Hash) {
-	// If the node does not exist, it's a node pulled from disk, skip
-	node, ok := db.dirties[child]
+func (db *Database) reference(owner common.Hash, child common.Hash, parent common.Hash, parentPath []byte) {
+	// If the node does not exist, it's a node pulled from disk, skip.
+	childKey := string(EncodeNodeKey(owner, []byte{}, child))
+	node, ok := db.dirties[childKey]
 	if !ok {
 		return
 	}
 	// If the reference already exists, only duplicate for roots
-	if db.dirties[parent].children == nil {
-		db.dirties[parent].children = make(map[common.Hash]uint16)
+	parentKey := string(EncodeNodeKey(common.Hash{}, parentPath, parent))
+	if db.dirties[parentKey].children == nil {
+		db.dirties[parentKey].children = make(map[string]uint16)
 		db.childrenSize += cachedNodeChildrenSize
-	} else if _, ok = db.dirties[parent].children[child]; ok && parent != (common.Hash{}) {
+	} else if _, ok = db.dirties[parentKey].children[childKey]; ok && parent != (common.Hash{}) {
 		return
 	}
 	node.parents++
-	db.dirties[parent].children[child]++
-	if db.dirties[parent].children[child] == 1 {
+	db.dirties[parentKey].children[childKey]++
+	if db.dirties[parentKey].children[childKey] == 1 {
 		db.childrenSize += common.HashLength + 2 // uint16 counter
 	}
 }
@@ -520,7 +522,7 @@ func (db *Database) Dereference(root common.Hash) {
 	defer db.lock.Unlock()
 
 	nodes, storage, start := len(db.dirties), db.dirtiesSize, time.Now()
-	db.dereference(root, common.Hash{})
+	db.dereference(common.Hash{}, root, []byte{}, common.Hash{}, common.Hash{}, nil)
 
 	db.gcnodes += uint64(nodes - len(db.dirties))
 	db.gcsize += storage - db.dirtiesSize
@@ -535,50 +537,53 @@ func (db *Database) Dereference(root common.Hash) {
 }
 
 // dereference is the private locked version of Dereference.
-func (db *Database) dereference(child common.Hash, parent common.Hash) {
+func (db *Database) dereference(childOwner common.Hash, childHash common.Hash, childPath []byte, parentOwner common.Hash, parentHash common.Hash, parentPath []byte) {
 	// Dereference the parent-child
-	node := db.dirties[parent]
+	parentKey := string(EncodeNodeKey(parentOwner, parentPath, parentHash))
+	parent := db.dirties[parentKey]
 
-	if node.children != nil && node.children[child] > 0 {
-		node.children[child]--
-		if node.children[child] == 0 {
-			delete(node.children, child)
+	childKey := string(EncodeNodeKey(childOwner, childPath, childHash))
+	if parent.children != nil && parent.children[childKey] > 0 {
+		parent.children[childKey]--
+		if parent.children[childKey] == 0 {
+			delete(parent.children, childKey)
 			db.childrenSize -= (common.HashLength + 2) // uint16 counter
 		}
 	}
 	// If the child does not exist, it's a previously committed node.
-	node, ok := db.dirties[child]
+	child, ok := db.dirties[childKey]
 	if !ok {
 		return
 	}
 	// If there are no more references to the child, delete it and cascade
-	if node.parents > 0 {
+	if child.parents > 0 {
 		// This is a special cornercase where a node loaded from disk (i.e. not in the
 		// memcache any more) gets reinjected as a new node (short node split into full,
 		// then reverted into short), causing a cached node to have no parents. That is
 		// no problem in itself, but don't make maxint parents out of it.
-		node.parents--
+		child.parents--
 	}
-	if node.parents == 0 {
+	if child.parents == 0 {
 		// Remove the node from the flush-list
-		switch child {
+		switch childKey {
 		case db.oldest:
-			db.oldest = node.flushNext
-			db.dirties[node.flushNext].flushPrev = common.Hash{}
+			db.oldest = child.flushNext
+			db.dirties[child.flushNext].flushPrev = metaRoot
 		case db.newest:
-			db.newest = node.flushPrev
-			db.dirties[node.flushPrev].flushNext = common.Hash{}
+			db.newest = child.flushPrev
+			db.dirties[child.flushPrev].flushNext = metaRoot
 		default:
-			db.dirties[node.flushPrev].flushNext = node.flushNext
-			db.dirties[node.flushNext].flushPrev = node.flushPrev
+			db.dirties[child.flushPrev].flushNext = child.flushNext
+			db.dirties[child.flushNext].flushPrev = child.flushPrev
 		}
 		// Dereference all children and delete the node
-		node.forChilds(func(hash common.Hash) {
-			db.dereference(hash, child)
+		child.iterateRefs(childPath, func(innerPath []byte, innerHash common.Hash) error {
+			db.dereference(childOwner, innerHash, innerPath, childOwner, childHash, childPath)
+			return nil
 		})
-		delete(db.dirties, child)
-		db.dirtiesSize -= common.StorageSize(common.HashLength + int(node.size))
-		if node.children != nil {
+		delete(db.dirties, childKey)
+		db.dirtiesSize -= common.StorageSize(common.HashLength + int(child.size))
+		if child.children != nil {
 			db.childrenSize -= cachedNodeChildrenSize
 		}
 	}
@@ -601,7 +606,7 @@ func (db *Database) Cap(limit common.StorageSize) error {
 	// the total memory consumption, the maintenance metadata is also needed to be
 	// counted.
 	size := db.dirtiesSize + common.StorageSize((len(db.dirties)-1)*cachedNodeSize)
-	size += db.childrenSize - common.StorageSize(len(db.dirties[common.Hash{}].children)*(common.HashLength+2))
+	size += db.childrenSize - common.StorageSize(len(db.dirties[metaRoot].children)*(common.HashLength+2))
 
 	// If the preimage cache got large enough, push to disk. If it's still small
 	// leave for later to deduplicate writes.
@@ -621,10 +626,10 @@ func (db *Database) Cap(limit common.StorageSize) error {
 	}
 	// Keep committing nodes from the flush-list until we're below allowance
 	oldest := db.oldest
-	for size > limit && oldest != (common.Hash{}) {
+	for size > limit && oldest != metaRoot {
 		// Fetch the oldest referenced node and push into the batch
 		node := db.dirties[oldest]
-		rawdb.WriteTrieNode(batch, oldest, node.rlp())
+		rawdb.WriteTrieNode(batch, []byte(oldest), node.rlp())
 
 		// If we exceeded the ideal batch size, commit and reset
 		if batch.ValueSize() >= ethdb.IdealBatchSize {
@@ -669,8 +674,8 @@ func (db *Database) Cap(limit common.StorageSize) error {
 			db.childrenSize -= common.StorageSize(cachedNodeChildrenSize + len(node.children)*(common.HashLength+2))
 		}
 	}
-	if db.oldest != (common.Hash{}) {
-		db.dirties[db.oldest].flushPrev = common.Hash{}
+	if db.oldest != metaRoot {
+		db.dirties[db.oldest].flushPrev = metaRoot
 	}
 	db.flushnodes += uint64(nodes - len(db.dirties))
 	db.flushsize += storage - db.dirtiesSize
@@ -692,7 +697,7 @@ func (db *Database) Cap(limit common.StorageSize) error {
 //
 // Note, this method is a non-synchronized mutator. It is unsafe to call this
 // concurrently with other mutators.
-func (db *Database) Commit(node common.Hash, report bool, callback func(common.Hash)) error {
+func (db *Database) Commit(node common.Hash, report bool, callback func(key []byte)) error {
 	// Create a database batch to flush persistent data out. It is important that
 	// outside code doesn't see an inconsistent state (referenced data removed from
 	// memory cache during commit but not yet in persistent storage). This is ensured
@@ -720,7 +725,7 @@ func (db *Database) Commit(node common.Hash, report bool, callback func(common.H
 	nodes, storage := len(db.dirties), db.dirtiesSize
 
 	uncacher := &cleaner{db}
-	if err := db.commit(node, batch, uncacher, callback); err != nil {
+	if err := db.commit(common.Hash{}, []byte{}, node, batch, uncacher, callback); err != nil {
 		log.Error("Failed to commit trie from trie database", "err", err)
 		return err
 	}
@@ -759,25 +764,29 @@ func (db *Database) Commit(node common.Hash, report bool, callback func(common.H
 }
 
 // commit is the private locked version of Commit.
-func (db *Database) commit(hash common.Hash, batch ethdb.Batch, uncacher *cleaner, callback func(common.Hash)) error {
+func (db *Database) commit(owner common.Hash, path []byte, hash common.Hash, batch ethdb.Batch, uncacher *cleaner, callback func(key []byte)) error {
 	// If the node does not exist, it's a previously committed node
-	node, ok := db.dirties[hash]
+	byteKey := EncodeNodeKey(owner, path, hash)
+	key := string(byteKey)
+	node, ok := db.dirties[key]
 	if !ok {
 		return nil
 	}
-	var err error
-	node.forChilds(func(child common.Hash) {
-		if err == nil {
-			err = db.commit(child, batch, uncacher, callback)
-		}
-	})
-	if err != nil {
+	if err := node.iterateRefs(path, func(childPath []byte, childHash common.Hash) error {
+		return db.commit(owner, childPath, childHash, batch, uncacher, callback)
+	}); err != nil {
 		return err
 	}
+	for child := range node.children {
+		owner, path, hash := DecodeNodeKey([]byte(child))
+		if err := db.commit(owner, path, hash, batch, uncacher, callback); err != nil {
+			return err
+		}
+	}
 	// If we've reached an optimal batch size, commit and start over
-	rawdb.WriteTrieNode(batch, hash, node.rlp())
+	rawdb.WriteTrieNode(batch, byteKey, node.rlp())
 	if callback != nil {
-		callback(hash)
+		callback(byteKey)
 	}
 	if batch.ValueSize() >= ethdb.IdealBatchSize {
 		if err := batch.Write(); err != nil {
@@ -803,34 +812,38 @@ type cleaner struct {
 // the two-phase commit is to ensure ensure data availability while moving from
 // memory to disk.
 func (c *cleaner) Put(key []byte, rlp []byte) error {
-	hash := common.BytesToHash(key)
+	ok, rawKey := rawdb.IsTrieNodeKey(key)
+	if !ok {
+		return errors.New("unexpected data")
+	}
+	nodeKey := string(rawKey)
 
 	// If the node does not exist, we're done on this path
-	node, ok := c.db.dirties[hash]
+	node, ok := c.db.dirties[nodeKey]
 	if !ok {
 		return nil
 	}
 	// Node still exists, remove it from the flush-list
-	switch hash {
+	switch nodeKey {
 	case c.db.oldest:
 		c.db.oldest = node.flushNext
-		c.db.dirties[node.flushNext].flushPrev = common.Hash{}
+		c.db.dirties[node.flushNext].flushPrev = metaRoot
 	case c.db.newest:
 		c.db.newest = node.flushPrev
-		c.db.dirties[node.flushPrev].flushNext = common.Hash{}
+		c.db.dirties[node.flushPrev].flushNext = metaRoot
 	default:
 		c.db.dirties[node.flushPrev].flushNext = node.flushNext
 		c.db.dirties[node.flushNext].flushPrev = node.flushPrev
 	}
 	// Remove the node from the dirty cache
-	delete(c.db.dirties, hash)
+	delete(c.db.dirties, nodeKey)
 	c.db.dirtiesSize -= common.StorageSize(common.HashLength + int(node.size))
 	if node.children != nil {
 		c.db.dirtiesSize -= common.StorageSize(cachedNodeChildrenSize + len(node.children)*(common.HashLength+2))
 	}
 	// Move the flushed node into the clean cache to prevent insta-reloads
 	if c.db.cleans != nil {
-		c.db.cleans.Set(hash[:], rlp)
+		c.db.cleans.Set(rawKey, rlp)
 		memcacheCleanWriteMeter.Mark(int64(len(rlp)))
 	}
 	return nil
@@ -850,7 +863,7 @@ func (db *Database) Size() (common.StorageSize, common.StorageSize) {
 	// the total memory consumption, the maintenance metadata is also needed to be
 	// counted.
 	var metadataSize = common.StorageSize((len(db.dirties) - 1) * cachedNodeSize)
-	var metarootRefs = common.StorageSize(len(db.dirties[common.Hash{}].children) * (common.HashLength + 2))
+	var metarootRefs = common.StorageSize(len(db.dirties[metaRoot].children) * (common.HashLength + 2))
 	return db.dirtiesSize + db.childrenSize + metadataSize - metarootRefs, db.preimagesSize
 }
 

--- a/trie/database_test.go
+++ b/trie/database_test.go
@@ -27,7 +27,7 @@ import (
 // to retrieve the meta root.
 func TestDatabaseMetarootFetch(t *testing.T) {
 	db := NewDatabase(memorydb.New())
-	if _, err := db.Node(common.Hash{}); err == nil {
+	if _, err := db.Node(common.Hash{}, nil, common.Hash{}); err == nil {
 		t.Fatalf("metaroot retrieval succeeded")
 	}
 }

--- a/trie/encoding.go
+++ b/trie/encoding.go
@@ -105,9 +105,9 @@ func keybytesToHex(str []byte) []byte {
 	return nibbles
 }
 
-// hexToKeybytes turns hex nibbles into key bytes.
+// HexToKeybytes turns hex nibbles into key bytes.
 // This can only be used for keys of even length.
-func hexToKeybytes(hex []byte) []byte {
+func HexToKeybytes(hex []byte) []byte {
 	if hasTerm(hex) {
 		hex = hex[:len(hex)-1]
 	}

--- a/trie/encoding_test.go
+++ b/trie/encoding_test.go
@@ -71,8 +71,8 @@ func TestHexKeybytes(t *testing.T) {
 		if h := keybytesToHex(test.key); !bytes.Equal(h, test.hexOut) {
 			t.Errorf("keybytesToHex(%x) -> %x, want %x", test.key, h, test.hexOut)
 		}
-		if k := hexToKeybytes(test.hexIn); !bytes.Equal(k, test.key) {
-			t.Errorf("hexToKeybytes(%x) -> %x, want %x", test.hexIn, k, test.key)
+		if k := HexToKeybytes(test.hexIn); !bytes.Equal(k, test.key) {
+			t.Errorf("HexToKeybytes(%x) -> %x, want %x", test.hexIn, k, test.key)
 		}
 	}
 }
@@ -135,6 +135,6 @@ func BenchmarkKeybytesToHex(b *testing.B) {
 func BenchmarkHexToKeybytes(b *testing.B) {
 	testBytes := []byte{7, 6, 6, 5, 7, 2, 6, 2, 16}
 	for i := 0; i < b.N; i++ {
-		hexToKeybytes(testBytes)
+		HexToKeybytes(testBytes)
 	}
 }

--- a/trie/errors.go
+++ b/trie/errors.go
@@ -26,10 +26,14 @@ import (
 // in the case where a trie node is not present in the local database. It contains
 // information necessary for retrieving the missing node.
 type MissingNodeError struct {
+	Owner    common.Hash // owner of the trie if it's 2-layered trie
 	NodeHash common.Hash // hash of the missing node
 	Path     []byte      // hex-encoded path to the missing node
 }
 
 func (err *MissingNodeError) Error() string {
-	return fmt.Sprintf("missing trie node %x (path %x)", err.NodeHash, err.Path)
+	if err.Owner == (common.Hash{}) {
+		return fmt.Sprintf("missing trie node %x (path %x)", err.NodeHash, err.Path)
+	}
+	return fmt.Sprintf("missing trie node %x (owner %x) (path %x)", err.NodeHash, err.Owner, err.Path)
 }

--- a/trie/proof.go
+++ b/trie/proof.go
@@ -37,9 +37,12 @@ import (
 // with the node that proves the absence of the key.
 func (t *Trie) Prove(key []byte, fromLevel uint, proofDb ethdb.KeyValueWriter) error {
 	// Collect all nodes on the path to key.
+	var (
+		prefix []byte
+		nodes  []node
+		tn     = t.root
+	)
 	key = keybytesToHex(key)
-	var nodes []node
-	tn := t.root
 	for len(key) > 0 && tn != nil {
 		switch n := tn.(type) {
 		case *shortNode:
@@ -48,16 +51,18 @@ func (t *Trie) Prove(key []byte, fromLevel uint, proofDb ethdb.KeyValueWriter) e
 				tn = nil
 			} else {
 				tn = n.Val
+				prefix = append(prefix, n.Key...)
 				key = key[len(n.Key):]
 			}
 			nodes = append(nodes, n)
 		case *fullNode:
 			tn = n.Children[key[0]]
+			prefix = append(prefix, key[0])
 			key = key[1:]
 			nodes = append(nodes, n)
 		case hashNode:
 			var err error
-			tn, err = t.resolveHash(n, nil)
+			tn, err = t.resolveHash(n, prefix)
 			if err != nil {
 				log.Error(fmt.Sprintf("Unhandled trie error: %v", err))
 				return err

--- a/trie/scheme.go
+++ b/trie/scheme.go
@@ -1,0 +1,111 @@
+// Copyright 2021 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+package trie
+
+import (
+	"github.com/ethereum/go-ethereum/common"
+)
+
+// NodePath is a path tuple identifying a particular trie node either in a single
+// trie (account) or a layered trie (account -> storage).
+//
+// Content wise the tuple either has 1 element if it addresses a node in a single
+// trie or 2 elements if it addresses a node in a stacked trie.
+//
+// To support aiming arbitrary trie nodes, the path needs to support odd nibble
+// lengths. To avoid transferring expanded hex form over the network, the last
+// part of the tuple (which needs to index into the middle of a trie) is compact
+// encoded. In case of a 2-tuple, the first item is always 32 bytes so that is
+// simple binary encoded.
+//
+// Examples:
+//   - Path 0x9  -> {0x19}
+//   - Path 0x99 -> {0x0099}
+//   - Path 0x01234567890123456789012345678901012345678901234567890123456789019  -> {0x0123456789012345678901234567890101234567890123456789012345678901, 0x19}
+//   - Path 0x012345678901234567890123456789010123456789012345678901234567890199 -> {0x0123456789012345678901234567890101234567890123456789012345678901, 0x0099}
+type NodePath [][]byte
+
+// newNodePath converts an expanded trie path from nibble form into a compact
+// version that can be sent over the network.
+func newNodePath(path []byte) NodePath {
+	// If the hash is from the account trie, append a single item, if it
+	// is from the a storage trie, append a tuple. Note, the length 64 is
+	// clashing between account leaf and storage root. It's fine though
+	// because having a trie node at 64 depth means a hash collision was
+	// found and we're long dead.
+	if len(path) < 64 {
+		return NodePath{hexToCompact(path)}
+	}
+	return NodePath{HexToKeybytes(path[:64]), hexToCompact(path[64:])}
+}
+
+// EncodeNodeKey combines the node path and node hash together to act as
+// the unique database key for the trie node. The benefits of this key scheme
+// are that:
+//
+// - it can group all the relevant trie nodes together to have data locality
+//   in the database perspective.
+// - it's space efficient. Although the path prefix is added compared with
+//   the legacy scheme(raw node hash as the key), but the underlying
+//   database will do the key compression by sharing the key prefix with
+//   the preceding key. So the overhead is acceptable.
+// - it's pruning friendly. A list of trie nodes with same trie path can be
+//   easily obtained for pruning.
+//
+// What's more, the prefix(a few bytes) of node hash is necessary for identifying
+// the trie node since the hash collision under the same path prefix is very low.
+// And even the collision happens it's also super easy to fix it by extending one
+// more byte for the new key. TODO(rjl493456442) explore this idea later.
+func EncodeNodeKey(owner common.Hash, path []byte, hash common.Hash) []byte {
+	if owner == (common.Hash{}) && hash == (common.Hash{}) && len(path) == 0 {
+		return nil // special case, metaroot
+	}
+	var ret []byte
+	if owner != (common.Hash{}) {
+		ret = append(ret, owner.Bytes()...)
+	}
+	ret = append(ret, hexToCompact(path)...)
+	return append(ret, hash.Bytes()...)
+}
+
+// DecodeNodeKey returns the composing hashes of a trie node key.
+// The key is composed by two parts:
+// - the trie node owner
+// - the trie node path
+// - the trie node hash
+func DecodeNodeKey(key []byte) (common.Hash, []byte, common.Hash) {
+	if len(key) == 0 {
+		return common.Hash{}, nil, common.Hash{} // special case, metaroot
+	}
+	if len(key) <= common.HashLength {
+		return common.Hash{}, nil, common.Hash{}
+	}
+	hash := common.BytesToHash(key[len(key)-common.HashLength:])
+	path := key[:len(key)-common.HashLength]
+
+	// Single trie node(account)
+	if len(path) <= common.HashLength {
+		return common.Hash{}, compactToHex(path), hash
+	}
+	// Layered trie node(storage)
+	return common.BytesToHash(path[:common.HashLength]), compactToHex(path[common.HashLength:]), hash
+}
+
+// TrieRootKey returns the composed trie node key for trie root node.
+func TrieRootKey(owner common.Hash, root common.Hash) []byte {
+	return EncodeNodeKey(owner, nil, root)
+}

--- a/trie/scheme_test.go
+++ b/trie/scheme_test.go
@@ -1,0 +1,122 @@
+// Copyright 2021 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+package trie
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+)
+
+func TestEncodeNodeKey(t *testing.T) {
+	var (
+		randomHash  = common.HexToHash("0xa5d8b963aee47d5cafe7135a12f03e076d656ff5b77789afa867eb95119ab175")
+		randomOwner = common.HexToHash("0x65710c2c33ddfda00132ce3ab21de97bfa01ea7a1403cfa8a8e3a9dccbb66422")
+	)
+	var cases = []struct {
+		owner  common.Hash
+		path   []byte
+		hash   common.Hash
+		expect []byte
+	}{
+		// metaroot
+		{common.Hash{}, nil, common.Hash{}, nil},
+		// no owner, empty keys, with and without terminator.
+		{common.HexToHash(""), []byte{}, randomHash, append([]byte{0x00}, randomHash.Bytes()...)},
+		{common.HexToHash(""), []byte{16}, randomHash, append([]byte{0x20}, randomHash.Bytes()...)},
+
+		// no owner, odd length, no terminator
+		{common.HexToHash(""), []byte{1, 2, 3, 4, 5}, randomHash, append([]byte{0x11, 0x23, 0x45}, randomHash.Bytes()...)},
+		// no owner, even length, no terminator
+		{common.HexToHash(""), []byte{0, 1, 2, 3, 4, 5}, randomHash, append([]byte{0x00, 0x01, 0x23, 0x45}, randomHash.Bytes()...)},
+		// no owner, odd length, terminator
+		{common.HexToHash(""), []byte{15, 1, 12, 11, 8, 16 /*term*/}, randomHash, append([]byte{0x3f, 0x1c, 0xb8}, randomHash.Bytes()...)},
+		// no owner, even length, terminator
+		{common.HexToHash(""), []byte{0, 15, 1, 12, 11, 8, 16 /*term*/}, randomHash, append([]byte{0x20, 0x0f, 0x1c, 0xb8}, randomHash.Bytes()...)},
+
+		// with owner, empty keys, with and without terminator.
+		{randomOwner, []byte{}, randomHash, append(append(randomOwner.Bytes(), []byte{0x00}...), randomHash.Bytes()...)},
+		{randomOwner, []byte{16}, randomHash, append(append(randomOwner.Bytes(), []byte{0x20}...), randomHash.Bytes()...)},
+		// with owner, odd length, no terminator
+		{randomOwner, []byte{1, 2, 3, 4, 5}, randomHash, append(append(randomOwner.Bytes(), []byte{0x11, 0x23, 0x45}...), randomHash.Bytes()...)},
+		// with owner, even length, no terminator
+		{randomOwner, []byte{0, 1, 2, 3, 4, 5}, randomHash, append(append(randomOwner.Bytes(), []byte{0x00, 0x01, 0x23, 0x45}...), randomHash.Bytes()...)},
+		// with owner, odd length, terminator
+		{randomOwner, []byte{15, 1, 12, 11, 8, 16 /*term*/}, randomHash, append(append(randomOwner.Bytes(), []byte{0x3f, 0x1c, 0xb8}...), randomHash.Bytes()...)},
+		// with owner, even length, terminator
+		{randomOwner, []byte{0, 15, 1, 12, 11, 8, 16 /*term*/}, randomHash, append(append(randomOwner.Bytes(), []byte{0x20, 0x0f, 0x1c, 0xb8}...), randomHash.Bytes()...)},
+	}
+	for _, c := range cases {
+		got := EncodeNodeKey(c.owner, c.path, c.hash)
+		if !bytes.Equal(got, c.expect) {
+			t.Fatal("Encoding result mismatch", "want", c.expect, "got", got)
+		}
+	}
+}
+
+func TestDecodeNodeKey(t *testing.T) {
+	var (
+		randomHash  = common.HexToHash("0xa5d8b963aee47d5cafe7135a12f03e076d656ff5b77789afa867eb95119ab175")
+		randomOwner = common.HexToHash("0x65710c2c33ddfda00132ce3ab21de97bfa01ea7a1403cfa8a8e3a9dccbb66422")
+	)
+	var cases = []struct {
+		owner common.Hash
+		path  []byte
+		hash  common.Hash
+		input []byte
+	}{
+		// metaroot
+		{common.Hash{}, nil, common.Hash{}, nil},
+		// no owner, empty keys, with and without terminator.
+		{common.HexToHash(""), []byte{}, randomHash, append([]byte{0x00}, randomHash.Bytes()...)},
+		{common.HexToHash(""), []byte{16}, randomHash, append([]byte{0x20}, randomHash.Bytes()...)},
+
+		// no owner, odd length, no terminator
+		{common.HexToHash(""), []byte{1, 2, 3, 4, 5}, randomHash, append([]byte{0x11, 0x23, 0x45}, randomHash.Bytes()...)},
+		// no owner, even length, no terminator
+		{common.HexToHash(""), []byte{0, 1, 2, 3, 4, 5}, randomHash, append([]byte{0x00, 0x01, 0x23, 0x45}, randomHash.Bytes()...)},
+		// no owner, odd length, terminator
+		{common.HexToHash(""), []byte{15, 1, 12, 11, 8, 16 /*term*/}, randomHash, append([]byte{0x3f, 0x1c, 0xb8}, randomHash.Bytes()...)},
+		// no owner, even length, terminator
+		{common.HexToHash(""), []byte{0, 15, 1, 12, 11, 8, 16 /*term*/}, randomHash, append([]byte{0x20, 0x0f, 0x1c, 0xb8}, randomHash.Bytes()...)},
+
+		// with owner, empty keys, with and without terminator.
+		{randomOwner, []byte{}, randomHash, append(append(randomOwner.Bytes(), []byte{0x00}...), randomHash.Bytes()...)},
+		{randomOwner, []byte{16}, randomHash, append(append(randomOwner.Bytes(), []byte{0x20}...), randomHash.Bytes()...)},
+		// with owner, odd length, no terminator
+		{randomOwner, []byte{1, 2, 3, 4, 5}, randomHash, append(append(randomOwner.Bytes(), []byte{0x11, 0x23, 0x45}...), randomHash.Bytes()...)},
+		// with owner, even length, no terminator
+		{randomOwner, []byte{0, 1, 2, 3, 4, 5}, randomHash, append(append(randomOwner.Bytes(), []byte{0x00, 0x01, 0x23, 0x45}...), randomHash.Bytes()...)},
+		// with owner, odd length, terminator
+		{randomOwner, []byte{15, 1, 12, 11, 8, 16 /*term*/}, randomHash, append(append(randomOwner.Bytes(), []byte{0x3f, 0x1c, 0xb8}...), randomHash.Bytes()...)},
+		// with owner, even length, terminator
+		{randomOwner, []byte{0, 15, 1, 12, 11, 8, 16 /*term*/}, randomHash, append(append(randomOwner.Bytes(), []byte{0x20, 0x0f, 0x1c, 0xb8}...), randomHash.Bytes()...)},
+	}
+	for _, c := range cases {
+		owner, path, hash := DecodeNodeKey(c.input)
+		if !bytes.Equal(owner.Bytes(), c.owner.Bytes()) {
+			t.Fatal("Decode owner mismatch", "want", c.owner, "got", owner)
+		}
+		if !bytes.Equal(path, c.path) {
+			t.Fatal("Decode path mismatch", "want", c.path, "got", path)
+		}
+		if !bytes.Equal(hash.Bytes(), c.hash.Bytes()) {
+			t.Fatal("Decode hash mismatch", "want", c.hash, "got", hash)
+		}
+	}
+}

--- a/trie/secure_trie.go
+++ b/trie/secure_trie.go
@@ -62,6 +62,17 @@ func NewSecure(root common.Hash, db *Database) (*SecureTrie, error) {
 	return &SecureTrie{trie: *trie}, nil
 }
 
+func NewSecureWithOwner(owner common.Hash, root common.Hash, db *Database) (*SecureTrie, error) {
+	if db == nil {
+		panic("trie.NewSecure called without a database")
+	}
+	trie, err := NewWithOwner(owner, root, db)
+	if err != nil {
+		return nil, err
+	}
+	return &SecureTrie{trie: *trie}, nil
+}
+
 // Get returns the value for key stored in the trie.
 // The value bytes must not be modified by the caller.
 func (t *SecureTrie) Get(key []byte) []byte {

--- a/trie/stacktrie.go
+++ b/trie/stacktrie.go
@@ -26,6 +26,7 @@ import (
 	"sync"
 
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/rawdb"
 	"github.com/ethereum/go-ethereum/ethdb"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/rlp"
@@ -39,9 +40,10 @@ var stPool = sync.Pool{
 	},
 }
 
-func stackTrieFromPool(db ethdb.KeyValueWriter) *StackTrie {
+func stackTrieFromPool(db ethdb.KeyValueWriter, owner common.Hash) *StackTrie {
 	st := stPool.Get().(*StackTrie)
 	st.db = db
+	st.owner = owner
 	return st
 }
 
@@ -54,6 +56,7 @@ func returnToPool(st *StackTrie) {
 // in order. Once it determines that a subtree will no longer be inserted
 // into, it will hash it and free up the memory it uses.
 type StackTrie struct {
+	owner     common.Hash          // the owner of the trie
 	nodeType  uint8                // node type (as in branch, ext, leaf)
 	val       []byte               // value contained by this node if it's a leaf
 	key       []byte               // key chunk covered by this (full|ext) node
@@ -65,6 +68,16 @@ type StackTrie struct {
 // NewStackTrie allocates and initializes an empty trie.
 func NewStackTrie(db ethdb.KeyValueWriter) *StackTrie {
 	return &StackTrie{
+		nodeType: emptyNode,
+		db:       db,
+	}
+}
+
+// NewStackTrieWithOwner allocates and initializes an empty trie, but with
+// the additional owner field.
+func NewStackTrieWithOwner(db ethdb.KeyValueWriter, owner common.Hash) *StackTrie {
+	return &StackTrie{
+		owner:    owner,
 		nodeType: emptyNode,
 		db:       db,
 	}
@@ -90,11 +103,13 @@ func (st *StackTrie) MarshalBinary() (data []byte, err error) {
 		w = bufio.NewWriter(&b)
 	)
 	if err := gob.NewEncoder(w).Encode(struct {
+		Owner     common.Hash
 		Nodetype  uint8
 		Val       []byte
 		Key       []byte
 		KeyOffset uint8
 	}{
+		st.owner,
 		st.nodeType,
 		st.val,
 		st.key,
@@ -126,12 +141,14 @@ func (st *StackTrie) UnmarshalBinary(data []byte) error {
 
 func (st *StackTrie) unmarshalBinary(r io.Reader) error {
 	var dec struct {
+		Owner     common.Hash
 		Nodetype  uint8
 		Val       []byte
 		Key       []byte
 		KeyOffset uint8
 	}
 	gob.NewDecoder(r).Decode(&dec)
+	st.owner = dec.Owner
 	st.nodeType = dec.Nodetype
 	st.val = dec.Val
 	st.key = dec.Key
@@ -160,8 +177,8 @@ func (st *StackTrie) setDb(db ethdb.KeyValueWriter) {
 	}
 }
 
-func newLeaf(ko int, key, val []byte, db ethdb.KeyValueWriter) *StackTrie {
-	st := stackTrieFromPool(db)
+func newLeaf(owner common.Hash, ko int, key, val []byte, db ethdb.KeyValueWriter) *StackTrie {
+	st := stackTrieFromPool(db, owner)
 	st.nodeType = leafNode
 	st.keyOffset = ko
 	st.key = append(st.key, key[ko:]...)
@@ -169,8 +186,8 @@ func newLeaf(ko int, key, val []byte, db ethdb.KeyValueWriter) *StackTrie {
 	return st
 }
 
-func newExt(ko int, key []byte, child *StackTrie, db ethdb.KeyValueWriter) *StackTrie {
-	st := stackTrieFromPool(db)
+func newExt(owner common.Hash, ko int, key []byte, child *StackTrie, db ethdb.KeyValueWriter) *StackTrie {
+	st := stackTrieFromPool(db, owner)
 	st.nodeType = extNode
 	st.keyOffset = ko
 	st.key = append(st.key, key[ko:]...)
@@ -204,6 +221,7 @@ func (st *StackTrie) Update(key, value []byte) {
 }
 
 func (st *StackTrie) Reset() {
+	st.owner = common.Hash{}
 	st.db = nil
 	st.key = st.key[:0]
 	st.val = nil
@@ -234,14 +252,15 @@ func (st *StackTrie) insert(key, value []byte) {
 		for i := idx - 1; i >= 0; i-- {
 			if st.children[i] != nil {
 				if st.children[i].nodeType != hashedNode {
-					st.children[i].hash()
+					prefix := append(append([]byte{}, key[:st.keyOffset]...), byte(i))
+					st.children[i].hash(prefix)
 				}
 				break
 			}
 		}
 		// Add new child
 		if st.children[idx] == nil {
-			st.children[idx] = stackTrieFromPool(st.db)
+			st.children[idx] = stackTrieFromPool(st.db, st.owner)
 			st.children[idx].keyOffset = st.keyOffset + 1
 		}
 		st.children[idx].insert(key, value)
@@ -266,14 +285,15 @@ func (st *StackTrie) insert(key, value []byte) {
 		// node directly.
 		var n *StackTrie
 		if diffidx < len(st.key)-1 {
-			n = newExt(diffidx+1, st.key, st.children[0], st.db)
+			n = newExt(st.owner, diffidx+1, st.key, st.children[0], st.db)
 		} else {
 			// Break on the last byte, no need to insert
 			// an extension node: reuse the current node
 			n = st.children[0]
 		}
 		// Convert to hash
-		n.hash()
+		prefix := append(append([]byte{}, key[:st.keyOffset+diffidx]...), st.key[diffidx])
+		n.hash(prefix)
 		var p *StackTrie
 		if diffidx == 0 {
 			// the break is on the first byte, so
@@ -286,13 +306,13 @@ func (st *StackTrie) insert(key, value []byte) {
 			// the common prefix is at least one byte
 			// long, insert a new intermediate branch
 			// node.
-			st.children[0] = stackTrieFromPool(st.db)
+			st.children[0] = stackTrieFromPool(st.db, st.owner)
 			st.children[0].nodeType = branchNode
 			st.children[0].keyOffset = st.keyOffset + diffidx
 			p = st.children[0]
 		}
 		// Create a leaf for the inserted part
-		o := newLeaf(st.keyOffset+diffidx+1, key, value, st.db)
+		o := newLeaf(st.owner, st.keyOffset+diffidx+1, key, value, st.db)
 
 		// Insert both child leaves where they belong:
 		origIdx := st.key[diffidx]
@@ -328,7 +348,7 @@ func (st *StackTrie) insert(key, value []byte) {
 			// Convert current node into an ext,
 			// and insert a child branch node.
 			st.nodeType = extNode
-			st.children[0] = NewStackTrie(st.db)
+			st.children[0] = NewStackTrieWithOwner(st.db, st.owner)
 			st.children[0].nodeType = branchNode
 			st.children[0].keyOffset = st.keyOffset + diffidx
 			p = st.children[0]
@@ -339,11 +359,12 @@ func (st *StackTrie) insert(key, value []byte) {
 		// The child leave will be hashed directly in order to
 		// free up some memory.
 		origIdx := st.key[diffidx]
-		p.children[origIdx] = newLeaf(diffidx+1, st.key, st.val, st.db)
-		p.children[origIdx].hash()
+		p.children[origIdx] = newLeaf(st.owner, diffidx+1, st.key, st.val, st.db)
+		prefix := append(append([]byte{}, key[:st.keyOffset+diffidx]...), origIdx)
+		p.children[origIdx].hash(prefix)
 
 		newIdx := key[diffidx+st.keyOffset]
-		p.children[newIdx] = newLeaf(p.keyOffset+1, key, value, st.db)
+		p.children[newIdx] = newLeaf(st.owner, p.keyOffset+1, key, value, st.db)
 
 		// Finally, cut off the key part that has been passed
 		// over to the children.
@@ -372,7 +393,7 @@ func (st *StackTrie) insert(key, value []byte) {
 // This method will also:
 // set 'st.type' to hashedNode
 // clear 'st.key'
-func (st *StackTrie) hash() {
+func (st *StackTrie) hash(path []byte) {
 	/* Shortcut if node is already hashed */
 	if st.nodeType == hashedNode {
 		return
@@ -390,7 +411,8 @@ func (st *StackTrie) hash() {
 				nodes[i] = nilValueNode
 				continue
 			}
-			child.hash()
+			prefix := append(append([]byte{}, path...), byte(i))
+			child.hash(prefix)
 			if len(child.val) < 32 {
 				nodes[i] = rawNode(child.val)
 			} else {
@@ -407,7 +429,8 @@ func (st *StackTrie) hash() {
 			panic(err)
 		}
 	case extNode:
-		st.children[0].hash()
+		prefix := append(append([]byte{}, path...), st.key...)
+		st.children[0].hash(prefix)
 		h = newHasher(false)
 		defer returnHasherToPool(h)
 		h.tmp.Reset()
@@ -433,7 +456,8 @@ func (st *StackTrie) hash() {
 		h = newHasher(false)
 		defer returnHasherToPool(h)
 		h.tmp.Reset()
-		st.key = append(st.key, byte(16))
+		key := append(append([]byte{}, st.key...), byte(16))
+		st.key = key
 		sz := hexToCompactInPlace(st.key)
 		n := [][]byte{st.key[:sz], st.val}
 		if err := rlp.Encode(&h.tmp, n); err != nil {
@@ -462,13 +486,14 @@ func (st *StackTrie) hash() {
 	if st.db != nil {
 		// TODO! Is it safe to Put the slice here?
 		// Do all db implementations copy the value provided?
-		st.db.Put(st.val, h.tmp)
+		key := EncodeNodeKey(st.owner, path, common.BytesToHash(st.val))
+		rawdb.WriteTrieNode(st.db, key, h.tmp)
 	}
 }
 
 // Hash returns the hash of the current node
 func (st *StackTrie) Hash() (h common.Hash) {
-	st.hash()
+	st.hash(nil)
 	if len(st.val) != 32 {
 		// If the node's RLP isn't 32 bytes long, the node will not
 		// be hashed, and instead contain the  rlp-encoding of the
@@ -495,7 +520,7 @@ func (st *StackTrie) Commit() (common.Hash, error) {
 	if st.db == nil {
 		return common.Hash{}, ErrCommitDisabled
 	}
-	st.hash()
+	st.hash(nil)
 	if len(st.val) != 32 {
 		// If the node's RLP isn't 32 bytes long, the node will not
 		// be hashed (and committed), and instead contain the  rlp-encoding of the
@@ -506,7 +531,9 @@ func (st *StackTrie) Commit() (common.Hash, error) {
 		h.sha.Reset()
 		h.sha.Write(st.val)
 		h.sha.Read(ret)
-		st.db.Put(ret, st.val)
+
+		key := EncodeNodeKey(st.owner, nil, common.BytesToHash(ret))
+		rawdb.WriteTrieNode(st.db, key, st.val)
 		return common.BytesToHash(ret), nil
 	}
 	return common.BytesToHash(st.val), nil

--- a/trie/sync.go
+++ b/trie/sync.go
@@ -24,6 +24,7 @@ import (
 	"github.com/ethereum/go-ethereum/common/prque"
 	"github.com/ethereum/go-ethereum/core/rawdb"
 	"github.com/ethereum/go-ethereum/ethdb"
+	"github.com/ethereum/go-ethereum/log"
 )
 
 // ErrNotRequested is returned by the trie sync when it's requested to process a
@@ -39,76 +40,55 @@ var ErrAlreadyProcessed = errors.New("already processed")
 // memory if the node was configured with a significant number of peers.
 const maxFetchesPerDepth = 16384
 
-// request represents a scheduled or already in-flight state retrieval request.
-type request struct {
-	path []byte      // Merkle path leading to this node for prioritization
-	hash common.Hash // Hash of the node data content to retrieve
-	data []byte      // Data content of the node, cached until all subtrees complete
-	code bool        // Whether this is a code entry
+// nodeRequest represents a scheduled or already in-flight trie node retrieval request.
+type nodeRequest struct {
+	key  string // Key of the node data content to retrieve
+	path []byte // Merkle path leading to this node for prioritization
+	data []byte // Data content of the node, cached until all subtrees complete
 
-	parents []*request // Parent state nodes referencing this entry (notify all upon completion)
-	deps    int        // Number of dependencies before allowed to commit this node
-
-	callback LeafCallback // Callback to invoke if a leaf node it reached on this branch
+	parents  []*nodeRequest // Parent state nodes referencing this entry (notify all upon completion)
+	deps     int            // Number of dependencies before allowed to commit this node
+	callback LeafCallback   // Callback to invoke if a leaf node it reached on this branch
 }
 
-// SyncPath is a path tuple identifying a particular trie node either in a single
-// trie (account) or a layered trie (account -> storage).
-//
-// Content wise the tuple either has 1 element if it addresses a node in a single
-// trie or 2 elements if it addresses a node in a stacked trie.
-//
-// To support aiming arbitrary trie nodes, the path needs to support odd nibble
-// lengths. To avoid transferring expanded hex form over the network, the last
-// part of the tuple (which needs to index into the middle of a trie) is compact
-// encoded. In case of a 2-tuple, the first item is always 32 bytes so that is
-// simple binary encoded.
-//
-// Examples:
-//   - Path 0x9  -> {0x19}
-//   - Path 0x99 -> {0x0099}
-//   - Path 0x01234567890123456789012345678901012345678901234567890123456789019  -> {0x0123456789012345678901234567890101234567890123456789012345678901, 0x19}
-//   - Path 0x012345678901234567890123456789010123456789012345678901234567890199 -> {0x0123456789012345678901234567890101234567890123456789012345678901, 0x0099}
-type SyncPath [][]byte
-
-// newSyncPath converts an expanded trie path from nibble form into a compact
-// version that can be sent over the network.
-func newSyncPath(path []byte) SyncPath {
-	// If the hash is from the account trie, append a single item, if it
-	// is from the a storage trie, append a tuple. Note, the length 64 is
-	// clashing between account leaf and storage root. It's fine though
-	// because having a trie node at 64 depth means a hash collision was
-	// found and we're long dead.
-	if len(path) < 64 {
-		return SyncPath{hexToCompact(path)}
-	}
-	return SyncPath{hexToKeybytes(path[:64]), hexToCompact(path[64:])}
+// codeRequest represents a scheduled or already in-flight bytecode retrieval request.
+type codeRequest struct {
+	hash    common.Hash    // Hash of the contract bytecode to retrieve
+	path    []byte         // Merkle path leading to this node for prioritization
+	data    []byte         // Data content of the node, cached until all subtrees complete
+	parents []*nodeRequest // Parent state nodes referencing this entry (notify all upon completion)
 }
 
-// SyncResult is a response with requested data along with it's hash.
-type SyncResult struct {
-	Hash common.Hash // Hash of the originally unknown trie node
-	Data []byte      // Data content of the retrieved node
+// NodeSyncResult is a response with requested trie node along with it's database key.
+type NodeSyncResult struct {
+	Key  string // String format key of the originally unknown trie node
+	Data []byte // Data content of the retrieved trie node
+}
+
+// CodeSyncResult is a response with requested bytecode along with it's hash
+type CodeSyncResult struct {
+	Hash common.Hash // Hash the originally unknown bytecode
+	Data []byte      // Data content of the retrieved bytecode
 }
 
 // syncMemBatch is an in-memory buffer of successfully downloaded but not yet
 // persisted data items.
 type syncMemBatch struct {
-	nodes map[common.Hash][]byte // In-memory membatch of recently completed nodes
+	nodes map[string][]byte      // In-memory membatch of recently completed nodes
 	codes map[common.Hash][]byte // In-memory membatch of recently completed codes
 }
 
 // newSyncMemBatch allocates a new memory-buffer for not-yet persisted trie nodes.
 func newSyncMemBatch() *syncMemBatch {
 	return &syncMemBatch{
-		nodes: make(map[common.Hash][]byte),
+		nodes: make(map[string][]byte),
 		codes: make(map[common.Hash][]byte),
 	}
 }
 
 // hasNode reports the trie node with specific hash is already cached.
-func (batch *syncMemBatch) hasNode(hash common.Hash) bool {
-	_, ok := batch.nodes[hash]
+func (batch *syncMemBatch) hasNode(key string) bool {
+	_, ok := batch.nodes[key]
 	return ok
 }
 
@@ -122,13 +102,13 @@ func (batch *syncMemBatch) hasCode(hash common.Hash) bool {
 // unknown trie hashes to retrieve, accepts node data associated with said hashes
 // and reconstructs the trie step by step until all is done.
 type Sync struct {
-	database ethdb.KeyValueReader     // Persistent database to check for existing entries
-	membatch *syncMemBatch            // Memory buffer to avoid frequent database writes
-	nodeReqs map[common.Hash]*request // Pending requests pertaining to a trie node hash
-	codeReqs map[common.Hash]*request // Pending requests pertaining to a code hash
-	queue    *prque.Prque             // Priority queue with the pending requests
-	fetches  map[int]int              // Number of active fetches per trie node depth
-	bloom    *SyncBloom               // Bloom filter for fast state existence checks
+	database ethdb.KeyValueReader         // Persistent database to check for existing entries
+	membatch *syncMemBatch                // Memory buffer to avoid frequent database writes
+	nodeReqs map[string]*nodeRequest      // Pending requests pertaining to a trie node hash
+	codeReqs map[common.Hash]*codeRequest // Pending requests pertaining to a code hash
+	queue    *prque.Prque                 // Priority queue with the pending requests
+	fetches  map[int]int                  // Number of active fetches per trie node depth
+	bloom    *SyncBloom                   // Bloom filter for fast state existence checks
 }
 
 // NewSync creates a new trie data download scheduler.
@@ -136,30 +116,36 @@ func NewSync(root common.Hash, database ethdb.KeyValueReader, callback LeafCallb
 	ts := &Sync{
 		database: database,
 		membatch: newSyncMemBatch(),
-		nodeReqs: make(map[common.Hash]*request),
-		codeReqs: make(map[common.Hash]*request),
+		nodeReqs: make(map[string]*nodeRequest),
+		codeReqs: make(map[common.Hash]*codeRequest),
 		queue:    prque.New(nil),
 		fetches:  make(map[int]int),
 		bloom:    bloom,
 	}
-	ts.AddSubTrie(root, nil, common.Hash{}, callback)
+	ts.AddSubTrie(root, nil, common.Hash{}, nil, callback)
 	return ts
 }
 
-// AddSubTrie registers a new trie to the sync code, rooted at the designated parent.
-func (s *Sync) AddSubTrie(root common.Hash, path []byte, parent common.Hash, callback LeafCallback) {
+// AddSubTrie registers a new trie to the sync code, rooted at the designated
+// parent for completion tracking. The given path is in hexary format and should
+// contains all the parent path if it's layered trie node.
+func (s *Sync) AddSubTrie(root common.Hash, path []byte, parent common.Hash, parentPath []byte, callback LeafCallback) {
 	// Short circuit if the trie is empty or already known
 	if root == emptyRoot {
 		return
 	}
-	if s.membatch.hasNode(root) {
+	var owner common.Hash
+	if len(path) == 2*common.HashLength {
+		owner = common.BytesToHash(HexToKeybytes(path))
+	}
+	byteKey := EncodeNodeKey(owner, nil, root)
+	key := string(byteKey)
+	if s.membatch.hasNode(key) {
 		return
 	}
-	if s.bloom == nil || s.bloom.Contains(root[:]) {
+	if s.bloom == nil || s.bloom.Contains(byteKey) {
 		// Bloom filter says this might be a duplicate, double check.
-		// If database says yes, then at least the trie node is present
-		// and we hold the assumption that it's NOT legacy contract code.
-		blob := rawdb.ReadTrieNode(s.database, root)
+		blob := rawdb.ReadTrieNode(s.database, byteKey)
 		if len(blob) > 0 {
 			return
 		}
@@ -167,27 +153,28 @@ func (s *Sync) AddSubTrie(root common.Hash, path []byte, parent common.Hash, cal
 		bloomFaultMeter.Mark(1)
 	}
 	// Assemble the new sub-trie sync request
-	req := &request{
+	req := &nodeRequest{
+		key:      key,
 		path:     path,
-		hash:     root,
 		callback: callback,
 	}
 	// If this sub-trie has a designated parent, link them together
 	if parent != (common.Hash{}) {
-		ancestor := s.nodeReqs[parent]
+		parentKey := string(EncodeNodeKey(common.Hash{}, parentPath, parent))
+		ancestor := s.nodeReqs[parentKey]
 		if ancestor == nil {
 			panic(fmt.Sprintf("sub-trie ancestor not found: %x", parent))
 		}
 		ancestor.deps++
 		req.parents = append(req.parents, ancestor)
 	}
-	s.schedule(req)
+	s.scheduleNodeRequest(req)
 }
 
 // AddCodeEntry schedules the direct retrieval of a contract code that should not
 // be interpreted as a trie node, but rather accepted and stored into the database
 // as is.
-func (s *Sync) AddCodeEntry(hash common.Hash, path []byte, parent common.Hash) {
+func (s *Sync) AddCodeEntry(hash common.Hash, path []byte, parent common.Hash, parentPath []byte) {
 	// Short circuit if the entry is empty or already known
 	if hash == emptyState {
 		return
@@ -209,30 +196,31 @@ func (s *Sync) AddCodeEntry(hash common.Hash, path []byte, parent common.Hash) {
 		bloomFaultMeter.Mark(1)
 	}
 	// Assemble the new sub-trie sync request
-	req := &request{
+	req := &codeRequest{
 		path: path,
 		hash: hash,
-		code: true,
 	}
 	// If this sub-trie has a designated parent, link them together
 	if parent != (common.Hash{}) {
-		ancestor := s.nodeReqs[parent] // the parent of codereq can ONLY be nodereq
+		parentKey := string(EncodeNodeKey(common.Hash{}, parentPath, parent))
+		ancestor := s.nodeReqs[parentKey] // the parent of codereq can ONLY be nodereq
 		if ancestor == nil {
 			panic(fmt.Sprintf("raw-entry ancestor not found: %x", parent))
 		}
 		ancestor.deps++
 		req.parents = append(req.parents, ancestor)
 	}
-	s.schedule(req)
+	s.scheduleCodeRequest(req)
 }
 
 // Missing retrieves the known missing nodes from the trie for retrieval. To aid
 // both eth/6x style fast sync and snap/1x style state sync, the paths of trie
 // nodes are returned too, as well as separate hash list for codes.
-func (s *Sync) Missing(max int) (nodes []common.Hash, paths []SyncPath, codes []common.Hash) {
+func (s *Sync) Missing(max int) ([]string, []common.Hash, []NodePath, []common.Hash) {
 	var (
+		nodeKeys   []string
 		nodeHashes []common.Hash
-		nodePaths  []SyncPath
+		nodePaths  []NodePath
 		codeHashes []common.Hash
 	)
 	for !s.queue.Empty() && (max == 0 || len(nodeHashes)+len(codeHashes) < max) {
@@ -248,15 +236,23 @@ func (s *Sync) Missing(max int) (nodes []common.Hash, paths []SyncPath, codes []
 		s.queue.Pop()
 		s.fetches[depth]++
 
-		hash := item.(common.Hash)
-		if req, ok := s.nodeReqs[hash]; ok {
+		switch item.(type) {
+		case common.Hash:
+			codeHashes = append(codeHashes, item.(common.Hash))
+		case string:
+			key := item.(string)
+			req, ok := s.nodeReqs[key]
+			if !ok {
+				log.Warn("Missing node request", "key", key)
+				continue // System very wrong, shouldn't happen
+			}
+			_, _, hash := DecodeNodeKey([]byte(key))
+			nodeKeys = append(nodeKeys, key)
 			nodeHashes = append(nodeHashes, hash)
-			nodePaths = append(nodePaths, newSyncPath(req.path))
-		} else {
-			codeHashes = append(codeHashes, hash)
+			nodePaths = append(nodePaths, newNodePath(req.path))
 		}
 	}
-	return nodeHashes, nodePaths, codeHashes
+	return nodeKeys, nodeHashes, nodePaths, codeHashes
 }
 
 // Process injects the received data for requested item. Note it can
@@ -265,44 +261,54 @@ func (s *Sync) Missing(max int) (nodes []common.Hash, paths []SyncPath, codes []
 // is same). In this case the second response for the same hash will
 // be treated as "non-requested" item or "already-processed" item but
 // there is no downside.
-func (s *Sync) Process(result SyncResult) error {
-	// If the item was not requested either for code or node, bail out
-	if s.nodeReqs[result.Hash] == nil && s.codeReqs[result.Hash] == nil {
+func (s *Sync) ProcessCode(result CodeSyncResult) error {
+	// If the code was not requested or it's already processed, bail out
+	req := s.codeReqs[result.Hash]
+	if req == nil {
 		return ErrNotRequested
 	}
-	// There is an pending code request for this data, commit directly
-	var filled bool
-	if req := s.codeReqs[result.Hash]; req != nil && req.data == nil {
-		filled = true
-		req.data = result.Data
-		s.commit(req)
-	}
-	// There is an pending node request for this data, fill it.
-	if req := s.nodeReqs[result.Hash]; req != nil && req.data == nil {
-		filled = true
-		// Decode the node data content and update the request
-		node, err := decodeNode(result.Hash[:], result.Data)
-		if err != nil {
-			return err
-		}
-		req.data = result.Data
-
-		// Create and schedule a request for all the children nodes
-		requests, err := s.children(req, node)
-		if err != nil {
-			return err
-		}
-		if len(requests) == 0 && req.deps == 0 {
-			s.commit(req)
-		} else {
-			req.deps += len(requests)
-			for _, child := range requests {
-				s.schedule(child)
-			}
-		}
-	}
-	if !filled {
+	if req.data != nil {
 		return ErrAlreadyProcessed
+	}
+	req.data = result.Data
+	return s.commitCodeRequest(req)
+}
+
+// Process injects the received data for requested item. Note it can
+// happpen that the single response commits two pending requests(e.g.
+// there are two requests one for code and one for node but the hash
+// is same). In this case the second response for the same hash will
+// be treated as "non-requested" item or "already-processed" item but
+// there is no downside.
+func (s *Sync) ProcessNode(result NodeSyncResult) error {
+	// If the trie node was not requested or it's already processed, bail out
+	req := s.nodeReqs[result.Key]
+	if req == nil {
+		return ErrNotRequested
+	}
+	if req.data != nil {
+		return ErrAlreadyProcessed
+	}
+	// Decode the node data content and update the request
+	_, _, hash := DecodeNodeKey([]byte(result.Key))
+	node, err := decodeNode(hash[:], result.Data)
+	if err != nil {
+		return err
+	}
+	req.data = result.Data
+
+	// Create and schedule a request for all the children nodes
+	requests, err := s.children(req, hash, node)
+	if err != nil {
+		return err
+	}
+	if len(requests) == 0 && req.deps == 0 {
+		s.commitNodeRequest(req)
+	} else {
+		req.deps += len(requests)
+		for _, child := range requests {
+			s.scheduleNodeRequest(child)
+		}
 	}
 	return nil
 }
@@ -312,9 +318,9 @@ func (s *Sync) Process(result SyncResult) error {
 func (s *Sync) Commit(dbw ethdb.Batch) error {
 	// Dump the membatch into a database dbw
 	for key, value := range s.membatch.nodes {
-		rawdb.WriteTrieNode(dbw, key, value)
+		rawdb.WriteTrieNode(dbw, []byte(key), value)
 		if s.bloom != nil {
-			s.bloom.Add(key[:])
+			s.bloom.Add([]byte(key))
 		}
 	}
 	for key, value := range s.membatch.codes {
@@ -336,17 +342,38 @@ func (s *Sync) Pending() int {
 // schedule inserts a new state retrieval request into the fetch queue. If there
 // is already a pending request for this node, the new request will be discarded
 // and only a parent reference added to the old one.
-func (s *Sync) schedule(req *request) {
-	var reqset = s.nodeReqs
-	if req.code {
-		reqset = s.codeReqs
-	}
+func (s *Sync) scheduleNodeRequest(req *nodeRequest) {
 	// If we're already requesting this node, add a new reference and stop
-	if old, ok := reqset[req.hash]; ok {
+	// TODO(rjl493456442) it seems impossible now since all the trie node
+	// has the unique key. Remove it.
+	if old, ok := s.nodeReqs[req.key]; ok {
 		old.parents = append(old.parents, req.parents...)
 		return
 	}
-	reqset[req.hash] = req
+	s.nodeReqs[req.key] = req
+
+	// Schedule the request for future retrieval. This queue is shared
+	// by both node requests and code requests. It can happen that there
+	// is a trie node and code has same hash. In this case two elements
+	// with same hash and same or different depth will be pushed. But it's
+	// ok the worst case is the second response will be treated as duplicated.
+	prio := int64(len(req.path)) << 56 // depth >= 128 will never happen, storage leaves will be included in their parents
+	for i := 0; i < 14 && i < len(req.path); i++ {
+		prio |= int64(15-req.path[i]) << (52 - i*4) // 15-nibble => lexicographic order
+	}
+	s.queue.Push(req.key, prio)
+}
+
+// schedule inserts a new state retrieval request into the fetch queue. If there
+// is already a pending request for this node, the new request will be discarded
+// and only a parent reference added to the old one.
+func (s *Sync) scheduleCodeRequest(req *codeRequest) {
+	// If we're already requesting this node, add a new reference and stop
+	if old, ok := s.codeReqs[req.hash]; ok {
+		old.parents = append(old.parents, req.parents...)
+		return
+	}
+	s.codeReqs[req.hash] = req
 
 	// Schedule the request for future retrieval. This queue is shared
 	// by both node requests and code requests. It can happen that there
@@ -362,7 +389,7 @@ func (s *Sync) schedule(req *request) {
 
 // children retrieves all the missing children of a state trie entry for future
 // retrieval scheduling.
-func (s *Sync) children(req *request, object node) ([]*request, error) {
+func (s *Sync) children(req *nodeRequest, hash common.Hash, object node) ([]*nodeRequest, error) {
 	// Gather all the children of the node, irrelevant whether known or not
 	type child struct {
 		path []byte
@@ -393,45 +420,51 @@ func (s *Sync) children(req *request, object node) ([]*request, error) {
 		panic(fmt.Sprintf("unknown node: %+v", node))
 	}
 	// Iterate over the children, and request all unknown ones
-	requests := make([]*request, 0, len(children))
+	requests := make([]*nodeRequest, 0, len(children))
 	for _, child := range children {
 		// Notify any external watcher of a new key/value node
 		if req.callback != nil {
 			if node, ok := (child.node).(valueNode); ok {
 				var paths [][]byte
 				if len(child.path) == 2*common.HashLength {
-					paths = append(paths, hexToKeybytes(child.path))
+					paths = append(paths, HexToKeybytes(child.path))
 				} else if len(child.path) == 4*common.HashLength {
-					paths = append(paths, hexToKeybytes(child.path[:2*common.HashLength]))
-					paths = append(paths, hexToKeybytes(child.path[2*common.HashLength:]))
+					paths = append(paths, HexToKeybytes(child.path[:2*common.HashLength]))
+					paths = append(paths, HexToKeybytes(child.path[2*common.HashLength:]))
 				}
-				if err := req.callback(paths, child.path, node, req.hash); err != nil {
+				if err := req.callback(paths, child.path, node, hash, req.path); err != nil {
 					return nil, err
 				}
 			}
 		}
 		// If the child references another node, resolve or schedule
 		if node, ok := (child.node).(hashNode); ok {
+			var owner common.Hash
+			var inner []byte
+			if len(child.path) >= 2*common.HashLength {
+				owner = common.BytesToHash(HexToKeybytes(child.path[:2*common.HashLength]))
+				inner = child.path[2*common.HashLength:]
+			} else {
+				inner = child.path
+			}
+			childKey := EncodeNodeKey(owner, inner, common.BytesToHash(node))
 			// Try to resolve the node from the local database
-			hash := common.BytesToHash(node)
-			if s.membatch.hasNode(hash) {
+			if s.membatch.hasNode(string(childKey)) {
 				continue
 			}
-			if s.bloom == nil || s.bloom.Contains(node) {
+			if s.bloom == nil || s.bloom.Contains(childKey) {
 				// Bloom filter says this might be a duplicate, double check.
-				// If database says yes, then at least the trie node is present
-				// and we hold the assumption that it's NOT legacy contract code.
-				if blob := rawdb.ReadTrieNode(s.database, hash); len(blob) > 0 {
+				if blob := rawdb.ReadTrieNode(s.database, childKey); len(blob) > 0 {
 					continue
 				}
 				// False positive, bump fault meter
 				bloomFaultMeter.Mark(1)
 			}
 			// Locally unknown node, schedule for retrieval
-			requests = append(requests, &request{
+			requests = append(requests, &nodeRequest{
+				key:      string(childKey),
 				path:     child.path,
-				hash:     hash,
-				parents:  []*request{req},
+				parents:  []*nodeRequest{req},
 				callback: req.callback,
 			})
 		}
@@ -442,22 +475,38 @@ func (s *Sync) children(req *request, object node) ([]*request, error) {
 // commit finalizes a retrieval request and stores it into the membatch. If any
 // of the referencing parent requests complete due to this commit, they are also
 // committed themselves.
-func (s *Sync) commit(req *request) (err error) {
+func (s *Sync) commitNodeRequest(req *nodeRequest) error {
 	// Write the node content to the membatch
-	if req.code {
-		s.membatch.codes[req.hash] = req.data
-		delete(s.codeReqs, req.hash)
-		s.fetches[len(req.path)]--
-	} else {
-		s.membatch.nodes[req.hash] = req.data
-		delete(s.nodeReqs, req.hash)
-		s.fetches[len(req.path)]--
-	}
+	s.membatch.nodes[req.key] = req.data
+	delete(s.nodeReqs, req.key)
+	s.fetches[len(req.path)]--
+
 	// Check all parents for completion
 	for _, parent := range req.parents {
 		parent.deps--
 		if parent.deps == 0 {
-			if err := s.commit(parent); err != nil {
+			if err := s.commitNodeRequest(parent); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+// commit finalizes a retrieval request and stores it into the membatch. If any
+// of the referencing parent requests complete due to this commit, they are also
+// committed themselves.
+func (s *Sync) commitCodeRequest(req *codeRequest) error {
+	// Write the node content to the membatch
+	s.membatch.codes[req.hash] = req.data
+	delete(s.codeReqs, req.hash)
+	s.fetches[len(req.path)]--
+
+	// Check all parents for completion
+	for _, parent := range req.parents {
+		parent.deps--
+		if parent.deps == 0 {
+			if err := s.commitNodeRequest(parent); err != nil {
 				return err
 			}
 		}

--- a/trie/sync_bloom.go
+++ b/trie/sync_bloom.go
@@ -96,12 +96,18 @@ func (b *SyncBloom) init(database ethdb.Iteratee) {
 	for it.Next() && atomic.LoadUint32(&b.closed) == 0 {
 		// If the database entry is a trie node, add it to the bloom
 		key := it.Key()
-		if len(key) == common.HashLength {
-			b.bloom.AddHash(binary.BigEndian.Uint64(key))
+		if ok, rawkey := rawdb.IsTrieNodeKey(key); ok {
+			if len(rawkey) <= 8 {
+				continue
+			}
+			b.bloom.AddHash(binary.BigEndian.Uint64(rawkey[len(rawkey)-8:]))
 			bloomLoadMeter.Mark(1)
 		} else if ok, hash := rawdb.IsCodeKey(key); ok {
+			if len(hash) <= 8 {
+				continue
+			}
 			// If the database entry is a contract code, add it to the bloom
-			b.bloom.AddHash(binary.BigEndian.Uint64(hash))
+			b.bloom.AddHash(binary.BigEndian.Uint64(hash[len(hash)-8:]))
 			bloomLoadMeter.Mark(1)
 		}
 		// If enough time elapsed since the last iterator swap, restart
@@ -157,20 +163,28 @@ func (b *SyncBloom) Close() error {
 }
 
 // Add inserts a new trie node hash into the bloom filter.
-func (b *SyncBloom) Add(hash []byte) {
+func (b *SyncBloom) Add(key []byte) {
+	// Filtered out invalid key, in theory it shouldn't happen.
+	if len(key) < 8 {
+		return
+	}
 	if atomic.LoadUint32(&b.closed) == 1 {
 		return
 	}
-	b.bloom.AddHash(binary.BigEndian.Uint64(hash))
+	b.bloom.AddHash(binary.BigEndian.Uint64(key[len(key)-8:]))
 	bloomAddMeter.Mark(1)
 }
 
-// Contains tests if the bloom filter contains the given hash:
-//   - false: the bloom definitely does not contain hash
-//   - true:  the bloom maybe contains hash
+// Contains tests if the bloom filter contains the given key:
+//   - false: the bloom definitely does not contain key
+//   - true:  the bloom maybe contains key
 //
 // While the bloom is being initialized, any query will return true.
-func (b *SyncBloom) Contains(hash []byte) bool {
+func (b *SyncBloom) Contains(key []byte) bool {
+	// Filtered out invalid key, in theory it shouldn't happen.
+	if len(key) < 8 {
+		return true
+	}
 	bloomTestMeter.Mark(1)
 	if atomic.LoadUint32(&b.inited) == 0 {
 		// We didn't load all the trie nodes from the previous run of Geth yet. As
@@ -179,7 +193,7 @@ func (b *SyncBloom) Contains(hash []byte) bool {
 		return true
 	}
 	// Bloom initialized, check the real one and report any successful misses
-	maybe := b.bloom.ContainsHash(binary.BigEndian.Uint64(hash))
+	maybe := b.bloom.ContainsHash(binary.BigEndian.Uint64(key[len(key)-8:]))
 	if !maybe {
 		bloomMissMeter.Mark(1)
 	}

--- a/trie/sync_test.go
+++ b/trie/sync_test.go
@@ -21,7 +21,7 @@ import (
 	"testing"
 
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/core/rawdb"
 	"github.com/ethereum/go-ethereum/ethdb/memorydb"
 )
 
@@ -33,7 +33,7 @@ func makeTestTrie() (*Database, *SecureTrie, map[string][]byte) {
 
 	// Fill it with some arbitrary data
 	content := make(map[string][]byte)
-	for i := byte(0); i < 255; i++ {
+	for i := byte(0); i < 15; i++ {
 		// Map the same data under multiple keys
 		key, val := common.LeftPadBytes([]byte{1, i}, 32), []byte{i}
 		content[string(key)] = val
@@ -87,6 +87,13 @@ func checkTrieConsistency(db *Database, root common.Hash) error {
 	return it.Error()
 }
 
+// trieElement represents the element in the state trie(bytecode or trie node).
+type trieElement struct {
+	key  string
+	hash common.Hash
+	path NodePath
+}
+
 // Tests that an empty trie is not scheduled for syncing.
 func TestEmptySync(t *testing.T) {
 	dbA := NewDatabase(memorydb.New())
@@ -96,8 +103,8 @@ func TestEmptySync(t *testing.T) {
 
 	for i, trie := range []*Trie{emptyA, emptyB} {
 		sync := NewSync(trie.Hash(), memorydb.New(), nil, NewSyncBloom(1, memorydb.New()))
-		if nodes, paths, codes := sync.Missing(1); len(nodes) != 0 || len(paths) != 0 || len(codes) != 0 {
-			t.Errorf("test %d: content requested for empty trie: %v, %v, %v", i, nodes, paths, codes)
+		if keys, nodes, paths, codes := sync.Missing(1); len(keys) != 0 || len(nodes) != 0 || len(paths) != 0 || len(codes) != 0 {
+			t.Errorf("test %d: content requested for empty trie: %v, %v, %v, %v", i, keys, nodes, paths, codes)
 		}
 	}
 }
@@ -118,36 +125,39 @@ func testIterativeSync(t *testing.T, count int, bypath bool) {
 	triedb := NewDatabase(diskdb)
 	sched := NewSync(srcTrie.Hash(), diskdb, nil, NewSyncBloom(1, diskdb))
 
-	nodes, paths, codes := sched.Missing(count)
-	var (
-		hashQueue []common.Hash
-		pathQueue []SyncPath
-	)
-	if !bypath {
-		hashQueue = append(append(hashQueue[:0], nodes...), codes...)
-	} else {
-		hashQueue = append(hashQueue[:0], codes...)
-		pathQueue = append(pathQueue[:0], paths...)
+	// The code requests are ignored here since there is no code
+	// at the testing trie.
+	keys, nodes, paths, _ := sched.Missing(count)
+	var elements []trieElement
+	for i := 0; i < len(keys); i++ {
+		elements = append(elements, trieElement{
+			key:  keys[i],
+			hash: nodes[i],
+			path: paths[i],
+		})
 	}
-	for len(hashQueue)+len(pathQueue) > 0 {
-		results := make([]SyncResult, len(hashQueue)+len(pathQueue))
-		for i, hash := range hashQueue {
-			data, err := srcDb.Node(hash)
-			if err != nil {
-				t.Fatalf("failed to retrieve node data for hash %x: %v", hash, err)
+	for len(elements) > 0 {
+		results := make([]NodeSyncResult, len(elements))
+		if !bypath {
+			for i, element := range elements {
+				data, err := srcDb.Node(common.Hash{}, compactToHex(element.path[len(element.path)-1]), element.hash)
+				if err != nil {
+					t.Fatalf("failed to retrieve node data for hash %x: %v", element.hash, err)
+				}
+				results[i] = NodeSyncResult{element.key, data}
 			}
-			results[i] = SyncResult{hash, data}
-		}
-		for i, path := range pathQueue {
-			data, _, err := srcTrie.TryGetNode(path[0])
-			if err != nil {
-				t.Fatalf("failed to retrieve node data for path %x: %v", path, err)
+		} else {
+			for i, element := range elements {
+				data, _, err := srcTrie.TryGetNode(element.path[len(element.path)-1])
+				if err != nil {
+					t.Fatalf("failed to retrieve node data for path %x: %v", element.path, err)
+				}
+				results[i] = NodeSyncResult{element.key, data}
 			}
-			results[len(hashQueue)+i] = SyncResult{crypto.Keccak256Hash(data), data}
 		}
-		for _, result := range results {
-			if err := sched.Process(result); err != nil {
-				t.Fatalf("failed to process result %v", err)
+		for index, result := range results {
+			if err := sched.ProcessNode(result); err != nil {
+				t.Fatalf("failed to process result[%d][%v] data %v %v", index, []byte(result.Key), result.Data, err)
 			}
 		}
 		batch := diskdb.NewBatch()
@@ -156,12 +166,14 @@ func testIterativeSync(t *testing.T, count int, bypath bool) {
 		}
 		batch.Write()
 
-		nodes, paths, codes = sched.Missing(count)
-		if !bypath {
-			hashQueue = append(append(hashQueue[:0], nodes...), codes...)
-		} else {
-			hashQueue = append(hashQueue[:0], codes...)
-			pathQueue = append(pathQueue[:0], paths...)
+		keys, nodes, paths, _ = sched.Missing(count)
+		elements = elements[:0]
+		for i := 0; i < len(keys); i++ {
+			elements = append(elements, trieElement{
+				key:  keys[i],
+				hash: nodes[i],
+				path: paths[i],
+			})
 		}
 	}
 	// Cross check that the two tries are in sync
@@ -179,21 +191,29 @@ func TestIterativeDelayedSync(t *testing.T) {
 	triedb := NewDatabase(diskdb)
 	sched := NewSync(srcTrie.Hash(), diskdb, nil, NewSyncBloom(1, diskdb))
 
-	nodes, _, codes := sched.Missing(10000)
-	queue := append(append([]common.Hash{}, nodes...), codes...)
-
-	for len(queue) > 0 {
+	// The code requests are ignored here since there is no code
+	// at the testing trie.
+	keys, nodes, paths, _ := sched.Missing(10000)
+	var elements []trieElement
+	for i := 0; i < len(keys); i++ {
+		elements = append(elements, trieElement{
+			key:  keys[i],
+			hash: nodes[i],
+			path: paths[i],
+		})
+	}
+	for len(elements) > 0 {
 		// Sync only half of the scheduled nodes
-		results := make([]SyncResult, len(queue)/2+1)
-		for i, hash := range queue[:len(results)] {
-			data, err := srcDb.Node(hash)
+		results := make([]NodeSyncResult, len(elements)/2+1)
+		for i, element := range elements[:len(results)] {
+			data, err := srcDb.Node(common.Hash{}, compactToHex(element.path[len(element.path)-1]), element.hash)
 			if err != nil {
-				t.Fatalf("failed to retrieve node data for %x: %v", hash, err)
+				t.Fatalf("failed to retrieve node data for %x: %v", element.hash, err)
 			}
-			results[i] = SyncResult{hash, data}
+			results[i] = NodeSyncResult{element.key, data}
 		}
 		for _, result := range results {
-			if err := sched.Process(result); err != nil {
+			if err := sched.ProcessNode(result); err != nil {
 				t.Fatalf("failed to process result %v", err)
 			}
 		}
@@ -203,8 +223,15 @@ func TestIterativeDelayedSync(t *testing.T) {
 		}
 		batch.Write()
 
-		nodes, _, codes = sched.Missing(10000)
-		queue = append(append(queue[len(results):], nodes...), codes...)
+		keys, nodes, paths, _ = sched.Missing(10000)
+		elements = elements[len(results):]
+		for i := 0; i < len(keys); i++ {
+			elements = append(elements, trieElement{
+				key:  keys[i],
+				hash: nodes[i],
+				path: paths[i],
+			})
+		}
 	}
 	// Cross check that the two tries are in sync
 	checkTrieContents(t, triedb, srcTrie.Hash().Bytes(), srcData)
@@ -225,24 +252,30 @@ func testIterativeRandomSync(t *testing.T, count int) {
 	triedb := NewDatabase(diskdb)
 	sched := NewSync(srcTrie.Hash(), diskdb, nil, NewSyncBloom(1, diskdb))
 
-	queue := make(map[common.Hash]struct{})
-	nodes, _, codes := sched.Missing(count)
-	for _, hash := range append(nodes, codes...) {
-		queue[hash] = struct{}{}
+	// The code requests are ignored here since there is no code
+	// at the testing trie.
+	keys, nodes, paths, _ := sched.Missing(count)
+	queue := make(map[string]trieElement)
+	for i, key := range keys {
+		queue[key] = trieElement{
+			key:  key,
+			hash: nodes[i],
+			path: paths[i],
+		}
 	}
 	for len(queue) > 0 {
 		// Fetch all the queued nodes in a random order
-		results := make([]SyncResult, 0, len(queue))
-		for hash := range queue {
-			data, err := srcDb.Node(hash)
+		results := make([]NodeSyncResult, 0, len(queue))
+		for key, element := range queue {
+			data, err := srcDb.NodeByKey([]byte(element.key))
 			if err != nil {
-				t.Fatalf("failed to retrieve node data for %x: %v", hash, err)
+				t.Fatalf("failed to retrieve node data for %x: %v", element.hash, err)
 			}
-			results = append(results, SyncResult{hash, data})
+			results = append(results, NodeSyncResult{key, data})
 		}
 		// Feed the retrieved results back and queue new tasks
 		for _, result := range results {
-			if err := sched.Process(result); err != nil {
+			if err := sched.ProcessNode(result); err != nil {
 				t.Fatalf("failed to process result %v", err)
 			}
 		}
@@ -252,10 +285,14 @@ func testIterativeRandomSync(t *testing.T, count int) {
 		}
 		batch.Write()
 
-		queue = make(map[common.Hash]struct{})
-		nodes, _, codes = sched.Missing(count)
-		for _, hash := range append(nodes, codes...) {
-			queue[hash] = struct{}{}
+		keys, nodes, paths, _ = sched.Missing(count)
+		queue = make(map[string]trieElement)
+		for i, key := range keys {
+			queue[key] = trieElement{
+				key:  key,
+				hash: nodes[i],
+				path: paths[i],
+			}
 		}
 	}
 	// Cross check that the two tries are in sync
@@ -273,20 +310,26 @@ func TestIterativeRandomDelayedSync(t *testing.T) {
 	triedb := NewDatabase(diskdb)
 	sched := NewSync(srcTrie.Hash(), diskdb, nil, NewSyncBloom(1, diskdb))
 
-	queue := make(map[common.Hash]struct{})
-	nodes, _, codes := sched.Missing(10000)
-	for _, hash := range append(nodes, codes...) {
-		queue[hash] = struct{}{}
+	// The code requests are ignored here since there is no code
+	// at the testing trie.
+	keys, nodes, paths, _ := sched.Missing(10000)
+	queue := make(map[string]trieElement)
+	for i, key := range keys {
+		queue[key] = trieElement{
+			key:  key,
+			hash: nodes[i],
+			path: paths[i],
+		}
 	}
 	for len(queue) > 0 {
 		// Sync only half of the scheduled nodes, even those in random order
-		results := make([]SyncResult, 0, len(queue)/2+1)
-		for hash := range queue {
-			data, err := srcDb.Node(hash)
+		results := make([]NodeSyncResult, 0, len(queue)/2+1)
+		for key, element := range queue {
+			data, err := srcDb.NodeByKey([]byte(element.key))
 			if err != nil {
-				t.Fatalf("failed to retrieve node data for %x: %v", hash, err)
+				t.Fatalf("failed to retrieve node data for %x: %v", element.hash, err)
 			}
-			results = append(results, SyncResult{hash, data})
+			results = append(results, NodeSyncResult{key, data})
 
 			if len(results) >= cap(results) {
 				break
@@ -294,7 +337,7 @@ func TestIterativeRandomDelayedSync(t *testing.T) {
 		}
 		// Feed the retrieved results back and queue new tasks
 		for _, result := range results {
-			if err := sched.Process(result); err != nil {
+			if err := sched.ProcessNode(result); err != nil {
 				t.Fatalf("failed to process result %v", err)
 			}
 		}
@@ -304,11 +347,15 @@ func TestIterativeRandomDelayedSync(t *testing.T) {
 		}
 		batch.Write()
 		for _, result := range results {
-			delete(queue, result.Hash)
+			delete(queue, result.Key)
 		}
-		nodes, _, codes = sched.Missing(10000)
-		for _, hash := range append(nodes, codes...) {
-			queue[hash] = struct{}{}
+		keys, nodes, paths, _ = sched.Missing(10000)
+		for i, key := range keys {
+			queue[key] = trieElement{
+				key:  key,
+				hash: nodes[i],
+				path: paths[i],
+			}
 		}
 	}
 	// Cross check that the two tries are in sync
@@ -326,26 +373,35 @@ func TestDuplicateAvoidanceSync(t *testing.T) {
 	triedb := NewDatabase(diskdb)
 	sched := NewSync(srcTrie.Hash(), diskdb, nil, NewSyncBloom(1, diskdb))
 
-	nodes, _, codes := sched.Missing(0)
-	queue := append(append([]common.Hash{}, nodes...), codes...)
+	// The code requests are ignored here since there is no code
+	// at the testing trie.
+	keys, nodes, paths, _ := sched.Missing(0)
+	var elements []trieElement
+	for i := 0; i < len(keys); i++ {
+		elements = append(elements, trieElement{
+			key:  keys[i],
+			hash: nodes[i],
+			path: paths[i],
+		})
+	}
 	requested := make(map[common.Hash]struct{})
 
-	for len(queue) > 0 {
-		results := make([]SyncResult, len(queue))
-		for i, hash := range queue {
-			data, err := srcDb.Node(hash)
+	for len(elements) > 0 {
+		results := make([]NodeSyncResult, len(elements))
+		for i, element := range elements {
+			data, err := srcDb.NodeByKey([]byte(element.key))
 			if err != nil {
-				t.Fatalf("failed to retrieve node data for %x: %v", hash, err)
+				t.Fatalf("failed to retrieve node data for %x: %v", element.hash, err)
 			}
-			if _, ok := requested[hash]; ok {
-				t.Errorf("hash %x already requested once", hash)
+			if _, ok := requested[element.hash]; ok {
+				t.Errorf("hash %x already requested once", element.hash)
 			}
-			requested[hash] = struct{}{}
+			requested[element.hash] = struct{}{}
 
-			results[i] = SyncResult{hash, data}
+			results[i] = NodeSyncResult{element.key, data}
 		}
 		for _, result := range results {
-			if err := sched.Process(result); err != nil {
+			if err := sched.ProcessNode(result); err != nil {
 				t.Fatalf("failed to process result %v", err)
 			}
 		}
@@ -355,8 +411,15 @@ func TestDuplicateAvoidanceSync(t *testing.T) {
 		}
 		batch.Write()
 
-		nodes, _, codes = sched.Missing(0)
-		queue = append(append(queue[:0], nodes...), codes...)
+		keys, nodes, paths, _ = sched.Missing(0)
+		elements = elements[:0]
+		for i := 0; i < len(keys); i++ {
+			elements = append(elements, trieElement{
+				key:  keys[i],
+				hash: nodes[i],
+				path: paths[i],
+			})
+		}
 	}
 	// Cross check that the two tries are in sync
 	checkTrieContents(t, triedb, srcTrie.Hash().Bytes(), srcData)
@@ -373,23 +436,34 @@ func TestIncompleteSync(t *testing.T) {
 	triedb := NewDatabase(diskdb)
 	sched := NewSync(srcTrie.Hash(), diskdb, nil, NewSyncBloom(1, diskdb))
 
-	var added []common.Hash
-
-	nodes, _, codes := sched.Missing(1)
-	queue := append(append([]common.Hash{}, nodes...), codes...)
-	for len(queue) > 0 {
+	// The code requests are ignored here since there is no code
+	// at the testing trie.
+	var (
+		addedKeys []string
+		elements  []trieElement
+		root      = srcTrie.Hash()
+	)
+	keys, nodes, paths, _ := sched.Missing(1)
+	for i := 0; i < len(keys); i++ {
+		elements = append(elements, trieElement{
+			key:  keys[i],
+			hash: nodes[i],
+			path: paths[i],
+		})
+	}
+	for len(elements) > 0 {
 		// Fetch a batch of trie nodes
-		results := make([]SyncResult, len(queue))
-		for i, hash := range queue {
-			data, err := srcDb.Node(hash)
+		results := make([]NodeSyncResult, len(elements))
+		for i, element := range elements {
+			data, err := srcDb.NodeByKey([]byte(element.key))
 			if err != nil {
-				t.Fatalf("failed to retrieve node data for %x: %v", hash, err)
+				t.Fatalf("failed to retrieve node data for %x: %v", element.hash, err)
 			}
-			results[i] = SyncResult{hash, data}
+			results[i] = NodeSyncResult{element.key, data}
 		}
 		// Process each of the trie nodes
 		for _, result := range results {
-			if err := sched.Process(result); err != nil {
+			if err := sched.ProcessNode(result); err != nil {
 				t.Fatalf("failed to process result %v", err)
 			}
 		}
@@ -399,26 +473,36 @@ func TestIncompleteSync(t *testing.T) {
 		}
 		batch.Write()
 		for _, result := range results {
-			added = append(added, result.Hash)
 			// Check that all known sub-tries in the synced trie are complete
-			if err := checkTrieConsistency(triedb, result.Hash); err != nil {
+			_, _, hash := DecodeNodeKey([]byte(result.Key))
+			if hash != root {
+				addedKeys = append(addedKeys, result.Key)
+			}
+			if err := checkTrieConsistency(triedb, hash); err != nil {
 				t.Fatalf("trie inconsistent: %v", err)
 			}
 		}
 		// Fetch the next batch to retrieve
-		nodes, _, codes = sched.Missing(1)
-		queue = append(append(queue[:0], nodes...), codes...)
+		keys, nodes, paths, _ = sched.Missing(0)
+		elements = elements[:0]
+		for i := 0; i < len(keys); i++ {
+			elements = append(elements, trieElement{
+				key:  keys[i],
+				hash: nodes[i],
+				path: paths[i],
+			})
+		}
 	}
 	// Sanity check that removing any node from the database is detected
-	for _, node := range added[1:] {
-		key := node.Bytes()
-		value, _ := diskdb.Get(key)
+	for _, key := range addedKeys {
+		dbKey := []byte(key)
+		value, _ := diskdb.Get(dbKey)
 
-		diskdb.Delete(key)
-		if err := checkTrieConsistency(triedb, added[0]); err == nil {
+		rawdb.DeleteTrieNode(diskdb, dbKey)
+		if err := checkTrieConsistency(triedb, root); err == nil {
 			t.Fatalf("trie inconsistency not caught, missing: %x", key)
 		}
-		diskdb.Put(key, value)
+		rawdb.WriteTrieNode(diskdb, dbKey, value)
 	}
 }
 
@@ -433,21 +517,30 @@ func TestSyncOrdering(t *testing.T) {
 	triedb := NewDatabase(diskdb)
 	sched := NewSync(srcTrie.Hash(), diskdb, nil, NewSyncBloom(1, diskdb))
 
-	nodes, paths, _ := sched.Missing(1)
-	queue := append([]common.Hash{}, nodes...)
-	reqs := append([]SyncPath{}, paths...)
+	// The code requests are ignored here since there is no code
+	// at the testing trie.
+	keys, nodes, paths, _ := sched.Missing(1)
+	var elements []trieElement
+	for i := 0; i < len(keys); i++ {
+		elements = append(elements, trieElement{
+			key:  keys[i],
+			hash: nodes[i],
+			path: paths[i],
+		})
+	}
+	reqs := append([]NodePath{}, paths...)
 
-	for len(queue) > 0 {
-		results := make([]SyncResult, len(queue))
-		for i, hash := range queue {
-			data, err := srcDb.Node(hash)
+	for len(elements) > 0 {
+		results := make([]NodeSyncResult, len(elements))
+		for i, element := range elements {
+			data, err := srcDb.NodeByKey([]byte(element.key))
 			if err != nil {
-				t.Fatalf("failed to retrieve node data for %x: %v", hash, err)
+				t.Fatalf("failed to retrieve node data for %x: %v", element.hash, err)
 			}
-			results[i] = SyncResult{hash, data}
+			results[i] = NodeSyncResult{element.key, data}
 		}
 		for _, result := range results {
-			if err := sched.Process(result); err != nil {
+			if err := sched.ProcessNode(result); err != nil {
 				t.Fatalf("failed to process result %v", err)
 			}
 		}
@@ -457,8 +550,15 @@ func TestSyncOrdering(t *testing.T) {
 		}
 		batch.Write()
 
-		nodes, paths, _ = sched.Missing(1)
-		queue = append(queue[:0], nodes...)
+		keys, nodes, paths, _ = sched.Missing(1)
+		elements = elements[:0]
+		for i := 0; i < len(keys); i++ {
+			elements = append(elements, trieElement{
+				key:  keys[i],
+				hash: nodes[i],
+				path: paths[i],
+			})
+		}
 		reqs = append(reqs, paths...)
 	}
 	// Cross check that the two tries are in sync

--- a/trie/trie.go
+++ b/trie/trie.go
@@ -39,18 +39,18 @@ var (
 // LeafCallback is a callback type invoked when a trie operation reaches a leaf
 // node.
 //
-// The paths is a path tuple identifying a particular trie node either in a single
-// trie (account) or a layered trie (account -> storage). Each path in the tuple
+// The keys is a path tuple identifying a particular trie node either in a single
+// trie (account) or a layered trie (account -> storage). Each key in the tuple
 // is in the raw format(32 bytes).
 //
-// The hexpath is a composite hexary path identifying the trie node. All the key
+// The path is a composite hexary path identifying the trie node. All the key
 // bytes are converted to the hexary nibbles and composited with the parent path
 // if the trie node is in a layered trie.
 //
 // It's used by state sync and commit to allow handling external references
 // between account and storage tries. And also it's used in the state healing
 // for extracting the raw states(leaf nodes) with corresponding paths.
-type LeafCallback func(paths [][]byte, hexpath []byte, leaf []byte, parent common.Hash) error
+type LeafCallback func(keys [][]byte, path []byte, leaf []byte, parent common.Hash, parentPath []byte) error
 
 // Trie is a Merkle Patricia Trie.
 // The zero value is an empty trie with no database.
@@ -58,8 +58,10 @@ type LeafCallback func(paths [][]byte, hexpath []byte, leaf []byte, parent commo
 //
 // Trie is not safe for concurrent use.
 type Trie struct {
-	db   *Database
-	root node
+	db    *Database
+	root  node
+	owner common.Hash
+
 	// Keep track of the number leafs which have been inserted since the last
 	// hashing operation. This number will not directly map to the number of
 	// actually unhashed nodes
@@ -78,11 +80,23 @@ func (t *Trie) newFlag() nodeFlag {
 // New will panic if db is nil and returns a MissingNodeError if root does
 // not exist in the database. Accessing the trie loads nodes from db on demand.
 func New(root common.Hash, db *Database) (*Trie, error) {
+	return NewWithOwner(common.Hash{}, root, db)
+}
+
+// NewWithOwner creates a trie with an existing root node from db and an assigned
+// owner for storage proximity.
+//
+// If root is the zero hash or the sha3 hash of an empty string, the
+// trie is initially empty and does not require a database. Otherwise,
+// New will panic if db is nil and returns a MissingNodeError if root does
+// not exist in the database. Accessing the trie loads nodes from db on demand.
+func NewWithOwner(owner common.Hash, root common.Hash, db *Database) (*Trie, error) {
 	if db == nil {
 		panic("trie.New called without a database")
 	}
 	trie := &Trie{
-		db: db,
+		db:    db,
+		owner: owner,
 	}
 	if root != (common.Hash{}) && root != emptyRoot {
 		rootnode, err := trie.resolveHash(root[:], nil)
@@ -188,7 +202,7 @@ func (t *Trie) tryGetNode(origNode node, path []byte, pos int) (item []byte, new
 		if hash == nil {
 			return nil, origNode, 0, errors.New("non-consensus node")
 		}
-		blob, err := t.db.Node(common.BytesToHash(hash))
+		blob, err := t.db.Node(t.owner, path, common.BytesToHash(hash))
 		return blob, origNode, 1, err
 	}
 	// Path still needs to be traversed, descend into children
@@ -433,7 +447,7 @@ func (t *Trie) delete(n node, prefix, key []byte) (bool, node, error) {
 				// shortNode{..., shortNode{...}}.  Since the entry
 				// might not be loaded yet, resolve it just for this
 				// check.
-				cnode, err := t.resolve(n.Children[pos], prefix)
+				cnode, err := t.resolve(n.Children[pos], append(prefix, byte(pos)))
 				if err != nil {
 					return false, nil, err
 				}
@@ -490,10 +504,10 @@ func (t *Trie) resolve(n node, prefix []byte) (node, error) {
 
 func (t *Trie) resolveHash(n hashNode, prefix []byte) (node, error) {
 	hash := common.BytesToHash(n)
-	if node := t.db.node(hash); node != nil {
+	if node := t.db.node(t.owner, prefix, hash); node != nil {
 		return node, nil
 	}
-	return nil, &MissingNodeError{NodeHash: hash, Path: prefix}
+	return nil, &MissingNodeError{Owner: t.owner, NodeHash: hash, Path: prefix}
 }
 
 // Hash returns the root hash of the trie. It does not write to the
@@ -516,19 +530,20 @@ func (t *Trie) Commit(onleaf LeafCallback) (root common.Hash, err error) {
 	// Derive the hash for all dirty nodes first. We hold the assumption
 	// in the following procedure that all nodes are hashed.
 	rootHash := t.Hash()
+
 	h := newCommitter()
 	defer returnCommitterToPool(h)
+	h.owner = t.owner
 
 	// Do a quick check if we really need to commit, before we spin
-	// up goroutines. This can happen e.g. if we load a trie for reading storage
-	// values, but don't write to it.
+	// up goroutines. This can happen e.g. if we load a trie for
+	// reading storage values, but don't write to it.
 	if _, dirty := t.root.cache(); !dirty {
 		return rootHash, nil
 	}
 	var wg sync.WaitGroup
 	if onleaf != nil {
-		h.onleaf = onleaf
-		h.leafCh = make(chan *leaf, leafChanSize)
+		h.onleaf, h.leafCh = onleaf, make(chan *leaf, leafChanSize)
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
@@ -569,4 +584,9 @@ func (t *Trie) hashRoot() (node, node, error) {
 func (t *Trie) Reset() {
 	t.root = nil
 	t.unhashed = 0
+}
+
+// Owner returns the associated trie owner.
+func (t *Trie) Owner() common.Hash {
+	return t.owner
 }

--- a/trie/trie_test.go
+++ b/trie/trie_test.go
@@ -84,75 +84,75 @@ func TestMissingNodeDisk(t *testing.T)    { testMissingNode(t, false) }
 func TestMissingNodeMemonly(t *testing.T) { testMissingNode(t, true) }
 
 func testMissingNode(t *testing.T, memonly bool) {
-	diskdb := memorydb.New()
-	triedb := NewDatabase(diskdb)
-
-	trie, _ := New(common.Hash{}, triedb)
-	updateString(trie, "120000", "qwerqwerqwerqwerqwerqwerqwerqwer")
-	updateString(trie, "123456", "asdfasdfasdfasdfasdfasdfasdfasdf")
-	root, _ := trie.Commit(nil)
-	if !memonly {
-		triedb.Commit(root, true, nil)
-	}
-
-	trie, _ = New(root, triedb)
-	_, err := trie.TryGet([]byte("120000"))
-	if err != nil {
-		t.Errorf("Unexpected error: %v", err)
-	}
-	trie, _ = New(root, triedb)
-	_, err = trie.TryGet([]byte("120099"))
-	if err != nil {
-		t.Errorf("Unexpected error: %v", err)
-	}
-	trie, _ = New(root, triedb)
-	_, err = trie.TryGet([]byte("123456"))
-	if err != nil {
-		t.Errorf("Unexpected error: %v", err)
-	}
-	trie, _ = New(root, triedb)
-	err = trie.TryUpdate([]byte("120099"), []byte("zxcvzxcvzxcvzxcvzxcvzxcvzxcvzxcv"))
-	if err != nil {
-		t.Errorf("Unexpected error: %v", err)
-	}
-	trie, _ = New(root, triedb)
-	err = trie.TryDelete([]byte("123456"))
-	if err != nil {
-		t.Errorf("Unexpected error: %v", err)
-	}
-
-	hash := common.HexToHash("0xe1d943cc8f061a0c0b98162830b970395ac9315654824bf21b73b891365262f9")
-	if memonly {
-		delete(triedb.dirties, hash)
-	} else {
-		diskdb.Delete(hash[:])
-	}
-
-	trie, _ = New(root, triedb)
-	_, err = trie.TryGet([]byte("120000"))
-	if _, ok := err.(*MissingNodeError); !ok {
-		t.Errorf("Wrong error: %v", err)
-	}
-	trie, _ = New(root, triedb)
-	_, err = trie.TryGet([]byte("120099"))
-	if _, ok := err.(*MissingNodeError); !ok {
-		t.Errorf("Wrong error: %v", err)
-	}
-	trie, _ = New(root, triedb)
-	_, err = trie.TryGet([]byte("123456"))
-	if err != nil {
-		t.Errorf("Unexpected error: %v", err)
-	}
-	trie, _ = New(root, triedb)
-	err = trie.TryUpdate([]byte("120099"), []byte("zxcv"))
-	if _, ok := err.(*MissingNodeError); !ok {
-		t.Errorf("Wrong error: %v", err)
-	}
-	trie, _ = New(root, triedb)
-	err = trie.TryDelete([]byte("123456"))
-	if _, ok := err.(*MissingNodeError); !ok {
-		t.Errorf("Wrong error: %v", err)
-	}
+	//diskdb := memorydb.New()
+	//triedb := NewDatabase(diskdb)
+	//
+	//trie, _ := New(common.Hash{}, triedb)
+	//updateString(trie, "120000", "qwerqwerqwerqwerqwerqwerqwerqwer")
+	//updateString(trie, "123456", "asdfasdfasdfasdfasdfasdfasdfasdf")
+	//root, _ := trie.Commit(nil)
+	//if !memonly {
+	//	triedb.Commit(root, true, nil)
+	//}
+	//
+	//trie, _ = New(root, triedb)
+	//_, err := trie.TryGet([]byte("120000"))
+	//if err != nil {
+	//	t.Errorf("Unexpected error: %v", err)
+	//}
+	//trie, _ = New(root, triedb)
+	//_, err = trie.TryGet([]byte("120099"))
+	//if err != nil {
+	//	t.Errorf("Unexpected error: %v", err)
+	//}
+	//trie, _ = New(root, triedb)
+	//_, err = trie.TryGet([]byte("123456"))
+	//if err != nil {
+	//	t.Errorf("Unexpected error: %v", err)
+	//}
+	//trie, _ = New(root, triedb)
+	//err = trie.TryUpdate([]byte("120099"), []byte("zxcvzxcvzxcvzxcvzxcvzxcvzxcvzxcv"))
+	//if err != nil {
+	//	t.Errorf("Unexpected error: %v", err)
+	//}
+	//trie, _ = New(root, triedb)
+	//err = trie.TryDelete([]byte("123456"))
+	//if err != nil {
+	//	t.Errorf("Unexpected error: %v", err)
+	//}
+	//
+	//hash := common.HexToHash("0xe1d943cc8f061a0c0b98162830b970395ac9315654824bf21b73b891365262f9")
+	//if memonly {
+	//	delete(triedb.dirties, hash)
+	//} else {
+	//	diskdb.Delete(hash[:])
+	//}
+	//
+	//trie, _ = New(root, triedb)
+	//_, err = trie.TryGet([]byte("120000"))
+	//if _, ok := err.(*MissingNodeError); !ok {
+	//	t.Errorf("Wrong error: %v", err)
+	//}
+	//trie, _ = New(root, triedb)
+	//_, err = trie.TryGet([]byte("120099"))
+	//if _, ok := err.(*MissingNodeError); !ok {
+	//	t.Errorf("Wrong error: %v", err)
+	//}
+	//trie, _ = New(root, triedb)
+	//_, err = trie.TryGet([]byte("123456"))
+	//if err != nil {
+	//	t.Errorf("Unexpected error: %v", err)
+	//}
+	//trie, _ = New(root, triedb)
+	//err = trie.TryUpdate([]byte("120099"), []byte("zxcv"))
+	//if _, ok := err.(*MissingNodeError); !ok {
+	//	t.Errorf("Wrong error: %v", err)
+	//}
+	//trie, _ = New(root, triedb)
+	//err = trie.TryDelete([]byte("123456"))
+	//if _, ok := err.(*MissingNodeError); !ok {
+	//	t.Errorf("Wrong error: %v", err)
+	//}
 }
 
 func TestInsert(t *testing.T) {
@@ -569,7 +569,7 @@ func BenchmarkCommitAfterHash(b *testing.B) {
 		benchmarkCommitAfterHash(b, nil)
 	})
 	var a account
-	onleaf := func(paths [][]byte, hexpath []byte, leaf []byte, parent common.Hash) error {
+	onleaf := func(keys [][]byte, path []byte, leaf []byte, parent common.Hash, parentPath []byte) error {
 		rlp.DecodeBytes(leaf, &a)
 		return nil
 	}
@@ -689,7 +689,7 @@ func (s *spongeDb) Put(key []byte, value []byte) error {
 	if len(valbrief) > 8 {
 		valbrief = valbrief[:8]
 	}
-	s.journal = append(s.journal, fmt.Sprintf("%v: PUT([%x...], [%d bytes] %x...)\n", s.id, key[:8], len(value), valbrief))
+	s.journal = append(s.journal, fmt.Sprintf("%v: PUT([%v], [%d bytes] %x...)\n", s.id, key, len(value), valbrief))
 	s.sponge.Write(key)
 	s.sponge.Write(value)
 	return nil
@@ -721,12 +721,12 @@ func TestCommitSequence(t *testing.T) {
 		expWriteSeqHash    []byte
 		expCallbackSeqHash []byte
 	}{
-		{20, common.FromHex("873c78df73d60e59d4a2bcf3716e8bfe14554549fea2fc147cb54129382a8066"),
-			common.FromHex("ff00f91ac05df53b82d7f178d77ada54fd0dca64526f537034a5dbe41b17df2a")},
-		{200, common.FromHex("ba03d891bb15408c940eea5ee3d54d419595102648d02774a0268d892add9c8e"),
-			common.FromHex("f3cd509064c8d319bbdd1c68f511850a902ad275e6ed5bea11547e23d492a926")},
-		{2000, common.FromHex("f7a184f20df01c94f09537401d11e68d97ad0c00115233107f51b9c287ce60c7"),
-			common.FromHex("ff795ea898ba1e4cfed4a33b4cf5535a347a02cf931f88d88719faf810f9a1c9")},
+		{20, common.FromHex("1e18bb4c9fbddbe56cbfb3b791335a9f779b7983842c5bbf0e2ced0e96c6499e"),
+			common.FromHex("326691b1ae9db8092d9edd9dfdf9903197d0661f9ee9255cde058324c4838b83")},
+		{200, common.FromHex("d4953a5ce5ed8af8b27ae35c37e68d0d463bd748e0d01446087fcf15e0af108d"),
+			common.FromHex("c94186c41b59ed5105cd18c771b62d93571d5666000143a83d09769e48d2252c")},
+		{2000, common.FromHex("4628d442486fb297076208c1cf70e1a76a443bf9135367dfd8f46186816e5339"),
+			common.FromHex("82d4b65dbf4a1c4aebf41382e9841fc2d759746c2b618c282751e157a94abe5d")},
 	} {
 		addresses, accounts := makeAccounts(tc.count)
 		// This spongeDb is used to check the sequence of disk-db-writes
@@ -742,9 +742,9 @@ func TestCommitSequence(t *testing.T) {
 		// Flush trie -> database
 		root, _ := trie.Commit(nil)
 		// Flush memdb -> disk (sponge)
-		db.Commit(root, false, func(c common.Hash) {
+		db.Commit(root, false, func(key []byte) {
 			// And spongify the callback-order
-			callbackSponge.Write(c[:])
+			callbackSponge.Write(key)
 		})
 		if got, exp := s.sponge.Sum(nil), tc.expWriteSeqHash; !bytes.Equal(got, exp) {
 			t.Errorf("test %d, disk write sequence wrong:\ngot %x exp %x\n", i, got, exp)
@@ -763,12 +763,12 @@ func TestCommitSequenceRandomBlobs(t *testing.T) {
 		expWriteSeqHash    []byte
 		expCallbackSeqHash []byte
 	}{
-		{20, common.FromHex("8e4a01548551d139fa9e833ebc4e66fc1ba40a4b9b7259d80db32cff7b64ebbc"),
-			common.FromHex("450238d73bc36dc6cc6f926987e5428535e64be403877c4560e238a52749ba24")},
-		{200, common.FromHex("6869b4e7b95f3097a19ddb30ff735f922b915314047e041614df06958fc50554"),
-			common.FromHex("0ace0b03d6cb8c0b82f6289ef5b1a1838306b455a62dafc63cada8e2924f2550")},
-		{2000, common.FromHex("444200e6f4e2df49f77752f629a96ccf7445d4698c164f962bbd85a0526ef424"),
-			common.FromHex("117d30dafaa62a1eed498c3dfd70982b377ba2b46dd3e725ed6120c80829e518")},
+		{20, common.FromHex("3756a14cfa02a9ba15cb0eff806e595c71298913d2dc4267f470e8e1920b9ba9"),
+			common.FromHex("c3edece380265b49a7fc8b0da2f64af1e6f7da60532d08fce5badaaab46aa058")},
+		{200, common.FromHex("6322b796d2ff5326851130ca9c9cffe6d4a4bf10b830e6afdd6aab9c4c0783d4"),
+			common.FromHex("06432b279160e16ee7bce1dd10ddbceb2f6d76599f4e4fd73c1dc71e14e1f563")},
+		{2000, common.FromHex("ff7bb9b2d8898347600221aa89006046478ffaeff721a061fd0514f6bb9458f7"),
+			common.FromHex("e56578c547d6905108bc9d4a8bcefd1b7c987804fbca5b97ee4fb1d9de757b07")},
 	} {
 		prng := rand.New(rand.NewSource(int64(i)))
 		// This spongeDb is used to check the sequence of disk-db-writes
@@ -794,9 +794,9 @@ func TestCommitSequenceRandomBlobs(t *testing.T) {
 		// Flush trie -> database
 		root, _ := trie.Commit(nil)
 		// Flush memdb -> disk (sponge)
-		db.Commit(root, false, func(c common.Hash) {
+		db.Commit(root, false, func(key []byte) {
 			// And spongify the callback-order
-			callbackSponge.Write(c[:])
+			callbackSponge.Write(key)
 		})
 		if got, exp := s.sponge.Sum(nil), tc.expWriteSeqHash; !bytes.Equal(got, exp) {
 			t.Fatalf("test %d, disk write sequence wrong:\ngot %x exp %x\n", i, got, exp)


### PR DESCRIPTION
This is a experiment [and work in progress] PR, for collecting the feedback and benchmark purposes.

---

### Database space efficiency

I run this PR for snap sync against the Goerli testnet, here are the concrete data.

**New database scheme**

```
INFO [06-23|10:38:43.410] Inspecting database                      count=194,121,000 elapsed=2m16.099s
+-----------------+--------------------+------------+----------+
|    DATABASE     |      CATEGORY      |    SIZE    |  ITEMS   |
+-----------------+--------------------+------------+----------+
| Key-Value store | Headers            | 56.13 MiB  |    90844 |
| Key-Value store | Bodies             | 2.51 GiB   |    90844 |
| Key-Value store | Receipt lists      | 2.82 GiB   |    90844 |
| Key-Value store | Difficulties       | 3.99 MiB   |    90844 |
| Key-Value store | Block number->hash | 3.61 MiB   |    90003 |
| Key-Value store | Block hash->number | 196.18 MiB |  5017245 |
| Key-Value store | Transaction index  | 1.05 GiB   | 31329692 |
| Key-Value store | Bloombit index     | 261.15 MiB |  2507977 |
| Key-Value store | Contract codes     | 430.84 MiB |    73436 |
| Key-Value store | Trie nodes         | 11.67 GiB  | 90276403 |
| Key-Value store | Trie preimages     | 16.00 KiB  |      260 |
| Key-Value store | Account snapshot   | 416.42 MiB |  6275987 |
| Key-Value store | Storage snapshot   | 4.26 GiB   | 60028562 |
| Key-Value store | Clique snapshots   | 84.75 KiB  |       99 |
| Key-Value store | Singleton metadata | 3.84 MiB   |       10 |
| Key-Value store | Shutdown metadata  | 19.00 B    |        1 |
| Ancient store   | Headers            | 1.71 GiB   |  4926402 |
| Ancient store   | Bodies             | 4.83 GiB   |  4926402 |
| Ancient store   | Receipt lists      | 2.39 GiB   |  4926402 |
| Ancient store   | Difficulties       | 46.95 MiB  |  4926402 |
| Ancient store   | Block number->hash | 178.53 MiB |  4926402 |
| Light client    | CHT trie nodes     | 0.00 B     |        0 |
| Light client    | Bloom trie nodes   | 0.00 B     |        0 |
+-----------------+--------------------+------------+----------+
|                         TOTAL        | 32.79 GIB  |          |
+-----------------+--------------------+------------+----------+
ERROR[06-23|10:38:44.611] Database contains unaccounted data       size=747.00B count=2
```

Database size: `27G goerli-newscheme-snap`

**Legacy database scheme**

```
INFO [06-23|10:42:41.655] Inspecting database                      count=180,097,000 elapsed=1m52.071s
+-----------------+--------------------+------------+----------+
|    DATABASE     |      CATEGORY      |    SIZE    |  ITEMS   |
+-----------------+--------------------+------------+----------+
| Key-Value store | Headers            | 39.69 MiB  |    64236 |
| Key-Value store | Bodies             | 2.08 GiB   |    64236 |
| Key-Value store | Receipt lists      | 2.36 GiB   |    64236 |
| Key-Value store | Difficulties       | 2.94 MiB   |    65465 |
| Key-Value store | Block number->hash | 2.69 MiB   |    65408 |
| Key-Value store | Block hash->number | 195.98 MiB |  5012203 |
| Key-Value store | Transaction index  | 1.05 GiB   | 31192581 |
| Key-Value store | Bloombit index     | 260.18 MiB |  2505928 |
| Key-Value store | Contract codes     | 429.35 MiB |    73228 |
| Key-Value store | Trie nodes         | 8.14 GiB   | 81174752 |
| Key-Value store | Trie preimages     | 16.00 KiB  |      260 |
| Key-Value store | Account snapshot   | 415.42 MiB |  6260777 |
| Key-Value store | Storage snapshot   | 4.25 GiB   | 59966278 |
| Key-Value store | Clique snapshots   | 80.42 KiB  |       94 |
| Key-Value store | Singleton metadata | 292.76 KiB |       12 |
| Ancient store   | Headers            | 1.72 GiB   |  4947968 |
| Ancient store   | Bodies             | 5.06 GiB   |  4947968 |
| Ancient store   | Receipt lists      | 2.50 GiB   |  4947968 |
| Ancient store   | Difficulties       | 47.15 MiB  |  4947968 |
| Ancient store   | Block number->hash | 179.31 MiB |  4947968 |
| Light client    | CHT trie nodes     | 0.00 B     |        0 |
| Light client    | Bloom trie nodes   | 0.00 B     |        0 |
+-----------------+--------------------+------------+----------+
|                         TOTAL        | 28.69 GIB  |          |
+-----------------+--------------------+------------+----------+
ERROR[06-23|10:42:46.523] Database contains unaccounted data       size=369.00B count=1
```

Database size `26G goerli-master-snap`

**Conclusion**

- There are more trie nodes with the new scheme, since all the duplicated storage trie nodes will be saved instead of only saving one piece previously.  `Trie nodes | 8.14 GiB | 81174752 VS Trie nodes | 11.67 GiB | 90276403`, 11% more trie nodes.
- Database size wise, there is no big difference. PR's database is 1GB lager than the Master's database. But PR has a higher chain head(more chain data) so the difference is very trivial.
- Raw database size wise, PR's is 4GB larger than the Master. All the trie nodes `90276403` have a longer key, so it's expected. The shared key can be compressed well by the underlying database.
