### PR TITLE
eth/catalyst: return 0x0 if latestvalid is pow block

### DIFF
--- a/eth/catalyst/api.go
+++ b/eth/catalyst/api.go
@@ -479,12 +479,11 @@ func (api *ConsensusAPI) checkInvalidAncestor(check common.Hash, head common.Has
 		}
 		api.invalidTipsets[head] = invalid
 	}
-	// if the last valid hash is the terminal pow block, return 0x0 for latest valid hash
+	// If the last valid hash is the terminal pow block, return 0x0 for latest valid hash
 	lastValid := &invalid.ParentHash
-	if header := api.eth.BlockChain().GetHeaderByHash(invalid.ParentHash); header != nil && header.Difficulty.BitLen() == 0 {
+	if header := api.eth.BlockChain().GetHeader(invalid.ParentHash, invalid.Number.Uint64()-1); header != nil && header.Difficulty.Sign() != 0 {
 		lastValid = &common.Hash{}
 	}
-
 	failure := "links to previously rejected block"
 	return &beacon.PayloadStatusV1{
 		Status:          beacon.INVALID,

--- a/eth/catalyst/api.go
+++ b/eth/catalyst/api.go
@@ -479,10 +479,16 @@ func (api *ConsensusAPI) checkInvalidAncestor(check common.Hash, head common.Has
 		}
 		api.invalidTipsets[head] = invalid
 	}
+	// if the last valid hash is the terminal pow block, return 0x0 for latest valid hash
+	lastValid := &invalid.ParentHash
+	if header := api.eth.BlockChain().GetHeaderByHash(invalid.ParentHash); header != nil && header.Difficulty.BitLen() == 0 {
+		lastValid = nil
+	}
+
 	failure := "links to previously rejected block"
 	return &beacon.PayloadStatusV1{
 		Status:          beacon.INVALID,
-		LatestValidHash: &invalid.ParentHash,
+		LatestValidHash: lastValid,
 		ValidationError: &failure,
 	}
 }

--- a/eth/catalyst/api.go
+++ b/eth/catalyst/api.go
@@ -482,7 +482,7 @@ func (api *ConsensusAPI) checkInvalidAncestor(check common.Hash, head common.Has
 	// if the last valid hash is the terminal pow block, return 0x0 for latest valid hash
 	lastValid := &invalid.ParentHash
 	if header := api.eth.BlockChain().GetHeaderByHash(invalid.ParentHash); header != nil && header.Difficulty.BitLen() == 0 {
-		lastValid = nil
+		lastValid = &common.Hash{}
 	}
 
 	failure := "links to previously rejected block"


### PR DESCRIPTION
Weird requirement of the engine api
> {payloadStatus: {status: INVALID, latestValidHash: 0x0000000000000000000000000000000000000000000000000000000000000000, validationError: errorMessage | null}, payloadId: null} obtained either from the [Payload validation](https://github.com/ethereum/execution-apis/blob/main/src/engine/specification.md#payload-validation) process or as a result of validating a terminal PoW block referenced by forkchoiceState.headBlockHash

Fixes two hive tests