### PR TITLE
aaccounts/abi/bind: replace context.TODO with context.Background

### DIFF
--- a/accounts/abi/bind/base.go
+++ b/accounts/abi/bind/base.go
@@ -443,7 +443,7 @@ func (c *BoundContract) UnpackLogIntoMap(out map[string]interface{}, event strin
 // user specified it as such.
 func ensureContext(ctx context.Context) context.Context {
 	if ctx == nil {
-		return context.TODO()
+		return context.Background()
 	}
 	return ctx
 }


### PR DESCRIPTION
While reviewing #23062 we found that call to `context.TODO`. Replace it with `context.Background`.