### PR TITLE
eth/tracers/logger: use JSON struct tag ",omitempty" to reduce log bloat from blank fields

### DIFF
--- a/eth/tracers/logger/gen_structlog.go
+++ b/eth/tracers/logger/gen_structlog.go
@@ -29,8 +29,8 @@ func (s StructLog) MarshalJSON() ([]byte, error) {
 		Depth         int                         `json:"depth"`
 		RefundCounter uint64                      `json:"refund"`
 		Err           error                       `json:"-"`
-		OpName        string                      `json:"opName"`
-		ErrorString   string                      `json:"error"`
+		OpName        string                      `json:"opName,omitempty"`
+		ErrorString   string                      `json:"error,omitempty"`
 	}
 	var enc StructLog
 	enc.Pc = s.Pc

--- a/eth/tracers/logger/logger.go
+++ b/eth/tracers/logger/logger.go
@@ -78,12 +78,12 @@ type StructLog struct {
 
 // overrides for gencodec
 type structLogMarshaling struct {
-	Gas         math.HexOrDecimal64
-	GasCost     math.HexOrDecimal64
-	Memory      hexutil.Bytes
-	ReturnData  hexutil.Bytes
-	OpName      string `json:"opName"` // adds call to OpName() in MarshalJSON
-	ErrorString string `json:"error"`  // adds call to ErrorString() in MarshalJSON
+	Gas         math.HexOrDecimal64 `json:",omitempty"`
+	GasCost     math.HexOrDecimal64 `json:",omitempty"`
+	Memory      hexutil.Bytes       `json:",omitempty"`
+	ReturnData  hexutil.Bytes       `json:",omitempty"`
+	OpName      string              `json:"opName,omitempty"` // adds call to OpName() in MarshalJSON
+	ErrorString string              `json:"error,omitempty"`  // adds call to ErrorString() in MarshalJSON
 }
 
 // OpName formats the operand name in a human-readable format.


### PR DESCRIPTION
Noticed while debugging Tharsis/EVMOS logs that the logs were
extraneous with empty fields such as
```json
{"pc":4716,"op":80,"gas":"0x688e5","gasCost":"0x2","memory":"0x","memSize":352,"stack":["0xfa31de01","0x29a","0x7d0","0xabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcd","0x80","0x534","0xc0","0x5f646b5592c4159d4963fbf901f81144ef53cc51a7082435e3a6120a45002ff7","0x15dc","0x34","0x5f646b5592c4159d4963fbf901f81144ef53cc51a7082435e3a6120a45002ff7"],"returnData":"0x","depth":2,"refund":0,"opName":"POP","error":""}
{"pc":4717,"op":80,"gas":"0x688e3","gasCost":"0x2","memory":"0x","memSize":352,"stack":["0xfa31de01","0x29a","0x7d0","0xabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcd","0x80","0x534","0xc0","0x5f646b5592c4159d4963fbf901f81144ef53cc51a7082435e3a6120a45002ff7","0x15dc","0x34"],"returnData":"0x","depth":2,"refund":0,"opName":"POP","error":""}
```

with empty fields like "error", "refund", "memory", "returnData".

This change adds the JSON tag ",omitempty" to remove the bloat from the
above empty fields which shows immediate impact of reducing the logs to
```json
{"pc":4716,"op":80,"gas":"0x688e5","gasCost":"0x2","memSize":352,"stack":["0xfa31de01","0x29a","0x7d0","0xabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcd","0x80","0x534","0xc0","0x5f646b5592c4159d4963fbf901f81144ef53cc51a7082435e3a6120a45002ff7","0x15dc","0x34","0x5f646b5592c4159d4963fbf901f81144ef53cc51a7082435e3a6120a45002ff7"],"depth":2,"opName":"POP"}
{"pc":4717,"op":80,"gas":"0x688e3","gasCost":"0x2","memSize":352,"stack":["0xfa31de01","0x29a","0x7d0","0xabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcd","0x80","0x534","0xc0","0x5f646b5592c4159d4963fbf901f81144ef53cc51a7082435e3a6120a45002ff7","0x15dc","0x34"],"depth":2,"opName":"POP"}
```

and not only does that reduce the size of logs but it also makes it much
easier to quickly debug and grep for errors, which will only be present if
erroring.

Fixes #24487