### PR TITLE
cmd/geth: inspect snapshot dangling storage

### DIFF
--- a/cmd/geth/snapshot.go
+++ b/cmd/geth/snapshot.go
@@ -20,6 +20,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"os"
 	"time"
 
@@ -102,6 +103,25 @@ geth snapshot verify-state <state-root>
 will traverse the whole accounts and storages set based on the specified
 snapshot and recalculate the root hash of state for verification.
 In other words, this command does the snapshot to trie conversion.
+`,
+			},
+			{
+				Name:      "check-dangling-storage",
+				Usage:     "Check that there is no 'dangling' snap storage",
+				ArgsUsage: "<root>",
+				Action:    utils.MigrateFlags(checkDanglingStorage),
+				Category:  "MISCELLANEOUS COMMANDS",
+				Flags: []cli.Flag{
+					utils.DataDirFlag,
+					utils.AncientFlag,
+					utils.RopstenFlag,
+					utils.SepoliaFlag,
+					utils.RinkebyFlag,
+					utils.GoerliFlag,
+				},
+				Description: `
+geth snapshot check-dangling-storage <state-root> traverses the snap storage 
+data, and verifies that all snapshot storage data has a corresponding account. 
 `,
 			},
 			{
@@ -242,6 +262,69 @@ func verifyState(ctx *cli.Context) error {
 		return err
 	}
 	log.Info("Verified the state", "root", root)
+	return nil
+}
+
+// checkDanglingStorage iterates the snap storage data, and verifies that all
+// storage also has corresponding account data.
+func checkDanglingStorage(ctx *cli.Context) error {
+	stack, _ := makeConfigNode(ctx)
+	defer stack.Close()
+
+	chaindb := utils.MakeChainDatabase(ctx, stack, true)
+	headBlock := rawdb.ReadHeadBlock(chaindb)
+	if headBlock == nil {
+		log.Error("Failed to load head block")
+		return errors.New("no head block")
+	}
+	snaptree, err := snapshot.New(chaindb, trie.NewDatabase(chaindb), 256, headBlock.Root(), false, false, false)
+	if err != nil {
+		log.Error("Failed to open snapshot tree", "err", err)
+		return err
+	}
+	if ctx.NArg() > 1 {
+		log.Error("Too many arguments given")
+		return errors.New("too many arguments")
+	}
+	var root = headBlock.Root()
+	if ctx.NArg() == 1 {
+		root, err = parseRoot(ctx.Args()[0])
+		if err != nil {
+			log.Error("Failed to resolve state root", "err", err)
+			return err
+		}
+	}
+	var (
+		lastReport = time.Now()
+		start      = time.Now()
+		snapshot   = snaptree.Snapshot(root)
+		lastKey    []byte
+		it         = rawdb.NewKeyLengthIterator(chaindb.NewIterator(rawdb.SnapshotStoragePrefix, nil), 1+2*common.HashLength)
+	)
+	defer it.Release()
+	for it.Next() {
+		k := it.Key()
+		accKey := k[1:33]
+		if bytes.Equal(accKey, lastKey) {
+			// No need to look up for every slot
+			continue
+		}
+		lastKey = common.CopyBytes(accKey)
+		if time.Since(lastReport) > time.Second*8 {
+			log.Info("Iterating snap storage", "at", fmt.Sprintf("%#x", accKey), "elapsed", common.PrettyDuration(time.Since(start)))
+			lastReport = time.Now()
+		}
+		data, err := snapshot.AccountRLP(common.BytesToHash(accKey))
+		if err != nil {
+			log.Error("Error loading snap storage data", "account", fmt.Sprintf("%#x", accKey), "err", err)
+			continue
+		}
+		if len(data) == 0 {
+			log.Error("Dangling storage - missing account", "account", fmt.Sprintf("%#x", accKey), "storagekey", fmt.Sprintf("%#x", k))
+			continue
+		}
+	}
+	log.Info("Verified the snapshot storage", "root", root, "time", common.PrettyDuration(time.Since(start)), "err", it.Error())
 	return nil
 }
 


### PR DESCRIPTION
While investigating a failure during post-merge goerli shadowfork, I found that there was 'dangling' snap storage data. 

Our `verify-state` iterates the snapshot data by iterating the snapshot accounts, and regenerating the trie. This method was unable to discover the flaw, since the account did not exist (only the storage data did), thus reported that the verification passed. 

This PR adds an additional checker. It iterates the `o<32byte account key><32 byte storage key>` items in the db, and verifies that for each storage, there is a corresponding account. 

Example of running it 
```
$ geth --datadir ./eth1data/geth snapshot check-dangling-storage
INFO [04-05|09:28:55.764] Maximum peer count                       ETH=50 LES=0 total=50
INFO [04-05|09:28:55.765] Smartcard socket not found, disabling    err="stat /run/pcscd/pcscd.comm: no such file or directory"
WARN [04-05|09:28:55.765] Using deprecated resource file /home/user/tmp/goerlishadowfork/eth1data/geth/nodekey, please move this file to the 'geth' subdirectory of datadir. 
INFO [04-05|09:28:55.765] Set global gas cap                       cap=50,000,000
INFO [04-05|09:28:55.766] Allocated cache and file handles         database=/home/user/tmp/goerlishadowfork/eth1data/geth/chaindata cache=512.00MiB handles=262,144 readonly=true
INFO [04-05|09:28:55.877] Opened ancient database                  database=/home/user/tmp/goerlishadowfork/eth1data/geth/chaindata/ancient readonly=true
INFO [04-05|09:29:05.176] Iterating snap storage                   at=0x1c488160412c5dc4086dbc93bd94b2bdc3346a37f7152282c5cdf524a8f01f6f elapsed=9.220s
INFO [04-05|09:29:13.176] Iterating snap storage                   at=0x3bf33ad4ac0beab534e8dc18ea36ba33acd878a85500378f55490a9d065a9e56 elapsed=17.220s
INFO [04-05|09:29:21.176] Iterating snap storage                   at=0x51c7d59d773a0121fb9c5a21f560b7e6403a7c1d2568758612b4956b30471935 elapsed=25.220s
INFO [04-05|09:29:29.244] Iterating snap storage                   at=0x6e72233b022b2447b4364d0dcdba7cbcfba390c261c755fec9fd46c9b584d80d elapsed=33.289s
ERROR[04-05|09:29:32.162] Dangling storage - missing account       account=0x725beb54c9fc8debc2b0c22865cc757ff911fd56f6068e53aeb935794e6c45c7 storagekey=0x6f725beb54c9fc8debc2b0c22865cc757ff911fd56f6068e53aeb935794e6c45c7b10e2d527612073b26eecdfd717e6a320cf44b4afac2b0732d9fcbe2b7fa0cf6
INFO [04-05|09:29:37.321] Iterating snap storage                   at=0x88365ceff946a5fdc5a5eb95cd68852d259f8fcfcd6bf428d9ebb3eebd47e51e elapsed=41.365s
INFO [04-05|09:29:45.321] Iterating snap storage                   at=0xa1f9cecf5fc9f11e303628245d659e8bc3d35bcde70bfe083cd541d95a5bfe2f elapsed=49.365s
INFO [04-05|09:29:53.321] Iterating snap storage                   at=0xb15c80a7a789fb5b6b4695c7ad7f7ee7a418f8f76cf1ea13035a686195c244bd elapsed=57.365s
INFO [04-05|09:30:01.321] Iterating snap storage                   at=0xcc03d7e25ad8ee1a2267ad6757644c14269ef24bf9f664a43acd1818ea89ba11 elapsed=1m5.366s
INFO [04-05|09:30:09.446] Iterating snap storage                   at=0xe581ad9a486d6504024c0ed40087a373f7f38a1d951964e177c5ea088d81d135 elapsed=1m13.490s
INFO [04-05|09:30:16.678] Verified the snapshot storage            root=faa279..7c9376 time=1m20.723s err=nil

```
