### PR TITLE
p2p: reduce the scope of dialPubkey

### DIFF
--- a/p2p/server.go
+++ b/p2p/server.go
@@ -943,9 +943,8 @@ func (srv *Server) setupConn(c *conn, flags connFlag, dialDest *enode.Node) erro
 	}
 
 	// If dialing, figure out the remote public key.
-	var dialPubkey *ecdsa.PublicKey
 	if dialDest != nil {
-		dialPubkey = new(ecdsa.PublicKey)
+		dialPubkey := new(ecdsa.PublicKey)
 		if err := dialDest.Load((*enode.Secp256k1)(dialPubkey)); err != nil {
 			err = errors.New("dial destination doesn't have a secp256k1 public key")
 			srv.log.Trace("Setting up connection failed", "addr", c.fd.RemoteAddr(), "conn", c.flags, "err", err)


### PR DESCRIPTION
`dialPubkey` isn't used anywhere else after `dialDest.Load`, so it should be safe to restrict its scope to the `if clause`.