### PR TITLE
Fix ReceiptForStorage comment

### DIFF
--- a/core/types/receipt.go
+++ b/core/types/receipt.go
@@ -267,8 +267,8 @@ func (r *Receipt) Size() common.StorageSize {
 	return size
 }
 
-// ReceiptForStorage is a wrapper around a Receipt that flattens and parses the
-// entire content of a receipt, as opposed to only the consensus fields originally.
+// ReceiptForStorage is a wrapper around a Receipt with RLP serialization that omits the Bloom 
+// field and deserialization that re-computes it.
 type ReceiptForStorage Receipt
 
 // EncodeRLP implements rlp.Encoder, and flattens all content fields of a receipt


### PR DESCRIPTION
The comment was stale and contradicted the current implementation.