### PR TITLE
internal/ethapi: always return chain id

### DIFF
--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -609,12 +609,8 @@ func NewBlockChainAPI(b Backend) *BlockChainAPI {
 }
 
 // ChainId is the EIP-155 replay-protection chain id for the current Ethereum chain config.
-func (api *BlockChainAPI) ChainId() (*hexutil.Big, error) {
-	// if current block is at or past the EIP-155 replay-protection fork block, return chainID from config
-	if config := api.b.ChainConfig(); config.IsEIP155(api.b.CurrentBlock().Number()) {
-		return (*hexutil.Big)(config.ChainID), nil
-	}
-	return nil, fmt.Errorf("chain not synced beyond EIP-155 replay-protection fork block")
+func (api *BlockChainAPI) ChainId() *hexutil.Big {
+	return (*hexutil.Big)(api.b.ChainConfig().ChainID)
 }
 
 // BlockNumber returns the block number of the chain head.


### PR DESCRIPTION
Always returns `chainId`, regardless of EIP-155 status.