### PR TITLE
core/rawdb, cmd, ethdb, eth: implement freezer tail deletion

### DIFF
--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -592,7 +592,7 @@ func (bc *BlockChain) setHeadBeyondRoot(head uint64, root common.Hash, repair bo
 		if num+1 <= frozen {
 			// Truncate all relative data(header, total difficulty, body, receipt
 			// and canonical hash) from ancient store.
-			if err := bc.db.TruncateAncients(num); err != nil {
+			if err := bc.db.TruncateHead(num); err != nil {
 				log.Crit("Failed to truncate ancient data", "number", num, "err", err)
 			}
 			// Remove the hash <-> number mapping from the active store.
@@ -991,7 +991,7 @@ func (bc *BlockChain) InsertReceiptChain(blockChain types.Blocks, receiptChain [
 				size += int64(batch.ValueSize())
 				if err = batch.Write(); err != nil {
 					fastBlock := bc.CurrentFastBlock().NumberU64()
-					if err := bc.db.TruncateAncients(fastBlock + 1); err != nil {
+					if err := bc.db.TruncateHead(fastBlock + 1); err != nil {
 						log.Error("Can't truncate ancient store after failed insert", "err", err)
 					}
 					return 0, err
@@ -1009,7 +1009,7 @@ func (bc *BlockChain) InsertReceiptChain(blockChain types.Blocks, receiptChain [
 		if !updateHead(blockChain[len(blockChain)-1]) {
 			// We end up here if the header chain has reorg'ed, and the blocks/receipts
 			// don't match the canonical chain.
-			if err := bc.db.TruncateAncients(previousFastBlock + 1); err != nil {
+			if err := bc.db.TruncateHead(previousFastBlock + 1); err != nil {
 				log.Error("Can't truncate ancient store after failed insert", "err", err)
 			}
 			return 0, errSideChainReceipts

--- a/core/rawdb/accessors_chain.go
+++ b/core/rawdb/accessors_chain.go
@@ -83,8 +83,8 @@ type NumberHash struct {
 	Hash   common.Hash
 }
 
-// ReadAllHashes retrieves all the hashes assigned to blocks at a certain heights,
-// both canonical and reorged forks included.
+// ReadAllHashesInRange retrieves all the hashes assigned to blocks at a certain
+// heights, both canonical and reorged forks included.
 // This method considers both limits to be _inclusive_.
 func ReadAllHashesInRange(db ethdb.Iteratee, first, last uint64) []*NumberHash {
 	var (
@@ -776,7 +776,7 @@ func WriteBlock(db ethdb.KeyValueWriter, block *types.Block) {
 	WriteHeader(db, block.Header())
 }
 
-// WriteAncientBlock writes entire block data into ancient store and returns the total written size.
+// WriteAncientBlocks writes entire block data into ancient store and returns the total written size.
 func WriteAncientBlocks(db ethdb.AncientWriter, blocks []*types.Block, receipts []types.Receipts, td *big.Int) (int64, error) {
 	var (
 		tdSum      = new(big.Int).Set(td)

--- a/core/rawdb/accessors_chain.go
+++ b/core/rawdb/accessors_chain.go
@@ -83,7 +83,7 @@ type NumberHash struct {
 	Hash   common.Hash
 }
 
-// ReadAllHashesInRange retrieves all the hashes assigned to blocks at a certain
+// ReadAllHashesInRange retrieves all the hashes assigned to blocks at certain
 // heights, both canonical and reorged forks included.
 // This method considers both limits to be _inclusive_.
 func ReadAllHashesInRange(db ethdb.Iteratee, first, last uint64) []*NumberHash {

--- a/core/rawdb/database.go
+++ b/core/rawdb/database.go
@@ -99,6 +99,11 @@ func (db *nofreezedb) Ancients() (uint64, error) {
 	return 0, errNotSupported
 }
 
+// Tail returns an error as we don't have a backing chain freezer.
+func (db *nofreezedb) Tail() (uint64, error) {
+	return 0, errNotSupported
+}
+
 // AncientSize returns an error as we don't have a backing chain freezer.
 func (db *nofreezedb) AncientSize(kind string) (uint64, error) {
 	return 0, errNotSupported
@@ -109,8 +114,13 @@ func (db *nofreezedb) ModifyAncients(func(ethdb.AncientWriteOp) error) (int64, e
 	return 0, errNotSupported
 }
 
-// TruncateAncients returns an error as we don't have a backing chain freezer.
-func (db *nofreezedb) TruncateAncients(items uint64) error {
+// TruncateHead returns an error as we don't have a backing chain freezer.
+func (db *nofreezedb) TruncateHead(items uint64) error {
+	return errNotSupported
+}
+
+// TruncateTail returns an error as we don't have a backing chain freezer.
+func (db *nofreezedb) TruncateTail(items uint64) error {
 	return errNotSupported
 }
 
@@ -211,7 +221,7 @@ func NewDatabaseWithFreezer(db ethdb.KeyValueStore, freezer string, namespace st
 				// Block #1 is still in the database, we're allowed to init a new feezer
 			}
 			// Otherwise, the head header is still the genesis, we're allowed to init a new
-			// feezer.
+			// freezer.
 		}
 	}
 	// Freezer is consistent with the key-value database, permit combining the two

--- a/core/rawdb/freezer.go
+++ b/core/rawdb/freezer.go
@@ -59,14 +59,14 @@ const (
 	freezerRecheckInterval = time.Minute
 
 	// freezerBatchLimit is the maximum number of blocks to freeze in one batch
-	// before doing an fsync and deleting it from the key-value store.
+	// before doing a fsync and deleting it from the key-value store.
 	freezerBatchLimit = 30000
 
 	// freezerTableSize defines the maximum size of freezer data files.
 	freezerTableSize = 2 * 1000 * 1000 * 1000
 )
 
-// freezer is an memory mapped append-only database to store immutable chain data
+// freezer is a memory mapped append-only database to store immutable chain data
 // into flat files:
 //
 // - The append only nature ensures that disk writes are minimized.
@@ -78,6 +78,7 @@ type freezer struct {
 	// 64-bit aligned fields can be atomic. The struct is guaranteed to be so aligned,
 	// so take advantage of that (https://golang.org/pkg/sync/atomic/#pkg-note-BUG).
 	frozen    uint64 // Number of blocks already frozen
+	tail      uint64 // Number of the first stored item in the freezer
 	threshold uint64 // Number of recent blocks not to freeze (params.FullImmutabilityThreshold apart from tests)
 
 	// This lock synchronizes writers and the truncate operation, as well as
@@ -226,6 +227,11 @@ func (f *freezer) Ancients() (uint64, error) {
 	return atomic.LoadUint64(&f.frozen), nil
 }
 
+// Tail returns the number of first stored item in the freezer.
+func (f *freezer) Tail() (uint64, error) {
+	return atomic.LoadUint64(&f.tail), nil
+}
+
 // AncientSize returns the ancient size of the specified category.
 func (f *freezer) AncientSize(kind string) (uint64, error) {
 	// This needs the write lock to avoid data races on table fields.
@@ -261,7 +267,7 @@ func (f *freezer) ModifyAncients(fn func(ethdb.AncientWriteOp) error) (writeSize
 		if err != nil {
 			// The write operation has failed. Go back to the previous item position.
 			for name, table := range f.tables {
-				err := table.truncate(prevItem)
+				err := table.truncateHead(prevItem)
 				if err != nil {
 					log.Error("Freezer table roll-back failed", "table", name, "index", prevItem, "err", err)
 				}
@@ -281,8 +287,8 @@ func (f *freezer) ModifyAncients(fn func(ethdb.AncientWriteOp) error) (writeSize
 	return writeSize, nil
 }
 
-// TruncateAncients discards any recent data above the provided threshold number.
-func (f *freezer) TruncateAncients(items uint64) error {
+// TruncateHead discards any recent data above the provided threshold number.
+func (f *freezer) TruncateHead(items uint64) error {
 	if f.readonly {
 		return errReadOnly
 	}
@@ -292,12 +298,42 @@ func (f *freezer) TruncateAncients(items uint64) error {
 	if atomic.LoadUint64(&f.frozen) <= items {
 		return nil
 	}
+	var frozen uint64
 	for _, table := range f.tables {
-		if err := table.truncate(items); err != nil {
+		if err := table.truncateHead(items); err != nil {
 			return err
 		}
+		// Tables should be aligned, only check the first table.
+		if frozen == 0 {
+			frozen = atomic.LoadUint64(&table.items)
+		}
 	}
-	atomic.StoreUint64(&f.frozen, items)
+	atomic.StoreUint64(&f.frozen, frozen)
+	return nil
+}
+
+// TruncateTail discards any recent data below the provided threshold number.
+func (f *freezer) TruncateTail(tail uint64) error {
+	if f.readonly {
+		return errReadOnly
+	}
+	f.writeLock.Lock()
+	defer f.writeLock.Unlock()
+
+	if atomic.LoadUint64(&f.tail) >= tail {
+		return nil
+	}
+	var truncated uint64
+	for _, table := range f.tables {
+		if err := table.truncateTail(tail); err != nil {
+			return err
+		}
+		if truncated == 0 {
+			// Tables should be aligned, only check the first table.
+			truncated = table.tail()
+		}
+	}
+	atomic.StoreUint64(&f.tail, truncated)
 	return nil
 }
 
@@ -344,19 +380,29 @@ func (f *freezer) validate() error {
 
 // repair truncates all data tables to the same length.
 func (f *freezer) repair() error {
-	min := uint64(math.MaxUint64)
+	var (
+		head = uint64(math.MaxUint64)
+		tail = uint64(0)
+	)
 	for _, table := range f.tables {
 		items := atomic.LoadUint64(&table.items)
-		if min > items {
-			min = items
+		if head > items {
+			head = items
+		}
+		if table.tail() > tail {
+			tail = table.tail()
 		}
 	}
 	for _, table := range f.tables {
-		if err := table.truncate(min); err != nil {
+		if err := table.truncateHead(head); err != nil {
+			return err
+		}
+		if err := table.truncateTail(tail); err != nil {
 			return err
 		}
 	}
-	atomic.StoreUint64(&f.frozen, min)
+	atomic.StoreUint64(&f.frozen, head)
+	atomic.StoreUint64(&f.tail, tail)
 	return nil
 }
 

--- a/core/rawdb/freezer.go
+++ b/core/rawdb/freezer.go
@@ -379,8 +379,9 @@ func (f *freezer) repair() error {
 		if head > items {
 			head = items
 		}
-		if table.tail() > tail {
-			tail = table.tail()
+		hidden := atomic.LoadUint64(&table.itemHidden)
+		if hidden > tail {
+			tail = hidden
 		}
 	}
 	for _, table := range f.tables {

--- a/core/rawdb/freezer_batch.go
+++ b/core/rawdb/freezer_batch.go
@@ -191,7 +191,7 @@ func (batch *freezerTableBatch) commit() error {
 	dataSize := int64(len(batch.dataBuffer))
 	batch.dataBuffer = batch.dataBuffer[:0]
 
-	// Write index.
+	// Write indices.
 	_, err = batch.t.index.Write(batch.indexBuffer)
 	if err != nil {
 		return err

--- a/core/rawdb/freezer_meta.go
+++ b/core/rawdb/freezer_meta.go
@@ -1,0 +1,236 @@
+// Copyright 2022 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>
+
+package rawdb
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"os"
+
+	"github.com/ethereum/go-ethereum/rlp"
+)
+
+const (
+	freezerVersion = 1    // The version tag of freezer table structure
+	metaLength     = 1024 // The number of bytes allocated for the freezer table metadata
+)
+
+var errIncompatibleVersion = errors.New("incompatible version")
+
+type incompatibleError struct {
+	version uint16
+	expect  uint16
+	err     error
+}
+
+func newIncompatibleError(version uint16) *incompatibleError {
+	return &incompatibleError{
+		version: version,
+		expect:  freezerVersion,
+		err:     errIncompatibleVersion,
+	}
+}
+
+// Unwrap returns the internal evm error which allows us for further
+// analysis outside.
+func (err *incompatibleError) Unwrap() error {
+	return err.err
+}
+
+func (err *incompatibleError) Error() string {
+	return fmt.Sprintf("%v, get %d, expect %d", err.err, err.version, err.expect)
+}
+
+// freezerTableMeta wraps all the metadata of the freezer table.
+type freezerTableMeta struct {
+	version uint16 // Freezer table version descriptor
+	tailId  uint32 // The number of the earliest file
+	deleted uint64 // The number of items that have been removed from the table
+	hidden  uint64 // The number of items that have been hidden in the table
+}
+
+// newMetadata initializes the metadata object with the given parameters.
+func newMetadata(tailId uint32, deleted uint64, hidden uint64) *freezerTableMeta {
+	return &freezerTableMeta{
+		version: freezerVersion,
+		tailId:  tailId,
+		deleted: deleted,
+		hidden:  hidden,
+	}
+}
+
+// encodeMetadata encodes the given parameters as the freezer table metadata.
+func encodeMetadata(meta *freezerTableMeta) ([]byte, error) {
+	buffer := new(bytes.Buffer)
+	if err := rlp.Encode(buffer, meta.version); err != nil {
+		return nil, err
+	}
+	if err := rlp.Encode(buffer, meta.tailId); err != nil {
+		return nil, err
+	}
+	if err := rlp.Encode(buffer, meta.deleted); err != nil {
+		return nil, err
+	}
+	if err := rlp.Encode(buffer, meta.hidden); err != nil {
+		return nil, err
+	}
+	buffer.Write(make([]byte, metaLength-buffer.Len())) // Right pad zero bytes to the specified length
+	return buffer.Bytes(), nil
+}
+
+// decodeMetadata decodes the freezer-table metadata from the given
+// rlp stream.
+func decodeMetadata(r *rlp.Stream) (*freezerTableMeta, error) {
+	var version uint16
+	if err := r.Decode(&version); err != nil {
+		return nil, err
+	}
+	if version != freezerVersion {
+		return nil, newIncompatibleError(version)
+	}
+	var tailId uint32
+	if err := r.Decode(&tailId); err != nil {
+		return nil, err
+	}
+	var deleted, hidden uint64
+	if err := r.Decode(&deleted); err != nil {
+		return nil, err
+	}
+	if err := r.Decode(&hidden); err != nil {
+		return nil, err
+	}
+	return newMetadata(tailId, deleted, hidden), nil
+}
+
+// storeMetadata stores the metadata of the freezer table into the
+// given index file.
+func storeMetadata(index *os.File, meta *freezerTableMeta) error {
+	encoded, err := encodeMetadata(meta)
+	if err != nil {
+		return err
+	}
+	if _, err := index.WriteAt(encoded, 0); err != nil {
+		return err
+	}
+	return nil
+}
+
+// loadMetadata loads the metadata of the freezer table from the
+// given index file. Return the error if the version of loaded
+// metadata is not expected.
+func loadMetadata(index *os.File) (*freezerTableMeta, error) {
+	stat, err := index.Stat()
+	if err != nil {
+		return nil, err
+	}
+	if stat.Size() < metaLength {
+		return nil, newIncompatibleError(0)
+	}
+	buffer := make([]byte, metaLength)
+	if _, err := index.ReadAt(buffer, 0); err != nil {
+		return nil, err
+	}
+	return decodeMetadata(rlp.NewStream(bytes.NewReader(buffer), 0))
+}
+
+// upgradeV0TableIndex extracts the indexes from version-0 index file and
+// encodes/stores them into the latest version index file.
+func upgradeV0TableIndex(index *os.File) error {
+	// Create a temporary offset buffer to read indexEntry info
+	buffer := make([]byte, indexEntrySize)
+
+	// Read index zero, determine what file is the earliest
+	// and how many entries are deleted from the freezer table.
+	var first indexEntry
+	if _, err := index.ReadAt(buffer, 0); err != nil {
+		return err
+	}
+	first.unmarshalBinary(buffer)
+
+	encoded, err := encodeMetadata(newMetadata(first.filenum, uint64(first.offset), 0))
+	if err != nil {
+		return err
+	}
+	// Close the origin index file.
+	if err := index.Close(); err != nil {
+		return err
+	}
+	return copyFrom(index.Name(), index.Name(), indexEntrySize, func(f *os.File) error {
+		_, err := f.Write(encoded)
+		return err
+	})
+}
+
+// upgradeTableIndex upgrades the legacy index file to the latest version.
+// This function should be responsible for closing the origin index file
+// and return the re-opened one.
+func upgradeTableIndex(index *os.File, version uint16) (*os.File, *freezerTableMeta, error) {
+	switch version {
+	case 0:
+		if err := upgradeV0TableIndex(index); err != nil {
+			return nil, nil, err
+		}
+	default:
+		return nil, nil, errors.New("unknown freezer table index")
+	}
+	// Reopen the upgraded index file and load the metadata from it
+	index, err := os.Open(index.Name())
+	if err != nil {
+		return nil, nil, err
+	}
+	meta, err := loadMetadata(index)
+	if err != nil {
+		return nil, nil, err
+	}
+	return index, meta, nil
+}
+
+// repairTableIndex repairs the given index file of freezer table and returns
+// the stored metadata inside. If the index file is be rewritten, the function
+// should be responsible for closing the origin one and return the new handler.
+// If the table is empty, commit the empty metadata;
+// If the table is legacy, upgrade it to the latest version;
+func repairTableIndex(index *os.File) (*os.File, *freezerTableMeta, error) {
+	stat, err := index.Stat()
+	if err != nil {
+		return nil, nil, err
+	}
+	if stat.Size() == 0 {
+		meta := newMetadata(0, 0, 0)
+		if err := storeMetadata(index, meta); err != nil {
+			return nil, nil, err
+		}
+		// Shift file cursor to the end for next write operation
+		_, err = index.Seek(0, 2)
+		if err != nil {
+			return nil, nil, err
+		}
+		return index, meta, nil
+	}
+	meta, err := loadMetadata(index)
+	if err != nil {
+		if !errors.Is(err, errIncompatibleVersion) {
+			return nil, nil, err
+		}
+		index, meta, err = upgradeTableIndex(index, err.(*incompatibleError).version)
+	}
+	if err != nil {
+		return nil, nil, err
+	}
+	return index, meta, nil
+}

--- a/core/rawdb/freezer_meta.go
+++ b/core/rawdb/freezer_meta.go
@@ -88,12 +88,7 @@ func writeMetadata(file *os.File, meta *freezerTableMeta) error {
 	if err != nil {
 		return err
 	}
-	encoded, err := rlp.EncodeToBytes(meta)
-	if err != nil {
-		return err
-	}
-	_, err = file.Write(encoded)
-	return err
+	return rlp.Encode(file, meta)
 }
 
 // loadMetadata loads the metadata from the given metadata file.

--- a/core/rawdb/freezer_meta.go
+++ b/core/rawdb/freezer_meta.go
@@ -20,6 +20,7 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 
 	"github.com/ethereum/go-ethereum/rlp"
@@ -175,7 +176,7 @@ func upgradeTableIndex(index *os.File, version uint16) (*os.File, *freezerTableM
 			return nil, nil, err
 		}
 	default:
-		return nil, nil, errors.New("unknown freezer table index")
+		return nil, nil, errors.New("unknown freezer table version")
 	}
 	// Reopen the upgraded index file and load the metadata from it
 	index, err := os.Open(index.Name())
@@ -205,7 +206,7 @@ func repairTableIndex(index *os.File) (*os.File, *freezerTableMeta, error) {
 			return nil, nil, err
 		}
 		// Shift file cursor to the end for next write operation
-		_, err = index.Seek(0, 2)
+		_, err = index.Seek(0, io.SeekEnd)
 		if err != nil {
 			return nil, nil, err
 		}

--- a/core/rawdb/freezer_meta_test.go
+++ b/core/rawdb/freezer_meta_test.go
@@ -1,0 +1,69 @@
+// Copyright 2022 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>
+
+package rawdb
+
+import (
+	"errors"
+	"io/ioutil"
+	"os"
+	"testing"
+)
+
+func TestStoreLoadFreezerTableMeta(t *testing.T) {
+	var cases = []struct {
+		version   uint16
+		deleted   uint64
+		hidden    uint64
+		expectErr error
+	}{
+		{
+			freezerVersion, 100, 200, nil,
+		},
+		{
+			0, 100, 200, errIncompatibleVersion, // legacy version
+		},
+	}
+	for _, c := range cases {
+		f, err := ioutil.TempFile(os.TempDir(), "*")
+		if err != nil {
+			t.Fatalf("Failed to create file %v", err)
+		}
+		err = storeMetadata(f, &freezerTableMeta{
+			version: c.version,
+			deleted: c.deleted,
+			hidden:  c.hidden,
+		})
+		if err != nil {
+			t.Fatalf("Failed to store metadata %v", err)
+		}
+		meta, err := loadMetadata(f)
+		if !errors.Is(err, c.expectErr) {
+			t.Fatalf("Unexpected error %v", err)
+		}
+		if c.expectErr == nil {
+			if meta.version != c.version {
+				t.Fatalf("Unexpected version field")
+			}
+			if meta.deleted != c.deleted {
+				t.Fatalf("Unexpected deleted field")
+			}
+			if meta.hidden != c.hidden {
+				t.Fatalf("Unexpected hidden field")
+			}
+		}
+	}
+}

--- a/core/rawdb/freezer_meta_test.go
+++ b/core/rawdb/freezer_meta_test.go
@@ -48,14 +48,14 @@ func TestInitializeFreezerTableMeta(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to create file %v", err)
 	}
-	meta, err := loadMetadata(f, uint64(0))
+	meta, err := loadMetadata(f, uint64(100))
 	if err != nil {
 		t.Fatalf("Failed to read metadata %v", err)
 	}
 	if meta.version != freezerVersion {
 		t.Fatalf("Unexpected version field")
 	}
-	if meta.VirtualTail != uint64(0) {
+	if meta.VirtualTail != uint64(100) {
 		t.Fatalf("Unexpected virtual tail field")
 	}
 }

--- a/core/rawdb/freezer_meta_test.go
+++ b/core/rawdb/freezer_meta_test.go
@@ -35,7 +35,7 @@ func TestReadWriteFreezerTableMeta(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to read metadata %v", err)
 	}
-	if meta.version != freezerVersion {
+	if meta.Version != freezerVersion {
 		t.Fatalf("Unexpected version field")
 	}
 	if meta.VirtualTail != uint64(100) {
@@ -52,7 +52,7 @@ func TestInitializeFreezerTableMeta(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to read metadata %v", err)
 	}
-	if meta.version != freezerVersion {
+	if meta.Version != freezerVersion {
 		t.Fatalf("Unexpected version field")
 	}
 	if meta.VirtualTail != uint64(100) {

--- a/core/rawdb/freezer_table.go
+++ b/core/rawdb/freezer_table.go
@@ -515,15 +515,8 @@ func (t *freezerTable) truncateTail(items uint64) error {
 			filenum: newTailId,
 			offset:  uint32(newDeleted),
 		}
-		encoded := tailIndex.append(nil)
-		n, err := f.Write(encoded)
-		if err != nil {
-			return err
-		}
-		if n != len(encoded) {
-			return fmt.Errorf("faield to write zero index %d %d", len(encoded), n)
-		}
-		return nil
+		_, err := f.Write(tailIndex.append(nil))
+		return err
 	})
 	if err != nil {
 		return err
@@ -531,12 +524,10 @@ func (t *freezerTable) truncateTail(items uint64) error {
 	if err := t.index.Close(); err != nil {
 		return err
 	}
-	offsets, err := openFreezerFileForAppend(t.index.Name())
+	t.index, err = openFreezerFileForAppend(t.index.Name())
 	if err != nil {
 		return err
 	}
-	t.index = offsets
-
 	// Release any files before the current tail
 	t.tailId = newTailId
 	atomic.StoreUint64(&t.itemOffset, newDeleted)

--- a/core/rawdb/freezer_table.go
+++ b/core/rawdb/freezer_table.go
@@ -896,7 +896,7 @@ func (t *freezerTable) dumpIndex(w io.Writer, start, stop int64) {
 		fmt.Fprintf(w, "Failed to decode freezer table %v\n", err)
 		return
 	}
-	fmt.Fprintf(w, "Version %d deleted %d, hidden %d\n", meta.version, atomic.LoadUint64(&t.itemOffset), atomic.LoadUint64(&t.itemHidden))
+	fmt.Fprintf(w, "Version %d deleted %d, hidden %d\n", meta.Version, atomic.LoadUint64(&t.itemOffset), atomic.LoadUint64(&t.itemHidden))
 
 	buf := make([]byte, indexEntrySize)
 

--- a/core/rawdb/freezer_table.go
+++ b/core/rawdb/freezer_table.go
@@ -94,10 +94,10 @@ type freezerTable struct {
 	items      uint64 // Number of items stored in the table (including items removed from tail)
 	itemOffset uint64 // Number of items removed from the table
 
-	// itemHidden is the number of items marked as deleted they are not removed
-	// from the table yet. Since the tail deletion is only supported at file level
-	// which means the actual deletion will be delayed until the total "marked as
-	// deleted" data reach the threshold. Before that these items will be hidden
+	// itemHidden is the number of items marked as deleted which are not removed
+	// from the table yet. Tail deletion is only supported at file level which
+	// means the actual deletion will be delayed until the total "marked as
+	// deleted" data reaches the threshold. Before that these items will be hidden
 	// to prevent being visited again.
 	itemHidden uint64
 

--- a/core/rawdb/freezer_table.go
+++ b/core/rawdb/freezer_table.go
@@ -371,13 +371,6 @@ func (t *freezerTable) preopen() (err error) {
 	return err
 }
 
-// tail returns the index of the first stored item in the freezer table.
-// It can also be interpreted as the number of items marked as deleted
-// from the tail.
-func (t *freezerTable) tail() uint64 {
-	return atomic.LoadUint64(&t.itemHidden)
-}
-
 // truncateHead discards any recent data above the provided threshold number.
 func (t *freezerTable) truncateHead(items uint64) error {
 	t.lock.Lock()
@@ -822,7 +815,7 @@ func (t *freezerTable) retrieveItems(start, count, maxBytes uint64) ([]byte, []i
 // has returns an indicator whether the specified number data is still accessible
 // in the freezer table.
 func (t *freezerTable) has(number uint64) bool {
-	return atomic.LoadUint64(&t.items) > number && t.tail() <= number
+	return atomic.LoadUint64(&t.items) > number && atomic.LoadUint64(&t.itemHidden) <= number
 }
 
 // size returns the total data size in the freezer table.

--- a/core/rawdb/freezer_table.go
+++ b/core/rawdb/freezer_table.go
@@ -46,7 +46,7 @@ var (
 	errNotSupported = errors.New("this operation is not supported")
 )
 
-// indexEntry contains the number/id of the file that the data resides in, as well as the
+// indexEntry contains the number/id of the file that the data resides in, aswell as the
 // offset within the file to the end of the data.
 // In serialized form, the filenum is stored as uint16.
 type indexEntry struct {

--- a/core/rawdb/freezer_table_test.go
+++ b/core/rawdb/freezer_table_test.go
@@ -760,7 +760,7 @@ func TestTruncateTail(t *testing.T) {
 	})
 
 	// truncate all, the entire freezer should be deleted
-	f.truncateTail(6)
+	f.truncateTail(7)
 	checkRetrieveError(t, f, map[uint64]error{
 		0: errOutOfBounds,
 		1: errOutOfBounds,
@@ -768,13 +768,11 @@ func TestTruncateTail(t *testing.T) {
 		3: errOutOfBounds,
 		4: errOutOfBounds,
 		5: errOutOfBounds,
-	})
-	checkRetrieve(t, f, map[uint64][]byte{
-		6: getChunk(20, 0x11),
+		6: errOutOfBounds,
 	})
 }
 
-func TestTruncateHeadBelowTail(t *testing.T) {
+func TestTruncateHead(t *testing.T) {
 	t.Parallel()
 	rm, wm, sg := metrics.NewMeter(), metrics.NewMeter(), metrics.NewGauge()
 	fname := fmt.Sprintf("truncate-head-blow-tail-%d", rand.Uint64())
@@ -821,12 +819,6 @@ func TestTruncateHeadBelowTail(t *testing.T) {
 		4: getChunk(20, 0xbb),
 		5: getChunk(20, 0xaa),
 		6: getChunk(20, 0x11),
-	})
-
-	f.truncateTail(5) // Lazy deleted the item-4, it's hidden
-	f.truncateHead(5) // New head is reset to item-4
-	checkRetrieveError(t, f, map[uint64]error{
-		4: errOutOfBounds, // Hidden item
 	})
 }
 

--- a/core/rawdb/freezer_table_test.go
+++ b/core/rawdb/freezer_table_test.go
@@ -663,7 +663,7 @@ func TestTruncateTail(t *testing.T) {
 	fname := fmt.Sprintf("truncate-tail-%d", rand.Uint64())
 
 	// Fill table
-	f, err := newTable(os.TempDir(), fname, rm, wm, sg, 40, true)
+	f, err := newTable(os.TempDir(), fname, rm, wm, sg, 40, true, false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -709,7 +709,7 @@ func TestTruncateTail(t *testing.T) {
 
 	// Reopen the table, the deletion information should be persisted as well
 	f.Close()
-	f, err = newTable(os.TempDir(), fname, rm, wm, sg, 40, true)
+	f, err = newTable(os.TempDir(), fname, rm, wm, sg, 40, true, false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -741,7 +741,7 @@ func TestTruncateTail(t *testing.T) {
 
 	// Reopen the table, the above testing should still pass
 	f.Close()
-	f, err = newTable(os.TempDir(), fname, rm, wm, sg, 40, true)
+	f, err = newTable(os.TempDir(), fname, rm, wm, sg, 40, true, false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -780,7 +780,7 @@ func TestTruncateHeadBelowTail(t *testing.T) {
 	fname := fmt.Sprintf("truncate-head-blow-tail-%d", rand.Uint64())
 
 	// Fill table
-	f, err := newTable(os.TempDir(), fname, rm, wm, sg, 40, true)
+	f, err := newTable(os.TempDir(), fname, rm, wm, sg, 40, true, false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -838,8 +838,8 @@ func TestUpgradeLegacyFreezerTable(t *testing.T) {
 	defer os.Remove(f.Name())
 
 	index := &indexEntry{
-		filenum: 100,
-		offset:  200,
+		filenum: 0,
+		offset:  0,
 	}
 	encoded := index.append(nil)
 	f.Write(encoded)
@@ -851,10 +851,10 @@ func TestUpgradeLegacyFreezerTable(t *testing.T) {
 	if newf.Name() != f.Name() {
 		t.Fatal("Unexpected file name")
 	}
-	if meta.tailId != 100 {
-		t.Fatal("Unexpected tail file")
+	if meta.tailId != 0 {
+		t.Fatal("Unexpected tail file", meta.tailId)
 	}
-	if meta.deleted != 200 {
+	if meta.deleted != 0 {
 		t.Fatal("Unexpected deleted items")
 	}
 	if meta.hidden != 0 {

--- a/core/rawdb/freezer_test.go
+++ b/core/rawdb/freezer_test.go
@@ -186,7 +186,7 @@ func TestFreezerConcurrentModifyRetrieve(t *testing.T) {
 	wg.Wait()
 }
 
-// This test runs ModifyAncients and TruncateAncients concurrently with each other.
+// This test runs ModifyAncients and TruncateHead concurrently with each other.
 func TestFreezerConcurrentModifyTruncate(t *testing.T) {
 	f, dir := newFreezerForTesting(t, freezerTestTableDef)
 	defer os.RemoveAll(dir)
@@ -196,7 +196,7 @@ func TestFreezerConcurrentModifyTruncate(t *testing.T) {
 
 	for i := 0; i < 1000; i++ {
 		// First reset and write 100 items.
-		if err := f.TruncateAncients(0); err != nil {
+		if err := f.TruncateHead(0); err != nil {
 			t.Fatal("truncate failed:", err)
 		}
 		_, err := f.ModifyAncients(func(op ethdb.AncientWriteOp) error {
@@ -231,7 +231,7 @@ func TestFreezerConcurrentModifyTruncate(t *testing.T) {
 			wg.Done()
 		}()
 		go func() {
-			truncateErr = f.TruncateAncients(10)
+			truncateErr = f.TruncateHead(10)
 			wg.Done()
 		}()
 		go func() {

--- a/core/rawdb/freezer_utils.go
+++ b/core/rawdb/freezer_utils.go
@@ -1,0 +1,83 @@
+// Copyright 2022 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+package rawdb
+
+import (
+	"io"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+)
+
+// copyFrom copies data from 'srcPath' at offset 'offset' into 'destPath'.
+// The 'destPath' is created if it doesn't exist, otherwise it is overwritten.
+// Before the copy is executed, there is a callback can be registered to
+// manipulate the dest file.
+// It is perfectly valid to have destPath == srcPath.
+func copyFrom(srcPath, destPath string, offset uint64, before func(f *os.File) error) error {
+	// Create a temp file in the same dir where we want it to wind up
+	f, err := ioutil.TempFile(filepath.Dir(destPath), "*")
+	if err != nil {
+		return err
+	}
+	fname := f.Name()
+
+	// Clean up the leftover file
+	defer func() {
+		if f != nil {
+			f.Close()
+		}
+		os.Remove(fname)
+	}()
+
+	// Apply the given function if it's not nil before we copy
+	// the content from the src.
+	if before != nil {
+		if err := before(f); err != nil {
+			return err
+		}
+	}
+	// Open the source file
+	src, err := os.Open(srcPath)
+	if err != nil {
+		return err
+	}
+	if _, err = src.Seek(int64(offset), 0); err != nil {
+		src.Close()
+		return err
+	}
+	// io.Copy uses 32K buffer internally.
+	_, err = io.Copy(f, src)
+	if err != nil {
+		src.Close()
+		return err
+	}
+	// Rename the temporary file to the specified dest name.
+	// src may be same as dest, so needs to be closed before
+	// we do the final move.
+	src.Close()
+
+	if err := f.Close(); err != nil {
+		return err
+	}
+	f = nil
+
+	if err := os.Rename(fname, destPath); err != nil {
+		return err
+	}
+	return nil
+}

--- a/core/rawdb/freezer_utils_test.go
+++ b/core/rawdb/freezer_utils_test.go
@@ -1,0 +1,76 @@
+// Copyright 2022 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+package rawdb
+
+import (
+	"bytes"
+	"io/ioutil"
+	"os"
+	"testing"
+)
+
+func TestCopyFrom(t *testing.T) {
+	var (
+		content = []byte{0x1, 0x2, 0x3, 0x4, 0x5, 0x6, 0x7, 0x8}
+		prefix  = []byte{0x9, 0xa, 0xb, 0xc, 0xd, 0xf}
+	)
+	var cases = []struct {
+		src, dest   string
+		offset      uint64
+		writePrefix bool
+	}{
+		{"foo", "bar", 0, false},
+		{"foo", "bar", 1, false},
+		{"foo", "bar", 8, false},
+		{"foo", "foo", 0, false},
+		{"foo", "foo", 1, false},
+		{"foo", "foo", 8, false},
+		{"foo", "bar", 0, true},
+		{"foo", "bar", 1, true},
+		{"foo", "bar", 8, true},
+	}
+	for _, c := range cases {
+		ioutil.WriteFile(c.src, content, 0644)
+
+		if err := copyFrom(c.src, c.dest, c.offset, func(f *os.File) error {
+			if !c.writePrefix {
+				return nil
+			}
+			f.Write(prefix)
+			return nil
+		}); err != nil {
+			os.Remove(c.src)
+			t.Fatalf("Failed to copy %v", err)
+		}
+
+		blob, err := ioutil.ReadFile(c.dest)
+		if err != nil {
+			os.Remove(c.src)
+			os.Remove(c.dest)
+			t.Fatalf("Failed to read %v", err)
+		}
+		want := content[c.offset:]
+		if c.writePrefix {
+			want = append(prefix, want...)
+		}
+		if !bytes.Equal(blob, want) {
+			t.Fatal("Unexpected value")
+		}
+		os.Remove(c.src)
+		os.Remove(c.dest)
+	}
+}

--- a/core/rawdb/table.go
+++ b/core/rawdb/table.go
@@ -74,6 +74,12 @@ func (t *table) Ancients() (uint64, error) {
 	return t.db.Ancients()
 }
 
+// Tail is a noop passthrough that just forwards the request to the underlying
+// database.
+func (t *table) Tail() (uint64, error) {
+	return t.db.Tail()
+}
+
 // AncientSize is a noop passthrough that just forwards the request to the underlying
 // database.
 func (t *table) AncientSize(kind string) (uint64, error) {
@@ -89,10 +95,16 @@ func (t *table) ReadAncients(fn func(reader ethdb.AncientReader) error) (err err
 	return t.db.ReadAncients(fn)
 }
 
-// TruncateAncients is a noop passthrough that just forwards the request to the underlying
+// TruncateHead is a noop passthrough that just forwards the request to the underlying
 // database.
-func (t *table) TruncateAncients(items uint64) error {
-	return t.db.TruncateAncients(items)
+func (t *table) TruncateHead(items uint64) error {
+	return t.db.TruncateHead(items)
+}
+
+// TruncateTail is a noop passthrough that just forwards the request to the underlying
+// database.
+func (t *table) TruncateTail(items uint64) error {
+	return t.db.TruncateTail(items)
 }
 
 // Sync is a noop passthrough that just forwards the request to the underlying

--- a/ethdb/database.go
+++ b/ethdb/database.go
@@ -86,6 +86,10 @@ type AncientReader interface {
 	// Ancients returns the ancient item numbers in the ancient store.
 	Ancients() (uint64, error)
 
+	// Tail returns the number of first stored item in the freezer.
+	// This number can also be interpreted as the total deleted item numbers.
+	Tail() (uint64, error)
+
 	// AncientSize returns the ancient size of the specified category.
 	AncientSize(kind string) (uint64, error)
 }
@@ -106,8 +110,16 @@ type AncientWriter interface {
 	// The integer return value is the total size of the written data.
 	ModifyAncients(func(AncientWriteOp) error) (int64, error)
 
-	// TruncateAncients discards all but the first n ancient data from the ancient store.
-	TruncateAncients(n uint64) error
+	// TruncateHead discards all but the first n ancient data from the ancient store.
+	// After the truncation, the latest item can be accessed it item_n-1(start from 0).
+	TruncateHead(n uint64) error
+
+	// TruncateTail discards the first n ancient data from the ancient store. The already
+	// deleted items are ignored. After the truncation, the earliest item can be accessed
+	// is item_n(start from 0). The deleted items may not be removed from the ancient store
+	// immediately, but only when the accumulated deleted data reach the threshold then
+	// will be removed all together.
+	TruncateTail(n uint64) error
 
 	// Sync flushes all in-memory ancient store data to disk.
 	Sync() error


### PR DESCRIPTION
This PR introduces the tail deletion of freezer.

### File level deletion
The tail deletion is at file level by design. It means whenever data items at tail are deleted, they will not be **removed** from the file immediately. Instead they will be **hidden** until items in the tail data file are all deleted then the entire data file will be dropped.

### Reasons

**Performance**
The reason for designing this *lazy deletion* mechanism is mainly for saving cost of updating index file. The lookup in freezer is using item id to calculate the relative position in index file, read the data position info from the index file and finally read the data from data file. 

However in order to delete the tail items from the data file, all the remaining items in this data file must be shifted forward and all of them need to be re-indexed by modifying the corresponding position information in the index file. This action is super expensive. So deletion by file is a good choice in terms of avoiding re-index.

**Atomicity**
Another big reason for lazy deletion is it's easier to gain atomicity guarantee. The deletion procedure contains the mutation to index file and data file. These two mutations should be applied at the same time, or apply none of them.
 
In this design we only need to update the index file atomically. The de-referenced data file can be dropped any time, even after the crash. For sake of simplification, it's a big win.