### PR TITLE
core: eth: rpc: implement safe rpc block

### DIFF
--- a/core/blockchain_reader.go
+++ b/core/blockchain_reader.go
@@ -55,6 +55,12 @@ func (bc *BlockChain) CurrentFinalizedBlock() *types.Block {
 	return bc.currentFinalizedBlock.Load().(*types.Block)
 }
 
+// CurrentSafeBlock retrieves the current safe block of the canonical
+// chain. The block is retrieved from the blockchain's internal cache.
+func (bc *BlockChain) CurrentSafeBlock() *types.Block {
+	return bc.currentSafeBlock.Load().(*types.Block)
+}
+
 // HasHeader checks if a block header is present in the database or not, caching
 // it if present.
 func (bc *BlockChain) HasHeader(hash common.Hash, number uint64) bool {

--- a/eth/api.go
+++ b/eth/api.go
@@ -272,6 +272,8 @@ func (api *DebugAPI) DumpBlock(blockNr rpc.BlockNumber) (state.Dump, error) {
 		block = api.eth.blockchain.CurrentBlock()
 	} else if blockNr == rpc.FinalizedBlockNumber {
 		block = api.eth.blockchain.CurrentFinalizedBlock()
+	} else if blockNr == rpc.SafeBlockNumber {
+		block = api.eth.blockchain.CurrentSafeBlock()
 	} else {
 		block = api.eth.blockchain.GetBlockByNumber(uint64(blockNr))
 	}
@@ -350,6 +352,8 @@ func (api *DebugAPI) AccountRange(blockNrOrHash rpc.BlockNumberOrHash, start hex
 				block = api.eth.blockchain.CurrentBlock()
 			} else if number == rpc.FinalizedBlockNumber {
 				block = api.eth.blockchain.CurrentFinalizedBlock()
+			} else if number == rpc.SafeBlockNumber {
+				block = api.eth.blockchain.CurrentSafeBlock()
 			} else {
 				block = api.eth.blockchain.GetBlockByNumber(uint64(number))
 			}

--- a/eth/api_backend.go
+++ b/eth/api_backend.go
@@ -76,6 +76,9 @@ func (b *EthAPIBackend) HeaderByNumber(ctx context.Context, number rpc.BlockNumb
 	if number == rpc.FinalizedBlockNumber {
 		return b.eth.blockchain.CurrentFinalizedBlock().Header(), nil
 	}
+	if number == rpc.SafeBlockNumber {
+		return b.eth.blockchain.CurrentSafeBlock().Header(), nil
+	}
 	return b.eth.blockchain.GetHeaderByNumber(uint64(number)), nil
 }
 
@@ -112,6 +115,9 @@ func (b *EthAPIBackend) BlockByNumber(ctx context.Context, number rpc.BlockNumbe
 	}
 	if number == rpc.FinalizedBlockNumber {
 		return b.eth.blockchain.CurrentFinalizedBlock(), nil
+	}
+	if number == rpc.SafeBlockNumber {
+		return b.eth.blockchain.CurrentSafeBlock(), nil
 	}
 	return b.eth.blockchain.GetBlockByNumber(uint64(number)), nil
 }

--- a/eth/api_backend.go
+++ b/eth/api_backend.go
@@ -74,10 +74,18 @@ func (b *EthAPIBackend) HeaderByNumber(ctx context.Context, number rpc.BlockNumb
 		return b.eth.blockchain.CurrentBlock().Header(), nil
 	}
 	if number == rpc.FinalizedBlockNumber {
-		return b.eth.blockchain.CurrentFinalizedBlock().Header(), nil
+		block := b.eth.blockchain.CurrentFinalizedBlock()
+		if block != nil {
+			return block.Header(), nil
+		}
+		return nil, errors.New("finalized block not found")
 	}
 	if number == rpc.SafeBlockNumber {
-		return b.eth.blockchain.CurrentSafeBlock().Header(), nil
+		block := b.eth.blockchain.CurrentSafeBlock()
+		if block != nil {
+			return block.Header(), nil
+		}
+		return nil, errors.New("safe block not found")
 	}
 	return b.eth.blockchain.GetHeaderByNumber(uint64(number)), nil
 }

--- a/eth/catalyst/api.go
+++ b/eth/catalyst/api.go
@@ -191,6 +191,8 @@ func (api *ConsensusAPI) ForkchoiceUpdatedV1(update beacon.ForkchoiceStateV1, pa
 			log.Warn("Safe block not in canonical chain")
 			return beacon.STATUS_INVALID, beacon.InvalidForkChoiceState.With(errors.New("safe block not in canonical chain"))
 		}
+		// Set the safe block
+		api.eth.BlockChain().SetSafe(safeBlock)
 	}
 	// If payload generation was requested, create a new block to be potentially
 	// sealed by the beacon client. The payload will be requested later, and we

