### PR TITLE
eth/protocols/eth: react to termination in dispatcher. Fixes #25775

### DIFF
--- a/eth/protocols/eth/dispatcher.go
+++ b/eth/protocols/eth/dispatcher.go
@@ -174,6 +174,8 @@ func (p *Peer) dispatchResponse(res *Response, metadata func() interface{}) erro
 				return <-res.Done // Response delivered, return any errors
 			case <-res.Req.cancel:
 				return nil // Request cancelled, silently discard response
+			case <-p.term:
+				return errDisconnected
 			}
 		}
 


### PR DESCRIPTION
We didn't listen for the termination chan in one of the sub-selects. 

See #25775 for more context. I _think_ this fixes it. 