### PR TITLE
tests: report mgas/s metric in evm benchmarks

### DIFF
--- a/tests/state_test.go
+++ b/tests/state_test.go
@@ -240,24 +240,29 @@ func runBenchmark(b *testing.B, t *StateTest) {
 				nil, 0)
 
 			var gasUsed uint64
-			start := time.Now()
+			var elapsed uint64
 
 			b.ResetTimer()
 			for n := 0; n < b.N; n++ {
 				snapshot := statedb.Snapshot()
+
 				b.StartTimer()
+				start := time.Now()
+
 				// Execute the message.
 				_, leftOverGas, err := evm.Call(sender, *msg.To(), msg.Data(), msg.Gas(), msg.Value())
 				if err != nil {
 					b.Error(err)
 					return
 				}
+
 				b.StopTimer()
-				statedb.RevertToSnapshot(snapshot)
+				elapsed += uint64(time.Since(start))
 				gasUsed += msg.Gas() - leftOverGas
+
+				statedb.RevertToSnapshot(snapshot)
 			}
 
-			elapsed := uint64(time.Since(start))
 			if elapsed < 1 {
 				elapsed = 1
 			}

--- a/tests/state_test.go
+++ b/tests/state_test.go
@@ -193,12 +193,14 @@ func runBenchmark(b *testing.B, t *StateTest) {
 				b.Error(err)
 				return
 			}
+			var rules = config.Rules(new(big.Int), false)
+
 			vmconfig.ExtraEips = eips
 			block := t.genesis(config).ToBlock(nil)
 			_, statedb := MakePreState(rawdb.NewMemoryDatabase(), t.json.Pre, false)
 
 			var baseFee *big.Int
-			if config.IsLondon(new(big.Int)) {
+			if rules.IsLondon {
 				baseFee = t.json.Env.BaseFee
 				if baseFee == nil {
 					// Retesteth uses `0x10` for genesis baseFee. Therefore, it defaults to
@@ -239,13 +241,17 @@ func runBenchmark(b *testing.B, t *StateTest) {
 			sender := vm.NewContract(vm.AccountRef(msg.From()), vm.AccountRef(msg.From()),
 				nil, 0)
 
-			var gasUsed uint64
-			var elapsed uint64
-
+			var (
+				gasUsed uint64
+				elapsed uint64
+				refund  uint64
+			)
 			b.ResetTimer()
 			for n := 0; n < b.N; n++ {
 				snapshot := statedb.Snapshot()
-
+				if rules.IsBerlin {
+					statedb.PrepareAccessList(msg.From(), msg.To(), vm.ActivePrecompiles(rules), msg.AccessList())
+				}
 				b.StartTimer()
 				start := time.Now()
 
@@ -258,16 +264,16 @@ func runBenchmark(b *testing.B, t *StateTest) {
 
 				b.StopTimer()
 				elapsed += uint64(time.Since(start))
+				refund += statedb.GetRefund()
 				gasUsed += msg.Gas() - leftOverGas
 
 				statedb.RevertToSnapshot(snapshot)
 			}
-
 			if elapsed < 1 {
 				elapsed = 1
 			}
 			// Keep it as uint64, multiply 100 to get two digit float later
-			mgasps := (100 * 1000 * gasUsed) / elapsed
+			mgasps := (100 * 1000 * (gasUsed - refund)) / elapsed
 			b.ReportMetric(float64(mgasps)/100, "mgas/s")
 		})
 	}


### PR DESCRIPTION
I think it's good to have `mgas/s` metric in EVM benchmarks, so anyone could compare geth's implementation with e.g. [evmone](https://github.com/ethereum/evmone)'s which has [the same reporting format](https://github.com/ethereum/evmone/blob/4ab4b4b928ed85fa6eea58cc135f31ab1f1ba8fa/test/bench/helpers.hpp#L145).

Ideally, we would be able to have all EVM implementations benchmarked against one metric that's comparable regardless of implementation language.