### PR TITLE
eth/tracers: add support for block overrides in debug_traceCall

### DIFF
--- a/core/evm.go
+++ b/core/evm.go
@@ -84,6 +84,11 @@ func GetHashFn(ref *types.Header, chain ChainContext) func(n uint64) common.Hash
 	var cache []common.Hash
 
 	return func(n uint64) common.Hash {
+		if ref.Number.Uint64() <= n {
+			// This situation can happen if we're doing tracing and using
+			// block overrides.
+			return common.Hash{}
+		}
 		// If there's no hash cache yet, make one
 		if len(cache) == 0 {
 			cache = append(cache, ref.ParentHash)

--- a/eth/tracers/api.go
+++ b/eth/tracers/api.go
@@ -180,6 +180,7 @@ type TraceCallConfig struct {
 	Timeout        *string
 	Reexec         *uint64
 	StateOverrides *ethapi.StateOverride
+	BlockOverrides *ethapi.BlockOverrides
 }
 
 // StdTraceConfig holds extra parameters to standard-json trace functions.
@@ -807,7 +808,6 @@ func (api *API) TraceTransaction(ctx context.Context, hash common.Hash, config *
 // TraceCall lets you trace a given eth_call. It collects the structured logs
 // created during the execution of EVM if the given transaction was added on
 // top of the provided block and returns them as a JSON object.
-// You can provide -2 as a block number to trace on top of the pending block.
 func (api *API) TraceCall(ctx context.Context, args ethapi.TransactionArgs, blockNrOrHash rpc.BlockNumberOrHash, config *TraceCallConfig) (interface{}, error) {
 	// Try to retrieve the specified block
 	var (
@@ -817,6 +817,14 @@ func (api *API) TraceCall(ctx context.Context, args ethapi.TransactionArgs, bloc
 	if hash, ok := blockNrOrHash.Hash(); ok {
 		block, err = api.blockByHash(ctx, hash)
 	} else if number, ok := blockNrOrHash.Number(); ok {
+		if number == rpc.PendingBlockNumber {
+			// We don't have access to the miner here. For tracing 'future' transactions,
+			// it can be done with block- and state-overrides instead, which offers
+			// more flexibility and stability than trying to trace on 'pending', since
+			// the contents of 'pending' is unstable and probably not a true representation
+			// of what the next actual block is likely to contain.
+			return nil, errors.New("tracing on top of pending is not supported")
+		}
 		block, err = api.blockByNumber(ctx, number)
 	} else {
 		return nil, errors.New("invalid arguments; neither block nor hash specified")
@@ -833,18 +841,19 @@ func (api *API) TraceCall(ctx context.Context, args ethapi.TransactionArgs, bloc
 	if err != nil {
 		return nil, err
 	}
-	// Apply the customized state rules if required.
+	vmctx := core.NewEVMBlockContext(block.Header(), api.chainContext(ctx), nil)
+	// Apply the customization rules if required.
 	if config != nil {
 		if err := config.StateOverrides.Apply(statedb); err != nil {
 			return nil, err
 		}
+		config.BlockOverrides.Apply(&vmctx)
 	}
 	// Execute the trace
 	msg, err := args.ToMessage(api.backend.RPCGasCap(), block.BaseFee())
 	if err != nil {
 		return nil, err
 	}
-	vmctx := core.NewEVMBlockContext(block.Header(), api.chainContext(ctx), nil)
 
 	var traceConfig *TraceConfig
 	if config != nil {

--- a/eth/tracers/api_test.go
+++ b/eth/tracers/api_test.go
@@ -196,13 +196,12 @@ func TestTraceCall(t *testing.T) {
 		tx, _ := types.SignTx(types.NewTransaction(uint64(i), accounts[1].addr, big.NewInt(1000), params.TxGas, b.BaseFee(), nil), signer, accounts[0].key)
 		b.AddTx(tx)
 	}))
-
 	var testSuite = []struct {
 		blockNumber rpc.BlockNumber
 		call        ethapi.TransactionArgs
 		config      *TraceCallConfig
 		expectErr   error
-		expect      interface{}
+		expect      string
 	}{
 		// Standard JSON trace upon the genesis, plain transfer.
 		{
@@ -214,12 +213,7 @@ func TestTraceCall(t *testing.T) {
 			},
 			config:    nil,
 			expectErr: nil,
-			expect: &logger.ExecutionResult{
-				Gas:         params.TxGas,
-				Failed:      false,
-				ReturnValue: "",
-				StructLogs:  []logger.StructLogRes{},
-			},
+			expect:    `{"gas":21000,"failed":false,"returnValue":"","structLogs":[]}`,
 		},
 		// Standard JSON trace upon the head, plain transfer.
 		{
@@ -231,12 +225,7 @@ func TestTraceCall(t *testing.T) {
 			},
 			config:    nil,
 			expectErr: nil,
-			expect: &logger.ExecutionResult{
-				Gas:         params.TxGas,
-				Failed:      false,
-				ReturnValue: "",
-				StructLogs:  []logger.StructLogRes{},
-			},
+			expect:    `{"gas":21000,"failed":false,"returnValue":"","structLogs":[]}`,
 		},
 		// Standard JSON trace upon the non-existent block, error expects
 		{
@@ -248,7 +237,7 @@ func TestTraceCall(t *testing.T) {
 			},
 			config:    nil,
 			expectErr: fmt.Errorf("block #%d not found", genBlocks+1),
-			expect:    nil,
+			//expect:    nil,
 		},
 		// Standard JSON trace upon the latest block
 		{
@@ -260,14 +249,9 @@ func TestTraceCall(t *testing.T) {
 			},
 			config:    nil,
 			expectErr: nil,
-			expect: &logger.ExecutionResult{
-				Gas:         params.TxGas,
-				Failed:      false,
-				ReturnValue: "",
-				StructLogs:  []logger.StructLogRes{},
-			},
+			expect:    `{"gas":21000,"failed":false,"returnValue":"","structLogs":[]}`,
 		},
-		// Standard JSON trace upon the pending block
+		// Tracing on 'pending' should fail:
 		{
 			blockNumber: rpc.PendingBlockNumber,
 			call: ethapi.TransactionArgs{
@@ -276,36 +260,48 @@ func TestTraceCall(t *testing.T) {
 				Value: (*hexutil.Big)(big.NewInt(1000)),
 			},
 			config:    nil,
-			expectErr: nil,
-			expect: &logger.ExecutionResult{
-				Gas:         params.TxGas,
-				Failed:      false,
-				ReturnValue: "",
-				StructLogs:  []logger.StructLogRes{},
+			expectErr: errors.New("tracing on top of pending is not supported"),
+		},
+		{
+			blockNumber: rpc.LatestBlockNumber,
+			call: ethapi.TransactionArgs{
+				From:  &accounts[0].addr,
+				Input: &hexutil.Bytes{0x43}, // blocknumber
 			},
+			config: &TraceCallConfig{
+				BlockOverrides: &ethapi.BlockOverrides{Number: (*hexutil.Big)(big.NewInt(0x1337))},
+			},
+			expectErr: nil,
+			expect: ` {"gas":53018,"failed":false,"returnValue":"","structLogs":[
+		{"pc":0,"op":"NUMBER","gas":24946984,"gasCost":2,"depth":1,"stack":[]},
+		{"pc":1,"op":"STOP","gas":24946982,"gasCost":0,"depth":1,"stack":["0x1337"]}]}`,
 		},
 	}
-	for _, testspec := range testSuite {
+	for i, testspec := range testSuite {
 		result, err := api.TraceCall(context.Background(), testspec.call, rpc.BlockNumberOrHash{BlockNumber: &testspec.blockNumber}, testspec.config)
 		if testspec.expectErr != nil {
 			if err == nil {
-				t.Errorf("Expect error %v, get nothing", testspec.expectErr)
+				t.Errorf("test %d: expect error %v, got nothing", i, testspec.expectErr)
 				continue
 			}
 			if !reflect.DeepEqual(err, testspec.expectErr) {
-				t.Errorf("Error mismatch, want %v, get %v", testspec.expectErr, err)
+				t.Errorf("test %d: error mismatch, want %v, git %v", i, testspec.expectErr, err)
 			}
 		} else {
 			if err != nil {
-				t.Errorf("Expect no error, get %v", err)
+				t.Errorf("test %d: expect no error, got %v", i, err)
 				continue
 			}
 			var have *logger.ExecutionResult
 			if err := json.Unmarshal(result.(json.RawMessage), &have); err != nil {
-				t.Errorf("failed to unmarshal result %v", err)
+				t.Errorf("test %d: failed to unmarshal result %v", i, err)
 			}
-			if !reflect.DeepEqual(have, testspec.expect) {
-				t.Errorf("Result mismatch, want %v, get %v", testspec.expect, have)
+			var want *logger.ExecutionResult
+			if err := json.Unmarshal([]byte(testspec.expect), &want); err != nil {
+				t.Errorf("test %d: failed to unmarshal result %v", i, err)
+			}
+			if !reflect.DeepEqual(have, want) {
+				t.Errorf("test %d: result mismatch, want %v, got %v", i, testspec.expect, string(result.(json.RawMessage)))
 			}
 		}
 	}
@@ -457,7 +453,7 @@ func TestTracingWithOverrides(t *testing.T) {
 	}{
 		// Call which can only succeed if state is state overridden
 		{
-			blockNumber: rpc.PendingBlockNumber,
+			blockNumber: rpc.LatestBlockNumber,
 			call: ethapi.TransactionArgs{
 				From:  &randomAccounts[0].addr,
 				To:    &randomAccounts[1].addr,
@@ -472,7 +468,7 @@ func TestTracingWithOverrides(t *testing.T) {
 		},
 		// Invalid call without state overriding
 		{
-			blockNumber: rpc.PendingBlockNumber,
+			blockNumber: rpc.LatestBlockNumber,
 			call: ethapi.TransactionArgs{
 				From:  &randomAccounts[0].addr,
 				To:    &randomAccounts[1].addr,
@@ -498,7 +494,7 @@ func TestTracingWithOverrides(t *testing.T) {
 		//      }
 		//  }
 		{
-			blockNumber: rpc.PendingBlockNumber,
+			blockNumber: rpc.LatestBlockNumber,
 			call: ethapi.TransactionArgs{
 				From: &randomAccounts[0].addr,
 				To:   &randomAccounts[2].addr,
@@ -514,6 +510,19 @@ func TestTracingWithOverrides(t *testing.T) {
 				},
 			},
 			want: `{"gas":23347,"failed":false,"returnValue":"000000000000000000000000000000000000000000000000000000000000007b"}`,
+		},
+		{ // Override blocknumber
+			blockNumber: rpc.LatestBlockNumber,
+			call: ethapi.TransactionArgs{
+				From:  &accounts[0].addr,
+				Input: &hexutil.Bytes{0x43}, // blocknumber
+			},
+			config: &TraceCallConfig{
+				BlockOverrides: &ethapi.BlockOverrides{Number: (*hexutil.Big)(big.NewInt(0x1337))},
+			},
+			want: ` {"gas":53018,"failed":false,"returnValue":"","structLogs":[
+		{"pc":0,"op":"NUMBER","gas":24946984,"gasCost":2,"depth":1,"stack":[]},
+		{"pc":1,"op":"STOP","gas":24946982,"gasCost":0,"depth":1,"stack":["0x1337"]}]}`,
 		},
 	}
 	for i, tc := range testSuite {

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -898,6 +898,7 @@ type BlockOverrides struct {
 	Random     *common.Hash
 }
 
+// Apply overrides the given header fields into the given block context.
 func (diff *BlockOverrides) Apply(blockCtx *vm.BlockContext) {
 	if diff == nil {
 		return

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -888,6 +888,40 @@ func (diff *StateOverride) Apply(state *state.StateDB) error {
 	return nil
 }
 
+// BlockOverrides is a set of header fields to override.
+type BlockOverrides struct {
+	Number     *hexutil.Big
+	Difficulty *hexutil.Big
+	Time       *hexutil.Big
+	GasLimit   *hexutil.Uint64
+	Coinbase   *common.Address
+	Random     *common.Hash
+}
+
+func (diff *BlockOverrides) Apply(blockCtx *vm.BlockContext) {
+	if diff == nil {
+		return
+	}
+	if diff.Number != nil {
+		blockCtx.BlockNumber = diff.Number.ToInt()
+	}
+	if diff.Difficulty != nil {
+		blockCtx.Difficulty = diff.Difficulty.ToInt()
+	}
+	if diff.Time != nil {
+		blockCtx.Time = diff.Time.ToInt()
+	}
+	if diff.GasLimit != nil {
+		blockCtx.GasLimit = uint64(*diff.GasLimit)
+	}
+	if diff.Coinbase != nil {
+		blockCtx.Coinbase = *diff.Coinbase
+	}
+	if diff.Random != nil {
+		blockCtx.Random = diff.Random
+	}
+}
+
 func DoCall(ctx context.Context, b Backend, args TransactionArgs, blockNrOrHash rpc.BlockNumberOrHash, overrides *StateOverride, timeout time.Duration, globalGasCap uint64) (*core.ExecutionResult, error) {
 	defer func(start time.Time) { log.Debug("Executing EVM call finished", "runtime", time.Since(start)) }(time.Now())
 


### PR DESCRIPTION
Closes https://github.com/ethereum/go-ethereum/issues/24830

This PR adds support for block overrides when doing `debug_traceCall`. 
- Previously, `debug_traceCall` against `pending` erroneously used a `common.Hash{}` stateroot when looking up the state, meaning that a totally empty state was used -- so it always failed, 
- With this change, we reject executing `debug_traceCall` against `pending`. 
- And we add ability to override all evm-visible header fields. 

Example when running this
First mine a block, 
```
> eth.sendTransaction({from: eth.accounts[0], to: eth.accounts[0], value:"0x1"})
INFO [05-13|10:25:03.671] Successfully sealed new block            number=1 sealhash=368ccd..9fe8c5 hash=eec9da..95c7ac elapsed="394.816µs"
INFO [05-13|10:25:03.671] 🔨 mined potential block                  number=1 hash=eec9da..95c7ac
INFO [05-13|10:25:03.672] Commit new sealing work                  number=2 sealhash=22b4ed..afd360 uncles=0 txs=0 gas=0     fees=0       elapsed="243.11µs"
WARN [05-13|10:25:03.672] Block sealing failed                     err="sealing paused while waiting for transactions"
INFO [05-13|10:25:03.672] Commit new sealing work                  number=2 sealhash=22b4ed..afd360 uncles=0 txs=0 gas=0     fees=0       elapsed="345.697µs"
```
Check if pending fails: 
```
> debug.traceCall({from: eth.accounts[0], value:"0x1", gasPrice: "0xffffffff", gas: "0xffff", input: "0x43"}, "pending")
WARN [05-13|10:25:13.197] Served debug_traceCall                   reqid=13 duration="129.516µs" err="tracing on top of pending is not supported"
Error: tracing on top of pending is not supported
	at web3.js:6365:37(47)
	at send (web3.js:5099:62(35))
	at <eval>:1:16(18)
```
Regular trace, which prints out the block number
```
> debug.traceCall({from: eth.accounts[0], value:"0x1", gasPrice: "0xffffffff", gas: "0xffff", input: "0x43"}, "latest")
{
  failed: false,
  gas: 53018,
  returnValue: "",
  structLogs: [{
      depth: 1,
      gas: 12519,
      gasCost: 2,
      op: "NUMBER",
      pc: 0,
      stack: []
  }, {
      depth: 1,
      gas: 12517,
      gasCost: 0,
      op: "STOP",
      pc: 1,
      stack: ["0x1"]
  }]
}
```
And with overrides: 
```
> debug.traceCall({from: eth.accounts[0], value:"0x1", gasPrice: "0xffffffff", gas: "0xffff", input: "0x43"}, "latest", {"blockoverrides":{"number": "0x50"}})
{
  failed: false,
  gas: 53018,
  returnValue: "",
  structLogs: [{
      depth: 1,
      gas: 12519,
      gasCost: 2,
      op: "NUMBER",
      pc: 0,
      stack: []
  }, {
      depth: 1,
      gas: 12517,
      gasCost: 0,
      op: "STOP",
      pc: 1,
      stack: ["0x50"]
  }]
}
```