### PR TITLE
cmd/devp2p: add eth cmd to send new block announcements

### DIFF
--- a/cmd/devp2p/README.md
+++ b/cmd/devp2p/README.md
@@ -118,7 +118,7 @@ geth --datadir <datadir> --nodiscover --nat=none --networkid 19763 --verbosity 5
 ```
 
 Then, run the following command, replacing `<enode>` with the enode of the geth node:
- ```
+```
  devp2p rlpx eth-test <enode> cmd/devp2p/internal/ethtest/testdata/chain.rlp cmd/devp2p/internal/ethtest/testdata/genesis.json
 ```
 

--- a/cmd/devp2p/ethcmd.go
+++ b/cmd/devp2p/ethcmd.go
@@ -1,0 +1,94 @@
+// Copyright 2022 The go-ethereum Authors
+// This file is part of go-ethereum.
+//
+// go-ethereum is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// go-ethereum is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with go-ethereum. If not, see <http://www.gnu.org/licenses/>.
+
+package main
+
+import (
+	"encoding/hex"
+	"fmt"
+
+	"github.com/ethereum/go-ethereum/cmd/devp2p/internal/ethtest"
+	"github.com/urfave/cli/v2"
+)
+
+var (
+	ethCommand = &cli.Command{
+		Name:  "eth",
+		Usage: "Eth Commands",
+		Subcommands: []*cli.Command{
+			&ethNewBlockCommand,
+		},
+		Flags: []cli.Flag{
+			chainFile,
+			genesisFile,
+		},
+	}
+	// Flags
+	chainFile = &cli.StringFlag{
+		Name:  "chain",
+		Usage: "Path to chain.rlp file.",
+		Value: "chain.rlp",
+	}
+	genesisFile = &cli.StringFlag{
+		Name:  "genesis",
+		Usage: "Path to genesis file.",
+		Value: "genesis.json",
+	}
+	// Subcommands
+	ethNewBlockCommand = cli.Command{
+		Name:   "new-block",
+		Usage:  "<node> <msg>",
+		Action: ethNewBlock,
+	}
+)
+
+// ethNewBlock peers with node, sends the provided new block announcement, then disconnects from the peer.
+func ethNewBlock(ctx *cli.Context) error {
+	// Decode message body.
+	msg, err := hex.DecodeString(ctx.Args().Get(1))
+	if err != nil {
+		return fmt.Errorf("unable to decode msg: %s", err)
+	}
+	fmt.Println("loading chain")
+	chain, err := ethtest.LoadChain(ctx.String(chainFile.Name), ctx.String(genesisFile.Name))
+	if err != nil {
+		return fmt.Errorf("error loading chain: %s", err)
+	}
+	fmt.Println("dialing")
+	conn, err := ethtest.Dial(getNodeArg(ctx))
+	if err != nil {
+		return fmt.Errorf("error dialing peer: %s", err)
+	}
+	// Peer with node.
+	status := &ethtest.Status{
+		ProtocolVersion: 66,
+		NetworkID:       chain.Config().ChainID.Uint64(),
+		TD:              chain.TD(),
+		Head:            chain.Head().Hash(),
+		Genesis:         chain.GetHeaderByNumber(0).Hash(),
+		ForkID:          chain.ForkID(),
+	}
+	fmt.Println("peering")
+	if err := conn.Peer(chain, status); err != nil {
+		return fmt.Errorf("unable to peer with node: %s", err)
+	}
+	// Send new block announcement.
+	code := uint64((ethtest.NewBlock{}).Code())
+	if _, err = conn.Conn.Write(code, msg); err != nil {
+		exit(fmt.Errorf("failed to write to connection: %w", err))
+	}
+	return conn.Close()
+}

