### PR TITLE
docs: add vuln info

### DIFF
--- a/docs/_vulnerabilities/vulnerabilities.json
+++ b/docs/_vulnerabilities/vulnerabilities.json
@@ -122,7 +122,7 @@
     "summary": "A consensus-flaw in the Geth EVM could cause a node to deviate from the canonical chain.",
     "description": "A memory-corruption bug within the EVM can cause a consensus error, where vulnerable nodes obtain a different `stateRoot` when processing a maliciously crafted transaction. This, in turn, would lead to the chain being split: mainnet splitting in two forks.\n\nAll Geth versions supporting the London hard fork are vulnerable (the bug is older than London), so all users should update.\n\nThis bug was exploited on Mainnet at block 13107518.\n\nCredits for the discovery go to @guidovranken (working for Sentnl during an audit of the Telos EVM) and reported via bounty@ethereum.org.",
     "links": [
-      "TODO: link to postmortem writeup",
+      "https://github.com/ethereum/go-ethereum/blob/master/docs/postmortems/2021-08-22-split-postmortem.md",
       "https://github.com/ethereum/go-ethereum/security/advisories/GHSA-9856-9gg9-qcmq",
       "https://github.com/ethereum/go-ethereum/releases/tag/v1.10.8"
     ],

--- a/docs/_vulnerabilities/vulnerabilities.json
+++ b/docs/_vulnerabilities/vulnerabilities.json
@@ -112,16 +112,17 @@
     ],
     "introduced": "v1.10.1",
     "fixed": "v1.10.6",
-    "published": "2020-07-22",
+    "published": "2021-07-22",
     "severity": "High",
     "check": "(Geth\\/v1\\.10\\.(1|2|3|4|5)-.*)$"
   },
   {
-    "name": " EVM flaw during block processing ",
+    "name": "RETURNDATA corruption via datacopy",
     "uid": "GETH-2021-02",
-    "summary": "A vulnerability in the Geth EVM could cause a node to no longer being able to process the chain. Further details about the vulnerability will be disclosed at a later date.",
-    "description": "The exact attack vector will be provided at a later date to give node operators and dependent downstream projects time to update their nodes and software.\n\nAll Geth versions supporting the London hard fork are vulnerable (the bug is older than London), so all users should update.\n\nCredits for the discovery go to @guidovranken (working for Sentnl during an audit of the Telos EVM) and reported via bounty@ethereum.org.",
+    "summary": "A consensus-flaw in the Geth EVM could cause a node to deviate from the canonical chain.",
+    "description": "A memory-corruption bug within the EVM can cause a consensus error, where vulnerable nodes obtain a different `stateRoot` when processing a maliciously crafted transaction. This, in turn, would lead to the chain being split: mainnet splitting in two forks.\n\nAll Geth versions supporting the London hard fork are vulnerable (the bug is older than London), so all users should update.\n\nThis bug was exploited on Mainnet at block 13107518.\n\nCredits for the discovery go to @guidovranken (working for Sentnl during an audit of the Telos EVM) and reported via bounty@ethereum.org.",
     "links": [
+      "TODO: link to postmortem writeup",
       "https://github.com/ethereum/go-ethereum/security/advisories/GHSA-9856-9gg9-qcmq",
       "https://github.com/ethereum/go-ethereum/releases/tag/v1.10.8"
     ],

--- a/docs/_vulnerabilities/vulnerabilities.json.minisig
+++ b/docs/_vulnerabilities/vulnerabilities.json.minisig
@@ -1,4 +1,4 @@
 untrusted comment: signature from minisign secret key
-RWQk7Lo5TQgd++3L4ak5YtTZati9peOJPh98Hyd3+clXS0o12nmm/WD4/7yuWHIIjBizJ74DqMesD7d2OhjwrExKEOhYnX7vrgg=
-trusted comment: timestamp:1629790360	file:vulnerabilities.json
-hoImXPiP448MxV7UOT/uQ1xj9jeJDGDqiFz/SVylfC5VC48bdjHTWN9LOgDGZfzLS+KIke0nDttel4vMZNg+AQ==
+RWQk7Lo5TQgd+66wU0ZNQlDYTsqSFA2o1aeaPo1ccQMJK/EMFyirawrl8Rq4NJI9md6x1xUthAT0Lr3HeTIQhYBGRtYcG5su0A0=
+trusted comment: timestamp:1630999630	file:vulnerabilities.json
+ezWYr/g7o55e/Yb+rdnp5fZoER4zVBxsm7g0yNt0/hPUhLa86uM1hRTE1Boeg1HxajcVe+iNEmsB/rIokBq3Bg==


### PR DESCRIPTION
This adds more info about the consensus vulnerability we had. It's a draft -- once we're OK with the wording, we also need to commit the updated signature, and add link to post-mortem . 

So, please review so I know when to do the final step(s)