### PR TITLE
cmd/geth: parse uint64 value with ParseUint instead of Atoi

### DIFF
--- a/cmd/geth/chaincmd.go
+++ b/cmd/geth/chaincmd.go
@@ -384,12 +384,12 @@ func parseDumpConfig(ctx *cli.Context, stack *node.Node) (*state.DumpConfig, eth
 				return nil, nil, common.Hash{}, fmt.Errorf("block %x not found", hash)
 			}
 		} else {
-			number, err := strconv.Atoi(arg)
+			number, err := strconv.ParseUint(arg, 10, 64)
 			if err != nil {
 				return nil, nil, common.Hash{}, err
 			}
-			if hash := rawdb.ReadCanonicalHash(db, uint64(number)); hash != (common.Hash{}) {
-				header = rawdb.ReadHeader(db, hash, uint64(number))
+			if hash := rawdb.ReadCanonicalHash(db, number); hash != (common.Hash{}) {
+				header = rawdb.ReadHeader(db, hash, number)
 			} else {
 				return nil, nil, common.Hash{}, fmt.Errorf("header for block %d not found", number)
 			}


### PR DESCRIPTION
It's cleaner/safer to parse this number with `ParseUint` than `Atoi`.

This was identified with Semgrep & the `string-to-int-signedness-cast` rule.

<img width="712" alt="image" src="https://user-images.githubusercontent.com/95511699/185424922-61ff12cf-13a5-4dad-a238-caee517fe136.png">

References:

* https://semgrep.dev/
* https://semgrep.dev/r?q=trailofbits.go.string-to-int-signedness-cast.string-to-int-signedness-cast
* https://github.com/trailofbits/semgrep-rules/blob/main/go/string-to-int-signedness-cast.yml