### PR TITLE
trie: update comments + err check for preimages

### DIFF
--- a/trie/committer.go
+++ b/trie/committer.go
@@ -137,7 +137,7 @@ func (c *committer) commitChildren(path []byte, n *fullNode) ([17]node, error) {
 }
 
 // store hashes the node n and adds it to the modified nodeset. If leaf collection
-// is enabled, key/value pairs are collected to the modified nodeset as well.
+// is enabled, leaf nodes will be tracked in the modified nodeset as well.
 func (c *committer) store(path []byte, n node) node {
 	// Larger nodes are replaced by their hash and stored in the database.
 	var hash, _ = n.cache()

--- a/trie/committer.go
+++ b/trie/committer.go
@@ -44,7 +44,8 @@ func newCommitter(owner common.Hash, collectLeaf bool) *committer {
 	}
 }
 
-// Commit collapses a node down into a hash node and inserts it into the database
+// Commit collapses a node down into a hash node and returns it along with
+// the modified nodeset.
 func (c *committer) Commit(n node) (hashNode, *NodeSet, error) {
 	h, err := c.commit(nil, n)
 	if err != nil {
@@ -53,7 +54,7 @@ func (c *committer) Commit(n node) (hashNode, *NodeSet, error) {
 	return h.(hashNode), c.nodes, nil
 }
 
-// commit collapses a node down into a hash node and inserts it into the database
+// commit collapses a node down into a hash node and returns it.
 func (c *committer) commit(path []byte, n node) (node, error) {
 	// if this path is clean, use available cached data
 	hash, dirty := n.cache()
@@ -75,7 +76,8 @@ func (c *committer) commit(path []byte, n node) (node, error) {
 			}
 			collapsed.Val = childV
 		}
-		// The key needs to be copied, since we're delivering it to database
+		// The key needs to be copied, since we're adding it to the
+		// modified nodeset.
 		collapsed.Key = hexToCompact(cn.Key)
 		hashedNode := c.store(path, collapsed)
 		if hn, ok := hashedNode.(hashNode); ok {
@@ -134,17 +136,16 @@ func (c *committer) commitChildren(path []byte, n *fullNode) ([17]node, error) {
 	return children, nil
 }
 
-// store hashes the node n and if we have a storage layer specified, it writes
-// the key/value pair to it and tracks any node->child references as well as any
-// node->external trie references.
+// store hashes the node n and adds it to the modified nodeset. If leaf collection
+// is enabled, key/value pairs are collected to the modified nodeset as well.
 func (c *committer) store(path []byte, n node) node {
 	// Larger nodes are replaced by their hash and stored in the database.
 	var hash, _ = n.cache()
 
 	// This was not generated - must be a small node stored in the parent.
 	// In theory, we should check if the node is leaf here (embedded node
-	// usually is leaf node). But small value(less than 32bytes) is not
-	// our target(leaves in account trie only).
+	// usually is leaf node). But small value (less than 32bytes) is not
+	// our target (leaves in account trie only).
 	if hash == nil {
 		return n
 	}

--- a/trie/database.go
+++ b/trie/database.go
@@ -567,7 +567,9 @@ func (db *Database) Cap(limit common.StorageSize) error {
 	// If the preimage cache got large enough, push to disk. If it's still small
 	// leave for later to deduplicate writes.
 	if db.preimages != nil {
-		db.preimages.commit(false)
+		if err := db.preimages.commit(false); err != nil {
+			return err
+		}
 	}
 	// Keep committing nodes from the flush-list until we're below allowance
 	oldest := db.oldest
@@ -645,7 +647,9 @@ func (db *Database) Commit(node common.Hash, report bool, callback func(common.H
 
 	// Move all of the accumulated preimages into a write batch
 	if db.preimages != nil {
-		db.preimages.commit(true)
+		if err := db.preimages.commit(true); err != nil {
+			return err
+		}
 	}
 	// Move the trie itself into the batch, flushing if enough data is accumulated
 	nodes, storage := len(db.dirties), db.dirtiesSize

--- a/trie/secure_trie.go
+++ b/trie/secure_trie.go
@@ -199,10 +199,10 @@ func (t *StateTrie) GetKey(shaKey []byte) []byte {
 	return t.preimages.preimage(common.BytesToHash(shaKey))
 }
 
-// Commit collects all dirty nodes in the trie and replace them with the
-// corresponding node hash. All collected nodes(including dirty leaves if
+// Commit collects all dirty nodes in the trie and replaces them with the
+// corresponding node hash. All collected nodes (including dirty leaves if
 // collectLeaf is true) will be encapsulated into a nodeset for return.
-// The returned nodeset can be nil if the trie is clean(nothing to commit).
+// The returned nodeset can be nil if the trie is clean (nothing to commit).
 // All cached preimages will be also flushed if preimages recording is enabled.
 // Once the trie is committed, it's not usable anymore. A new trie must
 // be created with new root and updated trie database for following usage
@@ -218,7 +218,7 @@ func (t *StateTrie) Commit(collectLeaf bool) (common.Hash, *NodeSet, error) {
 		}
 		t.secKeyCache = make(map[string][]byte)
 	}
-	// Commit the trie to its intermediate node database
+	// Commit the trie and return its modified nodeset.
 	return t.trie.Commit(collectLeaf)
 }
 

--- a/trie/trie.go
+++ b/trie/trie.go
@@ -582,10 +582,10 @@ func (t *Trie) Hash() common.Hash {
 	return common.BytesToHash(hash.(hashNode))
 }
 
-// Commit collects all dirty nodes in the trie and replace them with the
-// corresponding node hash. All collected nodes(including dirty leaves if
+// Commit collects all dirty nodes in the trie and replaces them with the
+// corresponding node hash. All collected nodes (including dirty leaves if
 // collectLeaf is true) will be encapsulated into a nodeset for return.
-// The returned nodeset can be nil if the trie is clean(nothing to commit).
+// The returned nodeset can be nil if the trie is clean (nothing to commit).
 // Once the trie is committed, it's not usable anymore. A new trie must
 // be created with new root and updated trie database for following usage
 func (t *Trie) Commit(collectLeaf bool) (common.Hash, *NodeSet, error) {


### PR DESCRIPTION
This PR includes minor updates to comments in trie/committer that reference insertion to the db, and adds an `err != nil` check for the return value of `preimages.commit`.

Thanks for having a look.