### PR TITLE
consensus/ethash: store checksums for cache and dataset files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,7 @@ profile.cov
 
 # VS Code
 .vscode
+.devcontainer
 
 # dashboard
 /dashboard/assets/flow-typed


### PR DESCRIPTION
This pr should resolve https://github.com/ethereum/go-ethereum/issues/22311

Changes:
- calculate checksum using crc32
- store to a cache file itself
- validate the checksum on mmap file stage, regenerate data if it mismatches

Added it for both `cache` and `dataset` structs in `consensus/ethash`