### PR TITLE
core: occasionally reheap the pricedList

### DIFF
--- a/core/tx_pool.go
+++ b/core/tx_pool.go
@@ -395,6 +395,8 @@ func (pool *TxPool) loop() {
 					queuedEvictionMeter.Mark(int64(len(list)))
 				}
 			}
+			// force a reheap of the priced list every now and then.
+			pool.priced.Reheap()
 			pool.mu.Unlock()
 
 		// Handle local transaction journal rotation


### PR DESCRIPTION
The txPricedList maintains a copy of the pointer to the transactions in urgent and floating.
If we remove the transactions from the pool, the txPricedList still maintains a pointer to
the transactions (meaning they can't be garbage collected) until the next Reheap operation.
The Reheap operation is triggered on an incoming new block (changing the basefee). If we
don't receive a new block, the memory is kept indefinitely