### PR TITLE
trie/node: use strings.Builder in fullNode.fstring

### DIFF
--- a/trie/node.go
+++ b/trie/node.go
@@ -79,15 +79,17 @@ func (n hashNode) String() string   { return n.fstring("") }
 func (n valueNode) String() string  { return n.fstring("") }
 
 func (n *fullNode) fstring(ind string) string {
-	resp := fmt.Sprintf("[\n%s  ", ind)
+	var buf strings.Builder
+	buf.WriteString(fmt.Sprintf("[\n%s  ", ind))
 	for i, node := range &n.Children {
 		if node == nil {
-			resp += fmt.Sprintf("%s: <nil> ", indices[i])
+			buf.WriteString(fmt.Sprintf("%s: <nil> ", indices[i]))
 		} else {
-			resp += fmt.Sprintf("%s: %v", indices[i], node.fstring(ind+"  "))
+			buf.WriteString(fmt.Sprintf("%s: %v", indices[i], node.fstring(ind+"  ")))
 		}
 	}
-	return resp + fmt.Sprintf("\n%s] ", ind)
+	buf.WriteString(fmt.Sprintf("\n%s] ", ind))
+	return buf.String()
 }
 func (n *shortNode) fstring(ind string) string {
 	return fmt.Sprintf("{%x: %v} ", n.Key, n.Val.fstring(ind+"  "))


### PR DESCRIPTION
The PR for reduce memory usage in fullNode.String.


This is my test codes about case all Children is hashNode.
```go
var indices = []string{"0", "1", "2", "3", "4", "5", "6", "7", "8", "9", "a", "b", "c", "d", "e", "f", "[17]"}
var hashnode = [32]byte{
	1, 2, 3, 4, 5, 6, 7, 8, 9, 10,
	1, 2, 3, 4, 5, 6, 7, 8, 9, 10,
	1, 2, 3, 4, 5, 6, 7, 8, 9, 10,
	1, 2,
}

type fullNode struct {
	Children [17][32]byte // test: hashNode ([32]byte)
}

func (n *fullNode) String_origin() string { return n.fstring_origin("") }
func (n *fullNode) String_newly() string  { return n.fstring_newly("") }

func (n *fullNode) fstring_origin(ind string) string {
	resp := fmt.Sprintf("[\n%s  ", ind)
	for i := 0; i < 17; i++ {
		resp += fmt.Sprintf("%s: %v", indices[i], fmt.Sprintf("<%x> ", hashnode))
	}
	return resp + fmt.Sprintf("\n%s] ", ind)
}

func (n *fullNode) fstring_newly(ind string) string {
	var buf strings.Builder
	buf.WriteString(fmt.Sprintf("[\n%s ", ind))
	for i := 0; i < 17; i++ {
		buf.WriteString(fmt.Sprintf("%s: %v", indices[i], fmt.Sprintf("<%x> ", hashnode)))
	}
	buf.WriteString(fmt.Sprintf("\n%s] ", ind))
	return buf.String()
}

func BenchmarkOrigin(b *testing.B) {
	fn := fullNode{}
	for i := 0; i < 17; i++ {
		fn.Children[i] = hashnode
	}
	b.ResetTimer()
	for j := 0; j < b.N; j++ {
		fn.String_origin()
	}
}

func BenchmarkNewly(b *testing.B) {
	fn := fullNode{}
	for i := 0; i < 17; i++ {
		fn.Children[i] = hashnode
	}
	b.ResetTimer()
	for j := 0; j < b.N; j++ {
		fn.String_newly()
	}
}
```

Result:
```
goos: darwin
goarch: arm64
pkg: bench
BenchmarkOrigin-10           100             15208 ns/op           17076 B/op        122 allocs/op
BenchmarkNewly-10            100             11315 ns/op            8145 B/op        111 allocs/op
```