### PR TITLE
eth, les, params: log chain config a bit saner

### DIFF
--- a/core/forkid/forkid_test.go
+++ b/core/forkid/forkid_test.go
@@ -31,7 +31,7 @@ import (
 // the correct fork ID.
 func TestCreation(t *testing.T) {
 	mergeConfig := *params.MainnetChainConfig
-	mergeConfig.MergeForkBlock = big.NewInt(15000000)
+	mergeConfig.MergeNetsplitBlock = big.NewInt(15000000)
 	type testcase struct {
 		head uint64
 		want ID

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -142,11 +142,11 @@ func New(stack *node.Node, config *ethconfig.Config) (*Ethereum, error) {
 		return nil, genesisErr
 	}
 	log.Info("")
-	log.Info("---------------------------------------------------------------------------------------------")
+	log.Info(strings.Repeat("-", 153))
 	for _, line := range strings.Split(chainConfig.String(), "\n") {
 		log.Info(line)
 	}
-	log.Info("---------------------------------------------------------------------------------------------")
+	log.Info(strings.Repeat("-", 153))
 	log.Info("")
 
 	if err := pruner.RecoverPruning(stack.ResolvePath(""), chainDb, stack.ResolvePath(config.TrieCleanCacheJournal)); err != nil {

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"math/big"
 	"runtime"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -140,7 +141,13 @@ func New(stack *node.Node, config *ethconfig.Config) (*Ethereum, error) {
 	if _, ok := genesisErr.(*params.ConfigCompatError); genesisErr != nil && !ok {
 		return nil, genesisErr
 	}
-	log.Info("Initialised chain configuration", "config", chainConfig)
+	log.Info("")
+	log.Info("---------------------------------------------------------------------------------------------")
+	for _, line := range strings.Split(chainConfig.String(), "\n") {
+		log.Info(line)
+	}
+	log.Info("---------------------------------------------------------------------------------------------")
+	log.Info("")
 
 	if err := pruner.RecoverPruning(stack.ResolvePath(""), chainDb, stack.ResolvePath(config.TrieCleanCacheJournal)); err != nil {
 		log.Error("Failed to recover state", "error", err)

--- a/les/client.go
+++ b/les/client.go
@@ -98,11 +98,11 @@ func New(stack *node.Node, config *ethconfig.Config) (*LightEthereum, error) {
 		return nil, genesisErr
 	}
 	log.Info("")
-	log.Info("---------------------------------------------------------------------------------------------")
+	log.Info(strings.Repeat("-", 153))
 	for _, line := range strings.Split(chainConfig.String(), "\n") {
 		log.Info(line)
 	}
-	log.Info("---------------------------------------------------------------------------------------------")
+	log.Info(strings.Repeat("-", 153))
 	log.Info("")
 
 	peers := newServerPeerSet()

--- a/les/client.go
+++ b/les/client.go
@@ -19,6 +19,7 @@ package les
 
 import (
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/ethereum/go-ethereum/accounts"
@@ -96,7 +97,13 @@ func New(stack *node.Node, config *ethconfig.Config) (*LightEthereum, error) {
 	if _, isCompat := genesisErr.(*params.ConfigCompatError); genesisErr != nil && !isCompat {
 		return nil, genesisErr
 	}
-	log.Info("Initialised chain configuration", "config", chainConfig)
+	log.Info("")
+	log.Info("---------------------------------------------------------------------------------------------")
+	for _, line := range strings.Split(chainConfig.String(), "\n") {
+		log.Info(line)
+	}
+	log.Info("---------------------------------------------------------------------------------------------")
+	log.Info("")
 
 	peers := newServerPeerSet()
 	merger := consensus.NewMerger(chainDb)

--- a/params/config.go
+++ b/params/config.go
@@ -569,7 +569,7 @@ func (c *ChainConfig) CheckConfigForkOrder() error {
 		{name: "berlinBlock", block: c.BerlinBlock},
 		{name: "londonBlock", block: c.LondonBlock},
 		{name: "arrowGlacierBlock", block: c.ArrowGlacierBlock, optional: true},
-		{name: "mergeNetwplitBlock", block: c.MergeNetsplitBlock, optional: true},
+		{name: "mergeNetsplitBlock", block: c.MergeNetsplitBlock, optional: true},
 	} {
 		if lastFork.name != "" {
 			// Next one must be higher number

--- a/params/config.go
+++ b/params/config.go
@@ -400,18 +400,18 @@ func (c *ChainConfig) String() string {
 	switch {
 	case c.Ethash != nil:
 		if c.TerminalTotalDifficulty == nil {
-			banner += fmt.Sprintf("Consensus: Ethash (proof-of-work)\n")
+			banner += "Consensus: Ethash (proof-of-work)\n"
 		} else {
-			banner += fmt.Sprintf("Consensus: Beacon (proof-of-stake), merged from Ethash (proof-of-work)\n")
+			banner += "Consensus: Beacon (proof-of-stake), merged from Ethash (proof-of-work)\n"
 		}
 	case c.Clique != nil:
 		if c.TerminalTotalDifficulty == nil {
-			banner += fmt.Sprintf("Consensus: Clique (proof-of-authority)\n")
+			banner += "Consensus: Clique (proof-of-authority)\n"
 		} else {
-			banner += fmt.Sprintf("Consensus: Beacon (proof-of-stake), merged from Clique (proof-of-authority)\n")
+			banner += "Consensus: Beacon (proof-of-stake), merged from Clique (proof-of-authority)\n"
 		}
 	default:
-		banner += fmt.Sprintf("Consensus: unknown\n")
+		banner += "Consensus: unknown\n"
 	}
 	banner += "\n"
 

--- a/params/config.go
+++ b/params/config.go
@@ -357,7 +357,7 @@ type ChainConfig struct {
 	BerlinBlock         *big.Int `json:"berlinBlock,omitempty"`         // Berlin switch block (nil = no fork, 0 = already on berlin)
 	LondonBlock         *big.Int `json:"londonBlock,omitempty"`         // London switch block (nil = no fork, 0 = already on london)
 	ArrowGlacierBlock   *big.Int `json:"arrowGlacierBlock,omitempty"`   // Eip-4345 (bomb delay) switch block (nil = no fork, 0 = already activated)
-	MergeForkBlock      *big.Int `json:"mergeForkBlock,omitempty"`      // EIP-3675 (TheMerge) switch block (nil = no fork, 0 = already in merge proceedings)
+	MergeNetsplitBlock  *big.Int `json:"mergeNetsplitBlock,omitempty"`  // Virtual fork after The Merge to use as a network splitter
 
 	// TerminalTotalDifficulty is the amount of total difficulty reached by
 	// the network that triggers the consensus upgrade.
@@ -419,34 +419,36 @@ func (c *ChainConfig) String() string {
 	// makes sense for mainnet should be optional at printing to avoid bloating
 	// the output for testnets and private networks.
 	banner += "Pre-Merge hard forks:\n"
-	banner += fmt.Sprintf(" - Homestead:                   %-8v (delegatecall)\n", c.HomesteadBlock)
+	banner += fmt.Sprintf(" - Homestead:                   %-8v (https://github.com/ethereum/execution-specs/blob/master/network-upgrades/mainnet-upgrades/homestead.md)\n", c.HomesteadBlock)
 	if c.DAOForkBlock != nil {
-		banner += fmt.Sprintf(" - DAO Fork:                    %-8v (TheDAO attack neutralization)\n", c.DAOForkBlock)
+		banner += fmt.Sprintf(" - DAO Fork:                    %-8v (https://github.com/ethereum/execution-specs/blob/master/network-upgrades/mainnet-upgrades/dao-fork.md)\n", c.DAOForkBlock)
 	}
-	banner += fmt.Sprintf(" - Tangerine Whistle (EIP 150): %-8v (Shanghai attack neutralization)\n", c.EIP150Block)
-	banner += fmt.Sprintf(" - Spurious Dragon/1 (EIP 155): %-8v (replay protection)\n", c.EIP155Block)
-	banner += fmt.Sprintf(" - Spurious Dragon/2 (EIP 158): %-8v (Shanghai attack cleanup)\n", c.EIP155Block)
-	banner += fmt.Sprintf(" - Byzantium:                   %-8v (revert, bn256, returndata, staticcall, status code)\n", c.ByzantiumBlock)
-	banner += fmt.Sprintf(" - Constantinople:              %-8v (bitshifts, create2, extcodehash, net metering)\n", c.ConstantinopleBlock)
-	banner += fmt.Sprintf(" - Petersburg:                  %-8v (undo faulty net metering)\n", c.PetersburgBlock)
-	banner += fmt.Sprintf(" - Istanbul:                    %-8v (blake2, chainid, fixed net metering)\n", c.IstanbulBlock)
+	banner += fmt.Sprintf(" - Tangerine Whistle (EIP 150): %-8v (https://github.com/ethereum/execution-specs/blob/master/network-upgrades/mainnet-upgrades/tangerine-whistle.md)\n", c.EIP150Block)
+	banner += fmt.Sprintf(" - Spurious Dragon/1 (EIP 155): %-8v (https://github.com/ethereum/execution-specs/blob/master/network-upgrades/mainnet-upgrades/spurious-dragon.md)\n", c.EIP155Block)
+	banner += fmt.Sprintf(" - Spurious Dragon/2 (EIP 158): %-8v (https://github.com/ethereum/execution-specs/blob/master/network-upgrades/mainnet-upgrades/spurious-dragon.md)\n", c.EIP155Block)
+	banner += fmt.Sprintf(" - Byzantium:                   %-8v (https://github.com/ethereum/execution-specs/blob/master/network-upgrades/mainnet-upgrades/byzantium.md)\n", c.ByzantiumBlock)
+	banner += fmt.Sprintf(" - Constantinople:              %-8v (https://github.com/ethereum/execution-specs/blob/master/network-upgrades/mainnet-upgrades/constantinople.md)\n", c.ConstantinopleBlock)
+	banner += fmt.Sprintf(" - Petersburg:                  %-8v (https://github.com/ethereum/execution-specs/blob/master/network-upgrades/mainnet-upgrades/petersburg.md)\n", c.PetersburgBlock)
+	banner += fmt.Sprintf(" - Istanbul:                    %-8v (https://github.com/ethereum/execution-specs/blob/master/network-upgrades/mainnet-upgrades/istanbul.md)\n", c.IstanbulBlock)
 	if c.MuirGlacierBlock != nil {
-		banner += fmt.Sprintf(" - Muir Glacier:                %-8v (ice age delay)\n", c.MuirGlacierBlock)
+		banner += fmt.Sprintf(" - Muir Glacier:                %-8v (https://github.com/ethereum/execution-specs/blob/master/network-upgrades/mainnet-upgrades/muir-glacier.md)\n", c.MuirGlacierBlock)
 	}
-	banner += fmt.Sprintf(" - Berlin:                      %-8v (typed transaction, access lists)\n", c.BerlinBlock)
-	banner += fmt.Sprintf(" - London:                      %-8v (fee burn, basefee)\n", c.LondonBlock)
+	banner += fmt.Sprintf(" - Berlin:                      %-8v (https://github.com/ethereum/execution-specs/blob/master/network-upgrades/mainnet-upgrades/berlin.md)\n", c.BerlinBlock)
+	banner += fmt.Sprintf(" - London:                      %-8v (https://github.com/ethereum/execution-specs/blob/master/network-upgrades/mainnet-upgrades/london.md)\n", c.LondonBlock)
 	if c.ArrowGlacierBlock != nil {
-		banner += fmt.Sprintf(" - Arrow Glacier:               %-8v (ice age delay)\n", c.ArrowGlacierBlock)
+		banner += fmt.Sprintf(" - Arrow Glacier:               %-8v (https://github.com/ethereum/execution-specs/blob/master/network-upgrades/mainnet-upgrades/arrow-glacier.md)\n", c.ArrowGlacierBlock)
 	}
 	banner += "\n"
 
 	// Add a special section for the merge as it's non-obvious
 	if c.TerminalTotalDifficulty == nil {
-		banner += "Merge not configured!"
+		banner += "Merge not configured!\n"
+		banner += " - Hard-fork specification: https://github.com/ethereum/execution-specs/blob/master/network-upgrades/mainnet-upgrades/paris.md)"
 	} else {
 		banner += "Merge configured:\n"
-		banner += fmt.Sprintf(" - Total terminal difficulty: %v (proof-of-stake switchover threshold)\n", c.TerminalTotalDifficulty)
-		banner += fmt.Sprintf(" - Merge fork block:          %-8v (network partitioning point)", c.MergeForkBlock)
+		banner += " - Hard-fork specification:   https://github.com/ethereum/execution-specs/blob/master/network-upgrades/mainnet-upgrades/paris.md)\n"
+		banner += fmt.Sprintf(" - Total terminal difficulty: %v\n", c.TerminalTotalDifficulty)
+		banner += fmt.Sprintf(" - Merge netsplit block:      %-8v", c.MergeNetsplitBlock)
 	}
 	return banner
 }
@@ -567,7 +569,7 @@ func (c *ChainConfig) CheckConfigForkOrder() error {
 		{name: "berlinBlock", block: c.BerlinBlock},
 		{name: "londonBlock", block: c.LondonBlock},
 		{name: "arrowGlacierBlock", block: c.ArrowGlacierBlock, optional: true},
-		{name: "mergeStartBlock", block: c.MergeForkBlock, optional: true},
+		{name: "mergeNetwplitBlock", block: c.MergeNetsplitBlock, optional: true},
 	} {
 		if lastFork.name != "" {
 			// Next one must be higher number
@@ -640,8 +642,8 @@ func (c *ChainConfig) checkCompatible(newcfg *ChainConfig, head *big.Int) *Confi
 	if isForkIncompatible(c.ArrowGlacierBlock, newcfg.ArrowGlacierBlock, head) {
 		return newCompatError("Arrow Glacier fork block", c.ArrowGlacierBlock, newcfg.ArrowGlacierBlock)
 	}
-	if isForkIncompatible(c.MergeForkBlock, newcfg.MergeForkBlock, head) {
-		return newCompatError("Merge Start fork block", c.MergeForkBlock, newcfg.MergeForkBlock)
+	if isForkIncompatible(c.MergeNetsplitBlock, newcfg.MergeNetsplitBlock, head) {
+		return newCompatError("Merge netsplit fork block", c.MergeNetsplitBlock, newcfg.MergeNetsplitBlock)
 	}
 	return nil
 }

--- a/tests/init.go
+++ b/tests/init.go
@@ -211,7 +211,7 @@ var Forks = map[string]*params.ChainConfig{
 		BerlinBlock:             big.NewInt(0),
 		LondonBlock:             big.NewInt(0),
 		ArrowGlacierBlock:       big.NewInt(0),
-		MergeForkBlock:          big.NewInt(0),
+		MergeNetsplitBlock:      big.NewInt(0),
 		TerminalTotalDifficulty: big.NewInt(0),
 	},
 }


### PR DESCRIPTION
Previously on Geth startup we just logged the chain config is a semi-json-y format. Whilst that worked while we had a handful of hard-forks defined, currently it's kind of unwieldy:

```
INFO [05-18|16:52:33.240] Initialised chain configuration          config="{ChainID: 3 Homestead: 0 DAO: <nil> DAOSupport: true EIP150: 0 EIP155: 10 EIP158: 10 Byzantium: 1700000 Constantinople: 4230000 Petersburg: 4939394 Istanbul: 6485846, Muir Glacier: 7117117, Berlin: 9812189, London: 10499401, Arrow Glacier: <nil>, MergeFork: <nil>, Terminal TD: 43531756765713534, Engine: ethash}"
```

This PR converts that original data dump and converts it into a user friendly - alas multiline - log output.

```
INFO [05-18|19:01:25.889] --------------------------------------------------------------------------------------------- 
INFO [05-18|19:01:25.889] Chain ID:  3 (ropsten) 
INFO [05-18|19:01:25.889] Consensus: Beacon (proof-of-stake), merged from Ethash (proof-of-work) 
INFO [05-18|19:01:25.890]  
INFO [05-18|19:01:25.890] Pre-Merge hard forks: 
INFO [05-18|19:01:25.890]  - Homestead:                   0        (delegatecall) 
INFO [05-18|19:01:25.890]  - Tangerine Whistle (EIP 150): 0        (Shanghai attack neutralization) 
INFO [05-18|19:01:25.890]  - Spurious Dragon/1 (EIP 155): 10       (replay protection) 
INFO [05-18|19:01:25.890]  - Spurious Dragon/2 (EIP 158): 10       (Shanghai attack cleanup) 
INFO [05-18|19:01:25.890]  - Byzantium:                   1700000  (revert, bn256, returndata, staticcall, status code) 
INFO [05-18|19:01:25.890]  - Constantinople:              4230000  (bitshifts, create2, extcodehash, net metering) 
INFO [05-18|19:01:25.890]  - Petersburg:                  4939394  (undo faulty net metering) 
INFO [05-18|19:01:25.890]  - Istanbul:                    6485846  (blake2, chainid, fixed net metering) 
INFO [05-18|19:01:25.890]  - Muir Glacier:                7117117  (ice age delay) 
INFO [05-18|19:01:25.890]  - Berlin:                      9812189  (typed transaction, access lists) 
INFO [05-18|19:01:25.890]  - London:                      10499401 (fee burn, basefee) 
INFO [05-18|19:01:25.890]  
INFO [05-18|19:01:25.890] Merge configured: 
INFO [05-18|19:01:25.890]  - Total terminal difficulty: 43531756765713534 (proof-of-stake switchover threshold) 
INFO [05-18|19:01:25.890]  - Merge fork block:          <nil> (network partitioning point) 
INFO [05-18|19:01:25.890] --------------------------------------------------------------------------------------------- 
```