### PR TITLE
EIP-4758 Implementation

### DIFF
--- a/core/vm/instructions.go
+++ b/core/vm/instructions.go
@@ -834,6 +834,21 @@ func opSelfdestruct(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext
 	return nil, errStopToken
 }
 
+func opSendall(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]byte, error) {
+	if interpreter.readOnly {
+		return nil, ErrWriteProtection
+	}
+	beneficiary := scope.Stack.pop()
+	balance := interpreter.evm.StateDB.GetBalance(scope.Contract.Address())
+	interpreter.evm.StateDB.AddBalance(beneficiary.Bytes20(), balance)
+	interpreter.evm.StateDB.SubBalance(scope.Contract.Address(), balance)
+	if interpreter.cfg.Debug {
+		interpreter.cfg.Tracer.CaptureEnter(SENDALL, scope.Contract.Address(), beneficiary.Bytes20(), []byte{}, 0, balance)
+		interpreter.cfg.Tracer.CaptureExit([]byte{}, 0, nil)
+	}
+	return nil, errStopToken
+}
+
 // following functions are used by the instruction jump  table
 
 // make log instruction function

--- a/core/vm/interpreter.go
+++ b/core/vm/interpreter.go
@@ -60,6 +60,8 @@ func NewEVMInterpreter(evm *EVM, cfg Config) *EVMInterpreter {
 	// If jump table was not initialised we set the default one.
 	if cfg.JumpTable == nil {
 		switch {
+		case evm.chainRules.IsShanghai:
+			cfg.JumpTable = &shanghaiInstructionSet
 		case evm.chainRules.IsMerge:
 			cfg.JumpTable = &mergeInstructionSet
 		case evm.chainRules.IsLondon:

--- a/core/vm/jump_table.go
+++ b/core/vm/jump_table.go
@@ -55,6 +55,7 @@ var (
 	berlinInstructionSet           = newBerlinInstructionSet()
 	londonInstructionSet           = newLondonInstructionSet()
 	mergeInstructionSet            = newMergeInstructionSet()
+	shanghaiInstructionSet         = newShanghaiInstructionSet()
 )
 
 // JumpTable contains the EVM opcodes supported at a given fork.
@@ -76,6 +77,17 @@ func validate(jt JumpTable) JumpTable {
 		}
 	}
 	return jt
+}
+
+func newShanghaiInstructionSet() JumpTable {
+	instructionSet := newMergeInstructionSet()
+	instructionSet[SENDALL] = &operation{
+		execute:    opSendall,
+		dynamicGas: gasSelfdestructEIP3529,
+		minStack:   minStack(1, 0),
+		maxStack:   maxStack(1, 0),
+	}
+	return validate(instructionSet)
 }
 
 func newMergeInstructionSet() JumpTable {

--- a/core/vm/opcodes.go
+++ b/core/vm/opcodes.go
@@ -217,6 +217,7 @@ const (
 	REVERT       OpCode = 0xfd
 	INVALID      OpCode = 0xfe
 	SELFDESTRUCT OpCode = 0xff
+	SENDALL      OpCode = 0xff
 )
 
 // Since the opcodes aren't all in order we can't use a regular slice.
@@ -383,7 +384,7 @@ var opCodeToString = map[OpCode]string{
 	STATICCALL:   "STATICCALL",
 	REVERT:       "REVERT",
 	INVALID:      "INVALID",
-	SELFDESTRUCT: "SELFDESTRUCT",
+	SELFDESTRUCT: "SELFDESTRUCT", // TODO: rename to self-destruct after EIP-4758 goes in
 }
 
 func (op OpCode) String() string {
@@ -540,6 +541,7 @@ var stringToOp = map[string]OpCode{
 	"REVERT":         REVERT,
 	"INVALID":        INVALID,
 	"SELFDESTRUCT":   SELFDESTRUCT,
+	"SENDALL":        SENDALL,
 }
 
 // StringToOp finds the opcode whose name is stored in `str`.


### PR DESCRIPTION
This is an implementation of the "nuclear" option for removing SELFDESTRUCT in a future hardfork:

At block `SendallForkBlock`, the behavior of `SELFDESTRUCT` changes to only send the balance of the originating contract to the target recipient and no longer deletes the originating contract.