### PR TITLE
Fix comment typo

### DIFF
--- a/cmd/ethkey/utils.go
+++ b/cmd/ethkey/utils.go
@@ -49,7 +49,7 @@ func getPassphrase(ctx *cli.Context, confirmation bool) string {
 // signHash is a helper function that calculates a hash for the given message
 // that can be safely used to calculate a signature from.
 //
-// The hash is calulcated as
+// The hash is calculated as
 //   keccak256("\x19Ethereum Signed Message:\n"${message length}${message}).
 //
 // This gives context to the signed message and prevents signing of transactions.


### PR DESCRIPTION
This PR fixes a small typo `calulcated -> calculated`