### PR TITLE
internal/build: show ppa upload process stdout on stdout

### DIFF
--- a/internal/build/util.go
+++ b/internal/build/util.go
@@ -115,7 +115,7 @@ func render(tpl *template.Template, outputFile string, outputPerm os.FileMode, x
 // the form sftp://[user@]host[:port].
 func UploadSFTP(identityFile, host, dir string, files []string) error {
 	sftp := exec.Command("sftp")
-	sftp.Stdout = nil
+	sftp.Stdout = os.Stdout
 	sftp.Stderr = os.Stderr
 	if identityFile != "" {
 		sftp.Args = append(sftp.Args, "-i", identityFile)


### PR DESCRIPTION
The travis sftp upload to ppa dies after 10m of inactivity. Hard to say what happens (we do get a notification about a successful upload from ppa), but directing the process stdout to stdout seems like thing that might tell us more. 