### PR TITLE
graphql: return correct logs for tx

### DIFF
--- a/graphql/graphql.go
+++ b/graphql/graphql.go
@@ -22,6 +22,7 @@ import (
 	"errors"
 	"fmt"
 	"math/big"
+	"sort"
 	"strconv"
 
 	"github.com/ethereum/go-ethereum"
@@ -478,16 +479,16 @@ func (t *Transaction) getLogs(ctx context.Context) (*[]*Log, error) {
 	if err != nil {
 		return nil, err
 	}
-	ret := make([]*Log, 0)
-	for _, log := range logs {
-		if uint64(log.TxIndex) != t.index {
-			continue
-		}
+	var ret []*Log
+	// Select tx logs from all block logs
+	ix := sort.Search(len(logs), func(i int) bool { return uint64(logs[i].TxIndex) == t.index })
+	for ix < len(logs) && uint64(logs[ix].TxIndex) == t.index {
 		ret = append(ret, &Log{
 			r:           t.r,
 			transaction: t,
-			log:         log,
+			log:         logs[ix],
 		})
+		ix++
 	}
 	return &ret, nil
 }

--- a/graphql/graphql.go
+++ b/graphql/graphql.go
@@ -478,13 +478,15 @@ func (t *Transaction) getLogs(ctx context.Context) (*[]*Log, error) {
 	if err != nil {
 		return nil, err
 	}
-	ret := make([]*Log, 0, len(logs))
+	ret := make([]*Log, 0)
 	for _, log := range logs {
-		ret = append(ret, &Log{
-			r:           t.r,
-			transaction: t,
-			log:         log,
-		})
+		if uint64(log.TxIndex) == t.index {
+			ret = append(ret, &Log{
+				r:           t.r,
+				transaction: t,
+				log:         log,
+			})
+		}
 	}
 	return &ret, nil
 }

--- a/graphql/graphql.go
+++ b/graphql/graphql.go
@@ -480,13 +480,14 @@ func (t *Transaction) getLogs(ctx context.Context) (*[]*Log, error) {
 	}
 	ret := make([]*Log, 0)
 	for _, log := range logs {
-		if uint64(log.TxIndex) == t.index {
-			ret = append(ret, &Log{
-				r:           t.r,
-				transaction: t,
-				log:         log,
-			})
+		if uint64(log.TxIndex) != t.index {
+			continue
 		}
+		ret = append(ret, &Log{
+			r:           t.r,
+			transaction: t,
+			log:         log,
+		})
 	}
 	return &ret, nil
 }


### PR DESCRIPTION
As part of #25459 I made a change so that graphql's tx log query goes through the usual filter system so it benefits from the newly added cache. However the filter system only handles logs on the block level, not tx level and I didn't select logs based on txindex which caused a regression.

Fixes #25583