### PR TITLE
eth/catalyst: update implementation to spec

### DIFF
--- a/core/beacon/errors.go
+++ b/core/beacon/errors.go
@@ -43,9 +43,9 @@ var (
 
 	INVALIDBLOCKHASH = "INVALID_BLOCK_HASH"
 
-	GenericServerError = rpc.CustomError{Code: -32000, ValidationError: "Server error"}
-	UnknownPayload     = rpc.CustomError{Code: -32001, ValidationError: "Unknown payload"}
-	InvalidTB          = rpc.CustomError{Code: -32002, ValidationError: "Invalid terminal block"}
+	GenericServerError       = rpc.CustomError{Code: -32000, ValidationError: "Server error"}
+	UnknownPayload           = rpc.CustomError{Code: -32001, ValidationError: "Unknown payload"}
+	InvalidPayloadAttributes = rpc.CustomError{Code: -31002, ValidationError: "Invalid payload attributes"}
 
 	STATUS_INVALID         = ForkChoiceResponse{PayloadStatus: PayloadStatusV1{Status: INVALID}, PayloadID: nil}
 	STATUS_SYNCING         = ForkChoiceResponse{PayloadStatus: PayloadStatusV1{Status: SYNCING}, PayloadID: nil}

--- a/core/beacon/errors.go
+++ b/core/beacon/errors.go
@@ -44,8 +44,9 @@ var (
 	INVALIDBLOCKHASH = "INVALID_BLOCK_HASH"
 
 	GenericServerError       = rpc.CustomError{Code: -32000, ValidationError: "Server error"}
-	UnknownPayload           = rpc.CustomError{Code: -32001, ValidationError: "Unknown payload"}
-	InvalidPayloadAttributes = rpc.CustomError{Code: -31002, ValidationError: "Invalid payload attributes"}
+	UnknownPayload           = rpc.CustomError{Code: -38001, ValidationError: "Unknown payload"}
+	InvalidForkChoiceState   = rpc.CustomError{Code: -38002, ValidationError: "Invalid forkchoice state"}
+	InvalidPayloadAttributes = rpc.CustomError{Code: -38003, ValidationError: "Invalid payload attributes"}
 
 	STATUS_INVALID         = ForkChoiceResponse{PayloadStatus: PayloadStatusV1{Status: INVALID}, PayloadID: nil}
 	STATUS_SYNCING         = ForkChoiceResponse{PayloadStatus: PayloadStatusV1{Status: SYNCING}, PayloadID: nil}

--- a/eth/catalyst/api.go
+++ b/eth/catalyst/api.go
@@ -200,13 +200,15 @@ func (api *ConsensusAPI) ForkchoiceUpdatedV1(update beacon.ForkchoiceStateV1, pa
 		// Create an empty block first which can be used as a fallback
 		empty, err := api.eth.Miner().GetSealingBlockSync(update.HeadBlockHash, payloadAttributes.Timestamp, payloadAttributes.SuggestedFeeRecipient, payloadAttributes.Random, true)
 		if err != nil {
-			return valid(nil), err
+			log.Error("Failed to create empty sealing payload", "err", err)
+			return valid(nil), &beacon.InvalidPayloadAttributes
 		}
 		// Send a request to generate a full block in the background.
 		// The result can be obtained via the returned channel.
 		resCh, err := api.eth.Miner().GetSealingBlockAsync(update.HeadBlockHash, payloadAttributes.Timestamp, payloadAttributes.SuggestedFeeRecipient, payloadAttributes.Random, false)
 		if err != nil {
-			return valid(nil), err
+			log.Error("Failed to create async sealing payload", "err", err)
+			return valid(nil), &beacon.InvalidPayloadAttributes
 		}
 		id := computePayloadId(update.HeadBlockHash, payloadAttributes)
 		api.localBlocks.put(id, &payload{empty: empty, result: resCh})

--- a/eth/catalyst/api.go
+++ b/eth/catalyst/api.go
@@ -29,6 +29,7 @@ import (
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/core/beacon"
 	"github.com/ethereum/go-ethereum/core/rawdb"
+	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/eth"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/node"
@@ -344,7 +345,7 @@ func computePayloadId(headBlockHash common.Hash, params *beacon.PayloadAttribute
 // invalid returns a response "INVALID" with the latest valid hash supplied by latest or to the current head
 // if no latestValid block was provided.
 func (api *ConsensusAPI) invalid(err error, latestValid *types.Block) beacon.PayloadStatusV1 {
-	currentHash := api.eth.BlockChain().CurrentHeader().Hash()
+	currentHash := api.eth.BlockChain().CurrentBlock().Hash()
 	if latestValid != nil {
 		currentHash = latestValid.Hash()
 	}

--- a/eth/catalyst/api.go
+++ b/eth/catalyst/api.go
@@ -166,10 +166,10 @@ func (api *ConsensusAPI) ForkchoiceUpdatedV1(update beacon.ForkchoiceStateV1, pa
 		finalBlock := api.eth.BlockChain().GetBlockByHash(update.FinalizedBlockHash)
 		if finalBlock == nil {
 			log.Warn("Final block not available in database", "hash", update.FinalizedBlockHash)
-			return beacon.STATUS_INVALID, errors.New("final block not available")
+			return beacon.STATUS_INVALID, &beacon.InvalidForkChoiceState
 		} else if rawdb.ReadCanonicalHash(api.eth.ChainDb(), finalBlock.NumberU64()) != update.FinalizedBlockHash {
 			log.Warn("Final block not in canonical chain", "number", block.NumberU64(), "hash", update.HeadBlockHash)
-			return beacon.STATUS_INVALID, errors.New("final block not canonical")
+			return beacon.STATUS_INVALID, &beacon.InvalidForkChoiceState
 		}
 		// Set the finalized block
 		api.eth.BlockChain().SetFinalized(finalBlock)
@@ -179,11 +179,11 @@ func (api *ConsensusAPI) ForkchoiceUpdatedV1(update beacon.ForkchoiceStateV1, pa
 		safeBlock := api.eth.BlockChain().GetBlockByHash(update.SafeBlockHash)
 		if safeBlock == nil {
 			log.Warn("Safe block not available in database")
-			return beacon.STATUS_INVALID, errors.New("safe head not available")
+			return beacon.STATUS_INVALID, &beacon.InvalidForkChoiceState
 		}
 		if rawdb.ReadCanonicalHash(api.eth.ChainDb(), safeBlock.NumberU64()) != update.SafeBlockHash {
 			log.Warn("Safe block not in canonical chain")
-			return beacon.STATUS_INVALID, errors.New("safe head not canonical")
+			return beacon.STATUS_INVALID, &beacon.InvalidForkChoiceState
 		}
 	}
 

--- a/eth/catalyst/api_test.go
+++ b/eth/catalyst/api_test.go
@@ -153,7 +153,7 @@ func TestEth2PrepareAndGetPayload(t *testing.T) {
 	api := NewConsensusAPI(ethservice)
 
 	// Put the 10th block's tx in the pool and produce a new block
-	api.eth.TxPool().AddLocals(blocks[9].Transactions())
+	ethservice.TxPool().AddLocals(blocks[9].Transactions())
 	blockParams := beacon.PayloadAttributesV1{
 		Timestamp: blocks[8].Time() + 5,
 	}
@@ -682,7 +682,7 @@ func getNewPayload(t *testing.T, api *ConsensusAPI, parent *types.Block) *beacon
 		SuggestedFeeRecipient: parent.Coinbase(),
 	}
 
-	payload, err := api.assembleBlock(parent.Hash(), &params)
+	payload, err := assembleBlock(api, parent.Hash(), &params)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/les/catalyst/api.go
+++ b/les/catalyst/api.go
@@ -161,7 +161,7 @@ func (api *ConsensusAPI) checkTerminalTotalDifficulty(head common.Hash) error {
 	}
 	td := api.les.BlockChain().GetTd(header.Hash(), header.Number.Uint64())
 	if td != nil && td.Cmp(api.les.BlockChain().Config().TerminalTotalDifficulty) < 0 {
-		return &beacon.InvalidTB
+		return errors.New("invalid ttd")
 	}
 	return nil
 }


### PR DESCRIPTION
This PR fixes an issue with our implementation where we deviated from the current spec which made us fail some tests on hive wrt. the `LatestValidHash`.
We expect
(1) The LVH to point to the current inserted payload if it was valid.
(2) The LVH to point to the valid parent on an invalid payload (if the parent is available).
(3) If the parent is unavailable, the LVH should not be set.

Before this PR our implementation only pointed to the latest hash set by FCU on an invalid payload.

See also https://github.com/ethereum/hive/pull/526#issuecomment-1113596741

This PR does another sneaky change in adding an error if the payload attributes are invalid, as specified here: https://github.com/ethereum/execution-apis/pull/211#issuecomment-1114164783