### PR TITLE
internal/ethapi: error if tx args includes chain id that doesn't match local

### DIFF
--- a/internal/ethapi/transaction_args.go
+++ b/internal/ethapi/transaction_args.go
@@ -165,8 +165,16 @@ func (args *TransactionArgs) setDefaults(ctx context.Context, b Backend) error {
 		args.Gas = &estimated
 		log.Trace("Estimate gas usage automatically", "gas", args.Gas)
 	}
-	if args.ChainID == nil {
-		id := (*hexutil.Big)(b.ChainConfig().ChainID)
+	// If chain id is provided, ensure it matches the local chain id. Otherwise, set the local
+	// chain id as the default.
+	want := b.ChainConfig().ChainID
+	if args.ChainID != nil {
+		got := (*big.Int)(args.ChainID)
+		if want.Cmp(got) != 0 {
+			return fmt.Errorf("chainId does not match local (got=%s, want=%s)", got.String(), want.String())
+		}
+	} else {
+		id := (*hexutil.Big)(want)
 		args.ChainID = id
 	}
 	return nil

--- a/internal/ethapi/transaction_args.go
+++ b/internal/ethapi/transaction_args.go
@@ -169,13 +169,11 @@ func (args *TransactionArgs) setDefaults(ctx context.Context, b Backend) error {
 	// chain id as the default.
 	want := b.ChainConfig().ChainID
 	if args.ChainID != nil {
-		got := (*big.Int)(args.ChainID)
-		if want.Cmp(got) != 0 {
-			return fmt.Errorf("chainId does not match local (got=%s, want=%s)", got.String(), want.String())
+		if have := (*big.Int)(args.ChainID); have.Cmp(want) != 0 {
+			return fmt.Errorf("chainId does not match node's (have=%v, want=%v)", have, want)
 		}
 	} else {
-		id := (*hexutil.Big)(want)
-		args.ChainID = id
+		args.ChainID = (*hexutil.Big)(want)
 	}
 	return nil
 }


### PR DESCRIPTION
Partially closes #25141.

```console
$ geth --dev console
> eth.sendTransaction({"from": personal.listAccounts[0], "to": personal.listAccounts[0], "chainId": "0x123"})
Error: chain id does not match local (got=291, want=1337)
        at web3.js:6365:9(45)
        at send (web3.js:5099:62(34))
        at <eval>:1:20(16)
> eth.sendTransaction({"from": personal.listAccounts[0], "to": personal.listAccounts[0], "chainId": "0x539"})
"0x2ae33c38f61d2b15f11b8af4298c9b12e53d0ac55b17209487d2f4f5d5a56ac6"
```