### PR TITLE
core/types: rlp decode unsigned transactions

### DIFF
--- a/core/types/access_list_tx.go
+++ b/core/types/access_list_tx.go
@@ -52,7 +52,7 @@ type AccessListTx struct {
 	Value      *big.Int        // wei amount
 	Data       []byte          // contract invocation input data
 	AccessList AccessList      // EIP-2930 access list
-	V, R, S    *big.Int        // signature values
+	V, R, S    *big.Int        `rlp:"optional"` // signature values
 }
 
 // copy creates a deep copy of the transaction data and initializes all fields.

--- a/core/types/dynamic_fee_tx.go
+++ b/core/types/dynamic_fee_tx.go
@@ -34,9 +34,9 @@ type DynamicFeeTx struct {
 	AccessList AccessList
 
 	// Signature values
-	V *big.Int `json:"v" gencodec:"required"`
-	R *big.Int `json:"r" gencodec:"required"`
-	S *big.Int `json:"s" gencodec:"required"`
+	V *big.Int `json:"v" gencodec:"required" rlp:"optional"`
+	R *big.Int `json:"r" gencodec:"required" rlp:"optional"`
+	S *big.Int `json:"s" gencodec:"required" rlp:"optional"`
 }
 
 // copy creates a deep copy of the transaction data and initializes all fields.

--- a/core/types/legacy_tx.go
+++ b/core/types/legacy_tx.go
@@ -30,7 +30,7 @@ type LegacyTx struct {
 	To       *common.Address `rlp:"nil"` // nil means contract creation
 	Value    *big.Int        // wei amount
 	Data     []byte          // contract invocation input data
-	V, R, S  *big.Int        // signature values
+	V, R, S  *big.Int        `rlp:"optional"` // signature values
 }
 
 // NewTransaction creates an unsigned legacy transaction.

--- a/core/types/transaction_test.go
+++ b/core/types/transaction_test.go
@@ -19,6 +19,7 @@ package types
 import (
 	"bytes"
 	"crypto/ecdsa"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"math/big"
@@ -530,4 +531,42 @@ func assertEqual(orig *Transaction, cpy *Transaction) error {
 		}
 	}
 	return nil
+}
+
+func decodeRLP(txData string) (*Transaction, error) {
+	txDataBytes, err := hex.DecodeString(txData)
+	if err != nil {
+		return nil, err
+	}
+
+	tx := new(Transaction)
+	err = tx.UnmarshalBinary(txDataBytes)
+	if err != nil {
+		return nil, err
+	}
+
+	return tx, nil
+}
+
+func TestUnsignedTxDecode(t *testing.T) {
+	// rlp encoded transactions sending 0.001 ETH to vitalik
+	// each RLP payload is missing the signature data fields
+
+	txDatas := []string{
+		// dynamic fee tx
+		"02ee03808459682f008459682f0a82520894d8da6bf26964af9d7eed9e03e53415d37aa9604587038d7ea4c6800080c0",
+
+		// access list tx
+		"01f86501800a8301e24194d8da6bf26964af9d7eed9e03e53415d37aa9604587038d7ea4c6800086616263646566f838f7940000000000000000000000000000000000000001e1a00000000000000000000000000000000000000000000000000000000000000000",
+
+		// legacy tx
+		"e780020194d8da6bf26964af9d7eed9e03e53415d37aa9604587038d7ea4c6800086616263646566",
+	}
+
+	for _, data := range txDatas {
+		_, err := decodeRLP(data)
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
 }


### PR DESCRIPTION
This PR enhances RLP decoding for transactions to enable decoding unsigned transactions.

This is necessary for compatibility with other ethereum libraries and better communication between different systems. For example, ethereumjs does not include signature bytes at all when serializing an unsigned transaction -- https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/tx/src/eip1559Transaction.ts#L294-L305. Prior to this change, attempting to decode unsigned transactions serialized by ethereumjs would result in the following errors (depending on transaction type):

```
rlp: too few elements for types.LegacyTx
rlp: too few elements for types.AccessListTx
rlp: too few elements for types.DynamicFeeTx
```

This PR also adds tests to ensure that the decoding works on hardcoded example payloads.