### PR TITLE
eth: fix trace config for `TraceCall`

### DIFF
--- a/eth/tracers/api.go
+++ b/eth/tracers/api.go
@@ -870,8 +870,8 @@ func (api *API) TraceCall(ctx context.Context, args ethapi.TransactionArgs, bloc
 	}
 	// try to recompute the state
 	reexec := defaultTraceReexec
-	if config != nil && config.Reexec != nil {
-		reexec = *config.Reexec
+	if config != nil && &config.TraceConfig != nil && config.TraceConfig.Reexec != nil {
+		reexec = *config.TraceConfig.Reexec
 	}
 	statedb, release, err := api.backend.StateAtBlock(ctx, block, reexec, nil, true, false)
 	if err != nil {
@@ -895,13 +895,7 @@ func (api *API) TraceCall(ctx context.Context, args ethapi.TransactionArgs, bloc
 
 	var traceConfig *TraceConfig
 	if config != nil {
-		traceConfig = &TraceConfig{
-			Config:       config.Config,
-			Tracer:       config.Tracer,
-			TracerConfig: config.TracerConfig,
-			Timeout:      config.Timeout,
-			Reexec:       config.Reexec,
-		}
+		traceConfig = &config.TraceConfig
 	}
 	return api.traceTx(ctx, msg, new(Context), vmctx, statedb, traceConfig)
 }

--- a/eth/tracers/api.go
+++ b/eth/tracers/api.go
@@ -870,7 +870,7 @@ func (api *API) TraceCall(ctx context.Context, args ethapi.TransactionArgs, bloc
 	}
 	// try to recompute the state
 	reexec := defaultTraceReexec
-	if config != nil && &config.TraceConfig != nil && config.TraceConfig.Reexec != nil {
+	if config != nil && config.Reexec != nil {
 		reexec = *config.TraceConfig.Reexec
 	}
 	statedb, release, err := api.backend.StateAtBlock(ctx, block, reexec, nil, true, false)

--- a/eth/tracers/api.go
+++ b/eth/tracers/api.go
@@ -871,7 +871,7 @@ func (api *API) TraceCall(ctx context.Context, args ethapi.TransactionArgs, bloc
 	// try to recompute the state
 	reexec := defaultTraceReexec
 	if config != nil && config.Reexec != nil {
-		reexec = *config.TraceConfig.Reexec
+		reexec = *config.Reexec
 	}
 	statedb, release, err := api.backend.StateAtBlock(ctx, block, reexec, nil, true, false)
 	if err != nil {

--- a/eth/tracers/api.go
+++ b/eth/tracers/api.go
@@ -896,10 +896,11 @@ func (api *API) TraceCall(ctx context.Context, args ethapi.TransactionArgs, bloc
 	var traceConfig *TraceConfig
 	if config != nil {
 		traceConfig = &TraceConfig{
-			Config:  config.Config,
-			Tracer:  config.Tracer,
-			Timeout: config.Timeout,
-			Reexec:  config.Reexec,
+			Config:       config.Config,
+			Tracer:       config.Tracer,
+			TracerConfig: config.TracerConfig,
+			Timeout:      config.Timeout,
+			Reexec:       config.Reexec,
 		}
 	}
 	return api.traceTx(ctx, msg, new(Context), vmctx, statedb, traceConfig)


### PR DESCRIPTION
Currently, trace configs (introduced in [#25430](https://github.com/ethereum/go-ethereum/pull/25430)) don't work for the function `TraceCall`. This PR fixes it.