### PR TITLE
typo: fix all synchronization spellings

### DIFF
--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -429,7 +429,7 @@ func startNode(ctx *cli.Context, stack *node.Node, backend ethapi.Backend, isCon
 					continue
 				}
 				if timestamp := time.Unix(int64(done.Latest.Time), 0); time.Since(timestamp) < 10*time.Minute {
-					log.Info("Synchronisation completed", "latestnum", done.Latest.Number, "latesthash", done.Latest.Hash(),
+					log.Info("Synchronization completed", "latestnum", done.Latest.Number, "latesthash", done.Latest.Hash(),
 						"age", common.PrettyAge(timestamp))
 					stack.Close()
 				}

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -184,7 +184,7 @@ var (
 	}
 	ExitWhenSyncedFlag = &cli.BoolFlag{
 		Name:     "exitwhensynced",
-		Usage:    "Exits after block synchronisation completes",
+		Usage:    "Exits after block synchronization completes",
 		Category: flags.EthCategory,
 	}
 

--- a/eth/downloader/api.go
+++ b/eth/downloader/api.go
@@ -25,7 +25,7 @@ import (
 	"github.com/ethereum/go-ethereum/rpc"
 )
 
-// DownloaderAPI provides an API which gives information about the current synchronisation status.
+// DownloaderAPI provides an API which gives information about the current synchronization status.
 // It offers only methods that operates on data that can be available to anyone without security risks.
 type DownloaderAPI struct {
 	d                         *Downloader
@@ -119,7 +119,7 @@ func (api *DownloaderAPI) Syncing(ctx context.Context) (*rpc.Subscription, error
 	return rpcSub, nil
 }
 
-// SyncingResult provides information about the current synchronisation status for this node.
+// SyncingResult provides information about the current synchronization status for this node.
 type SyncingResult struct {
 	Syncing bool                  `json:"syncing"`
 	Status  ethereum.SyncProgress `json:"status"`
@@ -158,7 +158,7 @@ func (s *SyncStatusSubscription) Unsubscribe() {
 	})
 }
 
-// SubscribeSyncStatus creates a subscription that will broadcast new synchronisation updates.
+// SubscribeSyncStatus creates a subscription that will broadcast new synchronization updates.
 // The given channel must receive interface values, the result can either.
 func (api *DownloaderAPI) SubscribeSyncStatus(status chan interface{}) *SyncStatusSubscription {
 	api.installSyncSubscription <- status

--- a/eth/downloader/downloader.go
+++ b/eth/downloader/downloader.go
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
 
-// Package downloader contains the manual full chain synchronisation.
+// Package downloader contains the manual full chain synchronization.
 package downloader
 
 import (
@@ -97,7 +97,7 @@ type headerTask struct {
 }
 
 type Downloader struct {
-	mode uint32         // Synchronisation mode defining the strategy used (per sync cycle), use d.getMode() to get the SyncMode
+	mode uint32         // Synchronization mode defining the strategy used (per sync cycle), use d.getMode() to get the SyncMode
 	mux  *event.TypeMux // Event multiplexer to announce sync operation events
 
 	checkpoint uint64   // Checkpoint block number to enforce head against (e.g. snap sync)
@@ -233,11 +233,11 @@ func New(checkpoint uint64, stateDb ethdb.Database, mux *event.TypeMux, chain Bl
 	return dl
 }
 
-// Progress retrieves the synchronisation boundaries, specifically the origin
-// block where synchronisation started at (may have failed/suspended); the block
+// Progress retrieves the synchronization boundaries, specifically the origin
+// block where synchronization started at (may have failed/suspended); the block
 // or header sync is currently at; and the latest known block which the sync targets.
 //
-// In addition, during the state download phase of snap synchronisation the number
+// In addition, during the state download phase of snap synchronization the number
 // of processed and the total number of known states are also returned. Otherwise
 // these are zero.
 func (d *Downloader) Progress() ethereum.SyncProgress {
@@ -340,7 +340,7 @@ func (d *Downloader) LegacySync(id string, head common.Hash, td, ttd *big.Int, m
 	if errors.Is(err, errInvalidChain) || errors.Is(err, errBadPeer) || errors.Is(err, errTimeout) ||
 		errors.Is(err, errStallingPeer) || errors.Is(err, errUnsyncedPeer) || errors.Is(err, errEmptyHeaderSet) ||
 		errors.Is(err, errPeersUnavailable) || errors.Is(err, errTooOld) || errors.Is(err, errInvalidAncestor) {
-		log.Warn("Synchronisation failed, dropping peer", "peer", id, "err", err)
+		log.Warn("Synchronization failed, dropping peer", "peer", id, "err", err)
 		if d.dropPeer == nil {
 			// The dropPeer method is nil when `--copydb` is used for a local copy.
 			// Timeouts can occur if e.g. compaction hits at the wrong time, and can be ignored
@@ -353,7 +353,7 @@ func (d *Downloader) LegacySync(id string, head common.Hash, td, ttd *big.Int, m
 	if errors.Is(err, ErrMergeTransition) {
 		return err // This is an expected fault, don't keep printing it in a spin-loop
 	}
-	log.Warn("Synchronisation failed, retrying", "err", err)
+	log.Warn("Synchronization failed, retrying", "err", err)
 	return err
 }
 
@@ -375,7 +375,7 @@ func (d *Downloader) synchronise(id string, hash common.Hash, td, ttd *big.Int, 
 			}
 		}()
 	}
-	// Mock out the synchronisation if testing
+	// Mock out the synchronization if testing
 	if d.synchroniseMock != nil {
 		return d.synchroniseMock(id, hash)
 	}
@@ -387,7 +387,7 @@ func (d *Downloader) synchronise(id string, hash common.Hash, td, ttd *big.Int, 
 
 	// Post a user notification of the sync (only once per session)
 	if atomic.CompareAndSwapInt32(&d.notified, 0, 1) {
-		log.Info("Block synchronisation started")
+		log.Info("Block synchronization started")
 	}
 	if mode == SnapSync {
 		// Snap sync uses the snapshot namespace to store potentially flakey data until
@@ -464,7 +464,7 @@ func (d *Downloader) syncWithPeer(p *peerConnection, hash common.Hash, td, ttd *
 		log.Debug("Backfilling with the network", "mode", mode)
 	}
 	defer func(start time.Time) {
-		log.Debug("Synchronisation terminated", "elapsed", common.PrettyDuration(time.Since(start)))
+		log.Debug("Synchronization terminated", "elapsed", common.PrettyDuration(time.Since(start)))
 	}(time.Now())
 
 	// Look up the sync boundaries: the common ancestor and the target block
@@ -1574,7 +1574,7 @@ func (d *Downloader) importBlockResults(results []*fetchResult) error {
 }
 
 // processSnapSyncContent takes fetch results from the queue and writes them to the
-// database. It also controls the synchronisation of state nodes of the pivot block.
+// database. It also controls the synchronization of state nodes of the pivot block.
 func (d *Downloader) processSnapSyncContent() error {
 	// Start syncing state of the reported head block. This should get us most of
 	// the state of the pivot block.

--- a/eth/downloader/downloader_test.go
+++ b/eth/downloader/downloader_test.go
@@ -437,12 +437,12 @@ func assertOwnChain(t *testing.T, tester *downloadTester, length int) {
 	}
 }
 
-func TestCanonicalSynchronisation66Full(t *testing.T)  { testCanonSync(t, eth.ETH66, FullSync) }
-func TestCanonicalSynchronisation66Snap(t *testing.T)  { testCanonSync(t, eth.ETH66, SnapSync) }
-func TestCanonicalSynchronisation66Light(t *testing.T) { testCanonSync(t, eth.ETH66, LightSync) }
-func TestCanonicalSynchronisation67Full(t *testing.T)  { testCanonSync(t, eth.ETH67, FullSync) }
-func TestCanonicalSynchronisation67Snap(t *testing.T)  { testCanonSync(t, eth.ETH67, SnapSync) }
-func TestCanonicalSynchronisation67Light(t *testing.T) { testCanonSync(t, eth.ETH67, LightSync) }
+func TestCanonicalSynchronization66Full(t *testing.T)  { testCanonSync(t, eth.ETH66, FullSync) }
+func TestCanonicalSynchronization66Snap(t *testing.T)  { testCanonSync(t, eth.ETH66, SnapSync) }
+func TestCanonicalSynchronization66Light(t *testing.T) { testCanonSync(t, eth.ETH66, LightSync) }
+func TestCanonicalSynchronization67Full(t *testing.T)  { testCanonSync(t, eth.ETH67, FullSync) }
+func TestCanonicalSynchronization67Snap(t *testing.T)  { testCanonSync(t, eth.ETH67, SnapSync) }
+func TestCanonicalSynchronization67Light(t *testing.T) { testCanonSync(t, eth.ETH67, LightSync) }
 
 func testCanonSync(t *testing.T, protocol uint, mode SyncMode) {
 	tester := newTester(t)
@@ -480,7 +480,7 @@ func testThrottling(t *testing.T, protocol uint, mode SyncMode) {
 		atomic.StoreUint32(&blocked, uint32(len(results)))
 		<-proceed
 	}
-	// Start a synchronisation concurrently
+	// Start a synchronization concurrently
 	errc := make(chan error, 1)
 	go func() {
 		errc <- tester.sync("peer", nil, mode)
@@ -706,15 +706,15 @@ func testCancel(t *testing.T, protocol uint, mode SyncMode) {
 	}
 }
 
-// Tests that synchronisation from multiple peers works as intended (multi thread sanity test).
-func TestMultiSynchronisation66Full(t *testing.T)  { testMultiSynchronisation(t, eth.ETH66, FullSync) }
-func TestMultiSynchronisation66Snap(t *testing.T)  { testMultiSynchronisation(t, eth.ETH66, SnapSync) }
-func TestMultiSynchronisation66Light(t *testing.T) { testMultiSynchronisation(t, eth.ETH66, LightSync) }
-func TestMultiSynchronisation67Full(t *testing.T)  { testMultiSynchronisation(t, eth.ETH67, FullSync) }
-func TestMultiSynchronisation67Snap(t *testing.T)  { testMultiSynchronisation(t, eth.ETH67, SnapSync) }
-func TestMultiSynchronisation67Light(t *testing.T) { testMultiSynchronisation(t, eth.ETH67, LightSync) }
+// Tests that synchronization from multiple peers works as intended (multi thread sanity test).
+func TestMultiSynchronization66Full(t *testing.T)  { testMultiSynchronization(t, eth.ETH66, FullSync) }
+func TestMultiSynchronization66Snap(t *testing.T)  { testMultiSynchronization(t, eth.ETH66, SnapSync) }
+func TestMultiSynchronization66Light(t *testing.T) { testMultiSynchronization(t, eth.ETH66, LightSync) }
+func TestMultiSynchronization67Full(t *testing.T)  { testMultiSynchronization(t, eth.ETH67, FullSync) }
+func TestMultiSynchronization67Snap(t *testing.T)  { testMultiSynchronization(t, eth.ETH67, SnapSync) }
+func TestMultiSynchronization67Light(t *testing.T) { testMultiSynchronization(t, eth.ETH67, LightSync) }
 
-func testMultiSynchronisation(t *testing.T, protocol uint, mode SyncMode) {
+func testMultiSynchronization(t *testing.T, protocol uint, mode SyncMode) {
 	tester := newTester(t)
 	defer tester.terminate()
 
@@ -732,14 +732,14 @@ func testMultiSynchronisation(t *testing.T, protocol uint, mode SyncMode) {
 	assertOwnChain(t, tester, len(chain.blocks))
 }
 
-// Tests that synchronisations behave well in multi-version protocol environments
+// Tests that synchronizations behave well in multi-version protocol environments
 // and not wreak havoc on other nodes in the network.
-func TestMultiProtoSynchronisation66Full(t *testing.T)  { testMultiProtoSync(t, eth.ETH66, FullSync) }
-func TestMultiProtoSynchronisation66Snap(t *testing.T)  { testMultiProtoSync(t, eth.ETH66, SnapSync) }
-func TestMultiProtoSynchronisation66Light(t *testing.T) { testMultiProtoSync(t, eth.ETH66, LightSync) }
-func TestMultiProtoSynchronisation67Full(t *testing.T)  { testMultiProtoSync(t, eth.ETH67, FullSync) }
-func TestMultiProtoSynchronisation67Snap(t *testing.T)  { testMultiProtoSync(t, eth.ETH67, SnapSync) }
-func TestMultiProtoSynchronisation67Light(t *testing.T) { testMultiProtoSync(t, eth.ETH67, LightSync) }
+func TestMultiProtoSynchronization66Full(t *testing.T)  { testMultiProtoSync(t, eth.ETH66, FullSync) }
+func TestMultiProtoSynchronization66Snap(t *testing.T)  { testMultiProtoSync(t, eth.ETH66, SnapSync) }
+func TestMultiProtoSynchronization66Light(t *testing.T) { testMultiProtoSync(t, eth.ETH66, LightSync) }
+func TestMultiProtoSynchronization67Full(t *testing.T)  { testMultiProtoSync(t, eth.ETH67, FullSync) }
+func TestMultiProtoSynchronization67Snap(t *testing.T)  { testMultiProtoSync(t, eth.ETH67, SnapSync) }
+func TestMultiProtoSynchronization67Light(t *testing.T) { testMultiProtoSync(t, eth.ETH67, LightSync) }
 
 func testMultiProtoSync(t *testing.T, protocol uint, mode SyncMode) {
 	tester := newTester(t)
@@ -837,7 +837,7 @@ func testMissingHeaderAttack(t *testing.T, protocol uint, mode SyncMode) {
 	attacker.withholdHeaders[chain.blocks[len(chain.blocks)/2-1].Hash()] = struct{}{}
 
 	if err := tester.sync("attack", nil, mode); err == nil {
-		t.Fatalf("succeeded attacker synchronisation")
+		t.Fatalf("succeeded attacker synchronization")
 	}
 	// Synchronise with the valid peer and make sure sync succeeds
 	tester.newPeer("valid", protocol, chain.blocks[1:])
@@ -867,7 +867,7 @@ func testShiftedHeaderAttack(t *testing.T, protocol uint, mode SyncMode) {
 	attacker.withholdHeaders[chain.blocks[1].Hash()] = struct{}{}
 
 	if err := tester.sync("attack", nil, mode); err == nil {
-		t.Fatalf("succeeded attacker synchronisation")
+		t.Fatalf("succeeded attacker synchronization")
 	}
 	// Synchronise with the valid peer and make sure sync succeeds
 	tester.newPeer("valid", protocol, chain.blocks[1:])
@@ -899,7 +899,7 @@ func testInvalidHeaderRollback(t *testing.T, protocol uint, mode SyncMode) {
 	fastAttacker.withholdHeaders[chain.blocks[missing].Hash()] = struct{}{}
 
 	if err := tester.sync("fast-attack", nil, mode); err == nil {
-		t.Fatalf("succeeded fast attacker synchronisation")
+		t.Fatalf("succeeded fast attacker synchronization")
 	}
 	if head := tester.chain.CurrentHeader().Number.Int64(); int(head) > MaxHeaderFetch {
 		t.Errorf("rollback head mismatch: have %v, want at most %v", head, MaxHeaderFetch)
@@ -914,7 +914,7 @@ func testInvalidHeaderRollback(t *testing.T, protocol uint, mode SyncMode) {
 	blockAttacker.withholdHeaders[chain.blocks[missing].Hash()] = struct{}{}
 
 	if err := tester.sync("block-attack", nil, mode); err == nil {
-		t.Fatalf("succeeded block attacker synchronisation")
+		t.Fatalf("succeeded block attacker synchronization")
 	}
 	if head := tester.chain.CurrentHeader().Number.Int64(); int(head) > 2*fsHeaderSafetyNet+MaxHeaderFetch {
 		t.Errorf("rollback head mismatch: have %v, want at most %v", head, 2*fsHeaderSafetyNet+MaxHeaderFetch)
@@ -936,7 +936,7 @@ func testInvalidHeaderRollback(t *testing.T, protocol uint, mode SyncMode) {
 		tester.downloader.syncInitHook = nil
 	}
 	if err := tester.sync("withhold-attack", nil, mode); err == nil {
-		t.Fatalf("succeeded withholding attacker synchronisation")
+		t.Fatalf("succeeded withholding attacker synchronization")
 	}
 	if head := tester.chain.CurrentHeader().Number.Int64(); int(head) > 2*fsHeaderSafetyNet+MaxHeaderFetch {
 		t.Errorf("rollback head mismatch: have %v, want at most %v", head, 2*fsHeaderSafetyNet+MaxHeaderFetch)
@@ -985,7 +985,7 @@ func testHighTDStarvationAttack(t *testing.T, protocol uint, mode SyncMode) {
 	chain := testChainBase.shorten(1)
 	tester.newPeer("attack", protocol, chain.blocks[1:])
 	if err := tester.sync("attack", big.NewInt(1000000), mode); err != errStallingPeer {
-		t.Fatalf("synchronisation error mismatch: have %v, want %v", err, errStallingPeer)
+		t.Fatalf("synchronization error mismatch: have %v, want %v", err, errStallingPeer)
 	}
 }
 
@@ -1013,7 +1013,7 @@ func testBlockHeaderAttackerDropping(t *testing.T, protocol uint) {
 		{errInvalidChain, true},             // Hash chain was detected as invalid, definitely drop
 		{errInvalidBody, false},             // A bad peer was detected, but not the sync origin
 		{errInvalidReceipt, false},          // A bad peer was detected, but not the sync origin
-		{errCancelContentProcessing, false}, // Synchronisation was canceled, origin may be innocent, don't drop
+		{errCancelContentProcessing, false}, // Synchronization was canceled, origin may be innocent, don't drop
 	}
 	// Run the tests and check disconnection status
 	tester := newTester(t)
@@ -1027,7 +1027,7 @@ func testBlockHeaderAttackerDropping(t *testing.T, protocol uint) {
 		if _, ok := tester.peers[id]; !ok {
 			t.Fatalf("test %d: registered peer not found", i)
 		}
-		// Simulate a synchronisation and check the required result
+		// Simulate a synchronization and check the required result
 		tester.downloader.synchroniseMock = func(string, common.Hash) error { return tt.result }
 
 		tester.downloader.LegacySync(id, tester.chain.Genesis().Hash(), big.NewInt(1000), nil, FullSync)
@@ -1037,7 +1037,7 @@ func testBlockHeaderAttackerDropping(t *testing.T, protocol uint) {
 	}
 }
 
-// Tests that synchronisation progress (origin block number, current block number
+// Tests that synchronization progress (origin block number, current block number
 // and highest block number) is tracked and updated correctly.
 func TestSyncProgress66Full(t *testing.T)  { testSyncProgress(t, eth.ETH66, FullSync) }
 func TestSyncProgress66Snap(t *testing.T)  { testSyncProgress(t, eth.ETH66, SnapSync) }
@@ -1116,7 +1116,7 @@ func checkProgress(t *testing.T, d *Downloader, stage string, want ethereum.Sync
 	}
 }
 
-// Tests that synchronisation progress (origin block number and highest block
+// Tests that synchronization progress (origin block number and highest block
 // number) is tracked and updated correctly in case of a fork (or manual head
 // revertal).
 func TestForkedSyncProgress66Full(t *testing.T)  { testForkedSyncProgress(t, eth.ETH66, FullSync) }
@@ -1190,7 +1190,7 @@ func testForkedSyncProgress(t *testing.T, protocol uint, mode SyncMode) {
 	})
 }
 
-// Tests that if synchronisation is aborted due to some failure, then the progress
+// Tests that if synchronization is aborted due to some failure, then the progress
 // origin is not updated in the next sync cycle, as it should be considered the
 // continuation of the previous sync and not a new instance.
 func TestFailedSyncProgress66Full(t *testing.T)  { testFailedSyncProgress(t, eth.ETH66, FullSync) }
@@ -1227,7 +1227,7 @@ func testFailedSyncProgress(t *testing.T, protocol uint, mode SyncMode) {
 	go func() {
 		defer pending.Done()
 		if err := tester.sync("faulty", nil, mode); err == nil {
-			panic("succeeded faulty synchronisation")
+			panic("succeeded faulty synchronization")
 		}
 	}()
 	<-starting
@@ -1295,7 +1295,7 @@ func testFakedSyncProgress(t *testing.T, protocol uint, mode SyncMode) {
 	go func() {
 		defer pending.Done()
 		if err := tester.sync("attack", nil, mode); err == nil {
-			panic("succeeded attacker synchronisation")
+			panic("succeeded attacker synchronization")
 		}
 	}()
 	<-starting

--- a/eth/downloader/modes.go
+++ b/eth/downloader/modes.go
@@ -18,7 +18,7 @@ package downloader
 
 import "fmt"
 
-// SyncMode represents the synchronisation mode of the downloader.
+// SyncMode represents the synchronization mode of the downloader.
 // It is a uint32 as it is used with atomic operations.
 type SyncMode uint32
 

--- a/eth/downloader/queue.go
+++ b/eth/downloader/queue.go
@@ -109,7 +109,7 @@ func (f *fetchResult) Done(kind uint) bool {
 
 // queue represents hashes that are either need fetching or are being fetched
 type queue struct {
-	mode SyncMode // Synchronisation mode to decide on the block parts to schedule for fetching
+	mode SyncMode // Synchronization mode to decide on the block parts to schedule for fetching
 
 	// Headers are "special", they download in batches, supported by a skeleton chain
 	headerHead      common.Hash                    // Hash of the last queued header to verify order

--- a/eth/downloader/statesync.go
+++ b/eth/downloader/statesync.go
@@ -55,7 +55,7 @@ func (d *Downloader) stateFetcher() {
 	}
 }
 
-// runStateSync runs a state synchronisation until it completes or another root
+// runStateSync runs a state synchronization until it completes or another root
 // hash is requested to be switched over to.
 func (d *Downloader) runStateSync(s *stateSync) *stateSync {
 	log.Trace("State sync starting", "root", s.root)

--- a/eth/fetcher/block_fetcher.go
+++ b/eth/fetcher/block_fetcher.go
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
 
-// Package fetcher contains the announcement based header, blocks or transaction synchronisation.
+// Package fetcher contains the announcement based header, blocks or transaction synchronization.
 package fetcher
 
 import (
@@ -574,7 +574,7 @@ func (f *BlockFetcher) loop() {
 			for _, header := range task.headers {
 				hash := header.Hash()
 
-				// Filter fetcher-requested headers from other synchronisation algorithms
+				// Filter fetcher-requested headers from other synchronization algorithms
 				if announce := f.fetching[hash]; announce != nil && announce.origin == task.peer && f.fetched[hash] == nil && f.completing[hash] == nil && f.queued[hash] == nil {
 					// If the delivered header does not match the promised number, drop the announcer
 					if header.Number.Uint64() != announce.number {

--- a/eth/sync_test.go
+++ b/eth/sync_test.go
@@ -92,6 +92,6 @@ func testSnapSyncDisabling(t *testing.T, ethVer uint, snapVer uint) {
 		t.Fatal("sync failed:", err)
 	}
 	if atomic.LoadUint32(&empty.handler.snapSync) == 1 {
-		t.Fatalf("snap sync not disabled after successful synchronisation")
+		t.Fatalf("snap sync not disabled after successful synchronization")
 	}
 }

--- a/graphql/graphql.go
+++ b/graphql/graphql.go
@@ -1340,7 +1340,7 @@ func (r *Resolver) ChainID(ctx context.Context) (hexutil.Big, error) {
 	return hexutil.Big(*r.backend.ChainConfig().ChainID), nil
 }
 
-// SyncState represents the synchronisation status returned from the `syncing` accessor.
+// SyncState represents the synchronization status returned from the `syncing` accessor.
 type SyncState struct {
 	progress ethereum.SyncProgress
 }
@@ -1411,7 +1411,7 @@ func (s *SyncState) HealingBytecode() hexutil.Uint64 {
 func (r *Resolver) Syncing() (*SyncState, error) {
 	progress := r.backend.SyncProgress()
 
-	// Return not syncing if the synchronisation already completed
+	// Return not syncing if the synchronization already completed
 	if progress.CurrentBlock >= progress.HighestBlock {
 		return nil, nil
 	}

--- a/graphql/schema.go
+++ b/graphql/schema.go
@@ -304,11 +304,11 @@ const schema string = `
         topics: [[Bytes32!]!]
     }
 
-    # SyncState contains the current synchronisation state of the client.
+    # SyncState contains the current synchronization state of the client.
     type SyncState{
-        # StartingBlock is the block number at which synchronisation started.
+        # StartingBlock is the block number at which synchronization started.
         startingBlock: Long!
-        # CurrentBlock is the point at which synchronisation has presently reached.
+        # CurrentBlock is the point at which synchronization has presently reached.
         currentBlock: Long!
         # HighestBlock is the latest known block number.
         highestBlock: Long!
@@ -348,7 +348,7 @@ const schema string = `
         # MaxPriorityFeePerGas returns the node's estimate of a gas tip sufficient
         # to ensure a transaction is mined in a timely fashion.
         maxPriorityFeePerGas: BigInt!
-        # Syncing returns information on the current synchronisation state.
+        # Syncing returns information on the current synchronization state.
         syncing: SyncState
         # ChainID returns the current chain ID for transaction replay protection.
         chainID: BigInt!

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -125,7 +125,7 @@ func (s *EthereumAPI) FeeHistory(ctx context.Context, blockCount rpc.DecimalOrHe
 func (s *EthereumAPI) Syncing() (interface{}, error) {
 	progress := s.b.SyncProgress()
 
-	// Return not syncing if the synchronisation already completed
+	// Return not syncing if the synchronization already completed
 	if progress.CurrentBlock >= progress.HighestBlock {
 		return false, nil
 	}

--- a/les/downloader/api.go
+++ b/les/downloader/api.go
@@ -25,7 +25,7 @@ import (
 	"github.com/ethereum/go-ethereum/rpc"
 )
 
-// DownloaderAPI provides an API which gives information about the current synchronisation status.
+// DownloaderAPI provides an API which gives information about the current synchronization status.
 // It offers only methods that operates on data that can be available to anyone without security risks.
 type DownloaderAPI struct {
 	d                         *Downloader
@@ -119,7 +119,7 @@ func (api *DownloaderAPI) Syncing(ctx context.Context) (*rpc.Subscription, error
 	return rpcSub, nil
 }
 
-// SyncingResult provides information about the current synchronisation status for this node.
+// SyncingResult provides information about the current synchronization status for this node.
 type SyncingResult struct {
 	Syncing bool                  `json:"syncing"`
 	Status  ethereum.SyncProgress `json:"status"`
@@ -158,7 +158,7 @@ func (s *SyncStatusSubscription) Unsubscribe() {
 	})
 }
 
-// SubscribeSyncStatus creates a subscription that will broadcast new synchronisation updates.
+// SubscribeSyncStatus creates a subscription that will broadcast new synchronization updates.
 // The given channel must receive interface values, the result can either
 func (api *DownloaderAPI) SubscribeSyncStatus(status chan interface{}) *SyncStatusSubscription {
 	api.installSyncSubscription <- status

--- a/les/downloader/downloader.go
+++ b/les/downloader/downloader.go
@@ -88,7 +88,7 @@ var (
 )
 
 type Downloader struct {
-	mode uint32         // Synchronisation mode defining the strategy used (per sync cycle), use d.getMode() to get the SyncMode
+	mode uint32         // Synchronization mode defining the strategy used (per sync cycle), use d.getMode() to get the SyncMode
 	mux  *event.TypeMux // Event multiplexer to announce sync operation events
 
 	checkpoint uint64   // Checkpoint block number to enforce head against (e.g. fast sync)
@@ -237,11 +237,11 @@ func New(checkpoint uint64, stateDb ethdb.Database, mux *event.TypeMux, chain Bl
 	return dl
 }
 
-// Progress retrieves the synchronisation boundaries, specifically the origin
-// block where synchronisation started at (may have failed/suspended); the block
+// Progress retrieves the synchronization boundaries, specifically the origin
+// block where synchronization started at (may have failed/suspended); the block
 // or header sync is currently at; and the latest known block which the sync targets.
 //
-// In addition, during the state download phase of fast synchronisation the number
+// In addition, during the state download phase of fast synchronization the number
 // of processed and the total number of known states are also returned. Otherwise
 // these are zero.
 func (d *Downloader) Progress() ethereum.SyncProgress {
@@ -332,7 +332,7 @@ func (d *Downloader) Synchronise(id string, head common.Hash, td *big.Int, mode 
 	if errors.Is(err, errInvalidChain) || errors.Is(err, errBadPeer) || errors.Is(err, errTimeout) ||
 		errors.Is(err, errStallingPeer) || errors.Is(err, errUnsyncedPeer) || errors.Is(err, errEmptyHeaderSet) ||
 		errors.Is(err, errPeersUnavailable) || errors.Is(err, errTooOld) || errors.Is(err, errInvalidAncestor) {
-		log.Warn("Synchronisation failed, dropping peer", "peer", id, "err", err)
+		log.Warn("Synchronization failed, dropping peer", "peer", id, "err", err)
 		if d.dropPeer == nil {
 			// The dropPeer method is nil when `--copydb` is used for a local copy.
 			// Timeouts can occur if e.g. compaction hits at the wrong time, and can be ignored
@@ -342,7 +342,7 @@ func (d *Downloader) Synchronise(id string, head common.Hash, td *big.Int, mode 
 		}
 		return err
 	}
-	log.Warn("Synchronisation failed, retrying", "err", err)
+	log.Warn("Synchronization failed, retrying", "err", err)
 	return err
 }
 
@@ -350,7 +350,7 @@ func (d *Downloader) Synchronise(id string, head common.Hash, td *big.Int, mode 
 // it will use the best peer possible and synchronize if its TD is higher than our own. If any of the
 // checks fail an error will be returned. This method is synchronous
 func (d *Downloader) synchronise(id string, hash common.Hash, td *big.Int, mode SyncMode) error {
-	// Mock out the synchronisation if testing
+	// Mock out the synchronization if testing
 	if d.synchroniseMock != nil {
 		return d.synchroniseMock(id, hash)
 	}
@@ -362,7 +362,7 @@ func (d *Downloader) synchronise(id string, hash common.Hash, td *big.Int, mode 
 
 	// Post a user notification of the sync (only once per session)
 	if atomic.CompareAndSwapInt32(&d.notified, 0, 1) {
-		log.Info("Block synchronisation started")
+		log.Info("Block synchronization started")
 	}
 	// If snap sync was requested, create the snap scheduler and switch to fast
 	// sync mode. Long term we could drop fast sync or merge the two together,
@@ -449,7 +449,7 @@ func (d *Downloader) syncWithPeer(p *peerConnection, hash common.Hash, td *big.I
 
 	log.Debug("Synchronising with the network", "peer", p.id, "eth", p.version, "head", hash, "td", td, "mode", mode)
 	defer func(start time.Time) {
-		log.Debug("Synchronisation terminated", "elapsed", common.PrettyDuration(time.Since(start)))
+		log.Debug("Synchronization terminated", "elapsed", common.PrettyDuration(time.Since(start)))
 	}(time.Now())
 
 	// Look up the sync boundaries: the common ancestor and the target block
@@ -1728,7 +1728,7 @@ func (d *Downloader) importBlockResults(results []*fetchResult) error {
 }
 
 // processFastSyncContent takes fetch results from the queue and writes them to the
-// database. It also controls the synchronisation of state nodes of the pivot block.
+// database. It also controls the synchronization of state nodes of the pivot block.
 func (d *Downloader) processFastSyncContent() error {
 	// Start syncing state of the reported head block. This should get us most of
 	// the state of the pivot block.

--- a/les/downloader/downloader_test.go
+++ b/les/downloader/downloader_test.go
@@ -522,9 +522,9 @@ func assertOwnForkedChain(t *testing.T, tester *downloadTester, common int, leng
 	}
 }
 
-func TestCanonicalSynchronisation66Full(t *testing.T)  { testCanonSync(t, eth.ETH66, FullSync) }
-func TestCanonicalSynchronisation66Fast(t *testing.T)  { testCanonSync(t, eth.ETH66, FastSync) }
-func TestCanonicalSynchronisation66Light(t *testing.T) { testCanonSync(t, eth.ETH66, LightSync) }
+func TestCanonicalSynchronization66Full(t *testing.T)  { testCanonSync(t, eth.ETH66, FullSync) }
+func TestCanonicalSynchronization66Fast(t *testing.T)  { testCanonSync(t, eth.ETH66, FastSync) }
+func TestCanonicalSynchronization66Light(t *testing.T) { testCanonSync(t, eth.ETH66, LightSync) }
 
 func testCanonSync(t *testing.T, protocol uint, mode SyncMode) {
 	t.Parallel()
@@ -562,7 +562,7 @@ func testThrottling(t *testing.T, protocol uint, mode SyncMode) {
 		atomic.StoreUint32(&blocked, uint32(len(results)))
 		<-proceed
 	}
-	// Start a synchronisation concurrently
+	// Start a synchronization concurrently
 	errc := make(chan error, 1)
 	go func() {
 		errc <- tester.sync("peer", nil, mode)
@@ -798,12 +798,12 @@ func testCancel(t *testing.T, protocol uint, mode SyncMode) {
 	}
 }
 
-// Tests that synchronisation from multiple peers works as intended (multi thread sanity test).
-func TestMultiSynchronisation66Full(t *testing.T)  { testMultiSynchronisation(t, eth.ETH66, FullSync) }
-func TestMultiSynchronisation66Fast(t *testing.T)  { testMultiSynchronisation(t, eth.ETH66, FastSync) }
-func TestMultiSynchronisation66Light(t *testing.T) { testMultiSynchronisation(t, eth.ETH66, LightSync) }
+// Tests that synchronization from multiple peers works as intended (multi thread sanity test).
+func TestMultiSynchronization66Full(t *testing.T)  { testMultiSynchronization(t, eth.ETH66, FullSync) }
+func TestMultiSynchronization66Fast(t *testing.T)  { testMultiSynchronization(t, eth.ETH66, FastSync) }
+func TestMultiSynchronization66Light(t *testing.T) { testMultiSynchronization(t, eth.ETH66, LightSync) }
 
-func testMultiSynchronisation(t *testing.T, protocol uint, mode SyncMode) {
+func testMultiSynchronization(t *testing.T, protocol uint, mode SyncMode) {
 	t.Parallel()
 
 	tester := newTester()
@@ -823,11 +823,11 @@ func testMultiSynchronisation(t *testing.T, protocol uint, mode SyncMode) {
 	assertOwnChain(t, tester, chain.len())
 }
 
-// Tests that synchronisations behave well in multi-version protocol environments
+// Tests that synchronizations behave well in multi-version protocol environments
 // and not wreak havoc on other nodes in the network.
-func TestMultiProtoSynchronisation66Full(t *testing.T)  { testMultiProtoSync(t, eth.ETH66, FullSync) }
-func TestMultiProtoSynchronisation66Fast(t *testing.T)  { testMultiProtoSync(t, eth.ETH66, FastSync) }
-func TestMultiProtoSynchronisation66Light(t *testing.T) { testMultiProtoSync(t, eth.ETH66, LightSync) }
+func TestMultiProtoSynchronization66Full(t *testing.T)  { testMultiProtoSync(t, eth.ETH66, FullSync) }
+func TestMultiProtoSynchronization66Fast(t *testing.T)  { testMultiProtoSync(t, eth.ETH66, FastSync) }
+func TestMultiProtoSynchronization66Light(t *testing.T) { testMultiProtoSync(t, eth.ETH66, LightSync) }
 
 func testMultiProtoSync(t *testing.T, protocol uint, mode SyncMode) {
 	t.Parallel()
@@ -925,7 +925,7 @@ func testMissingHeaderAttack(t *testing.T, protocol uint, mode SyncMode) {
 	tester.newPeer("attack", protocol, brokenChain)
 
 	if err := tester.sync("attack", nil, mode); err == nil {
-		t.Fatalf("succeeded attacker synchronisation")
+		t.Fatalf("succeeded attacker synchronization")
 	}
 	// Synchronise with the valid peer and make sure sync succeeds
 	tester.newPeer("valid", protocol, chain)
@@ -956,7 +956,7 @@ func testShiftedHeaderAttack(t *testing.T, protocol uint, mode SyncMode) {
 	delete(brokenChain.receiptm, brokenChain.chain[1])
 	tester.newPeer("attack", protocol, brokenChain)
 	if err := tester.sync("attack", nil, mode); err == nil {
-		t.Fatalf("succeeded attacker synchronisation")
+		t.Fatalf("succeeded attacker synchronization")
 	}
 
 	// Synchronise with the valid peer and make sure sync succeeds
@@ -989,7 +989,7 @@ func testInvalidHeaderRollback(t *testing.T, protocol uint, mode SyncMode) {
 	tester.newPeer("fast-attack", protocol, fastAttackChain)
 
 	if err := tester.sync("fast-attack", nil, mode); err == nil {
-		t.Fatalf("succeeded fast attacker synchronisation")
+		t.Fatalf("succeeded fast attacker synchronization")
 	}
 	if head := tester.CurrentHeader().Number.Int64(); int(head) > MaxHeaderFetch {
 		t.Errorf("rollback head mismatch: have %v, want at most %v", head, MaxHeaderFetch)
@@ -1005,7 +1005,7 @@ func testInvalidHeaderRollback(t *testing.T, protocol uint, mode SyncMode) {
 	tester.newPeer("block-attack", protocol, blockAttackChain)
 
 	if err := tester.sync("block-attack", nil, mode); err == nil {
-		t.Fatalf("succeeded block attacker synchronisation")
+		t.Fatalf("succeeded block attacker synchronization")
 	}
 	if head := tester.CurrentHeader().Number.Int64(); int(head) > 2*fsHeaderSafetyNet+MaxHeaderFetch {
 		t.Errorf("rollback head mismatch: have %v, want at most %v", head, 2*fsHeaderSafetyNet+MaxHeaderFetch)
@@ -1028,7 +1028,7 @@ func testInvalidHeaderRollback(t *testing.T, protocol uint, mode SyncMode) {
 		tester.downloader.syncInitHook = nil
 	}
 	if err := tester.sync("withhold-attack", nil, mode); err == nil {
-		t.Fatalf("succeeded withholding attacker synchronisation")
+		t.Fatalf("succeeded withholding attacker synchronization")
 	}
 	if head := tester.CurrentHeader().Number.Int64(); int(head) > 2*fsHeaderSafetyNet+MaxHeaderFetch {
 		t.Errorf("rollback head mismatch: have %v, want at most %v", head, 2*fsHeaderSafetyNet+MaxHeaderFetch)
@@ -1078,7 +1078,7 @@ func testHighTDStarvationAttack(t *testing.T, protocol uint, mode SyncMode) {
 	chain := testChainBase.shorten(1)
 	tester.newPeer("attack", protocol, chain)
 	if err := tester.sync("attack", big.NewInt(1000000), mode); err != errStallingPeer {
-		t.Fatalf("synchronisation error mismatch: have %v, want %v", err, errStallingPeer)
+		t.Fatalf("synchronization error mismatch: have %v, want %v", err, errStallingPeer)
 	}
 	tester.terminate()
 }
@@ -1108,7 +1108,7 @@ func testBlockHeaderAttackerDropping(t *testing.T, protocol uint) {
 		{errInvalidChain, true},             // Hash chain was detected as invalid, definitely drop
 		{errInvalidBody, false},             // A bad peer was detected, but not the sync origin
 		{errInvalidReceipt, false},          // A bad peer was detected, but not the sync origin
-		{errCancelContentProcessing, false}, // Synchronisation was canceled, origin may be innocent, don't drop
+		{errCancelContentProcessing, false}, // Synchronization was canceled, origin may be innocent, don't drop
 	}
 	// Run the tests and check disconnection status
 	tester := newTester()
@@ -1124,7 +1124,7 @@ func testBlockHeaderAttackerDropping(t *testing.T, protocol uint) {
 		if _, ok := tester.peers[id]; !ok {
 			t.Fatalf("test %d: registered peer not found", i)
 		}
-		// Simulate a synchronisation and check the required result
+		// Simulate a synchronization and check the required result
 		tester.downloader.synchroniseMock = func(string, common.Hash) error { return tt.result }
 
 		tester.downloader.Synchronise(id, tester.genesis.Hash(), big.NewInt(1000), FullSync)
@@ -1134,7 +1134,7 @@ func testBlockHeaderAttackerDropping(t *testing.T, protocol uint) {
 	}
 }
 
-// Tests that synchronisation progress (origin block number, current block number
+// Tests that synchronization progress (origin block number, current block number
 // and highest block number) is tracked and updated correctly.
 func TestSyncProgress66Full(t *testing.T)  { testSyncProgress(t, eth.ETH66, FullSync) }
 func TestSyncProgress66Fast(t *testing.T)  { testSyncProgress(t, eth.ETH66, FastSync) }
@@ -1213,7 +1213,7 @@ func checkProgress(t *testing.T, d *Downloader, stage string, want ethereum.Sync
 	}
 }
 
-// Tests that synchronisation progress (origin block number and highest block
+// Tests that synchronization progress (origin block number and highest block
 // number) is tracked and updated correctly in case of a fork (or manual head
 // revertal).
 func TestForkedSyncProgress66Full(t *testing.T)  { testForkedSyncProgress(t, eth.ETH66, FullSync) }
@@ -1285,7 +1285,7 @@ func testForkedSyncProgress(t *testing.T, protocol uint, mode SyncMode) {
 	})
 }
 
-// Tests that if synchronisation is aborted due to some failure, then the progress
+// Tests that if synchronization is aborted due to some failure, then the progress
 // origin is not updated in the next sync cycle, as it should be considered the
 // continuation of the previous sync and not a new instance.
 func TestFailedSyncProgress66Full(t *testing.T)  { testFailedSyncProgress(t, eth.ETH66, FullSync) }
@@ -1322,7 +1322,7 @@ func testFailedSyncProgress(t *testing.T, protocol uint, mode SyncMode) {
 	go func() {
 		defer pending.Done()
 		if err := tester.sync("faulty", nil, mode); err == nil {
-			panic("succeeded faulty synchronisation")
+			panic("succeeded faulty synchronization")
 		}
 	}()
 	<-starting
@@ -1390,7 +1390,7 @@ func testFakedSyncProgress(t *testing.T, protocol uint, mode SyncMode) {
 	go func() {
 		defer pending.Done()
 		if err := tester.sync("attack", nil, mode); err == nil {
-			panic("succeeded attacker synchronisation")
+			panic("succeeded attacker synchronization")
 		}
 	}()
 	<-starting

--- a/les/downloader/modes.go
+++ b/les/downloader/modes.go
@@ -18,7 +18,7 @@ package downloader
 
 import "fmt"
 
-// SyncMode represents the synchronisation mode of the downloader.
+// SyncMode represents the synchronization mode of the downloader.
 // It is a uint32 as it is used with atomic operations.
 type SyncMode uint32
 

--- a/les/downloader/queue.go
+++ b/les/downloader/queue.go
@@ -110,7 +110,7 @@ func (f *fetchResult) Done(kind uint) bool {
 
 // queue represents hashes that are either need fetching or are being fetched
 type queue struct {
-	mode SyncMode // Synchronisation mode to decide on the block parts to schedule for fetching
+	mode SyncMode // Synchronization mode to decide on the block parts to schedule for fetching
 
 	// Headers are "special", they download in batches, supported by a skeleton chain
 	headerHead      common.Hash                    // Hash of the last queued header to verify order

--- a/les/downloader/statesync.go
+++ b/les/downloader/statesync.go
@@ -92,7 +92,7 @@ func (d *Downloader) stateFetcher() {
 	}
 }
 
-// runStateSync runs a state synchronisation until it completes or another root
+// runStateSync runs a state synchronization until it completes or another root
 // hash is requested to be switched over to.
 func (d *Downloader) runStateSync(s *stateSync) *stateSync {
 	var (

--- a/les/fetcher.go
+++ b/les/fetcher.go
@@ -527,7 +527,7 @@ func (f *lightFetcher) requestHeaderByHash(peerid enode.ID) func(common.Hash) er
 	}
 }
 
-// startSync invokes synchronisation callback to start syncing.
+// startSync invokes synchronization callback to start syncing.
 func (f *lightFetcher) startSync(id enode.ID) {
 	defer func(header *types.Header) {
 		f.syncDone <- header

--- a/les/fetcher/block_fetcher.go
+++ b/les/fetcher/block_fetcher.go
@@ -523,7 +523,7 @@ func (f *BlockFetcher) loop() {
 			for _, header := range task.headers {
 				hash := header.Hash()
 
-				// Filter fetcher-requested headers from other synchronisation algorithms
+				// Filter fetcher-requested headers from other synchronization algorithms
 				if announce := f.fetching[hash]; announce != nil && announce.origin == task.peer && f.fetched[hash] == nil && f.completing[hash] == nil && f.queued[hash] == nil {
 					// If the delivered header does not match the promised number, drop the announcer
 					if header.Number.Uint64() != announce.number {

--- a/p2p/discover/ntp.go
+++ b/p2p/discover/ntp.go
@@ -50,7 +50,7 @@ func checkClockDrift() {
 	}
 	if drift < -driftThreshold || drift > driftThreshold {
 		log.Warn(fmt.Sprintf("System clock seems off by %v, which can prevent network connectivity", drift))
-		log.Warn("Please enable network time synchronisation in system settings.")
+		log.Warn("Please enable network time synchronization in system settings.")
 	} else {
 		log.Debug("NTP sanity check done", "drift", drift)
 	}

--- a/trie/sync.go
+++ b/trie/sync.go
@@ -134,7 +134,7 @@ func (batch *syncMemBatch) hasCode(hash common.Hash) bool {
 	return ok
 }
 
-// Sync is the main state trie synchronisation scheduler, which provides yet
+// Sync is the main state trie synchronization scheduler, which provides yet
 // unknown trie hashes to retrieve, accepts node data associated with said hashes
 // and reconstructs the trie step by step until all is done.
 type Sync struct {


### PR DESCRIPTION
# Description
In this MR I have fixed all the typo issues with synchronization

Notable changes:

- synchronisation replaced with synchronization