### PR TITLE
core: use blockchain's block cache for headers

### DIFF
--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -2417,12 +2417,22 @@ func (bc *BlockChain) GetTdByHash(hash common.Hash) *big.Int {
 // GetHeader retrieves a block header from the database by hash and number,
 // caching it if found.
 func (bc *BlockChain) GetHeader(hash common.Hash, number uint64) *types.Header {
+	// Blockchain might have cached the whole block, only if not go to headerchain
+	if block, ok := bc.blockCache.Get(hash); ok {
+		return block.(*types.Block).Header()
+	}
+
 	return bc.hc.GetHeader(hash, number)
 }
 
 // GetHeaderByHash retrieves a block header from the database by hash, caching it if
 // found.
 func (bc *BlockChain) GetHeaderByHash(hash common.Hash) *types.Header {
+	// Blockchain might have cached the whole block, only if not go to headerchain
+	if block, ok := bc.blockCache.Get(hash); ok {
+		return block.(*types.Block).Header()
+	}
+
 	return bc.hc.GetHeaderByHash(hash)
 }
 


### PR DESCRIPTION
When looking at #23277 I noticed that `GetTransactionReceipt` fetches the same block body twice and its header once from storage. This PR targets one of those, i.e. getting the header of a block when that block is already cached in `Blockchain`.

Alternatively I could warm the headerchain's cache when a block is cached.

This only saves one lookup for each block that's cached (when the header is not)..