### PR TITLE
eth/fetcher: ensure tx fetcher requests transactions from a peer in the order they were announced

### DIFF
--- a/eth/fetcher/tx_fetcher_test.go
+++ b/eth/fetcher/tx_fetcher_test.go
@@ -481,7 +481,7 @@ func TestTransactionFetcherMissingRescheduling(t *testing.T) {
 			},
 			// Deliver the middle transaction requested, the one before which
 			// should be dropped and the one after re-requested.
-			doTxEnqueue{peer: "A", txs: []*types.Transaction{testTxs[0]}, direct: true}, // This depends on the deterministic random
+			doTxEnqueue{peer: "A", txs: []*types.Transaction{testTxs[1]}, direct: true}, // This depends on the deterministic random
 			isScheduled{
 				tracking: map[string][]common.Hash{
 					"A": {testTxsHashes[2]},
@@ -785,7 +785,8 @@ func TestTransactionFetcherRateLimiting(t *testing.T) {
 					"A": hashes,
 				},
 				fetching: map[string][]common.Hash{
-					"A": hashes[1643 : 1643+maxTxRetrievals],
+					//"A": hashes[1643 : 1643+maxTxRetrievals],
+					"A": hashes[:maxTxRetrievals],
 				},
 			},
 		},
@@ -804,6 +805,7 @@ func TestTransactionFetcherDoSProtection(t *testing.T) {
 	for i := 0; i < maxTxAnnounces+1; i++ {
 		hashesB = append(hashesB, common.Hash{0x02, byte(i / 256), byte(i % 256)})
 	}
+
 	testTransactionFetcherParallel(t, txFetcherTest{
 		init: func() *TxFetcher {
 			return NewTxFetcher(
@@ -833,8 +835,8 @@ func TestTransactionFetcherDoSProtection(t *testing.T) {
 					"B": hashesB[:maxTxAnnounces/2-1],
 				},
 				fetching: map[string][]common.Hash{
-					"A": hashesA[1643 : 1643+maxTxRetrievals],
-					"B": append(append([]common.Hash{}, hashesB[maxTxAnnounces/2-3:maxTxAnnounces/2-1]...), hashesB[:maxTxRetrievals-2]...),
+					"A": hashesA[:maxTxRetrievals],
+					"B": hashesB[:maxTxRetrievals],
 				},
 			},
 			// Ensure that adding even one more hash results in dropping the hash
@@ -851,8 +853,8 @@ func TestTransactionFetcherDoSProtection(t *testing.T) {
 					"B": hashesB[:maxTxAnnounces/2-1],
 				},
 				fetching: map[string][]common.Hash{
-					"A": hashesA[1643 : 1643+maxTxRetrievals],
-					"B": append(append([]common.Hash{}, hashesB[maxTxAnnounces/2-3:maxTxAnnounces/2-1]...), hashesB[:maxTxRetrievals-2]...),
+					"A": hashesA[:maxTxRetrievals],
+					"B": hashesB[:maxTxRetrievals],
 				},
 			},
 		},


### PR DESCRIPTION
This PR augments the trackers in the tx fetcher to remember the order in which txs were announced by a peer, and when requesting txs from that peer, it requests them in the order they were announced.

The rationale for this change is that it serves as a stop-gap solution for the issue encountered https://github.com/ethereum/go-ethereum/issues/22308 .

That issue can be reproduced as follows:
* send a bunch of transactions from the same account to node A
* node A announces these to node B (in nonce-ascending order if node A is geth)
* node B requests them in a different order than they were announced.
* node B receives the transactions, higher nonce txs fill up the queue slot for the account in the tx pool, and other lower-nonce transactions received are dropped.  This "nonce gap" causes node B to not accept any additional transactions for the account until it is restarted.

If we assume that peers are running Geth (which already announces txs in nonce-ascending order), then this issue can be mitigated somewhat by this PR.

However, there is a remaining problem:  If we are fetching transactions from multiple peers, and these transactions originate from the same account and have unique nonces (not replacement transactions), we cannot ensure they will be received and ingested in nonce-ascending order.  So the "nonce-gap" issue can still happen.

However, it is likely that most users who are trying to spam hundreds of transactions like this are operating on permissioned networks.  And it is reasonable to assume that they are broadcasting directly to a block-producing node.  So it is likely that at least one block producing node in the network will receive the txs in the correct order and include them in a block.

In this case, instead of the sending account being blocked from getting txs included, they will slowly be mined into the network (depending on how many block producer nodes received the txs in nonce-ascending order).  The account will become unstuck in a finite amount of time.