### PR TITLE
core: move build version reading to its own package

### DIFF
--- a/internal/version/vcs_fallback.go
+++ b/internal/version/vcs_fallback.go
@@ -1,0 +1,28 @@
+// Copyright 2022 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+//go:build !go1.18
+// +build !go1.18
+
+package version
+
+import "runtime/debug"
+
+// In Go versions before 1.18, VCS information is not available.
+
+func vcsInfo(info *debug.BuildInfo) (gitStatus, bool) {
+	return gitStatus{}, false
+}

--- a/internal/version/vcs_go1.18.go
+++ b/internal/version/vcs_go1.18.go
@@ -1,0 +1,48 @@
+// Copyright 2022 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+//go:build go1.18
+// +build go1.18
+
+package version
+
+import "runtime/debug"
+
+// In go 1.18 and beyond, the go tool embeds VCS information into the build.
+
+// vcsInfo returns VCS information of the build.
+func vcsInfo(info *debug.BuildInfo) (s gitStatus, ok bool) {
+	for _, v := range info.Settings {
+		switch v.Key {
+		case "vcs.revision":
+			if len(v.Value) < 8 {
+				s.revision = v.Value
+			} else {
+				s.revision = v.Value[:8]
+			}
+		case "vcs.modified":
+			if v.Value == "true" {
+				s.modified = true
+			}
+		case "vcs.time":
+			s.time = v.Value
+		}
+	}
+	if s.revision != "" && s.time != "" {
+		ok = true
+	}
+	return
+}


### PR DESCRIPTION
This fixes the build with Go 1.17, which does not have BuildInfo.Settings yet.