### PR TITLE
cmd/geth: tooling to verify integrity of trie nodes

### DIFF
--- a/cmd/geth/dbcmd.go
+++ b/cmd/geth/dbcmd.go
@@ -35,6 +35,7 @@ import (
 	"github.com/ethereum/go-ethereum/core/rawdb"
 	"github.com/ethereum/go-ethereum/core/state/snapshot"
 	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/ethdb"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/trie"
@@ -71,6 +72,7 @@ Remove blockchain and state databases`,
 			dbExportCmd,
 			dbMetadataCmd,
 			dbMigrateFreezerCmd,
+			dbCheckStateContentCmd,
 		},
 	}
 	dbInspectCmd = cli.Command{
@@ -82,6 +84,16 @@ Remove blockchain and state databases`,
 		}, utils.NetworkFlags, utils.DatabasePathFlags),
 		Usage:       "Inspect the storage size for each type of data in the database",
 		Description: `This commands iterates the entire database. If the optional 'prefix' and 'start' arguments are provided, then the iteration is limited to the given subset of data.`,
+	}
+	dbCheckStateContentCmd = cli.Command{
+		Action:    utils.MigrateFlags(checkStateContent),
+		Name:      "check-state-content",
+		ArgsUsage: "<prefix> <start>",
+		Flags:     utils.GroupFlags(utils.NetworkFlags, utils.DatabasePathFlags),
+		Usage:     "Verify that state data is cryptographically correct",
+		Description: `This command iterates the entire database for 32-byte keys, looking for rlp-encoded trie nodes.
+For each trie node encountered, it checks that the key corresponds to the keccak256(value). If this is not true, this indicates
+a data corruption.`,
 	}
 	dbStatCmd = cli.Command{
 		Action: utils.MigrateFlags(dbStats),
@@ -287,6 +299,66 @@ func inspect(ctx *cli.Context) error {
 	defer db.Close()
 
 	return rawdb.InspectDatabase(db, prefix, start)
+}
+
+func checkStateContent(ctx *cli.Context) error {
+	var (
+		prefix []byte
+		start  []byte
+	)
+	if ctx.NArg() > 2 {
+		return fmt.Errorf("Max 2 arguments: %v", ctx.Command.ArgsUsage)
+	}
+	if ctx.NArg() >= 1 {
+		if d, err := hexutil.Decode(ctx.Args().Get(0)); err != nil {
+			return fmt.Errorf("failed to hex-decode 'prefix': %v", err)
+		} else {
+			prefix = d
+		}
+	}
+	if ctx.NArg() >= 2 {
+		if d, err := hexutil.Decode(ctx.Args().Get(1)); err != nil {
+			return fmt.Errorf("failed to hex-decode 'start': %v", err)
+		} else {
+			start = d
+		}
+	}
+	stack, _ := makeConfigNode(ctx)
+	defer stack.Close()
+
+	db := utils.MakeChainDatabase(ctx, stack, true)
+	defer db.Close()
+	it := rawdb.NewKeyLengthIterator(db.NewIterator(prefix, start), 32)
+	hasher := crypto.NewKeccakState()
+	t := time.Now()
+	var (
+		got   = make([]byte, 32)
+		errs  int
+		count int
+	)
+	for it.Next() {
+		count++
+		v := it.Value()
+		k := it.Key()
+		hasher.Reset()
+		hasher.Write(v)
+		hasher.Read(got)
+		if !bytes.Equal(k, got) {
+			errs++
+			fmt.Printf("Error at 0x%x\n", k)
+			fmt.Printf("  Hash:  0x%x\n", got)
+			fmt.Printf("  Data:  0x%x\n", v)
+		}
+		if time.Since(t) > 8*time.Second {
+			log.Info("Iterating the database", "at", k)
+			t = time.Now()
+		}
+	}
+	if err := it.Error(); err != nil {
+		return err
+	}
+	log.Info("Iterated the state content", "errors", errs, "items", count)
+	return nil
 }
 
 func showLeveldbStats(db ethdb.KeyValueStater) {

--- a/cmd/geth/dbcmd.go
+++ b/cmd/geth/dbcmd.go
@@ -88,7 +88,7 @@ Remove blockchain and state databases`,
 	dbCheckStateContentCmd = cli.Command{
 		Action:    utils.MigrateFlags(checkStateContent),
 		Name:      "check-state-content",
-		ArgsUsage: "<prefix> <start>",
+		ArgsUsage: "<start (optional)>",
 		Flags:     utils.GroupFlags(utils.NetworkFlags, utils.DatabasePathFlags),
 		Usage:     "Verify that state data is cryptographically correct",
 		Description: `This command iterates the entire database for 32-byte keys, looking for rlp-encoded trie nodes.
@@ -306,18 +306,11 @@ func checkStateContent(ctx *cli.Context) error {
 		prefix []byte
 		start  []byte
 	)
-	if ctx.NArg() > 2 {
+	if ctx.NArg() > 1 {
 		return fmt.Errorf("Max 2 arguments: %v", ctx.Command.ArgsUsage)
 	}
-	if ctx.NArg() >= 1 {
-		if d, err := hexutil.Decode(ctx.Args().Get(0)); err != nil {
-			return fmt.Errorf("failed to hex-decode 'prefix': %v", err)
-		} else {
-			prefix = d
-		}
-	}
-	if ctx.NArg() >= 2 {
-		if d, err := hexutil.Decode(ctx.Args().Get(1)); err != nil {
+	if ctx.NArg() > 0 {
+		if d, err := hexutil.Decode(ctx.Args().First()); err != nil {
 			return fmt.Errorf("failed to hex-decode 'start': %v", err)
 		} else {
 			start = d
@@ -351,7 +344,7 @@ func checkStateContent(ctx *cli.Context) error {
 			fmt.Printf("  Data:  0x%x\n", v)
 		}
 		if time.Since(lastLog) > 8*time.Second {
-			log.Info("Iterating the database", "at", fmt.Sprintf("%#x", k), "elapsed", time.Since(startTime))
+			log.Info("Iterating the database", "at", fmt.Sprintf("%#x", k), "elapsed", common.PrettyDuration(time.Since(startTime)))
 			lastLog = time.Now()
 		}
 	}

--- a/cmd/geth/dbcmd.go
+++ b/cmd/geth/dbcmd.go
@@ -328,13 +328,14 @@ func checkStateContent(ctx *cli.Context) error {
 
 	db := utils.MakeChainDatabase(ctx, stack, true)
 	defer db.Close()
-	it := rawdb.NewKeyLengthIterator(db.NewIterator(prefix, start), 32)
-	hasher := crypto.NewKeccakState()
-	t := time.Now()
 	var (
-		got   = make([]byte, 32)
-		errs  int
-		count int
+		it        = rawdb.NewKeyLengthIterator(db.NewIterator(prefix, start), 32)
+		hasher    = crypto.NewKeccakState()
+		got       = make([]byte, 32)
+		errs      int
+		count     int
+		startTime = time.Now()
+		lastLog   = time.Now()
 	)
 	for it.Next() {
 		count++
@@ -349,9 +350,9 @@ func checkStateContent(ctx *cli.Context) error {
 			fmt.Printf("  Hash:  0x%x\n", got)
 			fmt.Printf("  Data:  0x%x\n", v)
 		}
-		if time.Since(t) > 8*time.Second {
-			log.Info("Iterating the database", "at", k)
-			t = time.Now()
+		if time.Since(lastLog) > 8*time.Second {
+			log.Info("Iterating the database", "at", fmt.Sprintf("%#x", k), "elapsed", time.Since(startTime))
+			lastLog = time.Now()
 		}
 	}
 	if err := it.Error(); err != nil {

--- a/cmd/geth/dbcmd.go
+++ b/cmd/geth/dbcmd.go
@@ -307,7 +307,7 @@ func checkStateContent(ctx *cli.Context) error {
 		start  []byte
 	)
 	if ctx.NArg() > 1 {
-		return fmt.Errorf("Max 2 arguments: %v", ctx.Command.ArgsUsage)
+		return fmt.Errorf("Max 1 argument: %v", ctx.Command.ArgsUsage)
 	}
 	if ctx.NArg() > 0 {
 		if d, err := hexutil.Decode(ctx.Args().First()); err != nil {


### PR DESCRIPTION
This PR adds `db` tooling to verify the integrity of trie nodes. It iterates through the 32-byte key space in the database, which is expected to contain RLP-encoded trie nodes, addressed by hash. 

It checks that the `hash(content)` corresponds to the key. 
Example when running this on a corrupt kiln-node database: 
```
INFO [05-10|08:43:32.845] Opened ancient database                  database=/home/user/tmp/kiln-investigation/geth/chaindata/ancient readonly=true
Error at 0x143ec96ddd6e1d624a5f3ad2cb8bc641f6adbda0817d8172c365a62fa0edfcd2
  Hash:  0x3004210bd6bc108fc06e951595ecd4599ec2391ed5ea4523b268535cfb1ee310
  Data:  0xf8719f2099a79d8d238177a65a424e9d5fb92c28e3021a49ea28e2cd766d0750f330b84ff84d808906f4cc3821aa200000a056e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421a0c5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470
Error at 0x2131115a6ef2577ee3eee37ea2a11c0dbee4f086f81e58efe9a5eb821633690f
  Hash:  0xcd1d0bc629f68dd281ee037ae833036d4e8011deaad9591a1aff2d4a95ecd170
  Data:  0xf8f1a01b5df4dff9832e5b516f98ad6c268f4d8c63c75f421b79cd2d5a2f42c4185aa2a0de189f162f9acee1d396960a7de539224a10490be8d8020f01c2afb0884ad09ca04fc212b60c1eb7af998971008d6a433fa81cad36f4a147dac189f2c65345d29b8080808080a0025f610ed7eba60ca506ce998239d9958bb1b184d737d39b39f710b47887762c8080a0a08aaa7b4fc16743a31cd91dd39110fef1c9516453794cd35f365f7479f10026a0f8256a0c594384301bd20dd7ec76c2724880d35a12631b0b959d67454a1270d68080a00e030eb425356690f5b4179b7fd999b9dc428645a7286692db3471b838c48dc680
Error at 0x2ff330b1c51e7b7109aaa2a71944cdf30708ceebc25d7b5d6fd10ba0d265c5fd
  Hash:  0x53ae6759e6c36cfd742cbb0bd36168756f6aaa82606427544de1c9979428b572
  Data:  0xf90211a0a0a3412dd207ff90bcbdcda83302776a61f4de2136951ac4d809b8ce583c4346a0f1020d65e41ab9ca272414a752b40a4b2a9758374f8c8cb4a150b168be17b785a0c9d52b2e6009b66aa72e272c78a30427494f2b9b00124ce388d5b028ea212cc6a049ef24c2b553874f13218d29836dfd4e07e98636db9a72ad09fe0d56888309daa05ac368638a5986139ca174bd0cae3a86a53c97459bca34e540244775c11d90d5a0c83d9a72001fbd6b8a096d9ec4212d6a6ebae348d9cc3ca2fe63e3b333569388a03770ffd1e93f123f514678efb1d37569db3378b3bf6885bd2d2f592b6e75d330a0ea440d1ec3b611e1fb90da539a0414b1d3f91d194c65438b2f40b21984867a4ca0e886ff89dc630c17cdc4e2feffd7236d5f55361c39284015a3278943cc367432a020f5ea3c391520121a9744ff0bbf0107465d1d33bda30562e60c0237506491f8a0fc40751197edc558a3d91a1d059fcc4c4d09ca43c0ab762e1b08a9688ddce2e6a05d928f673fe1b70fdf67ecaf1ffe8b15cf1a7d4cf58908c2aeb1c07e45045a65a0c7ad58b47e33a97b62792d9aaeb774efdcd957a01f8fc89f888f8468216f871fa001dc494b0b630810caeddcbc11dfe17989e1bef77568d91e15171547a2711d38a0f2c005d59584ef7a253f9b5edc17293e67dd7c5fca550cb8e412d6d10fa9d830a06979b49dbd2ba492c2b7450b69fc3f2cf1c2e5e7c02fbc118268174e918aeb9b80
Error at 0x42f8e6c024b9378159eb685ccfccbd26ea9cf7c025f3edc5f65a91a0b693360d
  Hash:  0xd468b02d98b88e932f9e15a0e9df526b1a27f729eddf4f943acfb260f893b58b
  Data:  0xf90211a045261b17cfc1605d50cf7489331cbcc6d218adffc2651066ea3d82f410fde63da0a447db3841da4726e070d346b5c89b5901a0a08771731830cdc514280aeb2225a03b892f4884ab34db112d36b97a584a852642809bfd69a0b8b684b03a5bb8b2aea0ccc38046ab4d8642034142be97068ff5afdf26c70515137e301eb19974ebc543a02ff28f71a9b3892a1152ef999c04c0c2f127ba9f8d2c74771714f8622b3a6205a0b544dacfc15f200661a9afcb82a8ce886e31ef93a27851fb2f269c373e20f8dfa0f849baaadc8e31ee0c58f1dedb145a648983cc5786477a9ccef67cfb937669d3a07930e4bda4fbd0a08f7f424a0a27580d96ec4f0df1393d27c98e55bafc9d3356a0d1611f7ce7b17c09e05280f554c87cb554c7f50549f79dae76d56411829ccc0aa003d68400e7030d5d76bde911f631b0bd0b5b8b579e6a4199541afe3b4e7d6004a044c4d9cf6c0ce06a4cfa081c8cbd1c7f64b8828085fbe2ea996266b98046f906a05c0ac0b3eb9c8992026909ded16187313645350d0df0c7030d98f0e5bfaf4453a0d0a85d14751da6c00487000814fe12273629523d4e58f553cc963375da588037a049e3ff8bf931291e43c811280a63a94440ef31e8d3453c3a1d9ad5181211c169a03d4acca1ae65dff9c27e1f835133b5507733587c85772bc15ec42b4be1a8ac4aa03d9eaa41c6b64779a6876a810419c51cb0d93f2521d72433c13c50accfcf217f80
Error at 0x68f78d289955e054f72d1b94fcfd6b955f7d5260185ba4396fe178267aa6503a
  Hash:  0xaf3ae3d36d25e86483f6e883ee95444ae4e2e6eb0f268485e856b463d708df71
  Data:  0xf851a0f06cf1cfee45a46e4536562c0037a2e0ac2338a603ca50c11b20d7a2308a14ea8080808080808080808080a06ea7ed92aab1ef9f9b86d4bf45d54f97c09fd635a84da0efe97e8a1f9c4c603080808080
Error at 0x92c6aed5a1455a299d1b08697eb02579bfd49dab7043bc251b09f0d96ee4ff24
  Hash:  0x5edb89bf3c22c2b7fcd82898bf6ff6033fcaf54b67b8742c70e02f1acb15e47f
  Data:  0xf85180808080a04e7eaee6ee9fd0ac6ff4e01195d344af4590bd3ba2e8998fd3ad93c9545170fa80808080808080808080a0ee7e80a91b7b7b3613f878ec17a54d5e22d4ef40a5a3de30bd5089c2de56b45a80
Error at 0x95139d2a91cb70b367beb126fc08835a0688e1c40c6c67f458d39446ba9ed24d
  Hash:  0xebee40d906443c44c8ff216be7ae54282c10f28cfffefc377bde017bccedb850
  Data:  0xf851a0e05e939bf08f4700dfa1f2e23e355e58751d29e65debddc703ea4652c9f1dc3a8080808080a077a6d2a5f8876a9aa386bf3b3796f94e509ed9dd9382eb9e25805867b61d163e80808080808080808080
Error at 0x972a54ff62baf5414c7e3e6ecf02a1fd8cff11b8d7f79baa538861e932d5fe27
  Hash:  0x48a70b1560b0dbdfaf89eeb8e4439c79ab6a84e56c9631177e86e95fa93ef746
  Data:  0xf8918080808080a03d1abf049c6780b314852f7a26728a17e474084ff4e80268b148d4745d5c93c2a0f0c7bd1b16dd22148040f93f0285f44a44a680ae8d1c999de134183b7012ac04a034ddff8cc6928353b92bbf7a90800b93aa235571e984f7ad912daac0cc71065b80808080808080a08139a919177c652cede0086dae9a552d1ea290419414bdf4e6cf757cf10b4f1880
Error at 0xaa7b003beda35de9746b4c71a8e3d7a03e8e6f03a012a8304ab9329dcef63af9
  Hash:  0x8f56a79e68718bd0bcc448771a8f30c4cc4516b0561bcce3e32cdadce7badfc8
  Data:  0xe21ca0ce85e962777c1140558f00b4dc5555353a491f9896fdc40b0ba3e1f392be62d8
Error at 0xad0a53460337827814106e29b3009edba092b263555b71b7124a25ed44e4a4b8
  Hash:  0xd1f12b88057dc8e32bd718e73b3048b1228976f81f9a011816ad457de354ea38
  Data:  0xf8429f20e0c73251854c2957ead6abf110bb31123a88630005660cf57079cf8cdb63a1a0706b66455835753036517a736737506730767a77537541594d57316c776e6f45
Error at 0xb3b81f4b301a24891f7c83db2a86f81072d028f4ab1274dde78f399368f6a136
  Hash:  0xb2856c2fd5ef76120eb8fad4023de1d53eb7ad339d914e73a08c54d651df3323
  Data:  0xf8718080808080808080a0f94eea872da881a138a072fbbbe2b7794243284668d50fa859626205f4372212a0655d2befa6c140fbfabe57c15f9756d95498b76ac001184a6addbf60c0899b328080a01fd6d3f965372040f5ca24d21d21db3ba2e48abf0549fd4da14026b5fc98f05380808080
Error at 0xb7b8fff7f05c920e2996a9374cbfa8fb00fc4f7ebbdfe3c9d6743b3678d1f773
  Hash:  0x48b5583e7e509cef5e15b61400d465938cae601d71a31686755cfb17b4d9e45a
  Data:  0xf8429f3280ff542a8c12f1601ee8f578fc2bcc171b0a7e14b8dae188e297f84a2c53a1a06f4c725030695279416c556b424a5857426b78794b4536643857626c47664733
Error at 0xcf7562193e317aa79f64482883e76ad5502fd9efb1d0f7dfcb4123194d4917e4
  Hash:  0xa251797efe8de4fdd5327e41983b0993f6c78f85bb19f082b45f72bda9435c5d
  Data:  0xf851808080a0c435ee67f428f8286e56aac8e33522a59f393ac60b068bd66dd8226b5d5a4eb48080808080a051abb526b88ae6109b750548268cc1f1ff966d4464a55fe33feecf59fe0aa27980808080808080
Error at 0xd0a8c092bb4d80b78f11c152137f6b143791cd759a8d502a339f2d939e426a11
  Hash:  0x25499ac647f67441fdb8d86818a6543307e343ad9fd21ff09524b4e1ac59857c
  Data:  0xf8b1808080a0020b4d971e12d6501331b84eae7473432829496d5d383d6ac333a7eea96a713da02d56ea9d651f1cc57d62e475f4fe3c9893159c9db30302e3f892496883c080b2808080808080a017bb89ed42ee56286fc26f9227c25e2aabfbea6773c32aa350e4dd70318a65528080a02dd82acc1a613f7498495a43cabc352d5bfde3972209993295aaef50a768c5aca02220ecfd80216bf041f9225938b72a813d3fc77b262ef7507d47327cd517782b80
INFO [05-10|08:43:34.646] Iterated the state content               errors=14 items=387,806

```