### PR TITLE
fixed broken web3 methods link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ This command will:
    causing it to download more data in exchange for avoiding processing the entire history
    of the Ethereum network, which is very CPU intensive.
  * Start up `geth`'s built-in interactive [JavaScript console](https://geth.ethereum.org/docs/interface/javascript-console),
-   (via the trailing `console` subcommand) through which you can interact using [`web3` methods](https://web3js.readthedocs.io/en/) 
+   (via the trailing `console` subcommand) through which you can interact using [`web3` methods](https://web3js.readthedocs.io/) 
    (note: the `web3` version bundled within `geth` is very old, and not up to date with official docs),
    as well as `geth`'s own [management APIs](https://geth.ethereum.org/docs/rpc/server).
    This tool is optional and if you leave it out you can always attach to an already running


### PR DESCRIPTION
PR to fix the 'web3 methods' broken link in README.md, https://web3js.readthedocs.io/en/ results in a 404, so I included the latest version `v1.5.2` before the latest release candidate `v3.0.0-rc.5`