### PR TITLE
common: improve pretty duration regex

### DIFF
--- a/common/format.go
+++ b/common/format.go
@@ -32,7 +32,7 @@ var prettyDurationRe = regexp.MustCompile(`\.[0-9]{4,}`)
 // String implements the Stringer interface, allowing pretty printing of duration
 // values rounded to three decimals.
 func (d PrettyDuration) String() string {
-	label := fmt.Sprintf("%v", time.Duration(d))
+	label := time.Duration(d).String()
 	if match := prettyDurationRe.FindString(label); len(match) > 4 {
 		label = strings.Replace(label, match, match[:4], 1)
 	}

--- a/common/format.go
+++ b/common/format.go
@@ -27,7 +27,7 @@ import (
 // the unnecessary precision off from the formatted textual representation.
 type PrettyDuration time.Duration
 
-var prettyDurationRe = regexp.MustCompile(`\.[0-9]+`)
+var prettyDurationRe = regexp.MustCompile(`\.[0-9]{4,}`)
 
 // String implements the Stringer interface, allowing pretty printing of duration
 // values rounded to three decimals.


### PR DESCRIPTION
Improves the speed of the prettyDuration regular expression by making it more specific

```
Master:
BenchmarkFormat-8   	 2040429	       659.9 ns/op	      53 B/op	       3 allocs/op
This PR:
BenchmarkFormat2-8   	 3560108	       334.8 ns/op	      30 B/op	       1 allocs/op
```
Benchmark code:
```go
func BenchmarkFormat(b *testing.B) {
	s := ""
	start := time.Now()
	for i := 0; i < b.N; i++ {
		dur := PrettyDuration(time.Since(start))
		s = dur.String()
	}
	_ = s
}
```