### PR TITLE
Marshal rpc.BlockNumber to JSON correctly

### DIFF
--- a/rpc/types.go
+++ b/rpc/types.go
@@ -97,6 +97,22 @@ func (bn *BlockNumber) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+// MarshalText implements encoding.TextMarshaler. It marshals:
+// - "latest", "earliest" or "pending" as strings
+// - other numbers as hex
+func (bn BlockNumber) MarshalText() ([]byte, error) {
+	switch bn {
+	case EarliestBlockNumber:
+		return []byte("earliest"), nil
+	case LatestBlockNumber:
+		return []byte("latest"), nil
+	case PendingBlockNumber:
+		return []byte("pending"), nil
+	default:
+		return hexutil.Uint64(bn).MarshalText()
+	}
+}
+
 func (bn BlockNumber) Int64() int64 {
 	return (int64)(bn)
 }

--- a/rpc/types_test.go
+++ b/rpc/types_test.go
@@ -18,6 +18,7 @@ package rpc
 
 import (
 	"encoding/json"
+	"reflect"
 	"testing"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -120,5 +121,35 @@ func TestBlockNumberOrHash_UnmarshalJSON(t *testing.T) {
 			num != expectedNum || numOk != expectedNumOk {
 			t.Errorf("Test %d got unexpected value, want %v, got %v", i, test.expected, bnh)
 		}
+	}
+}
+
+func TestBlockNumberOrHash_WithNumber_MarshalAndUnmarshal(t *testing.T) {
+	tests := []struct {
+		name   string
+		number int64
+	}{
+		{"max", math.MaxInt64},
+		{"pending", int64(PendingBlockNumber)},
+		{"latest", int64(LatestBlockNumber)},
+		{"earliest", int64(EarliestBlockNumber)},
+	}
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			bnh := BlockNumberOrHashWithNumber(BlockNumber(test.number))
+			marshalled, err := json.Marshal(bnh)
+			if err != nil {
+				t.Fatal("cannot marshal:", err)
+			}
+			var unmarshalled BlockNumberOrHash
+			err = json.Unmarshal(marshalled, &unmarshalled)
+			if err != nil {
+				t.Fatal("cannot unmarshal:", err)
+			}
+			if !reflect.DeepEqual(bnh, unmarshalled) {
+				t.Fatalf("wrong result: expected %v, got %v", bnh, unmarshalled)
+			}
+		})
 	}
 }


### PR DESCRIPTION
Currently rpc.BlockNumber is marshalled to JSON as a numeric value ```{"blockNumber":123}``` which is wrong because BlockNumber.UnmarshalJSON() wants it either to be hex-encoded or have a special value ("earliest"/"latest"/"pending"). As a result, the chain rpc.BlockNumberOrHashWithNumber(123) -> json.Marshal() -> json.Unmarshal() fails with an error "cannot unmarshal object into Go value of type string".

The PR fixes the issue by adding BlockNumber.MarshalText() method which outputs either a hex-encoded number or a special string depending on the given block number.