### PR TITLE
dockerfile: get rid of make and env, see if that fixes builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,10 +6,10 @@ ARG BUILDNUM=""
 # Build Geth in a stock Go builder container
 FROM golang:1.16-alpine as builder
 
-RUN apk add --no-cache make gcc musl-dev linux-headers git
+RUN apk add --no-cache gcc musl-dev linux-headers git
 
 ADD . /go-ethereum
-RUN cd /go-ethereum && make geth
+RUN cd /go-ethereum && go run build/ci.go install ./cmd/geth
 
 # Pull Geth into a second stage deploy alpine container
 FROM alpine:latest

--- a/Dockerfile.alltools
+++ b/Dockerfile.alltools
@@ -6,10 +6,10 @@ ARG BUILDNUM=""
 # Build Geth in a stock Go builder container
 FROM golang:1.16-alpine as builder
 
-RUN apk add --no-cache make gcc musl-dev linux-headers git
+RUN apk add --no-cache gcc musl-dev linux-headers git
 
 ADD . /go-ethereum
-RUN cd /go-ethereum && make all
+RUN cd /go-ethereum && go run build/ci.go install
 
 # Pull all binaries into a second stage deploy alpine container
 FROM alpine:latest


### PR DESCRIPTION
Docker hub started choking on `env` with `Operation not permitted` on the new 1.14 Alpine guest images. Well, might as well try to get rid of make from our Dockerfiles, see if that fixes anything.