### PR TITLE
eth/downloader: attempting to create downloader beacon tests

### DIFF
--- a/eth/downloader/downloader.go
+++ b/eth/downloader/downloader.go
@@ -509,7 +509,6 @@ func (d *Downloader) syncWithPeer(p *peerConnection, hash common.Hash, td, ttd *
 	}
 	d.syncStatsChainHeight = height
 	d.syncStatsLock.Unlock()
-
 	// Ensure our origin point is below any snap sync pivot point
 	if mode == SnapSync {
 		if height <= uint64(fsMinFullBlocks) {
@@ -517,6 +516,9 @@ func (d *Downloader) syncWithPeer(p *peerConnection, hash common.Hash, td, ttd *
 		} else {
 			pivotNumber := pivot.Number.Uint64()
 			if pivotNumber <= origin {
+				if pivotNumber == 0 {
+					panic("Going to set origin to -1")
+				}
 				origin = pivotNumber - 1
 			}
 			// Write out the pivot into the database so a rollback beyond it will


### PR DESCRIPTION
Trying to make some downloader tests which covers the beacon code. Not quite there yet, running this triggers
```
=== RUN   TestBeaconSynchronisation66Snap
    downloader_test.go:1403: failed to synchronise blocks: beacon linkup unavailable locally: 1007 [711d5473fbee0f9d8ed5013a48188c798cdf277c67e118008b448a062e294f20]
```
