### PR TITLE
crypto: optimize Keccak*/SHA3 calls by re-using hashes

### DIFF
--- a/crypto/bench_test.go
+++ b/crypto/bench_test.go
@@ -1,0 +1,87 @@
+// Copyright 2022 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+package crypto
+
+import (
+	"bytes"
+	"testing"
+)
+
+var rows = [][][]byte{
+	{[]byte("abcdef"), []byte("ghijklm")},
+	{[]byte("ABCDEF"), []byte("GHIJKLM")},
+	{[]byte("123456789"), []byte("XXXXXXX")},
+	{[]byte("1234567890ABCDEFGHIJKLMNOPQRSTUVWXYZ"), bytes.Repeat([]byte("abcdef"), 10), bytes.Repeat([]byte("a"), 26)},
+	{[]byte("1234567890ABCDEFGHIJKLMNOPQRSTUVWXYZ"), bytes.Repeat([]byte("a"), 101), bytes.Repeat([]byte("a"), 31)},
+	{[]byte("1234567890ABCDEFGHIJKLMNOPQRSTUVWXYZ"), bytes.Repeat([]byte("a"), 100), bytes.Repeat([]byte("a"), 256)},
+}
+
+var sink interface{}
+
+func BenchmarkKeccak256(b *testing.B) {
+	b.ReportAllocs()
+
+	for i := 0; i < b.N; i++ {
+		for _, row := range rows {
+			hash := Keccak256(row...)
+			b.SetBytes(int64(len(hash)))
+			sink = hash
+		}
+	}
+
+	if sink == nil {
+		b.Fatal("Benchmark did not run")
+	}
+
+	sink = (interface{})(nil)
+}
+
+func BenchmarkKeccak256Hash(b *testing.B) {
+	b.ReportAllocs()
+
+	for i := 0; i < b.N; i++ {
+		for _, row := range rows {
+			hash := Keccak256Hash(row...)
+			b.SetBytes(int64(len(hash)))
+			sink = hash
+		}
+	}
+
+	if sink == nil {
+		b.Fatal("Benchmark did not run")
+	}
+
+	sink = (interface{})(nil)
+}
+
+func BenchmarkKeccak512(b *testing.B) {
+	b.ReportAllocs()
+
+	for i := 0; i < b.N; i++ {
+		for _, row := range rows {
+			hash := Keccak512(row...)
+			b.SetBytes(int64(len(hash)))
+			sink = hash
+		}
+	}
+
+	if sink == nil {
+		b.Fatal("Benchmark did not run")
+	}
+
+	sink = (interface{})(nil)
+}

--- a/crypto/crypto_test.go
+++ b/crypto/crypto_test.go
@@ -61,7 +61,8 @@ func TestToECDSAErrors(t *testing.T) {
 func BenchmarkSha3(b *testing.B) {
 	a := []byte("hello world")
 	for i := 0; i < b.N; i++ {
-		Keccak256(a)
+		h := Keccak256(a)
+		b.SetBytes(int64(len(h)))
 	}
 }
 


### PR DESCRIPTION
By examining the hot path of commonly used code, the hashing
algorithms and then auditing their code, I noticed that most of
it created hashes which are expensive yet discarded them after.
However, each one of them that implements hashs.Hash has a method
hash.Hasher.Reset which allows them to be reused.
This change employs a sync.Pool with the appropriate hash constructors
and the performance improvements are radical

```shell
name                  old time/op    new time/op    delta
Keccak256-8             5.43µs ± 0%    4.92µs ± 2%   -9.33%  (p=0.000 n=8+10)
Keccak256Hash-8         5.37µs ± 3%    4.90µs ± 4%   -8.67%  (p=0.000 n=10+10)
Keccak512-8             8.24µs ± 2%    7.81µs ± 2%   -5.24%  (p=0.000 n=10+10)
Sha3-8                   641ns ± 1%     572ns ± 3%  -10.82%  (p=0.000 n=9+10)
EcrecoverSignature-8    62.3µs ± 2%    62.7µs ± 2%     ~     (p=0.247 n=10+10)
VerifySignature-8       54.5µs ± 1%    55.2µs ± 2%   +1.28%  (p=0.035 n=10+10)
DecompressPubkey-8      5.67µs ± 4%    5.80µs ± 4%   +2.17%  (p=0.035 n=10+10)

name                  old speed      new speed      delta
Keccak256-8           5.90MB/s ± 0%  6.50MB/s ± 2%  +10.29%  (p=0.000 n=8+10)
Keccak256Hash-8       5.96MB/s ± 3%  6.53MB/s ± 4%   +9.51%  (p=0.000 n=10+10)
Keccak512-8           7.76MB/s ± 2%  8.19MB/s ± 2%   +5.52%  (p=0.000 n=10+10)
Sha3-8                49.9MB/s ± 1%  56.0MB/s ± 3%  +12.16%  (p=0.000 n=9+10)

name                  old alloc/op   new alloc/op   delta
Keccak256-8             3.02kB ± 0%    0.34kB ± 0%  -88.89%  (p=0.000 n=10+10)
Keccak256Hash-8         3.07kB ± 0%    0.38kB ± 0%  -87.50%  (p=0.000 n=10+10)
Keccak512-8             6.29kB ± 0%    3.60kB ± 0%  -42.73%  (p=0.000 n=10+10)
Sha3-8                    480B ± 0%       32B ± 0%  -93.33%  (p=0.000 n=10+10)
EcrecoverSignature-8     80.0B ± 0%     80.0B ± 0%     ~     (all equal)
VerifySignature-8        0.00B          0.00B          ~     (all equal)
DecompressPubkey-8        304B ± 0%      304B ± 0%     ~     (all equal)

name                  old allocs/op  new allocs/op  delta
Keccak256-8               18.0 ± 0%      12.0 ± 0%  -33.33%  (p=0.000 n=10+10)
Keccak256Hash-8           18.0 ± 0%      12.0 ± 0%  -33.33%  (p=0.000 n=10+10)
Keccak512-8               30.0 ± 0%      24.0 ± 0%  -20.00%  (p=0.000 n=10+10)
Sha3-8                    2.00 ± 0%      1.00 ± 0%  -50.00%  (p=0.000 n=10+10)
EcrecoverSignature-8      1.00 ± 0%      1.00 ± 0%     ~     (all equal)
VerifySignature-8         0.00           0.00          ~     (all equal)
DecompressPubkey-8        6.00 ± 0%      6.00 ± 0%     ~     (all equal)
```