### PR TITLE
core/vm: Add method Stack.popptr and apply to a bunch of instructions

### DIFF
--- a/core/vm/instructions.go
+++ b/core/vm/instructions.go
@@ -27,56 +27,56 @@ import (
 )
 
 func opAdd(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]byte, error) {
-	x, y := scope.Stack.pop(), scope.Stack.peek()
-	y.Add(&x, y)
+	x, y := scope.Stack.popptr(), scope.Stack.peek()
+	y.Add(x, y)
 	return nil, nil
 }
 
 func opSub(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]byte, error) {
-	x, y := scope.Stack.pop(), scope.Stack.peek()
-	y.Sub(&x, y)
+	x, y := scope.Stack.popptr(), scope.Stack.peek()
+	y.Sub(x, y)
 	return nil, nil
 }
 
 func opMul(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]byte, error) {
-	x, y := scope.Stack.pop(), scope.Stack.peek()
-	y.Mul(&x, y)
+	x, y := scope.Stack.popptr(), scope.Stack.peek()
+	y.Mul(x, y)
 	return nil, nil
 }
 
 func opDiv(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]byte, error) {
-	x, y := scope.Stack.pop(), scope.Stack.peek()
-	y.Div(&x, y)
+	x, y := scope.Stack.popptr(), scope.Stack.peek()
+	y.Div(x, y)
 	return nil, nil
 }
 
 func opSdiv(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]byte, error) {
-	x, y := scope.Stack.pop(), scope.Stack.peek()
-	y.SDiv(&x, y)
+	x, y := scope.Stack.popptr(), scope.Stack.peek()
+	y.SDiv(x, y)
 	return nil, nil
 }
 
 func opMod(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]byte, error) {
-	x, y := scope.Stack.pop(), scope.Stack.peek()
-	y.Mod(&x, y)
+	x, y := scope.Stack.popptr(), scope.Stack.peek()
+	y.Mod(x, y)
 	return nil, nil
 }
 
 func opSmod(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]byte, error) {
-	x, y := scope.Stack.pop(), scope.Stack.peek()
-	y.SMod(&x, y)
+	x, y := scope.Stack.popptr(), scope.Stack.peek()
+	y.SMod(x, y)
 	return nil, nil
 }
 
 func opExp(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]byte, error) {
-	base, exponent := scope.Stack.pop(), scope.Stack.peek()
-	exponent.Exp(&base, exponent)
+	base, exponent := scope.Stack.popptr(), scope.Stack.peek()
+	exponent.Exp(base, exponent)
 	return nil, nil
 }
 
 func opSignExtend(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]byte, error) {
-	back, num := scope.Stack.pop(), scope.Stack.peek()
-	num.ExtendSign(num, &back)
+	back, num := scope.Stack.popptr(), scope.Stack.peek()
+	num.ExtendSign(num, back)
 	return nil, nil
 }
 
