### PR TITLE
rlp: minor optimizations for slice/array encoding

### DIFF
--- a/rlp/decode.go
+++ b/rlp/decode.go
@@ -379,7 +379,7 @@ func decodeByteArray(s *Stream, val reflect.Value) error {
 	if err != nil {
 		return err
 	}
-	slice := byteArrayBytes(val)
+	slice := byteArrayBytes(val, val.Len())
 	switch kind {
 	case Byte:
 		if len(slice) == 0 {

--- a/rlp/encode_test.go
+++ b/rlp/encode_test.go
@@ -540,3 +540,31 @@ func BenchmarkEncodeByteArrayStruct(b *testing.B) {
 		}
 	}
 }
+
+type structSliceElem struct {
+	X uint64
+	Y uint64
+	Z uint64
+}
+
+type structPtrSlice []*structSliceElem
+
+func BenchmarkEncodeStructPtrSlice(b *testing.B) {
+	var out bytes.Buffer
+	var value = structPtrSlice{
+		&structSliceElem{1, 1, 1},
+		&structSliceElem{2, 2, 2},
+		&structSliceElem{3, 3, 3},
+		&structSliceElem{5, 5, 5},
+		&structSliceElem{6, 6, 6},
+		&structSliceElem{7, 7, 7},
+	}
+
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		out.Reset()
+		if err := Encode(&out, &value); err != nil {
+			b.Fatal(err)
+		}
+	}
+}

--- a/rlp/safe.go
+++ b/rlp/safe.go
@@ -21,6 +21,6 @@ package rlp
 import "reflect"
 
 // byteArrayBytes returns a slice of the byte array v.
-func byteArrayBytes(v reflect.Value) []byte {
-	return v.Slice(0, v.Len()).Bytes()
+func byteArrayBytes(v reflect.Value, length int) []byte {
+	return v.Slice(0, length).Bytes()
 }

--- a/rlp/unsafe.go
+++ b/rlp/unsafe.go
@@ -24,12 +24,11 @@ import (
 )
 
 // byteArrayBytes returns a slice of the byte array v.
-func byteArrayBytes(v reflect.Value) []byte {
-	len := v.Len()
+func byteArrayBytes(v reflect.Value, length int) []byte {
 	var s []byte
 	hdr := (*reflect.SliceHeader)(unsafe.Pointer(&s))
 	hdr.Data = v.UnsafeAddr()
-	hdr.Cap = len
-	hdr.Len = len
+	hdr.Cap = length
+	hdr.Len = length
 	return s
 }


### PR DESCRIPTION
As per benchmark results below, these changes speed up encoding/decoding of consensus objects a bit.

```
name                             old time/op    new time/op    delta
EncodeRLP/legacy-header-8           384ns ± 1%     331ns ± 3%  -13.83%  (p=0.000 n=7+8)
EncodeRLP/london-header-8           411ns ± 1%     359ns ± 2%  -12.53%  (p=0.000 n=8+8)
EncodeRLP/receipt-for-storage-8     251ns ± 0%     239ns ± 0%   -4.97%  (p=0.000 n=8+8)
EncodeRLP/receipt-full-8            319ns ± 0%     300ns ± 0%   -5.89%  (p=0.000 n=8+7)
EncodeRLP/legacy-transaction-8      389ns ± 1%     387ns ± 1%     ~     (p=0.099 n=8+8)
EncodeRLP/access-transaction-8      607ns ± 0%     581ns ± 0%   -4.26%  (p=0.000 n=8+8)
EncodeRLP/1559-transaction-8        627ns ± 0%     606ns ± 1%   -3.44%  (p=0.000 n=8+8)
DecodeRLP/legacy-header-8           831ns ± 1%     813ns ± 1%   -2.20%  (p=0.000 n=8+8)
DecodeRLP/london-header-8           824ns ± 0%     804ns ± 1%   -2.44%  (p=0.000 n=8+7)
```

I created these changes before starting work on the code generator. Mostly submitting this because it took non-trivial efforts to find these optimizations, so I feel like the changes are valuable even if we end up not using the reflect-based encoder/decoder later.