### PR TITLE
all: remove `public` field from `rpc.API`

### DIFF
--- a/cmd/clef/main.go
+++ b/cmd/clef/main.go
@@ -647,7 +647,6 @@ func signer(c *cli.Context) error {
 	rpcAPI := []rpc.API{
 		{
 			Namespace: "account",
-			Public:    true,
 			Service:   api,
 			Version:   "1.0"},
 	}
@@ -656,7 +655,7 @@ func signer(c *cli.Context) error {
 		cors := utils.SplitAndTrim(c.GlobalString(utils.HTTPCORSDomainFlag.Name))
 
 		srv := rpc.NewServer()
-		err := node.RegisterApis(rpcAPI, []string{"account"}, srv, false)
+		err := node.RegisterApis(rpcAPI, []string{"account"}, srv)
 		if err != nil {
 			utils.Fatalf("Could not register API: %w", err)
 		}

--- a/consensus/clique/clique.go
+++ b/consensus/clique/clique.go
@@ -699,7 +699,6 @@ func (c *Clique) APIs(chain consensus.ChainHeaderReader) []rpc.API {
 		Namespace: "clique",
 		Version:   "1.0",
 		Service:   &API{chain: chain, clique: c},
-		Public:    false,
 	}}
 }
 

--- a/consensus/ethash/ethash.go
+++ b/consensus/ethash/ethash.go
@@ -680,13 +680,11 @@ func (ethash *Ethash) APIs(chain consensus.ChainHeaderReader) []rpc.API {
 			Namespace: "eth",
 			Version:   "1.0",
 			Service:   &API{ethash},
-			Public:    true,
 		},
 		{
 			Namespace: "ethash",
 			Version:   "1.0",
 			Service:   &API{ethash},
-			Public:    true,
 		},
 	}
 }

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -310,22 +310,18 @@ func (s *Ethereum) APIs() []rpc.API {
 			Namespace: "eth",
 			Version:   "1.0",
 			Service:   NewEthereumAPI(s),
-			Public:    true,
 		}, {
 			Namespace: "miner",
 			Version:   "1.0",
 			Service:   NewMinerAPI(s),
-			Public:    true,
 		}, {
 			Namespace: "eth",
 			Version:   "1.0",
 			Service:   downloader.NewDownloaderAPI(s.handler.downloader, s.eventMux),
-			Public:    true,
 		}, {
 			Namespace: "eth",
 			Version:   "1.0",
 			Service:   filters.NewFilterAPI(s.APIBackend, false, 5*time.Minute),
-			Public:    true,
 		}, {
 			Namespace: "admin",
 			Version:   "1.0",
@@ -334,12 +330,10 @@ func (s *Ethereum) APIs() []rpc.API {
 			Namespace: "debug",
 			Version:   "1.0",
 			Service:   NewDebugAPI(s),
-			Public:    true,
 		}, {
 			Namespace: "net",
 			Version:   "1.0",
 			Service:   s.netRPCService,
-			Public:    true,
 		},
 	}...)
 }

--- a/eth/catalyst/api.go
+++ b/eth/catalyst/api.go
@@ -44,7 +44,6 @@ func Register(stack *node.Node, backend *eth.Ethereum) error {
 			Namespace:     "engine",
 			Version:       "1.0",
 			Service:       NewConsensusAPI(backend),
-			Public:        true,
 			Authenticated: true,
 		},
 	})

--- a/eth/tracers/api.go
+++ b/eth/tracers/api.go
@@ -920,7 +920,6 @@ func APIs(backend Backend) []rpc.API {
 			Namespace: "debug",
 			Version:   "1.0",
 			Service:   NewAPI(backend),
-			Public:    false,
 		},
 	}
 }

--- a/internal/ethapi/backend.go
+++ b/internal/ethapi/backend.go
@@ -103,37 +103,30 @@ func GetAPIs(apiBackend Backend) []rpc.API {
 			Namespace: "eth",
 			Version:   "1.0",
 			Service:   NewEthereumAPI(apiBackend),
-			Public:    true,
 		}, {
 			Namespace: "eth",
 			Version:   "1.0",
 			Service:   NewBlockChainAPI(apiBackend),
-			Public:    true,
 		}, {
 			Namespace: "eth",
 			Version:   "1.0",
 			Service:   NewTransactionAPI(apiBackend, nonceLock),
-			Public:    true,
 		}, {
 			Namespace: "txpool",
 			Version:   "1.0",
 			Service:   NewTxPoolAPI(apiBackend),
-			Public:    true,
 		}, {
 			Namespace: "debug",
 			Version:   "1.0",
 			Service:   NewDebugAPI(apiBackend),
-			Public:    true,
 		}, {
 			Namespace: "eth",
 			Version:   "1.0",
 			Service:   NewEthereumAccountAPI(apiBackend.AccountManager()),
-			Public:    true,
 		}, {
 			Namespace: "personal",
 			Version:   "1.0",
 			Service:   NewPersonalAccountAPI(apiBackend, nonceLock),
-			Public:    false,
 		},
 	}
 }

--- a/les/catalyst/api.go
+++ b/les/catalyst/api.go
@@ -37,7 +37,6 @@ func Register(stack *node.Node, backend *les.LightEthereum) error {
 			Namespace:     "engine",
 			Version:       "1.0",
 			Service:       NewConsensusAPI(backend),
-			Public:        true,
 			Authenticated: true,
 		},
 	})

