### PR TITLE
trie, core: don't attempt to commit empty state roots

### DIFF
--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -838,6 +838,9 @@ func (bc *BlockChain) Stop() {
 		for _, offset := range []uint64{0, 1, TriesInMemory - 1} {
 			if number := bc.CurrentBlock().NumberU64(); number > offset {
 				recent := bc.GetBlockByNumber(number - offset)
+				if recent.Root() == (common.Hash{}) {
+					continue
+				}
 
 				log.Info("Writing cached state to disk", "block", recent.Number(), "hash", recent.Hash(), "root", recent.Root())
 				if err := triedb.Commit(recent.Root(), true, nil); err != nil {

--- a/trie/database.go
+++ b/trie/database.go
@@ -685,6 +685,11 @@ func (db *Database) Cap(limit common.StorageSize) error {
 // Note, this method is a non-synchronized mutator. It is unsafe to call this
 // concurrently with other mutators.
 func (db *Database) Commit(node common.Hash, report bool, callback func(common.Hash)) error {
+	if node == (common.Hash{}) {
+		// There's no data to commit in this node
+		return nil
+	}
+
 	// Create a database batch to flush persistent data out. It is important that
 	// outside code doesn't see an inconsistent state (referenced data removed from
 	// memory cache during commit but not yet in persistent storage). This is ensured


### PR DESCRIPTION
This should be nearly unreachable in practice, as it'd require an empty state in a block (and the coinbase reward populates state in early blocks), but this protects geth from attempting to commit an empty state root. Currently, if it attempts to do so, it'll crash as the cachedNode dirties entry for the empty hash contains a list of children but a nil node (which it attempts to RLP serialize).

I've fixed both the blockchain code calling Commit and Commit itself to not panic in this circumstance. Let me know if you'd prefer to only apply one of these checks and I'll update the PR :) 