### PR TITLE
rpc, node: refactor request validation and add jwt validation

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -27,6 +27,7 @@ require (
 	github.com/gballet/go-libpcsclite v0.0.0-20190607065134-2772fd86a8ff
 	github.com/go-ole/go-ole v1.2.1 // indirect
 	github.com/go-stack/stack v1.8.0
+	github.com/golang-jwt/jwt/v4 v4.2.0 // indirect
 	github.com/golang/protobuf v1.4.3
 	github.com/golang/snappy v0.0.4
 	github.com/google/gofuzz v1.1.1-0.20200604201612-c04b05f3adfa

--- a/go.sum
+++ b/go.sum
@@ -167,6 +167,8 @@ github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/me
 github.com/gofrs/uuid v3.3.0+incompatible/go.mod h1:b2aQJv3Z4Fp6yNu3cdSllBxTCLRxnplIgP/c0N/04lM=
 github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
 github.com/gogo/protobuf v1.3.1/go.mod h1:SlYgWuQ5SjCEi6WLHjHCa1yvBfUnHcTbrrZtXPKa29o=
+github.com/golang-jwt/jwt/v4 v4.2.0 h1:besgBTC8w8HjP6NzQdxwKH9Z5oQMZ24ThTrHp3cZ8eU=
+github.com/golang-jwt/jwt/v4 v4.2.0/go.mod h1:/xlHOz8bRuivTWchD4jCa+NbatV+wEUSzwAxVc6locg=
 github.com/golang/freetype v0.0.0-20170609003504-e2365dfdc4a0/go.mod h1:E/TSTwGwJL78qG/PmXZO1EjYhfJinVAhrmmHX6Z8B9k=
 github.com/golang/geo v0.0.0-20190916061304-5b978397cfec/go.mod h1:QZ0nwyI2jOfgRAoBvP+ab5aRr7c9x7lhGEJrKvBwjWI=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=

--- a/node/node.go
+++ b/node/node.go
@@ -349,7 +349,7 @@ func (n *Node) startRPC() error {
 			return err
 		}
 	}
