### PR TITLE
tests: only activate merge on london rules

### DIFF
--- a/tests/state_test_util.go
+++ b/tests/state_test_util.go
@@ -220,7 +220,8 @@ func (t *StateTest) RunNoVerify(subtest StateSubtest, vmconfig vm.Config, snapsh
 	context := core.NewEVMBlockContext(block.Header(), nil, &t.json.Env.Coinbase)
 	context.GetHash = vmTestBlockHash
 	context.BaseFee = baseFee
-	if t.json.Env.Random != nil {
+	context.Random = nil
+	if config.IsLondon(new(big.Int)) && t.json.Env.Random != nil {
 		rnd := common.BigToHash(t.json.Env.Random)
 		context.Random = &rnd
 		context.Difficulty = big.NewInt(0)


### PR DESCRIPTION
Otherwise some rules might be enabled even if others are disabled (e.g. berlin gas calculation on istanbul chain config)