### PR TITLE
core/vm: faster code analysis

### DIFF
--- a/core/vm/analysis.go
+++ b/core/vm/analysis.go
@@ -25,75 +25,75 @@ var lookup = [8]byte{
 	0x80, 0x40, 0x20, 0x10, 0x8, 0x4, 0x2, 0x1,
 }
 
-func (bits *bitvec) set(pos uint64) {
+func (bits bitvec) set(pos uint64) {
 	//(*bits)[pos/8] |= 0x80 >> (pos % 8)
-	(*bits)[pos/8] |= lookup[pos%8]
+	bits[pos/8] |= lookup[pos%8]
 }
 
-func (bits *bitvec) set2(pos uint64) {
+func (bits bitvec) set2(pos uint64) {
 	a := uint16(0b1100_0000_0000_0000) >> (pos % 8)
-	(*bits)[pos/8] |= byte(a >> 8)
+	bits[pos/8] |= byte(a >> 8)
 	if b := byte(a); b != 0 {
 		//	If the bit-setting affects the neigbouring byte, we can assign - no need to OR it,
 		//	since it's the first write to that byte
-		(*bits)[pos/8+1] = b
+		bits[pos/8+1] = b
 	}
 }
 
-func (bits *bitvec) set3(pos uint64) {
+func (bits bitvec) set3(pos uint64) {
 	a := uint16(0b1110_0000_0000_0000) >> (pos % 8)
-	(*bits)[pos/8] |= byte(a >> 8)
+	bits[pos/8] |= byte(a >> 8)
 	if b := byte(a); b != 0 {
-		(*bits)[pos/8+1] = b
+		bits[pos/8+1] = b
 	}
 }
 
-func (bits *bitvec) set4(pos uint64) {
+func (bits bitvec) set4(pos uint64) {
 	a := uint16(0b1111_0000_0000_0000) >> (pos % 8)
-	(*bits)[pos/8] |= byte(a >> 8)
+	bits[pos/8] |= byte(a >> 8)
 	if b := byte(a); b != 0 {
-		(*bits)[pos/8+1] = b
+		bits[pos/8+1] = b
 	}
 }
 
-func (bits *bitvec) set5(pos uint64) {
+func (bits bitvec) set5(pos uint64) {
 	a := uint16(0b1111_1000_0000_0000) >> (pos % 8)
-	(*bits)[pos/8] |= byte(a >> 8)
+	bits[pos/8] |= byte(a >> 8)
 	if b := byte(a); b != 0 {
-		(*bits)[pos/8+1] = b
+		bits[pos/8+1] = b
 	}
 }
 
-func (bits *bitvec) set6(pos uint64) {
+func (bits bitvec) set6(pos uint64) {
 	a := uint16(0b1111_1100_0000_0000) >> (pos % 8)
-	(*bits)[pos/8] |= byte(a >> 8)
+	bits[pos/8] |= byte(a >> 8)
 	if b := byte(a); b != 0 {
-		(*bits)[pos/8+1] = b
+		bits[pos/8+1] = b
 	}
 }
 
-func (bits *bitvec) set7(pos uint64) {
+func (bits bitvec) set7(pos uint64) {
 	a := uint16(0b1111_1110_0000_0000) >> (pos % 8)
-	(*bits)[pos/8] |= byte(a >> 8)
+	bits[pos/8] |= byte(a >> 8)
 	if b := byte(a); b != 0 {
-		(*bits)[pos/8+1] = b
+		bits[pos/8+1] = b
 	}
 }
 
-func (bits *bitvec) set8(pos uint64) {
+func (bits bitvec) set8(pos uint64) {
 	a := byte(0xFF >> (pos % 8))
-	(*bits)[pos/8] |= a
+	bits[pos/8] |= a
 	if ^a != 0 {
-		(*bits)[pos/8+1] = ^a
+		bits[pos/8+1] = ^a
 	}
 }
 
-func (bits *bitvec) set16(pos uint64) {
+func (bits bitvec) set16(pos uint64) {
 	a := byte(0xFF >> (pos % 8))
-	(*bits)[pos/8] |= a
-	(*bits)[pos/8+1] = 0xFF
+	bits[pos/8] |= a
+	bits[pos/8+1] = 0xFF
 	if ^a != 0 {
-		(*bits)[pos/8+2] = ^a
+		bits[pos/8+2] = ^a
 	}
 }
 

--- a/core/vm/analysis.go
+++ b/core/vm/analysis.go
@@ -16,6 +16,15 @@
 
 package vm
 
+const (
+	set2BitsMask = uint16(0b1100_0000_0000_0000)
+	set3BitsMask = uint16(0b1110_0000_0000_0000)
+	set4BitsMask = uint16(0b1111_0000_0000_0000)
+	set5BitsMask = uint16(0b1111_1000_0000_0000)
+	set6BitsMask = uint16(0b1111_1100_0000_0000)
+	set7BitsMask = uint16(0b1111_1110_0000_0000)
+)
+
 // bitvec is a bit vector which maps bytes in a program.
 // An unset bit means the byte is an opcode, a set bit means
 // it's data (i.e. argument of PUSHxx).
@@ -25,57 +34,16 @@ var lookup = [8]byte{
 	0x80, 0x40, 0x20, 0x10, 0x8, 0x4, 0x2, 0x1,
 }
 
-func (bits bitvec) set(pos uint64) {
-	//(*bits)[pos/8] |= 0x80 >> (pos % 8)
+func (bits bitvec) set1(pos uint64) {
 	bits[pos/8] |= lookup[pos%8]
 }
 
-func (bits bitvec) set2(pos uint64) {
-	a := uint16(0b1100_0000_0000_0000) >> (pos % 8)
+func (bits bitvec) setN(flag uint16, pos uint64) {
+	a := flag >> (pos % 8)
 	bits[pos/8] |= byte(a >> 8)
 	if b := byte(a); b != 0 {
 		//	If the bit-setting affects the neighbouring byte, we can assign - no need to OR it,
 		//	since it's the first write to that byte
-		bits[pos/8+1] = b
-	}
-}
-
-func (bits bitvec) set3(pos uint64) {
-	a := uint16(0b1110_0000_0000_0000) >> (pos % 8)
-	bits[pos/8] |= byte(a >> 8)
-	if b := byte(a); b != 0 {
-		bits[pos/8+1] = b
-	}
-}
-
-func (bits bitvec) set4(pos uint64) {
-	a := uint16(0b1111_0000_0000_0000) >> (pos % 8)
-	bits[pos/8] |= byte(a >> 8)
-	if b := byte(a); b != 0 {
-		bits[pos/8+1] = b
-	}
-}
-
-func (bits bitvec) set5(pos uint64) {
-	a := uint16(0b1111_1000_0000_0000) >> (pos % 8)
-	bits[pos/8] |= byte(a >> 8)
-	if b := byte(a); b != 0 {
-		bits[pos/8+1] = b
-	}
-}
-
-func (bits bitvec) set6(pos uint64) {
-	a := uint16(0b1111_1100_0000_0000) >> (pos % 8)
-	bits[pos/8] |= byte(a >> 8)
-	if b := byte(a); b != 0 {
-		bits[pos/8+1] = b
-	}
-}
-
-func (bits bitvec) set7(pos uint64) {
-	a := uint16(0b1111_1110_0000_0000) >> (pos % 8)
-	bits[pos/8] |= byte(a >> 8)
-	if b := byte(a); b != 0 {
 		bits[pos/8+1] = b
 	}
 }
@@ -130,25 +98,25 @@ func codeBitmapInternal(code, bits bitvec) bitvec {
 		}
 		switch numbits {
 		case 1:
-			bits.set(pc)
+			bits.set1(pc)
 			pc += 1
 		case 2:
-			bits.set2(pc)
+			bits.setN(set2BitsMask, pc)
 			pc += 2
 		case 3:
-			bits.set3(pc)
+			bits.setN(set3BitsMask, pc)
 			pc += 3
 		case 4:
-			bits.set4(pc)
+			bits.setN(set4BitsMask, pc)
 			pc += 4
 		case 5:
-			bits.set5(pc)
+			bits.setN(set5BitsMask, pc)
 			pc += 5
 		case 6:
-			bits.set6(pc)
+			bits.setN(set6BitsMask, pc)
 			pc += 6
 		case 7:
-			bits.set7(pc)
+			bits.setN(set7BitsMask, pc)
 			pc += 7
 		}
 	}

--- a/core/vm/analysis.go
+++ b/core/vm/analysis.go
@@ -89,6 +89,32 @@ func codeBitmapInternal(code, bits bitvec) bitvec {
 		if op < PUSH1 || op > PUSH32 {
 			continue
 		}
+		if op < PUSH8 {
+			switch op {
+			case PUSH1:
+				bits.set(pc)
+				pc += 1
+			case PUSH2:
+				bits.set2(pc)
+				pc += 2
+			case PUSH3:
+				bits.set3(pc)
+				pc += 3
+			case PUSH4:
+				bits.set4(pc)
+				pc += 4
+			case PUSH5:
+				bits.set5(pc)
+				pc += 5
+			case PUSH6:
+				bits.set6(pc)
+				pc += 6
+			case PUSH7:
+				bits.set7(pc)
+				pc += 7
+			}
+			continue
+		}
 		numbits := op - PUSH1 + 1
 		for ; numbits >= 8; numbits -= 8 {
 			bits.set8(pc) // 8

--- a/core/vm/analysis.go
+++ b/core/vm/analysis.go
@@ -21,12 +21,48 @@ package vm
 // it's data (i.e. argument of PUSHxx).
 type bitvec []byte
 
-func (bits *bitvec) set(pos uint64) {
-	(*bits)[pos/8] |= 0x80 >> (pos % 8)
+var lookup = [8]byte{
+	0x80, 0x40, 0x20, 0x10, 0x8, 0x4, 0x2, 0x1,
 }
+
+func (bits *bitvec) set(pos uint64) {
+	//(*bits)[pos/8] |= 0x80 >> (pos % 8)
+	(*bits)[pos/8] |= lookup[pos%8]
+}
+
+func (bits *bitvec) set2(pos uint64) {
+	(*bits)[pos/8+1] |= 0b1100_0000 << (8 - pos%8)
+	(*bits)[pos/8] |= 0b1100_0000 >> (pos % 8)
+}
+
+func (bits *bitvec) set3(pos uint64) {
+	(*bits)[pos/8+1] |= 0b1110_0000 << (8 - pos%8)
+	(*bits)[pos/8] |= 0b1110_0000 >> (pos % 8)
+}
+
+func (bits *bitvec) set4(pos uint64) {
+	(*bits)[pos/8+1] |= 0b1111_0000 << (8 - pos%8)
+	(*bits)[pos/8] |= 0b1111_0000 >> (pos % 8)
+}
+
+func (bits *bitvec) set5(pos uint64) {
+	(*bits)[pos/8+1] |= 0b1111_1000 << (8 - pos%8)
+	(*bits)[pos/8] |= 0b1111_1000 >> (pos % 8)
+}
+
+func (bits *bitvec) set6(pos uint64) {
+	(*bits)[pos/8+1] |= 0b1111_1100 << (8 - pos%8)
+	(*bits)[pos/8] |= 0b1111_1100 >> (pos % 8)
+}
+
+func (bits *bitvec) set7(pos uint64) {
+	(*bits)[pos/8+1] |= 0b1111_1110 << (8 - pos%8)
+	(*bits)[pos/8] |= 0b1111_1110 >> (pos % 8)
+}
+
 func (bits *bitvec) set8(pos uint64) {
-	(*bits)[pos/8] |= 0xFF >> (pos % 8)
 	(*bits)[pos/8+1] |= ^(0xFF >> (pos % 8))
+	(*bits)[pos/8] |= 0xFF >> (pos % 8)
 }
 
 // codeSegment checks if the position is in a code segment.
@@ -49,21 +85,33 @@ func codeBitmap(code []byte) bitvec {
 func codeBitmapInternal(code, bits bitvec) bitvec {
 	for pc := uint64(0); pc < uint64(len(code)); {
 		op := OpCode(code[pc])
-
-		if op >= PUSH1 && op <= PUSH32 {
-			numbits := op - PUSH1 + 1
-			pc++
-			for ; numbits >= 8; numbits -= 8 {
-				bits.set8(pc) // 8
-				pc += 8
-			}
-			for ; numbits > 0; numbits-- {
-				bits.set(pc)
-				pc++
-			}
-		} else {
-			pc++
+		pc++
+		if op < PUSH1 || op > PUSH32 {
+			continue
 		}
+		numbits := op - PUSH1 + 1
+		for ; numbits >= 8; numbits -= 8 {
+			bits.set8(pc) // 8
+			pc += 8
+		}
+		// numbits now max 7
+		switch numbits {
+		case 1:
+			bits.set(pc)
+		case 2:
+			bits.set2(pc)
+		case 3:
+			bits.set3(pc)
+		case 4:
+			bits.set4(pc)
+		case 5:
+			bits.set5(pc)
+		case 6:
+			bits.set6(pc)
+		case 7:
+			bits.set7(pc)
+		}
+		pc += uint64(numbits)
 	}
 	return bits
 }

--- a/core/vm/analysis.go
+++ b/core/vm/analysis.go
@@ -40,6 +40,13 @@ func codeBitmap(code []byte) bitvec {
 	// ends with a PUSH32, the algorithm will push zeroes onto the
 	// bitvector outside the bounds of the actual code.
 	bits := make(bitvec, len(code)/8+1+4)
+	return codeBitmapInternal(code, bits)
+}
+
+// codeBitmapInternal is the internal implementation of codeBitmap.
+// It exists for the purpose of being able to run benchmark tests
+// without dynamic allocations affecting the results.
+func codeBitmapInternal(code, bits bitvec) bitvec {
 	for pc := uint64(0); pc < uint64(len(code)); {
 		op := OpCode(code[pc])
 

--- a/core/vm/analysis.go
+++ b/core/vm/analysis.go
@@ -83,18 +83,14 @@ func (bits bitvec) set7(pos uint64) {
 func (bits bitvec) set8(pos uint64) {
 	a := byte(0xFF >> (pos % 8))
 	bits[pos/8] |= a
-	if ^a != 0 {
-		bits[pos/8+1] = ^a
-	}
+	bits[pos/8+1] = ^a
 }
 
 func (bits bitvec) set16(pos uint64) {
 	a := byte(0xFF >> (pos % 8))
 	bits[pos/8] |= a
 	bits[pos/8+1] = 0xFF
-	if ^a != 0 {
-		bits[pos/8+2] = ^a
-	}
+	bits[pos/8+2] = ^a
 }
 
 // codeSegment checks if the position is in a code segment.

--- a/core/vm/analysis.go
+++ b/core/vm/analysis.go
@@ -83,8 +83,17 @@ func (bits *bitvec) set7(pos uint64) {
 func (bits *bitvec) set8(pos uint64) {
 	a := byte(0xFF >> (pos % 8))
 	(*bits)[pos/8] |= a
-	if ^a != 0{
+	if ^a != 0 {
 		(*bits)[pos/8+1] = ^a
+	}
+}
+
+func (bits *bitvec) set16(pos uint64) {
+	a := byte(0xFF >> (pos % 8))
+	(*bits)[pos/8] |= a
+	(*bits)[pos/8+1] = 0xFF
+	if ^a != 0 {
+		(*bits)[pos/8+2] = ^a
 	}
 }
 
@@ -113,9 +122,15 @@ func codeBitmapInternal(code, bits bitvec) bitvec {
 			continue
 		}
 		numbits := op - PUSH1 + 1
-		for ; numbits >= 8; numbits -= 8 {
-			bits.set8(pc)
-			pc += 8
+		if numbits >= 8 {
+			for ; numbits >= 16; numbits -= 16 {
+				bits.set16(pc)
+				pc += 16
+			}
+			for ; numbits >= 8; numbits -= 8 {
+				bits.set8(pc)
+				pc += 8
+			}
 		}
 		switch numbits {
 		case 1:

--- a/core/vm/analysis.go
+++ b/core/vm/analysis.go
@@ -34,7 +34,7 @@ func (bits bitvec) set2(pos uint64) {
 	a := uint16(0b1100_0000_0000_0000) >> (pos % 8)
 	bits[pos/8] |= byte(a >> 8)
 	if b := byte(a); b != 0 {
-		//	If the bit-setting affects the neigbouring byte, we can assign - no need to OR it,
+		//	If the bit-setting affects the neighbouring byte, we can assign - no need to OR it,
 		//	since it's the first write to that byte
 		bits[pos/8+1] = b
 	}

--- a/core/vm/analysis_test.go
+++ b/core/vm/analysis_test.go
@@ -73,3 +73,22 @@ func BenchmarkJumpdestHashing_1200k(bench *testing.B) {
 	}
 	bench.StopTimer()
 }
+
+func BenchmarkJumpdestOpAnalysis(bench *testing.B) {
+	var op OpCode
+	bencher := func(b *testing.B) {
+		code := make([]byte, 32*b.N)
+		for i := range code {
+			code[i] = byte(op)
+		}
+		b.ResetTimer()
+		codeBitmap(code)
+	}
+	for op = PUSH1; op <= PUSH32; op++ {
+		bench.Run(op.String(), bencher)
+	}
+	op = JUMPDEST
+	bench.Run(op.String(), bencher)
+	op = STOP
+	bench.Run(op.String(), bencher)
+}

--- a/core/vm/analysis_test.go
+++ b/core/vm/analysis_test.go
@@ -81,8 +81,9 @@ func BenchmarkJumpdestOpAnalysis(bench *testing.B) {
 		for i := range code {
 			code[i] = byte(op)
 		}
+		bits := make(bitvec, len(code)/8+1+4)
 		b.ResetTimer()
-		codeBitmap(code)
+		codeBitmapInternal(code, bits)
 	}
 	for op = PUSH1; op <= PUSH32; op++ {
 		bench.Run(op.String(), bencher)

--- a/core/vm/analysis_test.go
+++ b/core/vm/analysis_test.go
@@ -47,10 +47,10 @@ func TestJumpDestAnalysis(t *testing.T) {
 		{[]byte{byte(PUSH32)}, 0xFF, 1},
 		{[]byte{byte(PUSH32)}, 0xFF, 2},
 	}
-	for _, test := range tests {
+	for i, test := range tests {
 		ret := codeBitmap(test.code)
 		if ret[test.which] != test.exp {
-			t.Fatalf("expected %x, got %02x", test.exp, ret[test.which])
+			t.Fatalf("test %d: expected %x, got %02x", i, test.exp, ret[test.which])
 		}
 	}
 }

--- a/core/vm/instructions.go
+++ b/core/vm/instructions.go
@@ -669,6 +669,7 @@ func opCall(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]byt
 	}
 	stack.push(&temp)
 	if err == nil || err == ErrExecutionReverted {
+		ret = common.CopyBytes(ret)
 		scope.Memory.Set(retOffset.Uint64(), retSize.Uint64(), ret)
 	}
 	scope.Contract.Gas += returnGas
@@ -703,6 +704,7 @@ func opCallCode(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([
 	}
 	stack.push(&temp)
 	if err == nil || err == ErrExecutionReverted {
+		ret = common.CopyBytes(ret)
 		scope.Memory.Set(retOffset.Uint64(), retSize.Uint64(), ret)
 	}
 	scope.Contract.Gas += returnGas
@@ -730,6 +732,7 @@ func opDelegateCall(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext
 	}
 	stack.push(&temp)
 	if err == nil || err == ErrExecutionReverted {
+		ret = common.CopyBytes(ret)
 		scope.Memory.Set(retOffset.Uint64(), retSize.Uint64(), ret)
 	}
 	scope.Contract.Gas += returnGas
@@ -757,6 +760,7 @@ func opStaticCall(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) 
 	}
 	stack.push(&temp)
 	if err == nil || err == ErrExecutionReverted {
+		ret = common.CopyBytes(ret)
 		scope.Memory.Set(retOffset.Uint64(), retSize.Uint64(), ret)
 	}
 	scope.Contract.Gas += returnGas

--- a/core/vm/interpreter.go
+++ b/core/vm/interpreter.go
@@ -262,7 +262,7 @@ func (in *EVMInterpreter) Run(contract *Contract, input []byte, readOnly bool) (
 		// if the operation clears the return data (e.g. it has returning data)
 		// set the last return to the result of the operation.
 		if operation.returns {
-			in.returnData = common.CopyBytes(res)
+			in.returnData = res
 		}
 
 		switch {


### PR DESCRIPTION
This makes the analysis for code/data faster, and more evenly spread. Previously, the worst-performing case was PUSH7.
`PUSH1` started at ~40ns, and going upwards towards `50ms` at `PUSH7`. 
This PR doesn't improve the PUSH1 situation, but does markedly improve the (previous) worst-case quite a lot, and also the normal-case (for code which is not push). 
 
```
name                           old time/op  new time/op  delta
JumpdestOpAnalysis/PUSH1-6     39.7ns ± 3%  40.2ns ± 0%     ~     (p=0.151 n=5+5)
JumpdestOpAnalysis/PUSH2-6     39.4ns ± 0%  38.6ns ± 3%     ~     (p=0.190 n=4+5)
JumpdestOpAnalysis/PUSH3-6     41.4ns ± 1%  31.5ns ± 3%  -23.83%  (p=0.008 n=5+5)
JumpdestOpAnalysis/PUSH4-6     44.5ns ± 6%  23.7ns ± 5%  -46.72%  (p=0.008 n=5+5)
JumpdestOpAnalysis/PUSH5-6     47.7ns ± 5%  22.0ns ± 1%  -53.95%  (p=0.016 n=5+4)
JumpdestOpAnalysis/PUSH6-6     47.2ns ± 1%  20.3ns ± 1%  -57.03%  (p=0.008 n=5+5)
JumpdestOpAnalysis/PUSH7-6     48.7ns ± 2%  18.1ns ± 5%  -62.91%  (p=0.008 n=5+5)
JumpdestOpAnalysis/PUSH8-6     12.0ns ± 2%  19.4ns ±12%  +60.79%  (p=0.008 n=5+5)
JumpdestOpAnalysis/PUSH9-6     15.2ns ± 0%  15.4ns ± 4%     ~     (p=0.460 n=4+5)
JumpdestOpAnalysis/PUSH10-6    18.8ns ± 1%  19.0ns ± 1%     ~     (p=0.095 n=5+5)
JumpdestOpAnalysis/PUSH11-6    22.2ns ± 9%  18.0ns ± 4%  -18.52%  (p=0.008 n=5+5)
JumpdestOpAnalysis/PUSH12-6    24.1ns ± 5%  16.0ns ± 6%  -33.56%  (p=0.008 n=5+5)
JumpdestOpAnalysis/PUSH13-6    25.9ns ± 4%  15.3ns ± 4%  -40.92%  (p=0.008 n=5+5)
JumpdestOpAnalysis/PUSH14-6    27.2ns ± 0%  15.0ns ± 2%  -44.80%  (p=0.016 n=4+5)
JumpdestOpAnalysis/PUSH15-6    29.1ns ± 0%  13.6ns ± 1%  -53.15%  (p=0.008 n=5+5)
JumpdestOpAnalysis/PUSH16-6    11.0ns ± 2%  13.7ns ± 5%  +24.60%  (p=0.008 n=5+5)
JumpdestOpAnalysis/PUSH17-6    12.9ns ± 1%  13.0ns ± 2%     ~     (p=0.905 n=4+5)
JumpdestOpAnalysis/PUSH18-6    15.1ns ± 0%  15.3ns ± 1%   +0.75%  (p=0.016 n=4+5)
JumpdestOpAnalysis/PUSH19-6    16.8ns ± 1%  15.0ns ± 1%  -10.72%  (p=0.008 n=5+5)
JumpdestOpAnalysis/PUSH20-6    19.8ns ±15%  14.1ns ± 6%  -28.64%  (p=0.008 n=5+5)
JumpdestOpAnalysis/PUSH21-6    21.5ns ±20%  13.3ns ± 0%  -38.33%  (p=0.016 n=5+4)
JumpdestOpAnalysis/PUSH22-6    21.2ns ± 1%  13.4ns ± 5%  -36.65%  (p=0.008 n=5+5)
JumpdestOpAnalysis/PUSH23-6    23.0ns ± 2%  12.8ns ± 3%  -44.43%  (p=0.008 n=5+5)
JumpdestOpAnalysis/PUSH24-6    10.8ns ± 3%  12.9ns ± 3%  +19.24%  (p=0.008 n=5+5)
JumpdestOpAnalysis/PUSH25-6    12.1ns ± 1%  12.6ns ± 5%   +4.83%  (p=0.016 n=4+5)
JumpdestOpAnalysis/PUSH26-6    13.4ns ± 0%  14.2ns ± 1%   +5.45%  (p=0.016 n=4+5)
JumpdestOpAnalysis/PUSH27-6    15.1ns ± 0%  13.7ns ± 0%   -9.64%  (p=0.016 n=5+4)
JumpdestOpAnalysis/PUSH28-6    16.1ns ± 2%  13.2ns ± 6%  -18.02%  (p=0.008 n=5+5)
JumpdestOpAnalysis/PUSH29-6    17.5ns ± 6%  12.9ns ± 2%  -26.38%  (p=0.008 n=5+5)
JumpdestOpAnalysis/PUSH30-6    18.4ns ± 0%  13.0ns ± 7%  -29.39%  (p=0.016 n=4+5)
JumpdestOpAnalysis/PUSH31-6    19.7ns ± 1%  12.3ns ± 1%  -37.36%  (p=0.008 n=5+5)
JumpdestOpAnalysis/PUSH32-6    10.6ns ± 2%  12.5ns ± 5%  +17.95%  (p=0.008 n=5+5)
JumpdestOpAnalysis/JUMPDEST-6  38.9ns ± 5%  20.1ns ± 1%  -48.29%  (p=0.008 n=5+5)
JumpdestOpAnalysis/STOP-6      38.8ns ± 4%  20.3ns ± 5%  -47.68%  (p=0.008 n=5+5)
```
