### PR TITLE
console: use all APIs if rpc_module not found

### DIFF
--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -773,6 +773,11 @@ var (
 		Usage:    "Allow for unprotected (non EIP155 signed) transactions to be submitted via RPC",
 		Category: flags.APICategory,
 	}
+	HeaderFlag = &cli.StringSliceFlag{
+		Name:     "header",
+		Usage:    "Set an HTTP header. <header:value>",
+		Category: flags.APICategory,
+	}
 
 	// Network Settings
 	MaxPeersFlag = &cli.IntFlag{


### PR DESCRIPTION
Use all api modules if "rpc_module" not found for external api services (such as infura) in the console.
And added header flags for rpc client.