### PR TITLE
core: avoid reflect.DeepEqual to compare errors in genesis test

### DIFF
--- a/core/genesis_test.go
+++ b/core/genesis_test.go
@@ -141,7 +141,7 @@ func TestSetupGenesis(t *testing.T) {
 		db := rawdb.NewMemoryDatabase()
 		config, hash, err := test.fn(db)
 		// Check the return values.
-		if !reflect.DeepEqual(err, test.wantErr) {
+		if err != nil && err.Error() != test.wantErr.Error() {
 			spew := spew.ConfigState{DisablePointerAddresses: true, DisableCapacities: true}
 			t.Errorf("%s: returned error %#v, want %#v", test.name, spew.NewFormatter(err), spew.NewFormatter(test.wantErr))
 		}


### PR DESCRIPTION
Rewrote error comparison in tests to not depend on the inner structure of errors.