@@ -87,7 +87,7 @@ func opNot(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]byte
 }
 
 func opLt(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]byte, error) {
-	x, y := scope.Stack.pop(), scope.Stack.peek()
+	x, y := scope.Stack.popptr(), scope.Stack.peek()
 	if x.Lt(y) {
 		y.SetOne()
 	} else {
@@ -97,7 +97,7 @@ func opLt(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]byte,
 }
 
 func opGt(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]byte, error) {
-	x, y := scope.Stack.pop(), scope.Stack.peek()
+	x, y := scope.Stack.popptr(), scope.Stack.peek()
 	if x.Gt(y) {
 		y.SetOne()
 	} else {
@@ -107,7 +107,7 @@ func opGt(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]byte,
 }
 
 func opSlt(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]byte, error) {
-	x, y := scope.Stack.pop(), scope.Stack.peek()
+	x, y := scope.Stack.popptr(), scope.Stack.peek()
 	if x.Slt(y) {
 		y.SetOne()
 	} else {
@@ -117,7 +117,7 @@ func opSlt(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]byte
 }
 
 func opSgt(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]byte, error) {
-	x, y := scope.Stack.pop(), scope.Stack.peek()
+	x, y := scope.Stack.popptr(), scope.Stack.peek()
 	if x.Sgt(y) {
 		y.SetOne()
 	} else {
@@ -127,7 +127,7 @@ func opSgt(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]byte
 }
 
 func opEq(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]byte, error) {
-	x, y := scope.Stack.pop(), scope.Stack.peek()
+	x, y := scope.Stack.popptr(), scope.Stack.peek()
 	if x.Eq(y) {
 		y.SetOne()
 	} else {
@@ -147,42 +147,42 @@ func opIszero(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]b
 }
 
 func opAnd(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]byte, error) {
-	x, y := scope.Stack.pop(), scope.Stack.peek()
-	y.And(&x, y)
+	x, y := scope.Stack.popptr(), scope.Stack.peek()
+	y.And(x, y)
 	return nil, nil
 }
 
 func opOr(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]byte, error) {
-	x, y := scope.Stack.pop(), scope.Stack.peek()
-	y.Or(&x, y)
+	x, y := scope.Stack.popptr(), scope.Stack.peek()
+	y.Or(x, y)
 	return nil, nil
 }
 
 func opXor(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]byte, error) {
-	x, y := scope.Stack.pop(), scope.Stack.peek()
-	y.Xor(&x, y)
+	x, y := scope.Stack.popptr(), scope.Stack.peek()
+	y.Xor(x, y)
 	return nil, nil
 }
 
 func opByte(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]byte, error) {
-	th, val := scope.Stack.pop(), scope.Stack.peek()
-	val.Byte(&th)
+	th, val := scope.Stack.popptr(), scope.Stack.peek()
+	val.Byte(th)
 	return nil, nil
 }
 
 func opAddmod(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]byte, error) {
-	x, y, z := scope.Stack.pop(), scope.Stack.pop(), scope.Stack.peek()
+	x, y, z := scope.Stack.popptr(), scope.Stack.popptr(), scope.Stack.peek()
 	if z.IsZero() {
 		z.Clear()
 	} else {
-		z.AddMod(&x, &y, z)
+		z.AddMod(x, y, z)
 	}
 	return nil, nil
 }
 
 func opMulmod(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]byte, error) {
-	x, y, z := scope.Stack.pop(), scope.Stack.pop(), scope.Stack.peek()
-	z.MulMod(&x, &y, z)
+	x, y, z := scope.Stack.popptr(), scope.Stack.popptr(), scope.Stack.peek()
+	z.MulMod(x, y, z)
 	return nil, nil
 }
 
