### PR TITLE
core/state/snapshot: avoid thrashing during block import

### DIFF
--- a/core/state/snapshot/journal.go
+++ b/core/state/snapshot/journal.go
@@ -187,6 +187,7 @@ func loadSnapshot(diskdb ethdb.KeyValueStore, triedb *trie.Database, cache int, 
 		go base.generate(&generatorStats{
 			origin:   origin,
 			start:    time.Now(),
+			lastAbort: time.Now(),
 			accounts: generator.Accounts,
 			slots:    generator.Slots,
 			storage:  common.StorageSize(generator.Storage),


### PR DESCRIPTION
The code in this PR is written by @karalabe  (I just moved a chunk of code a bit north)
When we're generating the snapshot, we're also processing blocks. In case we're importing multiple blocks (catching up), this adds a penalty, since there are background processes which are reading a __lot__ from disk, all the while we're trying to catch up. 

This PR instead makes it so that if the previous generation-effort ended within 450ms, then it won't start anew. 