### PR TITLE
cmd/geth: make dumpgenesis command load genesis from the datadir if it exists

### DIFF
--- a/cmd/geth/chaincmd.go
+++ b/cmd/geth/chaincmd.go
@@ -62,7 +62,6 @@ It expects the genesis file as argument.`,
 		Usage:     "Dumps genesis block JSON configuration to stdout",
 		ArgsUsage: "",
 		Flags:     append([]cli.Flag{utils.DataDirFlag}, utils.NetworkFlags...),
-		Category:  "BLOCKCHAIN COMMANDS",
 		Description: `
 The dumpgenesis command prints the genesis configuration of the network preset
 if one is set.  Otherwise it prints the genesis from the datadir.`,

--- a/cmd/geth/chaincmd.go
+++ b/cmd/geth/chaincmd.go
@@ -61,9 +61,11 @@ It expects the genesis file as argument.`,
 		Name:      "dumpgenesis",
 		Usage:     "Dumps genesis block JSON configuration to stdout",
 		ArgsUsage: "",
-		Flags:     utils.NetworkFlags,
+		Flags:     append([]cli.Flag{utils.DataDirFlag}, utils.NetworkFlags...),
+		Category:  "BLOCKCHAIN COMMANDS",
 		Description: `
-The dumpgenesis command prints a genesis block as JSON. What it outputs is determined in order of preference: testnet preset if it is set, preexisting datadir, mainnet.`,
+The dumpgenesis command prints the genesis configuration of the network preset
+if one is set.  Otherwise it prints the genesis from the datadir.`,
 	}
 	importCommand = &cli.Command{
 		Action:    importChain,
@@ -204,7 +206,7 @@ func initGenesis(ctx *cli.Context) error {
 
 func dumpGenesis(ctx *cli.Context) error {
 	// if there is a testnet preset enabled, dump that
-	if utils.IsTestnetPreset(ctx) {
+	if utils.IsNetworkPreset(ctx) {
 		genesis := utils.MakeGenesis(ctx)
 		if err := json.NewEncoder(os.Stdout).Encode(genesis); err != nil {
 			utils.Fatalf("could not encode genesis: %s", err)
@@ -232,13 +234,10 @@ func dumpGenesis(ctx *cli.Context) error {
 		}
 		return nil
 	}
-	if ctx.GlobalIsSet(utils.DataDirFlag.Name) {
+	if ctx.IsSet(utils.DataDirFlag.Name) {
 		utils.Fatalf("no existing datadir at %s", stack.Config().DataDir)
 	}
-	// no datadir exists or is specified, dump mainnet
-	if err := json.NewEncoder(os.Stdout).Encode(core.DefaultGenesisBlock()); err != nil {
-		utils.Fatalf("could not encode genesis: %s", err)
-	}
+	utils.Fatalf("no network preset provided.  no exisiting genesis in the default datadir")
 	return nil
 }
 

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -988,9 +988,7 @@ var (
 		KilnFlag,
 	}
 	// NetworkFlags is the flag group of all built-in supported networks.
-	NetworkFlags = append([]cli.Flag{
-		MainnetFlag,
-	}, TestnetFlags...)
+	NetworkFlags = append([]cli.Flag{MainnetFlag}, TestnetFlags...)
 
 	// DatabasePathFlags is the flag group of all database path flags.
 	DatabasePathFlags = []cli.Flag{
@@ -2141,13 +2139,11 @@ func MakeChainDatabase(ctx *cli.Context, stack *node.Node, readonly bool) ethdb.
 }
 
 func IsNetworkPreset(ctx *cli.Context) bool {
-	for _, flag := range TestnetFlags {
-		if ctx.Bool(flag.String()) {
+	for _, flag := range NetworkFlags {
+		bFlag, _ := flag.(*cli.BoolFlag)
+		if ctx.IsSet(bFlag.Name) {
 			return true
 		}
-	}
-	if ctx.Bool(MainnetFlag.Name) {
-		return true
 	}
 	return false
 }

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -2141,8 +2141,10 @@ func MakeChainDatabase(ctx *cli.Context, stack *node.Node, readonly bool) ethdb.
 }
 
 func IsTestnetPreset(ctx *cli.Context) bool {
-	if ctx.GlobalBool(RopstenFlag.Name) || ctx.GlobalBool(SepoliaFlag.Name) || ctx.GlobalBool(RinkebyFlag.Name) || ctx.GlobalBool(GoerliFlag.Name) || ctx.GlobalBool(KilnFlag.Name) || ctx.GlobalBool(DeveloperFlag.Name) {
-		return true
+	for _, flag := range TestnetFlags {
+		if ctx.GlobalBool(flag.GetName()) {
+			return true
+		}
 	}
 	return false
 }

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -2140,11 +2140,14 @@ func MakeChainDatabase(ctx *cli.Context, stack *node.Node, readonly bool) ethdb.
 	return chainDb
 }
 
-func IsTestnetPreset(ctx *cli.Context) bool {
+func IsNetworkPreset(ctx *cli.Context) bool {
 	for _, flag := range TestnetFlags {
-		if ctx.GlobalBool(flag.GetName()) {
+		if ctx.Bool(flag.String()) {
 			return true
 		}
+	}
+	if ctx.Bool(MainnetFlag.Name) {
+		return true
 	}
 	return false
 }

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -2140,6 +2140,13 @@ func MakeChainDatabase(ctx *cli.Context, stack *node.Node, readonly bool) ethdb.
 	return chainDb
 }
 
+func IsTestnetPreset(ctx *cli.Context) bool {
+	if ctx.GlobalBool(RopstenFlag.Name) || ctx.GlobalBool(SepoliaFlag.Name) || ctx.GlobalBool(RinkebyFlag.Name) || ctx.GlobalBool(GoerliFlag.Name) || ctx.GlobalBool(KilnFlag.Name) || ctx.GlobalBool(DeveloperFlag.Name) {
+		return true
+	}
+	return false
+}
+
 func MakeGenesis(ctx *cli.Context) *core.Genesis {
 	var genesis *core.Genesis
 	switch {

--- a/core/genesis.go
+++ b/core/genesis.go
@@ -65,6 +65,41 @@ type Genesis struct {
 	BaseFee    *big.Int    `json:"baseFeePerGas"`
 }
 
+func ReadGenesis(db ethdb.Database) (*Genesis, error) {
+	var genesis Genesis
+	stored := rawdb.ReadCanonicalHash(db, 0)
+	if (stored == common.Hash{}) {
+		return nil, fmt.Errorf("invalid genesis hash in database: %x", stored)
+	}
+	blob := rawdb.ReadGenesisState(db, stored)
+	if blob == nil {
+		return nil, fmt.Errorf("genesis state missing from db")
+	}
+	if len(blob) != 0 {
+		if err := genesis.Alloc.UnmarshalJSON(blob); err != nil {
+			return nil, fmt.Errorf("could not unmartial genesis state json: %s", err)
+		}
+	}
+	genesis.Config = rawdb.ReadChainConfig(db, stored)
+	if genesis.Config == nil {
+		return nil, fmt.Errorf("genesis config missing from db")
+	}
+	genesisBlock := rawdb.ReadBlock(db, stored, 0)
+	if genesisBlock == nil {
+		return nil, fmt.Errorf("genesis block missing from db")
+	}
+	genesisHeader := genesisBlock.Header()
+	genesis.Nonce = genesisHeader.Nonce.Uint64()
+	genesis.Timestamp = genesisHeader.Time
+	genesis.ExtraData = genesisHeader.Extra
+	genesis.GasLimit = genesisHeader.GasLimit
+	genesis.Difficulty = genesisHeader.Difficulty
+	genesis.Mixhash = genesisHeader.MixDigest
+	genesis.Coinbase = genesisHeader.Coinbase
+
+	return &genesis, nil
+}
+
 // GenesisAlloc specifies the initial state that is part of the genesis block.
 type GenesisAlloc map[common.Address]GenesisAccount
 

--- a/core/genesis.go
+++ b/core/genesis.go
@@ -77,7 +77,7 @@ func ReadGenesis(db ethdb.Database) (*Genesis, error) {
 	}
 	if len(blob) != 0 {
 		if err := genesis.Alloc.UnmarshalJSON(blob); err != nil {
-			return nil, fmt.Errorf("could not unmartial genesis state json: %s", err)
+			return nil, fmt.Errorf("could not unmarshal genesis state json: %s", err)
 		}
 	}
 	genesis.Config = rawdb.ReadChainConfig(db, stored)

--- a/core/genesis.go
+++ b/core/genesis.go
@@ -71,7 +71,7 @@ func ReadGenesis(db ethdb.Database) (*Genesis, error) {
 	if (stored == common.Hash{}) {
 		return nil, fmt.Errorf("invalid genesis hash in database: %x", stored)
 	}
-	blob := rawdb.ReadGenesisState(db, stored)
+	blob := rawdb.ReadGenesisStateSpec(db, stored)
 	if blob == nil {
 		return nil, fmt.Errorf("genesis state missing from db")
 	}


### PR DESCRIPTION
`geth dumpgenesis` current does not respect the content of the data directory. Instead, it outputs the genesis block created by command-line flags. This PR fixes it to read the genesis from the database, if the database already exists.