### PR TITLE
internal/ethapi: don't binary search for gas estimates on transfers

### DIFF
--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -1020,6 +1020,10 @@ func (s *BlockChainAPI) Call(ctx context.Context, args TransactionArgs, blockNrO
 }
 
 func DoEstimateGas(ctx context.Context, b Backend, args TransactionArgs, blockNrOrHash rpc.BlockNumberOrHash, gasCap uint64) (hexutil.Uint64, error) {
+	// If there is no data, it is considered a simple transfer which has a fixed cost.
+	if args.To != nil && len(args.data()) == 0 {
+		return hexutil.Uint64(params.TxGas), nil
+	}
 	// Binary search the gas requirement, as it may be higher than the amount used
 	var (
 		lo  uint64 = params.TxGas - 1


### PR DESCRIPTION
There was a neat graph on twitter by the nethermind team comparing the performance of geth rpcs calls vs. theirs: https://twitter.com/URozmej/status/1542481475534295040?s=20&t=9bUwS5mYFTZADOl8jNll1Q

They proved to be substantially faster at estimating gas for simple transfers than geth. This is almost certainly due to the fact that geth instantiates a lot of machinery to binary search for a correct gas limit. A quick run locally and it appears to come up with the correct limit of 21,000 after 23 rounds.

To avoid this unnecessary computation, we can check at the beginning of the gas estimation whether there is any data in the tx. To be safe, I also guarded with checking if the transaction `to` address was not `nil`, because I believe it is technically possible to have a "create" transaction w/o and data.