### PR TITLE
Metrics Data issue : P2P metrics values are high; decrement when metered connection is closed

### DIFF
--- a/p2p/metrics.go
+++ b/p2p/metrics.go
@@ -86,9 +86,6 @@ func (c *meteredConn) Write(b []byte) (n int, err error) {
 // Close delegates a close operation to the underlying connection, unregisters
 // the peer from the traffic registries and emits close event.
 func (c *meteredConn) Close() error {
-	err := c.Conn.Close()
-	if err == nil {
-		activePeerGauge.Dec(1)
-	}
-	return err
+	defer activePeerGauge.Dec(1)
+	return c.Conn.Close()
 }


### PR DESCRIPTION
We have an issue raised by the GoQuorum community: https://github.com/ConsenSys/quorum/issues/1418

There is a mismatch between `net.peerCount` and `p2p_peers` gauge. Should they match?

My analysis is that the metered connection decrement the count only when the close call is successful, while it is always decrement on the p2p server side.

I am not sure of my fix, we may check the error type first, but that would mean that `net.peerCount` is not correct too.

I want to know if it is a possible reason of this issue, if not, please close this PR.