### PR TITLE
accounts/usbwallet: properly close wallet after failure

### DIFF
--- a/accounts/usbwallet/wallet.go
+++ b/accounts/usbwallet/wallet.go
@@ -209,9 +209,7 @@ func (w *wallet) heartbeat() {
 		w.stateLock.RUnlock()
 
 		if err != nil {
-			w.stateLock.Lock() // Lock state to tear the wallet down
-			w.close()
-			w.stateLock.Unlock()
+			go w.Close()
 		}
 		// Ignore non hardware related errors
 		err = nil


### PR DESCRIPTION
This is a minor improvement, not a bug fix. The wallet's heartbeat (and self-derivation) loops continue even after a failure has occured. And after such failure the wallet is unusable anyway and has to be re-opened, so we won't need those loops.