### PR TITLE
core/types: change default for DecodeRLP in transaction and recipt

### DIFF
--- a/cmd/evm/testdata/15/exp3.json
+++ b/cmd/evm/testdata/15/exp3.json
@@ -21,19 +21,19 @@
     "error": "transaction type not supported"
   },
   {
-    "error": "rlp: expected List"
+    "error": "typed transaction too short"
   },
   {
-    "error": "rlp: expected List"
+    "error": "typed transaction too short"
   },
   {
-    "error": "rlp: expected List"
+    "error": "typed transaction too short"
   },
   {
-    "error": "rlp: expected List"
+    "error": "typed transaction too short"
   },
   {
-    "error": "rlp: expected List"
+    "error": "typed transaction too short"
   },
   {
     "error": "rlp: expected input list for types.AccessListTx"

--- a/core/types/receipt.go
+++ b/core/types/receipt.go
@@ -182,7 +182,7 @@ func (r *Receipt) DecodeRLP(s *rlp.Stream) error {
 		}
 		r.Type = LegacyTxType
 		return r.setFromRLP(dec)
-	case kind == rlp.String:
+	default:
 		// It's an EIP-2718 typed tx receipt.
 		b, err := s.Bytes()
 		if err != nil {
@@ -200,9 +200,6 @@ func (r *Receipt) DecodeRLP(s *rlp.Stream) error {
 			return r.setFromRLP(dec)
 		}
 		return ErrTxTypeNotSupported
-	default:
-		// Expects the EIP-2718 transaction as default.
-		return rlp.ErrExpectedString
 	}
 }
 

--- a/core/types/receipt.go
+++ b/core/types/receipt.go
@@ -201,7 +201,8 @@ func (r *Receipt) DecodeRLP(s *rlp.Stream) error {
 		}
 		return ErrTxTypeNotSupported
 	default:
-		return rlp.ErrExpectedList
+		// Expects the EIP-2718 transaction as default.
+		return rlp.ErrExpectedString
 	}
 }
 

--- a/core/types/receipt_test.go
+++ b/core/types/receipt_test.go
@@ -86,7 +86,7 @@ func TestDecodeEmptyTypedReceipt(t *testing.T) {
 	input := []byte{0x80}
 	var r Receipt
 	err := rlp.DecodeBytes(input, &r)
-	if err != errEmptyTypedReceipt {
+	if err != errShortTypedReceipt {
 		t.Fatal("wrong error:", err)
 	}
 }

--- a/core/types/transaction.go
+++ b/core/types/transaction.go
@@ -146,7 +146,8 @@ func (tx *Transaction) DecodeRLP(s *rlp.Stream) error {
 		}
 		return err
 	default:
-		return rlp.ErrExpectedList
+		// Expects the EIP-2718 transaction as default.
+		return rlp.ErrExpectedString
 	}
 }
 

--- a/core/types/transaction.go
+++ b/core/types/transaction.go
@@ -134,7 +134,7 @@ func (tx *Transaction) DecodeRLP(s *rlp.Stream) error {
 			tx.setDecoded(&inner, int(rlp.ListSize(size)))
 		}
 		return err
-	case kind == rlp.String:
+	default:
 		// It's an EIP-2718 typed TX envelope.
 		var b []byte
 		if b, err = s.Bytes(); err != nil {
@@ -145,9 +145,6 @@ func (tx *Transaction) DecodeRLP(s *rlp.Stream) error {
 			tx.setDecoded(inner, len(b))
 		}
 		return err
-	default:
-		// Expects the EIP-2718 transaction as default.
-		return rlp.ErrExpectedString
 	}
 }
 

--- a/core/types/transaction.go
+++ b/core/types/transaction.go
@@ -37,7 +37,7 @@ var (
 	ErrInvalidTxType        = errors.New("transaction type not valid in this context")
 	ErrTxTypeNotSupported   = errors.New("transaction type not supported")
 	ErrGasFeeCapTooLow      = errors.New("fee cap less than base fee")
-	errEmptyTypedTx         = errors.New("empty typed transaction bytes")
+	errShortTypedTx         = errors.New("typed transaction too short")
 )
 
 // Transaction types.
@@ -172,8 +172,8 @@ func (tx *Transaction) UnmarshalBinary(b []byte) error {
 
 // decodeTyped decodes a typed transaction from the canonical format.
 func (tx *Transaction) decodeTyped(b []byte) (TxData, error) {
-	if len(b) == 0 {
-		return nil, errEmptyTypedTx
+	if len(b) <= 1 {
+		return nil, errShortTypedTx
 	}
 	switch b[0] {
 	case AccessListTxType:

--- a/core/types/transaction_test.go
+++ b/core/types/transaction_test.go
@@ -76,7 +76,7 @@ func TestDecodeEmptyTypedTx(t *testing.T) {
 	input := []byte{0x80}
 	var tx Transaction
 	err := rlp.DecodeBytes(input, &tx)
-	if err != errEmptyTypedTx {
+	if err != errShortTypedTx {
 		t.Fatal("wrong error:", err)
 	}
 }


### PR DESCRIPTION
Because the switch statement checks for EIP-2718 (String and Bytes) *and* legacy (List) transactions, the default should throw an error expecting the newer String and Bytes rather than the List. Changed `return rlp.ErrExpectedList` to `return rlp.ErrExpectedString` in the default cases.

closes #24227