### PR TITLE
miner: build a more Merge friendly pending block

### DIFF
--- a/miner/worker.go
+++ b/miner/worker.go
@@ -980,7 +980,7 @@ func (w *worker) prepareWork(genParams *generateParams) (*environment, error) {
 		if genParams.forceTime {
 			return nil, fmt.Errorf("invalid timestamp, parent %d given %d", parent.Time(), timestamp)
 		}
-		timestamp = parent.Time() + 12
+		timestamp = parent.Time() + 12 // seconds per slot
 	}
 	// Construct the sealing block header, set the extra field if it's allowed
 	num := parent.Number()

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -20,6 +20,7 @@ import (
 	"errors"
 	"fmt"
 	"math/big"
+	"math/rand"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -994,12 +995,14 @@ func (w *worker) prepareWork(genParams *generateParams) (*environment, error) {
 	if !genParams.noExtra && len(w.extra) != 0 {
 		header.Extra = w.extra
 	}
-	// Set the randomness field from the beacon chain if it's available.
+	// Set the randomness field from the beacon chain if it's available,
+	// otherwise fill with random bytes.
 	if genParams.random != (common.Hash{}) {
 		header.MixDigest = genParams.random
 	} else {
-		// Beacon chain randomness changes every epoch, this will usually be correct.
-		header.MixDigest = parent.Header().MixDigest
+		for ind := range header.MixDigest {
+			header.MixDigest[ind] = byte(rand.Intn(256))
+		}
 	}
 	// Set baseFee and GasLimit if we are on an EIP-1559 chain
 	if w.chainConfig.IsLondon(header.Number) {

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -1135,15 +1135,15 @@ func (w *worker) commit(env *environment, interval func(), update bool, start ti
 		if interval != nil {
 			interval()
 		}
-		// Create a local environment copy, avoid the data race with snapshot state.
-		// https://github.com/ethereum/go-ethereum/issues/24299
-		env := env.copy()
 		block, err := w.engine.FinalizeAndAssemble(w.chain, env.header, env.state, env.txs, env.unclelist(), env.receipts)
 		if err != nil {
 			return err
 		}
 		// If we're post merge, just ignore
 		if !w.isTTDReached(block.Header()) {
+			// Create a local environment copy, avoid the data race with snapshot state.
+			// https://github.com/ethereum/go-ethereum/issues/24299
+			env := env.copy()
 			select {
 			case w.taskCh <- &task{receipts: env.receipts, state: env.state, block: block, createdAt: time.Now()}:
 				w.unconfirmed.Shift(block.NumberU64() - 1)

--- a/miner/worker_test.go
+++ b/miner/worker_test.go
@@ -576,7 +576,8 @@ func testGetSealingWork(t *testing.T, chainConfig *params.ChainConfig, engine co
 			}
 		}
 		if !isClique {
-			if block.MixDigest() != random {
+			if block.MixDigest() != random && random != (common.Hash{}) {
+				// if random unset, MixDigest will be set randomly.
 				t.Error("Unexpected mix digest")
 			}
 		}


### PR DESCRIPTION
Adjust geth's block building parameters to produce a pending block more similar to the real one which is produced through the engine API.

* Set header.Time = parent.Time() + 12. This is the correct value unless the previous slot block proposal was missed.

* Set header.MixDigest to a random hash. This won't match the real block, but it's more realistic than 0.

* Apply FinalizeAndAssemble to the snapshot block. This sets header.Root.