### PR TITLE
params: set sepolia mergeNetsplitBlock to 1735371

### DIFF
--- a/core/forkid/forkid_test.go
+++ b/core/forkid/forkid_test.go
@@ -138,6 +138,16 @@ func TestCreation(t *testing.T) {
 				{6000000, ID{Hash: checksumToBytes(0xB8C6299D), Next: 0}},       // Future London block
 			},
 		},
+		// Sepolia test cases
+		{
+			params.SepoliaChainConfig,
+			params.SepoliaGenesisHash,
+			[]testcase{
+				{0, ID{Hash: checksumToBytes(0xfe3366e7), Next: 1735371}},       // Unsynced, last Frontier, Homestead, Tangerine, Spurious, Byzantium, Constantinople, Petersburg, Istanbul, Berlin and first London block
+				{1735370, ID{Hash: checksumToBytes(0xfe3366e7), Next: 1735371}}, // Last London block
+				{1735371, ID{Hash: checksumToBytes(0xb96cbd13), Next: 0}},       // First MergeNetsplit block
+			},
+		},
 		// Merge test cases
 		{
 			&mergeConfig,

--- a/params/config.go
+++ b/params/config.go
@@ -157,6 +157,7 @@ var (
 		BerlinBlock:             big.NewInt(0),
 		LondonBlock:             big.NewInt(0),
 		TerminalTotalDifficulty: big.NewInt(17_000_000_000_000_000),
+		MergeNetsplitBlock:      big.NewInt(1735371),
 		Ethash:                  new(EthashConfig),
 	}
 


### PR DESCRIPTION
This PR sets the merge netsplit block for sepolia as defined in https://github.com/ethereum/execution-specs/pull/564/files