### PR TITLE
core: fixed stale comment in txlist

### DIFF
--- a/core/tx_list.go
+++ b/core/tx_list.go
@@ -295,9 +295,9 @@ func (l *txList) Add(tx *types.Transaction, priceBump uint64) (bool, *types.Tran
 		thresholdFeeCap := aFeeCap.Div(aFeeCap, b)
 		thresholdTip := aTip.Div(aTip, b)
 
-		// Have to ensure that either the new fee cap or tip is higher than the
+		// We have to ensure that both the new fee cap and tip are higher than the
 		// old ones as well as checking the percentage threshold to ensure that
-		// this is accurate for low (Wei-level) gas price replacements
+		// this is accurate for low (Wei-level) gas price replacements.
 		if tx.GasFeeCapIntCmp(thresholdFeeCap) < 0 || tx.GasTipCapIntCmp(thresholdTip) < 0 {
 			return false, nil
 		}


### PR DESCRIPTION
This PR fixes a comment in the txlist.

### Why do we need to bump both FeeCap and Tip?

We aim to have all transactions in the txpool executable, otherwise an attacker could flood the txpool with invalid transactions or keep their transactions in the txpool indefinitely, taking up space for real users.
If we allowed users to only bump the tip, they could spam the transaction pool with transactions that have a low feecap and bump their tip up every now and then to keep them in the txpools.
If we allowed users to only bumb the feecap, we could reach a similar situation. Right now the miners only accept transactions with tip > 1Gwei by default. This means if someone added a transaction with a tip < 1 gwei, and keeps bumping the feecap, the transaction would remain in the txpool indefinitely.

An attacker introducing a transaction with 1/1 Gwei could bump it twice as much if we allowed for both feecap and tip to be bumped individually, compared to now

closes https://github.com/ethereum/go-ethereum/issues/23311