### PR TITLE
light/trie_test.go: fix differTries err message

### DIFF
--- a/light/trie_test.go
+++ b/light/trie_test.go
@@ -76,7 +76,7 @@ func diffTries(t1, t2 state.Trie) error {
 	case i1.Err != nil:
 		return fmt.Errorf("full trie iterator error: %v", i1.Err)
 	case i2.Err != nil:
-		return fmt.Errorf("light trie iterator error: %v", i1.Err)
+		return fmt.Errorf("light trie iterator error: %v", i2.Err)
 	case i1.Next():
 		return fmt.Errorf("full trie iterator has more k/v pairs")
 	case i2.Next():


### PR DESCRIPTION
fix `differTries()` error message