### PR TITLE
cmd/evm: make t9n intrinsicGas output hex, fixes #23883

### DIFF
--- a/cmd/evm/internal/t8ntool/transaction.go
+++ b/cmd/evm/internal/t8ntool/transaction.go
@@ -48,7 +48,7 @@ func (r *result) MarshalJSON() ([]byte, error) {
 		Error        string          `json:"error,omitempty"`
 		Address      *common.Address `json:"address,omitempty"`
 		Hash         *common.Hash    `json:"hash,omitempty"`
-		IntrinsicGas uint64          `json:"intrinsicGas,omitempty"`
+		IntrinsicGas hexutil.Uint64  `json:"intrinsicGas,omitempty"`
 	}
 	var out xx
 	if r.Error != nil {
@@ -60,7 +60,7 @@ func (r *result) MarshalJSON() ([]byte, error) {
 	if r.Hash != (common.Hash{}) {
 		out.Hash = &r.Hash
 	}
-	out.IntrinsicGas = r.IntrinsicGas
+	out.IntrinsicGas = hexutil.Uint64(r.IntrinsicGas)
 	return json.Marshal(out)
 }
 

--- a/cmd/evm/testdata/15/exp2.json
+++ b/cmd/evm/testdata/15/exp2.json
@@ -2,11 +2,11 @@
   {
     "address": "0xd02d72e067e77158444ef2020ff2d325f929b363",
     "hash": "0xa98a24882ea90916c6a86da650fbc6b14238e46f0af04a131ce92be897507476",
-    "intrinsicGas": 21000
+    "intrinsicGas": "0x5208"
   },
   {
     "address": "0xd02d72e067e77158444ef2020ff2d325f929b363",
     "hash": "0x36bad80acce7040c45fd32764b5c2b2d2e6f778669fb41791f73f546d56e739a",
-    "intrinsicGas": 21000
+    "intrinsicGas": "0x5208"
   }
 ]

--- a/cmd/evm/testdata/16/exp.json
+++ b/cmd/evm/testdata/16/exp.json
@@ -2,12 +2,12 @@
   {
     "address": "0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b",
     "hash": "0x7cc3d1a8540a44736750f03bb4d85c0113be4b3472a71bf82241a3b261b479e6",
-    "intrinsicGas": 21000
+    "intrinsicGas": "0x5208"
   },
   {
     "error": "intrinsic gas too low: have 82, want 21000",
     "address": "0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b",
     "hash": "0x3b2d2609e4361562edb9169314f4c05afc6dbf5d706bf9dda5abe242ab76a22b",
-    "intrinsicGas": 21000
+    "intrinsicGas": "0x5208"
   }
 ]

--- a/cmd/evm/testdata/17/exp.json
+++ b/cmd/evm/testdata/17/exp.json
@@ -3,13 +3,13 @@
       "error": "value exceeds 256 bits",
       "address": "0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b",
       "hash": "0xfbd91685dcbf8172f0e8c53e2ddbb4d26707840da6b51a74371f62a33868fd82",
-      "intrinsicGas": 21000
+      "intrinsicGas": "0x5208"
     },
     {
       "error": "gasPrice exceeds 256 bits",
       "address": "0x1b57ccef1fe5fb73f1e64530fb4ebd9cf1655964",
       "hash": "0x45dc05035cada83748e4c1fe617220106b331eca054f44c2304d5654a9fb29d5",
-      "intrinsicGas": 21000
+      "intrinsicGas": "0x5208"
     },
     {
       "error": "invalid transaction v, r, s values",


### PR DESCRIPTION
current output

```
  {
    "error": "gasPrice exceeds 256 bits",
    "address": "0x54b0dfad82e7660aa185dbd371c359757fc3e656",
    "hash": "0x63cc78c654a6cc5f8ab4f17d03caef02d49ef43275282b12d432880f1192b987",
    "intrinsicGas": 21000
  }
```

new output:
```
  {
    "error": "gasPrice exceeds 256 bits",
    "address": "0x54b0dfad82e7660aa185dbd371c359757fc3e656",
    "hash": "0x63cc78c654a6cc5f8ab4f17d03caef02d49ef43275282b12d432880f1192b987",
    "intrinsicGas": "0x5208"
  }
```