### PR TITLE
Heal timeout fix

### DIFF
--- a/eth/protocols/snap/sync.go
+++ b/eth/protocols/snap/sync.go
@@ -1276,6 +1276,9 @@ func (s *Syncer) assignTrienodeHealTasks(success chan *trienodeHealResponse, fai
 
 	// Iterate over pending tasks and try to find a peer to retrieve with
 	for len(s.healer.trieTasks) > 0 || s.healer.scheduler.Pending() > 0 {
+		if len(s.trienodeHealReqs) > 15 {
+			break
+		}
 		// If there are not enough trie tasks queued to fully assign, fill the
 		// queue from the state sync scheduler. The trie synced schedules these
 		// together with bytecodes, so we need to queue them combined.

--- a/eth/protocols/snap/sync.go
+++ b/eth/protocols/snap/sync.go
@@ -1253,8 +1253,8 @@ func (s *Syncer) assignTrienodeHealTasks(success chan *trienodeHealResponse, fai
 	defer s.lock.Unlock()
 	// We don't want to have too many pending trienode requests out.
 	// Hard cap at 10.
-	len(s.trienodeHealReqs) > 10{
-		break
+	if len(s.trienodeHealReqs) > 10 {
+		return
 	}
 	// Sort the peers by download capacity to use faster ones if many available
 	idlers := &capacitySort{

--- a/eth/protocols/snap/sync.go
+++ b/eth/protocols/snap/sync.go
@@ -457,7 +457,7 @@ type Syncer struct {
 var (
 	snapUnexpectedMeter = metrics.NewRegisteredCounter("eth/snap/unexpected", nil)
 	snapExpectedMeter   = metrics.NewRegisteredCounter("eth/snap/expected", nil)
-	maxPendingRequests  = 500 // a.k.a unlimited
+	maxPendingRequests  = 15
 )
 
 // NewSyncer creates a new snapshot syncer to download the Ethereum state over the

--- a/eth/protocols/snap/sync.go
+++ b/eth/protocols/snap/sync.go
@@ -1251,7 +1251,11 @@ func (s *Syncer) assignStorageTasks(success chan *storageResponse, fail chan *st
 func (s *Syncer) assignTrienodeHealTasks(success chan *trienodeHealResponse, fail chan *trienodeHealRequest, cancel chan struct{}) {
 	s.lock.Lock()
 	defer s.lock.Unlock()
-
+	// We don't want to have too many pending trienode requests out.
+	// Hard cap at 10.
+	len(s.trienodeHealReqs) > 10{
+		break
+	}
 	// Sort the peers by download capacity to use faster ones if many available
 	idlers := &capacitySort{
 		ids:  make([]string, 0, len(s.trienodeHealIdlers)),


### PR DESCRIPTION
This is meant to fix https://github.com/ethereum/go-ethereum/issues/25600 . 
Work in progress. 

Will run the version with "15 cap" versus "no cap" (same as master + some more metrics), on two azure-nodes each, in order to get some measurements on how the cap affects the overall packet lossiness.  

```
ansible-playbook playbook.yaml -t geth -l bootnode-azure-westus-001,bootnode-azure-koreasouth-001  -e "geth_image=holiman/geth-experimental:latest" -e "geth_datadir_wipe=partial"
ansible-playbook playbook.yaml -t geth -l bootnode-azure-brazilsouth-001,bootnode-azure-australiaeast-001  -e "geth_image=holiman/geth-master:latest" -e "geth_datadir_wipe=partial"
```
`westus`, `koreasouth`: this PR (cap on pending)
`brazilsouth`, `australiaeast`: no cap on pending