### PR TITLE
ci: enable race tests as cron job on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -263,3 +263,15 @@ jobs:
         submodules: false # avoid cloning ethereum/tests
       script:
         - go run build/ci.go purge -store gethstore/builds -days 14
+
+    # This builder executes race tests
+    - stage: build
+      if: type = cron
+      os: linux
+      dist: bionic
+      go: 1.17.x
+      env:
+        - GO111MODULE=on
+      script:
+        - go run build/ci.go test  -race -coverage $TEST_PACKAGES
+

--- a/build/ci.go
+++ b/build/ci.go
@@ -276,6 +276,7 @@ func doTest(cmdline []string) {
 		cc       = flag.String("cc", "", "Sets C compiler binary")
 		coverage = flag.Bool("coverage", false, "Whether to record code coverage")
 		verbose  = flag.Bool("v", false, "Whether to log verbosely")
+		race     = flag.Bool("race", false, "Execute the race detector")
 	)
 	flag.CommandLine.Parse(cmdline)
 
@@ -295,6 +296,9 @@ func doTest(cmdline []string) {
 	}
 	if *verbose {
 		gotest.Args = append(gotest.Args, "-v")
+	}
+	if *race {
+		gotest.Args = append(gotest.Args, "-race")
 	}
 
 	packages := []string{"./..."}


### PR DESCRIPTION
Once we have the race condition fixes merged in it would be cool to enable the race tests as a cron job which runs once a week or so, such that we are alerted faster to potential races

Waits for 
https://github.com/ethereum/go-ethereum/pull/23474
https://github.com/ethereum/go-ethereum/pull/23435
https://github.com/ethereum/go-ethereum/pull/23457
https://github.com/ethereum/go-ethereum/pull/23434
(and probably one more)