### PR TITLE
Convert int/hash values from context into js object

### DIFF
--- a/eth/tracers/tracer.go
+++ b/eth/tracers/tracer.go
@@ -666,7 +666,8 @@ func (jst *Tracer) GetResult() (json.RawMessage, error) {
 			jst.vm.PushInt(val)
 
 		case common.Hash:
-			jst.vm.PushString(val.Hex())
+			ptr := jst.vm.PushFixedBuffer(32)
+			copy(makeSlice(ptr, 32), val[:])
 
 		default:
 			panic(fmt.Sprintf("unsupported type: %T", val))

--- a/eth/tracers/tracer.go
+++ b/eth/tracers/tracer.go
@@ -662,6 +662,12 @@ func (jst *Tracer) GetResult() (json.RawMessage, error) {
 		case *big.Int:
 			pushBigInt(val, jst.vm)
 
+		case int:
+			jst.vm.PushInt(val)
+
+		case common.Hash:
+			jst.vm.PushString(val.Hex())
+
 		default:
 			panic(fmt.Sprintf("unsupported type: %T", val))
 		}


### PR DESCRIPTION
The tracer context now has `int` and `Hash` types. They need to be converted before they're pushed on the js stack.