### PR TITLE
core/types/hashing.go: reset object before return to encodeBufferPool

### DIFF
--- a/core/types/hashing.go
+++ b/core/types/hashing.go
@@ -89,6 +89,7 @@ func DeriveSha(list DerivableList, hasher TrieHasher) common.Hash {
 
 	valueBuf := encodeBufferPool.Get().(*bytes.Buffer)
 	defer encodeBufferPool.Put(valueBuf)
+	defer valueBuf.Reset()
 
 	// StackTrie requires values to be inserted in increasing hash order, which is not the
 	// order that `list` provides hashes in. This insertion sequence ensures that the


### PR DESCRIPTION
https://github.com/ethereum/go-ethereum/blob/89b138cf2fe5c988eea8f2e74d042fc092849f8e/core/types/hashing.go#L90-L91


To avoid high memory usage, `valueBuf` should call `valueBuf.Reset()` before returning it to `encodeBufferPool`.