### PR TITLE
README.md: update Go min required version to 1.16

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ archives are published at https://geth.ethereum.org/downloads/.
 
 For prerequisites and detailed build instructions please read the [Installation Instructions](https://geth.ethereum.org/docs/install-and-build/installing-geth).
 
-Building `geth` requires both a Go (version 1.14 or later) and a C compiler. You can install
+Building `geth` requires both a Go (version 1.16 or later) and a C compiler. You can install
 them using your favourite package manager. Once the dependencies are installed, run
 
 ```shell


### PR DESCRIPTION
I was not able to build the project locally with Go v1.15 because Azure SDK was throwing errors:

```bash
$ make geth
env GO111MODULE=on go run build/ci.go install ./cmd/geth
package command-line-arguments
        imports github.com/ethereum/go-ethereum/internal/build
        imports github.com/Azure/azure-sdk-for-go/sdk/storage/azblob
        imports github.com/Azure/azure-sdk-for-go/sdk/azcore: build constraints exclude all Go files in ~/go/pkg/mod/github.com/!azure/azure-sdk-for-go/sdk/azcore@v0.21.1
package command-line-arguments
        imports github.com/ethereum/go-ethereum/internal/build
        imports github.com/Azure/azure-sdk-for-go/sdk/storage/azblob
        imports github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime
        imports github.com/Azure/azure-sdk-for-go/sdk/azcore/internal/shared: build constraints exclude all Go files in ~/go/pkg/mod/github.com/!azure/azure-sdk-for-go/sdk/azcore@v0.21.1/internal/shared
package command-line-arguments
        imports github.com/ethereum/go-ethereum/internal/build
        imports github.com/Azure/azure-sdk-for-go/sdk/storage/azblob
        imports github.com/Azure/azure-sdk-for-go/sdk/azcore/policy: build constraints exclude all Go files in ~/go/pkg/mod/github.com/!azure/azure-sdk-for-go/sdk/azcore@v0.21.1/policy
package command-line-arguments
        imports github.com/ethereum/go-ethereum/internal/build
        imports github.com/Azure/azure-sdk-for-go/sdk/storage/azblob
        imports github.com/Azure/azure-sdk-for-go/sdk/azcore/streaming: build constraints exclude all Go files in ~/go/pkg/mod/github.com/!azure/azure-sdk-for-go/sdk/azcore@v0.21.1/streaming
package command-line-arguments
        imports github.com/ethereum/go-ethereum/internal/build
        imports github.com/Azure/azure-sdk-for-go/sdk/storage/azblob
        imports github.com/Azure/azure-sdk-for-go/sdk/azcore/to: build constraints exclude all Go files in ~/go/pkg/mod/github.com/!azure/azure-sdk-for-go/sdk/azcore@v0.21.1/to
package command-line-arguments
        imports github.com/ethereum/go-ethereum/internal/build
        imports github.com/Azure/azure-sdk-for-go/sdk/storage/azblob
        imports github.com/Azure/azure-sdk-for-go/sdk/internal/uuid: build constraints exclude all Go files in ~/go/pkg/mod/github.com/!azure/azure-sdk-for-go/sdk/internal@v0.8.3/uuid
package command-line-arguments
        imports github.com/ethereum/go-ethereum/internal/build
        imports github.com/Azure/azure-sdk-for-go/sdk/storage/azblob
        imports github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/internal: build constraints exclude all Go files in ~/go/pkg/mod/github.com/!azure/azure-sdk-for-go/sdk/storage/azblob@v0.3.0/internal
make: *** [Makefile:12: geth] Error 1
```

After doing some research, it turned out that Azure SDK needs to be built with a newer version. I tried all 1.15, 1.16, 1.17 and 1.18. All versions worked for me except 1.15.