### PR TITLE
trie: move locking into trieDB insert method

### DIFF
--- a/trie/committer.go
+++ b/trie/committer.go
@@ -193,9 +193,7 @@ func (c *committer) store(n node, db *Database) node {
 	} else if db != nil {
 		// No leaf-callback used, but there's still a database. Do serial
 		// insertion
-		db.lock.Lock()
 		db.insert(common.BytesToHash(hash), size, n)
-		db.lock.Unlock()
 	}
 	return hash
 }
@@ -209,9 +207,7 @@ func (c *committer) commitLoop(db *Database) {
 			n    = item.node
 		)
 		// We are pooling the trie nodes into an intermediate memory cache
-		db.lock.Lock()
 		db.insert(hash, size, n)
-		db.lock.Unlock()
 
 		if c.onleaf != nil {
 			switch n := n.(type) {

--- a/trie/database.go
+++ b/trie/database.go
@@ -310,6 +310,9 @@ func (db *Database) DiskDB() ethdb.KeyValueStore {
 // All nodes inserted by this function will be reference tracked
 // and in theory should only used for **trie nodes** insertion.
 func (db *Database) insert(hash common.Hash, size int, node node) {
+	db.lock.Lock()
+	defer db.lock.Unlock()
+
 	// If the node's already cached, skip
 	if _, ok := db.dirties[hash]; ok {
 		return


### PR DESCRIPTION
This PR moves grabbing and releasing the lock on inserting a node into the trie DB into the trie DB `insert` function, since currently the lock is grabbed externally to the function and then released immediately after the function is called everywhere that it gets called.