### PR TITLE
Tweak downloads page to work better on slow networks

### DIFF
--- a/downloads.html
+++ b/downloads.html
@@ -256,6 +256,9 @@ js:
           type: 'GET',
           error: function() {
             alert("Failed to load releases!");
+            // Remove the modal blocker, so the user can at least access the things which have loaded
+            $('#loader, .modal-backdrop').remove();
+            $('body').removeClass('modal-open');
           },
           dataType: 'xml',
           timeout: 3 * 60 * 1000,

--- a/downloads.html
+++ b/downloads.html
@@ -247,7 +247,7 @@ js:
       var blobs = [];
       var retrieveBlobs = function(marker, finished) {
         // Generate the blob listing URL and request it from Azure
-        var url = 'https://gethstore.blob.core.windows.net/builds?restype=container&comp=list&maxresults=5000&prefix=geth-';
+        var url = 'https://gethstore.blob.core.windows.net/builds?restype=container&comp=list&maxresults=250&prefix=geth-';
         if (marker != "") {
           url += "&marker=" + marker;
         }
@@ -258,6 +258,7 @@ js:
             alert("Failed to load releases!");
           },
           dataType: 'xml',
+          timeout: 3 * 60 * 1000,
           success: function(data) {
             // List of blobs retrieved, acumulate them first of all
             Array.prototype.push.apply(blobs, $(data).find('Blob'));

--- a/downloads.html
+++ b/downloads.html
@@ -254,14 +254,13 @@ js:
         $.ajax({
           url: url,
           type: 'GET',
+          dataType: 'xml',
+          timeout: 3 * 60 * 1000,
           error: function() {
             alert("Failed to load releases!");
             // Remove the modal blocker, so the user can at least access the things which have loaded
-            $('#loader, .modal-backdrop').remove();
-            $('body').removeClass('modal-open');
+            $('#loader').modal('hide');
           },
-          dataType: 'xml',
-          timeout: 3 * 60 * 1000,
           success: function(data) {
             // List of blobs retrieved, acumulate them first of all
             Array.prototype.push.apply(blobs, $(data).find('Blob'));


### PR DESCRIPTION
For #20855. Reduces the size of batches to fetch, and increases the timeout.

I'm not sure if setting the timeout in jQuery will work, because it might be timing out on the server end. But it's worth a try.

The new batch size of 250 is pretty low, but I figure it's better to ensure the page works for everyone, than to worry about optimising it for people who have healthy networks.

That change is also on line 250, so it might be ... fate? :smile: