### PR TITLE
Update blockchain reorg, remove random behaviour

### DIFF
--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -22,7 +22,6 @@ import (
 	"fmt"
 	"io"
 	"math/big"
-	mrand "math/rand"
 	"sort"
 	"sync"
 	"sync/atomic"
@@ -1545,7 +1544,7 @@ func (bc *BlockChain) writeBlockWithState(block *types.Block, receipts []*types.
 			if bc.shouldPreserve != nil {
 				currentPreserve, blockPreserve = bc.shouldPreserve(currentBlock), bc.shouldPreserve(block)
 			}
-			reorg = !currentPreserve && (blockPreserve || mrand.Float64() < 0.5)
+			reorg = !currentPreserve && blockPreserve
 		}
 	}
 	if reorg {


### PR DESCRIPTION
This update will provide a deterministic behaviour which is much more preferable than the random and will increase an efficiency up to the 50% for this algorithm, because if we have two identical chains we don not want actually switch to another one, because it leads to the unneeded state changes actually with the no effect for the consensus.