### PR TITLE
build: disable hirsuite builds

### DIFF
--- a/build/ci.go
+++ b/build/ci.go
@@ -130,13 +130,12 @@ var (
 	// Distros for which packages are created.
 	// Note: vivid is unsupported because there is no golang-1.6 package for it.
 	// Note: the following Ubuntu releases have been officially deprecated on Launchpad:
-	//   wily, yakkety, zesty, artful, cosmic, disco, eoan, groovy
+	//   wily, yakkety, zesty, artful, cosmic, disco, eoan, groovy, hirsuite
 	debDistroGoBoots = map[string]string{
 		"trusty":  "golang-1.11",
 		"xenial":  "golang-go",
 		"bionic":  "golang-go",
 		"focal":   "golang-go",
-		"hirsute": "golang-go",
 	}
 
 	debGoBootPaths = map[string]string{


### PR DESCRIPTION
From our launchpad build-uploader: 
```
Rejected:
hirsute is obsolete and will not accept new uploads.

ethereum (1.10.16+build27677+hirsute) hirsute; urgency=low

  * git build of 20356e57b119b4e70ce47665a71964434e15200d

```