### PR TITLE
Fix SyncProgress() Unmarshalling

### DIFF
--- a/eth/downloader/downloader.go
+++ b/eth/downloader/downloader.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/core/rawdb"
 	"github.com/ethereum/go-ethereum/core/state/snapshot"
 	"github.com/ethereum/go-ethereum/core/types"
@@ -250,21 +251,21 @@ func (d *Downloader) Progress() ethereum.SyncProgress {
 	progress, pending := d.SnapSyncer.Progress()
 
 	return ethereum.SyncProgress{
-		StartingBlock:       d.syncStatsChainOrigin,
-		CurrentBlock:        current,
-		HighestBlock:        d.syncStatsChainHeight,
-		SyncedAccounts:      progress.AccountSynced,
-		SyncedAccountBytes:  uint64(progress.AccountBytes),
-		SyncedBytecodes:     progress.BytecodeSynced,
-		SyncedBytecodeBytes: uint64(progress.BytecodeBytes),
-		SyncedStorage:       progress.StorageSynced,
-		SyncedStorageBytes:  uint64(progress.StorageBytes),
-		HealedTrienodes:     progress.TrienodeHealSynced,
-		HealedTrienodeBytes: uint64(progress.TrienodeHealBytes),
-		HealedBytecodes:     progress.BytecodeHealSynced,
-		HealedBytecodeBytes: uint64(progress.BytecodeHealBytes),
-		HealingTrienodes:    pending.TrienodeHeal,
-		HealingBytecode:     pending.BytecodeHeal,
+		StartingBlock:       hexutil.Uint64(d.syncStatsChainOrigin),
+		CurrentBlock:        hexutil.Uint64(current),
+		HighestBlock:        hexutil.Uint64(d.syncStatsChainHeight),
+		SyncedAccounts:      hexutil.Uint64(progress.AccountSynced),
+		SyncedAccountBytes:  hexutil.Uint64(progress.AccountBytes),
+		SyncedBytecodes:     hexutil.Uint64(progress.BytecodeSynced),
+		SyncedBytecodeBytes: hexutil.Uint64(progress.BytecodeBytes),
+		SyncedStorage:       hexutil.Uint64(progress.StorageSynced),
+		SyncedStorageBytes:  hexutil.Uint64(progress.StorageBytes),
+		HealedTrienodes:     hexutil.Uint64(progress.TrienodeHealSynced),
+		HealedTrienodeBytes: hexutil.Uint64(progress.TrienodeHealBytes),
+		HealedBytecodes:     hexutil.Uint64(progress.BytecodeHealSynced),
+		HealedBytecodeBytes: hexutil.Uint64(progress.BytecodeHealBytes),
+		HealingTrienodes:    hexutil.Uint64(pending.TrienodeHeal),
+		HealingBytecode:     hexutil.Uint64(pending.BytecodeHeal),
 	}
 }
 

