### PR TITLE
Follow convention for balanceCheck

### DIFF
--- a/core/state_transition.go
+++ b/core/state_transition.go
@@ -193,7 +193,7 @@ func (st *StateTransition) buyGas() error {
 	if st.gasFeeCap != nil {
 		balanceCheck = new(big.Int).SetUint64(st.msg.Gas())
 		balanceCheck = balanceCheck.Mul(balanceCheck, st.gasFeeCap)
-		balanceCheck.Add(balanceCheck, st.value)
+		balanceCheck = balanceCheck.Add(balanceCheck, st.value)
 	}
 	if have, want := st.state.GetBalance(st.msg.From()), balanceCheck; have.Cmp(want) < 0 {
 		return fmt.Errorf("%w: address %v have %v want %v", ErrInsufficientFunds, st.msg.From().Hex(), have, want)


### PR DESCRIPTION
This PR updates the `balanceCheck` variable while also assigning it back to balanceCheck. The `Add` function already sets the value, but this seems to be the style used most often throughout the codebase, so it seemed to make sense to update it here to follow the convention.