### PR TITLE
eth/tracers/logger: use omitempty to reduce log bloat 

### DIFF
--- a/eth/tracers/logger/gen_structlog.go
+++ b/eth/tracers/logger/gen_structlog.go
@@ -29,7 +29,7 @@ func (s StructLog) MarshalJSON() ([]byte, error) {
 		Depth         int                         `json:"depth"`
 		RefundCounter uint64                      `json:"refund"`
 		Err           error                       `json:"-"`
-		OpName        string                      `json:"opName,omitempty"`
+		OpName        string                      `json:"opName"`
 		ErrorString   string                      `json:"error,omitempty"`
 	}
 	var enc StructLog

--- a/eth/tracers/logger/gen_structlog.go
+++ b/eth/tracers/logger/gen_structlog.go
@@ -29,8 +29,8 @@ func (s StructLog) MarshalJSON() ([]byte, error) {
 		Depth         int                         `json:"depth"`
 		RefundCounter uint64                      `json:"refund"`
 		Err           error                       `json:"-"`
-		OpName        string                      `json:"opName"`
-		ErrorString   string                      `json:"error"`
+		OpName        string                      `json:"opName,omitempty"`
+		ErrorString   string                      `json:"error,omitempty"`
 	}
 	var enc StructLog
 	enc.Pc = s.Pc

