### PR TITLE
core: apply ttd override to uninitialized db

### DIFF
--- a/core/genesis.go
+++ b/core/genesis.go
@@ -237,6 +237,10 @@ func SetupGenesisBlockWithOverride(db ethdb.Database, genesis *Genesis, override
 	if genesis != nil && genesis.Config == nil {
 		return params.AllEthashProtocolChanges, common.Hash{}, errGenesisNoConfig
 	}
+	// Apply the TTD override to uninitialized databases too.
+	if overrideTerminalTotalDifficulty != nil {
+		genesis.Config.TerminalTotalDifficulty = overrideTerminalTotalDifficulty
+	}
 	// Just commit the new block if there is no stored genesis block.
 	stored := rawdb.ReadCanonicalHash(db, 0)
 	if (stored == common.Hash{}) {

--- a/core/genesis.go
+++ b/core/genesis.go
@@ -237,10 +237,18 @@ func SetupGenesisBlockWithOverride(db ethdb.Database, genesis *Genesis, override
 	if genesis != nil && genesis.Config == nil {
 		return params.AllEthashProtocolChanges, common.Hash{}, errGenesisNoConfig
 	}
-	// Apply the TTD override to uninitialized databases too.
-	if overrideTerminalTotalDifficulty != nil {
-		genesis.Config.TerminalTotalDifficulty = overrideTerminalTotalDifficulty
+
+	applyOverrides := func(config *params.ChainConfig) {
+		if config != nil {
+			if overrideTerminalTotalDifficulty != nil {
+				config.TerminalTotalDifficulty = overrideTerminalTotalDifficulty
+			}
+			if overrideGrayGlacier != nil {
+				config.GrayGlacierBlock = overrideGrayGlacier
+			}
+		}
 	}
+
 	// Just commit the new block if there is no stored genesis block.
 	stored := rawdb.ReadCanonicalHash(db, 0)
 	if (stored == common.Hash{}) {
@@ -254,6 +262,7 @@ func SetupGenesisBlockWithOverride(db ethdb.Database, genesis *Genesis, override
 		if err != nil {
 			return genesis.Config, common.Hash{}, err
 		}
+		applyOverrides(genesis.Config)
 		return genesis.Config, block.Hash(), nil
 	}
 	// We have the genesis block in database(perhaps in ancient database)
@@ -272,6 +281,7 @@ func SetupGenesisBlockWithOverride(db ethdb.Database, genesis *Genesis, override
 		if err != nil {
 			return genesis.Config, hash, err
 		}
+		applyOverrides(genesis.Config)
 		return genesis.Config, block.Hash(), nil
 	}
 	// Check whether the genesis block is already written.
@@ -283,12 +293,7 @@ func SetupGenesisBlockWithOverride(db ethdb.Database, genesis *Genesis, override
 	}
 	// Get the existing chain configuration.
 	newcfg := genesis.configOrDefault(stored)
-	if overrideGrayGlacier != nil {
-		newcfg.GrayGlacierBlock = overrideGrayGlacier
-	}
-	if overrideTerminalTotalDifficulty != nil {
-		newcfg.TerminalTotalDifficulty = overrideTerminalTotalDifficulty
-	}
+	applyOverrides(newcfg)
 	if err := newcfg.CheckConfigForkOrder(); err != nil {
 		return newcfg, common.Hash{}, err
 	}
@@ -305,12 +310,7 @@ func SetupGenesisBlockWithOverride(db ethdb.Database, genesis *Genesis, override
 	// apply the overrides.
 	if genesis == nil && stored != params.MainnetGenesisHash {
 		newcfg = storedcfg
-		if overrideGrayGlacier != nil {
-			newcfg.GrayGlacierBlock = overrideGrayGlacier
-		}
-		if overrideTerminalTotalDifficulty != nil {
-			newcfg.TerminalTotalDifficulty = overrideTerminalTotalDifficulty
-		}
+		applyOverrides(newcfg)
 	}
 	// Check config compatibility and write the config. Compatibility errors
 	// are returned to the caller unless we're already at block zero.


### PR DESCRIPTION
This PR fixes #25133. The issue is that if the datadir is uninitialized (or we're missing the state for the genesis block) we don't apply the overrideTTD flag correctly.  