### PR TITLE
travis: transition from docker auto builds to manual pushes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,7 +41,7 @@ jobs:
       before_install:
         - export DOCKER_CLI_EXPERIMENTAL=enabled
       script:
-        - go run build/ci.go docker -image -manifest amd64,arm64 -upload karalabe/geth-docker-test
+        - go run build/ci.go docker -image -manifest amd64,arm64 -upload ethereum/client-go
 
     - stage: build
       if: type = push
@@ -58,7 +58,7 @@ jobs:
       before_install:
         - export DOCKER_CLI_EXPERIMENTAL=enabled
       script:
-        - go run build/ci.go docker -image -manifest amd64,arm64 -upload karalabe/geth-docker-test
+        - go run build/ci.go docker -image -manifest amd64,arm64 -upload ethereum/client-go
 
     # This builder does the Ubuntu PPA upload
     - stage: build


### PR DESCRIPTION
Docker revoked our automated build capabilities on the ~29th of June. Since we don't want to upgrade the entire Ethereum org to a team plan, this PR makes the switch to manually building containers on Travis and pushing them to Docker Hub. On the upside, this also enables us to build multi-arch images with both amd64 and arm64 architectures.

This functionality has been working and pushing into [karalabe/geth-docker-test](https://hub.docker.com/repository/docker/karalabe/geth-docker-test) for the past 2 months.