### PR TITLE
common/hexutil: Improve Performance of `EncodeBig(...)` 

### DIFF
--- a/common/hexutil/hexutil.go
+++ b/common/hexutil/hexutil.go
@@ -176,13 +176,14 @@ func MustDecodeBig(input string) *big.Int {
 }
 
 // EncodeBig encodes bigint as a hex string with 0x prefix.
-// The sign of the integer is ignored.
 func EncodeBig(bigint *big.Int) string {
-	nbits := bigint.BitLen()
-	if nbits == 0 {
+	if sign := bigint.Sign(); sign == 0 {
 		return "0x0"
+	} else if sign > 0 {
+		return "0x" + bigint.Text(16)
+	} else {
+		return "-0x" + bigint.Text(16)[1:]
 	}
-	return fmt.Sprintf("%#x", bigint)
 }
 
 func has0xPrefix(input string) bool {

--- a/common/hexutil/hexutil_test.go
+++ b/common/hexutil/hexutil_test.go
@@ -201,3 +201,15 @@ func TestDecodeUint64(t *testing.T) {
 		}
 	}
 }
+
+func BenchmarkEncodeBig(b *testing.B) {
+	for _, bench := range encodeBigTests {
+		b.Run(bench.want, func(b *testing.B) {
+			b.ReportAllocs()
+			bigint := bench.input.(*big.Int)
+			for i := 0; i < b.N; i++ {
+				EncodeBig(bigint)
+			}
+		})
+	}
+}


### PR DESCRIPTION
- `fmt.Sprintf(...)` to `big.Int.Text(16)`
- reduced allocs from 6 to 2
- improved speed
- removed comment `// The sign of the integer is ignored.` as the tests state otherwise.

## Benchmark:

```
goos: linux
goarch: amd64
pkg: github.com/ethereum/go-ethereum/common/hexutil
cpu: 11th Gen Intel(R) Core(TM) i7-1185G7 @ 3.00GHz

name                                          old time/op    new time/op    delta
EncodeBig/0x0-8                                 2.35ns ± 6%    2.01ns ± 1%  -14.76%  (p=0.000 n=10+9)
EncodeBig/0x1-8                                  401ns ± 9%      66ns ± 5%  -83.54%  (p=0.000 n=9+10)
EncodeBig/0xff-8                                 404ns ±10%      81ns ± 8%  -79.85%  (p=0.000 n=10+10)
EncodeBig/0x112233445566778899aabbccddeeff-8     548ns ± 8%     206ns ±14%  -62.48%  (p=0.000 n=10+10)
EncodeBig/0x80a7f2c1bcc396c00-8                  513ns ± 8%     163ns ± 9%  -68.16%  (p=0.000 n=10+10)
EncodeBig/-0x80a7f2c1bcc396c00-8                 565ns ±11%     158ns ±12%  -72.07%  (p=0.000 n=10+10)

name                                          old alloc/op   new alloc/op   delta
EncodeBig/0x0-8                                  0.00B          0.00B          ~     (all equal)
EncodeBig/0x1-8                                  40.0B ± 0%      4.0B ± 0%  -90.00%  (p=0.000 n=10+10)
EncodeBig/0xff-8                                 40.0B ± 0%      8.0B ± 0%  -80.00%  (p=0.000 n=10+10)
EncodeBig/0x112233445566778899aabbccddeeff-8     96.0B ± 0%     64.0B ± 0%  -33.33%  (p=0.000 n=10+10)
EncodeBig/0x80a7f2c1bcc396c00-8                  80.0B ± 0%     48.0B ± 0%  -40.00%  (p=0.000 n=10+10)
EncodeBig/-0x80a7f2c1bcc396c00-8                 88.0B ± 0%     48.0B ± 0%  -45.45%  (p=0.000 n=10+10)

name                                          old allocs/op  new allocs/op  delta
EncodeBig/0x0-8                                   0.00           0.00          ~     (all equal)
EncodeBig/0x1-8                                   6.00 ± 0%      2.00 ± 0%  -66.67%  (p=0.000 n=10+10)
EncodeBig/0xff-8                                  6.00 ± 0%      2.00 ± 0%  -66.67%  (p=0.000 n=10+10)
EncodeBig/0x112233445566778899aabbccddeeff-8      6.00 ± 0%      2.00 ± 0%  -66.67%  (p=0.000 n=10+10)
EncodeBig/0x80a7f2c1bcc396c00-8                   6.00 ± 0%      2.00 ± 0%  -66.67%  (p=0.000 n=10+10)
EncodeBig/-0x80a7f2c1bcc396c00-8                  7.00 ± 0%      2.00 ± 0%  -71.43%  (p=0.000 n=10+10)
```