### PR TITLE
internal/ethapi/api: return maxFeePerGas for gasPrice for EIP-1559 txs

### DIFF
--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -1323,7 +1323,7 @@ func newRPCTransaction(tx *types.Transaction, blockHash common.Hash, blockNumber
 			price := math.BigMin(new(big.Int).Add(tx.GasTipCap(), baseFee), tx.GasFeeCap())
 			result.GasPrice = (*hexutil.Big)(price)
 		} else {
-			result.GasPrice = nil
+			result.GasPrice = (*hexutil.Big)(tx.GasFeeCap())
 		}
 	}
 	return result


### PR DESCRIPTION
Currently geth returns ~~`0`~~ `null`(console converts to `0`) for `gasPrice` for pending transactions:

```
> params = { from: me, to: me, maxFeePerGas: "0x1000000000", maxTipPerGas: "0x0", gas: "0x5208" }
{
  from: "0xc0ffee61108b46c8b84c63df14e3a607ac981e93",
  gas: "0x5208",
  maxFeePerGas: "0x1000000000",
  maxTipPerGas: "0x0",
  to: "0xc0ffee61108b46c8b84c63df14e3a607ac981e93"
}
> personal.sendTransaction(params)
"0xd7291f16ce57eb4e6aaae4b3d81f3f16ed947763cbed230eef3d9d1cb395fa5d"
> eth.getTransaction("0xd7291f16ce57eb4e6aaae4b3d81f3f16ed947763cbed230eef3d9d1cb395fa5d")
{
  accessList: [],
  blockHash: null,
  blockNumber: null,
  chainId: "0x5",
  from: "0xc0ffee61108b46c8b84c63df14e3a607ac981e93",
  gas: 21000,
  gasPrice: 0,
  hash: "0xd7291f16ce57eb4e6aaae4b3d81f3f16ed947763cbed230eef3d9d1cb395fa5d",
  input: "0x",
  maxFeePerGas: "0x1000000000",
  maxPriorityFeePerGas: "0x12a05f1f9",
  nonce: 0,
  r: "0x10f320d15d1d8c84ae687c9f446379d5c4c76e16146361349002e0af77996fc0",
  s: "0x23c3e3bf21d272a1978f8923603171e462740764f5e03c1ef859f318fc72b34d",
  to: "0xc0ffee61108b46c8b84c63df14e3a607ac981e93",
  transactionIndex: null,
  type: "0x2",
  v: "0x1",
  value: 0
}
```

After this change, it will return `maxFeePerGas` as [specified by the RPC spec](https://github.com/ethereum/eth1.0-specs/pull/251#pullrequestreview-716283338):

```
> params = { from: me, to: me, maxFeePerGas: "0x1000000000", maxTipPerGas: "0x0", gas: "0x5208" }
{
  from: "0xc0ffee61108b46c8b84c63df14e3a607ac981e93",
  gas: "0x5208",
  maxFeePerGas: "0x1000000000",
  maxTipPerGas: "0x0",
  to: "0xc0ffee61108b46c8b84c63df14e3a607ac981e93"
}
> personal.sendTransaction(params)
"0x646d8b7343e06c3f944c022c7f2c898a7ff8a84c714f967bd75f60d3ca04710b"
> eth.getTransaction("0x646d8b7343e06c3f944c022c7f2c898a7ff8a84c714f967bd75f60d3ca04710b")
{
  accessList: [],
  blockHash: null,
  blockNumber: null,
  chainId: "0x5",
  from: "0xc0ffee61108b46c8b84c63df14e3a607ac981e93",
  gas: 21000,
  gasPrice: 68719476736,
  hash: "0x646d8b7343e06c3f944c022c7f2c898a7ff8a84c714f967bd75f60d3ca04710b",
  input: "0x",
  maxFeePerGas: "0x1000000000",
  maxPriorityFeePerGas: "0x12a05f1f9",
  nonce: 1,
  r: "0xf755782c9d7455ce2ffddafbb974faabc24801062d86ff471b3d7a132c3bb88d",
  s: "0x28fee09dc49d86c0214ee7c95cce30fd658494ee5810ccfe2649fbd3035ae370",
  to: "0xc0ffee61108b46c8b84c63df14e3a607ac981e93",
  transactionIndex: null,
  type: "0x2",
  v: "0x1",
  value: 0
}
```

edit: I realize I included an invalid value `maxTipPerGas`, but it ended up just estimating a priority fee so I don't think it affects the overall issue at all.