### PR TITLE
log: modify lock defer unlock order in sync handler

### DIFF
--- a/log/handler.go
+++ b/log/handler.go
@@ -52,8 +52,9 @@ func StreamHandler(wr io.Writer, fmtr Format) Handler {
 func SyncHandler(h Handler) Handler {
 	var mu sync.Mutex
 	return FuncHandler(func(r *Record) error {
-		defer mu.Unlock()
 		mu.Lock()
+		defer mu.Unlock()
+
 		return h.Log(r)
 	})
 }


### PR DESCRIPTION
This PR modifies the order of `Lock()` `defer Unlock()` to follow the more typically used pattern.