### PR TITLE
clique: fix block number unmarshal

### DIFF
--- a/consensus/clique/api.go
+++ b/consensus/clique/api.go
@@ -196,7 +196,11 @@ func (sb *blockNumberOrHashOrRLP) UnmarshalJSON(data []byte) error {
 	if err := json.Unmarshal(data, &input); err != nil {
 		return err
 	}
-	sb.RLP = hexutil.MustDecode(input)
+	unhexed, err := hexutil.Decode(input)
+	if err != nil {
+		return err
+	}
+	sb.RLP = unhexed
 	return nil
 }
 

--- a/consensus/clique/api.go
+++ b/consensus/clique/api.go
@@ -196,11 +196,11 @@ func (sb *blockNumberOrHashOrRLP) UnmarshalJSON(data []byte) error {
 	if err := json.Unmarshal(data, &input); err != nil {
 		return err
 	}
-	unhexed, err := hexutil.Decode(input)
+	blob, err := hexutil.Decode(input)
 	if err != nil {
 		return err
 	}
-	sb.RLP = unhexed
+	sb.RLP = blob
 	return nil
 }
 


### PR DESCRIPTION
Doing `clique.getSigner('00ff')` (hex string without `0x`) in the console caused a crash