### PR TITLE
accounts: increased test coverage for TerminalStringer and UnmarshalJSON

### DIFF
--- a/accounts/url_test.go
+++ b/accounts/url_test.go
@@ -94,3 +94,71 @@ func TestURLComparison(t *testing.T) {
 		}
 	}
 }
+
+func TestTerminalStringTransformation(t *testing.T) {
+	testCases := []struct {
+		name                string
+		url                 string
+		expectedTerminalUrl string
+	}{
+		{
+			"long-url",
+			"https://ethereum.org/test/account",
+			"https://ethereum.org/test/accou..",
+		},
+		{
+			"short-url",
+			"https://ethereum.org/",
+			"https://ethereum.org/",
+		},
+	}
+
+	for _, testCase := range testCases {
+		testCase := testCase
+
+		t.Run(testCase.name, func(t *testing.T) {
+			url, err := parseURL(testCase.url)
+			if err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+			terminalString := url.TerminalString()
+			if terminalString != testCase.expectedTerminalUrl {
+				t.Errorf("expected: %v, got: %v", testCase.expectedTerminalUrl, terminalString)
+			}
+		})
+	}
+}
+
+func TestUnmarshalBrokenJson(t *testing.T) {
+
+	testCases := []struct {
+		name            string
+		brokenData      string
+		expectedMessage string
+	}{
+		{
+			"broken json",
+			"{\"test ",
+			"unexpected end of JSON input",
+		},
+		{
+			"broken url",
+			"\"tomato\"",
+			"protocol scheme missing",
+		},
+	}
+
+	for _, testCase := range testCases {
+		testCase := testCase
+		t.Run(testCase.name, func(t *testing.T) {
+			url := &URL{}
+			err := url.UnmarshalJSON([]byte(testCase.brokenData))
+			if err == nil {
+				t.Errorf("expected error in unmarshaling %v", testCase.brokenData)
+			}
+			if err.Error() != testCase.expectedMessage {
+				t.Errorf("unexpected error: %v in unmarshaling json: %v", testCase.brokenData, err.Error())
+			}
+		})
+	}
+}

--- a/accounts/url_test.go
+++ b/accounts/url_test.go
@@ -102,12 +102,12 @@ func TestTerminalStringTransformation(t *testing.T) {
 		expectedTerminalUrl string
 	}{
 		{
-			"long-url",
+			"long url",
 			"https://ethereum.org/test/account",
 			"https://ethereum.org/test/accou..",
 		},
 		{
-			"short-url",
+			"short url",
 			"https://ethereum.org/",
 			"https://ethereum.org/",
 		},


### PR DESCRIPTION
Added test cases to cover URL functions TerminalString() and UnmarshalJSON()

Before:
![image](https://user-images.githubusercontent.com/10694338/135323492-decdd142-8025-4f34-974d-776d8fff545f.png)

After:
![image](https://user-images.githubusercontent.com/10694338/135323360-96d33ece-2537-4f0b-a97b-70465ca325b8.png)
