### PR TITLE
node: allow JWT pass by file only

### DIFF
--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -548,7 +548,7 @@ var (
 	}
 	JWTSecretFlag = cli.StringFlag{
 		Name:  "authrpc.jwtsecret",
-		Usage: "JWT secret (or path to a jwt secret) to use for authenticated RPC endpoints",
+		Usage: "Path to a JWT secret to use for authenticated RPC endpoints",
 	}
 	// Logging and debug settings
 	EthStatsURLFlag = cli.StringFlag{

--- a/node/node.go
+++ b/node/node.go
@@ -346,17 +346,8 @@ func (n *Node) closeDataDir() {
 // or from the default location. If neither of those are present, it generates
 // a new secret and stores to the default location.
 func (n *Node) obtainJWTSecret(cliParam string) ([]byte, error) {
-	var fileName string
-	if len(cliParam) > 0 {
-		// If a plaintext secret was provided via cli flags, use that
-		jwtSecret := common.FromHex(cliParam)
-		if len(jwtSecret) == 32 && strings.HasPrefix(cliParam, "0x") {
-			log.Warn("Plaintext JWT secret provided, please consider passing via file")
-			return jwtSecret, nil
-		}
-		// path provided
-		fileName = cliParam
-	} else {
+	fileName := cliParam
+	if len(fileName) == 0 {
 		// no path provided, use default
 		fileName = n.ResolvePath(datadirJWTKey)
 	}


### PR DESCRIPTION
Removes the ability to pass a JWT secret in plaintext via CLI
This should help users not reveal their secret e.g. in bug reports