### PR TITLE
core/vm: for tracing, do not report post-op memory

### DIFF
--- a/core/vm/interpreter.go
+++ b/core/vm/interpreter.go
@@ -223,11 +223,15 @@ func (in *EVMInterpreter) Run(contract *Contract, input []byte, readOnly bool) (
 			if err != nil || !contract.UseGas(dynamicCost) {
 				return nil, ErrOutOfGas
 			}
+			// Do tracing before memory expansion
+			if in.cfg.Debug {
+				in.cfg.Tracer.CaptureState(pc, op, gasCopy, cost, callContext, in.returnData, in.evm.depth, err)
+				logged = true
+			}
 			if memorySize > 0 {
 				mem.Resize(memorySize)
 			}
-		}
-		if in.cfg.Debug {
+		} else if in.cfg.Debug {
 			in.cfg.Tracer.CaptureState(pc, op, gasCopy, cost, callContext, in.returnData, in.evm.depth, err)
 			logged = true
 		}


### PR DESCRIPTION
closes #24109

> Currently, if you try to trace a transaction which MSTOREs something at an offset previously not written to, then the debug_traceTransaction will pad the memory with zeros. In the trace, usually the reported values are what happens before running the opcode
> ... 

On `master`
```
$ go run . --code 60406040526001 --json run 
{"pc":0,"op":96,"gas":"0x2540be400","gasCost":"0x3","memSize":0,"stack":[],"depth":1,"refund":0,"opName":"PUSH1"}
{"pc":2,"op":96,"gas":"0x2540be3fd","gasCost":"0x3","memSize":0,"stack":["0x40"],"depth":1,"refund":0,"opName":"PUSH1"}
{"pc":4,"op":82,"gas":"0x2540be3fa","gasCost":"0xc","memSize":96,"stack":["0x40","0x40"],"depth":1,"refund":0,"opName":"MSTORE"}
{"pc":5,"op":96,"gas":"0x2540be3ee","gasCost":"0x3","memSize":96,"stack":[],"depth":1,"refund":0,"opName":"PUSH1"}
{"pc":7,"op":0,"gas":"0x2540be3eb","gasCost":"0x0","memSize":96,"stack":["0x1"],"depth":1,"refund":0,"opName":"STOP"}
{"output":"","gasUsed":"0x15","time":739636}
```
With this PR:
```
[user@work evm]$ go run . --code 60406040526001 --json run 
{"pc":0,"op":96,"gas":"0x2540be400","gasCost":"0x3","memSize":0,"stack":[],"depth":1,"refund":0,"opName":"PUSH1"}
{"pc":2,"op":96,"gas":"0x2540be3fd","gasCost":"0x3","memSize":0,"stack":["0x40"],"depth":1,"refund":0,"opName":"PUSH1"}
{"pc":4,"op":82,"gas":"0x2540be3fa","gasCost":"0xc","memSize":0,"stack":["0x40","0x40"],"depth":1,"refund":0,"opName":"MSTORE"}
{"pc":5,"op":96,"gas":"0x2540be3ee","gasCost":"0x3","memSize":96,"stack":[],"depth":1,"refund":0,"opName":"PUSH1"}
{"pc":7,"op":0,"gas":"0x2540be3eb","gasCost":"0x0","memSize":96,"stack":["0x1"],"depth":1,"refund":0,"opName":"STOP"}
{"output":"","gasUsed":"0x15","time":128972}
```