--- a/eth/downloader/downloader_test.go
+++ b/eth/downloader/downloader_test.go
@@ -30,6 +30,7 @@ import (
 
 	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/consensus/ethash"
 	"github.com/ethereum/go-ethereum/core"
 	"github.com/ethereum/go-ethereum/core/rawdb"
@@ -1013,7 +1014,7 @@ func testSyncProgress(t *testing.T, protocol uint, mode SyncMode) {
 	}()
 	<-starting
 	checkProgress(t, tester.downloader, "initial", ethereum.SyncProgress{
-		HighestBlock: uint64(len(chain.blocks)/2 - 1),
+		HighestBlock: hexutil.Uint64(len(chain.blocks)/2 - 1),
 	})
 	progress <- struct{}{}
 	pending.Wait()
@@ -1029,18 +1030,18 @@ func testSyncProgress(t *testing.T, protocol uint, mode SyncMode) {
 	}()
 	<-starting
 	checkProgress(t, tester.downloader, "completing", ethereum.SyncProgress{
-		StartingBlock: uint64(len(chain.blocks)/2 - 1),
-		CurrentBlock:  uint64(len(chain.blocks)/2 - 1),
-		HighestBlock:  uint64(len(chain.blocks) - 1),
+		StartingBlock: hexutil.Uint64(len(chain.blocks)/2 - 1),
+		CurrentBlock:  hexutil.Uint64(len(chain.blocks)/2 - 1),
+		HighestBlock:  hexutil.Uint64(len(chain.blocks) - 1),
 	})
 
 	// Check final progress after successful sync
 	progress <- struct{}{}
 	pending.Wait()
 	checkProgress(t, tester.downloader, "final", ethereum.SyncProgress{
-		StartingBlock: uint64(len(chain.blocks)/2 - 1),
-		CurrentBlock:  uint64(len(chain.blocks) - 1),
-		HighestBlock:  uint64(len(chain.blocks) - 1),
+		StartingBlock: hexutil.Uint64(len(chain.blocks)/2 - 1),
+		CurrentBlock:  hexutil.Uint64(len(chain.blocks) - 1),
+		HighestBlock:  hexutil.Uint64(len(chain.blocks) - 1),
 	})
 }
 
@@ -1091,7 +1092,7 @@ func testForkedSyncProgress(t *testing.T, protocol uint, mode SyncMode) {
 	<-starting
 
 	checkProgress(t, tester.downloader, "initial", ethereum.SyncProgress{
-		HighestBlock: uint64(len(chainA.blocks) - 1),
+		HighestBlock: hexutil.Uint64(len(chainA.blocks) - 1),
 	})
 	progress <- struct{}{}
 	pending.Wait()
@@ -1110,18 +1111,18 @@ func testForkedSyncProgress(t *testing.T, protocol uint, mode SyncMode) {
 	}()
 	<-starting
 	checkProgress(t, tester.downloader, "forking", ethereum.SyncProgress{
-		StartingBlock: uint64(len(testChainBase.blocks)) - 1,
-		CurrentBlock:  uint64(len(chainA.blocks) - 1),
-		HighestBlock:  uint64(len(chainB.blocks) - 1),
+		StartingBlock: hexutil.Uint64(len(testChainBase.blocks)) - 1,
+		CurrentBlock:  hexutil.Uint64(len(chainA.blocks) - 1),
+		HighestBlock:  hexutil.Uint64(len(chainB.blocks) - 1),
 	})
 
 	// Check final progress after successful sync
 	progress <- struct{}{}
 	pending.Wait()
 	checkProgress(t, tester.downloader, "final", ethereum.SyncProgress{
-		StartingBlock: uint64(len(testChainBase.blocks)) - 1,
-		CurrentBlock:  uint64(len(chainB.blocks) - 1),
-		HighestBlock:  uint64(len(chainB.blocks) - 1),
+		StartingBlock: hexutil.Uint64(len(testChainBase.blocks)) - 1,
+		CurrentBlock:  hexutil.Uint64(len(chainB.blocks) - 1),
+		HighestBlock:  hexutil.Uint64(len(chainB.blocks) - 1),
 	})
 }
 
@@ -1164,7 +1165,7 @@ func testFailedSyncProgress(t *testing.T, protocol uint, mode SyncMode) {
 	}()
 	<-starting
 	checkProgress(t, tester.downloader, "initial", ethereum.SyncProgress{
-		HighestBlock: uint64(len(chain.blocks) - 1),
+		HighestBlock: hexutil.Uint64(len(chain.blocks) - 1),
 	})
 	progress <- struct{}{}
 	pending.Wait()
@@ -1187,8 +1188,8 @@ func testFailedSyncProgress(t *testing.T, protocol uint, mode SyncMode) {
 	progress <- struct{}{}
 	pending.Wait()
 	checkProgress(t, tester.downloader, "final", ethereum.SyncProgress{
-		CurrentBlock: uint64(len(chain.blocks) - 1),
-		HighestBlock: uint64(len(chain.blocks) - 1),
+		CurrentBlock: hexutil.Uint64(len(chain.blocks) - 1),
+		HighestBlock: hexutil.Uint64(len(chain.blocks) - 1),
 	})
 }
 
