### PR TITLE
rpc: add client constructor with headers

### DIFF
--- a/rpc/websocket.go
+++ b/rpc/websocket.go
@@ -181,13 +181,9 @@ func parseOriginURL(origin string) (string, string, string, error) {
 	return scheme, hostname, port, nil
 }
 
-// DialWebsocketWithDialer creates a new RPC client that communicates with a JSON-RPC server
+// DialWebsocketWithHeaders creates a new RPC client that communicates with a JSON-RPC server
 // that is listening on the given endpoint using the provided dialer.
-func DialWebsocketWithDialer(ctx context.Context, endpoint, origin string, dialer websocket.Dialer) (*Client, error) {
-	endpoint, header, err := wsClientHeaders(endpoint, origin)
-	if err != nil {
-		return nil, err
-	}
+func DialWebsocketWithHeaders(ctx context.Context, endpoint string, header http.Header, dialer websocket.Dialer) (*Client, error) {
 	return newClient(ctx, func(ctx context.Context) (ServerCodec, error) {
 		conn, resp, err := dialer.DialContext(ctx, endpoint, header)
 		if err != nil {
@@ -199,6 +195,16 @@ func DialWebsocketWithDialer(ctx context.Context, endpoint, origin string, diale
 		}
 		return newWebsocketCodec(conn, endpoint, header), nil
 	})
+}
+
+// DialWebsocketWithDialer creates a new RPC client that communicates with a JSON-RPC server
+// that is listening on the given endpoint using the provided dialer.
+func DialWebsocketWithDialer(ctx context.Context, endpoint, origin string, dialer websocket.Dialer) (*Client, error) {
+	endpoint, header, err := wsClientHeaders(endpoint, origin)
+	if err != nil {
+		return nil, err
+	}
+	return DialWebsocketWithHeaders(ctx, endpoint, header, dialer)
 }
 
 // DialWebsocket creates a new RPC client that communicates with a JSON-RPC server


### PR DESCRIPTION
Adds a new constructor `DialWebsocketWithHeaders` that takes in `http.Header` to connect to the websocket with.  Currently, some headers like basic auth and origin are added automagically through the existing constructor `DialWebsocketWithDialer`.

This doesn't change the behavior of that constructor at all, but code is shifted around slightly to add the minimal amount of new code and reuse existing constructors. 

Happy to make this more extensible by added some sort of options pattern, but didn't want to change any of the existing APIs.