### PR TITLE
miner/stress: initialize account backends explicitly

### DIFF
--- a/miner/stress/1559/main.go
+++ b/miner/stress/1559/main.go
@@ -23,10 +23,9 @@ import (
 	"math/big"
 	"math/rand"
 	"os"
-	"path/filepath"
+	"os/signal"
 	"time"
 
-	"github.com/ethereum/go-ethereum/accounts/keystore"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/fdlimit"
 	"github.com/ethereum/go-ethereum/consensus/ethash"
@@ -58,12 +57,17 @@ func main() {
 		faucets[i], _ = crypto.GenerateKey()
 	}
 	// Pre-generate the ethash mining DAG so we don't race
-	ethash.MakeDataset(1, filepath.Join(os.Getenv("HOME"), ".ethash"))
+	ethash.MakeDataset(1, ethconfig.Defaults.Ethash.DatasetDir)
 
 	// Create an Ethash network based off of the Ropsten config
 	genesis := makeGenesis(faucets)
 
+	// Handle interrupts.
+	interruptCh := make(chan os.Signal, 5)
+	signal.Notify(interruptCh, os.Interrupt)
+
 	var (
+		stacks []*node.Node
 		nodes  []*eth.Ethereum
 		enodes []*enode.Node
 	)
@@ -85,12 +89,6 @@ func main() {
 		// Start tracking the node and its enode
 		nodes = append(nodes, ethBackend)
 		enodes = append(enodes, stack.Server().Self())
-
-		// Inject the signer key and start sealing with it
-		store := stack.AccountManager().Backends(keystore.KeyStoreType)[0].(*keystore.KeyStore)
-		if _, err := store.NewAccount(""); err != nil {
-			panic(err)
-		}
 	}
 
 	// Iterate over all the nodes and start mining
@@ -111,6 +109,16 @@ func main() {
 		signer = types.LatestSignerForChainID(genesis.Config.ChainID)
 	)
 	for {
+		// Stop when interrupted.
+		select {
+		case <-interruptCh:
+			for _, node := range stacks {
+				node.Close()
+			}
+			return
+		default:
+		}
+
 		// Pick a random mining node
 		index := rand.Intn(len(faucets))
 		backend := nodes[index%len(nodes)]
@@ -242,9 +250,10 @@ func makeMiner(genesis *core.Genesis) (*node.Node, *eth.Ethereum, error) {
 		GPO:             ethconfig.Defaults.GPO,
 		Ethash:          ethconfig.Defaults.Ethash,
 		Miner: miner.Config{
-			GasCeil:  genesis.GasLimit * 11 / 10,
-			GasPrice: big.NewInt(1),
-			Recommit: time.Second,
+			Etherbase: common.Address{1},
+			GasCeil:   genesis.GasLimit * 11 / 10,
+			GasPrice:  big.NewInt(1),
+			Recommit:  time.Second,
 		},
 	})
 	if err != nil {

--- a/miner/stress/clique/main.go
+++ b/miner/stress/clique/main.go
@@ -24,6 +24,7 @@ import (
 	"math/big"
 	"math/rand"
 	"os"
+	"os/signal"
 	"time"
 
 	"github.com/ethereum/go-ethereum/accounts/keystore"
@@ -59,11 +60,15 @@ func main() {
 	// Create a Clique network based off of the Rinkeby config
 	genesis := makeGenesis(faucets, sealers)
 
+	// Handle interrupts.
+	interruptCh := make(chan os.Signal, 5)
+	signal.Notify(interruptCh, os.Interrupt)
+
 	var (
+		stacks []*node.Node
 		nodes  []*eth.Ethereum
 		enodes []*enode.Node
 	)
-
 	for _, sealer := range sealers {
 		// Start the node and wait until it's up
 		stack, ethBackend, err := makeSealer(genesis)
@@ -80,18 +85,20 @@ func main() {
 			stack.Server().AddPeer(n)
 		}
 		// Start tracking the node and its enode
+		stacks = append(stacks, stack)
 		nodes = append(nodes, ethBackend)
 		enodes = append(enodes, stack.Server().Self())
 
 		// Inject the signer key and start sealing with it
-		store := stack.AccountManager().Backends(keystore.KeyStoreType)[0].(*keystore.KeyStore)
-		signer, err := store.ImportECDSA(sealer, "")
+		ks := keystore.NewKeyStore(stack.KeyStoreDir(), keystore.LightScryptN, keystore.LightScryptP)
+		signer, err := ks.ImportECDSA(sealer, "")
 		if err != nil {
 			panic(err)
 		}
-		if err := store.Unlock(signer, ""); err != nil {
+		if err := ks.Unlock(signer, ""); err != nil {
 			panic(err)
 		}
+		stack.AccountManager().AddBackend(ks)
 	}
 
 	// Iterate over all the nodes and start signing on them
@@ -106,6 +113,16 @@ func main() {
 	// Start injecting transactions from the faucet like crazy
 	nonces := make([]uint64, len(faucets))
 	for {
+		// Stop when interrupted.
+		select {
+		case <-interruptCh:
+			for _, node := range stacks {
+				node.Close()
+			}
+			return
+		default:
+		}
+
 		// Pick a random signer node
 		index := rand.Intn(len(faucets))
 		backend := nodes[index%len(nodes)]

--- a/miner/stress/ethash/main.go
+++ b/miner/stress/ethash/main.go
@@ -23,10 +23,9 @@ import (
 	"math/big"
 	"math/rand"
 	"os"
-	"path/filepath"
+	"os/signal"
 	"time"
 
-	"github.com/ethereum/go-ethereum/accounts/keystore"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/fdlimit"
 	"github.com/ethereum/go-ethereum/consensus/ethash"
@@ -54,12 +53,17 @@ func main() {
 		faucets[i], _ = crypto.GenerateKey()
 	}
 	// Pre-generate the ethash mining DAG so we don't race
-	ethash.MakeDataset(1, filepath.Join(os.Getenv("HOME"), ".ethash"))
+	ethash.MakeDataset(1, ethconfig.Defaults.Ethash.DatasetDir)
 
 	// Create an Ethash network based off of the Ropsten config
 	genesis := makeGenesis(faucets)
 
+	// Handle interrupts.
+	interruptCh := make(chan os.Signal, 5)
+	signal.Notify(interruptCh, os.Interrupt)
+
 	var (
+		stacks []*node.Node
 		nodes  []*eth.Ethereum
 		enodes []*enode.Node
 	)
@@ -79,14 +83,9 @@ func main() {
 			stack.Server().AddPeer(n)
 		}
 		// Start tracking the node and its enode
+		stacks = append(stacks, stack)
 		nodes = append(nodes, ethBackend)
 		enodes = append(enodes, stack.Server().Self())
-
-		// Inject the signer key and start sealing with it
-		store := stack.AccountManager().Backends(keystore.KeyStoreType)[0].(*keystore.KeyStore)
-		if _, err := store.NewAccount(""); err != nil {
-			panic(err)
-		}
 	}
 
 	// Iterate over all the nodes and start mining
@@ -101,6 +100,16 @@ func main() {
 	// Start injecting transactions from the faucets like crazy
 	nonces := make([]uint64, len(faucets))
 	for {
+		// Stop when interrupted.
+		select {
+		case <-interruptCh:
+			for _, node := range stacks {
+				node.Close()
+			}
+			return
+		default:
+		}
+
 		// Pick a random mining node
 		index := rand.Intn(len(faucets))
 		backend := nodes[index%len(nodes)]
@@ -171,9 +180,10 @@ func makeMiner(genesis *core.Genesis) (*node.Node, *eth.Ethereum, error) {
 		GPO:             ethconfig.Defaults.GPO,
 		Ethash:          ethconfig.Defaults.Ethash,
 		Miner: miner.Config{
-			GasCeil:  genesis.GasLimit * 11 / 10,
-			GasPrice: big.NewInt(1),
-			Recommit: time.Second,
+			Etherbase: common.Address{1},
+			GasCeil:   genesis.GasLimit * 11 / 10,
+			GasPrice:  big.NewInt(1),
+			Recommit:  time.Second,
 		},
 	})
 	if err != nil {


### PR DESCRIPTION
node.Node no longer has any account manager backends by default, they need to be registered explicitly. This was changed recently, in #23019, and broke the stress tests.

For ethash-based tests, we actually don't need any accounts in the miner keystore. Just set the etherbase instead to make mining work. For clique, the signer account must be in the keystore.

The change also adds interrupt handling in all stress tests.