### PR TITLE
Add -export.receipts flag to include receipts in exports

### DIFF
--- a/cmd/geth/chaincmd.go
+++ b/cmd/geth/chaincmd.go
@@ -108,6 +108,7 @@ processing will proceed even if an individual RLP-file import failure occurs.`,
 		Usage:     "Export blockchain into file",
 		ArgsUsage: "<filename> [<blockNumFirst> <blockNumLast>]",
 		Flags: append([]cli.Flag{
+			utils.ExportReceiptsFlag,
 			utils.CacheFlag,
 			utils.SyncModeFlag,
 		}, utils.DatabasePathFlags...),
@@ -311,7 +312,7 @@ func exportChain(ctx *cli.Context) error {
 	var err error
 	fp := ctx.Args().First()
 	if len(ctx.Args()) < 3 {
-		err = utils.ExportChain(chain, fp)
+		err = utils.ExportChain(chain, fp, ctx.GlobalBool(utils.ExportReceiptsFlag.Name))
 	} else {
 		// This can be improved to allow for numbers larger than 9223372036854775807
 		first, ferr := strconv.ParseInt(ctx.Args().Get(1), 10, 64)
@@ -325,7 +326,7 @@ func exportChain(ctx *cli.Context) error {
 		if head := chain.CurrentFastBlock(); uint64(last) > head.NumberU64() {
 			utils.Fatalf("Export error: block number %d larger than head block %d\n", uint64(last), head.NumberU64())
 		}
-		err = utils.ExportAppendChain(chain, fp, uint64(first), uint64(last))
+		err = utils.ExportAppendChain(chain, fp, uint64(first), uint64(last), ctx.GlobalBool(utils.ExportReceiptsFlag.Name))
 	}
 
 	if err != nil {

--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -153,6 +153,7 @@ var (
 		utils.MinerNotifyFullFlag,
 		utils.IgnoreLegacyReceiptsFlag,
 		configFileFlag,
+		utils.ExportReceiptsFlag,
 	}, utils.NetworkFlags, utils.DatabasePathFlags)
 
 	rpcFlags = []cli.Flag{

--- a/cmd/utils/cmd.go
+++ b/cmd/utils/cmd.go
@@ -238,7 +238,7 @@ func missingBlocks(chain *core.BlockChain, blocks []*types.Block) []*types.Block
 
 // ExportChain exports a blockchain into the specified file, truncating any data
 // already present in the file.
-func ExportChain(blockchain *core.BlockChain, fn string) error {
+func ExportChain(blockchain *core.BlockChain, fn string, receipts bool) error {
 	log.Info("Exporting blockchain", "file", fn)
 
 	// Open the file handle and potentially wrap with a gzip stream
@@ -254,7 +254,7 @@ func ExportChain(blockchain *core.BlockChain, fn string) error {
 		defer writer.(*gzip.Writer).Close()
 	}
 	// Iterate over the blocks and export them
-	if err := blockchain.Export(writer); err != nil {
+	if err := blockchain.Export(writer, receipts); err != nil {
 		return err
 	}
 	log.Info("Exported blockchain", "file", fn)
@@ -264,7 +264,7 @@ func ExportChain(blockchain *core.BlockChain, fn string) error {
 
 // ExportAppendChain exports a blockchain into the specified file, appending to
 // the file if data already exists in it.
-func ExportAppendChain(blockchain *core.BlockChain, fn string, first uint64, last uint64) error {
+func ExportAppendChain(blockchain *core.BlockChain, fn string, first uint64, last uint64, receipts bool) error {
 	log.Info("Exporting blockchain", "file", fn)
 
 	// Open the file handle and potentially wrap with a gzip stream
@@ -280,7 +280,7 @@ func ExportAppendChain(blockchain *core.BlockChain, fn string, first uint64, las
 		defer writer.(*gzip.Writer).Close()
 	}
 	// Iterate over the blocks and export them
-	if err := blockchain.ExportN(writer, first, last); err != nil {
+	if err := blockchain.ExportN(writer, first, last, receipts); err != nil {
 		return err
 	}
 	log.Info("Exported blockchain to", "file", fn)

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -829,6 +829,10 @@ var (
 		Usage: "InfluxDB organization name (v2 only)",
 		Value: metrics.DefaultConfig.InfluxDBOrganization,
 	}
+	ExportReceiptsFlag = cli.BoolFlag{
+		Name:  "export.receipts",
+		Usage: "Include receipts in exported blocks",
+	}
 )
 
 var (

--- a/eth/api.go
+++ b/eth/api.go
@@ -189,10 +189,10 @@ func (api *PrivateAdminAPI) ExportChain(file string, first *uint64, last *uint64
 
 	// Export the blockchain
 	if first != nil {
-		if err := api.eth.BlockChain().ExportN(writer, *first, *last); err != nil {
+		if err := api.eth.BlockChain().ExportN(writer, *first, *last, false); err != nil {
 			return false, err
 		}
-	} else if err := api.eth.BlockChain().Export(writer); err != nil {
+	} else if err := api.eth.BlockChain().Export(writer, false); err != nil {
 		return false, err
 	}
 	return true, nil


### PR DESCRIPTION
This PR adds a boolean `-export.receipts` flag to the `geth export` subcommand. When enabled, geth export's output format is modified to include receipts interleaved with blocks. Specifically, each block is encoded as it would be in a plain `geth export`, but is followed by the RLP serialization of an array of receipts. The flag defaults to false, making this change non-breaking.

The motivation for this feature is EIP-4444, which seeks to store historical headers, bodies, and receipts outside of the EL. This tool already uses the RLP exports with receipts: https://github.com/henridf/eip44s-proto.

