### PR TITLE
eth: fix typo in comment

### DIFF
--- a/eth/api.go
+++ b/eth/api.go
@@ -157,7 +157,7 @@ func (api *AdminAPI) ExportChain(file string, first *uint64, last *uint64) (bool
 	}
 	if _, err := os.Stat(file); err == nil {
 		// File already exists. Allowing overwrite could be a DoS vector,
-		// since the 'file' may point to arbitrary paths on the drive
+		// since the 'file' may point to arbitrary paths on the drive.
 		return false, errors.New("location would overwrite an existing file")
 	}
 	// Make sure we can create the file to export into


### PR DESCRIPTION
Fixed grammatical error in comment. 
Added a period at the end of the comment on line 160 of 'eth/api.go' to make the comment style consistent with both [gofmt](https://github.com/golang/go/blob/master/src/cmd/gofmt/gofmt.go) comment conventions and the rest of the file.

Co-Authored-By: Rithwik Babu <54031798+rithwikbabu@users.noreply.github.com>
Co-Authored-By: JAIN0103 <85311310+jain0103@users.noreply.github.com>