### PR TITLE
cmd, core, eth: supply delta tracking

### DIFF
--- a/accounts/abi/bind/backends/simulated.go
+++ b/accounts/abi/bind/backends/simulated.go
@@ -37,6 +37,7 @@ import (
 	"github.com/ethereum/go-ethereum/core/state"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/core/vm"
+	"github.com/ethereum/go-ethereum/eth/ethconfig"
 	"github.com/ethereum/go-ethereum/eth/filters"
 	"github.com/ethereum/go-ethereum/ethdb"
 	"github.com/ethereum/go-ethereum/event"
@@ -919,6 +920,10 @@ func (fb *filterBackend) SubscribePendingLogsEvent(ch chan<- []*types.Log) event
 func (fb *filterBackend) BloomStatus() (uint64, uint64) { return 4096, 0 }
 
 func (fb *filterBackend) ServiceFilter(ctx context.Context, ms *bloombits.MatcherSession) {
+	panic("not supported")
+}
+
+func (fb *filterBackend) Config() *ethconfig.Config {
 	panic("not supported")
 }
 

--- a/cmd/geth/consolecmd_test.go
+++ b/cmd/geth/consolecmd_test.go
@@ -30,7 +30,7 @@ import (
 )
 
 const (
-	ipcAPIs  = "admin:1.0 clique:1.0 debug:1.0 engine:1.0 eth:1.0 miner:1.0 net:1.0 rpc:1.0 txpool:1.0 web3:1.0"
+	ipcAPIs  = "admin:1.0 clique:1.0 debug:1.0 engine:1.0 eth:1.0 geth:1.0 miner:1.0 net:1.0 rpc:1.0 txpool:1.0 web3:1.0"
 	httpAPIs = "eth:1.0 net:1.0 rpc:1.0 web3:1.0"
 )
 

--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -70,6 +70,7 @@ var (
 		utils.OverrideCancun,
 		utils.OverrideVerkle,
 		utils.EnablePersonal,
+		utils.SupplyDeltaFlag,
 		utils.TxPoolLocalsFlag,
 		utils.TxPoolNoLocalsFlag,
 		utils.TxPoolJournalFlag,

--- a/cmd/geth/snapshot.go
+++ b/cmd/geth/snapshot.go
@@ -29,7 +29,7 @@ import (
 	"github.com/ethereum/go-ethereum/core/state"
 	"github.com/ethereum/go-ethereum/core/state/pruner"
 	"github.com/ethereum/go-ethereum/core/state/snapshot"
-	"github.com/ethereum/go-ethereum/core/supplydelta"
+	"github.com/ethereum/go-ethereum/core/supply"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/internal/flags"
@@ -644,7 +644,7 @@ func crawlSupply(ctx *cli.Context) error {
 		log.Error("Failed to open snapshot tree", "err", err)
 		return err
 	}
-	if _, err = supplydelta.Supply(headBlock.Header(), snaptree); err != nil {
+	if _, err = supply.Supply(headBlock.Header(), snaptree); err != nil {
 		log.Error("Failed to calculate current supply", "err", err)
 		return err
 	}

--- a/cmd/geth/snapshot.go
+++ b/cmd/geth/snapshot.go
@@ -155,13 +155,13 @@ block is used.
 			},
 			{
 				Name:     "crawl-supply",
-				Usage:    "Calculate the Ether supply at a specific block",
+				Usage:    "Calculate the ether supply at a specific block",
 				Action:   crawlSupply,
 				Category: "MISCELLANEOUS COMMANDS",
 				Flags:    flags.Merge(utils.NetworkFlags, utils.DatabasePathFlags),
 				Description: `
 geth snapshot crawl-supply
-will traverse the whole state from the given root and accumulate all the Ether
+will traverse the whole state from the given root and accumulate all the ether
 balances to calculate the total supply.
 `,
 			},

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -911,6 +911,10 @@ Please note that --` + MetricsHTTPFlag.Name + ` must be set to start the server.
 		Value:    metrics.DefaultConfig.InfluxDBOrganization,
 		Category: flags.MetricsCategory,
 	}
+	SupplyDeltaFlag = &cli.BoolFlag{
+		Name:  "supplydelta",
+		Usage: "Track Ether supply deltas (don't use in production)",
+	}
 )
 
 var (
@@ -1723,6 +1727,9 @@ func SetEthConfig(ctx *cli.Context, stack *node.Node, cfg *ethconfig.Config) {
 		} else {
 			cfg.EthDiscoveryURLs = SplitAndTrim(urls)
 		}
+	}
+	if ctx.IsSet(SupplyDeltaFlag.Name) {
+		cfg.EnableSupplyDeltaRecording = ctx.Bool(SupplyDeltaFlag.Name)
 	}
 	// Override any default configs for hard coded networks.
 	switch {

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -36,7 +36,7 @@ import (
 	"github.com/ethereum/go-ethereum/core/rawdb"
 	"github.com/ethereum/go-ethereum/core/state"
 	"github.com/ethereum/go-ethereum/core/state/snapshot"
-	"github.com/ethereum/go-ethereum/core/supplydelta"
+	"github.com/ethereum/go-ethereum/core/supply"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/core/vm"
 	"github.com/ethereum/go-ethereum/ethdb"
@@ -1401,7 +1401,7 @@ func (bc *BlockChain) writeBlockWithState(block *types.Block, receipts []*types.
 		if parent == nil {
 			log.Error("Failed to retrieve parent for supply delta", "err", err)
 		} else {
-			supplyDelta, err := supplydelta.SupplyDelta(block, parent, bc.stateCache.TrieDB(), bc.chainConfig)
+			supplyDelta, err := supply.Delta(block, parent, bc.stateCache.TrieDB(), bc.chainConfig)
 			if err != nil {
 				log.Error("Failed to record Ether supply delta", "err", err)
 			} else {

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -1411,16 +1411,16 @@ func (bc *BlockChain) writeBlockWithState(block *types.Block, receipts []*types.
 			}
 
 			// Calculate the block coinbaseReward based on chain rules and progression.
-			coinbaseReward, unclesReward, burn, withdrawals := supply.Subsidy(block, bc.chainConfig)
+			rewards, withdrawals := supply.Issuance(block, bc.chainConfig)
+			burn := supply.Burn(block.Header())
 
 			// Calculate the difference between the "calculated" and "crawled" supply delta.
 			diff := new(big.Int).Set(supplyDelta)
-			diff.Sub(diff, coinbaseReward)
-			diff.Sub(diff, unclesReward)
+			diff.Sub(diff, rewards)
 			diff.Sub(diff, withdrawals)
 			diff.Add(diff, burn)
 
-			log.Info("Calculated supply delta for block", "number", block.Number(), "hash", block.Hash(), "supplydelta", supplyDelta, "coinbasereward", coinbaseReward, "unclesreward", unclesReward, "burn", burn, "withdrawals", withdrawals, "diff", diff, "elapsed", time.Since(start))
+			log.Info("Calculated supply delta for block", "number", block.Number(), "hash", block.Hash(), "supplydelta", supplyDelta, "rewards", rewards, "burn", burn, "withdrawals", withdrawals, "diff", diff, "elapsed", time.Since(start))
 		}
 	}
 	return nil

--- a/core/blockchain_test.go
+++ b/core/blockchain_test.go
@@ -4341,7 +4341,6 @@ func TestEIP3651(t *testing.T) {
 	if actual.Cmp(expected) != 0 {
 		t.Fatalf("sender balance incorrect: expected %d, got %d", expected, actual)
 	}
-
 }
 
 func TestDelta(t *testing.T) {

--- a/core/blockchain_test.go
+++ b/core/blockchain_test.go
@@ -4406,10 +4406,11 @@ func TestDelta(t *testing.T) {
 	}
 
 	// Calculate delta, w/o self-destructs
-	coinbaseReward, _, burn, withdrawals := supply.Subsidy(block, gspec.Config)
+	rewards, withdrawals := supply.Issuance(block, gspec.Config)
+	burn := supply.Burn(block.Header())
 
 	want := new(big.Int)
-	want.Add(want, coinbaseReward)
+	want.Add(want, rewards)
 	want.Add(want, withdrawals)
 	want.Sub(want, burn)
 

--- a/core/rawdb/database.go
+++ b/core/rawdb/database.go
@@ -457,21 +457,22 @@ func InspectDatabase(db ethdb.Database, keyPrefix, keyStart []byte) error {
 		logged = time.Now()
 
 		// Key-value store statistics
-		headers         stat
-		bodies          stat
-		receipts        stat
-		tds             stat
-		numHashPairings stat
-		hashNumPairings stat
-		tries           stat
-		codes           stat
-		txLookups       stat
-		accountSnaps    stat
-		storageSnaps    stat
-		preimages       stat
-		bloomBits       stat
-		beaconHeaders   stat
-		cliqueSnaps     stat
+		headers          stat
+		bodies           stat
+		receipts         stat
+		tds              stat
+		numHashPairings  stat
+		hashNumPairings  stat
+		tries            stat
+		codes            stat
+		txLookups        stat
+		accountSnaps     stat
+		storageSnaps     stat
+		preimages        stat
+		bloomBits        stat
+		beaconHeaders    stat
+		cliqueSnaps      stat
+		supplyDeltaDiffs stat
 
 		// Les statistic
 		chtTrieNodes   stat
@@ -527,6 +528,8 @@ func InspectDatabase(db ethdb.Database, keyPrefix, keyStart []byte) error {
 		case bytes.HasPrefix(key, skeletonHeaderPrefix) && len(key) == (len(skeletonHeaderPrefix)+8):
 			beaconHeaders.Add(size)
 		case bytes.HasPrefix(key, CliqueSnapshotPrefix) && len(key) == 7+common.HashLength:
+		case bytes.HasPrefix(key, supplyDeltaPrefix) && len(key) == (len(supplyDeltaPrefix)+8+common.HashLength):
+			supplyDeltaDiffs.Add(size)
 			cliqueSnaps.Add(size)
 		case bytes.HasPrefix(key, ChtTablePrefix) ||
 			bytes.HasPrefix(key, ChtIndexTablePrefix) ||
@@ -577,6 +580,7 @@ func InspectDatabase(db ethdb.Database, keyPrefix, keyStart []byte) error {
 		{"Key-Value store", "Storage snapshot", storageSnaps.Size(), storageSnaps.Count()},
 		{"Key-Value store", "Beacon sync headers", beaconHeaders.Size(), beaconHeaders.Count()},
 		{"Key-Value store", "Clique snapshots", cliqueSnaps.Size(), cliqueSnaps.Count()},
+		{"Key-Value store", "Supply delta counters", supplyDeltaDiffs.Size(), supplyDeltaDiffs.Count()},
 		{"Key-Value store", "Singleton metadata", metadata.Size(), metadata.Count()},
 		{"Light client", "CHT trie nodes", chtTrieNodes.Size(), chtTrieNodes.Count()},
 		{"Light client", "Bloom trie nodes", bloomTrieNodes.Size(), bloomTrieNodes.Count()},

--- a/core/rawdb/schema.go
+++ b/core/rawdb/schema.go
@@ -105,6 +105,8 @@ var (
 	trieNodeAccountPrefix = []byte("A") // trieNodeAccountPrefix + hexPath -> trie node
 	trieNodeStoragePrefix = []byte("O") // trieNodeStoragePrefix + accountHash + hexPath -> trie node
 
+	supplyDeltaPrefix = []byte("e") // supplyDeltaPrefix + num (uint64 big endian) + hash -> wei diff
+
 	PreimagePrefix = []byte("secure-key-")       // PreimagePrefix + hash -> preimage
 	configPrefix   = []byte("ethereum-config-")  // config prefix for the db
 	genesisPrefix  = []byte("ethereum-genesis-") // genesis state prefix for the db
@@ -293,4 +295,9 @@ func IsStorageTrieNode(key []byte) (bool, common.Hash, []byte) {
 	}
 	accountHash := common.BytesToHash(key[len(trieNodeStoragePrefix) : len(trieNodeStoragePrefix)+common.HashLength])
 	return true, accountHash, key[len(trieNodeStoragePrefix)+common.HashLength:]
+}
+
+// supplyDeltaKey = supplyDeltaPrefix + num (uint64 big endian) + hash
+func supplyDeltaKey(number uint64, hash common.Hash) []byte {
+	return append(append(supplyDeltaPrefix, encodeBlockNumber(number)...), hash.Bytes()...)
 }

--- a/core/supply/supply.go
+++ b/core/supply/supply.go
@@ -1,0 +1,62 @@
+// Copyright 2023 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+package supply
+
+import (
+	"math/big"
+	"time"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/state/snapshot"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/log"
+)
+
+// Supply crawls the state snapshot at a given header and gathers all the account
+// balances to sum into the total Ether supply.
+func Supply(header *types.Header, snaptree *snapshot.Tree) (*big.Int, error) {
+	accIt, err := snaptree.AccountIterator(header.Root, common.Hash{})
+	if err != nil {
+		return nil, err
+	}
+	defer accIt.Release()
+
+	log.Info("Ether supply counting started", "block", header.Number, "hash", header.Hash(), "root", header.Root)
+	var (
+		start    = time.Now()
+		logged   = time.Now()
+		accounts uint64
+	)
+	supply := big.NewInt(0)
+	for accIt.Next() {
+		account, err := types.FullAccount(accIt.Account())
+		if err != nil {
+			return nil, err
+		}
+		supply.Add(supply, account.Balance)
+		accounts++
+		if time.Since(logged) > 8*time.Second {
+			log.Info("Ether supply counting in progress", "at", accIt.Hash(),
+				"accounts", accounts, "supply", supply, "elapsed", common.PrettyDuration(time.Since(start)))
+			logged = time.Now()
+		}
+	}
+	log.Info("Ether supply counting complete", "block", header.Number, "hash", header.Hash(), "root", header.Root,
+		"accounts", accounts, "supply", supply, "elapsed", common.PrettyDuration(time.Since(start)))
+
+	return supply, nil
+}

--- a/core/supply/supply.go
+++ b/core/supply/supply.go
@@ -27,7 +27,7 @@ import (
 )
 
 // Supply crawls the state snapshot at a given header and gathers all the account
-// balances to sum into the total Ether supply.
+// balances to sum into the total ether supply.
 func Supply(header *types.Header, snaptree *snapshot.Tree) (*big.Int, error) {
 	accIt, err := snaptree.AccountIterator(header.Root, common.Hash{})
 	if err != nil {

--- a/core/supply/supply.go
+++ b/core/supply/supply.go
@@ -36,6 +36,7 @@ func Supply(header *types.Header, snaptree *snapshot.Tree) (*big.Int, error) {
 	defer accIt.Release()
 
 	log.Info("Ether supply counting started", "block", header.Number, "hash", header.Hash(), "root", header.Root)
+
 	var (
 		start    = time.Now()
 		logged   = time.Now()
@@ -50,13 +51,11 @@ func Supply(header *types.Header, snaptree *snapshot.Tree) (*big.Int, error) {
 		supply.Add(supply, account.Balance)
 		accounts++
 		if time.Since(logged) > 8*time.Second {
-			log.Info("Ether supply counting in progress", "at", accIt.Hash(),
-				"accounts", accounts, "supply", supply, "elapsed", common.PrettyDuration(time.Since(start)))
+			log.Info("Ether supply counting in progress", "at", accIt.Hash(), "accounts", accounts, "supply", supply, "elapsed", common.PrettyDuration(time.Since(start)))
 			logged = time.Now()
 		}
 	}
-	log.Info("Ether supply counting complete", "block", header.Number, "hash", header.Hash(), "root", header.Root,
-		"accounts", accounts, "supply", supply, "elapsed", common.PrettyDuration(time.Since(start)))
+	log.Info("Ether supply counting complete", "block", header.Number, "hash", header.Hash(), "root", header.Root, "accounts", accounts, "supply", supply, "elapsed", common.PrettyDuration(time.Since(start)))
 
 	return supply, nil
 }

--- a/core/supplydelta/supplydelta.go
+++ b/core/supplydelta/supplydelta.go
@@ -1,0 +1,175 @@
+// Copyright 2022 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+package supplydelta
+
+import (
+	"fmt"
+	"math/big"
+	"time"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/consensus/ethash"
+	"github.com/ethereum/go-ethereum/core/state/snapshot"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/log"
+	"github.com/ethereum/go-ethereum/params"
+	"github.com/ethereum/go-ethereum/rlp"
+	"github.com/ethereum/go-ethereum/trie"
+)
+
+// SupplyDelta calculates the Ether delta across two state tries. That is, the
+// issuance minus the ETH destroyed.
+func SupplyDelta(block *types.Block, parent *types.Header, db *trie.Database, config *params.ChainConfig) (*big.Int, error) {
+	var (
+		supplyDelta = new(big.Int)
+		start       = time.Now()
+	)
+	// Open the two tries.
+	if block.ParentHash() != parent.Hash() {
+		return nil, fmt.Errorf("parent hash mismatch: have %s, want %s", block.ParentHash().Hex(), parent.Hash().Hex())
+	}
+	src, err := trie.New(trie.StateTrieID(parent.Root), db)
+	if err != nil {
+		return nil, fmt.Errorf("failed to open source trie: %v", err)
+	}
+	dst, err := trie.New(trie.StateTrieID(block.Root()), db)
+	if err != nil {
+		return nil, fmt.Errorf("failed to open destination trie: %v", err)
+	}
+	// Gather all the changes across from source to destination.
+	fwdDiffIt, _ := trie.NewDifferenceIterator(src.MustNodeIterator(nil), dst.MustNodeIterator(nil))
+	fwdIt := trie.NewIterator(fwdDiffIt)
+
+	for fwdIt.Next() {
+		acc := new(types.StateAccount)
+		if err := rlp.DecodeBytes(fwdIt.Value, acc); err != nil {
+			panic(err)
+		}
+		supplyDelta.Add(supplyDelta, acc.Balance)
+	}
+	// Gather all the changes across from destination to source.
+	rewDiffIt, _ := trie.NewDifferenceIterator(dst.MustNodeIterator(nil), src.MustNodeIterator(nil))
+	rewIt := trie.NewIterator(rewDiffIt)
+
+	for rewIt.Next() {
+		acc := new(types.StateAccount)
+		if err := rlp.DecodeBytes(rewIt.Value, acc); err != nil {
+			panic(err)
+		}
+		supplyDelta.Sub(supplyDelta, acc.Balance)
+	}
+	// Calculate the block fixedReward based on chain rules and progression.
+	fixedReward, unclesReward, burn, withdrawals := Subsidy(block, config)
+
+	// Calculate the difference between the "calculated" and "crawled" supply
+	// delta.
+	diff := new(big.Int).Set(supplyDelta)
+	diff.Sub(diff, fixedReward)
+	diff.Sub(diff, unclesReward)
+	diff.Add(diff, burn)
+
+	log.Info("Calculated supply delta for block", "number", block.Number(), "hash", block.Hash(), "supplydelta", supplyDelta, "fixedreward", fixedReward, "unclesreward", unclesReward, "burn", burn, "withdrawals", withdrawals, "diff", diff, "elapsed", time.Since(start))
+	return supplyDelta, nil
+}
+
+// Subsidy calculates the block mining (fixed) and uncle subsidy as well as the
+// 1559 burn solely based on header fields. This method is a very accurate
+// approximation of the true supply delta, but cannot take into account Ether
+// burns via selfdestructs, so it will always be ever so slightly off.
+func Subsidy(block *types.Block, config *params.ChainConfig) (fixedReward *big.Int, unclesReward *big.Int, burn *big.Int, withdrawals *big.Int) {
+	// Calculate the block rewards based on chain rules and progression.
+	fixedReward = new(big.Int)
+	unclesReward = new(big.Int)
+	withdrawals = new(big.Int)
+
+	// Select the correct block reward based on chain progression.
+	if config.Ethash != nil {
+		if block.Difficulty().BitLen() != 0 {
+			fixedReward = ethash.FrontierBlockReward
+			if config.IsByzantium(block.Number()) {
+				fixedReward = ethash.ByzantiumBlockReward
+			}
+			if config.IsConstantinople(block.Number()) {
+				fixedReward = ethash.ConstantinopleBlockReward
+			}
+		}
+		// Accumulate the rewards for included uncles.
+		var (
+			big8  = big.NewInt(8)
+			big32 = big.NewInt(32)
+			r     = new(big.Int)
+		)
+		for _, uncle := range block.Uncles() {
+			// Add the reward for the side blocks.
+			r.Add(uncle.Number, big8)
+			r.Sub(r, block.Number())
+			r.Mul(r, fixedReward)
+			r.Div(r, big8)
+			unclesReward.Add(unclesReward, r)
+
+			// Add the reward for accumulating the side blocks.
+			r.Div(fixedReward, big32)
+			unclesReward.Add(unclesReward, r)
+		}
+	}
+	// Calculate the burn based on chain rules and progression.
+	burn = new(big.Int)
+	if block.BaseFee() != nil {
+		burn = new(big.Int).Mul(new(big.Int).SetUint64(block.GasUsed()), block.BaseFee())
+	}
+
+	for _, w := range block.Withdrawals() {
+		withdrawals.Add(withdrawals, big.NewInt(int64(w.Amount)))
+	}
+
+	return fixedReward, unclesReward, burn, withdrawals
+}
+
+// Supply crawls the state snapshot at a given header and gathers all the account
+// balances to sum into the total Ether supply.
+func Supply(header *types.Header, snaptree *snapshot.Tree) (*big.Int, error) {
+	accIt, err := snaptree.AccountIterator(header.Root, common.Hash{})
+	if err != nil {
+		return nil, err
+	}
+	defer accIt.Release()
+
+	log.Info("Ether supply counting started", "block", header.Number, "hash", header.Hash(), "root", header.Root)
+	var (
+		start    = time.Now()
+		logged   = time.Now()
+		accounts uint64
+	)
+	supply := big.NewInt(0)
+	for accIt.Next() {
+		account, err := types.FullAccount(accIt.Account())
+		if err != nil {
+			return nil, err
+		}
+		supply.Add(supply, account.Balance)
+		accounts++
+		if time.Since(logged) > 8*time.Second {
+			log.Info("Ether supply counting in progress", "at", accIt.Hash(),
+				"accounts", accounts, "supply", supply, "elapsed", common.PrettyDuration(time.Since(start)))
+			logged = time.Now()
+		}
+	}
+	log.Info("Ether supply counting complete", "block", header.Number, "hash", header.Hash(), "root", header.Root,
+		"accounts", accounts, "supply", supply, "elapsed", common.PrettyDuration(time.Since(start)))
+
+	return supply, nil
+}

--- a/core/vm/interpreter.go
+++ b/core/vm/interpreter.go
@@ -25,10 +25,11 @@ import (
 
 // Config are the configuration options for the Interpreter
 type Config struct {
-	Tracer                  EVMLogger // Opcode logger
-	NoBaseFee               bool      // Forces the EIP-1559 baseFee to 0 (needed for 0 price calls)
-	EnablePreimageRecording bool      // Enables recording of SHA3/keccak preimages
-	ExtraEips               []int     // Additional EIPS that are to be enabled
+	Tracer                     EVMLogger // Opcode logger
+	NoBaseFee                  bool      // Forces the EIP-1559 baseFee to 0 (needed for 0 price calls)
+	EnablePreimageRecording    bool      // Enables recording of SHA3/keccak preimages
+	EnableSupplyDeltaRecording bool      // Enables recording Ether supply delta counters
+	ExtraEips                  []int     // Additional EIPS that are to be enabled
 }
 
 // ScopeContext contains the things that are per-call, such as stack and memory,

--- a/eth/api.go
+++ b/eth/api.go
@@ -17,18 +17,8 @@
 package eth
 
 import (
-	"context"
-	"errors"
-	"math/big"
-
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
-	"github.com/ethereum/go-ethereum/core"
-	"github.com/ethereum/go-ethereum/core/rawdb"
-	"github.com/ethereum/go-ethereum/core/supply"
-	"github.com/ethereum/go-ethereum/core/types"
-	"github.com/ethereum/go-ethereum/log"
-	"github.com/ethereum/go-ethereum/rpc"
 )
 
 // EthereumAPI provides an API to access Ethereum full node-related information.
@@ -59,103 +49,4 @@ func (api *EthereumAPI) Hashrate() hexutil.Uint64 {
 // Mining returns an indication if this node is currently mining.
 func (api *EthereumAPI) Mining() bool {
 	return api.e.IsMining()
-}
-
-// SupplyDelta send a notification each time a new block is appended to the chain
-// with various counters about Ether supply delta: the state diff (if
-// available), block and uncle subsidy, 1559 burn.
-func (api *EthereumAPI) SupplyDelta(ctx context.Context, from uint64) (*rpc.Subscription, error) {
-	// If supply delta tracking is not explcitly enabled, refuse to service this
-	// endpoint. Although we could enable the simple calculations, it might
-	// end up as an unexpected load on RPC providers, so let's not surprise.
-	if !api.e.config.EnableSupplyDeltaRecording {
-		return nil, errors.New("supply delta recording not enabled")
-	}
-	config := api.e.blockchain.Config()
-
-	// Supply delta recording enabled, create a subscription to stream through
-	notifier, supported := rpc.NotifierFromContext(ctx)
-	if !supported {
-		return &rpc.Subscription{}, rpc.ErrNotificationsUnsupported
-	}
-	rpcSub := notifier.CreateSubscription()
-
-	// Define an internal type for supply delta notifications
-	type supplyDeltaNotification struct {
-		Number      uint64      `json:"block"`
-		Hash        common.Hash `json:"hash"`
-		ParentHash  common.Hash `json:"parentHash"`
-		SupplyDelta *big.Int    `json:"supplyDelta"`
-		Reward      *big.Int    `json:"reward"`
-		Withdrawals *big.Int    `json:"withdrawals"`
-		Burn        *big.Int    `json:"burn"`
-		Destruct    *big.Int    `json:"destruct"`
-	}
-	// Define a method to convert a block into an supply delta notification
-	service := func(block *types.Block) {
-		// Retrieve the state-crawled supply delta - if available
-		crawled := rawdb.ReadSupplyDelta(api.e.chainDb, block.NumberU64(), block.Hash())
-
-		// Calculate the issuance and burn from the block's contents
-		rewards, withdrawals := supply.Issuance(block, config)
-		burn := supply.Burn(block.Header())
-
-		// Calculate the difference between the "calculated" and "crawled" supply delta
-		var diff *big.Int
-		if crawled != nil {
-			diff = new(big.Int).Set(crawled)
-			diff.Sub(diff, rewards)
-			diff.Sub(diff, withdrawals)
-			diff.Add(diff, burn)
-		}
-		// Push the supply delta to the user
-		notifier.Notify(rpcSub.ID, &supplyDeltaNotification{
-			Number:      block.NumberU64(),
-			Hash:        block.Hash(),
-			ParentHash:  block.ParentHash(),
-			SupplyDelta: crawled,
-			Reward:      rewards,
-			Withdrawals: withdrawals,
-			Burn:        burn,
-			Destruct:    diff,
-		})
-	}
-	go func() {
-		// Iterate over all blocks from the requested source up to head and push
-		// out historical supply delta values to the user. Checking the head after
-		// each iteration is a bit heavy, but it's not really relevant compared
-		// to pulling blocks from disk, so this keeps thing simpler to switch
-		// from historical blocks to live blocks.
-		for number := from; number <= api.e.blockchain.CurrentBlock().Number.Uint64(); number++ {
-			block := rawdb.ReadBlock(api.e.chainDb, rawdb.ReadCanonicalHash(api.e.chainDb, number), number)
-			if block == nil {
-				log.Error("Missing block for supply delta reporting", "number", number)
-				return
-			}
-			service(block)
-		}
-		// Subscribe to chain events and keep emitting supply deltas on all
-		// branches
-		canonBlocks := make(chan core.ChainEvent)
-		canonBlocksSub := api.e.blockchain.SubscribeChainEvent(canonBlocks)
-		defer canonBlocksSub.Unsubscribe()
-
-		sideBlocks := make(chan core.ChainSideEvent)
-		sideBlocksSub := api.e.blockchain.SubscribeChainSideEvent(sideBlocks)
-		defer sideBlocksSub.Unsubscribe()
-
-		for {
-			select {
-			case event := <-canonBlocks:
-				service(event.Block)
-			case event := <-sideBlocks:
-				service(event.Block)
-			case <-rpcSub.Err():
-				return
-			case <-notifier.Closed():
-				return
-			}
-		}
-	}()
-	return rpcSub, nil
 }

--- a/eth/api.go
+++ b/eth/api.go
@@ -25,7 +25,7 @@ import (
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/core"
 	"github.com/ethereum/go-ethereum/core/rawdb"
-	"github.com/ethereum/go-ethereum/core/supplydelta"
+	"github.com/ethereum/go-ethereum/core/supply"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/rpc"
@@ -97,7 +97,7 @@ func (api *EthereumAPI) SupplyDelta(ctx context.Context, from uint64) (*rpc.Subs
 		crawled := rawdb.ReadSupplyDelta(api.e.chainDb, block.NumberU64(), block.Hash())
 
 		// Calculate the subsidy from the block's contents
-		fixedReward, unclesReward, burn, withdrawals := supplydelta.Subsidy(block, config)
+		fixedReward, unclesReward, burn, withdrawals := supply.Subsidy(block, config)
 		_ = withdrawals
 
 		// Calculate the difference between the "calculated" and "crawled" supply delta

--- a/eth/api.go
+++ b/eth/api.go
@@ -17,8 +17,18 @@
 package eth
 
 import (
+	"context"
+	"errors"
+	"math/big"
+
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/ethereum/go-ethereum/core"
+	"github.com/ethereum/go-ethereum/core/rawdb"
+	"github.com/ethereum/go-ethereum/core/supplydelta"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/log"
+	"github.com/ethereum/go-ethereum/rpc"
 )
 
 // EthereumAPI provides an API to access Ethereum full node-related information.
@@ -49,4 +59,103 @@ func (api *EthereumAPI) Hashrate() hexutil.Uint64 {
 // Mining returns an indication if this node is currently mining.
 func (api *EthereumAPI) Mining() bool {
 	return api.e.IsMining()
+}
+
+// SupplyDelta send a notification each time a new block is appended to the chain
+// with various counters about Ether supply delta: the state diff (if
+// available), block and uncle subsidy, 1559 burn.
+func (api *EthereumAPI) SupplyDelta(ctx context.Context, from uint64) (*rpc.Subscription, error) {
+	// If supply delta tracking is not explcitly enabled, refuse to service this
+	// endpoint. Although we could enable the simple calculations, it might
+	// end up as an unexpected load on RPC providers, so let's not surprise.
+	if !api.e.config.EnableSupplyDeltaRecording {
+		return nil, errors.New("supply delta recording not enabled")
+	}
+	config := api.e.blockchain.Config()
+
+	// Supply delta recording enabled, create a subscription to stream through
+	notifier, supported := rpc.NotifierFromContext(ctx)
+	if !supported {
+		return &rpc.Subscription{}, rpc.ErrNotificationsUnsupported
+	}
+	rpcSub := notifier.CreateSubscription()
+
+	// Define an internal type for supply delta notifications
+	type supplyDeltaNotification struct {
+		Number       uint64      `json:"block"`
+		Hash         common.Hash `json:"hash"`
+		ParentHash   common.Hash `json:"parentHash"`
+		SupplyDelta  *big.Int    `json:"supplyDelta"`
+		FixedReward  *big.Int    `json:"fixedReward"`
+		UnclesReward *big.Int    `json:"unclesReward"`
+		Burn         *big.Int    `json:"burn"`
+		Destruct     *big.Int    `json:"destruct"`
+	}
+	// Define a method to convert a block into an supply delta notification
+	service := func(block *types.Block) {
+		// Retrieve the state-crawled supply delta - if available
+		crawled := rawdb.ReadSupplyDelta(api.e.chainDb, block.NumberU64(), block.Hash())
+
+		// Calculate the subsidy from the block's contents
+		fixedReward, unclesReward, burn, withdrawals := supplydelta.Subsidy(block, config)
+		_ = withdrawals
+
+		// Calculate the difference between the "calculated" and "crawled" supply delta
+		var diff *big.Int
+		if crawled != nil {
+			diff = new(big.Int).Set(crawled)
+			diff.Sub(diff, fixedReward)
+			diff.Sub(diff, unclesReward)
+			diff.Add(diff, burn)
+		}
+		// Push the supply delta to the user
+		notifier.Notify(rpcSub.ID, &supplyDeltaNotification{
+			Number:       block.NumberU64(),
+			Hash:         block.Hash(),
+			ParentHash:   block.ParentHash(),
+			SupplyDelta:  crawled,
+			FixedReward:  fixedReward,
+			UnclesReward: unclesReward,
+			Burn:         burn,
+			Destruct:     diff,
+		})
+	}
+	go func() {
+		// Iterate over all blocks from the requested source up to head and push
+		// out historical supply delta values to the user. Checking the head after
+		// each iteration is a bit heavy, but it's not really relevant compared
+		// to pulling blocks from disk, so this keeps thing simpler to switch
+		// from historical blocks to live blocks.
+		for number := from; number <= api.e.blockchain.CurrentBlock().Number.Uint64(); number++ {
+			block := rawdb.ReadBlock(api.e.chainDb, rawdb.ReadCanonicalHash(api.e.chainDb, number), number)
+			if block == nil {
+				log.Error("Missing block for supply delta reporting", "number", number)
+				return
+			}
+			service(block)
+		}
+		// Subscribe to chain events and keep emitting supply deltas on all
+		// branches
+		canonBlocks := make(chan core.ChainEvent)
+		canonBlocksSub := api.e.blockchain.SubscribeChainEvent(canonBlocks)
+		defer canonBlocksSub.Unsubscribe()
+
+		sideBlocks := make(chan core.ChainSideEvent)
+		sideBlocksSub := api.e.blockchain.SubscribeChainSideEvent(sideBlocks)
+		defer sideBlocksSub.Unsubscribe()
+
+		for {
+			select {
+			case event := <-canonBlocks:
+				service(event.Block)
+			case event := <-sideBlocks:
+				service(event.Block)
+			case <-rpcSub.Err():
+				return
+			case <-notifier.Closed():
+				return
+			}
+		}
+	}()
+	return rpcSub, nil
 }

--- a/eth/api.go
+++ b/eth/api.go
@@ -82,42 +82,42 @@ func (api *EthereumAPI) SupplyDelta(ctx context.Context, from uint64) (*rpc.Subs
 
 	// Define an internal type for supply delta notifications
 	type supplyDeltaNotification struct {
-		Number       uint64      `json:"block"`
-		Hash         common.Hash `json:"hash"`
-		ParentHash   common.Hash `json:"parentHash"`
-		SupplyDelta  *big.Int    `json:"supplyDelta"`
-		FixedReward  *big.Int    `json:"fixedReward"`
-		UnclesReward *big.Int    `json:"unclesReward"`
-		Burn         *big.Int    `json:"burn"`
-		Destruct     *big.Int    `json:"destruct"`
+		Number      uint64      `json:"block"`
+		Hash        common.Hash `json:"hash"`
+		ParentHash  common.Hash `json:"parentHash"`
+		SupplyDelta *big.Int    `json:"supplyDelta"`
+		Reward      *big.Int    `json:"reward"`
+		Withdrawals *big.Int    `json:"withdrawals"`
+		Burn        *big.Int    `json:"burn"`
+		Destruct    *big.Int    `json:"destruct"`
 	}
 	// Define a method to convert a block into an supply delta notification
 	service := func(block *types.Block) {
 		// Retrieve the state-crawled supply delta - if available
 		crawled := rawdb.ReadSupplyDelta(api.e.chainDb, block.NumberU64(), block.Hash())
 
-		// Calculate the subsidy from the block's contents
-		fixedReward, unclesReward, burn, withdrawals := supply.Subsidy(block, config)
-		_ = withdrawals
+		// Calculate the issuance and burn from the block's contents
+		rewards, withdrawals := supply.Issuance(block, config)
+		burn := supply.Burn(block.Header())
 
 		// Calculate the difference between the "calculated" and "crawled" supply delta
 		var diff *big.Int
 		if crawled != nil {
 			diff = new(big.Int).Set(crawled)
-			diff.Sub(diff, fixedReward)
-			diff.Sub(diff, unclesReward)
+			diff.Sub(diff, rewards)
+			diff.Sub(diff, withdrawals)
 			diff.Add(diff, burn)
 		}
 		// Push the supply delta to the user
 		notifier.Notify(rpcSub.ID, &supplyDeltaNotification{
-			Number:       block.NumberU64(),
-			Hash:         block.Hash(),
-			ParentHash:   block.ParentHash(),
-			SupplyDelta:  crawled,
-			FixedReward:  fixedReward,
-			UnclesReward: unclesReward,
-			Burn:         burn,
-			Destruct:     diff,
+			Number:      block.NumberU64(),
+			Hash:        block.Hash(),
+			ParentHash:  block.ParentHash(),
+			SupplyDelta: crawled,
+			Reward:      rewards,
+			Withdrawals: withdrawals,
+			Burn:        burn,
+			Destruct:    diff,
 		})
 	}
 	go func() {

--- a/eth/api_backend.go
+++ b/eth/api_backend.go
@@ -33,6 +33,7 @@ import (
 	"github.com/ethereum/go-ethereum/core/txpool"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/core/vm"
+	"github.com/ethereum/go-ethereum/eth/ethconfig"
 	"github.com/ethereum/go-ethereum/eth/gasprice"
 	"github.com/ethereum/go-ethereum/eth/tracers"
 	"github.com/ethereum/go-ethereum/ethdb"
@@ -48,6 +49,10 @@ type EthAPIBackend struct {
 	allowUnprotectedTxs bool
 	eth                 *Ethereum
 	gpo                 *gasprice.Oracle
+}
+
+func (b *EthAPIBackend) Config() *ethconfig.Config {
+	return b.eth.config
 }
 
 // ChainConfig returns the active chain configuration.

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -180,7 +180,8 @@ func New(stack *node.Node, config *ethconfig.Config) (*Ethereum, error) {
 	}
 	var (
 		vmConfig = vm.Config{
-			EnablePreimageRecording: config.EnablePreimageRecording,
+			EnablePreimageRecording:    config.EnablePreimageRecording,
+			EnableSupplyDeltaRecording: config.EnableSupplyDeltaRecording,
 		}
 		cacheConfig = &core.CacheConfig{
 			TrieCleanLimit:      config.TrieCleanCache,

--- a/eth/ethconfig/config.go
+++ b/eth/ethconfig/config.go
@@ -140,6 +140,9 @@ type Config struct {
 	// Miscellaneous options
 	DocRoot string `toml:"-"`
 
+	// Enables tracking Ether supply deltas during block processing.
+	EnableSupplyDeltaRecording bool
+
 	// RPCGasCap is the global gas cap for eth-call variants.
 	RPCGasCap uint64
 

--- a/eth/ethconfig/gen_config.go
+++ b/eth/ethconfig/gen_config.go
@@ -51,6 +51,7 @@ func (c Config) MarshalTOML() (interface{}, error) {
 		RPCTxFeeCap             float64
 		OverrideCancun          *uint64 `toml:",omitempty"`
 		OverrideVerkle          *uint64 `toml:",omitempty"`
+		EnableSupplyDeltaRecording bool
 	}
 	var enc Config
 	enc.Genesis = c.Genesis
@@ -88,6 +89,7 @@ func (c Config) MarshalTOML() (interface{}, error) {
 	enc.RPCTxFeeCap = c.RPCTxFeeCap
 	enc.OverrideCancun = c.OverrideCancun
 	enc.OverrideVerkle = c.OverrideVerkle
+	enc.EnableSupplyDeltaRecording = c.EnableSupplyDeltaRecording
 	return &enc, nil
 }
 
@@ -129,6 +131,7 @@ func (c *Config) UnmarshalTOML(unmarshal func(interface{}) error) error {
 		RPCTxFeeCap             *float64
 		OverrideCancun          *uint64 `toml:",omitempty"`
 		OverrideVerkle          *uint64 `toml:",omitempty"`
+		EnableSupplyDeltaRecording *bool
 	}
 	var dec Config
 	if err := unmarshal(&dec); err != nil {
@@ -238,6 +241,9 @@ func (c *Config) UnmarshalTOML(unmarshal func(interface{}) error) error {
 	}
 	if dec.OverrideVerkle != nil {
 		c.OverrideVerkle = dec.OverrideVerkle
+	}
+	if dec.EnableSupplyDeltaRecording != nil {
+		c.EnableSupplyDeltaRecording = *dec.EnableSupplyDeltaRecording
 	}
 	return nil
 }

--- a/internal/ethapi/api_test.go
+++ b/internal/ethapi/api_test.go
@@ -40,6 +40,7 @@ import (
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/core/vm"
 	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/eth/ethconfig"
 	"github.com/ethereum/go-ethereum/ethdb"
 	"github.com/ethereum/go-ethereum/event"
 	"github.com/ethereum/go-ethereum/internal/blocktest"
@@ -206,6 +207,7 @@ type testBackend struct {
 	db      ethdb.Database
 	chain   *core.BlockChain
 	pending *types.Block
+	config  *ethconfig.Config
 }
 
 func newTestBackend(t *testing.T, n int, gspec *core.Genesis, generator func(i int, b *core.BlockGen)) *testBackend {
@@ -230,7 +232,7 @@ func newTestBackend(t *testing.T, n int, gspec *core.Genesis, generator func(i i
 		t.Fatalf("block %d: failed to insert into chain: %v", n, err)
 	}
 
-	backend := &testBackend{db: db, chain: chain}
+	backend := &testBackend{db: db, chain: chain, config: &ethconfig.Config{EnableSupplyDeltaRecording: true}}
 	return backend
 }
 
@@ -379,6 +381,7 @@ func (b testBackend) TxPoolContentFrom(addr common.Address) ([]*types.Transactio
 func (b testBackend) SubscribeNewTxsEvent(events chan<- core.NewTxsEvent) event.Subscription {
 	panic("implement me")
 }
+func (b testBackend) Config() *ethconfig.Config        { return b.config }
 func (b testBackend) ChainConfig() *params.ChainConfig { return b.chain.Config() }
 func (b testBackend) Engine() consensus.Engine         { return b.chain.Engine() }
 func (b testBackend) GetLogs(ctx context.Context, blockHash common.Hash, number uint64) ([][]*types.Log, error) {

--- a/internal/ethapi/geth_api.go
+++ b/internal/ethapi/geth_api.go
@@ -1,0 +1,141 @@
+// Copyright 2023 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+package ethapi
+
+import (
+	"context"
+	"errors"
+	"math/big"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core"
+	"github.com/ethereum/go-ethereum/core/rawdb"
+	"github.com/ethereum/go-ethereum/core/supply"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/log"
+	"github.com/ethereum/go-ethereum/rpc"
+)
+
+// GethAPI is the collection of geth-specific APIs exposed over the geth
+// namespace.
+type GethAPI struct {
+	b Backend
+}
+
+// NewDebugAPI creates a new instance of DebugAPI.
+func NewGethAPI(b Backend) *GethAPI {
+	return &GethAPI{b: b}
+}
+
+// SupplyDelta send a notification each time a new block is appended to the chain
+// with various counters about Ether supply delta: the state diff (if
+// available), block and uncle subsidy, 1559 burn.
+func (api *GethAPI) SupplyDelta(ctx context.Context, from uint64) (*rpc.Subscription, error) {
+	// If supply delta tracking is not explcitly enabled, refuse to service this
+	// endpoint. Although we could enable the simple calculations, it might
+	// end up as an unexpected load on RPC providers, so let's not surprise.
+	if !api.b.Config().EnableSupplyDeltaRecording {
+		return nil, errors.New("supply delta recording not enabled")
+	}
+	config := api.b.ChainConfig()
+
+	// Supply delta recording enabled, create a subscription to stream through
+	notifier, supported := rpc.NotifierFromContext(ctx)
+	if !supported {
+		return &rpc.Subscription{}, rpc.ErrNotificationsUnsupported
+	}
+	rpcSub := notifier.CreateSubscription()
+
+	// Define an internal type for supply delta notifications
+	type supplyDeltaNotification struct {
+		Number      uint64      `json:"block"`
+		Hash        common.Hash `json:"hash"`
+		ParentHash  common.Hash `json:"parentHash"`
+		SupplyDelta *big.Int    `json:"supplyDelta"`
+		Reward      *big.Int    `json:"reward"`
+		Withdrawals *big.Int    `json:"withdrawals"`
+		Burn        *big.Int    `json:"burn"`
+		Destruct    *big.Int    `json:"destruct"`
+	}
+	// Define a method to convert a block into an supply delta notification
+	service := func(block *types.Block) {
+		// Retrieve the state-crawled supply delta - if available
+		crawled := rawdb.ReadSupplyDelta(api.b.ChainDb(), block.NumberU64(), block.Hash())
+
+		// Calculate the issuance and burn from the block's contents
+		rewards, withdrawals := supply.Issuance(block, config)
+		burn := supply.Burn(block.Header())
+
+		// Calculate the difference between the "calculated" and "crawled" supply delta
+		var diff *big.Int
+		if crawled != nil {
+			diff = new(big.Int).Set(crawled)
+			diff.Sub(diff, rewards)
+			diff.Sub(diff, withdrawals)
+			diff.Add(diff, burn)
+		}
+		// Push the supply delta to the user
+		notifier.Notify(rpcSub.ID, &supplyDeltaNotification{
+			Number:      block.NumberU64(),
+			Hash:        block.Hash(),
+			ParentHash:  block.ParentHash(),
+			SupplyDelta: crawled,
+			Reward:      rewards,
+			Withdrawals: withdrawals,
+			Burn:        burn,
+			Destruct:    diff,
+		})
+	}
+	go func() {
+		// Iterate over all blocks from the requested source up to head and push
+		// out historical supply delta values to the user. Checking the head after
+		// each iteration is a bit heavy, but it's not really relevant compared
+		// to pulling blocks from disk, so this keeps thing simpler to switch
+		// from historical blocks to live blocks.
+		for number := from; number <= api.b.CurrentBlock().Number.Uint64(); number++ {
+			block := rawdb.ReadBlock(api.b.ChainDb(), rawdb.ReadCanonicalHash(api.b.ChainDb(), number), number)
+			if block == nil {
+				log.Error("Missing block for supply delta reporting", "number", number)
+				return
+			}
+			service(block)
+		}
+		// Subscribe to chain events and keep emitting supply deltas on all
+		// branches
+		canonBlocks := make(chan core.ChainEvent)
+		canonBlocksSub := api.b.SubscribeChainEvent(canonBlocks)
+		defer canonBlocksSub.Unsubscribe()
+
+		sideBlocks := make(chan core.ChainSideEvent)
+		sideBlocksSub := api.b.SubscribeChainSideEvent(sideBlocks)
+		defer sideBlocksSub.Unsubscribe()
+
+		for {
+			select {
+			case event := <-canonBlocks:
+				service(event.Block)
+			case event := <-sideBlocks:
+				service(event.Block)
+			case <-rpcSub.Err():
+				return
+			case <-notifier.Closed():
+				return
+			}
+		}
+	}()
+	return rpcSub, nil
+}

--- a/internal/ethapi/transaction_args_test.go
+++ b/internal/ethapi/transaction_args_test.go
@@ -34,6 +34,7 @@ import (
 	"github.com/ethereum/go-ethereum/core/state"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/core/vm"
+	"github.com/ethereum/go-ethereum/eth/ethconfig"
 	"github.com/ethereum/go-ethereum/ethdb"
 	"github.com/ethereum/go-ethereum/event"
 	"github.com/ethereum/go-ethereum/params"
@@ -255,6 +256,7 @@ func (b *backendMock) SuggestGasTipCap(ctx context.Context) (*big.Int, error) {
 }
 func (b *backendMock) CurrentHeader() *types.Header     { return b.current }
 func (b *backendMock) ChainConfig() *params.ChainConfig { return b.config }
+func (b *backendMock) Config() *ethconfig.Config        { panic("not supported") }
 
 // Other methods needed to implement Backend interface.
 func (b *backendMock) SyncProgress() ethereum.SyncProgress { return ethereum.SyncProgress{} }

--- a/les/api_backend.go
+++ b/les/api_backend.go
@@ -32,6 +32,7 @@ import (
 	"github.com/ethereum/go-ethereum/core/state"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/core/vm"
+	"github.com/ethereum/go-ethereum/eth/ethconfig"
 	"github.com/ethereum/go-ethereum/eth/gasprice"
 	"github.com/ethereum/go-ethereum/eth/tracers"
 	"github.com/ethereum/go-ethereum/ethdb"
@@ -46,6 +47,10 @@ type LesApiBackend struct {
 	allowUnprotectedTxs bool
 	eth                 *LightEthereum
 	gpo                 *gasprice.Oracle
+}
+
+func (b *LesApiBackend) Config() *ethconfig.Config {
+	return b.eth.config
 }
 
 func (b *LesApiBackend) ChainConfig() *params.ChainConfig {


### PR DESCRIPTION
_By all means, ignore this PR for now and focus on the merge._

This PR is based on #24723 by @karalabe / @holiman  , however that PR was getting stale, and https://ultrasound.money needs this code to keep track of various models that take the current ETH supply as an input. We've been running the fork in production for a while, we can't expect you busy gethians to prioritise it now. So here we are. I was planning on using a private fork, some things broke in the rebase, after putting in the effort to properly understand what was going on and fix things, I felt I might as well contribute back the code.

This PR adds the following on top of #24723
1. rewrite a commit to fix a seemingly accidentally removed flag (DocRoot).
2. rewrite a commit to use new flag fns, some larger shift around updating to urfave/cli/v2 I believe.
3. fix various typos.
4. update to new `trie.New` interface requesting an `owner` arg (please closely review this change, I'll mark it in the diff).
5. rename many bits as proposed by @JustinDrake and @holiman.
6. add a `parentHash` to the supply delta notification. 

I'm not married to anything in this PR. Feel free to edit, request edits, propose to drop some of the renamed bits, all fine 👍 .

I don't normally write golang, but apart from 2. and 3. everything logically appears unchanged to my untrained eyes.

Many blessings for the merge core devs 🐼 🙏 ✨ !

🦇🔊 