### PR TITLE
all: use strings.EqualFold for string comparison

### DIFF
--- a/console/prompt/prompter.go
+++ b/console/prompt/prompter.go
@@ -143,7 +143,7 @@ func (p *terminalPrompter) PromptPassword(prompt string) (passwd string, err err
 // choice to be made, returning that choice.
 func (p *terminalPrompter) PromptConfirm(prompt string) (bool, error) {
 	input, err := p.Prompt(prompt + " [y/n] ")
-	if len(input) > 0 && strings.ToUpper(input[:1]) == "Y" {
+	if len(input) > 0 && strings.EqualFold(input[:1], "y") {
 		return true, nil
 	}
 	return false, err

--- a/core/asm/compiler.go
+++ b/core/asm/compiler.go
@@ -243,12 +243,12 @@ func (c *Compiler) pushBin(v interface{}) {
 // isPush returns whether the string op is either any of
 // push(N).
 func isPush(op string) bool {
-	return strings.ToUpper(op) == "PUSH"
+	return strings.EqualFold(op, "PUSH")
 }
 
 // isJump returns whether the string op is jump(i)
 func isJump(op string) bool {
-	return strings.ToUpper(op) == "JUMPI" || strings.ToUpper(op) == "JUMP"
+	return strings.EqualFold(op, "JUMPI") || strings.EqualFold(op, "JUMP")
 }
 
 // toBinary converts text to a vm.OpCode

--- a/node/rpcstack.go
+++ b/node/rpcstack.go
@@ -357,7 +357,7 @@ func (h *httpServer) wsAllowed() bool {
 
 // isWebsocket checks the header of an http request for a websocket upgrade request.
 func isWebsocket(r *http.Request) bool {
-	return strings.ToLower(r.Header.Get("Upgrade")) == "websocket" &&
+	return strings.EqualFold(r.Header.Get("Upgrade"), "websocket") &&
 		strings.Contains(strings.ToLower(r.Header.Get("Connection")), "upgrade")
 }
 

--- a/node/rpcstack_test.go
+++ b/node/rpcstack_test.go
@@ -283,7 +283,7 @@ func rpcRequest(t *testing.T, url string, extraHeaders ...string) *http.Response
 	}
 	for i := 0; i < len(extraHeaders); i += 2 {
 		key, value := extraHeaders[i], extraHeaders[i+1]
-		if strings.ToLower(key) == "host" {
+		if strings.EqualFold(key, "host") {
 			req.Host = value
 		} else {
 			req.Header.Set(key, value)


### PR DESCRIPTION
It's [more efficient](https://stackoverflow.com/questions/34383705/how-do-i-compare-strings-in-golang) to use `strings.EqualFold()` for [string comparison](https://github.com/dgryski/go-perfbook/blob/master/performance.md#common-gotchas-with-the-standard-library) than the normal operator. Especially when you have to lower or upper case one of the strings first.
