### PR TITLE
eth/tracers/js: add memory.length method

### DIFF
--- a/eth/tracers/js/goja.go
+++ b/eth/tracers/js/goja.go
@@ -517,10 +517,15 @@ func (mo *memoryObj) GetUint(addr int64) goja.Value {
 	return res
 }
 
+func (mo *memoryObj) Length() int {
+	return mo.w.memory.Len()
+}
+
 func (m *memoryObj) setupObject() *goja.Object {
 	o := m.vm.NewObject()
 	o.Set("slice", m.vm.ToValue(m.Slice))
 	o.Set("getUint", m.vm.ToValue(m.GetUint))
+	o.Set("length", m.vm.ToValue(m.Length))
 	return o
 }
 

--- a/eth/tracers/js/tracer.go
+++ b/eth/tracers/js/tracer.go
@@ -148,6 +148,10 @@ func (mw *memoryWrapper) getUint(addr int64) *big.Int {
 func (mw *memoryWrapper) pushObject(vm *duktape.Context) {
 	obj := vm.PushObject()
 
+	// Generate the `length` method which returns the memory length
+	vm.PushGoFunction(func(ctx *duktape.Context) int { ctx.PushInt(mw.memory.Len()); return 1 })
+	vm.PutPropString(obj, "length")
+
 	// Generate the `slice` method which takes two ints and returns a buffer
 	vm.PushGoFunction(func(ctx *duktape.Context) int {
 		blob := mw.slice(int64(ctx.GetInt(-2)), int64(ctx.GetInt(-1)))

--- a/eth/tracers/js/tracer_test.go
+++ b/eth/tracers/js/tracer_test.go
@@ -125,6 +125,9 @@ func testTracer(t *testing.T, newTracer tracerCtor) {
 		}, { // tests that depth is reported correctly
 			code: "{depths: [], step: function(log) { this.depths.push(log.stack.length()); }, fault: function() {}, result: function() { return this.depths; }}",
 			want: `[0,1,2]`,
+		}, { // tests memory length
+			code: "{lengths: [], step: function(log) { this.lengths.push(log.memory.length()); }, fault: function() {}, result: function() { return this.lengths; }}",
+			want: `[0,0,0]`,
 		}, { // tests to-string of opcodes
 			code: "{opcodes: [], step: function(log) { this.opcodes.push(log.op.toString()); }, fault: function() {}, result: function() { return this.opcodes; }}",
 			want: `["PUSH1","PUSH1","STOP"]`,


### PR DESCRIPTION
Currently there's no way to get the memory length in the js tracer.  I've added the method following the pattern of the `length` method from the stack property:
https://github.com/ethereum/go-ethereum/blob/af806168b62b6a0e772b73ce25d31d8e61d26043/eth/tracers/js/tracer.go#L210-L211
