### PR TITLE
eth/tracers/logger: remove unnecessary comparisons in accessList.equal

### DIFF
--- a/eth/tracers/logger/access_list_tracer.go
+++ b/eth/tracers/logger/access_list_tracer.go
@@ -62,16 +62,14 @@ func (al accessList) equal(other accessList) bool {
 	if len(al) != len(other) {
 		return false
 	}
+	// Given that len(al) == len(other), we only need to check that
+	// all the items from al are in other.
 	for addr := range al {
 		if _, ok := other[addr]; !ok {
 			return false
 		}
 	}
-	for addr := range other {
-		if _, ok := al[addr]; !ok {
-			return false
-		}
-	}
+
 	// Accounts match, cross reference the storage slots too
 	for addr, slots := range al {
 		otherslots := other[addr]
@@ -79,13 +77,10 @@ func (al accessList) equal(other accessList) bool {
 		if len(slots) != len(otherslots) {
 			return false
 		}
+		// Given that len(slots) == len(otherslots), we only need to check that
+		// all the items from slots are in otherslots.
 		for hash := range slots {
 			if _, ok := otherslots[hash]; !ok {
-				return false
-			}
-		}
-		for hash := range otherslots {
-			if _, ok := slots[hash]; !ok {
 				return false
 			}
 		}


### PR DESCRIPTION
This change removes extraneous/unnecessary checks for equality
when comparing 2 accessList values A and B. Given that we validate that
their lengths of A and B are equal, if so and if every element in A is
in B, reflexively every element in B is already in A. If that weren't
the case and an element g existed in A but not in B, that would mean
that there is an extra element and hence a Mathematical contradiction.

While here, added benchmarks to exhibit the performance gains as below:

```shell
name                    old time/op    new time/op    delta
AccessListEqual10-8       14.8µs ± 5%     7.2µs ± 5%  -51.16%  (p=0.000 n=19+20)
AccessListEqual100-8       151µs ± 5%      74µs ± 5%  -50.89%  (p=0.000 n=19+19)
AccessListEqual1000-8     1.50ms ± 3%    0.74ms ± 2%  -50.67%  (p=0.000 n=19+17)
AccessListEqual10000-8    17.6ms ± 4%     9.7ms ± 7%  -44.94%  (p=0.000 n=20+20)

name                    old alloc/op   new alloc/op   delta
AccessListEqual10-8        0.00B          0.00B          ~     (all equal)
AccessListEqual100-8       0.00B          0.00B          ~     (all equal)
AccessListEqual1000-8      50.4B ± 3%     25.2B ± 7%  -50.03%  (p=0.000 n=20+19)
AccessListEqual10000-8    6.13kB ± 7%    3.25kB ± 3%  -46.92%  (p=0.000 n=19+15)

name                    old allocs/op  new allocs/op  delta
AccessListEqual10-8         0.00           0.00          ~     (all equal)
AccessListEqual100-8        0.00           0.00          ~     (all equal)
AccessListEqual1000-8       2.00 ± 0%      1.00 ± 0%  -50.00%  (p=0.000 n=20+20)
AccessListEqual10000-8       255 ± 7%       135 ± 3%  -47.08%  (p=0.000 n=19+15)
```

Fixes #24658