### PR TITLE
ethclient: make CallContract also accept block hash

### DIFF
--- a/accounts/abi/bind/backend.go
+++ b/accounts/abi/bind/backend.go
@@ -24,6 +24,7 @@ import (
 	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/rpc"
 )
 
 var (
@@ -50,7 +51,7 @@ type ContractCaller interface {
 
 	// CallContract executes an Ethereum contract call with the specified data as the
 	// input.
-	CallContract(ctx context.Context, call ethereum.CallMsg, blockNumber *big.Int) ([]byte, error)
+	CallContract(ctx context.Context, call ethereum.CallMsg, blockNumber rpc.BlockNumberOrHash) ([]byte, error)
 }
 
 // PendingContractCaller defines methods to perform contract calls on the pending state.

--- a/accounts/abi/bind/backend.go
+++ b/accounts/abi/bind/backend.go
@@ -51,7 +51,7 @@ type ContractCaller interface {
 
 	// CallContract executes an Ethereum contract call with the specified data as the
 	// input.
-	CallContract(ctx context.Context, call ethereum.CallMsg, blockNumber rpc.BlockNumberOrHash) ([]byte, error)
+	CallContract(ctx context.Context, call ethereum.CallMsg, blockNumberOrHash rpc.BlockNumberOrHash) ([]byte, error)
 }
 
 // PendingContractCaller defines methods to perform contract calls on the pending state.

--- a/accounts/abi/bind/backends/simulated.go
+++ b/accounts/abi/bind/backends/simulated.go
@@ -419,7 +419,7 @@ func (b *SimulatedBackend) CallContract(ctx context.Context, call ethereum.CallM
 	defer b.mu.Unlock()
 
 	currentBlock := b.blockchain.CurrentBlock()
-	if (blockNumberOrHash.BlockHash != nil && *blockNumberOrHash.BlockHash != currentBlock.Hash()) || (blockNumberOrHash.BlockNumber != nil && *blockNumberOrHash.BlockNumber != (rpc.BlockNumber(currentBlock.Number().Int64()))) {
+	if (blockNumberOrHash.BlockHash != nil && *blockNumberOrHash.BlockHash != currentBlock.Hash()) || (blockNumberOrHash.BlockNumber != nil && *blockNumberOrHash.BlockNumber != rpc.BlockNumber(currentBlock.Number().Int64())) {
 		return nil, errBlockNumberUnsupported
 	}
 	stateDB, err := b.blockchain.State()

--- a/accounts/abi/bind/backends/simulated.go
+++ b/accounts/abi/bind/backends/simulated.go
@@ -418,7 +418,8 @@ func (b *SimulatedBackend) CallContract(ctx context.Context, call ethereum.CallM
 	b.mu.Lock()
 	defer b.mu.Unlock()
 
-	if (blockNumberOrHash.BlockHash != nil && *blockNumberOrHash.BlockHash != b.blockchain.CurrentBlock().Hash()) || (blockNumberOrHash.BlockNumber != nil && (*blockNumberOrHash.BlockNumber) != (rpc.BlockNumber(b.blockchain.CurrentBlock().Number().Int64()))) {
+	currentBlock := b.blockchain.CurrentBlock()
+	if (blockNumberOrHash.BlockHash != nil && *blockNumberOrHash.BlockHash != currentBlock.Hash()) || (blockNumberOrHash.BlockNumber != nil && *blockNumberOrHash.BlockNumber != (rpc.BlockNumber(currentBlock.Number().Int64()))) {
 		return nil, errBlockNumberUnsupported
 	}
 	stateDB, err := b.blockchain.State()

--- a/accounts/abi/bind/backends/simulated.go
+++ b/accounts/abi/bind/backends/simulated.go
@@ -414,11 +414,11 @@ func (e *revertError) ErrorData() interface{} {
 }
 
 // CallContract executes a contract call.
-func (b *SimulatedBackend) CallContract(ctx context.Context, call ethereum.CallMsg, blockNumber *big.Int) ([]byte, error) {
+func (b *SimulatedBackend) CallContract(ctx context.Context, call ethereum.CallMsg, blockNumberOrHash rpc.BlockNumberOrHash) ([]byte, error) {
 	b.mu.Lock()
 	defer b.mu.Unlock()
 
-	if blockNumber != nil && blockNumber.Cmp(b.blockchain.CurrentBlock().Number()) != 0 {
+	if (blockNumberOrHash.BlockHash != nil && *blockNumberOrHash.BlockHash != b.blockchain.CurrentBlock().Hash()) || (blockNumberOrHash.BlockNumber != nil && (*blockNumberOrHash.BlockNumber) != (rpc.BlockNumber(b.blockchain.CurrentBlock().Number().Int64()))) {
 		return nil, errBlockNumberUnsupported
 	}
 	stateDB, err := b.blockchain.State()

--- a/accounts/abi/bind/backends/simulated_test.go
+++ b/accounts/abi/bind/backends/simulated_test.go
@@ -35,6 +35,7 @@ import (
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/params"
+	"github.com/ethereum/go-ethereum/rpc"
 )
 
 func TestSimulatedBackend(t *testing.T) {
@@ -1042,7 +1043,7 @@ func TestPendingAndCallContract(t *testing.T) {
 		From: testAddr,
 		To:   &addr,
 		Data: input,
-	}, nil)
+	}, rpc.BlockNumberOrHash{})
 	if err != nil {
 		t.Errorf("could not call receive method on contract: %v", err)
 	}
@@ -1117,7 +1118,7 @@ func TestCallContractRevert(t *testing.T) {
 			From: testAddr,
 			To:   &addr,
 			Data: input,
-		}, nil)
+		}, rpc.BlockNumberOrHash{})
 	}
 
 	// Run pending calls then commit

--- a/accounts/abi/bind/base.go
+++ b/accounts/abi/bind/base.go
@@ -30,6 +30,7 @@ import (
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/event"
+	"github.com/ethereum/go-ethereum/rpc"
 )
 
 // SignerFn is a signer function callback when a contract requires a method to
@@ -180,7 +181,12 @@ func (c *BoundContract) Call(opts *CallOpts, results *[]interface{}, method stri
 			}
 		}
 	} else {
-		output, err = c.caller.CallContract(ctx, msg, opts.BlockNumber)
+		blockNumberOrHash := rpc.BlockNumberOrHash{}
+		if opts.BlockNumber != nil {
+			blockNumber := rpc.BlockNumber(opts.BlockNumber.Int64())
+			blockNumberOrHash.BlockNumber = &blockNumber
+		}
+		output, err = c.caller.CallContract(ctx, msg, blockNumberOrHash)
 		if err != nil {
 			return err
 		}

--- a/accounts/abi/bind/base.go
+++ b/accounts/abi/bind/base.go
@@ -42,6 +42,7 @@ type CallOpts struct {
 	Pending     bool            // Whether to operate on the pending state or the last known one
 	From        common.Address  // Optional the sender address, otherwise the first account is used
 	BlockNumber *big.Int        // Optional the block number on which the call should be performed
+	BlockHash   *common.Hash    // Optional the block hash on which the call should be performed
 	Context     context.Context // Network context to support cancellation and timeouts (nil = no timeout)
 }
 
@@ -185,6 +186,12 @@ func (c *BoundContract) Call(opts *CallOpts, results *[]interface{}, method stri
 		if opts.BlockNumber != nil {
 			blockNumber := rpc.BlockNumber(opts.BlockNumber.Int64())
 			blockNumberOrHash.BlockNumber = &blockNumber
+		}
+		if opts.BlockHash != nil {
+			if blockNumberOrHash.BlockNumber != nil {
+				return fmt.Errorf("cannot specify both BlockHash and BlockNumber, choose one or the other")
+			}
+			blockNumberOrHash.BlockHash = opts.BlockHash
 		}
 		output, err = c.caller.CallContract(ctx, msg, blockNumberOrHash)
 		if err != nil {

--- a/ethclient/ethclient.go
+++ b/ethclient/ethclient.go
@@ -444,12 +444,16 @@ func (ec *Client) PendingTransactionCount(ctx context.Context) (uint, error) {
 // CallContract executes a message call transaction, which is directly executed in the VM
 // of the node, but never mined into the blockchain.
 //
-// blockNumber selects the block height at which the call runs. It can be nil, in which
+// blockNumberOrHash selects the block height or block hash at which the call runs. It can be empty, in which
 // case the code is taken from the latest known block. Note that state from very old
 // blocks might not be available.
-func (ec *Client) CallContract(ctx context.Context, msg ethereum.CallMsg, blockNumber *big.Int) ([]byte, error) {
+func (ec *Client) CallContract(ctx context.Context, msg ethereum.CallMsg, blockNumberOrHash rpc.BlockNumberOrHash) ([]byte, error) {
+	if blockNumberOrHash.BlockHash == nil && blockNumberOrHash.BlockNumber == nil {
+		latest := rpc.BlockNumber(rpc.LatestBlockNumber)
+		blockNumberOrHash.BlockNumber = &latest
+	}
 	var hex hexutil.Bytes
-	err := ec.c.CallContext(ctx, &hex, "eth_call", toCallArg(msg), toBlockNumArg(blockNumber))
+	err := ec.c.CallContext(ctx, &hex, "eth_call", toCallArg(msg), blockNumberOrHash)
 	if err != nil {
 		return nil, err
 	}

--- a/ethclient/ethclient_test.go
+++ b/ethclient/ethclient_test.go
@@ -525,7 +525,7 @@ func testCallContract(t *testing.T, client *rpc.Client) {
 		t.Fatalf("unexpected gas price: %v", gas)
 	}
 	// CallContract
-	if _, err := ec.CallContract(context.Background(), msg, big.NewInt(1)); err != nil {
+	if _, err := ec.CallContract(context.Background(), msg, rpc.BlockNumberOrHashWithNumber(1)); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	// PendingCallCOntract

--- a/interfaces.go
+++ b/interfaces.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/rpc"
 )
 
 // NotFound is returned by API methods if the requested item does not exist.
@@ -149,7 +150,7 @@ type CallMsg struct {
 // execute such calls. For applications which are structured around specific contracts,
 // the abigen tool provides a nicer, properly typed way to perform calls.
 type ContractCaller interface {
-	CallContract(ctx context.Context, call CallMsg, blockNumber *big.Int) ([]byte, error)
+	CallContract(ctx context.Context, call CallMsg, blockNumberOrHash rpc.BlockNumberOrHash) ([]byte, error)
 }
 
 // FilterQuery contains options for contract log filtering.

--- a/mobile/ethclient.go
+++ b/mobile/ethclient.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/ethclient"
+	"github.com/ethereum/go-ethereum/rpc"
 )
 
 // EthereumClient provides access to the Ethereum APIs.
@@ -280,9 +281,9 @@ func (ec *EthereumClient) GetPendingTransactionCount(ctx *Context) (count int, _
 // blocks might not be available.
 func (ec *EthereumClient) CallContract(ctx *Context, msg *CallMsg, number int64) (output []byte, _ error) {
 	if number < 0 {
-		return ec.client.CallContract(ctx.context, msg.msg, nil)
+		return ec.client.CallContract(ctx.context, msg.msg, rpc.BlockNumberOrHash{})
 	}
-	return ec.client.CallContract(ctx.context, msg.msg, big.NewInt(number))
+	return ec.client.CallContract(ctx.context, msg.msg, rpc.BlockNumberOrHashWithNumber(rpc.BlockNumber(number)))
 }
 
 // PendingCallContract executes a message call transaction using the EVM.


### PR DESCRIPTION
[`Client.CallContract`](https://github.com/ethereum/go-ethereum/blob/master/ethclient/ethclient.go#L450) should be aligned with [`PublicBlockChainAPI.Call`](https://github.com/ethereum/go-ethereum/blob/master/internal/ethapi/api.go#L983) so that the user can choose to call contract at specific height or block hash.

Constants like [`EarliestBlockNumber`](https://github.com/ethereum/go-ethereum/blob/master/rpc/types.go#L65) or [`LatestBlockNumber`](https://github.com/ethereum/go-ethereum/blob/master/rpc/types.go#L64) can still be used with minimal change .