### PR TITLE
eth/filters: remove explicit continue label in filterLogs

### DIFF
--- a/eth/filters/filter.go
+++ b/eth/filters/filter.go
@@ -299,7 +299,7 @@ Logs:
 		}
 		// If the to filtered topics is greater than the amount of topics in logs, skip.
 		if len(topics) > len(log.Topics) {
-			continue Logs
+			continue
 		}
 		for i, sub := range topics {
 			match := len(sub) == 0 // empty rule set == wildcard


### PR DESCRIPTION
In filter.go:
https://github.com/ethereum/go-ethereum/blob/f94e23ca66eef8fdac2473ce99ca6ad57324aaa2/eth/filters/filter.go#L300-L305
If `len(topics)` greater than len(log.Topics), `continue Logs` will make `filterLogs()` got an infinite loop.
So, It should be `continue`, not `continue Logs`.
