### PR TITLE
fix: typo in the port command example for graphql

### DIFF
--- a/docs/_rpc/graphql.md
+++ b/docs/_rpc/graphql.md
@@ -14,7 +14,7 @@ geth --http --graphql
 Now you can start querying against `http://localhost:8545/graphql`. To change the port, you'll need to provide `--http.port`, e.g.:
 
 ```bash
-geth --http --http.port 9545 --graphql
+geth --http --http.port 8545 --graphql
 ```
 
 ### GraphiQL


### PR DESCRIPTION
The port used in the example command does not match the other port references. I assume this is a typo because when I run the command using port 9545, the rest of the document port references to port 8545 don't work.