### PR TITLE
eth: continue after whitelist check

### DIFF
--- a/eth/handler.go
+++ b/eth/handler.go
@@ -433,7 +433,7 @@ func (h *handler) runEthPeer(peer *eth.Peer, handler eth.Handler) error {
 					return
 				}
 				peer.Log().Debug("Whitelist block verified", "number", number, "hash", hash)
-
+				res.Done <- nil
 			case <-timeout.C:
 				peer.Log().Warn("Whitelist challenge timed out, dropping", "addr", peer.RemoteAddr(), "type", peer.Name())
 				h.removePeer(peer.ID())


### PR DESCRIPTION
The whitelist mechanism got broken in https://github.com/ethereum/go-ethereum/pull/23576, afaict, making it so that if the whitelist check succeeds, the code stalls. The peer is left somehow neither accepted nor rejected, in a state where it's marked as shutting down but not actually kicked out. 

This is the cause behind https://github.com/ethereum/go-ethereum/issues/24202 . 
Also, aside from not being able to sync, it also (on my test) causes failure to shut down. 

With this fix, I was able to start syncing with peers after the check completes. 