### PR TITLE
tests: external evm benchmarks

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2,3 +2,7 @@
 	path = tests/testdata
 	url = https://github.com/ethereum/tests
 	shallow = true
+[submodule "evm-benchmarks"]
+	path = tests/evm-benchmarks
+	url = https://github.com/ipsilon/evm-benchmarks
+	shallow = true

--- a/tests/init_test.go
+++ b/tests/init_test.go
@@ -41,6 +41,7 @@ var (
 	transactionTestDir = filepath.Join(baseDir, "TransactionTests")
 	rlpTestDir         = filepath.Join(baseDir, "RLPTests")
 	difficultyTestDir  = filepath.Join(baseDir, "BasicTests")
+	benchmarksDir      = filepath.Join(".", "evm-benchmarks", "benchmarks")
 )
 
 func readJSON(reader io.Reader, value interface{}) error {


### PR DESCRIPTION
I converted evmone's benchmarks to StateTest format and they are available at https://github.com/ipsilon/evm-benchmarks. Here added as a git submodule. We are still discussing how exactly extract and maintain the benchmark suite outside of the evmone project.

Then I copied a lot of code from `TestState()` to create `BenchmarkState()` with the goal to use the lowest EVM execute function possible. I stopped at `EVM.Call()` but I believe even `Interpreter.Run()` is possible.

If some refactoring is done, some code can be shared between `TestState()` and `BenchmarkState()`. But the test runner is quite convoluted with `reflect` being used at some level...

```
go test -run - -bench='.*' ./tests/...
```