### PR TITLE
p2p/simulations: fix typo in network_test.go

### DIFF
--- a/p2p/simulations/network_test.go
+++ b/p2p/simulations/network_test.go
@@ -448,7 +448,7 @@ func TestGetNodeIDs(t *testing.T) {
 	numNodes := 5
 	nodes, err := createTestNodes(numNodes, network)
 	if err != nil {
-		t.Fatalf("Could not creat test nodes %v", err)
+		t.Fatalf("Could not create test nodes %v", err)
 	}
 
 	gotNodeIDs := network.GetNodeIDs()
@@ -497,7 +497,7 @@ func TestGetNodes(t *testing.T) {
 	numNodes := 5
 	nodes, err := createTestNodes(numNodes, network)
 	if err != nil {
-		t.Fatalf("Could not creat test nodes %v", err)
+		t.Fatalf("Could not create test nodes %v", err)
 	}
 
 	gotNodes := network.GetNodes()


### PR DESCRIPTION
creat -> create