### PR TITLE
RPC API:The miner returned by Block is consensus.Engine.Author

### DIFF
--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -740,6 +740,9 @@ func (s *PublicBlockChainAPI) GetBlockByNumber(ctx context.Context, number rpc.B
 			for _, field := range []string{"hash", "nonce", "miner"} {
 				response[field] = nil
 			}
+		} else if err == nil {
+			author, _ := s.b.Engine().Author(block.Header())
+			response["miner"] = author
 		}
 		return response, err
 	}
@@ -1233,6 +1236,8 @@ func RPCMarshalBlock(block *types.Block, inclTx bool, fullTx bool) (map[string]i
 func (s *PublicBlockChainAPI) rpcMarshalHeader(ctx context.Context, header *types.Header) map[string]interface{} {
 	fields := RPCMarshalHeader(header)
 	fields["totalDifficulty"] = (*hexutil.Big)(s.b.GetTd(ctx, header.Hash()))
+	author, _ := s.b.Engine().Author(header)
+	fields["miner"] = author
 	return fields
 }
 
@@ -1246,6 +1251,8 @@ func (s *PublicBlockChainAPI) rpcMarshalBlock(ctx context.Context, b *types.Bloc
 	if inclTx {
 		fields["totalDifficulty"] = (*hexutil.Big)(s.b.GetTd(ctx, b.Hash()))
 	}
+	author, _ := s.b.Engine().Author(b.Header())
+	fields["miner"] = author
 	return fields, err
 }
 


### PR DESCRIPTION
If the poa consensus mechanism is used, the miner of each block will be 0x0000000000000000000000000000000000000000, modify the author method of returning to the engine.

RPC API:The miner returned by Block is consensus.Engine.Author(block.Header())

Also, implemented tests for:   
eth_getBlockByNumber eth_getBlockByHash