### PR TITLE
docs: fix mascot sizing on homepage

### DIFF
--- a/index.html
+++ b/index.html
@@ -15,7 +15,7 @@ css:
     </div>
 
     <div class="container mascot-mobile">
-      <img src="./static/images/mascot.png" alt="Geth mascot" height="200px" />
+      <img src="./static/images/mascot.png" alt="Geth mascot" height="auto" />
     </div>
 
     <div class="container marketing">

--- a/static/styles/custom/common.css
+++ b/static/styles/custom/common.css
@@ -69,7 +69,6 @@ table thead tr th, table tbody tr td {
 
 
 img{
-    width: 300px; 
     margin-top: 2rem;
     margin-bottom: 2rem
 }


### PR DESCRIPTION
Mascot on homepage was rendering too wide because image height and width were both hardcoded. This removes the hardcoded values which should enable the image to dynamically size.