### PR TITLE
eth/tracers: avoid using blockCtx concurrently

### DIFF
--- a/eth/tracers/api.go
+++ b/eth/tracers/api.go
@@ -592,11 +592,11 @@ func (api *API) traceBlock(ctx context.Context, block *types.Block, config *Trac
 	if threads > len(txs) {
 		threads = len(txs)
 	}
-	blockCtx := core.NewEVMBlockContext(block.Header(), api.chainContext(ctx), nil)
 	blockHash := block.Hash()
 	for th := 0; th < threads; th++ {
 		pend.Add(1)
 		go func() {
+			blockCtx := core.NewEVMBlockContext(block.Header(), api.chainContext(ctx), nil)
 			defer pend.Done()
 			// Fetch and execute the next transaction trace tasks
 			for task := range jobs {
@@ -617,6 +617,7 @@ func (api *API) traceBlock(ctx context.Context, block *types.Block, config *Trac
 	}
 	// Feed the transactions into the tracers and return
 	var failed error
+	blockCtx := core.NewEVMBlockContext(block.Header(), api.chainContext(ctx), nil)
 	for i, tx := range txs {
 		// Send the trace task over for execution
 		jobs <- &txTraceTask{statedb: statedb.Copy(), index: i}


### PR DESCRIPTION
This is an alternative to #24283, and also closes  #23205.

This PR fixes the root cause, which are data-races in the blockhash cache. Although crisp new evm's were used, they all fell back to the same blockhash lookup closure. 

This PR produces identical results each time: 
```
-rw-rw-r-- 1 martin martin 1738663 jan 24 21:32 foo.1643056374.json
-rw-rw-r-- 1 martin martin 1738663 jan 24 21:32 foo.1643056376.json
-rw-rw-r-- 1 martin martin 1738663 jan 24 21:32 foo.1643056377.json
-rw-rw-r-- 1 martin martin 1738663 jan 24 21:32 foo.1643056378.json
-rw-rw-r-- 1 martin martin 1738663 jan 24 21:32 foo.1643056379.json
-rw-rw-r-- 1 martin martin 1738663 jan 24 21:33 foo.1643056383.json
-rw-rw-r-- 1 martin martin 1738663 jan 24 21:33 foo.1643056384.json
-rw-rw-r-- 1 martin martin 1738663 jan 24 21:33 foo.1643056385.json
-rw-rw-r-- 1 martin martin 1738663 jan 24 21:33 foo.1643056386.json

```
Timing-wise, this PR (like master) is still slower than the more simplistic approach in #24283, so I'd prefer that one actually. However, for a custom js-tracer, it's likely that this pr / master is faster, whereas #24283 is overall faster on native tracers. 

```
DEBUG[01-24|21:32:55.378] Served debug_traceBlockByHash            reqid=1 duration=485.41308ms
DEBUG[01-24|21:32:56.568] Served debug_traceBlockByHash            reqid=1 duration=342.59002ms
DEBUG[01-24|21:32:57.683] Served debug_traceBlockByHash            reqid=1 duration=332.445518ms
DEBUG[01-24|21:32:58.695] Served debug_traceBlockByHash            reqid=1 duration=321.028948ms
DEBUG[01-24|21:32:59.639] Served debug_traceBlockByHash            reqid=1 duration=343.162541ms
DEBUG[01-24|21:33:03.618] Served debug_traceBlockByHash            reqid=1 duration=327.178375ms
DEBUG[01-24|21:33:04.644] Served debug_traceBlockByHash            reqid=1 duration=332.759627ms
DEBUG[01-24|21:33:05.602] Served debug_traceBlockByHash            reqid=1 duration=335.360167ms
DEBUG[01-24|21:33:06.489] Served debug_traceBlockByHash            reqid=1 duration=330.544238ms
```


Example race: 

```
WARNING: DATA RACE
Read at 0x00c01150a240 by goroutine 148:
  github.com/ethereum/go-ethereum/core.GetHashFn.func1()
      /home/martin/go/src/github.com/ethereum/go-ethereum/core/evm.go:95 +0x1bc 
  github.com/ethereum/go-ethereum/core/vm.opBlockhash()
      /home/martin/go/src/github.com/ethereum/go-ethereum/core/vm/instructions.go:450 +0x36f
  github.com/ethereum/go-ethereum/core/vm.(*EVMInterpreter).Run()
      /home/martin/go/src/github.com/ethereum/go-ethereum/core/vm/interpreter.go:235 +0x761
  github.com/ethereum/go-ethereum/core/vm.(*EVM).Call()
      /home/martin/go/src/github.com/ethereum/go-ethereum/core/vm/evm.go:228 +0x965
  github.com/ethereum/go-ethereum/core/vm.opCall()
      /home/martin/go/src/github.com/ethereum/go-ethereum/core/vm/instructions.go:691 +0xd76
  github.com/ethereum/go-ethereum/core/vm.(*EVMInterpreter).Run()
      /home/martin/go/src/github.com/ethereum/go-ethereum/core/vm/interpreter.go:235 +0x761
  github.com/ethereum/go-ethereum/core/vm.(*EVM).Call()
      /home/martin/go/src/github.com/ethereum/go-ethereum/core/vm/evm.go:228 +0x965
  github.com/ethereum/go-ethereum/core.(*StateTransition).TransitionDb()
      /home/martin/go/src/github.com/ethereum/go-ethereum/core/state_transition.go:325 +0xe6f
  github.com/ethereum/go-ethereum/core.ApplyMessage()
      /home/martin/go/src/github.com/ethereum/go-ethereum/core/state_transition.go:181 +0x68
  github.com/ethereum/go-ethereum/eth/tracers.(*API).traceTx()
      /home/martin/go/src/github.com/ethereum/go-ethereum/eth/tracers/api.go:903 +0x73d
  github.com/ethereum/go-ethereum/eth/tracers.(*API).traceBlock.func1()
      /home/martin/go/src/github.com/ethereum/go-ethereum/eth/tracers/api.go:609 +0x519

Previous write at 0x00c01150a240 by goroutine 144:
  github.com/ethereum/go-ethereum/core.GetHashFn.func1()
      /home/martin/go/src/github.com/ethereum/go-ethereum/core/evm.go:103 +0x36a
  github.com/ethereum/go-ethereum/core/vm.opBlockhash()
      /home/martin/go/src/github.com/ethereum/go-ethereum/core/vm/instructions.go:450 +0x36f
  github.com/ethereum/go-ethereum/core/vm.(*EVMInterpreter).Run()
      /home/martin/go/src/github.com/ethereum/go-ethereum/core/vm/interpreter.go:235 +0x761
  github.com/ethereum/go-ethereum/core/vm.(*EVM).Call()
      /home/martin/go/src/github.com/ethereum/go-ethereum/core/vm/evm.go:228 +0x965
  github.com/ethereum/go-ethereum/core/vm.opCall()
      /home/martin/go/src/github.com/ethereum/go-ethereum/core/vm/instructions.go:691 +0xd76
  github.com/ethereum/go-ethereum/core/vm.(*EVMInterpreter).Run()
      /home/martin/go/src/github.com/ethereum/go-ethereum/core/vm/interpreter.go:235 +0x761
  github.com/ethereum/go-ethereum/core/vm.(*EVM).Call()
      /home/martin/go/src/github.com/ethereum/go-ethereum/core/vm/evm.go:228 +0x965
  github.com/ethereum/go-ethereum/core.(*StateTransition).TransitionDb()
      /home/martin/go/src/github.com/ethereum/go-ethereum/core/state_transition.go:325 +0xe6f
  github.com/ethereum/go-ethereum/core.ApplyMessage()
      /home/martin/go/src/github.com/ethereum/go-ethereum/core/state_transition.go:181 +0x68
  github.com/ethereum/go-ethereum/eth/tracers.(*API).traceBlock()
      /home/martin/go/src/github.com/ethereum/go-ethereum/eth/tracers/api.go:628 +0xf7d
  github.com/ethereum/go-ethereum/eth/tracers.(*API).TraceBlockByHash()
      /home/martin/go/src/github.com/ethereum/go-ethereum/eth/tracers/api.go:450 +0x14d
  runtime.call128()
      /usr/local/go/src/runtime/asm_amd64.s:553 +0x58
```