### PR TITLE
[DOCS]: Remove fast sync from "Getting Started"

### DIFF
--- a/docs/_getting-started/index.md
+++ b/docs/_getting-started/index.md
@@ -60,9 +60,6 @@ These are:
 
 - **Full**: Downloads all blocks (including headers, transactions, and receipts) and
 generates the state of the blockchain incrementally by executing every block.
-- **Fast**: Downloads all blocks (including headers, transactions and
-receipts), verifies all headers, and downloads the state and verifies it against the
-headers.
 - **Snap** (Default): Same functionality as fast, but with a faster algorithm.   
 - **Light**: Downloads all block headers, block data, and verifies some randomly.
 


### PR DESCRIPTION
Fast sync mode has [been removed](https://github.com/ethereum/go-ethereum/commit/c10a0a62c3537fbcf899358e3c3d6be9507fa18c#diff-23ce58cf1d66350fa0080c4020e681646f05e1d033d97930aaea0911643da47a) (#23576) from the Geth client, and this PR removes it from the Getting Started page of the docs too.