### PR TITLE
Fix fee cap calculation if NoBaseFee is false

### DIFF
--- a/core/state_transition.go
+++ b/core/state_transition.go
@@ -193,7 +193,7 @@ func (st *StateTransition) buyGas() error {
 	mgval := new(big.Int).SetUint64(st.msg.Gas())
 	mgval = mgval.Mul(mgval, st.gasPrice)
 	balanceCheck := mgval
-	if st.gasFeeCap != nil {
+	if !st.evm.Config.NoBaseFee && st.gasFeeCap != nil {
 		balanceCheck = new(big.Int).SetUint64(st.msg.Gas())
 		balanceCheck = balanceCheck.Mul(balanceCheck, st.gasFeeCap)
 		balanceCheck.Add(balanceCheck, st.value)
@@ -232,7 +232,7 @@ func (st *StateTransition) preCheck() error {
 	// Make sure that transaction gasFeeCap is greater than the baseFee (post london)
 	if st.evm.ChainConfig().IsLondon(st.evm.Context.BlockNumber) {
 		// Skip the checks if gas fields are zero and baseFee was explicitly disabled (eth_call)
-		if !st.evm.Config.NoBaseFee || st.gasFeeCap.BitLen() > 0 || st.gasTipCap.BitLen() > 0 {
+		if !st.evm.Config.NoBaseFee && (st.gasFeeCap.BitLen() > 0 || st.gasTipCap.BitLen() > 0) {
 			if l := st.gasFeeCap.BitLen(); l > 256 {
 				return fmt.Errorf("%w: address %v, maxFeePerGas bit length: %d", ErrFeeCapVeryHigh,
 					st.msg.From().Hex(), l)


### PR DESCRIPTION
Found this issue after update to `go-ethereum:v1.10.8` when I using `ethtypes.NewMessage` for the VM state_transition `Apply`. Basically `gasFeeCap` and `gasTipCap` I have used as `nil` values (before `v1.10.8`) and all was fine. But after the update, `nil` not working anymore (panic occurred here) https://github.com/ethereum/go-ethereum/blob/26675454bf93bf904be7a43cce6b3f550115ff90/core/state_transition.go#L235  so I have resolved this with `big.NewInt(0)`.

However, in our network, we do not use a `gasFeeCap` and `gasTipCap`, so for the https://github.com/ethereum/go-ethereum/blob/26675454bf93bf904be7a43cce6b3f550115ff90/core/vm/interpreter.go#L33 I have set `NoBaseFee` as `true`. But got another issue here https://github.com/ethereum/go-ethereum/blob/26675454bf93bf904be7a43cce6b3f550115ff90/core/state_transition.go#L198 as `balanceCheck` started to be zero, because of `gasFeeCap ` zero.

In case, if you do not use a new fee mechanism in the fork or if u have a go-ethereum VM integration, this should be covered by `NoBaseFee` property.