### PR TITLE
internal/ethapi: add back missing check for maxfee < maxPriorityFee

### DIFF
--- a/internal/ethapi/transaction_args.go
+++ b/internal/ethapi/transaction_args.go
@@ -120,6 +120,11 @@ func (args *TransactionArgs) setDefaults(ctx context.Context, b Backend) error {
 				args.GasPrice = (*hexutil.Big)(price)
 			}
 		}
+	} else {
+		// Both maxPriorityfee and maxFee set by caller. Sanity-check their internal relation
+		if args.MaxFeePerGas.ToInt().Cmp(args.MaxPriorityFeePerGas.ToInt()) < 0 {
+			return fmt.Errorf("maxFeePerGas (%v) < maxPriorityFeePerGas (%v)", args.MaxFeePerGas, args.MaxPriorityFeePerGas)
+		}
 	}
 	if args.Value == nil {
 		args.Value = new(hexutil.Big)


### PR DESCRIPTION
In https://github.com/ethereum/go-ethereum/pull/23274/files#diff-4a9c1433c7c79c50cb72fd743c896f7bf5a976f46ccbb5fae83f5c46b2465db9R103, a check got lost. When the user/caller supplies both maxFee and maxPriorityFee, we still should verify that they are valid. 