### PR TITLE
eth/catalyst: return syncing not accepted

### DIFF
--- a/eth/catalyst/api.go
+++ b/eth/catalyst/api.go
@@ -428,7 +428,7 @@ func (api *ConsensusAPI) delayPayloadImport(block *types.Block) (beacon.PayloadS
 		// and cannot afford concurrent out-if-band modifications via imports.
 		log.Warn("Ignoring payload while snap syncing", "number", block.NumberU64(), "hash", block.Hash())
 	}
-	return beacon.PayloadStatusV1{Status: beacon.ACCEPTED}, nil
+	return beacon.PayloadStatusV1{Status: beacon.SYNCING}, nil
 }
 
 // setInvalidAncestor is a callback for the downloader to notify us if a bad block

--- a/eth/catalyst/api_test.go
+++ b/eth/catalyst/api_test.go
@@ -662,8 +662,8 @@ func TestEmptyBlocks(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if status.Status != beacon.ACCEPTED {
-		t.Errorf("invalid status: expected ACCEPTED got: %v", status.Status)
+	if status.Status != beacon.SYNCING {
+		t.Errorf("invalid status: expected SYNCING got: %v", status.Status)
 	}
 	if status.LatestValidHash != nil {
 		t.Fatalf("invalid LVH: got %v wanted nil", status.LatestValidHash)


### PR DESCRIPTION
> ACCEPTED is only allowed when "ancestors of a payload are known and comprise a well-formed chain."

At this point we don't know that, so we need to return syncing