### PR TITLE
core/types: marshal `Address` as `eip-55` instead of hex

### DIFF
--- a/cmd/evm/testdata/1/exp.json
+++ b/cmd/evm/testdata/1/exp.json
@@ -1,14 +1,14 @@
 {
   "alloc": {
-    "0x8a8eafb1cf62bfbeb1741769dae1a9dd47996192": {
+    "0x8A8eAFb1cf62BfBeb1741769DAE1a9dd47996192": {
       "balance": "0xfeed1a9d",
       "nonce": "0x1"
     },
-    "0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b": {
+    "0xa94f5374Fce5edBC8E2a8697C15331677e6EbF0B": {
       "balance": "0x5ffd4878be161d74",
       "nonce": "0xac"
     },
-    "0xc94f5374fce5edbc8e2a8697c15331677e6ebf0b": {
+    "0xc94f5374fCe5eDBc8e2a8697C15331677E6EBF0B": {
       "balance": "0xa410"
     }
   },

--- a/cmd/evm/testdata/10/alloc.json
+++ b/cmd/evm/testdata/10/alloc.json
@@ -6,14 +6,14 @@
     "storage" : {
     }
   },
-  "0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b" : {
+  "0xa94f5374Fce5edBC8E2a8697C15331677e6EbF0B" : {
     "balance" : "0x010000000000",
     "code" : "0x",
     "nonce" : "0x01",
     "storage" : {
     }
   },
-  "0xd02d72e067e77158444ef2020ff2d325f929b363" : {
+  "0xd02d72E067e77158444ef2020Ff2d325f929B363" : {
     "balance" : "0x01000000000000",
     "code" : "0x",
     "nonce" : "0x01",

--- a/cmd/evm/testdata/10/env.json
+++ b/cmd/evm/testdata/10/env.json
@@ -1,5 +1,5 @@
 {
-  "currentCoinbase" : "0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
+  "currentCoinbase" : "0x2ADC25665018Aa1FE0E6BC666DaC8Fc2697fF9bA",
   "currentDifficulty" : "0x020000",
   "currentNumber" : "0x01",
   "currentTimestamp" : "0x079e",

--- a/cmd/evm/testdata/10/readme.md
+++ b/cmd/evm/testdata/10/readme.md
@@ -15,11 +15,11 @@ Output:
    "balance": "0x10000000000",
    "nonce": "0x1"
   },
-  "0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b": {
+  "0xa94f5374Fce5edBC8E2a8697C15331677e6EbF0B": {
    "balance": "0x10000000000",
    "nonce": "0x1"
   },
-  "0xd02d72e067e77158444ef2020ff2d325f929b363": {
+  "0xd02d72E067e77158444ef2020Ff2d325f929B363": {
    "balance": "0xff5beffffc95",
    "nonce": "0x4"
   }

--- a/cmd/evm/testdata/11/alloc.json
+++ b/cmd/evm/testdata/11/alloc.json
@@ -1,12 +1,12 @@
 {
-    "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6" : {
+    "0x0f572e5295c57F15886F9b263E2f6d2d6c7b5ec6" : {
         "balance" : "0x0de0b6b3a7640000",
         "code" : "0x61ffff5060046000f3",
         "nonce" : "0x01",
         "storage" : {
         }
     },
-    "0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b" : {
+    "0xa94f5374Fce5edBC8E2a8697C15331677e6EbF0B" : {
         "balance" : "0x0de0b6b3a7640000",
         "code" : "0x",
         "nonce" : "0x00",

--- a/cmd/evm/testdata/11/env.json
+++ b/cmd/evm/testdata/11/env.json
@@ -1,5 +1,5 @@
 {
-    "currentCoinbase" : "0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
+    "currentCoinbase" : "0x2ADC25665018Aa1FE0E6BC666DaC8Fc2697fF9bA",
     "currentDifficulty" : "0x020000",
     "currentNumber" : "0x01",
     "currentTimestamp" : "0x03e8",

--- a/cmd/evm/testdata/12/alloc.json
+++ b/cmd/evm/testdata/12/alloc.json
@@ -1,5 +1,5 @@
 {
-    "0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b" : {
+    "0xa94f5374Fce5edBC8E2a8697C15331677e6EbF0B" : {
         "balance" : "84000000",
         "code" : "0x",
         "nonce" : "0x00",

--- a/cmd/evm/testdata/12/env.json
+++ b/cmd/evm/testdata/12/env.json
@@ -1,5 +1,5 @@
 {
-    "currentCoinbase" : "0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
+    "currentCoinbase" : "0x2ADC25665018Aa1FE0E6BC666DaC8Fc2697fF9bA",
     "currentDifficulty" : "0x020000",
     "currentNumber" : "0x01",
     "currentTimestamp" : "0x03e8",

--- a/cmd/evm/testdata/12/readme.md
+++ b/cmd/evm/testdata/12/readme.md
@@ -16,7 +16,7 @@ INFO [07-21|19:03:50.276] Trie dumping started                     root=e05f81..
 INFO [07-21|19:03:50.276] Trie dumping complete                    accounts=1 elapsed="39.549µs"
 {
  "alloc": {
-  "0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b": {
+  "0xa94f5374Fce5edBC8E2a8697C15331677e6EbF0B": {
    "balance": "0x501bd00"
   }
  },

--- a/cmd/evm/testdata/13/alloc.json
+++ b/cmd/evm/testdata/13/alloc.json
@@ -6,14 +6,14 @@
     "storage" : {
     }
   },
-  "0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b" : {
+  "0xa94f5374Fce5edBC8E2a8697C15331677e6EbF0B" : {
     "balance" : "0x010000000000",
     "code" : "0x",
     "nonce" : "0x01",
     "storage" : {
     }
   },
-  "0xd02d72e067e77158444ef2020ff2d325f929b363" : {
+  "0xd02d72E067e77158444ef2020Ff2d325f929B363" : {
     "balance" : "0x01000000000000",
     "code" : "0x",
     "nonce" : "0x01",

--- a/cmd/evm/testdata/13/env.json
+++ b/cmd/evm/testdata/13/env.json
@@ -1,5 +1,5 @@
 {
-  "currentCoinbase" : "0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
+  "currentCoinbase" : "0x2ADC25665018Aa1FE0E6BC666DaC8Fc2697fF9bA",
   "currentDifficulty" : "0x020000",
   "currentNumber" : "0x01",
   "currentTimestamp" : "0x079e",

--- a/cmd/evm/testdata/14/alloc.json
+++ b/cmd/evm/testdata/14/alloc.json
@@ -1,11 +1,11 @@
 {
-  "a94f5374fce5edbc8e2a8697c15331677e6ebf0b": {
+  "a94f5374Fce5edBC8E2a8697C15331677e6EbF0B": {
     "balance": "0x5ffd4878be161d74",
     "code": "0x",
     "nonce": "0xac",
     "storage": {}
   },
-  "0x8a8eafb1cf62bfbeb1741769dae1a9dd47996192":{
+  "0x8A8eAFb1cf62BfBeb1741769DAE1a9dd47996192":{
     "balance": "0xfeedbead",
     "nonce" : "0x00"
   }

--- a/cmd/evm/testdata/14/env.json
+++ b/cmd/evm/testdata/14/env.json
@@ -1,5 +1,5 @@
 {
-  "currentCoinbase": "0xc94f5374fce5edbc8e2a8697c15331677e6ebf0b",
+  "currentCoinbase": "0xc94f5374fCe5eDBc8e2a8697C15331677E6EBF0B",
   "currentGasLimit": "0x750a163df65e8a",
   "currentBaseFee": "0x500",
   "currentNumber": "12800000",

--- a/cmd/evm/testdata/14/env.uncles.json
+++ b/cmd/evm/testdata/14/env.uncles.json
@@ -1,5 +1,5 @@
 {
-  "currentCoinbase": "0xc94f5374fce5edbc8e2a8697c15331677e6ebf0b",
+  "currentCoinbase": "0xc94f5374fCe5eDBc8e2a8697C15331677E6EBF0B",
   "currentGasLimit": "0x750a163df65e8a",
   "currentBaseFee": "0x500",
   "currentNumber": "12800000",

--- a/cmd/evm/testdata/15/exp2.json
+++ b/cmd/evm/testdata/15/exp2.json
@@ -1,11 +1,11 @@
 [
   {
-    "address": "0xd02d72e067e77158444ef2020ff2d325f929b363",
+    "address": "0xd02d72E067e77158444ef2020Ff2d325f929B363",
     "hash": "0xa98a24882ea90916c6a86da650fbc6b14238e46f0af04a131ce92be897507476",
     "intrinsicGas": "0x5208"
   },
   {
-    "address": "0xd02d72e067e77158444ef2020ff2d325f929b363",
+    "address": "0xd02d72E067e77158444ef2020Ff2d325f929B363",
     "hash": "0x36bad80acce7040c45fd32764b5c2b2d2e6f778669fb41791f73f546d56e739a",
     "intrinsicGas": "0x5208"
   }

--- a/cmd/evm/testdata/16/exp.json
+++ b/cmd/evm/testdata/16/exp.json
@@ -1,12 +1,12 @@
 [
   {
-    "address": "0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b",
+    "address": "0xa94f5374Fce5edBC8E2a8697C15331677e6EbF0B",
     "hash": "0x7cc3d1a8540a44736750f03bb4d85c0113be4b3472a71bf82241a3b261b479e6",
     "intrinsicGas": "0x5208"
   },
   {
     "error": "intrinsic gas too low: have 82, want 21000",
-    "address": "0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b",
+    "address": "0xa94f5374Fce5edBC8E2a8697C15331677e6EbF0B",
     "hash": "0x3b2d2609e4361562edb9169314f4c05afc6dbf5d706bf9dda5abe242ab76a22b",
     "intrinsicGas": "0x5208"
   }

--- a/cmd/evm/testdata/17/exp.json
+++ b/cmd/evm/testdata/17/exp.json
@@ -1,13 +1,13 @@
  [
     {
       "error": "value exceeds 256 bits",
-      "address": "0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b",
+      "address": "0xa94f5374Fce5edBC8E2a8697C15331677e6EbF0B",
       "hash": "0xfbd91685dcbf8172f0e8c53e2ddbb4d26707840da6b51a74371f62a33868fd82",
       "intrinsicGas": "0x5208"
     },
     {
       "error": "gasPrice exceeds 256 bits",
-      "address": "0x1b57ccef1fe5fb73f1e64530fb4ebd9cf1655964",
+      "address": "0x1b57Ccef1FE5Fb73f1E64530fB4eBD9Cf1655964",
       "hash": "0x45dc05035cada83748e4c1fe617220106b331eca054f44c2304d5654a9fb29d5",
       "intrinsicGas": "0x5208"
     },

--- a/cmd/evm/testdata/19/alloc.json
+++ b/cmd/evm/testdata/19/alloc.json
@@ -1,11 +1,11 @@
 {
-  "a94f5374fce5edbc8e2a8697c15331677e6ebf0b": {
+  "a94f5374Fce5edBC8E2a8697C15331677e6EbF0B": {
     "balance": "0x5ffd4878be161d74",
     "code": "0x",
     "nonce": "0xac",
     "storage": {}
   },
-  "0x8a8eafb1cf62bfbeb1741769dae1a9dd47996192":{
+  "0x8A8eAFb1cf62BfBeb1741769DAE1a9dd47996192":{
     "balance": "0xfeedbead",
     "nonce" : "0x00"
   }

--- a/cmd/evm/testdata/19/env.json
+++ b/cmd/evm/testdata/19/env.json
@@ -1,5 +1,5 @@
 {
-  "currentCoinbase": "0xc94f5374fce5edbc8e2a8697c15331677e6ebf0b",
+  "currentCoinbase": "0xc94f5374fCe5eDBc8e2a8697C15331677E6EBF0B",
   "currentGasLimit": "0x750a163df65e8a",
   "currentBaseFee": "0x500",
   "currentNumber": "13000000",

--- a/cmd/evm/testdata/2/alloc.json
+++ b/cmd/evm/testdata/2/alloc.json
@@ -1,12 +1,12 @@
 {
-  "0x095e7baea6a6c7c4c2dfeb977efac326af552d87" : {
+  "0x095E7BAea6a6c7c4c2DfeB977eFac326aF552d87" : {
     "balance" : "0x0de0b6b3a7640000",
     "code" : "0x6001600053600160006001f0ff00",
     "nonce" : "0x00",
     "storage" : {
     }
   },
-  "0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b" : {
+  "0xa94f5374Fce5edBC8E2a8697C15331677e6EbF0B" : {
     "balance" : "0x0de0b6b3a7640000",
     "code" : "0x",
     "nonce" : "0x00",

--- a/cmd/evm/testdata/2/env.json
+++ b/cmd/evm/testdata/2/env.json
@@ -1,5 +1,5 @@
 {
-  "currentCoinbase" : "0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
+  "currentCoinbase" : "0x2ADC25665018Aa1FE0E6BC666DaC8Fc2697fF9bA",
   "currentDifficulty" : "0x020000",
   "currentGasLimit" : "0x3b9aca00",
   "currentNumber" : "0x01",

--- a/cmd/evm/testdata/2/txs.json
+++ b/cmd/evm/testdata/2/txs.json
@@ -4,7 +4,7 @@
     "gas" : "0x5f5e100",
     "gasPrice" : "0x1",
     "nonce" : "0x0",
-    "to" : "0x095e7baea6a6c7c4c2dfeb977efac326af552d87",
+    "to" : "0x095E7BAea6a6c7c4c2DfeB977eFac326aF552d87",
     "value" : "0x186a0",
     "v" : "0x1b",
     "r" : "0x88544c93a564b4c28d2ffac2074a0c55fdd4658fe0d215596ed2e32e3ef7f56b",

--- a/cmd/evm/testdata/21/clique.json
+++ b/cmd/evm/testdata/21/clique.json
@@ -1,6 +1,6 @@
 {
   "secretKey": "0x45a915e4d060149eb4365960e6a7a45f334393093061116b197e3240065ff2d8",
-  "voted": "0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
+  "voted": "0x2ADC25665018Aa1FE0E6BC666DaC8Fc2697fF9bA",
   "authorize": false,
   "vanity": "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
 }

--- a/cmd/evm/testdata/23/alloc.json
+++ b/cmd/evm/testdata/23/alloc.json
@@ -1,12 +1,12 @@
 {
-  "0x095e7baea6a6c7c4c2dfeb977efac326af552d87" : {
+  "0x095E7BAea6a6c7c4c2DfeB977eFac326aF552d87" : {
     "balance" : "0x0de0b6b3a7640000",
     "code" : "0x6001",
     "nonce" : "0x00",
     "storage" : {
     }
   },
-  "0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b" : {
+  "0xa94f5374Fce5edBC8E2a8697C15331677e6EbF0B" : {
     "balance" : "0x0de0b6b3a7640000",
     "code" : "0x",
     "nonce" : "0x00",

--- a/cmd/evm/testdata/23/env.json
+++ b/cmd/evm/testdata/23/env.json
@@ -1,5 +1,5 @@
 {
-  "currentCoinbase" : "0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
+  "currentCoinbase" : "0x2ADC25665018Aa1FE0E6BC666DaC8Fc2697fF9bA",
   "currentDifficulty" : "0x020000",
   "currentGasLimit" : "0x3b9aca00",
   "currentNumber" : "0x05",

--- a/cmd/evm/testdata/23/txs.json
+++ b/cmd/evm/testdata/23/txs.json
@@ -4,7 +4,7 @@
     "gas" : "0x5f5e100",
     "gasPrice" : "0x1",
     "nonce" : "0x0",
-    "to" : "0x095e7baea6a6c7c4c2dfeb977efac326af552d87",
+    "to" : "0x095E7BAea6a6c7c4c2DfeB977eFac326aF552d87",
     "value" : "0x186a0",
     "v" : "0x0",
     "r" : "0x0",

--- a/cmd/evm/testdata/3/alloc.json
+++ b/cmd/evm/testdata/3/alloc.json
@@ -1,12 +1,12 @@
 {
-  "0x095e7baea6a6c7c4c2dfeb977efac326af552d87" : {
+  "0x095E7BAea6a6c7c4c2DfeB977eFac326aF552d87" : {
     "balance" : "0x0de0b6b3a7640000",
     "code" : "0x600140",
     "nonce" : "0x00",
     "storage" : {
     }
   },
-  "0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b" : {
+  "0xa94f5374Fce5edBC8E2a8697C15331677e6EbF0B" : {
     "balance" : "0x0de0b6b3a7640000",
     "code" : "0x",
     "nonce" : "0x00",

--- a/cmd/evm/testdata/3/env.json
+++ b/cmd/evm/testdata/3/env.json
@@ -1,5 +1,5 @@
 {
-  "currentCoinbase" : "0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
+  "currentCoinbase" : "0x2ADC25665018Aa1FE0E6BC666DaC8Fc2697fF9bA",
   "currentDifficulty" : "0x020000",
   "currentGasLimit" : "0x3b9aca00",
   "currentNumber" : "0x05",

--- a/cmd/evm/testdata/3/exp.json
+++ b/cmd/evm/testdata/3/exp.json
@@ -1,13 +1,13 @@
 {
   "alloc": {
-    "0x095e7baea6a6c7c4c2dfeb977efac326af552d87": {
+    "0x095E7BAea6a6c7c4c2DfeB977eFac326aF552d87": {
       "code": "0x600140",
       "balance": "0xde0b6b3a76586a0"
     },
-    "0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba": {
+    "0x2ADC25665018Aa1FE0E6BC666DaC8Fc2697fF9bA": {
       "balance": "0x521f"
     },
-    "0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b": {
+    "0xa94f5374Fce5edBC8E2a8697C15331677e6EbF0B": {
       "balance": "0xde0b6b3a7622741",
       "nonce": "0x1"
     }

--- a/cmd/evm/testdata/3/txs.json
+++ b/cmd/evm/testdata/3/txs.json
@@ -4,7 +4,7 @@
     "gas" : "0x5f5e100",
     "gasPrice" : "0x1",
     "nonce" : "0x0",
-    "to" : "0x095e7baea6a6c7c4c2dfeb977efac326af552d87",
+    "to" : "0x095E7BAea6a6c7c4c2DfeB977eFac326aF552d87",
     "value" : "0x186a0",
     "v" : "0x1b",
     "r" : "0x88544c93a564b4c28d2ffac2074a0c55fdd4658fe0d215596ed2e32e3ef7f56b",

--- a/cmd/evm/testdata/4/alloc.json
+++ b/cmd/evm/testdata/4/alloc.json
@@ -1,12 +1,12 @@
 {
-  "0x095e7baea6a6c7c4c2dfeb977efac326af552d87" : {
+  "0x095E7BAea6a6c7c4c2DfeB977eFac326aF552d87" : {
     "balance" : "0x0de0b6b3a7640000",
     "code" : "0x600340",
     "nonce" : "0x00",
     "storage" : {
     }
   },
-  "0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b" : {
+  "0xa94f5374Fce5edBC8E2a8697C15331677e6EbF0B" : {
     "balance" : "0x0de0b6b3a7640000",
     "code" : "0x",
     "nonce" : "0x00",

--- a/cmd/evm/testdata/4/env.json
+++ b/cmd/evm/testdata/4/env.json
@@ -1,5 +1,5 @@
 {
-  "currentCoinbase" : "0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
+  "currentCoinbase" : "0x2ADC25665018Aa1FE0E6BC666DaC8Fc2697fF9bA",
   "currentDifficulty" : "0x020000",
   "currentGasLimit" : "0x3b9aca00",
   "currentNumber" : "0x05",

--- a/cmd/evm/testdata/4/txs.json
+++ b/cmd/evm/testdata/4/txs.json
@@ -4,7 +4,7 @@
     "gas" : "0x5f5e100",
     "gasPrice" : "0x1",
     "nonce" : "0x0",
-    "to" : "0x095e7baea6a6c7c4c2dfeb977efac326af552d87",
+    "to" : "0x095E7BAea6a6c7c4c2DfeB977eFac326aF552d87",
     "value" : "0x186a0",
     "v" : "0x1b",
     "r" : "0x88544c93a564b4c28d2ffac2074a0c55fdd4658fe0d215596ed2e32e3ef7f56b",

--- a/cmd/evm/testdata/5/env.json
+++ b/cmd/evm/testdata/5/env.json
@@ -1,11 +1,11 @@
 {
-  "currentCoinbase": "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "currentCoinbase": "0xaAaAaAaaAaAaAaaAaAAAAAAAAaaaAaAaAaaAaaAa",
   "currentDifficulty": "0x20000",
   "currentGasLimit": "0x750a163df65e8a",
   "currentNumber": "1",
   "currentTimestamp": "1000",
   "ommers": [
-    {"delta":  1, "address": "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb" },
-    {"delta":  2, "address": "0xcccccccccccccccccccccccccccccccccccccccc" }
+    {"delta":  1, "address": "0xbBbBBBBbbBBBbbbBbbBbbbbBBbBbbbbBbBbbBBbB" },
+    {"delta":  2, "address": "0xCcCCccccCCCCcCCCCCCcCcCccCcCCCcCcccccccC" }
   ]
 }

--- a/cmd/evm/testdata/5/exp.json
+++ b/cmd/evm/testdata/5/exp.json
@@ -1,12 +1,12 @@
 {
   "alloc": {
-    "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa": {
+    "0xaAaAaAaaAaAaAaaAaAAAAAAAAaaaAaAaAaaAaaAa": {
       "balance": "0x88"
     },
-    "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb": {
+    "0xbBbBBBBbbBBBbbbBbbBbbbbBBbBbbbbBbBbbBBbB": {
       "balance": "0x70"
     },
-    "0xcccccccccccccccccccccccccccccccccccccccc": {
+    "0xCcCCccccCCCCcCCCCCCcCcCccCcCCCcCcccccccC": {
       "balance": "0x60"
     }
   },

--- a/cmd/evm/testdata/7/alloc.json
+++ b/cmd/evm/testdata/7/alloc.json
@@ -1,11 +1,11 @@
 {
-  "a94f5374fce5edbc8e2a8697c15331677e6ebf0b": {
+  "a94f5374Fce5edBC8E2a8697C15331677e6EbF0B": {
     "balance": "0x5ffd4878be161d74",
     "code": "0x",
     "nonce": "0xac",
     "storage": {}
   },
-  "0x8a8eafb1cf62bfbeb1741769dae1a9dd47996192":{
+  "0x8A8eAFb1cf62BfBeb1741769DAE1a9dd47996192":{
     "balance": "0xfeedbead",
     "nonce" : "0x00"
   }

--- a/cmd/evm/testdata/7/env.json
+++ b/cmd/evm/testdata/7/env.json
@@ -1,5 +1,5 @@
 {
-  "currentCoinbase": "0xc94f5374fce5edbc8e2a8697c15331677e6ebf0b",
+  "currentCoinbase": "0xc94f5374fCe5eDBc8e2a8697C15331677E6EBF0B",
   "currentDifficulty": "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffff020000",
   "currentGasLimit": "0x750a163df65e8a",
   "currentNumber": "5",

--- a/cmd/evm/testdata/8/alloc.json
+++ b/cmd/evm/testdata/8/alloc.json
@@ -4,7 +4,7 @@
     "code": "0x5854505854",
     "nonce": "0x1"
   },
-  "0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b": {
+  "0xa94f5374Fce5edBC8E2a8697C15331677e6EbF0B": {
     "balance": "0x100000",
     "nonce": "0x00"
   }

--- a/cmd/evm/testdata/8/env.json
+++ b/cmd/evm/testdata/8/env.json
@@ -1,5 +1,5 @@
 {
-  "currentCoinbase": "0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
+  "currentCoinbase": "0x2ADC25665018Aa1FE0E6BC666DaC8Fc2697fF9bA",
   "currentDifficulty": "0x20000",
   "currentGasLimit": "0x1000000000",
   "currentNumber": "0x1000000",

--- a/cmd/evm/testdata/8/readme.md
+++ b/cmd/evm/testdata/8/readme.md
@@ -9,7 +9,7 @@ following code: `0x5854505854`: `PC ;SLOAD; POP; PC; SLOAD`.
 
 Essentialy, this contract does `SLOAD(0)` and `SLOAD(3)`.
 
-The alloc also contains some funds on `0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b`. 
+The alloc also contains some funds on `0xa94f5374Fce5edBC8E2a8697C15331677e6EbF0B`. 
 
 ## Transactions
 

--- a/cmd/evm/testdata/9/alloc.json
+++ b/cmd/evm/testdata/9/alloc.json
@@ -4,7 +4,7 @@
     "code": "0x58585454",
     "nonce": "0x1"
   },
-  "0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b": {
+  "0xa94f5374Fce5edBC8E2a8697C15331677e6EbF0B": {
     "balance": "0x100000000000000",
     "nonce": "0x00"
   }

--- a/cmd/evm/testdata/9/env.json
+++ b/cmd/evm/testdata/9/env.json
@@ -1,5 +1,5 @@
 {
-  "currentCoinbase": "0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
+  "currentCoinbase": "0x2ADC25665018Aa1FE0E6BC666DaC8Fc2697fF9bA",
   "currentDifficulty": "0x20000",
   "currentGasTarget": "0x1000000000",
   "currentBaseFee": "0x3B9ACA00",

--- a/cmd/evm/testdata/9/readme.md
+++ b/cmd/evm/testdata/9/readme.md
@@ -9,7 +9,7 @@ following code: `0x58585454`: `PC; PC; SLOAD; SLOAD`.
 
 Essentialy, this contract does `SLOAD(0)` and `SLOAD(1)`.
 
-The alloc also contains some funds on `0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b`. 
+The alloc also contains some funds on `0xa94f5374Fce5edBC8E2a8697C15331677e6EbF0B`. 
 
 ## Transactions
 
@@ -43,10 +43,10 @@ $ dir=./testdata/9 && ./evm t8n --state.fork=London --input.alloc=$dir/alloc.jso
    "balance": "0x3",
    "nonce": "0x1"
   },
-  "0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba": {
+  "0x2ADC25665018Aa1FE0E6BC666DaC8Fc2697fF9bA": {
    "balance": "0xbfc02677a000"
   },
-  "0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b": {
+  "0xa94f5374Fce5edBC8E2a8697C15331677e6EbF0B": {
    "balance": "0xff104fcfea7800",
    "nonce": "0x2"
   }

--- a/cmd/geth/consolecmd_test.go
+++ b/cmd/geth/consolecmd_test.go
@@ -50,7 +50,7 @@ func runMinimalGeth(t *testing.T, args ...string) *testgeth {
 // Tests that a node embedded within a console can be started up properly and
 // then terminated by closing the input stream.
 func TestConsoleWelcome(t *testing.T) {
-	coinbase := "0x8605cdbbdb6d264aa742e77020dcbc58fcdce182"
+	coinbase := "0x8605CdbbDb6D264Aa742e77020dCbc58FcDCe182"
 
 	// Start a geth console, make sure it's cleaned up and terminate the console
 	geth := runMinimalGeth(t, "--miner.etherbase", coinbase, "console")
@@ -100,7 +100,7 @@ func TestAttachWelcome(t *testing.T) {
 	p := trulyRandInt(1024, 65533) // Yeah, sometimes this will fail, sorry :P
 	httpPort = strconv.Itoa(p)
 	wsPort = strconv.Itoa(p + 1)
-	geth := runMinimalGeth(t, "--miner.etherbase", "0x8605cdbbdb6d264aa742e77020dcbc58fcdce182",
+	geth := runMinimalGeth(t, "--miner.etherbase", "0x8605CdbbDb6D264Aa742e77020dCbc58FcDCe182",
 		"--ipcpath", ipc,
 		"--http", "--http.port", httpPort,
 		"--ws", "--ws.port", wsPort)

--- a/common/types.go
+++ b/common/types.go
@@ -308,7 +308,7 @@ func (a *Address) SetBytes(b []byte) {
 
 // MarshalText returns the hex representation of a.
 func (a Address) MarshalText() ([]byte, error) {
-	return hexutil.Bytes(a[:]).MarshalText()
+	return a.checksumHex(), nil
 }
 
 // UnmarshalText parses a hash in hex syntax.

--- a/console/console_test.go
+++ b/console/console_test.go
@@ -39,7 +39,7 @@ import (
 
 const (
 	testInstance = "console-tester"
-	testAddress  = "0x8605cdbbdb6d264aa742e77020dcbc58fcdce182"
+	testAddress  = "0x8605CdbbDb6D264Aa742e77020dCbc58FcDCe182"
 )
 
 // hookedPrompter implements UserPrompter to simulate use input via channels.

--- a/graphql/graphql_test.go
+++ b/graphql/graphql_test.go
@@ -177,7 +177,7 @@ func TestGraphQLBlockSerializationEIP2718(t *testing.T) {
 	}{
 		{
 			body: `{"query": "{block {number transactions { from { address } to { address } value hash type accessList { address storageKeys } index}}}"}`,
-			want: `{"data":{"block":{"number":1,"transactions":[{"from":{"address":"0x71562b71999873db5b286df957af199ec94617f7"},"to":{"address":"0x0000000000000000000000000000000000000dad"},"value":"0x64","hash":"0xd864c9d7d37fade6b70164740540c06dd58bb9c3f6b46101908d6339db6a6a7b","type":0,"accessList":[],"index":0},{"from":{"address":"0x71562b71999873db5b286df957af199ec94617f7"},"to":{"address":"0x0000000000000000000000000000000000000dad"},"value":"0x32","hash":"0x19b35f8187b4e15fb59a9af469dca5dfa3cd363c11d372058c12f6482477b474","type":1,"accessList":[{"address":"0x0000000000000000000000000000000000000dad","storageKeys":["0x0000000000000000000000000000000000000000000000000000000000000000"]}],"index":1}]}}}`,
+			want: `{"data":{"block":{"number":1,"transactions":[{"from":{"address":"0x71562b71999873DB5b286dF957af199Ec94617F7"},"to":{"address":"0x0000000000000000000000000000000000000DAd"},"value":"0x64","hash":"0xd864c9d7d37fade6b70164740540c06dd58bb9c3f6b46101908d6339db6a6a7b","type":0,"accessList":[],"index":0},{"from":{"address":"0x71562b71999873DB5b286dF957af199Ec94617F7"},"to":{"address":"0x0000000000000000000000000000000000000DAd"},"value":"0x32","hash":"0x19b35f8187b4e15fb59a9af469dca5dfa3cd363c11d372058c12f6482477b474","type":1,"accessList":[{"address":"0x0000000000000000000000000000000000000DAd","storageKeys":["0x0000000000000000000000000000000000000000000000000000000000000000"]}],"index":1}]}}}`,
 			code: 200,
 		},
 	} {
@@ -277,7 +277,7 @@ func createGQLServiceWithTransactions(t *testing.T, stack *node.Node) {
 	key, _ := crypto.HexToECDSA("b71c71a67e1177ad4e901695e1b4b9ee17ae16c6668d313eac2f96dbcda3f291")
 	address := crypto.PubkeyToAddress(key.PublicKey)
 	funds := big.NewInt(1000000000000000)
-	dad := common.HexToAddress("0x0000000000000000000000000000000000000dad")
+	dad := common.HexToAddress("0x0000000000000000000000000000000000000DAd")
 
 	ethConf := &ethconfig.Config{
 		Genesis: &core.Genesis{


### PR DESCRIPTION
This PR changes the default format of `Address` from hex to [eip-55](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-55.md)
mentioned in #24406 

Details(common/types.go):
before
```
// MarshalText returns the hex representation of a.
func (a Address) MarshalText() ([]byte, error) {
	return hexutil.Bytes(a[:]).MarshalText()
}
```
after
```
// MarshalText returns the hex representation of a.
func (a Address) MarshalText() ([]byte, error) {
	return a.checksumHex(), nil
}
```

Is this OK? can you take a look at this please? @holiman 