### PR TITLE
core/types: document JSON field name equivalents of DynamicFeeTx

### DIFF
--- a/core/types/dynamic_fee_tx.go
+++ b/core/types/dynamic_fee_tx.go
@@ -25,8 +25,8 @@ import (
 type DynamicFeeTx struct {
 	ChainID    *big.Int
 	Nonce      uint64
-	GasTipCap  *big.Int
-	GasFeeCap  *big.Int
+	GasTipCap  *big.Int // a.k.a. maxPriorityFeePerGas
+	GasFeeCap  *big.Int // a.k.a. maxFeePerGas
 	Gas        uint64
 	To         *common.Address `rlp:"nil"` // nil means contract creation
 	Value      *big.Int


### PR DESCRIPTION
While researching something about EIP-1559, I noticed that these fields are not documented. While I still think the Go names are better than the JSON-RPC ones, it can't hurt to document what they correspond to.