### PR TITLE
core/state: fix read-meters + simplify code

### DIFF
--- a/core/state/state_object.go
+++ b/core/state/state_object.go
@@ -198,25 +198,10 @@ func (s *stateObject) GetCommittedState(db Database, key common.Hash) common.Has
 	}
 	// If no live objects are available, attempt to use snapshots
 	var (
-		enc   []byte
-		err   error
-		meter *time.Duration
+		enc []byte
+		err error
 	)
-	readStart := time.Now()
-	if metrics.EnabledExpensive {
-		// If the snap is 'under construction', the first lookup may fail. If that
-		// happens, we don't want to double-count the time elapsed. Thus this
-		// dance with the metering.
-		defer func() {
-			if meter != nil {
-				*meter += time.Since(readStart)
-			}
-		}()
-	}
 	if s.db.snap != nil {
-		if metrics.EnabledExpensive {
-			meter = &s.db.SnapshotStorageReads
-		}
 		// If the object was destructed in *this* block (and potentially resurrected),
 		// the storage has been cleared out, and we should *not* consult the previous
 		// snapshot about any storage values. The only possible alternatives are:
@@ -226,20 +211,20 @@ func (s *stateObject) GetCommittedState(db Database, key common.Hash) common.Has
 		if _, destructed := s.db.snapDestructs[s.addrHash]; destructed {
 			return common.Hash{}
 		}
+		start := time.Now()
 		enc, err = s.db.snap.Storage(s.addrHash, crypto.Keccak256Hash(key.Bytes()))
+		if metrics.EnabledExpensive {
+			s.db.SnapshotStorageReads += time.Since(start)
+		}
 	}
 	// If the snapshot is unavailable or reading from it fails, load from the database.
 	if s.db.snap == nil || err != nil {
-		if meter != nil {
-			// If we already spent time checking the snapshot, account for it
-			// and reset the readStart
-			*meter += time.Since(readStart)
-			readStart = time.Now()
-		}
+		start := time.Now()
+		enc, err = s.getTrie(db).TryGet(key.Bytes())
 		if metrics.EnabledExpensive {
-			meter = &s.db.StorageReads
+			s.db.StorageReads += time.Since(start)
 		}
-		if enc, err = s.getTrie(db).TryGet(key.Bytes()); err != nil {
+		if err != nil {
 			s.setError(err)
 			return common.Hash{}
 		}


### PR DESCRIPTION
I noticed that our meters are still not quite 100%. 
![Screenshot 2022-01-28 at 15-33-32 Dual Geth - Grafana](https://user-images.githubusercontent.com/142290/151570865-3023ad28-f5a3-42a3-a12e-09efecdcfeaa.png)

I think the fault lies on the `s.SnapshotAccountReads` handling. The `SnapshotStorageReads/StorageReads` were seemingly correct, because they did this litlte dance with pointers, to ensure that the final defer-method would update the correct counter, which the `SnapshotAccountReads/AccountReads` was missing. 

When looking into it a bit, I found that it could be simplified. This _slightly_ changes the semantics of the timer -- the timer measurement in this PR covers only the pure lookup from snapshot/trie, not the time for rlp decoding and other paths -- the time for that will wind up on the `execution` timer. I don't think either approach is more correct than the other, but it does simplify the code to do it like this. The alternative would be to add the same complex pointer-dance to the AccountReads handling.