--- a/cmd/devp2p/ethcmd.go
+++ b/cmd/devp2p/ethcmd.go
@@ -62,12 +62,10 @@ func ethNewBlock(ctx *cli.Context) error {
 	if err != nil {
 		return fmt.Errorf("unable to decode msg: %s", err)
 	}
-	fmt.Println("loading chain")
 	chain, err := ethtest.LoadChain(ctx.String(chainFile.Name), ctx.String(genesisFile.Name))
 	if err != nil {
 		return fmt.Errorf("error loading chain: %s", err)
 	}
-	fmt.Println("dialing")
 	conn, err := ethtest.Dial(getNodeArg(ctx))
 	if err != nil {
 		return fmt.Errorf("error dialing peer: %s", err)
@@ -81,7 +79,6 @@ func ethNewBlock(ctx *cli.Context) error {
 		Genesis:         chain.GetHeaderByNumber(0).Hash(),
 		ForkID:          chain.ForkID(),
 	}
-	fmt.Println("peering")
 	if err := conn.Peer(chain, status); err != nil {
 		return fmt.Errorf("unable to peer with node: %s", err)
 	}

--- a/cmd/devp2p/ethcmd.go
+++ b/cmd/devp2p/ethcmd.go
@@ -18,12 +18,12 @@ package main
 
 import (
 	"encoding/hex"
-	"fmt"
-
 	"errors"
+	"fmt"
+	"math/big"
+
 	"github.com/ethereum/go-ethereum/cmd/devp2p/internal/ethtest"
 	"github.com/urfave/cli/v2"
-	"math/big"
 )
 
 var (

--- a/cmd/devp2p/ethcmd_test.go
+++ b/cmd/devp2p/ethcmd_test.go
@@ -37,7 +37,6 @@ import (
 var (
 	genesisPath   = "./internal/ethtest/testdata/genesis.json"
 	halfchainFile = "./internal/ethtest/testdata/halfchain.rlp"
-	fullchainFile = "./internal/ethtest/testdata/chain.rlp"
 )
 
 type testEth struct {

--- a/cmd/devp2p/ethcmd_test.go
+++ b/cmd/devp2p/ethcmd_test.go
@@ -1,0 +1,157 @@
+// Copyright 2022 The go-ethereum Authors
+// This file is part of go-ethereum.
+//
+// go-ethereum is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// go-ethereum is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with go-ethereum. If not, see <http://www.gnu.org/licenses/>.
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/docker/docker/pkg/reexec"
+	"github.com/ethereum/go-ethereum/cmd/devp2p/internal/ethtest"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/eth"
+	"github.com/ethereum/go-ethereum/eth/ethconfig"
+	"github.com/ethereum/go-ethereum/ethclient"
+	"github.com/ethereum/go-ethereum/internal/cmdtest"
+	"github.com/ethereum/go-ethereum/node"
+	"github.com/ethereum/go-ethereum/p2p"
+)
+
+var (
+	genesisPath   = "./internal/ethtest/testdata/genesis.json"
+	halfchainFile = "./internal/ethtest/testdata/halfchain.rlp"
+	fullchainFile = "./internal/ethtest/testdata/chain.rlp"
+)
+
+type testEth struct {
+	*cmdtest.TestCmd
+}
+
+func TestMain(m *testing.M) {
+	// Run the app if we've been exec'd as "ethkey-test" in runEthkey.
+	reexec.Register("devp2p-test", func() {
+		if err := app.Run(os.Args); err != nil {
+			fmt.Fprintln(os.Stderr, err)
+			os.Exit(1)
+		}
+		os.Exit(0)
+	})
+	// check if we have been reexec'd
+	if reexec.Init() {
+		return
+	}
+	os.Exit(m.Run())
+}
+
+func TestNewBlockAnnouncement(t *testing.T) {
+	geth, err := runGeth()
+	if err != nil {
+		t.Fatalf("could not run geth: %v", err)
+	}
+	defer geth.Close()
+
+	tt := new(testEth)
+	tt.TestCmd = cmdtest.NewTestCmd(t, tt)
+
+	// NewBlock msg with block 1000 from fullchain.rlp.
+	msg := "f90206f901fef901f9a00e70e01064023f70f047dbf0b97e7109e4aa5df3d643d45f8e91e47d3d67a424a01dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347940000000000000000000000000000000000000000a04327919f498aefdfe87f9c5a83cfd4a0bb444973d4a99d44fa9f4728497c3608a056e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421a056e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421b9010000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000830200008203e884800000008083e51c5880a02807078eecff82eef7ad486076c4989e331a8a4c54592a690f083ef7b24820ec886cad2133e8e98457c0c08407d20000"
+	hash := common.HexToHash("0x8c795a2497f393359fd66bfd5696442d12a81ccb1110dffd636604bfc9af4df3")
+
+	rpc, err := geth.Attach()
+	if err != nil {
+		tt.Fatalf("unable to attach client: %v", err)
+	}
+	ctx := context.Background()
+	client := ethclient.NewClient(rpc)
+
+	// Before the announcement, the propogated block should not be retrievable.
+	_, err = client.BlockByHash(ctx, hash)
+	if err == nil || (err != nil && err.Error() != "not found") {
+		tt.Fatalf("should fail to retrieve block before announcement: %v", err)
+	}
+
+	// Run devp2p eth new-block against node.
+	args := []string{"--verbosity=5", "eth", fmt.Sprintf("--genesis=%s", genesisPath), fmt.Sprintf("--chain=%s", halfchainFile), "new-block", geth.Server().Self().String(), msg}
+	tt.Run("devp2p-test", args...)
+	tt.WaitExit()
+
+	// Give geth a moment to ingest the new block.
+	time.Sleep(time.Second)
+
+	// After the announcement, the block should be readily available.
+	got, err := client.BlockByHash(ctx, hash)
+	if err != nil {
+		tt.Fatalf("unable to get announced block: %v", err)
+	}
+	if hash != got.Hash() {
+		tt.Fatalf("block mismatch (got: %s, want: %s)", hash, got.Hash())
+	}
+}
+
+// runGeth creates and starts a geth node
+func runGeth() (*node.Node, error) {
+	stack, err := node.New(&node.Config{
+		P2P: p2p.Config{
+			ListenAddr:  "127.0.0.1:0",
+			NoDiscovery: true,
+			MaxPeers:    1,
+			NoDial:      true,
+		},
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	err = setupGeth(stack)
+	if err != nil {
+		stack.Close()
+		return nil, err
+	}
+	if err = stack.Start(); err != nil {
+		stack.Close()
+		return nil, err
+	}
+	return stack, nil
+}
+
+func setupGeth(stack *node.Node) error {
+	chain, err := ethtest.LoadChain(halfchainFile, genesisPath)
+	if err != nil {
+		return err
+	}
+
+	backend, err := eth.New(stack, &ethconfig.Config{
+		Genesis:                 chain.Genesis(),
+		NetworkId:               chain.Config().ChainID.Uint64(), // 19763
+		DatabaseCache:           10,
+		TrieCleanCache:          10,
+		TrieCleanCacheJournal:   "",
+		TrieCleanCacheRejournal: 60 * time.Minute,
+		TrieDirtyCache:          16,
+		TrieTimeout:             60 * time.Minute,
+		SnapshotCache:           10,
+	})
+	if err != nil {
+		return err
+	}
+
+	_, err = backend.BlockChain().InsertChain(chain.Blocks()[1:])
+	return err
+}

--- a/cmd/devp2p/internal/ethtest/chain.go
+++ b/cmd/devp2p/internal/ethtest/chain.go
@@ -39,9 +39,19 @@ type Chain struct {
 	chainConfig *params.ChainConfig
 }
 
-// Config returns the chain config.
+// Genesis returns the chain config.
+func (c *Chain) Genesis() *core.Genesis {
+	return &c.genesis
+}
+
+// Config returns the chain genesis.
 func (c *Chain) Config() *params.ChainConfig {
 	return c.chainConfig
+}
+
+// Blocks returns the length of the chain.
+func (c *Chain) Blocks() []*types.Block {
+	return c.blocks
 }
 
 // Len returns the length of the chain.

--- a/cmd/devp2p/internal/ethtest/chain.go
+++ b/cmd/devp2p/internal/ethtest/chain.go
@@ -39,9 +39,22 @@ type Chain struct {
 	chainConfig *params.ChainConfig
 }
 
+// Config returns the chain config.
+func (c *Chain) Config() *params.ChainConfig {
+	return c.chainConfig
+}
+
 // Len returns the length of the chain.
 func (c *Chain) Len() int {
 	return len(c.blocks)
+}
+
+// GetHeaderByNumber returns a header by number.
+func (c *Chain) GetHeaderByNumber(n uint64) *types.Header {
+	if n >= uint64(c.Len()) {
+		return nil
+	}
+	return c.blocks[n].Header()
 }
 
 // TD calculates the total difficulty of the chain at the
@@ -132,9 +145,9 @@ func (c *Chain) GetHeaders(req *GetBlockHeaders) ([]*types.Header, error) {
 	return headers, nil
 }
 
-// loadChain takes the given chain.rlp file, and decodes and returns
+// LoadChain takes the given chain.rlp file, and decodes and returns
 // the blocks from the file.
-func loadChain(chainfile string, genesis string) (*Chain, error) {
+func LoadChain(chainfile string, genesis string) (*Chain, error) {
 	gen, err := loadGenesis(genesis)
 	if err != nil {
 		return nil, err
@@ -153,7 +166,7 @@ func loadChain(chainfile string, genesis string) (*Chain, error) {
 func loadGenesis(genesisFile string) (core.Genesis, error) {
 	chainConfig, err := os.ReadFile(genesisFile)
 	if err != nil {
-		return core.Genesis{}, err
+		return core.Genesis{}, fmt.Errorf("unable to load %s: %s", genesisFile, err)
 	}
 	var gen core.Genesis
 	if err := json.Unmarshal(chainConfig, &gen); err != nil {

--- a/cmd/devp2p/internal/ethtest/chain_test.go
+++ b/cmd/devp2p/internal/ethtest/chain_test.go
@@ -133,8 +133,8 @@ func TestChain_GetHeaders(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	LoadChain
-	chain, err := loadChain(chainFile, genesisFile)
+
+	chain, err := LoadChain(chainFile, genesisFile)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/cmd/devp2p/internal/ethtest/chain_test.go
+++ b/cmd/devp2p/internal/ethtest/chain_test.go
@@ -133,7 +133,7 @@ func TestChain_GetHeaders(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-
+	LoadChain
 	chain, err := loadChain(chainFile, genesisFile)
 	if err != nil {
 		t.Fatal(err)

--- a/cmd/devp2p/internal/ethtest/helpers.go
+++ b/cmd/devp2p/internal/ethtest/helpers.go
@@ -80,9 +80,9 @@ func (s *Suite) dialSnap() (*Conn, error) {
 	return conn, nil
 }
 
-// peer performs both the protocol handshake and the status message
-// exchange with the node in order to peer with it.
-func (c *Conn) peer(chain *Chain, status *Status) error {
+// Peer performs both the protocol handshake and the status message
+// exchange with the node in order to Peer with it.
+func (c *Conn) Peer(chain *Chain, status *Status) error {
 	if err := c.handshake(); err != nil {
 		return fmt.Errorf("handshake failed: %v", err)
 	}
@@ -305,10 +305,10 @@ func (s *Suite) sendNextBlock() error {
 	}
 	defer sendConn.Close()
 	defer recvConn.Close()
-	if err = sendConn.peer(s.chain, nil); err != nil {
+	if err = sendConn.Peer(s.chain, nil); err != nil {
 		return fmt.Errorf("peering failed: %v", err)
 	}
-	if err = recvConn.peer(s.chain, nil); err != nil {
+	if err = recvConn.Peer(s.chain, nil); err != nil {
 		return fmt.Errorf("peering failed: %v", err)
 	}
 	// create new block announcement
@@ -411,10 +411,10 @@ func (s *Suite) oldAnnounce() error {
 	}
 	defer sendConn.Close()
 	defer receiveConn.Close()
-	if err := sendConn.peer(s.chain, nil); err != nil {
+	if err := sendConn.Peer(s.chain, nil); err != nil {
 		return fmt.Errorf("peering failed: %v", err)
 	}
-	if err := receiveConn.peer(s.chain, nil); err != nil {
+	if err := receiveConn.Peer(s.chain, nil); err != nil {
 		return fmt.Errorf("peering failed: %v", err)
 	}
 	// create old block announcement
@@ -569,10 +569,10 @@ func (s *Suite) hashAnnounce() error {
 	}
 	defer sendConn.Close()
 	defer recvConn.Close()
-	if err := sendConn.peer(s.chain, nil); err != nil {
+	if err := sendConn.Peer(s.chain, nil); err != nil {
 		return fmt.Errorf("peering failed: %v", err)
 	}
-	if err := recvConn.peer(s.chain, nil); err != nil {
+	if err := recvConn.Peer(s.chain, nil); err != nil {
 		return fmt.Errorf("peering failed: %v", err)
 	}
 

--- a/cmd/devp2p/internal/ethtest/snap.go
+++ b/cmd/devp2p/internal/ethtest/snap.go
@@ -38,7 +38,7 @@ func (s *Suite) TestSnapStatus(t *utesting.T) {
 		t.Fatalf("dial failed: %v", err)
 	}
 	defer conn.Close()
-	if err := conn.peer(s.chain, nil); err != nil {
+	if err := conn.Peer(s.chain, nil); err != nil {
 		t.Fatalf("peering failed: %v", err)
 	}
 }
@@ -475,7 +475,7 @@ func (s *Suite) snapGetAccountRange(t *utesting.T, tc *accRangeTest) error {
 		t.Fatalf("dial failed: %v", err)
 	}
 	defer conn.Close()
-	if err = conn.peer(s.chain, nil); err != nil {
+	if err = conn.Peer(s.chain, nil); err != nil {
 		t.Fatalf("peering failed: %v", err)
 	}
 	// write request
@@ -550,7 +550,7 @@ func (s *Suite) snapGetStorageRanges(t *utesting.T, tc *stRangesTest) error {
 		t.Fatalf("dial failed: %v", err)
 	}
 	defer conn.Close()
-	if err = conn.peer(s.chain, nil); err != nil {
+	if err = conn.Peer(s.chain, nil); err != nil {
 		t.Fatalf("peering failed: %v", err)
 	}
 	// write request
@@ -594,7 +594,7 @@ func (s *Suite) snapGetByteCodes(t *utesting.T, tc *byteCodesTest) error {
 		t.Fatalf("dial failed: %v", err)
 	}
 	defer conn.Close()
-	if err = conn.peer(s.chain, nil); err != nil {
+	if err = conn.Peer(s.chain, nil); err != nil {
 		t.Fatalf("peering failed: %v", err)
 	}
 	// write request
@@ -655,7 +655,7 @@ func (s *Suite) snapGetTrieNodes(t *utesting.T, tc *trieNodesTest) error {
 		t.Fatalf("dial failed: %v", err)
 	}
 	defer conn.Close()
-	if err = conn.peer(s.chain, nil); err != nil {
+	if err = conn.Peer(s.chain, nil); err != nil {
 		t.Fatalf("peering failed: %v", err)
 	}
 	// write request

--- a/cmd/devp2p/internal/ethtest/suite.go
+++ b/cmd/devp2p/internal/ethtest/suite.go
@@ -38,7 +38,7 @@ type Suite struct {
 // be used to test the given node against the given blockchain
 // data.
 func NewSuite(dest *enode.Node, chainfile string, genesisfile string) (*Suite, error) {
-	chain, err := loadChain(chainfile, genesisfile)
+	chain, err := LoadChain(chainfile, genesisfile)
 	if err != nil {
 		return nil, err
 	}
@@ -94,7 +94,7 @@ func (s *Suite) TestStatus(t *utesting.T) {
 		t.Fatalf("dial failed: %v", err)
 	}
 	defer conn.Close()
-	if err := conn.peer(s.chain, nil); err != nil {
+	if err := conn.Peer(s.chain, nil); err != nil {
 		t.Fatalf("peering failed: %v", err)
 	}
 }
@@ -107,7 +107,7 @@ func (s *Suite) TestGetBlockHeaders(t *utesting.T) {
 		t.Fatalf("dial failed: %v", err)
 	}
 	defer conn.Close()
-	if err = conn.peer(s.chain, nil); err != nil {
+	if err = conn.Peer(s.chain, nil); err != nil {
 		t.Fatalf("peering failed: %v", err)
 	}
 	// write request
@@ -143,7 +143,7 @@ func (s *Suite) TestSimultaneousRequests(t *utesting.T) {
 		t.Fatalf("dial failed: %v", err)
 	}
 	defer conn.Close()
-	if err := conn.peer(s.chain, nil); err != nil {
+	if err := conn.Peer(s.chain, nil); err != nil {
 		t.Fatalf("peering failed: %v", err)
 	}
 
@@ -217,7 +217,7 @@ func (s *Suite) TestSameRequestID(t *utesting.T) {
 		t.Fatalf("dial failed: %v", err)
 	}
 	defer conn.Close()
-	if err := conn.peer(s.chain, nil); err != nil {
+	if err := conn.Peer(s.chain, nil); err != nil {
 		t.Fatalf("peering failed: %v", err)
 	}
 	// create requests
@@ -286,7 +286,7 @@ func (s *Suite) TestZeroRequestID(t *utesting.T) {
 		t.Fatalf("dial failed: %v", err)
 	}
 	defer conn.Close()
-	if err := conn.peer(s.chain, nil); err != nil {
+	if err := conn.Peer(s.chain, nil); err != nil {
 		t.Fatalf("peering failed: %v", err)
 	}
 	req := &GetBlockHeaders{
@@ -316,7 +316,7 @@ func (s *Suite) TestGetBlockBodies(t *utesting.T) {
 		t.Fatalf("dial failed: %v", err)
 	}
 	defer conn.Close()
-	if err := conn.peer(s.chain, nil); err != nil {
+	if err := conn.Peer(s.chain, nil); err != nil {
 		t.Fatalf("peering failed: %v", err)
 	}
 	// create block bodies request
@@ -376,7 +376,7 @@ func (s *Suite) TestLargeAnnounce(t *utesting.T) {
 		if err != nil {
 			t.Fatalf("dial failed: %v", err)
 		}
-		if err := conn.peer(s.chain, nil); err != nil {
+		if err := conn.Peer(s.chain, nil); err != nil {
 			t.Fatalf("peering failed: %v", err)
 		}
 		if err := conn.Write(blockAnnouncement); err != nil {
@@ -472,7 +472,7 @@ func (s *Suite) TestLargeTxRequest(t *utesting.T) {
 		t.Fatalf("dial failed: %v", err)
 	}
 	defer conn.Close()
-	if err = conn.peer(s.chain, nil); err != nil {
+	if err = conn.Peer(s.chain, nil); err != nil {
 		t.Fatalf("peering failed: %v", err)
 	}
 	// create and send pooled tx request
@@ -529,7 +529,7 @@ func (s *Suite) TestNewPooledTxs(t *utesting.T) {
 		t.Fatalf("dial failed: %v", err)
 	}
 	defer conn.Close()
-	if err = conn.peer(s.chain, nil); err != nil {
+	if err = conn.Peer(s.chain, nil); err != nil {
 		t.Fatalf("peering failed: %v", err)
 	}
 

--- a/cmd/devp2p/internal/ethtest/suite_test.go
+++ b/cmd/devp2p/internal/ethtest/suite_test.go
@@ -103,7 +103,7 @@ func runGeth() (*node.Node, error) {
 }
 
 func setupGeth(stack *node.Node) error {
-	chain, err := loadChain(halfchainFile, genesisFile)
+	chain, err := LoadChain(halfchainFile, genesisFile)
 	if err != nil {
 		return err
 	}

--- a/cmd/devp2p/internal/ethtest/transaction.go
+++ b/cmd/devp2p/internal/ethtest/transaction.go
@@ -62,7 +62,7 @@ func sendSuccessfulTx(s *Suite, tx *types.Transaction, prevTx *types.Transaction
 	}
 	defer sendConn.Close()
 	defer recvConn.Close()
-	if err = sendConn.peer(s.chain, nil); err != nil {
+	if err = sendConn.Peer(s.chain, nil); err != nil {
 		return fmt.Errorf("peering failed: %v", err)
 	}
 	// Send the transaction
@@ -70,7 +70,7 @@ func sendSuccessfulTx(s *Suite, tx *types.Transaction, prevTx *types.Transaction
 		return fmt.Errorf("failed to write to connection: %v", err)
 	}
 	// peer receiving connection to node
-	if err = recvConn.peer(s.chain, nil); err != nil {
+	if err = recvConn.Peer(s.chain, nil); err != nil {
 		return fmt.Errorf("peering failed: %v", err)
 	}
 
@@ -159,7 +159,7 @@ func (s *Suite) sendMaliciousTxs(t *utesting.T) error {
 		return fmt.Errorf("dial failed: %v", err)
 	}
 	defer recvConn.Close()
-	if err = recvConn.peer(s.chain, nil); err != nil {
+	if err = recvConn.Peer(s.chain, nil); err != nil {
 		return fmt.Errorf("peering failed: %v", err)
 	}
 
@@ -179,7 +179,7 @@ func sendMaliciousTx(s *Suite, tx *types.Transaction) error {
 		return fmt.Errorf("dial failed: %v", err)
 	}
 	defer conn.Close()
-	if err = conn.peer(s.chain, nil); err != nil {
+	if err = conn.Peer(s.chain, nil); err != nil {
 		return fmt.Errorf("peering failed: %v", err)
 	}
 
@@ -204,10 +204,10 @@ func sendMultipleSuccessfulTxs(t *utesting.T, s *Suite, txs []*types.Transaction
 	}
 	defer sendConn.Close()
 	defer recvConn.Close()
-	if err = sendConn.peer(s.chain, nil); err != nil {
+	if err = sendConn.Peer(s.chain, nil); err != nil {
 		return fmt.Errorf("peering failed: %v", err)
 	}
-	if err = recvConn.peer(s.chain, nil); err != nil {
+	if err = recvConn.Peer(s.chain, nil); err != nil {
 		return fmt.Errorf("peering failed: %v", err)
 	}
 

--- a/cmd/devp2p/main.go
+++ b/cmd/devp2p/main.go
@@ -53,6 +53,7 @@ func init() {
 		dnsCommand,
 		nodesetCommand,
 		rlpxCommand,
+		ethCommand,
 	}
 }
 
@@ -82,7 +83,7 @@ func getNodeArg(ctx *cli.Context) *enode.Node {
 	}
 	n, err := parseNode(ctx.Args().First())
 	if err != nil {
-		exit(err)
+		exit(fmt.Errorf("unable to parse enode: %s", err))
 	}
 	return n
 }


### PR DESCRIPTION
This PR adds a new subcommand to `devp2p`: `eth`. This subcommand has a single command of it's own currently, `new-block` which sends the specified hex as a devp2p block announcement message. We can expand `eth` to support more arbitrary message sending in the future.

```console
$ devp2p eth new-block <enode> <msg>
```