### PR TITLE
node: set JWT expiry to 60 seconds

### DIFF
--- a/node/jwt_handler.go
+++ b/node/jwt_handler.go
@@ -24,6 +24,8 @@ import (
 	"github.com/golang-jwt/jwt/v4"
 )
 
+const expiryTime = 60 * time.Second
+
 type jwtHandler struct {
 	keyFunc func(token *jwt.Token) (interface{}, error)
 	next    http.Handler
@@ -68,9 +70,9 @@ func (handler *jwtHandler) ServeHTTP(out http.ResponseWriter, r *http.Request) {
 		http.Error(out, "token is expired", http.StatusForbidden)
 	case claims.IssuedAt == nil:
 		http.Error(out, "missing issued-at", http.StatusForbidden)
-	case time.Since(claims.IssuedAt.Time) > 5*time.Second:
+	case time.Since(claims.IssuedAt.Time) > expiryTime:
 		http.Error(out, "stale token", http.StatusForbidden)
-	case time.Until(claims.IssuedAt.Time) > 5*time.Second:
+	case time.Until(claims.IssuedAt.Time) > expiryTime:
 		http.Error(out, "future token", http.StatusForbidden)
 	default:
 		handler.next.ServeHTTP(out, r)

--- a/node/jwt_handler.go
+++ b/node/jwt_handler.go
@@ -24,7 +24,7 @@ import (
 	"github.com/golang-jwt/jwt/v4"
 )
 
-const expiryTime = 60 * time.Second
+const jwtExpiryTimeout = 60 * time.Second
 
 type jwtHandler struct {
 	keyFunc func(token *jwt.Token) (interface{}, error)
@@ -70,9 +70,9 @@ func (handler *jwtHandler) ServeHTTP(out http.ResponseWriter, r *http.Request) {
 		http.Error(out, "token is expired", http.StatusForbidden)
 	case claims.IssuedAt == nil:
 		http.Error(out, "missing issued-at", http.StatusForbidden)
-	case time.Since(claims.IssuedAt.Time) > expiryTime:
+	case time.Since(claims.IssuedAt.Time) > jwtExpiryTimeout:
 		http.Error(out, "stale token", http.StatusForbidden)
-	case time.Until(claims.IssuedAt.Time) > expiryTime:
+	case time.Until(claims.IssuedAt.Time) > jwtExpiryTimeout:
 		http.Error(out, "future token", http.StatusForbidden)
 	default:
 		handler.next.ServeHTTP(out, r)

--- a/node/rpcstack_test.go
+++ b/node/rpcstack_test.go
@@ -356,11 +356,11 @@ func TestJWT(t *testing.T) {
 	expFail := []func() string{
 		// future
 		func() string {
-			return fmt.Sprintf("Bearer %v", issueToken(secret, nil, testClaim{"iat": time.Now().Unix() + int64(expiryTime.Seconds()) + 1}))
+			return fmt.Sprintf("Bearer %v", issueToken(secret, nil, testClaim{"iat": time.Now().Unix() + int64(jwtExpiryTimeout.Seconds()) + 1}))
 		},
 		// stale
 		func() string {
-			return fmt.Sprintf("Bearer %v", issueToken(secret, nil, testClaim{"iat": time.Now().Unix() - int64(expiryTime.Seconds()) - 1}))
+			return fmt.Sprintf("Bearer %v", issueToken(secret, nil, testClaim{"iat": time.Now().Unix() - int64(jwtExpiryTimeout.Seconds()) - 1}))
 		},
 		// wrong algo
 		func() string {

--- a/node/rpcstack_test.go
+++ b/node/rpcstack_test.go
@@ -356,11 +356,11 @@ func TestJWT(t *testing.T) {
 	expFail := []func() string{
 		// future
 		func() string {
-			return fmt.Sprintf("Bearer %v", issueToken(secret, nil, testClaim{"iat": time.Now().Unix() + 6}))
+			return fmt.Sprintf("Bearer %v", issueToken(secret, nil, testClaim{"iat": time.Now().Unix() + int64(expiryTime.Seconds()) + 1}))
 		},
 		// stale
 		func() string {
-			return fmt.Sprintf("Bearer %v", issueToken(secret, nil, testClaim{"iat": time.Now().Unix() - 6}))
+			return fmt.Sprintf("Bearer %v", issueToken(secret, nil, testClaim{"iat": time.Now().Unix() - int64(expiryTime.Seconds()) - 1}))
 		},
 		// wrong algo
 		func() string {


### PR DESCRIPTION
The default JWT timeout recently changed: https://github.com/ethereum/execution-apis/blob/main/src/engine/authentication.md#jwt-claims