### PR TITLE
rlp/rlpgen: fix error handling when target type not found

### DIFF
--- a/rlp/rlpgen/main.go
+++ b/rlp/rlpgen/main.go
@@ -106,7 +106,7 @@ func (cfg *Config) process() (code []byte, err error) {
 	// Find the type and generate.
 	typ, err := lookupStructType(pkg.Scope(), cfg.Type)
 	if err != nil {
-		return nil, fmt.Errorf("can't find %s in %s: %v", typ, pkg, err)
+		return nil, fmt.Errorf("can't find %s in %s: %v", cfg.Type, pkg, err)
 	}
 	code, err = bctx.generate(typ, cfg.GenerateEncoder, cfg.GenerateDecoder)
 	if err != nil {


### PR DESCRIPTION
`typ` will be `nil` if `lookupStructType` returns an error. I think `cfg.Type` should be used instead.