### PR TITLE
tests/fuzzers/rlp: avoid very large input

### DIFF
--- a/tests/fuzzers/rlp/rlp_fuzzer.go
+++ b/tests/fuzzers/rlp/rlp_fuzzer.go
@@ -40,6 +40,9 @@ func Fuzz(input []byte) int {
 	if len(input) == 0 {
 		return 0
 	}
+	if len(input) > 500*1024 {
+		return 0
+	}
 
 	var i int
 	{


### PR DESCRIPTION
The oss-fuzz engine crashes due to stack overflow decoding a large nested structure into a `interface{}`. This PR limits the size of the input data, so should avoid such crashes. 