### PR TITLE
eth/filter: real time exceed deadline filters removal

### DIFF
--- a/eth/filters/api.go
+++ b/eth/filters/api.go
@@ -106,6 +106,7 @@ func (api *FilterAPI) NewPendingTransactionFilter() rpc.ID {
 	api.filters[pendingTxSub.ID] = &filter{typ: PendingTransactionsSubscription, deadline: deadline, hashes: make([]common.Hash, 0), s: pendingTxSub}
 	api.filtersMu.Unlock()
 
+	defer deadline.Stop()
 	go func() {
 		for {
 			select {
@@ -116,7 +117,6 @@ func (api *FilterAPI) NewPendingTransactionFilter() rpc.ID {
 				}
 				api.filtersMu.Unlock()
 			case <-deadline.C:
-				deadline.Stop()
 				api.sys.deadlineCh <- pendingTxSub.ID
 				return
 			case <-pendingTxSub.Err():
@@ -179,6 +179,7 @@ func (api *FilterAPI) NewBlockFilter() rpc.ID {
 	api.filters[headerSub.ID] = &filter{typ: BlocksSubscription, deadline: deadline, hashes: make([]common.Hash, 0), s: headerSub}
 	api.filtersMu.Unlock()
 
+	defer deadline.Stop()
 	go func() {
 		for {
 			select {
@@ -189,7 +190,6 @@ func (api *FilterAPI) NewBlockFilter() rpc.ID {
 				}
 				api.filtersMu.Unlock()
 			case <-deadline.C:
-				deadline.Stop()
 				api.sys.deadlineCh <- headerSub.ID
 				return
 			case <-headerSub.Err():
@@ -302,6 +302,7 @@ func (api *FilterAPI) NewFilter(crit FilterCriteria) (rpc.ID, error) {
 	api.filters[logsSub.ID] = &filter{typ: LogsSubscription, crit: crit, deadline: deadline, logs: make([]*types.Log, 0), s: logsSub}
 	api.filtersMu.Unlock()
 
+	defer deadline.Stop()
 	go func() {
 		for {
 			select {
@@ -312,7 +313,6 @@ func (api *FilterAPI) NewFilter(crit FilterCriteria) (rpc.ID, error) {
 				}
 				api.filtersMu.Unlock()
 			case <-deadline.C:
-				deadline.Stop()
 				api.sys.deadlineCh <- logsSub.ID
 				return
 			case <-logsSub.Err():

--- a/eth/filters/api.go
+++ b/eth/filters/api.go
@@ -69,9 +69,10 @@ func NewFilterAPI(system *FilterSystem, lightMode bool) *FilterAPI {
 // timeoutLoop deletes filters that reached the deadline.
 // It is started when the API is created.
 func (api *FilterAPI) timeoutLoop() {
-	var toUninstall *Subscription
 	for {
 		go func(id rpc.ID) {
+			var toUninstall *Subscription
+
 			api.filtersMu.Lock()
 			if f, ok := api.filters[id]; ok {
 				toUninstall = f.s
@@ -85,7 +86,6 @@ func (api *FilterAPI) timeoutLoop() {
 			if toUninstall != nil {
 				toUninstall.Unsubscribe()
 			}
-			toUninstall = nil
 		}(<-api.sys.deadlineCh)
 	}
 }

--- a/eth/filters/api.go
+++ b/eth/filters/api.go
@@ -106,8 +106,8 @@ func (api *FilterAPI) NewPendingTransactionFilter() rpc.ID {
 	api.filters[pendingTxSub.ID] = &filter{typ: PendingTransactionsSubscription, deadline: deadline, hashes: make([]common.Hash, 0), s: pendingTxSub}
 	api.filtersMu.Unlock()
 
-	defer deadline.Stop()
 	go func() {
+		defer deadline.Stop()
 		for {
 			select {
 			case ph := <-pendingTxs:
@@ -179,8 +179,8 @@ func (api *FilterAPI) NewBlockFilter() rpc.ID {
 	api.filters[headerSub.ID] = &filter{typ: BlocksSubscription, deadline: deadline, hashes: make([]common.Hash, 0), s: headerSub}
 	api.filtersMu.Unlock()
 
-	defer deadline.Stop()
 	go func() {
+		defer deadline.Stop()
 		for {
 			select {
 			case h := <-headers:
@@ -302,8 +302,8 @@ func (api *FilterAPI) NewFilter(crit FilterCriteria) (rpc.ID, error) {
 	api.filters[logsSub.ID] = &filter{typ: LogsSubscription, crit: crit, deadline: deadline, logs: make([]*types.Log, 0), s: logsSub}
 	api.filtersMu.Unlock()
 
-	defer deadline.Stop()
 	go func() {
+		defer deadline.Stop()
 		for {
 			select {
 			case l := <-logs:

--- a/eth/filters/api.go
+++ b/eth/filters/api.go
@@ -71,20 +71,19 @@ func NewFilterAPI(system *FilterSystem, lightMode bool) *FilterAPI {
 func (api *FilterAPI) timeoutLoop() {
 	var toUninstall *Subscription
 	for {
-		id := <-api.sys.deadlineCh
-		fmt.Println(id, "timeout!")
+		go func(id rpc.ID) {
+			api.filtersMu.Lock()
+			f := api.filters[id]
+			toUninstall = f.s
+			delete(api.filters, id)
+			api.filtersMu.Unlock()
 
-		api.filtersMu.Lock()
-		f := api.filters[id]
-		toUninstall = f.s
-		delete(api.filters, id)
-		api.filtersMu.Unlock()
-
-		// Unsubscribes are processed outside the lock to avoid the following scenario:
-		// event loop attempts broadcasting events to still active filters while
-		// Unsubscribe is waiting for it to process the uninstall request.
-		toUninstall.Unsubscribe()
-		toUninstall = nil
+			// Unsubscribes are processed outside the lock to avoid the following scenario:
+			// event loop attempts broadcasting events to still active filters while
+			// Unsubscribe is waiting for it to process the uninstall request.
+			toUninstall.Unsubscribe()
+			toUninstall = nil
+		}(<-api.sys.deadlineCh)
 	}
 }
 

--- a/eth/filters/filter_system.go
+++ b/eth/filters/filter_system.go
@@ -76,6 +76,8 @@ type FilterSystem struct {
 	backend   Backend
 	logsCache *lru.Cache
 	cfg       *Config
+
+	deadlineCh chan rpc.ID
 }
 
 // NewFilterSystem creates a filter system.
@@ -87,9 +89,10 @@ func NewFilterSystem(backend Backend, config Config) *FilterSystem {
 		panic(err)
 	}
 	return &FilterSystem{
-		backend:   backend,
-		logsCache: cache,
-		cfg:       &config,
+		backend:    backend,
+		logsCache:  cache,
+		cfg:        &config,
+		deadlineCh: make(chan rpc.ID),
 	}
 }
 

--- a/eth/filters/filter_system.go
+++ b/eth/filters/filter_system.go
@@ -77,7 +77,7 @@ type FilterSystem struct {
 	logsCache *lru.Cache
 	cfg       *Config
 
-	deadlineCh chan rpc.ID
+	deadlineCh chan rpc.ID // deadlineCh detects that the filter is exceed deadline.
 }
 
 // NewFilterSystem creates a filter system.


### PR DESCRIPTION
While test something about filters, I found the created filter queue not deallocated after 5 minute passes(without call GetFilterChanges). So I looked at the code. And saw that the timeoutLoop works per every 5 minutes.

The filter deadline is 5 minute and also timeoutLoop ticker is 5 minute too.
So, real filter deadline is 5 minute(best) between and 10 minute(worst). Of course, batch processing every 5 minutes in detect timeout logics will decrease calls and request but the variable's name 'deadline' seems to lose its meaning, and it feels like there is memory left that should have been deallocated.

This PR suggest removing the exceed deadline filter immediately.
(If any discussion or history of this already exists, I'm sorry. I couldn't find that.)