### PR TITLE
core/rawdb: use AncientRange when initializing leveldb from freezer

### DIFF
--- a/core/rawdb/chain_iterator.go
+++ b/core/rawdb/chain_iterator.go
@@ -81,24 +81,6 @@ func InitDatabaseFromFreezer(db ethdb.Database) {
 	WriteHeadHeaderHash(db, hash)
 	WriteHeadFastBlockHash(db, hash)
 	log.Info("Initialized database from freezer", "blocks", frozen, "elapsed", common.PrettyDuration(time.Since(start)))
-	/**
-	Sanity check
-	This code should be removed before merging this PR, but it
-	is useful for validating that things work as expected.
-	*/
-	for i := uint64(0); i < frozen; i++ {
-		h, err := db.Ancient(freezerHashTable, i)
-		if err != nil {
-			log.Crit("Something bad happened", "number", i, "err", err)
-		}
-		num := ReadHeaderNumber(db, common.BytesToHash(h))
-		if num == nil {
-			log.Crit("Missing hash->number mapping", "number", i, "err", err)
-		}
-		if *num != i {
-			log.Crit("Erroneous hash->number mapping", "number", i)
-		}
-	}
 }
 
 type blockTxHashes struct {


### PR DESCRIPTION
When we restore from ancients, we go through them and write the `hash->number` mapping into leveldb. As of a while back, we now have a methods to read ancients sequentially a lot faster. 

This PR can most easily be tested by doing a `geth --goerli removedb`, and leave ancients intact. Then a `geth --goerli --nodiscover --maxpeers 0`. 

~~The PR (in draft) contains a little self-validator, which should `CRIT` if the contents is not correct.~~ 