### PR TITLE
docs: Update private network config

### DIFF
--- a/docs/_interface/Private-Network.md
+++ b/docs/_interface/Private-Network.md
@@ -278,6 +278,12 @@ In each data directory save a copy of the following `genesis.json` to the top le
     "byzantiumBlock": 0,
     "constantinopleBlock": 0,
     "petersburgBlock": 0,
+    "istanbulBlock": 0,
+    "muirGlacierBlock": 0,
+    "berlinBlock: 0,
+    "londonBlock": 0,
+    "arrowGlacierBlock": 0,
+    "grayGlacierBlock": 0,
     "clique": {
       "period": 5,
       "epoch": 30000

--- a/docs/_interface/Private-Network.md
+++ b/docs/_interface/Private-Network.md
@@ -280,7 +280,7 @@ In each data directory save a copy of the following `genesis.json` to the top le
     "petersburgBlock": 0,
     "istanbulBlock": 0,
     "muirGlacierBlock": 0,
-    "berlinBlock: 0,
+    "berlinBlock": 0,
     "londonBlock": 0,
     "arrowGlacierBlock": 0,
     "grayGlacierBlock": 0,


### PR DESCRIPTION
I updated the example genesis.json so that it matches mainnet's HF from block 0. 

The reason I think this is a positive change is that users get confused by tools not behaving like their private network by default: https://github.com/NomicFoundation/hardhat/issues/2946