### PR TITLE
eth/downloader: make flakey test less flakey

### DIFF
--- a/eth/downloader/skeleton_test.go
+++ b/eth/downloader/skeleton_test.go
@@ -803,7 +803,7 @@ func TestSkeletonSyncRetrievals(t *testing.T) {
 		}
 
 		waitStart := time.Now()
-		for waitTime := 20 * time.Millisecond; time.Since(waitStart) < time.Second; waitTime = waitTime * 2 {
+		for waitTime := 20 * time.Millisecond; time.Since(waitStart) < 2*time.Second; waitTime = waitTime * 2 {
 			time.Sleep(waitTime)
 			// Check the post-init end state if it matches the required results
 			json.Unmarshal(rawdb.ReadSkeletonSyncStatus(db), &progress)
@@ -855,7 +855,7 @@ func TestSkeletonSyncRetrievals(t *testing.T) {
 			return nil
 		}
 		waitStart = time.Now()
-		for waitTime := 20 * time.Millisecond; time.Since(waitStart) < time.Second; waitTime = waitTime * 2 {
+		for waitTime := 20 * time.Millisecond; time.Since(waitStart) < 2*time.Second; waitTime = waitTime * 2 {
 			time.Sleep(waitTime)
 			// Check the post-init end state if it matches the required results
 			json.Unmarshal(rawdb.ReadSkeletonSyncStatus(db), &progress)


### PR DESCRIPTION
This PR tries to fix these which fail on CI from time to time: 

```
ok  	github.com/ethereum/go-ethereum/crypto/signify	0.079s	coverage: 83.8% of statements
ok  	github.com/ethereum/go-ethereum/eth	12.955s	coverage: 28.4% of statements
ok  	github.com/ethereum/go-ethereum/eth/catalyst	2.262s	coverage: 63.4% of statements
--- FAIL: TestSkeletonSyncRetrievals (1.84s)
    skeleton_test.go:830: test 6, mid state: dropped peers mismatch: have 0, want 1
FAIL
coverage: 76.2% of statements
FAIL	github.com/ethereum/go-ethereum/eth/downloader	160.461s
?   	github.com/ethereum/go-ethereum/eth/ethconfig	[no test files]

```
I think the err above simply happens because the CH machines are too slow, we need to give them some more time to reach the desired state. This PR bumps a timeout from one to two seconds.  