### PR TITLE
core: Implement EIP 1153

### DIFF
--- a/core/vm/interpreter.go
+++ b/core/vm/interpreter.go
@@ -62,6 +62,8 @@ type EVMInterpreter struct {
 
 	readOnly   bool   // Whether to throw on stateful modifications
 	returnData []byte // Last CALL's return data for subsequent reuse
+
+	transient *transientStore // Transient Storage
 }
 
 // NewEVMInterpreter returns a new instance of the Interpreter.
@@ -102,8 +104,9 @@ func NewEVMInterpreter(evm *EVM, cfg Config) *EVMInterpreter {
 	}
 
 	return &EVMInterpreter{
-		evm: evm,
-		cfg: cfg,
+		evm:       evm,
+		cfg:       cfg,
+		transient: NewTransientStore(),
 	}
 }
 

--- a/core/vm/opcodes.go
+++ b/core/vm/opcodes.go
@@ -116,6 +116,8 @@ const (
 	MSIZE    OpCode = 0x59
 	GAS      OpCode = 0x5a
 	JUMPDEST OpCode = 0x5b
+	TLOAD    OpCode = 0x5c
+	TSTORE   OpCode = 0x5d
 )
 
 // 0x60 range - pushes.

--- a/core/vm/transient.go
+++ b/core/vm/transient.go
@@ -1,0 +1,61 @@
+package vm
+
+import (
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/holiman/uint256"
+)
+
+type storekey struct {
+	key uint256.Int
+	who common.Address
+}
+type transientStore struct {
+	store    map[storekey]uint256.Int
+	rollback []rollbackEntry
+	shadow   []int
+}
+
+type rollbackEntry struct {
+	address uint256.Int
+	who     common.Address
+	value   uint256.Int
+}
+
+func NewTransientStore() *transientStore {
+	return &transientStore{
+		store:    make(map[storekey]uint256.Int),
+		rollback: nil,
+		shadow:   nil,
+	}
+}
+
+func (ts *transientStore) Store(key uint256.Int, value uint256.Int, who common.Address) {
+	ts.rollback = append(ts.rollback, rollbackEntry{
+		address: key,
+		value:   ts.store[storekey{key, who}],
+		who:     who,
+	})
+	ts.store[storekey{key, who}] = value
+}
+
+func (ts *transientStore) Load(key uint256.Int, who common.Address) uint256.Int {
+	return ts.store[storekey{key, who}]
+}
+
+func (ts *transientStore) Call() {
+	ts.shadow = append(ts.shadow, len(ts.rollback))
+}
+
+func (ts *transientStore) Revert() {
+	oldlen := ts.shadow[len(ts.shadow)-1]
+	reverts := ts.rollback[oldlen:len(ts.rollback)]
+	ts.rollback = ts.rollback[0:oldlen]
+	for i := len(reverts) - 1; i >= 0; i-- {
+		ts.store[storekey{reverts[i].address, reverts[i].who}] = reverts[i].value
+	}
+}
+
+func (ts *transientStore) Commit() {
+	oldlen := ts.shadow[len(ts.shadow)-1]
+	ts.rollback = ts.rollback[0:oldlen]
+}

--- a/core/vm/transient_test.go
+++ b/core/vm/transient_test.go
@@ -1,0 +1,78 @@
+package vm
+
+import (
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/holiman/uint256"
+)
+
+var (
+	alice = common.Address{1}
+	bob   = common.Address{2}
+)
+
+type pair struct {
+	key, value int
+}
+
+func TestAsMap(t *testing.T) {
+	store := NewTransientStore()
+	store.Store(*uint256.NewInt(1), *uint256.NewInt(2), alice)
+	if !isIncluded(store, []pair{{key: 1, value: 2}}, alice) {
+		t.Fail()
+	}
+}
+
+func TestCommit(t *testing.T) {
+	store := NewTransientStore()
+	writepair(store, 1, 2, alice)
+	store.Call()
+	writepair(store, 3, 4, alice)
+	store.Commit()
+	if !isIncluded(store, []pair{
+		{key: 1, value: 2},
+		{key: 3, value: 4},
+	}, alice) {
+		t.Fail()
+	}
+
+}
+
+func TestRevert(t *testing.T) {
+	store := NewTransientStore()
+	writepair(store, 1, 2, alice)
+	store.Call()
+	writepair(store, 1, 4, alice)
+	store.Revert()
+	if !isIncluded(store, []pair{{key: 1, value: 2}}, alice) {
+		t.Fail()
+	}
+}
+
+func isIncluded(store *transientStore, pairs []pair, who common.Address) bool {
+	for _, kv := range pairs {
+		key := *uint256.NewInt(uint64(kv.key))
+		val := store.Load(key, who)
+		if !val.Eq(uint256.NewInt(uint64(kv.value))) {
+			return false
+		}
+	}
+	return true
+}
+
+func writepair(s *transientStore, key int, val int, who common.Address) {
+	s.Store(*uint256.NewInt(uint64(key)), *uint256.NewInt(uint64(val)), who)
+}
+
+func TestIsolation(t *testing.T) {
+	store := NewTransientStore()
+	writepair(store, 1, 2, alice)
+	writepair(store, 1, 3, bob)
+	if !isIncluded(store, []pair{{key: 1, value: 2}}, alice) {
+		t.Fail()
+	}
+	if !isIncluded(store, []pair{{key: 1, value: 3}}, bob) {
+		t.Fail()
+	}
+}


### PR DESCRIPTION
This implements EIP 1153: I've made it a draft because I would like guidance on the following points.

1.  This really needs some tests exercising the new logic via bytecode sequences, I'm not sure where tests like that should live
2. I don't know if I did all the work to enable turning this on on a testnet correctly
3. The shadowstack approach works, but relies on having an address of the contract: during creation it won't work right. This is probably OK, but should be called out in the EIP.
4. We don't disable this feature during readonly calls.
5. Haven't approach compiler support at all on this.