### PR TITLE
core/vm: improve codeBitmap generation by caching

### DIFF
--- a/core/vm/analysis.go
+++ b/core/vm/analysis.go
@@ -16,6 +16,11 @@
 
 package vm
 
+import (
+	"github.com/ethereum/go-ethereum/common"
+	lru "github.com/hashicorp/golang-lru"
+)
+
 const (
 	set2BitsMask = uint16(0b1100_0000_0000_0000)
 	set3BitsMask = uint16(0b1110_0000_0000_0000)
@@ -24,6 +29,10 @@ const (
 	set6BitsMask = uint16(0b1111_1100_0000_0000)
 	set7BitsMask = uint16(0b1111_1110_0000_0000)
 )
+
+const codeBitmapCacheSize = 10000
+
+var codeBitmapCache, _ = lru.NewARC(codeBitmapCacheSize)
 
 // bitvec is a bit vector which maps bytes in a program.
 // An unset bit means the byte is an opcode, a set bit means
@@ -71,6 +80,7 @@ func codeBitmap(code []byte) bitvec {
 	// The bitmap is 4 bytes longer than necessary, in case the code
 	// ends with a PUSH32, the algorithm will push zeroes onto the
 	// bitvector outside the bounds of the actual code.
+
 	bits := make(bitvec, len(code)/8+1+4)
 	return codeBitmapInternal(code, bits)
 }
@@ -121,4 +131,18 @@ func codeBitmapInternal(code, bits bitvec) bitvec {
 		}
 	}
 	return bits
+}
+
+func codeBitmapWithCache(code []byte, codeHash common.Hash) bitvec {
+	if (codeHash == emptyCodeHash || codeHash == common.Hash{}) {
+		return nil
+	}
+
+	if val, ok := codeBitmapCache.Get(codeHash); ok {
+		return val.(bitvec)
+	} else {
+		val := codeBitmap(code)
+		codeBitmapCache.Add(codeHash, val)
+		return val
+	}
 }

--- a/core/vm/contract.go
+++ b/core/vm/contract.go
@@ -106,13 +106,13 @@ func (c *Contract) isCode(udest uint64) bool {
 	// Do we have a contract hash already?
 	// If we do have a hash, that means it's a 'regular' contract. For regular
 	// contracts ( not temporary initcode), we store the analysis in a map
-	if c.CodeHash != (common.Hash{}) {
+	if c.CodeHash != (common.Hash{}) && c.CodeHash != emptyCodeHash {
 		// Does parent context have the analysis?
 		analysis, exist := c.jumpdests[c.CodeHash]
 		if !exist {
 			// Do the analysis and save in parent context
 			// We do not need to store it in c.analysis
-			analysis = codeBitmap(c.Code)
+			analysis = codeBitmapWithCache(c.Code, c.CodeHash)
 			c.jumpdests[c.CodeHash] = analysis
 		}
 		// Also stash it in current contract for faster access

--- a/core/vm/contract.go
+++ b/core/vm/contract.go
@@ -106,7 +106,7 @@ func (c *Contract) isCode(udest uint64) bool {
 	// Do we have a contract hash already?
 	// If we do have a hash, that means it's a 'regular' contract. For regular
 	// contracts ( not temporary initcode), we store the analysis in a map
-	if c.CodeHash != (common.Hash{}) && c.CodeHash != emptyCodeHash {
+	if c.CodeHash != (common.Hash{}) {
 		// Does parent context have the analysis?
 		analysis, exist := c.jumpdests[c.CodeHash]
 		if !exist {


### PR DESCRIPTION
Generating code bitmap might be a time-consuming process, so there's no need to generate it over and over again.

This PR aims to using a global LRU cache of limit size to save the result of generating code bitmap, so next time when some transaction calls the same contract, the cached code bitmap can be used directly.

Based on observations over the past period of time, only a few of contracts(the famous ones, like uniswap, opensea, some erc20 stable tokens, etc) were called in most transactions. So this PR could reduce the transaction execution time averagely to some extent.