### PR TITLE
cmd/utils: add deprecation warning for Rinkeby

### DIFF
--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -1724,6 +1724,16 @@ func SetEthConfig(ctx *cli.Context, stack *node.Node, cfg *ethconfig.Config) {
 		cfg.Genesis = core.DefaultSepoliaGenesisBlock()
 		SetDNSDiscoveryDefaults(cfg, params.SepoliaGenesisHash)
 	case ctx.GlobalBool(RinkebyFlag.Name):
+		log.Warn("")
+		log.Warn("--------------------------------------------------------------------------------")
+		log.Warn("Please note, Rinkeby has been deprecated. It will still work for the time being,")
+		log.Warn("but there will be no further hard-forks shipped for it. Eventually the network")
+		log.Warn("will be permanently halted after the other networks transition through the merge")
+		log.Warn("and prove stable enough. For the most future proof testnet, choose Sepolia as")
+		log.Warn("your replacement environment (--sepolia instead of --rinkeby).")
+		log.Warn("--------------------------------------------------------------------------------")
+		log.Warn("")
+
 		if !ctx.GlobalIsSet(NetworkIdFlag.Name) {
 			cfg.NetworkId = 4
 		}


### PR DESCRIPTION
TL;DR:

```
$ geth --rinkeby --syncmode=light console]

INFO [05-16|08:28:09.050] Starting Geth on Rinkeby testnet... 
INFO [05-16|08:28:09.050] Dropping default light client cache      provided=1024 updated=128
INFO [05-16|08:28:09.052] Maximum peer count                       ETH=0 LES=10 total=50
INFO [05-16|08:28:09.053] Set global gas cap                       cap=50,000,000
WARN [05-16|08:28:09.053]  
WARN [05-16|08:28:09.053] -------------------------------------------------------------------------------- 
WARN [05-16|08:28:09.053] Please note, Rinkeby has been deprecated. It will still work for the time being, 
WARN [05-16|08:28:09.053] but there will be no further hard-forks shipped for it. Eventually the network 
WARN [05-16|08:28:09.053] will be permanently halted after the other networks transition through the merge 
WARN [05-16|08:28:09.053] and prove stable enough. For the most future proof testnet, choose Sepolia as 
WARN [05-16|08:28:09.053] your replacement environment (--sepolia instead of --rinkeby). 
WARN [05-16|08:28:09.053] -------------------------------------------------------------------------------- 
WARN [05-16|08:28:09.053]  
INFO [05-16|08:28:09.053] Allocated cache and file handles         database=~/.ethereum/rinkeby/geth/lightchaindata cache=64.00MiB handles=524,288
```