### PR TITLE
docs: fix data directory location

### DIFF
--- a/docs/_install-and-build/Backup--restore.md
+++ b/docs/_install-and-build/Backup--restore.md
@@ -12,7 +12,7 @@ directory locations are platform specific:
 
 * Mac: `~/Library/Ethereum`
 * Linux: `~/.ethereum`
-* Windows: `%APPDATA%\Ethereum`
+* Windows: `%LOCALAPPDATA%\Ethereum`
 
 Accounts are stored in the `keystore` subdirectory. The contents of this directories
 should be transportable between nodes, platforms, implementations (C++, Go, Python).


### PR DESCRIPTION
After looking into the newest geth version and installed geth on my windows os, i found the location of data directory is on :
%LOCALAPPDATA%\Ethereum

not

%APPDATA%\Ethereum