### PR TITLE
crypto/bls12381: docfix of g1 Affine

### DIFF
--- a/crypto/bls12381/g1.go
+++ b/crypto/bls12381/g1.go
@@ -228,7 +228,7 @@ func (g *G1) IsAffine(p *PointG1) bool {
 	return p[2].isOne()
 }
 
-// Add adds two G1 points p1, p2 and assigns the result to point at first argument.
+// Affine calculates affine form of given G1 point.
 func (g *G1) Affine(p *PointG1) *PointG1 {
 	if g.IsZero(p) {
 		return p


### PR DESCRIPTION
Documentation of g1.Affine function was incorrect and appeared to be accidentally copied from the g1.Add function.