### PR TITLE
signer/rules: register clef api properly when rules are used

### DIFF
--- a/signer/rules/rules.go
+++ b/signer/rules/rules.go
@@ -59,6 +59,7 @@ func NewRuleEvaluator(next core.UIClientAPI, jsbackend storage.Storage) (*rulese
 	return c, nil
 }
 func (r *rulesetUI) RegisterUIServer(api *core.UIServerAPI) {
+	r.next.RegisterUIServer(api)
 	// TODO, make it possible to query from js
 }
 


### PR DESCRIPTION
The bidirectional channel was not working properly when a ruleset UI was used, which is fixed by this PR. 

Fixes #25298