### PR TITLE
rpc: add graceful shutdown timeout for HTTP server

### DIFF
--- a/node/rpcstack.go
+++ b/node/rpcstack.go
@@ -19,7 +19,6 @@ package node
 import (
 	"compress/gzip"
 	"context"
-	"errors"
 	"fmt"
 	"io"
 	"net"

--- a/node/rpcstack.go
+++ b/node/rpcstack.go
@@ -27,6 +27,7 @@ import (
 	"strings"
 	"sync"
 	"sync/atomic"
+	"time"
 
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/rpc"
@@ -80,6 +81,10 @@ type httpServer struct {
 
 	handlerNames map[string]string
 }
+
+const (
+	shutdownTimeout = 5 * time.Second
+)
 
 func newHTTPServer(log log.Logger, timeouts rpc.HTTPTimeouts) *httpServer {
 	h := &httpServer{log: log, timeouts: timeouts, handlerNames: make(map[string]string)}
@@ -261,7 +266,12 @@ func (h *httpServer) doStop() {
 		h.wsHandler.Store((*rpcHandler)(nil))
 		wsHandler.server.Stop()
 	}
-	h.server.Shutdown(context.Background())
+	ctx, cancel := context.WithTimeout(context.Background(), shutdownTimeout)
+	defer cancel()
+	err := h.server.Shutdown(ctx)
+	if err != nil {
+		h.log.Warn("Something wrong with HTTP server graceful shutdown", "error", err)
+	}
 	h.listener.Close()
 	h.log.Info("HTTP server stopped", "endpoint", h.listener.Addr())
 

--- a/node/rpcstack.go
+++ b/node/rpcstack.go
@@ -270,8 +270,8 @@ func (h *httpServer) doStop() {
 	ctx, cancel := context.WithTimeout(context.Background(), shutdownTimeout)
 	defer cancel()
 	err := h.server.Shutdown(ctx)
-	if errors.Is(err, context.DeadlineExceeded) {
-		h.log.Warn("Some connections are not shutdown gracefully within the time bound, close them actively")
+	if err == ctx.Err() {
+		h.log.Warn("HTTP server graceful shutdown timed out")
 		h.server.Close()
 	}
 	h.listener.Close()


### PR DESCRIPTION
This is a proposed fix for #25257.

I triggered a pprof and got the goroutine snapshot during the time geth hangs. It shows that the program has caught the SIGINT signal and has entered the `shutdown()` sub-func in `StartNode()`, so it spawns the `go stack.Close()`(https://github.com/ethereum/go-ethereum/blob/master/cmd/utils/cmd.go#L92) but this goroutine then hangs at the `net/http.Shutdown()` so the terminating procedure cannot proceed.

```
goroutine 19333821 [select]:
net/http.(*Server).Shutdown(0xc014d0c620, {0x17deb68, 0xc000138000})
    net/http/server.go:2775 +0x269
github.com/ethereum/go-ethereum/node.(*httpServer).doStop(0xc0002a3040)
    github.com/ethereum/go-ethereum/node/rpcstack.go:264 +0x152
github.com/ethereum/go-ethereum/node.(*httpServer).stop(0x1357081a9754b950?)
    github.com/ethereum/go-ethereum/node/rpcstack.go:245 +0x8b
github.com/ethereum/go-ethereum/node.(*Node).stopRPC(0xc0002135e0)
    github.com/ethereum/go-ethereum/node/node.go:523 +0x2c
github.com/ethereum/go-ethereum/node.(*Node).stopServices(0xc0002135e0, {0xc014d6e690, 0x1, 0x1c69da15893bce9d?})
    github.com/ethereum/go-ethereum/node/node.go:312 +0x32
github.com/ethereum/go-ethereum/node.(*Node).Close(0xc0002135e0)
    github.com/ethereum/go-ethereum/node/node.go:237 +0x191
created by github.com/ethereum/go-ethereum/cmd/utils.StartNode.func1.1
    github.com/ethereum/go-ethereum/cmd/utils/cmd.go:92 +0x96
```

I'm not sure if there's something wrong inside the `net/http.Shutdown(ctx)` or if this is expected behavior(since it allows us to pass in a time-bound context). I'd like to post this to golang boards for some inspiration as well.