### PR TITLE
les/vflux: fixed panic and data races

### DIFF
--- a/les/vflux/server/balance_tracker.go
+++ b/les/vflux/server/balance_tracker.go
@@ -223,8 +223,9 @@ func (bt *balanceTracker) BalanceOperation(id enode.ID, connAddress string, cb f
 		var nb *nodeBalance
 		if node := bt.ns.GetNode(id); node != nil {
 			nb, _ = bt.ns.GetField(node, bt.setup.balanceField).(*nodeBalance)
-		} else {
-			node = enode.SignNull(&enr.Record{}, id)
+		}
+		if nb == nil {
+			node := enode.SignNull(&enr.Record{}, id)
 			nb = bt.newNodeBalance(node, connAddress, false)
 		}
 		cb(nb)


### PR DESCRIPTION
This PR fixes a faulty condition in the les/vflux/server package that caused BalanceOperation to panic in some rare cases. The data races reported in https://github.com/ethereum/go-ethereum/issues/23848 are also fixed in les/vflux/client.