### PR TITLE
core/state/snapshot: monitor snapshot content/size churn

### DIFF
--- a/core/state/snapshot/metrics.go
+++ b/core/state/snapshot/metrics.go
@@ -18,8 +18,8 @@ package snapshot
 
 import "github.com/ethereum/go-ethereum/metrics"
 
-// Metrics in generation
 var (
+	// Snapshot generation metrics
 	snapGeneratedAccountMeter     = metrics.NewRegisteredMeter("state/snapshot/generation/account/generated", nil)
 	snapRecoveredAccountMeter     = metrics.NewRegisteredMeter("state/snapshot/generation/account/recovered", nil)
 	snapWipedAccountMeter         = metrics.NewRegisteredMeter("state/snapshot/generation/account/wiped", nil)
@@ -32,22 +32,62 @@ var (
 	snapSuccessfulRangeProofMeter = metrics.NewRegisteredMeter("state/snapshot/generation/proof/success", nil)
 	snapFailedRangeProofMeter     = metrics.NewRegisteredMeter("state/snapshot/generation/proof/failure", nil)
 
-	// snapAccountProveCounter measures time spent on the account proving
-	snapAccountProveCounter = metrics.NewRegisteredCounter("state/snapshot/generation/duration/account/prove", nil)
-	// snapAccountTrieReadCounter measures time spent on the account trie iteration
+	snapAccountProveCounter    = metrics.NewRegisteredCounter("state/snapshot/generation/duration/account/prove", nil)
 	snapAccountTrieReadCounter = metrics.NewRegisteredCounter("state/snapshot/generation/duration/account/trieread", nil)
-	// snapAccountSnapReadCounter measures time spent on the snapshot account iteration
 	snapAccountSnapReadCounter = metrics.NewRegisteredCounter("state/snapshot/generation/duration/account/snapread", nil)
-	// snapAccountWriteCounter measures time spent on writing/updating/deleting accounts
-	snapAccountWriteCounter = metrics.NewRegisteredCounter("state/snapshot/generation/duration/account/write", nil)
-	// snapStorageProveCounter measures time spent on storage proving
-	snapStorageProveCounter = metrics.NewRegisteredCounter("state/snapshot/generation/duration/storage/prove", nil)
-	// snapStorageTrieReadCounter measures time spent on the storage trie iteration
+	snapAccountWriteCounter    = metrics.NewRegisteredCounter("state/snapshot/generation/duration/account/write", nil)
+	snapStorageProveCounter    = metrics.NewRegisteredCounter("state/snapshot/generation/duration/storage/prove", nil)
 	snapStorageTrieReadCounter = metrics.NewRegisteredCounter("state/snapshot/generation/duration/storage/trieread", nil)
-	// snapStorageSnapReadCounter measures time spent on the snapshot storage iteration
 	snapStorageSnapReadCounter = metrics.NewRegisteredCounter("state/snapshot/generation/duration/storage/snapread", nil)
-	// snapStorageWriteCounter measures time spent on writing/updating storages
-	snapStorageWriteCounter = metrics.NewRegisteredCounter("state/snapshot/generation/duration/storage/write", nil)
-	// snapStorageCleanCounter measures time spent on deleting storages
-	snapStorageCleanCounter = metrics.NewRegisteredCounter("state/snapshot/generation/duration/storage/clean", nil)
+	snapStorageWriteCounter    = metrics.NewRegisteredCounter("state/snapshot/generation/duration/storage/write", nil)
+	snapStorageCleanCounter    = metrics.NewRegisteredCounter("state/snapshot/generation/duration/storage/clean", nil)
+
+	// Snapshot operational metrics
+	snapshotCleanAccountHitMeter   = metrics.NewRegisteredMeter("state/snapshot/clean/account/hit", nil)
+	snapshotCleanAccountMissMeter  = metrics.NewRegisteredMeter("state/snapshot/clean/account/miss", nil)
+	snapshotCleanAccountInexMeter  = metrics.NewRegisteredMeter("state/snapshot/clean/account/inex", nil)
+	snapshotCleanAccountReadMeter  = metrics.NewRegisteredMeter("state/snapshot/clean/account/read", nil)
+	snapshotCleanAccountWriteMeter = metrics.NewRegisteredMeter("state/snapshot/clean/account/write", nil)
+
+	snapshotCleanStorageHitMeter   = metrics.NewRegisteredMeter("state/snapshot/clean/storage/hit", nil)
+	snapshotCleanStorageMissMeter  = metrics.NewRegisteredMeter("state/snapshot/clean/storage/miss", nil)
+	snapshotCleanStorageInexMeter  = metrics.NewRegisteredMeter("state/snapshot/clean/storage/inex", nil)
+	snapshotCleanStorageReadMeter  = metrics.NewRegisteredMeter("state/snapshot/clean/storage/read", nil)
+	snapshotCleanStorageWriteMeter = metrics.NewRegisteredMeter("state/snapshot/clean/storage/write", nil)
+
+	snapshotDirtyAccountHitMeter   = metrics.NewRegisteredMeter("state/snapshot/dirty/account/hit", nil)
+	snapshotDirtyAccountMissMeter  = metrics.NewRegisteredMeter("state/snapshot/dirty/account/miss", nil)
+	snapshotDirtyAccountInexMeter  = metrics.NewRegisteredMeter("state/snapshot/dirty/account/inex", nil)
+	snapshotDirtyAccountReadMeter  = metrics.NewRegisteredMeter("state/snapshot/dirty/account/read", nil)
+	snapshotDirtyAccountWriteMeter = metrics.NewRegisteredMeter("state/snapshot/dirty/account/write", nil)
+
+	snapshotDirtyStorageHitMeter   = metrics.NewRegisteredMeter("state/snapshot/dirty/storage/hit", nil)
+	snapshotDirtyStorageMissMeter  = metrics.NewRegisteredMeter("state/snapshot/dirty/storage/miss", nil)
+	snapshotDirtyStorageInexMeter  = metrics.NewRegisteredMeter("state/snapshot/dirty/storage/inex", nil)
+	snapshotDirtyStorageReadMeter  = metrics.NewRegisteredMeter("state/snapshot/dirty/storage/read", nil)
+	snapshotDirtyStorageWriteMeter = metrics.NewRegisteredMeter("state/snapshot/dirty/storage/write", nil)
+
+	snapshotDirtyAccountHitDepthHist = metrics.NewRegisteredHistogram("state/snapshot/dirty/account/hit/depth", nil, metrics.NewExpDecaySample(1028, 0.015))
+	snapshotDirtyStorageHitDepthHist = metrics.NewRegisteredHistogram("state/snapshot/dirty/storage/hit/depth", nil, metrics.NewExpDecaySample(1028, 0.015))
+
+	snapshotFlushAccountItemMeter = metrics.NewRegisteredMeter("state/snapshot/flush/account/item", nil)
+	snapshotFlushAccountSizeMeter = metrics.NewRegisteredMeter("state/snapshot/flush/account/size", nil)
+	snapshotFlushStorageItemMeter = metrics.NewRegisteredMeter("state/snapshot/flush/storage/item", nil)
+	snapshotFlushStorageSizeMeter = metrics.NewRegisteredMeter("state/snapshot/flush/storage/size", nil)
+
+	snapshotBloomIndexTimer = metrics.NewRegisteredResettingTimer("state/snapshot/bloom/index", nil)
+	snapshotBloomErrorGauge = metrics.NewRegisteredGaugeFloat64("state/snapshot/bloom/error", nil)
+
+	snapshotBloomAccountTrueHitMeter  = metrics.NewRegisteredMeter("state/snapshot/bloom/account/truehit", nil)
+	snapshotBloomAccountFalseHitMeter = metrics.NewRegisteredMeter("state/snapshot/bloom/account/falsehit", nil)
+	snapshotBloomAccountMissMeter     = metrics.NewRegisteredMeter("state/snapshot/bloom/account/miss", nil)
+
+	snapshotBloomStorageTrueHitMeter  = metrics.NewRegisteredMeter("state/snapshot/bloom/storage/truehit", nil)
+	snapshotBloomStorageFalseHitMeter = metrics.NewRegisteredMeter("state/snapshot/bloom/storage/falsehit", nil)
+	snapshotBloomStorageMissMeter     = metrics.NewRegisteredMeter("state/snapshot/bloom/storage/miss", nil)
+
+	snapshotAccountCountGrowthMeter = metrics.NewRegisteredMeter("state/snapshot/growth/account/count", nil)
+	snapshotAccountBytesGrowthMeter = metrics.NewRegisteredMeter("state/snapshot/growth/account/bytes", nil)
+	snapshotStorageCountGrowthMeter = metrics.NewRegisteredMeter("state/snapshot/growth/storage/count", nil)
+	snapshotStorageBytesGrowthMeter = metrics.NewRegisteredMeter("state/snapshot/growth/storage/bytes", nil)
 )

--- a/core/state/snapshot/snapshot.go
+++ b/core/state/snapshot/snapshot.go
@@ -598,8 +598,6 @@ func diffToDisk(bottom *diffLayer) *diskLayer {
 					} else {
 						snapshotStorageBytesGrowthMeter.Mark(int64(len(data) - oldbytes))
 					}
-					snapshotFlushStorageItemMeter.Mark(1)
-					snapshotFlushStorageSizeMeter.Mark(2*common.HashLength + int64(len(data)))
 				}
 			} else {
 				rawdb.DeleteStorageSnapshot(batch, accountHash, storageHash)
@@ -609,8 +607,9 @@ func diffToDisk(bottom *diffLayer) *diskLayer {
 					snapshotStorageCountGrowthMeter.Mark(-1)
 					snapshotStorageBytesGrowthMeter.Mark(-int64(2*common.HashLength + len(rawdb.ReadStorageSnapshot(base.diskdb, accountHash, storageHash))))
 				}
-				snapshotFlushStorageItemMeter.Mark(1)
 			}
