### PR TITLE
core/state/snapshot: fix benchmarks

### DIFF
--- a/core/state/snapshot/difflayer_test.go
+++ b/core/state/snapshot/difflayer_test.go
@@ -388,7 +388,7 @@ func BenchmarkJournal(b *testing.B) {
 		}
 		return newDiffLayer(parent, common.Hash{}, destructs, accounts, storage)
 	}
-	layer := snapshot(new(diskLayer))
+	layer := snapshot(emptyLayer())
 	for i := 1; i < 128; i++ {
 		layer = fill(layer)
 	}


### PR DESCRIPTION
Fixes a benchmark
Before:
```
[user@work core]$ go test ./state/snapshot/ -run - -bench Journal
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x20 pc=0x5aaafc]

goroutine 7 [running]:
github.com/ethereum/go-ethereum/core/rawdb.WriteSnapshotGenerator({0x0, 0x0}, {0xc000c062f0, 0x4, 0xc0348bf130})
	/home/user/go/src/github.com/ethereum/go-ethereum/core/rawdb/accessors_snapshot.go:154 +0x3c
github.com/ethereum/go-ethereum/core/state/snapshot.journalProgress({0x0, 0x0}, {0x0, 0x0, 0x0}, 0x0)
	/home/user/go/src/github.com/ethereum/go-ethereum/core/state/snapshot/generate.go:203 +0x392
github.com/ethereum/go-ethereum/core/state/snapshot.(*diskLayer).Journal(0xc00015a000, 0x0)

```