### PR TITLE
p2p: add channel buffers to avoid goroutine leaks in tests

### DIFF
--- a/p2p/discover/v4_udp_test.go
+++ b/p2p/discover/v4_udp_test.go
@@ -312,7 +312,7 @@ func TestUDPv4_findnodeMultiReply(t *testing.T) {
 	test.table.db.UpdateLastPingReceived(rid, test.remoteaddr.IP, time.Now())
 
 	// queue a pending findnode request
-	resultc, errc := make(chan []*node), make(chan error)
+	resultc, errc := make(chan []*node, 1), make(chan error, 1)
 	go func() {
 		rid := encodePubkey(&test.remotekey.PublicKey).id()
 		ns, err := test.udp.findnode(rid, test.remoteaddr, testTarget)

--- a/p2p/dnsdisc/client_test.go
+++ b/p2p/dnsdisc/client_test.go
@@ -265,7 +265,7 @@ func TestIteratorEmptyTree(t *testing.T) {
 	resolver.add(tree1.ToTXT("n"))
 
 	// Start the iterator.
-	node := make(chan *enode.Node)
+	node := make(chan *enode.Node, 1)
 	it, err := c.NewIterator(url)
 	if err != nil {
 		t.Fatal(err)

--- a/p2p/simulations/examples/ping-pong.go
+++ b/p2p/simulations/examples/ping-pong.go
@@ -139,7 +139,7 @@ const (
 func (p *pingPongService) Run(peer *p2p.Peer, rw p2p.MsgReadWriter) error {
 	log := p.log.New("peer.id", peer.ID())
 
-	errC := make(chan error)
+	errC := make(chan error, 1)
 	go func() {
 		for range time.Tick(10 * time.Second) {
 			log.Info("sending ping")

--- a/p2p/simulations/http_test.go
+++ b/p2p/simulations/http_test.go
@@ -598,7 +598,7 @@ func TestHTTPSnapshot(t *testing.T) {
 	network, s := testHTTPServer(t)
 	defer s.Close()
 
-	var eventsDone = make(chan struct{})
+	var eventsDone = make(chan struct{}, 1)
 	count := 1
 	eventsDoneChan := make(chan *Event)
 	eventSub := network.Events().Subscribe(eventsDoneChan)


### PR DESCRIPTION
There are four potential goroutine leaks in p2p tests.
1. In func `TestUDPv4_findnodeMultiReply` in `p2p/discover/v4_udp_test.go`, sending to chan `errc` is blocked forever on [L320](https://github.com/ethereum/go-ethereum/blob/2b0d0ce8b0a02634b90b02bc038523eacd2b220a/p2p/discover/v4_udp_test.go#L320) when `select` selects `result` on [L350](https://github.com/ethereum/go-ethereum/blob/2b0d0ce8b0a02634b90b02bc038523eacd2b220a/p2p/discover/v4_udp_test.go#L350) or `time.After` on [L357](https://github.com/ethereum/go-ethereum/blob/2b0d0ce8b0a02634b90b02bc038523eacd2b220a/p2p/discover/v4_udp_test.go#L357) and sending to `resultc` is blocked forever on [L322](https://github.com/ethereum/go-ethereum/blob/2b0d0ce8b0a02634b90b02bc038523eacd2b220a/p2p/discover/v4_udp_test.go#L322) when `select` selects `err` on [L355](https://github.com/ethereum/go-ethereum/blob/2b0d0ce8b0a02634b90b02bc038523eacd2b220a/p2p/discover/v4_udp_test.go#L355) or `time.After` on [L357](https://github.com/ethereum/go-ethereum/blob/2b0d0ce8b0a02634b90b02bc038523eacd2b220a/p2p/discover/v4_udp_test.go#L357).
2. In func `TestIteratorEmptyTree` in `p2p/dnsdisc/client_test.go`, sending to chan `node` is blocked forever on [L275](https://github.com/ethereum/go-ethereum/blob/2b0d0ce8b0a02634b90b02bc038523eacd2b220a/p2p/dnsdisc/client_test.go#L275) when` select` selects `time.After` on [L291](https://github.com/ethereum/go-ethereum/blob/2b0d0ce8b0a02634b90b02bc038523eacd2b220a/p2p/dnsdisc/client_test.go#L291).
3. In func `TestHTTPSnapshot` in `p2p/simulations/http_test.go`, sending to chan `eventsDone` is blocked forever on [L611](https://github.com/ethereum/go-ethereum/blob/2b0d0ce8b0a02634b90b02bc038523eacd2b220a/p2p/simulations/http_test.go#L611) or [L676](https://github.com/ethereum/go-ethereum/blob/2b0d0ce8b0a02634b90b02bc038523eacd2b220a/p2p/simulations/http_test.go#L676) when receiving from chan on [L651](https://github.com/ethereum/go-ethereum/blob/2b0d0ce8b0a02634b90b02bc038523eacd2b220a/p2p/simulations/http_test.go#L651) or [L696](https://github.com/ethereum/go-ethereum/blob/2b0d0ce8b0a02634b90b02bc038523eacd2b220a/p2p/simulations/http_test.go#L696) is skipped due to fatal errors.
4. In func `Run` in `p2p/simulations/examples/ping-pong.go`, sending to chan `errC` may be blocked forever on [L147](https://github.com/ethereum/go-ethereum/blob/2b0d0ce8b0a02634b90b02bc038523eacd2b220a/p2p/simulations/examples/ping-pong.go#L147) in goroutine1 or ([L156](https://github.com/ethereum/go-ethereum/blob/2b0d0ce8b0a02634b90b02bc038523eacd2b220a/p2p/simulations/examples/ping-pong.go#L156) or [L161](https://github.com/ethereum/go-ethereum/blob/2b0d0ce8b0a02634b90b02bc038523eacd2b220a/p2p/simulations/examples/ping-pong.go#L161)) in goroutine2. If either goroutine receives from `errC` and exits, the other goroutine will block forever.

The fix is to replace the unbuffered channel with a buffered channel (buffer size 1), and the semantic is not changed.