### PR TITLE
rpc: avoid crashing on clique getSigner during sync

### DIFF
--- a/consensus/clique/api.go
+++ b/consensus/clique/api.go
@@ -214,6 +214,9 @@ func (api *API) GetSigner(rlpOrBlockNr *blockNumberOrHashOrRLP) (common.Address,
 		} else if number, ok := blockNrOrHash.Number(); ok {
 			header = api.chain.GetHeaderByNumber(uint64(number.Int64()))
 		}
+		if header == nil {
+			return common.Address{}, fmt.Errorf("missing block %v", blockNrOrHash.String())
+		}
 		return api.clique.Author(header)
 	}
 	block := new(types.Block)

--- a/rpc/types.go
+++ b/rpc/types.go
@@ -186,6 +186,16 @@ func (bnh *BlockNumberOrHash) Number() (BlockNumber, bool) {
 	return BlockNumber(0), false
 }
 
+func (bnh *BlockNumberOrHash) String() string {
+	if bnh.BlockNumber != nil {
+		return strconv.Itoa(int(*bnh.BlockNumber))
+	}
+	if bnh.BlockHash != nil {
+		return bnh.BlockHash.String()
+	}
+	return "nil"
+}
+
 func (bnh *BlockNumberOrHash) Hash() (common.Hash, bool) {
 	if bnh.BlockHash != nil {
 		return *bnh.BlockHash, true


### PR DESCRIPTION
With an empty database, before this PR: 
```
> clique.getSigner("latest")
ERROR[10-29|13:43:56.110] RPC method clique_getSigner crashed: runtime error: invalid memory address or nil pointer dereference
goroutine 153 [running]:
github.com/ethereum/go-ethereum/rpc.(*callback).call.func1()
	github.com/ethereum/go-ethereum/rpc/service.go:200 +0x89
panic({0x103e200, 0x1b263a0})
	runtime/panic.go:1038 +0x215
github.com/ethereum/go-ethereum/consensus/clique.ecrecover(0x0, 0x2)
	github.com/ethereum/go-ethereum/consensus/clique/clique.go:153 +0x170
github.com/ethereum/go-ethereum/consensus/clique.(*Clique).Author(...)
	github.com/ethereum/go-ethereum/consensus/clique/clique.go:213
github.com/ethereum/go-ethereum/consensus/clique.(*API).GetSigner(0xc003f7e3f0, 0x18)
	github.com/ethereum/go-ethereum/consensus/clique/api.go:217 +0x11d
reflect.Value.call({0xc0045ff560, 0xc002d1dc78, 0x79af2f9ab3c8}, {0x118fbee, 0x4}, {0xc004000eb0, 0x2, 0xc00401c640})
	reflect/value.go:543 +0x814
```
With this PR: 
```
> clique.getSigner("latest")
WARN [10-29|13:48:50.806] Served clique_getSigner                  reqid=9 t="278.136µs" err="missing block -1"
Error: missing block -1
	at web3.js:6357:37(47)
	at send (web3.js:5091:62(35))
	at <eval>:1:17(4)
```
Q.E.D