### PR TITLE
internal/ethapi/api, accounts/abi/bind: Cap highest gas limit by account balance for 1559 fee parameters

### DIFF
--- a/accounts/abi/bind/backends/simulated.go
+++ b/accounts/abi/bind/backends/simulated.go
@@ -488,11 +488,10 @@ func (b *SimulatedBackend) EstimateGas(ctx context.Context, call ethereum.CallMs
 	} else {
 		hi = b.pendingBlock.GasLimit()
 	}
-
 	// Normalize the max fee per gas the call is willing to spend.
 	var feeCap *big.Int
 	if call.GasPrice != nil && (call.GasFeeCap != nil || call.GasTipCap != nil) {
-		return 0, errors.New("both gasPrice and (gasFeeCap or gasTipCap) specified")
+		return 0, errors.New("both gasPrice and (maxFeePerGas or maxPriorityFeePerGas) specified")
 	} else if call.GasPrice != nil {
 		feeCap = call.GasPrice
 	} else if call.GasFeeCap != nil {
@@ -500,7 +499,6 @@ func (b *SimulatedBackend) EstimateGas(ctx context.Context, call ethereum.CallMs
 	} else {
 		feeCap = common.Big0
 	}
-
 	// Recap the highest gas allowance with account's balance.
 	if feeCap.BitLen() != 0 {
 		balance := b.pendingState.GetBalance(call.From) // from can't be nil

--- a/accounts/abi/bind/backends/simulated.go
+++ b/accounts/abi/bind/backends/simulated.go
@@ -488,8 +488,21 @@ func (b *SimulatedBackend) EstimateGas(ctx context.Context, call ethereum.CallMs
 	} else {
 		hi = b.pendingBlock.GasLimit()
 	}
+
+	// Normalize the max fee per gas the call is willing to spend.
+	var feeCap *big.Int
+	if call.GasPrice != nil && (call.GasFeeCap != nil || call.GasTipCap != nil) {
+		return 0, errors.New("both gasPrice and (gasFeeCap or gasTipCap) specified")
+	} else if call.GasPrice != nil {
+		feeCap = call.GasPrice
+	} else if call.GasFeeCap != nil {
+		feeCap = call.GasFeeCap
+	} else {
+		feeCap = common.Big0
+	}
+
 	// Recap the highest gas allowance with account's balance.
-	if call.GasPrice != nil && call.GasPrice.BitLen() != 0 {
+	if feeCap.BitLen() != 0 {
 		balance := b.pendingState.GetBalance(call.From) // from can't be nil
 		available := new(big.Int).Set(balance)
 		if call.Value != nil {
@@ -498,14 +511,14 @@ func (b *SimulatedBackend) EstimateGas(ctx context.Context, call ethereum.CallMs
 			}
 			available.Sub(available, call.Value)
 		}
-		allowance := new(big.Int).Div(available, call.GasPrice)
+		allowance := new(big.Int).Div(available, feeCap)
 		if allowance.IsUint64() && hi > allowance.Uint64() {
 			transfer := call.Value
 			if transfer == nil {
 				transfer = new(big.Int)
 			}
 			log.Warn("Gas estimation capped by limited funds", "original", hi, "balance", balance,
-				"sent", transfer, "gasprice", call.GasPrice, "fundable", allowance)
+				"sent", transfer, "feecap", feeCap, "fundable", allowance)
 			hi = allowance.Uint64()
 		}
 	}

--- a/accounts/abi/bind/backends/simulated_test.go
+++ b/accounts/abi/bind/backends/simulated_test.go
@@ -580,6 +580,26 @@ func TestEstimateGasWithPrice(t *testing.T) {
 			Value:    big.NewInt(100000000000),
 			Data:     nil,
 		}, 21000, errors.New("gas required exceeds allowance (10999)")}, // 10999=(2.2ether-1000wei)/(2e14)
+
+		{"EstimateEIP1559WithHighFees", ethereum.CallMsg{
+			From:      addr,
+			To:        &addr,
+			Gas:       0,
+			GasFeeCap: big.NewInt(1e14), // maxgascost = 2.1ether
+			GasTipCap: big.NewInt(1),
+			Value:     big.NewInt(1e17), // the remaining balance for fee is 2.1ether
+			Data:      nil,
+		}, params.TxGas, nil},
+
+		{"EstimateEIP1559WithSuperHighFees", ethereum.CallMsg{
+			From:      addr,
+			To:        &addr,
+			Gas:       0,
+			GasFeeCap: big.NewInt(1e14), // maxgascost = 2.1ether
+			GasTipCap: big.NewInt(1),
+			Value:     big.NewInt(1e17 + 1), // the remaining balance for fee is 2.1ether
+			Data:      nil,
+		}, params.TxGas, errors.New("gas required exceeds allowance (20999)")}, // 20999=(2.2ether-0.1ether-1wei)/(1e14)
 	}
 	for i, c := range cases {
 		got, err := sim.EstimateGas(context.Background(), c.message)
@@ -591,6 +611,9 @@ func TestEstimateGasWithPrice(t *testing.T) {
 				t.Fatalf("test %d: expect error, want %v, got %v", i, c.expectError, err)
 			}
 			continue
+		}
+		if c.expectError == nil && err != nil {
+			t.Fatalf("test %d: didn't expect error, got %v", i, err)
 		}
 		if got != c.expect {
 			t.Fatalf("test %d: gas estimation mismatch, want %d, got %d", i, c.expect, got)

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -477,7 +477,7 @@ func (s *PrivateAccountAPI) SignTransaction(ctx context.Context, args Transactio
 	if args.Nonce == nil {
 		return nil, fmt.Errorf("nonce not specified")
 	}
-	// Before actually sign the transaction, ensure the transaction fee is reasonable.
+	// Before actually signing the transaction, ensure the transaction fee is reasonable.
 	tx := args.toTransaction()
 	if err := checkTxFee(tx.GasPrice(), tx.Gas(), s.b.RPCTxFeeCap()); err != nil {
 		return nil, err


### PR DESCRIPTION
Currently, you can call `eth_estimateGas` with EIP-1559 fee parameters and it won't cap the gas limits it tries based on the account balance. This can cause an `ErrInsufficientFunds` to be propagated back to the users if they can't afford the initial `hi * maxFeeCapPerGas + value`.

Before:
```console
$ curl http://localhost:8645 -H 'Content-Type: application/json' -d '{"method":"eth_estimateGas","id":1,"jsonrpc":"2.0", "params":[{"type":"0x2","maxFeePerGas":"0xb2d05e00","maxPriorityFeePerGas":"0xb2d05e00","value":"0x2386f26fc10000","from":"0xe77162b7d2ceb3625a4993bab557403a7b706f18","to":"0xe77162b7d2ceb3625a4993bab557403a7b706f18","data":"0x"}]}' | jq .
{
  "jsonrpc": "2.0",
  "id": 1,
  "error": {
    "code": -32000,
    "message": "err: insufficient funds for gas * price + value: address 0xe77162b7D2CEb3625a4993Bab557403a7B706F18 have 50000000000000000 want 54943570000000000 (supplied gas 14981190)"
  }
}
```

After:
```console
$ curl http://localhost:8645 -H 'Content-Type: application/json' -d '{"method":"eth_estimateGas","i
d":1,"jsonrpc":"2.0", "params":[{"type":"0x2","maxFeePerGas":"0xb2d05e00","maxPriorityFeePerGas":"0xb2d05e00","value":"0x2386f26fc10
000","from":"0xe77162b7d2ceb3625a4993bab557403a7b706f18","to":"0xe77162b7d2ceb3625a4993bab557403a7b706f18","data":"0x"}]}' | jq .
{
  "jsonrpc": "2.0",
  "id": 1,
  "result": "0x5208"
}
```

*Note that these request are against a Gorli node.*