### PR TITLE
core/state/pruner: fix state bloom sync permission in Windows

### DIFF
--- a/core/state/pruner/bloom.go
+++ b/core/state/pruner/bloom.go
@@ -90,7 +90,7 @@ func (bloom *stateBloom) Commit(filename, tempname string) error {
 		return err
 	}
 	// Ensure the file is synced to disk
-	f, err := os.Open(tempname)
+	f, err := os.OpenFile(tempname, os.O_RDWR, 0666)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
After writing the bloom filter for the offline pruner, we opened the file read-only and synced it to disk. This ensures that the OS flushes all it's internal buffers before we start deleting data.

Whilst on Linux calling `fsync` on a read-only file works, it does not on Windows. This PR opens the file in read-write mode to work around this quirk.

Fixes https://github.com/ethereum/go-ethereum/issues/23364.