### PR TITLE
Fix state test error checking

### DIFF
--- a/tests/state_test.go
+++ b/tests/state_test.go
@@ -57,12 +57,12 @@ func TestState(t *testing.T) {
 
 	// Broken tests:
 	// Expected failures:
-	//st.fails(`^stRevertTest/RevertPrecompiledTouch(_storage)?\.json/Byzantium/0`, "bug in test")
-	//st.fails(`^stRevertTest/RevertPrecompiledTouch(_storage)?\.json/Byzantium/3`, "bug in test")
-	//st.fails(`^stRevertTest/RevertPrecompiledTouch(_storage)?\.json/Constantinople/0`, "bug in test")
-	//st.fails(`^stRevertTest/RevertPrecompiledTouch(_storage)?\.json/Constantinople/3`, "bug in test")
-	//st.fails(`^stRevertTest/RevertPrecompiledTouch(_storage)?\.json/ConstantinopleFix/0`, "bug in test")
-	//st.fails(`^stRevertTest/RevertPrecompiledTouch(_storage)?\.json/ConstantinopleFix/3`, "bug in test")
+	// st.fails(`^stRevertTest/RevertPrecompiledTouch(_storage)?\.json/Byzantium/0`, "bug in test")
+	// st.fails(`^stRevertTest/RevertPrecompiledTouch(_storage)?\.json/Byzantium/3`, "bug in test")
+	// st.fails(`^stRevertTest/RevertPrecompiledTouch(_storage)?\.json/Constantinople/0`, "bug in test")
+	// st.fails(`^stRevertTest/RevertPrecompiledTouch(_storage)?\.json/Constantinople/3`, "bug in test")
+	// st.fails(`^stRevertTest/RevertPrecompiledTouch(_storage)?\.json/ConstantinopleFix/0`, "bug in test")
+	// st.fails(`^stRevertTest/RevertPrecompiledTouch(_storage)?\.json/ConstantinopleFix/3`, "bug in test")
 
 	// For Istanbul, older tests were moved into LegacyTests
 	for _, dir := range []string{
@@ -82,6 +82,9 @@ func TestState(t *testing.T) {
 							// Ignore expected errors (TODO MariusVanDerWijden check error string)
 							return nil
 						}
+						if err == nil && len(test.json.Post[subtest.Fork][subtest.Index].ExpectException) > 0 {
+							return fmt.Errorf("expected exception %q", test.json.Post[subtest.Fork][subtest.Index].ExpectException)
+						}
 						return st.checkFailure(t, err)
 					})
 				})
@@ -96,6 +99,9 @@ func TestState(t *testing.T) {
 						if err != nil && len(test.json.Post[subtest.Fork][subtest.Index].ExpectException) > 0 {
 							// Ignore expected errors (TODO MariusVanDerWijden check error string)
 							return nil
+						}
+						if err == nil && len(test.json.Post[subtest.Fork][subtest.Index].ExpectException) > 0 {
+							return fmt.Errorf("expected exception %q", test.json.Post[subtest.Fork][subtest.Index].ExpectException)
 						}
 						return st.checkFailure(t, err)
 					})

--- a/tests/state_test.go
+++ b/tests/state_test.go
@@ -78,13 +78,6 @@ func TestState(t *testing.T) {
 				t.Run(key+"/trie", func(t *testing.T) {
 					withTrace(t, test.gasLimit(subtest), func(vmconfig vm.Config) error {
 						_, _, err := test.Run(subtest, vmconfig, false)
-						if err != nil && len(test.json.Post[subtest.Fork][subtest.Index].ExpectException) > 0 {
-							// Ignore expected errors (TODO MariusVanDerWijden check error string)
-							return nil
-						}
-						if err == nil && len(test.json.Post[subtest.Fork][subtest.Index].ExpectException) > 0 {
-							return fmt.Errorf("expected exception %q", test.json.Post[subtest.Fork][subtest.Index].ExpectException)
-						}
 						return st.checkFailure(t, err)
 					})
 				})
@@ -95,13 +88,6 @@ func TestState(t *testing.T) {
 							if _, err := snaps.Journal(statedb.IntermediateRoot(false)); err != nil {
 								return err
 							}
-						}
-						if err != nil && len(test.json.Post[subtest.Fork][subtest.Index].ExpectException) > 0 {
-							// Ignore expected errors (TODO MariusVanDerWijden check error string)
-							return nil
-						}
-						if err == nil && len(test.json.Post[subtest.Fork][subtest.Index].ExpectException) > 0 {
-							return fmt.Errorf("expected exception %q", test.json.Post[subtest.Fork][subtest.Index].ExpectException)
 						}
 						return st.checkFailure(t, err)
 					})

--- a/tests/state_test_util.go
+++ b/tests/state_test_util.go
@@ -231,7 +231,8 @@ func (t *StateTest) RunNoVerify(subtest StateSubtest, vmconfig vm.Config, snapsh
 	snapshot := statedb.Snapshot()
 	gaspool := new(core.GasPool)
 	gaspool.AddGas(block.GasLimit())
-	if _, err := core.ApplyMessage(evm, msg, gaspool); err != nil {
+	_, err = core.ApplyMessage(evm, msg, gaspool)
+	if err != nil {
 		statedb.RevertToSnapshot(snapshot)
 	}
 	// Add 0-value mining reward. This only makes a difference in the cases
@@ -244,7 +245,7 @@ func (t *StateTest) RunNoVerify(subtest StateSubtest, vmconfig vm.Config, snapsh
 	statedb.Commit(config.IsEIP158(block.Number()))
 	// And _now_ get the state root
 	root := statedb.IntermediateRoot(config.IsEIP158(block.Number()))
-	return snaps, statedb, root, nil
+	return snaps, statedb, root, err
 }
 
 func (t *StateTest) gasLimit(subtest StateSubtest) uint64 {


### PR DESCRIPTION
This patch fixes error checking, which was silently failing (or, passing for the wrong reasons) for some tests, like `GeneralStateTests/stTransactionTest/HighGasPrice.json`, which expected an error `TR_NoFunds`. In this test, the error was discarded by `RunNoVerify`. 

Note that when an expected error is matched, validations on state root and logs are skipped. If they are not skipped, they will fail. (Why?)