### PR TITLE
poc: less allocations during snap-sync

### DIFF
--- a/core/state/snapshot/generate.go
+++ b/core/state/snapshot/generate.go
@@ -428,7 +428,7 @@ func (dl *diskLayer) generateRange(root common.Hash, prefix []byte, kind string,
 
 	// We use the snap data to build up a cache which can be used by the
 	// main account trie as a primary lookup when resolving hashes
-	var snapNodeCache ethdb.KeyValueStore
+	var snapNodeCache *memorydb.Database
 	if len(result.keys) > 0 {
 		snapNodeCache = memorydb.New()
 		snapTrieDb := trie.NewDatabase(snapNodeCache)

--- a/core/vm/contracts_test.go
+++ b/core/vm/contracts_test.go
@@ -391,3 +391,18 @@ func BenchmarkPrecompiledBLS12381G2MultiExpWorstCase(b *testing.B) {
 	}
 	benchmarkPrecompiled("0f", testcase, b)
 }
+
+// TestEcrecover2 uses input from
+// https://github.com/ethereum/go-ethereum/issues/24037#issuecomment-1005641824
+func TestEcrecover2(t *testing.T) {
+	ec := &ecrecover{}
+	input := []byte{187, 96, 219, 168, 155, 3, 169, 4, 121, 177, 81, 151, 52, 171, 4, 70, 63, 107, 57, 13, 239, 31, 227, 245, 37, 152, 194, 136, 190, 12, 160, 188, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 28, 175, 213, 44, 44, 157, 70, 98, 170, 123, 13, 188, 240, 91, 160, 47, 101, 215, 183, 32, 89, 157, 103, 110, 15, 33, 90, 222, 137, 70, 187, 65, 238, 26, 171, 201, 10, 15, 215, 197, 247, 232, 145, 134, 173, 164, 40, 30, 36, 208, 100, 103, 222, 129, 78, 22, 77, 104, 166, 49, 40, 31, 50, 80, 147}
+	fmt.Printf("input: %d %x\n", len(input), input)
+	out, err := ec.Run(input)
+	if err != nil {
+		t.Fatal("expected no error")
+	}
+	if len(out) != 0 {
+		fmt.Printf("expected no output")
+	}
+}

--- a/ethdb/database.go
+++ b/ethdb/database.go
@@ -28,6 +28,12 @@ type KeyValueReader interface {
 	Get(key []byte) ([]byte, error)
 }
 
+type KeyValueMemReader interface {
+	KeyValueReader
+
+	GetDo(key []byte, onValue func([]byte)) error
+}
+
 // KeyValueWriter wraps the Put method of a backing data store.
 type KeyValueWriter interface {
 	// Put inserts the given value into the key-value data store.

--- a/ethdb/memorydb/memorydb.go
+++ b/ethdb/memorydb/memorydb.go
@@ -97,6 +97,22 @@ func (db *Database) Get(key []byte) ([]byte, error) {
 	return nil, errMemorydbNotFound
 }
 
+// Get looks up the given key. If it's present in the key-value store, then
+// the onValueFn is invoked. At this point, the data is 'raw' -- not copied, so
+// the method must not modify the backing slice.
+func (db *Database) GetDo(key []byte, onValueFn func([]byte)) error {
+	db.lock.RLock()
+	defer db.lock.RUnlock()
+	if db.db == nil {
+		return errMemorydbClosed
+	}
+	if entry, ok := db.db[string(key)]; ok {
+		onValueFn(entry)
+		return nil
+	}
+	return errMemorydbNotFound
+}
+
 // Put inserts the given value into the key-value store.
 func (db *Database) Put(key []byte, value []byte) error {
 	db.lock.Lock()


### PR DESCRIPTION
Based on an idea I had while reviewing a PR from Gary. 
Basically, when we use a resolver as a memory-backend to generate the snap trie, the backing db (a memorydb) copies out the data. But all we do with it is marshal it into a `node`, which we can do on the 'raw' data without actually doing the extra alloc there. 

Unfortunately, we don't seem to have any existing benchmarks for this case. Putting it up here for discussion. Might do a benchmark run with it at some point. 