### PR TITLE
docs: Discord server instead of gitter for communication with devs

### DIFF
--- a/README.md
+++ b/README.md
@@ -332,7 +332,7 @@ from anyone on the internet, and are grateful for even the smallest of fixes!
 
 If you'd like to contribute to go-ethereum, please fork, fix, commit and send a pull request
 for the maintainers to review and merge into the main code base. If you wish to submit
-more complex changes though, please check up with the core devs first on [our gitter channel](https://gitter.im/ethereum/go-ethereum)
+more complex changes though, please check up with the core devs first on [our Discord Server](https://discord.gg/invite/nthXNEv)
 to ensure those changes are in line with the general philosophy of the project and/or get
 some early feedback which can make both your efforts much lighter as well as our review
 and merge procedures quick and simple.


### PR DESCRIPTION
The `README.md` links the Gitter channel for discussions, but the
official docs and even the Gitter channel itself recommend using the
official Discord Server for such discussions.
This PR simply changes the Gitter link and provides Discord invite link.