### PR TITLE
internal/ethapi: add comment explaining return of nil instead of error

### DIFF
--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -1581,7 +1581,7 @@ func (s *PublicTransactionPoolAPI) GetRawTransactionByHash(ctx context.Context, 
 func (s *PublicTransactionPoolAPI) GetTransactionReceipt(ctx context.Context, hash common.Hash) (map[string]interface{}, error) {
 	tx, blockHash, blockNumber, index, err := s.b.GetTransaction(ctx, hash)
 	if err != nil {
-		// return nil on purpose
+		// Returns nil on purpose instead of err
 		// When the transaction doesn't exist, the return value of this RPC call should be JSON null.
 		return nil, nil
 	}

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -1581,8 +1581,8 @@ func (s *PublicTransactionPoolAPI) GetRawTransactionByHash(ctx context.Context, 
 func (s *PublicTransactionPoolAPI) GetTransactionReceipt(ctx context.Context, hash common.Hash) (map[string]interface{}, error) {
 	tx, blockHash, blockNumber, index, err := s.b.GetTransaction(ctx, hash)
 	if err != nil {
-		// Returns nil on purpose instead of err
-		// When the transaction doesn't exist, the return value of this RPC call should be JSON null.
+		// When the transaction doesn't exist, the RPC method should return JSON null
+		// as per specification.
 		return nil, nil
 	}
 	receipts, err := s.b.GetReceipts(ctx, blockHash)


### PR DESCRIPTION
- Added a comment explaining that it dares to return nil instead of err.