### PR TITLE
consensus/beacon: check ttd reached on pos blocks

### DIFF
--- a/consensus/beacon/consensus.go
+++ b/consensus/beacon/consensus.go
@@ -114,8 +114,8 @@ func (beacon *Beacon) VerifyHeaders(chain consensus.ChainHeaderReader, headers [
 		}
 	}
 
-	// All the headers have passed the transition point, use new rules.
 	if len(preHeaders) == 0 {
+		// All the headers are pos headers. Verify that the parent block reached total terminal difficulty.
 		if reached, _ := IsTTDReached(chain, headers[0].ParentHash, headers[0].Number.Uint64()-1); !reached {
 			// TTD not reached for the first block, mark subsequent with invalid terminal block
 			results := make(chan error, len(headers))

--- a/consensus/beacon/consensus.go
+++ b/consensus/beacon/consensus.go
@@ -116,6 +116,16 @@ func (beacon *Beacon) VerifyHeaders(chain consensus.ChainHeaderReader, headers [
 
 	// All the headers have passed the transition point, use new rules.
 	if len(preHeaders) == 0 {
+		if reached, _ := IsTTDReached(chain, headers[0].ParentHash, headers[0].Number.Uint64()-1); !reached {
+			// TTD not reached for the first block, mark subsequent with invalid terminal block
+			results := make(chan error, len(headers))
+			go func() {
+				for i := 0; i < len(headers); i++ {
+					results <- consensus.ErrInvalidTerminalBlock
+				}
+			}()
+			return make(chan struct{}), results
+		}
 		return beacon.verifyHeaders(chain, headers, nil)
 	}
 

--- a/consensus/beacon/consensus.go
+++ b/consensus/beacon/consensus.go
@@ -119,11 +119,9 @@ func (beacon *Beacon) VerifyHeaders(chain consensus.ChainHeaderReader, headers [
 		if reached, _ := IsTTDReached(chain, headers[0].ParentHash, headers[0].Number.Uint64()-1); !reached {
 			// TTD not reached for the first block, mark subsequent with invalid terminal block
 			results := make(chan error, len(headers))
-			go func() {
-				for i := 0; i < len(headers); i++ {
-					results <- consensus.ErrInvalidTerminalBlock
-				}
-			}()
+			for i := 0; i < len(headers); i++ {
+				results <- consensus.ErrInvalidTerminalBlock
+			}
 			return make(chan struct{}), results
 		}
 		return beacon.verifyHeaders(chain, headers, nil)


### PR DESCRIPTION
Fixes the last failing hive test. Basically we need to check that the TTD is reached even if we only get a batch of post merge headers