### PR TITLE
core: don't return a nil value upon error in GetTd

### DIFF
--- a/core/headerchain.go
+++ b/core/headerchain.go
@@ -446,7 +446,8 @@ func (hc *HeaderChain) GetTd(hash common.Hash, number uint64) *big.Int {
 	}
 	td := rawdb.ReadTd(hc.chainDb, hash, number)
 	if td == nil {
-		return nil
+		log.Crit("could not find the difficulty for block", "hash", hash)
+		return big.NewInt(0)
 	}
 	// Cache the found body for next time and return
 	hc.tdCache.Add(hash, td)


### PR DESCRIPTION
Found this one while trying to sync with an invalid genesis block on a private testnet: it recovers an invalid hash from the db, looks for the td for that hash, doesn't find it and as a result returns a `nil` that will cause a panic at a different location.

I suggest that an error be logged, but that geth doesn't crash, especially in the wrong location. 0 sounds like the only valid value to return: the difficulty of a non-existent chain.