### PR TITLE
Run container with a non root user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,10 @@ FROM alpine:latest
 RUN apk add --no-cache ca-certificates
 COPY --from=builder /go-ethereum/build/bin/geth /usr/local/bin/
 
+RUN adduser -D geth
+USER geth
+WORKDIR /home/geth
+
 EXPOSE 8545 8546 30303 30303/udp
 ENTRYPOINT ["geth"]
 

--- a/Dockerfile.alltools
+++ b/Dockerfile.alltools
@@ -17,6 +17,10 @@ FROM alpine:latest
 RUN apk add --no-cache ca-certificates
 COPY --from=builder /go-ethereum/build/bin/* /usr/local/bin/
 
+RUN adduser -D geth
+USER geth
+WORKDIR /home/geth
+
 EXPOSE 8545 8546 30303 30303/udp
 
 # Add some metadata labels to help programatic image consumption


### PR DESCRIPTION
Note this is potentially a breaking change for some users the default data directory changes from `/root/.ethereum` to `/home/geth/.ethereum`

Initially raised in https://github.com/ConsenSys/quorum/issues/1367