### PR TITLE
travis, Dockerfile, build: docker build and multi-arch publish combo

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,8 @@ jobs:
       script:
         - go run build/ci.go lint
 
-    # These builders create the Docker sub-images for multi-arch push
+    # These builders create the Docker sub-images for multi-arch push and each
+    # will attempt to push the multi-arch image if they are the last builder
     - stage: build
       if: type = push
       os: linux
@@ -38,7 +39,7 @@ jobs:
       git:
         submodules: false # avoid cloning ethereum/tests
       script:
-        - go run build/ci.go docker -image -upload karalabe/geth-docker-test
+        - go run build/ci.go docker -image -manifest amd64,arm64 -upload karalabe/geth-docker-test
 
     - stage: build
       if: type = push
@@ -53,24 +54,7 @@ jobs:
       git:
         submodules: false # avoid cloning ethereum/tests
       script:
-        - go run build/ci.go docker -image -upload karalabe/geth-docker-test
-
-    # This builder does the Docker Hub multi-arch image
-    - stage: publish
-      if: type = push
-      os: linux
-      dist: bionic
-      go: 1.16.x
-      env:
-        - docker
-      services:
-        - docker
-      git:
-        submodules: false # avoid cloning ethereum/tests
-      before_install:
-        - export DOCKER_CLI_EXPERIMENTAL=enabled
-      script:
-        - go run build/ci.go docker -manifest amd64,arm64 -upload karalabe/geth-docker-test
+        - go run build/ci.go docker -image -manifest amd64,arm64 -upload karalabe/geth-docker-test
 
     # This builder does the Ubuntu PPA upload
     - stage: build

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,8 @@
+# Support setting various labels on the final image
+ARG COMMIT=""
+ARG VERSION=""
+ARG BUILDNUM=""
+
 # Build Geth in a stock Go builder container
 FROM golang:1.16-alpine as builder
 
@@ -14,3 +19,10 @@ COPY --from=builder /go-ethereum/build/bin/geth /usr/local/bin/
 
 EXPOSE 8545 8546 30303 30303/udp
 ENTRYPOINT ["geth"]
+
+# Add some metadata labels to help programatic image consumption
+ARG COMMIT=""
+ARG VERSION=""
+ARG BUILDNUM=""
+
+LABEL commit="$COMMIT" version="$VERSION" buildnum="$BUILDNUM"

--- a/Dockerfile.alltools
+++ b/Dockerfile.alltools
@@ -1,3 +1,8 @@
+# Support setting various labels on the final image
+ARG COMMIT=""
+ARG VERSION=""
+ARG BUILDNUM=""
+
 # Build Geth in a stock Go builder container
 FROM golang:1.16-alpine as builder
 
@@ -13,3 +18,10 @@ RUN apk add --no-cache ca-certificates
 COPY --from=builder /go-ethereum/build/bin/* /usr/local/bin/
 
 EXPOSE 8545 8546 30303 30303/udp
+
+# Add some metadata labels to help programatic image consumption
+ARG COMMIT=""
+ARG VERSION=""
+ARG BUILDNUM=""
+
+LABEL commit="$COMMIT" version="$VERSION" buildnum="$BUILDNUM"


### PR DESCRIPTION
This PR merges docker push and multi-arch publish. Each individual builder will try to own the publishing, but only the last should succeed. This is achieved by pushing the travis build number into the final docker images and using those to match up published images with the builder runs form different architectures / travis jobs.