### PR TITLE
all: extend ancient store API with freezer identifier routing

### DIFF
--- a/cmd/devp2p/internal/ethtest/snap.go
+++ b/cmd/devp2p/internal/ethtest/snap.go
@@ -372,8 +372,8 @@ func (s *Suite) TestSnapTrieNodes(t *utesting.T) {
 		{
 			root: s.chain.RootAt(999),
 			paths: []snap.TrieNodePathSet{
-				snap.TrieNodePathSet{}, // zero-length pathset should 'abort' and kick us off
-				snap.TrieNodePathSet{[]byte{0}},
+				{}, // zero-length pathset should 'abort' and kick us off
+				{[]byte{0}},
 			},
 			nBytes:    5000,
 			expHashes: []common.Hash{},
@@ -382,8 +382,8 @@ func (s *Suite) TestSnapTrieNodes(t *utesting.T) {
 		{
 			root: s.chain.RootAt(999),
 			paths: []snap.TrieNodePathSet{
-				snap.TrieNodePathSet{[]byte{0}},
-				snap.TrieNodePathSet{[]byte{1}, []byte{0}},
+				{[]byte{0}},
+				{[]byte{1}, []byte{0}},
 			},
 			nBytes: 5000,
 			//0x6b3724a41b8c38b46d4d02fba2bb2074c47a507eb16a9a4b978f91d32e406faf
@@ -392,7 +392,7 @@ func (s *Suite) TestSnapTrieNodes(t *utesting.T) {
 		{ // nonsensically long path
 			root: s.chain.RootAt(999),
 			paths: []snap.TrieNodePathSet{
-				snap.TrieNodePathSet{[]byte{0, 1, 2, 3, 4, 5, 6, 7, 8, 0, 1, 2, 3, 4, 5, 6, 7, 8, 0, 1, 2, 3, 4, 5, 6, 7, 8,
+				{[]byte{0, 1, 2, 3, 4, 5, 6, 7, 8, 0, 1, 2, 3, 4, 5, 6, 7, 8, 0, 1, 2, 3, 4, 5, 6, 7, 8,
 					0, 1, 2, 3, 4, 5, 6, 7, 8, 0, 1, 2, 3, 4, 5, 6, 7, 8, 0, 1, 2, 3, 4, 5, 6, 7, 8}},
 			},
 			nBytes:    5000,
@@ -401,8 +401,8 @@ func (s *Suite) TestSnapTrieNodes(t *utesting.T) {
 		{
 			root: s.chain.RootAt(0),
 			paths: []snap.TrieNodePathSet{
-				snap.TrieNodePathSet{[]byte{0}},
-				snap.TrieNodePathSet{[]byte{1}, []byte{0}},
+				{[]byte{0}},
+				{[]byte{1}, []byte{0}},
 			},
 			nBytes:    5000,
 			expHashes: []common.Hash{},

--- a/cmd/geth/dbcmd.go
+++ b/cmd/geth/dbcmd.go
@@ -708,7 +708,7 @@ func showMetaData(ctx *cli.Context) error {
 	stack, _ := makeConfigNode(ctx)
 	defer stack.Close()
 	db := utils.MakeChainDatabase(ctx, stack, true)
-	ancients, err := db.Ancients()
+	ancients, err := db.Ancients(rawdb.ChainFreezer)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Error accessing ancients: %v", err)
 	}

--- a/core/blockchain_repair_test.go
+++ b/core/blockchain_repair_test.go
@@ -1819,7 +1819,7 @@ func testRepair(t *testing.T, tt *rewindTest, snapshots bool) {
 	// Force run a freeze cycle
 	type freezer interface {
 		Freeze(threshold uint64) error
-		Ancients() (uint64, error)
+		Ancients(string) (uint64, error)
 	}
 	db.(freezer).Freeze(tt.freezeThreshold)
 
@@ -1858,7 +1858,7 @@ func testRepair(t *testing.T, tt *rewindTest, snapshots bool) {
 	if head := newChain.CurrentBlock(); head.NumberU64() != tt.expHeadBlock {
 		t.Errorf("Head block mismatch: have %d, want %d", head.NumberU64(), tt.expHeadBlock)
 	}
-	if frozen, err := db.(freezer).Ancients(); err != nil {
+	if frozen, err := db.(freezer).Ancients(rawdb.ChainFreezer); err != nil {
 		t.Errorf("Failed to retrieve ancient count: %v\n", err)
 	} else if int(frozen) != tt.expFrozen {
 		t.Errorf("Frozen block count mismatch: have %d, want %d", frozen, tt.expFrozen)

--- a/core/blockchain_sethead_test.go
+++ b/core/blockchain_sethead_test.go
@@ -2024,7 +2024,7 @@ func testSetHead(t *testing.T, tt *rewindTest, snapshots bool) {
 	// Force run a freeze cycle
 	type freezer interface {
 		Freeze(threshold uint64) error
-		Ancients() (uint64, error)
+		Ancients(string) (uint64, error)
 	}
 	db.(freezer).Freeze(tt.freezeThreshold)
 
@@ -2050,7 +2050,7 @@ func testSetHead(t *testing.T, tt *rewindTest, snapshots bool) {
 	if head := chain.CurrentBlock(); head.NumberU64() != tt.expHeadBlock {
 		t.Errorf("Head block mismatch: have %d, want %d", head.NumberU64(), tt.expHeadBlock)
 	}
-	if frozen, err := db.(freezer).Ancients(); err != nil {
+	if frozen, err := db.(freezer).Ancients(rawdb.ChainFreezer); err != nil {
 		t.Errorf("Failed to retrieve ancient count: %v\n", err)
 	} else if int(frozen) != tt.expFrozen {
 		t.Errorf("Frozen block count mismatch: have %d, want %d", frozen, tt.expFrozen)

--- a/core/blockchain_test.go
+++ b/core/blockchain_test.go
@@ -969,7 +969,7 @@ func TestLightVsFastVsFullChainHeads(t *testing.T) {
 	ancient.SetHead(remove - 1)
 	assert(t, "ancient", ancient, 0, 0, 0)
 
-	if frozen, err := ancientDb.Ancients(); err != nil || frozen != 1 {
+	if frozen, err := ancientDb.Ancients(rawdb.ChainFreezer); err != nil || frozen != 1 {
 		t.Fatalf("failed to truncate ancient store, want %v, have %v", 1, frozen)
 	}
 	// Import the chain as a light node and ensure all pointers are updated
@@ -1856,7 +1856,7 @@ func TestInsertReceiptChainRollback(t *testing.T) {
 	if ancientChain.CurrentFastBlock().NumberU64() != 0 {
 		t.Fatalf("failed to rollback ancient data, want %d, have %d", 0, ancientChain.CurrentFastBlock().NumberU64())
 	}
-	if frozen, err := ancientChain.db.Ancients(); err != nil || frozen != 1 {
+	if frozen, err := ancientChain.db.Ancients(rawdb.ChainFreezer); err != nil || frozen != 1 {
 		t.Fatalf("failed to truncate ancient data, frozen index is %d", frozen)
 	}
 
@@ -1868,7 +1868,7 @@ func TestInsertReceiptChainRollback(t *testing.T) {
 	if ancientChain.CurrentFastBlock().NumberU64() != canonblocks[len(canonblocks)-1].NumberU64() {
 		t.Fatalf("failed to insert ancient recept chain after rollback")
 	}
-	if frozen, _ := ancientChain.db.Ancients(); frozen != uint64(len(canonblocks))+1 {
+	if frozen, _ := ancientChain.db.Ancients(rawdb.ChainFreezer); frozen != uint64(len(canonblocks))+1 {
 		t.Fatalf("wrong ancients count %d", frozen)
 	}
 }

--- a/core/rawdb/chain_iterator.go
+++ b/core/rawdb/chain_iterator.go
@@ -34,7 +34,7 @@ import (
 // injects into the database the block hash->number mappings.
 func InitDatabaseFromFreezer(db ethdb.Database) {
 	// If we can't access the freezer or it's empty, abort
-	frozen, err := db.Ancients()
+	frozen, err := db.Ancients(ChainFreezer)
 	if err != nil || frozen == 0 {
 		return
 	}
@@ -50,7 +50,7 @@ func InitDatabaseFromFreezer(db ethdb.Database) {
 		if i+count > frozen {
 			count = frozen - i
 		}
-		data, err := db.AncientRange(freezerHashTable, i, count, 32*count)
+		data, err := db.AncientRange(ChainFreezer, freezerHashTable, i, count, 32*count)
 		if err != nil {
 			log.Crit("Failed to init database from freezer", "err", err)
 		}

--- a/core/rawdb/database.go
+++ b/core/rawdb/database.go
@@ -35,14 +35,73 @@ import (
 // freezerdb is a database wrapper that enabled freezer data retrievals.
 type freezerdb struct {
 	ethdb.KeyValueStore
-	ethdb.AncientStore
+	chain *freezer
+}
+
+// HasAncient returns an indicator whether the specified data exists in the
+// ancient store.
+func (frdb *freezerdb) HasAncient(typ string, kind string, id uint64) (bool, error) {
+	return frdb.chain.HasAncient(kind, id)
+}
+
+// Ancient retrieves an ancient binary blob from the append-only immutable files.
+func (frdb *freezerdb) Ancient(typ string, kind string, id uint64) ([]byte, error) {
+	return frdb.chain.Ancient(kind, id)
+}
+
+// AncientRange retrieves multiple items in sequence, starting from the index 'start'.
+func (frdb *freezerdb) AncientRange(typ string, kind string, start, max, maxByteSize uint64) ([][]byte, error) {
+	return frdb.chain.AncientRange(kind, start, max, maxByteSize)
+}
+
+// Ancients returns the ancient item numbers in the ancient store.
+func (frdb *freezerdb) Ancients(typ string) (uint64, error) {
+	return frdb.chain.Ancients()
+}
+
+// Tail returns the number of first stored item in the freezer.
+func (frdb *freezerdb) Tail(typ string) (uint64, error) {
+	return frdb.chain.Tail()
+}
+
+// AncientSize returns the ancient size of the specified category.
+func (frdb *freezerdb) AncientSize(typ string, kind string) (uint64, error) {
+	return frdb.chain.AncientSize(kind)
+}
+
+// ModifyAncients runs a write operation on the ancient store.
+// If the function returns an error, any changes to the underlying store are reverted.
+// The integer return value is the total size of the written data.
+func (frdb *freezerdb) ModifyAncients(typ string, fn func(ethdb.AncientWriteOp) error) (int64, error) {
+	return frdb.chain.ModifyAncients(fn)
+}
+
+// TruncateHead discards all but the first n ancient data from the ancient store.
+func (frdb *freezerdb) TruncateHead(typ string, items uint64) error {
+	return frdb.chain.TruncateHead(items)
+}
+
+// TruncateTail discards the first n ancient data from the ancient store.
+func (frdb *freezerdb) TruncateTail(typ string, tail uint64) error {
+	return frdb.chain.TruncateTail(tail)
+}
+
+// Sync flushes all in-memory ancient store data to disk.
+func (frdb *freezerdb) Sync(typ string) error {
+	return frdb.chain.Sync()
+}
+
+// ReadAncients runs the given read operation while ensuring that no writes take place
+// on the underlying freezer.
+func (frdb *freezerdb) ReadAncients(typ string, fn func(reader ethdb.AncientReadOp) error) (err error) {
+	return frdb.chain.ReadAncients(fn)
 }
 
 // Close implements io.Closer, closing both the fast key-value store as well as
 // the slow ancient tables.
 func (frdb *freezerdb) Close() error {
 	var errs []error
-	if err := frdb.AncientStore.Close(); err != nil {
+	if err := frdb.chain.Close(); err != nil {
 		errs = append(errs, err)
 	}
 	if err := frdb.KeyValueStore.Close(); err != nil {
@@ -58,18 +117,18 @@ func (frdb *freezerdb) Close() error {
 // a freeze cycle completes, without having to sleep for a minute to trigger the
 // automatic background run.
 func (frdb *freezerdb) Freeze(threshold uint64) error {
-	if frdb.AncientStore.(*freezer).readonly {
+	if frdb.chain.readonly {
 		return errReadOnly
 	}
 	// Set the freezer threshold to a temporary value
 	defer func(old uint64) {
-		atomic.StoreUint64(&frdb.AncientStore.(*freezer).threshold, old)
-	}(atomic.LoadUint64(&frdb.AncientStore.(*freezer).threshold))
-	atomic.StoreUint64(&frdb.AncientStore.(*freezer).threshold, threshold)
+		atomic.StoreUint64(&frdb.chain.threshold, old)
+	}(atomic.LoadUint64(&frdb.chain.threshold))
+	atomic.StoreUint64(&frdb.chain.threshold, threshold)
 
 	// Trigger a freeze cycle and block until it's done
 	trigger := make(chan struct{}, 1)
-	frdb.AncientStore.(*freezer).trigger <- trigger
+	frdb.chain.trigger <- trigger
 	<-trigger
 	return nil
 }
@@ -80,56 +139,88 @@ type nofreezedb struct {
 }
 
 // HasAncient returns an error as we don't have a backing chain freezer.
-func (db *nofreezedb) HasAncient(kind string, number uint64) (bool, error) {
+func (db *nofreezedb) HasAncient(typ string, kind string, number uint64) (bool, error) {
 	return false, errNotSupported
 }
 
 // Ancient returns an error as we don't have a backing chain freezer.
-func (db *nofreezedb) Ancient(kind string, number uint64) ([]byte, error) {
+func (db *nofreezedb) Ancient(typ string, kind string, number uint64) ([]byte, error) {
 	return nil, errNotSupported
 }
 
 // AncientRange returns an error as we don't have a backing chain freezer.
-func (db *nofreezedb) AncientRange(kind string, start, max, maxByteSize uint64) ([][]byte, error) {
+func (db *nofreezedb) AncientRange(typ string, kind string, start, max, maxByteSize uint64) ([][]byte, error) {
 	return nil, errNotSupported
 }
 
 // Ancients returns an error as we don't have a backing chain freezer.
-func (db *nofreezedb) Ancients() (uint64, error) {
+func (db *nofreezedb) Ancients(typ string) (uint64, error) {
 	return 0, errNotSupported
 }
 
 // Tail returns an error as we don't have a backing chain freezer.
-func (db *nofreezedb) Tail() (uint64, error) {
+func (db *nofreezedb) Tail(typ string) (uint64, error) {
 	return 0, errNotSupported
 }
 
 // AncientSize returns an error as we don't have a backing chain freezer.
-func (db *nofreezedb) AncientSize(kind string) (uint64, error) {
+func (db *nofreezedb) AncientSize(typ string, kind string) (uint64, error) {
 	return 0, errNotSupported
 }
 
-// ModifyAncients is not supported.
-func (db *nofreezedb) ModifyAncients(func(ethdb.AncientWriteOp) error) (int64, error) {
+// ModifyAncients returns an error as we don't have a backing chain freezer.
+func (db *nofreezedb) ModifyAncients(typ string, fn func(ethdb.AncientWriteOp) error) (int64, error) {
 	return 0, errNotSupported
 }
 
 // TruncateHead returns an error as we don't have a backing chain freezer.
-func (db *nofreezedb) TruncateHead(items uint64) error {
+func (db *nofreezedb) TruncateHead(typ string, items uint64) error {
 	return errNotSupported
 }
 
 // TruncateTail returns an error as we don't have a backing chain freezer.
-func (db *nofreezedb) TruncateTail(items uint64) error {
+func (db *nofreezedb) TruncateTail(typ string, tail uint64) error {
 	return errNotSupported
 }
 
 // Sync returns an error as we don't have a backing chain freezer.
-func (db *nofreezedb) Sync() error {
+func (db *nofreezedb) Sync(typ string) error {
 	return errNotSupported
 }
 
-func (db *nofreezedb) ReadAncients(fn func(reader ethdb.AncientReader) error) (err error) {
+type nullAncientReadOp struct{}
+
+// HasAncient returns an error as we don't have a backing chain freezer.
+func (db *nullAncientReadOp) HasAncient(kind string, number uint64) (bool, error) {
+	return false, errNotSupported
+}
+
+// Ancient returns an error as we don't have a backing chain freezer.
+func (db *nullAncientReadOp) Ancient(kind string, number uint64) ([]byte, error) {
+	return nil, errNotSupported
+}
+
+// AncientRange returns an error as we don't have a backing chain freezer.
+func (db *nullAncientReadOp) AncientRange(kind string, start, max, maxByteSize uint64) ([][]byte, error) {
+	return nil, errNotSupported
+}
+
+// Ancients returns an error as we don't have a backing chain freezer.
+func (db *nullAncientReadOp) Ancients() (uint64, error) {
+	return 0, errNotSupported
+}
+
+// Tail returns an error as we don't have a backing chain freezer.
+func (db *nullAncientReadOp) Tail() (uint64, error) {
+	return 0, errNotSupported
+}
+
+// AncientSize returns an error as we don't have a backing chain freezer.
+func (db *nullAncientReadOp) AncientSize(kind string) (uint64, error) {
+	return 0, errNotSupported
+}
+
+func (db *nofreezedb) ReadAncients(typ string, fn func(reader ethdb.AncientReadOp) error) (err error) {
 	// Unlike other ancient-related methods, this method does not return
 	// errNotSupported when invoked.
 	// The reason for this is that the caller might want to do several things:
@@ -142,7 +233,7 @@ func (db *nofreezedb) ReadAncients(fn func(reader ethdb.AncientReader) error) (e
 	// If we instead were to return errNotSupported here, then the caller would
 	// have to explicitly check for that, having an extra clause to do the
 	// non-ancient operations.
-	return fn(db)
+	return fn(&nullAncientReadOp{})
 }
 
 // NewDatabase creates a high level database on top of a given key-value data
@@ -234,7 +325,7 @@ func NewDatabaseWithFreezer(db ethdb.KeyValueStore, freezer string, namespace st
 	}
 	return &freezerdb{
 		KeyValueStore: db,
-		AncientStore:  frdb,
+		chain:         frdb,
 	}, nil
 }
 
@@ -431,14 +522,14 @@ func InspectDatabase(db ethdb.Database, keyPrefix, keyStart []byte) error {
 	// Inspect append-only file store then.
 	ancientSizes := []*common.StorageSize{&ancientHeadersSize, &ancientBodiesSize, &ancientReceiptsSize, &ancientHashesSize, &ancientTdsSize}
 	for i, category := range []string{freezerHeaderTable, freezerBodiesTable, freezerReceiptTable, freezerHashTable, freezerDifficultyTable} {
-		if size, err := db.AncientSize(category); err == nil {
+		if size, err := db.AncientSize(ChainFreezer, category); err == nil {
 			*ancientSizes[i] += common.StorageSize(size)
 			total += common.StorageSize(size)
 		}
 	}
 	// Get number of ancient rows inside the freezer
 	ancients := counter(0)
-	if count, err := db.Ancients(); err == nil {
+	if count, err := db.Ancients(ChainFreezer); err == nil {
 		ancients = counter(count)
 	}
 	// Display the database statistic.

--- a/core/rawdb/freezer.go
+++ b/core/rawdb/freezer.go
@@ -247,7 +247,7 @@ func (f *freezer) AncientSize(kind string) (uint64, error) {
 
 // ReadAncients runs the given read operation while ensuring that no writes take place
 // on the underlying freezer.
-func (f *freezer) ReadAncients(fn func(ethdb.AncientReader) error) (err error) {
+func (f *freezer) ReadAncients(fn func(op ethdb.AncientReadOp) error) (err error) {
 	f.writeLock.RLock()
 	defer f.writeLock.RUnlock()
 	return fn(f)

--- a/core/rawdb/schema.go
+++ b/core/rawdb/schema.go
@@ -135,6 +135,11 @@ var FreezerNoSnappy = map[string]bool{
 	freezerDifficultyTable: true,
 }
 
+const (
+	// ChainFreezer indicates the name of ancient chain freezer
+	ChainFreezer = "chain"
+)
+
 // LegacyTxLookupEntry is the legacy TxLookupEntry definition with some unnecessary
 // fields.
 type LegacyTxLookupEntry struct {

--- a/core/rawdb/table.go
+++ b/core/rawdb/table.go
@@ -52,65 +52,68 @@ func (t *table) Get(key []byte) ([]byte, error) {
 
 // HasAncient is a noop passthrough that just forwards the request to the underlying
 // database.
-func (t *table) HasAncient(kind string, number uint64) (bool, error) {
-	return t.db.HasAncient(kind, number)
+func (t *table) HasAncient(typ string, kind string, number uint64) (bool, error) {
+	return t.db.HasAncient(typ, kind, number)
 }
 
 // Ancient is a noop passthrough that just forwards the request to the underlying
 // database.
-func (t *table) Ancient(kind string, number uint64) ([]byte, error) {
-	return t.db.Ancient(kind, number)
+func (t *table) Ancient(typ string, kind string, number uint64) ([]byte, error) {
+	return t.db.Ancient(typ, kind, number)
 }
 
 // AncientRange is a noop passthrough that just forwards the request to the underlying
 // database.
-func (t *table) AncientRange(kind string, start, count, maxBytes uint64) ([][]byte, error) {
-	return t.db.AncientRange(kind, start, count, maxBytes)
+func (t *table) AncientRange(typ string, kind string, start, count, maxBytes uint64) ([][]byte, error) {
+	return t.db.AncientRange(typ, kind, start, count, maxBytes)
 }
 
 // Ancients is a noop passthrough that just forwards the request to the underlying
 // database.
-func (t *table) Ancients() (uint64, error) {
-	return t.db.Ancients()
+func (t *table) Ancients(typ string) (uint64, error) {
+	return t.db.Ancients(typ)
 }
 
 // Tail is a noop passthrough that just forwards the request to the underlying
 // database.
-func (t *table) Tail() (uint64, error) {
-	return t.db.Tail()
+func (t *table) Tail(typ string) (uint64, error) {
+	return t.db.Tail(typ)
 }
 
 // AncientSize is a noop passthrough that just forwards the request to the underlying
 // database.
-func (t *table) AncientSize(kind string) (uint64, error) {
-	return t.db.AncientSize(kind)
+func (t *table) AncientSize(typ string, kind string) (uint64, error) {
+	return t.db.AncientSize(typ, kind)
 }
 
-// ModifyAncients runs an ancient write operation on the underlying database.
-func (t *table) ModifyAncients(fn func(ethdb.AncientWriteOp) error) (int64, error) {
-	return t.db.ModifyAncients(fn)
+// ModifyAncients is a noop passthrough that just forwards the request to the underlying
+// database.
+func (t *table) ModifyAncients(typ string, fn func(ethdb.AncientWriteOp) error) (int64, error) {
+	return t.db.ModifyAncients(typ, fn)
 }
 
-func (t *table) ReadAncients(fn func(reader ethdb.AncientReader) error) (err error) {
-	return t.db.ReadAncients(fn)
+// ReadAncients is a noop passthrough that just forwards the request to the underlying
+// database.
+func (t *table) ReadAncients(typ string, fn func(reader ethdb.AncientReadOp) error) (err error) {
+	return t.db.ReadAncients(typ, fn)
 }
 
 // TruncateHead is a noop passthrough that just forwards the request to the underlying
 // database.
-func (t *table) TruncateHead(items uint64) error {
-	return t.db.TruncateHead(items)
+func (t *table) TruncateHead(typ string, items uint64) error {
+	return t.db.TruncateHead(typ, items)
 }
 
 // TruncateTail is a noop passthrough that just forwards the request to the underlying
 // database.
-func (t *table) TruncateTail(items uint64) error {
-	return t.db.TruncateTail(items)
+func (t *table) TruncateTail(typ string, tail uint64) error {
+	return t.db.TruncateTail(typ, tail)
 }
 
 // Sync is a noop passthrough that just forwards the request to the underlying
 // database.
-func (t *table) Sync() error {
-	return t.db.Sync()
+func (t *table) Sync(typ string) error {
+	return t.db.Sync(typ)
 }
 
 // Put inserts the given value into the database at a prefixed version of the

--- a/eth/downloader/downloader.go
+++ b/eth/downloader/downloader.go
@@ -550,7 +550,7 @@ func (d *Downloader) syncWithPeer(p *peerConnection, hash common.Hash, td, ttd *
 		} else {
 			d.ancientLimit = 0
 		}
-		frozen, _ := d.stateDB.Ancients() // Ignore the error here since light client can also hit here.
+		frozen, _ := d.stateDB.Ancients(rawdb.ChainFreezer) // Ignore the error here since light client can also hit here.
 
 		// If a part of blockchain data has already been written into active store,
 		// disable the ancient style insertion explicitly.

--- a/ethdb/database.go
+++ b/ethdb/database.go
@@ -72,6 +72,58 @@ type KeyValueStore interface {
 type AncientReader interface {
 	// HasAncient returns an indicator whether the specified data exists in the
 	// ancient store.
+	HasAncient(typ string, kind string, number uint64) (bool, error)
+
+	// Ancient retrieves an ancient binary blob from the append-only immutable files.
+	Ancient(typ string, kind string, number uint64) ([]byte, error)
+
+	// AncientRange retrieves multiple items in sequence, starting from the index 'start'.
+	// It will return
+	//  - at most 'count' items,
+	//  - at least 1 item (even if exceeding the maxBytes), but will otherwise
+	//   return as many items as fit into maxBytes.
+	AncientRange(typ string, kind string, start, count, maxBytes uint64) ([][]byte, error)
+
+	// Ancients returns the ancient item numbers in the ancient store.
+	Ancients(typ string) (uint64, error)
+
+	// Tail returns the number of first stored item in the freezer.
+	Tail(typ string) (uint64, error)
+
+	// AncientSize returns the ancient size of the specified category.
+	AncientSize(typ string, kind string) (uint64, error)
+
+	// ReadAncients runs the given read operation while ensuring that no writes take place
+	// on the underlying freezer.
+	ReadAncients(typ string, fn func(AncientReadOp) error) (err error)
+}
+
+// AncientWriter contains the methods required to write to immutable ancient data.
+type AncientWriter interface {
+	// ModifyAncients runs a write operation on the ancient store.
+	// If the function returns an error, any changes to the underlying store are reverted.
+	// The integer return value is the total size of the written data.
+	ModifyAncients(typ string, fn func(AncientWriteOp) error) (int64, error)
+
+	// TruncateHead discards all but the first n ancient data from the ancient store.
+	// After the truncation, the latest item can be accessed it item_n-1(start from 0).
+	TruncateHead(typ string, n uint64) error
+
+	// TruncateTail discards the first n ancient data from the ancient store. The already
+	// deleted items are ignored. After the truncation, the earliest item can be accessed
+	// is item_n(start from 0). The deleted items may not be removed from the ancient store
+	// immediately, but only when the accumulated deleted data reach the threshold then
+	// will be removed all together.
+	TruncateTail(typ string, n uint64) error
+
+	// Sync flushes all in-memory ancient store data to disk.
+	Sync(typ string) error
+}
+
+// AncientReadOp is given to the function argument of ReadAncients.
+type AncientReadOp interface {
+	// HasAncient returns an indicator whether the specified data exists in the
+	// ancient store.
 	HasAncient(kind string, number uint64) (bool, error)
 
 	// Ancient retrieves an ancient binary blob from the append-only immutable files.
@@ -88,42 +140,10 @@ type AncientReader interface {
 	Ancients() (uint64, error)
 
 	// Tail returns the number of first stored item in the freezer.
-	// This number can also be interpreted as the total deleted item numbers.
 	Tail() (uint64, error)
 
 	// AncientSize returns the ancient size of the specified category.
 	AncientSize(kind string) (uint64, error)
-}
-
-// AncientBatchReader is the interface for 'batched' or 'atomic' reading.
-type AncientBatchReader interface {
-	AncientReader
-
-	// ReadAncients runs the given read operation while ensuring that no writes take place
-	// on the underlying freezer.
-	ReadAncients(fn func(AncientReader) error) (err error)
-}
-
-// AncientWriter contains the methods required to write to immutable ancient data.
-type AncientWriter interface {
-	// ModifyAncients runs a write operation on the ancient store.
-	// If the function returns an error, any changes to the underlying store are reverted.
-	// The integer return value is the total size of the written data.
-	ModifyAncients(func(AncientWriteOp) error) (int64, error)
-
-	// TruncateHead discards all but the first n ancient data from the ancient store.
-	// After the truncation, the latest item can be accessed it item_n-1(start from 0).
-	TruncateHead(n uint64) error
-
-	// TruncateTail discards the first n ancient data from the ancient store. The already
-	// deleted items are ignored. After the truncation, the earliest item can be accessed
-	// is item_n(start from 0). The deleted items may not be removed from the ancient store
-	// immediately, but only when the accumulated deleted data reach the threshold then
-	// will be removed all together.
-	TruncateTail(n uint64) error
-
-	// Sync flushes all in-memory ancient store data to disk.
-	Sync() error
 }
 
 // AncientWriteOp is given to the function argument of ModifyAncients.
@@ -139,7 +159,7 @@ type AncientWriteOp interface {
 // immutable ancient data.
 type Reader interface {
 	KeyValueReader
-	AncientBatchReader
+	AncientReader
 }
 
 // Writer contains the methods required to write data to both key-value as well as
@@ -152,7 +172,7 @@ type Writer interface {
 // AncientStore contains all the methods required to allow handling different
 // ancient data stores backing immutable chain data store.
 type AncientStore interface {
-	AncientBatchReader
+	AncientReader
 	AncientWriter
 	io.Closer
 }

--- a/les/downloader/downloader.go
+++ b/les/downloader/downloader.go
@@ -517,7 +517,7 @@ func (d *Downloader) syncWithPeer(p *peerConnection, hash common.Hash, td *big.I
 		} else {
 			d.ancientLimit = 0
 		}
-		frozen, _ := d.stateDB.Ancients() // Ignore the error here since light client can also hit here.
+		frozen, _ := d.stateDB.Ancients(rawdb.ChainFreezer) // Ignore the error here since light client can also hit here.
 
 		// If a part of blockchain data has already been written into active store,
 		// disable the ancient style insertion explicitly.


### PR DESCRIPTION
It's a PR based on #23954 

Currently, ancient store is only used to store ancient chain data, but actually it can be extended.
In the near future, we will introduce reverse diff notion which is perfectly suitable with ancient
store. Before that we need to extend the current ancient store API with freezer routing.

In this PR, the routing is implemented by a freezer identifier, although there is only a single freezer
instance right now.

Only the last commit is relevant in this PR. https://github.com/ethereum/go-ethereum/pull/24481/commits/2dd348d0fa6c9072f288cca3777fe04216cc8777