### PR TITLE
dockerfile: better reuse of cached docker layers

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,11 @@ FROM golang:1.18-alpine as builder
 
 RUN apk add --no-cache gcc musl-dev linux-headers git
 
+# Get dependencies - will also be cached if we won't change go.mod/go.sum
+COPY go.mod /go-ethereum/
+COPY go.sum /go-ethereum/
+RUN cd /go-ethereum && go mod download
+
 ADD . /go-ethereum
 RUN cd /go-ethereum && go run build/ci.go install ./cmd/geth
 

--- a/Dockerfile.alltools
+++ b/Dockerfile.alltools
@@ -8,6 +8,11 @@ FROM golang:1.18-alpine as builder
 
 RUN apk add --no-cache gcc musl-dev linux-headers git
 
+# Get dependencies - will also be cached if we won't change go.mod/go.sum
+COPY go.mod /go-ethereum/
+COPY go.sum /go-ethereum/
+RUN cd /go-ethereum && go mod download
+
 ADD . /go-ethereum
 RUN cd /go-ethereum && go run build/ci.go install
 


### PR DESCRIPTION
Docker image build will use cached layers, since`go.mod` and `go.sum` won't changed very often, so we can add `RUN go mod download` early in `Dockerfile`.

# Reference:
https://cloud.google.com/architecture/best-practices-for-building-containers#optimize-for-the-docker-build-cache