### PR TITLE
crypto: fix build directives

### DIFF
--- a/crypto/secp256k1/panic_cb.go
+++ b/crypto/secp256k1/panic_cb.go
@@ -2,7 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be found in
 // the LICENSE file.
 
-// +build !gofuzz cgo
+// +build !gofuzz
+// +build cgo
 
 package secp256k1
 

--- a/crypto/secp256k1/scalar_mult_cgo.go
+++ b/crypto/secp256k1/scalar_mult_cgo.go
@@ -2,7 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be found in
 // the LICENSE file.
 
-// +build !gofuzz cgo
+// +build !gofuzz
+// +build cgo
 
 package secp256k1
 

--- a/crypto/secp256k1/secp256.go
+++ b/crypto/secp256k1/secp256.go
@@ -2,7 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be found in
 // the LICENSE file.
 
-// +build !gofuzz cgo
+// +build !gofuzz
+// +build cgo
 
 // Package secp256k1 wraps the bitcoin secp256k1 C library.
 package secp256k1


### PR DESCRIPTION
The fuzzer build is failing: https://oss-fuzz-build-logs.storage.googleapis.com/log-c9d947df-e83c-4880-bf8b-6d4e24222421.txt 

```
Step #4: Building fuzzVmRuntime
Step #4: + corpusfile=/root/go/src/github.com/ethereum/go-ethereum/tests/fuzzers/bn256/testdata/fuzzBn256Pair_seed_corpus.zip
Step #4: + '[' -f /root/go/src/github.com/ethereum/go-ethereum/tests/fuzzers/bn256/testdata/fuzzBn256Pair_seed_corpus.zip ']'
Step #4: + compile_fuzzer tests/fuzzers/runtime Fuzz fuzzVmRuntime
Step #4: + path=/root/go/src/github.com/ethereum/go-ethereum/tests/fuzzers/runtime
Step #4: + func=Fuzz
Step #4: + fuzzer=fuzzVmRuntime
Step #4: + echo 'Building fuzzVmRuntime'
Step #4: + [[ address = *coverage* ]]
Step #4: + cd /root/go/src/github.com/ethereum/go-ethereum/tests/fuzzers/runtime
Step #4: + go-fuzz -func Fuzz -o /work/fuzzVmRuntime.a .
Step #4: # github.com/ethereum/go-ethereum/crypto/secp256k1
Step #4: ../../../crypto/secp256k1/scalar_mult_cgo.go:23:27: (*BitCurve).ScalarMult redeclared in this block
Step #4: 	previous declaration at ../../../crypto/secp256k1/scalar_mult_nocgo.go:11:6
Step #4: 2021/06/22 07:33:22 failed to build packages:exit status 2
```
I got the same error locally, and this PR fixes it (at least for `CGO_ENABLED=0  go-fuzz-build .` in runtime. 
This PR changes from `OR` to `AND` on the cgo-and-nofuzz files. 
