### PR TITLE
core/evm: Random opcode (EIP-4399)

### DIFF
--- a/cmd/evm/internal/t8ntool/execution.go
+++ b/cmd/evm/internal/t8ntool/execution.go
@@ -67,6 +67,7 @@ type ommer struct {
 type stEnv struct {
 	Coinbase         common.Address                      `json:"currentCoinbase"   gencodec:"required"`
 	Difficulty       *big.Int                            `json:"currentDifficulty"`
+	Random           *big.Int                            `json:"currentRandom"`
 	ParentDifficulty *big.Int                            `json:"parentDifficulty"`
 	GasLimit         uint64                              `json:"currentGasLimit"   gencodec:"required"`
 	Number           uint64                              `json:"currentNumber"     gencodec:"required"`
@@ -81,6 +82,7 @@ type stEnv struct {
 type stEnvMarshaling struct {
 	Coinbase         common.UnprefixedAddress
 	Difficulty       *math.HexOrDecimal256
+	Random           *math.HexOrDecimal256
 	ParentDifficulty *math.HexOrDecimal256
 	GasLimit         math.HexOrDecimal64
 	Number           math.HexOrDecimal64

--- a/cmd/evm/internal/t8ntool/gen_stenv.go
+++ b/cmd/evm/internal/t8ntool/gen_stenv.go
@@ -18,6 +18,7 @@ func (s stEnv) MarshalJSON() ([]byte, error) {
 	type stEnv struct {
 		Coinbase         common.UnprefixedAddress            `json:"currentCoinbase"   gencodec:"required"`
 		Difficulty       *math.HexOrDecimal256               `json:"currentDifficulty"`
+		Random           *math.HexOrDecimal256               `json:"currentRandom"`
 		ParentDifficulty *math.HexOrDecimal256               `json:"parentDifficulty"`
 		GasLimit         math.HexOrDecimal64                 `json:"currentGasLimit"   gencodec:"required"`
 		Number           math.HexOrDecimal64                 `json:"currentNumber"     gencodec:"required"`
@@ -31,6 +32,7 @@ func (s stEnv) MarshalJSON() ([]byte, error) {
 	var enc stEnv
 	enc.Coinbase = common.UnprefixedAddress(s.Coinbase)
 	enc.Difficulty = (*math.HexOrDecimal256)(s.Difficulty)
+	enc.Random = (*math.HexOrDecimal256)(s.Random)
 	enc.ParentDifficulty = (*math.HexOrDecimal256)(s.ParentDifficulty)
 	enc.GasLimit = math.HexOrDecimal64(s.GasLimit)
 	enc.Number = math.HexOrDecimal64(s.Number)
@@ -48,6 +50,7 @@ func (s *stEnv) UnmarshalJSON(input []byte) error {
 	type stEnv struct {
 		Coinbase         *common.UnprefixedAddress           `json:"currentCoinbase"   gencodec:"required"`
 		Difficulty       *math.HexOrDecimal256               `json:"currentDifficulty"`
+		Random           *math.HexOrDecimal256               `json:"currentRandom"`
 		ParentDifficulty *math.HexOrDecimal256               `json:"parentDifficulty"`
 		GasLimit         *math.HexOrDecimal64                `json:"currentGasLimit"   gencodec:"required"`
 		Number           *math.HexOrDecimal64                `json:"currentNumber"     gencodec:"required"`
@@ -68,6 +71,9 @@ func (s *stEnv) UnmarshalJSON(input []byte) error {
 	s.Coinbase = common.Address(*dec.Coinbase)
 	if dec.Difficulty != nil {
 		s.Difficulty = (*big.Int)(dec.Difficulty)
+	}
+	if dec.Random != nil {
+		s.Random = (*big.Int)(dec.Random)
 	}
 	if dec.ParentDifficulty != nil {
 		s.ParentDifficulty = (*big.Int)(dec.ParentDifficulty)

--- a/consensus/beacon/consensus.go
+++ b/consensus/beacon/consensus.go
@@ -43,7 +43,6 @@ var (
 // error types into the consensus package.
 var (
 	errTooManyUncles    = errors.New("too many uncles")
-	errInvalidMixDigest = errors.New("invalid mix digest")
 	errInvalidNonce     = errors.New("invalid nonce")
 	errInvalidUncleHash = errors.New("invalid uncle hash")
 )
@@ -182,10 +181,7 @@ func (beacon *Beacon) verifyHeader(chain consensus.ChainHeaderReader, header, pa
 	if len(header.Extra) > 32 {
 		return fmt.Errorf("extra-data longer than 32 bytes (%d)", len(header.Extra))
 	}
-	// Verify the seal parts. Ensure the mixhash, nonce and uncle hash are the expected value.
-	if header.MixDigest != (common.Hash{}) {
-		return errInvalidMixDigest
-	}
+	// Verify the seal parts. Ensure the nonce and uncle hash are the expected value.
 	if header.Nonce != beaconNonce {
 		return errInvalidNonce
 	}

--- a/core/blockchain_reader.go
+++ b/core/blockchain_reader.go
@@ -346,12 +346,16 @@ func (bc *BlockChain) Genesis() *types.Block {
 
 // GetVMConfig returns the block chain VM config.
 func (bc *BlockChain) GetVMConfig() *vm.Config {
-	return &bc.vmConfig
+	bc.vmConfigMu.RLock()
+	defer bc.vmConfigMu.RUnlock()
+	copy := bc.vmConfig
+	return &copy
 }
 
 // SetVMConfig sets the vm config.
-// Warning: might not be threadsafe with other components
 func (bc *BlockChain) SetVMConfig(config vm.Config) {
+	bc.vmConfigMu.Lock()
+	defer bc.vmConfigMu.Unlock()
 	bc.vmConfig = config
 }
 

--- a/core/blockchain_reader.go
+++ b/core/blockchain_reader.go
@@ -345,11 +345,10 @@ func (bc *BlockChain) Genesis() *types.Block {
 }
 
 // GetVMConfig returns the block chain VM config.
-func (bc *BlockChain) GetVMConfig() *vm.Config {
+func (bc *BlockChain) GetVMConfig() vm.Config {
 	bc.vmConfigMu.RLock()
 	defer bc.vmConfigMu.RUnlock()
-	copy := bc.vmConfig
-	return &copy
+	return bc.vmConfig
 }
 
 // SetVMConfig sets the vm config.

--- a/core/blockchain_reader.go
+++ b/core/blockchain_reader.go
@@ -349,6 +349,12 @@ func (bc *BlockChain) GetVMConfig() *vm.Config {
 	return &bc.vmConfig
 }
 
+// SetVMConfig sets the vm config.
+// Warning: might not be threadsafe with other components
+func (bc *BlockChain) SetVMConfig(config vm.Config) {
+	bc.vmConfig = config
+}
+
 // SetTxLookupLimit is responsible for updating the txlookup limit to the
 // original one stored in db if the new mismatches with the old one.
 func (bc *BlockChain) SetTxLookupLimit(limit uint64) {

--- a/core/evm.go
+++ b/core/evm.go
@@ -61,6 +61,7 @@ func NewEVMBlockContext(header *types.Header, chain ChainContext, author *common
 		Difficulty:  new(big.Int).Set(header.Difficulty),
 		BaseFee:     baseFee,
 		GasLimit:    header.GasLimit,
+		Random:      header.MixDigest,
 	}
 }
 

--- a/core/genesis.go
+++ b/core/genesis.go
@@ -294,7 +294,7 @@ func (g *Genesis) ToBlock(db ethdb.Database) *types.Block {
 	if g.GasLimit == 0 {
 		head.GasLimit = params.GenesisGasLimit
 	}
-	if g.Difficulty == nil {
+	if g.Difficulty == nil && g.Mixhash == (common.Hash{}) {
 		head.Difficulty = params.GenesisDifficulty
 	}
 	if g.Config != nil && g.Config.IsLondon(common.Big0) {

--- a/core/vm/evm.go
+++ b/core/vm/evm.go
@@ -75,6 +75,7 @@ type BlockContext struct {
 	Time        *big.Int       // Provides information for TIME
 	Difficulty  *big.Int       // Provides information for DIFFICULTY
 	BaseFee     *big.Int       // Provides information for BASEFEE
+	Random      common.Hash    // Provides information for RANDOM
 }
 
 // TxContext provides the EVM with information about a transaction.

--- a/core/vm/instructions.go
+++ b/core/vm/instructions.go
@@ -477,6 +477,12 @@ func opDifficulty(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) 
 	return nil, nil
 }
 
+func opRandom(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]byte, error) {
+	v := new(uint256.Int).SetBytes((interpreter.evm.Context.Random.Bytes()))
+	scope.Stack.push(v)
+	return nil, nil
+}
+
 func opGasLimit(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]byte, error) {
 	scope.Stack.push(new(uint256.Int).SetUint64(interpreter.evm.Context.GasLimit))
 	return nil, nil

--- a/core/vm/instructions_test.go
+++ b/core/vm/instructions_test.go
@@ -21,6 +21,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
+	"math/big"
 	"testing"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -651,6 +652,39 @@ func TestCreate2Addreses(t *testing.T) {
 		expected := common.BytesToAddress(common.FromHex(tt.expected))
 		if !bytes.Equal(expected.Bytes(), address.Bytes()) {
 			t.Errorf("test %d: expected %s, got %s", i, expected.String(), address.String())
+		}
+	}
+}
+
+func TestRandom(t *testing.T) {
+	type testcase struct {
+		name   string
+		random common.Hash
+	}
+
+	for _, tt := range []testcase{
+		{name: "empty hash", random: common.Hash{}},
+		{name: "1", random: common.Hash{0}},
+		{name: "emptyCodeHash", random: emptyCodeHash},
+		{name: "hash(0x010203)", random: crypto.Keccak256Hash([]byte{0x01, 0x02, 0x03})},
+	} {
+		var (
+			env            = NewEVM(BlockContext{Random: tt.random}, TxContext{}, nil, params.TestChainConfig, Config{RandomOpcode: true})
+			stack          = newstack()
+			pc             = uint64(0)
+			evmInterpreter = env.interpreter
+		)
+		opRandom(&pc, evmInterpreter, &ScopeContext{nil, stack, nil})
+		if len(stack.data) != 1 {
+			t.Errorf("Expected one item on stack after %v, got %d: ", tt.name, len(stack.data))
+		}
+		actual := stack.pop()
+		expected, overflow := uint256.FromBig(new(big.Int).SetBytes(tt.random.Bytes()))
+		if overflow {
+			t.Errorf("Testcase %v: invalid overflow", tt.name)
+		}
+		if actual.Cmp(expected) != 0 {
+			t.Errorf("Testcase %v: expected  %x, got %x", tt.name, expected, actual)
 		}
 	}
 }

--- a/core/vm/interpreter.go
+++ b/core/vm/interpreter.go
@@ -29,6 +29,7 @@ type Config struct {
 	Debug                   bool      // Enables debugging
 	Tracer                  EVMLogger // Opcode logger
 	NoBaseFee               bool      // Forces the EIP-1559 baseFee to 0 (needed for 0 price calls)
+	RandomOpcode            bool      // Enables the random opcode
 	EnablePreimageRecording bool      // Enables recording of SHA3/keccak preimages
 
 	JumpTable *JumpTable // EVM instruction table, automatically populated if unset
@@ -69,6 +70,8 @@ func NewEVMInterpreter(evm *EVM, cfg Config) *EVMInterpreter {
 	// If jump table was not initialised we set the default one.
 	if cfg.JumpTable == nil {
 		switch {
+		case cfg.RandomOpcode:
+			cfg.JumpTable = &mergeInstructionSet
 		case evm.chainRules.IsLondon:
 			cfg.JumpTable = &londonInstructionSet
 		case evm.chainRules.IsBerlin:

--- a/core/vm/jump_table.go
+++ b/core/vm/jump_table.go
@@ -54,6 +54,7 @@ var (
 	istanbulInstructionSet         = newIstanbulInstructionSet()
 	berlinInstructionSet           = newBerlinInstructionSet()
 	londonInstructionSet           = newLondonInstructionSet()
+	mergeInstructionSet            = newMergeInstructionSet()
 )
 
 // JumpTable contains the EVM opcodes supported at a given fork.
@@ -75,6 +76,17 @@ func validate(jt JumpTable) JumpTable {
 		}
 	}
 	return jt
+}
+
+func newMergeInstructionSet() JumpTable {
+	instructionSet := newLondonInstructionSet()
+	instructionSet[RANDOM] = &operation{
+		execute:     opRandom,
+		constantGas: GasQuickStep,
+		minStack:    minStack(0, 1),
+		maxStack:    maxStack(0, 1),
+	}
+	return validate(instructionSet)
 }
 
 // newLondonInstructionSet returns the frontier, homestead, byzantium,

--- a/core/vm/opcodes.go
+++ b/core/vm/opcodes.go
@@ -99,6 +99,7 @@ const (
 	CHAINID     OpCode = 0x46
 	SELFBALANCE OpCode = 0x47
 	BASEFEE     OpCode = 0x48
+	RANDOM      OpCode = 0x44 // Same as DIFFICULTY
 )
 
 // 0x50 range - 'storage' and execution.
@@ -275,7 +276,7 @@ var opCodeToString = map[OpCode]string{
 	COINBASE:    "COINBASE",
 	TIMESTAMP:   "TIMESTAMP",
 	NUMBER:      "NUMBER",
-	DIFFICULTY:  "DIFFICULTY",
+	DIFFICULTY:  "DIFFICULTY", // TODO (MariusVanDerWijden) rename to RANDOM post merge
 	GASLIMIT:    "GASLIMIT",
 	CHAINID:     "CHAINID",
 	SELFBALANCE: "SELFBALANCE",

--- a/eth/api_backend.go
+++ b/eth/api_backend.go
@@ -204,7 +204,8 @@ func (b *EthAPIBackend) GetTd(ctx context.Context, hash common.Hash) *big.Int {
 func (b *EthAPIBackend) GetEVM(ctx context.Context, msg core.Message, state *state.StateDB, header *types.Header, vmConfig *vm.Config) (*vm.EVM, func() error, error) {
 	vmError := func() error { return nil }
 	if vmConfig == nil {
-		vmConfig = b.eth.blockchain.GetVMConfig()
+		conf := b.eth.blockchain.GetVMConfig()
+		vmConfig = &conf
 	}
 	txContext := core.NewEVMTxContext(msg)
 	context := core.NewEVMBlockContext(header, b.eth.BlockChain(), nil)

--- a/eth/catalyst/api.go
+++ b/eth/catalyst/api.go
@@ -134,6 +134,7 @@ type blockExecutionEnv struct {
 
 func (env *blockExecutionEnv) commitTransaction(tx *types.Transaction, coinbase common.Address) error {
 	vmconfig := *env.chain.GetVMConfig()
+	vmconfig.RandomOpcode = true
 	snap := env.state.Snapshot()
 	receipt, err := core.ApplyTransaction(env.chain.Config(), env.chain, &coinbase, env.gasPool, env.state, env.header, tx, &env.header.GasUsed, vmconfig)
 	if err != nil {
@@ -276,6 +277,9 @@ func (api *ConsensusAPI) ExecutePayloadV1(params ExecutableDataV1) (ExecutePaylo
 	if td.Cmp(ttd) < 0 {
 		return api.invalid(), fmt.Errorf("can not execute payload on top of block with low td got: %v threshold %v", td, ttd)
 	}
+	conf := api.eth.BlockChain().GetVMConfig()
+	conf.RandomOpcode = true
+	api.eth.BlockChain().SetVMConfig(*conf)
 	if err := api.eth.BlockChain().InsertBlockWithoutSetHead(block); err != nil {
 		return api.invalid(), err
 	}
@@ -318,7 +322,11 @@ func (api *ConsensusAPI) assembleBlock(parentHash common.Hash, params *PayloadAt
 		GasLimit:   parent.GasLimit(), // Keep the gas limit constant in this prototype
 		Extra:      []byte{},          // TODO (MariusVanDerWijden) properly set extra data
 		Time:       params.Timestamp,
+		MixDigest:  params.Random,
 	}
+	conf := api.eth.BlockChain().GetVMConfig()
+	conf.RandomOpcode = true
+	api.eth.BlockChain().SetVMConfig(*conf)
 	if config := api.eth.BlockChain().Config(); config.IsLondon(header.Number) {
 		header.BaseFee = misc.CalcBaseFee(config, parent.Header())
 	}
@@ -432,6 +440,7 @@ func ExecutableDataToBlock(params ExecutableDataV1) (*types.Block, error) {
 		Time:        params.Timestamp,
 		BaseFee:     params.BaseFeePerGas,
 		Extra:       params.ExtraData,
+		MixDigest:   params.Random,
 		// TODO (MariusVanDerWijden) add params.Random to header once required
 	}
 	block := types.NewBlockWithHeader(header).WithBody(txs, nil /* uncles */)

--- a/eth/catalyst/api.go
+++ b/eth/catalyst/api.go
@@ -441,7 +441,6 @@ func ExecutableDataToBlock(params ExecutableDataV1) (*types.Block, error) {
 		BaseFee:     params.BaseFeePerGas,
 		Extra:       params.ExtraData,
 		MixDigest:   params.Random,
-		// TODO (MariusVanDerWijden) add params.Random to header once required
 	}
 	block := types.NewBlockWithHeader(header).WithBody(txs, nil /* uncles */)
 	if block.Hash() != params.BlockHash {

--- a/eth/catalyst/api.go
+++ b/eth/catalyst/api.go
@@ -133,7 +133,7 @@ type blockExecutionEnv struct {
 }
 
 func (env *blockExecutionEnv) commitTransaction(tx *types.Transaction, coinbase common.Address) error {
-	vmconfig := *env.chain.GetVMConfig()
+	vmconfig := env.chain.GetVMConfig()
 	vmconfig.RandomOpcode = true
 	snap := env.state.Snapshot()
 	receipt, err := core.ApplyTransaction(env.chain.Config(), env.chain, &coinbase, env.gasPool, env.state, env.header, tx, &env.header.GasUsed, vmconfig)
@@ -279,7 +279,7 @@ func (api *ConsensusAPI) ExecutePayloadV1(params ExecutableDataV1) (ExecutePaylo
 	}
 	conf := api.eth.BlockChain().GetVMConfig()
 	conf.RandomOpcode = true
-	api.eth.BlockChain().SetVMConfig(*conf)
+	api.eth.BlockChain().SetVMConfig(conf)
 	if err := api.eth.BlockChain().InsertBlockWithoutSetHead(block); err != nil {
 		return api.invalid(), err
 	}
@@ -326,7 +326,7 @@ func (api *ConsensusAPI) assembleBlock(parentHash common.Hash, params *PayloadAt
 	}
 	conf := api.eth.BlockChain().GetVMConfig()
 	conf.RandomOpcode = true
-	api.eth.BlockChain().SetVMConfig(*conf)
+	api.eth.BlockChain().SetVMConfig(conf)
 	if config := api.eth.BlockChain().Config(); config.IsLondon(header.Number) {
 		header.BaseFee = misc.CalcBaseFee(config, parent.Header())
 	}

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -773,7 +773,7 @@ func (w *worker) updateSnapshot() {
 func (w *worker) commitTransaction(tx *types.Transaction, coinbase common.Address) ([]*types.Log, error) {
 	snap := w.current.state.Snapshot()
 
-	receipt, err := core.ApplyTransaction(w.chainConfig, w.chain, &coinbase, w.current.gasPool, w.current.state, w.current.header, tx, &w.current.header.GasUsed, *w.chain.GetVMConfig())
+	receipt, err := core.ApplyTransaction(w.chainConfig, w.chain, &coinbase, w.current.gasPool, w.current.state, w.current.header, tx, &w.current.header.GasUsed, w.chain.GetVMConfig())
 	if err != nil {
 		w.current.state.RevertToSnapshot(snap)
 		return nil, err

--- a/params/config.go
+++ b/params/config.go
@@ -672,6 +672,7 @@ type Rules struct {
 
 // Rules ensures c's ChainID is not nil.
 func (c *ChainConfig) Rules(num *big.Int) Rules {
+	// TODO (MariusVanDerWijden) replace isMerge after the merge once we know the merge block
 	chainID := c.ChainID
 	if chainID == nil {
 		chainID = new(big.Int)

--- a/params/config.go
+++ b/params/config.go
@@ -672,7 +672,6 @@ type Rules struct {
 
 // Rules ensures c's ChainID is not nil.
 func (c *ChainConfig) Rules(num *big.Int) Rules {
-	// TODO (MariusVanDerWijden) replace isMerge after the merge once we know the merge block
 	chainID := c.ChainID
 	if chainID == nil {
 		chainID = new(big.Int)

--- a/tests/gen_stenv.go
+++ b/tests/gen_stenv.go
@@ -17,7 +17,8 @@ var _ = (*stEnvMarshaling)(nil)
 func (s stEnv) MarshalJSON() ([]byte, error) {
 	type stEnv struct {
 		Coinbase   common.UnprefixedAddress `json:"currentCoinbase"   gencodec:"required"`
-		Difficulty *math.HexOrDecimal256    `json:"currentDifficulty" gencodec:"required"`
+		Difficulty *math.HexOrDecimal256    `json:"currentDifficulty" gencodec:"optional"`
+		Random     *math.HexOrDecimal256    `json:"currentRandom" gencodec:"optional"`
 		GasLimit   math.HexOrDecimal64      `json:"currentGasLimit"   gencodec:"required"`
 		Number     math.HexOrDecimal64      `json:"currentNumber"     gencodec:"required"`
 		Timestamp  math.HexOrDecimal64      `json:"currentTimestamp"  gencodec:"required"`
@@ -26,6 +27,7 @@ func (s stEnv) MarshalJSON() ([]byte, error) {
 	var enc stEnv
 	enc.Coinbase = common.UnprefixedAddress(s.Coinbase)
 	enc.Difficulty = (*math.HexOrDecimal256)(s.Difficulty)
+	enc.Random = (*math.HexOrDecimal256)(s.Random)
 	enc.GasLimit = math.HexOrDecimal64(s.GasLimit)
 	enc.Number = math.HexOrDecimal64(s.Number)
 	enc.Timestamp = math.HexOrDecimal64(s.Timestamp)
@@ -37,7 +39,8 @@ func (s stEnv) MarshalJSON() ([]byte, error) {
 func (s *stEnv) UnmarshalJSON(input []byte) error {
 	type stEnv struct {
 		Coinbase   *common.UnprefixedAddress `json:"currentCoinbase"   gencodec:"required"`
-		Difficulty *math.HexOrDecimal256     `json:"currentDifficulty" gencodec:"required"`
+		Difficulty *math.HexOrDecimal256     `json:"currentDifficulty" gencodec:"optional"`
+		Random     *math.HexOrDecimal256     `json:"currentRandom" gencodec:"optional"`
 		GasLimit   *math.HexOrDecimal64      `json:"currentGasLimit"   gencodec:"required"`
 		Number     *math.HexOrDecimal64      `json:"currentNumber"     gencodec:"required"`
 		Timestamp  *math.HexOrDecimal64      `json:"currentTimestamp"  gencodec:"required"`
@@ -51,10 +54,12 @@ func (s *stEnv) UnmarshalJSON(input []byte) error {
 		return errors.New("missing required field 'currentCoinbase' for stEnv")
 	}
 	s.Coinbase = common.Address(*dec.Coinbase)
-	if dec.Difficulty == nil {
-		return errors.New("missing required field 'currentDifficulty' for stEnv")
+	if dec.Difficulty != nil {
+		s.Difficulty = (*big.Int)(dec.Difficulty)
 	}
-	s.Difficulty = (*big.Int)(dec.Difficulty)
+	if dec.Random != nil {
+		s.Random = (*big.Int)(dec.Random)
+	}
 	if dec.GasLimit == nil {
 		return errors.New("missing required field 'currentGasLimit' for stEnv")
 	}

--- a/tests/state_test_util.go
+++ b/tests/state_test_util.go
@@ -80,7 +80,8 @@ type stPostState struct {
 
 type stEnv struct {
 	Coinbase   common.Address `json:"currentCoinbase"   gencodec:"required"`
-	Difficulty *big.Int       `json:"currentDifficulty" gencodec:"required"`
+	Difficulty *big.Int       `json:"currentDifficulty" gencodec:"optional"`
+	Random     *big.Int       `json:"currentRandom" gencodec:"optional"`
 	GasLimit   uint64         `json:"currentGasLimit"   gencodec:"required"`
 	Number     uint64         `json:"currentNumber"     gencodec:"required"`
 	Timestamp  uint64         `json:"currentTimestamp"  gencodec:"required"`
@@ -90,6 +91,7 @@ type stEnv struct {
 type stEnvMarshaling struct {
 	Coinbase   common.UnprefixedAddress
 	Difficulty *math.HexOrDecimal256
+	Random     *math.HexOrDecimal256
 	GasLimit   math.HexOrDecimal64
 	Number     math.HexOrDecimal64
 	Timestamp  math.HexOrDecimal64
@@ -218,8 +220,12 @@ func (t *StateTest) RunNoVerify(subtest StateSubtest, vmconfig vm.Config, snapsh
 	context := core.NewEVMBlockContext(block.Header(), nil, &t.json.Env.Coinbase)
 	context.GetHash = vmTestBlockHash
 	context.BaseFee = baseFee
+	if t.json.Env.Random != nil {
+		vmconfig.RandomOpcode = true
+		context.Random = common.BigToHash(t.json.Env.Random)
+		context.Difficulty = nil
+	}
 	evm := vm.NewEVM(context, txContext, statedb, config, vmconfig)
-
 	// Execute the message.
 	snapshot := statedb.Snapshot()
 	gaspool := new(core.GasPool)
@@ -268,7 +274,7 @@ func MakePreState(db ethdb.Database, accounts core.GenesisAlloc, snapshotter boo
 }
 
 func (t *StateTest) genesis(config *params.ChainConfig) *core.Genesis {
-	return &core.Genesis{
+	genesis := &core.Genesis{
 		Config:     config,
 		Coinbase:   t.json.Env.Coinbase,
 		Difficulty: t.json.Env.Difficulty,
@@ -277,6 +283,12 @@ func (t *StateTest) genesis(config *params.ChainConfig) *core.Genesis {
 		Timestamp:  t.json.Env.Timestamp,
 		Alloc:      t.json.Pre,
 	}
+	if t.json.Env.Random != nil {
+		// Post-Merge
+		genesis.Mixhash = common.BigToHash(t.json.Env.Random)
+		genesis.Difficulty = nil
+	}
+	return genesis
 }
 
 func (tx *stTransaction) toMessage(ps stPostState, baseFee *big.Int) (core.Message, error) {


### PR DESCRIPTION
This PR implements EIP-4399, the RANDOM opcode post-merge.
Since we don't know the merge block number beforehand, we need to somehow signal to the EVM that the Random opcode should be used now. For that I've implemented the `SetVMConfig` method. Since the transition can happen both during block insertion over the API and during the sync, I needed to add a lock for the `vmConf`. Might not be the greatest way to do it (suggestions very welcome). I also pass the `vmConf` by value now, not by reference as it is dereferenced in all callers anyway.

Additionally I extended the StateTestUtil to be able to create state tests with the RANDOM opcode. An example for that later.

replaces #23985 

```
{"FuzzyVM-37426906-1385711810":
{"env":{"currentCoinbase":"b94f5374fce5edbc8e2a8697c15331677e6ebf0b","currentRandom":"0x1000000000000000000000000000000000000000000000000000000000000001","currentGasLimit":"0x26e1f476fe1e22","currentNumber":"0x1",
"currentTimestamp":"0x3e8","currentBaseFee":"0x3B","previousHash":"0x000000000000000000000000000000000000000000000000000000000000000"},
"pre":{
	"0x00000000000000000000000000000000b0b0face": {"code":"0x40600052","storage":{},"balance":"0x0","nonce":"0x0"},
	"0x000000000000000000000000000000ca1100f022": {"code":"0x444455","storage":{},"balance":"0x0","nonce":"0x0"},
	"0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b":{"code":"0x","storage":{},"balance":"0x3fffffffffffffff","nonce":"0x0"}
	},
"transaction":{"gasPrice":"0x80","nonce":"0x0","to":"0x000000000000000000000000000000ca1100f022","data":[""],"gasLimit":["0x1312d00"],"value":["0xec43921b"],"secretKey":"0x45a915e4d060149eb4365960e6a7a45f334393093061116b197e3240065ff2d8"}
,"out":"0x","post":{
	"London":[{"hash":"63f729142596e783fee36c8db6d47db30783290dc33073d242108baf0281ca71","logs":"1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
	"indexes":{"data":0,"gas":0,"value":0}}]
	}}}
```