### PR TITLE
eth/tracers: optimize goja buffer conversion

### DIFF
--- a/eth/tracers/js/goja.go
+++ b/eth/tracers/js/goja.go
@@ -759,7 +759,7 @@ func (co *contractObj) GetValue() goja.Value {
 }
 
 func (co *contractObj) GetInput() goja.Value {
-	input := co.contract.Input
+	input := common.CopyBytes(co.contract.Input)
 	res, err := co.toBuf(co.vm, input)
 	if err != nil {
 		co.vm.Interrupt(err)

--- a/eth/tracers/js/goja.go
+++ b/eth/tracers/js/goja.go
@@ -55,7 +55,7 @@ type fromBufFn = func(vm *goja.Runtime, buf goja.Value, allowString bool) ([]byt
 
 func toBuf(vm *goja.Runtime, bufType goja.Value, val []byte) (goja.Value, error) {
 	// bufType is usually Uint8Array. This is equivalent to `new Uint8Array(val)` in JS.
-	res, err := vm.New(bufType, vm.ToValue(val))
+	res, err := vm.New(bufType, vm.ToValue(vm.NewArrayBuffer(val)))
 	if err != nil {
 		return nil, err
 	}
@@ -81,11 +81,11 @@ func fromBuf(vm *goja.Runtime, bufType goja.Value, buf goja.Value, allowString b
 		if !obj.Get("constructor").SameAs(bufType) {
 			break
 		}
-		var b []byte
-		if err := vm.ExportTo(buf, &b); err != nil {
+		var b goja.ArrayBuffer
+		if err := vm.ExportTo(obj.Get("buffer"), &b); err != nil {
 			return nil, err
 		}
-		return b, nil
+		return b.Bytes(), nil
 	}
 	return nil, fmt.Errorf("invalid buffer type")
 }

--- a/eth/tracers/js/goja.go
+++ b/eth/tracers/js/goja.go
@@ -70,6 +70,7 @@ func fromBuf(vm *goja.Runtime, bufType goja.Value, buf goja.Value, allowString b
 			break
 		}
 		return common.FromHex(obj.String()), nil
+
 	case "Array":
 		var b []byte
 		if err := vm.ExportTo(buf, &b); err != nil {
@@ -81,11 +82,8 @@ func fromBuf(vm *goja.Runtime, bufType goja.Value, buf goja.Value, allowString b
 		if !obj.Get("constructor").SameAs(bufType) {
 			break
 		}
-		var b goja.ArrayBuffer
-		if err := vm.ExportTo(obj.Get("buffer"), &b); err != nil {
-			return nil, err
-		}
-		return b.Bytes(), nil
+		b := obj.Get("buffer").Export().(goja.ArrayBuffer).Bytes()
+		return b, nil
 	}
 	return nil, fmt.Errorf("invalid buffer type")
 }

--- a/eth/tracers/js/goja.go
+++ b/eth/tracers/js/goja.go
@@ -55,11 +55,7 @@ type fromBufFn = func(vm *goja.Runtime, buf goja.Value, allowString bool) ([]byt
 
 func toBuf(vm *goja.Runtime, bufType goja.Value, val []byte) (goja.Value, error) {
 	// bufType is usually Uint8Array. This is equivalent to `new Uint8Array(val)` in JS.
-	res, err := vm.New(bufType, vm.ToValue(vm.NewArrayBuffer(val)))
-	if err != nil {
-		return nil, err
-	}
-	return vm.ToValue(res), nil
+	return vm.New(bufType, vm.ToValue(vm.NewArrayBuffer(val)))
 }
 
 func fromBuf(vm *goja.Runtime, bufType goja.Value, buf goja.Value, allowString bool) ([]byte, error) {


### PR DESCRIPTION
It seems like going directly from a byte array to `Uint8Array` incurs more copying than going through an `ArrayBuffer` which typed arrays use as the underlying buffer.

Testing this on block 14996244. Before:

```console
Duktape prestateTracerLegacy for block 14996244: 8785ms
Goja prestateTracerLegacy for block 14996244: 17213ms
```

After:

```console
Duktape prestateTracerLegacy for block 14996244: 8913ms
Goja prestateTracerLegacy for block 14996244: 8743ms
```

Fixes #25125