### PR TITLE
internal/ethapi: fix check legacy tx

### DIFF
--- a/internal/ethapi/transaction_args.go
+++ b/internal/ethapi/transaction_args.go
@@ -111,7 +111,7 @@ func (args *TransactionArgs) setDefaults(ctx context.Context, b Backend) error {
 				if err != nil {
 					return err
 				}
-				if b.ChainConfig().IsLondon(head.Number) {
+				if !b.ChainConfig().IsLondon(head.Number) {
 					// The legacy tx gas price suggestion should not add 2x base fee
 					// because all fees are consumed, so it would result in a spiral
 					// upwards.


### PR DESCRIPTION
legacy tx must be IsLondon(head.Number) is false.

This `if` statement, https://github.com/ethereum/go-ethereum/blob/master/internal/ethapi/transaction_args.go#L114-L119
is always `false` and never processed.