### PR TITLE
cmd/geth: add command to generate a verkle tree from the snapshot

### DIFF
--- a/cmd/geth/snapshot.go
+++ b/cmd/geth/snapshot.go
@@ -18,6 +18,7 @@ package main
 
 import (
 	"bytes"
+	"encoding/binary"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -36,6 +37,9 @@ import (
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/rlp"
 	"github.com/ethereum/go-ethereum/trie"
+	trieUtils "github.com/ethereum/go-ethereum/trie/utils"
+	"github.com/gballet/go-verkle"
+	"github.com/holiman/uint256"
 	cli "gopkg.in/urfave/cli.v1"
 )
 
@@ -157,6 +161,26 @@ as the backend data source, making this command a lot faster.
 The argument is interpreted as block number or hash. If none is provided, the latest
 block is used.
 `,
+			},
+			{
+				Name:      "to-verkle",
+				Usage:     "use the snapshot to compute a translation of a MPT into a verkle tree",
+				ArgsUsage: "<root>",
+				Action:    utils.MigrateFlags(convertToVerkle),
+				Category:  "MISCELLANEOUS COMMANDS",
+				Flags: []cli.Flag{
+					utils.DataDirFlag,
+					utils.RopstenFlag,
+					utils.RinkebyFlag,
+					utils.GoerliFlag,
+				},
+				Description: `
+geth snapshot to-verkle <state-root>
+This command takes a snapshot and inserts its values in a fresh verkle tree.
+
+The argument is interpreted as the root hash. If none is provided, the latest
+block is used.
+ `,
 			},
 		},
 	}
@@ -574,5 +598,186 @@ func dumpState(ctx *cli.Context) error {
 	}
 	log.Info("Snapshot dumping complete", "accounts", accounts,
 		"elapsed", common.PrettyDuration(time.Since(start)))
+	return nil
+}
+
+func convertToVerkle(ctx *cli.Context) error {
+	stack, _ := makeConfigNode(ctx)
+	defer stack.Close()
+
+	chaindb := utils.MakeChainDatabase(ctx, stack, true)
+	headBlock := rawdb.ReadHeadBlock(chaindb)
+	if headBlock == nil {
+		log.Error("Failed to load head block")
+		return errors.New("no head block")
+	}
+	if ctx.NArg() > 1 {
+		log.Error("Too many arguments given")
+		return errors.New("too many arguments")
+	}
+	var (
+		root common.Hash
+		err  error
+	)
+	if ctx.NArg() == 1 {
+		root, err = parseRoot(ctx.Args()[0])
+		if err != nil {
+			log.Error("Failed to resolve state root", "error", err)
+			return err
+		}
+		log.Info("Start traversing the state", "root", root)
+	} else {
+		root = headBlock.Root()
+		log.Info("Start traversing the state", "root", root, "number", headBlock.NumberU64())
+	}
+	var (
+		accounts   int
+		lastReport time.Time
+		start      = time.Now()
+	)
+
+	convdb, err := rawdb.NewLevelDBDatabase("verkle", 128, 128, "", false)
+	if err != nil {
+		panic(err)
+	}
+
+	saveverkle := func(n verkle.VerkleNode) {
+		s, err := n.Serialize()
+		if err != nil {
+			panic(err)
+		}
+		comm := n.ComputeCommitment().Bytes()
+		if err := convdb.Put(comm[:], s); err != nil {
+			panic(err)
+		}
+	}
+
+	vRoot := verkle.New()
+	snaptree, err := snapshot.New(chaindb, trie.NewDatabase(chaindb), 256, root, false, false, false)
+	if err != nil {
+		return err
+	}
+	accIt, err := snaptree.AccountIterator(root, common.Hash{})
+	if err != nil {
+		return err
+	}
+	defer accIt.Release()
+
+	for accIt.Next() {
+		accounts += 1
+
+		var acc types.StateAccount
+		accIt, err := snaptree.AccountIterator(root, common.Hash{})
+		if err != nil {
+			log.Error("Invalid account encountered during traversal", "error", err)
+			return err
+		}
+
+		// Store the basic account data
+		var nonce, balance, version [32]byte
+		binary.LittleEndian.PutUint64(nonce[:8], acc.Nonce)
+		for i, b := range acc.Balance.Bytes() {
+			balance[len(acc.Balance.Bytes())-1-i] = b
+		}
+		// XXX use preimages, accIter is the hash of the address
+		versionkey := trieUtils.GetTreeKeyVersion(accIt.Hash().Bytes())
+		vRoot.Insert(versionkey, version[:], convdb.Get)
+		var balanceKey [32]byte
+		copy(balanceKey[:31], versionkey[:31])
+		balanceKey[31] = 1
+		vRoot.Insert(balanceKey[:], balance[:], convdb.Get)
+		var nonceKey [32]byte
+		copy(nonceKey[:31], versionkey[:31])
+		nonceKey[31] = 2
+		vRoot.Insert(nonceKey[:], nonce[:], convdb.Get)
+		var shakey [32]byte
+		copy(shakey[:31], versionkey[:31])
+		shakey[31] = 3
+		vRoot.Insert(shakey[:], acc.CodeHash, convdb.Get)
+		var sizekey [32]byte
+		copy(sizekey[:31], versionkey[:31])
+		sizekey[31] = 3
+
+		// Store the account code if present
+		if !bytes.Equal(acc.CodeHash, emptyCode) {
+			code := rawdb.ReadCode(chaindb, common.BytesToHash(acc.CodeHash))
+			chunks, err := trie.ChunkifyCode(code)
+			if err != nil {
+				panic(err)
+			}
+			laststem := make([]byte, 31)
+			copy(laststem, versionkey[:31])
+			for i, chunk := range chunks {
+				chunkkey := trieUtils.GetTreeKeyCodeChunk(accIt.Hash().Bytes(), uint256.NewInt(uint64(i)))
+
+				// if this chunk is inserted into a new group, and the previous group isn't
+				// that of the account header, flush the previous group.
+				if !bytes.Equal(laststem, chunkkey[:31]) {
+					if !bytes.Equal(laststem, versionkey[:31]) {
+						vRoot.(*verkle.InternalNode).FlushStem(laststem, saveverkle)
+					}
+
+					laststem = chunkkey[:31]
+				}
+				vRoot.Insert(chunkkey, chunk[:], convdb.Get)
+			}
+			var size [32]byte
+			binary.LittleEndian.PutUint64(size[:8], uint64(len(code)))
+			vRoot.Insert(sizekey[:], size[:], convdb.Get)
+		} else {
+			// hack: because version is also 0, use it as the code size
+			vRoot.Insert(sizekey[:], version[:], convdb.Get)
+		}
+
+		// Save every slot into the tree
+		if acc.Root != emptyRoot {
+			laststem := make([]byte, 31)
+			copy(laststem, versionkey[:31])
+			storageIt, err := snaptree.StorageIterator(root, acc.Root, common.Hash{})
+			if err != nil {
+				log.Error("Failed to open storage trie", "root", acc.Root, "error", err)
+				return err
+			}
+			defer storageIt.Release()
+			for storageIt.Next() {
+				slotkey := trieUtils.GetTreeKeyStorageSlot(accIt.Hash().Bytes(), uint256.NewInt(0).SetBytes(storageIt.Hash().Bytes()))
+
+				// if this slot is inserted into a new group, and the previous group isn't
+				// that of the account header, flush the previous group.
+				if !bytes.Equal(laststem, slotkey[:31]) {
+					if !bytes.Equal(laststem, versionkey[:31]) {
+						vRoot.(*verkle.InternalNode).FlushStem(laststem, saveverkle)
+					}
+
+					laststem = slotkey[:31]
+				}
+				var value [32]byte
+				copy(value[:len(storageIt.Slot())-1], storageIt.Slot())
+				// XXX use preimages, accIter is the hash of the address
+				err = vRoot.Insert(slotkey, value[:], convdb.Get)
+				if err != nil {
+					panic(err)
+				}
+			}
+			if !bytes.Equal(laststem, versionkey[:31]) {
+				vRoot.(*verkle.InternalNode).FlushStem(laststem, saveverkle)
+			}
+			if storageIt.Error() != nil {
+				log.Error("Failed to traverse storage trie", "root", acc.Root, "error", storageIt.Error())
+				return storageIt.Error()
+			}
+		}
+
+		vRoot.(*verkle.InternalNode).FlushStem(versionkey[:31], saveverkle)
+		if time.Since(lastReport) > time.Second*8 {
+			log.Info("Traversing state", "accounts", accounts, "elapsed", common.PrettyDuration(time.Since(start)))
+			lastReport = time.Now()
+		}
+	}
+	if accIt.Error() != nil {
+		log.Error("Failed to compute commitment", "root", root, "error", accIt.Error())
+		return accIt.Error()
+	}
+	log.Info("Conversion complete", "root commitment", vRoot.ComputeCommitment(), "accounts", accounts, "elapsed", common.PrettyDuration(time.Since(start)))
 	return nil
 }

--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,7 @@ require (
 	github.com/cespare/cp v0.1.0
 	github.com/cloudflare/cloudflare-go v0.14.0
 	github.com/consensys/gnark-crypto v0.4.1-0.20210426202927-39ac3d4b3f1f
+	github.com/crate-crypto/go-ipa v0.0.0-20220309173511-816621cb2ec4 // indirect
 	github.com/davecgh/go-spew v1.1.1
 	github.com/deckarep/golang-set v1.8.0
 	github.com/deepmap/oapi-codegen v1.8.2 // indirect
@@ -25,6 +26,7 @@ require (
 	github.com/fjl/gencodec v0.0.0-20220412091415-8bb9e558978c
 	github.com/fjl/memsize v0.0.0-20190710130421-bcb5799ab5e5
 	github.com/gballet/go-libpcsclite v0.0.0-20190607065134-2772fd86a8ff
+	github.com/gballet/go-verkle v0.0.0-20220513051939-46e6a0261e0f // indirect
 	github.com/go-ole/go-ole v1.2.1 // indirect
 	github.com/go-stack/stack v1.8.0
 	github.com/golang-jwt/jwt/v4 v4.3.0
@@ -65,7 +67,7 @@ require (
 	golang.org/x/crypto v0.0.0-20210322153248-0c34fe9e7dc2
 	golang.org/x/mobile v0.0.0-20190719004257-d2bd2a29d028
 	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c
-	golang.org/x/sys v0.0.0-20210816183151-1e6c022a8912
+	golang.org/x/sys v0.0.0-20220503163025-988cb79eb6c6
 	golang.org/x/text v0.3.7
 	golang.org/x/time v0.0.0-20210220033141-f8bda1e9f3ba
 	golang.org/x/tools v0.1.0

--- a/go.sum
+++ b/go.sum
@@ -84,6 +84,8 @@ github.com/consensys/bavard v0.1.8-0.20210406032232-f3452dc9b572/go.mod h1:Bpd0/
 github.com/consensys/gnark-crypto v0.4.1-0.20210426202927-39ac3d4b3f1f h1:C43yEtQ6NIf4ftFXD/V55gnGFgPbMQobd//YlnLjUJ8=
 github.com/consensys/gnark-crypto v0.4.1-0.20210426202927-39ac3d4b3f1f/go.mod h1:815PAHg3wvysy0SyIqanF8gZ0Y1wjk/hrDHD/iT88+Q=
 github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
+github.com/crate-crypto/go-ipa v0.0.0-20220309173511-816621cb2ec4 h1:6KIFkDoBRVfE2I4cUt2wUuejBs+ReEe0cNQnTLs8AwE=
+github.com/crate-crypto/go-ipa v0.0.0-20220309173511-816621cb2ec4/go.mod h1:gFnFS95y8HstDP6P9pPwzrxOOC5TRDkwbM+ao15ChAI=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/cyberdelia/templates v0.0.0-20141128023046-ca7fffd4298c/go.mod h1:GyV+0YP4qX0UQ7r2MoYZ+AvYDp12OF5yg4q8rGnyNh4=
 github.com/dave/jennifer v1.2.0/go.mod h1:fIb+770HOpJ2fmN9EPPKOqm1vMGhB+TwXKMZhrIygKg=
@@ -131,6 +133,12 @@ github.com/garslo/gogen v0.0.0-20170306192744-1d203ffc1f61 h1:IZqZOB2fydHte3kUgx
 github.com/garslo/gogen v0.0.0-20170306192744-1d203ffc1f61/go.mod h1:Q0X6pkwTILDlzrGEckF6HKjXe48EgsY/l7K7vhY4MW8=
 github.com/gballet/go-libpcsclite v0.0.0-20190607065134-2772fd86a8ff h1:tY80oXqGNY4FhTFhk+o9oFHGINQ/+vhlm8HFzi6znCI=
 github.com/gballet/go-libpcsclite v0.0.0-20190607065134-2772fd86a8ff/go.mod h1:x7DCsMOv1taUwEWCzT4cmDeAkigA5/QCwUodaVOe8Ww=
+github.com/gballet/go-verkle v0.0.0-20220405092011-81f643ddb353 h1:qQkgf4WRxKTRCuQCu3lMtGHkzaj7xzRwzoGwsnbFgj8=
+github.com/gballet/go-verkle v0.0.0-20220405092011-81f643ddb353/go.mod h1:tJlhnY02dv8C/jS2PjNfkazg/Zen6yyFmmzgXyMeb4U=
+github.com/gballet/go-verkle v0.0.0-20220504145609-a7bc1708eb4a h1:eGLgtr3O+gKSyX6GrKnpX9dckcKJfea56AYQ8SWltSA=
+github.com/gballet/go-verkle v0.0.0-20220504145609-a7bc1708eb4a/go.mod h1:tJlhnY02dv8C/jS2PjNfkazg/Zen6yyFmmzgXyMeb4U=
+github.com/gballet/go-verkle v0.0.0-20220513051939-46e6a0261e0f h1:mwtM5rJwVJ8yzAXKIzISz0RKUMLnd/hiSAZaAlIgzDw=
+github.com/gballet/go-verkle v0.0.0-20220513051939-46e6a0261e0f/go.mod h1:tJlhnY02dv8C/jS2PjNfkazg/Zen6yyFmmzgXyMeb4U=
 github.com/getkin/kin-openapi v0.53.0/go.mod h1:7Yn5whZr5kJi6t+kShccXS8ae1APpYTW6yheSwk8Yi4=
 github.com/getkin/kin-openapi v0.61.0/go.mod h1:7Yn5whZr5kJi6t+kShccXS8ae1APpYTW6yheSwk8Yi4=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
@@ -526,6 +534,11 @@ golang.org/x/sys v0.0.0-20210420205809-ac73e9fd8988/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20210423082822-04245dca01da/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210816183151-1e6c022a8912 h1:uCLL3g5wH2xjxVREVuAbP9JM5PPKjRbXKRa6IBjkzmU=
 golang.org/x/sys v0.0.0-20210816183151-1e6c022a8912/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20211020174200-9d6173849985/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20220307203707-22a9840ba4d7 h1:8IVLkfbr2cLhv0a/vKq4UFUcJym8RmDoDboxCFWEjYE=
+golang.org/x/sys v0.0.0-20220307203707-22a9840ba4d7/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20220503163025-988cb79eb6c6 h1:nonptSpoQ4vQjyraW20DXPAglgQfVnM9ZC6MmNLMR60=
+golang.org/x/sys v0.0.0-20220503163025-988cb79eb6c6/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201117132131-f5c789dd3221/go.mod h1:Nr5EML6q2oocZ2LXRh80K7BxOlk5/8JxuGnuhpl+muw=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1 h1:v+OssWQX+hTHEmOBgwxdZxK4zHq3yOs8F9J7mk0PY8E=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=

--- a/trie/utils/verkle.go
+++ b/trie/utils/verkle.go
@@ -1,0 +1,134 @@
+// Copyright 2021 go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+package utils
+
+import (
+	"github.com/crate-crypto/go-ipa/bandersnatch/fr"
+	"github.com/gballet/go-verkle"
+
+	"github.com/holiman/uint256"
+)
+
+const (
+	VersionLeafKey    = 0
+	BalanceLeafKey    = 1
+	NonceLeafKey      = 2
+	CodeKeccakLeafKey = 3
+	CodeSizeLeafKey   = 4
+)
+
+var (
+	zero                = uint256.NewInt(0)
+	HeaderStorageOffset = uint256.NewInt(64)
+	CodeOffset          = uint256.NewInt(128)
+	MainStorageOffset   = new(uint256.Int).Lsh(uint256.NewInt(256), 31)
+	VerkleNodeWidth     = uint256.NewInt(256)
+	codeStorageDelta    = uint256.NewInt(0).Sub(CodeOffset, HeaderStorageOffset)
+)
+
+// GetTreeKey performs both the work of the spec's get_tree_key function, and that
+// of pedersen_hash: it builds the polynomial in pedersen_hash without having to
+// create a mostly zero-filled buffer and "type cast" it to a 128-long 16-byte
+// array. Since at most the first 5 coefficients of the polynomial will be non-zero,
+// these 5 coefficients are created directly.
+func GetTreeKey(address []byte, treeIndex *uint256.Int, subIndex byte) []byte {
+	if len(address) < 32 {
+		var aligned [32]byte
+		address = append(aligned[:32-len(address)], address...)
+	}
+	var poly [5]fr.Element
+
+	// (2 + 256 * length) little endian, length = 64 bytes
+	verkle.FromLEBytes(&poly[0], []byte{2, 64})
+
+	// 32-byte address, interpreted as two little endian
+	// 16-byte numbers.
+	verkle.FromLEBytes(&poly[1], address[:16])
+	verkle.FromLEBytes(&poly[2], address[16:])
+
+	// little-endian, 32-byte aligned treeIndex
+	var index [32]byte
+	for i, b := range treeIndex.Bytes() {
+		index[len(treeIndex.Bytes())-1-i] = b
+	}
+	verkle.FromLEBytes(&poly[3], index[:16])
+	verkle.FromLEBytes(&poly[4], index[16:])
+
+	cfg, _ := verkle.GetConfig()
+	ret := cfg.CommitToPoly(poly[:], 0)
+	retb := ret.Bytes()
+	retb[31] = subIndex
+	return retb[:]
+
+}
+
+func GetTreeKeyAccountLeaf(address []byte, leaf byte) []byte {
+	return GetTreeKey(address, zero, leaf)
+}
+
+func GetTreeKeyVersion(address []byte) []byte {
+	return GetTreeKey(address, zero, VersionLeafKey)
+}
+
+func GetTreeKeyBalance(address []byte) []byte {
+	return GetTreeKey(address, zero, BalanceLeafKey)
+}
+
+func GetTreeKeyNonce(address []byte) []byte {
+	return GetTreeKey(address, zero, NonceLeafKey)
+}
+
+func GetTreeKeyCodeKeccak(address []byte) []byte {
+	return GetTreeKey(address, zero, CodeKeccakLeafKey)
+}
+
+func GetTreeKeyCodeSize(address []byte) []byte {
+	return GetTreeKey(address, zero, CodeSizeLeafKey)
+}
+
+func GetTreeKeyCodeChunk(address []byte, chunk *uint256.Int) []byte {
+	chunkOffset := new(uint256.Int).Add(CodeOffset, chunk)
+	treeIndex := new(uint256.Int).Div(chunkOffset, VerkleNodeWidth)
+	subIndexMod := new(uint256.Int).Mod(chunkOffset, VerkleNodeWidth).Bytes()
+	var subIndex byte
+	if len(subIndexMod) != 0 {
+		subIndex = subIndexMod[0]
+	}
+	return GetTreeKey(address, treeIndex, subIndex)
+}
+
+func GetTreeKeyStorageSlot(address []byte, storageKey *uint256.Int) []byte {
+	pos := storageKey.Clone()
+	if storageKey.Cmp(codeStorageDelta) < 0 {
+		pos.Add(HeaderStorageOffset, storageKey)
+	} else {
+		pos.Add(MainStorageOffset, storageKey)
+	}
+	treeIndex := new(uint256.Int).Div(pos, VerkleNodeWidth)
+
+	// calculate the sub_index, i.e. the index in the stem tree.
+	// Because the modulus is 256, it's the last byte of treeIndex
+	subIndexMod := new(uint256.Int).Mod(pos, VerkleNodeWidth).Bytes()
+	var subIndex byte
+	if len(subIndexMod) != 0 {
+		// uint256 is broken into 4 little-endian quads,
+		// each with native endianness. Extract the least
+		// significant byte.
+		subIndex = byte(subIndexMod[0] & 0xFF)
+	}
+	return GetTreeKey(address, treeIndex, subIndex)
+}

--- a/trie/verkle.go
+++ b/trie/verkle.go
@@ -1,0 +1,78 @@
+// Copyright 2021 go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+package trie
+
+// Copy the values here so as to avoid an import cycle
+const (
+	PUSH1  = byte(0x60)
+	PUSH3  = byte(0x62)
+	PUSH4  = byte(0x63)
+	PUSH7  = byte(0x66)
+	PUSH21 = byte(0x74)
+	PUSH30 = byte(0x7d)
+	PUSH32 = byte(0x7f)
+)
+
+func ChunkifyCode(code []byte) ([][32]byte, error) {
+	var (
+		chunkOffset = 0 // offset in the chunk
+		chunkCount  = len(code) / 31
+		codeOffset  = 0 // offset in the code
+	)
+	if len(code)%31 != 0 {
+		chunkCount++
+	}
+	chunks := make([][32]byte, chunkCount)
+	for i := range chunks {
+		// number of bytes to copy, 31 unless
+		// the end of the code has been reached.
+		end := 31 * (i + 1)
+		if len(code) < end {
+			end = len(code)
+		}
+
+		// Copy the code itself
+		copy(chunks[i][1:], code[31*i:end])
+
+		// chunk offset = taken from the
+		// last chunk.
+		if chunkOffset > 31 {
+			// skip offset calculation if push
+			// data covers the whole chunk
+			chunks[i][0] = 31
+			chunkOffset = 1
+			continue
+		}
+		chunks[i][0] = byte(chunkOffset)
+		chunkOffset = 0
+
+		// Check each instruction and update the offset
+		// it should be 0 unless a PUSHn overflows.
+		for ; codeOffset < end; codeOffset++ {
+			if code[codeOffset] >= PUSH1 && code[codeOffset] <= PUSH32 {
+				codeOffset += int(code[codeOffset] - PUSH1 + 1)
+				if codeOffset+1 >= 31*(i+1) {
+					codeOffset++
+					chunkOffset = codeOffset - 31*(i+1)
+					break
+				}
+			}
+		}
+	}
+
+	return chunks, nil
+}


### PR DESCRIPTION
Current state:

  - [x] no converted data is currently saved to disk. A conversion will likely oom.
  - [ ] no preimage is used, so the destination is invalid. At this time, it can only be used to
        estimate how long the conversion takes.
  - [ ] need to optimize the key calculation