### PR TITLE
internal/debug: remove deprecated flags

### DIFF
--- a/internal/debug/flags.go
+++ b/internal/debug/flags.go
@@ -139,20 +139,12 @@ func Setup(ctx *cli.Context) error {
 	glogger.Vmodule(vmodule)
 
 	debug := ctx.GlobalBool(debugFlag.Name)
-	if ctx.GlobalIsSet(legacyDebugFlag.Name) {
-		debug = ctx.GlobalBool(legacyDebugFlag.Name)
-		log.Warn("The flag --debug is deprecated and will be removed in the future, please use --log.debug")
-	}
 	if ctx.GlobalIsSet(debugFlag.Name) {
 		debug = ctx.GlobalBool(debugFlag.Name)
 	}
 	log.PrintOrigins(debug)
 
 	backtrace := ctx.GlobalString(backtraceAtFlag.Name)
-	if b := ctx.GlobalString(legacyBacktraceAtFlag.Name); b != "" {
-		backtrace = b
-		log.Warn("The flag --backtrace is deprecated and will be removed in the future, please use --log.backtrace")
-	}
 	if b := ctx.GlobalString(backtraceAtFlag.Name); b != "" {
 		backtrace = b
 	}

--- a/internal/debug/flags.go
+++ b/internal/debug/flags.go
@@ -90,39 +90,6 @@ var (
 		Name:  "trace",
 		Usage: "Write execution trace to the given file",
 	}
-	// (Deprecated April 2020)
-	legacyPprofPortFlag = cli.IntFlag{
-		Name:  "pprofport",
-		Usage: "pprof HTTP server listening port (deprecated, use --pprof.port)",
-		Value: 6060,
-	}
-	legacyPprofAddrFlag = cli.StringFlag{
-		Name:  "pprofaddr",
-		Usage: "pprof HTTP server listening interface (deprecated, use --pprof.addr)",
-		Value: "127.0.0.1",
-	}
-	legacyMemprofilerateFlag = cli.IntFlag{
-		Name:  "memprofilerate",
-		Usage: "Turn on memory profiling with the given rate (deprecated, use --pprof.memprofilerate)",
-		Value: runtime.MemProfileRate,
-	}
-	legacyBlockprofilerateFlag = cli.IntFlag{
-		Name:  "blockprofilerate",
-		Usage: "Turn on block profiling with the given rate (deprecated, use --pprof.blockprofilerate)",
-	}
-	legacyCpuprofileFlag = cli.StringFlag{
-		Name:  "cpuprofile",
-		Usage: "Write CPU profile to the given file (deprecated, use --pprof.cpuprofile)",
-	}
-	legacyBacktraceAtFlag = cli.StringFlag{
-		Name:  "backtrace",
-		Usage: "Request a stack trace at a specific logging statement (e.g. \"block.go:271\") (deprecated, use --log.backtrace)",
-		Value: "",
-	}
-	legacyDebugFlag = cli.BoolFlag{
-		Name:  "debug",
-		Usage: "Prepends log messages with call-site location (file and line number) (deprecated, use --log.debug)",
-	}
 )
 
 // Flags holds all command-line flags required for debugging.
@@ -139,17 +106,6 @@ var Flags = []cli.Flag{
 	blockprofilerateFlag,
 	cpuprofileFlag,
 	traceFlag,
-}
-
-// This is the list of deprecated debugging flags.
-var DeprecatedFlags = []cli.Flag{
-	legacyPprofPortFlag,
-	legacyPprofAddrFlag,
-	legacyMemprofilerateFlag,
-	legacyBlockprofilerateFlag,
-	legacyCpuprofileFlag,
-	legacyBacktraceAtFlag,
-	legacyDebugFlag,
 }
 
 var glogger *log.GlogHandler
@@ -206,19 +162,11 @@ func Setup(ctx *cli.Context) error {
 
 	// profiling, tracing
 	runtime.MemProfileRate = memprofilerateFlag.Value
-	if ctx.GlobalIsSet(legacyMemprofilerateFlag.Name) {
-		runtime.MemProfileRate = ctx.GlobalInt(legacyMemprofilerateFlag.Name)
-		log.Warn("The flag --memprofilerate is deprecated and will be removed in the future, please use --pprof.memprofilerate")
-	}
 	if ctx.GlobalIsSet(memprofilerateFlag.Name) {
 		runtime.MemProfileRate = ctx.GlobalInt(memprofilerateFlag.Name)
 	}
 
 	blockProfileRate := blockprofilerateFlag.Value
-	if ctx.GlobalIsSet(legacyBlockprofilerateFlag.Name) {
-		blockProfileRate = ctx.GlobalInt(legacyBlockprofilerateFlag.Name)
-		log.Warn("The flag --blockprofilerate is deprecated and will be removed in the future, please use --pprof.blockprofilerate")
-	}
 	if ctx.GlobalIsSet(blockprofilerateFlag.Name) {
 		blockProfileRate = ctx.GlobalInt(blockprofilerateFlag.Name)
 	}

--- a/internal/debug/flags.go
+++ b/internal/debug/flags.go
@@ -145,9 +145,6 @@ func Setup(ctx *cli.Context) error {
 	log.PrintOrigins(debug)
 
 	backtrace := ctx.GlobalString(backtraceAtFlag.Name)
-	if b := ctx.GlobalString(backtraceAtFlag.Name); b != "" {
-		backtrace = b
-	}
 	glogger.BacktraceAt(backtrace)
 
 	log.Root().SetHandler(glogger)
@@ -158,10 +155,7 @@ func Setup(ctx *cli.Context) error {
 		runtime.MemProfileRate = ctx.GlobalInt(memprofilerateFlag.Name)
 	}
 
-	blockProfileRate := blockprofilerateFlag.Value
-	if ctx.GlobalIsSet(blockprofilerateFlag.Name) {
-		blockProfileRate = ctx.GlobalInt(blockprofilerateFlag.Name)
-	}
+	blockProfileRate := ctx.GlobalInt(blockprofilerateFlag.Name)
 	Handler.SetBlockProfileRate(blockProfileRate)
 
 	if traceFile := ctx.GlobalString(traceFlag.Name); traceFile != "" {


### PR DESCRIPTION
The deprecated flags are removed in the main portion of geth, this PR removes it internally too.