### PR TITLE
Reuse tracer

### DIFF
--- a/eth/tracers/tracer.go
+++ b/eth/tracers/tracer.go
@@ -832,9 +832,6 @@ func (jst *Tracer) GetResult() (json.RawMessage, error) {
 	if err != nil {
 		jst.err = wrapError("result", err)
 	}
-	// Clean up the JavaScript environment
-	jst.vm.DestroyHeap()
-	jst.vm.Destroy()
 
 	return result, jst.err
 }


### PR DESCRIPTION
This was suggested by @holiman to avoid setting up the JS context when running the same tracing script for many txes in a row.

Right now we destroy the JS context and heap in `GetResult`. This can be moved to a `Tracer.Destroy` method which can be invoked at the end of, e.g. `traceChain`. However problem is JS global vars (e.g. `this.enters` in the test). I need to find a way to reset those.

Also added a bench to compare current approach vs reuse. But I don't think its very useful in its current form. The result depends a lot on how much gas is available to the simple loop.