### PR TITLE
core/types: fix unhandled errors in TestTransactionCoding

### DIFF
--- a/core/types/transaction_test.go
+++ b/core/types/transaction_test.go
@@ -477,14 +477,18 @@ func TestTransactionCoding(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		assertEqual(parsedTx, tx)
+		if err := assertEqual(parsedTx, tx); err != nil {
+			t.Fatal(err)
+		}
 
 		// JSON
 		parsedTx, err = encodeDecodeJSON(tx)
 		if err != nil {
 			t.Fatal(err)
 		}
-		assertEqual(parsedTx, tx)
+		if err := assertEqual(parsedTx, tx); err != nil {
+			t.Fatal(err)
+		}
 	}
 }
 


### PR DESCRIPTION
Fix unhandled errors in `TestTransactionCoding`. The comparison results of `assertEqual` are not used and we can compare two transactions by their hashes directly.