### PR TITLE
core, light, tests, trie: extract trie diff information and display in metrics

### DIFF
--- a/core/state/database.go
+++ b/core/state/database.go
@@ -86,7 +86,7 @@ type Trie interface {
 
 	// Commit writes all nodes to the trie's memory database, tracking the internal
 	// and external (for account tries) references.
-	Commit(onleaf trie.LeafCallback) (common.Hash, int, error)
+	Commit(onleaf trie.LeafCallback) (*trie.CommitResult, error)
 
 	// NodeIterator returns an iterator that returns nodes of the trie. Iteration
 	// starts at the key after the given start key.

--- a/core/state/metrics.go
+++ b/core/state/metrics.go
@@ -19,10 +19,12 @@ package state
 import "github.com/ethereum/go-ethereum/metrics"
 
 var (
-	accountUpdatedMeter   = metrics.NewRegisteredMeter("state/update/account", nil)
-	storageUpdatedMeter   = metrics.NewRegisteredMeter("state/update/storage", nil)
-	accountDeletedMeter   = metrics.NewRegisteredMeter("state/delete/account", nil)
-	storageDeletedMeter   = metrics.NewRegisteredMeter("state/delete/storage", nil)
-	accountCommittedMeter = metrics.NewRegisteredMeter("state/commit/account", nil)
-	storageCommittedMeter = metrics.NewRegisteredMeter("state/commit/storage", nil)
+	rawAccountUpdatedMeter  = metrics.NewRegisteredMeter("state/raw/update/account", nil)
+	rawStorageUpdatedMeter  = metrics.NewRegisteredMeter("state/raw/update/storage", nil)
+	rawAccountDeletedMeter  = metrics.NewRegisteredMeter("state/raw/delete/account", nil)
+	rawStorageDeletedMeter  = metrics.NewRegisteredMeter("state/raw/delete/storage", nil)
+	trieAccountUpdatedMeter = metrics.NewRegisteredMeter("state/trie/update/account", nil)
+	trieStorageUpdatedMeter = metrics.NewRegisteredMeter("state/trie/update/storage", nil)
+	trieAccountDeletedMeter = metrics.NewRegisteredMeter("state/trie/delete/account", nil)
+	trieStorageDeletedMeter = metrics.NewRegisteredMeter("state/trie/delete/storage", nil)
 )

--- a/core/state/snapshot/generate.go
+++ b/core/state/snapshot/generate.go
@@ -436,8 +436,10 @@ func (dl *diskLayer) generateRange(root common.Hash, prefix []byte, kind string,
 		for i, key := range result.keys {
 			snapTrie.Update(key, result.vals[i])
 		}
-		root, _, _ := snapTrie.Commit(nil)
-		snapTrieDb.Commit(root, false, nil)
+		result, err := snapTrie.Commit(nil)
+		if err == nil {
+			snapTrieDb.Commit(result.Root, false, nil)
+		}
 	}
 	tr := result.tr
 	if tr == nil {

--- a/core/state/snapshot/generate_test.go
+++ b/core/state/snapshot/generate_test.go
@@ -60,7 +60,8 @@ func TestGeneration(t *testing.T) {
 	acc = &Account{Balance: big.NewInt(3), Root: stTrie.Hash().Bytes(), CodeHash: emptyCode.Bytes()}
 	val, _ = rlp.EncodeToBytes(acc)
 	accTrie.Update([]byte("acc-3"), val) // 0x50815097425d000edfc8b3a4a13e175fc2bdcfee8bdfbf2d1ff61041d3c235b2
-	root, _, _ := accTrie.Commit(nil)    // Root: 0xe3712f1a226f3782caca78ca770ccc19ee000552813a9f59d479f8611db9b1fd
+	result, _ := accTrie.Commit(nil)     // Root: 0xe3712f1a226f3782caca78ca770ccc19ee000552813a9f59d479f8611db9b1fd
+	root := result.Root
 	triedb.Commit(root, false, nil)
 
 	if have, want := root, common.HexToHash("0xe3712f1a226f3782caca78ca770ccc19ee000552813a9f59d479f8611db9b1fd"); have != want {
@@ -128,7 +129,8 @@ func TestGenerateExistentState(t *testing.T) {
 	rawdb.WriteStorageSnapshot(diskdb, hashData([]byte("acc-3")), hashData([]byte("key-2")), []byte("val-2"))
 	rawdb.WriteStorageSnapshot(diskdb, hashData([]byte("acc-3")), hashData([]byte("key-3")), []byte("val-3"))
 
-	root, _, _ := accTrie.Commit(nil) // Root: 0xe3712f1a226f3782caca78ca770ccc19ee000552813a9f59d479f8611db9b1fd
+	result, _ := accTrie.Commit(nil) // Root: 0xe3712f1a226f3782caca78ca770ccc19ee000552813a9f59d479f8611db9b1fd
+	root := result.Root
 	triedb.Commit(root, false, nil)
 
 	snap := generateSnapshot(diskdb, triedb, 16, root)
@@ -215,12 +217,14 @@ func (t *testHelper) makeStorageTrie(keys []string, vals []string) []byte {
 	for i, k := range keys {
 		stTrie.Update([]byte(k), []byte(vals[i]))
 	}
-	root, _, _ := stTrie.Commit(nil)
+	result, _ := stTrie.Commit(nil)
+	root := result.Root
 	return root.Bytes()
 }
 
 func (t *testHelper) Generate() (common.Hash, *diskLayer) {
-	root, _, _ := t.accTrie.Commit(nil)
+	result, _ := t.accTrie.Commit(nil)
+	root := result.Root
 	t.triedb.Commit(root, false, nil)
 	snap := generateSnapshot(t.diskdb, t.triedb, 16, root)
 	return root, snap
@@ -575,7 +579,8 @@ func TestGenerateWithExtraAccounts(t *testing.T) {
 		rawdb.WriteStorageSnapshot(diskdb, key, hashData([]byte("b-key-2")), []byte("b-val-2"))
 		rawdb.WriteStorageSnapshot(diskdb, key, hashData([]byte("b-key-3")), []byte("b-val-3"))
 	}
-	root, _, _ := accTrie.Commit(nil)
+	result, _ := accTrie.Commit(nil)
+	root := result.Root
 	t.Logf("root: %x", root)
 	triedb.Commit(root, false, nil)
 	// To verify the test: If we now inspect the snap db, there should exist extraneous storage items
@@ -637,7 +642,8 @@ func TestGenerateWithManyExtraAccounts(t *testing.T) {
 			rawdb.WriteAccountSnapshot(diskdb, key, val)
 		}
 	}
-	root, _, _ := accTrie.Commit(nil)
+	result, _ := accTrie.Commit(nil)
+	root := result.Root
 	t.Logf("root: %x", root)
 	triedb.Commit(root, false, nil)
 
@@ -690,7 +696,8 @@ func TestGenerateWithExtraBeforeAndAfter(t *testing.T) {
 		rawdb.WriteAccountSnapshot(diskdb, common.HexToHash("0x07"), val)
 	}
 
-	root, _, _ := accTrie.Commit(nil)
+	result, _ := accTrie.Commit(nil)
+	root := result.Root
 	t.Logf("root: %x", root)
 	triedb.Commit(root, false, nil)
 
@@ -734,7 +741,8 @@ func TestGenerateWithMalformedSnapdata(t *testing.T) {
 		rawdb.WriteAccountSnapshot(diskdb, common.HexToHash("0x05"), junk)
 	}
 
-	root, _, _ := accTrie.Commit(nil)
+	result, _ := accTrie.Commit(nil)
+	root := result.Root
 	t.Logf("root: %x", root)
 	triedb.Commit(root, false, nil)
 

--- a/core/state/state_object.go
+++ b/core/state/state_object.go
@@ -398,23 +398,24 @@ func (s *stateObject) updateRoot(db Database) {
 
 // CommitTrie the storage trie of the object to db.
 // This updates the trie root.
-func (s *stateObject) CommitTrie(db Database) (int, error) {
+func (s *stateObject) CommitTrie(db Database) (int, int, error) {
 	// If nothing changed, don't bother with hashing anything
 	if s.updateTrie(db) == nil {
-		return 0, nil
+		return 0, 0, nil
 	}
 	if s.dbErr != nil {
-		return 0, s.dbErr
+		return 0, 0, s.dbErr
 	}
 	// Track the amount of time wasted on committing the storage trie
 	if metrics.EnabledExpensive {
 		defer func(start time.Time) { s.db.StorageCommits += time.Since(start) }(time.Now())
 	}
-	root, committed, err := s.trie.Commit(nil)
-	if err == nil {
-		s.data.Root = root
+	result, err := s.trie.Commit(nil)
+	if err != nil {
+		return 0, 0, err
 	}
-	return committed, err
+	s.data.Root = result.Root
+	return len(result.UpdatedNodes), len(result.DeletedNodes), err
 }
 
 // AddBalance adds amount to s's balance.

--- a/core/state/statedb.go
+++ b/core/state/statedb.go
@@ -910,7 +910,10 @@ func (s *StateDB) Commit(deleteEmptyObjects bool) (common.Hash, error) {
 	s.IntermediateRoot(deleteEmptyObjects)
 
 	// Commit objects to the trie, measuring the elapsed time
-	var storageCommitted int
+	var (
+		storageUpdated int
+		storageDeleted int
+	)
 	codeWriter := s.db.TrieDB().DiskDB().NewBatch()
 	for addr := range s.stateObjectsDirty {
 		if obj := s.stateObjects[addr]; !obj.deleted {
@@ -920,11 +923,12 @@ func (s *StateDB) Commit(deleteEmptyObjects bool) (common.Hash, error) {
 				obj.dirtyCode = false
 			}
 			// Write any storage changes in the state object to its storage trie
-			committed, err := obj.CommitTrie(s.db)
+			updated, deleted, err := obj.CommitTrie(s.db)
 			if err != nil {
 				return common.Hash{}, err
 			}
-			storageCommitted += committed
+			storageUpdated += updated
+			storageDeleted += deleted
 		}
 	}
 	if len(s.stateObjectsDirty) > 0 {
@@ -943,7 +947,7 @@ func (s *StateDB) Commit(deleteEmptyObjects bool) (common.Hash, error) {
 	// The onleaf func is called _serially_, so we can reuse the same account
 	// for unmarshalling every time.
 	var account Account
-	root, accountCommitted, err := s.trie.Commit(func(_ [][]byte, _ []byte, leaf []byte, parent common.Hash) error {
+	result, err := s.trie.Commit(func(_ [][]byte, _ []byte, leaf []byte, parent common.Hash) error {
 		if err := rlp.DecodeBytes(leaf, &account); err != nil {
 			return nil
 		}
@@ -955,15 +959,19 @@ func (s *StateDB) Commit(deleteEmptyObjects bool) (common.Hash, error) {
 	if err != nil {
 		return common.Hash{}, err
 	}
+	root := result.Root
+
 	if metrics.EnabledExpensive {
 		s.AccountCommits += time.Since(start)
 
-		accountUpdatedMeter.Mark(int64(s.AccountUpdated))
-		storageUpdatedMeter.Mark(int64(s.StorageUpdated))
-		accountDeletedMeter.Mark(int64(s.AccountDeleted))
-		storageDeletedMeter.Mark(int64(s.StorageDeleted))
-		accountCommittedMeter.Mark(int64(accountCommitted))
-		storageCommittedMeter.Mark(int64(storageCommitted))
+		rawAccountUpdatedMeter.Mark(int64(s.AccountUpdated))
+		rawStorageUpdatedMeter.Mark(int64(s.StorageUpdated))
+		rawAccountDeletedMeter.Mark(int64(s.AccountDeleted))
+		rawStorageDeletedMeter.Mark(int64(s.StorageDeleted))
+		trieAccountUpdatedMeter.Mark(int64(len(result.UpdatedNodes)))
+		trieAccountDeletedMeter.Mark(int64(len(result.DeletedNodes)))
+		trieStorageUpdatedMeter.Mark(int64(storageUpdated))
+		trieStorageDeletedMeter.Mark(int64(storageDeleted))
 		s.AccountUpdated, s.AccountDeleted = 0, 0
 		s.StorageUpdated, s.StorageDeleted = 0, 0
 	}

--- a/light/postprocess.go
+++ b/light/postprocess.go
@@ -217,10 +217,12 @@ func (c *ChtIndexerBackend) Process(ctx context.Context, header *types.Header) e
 
 // Commit implements core.ChainIndexerBackend
 func (c *ChtIndexerBackend) Commit() error {
-	root, _, err := c.trie.Commit(nil)
+	result, err := c.trie.Commit(nil)
 	if err != nil {
 		return err
 	}
+	root := result.Root
+
 	// Pruning historical trie nodes if necessary.
 	if !c.disablePruning {
 		// Flush the triedb and track the latest trie nodes.
@@ -253,7 +255,7 @@ func (c *ChtIndexerBackend) Commit() error {
 	return nil
 }
 
-// PruneSections implements core.ChainIndexerBackend which deletes all
+// Prune implements core.ChainIndexerBackend which deletes all
 // chain data(except hash<->number mappings) older than the specified
 // threshold.
 func (c *ChtIndexerBackend) Prune(threshold uint64) error {
@@ -454,10 +456,12 @@ func (b *BloomTrieIndexerBackend) Commit() error {
 			b.trie.Delete(encKey[:])
 		}
 	}
-	root, _, err := b.trie.Commit(nil)
+	result, err := b.trie.Commit(nil)
 	if err != nil {
 		return err
 	}
+	root := result.Root
+
 	// Pruning historical trie nodes if necessary.
 	if !b.disablePruning {
 		// Flush the triedb and track the latest trie nodes.

--- a/light/trie.go
+++ b/light/trie.go
@@ -125,9 +125,9 @@ func (t *odrTrie) TryDelete(key []byte) error {
 	})
 }
 
-func (t *odrTrie) Commit(onleaf trie.LeafCallback) (common.Hash, int, error) {
+func (t *odrTrie) Commit(onleaf trie.LeafCallback) (*trie.CommitResult, error) {
 	if t.trie == nil {
-		return t.id.Root, 0, nil
+		return &trie.CommitResult{Root: t.id.Root}, nil
 	}
 	return t.trie.Commit(onleaf)
 }

--- a/tests/fuzzers/stacktrie/trie_fuzzer.go
+++ b/tests/fuzzers/stacktrie/trie_fuzzer.go
@@ -173,10 +173,12 @@ func (f *fuzzer) fuzz() int {
 		return 0
 	}
 	// Flush trie -> database
-	rootA, _, err := trieA.Commit(nil)
+	result, err := trieA.Commit(nil)
 	if err != nil {
 		panic(err)
 	}
+	rootA := result.Root
+
 	// Flush memdb -> disk (sponge)
 	dbA.Commit(rootA, false, nil)
 

--- a/tests/fuzzers/trie/trie-fuzzer.go
+++ b/tests/fuzzers/trie/trie-fuzzer.go
@@ -162,14 +162,15 @@ func runRandTest(rt randTest) error {
 				rt[i].err = fmt.Errorf("mismatch for key 0x%x, got 0x%x want 0x%x", step.key, v, want)
 			}
 		case opCommit:
-			_, _, rt[i].err = tr.Commit(nil)
+			_, rt[i].err = tr.Commit(nil)
 		case opHash:
 			tr.Hash()
 		case opReset:
-			hash, _, err := tr.Commit(nil)
+			result, err := tr.Commit(nil)
 			if err != nil {
 				return err
 			}
+			hash := result.Root
 			newtr, err := trie.New(hash, triedb)
 			if err != nil {
 				return err

--- a/trie/committer.go
+++ b/trie/committer.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/rlp"
 	"golang.org/x/crypto/sha3"
 )
 
@@ -47,8 +48,10 @@ type committer struct {
 	tmp sliceBuffer
 	sha crypto.KeccakState
 
-	onleaf LeafCallback
-	leafCh chan *leaf
+	owner   common.Hash
+	onleaf  LeafCallback
+	leafCh  chan *leaf
+	tracker *diffTracker
 }
 
 // committers live in a global sync.Pool
@@ -62,36 +65,40 @@ var committerPool = sync.Pool{
 }
 
 // newCommitter creates a new committer or picks one from the pool.
-func newCommitter() *committer {
-	return committerPool.Get().(*committer)
+func newCommitter(tracker *diffTracker) *committer {
+	committer := committerPool.Get().(*committer)
+	committer.tracker = tracker
+	return committer
 }
 
 func returnCommitterToPool(h *committer) {
 	h.onleaf = nil
 	h.leafCh = nil
+	h.owner = common.Hash{}
+	h.tracker = nil
 	committerPool.Put(h)
 }
 
 // Commit collapses a node down into a hash node and inserts it into the database
-func (c *committer) Commit(n node, db *Database) (hashNode, int, error) {
+func (c *committer) Commit(n node, db *Database) (hashNode, error) {
 	if db == nil {
-		return nil, 0, errors.New("no db provided")
+		return nil, errors.New("no db provided")
 	}
-	h, committed, err := c.commit(n, db)
+	h, err := c.commit(nil, n, db)
 	if err != nil {
-		return nil, 0, err
+		return nil, err
 	}
-	return h.(hashNode), committed, nil
+	return h.(hashNode), nil
 }
 
 // commit collapses a node down into a hash node and inserts it into the database
-func (c *committer) commit(n node, db *Database) (node, int, error) {
+func (c *committer) commit(path []byte, n node, db *Database) (node, error) {
 	// if this path is clean, use available cached data
 	hash, dirty := n.cache()
 	if hash != nil && !dirty {
-		return hash, 0, nil
+		return hash, nil
 	}
-	// Commit children, then parent, and remove remove the dirty flag.
+	// Commit children, then parent, and remove the dirty flag.
 	switch cn := n.(type) {
 	case *shortNode:
 		// Commit child
@@ -99,36 +106,35 @@ func (c *committer) commit(n node, db *Database) (node, int, error) {
 
 		// If the child is fullNode, recursively commit,
 		// otherwise it can only be hashNode or valueNode.
-		var childCommitted int
 		if _, ok := cn.Val.(*fullNode); ok {
-			childV, committed, err := c.commit(cn.Val, db)
+			childV, err := c.commit(append(path, cn.Key...), cn.Val, db)
 			if err != nil {
-				return nil, 0, err
+				return nil, err
 			}
-			collapsed.Val, childCommitted = childV, committed
+			collapsed.Val = childV
 		}
 		// The key needs to be copied, since we're delivering it to database
 		collapsed.Key = hexToCompact(cn.Key)
-		hashedNode := c.store(collapsed, db)
+		hashedNode := c.store(path, collapsed, db)
 		if hn, ok := hashedNode.(hashNode); ok {
-			return hn, childCommitted + 1, nil
+			return hn, nil
 		}
-		return collapsed, childCommitted, nil
+		return collapsed, nil
 	case *fullNode:
-		hashedKids, childCommitted, err := c.commitChildren(cn, db)
+		hashedKids, err := c.commitChildren(path, cn, db)
 		if err != nil {
-			return nil, 0, err
+			return nil, err
 		}
 		collapsed := cn.copy()
 		collapsed.Children = hashedKids
 
-		hashedNode := c.store(collapsed, db)
+		hashedNode := c.store(path, collapsed, db)
 		if hn, ok := hashedNode.(hashNode); ok {
-			return hn, childCommitted + 1, nil
+			return hn, nil
 		}
-		return collapsed, childCommitted, nil
+		return collapsed, nil
 	case hashNode:
-		return cn, 0, nil
+		return cn, nil
 	default:
 		// nil, valuenode shouldn't be committed
 		panic(fmt.Sprintf("%T: invalid node: %v", n, n))
@@ -136,11 +142,8 @@ func (c *committer) commit(n node, db *Database) (node, int, error) {
 }
 
 // commitChildren commits the children of the given fullnode
-func (c *committer) commitChildren(n *fullNode, db *Database) ([17]node, int, error) {
-	var (
-		committed int
-		children  [17]node
-	)
+func (c *committer) commitChildren(path []byte, n *fullNode, db *Database) ([17]node, error) {
+	var children [17]node
 	for i := 0; i < 16; i++ {
 		child := n.Children[i]
 		if child == nil {
@@ -156,39 +159,41 @@ func (c *committer) commitChildren(n *fullNode, db *Database) ([17]node, int, er
 		// Commit the child recursively and store the "hashed" value.
 		// Note the returned node can be some embedded nodes, so it's
 		// possible the type is not hashNode.
-		hashed, childCommitted, err := c.commit(child, db)
+		hashed, err := c.commit(append(path, byte(i)), child, db)
 		if err != nil {
-			return children, 0, err
+			return children, err
 		}
 		children[i] = hashed
-		committed += childCommitted
 	}
 	// For the 17th child, it's possible the type is valuenode.
 	if n.Children[16] != nil {
 		children[16] = n.Children[16]
 	}
-	return children, committed, nil
+	return children, nil
 }
 
 // store hashes the node n and if we have a storage layer specified, it writes
 // the key/value pair to it and tracks any node->child references as well as any
 // node->external trie references.
-func (c *committer) store(n node, db *Database) node {
+func (c *committer) store(path []byte, n node, db *Database) node {
 	// Larger nodes are replaced by their hash and stored in the database.
-	var (
-		hash, _ = n.cache()
-		size    int
-	)
+	var hash, _ = n.cache()
+
+	// This was not generated - must be a small node stored in the parent.
+	// In theory, we should apply the leafCall here if it's not nil(embedded
+	// node usually contains value). But small value(less than 32bytes) is
+	// not our target.
 	if hash == nil {
-		// This was not generated - must be a small node stored in the parent.
-		// In theory, we should apply the leafCall here if it's not nil(embedded
-		// node usually contains value). But small value(less than 32bytes) is
-		// not our target.
 		return n
-	} else {
-		// We have the hash already, estimate the RLP encoding-size of the node.
-		// The size is used for mem tracking, does not need to be exact
-		size = estimateSize(n)
+	}
+	// We have the hash already, estimate the RLP encoding-size of the node.
+	// The size is used for mem tracking, does not need to be exact
+	size := estimateSize(n)
+
+	// Track the updated trie nodes during the commit operation.
+	if c.tracker != nil {
+		blob, _ := rlp.EncodeToBytes(n)
+		c.tracker.onUpdate(path, blob)
 	}
 	// If we're using channel-based leaf-reporting, send to channel.
 	// The leaf channel will be active only when there an active leaf-callback

--- a/trie/iterator_test.go
+++ b/trie/iterator_test.go
@@ -393,7 +393,8 @@ func testIteratorContinueAfterSeekError(t *testing.T, memonly bool) {
 	for _, val := range testdata1 {
 		ctr.Update([]byte(val.k), []byte(val.v))
 	}
-	root, _, _ := ctr.Commit(nil)
+	result, _ := ctr.Commit(nil)
+	root := result.Root
 	if !memonly {
 		triedb.Commit(root, true, nil)
 	}

--- a/trie/secure_trie.go
+++ b/trie/secure_trie.go
@@ -144,7 +144,7 @@ func (t *SecureTrie) GetKey(shaKey []byte) []byte {
 //
 // Committing flushes nodes from memory. Subsequent Get calls will load nodes
 // from the database.
-func (t *SecureTrie) Commit(onleaf LeafCallback) (common.Hash, int, error) {
+func (t *SecureTrie) Commit(onleaf LeafCallback) (*CommitResult, error) {
 	// Write all the pre-images to the actual disk database
 	if len(t.getSecKeyCache()) > 0 {
 		if t.trie.db.preimages != nil { // Ugly direct check but avoids the below write lock


### PR DESCRIPTION
This PR extracts the trie diffs in each commit operation and display them on the metric system.

NOTE: it's an experiment feature. Don't merge it now.