### PR TITLE
ethdb/remotedb, cmd: add support for remote (readonly) databases

### DIFF
--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -50,6 +50,7 @@ import (
 	"github.com/ethereum/go-ethereum/eth/gasprice"
 	"github.com/ethereum/go-ethereum/eth/tracers"
 	"github.com/ethereum/go-ethereum/ethdb"
+	"github.com/ethereum/go-ethereum/ethdb/remotedb"
 	"github.com/ethereum/go-ethereum/ethstats"
 	"github.com/ethereum/go-ethereum/graphql"
 	"github.com/ethereum/go-ethereum/internal/ethapi"
@@ -113,6 +114,10 @@ var (
 		Name:  "datadir",
 		Usage: "Data directory for the databases and keystore",
 		Value: DirectoryString(node.DefaultDataDir()),
+	}
+	RemoteDBFlag = cli.StringFlag{
+		Name:  "remotedb",
+		Usage: "URL for remote database",
 	}
 	AncientFlag = DirectoryFlag{
 		Name:  "datadir.ancient",
@@ -841,6 +846,7 @@ var (
 	DatabasePathFlags = []cli.Flag{
 		DataDirFlag,
 		AncientFlag,
+		RemoteDBFlag,
 	}
 )
 
@@ -1953,6 +1959,9 @@ func MakeChainDatabase(ctx *cli.Context, stack *node.Node, readonly bool) ethdb.
 		err     error
 		chainDb ethdb.Database
 	)
+	if ctx.GlobalIsSet(RemoteDBFlag.Name) {
+		chainDb, err = remotedb.New(ctx.GlobalString(RemoteDBFlag.Name))
+	}
 	if ctx.GlobalString(SyncModeFlag.Name) == "light" {
 		name := "lightchaindata"
 		chainDb, err = stack.OpenDatabase(name, cache, handles, "", readonly)

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -1959,15 +1959,14 @@ func MakeChainDatabase(ctx *cli.Context, stack *node.Node, readonly bool) ethdb.
 		err     error
 		chainDb ethdb.Database
 	)
-	if ctx.GlobalIsSet(RemoteDBFlag.Name) {
+	switch {
+	case ctx.GlobalIsSet(RemoteDBFlag.Name):
+		log.Info("Using remote db", "url", ctx.GlobalString(RemoteDBFlag.Name))
 		chainDb, err = remotedb.New(ctx.GlobalString(RemoteDBFlag.Name))
-	}
-	if ctx.GlobalString(SyncModeFlag.Name) == "light" {
-		name := "lightchaindata"
-		chainDb, err = stack.OpenDatabase(name, cache, handles, "", readonly)
-	} else {
-		name := "chaindata"
-		chainDb, err = stack.OpenDatabaseWithFreezer(name, cache, handles, ctx.GlobalString(AncientFlag.Name), "", readonly)
+	case ctx.GlobalString(SyncModeFlag.Name) == "light":
+		chainDb, err = stack.OpenDatabase("lightchaindata", cache, handles, "", readonly)
+	default:
+		chainDb, err = stack.OpenDatabaseWithFreezer("chaindata", cache, handles, ctx.GlobalString(AncientFlag.Name), "", readonly)
 	}
 	if err != nil {
 		Fatalf("Could not open database: %v", err)

--- a/ethdb/remotedb/remotedb.go
+++ b/ethdb/remotedb/remotedb.go
@@ -51,11 +51,19 @@ func (db *Database) Get(key []byte) ([]byte, error) {
 }
 
 func (db *Database) HasAncient(kind string, number uint64) (bool, error) {
-	panic("not supported")
+	if _, err := db.Ancient(kind, number); err != nil {
+		return true, nil
+	}
+	return false, nil
 }
 
 func (db *Database) Ancient(kind string, number uint64) ([]byte, error) {
-	panic("not supported")
+	var resp hexutil.Bytes
+	err := db.remote.Call(&resp, "debug_dbAncient", kind, number)
+	if err != nil {
+		return nil, err
+	}
+	return resp, nil
 }
 
 func (db *Database) AncientRange(kind string, start, count, maxBytes uint64) ([][]byte, error) {
@@ -63,7 +71,9 @@ func (db *Database) AncientRange(kind string, start, count, maxBytes uint64) ([]
 }
 
 func (db *Database) Ancients() (uint64, error) {
-	panic("not supported")
+	var resp uint64
+	err := db.remote.Call(&resp, "debug_dbAncients")
+	return resp, err
 }
 
 func (db *Database) Tail() (uint64, error) {
@@ -75,7 +85,7 @@ func (db *Database) AncientSize(kind string) (uint64, error) {
 }
 
 func (db *Database) ReadAncients(fn func(op ethdb.AncientReaderOp) error) (err error) {
-	panic("not supported")
+	return fn(db)
 }
 
 func (db *Database) Put(key []byte, value []byte) error {

--- a/ethdb/remotedb/remotedb.go
+++ b/ethdb/remotedb/remotedb.go
@@ -51,113 +51,91 @@ func (db *Database) Get(key []byte) ([]byte, error) {
 }
 
 func (db *Database) HasAncient(kind string, number uint64) (bool, error) {
-	//TODO implement me
-	panic("implement me")
+	panic("not supported")
 }
 
 func (db *Database) Ancient(kind string, number uint64) ([]byte, error) {
-	//TODO implement me
-	panic("implement me")
+	panic("not supported")
 }
 
 func (db *Database) AncientRange(kind string, start, count, maxBytes uint64) ([][]byte, error) {
-	//TODO implement me
-	panic("implement me")
+	panic("not supported")
 }
 
 func (db *Database) Ancients() (uint64, error) {
-	//TODO implement me
-	panic("implement me")
+	panic("not supported")
 }
 
 func (db *Database) Tail() (uint64, error) {
-	//TODO implement me
-	panic("implement me")
+	panic("not supported")
 }
 
 func (db *Database) AncientSize(kind string) (uint64, error) {
-	//TODO implement me
-	panic("implement me")
+	panic("not supported")
 }
 
 func (db *Database) ReadAncients(fn func(op ethdb.AncientReaderOp) error) (err error) {
-	//TODO implement me
-	panic("implement me")
+	panic("not supported")
 }
 
 func (db *Database) Put(key []byte, value []byte) error {
-	//TODO implement me
-	panic("implement me")
+	panic("not supported")
 }
 
 func (db *Database) Delete(key []byte) error {
-	//TODO implement me
-	panic("implement me")
+	panic("not supported")
 }
 
 func (db *Database) ModifyAncients(f func(ethdb.AncientWriteOp) error) (int64, error) {
-	//TODO implement me
-	panic("implement me")
+	panic("not supported")
 }
 
 func (db *Database) TruncateHead(n uint64) error {
-	//TODO implement me
-	panic("implement me")
+	panic("not supported")
 }
 
 func (db *Database) TruncateTail(n uint64) error {
-	//TODO implement me
-	panic("implement me")
+	panic("not supported")
 }
 
 func (db *Database) Sync() error {
-	//TODO implement me
-	panic("implement me")
+	return nil
 }
 
 func (db *Database) MigrateTable(s string, f func([]byte) ([]byte, error)) error {
-	//TODO implement me
-	panic("implement me")
+	panic("not supported")
 }
 
 func (db *Database) NewBatch() ethdb.Batch {
-	//TODO implement me
-	panic("implement me")
+	panic("not supported")
 }
 
 func (db *Database) NewBatchWithSize(size int) ethdb.Batch {
-	//TODO implement me
-	panic("implement me")
+	panic("not supported")
 }
 
 func (db *Database) NewIterator(prefix []byte, start []byte) ethdb.Iterator {
-	//TODO implement me
-	panic("implement me")
+	panic("not supported")
 }
 
 func (db *Database) Stat(property string) (string, error) {
-	//TODO implement me
-	panic("implement me")
+	panic("not supported")
 }
 
 func (db *Database) AncientDatadir() (string, error) {
-	//TODO implement me
-	panic("implement me")
+	panic("not supported")
 }
 
 func (db *Database) Compact(start []byte, limit []byte) error {
-	//TODO implement me
-	panic("implement me")
+	return nil
 }
 
 func (db *Database) NewSnapshot() (ethdb.Snapshot, error) {
-	//TODO implement me
-	panic("implement me")
+	panic("not supported")
 }
 
 func (db *Database) Close() error {
-	//TODO implement me
-	panic("implement me")
+	return nil
 }
 
 func dialRPC(endpoint string) (*rpc.Client, error) {

--- a/ethdb/remotedb/remotedb.go
+++ b/ethdb/remotedb/remotedb.go
@@ -23,10 +23,11 @@ package remotedb
 
 import (
 	"errors"
+	"strings"
+
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/ethdb"
 	"github.com/ethereum/go-ethereum/rpc"
-	"strings"
 )
 
 // Database is a key-value lookup for a remote database via debug_dbGet.

--- a/ethdb/remotedb/remotedb.go
+++ b/ethdb/remotedb/remotedb.go
@@ -1,0 +1,183 @@
+// Copyright 2022 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+// Package remotedb implements the key-value database layer based on a remote geth
+// node. Under the hood, it utilises the `debug_dbGet` method to implement a
+// read-only database.
+// There really are no guarantees in this database, since the local geth does not
+// exclusive access, but it can be used for basic diagnostics of a remote node.
+package remotedb
+
+import (
+	"errors"
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/ethereum/go-ethereum/ethdb"
+	"github.com/ethereum/go-ethereum/rpc"
+	"strings"
+)
+
+// Database is a key-value lookup for a remote database via debug_dbGet.
+type Database struct {
+	remote *rpc.Client
+}
+
+func (db *Database) Has(key []byte) (bool, error) {
+	if _, err := db.Get(key); err != nil {
+		return true, nil
+	}
+	return false, nil
+}
+
+func (db *Database) Get(key []byte) ([]byte, error) {
+	var resp hexutil.Bytes
+	err := db.remote.Call(&resp, "debug_dbGet", hexutil.Bytes(key))
+	if err != nil {
+		return nil, err
+	}
+	return resp, nil
+}
+
+func (db *Database) HasAncient(kind string, number uint64) (bool, error) {
+	//TODO implement me
+	panic("implement me")
+}
+
+func (db *Database) Ancient(kind string, number uint64) ([]byte, error) {
+	//TODO implement me
+	panic("implement me")
+}
+
+func (db *Database) AncientRange(kind string, start, count, maxBytes uint64) ([][]byte, error) {
+	//TODO implement me
+	panic("implement me")
+}
+
+func (db *Database) Ancients() (uint64, error) {
+	//TODO implement me
+	panic("implement me")
+}
+
+func (db *Database) Tail() (uint64, error) {
+	//TODO implement me
+	panic("implement me")
+}
+
+func (db *Database) AncientSize(kind string) (uint64, error) {
+	//TODO implement me
+	panic("implement me")
+}
+
+func (db *Database) ReadAncients(fn func(op ethdb.AncientReaderOp) error) (err error) {
+	//TODO implement me
+	panic("implement me")
+}
+
+func (db *Database) Put(key []byte, value []byte) error {
+	//TODO implement me
+	panic("implement me")
+}
+
+func (db *Database) Delete(key []byte) error {
+	//TODO implement me
+	panic("implement me")
+}
+
+func (db *Database) ModifyAncients(f func(ethdb.AncientWriteOp) error) (int64, error) {
+	//TODO implement me
+	panic("implement me")
+}
+
+func (db *Database) TruncateHead(n uint64) error {
+	//TODO implement me
+	panic("implement me")
+}
+
+func (db *Database) TruncateTail(n uint64) error {
+	//TODO implement me
+	panic("implement me")
+}
+
+func (db *Database) Sync() error {
+	//TODO implement me
+	panic("implement me")
+}
+
+func (db *Database) MigrateTable(s string, f func([]byte) ([]byte, error)) error {
+	//TODO implement me
+	panic("implement me")
+}
+
+func (db *Database) NewBatch() ethdb.Batch {
+	//TODO implement me
+	panic("implement me")
+}
+
+func (db *Database) NewBatchWithSize(size int) ethdb.Batch {
+	//TODO implement me
+	panic("implement me")
+}
+
+func (db *Database) NewIterator(prefix []byte, start []byte) ethdb.Iterator {
+	//TODO implement me
+	panic("implement me")
+}
+
+func (db *Database) Stat(property string) (string, error) {
+	//TODO implement me
+	panic("implement me")
+}
+
+func (db *Database) AncientDatadir() (string, error) {
+	//TODO implement me
+	panic("implement me")
+}
+
+func (db *Database) Compact(start []byte, limit []byte) error {
+	//TODO implement me
+	panic("implement me")
+}
+
+func (db *Database) NewSnapshot() (ethdb.Snapshot, error) {
+	//TODO implement me
+	panic("implement me")
+}
+
+func (db *Database) Close() error {
+	//TODO implement me
+	panic("implement me")
+}
+
+func dialRPC(endpoint string) (*rpc.Client, error) {
+	if endpoint == "" {
+		return nil, errors.New("endpoint must be specified")
+	}
+	if strings.HasPrefix(endpoint, "rpc:") || strings.HasPrefix(endpoint, "ipc:") {
+		// Backwards compatibility with geth < 1.5 which required
+		// these prefixes.
+		endpoint = endpoint[4:]
+	}
+	return rpc.Dial(endpoint)
+}
+
+func New(endpoint string) (ethdb.Database, error) {
+	client, err := dialRPC(endpoint)
+	if err != nil {
+		return nil, err
+	}
+	return &Database{
+		remote: client,
+	}, nil
+}

--- a/ethdb/remotedb/remotedb.go
+++ b/ethdb/remotedb/remotedb.go
@@ -135,6 +135,7 @@ func (db *Database) NewSnapshot() (ethdb.Snapshot, error) {
 }
 
 func (db *Database) Close() error {
+	db.remote.Close()
 	return nil
 }
 

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -1972,15 +1972,6 @@ func (api *PrivateDebugAPI) SetHead(number hexutil.Uint64) {
 	api.b.SetHead(uint64(number))
 }
 
-// DbGet returns the raw value of a key stored in the database.
-func (api *PrivateDebugAPI) DbGet(key string) (hexutil.Bytes, error) {
-	blob, err := common.ParseHexOrString(key)
-	if err != nil {
-		return nil, err
-	}
-	return api.b.ChainDb().Get(blob)
-}
-
 // PublicNetAPI offers network related RPC methods
 type PublicNetAPI struct {
 	net            *p2p.Server

--- a/internal/ethapi/dbapi.go
+++ b/internal/ethapi/dbapi.go
@@ -1,0 +1,27 @@
+package ethapi
+
+import (
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
+)
+
+// DbGet returns the raw value of a key stored in the database.
+func (api *PrivateDebugAPI) DbGet(key string) (hexutil.Bytes, error) {
+	blob, err := common.ParseHexOrString(key)
+	if err != nil {
+		return nil, err
+	}
+	return api.b.ChainDb().Get(blob)
+}
+
+// DbAncient retrieves an ancient binary blob from the append-only immutable files.
+// It is a mapping to the `AncientReaderOp.Ancient` method
+func (api *PrivateDebugAPI) DbAncient(kind string, number uint64) (hexutil.Bytes, error) {
+	return api.b.ChainDb().Ancient(kind, number)
+}
+
+// DbAncients returns the ancient item numbers in the ancient store.
+// It is a mapping to the `AncientReaderOp.Ancients` method
+func (api *PrivateDebugAPI) DbAncients() (uint64, error) {
+	return api.b.ChainDb().Ancients()
+}

--- a/internal/ethapi/dbapi.go
+++ b/internal/ethapi/dbapi.go
@@ -1,3 +1,19 @@
+// Copyright 2022 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
 package ethapi
 
 import (

--- a/internal/web3ext/web3ext.go
+++ b/internal/web3ext/web3ext.go
@@ -476,6 +476,16 @@ web3._extend({
 			call: 'debug_dbGet',
 			params: 1
 		}),
+		new web3._extend.Method({
+			name: 'dbAncient',
+			call: 'debug_dbAncient',
+			params: 2
+		}),
+		new web3._extend.Method({
+			name: 'dbAncients',
+			call: 'debug_dbAncients',
+			params: 0
+		}),
 	],
 	properties: []
 });


### PR DESCRIPTION
I'm not sure if this PR belongs in geth -- it's one of those PRs which doesn't _have_ to be in mainline geth, since it's not useful for the bulk of users. 
This is useful for investigating remote nodes. In many cases when something odd happens, we have to ask people to do various tasks, looking up db values or checking things over rpc. 

Alternatively, we make a special branch with some investigative tools and ask them to compile + redeploy. 

Since a while back, we added `debug_dbGet` to the rpc namespace, which allows us to just wrap the remote rpc endpoint as a database (it'll be readonly, since we decided not to include deletion/modification). 

Examples

Attaching to a local rpc node and getting the metadata: 
```
$ ./build/bin/geth --remotedb "ipc:///home/user/.ethereum/sepolia/geth.ipc" db metadata
INFO [05-09|13:37:50.715] Maximum peer count                       ETH=50 LES=0 total=50
INFO [05-09|13:37:50.715] Smartcard socket not found, disabling    err="stat /run/pcscd/pcscd.comm: no such file or directory"
INFO [05-09|13:37:50.716] Set global gas cap                       cap=50,000,000
INFO [05-09|13:37:50.716] Allocated cache and file handles         database=/home/user/.ethereum/geth/chaindata cache=512.00MiB handles=262,144 readonly=true
INFO [05-09|13:37:50.724] Opened ancient database                  database=/home/user/.ethereum/geth/chaindata/ancient readonly=true
+-------------------------+--------------------------------------------------------------------+
|          FIELD          |                               VALUE                                |
+-------------------------+--------------------------------------------------------------------+
| databaseVersion         | 8 (0x8)                                                            |
| headBlockHash           | 0xd4e56740f876aef8c010b86a40d5f56745a118d0906a34e69aec8c0db1cb8fa3 |
| headFastBlockHash       | 0xd4e56740f876aef8c010b86a40d5f56745a118d0906a34e69aec8c0db1cb8fa3 |
| headHeaderHash          | 0xd4e56740f876aef8c010b86a40d5f56745a118d0906a34e69aec8c0db1cb8fa3 |
| headBlock.Hash          | 0xd4e56740f876aef8c010b86a40d5f56745a118d0906a34e69aec8c0db1cb8fa3 |
| headBlock.Root          | 0xd7f8974fb5ac78d9ac099b9ad5018bedc2ce0a72dad1827a1709da30580f0544 |
| headBlock.Number        | 0 (0x0)                                                            |
| headHeader.Hash         | 0xd4e56740f876aef8c010b86a40d5f56745a118d0906a34e69aec8c0db1cb8fa3 |
| headHeader.Root         | 0xd7f8974fb5ac78d9ac099b9ad5018bedc2ce0a72dad1827a1709da30580f0544 |
| headHeader.Number       | 0 (0x0)                                                            |
| frozen                  | 0 items                                                            |
| lastPivotNumber         | <nil>                                                              |
| len(snapshotSyncStatus) | 0 bytes                                                            |
| snapshotGenerator       | Done: true, Accounts: 0,                                           |
|                         | Slots: 0, Storage: 0, Marker:                                      |
| snapshotDisabled        | false                                                              |
| snapshotJournal         | 34 bytes                                                           |
| snapshotRecoveryNumber  | <nil>                                                              |
| snapshotRoot            | 0xd7f8974fb5ac78d9ac099b9ad5018bedc2ce0a72dad1827a1709da30580f0544 |
| txIndexTail             | <nil>                                                              |
| fastTxLookupLimit       | <nil>                                                              |
+-------------------------+--------------------------------------------------------------------+

```
Attaching to a local ipc endpoint and fetching the snapshot root
```
$ ./build/bin/geth --remotedb "ipc:///home/user/.ethereum/sepolia/geth.ipc" db get SnapshotRoot
INFO [05-09|13:50:50.530] Maximum peer count                       ETH=50 LES=0 total=50
INFO [05-09|13:50:50.530] Smartcard socket not found, disabling    err="stat /run/pcscd/pcscd.comm: no such file or directory"
INFO [05-09|13:50:50.531] Set global gas cap                       cap=50,000,000
INFO [05-09|13:50:50.531] Allocated cache and file handles         database=/home/user/.ethereum/geth/chaindata cache=512.00MiB handles=262,144 readonly=true
INFO [05-09|13:50:50.535] Opened ancient database                  database=/home/user/.ethereum/geth/chaindata/ancient readonly=true
key 0x536e617073686f74526f6f74: 0xd7f8974fb5ac78d9ac099b9ad5018bedc2ce0a72dad1827a1709da30580f0544
```
Dumping the snapshot state
```
[user@work go-ethereum]$ ./build/bin/geth --remotedb "ipc:///home/user/.ethereum/sepolia/geth.ipc" snapshot dump
INFO [05-09|13:51:49.470] Maximum peer count                       ETH=50 LES=0 total=50
INFO [05-09|13:51:49.470] Smartcard socket not found, disabling    err="stat /run/pcscd/pcscd.comm: no such file or directory"
INFO [05-09|13:51:49.472] Set global gas cap                       cap=50,000,000
INFO [05-09|13:51:49.472] Allocated cache and file handles         database=/home/user/.ethereum/geth/chaindata cache=512.00MiB handles=262,144 readonly=true
INFO [05-09|13:51:49.477] Opened ancient database                  database=/home/user/.ethereum/geth/chaindata/ancient readonly=true
INFO [05-09|13:51:49.477] State dump configured                    block=0 hash=0xd4e56740f876aef8c010b86a40d5f56745a118d0906a34e69aec8c0db1cb8fa3 skipcode=false skipstorage=false start=0x0000000000000000000000000000000000000000000000000000000000000000 limit=0
INFO [05-09|13:51:49.478] Snapshot dumping started                 root=d7f897..0f0544
{"root":"0xd7f8974fb5ac78d9ac099b9ad5018bedc2ce0a72dad1827a1709da30580f0544"}
{"balance":"466215000000000000000","nonce":0,"root":"0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421","codeHash":"0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470","key":"0x000388c5ba62b0e7342687d94b0e03b772aa4ab7c08f13fe3fa9f9d0a3153e05"}
{"balance":"100000000000000000000000","nonce":0,"root":"0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421","codeHash":"0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470","key":"0x0004204188718653cd7e50f3fd51a820db66112517ca190c637e7cdd80782d56"}
{"balance":"2000000000000000000000","nonce":0,"root":"0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421","codeHash":"0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470","key":"0x0004a390953f116afb00f89fbedb2f8e77297e4e7e1749e2ef0e32e17808e4ad"}
{"balance":"910000000000000000000","nonce":0,"root":"0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421","codeHash":"0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470","key":"0x0005bd66f60e5b954e1af93ded1b02cb575ff0ed6d9241797eff7576b0bf0637"}
{"balance":"206764195000000000000000","nonce":0,"root":"0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421","codeHash":"0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470","key":"0x00074ae55b1d051a42ba19c0cc51f93eae4ab2db5a2eebc31a7b89cb0bb88039"}
{"balance":"16011846000000000000000","nonce":0,"root":"0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421","codeHash":"0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470","key":"0x0016c9db9bb545a03425e300f3ee72bae098110336dd3eaf48c20a2e5b6865fc"}
```
Verifying the snapshot state
```
$ ./build/bin/geth --remotedb "ipc:///home/user/.ethereum/sepolia/geth.ipc" snapshot verify-state
INFO [05-09|13:52:24.602] Maximum peer count                       ETH=50 LES=0 total=50
INFO [05-09|13:52:24.602] Smartcard socket not found, disabling    err="stat /run/pcscd/pcscd.comm: no such file or directory"
INFO [05-09|13:52:24.603] Set global gas cap                       cap=50,000,000
INFO [05-09|13:52:24.604] Allocated cache and file handles         database=/home/user/.ethereum/geth/chaindata cache=512.00MiB handles=262,144 readonly=true
INFO [05-09|13:52:24.612] Opened ancient database                  database=/home/user/.ethereum/geth/chaindata/ancient readonly=true
INFO [05-09|13:52:24.614] Iterating state snapshot                 accounts=0 slots=0 elapsed="304.4µs"
INFO [05-09|13:52:24.869] Iterated snapshot                        accounts=8893 elapsed=255.693ms
INFO [05-09|13:52:24.869] Verified the state                       root=d7f897..0f0544
INFO [05-09|13:52:24.869] Checking dangling snapshot disk storage 
INFO [05-09|13:52:24.869] Verified the snapshot disk storage       time="26.632µs" err=nil
INFO [05-09|13:52:24.869] Checking dangling snapshot difflayer journalled storage 
INFO [05-09|13:52:24.869] Verified the snapshot journalled storage time="16.572µs"
```