### PR TITLE
les/vflux/client: fix goroutine leak in testIter

### DIFF
--- a/les/vflux/client/fillset_test.go
+++ b/les/vflux/client/fillset_test.go
@@ -34,16 +34,20 @@ type testIter struct {
 }
 
 func (i *testIter) Next() bool {
-	i.waitCh <- struct{}{}
+	if _, ok := <-i.waitCh; !ok {
+		return false
+	}
 	i.node = <-i.nodeCh
-	return i.node != nil
+	return true
 }
 
 func (i *testIter) Node() *enode.Node {
 	return i.node
 }
 
-func (i *testIter) Close() {}
+func (i *testIter) Close() {
+	close(i.waitCh)
+}
 
 func (i *testIter) push() {
 	var id enode.ID
@@ -53,7 +57,7 @@ func (i *testIter) push() {
 
 func (i *testIter) waiting(timeout time.Duration) bool {
 	select {
-	case <-i.waitCh:
+	case i.waitCh <- struct{}{}:
 		return true
 	case <-time.After(timeout):
 		return false


### PR DESCRIPTION
This PR fixes a goroutine leak in testIter (used by TestFillSet).
This is an alternative solution to https://github.com/ethereum/go-ethereum/pull/24379
Fixes https://github.com/ethereum/go-ethereum/issues/24213
