### PR TITLE
cmd/utils: fixing metrics flags logic

### DIFF
--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -1816,9 +1816,9 @@ func SetupMetrics(ctx *cli.Context) {
 			log.Info("Enabling stand-alone metrics HTTP endpoint", "address", address)
 			exp.Setup(address)
 		} else {
-                        address := fmt.Sprintf("%s:%d", MetricsHTTPFlag.Value, MetricsPortFlag.Value)
-                        log.Info("Enabling stand-alone metrics HTTP endpoint", "address", address)
-                        exp.Setup(address)
+			address := fmt.Sprintf("%s:%d", MetricsHTTPFlag.Value, MetricsPortFlag.Value)
+			log.Info("Enabling stand-alone metrics HTTP endpoint", "address", address)
+			exp.Setup(address)
 		}
 	}
 }

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -1811,10 +1811,14 @@ func SetupMetrics(ctx *cli.Context) {
 			go influxdb.InfluxDBV2WithTags(metrics.DefaultRegistry, 10*time.Second, endpoint, token, bucket, organization, "geth.", tagsMap)
 		}
 
-		if ctx.GlobalIsSet(MetricsHTTPFlag.Name) {
+		if ctx.GlobalIsSet(MetricsHTTPFlag.Name) || ctx.GlobalIsSet(MetricsPortFlag.Name) {
 			address := fmt.Sprintf("%s:%d", ctx.GlobalString(MetricsHTTPFlag.Name), ctx.GlobalInt(MetricsPortFlag.Name))
 			log.Info("Enabling stand-alone metrics HTTP endpoint", "address", address)
 			exp.Setup(address)
+		} else {
+                        address := fmt.Sprintf("%s:%d", MetricsHTTPFlag.Value, MetricsPortFlag.Value)
+                        log.Info("Enabling stand-alone metrics HTTP endpoint", "address", address)
+                        exp.Setup(address)
 		}
 	}
 }


### PR DESCRIPTION
This PR fix the metrics flags logic

Before:
The enable metrics flag used alone `geth --metrics`  don't starts the metrics server. Need to add address metrics flag `geth --metrics --metrics.addr 127.0.0.1` to start the metrics server with default host and port values. All flags needed to change only port value `geth --metrics --metrics.addr 127.0.0.1 --metrics.port 6061` 

After:
Metrics server starts with default values with one flag `geth --metrics`. Adding specific host or port metrics flag changes the respective default value.