@@ -1229,7 +1230,7 @@ func testFakedSyncProgress(t *testing.T, protocol uint, mode SyncMode) {
 	}()
 	<-starting
 	checkProgress(t, tester.downloader, "initial", ethereum.SyncProgress{
-		HighestBlock: uint64(len(chain.blocks) - 1),
+		HighestBlock: hexutil.Uint64(len(chain.blocks) - 1),
 	})
 	progress <- struct{}{}
 	pending.Wait()
@@ -1250,14 +1251,14 @@ func testFakedSyncProgress(t *testing.T, protocol uint, mode SyncMode) {
 	<-starting
 	checkProgress(t, tester.downloader, "completing", ethereum.SyncProgress{
 		CurrentBlock: afterFailedSync.CurrentBlock,
-		HighestBlock: uint64(len(validChain.blocks) - 1),
+		HighestBlock: hexutil.Uint64(len(validChain.blocks) - 1),
 	})
 	// Check final progress after successful sync.
 	progress <- struct{}{}
 	pending.Wait()
 	checkProgress(t, tester.downloader, "final", ethereum.SyncProgress{
-		CurrentBlock: uint64(len(validChain.blocks) - 1),
-		HighestBlock: uint64(len(validChain.blocks) - 1),
+		CurrentBlock: hexutil.Uint64(len(validChain.blocks) - 1),
+		HighestBlock: hexutil.Uint64(len(validChain.blocks) - 1),
 	})
 }
 

--- a/ethstats/ethstats.go
+++ b/ethstats/ethstats.go
@@ -778,7 +778,7 @@ func (s *Service) reportStats(conn *connWrapper) error {
 		hashrate = int(fullBackend.Miner().Hashrate())
 
 		sync := fullBackend.SyncProgress()
-		syncing = fullBackend.CurrentHeader().Number.Uint64() >= sync.HighestBlock
+		syncing = fullBackend.CurrentHeader().Number.Uint64() >= uint64(sync.HighestBlock)
 
 		price, _ := fullBackend.SuggestGasTipCap(context.Background())
 		gasprice = int(price.Uint64())
@@ -787,7 +787,7 @@ func (s *Service) reportStats(conn *connWrapper) error {
 		}
 	} else {
 		sync := s.backend.SyncProgress()
-		syncing = s.backend.CurrentHeader().Number.Uint64() >= sync.HighestBlock
+		syncing = s.backend.CurrentHeader().Number.Uint64() >= uint64(sync.HighestBlock)
 	}
 	// Assemble the node stats and send it to the server
 	log.Trace("Sending node details to ethstats")

