### PR TITLE
ethclient: add 'finalized' and 'safe' block numbers

### DIFF
--- a/ethclient/ethclient.go
+++ b/ethclient/ethclient.go
@@ -570,6 +570,14 @@ func toBlockNumArg(number *big.Int) string {
 	if number.Cmp(pending) == 0 {
 		return "pending"
 	}
+	finalized := big.NewInt(int64(rpc.FinalizedBlockNumber))
+	if number.Cmp(finalized) == 0 {
+		return "finalized"
+	}
+	safe := big.NewInt(int64(rpc.SafeBlockNumber))
+	if number.Cmp(safe) == 0 {
+		return "safe"
+	}
 	return hexutil.EncodeBig(number)
 }
 

--- a/ethclient/gethclient/gethclient.go
+++ b/ethclient/gethclient/gethclient.go
@@ -187,6 +187,14 @@ func toBlockNumArg(number *big.Int) string {
 	if number.Cmp(pending) == 0 {
 		return "pending"
 	}
+	finalized := big.NewInt(int64(rpc.FinalizedBlockNumber))
+	if number.Cmp(finalized) == 0 {
+		return "finalized"
+	}
+	safe := big.NewInt(int64(rpc.SafeBlockNumber))
+	if number.Cmp(safe) == 0 {
+		return "safe"
+	}
 	return hexutil.EncodeBig(number)
 }
 


### PR DESCRIPTION
This PR adds support for using the strings `"finalized"` and `"safe"` in `ethclient`.

`"latest"` and `"pending"` have long been supported, but there's a small gap given these two new concepts.