### PR TITLE
eth, internal: add debug_getBlockReceipts

### DIFF
--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -1600,9 +1600,13 @@ func (s *PublicTransactionPoolAPI) GetTransactionReceipt(ctx context.Context, ha
 	}
 	receipt := receipts[index]
 
+	return ToTransactionReceipt(ctx, s.b, tx, receipt, blockHash, hash, blockNumber, index)
+}
+
+func ToTransactionReceipt(ctx context.Context, b Backend, tx *types.Transaction, receipt *types.Receipt, blockHash common.Hash, hash common.Hash, blockNumber uint64, index uint64) (map[string]interface{}, error) {
 	// Derive the sender.
 	bigblock := new(big.Int).SetUint64(blockNumber)
-	signer := types.MakeSigner(s.b.ChainConfig(), bigblock)
+	signer := types.MakeSigner(b.ChainConfig(), bigblock)
 	from, _ := types.Sender(signer, tx)
 
 	fields := map[string]interface{}{
@@ -1620,10 +1624,10 @@ func (s *PublicTransactionPoolAPI) GetTransactionReceipt(ctx context.Context, ha
 		"type":              hexutil.Uint(tx.Type()),
 	}
 	// Assign the effective gas price paid
-	if !s.b.ChainConfig().IsLondon(bigblock) {
+	if !b.ChainConfig().IsLondon(bigblock) {
 		fields["effectiveGasPrice"] = hexutil.Uint64(tx.GasPrice().Uint64())
 	} else {
-		header, err := s.b.HeaderByHash(ctx, blockHash)
+		header, err := b.HeaderByHash(ctx, blockHash)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/web3ext/web3ext.go
+++ b/internal/web3ext/web3ext.go
@@ -453,6 +453,12 @@ web3._extend({
 			call: 'debug_freezeClient',
 			params: 1,
 		}),
+		new web3._extend.Method({
+			name: 'getBlockReceipts',
+			call: 'debug_getBlockReceipts',
+			params: 1,
+			inputFormatter: [null],
+		}),
 	],
 	properties: []
 });


### PR DESCRIPTION
Implements a new RPC API: debug_getBlockReceipts.  It returns receipts by block hash.