### PR TITLE
eth/downloader: remove stale beacon headers as backfilling progresses

### DIFF
--- a/eth/downloader/skeleton_test.go
+++ b/eth/downloader/skeleton_test.go
@@ -55,10 +55,11 @@ func newHookedBackfiller() backfiller {
 // based on the skeleton chain as it might be invalid. The backfiller should
 // gracefully handle multiple consecutive suspends without a resume, even
 // on initial sartup.
-func (hf *hookedBackfiller) suspend() {
+func (hf *hookedBackfiller) suspend() *types.Header {
 	if hf.suspendHook != nil {
 		hf.suspendHook()
 	}
+	return nil // we don't really care about header cleanups for now
 }
 
 // resume requests the backfiller to start running fill or snap sync based on
@@ -426,7 +427,6 @@ func TestSkeletonSyncExtend(t *testing.T) {
 			newstate: []*subchain{
 				{Head: 49, Tail: 49},
 			},
-			err: errReorgDenied,
 		},
 		// Initialize a sync and try to extend it with a sibling block.
 		{
@@ -489,7 +489,7 @@ func TestSkeletonSyncExtend(t *testing.T) {
 
 		<-wait
 		if err := skeleton.Sync(tt.extend, false); err != tt.err {
-			t.Errorf("extension failure mismatch: have %v, want %v", err, tt.err)
+			t.Errorf("test %d: extension failure mismatch: have %v, want %v", i, err, tt.err)
 		}
 		skeleton.Terminate()
 


### PR DESCRIPTION
Currently when we do a beacon sync, we download the headers from the head (announced via the engine API) till we find an ancestor known locally (genesis at worse case) and store the headers in a separate database namespace for backfilling with data. But currently when backfilling is done (and the local chain is extended till the head). the original beacon headers from this helper namespace are not deleted. This is potentially a problem as there are a few GBs of headers on mainnet already, which would linger in the database forever.

This PR adds a mechanism to remove those beacon headers which have already been backfilled and thus are useless for the further operation of the node. Ideally we would delete headers in lockstep with backfilling them, but that gets messy due to the downloader needing to call back into the skeleton syncer (too easy to deadlock everything or leak internals all over the place). The solution in this PR is to wait until a sync cycle spins down (whether cancelled, failed to finished) and only then delete all the stale headers (< head block). This variation has the drawback that we might potentially need to delete 15M headers in one go, but it is significantly simpler and easier to reason about.

TODO:

- If a few blocks are imported via the engine API and sync is called again, currently that jumps forward in time, not deleting the headers from the old sync termination head.
- Currently all beacon headers are deleted in one go. This is ok if the sync cycle was short-ish, or if there are occasional failures; but at worse this could mean a 15M deletion batch. That is excessive and needs to be broken down into more meaningful batch sizes.