### PR TITLE
eth/gasprice: feeHistory improvements

### DIFF
--- a/eth/ethconfig/config.go
+++ b/eth/ethconfig/config.go
@@ -43,8 +43,8 @@ import (
 var FullNodeGPO = gasprice.Config{
 	Blocks:           20,
 	Percentile:       60,
-	MaxHeaderHistory: 0,
-	MaxBlockHistory:  0,
+	MaxHeaderHistory: 1024,
+	MaxBlockHistory:  1024,
 	MaxPrice:         gasprice.DefaultMaxPrice,
 	IgnorePrice:      gasprice.DefaultIgnorePrice,
 }

--- a/eth/gasprice/feehistory_test.go
+++ b/eth/gasprice/feehistory_test.go
@@ -36,20 +36,20 @@ func TestFeeHistory(t *testing.T) {
 		expCount            int
 		expErr              error
 	}{
-		{false, 0, 0, 10, 30, nil, 21, 10, nil},
-		{false, 0, 0, 10, 30, []float64{0, 10}, 21, 10, nil},
-		{false, 0, 0, 10, 30, []float64{20, 10}, 0, 0, errInvalidPercentile},
-		{false, 0, 0, 1000000000, 30, nil, 0, 31, nil},
-		{false, 0, 0, 1000000000, rpc.LatestBlockNumber, nil, 0, 33, nil},
-		{false, 0, 0, 10, 40, nil, 0, 0, errRequestBeyondHead},
-		{true, 0, 0, 10, 40, nil, 0, 0, errRequestBeyondHead},
+		{false, 1000, 1000, 10, 30, nil, 21, 10, nil},
+		{false, 1000, 1000, 10, 30, []float64{0, 10}, 21, 10, nil},
+		{false, 1000, 1000, 10, 30, []float64{20, 10}, 0, 0, errInvalidPercentile},
+		{false, 1000, 1000, 1000000000, 30, nil, 0, 31, nil},
+		{false, 1000, 1000, 1000000000, rpc.LatestBlockNumber, nil, 0, 33, nil},
+		{false, 1000, 1000, 10, 40, nil, 0, 0, errRequestBeyondHead},
+		{true, 1000, 1000, 10, 40, nil, 0, 0, errRequestBeyondHead},
 		{false, 20, 2, 100, rpc.LatestBlockNumber, nil, 13, 20, nil},
 		{false, 20, 2, 100, rpc.LatestBlockNumber, []float64{0, 10}, 31, 2, nil},
 		{false, 20, 2, 100, 32, []float64{0, 10}, 31, 2, nil},
-		{false, 0, 0, 1, rpc.PendingBlockNumber, nil, 0, 0, nil},
-		{false, 0, 0, 2, rpc.PendingBlockNumber, nil, 32, 1, nil},
-		{true, 0, 0, 2, rpc.PendingBlockNumber, nil, 32, 2, nil},
-		{true, 0, 0, 2, rpc.PendingBlockNumber, []float64{0, 10}, 32, 2, nil},
+		{false, 1000, 1000, 1, rpc.PendingBlockNumber, nil, 0, 0, nil},
+		{false, 1000, 1000, 2, rpc.PendingBlockNumber, nil, 32, 1, nil},
+		{true, 1000, 1000, 2, rpc.PendingBlockNumber, nil, 32, 2, nil},
+		{true, 1000, 1000, 2, rpc.PendingBlockNumber, []float64{0, 10}, 32, 2, nil},
 	}
 	for i, c := range cases {
 		config := Config{

--- a/eth/gasprice/gasprice.go
+++ b/eth/gasprice/gasprice.go
@@ -27,6 +27,7 @@ import (
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/params"
 	"github.com/ethereum/go-ethereum/rpc"
+	lru "github.com/hashicorp/golang-lru"
 )
 
 const sampleNumber = 3 // Number of transactions sampled in a block
@@ -68,6 +69,7 @@ type Oracle struct {
 
 	checkBlocks, percentile           int
 	maxHeaderHistory, maxBlockHistory int
+	historyCache                      *lru.Cache
 }
 
 // NewOracle returns a new gasprice oracle which can recommend suitable
@@ -99,6 +101,7 @@ func NewOracle(backend OracleBackend, params Config) *Oracle {
 	} else if ignorePrice.Int64() > 0 {
 		log.Info("Gasprice oracle is ignoring threshold set", "threshold", ignorePrice)
 	}
+	cache, _ := lru.New(2048)
 	return &Oracle{
 		backend:          backend,
 		lastPrice:        params.Default,
@@ -108,6 +111,7 @@ func NewOracle(backend OracleBackend, params Config) *Oracle {
 		percentile:       percent,
 		maxHeaderHistory: params.MaxHeaderHistory,
 		maxBlockHistory:  params.MaxBlockHistory,
+		historyCache:     cache,
 	}
 }
 

--- a/eth/gasprice/gasprice_test.go
+++ b/eth/gasprice/gasprice_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/core/vm"
 	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/event"
 	"github.com/ethereum/go-ethereum/params"
 	"github.com/ethereum/go-ethereum/rpc"
 )
@@ -88,6 +89,10 @@ func (b *testBackend) PendingBlockAndReceipts() (*types.Block, types.Receipts) {
 
 func (b *testBackend) ChainConfig() *params.ChainConfig {
 	return b.chain.Config()
+}
+
+func (b *testBackend) SubscribeChainHeadEvent(ch chan<- core.ChainHeadEvent) event.Subscription {
+	return nil
 }
 
 func newTestBackend(t *testing.T, londonBlock *big.Int, pending bool) *testBackend {


### PR DESCRIPTION
This PR changes the block count limitation rules in light client mode so that only the length of the queried section is limited per request but querying older sections of the chain is not limited. The feeHistory spec only mandates providing access to the most recent section because some clients might not be able to serve older data but the Geth light client is capable of doing so and therefore the limitations can be eased, allowing fee estimators to examine/sample a longer history if necessary.
The processed results are also cached per block now which greatly improves the performance of the calibration process of the [Economical Fee Oracle](https://github.com/zsfelfoldi/feehistory/blob/main/js/feeOracle.js).