### PR TITLE
build: append GOARM to arm lint download URL

### DIFF
--- a/build/ci.go
+++ b/build/ci.go
@@ -334,7 +334,11 @@ func downloadLinter(cachedir string) string {
 	const version = "1.42.0"
 
 	csdb := build.MustLoadChecksums("build/checksums.txt")
-	base := fmt.Sprintf("golangci-lint-%s-%s-%s", version, runtime.GOOS, runtime.GOARCH)
+	arch := runtime.GOARCH
+	if arch == "arm" {
+		arch += "v" + os.Getenv("GOARM")
+	}
+	base := fmt.Sprintf("golangci-lint-%s-%s-%s", version, runtime.GOOS, arch)
 	url := fmt.Sprintf("https://github.com/golangci/golangci-lint/releases/download/v%s/%s.tar.gz", version, base)
 	archivePath := filepath.Join(cachedir, base+".tar.gz")
 	if err := csdb.DownloadFile(url, archivePath); err != nil {


### PR DESCRIPTION
otherwise it fails with:

```
downloading from https://github.com/golangci/golangci-lint/releases/download/v1.42.0/golangci-lint-1.42.0-linux-arm.tar.gz
ci.go:347: download error: status 404
```

not 100% sure how to deal with GOARM not being set - but there is another occurrence in ci.go that just expects it to be there - so doing the same for now