### PR TITLE
Jumpdest Analysis: unroll loops in analysis bitmap population

### DIFF
--- a/core/vm/analysis.go
+++ b/core/vm/analysis.go
@@ -81,13 +81,20 @@ func codeBitmapInternal(code, bits bitvec) bitvec {
 		}
 		numbits := op - PUSH1 + 1
 		if numbits >= 8 {
-			for ; numbits >= 16; numbits -= 16 {
+			if numbits >= 16 {
 				bits.set16(pc)
 				pc += 16
+				numbits -= 16
 			}
-			for ; numbits >= 8; numbits -= 8 {
+			if numbits >= 16 {
+				bits.set16(pc)
+				pc += 16
+				numbits -= 16
+			}
+			if numbits >= 8 {
 				bits.set8(pc)
 				pc += 8
+				numbits -= 8
 			}
 		}
 		switch numbits {


### PR DESCRIPTION
Unroll loops in bitvec.setN(): first one can at most run 2 times, second one at most once.

This is continuation of #23500.

This change affect performance either way and has slightly negative impact overall. The only positive effect I can see so far is that it bumps the performance of the worst case by 8%.

Please do your own benchmarks.
```sh
go test -bench JumpdestOpAnalysis ./core/vm -run - -count=13 | tee -a analysis-opt
```


```
name                           old speed      new speed      delta
JumpdestOpAnalysis/PUSH1-8     1.35GB/s ± 0%  1.46GB/s ± 0%   +8.29%  (p=0.000 n=11+11)
JumpdestOpAnalysis/PUSH2-8     1.61GB/s ± 0%  1.44GB/s ± 0%  -10.94%  (p=0.000 n=12+12)
JumpdestOpAnalysis/PUSH3-8     2.17GB/s ± 0%  1.94GB/s ± 0%  -10.72%  (p=0.000 n=11+11)
JumpdestOpAnalysis/PUSH4-8     2.40GB/s ± 0%  2.32GB/s ± 0%   -3.31%  (p=0.000 n=12+13)
JumpdestOpAnalysis/PUSH5-8     3.06GB/s ± 0%  2.56GB/s ± 0%  -16.58%  (p=0.000 n=12+13)
JumpdestOpAnalysis/PUSH6-8     3.16GB/s ± 0%  2.63GB/s ± 0%  -17.02%  (p=0.000 n=12+11)
JumpdestOpAnalysis/PUSH7-8     3.76GB/s ± 2%  3.48GB/s ± 0%   -7.35%  (p=0.000 n=13+11)
JumpdestOpAnalysis/PUSH8-8     3.56GB/s ± 0%  3.91GB/s ± 0%   +9.81%  (p=0.000 n=11+13)
JumpdestOpAnalysis/PUSH9-8     3.60GB/s ± 0%  3.63GB/s ± 0%   +0.93%  (p=0.000 n=12+13)
JumpdestOpAnalysis/PUSH10-8    3.17GB/s ± 0%  2.99GB/s ± 0%   -5.41%  (p=0.000 n=11+12)
JumpdestOpAnalysis/PUSH11-8    3.07GB/s ± 0%  3.72GB/s ± 0%  +21.16%  (p=0.000 n=11+11)
JumpdestOpAnalysis/PUSH12-8    3.30GB/s ± 0%  3.53GB/s ± 0%   +7.04%  (p=0.000 n=13+11)
JumpdestOpAnalysis/PUSH13-8    3.77GB/s ± 0%  3.77GB/s ± 0%     ~     (p=0.920 n=13+13)
JumpdestOpAnalysis/PUSH14-8    3.73GB/s ± 0%  3.70GB/s ± 0%   -0.70%  (p=0.000 n=13+11)
JumpdestOpAnalysis/PUSH15-8    3.65GB/s ± 0%  3.86GB/s ± 0%   +5.84%  (p=0.000 n=12+12)
JumpdestOpAnalysis/PUSH16-8    6.11GB/s ± 0%  5.65GB/s ± 0%   -7.47%  (p=0.000 n=11+11)
JumpdestOpAnalysis/PUSH17-8    5.98GB/s ± 0%  5.97GB/s ± 0%   -0.10%  (p=0.025 n=12+13)
JumpdestOpAnalysis/PUSH18-8    5.10GB/s ± 0%  4.81GB/s ± 0%   -5.70%  (p=0.000 n=13+12)
JumpdestOpAnalysis/PUSH19-8    4.81GB/s ± 0%  4.81GB/s ± 0%     ~     (p=0.761 n=11+11)
JumpdestOpAnalysis/PUSH20-8    5.00GB/s ± 0%  5.23GB/s ± 0%   +4.55%  (p=0.000 n=13+11)
JumpdestOpAnalysis/PUSH21-8    5.52GB/s ± 0%  5.24GB/s ± 0%   -4.99%  (p=0.000 n=13+13)
JumpdestOpAnalysis/PUSH22-8    5.39GB/s ± 0%  5.07GB/s ± 0%   -5.87%  (p=0.000 n=10+11)
JumpdestOpAnalysis/PUSH23-8    5.18GB/s ± 0%  5.19GB/s ± 0%   +0.14%  (p=0.000 n=11+11)
JumpdestOpAnalysis/PUSH24-8    6.00GB/s ± 0%  5.99GB/s ± 0%   -0.05%  (p=0.008 n=12+11)
JumpdestOpAnalysis/PUSH25-8    5.62GB/s ± 0%  6.23GB/s ± 0%  +10.93%  (p=0.000 n=11+12)
JumpdestOpAnalysis/PUSH26-8    5.52GB/s ± 0%  5.52GB/s ± 0%   +0.10%  (p=0.001 n=12+11)
JumpdestOpAnalysis/PUSH27-8    5.27GB/s ± 0%  5.50GB/s ± 0%   +4.48%  (p=0.000 n=12+11)
JumpdestOpAnalysis/PUSH28-8    5.39GB/s ± 0%  5.86GB/s ± 0%   +8.61%  (p=0.000 n=11+11)
JumpdestOpAnalysis/PUSH29-8    5.84GB/s ± 0%  5.85GB/s ± 0%   +0.21%  (p=0.002 n=12+13)
JumpdestOpAnalysis/PUSH30-8    5.70GB/s ± 0%  5.67GB/s ± 0%   -0.54%  (p=0.000 n=13+11)
JumpdestOpAnalysis/PUSH31-8    5.52GB/s ± 0%  5.76GB/s ± 0%   +4.28%  (p=0.000 n=12+11)
JumpdestOpAnalysis/PUSH32-8    7.46GB/s ± 0%  7.46GB/s ± 0%     ~     (p=0.151 n=12+11)
JumpdestOpAnalysis/JUMPDEST-8  2.72GB/s ± 0%  2.73GB/s ± 0%   +0.12%  (p=0.000 n=13+11)
JumpdestOpAnalysis/STOP-8      2.73GB/s ± 0%  2.73GB/s ± 0%     ~     (p=0.091 n=12+12)
[Geo mean]                     4.01GB/s       3.99GB/s        -0.60%
```