### PR TITLE
p2p/discover/v5wire: reset buffer including cap reset

### DIFF
--- a/p2p/discover/v5wire/encoding.go
+++ b/p2p/discover/v5wire/encoding.go
@@ -402,7 +402,7 @@ func (c *Codec) encodeMessageHeader(toID enode.ID, s *session) (Header, error) {
 
 func (c *Codec) encryptMessage(s *session, p Packet, head *Header, headerData []byte) ([]byte, error) {
 	// Encode message plaintext.
-	resetBufferWithSize(&c.msgbuf, 1)
+	resetBufferWithSize(&c.msgbuf, 0)
 	c.msgbuf.WriteByte(p.Kind())
 	if err := rlp.Encode(&c.msgbuf, p); err != nil {
 		return nil, err


### PR DESCRIPTION
/go-ethereum/p2p/discover/v5wire
```go
func (c *Codec) writeHeaders(head *Header) {
	c.buf.Reset()
	c.buf.Write(head.IV[:])
	binary.Write(&c.buf, binary.BigEndian, &head.StaticHeader)
	c.buf.Write(head.AuthData)
}
```
In the original codes, bytes.Buffer.Reset is used. There is no capacity reset. 
Of course, the capacity will not grow indefinitely, but in the worst case capacity will continue to maintain the maximum possible buffer size.

(+) Example test code  I used
```go
func (c *Codec) writeHeaders(head *Header) {
	fmt.Println("writeHeaders")
	c.buf.Reset()
	fmt.Printf("[Before] len: %d cap: %d\n", c.buf.Len(), c.buf.Cap())
	c.buf.Write(head.IV[:])
	binary.Write(&c.buf, binary.BigEndian, &head.StaticHeader)
	c.buf.Write(head.AuthData)
	fmt.Printf("[After] len: %d cap: %d\n", c.buf.Len(), c.buf.Cap())
}
```
<br>

Original codes
```
# /go-ethereum/p2p/discover/v5wire
go test -run TestHandshake_timeout
encodeRandom
[Before] len: 0 cap: 0
[After] len: 32 cap: 64
writeHeaders
[Before] len: 0 cap: 0
[After] len: 71 cap: 160
writeHeaders
[Before] len: 0 cap: 160
[After] len: 71 cap: 160
encodeWhoareyou
[Before] len: 0 cap: 0
[After] len: 24 cap: 64
writeHeaders
[Before] len: 0 cap: 0
[After] len: 63 cap: 64
writeHeaders
[Before] len: 0 cap: 64
[After] len: 63 cap: 64
encodeHandshakeHeader
[Before] len: 0 cap: 64
[After] len: 264 cap: 517
writeHeaders
[Before] len: 0 cap: 160
[After] len: 303 cap: 584
writeHeaders
[Before] len: 0 cap: 584
[After] len: 303 cap: 584
```




PR test results.
```
# /go-ethereum/p2p/discover/v5wire
go test -run TestHandshake_timeout
encodeRandom
[Before] len: 0 cap: 32
[After] len: 32 cap: 32
writeHeaders
[Before] len: 0 cap: 71
[After] len: 71 cap: 71
writeHeaders
[Before] len: 0 cap: 71
[After] len: 71 cap: 71
encodeWhoareyou
[Before] len: 0 cap: 24
[After] len: 24 cap: 24
writeHeaders
[Before] len: 0 cap: 63
[After] len: 63 cap: 63
writeHeaders
[Before] len: 0 cap: 63
[After] len: 63 cap: 63
encodeHandshakeHeader
[Before] len: 0 cap: 264
[After] len: 264 cap: 264
writeHeaders
[Before] len: 0 cap: 303
[After] len: 303 cap: 303
writeHeaders
[Before] len: 0 cap: 303
[After] len: 303 cap: 303
```
