### PR TITLE
accounts/abi: fix setStruct if src is pointer (e.g. big.Int)

### DIFF
--- a/accounts/abi/reflect.go
+++ b/accounts/abi/reflect.go
@@ -109,8 +109,10 @@ func set(dst, src reflect.Value) error {
 		return setSlice(dst, src)
 	case dstType.Kind() == reflect.Array:
 		return setArray(dst, src)
-	case dstType.Kind() == reflect.Struct:
+	case srcType.Kind() == reflect.Struct && dstType.Kind() == reflect.Struct:
 		return setStruct(dst, src)
+	case srcType.Kind() == reflect.Ptr && dstType.Kind() == reflect.Struct:
+		return setStruct(dst, src.Elem())
 	default:
 		return fmt.Errorf("abi: cannot unmarshal %v in to %v", src.Type(), dst.Type())
 	}


### PR DESCRIPTION
closes https://github.com/ethereum/go-ethereum/issues/23551

The issue here was that we were trying to setStruct from a struct to a pointer to a struct, so we need to dereference the pointer first