### PR TITLE
core/vm: optimize jumpdest analysis

### DIFF
--- a/core/vm/analysis.go
+++ b/core/vm/analysis.go
@@ -76,7 +76,7 @@ func codeBitmapInternal(code, bits bitvec) bitvec {
 	for pc := uint64(0); pc < uint64(len(code)); {
 		op := OpCode(code[pc])
 		pc++
-		if op < PUSH1 || op > PUSH32 {
+		if int8(op) < int8(PUSH1) { // If not PUSH (the int8(op) > int(PUSH32) is always false).
 			continue
 		}
 		numbits := op - PUSH1 + 1


### PR DESCRIPTION
I benchmarked each commit separately, each giving some positive results but with tiny regressions in some cases (two worst cases PUSH1 and PUSH2 were never negatively affected).

Total performance change:
```
name                           old time/op    new time/op    delta                                                                                                                                                                
JumpdestOpAnalysis/PUSH1-8        983µs ± 0%     843µs ± 0%  -14.22%  (p=0.000 n=9+9)                                                                                                                                             
JumpdestOpAnalysis/PUSH2-8        947µs ± 0%     843µs ± 0%  -11.05%  (p=0.000 n=8+9)                                                                                                                                             
JumpdestOpAnalysis/PUSH3-8        698µs ± 0%     633µs ± 0%   -9.28%  (p=0.000 n=10+8)                                                                                                                                            
JumpdestOpAnalysis/PUSH4-8        584µs ± 0%     507µs ± 0%  -13.22%  (p=0.000 n=9+9)                                                                                                                                             
JumpdestOpAnalysis/PUSH5-8        493µs ± 0%     423µs ± 0%  -14.18%  (p=0.000 n=8+8)                                                                                                                                             
JumpdestOpAnalysis/PUSH6-8        468µs ± 0%     363µs ± 0%  -22.40%  (p=0.000 n=9+8)                                                                                                                                             
JumpdestOpAnalysis/PUSH7-8        353µs ± 0%     353µs ± 0%     ~     (p=0.161 n=8+8)                                                                                                                                             
JumpdestOpAnalysis/PUSH8-8        409µs ± 0%     345µs ± 0%  -15.44%  (p=0.000 n=9+9)                                                                                                                                             
JumpdestOpAnalysis/PUSH9-8        366µs ± 0%     367µs ± 0%   +0.19%  (p=0.000 n=9+8)                                                                                                                                             
JumpdestOpAnalysis/PUSH10-8       438µs ± 0%     410µs ± 0%   -6.20%  (p=0.000 n=9+9)                                                                                                                                             
JumpdestOpAnalysis/PUSH11-8       423µs ± 0%     400µs ± 0%   -5.50%  (p=0.000 n=8+8)                                                                                                                                             
JumpdestOpAnalysis/PUSH12-8       356µs ± 0%     337µs ± 0%   -5.33%  (p=0.000 n=9+9)                                                                                                                                             
JumpdestOpAnalysis/PUSH13-8       341µs ± 5%     323µs ± 0%   -5.42%  (p=0.000 n=9+8)                                                                                                                                             
JumpdestOpAnalysis/PUSH14-8       342µs ± 0%     321µs ± 0%   -6.14%  (p=0.000 n=9+8)
JumpdestOpAnalysis/PUSH15-8       336µs ± 0%     319µs ± 0%   -5.13%  (p=0.000 n=10+10)
JumpdestOpAnalysis/PUSH16-8       247µs ± 2%     218µs ± 0%  -11.98%  (p=0.000 n=10+9)
JumpdestOpAnalysis/PUSH17-8       221µs ± 0%     209µs ± 0%   -5.41%  (p=0.000 n=9+10)
JumpdestOpAnalysis/PUSH18-8       270µs ± 0%     254µs ± 0%   -5.85%  (p=0.000 n=8+9)
JumpdestOpAnalysis/PUSH19-8       269µs ± 0%     255µs ± 0%   -5.19%  (p=0.000 n=9+8)
JumpdestOpAnalysis/PUSH20-8       235µs ± 0%     230µs ± 0%   -2.14%  (p=0.000 n=9+8)
JumpdestOpAnalysis/PUSH21-8       226µs ± 0%     220µs ± 0%   -2.80%  (p=0.000 n=8+9)
JumpdestOpAnalysis/PUSH22-8       237µs ± 0%     223µs ± 0%   -5.99%  (p=0.000 n=10+9)
JumpdestOpAnalysis/PUSH23-8       237µs ± 0%     225µs ± 0%   -4.90%  (p=0.000 n=9+9)
JumpdestOpAnalysis/PUSH24-8       216µs ± 0%     205µs ± 0%   -5.17%  (p=0.000 n=9+8)
JumpdestOpAnalysis/PUSH25-8       219µs ± 0%     208µs ± 0%   -4.85%  (p=0.000 n=8+9)
JumpdestOpAnalysis/PUSH26-8       243µs ± 0%     221µs ± 0%   -8.90%  (p=0.000 n=8+9)
JumpdestOpAnalysis/PUSH27-8       243µs ± 0%     223µs ± 0%   -8.17%  (p=0.000 n=8+9)
JumpdestOpAnalysis/PUSH28-8       220µs ± 0%     206µs ± 0%   -6.10%  (p=0.000 n=10+9)
JumpdestOpAnalysis/PUSH29-8       213µs ± 0%     199µs ± 0%   -6.51%  (p=0.000 n=9+8)
JumpdestOpAnalysis/PUSH30-8       221µs ± 0%     202µs ± 0%   -8.61%  (p=0.000 n=10+9)
JumpdestOpAnalysis/PUSH31-8       222µs ± 0%     205µs ± 0%   -7.84%  (p=0.000 n=9+9)
JumpdestOpAnalysis/PUSH32-8       173µs ± 0%     165µs ± 0%   -4.87%  (p=0.000 n=8+9)
JumpdestOpAnalysis/JUMPDEST-8     493µs ± 0%     423µs ± 0%  -14.20%  (p=0.000 n=9+9)
JumpdestOpAnalysis/STOP-8         493µs ± 0%     424µs ± 0%  -14.07%  (p=0.000 n=8+10)

name                           old speed      new speed      delta
JumpdestOpAnalysis/PUSH1-8     1.25GB/s ± 0%  1.46GB/s ± 0%  +16.57%  (p=0.000 n=9+9)
JumpdestOpAnalysis/PUSH2-8     1.30GB/s ± 0%  1.46GB/s ± 0%  +12.42%  (p=0.000 n=8+9)
JumpdestOpAnalysis/PUSH3-8     1.76GB/s ± 0%  1.94GB/s ± 0%  +10.23%  (p=0.000 n=10+8)
JumpdestOpAnalysis/PUSH4-8     2.10GB/s ± 0%  2.42GB/s ± 0%  +15.23%  (p=0.000 n=9+9)
JumpdestOpAnalysis/PUSH5-8     2.49GB/s ± 0%  2.90GB/s ± 0%  +16.53%  (p=0.000 n=8+8)
JumpdestOpAnalysis/PUSH6-8     2.63GB/s ± 0%  3.38GB/s ± 0%  +28.86%  (p=0.000 n=9+8)
JumpdestOpAnalysis/PUSH7-8     3.48GB/s ± 0%  3.48GB/s ± 0%     ~     (p=0.161 n=8+8)
JumpdestOpAnalysis/PUSH8-8     3.01GB/s ± 0%  3.56GB/s ± 0%  +18.26%  (p=0.000 n=9+9)
JumpdestOpAnalysis/PUSH9-8     3.36GB/s ± 0%  3.35GB/s ± 0%   -0.19%  (p=0.000 n=9+8)
JumpdestOpAnalysis/PUSH10-8    2.81GB/s ± 0%  2.99GB/s ± 0%   +6.61%  (p=0.000 n=9+9)
JumpdestOpAnalysis/PUSH11-8    2.90GB/s ± 0%  3.07GB/s ± 0%   +5.82%  (p=0.000 n=8+8)
JumpdestOpAnalysis/PUSH12-8    3.45GB/s ± 0%  3.65GB/s ± 0%   +5.63%  (p=0.000 n=9+9)
JumpdestOpAnalysis/PUSH13-8    3.60GB/s ± 5%  3.81GB/s ± 0%   +5.62%  (p=0.000 n=9+8)
JumpdestOpAnalysis/PUSH14-8    3.60GB/s ± 0%  3.83GB/s ± 0%   +6.54%  (p=0.000 n=9+8)
JumpdestOpAnalysis/PUSH15-8    3.66GB/s ± 0%  3.86GB/s ± 0%   +5.40%  (p=0.000 n=10+10)
JumpdestOpAnalysis/PUSH16-8    4.97GB/s ± 2%  5.64GB/s ± 0%  +13.59%  (p=0.000 n=10+9)
JumpdestOpAnalysis/PUSH17-8    5.56GB/s ± 0%  5.88GB/s ± 0%   +5.72%  (p=0.000 n=9+10)
JumpdestOpAnalysis/PUSH18-8    4.56GB/s ± 0%  4.84GB/s ± 0%   +6.21%  (p=0.000 n=8+9)
JumpdestOpAnalysis/PUSH19-8    4.56GB/s ± 0%  4.81GB/s ± 0%   +5.47%  (p=0.000 n=9+8)
JumpdestOpAnalysis/PUSH20-8    5.23GB/s ± 0%  5.34GB/s ± 0%   +2.18%  (p=0.000 n=9+8)
JumpdestOpAnalysis/PUSH21-8    5.43GB/s ± 0%  5.59GB/s ± 0%   +2.88%  (p=0.000 n=8+9)
JumpdestOpAnalysis/PUSH22-8    5.19GB/s ± 0%  5.52GB/s ± 0%   +6.37%  (p=0.000 n=10+9)
JumpdestOpAnalysis/PUSH23-8    5.19GB/s ± 0%  5.46GB/s ± 0%   +5.15%  (p=0.000 n=9+9)
JumpdestOpAnalysis/PUSH24-8    5.68GB/s ± 0%  5.99GB/s ± 0%   +5.45%  (p=0.000 n=9+8)
JumpdestOpAnalysis/PUSH25-8    5.62GB/s ± 0%  5.90GB/s ± 0%   +5.10%  (p=0.000 n=8+9)
JumpdestOpAnalysis/PUSH26-8    5.06GB/s ± 0%  5.55GB/s ± 0%   +9.77%  (p=0.000 n=8+9)
JumpdestOpAnalysis/PUSH27-8    5.05GB/s ± 0%  5.50GB/s ± 0%   +8.89%  (p=0.000 n=8+9)
JumpdestOpAnalysis/PUSH28-8    5.60GB/s ± 0%  5.96GB/s ± 0%   +6.50%  (p=0.000 n=10+9)
JumpdestOpAnalysis/PUSH29-8    5.76GB/s ± 0%  6.16GB/s ± 0%   +6.97%  (p=0.000 n=9+8)
JumpdestOpAnalysis/PUSH30-8    5.55GB/s ± 0%  6.08GB/s ± 0%   +9.43%  (p=0.000 n=10+9)
JumpdestOpAnalysis/PUSH31-8    5.53GB/s ± 0%  6.00GB/s ± 0%   +8.51%  (p=0.000 n=9+9)
JumpdestOpAnalysis/PUSH32-8    7.10GB/s ± 0%  7.46GB/s ± 0%   +5.11%  (p=0.000 n=8+9)
JumpdestOpAnalysis/JUMPDEST-8  2.49GB/s ± 0%  2.90GB/s ± 0%  +16.55%  (p=0.000 n=9+9)
JumpdestOpAnalysis/STOP-8      2.49GB/s ± 0%  2.90GB/s ± 0%  +16.37%  (p=0.000 n=8+10)
```