### PR TITLE
cmd/geth: add db cmd to show metadata

### DIFF
--- a/cmd/geth/dbcmd.go
+++ b/cmd/geth/dbcmd.go
@@ -734,7 +734,7 @@ func showMetaData(ctx *cli.Context) error {
 	}
 	data = append(data, [][]string{{"frozen", fmt.Sprintf("%d items", ancients)},
 		{"lastPivotNumber", pp(rawdb.ReadLastPivotNumber(db))},
-		{"snapshotSyncStatus", fmt.Sprintf("%d bytes", len(rawdb.ReadSnapshotSyncStatus(db)))},
+		{"len(snapshotSyncStatus)", fmt.Sprintf("%d bytes", len(rawdb.ReadSnapshotSyncStatus(db)))},
 		{"snapshotGenerator", snapshot.ParseGeneratorStatus(rawdb.ReadSnapshotGenerator(db))},
 		{"snapshotDisabled", fmt.Sprintf("%v", rawdb.ReadSnapshotDisabled(db))},
 		{"snapshotJournal", fmt.Sprintf("%d bytes", len(rawdb.ReadSnapshotJournal(db)))},

--- a/cmd/geth/dbcmd.go
+++ b/cmd/geth/dbcmd.go
@@ -34,6 +34,7 @@ import (
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/console/prompt"
 	"github.com/ethereum/go-ethereum/core/rawdb"
+	"github.com/ethereum/go-ethereum/core/state/snapshot"
 	"github.com/ethereum/go-ethereum/ethdb"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/trie"
@@ -243,6 +244,7 @@ WARNING: This is a low-level operation which may cause database corruption!`,
 			utils.SyncModeFlag,
 			utils.MainnetFlag,
 			utils.RopstenFlag,
+			utils.SepoliaFlag,
 			utils.RinkebyFlag,
 			utils.GoerliFlag,
 		},
@@ -730,14 +732,16 @@ func showMetaData(ctx *cli.Context) error {
 		data = append(data, []string{"headHeader.Root", fmt.Sprintf("%v", h.Root)})
 		data = append(data, []string{"headHeader.Number", fmt.Sprintf("%d (0x%x)", h.Number, h.Number)})
 	}
-	data = append(data, [][]string{{"frozen", fmt.Sprintf("%v", ancients)},
+	data = append(data, [][]string{{"frozen", fmt.Sprintf("%d items", ancients)},
 		{"lastPivotNumber", pp(rawdb.ReadLastPivotNumber(db))},
 		{"snapshotSyncStatus", fmt.Sprintf("%d bytes", len(rawdb.ReadSnapshotSyncStatus(db)))},
-		{"snapshotGenerator", fmt.Sprintf("%x", rawdb.ReadSnapshotGenerator(db))},
+		{"snapshotGenerator", snapshot.ParseGeneratorStatus(rawdb.ReadSnapshotGenerator(db))},
 		{"snapshotDisabled", fmt.Sprintf("%v", rawdb.ReadSnapshotDisabled(db))},
 		{"snapshotJournal", fmt.Sprintf("%d bytes", len(rawdb.ReadSnapshotJournal(db)))},
 		{"snapshotRecoveryNumber", pp(rawdb.ReadSnapshotRecoveryNumber(db))},
 		{"snapshotRoot", fmt.Sprintf("%v", rawdb.ReadSnapshotRoot(db))},
+		{"txIndexTail", pp(rawdb.ReadTxIndexTail(db))},
+		{"fastTxLookupLimit", pp(rawdb.ReadFastTxLookupLimit(db))},
 	}...)
 	table := tablewriter.NewWriter(os.Stdout)
 	table.SetHeader([]string{"Field", "Value"})


### PR DESCRIPTION
```
[user@work go-ethereum]$ ./build/bin/geth --sepolia db metadata
INFO [11-12|14:02:05.331] Maximum peer count                       ETH=50 LES=0 total=50
INFO [11-12|14:02:05.331] Smartcard socket not found, disabling    err="stat /run/pcscd/pcscd.comm: no such file or directory"
INFO [11-12|14:02:05.332] Set global gas cap                       cap=50,000,000
INFO [11-12|14:02:05.332] Allocated cache and file handles         database=/home/user/.ethereum/sepolia/geth/chaindata cache=512.00MiB handles=262,144 readonly=true
INFO [11-12|14:02:05.536] Opened ancient database                  database=/home/user/.ethereum/sepolia/geth/chaindata/ancient readonly=true
+------------------------+--------------------------------------------------------------------+
|         FIELD          |                               VALUE                                |
+------------------------+--------------------------------------------------------------------+
| databaseVersion        | 8 (0x8)                                                            |
| headBlockHash          | 0x58552a4eec5f77b1145256e58ea0576ad6e11127bdf2329b947b0e94bc1986fb |
| headFastBlockHash      | 0x58552a4eec5f77b1145256e58ea0576ad6e11127bdf2329b947b0e94bc1986fb |
| headHeaderHash         | 0x58552a4eec5f77b1145256e58ea0576ad6e11127bdf2329b947b0e94bc1986fb |
| headBlock.Hash         | 0x58552a4eec5f77b1145256e58ea0576ad6e11127bdf2329b947b0e94bc1986fb |
| headBlock.Root         | 0x4eaa376b7e4634c1c2258a40206221ff20e126fe529a160cc9eec7fd9286c4cb |
| headBlock.Number       | 96236 (0x177ec)                                                    |
| headHeader.Hash        | 0x58552a4eec5f77b1145256e58ea0576ad6e11127bdf2329b947b0e94bc1986fb |
| headHeader.Root        | 0x4eaa376b7e4634c1c2258a40206221ff20e126fe529a160cc9eec7fd9286c4cb |
| headHeader.Number      | 96236 (0x177ec)                                                    |
| frozen                 |                                                               6237 |
| lastPivotNumber        | 96168 (0x177a8)                                                    |
| snapshotSyncStatus     | 299 bytes                                                          |
| snapshotGenerator      | c6800180808080                                                     |
| snapshotDisabled       | false                                                              |
| snapshotJournal        | 5882 bytes                                                         |
| snapshotRecoveryNumber | <nil>                                                              |
| snapshotRoot           | 0xcf36401ce2143625f9823620740e59efa93445451acc7cc1e8b621bbc6dab95b |
+------------------------+--------------------------------------------------------------------+
```
Example with a quirky (broken) datadir, where some things don't match up -- both header hashes/number as well as the frozen-count, which is off. 
```
+------------------------+--------------------------------------------------------------------+
|         FIELD          |                               VALUE                                |
+------------------------+--------------------------------------------------------------------+
| databaseVersion        | 8 (0x8)                                                            |
| headBlockHash          | 0xd4e56740f876aef8c010b86a40d5f56745a118d0906a34e69aec8c0db1cb8fa3 |
| headFastBlockHash      | 0xd4e56740f876aef8c010b86a40d5f56745a118d0906a34e69aec8c0db1cb8fa3 |
| headHeaderHash         | 0x723899e82d352c6eabd21e34942f868687203ca14b3d5a23aeb47c555c123390 |
| headBlock.Hash         | 0xd4e56740f876aef8c010b86a40d5f56745a118d0906a34e69aec8c0db1cb8fa3 |
| headBlock.Root         | 0xd7f8974fb5ac78d9ac099b9ad5018bedc2ce0a72dad1827a1709da30580f0544 |
| headBlock.Number       | 0 (0x0)                                                            |
| headHeader.Hash        | 0x723899e82d352c6eabd21e34942f868687203ca14b3d5a23aeb47c555c123390 |
| headHeader.Root        | 0x90a744bf211c10d2ef5a745a09b6813563e6d14453042a916771237aa5ec3f3b |
| headHeader.Number      | 192 (0xc0)                                                         |
| frozen                 |                                                                  2 |
| lastPivotNumber        | 13597267 (0xcf7a53)                                                |
| snapshotSyncStatus     | 227 bytes                                                          |
| snapshotGenerator      |                                                                    |
| snapshotDisabled       | true                                                               |
| snapshotJournal        | 0 bytes                                                            |
| snapshotRecoveryNumber | <nil>                                                              |
| snapshotRoot           | 0x0000000000000000000000000000000000000000000000000000000000000000 |
+------------------------+--------------------------------------------------------------------+
```