### PR TITLE
core/vm, core/state/snapshot: remove unused code

### DIFF
--- a/core/vm/opcodes.go
+++ b/core/vm/opcodes.go
@@ -207,13 +207,6 @@ const (
 	LOG4
 )
 
-// unofficial opcodes used for parsing.
-const (
-	PUSH OpCode = 0xb0 + iota
-	DUP
-	SWAP
-)
-
 // 0xf0 range - closures.
 const (
 	CREATE       OpCode = 0xf0
@@ -391,10 +384,6 @@ var opCodeToString = map[OpCode]string{
 	STATICCALL:   "STATICCALL",
 	REVERT:       "REVERT",
 	SELFDESTRUCT: "SELFDESTRUCT",
-
-	PUSH: "PUSH",
-	DUP:  "DUP",
-	SWAP: "SWAP",
 }
 
 func (op OpCode) String() string {


### PR DESCRIPTION
This PR removes the 'wiper', which was used in an early version of snap sync to clean out snap data. It was deprecated since we figured out how to use the mostly-correct-but-partially-corrupt snapshot data without wiping it fully. 
This PR also removes some "unofficial opcodes used for parsing", which, actually, aren't used for parsing. 