### PR TITLE
[DOCS] update vulnerabilities

### DIFF
--- a/docs/_vulnerabilities/vulnerabilities.json
+++ b/docs/_vulnerabilities/vulnerabilities.json
@@ -100,5 +100,20 @@
     "severity": "High",
     "CVE": "CVE-2020-26265",
     "check": "(Geth\\/v1\\.9\\.(4|5|6|7|8|9)-.*)|(Geth\\/v1\\.9\\.1\\d-.*)$"
+  },
+  {
+    "name": "Not ready for London upgrade",
+    "uid": "GETH-2021-01",
+    "summary": "The client is not ready for the 'London' technical upgrade, and will deviate from the canonical chain when the London upgrade occurs (at block '12965000' around August 4, 2021.",
+    "description": "At (or around) August 4, Ethereum will undergo a technical upgrade called 'London'. Clients not upgraded will fail to progress on the canonical chain.",
+    "links": [
+      "https://github.com/ethereum/eth1.0-specs/blob/master/network-upgrades/mainnet-upgrades/london.md",
+      "https://notes.ethereum.org/@timbeiko/ropsten-postmortem"
+    ],
+    "introduced": "v1.10.1",
+    "fixed": "v1.10.6",
+    "published": "2020-12-10",
+    "severity": "High",
+    "check": "(Geth\\/v1\\.10\\.(1|2|3|4|5)-.*)$"
   }
 ]

--- a/docs/_vulnerabilities/vulnerabilities.json.minisig
+++ b/docs/_vulnerabilities/vulnerabilities.json.minisig
@@ -1,4 +1,4 @@
 untrusted comment: signature from minisign secret key
-RWQk7Lo5TQgd+0Mtk5yL9YI4wcssqdS5gMvk42XA/nHPyjp0GDntKwiqidpzWQoIwb9wm42+aDprgdhxZM0qrSKOZHelOytK+As=
-trusted comment: timestamp:1616697710	file:vulnerabilities.json
-jL7R7rHrxAoHH49KMyrQOkUCjRsHGa7qxVWkdz9Nb5QAavtVH3lHO3Rg/WQtpLJQmW2nYpaloKOJIQuE5ZI/AA==
+RWQk7Lo5TQgd+4GvOo3mu4yn1fe38AaBhs41V+ldNclGaCAiJ14i/GAvaXISL9b5+K/8HE9YLBVwqrcoJwaqaGPcXd4023FTxwI=
+trusted comment: timestamp:1626982808	file:vulnerabilities.json
+G9/AvsE90wCD5Z0VXx3fuJnrolE/AAxS6y9d8G/lXvoyvAWrMx41MiIj+pz4OwcnhyQzOYo2+7nSza9H22g6DA==


### PR DESCRIPTION
This updates the vulnerability info to report 10.0.1 (first Berlin release) up until v1.10.5 to be not London-ready. 

Test:
```
geth version-check --check.url file:///home/user/QubesIncoming/vault/vulnerabilities.json --check.version Geth/v1.10.1-unstable-3
INFO [07-22|21:43:25.256] Checking vulnerabilities                 version=Geth/v1.10.1-unstable-3 url=file:///home/user/QubesIncoming/vault/vulnerabilities.json
## Vulnerable to GETH-2021-01 (Not ready for London upgrade)

Severity: High
Summary : The client is not ready for the 'London' technical upgrade, and will deviate from the canonical chain when the London upgrade occurs (at block '12965000' around August 4, 2021.
Fixed in: v1.10.6
References:
	- https://github.com/ethereum/eth1.0-specs/blob/master/network-upgrades/mainnet-upgrades/london.md
	- https://notes.ethereum.org/@timbeiko/ropsten-postmortem

```