### PR TITLE
core/state/snapshot: clean up dangling storages in snapshot generation

### DIFF
--- a/cmd/devp2p/internal/ethtest/snap.go
+++ b/cmd/devp2p/internal/ethtest/snap.go
@@ -372,8 +372,8 @@ func (s *Suite) TestSnapTrieNodes(t *utesting.T) {
 		{
 			root: s.chain.RootAt(999),
 			paths: []snap.TrieNodePathSet{
-				snap.TrieNodePathSet{}, // zero-length pathset should 'abort' and kick us off
-				snap.TrieNodePathSet{[]byte{0}},
+				{}, // zero-length pathset should 'abort' and kick us off
+				{[]byte{0}},
 			},
 			nBytes:    5000,
 			expHashes: []common.Hash{},
@@ -382,8 +382,8 @@ func (s *Suite) TestSnapTrieNodes(t *utesting.T) {
 		{
 			root: s.chain.RootAt(999),
 			paths: []snap.TrieNodePathSet{
-				snap.TrieNodePathSet{[]byte{0}},
-				snap.TrieNodePathSet{[]byte{1}, []byte{0}},
+				{[]byte{0}},
+				{[]byte{1}, []byte{0}},
 			},
 			nBytes: 5000,
 			//0x6b3724a41b8c38b46d4d02fba2bb2074c47a507eb16a9a4b978f91d32e406faf
@@ -392,7 +392,7 @@ func (s *Suite) TestSnapTrieNodes(t *utesting.T) {
 		{ // nonsensically long path
 			root: s.chain.RootAt(999),
 			paths: []snap.TrieNodePathSet{
-				snap.TrieNodePathSet{[]byte{0, 1, 2, 3, 4, 5, 6, 7, 8, 0, 1, 2, 3, 4, 5, 6, 7, 8, 0, 1, 2, 3, 4, 5, 6, 7, 8,
+				{[]byte{0, 1, 2, 3, 4, 5, 6, 7, 8, 0, 1, 2, 3, 4, 5, 6, 7, 8, 0, 1, 2, 3, 4, 5, 6, 7, 8,
 					0, 1, 2, 3, 4, 5, 6, 7, 8, 0, 1, 2, 3, 4, 5, 6, 7, 8, 0, 1, 2, 3, 4, 5, 6, 7, 8}},
 			},
 			nBytes:    5000,
@@ -401,8 +401,8 @@ func (s *Suite) TestSnapTrieNodes(t *utesting.T) {
 		{
 			root: s.chain.RootAt(0),
 			paths: []snap.TrieNodePathSet{
-				snap.TrieNodePathSet{[]byte{0}},
-				snap.TrieNodePathSet{[]byte{1}, []byte{0}},
+				{[]byte{0}},
+				{[]byte{1}, []byte{0}},
 			},
 			nBytes:    5000,
 			expHashes: []common.Hash{},

--- a/cmd/geth/snapshot.go
+++ b/cmd/geth/snapshot.go
@@ -277,6 +277,9 @@ func checkDanglingStorage(ctx *cli.Context) error {
 	defer stack.Close()
 
 	chaindb := utils.MakeChainDatabase(ctx, stack, true)
+
+	snapshot.NewDanglingRange(chaindb, nil, nil, true)
+
 	headBlock := rawdb.ReadHeadBlock(chaindb)
 	if headBlock == nil {
 		log.Error("Failed to load head block")

--- a/cmd/geth/snapshot.go
+++ b/cmd/geth/snapshot.go
@@ -20,7 +20,6 @@ import (
 	"bytes"
 	"encoding/json"
 	"errors"
-	"fmt"
 	"os"
 	"time"
 
@@ -263,10 +262,9 @@ func verifyState(ctx *cli.Context) error {
 		return err
 	}
 	log.Info("Verified the state", "root", root)
-	if err := checkDangling(chaindb, snaptree.Snapshot(root)); err != nil {
-		log.Error("Dangling snap storage check failed", "root", root, "err", err)
-		return err
-	}
+
+	// Detect if there is any dangling storages.
+	checkDangling(chaindb)
 	return nil
 }
 
@@ -276,68 +274,16 @@ func checkDanglingStorage(ctx *cli.Context) error {
 	stack, _ := makeConfigNode(ctx)
 	defer stack.Close()
 
-	chaindb := utils.MakeChainDatabase(ctx, stack, true)
-
-	snapshot.NewDanglingRange(chaindb, nil, nil, true)
-
-	headBlock := rawdb.ReadHeadBlock(chaindb)
-	if headBlock == nil {
-		log.Error("Failed to load head block")
-		return errors.New("no head block")
-	}
-	snaptree, err := snapshot.New(chaindb, trie.NewDatabase(chaindb), 256, headBlock.Root(), false, false, false)
-	if err != nil {
-		log.Error("Failed to open snapshot tree", "err", err)
-		return err
-	}
-	if ctx.NArg() > 1 {
-		log.Error("Too many arguments given")
-		return errors.New("too many arguments")
-	}
-	var root = headBlock.Root()
-	if ctx.NArg() == 1 {
-		root, err = parseRoot(ctx.Args()[0])
-		if err != nil {
-			log.Error("Failed to resolve state root", "err", err)
-			return err
-		}
-	}
-	return checkDangling(chaindb, snaptree.Snapshot(root))
+	checkDangling(utils.MakeChainDatabase(ctx, stack, true))
+	return nil
 }
 
-func checkDangling(chaindb ethdb.Database, snap snapshot.Snapshot) error {
-	log.Info("Checking dangling snapshot storage")
-	var (
-		lastReport = time.Now()
-		start      = time.Now()
-		lastKey    []byte
-		it         = rawdb.NewKeyLengthIterator(chaindb.NewIterator(rawdb.SnapshotStoragePrefix, nil), 1+2*common.HashLength)
-	)
-	defer it.Release()
-	for it.Next() {
-		k := it.Key()
-		accKey := k[1:33]
-		if bytes.Equal(accKey, lastKey) {
-			// No need to look up for every slot
-			continue
-		}
-		lastKey = common.CopyBytes(accKey)
-		if time.Since(lastReport) > time.Second*8 {
-			log.Info("Iterating snap storage", "at", fmt.Sprintf("%#x", accKey), "elapsed", common.PrettyDuration(time.Since(start)))
-			lastReport = time.Now()
-		}
-		data, err := snap.AccountRLP(common.BytesToHash(accKey))
-		if err != nil {
-			log.Error("Error loading snap storage data", "account", fmt.Sprintf("%#x", accKey), "err", err)
-			return err
-		}
-		if len(data) == 0 {
-			log.Error("Dangling storage - missing account", "account", fmt.Sprintf("%#x", accKey), "storagekey", fmt.Sprintf("%#x", k))
-			return fmt.Errorf("dangling snapshot storage account %#x", accKey)
-		}
-	}
-	log.Info("Verified the snapshot storage", "root", snap.Root(), "time", common.PrettyDuration(time.Since(start)), "err", it.Error())
-	return nil
+// checkDangling is the internal function for detecting dangling storages.
+func checkDangling(chaindb ethdb.Database) {
+	// Detect dangling storages in disk layer
+	snapshot.NewDanglingRange(chaindb, nil, nil, true)
+
+	// TODO(rjl493456442) Detect dangling storages in diff layers
 }
 
 // traverseState is a helper function used for pruning verification.

--- a/core/state/snapshot/dangling.go
+++ b/core/state/snapshot/dangling.go
@@ -28,8 +28,8 @@ import (
 	"github.com/ethereum/go-ethereum/log"
 )
 
-// danglingRange describes the range for detecting dangling storages.
-type danglingRange struct {
+// DanglingRange describes the range for detecting dangling storages.
+type DanglingRange struct {
 	db    ethdb.KeyValueStore // The database stores the snapshot data
 	start []byte              // The start of the key range
 	limit []byte              // The last of the key range
@@ -38,10 +38,10 @@ type danglingRange struct {
 	duration time.Duration // Total time spent on the iteration
 }
 
-// newDanglingRange initializes a dangling storage scanner and detects all the
+// NewDanglingRange initializes a dangling storage scanner and detects all the
 // dangling accounts out.
-func newDanglingRange(db ethdb.KeyValueStore, start, limit []byte, report bool) *danglingRange {
-	r := &danglingRange{
+func NewDanglingRange(db ethdb.KeyValueStore, start, limit []byte, report bool) *DanglingRange {
+	r := &DanglingRange{
 		db:    db,
 		start: start,
 		limit: limit,
@@ -67,7 +67,7 @@ func newDanglingRange(db ethdb.KeyValueStore, start, limit []byte, report bool) 
 // detect iterates the storage snapshot in the specified key range and
 // returns a list of account hash of the dangling storages. Note both
 // start and limit are included for iteration.
-func (r *danglingRange) detect(report bool) ([]common.Hash, time.Duration) {
+func (r *DanglingRange) detect(report bool) ([]common.Hash, time.Duration) {
 	var (
 		checked    []byte
 		result     []common.Hash
@@ -96,6 +96,9 @@ func (r *danglingRange) detect(report bool) ([]common.Hash, time.Duration) {
 		}
 		result = append(result, accountHash)
 
+		if report {
+			log.Warn("Dangling storage - missing account", "account", fmt.Sprintf("%#x", accountHash))
+		}
 		if time.Since(lastReport) > time.Second*8 && report {
 			log.Info("Detecting dangling storage", "at", fmt.Sprintf("%#x", accountHash), "elapsed", common.PrettyDuration(time.Since(start)))
 			lastReport = time.Now()
@@ -105,7 +108,7 @@ func (r *danglingRange) detect(report bool) ([]common.Hash, time.Duration) {
 }
 
 // cleanup wipes the dangling storages which fall within the range before the given key.
-func (r *danglingRange) cleanup(limit []byte) error {
+func (r *DanglingRange) cleanup(limit []byte) error {
 	var (
 		err   error
 		wiped int

--- a/core/state/snapshot/dangling.go
+++ b/core/state/snapshot/dangling.go
@@ -47,6 +47,8 @@ func newDanglingRange(db ethdb.KeyValueStore, start, limit []byte, report bool) 
 		limit: limit,
 	}
 	r.result, r.duration = r.detect(report)
+
+	// Update metrics
 	snapDanglingStoragesCounter.Inc(int64(len(r.result)))
 	snapDanglingStoragesTimer.Update(r.duration)
 
@@ -109,7 +111,7 @@ func (r *danglingRange) cleanup(limit []byte) error {
 		wiped int
 	)
 	for _, accountHash := range r.result {
-		if bytes.Compare(accountHash.Bytes(), limit) >= 0 {
+		if limit != nil && bytes.Compare(accountHash.Bytes(), limit) >= 0 {
 			break
 		}
 		prefix := append(rawdb.SnapshotStoragePrefix, accountHash.Bytes()...)

--- a/core/state/snapshot/dangling.go
+++ b/core/state/snapshot/dangling.go
@@ -1,0 +1,105 @@
+// Copyright 2022 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+package snapshot
+
+import (
+	"bytes"
+	"time"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/rawdb"
+	"github.com/ethereum/go-ethereum/ethdb"
+)
+
+// danglingRange describes the range for detecting dangling storages.
+type danglingRange struct {
+	db    ethdb.KeyValueStore // The database stores the snapshot data
+	start []byte              // The start of the key range
+	limit []byte              // The last of the key range
+
+	result   []common.Hash // The list of account hashes which have the dangling storages
+	duration time.Duration // Total time spent on the iteration
+}
+
+// newDanglingRange initializes a dangling storage scanner and detects all the
+// dangling accounts out.
+func newDanglingRange(db ethdb.KeyValueStore, start, limit []byte) *danglingRange {
+	r := &danglingRange{
+		db:    db,
+		start: start,
+		limit: limit,
+	}
+	r.result, r.duration = r.detect()
+	snapDanglingStoragesCounter.Inc(int64(len(r.result)))
+	snapDanglingStoragesTimer.Update(r.duration)
+	return r
+}
+
+// detect iterates the storage snapshot in the specified key range and
+// returns a list of account hash of the dangling storages. Note both
+// start and limit are included for iteration.
+func (r *danglingRange) detect() ([]common.Hash, time.Duration) {
+	var (
+		checked []byte
+		result  []common.Hash
+		start   = time.Now()
+	)
+	iter := rawdb.NewKeyLengthIterator(r.db.NewIterator(rawdb.SnapshotStoragePrefix, r.start), len(rawdb.SnapshotStoragePrefix)+2*common.HashLength)
+	defer iter.Release()
+
+	for iter.Next() {
+		account := iter.Key()[len(rawdb.SnapshotStoragePrefix) : len(rawdb.SnapshotStoragePrefix)+common.HashLength]
+		if r.limit != nil && bytes.Compare(account, r.limit) > 0 {
+			break
+		}
+		// Skip unnecessary checks for checked storage.
+		if bytes.Equal(account, checked) {
+			continue
+		}
+		checked = common.CopyBytes(account)
+
+		// Check the presence of the corresponding account.
+		accountHash := common.BytesToHash(account)
+		data := rawdb.ReadAccountSnapshot(r.db, accountHash)
+		if len(data) != 0 {
+			continue
+		}
+		result = append(result, accountHash)
+	}
+	return result, time.Since(start)
+}
+
+// cleanup wipes the dangling storages which fall within the range before the given key.
+func (r *danglingRange) cleanup(limit []byte) error {
+	var (
+		err   error
+		wiped int
+	)
+	for _, accountHash := range r.result {
+		if bytes.Compare(accountHash.Bytes(), limit) >= 0 {
+			break
+		}
+		prefix := append(rawdb.SnapshotStoragePrefix, accountHash.Bytes()...)
+		keyLen := len(rawdb.SnapshotStoragePrefix) + 2*common.HashLength
+		if err = wipeKeyRange(r.db, "storage", prefix, nil, nil, keyLen, snapWipedStorageMeter, false); err != nil {
+			break
+		}
+		wiped += 1
+	}
+	r.result = r.result[wiped:]
+	return err
+}

--- a/core/state/snapshot/generate.go
+++ b/core/state/snapshot/generate.go
@@ -412,7 +412,7 @@ func (dl *diskLayer) generateRange(root common.Hash, prefix []byte, kind string,
 		// corresponding storage check will be performed in the callback
 		var r *danglingRange
 		if kind != "storage" {
-			r = newDanglingRange(dl.diskdb, origin, result.last())
+			r = newDanglingRange(dl.diskdb, origin, result.last(), false)
 		}
 		if err := result.forEach(func(key []byte, val []byte) error { return onState(key, val, r, false, false) }); err != nil {
 			return false, nil, err
@@ -479,7 +479,7 @@ func (dl *diskLayer) generateRange(root common.Hash, prefix []byte, kind string,
 
 	var r *danglingRange
 	if kind != "storage" {
-		r = newDanglingRange(dl.diskdb, origin, result.last())
+		r = newDanglingRange(dl.diskdb, origin, result.last(), false)
 	}
 	for iter.Next() {
 		if last != nil && bytes.Compare(iter.Key, last) > 0 {

--- a/core/state/snapshot/generate.go
+++ b/core/state/snapshot/generate.go
@@ -620,12 +620,17 @@ func generateStorages(dl *diskLayer, account common.Hash, storageRoot common.Has
 		if err != nil {
 			return err // The procedure it aborted, either by external signal or internal error.
 		}
-		// Abort the procedure if the entire contract storage is generated
-		if exhausted {
-			break
-		}
 		if origin = increaseKey(last); origin == nil {
 			break // special case, the last is 0xffffffff...fff
+		}
+		// Abort the procedure if the entire contract storage is generated
+		if exhausted {
+			// Last step, cleanup the storages after the last generated
+			// account. All the left storages should be treated as dangling.
+			if err := newDanglingRange(dl.diskdb, origin, nil, false).cleanup(nil); err != nil {
+				return err
+			}
+			break
 		}
 	}
 	return nil

--- a/core/state/snapshot/generate.go
+++ b/core/state/snapshot/generate.go
@@ -381,7 +381,7 @@ func (dl *diskLayer) proveRange(stats *generatorStats, root common.Hash, prefix 
 //
 // However, for accounts, the storage trie of the account needs to be checked. Also,
 // dangling storages(storage exists but the corresponding account is missing) need to
-// be cleaned up. The range between the prevKey
+// be cleaned up.
 type onStateCallback func(key []byte, val []byte, r *danglingRange, write bool, delete bool) error
 
 // generateRange generates the state segment with particular prefix. Generation can

--- a/core/state/snapshot/generate_test.go
+++ b/core/state/snapshot/generate_test.go
@@ -170,7 +170,7 @@ func checkSnapRoot(t *testing.T, snap *diskLayer, trieRoot common.Hash) {
 	if snapRoot != trieRoot {
 		t.Fatalf("snaproot: %#x != trieroot #%x", snapRoot, trieRoot)
 	}
-	scanner := newDanglingRange(snap.diskdb, nil, nil, false)
+	scanner := NewDanglingRange(snap.diskdb, nil, nil, false)
 	if len(scanner.result) != 0 {
 		t.Fatalf("Detected dangling storages %d", len(scanner.result))
 	}

--- a/core/state/snapshot/generate_test.go
+++ b/core/state/snapshot/generate_test.go
@@ -148,8 +148,10 @@ func TestGenerateExistentState(t *testing.T) {
 
 func checkSnapRoot(t *testing.T, snap *diskLayer, trieRoot common.Hash) {
 	t.Helper()
+
 	accIt := snap.AccountIterator(common.Hash{})
 	defer accIt.Release()
+
 	snapRoot, err := generateTrieRoot(nil, accIt, common.Hash{}, stackTrieGenerate,
 		func(db ethdb.KeyValueWriter, accountHash, codeHash common.Hash, stat *generateStats) (common.Hash, error) {
 			storageIt, _ := snap.StorageIterator(accountHash, common.Hash{})
@@ -167,6 +169,10 @@ func checkSnapRoot(t *testing.T, snap *diskLayer, trieRoot common.Hash) {
 	}
 	if snapRoot != trieRoot {
 		t.Fatalf("snaproot: %#x != trieroot #%x", snapRoot, trieRoot)
+	}
+	scanner := newDanglingRange(snap.diskdb, nil, nil, false)
+	if len(scanner.result) != 0 {
+		t.Fatalf("Detected dangling storages %d", len(scanner.result))
 	}
 }
 
@@ -826,6 +832,125 @@ func TestGenerateWithIncompleteStorage(t *testing.T) {
 		t.Errorf("Snapshot generation failed")
 	}
 	checkSnapRoot(t, snap, root)
+	// Signal abortion to the generator and wait for it to tear down
+	stop := make(chan *generatorStats)
+	snap.genAbort <- stop
+	<-stop
+}
+
+func incKey(key []byte) []byte {
+	for i := len(key) - 1; i >= 0; i-- {
+		key[i]++
+		if key[i] != 0x0 {
+			break
+		}
+	}
+	return key
+}
+
+func decKey(key []byte) []byte {
+	for i := len(key) - 1; i >= 0; i-- {
+		key[i]--
+		if key[i] != 0xff {
+			break
+		}
+	}
+	return key
+}
+
+func populateDangling(disk ethdb.KeyValueStore) {
+	populate := func(accountHash common.Hash, keys []string, vals []string) {
+		for i, key := range keys {
+			rawdb.WriteStorageSnapshot(disk, accountHash, hashData([]byte(key)), []byte(vals[i]))
+		}
+	}
+	// Dangling storages of the "first" account
+	populate(common.Hash{}, []string{"key-1", "key-2", "key-3"}, []string{"val-1", "val-2", "val-3"})
+
+	// Dangling storages of the "last" account
+	populate(common.HexToHash("ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"), []string{"key-1", "key-2", "key-3"}, []string{"val-1", "val-2", "val-3"})
+
+	// Dangling storages around the account 1
+	hash := decKey(hashData([]byte("acc-1")).Bytes())
+	populate(common.BytesToHash(hash), []string{"key-1", "key-2", "key-3"}, []string{"val-1", "val-2", "val-3"})
+	hash = incKey(hashData([]byte("acc-1")).Bytes())
+	populate(common.BytesToHash(hash), []string{"key-1", "key-2", "key-3"}, []string{"val-1", "val-2", "val-3"})
+
+	// Dangling storages around the account 2
+	hash = decKey(hashData([]byte("acc-2")).Bytes())
+	populate(common.BytesToHash(hash), []string{"key-1", "key-2", "key-3"}, []string{"val-1", "val-2", "val-3"})
+	hash = incKey(hashData([]byte("acc-2")).Bytes())
+	populate(common.BytesToHash(hash), []string{"key-1", "key-2", "key-3"}, []string{"val-1", "val-2", "val-3"})
+
+	// Dangling storages around the account 3
+	hash = decKey(hashData([]byte("acc-3")).Bytes())
+	populate(common.BytesToHash(hash), []string{"key-1", "key-2", "key-3"}, []string{"val-1", "val-2", "val-3"})
+	hash = incKey(hashData([]byte("acc-3")).Bytes())
+	populate(common.BytesToHash(hash), []string{"key-1", "key-2", "key-3"}, []string{"val-1", "val-2", "val-3"})
+
+	// Dangling storages of the random account
+	populate(randomHash(), []string{"key-1", "key-2", "key-3"}, []string{"val-1", "val-2", "val-3"})
+	populate(randomHash(), []string{"key-1", "key-2", "key-3"}, []string{"val-1", "val-2", "val-3"})
+	populate(randomHash(), []string{"key-1", "key-2", "key-3"}, []string{"val-1", "val-2", "val-3"})
+}
+
+// Tests that snapshot generation with dangling storages. Dangling storage means
+// the storage data is existent while the corresponding account data is missing.
+//
+// This test will populate some dangling storages to see if they can be cleaned up.
+func TestGenerateCompleteSnapshotWithDanglingStorage(t *testing.T) {
+	var helper = newHelper()
+	stRoot := helper.makeStorageTrie([]string{"key-1", "key-2", "key-3"}, []string{"val-1", "val-2", "val-3"})
+
+	helper.addAccount("acc-1", &Account{Balance: big.NewInt(1), Root: stRoot, CodeHash: emptyCode.Bytes()})
+	helper.addAccount("acc-2", &Account{Balance: big.NewInt(1), Root: emptyRoot.Bytes(), CodeHash: emptyCode.Bytes()})
+	helper.addAccount("acc-3", &Account{Balance: big.NewInt(1), Root: stRoot, CodeHash: emptyCode.Bytes()})
+
+	helper.addSnapStorage("acc-1", []string{"key-1", "key-2", "key-3"}, []string{"val-1", "val-2", "val-3"})
+	helper.addSnapStorage("acc-3", []string{"key-1", "key-2", "key-3"}, []string{"val-1", "val-2", "val-3"})
+
+	populateDangling(helper.diskdb)
+
+	root, snap := helper.Generate()
+	select {
+	case <-snap.genPending:
+		// Snapshot generation succeeded
+
+	case <-time.After(3 * time.Second):
+		t.Errorf("Snapshot generation failed")
+	}
+	checkSnapRoot(t, snap, root)
+
+	// Signal abortion to the generator and wait for it to tear down
+	stop := make(chan *generatorStats)
+	snap.genAbort <- stop
+	<-stop
+}
+
+// Tests that snapshot generation with dangling storages. Dangling storage means
+// the storage data is existent while the corresponding account data is missing.
+//
+// This test will populate some dangling storages to see if they can be cleaned up.
+func TestGenerateBrokenSnapshotWithDanglingStorage(t *testing.T) {
+	var helper = newHelper()
+	stRoot := helper.makeStorageTrie([]string{"key-1", "key-2", "key-3"}, []string{"val-1", "val-2", "val-3"})
+
+	helper.addTrieAccount("acc-1", &Account{Balance: big.NewInt(1), Root: stRoot, CodeHash: emptyCode.Bytes()})
+	helper.addTrieAccount("acc-2", &Account{Balance: big.NewInt(2), Root: emptyRoot.Bytes(), CodeHash: emptyCode.Bytes()})
+	helper.addTrieAccount("acc-3", &Account{Balance: big.NewInt(3), Root: stRoot, CodeHash: emptyCode.Bytes()})
+
+	populateDangling(helper.diskdb)
+
+	root, snap := helper.Generate()
+	select {
+	case <-snap.genPending:
+		// Snapshot generation succeeded
+
+	case <-time.After(3 * time.Second):
+		t.Errorf("Snapshot generation failed")
+	}
+	checkSnapRoot(t, snap, root)
+
 	// Signal abortion to the generator and wait for it to tear down
 	stop := make(chan *generatorStats)
 	snap.genAbort <- stop


### PR DESCRIPTION
This PR improves the snapshot generation, it will detect the dangling storages in snapshot generation.

Dangling storage means the storage snapshot data is existent while the corresponding account snapshot
data is missing. It's possible to happen in such scenario(text copied from Peter):

---

During snap sync, we pull in pieces of storage slots, but between two cycles, the contract might get deleted. In that case if the deletion happens in between an interrupt, I think, the old slots will end up on disk, but the old account not... neither the new one which got deleted. So we have storage slots, but no accounts on top.

After snap sync finishes, we need to regenerate the state snapshot. So we use our batched account prover to fix any issues in the accounts. The account range may or may not be correct - and we will fix it - however, we will not care about the deleted account since it's not part of the snapshot account range.

Then after fixing the account range, we verify each of the account's storage slots - each existing one that is, or freshly deleted ones. But we don't ever consider dangling storage data without an account.

---

This PR fixes this issue by introducing a storage scanner. It will be constructed for each account range which detects all the dangling accounts and caches them in memory(the size is limited, no OOM issue).  Constructing scanner is not trivial which might involve lots of disk reads, but it's per account range so it's still acceptable. The detected dangling storages will be wiped at the correct time during the generation.