### PR TITLE
eth/downloader: retrieve pivot header from local chain if necessary

### DIFF
--- a/eth/downloader/beaconsync.go
+++ b/eth/downloader/beaconsync.go
@@ -265,7 +265,11 @@ func (d *Downloader) fetchBeaconHeaders(from uint64) error {
 			hashes  = make([]common.Hash, 0, maxHeadersProcess)
 		)
 		for i := 0; i < maxHeadersProcess && from <= head.Number.Uint64(); i++ {
-			headers = append(headers, d.skeleton.Header(from))
+			header := d.skeleton.Header(from)
+			if header == nil {
+				header = d.lightchain.GetHeaderByNumber(from)
+			}
+			headers = append(headers, header)
 			hashes = append(hashes, headers[i].Hash())
 			from++
 		}

--- a/eth/downloader/downloader.go
+++ b/eth/downloader/downloader.go
@@ -493,9 +493,9 @@ func (d *Downloader) syncWithPeer(p *peerConnection, hash common.Hash, td, ttd *
 	// threshold (i.e. new chain). In that case we won't really snap sync
 	// anyway, but still need a valid pivot block to avoid some code hitting
 	// nil panics on access.
-	var noSnap bool
+	var syncState = true // means whether state sync is required in this cycle
 	if mode == SnapSync && pivot == nil {
-		pivot, noSnap = d.blockchain.CurrentBlock().Header(), true
+		pivot, syncState = d.blockchain.CurrentBlock().Header(), false
 	}
 	height := latest.Number.Uint64()
 
@@ -527,9 +527,8 @@ func (d *Downloader) syncWithPeer(p *peerConnection, hash common.Hash, td, ttd *
 		} else {
 			pivotNumber := pivot.Number.Uint64()
 
-			// Only cap the sync origin number by pivot point when
-			// state sync is required.
-			if pivotNumber <= origin && !noSnap {
+			// Cap the sync origin by pivot header when state sync is required.
+			if pivotNumber <= origin && syncState {
 				origin = pivotNumber - 1
 			}
 			// Write out the pivot into the database so a rollback beyond it will

--- a/eth/downloader/downloader_test.go
+++ b/eth/downloader/downloader_test.go
@@ -79,6 +79,31 @@ func newTester() *downloadTester {
 	return tester
 }
 
+// newTester creates a new downloader test mocker.
+func newTesterWithNotification(success func()) *downloadTester {
+	freezer, err := ioutil.TempDir("", "")
+	if err != nil {
+		panic(err)
+	}
+	db, err := rawdb.NewDatabaseWithFreezer(rawdb.NewMemoryDatabase(), freezer, "", false)
+	if err != nil {
+		panic(err)
+	}
+	core.GenesisBlockForTesting(db, testAddress, big.NewInt(1000000000000000))
+
+	chain, err := core.NewBlockChain(db, nil, params.TestChainConfig, ethash.NewFaker(), vm.Config{}, nil, nil)
+	if err != nil {
+		panic(err)
+	}
+	tester := &downloadTester{
+		freezer: freezer,
+		chain:   chain,
+		peers:   make(map[string]*downloadTesterPeer),
+	}
+	tester.downloader = New(0, db, new(event.TypeMux), tester.chain, nil, tester.dropPeer, success)
+	return tester
+}
+
 // terminate aborts any operations on the embedded downloader and releases all
 // held resources.
 func (dl *downloadTester) terminate() {
@@ -1366,5 +1391,53 @@ func testCheckpointEnforcement(t *testing.T, protocol uint, mode SyncMode) {
 		assertOwnChain(t, tester, 1)
 	} else {
 		assertOwnChain(t, tester, len(chain.blocks))
+	}
+}
+
+// Tests that peers below a pre-configured checkpoint block are prevented from
+// being fast-synced from, avoiding potential cheap eclipse attacks.
+func TestBeaconSync66Full(t *testing.T) { testBeaconSync(t, eth.ETH66, FullSync) }
+func TestBeaconSync66Snap(t *testing.T) { testBeaconSync(t, eth.ETH66, SnapSync) }
+
+func testBeaconSync(t *testing.T, protocol uint, mode SyncMode) {
+	//log.Root().SetHandler(log.LvlFilterHandler(log.LvlInfo, log.StreamHandler(os.Stderr, log.TerminalFormat(true))))
+
+	var cases = []struct {
+		name  string // The name of testing scenario
+		local int    // The length of local chain(canonical chain assumed), 0 means genesis is the head
+	}{
+		{name: "Beacon sync since genesis", local: 0},
+		{name: "Beacon sync with short local chain", local: 1},
+		{name: "Beacon sync with long local chain", local: blockCacheMaxItems - 15 - fsMinFullBlocks/2},
+		{name: "Beacon sync with full local chain", local: blockCacheMaxItems - 15 - 1},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			success := make(chan struct{})
+			tester := newTesterWithNotification(func() {
+				close(success)
+			})
+			defer tester.terminate()
+
+			chain := testChainBase.shorten(blockCacheMaxItems - 15)
+			tester.newPeer("peer", protocol, chain.blocks[1:])
+
+			// Build the local chain segment if it's required
+			if c.local > 0 {
+				tester.chain.InsertChain(chain.blocks[1 : c.local+1])
+			}
+			if err := tester.downloader.BeaconSync(mode, chain.blocks[len(chain.blocks)-1].Header()); err != nil {
+				t.Fatalf("Failed to beacon sync chain %v %v", c.name, err)
+			}
+			select {
+			case <-success:
+				// Ok, downloader fully cancelled after sync cycle
+				if bs := int(tester.chain.CurrentBlock().NumberU64()) + 1; bs != len(chain.blocks) {
+					t.Fatalf("synchronised blocks mismatch: have %v, want %v", bs, len(chain.blocks))
+				}
+			case <-time.NewTimer(time.Second * 3).C:
+				t.Fatalf("Failed to sync chain in three seconds")
+			}
+		})
 	}
 }

--- a/eth/downloader/downloader_test.go
+++ b/eth/downloader/downloader_test.go
@@ -56,27 +56,7 @@ type downloadTester struct {
 
 // newTester creates a new downloader test mocker.
 func newTester() *downloadTester {
-	freezer, err := ioutil.TempDir("", "")
-	if err != nil {
-		panic(err)
-	}
-	db, err := rawdb.NewDatabaseWithFreezer(rawdb.NewMemoryDatabase(), freezer, "", false)
-	if err != nil {
-		panic(err)
-	}
-	core.GenesisBlockForTesting(db, testAddress, big.NewInt(1000000000000000))
-
-	chain, err := core.NewBlockChain(db, nil, params.TestChainConfig, ethash.NewFaker(), vm.Config{}, nil, nil)
-	if err != nil {
-		panic(err)
-	}
-	tester := &downloadTester{
-		freezer: freezer,
-		chain:   chain,
-		peers:   make(map[string]*downloadTesterPeer),
-	}
-	tester.downloader = New(0, db, new(event.TypeMux), tester.chain, nil, tester.dropPeer, nil)
-	return tester
+	return newTesterWithNotification(nil)
 }
 
 // newTester creates a new downloader test mocker.


### PR DESCRIPTION
This PR fixes a panic in beacon sync.

**Panic logs**

```
WARN [03-29|23:55:59.938] Local chain is post-merge, waiting for beacon client sync switch-over...
WARN [03-29|23:56:11.942] Ignoring payload with missing parent     number=55128   hash=be29d4..273c2e parent=0d8429..6eba9e
WARN [03-29|23:56:12.044] Ignoring payload with missing parent     number=55129   hash=e6b72a..fe7dc8 parent=be29d4..273c2e
INFO [03-29|23:56:12.176] Left PoW stage
INFO [03-29|23:56:12.176] Forkchoice requested sync to new head    number=55129   hash=e6b72a..fe7dc8
INFO [03-29|23:56:12.322] Looking for peers                        peercount=2 tried=79  static=0
INFO [03-29|23:56:12.366] Forkchoice requested sync to new head    number=55129   hash=e6b72a..fe7dc8
WARN [03-29|23:56:12.366] Beacon chain reorged                     tail=55129 newHead=55129
INFO [03-29|23:56:12.852] Forkchoice requested sync to new head    number=55129   hash=e6b72a..fe7dc8
WARN [03-29|23:56:12.852] Beacon chain reorged                     tail=55129 newHead=55129
INFO [03-29|23:56:13.335] Forkchoice requested sync to new head    number=55129   hash=e6b72a..fe7dc8
WARN [03-29|23:56:13.335] Beacon chain reorged                     tail=55129 newHead=55129
WARN [03-29|23:56:19.918] Header request timed out, dropping peer  peer=f3a3e8ab elapsed=6.574627812s
INFO [03-29|23:56:20.419] Syncing beacon headers                   downloaded=10 left=0           eta=0s
INFO [03-29|23:56:20.420] Disabling direct-ancient mode            origin=18,446,744,073,709,551,615 ancient=55118
WARN [03-29|23:56:20.420] Rewinding blockchain                     target=18,446,744,073,709,551,615
INFO [03-29|23:56:20.423] Loaded most recent local header          number=55127   hash=0d8429..6eba9e td=20,001,479,054,577 age=2w41m28s
INFO [03-29|23:56:20.423] Loaded most recent local full block      number=0       hash=51c7fe..4dd4f8 td=1                  age=53y15h56m
INFO [03-29|23:56:20.423] Loaded most recent local fast block      number=55118   hash=a09656..2c6f47 td=19,986,021,607,809 age=2w42m5s
INFO [03-29|23:56:20.423] Loaded last fast-sync pivot marker       number=0
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x2 addr=0x1c0 pc=0x100c24d50]

goroutine 136289 [running]:
github.com/ethereum/go-ethereum/eth/downloader.(*Downloader).processHeaders(0x1400016e180, 0x0, 0x0, 0x0, 0x1)
	/Users/mac/gopath/src/github.com/ethereum/go-ethereum/eth/downloader/downloader.go:1346 +0x810
github.com/ethereum/go-ethereum/eth/downloader.(*Downloader).syncWithPeer.func7()
	/Users/mac/gopath/src/github.com/ethereum/go-ethereum/eth/downloader/downloader.go:587 +0x4c
github.com/ethereum/go-ethereum/eth/downloader.(*Downloader).spawnSync.func1(0x1400016e180, 0x14005e34b40, 0x14013315560)
	/Users/mac/gopath/src/github.com/ethereum/go-ethereum/eth/downloader/downloader.go:608 +0x58
created by github.com/ethereum/go-ethereum/eth/downloader.(*Downloader).spawnSync
	/Users/mac/gopath/src/github.com/ethereum/go-ethereum/eth/downloader/downloader.go:608 +0x98
```

**What's the root cause**

In snap sync, the pivot point is assigned with a remote advertised head minus the safety threshold(64). In beacon sync it obeys the same rules by retrieving the header from the skeleton space. However, if the pivot header is not existent in the skeleton space(e.g. beacon sync only fetch 10 headers as skeleton), the pivot header is left as nil and later set to header(0).