### PR TITLE
core/types: sanity check the basefee length inside a header

### DIFF
--- a/core/types/block.go
+++ b/core/types/block.go
@@ -129,6 +129,11 @@ func (h *Header) SanityCheck() error {
 	if eLen := len(h.Extra); eLen > 100*1024 {
 		return fmt.Errorf("too large block extradata: size %d", eLen)
 	}
+	if h.BaseFee != nil {
+		if bfLen := h.BaseFee.BitLen(); bfLen > 256 {
+			return fmt.Errorf("too large base fee: bitlen %d", bfLen)
+		}
+	}
 	return nil
 }
 


### PR DESCRIPTION
EIP 1559 added a new unbounded type to the headers (base fee). This PR adds a meaningful can on top of it to prevent anyone from finding an ingenious way to do an amplification attack with junk basefees (with valid PoW).