### PR TITLE
cmd/utils: update --ropsten description

### DIFF
--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -150,7 +150,7 @@ var (
 	}
 	RopstenFlag = cli.BoolFlag{
 		Name:  "ropsten",
-		Usage: "Ropsten network: pre-configured proof-of-work test network",
+		Usage: "Ropsten network: pre-configured proof-of-stake test network",
 	}
 	RinkebyFlag = cli.BoolFlag{
 		Name:  "rinkeby",


### PR DESCRIPTION
Just changed to `Ropsten network: pre-configured proof-of-stake test network`