### PR TITLE
p2p/discover: reject packets if smaller than 63 bytes

### DIFF
--- a/p2p/discover/v5wire/encoding.go
+++ b/p2p/discover/v5wire/encoding.go
@@ -90,6 +90,10 @@ const (
 	minVersion      = 1
 	sizeofMaskingIV = 16
 
+	// The minimum size of any Discovery v5 packet is 63 bytes.
+	// Should reject packets smaller than minPacketSize.
+	minPacketSize = 63
+
 	minMessageSize      = 48 // this refers to data after static headers
 	randomPacketMsgSize = 20
 )
@@ -415,10 +419,10 @@ func (c *Codec) encryptMessage(s *session, p Packet, head *Header, headerData []
 
 // Decode decodes a discovery packet.
 func (c *Codec) Decode(input []byte, addr string) (src enode.ID, n *enode.Node, p Packet, err error) {
-	// Unmask the static header.
-	if len(input) < sizeofStaticPacketData {
+	if len(input) < minPacketSize {
 		return enode.ID{}, nil, nil, errTooShort
 	}
+	// Unmask the static header.
 	var head Header
 	copy(head.IV[:], input[:sizeofMaskingIV])
 	mask := head.mask(c.localnode.ID())

--- a/p2p/discover/v5wire/encoding_test.go
+++ b/p2p/discover/v5wire/encoding_test.go
@@ -275,7 +275,15 @@ func TestDecodeErrorsV5(t *testing.T) {
 	net := newHandshakeTest()
 	defer net.close()
 
-	net.nodeA.expectDecodeErr(t, errTooShort, []byte{})
+	b := make([]byte, 0)
+	net.nodeA.expectDecodeErr(t, errTooShort, b)
+
+	b = make([]byte, 62)
+	net.nodeA.expectDecodeErr(t, errTooShort, b)
+
+	b = make([]byte, 63)
+	net.nodeA.expectDecodeErr(t, errInvalidHeader, b)
+
 	// TODO some more tests would be nice :)
 	// - check invalid authdata sizes
 	// - check invalid handshake data sizes


### PR DESCRIPTION
Implemented to reject packet if Discovery v5 packet size smaller than 63 bytes.
Of course, the original code also rejects the packet if it is smaller than 63 bytes. But it's not an 'errTooShort' error.
It's occur error about `Decode auth part and message`.

ref: [devp2p](https://github.com/ethereum/devp2p/blob/master/discv5/discv5-wire.md)


