### PR TITLE
eth, les: unlock peerSet if there's an error

### DIFF
--- a/eth/downloader/peer.go
+++ b/eth/downloader/peer.go
@@ -237,6 +237,7 @@ func (ps *peerSet) Register(p *peerConnection) error {
 	}
 	p.rates = msgrate.NewTracker(ps.rates.MeanCapacities(), ps.rates.MedianRoundTrip())
 	if err := ps.rates.Track(p.id, p.rates); err != nil {
+		ps.lock.Unlock()
 		return err
 	}
 	ps.peers[p.id] = p

--- a/les/downloader/peer.go
+++ b/les/downloader/peer.go
@@ -350,6 +350,7 @@ func (ps *peerSet) Register(p *peerConnection) error {
 	}
 	p.rates = msgrate.NewTracker(ps.rates.MeanCapacities(), ps.rates.MedianRoundTrip())
 	if err := ps.rates.Track(p.id, p.rates); err != nil {
+		ps.lock.Unlock()
 		return err
 	}
 	ps.peers[p.id] = p


### PR DESCRIPTION
Noticed these two missing unlocks. The mutex is unlocked in the error check right above, but not in this error check. I suspect that this check was added later and the author forgot to add the unlock.