### PR TITLE
docs/_interface: 0x0000000000000000000000000000000000000000 will be parsed as common.Address{}, should not be used as etherbase

### DIFF
--- a/docs/_interface/Private-Network.md
+++ b/docs/_interface/Private-Network.md
@@ -291,7 +291,7 @@ create a stable stream of blocks at regular intervals. To start a Geth instance 
 mining, run it with all the usual flags and add the following to configure mining:
 
 ```shell
-geth <other-flags> --mine --miner.threads=1 --miner.etherbase=0x0000000000000000000000000000000000000000
+geth <other-flags> --mine --miner.threads=1 --miner.etherbase=0x0000000000000000000000000000000000000001
 ```
 
 This will start mining bocks and transactions on a single CPU thread, crediting all block


### PR DESCRIPTION
And it would output error message as follow:
```
ERROR[06-16|14:45:09.207] Cannot start mining without etherbase    err="etherbase must be explicitly specified"
Fatal: Failed to start mining: etherbase missing: etherbase must be explicitly specified
```