### PR TITLE
core/vm: Simplify Contract.GetByte function

### DIFF
--- a/core/vm/contract.go
+++ b/core/vm/contract.go
@@ -143,16 +143,11 @@ func (c *Contract) AsDelegate() *Contract {
 
 // GetOp returns the n'th element in the contract's byte array
 func (c *Contract) GetOp(n uint64) OpCode {
-	return OpCode(c.GetByte(n))
-}
-
-// GetByte returns the n'th byte in the contract's byte array
-func (c *Contract) GetByte(n uint64) byte {
 	if n < uint64(len(c.Code)) {
-		return c.Code[n]
+		return OpCode(c.Code[n])
 	}
 
-	return 0
+	return STOP
 }
 
 // Caller returns the caller of the contract.


### PR DESCRIPTION
Small cleanup to remove unneed extra helper + use `STOP` literal instead of `0`.