### PR TITLE
abi: include tuple name in the string kind

### DIFF
--- a/accounts/abi/type.go
+++ b/accounts/abi/type.go
@@ -211,6 +211,7 @@ func NewType(t string, internalType string, components []ArgumentMarshaling) (ty
 			// Foo.Bar type definition is not allowed in golang,
 			// convert the format to FooBar
 			typ.TupleRawName = strings.ReplaceAll(internalType[len(structPrefix):], ".", "")
+			typ.stringKind = typ.TupleRawName + expression
 		}
 
 	case "function":

--- a/accounts/abi/type_test.go
+++ b/accounts/abi/type_test.go
@@ -315,7 +315,7 @@ func TestInternalType(t *testing.T) {
 		TupleType: reflect.TypeOf(struct {
 			A int64 `json:"a"`
 		}{}),
-		stringKind:    "(int64)",
+		stringKind:    "ab[](int64)",
 		TupleRawName:  "ab[]",
 		TupleElems:    []*Type{{T: IntTy, Size: 64, stringKind: "int64"}},
 		TupleRawNames: []string{"a"},


### PR DESCRIPTION
I am rather curious if the original code is the intended behaviour or not. I'd assume that the internal type name must be included in the string output, but I have very limited ETH knowledge, so I am not sure if this is the way to go or not.