### PR TITLE
rpc: fix time key collision for logger with json output

### DIFF
--- a/rpc/handler.go
+++ b/rpc/handler.go
@@ -240,7 +240,7 @@ func (h *handler) handleImmediate(msg *jsonrpcMessage) bool {
 		return false
 	case msg.isResponse():
 		h.handleResponse(msg)
-		h.log.Trace("Handled RPC response", "reqid", idForLog{msg.ID}, "t", time.Since(start))
+		h.log.Trace("Handled RPC response", "reqid", idForLog{msg.ID}, "time", time.Since(start))
 		return true
 	default:
 		return false
@@ -292,12 +292,12 @@ func (h *handler) handleCallMsg(ctx *callProc, msg *jsonrpcMessage) *jsonrpcMess
 	switch {
 	case msg.isNotification():
 		h.handleCall(ctx, msg)
-		h.log.Debug("Served "+msg.Method, "t", time.Since(start))
+		h.log.Debug("Served "+msg.Method, "time", time.Since(start))
 		return nil
 	case msg.isCall():
 		resp := h.handleCall(ctx, msg)
 		var ctx []interface{}
-		ctx = append(ctx, "reqid", idForLog{msg.ID}, "t", time.Since(start))
+		ctx = append(ctx, "reqid", idForLog{msg.ID}, "time", time.Since(start))
 		if resp.Error != nil {
 			ctx = append(ctx, "err", resp.Error.Message)
 			if resp.Error.Data != nil {

--- a/rpc/handler.go
+++ b/rpc/handler.go
@@ -240,7 +240,7 @@ func (h *handler) handleImmediate(msg *jsonrpcMessage) bool {
 		return false
 	case msg.isResponse():
 		h.handleResponse(msg)
-		h.log.Trace("Handled RPC response", "reqid", idForLog{msg.ID}, "time", time.Since(start))
+		h.log.Trace("Handled RPC response", "reqid", idForLog{msg.ID}, "duration", time.Since(start))
 		return true
 	default:
 		return false
@@ -292,12 +292,12 @@ func (h *handler) handleCallMsg(ctx *callProc, msg *jsonrpcMessage) *jsonrpcMess
 	switch {
 	case msg.isNotification():
 		h.handleCall(ctx, msg)
-		h.log.Debug("Served "+msg.Method, "time", time.Since(start))
+		h.log.Debug("Served "+msg.Method, "duration", time.Since(start))
 		return nil
 	case msg.isCall():
 		resp := h.handleCall(ctx, msg)
 		var ctx []interface{}
-		ctx = append(ctx, "reqid", idForLog{msg.ID}, "time", time.Since(start))
+		ctx = append(ctx, "reqid", idForLog{msg.ID}, "duration", time.Since(start))
 		if resp.Error != nil {
 			ctx = append(ctx, "err", resp.Error.Message)
 			if resp.Error.Data != nil {


### PR DESCRIPTION
There's `t` parameter overwriting for messages in `rpc` package when Geth node uses `--log.json` flag. Here's an example of such overwriting:

```JSON
{"err":"sealing paused while waiting for transactions","lvl":"warn","msg":"Block sealing failed","t":"2021-12-15T14:16:48.131233613+03:00"}
{"lvl":"dbug","msg":"Served rpc_modules","reqid":"1","t":"33.633µs"}
{"lvl":"trce","msg":"Handled RPC response","reqid":"1","t":"334ns"}
{"lvl":"dbug","msg":"Served web3_clientVersion","reqid":"2","t":"27.963µs"}
```

In this PR I've tried to fix this by renaming `t` parameter.