### PR TITLE
docs: fix a typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ saving your blockchain as well as map the default ports. There is also an `alpin
 available for a slim version of the image.
 
 Do not forget `--http.addr 0.0.0.0`, if you want to access RPC from other containers
-and/or hosts. By default, `geth` binds to the local interface and RPC endpoints is not
+and/or hosts. By default, `geth` binds to the local interface and RPC endpoints are not
 accessible from the outside.
 
 ### Programmatically interfacing `geth` nodes


### PR DESCRIPTION
Fix a typo