### PR TITLE
miner: update pending block even after the PoS transition

### DIFF
--- a/miner/worker.go
+++ b/miner/worker.go
@@ -1039,16 +1039,14 @@ func (w *worker) commit(uncles []*types.Header, interval func(), update bool, st
 	if err != nil {
 		return err
 	}
-
-	// If we're post merge, just ignore
-	td, ttd := w.chain.GetTd(block.ParentHash(), block.NumberU64()-1), w.chain.Config().TerminalTotalDifficulty
-	if td != nil && ttd != nil && td.Cmp(ttd) >= 0 {
-		return nil
-	}
-
 	if w.isRunning() {
 		if interval != nil {
 			interval()
+		}
+		// If we're post merge, just ignore
+		td, ttd := w.chain.GetTd(block.ParentHash(), block.NumberU64()-1), w.chain.Config().TerminalTotalDifficulty
+		if td != nil && ttd != nil && td.Cmp(ttd) >= 0 {
+			return nil
 		}
 		select {
 		case w.taskCh <- &task{receipts: receipts, state: s, block: block, createdAt: time.Now()}:


### PR DESCRIPTION
Whenever The Merge happens, the pow mining will be meaningless and be disabled by default in miner package. However miner package is still responsible for creating/maintaining the pending block/state for API usage.

This PR re-enables this functionality.