### PR TITLE
cmd/utils: make --authrpc.jwtsecret a DirectoryFlag

### DIFF
--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -631,7 +631,7 @@ var (
 		Value:    strings.Join(node.DefaultConfig.AuthVirtualHosts, ","),
 		Category: flags.APICategory,
 	}
-	JWTSecretFlag = &cli.StringFlag{
+	JWTSecretFlag = &flags.DirectoryFlag{
 		Name:     "authrpc.jwtsecret",
 		Usage:    "Path to a JWT secret to use for authenticated RPC endpoints",
 		Category: flags.APICategory,


### PR DESCRIPTION
Currently, geth command line can't expand the argument such as `--authrpc.jwtsecret=~/.geth/jwt.secret`, use `flags.DirectoryFlag` instead