### PR TITLE
eth/downloader: add optional id parameter to Downloader.Cancel

### DIFF
--- a/eth/downloader/downloader.go
+++ b/eth/downloader/downloader.go
@@ -411,6 +411,14 @@ func (d *Downloader) synchronise(id string, hash common.Hash, td, ttd *big.Int, 
 	}
 	// Create cancel channel for aborting mid-flight and mark the master peer
 	d.cancelLock.Lock()
+	if d.cancelCh != nil {
+		select {
+		case <-d.cancelCh:
+			// Channel was already closed
+		default:
+			close(d.cancelCh)
+		}
+	}
 	d.cancelCh = make(chan struct{})
 	d.cancelPeer = id
 	d.cancelLock.Unlock()

--- a/eth/downloader/fetchers_concurrent.go
+++ b/eth/downloader/fetchers_concurrent.go
@@ -317,15 +317,9 @@ func (d *Downloader) concurrentFetch(queue typedQueue, beaconMode bool) error {
 			} else {
 				d.dropPeer(peer.id)
 
-				// If this peer was the master peer, abort sync immediately
-				d.cancelLock.RLock()
-				master := peer.id == d.cancelPeer
-				d.cancelLock.RUnlock()
-
-				if master {
-					d.cancel()
-					return errTimeout
-				}
+				// If this peer was the master peer, abort sync immediate
+				d.cancel(peer.id)
+				return errTimeout
 			}
 
 		case res := <-responses:


### PR DESCRIPTION
This PR also removes call to d.Cancel in d.spawnSync as d.synchronise has already ensured it.