### PR TITLE
cmd/geth: add banner for devmode on console

### DIFF
--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -291,6 +291,12 @@ func prepare(ctx *cli.Context) {
 
 	case ctx.GlobalIsSet(utils.DeveloperFlag.Name):
 		log.Info("Starting Geth in ephemeral dev mode...")
+		log.Warn("You are running Geth in --dev mode. Please note the following:")
+		log.Warn("\t1. This mode is only intended for fast, iterative development without assumptions on security or persistence.")
+		log.Warn("\t2. The database is created in memory unless specified otherwise. Therefore, shutting down your computer or losing power will wipe your entire block data and chain state for your dev environment.")
+		log.Warn("\t3. A random, pre-allocated developer account will be available and unlocked as eth.coinbase, which can be used for testing. The random dev account is temporary, stored on a ramdisk, and will be lost if your machine is restarted.")
+		log.Warn("\t4. Mining is enabled by default. However, the client will only seal blocks if transactions are pending in the mempool. The miner's minimum accepted gas price is 1.")
+		log.Warn("\t5. Networking is disabled; there is no listen-address, the maximum number of peers is set to 0, and discovery is disabled.")
 
 	case !ctx.GlobalIsSet(utils.NetworkIdFlag.Name):
 		log.Info("Starting Geth on Ethereum mainnet...")

--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -291,12 +291,21 @@ func prepare(ctx *cli.Context) {
 
 	case ctx.GlobalIsSet(utils.DeveloperFlag.Name):
 		log.Info("Starting Geth in ephemeral dev mode...")
-		log.Warn("You are running Geth in --dev mode. Please note the following:")
-		log.Warn("\t1. This mode is only intended for fast, iterative development without assumptions on security or persistence.")
-		log.Warn("\t2. The database is created in memory unless specified otherwise. Therefore, shutting down your computer or losing power will wipe your entire block data and chain state for your dev environment.")
-		log.Warn("\t3. A random, pre-allocated developer account will be available and unlocked as eth.coinbase, which can be used for testing. The random dev account is temporary, stored on a ramdisk, and will be lost if your machine is restarted.")
-		log.Warn("\t4. Mining is enabled by default. However, the client will only seal blocks if transactions are pending in the mempool. The miner's minimum accepted gas price is 1.")
-		log.Warn("\t5. Networking is disabled; there is no listen-address, the maximum number of peers is set to 0, and discovery is disabled.")
+		log.Warn(`You are running Geth in --dev mode. Please note the following:
+
+  1. This mode is only intended for fast, iterative development without assumptions on
+     security or persistence.
+  2. The database is created in memory unless specified otherwise. Therefore, shutting down
+     your computer or losing power will wipe your entire block data and chain state for
+     your dev environment.
+  3. A random, pre-allocated developer account will be available and unlocked as
+     eth.coinbase, which can be used for testing. The random dev account is temporary,
+     stored on a ramdisk, and will be lost if your machine is restarted.
+  4. Mining is enabled by default. However, the client will only seal blocks if transactions
+     are pending in the mempool. The miner's minimum accepted gas price is 1.
+  5. Networking is disabled; there is no listen-address, the maximum number of peers is set
+     to 0, and discovery is disabled.
+`)
 
 	case !ctx.GlobalIsSet(utils.NetworkIdFlag.Name):
 		log.Info("Starting Geth on Ethereum mainnet...")


### PR DESCRIPTION
fixes #18243

> You are running Geth in --dev mode. Please note the following:
>      1.  This mode is only intended for fast, iterative developmentwithout assumptions on security or persistence.
>     2.  The database is created in memory unless specified otherwise. Therefore, shutting down your computer or losing power will wipe your entire block data and chain state for your dev environment.
 >     3.  A random, pre-allocated developer account will be available andunlocked as eth.coinbase, which can be used for testing. Therandom dev account is temporary, stored on a ramdisk, and willbe lost if your machine is restarted.
>      4.  Mining is enabled by default. However, the client will only seal blocks if transactions are pending in the mempool. The miner's minimum accepted gas price is 1.
>      5.  Networking is disabled; there is no listen-address, the maximum number of peers is set to 0, and discovery is disabled.