### PR TITLE
cmd/geth, core/state/snapshot: rework journal loading, implement account-check

### DIFF
--- a/cmd/geth/snapshot.go
+++ b/cmd/geth/snapshot.go
@@ -109,16 +109,9 @@ data, and verifies that all snapshot storage data has a corresponding account.
 				ArgsUsage: "<address | hash>",
 				Action:    utils.MigrateFlags(checkAccount),
 				Category:  "MISCELLANEOUS COMMANDS",
-				Flags: []cli.Flag{
-					utils.DataDirFlag,
-					utils.AncientFlag,
-					utils.RopstenFlag,
-					utils.SepoliaFlag,
-					utils.RinkebyFlag,
-					utils.GoerliFlag,
-				},
+				Flags: utils.GroupFlags(utils.NetworkFlags, utils.DatabasePathFlags),
 				Description: `
-geth snapshot inspect-account <address> checks all snapshot layers and prints out
+geth snapshot inspect-account <address | hash> checks all snapshot layers and prints out
 information about the specified address. 
 `,
 			},
@@ -543,8 +536,10 @@ func checkAccount(ctx *cli.Context) error {
 	if ctx.NArg() != 1 {
 		return errors.New("need <address|hash> arg")
 	}
-	var addr common.Address
-	var hash common.Hash
+	var (
+		hash common.Hash
+		addr common.Address
+	)
 	switch len(ctx.Args()[0]) {
 	case 40, 42:
 		addr = common.HexToAddress(ctx.Args()[0])

--- a/cmd/geth/snapshot.go
+++ b/cmd/geth/snapshot.go
@@ -109,7 +109,7 @@ data, and verifies that all snapshot storage data has a corresponding account.
 				ArgsUsage: "<address | hash>",
 				Action:    utils.MigrateFlags(checkAccount),
 				Category:  "MISCELLANEOUS COMMANDS",
-				Flags: utils.GroupFlags(utils.NetworkFlags, utils.DatabasePathFlags),
+				Flags:     utils.GroupFlags(utils.NetworkFlags, utils.DatabasePathFlags),
 				Description: `
 geth snapshot inspect-account <address | hash> checks all snapshot layers and prints out
 information about the specified address. 

--- a/core/state/snapshot/dangling.go
+++ b/core/state/snapshot/dangling.go
@@ -18,16 +18,13 @@ package snapshot
 
 import (
 	"bytes"
-	"errors"
 	"fmt"
-	"io"
 	"time"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/rawdb"
 	"github.com/ethereum/go-ethereum/ethdb"
 	"github.com/ethereum/go-ethereum/log"
-	"github.com/ethereum/go-ethereum/rlp"
 )
 
 // CheckDanglingStorage iterates the snap storage data, and verifies that all
@@ -75,81 +72,16 @@ func checkDanglingDiskStorage(chaindb ethdb.KeyValueStore) error {
 // checkDanglingMemStorage checks if there is any 'dangling' storage in the journalled
 // snapshot difflayers.
 func checkDanglingMemStorage(db ethdb.KeyValueStore) error {
-	var (
-		start   = time.Now()
-		journal = rawdb.ReadSnapshotJournal(db)
-	)
-	if len(journal) == 0 {
-		log.Warn("Loaded snapshot journal", "diffs", "missing")
+	log.Info("Checking dangling journalled storage")
+	start := time.Now()
+	iterateJournal(db, func(pRoot, root common.Hash, destructs map[common.Hash]struct{}, accounts map[common.Hash][]byte, storage map[common.Hash]map[common.Hash][]byte) error {
+		for accHash := range storage {
+			if _, ok := accounts[accHash]; !ok {
+				log.Error("Dangling storage - missing account", "account", fmt.Sprintf("%#x", accHash), "root", root)
+			}
+		}
 		return nil
-	}
-	r := rlp.NewStream(bytes.NewReader(journal), 0)
-	// Firstly, resolve the first element as the journal version
-	version, err := r.Uint()
-	if err != nil {
-		log.Warn("Failed to resolve the journal version", "error", err)
-		return nil
-	}
-	if version != journalVersion {
-		log.Warn("Discarded the snapshot journal with wrong version", "required", journalVersion, "got", version)
-		return nil
-	}
-	// Secondly, resolve the disk layer root, ensure it's continuous
-	// with disk layer. Note now we can ensure it's the snapshot journal
-	// correct version, so we expect everything can be resolved properly.
-	var root common.Hash
-	if err := r.Decode(&root); err != nil {
-		return errors.New("missing disk layer root")
-	}
-	// The diff journal is not matched with disk, discard them.
-	// It can happen that Geth crashes without persisting the latest
-	// diff journal.
-	// Load all the snapshot diffs from the journal
-	if err := checkDanglingJournalStorage(r); err != nil {
-		return err
-	}
+	})
 	log.Info("Verified the snapshot journalled storage", "time", common.PrettyDuration(time.Since(start)))
 	return nil
-}
-
-// loadDiffLayer reads the next sections of a snapshot journal, reconstructing a new
-// diff and verifying that it can be linked to the requested parent.
-func checkDanglingJournalStorage(r *rlp.Stream) error {
-	for {
-		// Read the next diff journal entry
-		var root common.Hash
-		if err := r.Decode(&root); err != nil {
-			// The first read may fail with EOF, marking the end of the journal
-			if err == io.EOF {
-				return nil
-			}
-			return fmt.Errorf("load diff root: %v", err)
-		}
-		var destructs []journalDestruct
-		if err := r.Decode(&destructs); err != nil {
-			return fmt.Errorf("load diff destructs: %v", err)
-		}
-		var accounts []journalAccount
-		if err := r.Decode(&accounts); err != nil {
-			return fmt.Errorf("load diff accounts: %v", err)
-		}
-		accountData := make(map[common.Hash][]byte)
-		for _, entry := range accounts {
-			if len(entry.Blob) > 0 { // RLP loses nil-ness, but `[]byte{}` is not a valid item, so reinterpret that
-				accountData[entry.Hash] = entry.Blob
-			} else {
-				accountData[entry.Hash] = nil
-			}
-		}
-		var storage []journalStorage
-		if err := r.Decode(&storage); err != nil {
-			return fmt.Errorf("load diff storage: %v", err)
-		}
-		for _, entry := range storage {
-			if _, ok := accountData[entry.Hash]; !ok {
-				log.Error("Dangling storage - missing account", "account", fmt.Sprintf("%#x", entry.Hash), "root", root)
-				return fmt.Errorf("dangling journal snapshot storage account %#x", entry.Hash)
-			}
-		}
-	}
 }

--- a/core/state/snapshot/generate_test.go
+++ b/core/state/snapshot/generate_test.go
@@ -171,7 +171,7 @@ func checkSnapRoot(t *testing.T, snap *diskLayer, trieRoot common.Hash) {
 		t.Fatalf("snaproot: %#x != trieroot #%x", snapRoot, trieRoot)
 	}
 	if err := CheckDanglingStorage(snap.diskdb); err != nil {
-		t.Fatalf("Detected dangling storages %v", err)
+		t.Fatalf("Detected dangling storages: %v", err)
 	}
 }
 

--- a/core/state/snapshot/journal.go
+++ b/core/state/snapshot/journal.go
@@ -108,44 +108,16 @@ func loadAndParseJournal(db ethdb.KeyValueStore, base *diskLayer) (snapshot, jou
 	// So if there is no journal, or the journal is invalid(e.g. the journal
 	// is not matched with disk layer; or the it's the legacy-format journal,
 	// etc.), we just discard all diffs and try to recover them later.
-	journal := rawdb.ReadSnapshotJournal(db)
-	if len(journal) == 0 {
-		log.Warn("Loaded snapshot journal", "diskroot", base.root, "diffs", "missing")
-		return base, generator, nil
-	}
-	r := rlp.NewStream(bytes.NewReader(journal), 0)
-
-	// Firstly, resolve the first element as the journal version
-	version, err := r.Uint()
+	var parentLayer snapshot
+	parentLayer = base
+	err := iterateJournal(db, func(parent common.Hash, root common.Hash, destructSet map[common.Hash]struct{}, accountData map[common.Hash][]byte, storageData map[common.Hash]map[common.Hash][]byte) error {
+		parentLayer = newDiffLayer(parentLayer, root, destructSet, accountData, storageData)
+		return nil
+	})
 	if err != nil {
-		log.Warn("Failed to resolve the journal version", "error", err)
 		return base, generator, nil
 	}
-	if version != journalVersion {
-		log.Warn("Discarded the snapshot journal with wrong version", "required", journalVersion, "got", version)
-		return base, generator, nil
-	}
-	// Secondly, resolve the disk layer root, ensure it's continuous
-	// with disk layer. Note now we can ensure it's the snapshot journal
-	// correct version, so we expect everything can be resolved properly.
-	var root common.Hash
-	if err := r.Decode(&root); err != nil {
-		return nil, journalGenerator{}, errors.New("missing disk layer root")
-	}
-	// The diff journal is not matched with disk, discard them.
-	// It can happen that Geth crashes without persisting the latest
-	// diff journal.
-	if !bytes.Equal(root.Bytes(), base.root.Bytes()) {
-		log.Warn("Loaded snapshot journal", "diskroot", base.root, "diffs", "unmatched")
-		return base, generator, nil
-	}
-	// Load all the snapshot diffs from the journal
-	snapshot, err := loadDiffLayer(base, r)
-	if err != nil {
-		return nil, journalGenerator{}, err
-	}
-	log.Debug("Loaded snapshot journal", "diskroot", base.root, "diffhead", snapshot.Root())
-	return snapshot, generator, nil
+	return parentLayer, generator, nil
 }
 
 // loadSnapshot loads a pre-existing state snapshot backed by a key-value store.
@@ -216,57 +188,6 @@ func loadSnapshot(diskdb ethdb.KeyValueStore, triedb *trie.Database, cache int, 
 		})
 	}
 	return snapshot, false, nil
-}
-
-// loadDiffLayer reads the next sections of a snapshot journal, reconstructing a new
-// diff and verifying that it can be linked to the requested parent.
-func loadDiffLayer(parent snapshot, r *rlp.Stream) (snapshot, error) {
-	// Read the next diff journal entry
-	var root common.Hash
-	if err := r.Decode(&root); err != nil {
-		// The first read may fail with EOF, marking the end of the journal
-		if err == io.EOF {
-			return parent, nil
-		}
-		return nil, fmt.Errorf("load diff root: %v", err)
-	}
-	var destructs []journalDestruct
-	if err := r.Decode(&destructs); err != nil {
-		return nil, fmt.Errorf("load diff destructs: %v", err)
-	}
-	destructSet := make(map[common.Hash]struct{})
-	for _, entry := range destructs {
-		destructSet[entry.Hash] = struct{}{}
-	}
-	var accounts []journalAccount
-	if err := r.Decode(&accounts); err != nil {
-		return nil, fmt.Errorf("load diff accounts: %v", err)
-	}
-	accountData := make(map[common.Hash][]byte)
-	for _, entry := range accounts {
-		if len(entry.Blob) > 0 { // RLP loses nil-ness, but `[]byte{}` is not a valid item, so reinterpret that
-			accountData[entry.Hash] = entry.Blob
-		} else {
-			accountData[entry.Hash] = nil
-		}
-	}
-	var storage []journalStorage
-	if err := r.Decode(&storage); err != nil {
-		return nil, fmt.Errorf("load diff storage: %v", err)
-	}
-	storageData := make(map[common.Hash]map[common.Hash][]byte)
-	for _, entry := range storage {
-		slots := make(map[common.Hash][]byte)
-		for i, key := range entry.Keys {
-			if len(entry.Vals[i]) > 0 { // RLP loses nil-ness, but `[]byte{}` is not a valid item, so reinterpret that
-				slots[key] = entry.Vals[i]
-			} else {
-				slots[key] = nil
-			}
-		}
-		storageData[entry.Hash] = slots
-	}
-	return loadDiffLayer(newDiffLayer(parent, root, destructSet, accountData, storageData), r)
 }
 
 // Journal terminates any in-progress snapshot generation, also implicitly pushing
@@ -344,4 +265,157 @@ func (dl *diffLayer) Journal(buffer *bytes.Buffer) (common.Hash, error) {
 	}
 	log.Debug("Journalled diff layer", "root", dl.root, "parent", dl.parent.Root())
 	return base, nil
+}
+
+// journalCallback is a function which is invoked by iterateJournal, every
+// time a difflayer is loaded from disk.
+type journalCallback = func(parent common.Hash, root common.Hash, destructs map[common.Hash]struct{}, accounts map[common.Hash][]byte, storage map[common.Hash]map[common.Hash][]byte) error
+
+// iterateJournal iterates through the journalled difflayers, loading them from
+// the datababase, and invoking the callback for each loaded layer.
+// The order is incremental; starting with the bottom-most difflayer, going towards
+// the most recent layer.
+// This method returns error either if there was some error reading from disk,
+// OR if the callback returns an error when invoked.
+func iterateJournal(db ethdb.KeyValueReader, callback journalCallback) error {
+	journal := rawdb.ReadSnapshotJournal(db)
+	if len(journal) == 0 {
+		log.Warn("Loaded snapshot journal", "diffs", "missing")
+		return errors.New("missing journal")
+	}
+	r := rlp.NewStream(bytes.NewReader(journal), 0)
+	// Firstly, resolve the first element as the journal version
+	version, err := r.Uint()
+	if err != nil {
+		log.Warn("Failed to resolve the journal version", "error", err)
+		return errors.New("failed to resolve journal version")
+	}
+	if version != journalVersion {
+		log.Warn("Discarded the snapshot journal with wrong version", "required", journalVersion, "got", version)
+		return errors.New("wrong journal version")
+	}
+	// Secondly, resolve the disk layer root, ensure it's continuous
+	// with disk layer. Note now we can ensure it's the snapshot journal
+	// correct version, so we expect everything can be resolved properly.
+	var parent common.Hash
+	if err := r.Decode(&parent); err != nil {
+		return errors.New("missing disk layer root")
+	}
+	if baseRoot := rawdb.ReadSnapshotRoot(db); baseRoot != parent {
+		log.Warn("Loaded snapshot journal", "diskroot", baseRoot, "diffs", "unmatched")
+		return fmt.Errorf("mismatched disk and diff layers")
+	}
+	for {
+		var (
+			root        common.Hash
+			destructs   []journalDestruct
+			accounts    []journalAccount
+			storage     []journalStorage
+			destructSet = make(map[common.Hash]struct{})
+			accountData = make(map[common.Hash][]byte)
+			storageData = make(map[common.Hash]map[common.Hash][]byte)
+		)
+		// Read the next diff journal entry
+		if err := r.Decode(&root); err != nil {
+			// The first read may fail with EOF, marking the end of the journal
+			if errors.Is(err, io.EOF) {
+				return nil
+			}
+			return fmt.Errorf("load diff root: %v", err)
+		}
+		if err := r.Decode(&destructs); err != nil {
+			return fmt.Errorf("load diff destructs: %v", err)
+		}
+		if err := r.Decode(&accounts); err != nil {
+			return fmt.Errorf("load diff accounts: %v", err)
+		}
+		if err := r.Decode(&storage); err != nil {
+			return fmt.Errorf("load diff storage: %v", err)
+		}
+		for _, entry := range destructs {
+			destructSet[entry.Hash] = struct{}{}
+		}
+		for _, entry := range accounts {
+			if len(entry.Blob) > 0 { // RLP loses nil-ness, but `[]byte{}` is not a valid item, so reinterpret that
+				accountData[entry.Hash] = entry.Blob
+			} else {
+				accountData[entry.Hash] = nil
+			}
+		}
+		for _, entry := range storage {
+			slots := make(map[common.Hash][]byte)
+			for i, key := range entry.Keys {
+				if len(entry.Vals[i]) > 0 { // RLP loses nil-ness, but `[]byte{}` is not a valid item, so reinterpret that
+					slots[key] = entry.Vals[i]
+				} else {
+					slots[key] = nil
+				}
+			}
+			storageData[entry.Hash] = slots
+		}
+		if err := callback(parent, root, destructSet, accountData, storageData); err != nil {
+			return err
+		}
+		parent = root
+	}
+}
+
+// CheckJournalAccount shows information about an account, from the disk layer and
+// up through the diff layers.
+func CheckJournalAccount(db ethdb.KeyValueStore, hash common.Hash) error {
+	// Look up the disk layer first
+	baseRoot := rawdb.ReadSnapshotRoot(db)
+	fmt.Printf("Disklayer: Root: %x\n", baseRoot)
+	if data := rawdb.ReadAccountSnapshot(db, hash); data != nil {
+		account := new(Account)
+		if err := rlp.DecodeBytes(data, account); err != nil {
+			panic(err)
+		}
+		fmt.Printf("\taccount.nonce: %d\n", account.Nonce)
+		fmt.Printf("\taccount.balance: %x\n", account.Balance)
+		fmt.Printf("\taccount.root: %x\n", account.Root)
+		fmt.Printf("\taccount.codehash: %x\n", account.CodeHash)
+	}
+	// Check storage
+	{
+		it := rawdb.NewKeyLengthIterator(db.NewIterator(append(rawdb.SnapshotStoragePrefix, hash.Bytes()...), nil), 1+2*common.HashLength)
+		fmt.Printf("\tStorage:\n")
+		for it.Next() {
+			slot := it.Key()[33:]
+			fmt.Printf("\t\t%x: %x\n", slot, it.Value())
+		}
+		it.Release()
+	}
+	var depth = 0
+
+	return iterateJournal(db, func(pRoot, root common.Hash, destructs map[common.Hash]struct{}, accounts map[common.Hash][]byte, storage map[common.Hash]map[common.Hash][]byte) error {
+		_, a := accounts[hash]
+		_, b := destructs[hash]
+		_, c := storage[hash]
+		depth++
+		if !a && !b && !c {
+			return nil
+		}
+		fmt.Printf("Disklayer+%d: Root: %x, parent %x\n", depth, root, pRoot)
+		if data, ok := accounts[hash]; ok {
+			account := new(Account)
+			if err := rlp.DecodeBytes(data, account); err != nil {
+				panic(err)
+			}
+			fmt.Printf("\taccount.nonce: %d\n", account.Nonce)
+			fmt.Printf("\taccount.balance: %x\n", account.Balance)
+			fmt.Printf("\taccount.root: %x\n", account.Root)
+			fmt.Printf("\taccount.codehash: %x\n", account.CodeHash)
+		}
+		if _, ok := destructs[hash]; ok {
+			fmt.Printf("\t Destructed!")
+		}
+		if data, ok := storage[hash]; ok {
+			fmt.Printf("\tStorage\n")
+			for k, v := range data {
+				fmt.Printf("\t\t%x: %x\n", k, v)
+			}
+		}
+		return nil
+	})
 }

--- a/core/state/snapshot/journal.go
+++ b/core/state/snapshot/journal.go
@@ -35,9 +35,6 @@ import (
 
 const journalVersion uint64 = 0
 
-// errNoJournal is returned if there is no snapshot journal in disk.
-var errNoJournal = errors.New("snapshot journal is not-existent")
-
 // journalGenerator is a disk layer entry containing the generator progress marker.
 type journalGenerator struct {
 	// Indicator that whether the database was in progress of being wiped.
@@ -283,7 +280,7 @@ func iterateJournal(db ethdb.KeyValueReader, callback journalCallback) error {
 	journal := rawdb.ReadSnapshotJournal(db)
 	if len(journal) == 0 {
 		log.Warn("Loaded snapshot journal", "diffs", "missing")
-		return errNoJournal
+		return nil
 	}
 	r := rlp.NewStream(bytes.NewReader(journal), 0)
 	// Firstly, resolve the first element as the journal version

--- a/core/state/snapshot/utils.go
+++ b/core/state/snapshot/utils.go
@@ -33,7 +33,7 @@ import (
 // storage also has corresponding account data.
 func CheckDanglingStorage(chaindb ethdb.KeyValueStore) error {
 	if err := checkDanglingDiskStorage(chaindb); err != nil {
-		return err
+		log.Error("Database check error", "err", err)
 	}
 	return checkDanglingMemStorage(chaindb)
 }
@@ -84,7 +84,7 @@ func checkDanglingMemStorage(db ethdb.KeyValueStore) error {
 		}
 		return nil
 	})
-	if !errors.Is(err, errNoJournal) {
+	if err != nil {
 		log.Info("Failed to resolve snapshot journal", "err", err)
 		return err
 	}

--- a/core/state/snapshot/utils.go
+++ b/core/state/snapshot/utils.go
@@ -18,7 +18,6 @@ package snapshot
 
 import (
 	"bytes"
-	"errors"
 	"fmt"
 	"time"
 
@@ -120,7 +119,7 @@ func CheckJournalAccount(db ethdb.KeyValueStore, hash common.Hash) error {
 	}
 	var depth = 0
 
-	err := iterateJournal(db, func(pRoot, root common.Hash, destructs map[common.Hash]struct{}, accounts map[common.Hash][]byte, storage map[common.Hash]map[common.Hash][]byte) error {
+	return iterateJournal(db, func(pRoot, root common.Hash, destructs map[common.Hash]struct{}, accounts map[common.Hash][]byte, storage map[common.Hash]map[common.Hash][]byte) error {
 		_, a := accounts[hash]
 		_, b := destructs[hash]
 		_, c := storage[hash]
@@ -150,8 +149,4 @@ func CheckJournalAccount(db ethdb.KeyValueStore, hash common.Hash) error {
 		}
 		return nil
 	})
-	if errors.Is(err, errNoJournal) {
-		return nil
-	}
-	return err
 }


### PR DESCRIPTION
This PR does a couple of things. 
It changes the journal loading, to make use of an iterator. The same iterator approach is used for 
- loading difflayers
- `account-check`
- `check-dangling-storage`. 

OBS: The dangerous part is the changes to _loading_ difflayers,  which, as opposed to the other changes, could actually _break_ geth if it's erroneously implemented.

## `geth snapshot inspect-account`

This feature makes it possible to inspect the layer-content for a given account (address). 
It starts at the disk layer, and prints out the data (account + storage). Then goes through the journalled difflayers, and shows the data in those too. 

The example run below is from one of the problematic goerli shadowfork nodes. It can be seen that the disk layer has a lot of dangling storage data, and a much more recent difflayer creates the account and sets one of the slots. 

```
[user@work goerlishadowfork]$ geth --datadir ./goerli-shadow-fork-3-lighthouse-geth-3/eth1data/geth snapshot inspect-account 0x2072953BEF2Be2C2c30841bf25b02A38f8E809ca


Disklayer: Root: 99530236a4f4e9967f0256e5a83558b45b234d9c968b96173184382232cdefb0
  Storage:
    024612386cd1555abe01c2c74d73fba5f056b16eda9580af03207d09dea1c458: 01
    0eb5be412f275a18f6e4d622aee4ff40b21467c926224771b782d4c095d1444b: 01
    28f3f3798d3eb3b9a1b1a0c9575e875d238bbad3b8a1a2f7d47f92f1ae8d8826: 94408b33def162c6e48dbb823cef9ba7a0181dc961
    36c013283a3ef779246660cab8d0296ce487110262b17dd51cbc31c772820d62: 01
    384561ea4488aa115f1cf091d5bbb1811460f0b9686e4cadc88ec43d43c414d0: 01
    405787fa12a823e0f2b7631cc41b3ba8828b3321ca811111fa75cd3aa3bb5ace: 05
    51017317195200950c768c2e0ae5c1fcbc6b51dca10fcbfac3f725914f0ef763: 94408b33def162c6e48dbb823cef9ba7a0181dc961
    8a35acfbc15ff81a39ae7d344fd709f28e8600b4aa8c65c6b64bfe7fe36bd19b: 01
    a66cc928b5edb82af9bd49922954155ab7b0942694bea4ce44661d9a8736c688: 64
    c2575a0e9e593c00f959f8c92f12db2869c3395a3b0502d05e2516446f71f85b: 01
Disklayer+97: Root: cc1e9f38fc05af1e280e8788088dacbe39e8036f00253a1081b8dd88762ee606, parent 79a746624e970b4b11a76e227d91973988f6a8ec2b1f5648f6bf5b33925a3619
  account.nonce: 1
  account.balance: 0
  account.root: c8674989c91fc59d70d10d898c48ee8c0f437132c23983e9f35e449f39fd31fd
  account.codehash: 7802668c64ffedfec446c2d68110b213b8e0d18919bf859ccca38c7f7a68a316
  Storage
    8a35acfbc15ff81a39ae7d344fd709f28e8600b4aa8c65c6b64bfe7fe36bd19b: 02

```