### PR TITLE
eth/catalyst: remove unauthenticated 'engine' api

### DIFF
--- a/eth/catalyst/api.go
+++ b/eth/catalyst/api.go
@@ -47,13 +47,6 @@ func Register(stack *node.Node, backend *eth.Ethereum) error {
 			Public:        true,
 			Authenticated: true,
 		},
-		{
-			Namespace:     "engine",
-			Version:       "1.0",
-			Service:       NewConsensusAPI(backend),
-			Public:        true,
-			Authenticated: false,
-		},
 	})
 	return nil
 }


### PR DESCRIPTION
Removes `engine` from any unauthenticated RPC service. I need to test it a bit

```
geth --ropsten --datadir /tmp/foo --nodiscover --maxpeers 0 console  --http --http.api=eth,debug,net,engine,web3
...
Welcome to the Geth JavaScript console!

instance: Geth/v1.10.19-unstable-107e28ac-20220531/linux-amd64/go1.18.1
at block: 0 (Thu Jan 01 1970 01:00:00 GMT+0100 (CET))
 datadir: /tmp/foo
 modules: admin:1.0 debug:1.0 engine:1.0 eth:1.0 ethash:1.0 miner:1.0 net:1.0 personal:1.0 rpc:1.0 txpool:1.0 web3:1.0
```
And connecting to it from remote:
```
> [user@work go-ethereum]$ geth attach http://127.0.0.1:8545
Welcome to the Geth JavaScript console!

instance: Geth/v1.10.19-unstable-107e28ac-20220531/linux-amd64/go1.18.1
at block: 0 (Thu Jan 01 1970 01:00:00 GMT+0100 (CET))
 modules: debug:1.0 eth:1.0 net:1.0 rpc:1.0 web3:1.0

To exit, press ctrl-d or type exit
> [user@work go-ethereum]$ geth --datadir /tmp/foo attach
Welcome to the Geth JavaScript console!

instance: Geth/v1.10.19-unstable-107e28ac-20220531/linux-amd64/go1.18.1
at block: 0 (Thu Jan 01 1970 01:00:00 GMT+0100 (CET))
 datadir: /tmp/foo
 modules: admin:1.0 debug:1.0 engine:1.0 eth:1.0 ethash:1.0 miner:1.0 net:1.0 personal:1.0 rpc:1.0 txpool:1.0 web3:1.0

To exit, press ctrl-d or type exit
```