### PR TITLE
Updated and do some refactor of buyGas

### DIFF
--- a/core/state_transition.go
+++ b/core/state_transition.go
@@ -190,14 +190,13 @@ func (st *StateTransition) to() common.Address {
 }
 
 func (st *StateTransition) buyGas() error {
-	mgval := new(big.Int).SetUint64(st.msg.Gas())
-	mgval = mgval.Mul(mgval, st.gasPrice)
+	gas := new(big.Int).SetUint64(st.msg.Gas())
+	mgval = gas.Mul(gas, st.gasPrice)
 	balanceCheck := mgval
 	if st.gasFeeCap != nil {
-		balanceCheck = new(big.Int).SetUint64(st.msg.Gas())
-		balanceCheck = balanceCheck.Mul(balanceCheck, st.gasFeeCap)
-		balanceCheck.Add(balanceCheck, st.value)
+		balanceCheck = balanceCheck.Mul(gas, st.gasFeeCap)
 	}
+	balanceCheck.Add(balanceCheck, st.value)
 	if have, want := st.state.GetBalance(st.msg.From()), balanceCheck; have.Cmp(want) < 0 {
 		return fmt.Errorf("%w: address %v have %v want %v", ErrInsufficientFunds, st.msg.From().Hex(), have, want)
 	}


### PR DESCRIPTION
When checking available balance of an msg caller, 
`value` should be considered regardless of `gasFeeCap` condition.

As-now:
* `value` is added to balanceCheck only when gasFeeCap exists.

To-be:
* `value` is added to balanceCheck.