### PR TITLE
accounts/abi/bind: fix gas price suggestion with pre EIP-1559 clients

### DIFF
--- a/accounts/abi/bind/base.go
+++ b/accounts/abi/bind/base.go
@@ -256,12 +256,9 @@ func (c *BoundContract) transact(opts *TransactOpts, contract *common.Address, i
 			return nil, errors.New("maxFeePerGas or maxPriorityFeePerGas specified but london is not active yet")
 		}
 		if opts.GasPrice == nil {
-			price, err := c.transactor.SuggestGasTipCap(ensureContext(opts.Context))
+			price, err := c.transactor.SuggestGasPrice(ensureContext(opts.Context))
 			if err != nil {
 				return nil, err
-			}
-			if head.BaseFee != nil {
-				price.Add(price, head.BaseFee)
 			}
 			opts.GasPrice = price
 		}


### PR DESCRIPTION
I believe this PR fix a bug that prevents gas price suggestion with go-ethereum 1.10.4 and a pre EIP-1559 client (e.g. geth < v1.10.4). Thanks!