### PR TITLE
Remove locking in (*BlockChain).ExportN

### DIFF
--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -754,7 +754,7 @@ func (bc *BlockChain) ExportN(w io.Writer, first uint64, last uint64) error {
 		if block == nil {
 			return fmt.Errorf("export failed on #%d: not found", nr)
 		}
-		if nr > first && block.Hash() != parentHash {
+		if nr > first && block.ParentHash() != parentHash {
 			return fmt.Errorf("export failed: chain reorg during export")
 		}
 		parentHash = block.Hash()

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -748,13 +748,13 @@ func (bc *BlockChain) ExportN(w io.Writer, first uint64, last uint64) error {
 	var parentHash common.Hash
 	for nr := first; nr <= last; nr++ {
 		block := bc.GetBlockByNumber(nr)
+		if block == nil {
+			return fmt.Errorf("export failed on #%d: not found", nr)
+		}
 		if nr > first && block.Hash() != parentHash {
 			return fmt.Errorf("export failed: chain reorg during export")
 		}
 		parentHash = block.Hash()
-		if block == nil {
-			return fmt.Errorf("export failed on #%d: not found", nr)
-		}
 		if err := block.EncodeRLP(w); err != nil {
 			return err
 		}

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -744,8 +744,11 @@ func (bc *BlockChain) ExportN(w io.Writer, first uint64, last uint64) error {
 	}
 	log.Info("Exporting batch of blocks", "count", last-first+1)
 
-	start, reported := time.Now(), time.Now()
-	var parentHash common.Hash
+	var (
+		parentHash common.Hash
+		start      = time.Now()
+		reported   = time.Now()
+	)
 	for nr := first; nr <= last; nr++ {
 		block := bc.GetBlockByNumber(nr)
 		if block == nil {

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -745,8 +745,13 @@ func (bc *BlockChain) ExportN(w io.Writer, first uint64, last uint64) error {
 	log.Info("Exporting batch of blocks", "count", last-first+1)
 
 	start, reported := time.Now(), time.Now()
+	var parentHash common.Hash
 	for nr := first; nr <= last; nr++ {
 		block := bc.GetBlockByNumber(nr)
+		if nr > first && block.Hash() != parentHash {
+			return fmt.Errorf("export failed: chain reorg during export")
+		}
+		parentHash = block.Hash()
 		if block == nil {
 			return fmt.Errorf("export failed on #%d: not found", nr)
 		}

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -739,11 +739,6 @@ func (bc *BlockChain) Export(w io.Writer) error {
 
 // ExportN writes a subset of the active chain to the given writer.
 func (bc *BlockChain) ExportN(w io.Writer, first uint64, last uint64) error {
-	if !bc.chainmu.TryLock() {
-		return errChainStopped
-	}
-	defer bc.chainmu.Unlock()
-
 	if first > last {
 		return fmt.Errorf("export failed: first (%d) is greater than last (%d)", first, last)
 	}


### PR DESCRIPTION
Since ExportN is read-only, it shouldn't need the lock. (?)