### PR TITLE
internal/ethapi: return error when requesting invalid trie key

### DIFF
--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -708,8 +708,10 @@ func (s *BlockChainAPI) GetProof(ctx context.Context, address common.Address, st
 	}, state.Error()
 }
 
+// decodeHash parses a hex-encoded 32-byte hash. The input may optionally
+// be prefixed by 0x and can have an byte length up to 32.
 func decodeHash(s string) (common.Hash, error) {
-	if has0xPrefix(s) {
+	if strings.HasPrefix(s, "0x") || strings.HasPrefix(s, "0X") {
 		s = s[2:]
 	}
 	b, err := hex.DecodeString(s)
@@ -720,10 +722,6 @@ func decodeHash(s string) (common.Hash, error) {
 		return common.Hash{}, fmt.Errorf("hex string too long, want at most 32 bytes")
 	}
 	return common.BytesToHash(b), nil
-}
-
-func has0xPrefix(input string) bool {
-	return len(input) >= 2 && input[0] == '0' && (input[1] == 'x' || input[1] == 'X')
 }
 
 // GetHeaderByNumber returns the requested canonical block header.

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -710,10 +710,10 @@ func (s *BlockChainAPI) GetProof(ctx context.Context, address common.Address, st
 func decodeHash(s string) (common.Hash, error) {
 	b, err := hexutil.Decode(s)
 	if err != nil {
-		return nil, err
+		return common.Hash{}, err
 	}
 	if len(b) > 32 {
-		return nil, fmt.Errorf("hex string too long, want at most 32 bytes")
+		return common.Hash{}, fmt.Errorf("hex string too long, want at most 32 bytes")
 	}
 	return common.BytesToHash(b)
 }


### PR DESCRIPTION
Fixes #25747.

The `key` parameter in `eth_getStorageAt` and `eth_getProof` currently uses `common.HexToHash` to convert the input string to `common.Hash`. This method disregards any errors and simply returns the decoded bytes up until the error. This can cause the RPC to return a different key than the user requested without error.

This PR changes the decoding method to use `hexutil.Decode`. This allows us to fail the request if the hex encoding is invalid. Since it only decodes to a `[]byte`, there is also a bound check to ensure the hex string is less than 32 bytes.

I have included a few tests in the `execution-apis` repo which will be pulled into `hive2`: https://github.com/ethereum/execution-apis/pull/305/files

Before:
```
>> {"jsonrpc":"2.0","id":11,"method":"eth_getStorageAt","params":["0xaa00000000000000000000000000000000000000","0xasdf","latest"]}
<< {"jsonrpc":"2.0","id":0,"result":"0x0000000000000000000000000000000000000000000000000000000000000000"}
```

After:

```
>> {"jsonrpc":"2.0","id":11,"method":"eth_getStorageAt","params":["0xaa00000000000000000000000000000000000000","0xasdf","latest"]}
<< {"jsonrpc":"2.0","id":11,"error":{"code":-32000,"message":"invalid hex string"}}
```