### PR TITLE
eth/mobile: fix receipt encoding to json

### DIFF
--- a/mobile/types.go
+++ b/mobile/types.go
@@ -358,7 +358,7 @@ func NewReceiptFromJSON(data string) (*Receipt, error) {
 
 // EncodeJSON encodes a transaction receipt into a JSON data dump.
 func (r *Receipt) EncodeJSON() (string, error) {
-	data, err := rlp.EncodeToBytes(r.receipt)
+	data, err := json.Marshal(r.receipt)
 	return string(data), err
 }
 


### PR DESCRIPTION
Currently, there's an issue with `Receipt` to JSON conversion: method returns binary data instead of JSON string.

This change fixes described behavior.