### PR TITLE
Config: Allow Trie timeout configuration in toml config

### DIFF
--- a/eth/ethconfig/config.go
+++ b/eth/ethconfig/config.go
@@ -168,7 +168,7 @@ type Config struct {
 	TrieCleanCacheJournal   string        `toml:",omitempty"` // Disk journal directory for trie cache to survive node restarts
 	TrieCleanCacheRejournal time.Duration `toml:",omitempty"` // Time interval to regenerate the journal for clean cache
 	TrieDirtyCache          int
-	TrieTimeout             time.Duration
+	TrieTimeout             time.Duration `toml:",omitempty` // Cumulative Time interval spent on gc, after which to flush trie cache to disk
 	SnapshotCache           int
 	Preimages               bool
 

--- a/eth/ethconfig/config.go
+++ b/eth/ethconfig/config.go
@@ -168,7 +168,7 @@ type Config struct {
 	TrieCleanCacheJournal   string        `toml:",omitempty"` // Disk journal directory for trie cache to survive node restarts
 	TrieCleanCacheRejournal time.Duration `toml:",omitempty"` // Time interval to regenerate the journal for clean cache
 	TrieDirtyCache          int
-	TrieTimeout             time.Duration `toml:",omitempty` // Cumulative Time interval spent on gc, after which to flush trie cache to disk
+	TrieTimeout             time.Duration `toml:",omitempty"` // Cumulative Time interval spent on gc, after which to flush trie cache to disk
 	SnapshotCache           int
 	Preimages               bool
 

--- a/eth/ethconfig/gen_config.go
+++ b/eth/ethconfig/gen_config.go
@@ -45,7 +45,7 @@ func (c Config) MarshalTOML() (interface{}, error) {
 		TrieCleanCacheJournal                 string        `toml:",omitempty"`
 		TrieCleanCacheRejournal               time.Duration `toml:",omitempty"`
 		TrieDirtyCache                        int
-		TrieTimeout                           time.Duration
+		TrieTimeout                           time.Duration `toml:",omitempty"`
 		SnapshotCache                         int
 		Preimages                             bool
 		FilterLogCacheSize                    int
@@ -141,7 +141,7 @@ func (c *Config) UnmarshalTOML(unmarshal func(interface{}) error) error {
 		TrieCleanCacheJournal                 *string        `toml:",omitempty"`
 		TrieCleanCacheRejournal               *time.Duration `toml:",omitempty"`
 		TrieDirtyCache                        *int
-		TrieTimeout                           *time.Duration
+		TrieTimeout                           *time.Duration `toml:",omitempty"`
 		SnapshotCache                         *int
 		Preimages                             *bool
 		FilterLogCacheSize                    *int


### PR DESCRIPTION
Currently, TrieTimeout is hardcoded to a default of [60 minutes](https://github.com/ethereum/go-ethereum/blob/master/eth/ethconfig/config.go#L84). Allow configuring
this via toml so that nodes adjust how frequently trie cache is flushed to disk,
The benefit of tuning this is obviously that the magnitude of chain rewind on the node
after a non-graceful restart can be decreased.

I'm not really sure if this also merits a CLI option on it's own. I see there are certain trie cache parameters that are allowed to be configured via CLI, for performance tuning. This seems more of a node resiliency configuration than a performance tuning one. Open to suggestions..