### PR TITLE
eth/downloader: make queue.deliver return errStaleDelivery correctly

### DIFF
--- a/eth/downloader/queue.go
+++ b/eth/downloader/queue.go
@@ -887,7 +887,7 @@ func (q *queue) deliver(id string, taskPool map[common.Hash]*types.Header,
 	if accepted > 0 {
 		return accepted, fmt.Errorf("partial failure: %v", failure)
 	}
-	return accepted, fmt.Errorf("%w: %v", failure, errStaleDelivery)
+	return accepted, fmt.Errorf("%w: %v", errStaleDelivery, failure)
 }
 
 // Prepare configures the result cache to allow accepting and caching inbound


### PR DESCRIPTION
There's a comment saying:

```
// If none of the data was good, it's a stale delivery
```

If the comment is true, the last line wants to return an instance of `errStaleDelivery`, and the position should correspond to `%w`.
