### PR TITLE
Export `DefaultErrorCode`

### DIFF
--- a/rpc/errors.go
+++ b/rpc/errors.go
@@ -57,7 +57,7 @@ var (
 	_ Error = new(CustomError)
 )
 
-const defaultErrorCode = -32000
+const DefaultErrorCode = -32000
 
 type methodNotFoundError struct{ method string }
 

--- a/rpc/json.go
+++ b/rpc/json.go
@@ -108,7 +108,7 @@ func (msg *jsonrpcMessage) response(result interface{}) *jsonrpcMessage {
 
 func errorMessage(err error) *jsonrpcMessage {
 	msg := &jsonrpcMessage{Version: vsn, ID: null, Error: &jsonError{
-		Code:    defaultErrorCode,
+		Code:    DefaultErrorCode,
 		Message: err.Error(),
 	}}
 	ec, ok := err.(Error)


### PR DESCRIPTION
This constant is useful outside of the library. Instead of copy-pasting into my own codebase, I'd like to use this repo as the source of truth.