### PR TITLE
go.mod: updated logfmt dependency

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -82,9 +82,11 @@ require (
 	github.com/deepmap/oapi-codegen v1.8.2 // indirect
 	github.com/dlclark/regexp2 v1.4.1-0.20201116162257-a2a8dda75c91 // indirect
 	github.com/garslo/gogen v0.0.0-20170306192744-1d203ffc1f61 // indirect
+	github.com/go-logfmt/logfmt v0.4.0 // indirect
 	github.com/go-ole/go-ole v1.2.1 // indirect
 	github.com/go-sourcemap/sourcemap v2.1.3+incompatible // indirect
 	github.com/influxdata/line-protocol v0.0.0-20210311194329-9aa0e372d097 // indirect
+	github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515 // indirect
 	github.com/kylelemons/godebug v1.1.0 // indirect
 	github.com/mattn/go-runewidth v0.0.9 // indirect
 	github.com/mitchellh/mapstructure v1.4.1 // indirect


### PR DESCRIPTION
This fixes an issue for tests ran with go-1.17
```
--- FAIL: TestGolangBindings (0.24s)
    bind_test.go:2072: failed to tidy Go module file: exit status 1
        bindtest imports
                github.com/ethereum/go-ethereum/core/types tested by
                github.com/ethereum/go-ethereum/core/types.test imports
                github.com/ethereum/go-ethereum/core/rawdb imports
                github.com/prometheus/tsdb/fileutil tested by
                github.com/prometheus/tsdb/fileutil.test imports
                github.com/prometheus/tsdb/testutil imports
                github.com/go-kit/kit/log imports
                github.com/go-logfmt/logfmt loaded from github.com/go-logfmt/logfmt@v0.3.0,
                but go 1.16 would select v0.4.0
        
        To upgrade to the versions selected by go 1.16:
                go mod tidy -go=1.16 && go mod tidy -go=1.17
        If reproducibility with go 1.16 is not needed:
                go mod tidy -compat=1.17
        For other options, see:
                https://golang.org/doc/modules/pruning
FAIL
FAIL    github.com/ethereum/go-ethereum/accounts/abi/bind       0.256s
```

See also https://app.travis-ci.com/github/ethereum/go-ethereum/jobs/575502263