### PR TITLE
cmd. core: save preimages on genesis creation

### DIFF
--- a/core/genesis.go
+++ b/core/genesis.go
@@ -104,7 +104,7 @@ func (ga *GenesisAlloc) deriveHash() (common.Hash, error) {
 // all the generated states will be persisted into the given database.
 // Also, the genesis state specification will be flushed as well.
 func (ga *GenesisAlloc) flush(db ethdb.Database) error {
-	statedb, err := state.New(common.Hash{}, state.NewDatabase(db), nil)
+	statedb, err := state.New(common.Hash{}, state.NewDatabaseWithConfig(db, &trie.Config{Preimages: true}), nil)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
The recent refactors to the preimage code have deactivated the saving of preimages during the generation of the genesis state. This PR re-enables it.