### PR TITLE
bls12381: improve pairing precompile

### DIFF
--- a/core/vm/contracts.go
+++ b/core/vm/contracts.go
@@ -935,7 +935,11 @@ func (c *bls12381Pairing) Run(input []byte) ([]byte, error) {
 			return nil, errBLS12381G2PointSubgroup
 		}
 
-		// Update pairing engine with G1 and G2 ponits
+		// Update pairing engine with G1 and G2 points
+    if i == 0 {
+      e.AddPairInv(p1, p2)
+      continue
+    }
 		e.AddPair(p1, p2)
 	}
 	// Prepare 32 byte output

--- a/core/vm/contracts.go
+++ b/core/vm/contracts.go
@@ -936,10 +936,10 @@ func (c *bls12381Pairing) Run(input []byte) ([]byte, error) {
 		}
 
 		// Update pairing engine with G1 and G2 points
-    if i == 0 {
-      e.AddPairInv(p1, p2)
-      continue
-    }
+		if i == 0 {
+		  e.AddPairInv(p1, p2)
+		  continue
+		}
 		e.AddPair(p1, p2)
 	}
 	// Prepare 32 byte output


### PR DESCRIPTION
The bls12381 precompile takes input 
```
// > Pairing call expects `384*k` bytes as an inputs that is interpreted as byte concatenation of `k` slices. Each slice has the following structure:
  // > - `128` bytes of G1 point encoding
  // > - `256` bytes of G2 point encoding
```
which assumes that the caller has inverted one of the [G1 point encoding, G2 point encoding] pairs.

Inverting one of these pairs "contract"-side requires extra operations incurring additional gas and complexity cost. 

This PR's change makes it to where all pairs encoded as input can resume their standard form and not be inverted. 

The goal here is: quality of life + gas efficiency + reduction in smart contract developer oversight/error  
