### PR TITLE
cmd/geth, cmd/utils: geth attach with custom headers

### DIFF
--- a/cmd/geth/attach_test.go
+++ b/cmd/geth/attach_test.go
@@ -1,3 +1,19 @@
+// Copyright 2022 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
 package main
 
 import (

--- a/cmd/geth/attach_test.go
+++ b/cmd/geth/attach_test.go
@@ -1,0 +1,67 @@
+package main
+
+import (
+	"fmt"
+	"net"
+	"net/http"
+	"sync/atomic"
+	"testing"
+)
+
+type testHandler struct {
+	body func(http.ResponseWriter, *http.Request)
+}
+
+func (t *testHandler) ServeHTTP(out http.ResponseWriter, in *http.Request) {
+	t.body(out, in)
+}
+
+// TestAttachWithHeaders tests that 'geth attach' with custom headers works, i.e
+// that custom headers are forwarded to the target.
+func TestAttachWithHeaders(t *testing.T) {
+	t.Parallel()
+	ln, err := net.Listen("tcp", "localhost:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	port := ln.Addr().(*net.TCPAddr).Port
+	testReceiveHeaders(t, ln, "attach", "-H", "first: one", "-H", "second: two", fmt.Sprintf("http://localhost:%d", port))
+	// This way to do it fails due to flag ordering:
+	//
+	// testReceiveHeaders(t, ln, "-H", "first: one", "-H", "second: two", "attach", fmt.Sprintf("http://localhost:%d", port))
+	// This is fixed in a follow-up PR.
+}
+
+// TestAttachWithHeaders tests that 'geth db --remotedb' with custom headers works, i.e
+// that custom headers are forwarded to the target.
+func TestRemoteDbWithHeaders(t *testing.T) {
+	t.Parallel()
+	ln, err := net.Listen("tcp", "localhost:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	port := ln.Addr().(*net.TCPAddr).Port
+	testReceiveHeaders(t, ln, "db", "metadata", "--remotedb", fmt.Sprintf("http://localhost:%d", port), "-H", "first: one", "-H", "second: two")
+}
+
+func testReceiveHeaders(t *testing.T, ln net.Listener, gethArgs ...string) {
+	var ok uint32
+	server := &http.Server{
+		Addr: "localhost:0",
+		Handler: &testHandler{func(w http.ResponseWriter, r *http.Request) {
+			// We expect two headers
+			if have, want := r.Header.Get("first"), "one"; have != want {
+				t.Fatalf("missing header, have %v want %v", have, want)
+			}
+			if have, want := r.Header.Get("second"), "two"; have != want {
+				t.Fatalf("missing header, have %v want %v", have, want)
+			}
+			atomic.StoreUint32(&ok, 1)
+		}}}
+	go server.Serve(ln)
+	defer server.Close()
+	runGeth(t, gethArgs...).WaitExit()
+	if atomic.LoadUint32(&ok) != 1 {
+		t.Fatal("Test fail, expected invocation to succeed")
+	}
+}

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -1002,6 +1002,7 @@ var (
 		DataDirFlag,
 		AncientFlag,
 		RemoteDBFlag,
+		HttpHeaderFlag,
 	}
 )
 
@@ -2132,8 +2133,8 @@ func MakeChainDatabase(ctx *cli.Context, stack *node.Node, readonly bool) ethdb.
 	)
 	switch {
 	case ctx.IsSet(RemoteDBFlag.Name):
-		log.Info("Using remote db", "url", ctx.String(RemoteDBFlag.Name))
-		chainDb, err = remotedb.New(ctx.String(RemoteDBFlag.Name))
+		log.Info("Using remote db", "url", ctx.String(RemoteDBFlag.Name), "headers", len(ctx.StringSlice(HttpHeaderFlag.Name)))
+		chainDb, err = remotedb.New(ctx.String(RemoteDBFlag.Name), ctx.StringSlice(HttpHeaderFlag.Name))
 	case ctx.String(SyncModeFlag.Name) == "light":
 		chainDb, err = stack.OpenDatabase("lightchaindata", cache, handles, "", readonly)
 	default:

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -983,7 +983,7 @@ var (
 	HttpHeaderFlag = &cli.StringSliceFlag{
 		Name:     "header",
 		Aliases:  []string{"H"},
-		Usage:    "Pass custom header(s) to server",
+		Usage:    "Pass custom headers to the RPC server wheng using --" + RemoteDBFlag.Name + " or the geth attach console.",
 		Category: flags.NetworkingCategory,
 	}
 )

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -976,6 +976,13 @@ var (
 		Value:    metrics.DefaultConfig.InfluxDBOrganization,
 		Category: flags.MetricsCategory,
 	}
+
+	HttpHeaderFlag = &cli.StringSliceFlag{
+		Name:     "header",
+		Aliases:  []string{"H"},
+		Usage:    "Pass custom header(s) to server",
+		Category: flags.NetworkingCategory,
+	}
 )
 
 var (

--- a/ethdb/remotedb/remotedb.go
+++ b/ethdb/remotedb/remotedb.go
@@ -22,12 +22,6 @@
 package remotedb
 
 import (
-	"context"
-	"errors"
-	"fmt"
-	"net/http"
-	"strings"
-
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/ethdb"
 	"github.com/ethereum/go-ethereum/rpc"
@@ -153,36 +147,8 @@ func (db *Database) Close() error {
 	return nil
 }
 
-func dialRPC(endpoint string, headers []string) (*rpc.Client, error) {
-	if endpoint == "" {
-		return nil, errors.New("endpoint must be specified")
-	}
-	if strings.HasPrefix(endpoint, "rpc:") || strings.HasPrefix(endpoint, "ipc:") {
-		// Backwards compatibility with geth < 1.5 which required
-		// these prefixes.
-		endpoint = endpoint[4:]
-	}
-	var opts []rpc.ClientOption
-	if len(headers) > 0 {
-		var customHeaders = make(http.Header)
-		for _, h := range headers {
-			kv := strings.Split(h, ":")
-			if len(kv) != 2 {
-				return nil, fmt.Errorf("invalid http header directive: %q", h)
-			}
-			customHeaders.Add(kv[0], kv[1])
-		}
-		opts = append(opts, rpc.WithHeaders(customHeaders))
-	}
-	return rpc.DialOptions(context.Background(), endpoint, opts...)
-}
-
-func New(endpoint string, headers []string) (ethdb.Database, error) {
-	client, err := dialRPC(endpoint, headers)
-	if err != nil {
-		return nil, err
-	}
+func New(client *rpc.Client) ethdb.Database {
 	return &Database{
 		remote: client,
-	}, nil
+	}
 }


### PR DESCRIPTION
This PR makes it possible to set custom headers. Example: 
```
$ source setheaders && go run . attach -H "CF-Access-Client-Id: $CFID" -H "CF-Access-Client-Secret: $CFSEC"  https://rpc.mainnet.ethpandaops.io
Welcome to the Geth JavaScript console!

instance: erigon/2022.09.1/linux-amd64/go1.18.5
```
Error handlng: 
```
go run . attach -H "a bad header"  https://rpc.mainnet.ethpandaops.io
Fatal: invalid http header directive: "a bad header"
```

