### PR TITLE
core/tutorial: tutorial to help learn the go-ethereum APIs

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -22,3 +22,7 @@ Wiki](https://github.com/ethereum/wiki/wiki)**.
 * [Ethereum Yellow Paper](https://ethereum.github.io/yellowpaper/paper.pdf)
 * [Ethereum Improvement Proposals (EIPs)](https://eips.ethereum.org)
 * [Peer-to-peer Networking Specifications](https://github.com/ethereum/devp2p/blob/master/README.md)
+
+### Tutorials
+
+* [Develop ethereum applications using Go](https://goethereumbook.org/en/)


### PR DESCRIPTION
added a tutorial in https://geth.ethereum.org/docs/ for 
using the go-ethereum, the official Ethereum implementation in Go, to interact with the blockchain. https://goethereumbook.org/en/

Following the principles of ethereum.org for its tutorials https://ethereum.org/en/developers/tutorials/