@@ -191,7 +191,7 @@ func opMulmod(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]b
 // and pushes on the stack arg2 shifted to the left by arg1 number of bits.
 func opSHL(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]byte, error) {
 	// Note, second operand is left in the stack; accumulate result into it, and no need to push it afterwards
-	shift, value := scope.Stack.pop(), scope.Stack.peek()
+	shift, value := scope.Stack.popptr(), scope.Stack.peek()
 	if shift.LtUint64(256) {
 		value.Lsh(value, uint(shift.Uint64()))
 	} else {
@@ -205,7 +205,7 @@ func opSHL(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]byte
 // and pushes on the stack arg2 shifted to the right by arg1 number of bits with zero fill.
 func opSHR(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]byte, error) {
 	// Note, second operand is left in the stack; accumulate result into it, and no need to push it afterwards
-	shift, value := scope.Stack.pop(), scope.Stack.peek()
+	shift, value := scope.Stack.popptr(), scope.Stack.peek()
 	if shift.LtUint64(256) {
 		value.Rsh(value, uint(shift.Uint64()))
 	} else {
@@ -218,7 +218,7 @@ func opSHR(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]byte
 // The SAR instruction (arithmetic shift right) pops 2 values from the stack, first arg1 and then arg2,
 // and pushes on the stack arg2 shifted to the right by arg1 number of bits with sign extension.
 func opSAR(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]byte, error) {
-	shift, value := scope.Stack.pop(), scope.Stack.peek()
+	shift, value := scope.Stack.popptr(), scope.Stack.peek()
 	if shift.GtUint64(256) {
 		if value.Sign() >= 0 {
 			value.Clear()
@@ -234,7 +234,7 @@ func opSAR(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]byte
 }
 
 func opKeccak256(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]byte, error) {
-	offset, size := scope.Stack.pop(), scope.Stack.peek()
+	offset, size := scope.Stack.popptr(), scope.Stack.peek()
 	data := scope.Memory.GetPtr(int64(offset.Uint64()), int64(size.Uint64()))
 
 	if interpreter.hasher == nil {
@@ -298,9 +298,9 @@ func opCallDataSize(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext
 
 func opCallDataCopy(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]byte, error) {
 	var (
-		memOffset  = scope.Stack.pop()
-		dataOffset = scope.Stack.pop()
-		length     = scope.Stack.pop()
+		memOffset  = scope.Stack.popptr()
+		dataOffset = scope.Stack.popptr()
+		length     = scope.Stack.popptr()
 	)
 	dataOffset64, overflow := dataOffset.Uint64WithOverflow()
 	if overflow {
@@ -321,9 +321,9 @@ func opReturnDataSize(pc *uint64, interpreter *EVMInterpreter, scope *ScopeConte
 
 func opReturnDataCopy(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]byte, error) {
 	var (
-		memOffset  = scope.Stack.pop()
-		dataOffset = scope.Stack.pop()
-		length     = scope.Stack.pop()
+		memOffset  = scope.Stack.popptr()
+		dataOffset = scope.Stack.popptr()
+		length     = scope.Stack.popptr()
 	)
 
 	offset64, overflow := dataOffset.Uint64WithOverflow()
@@ -332,7 +332,7 @@ func opReturnDataCopy(pc *uint64, interpreter *EVMInterpreter, scope *ScopeConte
 	}
 	// we can reuse dataOffset now (aliasing it for clarity)
 	var end = dataOffset
-	end.Add(&dataOffset, &length)
+	end.Add(dataOffset, length)
 	end64, overflow := end.Uint64WithOverflow()
 	if overflow || uint64(len(interpreter.returnData)) < end64 {
 		return nil, ErrReturnDataOutOfBounds
@@ -356,9 +356,9 @@ func opCodeSize(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([
 
 func opCodeCopy(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]byte, error) {
 	var (
-		memOffset  = scope.Stack.pop()
-		codeOffset = scope.Stack.pop()
-		length     = scope.Stack.pop()
+		memOffset  = scope.Stack.popptr()
+		codeOffset = scope.Stack.popptr()
+		length     = scope.Stack.popptr()
 	)
 	uint64CodeOffset, overflow := codeOffset.Uint64WithOverflow()
 	if overflow {
@@ -373,10 +373,10 @@ func opCodeCopy(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([
 func opExtCodeCopy(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]byte, error) {
 	var (
 		stack      = scope.Stack
-		a          = stack.pop()
-		memOffset  = stack.pop()
-		codeOffset = stack.pop()
-		length     = stack.pop()
+		a          = stack.popptr()
+		memOffset  = stack.popptr()
+		codeOffset = stack.popptr()
+		length     = stack.popptr()
 	)
 	uint64CodeOffset, overflow := codeOffset.Uint64WithOverflow()
 	if overflow {
@@ -502,13 +502,13 @@ func opMload(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]by
 
 func opMstore(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]byte, error) {
 	// pop value of the stack
-	mStart, val := scope.Stack.pop(), scope.Stack.pop()
-	scope.Memory.Set32(mStart.Uint64(), &val)
+	mStart, val := scope.Stack.popptr(), scope.Stack.popptr()
+	scope.Memory.Set32(mStart.Uint64(), val)
 	return nil, nil
 }
 
 func opMstore8(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]byte, error) {
-	off, val := scope.Stack.pop(), scope.Stack.pop()
+	off, val := scope.Stack.popptr(), scope.Stack.popptr()
 	scope.Memory.store[off.Uint64()] = byte(val.Uint64())
 	return nil, nil
 }
@@ -525,8 +525,8 @@ func opSstore(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]b
 	if interpreter.readOnly {
 		return nil, ErrWriteProtection
 	}
-	loc := scope.Stack.pop()
-	val := scope.Stack.pop()
+	loc := scope.Stack.popptr()
+	val := scope.Stack.popptr()
 	interpreter.evm.StateDB.SetState(scope.Contract.Address(),
 		loc.Bytes32(), val.Bytes32())
 	return nil, nil
@@ -536,8 +536,8 @@ func opJump(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]byt
 	if atomic.LoadInt32(&interpreter.evm.abort) != 0 {
 		return nil, errStopToken
 	}
-	pos := scope.Stack.pop()
-	if !scope.Contract.validJumpdest(&pos) {
+	pos := scope.Stack.popptr()
+	if !scope.Contract.validJumpdest(pos) {
 		return nil, ErrInvalidJump
 	}
 	*pc = pos.Uint64() - 1 // pc will be increased by the interpreter loop
@@ -548,9 +548,9 @@ func opJumpi(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]by
 	if atomic.LoadInt32(&interpreter.evm.abort) != 0 {
 		return nil, errStopToken
 	}
-	pos, cond := scope.Stack.pop(), scope.Stack.pop()
+	pos, cond := scope.Stack.popptr(), scope.Stack.popptr()
 	if !cond.IsZero() {
-		if !scope.Contract.validJumpdest(&pos) {
+		if !scope.Contract.validJumpdest(pos) {
 			return nil, ErrInvalidJump
 		}
 		*pc = pos.Uint64() - 1 // pc will be increased by the interpreter loop
@@ -583,15 +583,13 @@ func opCreate(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]b
 	}
 	var (
 		value        = scope.Stack.pop()
-		offset, size = scope.Stack.pop(), scope.Stack.pop()
-		input        = scope.Memory.GetCopy(int64(offset.Uint64()), int64(size.Uint64()))
+		offset, size = scope.Stack.popptr().Uint64(), scope.Stack.popptr().Uint64()
+		input        = scope.Memory.GetCopy(int64(offset), int64(size))
 		gas          = scope.Contract.Gas
 	)
 	if interpreter.evm.chainRules.IsEIP150 {
 		gas -= gas / 64
 	}
-	// reuse size int for stackvalue
-	stackvalue := size
 
 	scope.Contract.UseGas(gas)
 	//TODO: use uint256.Int instead of converting with toBig()
@@ -606,13 +604,12 @@ func opCreate(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]b
 	// rule) and treat as an error, if the ruleset is frontier we must
 	// ignore this error and pretend the operation was successful.
 	if interpreter.evm.chainRules.IsHomestead && suberr == ErrCodeStoreOutOfGas {
-		stackvalue.Clear()
+		scope.Stack.push(new(uint256.Int))
 	} else if suberr != nil && suberr != ErrCodeStoreOutOfGas {
-		stackvalue.Clear()
+		scope.Stack.push(new(uint256.Int))
 	} else {
-		stackvalue.SetBytes(addr.Bytes())
+		scope.Stack.push(new(uint256.Int).SetBytes(addr.Bytes()))
 	}
-	scope.Stack.push(&stackvalue)
 	scope.Contract.Gas += returnGas
 
 	if suberr == ErrExecutionReverted {
@@ -629,17 +626,16 @@ func opCreate2(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]
 	}
 	var (
 		endowment    = scope.Stack.pop()
-		offset, size = scope.Stack.pop(), scope.Stack.pop()
+		offset, size = scope.Stack.popptr().Uint64(), scope.Stack.popptr().Uint64()
 		salt         = scope.Stack.pop()
-		input        = scope.Memory.GetCopy(int64(offset.Uint64()), int64(size.Uint64()))
+		input        = scope.Memory.GetCopy(int64(offset), int64(size))
 		gas          = scope.Contract.Gas
 	)
 
 	// Apply EIP150
 	gas -= gas / 64
 	scope.Contract.UseGas(gas)
-	// reuse size int for stackvalue
-	stackvalue := size
+
 	//TODO: use uint256.Int instead of converting with toBig()
 	bigEndowment := big0
 	if !endowment.IsZero() {
@@ -649,11 +645,10 @@ func opCreate2(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]
 		bigEndowment, &salt)
 	// Push item on the stack based on the returned error.
 	if suberr != nil {
-		stackvalue.Clear()
+		scope.Stack.push(new(uint256.Int))
 	} else {
-		stackvalue.SetBytes(addr.Bytes())
+		scope.Stack.push(new(uint256.Int).SetBytes(addr.Bytes()))
 	}
-	scope.Stack.push(&stackvalue)
 	scope.Contract.Gas += returnGas
 
 	if suberr == ErrExecutionReverted {
@@ -667,14 +662,15 @@ func opCreate2(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]
 func opCall(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]byte, error) {
 	stack := scope.Stack
 	// Pop gas. The actual gas in interpreter.evm.callGasTemp.
-	// We can use this as a temporary value
-	temp := stack.pop()
+	stack.pop()
 	gas := interpreter.evm.callGasTemp
 	// Pop other call parameters.
-	addr, value, inOffset, inSize, retOffset, retSize := stack.pop(), stack.pop(), stack.pop(), stack.pop(), stack.pop(), stack.pop()
-	toAddr := common.Address(addr.Bytes20())
+	addr, value := stack.popptr().Bytes20(), stack.pop()
+	inOffset, inSize := stack.popptr().Uint64(), stack.popptr().Uint64()
+	retOffset, retSize := stack.popptr().Uint64(), stack.popptr().Uint64()
+	toAddr := common.Address(addr)
 	// Get the arguments from the memory.
-	args := scope.Memory.GetPtr(int64(inOffset.Uint64()), int64(inSize.Uint64()))
+	args := scope.Memory.GetPtr(int64(inOffset), int64(inSize))
 
 	if interpreter.readOnly && !value.IsZero() {
 		return nil, ErrWriteProtection
@@ -691,14 +687,14 @@ func opCall(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]byt
 	ret, returnGas, err := interpreter.evm.Call(scope.Contract, toAddr, args, gas, bigVal)
 
 	if err != nil {
-		temp.Clear()
+		stack.push(new(uint256.Int))
 	} else {
-		temp.SetOne()
+		stack.push(new(uint256.Int).SetOne())
 	}
-	stack.push(&temp)
+
 	if err == nil || err == ErrExecutionReverted {
 		ret = common.CopyBytes(ret)
-		scope.Memory.Set(retOffset.Uint64(), retSize.Uint64(), ret)
+		scope.Memory.Set(retOffset, retSize, ret)
 	}
 	scope.Contract.Gas += returnGas
 
@@ -709,14 +705,15 @@ func opCall(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]byt
 func opCallCode(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]byte, error) {
 	// Pop gas. The actual gas is in interpreter.evm.callGasTemp.
 	stack := scope.Stack
-	// We use it as a temporary value
-	temp := stack.pop()
+	stack.pop()
 	gas := interpreter.evm.callGasTemp
 	// Pop other call parameters.
-	addr, value, inOffset, inSize, retOffset, retSize := stack.pop(), stack.pop(), stack.pop(), stack.pop(), stack.pop(), stack.pop()
-	toAddr := common.Address(addr.Bytes20())
+	addr, value := stack.popptr().Bytes20(), stack.pop()
+	inOffset, inSize := stack.popptr().Uint64(), stack.popptr().Uint64()
+	retOffset, retSize := stack.popptr().Uint64(), stack.popptr().Uint64()
+	toAddr := common.Address(addr)
 	// Get arguments from the memory.
-	args := scope.Memory.GetPtr(int64(inOffset.Uint64()), int64(inSize.Uint64()))
+	args := scope.Memory.GetPtr(int64(inOffset), int64(inSize))
 
 	//TODO: use uint256.Int instead of converting with toBig()
 	var bigVal = big0
@@ -727,14 +724,14 @@ func opCallCode(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([
 
 	ret, returnGas, err := interpreter.evm.CallCode(scope.Contract, toAddr, args, gas, bigVal)
 	if err != nil {
-		temp.Clear()
+		stack.push(new(uint256.Int))
 	} else {
-		temp.SetOne()
+		stack.push(new(uint256.Int).SetOne())
 	}
-	stack.push(&temp)
+
 	if err == nil || err == ErrExecutionReverted {
 		ret = common.CopyBytes(ret)
-		scope.Memory.Set(retOffset.Uint64(), retSize.Uint64(), ret)
+		scope.Memory.Set(retOffset, retSize, ret)
 	}
 	scope.Contract.Gas += returnGas
 
@@ -745,25 +742,26 @@ func opCallCode(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([
 func opDelegateCall(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]byte, error) {
 	stack := scope.Stack
 	// Pop gas. The actual gas is in interpreter.evm.callGasTemp.
-	// We use it as a temporary value
-	temp := stack.pop()
+	stack.pop()
 	gas := interpreter.evm.callGasTemp
 	// Pop other call parameters.
-	addr, inOffset, inSize, retOffset, retSize := stack.pop(), stack.pop(), stack.pop(), stack.pop(), stack.pop()
-	toAddr := common.Address(addr.Bytes20())
+	addr := stack.popptr().Bytes20()
+	inOffset, inSize := stack.popptr().Uint64(), stack.popptr().Uint64()
+	retOffset, retSize := stack.popptr().Uint64(), stack.popptr().Uint64()
+	toAddr := common.Address(addr)
 	// Get arguments from the memory.
-	args := scope.Memory.GetPtr(int64(inOffset.Uint64()), int64(inSize.Uint64()))
+	args := scope.Memory.GetPtr(int64(inOffset), int64(inSize))
 
 	ret, returnGas, err := interpreter.evm.DelegateCall(scope.Contract, toAddr, args, gas)
 	if err != nil {
-		temp.Clear()
+		stack.push(new(uint256.Int))
 	} else {
-		temp.SetOne()
+		stack.push(new(uint256.Int).SetOne())
 	}
-	stack.push(&temp)
+
 	if err == nil || err == ErrExecutionReverted {
 		ret = common.CopyBytes(ret)
-		scope.Memory.Set(retOffset.Uint64(), retSize.Uint64(), ret)
+		scope.Memory.Set(retOffset, retSize, ret)
 	}
 	scope.Contract.Gas += returnGas
 
@@ -774,25 +772,26 @@ func opDelegateCall(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext
 func opStaticCall(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]byte, error) {
 	// Pop gas. The actual gas is in interpreter.evm.callGasTemp.
 	stack := scope.Stack
-	// We use it as a temporary value
-	temp := stack.pop()
+	stack.pop()
 	gas := interpreter.evm.callGasTemp
 	// Pop other call parameters.
-	addr, inOffset, inSize, retOffset, retSize := stack.pop(), stack.pop(), stack.pop(), stack.pop(), stack.pop()
-	toAddr := common.Address(addr.Bytes20())
+	addr := stack.popptr().Bytes20()
+	inOffset, inSize := stack.popptr().Uint64(), stack.popptr().Uint64()
+	retOffset, retSize := stack.popptr().Uint64(), stack.popptr().Uint64()
+	toAddr := common.Address(addr)
 	// Get arguments from the memory.
-	args := scope.Memory.GetPtr(int64(inOffset.Uint64()), int64(inSize.Uint64()))
+	args := scope.Memory.GetPtr(int64(inOffset), int64(inSize))
 
 	ret, returnGas, err := interpreter.evm.StaticCall(scope.Contract, toAddr, args, gas)
 	if err != nil {
-		temp.Clear()
+		stack.push(new(uint256.Int))
 	} else {
-		temp.SetOne()
+		stack.push(new(uint256.Int).SetOne())
 	}
-	stack.push(&temp)
+
 	if err == nil || err == ErrExecutionReverted {
 		ret = common.CopyBytes(ret)
-		scope.Memory.Set(retOffset.Uint64(), retSize.Uint64(), ret)
+		scope.Memory.Set(retOffset, retSize, ret)
 	}
 	scope.Contract.Gas += returnGas
 
@@ -801,14 +800,14 @@ func opStaticCall(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) 
 }
 
 func opReturn(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]byte, error) {
-	offset, size := scope.Stack.pop(), scope.Stack.pop()
+	offset, size := scope.Stack.popptr(), scope.Stack.popptr()
 	ret := scope.Memory.GetPtr(int64(offset.Uint64()), int64(size.Uint64()))
 
 	return ret, errStopToken
 }
 
 func opRevert(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]byte, error) {
-	offset, size := scope.Stack.pop(), scope.Stack.pop()
+	offset, size := scope.Stack.popptr(), scope.Stack.popptr()
 	ret := scope.Memory.GetPtr(int64(offset.Uint64()), int64(size.Uint64()))
 
 	interpreter.returnData = ret
@@ -827,12 +826,12 @@ func opSelfdestruct(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext
 	if interpreter.readOnly {
 		return nil, ErrWriteProtection
 	}
-	beneficiary := scope.Stack.pop()
+	beneficiary := scope.Stack.popptr().Bytes20()
 	balance := interpreter.evm.StateDB.GetBalance(scope.Contract.Address())
-	interpreter.evm.StateDB.AddBalance(beneficiary.Bytes20(), balance)
+	interpreter.evm.StateDB.AddBalance(beneficiary, balance)
 	interpreter.evm.StateDB.Suicide(scope.Contract.Address())
 	if interpreter.cfg.Debug {
-		interpreter.cfg.Tracer.CaptureEnter(SELFDESTRUCT, scope.Contract.Address(), beneficiary.Bytes20(), []byte{}, 0, balance)
+		interpreter.cfg.Tracer.CaptureEnter(SELFDESTRUCT, scope.Contract.Address(), beneficiary, []byte{}, 0, balance)
 		interpreter.cfg.Tracer.CaptureExit([]byte{}, 0, nil)
 	}
 	return nil, errStopToken
@@ -848,9 +847,9 @@ func makeLog(size int) executionFunc {
 		}
 		topics := make([]common.Hash, size)
 		stack := scope.Stack
-		mStart, mSize := stack.pop(), stack.pop()
+		mStart, mSize := stack.popptr(), stack.popptr()
 		for i := 0; i < size; i++ {
-			addr := stack.pop()
+			addr := stack.popptr()
 			topics[i] = addr.Bytes32()
 		}
 

--- a/core/vm/stack.go
+++ b/core/vm/stack.go
@@ -55,7 +55,11 @@ func (st *Stack) push(d *uint256.Int) {
 }
 
 func (st *Stack) pop() (ret uint256.Int) {
-	ret = st.data[len(st.data)-1]
+	return *st.popptr()
+}
+
+func (st *Stack) popptr() (ret *uint256.Int) {
+	ret = &st.data[len(st.data)-1]
 	st.data = st.data[:len(st.data)-1]
 	return
 }


### PR DESCRIPTION
It's safe if the popped ptr not escape the body of OP function. 

```
benchstat before.txt after.txt 
name            old time/op  new time/op  delta
OpAdd64-8       13.2ns ± 1%  11.5ns ± 0%  -12.70%  (p=0.016 n=5+4)
OpAdd128-8      13.3ns ± 4%  11.5ns ± 2%  -13.43%  (p=0.008 n=5+5)
OpAdd256-8      13.2ns ± 1%  12.0ns ±18%     ~     (p=0.143 n=5+5)
OpSub64-8       13.0ns ± 1%  11.4ns ± 2%  -11.95%  (p=0.008 n=5+5)
OpSub128-8      13.0ns ± 2%  11.9ns ± 9%     ~     (p=0.056 n=5+5)
OpSub256-8      12.9ns ± 1%  11.5ns ± 3%  -11.17%  (p=0.008 n=5+5)
OpMul-8         17.7ns ± 4%  15.6ns ± 1%  -11.54%  (p=0.008 n=5+5)
OpDiv256-8      83.4ns ± 0%  82.3ns ± 0%   -1.33%  (p=0.016 n=4+5)
OpDiv128-8      52.8ns ± 1%  51.7ns ± 1%   -2.17%  (p=0.008 n=5+5)
OpDiv64-8       18.3ns ± 1%  16.4ns ± 0%  -10.50%  (p=0.008 n=5+5)
OpSdiv-8        89.7ns ± 0%  89.3ns ± 0%     ~     (p=0.063 n=5+5)
OpMod-8         15.0ns ± 9%  13.4ns ± 8%  -10.29%  (p=0.008 n=5+5)
OpSmod-8        22.9ns ± 1%  21.5ns ± 1%   -6.17%  (p=0.008 n=5+5)
OpExp-8         2.28µs ± 0%  2.28µs ± 0%     ~     (p=0.143 n=5+5)
OpSignExtend-8  12.6ns ±11%  10.8ns ± 3%  -14.19%  (p=0.008 n=5+5)
OpLt-8          12.7ns ± 1%  11.5ns ± 3%   -9.85%  (p=0.008 n=5+5)
OpGt-8          12.1ns ± 1%  11.9ns ± 8%     ~     (p=0.135 n=5+5)
OpSlt-8         14.4ns ± 4%  12.3ns ± 0%  -14.92%  (p=0.008 n=5+5)
OpSgt-8         13.9ns ± 2%  12.4ns ± 1%  -11.00%  (p=0.008 n=5+5)
OpEq-8          12.7ns ± 1%  11.6ns ± 3%   -9.25%  (p=0.008 n=5+5)
OpEq2-8         11.4ns ± 2%  10.6ns ±12%     ~     (p=0.151 n=5+5)
OpAnd-8         12.8ns ± 2%  11.3ns ± 3%  -11.15%  (p=0.008 n=5+5)
OpOr-8          12.7ns ± 1%  11.4ns ± 3%  -10.15%  (p=0.008 n=5+5)
OpXor-8         12.7ns ± 1%  11.4ns ± 2%  -10.27%  (p=0.008 n=5+5)
OpByte-8        12.9ns ± 5%  10.7ns ± 5%  -17.26%  (p=0.008 n=5+5)
OpAddmod-8      98.3ns ± 0%  94.4ns ± 0%   -4.04%  (p=0.008 n=5+5)
OpMulmod-8       160ns ± 0%   157ns ± 0%   -2.03%  (p=0.008 n=5+5)
OpSHL-8         13.1ns ± 3%  11.7ns ± 6%  -10.62%  (p=0.008 n=5+5)
OpSHR-8         13.0ns ± 1%  11.8ns ± 5%   -9.07%  (p=0.008 n=5+5)
OpSAR-8         13.9ns ± 3%  12.3ns ± 1%  -11.13%  (p=0.008 n=5+5)
OpIsZero-8      5.70ns ± 0%  5.61ns ± 2%     ~     (p=0.143 n=5+5)
OpMstore-8      19.1ns ± 0%  14.5ns ± 0%  -23.90%  (p=0.008 n=5+5)
OpKeccak256-8    488ns ± 0%   488ns ± 0%     ~     (p=0.230 n=5+5)
```