### PR TITLE
Fix outdated statedb Prepare comment

### DIFF
--- a/core/state/statedb.go
+++ b/core/state/statedb.go
@@ -878,7 +878,7 @@ func (s *StateDB) IntermediateRoot(deleteEmptyObjects bool) common.Hash {
 	return s.trie.Hash()
 }
 
-// Prepare sets the current transaction hash and index and block hash which is
+// Prepare sets the current transaction hash and index which are
 // used when the EVM emits new state logs.
 func (s *StateDB) Prepare(thash common.Hash, ti int) {
 	s.thash = thash


### PR DESCRIPTION
This PR fixes an outdated comment that states `statedb.Prepare` sets the blockHash of the statedb, when this is no longer the case.