### PR TITLE
core,eth: api for flushing block state

### DIFF
--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -2324,3 +2324,10 @@ func (bc *BlockChain) InsertHeaderChain(chain []*types.Header, checkFreq int) (i
 	_, err := bc.hc.InsertHeaderChain(chain, start, bc.forker)
 	return 0, err
 }
+
+func (bc *BlockChain) FlushState(number uint64) error {
+	triedb := bc.stateCache.TrieDB()
+	block := bc.GetBlockByNumber(number)
+	log.Info("Writing cached state to disk", "block", block.Number(), "hash", block.Hash(), "root", block.Root())
+	return triedb.Commit(block.Root(), true, nil)
+}

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -2325,7 +2325,13 @@ func (bc *BlockChain) InsertHeaderChain(chain []*types.Header, checkFreq int) (i
 	return 0, err
 }
 
+// FlushState persists the post-state of a block to disk.
 func (bc *BlockChain) FlushState(number uint64) error {
+	if !bc.chainmu.TryLock() {
+		return errChainStopped
+	}
+	defer bc.chainmu.Unlock()
+
 	triedb := bc.stateCache.TrieDB()
 	block := bc.GetBlockByNumber(number)
 	log.Info("Writing cached state to disk", "block", block.Number(), "hash", block.Hash(), "root", block.Root())

--- a/eth/api.go
+++ b/eth/api.go
@@ -607,3 +607,12 @@ func (api *PrivateDebugAPI) GetAccessibleState(from, to rpc.BlockNumber) (uint64
 	}
 	return 0, fmt.Errorf("No state found")
 }
+
+// FlushState persists the state of a given block to disk.
+func (api *PrivateDebugAPI) FlushState(number rpc.BlockNumber) error {
+	// Genesis, latest and pending not supported
+	if number.Int64() <= 0 {
+		return fmt.Errorf("Invalid block number")
+	}
+	return api.eth.BlockChain().FlushState(uint64(number.Int64()))
+}

--- a/internal/web3ext/web3ext.go
+++ b/internal/web3ext/web3ext.go
@@ -471,6 +471,12 @@ web3._extend({
 			params: 2,
 			inputFormatter:[web3._extend.formatters.inputBlockNumberFormatter, web3._extend.formatters.inputBlockNumberFormatter],
 		}),
+		new web3._extend.Method({
+			name: 'flushState',
+			call: 'debug_flushState',
+			params: 1,
+			inputFormatter:[web3._extend.formatters.inputBlockNumberFormatter],
+		}),
 	],
 	properties: []
 });


### PR DESCRIPTION
See https://github.com/ethereum/go-ethereum/issues/24720 for use-case.

After trying this and shutting down the node I got a dangling trie nodes error. I'm wondering if commit dereferences some nodes which make it impossible for the shutdown process to access subtries of that node for flushing.

Also there's the possibility that the block is reorged shortly after being flushed