### PR TITLE
p2p/enode: store local port number as uint16

### DIFF
--- a/p2p/simulations/adapters/types.go
+++ b/p2p/simulations/adapters/types.go
@@ -242,7 +242,7 @@ func assignTCPPort() (uint16, error) {
 	if err != nil {
 		return 0, err
 	}
-	p, err := strconv.ParseInt(port, 10, 32)
+	p, err := strconv.ParseUint(port, 10, 16)
 	if err != nil {
 		return 0, err
 	}


### PR DESCRIPTION
Fix integer conversions discovered by CodeQL