### PR TITLE
eth/traces: add state limit

### DIFF
--- a/eth/tracers/api.go
+++ b/eth/tracers/api.go
@@ -61,6 +61,11 @@ const (
 	// For non-archive nodes, this limit _will_ be overblown, as disk-backed tries
 	// will only be found every ~15K blocks or so.
 	defaultTracechainMemLimit = common.StorageSize(500 * 1024 * 1024)
+
+	// maximumPendingTraceStates is the maximum number of states allowed waiting
+	// for tracing. The creation of trace state will be paused if the unused
+	// trace states exceed this limit.
+	maximumPendingTraceStates = 128
 )
 
 // StateReleaseFunc is used to deallocate resources held by constructing a
@@ -251,30 +256,6 @@ func (api *API) TraceChain(ctx context.Context, start, end rpc.BlockNumber, conf
 	return sub, nil
 }
 
-// releaser is a helper tool responsible for caching the release
-// callbacks of tracing state.
-type releaser struct {
-	releases []StateReleaseFunc
-	lock     sync.Mutex
-}
-
-func (r *releaser) add(release StateReleaseFunc) {
-	r.lock.Lock()
-	defer r.lock.Unlock()
-
-	r.releases = append(r.releases, release)
-}
-
-func (r *releaser) call() {
-	r.lock.Lock()
-	defer r.lock.Unlock()
-
-	for _, release := range r.releases {
-		release()
-	}
-	r.releases = r.releases[:0]
-}
-
 // traceChain configures a new tracer according to the provided configuration, and
 // executes all the transactions contained within. The tracing chain range includes
 // the end block but excludes the start one. The return value will be one item per
