### PR TITLE
Stacktrie prover v3

### DIFF
--- a/cmd/devp2p/internal/ethtest/snap.go
+++ b/cmd/devp2p/internal/ethtest/snap.go
@@ -26,7 +26,6 @@ import (
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/eth/protocols/snap"
 	"github.com/ethereum/go-ethereum/internal/utesting"
-	"github.com/ethereum/go-ethereum/light"
 	"github.com/ethereum/go-ethereum/trie"
 	"golang.org/x/crypto/sha3"
 )
@@ -503,7 +502,7 @@ func (s *Suite) snapGetAccountRange(t *utesting.T, tc *accRangeTest) error {
 	for i, key := range hashes {
 		keys[i] = common.CopyBytes(key[:])
 	}
-	nodes := make(light.NodeList, len(proof))
+	nodes := make(trie.NodeList, len(proof))
 	for i, node := range proof {
 		nodes[i] = node
 	}

--- a/eth/protocols/snap/handler.go
+++ b/eth/protocols/snap/handler.go
@@ -24,7 +24,6 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core"
 	"github.com/ethereum/go-ethereum/core/types"
-	"github.com/ethereum/go-ethereum/light"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/metrics"
 	"github.com/ethereum/go-ethereum/p2p"
@@ -322,7 +321,7 @@ func ServiceGetAccountRangeQuery(chain *core.BlockChain, req *GetAccountRangePac
 	it.Release()
 
 	// Generate the Merkle proofs for the first and last account
-	proof := light.NewNodeSet()
+	proof := trie.NewNodeSet()
 	if err := tr.Prove(req.Origin[:], 0, proof); err != nil {
 		log.Warn("Failed to prove account range", "origin", req.Origin, "err", err)
 		return nil, nil
@@ -425,7 +424,7 @@ func ServiceGetStorageRangesQuery(chain *core.BlockChain, req *GetStorageRangesP
 			if err != nil {
 				return nil, nil
 			}
-			proof := light.NewNodeSet()
+			proof := trie.NewNodeSet()
 			if err := stTrie.Prove(origin[:], 0, proof); err != nil {
 				log.Warn("Failed to prove storage range", "origin", req.Origin, "err", err)
 				return nil, nil

--- a/eth/protocols/snap/sync.go
+++ b/eth/protocols/snap/sync.go
@@ -36,7 +36,6 @@ import (
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/ethdb"
 	"github.com/ethereum/go-ethereum/event"
-	"github.com/ethereum/go-ethereum/light"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/p2p/msgrate"
 	"github.com/ethereum/go-ethereum/rlp"
@@ -2286,7 +2285,7 @@ func (s *Syncer) OnAccounts(peer SyncPeer, id uint64, hashes []common.Hash, acco
 	for i, key := range hashes {
 		keys[i] = common.CopyBytes(key[:])
 	}
-	nodes := make(light.NodeList, len(proof))
+	nodes := make(trie.NodeList, len(proof))
 	for i, node := range proof {
 		nodes[i] = node
 	}
@@ -2523,7 +2522,7 @@ func (s *Syncer) OnStorage(peer SyncPeer, id uint64, hashes [][]common.Hash, slo
 		for j, key := range hashes[i] {
 			keys[j] = common.CopyBytes(key[:])
 		}
-		nodes := make(light.NodeList, 0, len(proof))
+		nodes := make(trie.NodeList, 0, len(proof))
 		if i == len(hashes)-1 {
 			for _, node := range proof {
 				nodes = append(nodes, node)

--- a/eth/protocols/snap/sync_test.go
+++ b/eth/protocols/snap/sync_test.go
@@ -32,7 +32,6 @@ import (
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/ethdb"
-	"github.com/ethereum/go-ethereum/light"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/rlp"
 	"github.com/ethereum/go-ethereum/trie"
@@ -264,7 +263,7 @@ func createAccountRequestResponse(t *testPeer, root common.Hash, origin common.H
 	// Unless we send the entire trie, we need to supply proofs
 	// Actually, we need to supply proofs either way! This seems to be an implementation
 	// quirk in go-ethereum
-	proof := light.NewNodeSet()
+	proof := trie.NewNodeSet()
 	if err := t.accountTrie.Prove(origin[:], 0, proof); err != nil {
 		t.logger.Error("Could not prove inexistence of origin", "origin", origin, "error", err)
 	}
@@ -343,7 +342,7 @@ func createStorageRequestResponse(t *testPeer, root common.Hash, accounts []comm
 		if originHash != (common.Hash{}) || abort {
 			// If we're aborting, we need to prove the first and last item
 			// This terminates the response (and thus the loop)
-			proof := light.NewNodeSet()
+			proof := trie.NewNodeSet()
 			stTrie := t.storageTries[account]
 
 			// Here's a potential gotcha: when constructing the proof, we cannot
@@ -401,7 +400,7 @@ func createStorageRequestResponseAlwaysProve(t *testPeer, root common.Hash, acco
 		if exit {
 			// If we're aborting, we need to prove the first and last item
 			// This terminates the response (and thus the loop)
-			proof := light.NewNodeSet()
+			proof := trie.NewNodeSet()
 			stTrie := t.storageTries[account]
 
 			// Here's a potential gotcha: when constructing the proof, we cannot
@@ -584,7 +583,7 @@ func TestSyncBloatedProof(t *testing.T) {
 			vals = append(vals, entry.v)
 		}
 		// The proofs
-		proof := light.NewNodeSet()
+		proof := trie.NewNodeSet()
 		if err := t.accountTrie.Prove(origin[:], 0, proof); err != nil {
 			t.logger.Error("Could not prove origin", "origin", origin, "error", err)
 		}

--- a/les/client_handler.go
+++ b/les/client_handler.go
@@ -34,6 +34,7 @@ import (
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/p2p"
 	"github.com/ethereum/go-ethereum/params"
+	"github.com/ethereum/go-ethereum/trie"
 )
 
 // clientHandler is responsible for receiving and processing all incoming server
@@ -304,7 +305,7 @@ func (h *clientHandler) handleMsg(p *serverPeer) error {
 		p.Log().Trace("Received les/2 proofs response")
 		var resp struct {
 			ReqID, BV uint64
-			Data      light.NodeList
+			Data      trie.NodeList
 		}
 		if err := msg.Decode(&resp); err != nil {
 			return errResp(ErrDecode, "msg %v: %v", msg, err)

--- a/les/handler_test.go
+++ b/les/handler_test.go
@@ -400,7 +400,7 @@ func testGetProofs(t *testing.T, protocol int) {
 	bc := server.handler.blockchain
 
 	var proofreqs []ProofReq
-	proofsV2 := light.NewNodeSet()
+	proofsV2 := trie.NewNodeSet()
 
 	accounts := []common.Address{bankAddr, userAddr1, userAddr2, signerAddr, {}}
 	for i := uint64(0); i <= bc.CurrentBlock().NumberU64(); i++ {
@@ -455,7 +455,7 @@ func testGetStaleProof(t *testing.T, protocol int) {
 
 		var expected []rlp.RawValue
 		if wantOK {
-			proofsV2 := light.NewNodeSet()
+			proofsV2 := trie.NewNodeSet()
 			t, _ := trie.New(header.Root, trie.NewDatabase(server.db))
 			t.Prove(account, 0, proofsV2)
 			expected = proofsV2.NodeList()

--- a/les/odr_requests.go
+++ b/les/odr_requests.go
@@ -222,7 +222,7 @@ func (r *TrieRequest) Validate(db ethdb.Database, msg *Msg) error {
 	if msg.MsgType != MsgProofsV2 {
 		return errInvalidMessageType
 	}
-	proofs := msg.Obj.(light.NodeList)
+	proofs := msg.Obj.(trie.NodeList)
 	// Verify the proof and store if checks out
 	nodeSet := proofs.NodeSet()
 	reads := &readTraceDB{db: nodeSet}
@@ -308,7 +308,7 @@ type HelperTrieReq struct {
 }
 
 type HelperTrieResps struct { // describes all responses, not just a single one
-	Proofs  light.NodeList
+	Proofs  trie.NodeList
 	AuxData [][]byte
 }
 

--- a/les/peer.go
+++ b/les/peer.go
@@ -41,6 +41,7 @@ import (
 	"github.com/ethereum/go-ethereum/p2p/enode"
 	"github.com/ethereum/go-ethereum/params"
 	"github.com/ethereum/go-ethereum/rlp"
+	"github.com/ethereum/go-ethereum/trie"
 )
 
 var (
@@ -907,7 +908,7 @@ func (p *clientPeer) replyReceiptsRLP(reqID uint64, receipts []rlp.RawValue) *re
 }
 
 // replyProofsV2 creates a reply with a batch of merkle proofs, corresponding to the ones requested.
-func (p *clientPeer) replyProofsV2(reqID uint64, proofs light.NodeList) *reply {
+func (p *clientPeer) replyProofsV2(reqID uint64, proofs trie.NodeList) *reply {
 	data, _ := rlp.EncodeToBytes(proofs)
 	return &reply{p.rw, ProofsV2Msg, reqID, data}
 }

--- a/les/server_requests.go
+++ b/les/server_requests.go
@@ -378,7 +378,7 @@ func handleGetProofs(msg Decoder) (serveRequestFn, uint64, uint64, error) {
 			err       error
 		)
 		bc := backend.BlockChain()
-		nodes := light.NewNodeSet()
+		nodes := trie.NewNodeSet()
 
 		for i, request := range r.Reqs {
 			if i != 0 && !waitOrStop() {
@@ -462,7 +462,7 @@ func handleGetHelperTrieProofs(msg Decoder) (serveRequestFn, uint64, uint64, err
 			auxData  [][]byte
 		)
 		bc := backend.BlockChain()
-		nodes := light.NewNodeSet()
+		nodes := trie.NewNodeSet()
 		for i, request := range r.Reqs {
 			if i != 0 && !waitOrStop() {
 				return nil

--- a/light/odr.go
+++ b/light/odr.go
@@ -26,6 +26,7 @@ import (
 	"github.com/ethereum/go-ethereum/core/rawdb"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/ethdb"
+	"github.com/ethereum/go-ethereum/trie"
 )
 
 // NoOdr is the default context passed to an ODR capable function when the ODR
@@ -85,7 +86,7 @@ func StorageTrieID(state *TrieID, addrHash, root common.Hash) *TrieID {
 type TrieRequest struct {
 	Id    *TrieID
 	Key   []byte
-	Proof *NodeSet
+	Proof *trie.NodeSet
 }
 
 // StoreResult stores the retrieved data in local database
@@ -141,7 +142,7 @@ type ChtRequest struct {
 	ChtRoot          common.Hash
 	Header           *types.Header
 	Td               *big.Int
-	Proof            *NodeSet
+	Proof            *trie.NodeSet
 }
 
 // StoreResult stores the retrieved data in local database
@@ -161,7 +162,7 @@ type BloomRequest struct {
 	SectionIndexList []uint64
 	BloomTrieRoot    common.Hash
 	BloomBits        [][]byte
-	Proofs           *NodeSet
+	Proofs           *trie.NodeSet
 }
 
 // StoreResult stores the retrieved data in local database

--- a/light/odr_test.go
+++ b/light/odr_test.go
@@ -83,7 +83,7 @@ func (odr *testOdr) Retrieve(ctx context.Context, req OdrRequest) error {
 		}
 	case *TrieRequest:
 		t, _ := trie.New(req.Id.Root, trie.NewDatabase(odr.sdb))
-		nodes := NewNodeSet()
+		nodes := trie.NewNodeSet()
 		t.Prove(req.Key, 0, nodes)
 		req.Proof = nodes
 	case *CodeRequest:

--- a/light/postprocess.go
+++ b/light/postprocess.go
@@ -356,7 +356,7 @@ func NewBloomTrieIndexer(db ethdb.Database, odr OdrBackend, parentSize, size uin
 func (b *BloomTrieIndexerBackend) fetchMissingNodes(ctx context.Context, section uint64, root common.Hash) error {
 	indexCh := make(chan uint, types.BloomBitLength)
 	type res struct {
-		nodes *NodeSet
+		nodes *trie.NodeSet
 		err   error
 	}
 	resCh := make(chan res, types.BloomBitLength)

--- a/trie/nodeset.go
+++ b/trie/nodeset.go
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
 
-package light
+package trie
 
 import (
 	"errors"

--- a/trie/proof_test.go
+++ b/trie/proof_test.go
@@ -1029,16 +1029,16 @@ func benchmarkVerifyRangeNoProof(b *testing.B, size int) {
 func randomTrie(n int) (*Trie, map[string]*kv) {
 	trie := new(Trie)
 	vals := make(map[string]*kv)
-	for i := byte(0); i < 100; i++ {
-		value := &kv{common.LeftPadBytes([]byte{i}, 32), []byte{i}, false}
-		value2 := &kv{common.LeftPadBytes([]byte{i + 10}, 32), []byte{i}, false}
-		trie.Update(value.k, value.v)
-		trie.Update(value2.k, value2.v)
-		vals[string(value.k)] = value
-		vals[string(value2.k)] = value2
-	}
+	//for i := byte(0); i < 100; i++ {
+	//	value := &kv{common.LeftPadBytes([]byte{i}, 64), []byte{i}, false}
+	//	value2 := &kv{common.LeftPadBytes([]byte{i + 10}, 64), []byte{i}, false}
+	//	trie.Update(value.k, value.v)
+	//	trie.Update(value2.k, value2.v)
+	//	vals[string(value.k)] = value
+	//	vals[string(value2.k)] = value2
+	//}
 	for i := 0; i < n; i++ {
-		value := &kv{randBytes(32), randBytes(20), false}
+		value := &kv{randBytes(32), randBytes(64), false}
 		trie.Update(value.k, value.v)
 		vals[string(value.k)] = value
 	}

--- a/trie/stackproof.go
+++ b/trie/stackproof.go
@@ -1,0 +1,133 @@
+package trie
+
+import (
+	"fmt"
+
+	"errors"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/ethdb"
+)
+
+type pathProof struct {
+	path  []byte
+	proof []byte
+}
+type shortN struct {
+	ext []byte
+	val []byte
+}
+type fullN struct {
+	siblings map[int]interface{}
+}
+
+func nodeToStacktrie(n node, key []byte) *StackTrie {
+	st := stackTrieFromPool(nil)
+	switch n := n.(type) {
+	case *shortNode:
+		st.nodeType = extNode
+		st.key = append([]byte{}, n.Key...)
+	case *fullNode:
+		st.nodeType = branchNode
+		idx := int(key[0])
+		for i := 0; i < idx; i++ {
+			sibling := n.Children[i]
+			if sibling == nil {
+				continue
+			}
+			siblingNode := stackTrieFromPool(nil)
+			siblingNode.nodeType = hashedNode
+			hash, _ := sibling.(hashNode)
+			siblingNode.val = []byte(hash)
+			st.children[i] = siblingNode
+		}
+	default:
+		panic(fmt.Sprintf("%T", n))
+	}
+	return st
+}
+
+func initLeftside(rootHash common.Hash, root node, key []byte, proofDb ethdb.KeyValueReader, allowNonExistent bool) (*StackTrie, []byte, error) {
+	// resolveNode retrieves and resolves trie node from merkle proof stream
+	resolveNode := func(hash common.Hash) (node, error) {
+		buf, _ := proofDb.Get(hash[:])
+		if buf == nil {
+			return nil, fmt.Errorf("proof node (hash %064x) missing", hash)
+		}
+		//fmt.Printf("[s] Looked up node %064x ok\n", hash)
+		n, err := decodeNode(hash[:], buf)
+		if err != nil {
+			return nil, fmt.Errorf("bad proof node %v", err)
+		}
+		return n, err
+	}
+	// If the root node is empty, resolve it first.
+	// Root node must be included in the proof.
+	if root == nil {
+		n, err := resolveNode(rootHash)
+		if err != nil {
+			return nil, nil, err
+		}
+		root = n
+	}
+	var (
+		err           error
+		child, parent node
+		keyrest       []byte
+		valnode       []byte
+	)
+	key, parent = keybytesToHex(key), root
+	stRoot := nodeToStacktrie(root, key)
+	stParent := stRoot
+	var stChild *StackTrie
+	for {
+		keyrest, child = get(parent, key, false)
+		switch cld := child.(type) {
+		case nil:
+			// The trie doesn't contain the key. It's possible
+			// the proof is a non-existing proof, but at least
+			// we can prove all resolved nodes are correct, it's
+			// enough for us to prove range.
+			if allowNonExistent {
+				return stRoot, nil, nil
+			}
+			return nil, nil, errors.New("the node is not contained in trie")
+		case hashNode:
+			child, err = resolveNode(common.BytesToHash(cld))
+			if err != nil {
+				return nil, nil, err
+			}
+		case valueNode:
+			valnode = cld
+			// The value node goes right into the child
+			stParent.val = common.CopyBytes(cld)
+			stParent.nodeType = leafNode
+			// remove the terminator
+			stParent.key = stParent.key[:len(stParent.key)-1]
+			return stRoot, valnode, nil
+		default:
+			// we don't expect shortnodes or fullnodes
+			panic(fmt.Sprintf("got %T", cld))
+		}
+		stChild = nodeToStacktrie(child, keyrest)
+		// Link the parent and child.
+		switch pnode := parent.(type) {
+		case *shortNode:
+			pnode.Val = child
+			stParent.children[0] = stChild
+		case *fullNode:
+			pnode.Children[key[0]] = child
+			stParent.children[key[0]] = stChild
+		default:
+			panic(fmt.Sprintf("%T: invalid node: %v", pnode, pnode))
+		}
+		if len(valnode) > 0 {
+			return stRoot, valnode, nil // The whole path is resolved
+		}
+		key, parent = keyrest, child
+		stParent = stChild
+	}
+}
+
+func finalizeRightSide(rootHash common.Hash, root *StackTrie, key []byte, proofDb ethdb.KeyValueReader, allowNonExistent bool) (*StackTrie, []byte, error) {
+	panic("not implemented")
+}

--- a/trie/stackproof_test.go
+++ b/trie/stackproof_test.go
@@ -1,0 +1,75 @@
+package trie
+
+import (
+	"sort"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/ethdb/memorydb"
+)
+
+type keyValue struct {
+	k []byte
+	v []byte
+}
+
+func TestStRangeProofLeftside(t *testing.T) {
+	trie, vals := randomTrie(4096)
+	var entries entrySlice
+	for _, kv := range vals {
+		entries = append(entries, kv)
+	}
+	sort.Sort(entries)
+	{
+		start := 10
+		end := len(vals)
+		proof := memorydb.New()
+		if err := trie.Prove(entries[start].k, 0, proof); err != nil {
+			t.Fatalf("Failed to prove the first node %v", err)
+		}
+		if err := trie.Prove(entries[end-1].k, 0, proof); err != nil {
+			t.Fatalf("Failed to prove the last node %v", err)
+		}
+		stRoot, _, err := initLeftside(trie.Hash(), nil, entries[start].k, proof, false)
+		if err != nil {
+			t.Fatal(err)
+		}
+		for i := start + 1; i < end; i++ {
+			stRoot.Update(entries[i].k, entries[i].v)
+		}
+		if got, want := stRoot.Hash(), trie.Hash(); got != want {
+			t.Fatalf("got %x want %x\n", stRoot.Hash(), trie.Hash())
+		}
+	}
+}
+
+func TestStRangeProofRightSide(t *testing.T) {
+	trie, vals := randomTrie(4096)
+	var entries entrySlice
+	for _, kv := range vals {
+		entries = append(entries, kv)
+	}
+	sort.Sort(entries)
+	{
+		start := 0
+		end := 50
+		proof := memorydb.New()
+		if err := trie.Prove(entries[start].k, 0, proof); err != nil {
+			t.Fatalf("Failed to prove the first node %v", err)
+		}
+		if err := trie.Prove(entries[end-1].k, 0, proof); err != nil {
+			t.Fatalf("Failed to prove the last node %v", err)
+		}
+		stRoot := NewStackTrie(nil)
+		for i := 0; i < end; i++ {
+			stRoot.Update(entries[i].k, entries[i].v)
+		}
+		var err error
+		stRoot, _, err = finalizeRightSide(trie.Hash(), stRoot, entries[end-1].k, proof, false)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got, want := stRoot.Hash(), trie.Hash(); got != want {
+			t.Fatalf("got %x want %x\n", stRoot.Hash(), trie.Hash())
+		}
+	}
+}

--- a/trie/stacktrie.go
+++ b/trie/stacktrie.go
@@ -507,3 +507,32 @@ func (st *StackTrie) Commit() (h common.Hash, err error) {
 	st.db.Put(h[:], st.val)
 	return h, nil
 }
+
+func (st *StackTrie) dumpTrie(lvl int) {
+	var indent []byte
+	for i := 0; i < lvl; i++ {
+		indent = append(indent, ' ')
+	}
+	switch st.nodeType {
+	case branchNode:
+		fmt.Printf("\n%s FN (key=%#x)", string(indent), st.key)
+
+		for i := 0; i < 16; i++ {
+			if st.children[i] == nil {
+				continue
+			}
+			fmt.Printf("\n%s %#x. ", string(indent), i)
+			st.children[i].dumpTrie(lvl + 1)
+		}
+		fmt.Println("")
+	case extNode:
+		fmt.Printf("%s: sn(%#x)", string(indent), st.key)
+		st.children[0].dumpTrie(lvl + 1)
+	case leafNode:
+		fmt.Printf("%s: leaf(%#x): %x ", string(indent), st.key, st.val)
+	case hashedNode:
+		fmt.Printf("hash: %#x", st.val)
+	default:
+		fmt.Printf("Foo: %d ? ", st.nodeType)
+	}
+}


### PR DESCRIPTION
This PR is my second attempt at implementing what I outline here: https://github.com/ethereum/go-ethereum/pull/24556#issuecomment-1072095300 . 
It (so far) implements half of verifying a range with stacktrie, which means initializing the stacktrie with the correct initial structure. After that, we can fill with the keys. 

IT does not yet contain code to fix up the right-hand side, if one does not want to fill it with the entire remaining range. It's a PoC so far, ideas/suggestions welcome. I find the latter part a bit more difficult than the initial part, since it cannot just create a stacktrie from given data, but must actually massage the existing stacktrie to conform to the desired structure. 