### PR TITLE
cmd/devp2p: update TTL max for Cloudflare

### DIFF
--- a/cmd/devp2p/dns_cloudflare.go
+++ b/cmd/devp2p/dns_cloudflare.go
@@ -133,7 +133,8 @@ func (c *cloudflareClient) uploadRecords(name string, records map[string]string)
 			log.Info(fmt.Sprintf("Creating %s = %q", path, val))
 			ttl := rootTTL
 			if path != name {
-				ttl = treeNodeTTL // Max TTL permitted by Cloudflare
+				ttl = treeNodeTTLCloudflare // Max TTL permitted by Cloudflare
+
 			}
 			record := cloudflare.DNSRecord{Type: "TXT", Name: path, Content: val, TTL: ttl}
 			_, err = c.CreateDNSRecord(context.Background(), c.zoneID, record)

--- a/cmd/devp2p/dnscmd.go
+++ b/cmd/devp2p/dnscmd.go
@@ -115,8 +115,9 @@ var (
 )
 
 const (
-	rootTTL     = 30 * 60              // 30 min
-	treeNodeTTL = 4 * 7 * 24 * 60 * 60 // 4 weeks
+	rootTTL               = 30 * 60              // 30 min
+	treeNodeTTL           = 4 * 7 * 24 * 60 * 60 // 4 weeks
+	treeNodeTTLCloudflare = 24 * 60 * 60         // 1 day
 )
 
 // dnsSync performs dnsSyncCommand.


### PR DESCRIPTION
This was apparently recently changed by Cloudflare, and
began returning an error: `TTL must be between 60 and 86400 seconds, or 1 for Automatic`

A failing run with an example error: https://github.com/etclabscore/discv4-dns-lists/actions/runs/1429049560
A fixed run with no error: https://github.com/etclabscore/discv4-dns-lists/actions/runs/1429650853

I created a new variable because `treeNodeTTL` is also used by the Route53 implementation.