### PR TITLE
rpc: check that "version" is "2.0" in request objects

### DIFF
--- a/rpc/json.go
+++ b/rpc/json.go
@@ -58,19 +58,23 @@ type jsonrpcMessage struct {
 }
 
 func (msg *jsonrpcMessage) isNotification() bool {
-	return msg.ID == nil && msg.Method != ""
+	return msg.hasValidVersion() && msg.ID == nil && msg.Method != ""
 }
 
 func (msg *jsonrpcMessage) isCall() bool {
-	return msg.hasValidID() && msg.Method != ""
+	return msg.hasValidVersion() && msg.hasValidID() && msg.Method != ""
 }
 
 func (msg *jsonrpcMessage) isResponse() bool {
-	return msg.hasValidID() && msg.Method == "" && msg.Params == nil && (msg.Result != nil || msg.Error != nil)
+	return msg.hasValidVersion() && msg.hasValidID() && msg.Method == "" && msg.Params == nil && (msg.Result != nil || msg.Error != nil)
 }
 
 func (msg *jsonrpcMessage) hasValidID() bool {
 	return len(msg.ID) > 0 && msg.ID[0] != '{' && msg.ID[0] != '['
+}
+
+func (msg *jsonrpcMessage) hasValidVersion() bool {
+	return msg.Version == vsn
 }
 
 func (msg *jsonrpcMessage) isSubscribe() bool {

--- a/rpc/subscription_test.go
+++ b/rpc/subscription_test.go
@@ -79,7 +79,7 @@ func TestSubscriptions(t *testing.T) {
 		request := map[string]interface{}{
 			"id":      i,
 			"method":  fmt.Sprintf("%s_subscribe", namespace),
-			"version": "2.0",
+			"jsonrpc": "2.0",
 			"params":  []interface{}{"someSubscription", notificationCount, i},
 		}
 		if err := out.Encode(&request); err != nil {

--- a/rpc/testdata/invalid-badversion.js
+++ b/rpc/testdata/invalid-badversion.js
@@ -1,19 +1,19 @@
 // This test checks processing of messages with invalid Version.
 
---> {"jsonrpc":"2.0","id": 1,"method":"test_echo","params":["x", 3]}
+--> {"jsonrpc":"2.0","id":1,"method":"test_echo","params":["x", 3]}
 <-- {"jsonrpc":"2.0","id":1,"result":{"String":"x","Int":3,"Args":null}}
 
---> {"jsonrpc":"2.1","id": 1,"method":"test_echo","params":["x", 3]}
+--> {"jsonrpc":"2.1","id":1,"method":"test_echo","params":["x", 3]}
 <-- {"jsonrpc":"2.0","id":1,"error":{"code":-32600,"message":"invalid request"}}
 
---> {"jsonrpc":"go-ethereum","id": 1,"method":"test_echo","params":["x", 3]}
+--> {"jsonrpc":"go-ethereum","id":1,"method":"test_echo","params":["x", 3]}
 <-- {"jsonrpc":"2.0","id":1,"error":{"code":-32600,"message":"invalid request"}}
 
---> {"jsonrpc": 1,"id": 1,"method":"test_echo","params":["x", 3]}
+--> {"jsonrpc":1,"id":1,"method":"test_echo","params":["x", 3]}
 <-- {"jsonrpc":"2.0","id":1,"error":{"code":-32600,"message":"invalid request"}}
 
---> {"jsonrpc": 2.0,"id": 1,"method":"test_echo","params":["x", 3]}
+--> {"jsonrpc":2.0,"id":1,"method":"test_echo","params":["x", 3]}
 <-- {"jsonrpc":"2.0","id":1,"error":{"code":-32600,"message":"invalid request"}}
 
---> {"id": 1,"method":"test_echo","params":["x", 3]}
+--> {"id":1,"method":"test_echo","params":["x", 3]}
 <-- {"jsonrpc":"2.0","id":1,"error":{"code":-32600,"message":"invalid request"}}

--- a/rpc/testdata/invalid-badversion.js
+++ b/rpc/testdata/invalid-badversion.js
@@ -1,0 +1,19 @@
+// This test checks processing of messages with invalid Version.
+
+--> {"jsonrpc":"2.0","id": 1,"method":"test_echo","params":["x", 3]}
+<-- {"jsonrpc":"2.0","id":1,"result":{"String":"x","Int":3,"Args":null}}
+
+--> {"jsonrpc":"2.1","id": 1,"method":"test_echo","params":["x", 3]}
+<-- {"jsonrpc":"2.0","id":1,"error":{"code":-32600,"message":"invalid request"}}
+
+--> {"jsonrpc":"go-ethereum","id": 1,"method":"test_echo","params":["x", 3]}
+<-- {"jsonrpc":"2.0","id":1,"error":{"code":-32600,"message":"invalid request"}}
+
+--> {"jsonrpc": 1,"id": 1,"method":"test_echo","params":["x", 3]}
+<-- {"jsonrpc":"2.0","id":1,"error":{"code":-32600,"message":"invalid request"}}
+
+--> {"jsonrpc": 2.0,"id": 1,"method":"test_echo","params":["x", 3]}
+<-- {"jsonrpc":"2.0","id":1,"error":{"code":-32600,"message":"invalid request"}}
+
+--> {"id": 1,"method":"test_echo","params":["x", 3]}
+<-- {"jsonrpc":"2.0","id":1,"error":{"code":-32600,"message":"invalid request"}}


### PR DESCRIPTION
According to https://www.jsonrpc.org/specification,
`jsonrpc` in JSON-RPC 2.0 Request object  must be exactly "2.0".

In now, 
```
curl -X POST -H "Content-Type: application/json" --data '{"jsonrpc":"2.0","method":"net_version","params":[],"id":1.11}' http://localhost:8545
<-- {"jsonrpc":"2.0","id":1.11,"result":"2757"}

curl -X POST -H "Content-Type: application/json" --data '{"jsonrpc":"geth","method":"net_version","params":[],"id":1.11}' http://localhost:8545
<-- {"jsonrpc":"2.0","id":1.11,"result":"2757"}

curl -X POST -H "Content-Type: application/json" --data '{"jsonrpc":"2411.0","method":"net_version","params":[],"id":1.11}' http://localhost:8545
<-- {"jsonrpc":"2.0","id":1.11,"result":"2757"}

curl -X POST -H "Content-Type: application/json" --data '{"method":"net_version","params":[], "id":12}' http://localhost:8545
<-- {"jsonrpc":"2.0","id":12,"result":"2757"}
```

Expect
```
curl -X POST -H "Content-Type: application/json" --data '{"jsonrpc":"2411.0","method":"net_version","params":[],"id":1.11}' http://localhost:8545
<-- {"jsonrpc":"2.0","id":1.11,"error":{"code":-32600,"message":"invalid request"}}
```
