### PR TITLE
trie: fixes two issues in trie iterator

### DIFF
--- a/trie/iterator.go
+++ b/trie/iterator.go
@@ -20,6 +20,7 @@ import (
 	"bytes"
 	"container/heap"
 	"errors"
+
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/ethdb"
 )

--- a/trie/iterator.go
+++ b/trie/iterator.go
@@ -20,7 +20,6 @@ import (
 	"bytes"
 	"container/heap"
 	"errors"
-
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/ethdb"
 )
@@ -154,8 +153,11 @@ func (e seekError) Error() string {
 }
 
 func newNodeIterator(trie *Trie, start []byte) NodeIterator {
-	if trie.Hash() == emptyState {
-		return new(nodeIterator)
+	if trie.Hash() == emptyRoot {
+		return &nodeIterator{
+			trie: trie,
+			err:  errIteratorEnd,
+		}
 	}
 	it := &nodeIterator{trie: trie}
 	it.err = it.seek(start)

--- a/trie/iterator.go
+++ b/trie/iterator.go
@@ -425,7 +425,7 @@ func findChild(n *fullNode, index int, path []byte, ancestor common.Hash) (node,
 func (it *nodeIterator) nextChild(parent *nodeIteratorState, ancestor common.Hash) (*nodeIteratorState, []byte, bool) {
 	switch node := parent.node.(type) {
 	case *fullNode:
-		//Full node, move to the first non-nil child.
+		// Full node, move to the first non-nil child.
 		if child, state, path, index := findChild(node, parent.index+1, it.path, ancestor); child != nil {
 			parent.index = index - 1
 			return state, path, true
@@ -503,8 +503,9 @@ func (it *nodeIterator) push(state *nodeIteratorState, parentIndex *int, path []
 }
 
 func (it *nodeIterator) pop() {
-	parent := it.stack[len(it.stack)-1]
-	it.path = it.path[:parent.pathlen]
+	last := it.stack[len(it.stack)-1]
+	it.path = it.path[:last.pathlen]
+	it.stack[len(it.stack)-1] = nil
 	it.stack = it.stack[:len(it.stack)-1]
 }
 

--- a/trie/iterator_test.go
+++ b/trie/iterator_test.go
@@ -29,6 +29,20 @@ import (
 	"github.com/ethereum/go-ethereum/ethdb/memorydb"
 )
 
+func TestEmptyIterator(t *testing.T) {
+	trie := newEmpty()
+	iter := trie.NodeIterator(nil)
+
+	seen := make(map[string]struct{})
+	for iter.Next(true) {
+		seen[string(iter.Path())] = struct{}{}
+		fmt.Println("iter.path", iter.Path(), "val", iter.NodeBlob())
+	}
+	if len(seen) != 0 {
+		t.Fatal("Unexpected trie node iterated")
+	}
+}
+
 func TestIterator(t *testing.T) {
 	trie := newEmpty()
 	vals := []struct{ k, v string }{

--- a/trie/iterator_test.go
+++ b/trie/iterator_test.go
@@ -36,7 +36,6 @@ func TestEmptyIterator(t *testing.T) {
 	seen := make(map[string]struct{})
 	for iter.Next(true) {
 		seen[string(iter.Path())] = struct{}{}
-		fmt.Println("iter.path", iter.Path(), "val", iter.NodeBlob())
 	}
 	if len(seen) != 0 {
 		t.Fatal("Unexpected trie node iterated")


### PR DESCRIPTION
This PR fixes two issues in iterator:

- Fix the memory leak in iterator. 

In trie iterator each resolved trie node will be wrapped with a struct and the corresponding pointer will be saved in the stack based slice. Whenever the node is visited, the struct is poped from stack. However this struct point should be explicitly set to nil in order to garbage collect the underlying struct.

- Fix the empty trie iterator

The empty trie shouldn't be iterated out any values. 