### PR TITLE
build: stop publishing deb packages for Ubuntu 20.10 Groovy Gorilla

### DIFF
--- a/build/ci.go
+++ b/build/ci.go
@@ -129,19 +129,13 @@ var (
 
 	// Distros for which packages are created.
 	// Note: vivid is unsupported because there is no golang-1.6 package for it.
-	// Note: wily is unsupported because it was officially deprecated on Launchpad.
-	// Note: yakkety is unsupported because it was officially deprecated on Launchpad.
-	// Note: zesty is unsupported because it was officially deprecated on Launchpad.
-	// Note: artful is unsupported because it was officially deprecated on Launchpad.
-	// Note: cosmic is unsupported because it was officially deprecated on Launchpad.
-	// Note: disco is unsupported because it was officially deprecated on Launchpad.
-	// Note: eoan is unsupported because it was officially deprecated on Launchpad.
+	// Note: the following Ubuntu releases have been officially deprecated on Launchpad:
+	//   wily, yakkety, zesty, artful, cosmic, disco, eoan, groovy
 	debDistroGoBoots = map[string]string{
 		"trusty":  "golang-1.11",
 		"xenial":  "golang-go",
 		"bionic":  "golang-go",
 		"focal":   "golang-go",
-		"groovy":  "golang-go",
 		"hirsute": "golang-go",
 	}
 


### PR DESCRIPTION
Support for this Ubuntu release has ended on July 22 2021 and
Launchpad no longer accepts uploads for it.