### PR TITLE
p2p: type DiscSubprotocolError as DiscReason

### DIFF
--- a/p2p/peer_error.go
+++ b/p2p/peer_error.go
@@ -69,7 +69,7 @@ const (
 	DiscUnexpectedIdentity
 	DiscSelf
 	DiscReadTimeout
-	DiscSubprotocolError = 0x10
+	DiscSubprotocolError = DiscReason(0x10)
 )
 
 var discReasonToString = [...]string{


### PR DESCRIPTION
`DiscSubprotocolError` was incorrectly typed as `int`; this change correctly types it as `DiscReason`.