### PR TITLE
eth: clarify the error string on getlogs failure

### DIFF
--- a/eth/api_backend.go
+++ b/eth/api_backend.go
@@ -19,6 +19,7 @@ package eth
 import (
 	"context"
 	"errors"
+	"fmt"
 	"math/big"
 	"time"
 
@@ -185,11 +186,11 @@ func (b *EthAPIBackend) GetLogs(ctx context.Context, hash common.Hash) ([][]*typ
 	db := b.eth.ChainDb()
 	number := rawdb.ReadHeaderNumber(db, hash)
 	if number == nil {
-		return nil, errors.New("failed to get block number from hash")
+		return nil, fmt.Errorf("failed to get block number for  hash %#x", hash)
 	}
 	logs := rawdb.ReadLogs(db, hash, *number, b.eth.blockchain.Config())
 	if logs == nil {
-		return nil, errors.New("failed to get logs for block")
+		return nil, fmt.Errorf("failed to get logs for block %d (0x%s)", *number, hash.TerminalString())
 	}
 	return logs, nil
 }


### PR DESCRIPTION
Related to #24606

This PR makes the errors we spit out a bit more clear about what block is problematic. 

```
failed to get block number for  hash 0x0000000000000000000000001234512345123451234512345123451234512345
failed to get logs for block 123 (0x000000..512345)
```