### PR TITLE
Expose totalDifficulty in go-ethereum client

### DIFF
--- a/core/types/block.go
+++ b/core/types/block.go
@@ -290,11 +290,12 @@ func (b *Block) Transaction(hash common.Hash) *Transaction {
 	return nil
 }
 
-func (b *Block) Number() *big.Int     { return new(big.Int).Set(b.header.Number) }
-func (b *Block) GasLimit() uint64     { return b.header.GasLimit }
-func (b *Block) GasUsed() uint64      { return b.header.GasUsed }
-func (b *Block) Difficulty() *big.Int { return new(big.Int).Set(b.header.Difficulty) }
-func (b *Block) Time() uint64         { return b.header.Time }
+func (b *Block) Number() *big.Int          { return new(big.Int).Set(b.header.Number) }
+func (b *Block) GasLimit() uint64          { return b.header.GasLimit }
+func (b *Block) GasUsed() uint64           { return b.header.GasUsed }
+func (b *Block) Difficulty() *big.Int      { return new(big.Int).Set(b.header.Difficulty) }
+func (b *Block) TotalDifficulty() *big.Int { return b.td }
+func (b *Block) Time() uint64              { return b.header.Time }
 
 func (b *Block) NumberU64() uint64        { return b.header.Number.Uint64() }
 func (b *Block) MixDigest() common.Hash   { return b.header.MixDigest }


### PR DESCRIPTION
This PR contains API to expose totalDifficulty in go-ethereum client. 
APIs like JSON-RPC, web3.js all expose totalDifficulty, but somehow go-ethereum was not exposing it.
Block object was populated with totalDifficulty as a private field but was not used anywhere.
