### PR TITLE
les: add flag to configure les recent available state

### DIFF
--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -105,6 +105,7 @@ var (
 		utils.UltraLightFractionFlag,
 		utils.UltraLightOnlyAnnounceFlag,
 		utils.LightNoSyncServeFlag,
+		utils.LightRecentStateFlag,
 		utils.EthRequiredBlocksFlag,
 		utils.LegacyWhitelistFlag,
 		utils.BloomFilterSizeFlag,

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -325,6 +325,12 @@ var (
 		Usage:    "Enables serving light clients before syncing",
 		Category: flags.LightCategory,
 	}
+	LightRecentStateFlag = &cli.IntFlag{
+		Name:     "light.recentstate",
+		Usage:    "Number of recent block states that should be advertised as available",
+		Value:    ethconfig.Defaults.LightRecentState,
+		Category: flags.LightCategory,
+	}
 
 	// Ethash settings
 	EthashCacheDirFlag = &flags.DirectoryFlag{
@@ -1286,6 +1292,12 @@ func setLes(ctx *cli.Context, cfg *ethconfig.Config) {
 	}
 	if ctx.IsSet(LightNoSyncServeFlag.Name) {
 		cfg.LightNoSyncServe = ctx.Bool(LightNoSyncServeFlag.Name)
+	}
+	if ctx.IsSet(LightRecentStateFlag.Name) {
+		cfg.LightRecentState = ctx.Int(LightRecentStateFlag.Name)
+		if cfg.LightRecentState <= les.BlockSafetyMargin {
+			log.Error("LES recent state value is too small", "have", cfg.LightRecentState, "safetyMargin", les.BlockSafetyMargin)
+		}
 	}
 }
 

--- a/eth/ethconfig/config.go
+++ b/eth/ethconfig/config.go
@@ -75,6 +75,7 @@ var Defaults = Config{
 	NetworkId:               1,
 	TxLookupLimit:           2350000,
 	LightPeers:              100,
+	LightRecentState:        core.TriesInMemory,
 	UltraLightFraction:      75,
 	DatabaseCache:           512,
 	TrieCleanCache:          154,
@@ -151,6 +152,7 @@ type Config struct {
 	LightNoPrune       bool `toml:",omitempty"` // Whether to disable light chain pruning
 	LightNoSyncServe   bool `toml:",omitempty"` // Whether to serve light clients before syncing
 	SyncFromCheckpoint bool `toml:",omitempty"` // Whether to sync the header chain from the configured checkpoint
+	LightRecentState   int  `toml:",omitempty"` // Number of recent block states to advertise as available
 
 	// Ultra Light client options
 	UltraLightServers      []string `toml:",omitempty"` // List of trusted ultra light servers

--- a/eth/ethconfig/gen_config.go
+++ b/eth/ethconfig/gen_config.go
@@ -34,6 +34,7 @@ func (c Config) MarshalTOML() (interface{}, error) {
 		LightNoPrune                    bool                   `toml:",omitempty"`
 		LightNoSyncServe                bool                   `toml:",omitempty"`
 		SyncFromCheckpoint              bool                   `toml:",omitempty"`
+		LightRecentState                int                    `toml:",omitempty"`
 		UltraLightServers               []string               `toml:",omitempty"`
 		UltraLightFraction              int                    `toml:",omitempty"`
 		UltraLightOnlyAnnounce          bool                   `toml:",omitempty"`
@@ -79,6 +80,7 @@ func (c Config) MarshalTOML() (interface{}, error) {
 	enc.LightNoPrune = c.LightNoPrune
 	enc.LightNoSyncServe = c.LightNoSyncServe
 	enc.SyncFromCheckpoint = c.SyncFromCheckpoint
+	enc.LightRecentState = c.LightRecentState
 	enc.UltraLightServers = c.UltraLightServers
 	enc.UltraLightFraction = c.UltraLightFraction
 	enc.UltraLightOnlyAnnounce = c.UltraLightOnlyAnnounce
@@ -128,6 +130,7 @@ func (c *Config) UnmarshalTOML(unmarshal func(interface{}) error) error {
 		LightNoPrune                    *bool                  `toml:",omitempty"`
 		LightNoSyncServe                *bool                  `toml:",omitempty"`
 		SyncFromCheckpoint              *bool                  `toml:",omitempty"`
+		LightRecentState                *int                   `toml:",omitempty"`
 		UltraLightServers               []string               `toml:",omitempty"`
 		UltraLightFraction              *int                   `toml:",omitempty"`
 		UltraLightOnlyAnnounce          *bool                  `toml:",omitempty"`
@@ -207,6 +210,9 @@ func (c *Config) UnmarshalTOML(unmarshal func(interface{}) error) error {
 	}
 	if dec.SyncFromCheckpoint != nil {
 		c.SyncFromCheckpoint = *dec.SyncFromCheckpoint
+	}
+	if dec.LightRecentState != nil {
+		c.LightRecentState = *dec.LightRecentState
 	}
 	if dec.UltraLightServers != nil {
 		c.UltraLightServers = dec.UltraLightServers

--- a/les/protocol.go
+++ b/les/protocol.go
@@ -51,7 +51,7 @@ var ProtocolLengths = map[uint]uint64{lpv2: 22, lpv3: 24, lpv4: 24}
 const (
 	NetworkId          = 1
 	ProtocolMaxMsgSize = 10 * 1024 * 1024 // Maximum cap on the size of a protocol message
-	blockSafetyMargin  = 4                // safety margin applied to block ranges specified relative to head block
+	BlockSafetyMargin  = 4                // safety margin applied to block ranges specified relative to head block
 
 	txIndexUnlimited    = 0 // this value in the "recentTxLookup" handshake field means the entire tx index history is served
 	txIndexDisabled     = 1 // this value means tx index is not served at all

--- a/les/server.go
+++ b/les/server.go
@@ -56,6 +56,7 @@ type LesServer struct {
 	lesCommons
 
 	archiveMode bool // Flag whether the ethereum node runs in archive mode.
+	recentState int
 	handler     *serverHandler
 	peers       *clientPeerSet
 	serverset   *serverSet
@@ -101,6 +102,7 @@ func NewLesServer(node *node.Node, e ethBackend, config *ethconfig.Config) (*Les
 			closeCh:          make(chan struct{}),
 		},
 		archiveMode:  e.ArchiveMode(),
+		recentState:  config.LightRecentState,
 		peers:        newClientPeerSet(),
 		serverset:    newServerSet(),
 		vfluxServer:  vfs.NewServer(time.Millisecond * 10),

--- a/les/server_handler.go
+++ b/les/server_handler.go
@@ -357,6 +357,11 @@ func (h *serverHandler) AddTxsSync() bool {
 	return h.addTxsSync
 }
 
+// RecentState implements serverBackend
+func (h *serverHandler) RecentState() int {
+	return h.server.recentState
+}
+
 // getAccount retrieves an account from the state based on root.
 func getAccount(triedb *trie.Database, root, hash common.Hash) (types.StateAccount, error) {
 	trie, err := trie.New(common.Hash{}, root, triedb)

--- a/les/server_requests.go
+++ b/les/server_requests.go
@@ -38,6 +38,7 @@ type serverBackend interface {
 	BlockChain() *core.BlockChain
 	TxPool() *core.TxPool
 	GetHelperTrie(typ uint, index uint64) *trie.Trie
+	RecentState() int
 }
 
 // Decoder is implemented by the messages passed to the handler functions
@@ -396,7 +397,7 @@ func handleGetProofs(msg Decoder) (serveRequestFn, uint64, uint64, error) {
 				// Refuse to search stale state data in the database since looking for
 				// a non-exist key is kind of expensive.
 				local := bc.CurrentHeader().Number.Uint64()
-				if !backend.ArchiveMode() && header.Number.Uint64()+core.TriesInMemory <= local {
+				if !backend.ArchiveMode() && header.Number.Uint64()+uint64(backend.RecentState()) <= local {
 					p.Log().Debug("Reject stale trie request", "number", header.Number.Uint64(), "head", local)
 					p.bumpInvalid()
 					continue

--- a/tests/fuzzers/les/les-fuzzer.go
+++ b/tests/fuzzers/les/les-fuzzer.go
@@ -252,6 +252,10 @@ func (f *fuzzer) GetHelperTrie(typ uint, index uint64) *trie.Trie {
 	return nil
 }
 
+func (f *fuzzer) RecentState() int {
+	return f.randomInt(1024)
+}
+
 type dummyMsg struct {
 	data []byte
 }


### PR DESCRIPTION
It is an expensive operation for light servers to search for unavailable state requested by light clients. Hence LES came with a heuristic of rejecting requests if they were older than 128 blocks. The exception is for archive servers which have all state available. That works fine. But if a full node sets `--gcmode archive` periodically and have some older states available they still won't be served to light clients. This PR makes the number of recent blocks to check requests for configurable through CLI.

Note that there are 2 guards against this. First, during handshake the server announces a `serveRecentState` value which clients check *before* making a request. Second, even if the client sends a request the server itself double-checks and rejects requests for stale state. I added one flag for both of these cases. If you think they are different and need separate flags happy to change it.

Fixes #25235