### PR TITLE
internal/ethapi: fix chain id check to return all non-zero ids

### DIFF
--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -1290,7 +1290,7 @@ func newRPCTransaction(tx *types.Transaction, blockHash common.Hash, blockNumber
 	switch tx.Type() {
 	case types.LegacyTxType:
 		// if a legacy transaction has an EIP-155 chain id, include it explicitly
-		if id := tx.ChainId(); id.Sign() == 0 {
+		if id := tx.ChainId(); id.Sign() != 0 {
 			result.ChainID = (*hexutil.Big)(id)
 		}
 	case types.AccessListTxType:


### PR DESCRIPTION
I made a mistake in #25155 and actually reversed the check I intended. The goal was to return the chain id for legacy transactions if they are set explicitly using EIP-155, but instead it only returns `0` for non-EIP-155 legacy transactions. This PR fixes the issue.

Example:

```console
>  eth.fillTransaction({ to: a, from: a , value:1, gas: 22000, nonce: 0 })
{
  raw: "0x02e8820539800184773594018255f094b496382820de50895d3f615fc20b393709640c800180c0808080",
  tx: {
    accessList: [],
    chainId: "0x539",
    gas: "0x55f0",
    gasPrice: null,
    hash: "0xead4db694c337eae8620d7dc7607449fab019dde0e54ccefb29defe04416fc95",
    input: "0x",
    maxFeePerGas: "0x77359401",
    maxPriorityFeePerGas: "0x1",
    nonce: "0x0",
    r: "0x0",
    s: "0x0",
    to: "0xb496382820de50895d3f615fc20b393709640c80",
    type: "0x2",
    v: "0x0",
    value: "0x1"
  }
}
```