### PR TITLE
Move scope close to after committing most recent trie root to reduce …

### DIFF
--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -778,9 +778,6 @@ func (bc *BlockChain) Stop() {
 		return
 	}
 
-	// Unsubscribe all subscriptions registered from blockchain.
-	bc.scope.Close()
-
 	// Signal shutdown to all goroutines.
 	close(bc.quit)
 	bc.StopInsert()
@@ -840,6 +837,10 @@ func (bc *BlockChain) Stop() {
 		triedb := bc.stateCache.TrieDB()
 		triedb.SaveCache(bc.cacheConfig.TrieCleanJournal)
 	}
+
+	// Unsubscribe all subscriptions registered from blockchain.
+	bc.scope.Close()
+
 	log.Info("Blockchain stopped")
 }
 


### PR DESCRIPTION
This PR moves `bc.scope.Close()` to the end of the `Stop()` call within `core/blockchain.go`. I have noticed that sometimes the chain seems to block here during shutdown, and when this happens before the cleanup code (committing the latest trie and snapshot journal layers), it requires regenerating the state when the node restarts.

I have not found the root cause of `bc.scope.Close()` blocking, so this is a stop gap measure until I can locate the root cause. Hope this helps!