### PR TITLE
build: fix auto-completion scripts and include them in .deb package

### DIFF
--- a/build/deb/ethereum/completions/bash_autocomplete
+++ b/build/deb/ethereum/completions/bash_autocomplete
@@ -1,8 +1,4 @@
-#! /bin/bash
-
-: ${PROG:=$(basename ${BASH_SOURCE})}
-
-_cli_bash_autocomplete() {
+_geth_bash_autocomplete() {
   if [[ "${COMP_WORDS[0]}" != "source" ]]; then
     local cur opts base
     COMPREPLY=()
@@ -17,5 +13,4 @@ _cli_bash_autocomplete() {
   fi
 }
 
-complete -o bashdefault -o default -o nospace -F _cli_bash_autocomplete $PROG
-unset PROG
+complete -o bashdefault -o default -o nospace -F _geth_bash_autocomplete geth

--- a/build/deb/ethereum/completions/zsh_autocomplete
+++ b/build/deb/ethereum/completions/zsh_autocomplete
@@ -1,6 +1,4 @@
-#compdef $PROG
-
-_cli_zsh_autocomplete() {
+_geth_zsh_autocomplete() {
   local -a opts
   local cur
   cur=${words[-1]}
@@ -17,4 +15,4 @@ _cli_zsh_autocomplete() {
   fi
 }
 
-compdef _cli_zsh_autocomplete $PROG
+compdef _geth_zsh_autocomplete geth

--- a/build/deb/ethereum/deb.install
+++ b/build/deb/ethereum/deb.install
@@ -1,5 +1,5 @@
 build/bin/{{.BinaryName}} usr/bin
 {{- if eq .BinaryName "geth" }}
-build/deb/ethereum/completions/bash_autocomplete /etc/bash_completion.d/geth
-build/deb/ethereum/completions/zsh_autocomplete /usr/share/zsh/vendor-completions/_geth
+build/deb/ethereum/completions/bash_autocomplete etc/bash_completion.d/geth
+build/deb/ethereum/completions/zsh_autocomplete usr/share/zsh/vendor-completions/_geth
 {{end -}}

--- a/build/deb/ethereum/deb.install
+++ b/build/deb/ethereum/deb.install
@@ -1,1 +1,5 @@
 build/bin/{{.BinaryName}} usr/bin
+{{- if eq .BinaryName "geth" }}
+build/deb/ethereum/completions/bash_autocomplete /etc/bash_completion.d/geth
+build/deb/ethereum/completions/zsh_autocomplete /usr/share/zsh/vendor-completions/_geth
+{{end -}}


### PR DESCRIPTION
The auto-completion scripts [urfave/cli](https://cli.urfave.org/v2/#enabling)from were added in https://github.com/ethereum/go-ethereum/pull/24751 but it also needs to reference `geth` and be added to the deb packaging.

I'll follow-up with a PR to update the gh-pages documentation.

NOTE: Zsh doesn't have a defined place to add completion files, like Bash. It's up to the user to fetch and reference the file.

I can confirm once the files (for Bash and Zsh completions) are sourced, the auto-completion works out of the box perfectly. Follow some screenshots:

![Screenshot_20220629_112120](https://user-images.githubusercontent.com/201236/176425641-a7bd615d-6573-47a7-8f1a-07fe2e56eb79.png)
![Screenshot_20220629_112135](https://user-images.githubusercontent.com/201236/176425668-884ebb3f-7c7b-43db-980c-5b47389bddec.png)
![Screenshot_20220629_112153](https://user-images.githubusercontent.com/201236/176425683-e9595241-f51a-4e60-9033-02e2d04dff19.png)



