### PR TITLE
core/bloombits: speed up windows-test

### DIFF
--- a/core/bloombits/scheduler_test.go
+++ b/core/bloombits/scheduler_test.go
@@ -19,11 +19,9 @@ package bloombits
 import (
 	"bytes"
 	"math/big"
-	"math/rand"
 	"sync"
 	"sync/atomic"
 	"testing"
-	"time"
 )
 
 // Tests that the scheduler can deduplicate and forward retrieval requests to
@@ -53,7 +51,6 @@ func testScheduler(t *testing.T, clients int, fetchers int, requests int) {
 			defer fetchPend.Done()
 
 			for req := range fetch {
-				time.Sleep(time.Duration(rand.Intn(int(100 * time.Microsecond))))
 				atomic.AddUint32(&delivered, 1)
 
 				f.deliver([]uint64{


### PR DESCRIPTION
This PR brings down the time on Windows from ~70 seconds down to 2-3 seconds. The windows sleep duration cannot go below ~15ms, it seems. 