### PR TITLE
common/rawdb: fix ReadHeaderRLP

### DIFF
--- a/core/rawdb/accessors_chain.go
+++ b/core/rawdb/accessors_chain.go
@@ -26,7 +26,6 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
-	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/ethdb"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/params"
@@ -332,18 +331,28 @@ func ReadHeaderRange(db ethdb.Reader, number uint64, count uint64) []rlp.RawValu
 // ReadHeaderRLP retrieves a block header in its raw RLP database encoding.
 func ReadHeaderRLP(db ethdb.Reader, hash common.Hash, number uint64) rlp.RawValue {
 	var data []byte
-	db.ReadAncients(func(reader ethdb.AncientReader) error {
+	err := db.ReadAncients(func(reader ethdb.AncientReader) error {
 		// First try to look up the data in ancient database. Extra hash
 		// comparison is necessary since ancient database only maintains
 		// the canonical data.
 		data, _ = reader.Ancient(freezerHeaderTable, number)
-		if len(data) > 0 && crypto.Keccak256Hash(data) == hash {
-			return nil
+		if len(data) > 0 {
+			var header *types.Header
+			err := rlp.DecodeBytes(data, &header)
+			if err != nil {
+				return err
+			}
+			if header != nil && header.Hash() == hash {
+				return nil
+			}
 		}
 		// If not, try reading from leveldb
 		data, _ = db.Get(headerKey(number, hash))
 		return nil
 	})
+	if err != nil {
+		return nil
+	}
 	return data
 }
 

--- a/core/rawdb/accessors_chain.go
+++ b/core/rawdb/accessors_chain.go
@@ -344,8 +344,8 @@ func ReadHeaderRLP(db ethdb.Reader, hash common.Hash, number uint64) rlp.RawValu
 		data, _ = reader.Ancient(freezerHeaderTable, number)
 		if len(data) > 0 {
 			if HashByHeader {
-				var header *types.Header
-				if err := rlp.DecodeBytes(data, &header); err != nil {
+				header := new(types.Header)
+				if err := rlp.DecodeBytes(data, header); err != nil {
 					return err
 				}
 				if header != nil && header.Hash() == hash {

--- a/core/rawdb/accessors_chain.go
+++ b/core/rawdb/accessors_chain.go
@@ -329,6 +329,9 @@ func ReadHeaderRange(db ethdb.Reader, number uint64, count uint64) []rlp.RawValu
 	return rlpHeaders
 }
 
+// HashByHeader is a compile-time constant, which can be used to toggle the behaviour of ReadHeaderRLP. If `false`,
+// it is assumed that the header hash == `crypto.Keccak256(header_rlp)`. This may not be true in all ethereum-forks.
+// Such forks need to set this constant to `true`, to force the hash-check to utilize the `header.Hash` method.
 const HashByHeader = false
 
 // ReadHeaderRLP retrieves a block header in its raw RLP database encoding.
@@ -342,8 +345,7 @@ func ReadHeaderRLP(db ethdb.Reader, hash common.Hash, number uint64) rlp.RawValu
 		if len(data) > 0 {
 			if HashByHeader {
 				var header *types.Header
-				err := rlp.DecodeBytes(data, &header)
-				if err != nil {
+				if err := rlp.DecodeBytes(data, &header); err != nil {
 					return err
 				}
 				if header != nil && header.Hash() == hash {

--- a/core/rawdb/accessors_chain.go
+++ b/core/rawdb/accessors_chain.go
@@ -329,7 +329,7 @@ func ReadHeaderRange(db ethdb.Reader, number uint64, count uint64) []rlp.RawValu
 	return rlpHeaders
 }
 
-var HashByHeader bool
+const HashByHeader = false
 
 // ReadHeaderRLP retrieves a block header in its raw RLP database encoding.
 func ReadHeaderRLP(db ethdb.Reader, hash common.Hash, number uint64) rlp.RawValue {

--- a/eth/protocols/eth/handlers.go
+++ b/eth/protocols/eth/handlers.go
@@ -84,7 +84,7 @@ func serviceNonContiguousBlockHeaderQuery(chain *core.BlockChain, query *GetBloc
 			break
 		}
 		if rlpData, err := rlp.EncodeToBytes(origin); err != nil {
-			log.Crit("Unable to decode our own headers", "err", err)
+			log.Crit("Unable to encode our own headers", "err", err)
 		} else {
 			headers = append(headers, rlp.RawValue(rlpData))
 			bytes += common.StorageSize(len(rlpData))

--- a/eth/protocols/snap/sync.go
+++ b/eth/protocols/snap/sync.go
@@ -68,7 +68,7 @@ const (
 	// and waste round trip times. If it's too high, we're capping responses and
 	// waste bandwidth.
 	//
-	// Depoyed bytecodes are currently capped at 24KB, so the minimum request
+	// Deployed bytecodes are currently capped at 24KB, so the minimum request
 	// size should be maxRequestSize / 24K. Assuming that most contracts do not
 	// come close to that, requesting 4x should be a good approximation.
 	maxCodeRequestCount = maxRequestSize / (24 * 1024) * 4


### PR DESCRIPTION
Fix `ReadHeaderRLP` in a way so that no future geth fork which integrates a bft consensus will ever stumble upon this bug again. 

Because for bft consensus the headers of each node is not exactly the same, they may collect different portions of 2/3+ signatures. So in that case, `header.Hash()` doesn't necessarily equal to `keccak(headerBytes)`.

