### PR TITLE
internal/ethapi: fix recover sender of pending transaction

### DIFF
--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -1334,10 +1334,12 @@ func newRPCTransaction(tx *types.Transaction, blockHash common.Hash, blockNumber
 // newRPCPendingTransaction returns a pending transaction that will serialize to the RPC representation
 func newRPCPendingTransaction(tx *types.Transaction, current *types.Header, config *params.ChainConfig) *RPCTransaction {
 	var baseFee *big.Int
+	blockNumber := uint64(0)
 	if current != nil {
 		baseFee = misc.CalcBaseFee(config, current)
+		blockNumber = current.Number.Uint64()
 	}
-	return newRPCTransaction(tx, common.Hash{}, current.Number.Uint64(), 0, baseFee, config)
+	return newRPCTransaction(tx, common.Hash{}, blockNumber, 0, baseFee, config)
 }
 
 // newRPCTransactionFromBlockIndex returns a transaction that will serialize to the RPC representation.


### PR DESCRIPTION
Fixes an issue where during sender recovery of pending transactions we always used 0 as the blocknumber, resulting in MakeSigner creating a homestead signer which is not able to recover new transaction types

fixes https://github.com/ethereum/go-ethereum/issues/23762
and https://github.com/ethereum/go-ethereum/issues/23763
