### PR TITLE
core/rawdb: refactor db inspector for extending multiple ancient store

### DIFF
--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -64,7 +64,6 @@ var (
 	storageReadTimer   = metrics.NewRegisteredTimer("chain/storage/reads", nil)
 	storageHashTimer   = metrics.NewRegisteredTimer("chain/storage/hashes", nil)
 	storageUpdateTimer = metrics.NewRegisteredTimer("chain/storage/updates", nil)
-	storageDeleteTimer = metrics.NewRegisteredTimer("chain/storage/deletes", nil)
 	storageCommitTimer = metrics.NewRegisteredTimer("chain/storage/commits", nil)
 
 	snapshotAccountReadTimer = metrics.NewRegisteredTimer("chain/snapshot/account/reads", nil)
@@ -1717,12 +1716,11 @@ func (bc *BlockChain) insertChain(chain types.Blocks, verifySeals, setHead bool)
 		storageReadTimer.Update(statedb.StorageReads)                 // Storage reads are complete, we can mark them
 		accountUpdateTimer.Update(statedb.AccountUpdates)             // Account updates are complete, we can mark them
 		storageUpdateTimer.Update(statedb.StorageUpdates)             // Storage updates are complete, we can mark them
-		storageDeleteTimer.Update(statedb.StorageDeletes)             // Storage deletes are complete, we can mark them
 		snapshotAccountReadTimer.Update(statedb.SnapshotAccountReads) // Account reads are complete, we can mark them
 		snapshotStorageReadTimer.Update(statedb.SnapshotStorageReads) // Storage reads are complete, we can mark them
 		triehash := statedb.AccountHashes + statedb.StorageHashes     // Save to not double count in validation
 		trieproc := statedb.SnapshotAccountReads + statedb.AccountReads + statedb.AccountUpdates
-		trieproc += statedb.SnapshotStorageReads + statedb.StorageReads + statedb.StorageUpdates + statedb.StorageDeletes
+		trieproc += statedb.SnapshotStorageReads + statedb.StorageReads + statedb.StorageUpdates
 
 		blockExecutionTimer.Update(time.Since(substart) - trieproc - triehash)
 

--- a/core/blockchain_test.go
+++ b/core/blockchain_test.go
@@ -4086,15 +4086,8 @@ func testCreateThenDelete(t *testing.T, config *params.ChainConfig) {
 	if err != nil {
 		t.Fatalf("failed to create tester chain: %v", err)
 	}
-	// First block tries to create, but fails
-	{
-		block := blocks[0]
-		if _, err := chain.InsertChain([]*types.Block{blocks[0]}); err != nil {
-			t.Fatalf("block %d: failed to insert into chain: %v", block.NumberU64(), err)
-		}
-	}
-	// Import the rest of the blocks
-	for _, block := range blocks[1:] {
+	// Import the blocks
+	for _, block := range blocks {
 		if _, err := chain.InsertChain([]*types.Block{block}); err != nil {
 			t.Fatalf("block %d: failed to insert into chain: %v", block.NumberU64(), err)
 		}

--- a/core/blockchain_test.go
+++ b/core/blockchain_test.go
@@ -4007,3 +4007,96 @@ func TestTxIndexer(t *testing.T) {
 		os.RemoveAll(frdir)
 	}
 }
+
+func TestCreateThenDeletePreByzantium(t *testing.T) {
+	// We use Ropsten chain config instead of Testchain config, this is
+	// deliberate: we want to use pre-byz rules where we have intermediate state roots
+	// between transactions.
+	testCreateThenDelete(t, params.RopstenChainConfig)
+}
+func TestCreateThenDeletePostByzantium(t *testing.T) {
+	testCreateThenDelete(t, params.TestChainConfig)
+}
+
+// testCreateThenDelete tests a creation and subsequent deletion of a contract, happening
+// within the same block.
+func testCreateThenDelete(t *testing.T, config *params.ChainConfig) {
+	var (
+		engine = ethash.NewFaker()
+		// A sender who makes transactions, has some funds
+		key, _      = crypto.HexToECDSA("b71c71a67e1177ad4e901695e1b4b9ee17ae16c6668d313eac2f96dbcda3f291")
+		address     = crypto.PubkeyToAddress(key.PublicKey)
+		destAddress = crypto.CreateAddress(address, 0)
+		funds       = big.NewInt(1000000000000000)
+	)
+
+	// runtime code is 	0x60ffff : PUSH1 0xFF SELFDESTRUCT, a.k.a SELFDESTRUCT(0xFF)
+	code := append([]byte{0x60, 0xff, 0xff}, make([]byte, 32-3)...)
+	initCode := []byte{
+		// SSTORE 1:1
+		byte(vm.PUSH1), 0x1,
+		byte(vm.PUSH1), 0x1,
+		byte(vm.SSTORE),
+		// Get the runtime-code on the stack
+		byte(vm.PUSH32)}
+	initCode = append(initCode, code...)
+	initCode = append(initCode, []byte{
+		byte(vm.PUSH1), 0x0, // offset
+		byte(vm.MSTORE),
+		byte(vm.PUSH1), 0x3, // size
+		byte(vm.PUSH1), 0x0, // offset
+		byte(vm.RETURN), // return 3 bytes of zero-code
+	}...)
+	gspec := &Genesis{
+		Config: config,
+		Alloc: GenesisAlloc{
+			address: {Balance: funds},
+		},
+	}
+	nonce := uint64(0)
+	signer := types.HomesteadSigner{}
+	_, blocks, _ := GenerateChainWithGenesis(gspec, engine, 2, func(i int, b *BlockGen) {
+		fee := big.NewInt(1)
+		if b.header.BaseFee != nil {
+			fee = b.header.BaseFee
+		}
+		b.SetCoinbase(common.Address{1})
+		tx, _ := types.SignNewTx(key, signer, &types.LegacyTx{
+			Nonce:    nonce,
+			GasPrice: new(big.Int).Set(fee),
+			Gas:      100000,
+			Data:     initCode,
+		})
+		nonce++
+		b.AddTx(tx)
+		tx, _ = types.SignNewTx(key, signer, &types.LegacyTx{
+			Nonce:    nonce,
+			GasPrice: new(big.Int).Set(fee),
+			Gas:      100000,
+			To:       &destAddress,
+		})
+		b.AddTx(tx)
+		nonce++
+	})
+	// Import the canonical chain
+	chain, err := NewBlockChain(rawdb.NewMemoryDatabase(), nil, gspec, nil, engine, vm.Config{
+		//Debug:  true,
+		//Tracer: logger.NewJSONLogger(nil, os.Stdout),
+	}, nil, nil)
+	if err != nil {
+		t.Fatalf("failed to create tester chain: %v", err)
+	}
+	// First block tries to create, but fails
+	{
+		block := blocks[0]
+		if _, err := chain.InsertChain([]*types.Block{blocks[0]}); err != nil {
+			t.Fatalf("block %d: failed to insert into chain: %v", block.NumberU64(), err)
+		}
+	}
+	// Import the rest of the blocks
+	for _, block := range blocks[1:] {
+		if _, err := chain.InsertChain([]*types.Block{block}); err != nil {
+			t.Fatalf("block %d: failed to insert into chain: %v", block.NumberU64(), err)
+		}
+	}
+}

--- a/core/rawdb/ancient_scheme.go
+++ b/core/rawdb/ancient_scheme.go
@@ -16,8 +16,6 @@
 
 package rawdb
 
-import "fmt"
-
 // The list of table names of chain freezer.
 const (
 	// chainFreezerHeaderTable indicates the name of the freezer header table.
@@ -53,34 +51,3 @@ var (
 
 // freezers the collections of all builtin freezers.
 var freezers = []string{chainFreezerName}
-
-// InspectFreezerTable dumps out the index of a specific freezer table. The passed
-// ancient indicates the path of root ancient directory where the chain freezer can
-// be opened. Start and end specify the range for dumping out indexes.
-// Note this function can only be used for debugging purposes.
-func InspectFreezerTable(ancient string, freezerName string, tableName string, start, end int64) error {
-	var (
-		path   string
-		tables map[string]bool
-	)
-	switch freezerName {
-	case chainFreezerName:
-		path, tables = resolveChainFreezerDir(ancient), chainFreezerNoSnappy
-	default:
-		return fmt.Errorf("unknown freezer, supported ones: %v", freezers)
-	}
-	noSnappy, exist := tables[tableName]
-	if !exist {
-		var names []string
-		for name := range tables {
-			names = append(names, name)
-		}
-		return fmt.Errorf("unknown table, supported ones: %v", names)
-	}
-	table, err := newFreezerTable(path, tableName, noSnappy, true)
-	if err != nil {
-		return err
-	}
-	table.dumpIndexStdout(start, end)
-	return nil
-}

--- a/core/rawdb/ancient_utils.go
+++ b/core/rawdb/ancient_utils.go
@@ -1,0 +1,134 @@
+// Copyright 2022 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+package rawdb
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/ethdb"
+)
+
+// freezerInfo contains the basic information of the freezer.
+type freezerInfo struct {
+	name  string                        // The identifier of freezer
+	head  uint64                        // The number of last stored item in the freezer
+	tail  uint64                        // The number of first stored item in the freezer
+	sizes map[string]common.StorageSize // The storage size per table
+}
+
+// count returns the number of stored items in the freezer.
+func (info freezerInfo) count() uint64 {
+	return info.head - info.tail + 1
+}
+
+// totalSize returns the storage size of entire freezer.
+func (info freezerInfo) totalSize() common.StorageSize {
+	var total common.StorageSize
+	for _, size := range info.sizes {
+		total += size
+	}
+	return total
+}
+
+// summary returns a string-representation of the freezerInfo.
+func (info freezerInfo) summary() [][]string {
+	var ret [][]string
+	for table, size := range info.sizes {
+		ret = append(ret, []string{
+			fmt.Sprintf("Ancient store (%s)", strings.Title(info.name)),
+			strings.Title(table),
+			size.String(),
+			fmt.Sprintf("%d", info.count()),
+		})
+	}
+	return ret
+}
+
+// inspectFreezers inspects all freezers registered in the system.
+func inspectFreezers(db ethdb.Database) ([]freezerInfo, error) {
+	var infos []freezerInfo
+	for _, freezer := range freezers {
+		switch freezer {
+		case chainFreezerName:
+			// Chain ancient store is a bit special. It's always opened along
+			// with the key-value store, inspect the chain store directly.
+			info := freezerInfo{
+				name:  freezer,
+				sizes: make(map[string]common.StorageSize),
+			}
+			// Retrieve storage size of every contained table.
+			for table := range chainFreezerNoSnappy {
+				size, err := db.AncientSize(table)
+				if err != nil {
+					return nil, err
+				}
+				info.sizes[table] = common.StorageSize(size)
+			}
+			// Retrieve the number of last stored item
+			ancients, err := db.Ancients()
+			if err != nil {
+				return nil, err
+			}
+			info.head = ancients - 1
+
+			// Retrieve the number of first stored item
+			tail, err := db.Tail()
+			if err != nil {
+				return nil, err
+			}
+			info.tail = tail
+			infos = append(infos, info)
+
+		default:
+			return nil, fmt.Errorf("unknown freezer, supported ones: %v", freezers)
+		}
+	}
+	return infos, nil
+}
+
+// InspectFreezerTable dumps out the index of a specific freezer table. The passed
+// ancient indicates the path of root ancient directory where the chain freezer can
+// be opened. Start and end specify the range for dumping out indexes.
+// Note this function can only be used for debugging purposes.
+func InspectFreezerTable(ancient string, freezerName string, tableName string, start, end int64) error {
+	var (
+		path   string
+		tables map[string]bool
+	)
+	switch freezerName {
+	case chainFreezerName:
+		path, tables = resolveChainFreezerDir(ancient), chainFreezerNoSnappy
+	default:
+		return fmt.Errorf("unknown freezer, supported ones: %v", freezers)
+	}
+	noSnappy, exist := tables[tableName]
+	if !exist {
+		var names []string
+		for name := range tables {
+			names = append(names, name)
+		}
+		return fmt.Errorf("unknown table, supported ones: %v", names)
+	}
+	table, err := newFreezerTable(path, tableName, noSnappy, true)
+	if err != nil {
+		return err
+	}
+	table.dumpIndexStdout(start, end)
+	return nil
+}

--- a/core/rawdb/database.go
+++ b/core/rawdb/database.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"os"
 	"path"
+	"strings"
 	"sync/atomic"
 	"time"
 
@@ -493,8 +494,15 @@ func InspectDatabase(db ethdb.Database, keyPrefix, keyStart []byte) error {
 		return err
 	}
 	for _, ancient := range ancients {
-		stats = append(stats, ancient.summary()...)
-		total += ancient.totalSize()
+		for _, table := range ancient.sizes {
+			stats = append(stats, []string{
+				fmt.Sprintf("Ancient store (%s)", strings.Title(ancient.name)),
+				strings.Title(table.name),
+				table.size.String(),
+				fmt.Sprintf("%d", ancient.count()),
+			})
+		}
+		total += ancient.size()
 	}
 	table := tablewriter.NewWriter(os.Stdout)
 	table.SetHeader([]string{"Database", "Category", "Size", "Items"})

--- a/core/rawdb/database.go
+++ b/core/rawdb/database.go
@@ -379,13 +379,6 @@ func InspectDatabase(db ethdb.Database, keyPrefix, keyStart []byte) error {
 		beaconHeaders   stat
 		cliqueSnaps     stat
 
-		// Ancient store statistics
-		ancientHeadersSize  common.StorageSize
-		ancientBodiesSize   common.StorageSize
-		ancientReceiptsSize common.StorageSize
-		ancientTdsSize      common.StorageSize
-		ancientHashesSize   common.StorageSize
-
 		// Les statistic
 		chtTrieNodes   stat
 		bloomTrieNodes stat
@@ -473,20 +466,7 @@ func InspectDatabase(db ethdb.Database, keyPrefix, keyStart []byte) error {
 			logged = time.Now()
 		}
 	}
-	// Inspect append-only file store then.
-	ancientSizes := []*common.StorageSize{&ancientHeadersSize, &ancientBodiesSize, &ancientReceiptsSize, &ancientHashesSize, &ancientTdsSize}
-	for i, category := range []string{chainFreezerHeaderTable, chainFreezerBodiesTable, chainFreezerReceiptTable, chainFreezerHashTable, chainFreezerDifficultyTable} {
-		if size, err := db.AncientSize(category); err == nil {
-			*ancientSizes[i] += common.StorageSize(size)
-			total += common.StorageSize(size)
-		}
-	}
-	// Get number of ancient rows inside the freezer
-	ancients := counter(0)
-	if count, err := db.Ancients(); err == nil {
-		ancients = counter(count)
-	}
-	// Display the database statistic.
+	// Display the database statistic of key-value store.
 	stats := [][]string{
 		{"Key-Value store", "Headers", headers.Size(), headers.Count()},
 		{"Key-Value store", "Bodies", bodies.Size(), bodies.Count()},
@@ -504,13 +484,17 @@ func InspectDatabase(db ethdb.Database, keyPrefix, keyStart []byte) error {
 		{"Key-Value store", "Beacon sync headers", beaconHeaders.Size(), beaconHeaders.Count()},
 		{"Key-Value store", "Clique snapshots", cliqueSnaps.Size(), cliqueSnaps.Count()},
 		{"Key-Value store", "Singleton metadata", metadata.Size(), metadata.Count()},
-		{"Ancient store", "Headers", ancientHeadersSize.String(), ancients.String()},
-		{"Ancient store", "Bodies", ancientBodiesSize.String(), ancients.String()},
-		{"Ancient store", "Receipt lists", ancientReceiptsSize.String(), ancients.String()},
-		{"Ancient store", "Difficulties", ancientTdsSize.String(), ancients.String()},
-		{"Ancient store", "Block number->hash", ancientHashesSize.String(), ancients.String()},
 		{"Light client", "CHT trie nodes", chtTrieNodes.Size(), chtTrieNodes.Count()},
 		{"Light client", "Bloom trie nodes", bloomTrieNodes.Size(), bloomTrieNodes.Count()},
+	}
+	// Inspect all registered append-only file store then.
+	ancients, err := inspectFreezers(db)
+	if err != nil {
+		return err
+	}
+	for _, ancient := range ancients {
+		stats = append(stats, ancient.summary()...)
+		total += ancient.totalSize()
 	}
 	table := tablewriter.NewWriter(os.Stdout)
 	table.SetHeader([]string{"Database", "Category", "Size", "Items"})
@@ -521,6 +505,5 @@ func InspectDatabase(db ethdb.Database, keyPrefix, keyStart []byte) error {
 	if unaccounted.size > 0 {
 		log.Error("Database contains unaccounted data", "size", unaccounted.size, "count", unaccounted.count)
 	}
-
 	return nil
 }

--- a/core/state/state_object.go
+++ b/core/state/state_object.go
@@ -395,6 +395,43 @@ func (s *stateObject) CommitTrie(db Database) (*trie.NodeSet, error) {
 	return nodes, err
 }
 
+// DeleteTrie the storage trie of the object from db.
+func (s *stateObject) DeleteTrie(db Database) (*trie.NodeSet, error) {
+	// Track the amount of time wasted on iterating and deleting the storage trie
+	if metrics.EnabledExpensive {
+		defer func(start time.Time) { s.db.StorageDeletes += time.Since(start) }(time.Now())
+	}
+	stTrie, err := db.OpenStorageTrie(s.db.originalRoot, s.addrHash, s.data.Root)
+	if err != nil {
+		return nil, err
+	}
+	// It can be an attack vector when iterating a huge contract. Stop collecting
+	// in case the accumulated nodes reach the threshold. It's fine to not clean
+	// up the dangling trie nodes since they are non-accessible dangling nodes
+	// anyway.
+	var (
+		paths [][]byte
+		blobs [][]byte
+		size  common.StorageSize
+		iter  = stTrie.NodeIterator(nil)
+	)
+	for iter.Next(true) {
+		if iter.Hash() == (common.Hash{}) {
+			continue
+		}
+		path, blob := common.CopyBytes(iter.Path()), common.CopyBytes(iter.NodeBlob())
+		paths = append(paths, path)
+		blobs = append(blobs, blob)
+
+		// Pretty arbitrary number, approximately 1GB as the threshold
+		size += common.StorageSize(len(path) + len(blob))
+		if size > 1073741824 {
+			return nil, nil
+		}
+	}
+	return trie.NewNodeSetWithDeletion(s.addrHash, paths, blobs), nil
+}
+
 // AddBalance adds amount to s's balance.
 // It is used to add funds to the destination account of a transfer.
 func (s *stateObject) AddBalance(amount *big.Int) {

--- a/core/state/state_object.go
+++ b/core/state/state_object.go
@@ -374,8 +374,8 @@ func (s *stateObject) updateRoot(db Database) {
 	s.data.Root = s.trie.Hash()
 }
 
-// CommitTrie the storage trie of the object to db.
-// This updates the trie root.
+// CommitTrie submits the storage changes into the storage trie and re-computes
+// the root. Besides, all trie changes will be collected in a nodeset and returned.
 func (s *stateObject) CommitTrie(db Database) (*trie.NodeSet, error) {
 	// If nothing changed, don't bother with hashing anything
 	if s.updateTrie(db) == nil {
@@ -395,7 +395,8 @@ func (s *stateObject) CommitTrie(db Database) (*trie.NodeSet, error) {
 	return nodes, err
 }
 
-// DeleteTrie the storage trie of the object from db.
+// DeleteTrie collects all storage trie nodes of the object and returns a nodeset
+// which marks them as deleted.
 func (s *stateObject) DeleteTrie(db Database) (*trie.NodeSet, error) {
 	// Track the amount of time wasted on iterating and deleting the storage trie
 	if metrics.EnabledExpensive {

--- a/core/state/statedb.go
+++ b/core/state/statedb.go
@@ -921,7 +921,7 @@ func (s *StateDB) Commit(deleteEmptyObjects bool) (common.Hash, error) {
 				obj.dirtyCode = false
 			}
 			// Write any storage changes in the state object to its storage trie
-			set, err := obj.CommitTrie(s.db)
+			set, err := obj.commitTrie(s.db)
 			if err != nil {
 				return common.Hash{}, err
 			}
@@ -934,20 +934,13 @@ func (s *StateDB) Commit(deleteEmptyObjects bool) (common.Hash, error) {
 				storageTrieNodesUpdated += updates
 				storageTrieNodesDeleted += deleted
 			}
-		} else {
-			// Account is deleted, nuke out the storage data as well.
-			set, err := obj.DeleteTrie(s.db)
-			if err != nil {
-				return common.Hash{}, err
-			}
-			if set != nil {
-				if err := nodes.Merge(set); err != nil {
-					return common.Hash{}, err
-				}
-				_, deleted := set.Size()
-				storageTrieNodesDeleted += deleted
-			}
 		}
+		// If the contract is destructed, the storage is still left in the
+		// database as dangling data. Theoretically it's should be wiped from
+		// database as well, but in hash-based-scheme it's extremely hard to
+		// determine that if the trie nodes are also referenced by other storage,
+		// and in path-based-scheme some technical challenges are still unsolved.
+		// Although it won't affect the correctness but please fix it TODO(rjl493456442).
 	}
 	if len(s.stateObjectsDirty) > 0 {
 		s.stateObjectsDirty = make(map[common.Address]struct{})

--- a/core/state/statedb.go
+++ b/core/state/statedb.go
@@ -117,7 +117,6 @@ type StateDB struct {
 	StorageHashes        time.Duration
 	StorageUpdates       time.Duration
 	StorageCommits       time.Duration
-	StorageDeletes       time.Duration
 	SnapshotAccountReads time.Duration
 	SnapshotStorageReads time.Duration
 	SnapshotCommits      time.Duration

--- a/trie/nodeset.go
+++ b/trie/nodeset.go
@@ -113,6 +113,7 @@ func NewNodeSet(owner common.Hash) *NodeSet {
 	}
 }
 
+/*
 // NewNodeSetWithDeletion initializes the nodeset with provided deletion set.
 func NewNodeSetWithDeletion(owner common.Hash, paths [][]byte, prev [][]byte) *NodeSet {
 	set := NewNodeSet(owner)
@@ -121,6 +122,7 @@ func NewNodeSetWithDeletion(owner common.Hash, paths [][]byte, prev [][]byte) *N
 	}
 	return set
 }
+*/
 
 // markUpdated marks the node as dirty(newly-inserted or updated) with provided
 // node path, node object along with its previous value.


### PR DESCRIPTION
This PR ports a few changes from PBSS

- ~The storage trie nodes of destructed contract will be marked as deleted~
- Fix the snapshot generator waiter in case the generation is not even initialized
- Refactor db inspector for ancient store

After the refactor, now inspector looks like 

```
+-----------------------+---------------------+------------+--------+
|       DATABASE        |      CATEGORY       |    SIZE    | ITEMS  |
+-----------------------+---------------------+------------+--------+
| Key-Value store       | Headers             | 576.00 B   |      1 |
| Key-Value store       | Bodies              | 44.00 B    |      1 |
| Key-Value store       | Receipt lists       | 42.00 B    |      1 |
| Key-Value store       | Difficulties        | 212.00 B   |      3 |
| Key-Value store       | Block number->hash  | 453.00 B   |      3 |
| Key-Value store       | Block hash->number  | 11.19 MiB  | 286075 |
| Key-Value store       | Transaction index   | 0.00 B     |      0 |
| Key-Value store       | Bloombit index      | 5.82 MiB   | 141382 |
| Key-Value store       | Contract codes      | 1.30 MiB   |    743 |
| Key-Value store       | Trie nodes          | 11.45 MiB  |  95278 |
| Key-Value store       | Trie preimages      | 547.13 KiB |   8893 |
| Key-Value store       | Account snapshot    | 1.69 MiB   |  36542 |
| Key-Value store       | Storage snapshot    | 2.52 MiB   |  35341 |
| Key-Value store       | Beacon sync headers | 0.00 B     |      0 |
| Key-Value store       | Clique snapshots    | 0.00 B     |      0 |
| Key-Value store       | Singleton metadata  | 695.06 KiB |     10 |
| Light client          | CHT trie nodes      | 0.00 B     |      0 |
| Light client          | Bloom trie nodes    | 0.00 B     |      0 |
| Ancient store (Chain) | Headers             | 82.31 MiB  | 286075 |
| Ancient store (Chain) | Hashes              | 10.37 MiB  | 286075 |
| Ancient store (Chain) | Bodies              | 33.41 MiB  | 286075 |
| Ancient store (Chain) | Receipts            | 10.95 MiB  | 286075 |
| Ancient store (Chain) | Diffs               | 4.03 MiB   | 286075 |
+-----------------------+---------------------+------------+--------+
|                                TOTAL        | 176.25 MIB |        |
+-----------------------+---------------------+------------+--------+
ERROR[09-30|13:10:16.045] Database contains unaccounted data       size=2.87KiB count=1
```