### PR TITLE
Update benchmark to use bench format instead of wrapping fmt sprintf

### DIFF
--- a/core/vm/contracts_test.go
+++ b/core/vm/contracts_test.go
@@ -185,7 +185,7 @@ func benchmarkPrecompiled(addr string, test precompiledTest, bench *testing.B) {
 			return
 		}
 		if common.Bytes2Hex(res) != test.Expected {
-			bench.Error(fmt.Sprintf("Expected %v, got %v", test.Expected, common.Bytes2Hex(res)))
+			bench.Errorf("Expected %v, got %v", test.Expected, common.Bytes2Hex(res))
 			return
 		}
 	})


### PR DESCRIPTION
This PR switches from wrapping `fmt.Sprintf` with `bench.Error` to calling `bench.Errorf` directly.