### PR TITLE
build: increase thread stack size when running alpine linux

### DIFF
--- a/build/ci.go
+++ b/build/ci.go
@@ -259,6 +259,10 @@ func buildFlags(env build.Environment) (flags []string) {
 	if runtime.GOOS == "darwin" {
 		ld = append(ld, "-s")
 	}
+	// Increase the thread stack size when running on alpine linux.
+	// TODO(gballet) figure out a way to detect we are running on alpine
+	// linux, as this line won't build on all platforms.
+	ld = append(ld, "-extldflags='-Wl,-z,-stack-size=0x200000'")
 	if len(ld) > 0 {
 		flags = append(flags, "-ldflags", strings.Join(ld, " "))
 	}


### PR DESCRIPTION
A potential solution for #23669. This PR is currently kept as a suggestion to collect feedback. To be completed, one must check that the ld flag is only activated when running alpine linux.