--- a/internal/jsre/deps/web3.js
+++ b/internal/jsre/deps/web3.js
@@ -3696,7 +3696,7 @@ var outputBigNumberFormatter = function (number) {
 };
 
 var isPredefinedBlockNumber = function (blockNumber) {
-    return blockNumber === 'latest' || blockNumber === 'pending' || blockNumber === 'earliest' || blockNumber === 'finalized';
+    return blockNumber === 'latest' || blockNumber === 'pending' || blockNumber === 'earliest' || blockNumber === 'finalized' || blockNumber === 'safe';
 };
 
 var inputDefaultBlockNumberFormatter = function (blockNumber) {

--- a/rpc/types.go
+++ b/rpc/types.go
@@ -61,6 +61,7 @@ type jsonWriter interface {
 type BlockNumber int64
 
 const (
+	SafeBlockNumber      = BlockNumber(-4)
 	FinalizedBlockNumber = BlockNumber(-3)
 	PendingBlockNumber   = BlockNumber(-2)
 	LatestBlockNumber    = BlockNumber(-1)
@@ -92,6 +93,9 @@ func (bn *BlockNumber) UnmarshalJSON(data []byte) error {
 	case "finalized":
 		*bn = FinalizedBlockNumber
 		return nil
+	case "safe":
+		*bn = SafeBlockNumber
+		return nil
 	}
 
 	blckNum, err := hexutil.DecodeUint64(input)
@@ -118,6 +122,8 @@ func (bn BlockNumber) MarshalText() ([]byte, error) {
 		return []byte("pending"), nil
 	case FinalizedBlockNumber:
 		return []byte("finalized"), nil
+	case SafeBlockNumber:
+		return []byte("safe"), nil
 	default:
 		return hexutil.Uint64(bn).MarshalText()
 	}
@@ -166,6 +172,10 @@ func (bnh *BlockNumberOrHash) UnmarshalJSON(data []byte) error {
 		return nil
 	case "finalized":
 		bn := FinalizedBlockNumber
+		bnh.BlockNumber = &bn
+		return nil
+	case "safe":
+		bn := SafeBlockNumber
 		bnh.BlockNumber = &bn
 		return nil
 	default:


### PR DESCRIPTION
This PR implements the `safe` block tag for all block related RPC calls.
Contrary to the `finalized` block, the safe block is not stored in the database. It is initialized to the finalized block on startup.

```
> eth.getBlock("safe")
{
  baseFeePerGas: 7,
  difficulty: 0,
  extraData: "0x",
  gasLimit: 30000000,
  gasUsed: 46083,
  hash: "0x676383cc22620f878a1ee56ef74fd35201a6bcf95f30424958e74684000867b1",
  logsBloom: "0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
  miner: "0x25c4a76e7d118705e7ea2e9b7d8c59930d8acd3b",
  mixHash: "0x97bf89591172df9a46fddf0fba365a9563d88b69925521f98e608003b7721249",
  nonce: "0x0000000000000000",
  number: 12359668,
  parentHash: "0x03ddee8d6c1146f7816a22caf84d7edb929246ad9c118dbea3f71a4332edd987",
  receiptsRoot: "0x9072d62848dff16db754fce9e7dbad85232df668bb473088ebed2dde12a1ae8e",
  sha3Uncles: "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
  size: 665,
  stateRoot: "0xaa3faac51ee7b9b35b838d7c90c3cee024f946bdaf23c66cb9ff4fc65d169712",
  timestamp: 1654814448,
  totalDifficulty: 50000820485795157,
  transactions: ["0xcbbb4537c6e287fa6510eea915c9689feb9a1e8114f26b9de519ab4afff621e1"],
  transactionsRoot: "0x3356700833bf29a50873ee63eb1349844fb7fa7a94fc3e7588223dee6c1b084d",
  uncles: []
}
```


```
> debug.setHead("0x16F380")
WARN [07-14|14:25:35.516] Rewinding blockchain                     target=1,504,128
WARN [07-14|14:25:35.522] SetHead invalidated safe block 
ERROR[07-14|14:25:35.522] SetHead invalidated finalized block 
INFO [07-14|14:25:35.522] Loaded most recent local header          number=1,504,128 hash=9993d2..67959c td=17,000,018,015,853,232 age=17m11s
INFO [07-14|14:25:35.522] Loaded most recent local full block      number=1,504,128 hash=9993d2..67959c td=17,000,018,015,853,232 age=17m11s
INFO [07-14|14:25:35.522] Loaded most recent local fast block      number=1,504,128 hash=9993d2..67959c td=17,000,018,015,853,232 age=17m11s
INFO [07-14|14:25:35.522] Loaded last fast-sync pivot marker       number=1,450,344
null
```