### PR TITLE
p2p/discover: fix panicky test

### DIFF
--- a/p2p/discover/v4_udp_test.go
+++ b/p2p/discover/v4_udp_test.go
@@ -284,6 +284,7 @@ func TestUDPv4_findnode(t *testing.T) {
 		test.waitPacketOut(func(p *v4wire.Neighbors, to *net.UDPAddr, hash []byte) {
 			if len(p.Nodes) != len(want) {
 				t.Errorf("wrong number of results: got %d, want %d", len(p.Nodes), bucketSize)
+				return
 			}
 			for i, n := range p.Nodes {
 				if n.ID.ID() != want[i].ID() {


### PR DESCRIPTION
This PR fixes a bug which was hit on appveyor. First we find an error, then the test itself panics. 

https://ci.appveyor.com/project/ethereum/go-ethereum/builds/43778141/job/bwxn7g0m3gqkb1b9

```
--- FAIL: TestUDPv4_findnode (4.04s)
    v4_udp.go:554: TRACE[06-07|06:42:24.039] << FINDNODE/v4                           id=86b26dcca98de10d addr=10.0.1.99:30303 err=nil
    v4_udp.go:509: TRACE[06-07|06:42:24.040] >> PING/v4                               id=64edc8796c90ce3c addr=10.13.0.8:2000  err=nil
    v4_udp.go:509: TRACE[06-07|06:42:24.041] >> NEIGHBORS/v4                          id=86b26dcca98de10d addr=10.0.1.99:30303 err=nil
    v4_udp.go:509: TRACE[06-07|06:42:24.041] >> NEIGHBORS/v4                          id=86b26dcca98de10d addr=10.0.1.99:30303 err=nil
    v4_udp_test.go:284: sent packet type mismatch, got: *v4wire.Ping, want: *v4wire.Neighbors
    v4_udp_test.go:286: wrong number of results: got 12, want 16
    v4_udp_test.go:290: result mismatch at 0:
          got:  {10.13.0.30 2000 0 [168 170 118 37 114 214 45 17 227 234 37 92 2 13 65 82 65 242 131 97 214 158 146 131 127 2 228 250 167 6 42 81 14 126 13 179 185 5 8 103 146 9 13 14 12 128 234 182 224 162 223 29 211 98 39 103 179 121 193 104 118 138 206 37]}
          want: enode://a8aa762572d62d11e3ea255c020d415241f28361d69e92837f02e4faa7062a510e7e0db3b905086792090d0e0c80eab6e0a2df1dd3622767b379c168768ace25@10.13.0.30:0?discport=2000
    v4_udp_test.go:290: result mismatch at 1:
          got:  {10.13.0.21 2000 0 [213 54 31 76 56 19 147 49 220 196 199 248 84 19 43 240 57 84 33 88 127 210 244 40 33 209 170 105 208 108 101 89 177 244 44 58 73 14 76 26 70 246 130 67 6 77 126 174 251 128 181 24 200 179 115 17 237 110 20 84 65 95 2 206]}
          want: enode://d5361f4c38139331dcc4c7f854132bf0395421587fd2f42821d1aa69d06c6559b1f42c3a490e4c1a46f68243064d7eaefb80b518c8b37311ed6e1454415f02ce@10.13.0.21:0?discport=2000
    table.go:351: DEBUG[06-07|06:42:24.042] Replaced dead node                       b=16 id=64edc8796c90ce3c ip=10.13.0.8 checks=0 r=64f9477bd15e487e rip=10.13.0.27
panic: runtime error: index out of range [2] with length 2 [recovered]
	panic: runtime error: index out of range [2] with length 2
goroutine 1495 [running]:
testing.tRunner.func1.2({0x58ce60, 0x11f2a680})
	C:/Users/appveyor/AppData/Local/geth-go-1.18.1-windows-amd64/go/src/testing/testing.go:1389 +0x2ab
testing.tRunner.func1()
	C:/Users/appveyor/AppData/Local/geth-go-1.18.1-windows-amd64/go/src/testing/testing.go:1392 +0x41f
panic({0x58ce60, 0x11f2a680})
	C:/Users/appveyor/AppData/Local/geth-go-1.18.1-windows-amd64/go/src/runtime/panic.go:838 +0x1ba
github.com/ethereum/go-ethereum/p2p/discover.TestUDPv4_findnode.func1.1(0x11c9c740, 0x11e075f0, {0x11c7a900, 0x20, 0x82a})
	C:/projects/go-ethereum/p2p/discover/v4_udp_test.go:289 +0x5d4
reflect.Value.call({0x569aa0, 0x11c9c700, 0x13}, {0x5a3af2, 0x4}, {0x11d77d04, 0x3, 0x3})
	C:/Users/appveyor/AppData/Local/geth-go-1.18.1-windows-amd64/go/src/reflect/value.go:556 +0x652
reflect.Value.Call({0x569aa0, 0x11c9c700, 0x13}, {0x11d77d04, 0x3, 0x3})
	C:/Users/appveyor/AppData/Local/geth-go-1.18.1-windows-amd64/go/src/reflect/value.go:339 +0x82
github.com/ethereum/go-ethereum/p2p/discover.(*udpTest).waitPacketOut(0x11e06660, {0x569aa0, 0x11c9c700})
	C:/projects/go-ethereum/p2p/discover/v4_udp_test.go:131 +0x6dd
github.com/ethereum/go-ethereum/p2p/discover.TestUDPv4_findnode.func1({0x12010cf0, 0x2, 0x4})
	C:/projects/go-ethereum/p2p/discover/v4_udp_test.go:284 +0xd3
github.com/ethereum/go-ethereum/p2p/discover.TestUDPv4_findnode(0x11c703c0)
	C:/projects/go-ethereum/p2p/discover/v4_udp_test.go:304 +0x6a4
testing.tRunner(0x11c703c0, 0x5b79d8)
	C:/Users/appveyor/AppData/Local/geth-go-1.18.1-windows-amd64/go/src/testing/testing.go:1439 +0x113
created by testing.(*T).Run
	C:/Users/appveyor/AppData/Local/geth-go-1.18.1-windows-amd64/go/src/testing/testing.go:1486 +0x374
```
