### PR TITLE
core/rawdb: implement sequential reads in freezer_table

### DIFF
--- a/core/rawdb/database.go
+++ b/core/rawdb/database.go
@@ -89,6 +89,11 @@ func (db *nofreezedb) Ancient(kind string, number uint64) ([]byte, error) {
 	return nil, errNotSupported
 }
 
+// ReadAncients returns an error as we don't have a backing chain freezer.
+func (db *nofreezedb) ReadAncients(kind string, start, max, maxByteSize uint64) ([][]byte, error) {
+	return nil, errNotSupported
+}
+
 // Ancients returns an error as we don't have a backing chain freezer.
 func (db *nofreezedb) Ancients() (uint64, error) {
 	return 0, errNotSupported

--- a/core/rawdb/freezer.go
+++ b/core/rawdb/freezer.go
@@ -180,6 +180,18 @@ func (f *freezer) Ancient(kind string, number uint64) ([]byte, error) {
 	return nil, errUnknownTable
 }
 
+// Ancient retrieves multiple items in sequence, starting from the index 'start'.
+// It will return
+//  - at most 'max' items,
+//  - at least 1 item (even if exceeding the maxByteSize), but will otherwise
+//   return as many items as fit into maxByteSize.
+func (f *freezer) ReadAncients(kind string, start, max, maxByteSize uint64) ([][]byte, error) {
+	if table := f.tables[kind]; table != nil {
+		return table.RetrieveItems(start, max, maxByteSize)
+	}
+	return nil, errUnknownTable
+}
+
 // Ancients returns the length of the frozen items.
 func (f *freezer) Ancients() (uint64, error) {
 	return atomic.LoadUint64(&f.frozen), nil

--- a/core/rawdb/freezer.go
+++ b/core/rawdb/freezer.go
@@ -180,14 +180,14 @@ func (f *freezer) Ancient(kind string, number uint64) ([]byte, error) {
 	return nil, errUnknownTable
 }
 
-// Ancient retrieves multiple items in sequence, starting from the index 'start'.
+// ReadAncients retrieves multiple items in sequence, starting from the index 'start'.
 // It will return
 //  - at most 'max' items,
 //  - at least 1 item (even if exceeding the maxByteSize), but will otherwise
 //   return as many items as fit into maxByteSize.
-func (f *freezer) ReadAncients(kind string, start, max, maxByteSize uint64) ([][]byte, error) {
+func (f *freezer) ReadAncients(kind string, start, count, maxBytes uint64) ([][]byte, error) {
 	if table := f.tables[kind]; table != nil {
-		return table.RetrieveItems(start, max, maxByteSize)
+		return table.RetrieveItems(start, count, maxBytes)
 	}
 	return nil, errUnknownTable
 }

--- a/core/rawdb/freezer_table.go
+++ b/core/rawdb/freezer_table.go
@@ -562,6 +562,9 @@ func (t *freezerTable) append(item uint64, encodedBlob []byte, wlock bool) (bool
 // getIndices returns the index entries for the given from-item, covering 'count' items.
 // N.B: The actual number of returned indices for N items will always be N+1 (unless an
 // error is returned).
+// OBS: This method assumes that the caller has already verified (and/or trimmed) the range
+// so that the items are within bounds. If this method is used to read out of bounds,
+// it will return error.
 func (t *freezerTable) getIndices(from, count uint64) ([]*indexEntry, error) {
 	// Apply the table-offset
 	from = from - uint64(t.itemOffset)
@@ -590,17 +593,6 @@ func (t *freezerTable) getIndices(from, count uint64) ([]*indexEntry, error) {
 		indices[0].filenum = indices[1].filenum
 	}
 	return indices, nil
-}
-
-// getBounds returns the indexes for the item
-// returns start, end, filenumber and error
-func (t *freezerTable) getBounds(item uint64) (uint32, uint32, uint32, error) {
-	indices, err := t.getIndices(item, 1)
-	if err != nil {
-		return 0, 0, 0, err
-	}
-	start, end, fileNum := indices[0].bounds(indices[1])
-	return start, end, fileNum, nil
 }
 
 // Retrieve looks up the data offset of an item with the given number and retrieves

--- a/core/rawdb/freezer_table.go
+++ b/core/rawdb/freezer_table.go
@@ -680,7 +680,7 @@ func (t *freezerTable) retrieveItems(start, max, maxBytes uint64) ([]byte, []int
 		if len(output) < length {
 			output = make([]byte, length)
 		}
-		if dataFile, exist := t.files[uint32(fileId)]; !exist {
+		if dataFile, exist := t.files[fileId]; !exist {
 			return fmt.Errorf("missing data file %d", fileId)
 		} else if _, err := dataFile.ReadAt(output[outputSize:outputSize+length], int64(start)); err != nil {
 			return err
@@ -709,7 +709,7 @@ func (t *freezerTable) retrieveItems(start, max, maxBytes uint64) ([]byte, []int
 		if secondIndex.filenum != firstIndex.filenum {
 			if unreadSize > 0 {
 				// If we have unread data in the first file, we need to do that read now.
-				if err := readData(firstIndex.filenum, uint32(readStart), unreadSize); err != nil {
+				if err := readData(firstIndex.filenum, readStart, unreadSize); err != nil {
 					return nil, nil, err
 				}
 				unreadSize = 0
@@ -725,7 +725,7 @@ func (t *freezerTable) retrieveItems(start, max, maxBytes uint64) ([]byte, []int
 		sizes = append(sizes, size)
 		if i == len(indices)-2 || uint64(totalSize) > maxBytes {
 			// Last item, need to do the read now
-			if err := readData(secondIndex.filenum, uint32(readStart), unreadSize); err != nil {
+			if err := readData(secondIndex.filenum, readStart, unreadSize); err != nil {
 				return nil, nil, err
 			}
 			break

--- a/core/rawdb/freezer_table_test.go
+++ b/core/rawdb/freezer_table_test.go
@@ -731,7 +731,7 @@ func TestSequentialRead(t *testing.T) {
 		f.Close()
 	}
 	{ // Open it, iterate, verify byte limit. The byte limit is less than item
-		// size, so each lookup should only return one otem
+		// size, so each lookup should only return one item
 		f, err := newCustomTable(os.TempDir(), fname, rm, wm, sg, 40, true)
 		if err != nil {
 			t.Fatal(err)

--- a/core/rawdb/table.go
+++ b/core/rawdb/table.go
@@ -64,8 +64,8 @@ func (t *table) Ancient(kind string, number uint64) ([]byte, error) {
 
 // ReadAncients is a noop passthrough that just forwards the request to the underlying
 // database.
-func (t *table) ReadAncients(kind string, start, max, maxByteSize uint64) ([][]byte, error) {
-	return t.db.ReadAncients(kind, start, max, maxByteSize)
+func (t *table) ReadAncients(kind string, start, count, maxBytes uint64) ([][]byte, error) {
+	return t.db.ReadAncients(kind, start, count, maxBytes)
 }
 
 // Ancients is a noop passthrough that just forwards the request to the underlying

--- a/core/rawdb/table.go
+++ b/core/rawdb/table.go
@@ -62,6 +62,12 @@ func (t *table) Ancient(kind string, number uint64) ([]byte, error) {
 	return t.db.Ancient(kind, number)
 }
 
+// ReadAncients is a noop passthrough that just forwards the request to the underlying
+// database.
+func (t *table) ReadAncients(kind string, start, max, maxByteSize uint64) ([][]byte, error) {
+	return t.db.ReadAncients(kind, start, max, maxByteSize)
+}
+
 // Ancients is a noop passthrough that just forwards the request to the underlying
 // database.
 func (t *table) Ancients() (uint64, error) {

--- a/ethdb/database.go
+++ b/ethdb/database.go
@@ -76,6 +76,13 @@ type AncientReader interface {
 	// Ancient retrieves an ancient binary blob from the append-only immutable files.
 	Ancient(kind string, number uint64) ([]byte, error)
 
+	// Ancient retrieves multiple items in sequence, starting from the index 'start'.
+	// It will return
+	//  - at most 'max' items,
+	//  - at least 1 item (even if exceeding the maxByteSize), but will otherwise
+	//   return as many items as fit into maxByteSize.
+	ReadAncients(kind string, start, max, maxByteSize uint64) ([][]byte, error)
+
 	// Ancients returns the ancient item numbers in the ancient store.
 	Ancients() (uint64, error)
 

--- a/ethdb/database.go
+++ b/ethdb/database.go
@@ -76,12 +76,12 @@ type AncientReader interface {
 	// Ancient retrieves an ancient binary blob from the append-only immutable files.
 	Ancient(kind string, number uint64) ([]byte, error)
 
-	// Ancient retrieves multiple items in sequence, starting from the index 'start'.
+	// ReadAncients retrieves multiple items in sequence, starting from the index 'start'.
 	// It will return
-	//  - at most 'max' items,
-	//  - at least 1 item (even if exceeding the maxByteSize), but will otherwise
-	//   return as many items as fit into maxByteSize.
-	ReadAncients(kind string, start, max, maxByteSize uint64) ([][]byte, error)
+	//  - at most 'count' items,
+	//  - at least 1 item (even if exceeding the maxBytes), but will otherwise
+	//   return as many items as fit into maxBytes.
+	ReadAncients(kind string, start, count, maxBytes uint64) ([][]byte, error)
 
 	// Ancients returns the ancient item numbers in the ancient store.
 	Ancients() (uint64, error)


### PR DESCRIPTION
This PR is a bit of a successor to https://github.com/ethereum/go-ethereum/pull/20308, which implemented sequential access to freezer data via an iterator interface. 
This PR instead returns a slice of data. It does not defer reads until `Next()`, so instead does all the reads while holding the readlock. 
It also switches the implementation of `Retrieve` to be a just a short-cut for doing a sequential read with max items set to `1`. This PR doesn't really add any uses of the new method (except the `Retrieve`), but does actually improve one thing as-is: previously, two syscalls were performed to read two index items from the index-file. This PR instead reads all (both) index items using only one syscall. 

Later on, this can be used to serve `eth64` data such as headers directly from ancients with a minimum number of syscalls.  If that is done, we can get by with `2` syscalls per "192-header-delivery" instead of `576`.