### PR TITLE
cmd/utils: open db in readonly when dev datadir exists

### DIFF
--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -1673,9 +1673,15 @@ func SetEthConfig(ctx *cli.Context, stack *node.Node, cfg *ethconfig.Config) {
 		// Create a new developer genesis block or reuse existing one
 		cfg.Genesis = core.DeveloperGenesisBlock(uint64(ctx.GlobalInt(DeveloperPeriodFlag.Name)), ctx.GlobalUint64(DeveloperGasLimitFlag.Name), developer.Address)
 		if ctx.GlobalIsSet(DataDirFlag.Name) {
+			// If datadir doesn't exist we need to open db in write-mode
+			// so leveldb can create files.
+			readonly := true
+			if !common.FileExist(stack.ResolvePath("chaindata")) {
+				readonly = false
+			}
 			// Check if we have an already initialized chain and fall back to
 			// that if so. Otherwise we need to generate a new genesis spec.
-			chaindb := MakeChainDatabase(ctx, stack, false)
+			chaindb := MakeChainDatabase(ctx, stack, readonly)
 			if rawdb.ReadCanonicalHash(chaindb, 0) != (common.Hash{}) {
 				cfg.Genesis = nil // fallback to db content
 			}


### PR DESCRIPTION
The PR https://github.com/ethereum/go-ethereum/pull/24119 introduced a regression where if the specified datadir for dev mode didn't exist geth wouldn't start. https://github.com/ethereum/go-ethereum/pull/24281 fixed that regression.

In this PR we add an extra check to see if the datadir exists. If so, then the db is opened in read-only. Otherwise it's opened in write-mode so leveldb can create the relevant files. Note that this is not the live db that dev mode uses for its operations. It's only opened temporarily to check for existence of a genesis block and closed immediately and hence doesn't need write access.