### PR TITLE
node: fix HTTP server always force closing

### DIFF
--- a/node/rpcstack.go
+++ b/node/rpcstack.go
@@ -269,8 +269,7 @@ func (h *httpServer) doStop() {
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), shutdownTimeout)
 	defer cancel()
-	err := h.server.Shutdown(ctx)
-	if err == ctx.Err() {
+	if err := h.server.Shutdown(ctx); err != nil && err == ctx.Err() {
 		h.log.Warn("HTTP server graceful shutdown timed out")
 		h.server.Close()
 	}

--- a/node/rpcstack.go
+++ b/node/rpcstack.go
@@ -267,12 +267,15 @@ func (h *httpServer) doStop() {
 		h.wsHandler.Store((*rpcHandler)(nil))
 		wsHandler.server.Stop()
 	}
+	
 	ctx, cancel := context.WithTimeout(context.Background(), shutdownTimeout)
 	defer cancel()
-	if err := h.server.Shutdown(ctx); err != nil && err == ctx.Err() {
+	err := h.server.Shutdown(ctx)
+	if err != nil && err == ctx.Err() {
 		h.log.Warn("HTTP server graceful shutdown timed out")
 		h.server.Close()
 	}
+	
 	h.listener.Close()
 	h.log.Info("HTTP server stopped", "endpoint", h.listener.Addr())
 


### PR DESCRIPTION
The HTTP server was always force closing with `HTTP server graceful shutdown timed out` because we didn't check that the error was not `nil`