### PR TITLE
core/state/snapshot: remove noop map item assignment

### DIFF
--- a/core/state/snapshot/difflayer.go
+++ b/core/state/snapshot/difflayer.go
@@ -470,7 +470,6 @@ func (dl *diffLayer) flatten() snapshot {
 		for storageHash, data := range storage {
 			comboData[storageHash] = data
 		}
-		parent.storageData[accountHash] = comboData
 	}
 	// Return the combo parent
 	return &diffLayer{


### PR DESCRIPTION
This line is not necessary, it reassigned an entry to a map, but that entry originated from the same map. I think this "noop" line originated from a previous code where the entry was a slice. However, if the entry being retrieved and reassigned is a map, that is a pointer internally in Go, so modifying it does not change the outer structure, thus no need for the reassignment.