### PR TITLE
tests/fuzzers: fix go vet warning about signature of ReadByte

### DIFF
--- a/tests/fuzzers/trie/trie-fuzzer.go
+++ b/tests/fuzzers/trie/trie-fuzzer.go
@@ -69,7 +69,7 @@ func newDataSource(input []byte) *dataSource {
 		input, bytes.NewReader(input),
 	}
 }
-func (ds *dataSource) ReadByte() byte {
+func (ds *dataSource) readByte() byte {
 	if b, err := ds.reader.ReadByte(); err != nil {
 		return 0
 	} else {
@@ -89,22 +89,22 @@ func Generate(input []byte) randTest {
 	r := newDataSource(input)
 	genKey := func() []byte {
 
-		if len(allKeys) < 2 || r.ReadByte() < 0x0f {
+		if len(allKeys) < 2 || r.readByte() < 0x0f {
 			// new key
-			key := make([]byte, r.ReadByte()%50)
+			key := make([]byte, r.readByte()%50)
 			r.Read(key)
 			allKeys = append(allKeys, key)
 			return key
 		}
 		// use existing key
-		return allKeys[int(r.ReadByte())%len(allKeys)]
+		return allKeys[int(r.readByte())%len(allKeys)]
 	}
 
 	var steps randTest
 
 	for i := 0; !r.Ended(); i++ {
 
-		step := randTestStep{op: int(r.ReadByte()) % opMax}
+		step := randTestStep{op: int(r.readByte()) % opMax}
 		switch step.op {
 		case opUpdate:
 			step.key = genKey()


### PR DESCRIPTION
go vet show a signature warning
```
go vet ./...
# github.com/ethereum/go-ethereum/cmd/devp2p/internal/ethtest
cmd/devp2p/internal/ethtest/chain.go:42:17: method WriteTo(writer io.Writer) error should have signature WriteTo(io.Writer) (int64, error)
```

I propose to fix that by making the function private.