### PR TITLE
account: fix typo in errors.go

### DIFF
--- a/accounts/errors.go
+++ b/accounts/errors.go
@@ -42,7 +42,7 @@ var ErrInvalidPassphrase = errors.New("invalid password")
 var ErrWalletAlreadyOpen = errors.New("wallet already open")
 
 // ErrWalletClosed is returned if a wallet is attempted to be opened the
-// secodn time.
+// second time.
 var ErrWalletClosed = errors.New("wallet closed")
 
 // AuthNeededError is returned by backends for signing requests where the user


### PR DESCRIPTION
Fix typo in `accounts/errors.go`, `secodn` => `second`.