### PR TITLE
eth/tracers: abort evm execution when trace is aborted

### DIFF
--- a/eth/tracers/tracer.go
+++ b/eth/tracers/tracer.go
@@ -600,6 +600,7 @@ func (jst *Tracer) CaptureState(env *vm.EVM, pc uint64, op vm.OpCode, gas, cost 
 	// If tracing was interrupted, set the error and stop
 	if atomic.LoadUint32(&jst.interrupt) > 0 {
 		jst.err = jst.reason
+		env.Cancel()
 		return
 	}
 	jst.opWrapper.op = op


### PR DESCRIPTION
This PR tries to fix https://github.com/ethereum/go-ethereum/issues/23397. Geth goes OOM after
heavy transaction tracing.

The tracer has a `Stop` method, which sets a flag. This flag causes the tracer to stop doing work, as in no longer invoking
the javascript engine for each opcode. However, it does not actually stop the evm execution.

I tested with a little `traceCall` where we just run in a loop, burning 10M gas:

```
> a=eth.accounts[0];for(i=0;i<10; i++){try{debug.traceCall({from:a, input: "0x5b600056", gas:"0x989680"}, "latest", {"tracer": "callTracer", "timeout": "1ms"})  }catch(e){}}
```
If I run this on `master`, with some added printout when the trace ends:
```
WARN [09-15|10:17:23.124] Served debug_traceCall                   reqid=63 t=62.092057ms err="execution timeout"
INFO [09-15|10:17:23.168] Trace done                               elapsed=37.435613ms err=0xbd92a0
WARN [09-15|10:17:23.170] Served debug_traceCall                   reqid=64 t=44.964981ms err="execution timeout"
INFO [09-15|10:17:23.213] Trace done                               elapsed=37.365314ms err=0xbd92a0
WARN [09-15|10:17:23.215] Served debug_traceCall                   reqid=65 t=44.787581ms err="execution timeout"
INFO [09-15|10:17:23.258] Trace done                               elapsed=37.015968ms err=0xbd92a0
WARN [09-15|10:17:23.259] Served debug_traceCall                   reqid=66 t=44.329423ms err="execution timeout"
INFO [09-15|10:17:23.303] Trace done                               elapsed=37.243615ms err=0xbd92a0
WARN [09-15|10:17:23.305] Served debug_traceCall                   reqid=67 t=44.622817ms err="execution timeout"
INFO [09-15|10:17:23.349] Trace done                               elapsed=38.016897ms err=0xbd92a0
WARN [09-15|10:17:23.350] Served debug_traceCall                   reqid=68 t=45.465781ms err="execution timeout"
INFO [09-15|10:17:23.395] Trace done                               elapsed=38.352121ms err=0xbd92a0
WARN [09-15|10:17:23.396] Served debug_traceCall                   reqid=69 t=45.750501ms err="execution timeout"
INFO [09-15|10:17:23.440] Trace done                               elapsed=37.428625ms err=0xbd92a0
WARN [09-15|10:17:23.442] Served debug_traceCall                   reqid=70 t=44.716995ms err="execution timeout"
INFO [09-15|10:17:23.486] Trace done                               elapsed=37.261927ms err=0xbd92a0
WARN [09-15|10:17:23.488] Served debug_traceCall                   reqid=71 t=45.757262ms err="execution timeout"
INFO [09-15|10:17:23.534] Trace done                               elapsed=39.421814ms err=0xbd92a0
WARN [09-15|10:17:23.535] Served debug_traceCall                   reqid=72 t=46.78345ms  err="execution timeout"
INFO [09-15|10:17:27.567] Trace done                               elapsed=38.01212ms  err=0xbd92a0
WARN [09-15|10:17:27.568] Served debug_traceCall                   reqid=74 t=60.048715ms err="execution timeout"
INFO [09-15|10:17:27.612] Trace done                               elapsed=37.354918ms err=0xbd92a0
WARN [09-15|10:17:27.614] Served debug_traceCall                   reqid=75 t=44.806464ms err="execution timeout"
INFO [09-15|10:17:27.659] Trace done                               elapsed=38.760404ms err=0xbd92a0
WARN [09-15|10:17:27.660] Served debug_traceCall                   reqid=76 t=46.200019ms err="execution timeout"
INFO [09-15|10:17:27.705] Trace done                               elapsed=37.843866ms err=0xbd92a0
WARN [09-15|10:17:27.706] Served debug_traceCall                   reqid=77 t=45.441603ms err="execution timeout"
INFO [09-15|10:17:27.752] Trace done                               elapsed=39.506866ms err=0xbd92a0
WARN [09-15|10:17:27.754] Served debug_traceCall                   reqid=78 t=47.262987ms err="execution timeout"
INFO [09-15|10:17:27.798] Trace done                               elapsed=37.453001ms err=0xbd92a0
WARN [09-15|10:17:27.799] Served debug_traceCall                   reqid=79 t=44.974827ms err="execution timeout"
INFO [09-15|10:17:27.843] Trace done                               elapsed=37.502113ms err=0xbd92a0
WARN [09-15|10:17:27.845] Served debug_traceCall                   reqid=80 t=45.10805ms  err="execution timeout"
INFO [09-15|10:17:27.891] Trace done                               elapsed=39.174589ms err=0xbd92a0
WARN [09-15|10:17:27.892] Served debug_traceCall                   reqid=81 t=46.773815ms err="execution timeout"
INFO [09-15|10:17:27.936] Trace done                               elapsed=37.509592ms err=0xbd92a0
WARN [09-15|10:17:27.937] Served debug_traceCall                   reqid=82 t=45.046033ms err="execution timeout"
INFO [09-15|10:17:27.982] Trace done                               elapsed=38.273ms    err=0xbd92a0
WARN [09-15|10:17:27.983] Served debug_traceCall                   reqid=83 t=45.614921ms err="execution timeout"
```
So even if we call `Stop()` after ~1ms, it takes ~40ms for the execution to complete.
Whereas running it on this PR (with the added printout):

```
INFO [09-15|10:12:39.352] Trace done                               elapsed=1.037024ms
WARN [09-15|10:12:39.354] Served debug_traceCall                   reqid=37 t=18.875244ms err="execution timeout"
INFO [09-15|10:12:48.072] Trace done                               elapsed=1.176966ms
WARN [09-15|10:12:48.074] Served debug_traceCall                   reqid=38 t=18.597476ms err="execution timeout"
INFO [09-15|10:12:48.853] Trace done                               elapsed=1.202925ms
WARN [09-15|10:12:48.855] Served debug_traceCall                   reqid=39 t=16.350088ms err="execution timeout"
INFO [09-15|10:12:49.550] Trace done                               elapsed=1.175699ms
WARN [09-15|10:12:49.552] Served debug_traceCall                   reqid=40 t=22.687372ms err="execution timeout"
INFO [09-15|10:14:12.953] Trace done                               elapsed=1.156763ms
WARN [09-15|10:14:12.954] Served debug_traceCall                   reqid=41 t=17.97693ms  err="execution timeout"
INFO [09-15|10:14:12.962] Trace done                               elapsed=1.238879ms
WARN [09-15|10:14:12.964] Served debug_traceCall                   reqid=42 t=8.683642ms  err="execution timeout"
INFO [09-15|10:14:12.972] Trace done                               elapsed=1.213763ms
WARN [09-15|10:14:12.974] Served debug_traceCall                   reqid=43 t=10.025599ms err="execution timeout"
INFO [09-15|10:14:12.982] Trace done                               elapsed=1.206566ms
WARN [09-15|10:14:12.984] Served debug_traceCall                   reqid=44 t=9.40188ms   err="execution timeout"
INFO [09-15|10:14:12.991] Trace done                               elapsed=1.200257ms
WARN [09-15|10:14:12.993] Served debug_traceCall                   reqid=45 t=9.11482ms   err="execution timeout"
INFO [09-15|10:14:13.003] Trace done                               elapsed=1.197946ms
WARN [09-15|10:14:13.004] Served debug_traceCall                   reqid=46 t=9.383057ms  err="execution timeout"
INFO [09-15|10:14:13.011] Trace done                               elapsed=1.210468ms
WARN [09-15|10:14:13.013] Served debug_traceCall                   reqid=47 t=8.535531ms  err="execution timeout"
INFO [09-15|10:14:13.020] Trace done                               elapsed=1.184903ms
WARN [09-15|10:14:13.022] Served debug_traceCall                   reqid=48 t=8.600543ms  err="execution timeout"
INFO [09-15|10:14:13.030] Trace done                               elapsed=1.163352ms
WARN [09-15|10:14:13.032] Served debug_traceCall                   reqid=49 t=9.858417ms  err="execution timeout"
INFO [09-15|10:14:13.042] Trace done                               elapsed=1.173591ms
WARN [09-15|10:14:13.043] Served debug_traceCall                   reqid=50 t=11.201256ms err="execution timeout"
INFO [09-15|10:14:37.894] Trace done                               elapsed=1.025216ms
WARN [09-15|10:14:37.896] Served debug_traceCall                   reqid=52 t=18.575947ms err="execution timeout"
INFO [09-15|10:14:37.903] Trace done                               elapsed=1.22123ms
WARN [09-15|10:14:37.905] Served debug_traceCall                   reqid=53 t=9.035504ms  err="execution timeout"
INFO [09-15|10:14:37.913] Trace done                               elapsed=1.178614ms
WARN [09-15|10:14:37.914] Served debug_traceCall                   reqid=54 t=8.956603ms  err="execution timeout"
INFO [09-15|10:14:37.922] Trace done                               elapsed=1.20833ms
WARN [09-15|10:14:37.923] Served debug_traceCall                   reqid=55 t=8.753149ms  err="execution timeout"
INFO [09-15|10:14:37.931] Trace done                               elapsed=1.212588ms
WARN [09-15|10:14:37.932] Served debug_traceCall                   reqid=56 t=8.385952ms  err="execution timeout"
INFO [09-15|10:14:37.940] Trace done                               elapsed=1.215262ms
WARN [09-15|10:14:37.942] Served debug_traceCall                   reqid=57 t=9.881463ms  err="execution timeout"
INFO [09-15|10:14:37.950] Trace done                               elapsed=1.202438ms
WARN [09-15|10:14:37.952] Served debug_traceCall                   reqid=58 t=9.149201ms  err="execution timeout"
INFO [09-15|10:14:37.959] Trace done                               elapsed=1.201389ms
WARN [09-15|10:14:37.960] Served debug_traceCall                   reqid=59 t=8.370293ms  err="execution timeout"
INFO [09-15|10:14:37.968] Trace done                               elapsed=1.209285ms
WARN [09-15|10:14:37.970] Served debug_traceCall                   reqid=60 t=9.475413ms  err="execution timeout"
INFO [09-15|10:14:37.978] Trace done                               elapsed=1.186982ms
WARN [09-15|10:14:37.979] Served debug_traceCall                   reqid=61 t=8.945892ms  err="execution timeout"
```
With the call to `env.Cancel`, the `evm` actually aborts after max `1000` more steps. If the cause of the OOMs are
lingering evm executions piling up, then this PR should fix it (or at least make it a lot more robust).

