### PR TITLE
cmd: properly set bootstrap nodes if present in config file

### DIFF
--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -940,8 +940,11 @@ func setBootstrapNodes(ctx *cli.Context, cfg *p2p.Config) {
 		urls = params.GoerliBootnodes
 	case ctx.GlobalBool(KilnFlag.Name):
 		urls = params.KilnBootnodes
-	case cfg.BootstrapNodes != nil:
-		return // already set, don't apply defaults.
+	}
+
+	// don't apply defaults if BootstrapNodes is already set
+	if cfg.BootstrapNodes != nil {
+		return
 	}
 
 	cfg.BootstrapNodes = make([]*enode.Node, 0, len(urls))


### PR DESCRIPTION
Hi, this is my first contribution to go-ethereum!

This fixes an issue where geth doesn't set custom BootstrapNodes from config.toml correctly if running geth with any of the test network flags (i.e. `./geth --config ./config.toml --ropsten, --sepolia, etc.`)


Thanks,
AP