### PR TITLE
core/transaction: Fixed a potential out of bound panic

### DIFF
--- a/core/types/transaction.go
+++ b/core/types/transaction.go
@@ -539,6 +539,9 @@ func (t *TransactionsByPriceAndNonce) Peek() *Transaction {
 
 // Shift replaces the current best head with the next one from the same account.
 func (t *TransactionsByPriceAndNonce) Shift() {
+	if len(t.heads) == 0 {
+		return
+	}
 	acc, _ := Sender(t.signer, t.heads[0].tx)
 	if txs, ok := t.txs[acc]; ok && len(txs) > 0 {
 		if wrapped, err := NewTxWithMinerFee(txs[0], t.baseFee); err == nil {


### PR DESCRIPTION
A length condition of a heap in the type `TransactionsByPriceAndNonce` is added. The Peek() function had been called as a guarantee of the existence of the heap elements before gets called the `Shift()` function. No buffer-over-run happens with the guard of the Peek(), but the function itself is not safe.

