### PR TITLE
ethclient, accounts/keystore: fix flaky tests

### DIFF
--- a/accounts/keystore/account_cache_test.go
+++ b/accounts/keystore/account_cache_test.go
@@ -96,7 +96,7 @@ func TestWatchNoDir(t *testing.T) {
 
 	// Create ks but not the directory that it watches.
 	rand.Seed(time.Now().UnixNano())
-	dir := filepath.Join(os.TempDir(), fmt.Sprintf("eth-keystore-watch-test-%d-%d", os.Getpid(), rand.Int()))
+	dir := filepath.Join(os.TempDir(), fmt.Sprintf("eth-keystore-watchnodir-test-%d-%d", os.Getpid(), rand.Int()))
 	ks := NewKeyStore(dir, LightScryptN, LightScryptP)
 
 	list := ks.Accounts()
@@ -322,7 +322,7 @@ func TestUpdatedKeyfileContents(t *testing.T) {
 
 	// Create a temporary kesytore to test with
 	rand.Seed(time.Now().UnixNano())
-	dir := filepath.Join(os.TempDir(), fmt.Sprintf("eth-keystore-watch-test-%d-%d", os.Getpid(), rand.Int()))
+	dir := filepath.Join(os.TempDir(), fmt.Sprintf("eth-keystore-updatedkeyfilecontents-test-%d-%d", os.Getpid(), rand.Int()))
 	ks := NewKeyStore(dir, LightScryptN, LightScryptP)
 
 	list := ks.Accounts()

--- a/ethclient/gethclient/gethclient_test.go
+++ b/ethclient/gethclient/gethclient_test.go
@@ -97,37 +97,40 @@ func TestGethClient(t *testing.T) {
 	defer backend.Close()
 	defer client.Close()
 
-	tests := map[string]struct {
+	tests := []struct {
+		name string
 		test func(t *testing.T)
 	}{
-		"TestAccessList": {
+		{
+			"TestAccessList",
 			func(t *testing.T) { testAccessList(t, client) },
 		},
-		"TestGetProof": {
+		{
+			"TestGetProof",
 			func(t *testing.T) { testGetProof(t, client) },
-		},
-		"TestGCStats": {
+		}, {
+			"TestGCStats",
 			func(t *testing.T) { testGCStats(t, client) },
-		},
-		"TestMemStats": {
+		}, {
+			"TestMemStats",
 			func(t *testing.T) { testMemStats(t, client) },
-		},
-		"TestGetNodeInfo": {
+		}, {
+			"TestGetNodeInfo",
 			func(t *testing.T) { testGetNodeInfo(t, client) },
-		},
-		"TestSetHead": {
+		}, {
+			"TestSetHead",
 			func(t *testing.T) { testSetHead(t, client) },
-		},
-		"TestSubscribePendingTxs": {
+		}, {
+			"TestSubscribePendingTxs",
 			func(t *testing.T) { testSubscribePendingTransactions(t, client) },
-		},
-		"TestCallContract": {
+		}, {
+			"TestCallContract",
 			func(t *testing.T) { testCallContract(t, client) },
 		},
 	}
 	t.Parallel()
-	for name, tt := range tests {
-		t.Run(name, tt.test)
+	for _, tt := range tests {
+		t.Run(tt.name, tt.test)
 	}
 }
 


### PR DESCRIPTION
This PR fixes a flaky test, `ethclient/gethclient`: `TestGethClient`. The reason it was flaky was that the table-driven test was actually a map-driven test, and the key order when iterating over the map is undefined. Some of the tests (particularly the setHead test) modifies the backend chain, which is problematic for the access list test, which fails if the basefee is too high. 

So this PR changes it to use a list instead. 

Example failure: https://ci.appveyor.com/project/ethereum/go-ethereum/builds/40814331/job/oh9s50w4lgcxge8d#L821 