### PR TITLE
consensus/ethash: avoid runtime errors due to OOD on mmap writes

### DIFF
--- a/consensus/ethash/mmap_help_linux.go
+++ b/consensus/ethash/mmap_help_linux.go
@@ -14,9 +14,8 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
 
-// Package ethash implements the ethash proof-of-work consensus engine.
-
 //go:build linux
+// +build linux
 
 package ethash
 

--- a/consensus/ethash/mmap_help_linux.go
+++ b/consensus/ethash/mmap_help_linux.go
@@ -1,0 +1,36 @@
+// Copyright 2021 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+// Package ethash implements the ethash proof-of-work consensus engine.
+
+//go:build linux
+
+package ethash
+
+import (
+	"os"
+
+	"golang.org/x/sys/unix"
+)
+
+// ensureSize expands the file to the given size. This is to prevent runtime
+// errors later on, if the underlying file expands beyond the disk capacity,
+// even though it ostensibly is already expanded, but due to being sparse
+// does not actually occupy the full declared size on disk.
+func ensureSize(f *os.File, size int64) error {
+	// Docs: https://www.man7.org/linux/man-pages/man2/fallocate.2.html
+	return unix.Fallocate(int(f.Fd()), 0, 0, size)
+}

--- a/consensus/ethash/mmap_help_other.go
+++ b/consensus/ethash/mmap_help_other.go
@@ -14,9 +14,8 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
 
-// Package ethash implements the ethash proof-of-work consensus engine.
-
 //go:build !linux
+// +build !linux
 
 package ethash
 

--- a/consensus/ethash/mmap_help_other.go
+++ b/consensus/ethash/mmap_help_other.go
@@ -1,0 +1,37 @@
+// Copyright 2021 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+// Package ethash implements the ethash proof-of-work consensus engine.
+
+//go:build !linux
+
+package ethash
+
+import (
+	"os"
+)
+
+// ensureSize expands the file to the given size. This is to prevent runtime
+// errors later on, if the underlying file expands beyond the disk capacity,
+// even though it ostensibly is already expanded, but due to being sparse
+// does not actually occupy the full declared size on disk.
+func ensureSize(f *os.File, size int64) error {
+	// On systems which do not support fallocate, we merely truncate it.
+	// More robust alternatives  would be to
+	// - Use posix_fallocate, or
+	// - explicitly fill the file with zeroes.
+	return f.Truncate(size)
+}


### PR DESCRIPTION
This PR avoids a pretty rare crash. 

Some more info here: https://github.com/edsrzf/mmap-go/issues/12#issuecomment-949649350 . 

When we map a file for generating the DAG, we do a simple truncate to e.g. `1Gb`. This is fine, even if we have nowhere near `1Gb` disk available, as the actual file doesn't take up the full `1Gb`, merely a few bytes. When we start generating into it, however, it eventually crashes with a `unexpected fault address `. 

Examples: 
- https://github.com/ethereum/go-ethereum/issues/21928 
- https://github.com/ethereum/go-ethereum/issues/23453

There are two ways we can fix this, the simplest being to use the `fallocate` linux system call. 
The second way is to convert the internals of ethash; instead of generating into a `[]byte`, we generate into an interface which supports `WriteAt`. Then we can first generate into a file (or into a wrapped memory slice), and later do a readonly-mmap on it. 

This PR implements the first approach. I tried the second approach, but it becomes a pretty large refactor, especially since it also touches the cache generator (which uses the same schema), and the cache-generator is not as 'linear' -- it reads from self in a way which the DAG-generator does not, and thus is more difficult to convert this way. In the end, I thought it seems a bit wasteful to do a major refactoring of ethash at this point. 

This PR also fixes an over-allocation that could happen if the mmap fails, and we generate the dag in-memory, and does some more cleanup in case of failures.  

### Re testing

I found this error when I tried running `go test . -run - -bench BenchmarkHashimotoFullMmap/WithLock -v`. It generates the dag to the system temp, which in my case was limited to `1Gb`. Without this fix, the benchmark crashed, but it runs fine with this fix. 

## Re platforms

I got the supported-platform info from this
```
[user@work syscall]$ grep Fallocate * 
grep: js: Is a directory
syscall_linux.go://sys	Fallocate(fd int, mode uint32, off int64, len int64) (err error)
zsyscall_linux_386.go:func Fallocate(fd int, mode uint32, off int64, len int64) (err error) {
zsyscall_linux_amd64.go:func Fallocate(fd int, mode uint32, off int64, len int64) (err error) {
zsyscall_linux_arm.go:func Fallocate(fd int, mode uint32, off int64, len int64) (err error) {
zsyscall_linux_arm64.go:func Fallocate(fd int, mode uint32, off int64, len int64) (err error) {
zsyscall_linux_mips.go:func Fallocate(fd int, mode uint32, off int64, len int64) (err error) {
zsyscall_linux_mips64.go:func Fallocate(fd int, mode uint32, off int64, len int64) (err error) {
zsyscall_linux_mips64le.go:func Fallocate(fd int, mode uint32, off int64, len int64) (err error) {
zsyscall_linux_mipsle.go:func Fallocate(fd int, mode uint32, off int64, len int64) (err error) {
zsyscall_linux_ppc64.go:func Fallocate(fd int, mode uint32, off int64, len int64) (err error) {
zsyscall_linux_ppc64le.go:func Fallocate(fd int, mode uint32, off int64, len int64) (err error) {
zsyscall_linux_riscv64.go:func Fallocate(fd int, mode uint32, off int64, len int64) (err error) {
zsyscall_linux_s390x.go:func Fallocate(fd int, mode uint32, off int64, len int64) (err error) {
```

