### PR TITLE
core/bloombits: avoid crash when storing errors of different type

### DIFF
--- a/core/bloombits/matcher.go
+++ b/core/bloombits/matcher.go
@@ -507,11 +507,12 @@ func (m *Matcher) distributor(dist chan *request, session *MatcherSession) {
 type MatcherSession struct {
 	matcher *Matcher
 
-	closer sync.Once     // Sync object to ensure we only ever close once
-	quit   chan struct{} // Quit channel to request pipeline termination
+	closer sync.Once     	// Sync object to ensure we only ever close once
+	quit   chan struct{} 	// Quit channel to request pipeline termination
 
-	ctx context.Context // Context used by the light client to abort filtering
-	err atomic.Value    // Global error to track retrieval failures deep in the chain
+	ctx     context.Context // Context used by the light client to abort filtering
+	err     error 			// Global error to track retrieval failures deep in the chain
+	errLock sync.Mutex
 
 	pend sync.WaitGroup
 }
@@ -529,10 +530,10 @@ func (s *MatcherSession) Close() {
 
 // Error returns any failure encountered during the matching session.
 func (s *MatcherSession) Error() error {
-	if err := s.err.Load(); err != nil {
-		return err.(error)
-	}
-	return nil
+	s.errLock.Lock()
+	defer s.errLock.Unlock()
+
+	return s.err
 }
 
 // allocateRetrieval assigns a bloom bit index to a client process that can either
@@ -630,7 +631,9 @@ func (s *MatcherSession) Multiplex(batch int, wait time.Duration, mux chan chan 
 
 			result := <-request
 			if result.Error != nil {
-				s.err.Store(result.Error)
+				s.errLock.Lock()
+				s.err = result.Error
+				s.errLock.Unlock()
 				s.Close()
 			}
 			s.deliverSections(result.Bit, result.Sections, result.Bitsets)

--- a/core/bloombits/matcher.go
+++ b/core/bloombits/matcher.go
@@ -507,11 +507,11 @@ func (m *Matcher) distributor(dist chan *request, session *MatcherSession) {
 type MatcherSession struct {
 	matcher *Matcher
 
-	closer sync.Once     	// Sync object to ensure we only ever close once
-	quit   chan struct{} 	// Quit channel to request pipeline termination
+	closer sync.Once     // Sync object to ensure we only ever close once
+	quit   chan struct{} // Quit channel to request pipeline termination
 
 	ctx     context.Context // Context used by the light client to abort filtering
-	err     error 			// Global error to track retrieval failures deep in the chain
+	err     error           // Global error to track retrieval failures deep in the chain
 	errLock sync.Mutex
 
 	pend sync.WaitGroup


### PR DESCRIPTION
When using `atomic.Value` it will panic if the error is a struct implementing the error interface and an error as been registered.

From https://pkg.go.dev/sync/atomic#Value.Store, `Store sets the value of the Value to x. All calls to Store for a given Value must use values of the same concrete type. Store of an inconsistent type panics, as does Store(nil).`

Check this example. https://play.golang.org/p/N5Zp15o_AoE

We recently found this error at https://github.com/ava-labs/ when a custom error was returned from `rawdb.ReadBloomBits`.
Kudos to https://github.com/StephenButtolph for writing the code.