### PR TITLE
core/rawdb: fix db commands

### DIFF
--- a/core/rawdb/freezer_table.go
+++ b/core/rawdb/freezer_table.go
@@ -153,8 +153,15 @@ func newTable(path string, name string, readMeter metrics.Meter, writeMeter metr
 		if err != nil {
 			return nil, err
 		}
-		// Will fail if the table is legacy(no metadata)
-		meta, err = openFreezerFileForReadOnly(filepath.Join(path, fmt.Sprintf("%s.meta", name)))
+		// TODO(rjl493456442) change it to read-only mode. Open the metadata file
+		// in rw mode. It's a temporary solution for now and should be changed
+		// whenever the tail deletion is actually used. The reason for this hack is
+		// the additional meta file for each freezer table is added in order to support
+		// tail deletion, but for most legacy nodes this file is missing. This check
+		// will suddenly break lots of database relevant commands. So the metadata file
+		// is always opened for mutation and nothing else will be written except
+		// the initialization.
+		meta, err = openFreezerFileForAppend(filepath.Join(path, fmt.Sprintf("%s.meta", name)))
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
This PR adds a hack to freezer, the newly introduced meta data file will always be opened in the read/write mode.

The reason for adding this hack is: the meta data files are missing for legacy nodes which means most of the db commands will fail when the db is opened in the read-only mode. 

Since tail deletion is not used right now, the only mutation can be made is initialization which is acceptable instead of breaking existent commands.