### PR TITLE
fuzzing: add CIFuzz

### DIFF
--- a/.github/workflows/cifuzz.yml
+++ b/.github/workflows/cifuzz.yml
@@ -1,0 +1,26 @@
+name: CIFuzz
+on: [pull_request]
+jobs:
+  Fuzzing:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Build Fuzzers
+      id: build
+      uses: google/oss-fuzz/infra/cifuzz/actions/build_fuzzers@master
+      with:
+        oss-fuzz-project-name: 'go-ethereum'
+        dry-run: false
+        language: go
+    - name: Run Fuzzers
+      uses: google/oss-fuzz/infra/cifuzz/actions/run_fuzzers@master
+      with:
+        oss-fuzz-project-name: 'go-ethereum'
+        fuzz-seconds: 1200
+        dry-run: false
+        language: go
+    - name: Upload Crash
+      uses: actions/upload-artifact@v1
+      if: failure() && steps.build.outcome == 'success'
+      with:
+        name: artifacts
+        path: ./out/artifacts


### PR DESCRIPTION
This adds CIFuzz to geths OSS-fuzz integration. Merging this PR will result in geths fuzzers running in the CI for 1200 seconds when a PR is made.

CIFuzz is an additional service to projects integrated into OSS-fuzz to help catch bugs before they are merged as well as check if a PR breaks the fuzzers.

This is optional and merely a suggestion. The 1200 seconds can be changed.

Documentation of CIFuzz can be found here: https://google.github.io/oss-fuzz/getting-started/continuous-integration/