### PR TITLE
accounts/abi: add name to method/event not found err

### DIFF
--- a/accounts/abi/abi.go
+++ b/accounts/abi/abi.go
@@ -95,7 +95,7 @@ func (abi ABI) getArguments(name string, data []byte) (Arguments, error) {
 		args = event.Inputs
 	}
 	if args == nil {
-		return nil, errors.New("abi: could not locate named method or event")
+		return nil, fmt.Errorf("abi: could not locate named method or event: %s", name)
 	}
 	return args, nil
 }


### PR DESCRIPTION
This PR replaces an `errors.New` with a slightly more informative `fmt.Errorf` including the name of the method/event that could not be found.