### PR TITLE
trie: test for edgecase in VerifyRangeProof

### DIFF
--- a/trie/proof_test.go
+++ b/trie/proof_test.go
@@ -1080,22 +1080,18 @@ func TestRangeProofKeysWithSharedPrefix(t *testing.T) {
 		common.Hex2Bytes("02"),
 		common.Hex2Bytes("03"),
 	}
-	db := memorydb.New()
-	tr, err := New(common.Hash{}, NewDatabase(db))
-	if err != nil {
-		t.Fatalf("could not create new trie: %v", err)
-	}
+	trie := new(Trie)
 	for i, key := range keys {
-		tr.Update(key, vals[i])
+		trie.Update(key, vals[i])
 	}
-	root := tr.Hash()
+	root := trie.Hash()
 	proof := memorydb.New()
 	start := common.Hex2Bytes("0000000000000000000000000000000000000000000000000000000000000000")
 	end := common.Hex2Bytes("ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff")
-	if err := tr.Prove(start, 0, proof); err != nil {
+	if err := trie.Prove(start, 0, proof); err != nil {
 		t.Fatalf("failed to prove start: %v", err)
 	}
-	if err := tr.Prove(end, 0, proof); err != nil {
+	if err := trie.Prove(end, 0, proof); err != nil {
 		t.Fatalf("failed to prove end: %v", err)
 	}
 

--- a/trie/proof_test.go
+++ b/trie/proof_test.go
@@ -1069,14 +1069,11 @@ func nonRandomTrie(n int) (*Trie, map[string]*kv) {
 }
 
 func TestRangeProofKeysWithSharedPrefix(t *testing.T) {
-	// TODO: test fails if 1st key/value pair is omitted.
 	keys := [][]byte{
-		common.Hex2Bytes("1000000000000000000000000000000000000000000000000000000000000000"),
 		common.Hex2Bytes("aa10000000000000000000000000000000000000000000000000000000000000"),
 		common.Hex2Bytes("aa20000000000000000000000000000000000000000000000000000000000000"),
 	}
 	vals := [][]byte{
-		common.Hex2Bytes("01"),
 		common.Hex2Bytes("02"),
 		common.Hex2Bytes("03"),
 	}


### PR DESCRIPTION
This is probably a case where I am setting up something incorrectly, though the test fails when I remove the 1st elements of `keys` and `vals` (but passes otherwise). I was hoping you could take a look, since I couldn't exactly figure it out. 

I'm assuming it's because there's a shared prefix on the keys, though not sure.

This is the stack trace I am getting:
```
panic: trie.hashNode: invalid node: <a94e2bd8ee1e6b49b14831e8bd8a7fa01f4582bd1c22e514468c62ee05ca144e>

goroutine 19 [running]:
testing.tRunner.func1.2({0x43a35a0, 0xc000212620})
	/usr/local/Cellar/go/1.17.2/libexec/src/testing/testing.go:1209 +0x36c
testing.tRunner.func1()
	/usr/local/Cellar/go/1.17.2/libexec/src/testing/testing.go:1212 +0x3b6
panic({0x43a35a0, 0xc000212620})
	/usr/local/Cellar/go/1.17.2/libexec/src/runtime/panic.go:1047 +0x266
github.com/ethereum/go-ethereum/trie.hasRightElement({0x445dc38, 0xc00018ea00}, {0xc0001a2ac0, 0x20, 0x40})
	/.../go-ethereum/trie/proof.go:431 +0x579
github.com/ethereum/go-ethereum/trie.VerifyRangeProof({0x60, 0x78, 0xfa, 0xa7, 0x31, 0x9c, 0x98, 0x7c, 0x67, 0xe5, ...}, ...)
	/.../go-ethereum/trie/proof.go:566 +0x10eb
```