### PR TITLE
internal/ethapi: add note about eth_chainId compatibility with EIP-695

### DIFF
--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -612,7 +612,8 @@ func NewBlockChainAPI(b Backend) *BlockChainAPI {
 //
 // Note, this method does not conform to EIP-695 because the configured chain ID is always
 // returned, regardless of the current head block. We used to return an error when the chain
-// wasn't synced up to the head block here, but it caused issues in CL clients.
+// wasn't synced up to a block where EIP-155 is enabled, but this behavior caused issues
+// in CL clients.
 func (api *BlockChainAPI) ChainId() *hexutil.Big {
 	return (*hexutil.Big)(api.b.ChainConfig().ChainID)
 }

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -610,8 +610,9 @@ func NewBlockChainAPI(b Backend) *BlockChainAPI {
 
 // ChainId is the EIP-155 replay-protection chain id for the current Ethereum chain config.
 //
-// Note, this method does not conform to EIP-695 becuase the configured chain id is always
-// returned regardless of the current head block.
+// Note, this method does not conform to EIP-695 because the configured chain ID is always
+// returned, regardless of the current head block. We used to return an error when the chain
+// wasn't synced up to the head block here, but it caused issues in CL clients.
 func (api *BlockChainAPI) ChainId() *hexutil.Big {
 	return (*hexutil.Big)(api.b.ChainConfig().ChainID)
 }

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -609,6 +609,9 @@ func NewBlockChainAPI(b Backend) *BlockChainAPI {
 }
 
 // ChainId is the EIP-155 replay-protection chain id for the current Ethereum chain config.
+//
+// Note, this method does not conform to EIP-695 becuase the configured chain id is always
+// returned regardless of the current head block.
 func (api *BlockChainAPI) ChainId() *hexutil.Big {
 	return (*hexutil.Big)(api.b.ChainConfig().ChainID)
 }


### PR DESCRIPTION
I think it would be good to actually note this behavior, because it does not conform to EIP-695 as @fjl pointed out here: https://github.com/ethereum/go-ethereum/pull/21686#issuecomment-740523125

--
quote:
> In [EIP-695](https://eips.ethereum.org/EIPS/eip-695), it says
> >  The chain ID returned should always correspond to the information in the current known head block. This ensures that caller of this RPC method can always use the retrieved information to sign transactions built on top of the head.
> > If the current known head block does not specify a chain ID, the client should treat any calls to eth_chainId as though the method were not supported, and return a suitable error.

> So, the current geth behavior and this PR are not correct. eth_chainId should return an error when the current block is not EIP155-enabled.