--- a/graphql/graphql.go
+++ b/graphql/graphql.go
@@ -1218,49 +1218,49 @@ type SyncState struct {
 }
 
 func (s *SyncState) StartingBlock() hexutil.Uint64 {
-	return hexutil.Uint64(s.progress.StartingBlock)
+	return s.progress.StartingBlock
 }
 func (s *SyncState) CurrentBlock() hexutil.Uint64 {
-	return hexutil.Uint64(s.progress.CurrentBlock)
+	return s.progress.CurrentBlock
 }
 func (s *SyncState) HighestBlock() hexutil.Uint64 {
-	return hexutil.Uint64(s.progress.HighestBlock)
+	return s.progress.HighestBlock
 }
 func (s *SyncState) SyncedAccounts() hexutil.Uint64 {
-	return hexutil.Uint64(s.progress.SyncedAccounts)
+	return s.progress.SyncedAccounts
 }
 func (s *SyncState) SyncedAccountBytes() hexutil.Uint64 {
-	return hexutil.Uint64(s.progress.SyncedAccountBytes)
+	return s.progress.SyncedAccountBytes
 }
 func (s *SyncState) SyncedBytecodes() hexutil.Uint64 {
-	return hexutil.Uint64(s.progress.SyncedBytecodes)
+	return s.progress.SyncedBytecodes
 }
 func (s *SyncState) SyncedBytecodeBytes() hexutil.Uint64 {
-	return hexutil.Uint64(s.progress.SyncedBytecodeBytes)
+	return s.progress.SyncedBytecodeBytes
 }
 func (s *SyncState) SyncedStorage() hexutil.Uint64 {
-	return hexutil.Uint64(s.progress.SyncedStorage)
+	return s.progress.SyncedStorage
 }
 func (s *SyncState) SyncedStorageBytes() hexutil.Uint64 {
-	return hexutil.Uint64(s.progress.SyncedStorageBytes)
+	return s.progress.SyncedStorageBytes
 }
 func (s *SyncState) HealedTrienodes() hexutil.Uint64 {
-	return hexutil.Uint64(s.progress.HealedTrienodes)
+	return s.progress.HealedTrienodes
 }
 func (s *SyncState) HealedTrienodeBytes() hexutil.Uint64 {
-	return hexutil.Uint64(s.progress.HealedTrienodeBytes)
+	return s.progress.HealedTrienodeBytes
 }
 func (s *SyncState) HealedBytecodes() hexutil.Uint64 {
-	return hexutil.Uint64(s.progress.HealedBytecodes)
+	return s.progress.HealedBytecodes
 }
 func (s *SyncState) HealedBytecodeBytes() hexutil.Uint64 {
-	return hexutil.Uint64(s.progress.HealedBytecodeBytes)
+	return s.progress.HealedBytecodeBytes
 }
 func (s *SyncState) HealingTrienodes() hexutil.Uint64 {
-	return hexutil.Uint64(s.progress.HealingTrienodes)
+	return s.progress.HealingTrienodes
 }
 func (s *SyncState) HealingBytecode() hexutil.Uint64 {
-	return hexutil.Uint64(s.progress.HealingBytecode)
+	return s.progress.HealingBytecode
 }
 
 // Syncing returns false in case the node is currently not syncing with the network. It can be up to date or has not

--- a/interfaces.go
+++ b/interfaces.go
@@ -23,6 +23,7 @@ import (
 	"math/big"
 
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/core/types"
 )
 
