### PR TITLE
miner: Ensure pending state ready for tx execution

### DIFF
--- a/core/state/statedb.go
+++ b/core/state/statedb.go
@@ -814,6 +814,9 @@ func (s *StateDB) Finalise(deleteEmptyObjects bool) {
 	}
 	// Invalidate journal because reverting across transactions is not allowed.
 	s.clearJournalAndRefund()
+
+	// Ensure that subsequently applied transactions use a new accessList.
+	s.accessList = newAccessList()
 }
 
 // IntermediateRoot computes the current root hash of the state trie.
@@ -884,7 +887,6 @@ func (s *StateDB) IntermediateRoot(deleteEmptyObjects bool) common.Hash {
 func (s *StateDB) Prepare(thash common.Hash, ti int) {
 	s.thash = thash
 	s.txIndex = ti
-	s.accessList = newAccessList()
 }
 
 func (s *StateDB) clearJournalAndRefund() {

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -343,6 +343,11 @@ func (w *worker) pending() (*types.Block, *state.StateDB) {
 	if w.snapshotState == nil {
 		return nil, nil
 	}
+	snapshotStateCopy := w.snapshotState.Copy()
+	// Call Prepare to ensure that access logs from the previously applied
+	// transaction do not affect gas estimation for the any subsequently
+	// applied transactions.
+	snapshotStateCopy.Prepare(common.Hash{}, 0)
 	return w.snapshotBlock, w.snapshotState.Copy()
 }
 

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -343,11 +343,6 @@ func (w *worker) pending() (*types.Block, *state.StateDB) {
 	if w.snapshotState == nil {
 		return nil, nil
 	}
-	snapshotStateCopy := w.snapshotState.Copy()
-	// Call Prepare to ensure that access logs from the previously applied
-	// transaction do not affect gas estimation for the any subsequently
-	// applied transactions.
-	snapshotStateCopy.Prepare(common.Hash{}, 0)
 	return w.snapshotBlock, w.snapshotState.Copy()
 }
 


### PR DESCRIPTION
This change ensures that the pending state returned by Miner.Pending is
ready for transactions to be applied without first requiring `StateDB.Prepare` to
be called.

Prior to [EIP-2929](https://github.com/ethereum/go-ethereum/pull/21509) `StateDB.Prepare` was only required to be called on the pending state before executing a transaction if the user needed to retrieve the transaction logs. 

The changes in [EIP-2929](https://github.com/ethereum/go-ethereum/pull/21509) changed the way that gas usage was calculated for transactions, such that users were now also required to call `StateDB.Prepare` before transaction execution to ensure correct calculation of gas usage. However [EIP-2929](https://github.com/ethereum/go-ethereum/pull/21509) did not update `worker.pending` or any of the users of the pending state to ensure correct gas usage calculations.

Without this change transactions executed on the pending state that access some of the same state as the prior transaction will report incorrect gas usage.

Originally fixed here: https://github.com/celo-org/celo-blockchain/pull/1858

I didn't see any easy way to test this, but hoping someone could point out how it should be tested.