@@ -291,11 +272,11 @@ func (api *API) traceChain(start, end *types.Block, config *TraceConfig, closed 
 		threads = blocks
 	}
 	var (
-		pend   = new(sync.WaitGroup)
-		ctx    = context.Background()
-		taskCh = make(chan *blockTraceTask, threads)
-		resCh  = make(chan *blockTraceTask, threads)
-		reler  = new(releaser)
+		pend    = new(sync.WaitGroup)
+		ctx     = context.Background()
+		taskCh  = make(chan *blockTraceTask, threads)
+		resCh   = make(chan *blockTraceTask, threads)
+		tracker = newStateTracker(maximumPendingTraceStates, start.NumberU64())
 	)
 	for th := 0; th < threads; th++ {
 		pend.Add(1)
@@ -326,8 +307,10 @@ func (api *API) traceChain(start, end *types.Block, config *TraceConfig, closed 
 					task.statedb.Finalise(api.backend.ChainConfig().IsEIP158(task.block.Number()))
 					task.results[i] = &txTraceResult{Result: res}
 				}
-				// Tracing state is used up, queue it for de-referencing
-				reler.add(task.release)
+				// Tracing state is used up, queue it for de-referencing. Note the
+				// state is the parent state of trace block, use block.number-1 as
+				// the state number.
+				tracker.releaseState(task.block.NumberU64()-1, task.release)
 
 				// Stream the result back to the result catcher or abort on teardown
 				select {
@@ -354,8 +337,8 @@ func (api *API) traceChain(start, end *types.Block, config *TraceConfig, closed 
 			close(taskCh)
 			pend.Wait()
 
-			// Clean out any pending derefs.
-			reler.call()
+			// Clean out any pending release functions of trace states.
+			tracker.callReleases()
 
 			// Log the chain result
 			switch {
@@ -392,6 +375,13 @@ func (api *API) traceChain(start, end *types.Block, config *TraceConfig, closed 
 				failed = err
 				break
 			}
+			// Make sure the state creator doesn't go too far. Too many unprocessed
+			// trace state may cause the oldest state to become stale(e.g. in
+			// path-based scheme).
+			if err = tracker.wait(number); err != nil {
+				failed = err
+				break
+			}
 			// Prepare the statedb for tracing. Don't use the live database for
 			// tracing to avoid persisting state junks into the database. Switch
 			// over to `preferDisk` mode only if the memory usage exceeds the
@@ -407,18 +397,18 @@ func (api *API) traceChain(start, end *types.Block, config *TraceConfig, closed 
 				failed = err
 				break
 			}
-			// Clean out any pending derefs. Note this step must be done after
-			// constructing tracing state, because the tracing state of block
-			// next depends on the parent state and construction may fail if
-			// we release too early.
-			reler.call()
+			// Clean out any pending release functions of trace state. Note this
+			// step must be done after constructing tracing state, because the
+			// tracing state of block next depends on the parent state and construction
+			// may fail if we release too early.
+			tracker.callReleases()
 
 			// Send the block over to the concurrent tracers (if not in the fast-forward phase)
 			txs := next.Transactions()
 			select {
 			case taskCh <- &blockTraceTask{statedb: statedb.Copy(), block: next, release: release, results: make([]*txTraceResult, len(txs))}:
 			case <-closed:
-				reler.add(release)
+				tracker.releaseState(number, release)
 				return
 			}
 			traced += uint64(len(txs))

--- a/eth/tracers/tracker.go
+++ b/eth/tracers/tracker.go
@@ -1,0 +1,93 @@
+// Copyright 2022 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+package tracers
+
+import (
+	"fmt"
+	"sync"
+	"time"
+)
+
+// stateTracker is an auxiliary tool used to cache the release functions of all
+// used trace states, and to determine whether the creation of trace state needs
+// to be paused in case there are too many states waiting for tracing.
+type stateTracker struct {
+	limit    int                // Maximum number of states allowed waiting for tracing
+	head     uint64             // The number of the first trace state which isn't used up
+	used     []bool             // List of flags indicating whether the trace state has been used up
+	releases []StateReleaseFunc // List of trace state release functions waiting to be called
+	lock     sync.RWMutex
+}
+
+// newStateTracker initializes the tracker with provided state limits and
+// head state number.
+func newStateTracker(limit int, head uint64) *stateTracker {
+	return &stateTracker{
+		limit: limit,
+		head:  head,
+		used:  make([]bool, limit),
+	}
+}
+
+// releaseState marks the state specified by the number is released and caches
+// the corresponding release functions internally.
+func (t *stateTracker) releaseState(number uint64, release StateReleaseFunc) {
+	t.lock.Lock()
+	defer t.lock.Unlock()
+
+	t.used[int(number-t.head)] = true
+	if number == t.head {
+		var count int
+		for i := 0; i < len(t.used); i++ {
+			if !t.used[i] {
+				break
+			}
+			count += 1
+		}
+		t.head += uint64(count)
+		copy(t.used, t.used[count:])
+	}
+	t.releases = append(t.releases, release)
+}
+
+// callReleases invokes all cached release functions.
+func (t *stateTracker) callReleases() {
+	t.lock.Lock()
+	defer t.lock.Unlock()
+
+	for _, release := range t.releases {
+		release()
+	}
+	t.releases = t.releases[:0]
+}
+
+// wait blocks until the accumulated trace states are less than the limit.
+func (t *stateTracker) wait(number uint64) error {
+	for {
+		t.lock.RLock()
+		head := t.head
+		t.lock.RUnlock()
+
+		if number < t.head {
+			return fmt.Errorf("invalid state number %d head %d", number, t.head)
+		}
+		if int(number-head) < t.limit {
+			return nil
+		}
+		time.Sleep(time.Millisecond * 100)
+	}
+}

--- a/eth/tracers/tracker.go
+++ b/eth/tracers/tracker.go
@@ -61,8 +61,8 @@ func (t *stateTracker) releaseState(number uint64, release StateReleaseFunc) {
 	// it to the next state which is not used up.
 	if number == t.oldest {
 		var count int
-		for i := 0; i < len(t.used); i++ {
-			if !t.used[i] {
+		for _, used := range t.used {
+			if !used {
 				break
 			}
 			count += 1

--- a/eth/tracers/tracker.go
+++ b/eth/tracers/tracker.go
@@ -99,7 +99,8 @@ func (t *stateTracker) wait(number uint64) error {
 		if number < t.oldest {
 			return fmt.Errorf("invalid state number %d head %d", number, t.oldest)
 		}
-		if int(number-t.oldest) < t.limit {
+		if number < t.oldest+uint64(t.limit) {
+			// number is now within limit, wait over
 			return nil
 		}
 		t.cond.Wait()

--- a/eth/tracers/tracker.go
+++ b/eth/tracers/tracker.go
@@ -70,9 +70,10 @@ func (t *stateTracker) releaseState(number uint64, release StateReleaseFunc) {
 		t.oldest += uint64(count)
 		copy(t.used, t.used[count:])
 
-		// The tail of t.used is left unchanged. It will be overwritten
-		// by the following states anyway.
-
+		// Clean up the array tail since they are useless now.
+		for i := t.limit - count; i < t.limit; i++ {
+			t.used[i] = false
+		}
 		// Fire the signal to all waiters that oldest marker is updated.
 		t.cond.Broadcast()
 	}

--- a/eth/tracers/tracker.go
+++ b/eth/tracers/tracker.go
@@ -92,18 +92,16 @@ func (t *stateTracker) callReleases() {
 
 // wait blocks until the accumulated trace states are less than the limit.
 func (t *stateTracker) wait(number uint64) error {
+	t.lock.Lock()
+	defer t.lock.Unlock()
+
 	for {
-		t.lock.Lock()
-		head := t.oldest
 		if number < t.oldest {
-			t.lock.Unlock()
 			return fmt.Errorf("invalid state number %d head %d", number, t.oldest)
 		}
-		if int(number-head) < t.limit {
-			t.lock.Unlock()
+		if int(number-t.oldest) < t.limit {
 			return nil
 		}
 		t.cond.Wait()
-		t.lock.Unlock()
 	}
 }

--- a/eth/tracers/tracker_test.go
+++ b/eth/tracers/tracker_test.go
@@ -1,0 +1,69 @@
+// Copyright 2022 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>
+
+package tracers
+
+import "testing"
+
+func TestTracker(t *testing.T) {
+	var cases = []struct {
+		limit   int
+		head    uint64
+		calls   []uint64
+		expHead uint64
+	}{
+		// Release in order
+		{
+			limit:   3,
+			head:    0,
+			calls:   []uint64{0, 1, 2},
+			expHead: 3,
+		},
+		{
+			limit:   3,
+			head:    0,
+			calls:   []uint64{0, 1, 2, 3, 4, 5},
+			expHead: 6,
+		},
+
+		// Release out of order
+		{
+			limit:   3,
+			head:    0,
+			calls:   []uint64{1, 2, 0},
+			expHead: 3,
+		},
+		{
+			limit:   3,
+			head:    0,
+			calls:   []uint64{1, 2, 0, 5, 4, 3},
+			expHead: 6,
+		},
+	}
+	for _, c := range cases {
+		tracker := newStateTracker(c.limit, c.head)
+		for _, call := range c.calls {
+			tracker.releaseState(call, func() {})
+		}
+		tracker.lock.RLock()
+		head := tracker.head
+		tracker.lock.RUnlock()
+
+		if head != c.expHead {
+			t.Fatalf("Unexpected head want %d got %d", c.expHead, head)
+		}
+	}
+}

--- a/eth/tracers/tracker_test.go
+++ b/eth/tracers/tracker_test.go
@@ -21,20 +21,17 @@ import "testing"
 func TestTracker(t *testing.T) {
 	var cases = []struct {
 		limit   int
-		head    uint64
 		calls   []uint64
 		expHead uint64
 	}{
 		// Release in order
 		{
 			limit:   3,
-			head:    0,
 			calls:   []uint64{0, 1, 2},
 			expHead: 3,
 		},
 		{
 			limit:   3,
-			head:    0,
 			calls:   []uint64{0, 1, 2, 3, 4, 5},
 			expHead: 6,
 		},
@@ -42,24 +39,22 @@ func TestTracker(t *testing.T) {
 		// Release out of order
 		{
 			limit:   3,
-			head:    0,
 			calls:   []uint64{1, 2, 0},
 			expHead: 3,
 		},
 		{
 			limit:   3,
-			head:    0,
 			calls:   []uint64{1, 2, 0, 5, 4, 3},
 			expHead: 6,
 		},
 	}
 	for _, c := range cases {
-		tracker := newStateTracker(c.limit, c.head)
+		tracker := newStateTracker(c.limit, 0)
 		for _, call := range c.calls {
 			tracker.releaseState(call, func() {})
 		}
 		tracker.lock.RLock()
-		head := tracker.head
+		head := tracker.oldest
 		tracker.lock.RUnlock()
 
 		if head != c.expHead {


### PR DESCRIPTION
This PR introduces a new mechanism in chain tracer for preventing creating too many trace states.

The workflow of chain tracer can be divided into several parts:
- state creator generates trace state in a thread
- state tracer retrieves the trace state and applies the tracing on top in another thread
- state collector gathers all result from state tracer and stream to users

It's basically a producer-consumer model here, while if we imagine that the state producer generates states too fast, then it will lead to accumulate lots of unused states in memory. Even worse, in path-based state scheme it will only keep the latest 128 states in memory, and the newly generated state will invalidate the oldest one by marking it as stale.

The solution for fixing it is to limit the speed of state generation. If there are over 128 states un-consumed in memory, then the creation will be paused until the states are be consumed properly.