@@ -98,25 +99,25 @@ type ChainStateReader interface {
 // SyncProgress gives progress indications when the node is synchronising with
 // the Ethereum network.
 type SyncProgress struct {
-	StartingBlock uint64 // Block number where sync began
-	CurrentBlock  uint64 // Current block number where sync is at
-	HighestBlock  uint64 // Highest alleged block number in the chain
+	StartingBlock hexutil.Uint64 // Block number where sync began
+	CurrentBlock  hexutil.Uint64 // Current block number where sync is at
+	HighestBlock  hexutil.Uint64 // Highest alleged block number in the chain
 
 	// Fields belonging to snap sync
-	SyncedAccounts      uint64 // Number of accounts downloaded
-	SyncedAccountBytes  uint64 // Number of account trie bytes persisted to disk
-	SyncedBytecodes     uint64 // Number of bytecodes downloaded
-	SyncedBytecodeBytes uint64 // Number of bytecode bytes downloaded
-	SyncedStorage       uint64 // Number of storage slots downloaded
-	SyncedStorageBytes  uint64 // Number of storage trie bytes persisted to disk
+	SyncedAccounts      hexutil.Uint64 // Number of accounts downloaded
+	SyncedAccountBytes  hexutil.Uint64 // Number of account trie bytes persisted to disk
+	SyncedBytecodes     hexutil.Uint64 // Number of bytecodes downloaded
+	SyncedBytecodeBytes hexutil.Uint64 // Number of bytecode bytes downloaded
+	SyncedStorage       hexutil.Uint64 // Number of storage slots downloaded
+	SyncedStorageBytes  hexutil.Uint64 // Number of storage trie bytes persisted to disk
 
-	HealedTrienodes     uint64 // Number of state trie nodes downloaded
-	HealedTrienodeBytes uint64 // Number of state trie bytes persisted to disk
-	HealedBytecodes     uint64 // Number of bytecodes downloaded
-	HealedBytecodeBytes uint64 // Number of bytecodes persisted to disk
+	HealedTrienodes     hexutil.Uint64 // Number of state trie nodes downloaded
+	HealedTrienodeBytes hexutil.Uint64 // Number of state trie bytes persisted to disk
+	HealedBytecodes     hexutil.Uint64 // Number of bytecodes downloaded
+	HealedBytecodeBytes hexutil.Uint64 // Number of bytecodes persisted to disk
 
-	HealingTrienodes uint64 // Number of state trie nodes pending
-	HealingBytecode  uint64 // Number of bytecodes pending
+	HealingTrienodes hexutil.Uint64 // Number of state trie nodes pending
+	HealingBytecode  hexutil.Uint64 // Number of bytecodes pending
 }
 
 // ChainSyncReader wraps access to the node's current sync status. If there's no

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -131,21 +131,21 @@ func (s *PublicEthereumAPI) Syncing() (interface{}, error) {
 	}
 	// Otherwise gather the block sync stats
 	return map[string]interface{}{
-		"startingBlock":       hexutil.Uint64(progress.StartingBlock),
-		"currentBlock":        hexutil.Uint64(progress.CurrentBlock),
-		"highestBlock":        hexutil.Uint64(progress.HighestBlock),
-		"syncedAccounts":      hexutil.Uint64(progress.SyncedAccounts),
-		"syncedAccountBytes":  hexutil.Uint64(progress.SyncedAccountBytes),
-		"syncedBytecodes":     hexutil.Uint64(progress.SyncedBytecodes),
-		"syncedBytecodeBytes": hexutil.Uint64(progress.SyncedBytecodeBytes),
-		"syncedStorage":       hexutil.Uint64(progress.SyncedStorage),
-		"syncedStorageBytes":  hexutil.Uint64(progress.SyncedStorageBytes),
-		"healedTrienodes":     hexutil.Uint64(progress.HealedTrienodes),
-		"healedTrienodeBytes": hexutil.Uint64(progress.HealedTrienodeBytes),
-		"healedBytecodes":     hexutil.Uint64(progress.HealedBytecodes),
-		"healedBytecodeBytes": hexutil.Uint64(progress.HealedBytecodeBytes),
-		"healingTrienodes":    hexutil.Uint64(progress.HealingTrienodes),
-		"healingBytecode":     hexutil.Uint64(progress.HealingBytecode),
+		"startingBlock":       progress.StartingBlock,
+		"currentBlock":        progress.CurrentBlock,
+		"highestBlock":        progress.HighestBlock,
+		"syncedAccounts":      progress.SyncedAccounts,
+		"syncedAccountBytes":  progress.SyncedAccountBytes,
+		"syncedBytecodes":     progress.SyncedBytecodes,
+		"syncedBytecodeBytes": progress.SyncedBytecodeBytes,
+		"syncedStorage":       progress.SyncedStorage,
+		"syncedStorageBytes":  progress.SyncedStorageBytes,
+		"healedTrienodes":     progress.HealedTrienodes,
+		"healedTrienodeBytes": progress.HealedTrienodeBytes,
+		"healedBytecodes":     progress.HealedBytecodes,
+		"healedBytecodeBytes": progress.HealedBytecodeBytes,
+		"healingTrienodes":    progress.HealingTrienodes,
+		"healingBytecode":     progress.HealingBytecode,
 	}, nil
 }
 

