### PR TITLE
miner: fix data race

### DIFF
--- a/miner/worker.go
+++ b/miner/worker.go
@@ -318,6 +318,8 @@ func (w *worker) isRunning() bool {
 // close terminates all background threads maintained by the worker.
 // Note the worker does not support being closed multiple times.
 func (w *worker) close() {
+	w.mu.Lock()
+	defer w.mu.Unlock()
 	if w.current != nil && w.current.state != nil {
 		w.current.state.StopPrefetcher()
 	}


### PR DESCRIPTION
Fixes a race between `close` and `makeCurrent`

```
==================
WARNING: DATA RACE
Read at 0x00c00048c5a8 by goroutine 128:
  github.com/ethereum/go-ethereum/miner.(*worker).close()
      /home/matematik/go/src/github.com/ethereum/go-ethereum/miner/worker.go:321 +0x4a
  github.com/ethereum/go-ethereum/miner.(*Miner).update()
      /home/matematik/go/src/github.com/ethereum/go-ethereum/miner/miner.go:141 +0xa88

Previous write at 0x00c00048c5a8 by goroutine 124:
  github.com/ethereum/go-ethereum/miner.(*worker).makeCurrent()
      /home/matematik/go/src/github.com/ethereum/go-ethereum/miner/worker.go:695 +0x8d4
  github.com/ethereum/go-ethereum/miner.(*worker).commitNewWork()
      /home/matematik/go/src/github.com/ethereum/go-ethereum/miner/worker.go:938 +0x818
  github.com/ethereum/go-ethereum/miner.(*worker).mainLoop()
      /home/matematik/go/src/github.com/ethereum/go-ethereum/miner/worker.go:456 +0x58d

Goroutine 128 (running) created at:
  github.com/ethereum/go-ethereum/miner.New()
      /home/matematik/go/src/github.com/ethereum/go-ethereum/miner/miner.go:78 +0x30c
  github.com/ethereum/go-ethereum/miner.createMiner()
      /home/matematik/go/src/github.com/ethereum/go-ethereum/miner/miner_test.go:260 +0x84f
  github.com/ethereum/go-ethereum/miner.TestCloseMiner()
      /home/matematik/go/src/github.com/ethereum/go-ethereum/miner/miner_test.go:185 +0x3c
  testing.tRunner()
      /usr/lib/go/src/testing/testing.go:1193 +0x202

Goroutine 124 (running) created at:
  github.com/ethereum/go-ethereum/miner.newWorker()
      /home/matematik/go/src/github.com/ethereum/go-ethereum/miner/worker.go:228 +0xa52
  github.com/ethereum/go-ethereum/miner.New()
      /home/matematik/go/src/github.com/ethereum/go-ethereum/miner/miner.go:76 +0x128
  github.com/ethereum/go-ethereum/miner.createMiner()
      /home/matematik/go/src/github.com/ethereum/go-ethereum/miner/miner_test.go:260 +0x84f
  github.com/ethereum/go-ethereum/miner.TestCloseMiner()
      /home/matematik/go/src/github.com/ethereum/go-ethereum/miner/miner_test.go:185 +0x3c
  testing.tRunner()
      /usr/lib/go/src/testing/testing.go:1193 +0x202
==================
==================
WARNING: DATA RACE
Read at 0x00c0002d8a30 by goroutine 128:
  github.com/ethereum/go-ethereum/miner.(*worker).close()
      /home/matematik/go/src/github.com/ethereum/go-ethereum/miner/worker.go:321 +0x19e
  github.com/ethereum/go-ethereum/miner.(*Miner).update()
      /home/matematik/go/src/github.com/ethereum/go-ethereum/miner/miner.go:141 +0xa88

Previous write at 0x00c0002d8a30 by goroutine 124:
  github.com/ethereum/go-ethereum/miner.(*worker).makeCurrent()
      /home/matematik/go/src/github.com/ethereum/go-ethereum/miner/worker.go:671 +0x31c
  github.com/ethereum/go-ethereum/miner.(*worker).commitNewWork()
      /home/matematik/go/src/github.com/ethereum/go-ethereum/miner/worker.go:938 +0x818
  github.com/ethereum/go-ethereum/miner.(*worker).mainLoop()
      /home/matematik/go/src/github.com/ethereum/go-ethereum/miner/worker.go:456 +0x58d

Goroutine 128 (running) created at:
  github.com/ethereum/go-ethereum/miner.New()
      /home/matematik/go/src/github.com/ethereum/go-ethereum/miner/miner.go:78 +0x30c
  github.com/ethereum/go-ethereum/miner.createMiner()
      /home/matematik/go/src/github.com/ethereum/go-ethereum/miner/miner_test.go:260 +0x84f
  github.com/ethereum/go-ethereum/miner.TestCloseMiner()
      /home/matematik/go/src/github.com/ethereum/go-ethereum/miner/miner_test.go:185 +0x3c
  testing.tRunner()
      /usr/lib/go/src/testing/testing.go:1193 +0x202

Goroutine 124 (running) created at:
  github.com/ethereum/go-ethereum/miner.newWorker()
      /home/matematik/go/src/github.com/ethereum/go-ethereum/miner/worker.go:228 +0xa52
  github.com/ethereum/go-ethereum/miner.New()
      /home/matematik/go/src/github.com/ethereum/go-ethereum/miner/miner.go:76 +0x128
  github.com/ethereum/go-ethereum/miner.createMiner()
      /home/matematik/go/src/github.com/ethereum/go-ethereum/miner/miner_test.go:260 +0x84f
  github.com/ethereum/go-ethereum/miner.TestCloseMiner()
      /home/matematik/go/src/github.com/ethereum/go-ethereum/miner/miner_test.go:185 +0x3c
  testing.tRunner()
      /usr/lib/go/src/testing/testing.go:1193 +0x202
==================
==================
WARNING: DATA RACE
Read at 0x00c000215690 by goroutine 128:
  github.com/ethereum/go-ethereum/core/state.(*StateDB).StopPrefetcher()
      /home/matematik/go/src/github.com/ethereum/go-ethereum/core/state/statedb.go:168 +0x106
  github.com/ethereum/go-ethereum/miner.(*worker).close()
      /home/matematik/go/src/github.com/ethereum/go-ethereum/miner/worker.go:322 +0xb5
  github.com/ethereum/go-ethereum/miner.(*Miner).update()
      /home/matematik/go/src/github.com/ethereum/go-ethereum/miner/miner.go:141 +0xa88

Previous write at 0x00c000215690 by goroutine 124:
  github.com/ethereum/go-ethereum/core/state.New()
      /home/matematik/go/src/github.com/ethereum/go-ethereum/core/state/statedb.go:128 +0x384
  github.com/ethereum/go-ethereum/core.(*BlockChain).StateAt()
      /home/matematik/go/src/github.com/ethereum/go-ethereum/core/blockchain.go:691 +0x19a
  github.com/ethereum/go-ethereum/miner.(*worker).makeCurrent()
      /home/matematik/go/src/github.com/ethereum/go-ethereum/miner/worker.go:665 +0x71
  github.com/ethereum/go-ethereum/miner.(*worker).commitNewWork()
      /home/matematik/go/src/github.com/ethereum/go-ethereum/miner/worker.go:938 +0x818
  github.com/ethereum/go-ethereum/miner.(*worker).mainLoop()
      /home/matematik/go/src/github.com/ethereum/go-ethereum/miner/worker.go:456 +0x58d

Goroutine 128 (running) created at:
  github.com/ethereum/go-ethereum/miner.New()
      /home/matematik/go/src/github.com/ethereum/go-ethereum/miner/miner.go:78 +0x30c
  github.com/ethereum/go-ethereum/miner.createMiner()
      /home/matematik/go/src/github.com/ethereum/go-ethereum/miner/miner_test.go:260 +0x84f
  github.com/ethereum/go-ethereum/miner.TestCloseMiner()
      /home/matematik/go/src/github.com/ethereum/go-ethereum/miner/miner_test.go:185 +0x3c
  testing.tRunner()
      /usr/lib/go/src/testing/testing.go:1193 +0x202

Goroutine 124 (running) created at:
  github.com/ethereum/go-ethereum/miner.newWorker()
      /home/matematik/go/src/github.com/ethereum/go-ethereum/miner/worker.go:228 +0xa52
  github.com/ethereum/go-ethereum/miner.New()
      /home/matematik/go/src/github.com/ethereum/go-ethereum/miner/miner.go:76 +0x128
  github.com/ethereum/go-ethereum/miner.createMiner()
      /home/matematik/go/src/github.com/ethereum/go-ethereum/miner/miner_test.go:260 +0x84f
  github.com/ethereum/go-ethereum/miner.TestCloseMiner()
      /home/matematik/go/src/github.com/ethereum/go-ethereum/miner/miner_test.go:185 +0x3c
  testing.tRunner()
      /usr/lib/go/src/testing/testing.go:1193 +0x202
==================
==================
WARNING: DATA RACE
Read at 0x00c00010dd78 by goroutine 128:
  github.com/ethereum/go-ethereum/core/state.(*triePrefetcher).close()
      /home/matematik/go/src/github.com/ethereum/go-ethereum/core/state/trie_prefetcher.go:78 +0x64
  github.com/ethereum/go-ethereum/core/state.(*StateDB).StopPrefetcher()
      /home/matematik/go/src/github.com/ethereum/go-ethereum/core/state/statedb.go:169 +0x13c
  github.com/ethereum/go-ethereum/miner.(*worker).close()
      /home/matematik/go/src/github.com/ethereum/go-ethereum/miner/worker.go:322 +0xb5
  github.com/ethereum/go-ethereum/miner.(*Miner).update()
      /home/matematik/go/src/github.com/ethereum/go-ethereum/miner/miner.go:141 +0xa88

Previous write at 0x00c00010dd78 by goroutine 124:
  github.com/ethereum/go-ethereum/core/state.newTriePrefetcher()
      /home/matematik/go/src/github.com/ethereum/go-ethereum/core/state/trie_prefetcher.go:57 +0x912
  github.com/ethereum/go-ethereum/core/state.(*StateDB).StartPrefetcher()
      /home/matematik/go/src/github.com/ethereum/go-ethereum/core/state/statedb.go:161 +0x147
  github.com/ethereum/go-ethereum/miner.(*worker).makeCurrent()
      /home/matematik/go/src/github.com/ethereum/go-ethereum/miner/worker.go:669 +0x1db
  github.com/ethereum/go-ethereum/miner.(*worker).commitNewWork()
      /home/matematik/go/src/github.com/ethereum/go-ethereum/miner/worker.go:938 +0x818
  github.com/ethereum/go-ethereum/miner.(*worker).mainLoop()
      /home/matematik/go/src/github.com/ethereum/go-ethereum/miner/worker.go:456 +0x58d

Goroutine 128 (running) created at:
  github.com/ethereum/go-ethereum/miner.New()
      /home/matematik/go/src/github.com/ethereum/go-ethereum/miner/miner.go:78 +0x30c
  github.com/ethereum/go-ethereum/miner.createMiner()
      /home/matematik/go/src/github.com/ethereum/go-ethereum/miner/miner_test.go:260 +0x84f
  github.com/ethereum/go-ethereum/miner.TestCloseMiner()
      /home/matematik/go/src/github.com/ethereum/go-ethereum/miner/miner_test.go:185 +0x3c
  testing.tRunner()
      /usr/lib/go/src/testing/testing.go:1193 +0x202

Goroutine 124 (running) created at:
  github.com/ethereum/go-ethereum/miner.newWorker()
      /home/matematik/go/src/github.com/ethereum/go-ethereum/miner/worker.go:228 +0xa52
  github.com/ethereum/go-ethereum/miner.New()
      /home/matematik/go/src/github.com/ethereum/go-ethereum/miner/miner.go:76 +0x128
  github.com/ethereum/go-ethereum/miner.createMiner()
      /home/matematik/go/src/github.com/ethereum/go-ethereum/miner/miner_test.go:260 +0x84f
  github.com/ethereum/go-ethereum/miner.TestCloseMiner()
      /home/matematik/go/src/github.com/ethereum/go-ethereum/miner/miner_test.go:185 +0x3c
  testing.tRunner()
      /usr/lib/go/src/testing/testing.go:1193 +0x202
==================
--- FAIL: TestCloseMiner (0.04s)
    testing.go:1092: race detected during execution of test
```