### PR TITLE
core: move RLP encoding of values to trie

### DIFF
--- a/core/state/database.go
+++ b/core/state/database.go
@@ -71,7 +71,9 @@ type Trie interface {
 	// trie.MissingNodeError is returned.
 	TryGet(key []byte) ([]byte, error)
 
-	// TryUpdateAccount abstract an account write in the trie.
+	TryGetAccount(key []byte) (*types.StateAccount, error)
+
+	// TryUpdateAccount abstract an account write to the trie.
 	TryUpdateAccount(key []byte, account *types.StateAccount) error
 
 	// TryUpdate associates key with value in the trie. If value has length zero, any

--- a/core/state/state_object.go
+++ b/core/state/state_object.go
@@ -333,9 +333,7 @@ func (s *stateObject) updateTrie(db Database) Trie {
 			s.setError(tr.TryDelete(key[:]))
 			s.db.StorageDeleted += 1
 		} else {
-			// Encoding []byte cannot fail, ok to ignore the error.
-			v, _ = rlp.EncodeToBytes(common.TrimLeftZeroes(value[:]))
-			s.setError(tr.TryUpdate(key[:], v))
+			s.setError(tr.TryUpdate(key[:], value[:]))
 			s.db.StorageUpdated += 1
 		}
 		// If state snapshotting is active, cache the data til commit

--- a/core/state/statedb.go
+++ b/core/state/statedb.go
@@ -537,20 +537,16 @@ func (s *StateDB) getDeletedStateObject(addr common.Address) *stateObject {
 	// If snapshot unavailable or reading from it failed, load from the database
 	if data == nil {
 		start := time.Now()
-		enc, err := s.trie.TryGet(addr.Bytes())
+		var err error
+		data, err = s.trie.TryGetAccount(addr.Bytes())
 		if metrics.EnabledExpensive {
 			s.AccountReads += time.Since(start)
 		}
 		if err != nil {
-			s.setError(fmt.Errorf("getDeleteStateObject (%x) error: %v", addr.Bytes(), err))
+			s.setError(fmt.Errorf("getDeleteStateObject (%x) error: %w", addr.Bytes(), err))
 			return nil
 		}
-		if len(enc) == 0 {
-			return nil
-		}
-		data = new(types.StateAccount)
-		if err := rlp.DecodeBytes(enc, data); err != nil {
-			log.Error("Failed to decode state object", "addr", addr, "err", err)
+		if data == nil {
 			return nil
 		}
 	}

--- a/eth/protocols/snap/handler.go
+++ b/eth/protocols/snap/handler.go
@@ -30,7 +30,6 @@ import (
 	"github.com/ethereum/go-ethereum/p2p"
 	"github.com/ethereum/go-ethereum/p2p/enode"
 	"github.com/ethereum/go-ethereum/p2p/enr"
-	"github.com/ethereum/go-ethereum/rlp"
 	"github.com/ethereum/go-ethereum/trie"
 )
 
@@ -419,8 +418,9 @@ func ServiceGetStorageRangesQuery(chain *core.BlockChain, req *GetStorageRangesP
 			if err != nil {
 				return nil, nil
 			}
-			var acc types.StateAccount
-			if err := rlp.DecodeBytes(accTrie.Get(account[:]), &acc); err != nil {
+			var acc *types.StateAccount
+			acc, err = accTrie.TryGetAccount(account[:])
+			if err != nil {
 				return nil, nil
 			}
 			stTrie, err := trie.New(account, acc.Root, chain.StateCache().TrieDB())

--- a/light/trie.go
+++ b/light/trie.go
@@ -27,7 +27,6 @@ import (
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/ethdb"
-	"github.com/ethereum/go-ethereum/rlp"
 	"github.com/ethereum/go-ethereum/trie"
 )
 
@@ -112,14 +111,20 @@ func (t *odrTrie) TryGet(key []byte) ([]byte, error) {
 	return res, err
 }
 
+func (t *odrTrie) TryGetAccount(key []byte) (*types.StateAccount, error) {
+	key = crypto.Keccak256(key)
+	var res *types.StateAccount
+	err := t.do(key, func() (err error) {
+		res, err = t.trie.TryGetAccount(key)
+		return err
+	})
+	return res, err
+}
+
 func (t *odrTrie) TryUpdateAccount(key []byte, acc *types.StateAccount) error {
 	key = crypto.Keccak256(key)
-	value, err := rlp.EncodeToBytes(acc)
-	if err != nil {
-		return fmt.Errorf("decoding error in account update: %w", err)
-	}
 	return t.do(key, func() error {
-		return t.trie.TryUpdate(key, value)
+		return t.trie.TryUpdateAccount(key, acc)
 	})
 }
 

--- a/trie/secure_trie.go
+++ b/trie/secure_trie.go
@@ -96,7 +96,7 @@ func (t *SecureTrie) TryUpdateAccount(key []byte, acc *types.StateAccount) error
 	if err != nil {
 		return err
 	}
-	if err := t.trie.TryUpdate(hk, data); err != nil {
+	if err := t.trie.tryUpdate(hk, data); err != nil {
 		return err
 	}
 	t.getSecKeyCache()[string(hk)] = common.CopyBytes(key)

--- a/trie/secure_trie.go
+++ b/trie/secure_trie.go
@@ -82,6 +82,10 @@ func (t *SecureTrie) TryGet(key []byte) ([]byte, error) {
 	return t.trie.TryGet(t.hashKey(key))
 }
 
+func (t *SecureTrie) TryGetAccount(key []byte) (*types.StateAccount, error) {
+	return t.trie.TryGetAccount(t.hashKey(key))
+}
+
 // TryGetNode attempts to retrieve a trie node by compact-encoded path. It is not
 // possible to use keybyte-encoding as the path might contain odd nibbles.
 func (t *SecureTrie) TryGetNode(path []byte) ([]byte, int, error) {

--- a/trie/trie.go
+++ b/trie/trie.go
@@ -154,6 +154,26 @@ func (t *Trie) Get(key []byte) []byte {
 	return res
 }
 
+func (t *Trie) GetAccount(key []byte) *types.StateAccount {
+	res, err := t.TryGetAccount(key)
+	if err != nil {
+		log.Error(fmt.Sprintf("Unhandled trie error: %v", err))
+	}
+	return res
+}
+func (t *Trie) TryGetAccount(key []byte) (*types.StateAccount, error) {
+	res, err := t.TryGet(key)
+	if err != nil {
+		return nil, fmt.Errorf("Unhandled trie error: %v", err)
+	}
+	if res == nil {
+		return nil, nil
+	}
+	var ret types.StateAccount
+	err = rlp.DecodeBytes(res, &ret)
+	return &ret, err
+}
+
 // TryGet returns the value for key stored in the trie.
 // The value bytes must not be modified by the caller.
 // If a node was not found in the database, a MissingNodeError is returned.

--- a/trie/trie.go
+++ b/trie/trie.go
@@ -295,7 +295,7 @@ func (t *Trie) TryUpdateAccount(key []byte, acc *types.StateAccount) error {
 	if err != nil {
 		return fmt.Errorf("can't encode object at %x: %w", key[:], err)
 	}
-	return t.TryUpdate(key, data)
+	return t.tryUpdate(key, data)
 }
 
 // TryUpdate associates key with value in the trie. Subsequent calls to
@@ -307,6 +307,14 @@ func (t *Trie) TryUpdateAccount(key []byte, acc *types.StateAccount) error {
 //
 // If a node was not found in the database, a MissingNodeError is returned.
 func (t *Trie) TryUpdate(key, value []byte) error {
+	// Encoding []byte cannot fail, ok to ignore the error.
+	v, _ := rlp.EncodeToBytes(common.TrimLeftZeroes(value[:]))
+	return t.tryUpdate(key, v)
+}
+
+// tryUpdate expects an RLP-encoded value and performs the core function
+// for TryUpdate and TryUpdateAccount.
+func (t *Trie) tryUpdate(key, value []byte) error {
 	t.unhashed++
 	k := keybytesToHex(key)
 	if len(value) != 0 {


### PR DESCRIPTION
Move the code that serializes an MPT leaf to the MPT tree code itself.

### Rationale

The encoding of the leaf in RLP is very much dependent on the format of the tree, and performing the encoding in the state database is causing an abstraction leak: Verkle trees use a different format, and therefore a distinction as to the type of tree has to be made at the database level, which imo should be abstracted to the tree itself.

### Consequence

Instead of writing the following in `state_object.go`'s `updateTrie`:

```golang
                if (value == common.Hash{}) {
                      if tr.IsVerkle() {
                              k := trieUtils.GetTreeKeyStorageSlotWithEvaluatedAddress(s.pointEval, new(uint256.Int).SetBytes(key[:]))
                              s.setError(tr.TryDelete(k))
                      } else {
                              s.setError(tr.TryDelete(key[:]))
                      }
                        s.db.StorageDeleted += 1
              } else {
                      // Encoding []byte cannot fail, ok to ignore the error.
                      v, _ = rlp.EncodeToBytes(common.TrimLeftZeroes(value[:]))
                      if !tr.IsVerkle() {
                              s.setError(tr.TryUpdate(key[:], v))
                      } else {
                              // Update the trie, with v as a value
                              s.setError(tr.TryUpdate(key, value[:]))
                      }
             }
```

the code that supports both MPT and verkle trees become:

```golang
                var v []byte
                if (value == common.Hash{}) {
                        s.setError(tr.TryDelete(key[:]))
                        s.db.StorageDeleted += 1
              } else {
                      // Encoding []byte cannot fail, ok to ignore the error.
                      v, _ = rlp.EncodeToBytes(common.TrimLeftZeroes(value[:]))
                      s.setError(tr.TryUpdate(key[:], value[:]))
                      s.db.StorageUpdated += 1
              }
```

It should have no impact on the root hash of the tree (although there is still an issue with the light client, which is why this PR is still a draft)

Note that `rlp.EncodeToBytes` is now called twice (in the case of an MPT), in case it ends in the snapshot. This pertains to the snapshot format, which ideally should also be abstracted but doesn't belong in this PR.