### PR TITLE
core: use less memory during reorgs

### DIFF
--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -22,7 +22,6 @@ import (
 	"fmt"
 	"io"
 	"math/big"
-	"runtime"
 	"sort"
 	"sync"
 	"sync/atomic"
@@ -2030,7 +2029,7 @@ func (bc *BlockChain) reorg(oldBlock, newBlock *types.Block) error {
 			return fmt.Errorf("invalid new chain")
 		}
 	}
-	PrintMemUsage()
+
 	// Ensure the user sees large reorgs
 	if len(oldChain) > 0 && len(newChain) > 0 {
 		logFn := log.Info
@@ -2066,7 +2065,6 @@ func (bc *BlockChain) reorg(oldBlock, newBlock *types.Block) error {
 		}
 	}
 
-	PrintMemUsage()
 	// Delete useless indexes right now which includes the non-canonical
 	// transaction indexes, canonical chain indexes which above the head.
 	indexesBatch := bc.db.NewBatch()
@@ -2098,8 +2096,6 @@ func (bc *BlockChain) reorg(oldBlock, newBlock *types.Block) error {
 	// this goroutine if there are no events to fire, but realistcally that only
 	// ever happens if we're reorging empty blocks, which will only happen on idle
 	// networks where performance is not an issue either way.
-
-	PrintMemUsage()
 	if len(deletedLogs) > 0 {
 		bc.rmLogsFeed.Send(RemovedLogsEvent{mergeLogs(deletedLogs, true)})
 	}
@@ -2112,20 +2108,6 @@ func (bc *BlockChain) reorg(oldBlock, newBlock *types.Block) error {
 		}
 	}
 	return nil
-}
-
-func PrintMemUsage() {
-	var m runtime.MemStats
-	runtime.ReadMemStats(&m)
-	// For info on each, see: https://golang.org/pkg/runtime/#MemStats
-	fmt.Printf("Alloc = %v MiB", bToMb(m.Alloc))
-	fmt.Printf("\tTotalAlloc = %v MiB", bToMb(m.TotalAlloc))
-	fmt.Printf("\tSys = %v MiB", bToMb(m.Sys))
-	fmt.Printf("\tNumGC = %v\n", m.NumGC)
-}
-
-func bToMb(b uint64) uint64 {
-	return b / 1024 / 1024
 }
 
 // InsertBlockWithoutSetHead executes the block, runs the necessary verification

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -2068,7 +2068,7 @@ func (bc *BlockChain) reorg(oldBlock, newBlock *types.Block) error {
 	// Delete useless indexes right now which includes the non-canonical
 	// transaction indexes, canonical chain indexes which above the head.
 	indexesBatch := bc.db.NewBatch()
-	for _, tx := range types.TxDifferenceHash(deletedTxs, addedTxs) {
+	for _, tx := range types.HashDifference(deletedTxs, addedTxs) {
 		rawdb.DeleteTxLookupEntry(indexesBatch, tx)
 	}
 	// Delete any canonical number assignments above the new head

--- a/core/types/transaction.go
+++ b/core/types/transaction.go
@@ -432,18 +432,18 @@ func TxDifference(a, b Transactions) Transactions {
 	return keep
 }
 
-// TxDifferenceHash returns a new set which is the difference between a and b.
-func TxDifferenceHash(a, b []common.Hash) []common.Hash {
+// HashDifference returns a new set which is the difference between a and b.
+func HashDifference(a, b []common.Hash) []common.Hash {
 	keep := make([]common.Hash, 0, len(a))
 
 	remove := make(map[common.Hash]struct{})
-	for _, tx := range b {
-		remove[tx] = struct{}{}
+	for _, hash := range b {
+		remove[hash] = struct{}{}
 	}
 
-	for _, tx := range a {
-		if _, ok := remove[tx]; !ok {
-			keep = append(keep, tx)
+	for _, hash := range a {
+		if _, ok := remove[hash]; !ok {
+			keep = append(keep, hash)
 		}
 	}
 

--- a/core/types/transaction.go
+++ b/core/types/transaction.go
@@ -432,6 +432,24 @@ func TxDifference(a, b Transactions) Transactions {
 	return keep
 }
 
+// TxDifferenceHash returns a new set which is the difference between a and b.
+func TxDifferenceHash(a, b []common.Hash) []common.Hash {
+	keep := make([]common.Hash, 0, len(a))
+
+	remove := make(map[common.Hash]struct{})
+	for _, tx := range b {
+		remove[tx] = struct{}{}
+	}
+
+	for _, tx := range a {
+		if _, ok := remove[tx]; !ok {
+			keep = append(keep, tx)
+		}
+	}
+
+	return keep
+}
+
 // TxByNonce implements the sort interface to allow sorting a list of transactions
 // by their nonces. This is usually only useful for sorting transactions from a
 // single account, otherwise a nonce comparison doesn't make much sense.


### PR DESCRIPTION
One thing that happened on the goerli-shadow-fork-1 testnet was that a really long reorg happened.
```
WARN [03-30|09:20:00.399] Long reorg                               newchain length=6,598,237 from=6,598,237 to=1
```
This means that the whole chain gets reorged in. This can only happen if we have the whole chain in the database but not marked canonical. I suspect that we started a sync which almost succeeded (the node had a lot of unclean shutdowns etc) so that we had all the blocks in the database and then we got a fcu which marks a post merge block as canonical. It also starts the reorg procedure. The problem now was that the reorg procedure took (understandably) too much memory and the node ran OOM. Would be good if @karalabe could double check my reasoning here or if you suspect anything different going on why the chain was not marked as canonical.


This PR significantly reduces the memory consumption of the reorg procedure. ~~It does increase the amount of database access by 2x though as every block has to be retrieved from the db twice.~~ 
It might make sense to have this though as post-merge longer reorgs can happen more frequently. 
Blocks are imported as non-canonical via `engine_newPayload` and are marked later on as canonical with `engine_forkChoiceUpdated`. In times of non-finalization it could be that a lot of blocks are imported as non-canonical and the reorg procedure is only called after a long time. So it might make sense to reduce the memory consumption of the reorg procedure