### PR TITLE
internal/jsre: handle null and undefined to prevent crash

### DIFF
--- a/internal/jsre/completion.go
+++ b/internal/jsre/completion.go
@@ -44,7 +44,7 @@ func getCompletions(vm *goja.Runtime, line string) (results []string) {
 	obj := vm.GlobalObject()
 	for i := 0; i < len(parts)-1; i++ {
 		v := obj.Get(parts[i])
-		if v == nil {
+		if v == nil || goja.IsNull(v) || goja.IsUndefined(v) {
 			return nil // No object was found
 		}
 		obj = v.ToObject(vm)


### PR DESCRIPTION
Prevents the console from crashing console when auto-completing a variable that is null or undefined.

Fixes #23693 