### PR TITLE
Add missing functions to `debug_traceTransaction` spec

### DIFF
--- a/docs/_rpc/ns-debug.md
+++ b/docs/_rpc/ns-debug.md
@@ -782,14 +782,15 @@ But this step function will:
 
 `log.op` has the following methods:
 
- - `isPush()` - returns true iff the opcode is a PUSHn
+ - `isPush()` - returns true if the opcode is a PUSHn
  - `toString()` - returns the string representation of the opcode
- - `toNumber()` - returns the opcode's number
+ - `toNumber()` - returns the number of elements in the stack
 
 `log.memory` has the following methods:
 
  - `slice(start, stop)` - returns the specified segment of memory as a byte slice
  - `getUint(offset)` - returns the 32 bytes at the given offset
+ - `length()` - returns the memory size
 
 `log.stack` has the following methods:
 
@@ -824,10 +825,12 @@ If the step function throws an exception or executes an illegal operation at any
 - `to` - Address, target of the transaction
 - `input` - Buffer, input transaction data
 - `gas` - Number, gas budget of the transaction
+- `gasUsed` - Number, amount of gas used in executing the transaction (excludes txdata costs)
+- `gasPrice` - Gas price configured in the transaction being executed
+- `intrinsicGas` - Intrinsic gas for the transaction being executed
 - `value` - big.Int, amount to be transferred in wei
 - `block` - Number, block number
 - `output` - Buffer, value returned from EVM
-- `gasUsed` - Number, amount of gas used in executing the transaction (excludes txdata costs)
 - `time` - String, execution runtime
 
 ##### Fault


### PR DESCRIPTION
Geth implements some functions for JavaScript-based tracing (used by `debug_traceTransaction`) that are not documented:
Log.Memory.length()
Context.gasPrice
Context.intrinsicGas