### PR TITLE
eth/tracers: fix the issue of panic in prestate with diffmode

### DIFF
--- a/eth/tracers/native/prestate.go
+++ b/eth/tracers/native/prestate.go
@@ -229,7 +229,7 @@ func (t *prestateTracer) CaptureTxEnd(restGas uint64) {
 	// the new created contracts' prestate were empty, so delete them
 	for a := range t.created {
 		// the created contract maybe exists in statedb before the creating tx
-		if s := t.pre[a]; s.Balance.Cmp(big.NewInt(0)) == 0 && len(s.Storage) == 0 && len(s.Code) == 0 {
+		if s := t.pre[a]; s != nil && s.Balance.Cmp(big.NewInt(0)) == 0 && len(s.Storage) == 0 && len(s.Code) == 0 {
 			delete(t.pre, a)
 		}
 	}


### PR DESCRIPTION
In some cases, the contract created may not be successful. eg in this tx [0x876a0668d1337e4734dbec13ce1407a918ccac7d1e76e47f82728d877fa5a819](https://etherscan.io/tx/0x876a0668d1337e4734dbec13ce1407a918ccac7d1e76e47f82728d877fa5a819), the inner contract was not creating. So don't need to delete the not existing contracts.