### PR TITLE
core, core/rawdb: fix transaction indexing

### DIFF
--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -2204,7 +2204,14 @@ func (bc *BlockChain) maintainTxIndex(ancients uint64) {
 		// If a previous indexing existed, make sure that we fill in any missing entries
 		if bc.txLookupLimit == 0 || head < bc.txLookupLimit {
 			if *tail > 0 {
-				rawdb.IndexTransactions(bc.db, 0, *tail, bc.quit)
+				// It can happen when chain is rewound to a historical point which
+				// is even lower than the indexes tail, recap the indexing target
+				// to new head to avoid reading non-existent block bodies.
+				end := *tail
+				if end > head+1 {
+					end = head+1
+				}
+				rawdb.IndexTransactions(bc.db, 0, end, bc.quit)
 			}
 			return
 		}

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -2209,7 +2209,7 @@ func (bc *BlockChain) maintainTxIndex(ancients uint64) {
 				// to new head to avoid reading non-existent block bodies.
 				end := *tail
 				if end > head+1 {
-					end = head+1
+					end = head + 1
 				}
 				rawdb.IndexTransactions(bc.db, 0, end, bc.quit)
 			}

--- a/core/rawdb/chain_iterator.go
+++ b/core/rawdb/chain_iterator.go
@@ -247,7 +247,8 @@ func indexTransactions(db ethdb.Database, from uint64, to uint64, interrupt chan
 	}
 }
 
-// IndexTransactions creates txlookup indices of the specified block range.
+// IndexTransactions creates txlookup indices of the specified block range. The from
+// is included while to is excluded.
 //
 // This function iterates canonical chain in reverse order, it has one main advantage:
 // We can write tx index tail flag periodically even without the whole indexing
@@ -339,6 +340,7 @@ func unindexTransactions(db ethdb.Database, from uint64, to uint64, interrupt ch
 }
 
 // UnindexTransactions removes txlookup indices of the specified block range.
+// The from is included while to is excluded.
 //
 // There is a passed channel, the whole procedure will be interrupted if any
 // signal received.


### PR DESCRIPTION
This PR fixes a special corner case in transaction indexing.

When the chain is rewound by `SetHead` to a historical point which is even lower than the transaction indexes tail, then system will report `Failed to decode block body` error all the time, because the relevant blocks are already deleted.

In order to avoid this "non-critical-but-annoying" issue, we can recap the indexing target to `head+1`(to is excluded, so it means indexing transactions from 0 to head).