### PR TITLE
core/vm:  use rsh instead of lookup

### DIFF
--- a/core/vm/analysis.go
+++ b/core/vm/analysis.go
@@ -30,12 +30,8 @@ const (
 // it's data (i.e. argument of PUSHxx).
 type bitvec []byte
 
-var lookup = [8]byte{
-	0x80, 0x40, 0x20, 0x10, 0x8, 0x4, 0x2, 0x1,
-}
-
 func (bits bitvec) set1(pos uint64) {
-	bits[pos/8] |= lookup[pos%8]
+	bits[pos/8] |= 0x80 >> (pos & 7)
 }
 
 func (bits bitvec) setN(flag uint16, pos uint64) {


### PR DESCRIPTION
This PR cleans up the code analysis a bit. There's this ugly lookup there, instead of a bitshift. 

For some reason, whenever I try to remove that lookup, like this PR does, there's a performance loss. Results from `go v1.17`, with `go test . -run - -bench JumpdestOp/\(PUSH1$\|STOP\) -count 10 ` 
```
name                        old time/op  new time/op  delta
JumpdestOpAnalysis/PUSH1-6  27.3ns ± 4%  31.0ns ± 0%  +13.41%  (p=0.000 n=10+8)
JumpdestOpAnalysis/STOP-6   22.0ns ± 8%  17.7ns ± 1%  -19.73%  (p=0.000 n=10+8)
```

So the `PUSH1` degrades `13%`, and the `STOP`, which _should not be affected at all_ improves by ~20%. 

:confused: 

Do other folks get similar numbers? 