### PR TITLE
eth,p2p: count timeout packet towards rtt

### DIFF
--- a/eth/protocols/snap/sync.go
+++ b/eth/protocols/snap/sync.go
@@ -960,7 +960,7 @@ func (s *Syncer) assignAccountTasks(success chan *accountResponse, fail chan *ac
 		}
 		req.timeout = time.AfterFunc(s.rates.TargetTimeout(), func() {
 			peer.Log().Debug("Account range request timed out", "reqid", reqid)
-			s.rates.Update(idle, AccountRangeMsg, 0, 0)
+			s.rates.Update(idle, AccountRangeMsg, 2*time.Since(req.time), 0)
 			s.scheduleRevertAccountRequest(req)
 		})
 		s.accountReqs[reqid] = req
@@ -1071,7 +1071,7 @@ func (s *Syncer) assignBytecodeTasks(success chan *bytecodeResponse, fail chan *
 		}
 		req.timeout = time.AfterFunc(s.rates.TargetTimeout(), func() {
 			peer.Log().Debug("Bytecode request timed out", "reqid", reqid)
-			s.rates.Update(idle, ByteCodesMsg, 0, 0)
+			s.rates.Update(idle, ByteCodesMsg, 2*time.Since(req.time), 0)
 			s.scheduleRevertBytecodeRequest(req)
 		})
 		s.bytecodeReqs[reqid] = req
@@ -1218,7 +1218,7 @@ func (s *Syncer) assignStorageTasks(success chan *storageResponse, fail chan *st
 		}
 		req.timeout = time.AfterFunc(s.rates.TargetTimeout(), func() {
 			peer.Log().Debug("Storage request timed out", "reqid", reqid)
-			s.rates.Update(idle, StorageRangesMsg, 0, 0)
+			s.rates.Update(idle, StorageRangesMsg, 2*time.Since(req.time), 0)
 			s.scheduleRevertStorageRequest(req)
 		})
 		s.storageReqs[reqid] = req
@@ -1351,7 +1351,7 @@ func (s *Syncer) assignTrienodeHealTasks(success chan *trienodeHealResponse, fai
 		}
 		req.timeout = time.AfterFunc(s.rates.TargetTimeout(), func() {
 			peer.Log().Debug("Trienode heal request timed out", "reqid", reqid)
-			s.rates.Update(idle, TrieNodesMsg, 0, 0)
+			s.rates.Update(idle, TrieNodesMsg, 2*time.Since(req.time), 0)
 			s.scheduleRevertTrienodeHealRequest(req)
 		})
 		s.trienodeHealReqs[reqid] = req
@@ -1467,7 +1467,7 @@ func (s *Syncer) assignBytecodeHealTasks(success chan *bytecodeHealResponse, fai
 		}
 		req.timeout = time.AfterFunc(s.rates.TargetTimeout(), func() {
 			peer.Log().Debug("Bytecode heal request timed out", "reqid", reqid)
-			s.rates.Update(idle, ByteCodesMsg, 0, 0)
+			s.rates.Update(idle, ByteCodesMsg, 2*time.Since(req.time), 0)
 			s.scheduleRevertBytecodeHealRequest(req)
 		})
 		s.bytecodeHealReqs[reqid] = req

--- a/p2p/msgrate/msgrate.go
+++ b/p2p/msgrate/msgrate.go
@@ -194,6 +194,9 @@ func (t *Tracker) Update(kind uint64, elapsed time.Duration, items int) {
 	// to minimum
 	if items == 0 {
 		t.capacity[kind] = 0
+		if elapsed > 0 {
+			t.roundtrip = time.Duration((1-measurementImpact)*float64(t.roundtrip) + measurementImpact*float64(elapsed))
+		}
 		return
 	}
 	// Otherwise update the throughput with a new measurement


### PR DESCRIPTION
This PR changes the way we calculate RTT a bit. I noticed that for some nodes (particularly our azure nodes), there are a lot of dropped/failed trie heal messages. 

Whenever we time out a packet, we update the capacity for that particular kind to `0`. But what we do _not_ do is update the rtt estimate. This PR changes that, so that a failed delivery does update the RTT, by pretending that it completed in 2x the amount of time spent so far. So  if it times out after two seconds, it RTT estimate is updated as if it had been successfully delivered after 4 seconds. The idea is to make timeouts bump up the RTT estimate. 


This is from one of the bootnodes, which is syncing. The graphs shows `Unexpected trienode heal` occurrences in the log. I restarted it with this PR at 11:50, when if flattens out. The dotted line represents 500 messages. 
![Screenshot 2022-08-24 at 12-04-56 bootnode-azure-koreasouth-001 - Papertrail](https://user-images.githubusercontent.com/142290/186391521-14cbff0f-9dd4-4ff1-93c1-b055a49944e6.png)
It's only one isolated and perhaps misrepresenting metric, but in that instance it seems to have improved the misdeliveries. 
