### PR TITLE
eth: drop non-updated peers in `handleBlock*`

### DIFF
--- a/eth/handler_eth.go
+++ b/eth/handler_eth.go
@@ -17,6 +17,7 @@
 package eth
 
 import (
+	"errors"
 	"fmt"
 	"math/big"
 	"sync/atomic"
@@ -88,9 +89,7 @@ func (h *ethHandler) handleBlockAnnounces(peer *eth.Peer, hashes []common.Hash, 
 	// the chain already entered the pos stage and disconnect the
 	// remote peer.
 	if h.merger.PoSFinalized() {
-		// TODO (MariusVanDerWijden) drop non-updated peers after the merge
-		return nil
-		// return errors.New("unexpected block announces")
+		return errors.New("unexpected block announces")
 	}
 	// Schedule all the unknown hashes for retrieval
 	var (
@@ -116,9 +115,7 @@ func (h *ethHandler) handleBlockBroadcast(peer *eth.Peer, block *types.Block, td
 	// the chain already entered the pos stage and disconnect the
 	// remote peer.
 	if h.merger.PoSFinalized() {
-		// TODO (MariusVanDerWijden) drop non-updated peers after the merge
-		return nil
-		// return errors.New("unexpected block announces")
+		return errors.New("unexpected block announces")
 	}
 	// Schedule the block for import
 	h.blockFetcher.Enqueue(peer.ID(), block)


### PR DESCRIPTION
The PR to resolve the TODOs.