### PR TITLE
cmd/geth: fix legacy receipt detection for empty db

### DIFF
--- a/cmd/geth/config.go
+++ b/cmd/geth/config.go
@@ -175,12 +175,13 @@ func makeFullNode(ctx *cli.Context) (*node.Node, ethapi.Backend) {
 		if cfg.Eth.NetworkId == 1 && ghash == params.MainnetGenesisHash {
 			firstIdx = 46147
 		}
-		isLegacy, _, err := dbHasLegacyReceipts(eth.ChainDb(), firstIdx)
+		isLegacy, firstLegacy, err := dbHasLegacyReceipts(eth.ChainDb(), firstIdx)
 		if err != nil {
 			log.Error("Failed to check db for legacy receipts", "err", err)
 		} else if isLegacy {
 			stack.Close()
-			utils.Fatalf("Database has receipts with a legacy format. Please run `geth db freezer-migrate`.")
+			log.Error("Database has receipts with a legacy format", "firstLegacy", firstLegacy)
+			utils.Fatalf("Aborting. Please run `geth db freezer-migrate`.")
 		}
 	}
 

--- a/cmd/geth/dbcmd.go
+++ b/cmd/geth/dbcmd.go
@@ -822,11 +822,15 @@ func dbHasLegacyReceipts(db ethdb.Database, firstIdx uint64) (bool, uint64, erro
 			}
 		}
 	}
-	// Is first non-empty receipt legacy?
 	first, err := db.Ancient("receipts", firstIdx)
 	if err != nil {
 		return false, 0, err
 	}
+	// We looped over all receipts and they were all empty
+	if bytes.Equal(first, emptyRLPList) {
+		return false, 0, nil
+	}
+	// Is first non-empty receipt legacy?
 	legacy, err = types.IsLegacyStoredReceipts(first)
 	return legacy, firstIdx, err
 }


### PR DESCRIPTION
The legacy receipt detector produced a false positive when there were no non-empty receipts in the db.

Fixes #25498