### PR TITLE
core/vm: Remove dead code (IsStaticJump)

### DIFF
--- a/core/vm/opcodes.go
+++ b/core/vm/opcodes.go
@@ -32,11 +32,6 @@ func (op OpCode) IsPush() bool {
 	return false
 }
 
-// IsStaticJump specifies if an opcode is JUMP.
-func (op OpCode) IsStaticJump() bool {
-	return op == JUMP
-}
-
 // 0x0 range - arithmetic ops.
 const (
 	STOP       OpCode = 0x0


### PR DESCRIPTION
This function does not seem to be used at all. If it is needed somehow, I'd suggest to rename it to `IsUnconditionalJump`.