### PR TITLE
Update debug_traceTransaction specification

### DIFF
--- a/docs/_rpc/ns-debug.md
+++ b/docs/_rpc/ns-debug.md
@@ -753,7 +753,7 @@ Specifying the `tracer` option in the second argument enables JavaScript-based t
 `log` has the following fields:
 
  - `op`: Object, an OpCode object representing the current opcode
- - `stack`: array[big.Int], the EVM execution stack
+ - `stack`: Object, a structure representing the EVM execution stack
  - `memory`: Object, a structure representing the contract's memory space
  - `contract`: Object, an object representing the account executing the current operation
 


### PR DESCRIPTION
Looking at the JavaScript-based tracing specification of debug_traceTransaction the specification of `log.stack` seems incorrect because there is a `log.stack` Object with a couple of methods defined (peek and lengh) but the list of fields of `log` does not mention this `stack` Object.
Please let me know what is the most correct/recent specification for this endpoint.