### PR TITLE
miner/stress/1559: baseFee big.Int set from uint64

### DIFF
--- a/miner/stress/1559/main.go
+++ b/miner/stress/1559/main.go
@@ -167,7 +167,7 @@ func makeTransaction(nonce uint64, privKey *ecdsa.PrivateKey, signer types.Signe
 	// If the given base fee is nil(the 1559 is still not available),
 	// generate a fake base fee in order to create 1559 tx forcibly.
 	if baseFee == nil {
-		baseFee = new(big.Int).SetInt64(int64(rand.Int31()))
+		baseFee = new(big.Int).SetUint64(uint64(rand.Int31()))
 	}
 	// Generate the feecap, 75% valid feecap and 25% unguaranted.
 	var gasFeeCap *big.Int


### PR DESCRIPTION
[rand.Int31()](https://github.com/golang/go/blob/release-branch.go1.19/src/math/rand/rand.go#L97) returns a non-negative number already

[bigint.SetUint64()](https://github.com/golang/go/blob/release-branch.go1.19/src/math/big/int.go#L60) spares an allocation