+			snapshotFlushStorageItemMeter.Mark(1)
+			snapshotFlushStorageSizeMeter.Mark(2*common.HashLength + int64(len(data)))
 		}
 	}
 	// Update the snapshot block marker and write any remainder data

--- a/core/state/snapshot/snapshot.go
+++ b/core/state/snapshot/snapshot.go
@@ -34,49 +34,6 @@ import (
 )
 
 var (
-	snapshotCleanAccountHitMeter   = metrics.NewRegisteredMeter("state/snapshot/clean/account/hit", nil)
-	snapshotCleanAccountMissMeter  = metrics.NewRegisteredMeter("state/snapshot/clean/account/miss", nil)
-	snapshotCleanAccountInexMeter  = metrics.NewRegisteredMeter("state/snapshot/clean/account/inex", nil)
-	snapshotCleanAccountReadMeter  = metrics.NewRegisteredMeter("state/snapshot/clean/account/read", nil)
-	snapshotCleanAccountWriteMeter = metrics.NewRegisteredMeter("state/snapshot/clean/account/write", nil)
-
-	snapshotCleanStorageHitMeter   = metrics.NewRegisteredMeter("state/snapshot/clean/storage/hit", nil)
-	snapshotCleanStorageMissMeter  = metrics.NewRegisteredMeter("state/snapshot/clean/storage/miss", nil)
-	snapshotCleanStorageInexMeter  = metrics.NewRegisteredMeter("state/snapshot/clean/storage/inex", nil)
-	snapshotCleanStorageReadMeter  = metrics.NewRegisteredMeter("state/snapshot/clean/storage/read", nil)
-	snapshotCleanStorageWriteMeter = metrics.NewRegisteredMeter("state/snapshot/clean/storage/write", nil)
-
-	snapshotDirtyAccountHitMeter   = metrics.NewRegisteredMeter("state/snapshot/dirty/account/hit", nil)
-	snapshotDirtyAccountMissMeter  = metrics.NewRegisteredMeter("state/snapshot/dirty/account/miss", nil)
-	snapshotDirtyAccountInexMeter  = metrics.NewRegisteredMeter("state/snapshot/dirty/account/inex", nil)
-	snapshotDirtyAccountReadMeter  = metrics.NewRegisteredMeter("state/snapshot/dirty/account/read", nil)
-	snapshotDirtyAccountWriteMeter = metrics.NewRegisteredMeter("state/snapshot/dirty/account/write", nil)
-
-	snapshotDirtyStorageHitMeter   = metrics.NewRegisteredMeter("state/snapshot/dirty/storage/hit", nil)
-	snapshotDirtyStorageMissMeter  = metrics.NewRegisteredMeter("state/snapshot/dirty/storage/miss", nil)
-	snapshotDirtyStorageInexMeter  = metrics.NewRegisteredMeter("state/snapshot/dirty/storage/inex", nil)
-	snapshotDirtyStorageReadMeter  = metrics.NewRegisteredMeter("state/snapshot/dirty/storage/read", nil)
-	snapshotDirtyStorageWriteMeter = metrics.NewRegisteredMeter("state/snapshot/dirty/storage/write", nil)
-
-	snapshotDirtyAccountHitDepthHist = metrics.NewRegisteredHistogram("state/snapshot/dirty/account/hit/depth", nil, metrics.NewExpDecaySample(1028, 0.015))
-	snapshotDirtyStorageHitDepthHist = metrics.NewRegisteredHistogram("state/snapshot/dirty/storage/hit/depth", nil, metrics.NewExpDecaySample(1028, 0.015))
-
-	snapshotFlushAccountItemMeter = metrics.NewRegisteredMeter("state/snapshot/flush/account/item", nil)
-	snapshotFlushAccountSizeMeter = metrics.NewRegisteredMeter("state/snapshot/flush/account/size", nil)
-	snapshotFlushStorageItemMeter = metrics.NewRegisteredMeter("state/snapshot/flush/storage/item", nil)
-	snapshotFlushStorageSizeMeter = metrics.NewRegisteredMeter("state/snapshot/flush/storage/size", nil)
-
-	snapshotBloomIndexTimer = metrics.NewRegisteredResettingTimer("state/snapshot/bloom/index", nil)
-	snapshotBloomErrorGauge = metrics.NewRegisteredGaugeFloat64("state/snapshot/bloom/error", nil)
-
-	snapshotBloomAccountTrueHitMeter  = metrics.NewRegisteredMeter("state/snapshot/bloom/account/truehit", nil)
-	snapshotBloomAccountFalseHitMeter = metrics.NewRegisteredMeter("state/snapshot/bloom/account/falsehit", nil)
-	snapshotBloomAccountMissMeter     = metrics.NewRegisteredMeter("state/snapshot/bloom/account/miss", nil)
-
-	snapshotBloomStorageTrueHitMeter  = metrics.NewRegisteredMeter("state/snapshot/bloom/storage/truehit", nil)
-	snapshotBloomStorageFalseHitMeter = metrics.NewRegisteredMeter("state/snapshot/bloom/storage/falsehit", nil)
-	snapshotBloomStorageMissMeter     = metrics.NewRegisteredMeter("state/snapshot/bloom/storage/miss", nil)
-
 	// ErrSnapshotStale is returned from data accessors if the underlying snapshot
 	// layer had been invalidated due to the chain progressing forward far enough
 	// to not maintain the layer's original state.
@@ -554,13 +511,22 @@ func diffToDisk(bottom *diffLayer) *diskLayer {
 		rawdb.DeleteAccountSnapshot(batch, hash)
 		base.cache.Set(hash[:], nil)
 
+		snapshotFlushAccountItemMeter.Mark(1)
+		if metrics.EnabledExpensive {
+			snapshotAccountCountGrowthMeter.Mark(-1)
+			snapshotAccountBytesGrowthMeter.Mark(-int64(common.HashLength + len(rawdb.ReadAccountSnapshot(base.diskdb, hash))))
+		}
 		it := rawdb.IterateStorageSnapshots(base.diskdb, hash)
 		for it.Next() {
 			key := it.Key()
 			batch.Delete(key)
 			base.cache.Del(key[1:])
-			snapshotFlushStorageItemMeter.Mark(1)
 
+			snapshotFlushStorageItemMeter.Mark(1)
+			if metrics.EnabledExpensive {
+				snapshotStorageCountGrowthMeter.Mark(-1)
+				snapshotStorageBytesGrowthMeter.Mark(-int64(2*common.HashLength + len(it.Value())))
+			}
 			// Ensure we don't delete too much data blindly (contract can be
 			// huge). It's ok to flush, the root will go missing in case of a
 			// crash and we'll detect and regenerate the snapshot.
@@ -582,11 +548,18 @@ func diffToDisk(bottom *diffLayer) *diskLayer {
 		// Push the account to disk
 		rawdb.WriteAccountSnapshot(batch, hash, data)
 		base.cache.Set(hash[:], data)
-		snapshotCleanAccountWriteMeter.Mark(int64(len(data)))
 
+		snapshotCleanAccountWriteMeter.Mark(int64(len(data)))
 		snapshotFlushAccountItemMeter.Mark(1)
 		snapshotFlushAccountSizeMeter.Mark(int64(len(data)))
-
+		if metrics.EnabledExpensive {
+			if oldbytes := len(rawdb.ReadAccountSnapshot(base.diskdb, hash)); oldbytes == 0 {
+				snapshotAccountCountGrowthMeter.Mark(1)
+				snapshotAccountBytesGrowthMeter.Mark(common.HashLength + int64(len(data)))
+			} else {
+				snapshotAccountBytesGrowthMeter.Mark(int64(len(data) - oldbytes))
+			}
+		}
 		// Ensure we don't write too much data blindly. It's ok to flush, the
 		// root will go missing in case of a crash and we'll detect and regen
 		// the snapshot.
@@ -614,10 +587,22 @@ func diffToDisk(bottom *diffLayer) *diskLayer {
 			if len(data) > 0 {
 				rawdb.WriteStorageSnapshot(batch, accountHash, storageHash, data)
 				base.cache.Set(append(accountHash[:], storageHash[:]...), data)
+
 				snapshotCleanStorageWriteMeter.Mark(int64(len(data)))
+				if metrics.EnabledExpensive {
+					if oldbytes := len(rawdb.ReadStorageSnapshot(base.diskdb, accountHash, storageHash)); oldbytes == 0 {
+						snapshotStorageCountGrowthMeter.Mark(1)
+						snapshotStorageBytesGrowthMeter.Mark(2*common.HashLength + int64(len(data)))
+					} else {
+						snapshotStorageBytesGrowthMeter.Mark(int64(len(data) - oldbytes))
+					}
+				}
 			} else {
 				rawdb.DeleteStorageSnapshot(batch, accountHash, storageHash)
 				base.cache.Set(append(accountHash[:], storageHash[:]...), nil)
+
+				snapshotStorageCountGrowthMeter.Mark(-1)
+				snapshotStorageBytesGrowthMeter.Mark(-int64(2*common.HashLength + len(rawdb.ReadStorageSnapshot(base.diskdb, accountHash, storageHash))))
 			}
 			snapshotFlushStorageItemMeter.Mark(1)
 			snapshotFlushStorageSizeMeter.Mark(int64(len(data)))


### PR DESCRIPTION
This PR fixes a couple of issues with snapshot flush monitoring; and adds 4 metrics to monitor the item and byte count churn. Monitoring the churn requires reading the snapshot's old value from disk before pushing a new one on top, so jury's still out how expensive this is. We should do some sync benchmark to see (I've placed it behind the expensiv emetrics flag). Still, I'm curious what the churn rate is and this should help us understand better. The charts have been added to the Single Geth page.