### PR TITLE
dockerfile: enable container to be run as non-root

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,7 @@ FROM alpine:latest
 
 RUN apk add --no-cache ca-certificates
 COPY --from=builder /go-ethereum/build/bin/geth /usr/local/bin/
+RUN mkdir -m 777 /.ethereum
 
 EXPOSE 8545 8546 30303 30303/udp
 ENTRYPOINT ["geth"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ FROM alpine:latest
 
 RUN apk add --no-cache ca-certificates
 COPY --from=builder /go-ethereum/build/bin/geth /usr/local/bin/
-RUN mkdir -m 777 /.ethereum
+RUN mkdir -m 777 /.ethereum /.ethash
 
 EXPOSE 8545 8546 30303 30303/udp
 ENTRYPOINT ["geth"]


### PR DESCRIPTION
### Why
Enable the the official docker container to be run as a non-root user. This allows people that want to run geth in Docker as non-root the option to do so and does not interfere with existing installations. From [22861](https://github.com/ethereum/go-ethereum/pull/22861) I see that creating an non-root user is not an option.

### Current container behavior
Trying to run as non-root with the current docker image fails.
```
$ docker run -ti --rm --user 65534 ethereum/client-go:v1.10.13 --ropsten
INFO [11-25|14:41:11.846] Starting Geth on Ropsten testnet...
INFO [11-25|14:41:11.849] Maximum peer count                       ETH=50 LES=0 total=50
INFO [11-25|14:41:11.850] Smartcard socket not found, disabling    err="stat /run/pcscd/pcscd.comm: no such file or directory"
Fatal: Failed to create the protocol stack: mkdir /.ethereum: permission denied
```

### New container behavior
A simple way to make it possible to run as non-root is to just create the `/.ethereum` directory in the Dockerfile. I have tested syncing Ropsten with this image running as non-root and as far as I can tell it works as expected. The resulting image also runs as expected as root.
```
docker build -t ethereum-dev:latest .
docker run -ti --rm --user 65534 ethereum-dev:latest --ropsten
```

### Alternatives
* There is an alternative to this to follow the [Red Hat Openshift](https://docs.openshift.com/container-platform/4.9/openshift_images/create-images.html) method of mapping UIDs to user accounts in an entrypoint script. If that is interesting I can create a PR for it.