### PR TITLE
mobile: remove deprecated Stop function

### DIFF
--- a/mobile/geth.go
+++ b/mobile/geth.go
@@ -220,14 +220,6 @@ func (n *Node) Start() error {
 	return n.node.Start()
 }
 
-// Stop terminates a running node along with all its services. If the node was not started,
-// an error is returned. It is not possible to restart a stopped node.
-//
-// Deprecated: use Close()
-func (n *Node) Stop() error {
-	return n.node.Close()
-}
-
 // GetEthereumClient retrieves a client to access the Ethereum subsystem.
 func (n *Node) GetEthereumClient() (client *EthereumClient, _ error) {
 	rpc, err := n.node.Attach()


### PR DESCRIPTION
The function removed in this PR was first deprecated around a year and a half ago, in #21105.
This PR removes support for the deprecated Stop() function.