### PR TITLE
accounts/abi/bin/backends: return basefee in suggestGasPrice's

### DIFF
--- a/accounts/abi/bind/backends/simulated.go
+++ b/accounts/abi/bind/backends/simulated.go
@@ -462,7 +462,7 @@ func (b *SimulatedBackend) PendingNonceAt(ctx context.Context, account common.Ad
 // SuggestGasPrice implements ContractTransactor.SuggestGasPrice. Since the simulated
 // chain doesn't have miners, we just return a gas price of 1 for any call.
 func (b *SimulatedBackend) SuggestGasPrice(ctx context.Context) (*big.Int, error) {
-	return big.NewInt(1), nil
+	return b.pendingBlock.Header().BaseFee, nil
 }
 
 // SuggestGasTipCap implements ContractTransactor.SuggestGasTipCap. Since the simulated

--- a/accounts/abi/bind/backends/simulated_test.go
+++ b/accounts/abi/bind/backends/simulated_test.go
@@ -916,8 +916,8 @@ func TestSuggestGasPrice(t *testing.T) {
 	if err != nil {
 		t.Errorf("could not get gas price: %v", err)
 	}
-	if gasPrice.Uint64() != uint64(1) {
-		t.Errorf("gas price was not expected value of 1. actual: %v", gasPrice.Uint64())
+	if gasPrice.Uint64() != sim.pendingBlock.Header().BaseFee.Uint64() {
+		t.Errorf("gas price was not expected value of %v. actual: %v", sim.pendingBlock.Header().BaseFee.Uint64(), gasPrice.Uint64())
 	}
 }
 


### PR DESCRIPTION
EIP-1559 changes the min amount of gas price we can execute a transaction with (current basefee).
The simulated backend always returned 1 on suggestGasPrice. With 1559 we need to return at least the basefee, otherwise transactions will never be mined.