### PR TITLE
core/state/snapshot: add log.Lvl to snapshot generator Log fn signature

### DIFF
--- a/core/state/snapshot/context.go
+++ b/core/state/snapshot/context.go
@@ -46,9 +46,9 @@ type generatorStats struct {
 	storage  common.StorageSize // Total account and storage slot size(generation or recovery)
 }
 
-// Log creates an contextual log with the given message and the context pulled
+// Log creates an contextual log with the given log level and message and the context pulled
 // from the internally maintained statistics.
-func (gs *generatorStats) Log(msg string, root common.Hash, marker []byte) {
+func (gs *generatorStats) Log(logLvl log.Lvl, msg string, root common.Hash, marker []byte) {
 	var ctx []interface{}
 	if root != (common.Hash{}) {
 		ctx = append(ctx, []interface{}{"root", root}...)
@@ -82,7 +82,7 @@ func (gs *generatorStats) Log(msg string, root common.Hash, marker []byte) {
 			}...)
 		}
 	}
-	log.Info(msg, ctx...)
+	log.Output(msg, logLvl, 0, ctx...)
 }
 
 // generatorContext carries a few global values to be shared by all generation functions.

--- a/core/state/snapshot/generate.go
+++ b/core/state/snapshot/generate.go
@@ -250,7 +250,7 @@ func (dl *diskLayer) proveRange(ctx *generatorContext, owner common.Hash, root c
 	// Snap state is chunked, generate edge proofs for verification.
 	tr, err := trie.New(owner, root, dl.triedb)
 	if err != nil {
-		ctx.stats.Log("Trie missing, state snapshotting paused", dl.root, dl.genMarker)
+		ctx.stats.Log(log.LvlWarn, "Trie missing, state snapshotting paused", dl.root, dl.genMarker)
 		return nil, errMissingTrie
 	}
 	// Firstly find out the key of last iterated element.
@@ -376,7 +376,7 @@ func (dl *diskLayer) generateRange(ctx *generatorContext, owner common.Hash, roo
 	if tr == nil {
 		tr, err = trie.New(owner, root, dl.triedb)
 		if err != nil {
-			ctx.stats.Log("Trie missing, state snapshotting paused", dl.root, dl.genMarker)
+			ctx.stats.Log(log.LvlWarn, "Trie missing, state snapshotting paused", dl.root, dl.genMarker)
 			return false, nil, errMissingTrie
 		}
 	}
@@ -492,7 +492,7 @@ func (dl *diskLayer) checkAndFlush(ctx *generatorContext, current []byte) error 
 		dl.lock.Unlock()
 
 		if abort != nil {
-			ctx.stats.Log("Aborting state snapshot generation", dl.root, current)
+			ctx.stats.Log(log.LvlDebug, "Aborting state snapshot generation", dl.root, current)
 			return newAbortErr(abort) // bubble up an error for interruption
 		}
 		// Don't hold the iterators too long, release them to let compactor works
@@ -500,7 +500,7 @@ func (dl *diskLayer) checkAndFlush(ctx *generatorContext, current []byte) error 
 		ctx.reopenIterator(snapStorage)
 	}
 	if time.Since(ctx.logged) > 8*time.Second {
-		ctx.stats.Log("Generating state snapshot", dl.root, current)
+		ctx.stats.Log(log.LvlInfo, "Generating state snapshot", dl.root, current)
 		ctx.logged = time.Now()
 	}
 	return nil
@@ -666,7 +666,7 @@ func (dl *diskLayer) generate(stats *generatorStats) {
 	if len(dl.genMarker) > 0 { // []byte{} is the start, use nil for that
 		accMarker = dl.genMarker[:common.HashLength]
 	}
-	stats.Log("Resuming state snapshot generation", dl.root, dl.genMarker)
+	stats.Log(log.LvlDebug, "Resuming state snapshot generation", dl.root, dl.genMarker)
 
 	// Initialize the global generator context. The snapshot iterators are
 	// opened at the interrupted position because the assumption is held

--- a/core/state/snapshot/journal.go
+++ b/core/state/snapshot/journal.go
@@ -199,7 +199,7 @@ func (dl *diskLayer) Journal(buffer *bytes.Buffer) (common.Hash, error) {
 		dl.genAbort <- abort
 
 		if stats = <-abort; stats != nil {
-			stats.Log("Journalling in-progress snapshot", dl.root, dl.genMarker)
+			stats.Log(log.LvlInfo, "Journalling in-progress snapshot", dl.root, dl.genMarker)
 		}
 	}
 	// Ensure the layer didn't get stale


### PR DESCRIPTION
This allows variable log levels across the
multiple uses of this stats printer.

This logger used to print a LOT of
Aborting/Resuming log lines which spammed
the user at log.Info.

This patch moves (apparently) 'normal' logs
to Debug, erroring (missing trie) logs to Warn,
and interval-based (/8sec) logs to Info.

![image](https://user-images.githubusercontent.com/45600330/175359328-3f184e68-b056-41f6-9037-548a766b5425.png)
