### PR TITLE
graphql: fix long literal passed in a variable

### DIFF
--- a/graphql/graphql.go
+++ b/graphql/graphql.go
@@ -65,6 +65,8 @@ func (b *Long) UnmarshalGraphQL(input interface{}) error {
 		*b = Long(input)
 	case int64:
 		*b = Long(input)
+	case float64:
+		*b = Long(input)
 	default:
 		err = fmt.Errorf("unexpected type %T for Long", input)
 	}


### PR DESCRIPTION
Fixes #24683