### PR TITLE
internal/ethapi,webext: add debug_getTransactionReceiptRlp RPC

### DIFF
--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -25,6 +25,8 @@ import (
 	"time"
 
 	"github.com/davecgh/go-spew/spew"
+	"github.com/tyler-smith/go-bip39"
+
 	"github.com/ethereum/go-ethereum/accounts"
 	"github.com/ethereum/go-ethereum/accounts/abi"
 	"github.com/ethereum/go-ethereum/accounts/keystore"
@@ -46,7 +48,6 @@ import (
 	"github.com/ethereum/go-ethereum/params"
 	"github.com/ethereum/go-ethereum/rlp"
 	"github.com/ethereum/go-ethereum/rpc"
-	"github.com/tyler-smith/go-bip39"
 )
 
 // PublicEthereumAPI provides an API to access Ethereum related information.
@@ -1873,6 +1874,23 @@ func (api *PublicDebugAPI) GetBlockRlp(ctx context.Context, number uint64) (hexu
 		return nil, fmt.Errorf("block #%d not found", number)
 	}
 	return rlp.EncodeToBytes(block)
+}
+
+// GetTransactionReceiptRlp returns the RLP-encoded transaction receipt for the given transaction hash.
+func (api *PublicDebugAPI) GetTransactionReceiptRlp(ctx context.Context, hash common.Hash) (hexutil.Bytes, error) {
+	_, blockHash, _, index, err := api.b.GetTransaction(ctx, hash)
+	if err != nil {
+		return nil, nil
+	}
+	receipts, err := api.b.GetReceipts(ctx, blockHash)
+	if err != nil {
+		return nil, err
+	}
+	if len(receipts) <= int(index) {
+		return nil, nil
+	}
+	receipt := receipts[index]
+	return rlp.EncodeToBytes(receipt)
 }
 
 // TestSignCliqueBlock fetches the given block number, and attempts to sign it as a clique header with the

--- a/internal/web3ext/web3ext.go
+++ b/internal/web3ext/web3ext.go
@@ -234,6 +234,11 @@ web3._extend({
 			params: 1
 		}),
 		new web3._extend.Method({
+			name: 'getTransactionReceiptRlp',
+			call: 'debug_getTransactionReceiptRlp',
+			params: 1
+		}),
+		new web3._extend.Method({
 			name: 'testSignCliqueBlock',
 			call: 'debug_testSignCliqueBlock',
 			params: 2,


### PR DESCRIPTION
@jflo as he was requesting this.  Follows the same pattern as `debug_getBlockRlp` above it, using the same preamble code as `eth_getTransactionReceipt` (https://github.com/ethereum/go-ethereum/blob/master/internal/ethapi/api.go#L1547).

Tested on this Sepolia transaction:

```
> debug.getTransactionReceiptRlp("0x30296f5f32972c7c3b39963cfd91073000cb882c294adc2dcf0ac9ca34d67bd2")
"0xb9018902f901850182aebbb9010000800000000000000000000000000000000000000000100000020000000000000000000000000000008000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000008000000000000000000000000000000000000000100000000000000000000000000000000000000000000000000000000000000000000001000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000800000000000000400000000000000000f87cf87a94830bf80a3839b300291915e7c67b70d90823ffedf842a0e1fffcc4923d04b559f4d29a8bfc6cda04eb5b0d3c460751c2402c5c5cc9109ca00000000000000000000000001b57edab586cbdabd4d914869ae8bb78dbc05571a00000000000000000000000000000000000000000000000000de0b6b3a7640000"
```

https://sepolia.otterscan.io/tx/0x30296f5f32972c7c3b39963cfd91073000cb882c294adc2dcf0ac9ca34d67bd2