### PR TITLE
rpc: swap out timer metrics to histograms

### DIFF
--- a/rpc/handler.go
+++ b/rpc/handler.go
@@ -346,7 +346,7 @@ func (h *handler) handleCall(cp *callProc, msg *jsonrpcMessage) *jsonrpcMessage 
 			successfulRequestGauge.Inc(1)
 		}
 		rpcServingTimer.UpdateSince(start)
-		newRPCServingTimer(msg.Method, answer.Error == nil).UpdateSince(start)
+		updateServeTimeHistogram(msg.Method, answer.Error == nil, time.Since(start))
 	}
 	return answer
 }

--- a/rpc/metrics.go
+++ b/rpc/metrics.go
@@ -18,6 +18,7 @@ package rpc
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/ethereum/go-ethereum/metrics"
 )
@@ -26,14 +27,24 @@ var (
 	rpcRequestGauge        = metrics.NewRegisteredGauge("rpc/requests", nil)
 	successfulRequestGauge = metrics.NewRegisteredGauge("rpc/success", nil)
 	failedRequestGauge     = metrics.NewRegisteredGauge("rpc/failure", nil)
-	rpcServingTimer        = metrics.NewRegisteredTimer("rpc/duration/all", nil)
+
+	// serveTimeHistName is the prefix of the per-request serving time histograms.
+	serveTimeHistName = "rpc/duration"
+
+	rpcServingTimer = metrics.NewRegisteredTimer("rpc/duration/all", nil)
 )
 
-func newRPCServingTimer(method string, valid bool) metrics.Timer {
-	flag := "success"
-	if !valid {
-		flag = "failure"
+// updateServeTimeHistogram tracks the serving time of a remote RPC call.
+func updateServeTimeHistogram(method string, success bool, elapsed time.Duration) {
+	note := "success"
+	if !success {
+		note = "failure"
 	}
-	m := fmt.Sprintf("rpc/duration/%s/%s", method, flag)
-	return metrics.GetOrRegisterTimer(m, nil)
+	h := fmt.Sprintf("%s/%s/%s", serveTimeHistName, method, note)
+	sampler := func() metrics.Sample {
+		return metrics.ResettingSample(
+			metrics.NewExpDecaySample(1028, 0.015),
+		)
+	}
+	metrics.GetOrRegisterHistogramLazy(h, nil, sampler).Update(elapsed.Microseconds())
 }


### PR DESCRIPTION
A while back we've added metrics to measure RPC serving times, but we used timers, which are not that useful since it's too 1 dimensional. This PR changes the timers to histograms, which allows us to have 2D heatmap plots: frequesncy of requests over time, groupped by serving times.