### PR TITLE
accounts/external, core/types: don't blindly init tx fields on copy

### DIFF
--- a/accounts/external/backend.go
+++ b/accounts/external/backend.go
@@ -218,7 +218,7 @@ func (api *ExternalSigner) SignTx(account accounts.Account, tx *types.Transactio
 		args.MaxFeePerGas = (*hexutil.Big)(tx.GasFeeCap())
 		args.MaxPriorityFeePerGas = (*hexutil.Big)(tx.GasTipCap())
 	default:
-		return nil, fmt.Errorf("Unsupported tx type %d", tx.Type())
+		return nil, fmt.Errorf("unsupported tx type %d", tx.Type())
 	}
 	// We should request the default chain id that we're operating with
 	// (the chain we're executing on)

--- a/core/types/access_list_tx.go
+++ b/core/types/access_list_tx.go
@@ -58,37 +58,30 @@ type AccessListTx struct {
 // copy creates a deep copy of the transaction data and initializes all fields.
 func (tx *AccessListTx) copy() TxData {
 	cpy := &AccessListTx{
-		Nonce: tx.Nonce,
-		To:    tx.To, // TODO: copy pointed-to address
-		Data:  common.CopyBytes(tx.Data),
-		Gas:   tx.Gas,
-		// These are copied below.
+		Nonce:      tx.Nonce,
+		To:         tx.To, // TODO: copy pointed-to address
+		Data:       common.CopyBytes(tx.Data),
+		Gas:        tx.Gas,
 		AccessList: make(AccessList, len(tx.AccessList)),
-		Value:      new(big.Int),
-		ChainID:    new(big.Int),
-		GasPrice:   new(big.Int),
-		V:          new(big.Int),
-		R:          new(big.Int),
-		S:          new(big.Int),
 	}
 	copy(cpy.AccessList, tx.AccessList)
 	if tx.Value != nil {
-		cpy.Value.Set(tx.Value)
+		cpy.Value = new(big.Int).Set(tx.Value)
 	}
 	if tx.ChainID != nil {
-		cpy.ChainID.Set(tx.ChainID)
+		cpy.ChainID = new(big.Int).Set(tx.ChainID)
 	}
 	if tx.GasPrice != nil {
-		cpy.GasPrice.Set(tx.GasPrice)
+		cpy.GasPrice = new(big.Int).Set(tx.GasPrice)
 	}
 	if tx.V != nil {
-		cpy.V.Set(tx.V)
+		cpy.V = new(big.Int).Set(tx.V)
 	}
 	if tx.R != nil {
-		cpy.R.Set(tx.R)
+		cpy.R = new(big.Int).Set(tx.R)
 	}
 	if tx.S != nil {
-		cpy.S.Set(tx.S)
+		cpy.S = new(big.Int).Set(tx.S)
 	}
 	return cpy
 }

--- a/core/types/dynamic_fee_tx.go
+++ b/core/types/dynamic_fee_tx.go
@@ -42,41 +42,33 @@ type DynamicFeeTx struct {
 // copy creates a deep copy of the transaction data and initializes all fields.
 func (tx *DynamicFeeTx) copy() TxData {
 	cpy := &DynamicFeeTx{
-		Nonce: tx.Nonce,
-		To:    tx.To, // TODO: copy pointed-to address
-		Data:  common.CopyBytes(tx.Data),
-		Gas:   tx.Gas,
-		// These are copied below.
+		Nonce:      tx.Nonce,
+		To:         tx.To, // TODO: copy pointed-to address
+		Data:       common.CopyBytes(tx.Data),
+		Gas:        tx.Gas,
 		AccessList: make(AccessList, len(tx.AccessList)),
-		Value:      new(big.Int),
-		ChainID:    new(big.Int),
-		GasTipCap:  new(big.Int),
-		GasFeeCap:  new(big.Int),
-		V:          new(big.Int),
-		R:          new(big.Int),
-		S:          new(big.Int),
 	}
 	copy(cpy.AccessList, tx.AccessList)
 	if tx.Value != nil {
-		cpy.Value.Set(tx.Value)
+		cpy.Value = new(big.Int).Set(tx.Value)
 	}
 	if tx.ChainID != nil {
-		cpy.ChainID.Set(tx.ChainID)
+		cpy.ChainID = new(big.Int).Set(tx.ChainID)
 	}
 	if tx.GasTipCap != nil {
-		cpy.GasTipCap.Set(tx.GasTipCap)
+		cpy.GasTipCap = new(big.Int).Set(tx.GasTipCap)
 	}
 	if tx.GasFeeCap != nil {
-		cpy.GasFeeCap.Set(tx.GasFeeCap)
+		cpy.GasFeeCap = new(big.Int).Set(tx.GasFeeCap)
 	}
 	if tx.V != nil {
-		cpy.V.Set(tx.V)
+		cpy.V = new(big.Int).Set(tx.V)
 	}
 	if tx.R != nil {
-		cpy.R.Set(tx.R)
+		cpy.R = new(big.Int).Set(tx.R)
 	}
 	if tx.S != nil {
-		cpy.S.Set(tx.S)
+		cpy.S = new(big.Int).Set(tx.S)
 	}
 	return cpy
 }

--- a/core/types/legacy_tx.go
+++ b/core/types/legacy_tx.go
@@ -65,27 +65,21 @@ func (tx *LegacyTx) copy() TxData {
 		To:    tx.To, // TODO: copy pointed-to address
 		Data:  common.CopyBytes(tx.Data),
 		Gas:   tx.Gas,
-		// These are initialized below.
-		Value:    new(big.Int),
-		GasPrice: new(big.Int),
-		V:        new(big.Int),
-		R:        new(big.Int),
-		S:        new(big.Int),
 	}
 	if tx.Value != nil {
-		cpy.Value.Set(tx.Value)
+		cpy.Value = new(big.Int).Set(tx.Value)
 	}
 	if tx.GasPrice != nil {
-		cpy.GasPrice.Set(tx.GasPrice)
+		cpy.GasPrice = new(big.Int).Set(tx.GasPrice)
 	}
 	if tx.V != nil {
-		cpy.V.Set(tx.V)
+		cpy.V = new(big.Int).Set(tx.V)
 	}
 	if tx.R != nil {
-		cpy.R.Set(tx.R)
+		cpy.R = new(big.Int).Set(tx.R)
 	}
 	if tx.S != nil {
-		cpy.S.Set(tx.S)
+		cpy.S = new(big.Int).Set(tx.S)
 	}
 	return cpy
 }


### PR DESCRIPTION
The transaction deep copy methods blindly initialized all optional fields to `0` and updated those that have been specified. This should be mostly benign, it can only mess things up when the user doesn't specify certain fields and wants Geth/Clef to auto-fill it. For transactions coming from the network, the fields are never nil, so no worries there.

Still, we need to keep the original version since the copies are sent over to other subsystems (e.g. to Clef for remote signing) and we can't fill things in that the user deliberately left empty for Clef.