### PR TITLE
make CallContract also accepts block hash

### DIFF
--- a/ethclient/ethclient.go
+++ b/ethclient/ethclient.go
@@ -447,9 +447,9 @@ func (ec *Client) PendingTransactionCount(ctx context.Context) (uint, error) {
 // blockNumber selects the block height at which the call runs. It can be nil, in which
 // case the code is taken from the latest known block. Note that state from very old
 // blocks might not be available.
-func (ec *Client) CallContract(ctx context.Context, msg ethereum.CallMsg, blockNumber *big.Int) ([]byte, error) {
+func (ec *Client) CallContract(ctx context.Context, msg ethereum.CallMsg, blockNumberOrHash rpc.BlockNumberOrHash) ([]byte, error) {
 	var hex hexutil.Bytes
-	err := ec.c.CallContext(ctx, &hex, "eth_call", toCallArg(msg), toBlockNumArg(blockNumber))
+	err := ec.c.CallContext(ctx, &hex, "eth_call", toCallArg(msg), blockNumberOrHash)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
[`Client.CallContract`](https://github.com/ethereum/go-ethereum/blob/master/ethclient/ethclient.go#L450) should be aligned with [`PublicBlockChainAPI.Call`](https://github.com/ethereum/go-ethereum/blob/master/internal/ethapi/api.go#L983) so that the user can choose to call contract at specific height or block hash.

Constants like [`EarliestBlockNumber`](https://github.com/ethereum/go-ethereum/blob/master/rpc/types.go#L65) or [`LatestBlockNumber`](https://github.com/ethereum/go-ethereum/blob/master/rpc/types.go#L64) can still be used with minimal change .