### PR TITLE
internal/build: exit sftp upload

### DIFF
--- a/internal/build/util.go
+++ b/internal/build/util.go
@@ -138,6 +138,7 @@ func UploadSFTP(identityFile, host, dir string, files []string) error {
 	for _, f := range files {
 		fmt.Fprintln(in, "put", f, path.Join(dir, filepath.Base(f)))
 	}
+	fmt.Fprintln(in, "exit")
 	// Avoid travis timout after 10m of inactivity by printing something
 	// every 8 minutes.
 	done := make(chan bool)


### PR DESCRIPTION
Now travis doesn't tear down the connection any longer, however, https://app.travis-ci.com/github/ethereum/go-ethereum/jobs/564712253 , neither do we. It appears the sftp upload kind of depended on travis eventually killing it. So this PR adds an `exit ` after all the sftp `put`s are done. 