### PR TITLE
p2p: change low port range

### DIFF
--- a/p2p/discover/v5_udp.go
+++ b/p2p/discover/v5_udp.go
@@ -410,7 +410,7 @@ func (t *UDPv5) verifyResponseNode(c *callV5, r *enr.Record, distances []uint, s
 	if t.netrestrict != nil && !t.netrestrict.Contains(node.IP()) {
 		return nil, errors.New("not contained in netrestrict list")
 	}
-	if c.node.UDP() <= 1024 {
+	if c.node.UDP() < 1024 {
 		return nil, errLowPort
 	}
 	if distances != nil {


### PR DESCRIPTION
```go
if c.node.UDP() <= 1024 {
		return nil, errLowPort
}
```
I think it's probably based on well-known port range. If true, it needs correction.(~1023)
Or is it's follow other judgments?
