### PR TITLE
vulnerabilities: update for CVE-2021-39137

### DIFF
--- a/docs/_vulnerabilities/vulnerabilities.json
+++ b/docs/_vulnerabilities/vulnerabilities.json
@@ -112,8 +112,24 @@
     ],
     "introduced": "v1.10.1",
     "fixed": "v1.10.6",
-    "published": "2020-12-10",
+    "published": "2020-07-22",
     "severity": "High",
     "check": "(Geth\\/v1\\.10\\.(1|2|3|4|5)-.*)$"
+  },
+  {
+    "name": " EVM flaw during block processing ",
+    "uid": "GETH-2021-02",
+    "summary": "A vulnerability in the Geth EVM could cause a node to no longer being able to process the chain. Further details about the vulnerability will be disclosed at a later date.",
+    "description": "The exact attack vector will be provided at a later date to give node operators and dependent downstream projects time to update their nodes and software.\n\nAll Geth versions supporting the London hard fork are vulnerable (the bug is older than London), so all users should update.\n\nCredits for the discovery go to @guidovranken (working for Sentnl during an audit of the Telos EVM) and reported via bounty@ethereum.org.",
+    "links": [
+      "https://github.com/ethereum/go-ethereum/security/advisories/GHSA-9856-9gg9-qcmq",
+      "https://github.com/ethereum/go-ethereum/releases/tag/v1.10.8"
+    ],
+    "introduced": "v1.10.0",
+    "fixed": "v1.10.8",
+    "published": "2021-08-24",
+    "severity": "High",
+    "CVE": "CVE-2021-39137",
+    "check": "(Geth\\/v1\\.10\\.(0|1|2|3|4|5|6|7)-.*)$"
   }
 ]

--- a/docs/_vulnerabilities/vulnerabilities.json.minisig
+++ b/docs/_vulnerabilities/vulnerabilities.json.minisig
@@ -1,4 +1,4 @@
 untrusted comment: signature from minisign secret key
-RWQk7Lo5TQgd+4GvOo3mu4yn1fe38AaBhs41V+ldNclGaCAiJ14i/GAvaXISL9b5+K/8HE9YLBVwqrcoJwaqaGPcXd4023FTxwI=
-trusted comment: timestamp:1626982808	file:vulnerabilities.json
-G9/AvsE90wCD5Z0VXx3fuJnrolE/AAxS6y9d8G/lXvoyvAWrMx41MiIj+pz4OwcnhyQzOYo2+7nSza9H22g6DA==
+RWQk7Lo5TQgd++3L4ak5YtTZati9peOJPh98Hyd3+clXS0o12nmm/WD4/7yuWHIIjBizJ74DqMesD7d2OhjwrExKEOhYnX7vrgg=
+trusted comment: timestamp:1629790360	file:vulnerabilities.json
+hoImXPiP448MxV7UOT/uQ1xj9jeJDGDqiFz/SVylfC5VC48bdjHTWN9LOgDGZfzLS+KIke0nDttel4vMZNg+AQ==


### PR DESCRIPTION
This PR updates the version-check to include info about the latest patch. 

```
[user@work go-ethereum]$ geth version-check --check.url file:///tmp/vulnerabilities.json
INFO [08-24|09:34:03.423] Checking vulnerabilities                 version=Geth/v1.10.7-unstable-e3e0ce00-20210818/linux-amd64/go1.16.4 url=file:///tmp/vulnerabilities.json
## Vulnerable to GETH-2021-02 ( EVM flaw during block processing )

Severity: High
Summary : A vulnerability in the Geth EVM could cause a node to no longer being able to process the chain. Further details about the vulnerability will be disclosed at a later date.
Fixed in: v1.10.8
CVE: CVE-2021-39137
References:
	- https://github.com/ethereum/go-ethereum/security/advisories/GHSA-9856-9gg9-qcmq
	- https://github.com/ethereum/go-ethereum/releases/tag/v1.10.8


```
