### PR TITLE
eth/catalyst: fix canon behind CurrentBlock

### DIFF
--- a/eth/catalyst/api.go
+++ b/eth/catalyst/api.go
@@ -144,7 +144,7 @@ func (api *ConsensusAPI) ForkchoiceUpdatedV1(update beacon.ForkchoiceStateV1, pa
 		}
 	}
 
-	if rawdb.ReadCanonicalHash(api.eth.ChainDb(), block.NumberU64()) != update.HeadBlockHash {
+	if rawdb.ReadCanonicalHash(api.eth.ChainDb(), block.NumberU64()) != update.HeadBlockHash || block.NumberU64() > api.eth.BlockChain().CurrentBlock().NumberU64() {
 		// Block is not canonical, set head.
 		if latestValid, err := api.eth.BlockChain().SetCanonical(block); err != nil {
 			return beacon.ForkChoiceResponse{PayloadStatus: beacon.PayloadStatusV1{Status: beacon.INVALID, LatestValidHash: &latestValid}}, err


### PR DESCRIPTION
This fixes all hive tests `Invalid Ancestor Chain Re-Org, Invalid StateRoot, Invalid P9', Reveal using newPayload (go-ethereum)` 
where we reveal using newPayload.
The issue is that the head block is marked as canonical but the current block is behind the head block.
I am not really confident in this as I suspect it might not fix the root cause (a block being marked canonical that is not really in our canonical chain). 

Maybe @rjl493456442 could take a look at this