-
+	jwtSecret := []byte("secret")
 	// Configure HTTP.
 	if n.config.HTTPHost != "" {
 		config := httpConfig{
@@ -357,6 +357,7 @@ func (n *Node) startRPC() error {
 			Vhosts:             n.config.HTTPVirtualHosts,
 			Modules:            n.config.HTTPModules,
 			prefix:             n.config.HTTPPathPrefix,
+			jwtSecret:          jwtSecret,
 		}
 		if err := n.http.setListenAddr(n.config.HTTPHost, n.config.HTTPPort); err != nil {
 			return err
@@ -370,9 +371,10 @@ func (n *Node) startRPC() error {
 	if n.config.WSHost != "" {
 		server := n.wsServerForPort(n.config.WSPort)
 		config := wsConfig{
-			Modules: n.config.WSModules,
-			Origins: n.config.WSOrigins,
-			prefix:  n.config.WSPathPrefix,
+			Modules:   n.config.WSModules,
+			Origins:   n.config.WSOrigins,
+			prefix:    n.config.WSPathPrefix,
+			jwtSecret: jwtSecret,
 		}
 		if err := server.setListenAddr(n.config.WSHost, n.config.WSPort); err != nil {
 			return err

--- a/rpc/server.go
+++ b/rpc/server.go
@@ -46,16 +46,32 @@ type Server struct {
 	idgen    func() ID
 	run      int32
 	codecs   mapset.Set
+
+	// Chained request validators
+	requestValidators []RequestValidator
 }
 
-// NewServer creates a new server instance with no registered handlers.
+// NewServer creates a new server instance with no registered handlers, but with the
+// default set of request validators.
 func NewServer() *Server {
-	server := &Server{idgen: randomIDGenerator(), codecs: mapset.NewSet(), run: 1}
+	server := &Server{idgen: randomIDGenerator(), codecs: mapset.NewSet(), run: 1,
+		requestValidators: DefaultValidators}
 	// Register the default service providing meta information about the RPC service such
 	// as the services and methods it offers.
 	rpcService := &RPCService{server}
 	server.RegisterName(MetadataApi, rpcService)
 	return server
+}
+
+// SetValidators sets the http request validators.
+func (s *Server) SetValidators(validators []RequestValidator) *Server {
+	s.requestValidators = validators
+	return s
+}
+
+// AppendValidator appends a http request validator.
+func (s *Server) AppendValidator(validator RequestValidator) {
+	s.requestValidators = append(s.requestValidators, validator)
 }
 
 // RegisterName creates a service for the given receiver type under the given name. When no

--- a/rpc/validation.go
+++ b/rpc/validation.go
@@ -1,0 +1,118 @@
+// Copyright 2015 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+package rpc
+
+import (
+	"errors"
+	"fmt"
+	"mime"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/golang-jwt/jwt/v4"
+)
+
+// RequestValidator is a HTTP request validator.
+// If the request is invalid/rejected, the method returns the http status code
+// along with an error.
+// If the request is valid/accepted, the method returns (0, nil).
+type RequestValidator func(r *http.Request) (int, error)
+
+var DefaultValidators = []RequestValidator{
+	ValidateMethod,
+	ValidateContentLength,
+	ValidateContentType}
+
+// ValidateMethod validates the HTTP method.
+func ValidateMethod(r *http.Request) (int, error) {
+	if r.Method == http.MethodPut || r.Method == http.MethodDelete {
+		return http.StatusMethodNotAllowed, errors.New("method not allowed")
+	}
+	return 0, nil
+}
+
+// ValidateContentLength validates the http Content-Length
+func ValidateContentLength(r *http.Request) (int, error) {
+	if r.ContentLength > maxRequestContentLength {
+		err := fmt.Errorf("content length too large (%d>%d)", r.ContentLength, maxRequestContentLength)
+		return http.StatusRequestEntityTooLarge, err
+	}
+	return 0, nil
+}
+
+// ValidateContentType validates the http content type.
+func ValidateContentType(r *http.Request) (int, error) {
+	// Allow OPTIONS (regardless of content-type)
+	if r.Method == http.MethodOptions {
+		return 0, nil
+	}
+	// Check content-type
+	if mt, _, err := mime.ParseMediaType(r.Header.Get("content-type")); err == nil {
+		for _, accepted := range acceptedContentTypes {
+			if accepted == mt {
+				return 0, nil
+			}
+		}
+	}
+	// Invalid content-type
+	err := fmt.Errorf("invalid content type, only %s is supported", contentType)
+	return http.StatusUnsupportedMediaType, err
+}
+
+// customClaim implements claims.Claim.
+type customClaim struct {
+	// the `iat` (Issued At) claim. See https://datatracker.ietf.org/doc/html/rfc7519#section-4.1.6
+	IssuedAt int64 `json:"iat,omitempty"`
+}
+
+// Valid implements claims.Claim, and checks that the iat is present and valid.
+func (c customClaim) Valid() error {
+	if time.Now().Unix()-5 < c.IssuedAt {
+		return errors.New("token issuance (iat) is too old")
+	}
+	if time.Now().Unix()+5 > c.IssuedAt {
+		return errors.New("token issuance (iat) is too far in the future")
+	}
+	return nil
+}
+
+// MakeJWTValidator creates a validator for jwt tokens.
+func MakeJWTValidator(secret []byte) RequestValidator {
+	keyFunc := func(token *jwt.Token) (interface{}, error) {
+		return secret, nil
+	}
+	return func(r *http.Request) (int, error) {
+		var token string
+		if auth := r.Header.Get("Authorization"); strings.HasPrefix(auth, "Bearer ") {
+			token = strings.TrimPrefix(auth, "Bearer ")
+		}
+		if len(token) == 0 {
+			return http.StatusForbidden, errors.New("missing token")
+		}
+		var claims customClaim
+		t, err := jwt.ParseWithClaims(token, claims, keyFunc, jwt.WithValidMethods([]string{"HS256"}))
+		if err != nil {
+			return http.StatusForbidden, err
+		}
+		if !t.Valid {
+			// This should not happen, but better safe than sorry if the implementation changes.
+			return http.StatusForbidden, errors.New("invalid token")
+		}
+		return 0, nil
+	}
+}


### PR DESCRIPTION
This is still a work in progress, putting it here for some early feedback. 

This PR adds support to add validators for http requests, and refactors the existing inlined validators out. This way, the jwt validators can just be appended as the last validator. 

This PR as is currently hardcodes a jwt secret on both http and ws (so would totally break everyone's UX), but ignore that for now...  