### PR TITLE
core: add more compact summary of chain config for bad blocks

### DIFF
--- a/core/badblock.go
+++ b/core/badblock.go
@@ -73,13 +73,18 @@ func runtimeInfo() string {
 		if dirty {
 			version += " (dirty)"
 		}
+
 	default:
 		// Not our main package, probably imported by a different
 		// project. VCS data less relevant here.
 		mod := findModule(buildInfo, ourPath)
-		version = fmt.Sprintf("%s%s %s@%s", buildInfo.Path, buildInfo.Main.Version, mod.Path, mod.Version)
-		if mod.Replace != nil {
-			version += fmt.Sprintf(" (replaced by %s@%s)", mod.Replace.Path, mod.Replace.Version)
+		if mod == nil {
+			version = params.VersionWithMeta
+		} else {
+			version = fmt.Sprintf("%s %s %s@%s", buildInfo.Path, buildInfo.Main.Version, mod.Path, mod.Version)
+			if mod.Replace != nil {
+				version += fmt.Sprintf(" (replaced by %s@%s)", mod.Replace.Path, mod.Replace.Version)
+			}
 		}
 	}
 	return fmt.Sprintf("%s %s %s %s", version, runtime.Version(), runtime.GOARCH, runtime.GOOS)

--- a/core/badblock.go
+++ b/core/badblock.go
@@ -1,0 +1,119 @@
+// Copyright 2022 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+package core
+
+import (
+	"fmt"
+	"runtime"
+	"runtime/debug"
+	"strings"
+
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/params"
+)
+
+const ourPath = "github.com/ethereum/go-ethereum" // Path to our module
+
+// summarizeBadBlock returns a string summarizing the bad block and other
+// relevant information.
+func summarizeBadBlock(block *types.Block, receipts []*types.Receipt, config *params.ChainConfig, err error) string {
+	var receiptString string
+	for i, receipt := range receipts {
+		receiptString += fmt.Sprintf("  %d: cumulative: %v gas: %v contract: %v status: %v tx: %v logs: %v bloom: %x state: %x\n",
+			i, receipt.CumulativeGasUsed, receipt.GasUsed, receipt.ContractAddress.Hex(),
+			receipt.Status, receipt.TxHash.Hex(), receipt.Logs, receipt.Bloom, receipt.PostState)
+	}
+	return fmt.Sprintf(`
+########## BAD BLOCK #########
+Block: %v (%#x)
+Error: %v
+Version: %v
+Chain config: %#v
+Receipts:
+%v##############################
+`, block.Number(), block.Hash(), err, runtimeInfo(), config, receiptString)
+}
+
+// RuntimeInfo returns build and platform information about the current binary.
+//
+// If the package that is currently executing is a prefixed by our go-ethereum
+// module path, it will print out commit and date VCS information. Otherwise,
+// it will assume it's imported by a third-party and will return the imported
+// version and whether it was replaced by another module.
+func runtimeInfo() string {
+	var (
+		version       string
+		buildInfo, ok = debug.ReadBuildInfo()
+	)
+
+	switch {
+	case !ok:
+		// BuildInfo should generally be set. Fallback to the coded
+		// version if not.
+		version = params.VersionWithMeta
+	case strings.HasPrefix(buildInfo.Path, ourPath):
+		// If the main package is from our repo, we can actually
+		// retrieve the VCS information directly from the buildInfo.
+		revision, date, dirty := vcsInfo(buildInfo)
+		version = fmt.Sprintf("geth %s", params.VersionWithCommit(revision, date))
+		if dirty {
+			version += " (dirty)"
+		}
+	default:
+		// Not our main package, probably imported by a different
+		// project. VCS data less relevant here.
+		mod := findModule(buildInfo, ourPath)
+		version = fmt.Sprintf("%s%s %s@%s", buildInfo.Path, buildInfo.Main.Version, mod.Path, mod.Version)
+		if mod.Replace != nil {
+			version += fmt.Sprintf(" (replaced by %s@%s)", mod.Replace.Path, mod.Replace.Version)
+		}
+	}
+	return fmt.Sprintf("%s %s %s %s", version, runtime.Version(), runtime.GOARCH, runtime.GOOS)
+}
+
+// findModule returns the module at path.
+func findModule(info *debug.BuildInfo, path string) *debug.Module {
+	if info.Path == ourPath {
+		return &info.Main
+	}
+	for _, mod := range info.Deps {
+		if mod.Path == path {
+			return mod
+		}
+	}
+	return nil
+}
+
+// vcsInfo returns VCS information of the build.
+func vcsInfo(info *debug.BuildInfo) (revision, date string, dirty bool) {
+	revision = "unknown"
+	date = "unknown"
+
+	for _, v := range info.Settings {
+		switch v.Key {
+		case "vcs.revision":
+			revision = v.Value
+		case "vcs.modified":
+			if v.Value == "true" {
+				dirty = true
+			}
+		case "vcs.time":
+			date = v.Value
+		}
+	}
+	return revision, date, dirty
+}

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -239,7 +239,7 @@ func NewBlockChain(db ethdb.Database, cacheConfig *CacheConfig, genesis *Genesis
 	}
 	log.Info("")
 	log.Info(strings.Repeat("-", 153))
-	for _, line := range strings.Split(chainConfig.String(), "\n") {
+	for _, line := range strings.Split(chainConfig.Description(), "\n") {
 		log.Info(line)
 	}
 	log.Info(strings.Repeat("-", 153))
@@ -2391,24 +2391,7 @@ func (bc *BlockChain) maintainTxIndex(ancients uint64) {
 // reportBlock logs a bad block error.
 func (bc *BlockChain) reportBlock(block *types.Block, receipts types.Receipts, err error) {
 	rawdb.WriteBadBlock(bc.db, block)
-
-	var receiptString string
-	for i, receipt := range receipts {
-		receiptString += fmt.Sprintf("\t %d: cumulative: %v gas: %v contract: %v status: %v tx: %v logs: %v bloom: %x state: %x\n",
-			i, receipt.CumulativeGasUsed, receipt.GasUsed, receipt.ContractAddress.Hex(),
-			receipt.Status, receipt.TxHash.Hex(), receipt.Logs, receipt.Bloom, receipt.PostState)
-	}
-	log.Error(fmt.Sprintf(`
-########## BAD BLOCK #########
-Chain config: %v
-
-Number: %v
-Hash: %#x
-%v
-
-Error: %v
-##############################
-`, bc.chainConfig, block.Number(), block.Hash(), receiptString, err))
+	log.Error(summarizeBadBlock(block, receipts, bc.Config(), err))
 }
 
 // InsertHeaderChain attempts to insert the given header chain in to the local

--- a/les/client.go
+++ b/les/client.go
@@ -105,7 +105,7 @@ func New(stack *node.Node, config *ethconfig.Config) (*LightEthereum, error) {
 	}
 	log.Info("")
 	log.Info(strings.Repeat("-", 153))
-	for _, line := range strings.Split(chainConfig.String(), "\n") {
+	for _, line := range strings.Split(chainConfig.Description(), "\n") {
 		log.Info(line)
 	}
 	log.Info(strings.Repeat("-", 153))

--- a/params/config.go
+++ b/params/config.go
@@ -406,8 +406,8 @@ func (c *CliqueConfig) String() string {
 	return "clique"
 }
 
-// String implements the fmt.Stringer interface.
-func (c *ChainConfig) String() string {
+// Description returns a human-readable description of ChainConfig.
+func (c *ChainConfig) Description() string {
 	var banner string
 
 	// Create some basinc network config output


### PR DESCRIPTION
This is more of an aesthetic preference, but I noticed that @s1na [also mentioned](https://github.com/ethereum/go-ethereum/pull/24904#issuecomment-1157614159) this issue so I thought I would propose it.

Before:

```console
########## BAD BLOCK #########
Chain config: Chain ID:  1 (mainnet)
Consensus: Ethash (proof-of-work)

Pre-Merge hard forks:
 - Homestead:                   0        (https://github.com/ethereum/execution-specs/blob/master/network-upgrades/ma
innet-upgrades/homestead.md)
 - Tangerine Whistle (EIP 150): 0        (https://github.com/ethereum/execution-specs/blob/master/network-upgrades/ma
innet-upgrades/tangerine-whistle.md)
 - Spurious Dragon/1 (EIP 155): 0        (https://github.com/ethereum/execution-specs/blob/master/network-upgrades/ma
innet-upgrades/spurious-dragon.md)
 - Spurious Dragon/2 (EIP 158): 0        (https://github.com/ethereum/execution-specs/blob/master/network-upgrades/ma
innet-upgrades/spurious-dragon.md)
 - Byzantium:                   0        (https://github.com/ethereum/execution-specs/blob/master/network-upgrades/ma
innet-upgrades/byzantium.md)
 - Constantinople:              0        (https://github.com/ethereum/execution-specs/blob/master/network-upgrades/ma
innet-upgrades/constantinople.md)
 - Petersburg:                  0        (https://github.com/ethereum/execution-specs/blob/master/network-upgrades/ma
innet-upgrades/petersburg.md)
 - Istanbul:                    0        (https://github.com/ethereum/execution-specs/blob/master/network-upgrades/ma
innet-upgrades/istanbul.md)
 - Muir Glacier:                0        (https://github.com/ethereum/execution-specs/blob/master/network-upgrades/ma
innet-upgrades/muir-glacier.md)
 - Berlin:                      0        (https://github.com/ethereum/execution-specs/blob/master/network-upgrades/ma
innet-upgrades/berlin.md)
 - London:                      0        (https://github.com/ethereum/execution-specs/blob/master/network-upgrades/ma
innet-upgrades/london.md)
 - Arrow Glacier:               0        (https://github.com/ethereum/execution-specs/blob/master/network-upgrades/ma
innet-upgrades/arrow-glacier.md)
 - Gray Glacier:                0        (https://github.com/ethereum/execution-specs/blob/master/network-upgrades/ma
innet-upgrades/gray-glacier.md)

The Merge is not yet available for this network!
 - Hard-fork specification: https://github.com/ethereum/execution-specs/blob/master/network-upgrades/mainnet-upgrades
/paris.md

Number: 1
Hash: 0x31553f1bb856b900a24d456f51ac4372fa57e08c5a16812db3ff87e63320bf26
         0: cumulative: 21011 gas: 21011 contract: 0x0000000000000000000000000000000000000000 status: 1 tx: 0x00c8d2e
a97ca412f2c474b9dbcdf6e2447e2feb5c7c5cc1b230c5a654dcd2f69 logs: [] bloom: 0000000000000000000000000000000000000000000
000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000
000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000
000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000
000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000
0 state:


Error: invalid gas used (remote: 21009 local: 21011)
##############################
```

After:
```console
########## BAD BLOCK #########
Block: 1 (0x31553f1bb856b900a24d456f51ac4372fa57e08c5a16812db3ff87e63320bf26)
Error: unknown ancestor
Platform: geth (devel) go1.19 arm64 darwin
VCS: c9311a4e-2022-09-15T11:50:14Z (dirty)
Chain config: &params.ChainConfig{ChainID:1, HomesteadBlock:1150000, DAOForkBlock:1920000, DAOForkSupport:true, EIP150Block:2463000, EIP150Hash:0x2086799aeebeae135c246c65021c82b4e15a2c451340993aacfd2751886514f0, EIP155Block:2675000, EIP158Block:2675000, ByzantiumBlock:4370000, ConstantinopleBlock:7280000, PetersburgBlock:7280000, IstanbulBlock:9069000, MuirGlacierBlock:9200000, BerlinBlock:12244000, LondonBlock:12965000, ArrowGlacierBlock:13773000, GrayGlacierBlock:15050000, MergeNetsplitBlock:<nil>, ShanghaiBlock:<nil>, CancunBlock:<nil>, TerminalTotalDifficulty:58750000000000000000000, TerminalTotalDifficultyPassed:false, Ethash:(*params.EthashConfig)(0x1026eeb58), Clique:(*params.CliqueConfig)(nil)}
Receipts:
##############################
```

```console
########## BAD BLOCK #########
Block: 1 (0x31553f1bb856b900a24d456f51ac4372fa57e08c5a16812db3ff87e63320bf26)
Error: invalid gas used (remote: 21009 local: 21011)
Version: wrong-price(devel) github.com/ethereum/go-ethereum@v1.10.23 (replaced by ./go-ethereum@(devel)) go1.19 arm64 darwin
Chain config: &params.ChainConfig{ChainID:1, HomesteadBlock:0, DAOForkBlock:<nil>, DAOForkSupport:false, EIP150Block:0, EIP150Hash:0x0000000000000000000000000000000000000000000000000000000000000000, EIP155Block:0, EIP158Block:0, ByzantiumBlock:0, ConstantinopleBlock:0, PetersburgBlock:0, IstanbulBlock:0, MuirGlacierBlock:0, BerlinBlock:0, LondonBlock:0, ArrowGlacierBlock:0, GrayGlacierBlock:0, MergeNetsplitBlock:<nil>, ShanghaiBlock:<nil>, CancunBlock:<nil>, TerminalTotalDifficulty:<nil>, TerminalTotalDifficultyPassed:false, Ethash:(*params.EthashConfig)(0x1018cd770), Clique:(*params.CliqueConfig)(nil)}
Receipts:
  0: cumulative: 21011 gas: 21011 contract: 0x0000000000000000000000000000000000000000 status: 1 tx: 0x00c8d2ea97ca412f2c474b9dbcdf6e2447e2feb5c7c5cc1b230c5a654dcd2f69 logs: [] bloom: 00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000 state:
##############################
```