### PR TITLE
eth: change snapshot extension registration failure to warning instead of error

### DIFF
--- a/eth/handler.go
+++ b/eth/handler.go
@@ -453,7 +453,7 @@ func (h *handler) runSnapExtension(peer *snap.Peer, handler snap.Handler) error 
 	defer h.peerWG.Done()
 
 	if err := h.peers.registerSnapExtension(peer); err != nil {
-		peer.Log().Debug("Snapshot extension registration failed", "err", err)
+		peer.Log().Warn("Snapshot extension registration failed", "err", err)
 		return err
 	}
 	return handler(peer)

--- a/eth/handler.go
+++ b/eth/handler.go
@@ -453,7 +453,7 @@ func (h *handler) runSnapExtension(peer *snap.Peer, handler snap.Handler) error 
 	defer h.peerWG.Done()
 
 	if err := h.peers.registerSnapExtension(peer); err != nil {
-		peer.Log().Error("Snapshot extension registration failed", "err", err)
+		peer.Log().Debug("Snapshot extension registration failed", "err", err)
 		return err
 	}
 	return handler(peer)


### PR DESCRIPTION
Hello!

I run a few geth nodes, and monitor the log output to check on their health (via an ELK stack).

The only `ERROR` level line I regularly get from `geth` looks like the one below:

```
Feb 27 12:39:19 xyz geth[324494]: ERROR[02-27|12:39:19.016] Snapshot extension registration failed   peer=664adfac err="peer connected on snap without compatible eth support"
```

I get over 100 of these `ERROR` messages an hour. They come from peer connections, and as it states, "Snapshot extension registration" has failed.  geth continues without any side-effects.

However, there's no action I can take here -- these are external clients, out of my control.  I'd really prefer `ERROR` level messages be kept to things I should address.  Then I can monitor the rate of `ERROR`s and alert.

As a result, I think the message here should be a different level - I suggest `DEBUG` instead of `ERROR` level.  If someone really cares about monitoring how often peers fail handshake registration, they can turn debugging on.  But I expect most users don't care, and can't do anything about it anyway, so `DEBUG` seems more appropriate.

For what it's worth, `DEBUG` is used if the overall `Ethereum handshake failed`:

https://github.com/ethereum/go-ethereum/blob/adc0a6adca90c4a784b7eb9ba88c1af15fd2b681/eth/handler.go#L305