### PR TITLE
Formatted error nit

### DIFF
--- a/eth/api.go
+++ b/eth/api.go
@@ -586,5 +586,5 @@ func (api *DebugAPI) GetAccessibleState(from, to rpc.BlockNumber) (uint64, error
 			return uint64(i), nil
 		}
 	}
-	return 0, fmt.Errorf("no state found")
+	return 0, errors.New("no state found")
 }


### PR DESCRIPTION
This PR changes an `fmt.Errorf(...)` to `errors.New(...)` since there are no formatted arguments in the error.