### PR TITLE
core/state: trie-prefetcher nitpick

### DIFF
--- a/core/state/trie_prefetcher.go
+++ b/core/state/trie_prefetcher.go
@@ -312,12 +312,11 @@ func (sf *subfetcher) loop() {
 
 				default:
 					// No termination request yet, prefetch the next entry
-					taskid := string(task)
-					if _, ok := sf.seen[taskid]; ok {
+					if _, ok := sf.seen[string(task)]; ok {
 						sf.dups++
 					} else {
 						sf.trie.TryGet(task)
-						sf.seen[taskid] = struct{}{}
+						sf.seen[string(task)] = struct{}{}
 					}
 				}
 			}


### PR DESCRIPTION
Might reduce memory consumption a bit.
We don't need to declare a new variable here, casting to string twice might be a bit slower but less memory intensive
```
OUTINE ======================== github.com/ethereum/go-ethereum/core/state.(*subfetcher).loop in github.com/ethereum/go-ethereum/core/state/trie_prefetcher.go
  823.72MB    63.55GB (flat, cum) 13.25% of Total
         .          .    277:func (sf *subfetcher) loop() {
 [...]
         .   638.60MB    282:    trie, err := sf.db.OpenTrie(sf.root)
         .          .    283:    if err != nil {
         .          .    284:        log.Warn("Trie prefetcher failed opening trie", "root", 
[...]
         .          .    289:    // Trie opened successfully, keep prefetching items
         .          .    290:    for {
      10MB       10MB    291:        select {
         .          .    292:        case <-sf.wake:
  [...]
         .          .    304:                    sf.lock.Lock()
    3.06MB     3.06MB    305:                    sf.tasks = append(sf.tasks, tasks[i:]...)
         .          .    306:                    sf.lock.Unlock()
         .          .    307:                    return
         .          .    308:
         .          .    309:                case ch := <-sf.copy:
         .          .    310:                    // Somebody wants a copy of the current trie, grant them
         .          .    311:                    ch <- sf.db.CopyTrie(sf.trie)
         .          .    312:
         .          .    313:                default:
         .          .    314:                    // No termination request yet, prefetch the next entry
  308.01MB   308.01MB    315:                    taskid := string(task)
         .          .    316:                    if _, ok := sf.seen[taskid]; ok {
         .          .    317:                        sf.dups++
         .          .    318:                    } else {
         .    62.05GB    319:                        sf.trie.TryGet(task)
  502.65MB   502.65MB    320:                        sf.seen[taskid] = struct{}{}
  ```