### PR TITLE
core: allow external code to set the validator

### DIFF
--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -1652,10 +1652,9 @@ func (bc *BlockChain) insertChain(chain types.Blocks, verifySeals, setHead bool)
 		// Validate the state using the default validator
 		substart = time.Now()
 		if err := bc.validator.ValidateState(block, statedb, receipts, usedGas); err != nil {
-			fmt.Println("#### ignoring invalid block")
-			// bc.reportBlock(block, receipts, err)
-			// atomic.StoreUint32(&followupInterrupt, 1)
-			// return it.index, err
+			bc.reportBlock(block, receipts, err)
+			atomic.StoreUint32(&followupInterrupt, 1)
+			return it.index, err
 		}
 		proctime := time.Since(start)
 

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -2375,9 +2375,9 @@ func (bc *BlockChain) InsertHeaderChain(chain []*types.Header, checkFreq int) (i
 	return 0, err
 }
 
-// SetValidator sets the current validator.
+// SetBlockValidatorForTesting sets the current validator.
 // This method can be used to force an invalid blockchain to be verified for tests.
 // This method is unsafe and should only be used before block import starts.
-func (bc *BlockChain) SetValidator(v Validator) {
+func (bc *BlockChain) SetBlockValidatorForTesting(v Validator) {
 	bc.validator = v
 }

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -2374,3 +2374,10 @@ func (bc *BlockChain) InsertHeaderChain(chain []*types.Header, checkFreq int) (i
 	_, err := bc.hc.InsertHeaderChain(chain, start, bc.forker)
 	return 0, err
 }
+
+// SetValidator sets the current validator.
+// This method can be used to force an invalid blockchain to be verified for tests.
+// This method is unsafe and should only be used before block import starts.
+func (bc *BlockChain) SetValidator(v Validator) {
+	bc.validator = v
+}

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -1652,9 +1652,10 @@ func (bc *BlockChain) insertChain(chain types.Blocks, verifySeals, setHead bool)
 		// Validate the state using the default validator
 		substart = time.Now()
 		if err := bc.validator.ValidateState(block, statedb, receipts, usedGas); err != nil {
-			bc.reportBlock(block, receipts, err)
-			atomic.StoreUint32(&followupInterrupt, 1)
-			return it.index, err
+			fmt.Println("#### ignoring invalid block")
+			// bc.reportBlock(block, receipts, err)
+			// atomic.StoreUint32(&followupInterrupt, 1)
+			// return it.index, err
 		}
 		proctime := time.Since(start)
 

--- a/core/blockchain_reader.go
+++ b/core/blockchain_reader.go
@@ -331,6 +331,8 @@ func (bc *BlockChain) Validator() Validator {
 }
 
 // SetValidator sets the current validator.
+// This method can be used to force an invalid blockchain to be verified for tests.
+// This method is unsafe and should only be used before block import starts.
 func (bc *BlockChain) SetValidator(v Validator) {
 	bc.validator = v
 }

--- a/core/blockchain_reader.go
+++ b/core/blockchain_reader.go
@@ -330,13 +330,6 @@ func (bc *BlockChain) Validator() Validator {
 	return bc.validator
 }
 
-// SetValidator sets the current validator.
-// This method can be used to force an invalid blockchain to be verified for tests.
-// This method is unsafe and should only be used before block import starts.
-func (bc *BlockChain) SetValidator(v Validator) {
-	bc.validator = v
-}
-
 // Processor returns the current processor.
 func (bc *BlockChain) Processor() Processor {
 	return bc.processor

--- a/core/blockchain_reader.go
+++ b/core/blockchain_reader.go
@@ -330,6 +330,10 @@ func (bc *BlockChain) Validator() Validator {
 	return bc.validator
 }
 
+func (bc *BlockChain) SetValidator(v Validator) {
+	bc.validator = v
+}
+
 // Processor returns the current processor.
 func (bc *BlockChain) Processor() Processor {
 	return bc.processor

--- a/core/blockchain_reader.go
+++ b/core/blockchain_reader.go
@@ -330,6 +330,7 @@ func (bc *BlockChain) Validator() Validator {
 	return bc.validator
 }
 
+// SetValidator sets the current validator.
 func (bc *BlockChain) SetValidator(v Validator) {
 	bc.validator = v
 }


### PR DESCRIPTION
This small change allows us to create an invalid blockchain for hive tests