### PR TITLE
cmd/geth: set EnableBashCompletion = true

### DIFF
--- a/internal/flags/helpers.go
+++ b/internal/flags/helpers.go
@@ -143,6 +143,7 @@ func FlagCategory(flag cli.Flag, flagGroups []FlagGroup) string {
 // NewApp creates an app with sane defaults.
 func NewApp(gitCommit, gitDate, usage string) *cli.App {
 	app := cli.NewApp()
+	app.EnableBashCompletion = true
 	app.Name = filepath.Base(os.Args[0])
 	app.Author = ""
 	app.Email = ""


### PR DESCRIPTION
context #24145

![image](https://user-images.githubusercontent.com/111600/151687976-6f2bb936-5114-4db8-8a77-c3f88f6a77ff.png)

maybe we should also add it for other commands - so far I only enabled it for `geth`