### PR TITLE
build: usage of opencontainers labels

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,3 @@
-# Support setting various labels on the final image
-ARG COMMIT=""
-ARG VERSION=""
-ARG BUILDNUM=""
-
 # Build Geth in a stock Go builder container
 FROM golang:1.18-alpine as builder
 
@@ -20,9 +15,14 @@ COPY --from=builder /go-ethereum/build/bin/geth /usr/local/bin/
 EXPOSE 8545 8546 30303 30303/udp
 ENTRYPOINT ["geth"]
 
-# Add some metadata labels to help programatic image consumption
-ARG COMMIT=""
-ARG VERSION=""
-ARG BUILDNUM=""
+# Add some metadata labels to help programmatic image consumption
+ARG BUILDNUM
+ARG COMMIT
+ARG VERSION
 
-LABEL commit="$COMMIT" version="$VERSION" buildnum="$BUILDNUM"
+LABEL org.opencontainers.image.build-number="$BUILDNUM"
+LABEL org.opencontainers.image.description="Geth is a full node Ethereum implementation written in Go."
+LABEL org.opencontainers.image.revision="$COMMIT"
+LABEL org.opencontainers.image.source="https://github.com/ethereum/go-ethereum"
+LABEL org.opencontainers.image.title="Geth"
+LABEL org.opencontainers.image.version="$VERSION"

--- a/Dockerfile.alltools
+++ b/Dockerfile.alltools
@@ -1,8 +1,3 @@
-# Support setting various labels on the final image
-ARG COMMIT=""
-ARG VERSION=""
-ARG BUILDNUM=""
-
 # Build Geth in a stock Go builder container
 FROM golang:1.18-alpine as builder
 
@@ -19,9 +14,14 @@ COPY --from=builder /go-ethereum/build/bin/* /usr/local/bin/
 
 EXPOSE 8545 8546 30303 30303/udp
 
-# Add some metadata labels to help programatic image consumption
-ARG COMMIT=""
-ARG VERSION=""
-ARG BUILDNUM=""
+# Add some metadata labels to help programmatic image consumption
+ARG COMMIT
+ARG VERSION
+ARG BUILDNUM
 
-LABEL commit="$COMMIT" version="$VERSION" buildnum="$BUILDNUM"
+LABEL org.opencontainers.image.build-number="$BUILDNUM"
+LABEL org.opencontainers.image.description="Geth is a full node Ethereum implementation written in Go."
+LABEL org.opencontainers.image.revision="$COMMIT"
+LABEL org.opencontainers.image.source="https://github.com/ethereum/go-ethereum"
+LABEL org.opencontainers.image.title="Geth alltools"
+LABEL org.opencontainers.image.version="$VERSION"

--- a/build/ci.go
+++ b/build/ci.go
@@ -571,7 +571,7 @@ func doDocker(cmdline []string) {
 							mismatch = true
 							break
 						}
-						buildnum, err := exec.Command("docker", "inspect", "--format", "{{index .Config.Labels \"buildnum\"}}", img).CombinedOutput()
+						buildnum, err := exec.Command("docker", "inspect", "--format", "{{index .Config.Labels \"org.opencontainers.image.build-number\"}}", img).CombinedOutput()
 						if err != nil {
 							log.Fatalf("Failed to inspect container: %v\nOutput: %s", err, string(buildnum))
 						}


### PR DESCRIPTION
Following Cloud Native recommendations, this PR follows the Open Container's [labels](https://github.com/opencontainers/image-spec/blob/main/annotations.md).
The rationale is compatibility with Cloud Native tools. [[1]](https://snyk.io/blog/how-and-when-to-use-docker-labels-oci-container-annotations/)