### PR TITLE
core/vm: rework jumpdest analysis benchmarks

### DIFF
--- a/core/vm/analysis_test.go
+++ b/core/vm/analysis_test.go
@@ -89,6 +89,9 @@ func BenchmarkJumpdestOpAnalysis(bench *testing.B) {
 		bits := make(bitvec, len(code)/8+1+4)
 		b.ResetTimer()
 		for i := 0; i < b.N; i++ {
+			for j := range bits {
+				bits[j] = 0
+			}
 			codeBitmapInternal(code, bits)
 		}
 	}

--- a/core/vm/analysis_test.go
+++ b/core/vm/analysis_test.go
@@ -55,9 +55,12 @@ func TestJumpDestAnalysis(t *testing.T) {
 	}
 }
 
+const analysisCodeSize = 1200 * 1024
+
 func BenchmarkJumpdestAnalysis_1200k(bench *testing.B) {
 	// 1.4 ms
-	code := make([]byte, 1200000)
+	code := make([]byte, analysisCodeSize)
+	bench.SetBytes(analysisCodeSize)
 	bench.ResetTimer()
 	for i := 0; i < bench.N; i++ {
 		codeBitmap(code)
@@ -66,7 +69,8 @@ func BenchmarkJumpdestAnalysis_1200k(bench *testing.B) {
 }
 func BenchmarkJumpdestHashing_1200k(bench *testing.B) {
 	// 4 ms
-	code := make([]byte, 1200000)
+	code := make([]byte, analysisCodeSize)
+	bench.SetBytes(analysisCodeSize)
 	bench.ResetTimer()
 	for i := 0; i < bench.N; i++ {
 		crypto.Keccak256Hash(code)
@@ -77,13 +81,16 @@ func BenchmarkJumpdestHashing_1200k(bench *testing.B) {
 func BenchmarkJumpdestOpAnalysis(bench *testing.B) {
 	var op OpCode
 	bencher := func(b *testing.B) {
-		code := make([]byte, 32*b.N)
+		code := make([]byte, analysisCodeSize)
+		b.SetBytes(analysisCodeSize)
 		for i := range code {
 			code[i] = byte(op)
 		}
 		bits := make(bitvec, len(code)/8+1+4)
 		b.ResetTimer()
-		codeBitmapInternal(code, bits)
+		for i := 0; i < b.N; i++ {
+			codeBitmapInternal(code, bits)
+		}
 	}
 	for op = PUSH1; op <= PUSH32; op++ {
 		bench.Run(op.String(), bencher)


### PR DESCRIPTION
For BenchmarkJumpdestOpAnalysis use fixed code size of ~1.2MB and classic benchmark loop.

```
> go test -bench Jumpdest ./core/vm
goos: linux
goarch: amd64
pkg: github.com/ethereum/go-ethereum/core/vm
cpu: Intel(R) Core(TM) i7-4790K CPU @ 4.00GHz
BenchmarkJumpdestAnalysis_1200k-8           2296            520734 ns/op        2359.75 MB/s
BenchmarkJumpdestHashing_1200k-8             374           3144320 ns/op         390.80 MB/s
BenchmarkJumpdestOpAnalysis/PUSH1-8         1222            979226 ns/op        1254.87 MB/s
BenchmarkJumpdestOpAnalysis/PUSH2-8         1269            949313 ns/op        1294.41 MB/s
BenchmarkJumpdestOpAnalysis/PUSH3-8         1747            693702 ns/op        1771.37 MB/s
BenchmarkJumpdestOpAnalysis/PUSH4-8         2064            580610 ns/op        2116.40 MB/s
BenchmarkJumpdestOpAnalysis/PUSH5-8         2450            490246 ns/op        2506.50 MB/s
BenchmarkJumpdestOpAnalysis/PUSH6-8         2578            464158 ns/op        2647.38 MB/s
BenchmarkJumpdestOpAnalysis/PUSH7-8         3426            349600 ns/op        3514.88 MB/s
BenchmarkJumpdestOpAnalysis/PUSH8-8         2959            405411 ns/op        3031.00 MB/s
BenchmarkJumpdestOpAnalysis/PUSH9-8         3300            363186 ns/op        3383.39 MB/s
BenchmarkJumpdestOpAnalysis/PUSH10-8                2762            433539 ns/op        2834.35 MB/s
BenchmarkJumpdestOpAnalysis/PUSH11-8                2854            419256 ns/op        2930.91 MB/s
BenchmarkJumpdestOpAnalysis/PUSH12-8                3392            352346 ns/op        3487.48 MB/s
BenchmarkJumpdestOpAnalysis/PUSH13-8                3620            330475 ns/op        3718.28 MB/s
BenchmarkJumpdestOpAnalysis/PUSH14-8                3506            337805 ns/op        3637.61 MB/s
BenchmarkJumpdestOpAnalysis/PUSH15-8                3594            332182 ns/op        3699.17 MB/s
BenchmarkJumpdestOpAnalysis/PUSH16-8                4899            240817 ns/op        5102.62 MB/s
BenchmarkJumpdestOpAnalysis/PUSH17-8                5511            210879 ns/op        5827.03 MB/s
BenchmarkJumpdestOpAnalysis/PUSH18-8                4498            265887 ns/op        4621.51 MB/s
BenchmarkJumpdestOpAnalysis/PUSH19-8                4502            265590 ns/op        4626.68 MB/s
BenchmarkJumpdestOpAnalysis/PUSH20-8                5181            231383 ns/op        5310.68 MB/s
BenchmarkJumpdestOpAnalysis/PUSH21-8                5390            223635 ns/op        5494.66 MB/s
BenchmarkJumpdestOpAnalysis/PUSH22-8                5059            232717 ns/op        5280.23 MB/s
BenchmarkJumpdestOpAnalysis/PUSH23-8                5137            233021 ns/op        5273.34 MB/s
BenchmarkJumpdestOpAnalysis/PUSH24-8                5631            212401 ns/op        5785.28 MB/s
BenchmarkJumpdestOpAnalysis/PUSH25-8                5566            215068 ns/op        5713.55 MB/s
BenchmarkJumpdestOpAnalysis/PUSH26-8                5005            239064 ns/op        5140.05 MB/s
BenchmarkJumpdestOpAnalysis/PUSH27-8                4989            239589 ns/op        5128.79 MB/s
BenchmarkJumpdestOpAnalysis/PUSH28-8                5527            215729 ns/op        5696.05 MB/s
BenchmarkJumpdestOpAnalysis/PUSH29-8                5695            209925 ns/op        5853.53 MB/s
BenchmarkJumpdestOpAnalysis/PUSH30-8                5012            217636 ns/op        5646.12 MB/s
BenchmarkJumpdestOpAnalysis/PUSH31-8                5478            218488 ns/op        5624.12 MB/s
BenchmarkJumpdestOpAnalysis/PUSH32-8                7039            169517 ns/op        7248.82 MB/s
BenchmarkJumpdestOpAnalysis/JUMPDEST-8              2448            489197 ns/op        2511.87 MB/s
BenchmarkJumpdestOpAnalysis/STOP-8                  2448            489231 ns/op        2511.70 MB/s
PASS
ok      github.com/ethereum/go-ethereum/core/vm 46.594s
```