### PR TITLE
core/types: add benchmark for rlp encoding/decoding

### DIFF
--- a/core/types/types_test.go
+++ b/core/types/types_test.go
@@ -1,0 +1,138 @@
+// Copyright 2021 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+package types
+
+import (
+	"math/big"
+	"reflect"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/rlp"
+)
+
+type devnull struct{ len int }
+
+func (d *devnull) Write(p []byte) (n int, err error) {
+	d.len += len(p)
+	return len(p), nil
+}
+
+func BenchmarkRLP(b *testing.B) {
+	key, _ := crypto.HexToECDSA("b71c71a67e1177ad4e901695e1b4b9ee17ae16c6668d313eac2f96dbcda3f291")
+	to := common.HexToAddress("0x00000000000000000000000000000000deadbeef")
+	signer := NewLondonSigner(big.NewInt(1337))
+	for _, tc := range []struct {
+		name string
+		obj  interface{}
+	}{
+		{
+			"legacy-header",
+			&Header{
+				Difficulty: big.NewInt(10000000000),
+				Number:     big.NewInt(1000),
+				GasLimit:   8_000_000,
+				GasUsed:    8_000_000,
+				Time:       555,
+				Extra:      make([]byte, 32),
+			},
+		},
+		{
+			"london-header",
+			&Header{
+				Difficulty: big.NewInt(10000000000),
+				Number:     big.NewInt(1000),
+				GasLimit:   8_000_000,
+				GasUsed:    8_000_000,
+				Time:       555,
+				Extra:      make([]byte, 32),
+				BaseFee:    big.NewInt(10000000000),
+			},
+		},
+		{
+			"receipt-for-storage",
+			&ReceiptForStorage{
+				Status:            ReceiptStatusSuccessful,
+				CumulativeGasUsed: 0x888888888,
+				Logs:              make([]*Log, 5),
+			},
+		},
+		{
+			"receipt-full",
+			&Receipt{
+				Status:            ReceiptStatusSuccessful,
+				CumulativeGasUsed: 0x888888888,
+				Logs:              make([]*Log, 5),
+			},
+		},
+		{
+			"legacy-transaction",
+			MustSignNewTx(key, signer,
+				&LegacyTx{
+					Nonce:    1,
+					GasPrice: big.NewInt(500),
+					Gas:      1000000,
+					To:       &to,
+					Value:    big.NewInt(1),
+				}),
+		},
+		{
+			"access-transaction",
+			MustSignNewTx(key, signer,
+				&AccessListTx{
+					Nonce:    1,
+					GasPrice: big.NewInt(500),
+					Gas:      1000000,
+					To:       &to,
+					Value:    big.NewInt(1),
+				}),
+		},
+		{
+			"1559-transaction",
+			MustSignNewTx(key, signer,
+				&DynamicFeeTx{
+					Nonce:     1,
+					Gas:       1000000,
+					To:        &to,
+					Value:     big.NewInt(1),
+					GasTipCap: big.NewInt(500),
+					GasFeeCap: big.NewInt(500),
+				}),
+		},
+	} {
+		// Test encoding
+		b.Run("encode-"+tc.name, func(b *testing.B) {
+			b.ReportAllocs()
+			var null = &devnull{}
+			for i := 0; i < b.N; i++ {
+				rlp.Encode(null, tc.obj)
+			}
+			b.SetBytes(int64(null.len / b.N))
+		})
+		data, _ := rlp.EncodeToBytes(tc.obj)
+		// Test decoding
+		obj := reflect.New(reflect.TypeOf(tc.obj))
+		b.Run("decode-"+tc.name, func(b *testing.B) {
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				rlp.DecodeBytes(data, obj)
+			}
+			b.SetBytes(int64(len(data)))
+		})
+	}
+}

--- a/core/types/types_test.go
+++ b/core/types/types_test.go
@@ -27,7 +27,7 @@ import (
 
 type devnull struct{ len int }
 
-func (d *devnull) Write(p []byte) (n int, err error) {
+func (d *devnull) Write(p []byte) (int, error) {
 	d.len += len(p)
 	return len(p), nil
 }


### PR DESCRIPTION
This PR just adds a benchmark of how performant the RLP encoding/decoding of core types is. 


```
BenchmarkEncodeRLP/legacy-header-6         	 2306220	       530.7 ns/op	1023.20 MB/s	       0 B/op	       0 allocs/op
BenchmarkEncodeRLP/london-header-6         	 2219181	       545.7 ns/op	1006.04 MB/s	       0 B/op	       0 allocs/op
BenchmarkEncodeRLP/receipt-for-storage-6   	 3012508	       404.4 ns/op	  22.25 MB/s	      64 B/op	       1 allocs/op
BenchmarkEncodeRLP/receipt-full-6          	 2059255	       668.5 ns/op	 403.88 MB/s	     320 B/op	       1 allocs/op
BenchmarkEncodeRLP/legacy-transaction-6    	 2062718	       624.7 ns/op	 163.27 MB/s	       0 B/op	       0 allocs/op
BenchmarkEncodeRLP/access-transaction-6    	 1271258	      1004 ns/op	 105.60 MB/s	      24 B/op	       1 allocs/op
BenchmarkEncodeRLP/1559-transaction-6      	 1212688	       991.2 ns/op	 110.97 MB/s	      24 B/op	       1 allocs/op
```
decode:
```
BenchmarkDecodeRLP/legacy-header-6         	  967195	      1313 ns/op	 413.49 MB/s	      80 B/op	       2 allocs/op
BenchmarkDecodeRLP/london-header-6         	 1000000	      1290 ns/op	 425.69 MB/s	      80 B/op	       2 allocs/op
BenchmarkDecodeRLP/receipt-for-storage-6   	 1000000	      1084 ns/op	   8.30 MB/s	     144 B/op	       5 allocs/op
BenchmarkDecodeRLP/receipt-full-6          	 1061335	       984.9 ns/op	 274.14 MB/s	     393 B/op	       4 allocs/op
BenchmarkDecodeRLP/legacy-transaction-6    	  460074	      2890 ns/op	  35.29 MB/s	     488 B/op	      14 allocs/op
BenchmarkDecodeRLP/access-transaction-6    	  333847	      3687 ns/op	  28.75 MB/s	     744 B/op	      19 allocs/op
BenchmarkDecodeRLP/1559-transaction-6      	  375579	      3961 ns/op	  27.77 MB/s	     776 B/op	      20 allocs/op
```
