### PR TITLE
core/types: remove LogForStorage type

### DIFF
--- a/core/types/log.go
+++ b/core/types/log.go
@@ -68,9 +68,6 @@ type rlpLog struct {
 	Data    []byte
 }
 
-// rlpStorageLog is the storage encoding of a log.
-type rlpStorageLog rlpLog
-
 // EncodeRLP implements rlp.Encoder.
 func (l *Log) EncodeRLP(w io.Writer) error {
 	return rlp.Encode(w, rlpLog{Address: l.Address, Topics: l.Topics, Data: l.Data})
@@ -84,29 +81,4 @@ func (l *Log) DecodeRLP(s *rlp.Stream) error {
 		l.Address, l.Topics, l.Data = dec.Address, dec.Topics, dec.Data
 	}
 	return err
-}
-
-// LogForStorage is a wrapper around a Log that flattens and parses the entire content of
-// a log including non-consensus fields.
-type LogForStorage Log
-
-// EncodeRLP implements rlp.Encoder.
-func (l *LogForStorage) EncodeRLP(w io.Writer) error {
-	return rlp.Encode(w, rlpStorageLog{
-		Address: l.Address,
-		Topics:  l.Topics,
-		Data:    l.Data,
-	})
-}
-
-// DecodeRLP implements rlp.Decoder.
-//
-// Note some redundant fields(e.g. block number, tx hash etc) will be assembled later.
-func (l *LogForStorage) DecodeRLP(s *rlp.Stream) error {
-	var dec rlpStorageLog
-	if err := s.Decode(&dec); err != nil {
-		return err
-	}
-	*l = LogForStorage{Address: dec.Address, Topics: dec.Topics, Data: dec.Data}
-	return nil
 }

--- a/core/types/log.go
+++ b/core/types/log.go
@@ -17,11 +17,8 @@
 package types
 
 import (
-	"io"
-
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
-	"github.com/ethereum/go-ethereum/rlp"
 )
 
 //go:generate gencodec -type Log -field-override logMarshaling -out gen_log_json.go
@@ -40,19 +37,19 @@ type Log struct {
 	// Derived fields. These fields are filled in by the node
 	// but not secured by consensus.
 	// block in which the transaction was included
-	BlockNumber uint64 `json:"blockNumber"`
+	BlockNumber uint64 `json:"blockNumber" rlp:"-"`
 	// hash of the transaction
-	TxHash common.Hash `json:"transactionHash" gencodec:"required"`
+	TxHash common.Hash `json:"transactionHash" gencodec:"required" rlp:"-"`
 	// index of the transaction in the block
-	TxIndex uint `json:"transactionIndex"`
+	TxIndex uint `json:"transactionIndex" rlp:"-"`
 	// hash of the block in which the transaction was included
-	BlockHash common.Hash `json:"blockHash"`
+	BlockHash common.Hash `json:"blockHash" rlp:"-"`
 	// index of the log in the block
-	Index uint `json:"logIndex"`
+	Index uint `json:"logIndex" rlp:"-"`
 
 	// The Removed field is true if this log was reverted due to a chain reorganisation.
 	// You must pay attention to this field if you receive logs through a filter query.
-	Removed bool `json:"removed"`
+	Removed bool `json:"removed" rlp:"-"`
 }
 
 type logMarshaling struct {
@@ -60,25 +57,4 @@ type logMarshaling struct {
 	BlockNumber hexutil.Uint64
 	TxIndex     hexutil.Uint
 	Index       hexutil.Uint
-}
-
-type rlpLog struct {
-	Address common.Address
-	Topics  []common.Hash
-	Data    []byte
-}
-
-// EncodeRLP implements rlp.Encoder.
-func (l *Log) EncodeRLP(w io.Writer) error {
-	return rlp.Encode(w, rlpLog{Address: l.Address, Topics: l.Topics, Data: l.Data})
-}
-
-// DecodeRLP implements rlp.Decoder.
-func (l *Log) DecodeRLP(s *rlp.Stream) error {
-	var dec rlpLog
-	err := s.Decode(&dec)
-	if err == nil {
-		l.Address, l.Topics, l.Data = dec.Address, dec.Topics, dec.Data
-	}
-	return err
 }

--- a/core/types/receipt.go
+++ b/core/types/receipt.go
@@ -232,10 +232,7 @@ func (r *ReceiptForStorage) DecodeRLP(s *rlp.Stream) error {
 		return err
 	}
 	r.CumulativeGasUsed = stored.CumulativeGasUsed
-	r.Logs = make([]*Log, len(stored.Logs))
-	for i, log := range stored.Logs {
-		r.Logs[i] = (*Log)(log)
-	}
+	r.Logs = stored.Logs
 	r.Bloom = CreateBloom(Receipts{(*Receipt)(r)})
 	return nil
 }

--- a/core/types/receipt.go
+++ b/core/types/receipt.go
@@ -94,7 +94,7 @@ type receiptRLP struct {
 type storedReceiptRLP struct {
 	PostStateOrStatus []byte
 	CumulativeGasUsed uint64
-	Logs              []*LogForStorage
+	Logs              []*Log
 }
 
 // NewReceipt creates a barebone transaction receipt, copying the init fields.
@@ -217,10 +217,7 @@ func (r *ReceiptForStorage) EncodeRLP(w io.Writer) error {
 	enc := &storedReceiptRLP{
 		PostStateOrStatus: (*Receipt)(r).statusEncoding(),
 		CumulativeGasUsed: r.CumulativeGasUsed,
-		Logs:              make([]*LogForStorage, len(r.Logs)),
-	}
-	for i, log := range r.Logs {
-		enc.Logs[i] = (*LogForStorage)(log)
+		Logs:              r.Logs,
 	}
 	return rlp.Encode(w, enc)
 }


### PR DESCRIPTION
Martin noticed that the encoding of `Log` and `LogForStorage` is exactly the same now. After tracking it down it seems like #17106 changed the storage schema of logs to be simply the encoding of `[Address, Topics, Data]`, which is equivalent to the encoding of `Log` (or `rlpLog`). Support for the legacy format was dropped in #22852 and if I'm not wrong there's no reason anymore to have these two equivalent types.

Switching to this branch on a running node didn't seem to create a problem, but I'm not sure what to look for.

Note: this change includes an API change in `core/types`