### PR TITLE
crypto/ecies: use AES-192 for curve P384

### DIFF
--- a/crypto/ecies/ecies_test.go
+++ b/crypto/ecies/ecies_test.go
@@ -279,7 +279,7 @@ var testCases = []testCase{
 	{
 		Curve:    elliptic.P384(),
 		Name:     "P384",
-		Expected: ECIES_AES256_SHA384,
+		Expected: ECIES_AES192_SHA384,
 	},
 	{
 		Curve:    elliptic.P521(),

--- a/crypto/ecies/params.go
+++ b/crypto/ecies/params.go
@@ -79,6 +79,14 @@ var (
 		BlockSize: aes.BlockSize,
 		KeyLen:    16,
 	}
+	
+	ECIES_AES192_SHA384 = &ECIESParams{
+		Hash:      sha512.New384,
+		hashAlgo:  crypto.SHA384,
+		Cipher:    aes.NewCipher,
+		BlockSize: aes.BlockSize,
+		KeyLen:    24,
+	}
 
 	ECIES_AES256_SHA256 = &ECIESParams{
 		Hash:      sha256.New,
@@ -108,7 +116,7 @@ var (
 var paramsFromCurve = map[elliptic.Curve]*ECIESParams{
 	ethcrypto.S256(): ECIES_AES128_SHA256,
 	elliptic.P256():  ECIES_AES128_SHA256,
-	elliptic.P384():  ECIES_AES256_SHA384,
+	elliptic.P384():  ECIES_AES192_SHA384,
 	elliptic.P521():  ECIES_AES256_SHA512,
 }
 

--- a/crypto/ecies/params.go
+++ b/crypto/ecies/params.go
@@ -79,7 +79,7 @@ var (
 		BlockSize: aes.BlockSize,
 		KeyLen:    16,
 	}
-	
+
 	ECIES_AES192_SHA384 = &ECIESParams{
 		Hash:      sha512.New384,
 		hashAlgo:  crypto.SHA384,


### PR DESCRIPTION
There is an error, which says "ecies: shared key params are too big", if we use P384 for encrypt. As it is said in readme.md, curve P384 should use AES192 not AES256.