### PR TITLE
core, params: prototype withdrawal transactions

### DIFF
--- a/core/types/transaction_marshalling.go
+++ b/core/types/transaction_marshalling.go
@@ -94,6 +94,9 @@ func (t *Transaction) MarshalJSON() ([]byte, error) {
 		enc.V = (*hexutil.Big)(tx.V)
 		enc.R = (*hexutil.Big)(tx.R)
 		enc.S = (*hexutil.Big)(tx.S)
+	case *WithdrawalTx:
+		enc.To = t.To()
+		enc.Value = (*hexutil.Big)(tx.Value)
 	}
 	return json.Marshal(&enc)
 }
@@ -263,6 +266,17 @@ func (t *Transaction) UnmarshalJSON(input []byte) error {
 			}
 		}
 
+	case WithdrawalTxType:
+		var itx WithdrawalTx
+		inner = &itx
+		if dec.To == nil {
+			return errors.New("missing required field 'to' in transaction")
+		}
+		itx.To = dec.To
+		if dec.Value == nil {
+			return errors.New("missing required field 'value' in transaction")
+		}
+		itx.Value = (*big.Int)(dec.Value)
 	default:
 		return ErrTxTypeNotSupported
 	}

--- a/core/types/withdrawal_tx.go
+++ b/core/types/withdrawal_tx.go
@@ -1,0 +1,68 @@
+// Copyright 2021 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+package types
+
+import (
+	"math/big"
+
+	"github.com/ethereum/go-ethereum/common"
+)
+
+// `WithdrawalTx` mirrors a withdrawal receipt committed to
+// on the consensus layer.
+//  This receipt is guaranteed to have some execution address
+// and an amount in Gwei.
+// NOTE: the amount is converted to Wei when the transaction data is
+// unmarshalled into this struct.
+type WithdrawalTx struct {
+	To    *common.Address
+	Value *big.Int
+}
+
+// copy creates a deep copy of the transaction data and initializes all fields.
+func (tx *WithdrawalTx) copy() TxData {
+	cpy := &WithdrawalTx{
+		To:    copyAddressPtr(tx.To),
+		Value: new(big.Int),
+	}
+	if tx.Value != nil {
+		cpy.Value.Set(tx.Value)
+	}
+	return cpy
+}
+
+// accessors for innerTx.
+func (tx *WithdrawalTx) txType() byte           { return WithdrawalTxType }
+func (tx *WithdrawalTx) chainID() *big.Int      { return new(big.Int) }
+func (tx *WithdrawalTx) accessList() AccessList { return nil }
+func (tx *WithdrawalTx) data() []byte           { return nil }
+func (tx *WithdrawalTx) gas() uint64            { return 0 }
+func (tx *WithdrawalTx) gasFeeCap() *big.Int    { return new(big.Int) }
+func (tx *WithdrawalTx) gasTipCap() *big.Int    { return new(big.Int) }
+func (tx *WithdrawalTx) gasPrice() *big.Int     { return new(big.Int) }
+func (tx *WithdrawalTx) value() *big.Int        { return tx.Value }
+func (tx *WithdrawalTx) nonce() uint64          { return 0 }
+func (tx *WithdrawalTx) to() *common.Address    { return tx.To }
+
+func (tx *WithdrawalTx) rawSignatureValues() (v, r, s *big.Int) {
+	// return "zero" values, this method should not be called
+	return new(big.Int), new(big.Int), new(big.Int)
+}
+
+func (tx *WithdrawalTx) setSignatureValues(chainID, v, r, s *big.Int) {
+	//  no-op, keep for broader compatibility
+}

--- a/params/config.go
+++ b/params/config.go
@@ -347,6 +347,7 @@ type ChainConfig struct {
 	LondonBlock         *big.Int `json:"londonBlock,omitempty"`         // London switch block (nil = no fork, 0 = already on london)
 	ArrowGlacierBlock   *big.Int `json:"arrowGlacierBlock,omitempty"`   // Eip-4345 (bomb delay) switch block (nil = no fork, 0 = already activated)
 	MergeForkBlock      *big.Int `json:"mergeForkBlock,omitempty"`      // EIP-3675 (TheMerge) switch block (nil = no fork, 0 = already in merge proceedings)
+	ShanghaiBlock       *big.Int `json:"shanghaiForkBlock,omitempty"`   // Shanghai switch block (nil = no fork, 0 = already on shanghai)
 
 	// TerminalTotalDifficulty is the amount of total difficulty reached by
 	// the network that triggers the consensus upgrade.
@@ -473,6 +474,11 @@ func (c *ChainConfig) IsLondon(num *big.Int) bool {
 // IsArrowGlacier returns whether num is either equal to the Arrow Glacier (EIP-4345) fork block or greater.
 func (c *ChainConfig) IsArrowGlacier(num *big.Int) bool {
 	return isForked(c.ArrowGlacierBlock, num)
+}
+
+// IsShanghai returns whether num is either equal to the Shanghai (EIP-TBD) fork block or greater.
+func (c *ChainConfig) IsShanghai(num *big.Int) bool {
+	return isForked(c.ShanghaiBlock, num)
 }
 
 // IsTerminalPoWBlock returns whether the given block is the last block of PoW stage.


### PR DESCRIPTION
PR prototyping "push"-style withdrawal transaction processing from the beacon chain to the EVM.

## TODO:
- [x] add block validations for tx collation
- [x] to Wei
- [x] clean up tx hash

## Open questions:

- ~Geth uses a transaction's hash to identify it -- in keeping w/ the use of SSZ elsewhere for the serialization of this transaction type, I'd suggest the hash identifier  is the SSZ hash tree root of the withdrawal receipt container. Open to other options though.~
- @fjl had the idea to emit logs for each withdrawal transaction processed. I'm open to the idea and left a note where it would make sense to write them to the state, but I'll leave out the implementation for now.

## Notes:

This PR will accompany a draft EIP that suggests EL upgrades to go into Shanghai to facilitate validator withdrawals. This stye of withdrawal method is accompanied by the CL upgrade in this PR: https://github.com/ethereum/consensus-specs/pull/2836

This PR assumes that this transaction type `0x3` is placed alongside regular user transactions in the `ExecutionPayload` -- the CL PR needs to be updated to reflect this change as noted there.

## Implementation rationale:

This PR changes the "outer" transaction processing logic during the application of state transitions. Another option would be to leverage more of the EVM machinery (detecting the transaction type during EVM execution) but that leads to a number of special cases to support this new transaction type (e.g. `msg.from` could be `nil` but that fails a number of invariants in the EVM that `from` is always some account address). The overall design of the "push"-style transactions also explicitly forgoes EVM processing (to avoid dealing with issues of gas accounting and dealing with failed executions on withdrawal consumption) so the current implementation seems like the best spot to add support for this new transaction type.