### PR TITLE
Chore: use same receiver names

### DIFF
--- a/internal/ethapi/transaction_args.go
+++ b/internal/ethapi/transaction_args.go
@@ -56,19 +56,19 @@ type TransactionArgs struct {
 
 // from retrieves the transaction sender address.
 func (args *TransactionArgs) from() common.Address {
-	if arg.From == nil {
+	if args.From == nil {
 		return common.Address{}
 	}
-	return *arg.From
+	return *args.From
 }
 
 // data retrieves the transaction calldata. Input field is preferred.
 func (args *TransactionArgs) data() []byte {
-	if arg.Input != nil {
-		return *arg.Input
+	if args.Input != nil {
+		return *args.Input
 	}
-	if arg.Data != nil {
-		return *arg.Data
+	if args.Data != nil {
+		return *args.Data
 	}
 	return nil
 }

--- a/internal/ethapi/transaction_args.go
+++ b/internal/ethapi/transaction_args.go
@@ -55,7 +55,7 @@ type TransactionArgs struct {
 }
 
 // from retrieves the transaction sender address.
-func (arg *TransactionArgs) from() common.Address {
+func (args *TransactionArgs) from() common.Address {
 	if arg.From == nil {
 		return common.Address{}
 	}
@@ -63,7 +63,7 @@ func (arg *TransactionArgs) from() common.Address {
 }
 
 // data retrieves the transaction calldata. Input field is preferred.
-func (arg *TransactionArgs) data() []byte {
+func (args *TransactionArgs) data() []byte {
 	if arg.Input != nil {
 		return *arg.Input
 	}


### PR DESCRIPTION
Using same receiver name will be greater than using different name.