### PR TITLE
internal/version: use gitCommit/gitDate injection in version handling code

### DIFF
--- a/build/ci.go
+++ b/build/ci.go
@@ -254,8 +254,8 @@ func doInstall(cmdline []string) {
 func buildFlags(env build.Environment, staticLinking bool, buildTags []string) (flags []string) {
 	var ld []string
 	if env.Commit != "" {
-		ld = append(ld, "-X", "main.gitCommit="+env.Commit)
-		ld = append(ld, "-X", "main.gitDate="+env.Date)
+		ld = append(ld, "-X", "github.com/ethereum/go-ethereum/internal/version.gitCommit="+env.Commit)
+		ld = append(ld, "-X", "github.com/ethereum/go-ethereum/internal/version.gitDate="+env.Date)
 	}
 	// Strip DWARF on darwin. This used to be required for certain things,
 	// and there is no downside to this, so we just keep doing it.

--- a/cmd/abigen/main.go
+++ b/cmd/abigen/main.go
@@ -34,14 +34,6 @@ import (
 )
 
 var (
-	// Git SHA1 commit hash of the release (set via linker flags)
-	gitCommit = ""
-	gitDate   = ""
-
-	app *cli.App
-)
-
-var (
 	// Flags needed by abigen
 	abiFlag = &cli.StringFlag{
 		Name:  "abi",
@@ -82,8 +74,9 @@ var (
 	}
 )
 
+var app = flags.NewApp("Ethereum ABI wrapper code generator")
+
 func init() {
-	app = flags.NewApp(gitCommit, gitDate, "ethereum checkpoint helper tool")
 	app.Name = "abigen"
 	app.Flags = []cli.Flag{
 		abiFlag,

--- a/cmd/checkpoint-admin/main.go
+++ b/cmd/checkpoint-admin/main.go
@@ -28,16 +28,9 @@ import (
 	"github.com/urfave/cli/v2"
 )
 
-var (
-	// Git SHA1 commit hash of the release (set via linker flags)
-	gitCommit = ""
-	gitDate   = ""
-
-	app *cli.App
-)
+var app = flags.NewApp("ethereum checkpoint helper tool")
 
 func init() {
-	app = flags.NewApp(gitCommit, gitDate, "ethereum checkpoint helper tool")
 	app.Commands = []*cli.Command{
 		commandStatus,
 		commandDeploy,

--- a/cmd/clef/main.go
+++ b/cmd/clef/main.go
@@ -215,13 +215,7 @@ The gendoc generates example structures of the json-rpc communication types.
 `}
 )
 
-var (
-	// Git SHA1 commit hash of the release (set via linker flags)
-	gitCommit = ""
-	gitDate   = ""
-
-	app = flags.NewApp(gitCommit, gitDate, "Manage Ethereum account operations")
-)
+var app = flags.NewApp("Manage Ethereum account operations")
 
 func init() {
 	app.Name = "Clef"

--- a/cmd/devp2p/main.go
+++ b/cmd/devp2p/main.go
@@ -19,30 +19,17 @@ package main
 import (
 	"fmt"
 	"os"
-	"path/filepath"
 
 	"github.com/ethereum/go-ethereum/internal/debug"
 	"github.com/ethereum/go-ethereum/internal/flags"
 	"github.com/ethereum/go-ethereum/p2p/enode"
-	"github.com/ethereum/go-ethereum/params"
 	"github.com/urfave/cli/v2"
 )
 
-var (
-	// Git information set by linker when building with ci.go.
-	gitCommit string
-	gitDate   string
-	app       = &cli.App{
-		Name:        filepath.Base(os.Args[0]),
-		Usage:       "go-ethereum devp2p tool",
-		Version:     params.VersionWithCommit(gitCommit, gitDate),
-		Writer:      os.Stdout,
-		HideVersion: true,
-	}
-)
+var app = flags.NewApp("go-ethereum devp2p tool")
 
 func init() {
-	// Set up the CLI app.
+	app.HideVersion = true
 	app.Flags = append(app.Flags, debug.Flags...)
 	app.Before = func(ctx *cli.Context) error {
 		flags.MigrateGlobalFlags(ctx)
@@ -56,6 +43,7 @@ func init() {
 		fmt.Fprintf(os.Stderr, "No such command: %s\n", cmd)
 		os.Exit(1)
 	}
+
 	// Add subcommands.
 	app.Commands = []*cli.Command{
 		enrdumpCommand,

--- a/cmd/ethkey/main.go
+++ b/cmd/ethkey/main.go
@@ -28,14 +28,10 @@ const (
 	defaultKeyfileName = "keyfile.json"
 )
 
-// Git SHA1 commit hash of the release (set via linker flags)
-var gitCommit = ""
-var gitDate = ""
-
 var app *cli.App
 
 func init() {
-	app = flags.NewApp(gitCommit, gitDate, "an Ethereum key manager")
+	app = flags.NewApp("Ethereum key manager")
 	app.Commands = []*cli.Command{
 		commandGenerate,
 		commandInspect,

--- a/cmd/evm/main.go
+++ b/cmd/evm/main.go
@@ -28,13 +28,6 @@ import (
 )
 
 var (
-	gitCommit = "" // Git SHA1 commit hash of the release (set via linker flags)
-	gitDate   = ""
-
-	app = flags.NewApp(gitCommit, gitDate, "the evm command line interface")
-)
-
-var (
 	DebugFlag = &cli.BoolFlag{
 		Name:  "debug",
 		Usage: "output full trace logs",
@@ -191,6 +184,8 @@ var blockBuilderCommand = &cli.Command{
 		t8ntool.VerbosityFlag,
 	},
 }
+
+var app = flags.NewApp("the evm command line interface")
 
 func init() {
 	app.Flags = []cli.Flag{

--- a/cmd/faucet/faucet.go
+++ b/cmd/faucet/faucet.go
@@ -49,6 +49,7 @@ import (
 	"github.com/ethereum/go-ethereum/eth/ethconfig"
 	"github.com/ethereum/go-ethereum/ethclient"
 	"github.com/ethereum/go-ethereum/ethstats"
+	"github.com/ethereum/go-ethereum/internal/version"
 	"github.com/ethereum/go-ethereum/les"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/node"
@@ -91,11 +92,6 @@ var (
 
 var (
 	ether = new(big.Int).Exp(big.NewInt(10), big.NewInt(18), nil)
-)
-
-var (
-	gitCommit = "" // Git SHA1 commit hash of the release (set via linker flags)
-	gitDate   = "" // Git commit date YYYYMMDD of the release (set via linker flags)
 )
 
 //go:embed faucet.html
@@ -226,9 +222,10 @@ type wsConn struct {
 
 func newFaucet(genesis *core.Genesis, port int, enodes []*enode.Node, network uint64, stats string, ks *keystore.KeyStore, index []byte) (*faucet, error) {
 	// Assemble the raw devp2p protocol stack
+	git, _ := version.VCS()
 	stack, err := node.New(&node.Config{
 		Name:    "geth",
-		Version: params.VersionWithCommit(gitCommit, gitDate),
+		Version: params.VersionWithCommit(git.Commit, git.Date),
 		DataDir: filepath.Join(os.Getenv("HOME"), ".faucet"),
 		P2P: p2p.Config{
 			NAT:              nat.Any(),

--- a/cmd/geth/config.go
+++ b/cmd/geth/config.go
@@ -35,6 +35,7 @@ import (
 	"github.com/ethereum/go-ethereum/eth/ethconfig"
 	"github.com/ethereum/go-ethereum/internal/ethapi"
 	"github.com/ethereum/go-ethereum/internal/flags"
+	"github.com/ethereum/go-ethereum/internal/version"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/metrics"
 	"github.com/ethereum/go-ethereum/node"
@@ -108,9 +109,10 @@ func loadConfig(file string, cfg *gethConfig) error {
 }
 
 func defaultNodeConfig() node.Config {
+	git, _ := version.VCS()
 	cfg := node.DefaultConfig
 	cfg.Name = clientIdentifier
-	cfg.Version = params.VersionWithCommit(gitCommit, gitDate)
+	cfg.Version = params.VersionWithCommit(git.Commit, git.Date)
 	cfg.HTTPModules = append(cfg.HTTPModules, "eth")
 	cfg.WSModules = append(cfg.WSModules, "eth")
 	cfg.IPCPath = "geth.ipc"

--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -52,11 +52,6 @@ const (
 )
 
 var (
-	// Git SHA1 commit hash of the release (set via linker flags)
-	gitCommit = ""
-	gitDate   = ""
-	// The app that holds all commands and flags.
-	app = flags.NewApp(gitCommit, gitDate, "the go-ethereum command line interface")
 	// flags that configure the node
 	nodeFlags = flags.Merge([]cli.Flag{
 		utils.IdentityFlag,
@@ -204,6 +199,8 @@ var (
 		utils.MetricsInfluxDBOrganizationFlag,
 	}
 )
+
+var app = flags.NewApp("the go-ethereum command line interface")
 
 func init() {
 	// Initialize the CLI app and start Geth

--- a/cmd/geth/misccmd.go
+++ b/cmd/geth/misccmd.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/ethereum/go-ethereum/cmd/utils"
 	"github.com/ethereum/go-ethereum/consensus/ethash"
+	"github.com/ethereum/go-ethereum/internal/version"
 	"github.com/ethereum/go-ethereum/params"
 	"github.com/urfave/cli/v2"
 )
@@ -38,9 +39,7 @@ var (
 	VersionCheckVersionFlag = &cli.StringFlag{
 		Name:  "check.version",
 		Usage: "Version to check",
-		Value: fmt.Sprintf("Geth/v%v/%v-%v/%v",
-			params.VersionWithCommit(gitCommit, gitDate),
-			runtime.GOOS, runtime.GOARCH, runtime.Version()),
+		Value: version.ClientName(clientIdentifier),
 	}
 	makecacheCommand = &cli.Command{
 		Action:    makecache,
@@ -67,7 +66,7 @@ Regular users do not need to execute it.
 `,
 	}
 	versionCommand = &cli.Command{
-		Action:    version,
+		Action:    printVersion,
 		Name:      "version",
 		Usage:     "Print version numbers",
 		ArgsUsage: " ",
@@ -127,14 +126,16 @@ func makedag(ctx *cli.Context) error {
 	return nil
 }
 
-func version(ctx *cli.Context) error {
+func printVersion(ctx *cli.Context) error {
+	git, _ := version.VCS()
+
 	fmt.Println(strings.Title(clientIdentifier))
 	fmt.Println("Version:", params.VersionWithMeta)
-	if gitCommit != "" {
-		fmt.Println("Git Commit:", gitCommit)
+	if git.Commit != "" {
+		fmt.Println("Git Commit:", git.Commit)
 	}
-	if gitDate != "" {
-		fmt.Println("Git Commit Date:", gitDate)
+	if git.Date != "" {
+		fmt.Println("Git Commit Date:", git.Date)
 	}
 	fmt.Println("Architecture:", runtime.GOARCH)
 	fmt.Println("Go Version:", runtime.Version())

--- a/cmd/p2psim/main.go
+++ b/cmd/p2psim/main.go
@@ -100,14 +100,8 @@ var (
 	}
 )
 
-var (
-	// Git information set by linker when building with ci.go.
-	gitCommit string
-	gitDate   string
-)
-
 func main() {
-	app := flags.NewApp(gitCommit, gitDate, "devp2p simulation command-line client")
+	app := flags.NewApp("devp2p simulation command-line client")
 	app.Flags = []cli.Flag{
 		apiFlag,
 	}

--- a/internal/flags/helpers.go
+++ b/internal/flags/helpers.go
@@ -20,15 +20,17 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/ethereum/go-ethereum/internal/version"
 	"github.com/ethereum/go-ethereum/params"
 	"github.com/urfave/cli/v2"
 )
 
 // NewApp creates an app with sane defaults.
-func NewApp(gitCommit, gitDate, usage string) *cli.App {
+func NewApp(usage string) *cli.App {
+	git, _ := version.VCS()
 	app := cli.NewApp()
 	app.EnableBashCompletion = true
-	app.Version = params.VersionWithCommit(gitCommit, gitDate)
+	app.Version = params.VersionWithCommit(git.Commit, git.Date)
 	app.Usage = usage
 	app.Copyright = "Copyright 2013-2022 The go-ethereum Authors"
 	app.Before = func(ctx *cli.Context) error {

--- a/internal/version/vcs_fallback.go
+++ b/internal/version/vcs_fallback.go
@@ -23,6 +23,6 @@ import "runtime/debug"
 
 // In Go versions before 1.18, VCS information is not available.
 
-func vcsInfo(info *debug.BuildInfo) (gitStatus, bool) {
-	return gitStatus{}, false
+func buildInfoVCS(info *debug.BuildInfo) (VCSInfo, bool) {
+	return VCSInfo{}, false
 }


### PR DESCRIPTION
This changes the CI build to store the git commit and date into package internal/version instead of package main. Doing this essentially merges our two ways of tracking the go-ethereum version into a single place, achieving two objectives:

- Bad block reports, which use version.Info(), will now have the git commit information even when geth is built in an environment such as launchpad.net, where git is unavailable.

- For geth builds created by `go build ./cmd/geth` (i.e. not using `go run build/ci.go install`), the git information stored by the go tool is now used in the p2p node name as well as in `geth version` and `geth version-check`.