### PR TITLE
core, eth/ethconfig: Snapshot rewind limit

### DIFF
--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -132,6 +132,7 @@ type CacheConfig struct {
 	TrieTimeLimit       time.Duration // Time limit after which to flush the current in-memory trie to disk
 	SnapshotLimit       int           // Memory allowance (MB) to use for caching snapshot entries in memory
 	Preimages           bool          // Whether to store preimage of trie key to the disk
+	SnapshotRewindLimit uint64        // Rollback up to this much gas to restore snapshot (otherwise snapshot recalculated from nothing)
 
 	SnapshotWait bool // Wait for snapshot construction on startup. TODO(karalabe): This is a dirty hack for testing, nuke it
 }
@@ -316,17 +317,20 @@ func NewBlockChain(db ethdb.Database, cacheConfig *CacheConfig, genesis *Genesis
 		if diskRoot != (common.Hash{}) {
 			log.Warn("Head state missing, repairing", "number", head.Number(), "hash", head.Hash(), "snaproot", diskRoot)
 
-			snapDisk, err := bc.setHeadBeyondRoot(head.NumberU64(), diskRoot, true)
+			snapDisk, diskRootFound, err := bc.setHeadBeyondRoot(head.NumberU64(), diskRoot, true, bc.cacheConfig.SnapshotRewindLimit)
 			if err != nil {
 				return nil, err
 			}
 			// Chain rewound, persist old snapshot number to indicate recovery procedure
-			if snapDisk != 0 {
+			if diskRootFound {
 				rawdb.WriteSnapshotRecoveryNumber(bc.db, snapDisk)
+			} else {
+				log.Warn("Snapshot root not found or too far back. Recreating snapshot from scratch.")
+				rawdb.DeleteSnapshotRecoveryNumber(bc.db)
 			}
 		} else {
 			log.Warn("Head state missing, repairing", "number", head.Number(), "hash", head.Hash())
-			if _, err := bc.setHeadBeyondRoot(head.NumberU64(), common.Hash{}, true); err != nil {
+			if _, _, err := bc.setHeadBeyondRoot(head.NumberU64(), common.Hash{}, true, 0); err != nil {
 				return nil, err
 			}
 		}
@@ -526,7 +530,7 @@ func (bc *BlockChain) loadLastState() error {
 // was fast synced or full synced and in which state, the method will try to
 // delete minimal data from disk whilst retaining chain consistency.
 func (bc *BlockChain) SetHead(head uint64) error {
-	_, err := bc.setHeadBeyondRoot(head, common.Hash{}, false)
+	_, _, err := bc.setHeadBeyondRoot(head, common.Hash{}, false, 0)
 	return err
 }
 
@@ -553,21 +557,24 @@ func (bc *BlockChain) SetSafe(block *types.Block) {
 }
 
 // setHeadBeyondRoot rewinds the local chain to a new head with the extra condition
-// that the rewind must pass the specified state root. This method is meant to be
+// that the rewind must pass the specified state root. The extra condition is
+// ignored if it causes rolling back more than rewindLimit Gas (0 meaning infinte).
+// If the limit was hit, rewind to last block with state. This method is meant to be
 // used when rewinding with snapshots enabled to ensure that we go back further than
 // persistent disk layer. Depending on whether the node was fast synced or full, and
 // in which state, the method will try to delete minimal data from disk whilst
 // retaining chain consistency.
 //
 // The method returns the block number where the requested root cap was found.
-func (bc *BlockChain) setHeadBeyondRoot(head uint64, root common.Hash, repair bool) (uint64, error) {
+func (bc *BlockChain) setHeadBeyondRoot(head uint64, root common.Hash, repair bool, rewindLimit uint64) (uint64, bool, error) {
 	if !bc.chainmu.TryLock() {
-		return 0, errChainStopped
+		return 0, false, errChainStopped
 	}
 	defer bc.chainmu.Unlock()
 
 	// Track the block number of the requested root hash
-	var rootNumber uint64 // (no root == always 0)
+	var blockNumber uint64 // (no root == always 0)
+	var rootFound bool
 
 	// Retrieve the last pivot block to short circuit rollbacks beyond it and the
 	// current freezer limit to start nuking id underflown
@@ -587,12 +594,15 @@ func (bc *BlockChain) setHeadBeyondRoot(head uint64, root common.Hash, repair bo
 				// Block exists, keep rewinding until we find one with state,
 				// keeping rewinding until we exceed the optional threshold
 				// root hash
-				beyondRoot := (root == common.Hash{}) // Flag whether we're beyond the requested root (no root, always true)
+				rootFound = (root == common.Hash{}) // Flag whether we're beyond the requested root (no root, always true)
+				lastFullBlock := uint64(0)
+				lastFullBlockHash := common.Hash{}
+				gasRolledBack := uint64(0)
 
 				for {
 					// If a root threshold was requested but not yet crossed, check
-					if root != (common.Hash{}) && !beyondRoot && newHeadBlock.Root() == root {
-						beyondRoot, rootNumber = true, newHeadBlock.NumberU64()
+					if root != (common.Hash{}) && !rootFound && newHeadBlock.Root() == root {
+						rootFound, blockNumber = true, newHeadBlock.NumberU64()
 					}
 					if _, err := state.New(newHeadBlock.Root(), bc.stateCache, bc.snaps); err != nil {
 						log.Trace("Block state missing, rewinding further", "number", newHeadBlock.NumberU64(), "hash", newHeadBlock.Hash())
@@ -608,8 +618,11 @@ func (bc *BlockChain) setHeadBeyondRoot(head uint64, root common.Hash, repair bo
 							log.Trace("Rewind passed pivot, aiming genesis", "number", newHeadBlock.NumberU64(), "hash", newHeadBlock.Hash(), "pivot", *pivot)
 							newHeadBlock = bc.genesisBlock
 						}
+					} else if lastFullBlock == 0 {
+						lastFullBlock = newHeadBlock.NumberU64()
+						lastFullBlockHash = newHeadBlock.Hash()
 					}
-					if beyondRoot || newHeadBlock.NumberU64() == 0 {
+					if rootFound || newHeadBlock.NumberU64() == 0 {
 						if newHeadBlock.NumberU64() == 0 {
 							// Recommit the genesis state into disk in case the rewinding destination
 							// is genesis block and the relevant state is gone. In the future this
@@ -625,6 +638,14 @@ func (bc *BlockChain) setHeadBeyondRoot(head uint64, root common.Hash, repair bo
 						}
 						log.Debug("Rewound to block with state", "number", newHeadBlock.NumberU64(), "hash", newHeadBlock.Hash())
 						break
+					}
+					if lastFullBlock != 0 && rewindLimit > 0 {
+						gasRolledBack += newHeadBlock.GasUsed()
+						if rewindLimit > 0 && gasRolledBack >= rewindLimit {
+							blockNumber = lastFullBlock
+							newHeadBlock = bc.GetBlock(lastFullBlockHash, lastFullBlock)
+							break
+						}
 					}
 					log.Debug("Skipping block with threshold state", "number", newHeadBlock.NumberU64(), "hash", newHeadBlock.Hash(), "root", newHeadBlock.Root())
 					newHeadBlock = bc.GetBlock(newHeadBlock.ParentHash(), newHeadBlock.NumberU64()-1) // Keep rewinding
@@ -717,7 +738,7 @@ func (bc *BlockChain) setHeadBeyondRoot(head uint64, root common.Hash, repair bo
 		bc.SetFinalized(nil)
 	}
 
-	return rootNumber, bc.loadLastState()
+	return blockNumber, rootFound, bc.loadLastState()
 }
 
 // SnapSyncCommitHead sets the current head block to the one defined by the hash

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -188,6 +188,7 @@ func New(stack *node.Node, config *ethconfig.Config) (*Ethereum, error) {
 			TrieDirtyLimit:      config.TrieDirtyCache,
 			TrieDirtyDisabled:   config.NoPruning,
 			TrieTimeLimit:       config.TrieTimeout,
+			SnapshotRewindLimit: config.SnapshotRewindLimit,
 			SnapshotLimit:       config.SnapshotCache,
 			Preimages:           config.Preimages,
 		}

--- a/eth/ethconfig/config.go
+++ b/eth/ethconfig/config.go
@@ -82,6 +82,7 @@ var Defaults = Config{
 	TrieCleanCacheRejournal: 60 * time.Minute,
 	TrieDirtyCache:          256,
 	TrieTimeout:             60 * time.Minute,
+	SnapshotRewindLimit:     300_000_000_000,
 	SnapshotCache:           102,
 	FilterLogCacheSize:      32,
 	Miner: miner.Config{
@@ -170,6 +171,7 @@ type Config struct {
 	TrieDirtyCache          int
 	TrieTimeout             time.Duration
 	SnapshotCache           int
+	SnapshotRewindLimit     uint64 `toml:",omitempty"` // Limit (in gas) of chain rewind looking for a snapshot
 	Preimages               bool
 
 	// This is the number of blocks for which logs will be cached in the filter system.


### PR DESCRIPTION
When recovering from an unclean shutdown - geth rolls back to the latest available stored trie that's also behind the latest known snapshot root.

The rate at which intermediate tries are written to storage is controlled by TrieTimeout parameter, which allows the user to balance disk-writes with unclean shutdown recovery. However, snapshot root could be far behind latest stored trie, forcing a very large rewind.

This PR suggests a new config parameter, letting the user choose how much of an extra-rewind is allowed when searching for a valid snapshot behind latest stored trie. This limit is given in gas units, which approximates cpu-time computing the blocks, similar to TrieTimeout parameter. If a snapshot is not found within that limit - geth will only roll back to the latest block with trie in the database, and will start creating a new snapshot from scratch.

Setups which use a config file should not experience any change in behavior unless they specify it, as the empty parameter is translated to no limit.

Default suggested for other setups is 300G gas, which fits about 1H of extra block-compute time to recover a valid snapshot from database - under assumptions of [0.3s / 25M gas](https://github.com/ethereum/go-ethereum/issues/22366#issuecomment-858440637).