### PR TITLE
eth,core: re-enable LRU cache in GetLogs

### DIFF
--- a/core/blockchain_reader.go
+++ b/core/blockchain_reader.go
@@ -222,6 +222,16 @@ func (bc *BlockChain) GetReceiptsByHash(hash common.Hash) types.Receipts {
 	return receipts
 }
 
+// GetLogsByHash retrieves the logs from all receipts for all transactions in a given block.
+func (bc *BlockChain) GetLogsByHash(hash common.Hash) [][]*types.Log {
+	receipts := bc.GetReceiptsByHash(hash)
+	logs := make([][]*types.Log, len(receipts))
+	for i, receipt := range receipts {
+		logs[i] = receipt.Logs
+	}
+	return logs
+}
+
 // GetUnclesInChain retrieves all the uncles from a given block backwards until
 // a specific distance is reached.
 func (bc *BlockChain) GetUnclesInChain(block *types.Block, length int) []*types.Header {

--- a/eth/api_backend.go
+++ b/eth/api_backend.go
@@ -208,11 +208,8 @@ func (b *EthAPIBackend) GetLogs(ctx context.Context, hash common.Hash) ([][]*typ
 	if number == nil {
 		return nil, fmt.Errorf("failed to get block number for hash %#x", hash)
 	}
-	logs := rawdb.ReadLogs(db, hash, *number, b.eth.blockchain.Config())
-	if logs == nil {
-		return nil, fmt.Errorf("failed to get logs for block #%d (0x%s)", *number, hash.TerminalString())
-	}
-	return logs, nil
+
+	return b.eth.blockchain.GetLogsByHash(hash), nil
 }
 
 func (b *EthAPIBackend) GetTd(ctx context.Context, hash common.Hash) *big.Int {


### PR DESCRIPTION
NOTE: IMO this PR is _not_ yet ready for merge, it's more of a starting off point.

As noted in https://github.com/ethereum/go-ethereum/issues/25421 I'm pretty sure there's a rather severe performance regression around the `eth_getLogs` RPC.

To validate that, I've made this PR which re-enables the `BlockChain` codepath to reintroduce the `receiptsCache` LRU into the mix.

On two mainnet nodes each receiving a rather high volume of `eth_getLogs` RPCs (but only for the most recent 128 blocks) the pprof flamegraph is rather telling.

Note that in both cases I'm already running with a small patch that raises the size of the receiptsCache LRU from `32` to `1024`, available here: https://github.com/ryanschneider/go-ethereum/commit/ae9a5ee0a027b7667821115766cbdd832e479b1b

Anyways, with only that patch applied, we see that overall a lot of time is spent in `unindexedLogs`, and that most of that time is spent in `ReadLogs`:

![image](https://user-images.githubusercontent.com/53520/181370061-c8d08c77-cdb8-407a-859c-6baeb42cb006.png)

Note that this flame graph is a 30s CPU profile, so at 188s of CPU time `unindexedLogs` is fully consuming more than 6 CPUs at 100% utilization.

And now with the work-in-progress patch in this PR:

![image](https://user-images.githubusercontent.com/53520/181369836-c4c545e7-5e2f-47d7-8569-57b1d1a63f05.png)

Of course we don't see `ReadLogs` at all any more, since that code isn't in the codepath anymore, but note that overall CPU time of `unindexedLogs` is now only 3.7s.

### Why I consider this PR is still  Work-In-Progess

There's two main reasons I'd consider this PR a WIP:

- I'm not familiar w/ what prompted the original changes in https://github.com/ethereum/go-ethereum/pull/23147 but as currently written this PR would undo those changes.
- If we wanted to go forward w/ this version, we'd probably want to remove `ReadLogs` entirely since it's not used.

It's definitely possible to get the "best of both worlds" by adding a LRU cache to `ReadLogs` but I don't currently see anything like that in `rawdb` and I wouldn't want to introduce something like that w/o discussing it first.  Note that doing so would also add more memory usage as this LRU would be specialized to logs and not receipts and thus could not be reused so would "compete" w/ the existing LRUs in `BlockChain`.

Basically the balancing act is that the current master version has somewhat better overall performance for single RPCs by avoiding some redundant decoding in the rawdb layer, but has overall worse _parallel_ performance due to the lack of caching leading to the same receipts/logs being read from the DB multiple times.

Anyways cc @s1na @fjl and @holiman since you three have been involved in ✅ for all recent PRs on this subject.
