### PR TITLE
fuzzing: fix typo in fuzzer definitions

### DIFF
--- a/oss-fuzz.sh
+++ b/oss-fuzz.sh
@@ -102,7 +102,7 @@ compile_fuzzer tests/fuzzers/stacktrie  Fuzz fuzzStackTrie
 compile_fuzzer tests/fuzzers/difficulty Fuzz fuzzDifficulty
 compile_fuzzer tests/fuzzers/abi        Fuzz fuzzAbi
 compile_fuzzer tests/fuzzers/les        Fuzz fuzzLes
-compile_fuzzer tests/fuzzers/secp265k1  Fuzz fuzzSecp256k1
+compile_fuzzer tests/fuzzers/secp256k1  Fuzz fuzzSecp256k1
 compile_fuzzer tests/fuzzers/vflux      FuzzClientPool fuzzClientPool
 
 compile_fuzzer tests/fuzzers/bls12381  FuzzG1Add fuzz_g1_add


### PR DESCRIPTION
Fixes a typo which prevents oss-fuzz from building/running. 