### PR TITLE
tests/testdata: make submodule shallow

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,4 @@
 [submodule "tests"]
 	path = tests/testdata
 	url = https://github.com/ethereum/tests
+	shallow = true


### PR DESCRIPTION
As @MariusVanDerWijden mentioned the tests submodule is quite heavy added the shallow setting for it - does not help that much as most weight is in the actual data - not the history - but it helps a bit - hence the PR.
Before:

`316M	.git/modules/tests/`

After:

`171M	.git/modules/tests/`

so 145M saved - not much - but also not nothing.