### PR TITLE
internal/ethapi: explicitly return chain id for EIP-155 legacy txs

### DIFF
--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -1283,6 +1283,11 @@ func newRPCTransaction(tx *types.Transaction, blockHash common.Hash, blockNumber
 		result.TransactionIndex = (*hexutil.Uint64)(&index)
 	}
 	switch tx.Type() {
+	case types.LegacyTxType:
+		// if a legacy transaction has an EIP-155 chain id, include it explicitly
+		if id := tx.ChainId(); id.Sign() == 0 {
+			result.ChainID = (*hexutil.Big)(id)
+		}
 	case types.AccessListTxType:
 		al := tx.AccessList()
 		result.Accesses = &al


### PR DESCRIPTION
Partially fixes #25141.

```console
$ geth --dev console
> eth.sendTransaction({"from": personal.listAccounts[0], "to": personal.listAccounts[0]})
"0x3ca1cc849ce362a83369aa6925287b616632e195c9f5c5fb10f8923d56298cfa"
> eth.getTransaction("0x3ca1cc849ce362a83369aa6925287b616632e195c9f5c5fb10f8923d56298cfa")
{
  accessList: [],
  blockHash: "0xe706635bf933e3b9d4ae3d6f245af30e5c15f3f8278501a4e59d5b40c61c0fdd",
  blockNumber: 1,
  chainId: "0x539",
  from: "0x579d7d50c7c69203dde8c46efb3b383ae948d0a9",
  gas: 21000,
  gasPrice: 875000001,
  hash: "0x3ca1cc849ce362a83369aa6925287b616632e195c9f5c5fb10f8923d56298cfa",
  input: "0x",
  maxFeePerGas: 2000000001,
  maxPriorityFeePerGas: 1,
  nonce: 0,
  r: "0xac23f21e665937e1777448d96f47a088b1423a7006322bf8d021f4a1f1e921a",
  s: "0x7c1b44c81699db53a249c0af97a5faf50771d7a532bd6d9ad1a29f8031549642",
  to: "0x579d7d50c7c69203dde8c46efb3b383ae948d0a9",
  transactionIndex: 0,
  type: "0x2",
  v: "0x0",
  value: 0
}
```