### PR TITLE
metrics: fix compilation for GOOS=js

### DIFF
--- a/metrics/cpu_disabled.go
+++ b/metrics/cpu_disabled.go
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
 
-// +build ios
+// +build ios js
 
 package metrics
 

--- a/metrics/cpu_enabled.go
+++ b/metrics/cpu_enabled.go
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
 
-// +build !ios
+// +build !ios,!js
 
 package metrics
 

--- a/metrics/cputime_nop.go
+++ b/metrics/cputime_nop.go
@@ -14,22 +14,12 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
 
-// +build !windows
+// +build windows js
 
 package metrics
 
-import (
-	syscall "golang.org/x/sys/unix"
-
-	"github.com/ethereum/go-ethereum/log"
-)
-
-// getProcessCPUTime retrieves the process' CPU time since program startup.
+// getProcessCPUTime returns 0 on Windows as there is no system call to resolve
+// the actual process' CPU time.
 func getProcessCPUTime() int64 {
-	var usage syscall.Rusage
-	if err := syscall.Getrusage(syscall.RUSAGE_SELF, &usage); err != nil {
-		log.Warn("Failed to retrieve CPU time", "err", err)
-		return 0
-	}
-	return int64(usage.Utime.Sec+usage.Stime.Sec)*100 + int64(usage.Utime.Usec+usage.Stime.Usec)/10000 //nolint:unconvert
+	return 0
 }

--- a/metrics/cputime_unix.go
+++ b/metrics/cputime_unix.go
@@ -14,10 +14,22 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
 
+// +build !windows,!js
+
 package metrics
 
-// getProcessCPUTime returns 0 on Windows as there is no system call to resolve
-// the actual process' CPU time.
+import (
+	syscall "golang.org/x/sys/unix"
+
+	"github.com/ethereum/go-ethereum/log"
+)
+
+// getProcessCPUTime retrieves the process' CPU time since program startup.
 func getProcessCPUTime() int64 {
-	return 0
+	var usage syscall.Rusage
+	if err := syscall.Getrusage(syscall.RUSAGE_SELF, &usage); err != nil {
+		log.Warn("Failed to retrieve CPU time", "err", err)
+		return 0
+	}
+	return int64(usage.Utime.Sec+usage.Stime.Sec)*100 + int64(usage.Utime.Usec+usage.Stime.Usec)/10000 //nolint:unconvert
 }

--- a/metrics/runtime_cgo.go
+++ b/metrics/runtime_cgo.go
@@ -1,5 +1,4 @@
-// +build cgo
-// +build !appengine
+// +build cgo,!appengine,!js
 
 package metrics
 

--- a/metrics/runtime_no_cgo.go
+++ b/metrics/runtime_no_cgo.go
@@ -1,4 +1,4 @@
-// +build !cgo appengine
+// +build !cgo appengine js
 
 package metrics
 


### PR DESCRIPTION
This change is required to allow compilation of accounts/abi/bind to WebAssembly.