### PR TITLE
internal/ethapi: use currentHeader instead of currentBlock for ChainI…

### DIFF
--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -613,7 +613,7 @@ func NewPublicBlockChainAPI(b Backend) *PublicBlockChainAPI {
 // ChainId is the EIP-155 replay-protection chain id for the current ethereum chain config.
 func (api *PublicBlockChainAPI) ChainId() (*hexutil.Big, error) {
 	// if current block is at or past the EIP-155 replay-protection fork block, return chainID from config
-	if config := api.b.ChainConfig(); config.IsEIP155(api.b.CurrentBlock().Number()) {
+	if config := api.b.ChainConfig(); config.IsEIP155(api.b.CurrentHeader().Number) {
 		return (*hexutil.Big)(config.ChainID), nil
 	}
 	return nil, fmt.Errorf("chain not synced beyond EIP-155 replay-protection fork block")


### PR DESCRIPTION
This allows us to return chainid once the headerchain is synced past 155