### PR TITLE
In some cases, the value of the input string s may come in odd length…

### DIFF
--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -714,6 +714,9 @@ func decodeHash(s string) (common.Hash, error) {
 	if strings.HasPrefix(s, "0x") || strings.HasPrefix(s, "0X") {
 		s = s[2:]
 	}
+	if (len(s) & 1) > 0 {
+		s = "0" + s
+	}
 	b, err := hex.DecodeString(s)
 	if err != nil {
 		return common.Hash{}, fmt.Errorf("hex string invalid")


### PR DESCRIPTION
… and in this case, an error occurred in the hex.DecodeString function, causing the problem of not being able to proceed next in many case, in the case of me, the problem of not being able to read the value of getStorageAt occurred