### PR TITLE
core/vm: Refactor jump table to merge dynamic gas cost with memory expansion cost calculations

### DIFF
--- a/core/vm/gas_table.go
+++ b/core/vm/gas_table.go
@@ -256,7 +256,16 @@ func makeGasLog(n uint64) gasFunc {
 			return 0, 0, ErrGasUintOverflow
 		}
 
-		gas, memorySize, err := memoryGasCostAndSize(stack, mem, memoryLog)
+		memSize, overflow := calcMemSize64(stack.Back(0), stack.Back(1))
+		if overflow {
+			return 0, 0, ErrGasUintOverflow
+		}
+		// memory is expanded in words of 32 bytes. Gas is also calculated in words.
+		memorySize, overflow := math.SafeMul(toWordSize(memSize), 32)
+		if overflow {
+			return 0, 0, ErrGasUintOverflow
+		}
+		gas, err := memoryGasCost(mem, memorySize)
 		if err != nil {
 			return 0, 0, err
 		}

--- a/core/vm/gas_table.go
+++ b/core/vm/gas_table.go
@@ -24,6 +24,9 @@ import (
 	"github.com/ethereum/go-ethereum/params"
 )
 
+// memorySizeFunc returns the required size, and whether the operation overflowed a uint64
+type memorySizeFunc func(*Stack) (size uint64, overflow bool)
+
 // memoryGasCost calculates the quadratic gas for memory expansion. It does so
 // only for the memory region that is expanded, not the total memory.
 func memoryGasCost(mem *Memory, newMemSize uint64) (uint64, error) {

--- a/core/vm/jump_table.go
+++ b/core/vm/jump_table.go
@@ -26,8 +26,6 @@ type (
 	executionFunc func(pc *uint64, interpreter *EVMInterpreter, callContext *ScopeContext) ([]byte, error)
 	// gasFunc returns required gas, required memory size, and error
 	gasFunc func(*EVM, *Contract, *Stack, *Memory) (gas uint64, memorySize uint64, err error)
-	// memorySizeFunc returns the required size, and whether the operation overflowed a uint64
-	memorySizeFunc func(*Stack) (size uint64, overflow bool)
 )
 
 type operation struct {

--- a/core/vm/memory_table.go
+++ b/core/vm/memory_table.go
@@ -67,7 +67,3 @@ func memoryStaticCall(stack *Stack) (uint64, bool) {
 	}
 	return y, false
 }
-
-func memoryLog(stack *Stack) (uint64, bool) {
-	return calcMemSize64(stack.Back(0), stack.Back(1))
-}

--- a/core/vm/memory_table.go
+++ b/core/vm/memory_table.go
@@ -20,22 +20,6 @@ func memoryKeccak256(stack *Stack) (uint64, bool) {
 	return calcMemSize64(stack.Back(0), stack.Back(1))
 }
 
-func memoryMLoad(stack *Stack) (uint64, bool) {
-	return calcMemSize64WithUint(stack.Back(0), 32)
-}
-
-func memoryMStore8(stack *Stack) (uint64, bool) {
-	return calcMemSize64WithUint(stack.Back(0), 1)
-}
-
-func memoryMStore(stack *Stack) (uint64, bool) {
-	return calcMemSize64WithUint(stack.Back(0), 32)
-}
-
-func memoryCreate(stack *Stack) (uint64, bool) {
-	return calcMemSize64(stack.Back(1), stack.Back(2))
-}
-
 func memoryCreate2(stack *Stack) (uint64, bool) {
 	return calcMemSize64(stack.Back(1), stack.Back(2))
 }
@@ -82,14 +66,6 @@ func memoryStaticCall(stack *Stack) (uint64, bool) {
 		return x, false
 	}
 	return y, false
-}
-
-func memoryReturn(stack *Stack) (uint64, bool) {
-	return calcMemSize64(stack.Back(0), stack.Back(1))
-}
-
-func memoryRevert(stack *Stack) (uint64, bool) {
-	return calcMemSize64(stack.Back(0), stack.Back(1))
 }
 
 func memoryLog(stack *Stack) (uint64, bool) {

--- a/core/vm/memory_table.go
+++ b/core/vm/memory_table.go
@@ -20,22 +20,6 @@ func memoryKeccak256(stack *Stack) (uint64, bool) {
 	return calcMemSize64(stack.Back(0), stack.Back(1))
 }
 
-func memoryCallDataCopy(stack *Stack) (uint64, bool) {
-	return calcMemSize64(stack.Back(0), stack.Back(2))
-}
-
-func memoryReturnDataCopy(stack *Stack) (uint64, bool) {
-	return calcMemSize64(stack.Back(0), stack.Back(2))
-}
-
-func memoryCodeCopy(stack *Stack) (uint64, bool) {
-	return calcMemSize64(stack.Back(0), stack.Back(2))
-}
-
-func memoryExtCodeCopy(stack *Stack) (uint64, bool) {
-	return calcMemSize64(stack.Back(1), stack.Back(3))
-}
-
 func memoryMLoad(stack *Stack) (uint64, bool) {
 	return calcMemSize64WithUint(stack.Back(0), 32)
 }


### PR DESCRIPTION
This was discussed in https://github.com/ethereum/go-ethereum/pull/24048#discussion_r761849601

Basically it merges `operation.dynamicGas` call with `operation.memorySize` call into single `dynamicGas` call returning both gas required and new memory size (or 0 if memory size doesn't change).

It allows to simplify logic in interpreter loop and also to get rid of init-time validation to check that `operation.memory != nil` iff `operation.dynamicGas != nil` (Because it's now expected from `dynamicGas` function author to correctly cover both costs, `operation.memory` member is removed)