### PR TITLE
crypto: gofuzz build directives

### DIFF
--- a/crypto/signature_cgo.go
+++ b/crypto/signature_cgo.go
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
 
-// +build !nacl,!js,cgo
+// +build !nacl,!js,cgo,!gofuzz
 
 package crypto
 

--- a/crypto/signature_nocgo.go
+++ b/crypto/signature_nocgo.go
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
 
-// +build nacl js !cgo
+// +build nacl js !cgo gofuzz
 
 package crypto
 


### PR DESCRIPTION
Witth these changes, I can build the evm with various flag combos: 
```
[user@work evm]$ go build -tags gofuzz . 
[user@work evm]$ go build -tags nocgo . 
[user@work evm]$ go build -tags gofuzz,nocgo . 
```
And also the runtime fuzzer again: 
```
[user@work runtime]$ go-fuzz-build .
```

Follow-up after https://github.com/ethereum/go-ethereum/pull/23089 which didn't fully fix all problems