--- a/eth/tracers/logger/gen_structlog.go
+++ b/eth/tracers/logger/gen_structlog.go
@@ -21,10 +21,10 @@ func (s StructLog) MarshalJSON() ([]byte, error) {
 		Op            vm.OpCode                   `json:"op"`
 		Gas           math.HexOrDecimal64         `json:"gas"`
 		GasCost       math.HexOrDecimal64         `json:"gasCost"`
-		Memory        hexutil.Bytes               `json:"memory"`
+		Memory        hexutil.Bytes               `json:"memory,omitempty"`
 		MemorySize    int                         `json:"memSize"`
 		Stack         []uint256.Int               `json:"stack"`
-		ReturnData    hexutil.Bytes               `json:"returnData"`
+		ReturnData    hexutil.Bytes               `json:"returnData,omitempty"`
 		Storage       map[common.Hash]common.Hash `json:"-"`
 		Depth         int                         `json:"depth"`
 		RefundCounter uint64                      `json:"refund"`
@@ -57,10 +57,10 @@ func (s *StructLog) UnmarshalJSON(input []byte) error {
 		Op            *vm.OpCode                  `json:"op"`
 		Gas           *math.HexOrDecimal64        `json:"gas"`
 		GasCost       *math.HexOrDecimal64        `json:"gasCost"`
-		Memory        *hexutil.Bytes              `json:"memory"`
+		Memory        *hexutil.Bytes              `json:"memory,omitempty"`
 		MemorySize    *int                        `json:"memSize"`
 		Stack         []uint256.Int               `json:"stack"`
-		ReturnData    *hexutil.Bytes              `json:"returnData"`
+		ReturnData    *hexutil.Bytes              `json:"returnData,omitempty"`
 		Storage       map[common.Hash]common.Hash `json:"-"`
 		Depth         *int                        `json:"depth"`
 		RefundCounter *uint64                     `json:"refund"`

--- a/eth/tracers/logger/logger.go
+++ b/eth/tracers/logger/logger.go
@@ -78,12 +78,12 @@ type StructLog struct {
 
 // overrides for gencodec
 type structLogMarshaling struct {
-	Gas         math.HexOrDecimal64 `json:",omitempty"`
-	GasCost     math.HexOrDecimal64 `json:",omitempty"`
-	Memory      hexutil.Bytes       `json:",omitempty"`
-	ReturnData  hexutil.Bytes       `json:",omitempty"`
-	OpName      string              `json:"opName,omitempty"` // adds call to OpName() in MarshalJSON
-	ErrorString string              `json:"error,omitempty"`  // adds call to ErrorString() in MarshalJSON
+	Gas         math.HexOrDecimal64
+	GasCost     math.HexOrDecimal64
+	Memory      hexutil.Bytes `json:",omitempty"`
+	ReturnData  hexutil.Bytes `json:",omitempty"`
+	OpName      string        `json:"opName"`          // adds call to OpName() in MarshalJSON
+	ErrorString string        `json:"error,omitempty"` // adds call to ErrorString() in MarshalJSON
 }
 
 // OpName formats the operand name in a human-readable format.

--- a/eth/tracers/logger/logger.go
+++ b/eth/tracers/logger/logger.go
@@ -66,10 +66,10 @@ type StructLog struct {
 	Op            vm.OpCode                   `json:"op"`
 	Gas           uint64                      `json:"gas"`
 	GasCost       uint64                      `json:"gasCost"`
-	Memory        []byte                      `json:"memory"`
+	Memory        []byte                      `json:"memory,omitempty"`
 	MemorySize    int                         `json:"memSize"`
 	Stack         []uint256.Int               `json:"stack"`
-	ReturnData    []byte                      `json:"returnData"`
+	ReturnData    []byte                      `json:"returnData,omitempty"`
 	Storage       map[common.Hash]common.Hash `json:"-"`
 	Depth         int                         `json:"depth"`
 	RefundCounter uint64                      `json:"refund"`
@@ -80,10 +80,10 @@ type StructLog struct {
 type structLogMarshaling struct {
 	Gas         math.HexOrDecimal64
 	GasCost     math.HexOrDecimal64
-	Memory      hexutil.Bytes `json:",omitempty"`
-	ReturnData  hexutil.Bytes `json:",omitempty"`
-	OpName      string        `json:"opName"`          // adds call to OpName() in MarshalJSON
-	ErrorString string        `json:"error,omitempty"` // adds call to ErrorString() in MarshalJSON
+	Memory      hexutil.Bytes
+	ReturnData  hexutil.Bytes
+	OpName      string `json:"opName"`          // adds call to OpName() in MarshalJSON
+	ErrorString string `json:"error,omitempty"` // adds call to ErrorString() in MarshalJSON
 }
 
 // OpName formats the operand name in a human-readable format.

--- a/eth/tracers/logger/logger.go
+++ b/eth/tracers/logger/logger.go
@@ -78,12 +78,12 @@ type StructLog struct {
 
 // overrides for gencodec
 type structLogMarshaling struct {
-	Gas         math.HexOrDecimal64
-	GasCost     math.HexOrDecimal64
-	Memory      hexutil.Bytes
-	ReturnData  hexutil.Bytes
-	OpName      string `json:"opName"` // adds call to OpName() in MarshalJSON
-	ErrorString string `json:"error"`  // adds call to ErrorString() in MarshalJSON
+	Gas         math.HexOrDecimal64 `json:",omitempty"`
+	GasCost     math.HexOrDecimal64 `json:",omitempty"`
+	Memory      hexutil.Bytes       `json:",omitempty"`
+	ReturnData  hexutil.Bytes       `json:",omitempty"`
+	OpName      string              `json:"opName,omitempty"` // adds call to OpName() in MarshalJSON
+	ErrorString string              `json:"error,omitempty"`  // adds call to ErrorString() in MarshalJSON
 }
 
 // OpName formats the operand name in a human-readable format.

--- a/eth/tracers/logger/logger_test.go
+++ b/eth/tracers/logger/logger_test.go
@@ -18,10 +18,10 @@ package logger
 
 import (
 	"encoding/json"
+	"fmt"
 	"math/big"
 	"testing"
 
-	"fmt"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/state"
 	"github.com/ethereum/go-ethereum/core/vm"

--- a/eth/tracers/logger/logger_test.go
+++ b/eth/tracers/logger/logger_test.go
@@ -82,9 +82,8 @@ func TestStructLogMarshalingOmitEmpty(t *testing.T) {
 		log  *structLogMarshaling
 		want string
 	}{
-		{"empty err and no fields", &structLogMarshaling{ErrorString: ""}, `{}`},
-		{"with Gas cost only", &structLogMarshaling{GasCost: 10}, `{"GasCost":"0xa"}`},
-		{"with err", &structLogMarshaling{ErrorString: "this failed"}, `{"error":"this failed"}`},
+		{"empty err and no fields", &structLogMarshaling{ErrorString: ""}, `{"Gas":"0x0","GasCost":"0x0","opName":""}`},
+		{"with err", &structLogMarshaling{ErrorString: "this failed"}, `{"Gas":"0x0","GasCost":"0x0","opName":"","error":"this failed"}`},
 	}
 
 	for _, tt := range tests {
@@ -93,8 +92,8 @@ func TestStructLogMarshalingOmitEmpty(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			if g, w := string(blob), tt.want; g != w {
-				t.Fatalf("Mismatched results\n\tGot:  %q\n\tWant: %q", g, w)
+			if have, want := string(blob), tt.want; have != want {
+				t.Fatalf("mismatched results\n\thave: %q\n\twant: %q", have, want)
 			}
 		})
 	}


### PR DESCRIPTION
This PR replaces #24491. I pushed some fixes on top, but do not have permissions to push to the submitter's repo. Also rebased on master. 

Closes #24487