### PR TITLE
Update abigen documentation

### DIFF
--- a/docs/_dapp/native-bindings.md
+++ b/docs/_dapp/native-bindings.md
@@ -52,7 +52,7 @@ repository checked out correctly, you can build the generator with:
 
 ```
 $ cd $GOPATH/src/github.com/ethereum/go-ethereum
-$ make devtools
+$ go build ./cmd/abigen
 ```
 
 ### Generating the bindings


### PR DESCRIPTION
it looks like `make abigen` has been removed and is included under `make devtools`