### PR TITLE
cmd/utils: utilize beacon wrapper in makechain

### DIFF
--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -1967,12 +1967,13 @@ func MakeChain(ctx *cli.Context, stack *node.Node) (chain *core.BlockChain, chai
 	if err != nil {
 		Fatalf("%v", err)
 	}
+
 	var engine consensus.Engine
+	ethashConf := ethconfig.Defaults.Ethash
 	if ctx.GlobalBool(FakePoWFlag.Name) {
-		engine = ethash.NewFaker()
-	} else {
-		engine = ethconfig.CreateConsensusEngine(stack, config, &ethconfig.Defaults.Ethash, nil, false, chainDb)
+		ethashConf.PowMode = ethash.ModeFake
 	}
+	engine = ethconfig.CreateConsensusEngine(stack, config, &ethashConf, nil, false, chainDb)
 	if gcmode := ctx.GlobalString(GCModeFlag.Name); gcmode != "full" && gcmode != "archive" {
 		Fatalf("--%s must be either 'full' or 'archive'", GCModeFlag.Name)
 	}

--- a/consensus/misc/eip1559.go
+++ b/consensus/misc/eip1559.go
@@ -46,7 +46,7 @@ func VerifyEip1559Header(config *params.ChainConfig, parent, header *types.Heade
 	expectedBaseFee := CalcBaseFee(config, parent)
 	if header.BaseFee.Cmp(expectedBaseFee) != 0 {
 		return fmt.Errorf("invalid baseFee: have %s, want %s, parentBaseFee %s, parentGasUsed %d",
-			expectedBaseFee, header.BaseFee, parent.BaseFee, parent.GasUsed)
+			header.BaseFee, expectedBaseFee, parent.BaseFee, parent.GasUsed)
 	}
 	return nil
 }


### PR DESCRIPTION
This PR will, sooner or later, close #24601

Running with this PR, instead of 'invalid difficulty', I get
```
########## BAD BLOCK #########
Chain config: {ChainID: 1 Homestead: 0 DAO: <nil> DAOSupport: true EIP150: 0 EIP155: 0 EIP158: 0 Byzantium: 0 Constantinople: 0 Petersburg: 0 Istanbul: 0, Muir Glacier: <nil>, Berlin: 0, London: 0, Arrow Glacier: <nil>, MergeFork: <nil>, Terminal TD: 0, Engine: ethash}

Number: 1
Hash: 0x8ce374ca14f5c8f25f1a5731cf10e44f8f05ab6968a764fa9d13752e04796c94


Error: invalid baseFee: have 1000, want 1142, parentBaseFee 1142, parentGasUsed 0
##############################
```
