### PR TITLE
core/rawdb: fix double-lock causing hang. fixes #24159

### DIFF
--- a/core/rawdb/accessors_chain.go
+++ b/core/rawdb/accessors_chain.go
@@ -447,10 +447,10 @@ func ReadCanonicalBodyRLP(db ethdb.Reader, number uint64) rlp.RawValue {
 		if len(data) > 0 {
 			return nil
 		}
-		// We're going to need the hash. The number is not in ancients,
-		// so we read it from db directly
+		// Block is not in ancients, read from leveldb by hash and number.
+		// Note: ReadCanonicalHash cannot be used here because it also
+		// calls ReadAncients internally.
 		hash, _ := db.Get(headerHashKey(number))
-		// Now get body by hash from leveldb
 		data, _ = db.Get(blockBodyKey(number, common.BytesToHash(hash)))
 		return nil
 	})

--- a/core/rawdb/accessors_chain.go
+++ b/core/rawdb/accessors_chain.go
@@ -447,8 +447,11 @@ func ReadCanonicalBodyRLP(db ethdb.Reader, number uint64) rlp.RawValue {
 		if len(data) > 0 {
 			return nil
 		}
-		// Get it by hash from leveldb
-		data, _ = db.Get(blockBodyKey(number, ReadCanonicalHash(db, number)))
+		// We're going to need the hash. The number is not in ancients,
+		// so we read it from db directly
+		hash, _ := db.Get(headerHashKey(number))
+		// Now get body by hash from leveldb
+		data, _ = db.Get(blockBodyKey(number, common.BytesToHash(hash)))
 		return nil
 	})
 	return data


### PR DESCRIPTION
Doing `ReadCanonicalHash` inside `ReadAncients` is a no-no, causing a double-locking. This PR fixes it. 