### PR TITLE
eth/fetcher: fix test to avoid hanging. Partial fix for #23331

### DIFF
--- a/eth/fetcher/tx_fetcher_test.go
+++ b/eth/fetcher/tx_fetcher_test.go
@@ -304,7 +304,7 @@ func TestTransactionFetcherSingletonRequesting(t *testing.T) {
 func TestTransactionFetcherFailedRescheduling(t *testing.T) {
 	// Create a channel to control when tx requests can fail
 	proceed := make(chan struct{})
-
+	defer close(proceed)
 	testTransactionFetcherParallel(t, txFetcherTest{
 		init: func() *TxFetcher {
 			return NewTxFetcher(
@@ -1262,6 +1262,17 @@ func testTransactionFetcher(t *testing.T, tt txFetcherTest) {
 
 	fetcher.Start()
 	defer fetcher.Stop()
+
+	defer func() { // drain the wait chan on exit
+		for {
+			select {
+			case <-wait:
+				continue
+			default:
+				return
+			}
+		}
+	}()
 
 	// Crunch through all the test steps and execute them
 	for i, step := range tt.steps {

--- a/eth/fetcher/tx_fetcher_test.go
+++ b/eth/fetcher/tx_fetcher_test.go
@@ -304,7 +304,6 @@ func TestTransactionFetcherSingletonRequesting(t *testing.T) {
 func TestTransactionFetcherFailedRescheduling(t *testing.T) {
 	// Create a channel to control when tx requests can fail
 	proceed := make(chan struct{})
-	defer close(proceed)
 	testTransactionFetcherParallel(t, txFetcherTest{
 		init: func() *TxFetcher {
 			return NewTxFetcher(
@@ -1267,7 +1266,6 @@ func testTransactionFetcher(t *testing.T, tt txFetcherTest) {
 		for {
 			select {
 			case <-wait:
-				continue
 			default:
 				return
 			}

--- a/eth/filters/filter_system_test.go
+++ b/eth/filters/filter_system_test.go
@@ -301,12 +301,15 @@ func TestLogFilterCreation(t *testing.T) {
 	)
 
 	for i, test := range testCases {
-		_, err := api.NewFilter(test.crit)
-		if test.success && err != nil {
+		id, err := api.NewFilter(test.crit)
+		if err != nil && test.success {
 			t.Errorf("expected filter creation for case %d to success, got %v", i, err)
 		}
-		if !test.success && err == nil {
-			t.Errorf("expected testcase %d to fail with an error", i)
+		if err == nil {
+			api.UninstallFilter(id)
+			if !test.success {
+				t.Errorf("expected testcase %d to fail with an error", i)
+			}
 		}
 	}
 }


### PR DESCRIPTION
Issue #23331 contains some very interesting cases of hard-to-find subtle bugs. This PR contains (so far) partial fixes for them. I'm not sure how to best verify the fixes though. 

This PR fixes (?) the following ones:

- [ ] 1. 
https://github.com/ethereum/go-ethereum/blob/56e9001a1a8ddecc478943170b00207ef46109b9/eth/downloader/downloader_test.go#L1517
- [x] 2. https://github.com/ethereum/go-ethereum/blob/56e9001a1a8ddecc478943170b00207ef46109b9/eth/fetcher/tx_fetcher_test.go#L1127
- [x] 3. https://github.com/ethereum/go-ethereum/blob/d8ff53dfb8a516f47db37dbc7fd7ad18a1e8a125/eth/fetcher/tx_fetcher_test.go#L1213
- [ ] 4. https://github.com/ethereum/go-ethereum/blob/56e9001a1a8ddecc478943170b00207ef46109b9/eth/filters/filter_system_test.go#L217
- [x] 5. https://github.com/ethereum/go-ethereum/blob/56e9001a1a8ddecc478943170b00207ef46109b9/eth/filters/filter_system_test.go#L274
- [ ] 6. https://github.com/ethereum/go-ethereum/blob/56e9001a1a8ddecc478943170b00207ef46109b9/eth/filters/filter_system_test.go#L477
