### PR TITLE
eth/protocols/snap: sort trienode heal requests by path

### DIFF
--- a/eth/protocols/snap/sort_test.go
+++ b/eth/protocols/snap/sort_test.go
@@ -1,4 +1,4 @@
-// Copyright 2020 The go-ethereum Authors
+// Copyright 2022 The go-ethereum Authors
 // This file is part of the go-ethereum library.
 //
 // The go-ethereum library is free software: you can redistribute it and/or modify

--- a/eth/protocols/snap/sort_test.go
+++ b/eth/protocols/snap/sort_test.go
@@ -17,10 +17,10 @@
 package snap
 
 import (
+	"bytes"
 	"fmt"
 	"testing"
 
-	"bytes"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/trie"
 )
@@ -32,7 +32,7 @@ func hexToNibbles(s string) []byte {
 	var s2 []byte
 	for _, ch := range []byte(s) {
 		s2 = append(s2, '0')
-		s2 = append(s2, byte(ch))
+		s2 = append(s2, ch)
 	}
 	return common.Hex2Bytes(string(s2))
 }
@@ -72,7 +72,7 @@ func TestRequestSorting(t *testing.T) {
 		paths = append(paths, sp)
 		pathsets = append(pathsets, tnps)
 	}
-	hashes, paths, pathsets = sortByAccountPath(hashes, paths)
+	_, paths, pathsets = sortByAccountPath(hashes, paths)
 	{
 		var b = new(bytes.Buffer)
 		for i := 0; i < len(paths); i++ {

--- a/eth/protocols/snap/sort_test.go
+++ b/eth/protocols/snap/sort_test.go
@@ -1,0 +1,69 @@
+package snap
+
+import (
+	"fmt"
+	"sort"
+	"testing"
+
+	"bytes"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/trie"
+)
+
+func hexToNibbles(s string) []byte {
+	if len(s) >= 2 && s[0] == '0' && s[1] == 'x' {
+		s = s[2:]
+	}
+	var s2 []byte
+	for _, ch := range []byte(s) {
+		s2 = append(s2, '0')
+		s2 = append(s2, byte(ch))
+	}
+	return common.Hex2Bytes(string(s2))
+}
+
+func TestRequestSorting(t *testing.T) {
+
+	//   - Path 0x9  -> {0x19}
+	//   - Path 0x99 -> {0x0099}
+	//   - Path 0x01234567890123456789012345678901012345678901234567890123456789019  -> {0x0123456789012345678901234567890101234567890123456789012345678901, 0x19}
+	//   - Path 0x012345678901234567890123456789010123456789012345678901234567890199 -> {0x0123456789012345678901234567890101234567890123456789012345678901, 0x0099}
+	var f = func(path string) (trie.SyncPath, TrieNodePathSet, common.Hash) {
+		data := hexToNibbles(path)
+		sp := trie.NewSyncPath(data)
+		tnps := TrieNodePathSet([][]byte(sp))
+		hash := common.Hash{}
+		return sp, tnps, hash
+	}
+	var test = new(healRequestSort)
+	for _, x := range []string{
+		"0x9",
+		"0x012345678901234567890123456789010123456789012345678901234567890195",
+		"0x012345678901234567890123456789010123456789012345678901234567890197",
+		"0x012345678901234567890123456789010123456789012345678901234567890196",
+		"0x99",
+		"0x012345678901234567890123456789010123456789012345678901234567890199",
+		"0x01234567890123456789012345678901012345678901234567890123456789019",
+		"0x0123456789012345678901234567890101234567890123456789012345678901",
+		"0x01234567890123456789012345678901012345678901234567890123456789010",
+		"0x01234567890123456789012345678901012345678901234567890123456789011",
+	} {
+		sp, tnps, hash := f(x)
+		test.hashes = append(test.hashes, hash)
+		test.paths = append(test.paths, sp)
+		test.pathsets = append(test.pathsets, tnps)
+	}
+	sort.Sort(test)
+	test.Merge()
+	var b = new(bytes.Buffer)
+	for i := 0; i < len(test.pathsets); i++ {
+		fmt.Fprintf(b, "\n%d. pathset %x", i, test.pathsets[i])
+	}
+	want := `
+0. pathset [0099]
+1. pathset [0123456789012345678901234567890101234567890123456789012345678901 00 0095 0096 0097 0099 10 11 19]
+2. pathset [19]`
+	if have := b.String(); have != want {
+		t.Errorf("have:%v\nwant:%v\n", have, want)
+	}
+}

--- a/eth/protocols/snap/sort_test.go
+++ b/eth/protocols/snap/sort_test.go
@@ -1,3 +1,19 @@
+// Copyright 2020 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
 package snap
 
 import (
@@ -56,16 +72,38 @@ func TestRequestSorting(t *testing.T) {
 		paths = append(paths, sp)
 		pathsets = append(pathsets, tnps)
 	}
-	hashes, paths, pathsets = sortByAccountPath(hashes, paths, pathsets)
-	var b = new(bytes.Buffer)
-	for i := 0; i < len(pathsets); i++ {
-		fmt.Fprintf(b, "\n%d. pathset %x", i, pathsets[i])
+	hashes, paths, pathsets = sortByAccountPath(hashes, paths)
+	{
+		var b = new(bytes.Buffer)
+		for i := 0; i < len(paths); i++ {
+			fmt.Fprintf(b, "\n%d. paths %x", i, paths[i])
+		}
+		want := `
+0. paths [0099]
+1. paths [0123456789012345678901234567890101234567890123456789012345678901 00]
+2. paths [0123456789012345678901234567890101234567890123456789012345678901 0095]
+3. paths [0123456789012345678901234567890101234567890123456789012345678901 0096]
+4. paths [0123456789012345678901234567890101234567890123456789012345678901 0097]
+5. paths [0123456789012345678901234567890101234567890123456789012345678901 0099]
+6. paths [0123456789012345678901234567890101234567890123456789012345678901 10]
+7. paths [0123456789012345678901234567890101234567890123456789012345678901 11]
+8. paths [0123456789012345678901234567890101234567890123456789012345678901 19]
+9. paths [19]`
+		if have := b.String(); have != want {
+			t.Errorf("have:%v\nwant:%v\n", have, want)
+		}
 	}
-	want := `
+	{
+		var b = new(bytes.Buffer)
+		for i := 0; i < len(pathsets); i++ {
+			fmt.Fprintf(b, "\n%d. pathset %x", i, pathsets[i])
+		}
+		want := `
 0. pathset [0099]
 1. pathset [0123456789012345678901234567890101234567890123456789012345678901 00 0095 0096 0097 0099 10 11 19]
 2. pathset [19]`
-	if have := b.String(); have != want {
-		t.Errorf("have:%v\nwant:%v\n", have, want)
+		if have := b.String(); have != want {
+			t.Errorf("have:%v\nwant:%v\n", have, want)
+		}
 	}
 }

--- a/eth/protocols/snap/sort_test.go
+++ b/eth/protocols/snap/sort_test.go
@@ -2,7 +2,6 @@ package snap
 
 import (
 	"fmt"
-	"sort"
 	"testing"
 
 	"bytes"
@@ -35,7 +34,11 @@ func TestRequestSorting(t *testing.T) {
 		hash := common.Hash{}
 		return sp, tnps, hash
 	}
-	var test = new(healRequestSort)
+	var (
+		hashes   []common.Hash
+		paths    []trie.SyncPath
+		pathsets []TrieNodePathSet
+	)
 	for _, x := range []string{
 		"0x9",
 		"0x012345678901234567890123456789010123456789012345678901234567890195",
@@ -49,15 +52,14 @@ func TestRequestSorting(t *testing.T) {
 		"0x01234567890123456789012345678901012345678901234567890123456789011",
 	} {
 		sp, tnps, hash := f(x)
-		test.hashes = append(test.hashes, hash)
-		test.paths = append(test.paths, sp)
-		test.pathsets = append(test.pathsets, tnps)
+		hashes = append(hashes, hash)
+		paths = append(paths, sp)
+		pathsets = append(pathsets, tnps)
 	}
-	sort.Sort(test)
-	test.Merge()
+	hashes, paths, pathsets = sortByAccountPath(hashes, paths, pathsets)
 	var b = new(bytes.Buffer)
-	for i := 0; i < len(test.pathsets); i++ {
-		fmt.Fprintf(b, "\n%d. pathset %x", i, test.pathsets[i])
+	for i := 0; i < len(pathsets); i++ {
+		fmt.Fprintf(b, "\n%d. pathset %x", i, pathsets[i])
 	}
 	want := `
 0. pathset [0099]

--- a/eth/protocols/snap/sync.go
+++ b/eth/protocols/snap/sync.go
@@ -2952,31 +2952,26 @@ func (t *healRequestSort) Swap(i, j int) {
 // same account are merged into one, to reduce bandwidth.
 // OBS: This operation is moot if t has not first been sorted.
 func (t *healRequestSort) Merge() []TrieNodePathSet {
-	var (
-		pathsets []TrieNodePathSet
-		last     TrieNodePathSet
-	)
+	var result []TrieNodePathSet
 	for _, path := range t.paths {
 		pathset := TrieNodePathSet([][]byte(path))
 		if len(path) == 1 {
 			// It's an account reference.
-			pathsets = append(pathsets, pathset)
-			last = nil
+			result = append(result, pathset)
 		} else {
 			// It's a storage reference.
-			if last == nil || !bytes.Equal(pathset[0], last[0]) {
+			end := len(result) - 1
+			if len(result) == 0 || !bytes.Equal(pathset[0], result[end][0]) {
 				// The account doesn't doesn't match last, create a new entry.
-				pathsets = append(pathsets, pathset)
-				last = pathset
+				result = append(result, pathset)
 			} else {
 				// It's the same account as the previous one, add to the storage
 				// paths of that request.
-				last = append(last, pathset[1])
-				pathsets[len(pathsets)-1] = last
+				result[end] = append(result[end], pathset[1])
 			}
 		}
 	}
-	return pathsets
+	return result
 }
 
 // sortByAccountPath takes hashes and paths, and sorts them. After that, it generates

--- a/eth/protocols/snap/sync.go
+++ b/eth/protocols/snap/sync.go
@@ -2962,14 +2962,14 @@ func (t *healRequestSort) Merge() []TrieNodePathSet {
 			last = nil
 			continue
 		}
-		if last != nil && bytes.Equal(pSet[0], last[0]) {
-			// we can merge this into the last one
-			last = append(last, pSet[1])
-			nPathset[len(nPathset)-1] = last
-		} else {
+		if last == nil || !bytes.Equal(pSet[0], last[0]) {
 			nPathset = append(nPathset, pSet)
 			last = pSet
+			continue
 		}
+		// we can merge this into the last one
+		last = append(last, pSet[1])
+		nPathset[len(nPathset)-1] = last
 	}
 	return nPathset
 }

--- a/eth/protocols/snap/sync.go
+++ b/eth/protocols/snap/sync.go
@@ -2952,26 +2952,28 @@ func (t *healRequestSort) Swap(i, j int) {
 // same account are merged into one, to reduce bandwidth.
 // OBS: This operation is moot if t has not first been sorted.
 func (t *healRequestSort) Merge() []TrieNodePathSet {
-	var nPathset []TrieNodePathSet
-	var last TrieNodePathSet
+	var (
+		pathsets []TrieNodePathSet
+		last     TrieNodePathSet
+	)
 
 	for _, path := range t.paths {
-		pSet := TrieNodePathSet([][]byte(path))
+		pathset := TrieNodePathSet([][]byte(path))
 		if len(path) == 1 {
-			nPathset = append(nPathset, pSet)
+			pathsets = append(pathsets, pathset)
 			last = nil
 			continue
 		}
-		if last == nil || !bytes.Equal(pSet[0], last[0]) {
-			nPathset = append(nPathset, pSet)
-			last = pSet
+		if last == nil || !bytes.Equal(pathset[0], last[0]) {
+			pathsets = append(pathsets, pathset)
+			last = pathset
 			continue
 		}
 		// we can merge this into the last one
-		last = append(last, pSet[1])
-		nPathset[len(nPathset)-1] = last
+		last = append(last, pathset[1])
+		pathsets[len(pathsets)-1] = last
 	}
-	return nPathset
+	return pathsets
 }
 
 // sortByAccountPath takes hashes and paths, and sorts them. After that, it generates

--- a/trie/sync.go
+++ b/trie/sync.go
@@ -71,9 +71,9 @@ type request struct {
 //   - Path 0x012345678901234567890123456789010123456789012345678901234567890199 -> {0x0123456789012345678901234567890101234567890123456789012345678901, 0x0099}
 type SyncPath [][]byte
 
-// newSyncPath converts an expanded trie path from nibble form into a compact
+// NewSyncPath converts an expanded trie path from nibble form into a compact
 // version that can be sent over the network.
-func newSyncPath(path []byte) SyncPath {
+func NewSyncPath(path []byte) SyncPath {
 	// If the hash is from the account trie, append a single item, if it
 	// is from the a storage trie, append a tuple. Note, the length 64 is
 	// clashing between account leaf and storage root. It's fine though
@@ -238,7 +238,7 @@ func (s *Sync) Missing(max int) (nodes []common.Hash, paths []SyncPath, codes []
 		hash := item.(common.Hash)
 		if req, ok := s.nodeReqs[hash]; ok {
 			nodeHashes = append(nodeHashes, hash)
-			nodePaths = append(nodePaths, newSyncPath(req.path))
+			nodePaths = append(nodePaths, NewSyncPath(req.path))
 		} else {
 			codeHashes = append(codeHashes, hash)
 		}


### PR DESCRIPTION
It was pointed out @dceleda that we do not merge storage trie heal requests which are on the same path. The spec allows for doing so, which saves some bandwidth, but it was left as a todo. 

This PR attempts to fix it. Testing it now, will remove some extraneous printouts when I've checked whether it works. 