### PR TITLE
core/state, trie: fix trie flush order for proper pruning

### DIFF
--- a/core/state/statedb_test.go
+++ b/core/state/statedb_test.go
@@ -914,3 +914,43 @@ func TestStateDBAccessList(t *testing.T) {
 		t.Fatalf("expected empty, got %d", got)
 	}
 }
+
+// Tests that account and storage tries are flushed in the correct order and that
+// no data loss occurs.
+func TestFlushOrderDataLoss(t *testing.T) {
+	// Create a state trie with many accounts and slots
+	var (
+		memdb    = rawdb.NewMemoryDatabase()
+		statedb  = NewDatabase(memdb)
+		state, _ = New(common.Hash{}, statedb, nil)
+	)
+	for a := byte(0); a < 10; a++ {
+		state.CreateAccount(common.Address{a})
+		for s := byte(0); s < 10; s++ {
+			state.SetState(common.Address{a}, common.Hash{a, s}, common.Hash{a, s})
+		}
+	}
+	root, err := state.Commit(false)
+	if err != nil {
+		t.Fatalf("failed to commit state trie: %v", err)
+	}
+	statedb.TrieDB().Reference(root, common.Hash{})
+	if err := statedb.TrieDB().Cap(1024); err != nil {
+		t.Fatalf("failed to cap trie dirty cache: %v", err)
+	}
+	if err := statedb.TrieDB().Commit(root, false, nil); err != nil {
+		t.Fatalf("failed to commit state trie: %v", err)
+	}
+	// Reopen the state trie from flushed disk and verify it
+	state, err = New(root, NewDatabase(memdb), nil)
+	if err != nil {
+		t.Fatalf("failed to reopen state trie: %v", err)
+	}
+	for a := byte(0); a < 10; a++ {
+		for s := byte(0); s < 10; s++ {
+			if have := state.GetState(common.Address{a}, common.Hash{a, s}); have != (common.Hash{a, s}) {
+				t.Errorf("account %d: slot %d: state mismatch: have %x, want %x", a, s, have, common.Hash{a, s})
+			}
+		}
+	}
+}


### PR DESCRIPTION
The trie commit rework PR made an unfortunate assumption (https://github.com/ethereum/go-ethereum/pull/25320/files#diff-8348a172e9fd3d3eb93c445d4ca58b8753b0f6d626c7af7db3b30b820d0788daR772) that the flush order doens't matter across storage tries and the account trie.

Unfortunately, this is false, because even though we do reference counting internally, the trie dirty cache drips trie nodes to disk when it's full, and the drip order is the insertion order. If the insertion order doesn't adhere to a strict child -> parent relationship, then we can end up with dangling storage trie nodes in the dirty cache, and missing subtries on disk.

As long as Geth keeps running, ll is fine because the dirty cache won't just flat out drop the data, and will eventually leak it to disk. But on shutdown it will happen that the unreferenced dangling storage nodes will be dropped. Upon restart, there might be nodes missing from disk.

E.g.

1. R -> A -> S, this is our "new trie", which we shove into the dirty cache.
2. But because the account / storage insertion order is wrong, we insert them as A, R, S
3. The dirty cache hits it's limit (2), so we need to flush the oldest item, A
4. We terminate Geth, so we will flush the latest trie R, which references A, already on disk
5. We terminate, losing S

This PR fixes the insertion order so all storage tries are flushed first and only then the account trie. It also adds a test which creates a bunch of contracts with random slots, flushes them partially to disk and terminates. If the account true is not added to the dirty cache last, the partial flush will result in data loss.