### PR TITLE
core: fix reindex tx after crashing

### DIFF
--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -2294,7 +2294,7 @@ func (bc *BlockChain) indexBlocks(tail *uint64, head uint64, done chan struct{})
 			from = head - bc.txLookupLimit + 1
 		}
 		rawdb.IndexTransactions(bc.db, from, head+1, bc.quit)
-		rawdb.WriteTxIndexTail(bc.db, 0)
+		rawdb.WriteTxIndexTail(bc.db, from)
 		return
 	}
 	// The tail flag is existent, but the whole chain is required to be indexed.

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -1211,7 +1211,7 @@ func (bc *BlockChain) InsertReceiptChain(blockChain types.Blocks, receiptChain [
 		// * ancient-limit: the indices of blocks before ancient-limit are ignored
 		if tail := rawdb.ReadTxIndexTail(bc.db); tail == nil {
 			if bc.txLookupLimit == 0 || ancientLimit <= bc.txLookupLimit {
-				rawdb.WriteTxIndexTail(bc.db, 0)
+				//rawdb.WriteTxIndexTail(bc.db, 0)
 			} else {
 				rawdb.WriteTxIndexTail(bc.db, ancientLimit-bc.txLookupLimit)
 			}
@@ -2294,6 +2294,7 @@ func (bc *BlockChain) indexBlocks(tail *uint64, head uint64, done chan struct{})
 			from = head - bc.txLookupLimit + 1
 		}
 		rawdb.IndexTransactions(bc.db, from, head+1, bc.quit)
+		rawdb.WriteTxIndexTail(bc.db, 0)
 		return
 	}
 	// The tail flag is existent, but the whole chain is required to be indexed.


### PR DESCRIPTION
Only set ```tail ``` when reindex completed for the first time