### PR TITLE
fix estimate gas

### DIFF
--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -954,6 +954,8 @@ func DoCall(ctx context.Context, b Backend, args TransactionArgs, blockNrOrHash 
 		evm.Cancel()
 	}()
 
+	// Call Prepare to clear out the statedb access list
+	state.Prepare(common.Hash{}, 0)
 	// Execute the message.
 	gp := new(core.GasPool).AddGas(math.MaxUint64)
 	result, err := core.ApplyMessage(evm, msg, gp)


### PR DESCRIPTION
This fix an issue that may cause the estimated gas less than actual need:

1. The `accessList` will be copied when copying the `statedb`;
2. The miner(worker object) will maintain a `snapshotState`, which will contains non-empty accessList after handling a transaction;
3. When doing `DoCall`(which will be called by `EstimateGas`), it will copy a statedb from the miner's `snapshotState`, then it may coincidentally contains some addresses or slotStorages needed by the estimating message, then it will cause the estimated gas less then the actual needed gas!

By applying `state.Prepare` before executing the message, we can safely fix this issue.