### PR TITLE
ethclient/gethclient: fix bugs in override object encoding

### DIFF
--- a/ethclient/gethclient/gethclient.go
+++ b/ethclient/gethclient/gethclient.go
@@ -216,16 +216,24 @@ func toOverrideMap(overrides *map[common.Address]OverrideAccount) interface{} {
 	}
 	type overrideAccount struct {
 		Nonce     hexutil.Uint64              `json:"nonce"`
-		Code      hexutil.Bytes               `json:"code"`
+		Code      []byte                      `json:"code"`
 		Balance   *hexutil.Big                `json:"balance"`
 		State     map[common.Hash]common.Hash `json:"state"`
 		StateDiff map[common.Hash]common.Hash `json:"stateDiff"`
 	}
 	result := make(map[common.Address]overrideAccount)
+
 	for addr, override := range *overrides {
+		var code []byte
+
+		if len(override.Code) > 0 {
+			// convert to hexutil.Bytes explicitly in order to marshal/unmarshal as a JSON string with 0x prefix.
+			code = hexutil.Bytes(override.Code)
+		}
+
 		result[addr] = overrideAccount{
 			Nonce:     hexutil.Uint64(override.Nonce),
-			Code:      override.Code,
+			Code:      code,
 			Balance:   (*hexutil.Big)(override.Balance),
 			State:     override.State,
 			StateDiff: override.StateDiff,

--- a/ethclient/gethclient/gethclient.go
+++ b/ethclient/gethclient/gethclient.go
@@ -217,8 +217,8 @@ type OverrideAccount struct {
 	Balance *big.Int
 
 	// State sets the complete storage. The override will be applied
-	// when the given map is non-nil. Using an empty map overrides the
-	// contract storage to be empty.
+	// when the given map is non-nil. Using an empty map wipes the
+	// entire contract storage during the call.
 	State map[common.Hash]common.Hash
 
 	// StateDiff allows overriding individual storage slots.

--- a/ethclient/gethclient/gethclient.go
+++ b/ethclient/gethclient/gethclient.go
@@ -204,11 +204,25 @@ func toCallArg(msg ethereum.CallMsg) interface{} {
 
 // OverrideAccount specifies the state of an account to be overridden.
 type OverrideAccount struct {
-	Nonce     uint64                      `json:"nonce"`
-	Code      []byte                      `json:"code"`
-	Balance   *big.Int                    `json:"balance"`
-	State     map[common.Hash]common.Hash `json:"state"`
-	StateDiff map[common.Hash]common.Hash `json:"stateDiff"`
+	// Nonce sets nonce of the account. Note: the nonce override will only
+	// be applied when it is set to a non-zero value.
+	Nonce uint64
+
+	// Code sets the contract code. The override will be applied
+	// when the code is non-nil, i.e. setting empty code is possible
+	// using an empty slice.
+	Code []byte
+
+	// Balance sets the account balance.
+	Balance *big.Int
+
+	// State sets the complete storage. The override will be applied
+	// when the given map is non-nil. Using an empty map overrides the
+	// contract storage to be empty.
+	State map[common.Hash]common.Hash
+
+	// StateDiff allows overriding individual storage slots.
+	StateDiff map[common.Hash]common.Hash
 }
 
 func (a OverrideAccount) MarshalJSON() ([]byte, error) {
@@ -220,16 +234,16 @@ func (a OverrideAccount) MarshalJSON() ([]byte, error) {
 		StateDiff map[common.Hash]common.Hash `json:"stateDiff,omitempty"`
 	}
 
-	m := acc{
+	output := acc{
 		Nonce:     hexutil.Uint64(a.Nonce),
 		Balance:   (*hexutil.Big)(a.Balance),
 		StateDiff: a.StateDiff,
 	}
 	if a.Code != nil {
-		m.Code = hexutil.Encode(a.Code)
+		output.Code = hexutil.Encode(a.Code)
 	}
 	if a.State != nil {
-		m.State = a.State
+		output.State = a.State
 	}
-	return json.Marshal(m)
+	return json.Marshal(output)
 }

--- a/ethclient/gethclient/gethclient.go
+++ b/ethclient/gethclient/gethclient.go
@@ -216,7 +216,7 @@ func toOverrideMap(overrides *map[common.Address]OverrideAccount) interface{} {
 	}
 	type overrideAccount struct {
 		Nonce     hexutil.Uint64              `json:"nonce"`
-		Code      []byte                      `json:"code"`
+		Code      string                      `json:"code,omitempty"`
 		Balance   *hexutil.Big                `json:"balance"`
 		State     map[common.Hash]common.Hash `json:"state"`
 		StateDiff map[common.Hash]common.Hash `json:"stateDiff"`
@@ -224,13 +224,10 @@ func toOverrideMap(overrides *map[common.Address]OverrideAccount) interface{} {
 	result := make(map[common.Address]overrideAccount)
 
 	for addr, override := range *overrides {
-		var code []byte
-
-		if len(override.Code) > 0 {
-			// convert to hexutil.Bytes explicitly in order to marshal/unmarshal as a JSON string with 0x prefix.
-			code = hexutil.Bytes(override.Code)
+		var code string
+		if override.Code != nil {
+			code = hexutil.Encode(override.Code)
 		}
-
 		result[addr] = overrideAccount{
 			Nonce:     hexutil.Uint64(override.Nonce),
 			Code:      code,

--- a/ethclient/gethclient/gethclient_test.go
+++ b/ethclient/gethclient/gethclient_test.go
@@ -365,11 +365,11 @@ func testNoCodeOverride(t *testing.T) {
 
 	account := accounts[testAddr]
 	if account == nil {
-		t.Fatal("unexpected error")
+		t.Fatal("Empty account retrieved")
 	}
 
 	if account.Code != nil {
-		t.Fatal("unexpected error")
+		t.Fatal("Code should be empty")
 	}
 }
 
@@ -403,10 +403,10 @@ func testCodeOverride(t *testing.T) {
 
 	account := accounts[testAddr]
 	if account == nil {
-		t.Fatal("unexpected error")
+		t.Fatal("Empty account retrieved")
 	}
 
 	if account.Code == nil {
-		t.Fatal("unexpected error")
+		t.Fatal("Code should not be empty")
 	}
 }

--- a/ethclient/gethclient/gethclient_test.go
+++ b/ethclient/gethclient/gethclient_test.go
@@ -348,6 +348,11 @@ func TestOverrideAccountMarshal(t *testing.T) {
 			// when the input is a non-nil but empty map.
 			State: map[common.Hash]common.Hash{},
 		},
+		common.Address{0xee}: OverrideAccount{
+			// This one checks that 'balance' is set
+			// when the input is a non-nil but zero integer.
+			Balance: big.NewInt(0),
+		},
 	}
 
 	marshalled, err := json.MarshalIndent(&om, "", "  ")
@@ -368,6 +373,9 @@ func TestOverrideAccountMarshal(t *testing.T) {
   },
   "0xdd00000000000000000000000000000000000000": {
     "state": {}
+  },
+  "0xee00000000000000000000000000000000000000": {
+    "balance": "0x0"
   }
 }`
 

--- a/ethclient/gethclient/gethclient_test.go
+++ b/ethclient/gethclient/gethclient_test.go
@@ -332,8 +332,7 @@ func testCallContract(t *testing.T, client *rpc.Client) {
 func TestOverrideAccountMarshal(t *testing.T) {
 	om := map[common.Address]OverrideAccount{
 		common.Address{0x11}: OverrideAccount{
-			// Zero-valued nonce is not overrideden, but simply dropped
-			// by the encoder.
+			// Zero-valued nonce is not overriddden, but simply dropped by the encoder.
 			Nonce: 0,
 		},
 		common.Address{0xaa}: OverrideAccount{
@@ -343,19 +342,14 @@ func TestOverrideAccountMarshal(t *testing.T) {
 			Code: []byte{1},
 		},
 		common.Address{0xcc}: OverrideAccount{
-			// This one checks that 'code' is set when
-			// the input is a non-nil but empty slice.
-			Code: []byte{},
-		},
-		common.Address{0xdd}: OverrideAccount{
-			// This one checks that 'state' is set
-			// when the input is a non-nil but empty map.
-			State: map[common.Hash]common.Hash{},
-		},
-		common.Address{0xee}: OverrideAccount{
-			// This one checks that 'balance' is set
-			// when the input is a non-nil but zero integer.
+			// 'code', 'balance', 'state' should be set when input is
+			// a non-nil but empty value.
+			Code:    []byte{},
 			Balance: big.NewInt(0),
+			State:   map[common.Hash]common.Hash{},
+			// For 'stateDiff' the behavior is different, empty map
+			// is ignored because it makes no difference.
+			StateDiff: map[common.Hash]common.Hash{},
 		},
 	}
 
@@ -373,13 +367,9 @@ func TestOverrideAccountMarshal(t *testing.T) {
     "code": "0x01"
   },
   "0xcc00000000000000000000000000000000000000": {
-    "code": "0x"
-  },
-  "0xdd00000000000000000000000000000000000000": {
+    "code": "0x",
+    "balance": "0x0",
     "state": {}
-  },
-  "0xee00000000000000000000000000000000000000": {
-    "balance": "0x0"
   }
 }`
 

--- a/ethclient/gethclient/gethclient_test.go
+++ b/ethclient/gethclient/gethclient_test.go
@@ -331,7 +331,11 @@ func testCallContract(t *testing.T, client *rpc.Client) {
 
 func TestOverrideAccountMarshal(t *testing.T) {
 	om := map[common.Address]OverrideAccount{
-		common.Address{0x11}: OverrideAccount{},
+		common.Address{0x11}: OverrideAccount{
+			// Zero-valued nonce is not overrideden, but simply dropped
+			// by the encoder.
+			Nonce: 0,
+		},
 		common.Address{0xaa}: OverrideAccount{
 			Nonce: 5,
 		},


### PR DESCRIPTION
If the `code` property is not present in the state overrides, it should be skipped or set to `null` on marshal. Because of the type of the property `hexutil.Bytes` the empty slice marshals to "0x" and the request fails.

fixes #25615