### PR TITLE
cmd, eth: allow DatabaseHandles to be set via TOML config file

### DIFF
--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -1778,7 +1778,9 @@ func SetEthConfig(ctx *cli.Context, stack *node.Node, cfg *ethconfig.Config) {
 	if ctx.IsSet(CacheFlag.Name) || ctx.IsSet(CacheDatabaseFlag.Name) {
 		cfg.DatabaseCache = ctx.Int(CacheFlag.Name) * ctx.Int(CacheDatabaseFlag.Name) / 100
 	}
-	cfg.DatabaseHandles = MakeDatabaseHandles(ctx.Int(FDLimitFlag.Name))
+	if cfg.DatabaseHandles == 0 {
+		cfg.DatabaseHandles = MakeDatabaseHandles(ctx.Int(FDLimitFlag.Name))
+	}
 	if ctx.IsSet(AncientFlag.Name) {
 		cfg.DatabaseFreezer = ctx.String(AncientFlag.Name)
 	}

--- a/eth/ethconfig/config.go
+++ b/eth/ethconfig/config.go
@@ -160,7 +160,7 @@ type Config struct {
 
 	// Database options
 	SkipBcVersionCheck bool `toml:"-"`
-	DatabaseHandles    int  `toml:"-"`
+	DatabaseHandles    int
 	DatabaseCache      int
 	DatabaseFreezer    string
 

--- a/eth/ethconfig/gen_config.go
+++ b/eth/ethconfig/gen_config.go
@@ -38,7 +38,7 @@ func (c Config) MarshalTOML() (interface{}, error) {
 		UltraLightFraction                    int                    `toml:",omitempty"`
 		UltraLightOnlyAnnounce                bool                   `toml:",omitempty"`
 		SkipBcVersionCheck                    bool                   `toml:"-"`
-		DatabaseHandles                       int                    `toml:"-"`
+		DatabaseHandles                       int
 		DatabaseCache                         int
 		DatabaseFreezer                       string
 		TrieCleanCache                        int
@@ -134,7 +134,7 @@ func (c *Config) UnmarshalTOML(unmarshal func(interface{}) error) error {
 		UltraLightFraction                    *int                   `toml:",omitempty"`
 		UltraLightOnlyAnnounce                *bool                  `toml:",omitempty"`
 		SkipBcVersionCheck                    *bool                  `toml:"-"`
-		DatabaseHandles                       *int                   `toml:"-"`
+		DatabaseHandles                       *int
 		DatabaseCache                         *int
 		DatabaseFreezer                       *string
 		TrieCleanCache                        *int


### PR DESCRIPTION
This PR is an attempt to solve the issue https://github.com/ethereum/go-ethereum/issues/24148 by allowing DatabaseHandles to be set via the Config file.