### PR TITLE
More verbose Log: added  "No beacon client is available"

### DIFF
--- a/eth/sync.go
+++ b/eth/sync.go
@@ -130,7 +130,7 @@ func (cs *chainSyncer) loop() {
 			// it has not yet switched us over, keep warning the user that their infra is
 			// potentially flaky.
 			if errors.Is(err, downloader.ErrMergeTransition) && time.Since(cs.warned) > 10*time.Second {
-				log.Warn("Local chain is post-merge, waiting for beacon client sync switch-over...")
+				log.Warn("Local chain is post-merge. No beacon client is available, waiting for beacon client sync switch-over...")
 				cs.warned = time.Now()
 			}
 		case <-cs.force.C:
@@ -190,7 +190,7 @@ func (cs *chainSyncer) nextSyncOp() *chainSyncOp {
 		// world, it can also mean we're stuck on the merge block, waiting for
 		// a beacon client. In the latter case, notify the user.
 		if ttd := cs.handler.chain.Config().TerminalTotalDifficulty; ttd != nil && ourTD.Cmp(ttd) >= 0 && time.Since(cs.warned) > 10*time.Second {
-			log.Warn("Local chain is post-merge, waiting for beacon client sync switch-over...")
+			log.Warn("Local chain is post-merge. No beacon client is available, waiting for beacon client sync switch-over...")
 			cs.warned = time.Now()
 		}
 		return nil // We're in sync


### PR DESCRIPTION
Moved part of the information from the comment to the log so we save some google search to the world.