--- a/les/client.go
+++ b/les/client.go
@@ -296,32 +296,26 @@ func (s *LightEthereum) APIs() []rpc.API {
 			Namespace: "eth",
 			Version:   "1.0",
 			Service:   &LightDummyAPI{},
-			Public:    true,
 		}, {
 			Namespace: "eth",
 			Version:   "1.0",
 			Service:   downloader.NewDownloaderAPI(s.handler.downloader, s.eventMux),
-			Public:    true,
 		}, {
 			Namespace: "eth",
 			Version:   "1.0",
 			Service:   filters.NewFilterAPI(s.ApiBackend, true, 5*time.Minute),
-			Public:    true,
 		}, {
 			Namespace: "net",
 			Version:   "1.0",
 			Service:   s.netRPCService,
-			Public:    true,
 		}, {
 			Namespace: "les",
 			Version:   "1.0",
 			Service:   NewLightAPI(&s.lesCommons),
-			Public:    false,
 		}, {
 			Namespace: "vflux",
 			Version:   "1.0",
 			Service:   s.serverPool.API(),
-			Public:    false,
 		},
 	}...)
 }

--- a/les/server.go
+++ b/les/server.go
@@ -161,19 +161,16 @@ func (s *LesServer) APIs() []rpc.API {
 			Namespace: "les",
 			Version:   "1.0",
 			Service:   NewLightAPI(&s.lesCommons),
-			Public:    false,
 		},
 		{
 			Namespace: "les",
 			Version:   "1.0",
 			Service:   NewLightServerAPI(s),
-			Public:    false,
 		},
 		{
 			Namespace: "debug",
 			Version:   "1.0",
 			Service:   NewDebugAPI(s),
-			Public:    false,
 		},
 	}
 }

--- a/node/api.go
+++ b/node/api.go
@@ -37,7 +37,6 @@ func (n *Node) apis() []rpc.API {
 			Namespace: "admin",
 			Version:   "1.0",
 			Service:   &adminAPI{n},
-			Public:    true,
 		}, {
 			Namespace: "debug",
 			Version:   "1.0",
@@ -46,7 +45,6 @@ func (n *Node) apis() []rpc.API {
 			Namespace: "web3",
 			Version:   "1.0",
 			Service:   &web3API{n},
-			Public:    true,
 		},
 	}
 }

--- a/node/rpcstack.go
+++ b/node/rpcstack.go
@@ -281,7 +281,7 @@ func (h *httpServer) enableRPC(apis []rpc.API, config httpConfig) error {
 
 	// Create RPC server and handler.
 	srv := rpc.NewServer()
-	if err := RegisterApis(apis, config.Modules, srv, false); err != nil {
+	if err := RegisterApis(apis, config.Modules, srv); err != nil {
 		return err
 	}
 	h.httpConfig = config
@@ -312,7 +312,7 @@ func (h *httpServer) enableWS(apis []rpc.API, config wsConfig) error {
 	}
 	// Create RPC server and handler.
 	srv := rpc.NewServer()
-	if err := RegisterApis(apis, config.Modules, srv, false); err != nil {
+	if err := RegisterApis(apis, config.Modules, srv); err != nil {
 		return err
 	}
 	h.wsConfig = config
@@ -528,7 +528,7 @@ func (is *ipcServer) stop() error {
 
 // RegisterApis checks the given modules' availability, generates an allowlist based on the allowed modules,
 // and then registers all of the APIs exposed by the services.
-func RegisterApis(apis []rpc.API, modules []string, srv *rpc.Server, exposeAll bool) error {
+func RegisterApis(apis []rpc.API, modules []string, srv *rpc.Server) error {
 	if bad, available := checkModuleAvailability(modules, apis); len(bad) > 0 {
 		log.Error("Unavailable modules in HTTP API list", "unavailable", bad, "available", available)
 	}
@@ -539,7 +539,7 @@ func RegisterApis(apis []rpc.API, modules []string, srv *rpc.Server, exposeAll b
 	}
 	// Register all the APIs exposed by the services
 	for _, api := range apis {
-		if exposeAll || allowList[api.Namespace] || (len(allowList) == 0 && api.Public) {
+		if allowList[api.Namespace] || len(allowList) == 0 {
 			if err := srv.RegisterName(api.Namespace, api.Service); err != nil {
 				return err
 			}

--- a/node/utils_test.go
+++ b/node/utils_test.go
@@ -100,12 +100,10 @@ func (f *FullService) APIs() []rpc.API {
 		{
 			Namespace: "debug",
 			Version:   "1.0",
-			Public:    true,
 		},
 		{
 			Namespace: "net",
 			Version:   "1.0",
-			Public:    true,
 		},
 	}
 }

--- a/rpc/types.go
+++ b/rpc/types.go
@@ -33,7 +33,7 @@ type API struct {
 	Namespace     string      // namespace under which the rpc methods of Service are exposed
 	Version       string      // api version for DApp's
 	Service       interface{} // receiver instance which holds the methods
-	Public        bool        // indication if the methods must be considered safe for public use
+	Public        bool        // deprecated - this field is no longer used, but retained for compatibility
 	Authenticated bool        // whether the api should only be available behind authentication.
 }
 


### PR DESCRIPTION
Depends on #25053.

This PR removes `public` from `rpc.API`.