### PR TITLE
rpc: set Request.GetBody for client requests

### DIFF
--- a/rpc/http.go
+++ b/rpc/http.go
@@ -174,6 +174,7 @@ func (hc *httpConn) doRequest(ctx context.Context, msg interface{}) (io.ReadClos
 		return nil, err
 	}
 	req.ContentLength = int64(len(body))
+	req.GetBody = func() (io.ReadCloser, error) { return ioutil.NopCloser(bytes.NewReader(body)), nil }
 
 	// set headers
 	hc.mu.Lock()


### PR DESCRIPTION
When talking to an HTTP2 server, there are situations where it needs to "rewind" the Request.Body.
To allow this, we have to set up the `Request.GetBody` function to return a brand new instance of the body.

If not set, we can end up with the following error:
```
http2: Transport: cannot retry err [http2: Transport received Server's graceful shutdown GOAWAY] after Request.Body was written; define Request.GetBody to avoid this error
```

Commit :
https://sourcegraph.com/github.com/golang/net/-/commit/cffdcf672aee934982473246bc7e9a8ba446aa9b?visible=2

Close #24291
