### PR TITLE
core: allow external processor

### DIFF
--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -2375,9 +2375,10 @@ func (bc *BlockChain) InsertHeaderChain(chain []*types.Header, checkFreq int) (i
 	return 0, err
 }
 
-// SetBlockValidatorForTesting sets the current validator.
+// SetBlockValidatorAndProcessorForTesting sets the current validator and processor.
 // This method can be used to force an invalid blockchain to be verified for tests.
 // This method is unsafe and should only be used before block import starts.
-func (bc *BlockChain) SetBlockValidatorForTesting(v Validator) {
+func (bc *BlockChain) SetBlockValidatorAndProcessorForTesting(v Validator, p Processor) {
 	bc.validator = v
+	bc.processor = p
 }


### PR DESCRIPTION
This extends the new `SetValidator` method so that we can also set a processor. This allows us to set invalid blocks with invalid transactions in hive