### PR TITLE
core/state, trie, light: Add a DeleteAccount method

### DIFF
--- a/core/state/database.go
+++ b/core/state/database.go
@@ -87,7 +87,7 @@ type Trie interface {
 	// found in the database, a trie.MissingNodeError is returned.
 	TryDelete(key []byte) error
 
-	// DeleteACcount abstracts an account deletion from the trie.
+	// DeleteAccount abstracts an account deletion from the trie.
 	DeleteAccount(key []byte) error
 
 	// Hash returns the root hash of the trie. It does not write to the database and

--- a/core/state/database.go
+++ b/core/state/database.go
@@ -87,8 +87,8 @@ type Trie interface {
 	// found in the database, a trie.MissingNodeError is returned.
 	TryDelete(key []byte) error
 
-	// DeleteAccount abstracts an account deletion from the trie.
-	DeleteAccount(key []byte) error
+	// TryDeleteAccount abstracts an account deletion from the trie.
+	TryDeleteAccount(key []byte) error
 
 	// Hash returns the root hash of the trie. It does not write to the database and
 	// can be used even if the trie doesn't have one.

--- a/core/state/database.go
+++ b/core/state/database.go
@@ -87,6 +87,9 @@ type Trie interface {
 	// found in the database, a trie.MissingNodeError is returned.
 	TryDelete(key []byte) error
 
+	// DeleteACcount abstracts an account deletion from the trie.
+	DeleteAccount(key []byte) error
+
 	// Hash returns the root hash of the trie. It does not write to the database and
 	// can be used even if the trie doesn't have one.
 	Hash() common.Hash

--- a/core/state/statedb.go
+++ b/core/state/statedb.go
@@ -484,7 +484,7 @@ func (s *StateDB) deleteStateObject(obj *stateObject) {
 	}
 	// Delete the account from the trie
 	addr := obj.Address()
-	if err := s.trie.TryDelete(addr[:]); err != nil {
+	if err := s.trie.DeleteAccount(addr[:]); err != nil {
 		s.setError(fmt.Errorf("deleteStateObject (%x) error: %v", addr[:], err))
 	}
 }

--- a/core/state/statedb.go
+++ b/core/state/statedb.go
@@ -484,7 +484,7 @@ func (s *StateDB) deleteStateObject(obj *stateObject) {
 	}
 	// Delete the account from the trie
 	addr := obj.Address()
-	if err := s.trie.DeleteAccount(addr[:]); err != nil {
+	if err := s.trie.TryDeleteAccount(addr[:]); err != nil {
 		s.setError(fmt.Errorf("deleteStateObject (%x) error: %v", addr[:], err))
 	}
 }

--- a/light/trie.go
+++ b/light/trie.go
@@ -153,8 +153,8 @@ func (t *odrTrie) TryDelete(key []byte) error {
 	})
 }
 
-// DeleteACcount abstracts an account deletion from the trie.
-func (t *odrTrie) DeleteAccount(key []byte) error {
+// TryDeleteACcount abstracts an account deletion from the trie.
+func (t *odrTrie) TryDeleteAccount(key []byte) error {
 	key = crypto.Keccak256(key)
 	return t.do(key, func() error {
 		return t.trie.TryDelete(key)

--- a/light/trie.go
+++ b/light/trie.go
@@ -153,6 +153,7 @@ func (t *odrTrie) TryDelete(key []byte) error {
 	})
 }
 
+// DeleteACcount abstracts an account deletion from the trie.
 func (t *odrTrie) DeleteAccount(key []byte) error {
 	key = crypto.Keccak256(key)
 	return t.do(key, func() error {

--- a/light/trie.go
+++ b/light/trie.go
@@ -153,6 +153,13 @@ func (t *odrTrie) TryDelete(key []byte) error {
 	})
 }
 
+func (t *odrTrie) DeleteAccount(key []byte) error {
+	key = crypto.Keccak256(key)
+	return t.do(key, func() error {
+		return t.trie.TryDelete(key)
+	})
+}
+
 func (t *odrTrie) Commit(collectLeaf bool) (common.Hash, *trie.NodeSet, error) {
 	if t.trie == nil {
 		return t.id.Root, nil, nil

--- a/trie/secure_trie.go
+++ b/trie/secure_trie.go
@@ -189,8 +189,8 @@ func (t *StateTrie) TryDelete(key []byte) error {
 	return t.trie.TryDelete(hk)
 }
 
-// DeleteACcount abstracts an account deletion from the trie.
-func (t *StateTrie) DeleteAccount(key []byte) error {
+// TryDeleteACcount abstracts an account deletion from the trie.
+func (t *StateTrie) TryDeleteAccount(key []byte) error {
 	hk := t.hashKey(key)
 	delete(t.getSecKeyCache(), string(hk))
 	return t.trie.TryDelete(hk)

--- a/trie/secure_trie.go
+++ b/trie/secure_trie.go
@@ -189,6 +189,12 @@ func (t *StateTrie) TryDelete(key []byte) error {
 	return t.trie.TryDelete(hk)
 }
 
+func (t *StateTrie) DeleteAccount(key []byte) error {
+	hk := t.hashKey(key)
+	delete(t.getSecKeyCache(), string(hk))
+	return t.trie.TryDelete(hk)
+}
+
 // GetKey returns the sha3 preimage of a hashed key that was
 // previously used to store a value.
 func (t *StateTrie) GetKey(shaKey []byte) []byte {

--- a/trie/secure_trie.go
+++ b/trie/secure_trie.go
@@ -189,6 +189,7 @@ func (t *StateTrie) TryDelete(key []byte) error {
 	return t.trie.TryDelete(hk)
 }
 
+// DeleteACcount abstracts an account deletion from the trie.
 func (t *StateTrie) DeleteAccount(key []byte) error {
 	hk := t.hashKey(key)
 	delete(t.getSecKeyCache(), string(hk))


### PR DESCRIPTION
Account deletion also needs to be abstracted, since verkle trees have to overwrite more than one leaf when deleting an account.