### PR TITLE
node: make jwt tests less time-dependent

### DIFF
--- a/node/rpcstack_test.go
+++ b/node/rpcstack_test.go
@@ -319,55 +319,100 @@ func TestJWT(t *testing.T) {
 	wsUrl := fmt.Sprintf("ws://%v", srv.listenAddr())
 	htUrl := fmt.Sprintf("http://%v", srv.listenAddr())
 
-	expOk := []string{
-		fmt.Sprintf("Bearer %v", issueToken(secret, nil, testClaim{"iat": time.Now().Unix()})),
-		fmt.Sprintf("Bearer %v", issueToken(secret, nil, testClaim{"iat": time.Now().Unix() + 4})),
-		fmt.Sprintf("Bearer %v", issueToken(secret, nil, testClaim{"iat": time.Now().Unix() - 4})),
-		fmt.Sprintf("Bearer %v", issueToken(secret, nil, testClaim{
-			"iat": time.Now().Unix(),
-			"exp": time.Now().Unix() + 2,
-		})),
-		fmt.Sprintf("Bearer %v", issueToken(secret, nil, testClaim{
-			"iat": time.Now().Unix(),
-			"bar": "baz",
-		})),
+	expOk := []func() string{
+		func() string {
+			return fmt.Sprintf("Bearer %v", issueToken(secret, nil, testClaim{"iat": time.Now().Unix()}))
+		},
+		func() string {
+			return fmt.Sprintf("Bearer %v", issueToken(secret, nil, testClaim{"iat": time.Now().Unix() + 4}))
+		},
+		func() string {
+			return fmt.Sprintf("Bearer %v", issueToken(secret, nil, testClaim{"iat": time.Now().Unix() - 4}))
+		},
+		func() string {
+			return fmt.Sprintf("Bearer %v", issueToken(secret, nil, testClaim{
+				"iat": time.Now().Unix(),
+				"exp": time.Now().Unix() + 2,
+			}))
+		},
+		func() string {
+			return fmt.Sprintf("Bearer %v", issueToken(secret, nil, testClaim{
+				"iat": time.Now().Unix(),
+				"bar": "baz",
+			}))
+		},
 	}
-	for i, token := range expOk {
+	for i, tokenFn := range expOk {
+		token := tokenFn()
 		if err := wsRequest(t, wsUrl, "Authorization", token); err != nil {
 			t.Errorf("test %d-ws, token '%v': expected ok, got %v", i, token, err)
 		}
+		token = tokenFn()
 		if resp := rpcRequest(t, htUrl, "Authorization", token); resp.StatusCode != 200 {
 			t.Errorf("test %d-http, token '%v': expected ok, got %v", i, token, resp.StatusCode)
 		}
 	}
-	expFail := []string{
+
+	expFail := []func() string{
 		// future
-		fmt.Sprintf("Bearer %v", issueToken(secret, nil, testClaim{"iat": time.Now().Unix() + 6})),
+		func() string {
+			return fmt.Sprintf("Bearer %v", issueToken(secret, nil, testClaim{"iat": time.Now().Unix() + 6}))
+		},
 		// stale
-		fmt.Sprintf("Bearer %v", issueToken(secret, nil, testClaim{"iat": time.Now().Unix() - 6})),
+		func() string {
+			return fmt.Sprintf("Bearer %v", issueToken(secret, nil, testClaim{"iat": time.Now().Unix() - 6}))
+		},
 		// wrong algo
-		fmt.Sprintf("Bearer %v", issueToken(secret, jwt.SigningMethodHS512, testClaim{"iat": time.Now().Unix() + 4})),
+		func() string {
+			return fmt.Sprintf("Bearer %v", issueToken(secret, jwt.SigningMethodHS512, testClaim{"iat": time.Now().Unix() + 4}))
+		},
 		// expired
-		fmt.Sprintf("Bearer %v", issueToken(secret, nil, testClaim{"iat": time.Now().Unix(), "exp": time.Now().Unix()})),
+		func() string {
+			return fmt.Sprintf("Bearer %v", issueToken(secret, nil, testClaim{"iat": time.Now().Unix(), "exp": time.Now().Unix()}))
+		},
 		// missing mandatory iat
-		fmt.Sprintf("Bearer %v", issueToken(secret, nil, testClaim{})),
-		// wrong secret
-		fmt.Sprintf("Bearer %v", issueToken([]byte("wrong"), nil, testClaim{"iat": time.Now().Unix()})),
-		fmt.Sprintf("Bearer %v", issueToken([]byte{}, nil, testClaim{"iat": time.Now().Unix()})),
-		fmt.Sprintf("Bearer %v", issueToken(nil, nil, testClaim{"iat": time.Now().Unix()})),
+		func() string {
+			return fmt.Sprintf("Bearer %v", issueToken(secret, nil, testClaim{}))
+		},
+		//  wrong secret
+		func() string {
+			return fmt.Sprintf("Bearer %v", issueToken([]byte("wrong"), nil, testClaim{"iat": time.Now().Unix()}))
+		},
+		func() string {
+			return fmt.Sprintf("Bearer %v", issueToken([]byte{}, nil, testClaim{"iat": time.Now().Unix()}))
+		},
+		func() string {
+			return fmt.Sprintf("Bearer %v", issueToken(nil, nil, testClaim{"iat": time.Now().Unix()}))
+		},
 		// Various malformed syntax
-		fmt.Sprintf("%v", issueToken(secret, nil, testClaim{"iat": time.Now().Unix()})),
-		fmt.Sprintf("Bearer  %v", issueToken(secret, nil, testClaim{"iat": time.Now().Unix()})),
-		fmt.Sprintf("bearer %v", issueToken(secret, nil, testClaim{"iat": time.Now().Unix()})),
-		fmt.Sprintf("Bearer: %v", issueToken(secret, nil, testClaim{"iat": time.Now().Unix()})),
-		fmt.Sprintf("Bearer:%v", issueToken(secret, nil, testClaim{"iat": time.Now().Unix()})),
-		fmt.Sprintf("Bearer\t%v", issueToken(secret, nil, testClaim{"iat": time.Now().Unix()})),
-		fmt.Sprintf("Bearer \t%v", issueToken(secret, nil, testClaim{"iat": time.Now().Unix()})),
+		func() string {
+			return fmt.Sprintf("%v", issueToken(secret, nil, testClaim{"iat": time.Now().Unix()}))
+		},
+		func() string {
+			return fmt.Sprintf("Bearer  %v", issueToken(secret, nil, testClaim{"iat": time.Now().Unix()}))
+		},
+		func() string {
+			return fmt.Sprintf("bearer %v", issueToken(secret, nil, testClaim{"iat": time.Now().Unix()}))
+		},
+		func() string {
+			return fmt.Sprintf("Bearer: %v", issueToken(secret, nil, testClaim{"iat": time.Now().Unix()}))
+		},
+		func() string {
+			return fmt.Sprintf("Bearer:%v", issueToken(secret, nil, testClaim{"iat": time.Now().Unix()}))
+		},
+		func() string {
+			return fmt.Sprintf("Bearer\t%v", issueToken(secret, nil, testClaim{"iat": time.Now().Unix()}))
+		},
+		func() string {
+			return fmt.Sprintf("Bearer \t%v", issueToken(secret, nil, testClaim{"iat": time.Now().Unix()}))
+		},
 	}
-	for i, token := range expFail {
+	for i, tokenFn := range expFail {
+		token := tokenFn()
 		if err := wsRequest(t, wsUrl, "Authorization", token); err == nil {
 			t.Errorf("tc %d-ws, token '%v': expected not to allow,  got ok", i, token)
 		}
+		token = tokenFn()
 		if resp := rpcRequest(t, htUrl, "Authorization", token); resp.StatusCode != 403 {
 			t.Errorf("tc %d-http, token '%v': expected not to allow,  got %v", i, token, resp.StatusCode)
 		}


### PR DESCRIPTION
https://github.com/ethereum/go-ethereum/pull/25016 made the jwt tests a bit less prone to fail on appveyor, however it still happens from time to time that the tests fail. 
This is due to the amount of time that passes between the creation of the token and the request is made. This PR modifies the tests to not use `[]string`, but instead methods which are evaluated right before the request is made. 