### PR TITLE
no value of type uint64 is less than 0

### DIFF
--- a/cmd/utils/diskusage.go
+++ b/cmd/utils/diskusage.go
@@ -32,12 +32,5 @@ func getFreeDiskSpace(path string) (uint64, error) {
 	}
 
 	// Available blocks * size per block = available space in bytes
-	var bavail = stat.Bavail
-	if stat.Bavail < 0 {
-		// FreeBSD can have a negative number of blocks available
-		// because of the grace limit.
-		bavail = 0
-	}
-	//nolint:unconvert
-	return uint64(bavail) * uint64(stat.Bsize), nil
+	return stat.Bavail * uint64(stat.Bsize), nil
 }


### PR DESCRIPTION
I removed this redundant code, because a check on a `uint64` type whether it's less than 0 is useless.
Also, remove the redundant `uint64` casting as both `bavail` and `stat.Bavail` are already `uint64`.

Is it possible to get negative number of blocks on FreeBSD !?
Because `stat.Bavail` is `uint64`...

Please correct me if I'm wrong.

A few nanoseconds faster is always better ^_^