### PR TITLE
Update clique_getSnapshot in RPC (ns-clique.md)

### DIFF
--- a/docs/_rpc/ns-clique.md
+++ b/docs/_rpc/ns-clique.md
@@ -16,7 +16,7 @@ Retrieves a snapshot of all clique state at a given block.
 | Client  | Method invocation                                          |
 |:--------|------------------------------------------------------------|
 | Console | `clique.getSnapshot(blockNumber)`                          |
-| RPC     | `{"method": "clique_getSnapsnot", "params": [blockNumber]}` |
+| RPC     | `{"method": "clique_getSnapshot", "params": [blockNumber]}` |
 
 Example:
 


### PR DESCRIPTION
clique_getSnapshot in RPC changed from `{"method": "clique_getSnapsnot", "params": [blockNumber]}` to `{"method": "clique_getSnapshot", "params": [blockNumber]}`