### PR TITLE
tests: avoid performance tests

### DIFF
--- a/tests/state_test.go
+++ b/tests/state_test.go
@@ -42,6 +42,7 @@ func TestState(t *testing.T) {
 
 	// Very time consuming
 	st.skipLoad(`^stTimeConsuming/`)
+	st.skipLoad(`.*vmPerformance/loop.*`)
 
 	// Uses 1GB RAM per tested fork
 	st.skipLoad(`^stStaticCall/static_Call1MB`)


### PR DESCRIPTION
Without this PR:
```
[user@work go-ethereum]$ go test ./tests --run TestState --count 1
ok      github.com/ethereum/go-ethereum/tests    111.655s
```
With this PR:
```
[user@work go-ethereum]$ go test ./tests --run TestState --count 1
ok      github.com/ethereum/go-ethereum/tests    54.563s
```
Let's see if it makes any difference on travis/appveyor