### PR TITLE
Update free space required

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,14 +58,14 @@ Minimum:
 
 * CPU with 2+ cores
 * 4GB RAM
-* 500GB free storage space to sync the Mainnet
+* 1TB free storage space to sync the Mainnet
 * 8 MBit/sec download Internet service
 
 Recommended:
 
 * Fast CPU with 4+ cores
 * 16GB+ RAM
-* High Performance SSD with at least 500GB free space
+* High Performance SSD with at least 1TB free space
 * 25+ MBit/sec download Internet service
 
 ### Full node on the main Ethereum network


### PR DESCRIPTION
A 500GB drive is no longer sufficient to sync mainnet with default settings. ~~A _freshly_ synced node will consume about 490GB, but then rapidly balloon beyond 500GB due to no online pruning. It's not reasonable to expect users to turn off (or severely degrade) their node every few weeks to prune, especially with The Merge on the horizon where an offline node means no staking.~~ A _freshly_ synced node will consume about 600GB (updating the PR description as my node actually syncs, until this is merged or I get lazy).