### PR TITLE
cmd/geth: make test pass on a pi4 by using lightkdf

### DIFF
--- a/cmd/geth/accountcmd_test.go
+++ b/cmd/geth/accountcmd_test.go
@@ -120,7 +120,7 @@ func importAccountWithExpect(t *testing.T, key string, expected string) {
 	if err := ioutil.WriteFile(passwordFile, []byte("foobar"), 0600); err != nil {
 		t.Error(err)
 	}
-	geth := runGeth(t, "account", "import", keyfile, "-password", passwordFile)
+	geth := runGeth(t, "--lightkdf", "account", "import", keyfile, "-password", passwordFile)
 	defer geth.ExpectExit()
 	geth.Expect(expected)
 }


### PR DESCRIPTION
before this change this test was failing reproducibly with:


```
--- FAIL: TestAccountImport (0.00s)
    --- FAIL: TestAccountImport/correct_account (5.08s)
        test_cmd.go:262: (stderr:4) INFO [01-30|04:50:50.619] Maximum peer count                       ETH=50 LES=0 total=50
        test_cmd.go:262: (stderr:4) INFO [01-30|04:50:50.619] Smartcard socket not found, disabling    err="stat /run/pcscd/pcscd.comm: no such file or directory"
        test_cmd.go:262: (stderr:4) WARN [01-30|04:50:50.622] Lowering memory allowance on 32bit arch  available=3838 addressable=2048
        test_cmd.go:262: (stderr:4) WARN [01-30|04:50:50.622] Sanitizing cache to Go's GC limits       provided=1024 updated=682
        test_cmd.go:262: (stderr:4) INFO [01-30|04:50:50.623] Set global gas cap                       cap=50,000,000
        test_cmd.go:242: killing the child process (timeout)
        test_cmd.go:116: not enough output, got until ◊:
            ---------------- (stdout text)
            
            ---------------- (expected text)
            ◊Address: {fcad0b19bb29d4674531d6f115237e16afce377c}
```

after this change this tests passes on a pi4 and it should also not harm the test to do lightkdf here