### PR TITLE
p2p/server: rename method in comment

### DIFF
--- a/p2p/server.go
+++ b/p2p/server.go
@@ -370,7 +370,7 @@ func (srv *Server) RemoveTrustedPeer(node *enode.Node) {
 	}
 }
 
-// SubscribePeers subscribes the given channel to peer events
+// SubscribeEvents subscribes the given channel to peer events
 func (srv *Server) SubscribeEvents(ch chan *PeerEvent) event.Subscription {
 	return srv.peerFeed.Subscribe(ch)
 }


### PR DESCRIPTION
Rename a method in comment that does not match the name in code.