--- a/les/downloader/downloader.go
+++ b/les/downloader/downloader.go
@@ -30,6 +30,7 @@ import (
 
 	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/core/rawdb"
 	"github.com/ethereum/go-ethereum/core/state/snapshot"
 	"github.com/ethereum/go-ethereum/core/types"
@@ -262,9 +263,9 @@ func (d *Downloader) Progress() ethereum.SyncProgress {
 		log.Error("Unknown downloader chain/mode combo", "light", d.lightchain != nil, "full", d.blockchain != nil, "mode", mode)
 	}
 	return ethereum.SyncProgress{
-		StartingBlock: d.syncStatsChainOrigin,
-		CurrentBlock:  current,
-		HighestBlock:  d.syncStatsChainHeight,
+		StartingBlock: hexutil.Uint64(d.syncStatsChainOrigin),
+		CurrentBlock:  hexutil.Uint64(current),
+		HighestBlock:  hexutil.Uint64(d.syncStatsChainHeight),
 		//PulledStates:  d.syncStatsState.processed,
 		//KnownStates:   d.syncStatsState.processed + d.syncStatsState.pending,
 	}

--- a/les/downloader/downloader_test.go
+++ b/les/downloader/downloader_test.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/core/rawdb"
 	"github.com/ethereum/go-ethereum/core/state/snapshot"
 	"github.com/ethereum/go-ethereum/core/types"
@@ -1171,7 +1172,7 @@ func testSyncProgress(t *testing.T, protocol uint, mode SyncMode) {
 	}()
 	<-starting
 	checkProgress(t, tester.downloader, "initial", ethereum.SyncProgress{
-		HighestBlock: uint64(chain.len()/2 - 1),
+		HighestBlock: hexutil.Uint64(chain.len()/2 - 1),
 	})
 	progress <- struct{}{}
 	pending.Wait()
@@ -1187,18 +1188,18 @@ func testSyncProgress(t *testing.T, protocol uint, mode SyncMode) {
 	}()
 	<-starting
 	checkProgress(t, tester.downloader, "completing", ethereum.SyncProgress{
-		StartingBlock: uint64(chain.len()/2 - 1),
-		CurrentBlock:  uint64(chain.len()/2 - 1),
-		HighestBlock:  uint64(chain.len() - 1),
+		StartingBlock: hexutil.Uint64(chain.len()/2 - 1),
+		CurrentBlock:  hexutil.Uint64(chain.len()/2 - 1),
+		HighestBlock:  hexutil.Uint64(chain.len() - 1),
 	})
 
 	// Check final progress after successful sync
 	progress <- struct{}{}
 	pending.Wait()
 	checkProgress(t, tester.downloader, "final", ethereum.SyncProgress{
-		StartingBlock: uint64(chain.len()/2 - 1),
-		CurrentBlock:  uint64(chain.len() - 1),
-		HighestBlock:  uint64(chain.len() - 1),
+		StartingBlock: hexutil.Uint64(chain.len()/2 - 1),
+		CurrentBlock:  hexutil.Uint64(chain.len() - 1),
+		HighestBlock:  hexutil.Uint64(chain.len() - 1),
 	})
 }
 
@@ -1252,7 +1253,7 @@ func testForkedSyncProgress(t *testing.T, protocol uint, mode SyncMode) {
 	<-starting
 
 	checkProgress(t, tester.downloader, "initial", ethereum.SyncProgress{
-		HighestBlock: uint64(chainA.len() - 1),
+		HighestBlock: hexutil.Uint64(chainA.len() - 1),
 	})
 	progress <- struct{}{}
 	pending.Wait()
@@ -1271,18 +1272,18 @@ func testForkedSyncProgress(t *testing.T, protocol uint, mode SyncMode) {
 	}()
 	<-starting
 	checkProgress(t, tester.downloader, "forking", ethereum.SyncProgress{
-		StartingBlock: uint64(testChainBase.len()) - 1,
-		CurrentBlock:  uint64(chainA.len() - 1),
-		HighestBlock:  uint64(chainB.len() - 1),
+		StartingBlock: hexutil.Uint64(testChainBase.len()) - 1,
+		CurrentBlock:  hexutil.Uint64(chainA.len() - 1),
+		HighestBlock:  hexutil.Uint64(chainB.len() - 1),
 	})
 
 	// Check final progress after successful sync
 	progress <- struct{}{}
 	pending.Wait()
 	checkProgress(t, tester.downloader, "final", ethereum.SyncProgress{
-		StartingBlock: uint64(testChainBase.len()) - 1,
-		CurrentBlock:  uint64(chainB.len() - 1),
-		HighestBlock:  uint64(chainB.len() - 1),
+		StartingBlock: hexutil.Uint64(testChainBase.len()) - 1,
+		CurrentBlock:  hexutil.Uint64(chainB.len() - 1),
+		HighestBlock:  hexutil.Uint64(chainB.len() - 1),
 	})
 }
 
