### PR TITLE
ethdb/memorydb: make keyvalue slice with cap

### DIFF
--- a/ethdb/memorydb/memorydb.go
+++ b/ethdb/memorydb/memorydb.go
@@ -136,7 +136,8 @@ func (db *Database) NewBatch() ethdb.Batch {
 // NewBatchWithSize creates a write-only database batch with pre-allocated buffer.
 func (db *Database) NewBatchWithSize(size int) ethdb.Batch {
 	return &batch{
-		db: db,
+		db:     db,
+		writes: make([]keyvalue, 0, size),
 	}
 }
 


### PR DESCRIPTION
Well, it's not used anywhere. But it seems better.