### PR TITLE
eth/fetcher: don't spend too much time on transaction inclusion

### DIFF
--- a/cmd/devp2p/internal/ethtest/helpers.go
+++ b/cmd/devp2p/internal/ethtest/helpers.go
@@ -357,9 +357,13 @@ func (s *Suite) waitAnnounce(conn *Conn, blockAnnouncement *NewBlock) error {
 				return fmt.Errorf("wrong block hash in announcement: expected %v, got %v", blockAnnouncement.Block.Hash(), hashes[0].Hash)
 			}
 			return nil
+
+		// ignore tx announcements from previous tests
 		case *NewPooledTransactionHashes:
-			// ignore tx announcements from previous tests
 			continue
+		case *Transactions:
+			continue
+
 		default:
 			return fmt.Errorf("unexpected: %s", pretty.Sdump(msg))
 		}

--- a/cmd/devp2p/internal/ethtest/suite.go
+++ b/cmd/devp2p/internal/ethtest/suite.go
@@ -544,9 +544,13 @@ func (s *Suite) TestNewPooledTxs(t *utesting.T) {
 				t.Fatalf("unexpected number of txs requested: wanted %d, got %d", len(hashes), len(msg.GetPooledTransactionsPacket))
 			}
 			return
+
 		// ignore propagated txs from previous tests
 		case *NewPooledTransactionHashes:
 			continue
+		case *Transactions:
+			continue
+
 		// ignore block announcements from previous tests
 		case *NewBlockHashes:
 			continue

--- a/cmd/devp2p/internal/ethtest/transaction.go
+++ b/cmd/devp2p/internal/ethtest/transaction.go
@@ -29,7 +29,7 @@ import (
 	"github.com/ethereum/go-ethereum/params"
 )
 
-//var faucetAddr = common.HexToAddress("0x71562b71999873DB5b286dF957af199Ec94617F7")
+// var faucetAddr = common.HexToAddress("0x71562b71999873DB5b286dF957af199Ec94617F7")
 var faucetKey, _ = crypto.HexToECDSA("b71c71a67e1177ad4e901695e1b4b9ee17ae16c6668d313eac2f96dbcda3f291")
 
 func (s *Suite) sendSuccessfulTxs(t *utesting.T) error {
@@ -192,10 +192,10 @@ func sendMultipleSuccessfulTxs(t *utesting.T, s *Suite, txs []*types.Transaction
 	nonce = txs[len(txs)-1].Nonce()
 
 	// Wait for the transaction announcement(s) and make sure all sent txs are being propagated.
-	// all txs should be announced within 3 announcements.
+	// all txs should be announced within a couple announcements.
 	recvHashes := make([]common.Hash, 0)
 
-	for i := 0; i < 3; i++ {
+	for i := 0; i < 20; i++ {
 		switch msg := recvConn.readAndServe(s.chain, timeout).(type) {
 		case *Transactions:
 			for _, tx := range *msg {

--- a/eth/fetcher/tx_fetcher.go
+++ b/eth/fetcher/tx_fetcher.go
@@ -328,7 +328,7 @@ func (f *TxFetcher) Enqueue(peer string, txs []*types.Transaction, direct bool) 
 		// out of sync with the chain or the peer is griefing us.
 		if otherreject > 128/4 {
 			delay = 200 * time.Millisecond
-			log.Warn("Peer delivering useless transactions", "ignored", len(txs)-end, "peer", peer)
+			log.Warn("Peer delivering useless transactions", "peer", peer, "ignored", len(txs)-end)
 			break
 		}
 	}

--- a/eth/fetcher/tx_fetcher.go
+++ b/eth/fetcher/tx_fetcher.go
@@ -303,7 +303,7 @@ func (f *TxFetcher) Enqueue(peer string, txs []*types.Transaction, direct bool) 
 				for f.underpriced.Cardinality() >= maxTxUnderpricedSetSize {
 					f.underpriced.Pop()
 				}
-				f.underpriced.Add(batch[i].Hash())
+				f.underpriced.Add(batch[j].Hash())
 			}
 			// Track a few interesting failure types
 			switch {
@@ -328,6 +328,7 @@ func (f *TxFetcher) Enqueue(peer string, txs []*types.Transaction, direct bool) 
 		// out of sync with the chain or the peer is griefing us.
 		if otherreject > 128/4 {
 			delay = 200 * time.Millisecond
+			log.Warn("Peer delivering useless transactions, sleeping", "ignored", len(txs)-i)
 			break
 		}
 	}

--- a/eth/fetcher/tx_fetcher.go
+++ b/eth/fetcher/tx_fetcher.go
@@ -328,7 +328,7 @@ func (f *TxFetcher) Enqueue(peer string, txs []*types.Transaction, direct bool) 
 		// out of sync with the chain or the peer is griefing us.
 		if otherreject > 128/4 {
 			delay = 200 * time.Millisecond
-			log.Warn("Peer delivering useless transactions, sleeping", "ignored", len(txs)-i)
+			log.Warn("Peer delivering useless transactions", "ignored", len(txs)-end, "peer", peer)
 			break
 		}
 	}

--- a/eth/fetcher/tx_fetcher.go
+++ b/eth/fetcher/tx_fetcher.go
@@ -310,14 +310,9 @@ func (f *TxFetcher) Enqueue(peer string, txs []*types.Transaction, direct bool) 
 			}
 			added = append(added, batch[j].Hash())
 		}
-		// If 'other reject' is >25% of the deliveries, abort
+		// If 'other reject' is >25% of the deliveries, abort. Either we are
+		// out of sync with the chain or the peer is griefing us.
 		if 4*otherreject > len(added) {
-			delay = time.Millisecond * 200
-			break
-		}
-		// If >50% of all transactions are rejected, abort. Either we or the peer
-		// are out of sync with the chain.
-		if 2*(duplicate+underpriced+otherreject) > len(added) {
 			delay = time.Millisecond * 200
 			break
 		}


### PR DESCRIPTION
This PR makes it so we'll sleep a bit when processing transactions, to avoid consuming too much resources