### PR TITLE
eth/downloader: optimize downloader.queue

### DIFF
--- a/eth/downloader/fetchers_concurrent_headers.go
+++ b/eth/downloader/fetchers_concurrent_headers.go
@@ -54,8 +54,8 @@ func (q *headerQueue) updateCapacity(peer *peerConnection, items int, span time.
 
 // reserve is responsible for allocating a requested number of pending headers
 // from the download queue to the specified peer.
-func (q *headerQueue) reserve(peer *peerConnection, items int) (*fetchRequest, bool, bool) {
-	return q.queue.ReserveHeaders(peer, items), false, false
+func (q *headerQueue) reserve(peer *peerConnection, _ int) (*fetchRequest, bool, bool) {
+	return q.queue.Reserve1SkeletonHeader(peer), false, false
 }
 
 // unreserve is responsible for removing the current header retrieval allocation

--- a/eth/downloader/queue.go
+++ b/eth/downloader/queue.go
@@ -411,9 +411,9 @@ func (q *queue) stats() []interface{} {
 	}
 }
 
-// ReserveHeaders reserves a set of headers for the given peer, skipping any
+// Reserve1SkeletonHeader reserves a single skeleton headers for the given peer, skipping any
 // previously failed batches.
-func (q *queue) ReserveHeaders(p *peerConnection, count int) *fetchRequest {
+func (q *queue) Reserve1SkeletonHeader(p *peerConnection) *fetchRequest {
 	q.lock.Lock()
 	defer q.lock.Unlock()
 
@@ -424,7 +424,7 @@ func (q *queue) ReserveHeaders(p *peerConnection, count int) *fetchRequest {
 	}
 	// Retrieve a batch of hashes, skipping previously failed ones
 	send, skip := uint64(0), []uint64{}
-	for send == 0 && !q.headerTaskQueue.Empty() {
+	for !q.headerTaskQueue.Empty() {
 		from, _ := q.headerTaskQueue.Pop()
 		if q.headerPeerMiss[p.id] != nil {
 			if _, ok := q.headerPeerMiss[p.id][from.(uint64)]; ok {
@@ -433,6 +433,7 @@ func (q *queue) ReserveHeaders(p *peerConnection, count int) *fetchRequest {
 			}
 		}
 		send = from.(uint64)
+		break
 	}
 	// Merge all the skipped batches back
 	for _, from := range skip {

--- a/eth/downloader/queue.go
+++ b/eth/downloader/queue.go
@@ -645,6 +645,7 @@ func (q *queue) expire(peer string, pendPool map[string]*fetchRequest, taskQueue
 	// Return any non-satisfied requests to the pool
 	if req.From > 0 {
 		taskQueue.Push(req.From, -int64(req.From))
+		// the invariant is that req.From > 0(for headers) and len(req.Headers) > 0(for bodies and receipts) can't both be true
 		return 1
 	}
 	for _, header := range req.Headers {

--- a/eth/downloader/queue.go
+++ b/eth/downloader/queue.go
@@ -645,6 +645,7 @@ func (q *queue) expire(peer string, pendPool map[string]*fetchRequest, taskQueue
 	// Return any non-satisfied requests to the pool
 	if req.From > 0 {
 		taskQueue.Push(req.From, -int64(req.From))
+		return 1
 	}
 	for _, header := range req.Headers {
 		taskQueue.Push(header, -int64(header.Number.Uint64()))

--- a/eth/downloader/queue.go
+++ b/eth/downloader/queue.go
@@ -411,7 +411,7 @@ func (q *queue) stats() []interface{} {
 	}
 }
 
-// Reserve1SkeletonHeader reserves a single skeleton headers for the given peer, skipping any
+// Reserve1SkeletonHeader reserves a single skeleton header for the given peer, skipping any
 // previously failed batches.
 func (q *queue) Reserve1SkeletonHeader(p *peerConnection) *fetchRequest {
 	q.lock.Lock()


### PR DESCRIPTION
Rename `queue.ReserveHeaders` to `queue.Reserve1SkeletonHeader` so that the name matches with the implementation.

And zero is never pushed into `headerTaskQueue`, it's safe to just break the loop after getting the first un-skipped height.

Also fixed the return value for `ExpireHeaders`(previously it always returns 0 IMO) and added some comment about the invariant of `fetchRequest`.

The first time I saw this code snippet:

```
	// Return any non-satisfied requests to the pool
	if req.From > 0 {
		taskQueue.Push(req.From, -int64(req.From))
	}
	for _, header := range req.Headers {
		taskQueue.Push(header, -int64(header.Number.Uint64()))
	}
```

I was wondering how can `uint64` and `*types.Header` be pushed into the same `taskQueue` and confidently type cast the retrieved value to `*types.Header` in some place).