### PR TITLE
cmd/geth: support string (non-hex) keys in db get/put/delete

### DIFF
--- a/cmd/geth/dbcmd.go
+++ b/cmd/geth/dbcmd.go
@@ -344,7 +344,7 @@ func dbGet(ctx *cli.Context) error {
 
 	data, err := db.Get(key)
 	if err != nil {
-		log.Info("Get operation failed", "error", err)
+		log.Info("Get operation failed", "key", fmt.Sprintf("0x%#x", key), "error", err)
 		return err
 	}
 	fmt.Printf("key %#x: %#x\n", key, data)
@@ -372,7 +372,7 @@ func dbDelete(ctx *cli.Context) error {
 		fmt.Printf("Previous value: %#x\n", data)
 	}
 	if err = db.Delete(key); err != nil {
-		log.Info("Delete operation returned an error", "error", err)
+		log.Info("Delete operation returned an error", "key", fmt.Sprintf("0x%#x", key), "error", err)
 		return err
 	}
 	return nil
@@ -506,7 +506,7 @@ func freezerInspect(ctx *cli.Context) error {
 func parseHexOrString(str string) ([]byte, error) {
 	b, err := hexutil.Decode(str)
 	if errors.Is(err, hexutil.ErrMissingPrefix) {
-		return []byte(b), nil
+		return []byte(str), nil
 	}
 	return b, err
 }


### PR DESCRIPTION
Hi,

This flag suppose to bring a little more convenience, when observing internal state,
via constant keys like `SnapshotSyncStatus`, `SnapshotRecovery` etc.

Now it's necessary to convert these strings to hex and to add a prefix `0x` which might be inconvenient.
And not intuitive at a first glance.
