### PR TITLE
cmd/rlpdump: add support for text to rlp

### DIFF
--- a/cmd/rlpdump/rlpdump_test.go
+++ b/cmd/rlpdump/rlpdump_test.go
@@ -1,11 +1,38 @@
 package main
 
 import (
+	"bytes"
+	"fmt"
 	"strings"
 	"testing"
 
+	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 )
+
+func TestRoundtrip(t *testing.T) {
+	for i, want := range []string{
+		"0xf880806482520894d0d0d0d0d0d0d0d0d0d0d0d0d0d0d0d0d0d0d0d0a1010000000000000000000000000000000000000000000000000000000000000001801ba0c16787a8e25e941d67691954642876c08f00996163ae7dfadbbfd6cd436f549da06180e5626cae31590f40641fe8f63734316c4bfeb4cdfab6714198c1044d2e28",
+		"0xd5c0d3cb84746573742a2a808213378667617a6f6e6b",
+		"0xc780c0c1c0825208",
+	} {
+		var out strings.Builder
+		err := rlpToText(bytes.NewReader(common.FromHex(want)), &out)
+		if err != nil {
+			t.Fatal(err)
+		}
+		text := out.String()
+		rlpBytes, err := textToRlp(strings.NewReader(text))
+		if err != nil {
+			t.Errorf("test %d: error %v", i, err)
+			continue
+		}
+		have := fmt.Sprintf("0x%x", rlpBytes)
+		if have != want {
+			t.Errorf("test %d: have\n%v\nwant:\n%v\n", i, have, want)
+		}
+	}
+}
 
 func TestTextToRlp(t *testing.T) {
 	type tc struct {
@@ -16,50 +43,13 @@ func TestTextToRlp(t *testing.T) {
 		{
 			text: `[
   "",
-  "d",
-  5208,
-  d0d0d0d0d0d0d0d0d0d0d0d0d0d0d0d0d0d0d0d0,
-  010000000000000000000000000000000000000000000000000000000000000001,
-  "",
-  1b,
-  c16787a8e25e941d67691954642876c08f00996163ae7dfadbbfd6cd436f549d,
-  6180e5626cae31590f40641fe8f63734316c4bfeb4cdfab6714198c1044d2e28,
-]`,
-			want: "0xf880806482520894d0d0d0d0d0d0d0d0d0d0d0d0d0d0d0d0d0d0d0d0a1010000000000000000000000000000000000000000000000000000000000000001801ba0c16787a8e25e941d67691954642876c08f00996163ae7dfadbbfd6cd436f549da06180e5626cae31590f40641fe8f63734316c4bfeb4cdfab6714198c1044d2e28",
-		},
-		{ // Same as above but no ascii
-			text: `[
-  "",
-  64,
-  5208,
-  d0d0d0d0d0d0d0d0d0d0d0d0d0d0d0d0d0d0d0d0,
-  010000000000000000000000000000000000000000000000000000000000000001,
-  "",
-  1b,
-  c16787a8e25e941d67691954642876c08f00996163ae7dfadbbfd6cd436f549d,
-  6180e5626cae31590f40641fe8f63734316c4bfeb4cdfab6714198c1044d2e28,
-]
-`,
-			want: "0xf880806482520894d0d0d0d0d0d0d0d0d0d0d0d0d0d0d0d0d0d0d0d0a1010000000000000000000000000000000000000000000000000000000000000001801ba0c16787a8e25e941d67691954642876c08f00996163ae7dfadbbfd6cd436f549da06180e5626cae31590f40641fe8f63734316c4bfeb4cdfab6714198c1044d2e28",
-		},
-		{
-			text: `
-[
   [],
-  [
-    [
-      "test",
-      "*",
-      "*",
-      "",
-      1337,
+[     
+ [],
     ],
-    "gazonk",
-  ],
-]
-
-`,
-			want: "0xd5c0d3cb84746573742a2a808213378667617a6f6e6b",
+  5208,
+]`,
+			want: "0xc780c0c1c0825208",
 		},
 	}
 	for i, tc := range cases {


### PR DESCRIPTION
This PR adds support for the `rlpdump` tool to go from text format to RLP. This is often a bit cumbersome: modifying RLP means that the lengths needs to be recalculated. Right now, I often create some golang testcase which defines some struct and then call rlp.EncodeToBytes on it, which is a bit PITA. 

Using a moderately complext struct: 
```
[user@work rlpdump]$ ./rlpdump -hex 0xd8c1c0d5d4cccb84746573742a2a808213378667617a6f6e6b 
[
  [
    [],
  ],
  [
    [
      [
        [
          "test",
          "*",
          "*",
          "",
          1337,
        ],
      ],
      "gazonk",
    ],
  ],
]
```
Examples: 
```
[user@work rlpdump]$ ./rlpdump -hex 0xd8c1c0d5d4cccb84746573742a2a808213378667617a6f6e6b | ./rlpdump -reverse 
0xd8c1c0d5d4cccb84746573742a2a808213378667617a6f6e6b
[user@work rlpdump]$ ./rlpdump -hex 0xd8c1c0d5d4cccb84746573742a2a808213378667617a6f6e6b > foo.test && ./rlpdump -reverse foo.test
0xd8c1c0d5d4cccb84746573742a2a808213378667617a6f6e6b

```

It doesn't handle 'bad input' well, and can panic, but that's not really important for this tool, IMO. 