### PR TITLE
eth/filters: use buffered channel to avoid goroutine leak

### DIFF
--- a/eth/filters/filter_system_test.go
+++ b/eth/filters/filter_system_test.go
@@ -592,7 +592,7 @@ func TestPendingLogsSubscription(t *testing.T) {
 	// (some) events are posted.
 	for i := range testCases {
 		testCases[i].c = make(chan []*types.Log)
-		testCases[i].err = make(chan error)
+		testCases[i].err = make(chan error, 1)
 
 		var err error
 		testCases[i].sub, err = api.events.SubscribeLogs(testCases[i].crit, testCases[i].c)


### PR DESCRIPTION
In func `TestPendingLogsSubscription`,
Goroutine may leak because sending to chan `testCases[i].err` is blocked forever on [L628](https://github.com/ethereum/go-ethereum/blob/2b0d0ce8b0a02634b90b02bc038523eacd2b220a/eth/filters/filter_system_test.go#L628), [L634](https://github.com/ethereum/go-ethereum/blob/2b0d0ce8b0a02634b90b02bc038523eacd2b220a/eth/filters/filter_system_test.go#L634), [L638](https://github.com/ethereum/go-ethereum/blob/2b0d0ce8b0a02634b90b02bc038523eacd2b220a/eth/filters/filter_system_test.go#L638), or [L642](https://github.com/ethereum/go-ethereum/blob/2b0d0ce8b0a02634b90b02bc038523eacd2b220a/eth/filters/filter_system_test.go#L642) when receiving from chan on [L652](https://github.com/ethereum/go-ethereum/blob/2b0d0ce8b0a02634b90b02bc038523eacd2b220a/eth/filters/filter_system_test.go#L652) is skipped due to fatal errors. Although `t.Fatal()` is called in this case, it won't stop the leaking, because  because "[Calling FailNow does not stop those other goroutines.](https://golang.org/pkg/testing/#T.FailNow)". 
The fix is to replace the unbuffered channel with a buffered channel (buffer size 1), and the semantic is not changed.