### PR TITLE
eth/tracers: avoid unsyncronized mutations on trie database

### DIFF
--- a/eth/state_accessor.go
+++ b/eth/state_accessor.go
@@ -119,7 +119,8 @@ func (eth *Ethereum) stateAtBlock(block *types.Block, reexec uint64, base *state
 		// Finalize the state so any modifications are written to the trie
 		root, err := statedb.Commit(eth.blockchain.Config().IsEIP158(current.Number()))
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("stateAtBlock commit failed, number %d root %v: %w",
+				current.NumberU64(), current.Root().Hex(), err)
 		}
 		statedb, err = state.New(root, database, nil)
 		if err != nil {

--- a/eth/tracers/api.go
+++ b/eth/tracers/api.go
@@ -349,11 +349,10 @@ func (api *API) traceChain(ctx context.Context, start, end *types.Block, config 
 			}
 			// Prepare the statedb for tracing. Don't use the live database for
 			// tracing to avoid persisting state junks into the database.
-			if _statedb, err := api.backend.StateAtBlock(localctx, block, reexec, statedb, false); err != nil {
+			statedb, err = api.backend.StateAtBlock(localctx, block, reexec, statedb, false)
+			if err != nil {
 				failed = err
 				break
-			} else {
-				statedb = _statedb
 			}
 			if statedb.Database().TrieDB() != nil {
 				// Hold the reference for tracer, will be released at the final stage

--- a/eth/tracers/api.go
+++ b/eth/tracers/api.go
@@ -290,7 +290,11 @@ func (api *API) traceChain(ctx context.Context, start, end *types.Block, config 
 		}()
 	}
 	// Start a goroutine to feed all the blocks into the tracers
-	begin := time.Now()
+	var (
+		begin     = time.Now()
+		derefTodo []common.Hash // list of hashes to dereference from the db
+		derefsMu  sync.Mutex    // mutex for the derefs
+	)
 
 	go func() {
 		var (
@@ -324,6 +328,14 @@ func (api *API) traceChain(ctx context.Context, start, end *types.Block, config 
 				return
 			default:
 			}
+			// clean out any derefs
+			derefsMu.Lock()
+			for _, h := range derefTodo {
+				statedb.Database().TrieDB().Dereference(h)
+			}
+			derefTodo = derefTodo[:0]
+			derefsMu.Unlock()
+
 			// Print progress logs if long enough time elapsed
 			if time.Since(logged) > 8*time.Second {
 				logged = time.Now()
@@ -337,10 +349,11 @@ func (api *API) traceChain(ctx context.Context, start, end *types.Block, config 
 			}
 			// Prepare the statedb for tracing. Don't use the live database for
 			// tracing to avoid persisting state junks into the database.
-			statedb, err = api.backend.StateAtBlock(localctx, block, reexec, statedb, false)
-			if err != nil {
+			if _statedb, err := api.backend.StateAtBlock(localctx, block, reexec, statedb, false); err != nil {
 				failed = err
 				break
+			} else {
+				statedb = _statedb
 			}
 			if statedb.Database().TrieDB() != nil {
 				// Hold the reference for tracer, will be released at the final stage
@@ -382,12 +395,11 @@ func (api *API) traceChain(ctx context.Context, start, end *types.Block, config 
 				Hash:   res.block.Hash(),
 				Traces: res.results,
 			}
+			// Schedule any parent tries held in memory by this task for dereferencing
 			done[uint64(result.Block)] = result
-
-			// Dereference any parent tries held in memory by this task
-			if res.statedb.Database().TrieDB() != nil {
-				res.statedb.Database().TrieDB().Dereference(res.rootref)
-			}
+			derefsMu.Lock()
+			derefTodo = append(derefTodo, res.rootref)
+			derefsMu.Unlock()
 			// Stream completed traces to the user, aborting on the first error
 			for result, ok := done[next]; ok; result, ok = done[next] {
 				if len(result.Traces) > 0 || next == end.NumberU64() {


### PR DESCRIPTION
This might fix https://github.com/ethereum/go-ethereum/issues/23559. 
The current code has several goroutine groups, for different purposes. 

1. Executors which trace chains. Even if those are disabled (replaced with a random timout), the error(s) still happen. So they're not the problem.
2. One state-maker loop, which readies the state for the executors to trace on. This one also references/dereferences state. 
3. One result-catcher loop. This one spews data to the caller, and also dereferences nodes. 

I think the root cause is the fact that a `statedb.Commit`, which is done on `2` inside the `StateAt` call writes to the trie.Database. While doing the actual insert, it does hold the trie mutex, but I suspect that the locking is too granular: if we are in the middle of a large commit when all of a sudden a dereference happens, then things might become br0ken. 

So this PR moves the final dereferencing into `2`, so all Reference/Dereference/Commit operations are done from one routine only. 

With this fix, I haven't been able to repro the issues any more. 

Further testing/verification would be appreciated, to find out if it's a correct fix or not.  