@@ -1328,7 +1329,7 @@ func testFailedSyncProgress(t *testing.T, protocol uint, mode SyncMode) {
 	}()
 	<-starting
 	checkProgress(t, tester.downloader, "initial", ethereum.SyncProgress{
-		HighestBlock: uint64(brokenChain.len() - 1),
+		HighestBlock: hexutil.Uint64(brokenChain.len() - 1),
 	})
 	progress <- struct{}{}
 	pending.Wait()
@@ -1351,8 +1352,8 @@ func testFailedSyncProgress(t *testing.T, protocol uint, mode SyncMode) {
 	progress <- struct{}{}
 	pending.Wait()
 	checkProgress(t, tester.downloader, "final", ethereum.SyncProgress{
-		CurrentBlock: uint64(chain.len() - 1),
-		HighestBlock: uint64(chain.len() - 1),
+		CurrentBlock: hexutil.Uint64(chain.len() - 1),
+		HighestBlock: hexutil.Uint64(chain.len() - 1),
 	})
 }
 
@@ -1396,7 +1397,7 @@ func testFakedSyncProgress(t *testing.T, protocol uint, mode SyncMode) {
 	}()
 	<-starting
 	checkProgress(t, tester.downloader, "initial", ethereum.SyncProgress{
-		HighestBlock: uint64(brokenChain.len() - 1),
+		HighestBlock: hexutil.Uint64(brokenChain.len() - 1),
 	})
 	progress <- struct{}{}
 	pending.Wait()
@@ -1417,15 +1418,15 @@ func testFakedSyncProgress(t *testing.T, protocol uint, mode SyncMode) {
 	<-starting
 	checkProgress(t, tester.downloader, "completing", ethereum.SyncProgress{
 		CurrentBlock: afterFailedSync.CurrentBlock,
-		HighestBlock: uint64(validChain.len() - 1),
+		HighestBlock: hexutil.Uint64(validChain.len() - 1),
 	})
 
 	// Check final progress after successful sync.
 	progress <- struct{}{}
 	pending.Wait()
 	checkProgress(t, tester.downloader, "final", ethereum.SyncProgress{
-		CurrentBlock: uint64(validChain.len() - 1),
-		HighestBlock: uint64(validChain.len() - 1),
+		CurrentBlock: hexutil.Uint64(validChain.len() - 1),
+		HighestBlock: hexutil.Uint64(validChain.len() - 1),
 	})
 }
 


### PR DESCRIPTION
This PR fixes #24180. It changes the fields in `ethereum.SyncProgress` to be `hexutil.Uint64` instead of `uint64` so they unmarshal correctly when using the Geth library to connect to a Geth RPC endpoint.

I believe this retains the spirit of [the changes in PR 23576](https://github.com/ethereum/go-ethereum/pull/23576/files#diff-1053ae80885a491cefa0ab360c605e7abbcec41fbb620c070a132c58a3bd6cac) because it unmarshals the struct all at once instead of manually handling the individual fields. However, I'm not sure if numbers being returned in `0x` format via the RPC endpoints is standard behavior or not so this might cause issues with other clients. A more robust change that retains the above spirit would be to add prefix-checking support to the `hexutil.Uint64` unmarshallers so it could handle incoming numbers in any format. I'm not sure if that's necessary so I've left it well-enough alone here.