### PR TITLE
ethclient: add `FeeHistory` support

### DIFF
--- a/ethclient/ethclient.go
+++ b/ethclient/ethclient.go
@@ -523,7 +523,7 @@ type feeHistoryResultMarshaling struct {
 // FeeHistory retrieves the fee market history.
 func (ec *Client) FeeHistory(ctx context.Context, blockCount uint64, lastBlock *big.Int, rewardPercentiles []float64) (*FeeHistoryResult, error) {
 	var res feeHistoryResultMarshaling
-	if err := ec.c.CallContext(ctx, &res, "eth_feeHistory", hexutil.Uint(blockCount), hexutil.Big(*lastBlock), rewardPercentiles); err != nil {
+	if err := ec.c.CallContext(ctx, &res, "eth_feeHistory", hexutil.Uint(blockCount), toBlockNumArg(lastBlock), rewardPercentiles); err != nil {
 		return nil, err
 	}
 	reward := make([][]*big.Int, len(res.Reward))

--- a/ethclient/ethclient.go
+++ b/ethclient/ethclient.go
@@ -505,6 +505,46 @@ func (ec *Client) SuggestGasTipCap(ctx context.Context) (*big.Int, error) {
 	return (*big.Int)(&hex), nil
 }
 
+// FeeHistoryResult is the result of FeeHistory.
+type FeeHistoryResult struct {
+	OldestBlock  *big.Int     `json:"oldestBlock"`
+	Reward       [][]*big.Int `json:"reward,omitempty"`
+	BaseFee      []*big.Int   `json:"baseFeePerGas,omitempty"`
+	GasUsedRatio []float64    `json:"gasUsedRatio"`
+}
+
+type feeHistoryResultMarshaling struct {
+	OldestBlock  *hexutil.Big     `json:"oldestBlock"`
+	Reward       [][]*hexutil.Big `json:"reward,omitempty"`
+	BaseFee      []*hexutil.Big   `json:"baseFeePerGas,omitempty"`
+	GasUsedRatio []float64        `json:"gasUsedRatio"`
+}
+
+// FeeHistory retrieves the fee market history.
+func (ec *Client) FeeHistory(ctx context.Context, blockCount uint64, lastBlock *big.Int, rewardPercentiles []float64) (*FeeHistoryResult, error) {
+	var res feeHistoryResultMarshaling
+	if err := ec.c.CallContext(ctx, &res, "eth_feeHistory", hexutil.Uint(blockCount), hexutil.Big(*lastBlock), rewardPercentiles); err != nil {
+		return nil, err
+	}
+	reward := make([][]*big.Int, len(res.Reward))
+	for i, r := range res.Reward {
+		reward[i] = make([]*big.Int, len(r))
+		for j, r := range r {
+			reward[i][j] = (*big.Int)(r)
+		}
+	}
+	baseFee := make([]*big.Int, len(res.BaseFee))
+	for i, b := range res.BaseFee {
+		baseFee[i] = (*big.Int)(b)
+	}
+	return &FeeHistoryResult{
+		OldestBlock:  (*big.Int)(res.OldestBlock),
+		Reward:       reward,
+		BaseFee:      baseFee,
+		GasUsedRatio: res.GasUsedRatio,
+	}, nil
+}
+
 // EstimateGas tries to estimate the gas needed to execute a specific transaction based on
 // the current pending state of the backend blockchain. There is no guarantee that this is
 // the true gas limit requirement as other transactions may be added or removed by miners,

--- a/ethclient/ethclient.go
+++ b/ethclient/ethclient.go
@@ -505,14 +505,6 @@ func (ec *Client) SuggestGasTipCap(ctx context.Context) (*big.Int, error) {
 	return (*big.Int)(&hex), nil
 }
 
-// FeeHistoryResult is the result of FeeHistory.
-type FeeHistoryResult struct {
-	OldestBlock  *big.Int     `json:"oldestBlock"`
-	Reward       [][]*big.Int `json:"reward,omitempty"`
-	BaseFee      []*big.Int   `json:"baseFeePerGas,omitempty"`
-	GasUsedRatio []float64    `json:"gasUsedRatio"`
-}
-
 type feeHistoryResultMarshaling struct {
 	OldestBlock  *hexutil.Big     `json:"oldestBlock"`
 	Reward       [][]*hexutil.Big `json:"reward,omitempty"`
@@ -521,7 +513,7 @@ type feeHistoryResultMarshaling struct {
 }
 
 // FeeHistory retrieves the fee market history.
-func (ec *Client) FeeHistory(ctx context.Context, blockCount uint64, lastBlock *big.Int, rewardPercentiles []float64) (*FeeHistoryResult, error) {
+func (ec *Client) FeeHistory(ctx context.Context, blockCount uint64, lastBlock *big.Int, rewardPercentiles []float64) (*ethereum.FeeHistory, error) {
 	var res feeHistoryResultMarshaling
 	if err := ec.c.CallContext(ctx, &res, "eth_feeHistory", hexutil.Uint(blockCount), toBlockNumArg(lastBlock), rewardPercentiles); err != nil {
 		return nil, err
@@ -537,7 +529,7 @@ func (ec *Client) FeeHistory(ctx context.Context, blockCount uint64, lastBlock *
 	for i, b := range res.BaseFee {
 		baseFee[i] = (*big.Int)(b)
 	}
-	return &FeeHistoryResult{
+	return &ethereum.FeeHistory{
 		OldestBlock:  (*big.Int)(res.OldestBlock),
 		Reward:       reward,
 		BaseFee:      baseFee,

--- a/ethclient/ethclient_test.go
+++ b/ethclient/ethclient_test.go
@@ -508,6 +508,29 @@ func testStatusFunctions(t *testing.T, client *rpc.Client) {
 	if gasTipCap.Cmp(big.NewInt(234375000)) != 0 {
 		t.Fatalf("unexpected gas tip cap: %v", gasTipCap)
 	}
+
+	// FeeHistory
+	history, err := ec.FeeHistory(context.Background(), 1, big.NewInt(2), []float64{95, 99})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := &FeeHistoryResult{
+		OldestBlock: big.NewInt(2),
+		Reward: [][]*big.Int{
+			{
+				big.NewInt(234375000),
+				big.NewInt(234375000),
+			},
+		},
+		BaseFee: []*big.Int{
+			big.NewInt(765625000),
+			big.NewInt(671627818),
+		},
+		GasUsedRatio: []float64{0.008912678667376286},
+	}
+	if !reflect.DeepEqual(history, want) {
+		t.Fatalf("FeeHistory result doesn't match expected: (got: %v, want: %v)", history, want)
+	}
 }
 
 func testCallContractAtHash(t *testing.T, client *rpc.Client) {

--- a/ethclient/ethclient_test.go
+++ b/ethclient/ethclient_test.go
@@ -514,7 +514,7 @@ func testStatusFunctions(t *testing.T, client *rpc.Client) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	want := &FeeHistoryResult{
+	want := &ethereum.FeeHistory{
 		OldestBlock: big.NewInt(2),
 		Reward: [][]*big.Int{
 			{

--- a/interfaces.go
+++ b/interfaces.go
@@ -204,10 +204,10 @@ type GasPricer interface {
 // FeeHistory provides recent fee market data that consumers can use to determine
 // a reasonable maxPriorityFeePerGas value.
 type FeeHistory struct {
-	OldestBlock  *big.Int     `json:"oldestBlock"`             // block coresponding to first response value
-	Reward       [][]*big.Int `json:"reward,omitempty"`        // list every txs priority fee per block
-	BaseFee      []*big.Int   `json:"baseFeePerGas,omitempty"` // list of each block's base fee
-	GasUsedRatio []float64    `json:"gasUsedRatio"`            // ratio of gas used out of the total avaialble limit
+	OldestBlock  *big.Int     // block coresponding to first response value
+	Reward       [][]*big.Int // list every txs priority fee per block
+	BaseFee      []*big.Int   // list of each block's base fee
+	GasUsedRatio []float64    // ratio of gas used out of the total avaialble limit
 }
 
 // A PendingStateReader provides access to the pending state, which is the result of all

--- a/interfaces.go
+++ b/interfaces.go
@@ -201,6 +201,15 @@ type GasPricer interface {
 	SuggestGasPrice(ctx context.Context) (*big.Int, error)
 }
 
+// FeeHistory provides recent fee market data that consumers can use to determine
+// a reasonable maxPriorityFeePerGas value.
+type FeeHistory struct {
+	OldestBlock  *big.Int     `json:"oldestBlock"`             // block coresponding to first response value
+	Reward       [][]*big.Int `json:"reward,omitempty"`        // list every txs priority fee per block
+	BaseFee      []*big.Int   `json:"baseFeePerGas,omitempty"` // list of each block's base fee
+	GasUsedRatio []float64    `json:"gasUsedRatio"`            // ratio of gas used out of the total avaialble limit
+}
+
 // A PendingStateReader provides access to the pending state, which is the result of all
 // known executable transactions which have not yet been included in the blockchain. It is
 // commonly used to display the result of ’unconfirmed’ actions (e.g. wallet value

--- a/interfaces.go
+++ b/interfaces.go
@@ -207,7 +207,7 @@ type FeeHistory struct {
 	OldestBlock  *big.Int     // block coresponding to first response value
 	Reward       [][]*big.Int // list every txs priority fee per block
 	BaseFee      []*big.Int   // list of each block's base fee
-	GasUsedRatio []float64    // ratio of gas used out of the total avaialble limit
+	GasUsedRatio []float64    // ratio of gas used out of the total available limit
 }
 
 // A PendingStateReader provides access to the pending state, which is the result of all

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -86,6 +86,7 @@ type feeHistoryResult struct {
 	GasUsedRatio []float64        `json:"gasUsedRatio"`
 }
 
+// FeeHistory returns the fee market history.
 func (s *EthereumAPI) FeeHistory(ctx context.Context, blockCount rpc.DecimalOrHex, lastBlock rpc.BlockNumber, rewardPercentiles []float64) (*feeHistoryResult, error) {
 	oldest, reward, baseFee, gasUsed, err := s.b.FeeHistory(ctx, int(blockCount), lastBlock, rewardPercentiles)
 	if err != nil {


### PR DESCRIPTION
Since fee history [is in](https://github.com/ethereum/execution-apis/blob/b4051c2f97cbd83f29c4f2cf3bdc2737600e5cc8/src/eth/fee_market.yaml#L9-L66) the JSON-RPC specification, I think it makes sense to support in `ethclient`. It's not trivial to decode the response into nice types when making the raw call.