### PR TITLE
eth/downloader: fix off-by-one error in test causing 50% fails

### DIFF
--- a/eth/downloader/skeleton_test.go
+++ b/eth/downloader/skeleton_test.go
@@ -742,13 +742,13 @@ func TestSkeletonSyncRetrievals(t *testing.T) {
 			head: chain[2*requestHeaders],
 			peers: []*skeletonTestPeer{
 				newSkeletonTestPeerWithHook("peer-1", chain, func(origin uint64) []*types.Header {
-					if origin == chain[2*requestHeaders+2].Number.Uint64() {
+					if origin == chain[2*requestHeaders+1].Number.Uint64() {
 						time.Sleep(100 * time.Millisecond)
 					}
 					return nil // Fallback to default behavior, just delayed
 				}),
 				newSkeletonTestPeerWithHook("peer-2", chain, func(origin uint64) []*types.Header {
-					if origin == chain[2*requestHeaders+2].Number.Uint64() {
+					if origin == chain[2*requestHeaders+1].Number.Uint64() {
 						time.Sleep(100 * time.Millisecond)
 					}
 					return nil // Fallback to default behavior, just delayed


### PR DESCRIPTION
I miscalculated which header is the one being retrieved that needs to be delayed to trigger the data race. It caused no delay thus 50% success 50% fail for the test.