### PR TITLE
internal/ethapi: add debug_getRawReceipts RPC method

### DIFF
--- a/internal/web3ext/web3ext.go
+++ b/internal/web3ext/web3ext.go
@@ -234,6 +234,11 @@ web3._extend({
 			params: 1
 		}),
 		new web3._extend.Method({
+			name: 'getRawReceipts',
+			call: 'debug_getRawReceipts',
+			params: 1
+		}),
+		new web3._extend.Method({
 			name: 'setHead',
 			call: 'debug_setHead',
 			params: 1


### PR DESCRIPTION
@holiman this is a follow-on to https://github.com/ethereum/go-ethereum/pull/24741 (but stand-alone) that implements the two debug methods I mentioned here https://github.com/ethereum/go-ethereum/issues/24720#issuecomment-1106868099

I ended up going with an array of receipts rather than the original map idea, since in practice the map felt a little clunky.

```
> r = debug.getRawReceipts("0x59d58395078eb687813eeade09f4ccd3a40084e607c3b0e0b987794c12be48cc")
["0x02f901850182aebbb9010000800000000000000000000000000000000000000000100000020000000000000000000000000000008000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000008000000000000000000000000000000000000000100000000000000000000000000000000000000000000000000000000000000000000001000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000800000000000000400000000000000000f87cf87a94830bf80a3839b300291915e7c67b70d90823ffedf842a0e1fffcc4923d04b559f4d29a8bfc6cda04eb5b0d3c460751c2402c5c5cc9109ca00000000000000000000000001b57edab586cbdabd4d914869ae8bb78dbc05571a00000000000000000000000000000000000000000000000000de0b6b3a7640000"]
> debug.calculateReceiptsRoot(r)
"0x7800894d3a17b7f4ce8f17f96740e13696982605164eb4465bdd8a313d0953a5"
> eth.getBlockByHash("0x59d58395078eb687813eeade09f4ccd3a40084e607c3b0e0b987794c12be48cc").receiptsRoot
"0x7800894d3a17b7f4ce8f17f96740e13696982605164eb4465bdd8a313d0953a5"
```