### PR TITLE
core, miner, rpc, eth: fix goroutine leaks in tests

### DIFF
--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -800,12 +800,8 @@ func (bc *BlockChain) Stop() {
 
 		for _, offset := range []uint64{0, 1, TriesInMemory - 1} {
 			if number := bc.CurrentBlock().NumberU64(); number > offset {
-				num := number - offset
-				recent := bc.GetBlockByNumber(num)
-				if recent == nil {
-					log.Error("Failed to get block", num)
-					continue
-				}
+				recent := bc.GetBlockByNumber(number - offset)
+
 				log.Info("Writing cached state to disk", "block", recent.Number(), "hash", recent.Hash(), "root", recent.Root())
 				if err := triedb.Commit(recent.Root(), true, nil); err != nil {
 					log.Error("Failed to commit recent state trie", "err", err)

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -800,8 +800,12 @@ func (bc *BlockChain) Stop() {
 
 		for _, offset := range []uint64{0, 1, TriesInMemory - 1} {
 			if number := bc.CurrentBlock().NumberU64(); number > offset {
-				recent := bc.GetBlockByNumber(number - offset)
-
+				num := number - offset
+				recent := bc.GetBlockByNumber(num)
+				if recent == nil {
+					log.Error("Failed to get block", num)
+					continue
+				}
 				log.Info("Writing cached state to disk", "block", recent.Number(), "hash", recent.Hash(), "root", recent.Root())
 				if err := triedb.Commit(recent.Root(), true, nil); err != nil {
 					log.Error("Failed to commit recent state trie", "err", err)

--- a/eth/fetcher/block_fetcher_test.go
+++ b/eth/fetcher/block_fetcher_test.go
@@ -364,6 +364,7 @@ func testSequentialAnnouncements(t *testing.T, light bool) {
 	hashes, blocks := makeChain(targetBlocks, 0, genesis)
 
 	tester := newTester(light)
+	defer tester.fetcher.Stop()
 	headerFetcher := tester.makeHeaderFetcher("valid", blocks, -gatherSlack)
 	bodyFetcher := tester.makeBodyFetcher("valid", blocks, 0)
 
@@ -743,7 +744,7 @@ func testInvalidNumberAnnouncement(t *testing.T, light bool) {
 	badBodyFetcher := tester.makeBodyFetcher("bad", blocks, 0)
 
 	imported := make(chan interface{})
-	announced := make(chan interface{})
+	announced := make(chan interface{}, 2)
 	tester.fetcher.importedHook = func(header *types.Header, block *types.Block) {
 		if light {
 			if header == nil {
@@ -806,6 +807,7 @@ func TestEmptyBlockShortCircuit(t *testing.T) {
 	hashes, blocks := makeChain(32, 0, genesis)
 
 	tester := newTester(false)
+	defer tester.fetcher.Stop()
 	headerFetcher := tester.makeHeaderFetcher("valid", blocks, -gatherSlack)
 	bodyFetcher := tester.makeBodyFetcher("valid", blocks, 0)
 

--- a/graphql/graphql_test.go
+++ b/graphql/graphql_test.go
@@ -48,6 +48,7 @@ func TestBuildSchema(t *testing.T) {
 	conf := node.DefaultConfig
 	conf.DataDir = ddir
 	stack, err := node.New(&conf)
+	defer stack.Close()
 	if err != nil {
 		t.Fatalf("could not create new node: %v", err)
 	}

--- a/internal/jsre/jsre_test.go
+++ b/internal/jsre/jsre_test.go
@@ -83,20 +83,20 @@ func TestNatto(t *testing.T) {
 
 	err := jsre.Exec("test.js")
 	if err != nil {
-		t.Errorf("expected no error, got %v", err)
+		t.Fatalf("expected no error, got %v", err)
 	}
 	time.Sleep(100 * time.Millisecond)
 	val, err := jsre.Run("msg")
 	if err != nil {
-		t.Errorf("expected no error, got %v", err)
+		t.Fatalf("expected no error, got %v", err)
 	}
 	if val.ExportType().Kind() != reflect.String {
-		t.Errorf("expected string value, got %v", val)
+		t.Fatalf("expected string value, got %v", val)
 	}
 	exp := "testMsg"
 	got := val.ToString().String()
 	if exp != got {
-		t.Errorf("expected '%v', got '%v'", exp, got)
+		t.Fatalf("expected '%v', got '%v'", exp, got)
 	}
 	jsre.Stop(false)
 }

--- a/miner/miner_test.go
+++ b/miner/miner_test.go
@@ -80,7 +80,8 @@ func (bc *testBlockChain) SubscribeChainHeadEvent(ch chan<- core.ChainHeadEvent)
 }
 
 func TestMiner(t *testing.T) {
-	miner, mux := createMiner(t)
+	miner, mux, cleanup := createMiner(t)
+	defer cleanup(false)
 	miner.Start(common.HexToAddress("0x12345"))
 	waitForMiningState(t, miner, true)
 	// Start the downloader
@@ -107,7 +108,8 @@ func TestMiner(t *testing.T) {
 // An initial FailedEvent should allow mining to stop on a subsequent
 // downloader StartEvent.
 func TestMinerDownloaderFirstFails(t *testing.T) {
-	miner, mux := createMiner(t)
+	miner, mux, cleanup := createMiner(t)
+	defer cleanup(false)
 	miner.Start(common.HexToAddress("0x12345"))
 	waitForMiningState(t, miner, true)
 	// Start the downloader
@@ -138,8 +140,8 @@ func TestMinerDownloaderFirstFails(t *testing.T) {
 }
 
 func TestMinerStartStopAfterDownloaderEvents(t *testing.T) {
-	miner, mux := createMiner(t)
-
+	miner, mux, cleanup := createMiner(t)
+	defer cleanup(false)
 	miner.Start(common.HexToAddress("0x12345"))
 	waitForMiningState(t, miner, true)
 	// Start the downloader
@@ -161,7 +163,8 @@ func TestMinerStartStopAfterDownloaderEvents(t *testing.T) {
 }
 
 func TestStartWhileDownload(t *testing.T) {
-	miner, mux := createMiner(t)
+	miner, mux, cleanup := createMiner(t)
+	defer cleanup(false)
 	waitForMiningState(t, miner, false)
 	miner.Start(common.HexToAddress("0x12345"))
 	waitForMiningState(t, miner, true)
@@ -174,16 +177,19 @@ func TestStartWhileDownload(t *testing.T) {
 }
 
 func TestStartStopMiner(t *testing.T) {
-	miner, _ := createMiner(t)
+	miner, _, cleanup := createMiner(t)
+	defer cleanup(false)
 	waitForMiningState(t, miner, false)
 	miner.Start(common.HexToAddress("0x12345"))
 	waitForMiningState(t, miner, true)
 	miner.Stop()
 	waitForMiningState(t, miner, false)
+
 }
 
 func TestCloseMiner(t *testing.T) {
-	miner, _ := createMiner(t)
+	miner, _, cleanup := createMiner(t)
+	defer cleanup(true)
 	waitForMiningState(t, miner, false)
 	miner.Start(common.HexToAddress("0x12345"))
 	waitForMiningState(t, miner, true)
@@ -195,7 +201,8 @@ func TestCloseMiner(t *testing.T) {
 // TestMinerSetEtherbase checks that etherbase becomes set even if mining isn't
 // possible at the moment
 func TestMinerSetEtherbase(t *testing.T) {
-	miner, mux := createMiner(t)
+	miner, mux, cleanup := createMiner(t)
+	defer cleanup(false)
 	// Start with a 'bad' mining address
 	miner.Start(common.HexToAddress("0xdead"))
 	waitForMiningState(t, miner, true)
@@ -230,7 +237,7 @@ func waitForMiningState(t *testing.T, m *Miner, mining bool) {
 	t.Fatalf("Mining() == %t, want %t", state, mining)
 }
 
-func createMiner(t *testing.T) (*Miner, *event.TypeMux) {
+func createMiner(t *testing.T) (*Miner, *event.TypeMux, func(skipMiner bool)) {
 	// Create Ethash config
 	config := Config{
 		Etherbase: common.HexToAddress("123456789"),
@@ -259,5 +266,14 @@ func createMiner(t *testing.T) (*Miner, *event.TypeMux) {
 	// Create event Mux
 	mux := new(event.TypeMux)
 	// Create Miner
-	return New(backend, &config, chainConfig, mux, engine, nil, merger), mux
+	miner := New(backend, &config, chainConfig, mux, engine, nil, merger)
+	cleanup := func(skipMiner bool) {
+		bc.Stop()
+		engine.Close()
+		pool.Stop()
+		if !skipMiner {
+			miner.Close()
+		}
+	}
+	return miner, mux, cleanup
 }

--- a/miner/worker_test.go
+++ b/miner/worker_test.go
@@ -382,7 +382,7 @@ func testRegenerateMiningBlock(t *testing.T, chainConfig *params.ChainConfig, en
 	w, b := newTestWorker(t, chainConfig, engine, rawdb.NewMemoryDatabase(), 0)
 	defer w.close()
 
-	var taskCh = make(chan struct{})
+	var taskCh = make(chan struct{}, 3)
 
 	taskIndex := 0
 	w.newTaskHook = func(task *task) {

--- a/node/node_test.go
+++ b/node/node_test.go
@@ -393,7 +393,7 @@ func TestLifecycleTerminationGuarantee(t *testing.T) {
 // on the given prefix
 func TestRegisterHandler_Successful(t *testing.T) {
 	node := createNode(t, 7878, 7979)
-
+	defer node.Close()
 	// create and mount handler
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Write([]byte("success"))

--- a/rpc/client_test.go
+++ b/rpc/client_test.go
@@ -615,6 +615,7 @@ func TestClientReconnect(t *testing.T) {
 	// Start a server and corresponding client.
 	s1, l1 := startServer("127.0.0.1:0")
 	client, err := DialContext(ctx, "ws://"+l1.Addr().String())
+	defer client.Close()
 	if err != nil {
 		t.Fatal("can't dial", err)
 	}

--- a/signer/core/api_test.go
+++ b/signer/core/api_test.go
@@ -256,6 +256,9 @@ func TestSignTx(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	if len(list) == 0 {
+		t.Fatal("Unexpected empty list")
+	}
 	a := common.NewMixedcaseAddress(list[0])
 
 	methodSig := "test(uint)"


### PR DESCRIPTION
This PR fixes following issues:

1.
testRepair goroutine leak

```
goroutine 73 [select]:
github.com/ethereum/go-ethereum/core.(*BlockChain).update(0xc00025b300)
   /repos/go-ethereum/core/blockchain.go:2443 +0x513
created by github.com/ethereum/go-ethereum/core.NewBlockChain
   /repos/go-ethereum/core/blockchain.go:378 +0xcb9
```

2.
TestRegisterHandler_Successful goroutine leak
```
goroutine 49 [select]:
github.com/ethereum/go-ethereum/accounts.(*Manager).update(0xc000198000)
   /repos/go-ethereum/accounts/manager.go:223 +0x15b4
created by github.com/ethereum/go-ethereum/accounts.NewManager
   /repos/go-ethereum/accounts/manager.go:80 +0x585

...omit others
```

3.
TestStartStopMiner
```
goroutine 69 [select]:
github.com/ethereum/go-ethereum/core.(*BlockChain).update(0xc000258600)
   /repos/go-ethereum/core/blockchain.go:2443 +0x513
created by github.com/ethereum/go-ethereum/core.NewBlockChain
   /repos/go-ethereum/core/blockchain.go:378 +0xcb9
 
goroutine 70 [select]:
github.com/ethereum/go-ethereum/core.(*TxPool).scheduleReorgLoop(0xc000059800)
   /repos/go-ethereum/core/tx_pool.go:2273 +0x26ec
created by github.com/ethereum/go-ethereum/core.NewTxPool
   /repos/go-ethereum/core/tx_pool.go:304 +0xa0a
 
goroutine 71 [select]:
github.com/ethereum/go-ethereum/core.(*TxPool).loop(0xc000059800)
   /repos/go-ethereum/core/tx_pool.go:936 +0x2065
created by github.com/ethereum/go-ethereum/core.NewTxPool
   /repos/go-ethereum/core/tx_pool.go:322 +0xb05
 
goroutine 72 [select]:
github.com/ethereum/go-ethereum/miner.(*worker).mainLoop(0xc000248000)
   /repos/go-ethereum/miner/worker.go:1792 +0x517c
created by github.com/ethereum/go-ethereum/miner.newWorker
   /repos/go-ethereum/miner/worker.go:232 +0x88e
 
goroutine 73 [select]:
github.com/ethereum/go-ethereum/miner.(*worker).newWorkLoop(0xc000248000, 0x3b9aca00)
   /repos/go-ethereum/miner/worker.go:877 +0x2405
created by github.com/ethereum/go-ethereum/miner.newWorker
   /repos/go-ethereum/miner/worker.go:233 +0x8ba
 
goroutine 74 [select]:
github.com/ethereum/go-ethereum/miner.(*worker).resultLoop(0xc000248000)
   /repos/go-ethereum/miner/worker.go:2267 +0x2c7b
created by github.com/ethereum/go-ethereum/miner.newWorker
   /repos/go-ethereum/miner/worker.go:234 +0x8dc
 
goroutine 75 [select]:
github.com/ethereum/go-ethereum/miner.(*worker).taskLoop(0xc000248000)
   /repos/go-ethereum/miner/worker.go:2025 +0x1795
created by github.com/ethereum/go-ethereum/miner.newWorker
   /repos/go-ethereum/miner/worker.go:235 +0x8fe
 
goroutine 76 [select]:
github.com/ethereum/go-ethereum/miner.(*Miner).update(0xc00002cea0)
   /repos/go-ethereum/miner/miner.go:350 +0x11b6
created by github.com/ethereum/go-ethereum/miner.New
   /repos/go-ethereum/miner/miner.go:79 +0x2ab

```

4.
TestClientReconnect
```
goroutine 24 [select]:
github.com/ethereum/go-ethereum/rpc.(*Client).dispatch(0xc00012cc00, 0x937a78, 0xc00012cb00)
   /repos/go-ethereum/rpc/client.go:1323 +0x1ce5
created by github.com/ethereum/go-ethereum/rpc.initClient
   /repos/go-ethereum/rpc/client.go:379 +0x5a6
```

5.
TestMinerDownloaderFirstFails
same as 3

6.
TestBuildSchema
Node created is missing close.

7.
TestMinerSetEtherbase
same as 3

8
TestCloseMiner
same as 3

9
testSequentialAnnouncements
```
goroutine 1154 [select]:
github.com/ethereum/go-ethereum/eth/fetcher.(*BlockFetcher).loop(0xc0001ea7e0)
   /repos/go-ethereum/eth/fetcher/block_fetcher.go:2260 +0x1878c
created by github.com/ethereum/go-ethereum/eth/fetcher.(*BlockFetcher).Start
   /repos/go-ethereum/eth/fetcher/block_fetcher.go:239 +0x67
```

10
TestEmptyBlockShortCircuit
if completing timeout happened first, sending operation of completing will be blocked
```
goroutine 92 [chan send]:
github.com/ethereum/go-ethereum/eth/fetcher.TestEmptyBlockShortCircuit.func2(0xc0005a2060, 0x1, 0x1)
   /repos/go-ethereum/eth/fetcher/block_fetcher_test.go:1235 +0xa9
github.com/ethereum/go-ethereum/eth/fetcher.(*BlockFetcher).loop(0xc0005da540)
   /repos/go-ethereum/eth/fetcher/block_fetcher.go:2412 +0x1a364
created by github.com/ethereum/go-ethereum/eth/fetcher.(*BlockFetcher).Start
   /repos/go-ethereum/eth/fetcher/block_fetcher.go:239 +0x67
```

11
TestNatto
```
panic: runtime error: invalid memory address or nil pointer dereference [recovered]
   panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x28 pc=0x6eb54a]
 
goroutine 18 [running]:
testing.tRunner.func1.2(0x7288e0, 0xae5710)
   /usr/local/go/src/testing/testing.go:1143 +0x335
testing.tRunner.func1(0xc000124a00)
   /usr/local/go/src/testing/testing.go:1146 +0x4c2
panic(0x7288e0, 0xae5710)
   /usr/local/go/src/runtime/panic.go:965 +0x1b9
github.com/ethereum/go-ethereum/internal/jsre.TestNatto(0xc000124a00)
   /repos/go-ethereum/internal/jsre/jsre_test.go:100 +0x22a
testing.tRunner(0xc000124a00, 0x78f4e0)
   /usr/local/go/src/testing/testing.go:1193 +0xef
created by testing.(*T).Run
   /usr/local/go/src/testing/testing.go:1238 +0x2b5
```

12
testRegenerateMiningBlock
if new task timeout happened first, sending operation on taskCh will be blocked
```
goroutine 71 [chan send]:
github.com/ethereum/go-ethereum/miner.testRegenerateMiningBlock.func1(0xc00011f780)
   /repos/go-ethereum/miner/worker_test.go:546 +0xc9
github.com/ethereum/go-ethereum/miner.(*worker).taskLoop(0xc000320000)
   /repos/go-ethereum/miner/worker.go:1917 +0x6c5
created by github.com/ethereum/go-ethereum/miner.newWorker
   /repos/go-ethereum/miner/worker.go:235 +0x8fe
```

13
TestSignTx
api.List might possibly return both nil
```
--- FAIL: TestSignTx (0.49s)
panic: runtime error: index out of range [0] with length 0 [recovered]
   panic: runtime error: index out of range [0] with length 0
 
goroutine 23 [running]:
testing.tRunner.func1.2(0xbd2540, 0xc0013b6000)
   /usr/local/go/src/testing/testing.go:1143 +0x335
testing.tRunner.func1(0xc00041f400)
   /usr/local/go/src/testing/testing.go:1146 +0x4c2
panic(0xbd2540, 0xc0013b6000)
   /usr/local/go/src/runtime/panic.go:965 +0x1b9
github.com/ethereum/go-ethereum/signer/core_test.TestSignTx(0xc00041f400)
   /repos/go-ethereum/signer/core/api_test.go:295 +0x162c
testing.tRunner(0xc00041f400, 0xc74200)
   /usr/local/go/src/testing/testing.go:1193 +0xef
created by testing.(*T).Run
   /usr/local/go/src/testing/testing.go:1238 +0x2b5
```

14
TestLightInvalidNumberAnnouncement
if announce timeout happened first, sending operation might be blocked
```
goroutine 23 [chan send]:
github.com/ethereum/go-ethereum/eth/fetcher.testInvalidNumberAnnouncement.func2(0x37e1ea9b1f2a122b, 0x62fa0e348adc0f38, 0x62e2422bef359fc3, 0xef08972a2a67d48a, 0x1)
   /repos/go-ethereum/eth/fetcher/block_fetcher_test.go:1139 +0x8e
github.com/ethereum/go-ethereum/eth/fetcher.(*BlockFetcher).loop(0xc000146380)
   /repos/go-ethereum/eth/fetcher/block_fetcher.go:2334 +0x1928c
created by github.com/ethereum/go-ethereum/eth/fetcher.(*BlockFetcher).Start
   /repos/go-ethereum/eth/fetcher/block_fetcher.go:239 +0x67
```
