### PR TITLE
rpc: set scheme for ws and ipc conns to the server

### DIFF
--- a/rpc/client.go
+++ b/rpc/client.go
@@ -146,7 +146,7 @@ func (op *requestOp) wait(ctx context.Context, c *Client) (*jsonrpcMessage, erro
 	select {
 	case <-ctx.Done():
 		// Send the timeout to dispatch so it can remove the request IDs.
-		if c.isHTTP() {
+		if !c.isHTTP() {
 			select {
 			case c.reqTimeout <- op:
 			case <-c.closing:

--- a/rpc/server.go
+++ b/rpc/server.go
@@ -83,10 +83,7 @@ func (s *Server) ServeCodec(codec ServerCodec, options CodecOption) {
 	s.codecs.Add(codec)
 	defer s.codecs.Remove(codec)
 
-	c, err := initClient(codec, s.idgen, &s.services)
-	if err != nil {
-		panic("failed to serve codec")
-	}
+	c := initClient(codec, s.idgen, &s.services)
 	<-codec.closed()
 	c.Close()
 }

--- a/rpc/server.go
+++ b/rpc/server.go
@@ -83,7 +83,10 @@ func (s *Server) ServeCodec(codec ServerCodec, options CodecOption) {
 	s.codecs.Add(codec)
 	defer s.codecs.Remove(codec)
 
-	c := initClient(codec, s.idgen, &s.services)
+	c, err := initClient(codec, s.idgen, &s.services)
+	if err != nil {
+		panic("failed to serve codec")
+	}
 	<-codec.closed()
 	c.Close()
 }


### PR DESCRIPTION
Fixes #23593

Clef is reading out the request scheme from key "scheme" of the context. Scheme is being set for http requests in https://github.com/ethereum/go-ethereum/blob/b61ef24ccef9b4d14f4f3c97298fa6d4c1b6b47d/rpc/http.go#L244 but its not set for websocket or ipc connections.