### PR TITLE
rpc: add method to test for subscriptions

### DIFF
--- a/ethclient/ethclient.go
+++ b/ethclient/ethclient.go
@@ -588,6 +588,10 @@ func (ec *Client) SendTransaction(ctx context.Context, tx *types.Transaction) er
 	return ec.c.CallContext(ctx, nil, "eth_sendRawTransaction", hexutil.Encode(data))
 }
 
+func (ec *Client) IsHTTP() bool {
+	return ec.c.IsHTTP()
+}
+
 func toBlockNumArg(number *big.Int) string {
 	if number == nil {
 		return "latest"

--- a/ethclient/ethclient.go
+++ b/ethclient/ethclient.go
@@ -588,8 +588,8 @@ func (ec *Client) SendTransaction(ctx context.Context, tx *types.Transaction) er
 	return ec.c.CallContext(ctx, nil, "eth_sendRawTransaction", hexutil.Encode(data))
 }
 
-func (ec *Client) IsHTTP() bool {
-	return ec.c.IsHTTP()
+func (ec *Client) SupportsSubscription() bool {
+	return ec.c.SupportsSubscription()
 }
 
 func toBlockNumArg(number *big.Int) string {

--- a/ethclient/ethclient.go
+++ b/ethclient/ethclient.go
@@ -588,8 +588,13 @@ func (ec *Client) SendTransaction(ctx context.Context, tx *types.Transaction) er
 	return ec.c.CallContext(ctx, nil, "eth_sendRawTransaction", hexutil.Encode(data))
 }
 
-func (ec *Client) SupportsSubscription() bool {
-	return ec.c.SupportsSubscription()
+// SupportSubscriptions reports whether the client transport supports publish/subscribe
+// APIs.
+//
+// Note that calls to SubscribeNewHeads and other subscription-based methods can still
+// fail even when this returns true, because the server might not support the mechanism.
+func (ec *Client) SupportsSubscriptions() bool {
+	return ec.c.SupportsSubscriptions()
 }
 
 func toBlockNumArg(number *big.Int) string {

--- a/ethclient/ethclient.go
+++ b/ethclient/ethclient.go
@@ -588,15 +588,6 @@ func (ec *Client) SendTransaction(ctx context.Context, tx *types.Transaction) er
 	return ec.c.CallContext(ctx, nil, "eth_sendRawTransaction", hexutil.Encode(data))
 }
 
-// SupportSubscriptions reports whether the client transport supports publish/subscribe
-// APIs.
-//
-// Note that calls to SubscribeNewHeads and other subscription-based methods can still
-// fail even when this returns true, because the server might not support the mechanism.
-func (ec *Client) SupportsSubscriptions() bool {
-	return ec.c.SupportsSubscriptions()
-}
-
 func toBlockNumArg(number *big.Int) string {
 	if number == nil {
 		return "latest"

--- a/rpc/client.go
+++ b/rpc/client.go
@@ -716,3 +716,7 @@ func (c *Client) read(codec ServerCodec) {
 		c.readOp <- readOp{msgs, batch}
 	}
 }
+
+func (c *Client) IsHTTP() bool {
+	return c.isHTTP
+}

--- a/rpc/client.go
+++ b/rpc/client.go
@@ -541,7 +541,7 @@ func (c *Client) Subscribe(ctx context.Context, namespace string, channel interf
 // SupportsSubscriptions reports whether subscriptions are supported by the client
 // transport. When this returns false, Subscribe and related methods will return
 // ErrNotificationsUnsupported.
-func (c *Client) SupportsSubscription() bool {
+func (c *Client) SupportsSubscriptions() bool {
 	return !c.isHTTP
 }
 

--- a/rpc/client.go
+++ b/rpc/client.go
@@ -717,6 +717,6 @@ func (c *Client) read(codec ServerCodec) {
 	}
 }
 
-func (c *Client) IsHTTP() bool {
-	return c.isHTTP
+func (c *Client) SupportsSubscription() bool {
+	return !c.isHTTP
 }

--- a/rpc/client.go
+++ b/rpc/client.go
@@ -538,6 +538,13 @@ func (c *Client) Subscribe(ctx context.Context, namespace string, channel interf
 	return op.sub, nil
 }
 
+// SupportsSubscriptions reports whether subscriptions are supported by the client
+// transport. When this returns false, Subscribe and related methods will return
+// ErrNotificationsUnsupported.
+func (c *Client) SupportsSubscription() bool {
+	return !c.isHTTP
+}
+
 func (c *Client) newMessage(method string, paramsIn ...interface{}) (*jsonrpcMessage, error) {
 	msg := &jsonrpcMessage{Version: vsn, ID: c.nextID(), Method: method}
 	if paramsIn != nil { // prevent sending "params":null
@@ -715,8 +722,4 @@ func (c *Client) read(codec ServerCodec) {
 		}
 		c.readOp <- readOp{msgs, batch}
 	}
-}
-
-func (c *Client) SupportsSubscription() bool {
-	return !c.isHTTP
 }

--- a/rpc/errors.go
+++ b/rpc/errors.go
@@ -58,11 +58,13 @@ var (
 )
 
 const (
-	errcodeDefault                  = -32000
-	errcodeTimeout                  = -32002
-	errcodeResponseTooLarge         = -32003
-	errcodePanic                    = -32603
-	errcodeMarshalError             = -32603
+	errcodeDefault          = -32000
+	errcodeTimeout          = -32002
+	errcodeResponseTooLarge = -32003
+	errcodePanic            = -32603
+	errcodeMarshalError     = -32603
+
+	legacyErrcodeNotificationsUnsupported = -32001
 )
 
 const (
@@ -100,7 +102,11 @@ func (e notificationsUnsupportedError) Is(other error) bool {
 		return true
 	}
 	rpcErr, ok := other.(Error)
-	return ok && rpcErr.ErrorCode() == -32601
+	if ok {
+		code := rpcErr.ErrorCode()
+		return code == -32601 || code == legacyErrcodeNotificationsUnsupported
+	}
+	return false
 }
 
 type subscriptionNotFoundError struct{ namespace, subscription string }

--- a/rpc/errors.go
+++ b/rpc/errors.go
@@ -59,7 +59,6 @@ var (
 
 const (
 	errcodeDefault                  = -32000
-	errcodeNotificationsUnsupported = -32001
 	errcodeTimeout                  = -32002
 	errcodeResponseTooLarge         = -32003
 	errcodePanic                    = -32603
@@ -78,6 +77,30 @@ func (e *methodNotFoundError) ErrorCode() int { return -32601 }
 
 func (e *methodNotFoundError) Error() string {
 	return fmt.Sprintf("the method %s does not exist/is not available", e.method)
+}
+
+type notificationsUnsupportedError struct{}
+
+func (e notificationsUnsupportedError) Error() string {
+	return "notifications not supported"
+}
+
+func (e notificationsUnsupportedError) ErrorCode() int { return -32601 }
+
+// Is checks for equivalence to another error. Here we define that all errors with code
+// -32601 (method not found) are equivalent to notificationsUnsupportedError. This is
+// done to enable the following pattern:
+//
+//	sub, err := client.Subscribe(...)
+//	if errors.Is(err, rpc.ErrNotificationsUnsupported) {
+//		// server doesn't support subscriptions
+//	}
+func (e notificationsUnsupportedError) Is(other error) bool {
+	if other == (notificationsUnsupportedError{}) {
+		return true
+	}
+	rpcErr, ok := other.(Error)
+	return ok && rpcErr.ErrorCode() == -32601
 }
 
 type subscriptionNotFoundError struct{ namespace, subscription string }

--- a/rpc/handler.go
+++ b/rpc/handler.go
@@ -530,10 +530,7 @@ func (h *handler) handleCall(cp *callProc, msg *jsonrpcMessage) *jsonrpcMessage 
 // handleSubscribe processes *_subscribe method calls.
 func (h *handler) handleSubscribe(cp *callProc, msg *jsonrpcMessage) *jsonrpcMessage {
 	if !h.allowSubscribe {
-		return msg.errorResponse(&internalServerError{
-			code:    errcodeNotificationsUnsupported,
-			message: ErrNotificationsUnsupported.Error(),
-		})
+		return msg.errorResponse(ErrNotificationsUnsupported)
 	}
 
 	// Subscription method name is first argument.

--- a/rpc/subscription.go
+++ b/rpc/subscription.go
@@ -33,7 +33,8 @@ import (
 
 var (
 	// ErrNotificationsUnsupported is returned when the connection doesn't support notifications
-	ErrNotificationsUnsupported = errors.New("notifications not supported")
+	ErrNotificationsUnsupported = notificationsUnsupportedError{}
+
 	// ErrSubscriptionNotFound is returned when the notification for the given id is not found
 	ErrSubscriptionNotFound = errors.New("subscription not found")
 )

--- a/rpc/subscription.go
+++ b/rpc/subscription.go
@@ -32,7 +32,15 @@ import (
 )
 
 var (
-	// ErrNotificationsUnsupported is returned when the connection doesn't support notifications
+	// ErrNotificationsUnsupported is returned by the client when the connection doesn't
+	// support notifications. You can use this error value to check for subscription
+	// support like this:
+	//
+	//	sub, err := client.EthSubscribe(ctx, channel, "newHeads", true)
+	//	if errors.Is(err, rpc.ErrNotificationsUnsupported) {
+	//		// Server does not support subscriptions, fall back to polling.
+	//	}
+	//
 	ErrNotificationsUnsupported = notificationsUnsupportedError{}
 
 	// ErrSubscriptionNotFound is returned when the notification for the given id is not found


### PR DESCRIPTION
`ethclient.Client` has methods which're only valid when `isHTTP` is false(e.g.:`Subscribe`), thus it's convenient to expose a `IsHTTP` method so that users can do different things based on whether the underlying connection is http or not.