### PR TITLE
mobile: register filter APIs

### DIFF
--- a/mobile/geth.go
+++ b/mobile/geth.go
@@ -24,10 +24,10 @@ import (
 	"fmt"
 	"path/filepath"
 
-	"github.com/ethereum/go-ethereum/cmd/utils"
 	"github.com/ethereum/go-ethereum/core"
 	"github.com/ethereum/go-ethereum/eth/downloader"
 	"github.com/ethereum/go-ethereum/eth/ethconfig"
+	"github.com/ethereum/go-ethereum/eth/filters"
 	"github.com/ethereum/go-ethereum/ethclient"
 	"github.com/ethereum/go-ethereum/ethstats"
 	"github.com/ethereum/go-ethereum/internal/debug"
@@ -36,6 +36,7 @@ import (
 	"github.com/ethereum/go-ethereum/p2p"
 	"github.com/ethereum/go-ethereum/p2p/nat"
 	"github.com/ethereum/go-ethereum/params"
+	"github.com/ethereum/go-ethereum/rpc"
 )
 
 // NodeConfig represents the collection of configuration values to fine tune the Geth
@@ -201,8 +202,14 @@ func NewNode(datadir string, config *NodeConfig) (stack *Node, _ error) {
 			rawStack.Close()
 			return nil, fmt.Errorf("ethereum init: %v", err)
 		}
-		// Configure log filter RPC API.
-		utils.RegisterFilterAPI(rawStack, lesBackend.ApiBackend, &ethConf)
+		// Register log filter RPC API.
+		filterSystem := filters.NewFilterSystem(lesBackend.ApiBackend, filters.Config{
+			LogCacheSize: ethConf.FilterLogCacheSize,
+		})
+		rawStack.RegisterAPIs([]rpc.API{{
+			Namespace: "eth",
+			Service:   filters.NewFilterAPI(filterSystem, true),
+		}})
 		// If netstats reporting is requested, do it
 		if config.EthereumNetStats != "" {
 			if err := ethstats.New(rawStack, lesBackend.ApiBackend, lesBackend.Engine(), config.EthereumNetStats); err != nil {

--- a/mobile/geth.go
+++ b/mobile/geth.go
@@ -24,6 +24,7 @@ import (
 	"fmt"
 	"path/filepath"
 
+	"github.com/ethereum/go-ethereum/cmd/utils"
 	"github.com/ethereum/go-ethereum/core"
 	"github.com/ethereum/go-ethereum/eth/downloader"
 	"github.com/ethereum/go-ethereum/eth/ethconfig"
@@ -200,6 +201,8 @@ func NewNode(datadir string, config *NodeConfig) (stack *Node, _ error) {
 			rawStack.Close()
 			return nil, fmt.Errorf("ethereum init: %v", err)
 		}
+		// Configure log filter RPC API.
+		utils.RegisterFilterAPI(rawStack, lesBackend.ApiBackend, &ethConf)
 		// If netstats reporting is requested, do it
 		if config.EthereumNetStats != "" {
 			if err := ethstats.New(rawStack, lesBackend.ApiBackend, lesBackend.Engine(), config.EthereumNetStats); err != nil {


### PR DESCRIPTION
This PR fixes a regression introduced by [#25459](https://github.com/ethereum/go-ethereum/pull/25459)
Removal of the following three lines makes `eth_subscribe("newHeads")` etc. no longer available on mobile platforms: https://github.com/ethereum/go-ethereum/pull/25459/files#diff-9443f03e7c706b082dc81e74820140747d7ca8afa3ff894930fd4f56495ad7c9L301-L303