### PR TITLE
Docs update- rpc server

### DIFF
--- a/docs/_rpc/server.md
+++ b/docs/_rpc/server.md
@@ -32,8 +32,8 @@ The default listening port is 8545. You can customize address and port using the
 
 JSON-RPC method namespaces must be whitelisted in order to be available through
 the HTTP server. An RPC error with error code `-32602` is generated if you call a
-namespace that isn't whitelisted. The default whitelist allows access to the "eth"
-and "shh" namespaces. To enable access to other APIs like account management ("personal")
+namespace that isn't whitelisted. The default whitelist allows access to the "eth", "net"
+and "web3" namespaces. To enable access to other APIs like account management ("personal")
 and debugging ("debug"), they must be configured via the `--http.api` flag. We do
 not recommend enabling such APIs over HTTP, however, since access to these
 methods increases the attack surface.

--- a/docs/_rpc/server.md
+++ b/docs/_rpc/server.md
@@ -33,10 +33,10 @@ The default listening port is 8545. You can customize address and port using the
 JSON-RPC method namespaces must be whitelisted in order to be available through
 the HTTP server. An RPC error with error code `-32602` is generated if you call a
 namespace that isn't whitelisted. The default whitelist allows access to the "eth", "net"
-and "web3" namespaces. To enable access to other APIs like account management ("personal")
-and debugging ("debug"), they must be configured via the `--http.api` flag. We do
-not recommend enabling such APIs over HTTP, however, since access to these
-methods increases the attack surface.
+and "web3" namespaces. To overwrite the default whitelist and enable access to other APIs 
+like account management ("personal") and debugging ("debug"), they must be configured via the 
+`--http.api` flag. We do not recommend enabling such APIs over HTTP, however, 
+since access to these methods increases the attack surface.
 
     geth --http --http.api personal,eth,net,web3
 


### PR DESCRIPTION
The rpc docs list "eth" and "shh" as the default namespaces, whereas the actual default namespaces are "eth", "web3" and "net".  Also want to explicitly mention the http.api flag will overwrite the default namespaces.

https://github.com/ethereum/go-ethereum/blob/ca298a28210622ddb18f2ec12b3ab7bf0f8d733c/cmd/geth/config.go#L114
https://github.com/ethereum/go-ethereum/blob/ca298a28210622ddb18f2ec12b3ab7bf0f8d733c/node/defaults.go#L56
