### PR TITLE
Update Debian control file to remove unencrypted git protocol

### DIFF
--- a/build/deb/ethereum/deb.control
+++ b/build/deb/ethereum/deb.control
@@ -5,7 +5,7 @@ Maintainer: {{.Author}}
 Build-Depends: debhelper (>= 8.0.0), {{.GoBootPackage}}
 Standards-Version: 3.9.5
 Homepage: https://ethereum.org
-Vcs-Git: git://github.com/ethereum/go-ethereum.git
+Vcs-Git: https://github.com/ethereum/go-ethereum.git
 Vcs-Browser: https://github.com/ethereum/go-ethereum
 
 Package: {{.Name}}


### PR DESCRIPTION
### Description

GitHub recently updated Git protocol security, and the usage of the unencrypted git protocol has been retired permanently on March 15th. But, the Debian control file `deb.control` still used git protocol for Vcs-Git.  Hence, may lead to bunch of unauthenticated git protocol errors.

### Proposed Solution

Use https protocol in place of unencrypted git protocol

`git://github.com/ethereum/go-ethereum.git` should be changed to
`https://github.com/ethereum/go-ethereum.git`


### Reference

https://github.blog/2021-09-01-improving-git-protocol-security-github/

Fixes #24675