### PR TITLE
core/types: fix typo in comment

### DIFF
--- a/core/types/hashing.go
+++ b/core/types/hashing.go
@@ -31,7 +31,7 @@ var hasherPool = sync.Pool{
 	New: func() interface{} { return sha3.NewLegacyKeccak256() },
 }
 
-// deriveBufferPool holds temporary encoder buffers for DeriveSha and TX encoding.
+// encodeBufferPool holds temporary encoder buffers for DeriveSha and TX encoding.
 var encodeBufferPool = sync.Pool{
 	New: func() interface{} { return new(bytes.Buffer) },
 }


### PR DESCRIPTION
Changed `deriveBufferPool` to `encodeBufferPool`, in comment for encodeBufferPool.