### PR TITLE
core/state/snapshot: fix race condition

### DIFF
--- a/core/state/snapshot/difflayer.go
+++ b/core/state/snapshot/difflayer.go
@@ -258,6 +258,8 @@ func (dl *diffLayer) Root() common.Hash {
 
 // Parent returns the subsequent layer of a diff layer.
 func (dl *diffLayer) Parent() snapshot {
+	dl.lock.RLock()
+	defer dl.lock.RUnlock()
 	return dl.parent
 }
 

--- a/core/state/snapshot/difflayer.go
+++ b/core/state/snapshot/difflayer.go
@@ -260,6 +260,7 @@ func (dl *diffLayer) Root() common.Hash {
 func (dl *diffLayer) Parent() snapshot {
 	dl.lock.RLock()
 	defer dl.lock.RUnlock()
+
 	return dl.parent
 }
 

--- a/eth/protocols/snap/sync.go
+++ b/eth/protocols/snap/sync.go
@@ -422,6 +422,8 @@ type Syncer struct {
 	storageSynced  uint64             // Number of storage slots downloaded
 	storageBytes   common.StorageSize // Number of storage trie bytes persisted to disk
 
+	extProgress *SyncProgress // progress that can be exposed to external caller.
+
 	// Request tracking during healing phase
 	trienodeHealIdlers map[string]struct{} // Peers that aren't serving trie node requests
 	bytecodeHealIdlers map[string]struct{} // Peers that aren't serving bytecode requests
@@ -477,6 +479,8 @@ func NewSyncer(db ethdb.KeyValueStore) *Syncer {
 		trienodeHealReqs: make(map[uint64]*trienodeHealRequest),
 		bytecodeHealReqs: make(map[uint64]*bytecodeHealRequest),
 		stateWriter:      db.NewBatch(),
+
+		extProgress: new(SyncProgress),
 	}
 }
 
@@ -633,6 +637,21 @@ func (s *Syncer) Sync(root common.Hash, cancel chan struct{}) error {
 			s.assignTrienodeHealTasks(trienodeHealResps, trienodeHealReqFails, cancel)
 			s.assignBytecodeHealTasks(bytecodeHealResps, bytecodeHealReqFails, cancel)
 		}
+		p := &SyncProgress{
+			AccountSynced:      s.accountSynced,
+			AccountBytes:       s.accountBytes,
+			BytecodeSynced:     s.bytecodeSynced,
+			BytecodeBytes:      s.bytecodeBytes,
+			StorageSynced:      s.storageSynced,
+			StorageBytes:       s.storageBytes,
+			TrienodeHealSynced: s.trienodeHealSynced,
+			TrienodeHealBytes:  s.trienodeHealBytes,
+			BytecodeHealSynced: s.bytecodeHealSynced,
+			BytecodeHealBytes:  s.bytecodeHealBytes,
+		}
+		s.lock.Lock()
+		s.extProgress = p
+		s.lock.Unlock()
 		// Wait for something to happen
 		select {
 		case <-s.update:
@@ -805,19 +824,7 @@ func (s *Syncer) saveSyncStatus() {
 func (s *Syncer) Progress() (*SyncProgress, *SyncPending) {
 	s.lock.Lock()
 	defer s.lock.Unlock()
-
-	progress := &SyncProgress{
-		AccountSynced:      s.accountSynced,
-		AccountBytes:       s.accountBytes,
-		BytecodeSynced:     s.bytecodeSynced,
-		BytecodeBytes:      s.bytecodeBytes,
-		StorageSynced:      s.storageSynced,
-		StorageBytes:       s.storageBytes,
-		TrienodeHealSynced: s.trienodeHealSynced,
-		TrienodeHealBytes:  s.trienodeHealBytes,
-		BytecodeHealSynced: s.bytecodeHealSynced,
-		BytecodeHealBytes:  s.bytecodeHealBytes,
-	}
+	progress := s.extProgress
 	pending := new(SyncPending)
 	if s.healer != nil {
 		pending.TrienodeHeal = uint64(len(s.healer.trieTasks))

--- a/eth/protocols/snap/sync.go
+++ b/eth/protocols/snap/sync.go
@@ -706,8 +706,9 @@ func (s *Syncer) loadSyncStatus() {
 				}
 			}
 			s.lock.Lock()
+			defer s.lock.Unlock()
+
 			s.snapped = len(s.tasks) == 0
-			s.lock.Unlock()
 
 			s.accountSynced = progress.AccountSynced
 			s.accountBytes = progress.AccountBytes

--- a/eth/protocols/snap/sync.go
+++ b/eth/protocols/snap/sync.go
@@ -705,7 +705,9 @@ func (s *Syncer) loadSyncStatus() {
 					}
 				}
 			}
+			s.lock.Lock()
 			s.snapped = len(s.tasks) == 0
+			s.lock.Unlock()
 
 			s.accountSynced = progress.AccountSynced
 			s.accountBytes = progress.AccountBytes


### PR DESCRIPTION
This PR fixes two race conditions:
- a data race between `difflayer.Cap()` and `difflayer.Parent()` where `Parent` reads the parent field without requiring a read lock
- a data race between `(*Syncer).loadSyncStatus()` and `(*Syncer).OnByteCodes` where the `loadSyncStatus` writes the `snapped` field without a lock.

```
==================
WARNING: DATA RACE
Write at 0x00c028443728 by goroutine 1404:
  github.com/ethereum/go-ethereum/core/state/snapshot.(*Tree).cap()
      github.com/ethereum/go-ethereum/core/state/snapshot/snapshot.go:484 +0x2b7
  github.com/ethereum/go-ethereum/core/state/snapshot.(*Tree).Cap()
      github.com/ethereum/go-ethereum/core/state/snapshot/snapshot.go:401 +0x1ca
  github.com/ethereum/go-ethereum/core/state.(*StateDB).Commit()
      github.com/ethereum/go-ethereum/core/state/statedb.go:977 +0x10c4
  github.com/ethereum/go-ethereum/core.(*BlockChain).writeBlockWithState()
      github.com/ethereum/go-ethereum/core/blockchain.go:1210 +0x9e4
  github.com/ethereum/go-ethereum/core.(*BlockChain).writeBlockAndSetHead()
      github.com/ethereum/go-ethereum/core/blockchain.go:1283 +0xca
  github.com/ethereum/go-ethereum/core.(*BlockChain).insertChain()
      github.com/ethereum/go-ethereum/core/blockchain.go:1648 +0x40af
  github.com/ethereum/go-ethereum/core.(*BlockChain).InsertChain()
      github.com/ethereum/go-ethereum/core/blockchain.go:1378 +0xfd4
  github.com/ethereum/go-ethereum/eth.newHandler.func4()
      github.com/ethereum/go-ethereum/eth/handler.go:279 +0x1604
  github.com/ethereum/go-ethereum/eth/fetcher.(*BlockFetcher).importBlocks.func1()
      github.com/ethereum/go-ethereum/eth/fetcher/block_fetcher.go:848 +0x8a1

Previous read at 0x00c028443728 by goroutine 1690:
  github.com/ethereum/go-ethereum/core/state/snapshot.(*diffLayer).Parent()
      github.com/ethereum/go-ethereum/core/state/snapshot/difflayer.go:261 +0x34
  github.com/ethereum/go-ethereum/core/state/snapshot.newFastIterator()
      github.com/ethereum/go-ethereum/core/state/snapshot/iterator_fast.go:112 +0x259
  github.com/ethereum/go-ethereum/core/state/snapshot.newFastStorageIterator()
      github.com/ethereum/go-ethereum/core/state/snapshot/iterator_fast.go:349 +0x1c4
  github.com/ethereum/go-ethereum/core/state/snapshot.(*Tree).StorageIterator()
      github.com/ethereum/go-ethereum/core/state/snapshot/snapshot.go:757 +0xa6
  github.com/ethereum/go-ethereum/eth/protocols/snap.ServiceGetStorageRangesQuery()
      github.com/ethereum/go-ethereum/eth/protocols/snap/handler.go:376 +0x609
  github.com/ethereum/go-ethereum/eth/protocols/snap.HandleMessage()
      github.com/ethereum/go-ethereum/eth/protocols/snap/handler.go:197 +0x1a07
  github.com/ethereum/go-ethereum/eth/protocols/snap.Handle()
      github.com/ethereum/go-ethereum/eth/protocols/snap/handler.go:123 +0x4a
  github.com/ethereum/go-ethereum/eth/protocols/snap.MakeProtocols.func2.1()
      github.com/ethereum/go-ethereum/eth/protocols/snap/handler.go:103 +0x48
  github.com/ethereum/go-ethereum/eth.(*handler).runSnapExtension()
      github.com/ethereum/go-ethereum/eth/handler.go:480 +0x291
  github.com/ethereum/go-ethereum/eth.(*snapHandler).RunPeer()
      github.com/ethereum/go-ethereum/eth/handler_snap.go:33 +0x44
  github.com/ethereum/go-ethereum/eth/protocols/snap.MakeProtocols.func2()
      github.com/ethereum/go-ethereum/eth/protocols/snap/handler.go:102 +0xdd
  github.com/ethereum/go-ethereum/p2p.(*Peer).startProtocols.func1()
      github.com/ethereum/go-ethereum/p2p/peer.go:415 +0xed

```
```
==================
WARNING: DATA RACE
Write at 0x00c008e6c048 by goroutine 685:
  github.com/ethereum/go-ethereum/eth/protocols/snap.(*Syncer).loadSyncStatus()
      github.com/ethereum/go-ethereum/eth/protocols/snap/sync.go:708 +0xa92
  github.com/ethereum/go-ethereum/eth/protocols/snap.(*Syncer).Sync()
      github.com/ethereum/go-ethereum/eth/protocols/snap/sync.go:560 +0x45e
  github.com/ethereum/go-ethereum/eth/downloader.(*stateSync).run()
      github.com/ethereum/go-ethereum/eth/downloader/statesync.go:107 +0xf0
  github.com/ethereum/go-ethereum/eth/downloader.(*Downloader).runStateSync.func1()
      github.com/ethereum/go-ethereum/eth/downloader/statesync.go:63 +0x39

Previous read at 0x00c008e6c048 by goroutine 1004:
  github.com/ethereum/go-ethereum/eth/protocols/snap.(*Syncer).OnByteCodes()
      github.com/ethereum/go-ethereum/eth/protocols/snap/sync.go:2332 +0x76
  github.com/ethereum/go-ethereum/eth/downloader.(*Downloader).DeliverSnapPacket()
      github.com/ethereum/go-ethereum/eth/downloader/downloader.go:1749 +0x4cb
  github.com/ethereum/go-ethereum/eth.(*snapHandler).Handle()
      github.com/ethereum/go-ethereum/eth/handler_snap.go:49 +0x64
  github.com/ethereum/go-ethereum/eth/protocols/snap.HandleMessage()
      github.com/ethereum/go-ethereum/eth/protocols/snap/handler.go:247 +0x10fa
  github.com/ethereum/go-ethereum/eth/protocols/snap.Handle()
      github.com/ethereum/go-ethereum/eth/protocols/snap/handler.go:123 +0x4a
  github.com/ethereum/go-ethereum/eth/protocols/snap.MakeProtocols.func2.1()
      github.com/ethereum/go-ethereum/eth/protocols/snap/handler.go:103 +0x48
  github.com/ethereum/go-ethereum/eth.(*handler).runSnapExtension()
      github.com/ethereum/go-ethereum/eth/handler.go:480 +0x291
  github.com/ethereum/go-ethereum/eth.(*snapHandler).RunPeer()
      github.com/ethereum/go-ethereum/eth/handler_snap.go:33 +0x44
  github.com/ethereum/go-ethereum/eth/protocols/snap.MakeProtocols.func2()
      github.com/ethereum/go-ethereum/eth/protocols/snap/handler.go:102 +0xdd
  github.com/ethereum/go-ethereum/p2p.(*Peer).startProtocols.func1()
      github.com/ethereum/go-ethereum/p2p/peer.go:415 +0xed

```

Big props to David Theodore for finding these
