### PR TITLE
build: add static linking support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ COPY go.sum /go-ethereum/
 RUN cd /go-ethereum && go mod download
 
 ADD . /go-ethereum
-RUN cd /go-ethereum && go run build/ci.go install ./cmd/geth
+RUN cd /go-ethereum && go run build/ci.go install -static ./cmd/geth
 
 # Pull Geth into a second stage deploy alpine container
 FROM alpine:latest

--- a/Dockerfile.alltools
+++ b/Dockerfile.alltools
@@ -14,7 +14,7 @@ COPY go.sum /go-ethereum/
 RUN cd /go-ethereum && go mod download
 
 ADD . /go-ethereum
-RUN cd /go-ethereum && go run build/ci.go install
+RUN cd /go-ethereum && go run build/ci.go install -static
 
 # Pull all binaries into a second stage deploy alpine container
 FROM alpine:latest

--- a/build/ci.go
+++ b/build/ci.go
@@ -218,7 +218,7 @@ func doInstall(cmdline []string) {
 	buildTags := []string{"urfave_cli_no_docs"}
 
 	// Configure the build.
-	env := build.Env()	
+	env := build.Env()
 	gobuild := tc.Go("build", buildFlags(env, *staticlink, buildTags)...)
 
 	// arm64 CI builders are memory-constrained and can't handle concurrent builds,
@@ -268,7 +268,7 @@ func buildFlags(env build.Environment, staticLinking bool, buildTags []string) (
 		if staticLinking {
 			staticflag = " -static"
 			// Under static linking, use of certain glibc features must be
-			// disable to avoid shared library dependencies.
+			// disabled to avoid shared library dependencies.
 			buildTags = append(buildTags, "osusergo", "netgo")
 		}
 		// Enforce the stacksize to 8M, which is the case on most platforms apart from
@@ -279,9 +279,9 @@ func buildFlags(env build.Environment, staticLinking bool, buildTags []string) (
 	if len(ld) > 0 {
 		flags = append(flags, "-ldflags", strings.Join(ld, " "))
 	}
-	
-	// Set build tags.
-	flags = append(flags, "-tags", strings.Join(buildTags, ","))
+	if len(buildTags) > 0 {
+		flags = append(flags, "-tags", strings.Join(buildTags, ","))
+	}
 	return flags
 }
 

--- a/build/ci.go
+++ b/build/ci.go
@@ -216,10 +216,7 @@ func doInstall(cmdline []string) {
 
 	// Configure the build.
 	env := build.Env()
-	if *staticlink {
-		env.StaticLink = true
-	}
-	gobuild := tc.Go("build", buildFlags(env)...)
+	gobuild := tc.Go("build", buildFlags(env, *staticlink)...)
 
 	// arm64 CI builders are memory-constrained and can't handle concurrent builds,
 	// better disable it. This check isn't the best, it should probably
@@ -255,7 +252,7 @@ func doInstall(cmdline []string) {
 }
 
 // buildFlags returns the go tool flags for building.
-func buildFlags(env build.Environment) (flags []string) {
+func buildFlags(env build.Environment, staticlink bool) (flags []string) {
 	var ld []string
 	if env.Commit != "" {
 		ld = append(ld, "-X", "main.gitCommit="+env.Commit)
@@ -270,7 +267,7 @@ func buildFlags(env build.Environment) (flags []string) {
 	// alpine Linux.
 	if runtime.GOOS == "linux" {
 		staticlinkflag := ""
-		if env.StaticLink {
+		if staticlink {
 			staticlinkflag = "-static"
 		}
 		ld = append(ld, "-extldflags", fmt.Sprintf("'-Wl,-z,stack-size=0x800000 %s'", staticlinkflag))

--- a/internal/build/env.go
+++ b/internal/build/env.go
@@ -34,6 +34,7 @@ var (
 	BuildnumFlag    = flag.String("buildnum", "", `Overrides CI build number`)
 	PullRequestFlag = flag.Bool("pull-request", false, `Overrides pull request status of the build`)
 	CronJobFlag     = flag.Bool("cron-job", false, `Overrides cron job status of the build`)
+	StaticLink      = flag.Bool("static-link", false, `Overrides static link status of the build`)
 )
 
 // Environment contains metadata provided by the build environment.
@@ -45,11 +46,12 @@ type Environment struct {
 	Buildnum                  string
 	IsPullRequest             bool
 	IsCronJob                 bool
+	StaticLink                bool
 }
 
 func (env Environment) String() string {
-	return fmt.Sprintf("%s env (commit:%s date:%s branch:%s tag:%s buildnum:%s pr:%t)",
-		env.Name, env.Commit, env.Date, env.Branch, env.Tag, env.Buildnum, env.IsPullRequest)
+	return fmt.Sprintf("%s env (commit:%s date:%s branch:%s tag:%s buildnum:%s pr:%t static:%t)",
+		env.Name, env.Commit, env.Date, env.Branch, env.Tag, env.Buildnum, env.IsPullRequest, env.StaticLink)
 }
 
 // Env returns metadata about the current CI environment, falling back to LocalEnv
@@ -167,6 +169,9 @@ func applyEnvFlags(env Environment) Environment {
 	}
 	if *CronJobFlag {
 		env.IsCronJob = true
+	}
+	if *StaticLink {
+		env.StaticLink = true
 	}
 	return env
 }

--- a/internal/build/env.go
+++ b/internal/build/env.go
@@ -34,7 +34,6 @@ var (
 	BuildnumFlag    = flag.String("buildnum", "", `Overrides CI build number`)
 	PullRequestFlag = flag.Bool("pull-request", false, `Overrides pull request status of the build`)
 	CronJobFlag     = flag.Bool("cron-job", false, `Overrides cron job status of the build`)
-	StaticLink      = flag.Bool("static-link", false, `Overrides static link status of the build`)
 )
 
 // Environment contains metadata provided by the build environment.
@@ -46,12 +45,11 @@ type Environment struct {
 	Buildnum                  string
 	IsPullRequest             bool
 	IsCronJob                 bool
-	StaticLink                bool
 }
 
 func (env Environment) String() string {
-	return fmt.Sprintf("%s env (commit:%s date:%s branch:%s tag:%s buildnum:%s pr:%t static:%t)",
-		env.Name, env.Commit, env.Date, env.Branch, env.Tag, env.Buildnum, env.IsPullRequest, env.StaticLink)
+	return fmt.Sprintf("%s env (commit:%s date:%s branch:%s tag:%s buildnum:%s pr:%t)",
+		env.Name, env.Commit, env.Date, env.Branch, env.Tag, env.Buildnum, env.IsPullRequest)
 }
 
 // Env returns metadata about the current CI environment, falling back to LocalEnv
@@ -169,9 +167,6 @@ func applyEnvFlags(env Environment) Environment {
 	}
 	if *CronJobFlag {
 		env.IsCronJob = true
-	}
-	if *StaticLink {
-		env.StaticLink = true
 	}
 	return env
 }

--- a/internal/build/util.go
+++ b/internal/build/util.go
@@ -29,6 +29,7 @@ import (
 	"os/exec"
 	"path"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"text/template"
 	"time"
@@ -39,7 +40,7 @@ var DryRunFlag = flag.Bool("n", false, "dry run, don't execute commands")
 // MustRun executes the given command and exits the host process for
 // any error.
 func MustRun(cmd *exec.Cmd) {
-	fmt.Println(">>>", strings.Join(cmd.Args, " "))
+	fmt.Println(">>>", printArgs(cmd.Args))
 	if !*DryRunFlag {
 		cmd.Stderr = os.Stderr
 		cmd.Stdout = os.Stdout
@@ -47,6 +48,20 @@ func MustRun(cmd *exec.Cmd) {
 			log.Fatal(err)
 		}
 	}
+}
+
+func printArgs(args []string) string {
+	var s strings.Builder
+	for i, arg := range args {
+		if i > 0 {
+			s.WriteByte(' ')
+		}
+		if strings.IndexByte(arg, ' ') >= 0 {
+			arg = strconv.QuoteToASCII(arg)
+		}
+		s.WriteString(arg)
+	}
+	return s.String()
 }
 
 func MustRunCommand(cmd string, args ...string) {
@@ -121,7 +136,7 @@ func UploadSFTP(identityFile, host, dir string, files []string) error {
 		sftp.Args = append(sftp.Args, "-i", identityFile)
 	}
 	sftp.Args = append(sftp.Args, host)
-	fmt.Println(">>>", strings.Join(sftp.Args, " "))
+	fmt.Println(">>>", printArgs(sftp.Args))
 	if *DryRunFlag {
 		return nil
 	}


### PR DESCRIPTION
improve from PR #17247

This adds a new flag to the ci.go install script, `-static` which produces static linked binary.

Note: this is **only** working in **Alpine Linux musl library**

#### Results:

No dynamic library dependencies