### PR TITLE
contracs/checkpointoracle: fix directives

### DIFF
--- a/contracts/checkpointoracle/oracle.go
+++ b/contracts/checkpointoracle/oracle.go
@@ -17,7 +17,8 @@
 // Package checkpointoracle is a an on-chain light client checkpoint oracle.
 package checkpointoracle
 
-//go:generate go run ../../cmd/abigen --sol contract/oracle.sol --pkg contract --out contract/oracle.go
+//go:generate solc contract/oracle.sol --combined-json bin,bin-runtime,srcmap,srcmap-runtime,abi,userdoc,devdoc,metadata,hashes --optimize -o ./ --overwrite
+//go:generate go run ../../cmd/abigen --pkg contract --out contract/oracle.go --combined-json ./combined.json
 
 import (
 	"errors"


### PR DESCRIPTION
This PR fixes our go-generate directives relying on solc compiler integration. 
This PR does not contain an updated version of the oracle, though. While testing this, I noticed that the oracle does not compile with the most recent version of `solc`. 
An older `0.6.10` version does compile (with warnings). I didn't think it made any sense to recompile with `0.6.10`, so just left it as it was instead. 
At some point maybe we could make it work on a more recent solc instead, and recompile it properly. 

