### PR TITLE
eth: add traceCallBlock method

### DIFF
--- a/internal/web3ext/web3ext.go
+++ b/internal/web3ext/web3ext.go
@@ -427,6 +427,12 @@ web3._extend({
 			inputFormatter: [null, null, null]
 		}),
 		new web3._extend.Method({
+			name: 'traceCallBlock',
+			call: 'debug_traceCallBlock',
+			params: 3,
+			inputFormatter: [null, null, null]
+		}),
+		new web3._extend.Method({
 			name: 'preimage',
 			call: 'debug_preimage',
 			params: 1,


### PR DESCRIPTION
It hasn't been tested much. There's much room for improvement
e.g.:

```console
> debug.traceCallBlock({number: '0x20', transactions: [{from: eth.accounts[0], value:"0x1", gasPrice: "0xffffffff", gas: "0xffff", input: "0x43"}]}, "latest")[0].result
{
  failed: false,
  gas: 53018,
  returnValue: "",
  structLogs: [{
      depth: 1,
      gas: 12519,
      gasCost: 2,
      op: "NUMBER",
      pc: 0,
      stack: []
  }, {
      depth: 1,
      gas: 12517,
      gasCost: 0,
      op: "STOP",
      pc: 1,
      stack: ["0x20"]
  }]
}
```