### PR TITLE
docs: update welcome-page

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -3,22 +3,37 @@ title: Geth Documentation
 root: ..
 ---
 
-You have found the user manual for geth, the Go language implementation of Ethereum.
+## Welcome to the Geth user manual!
+
+Geth (go-ethereum) is an Ethereum client implemented in [Go](https://go.dev/). This website 
+contains the Geth documentation, including:
 
 * [Getting Started Guide](./getting-started)
 * [Installation Instructions](./install-and-build/installing-geth)
 * [JSON-RPC Server](./rpc/server)
 * [JavaScript Console](./interface/javascript-console)
+* [Dapp developer docs](/docs/dapp/native)
 
 For the Go API reference and developer documentation head over to
-[GoDoc](https://godoc.org/github.com/ethereum/go-ethereum).
+[GoDoc](https://godoc.org/github.com/ethereum/go-ethereum). Geth's source code can
+be found on Geth's [Github](https://github.com/ethereum/go-ethereum).
 
-### Other Ethereum Documentation
+For information on [The Merge](https://ethereum.org/en/upgrades/merge) 
+(Ethereum's transition from proof-of-work to proof-of-stake) and
+how it will affect Geth users, visit the [Merge page](/docs/interface/merge).
 
-For generic Ethereum-related information, check the **[Ethereum
-Wiki](https://github.com/ethereum/wiki/wiki)**.
 
-* [Ethereum Whitepaper](https://github.com/ethereum/wiki/wiki/White-Paper)
+### Other Ethereum information
+
+For background information on Ethereum, visit [ethereum.org](https://ethereum.org). Below are 
+links to some of the key Ethereum resources:
+
+* [Ethereum Whitepaper](https://ethereum.org/en/whitepaper/)
 * [Ethereum Yellow Paper](https://ethereum.github.io/yellowpaper/paper.pdf)
 * [Ethereum Improvement Proposals (EIPs)](https://eips.ethereum.org)
 * [Peer-to-peer Networking Specifications](https://github.com/ethereum/devp2p/blob/master/README.md)
+* [Ethereum execution-layer JSON_RPC_API Specification](https://github.com/ethereum/execution-apis)
+* [Ethereum events and meetups](https://ethereum.org/en/community/events/)
+* [Ethereum dapp developer documentation](https://ethereum.org/en/developers/docs/)
+
+Geth is also on [Twitter](https://twitter.com/go_ethereum) and [Discord](https://discord.gg/wQdpS5aA). 


### PR DESCRIPTION
replaces out-of-date links with links to ethereum.org, adds some new links and makes minor updates to page content.