### PR TITLE
Cleanup no-op in gasprice test

### DIFF
--- a/eth/gasprice/gasprice_test.go
+++ b/eth/gasprice/gasprice_test.go
@@ -100,12 +100,7 @@ func newTestBackend(t *testing.T, londonBlock *big.Int, pending bool) *testBacke
 		}
 		signer = types.LatestSigner(gspec.Config)
 	)
-	if londonBlock != nil {
-		gspec.Config.LondonBlock = londonBlock
-		signer = types.LatestSigner(gspec.Config)
-	} else {
-		gspec.Config.LondonBlock = nil
-	}
+	gspec.Config.LondonBlock = londonBlock
 	engine := ethash.NewFaker()
 	db := rawdb.NewMemoryDatabase()
 	genesis, _ := gspec.Commit(db)


### PR DESCRIPTION
This PR cleans up a no-op in the gasprice unit tests where a variable is overwritten in a conditional checking if it is nil or not, but the conditional is not necessary. In one branch, there is additionally a signer object that is overwritten, which will be identical to the one created and overwritten directly above it.