### PR TITLE
core, eth/downloader: handle spurious junk bodies from racey rollbacks

### DIFF
--- a/core/blockchain_reader.go
+++ b/core/blockchain_reader.go
@@ -137,6 +137,9 @@ func (bc *BlockChain) HasBlock(hash common.Hash, number uint64) bool {
 	if bc.blockCache.Contains(hash) {
 		return true
 	}
+	if !bc.HasHeader(hash, number) {
+		return false
+	}
 	return rawdb.HasBody(bc.db, hash, number)
 }
 


### PR DESCRIPTION
Currently the snap sync header insertion runs concurrently with the body/receipt insertion. In case of a failure, the header inserter spins down and rolls back the head of the chain. However, the body inserter might be running ocncurrently, ending up in a few unexpected items in the database. This should be fixed separately.

However, the presence of a spurious block body/receipt in the database can cause the old legacy sync to very rarely crash in the ancestor lookup, and can cause the new beacon sync to almost always hang and loop on an error. This PR adds an additional check that in both scenarios, a block is only considered present if all header, body and receipt is available. Whislt this is a tiny extra database read, it ensures that the two entity types (headerchain, blockchain) can go slightly out of sync and still not choke, rather recover.

Not saying the race should not be fixed, but it's a nasty enough scenario that we can afford a bit of recovery flexibility.