### PR TITLE
core/rawdb: Enforce readonly in freezer instantiation

### DIFF
--- a/cmd/geth/dbcmd.go
+++ b/cmd/geth/dbcmd.go
@@ -539,7 +539,7 @@ func freezerInspect(ctx *cli.Context) error {
 	defer stack.Close()
 	path := filepath.Join(stack.ResolvePath("chaindata"), "ancient")
 	log.Info("Opening freezer", "location", path, "name", kind)
-	if f, err := rawdb.NewFreezerTable(path, kind, disableSnappy); err != nil {
+	if f, err := rawdb.NewFreezerTable(path, kind, disableSnappy, true); err != nil {
 		return err
 	} else {
 		f.DumpIndex(start, end)

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -1675,7 +1675,7 @@ func SetEthConfig(ctx *cli.Context, stack *node.Node, cfg *ethconfig.Config) {
 		if ctx.GlobalIsSet(DataDirFlag.Name) {
 			// Check if we have an already initialized chain and fall back to
 			// that if so. Otherwise we need to generate a new genesis spec.
-			chaindb := MakeChainDatabase(ctx, stack, false) // TODO (MariusVanDerWijden) make this read only
+			chaindb := MakeChainDatabase(ctx, stack, true)
 			if rawdb.ReadCanonicalHash(chaindb, 0) != (common.Hash{}) {
 				cfg.Genesis = nil // fallback to db content
 			}

--- a/core/rawdb/freezer.go
+++ b/core/rawdb/freezer.go
@@ -133,7 +133,7 @@ func newFreezer(datadir string, namespace string, readonly bool, maxTableSize ui
 
 	// Create the tables.
 	for name, disableSnappy := range tables {
-		table, err := newTable(datadir, name, readMeter, writeMeter, sizeGauge, maxTableSize, disableSnappy)
+		table, err := newTable(datadir, name, readMeter, writeMeter, sizeGauge, maxTableSize, disableSnappy, readonly)
 		if err != nil {
 			for _, table := range freezer.tables {
 				table.Close()

--- a/core/rawdb/freezer.go
+++ b/core/rawdb/freezer.go
@@ -321,12 +321,14 @@ func (f *freezer) validate() error {
 	if len(f.tables) == 0 {
 		return nil
 	}
-	var length uint64
-	var name string
+	var (
+		length uint64
+		name   string
+	)
 	// Hack to get length of any table
-	for k, table := range f.tables {
+	for kind, table := range f.tables {
 		length = atomic.LoadUint64(&table.items)
-		name = k
+		name = kind
 		break
 	}
 	// Now check every table against that length

--- a/core/rawdb/freezer.go
+++ b/core/rawdb/freezer.go
@@ -329,7 +329,6 @@ func (f *freezer) validate() error {
 		name = k
 		break
 	}
-	log.Info("validate", "name", name, "length", length)
 	// Now check every table against that length
 	for k, table := range f.tables {
 		items := atomic.LoadUint64(&table.items)

--- a/core/rawdb/freezer.go
+++ b/core/rawdb/freezer.go
@@ -332,10 +332,10 @@ func (f *freezer) validate() error {
 		break
 	}
 	// Now check every table against that length
-	for k, table := range f.tables {
+	for kind, table := range f.tables {
 		items := atomic.LoadUint64(&table.items)
 		if length != items {
-			return fmt.Errorf("freezer tables %s and %s have differing lengths: %d != %d", k, name, items, length)
+			return fmt.Errorf("freezer tables %s and %s have differing lengths: %d != %d", kind, name, items, length)
 		}
 	}
 	atomic.StoreUint64(&f.frozen, length)

--- a/core/rawdb/freezer_batch.go
+++ b/core/rawdb/freezer_batch.go
@@ -115,6 +115,11 @@ func (batch *freezerTableBatch) reset() {
 // precautionary parameter to ensure data correctness, but the table will reject already
 // existing data.
 func (batch *freezerTableBatch) Append(item uint64, data interface{}) error {
+	// Sanity check. In principle this method shouldn't be called at all
+	// in readonly mode.
+	if batch.t.readonly {
+		return fmt.Errorf("permission error: table in readonly mode")
+	}
 	if item != batch.curItem {
 		return fmt.Errorf("%w: have %d want %d", errOutOrderInsertion, item, batch.curItem)
 	}
@@ -135,6 +140,11 @@ func (batch *freezerTableBatch) Append(item uint64, data interface{}) error {
 // precautionary parameter to ensure data correctness, but the table will reject already
 // existing data.
 func (batch *freezerTableBatch) AppendRaw(item uint64, blob []byte) error {
+	// Sanity check. In principle this method shouldn't be called at all
+	// in readonly mode.
+	if batch.t.readonly {
+		return fmt.Errorf("permission error: table in readonly mode")
+	}
 	if item != batch.curItem {
 		return fmt.Errorf("%w: have %d want %d", errOutOrderInsertion, item, batch.curItem)
 	}

--- a/core/rawdb/freezer_batch.go
+++ b/core/rawdb/freezer_batch.go
@@ -115,11 +115,6 @@ func (batch *freezerTableBatch) reset() {
 // precautionary parameter to ensure data correctness, but the table will reject already
 // existing data.
 func (batch *freezerTableBatch) Append(item uint64, data interface{}) error {
-	// Sanity check. In principle this method shouldn't be called at all
-	// in readonly mode.
-	if batch.t.readonly {
-		return fmt.Errorf("permission error: table in readonly mode")
-	}
 	if item != batch.curItem {
 		return fmt.Errorf("%w: have %d want %d", errOutOrderInsertion, item, batch.curItem)
 	}
@@ -140,11 +135,6 @@ func (batch *freezerTableBatch) Append(item uint64, data interface{}) error {
 // precautionary parameter to ensure data correctness, but the table will reject already
 // existing data.
 func (batch *freezerTableBatch) AppendRaw(item uint64, blob []byte) error {
-	// Sanity check. In principle this method shouldn't be called at all
-	// in readonly mode.
-	if batch.t.readonly {
-		return fmt.Errorf("permission error: table in readonly mode")
-	}
 	if item != batch.curItem {
 		return fmt.Errorf("%w: have %d want %d", errOutOrderInsertion, item, batch.curItem)
 	}

--- a/core/rawdb/freezer_table.go
+++ b/core/rawdb/freezer_table.go
@@ -316,12 +316,14 @@ func (t *freezerTable) repair() error {
 			contentExp = int64(lastIndex.offset)
 		}
 	}
-	// Ensure all reparation changes have been written to disk
-	if err := t.index.Sync(); err != nil {
-		return err
-	}
-	if err := t.head.Sync(); err != nil {
-		return err
+	if !t.readonly {
+		// Ensure all reparation changes have been written to disk
+		if err := t.index.Sync(); err != nil {
+			return err
+		}
+		if err := t.head.Sync(); err != nil {
+			return err
+		}
 	}
 	// Update the item and byte counters and return
 	t.items = uint64(t.itemOffset) + uint64(offsetsSize/indexEntrySize-1) // last indexEntry points to the end of the data file

--- a/core/rawdb/freezer_table.go
+++ b/core/rawdb/freezer_table.go
@@ -321,13 +321,11 @@ func (t *freezerTable) repair() error {
 		}
 	}
 	// Ensure all reparation changes have been written to disk
-	if !t.readonly {
-		if err := t.index.Sync(); err != nil {
-			return err
-		}
-		if err := t.head.Sync(); err != nil {
-			return err
-		}
+	if err := t.index.Sync(); err != nil {
+		return err
+	}
+	if err := t.head.Sync(); err != nil {
+		return err
 	}
 	// Update the item and byte counters and return
 	t.items = uint64(t.itemOffset) + uint64(offsetsSize/indexEntrySize-1) // last indexEntry points to the end of the data file

--- a/core/rawdb/freezer_table.go
+++ b/core/rawdb/freezer_table.go
@@ -316,6 +316,7 @@ func (t *freezerTable) repair() error {
 			contentExp = int64(lastIndex.offset)
 		}
 	}
+	// Sync() fails for read-only files on windows.
 	if !t.readonly {
 		// Ensure all reparation changes have been written to disk
 		if err := t.index.Sync(); err != nil {

--- a/core/rawdb/freezer_table_test.go
+++ b/core/rawdb/freezer_table_test.go
@@ -830,7 +830,7 @@ func TestSequentialReadByteLimit(t *testing.T) {
 	}
 }
 
-func TestFreezerReadonlyBasics(t *testing.T) {
+func TestFreezerReadonly(t *testing.T) {
 	// Case 1: Check it fails on non-existent file.
 	_, err := newTable(os.TempDir(),
 		fmt.Sprintf("readonlytest-%d", rand.Uint64()),
@@ -904,7 +904,8 @@ func TestFreezerReadonlyBasics(t *testing.T) {
 		t.Errorf("retrieved value is incorrect")
 	}
 
-	// Now write some data. This should fail either during AppendRaw or Commit
+	// Case 5: Now write some data via a batch.
+	// This should fail either during AppendRaw or Commit
 	batch := f.newBatch()
 	writeErr := batch.AppendRaw(32, make([]byte, 1))
 	if writeErr == nil {

--- a/core/rawdb/freezer_table_test.go
+++ b/core/rawdb/freezer_table_test.go
@@ -40,7 +40,7 @@ func TestFreezerBasics(t *testing.T) {
 	// set cutoff at 50 bytes
 	f, err := newTable(os.TempDir(),
 		fmt.Sprintf("unittest-%d", rand.Uint64()),
-		metrics.NewMeter(), metrics.NewMeter(), metrics.NewGauge(), 50, true)
+		metrics.NewMeter(), metrics.NewMeter(), metrics.NewGauge(), 50, true, false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -85,7 +85,7 @@ func TestFreezerBasicsClosing(t *testing.T) {
 		f          *freezerTable
 		err        error
 	)
-	f, err = newTable(os.TempDir(), fname, rm, wm, sg, 50, true)
+	f, err = newTable(os.TempDir(), fname, rm, wm, sg, 50, true, false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -99,7 +99,7 @@ func TestFreezerBasicsClosing(t *testing.T) {
 		require.NoError(t, batch.commit())
 		f.Close()
 
-		f, err = newTable(os.TempDir(), fname, rm, wm, sg, 50, true)
+		f, err = newTable(os.TempDir(), fname, rm, wm, sg, 50, true, false)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -116,7 +116,7 @@ func TestFreezerBasicsClosing(t *testing.T) {
 			t.Fatalf("test %d, got \n%x != \n%x", y, got, exp)
 		}
 		f.Close()
-		f, err = newTable(os.TempDir(), fname, rm, wm, sg, 50, true)
+		f, err = newTable(os.TempDir(), fname, rm, wm, sg, 50, true, false)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -131,7 +131,7 @@ func TestFreezerRepairDanglingHead(t *testing.T) {
 
 	// Fill table
 	{
-		f, err := newTable(os.TempDir(), fname, rm, wm, sg, 50, true)
+		f, err := newTable(os.TempDir(), fname, rm, wm, sg, 50, true, false)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -160,7 +160,7 @@ func TestFreezerRepairDanglingHead(t *testing.T) {
 
 	// Now open it again
 	{
-		f, err := newTable(os.TempDir(), fname, rm, wm, sg, 50, true)
+		f, err := newTable(os.TempDir(), fname, rm, wm, sg, 50, true, false)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -183,7 +183,7 @@ func TestFreezerRepairDanglingHeadLarge(t *testing.T) {
 
 	// Fill a table and close it
 	{
-		f, err := newTable(os.TempDir(), fname, rm, wm, sg, 50, true)
+		f, err := newTable(os.TempDir(), fname, rm, wm, sg, 50, true, false)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -209,7 +209,7 @@ func TestFreezerRepairDanglingHeadLarge(t *testing.T) {
 
 	// Now open it again
 	{
-		f, err := newTable(os.TempDir(), fname, rm, wm, sg, 50, true)
+		f, err := newTable(os.TempDir(), fname, rm, wm, sg, 50, true, false)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -232,7 +232,7 @@ func TestFreezerRepairDanglingHeadLarge(t *testing.T) {
 
 	// And if we open it, we should now be able to read all of them (new values)
 	{
-		f, _ := newTable(os.TempDir(), fname, rm, wm, sg, 50, true)
+		f, _ := newTable(os.TempDir(), fname, rm, wm, sg, 50, true, false)
 		for y := 1; y < 255; y++ {
 			exp := getChunk(15, ^y)
 			got, err := f.Retrieve(uint64(y))
@@ -254,7 +254,7 @@ func TestSnappyDetection(t *testing.T) {
 
 	// Open with snappy
 	{
-		f, err := newTable(os.TempDir(), fname, rm, wm, sg, 50, true)
+		f, err := newTable(os.TempDir(), fname, rm, wm, sg, 50, true, false)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -265,7 +265,7 @@ func TestSnappyDetection(t *testing.T) {
 
 	// Open without snappy
 	{
-		f, err := newTable(os.TempDir(), fname, rm, wm, sg, 50, false)
+		f, err := newTable(os.TempDir(), fname, rm, wm, sg, 50, false, false)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -277,7 +277,7 @@ func TestSnappyDetection(t *testing.T) {
 
 	// Open with snappy
 	{
-		f, err := newTable(os.TempDir(), fname, rm, wm, sg, 50, true)
+		f, err := newTable(os.TempDir(), fname, rm, wm, sg, 50, true, false)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -309,7 +309,7 @@ func TestFreezerRepairDanglingIndex(t *testing.T) {
 
 	// Fill a table and close it
 	{
-		f, err := newTable(os.TempDir(), fname, rm, wm, sg, 50, true)
+		f, err := newTable(os.TempDir(), fname, rm, wm, sg, 50, true, false)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -345,7 +345,7 @@ func TestFreezerRepairDanglingIndex(t *testing.T) {
 	// 45, 45, 15
 	// with 3+3+1 items
 	{
-		f, err := newTable(os.TempDir(), fname, rm, wm, sg, 50, true)
+		f, err := newTable(os.TempDir(), fname, rm, wm, sg, 50, true, false)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -366,7 +366,7 @@ func TestFreezerTruncate(t *testing.T) {
 
 	// Fill table
 	{
-		f, err := newTable(os.TempDir(), fname, rm, wm, sg, 50, true)
+		f, err := newTable(os.TempDir(), fname, rm, wm, sg, 50, true, false)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -382,7 +382,7 @@ func TestFreezerTruncate(t *testing.T) {
 
 	// Reopen, truncate
 	{
-		f, err := newTable(os.TempDir(), fname, rm, wm, sg, 50, true)
+		f, err := newTable(os.TempDir(), fname, rm, wm, sg, 50, true, false)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -407,7 +407,7 @@ func TestFreezerRepairFirstFile(t *testing.T) {
 
 	// Fill table
 	{
-		f, err := newTable(os.TempDir(), fname, rm, wm, sg, 50, true)
+		f, err := newTable(os.TempDir(), fname, rm, wm, sg, 50, true, false)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -440,7 +440,7 @@ func TestFreezerRepairFirstFile(t *testing.T) {
 
 	// Reopen
 	{
-		f, err := newTable(os.TempDir(), fname, rm, wm, sg, 50, true)
+		f, err := newTable(os.TempDir(), fname, rm, wm, sg, 50, true, false)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -475,7 +475,7 @@ func TestFreezerReadAndTruncate(t *testing.T) {
 
 	// Fill table
 	{
-		f, err := newTable(os.TempDir(), fname, rm, wm, sg, 50, true)
+		f, err := newTable(os.TempDir(), fname, rm, wm, sg, 50, true, false)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -491,7 +491,7 @@ func TestFreezerReadAndTruncate(t *testing.T) {
 
 	// Reopen and read all files
 	{
-		f, err := newTable(os.TempDir(), fname, rm, wm, sg, 50, true)
+		f, err := newTable(os.TempDir(), fname, rm, wm, sg, 50, true, false)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -523,7 +523,7 @@ func TestFreezerOffset(t *testing.T) {
 
 	// Fill table
 	{
-		f, err := newTable(os.TempDir(), fname, rm, wm, sg, 40, true)
+		f, err := newTable(os.TempDir(), fname, rm, wm, sg, 40, true, false)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -584,7 +584,7 @@ func TestFreezerOffset(t *testing.T) {
 
 	// Now open again
 	{
-		f, err := newTable(os.TempDir(), fname, rm, wm, sg, 40, true)
+		f, err := newTable(os.TempDir(), fname, rm, wm, sg, 40, true, false)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -638,7 +638,7 @@ func TestFreezerOffset(t *testing.T) {
 
 	// Check that existing items have been moved to index 1M.
 	{
-		f, err := newTable(os.TempDir(), fname, rm, wm, sg, 40, true)
+		f, err := newTable(os.TempDir(), fname, rm, wm, sg, 40, true, false)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -726,7 +726,7 @@ func TestSequentialRead(t *testing.T) {
 	rm, wm, sg := metrics.NewMeter(), metrics.NewMeter(), metrics.NewGauge()
 	fname := fmt.Sprintf("batchread-%d", rand.Uint64())
 	{ // Fill table
-		f, err := newTable(os.TempDir(), fname, rm, wm, sg, 50, true)
+		f, err := newTable(os.TempDir(), fname, rm, wm, sg, 50, true, false)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -736,7 +736,7 @@ func TestSequentialRead(t *testing.T) {
 		f.Close()
 	}
 	{ // Open it, iterate, verify iteration
-		f, err := newTable(os.TempDir(), fname, rm, wm, sg, 50, true)
+		f, err := newTable(os.TempDir(), fname, rm, wm, sg, 50, true, false)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -757,7 +757,7 @@ func TestSequentialRead(t *testing.T) {
 	}
 	{ // Open it, iterate, verify byte limit. The byte limit is less than item
 		// size, so each lookup should only return one item
-		f, err := newTable(os.TempDir(), fname, rm, wm, sg, 40, true)
+		f, err := newTable(os.TempDir(), fname, rm, wm, sg, 40, true, false)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -786,7 +786,7 @@ func TestSequentialReadByteLimit(t *testing.T) {
 	rm, wm, sg := metrics.NewMeter(), metrics.NewMeter(), metrics.NewGauge()
 	fname := fmt.Sprintf("batchread-2-%d", rand.Uint64())
 	{ // Fill table
-		f, err := newTable(os.TempDir(), fname, rm, wm, sg, 100, true)
+		f, err := newTable(os.TempDir(), fname, rm, wm, sg, 100, true, false)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -808,7 +808,7 @@ func TestSequentialReadByteLimit(t *testing.T) {
 		{100, 109, 10},
 	} {
 		{
-			f, err := newTable(os.TempDir(), fname, rm, wm, sg, 100, true)
+			f, err := newTable(os.TempDir(), fname, rm, wm, sg, 100, true, false)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/core/rawdb/freezer_table_test.go
+++ b/core/rawdb/freezer_table_test.go
@@ -904,12 +904,13 @@ func TestFreezerReadonlyBasics(t *testing.T) {
 		t.Errorf("retrieved value is incorrect")
 	}
 
-	// Now write some data. Append/AppendRaw should fail.
+	// Now write some data. This should fail either during AppendRaw or Commit
 	batch := f.newBatch()
-	if err := batch.AppendRaw(32, make([]byte, 1)); err == nil {
-		t.Errorf("Writing to readonly table should fail")
+	writeErr := batch.AppendRaw(32, make([]byte, 1))
+	if writeErr == nil {
+		writeErr = batch.commit()
 	}
-	if err := batch.Append(0, make([]byte, 1)); err == nil {
-		t.Errorf("Writing to readonly table should fail")
+	if writeErr == nil {
+		t.Fatalf("Writing to readonly table should fail")
 	}
 }

--- a/core/rawdb/freezer_table_test.go
+++ b/core/rawdb/freezer_table_test.go
@@ -903,4 +903,13 @@ func TestFreezerReadonlyBasics(t *testing.T) {
 	if !bytes.Equal(v, exp) {
 		t.Errorf("retrieved value is incorrect")
 	}
+	// Now write some data. This should fail either during AppendRaw or Commit
+	batch := f.newBatch()
+	writeErr := batch.AppendRaw(32, make([]byte, 1))
+	if writeErr == nil {
+		writeErr = batch.commit()
+	}
+	if writeErr == nil {
+		t.Fatalf("Writing to readonly table should fail")
+	}
 }

--- a/core/rawdb/freezer_table_test.go
+++ b/core/rawdb/freezer_table_test.go
@@ -831,8 +831,9 @@ func TestSequentialReadByteLimit(t *testing.T) {
 }
 
 func TestFreezerReadonly(t *testing.T) {
+	tmpdir := os.TempDir()
 	// Case 1: Check it fails on non-existent file.
-	_, err := newTable(os.TempDir(),
+	_, err := newTable(tmpdir,
 		fmt.Sprintf("readonlytest-%d", rand.Uint64()),
 		metrics.NewMeter(), metrics.NewMeter(), metrics.NewGauge(), 50, true, true)
 	if err == nil {
@@ -840,7 +841,6 @@ func TestFreezerReadonly(t *testing.T) {
 	}
 
 	// Case 2: Check that it fails on invalid index length.
-	tmpdir := os.TempDir()
 	fname := fmt.Sprintf("readonlytest-%d", rand.Uint64())
 	idxFile, err := openFreezerFileForAppend(filepath.Join(tmpdir, fmt.Sprintf("%s.ridx", fname)))
 	if err != nil {
@@ -859,7 +859,7 @@ func TestFreezerReadonly(t *testing.T) {
 	// Then corrupt the head file and make sure opening the table
 	// again in readonly triggers an error.
 	fname = fmt.Sprintf("readonlytest-%d", rand.Uint64())
-	f, err := newTable(os.TempDir(), fname,
+	f, err := newTable(tmpdir, fname,
 		metrics.NewMeter(), metrics.NewMeter(), metrics.NewGauge(), 50, true, false)
 	if err != nil {
 		t.Fatalf("failed to instantiate table: %v", err)
@@ -872,7 +872,7 @@ func TestFreezerReadonly(t *testing.T) {
 	if err := f.Close(); err != nil {
 		t.Fatal(err)
 	}
-	_, err = newTable(os.TempDir(), fname,
+	_, err = newTable(tmpdir, fname,
 		metrics.NewMeter(), metrics.NewMeter(), metrics.NewGauge(), 50, true, true)
 	if err == nil {
 		t.Errorf("readonly table instantiation should fail for corrupt table file")
@@ -881,7 +881,7 @@ func TestFreezerReadonly(t *testing.T) {
 	// Case 4: Write some data to a table and later re-open it as readonly.
 	// Should be successful.
 	fname = fmt.Sprintf("readonlytest-%d", rand.Uint64())
-	f, err = newTable(os.TempDir(), fname,
+	f, err = newTable(tmpdir, fname,
 		metrics.NewMeter(), metrics.NewMeter(), metrics.NewGauge(), 50, true, false)
 	if err != nil {
 		t.Fatalf("failed to instantiate table: %v\n", err)
@@ -890,7 +890,7 @@ func TestFreezerReadonly(t *testing.T) {
 	if err := f.Close(); err != nil {
 		t.Fatal(err)
 	}
-	f, err = newTable(os.TempDir(), fname,
+	f, err = newTable(tmpdir, fname,
 		metrics.NewMeter(), metrics.NewMeter(), metrics.NewGauge(), 50, true, true)
 	if err != nil {
 		t.Fatal(err)

--- a/core/rawdb/freezer_table_test.go
+++ b/core/rawdb/freezer_table_test.go
@@ -893,7 +893,7 @@ func TestFreezerReadonlyBasics(t *testing.T) {
 	f, err = newTable(os.TempDir(), fname,
 		metrics.NewMeter(), metrics.NewMeter(), metrics.NewGauge(), 50, true, true)
 	if err != nil {
-		t.Error(err)
+		t.Fatal(err)
 	}
 	v, err := f.Retrieve(10)
 	if err != nil {
@@ -903,6 +903,7 @@ func TestFreezerReadonlyBasics(t *testing.T) {
 	if !bytes.Equal(v, exp) {
 		t.Errorf("retrieved value is incorrect")
 	}
+
 	// Now write some data. Append/AppendRaw should fail.
 	batch := f.newBatch()
 	if err := batch.AppendRaw(32, make([]byte, 1)); err == nil {

--- a/core/rawdb/freezer_table_test.go
+++ b/core/rawdb/freezer_table_test.go
@@ -861,6 +861,9 @@ func TestFreezerReadonlyBasics(t *testing.T) {
 	fname = fmt.Sprintf("readonlytest-%d", rand.Uint64())
 	f, err := newTable(os.TempDir(), fname,
 		metrics.NewMeter(), metrics.NewMeter(), metrics.NewGauge(), 50, true, false)
+	if err != nil {
+		t.Fatalf("failed to instantiate table: %v", err)
+	}
 	writeChunks(t, f, 8, 32)
 	// Corrupt table file
 	if _, err := f.head.Write([]byte{1, 1}); err != nil {
@@ -880,6 +883,9 @@ func TestFreezerReadonlyBasics(t *testing.T) {
 	fname = fmt.Sprintf("readonlytest-%d", rand.Uint64())
 	f, err = newTable(os.TempDir(), fname,
 		metrics.NewMeter(), metrics.NewMeter(), metrics.NewGauge(), 50, true, false)
+	if err != nil {
+		t.Fatalf("failed to instantiate table: %v\n", err)
+	}
 	writeChunks(t, f, 32, 128)
 	if err := f.Close(); err != nil {
 		t.Fatal(err)

--- a/core/rawdb/freezer_table_test.go
+++ b/core/rawdb/freezer_table_test.go
@@ -903,13 +903,12 @@ func TestFreezerReadonlyBasics(t *testing.T) {
 	if !bytes.Equal(v, exp) {
 		t.Errorf("retrieved value is incorrect")
 	}
-	// Now write some data. This should fail either during AppendRaw or Commit
+	// Now write some data. Append/AppendRaw should fail.
 	batch := f.newBatch()
-	writeErr := batch.AppendRaw(32, make([]byte, 1))
-	if writeErr == nil {
-		writeErr = batch.commit()
+	if err := batch.AppendRaw(32, make([]byte, 1)); err == nil {
+		t.Errorf("Writing to readonly table should fail")
 	}
-	if writeErr == nil {
-		t.Fatalf("Writing to readonly table should fail")
+	if err := batch.Append(0, make([]byte, 1)); err == nil {
+		t.Errorf("Writing to readonly table should fail")
 	}
 }

--- a/core/rawdb/freezer_test.go
+++ b/core/rawdb/freezer_test.go
@@ -253,6 +253,44 @@ func TestFreezerConcurrentModifyTruncate(t *testing.T) {
 	}
 }
 
+func TestFreezerReadonlyValidate(t *testing.T) {
+	tables := map[string]bool{"a": true, "b": true}
+	dir, err := ioutil.TempDir("", "freezer")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(dir)
+	// Open non-readonly freezer and fill individual tables
+	// with different amount of data.
+	f, err := newFreezer(dir, "", false, 2049, tables)
+	if err != nil {
+		t.Fatal("can't open freezer", err)
+	}
+	var item = make([]byte, 1024)
+	aBatch := f.tables["a"].newBatch()
+	require.NoError(t, aBatch.AppendRaw(0, item))
+	require.NoError(t, aBatch.AppendRaw(1, item))
+	require.NoError(t, aBatch.AppendRaw(2, item))
+	require.NoError(t, aBatch.commit())
+	bBatch := f.tables["b"].newBatch()
+	require.NoError(t, bBatch.AppendRaw(0, item))
+	require.NoError(t, bBatch.commit())
+	if f.tables["a"].items != 3 {
+		t.Fatalf("unexpected number of items in table")
+	}
+	if f.tables["b"].items != 1 {
+		t.Fatalf("unexpected number of items in table")
+	}
+	require.NoError(t, f.Close())
+
+	// Re-openening as readonly should fail when validating
+	// table lengths.
+	f, err = newFreezer(dir, "", true, 2049, tables)
+	if err == nil {
+		t.Fatal("readonly freezer should fail with differing table lengths")
+	}
+}
+
 func newFreezerForTesting(t *testing.T, tables map[string]bool) (*freezer, string) {
 	t.Helper()
 


### PR DESCRIPTION
When opening the freezer in readonly mode (e.g. `db inspect` command) we still perform repair, possibly modifying the underlying files. This PR changes that and only raises an error instead when freezer is in an invalid state.

