### PR TITLE
cmd/utils: actually show Aliased Flags as deprecated

### DIFF
--- a/cmd/utils/flags_legacy.go
+++ b/cmd/utils/flags_legacy.go
@@ -77,4 +77,4 @@ func showDeprecated(*cli.Context) {
 
 for _, flag := range DeprecatedFlags {
 		fmt.Println(flag.String())
-	}
+}

--- a/cmd/utils/flags_legacy.go
+++ b/cmd/utils/flags_legacy.go
@@ -74,13 +74,7 @@ func showDeprecated(*cli.Context) {
 	fmt.Println("The following flags are deprecated and will be removed in the future!")
 	fmt.Println("--------------------------------------------------------------------")
 	fmt.Println()
-	// These are the deprecated aliased flags
-	fmt.Println("--nousb")
-	fmt.Println("--rpc")
-	fmt.Println("--rpcaddr value")
-	fmt.Println("--rpcport value")
-	fmt.Println("--rpccorsdomain value")
-	fmt.Println("--rpcvhosts value")
-	fmt.Println("--rpcapi value")
-	fmt.Println()
-}
+
+for _, flag := range DeprecatedFlags {
+		fmt.Println(flag.String())
+	}

--- a/cmd/utils/flags_legacy.go
+++ b/cmd/utils/flags_legacy.go
@@ -75,6 +75,11 @@ func showDeprecated(*cli.Context) {
 	fmt.Println("--------------------------------------------------------------------")
 	fmt.Println()
 	// TODO remove when there are newly deprecated flags
-	fmt.Println("no deprecated flags to show at this time")
-	fmt.Println()
+	fmt.Println("--nousb")
+	fmt.Println("--rpc")
+	fmt.Println("--rpcaddr value")
+	fmt.Println("--rpcport value")
+	fmt.Println("--rpccorsdomain value")
+	fmt.Println("--rpcvhosts value")
+	fmt.Println("--rpcapi value")
 }

--- a/cmd/utils/flags_legacy.go
+++ b/cmd/utils/flags_legacy.go
@@ -74,7 +74,7 @@ func showDeprecated(*cli.Context) {
 	fmt.Println("The following flags are deprecated and will be removed in the future!")
 	fmt.Println("--------------------------------------------------------------------")
 	fmt.Println()
-	// TODO remove when there are newly deprecated flags
+	// These are the deprecated aliased flags
 	fmt.Println("--nousb")
 	fmt.Println("--rpc")
 	fmt.Println("--rpcaddr value")
@@ -82,4 +82,5 @@ func showDeprecated(*cli.Context) {
 	fmt.Println("--rpccorsdomain value")
 	fmt.Println("--rpcvhosts value")
 	fmt.Println("--rpcapi value")
+	fmt.Println()
 }


### PR DESCRIPTION
I'm working on getting the Aliased RPC flags removed entirely over at #23358, but, until then, this will actually show the RPC commands as deprecated when someone runs ``geth show-deprecated-flags``.