### PR TITLE
ethdb: improve batch size calculation

### DIFF
--- a/ethdb/leveldb/leveldb.go
+++ b/ethdb/leveldb/leveldb.go
@@ -455,7 +455,7 @@ type batch struct {
 // Put inserts the given value into the batch for later committing.
 func (b *batch) Put(key, value []byte) error {
 	b.b.Put(key, value)
-	b.size += len(value)
+	b.size += len(key) + len(value)
 	return nil
 }
 

--- a/ethdb/memorydb/memorydb.go
+++ b/ethdb/memorydb/memorydb.go
@@ -204,7 +204,7 @@ type batch struct {
 // Put inserts the given value into the batch for later committing.
 func (b *batch) Put(key, value []byte) error {
 	b.writes = append(b.writes, keyvalue{common.CopyBytes(key), common.CopyBytes(value), false})
-	b.size += len(value)
+	b.size += len(key) + len(value)
 	return nil
 }
 


### PR DESCRIPTION
This PR fixes the batch size calculation a bit. 

In Geth there is a function called `ValueSize` of db batch, the number returned can act as an indicator to prevent accumulate too much data in a single batch. 

However it only counts the value size, instead of counting both key and value size. It's OK in most of cases but may lead to critical issue in some special scenarios, e.g. there are only `Batch.Put(key, nil)` operations queued up in the batch, then they will all be ignored.

So in this PR, key size is also counted. It won't have a big impact to the system, but try to avoid some unexpected error.