### PR TITLE
les: fix crash happening after setHead

### DIFF
--- a/les/server_handler.go
+++ b/les/server_handler.go
@@ -421,7 +421,10 @@ func (h *serverHandler) broadcastLoop() {
 			}
 			var reorg uint64
 			if lastHead != nil {
-				reorg = lastHead.Number.Uint64() - rawdb.FindCommonAncestor(h.chainDb, header, lastHead).Number.Uint64()
+				// If a setHead has been performed, the common ancestor can be nil.
+				if ancestor := rawdb.FindCommonAncestor(h.chainDb, header, lastHead); ancestor != nil {
+					reorg = lastHead.Number.Uint64() - ancestor.Number.Uint64()
+				}
 			}
 			lastHead, lastTd = header, td
 			log.Debug("Announcing block to peers", "number", number, "hash", hash, "td", td, "reorg", reorg)


### PR DESCRIPTION
This PR fixes a crash that happened on one of the sealers, after a `setHead` was performed on it: 
```
 Jan 04 10:10:20 rinkeby-aws-eu-north-1-001 geth panic: runtime error: invalid memory address or nil pointer dereference
Jan 04 10:10:20 rinkeby-aws-eu-north-1-001 geth [signal SIGSEGV: segmentation violation code=0x1 addr=0x1c0 pc=0xc69da5]
Jan 04 10:10:20 rinkeby-aws-eu-north-1-001 geth goroutine 155 [running]:
Jan 04 10:10:20 rinkeby-aws-eu-north-1-001 geth github.com/ethereum/go-ethereum/les.(*serverHandler).broadcastLoop(0xc007bf98c0)
Jan 04 10:10:20 rinkeby-aws-eu-north-1-001 geth github.com/ethereum/go-ethereum/les/server_handler.go:424 +0x3a5
Jan 04 10:10:20 rinkeby-aws-eu-north-1-001 geth created by github.com/ethereum/go-ethereum/les.(*serverHandler).start
Jan 04 10:10:20 rinkeby-aws-eu-north-1-001 geth github.com/ethereum/go-ethereum/les/server_handler.go:92 +0x6f
```
