### PR TITLE
internal/flags: fix issue with stringslice migration

### DIFF
--- a/internal/flags/helpers.go
+++ b/internal/flags/helpers.go
@@ -95,7 +95,14 @@ func doMigrateFlags(ctx *cli.Context) {
 	for _, name := range ctx.FlagNames() {
 		for _, parent := range ctx.Lineage()[1:] {
 			if parent.IsSet(name) {
-				ctx.Set(name, parent.String(name))
+				// It is a string-slice, not a string. We need to set it
+				// as "alfa, beta, gamma" instead of "[alfa beta gamma]", in order
+				// for the backing StringSlice to parse it properly.
+				if result := parent.StringSlice(name); len(result) > 0 {
+					ctx.Set(name, strings.Join(result, ","))
+				} else {
+					ctx.Set(name, parent.String(name))
+				}
 				break
 			}
 		}

--- a/internal/flags/helpers.go
+++ b/internal/flags/helpers.go
@@ -92,11 +92,28 @@ func MigrateGlobalFlags(ctx *cli.Context) {
 }
 
 func doMigrateFlags(ctx *cli.Context) {
+	// Figure out if there are any aliases of commands. If there are, we want
+	// to ignore them when iterating over the flags.
+	var aliases = make(map[string]bool)
+	for _, fl := range ctx.Command.Flags {
+		for _, alias := range fl.Names()[1:] {
+			aliases[alias] = true
+		}
+	}
 	for _, name := range ctx.FlagNames() {
 		for _, parent := range ctx.Lineage()[1:] {
 			if parent.IsSet(name) {
-				// It is a string-slice, not a string. We need to set it
-				// as "alfa, beta, gamma" instead of "[alfa beta gamma]", in order
+				// When iterating across the lineage, we will be served both
+				// the 'canon' and alias formats of all commmands. In most cases,
+				// it's fine to set it in the ctx multiple times (one for each
+				// name), however, the Slice-flags are not fine.
+				// The slice-flags accumulate, so if we set it once as
+				// "foo" and once as alias "F", then both will be present in the slice.
+				if _, isAlias := aliases[name]; isAlias {
+					continue
+				}
+				// If it is a string-slice, we need to set it as
+				// "alfa, beta, gamma" instead of "[alfa beta gamma]", in order
 				// for the backing StringSlice to parse it properly.
 				if result := parent.StringSlice(name); len(result) > 0 {
 					ctx.Set(name, strings.Join(result, ","))


### PR DESCRIPTION
This PR fixes an issue related to how subcommands are hoisted into the global scope. 

Here's an example app: https://gist.github.com/holiman/5ed50fc9dcf44fd661abdb91a59137fe#file-main-go . This has a stringslice argument, and shows the corruption that happens when that stringslice is migrated across scopes: 

```
[user@work cmdtest]$ ./cmdtest  --header aa --header bb --url foo connect
invoked via subcommand
  ctx.IsSet(HttpHeaderFlag.Name): true
    0: [aa bb]
  ctx.IsSet(UrlFlag.Name): true
    foo
```
The value is migrated as the literal string `[aa bb]`, which is the string-equivalent of the stringslice. Unfortunately, the backing type, `StringSlice` cannot convert this back to a proper stringslice -- it expects input to be on the form `aa,bb`. 

This PR fixes it by detecting whether a given type is indeed a stringslice, and then uses a different string-representation than the default. This works nicely with the backing-type, which is then set correctly. 

```
[user@work cmdtest]$ ./cmdtest  --header aa --header bb --url foo connect
invoked via subcommand
  ctx.IsSet(HttpHeaderFlag.Name): true
    0: aa
    1: bb
  ctx.IsSet(UrlFlag.Name): true
    foo
```