### PR TITLE
les: fix panic in ultra light client sync

### DIFF
--- a/les/fetcher.go
+++ b/les/fetcher.go
@@ -446,8 +446,6 @@ func (f *lightFetcher) mainloop() {
 				// is not found. It can happen the original head is before the
 				// checkpoint while the synced headers are after it. In this
 				// case there is no ancestor between them.
-				// TODO(rjl493456442) it's quite expensive for searching the
-				// ancestor in this case, try to avoid it in the first place.
 				if ancestor == nil {
 					ancestor = f.chain.Genesis().Header()
 				}

--- a/les/fetcher.go
+++ b/les/fetcher.go
@@ -441,6 +441,16 @@ func (f *lightFetcher) mainloop() {
 			if ulc {
 				head := f.chain.CurrentHeader()
 				ancestor := rawdb.FindCommonAncestor(f.chaindb, origin, head)
+
+				// Recap the ancestor with genesis header in case the ancestor
+				// is not found. It can happen the original head is before the
+				// checkpoint while the synced headers are after it. In this
+				// case there is no ancestor between them.
+				// TODO(rjl493456442) it's quite expensive for searching the
+				// ancestor in this case, try to avoid it in the first place.
+				if ancestor == nil {
+					ancestor = f.chain.Genesis().Header()
+				}
 				var untrusted []common.Hash
 				for head.Number.Cmp(ancestor.Number) > 0 {
 					hash, number := head.Hash(), head.Number.Uint64()
@@ -449,6 +459,9 @@ func (f *lightFetcher) mainloop() {
 					}
 					untrusted = append(untrusted, hash)
 					head = f.chain.GetHeader(head.ParentHash, number-1)
+					if head == nil {
+						break // all the synced headers will be dropped
+					}
 				}
 				if len(untrusted) > 0 {
 					for i, j := 0, len(untrusted)-1; i < j; i, j = i+1, j-1 {
@@ -514,7 +527,7 @@ func (f *lightFetcher) requestHeaderByHash(peerid enode.ID) func(common.Hash) er
 	}
 }
 
-// requestResync invokes synchronisation callback to start syncing.
+// startSync invokes synchronisation callback to start syncing.
 func (f *lightFetcher) startSync(id enode.ID) {
 	defer func(header *types.Header) {
 		f.syncDone <- header

--- a/les/ulc_test.go
+++ b/les/ulc_test.go
@@ -55,7 +55,7 @@ func testULCAnnounceThreshold(t *testing.T, protocol int) {
 			ids       []string
 		)
 		for i := 0; i < len(testcase.height); i++ {
-			s, n, teardown := newTestServerPeer(t, 0, protocol)
+			s, n, teardown := newTestServerPeer(t, 0, protocol, nil)
 
 			servers = append(servers, s)
 			nodes = append(nodes, n)
@@ -132,10 +132,11 @@ func connect(server *serverHandler, serverId enode.ID, client *clientHandler, pr
 }
 
 // newTestServerPeer creates server peer.
-func newTestServerPeer(t *testing.T, blocks int, protocol int) (*testServer, *enode.Node, func()) {
+func newTestServerPeer(t *testing.T, blocks int, protocol int, indexFn indexerCallback) (*testServer, *enode.Node, func()) {
 	netconfig := testnetConfig{
 		blocks:    blocks,
 		protocol:  protocol,
+		indexFn:   indexFn,
 		nopruning: true,
 	}
 	s, _, teardown := newClientServerEnv(t, netconfig)


### PR DESCRIPTION
The panic can happen in ultra light client mode when original local chain has no common ancestor with newly synced chain. It's because the newly synced chain can be located after the checkpoint while the original local headers are before the checkpoint.

This fix recaps the common ancestor to genesis in case it's not found.

Fixes #24611