### PR TITLE
miner: retrieve mining state from live database

### DIFF
--- a/miner/miner.go
+++ b/miner/miner.go
@@ -40,7 +40,6 @@ import (
 type Backend interface {
 	BlockChain() *core.BlockChain
 	TxPool() *core.TxPool
-	StateAtBlock(block *types.Block, reexec uint64, base *state.StateDB, checkLive bool, preferDisk bool) (statedb *state.StateDB, err error)
 }
 
 // Config is the configuration parameters of mining.

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -757,16 +757,6 @@ func (w *worker) makeEnv(parent *types.Block, header *types.Header, coinbase com
 	// the miner to speed block sealing up a bit.
 	state, err := w.chain.StateAt(parent.Root())
 	if err != nil {
-		// Note since the sealing block can be created upon the arbitrary parent
-		// block, but the state of parent block may already be pruned, so the necessary
-		// state recovery is needed here in the future.
-		//
-		// The maximum acceptable reorg depth can be limited by the finalised block
-		// somehow. TODO(rjl493456442) fix the hard-coded number here later.
-		state, err = w.eth.StateAtBlock(parent, 1024, nil, false, false)
-		log.Warn("Recovered mining state", "root", parent.Root(), "err", err)
-	}
-	if err != nil {
 		return nil, err
 	}
 	state.StartPrefetcher("miner")


### PR DESCRIPTION
This PR drops the necessity of recovering state for mining block.

In PoW, the state of head block is always used as base for preparing a mining block. It's unnecessary to recover state at all.
In PoS, the mining block is always generated with a `ForkchoiceUpdatedV1` request from consensus client with the head block specified. It means the base state should always be prepared for new mining block.

All in all, it's unnecessary to have this complicated mechanism for recovering a state for new mining block.