### PR TITLE
core/vm: reduce overhead in instructions-benchmark

### DIFF
--- a/core/vm/instructions_test.go
+++ b/core/vm/instructions_test.go
@@ -284,24 +284,23 @@ func opBenchmark(bench *testing.B, op executionFunc, args ...string) {
 	var (
 		env            = NewEVM(BlockContext{}, TxContext{}, nil, params.TestChainConfig, Config{})
 		stack          = newstack()
+		scope          = &ScopeContext{nil, stack, nil}
 		evmInterpreter = NewEVMInterpreter(env, env.Config)
 	)
 
 	env.interpreter = evmInterpreter
 	// convert args
-	byteArgs := make([][]byte, len(args))
+	intArgs := make([]*uint256.Int, len(args))
 	for i, arg := range args {
-		byteArgs[i] = common.Hex2Bytes(arg)
+		intArgs[i] = new(uint256.Int).SetBytes(common.Hex2Bytes(arg))
 	}
 	pc := uint64(0)
 	bench.ResetTimer()
 	for i := 0; i < bench.N; i++ {
-		for _, arg := range byteArgs {
-			a := new(uint256.Int)
-			a.SetBytes(arg)
-			stack.push(a)
+		for _, arg := range intArgs {
+			stack.push(arg)
 		}
-		op(&pc, evmInterpreter, &ScopeContext{nil, stack, nil})
+		op(&pc, evmInterpreter, scope)
 		stack.pop()
 	}
 }

--- a/core/vm/instructions_test.go
+++ b/core/vm/instructions_test.go
@@ -305,9 +305,9 @@ func opBenchmark(bench *testing.B, op executionFunc, args ...string) {
 	}
 
 	for i, arg := range args {
-		origArg := new(uint256.Int).SetBytes(common.Hex2Bytes(arg))
-		if !origArg.Eq(intArgs[i]) {
-			bench.Fatalf("input #%d mutated", i)
+		want := new(uint256.Int).SetBytes(common.Hex2Bytes(arg))
+		if have:= intArgs[i]; !want.Eq(have) {
+			bench.Fatalf("input #%d mutated, have %x want %x", i, have, want)
 		}
 	}
 }

--- a/core/vm/instructions_test.go
+++ b/core/vm/instructions_test.go
@@ -303,10 +303,11 @@ func opBenchmark(bench *testing.B, op executionFunc, args ...string) {
 		op(&pc, evmInterpreter, scope)
 		stack.pop()
 	}
+	bench.StopTimer()
 
 	for i, arg := range args {
 		want := new(uint256.Int).SetBytes(common.Hex2Bytes(arg))
-		if have:= intArgs[i]; !want.Eq(have) {
+		if have := intArgs[i]; !want.Eq(have) {
 			bench.Fatalf("input #%d mutated, have %x want %x", i, have, want)
 		}
 	}

--- a/core/vm/instructions_test.go
+++ b/core/vm/instructions_test.go
@@ -303,6 +303,13 @@ func opBenchmark(bench *testing.B, op executionFunc, args ...string) {
 		op(&pc, evmInterpreter, scope)
 		stack.pop()
 	}
+
+	for i, arg := range args {
+		origArg := new(uint256.Int).SetBytes(common.Hex2Bytes(arg))
+		if !origArg.Eq(intArgs[i]) {
+			bench.Fatalf("input #%d mutated", i)
+		}
+	}
 }
 
 func BenchmarkOpAdd64(b *testing.B) {


### PR DESCRIPTION
The op benchmark result will be like:

master 
```
BenchmarkOpAdd64-8   	33818551	        35.51 ns/op	      24 B/op	       1 allocs/op
```

this PR
```
BenchmarkOpAdd64-8   	85392249	        13.81 ns/op	       0 B/op	       0 allocs/op
```