### PR TITLE
eth/downloader, les/downloader: fix subtle flaw in queue delivery

### DIFF
--- a/eth/downloader/queue.go
+++ b/eth/downloader/queue.go
@@ -857,7 +857,7 @@ func (q *queue) deliver(id string, taskPool map[common.Hash]*types.Header,
 	}
 
 	for _, header := range request.Headers[:i] {
-		if res, stale, err := q.resultCache.GetDeliverySlot(header.Number.Uint64()); err == nil {
+		if res, stale, err := q.resultCache.GetDeliverySlot(header.Number.Uint64()); err == nil && !stale {
 			reconstruct(accepted, res)
 		} else {
 			// else: between here and above, some other peer filled this result,

--- a/les/downloader/queue.go
+++ b/les/downloader/queue.go
@@ -870,7 +870,7 @@ func (q *queue) deliver(id string, taskPool map[common.Hash]*types.Header,
 	}
 
 	for _, header := range request.Headers[:i] {
-		if res, stale, err := q.resultCache.GetDeliverySlot(header.Number.Uint64()); err == nil {
+		if res, stale, err := q.resultCache.GetDeliverySlot(header.Number.Uint64()); err == nil && !stale {
 			reconstruct(accepted, res)
 		} else {
 			// else: between here and above, some other peer filled this result,


### PR DESCRIPTION
When `stale` is true, `res` will be nil, in that case `reconstruct` will report nil pointer error.