### PR TITLE
core/vm: Rename opSuicide to opSelfdestruct

### DIFF
--- a/core/vm/instructions.go
+++ b/core/vm/instructions.go
@@ -793,7 +793,7 @@ func opStop(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]byt
 	return nil, errStopToken
 }
 
-func opSuicide(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]byte, error) {
+func opSelfdestruct(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]byte, error) {
 	beneficiary := scope.Stack.pop()
 	balance := interpreter.evm.StateDB.GetBalance(scope.Contract.Address())
 	interpreter.evm.StateDB.AddBalance(beneficiary.Bytes20(), balance)

--- a/core/vm/jump_table.go
+++ b/core/vm/jump_table.go
@@ -1006,7 +1006,7 @@ func newFrontierInstructionSet() JumpTable {
 			memorySize: memoryReturn,
 		},
 		SELFDESTRUCT: {
-			execute:    opSuicide,
+			execute:    opSelfdestruct,
 			dynamicGas: gasSelfdestruct,
 			minStack:   minStack(1, 0),
 			maxStack:   maxStack(1, 0),


### PR DESCRIPTION
The opcode was renamed in the codebase in 2017, but the functions were kept unchanged.

There are many other places where `suicide` is used as a term, including a lot in `core/state` (such as `StateDB.Suicide`) and the `Suicide`/`HasSuicided` interface in `core/vm`.  The nitpicker in me would try to rename all those, but that may be too much for little benefit. 

Let me know if this change here is not very useful and I'll avoid doing anything similar later.