### PR TITLE
miner: build a more Merge friendly pending block

### DIFF
--- a/miner/worker.go
+++ b/miner/worker.go
@@ -980,7 +980,7 @@ func (w *worker) prepareWork(genParams *generateParams) (*environment, error) {
 		if genParams.forceTime {
 			return nil, fmt.Errorf("invalid timestamp, parent %d given %d", parent.Time(), timestamp)
 		}
-		timestamp = parent.Time() + 12
+		timestamp = parent.Time() + 12 // seconds per slot
 	}
 	// Construct the sealing block header, set the extra field if it's allowed
 	num := parent.Number()


### PR DESCRIPTION
Adjust geth's block building parameters to produce (most of the time) a block acceptable to consensus clients.

Set header.Time = parent.Time() + 12. This is the correct value unless the previous slot block proposal was missed.

Set header.MixDigest = parent.Header().MixDigest. This is the correct value except at the beginning of a new epoch.

An alternative would be to add/modify an API which allows the user to specify these values, similar to how the consensus client currently acquires a block from geth.