### PR TITLE
core, trie: flush preimages to db on database close

### DIFF
--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -893,15 +893,15 @@ func (bc *BlockChain) Stop() {
 			log.Error("Dangling trie nodes after full cleanup")
 		}
 	}
+	// Flush the collected preimages to disk
+	if err := bc.stateCache.TrieDB().CommitPreimages(); err != nil {
+		log.Error("Failed to commit trie preimages", "err", err)
+	}
 	// Ensure all live cached entries be saved into disk, so that we can skip
 	// cache warmup when node restarts.
 	if bc.cacheConfig.TrieCleanJournal != "" {
 		triedb := bc.stateCache.TrieDB()
 		triedb.SaveCache(bc.cacheConfig.TrieCleanJournal)
-	}
-	// Flush the preimages to disk
-	if err := bc.stateCache.TrieDB().CommitPreimages(); err != nil {
-		log.Error("Error closing Trie database", "err", err)
 	}
 	log.Info("Blockchain stopped")
 }

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -899,6 +899,10 @@ func (bc *BlockChain) Stop() {
 		triedb := bc.stateCache.TrieDB()
 		triedb.SaveCache(bc.cacheConfig.TrieCleanJournal)
 	}
+	// Flush the preimages to disk
+	if err := bc.stateCache.TrieDB().Close(); err != nil {
+		log.Error("Error closing Trie database", "err", err)
+	}
 	log.Info("Blockchain stopped")
 }
 

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -900,7 +900,7 @@ func (bc *BlockChain) Stop() {
 		triedb.SaveCache(bc.cacheConfig.TrieCleanJournal)
 	}
 	// Flush the preimages to disk
-	if err := bc.stateCache.TrieDB().Close(); err != nil {
+	if err := bc.stateCache.TrieDB().CommitPreimages(); err != nil {
 		log.Error("Error closing Trie database", "err", err)
 	}
 	log.Info("Blockchain stopped")

--- a/trie/database.go
+++ b/trie/database.go
@@ -853,9 +853,9 @@ func (db *Database) SaveCachePeriodically(dir string, interval time.Duration, st
 	}
 }
 
-// Close will flush the dangling preimages to disk. It is meant to be called when closing
+// CommitPreimages will flush the dangling preimages to disk. It is meant to be called when closing
 // the blockchain object, so that all preimages are persisted to the db.
-func (db *Database) Close() error {
+func (db *Database) CommitPreimages() error {
 	db.lock.Lock()
 	defer db.lock.Unlock()
 

--- a/trie/database.go
+++ b/trie/database.go
@@ -852,3 +852,15 @@ func (db *Database) SaveCachePeriodically(dir string, interval time.Duration, st
 		}
 	}
 }
+
+// Close will flush the dangling preimages to disk. It is meant to be called when closing
+// the blockchain object, so that all preimages are persisted to the db.
+func (db *Database) Close() error {
+	db.lock.Lock()
+	defer db.lock.Unlock()
+
+	if db.preimages != nil {
+		return db.preimages.commit(true)
+	}
+	return nil
+}

--- a/trie/database.go
+++ b/trie/database.go
@@ -853,14 +853,15 @@ func (db *Database) SaveCachePeriodically(dir string, interval time.Duration, st
 	}
 }
 
-// CommitPreimages will flush the dangling preimages to disk. It is meant to be called when closing
-// the blockchain object, so that all preimages are persisted to the db.
+// CommitPreimages flushes the dangling preimages to disk. It is meant to be
+// called when closing the blockchain object, so that preimages are persisted
+// to the database.
 func (db *Database) CommitPreimages() error {
 	db.lock.Lock()
 	defer db.lock.Unlock()
 
-	if db.preimages != nil {
-		return db.preimages.commit(true)
+	if db.preimages == nil {
+		return nil
 	}
-	return nil
+	return db.preimages.commit(true)
 }


### PR DESCRIPTION
While working on verkle, I noticed that preimages were not properly saved. This PR adds a `Close` method on the trie database, so that preimages are saved.

Co-authored-by: rjl493456442 <garyrong0905@gmail.com>