### PR TITLE
core: preallocate batch size in bloomIndexer

### DIFF
--- a/core/bloom_indexer.go
+++ b/core/bloom_indexer.go
@@ -75,7 +75,7 @@ func (b *BloomIndexer) Process(ctx context.Context, header *types.Header) error 
 // Commit implements core.ChainIndexerBackend, finalizing the bloom section and
 // writing it out into the database.
 func (b *BloomIndexer) Commit() error {
-	batch := b.db.NewBatch()
+	batch := b.db.NewBatchWithSize((int(b.size) / 8) * types.BloomBitLength)
 	for i := 0; i < types.BloomBitLength; i++ {
 		bits, err := b.gen.Bitset(uint(i))
 		if err != nil {


### PR DESCRIPTION
I guess, it possible that get the need memory size to Batch for BloomIndexer.Commit() in advance.
So it seems better to use NewBatchWithSize() than NewBatch().

```
// b.size will be set types.BloomBitsBlocks
batch := b.db.NewBatchWithSize((int(b.size) / 8) * types.BloomBitLength)
```
<br>

Here is my test codes and result about this.

```go
package test

import (
	"testing"
)

const BloomBitsBlocks = 4096
const BloomBitLength = 2048

type Batch struct {
	data []byte
}

func generateBloom() [BloomBitLength][]byte {
	var bloom [BloomBitLength][]byte
	for i := 0; i < BloomBitLength; i++ {
		bloom[i] = make([]byte, BloomBitsBlocks/8)
	}
	return bloom
}

func BenchmarkOrigin(b *testing.B) {
	bloom := generateBloom()

	b.ResetTimer()
	for i := 0; i < b.N; i++ {
		tBatch := Batch{}
		for j := 0; j < BloomBitLength; j++ {
			// leveldb.batch.Put() has prefix memory: 1 + binary.MaxVarintLen32 + binary.MaxVarintLen32 = 11
			// So, memory Grow occurs due to prefix memory even when an correct size is set.
			prefixMemory := make([]byte, 11)
			tBatch.data = append(tBatch.data, bloom[j]...)
			tBatch.data = append(tBatch.data, prefixMemory...)
		}
	}
}

func BenchmarkPreAllocate(b *testing.B) {
	bloom := generateBloom()

	b.ResetTimer()
	for i := 0; i < b.N; i++ {
		tBatch := Batch{
			data: make([]byte, 0, (BloomBitsBlocks/8)*BloomBitLength),
		}
		for j := 0; j < BloomBitLength; j++ {
			prefixMemory := make([]byte, 11)
			tBatch.data = append(tBatch.data, bloom[j]...)
			tBatch.data = append(tBatch.data, prefixMemory...)
		}
	}
}

```
```
goos: darwin
goarch: arm64
pkg: test/pre
BenchmarkOrigin-10                  2919            424693 ns/op
BenchmarkPreAllocate-10             7327            159329 ns/op
```

