### PR TITLE
internal/ethapi: support both input and data for personal_sendTransaction

### DIFF
--- a/internal/ethapi/transaction_args.go
+++ b/internal/ethapi/transaction_args.go
@@ -146,6 +146,7 @@ func (args *TransactionArgs) setDefaults(ctx context.Context, b Backend) error {
 	if args.Gas == nil {
 		// These fields are immutable during the estimation, safe to
 		// pass the pointer directly.
+		data := args.data()
 		callArgs := TransactionArgs{
 			From:                 args.From,
 			To:                   args.To,
@@ -153,7 +154,7 @@ func (args *TransactionArgs) setDefaults(ctx context.Context, b Backend) error {
 			MaxFeePerGas:         args.MaxFeePerGas,
 			MaxPriorityFeePerGas: args.MaxPriorityFeePerGas,
 			Value:                args.Value,
-			Data:                 args.Data,
+			Data:                 (*hexutil.Bytes)(&data),
 			AccessList:           args.AccessList,
 		}
 		pendingBlockNr := rpc.BlockNumberOrHashWithNumber(rpc.PendingBlockNumber)


### PR DESCRIPTION
Currently, `setDefaults` [overwrites](https://github.com/ethereum/go-ethereum/blob/62ad17fb0046243255048fbf8cb0882f48d8d850/internal/ethapi/transaction_args.go#L156) the transaction input value if only `input` is provided. This causes `personal_sendTransaction` to estimate the gas based on a transaction with empty data. `eth_estimateGas` never calls `setDefaults` so it was unaffected by this.

```console
> params = { data: "0x6001", from: personal.listAccounts[0]  }
{
  data: "0x6001",
  from: "0xc0ffee61108b46c8b84c63df14e3a607ac981e93"
}
> personal.sendTransaction(params)
Error: intrinsic gas too low
        at web3.js:6347:37(47)
        at web3.js:5081:62(37)
        at <eval>:1:25(4)
```