### PR TITLE
accounts/abi/bind: parse ABI once on bind

### DIFF
--- a/accounts/abi/bind/template.go
+++ b/accounts/abi/bind/template.go
@@ -110,6 +110,7 @@ var (
 	_ = common.Big1
 	_ = types.BloomLookup
 	_ = event.NewSubscription
+	_ = abi.ConvertType
 )
 
 {{$structs := .Structs}}

--- a/accounts/abi/bind/template.go
+++ b/accounts/abi/bind/template.go
@@ -268,11 +268,11 @@ var (
 
 	// bind{{.Type}} binds a generic wrapper to an already deployed contract.
 	func bind{{.Type}}(address common.Address, caller bind.ContractCaller, transactor bind.ContractTransactor, filterer bind.ContractFilterer) (*bind.BoundContract, error) {
-	  parsed, err := abi.JSON(strings.NewReader({{.Type}}ABI))
+	  parsed, err := {{.Type}}MetaData.GetAbi()
 	  if err != nil {
 	    return nil, err
 	  }
-	  return bind.NewBoundContract(address, parsed, caller, transactor, filterer), nil
+	  return bind.NewBoundContract(address, *parsed, caller, transactor, filterer), nil
 	}
 
 	// Call invokes the (constant) contract method with params as input values and


### PR DESCRIPTION
This PR should close the issue originally described in #22269, where useless JSON parsing happened on every contract bind call. The solution of this issue merged in #22583 was not complete and only fixed issue for deploy, but not in bind. 

I also faced with this useless JSON parsing during contract calls and overhead becomes noticeable when need to call contract for different addresses.