### PR TITLE
cmd/evm: rename t8n args to improve clarity when tracing

### DIFF
--- a/cmd/evm/internal/t8ntool/flags.go
+++ b/cmd/evm/internal/t8ntool/flags.go
@@ -30,17 +30,17 @@ var (
 		Name:  "trace",
 		Usage: "Output full trace logs to files <txhash>.jsonl",
 	}
-	TraceDisableMemoryFlag = cli.BoolTFlag{
-		Name:  "trace.nomemory",
-		Usage: "Disable full memory dump in traces",
+	TraceEnableMemoryFlag = cli.BoolFlag{
+		Name:  "trace.memory",
+		Usage: "Enable full memory dump in traces",
 	}
 	TraceDisableStackFlag = cli.BoolFlag{
 		Name:  "trace.nostack",
 		Usage: "Disable stack output in traces",
 	}
-	TraceDisableReturnDataFlag = cli.BoolTFlag{
-		Name:  "trace.noreturndata",
-		Usage: "Disable return data output in traces",
+	TraceEnableReturnDataFlag = cli.BoolFlag{
+		Name:  "trace.returndata",
+		Usage: "Enable return data output in traces",
 	}
 	OutputBasedir = cli.StringFlag{
 		Name:  "output.basedir",

--- a/cmd/evm/internal/t8ntool/flags.go
+++ b/cmd/evm/internal/t8ntool/flags.go
@@ -30,6 +30,10 @@ var (
 		Name:  "trace",
 		Usage: "Output full trace logs to files <txhash>.jsonl",
 	}
+	TraceDisableMemoryFlag = cli.BoolTFlag{
+		Name:  "trace.nomemory",
+		Usage: "Disable full memory dump in traces (deprecated)",
+	}
 	TraceEnableMemoryFlag = cli.BoolFlag{
 		Name:  "trace.memory",
 		Usage: "Enable full memory dump in traces",
@@ -37,6 +41,10 @@ var (
 	TraceDisableStackFlag = cli.BoolFlag{
 		Name:  "trace.nostack",
 		Usage: "Disable stack output in traces",
+	}
+	TraceDisableReturnDataFlag = cli.BoolTFlag{
+		Name:  "trace.noreturndata",
+		Usage: "Disable return data output in traces (deprecated)",
 	}
 	TraceEnableReturnDataFlag = cli.BoolFlag{
 		Name:  "trace.returndata",

--- a/cmd/evm/internal/t8ntool/transition.go
+++ b/cmd/evm/internal/t8ntool/transition.go
@@ -102,8 +102,8 @@ func Transition(ctx *cli.Context) error {
 		// Configure the EVM logger
 		logConfig := &vm.LogConfig{
 			DisableStack:     ctx.Bool(TraceDisableStackFlag.Name),
-			EnableMemory:     !ctx.Bool(TraceDisableMemoryFlag.Name),
-			EnableReturnData: !ctx.Bool(TraceDisableReturnDataFlag.Name),
+			EnableMemory:     ctx.Bool(TraceEnableMemoryFlag.Name),
+			EnableReturnData: ctx.Bool(TraceEnableReturnDataFlag.Name),
 			Debug:            true,
 		}
 		var prevFile *os.File

--- a/cmd/evm/internal/t8ntool/transition.go
+++ b/cmd/evm/internal/t8ntool/transition.go
@@ -99,11 +99,17 @@ func Transition(ctx *cli.Context) error {
 		return NewError(ErrorIO, fmt.Errorf("failed creating output basedir: %v", err))
 	}
 	if ctx.Bool(TraceFlag.Name) {
+		if ctx.IsSet(TraceDisableMemoryFlag.Name) && ctx.IsSet(TraceEnableMemoryFlag.Name) {
+			return NewError(ErrorConfig, fmt.Errorf("can't use both flags --%s and --%s", TraceDisableMemoryFlag.Name, TraceEnableMemoryFlag.Name))
+		}
+		if ctx.IsSet(TraceDisableReturnDataFlag.Name) && ctx.IsSet(TraceEnableReturnDataFlag.Name) {
+			return NewError(ErrorConfig, fmt.Errorf("can't use both flags --%s and --%s", TraceDisableReturnDataFlag.Name, TraceEnableReturnDataFlag.Name))
+		}
 		// Configure the EVM logger
 		logConfig := &vm.LogConfig{
 			DisableStack:     ctx.Bool(TraceDisableStackFlag.Name),
-			EnableMemory:     ctx.Bool(TraceEnableMemoryFlag.Name),
-			EnableReturnData: ctx.Bool(TraceEnableReturnDataFlag.Name),
+			EnableMemory:     !ctx.Bool(TraceDisableMemoryFlag.Name) || ctx.Bool(TraceEnableMemoryFlag.Name),
+			EnableReturnData: !ctx.Bool(TraceDisableReturnDataFlag.Name) || ctx.Bool(TraceEnableReturnDataFlag.Name),
 			Debug:            true,
 		}
 		var prevFile *os.File

--- a/cmd/evm/internal/t8ntool/transition.go
+++ b/cmd/evm/internal/t8ntool/transition.go
@@ -105,6 +105,12 @@ func Transition(ctx *cli.Context) error {
 		if ctx.IsSet(TraceDisableReturnDataFlag.Name) && ctx.IsSet(TraceEnableReturnDataFlag.Name) {
 			return NewError(ErrorConfig, fmt.Errorf("can't use both flags --%s and --%s", TraceDisableReturnDataFlag.Name, TraceEnableReturnDataFlag.Name))
 		}
+		if ctx.IsSet(TraceDisableMemoryFlag.Name) {
+			log.Warn(fmt.Sprintf("--%s has been deprecated in favour of --%s", TraceDisableMemoryFlag.Name, TraceEnableMemoryFlag.Name))
+		}
+		if ctx.IsSet(TraceDisableReturnDataFlag.Name) {
+			log.Warn(fmt.Sprintf("--%s has been deprecated in favour of --%s", TraceDisableReturnDataFlag.Name, TraceEnableReturnDataFlag.Name))
+		}
 		// Configure the EVM logger
 		logConfig := &vm.LogConfig{
 			DisableStack:     ctx.Bool(TraceDisableStackFlag.Name),

--- a/cmd/evm/main.go
+++ b/cmd/evm/main.go
@@ -138,9 +138,9 @@ var stateTransitionCommand = cli.Command{
 	Action:  t8ntool.Transition,
 	Flags: []cli.Flag{
 		t8ntool.TraceFlag,
-		t8ntool.TraceDisableMemoryFlag,
+		t8ntool.TraceEnableMemoryFlag,
 		t8ntool.TraceDisableStackFlag,
-		t8ntool.TraceDisableReturnDataFlag,
+		t8ntool.TraceEnableReturnDataFlag,
 		t8ntool.OutputBasedir,
 		t8ntool.OutputAllocFlag,
 		t8ntool.OutputResultFlag,

--- a/cmd/evm/main.go
+++ b/cmd/evm/main.go
@@ -138,8 +138,10 @@ var stateTransitionCommand = cli.Command{
 	Action:  t8ntool.Transition,
 	Flags: []cli.Flag{
 		t8ntool.TraceFlag,
+		t8ntool.TraceDisableMemoryFlag,
 		t8ntool.TraceEnableMemoryFlag,
 		t8ntool.TraceDisableStackFlag,
+		t8ntool.TraceDisableReturnDataFlag,
 		t8ntool.TraceEnableReturnDataFlag,
 		t8ntool.OutputBasedir,
 		t8ntool.OutputAllocFlag,


### PR DESCRIPTION
Apologizes for another PR - my new commits weren't coming through in #23933.

Okay I misunderstood the meaning of the args `tracer.nomemory` and `tracer.noreturndata`. I understand now that it is preferred that memory and return data are *not* printed by default. Given this, I think the flag name are confusing. I didn't realize until looking deeply into this that `--tracer.nomemory=false` is a valid argument. I would've assumed the flag did not take a value and was a simple on/off switch, and therefore assumed the correct default behavior for these values should be *on*. [Others](https://discord.com/channels/717003406484701255/717010234669006899/910916940426530886) have also encountered this.

For these reasons, I propose renaming them to `tracer.memory` and `tracer.returndata` to avoid the double-negative flag `tracer.nomemory=false`.