### PR TITLE
Fetch sub-modules recursively

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,7 +13,7 @@ environment:
       GETH_MINGW: 'C:\msys64\mingw32'
 
 install:
-  - git submodule update --init --depth 1
+  - git submodule update --init --depth 1 --recursive
   - go version
 
 for:


### PR DESCRIPTION
The legacy tests are now in a sub-module within the tests repository. Hence, the CI tools need to fetch the sub-modules recursively before running the checks. This PR changes `appveyor.yml` to that end.

Fixes [#24312](https://github.com/ethereum/go-ethereum/issues/24312)