### PR TITLE
cmd/utils: double limit on free-disk monitor

### DIFF
--- a/cmd/geth/consolecmd_test.go
+++ b/cmd/geth/consolecmd_test.go
@@ -42,7 +42,8 @@ func runMinimalGeth(t *testing.T, args ...string) *testgeth {
 	// --networkid=1337 to avoid cache bump
 	// --syncmode=full to avoid allocating fast sync bloom
 	allArgs := []string{"--ropsten", "--networkid", "1337", "--syncmode=full", "--port", "0",
-		"--nat", "none", "--nodiscover", "--maxpeers", "0", "--cache", "64"}
+		"--nat", "none", "--nodiscover", "--maxpeers", "0", "--cache", "64",
+		"--datadir.minfreedisk", "0"}
 	return runGeth(t, append(allArgs, args...)...)
 }
 

--- a/cmd/utils/cmd.go
+++ b/cmd/utils/cmd.go
@@ -77,11 +77,11 @@ func StartNode(ctx *cli.Context, stack *node.Node, isConsole bool) {
 		signal.Notify(sigc, syscall.SIGINT, syscall.SIGTERM)
 		defer signal.Stop(sigc)
 
-		minFreeDiskSpace := ethconfig.Defaults.TrieDirtyCache
+		minFreeDiskSpace := 2 * ethconfig.Defaults.TrieDirtyCache // Default 2 * 256Mb
 		if ctx.GlobalIsSet(MinFreeDiskSpaceFlag.Name) {
 			minFreeDiskSpace = ctx.GlobalInt(MinFreeDiskSpaceFlag.Name)
 		} else if ctx.GlobalIsSet(CacheFlag.Name) || ctx.GlobalIsSet(CacheGCFlag.Name) {
-			minFreeDiskSpace = ctx.GlobalInt(CacheFlag.Name) * ctx.GlobalInt(CacheGCFlag.Name) / 100
+			minFreeDiskSpace = 2 * ctx.GlobalInt(CacheFlag.Name) * ctx.GlobalInt(CacheGCFlag.Name) / 100
 		}
 		if minFreeDiskSpace > 0 {
 			go monitorFreeDiskSpace(sigc, stack.InstanceDir(), uint64(minFreeDiskSpace)*1024*1024)
@@ -131,7 +131,7 @@ func monitorFreeDiskSpace(sigc chan os.Signal, path string, freeDiskSpaceCritica
 		} else if freeSpace < 2*freeDiskSpaceCritical {
 			log.Warn("Disk space is running low. Geth will shutdown if disk space runs below critical level.", "available", common.StorageSize(freeSpace), "critical_level", common.StorageSize(freeDiskSpaceCritical))
 		}
-		time.Sleep(60 * time.Second)
+		time.Sleep(30 * time.Second)
 	}
 }
 


### PR DESCRIPTION
Our monitor for free disk space works pretty well, but the limits are a bit too low -- particularly if we only check once per minute, as geth can eat up space pretty quickly. 

Example from a goerli sync: 
```
WARN [04-28|03:03:52.002] Disk space is running low. Geth will shutdown if disk space runs below critical level. available=439.25MiB critical_level=256.00MiB
...
INFO [04-28|03:04:40.226] Imported new chain segment               blocks=1       txs=8          mgas=0.976   elapsed=13.695ms    mgasps=71.296  number=6,791,790 hash=b67fb8..fd998f dirty=32.31MiB
INFO [04-28|03:04:45.911] Generating state snapshot                root=3f18e4..9a32e2 in=41c151..6351f9 at=6dc5b3..21e749 accounts=2,592,389            slots=27,928,843           storage=2.20GiB    elapsed=29m56.158s  eta=1h26m36.703s
ERROR[04-28|03:04:52.002] Low disk space. Gracefully shutting down Geth to prevent database corruption. available=9.21MiB
INFO [04-28|03:04:52.174] Got interrupt, shutting down... 
...
INFO [04-28|03:04:52.196] Writing cached state to disk             block=6,791,790 hash=32c402..8ea997 root=789099..2ded8d
ERROR[04-28|03:04:52.385] Failed to commit trie from trie database err="write /home/martin/.ethereum/goerli/geth/chaindata/137381.log: no space left on device"
ERROR[04-28|03:04:52.385] Failed to commit recent state trie       err="write /home/martin/.ethereum/goerli/geth/chaindata/137381.log: no space left on device"
INFO [04-28|03:04:52.385] Writing cached state to disk             block=6,791,789 hash=7d55d2..a9d664 root=b58321..9ad02a
ERROR[04-28|03:04:52.386] Failed to commit trie from trie database err="write /home/martin/.ethereum/goerli/geth/chaindata/137381.log: no space left on device"
ERROR[04-28|03:04:52.386] Failed to commit recent state trie       err="write /home/martin/.ethereum/goerli/geth/chaindata/137381.log: no space left on device"
...
INFO [04-28|03:04:52.635] Blockchain stopped 
WARN [04-28|03:04:52.636] Failed to clear unclean-shutdown marker  err="write /home/martin/.ethereum/goerli/geth/chaindata/137381.log: no space left on device"
```
The limit is currently targeting the dirty-cache size. This PR doubles it, and also changes the timer to run once every 30s instead of 60s. 