### PR TITLE
internal/build: add a timestamp to the tar archive folder

### DIFF
--- a/internal/build/archive.go
+++ b/internal/build/archive.go
@@ -25,6 +25,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 )
 
 type Archive interface {
@@ -159,6 +160,7 @@ func (a *TarballArchive) Directory(name string) error {
 		Name:     a.dir,
 		Mode:     0755,
 		Typeflag: tar.TypeDir,
+		ModTime:  time.Now(),
 	})
 }
 


### PR DESCRIPTION
When creating the release archive tarballs, we place the files into a nested folder (e.g. `geth-linux-amd64-1.10.20-8f2416a8`). When creating this folder inside the tarball, the modification time is not set and defaults to the `0 unix timestamp`, which certain tools warn about. This PR fixes it by actually setting a timestamp on the directory header inside the tarball.

Fixes https://github.com/ethereum/go-ethereum/issues/25263.