### PR TITLE
internal/build: prevent travis timeout during ppa upload

### DIFF
--- a/internal/build/util.go
+++ b/internal/build/util.go
@@ -31,6 +31,7 @@ import (
 	"path/filepath"
 	"strings"
 	"text/template"
+	"time"
 )
 
 var DryRunFlag = flag.Bool("n", false, "dry run, don't execute commands")
@@ -137,7 +138,23 @@ func UploadSFTP(identityFile, host, dir string, files []string) error {
 	for _, f := range files {
 		fmt.Fprintln(in, "put", f, path.Join(dir, filepath.Base(f)))
 	}
+	// Avoid travis timout after 10m of inactivity by printing something
+	// every 8 minutes.
+	done := make(chan bool)
+	go func() {
+		for {
+			select {
+			case <-time.After(8 * time.Minute):
+				fmt.Println("keepalive log")
+				continue
+			case <-done:
+				return
+			}
+
+		}
+	}()
 	stdin.Close()
+	defer close(done)
 	return sftp.Wait()
 }
 


### PR DESCRIPTION
Trying to solve travis timeout issues. They recommend https://docs.travis-ci.com/user/common-build-problems/#build-times-out-because-no-output-was-received : 
```
If you have a command that doesn’t produce output for more than 10 minutes, you can prefix it with travis_wait, a function that’s exported by our build environment. For example:

>    install: travis_wait mvn install

spawns a process running mvn install. travis_wait then writes a short line to the build log every minute for 20 minutes, extending the amount of time your command has to finish.

If you expect the command to take more than 20 minutes, prefix the command with travis_wait n where n is the number of minutes by which the waiting time is extended.
```

Seems a bit overkill ot install another dependency just to spit out message once per minute, so this PR does it internally instead. 