### PR TITLE
rpc: export JsonError 

### DIFF
--- a/rpc/client_test.go
+++ b/rpc/client_test.go
@@ -140,7 +140,7 @@ func TestClientBatchRequest(t *testing.T) {
 			Method: "no_such_method",
 			Args:   []interface{}{1, 2, 3},
 			Result: new(int),
-			Error:  &jsonError{Code: -32601, Message: "the method no_such_method does not exist/is not available"},
+			Error:  &JsonError{Code: -32601, Message: "the method no_such_method does not exist/is not available"},
 		},
 	}
 	if !reflect.DeepEqual(batch, wantResult) {

--- a/rpc/json.go
+++ b/rpc/json.go
@@ -53,7 +53,7 @@ type jsonrpcMessage struct {
 	ID      json.RawMessage `json:"id,omitempty"`
 	Method  string          `json:"method,omitempty"`
 	Params  json.RawMessage `json:"params,omitempty"`
-	Error   *jsonError      `json:"error,omitempty"`
+	Error   *JsonError      `json:"error,omitempty"`
 	Result  json.RawMessage `json:"result,omitempty"`
 }
 
@@ -110,7 +110,7 @@ func (msg *jsonrpcMessage) response(result interface{}) *jsonrpcMessage {
 }
 
 func errorMessage(err error) *jsonrpcMessage {
-	msg := &jsonrpcMessage{Version: vsn, ID: null, Error: &jsonError{
+	msg := &jsonrpcMessage{Version: vsn, ID: null, Error: &JsonError{
 		Code:    errcodeDefault,
 		Message: err.Error(),
 	}}
@@ -125,24 +125,24 @@ func errorMessage(err error) *jsonrpcMessage {
 	return msg
 }
 
-type jsonError struct {
+type JsonError struct {
 	Code    int         `json:"code"`
 	Message string      `json:"message"`
 	Data    interface{} `json:"data,omitempty"`
 }
 
-func (err *jsonError) Error() string {
+func (err *JsonError) Error() string {
 	if err.Message == "" {
 		return fmt.Sprintf("json-rpc error %d", err.Code)
 	}
 	return err.Message
 }
 
-func (err *jsonError) ErrorCode() int {
+func (err *JsonError) ErrorCode() int {
 	return err.Code
 }
 
-func (err *jsonError) ErrorData() interface{} {
+func (err *JsonError) ErrorData() interface{} {
 	return err.Data
 }
 


### PR DESCRIPTION
Export `JsonError` so that caller can try to type cast the returned error of [Client.CallContext](https://github.com/ethereum/go-ethereum/blob/master/rpc/client.go#L319) to know the error category.

This is useful for high level apis like [SendTransaction](https://github.com/ethereum/go-ethereum/blob/master/ethclient/ethclient.go#L557),say if the error is from [op.wait](https://github.com/ethereum/go-ethereum/blob/master/rpc/client.go#L339) the caller may want to retry, otherwise the caller may want to ignore returned error(like `ErrAlreadyKnown`) since the remote has already received the transaction.