### PR TITLE
update vulnerabilities

### DIFF
--- a/docs/_vulnerabilities/vulnerabilities.json
+++ b/docs/_vulnerabilities/vulnerabilities.json
@@ -97,5 +97,20 @@
     "severity": "High",
     "CVE": "CVE-2020-26265",
     "check": "(Geth\\/v1\\.9\\.(4|5|6|7|8|9)-.*)|(Geth\\/v1\\.9\\.1\\d-.*)$"
+  },
+    {
+    "name": "Not ready for London upgrade",
+    "uid": "GETH-2021-01",
+    "summary": "The client is not ready for the 'London' technical upgrade, and will deviate from the canonical chain when the London upgrade occurs (at block '12965000' around August 4, 2021.",
+    "description": "At (or around) August 4, Ethereum will undergo a technical upgrade called 'London'. Clients not upgraded will fail to progress on the canonical chain.",
+    "links": [
+      "https://github.com/ethereum/eth1.0-specs/blob/master/network-upgrades/mainnet-upgrades/london.md",
+      "https://notes.ethereum.org/@timbeiko/ropsten-postmortem"
+    ],
+    "introduced": "v1.10.1",
+    "fixed": "v1.10.6",
+    "published": "2020-12-10",
+    "severity": "High",
+    "check": "(Geth\\/v1\\.10\\.(1|2|3|4|5)-.*)$"
   }
 ]

--- a/docs/_vulnerabilities/vulnerabilities.json.minisig
+++ b/docs/_vulnerabilities/vulnerabilities.json.minisig
@@ -1,4 +1,4 @@
 untrusted comment: signature from minisign secret key
-RWQk7Lo5TQgd+zxfhTVu9RKveaSCRXSMeOq6nKsv/f1cJmHJEB75gOTTsh6P7SzKwwNCES4LgD9ozE4FEUBRUguSZP3ITc2rvAg=
-trusted comment: timestamp:1607605939	file:vulnerabilities.json
-lC8y+82roRxdNTsA3VZkG6vPxkpYq+yIiTXPdkigaDvZaT4Kro1FqfVGIZ60Uh/6MYz4pSgQYAmD6ujLOQjoAA==
+RWQk7Lo5TQgd++2CkAs6CekBlyaHJBtzoL52xVpCNVTl7ZU+20MKJff2FTHwCkBtC0JaDMv4Ofwq+Hrm4Yb0HhpdkZCNkOKJowc=
+trusted comment: timestamp:1626982092	file:vulnerabilities.json
+ZdKDlTAAheYyJP2a1WiWVNkxlxUNIkBRHGNCZJnD/TZGMNestQ6fW5flRDabyXhj4I27TlQQJlCi989gPe9UAw==


### PR DESCRIPTION
This updates the vulnerability info to report 10.0.1 (first Berlin release) up until v1.10.5 to be not London-ready. 

Test:
```
geth version-check --check.url file:///home/user/go/src/github.com/ethereum/go-ethereum/cmd/geth/testdata/vcheck/vulnerabilities.json --check.version Geth/v1.10.5-unstable-3
INFO [07-22|21:30:29.562] Checking vulnerabilities                 version=Geth/v1.10.5-unstable-3 url=file:///home/user/go/src/github.com/ethereum/go-ethereum/cmd/geth/testdata/vcheck/vulnerabilities.json
## Vulnerable to GETH-2021-01 (Not ready for London upgrade)

Severity: High
Summary : The client is not ready for the 'London' technical upgrade, and will deviate from the canonical chain when the London upgrade occurs (at block '12965000' around August 4, 2021.
Fixed in: v1.10.6
References:
	- https://github.com/ethereum/eth1.0-specs/blob/master/network-upgrades/mainnet-upgrades/london.md
	- https://notes.ethereum.org/@timbeiko/ropsten-postmortem

```