### PR TITLE
eth/tracers: output stack values in 32-byte length

### DIFF
--- a/eth/tracers/logger/logger.go
+++ b/eth/tracers/logger/logger.go
@@ -292,7 +292,7 @@ func WriteTrace(writer io.Writer, logs []StructLog) {
 		if len(log.Stack) > 0 {
 			fmt.Fprintln(writer, "Stack:")
 			for i := len(log.Stack) - 1; i >= 0; i-- {
-				fmt.Fprintf(writer, "%08d  %s\n", len(log.Stack)-i-1, log.Stack[i].Hex())
+				fmt.Fprintf(writer, "%08d  %x\n", len(log.Stack)-i-1, log.Stack[i].Bytes32())
 			}
 		}
 		if len(log.Memory) > 0 {
@@ -370,7 +370,7 @@ func (t *mdLogger) CaptureState(pc uint64, op vm.OpCode, gas, cost uint64, scope
 		// format stack
 		var a []string
 		for _, elem := range stack.Data() {
-			a = append(a, elem.Hex())
+			a = append(a, fmt.Sprintf("%x", elem.Bytes32()))
 		}
 		b := fmt.Sprintf("[%v]", strings.Join(a, ","))
 		fmt.Fprintf(t.out, "%10v |", b)
@@ -441,7 +441,7 @@ func formatLogs(logs []StructLog) []StructLogRes {
 		if trace.Stack != nil {
 			stack := make([]string, len(trace.Stack))
 			for i, stackValue := range trace.Stack {
-				stack[i] = stackValue.Hex()
+				stack[i] = fmt.Sprintf("%x", stackValue.Bytes32())
 			}
 			formatted[index].Stack = &stack
 		}


### PR DESCRIPTION
Not sure if this is the right way, but this will improve the readability of stack output.