### PR TITLE
core: cmd: invert disableMemory

### DIFF
--- a/cmd/evm/disasm.go
+++ b/cmd/evm/disasm.go
@@ -46,7 +46,7 @@ func disasmCmd(ctx *cli.Context) error {
 	case ctx.GlobalIsSet(InputFlag.Name):
 		in = ctx.GlobalString(InputFlag.Name)
 	default:
-		return errors.New("Missing filename or --input value")
+		return errors.New("missing filename or --input value")
 	}
 
 	code := strings.TrimSpace(in)

--- a/cmd/evm/internal/t8ntool/flags.go
+++ b/cmd/evm/internal/t8ntool/flags.go
@@ -30,17 +30,17 @@ var (
 		Name:  "trace",
 		Usage: "Output full trace logs to files <txhash>.jsonl",
 	}
-	TraceDisableMemoryFlag = cli.BoolFlag{
-		Name:  "trace.nomemory",
-		Usage: "Disable full memory dump in traces",
+	TraceEnableMemoryFlag = cli.BoolFlag{
+		Name:  "trace.memory",
+		Usage: "Enable full memory dump in traces",
 	}
 	TraceDisableStackFlag = cli.BoolFlag{
 		Name:  "trace.nostack",
 		Usage: "Disable stack output in traces",
 	}
-	TraceDisableReturnDataFlag = cli.BoolFlag{
-		Name:  "trace.noreturndata",
-		Usage: "Disable return data output in traces",
+	TraceEnableReturnDataFlag = cli.BoolFlag{
+		Name:  "trace.returndata",
+		Usage: "Enable return data output in traces",
 	}
 	OutputBasedir = cli.StringFlag{
 		Name:  "output.basedir",

--- a/cmd/evm/internal/t8ntool/flags.go
+++ b/cmd/evm/internal/t8ntool/flags.go
@@ -30,17 +30,17 @@ var (
 		Name:  "trace",
 		Usage: "Output full trace logs to files <txhash>.jsonl",
 	}
-	TraceEnableMemoryFlag = cli.BoolFlag{
-		Name:  "trace.memory",
-		Usage: "Enable full memory dump in traces",
+	TraceDisableMemoryFlag = cli.BoolTFlag{
+		Name:  "trace.nomemory",
+		Usage: "Disable full memory dump in traces",
 	}
 	TraceDisableStackFlag = cli.BoolFlag{
 		Name:  "trace.nostack",
 		Usage: "Disable stack output in traces",
 	}
-	TraceEnableReturnDataFlag = cli.BoolFlag{
-		Name:  "trace.returndata",
-		Usage: "Enable return data output in traces",
+	TraceDisableReturnDataFlag = cli.BoolTFlag{
+		Name:  "trace.noreturndata",
+		Usage: "Disable return data output in traces",
 	}
 	OutputBasedir = cli.StringFlag{
 		Name:  "output.basedir",

--- a/cmd/evm/internal/t8ntool/transition.go
+++ b/cmd/evm/internal/t8ntool/transition.go
@@ -108,8 +108,8 @@ func Main(ctx *cli.Context) error {
 		// Configure the EVM logger
 		logConfig := &vm.LogConfig{
 			DisableStack:     ctx.Bool(TraceDisableStackFlag.Name),
-			EnableMemory:     ctx.Bool(TraceEnableMemoryFlag.Name),
-			EnableReturnData: ctx.Bool(TraceEnableReturnDataFlag.Name),
+			EnableMemory:     !ctx.Bool(TraceDisableMemoryFlag.Name),
+			EnableReturnData: !ctx.Bool(TraceDisableReturnDataFlag.Name),
 			Debug:            true,
 		}
 		var prevFile *os.File

--- a/cmd/evm/internal/t8ntool/transition.go
+++ b/cmd/evm/internal/t8ntool/transition.go
@@ -107,10 +107,10 @@ func Main(ctx *cli.Context) error {
 	if ctx.Bool(TraceFlag.Name) {
 		// Configure the EVM logger
 		logConfig := &vm.LogConfig{
-			DisableStack:      ctx.Bool(TraceDisableStackFlag.Name),
-			DisableMemory:     ctx.Bool(TraceDisableMemoryFlag.Name),
-			DisableReturnData: ctx.Bool(TraceDisableReturnDataFlag.Name),
-			Debug:             true,
+			DisableStack:     ctx.Bool(TraceDisableStackFlag.Name),
+			EnableMemory:     ctx.Bool(TraceEnableMemoryFlag.Name),
+			EnableReturnData: ctx.Bool(TraceEnableReturnDataFlag.Name),
+			Debug:            true,
 		}
 		var prevFile *os.File
 		// This one closes the last file

--- a/cmd/evm/main.go
+++ b/cmd/evm/main.go
@@ -113,9 +113,9 @@ var (
 		Name:  "receiver",
 		Usage: "The transaction receiver (execution context)",
 	}
-	DisableMemoryFlag = cli.BoolFlag{
-		Name:  "nomemory",
-		Usage: "disable memory output",
+	EnableMemoryFlag = cli.BoolFlag{
+		Name:  "memory",
+		Usage: "enable memory output",
 	}
 	DisableStackFlag = cli.BoolFlag{
 		Name:  "nostack",
@@ -125,9 +125,9 @@ var (
 		Name:  "nostorage",
 		Usage: "disable storage output",
 	}
-	DisableReturnDataFlag = cli.BoolFlag{
-		Name:  "noreturndata",
-		Usage: "disable return data output",
+	EnableReturnDataFlag = cli.BoolFlag{
+		Name:  "returndata",
+		Usage: "enable return data output",
 	}
 )
 
@@ -138,9 +138,9 @@ var stateTransitionCommand = cli.Command{
 	Action:  t8ntool.Main,
 	Flags: []cli.Flag{
 		t8ntool.TraceFlag,
-		t8ntool.TraceDisableMemoryFlag,
+		t8ntool.TraceEnableMemoryFlag,
 		t8ntool.TraceDisableStackFlag,
-		t8ntool.TraceDisableReturnDataFlag,
+		t8ntool.TraceEnableReturnDataFlag,
 		t8ntool.OutputBasedir,
 		t8ntool.OutputAllocFlag,
 		t8ntool.OutputResultFlag,
@@ -176,10 +176,10 @@ func init() {
 		MachineFlag,
 		SenderFlag,
 		ReceiverFlag,
-		DisableMemoryFlag,
+		EnableMemoryFlag,
 		DisableStackFlag,
 		DisableStorageFlag,
-		DisableReturnDataFlag,
+		EnableReturnDataFlag,
 	}
 	app.Commands = []cli.Command{
 		compileCommand,

--- a/cmd/evm/main.go
+++ b/cmd/evm/main.go
@@ -113,9 +113,9 @@ var (
 		Name:  "receiver",
 		Usage: "The transaction receiver (execution context)",
 	}
-	EnableMemoryFlag = cli.BoolFlag{
-		Name:  "memory",
-		Usage: "enable memory output",
+	DisableMemoryFlag = cli.BoolTFlag{
+		Name:  "nomemory",
+		Usage: "disable memory output",
 	}
 	DisableStackFlag = cli.BoolFlag{
 		Name:  "nostack",
@@ -125,8 +125,8 @@ var (
 		Name:  "nostorage",
 		Usage: "disable storage output",
 	}
-	EnableReturnDataFlag = cli.BoolFlag{
-		Name:  "returndata",
+	DisableReturnDataFlag = cli.BoolTFlag{
+		Name:  "noreturndata",
 		Usage: "enable return data output",
 	}
 )
@@ -138,9 +138,9 @@ var stateTransitionCommand = cli.Command{
 	Action:  t8ntool.Main,
 	Flags: []cli.Flag{
 		t8ntool.TraceFlag,
-		t8ntool.TraceEnableMemoryFlag,
+		t8ntool.TraceDisableMemoryFlag,
 		t8ntool.TraceDisableStackFlag,
-		t8ntool.TraceEnableReturnDataFlag,
+		t8ntool.TraceDisableReturnDataFlag,
 		t8ntool.OutputBasedir,
 		t8ntool.OutputAllocFlag,
 		t8ntool.OutputResultFlag,
@@ -176,10 +176,10 @@ func init() {
 		MachineFlag,
 		SenderFlag,
 		ReceiverFlag,
-		EnableMemoryFlag,
+		DisableMemoryFlag,
 		DisableStackFlag,
 		DisableStorageFlag,
-		EnableReturnDataFlag,
+		DisableReturnDataFlag,
 	}
 	app.Commands = []cli.Command{
 		compileCommand,

--- a/cmd/evm/runner.go
+++ b/cmd/evm/runner.go
@@ -108,10 +108,10 @@ func runCmd(ctx *cli.Context) error {
 	glogger.Verbosity(log.Lvl(ctx.GlobalInt(VerbosityFlag.Name)))
 	log.Root().SetHandler(glogger)
 	logconfig := &vm.LogConfig{
-		EnableMemory:     ctx.GlobalBool(EnableMemoryFlag.Name),
+		EnableMemory:     !ctx.GlobalBool(DisableMemoryFlag.Name),
 		DisableStack:     ctx.GlobalBool(DisableStackFlag.Name),
 		DisableStorage:   ctx.GlobalBool(DisableStorageFlag.Name),
-		EnableReturnData: ctx.GlobalBool(EnableReturnDataFlag.Name),
+		EnableReturnData: !ctx.GlobalBool(DisableReturnDataFlag.Name),
 		Debug:            ctx.GlobalBool(DebugFlag.Name),
 	}
 

--- a/cmd/evm/runner.go
+++ b/cmd/evm/runner.go
@@ -108,11 +108,11 @@ func runCmd(ctx *cli.Context) error {
 	glogger.Verbosity(log.Lvl(ctx.GlobalInt(VerbosityFlag.Name)))
 	log.Root().SetHandler(glogger)
 	logconfig := &vm.LogConfig{
-		DisableMemory:     ctx.GlobalBool(DisableMemoryFlag.Name),
-		DisableStack:      ctx.GlobalBool(DisableStackFlag.Name),
-		DisableStorage:    ctx.GlobalBool(DisableStorageFlag.Name),
-		DisableReturnData: ctx.GlobalBool(DisableReturnDataFlag.Name),
-		Debug:             ctx.GlobalBool(DebugFlag.Name),
+		EnableMemory:     ctx.GlobalBool(EnableMemoryFlag.Name),
+		DisableStack:     ctx.GlobalBool(DisableStackFlag.Name),
+		DisableStorage:   ctx.GlobalBool(DisableStorageFlag.Name),
+		EnableReturnData: ctx.GlobalBool(EnableReturnDataFlag.Name),
+		Debug:            ctx.GlobalBool(DebugFlag.Name),
 	}
 
 	var (

--- a/cmd/evm/staterunner.go
+++ b/cmd/evm/staterunner.go
@@ -59,10 +59,10 @@ func stateTestCmd(ctx *cli.Context) error {
 
 	// Configure the EVM logger
 	config := &vm.LogConfig{
-		EnableMemory:     ctx.GlobalBool(EnableMemoryFlag.Name),
+		EnableMemory:     !ctx.GlobalBool(DisableMemoryFlag.Name),
 		DisableStack:     ctx.GlobalBool(DisableStackFlag.Name),
 		DisableStorage:   ctx.GlobalBool(DisableStorageFlag.Name),
-		EnableReturnData: ctx.GlobalBool(EnableReturnDataFlag.Name),
+		EnableReturnData: !ctx.GlobalBool(DisableReturnDataFlag.Name),
 	}
 	var (
 		tracer   vm.Tracer

--- a/cmd/evm/staterunner.go
+++ b/cmd/evm/staterunner.go
@@ -59,10 +59,10 @@ func stateTestCmd(ctx *cli.Context) error {
 
 	// Configure the EVM logger
 	config := &vm.LogConfig{
-		DisableMemory:     ctx.GlobalBool(DisableMemoryFlag.Name),
-		DisableStack:      ctx.GlobalBool(DisableStackFlag.Name),
-		DisableStorage:    ctx.GlobalBool(DisableStorageFlag.Name),
-		DisableReturnData: ctx.GlobalBool(DisableReturnDataFlag.Name),
+		EnableMemory:     ctx.GlobalBool(EnableMemoryFlag.Name),
+		DisableStack:     ctx.GlobalBool(DisableStackFlag.Name),
+		DisableStorage:   ctx.GlobalBool(DisableStorageFlag.Name),
+		EnableReturnData: ctx.GlobalBool(EnableReturnDataFlag.Name),
 	}
 	var (
 		tracer   vm.Tracer

--- a/core/vm/logger.go
+++ b/core/vm/logger.go
@@ -160,7 +160,7 @@ func (l *StructLogger) CaptureState(env *EVM, pc uint64, op OpCode, gas, cost ui
 	}
 	// Copy a snapshot of the current memory state to a new buffer
 	var mem []byte
-	if !l.cfg.EnableMemory {
+	if l.cfg.EnableMemory {
 		mem = make([]byte, len(memory.Data()))
 		copy(mem, memory.Data())
 	}
@@ -199,7 +199,7 @@ func (l *StructLogger) CaptureState(env *EVM, pc uint64, op OpCode, gas, cost ui
 		}
 	}
 	var rdata []byte
-	if !l.cfg.EnableReturnData {
+	if l.cfg.EnableReturnData {
 		rdata = make([]byte, len(rData))
 		copy(rdata, rData)
 	}

--- a/core/vm/logger.go
+++ b/core/vm/logger.go
@@ -46,12 +46,12 @@ func (s Storage) Copy() Storage {
 
 // LogConfig are the configuration options for structured logger the EVM
 type LogConfig struct {
-	DisableMemory     bool // disable memory capture
-	DisableStack      bool // disable stack capture
-	DisableStorage    bool // disable storage capture
-	DisableReturnData bool // disable return data capture
-	Debug             bool // print output during capture end
-	Limit             int  // maximum length of output, but zero means unlimited
+	EnableMemory     bool // disable memory capture
+	DisableStack     bool // disable stack capture
+	DisableStorage   bool // disable storage capture
+	EnableReturnData bool // disable return data capture
+	Debug            bool // print output during capture end
+	Limit            int  // maximum length of output, but zero means unlimited
 	// Chain overrides, can be used to execute a trace using future fork rules
 	Overrides *params.ChainConfig `json:"overrides,omitempty"`
 }
@@ -160,7 +160,7 @@ func (l *StructLogger) CaptureState(env *EVM, pc uint64, op OpCode, gas, cost ui
 	}
 	// Copy a snapshot of the current memory state to a new buffer
 	var mem []byte
-	if !l.cfg.DisableMemory {
+	if !l.cfg.EnableMemory {
 		mem = make([]byte, len(memory.Data()))
 		copy(mem, memory.Data())
 	}
@@ -199,7 +199,7 @@ func (l *StructLogger) CaptureState(env *EVM, pc uint64, op OpCode, gas, cost ui
 		}
 	}
 	var rdata []byte
-	if !l.cfg.DisableReturnData {
+	if !l.cfg.EnableReturnData {
 		rdata = make([]byte, len(rData))
 		copy(rdata, rData)
 	}

--- a/core/vm/logger.go
+++ b/core/vm/logger.go
@@ -46,10 +46,10 @@ func (s Storage) Copy() Storage {
 
 // LogConfig are the configuration options for structured logger the EVM
 type LogConfig struct {
-	EnableMemory     bool // disable memory capture
+	EnableMemory     bool // enable memory capture
 	DisableStack     bool // disable stack capture
 	DisableStorage   bool // disable storage capture
-	EnableReturnData bool // disable return data capture
+	EnableReturnData bool // enable return data capture
 	Debug            bool // print output during capture end
 	Limit            int  // maximum length of output, but zero means unlimited
 	// Chain overrides, can be used to execute a trace using future fork rules

--- a/core/vm/logger_json.go
+++ b/core/vm/logger_json.go
@@ -61,13 +61,13 @@ func (l *JSONLogger) CaptureState(env *EVM, pc uint64, op OpCode, gas, cost uint
 		RefundCounter: env.StateDB.GetRefund(),
 		Err:           err,
 	}
-	if !l.cfg.DisableMemory {
+	if l.cfg.EnableMemory {
 		log.Memory = memory.Data()
 	}
 	if !l.cfg.DisableStack {
 		log.Stack = stack.data
 	}
-	if !l.cfg.DisableReturnData {
+	if l.cfg.EnableReturnData {
 		log.ReturnData = rData
 	}
 	l.encoder.Encode(log)

--- a/eth/tracers/tracers_test.go
+++ b/eth/tracers/tracers_test.go
@@ -353,8 +353,8 @@ func BenchmarkTransactionTrace(b *testing.B) {
 	tracer := vm.NewStructLogger(&vm.LogConfig{
 		Debug: false,
 		//DisableStorage: true,
-		//DisableMemory: true,
-		//DisableReturnData: true,
+		//EnableMemory: false,
+		//EnableReturnData: false,
 	})
 	evm := vm.NewEVM(context, txContext, statedb, params.AllEthashProtocolChanges, vm.Config{Debug: true, Tracer: tracer})
 	msg, err := tx.AsMessage(signer, nil)

--- a/tests/state_test.go
+++ b/tests/state_test.go
@@ -115,7 +115,7 @@ func withTrace(t *testing.T, gasLimit uint64, test func(vm.Config) error) {
 	}
 	buf := new(bytes.Buffer)
 	w := bufio.NewWriter(buf)
-	tracer := vm.NewJSONLogger(&vm.LogConfig{DisableMemory: true}, w)
+	tracer := vm.NewJSONLogger(&vm.LogConfig{EnableMemory: false}, w)
 	config.Debug, config.Tracer = true, tracer
 	err2 := test(config)
 	if !reflect.DeepEqual(err, err2) {

--- a/tests/state_test.go
+++ b/tests/state_test.go
@@ -115,7 +115,7 @@ func withTrace(t *testing.T, gasLimit uint64, test func(vm.Config) error) {
 	}
 	buf := new(bytes.Buffer)
 	w := bufio.NewWriter(buf)
-	tracer := vm.NewJSONLogger(&vm.LogConfig{EnableMemory: false}, w)
+	tracer := vm.NewJSONLogger(&vm.LogConfig{}, w)
 	config.Debug, config.Tracer = true, tracer
 	err2 := test(config)
 	if !reflect.DeepEqual(err, err2) {


### PR DESCRIPTION
Both `ReturnData` and `Memory` are pretty big and should not be part of traces by default. 
This inverts the behavior of DisableMemory and DisableReturnData.