### PR TITLE
cmd/geth: change to non-fatal error message when legacy receipt storage is not implemented

### DIFF
--- a/cmd/geth/config.go
+++ b/cmd/geth/config.go
@@ -174,7 +174,7 @@ func makeFullNode(ctx *cli.Context) (*node.Node, ethapi.Backend) {
 		}
 		isLegacy, _, err := dbHasLegacyReceipts(eth.ChainDb(), firstIdx)
 		if err != nil {
-			log.Error("Failed to check db for legacy receipts: %v", err)
+			log.Error("Failed to check db for legacy receipts", "err", err)
 		} else if isLegacy {
 			log.Warn("Database has receipts with a legacy format. Please run `geth db freezer-migrate`.")
 		}

--- a/cmd/geth/config.go
+++ b/cmd/geth/config.go
@@ -164,7 +164,7 @@ func makeFullNode(ctx *cli.Context) (*node.Node, ethapi.Backend) {
 	}
 	backend, eth := utils.RegisterEthService(stack, &cfg.Eth)
 	// Warn users to migrate if they have a legacy freezer format.
-	if eth != nil {
+	if eth != nil && !ctx.GlobalIsSet(utils.DeveloperFlag.Name) {
 		firstIdx := uint64(0)
 		// Hack to speed up check for mainnet because we know
 		// the first non-empty block.

--- a/cmd/geth/config.go
+++ b/cmd/geth/config.go
@@ -164,7 +164,7 @@ func makeFullNode(ctx *cli.Context) (*node.Node, ethapi.Backend) {
 	}
 	backend, eth := utils.RegisterEthService(stack, &cfg.Eth)
 	// Warn users to migrate if they have a legacy freezer format.
-	if eth != nil && !ctx.GlobalIsSet(utils.DeveloperFlag.Name) {
+	if eth != nil {
 		firstIdx := uint64(0)
 		// Hack to speed up check for mainnet because we know
 		// the first non-empty block.
@@ -174,9 +174,8 @@ func makeFullNode(ctx *cli.Context) (*node.Node, ethapi.Backend) {
 		}
 		isLegacy, _, err := dbHasLegacyReceipts(eth.ChainDb(), firstIdx)
 		if err != nil {
-			utils.Fatalf("Failed to check db for legacy receipts: %v", err)
-		}
-		if isLegacy {
+			log.Error("Failed to check db for legacy receipts: %v", err)
+		} else if isLegacy {
 			log.Warn("Database has receipts with a legacy format. Please run `geth db freezer-migrate`.")
 		}
 	}


### PR DESCRIPTION
fixes #24602