### PR TITLE
accounts: correct spelling mistakes

### DIFF
--- a/accounts/accounts.go
+++ b/accounts/accounts.go
@@ -46,7 +46,7 @@ const (
 // accounts (derived from the same seed).
 type Wallet interface {
 	// URL retrieves the canonical path under which this wallet is reachable. It is
-	// user by upper layers to define a sorting order over all wallets from multiple
+	// used by upper layers to define a sorting order over all wallets from multiple
 	// backends.
 	URL() URL
 


### PR DESCRIPTION
I believe the sentence is attempting to explain that the URL is "[used] by upper layers to define a sorting order over all wallets from multiple backends."