### PR TITLE
core/vm: correct logic for eip check of NewEVMInterpreter

### DIFF
--- a/core/vm/interpreter.go
+++ b/core/vm/interpreter.go
@@ -90,12 +90,13 @@ func NewEVMInterpreter(evm *EVM, cfg Config) *EVMInterpreter {
 		default:
 			cfg.JumpTable = &frontierInstructionSet
 		}
-		for i, eip := range cfg.ExtraEips {
+		for i := 0; i < len(cfg.ExtraEips); i++ {
 			copy := *cfg.JumpTable
-			if err := EnableEIP(eip, &copy); err != nil {
+			if err := EnableEIP(cfg.ExtraEips[i], &copy); err != nil {
 				// Disable it, so caller can check if it's activated or not
 				cfg.ExtraEips = append(cfg.ExtraEips[:i], cfg.ExtraEips[i+1:]...)
-				log.Error("EIP activation failed", "eip", eip, "error", err)
+				log.Error("EIP activation failed", "eip", cfg.ExtraEips[i], "error", err)
+				i--
 			}
 			cfg.JumpTable = &copy
 		}

--- a/core/vm/interpreter.go
+++ b/core/vm/interpreter.go
@@ -90,16 +90,18 @@ func NewEVMInterpreter(evm *EVM, cfg Config) *EVMInterpreter {
 		default:
 			cfg.JumpTable = &frontierInstructionSet
 		}
-		for i := 0; i < len(cfg.ExtraEips); i++ {
+		var extraEips []int
+		for _, eip := range cfg.ExtraEips {
 			copy := *cfg.JumpTable
-			if err := EnableEIP(cfg.ExtraEips[i], &copy); err != nil {
+			if err := EnableEIP(eip, &copy); err != nil {
 				// Disable it, so caller can check if it's activated or not
-				cfg.ExtraEips = append(cfg.ExtraEips[:i], cfg.ExtraEips[i+1:]...)
-				log.Error("EIP activation failed", "eip", cfg.ExtraEips[i], "error", err)
-				i--
+				log.Error("EIP activation failed", "eip", eip, "error", err)
+			} else {
+				extraEips = append(extraEips, eip)
 			}
 			cfg.JumpTable = &copy
 		}
+		cfg.ExtraEips = extraEips
 	}
 
 	return &EVMInterpreter{


### PR DESCRIPTION
### Description
current code logic of `for...range...`check to delete elements in slice is not correct, would skip checking the element next to the element be deleted of which error was detected.
```
for i, v := range slice{
   // check slice[i]
    slice = append(slice[:i], slice[i+1:]...)
}
```
### Rationale
backwards the index when delete element from a slice
```
for i:=0; i<len(slice); i++{
    // check slice[i]
    slice = append(slice[:i], slice[i+1:]...)
    i--
}
```
### Changes
`core/vm/interpreter.go : NewEVMInterpreter(...)`