### PR TITLE
fix dao_test to work with custom client identifier

### DIFF
--- a/cmd/geth/dao_test.go
+++ b/cmd/geth/dao_test.go
@@ -120,7 +120,7 @@ func testDAOForkBlockNewChain(t *testing.T, test int, genesis string, expectBloc
 		runGeth(t, append(args, []string{"--exec", "2+2", "console"}...)...).WaitExit()
 	}
 	// Retrieve the DAO config flag from the database
-	path := filepath.Join(datadir, "geth", "chaindata")
+	path := filepath.Join(datadir, clientIdentifier, "chaindata")
 	db, err := rawdb.NewLevelDBDatabase(path, 0, 0, "", false)
 	if err != nil {
 		t.Fatalf("test %d: failed to open test database: %v", test, err)


### PR DESCRIPTION
If the `clientIdentifier` in `cmd/geth/main.go` is ever changed, e.g. to `geth2`, the `TestDAOForkBlockNewChain` will fail because the chaindata would no longer be under `.../geth/chaindata`