### PR TITLE
internal/ethapi: support retrieving header RLPs too

### DIFF
--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -1915,6 +1915,19 @@ func NewPublicDebugAPI(b Backend) *PublicDebugAPI {
 	return &PublicDebugAPI{b: b}
 }
 
+// GetHeaderRlp retrieves the RLP encoded for of a single header.
+func (api *PublicDebugAPI) GetHeaderRlp(ctx context.Context, number uint64) (string, error) {
+	header, _ := api.b.HeaderByNumber(ctx, rpc.BlockNumber(number))
+	if header == nil {
+		return "", fmt.Errorf("header #%d not found", number)
+	}
+	encoded, err := rlp.EncodeToBytes(header)
+	if err != nil {
+		return "", err
+	}
+	return fmt.Sprintf("%x", encoded), nil
+}
+
 // GetBlockRlp retrieves the RLP encoded for of a single block.
 func (api *PublicDebugAPI) GetBlockRlp(ctx context.Context, number uint64) (string, error) {
 	block, _ := api.b.BlockByNumber(ctx, rpc.BlockNumber(number))

--- a/internal/web3ext/web3ext.go
+++ b/internal/web3ext/web3ext.go
@@ -224,6 +224,11 @@ web3._extend({
 			outputFormatter: console.log
 		}),
 		new web3._extend.Method({
+			name: 'getHeaderRlp',
+			call: 'debug_getHeaderRlp',
+			params: 1
+		}),
+		new web3._extend.Method({
 			name: 'getBlockRlp',
 			call: 'debug_getBlockRlp',
 			params: 1


### PR DESCRIPTION
We have a method to retrieve a block in RLP form (`debug.GetBlockRlp`), but sometimes we only need the header. Retrieving and managing the entire block RLP in that case can be unwieldy on mainnet tx counts. This PR introduces a `GetHeaderRlp` counterpart that only retrieves and serializes the header for use cases where that's enough.