### PR TITLE
graphql: fee history fields

### DIFF
--- a/eth/gasprice/feehistory.go
+++ b/eth/gasprice/feehistory.go
@@ -117,7 +117,7 @@ func (oracle *Oracle) processBlock(bf *blockFees, percentiles []float64) {
 		reward, _ := tx.EffectiveGasTip(bf.block.BaseFee())
 		sorter[i] = txGasAndReward{gasUsed: bf.receipts[i].GasUsed, reward: reward}
 	}
-	sort.Sort(sorter)
+	sort.Stable(sorter)
 
 	var txIndex int
 	sumGasUsed := sorter[0].gasUsed

--- a/graphql/graphql.go
+++ b/graphql/graphql.go
@@ -299,6 +299,7 @@ func (t *Transaction) EffectiveTip(ctx context.Context) (*hexutil.Big, error) {
 		return (*hexutil.Big)(tx.GasPrice()), nil
 	}
 
+	// TODO: What to return for non-dynamicfee tx types?
 	switch tx.Type() {
 	case types.AccessListTxType:
 		return nil, nil

--- a/graphql/graphql.go
+++ b/graphql/graphql.go
@@ -299,19 +299,11 @@ func (t *Transaction) EffectiveTip(ctx context.Context) (*hexutil.Big, error) {
 		return (*hexutil.Big)(tx.GasPrice()), nil
 	}
 
-	// TODO: What to return for non-dynamicfee tx types?
-	switch tx.Type() {
-	case types.AccessListTxType:
-		return nil, nil
-	case types.DynamicFeeTxType:
-		tip, err := tx.EffectiveGasTip(header.BaseFee)
-		if err != nil {
-			return nil, err
-		}
-		return (*hexutil.Big)(tip), nil
-	default:
-		return nil, nil
+	tip, err := tx.EffectiveGasTip(header.BaseFee)
+	if err != nil {
+		return nil, err
 	}
+	return (*hexutil.Big)(tip), nil
 }
 
 func (t *Transaction) Value(ctx context.Context) (hexutil.Big, error) {

--- a/graphql/graphql.go
+++ b/graphql/graphql.go
@@ -246,6 +246,10 @@ func (t *Transaction) EffectiveGasPrice(ctx context.Context) (*hexutil.Big, erro
 	if err != nil || tx == nil {
 		return nil, err
 	}
+	// Pending tx
+	if t.block == nil {
+		return nil, nil
+	}
 	header, err := t.block.resolveHeader(ctx)
 	if err != nil || header == nil {
 		return nil, err
@@ -290,6 +294,10 @@ func (t *Transaction) EffectiveTip(ctx context.Context) (*hexutil.Big, error) {
 	tx, err := t.resolve(ctx)
 	if err != nil || tx == nil {
 		return nil, err
+	}
+	// Pending tx
+	if t.block == nil {
+		return nil, nil
 	}
 	header, err := t.block.resolveHeader(ctx)
 	if err != nil || header == nil {

--- a/graphql/graphql.go
+++ b/graphql/graphql.go
@@ -624,10 +624,13 @@ func (b *Block) NextBaseFeePerGas(ctx context.Context) (*hexutil.Big, error) {
 	if err != nil {
 		return nil, err
 	}
-	if header.BaseFee == nil {
-		return nil, nil
-	}
 	chaincfg := b.backend.ChainConfig()
+	if header.BaseFee == nil {
+		// Make sure next block doesn't enable EIP-1559
+		if !chaincfg.IsLondon(new(big.Int).Add(header.Number, common.Big1)) {
+			return nil, nil
+		}
+	}
 	nextBaseFee := misc.CalcBaseFee(chaincfg, header)
 	return (*hexutil.Big)(nextBaseFee), nil
 }

--- a/graphql/schema.go
+++ b/graphql/schema.go
@@ -69,7 +69,7 @@ const schema string = `
         transaction: Transaction!
     }
 
-    #EIP-2718 
+    #EIP-2718
     type AccessTuple{
         address: Address!
         storageKeys : [Bytes32!]!
@@ -94,10 +94,10 @@ const schema string = `
         value: BigInt!
         # GasPrice is the price offered to miners for gas, in wei per unit.
         gasPrice: BigInt!
-        # MaxFeePerGas is the maximum fee per gas offered to include a transaction, in wei. 
-		maxFeePerGas: BigInt
-        # MaxPriorityFeePerGas is the maximum miner tip per gas offered to include a transaction, in wei. 
-		maxPriorityFeePerGas: BigInt
+        # MaxFeePerGas is the maximum fee per gas offered to include a transaction, in wei.
+        maxFeePerGas: BigInt
+        # MaxPriorityFeePerGas is the maximum miner tip per gas offered to include a transaction, in wei.
+        maxPriorityFeePerGas: BigInt
         # EffectiveTip is the actual amount of reward going to miner after considering the max fee cap.
         effectiveTip: BigInt
         # Gas is the maximum amount of gas this transaction can consume.
@@ -190,9 +190,9 @@ const schema string = `
         # GasUsed is the amount of gas that was used executing transactions in this block.
         gasUsed: Long!
         # BaseFeePerGas is the fee per unit of gas burned by the protocol in this block.
-		baseFeePerGas: BigInt
-		# NextBaseFeePerGas is the fee per unit of gas which needs to be burned in the next block.
-		nextBaseFeePerGas: BigInt
+        baseFeePerGas: BigInt
+        # NextBaseFeePerGas is the fee per unit of gas which needs to be burned in the next block.
+        nextBaseFeePerGas: BigInt
         # Timestamp is the unix timestamp at which this block was mined.
         timestamp: Long!
         # LogsBloom is a bloom filter that can be used to check if a block may
@@ -248,10 +248,10 @@ const schema string = `
         gas: Long
         # GasPrice is the price, in wei, offered for each unit of gas.
         gasPrice: BigInt
-        # MaxFeePerGas is the maximum fee per gas offered, in wei. 
-		maxFeePerGas: BigInt
-        # MaxPriorityFeePerGas is the maximum miner tip per gas offered, in wei. 
-		maxPriorityFeePerGas: BigInt
+        # MaxFeePerGas is the maximum fee per gas offered, in wei.
+        maxFeePerGas: BigInt
+        # MaxPriorityFeePerGas is the maximum miner tip per gas offered, in wei.
+        maxPriorityFeePerGas: BigInt
         # Value is the value, in wei, sent along with the call.
         value: BigInt
         # Data is the data sent to the callee.

--- a/graphql/schema.go
+++ b/graphql/schema.go
@@ -98,6 +98,8 @@ const schema string = `
 		maxFeePerGas: BigInt
         # MaxPriorityFeePerGas is the maximum miner tip per gas offered to include a transaction, in wei. 
 		maxPriorityFeePerGas: BigInt
+        # EffectiveTip is the actual amount of reward going to miner after considering the max fee cap.
+        effectiveTip: BigInt
         # Gas is the maximum amount of gas this transaction can consume.
         gas: Long!
         # InputData is the data supplied to the target of the transaction.
@@ -187,8 +189,10 @@ const schema string = `
         gasLimit: Long!
         # GasUsed is the amount of gas that was used executing transactions in this block.
         gasUsed: Long!
-        # BaseFeePerGas is the fee perunit of gas burned by the protocol in this block.
+        # BaseFeePerGas is the fee per unit of gas burned by the protocol in this block.
 		baseFeePerGas: BigInt
+		# NextBaseFeePerGas is the fee per unit of gas which needs to be burned in the next block.
+		nextBaseFeePerGas: BigInt
         # Timestamp is the unix timestamp at which this block was mined.
         timestamp: Long!
         # LogsBloom is a bloom filter that can be used to check if a block may


### PR DESCRIPTION
This PR adds the `NextBaseFeePerGas` to `Block` and `EffectiveTip` to `Transaction` to make it easier for clients to compute fee history themselves. Note I made the tx reward sorting logic in our fee history algorithm stable so clients can compute consistent results.

Example client script: https://gist.github.com/s1na/851ad57e8fca7c74b2464207b2e99021
Result of a run on a few Goerli blocks:

```sh
❯ node index.js 4 6415924 "50, 75"
# JSON-RPC result
{
  oldestBlock: '0x61e631',
  reward: [
    [ '0x9502f900', '0x165a0bbf9' ],
    [ '0x59682f00', '0x59682f00' ],
    [ '0x3b9aca00', '0x9502f900' ],
    [ '0x9502f900', '0x9502f900' ]
  ],
  baseFeePerGas: [ '0x7', '0x7', '0x7', '0x7', '0x7' ],
  gasUsedRatio: [
    0.10796890077097406,
    0.0061631333333333335,
    0.008546466666666667,
    0.13900370378341118
  ]
}
# GraphQL Result
{
  oldestBlock: '0x61e631',
  baseFeePerGas: [ '0x7', '0x7', '0x7', '0x7', '0x7' ],
  gasUsedRatio: [
    0.10796890077097406,
    0.0061631333333333335,
    0.008546466666666667,
    0.13900370378341118
  ],
  rewards: [
    [ '0x9502f900', '0x165a0bbf9' ],
    [ '0x59682f00', '0x59682f00' ],
    [ '0x3b9aca00', '0x9502f900' ],
    [ '0x9502f900', '0x9502f900' ]
  ]
}
```

Fixes #24386