### PR TITLE
eth/downloader: ignore zero size header batch for importing

### DIFF
--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -2296,6 +2296,9 @@ Error: %v
 // of the header retrieval mechanisms already need to verify nonces, as well as
 // because nonces can be verified sparsely, not needing to check each.
 func (bc *BlockChain) InsertHeaderChain(chain []*types.Header, checkFreq int) (int, error) {
+	if len(chain) == 0 {
+		return 0, nil
+	}
 	start := time.Now()
 	if i, err := bc.hc.ValidateHeaderChain(chain, checkFreq); err != nil {
 		return i, err

--- a/light/lightchain.go
+++ b/light/lightchain.go
@@ -419,6 +419,9 @@ func (lc *LightChain) SetChainHead(header *types.Header) error {
 // In the case of a light chain, InsertHeaderChain also creates and posts light
 // chain events when necessary.
 func (lc *LightChain) InsertHeaderChain(chain []*types.Header, checkFreq int) (int, error) {
+	if len(chain) == 0 {
+		return 0, nil
+	}
 	if atomic.LoadInt32(&lc.disableCheckFreq) == 1 {
 		checkFreq = 0
 	}


### PR DESCRIPTION
This PR fixes a panic by importing zero size header batch. It can happen when the imported headers are crossing the ttd border and all the synced headers are post-merge.