### PR TITLE
core: fix linter complaint

### DIFF
--- a/core/state_transition.go
+++ b/core/state_transition.go
@@ -33,7 +33,7 @@ var emptyCodeHash = crypto.Keccak256Hash(nil)
 
 // StateTransition represents a state transition.
 //
-// The State Transitioning Model
+// == The State Transitioning Model
 //
 // A state transition is a change made when a transaction is applied to the current world
 // state. The state transitioning model does all the necessary work to work out a valid new


### PR DESCRIPTION
I think https://github.com/ethereum/go-ethereum/pull/25924 accidentally broke master, for some reason the linter complains that the state_transition is not goimport:ed. This seems to solve it. 

I'm just a monkey pushing buttons here, no idea how or why 