### PR TITLE
miner: discard interrupted blocks

### DIFF
--- a/eth/catalyst/api.go
+++ b/eth/catalyst/api.go
@@ -28,7 +28,6 @@ import (
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/core/beacon"
 	"github.com/ethereum/go-ethereum/core/rawdb"
-	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/eth"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/node"
@@ -348,12 +347,4 @@ func (api *ConsensusAPI) assembleBlock(parentHash common.Hash, params *beacon.Pa
 		return nil, err
 	}
 	return beacon.BlockToExecutableData(block), nil
-}
-
-// Used in tests to add a the list of transactions from a block to the tx pool.
-func (api *ConsensusAPI) insertTransactions(txs types.Transactions) error {
-	for _, tx := range txs {
-		api.eth.TxPool().AddLocal(tx)
-	}
-	return nil
 }

--- a/eth/catalyst/api_test.go
+++ b/eth/catalyst/api_test.go
@@ -108,7 +108,7 @@ func TestEth2AssembleBlockWithAnotherBlocksTxs(t *testing.T) {
 	api := NewConsensusAPI(ethservice)
 
 	// Put the 10th block's tx in the pool and produce a new block
-	api.insertTransactions(blocks[9].Transactions())
+	api.eth.TxPool().AddRemotesSync(blocks[9].Transactions())
 	blockParams := beacon.PayloadAttributesV1{
 		Timestamp: blocks[8].Time() + 5,
 	}

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -1069,19 +1069,16 @@ func (w *worker) fillTransactions(interrupt *int32, env *environment) error {
 	}
 	if len(localTxs) > 0 {
 		txs := types.NewTransactionsByPriceAndNonce(env.signer, localTxs, env.header.BaseFee)
-		err := w.commitTransactions(env, txs, interrupt)
-		if err != nil {
+		if err := w.commitTransactions(env, txs, interrupt); err != nil {
 			return err
 		}
 	}
 	if len(remoteTxs) > 0 {
 		txs := types.NewTransactionsByPriceAndNonce(env.signer, remoteTxs, env.header.BaseFee)
-		err := w.commitTransactions(env, txs, interrupt)
-		if err != nil {
+		if err := w.commitTransactions(env, txs, interrupt); err != nil {
 			return err
 		}
 	}
-
 	return nil
 }
 

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -1124,7 +1124,7 @@ func (w *worker) commitWork(interrupt *int32, noempty bool, timestamp int64) {
 
 	// Fill pending transactions from the txpool
 	err = w.fillTransactions(interrupt, work)
-	if err != nil && !errors.Is(err, errBlockInterruptedByRecommit) {
+	if errors.Is(err, errBlockInterruptedByNewHead) {
 		work.discard()
 		return
 	}


### PR DESCRIPTION
Head-interrupted blocks should not be `commit`-ed, since that introduces unnecessary delay, and possibly causes miner to mine on the previous head.
This could result in higher uncle rate (which seems to be up by some 0.5% since 3rd of March).

I kept the boolean semantics consitent with `commitTransactions`, but I'd be happy to refactor.

Intuitively, `w.current` should also not be set, since it could actually be a worse block than what was built previously (and we don't want to apply uncles on that block anyway).

This should never happen in `generateWork` (no interrupt passed in), but I added an error for completeness, since this could change.