### PR TITLE
p2p: custom discovery UDP port

### DIFF
--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -119,7 +119,7 @@ var (
 		utils.CachePreimagesFlag,
 		utils.FDLimitFlag,
 		utils.ListenPortFlag,
-		utils.DiscPortFlag,
+		utils.DiscoveryPortFlag,
 		utils.MaxPeersFlag,
 		utils.MaxPendingPeersFlag,
 		utils.MiningEnabledFlag,

--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -119,6 +119,7 @@ var (
 		utils.CachePreimagesFlag,
 		utils.FDLimitFlag,
 		utils.ListenPortFlag,
+		utils.DiscPortFlag,
 		utils.MaxPeersFlag,
 		utils.MaxPendingPeersFlag,
 		utils.MiningEnabledFlag,

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -799,6 +799,12 @@ var (
 		Value:    "",
 		Category: flags.NetworkingCategory,
 	}
+	DiscPortFlag = &cli.IntFlag{
+		Name:     "discport",
+		Usage:    "Use a custom UDP port for P2P discovery",
+		Value:    30303,
+		Category: flags.NetworkingCategory,
+	}
 	NodeKeyFileFlag = &cli.StringFlag{
 		Name:     "nodekey",
 		Usage:    "P2P node key file",
@@ -1116,11 +1122,14 @@ func setBootstrapNodesV5(ctx *cli.Context, cfg *p2p.Config) {
 	}
 }
 
-// setListenAddress creates a TCP listening address string from set command
-// line flags.
+// setListenAddress creates TCP/UDP listening address strings from set command
+// line flags
 func setListenAddress(ctx *cli.Context, cfg *p2p.Config) {
 	if ctx.IsSet(ListenPortFlag.Name) {
 		cfg.ListenAddr = fmt.Sprintf(":%d", ctx.Int(ListenPortFlag.Name))
+	}
+	if ctx.GlobalIsSet(DiscPortFlag.Name) {
+		cfg.DiscAddr = fmt.Sprintf(":%d", ctx.GlobalInt(DiscPortFlag.Name))
 	}
 }
 

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -805,6 +805,12 @@ var (
 		Value:    30303,
 		Category: flags.NetworkingCategory,
 	}
+	DiscPortFlag = &cli.IntFlag{
+		Name:     "discport",
+		Usage:    "Use a custom UDP port for P2P discovery",
+		Value:    30303,
+		Category: flags.NetworkingCategory,
+	}
 	NodeKeyFileFlag = &cli.StringFlag{
 		Name:     "nodekey",
 		Usage:    "P2P node key file",

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -799,12 +799,6 @@ var (
 		Value:    "",
 		Category: flags.NetworkingCategory,
 	}
-	DiscPortFlag = &cli.IntFlag{
-		Name:     "discport",
-		Usage:    "Use a custom UDP port for P2P discovery",
-		Value:    30303,
-		Category: flags.NetworkingCategory,
-	}
 	NodeKeyFileFlag = &cli.StringFlag{
 		Name:     "nodekey",
 		Usage:    "P2P node key file",
@@ -839,6 +833,12 @@ var (
 	DNSDiscoveryFlag = &cli.StringFlag{
 		Name:     "discovery.dns",
 		Usage:    "Sets DNS discovery entry points (use \"\" to disable DNS)",
+		Category: flags.NetworkingCategory,
+	}
+	DiscoveryPortFlag = &cli.IntFlag{
+		Name:     "discovery.port",
+		Usage:    "Use a custom UDP port for P2P discovery",
+		Value:    30303,
 		Category: flags.NetworkingCategory,
 	}
 
@@ -1128,8 +1128,8 @@ func setListenAddress(ctx *cli.Context, cfg *p2p.Config) {
 	if ctx.IsSet(ListenPortFlag.Name) {
 		cfg.ListenAddr = fmt.Sprintf(":%d", ctx.Int(ListenPortFlag.Name))
 	}
-	if ctx.IsSet(DiscPortFlag.Name) {
-		cfg.DiscAddr = fmt.Sprintf(":%d", ctx.Int(DiscPortFlag.Name))
+	if ctx.IsSet(DiscoveryPortFlag.Name) {
+		cfg.DiscAddr = fmt.Sprintf(":%d", ctx.Int(DiscoveryPortFlag.Name))
 	}
 }
 

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -805,12 +805,6 @@ var (
 		Value:    30303,
 		Category: flags.NetworkingCategory,
 	}
-	DiscPortFlag = &cli.IntFlag{
-		Name:     "discport",
-		Usage:    "Use a custom UDP port for P2P discovery",
-		Value:    30303,
-		Category: flags.NetworkingCategory,
-	}
 	NodeKeyFileFlag = &cli.StringFlag{
 		Name:     "nodekey",
 		Usage:    "P2P node key file",

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -1128,8 +1128,8 @@ func setListenAddress(ctx *cli.Context, cfg *p2p.Config) {
 	if ctx.IsSet(ListenPortFlag.Name) {
 		cfg.ListenAddr = fmt.Sprintf(":%d", ctx.Int(ListenPortFlag.Name))
 	}
-	if ctx.GlobalIsSet(DiscPortFlag.Name) {
-		cfg.DiscAddr = fmt.Sprintf(":%d", ctx.GlobalInt(DiscPortFlag.Name))
+	if ctx.IsSet(DiscPortFlag.Name) {
+		cfg.DiscAddr = fmt.Sprintf(":%d", ctx.Int(DiscPortFlag.Name))
 	}
 }
 

--- a/p2p/server.go
+++ b/p2p/server.go
@@ -136,6 +136,10 @@ type Config struct {
 	// the server is started.
 	ListenAddr string
 
+	// If DiscAddr is set to a non-nil value, the server will use ListenAddr
+	// for TCP and DiscAddr for the UDP discovery protocol.
+	DiscAddr string
+
 	// If set to a non-nil value, the given NAT port mapper
 	// is used to make the listening port available to the
 	// Internet.
@@ -549,7 +553,15 @@ func (srv *Server) setupDiscovery() error {
 		return nil
 	}
 
-	addr, err := net.ResolveUDPAddr("udp", srv.ListenAddr)
+	listenAddr := srv.ListenAddr
+
+	// Use an alternate listening address for UDP if
+	// a custom discovery address is configured.
+	if (srv.DiscAddr != "") {
+		listenAddr = srv.DiscAddr
+	}
+
+	addr, err := net.ResolveUDPAddr("udp", listenAddr)
 	if err != nil {
 		return err
 	}

--- a/p2p/server.go
+++ b/p2p/server.go
@@ -557,7 +557,7 @@ func (srv *Server) setupDiscovery() error {
 
 	// Use an alternate listening address for UDP if
 	// a custom discovery address is configured.
-	if (srv.DiscAddr != "") {
+	if srv.DiscAddr != "" {
 		listenAddr = srv.DiscAddr
 	}
 


### PR DESCRIPTION
Implements a geth cli flag to modify the P2P discovery server's UDP listening address. Solves issue #22040. 
See the issue for an overview of my proposed changes. 
