### PR TITLE
core/state: remove notion of fake storage

### DIFF
--- a/core/state/state_object.go
+++ b/core/state/state_object.go
@@ -263,9 +263,11 @@ func (s *stateObject) SetState(db Database, key, value common.Hash) {
 //
 // Note this function should only be used for debugging purpose.
 //
-//@deprecated use SetState per item instead. This method no longer fully replaces
-// all slots.
 func (s *stateObject) SetStorage(db Database, storage map[common.Hash]common.Hash) {
+	// We set the root to empty root, to make prevent GetCommittedState from
+	// reading the original data, it should thus only have access to what is
+	// set in the loop below.
+	s.data.Root = emptyRoot
 	for k, v := range storage {
 		s.SetState(db, k, v)
 	}

--- a/core/state/state_object.go
+++ b/core/state/state_object.go
@@ -84,7 +84,6 @@ type stateObject struct {
 	originStorage  Storage // Storage cache of original entries to dedup rewrites, reset for every transaction
 	pendingStorage Storage // Storage entries that need to be flushed to disk, at the end of an entire block
 	dirtyStorage   Storage // Storage entries that have been modified in the current transaction execution
-	fakeStorage    Storage // Fake storage which constructed by caller for debugging purpose.
 
 	// Cache flags.
 	// When an object is marked suicided it will be delete from the trie
@@ -173,10 +172,6 @@ func (s *stateObject) getTrie(db Database) (Trie, error) {
 
 // GetState retrieves a value from the account storage trie.
 func (s *stateObject) GetState(db Database, key common.Hash) common.Hash {
-	// If the fake storage is set, only lookup the state here(in the debugging mode)
-	if s.fakeStorage != nil {
-		return s.fakeStorage[key]
-	}
 	// If we have a dirty value for this state entry, return it
 	value, dirty := s.dirtyStorage[key]
 	if dirty {
@@ -188,10 +183,6 @@ func (s *stateObject) GetState(db Database, key common.Hash) common.Hash {
 
 // GetCommittedState retrieves a value from the committed account storage trie.
 func (s *stateObject) GetCommittedState(db Database, key common.Hash) common.Hash {
-	// If the fake storage is set, only lookup the state here(in the debugging mode)
-	if s.fakeStorage != nil {
-		return s.fakeStorage[key]
-	}
 	// If we have a pending write or clean cached, return that
 	if value, pending := s.pendingStorage[key]; pending {
 		return value
@@ -251,11 +242,6 @@ func (s *stateObject) GetCommittedState(db Database, key common.Hash) common.Has
 
 // SetState updates a value in account storage.
 func (s *stateObject) SetState(db Database, key, value common.Hash) {
-	// If the fake storage is set, put the temporary state update here.
-	if s.fakeStorage != nil {
-		s.fakeStorage[key] = value
-		return
-	}
 	// If the new value is the same as old, don't set
 	prev := s.GetState(db, key)
 	if prev == value {
@@ -276,16 +262,13 @@ func (s *stateObject) SetState(db Database, key, value common.Hash) {
 // lookup only happens in the fake state storage.
 //
 // Note this function should only be used for debugging purpose.
-func (s *stateObject) SetStorage(storage map[common.Hash]common.Hash) {
-	// Allocate fake storage if it's nil.
-	if s.fakeStorage == nil {
-		s.fakeStorage = make(Storage)
+//
+//@deprecated use SetState per item instead. This method no longer fully replaces
+// all slots.
+func (s *stateObject) SetStorage(db Database, storage map[common.Hash]common.Hash) {
+	for k, v := range storage {
+		s.SetState(db, k, v)
 	}
-	for key, value := range storage {
-		s.fakeStorage[key] = value
-	}
-	// Don't bother journal since this function should only be used for
-	// debugging and the `fake` storage won't be committed to database.
 }
 
 func (s *stateObject) setState(key, value common.Hash) {

--- a/core/state/state_object.go
+++ b/core/state/state_object.go
@@ -256,23 +256,6 @@ func (s *stateObject) SetState(db Database, key, value common.Hash) {
 	s.setState(key, value)
 }
 
-// SetStorage replaces the entire state storage with the given one.
-//
-// After this function is called, all original state will be ignored and state
-// lookup only happens in the fake state storage.
-//
-// Note this function should only be used for debugging purpose.
-//
-func (s *stateObject) SetStorage(db Database, storage map[common.Hash]common.Hash) {
-	// We set the root to empty root, to make prevent GetCommittedState from
-	// reading the original data, it should thus only have access to what is
-	// set in the loop below.
-	s.data.Root = emptyRoot
-	for k, v := range storage {
-		s.SetState(db, k, v)
-	}
-}
-
 func (s *stateObject) setState(key, value common.Hash) {
 	s.dirtyStorage[key] = value
 }

--- a/core/state/statedb.go
+++ b/core/state/statedb.go
@@ -444,7 +444,7 @@ func (s *StateDB) SetState(addr common.Address, key, value common.Hash) {
 func (s *StateDB) SetStorage(addr common.Address, storage map[common.Hash]common.Hash) {
 	stateObject := s.GetOrNewStateObject(addr)
 	if stateObject != nil {
-		stateObject.SetStorage(storage)
+		stateObject.SetStorage(s.db, storage)
 	}
 }
 

--- a/core/state/statedb.go
+++ b/core/state/statedb.go
@@ -442,9 +442,15 @@ func (s *StateDB) SetState(addr common.Address, key, value common.Hash) {
 // SetStorage replaces the entire storage for the specified account with given
 // storage. This function should only be used for debugging.
 func (s *StateDB) SetStorage(addr common.Address, storage map[common.Hash]common.Hash) {
+	// SetStorage needs to wipe existing storage. We achieve this by pretending
+	// that the account self-destructed earlier in this block, by flagging
+	// it in stateObjectsDestruct. The effect of doing so is that storage lookups
+	// will not hit disk, since it is assumed that the disk-data is belonging
+	// to a previous incarnation of the object.
+	s.stateObjectsDestruct[addr] = struct{}{}
 	stateObject := s.GetOrNewStateObject(addr)
-	if stateObject != nil {
-		stateObject.SetStorage(s.db, storage)
+	for k, v := range storage {
+		stateObject.SetState(s.db, k, v)
 	}
 }
 

--- a/eth/tracers/api_test.go
+++ b/eth/tracers/api_test.go
@@ -628,7 +628,8 @@ func TestTracingWithOverrides(t *testing.T) {
 					},
 				},
 			},
-			want: `{"gas":46900,"failed":false,"returnValue":"0000000000000000000000000000000000000000000000000000000000000539"}`,
+			//want: `{"gas":46900,"failed":false,"returnValue":"0000000000000000000000000000000000000000000000000000000000000539"}`,
+			want: `{"gas":44100,"failed":false,"returnValue":"0000000000000000000000000000000000000000000000000000000000000001"}`,
 		},
 	}
 	for i, tc := range testSuite {

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -909,6 +909,8 @@ func (diff *StateOverride) Apply(state *state.StateDB) error {
 			}
 		}
 	}
+	// Now commit the changes
+	state.Commit(false)
 	return nil
 }
 

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -909,8 +909,10 @@ func (diff *StateOverride) Apply(state *state.StateDB) error {
 			}
 		}
 	}
-	// Now commit the changes
-	state.Commit(false)
+	// Now finalize the changes. Finalize is normally performed between transactions.
+	// By using finalize, the overrides are semantically behaving as
+	// if they were created in a transaction just before the tracing occur.
+	state.Finalise(false)
 	return nil
 }
 


### PR DESCRIPTION
This PR fixes https://github.com/ethereum/go-ethereum/issues/24456 . 

This PR removes the notion of `fakeStorage` from the state objects, and instead, for any state modifications that are needed, it simply makes the changes and commits it. 

I'm not fully certain if there are any tangible negative side-effects of doing a `Commit` (such as, does it have potential to flush stuff to disk? I _think_ not). 

One other change is that this change makes it not possible to replace the entire storage in one go, rather we can only update slots explicitly. I don't know how much of a biggie that is. 