### PR TITLE
p2p/msgrate: be more lenient when calculating 'mean'

### DIFF
--- a/p2p/msgrate/msgrate.go
+++ b/p2p/msgrate/msgrate.go
@@ -38,14 +38,6 @@ const measurementImpact = 0.1
 // to fetch more than some local stable value.
 const capacityOverestimation = 1.01
 
-// qosTuningPeers is the number of best peers to tune round trip times based on.
-// An Ethereum node doesn't need hundreds of connections to operate correctly,
-// so instead of lowering our download speed to the median of potentially many
-// bad nodes, we can target a smaller set of vey good nodes. At worse this will
-// result in less nodes to sync from, but that's still better than some hogging
-// the pipeline.
-const qosTuningPeers = 5
-
 // rttMinEstimate is the minimal round trip time to target requests for. Since
 // every request entails a 2 way latency + bandwidth + serving database lookups,
 // it should be generous enough to permit meaningful work to be done on top of
@@ -303,11 +295,15 @@ func (t *Trackers) medianRoundTrip() time.Duration {
 	}
 	sort.Float64s(rtts)
 
-	median := rttMaxEstimate
-	if qosTuningPeers <= len(rtts) {
-		median = time.Duration(rtts[qosTuningPeers/2]) // Median of our best few peers
-	} else if len(rtts) > 0 {
-		median = time.Duration(rtts[len(rtts)/2]) // Median of all out connected peers
+	var median time.Duration
+	switch len(rtts) {
+	case 0:
+		median = rttMaxEstimate
+	case 1:
+		median = time.Duration(rtts[0])
+	default:
+		idx := int(math.Sqrt(float64(len(rtts))))
+		median = time.Duration(rtts[idx])
 	}
 	// Restrict the RTT into some QoS defaults, irrelevant of true RTT
 	if median < rttMinEstimate {


### PR DESCRIPTION
The `p2p` msgrate tracker is a thing which tries to estimate some mean round-trip times. However, it did so in a very curious way: if a node had 200 peers, it would sort their 200 respective `rtt` estimates, and then it would pick item number `2` as the `mean`. So effectively taking `third fastest` and calling it mean. This probably works "ok" when the number of peers are low (there are other factors too, such as `ttlScaling` which takes some of the edge off this) -- however when the number of peers is high, it becomes very skewed. 

Also, note: the peers that fail to deliver within the allotted time are _not discarded_ (at least if we're talking snap protocol). When they finally deliver, their response will be discarded, and they will be given a new task -- presumably failing again, thus wasting resources for both parties.  

This PR instead bases the 'mean' on the square root of the length of the list. Still pretty harsh, but a bit more lenient.

|Number of peers |1 |2 |3 |4 |5 |10 |15 |50 |100 |200|
|---------------|--|--|--|---|--|--|----|---|----|---|
|Index (master) | 0 |1 |1 |2 |2 |2  |2  |2  |2   |2 |
|Index (PR)     | 0 |1 |1 |2 |2 |3  |3  |7  |10  |14|
