### PR TITLE
cmd/evm: fix incorrect default value for trace.nomemory and trace.noreturndata

### DIFF
--- a/cmd/evm/internal/t8ntool/flags.go
+++ b/cmd/evm/internal/t8ntool/flags.go
@@ -30,7 +30,7 @@ var (
 		Name:  "trace",
 		Usage: "Output full trace logs to files <txhash>.jsonl",
 	}
-	TraceDisableMemoryFlag = cli.BoolTFlag{
+	TraceDisableMemoryFlag = cli.BoolFlag{
 		Name:  "trace.nomemory",
 		Usage: "Disable full memory dump in traces",
 	}
@@ -38,7 +38,7 @@ var (
 		Name:  "trace.nostack",
 		Usage: "Disable stack output in traces",
 	}
-	TraceDisableReturnDataFlag = cli.BoolTFlag{
+	TraceDisableReturnDataFlag = cli.BoolFlag{
 		Name:  "trace.noreturndata",
 		Usage: "Disable return data output in traces",
 	}


### PR DESCRIPTION
These should default to `false` since they're later inverted:

https://github.com/ethereum/go-ethereum/blob/ac23e91f0cc68a6897e852caa159f12c262ba36d/cmd/evm/internal/t8ntool/transition.go#L109-L114