### PR TITLE
eth/tracers: implement debug.intermediateRoots

### DIFF
--- a/internal/web3ext/web3ext.go
+++ b/internal/web3ext/web3ext.go
@@ -391,6 +391,12 @@ web3._extend({
 			inputFormatter: [null, null]
 		}),
 		new web3._extend.Method({
+			name: 'intermediateRoots',
+			call: 'debug_intermediateRoots',
+			params: 2,
+			inputFormatter: [null, null]
+		}),
+		new web3._extend.Method({
 			name: 'standardTraceBlockToFile',
 			call: 'debug_standardTraceBlockToFile',
 			params: 2,


### PR DESCRIPTION
This PR implements a new debug method, which I've talked briefly about to some other client developers. It allows the caller to obtain the intermediate state roots for a block (which might be either a canon block or a 'bad' block). 

This is meant to be a useful tool when investigating a chain split, to quickly narrow down what transaction causes the problem. Previous/alternative schemes to do this often rely on either comparing the `gasUsed`, or checking the receipts. However, more intricate bugs such as "wrong value stored in a storage slot" are not necessarily captured in gas differences -- but the stateroot will always capture any state diff (by definition). 

Tested with `--dev`; since it's PoA, it was pretty convenient to check that it becomes correct -- the last intermediate stateroot should be identical to the block stateroot, since there's no reward. 

```
[user@work testAnnounce]$ geth --dev console
...
> miner.stop()
> for(i =0; i < 10;i++){eth.sendTransaction({from:eth.accounts[0], to: eth.accounts[0], value:1})}
...
> miner.start()
...
> INFO [09-17|23:12:31.941] Commit new mining work                   number=1 sealhash=e532fa..ab3046 uncles=0 txs=0 gas=0 fees=0 elapsed="210.555µs"
INFO [09-17|23:12:31.941] Sealing paused, waiting for transactions 
INFO [09-17|23:12:31.943] Commit new mining work                   number=1 sealhash=64e40f..bbeecc uncles=0 txs=10 gas=210,000 fees=2.1e-13 elapsed=1.963ms
INFO [09-17|23:12:31.944] Successfully sealed new block            number=1 sealhash=64e40f..bbeecc hash=81a821..ea92b6 elapsed=1.378ms
INFO [09-17|23:12:31.944] 🔨 mined potential block                  number=1 hash=81a821..ea92b6
INFO [09-17|23:12:31.945] Commit new mining work                   number=2 sealhash=5795b3..415c88 uncles=0 txs=0  gas=0       fees=0       elapsed=1.098ms
INFO [09-17|23:12:31.946] Sealing paused, waiting for transactions 

> eth.getBlock(1)
{
  baseFeePerGas: 875000000,
  difficulty: 2,
  extraData: "0xd683010a09846765746886676f312e3137856c696e75780000000000000000003943130f238a26072e3b16a5f42cd1e6b88131d71f29d711cdb458defc57a1bd0e3a35efedb654a34021ad119c5523734996df5c300fc80ac39d4928920763b800",
  gasLimit: 11488771,
  gasUsed: 210000,
  hash: "0x81a821148704fdb9d03e9fd14d87702911c5650f45f5c1a0756df05ed2ea92b6",
  logsBloom: "0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
  miner: "0x0000000000000000000000000000000000000000",
  mixHash: "0x0000000000000000000000000000000000000000000000000000000000000000",
  nonce: "0x0000000000000000",
  number: 1,
  parentHash: "0x4e8510f4b02d903b29baea942dd6f1a20002e6327c491c1a98ee235c0ea47479",
  receiptsRoot: "0xb34a29e4a30ab5d32fdbc0292a97ac1cf1028c085f538dec2d91d91c6d0b0562",
  sha3Uncles: "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
  size: 1706,
  stateRoot: "0x0d13998e10fe25958e9601683e345fad324f261e7593119c97bcfde80fbef268",
  timestamp: 1631913151,
  totalDifficulty: 3,
  transactions: ["0x3134025ebcd8f817482c2109a7e8f33351dfbed66498b82170544486c2af4de0", "0x3bedd15bc46d193b5c5a1fc7967902cb8dee95d52e7b2d8a3effbc103b9f18b5", "0x9d205519af9b8dc5644e0ffbab5352fded10bcb13aae30c03d50436aa8fbcaaf", "0x0acf38b6ac335209f9bb12f646ec89aa95b18249e5c6ecf1432b429b75ec5d49", "0x015f5057dd725a53122adcc557b5be02da45798f71aa1914d06eefed94c1733f", "0x2e57ddacb638fc6bcac9933a3cab8e07820b11785ead4f18577f5f86193e11b8", "0x00badf8aaa14f1b7be806d377a5542784ff720da3de964c695038a4d5a28f5ab", "0xc8d2c86b6530432aee7e9a713401ec1dee802834759863f0a55cd52d7b114931", "0x719834802667b92d859687f99acbfb9f3244dbe381c339fe3a7cec31033536f5", "0xdcec900827074dafe50a1fe0ae54d8f1e2abe20397cdd4bce1aea16c90050077"],
  transactionsRoot: "0xd967afecd26c4899f19f2c7e7b6d88ce5379fbd1a6a6bf9daffcdcc85955c7b0",
  uncles: []
}
> debug.intermediateRoots("0x81a821148704fdb9d03e9fd14d87702911c5650f45f5c1a0756df05ed2ea92b6")
["0x6636e76e81cf9fa579c4ce49f95bb2c80ed2d1ef338326b05c6b80bdbec7b21a", "0x048d9ba2faf245ee57e6c5ac7ecb1217082571d108bd97c5ed6bb8ffee193f6a", "0xbf2f0a97f731d5a93f9407d760aa26073c8b864072186d028adeffd79761c373", "0xef1d90f41c09fe9320325a9f453573d557eb7dc3be596df548acffe402902960", "0xbd26c81de4a04e0cb83127403d4acef711ff5d0d8087706f6c6ec4fd73bc8b0b", "0xad177d456977ba7911ff2d668804623467a457a47f9674af2ee66fb2f2e88eb3", "0x0c80ddefb97566528df9381397bb42744005d8df99c73410115dd27c438785db", "0x63e608cb274c04644293e853843b1b9479062655fb27b677b3600547499731f7", "0xda533da664d24d6b1328b1fbf30a49cd09cac33880204faf8a46bf13775e18d8", "0x0d13998e10fe25958e9601683e345fad324f261e7593119c97bcfde80fbef268"]
> 

```

I'm hoping that if we add this method, other clients will do the same, and we'll be in a much better position to act quickly on consensus errors. 

cc @LukaszRozmej @garyschulte @AlexeyAkhunov 
