### PR TITLE
rpc: use acceptedContentTypes in invalid content type error

### DIFF
--- a/rpc/http.go
+++ b/rpc/http.go
@@ -318,6 +318,6 @@ func validateRequest(r *http.Request) (int, error) {
 		}
 	}
 	// Invalid content-type
-	err := fmt.Errorf("invalid content type, only %s is supported", contentType)
+	err := fmt.Errorf("invalid content type, only %q are supported", acceptedContentTypes)
 	return http.StatusUnsupportedMediaType, err
 }


### PR DESCRIPTION
The PR for fix error message.
I think using the format `%q` is better than using `strings.Join`.
```
fmt.Errorf("invalid content type, only %s are supported", strings.Join(acceptedContentTypes, ", "))
-> invalid content type, only application/json, application/json-rpc, application/jsonrequest are supported

fmt.Errorf("invalid content type, only %q are supported", acceptedContentTypes)
-> invalid content type, only ["application/json" "application/json-rpc" "application/jsonrequest"] are supported
```