### PR TITLE
eth/tracers: add access list difference tracer

### DIFF
--- a/core/state_transition.go
+++ b/core/state_transition.go
@@ -289,7 +289,7 @@ func (st *StateTransition) TransitionDb() (*ExecutionResult, error) {
 	}
 
 	if st.evm.Config.Debug {
-		st.evm.Config.Tracer.CaptureTxStart(st.initialGas)
+		st.evm.Config.Tracer.CaptureTxStart(st.initialGas, st.msg.AccessList())
 		defer func() {
 			st.evm.Config.Tracer.CaptureTxEnd(st.gas)
 		}()

--- a/core/vm/logger.go
+++ b/core/vm/logger.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
 )
 
 // EVMLogger is used to collect execution traces from an EVM transaction
@@ -30,7 +31,7 @@ import (
 // if you need to retain them beyond the current call.
 type EVMLogger interface {
 	// Transaction level
-	CaptureTxStart(gasLimit uint64)
+	CaptureTxStart(gasLimit uint64, accessList types.AccessList)
 	CaptureTxEnd(restGas uint64)
 	// Top call frame
 	CaptureStart(env *EVM, from common.Address, to common.Address, create bool, input []byte, gas uint64, value *big.Int)

--- a/eth/tracers/api.go
+++ b/eth/tracers/api.go
@@ -882,9 +882,13 @@ func (api *API) traceTx(ctx context.Context, message core.Message, txctx *Contex
 	// Default tracer is the struct logger
 	tracer = logger.NewStructLogger(config.Config)
 	if config.Tracer != nil {
-		tracer, err = New(*config.Tracer, txctx)
-		if err != nil {
-			return nil, err
+		if *config.Tracer == "aclDiffTracer" {
+			tracer = logger.NewACLDiffTracer()
+		} else {
+			tracer, err = New(*config.Tracer, txctx)
+			if err != nil {
+				return nil, err
+			}
 		}
 	}
 	// Define a meaningful timeout of a single transaction trace

--- a/eth/tracers/js/goja.go
+++ b/eth/tracers/js/goja.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/core/vm"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/eth/tracers"
@@ -201,7 +202,7 @@ func newJsTracer(code string, ctx *tracers.Context) (tracers.Tracer, error) {
 
 // CaptureTxStart implements the Tracer interface and is invoked at the beginning of
 // transaction processing.
-func (t *jsTracer) CaptureTxStart(gasLimit uint64) {
+func (t *jsTracer) CaptureTxStart(gasLimit uint64, acl types.AccessList) {
 	t.gasLimit = gasLimit
 }
 

--- a/eth/tracers/js/tracer_test.go
+++ b/eth/tracers/js/tracer_test.go
@@ -70,7 +70,7 @@ func runTrace(tracer tracers.Tracer, vmctx *vmContext, chaincfg *params.ChainCon
 	)
 	contract.Code = []byte{byte(vm.PUSH1), 0x1, byte(vm.PUSH1), 0x1, 0x0}
 
-	tracer.CaptureTxStart(gasLimit)
+	tracer.CaptureTxStart(gasLimit, nil)
 	tracer.CaptureStart(env, contract.Caller(), contract.Address(), false, []byte{}, startGas, value)
 	ret, err := env.Interpreter().Run(contract, []byte{}, false)
 	tracer.CaptureEnd(ret, startGas-contract.Gas, 1, err)

--- a/eth/tracers/logger/access_list_tracer.go
+++ b/eth/tracers/logger/access_list_tracer.go
@@ -169,7 +169,7 @@ func (*AccessListTracer) CaptureEnter(typ vm.OpCode, from common.Address, to com
 
 func (*AccessListTracer) CaptureExit(output []byte, gasUsed uint64, err error) {}
 
-func (*AccessListTracer) CaptureTxStart(gasLimit uint64) {}
+func (*AccessListTracer) CaptureTxStart(gasLimit uint64, acl types.AccessList) {}
 
 func (*AccessListTracer) CaptureTxEnd(restGas uint64) {}
 

--- a/eth/tracers/logger/acl_diff_tracer.go
+++ b/eth/tracers/logger/acl_diff_tracer.go
@@ -1,0 +1,121 @@
+package logger
+
+import (
+	"encoding/json"
+	"fmt"
+	"math/big"
+	"sync/atomic"
+	"time"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/core/vm"
+)
+
+type ACLDiffTracer struct {
+	env       *vm.EVM
+	tracer    *AccessListTracer
+	txACL     types.AccessList
+	interrupt uint32 // Atomic flag to signal execution interruption
+	reason    error  // Textual reason for the interruption
+}
+
+func NewACLDiffTracer() *ACLDiffTracer {
+	return &ACLDiffTracer{}
+}
+
+// CaptureStart implements the EVMLogger interface to initialize the tracing operation.
+func (t *ACLDiffTracer) CaptureStart(env *vm.EVM, from common.Address, to common.Address, create bool, input []byte, gas uint64, value *big.Int) {
+	t.env = env
+	rules := env.ChainConfig().Rules(env.Context.BlockNumber, env.Context.Random != nil)
+	precompiles := vm.ActivePrecompiles(rules)
+	t.tracer = NewAccessListTracer(nil, from, to, precompiles)
+}
+
+// CaptureEnd is called after the call finishes to finalize the tracing.
+func (t *ACLDiffTracer) CaptureEnd(output []byte, gasUsed uint64, _ time.Duration, err error) {
+}
+
+// CaptureState implements the EVMLogger interface to trace a single step of VM execution.
+func (t *ACLDiffTracer) CaptureState(pc uint64, op vm.OpCode, gas, cost uint64, scope *vm.ScopeContext, rData []byte, depth int, err error) {
+	// Skip if tracing was interrupted
+	if atomic.LoadUint32(&t.interrupt) > 0 {
+		t.env.Cancel()
+		return
+	}
+	t.tracer.CaptureState(pc, op, gas, cost, scope, rData, depth, err)
+}
+
+// CaptureFault implements the EVMLogger interface to trace an execution fault.
+func (t *ACLDiffTracer) CaptureFault(pc uint64, op vm.OpCode, gas, cost uint64, _ *vm.ScopeContext, depth int, err error) {
+}
+
+// CaptureEnter is called when EVM enters a new scope (via call, create or selfdestruct).
+func (t *ACLDiffTracer) CaptureEnter(typ vm.OpCode, from common.Address, to common.Address, input []byte, gas uint64, value *big.Int) {
+	// Skip if tracing was interrupted
+	if atomic.LoadUint32(&t.interrupt) > 0 {
+		t.env.Cancel()
+		return
+	}
+
+}
+
+// CaptureExit is called when EVM exits a scope, even if the scope didn't
+// execute any code.
+func (t *ACLDiffTracer) CaptureExit(output []byte, gasUsed uint64, err error) {
+}
+
+func (t *ACLDiffTracer) CaptureTxStart(gasLimit uint64, acl types.AccessList) {
+	t.txACL = acl
+}
+
+func (t *ACLDiffTracer) CaptureTxEnd(restGas uint64) {}
+
+// GetResult returns the json-encoded nested list of call traces, and any
+// error arising from the encoding or forceful termination (via `Stop`).
+func (t *ACLDiffTracer) GetResult() (json.RawMessage, error) {
+	if len(t.txACL) == 0 {
+		return nil, fmt.Errorf("Transaction not of type 1")
+	}
+	touched := t.tracer.list
+	diff, err := aclDiff(t.txACL, touched)
+	if err != nil {
+		return nil, err
+	}
+	res, err := json.Marshal(diff)
+	if err != nil {
+		return nil, err
+	}
+	return json.RawMessage(res), t.reason
+
+}
+
+// Stop terminates execution of the tracer at the first opportune moment.
+func (t *ACLDiffTracer) Stop(err error) {
+	t.reason = err
+	atomic.StoreUint32(&t.interrupt, 1)
+}
+
+// aclDiff returns a - b. b must be a subset of a.
+func aclDiff(a types.AccessList, b accessList) (types.AccessList, error) {
+	if len(b) > len(a) {
+		return nil, fmt.Errorf("Touched access list must be smaller than announced access list: %d vs %d", len(b), len(a))
+	}
+	res := newAccessList()
+	for _, al := range a {
+		bAcc, ok := b[al.Address]
+		// Whole account is missing
+		if !ok {
+			res.addAddress(al.Address)
+			for _, slot := range al.StorageKeys {
+				res.addSlot(al.Address, slot)
+			}
+		}
+		for _, slot := range al.StorageKeys {
+			if _, ok := bAcc[slot]; !ok {
+				res.addSlot(al.Address, slot)
+			}
+		}
+	}
+	return res.accessList(), nil
+}

--- a/eth/tracers/logger/logger.go
+++ b/eth/tracers/logger/logger.go
@@ -263,7 +263,7 @@ func (l *StructLogger) Stop(err error) {
 	atomic.StoreUint32(&l.interrupt, 1)
 }
 
-func (l *StructLogger) CaptureTxStart(gasLimit uint64) {
+func (l *StructLogger) CaptureTxStart(gasLimit uint64, acl types.AccessList) {
 	l.gasLimit = gasLimit
 }
 
@@ -396,7 +396,7 @@ func (t *mdLogger) CaptureEnter(typ vm.OpCode, from common.Address, to common.Ad
 
 func (t *mdLogger) CaptureExit(output []byte, gasUsed uint64, err error) {}
 
-func (*mdLogger) CaptureTxStart(gasLimit uint64) {}
+func (*mdLogger) CaptureTxStart(gasLimit uint64, acl types.AccessList) {}
 
 func (*mdLogger) CaptureTxEnd(restGas uint64) {}
 

--- a/eth/tracers/logger/logger_json.go
+++ b/eth/tracers/logger/logger_json.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/math"
+	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/core/vm"
 )
 
@@ -99,6 +100,6 @@ func (l *JSONLogger) CaptureEnter(typ vm.OpCode, from common.Address, to common.
 
 func (l *JSONLogger) CaptureExit(output []byte, gasUsed uint64, err error) {}
 
-func (l *JSONLogger) CaptureTxStart(gasLimit uint64) {}
+func (l *JSONLogger) CaptureTxStart(gasLimit uint64, acl types.AccessList) {}
 
 func (l *JSONLogger) CaptureTxEnd(restGas uint64) {}

--- a/eth/tracers/native/4byte.go
+++ b/eth/tracers/native/4byte.go
@@ -24,6 +24,7 @@ import (
 	"time"
 
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/core/vm"
 	"github.com/ethereum/go-ethereum/eth/tracers"
 )
@@ -131,7 +132,7 @@ func (t *fourByteTracer) CaptureFault(pc uint64, op vm.OpCode, gas, cost uint64,
 func (t *fourByteTracer) CaptureEnd(output []byte, gasUsed uint64, _ time.Duration, err error) {
 }
 
-func (*fourByteTracer) CaptureTxStart(gasLimit uint64) {}
+func (*fourByteTracer) CaptureTxStart(gasLimit uint64, acl types.AccessList) {}
 
 func (*fourByteTracer) CaptureTxEnd(restGas uint64) {}
 

--- a/eth/tracers/native/call.go
+++ b/eth/tracers/native/call.go
@@ -26,6 +26,7 @@ import (
 	"time"
 
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/core/vm"
 	"github.com/ethereum/go-ethereum/eth/tracers"
 )
@@ -142,7 +143,7 @@ func (t *callTracer) CaptureExit(output []byte, gasUsed uint64, err error) {
 	t.callstack[size-1].Calls = append(t.callstack[size-1].Calls, call)
 }
 
-func (*callTracer) CaptureTxStart(gasLimit uint64) {}
+func (*callTracer) CaptureTxStart(gasLimit uint64, acl types.AccessList) {}
 
 func (*callTracer) CaptureTxEnd(restGas uint64) {}
 

--- a/eth/tracers/native/noop.go
+++ b/eth/tracers/native/noop.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/core/vm"
 	"github.com/ethereum/go-ethereum/eth/tracers"
 )
@@ -64,7 +65,7 @@ func (t *noopTracer) CaptureEnter(typ vm.OpCode, from common.Address, to common.
 func (t *noopTracer) CaptureExit(output []byte, gasUsed uint64, err error) {
 }
 
-func (*noopTracer) CaptureTxStart(gasLimit uint64) {}
+func (*noopTracer) CaptureTxStart(gasLimit uint64, acl types.AccessList) {}
 
 func (*noopTracer) CaptureTxEnd(restGas uint64) {}
 

--- a/eth/tracers/native/prestate.go
+++ b/eth/tracers/native/prestate.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/core/vm"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/eth/tracers"
@@ -131,7 +132,7 @@ func (t *prestateTracer) CaptureEnter(typ vm.OpCode, from common.Address, to com
 func (t *prestateTracer) CaptureExit(output []byte, gasUsed uint64, err error) {
 }
 
-func (t *prestateTracer) CaptureTxStart(gasLimit uint64) {
+func (t *prestateTracer) CaptureTxStart(gasLimit uint64, acl types.AccessList) {
 	t.gasLimit = gasLimit
 }
 


### PR DESCRIPTION
This PR adds a new native tracer. The tracer compares the addresses and slots touched during execution to the access list which came as part of the transaction envelope. The goal is to see how well access patterns are predicted.