### PR TITLE
core: force snapshot creation upon genesis init

### DIFF
--- a/core/genesis.go
+++ b/core/genesis.go
@@ -30,6 +30,7 @@ import (
 	"github.com/ethereum/go-ethereum/common/math"
 	"github.com/ethereum/go-ethereum/core/rawdb"
 	"github.com/ethereum/go-ethereum/core/state"
+	"github.com/ethereum/go-ethereum/core/state/snapshot"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/ethdb"
@@ -83,7 +84,12 @@ func (ga *GenesisAlloc) UnmarshalJSON(data []byte) error {
 // flush adds allocated genesis accounts into a fresh new statedb and
 // commit the state changes into the given database handler.
 func (ga *GenesisAlloc) flush(db ethdb.Database) (common.Hash, error) {
-	statedb, err := state.New(common.Hash{}, state.NewDatabase(db), nil)
+	triedb := state.NewDatabase(db)
+	snaps, err := snapshot.New(db, triedb.TrieDB(), 1, common.Hash{}, false, true, false)
+	if err != nil {
+		return common.Hash{}, err
+	}
+	statedb, err := state.New(common.Hash{}, triedb, snaps)
 	if err != nil {
 		return common.Hash{}, err
 	}


### PR DESCRIPTION
Second PR to minimize the final footprint of the verkle code: ensure that the snapshot is created at genesis time. This is useful for the verkle tree, because it reads account/storage data directly from the snapshot.

I have thought of making this creation still conditional on `--snapshot` not being `false`. I refrained from doing that because 1) I assume this flag will soon be deprecated, and 2) even in the case of `--snapshot=false`, the snapshot would be created only for the genesis block and would not be used after that.  I can certainly update the PR to take this flag into account if this is desirable.