### PR TITLE
core/state/snapshot: fix BAD BLOCK error when snapshot is generating

### DIFF
--- a/core/state/snapshot/generate.go
+++ b/core/state/snapshot/generate.go
@@ -560,6 +560,15 @@ func (dl *diskLayer) generate(stats *generatorStats) {
 		default:
 		}
 		if batch.ValueSize() > ethdb.IdealBatchSize || abort != nil {
+			// currentLocation may lost its `storageHash` part, when currentLocation
+			// and dl.genMarker has the same `accountHash` part and abort generation
+			// before this function is firstly called in onAccount function,
+			//  which will result in ignoring updating the storage snapshot of
+			// that `accountHash`, thus the value in the cache of diskLayer will be an old one.
+			if bytes.Compare(currentLocation, dl.genMarker) < 0 {
+				currentLocation = dl.genMarker
+			}
+
 			// Flush out the batch anyway no matter it's empty or not.
 			// It's possible that all the states are recovered and the
 			// generation indeed makes progress.


### PR DESCRIPTION
This pr is trying to resolve the BAD BLOCK problem in #23531, it is a little obscure to find out

It occurred when geth was syncing from the block of some days ago in full sync mode, while generating snapshots from the beginning

The following is the process how 'BAD BLOCK' occurrs
- The snapshot is generating, its genMarker comes to some key, let's assume  `diskLayer.genMarker = accountHash + storageHash0`
- Then a storage key `accountHash + storageHash1` (storageHash1 < storageHash0) was read from snapshot diskLayer because `accountHash + storageHash1` < `diskLayer.genMarker`. And the storage kv `<accountHash + storageHash1, value1>` will be cached in diskLayer.cache
- After that a new block is written to the chain by `BlockChain.writeBlockWithState()`, and the bottom diffLayer is prepared to be merged to diskLayer by 'snapshot.diffToDisk()', thus will send a abort signal to snapshot generating process
- Then generating process comes to `checkAndFlush`(core/state/snapshot/generate.go:638), receives the abort signal. But it will set `diskLayer.genMarker=accountHash` and thus makes `diskLayer.genMarker` **become smaller**(`accountHash` < `accountHash + storageHash1`)
- 'snapshot.diffToDisk()' receives abort finish signal from snapshot generation process and continues to write data to diskLayer. A new value of key `accountHash + storageHash1` is in that data but will be ignored because its key is greater than 
`diskLayer.genMarker`(accountHash)
- As the snapshot generation proceeding, the new value of  `accountHash + storageHash1` will be finally written to diskLayer(core/state/snapshot/generate.go:673) and `diskLayer.genMarker` will become larger than `accountHash + storageHash1`, let's assume `diskLayer.genMarker = accountHash + storageHash3`, **but the value in `diskLayer.cache` still remains OLD**
- Then next time when `accountHash + storageHash1` is read, the old value in `diskLayer.cache` will be returned and that will cause a **BAD BLOCK** error

In terms of the resolution, I have 2 proposals
1. Make sure the `diskLayer.genMarker` will never go smaller, which was applied in this pr
2. Delete the key in `diskLayer.cache` to make sure any stale value will be evicted, like following code
![image](https://user-images.githubusercontent.com/8242525/134612551-d9085afc-9cf6-4b91-83d6-0bb8b0118fc3.png)

I currently prefer the first one because I think the second will increase a lot of cache query

