### PR TITLE
internal/ethapi: make header/block rlp retrieval canonical

### DIFF
--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -1916,29 +1916,21 @@ func NewPublicDebugAPI(b Backend) *PublicDebugAPI {
 }
 
 // GetHeaderRlp retrieves the RLP encoded for of a single header.
-func (api *PublicDebugAPI) GetHeaderRlp(ctx context.Context, number uint64) (string, error) {
+func (api *PublicDebugAPI) GetHeaderRlp(ctx context.Context, number uint64) (hexutil.Bytes, error) {
 	header, _ := api.b.HeaderByNumber(ctx, rpc.BlockNumber(number))
 	if header == nil {
-		return "", fmt.Errorf("header #%d not found", number)
+		return nil, fmt.Errorf("header #%d not found", number)
 	}
-	encoded, err := rlp.EncodeToBytes(header)
-	if err != nil {
-		return "", err
-	}
-	return fmt.Sprintf("%x", encoded), nil
+	return rlp.EncodeToBytes(header)
 }
 
 // GetBlockRlp retrieves the RLP encoded for of a single block.
-func (api *PublicDebugAPI) GetBlockRlp(ctx context.Context, number uint64) (string, error) {
+func (api *PublicDebugAPI) GetBlockRlp(ctx context.Context, number uint64) (hexutil.Bytes, error) {
 	block, _ := api.b.BlockByNumber(ctx, rpc.BlockNumber(number))
 	if block == nil {
-		return "", fmt.Errorf("block #%d not found", number)
+		return nil, fmt.Errorf("block #%d not found", number)
 	}
-	encoded, err := rlp.EncodeToBytes(block)
-	if err != nil {
-		return "", err
-	}
-	return fmt.Sprintf("%x", encoded), nil
+	return rlp.EncodeToBytes(block)
 }
 
 // TestSignCliqueBlock fetches the given block number, and attempts to sign it as a clique header with the


### PR DESCRIPTION
Use `hextuils` to return `debug_getHeaderRlp` or `debug_getBlockRlp` (it's annoying to feed the result into other API calls because I always need to manually much with the hex string).