### PR TITLE
eth/catalyst: disallow importing blocks via newPayload during snap sync

### DIFF
--- a/eth/catalyst/api.go
+++ b/eth/catalyst/api.go
@@ -342,7 +342,7 @@ func computePayloadId(headBlockHash common.Hash, params *beacon.PayloadAttribute
 // be called by the newpayload command when the block seems to be ok, but some
 // prerequisite prevents it from being processed (e.g. no parent, or nap sync).
 func (api *ConsensusAPI) delayPayloadImport(block *types.Block) (beacon.PayloadStatusV1, error) {
-	// Stash the block away for a potential forced forckchoice update to it
+	// Stash the block away for a potential forced forkchoice update to it
 	// at a later time.
 	api.remoteBlocks.put(block.Hash(), block.Header())
 

--- a/eth/catalyst/api.go
+++ b/eth/catalyst/api.go
@@ -273,30 +273,9 @@ func (api *ConsensusAPI) NewPayloadV1(params beacon.ExecutableDataV1) (beacon.Pa
 	// our live chain. As such, payload execution will not permit reorgs and thus
 	// will not trigger a sync cycle. That is fine though, if we get a fork choice
 	// update after legit payload executions.
-	//
-	// A similar cornercase is when the node is in snap sync mode, but the CL client
-	// tries to make it import a block. That should be denied as pushing something
-	// into the database directly will conflict with the assumptions of snap sync
-	// that it has an empty db that it can fill itself.
 	parent := api.eth.BlockChain().GetBlock(block.ParentHash(), block.NumberU64()-1)
-	if parent == nil || api.eth.SyncMode() != downloader.FullSync {
-		// Stash the block away for a potential forced forckchoice update to it
-		// at a later time.
-		api.remoteBlocks.put(block.Hash(), block.Header())
-
-		// Although we don't want to trigger a sync, if there is one already in
-		// progress, try to extend if with the current payload request to relieve
-		// some strain from the forkchoice update.
-		if err := api.eth.Downloader().BeaconExtend(api.eth.SyncMode(), block.Header()); err == nil {
-			log.Debug("Payload accepted for sync extension", "number", params.Number, "hash", params.BlockHash)
-			return beacon.PayloadStatusV1{Status: beacon.SYNCING}, nil
-		}
-		// Either no beacon sync was started yet, or it rejected the delivered
-		// payload as non-integratable on top of the existing sync. We'll just
-		// have to rely on the beacon client to forcefully update the head with
-		// a forkchoice update request.
-		log.Warn("Ignoring payload with missing parent", "number", params.Number, "hash", params.BlockHash, "parent", params.ParentHash)
-		return beacon.PayloadStatusV1{Status: beacon.ACCEPTED}, nil
+	if parent == nil {
+		return api.delayPayloadImport(block)
 	}
 	// We have an existing parent, do some sanity checks to avoid the beacon client
 	// triggering too early
@@ -316,6 +295,13 @@ func (api *ConsensusAPI) NewPayloadV1(params beacon.ExecutableDataV1) (beacon.Pa
 	if block.Time() <= parent.Time() {
 		log.Warn("Invalid timestamp", "parent", block.Time(), "block", block.Time())
 		return api.invalid(errors.New("invalid timestamp"), parent), nil
+	}
+	// Another cornercase: if the node is in snap sync mode, but the CL client
+	// tries to make it import a block. That should be denied as pushing something
+	// into the database directly will conflict with the assumptions of snap sync
+	// that it has an empty db that it can fill itself.
+	if api.eth.SyncMode() != downloader.FullSync {
+		return api.delayPayloadImport(block)
 	}
 	if !api.eth.BlockChain().HasBlockAndState(block.ParentHash(), block.NumberU64()-1) {
 		api.remoteBlocks.put(block.Hash(), block.Header())
@@ -349,6 +335,30 @@ func computePayloadId(headBlockHash common.Hash, params *beacon.PayloadAttribute
 	var out beacon.PayloadID
 	copy(out[:], hasher.Sum(nil)[:8])
 	return out
+}
+
+// delayPayloadImport stashes the given block away for import at a later time,
+// either via a forkchoice update or a sync extension. This method is meant to
+// be called by the newpayload command when the block seems to be ok, but some
+// prerequisite prevents it from being processed (e.g. no parent, or nap sync).
+func (api *ConsensusAPI) delayPayloadImport(block *types.Block) (beacon.PayloadStatusV1, error) {
+	// Stash the block away for a potential forced forckchoice update to it
+	// at a later time.
+	api.remoteBlocks.put(block.Hash(), block.Header())
+
+	// Although we don't want to trigger a sync, if there is one already in
+	// progress, try to extend if with the current payload request to relieve
+	// some strain from the forkchoice update.
+	if err := api.eth.Downloader().BeaconExtend(api.eth.SyncMode(), block.Header()); err == nil {
+		log.Debug("Payload accepted for sync extension", "number", block.NumberU64(), "hash", block.Hash())
+		return beacon.PayloadStatusV1{Status: beacon.SYNCING}, nil
+	}
+	// Either no beacon sync was started yet, or it rejected the delivered
+	// payload as non-integratable on top of the existing sync. We'll just
+	// have to rely on the beacon client to forcefully update the head with
+	// a forkchoice update request.
+	log.Warn("Ignoring payload with missing parent", "number", block.NumberU64(), "hash", block.Hash(), "parent", block.ParentHash())
+	return beacon.PayloadStatusV1{Status: beacon.ACCEPTED}, nil
 }
 
 // invalid returns a response "INVALID" with the latest valid hash supplied by latest or to the current head

--- a/eth/catalyst/api_test.go
+++ b/eth/catalyst/api_test.go
@@ -403,7 +403,7 @@ func startEthService(t *testing.T, genesis *core.Genesis, blocks []*types.Block)
 		t.Fatal("can't create node:", err)
 	}
 
-	ethcfg := &ethconfig.Config{Genesis: genesis, Ethash: ethash.Config{PowMode: ethash.ModeFake}, SyncMode: downloader.SnapSync, TrieTimeout: time.Minute, TrieDirtyCache: 256, TrieCleanCache: 256}
+	ethcfg := &ethconfig.Config{Genesis: genesis, Ethash: ethash.Config{PowMode: ethash.ModeFake}, SyncMode: downloader.FullSync, TrieTimeout: time.Minute, TrieDirtyCache: 256, TrieCleanCache: 256}
 	ethservice, err := eth.New(n, ethcfg)
 	if err != nil {
 		t.Fatal("can't create eth service:", err)

--- a/eth/handler.go
+++ b/eth/handler.go
@@ -249,7 +249,7 @@ func newHandler(config *handlerConfig) (*handler, error) {
 		// out a way yet where nodes can decide unilaterally whether the network is new
 		// or not. This should be fixed if we figure out a solution.
 		if atomic.LoadUint32(&h.snapSync) == 1 {
-			log.Warn("Fast syncing, discarded propagated block", "number", blocks[0].Number(), "hash", blocks[0].Hash())
+			log.Warn("Snap syncing, discarded propagated block", "number", blocks[0].Number(), "hash", blocks[0].Hash())
 			return 0, nil
 		}
 		if h.merger.TDDReached() {


### PR DESCRIPTION
**Tests should be expanded to cover both full and snap sync behavioral requirements**

There is a very subtle bug in the catalysts API. Specifically, `newPayload` will always import a block if the parent's state is available, independent of what sync mode we're in. This does not match the behavior of pre-merge sync, where propagates blocks during snap sync are discarded.

The subtlety is important however. The snap sync code - everywhere - assumes that is has full control over the database and nobody else will poke at it. There are various optimizations (like the direct freezer inserter, rollback points, pivot markers, beacon sync link points) that all rely on the invariant that only snap modifies the db initially.

Allowing newPayload to always import a block if the state is available is a weird cornercase that cannot happen on mainnet. This is because a snap syncing node will not have the state for a post-merge block. On a testnet/privnet (or hive tests) where the genesis is already merged, newPayload with block #1 will result in a state corruption as snap sync will expect to operate of the entire chain range, which newPayload modified.

* If everything is correct and the same chain, the corruptions will be the same data, so it won't be noticed.
* If snap sync starts and newPayload inserts a different chain, a silent replacement of a block will happen, making a bad chain tail.
* If newPayload runs first, after which snap sync runs and hits a bad block, it can roll back the data from newPayload, but it might not expect to roll back anything it did not insert, leading to a missing header in the beacon chain sync data struct.

TL;DR: We need to let snap sync do its stuff in peace. This PR modifies newPayload to ignore block data suring snap sync and only stash it away for forkchoiceupdate.