### PR TITLE
core/rawdb: better error message in freezer

### DIFF
--- a/core/rawdb/freezer_batch.go
+++ b/core/rawdb/freezer_batch.go
@@ -116,7 +116,7 @@ func (batch *freezerTableBatch) reset() {
 // existing data.
 func (batch *freezerTableBatch) Append(item uint64, data interface{}) error {
 	if item != batch.curItem {
-		return fmt.Errorf("%w, have %d want %d", errOutOrderInsertion, item, batch.curItem)
+		return fmt.Errorf("%w: have %d want %d", errOutOrderInsertion, item, batch.curItem)
 	}
 
 	// Encode the item.
@@ -136,7 +136,7 @@ func (batch *freezerTableBatch) Append(item uint64, data interface{}) error {
 // existing data.
 func (batch *freezerTableBatch) AppendRaw(item uint64, blob []byte) error {
 	if item != batch.curItem {
-		return fmt.Errorf("%w, have %d want %d", errOutOrderInsertion, item, batch.curItem)
+		return fmt.Errorf("%w: have %d want %d", errOutOrderInsertion, item, batch.curItem)
 	}
 
 	encItem := blob

--- a/core/rawdb/freezer_batch.go
+++ b/core/rawdb/freezer_batch.go
@@ -116,7 +116,7 @@ func (batch *freezerTableBatch) reset() {
 // existing data.
 func (batch *freezerTableBatch) Append(item uint64, data interface{}) error {
 	if item != batch.curItem {
-		return errOutOrderInsertion
+		return fmt.Errorf("%w, have %d want %d", errOutOrderInsertion, item, batch.curItem)
 	}
 
 	// Encode the item.
@@ -136,7 +136,7 @@ func (batch *freezerTableBatch) Append(item uint64, data interface{}) error {
 // existing data.
 func (batch *freezerTableBatch) AppendRaw(item uint64, blob []byte) error {
 	if item != batch.curItem {
-		return errOutOrderInsertion
+		return fmt.Errorf("%w, have %d want %d", errOutOrderInsertion, item, batch.curItem)
 	}
 
 	encItem := blob

--- a/core/rawdb/freezer_test.go
+++ b/core/rawdb/freezer_test.go
@@ -246,7 +246,7 @@ func TestFreezerConcurrentModifyTruncate(t *testing.T) {
 		if truncateErr != nil {
 			t.Fatal("concurrent truncate failed:", err)
 		}
-		if !(modifyErr == nil || modifyErr == errOutOrderInsertion) {
+		if !(errors.Is(modifyErr, nil) || errors.Is(modifyErr, errOutOrderInsertion)) {
 			t.Fatal("wrong error from concurrent modify:", modifyErr)
 		}
 		checkAncientCount(t, f, "test", 10)


### PR DESCRIPTION
This PR provides a better error message in case there's a mismatch between what's in ancients and what we try to put there. Right now, we can't really tell if we're missing something or if we have too much data there already. 