### PR TITLE
build: ppa build for jammy (ubuntu 22.04)

### DIFF
--- a/build/ci.go
+++ b/build/ci.go
@@ -133,12 +133,13 @@ var (
 	// Note: the following Ubuntu releases have been officially deprecated on Launchpad:
 	//   wily, yakkety, zesty, artful, cosmic, disco, eoan, groovy, hirsuite
 	debDistroGoBoots = map[string]string{
-		"trusty": "golang-1.11", // EOL: 04/2024
-		"xenial": "golang-go",   // EOL: 04/2026
-		"bionic": "golang-go",   // EOL: 04/2028
-		"focal":  "golang-go",   // EOL: 04/2030
-		"impish": "golang-go",   // EOL: 07/2022
-		// "jammy": "golang-go",   // EOL: 04/2027
+		"trusty":  "golang-1.11", // EOL: 04/2024
+		"xenial":  "golang-go",   // EOL: 04/2026
+		"bionic":  "golang-go",   // EOL: 04/2028
+		"focal":   "golang-go",   // EOL: 04/2030
+		"impish":  "golang-go",   // EOL: 07/2022
+		"jammy":   "golang-go",   // EOL: 04/2032
+		//"kinetic": "golang-go",   //  EOL: 07/2023
 	}
 
 	debGoBootPaths = map[string]string{


### PR DESCRIPTION
This might enable builds for Jammy. 
Context info about ubuntu releases: https://wiki.ubuntu.com/Releases