### PR TITLE
core/vm/memory: fix Memory.Set32 use make fill with 0 to []byte is better

### DIFF
--- a/core/vm/memory.go
+++ b/core/vm/memory.go
@@ -22,6 +22,8 @@ import (
 	"github.com/holiman/uint256"
 )
 
+const bit32 = 32
+
 // Memory implements a simple memory model for the ethereum virtual machine.
 type Memory struct {
 	store       []byte
@@ -52,11 +54,12 @@ func (m *Memory) Set(offset, size uint64, value []byte) {
 func (m *Memory) Set32(offset uint64, val *uint256.Int) {
 	// length of store may never be less than offset + size.
 	// The store should be resized PRIOR to setting the memory
-	if offset+32 > uint64(len(m.store)) {
+	var empty = make([]byte, bit32)
+	if offset+bit32 > uint64(len(m.store)) {
 		panic("invalid memory: store empty")
 	}
 	// Zero the memory area
-	copy(m.store[offset:offset+32], []byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0})
+	copy(m.store[offset:offset+bit32], empty)
 	// Fill in relevant bits
 	val.WriteToSlice(m.store[offset:])
 }
@@ -68,7 +71,7 @@ func (m *Memory) Resize(size uint64) {
 	}
 }
 
-// Get returns offset + size as a new slice
+// GetCopy Get returns offset + size as a new slice
 func (m *Memory) GetCopy(offset, size int64) (cpy []byte) {
 	if size == 0 {
 		return nil
@@ -112,7 +115,7 @@ func (m *Memory) Print() {
 	fmt.Printf("### mem %d bytes ###\n", len(m.store))
 	if len(m.store) > 0 {
 		addr := 0
-		for i := 0; i+32 <= len(m.store); i += 32 {
+		for i := 0; i+bit32 <= len(m.store); i += bit32 {
 			fmt.Printf("%03d: % x\n", addr, m.store[i:i+32])
 			addr++
 		}


### PR DESCRIPTION
I think using make function fill []byte is obvious than literal,
Memory.GetCopy add "GetCopy" prefix to comment.