### PR TITLE
all: derive log fields only after filtering

### DIFF
--- a/accounts/abi/bind/backends/simulated.go
+++ b/accounts/abi/bind/backends/simulated.go
@@ -850,6 +850,10 @@ func (fb *filterBackend) GetLogs(ctx context.Context, hash common.Hash) ([][]*ty
 	return logs, nil
 }
 
+func (fb *filterBackend) GetLogsFiltered(ctx context.Context, hash common.Hash, _ func([]*types.Log) []*types.Log) ([]*types.Log, error) {
+	panic("hi")
+}
+
 func (fb *filterBackend) SubscribeNewTxsEvent(ch chan<- core.NewTxsEvent) event.Subscription {
 	return nullSubscription()
 }

--- a/accounts/abi/bind/backends/simulated.go
+++ b/accounts/abi/bind/backends/simulated.go
@@ -851,7 +851,7 @@ func (fb *filterBackend) GetLogs(ctx context.Context, hash common.Hash) ([][]*ty
 }
 
 func (fb *filterBackend) GetLogsFiltered(ctx context.Context, hash common.Hash, _ func([]*types.Log) []*types.Log) ([]*types.Log, error) {
-	panic("hi")
+	panic("unimplemented")
 }
 
 func (fb *filterBackend) SubscribeNewTxsEvent(ch chan<- core.NewTxsEvent) event.Subscription {

--- a/core/rawdb/accessors_chain.go
+++ b/core/rawdb/accessors_chain.go
@@ -763,7 +763,7 @@ func ReadLogs(db ethdb.Reader, hash common.Hash, number uint64, fn func([]*types
 		  }*/
 		return filtered
 	} else {
-		return nil
+		return []*types.Log{}
 	}
 }
 

