### PR TITLE
cmd/geth: make authrpc listening address settable from command line

### DIFF
--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -165,6 +165,7 @@ var (
 		utils.HTTPListenAddrFlag,
 		utils.HTTPPortFlag,
 		utils.HTTPCORSDomainFlag,
+		utils.AuthHostFlag,
 		utils.AuthPortFlag,
 		utils.JWTSecretFlag,
 		utils.HTTPVirtualHostsFlag,

--- a/cmd/geth/usage.go
+++ b/cmd/geth/usage.go
@@ -136,7 +136,6 @@ var AppHelpFlagGroups = []flags.FlagGroup{
 		Flags: []cli.Flag{
 			utils.IPCDisabledFlag,
 			utils.IPCPathFlag,
-			utils.JWTSecretFlag,
 			utils.HTTPEnabledFlag,
 			utils.HTTPListenAddrFlag,
 			utils.HTTPPortFlag,
@@ -150,6 +149,9 @@ var AppHelpFlagGroups = []flags.FlagGroup{
 			utils.WSApiFlag,
 			utils.WSPathPrefixFlag,
 			utils.WSAllowedOriginsFlag,
+			utils.JWTSecretFlag,
+			utils.AuthHostFlag,
+			utils.AuthPortFlag,
 			utils.GraphQLEnabledFlag,
 			utils.GraphQLCORSDomainFlag,
 			utils.GraphQLVirtualHostsFlag,

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -522,11 +522,16 @@ var (
 		Usage: "Sets a cap on transaction fee (in ether) that can be sent via the RPC APIs (0 = no cap)",
 		Value: ethconfig.Defaults.RPCTxFeeCap,
 	}
-	// Authenticated port settings
+	// Authenticated RPC HTTP settings
+	AuthHostFlag = cli.StringFlag{
+		Name:  "authrpc.host",
+		Usage: "Listening address for authenticated APIs",
+		Value: node.DefaultConfig.AuthHost,
+	}
 	AuthPortFlag = cli.IntFlag{
 		Name:  "authrpc.port",
 		Usage: "Listening port for authenticated APIs",
-		Value: node.DefaultAuthPort,
+		Value: node.DefaultConfig.AuthPort,
 	}
 	JWTSecretFlag = cli.StringFlag{
 		Name:  "authrpc.jwtsecret",
@@ -965,6 +970,9 @@ func setHTTP(ctx *cli.Context, cfg *node.Config) {
 		cfg.HTTPPort = ctx.GlobalInt(HTTPPortFlag.Name)
 	}
 
+	if ctx.GlobalIsSet(AuthHostFlag.Name) {
+		cfg.AuthHost = ctx.GlobalString(AuthHostFlag.Name)
+	}
 	if ctx.GlobalIsSet(AuthPortFlag.Name) {
 		cfg.AuthPort = ctx.GlobalInt(AuthPortFlag.Name)
 	}

--- a/node/config.go
+++ b/node/config.go
@@ -113,9 +113,6 @@ type Config struct {
 	// for ephemeral nodes).
 	HTTPPort int `toml:",omitempty"`
 
-	// Authport is the port number on which the authenticated API is provided.
-	AuthPort int `toml:",omitempty"`
-
 	// HTTPCors is the Cross-Origin Resource Sharing header to send to requesting
 	// clients. Please be aware that CORS is a browser enforced security, it's fully
 	// useless for custom HTTP clients.
@@ -141,6 +138,12 @@ type Config struct {
 
 	// HTTPPathPrefix specifies a path prefix on which http-rpc is to be served.
 	HTTPPathPrefix string `toml:",omitempty"`
+
+	// AuthHost is the listening address on which authenticated APIs are provided.
+	AuthHost string `toml:",omitempty"`
+
+	// AuthPort is the port number on which authenticated APIs are provided.
+	AuthPort int `toml:",omitempty"`
 
 	// WSHost is the host interface on which to start the websocket RPC server. If
 	// this field is empty, no websocket API endpoint will be started.

--- a/node/defaults.go
+++ b/node/defaults.go
@@ -50,6 +50,7 @@ var (
 var DefaultConfig = Config{
 	DataDir:             DefaultDataDir(),
 	HTTPPort:            DefaultHTTPPort,
+	AuthHost:            DefaultAuthHost,
 	AuthPort:            DefaultAuthPort,
 	HTTPModules:         []string{"net", "web3"},
 	HTTPVirtualHosts:    []string{"localhost"},

--- a/node/node.go
+++ b/node/node.go
@@ -419,6 +419,7 @@ func (n *Node) startRPC() error {
 		servers = append(servers, server)
 		return nil
 	}
+
 	initWS := func(apis []rpc.API, port int) error {
 		server := n.wsServerForPort(port, false)
 		if err := server.setListenAddr(n.config.WSHost, port); err != nil {
@@ -438,7 +439,7 @@ func (n *Node) startRPC() error {
 	initAuth := func(apis []rpc.API, port int, secret []byte) error {
 		// Enable auth via HTTP
 		server := n.httpAuth
-		if err := server.setListenAddr(DefaultAuthHost, port); err != nil {
+		if err := server.setListenAddr(n.config.AuthHost, port); err != nil {
 			return err
 		}
 		if err := server.enableRPC(apis, httpConfig{
@@ -453,7 +454,7 @@ func (n *Node) startRPC() error {
 		servers = append(servers, server)
 		// Enable auth via WS
 		server = n.wsServerForPort(port, true)
-		if err := server.setListenAddr(DefaultAuthHost, port); err != nil {
+		if err := server.setListenAddr(n.config.AuthHost, port); err != nil {
 			return err
 		}
 		if err := server.enableWS(apis, wsConfig{
@@ -467,6 +468,7 @@ func (n *Node) startRPC() error {
 		servers = append(servers, server)
 		return nil
 	}
+
 	// Set up HTTP.
 	if n.config.HTTPHost != "" {
 		// Configure legacy unauthenticated HTTP.


### PR DESCRIPTION
The default listening address "localhost" is not sufficient when running geth in Docker.

I discovered this while trying to run the Hive engine API tests: https://github.com/ethereum/hive/pull/507#issuecomment-1062809913