### PR TITLE
ethtest: go vet warns of signature of unused function

### DIFF
--- a/cmd/devp2p/internal/ethtest/chain.go
+++ b/cmd/devp2p/internal/ethtest/chain.go
@@ -39,15 +39,6 @@ type Chain struct {
 	chainConfig *params.ChainConfig
 }
 
-func (c *Chain) WriteTo(writer io.Writer) (int64, error) {
-	for _, block := range c.blocks {
-		if err := rlp.Encode(writer, block); err != nil {
-			return 0, err
-		}
-	}
-	return int64(len(c.blocks)), nil
-}
-
 // Len returns the length of the chain.
 func (c *Chain) Len() int {
 	return len(c.blocks)

--- a/cmd/devp2p/internal/ethtest/chain.go
+++ b/cmd/devp2p/internal/ethtest/chain.go
@@ -39,14 +39,13 @@ type Chain struct {
 	chainConfig *params.ChainConfig
 }
 
-func (c *Chain) WriteTo(writer io.Writer) error {
+func (c *Chain) WriteTo(writer io.Writer) (int64, error) {
 	for _, block := range c.blocks {
 		if err := rlp.Encode(writer, block); err != nil {
-			return err
+			return 0, err
 		}
 	}
-
-	return nil
+	return int64(len(c.blocks)), nil
 }
 
 // Len returns the length of the chain.


### PR DESCRIPTION
doing a go vet

```
go vet ./...
# github.com/ethereum/go-ethereum/cmd/devp2p/internal/ethtest
cmd/devp2p/internal/ethtest/chain.go:42:17: method WriteTo(writer io.Writer) error should have signature WriteTo(io.Writer) (int64, error)
# github.com/ethereum/go-ethereum/tests/fuzzers/trie
tests/fuzzers/trie/trie-fuzzer.go:72:23: method ReadByte() byte should have signature ReadByte() (byte, error)
```

Propose to fix the 1st one.