### PR TITLE
build: add -buildid='' to make the binary reproducible

### DIFF
--- a/build/ci.go
+++ b/build/ci.go
@@ -249,7 +249,7 @@ func doInstall(cmdline []string) {
 
 // buildFlags returns the go tool flags for building.
 func buildFlags(env build.Environment) (flags []string) {
-	var ld []string
+	var ld []string = []string{"-buildid", "''"} // to get reproducible binaries
 	if env.Commit != "" {
 		ld = append(ld, "-X", "main.gitCommit="+env.Commit)
 		ld = append(ld, "-X", "main.gitDate="+env.Date)


### PR DESCRIPTION
i checked it only briefly by copying the source to another directory, and `make clean` followed by `make`, both with and without this commit.

what's missing: something in the CI to test this.