### PR TITLE
internal/ethapi: add refund to StructLogRes

### DIFF
--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -1144,7 +1144,7 @@ type StructLogRes struct {
 	Stack         *[]string          `json:"stack,omitempty"`
 	Memory        *[]string          `json:"memory,omitempty"`
 	Storage       *map[string]string `json:"storage,omitempty"`
-	RefundCounter uint64             `json:"refund"`
+	RefundCounter uint64             `json:"refund,omitempty"`
 }
 
 // FormatLogs formats EVM returned structured logs for json output

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -1135,15 +1135,16 @@ type ExecutionResult struct {
 // StructLogRes stores a structured log emitted by the EVM while replaying a
 // transaction in debug mode
 type StructLogRes struct {
-	Pc      uint64             `json:"pc"`
-	Op      string             `json:"op"`
-	Gas     uint64             `json:"gas"`
-	GasCost uint64             `json:"gasCost"`
-	Depth   int                `json:"depth"`
-	Error   string             `json:"error,omitempty"`
-	Stack   *[]string          `json:"stack,omitempty"`
-	Memory  *[]string          `json:"memory,omitempty"`
-	Storage *map[string]string `json:"storage,omitempty"`
+	Pc            uint64             `json:"pc"`
+	Op            string             `json:"op"`
+	Gas           uint64             `json:"gas"`
+	GasCost       uint64             `json:"gasCost"`
+	Depth         int                `json:"depth"`
+	Error         string             `json:"error,omitempty"`
+	Stack         *[]string          `json:"stack,omitempty"`
+	Memory        *[]string          `json:"memory,omitempty"`
+	Storage       *map[string]string `json:"storage,omitempty"`
+	RefundCounter uint64             `json:"refund"`
 }
 
 // FormatLogs formats EVM returned structured logs for json output
@@ -1151,12 +1152,13 @@ func FormatLogs(logs []logger.StructLog) []StructLogRes {
 	formatted := make([]StructLogRes, len(logs))
 	for index, trace := range logs {
 		formatted[index] = StructLogRes{
-			Pc:      trace.Pc,
-			Op:      trace.Op.String(),
-			Gas:     trace.Gas,
-			GasCost: trace.GasCost,
-			Depth:   trace.Depth,
-			Error:   trace.ErrorString(),
+			Pc:            trace.Pc,
+			Op:            trace.Op.String(),
+			Gas:           trace.Gas,
+			GasCost:       trace.GasCost,
+			Depth:         trace.Depth,
+			Error:         trace.ErrorString(),
+			RefundCounter: trace.RefundCounter,
 		}
 		if trace.Stack != nil {
 			stack := make([]string, len(trace.Stack))


### PR DESCRIPTION
Refund is helpful for tracing. So will it make sense to add it into `StructLogRes`?

(Background info: we are implementing zkevm, proving every opcode step using zk-proof, so very detailed information needed for every step, for example, refund is needed to sstore op. If refund is included in StructLogRes, we don't need to recalculate it outside) 