--- a/core/rawdb/accessors_chain.go
+++ b/core/rawdb/accessors_chain.go
@@ -753,14 +753,6 @@ func ReadLogs(db ethdb.Reader, hash common.Hash, number uint64, fn func([]*types
 			log.BlockHash = hash
 			log.TxHash = body.Transactions[log.TxIndex].Hash()
 		}
-		/*if err := deriveLogFields(receipts, hash, number, body.Transactions); err != nil {
-		      log.Error("Failed to derive block receipts fields", "hash", hash, "number", number, "err", err)
-		      return nil
-		  }
-		  logs := make([][]*types.Log, len(receipts))
-		  for i, receipt := range receipts {
-		      logs[i] = receipt.Logs
-		  }*/
 		return filtered
 	} else {
 		return []*types.Log{}

--- a/core/rawdb/accessors_chain_test.go
+++ b/core/rawdb/accessors_chain_test.go
@@ -744,30 +744,26 @@ func TestReadLogs(t *testing.T) {
 	// Insert the receipt slice into the database and check presence
 	WriteReceipts(db, hash, 0, receipts)
 
-	logs := ReadLogs(db, hash, 0)
+	logs := ReadLogs(db, hash, 0, func(logs []*types.Log) []*types.Log { return logs })
 	if len(logs) == 0 {
 		t.Fatalf("no logs returned")
 	}
-	if have, want := len(logs), 2; have != want {
+	if have, want := len(logs), 4; have != want {
 		t.Fatalf("unexpected number of logs returned, have %d want %d", have, want)
-	}
-	if have, want := len(logs[0]), 2; have != want {
-		t.Fatalf("unexpected number of logs[0] returned, have %d want %d", have, want)
-	}
-	if have, want := len(logs[1]), 2; have != want {
-		t.Fatalf("unexpected number of logs[1] returned, have %d want %d", have, want)
 	}
 
 	// Fill in log fields so we can compare their rlp encoding
 	if err := types.Receipts(receipts).DeriveFields(params.TestChainConfig, hash, 0, body.Transactions); err != nil {
 		t.Fatal(err)
 	}
+	idx := 0
 	for i, pr := range receipts {
-		for j, pl := range pr.Logs {
-			rlpHave, err := rlp.EncodeToBytes(newFullLogRLP(logs[i][j]))
+		for _, pl := range pr.Logs {
+			rlpHave, err := rlp.EncodeToBytes(newFullLogRLP(logs[idx]))
 			if err != nil {
 				t.Fatal(err)
 			}
+			idx++
 			rlpWant, err := rlp.EncodeToBytes(newFullLogRLP(pl))
 			if err != nil {
 				t.Fatal(err)

--- a/eth/api_backend.go
+++ b/eth/api_backend.go
@@ -181,17 +181,15 @@ func (b *EthAPIBackend) GetReceipts(ctx context.Context, hash common.Hash) (type
 }
 
 func (b *EthAPIBackend) GetLogs(ctx context.Context, hash common.Hash) ([][]*types.Log, error) {
-	db := b.eth.ChainDb()
-	number := rawdb.ReadHeaderNumber(db, hash)
-	if number == nil {
-		return nil, errors.New("failed to get block number from hash")
+	receipts := b.eth.blockchain.GetReceiptsByHash(hash)
+	if receipts == nil {
+		return nil, nil
 	}
-	return nil, nil
-	/*logs := rawdb.ReadLogs(db, hash, *number, filterFn)
-	if logs == nil {
-		return nil, errors.New("failed to get logs for block")
+	logs := make([][]*types.Log, len(receipts))
+	for i, receipt := range receipts {
+		logs[i] = receipt.Logs
 	}
-	return logs, nil*/
+	return logs, nil
 }
 
 func (b *EthAPIBackend) GetLogsFiltered(ctx context.Context, hash common.Hash, filterFn func([]*types.Log) []*types.Log) ([]*types.Log, error) {

--- a/eth/api_backend.go
+++ b/eth/api_backend.go
@@ -186,7 +186,21 @@ func (b *EthAPIBackend) GetLogs(ctx context.Context, hash common.Hash) ([][]*typ
 	if number == nil {
 		return nil, errors.New("failed to get block number from hash")
 	}
-	logs := rawdb.ReadLogs(db, hash, *number)
+	return nil, nil
+	/*logs := rawdb.ReadLogs(db, hash, *number, filterFn)
+	if logs == nil {
+		return nil, errors.New("failed to get logs for block")
+	}
+	return logs, nil*/
+}
+
+func (b *EthAPIBackend) GetLogsFiltered(ctx context.Context, hash common.Hash, filterFn func([]*types.Log) []*types.Log) ([]*types.Log, error) {
+	db := b.eth.ChainDb()
+	number := rawdb.ReadHeaderNumber(db, hash)
+	if number == nil {
+		return nil, errors.New("failed to get block number from hash")
+	}
+	logs := rawdb.ReadLogs(db, hash, *number, filterFn)
 	if logs == nil {
 		return nil, errors.New("failed to get logs for block")
 	}

--- a/eth/filters/filter.go
+++ b/eth/filters/filter.go
@@ -253,24 +253,19 @@ func (f *Filter) checkMatches(ctx context.Context, header *types.Header) (logs [
 	if err != nil {
 		return nil, err
 	}
-	/*var unfiltered []*types.Log
-	for _, logs := range logsList {
-		unfiltered = append(unfiltered, logs...)
-	}
-	logs = filterLogs(unfiltered, nil, nil, f.addresses, f.topics)*/
 	if len(logs) > 0 {
 		// We have matching logs, check if we need to resolve full logs via the light client
-		/*if logs[0].TxHash == (common.Hash{}) {
+		if logs[0].TxHash == (common.Hash{}) {
 			receipts, err := f.backend.GetReceipts(ctx, header.Hash())
 			if err != nil {
 				return nil, err
 			}
-			unfiltered = unfiltered[:0]
+			var unfiltered []*types.Log
 			for _, receipt := range receipts {
 				unfiltered = append(unfiltered, receipt.Logs...)
 			}
 			logs = filterLogs(unfiltered, nil, nil, f.addresses, f.topics)
-		}*/
+		}
 		return logs, nil
 	}
 	return nil, nil

--- a/internal/ethapi/backend.go
+++ b/internal/ethapi/backend.go
@@ -84,6 +84,7 @@ type Backend interface {
 	// Filter API
 	BloomStatus() (uint64, uint64)
 	GetLogs(ctx context.Context, blockHash common.Hash) ([][]*types.Log, error)
+	GetLogsFiltered(ctx context.Context, blockHash common.Hash, _ func([]*types.Log) []*types.Log) ([]*types.Log, error)
 	ServiceFilter(ctx context.Context, session *bloombits.MatcherSession)
 	SubscribeLogsEvent(ch chan<- []*types.Log) event.Subscription
 	SubscribePendingLogsEvent(ch chan<- []*types.Log) event.Subscription

--- a/les/api_backend.go
+++ b/les/api_backend.go
@@ -174,6 +174,10 @@ func (b *LesApiBackend) GetLogs(ctx context.Context, hash common.Hash) ([][]*typ
 	return nil, nil
 }
 
+func (b *LesApiBackend) GetLogsFiltered(ctx context.Context, hash common.Hash, _ func([]*types.Log) []*types.Log) ([]*types.Log, error) {
+	panic("hi")
+}
+
 func (b *LesApiBackend) GetTd(ctx context.Context, hash common.Hash) *big.Int {
 	if number := rawdb.ReadHeaderNumber(b.eth.chainDb, hash); number != nil {
 		return b.eth.blockchain.GetTdOdr(ctx, hash, *number)

--- a/les/api_backend.go
+++ b/les/api_backend.go
@@ -175,7 +175,7 @@ func (b *LesApiBackend) GetLogs(ctx context.Context, hash common.Hash) ([][]*typ
 }
 
 func (b *LesApiBackend) GetLogsFiltered(ctx context.Context, hash common.Hash, _ func([]*types.Log) []*types.Log) ([]*types.Log, error) {
-	panic("hi")
+	panic("unimplemented")
 }
 
 func (b *LesApiBackend) GetTd(ctx context.Context, hash common.Hash) *big.Int {


### PR DESCRIPTION
This PR includes Optim2 mentioned here: https://github.com/ethereum/go-ethereum/pull/23147#issuecomment-915065457
We want to avoid deriving log fields like tx hash which require reading the block body from disk unless there are actually matching logs in that block.

Not super happy with the implementation. I added a new method to Backend `GetLogsFiltered` only to avoid breaking other places which use `GetLogs` like LES. Might re-write if I think of a better solution