### PR TITLE
core/rawdb: close database in test to avoid goroutine leak

### DIFF
--- a/core/rawdb/accessors_chain_test.go
+++ b/core/rawdb/accessors_chain_test.go
@@ -494,6 +494,9 @@ func TestAncientStorage(t *testing.T) {
 	if blob := ReadTdRLP(db, fakeHash, number); len(blob) != 0 {
 		t.Fatalf("invalid td returned")
 	}
+	if err := db.Close(); err != nil {
+		t.Fatalf("failed to close database")
+	}
 }
 
 func TestCanonicalHashIteration(t *testing.T) {

--- a/core/rawdb/accessors_chain_test.go
+++ b/core/rawdb/accessors_chain_test.go
@@ -444,6 +444,7 @@ func TestAncientStorage(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to create database with ancient backend")
 	}
+	defer db.Close()
 	// Create a test block
 	block := types.NewBlockWithHeader(&types.Header{
 		Number:      big.NewInt(0),
@@ -493,9 +494,6 @@ func TestAncientStorage(t *testing.T) {
 	}
 	if blob := ReadTdRLP(db, fakeHash, number); len(blob) != 0 {
 		t.Fatalf("invalid td returned")
-	}
-	if err := db.Close(); err != nil {
-		t.Fatalf("failed to close database")
 	}
 }
 


### PR DESCRIPTION
In core/rawdb/accessors_chain_test.go:435
```go
func TestAncientStorage(t *testing.T) {
}
```
db never close so goroutine created at core/rawdb/database.go:199 never return:
```go
...
	if !frdb.readonly {
		frdb.wg.Add(1)
		go func() {
			frdb.freeze(db)    <==== not return until Close been call
			frdb.wg.Done()
		}()
	}
...
```