### PR TITLE
Remove the outdated link

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -15,6 +15,8 @@ For the Go API reference and developer documentation head over to
 
 ### Other Ethereum Documentation
 
+For generic Ethereum-related information, check the [introduction](https://ethereum.org/en/developers/docs/intro-to-ethereum/) at ethereum.org.
+
 * [Ethereum Whitepaper](https://github.com/ethereum/wiki/wiki/White-Paper)
 * [Ethereum Yellow Paper](https://ethereum.github.io/yellowpaper/paper.pdf)
 * [Ethereum Improvement Proposals (EIPs)](https://eips.ethereum.org)

--- a/docs/index.md
+++ b/docs/index.md
@@ -15,9 +15,6 @@ For the Go API reference and developer documentation head over to
 
 ### Other Ethereum Documentation
 
-For generic Ethereum-related information, check the **[Ethereum
-Wiki](https://github.com/ethereum/wiki/wiki)**.
-
 * [Ethereum Whitepaper](https://github.com/ethereum/wiki/wiki/White-Paper)
 * [Ethereum Yellow Paper](https://ethereum.github.io/yellowpaper/paper.pdf)
 * [Ethereum Improvement Proposals (EIPs)](https://eips.ethereum.org)


### PR DESCRIPTION
The link directs to an outdated page, the knowledge in ethereum community spreads everywhere, it's good to clean them up and save our developers from the thousands of pieces of documents