### PR TITLE
core/vm: Memory.GetPtr should not read beyond store

### DIFF
--- a/core/vm/memory.go
+++ b/core/vm/memory.go
@@ -90,15 +90,12 @@ func (m *Memory) GetPtr(offset, size int64) []byte {
 		return nil
 	}
 
-	if len(m.store) > int(offset) {
-		if len(m.store) >= int(offset+size) {
-			return m.store[offset : offset+size]
-		} else {
-			return m.store[offset:]
-		}
+	if len(m.store) >= int(offset+size) {
+		return m.store[offset : offset+size]
+	} else {
+		panic("invalid memory: get out of bound")
 	}
 
-	return nil
 }
 
 // Len returns the length of the backing slice

--- a/core/vm/memory.go
+++ b/core/vm/memory.go
@@ -91,7 +91,11 @@ func (m *Memory) GetPtr(offset, size int64) []byte {
 	}
 
 	if len(m.store) > int(offset) {
-		return m.store[offset : offset+size]
+		if len(m.store) >= int(offset+size) {
+			return m.store[offset : offset+size]
+		} else {
+			return m.store[offset:]
+		}
 	}
 
 	return nil


### PR DESCRIPTION
go will panic when read beyond slice boundary:

```
xuzhiqiangdeMacBook-Pro:go xuzhiqiang$ cat 1.go 
package main

import "fmt"
func main() {
        s := make([]byte, 3)

        ss := s[1:5]
        fmt.Println(len(ss))
}
xuzhiqiangdeMacBook-Pro:go xuzhiqiang$ go run 1.go 
panic: runtime error: slice bounds out of range [:5] with capacity 3

goroutine 1 [running]:
main.main()
        /tmp/go/1.go:7 +0x1d
exit status 2
```