### PR TITLE
Reuse var for getting outputLen

### DIFF
--- a/accounts/abi/unpack.go
+++ b/accounts/abi/unpack.go
@@ -290,7 +290,7 @@ func tuplePointsTo(index int, output []byte) (start int, err error) {
 	offset := big.NewInt(0).SetBytes(output[index : index+32])
 	outputLen := big.NewInt(int64(len(output)))
 
-	if offset.Cmp(big.NewInt(int64(len(output)))) > 0 {
+	if offset.Cmp(outputLen) > 0 {
 		return 0, fmt.Errorf("abi: cannot marshal in to go slice: offset %v would go over slice boundary (len=%v)", offset, outputLen)
 	}
 	if offset.BitLen() > 63 {


### PR DESCRIPTION
Instead of recomputing the `outputLen` reuse existing var that has the length.