### PR TITLE
eth/downloader: resolve local header by hash for beacon sync

### DIFF
--- a/eth/downloader/beaconsync.go
+++ b/eth/downloader/beaconsync.go
@@ -276,7 +276,7 @@ func (d *Downloader) fetchBeaconHeaders(from uint64) error {
 			// The header is still missing, the beacon sync is corrupted and bail out
 			// the error here.
 			if header == nil {
-				return fmt.Errorf("missing beacon header %d %x", tail.Number.Uint64()-1, tail.ParentHash)
+				return fmt.Errorf("missing beacon header %d", from)
 			}
 			headers = append(headers, header)
 			hashes = append(hashes, headers[i].Hash())

--- a/eth/downloader/beaconsync.go
+++ b/eth/downloader/beaconsync.go
@@ -269,6 +269,7 @@ func (d *Downloader) fetchBeaconHeaders(from uint64) error {
 			return fmt.Errorf("invalid origin (%d) of beacon sync (%d)", from, tail.Number)
 		}
 		localHeaders = d.readHeaderRange(tail, int(count))
+		log.Warn("Retrieved beacon headers from local", "from", from, "count", count)
 	}
 	for {
 		// Retrieve a batch of headers and feed it to the header processor

--- a/eth/downloader/downloader.go
+++ b/eth/downloader/downloader.go
@@ -489,6 +489,7 @@ func (d *Downloader) syncWithPeer(p *peerConnection, hash common.Hash, td, ttd *
 					headers := d.readHeaderRange(oldest, count)
 					if len(headers) == count {
 						pivot = headers[len(headers)-1]
+						log.Warn("Retrieved pivot header from local", "number", pivot.Number, "hash", pivot.Hash(), "latest", latest.Number, "oldest", oldest.Number)
 					}
 				}
 			}

--- a/eth/downloader/downloader_test.go
+++ b/eth/downloader/downloader_test.go
@@ -1385,10 +1385,10 @@ func testBeaconSync(t *testing.T, protocol uint, mode SyncMode) {
 		name  string // The name of testing scenario
 		local int    // The length of local chain(canonical chain assumed), 0 means genesis is the head
 	}{
-		{name: "Beacon sync since genesis", local: 0},
-		{name: "Beacon sync with short local chain", local: 1},
+		//{name: "Beacon sync since genesis", local: 0},
+		//{name: "Beacon sync with short local chain", local: 1},
 		{name: "Beacon sync with long local chain", local: blockCacheMaxItems - 15 - fsMinFullBlocks/2},
-		{name: "Beacon sync with full local chain", local: blockCacheMaxItems - 15 - 1},
+		//{name: "Beacon sync with full local chain", local: blockCacheMaxItems - 15 - 1},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {

--- a/eth/downloader/downloader_test.go
+++ b/eth/downloader/downloader_test.go
@@ -1385,10 +1385,10 @@ func testBeaconSync(t *testing.T, protocol uint, mode SyncMode) {
 		name  string // The name of testing scenario
 		local int    // The length of local chain(canonical chain assumed), 0 means genesis is the head
 	}{
-		//{name: "Beacon sync since genesis", local: 0},
-		//{name: "Beacon sync with short local chain", local: 1},
+		{name: "Beacon sync since genesis", local: 0},
+		{name: "Beacon sync with short local chain", local: 1},
 		{name: "Beacon sync with long local chain", local: blockCacheMaxItems - 15 - fsMinFullBlocks/2},
-		//{name: "Beacon sync with full local chain", local: blockCacheMaxItems - 15 - 1},
+		{name: "Beacon sync with full local chain", local: blockCacheMaxItems - 15 - 1},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {


### PR DESCRIPTION
This PR fixes a panic found by @marioevz.

The scenario is: 

- Geth starts beacon sync with remote head as 7 and local head as 5
- At the same time, Geth inserts a new block 6 via `NewPayload` API. The corresponding `ForkchoiceUpdate` event is not received yet, so it's still non-canonical.
- Beacon skeleton links with local chain at header 6, because the body and receipts of block 6 is present in disk 
- Geth then spins up the downloader for sync, the origin is recapped to 0 because in snap sync, the safety distance is 64 while our remote head is only 7
- Geth tries to deliver the header in range [1, 7] in `fetchBeaconHeaders`, for headers [1, 6] they are not present in skeleton space, so try to resolve them locally
- Header 6 is non-canonical, previously we only search the canonical header for it, so it's missing