### PR TITLE
core: generic test suite for AncientStore

### DIFF
--- a/core/rawdb/database.go
+++ b/core/rawdb/database.go
@@ -79,11 +79,6 @@ type nofreezedb struct {
 	ethdb.KeyValueStore
 }
 
-// HasAncient returns an error as we don't have a backing chain freezer.
-func (db *nofreezedb) HasAncient(kind string, number uint64) (bool, error) {
-	return false, errNotSupported
-}
-
 // Ancient returns an error as we don't have a backing chain freezer.
 func (db *nofreezedb) Ancient(kind string, number uint64) ([]byte, error) {
 	return nil, errNotSupported

--- a/core/rawdb/freezer.go
+++ b/core/rawdb/freezer.go
@@ -185,15 +185,6 @@ func (f *freezer) Close() error {
 	return nil
 }
 
-// HasAncient returns an indicator whether the specified ancient data exists
-// in the freezer.
-func (f *freezer) HasAncient(kind string, number uint64) (bool, error) {
-	if table := f.tables[kind]; table != nil {
-		return table.has(number), nil
-	}
-	return false, ethdb.ErrAncientUnknownKind
-}
-
 // Ancient retrieves an ancient binary blob from the append-only immutable files.
 func (f *freezer) Ancient(kind string, number uint64) ([]byte, error) {
 	if table := f.tables[kind]; table != nil {

--- a/core/rawdb/freezer.go
+++ b/core/rawdb/freezer.go
@@ -39,14 +39,6 @@ var (
 	// mutations are disallowed.
 	errReadOnly = errors.New("read only")
 
-	// errUnknownTable is returned if the user attempts to read from a table that is
-	// not tracked by the freezer.
-	errUnknownTable = errors.New("unknown table")
-
-	// errOutOrderInsertion is returned if the user attempts to inject out-of-order
-	// binary blobs into the freezer.
-	errOutOrderInsertion = errors.New("the append operation is out-order")
-
 	// errSymlinkDatadir is returned if the ancient directory specified by user
 	// is a symbolic link.
 	errSymlinkDatadir = errors.New("symbolic link datadir is not supported")
@@ -199,7 +191,7 @@ func (f *freezer) HasAncient(kind string, number uint64) (bool, error) {
 	if table := f.tables[kind]; table != nil {
 		return table.has(number), nil
 	}
-	return false, nil
+	return false, ethdb.ErrAncientUnknownKind
 }
 
 // Ancient retrieves an ancient binary blob from the append-only immutable files.
@@ -207,7 +199,7 @@ func (f *freezer) Ancient(kind string, number uint64) ([]byte, error) {
 	if table := f.tables[kind]; table != nil {
 		return table.Retrieve(number)
 	}
-	return nil, errUnknownTable
+	return nil, ethdb.ErrAncientUnknownKind
 }
 
 // AncientRange retrieves multiple items in sequence, starting from the index 'start'.
@@ -219,7 +211,7 @@ func (f *freezer) AncientRange(kind string, start, count, maxBytes uint64) ([][]
 	if table := f.tables[kind]; table != nil {
 		return table.RetrieveItems(start, count, maxBytes)
 	}
-	return nil, errUnknownTable
+	return nil, ethdb.ErrAncientUnknownKind
 }
 
 // Ancients returns the length of the frozen items.
@@ -242,7 +234,7 @@ func (f *freezer) AncientSize(kind string) (uint64, error) {
 	if table := f.tables[kind]; table != nil {
 		return table.size()
 	}
-	return 0, errUnknownTable
+	return 0, ethdb.ErrAncientUnknownKind
 }
 
 // ReadAncients runs the given read operation while ensuring that no writes take place

--- a/core/rawdb/freezer_batch.go
+++ b/core/rawdb/freezer_batch.go
@@ -21,6 +21,7 @@ import (
 	"sync/atomic"
 
 	"github.com/ethereum/go-ethereum/common/math"
+	"github.com/ethereum/go-ethereum/ethdb"
 	"github.com/ethereum/go-ethereum/rlp"
 	"github.com/golang/snappy"
 )
@@ -116,7 +117,7 @@ func (batch *freezerTableBatch) reset() {
 // existing data.
 func (batch *freezerTableBatch) Append(item uint64, data interface{}) error {
 	if item != batch.curItem {
-		return fmt.Errorf("%w: have %d want %d", errOutOrderInsertion, item, batch.curItem)
+		return fmt.Errorf("%w: have %d want %d", ethdb.ErrAncientOutOrderInsertion, item, batch.curItem)
 	}
 
 	// Encode the item.
@@ -136,7 +137,7 @@ func (batch *freezerTableBatch) Append(item uint64, data interface{}) error {
 // existing data.
 func (batch *freezerTableBatch) AppendRaw(item uint64, blob []byte) error {
 	if item != batch.curItem {
-		return fmt.Errorf("%w: have %d want %d", errOutOrderInsertion, item, batch.curItem)
+		return fmt.Errorf("%w: have %d want %d", ethdb.ErrAncientOutOrderInsertion, item, batch.curItem)
 	}
 
 	encItem := blob

--- a/core/rawdb/freezer_table.go
+++ b/core/rawdb/freezer_table.go
@@ -28,6 +28,7 @@ import (
 	"sync/atomic"
 
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/ethdb"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/metrics"
 	"github.com/golang/snappy"
@@ -37,10 +38,6 @@ var (
 	// errClosed is returned if an operation attempts to read from or write to the
 	// freezer table after it has already been closed.
 	errClosed = errors.New("closed")
-
-	// errOutOfBounds is returned if the item requested is not contained within the
-	// freezer table.
-	errOutOfBounds = errors.New("out of bounds")
 
 	// errNotSupported is returned if the database doesn't support the required operation.
 	errNotSupported = errors.New("this operation is not supported")
@@ -735,7 +732,7 @@ func (t *freezerTable) retrieveItems(start, count, maxBytes uint64) ([]byte, []i
 	// Ensure the start is written, not deleted from the tail, and that the
 	// caller actually wants something
 	if items <= start || hidden > start || count == 0 {
-		return nil, nil, errOutOfBounds
+		return nil, nil, ethdb.ErrAncientOutOfBounds
 	}
 	if start+count > items {
 		count = items - start

--- a/core/rawdb/freezer_table_test.go
+++ b/core/rawdb/freezer_table_test.go
@@ -30,6 +30,7 @@ import (
 	"time"
 
 	"github.com/davecgh/go-spew/spew"
+	"github.com/ethereum/go-ethereum/ethdb"
 	"github.com/ethereum/go-ethereum/metrics"
 	"github.com/stretchr/testify/require"
 )
@@ -74,7 +75,7 @@ func TestFreezerBasics(t *testing.T) {
 	}
 	// Check that we cannot read too far
 	_, err = f.Retrieve(uint64(255))
-	if err != errOutOfBounds {
+	if err != ethdb.ErrAncientOutOfBounds {
 		t.Fatal(err)
 	}
 }
@@ -603,10 +604,10 @@ func TestFreezerOffset(t *testing.T) {
 		require.NoError(t, batch.commit())
 
 		checkRetrieveError(t, f, map[uint64]error{
-			0: errOutOfBounds,
-			1: errOutOfBounds,
-			2: errOutOfBounds,
-			3: errOutOfBounds,
+			0: ethdb.ErrAncientOutOfBounds,
+			1: ethdb.ErrAncientOutOfBounds,
+			2: ethdb.ErrAncientOutOfBounds,
+			3: ethdb.ErrAncientOutOfBounds,
 		})
 		checkRetrieve(t, f, map[uint64][]byte{
 			4: getChunk(20, 0xbb),
@@ -651,11 +652,11 @@ func TestFreezerOffset(t *testing.T) {
 		t.Log(f.dumpIndexString(0, 100))
 
 		checkRetrieveError(t, f, map[uint64]error{
-			0:      errOutOfBounds,
-			1:      errOutOfBounds,
-			2:      errOutOfBounds,
-			3:      errOutOfBounds,
-			999999: errOutOfBounds,
+			0:      ethdb.ErrAncientOutOfBounds,
+			1:      ethdb.ErrAncientOutOfBounds,
+			2:      ethdb.ErrAncientOutOfBounds,
+			3:      ethdb.ErrAncientOutOfBounds,
+			999999: ethdb.ErrAncientOutOfBounds,
 		})
 		checkRetrieve(t, f, map[uint64][]byte{
 			1000000: getChunk(20, 0xbb),
@@ -703,7 +704,7 @@ func TestTruncateTail(t *testing.T) {
 	f.truncateTail(1)
 	fmt.Println(f.dumpIndexString(0, 1000))
 	checkRetrieveError(t, f, map[uint64]error{
-		0: errOutOfBounds,
+		0: ethdb.ErrAncientOutOfBounds,
 	})
 	checkRetrieve(t, f, map[uint64][]byte{
 		1: getChunk(20, 0xEE),
@@ -721,7 +722,7 @@ func TestTruncateTail(t *testing.T) {
 		t.Fatal(err)
 	}
 	checkRetrieveError(t, f, map[uint64]error{
-		0: errOutOfBounds,
+		0: ethdb.ErrAncientOutOfBounds,
 	})
 	checkRetrieve(t, f, map[uint64][]byte{
 		1: getChunk(20, 0xEE),
@@ -735,8 +736,8 @@ func TestTruncateTail(t *testing.T) {
 	// truncate two elements( item 0, item 1 ), the file 0 should be deleted
 	f.truncateTail(2)
 	checkRetrieveError(t, f, map[uint64]error{
-		0: errOutOfBounds,
-		1: errOutOfBounds,
+		0: ethdb.ErrAncientOutOfBounds,
+		1: ethdb.ErrAncientOutOfBounds,
 	})
 	checkRetrieve(t, f, map[uint64][]byte{
 		2: getChunk(20, 0xdd),
@@ -755,8 +756,8 @@ func TestTruncateTail(t *testing.T) {
 	defer f.Close()
 
 	checkRetrieveError(t, f, map[uint64]error{
-		0: errOutOfBounds,
-		1: errOutOfBounds,
+		0: ethdb.ErrAncientOutOfBounds,
+		1: ethdb.ErrAncientOutOfBounds,
 	})
 	checkRetrieve(t, f, map[uint64][]byte{
 		2: getChunk(20, 0xdd),
@@ -769,13 +770,13 @@ func TestTruncateTail(t *testing.T) {
 	// truncate all, the entire freezer should be deleted
 	f.truncateTail(7)
 	checkRetrieveError(t, f, map[uint64]error{
-		0: errOutOfBounds,
-		1: errOutOfBounds,
-		2: errOutOfBounds,
-		3: errOutOfBounds,
-		4: errOutOfBounds,
-		5: errOutOfBounds,
-		6: errOutOfBounds,
+		0: ethdb.ErrAncientOutOfBounds,
+		1: ethdb.ErrAncientOutOfBounds,
+		2: ethdb.ErrAncientOutOfBounds,
+		3: ethdb.ErrAncientOutOfBounds,
+		4: ethdb.ErrAncientOutOfBounds,
+		5: ethdb.ErrAncientOutOfBounds,
+		6: ethdb.ErrAncientOutOfBounds,
 	})
 }
 
@@ -806,13 +807,13 @@ func TestTruncateHead(t *testing.T) {
 	// NewHead is required to be 3, the entire table should be truncated
 	f.truncateHead(4)
 	checkRetrieveError(t, f, map[uint64]error{
-		0: errOutOfBounds, // Deleted by tail
-		1: errOutOfBounds, // Deleted by tail
-		2: errOutOfBounds, // Deleted by tail
-		3: errOutOfBounds, // Deleted by tail
-		4: errOutOfBounds, // Deleted by Head
-		5: errOutOfBounds, // Deleted by Head
-		6: errOutOfBounds, // Deleted by Head
+		0: ethdb.ErrAncientOutOfBounds, // Deleted by tail
+		1: ethdb.ErrAncientOutOfBounds, // Deleted by tail
+		2: ethdb.ErrAncientOutOfBounds, // Deleted by tail
+		3: ethdb.ErrAncientOutOfBounds, // Deleted by tail
+		4: ethdb.ErrAncientOutOfBounds, // Deleted by Head
+		5: ethdb.ErrAncientOutOfBounds, // Deleted by Head
+		6: ethdb.ErrAncientOutOfBounds, // Deleted by Head
 	})
 
 	// Append new items

--- a/core/rawdb/freezer_test.go
+++ b/core/rawdb/freezer_test.go
@@ -17,240 +17,29 @@
 package rawdb
 
 import (
-	"bytes"
-	"errors"
-	"fmt"
 	"io/ioutil"
-	"math/big"
-	"math/rand"
 	"os"
-	"sync"
 	"testing"
 
 	"github.com/ethereum/go-ethereum/ethdb"
-	"github.com/ethereum/go-ethereum/rlp"
+	"github.com/ethereum/go-ethereum/ethdb/dbtest"
 	"github.com/stretchr/testify/require"
 )
 
-var freezerTestTableDef = map[string]bool{"test": true}
-
-func TestFreezerModify(t *testing.T) {
-	t.Parallel()
-
-	// Create test data.
-	var valuesRaw [][]byte
-	var valuesRLP []*big.Int
-	for x := 0; x < 100; x++ {
-		v := getChunk(256, x)
-		valuesRaw = append(valuesRaw, v)
-		iv := big.NewInt(int64(x))
-		iv = iv.Exp(iv, iv, nil)
-		valuesRLP = append(valuesRLP, iv)
-	}
-
-	tables := map[string]bool{"raw": true, "rlp": false}
-	f, dir := newFreezerForTesting(t, tables)
-	defer os.RemoveAll(dir)
-	defer f.Close()
-
-	// Commit test data.
-	_, err := f.ModifyAncients(func(op ethdb.AncientWriteOp) error {
-		for i := range valuesRaw {
-			if err := op.AppendRaw("raw", uint64(i), valuesRaw[i]); err != nil {
-				return err
-			}
-			if err := op.Append("rlp", uint64(i), valuesRLP[i]); err != nil {
-				return err
-			}
-		}
-		return nil
-	})
-	if err != nil {
-		t.Fatal("ModifyAncients failed:", err)
-	}
-
-	// Dump indexes.
-	for _, table := range f.tables {
-		t.Log(table.name, "index:", table.dumpIndexString(0, int64(len(valuesRaw))))
-	}
-
-	// Read back test data.
-	checkAncientCount(t, f, "raw", uint64(len(valuesRaw)))
-	checkAncientCount(t, f, "rlp", uint64(len(valuesRLP)))
-	for i := range valuesRaw {
-		v, _ := f.Ancient("raw", uint64(i))
-		if !bytes.Equal(v, valuesRaw[i]) {
-			t.Fatalf("wrong raw value at %d: %x", i, v)
-		}
-		ivEnc, _ := f.Ancient("rlp", uint64(i))
-		want, _ := rlp.EncodeToBytes(valuesRLP[i])
-		if !bytes.Equal(ivEnc, want) {
-			t.Fatalf("wrong RLP value at %d: %x", i, ivEnc)
-		}
-	}
-}
-
-// This checks that ModifyAncients rolls back freezer updates
-// when the function passed to it returns an error.
-func TestFreezerModifyRollback(t *testing.T) {
-	t.Parallel()
-
-	f, dir := newFreezerForTesting(t, freezerTestTableDef)
-	defer os.RemoveAll(dir)
-
-	theError := errors.New("oops")
-	_, err := f.ModifyAncients(func(op ethdb.AncientWriteOp) error {
-		// Append three items. This creates two files immediately,
-		// because the table size limit of the test freezer is 2048.
-		require.NoError(t, op.AppendRaw("test", 0, make([]byte, 2048)))
-		require.NoError(t, op.AppendRaw("test", 1, make([]byte, 2048)))
-		require.NoError(t, op.AppendRaw("test", 2, make([]byte, 2048)))
-		return theError
-	})
-	if err != theError {
-		t.Errorf("ModifyAncients returned wrong error %q", err)
-	}
-	checkAncientCount(t, f, "test", 0)
-	f.Close()
-
-	// Reopen and check that the rolled-back data doesn't reappear.
-	tables := map[string]bool{"test": true}
-	f2, err := newFreezer(dir, "", false, 2049, tables)
-	if err != nil {
-		t.Fatalf("can't reopen freezer after failed ModifyAncients: %v", err)
-	}
-	defer f2.Close()
-	checkAncientCount(t, f2, "test", 0)
-}
-
-// This test runs ModifyAncients and Ancient concurrently with each other.
-func TestFreezerConcurrentModifyRetrieve(t *testing.T) {
-	t.Parallel()
-
-	f, dir := newFreezerForTesting(t, freezerTestTableDef)
-	defer os.RemoveAll(dir)
-	defer f.Close()
-
-	var (
-		numReaders     = 5
-		writeBatchSize = uint64(50)
-		written        = make(chan uint64, numReaders*6)
-		wg             sync.WaitGroup
-	)
-	wg.Add(numReaders + 1)
-
-	// Launch the writer. It appends 10000 items in batches.
-	go func() {
-		defer wg.Done()
-		defer close(written)
-		for item := uint64(0); item < 10000; item += writeBatchSize {
-			_, err := f.ModifyAncients(func(op ethdb.AncientWriteOp) error {
-				for i := uint64(0); i < writeBatchSize; i++ {
-					item := item + i
-					value := getChunk(32, int(item))
-					if err := op.AppendRaw("test", item, value); err != nil {
-						return err
-					}
+func TestFreezer(t *testing.T) {
+	t.Run("AncientStoreSuite", func(t *testing.T) {
+		dbtest.TestAncientStoreSuite(t, func(tables map[string]bool) (store ethdb.AncientStore, closeAndCleanup func()) {
+			f, dir := newFreezerForTesting(t, tables)
+			return f, func() {
+				if err := f.Close(); err != nil {
+					t.Errorf("failed to close freezer: %v", err)
 				}
-				return nil
-			})
-			if err != nil {
-				panic(err)
-			}
-			for i := 0; i < numReaders; i++ {
-				written <- item + writeBatchSize
-			}
-		}
-	}()
-
-	// Launch the readers. They read random items from the freezer up to the
-	// current frozen item count.
-	for i := 0; i < numReaders; i++ {
-		go func() {
-			defer wg.Done()
-			for frozen := range written {
-				for rc := 0; rc < 80; rc++ {
-					num := uint64(rand.Intn(int(frozen)))
-					value, err := f.Ancient("test", num)
-					if err != nil {
-						panic(fmt.Errorf("error reading %d (frozen %d): %v", num, frozen, err))
-					}
-					if !bytes.Equal(value, getChunk(32, int(num))) {
-						panic(fmt.Errorf("wrong value at %d", num))
-					}
+				if err := os.RemoveAll(dir); err != nil {
+					t.Errorf("failed to cleanup after freezer close: %v", err)
 				}
 			}
-		}()
-	}
-
-	wg.Wait()
-}
-
-// This test runs ModifyAncients and TruncateHead concurrently with each other.
-func TestFreezerConcurrentModifyTruncate(t *testing.T) {
-	f, dir := newFreezerForTesting(t, freezerTestTableDef)
-	defer os.RemoveAll(dir)
-	defer f.Close()
-
-	var item = make([]byte, 256)
-
-	for i := 0; i < 1000; i++ {
-		// First reset and write 100 items.
-		if err := f.TruncateHead(0); err != nil {
-			t.Fatal("truncate failed:", err)
-		}
-		_, err := f.ModifyAncients(func(op ethdb.AncientWriteOp) error {
-			for i := uint64(0); i < 100; i++ {
-				if err := op.AppendRaw("test", i, item); err != nil {
-					return err
-				}
-			}
-			return nil
 		})
-		if err != nil {
-			t.Fatal("modify failed:", err)
-		}
-		checkAncientCount(t, f, "test", 100)
-
-		// Now append 100 more items and truncate concurrently.
-		var (
-			wg          sync.WaitGroup
-			truncateErr error
-			modifyErr   error
-		)
-		wg.Add(3)
-		go func() {
-			_, modifyErr = f.ModifyAncients(func(op ethdb.AncientWriteOp) error {
-				for i := uint64(100); i < 200; i++ {
-					if err := op.AppendRaw("test", i, item); err != nil {
-						return err
-					}
-				}
-				return nil
-			})
-			wg.Done()
-		}()
-		go func() {
-			truncateErr = f.TruncateHead(10)
-			wg.Done()
-		}()
-		go func() {
-			f.AncientSize("test")
-			wg.Done()
-		}()
-		wg.Wait()
-
-		// Now check the outcome. If the truncate operation went through first, the append
-		// fails, otherwise it succeeds. In either case, the freezer should be positioned
-		// at 10 after both operations are done.
-		if truncateErr != nil {
-			t.Fatal("concurrent truncate failed:", err)
-		}
-		if !(errors.Is(modifyErr, nil) || errors.Is(modifyErr, errOutOrderInsertion)) {
-			t.Fatal("wrong error from concurrent modify:", modifyErr)
-		}
-		checkAncientCount(t, f, "test", 10)
-	}
+	})
 }
 
 func TestFreezerReadonlyValidate(t *testing.T) {
@@ -305,35 +94,4 @@ func newFreezerForTesting(t *testing.T, tables map[string]bool) (*freezer, strin
 		t.Fatal("can't open freezer", err)
 	}
 	return f, dir
-}
-
-// checkAncientCount verifies that the freezer contains n items.
-func checkAncientCount(t *testing.T, f *freezer, kind string, n uint64) {
-	t.Helper()
-
-	if frozen, _ := f.Ancients(); frozen != n {
-		t.Fatalf("Ancients() returned %d, want %d", frozen, n)
-	}
-
-	// Check at index n-1.
-	if n > 0 {
-		index := n - 1
-		if ok, _ := f.HasAncient(kind, index); !ok {
-			t.Errorf("HasAncient(%q, %d) returned false unexpectedly", kind, index)
-		}
-		if _, err := f.Ancient(kind, index); err != nil {
-			t.Errorf("Ancient(%q, %d) returned unexpected error %q", kind, index, err)
-		}
-	}
-
-	// Check at index n.
-	index := n
-	if ok, _ := f.HasAncient(kind, index); ok {
-		t.Errorf("HasAncient(%q, %d) returned true unexpectedly", kind, index)
-	}
-	if _, err := f.Ancient(kind, index); err == nil {
-		t.Errorf("Ancient(%q, %d) didn't return expected error", kind, index)
-	} else if err != errOutOfBounds {
-		t.Errorf("Ancient(%q, %d) returned unexpected error %q", kind, index, err)
-	}
 }

--- a/core/rawdb/table.go
+++ b/core/rawdb/table.go
@@ -50,12 +50,6 @@ func (t *table) Get(key []byte) ([]byte, error) {
 	return t.db.Get(append([]byte(t.prefix), key...))
 }
 
-// HasAncient is a noop passthrough that just forwards the request to the underlying
-// database.
-func (t *table) HasAncient(kind string, number uint64) (bool, error) {
-	return t.db.HasAncient(kind, number)
-}
-
 // Ancient is a noop passthrough that just forwards the request to the underlying
 // database.
 func (t *table) Ancient(kind string, number uint64) ([]byte, error) {

--- a/ethdb/database.go
+++ b/ethdb/database.go
@@ -22,12 +22,19 @@ import (
 	"io"
 )
 
+var (
+	// ErrKVNotFound is returned if a key is requested that is not found in
+	// the KeyValueStore.
+	ErrKVNotFound = errors.New("not found")
+)
+
 // KeyValueReader wraps the Has and Get method of a backing data store.
 type KeyValueReader interface {
 	// Has retrieves if a key is present in the key-value data store.
 	Has(key []byte) (bool, error)
 
 	// Get retrieves the given key if it's present in the key-value data store.
+	// Returns ErrKVNotFound if the key is not found.
 	Get(key []byte) ([]byte, error)
 }
 
@@ -37,6 +44,7 @@ type KeyValueWriter interface {
 	Put(key []byte, value []byte) error
 
 	// Delete removes the key from the key-value data store.
+	// If the key doesn't exist, this method returns no error.
 	Delete(key []byte) error
 }
 

--- a/ethdb/database.go
+++ b/ethdb/database.go
@@ -95,11 +95,6 @@ var (
 
 // AncientReader contains the methods required to read from immutable ancient data.
 type AncientReader interface {
-	// HasAncient returns an indicator whether the specified data exists in the
-	// ancient store.
-	// Returns ErrAncientUnknownKind if the kind is unknown.
-	HasAncient(kind string, number uint64) (bool, error)
-
 	// Ancient retrieves an ancient binary blob from the append-only immutable files.
 	// Returns ErrAncientUnknownKind if the kind is unknown.
 	Ancient(kind string, number uint64) ([]byte, error)

--- a/ethdb/database.go
+++ b/ethdb/database.go
@@ -23,9 +23,8 @@ import (
 )
 
 var (
-	// ErrKVNotFound is returned if a key is requested that is not found in
-	// the KeyValueStore.
-	ErrKVNotFound = errors.New("not found")
+	// ErrNotFound is returned if a key is requested that is not found.
+	ErrNotFound = errors.New("not found")
 )
 
 // KeyValueReader wraps the Has and Get method of a backing data store.
@@ -34,7 +33,7 @@ type KeyValueReader interface {
 	Has(key []byte) (bool, error)
 
 	// Get retrieves the given key if it's present in the key-value data store.
-	// Returns ErrKVNotFound if the key is not found.
+	// Returns ErrNotFound if the key is not found.
 	Get(key []byte) ([]byte, error)
 }
 

--- a/ethdb/dbtest/testsuite.go
+++ b/ethdb/dbtest/testsuite.go
@@ -620,9 +620,6 @@ func checkAncientCount(t *testing.T, store ethdb.AncientStore, kind string, n ui
 	// Check at index n-1.
 	if n > 0 {
 		index := n - 1
-		if ok, _ := store.HasAncient(kind, index); !ok {
-			t.Errorf("HasAncient(%q, %d) returned false unexpectedly", kind, index)
-		}
 		if _, err := store.Ancient(kind, index); err != nil {
 			t.Errorf("Ancient(%q, %d) returned unexpected error %q", kind, index, err)
 		}
@@ -630,9 +627,6 @@ func checkAncientCount(t *testing.T, store ethdb.AncientStore, kind string, n ui
 
 	// Check at index n.
 	index := n
-	if ok, _ := store.HasAncient(kind, index); ok {
-		t.Errorf("HasAncient(%q, %d) returned true unexpectedly", kind, index)
-	}
 	if _, err := store.Ancient(kind, index); err == nil {
 		t.Errorf("Ancient(%q, %d) didn't return expected error", kind, index)
 	} else if err != ethdb.ErrAncientOutOfBounds {

--- a/ethdb/dbtest/testsuite.go
+++ b/ethdb/dbtest/testsuite.go
@@ -216,6 +216,10 @@ func TestKeyValueStoreSuite(t *testing.T, New func() ethdb.KeyValueStore) {
 			t.Errorf("wrong value: %t", got)
 		}
 
+		if _, err := db.Get(key); err != ethdb.ErrKVNotFound {
+			t.Errorf("expected ethdb.ErrKVNotFound")
+		}
+
 		value := []byte("hello world")
 		if err := db.Put(key, value); err != nil {
 			t.Error(err)

--- a/ethdb/dbtest/testsuite.go
+++ b/ethdb/dbtest/testsuite.go
@@ -18,16 +18,23 @@ package dbtest
 
 import (
 	"bytes"
+	"errors"
+	"fmt"
+	"math/big"
+	"math/rand"
 	"reflect"
 	"sort"
+	"sync"
 	"testing"
 
 	"github.com/ethereum/go-ethereum/ethdb"
+	"github.com/ethereum/go-ethereum/rlp"
+	"github.com/stretchr/testify/require"
 )
 
-// TestDatabaseSuite runs a suite of tests against a KeyValueStore database
+// TestKeyValueStoreSuite runs a suite of tests against a KeyValueStore database
 // implementation.
-func TestDatabaseSuite(t *testing.T, New func() ethdb.KeyValueStore) {
+func TestKeyValueStoreSuite(t *testing.T, New func() ethdb.KeyValueStore) {
 	t.Run("Iterator", func(t *testing.T) {
 		tests := []struct {
 			content map[string]string
@@ -385,4 +392,255 @@ func iterateKeys(it ethdb.Iterator) []string {
 	sort.Strings(keys)
 	it.Release()
 	return keys
+}
+
+type AncientCreator func(tables map[string]bool) (store ethdb.AncientStore, closeAndCleanup func())
+
+func TestAncientStoreSuite(t *testing.T, New AncientCreator) {
+	const testKind = "test"
+	var tableDef = map[string]bool{testKind: true}
+
+	t.Run("Modify", func(t *testing.T) {
+		t.Parallel()
+
+		// Create test data.
+		var valuesRaw [][]byte
+		var valuesRLP []*big.Int
+		for x := 0; x < 100; x++ {
+			v := getChunk(256, x)
+			valuesRaw = append(valuesRaw, v)
+			iv := big.NewInt(int64(x))
+			iv = iv.Exp(iv, iv, nil)
+			valuesRLP = append(valuesRLP, iv)
+		}
+
+		tables := map[string]bool{"raw": true, "rlp": false}
+
+		store, closeAndCleanup := New(tables)
+		defer closeAndCleanup()
+
+		// Commit test data.
+		_, err := store.ModifyAncients(func(op ethdb.AncientWriteOp) error {
+			for i := range valuesRaw {
+				if err := op.AppendRaw("raw", uint64(i), valuesRaw[i]); err != nil {
+					return err
+				}
+				if err := op.Append("rlp", uint64(i), valuesRLP[i]); err != nil {
+					return err
+				}
+			}
+			return nil
+		})
+		if err != nil {
+			t.Fatal("ModifyAncients failed:", err)
+		}
+
+		// Read back test data.
+		checkAncientCount(t, store, "raw", uint64(len(valuesRaw)))
+		checkAncientCount(t, store, "rlp", uint64(len(valuesRLP)))
+		for i := range valuesRaw {
+			v, _ := store.Ancient("raw", uint64(i))
+			if !bytes.Equal(v, valuesRaw[i]) {
+				t.Fatalf("wrong raw value at %d: %x", i, v)
+			}
+			ivEnc, _ := store.Ancient("rlp", uint64(i))
+			want, _ := rlp.EncodeToBytes(valuesRLP[i])
+			if !bytes.Equal(ivEnc, want) {
+				t.Fatalf("wrong RLP value at %d: %x", i, ivEnc)
+			}
+		}
+	})
+
+	// This checks that ModifyAncients rolls back updates
+	// when the function passed to it returns an error.
+	t.Run("ModifyRollback", func(t *testing.T) {
+		t.Parallel()
+
+		store, closeAndCleanup := New(tableDef)
+
+		theError := errors.New("oops")
+		_, err := store.ModifyAncients(func(op ethdb.AncientWriteOp) error {
+			require.NoError(t, op.AppendRaw(testKind, 0, make([]byte, 2048)))
+			require.NoError(t, op.AppendRaw(testKind, 1, make([]byte, 2048)))
+			require.NoError(t, op.AppendRaw(testKind, 2, make([]byte, 2048)))
+			return theError
+		})
+		if err != theError {
+			t.Errorf("ModifyAncients returned wrong error %q", err)
+		}
+		checkAncientCount(t, store, testKind, 0)
+		closeAndCleanup()
+
+		// Reopen and check that the rolled-back data doesn't reappear.
+		store, closeAndCleanup = New(tableDef)
+
+		checkAncientCount(t, store, testKind, 0)
+		closeAndCleanup()
+	})
+
+	t.Run("ConcurrentModifyRetrieve", func(t *testing.T) {
+		t.Parallel()
+
+		store, closeAndCleanup := New(tableDef)
+		defer closeAndCleanup()
+
+		var (
+			numReaders     = 5
+			writeBatchSize = uint64(50)
+			written        = make(chan uint64, numReaders*6)
+			wg             sync.WaitGroup
+		)
+		wg.Add(numReaders + 1)
+
+		// Launch the writer. It appends 10000 items in batches.
+		go func() {
+			defer wg.Done()
+			defer close(written)
+			for item := uint64(0); item < 10000; item += writeBatchSize {
+				_, err := store.ModifyAncients(func(op ethdb.AncientWriteOp) error {
+					for i := uint64(0); i < writeBatchSize; i++ {
+						item := item + i
+						value := getChunk(32, int(item))
+						if err := op.AppendRaw(testKind, item, value); err != nil {
+							return err
+						}
+					}
+					return nil
+				})
+				if err != nil {
+					panic(err)
+				}
+				for i := 0; i < numReaders; i++ {
+					written <- item + writeBatchSize
+				}
+			}
+		}()
+
+		// Launch the readers. They read random items from the AncientStore up to the
+		// current frozen item count.
+		for i := 0; i < numReaders; i++ {
+			go func() {
+				defer wg.Done()
+				for frozen := range written {
+					for rc := 0; rc < 80; rc++ {
+						num := uint64(rand.Intn(int(frozen)))
+						value, err := store.Ancient(testKind, num)
+						if err != nil {
+							panic(fmt.Errorf("error reading %d (frozen %d): %v", num, frozen, err))
+						}
+						if !bytes.Equal(value, getChunk(32, int(num))) {
+							panic(fmt.Errorf("wrong value at %d", num))
+						}
+					}
+				}
+			}()
+		}
+
+		wg.Wait()
+	})
+
+	t.Run("ConcurrentModifyTruncate", func(t *testing.T) {
+		store, closeAndCleanup := New(tableDef)
+		defer closeAndCleanup()
+
+		var item = make([]byte, 256)
+
+		for i := 0; i < 1000; i++ {
+			// First reset and write 100 items.
+			if err := store.TruncateHead(0); err != nil {
+				t.Fatal("truncate failed:", err)
+			}
+			_, err := store.ModifyAncients(func(op ethdb.AncientWriteOp) error {
+				for i := uint64(0); i < 100; i++ {
+					if err := op.AppendRaw("test", i, item); err != nil {
+						return err
+					}
+				}
+				return nil
+			})
+			if err != nil {
+				t.Fatal("modify failed:", err)
+			}
+			checkAncientCount(t, store, "test", 100)
+
+			// Now append 100 more items and truncate concurrently.
+			var (
+				wg          sync.WaitGroup
+				truncateErr error
+				modifyErr   error
+			)
+			wg.Add(3)
+			go func() {
+				_, modifyErr = store.ModifyAncients(func(op ethdb.AncientWriteOp) error {
+					for i := uint64(100); i < 200; i++ {
+						if err := op.AppendRaw("test", i, item); err != nil {
+							return err
+						}
+					}
+					return nil
+				})
+				wg.Done()
+			}()
+			go func() {
+				truncateErr = store.TruncateHead(10)
+				wg.Done()
+			}()
+			go func() {
+				store.AncientSize("test")
+				wg.Done()
+			}()
+			wg.Wait()
+
+			// Now check the outcome. If the truncate operation went through first, the append
+			// fails, otherwise it succeeds. In either case, the freezer should be positioned
+			// at 10 after both operations are done.
+			if truncateErr != nil {
+				t.Fatal("concurrent truncate failed:", err)
+			}
+			if !(errors.Is(modifyErr, nil) || errors.Is(modifyErr, ethdb.ErrAncientOutOrderInsertion)) {
+				t.Fatal("wrong error from concurrent modify:", modifyErr)
+			}
+			checkAncientCount(t, store, "test", 10)
+		}
+	})
+}
+
+// checkAncientCount verifies that the AncientStore contains n items.
+func checkAncientCount(t *testing.T, store ethdb.AncientStore, kind string, n uint64) {
+	t.Helper()
+
+	if frozen, _ := store.Ancients(); frozen != n {
+		t.Fatalf("Ancients() returned %d, want %d", frozen, n)
+	}
+
+	// Check at index n-1.
+	if n > 0 {
+		index := n - 1
+		if ok, _ := store.HasAncient(kind, index); !ok {
+			t.Errorf("HasAncient(%q, %d) returned false unexpectedly", kind, index)
+		}
+		if _, err := store.Ancient(kind, index); err != nil {
+			t.Errorf("Ancient(%q, %d) returned unexpected error %q", kind, index, err)
+		}
+	}
+
+	// Check at index n.
+	index := n
+	if ok, _ := store.HasAncient(kind, index); ok {
+		t.Errorf("HasAncient(%q, %d) returned true unexpectedly", kind, index)
+	}
+	if _, err := store.Ancient(kind, index); err == nil {
+		t.Errorf("Ancient(%q, %d) didn't return expected error", kind, index)
+	} else if err != ethdb.ErrAncientOutOfBounds {
+		t.Errorf("Ancient(%q, %d) returned unexpected error %q", kind, index, err)
+	}
+}
+
+// Gets a chunk of data, filled with 'b'
+func getChunk(size int, b int) []byte {
+	data := make([]byte, size)
+	for i := range data {
+		data[i] = byte(b)
+	}
+	return data
 }

--- a/ethdb/dbtest/testsuite.go
+++ b/ethdb/dbtest/testsuite.go
@@ -216,8 +216,8 @@ func TestKeyValueStoreSuite(t *testing.T, New func() ethdb.KeyValueStore) {
 			t.Errorf("wrong value: %t", got)
 		}
 
-		if _, err := db.Get(key); err != ethdb.ErrKVNotFound {
-			t.Errorf("expected ethdb.ErrKVNotFound")
+		if _, err := db.Get(key); err != ethdb.ErrNotFound {
+			t.Errorf("expected ethdb.ErrNotFound")
 		}
 
 		value := []byte("hello world")
@@ -375,7 +375,7 @@ func TestKeyValueStoreSuite(t *testing.T, New func() ethdb.KeyValueStore) {
 		}
 		for k := range insert {
 			got, err := snapshot.Get([]byte(k))
-			if err != ethdb.ErrSnapshotNotFound || len(got) != 0 {
+			if err != ethdb.ErrNotFound || len(got) != 0 {
 				t.Fatal("Unexpected value")
 			}
 		}

--- a/ethdb/dbtest/testsuite.go
+++ b/ethdb/dbtest/testsuite.go
@@ -375,7 +375,7 @@ func TestKeyValueStoreSuite(t *testing.T, New func() ethdb.KeyValueStore) {
 		}
 		for k := range insert {
 			got, err := snapshot.Get([]byte(k))
-			if err == nil || len(got) != 0 {
+			if err != ethdb.ErrSnapshotNotFound || len(got) != 0 {
 				t.Fatal("Unexpected value")
 			}
 		}

--- a/ethdb/leveldb/leveldb.go
+++ b/ethdb/leveldb/leveldb.go
@@ -552,13 +552,24 @@ type snapshot struct {
 // Has retrieves if a key is present in the snapshot backing by a key-value
 // data store.
 func (snap *snapshot) Has(key []byte) (bool, error) {
-	return snap.db.Has(key, nil)
+	has, err := snap.db.Has(key, nil)
+	if err == leveldb.ErrSnapshotReleased {
+		return false, ethdb.ErrSnapshotReleased
+	}
+	return has, err
 }
 
 // Get retrieves the given key if it's present in the snapshot backing by
 // key-value data store.
 func (snap *snapshot) Get(key []byte) ([]byte, error) {
-	return snap.db.Get(key, nil)
+	val, err := snap.db.Get(key, nil)
+	if err == leveldb.ErrSnapshotReleased {
+		return nil, ethdb.ErrSnapshotReleased
+	}
+	if err == leveldb.ErrNotFound {
+		return nil, ethdb.ErrSnapshotNotFound
+	}
+	return val, err
 }
 
 // Release releases associated resources. Release should always succeed and can

--- a/ethdb/leveldb/leveldb.go
+++ b/ethdb/leveldb/leveldb.go
@@ -188,6 +188,9 @@ func (db *Database) Has(key []byte) (bool, error) {
 // Get retrieves the given key if it's present in the key-value store.
 func (db *Database) Get(key []byte) ([]byte, error) {
 	dat, err := db.db.Get(key, nil)
+	if err == leveldb.ErrNotFound {
+		return nil, ethdb.ErrKVNotFound
+	}
 	if err != nil {
 		return nil, err
 	}

--- a/ethdb/leveldb/leveldb.go
+++ b/ethdb/leveldb/leveldb.go
@@ -189,7 +189,7 @@ func (db *Database) Has(key []byte) (bool, error) {
 func (db *Database) Get(key []byte) ([]byte, error) {
 	dat, err := db.db.Get(key, nil)
 	if err == leveldb.ErrNotFound {
-		return nil, ethdb.ErrKVNotFound
+		return nil, ethdb.ErrNotFound
 	}
 	if err != nil {
 		return nil, err
@@ -567,7 +567,7 @@ func (snap *snapshot) Get(key []byte) ([]byte, error) {
 		return nil, ethdb.ErrSnapshotReleased
 	}
 	if err == leveldb.ErrNotFound {
-		return nil, ethdb.ErrSnapshotNotFound
+		return nil, ethdb.ErrNotFound
 	}
 	return val, err
 }

--- a/ethdb/leveldb/leveldb_test.go
+++ b/ethdb/leveldb/leveldb_test.go
@@ -27,7 +27,7 @@ import (
 
 func TestLevelDB(t *testing.T) {
 	t.Run("DatabaseSuite", func(t *testing.T) {
-		dbtest.TestDatabaseSuite(t, func() ethdb.KeyValueStore {
+		dbtest.TestKeyValueStoreSuite(t, func() ethdb.KeyValueStore {
 			db, err := leveldb.Open(storage.NewMemStorage(), nil)
 			if err != nil {
 				t.Fatal(err)

--- a/ethdb/memorydb/memorydb.go
+++ b/ethdb/memorydb/memorydb.go
@@ -90,7 +90,7 @@ func (db *Database) Get(key []byte) ([]byte, error) {
 	if entry, ok := db.db[string(key)]; ok {
 		return common.CopyBytes(entry), nil
 	}
-	return nil, ethdb.ErrKVNotFound
+	return nil, ethdb.ErrNotFound
 }
 
 // Put inserts the given value into the key-value store.
@@ -368,7 +368,7 @@ func (snap *snapshot) Get(key []byte) ([]byte, error) {
 	if entry, ok := snap.db[string(key)]; ok {
 		return common.CopyBytes(entry), nil
 	}
-	return nil, ethdb.ErrSnapshotNotFound
+	return nil, ethdb.ErrNotFound
 }
 
 // Release releases associated resources. Release should always succeed and can

--- a/ethdb/memorydb/memorydb_test.go
+++ b/ethdb/memorydb/memorydb_test.go
@@ -25,7 +25,7 @@ import (
 
 func TestMemoryDB(t *testing.T) {
 	t.Run("DatabaseSuite", func(t *testing.T) {
-		dbtest.TestDatabaseSuite(t, func() ethdb.KeyValueStore {
+		dbtest.TestKeyValueStoreSuite(t, func() ethdb.KeyValueStore {
 			return New()
 		})
 	})

--- a/ethdb/snapshot.go
+++ b/ethdb/snapshot.go
@@ -16,13 +16,28 @@
 
 package ethdb
 
+import "errors"
+
+var (
+	// ErrSnapshotNotFound is returned if a key is requested that is not found in
+	// a snapshot.
+	ErrSnapshotNotFound = errors.New("not found")
+
+	// ErrSnapshotReleased is returned if callers want to retrieve data from a
+	// released snapshot.
+	ErrSnapshotReleased = errors.New("snapshot released")
+)
+
 type Snapshot interface {
 	// Has retrieves if a key is present in the snapshot backing by a key-value
 	// data store.
+	// Returns ErrSnapshotReleased if the Snapshot has already been released.
 	Has(key []byte) (bool, error)
 
 	// Get retrieves the given key if it's present in the snapshot backing by
 	// key-value data store.
+	// Returns ErrSnapshotReleased if the Snapshot has already been released.
+	// Returns ErrSnapshotNotFound if the key is not found in the Snapshot.
 	Get(key []byte) ([]byte, error)
 
 	// Release releases associated resources. Release should always succeed and can

--- a/ethdb/snapshot.go
+++ b/ethdb/snapshot.go
@@ -19,10 +19,6 @@ package ethdb
 import "errors"
 
 var (
-	// ErrSnapshotNotFound is returned if a key is requested that is not found in
-	// a snapshot.
-	ErrSnapshotNotFound = errors.New("not found")
-
 	// ErrSnapshotReleased is returned if callers want to retrieve data from a
 	// released snapshot.
 	ErrSnapshotReleased = errors.New("snapshot released")
@@ -37,7 +33,7 @@ type Snapshot interface {
 	// Get retrieves the given key if it's present in the snapshot backing by
 	// key-value data store.
 	// Returns ErrSnapshotReleased if the Snapshot has already been released.
-	// Returns ErrSnapshotNotFound if the key is not found in the Snapshot.
+	// Returns ErrNotFound if the key is not found in the Snapshot.
 	Get(key []byte) ([]byte, error)
 
 	// Release releases associated resources. Release should always succeed and can


### PR DESCRIPTION
Refactor the freezer test suite into one that can be used for other AncientStore implementation. Ultimately that simplify greatly having an alternative implementation.

To achieve that, a subset of previously private errors have been promoted as part of the AncientStore interface.

Untangle some code in the process: I believe freezer can now be extracted from rawdb if that's
deemed beneficial.

CC @holiman, I believe you are the one to bug about that.