### PR TITLE
internal/ethapi: handle odd length hex in decodeHash

### DIFF
--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -714,6 +714,9 @@ func decodeHash(s string) (common.Hash, error) {
 	if strings.HasPrefix(s, "0x") || strings.HasPrefix(s, "0X") {
 		s = s[2:]
 	}
+	if (len(s) & 1) > 0 {
+		s = "0" + s
+	}
 	b, err := hex.DecodeString(s)
 	if err != nil {
 		return common.Hash{}, fmt.Errorf("hex string invalid")


### PR DESCRIPTION
This PR is for fixing bug.

This problem is causing problems everywhere using the decodeHash() function.
In some cases, the length of the string s, that is, the length of the hash, is odd like (0x6). 

In this case, the request fails with the following message.
"unable to decode storage key: hex string invalid"

In the case I experienced, it always failed to print out the above message when calling a function in a forked network through a hardhat.