### PR TITLE
consensus/beacon: check that only the latest pow block is valid ttd block

### DIFF
--- a/consensus/beacon/consensus.go
+++ b/consensus/beacon/consensus.go
@@ -172,15 +172,10 @@ func (beacon *Beacon) VerifyHeaders(chain consensus.ChainHeaderReader, headers [
 // - the preHeaders to have a set difficulty
 // - the last element to be the terminal block
 func verifyTerminalPoWBlock(chain consensus.ChainHeaderReader, preHeaders []*types.Header) (int, error) {
-	var (
-		first = preHeaders[0]
-	)
-
-	td := chain.GetTd(first.ParentHash, first.Number.Uint64()-1)
+	td := chain.GetTd(preHeaders[0].ParentHash, preHeaders[0].Number.Uint64()-1)
 	if td == nil {
 		return 0, consensus.ErrUnknownAncestor
 	}
-
 	for i, head := range preHeaders {
 		// Check if the parent was already the terminal block
 		if td.Cmp(chain.Config().TerminalTotalDifficulty) >= 0 {

--- a/consensus/beacon/consensus_test.go
+++ b/consensus/beacon/consensus_test.go
@@ -1,0 +1,137 @@
+package beacon
+
+import (
+	"fmt"
+	"math/big"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/consensus"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/params"
+)
+
+type mockChain struct {
+	config *params.ChainConfig
+	tds    map[uint64]*big.Int
+}
+
+func newMockChain() *mockChain {
+	return &mockChain{
+		config: new(params.ChainConfig),
+		tds:    make(map[uint64]*big.Int),
+	}
+}
+
+func (m *mockChain) Config() *params.ChainConfig {
+	return m.config
+}
+
+func (m *mockChain) CurrentHeader() *types.Header { panic("not implemented") }
+
+func (m *mockChain) GetHeader(hash common.Hash, number uint64) *types.Header {
+	panic("not implemented")
+}
+
+func (m *mockChain) GetHeaderByNumber(number uint64) *types.Header { panic("not implemented") }
+
+func (m *mockChain) GetHeaderByHash(hash common.Hash) *types.Header { panic("not implemented") }
+
+func (m *mockChain) GetTd(hash common.Hash, number uint64) *big.Int {
+	num, ok := m.tds[number]
+	if ok {
+		return new(big.Int).Set(num)
+	}
+	return nil
+}
+
+func TestVerifyTerminalBlock(t *testing.T) {
+	chain := newMockChain()
+	chain.tds[0] = big.NewInt(10)
+	chain.config.TerminalTotalDifficulty = big.NewInt(50)
+
+	tests := []struct {
+		preHeaders []*types.Header
+		ttd        *big.Int
+		err        error
+		index      int
+	}{
+		// valid ttd
+		{
+			preHeaders: []*types.Header{
+				{Number: big.NewInt(1), Difficulty: big.NewInt(10)},
+				{Number: big.NewInt(2), Difficulty: big.NewInt(10)},
+				{Number: big.NewInt(3), Difficulty: big.NewInt(10)},
+				{Number: big.NewInt(4), Difficulty: big.NewInt(10)},
+			},
+			ttd: big.NewInt(50),
+		},
+		// last block doesn't reach ttd
+		{
+			preHeaders: []*types.Header{
+				{Number: big.NewInt(1), Difficulty: big.NewInt(10)},
+				{Number: big.NewInt(2), Difficulty: big.NewInt(10)},
+				{Number: big.NewInt(3), Difficulty: big.NewInt(10)},
+				{Number: big.NewInt(4), Difficulty: big.NewInt(9)},
+			},
+			ttd:   big.NewInt(50),
+			err:   consensus.ErrInvalidTerminalBlock,
+			index: 3,
+		},
+		// two blocks reach ttd
+		{
+			preHeaders: []*types.Header{
+				{Number: big.NewInt(1), Difficulty: big.NewInt(10)},
+				{Number: big.NewInt(2), Difficulty: big.NewInt(10)},
+				{Number: big.NewInt(3), Difficulty: big.NewInt(20)},
+				{Number: big.NewInt(4), Difficulty: big.NewInt(10)},
+			},
+			ttd:   big.NewInt(50),
+			err:   consensus.ErrInvalidTerminalBlock,
+			index: 3,
+		},
+		// three blocks reach ttd
+		{
+			preHeaders: []*types.Header{
+				{Number: big.NewInt(1), Difficulty: big.NewInt(10)},
+				{Number: big.NewInt(2), Difficulty: big.NewInt(10)},
+				{Number: big.NewInt(3), Difficulty: big.NewInt(20)},
+				{Number: big.NewInt(4), Difficulty: big.NewInt(10)},
+				{Number: big.NewInt(4), Difficulty: big.NewInt(10)},
+			},
+			ttd:   big.NewInt(50),
+			err:   consensus.ErrInvalidTerminalBlock,
+			index: 3,
+		},
+		// parent reached ttd
+		{
+			preHeaders: []*types.Header{
+				{Number: big.NewInt(1), Difficulty: big.NewInt(10)},
+			},
+			ttd:   big.NewInt(9),
+			err:   consensus.ErrInvalidTerminalBlock,
+			index: 0,
+		},
+		// unknown parent
+		{
+			preHeaders: []*types.Header{
+				{Number: big.NewInt(4), Difficulty: big.NewInt(10)},
+			},
+			ttd:   big.NewInt(9),
+			err:   consensus.ErrUnknownAncestor,
+			index: 0,
+		},
+	}
+
+	for i, test := range tests {
+		fmt.Printf("Test: %v\n", i)
+		chain.config.TerminalTotalDifficulty = test.ttd
+		index, err := verifyTerminalPoWBlock(chain, test.preHeaders)
+		if err != test.err {
+			t.Fatalf("Invalid error encountered, expected %v got %v", test.err, err)
+		}
+		if index != test.index {
+			t.Fatalf("Invalid index, expected %v got %v", test.index, index)
+		}
+	}
+}

--- a/consensus/errors.go
+++ b/consensus/errors.go
@@ -34,4 +34,8 @@ var (
 	// ErrInvalidNumber is returned if a block's number doesn't equal its parent's
 	// plus one.
 	ErrInvalidNumber = errors.New("invalid block number")
+
+	// ErrInvalidTerminalBlock is returned if a block is invalid wrt. the terminal
+	// total difficulty.
+	ErrInvalidTerminalBlock = errors.New("invalid terminal block")
 )

--- a/core/block_validator_test.go
+++ b/core/block_validator_test.go
@@ -107,7 +107,8 @@ func testHeaderVerificationForMerging(t *testing.T, isClique bool) {
 			Alloc: map[common.Address]GenesisAccount{
 				addr: {Balance: big.NewInt(1)},
 			},
-			BaseFee: big.NewInt(params.InitialBaseFee),
+			BaseFee:    big.NewInt(params.InitialBaseFee),
+			Difficulty: new(big.Int),
 		}
 		copy(genspec.ExtraData[32:], addr[:])
 		genesis := genspec.MustCommit(testdb)


### PR DESCRIPTION
Before this PR the following chain would be deemed valid during sync:
p1 <- p2 <- p3 <- p4 <- b1 <- b2 (each pX block with difficulty of 1)
and TTD = 3 
even though the chain has two blocks that passed the ttd requirement

This PR fixes an issue surfaced by the hive tests cc @marioevz @mkalinin 
The following hive tests *should* be fixed by this:

- Transition to a Chain with Invalid Terminal Block, Higher Configured Total Difficulty
- Transition to a Chain with Invalid Terminal Block, Higher Configured Total Difficulty (Transition Payload)






