### PR TITLE
cmd/geth: add missing sepolia testnet flag checks

### DIFF
--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -274,6 +274,9 @@ func prepare(ctx *cli.Context) {
 	case ctx.GlobalIsSet(utils.RopstenFlag.Name):
 		log.Info("Starting Geth on Ropsten testnet...")
 
+	case ctx.GlobalIsSet(utils.SepoliaFlag.Name):
+		log.Info("Starting Geth on Sepolia testnet...")
+
 	case ctx.GlobalIsSet(utils.RinkebyFlag.Name):
 		log.Info("Starting Geth on Rinkeby testnet...")
 
@@ -289,7 +292,11 @@ func prepare(ctx *cli.Context) {
 	// If we're a full node on mainnet without --cache specified, bump default cache allowance
 	if ctx.GlobalString(utils.SyncModeFlag.Name) != "light" && !ctx.GlobalIsSet(utils.CacheFlag.Name) && !ctx.GlobalIsSet(utils.NetworkIdFlag.Name) {
 		// Make sure we're not on any supported preconfigured testnet either
-		if !ctx.GlobalIsSet(utils.RopstenFlag.Name) && !ctx.GlobalIsSet(utils.RinkebyFlag.Name) && !ctx.GlobalIsSet(utils.GoerliFlag.Name) && !ctx.GlobalIsSet(utils.DeveloperFlag.Name) {
+		if !ctx.GlobalIsSet(utils.RopstenFlag.Name) &&
+			!ctx.GlobalIsSet(utils.SepoliaFlag.Name) &&
+			!ctx.GlobalIsSet(utils.RinkebyFlag.Name) &&
+			!ctx.GlobalIsSet(utils.GoerliFlag.Name) &&
+			!ctx.GlobalIsSet(utils.DeveloperFlag.Name) {
 			// Nope, we're really on mainnet. Bump that cache up!
 			log.Info("Bumping default cache on mainnet", "provided", ctx.GlobalInt(utils.CacheFlag.Name), "updated", 4096)
 			ctx.GlobalSet(utils.CacheFlag.Name, strconv.Itoa(4096))


### PR DESCRIPTION
Before:
```console
➜  go-ethereum git:(master) ./build/bin/geth --sepolia 2>&1 | grep -i -E 'sepolia|mainnet'
INFO [12-22|10:13:57.694] Starting Geth on Ethereum mainnet... 
INFO [12-22|10:13:57.694] Bumping default cache on mainnet         provided=1024 updated=4096
```

After:
```console
➜  go-ethereum git:(fix/missing-sepolia-mentions) ./build/bin/geth --sepolia 2>&1 | grep -i -E 'sepolia|mainnet'
INFO [12-22|10:13:29.484] Starting Geth on Sepolia testnet... 
```