### PR TITLE
newHeads subscription doesn't take a second param

### DIFF
--- a/docs/_rpc/pubsub.md
+++ b/docs/_rpc/pubsub.md
@@ -13,7 +13,7 @@ together with the subscription id.
 Example:
 
     // create subscription
-    >> {"id": 1, "method": "eth_subscribe", "params": ["newHeads", {}]}
+    >> {"id": 1, "method": "eth_subscribe", "params": ["newHeads"]}
     << {"jsonrpc":"2.0","id":1,"result":"0xcd0c3e8af590364c09d0fa6a1210faf5"}
 
     // incoming notifications


### PR DESCRIPTION
Running this command results in the response:
```
{"jsonrpc":"2.0","id":1,"error":{"code":-32602,"message":"too many arguments, want at most 1"}}
```

Also there are other newHeads subscription examples in this page, which don't have the {} param.