### PR TITLE
rpc: add method which returns list of all API methods

### DIFF
--- a/ethclient/gethclient/gethclient.go
+++ b/ethclient/gethclient/gethclient.go
@@ -180,6 +180,12 @@ func (ec *Client) SubscribePendingTransactions(ctx context.Context, ch chan<- co
 	return ec.c.EthSubscribe(ctx, ch, "newPendingTransactions")
 }
 
+func (ec *Client) RPCMethods(ctx context.Context) (map[string][]string, error) {
+	var result map[string][]string
+	err := ec.c.CallContext(ctx, &result, "rpc_methods")
+	return result, err
+}
+
 func toBlockNumArg(number *big.Int) string {
 	if number == nil {
 		return "latest"

--- a/ethclient/gethclient/gethclient.go
+++ b/ethclient/gethclient/gethclient.go
@@ -180,9 +180,9 @@ func (ec *Client) SubscribePendingTransactions(ctx context.Context, ch chan<- co
 	return ec.c.EthSubscribe(ctx, ch, "newPendingTransactions")
 }
 
-func (ec *Client) RPCMethods(ctx context.Context) (map[string][]string, error) {
+func (ec *Client) RPCMethods(ctx context.Context, includeSubscriptions bool) (map[string][]string, error) {
 	var result map[string][]string
-	err := ec.c.CallContext(ctx, &result, "rpc_methods")
+	err := ec.c.CallContext(ctx, &result, "rpc_methods", includeSubscriptions)
 	return result, err
 }
 

--- a/internal/web3ext/web3ext.go
+++ b/internal/web3ext/web3ext.go
@@ -747,6 +747,10 @@ web3._extend({
 			name: 'modules',
 			getter: 'rpc_modules'
 		}),
+		new web3._extend.Property({
+			name: 'methods',
+			getter: 'rpc_methods'
+		}),
 	]
 });
 `

--- a/internal/web3ext/web3ext.go
+++ b/internal/web3ext/web3ext.go
@@ -749,7 +749,8 @@ web3._extend({
 		}),
 		new web3._extend.Property({
 			name: 'methods',
-			getter: 'rpc_methods'
+			getter: 'rpc_methods',
+			params: 1,
 		}),
 	]
 });

--- a/rpc/server.go
+++ b/rpc/server.go
@@ -18,7 +18,6 @@ package rpc
 
 import (
 	"context"
-	"fmt"
 	"io"
 	"sync/atomic"
 
@@ -142,12 +141,8 @@ func (s *RPCService) Modules() map[string]string {
 	defer s.server.services.mu.Unlock()
 
 	modules := make(map[string]string)
-	for name, service := range s.server.services.services {
+	for name := range s.server.services.services {
 		modules[name] = "1.0"
-		for mname := range service.callbacks {
-			fmt.Printf("%s:%s, ", name, mname)
-		}
-		fmt.Printf("\n")
 	}
 	return modules
 }

--- a/rpc/server.go
+++ b/rpc/server.go
@@ -148,7 +148,7 @@ func (s *RPCService) Modules() map[string]string {
 }
 
 // Methods returns the list of methods for each RPC service.
-func (s *RPCService) Methods() map[string][]string {
+func (s *RPCService) Methods(includeSubscriptions bool) map[string][]string {
 	s.server.services.mu.Lock()
 	defer s.server.services.mu.Unlock()
 
@@ -162,6 +162,11 @@ func (s *RPCService) Methods() map[string][]string {
 		methods[name] = make([]string, 0, len(service.callbacks))
 		for mname := range service.callbacks {
 			methods[name] = append(methods[name], mname)
+		}
+		if includeSubscriptions {
+			for mname := range service.subscriptions {
+				methods[name] = append(methods[name], mname)
+			}
 		}
 	}
 	return methods


### PR DESCRIPTION
I'm writing a script which compares the methods defined in the website against those exposed by the client so we can more easily find discrepancies.