### PR TITLE
all: remove version field

### DIFF
--- a/cmd/clef/main.go
+++ b/cmd/clef/main.go
@@ -648,7 +648,7 @@ func signer(c *cli.Context) error {
 		{
 			Namespace: "account",
 			Service:   api,
-			Version:   "1.0"},
+		},
 	}
 	if c.GlobalBool(utils.HTTPEnabledFlag.Name) {
 		vhosts := utils.SplitAndTrim(c.GlobalString(utils.HTTPVirtualHostsFlag.Name))

--- a/consensus/clique/clique.go
+++ b/consensus/clique/clique.go
@@ -697,7 +697,6 @@ func (c *Clique) Close() error {
 func (c *Clique) APIs(chain consensus.ChainHeaderReader) []rpc.API {
 	return []rpc.API{{
 		Namespace: "clique",
-		Version:   "1.0",
 		Service:   &API{chain: chain, clique: c},
 	}}
 }

--- a/consensus/ethash/ethash.go
+++ b/consensus/ethash/ethash.go
@@ -678,12 +678,10 @@ func (ethash *Ethash) APIs(chain consensus.ChainHeaderReader) []rpc.API {
 	return []rpc.API{
 		{
 			Namespace: "eth",
-			Version:   "1.0",
 			Service:   &API{ethash},
 		},
 		{
 			Namespace: "ethash",
-			Version:   "1.0",
 			Service:   &API{ethash},
 		},
 	}

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -308,31 +308,24 @@ func (s *Ethereum) APIs() []rpc.API {
 	return append(apis, []rpc.API{
 		{
 			Namespace: "eth",
-			Version:   "1.0",
 			Service:   NewEthereumAPI(s),
 		}, {
 			Namespace: "miner",
-			Version:   "1.0",
 			Service:   NewMinerAPI(s),
 		}, {
 			Namespace: "eth",
-			Version:   "1.0",
 			Service:   downloader.NewDownloaderAPI(s.handler.downloader, s.eventMux),
 		}, {
 			Namespace: "eth",
-			Version:   "1.0",
 			Service:   filters.NewFilterAPI(s.APIBackend, false, 5*time.Minute),
 		}, {
 			Namespace: "admin",
-			Version:   "1.0",
 			Service:   NewAdminAPI(s),
 		}, {
 			Namespace: "debug",
-			Version:   "1.0",
 			Service:   NewDebugAPI(s),
 		}, {
 			Namespace: "net",
-			Version:   "1.0",
 			Service:   s.netRPCService,
 		},
 	}...)

--- a/eth/catalyst/api.go
+++ b/eth/catalyst/api.go
@@ -42,7 +42,6 @@ func Register(stack *node.Node, backend *eth.Ethereum) error {
 	stack.RegisterAPIs([]rpc.API{
 		{
 			Namespace:     "engine",
-			Version:       "1.0",
 			Service:       NewConsensusAPI(backend),
 			Authenticated: true,
 		},

--- a/eth/tracers/api.go
+++ b/eth/tracers/api.go
@@ -918,7 +918,6 @@ func APIs(backend Backend) []rpc.API {
 	return []rpc.API{
 		{
 			Namespace: "debug",
-			Version:   "1.0",
 			Service:   NewAPI(backend),
 		},
 	}

--- a/internal/ethapi/backend.go
+++ b/internal/ethapi/backend.go
@@ -101,31 +101,24 @@ func GetAPIs(apiBackend Backend) []rpc.API {
 	return []rpc.API{
 		{
 			Namespace: "eth",
-			Version:   "1.0",
 			Service:   NewEthereumAPI(apiBackend),
 		}, {
 			Namespace: "eth",
-			Version:   "1.0",
 			Service:   NewBlockChainAPI(apiBackend),
 		}, {
 			Namespace: "eth",
-			Version:   "1.0",
 			Service:   NewTransactionAPI(apiBackend, nonceLock),
 		}, {
 			Namespace: "txpool",
-			Version:   "1.0",
 			Service:   NewTxPoolAPI(apiBackend),
 		}, {
 			Namespace: "debug",
-			Version:   "1.0",
 			Service:   NewDebugAPI(apiBackend),
 		}, {
 			Namespace: "eth",
-			Version:   "1.0",
 			Service:   NewEthereumAccountAPI(apiBackend.AccountManager()),
 		}, {
 			Namespace: "personal",
-			Version:   "1.0",
 			Service:   NewPersonalAccountAPI(apiBackend, nonceLock),
 		},
 	}

--- a/les/catalyst/api.go
+++ b/les/catalyst/api.go
@@ -35,7 +35,6 @@ func Register(stack *node.Node, backend *les.LightEthereum) error {
 	stack.RegisterAPIs([]rpc.API{
 		{
 			Namespace:     "engine",
-			Version:       "1.0",
 			Service:       NewConsensusAPI(backend),
 			Authenticated: true,
 		},

--- a/les/client.go
+++ b/les/client.go
@@ -294,27 +294,21 @@ func (s *LightEthereum) APIs() []rpc.API {
 	return append(apis, []rpc.API{
 		{
 			Namespace: "eth",
-			Version:   "1.0",
 			Service:   &LightDummyAPI{},
 		}, {
 			Namespace: "eth",
-			Version:   "1.0",
 			Service:   downloader.NewDownloaderAPI(s.handler.downloader, s.eventMux),
 		}, {
 			Namespace: "eth",
-			Version:   "1.0",
 			Service:   filters.NewFilterAPI(s.ApiBackend, true, 5*time.Minute),
 		}, {
 			Namespace: "net",
-			Version:   "1.0",
 			Service:   s.netRPCService,
 		}, {
 			Namespace: "les",
-			Version:   "1.0",
 			Service:   NewLightAPI(&s.lesCommons),
 		}, {
 			Namespace: "vflux",
-			Version:   "1.0",
 			Service:   s.serverPool.API(),
 		},
 	}...)

--- a/les/server.go
+++ b/les/server.go
@@ -159,17 +159,14 @@ func (s *LesServer) APIs() []rpc.API {
 	return []rpc.API{
 		{
 			Namespace: "les",
-			Version:   "1.0",
 			Service:   NewLightAPI(&s.lesCommons),
 		},
 		{
 			Namespace: "les",
-			Version:   "1.0",
 			Service:   NewLightServerAPI(s),
 		},
 		{
 			Namespace: "debug",
-			Version:   "1.0",
 			Service:   NewDebugAPI(s),
 		},
 	}

--- a/node/api.go
+++ b/node/api.go
@@ -35,15 +35,12 @@ func (n *Node) apis() []rpc.API {
 	return []rpc.API{
 		{
 			Namespace: "admin",
-			Version:   "1.0",
 			Service:   &adminAPI{n},
 		}, {
 			Namespace: "debug",
-			Version:   "1.0",
 			Service:   debug.Handler,
 		}, {
 			Namespace: "web3",
-			Version:   "1.0",
 			Service:   &web3API{n},
 		},
 	}

--- a/node/utils_test.go
+++ b/node/utils_test.go
@@ -95,15 +95,12 @@ func (f *FullService) APIs() []rpc.API {
 	return []rpc.API{
 		{
 			Namespace: "admin",
-			Version:   "1.0",
 		},
 		{
 			Namespace: "debug",
-			Version:   "1.0",
 		},
 		{
 			Namespace: "net",
-			Version:   "1.0",
 		},
 	}
 }

--- a/p2p/simulations/adapters/exec.go
+++ b/p2p/simulations/adapters/exec.go
@@ -501,7 +501,6 @@ func startExecNodeStack() (*node.Node, error) {
 	// Add the snapshot API.
 	stack.RegisterAPIs([]rpc.API{{
 		Namespace: "simulation",
-		Version:   "1.0",
 		Service:   SnapshotAPI{services},
 	}})
 

--- a/rpc/types.go
+++ b/rpc/types.go
@@ -31,7 +31,7 @@ import (
 // API describes the set of methods offered over the RPC interface
 type API struct {
 	Namespace     string      // namespace under which the rpc methods of Service are exposed
-	Version       string      // api version for DApp's
+	Version       string      // deprecated - this field is no longer used, but retained for compatibility
 	Service       interface{} // receiver instance which holds the methods
 	Public        bool        // deprecated - this field is no longer used, but retained for compatibility
 	Authenticated bool        // whether the api should only be available behind authentication.


### PR DESCRIPTION
Follow on to #25059

Remove the use of `rpc.API.Version` since it is not subsequently used anywhere. It could be neat to eventually use this method to define methods like `eth_callV2` or something, but that feels like far enough in the future (and uncertain enough) to deprecate the field for now.