### PR TITLE
vm, tracers: introduce settings for tracers

### DIFF
--- a/core/vm/evm.go
+++ b/core/vm/evm.go
@@ -184,7 +184,7 @@ func (evm *EVM) Call(caller ContractRef, addr common.Address, input []byte, gas 
 				if evm.depth == 0 {
 					evm.Config.Tracer.CaptureStart(evm, caller.Address(), addr, false, input, gas, value)
 					evm.Config.Tracer.CaptureEnd(ret, 0, 0, nil)
-				} else if evm.Config.Tracer.Settings().HasHook(CallFrameHook) {
+				} else if evm.Config.Tracer.Hooks().Has(CallFrameHook) {
 					evm.Config.Tracer.CaptureEnter(CALL, caller.Address(), addr, input, gas, value)
 					evm.Config.Tracer.CaptureExit(ret, 0, nil)
 				}
@@ -202,7 +202,7 @@ func (evm *EVM) Call(caller ContractRef, addr common.Address, input []byte, gas 
 			defer func(startGas uint64, startTime time.Time) { // Lazy evaluation of the parameters
 				evm.Config.Tracer.CaptureEnd(ret, startGas-gas, time.Since(startTime), err)
 			}(gas, time.Now())
-		} else if evm.Config.Tracer.Settings().HasHook(CallFrameHook) {
+		} else if evm.Config.Tracer.Hooks().Has(CallFrameHook) {
 			// Handle tracer events for entering and exiting a call frame
 			evm.Config.Tracer.CaptureEnter(CALL, caller.Address(), addr, input, gas, value)
 			defer func(startGas uint64) {
@@ -266,7 +266,7 @@ func (evm *EVM) CallCode(caller ContractRef, addr common.Address, input []byte, 
 	var snapshot = evm.StateDB.Snapshot()
 
 	// Invoke tracer hooks that signal entering/exiting a call frame
-	if evm.Config.Debug && evm.Config.Tracer.Settings().HasHook(CallFrameHook) {
+	if evm.Config.Debug && evm.Config.Tracer.Hooks().Has(CallFrameHook) {
 		evm.Config.Tracer.CaptureEnter(CALLCODE, caller.Address(), addr, input, gas, value)
 		defer func(startGas uint64) {
 			evm.Config.Tracer.CaptureExit(ret, startGas-gas, err)
@@ -307,7 +307,7 @@ func (evm *EVM) DelegateCall(caller ContractRef, addr common.Address, input []by
 	var snapshot = evm.StateDB.Snapshot()
 
 	// Invoke tracer hooks that signal entering/exiting a call frame
-	if evm.Config.Debug && evm.Config.Tracer.Settings().HasHook(CallFrameHook) {
+	if evm.Config.Debug && evm.Config.Tracer.Hooks().Has(CallFrameHook) {
 		evm.Config.Tracer.CaptureEnter(DELEGATECALL, caller.Address(), addr, input, gas, nil)
 		defer func(startGas uint64) {
 			evm.Config.Tracer.CaptureExit(ret, startGas-gas, err)
@@ -357,7 +357,7 @@ func (evm *EVM) StaticCall(caller ContractRef, addr common.Address, input []byte
 	evm.StateDB.AddBalance(addr, big0)
 
 	// Invoke tracer hooks that signal entering/exiting a call frame
-	if evm.Config.Debug && evm.Config.Tracer.Settings().HasHook(CallFrameHook) {
+	if evm.Config.Debug && evm.Config.Tracer.Hooks().Has(CallFrameHook) {
 		evm.Config.Tracer.CaptureEnter(STATICCALL, caller.Address(), addr, input, gas, nil)
 		defer func(startGas uint64) {
 			evm.Config.Tracer.CaptureExit(ret, startGas-gas, err)
@@ -443,7 +443,7 @@ func (evm *EVM) create(caller ContractRef, codeAndHash *codeAndHash, gas uint64,
 	if evm.Config.Debug {
 		if evm.depth == 0 {
 			evm.Config.Tracer.CaptureStart(evm, caller.Address(), address, true, codeAndHash.code, gas, value)
-		} else if evm.Config.Tracer.Settings().HasHook(CallFrameHook) {
+		} else if evm.Config.Tracer.Hooks().Has(CallFrameHook) {
 			evm.Config.Tracer.CaptureEnter(typ, caller.Address(), address, codeAndHash.code, gas, value)
 		}
 	}

--- a/core/vm/evm.go
+++ b/core/vm/evm.go
@@ -184,7 +184,7 @@ func (evm *EVM) Call(caller ContractRef, addr common.Address, input []byte, gas 
 				if evm.depth == 0 {
 					evm.Config.Tracer.CaptureStart(evm, caller.Address(), addr, false, input, gas, value)
 					evm.Config.Tracer.CaptureEnd(ret, 0, 0, nil)
-				} else {
+				} else if evm.Config.Tracer.Settings().HasHook(CallFrameHook) {
 					evm.Config.Tracer.CaptureEnter(CALL, caller.Address(), addr, input, gas, value)
 					evm.Config.Tracer.CaptureExit(ret, 0, nil)
 				}
@@ -202,7 +202,7 @@ func (evm *EVM) Call(caller ContractRef, addr common.Address, input []byte, gas 
 			defer func(startGas uint64, startTime time.Time) { // Lazy evaluation of the parameters
 				evm.Config.Tracer.CaptureEnd(ret, startGas-gas, time.Since(startTime), err)
 			}(gas, time.Now())
-		} else {
+		} else if evm.Config.Tracer.Settings().HasHook(CallFrameHook) {
 			// Handle tracer events for entering and exiting a call frame
 			evm.Config.Tracer.CaptureEnter(CALL, caller.Address(), addr, input, gas, value)
 			defer func(startGas uint64) {
@@ -266,7 +266,7 @@ func (evm *EVM) CallCode(caller ContractRef, addr common.Address, input []byte, 
 	var snapshot = evm.StateDB.Snapshot()
 
 	// Invoke tracer hooks that signal entering/exiting a call frame
-	if evm.Config.Debug {
+	if evm.Config.Debug && evm.Config.Tracer.Settings().HasHook(CallFrameHook) {
 		evm.Config.Tracer.CaptureEnter(CALLCODE, caller.Address(), addr, input, gas, value)
 		defer func(startGas uint64) {
 			evm.Config.Tracer.CaptureExit(ret, startGas-gas, err)
@@ -307,7 +307,7 @@ func (evm *EVM) DelegateCall(caller ContractRef, addr common.Address, input []by
 	var snapshot = evm.StateDB.Snapshot()
 
 	// Invoke tracer hooks that signal entering/exiting a call frame
-	if evm.Config.Debug {
+	if evm.Config.Debug && evm.Config.Tracer.Settings().HasHook(CallFrameHook) {
 		evm.Config.Tracer.CaptureEnter(DELEGATECALL, caller.Address(), addr, input, gas, nil)
 		defer func(startGas uint64) {
 			evm.Config.Tracer.CaptureExit(ret, startGas-gas, err)
@@ -357,7 +357,7 @@ func (evm *EVM) StaticCall(caller ContractRef, addr common.Address, input []byte
 	evm.StateDB.AddBalance(addr, big0)
 
 	// Invoke tracer hooks that signal entering/exiting a call frame
-	if evm.Config.Debug {
+	if evm.Config.Debug && evm.Config.Tracer.Settings().HasHook(CallFrameHook) {
 		evm.Config.Tracer.CaptureEnter(STATICCALL, caller.Address(), addr, input, gas, nil)
 		defer func(startGas uint64) {
 			evm.Config.Tracer.CaptureExit(ret, startGas-gas, err)
@@ -443,7 +443,7 @@ func (evm *EVM) create(caller ContractRef, codeAndHash *codeAndHash, gas uint64,
 	if evm.Config.Debug {
 		if evm.depth == 0 {
 			evm.Config.Tracer.CaptureStart(evm, caller.Address(), address, true, codeAndHash.code, gas, value)
-		} else {
+		} else if evm.Config.Tracer.Settings().HasHook(CallFrameHook) {
 			evm.Config.Tracer.CaptureEnter(typ, caller.Address(), address, codeAndHash.code, gas, value)
 		}
 	}

--- a/core/vm/interpreter.go
+++ b/core/vm/interpreter.go
@@ -167,7 +167,7 @@ func (in *EVMInterpreter) Run(contract *Contract, input []byte, readOnly bool) (
 		defer func() {
 			if err != nil {
 				if !logged {
-					if in.cfg.Tracer.Settings().HasHook(StepHook) {
+					if in.cfg.Tracer.Hooks().Has(StepHook) {
 						in.cfg.Tracer.CaptureState(pcCopy, op, gasCopy, cost, callContext, in.returnData, in.evm.depth, err)
 					}
 				} else {
@@ -230,7 +230,7 @@ func (in *EVMInterpreter) Run(contract *Contract, input []byte, readOnly bool) (
 			}
 		}
 		if in.cfg.Debug {
-			if in.cfg.Tracer.Settings().HasHook(StepHook) {
+			if in.cfg.Tracer.Hooks().Has(StepHook) {
 				in.cfg.Tracer.CaptureState(pc, op, gasCopy, cost, callContext, in.returnData, in.evm.depth, err)
 			}
 			// TODO: fault and step are kind of related. What to do here?

--- a/core/vm/interpreter.go
+++ b/core/vm/interpreter.go
@@ -167,7 +167,9 @@ func (in *EVMInterpreter) Run(contract *Contract, input []byte, readOnly bool) (
 		defer func() {
 			if err != nil {
 				if !logged {
-					in.cfg.Tracer.CaptureState(pcCopy, op, gasCopy, cost, callContext, in.returnData, in.evm.depth, err)
+					if in.cfg.Tracer.Settings().HasHook(StepHook) {
+						in.cfg.Tracer.CaptureState(pcCopy, op, gasCopy, cost, callContext, in.returnData, in.evm.depth, err)
+					}
 				} else {
 					in.cfg.Tracer.CaptureFault(pcCopy, op, gasCopy, cost, callContext, in.evm.depth, err)
 				}
@@ -228,7 +230,10 @@ func (in *EVMInterpreter) Run(contract *Contract, input []byte, readOnly bool) (
 			}
 		}
 		if in.cfg.Debug {
-			in.cfg.Tracer.CaptureState(pc, op, gasCopy, cost, callContext, in.returnData, in.evm.depth, err)
+			if in.cfg.Tracer.Settings().HasHook(StepHook) {
+				in.cfg.Tracer.CaptureState(pc, op, gasCopy, cost, callContext, in.returnData, in.evm.depth, err)
+			}
+			// TODO: fault and step are kind of related. What to do here?
 			logged = true
 		}
 		// execute the operation

--- a/core/vm/logger.go
+++ b/core/vm/logger.go
@@ -35,7 +35,7 @@ type EVMLogger interface {
 	CaptureExit(output []byte, gasUsed uint64, err error)
 	CaptureFault(pc uint64, op OpCode, gas, cost uint64, scope *ScopeContext, depth int, err error)
 	CaptureEnd(output []byte, gasUsed uint64, t time.Duration, err error)
-	Settings() LoggerSettings
+	Settings() *LoggerSettings
 }
 
 type Hooks uint16
@@ -49,5 +49,5 @@ type LoggerSettings struct {
 	Hooks Hooks
 }
 
-func (s LoggerSettings) SetHook(flag Hooks)      { s.Hooks = s.Hooks | flag }
-func (s LoggerSettings) HasHook(flag Hooks) bool { return s.Hooks&flag != 0 }
+func (s *LoggerSettings) SetHook(flag Hooks)      { s.Hooks = s.Hooks | flag }
+func (s *LoggerSettings) HasHook(flag Hooks) bool { return s.Hooks&flag != 0 }

--- a/core/vm/logger.go
+++ b/core/vm/logger.go
@@ -35,4 +35,19 @@ type EVMLogger interface {
 	CaptureExit(output []byte, gasUsed uint64, err error)
 	CaptureFault(pc uint64, op OpCode, gas, cost uint64, scope *ScopeContext, depth int, err error)
 	CaptureEnd(output []byte, gasUsed uint64, t time.Duration, err error)
+	Settings() LoggerSettings
 }
+
+type Hooks uint16
+
+const (
+	StepHook      Hooks = 1 << iota
+	CallFrameHook Hooks = 2 << iota
+)
+
+type LoggerSettings struct {
+	Hooks Hooks
+}
+
+func (s LoggerSettings) SetHook(flag Hooks)      { s.Hooks = s.Hooks | flag }
+func (s LoggerSettings) HasHook(flag Hooks) bool { return s.Hooks&flag != 0 }

--- a/core/vm/logger.go
+++ b/core/vm/logger.go
@@ -35,7 +35,7 @@ type EVMLogger interface {
 	CaptureExit(output []byte, gasUsed uint64, err error)
 	CaptureFault(pc uint64, op OpCode, gas, cost uint64, scope *ScopeContext, depth int, err error)
 	CaptureEnd(output []byte, gasUsed uint64, t time.Duration, err error)
-	Settings() *LoggerSettings
+	Hooks() *Hooks
 }
 
 type Hooks uint16
@@ -45,9 +45,5 @@ const (
 	CallFrameHook Hooks = 2 << iota
 )
 
-type LoggerSettings struct {
-	Hooks Hooks
-}
-
-func (s *LoggerSettings) SetHook(flag Hooks)      { s.Hooks = s.Hooks | flag }
-func (s *LoggerSettings) HasHook(flag Hooks) bool { return s.Hooks&flag != 0 }
+func (h *Hooks) Set(flag Hooks)      { *h = *h | flag }
+func (h *Hooks) Has(flag Hooks) bool { return *h&flag != 0 }

--- a/eth/tracers/api.go
+++ b/eth/tracers/api.go
@@ -891,6 +891,8 @@ func (api *API) traceTx(ctx context.Context, message core.Message, txctx *Contex
 			}()
 			defer cancel()
 			tracer = t
+			// Check tracer engine
+			log.Info("Initiated tracer", "engine", tracer.(Tracer).Settings().Engine)
 		}
 	default:
 		tracer = logger.NewStructLogger(config.Config)

--- a/eth/tracers/js/tracer.go
+++ b/eth/tracers/js/tracer.go
@@ -827,8 +827,8 @@ func (jst *jsTracer) CaptureExit(output []byte, gasUsed uint64, err error) {
 
 // Settings returns information about the tracer and which hooks
 // it is interested in.
-func (jst *jsTracer) Settings() tracers2.TracerSettings {
-	return tracers2.TracerSettings{Engine: "js", Hooks: tracers2.Step | tracers2.CallFrame}
+func (jst *jsTracer) Settings() vm.LoggerSettings {
+	return vm.LoggerSettings{Hooks: vm.StepHook | vm.CallFrameHook}
 }
 
 // GetResult calls the Javascript 'result' function and returns its value, or any accumulated error

--- a/eth/tracers/js/tracer.go
+++ b/eth/tracers/js/tracer.go
@@ -825,6 +825,12 @@ func (jst *jsTracer) CaptureExit(output []byte, gasUsed uint64, err error) {
 	}
 }
 
+// Settings returns information about the tracer and which hooks
+// it is interested in.
+func (jst *jsTracer) Settings() tracers2.TracerSettings {
+	return tracers2.TracerSettings{Engine: "js"}
+}
+
 // GetResult calls the Javascript 'result' function and returns its value, or any accumulated error
 func (jst *jsTracer) GetResult() (json.RawMessage, error) {
 	// Transform the context into a JavaScript object and inject into the state

--- a/eth/tracers/js/tracer.go
+++ b/eth/tracers/js/tracer.go
@@ -850,6 +850,10 @@ func (jst *jsTracer) Hooks() *vm.Hooks {
 	return jst.hooks
 }
 
+func (t *jsTracer) Settings() *tracers2.TracerSettings {
+	return &tracers2.TracerSettings{Engine: "js"}
+}
+
 // GetResult calls the Javascript 'result' function and returns its value, or any accumulated error
 func (jst *jsTracer) GetResult() (json.RawMessage, error) {
 	// Transform the context into a JavaScript object and inject into the state

--- a/eth/tracers/js/tracer.go
+++ b/eth/tracers/js/tracer.go
@@ -828,7 +828,7 @@ func (jst *jsTracer) CaptureExit(output []byte, gasUsed uint64, err error) {
 // Settings returns information about the tracer and which hooks
 // it is interested in.
 func (jst *jsTracer) Settings() tracers2.TracerSettings {
-	return tracers2.TracerSettings{Engine: "js"}
+	return tracers2.TracerSettings{Engine: "js", Hooks: tracers2.Step | tracers2.CallFrame}
 }
 
 // GetResult calls the Javascript 'result' function and returns its value, or any accumulated error

--- a/eth/tracers/logger/access_list_tracer.go
+++ b/eth/tracers/logger/access_list_tracer.go
@@ -174,8 +174,10 @@ func (*AccessListTracer) CaptureEnter(typ vm.OpCode, from common.Address, to com
 
 func (*AccessListTracer) CaptureExit(output []byte, gasUsed uint64, err error) {}
 
-func (*AccessListTracer) Settings() *vm.LoggerSettings {
-	return &vm.LoggerSettings{Hooks: vm.StepHook}
+func (*AccessListTracer) Hooks() *vm.Hooks {
+	h := new(vm.Hooks)
+	h.Set(vm.StepHook)
+	return h
 }
 
 // AccessList returns the current accesslist maintained by the tracer.

--- a/eth/tracers/logger/access_list_tracer.go
+++ b/eth/tracers/logger/access_list_tracer.go
@@ -174,6 +174,10 @@ func (*AccessListTracer) CaptureEnter(typ vm.OpCode, from common.Address, to com
 
 func (*AccessListTracer) CaptureExit(output []byte, gasUsed uint64, err error) {}
 
+func (*AccessListTracer) Settings() vm.LoggerSettings {
+	return vm.LoggerSettings{Hooks: vm.StepHook}
+}
+
 // AccessList returns the current accesslist maintained by the tracer.
 func (a *AccessListTracer) AccessList() types.AccessList {
 	return a.list.accessList()

--- a/eth/tracers/logger/access_list_tracer.go
+++ b/eth/tracers/logger/access_list_tracer.go
@@ -174,8 +174,8 @@ func (*AccessListTracer) CaptureEnter(typ vm.OpCode, from common.Address, to com
 
 func (*AccessListTracer) CaptureExit(output []byte, gasUsed uint64, err error) {}
 
-func (*AccessListTracer) Settings() vm.LoggerSettings {
-	return vm.LoggerSettings{Hooks: vm.StepHook}
+func (*AccessListTracer) Settings() *vm.LoggerSettings {
+	return &vm.LoggerSettings{Hooks: vm.StepHook}
 }
 
 // AccessList returns the current accesslist maintained by the tracer.

--- a/eth/tracers/logger/logger.go
+++ b/eth/tracers/logger/logger.go
@@ -351,3 +351,7 @@ func (t *mdLogger) CaptureEnter(typ vm.OpCode, from common.Address, to common.Ad
 }
 
 func (t *mdLogger) CaptureExit(output []byte, gasUsed uint64, err error) {}
+
+func (t *mdLogger) Settings() *vm.LoggerSettings {
+	return &vm.LoggerSettings{Hooks: vm.StepHook}
+}

--- a/eth/tracers/logger/logger.go
+++ b/eth/tracers/logger/logger.go
@@ -223,6 +223,10 @@ func (l *StructLogger) CaptureEnter(typ vm.OpCode, from common.Address, to commo
 
 func (l *StructLogger) CaptureExit(output []byte, gasUsed uint64, err error) {}
 
+func (l *StructLogger) Settings() vm.LoggerSettings {
+	return vm.LoggerSettings{Hooks: vm.StepHook}
+}
+
 // StructLogs returns the captured log entries.
 func (l *StructLogger) StructLogs() []StructLog { return l.logs }
 

--- a/eth/tracers/logger/logger.go
+++ b/eth/tracers/logger/logger.go
@@ -223,8 +223,10 @@ func (l *StructLogger) CaptureEnter(typ vm.OpCode, from common.Address, to commo
 
 func (l *StructLogger) CaptureExit(output []byte, gasUsed uint64, err error) {}
 
-func (l *StructLogger) Settings() *vm.LoggerSettings {
-	return &vm.LoggerSettings{Hooks: vm.StepHook}
+func (l *StructLogger) Hooks() *vm.Hooks {
+	h := new(vm.Hooks)
+	h.Set(vm.StepHook)
+	return h
 }
 
 // StructLogs returns the captured log entries.
@@ -352,6 +354,8 @@ func (t *mdLogger) CaptureEnter(typ vm.OpCode, from common.Address, to common.Ad
 
 func (t *mdLogger) CaptureExit(output []byte, gasUsed uint64, err error) {}
 
-func (t *mdLogger) Settings() *vm.LoggerSettings {
-	return &vm.LoggerSettings{Hooks: vm.StepHook}
+func (t *mdLogger) Hooks() *vm.Hooks {
+	h := new(vm.Hooks)
+	h.Set(vm.StepHook)
+	return h
 }

--- a/eth/tracers/logger/logger.go
+++ b/eth/tracers/logger/logger.go
@@ -223,8 +223,8 @@ func (l *StructLogger) CaptureEnter(typ vm.OpCode, from common.Address, to commo
 
 func (l *StructLogger) CaptureExit(output []byte, gasUsed uint64, err error) {}
 
-func (l *StructLogger) Settings() vm.LoggerSettings {
-	return vm.LoggerSettings{Hooks: vm.StepHook}
+func (l *StructLogger) Settings() *vm.LoggerSettings {
+	return &vm.LoggerSettings{Hooks: vm.StepHook}
 }
 
 // StructLogs returns the captured log entries.

--- a/eth/tracers/logger/logger_json.go
+++ b/eth/tracers/logger/logger_json.go
@@ -99,6 +99,6 @@ func (l *JSONLogger) CaptureEnter(typ vm.OpCode, from common.Address, to common.
 
 func (l *JSONLogger) CaptureExit(output []byte, gasUsed uint64, err error) {}
 
-func (l *JSONLogger) Settings() vm.LoggerSettings {
-	return vm.LoggerSettings{Hooks: vm.StepHook}
+func (l *JSONLogger) Settings() *vm.LoggerSettings {
+	return &vm.LoggerSettings{Hooks: vm.StepHook}
 }

--- a/eth/tracers/logger/logger_json.go
+++ b/eth/tracers/logger/logger_json.go
@@ -98,3 +98,7 @@ func (l *JSONLogger) CaptureEnter(typ vm.OpCode, from common.Address, to common.
 }
 
 func (l *JSONLogger) CaptureExit(output []byte, gasUsed uint64, err error) {}
+
+func (l *JSONLogger) Settings() vm.LoggerSettings {
+	return vm.LoggerSettings{Hooks: vm.StepHook}
+}

--- a/eth/tracers/logger/logger_json.go
+++ b/eth/tracers/logger/logger_json.go
@@ -99,6 +99,8 @@ func (l *JSONLogger) CaptureEnter(typ vm.OpCode, from common.Address, to common.
 
 func (l *JSONLogger) CaptureExit(output []byte, gasUsed uint64, err error) {}
 
-func (l *JSONLogger) Settings() *vm.LoggerSettings {
-	return &vm.LoggerSettings{Hooks: vm.StepHook}
+func (l *JSONLogger) Hooks() *vm.Hooks {
+	h := new(vm.Hooks)
+	h.Set(vm.StepHook)
+	return h
 }

--- a/eth/tracers/native/4byte.go
+++ b/eth/tracers/native/4byte.go
@@ -133,8 +133,10 @@ func (t *fourByteTracer) CaptureEnd(output []byte, gasUsed uint64, _ time.Durati
 
 // Settings returns information about the tracer and which hooks
 // it is interested in.
-func (t *fourByteTracer) Settings() *vm.LoggerSettings {
-	return &vm.LoggerSettings{Hooks: vm.CallFrameHook}
+func (t *fourByteTracer) Hooks() *vm.Hooks {
+	h := new(vm.Hooks)
+	h.Set(vm.CallFrameHook)
+	return h
 }
 
 // GetResult returns the json-encoded nested list of call traces, and any

--- a/eth/tracers/native/4byte.go
+++ b/eth/tracers/native/4byte.go
@@ -133,8 +133,8 @@ func (t *fourByteTracer) CaptureEnd(output []byte, gasUsed uint64, _ time.Durati
 
 // Settings returns information about the tracer and which hooks
 // it is interested in.
-func (t *fourByteTracer) Settings() vm.LoggerSettings {
-	return vm.LoggerSettings{Hooks: vm.CallFrameHook}
+func (t *fourByteTracer) Settings() *vm.LoggerSettings {
+	return &vm.LoggerSettings{Hooks: vm.CallFrameHook}
 }
 
 // GetResult returns the json-encoded nested list of call traces, and any

--- a/eth/tracers/native/4byte.go
+++ b/eth/tracers/native/4byte.go
@@ -131,6 +131,14 @@ func (t *fourByteTracer) CaptureFault(pc uint64, op vm.OpCode, gas, cost uint64,
 func (t *fourByteTracer) CaptureEnd(output []byte, gasUsed uint64, _ time.Duration, err error) {
 }
 
+// Settings returns information about the tracer and which hooks
+// it is interested in.
+func (t *fourByteTracer) Settings() tracers.TracerSettings {
+	return tracers.TracerSettings{
+		Engine: "native",
+	}
+}
+
 // GetResult returns the json-encoded nested list of call traces, and any
 // error arising from the encoding or forceful termination (via `Stop`).
 func (t *fourByteTracer) GetResult() (json.RawMessage, error) {

--- a/eth/tracers/native/4byte.go
+++ b/eth/tracers/native/4byte.go
@@ -139,6 +139,10 @@ func (t *fourByteTracer) Hooks() *vm.Hooks {
 	return h
 }
 
+func (t *fourByteTracer) Settings() *tracers.TracerSettings {
+	return &tracers.TracerSettings{Engine: "native"}
+}
+
 // GetResult returns the json-encoded nested list of call traces, and any
 // error arising from the encoding or forceful termination (via `Stop`).
 func (t *fourByteTracer) GetResult() (json.RawMessage, error) {

--- a/eth/tracers/native/4byte.go
+++ b/eth/tracers/native/4byte.go
@@ -133,8 +133,8 @@ func (t *fourByteTracer) CaptureEnd(output []byte, gasUsed uint64, _ time.Durati
 
 // Settings returns information about the tracer and which hooks
 // it is interested in.
-func (t *fourByteTracer) Settings() tracers.TracerSettings {
-	return tracers.TracerSettings{Engine: "native", Hooks: tracers.CallFrame}
+func (t *fourByteTracer) Settings() vm.LoggerSettings {
+	return vm.LoggerSettings{Hooks: vm.CallFrameHook}
 }
 
 // GetResult returns the json-encoded nested list of call traces, and any

--- a/eth/tracers/native/4byte.go
+++ b/eth/tracers/native/4byte.go
@@ -134,9 +134,7 @@ func (t *fourByteTracer) CaptureEnd(output []byte, gasUsed uint64, _ time.Durati
 // Settings returns information about the tracer and which hooks
 // it is interested in.
 func (t *fourByteTracer) Settings() tracers.TracerSettings {
-	return tracers.TracerSettings{
-		Engine: "native",
-	}
+	return tracers.TracerSettings{Engine: "native", Hooks: tracers.CallFrame}
 }
 
 // GetResult returns the json-encoded nested list of call traces, and any

--- a/eth/tracers/native/call.go
+++ b/eth/tracers/native/call.go
@@ -151,6 +151,10 @@ func (t *callTracer) Hooks() *vm.Hooks {
 	return h
 }
 
+func (t *callTracer) Settings() *tracers.TracerSettings {
+	return &tracers.TracerSettings{Engine: "native"}
+}
+
 // GetResult returns the json-encoded nested list of call traces, and any
 // error arising from the encoding or forceful termination (via `Stop`).
 func (t *callTracer) GetResult() (json.RawMessage, error) {

--- a/eth/tracers/native/call.go
+++ b/eth/tracers/native/call.go
@@ -145,8 +145,8 @@ func (t *callTracer) CaptureExit(output []byte, gasUsed uint64, err error) {
 
 // Settings returns information about the tracer and which hooks
 // it is interested in.
-func (t *callTracer) Settings() vm.LoggerSettings {
-	return vm.LoggerSettings{Hooks: vm.CallFrameHook}
+func (t *callTracer) Settings() *vm.LoggerSettings {
+	return &vm.LoggerSettings{Hooks: vm.CallFrameHook}
 }
 
 // GetResult returns the json-encoded nested list of call traces, and any

--- a/eth/tracers/native/call.go
+++ b/eth/tracers/native/call.go
@@ -145,8 +145,10 @@ func (t *callTracer) CaptureExit(output []byte, gasUsed uint64, err error) {
 
 // Settings returns information about the tracer and which hooks
 // it is interested in.
-func (t *callTracer) Settings() *vm.LoggerSettings {
-	return &vm.LoggerSettings{Hooks: vm.CallFrameHook}
+func (t *callTracer) Hooks() *vm.Hooks {
+	h := new(vm.Hooks)
+	h.Set(vm.CallFrameHook)
+	return h
 }
 
 // GetResult returns the json-encoded nested list of call traces, and any

--- a/eth/tracers/native/call.go
+++ b/eth/tracers/native/call.go
@@ -146,7 +146,8 @@ func (t *callTracer) CaptureExit(output []byte, gasUsed uint64, err error) {
 // Settings returns information about the tracer and which hooks
 // it is interested in.
 func (t *callTracer) Settings() tracers.TracerSettings {
-	return tracers.TracerSettings{Engine: "native"}
+	hooks := tracers.CallFrame
+	return tracers.TracerSettings{Engine: "native", Hooks: hooks}
 }
 
 // GetResult returns the json-encoded nested list of call traces, and any

--- a/eth/tracers/native/call.go
+++ b/eth/tracers/native/call.go
@@ -143,6 +143,12 @@ func (t *callTracer) CaptureExit(output []byte, gasUsed uint64, err error) {
 	t.callstack[size-1].Calls = append(t.callstack[size-1].Calls, call)
 }
 
+// Settings returns information about the tracer and which hooks
+// it is interested in.
+func (t *callTracer) Settings() tracers.TracerSettings {
+	return tracers.TracerSettings{Engine: "native"}
+}
+
 // GetResult returns the json-encoded nested list of call traces, and any
 // error arising from the encoding or forceful termination (via `Stop`).
 func (t *callTracer) GetResult() (json.RawMessage, error) {

--- a/eth/tracers/native/call.go
+++ b/eth/tracers/native/call.go
@@ -145,9 +145,8 @@ func (t *callTracer) CaptureExit(output []byte, gasUsed uint64, err error) {
 
 // Settings returns information about the tracer and which hooks
 // it is interested in.
-func (t *callTracer) Settings() tracers.TracerSettings {
-	hooks := tracers.CallFrame
-	return tracers.TracerSettings{Engine: "native", Hooks: hooks}
+func (t *callTracer) Settings() vm.LoggerSettings {
+	return vm.LoggerSettings{Hooks: vm.CallFrameHook}
 }
 
 // GetResult returns the json-encoded nested list of call traces, and any

--- a/eth/tracers/native/noop.go
+++ b/eth/tracers/native/noop.go
@@ -64,6 +64,12 @@ func (t *noopTracer) CaptureEnter(typ vm.OpCode, from common.Address, to common.
 func (t *noopTracer) CaptureExit(output []byte, gasUsed uint64, err error) {
 }
 
+// Settings returns information about the tracer and which hooks
+// it is interested in.
+func (t *noopTracer) Settings() tracers.TracerSettings {
+	return tracers.TracerSettings{Engine: "native"}
+}
+
 // GetResult returns an empty json object.
 func (t *noopTracer) GetResult() (json.RawMessage, error) {
 	return json.RawMessage(`{}`), nil

--- a/eth/tracers/native/noop.go
+++ b/eth/tracers/native/noop.go
@@ -67,7 +67,7 @@ func (t *noopTracer) CaptureExit(output []byte, gasUsed uint64, err error) {
 // Settings returns information about the tracer and which hooks
 // it is interested in.
 func (t *noopTracer) Settings() tracers.TracerSettings {
-	return tracers.TracerSettings{Engine: "native"}
+	return tracers.TracerSettings{Engine: "native", Hooks: 0}
 }
 
 // GetResult returns an empty json object.

--- a/eth/tracers/native/noop.go
+++ b/eth/tracers/native/noop.go
@@ -68,6 +68,10 @@ func (t *noopTracer) Hooks() *vm.Hooks {
 	return new(vm.Hooks)
 }
 
+func (t *noopTracer) Settings() *tracers.TracerSettings {
+	return &tracers.TracerSettings{Engine: "native"}
+}
+
 // GetResult returns an empty json object.
 func (t *noopTracer) GetResult() (json.RawMessage, error) {
 	return json.RawMessage(`{}`), nil

--- a/eth/tracers/native/noop.go
+++ b/eth/tracers/native/noop.go
@@ -64,8 +64,8 @@ func (t *noopTracer) CaptureExit(output []byte, gasUsed uint64, err error) {}
 
 // Settings returns information about the tracer and which hooks
 // it is interested in.
-func (t *noopTracer) Settings() *vm.LoggerSettings {
-	return &vm.LoggerSettings{Hooks: 0}
+func (t *noopTracer) Hooks() *vm.Hooks {
+	return new(vm.Hooks)
 }
 
 // GetResult returns an empty json object.

--- a/eth/tracers/native/noop.go
+++ b/eth/tracers/native/noop.go
@@ -44,8 +44,7 @@ func (t *noopTracer) CaptureStart(env *vm.EVM, from common.Address, to common.Ad
 }
 
 // CaptureEnd is called after the call finishes to finalize the tracing.
-func (t *noopTracer) CaptureEnd(output []byte, gasUsed uint64, _ time.Duration, err error) {
-}
+func (t *noopTracer) CaptureEnd(output []byte, gasUsed uint64, _ time.Duration, err error) {}
 
 // CaptureState implements the EVMLogger interface to trace a single step of VM execution.
 func (t *noopTracer) CaptureState(pc uint64, op vm.OpCode, gas, cost uint64, scope *vm.ScopeContext, rData []byte, depth int, err error) {
@@ -61,13 +60,12 @@ func (t *noopTracer) CaptureEnter(typ vm.OpCode, from common.Address, to common.
 
 // CaptureExit is called when EVM exits a scope, even if the scope didn't
 // execute any code.
-func (t *noopTracer) CaptureExit(output []byte, gasUsed uint64, err error) {
-}
+func (t *noopTracer) CaptureExit(output []byte, gasUsed uint64, err error) {}
 
 // Settings returns information about the tracer and which hooks
 // it is interested in.
-func (t *noopTracer) Settings() vm.LoggerSettings {
-	return vm.LoggerSettings{Hooks: 0}
+func (t *noopTracer) Settings() *vm.LoggerSettings {
+	return &vm.LoggerSettings{Hooks: 0}
 }
 
 // GetResult returns an empty json object.

--- a/eth/tracers/native/noop.go
+++ b/eth/tracers/native/noop.go
@@ -66,8 +66,8 @@ func (t *noopTracer) CaptureExit(output []byte, gasUsed uint64, err error) {
 
 // Settings returns information about the tracer and which hooks
 // it is interested in.
-func (t *noopTracer) Settings() tracers.TracerSettings {
-	return tracers.TracerSettings{Engine: "native", Hooks: 0}
+func (t *noopTracer) Settings() vm.LoggerSettings {
+	return vm.LoggerSettings{Hooks: 0}
 }
 
 // GetResult returns an empty json object.

--- a/eth/tracers/tracers.go
+++ b/eth/tracers/tracers.go
@@ -37,9 +37,15 @@ type Context struct {
 // allows collecting the tracing result.
 type Tracer interface {
 	vm.EVMLogger
+	// Returns info such as which hooks the tracer is interested in.
+	Settings() TracerSettings
 	GetResult() (json.RawMessage, error)
 	// Stop terminates execution of the tracer at the first opportune moment.
 	Stop(err error)
+}
+
+type TracerSettings struct {
+	Engine string
 }
 
 type lookupFunc func(string, *Context) (Tracer, error)

--- a/eth/tracers/tracers.go
+++ b/eth/tracers/tracers.go
@@ -44,8 +44,19 @@ type Tracer interface {
 	Stop(err error)
 }
 
+type Hooks uint16
+
+const (
+	Step      Hooks = 1 << iota
+	CallFrame Hooks = 2 << iota
+)
+
+func Set(h, flag Hooks) Hooks { return h | flag }
+func Has(h, flag Hooks) bool  { return h&flag != 0 }
+
 type TracerSettings struct {
 	Engine string
+	Hooks  Hooks
 }
 
 type lookupFunc func(string, *Context) (Tracer, error)

--- a/eth/tracers/tracers.go
+++ b/eth/tracers/tracers.go
@@ -40,6 +40,11 @@ type Tracer interface {
 	GetResult() (json.RawMessage, error)
 	// Stop terminates execution of the tracer at the first opportune moment.
 	Stop(err error)
+	Settings() *TracerSettings
+}
+
+type TracerSettings struct {
+	Engine string
 }
 
 type lookupFunc func(string, *Context) (Tracer, error)

--- a/eth/tracers/tracers.go
+++ b/eth/tracers/tracers.go
@@ -37,26 +37,9 @@ type Context struct {
 // allows collecting the tracing result.
 type Tracer interface {
 	vm.EVMLogger
-	// Returns info such as which hooks the tracer is interested in.
-	Settings() TracerSettings
 	GetResult() (json.RawMessage, error)
 	// Stop terminates execution of the tracer at the first opportune moment.
 	Stop(err error)
-}
-
-type Hooks uint16
-
-const (
-	Step      Hooks = 1 << iota
-	CallFrame Hooks = 2 << iota
-)
-
-func Set(h, flag Hooks) Hooks { return h | flag }
-func Has(h, flag Hooks) bool  { return h&flag != 0 }
-
-type TracerSettings struct {
-	Engine string
-	Hooks  Hooks
 }
 
 type lookupFunc func(string, *Context) (Tracer, error)


### PR DESCRIPTION
I'm thinking about an alternative approach to have a "proxy" tracer which checks the hooks and forwards only the desired events. So that we don't pollute the Logger interface.