### PR TITLE
node: make generated jwt-secret ga+rw

### DIFF
--- a/node/node.go
+++ b/node/node.go
@@ -370,7 +370,7 @@ func (n *Node) obtainJWTSecret(cliParam string) ([]byte, error) {
 		log.Info("Generated ephemeral JWT secret", "secret", hexutil.Encode(jwtSecret))
 		return jwtSecret, nil
 	}
-	if err := os.WriteFile(fileName, []byte(hexutil.Encode(jwtSecret)), 0600); err != nil {
+	if err := os.WriteFile(fileName, []byte(hexutil.Encode(jwtSecret)), 0666); err != nil {
 		return nil, err
 	}
 	log.Info("Generated JWT secret", "path", fileName)


### PR DESCRIPTION
If geth generates a `jwtsecret` file, geth `master` makes it `0600`, or `-rw------` mode. This PR makes it into `0666`, or `-rw-rw-rw-`. The reason is that a lot of setups uses different users for the EL and the CL, due to differing docker image setups. Geth dockerfile, IIRC, runs with least hassle as `root`, whereas other dockerfiles might be more "according to best practice", and uses a different user. 
Anyway, the idea is that anyone can read it, or modify it. 
As for the security implications: it makes geth a tad less 'secure' in a hostile multi-user scenarion, but I'd argue that a validator beacon-geth setup where hostile parties have access to the OS is already pretty much compromised.  