### PR TITLE
cmd/utils: enable snapshot generation in import-mode

### DIFF
--- a/cmd/geth/chaincmd.go
+++ b/cmd/geth/chaincmd.go
@@ -252,7 +252,7 @@ func importChain(ctx *cli.Context) error {
 	stack, _ := makeConfigNode(ctx)
 	defer stack.Close()
 
-	chain, db := utils.MakeChain(ctx, stack)
+	chain, db := utils.MakeChain(ctx, stack, false)
 	defer db.Close()
 
 	// Start periodically gathering memory profiles
@@ -327,7 +327,7 @@ func exportChain(ctx *cli.Context) error {
 	stack, _ := makeConfigNode(ctx)
 	defer stack.Close()
 
-	chain, _ := utils.MakeChain(ctx, stack)
+	chain, _ := utils.MakeChain(ctx, stack, true)
 	start := time.Now()
 
 	var err error

--- a/cmd/geth/exportcmd_test.go
+++ b/cmd/geth/exportcmd_test.go
@@ -1,4 +1,4 @@
-// Copyright 2016 The go-ethereum Authors
+// Copyright 2022 The go-ethereum Authors
 // This file is part of go-ethereum.
 //
 // go-ethereum is free software: you can redistribute it and/or modify

--- a/cmd/geth/exportcmd_test.go
+++ b/cmd/geth/exportcmd_test.go
@@ -1,0 +1,45 @@
+// Copyright 2016 The go-ethereum Authors
+// This file is part of go-ethereum.
+//
+// go-ethereum is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// go-ethereum is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with go-ethereum. If not, see <http://www.gnu.org/licenses/>.
+
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+)
+
+// TestExport does a basic test of "geth export", exporting the test-genesis.
+func TestExport(t *testing.T) {
+	outfile := fmt.Sprintf("%v/testExport.out", os.TempDir())
+	defer os.Remove(outfile)
+	geth := runGeth(t, "--datadir", initGeth(t), "export", outfile)
+	geth.WaitExit()
+	if have, want := geth.ExitStatus(), 0; have != want {
+		t.Errorf("exit error, have %d want %d", have, want)
+	}
+	have, err := os.ReadFile(outfile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := common.FromHex("0xf9026bf90266a00000000000000000000000000000000000000000000000000000000000000000a01dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347940000000000000000000000000000000000000000a08758259b018f7bce3d2be2ddb62f325eaeea0a0c188cf96623eab468a4413e03a056e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421a056e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421b90100000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000180837a12008080b875000000000000000000000000000000000000000000000000000000000000000002f0d131f1f97aef08aec6e3291b957d9efe71050000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000a00000000000000000000000000000000000000000000000000000000000000000880000000000000000c0c0")
+	if !bytes.Equal(have, want) {
+		t.Fatalf("wrong content exported")
+	}
+}

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -2217,10 +2217,10 @@ func MakeGenesis(ctx *cli.Context) *core.Genesis {
 }
 
 // MakeChain creates a chain manager from set command line flags.
-func MakeChain(ctx *cli.Context, stack *node.Node) (*core.BlockChain, ethdb.Database) {
+func MakeChain(ctx *cli.Context, stack *node.Node, readonly bool) (*core.BlockChain, ethdb.Database) {
 	var (
 		gspec   = MakeGenesis(ctx)
-		chainDb = MakeChainDatabase(ctx, stack, false) // TODO(rjl493456442) support read-only database
+		chainDb = MakeChainDatabase(ctx, stack, readonly)
 	)
 	cliqueConfig, err := core.LoadCliqueConfig(chainDb, gspec)
 	if err != nil {
@@ -2250,9 +2250,10 @@ func MakeChain(ctx *cli.Context, stack *node.Node) (*core.BlockChain, ethdb.Data
 	if !ctx.Bool(SnapshotFlag.Name) {
 		cache.SnapshotLimit = 0 // Disabled
 	}
-	// TODO(rjl493456442) disable snapshot generation/wiping if the chain is read only.
-	// Enable snapshot generation/wiping by default
-	cache.SnapshotNoBuild = false
+	// If we're in readonly, do not bother generating snapshot data.
+	if readonly {
+		cache.SnapshotNoBuild = true
+	}
 
 	if ctx.IsSet(CacheFlag.Name) || ctx.IsSet(CacheTrieFlag.Name) {
 		cache.TrieCleanLimit = ctx.Int(CacheFlag.Name) * ctx.Int(CacheTrieFlag.Name) / 100

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -2250,8 +2250,9 @@ func MakeChain(ctx *cli.Context, stack *node.Node) (*core.BlockChain, ethdb.Data
 	if !ctx.Bool(SnapshotFlag.Name) {
 		cache.SnapshotLimit = 0 // Disabled
 	}
-	// Disable snapshot generation/wiping by default
-	cache.SnapshotNoBuild = true
+	// TODO(rjl493456442) disable snapshot generation/wiping if the chain is read only.
+	// Enable snapshot generation/wiping by default
+	cache.SnapshotNoBuild = false
 
 	if ctx.IsSet(CacheFlag.Name) || ctx.IsSet(CacheTrieFlag.Name) {
 		cache.TrieCleanLimit = ctx.Int(CacheFlag.Name) * ctx.Int(CacheTrieFlag.Name) / 100

--- a/core/genesis.go
+++ b/core/genesis.go
@@ -358,6 +358,7 @@ func SetupGenesisBlockWithOverride(db ethdb.Database, genesis *Genesis, override
 		rawdb.WriteChainConfig(db, stored, newcfg)
 		return newcfg, stored, nil
 	}
+	storedData, _ := json.Marshal(storedcfg)
 	// Special case: if a private network is being used (no genesis and also no
 	// mainnet hash in the database), we must not apply the `configOrDefault`
 	// chain config as that would be AllProtocolChanges (applying any new fork
@@ -377,7 +378,10 @@ func SetupGenesisBlockWithOverride(db ethdb.Database, genesis *Genesis, override
 	if compatErr != nil && *height != 0 && compatErr.RewindTo != 0 {
 		return newcfg, stored, compatErr
 	}
-	rawdb.WriteChainConfig(db, stored, newcfg)
+	// Don't overwrite if the old is identical to the new
+	if newData, _ := json.Marshal(newcfg); !bytes.Equal(storedData, newData) {
+		rawdb.WriteChainConfig(db, stored, newcfg)
+	}
 	return newcfg, stored, nil
 }
 

--- a/core/rawdb/accessors_metadata.go
+++ b/core/rawdb/accessors_metadata.go
@@ -17,7 +17,6 @@
 package rawdb
 
 import (
-	"bytes"
 	"encoding/json"
 	"time"
 
@@ -69,19 +68,13 @@ func ReadChainConfig(db ethdb.KeyValueReader, hash common.Hash) *params.ChainCon
 }
 
 // WriteChainConfig writes the chain config settings to the database.
-func WriteChainConfig(db ethdb.KeyValueStore, hash common.Hash, cfg *params.ChainConfig) {
+func WriteChainConfig(db ethdb.KeyValueWriter, hash common.Hash, cfg *params.ChainConfig) {
 	if cfg == nil {
 		return
 	}
 	data, err := json.Marshal(cfg)
 	if err != nil {
 		log.Crit("Failed to JSON encode chain config", "err", err)
-	}
-	// We can compare against any existing value. This makes "WriteChainConfig"
-	// safe to call even if the database is in readonly mode.
-	if old, _ := db.Get(configKey(hash)); bytes.Equal(old, data) {
-		// No need to write
-		return
 	}
 	if err := db.Put(configKey(hash), data); err != nil {
 		log.Crit("Failed to store chain config", "err", err)

--- a/core/rawdb/accessors_metadata.go
+++ b/core/rawdb/accessors_metadata.go
@@ -20,6 +20,7 @@ import (
 	"encoding/json"
 	"time"
 
+	"bytes"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/ethdb"
 	"github.com/ethereum/go-ethereum/log"
@@ -68,13 +69,19 @@ func ReadChainConfig(db ethdb.KeyValueReader, hash common.Hash) *params.ChainCon
 }
 
 // WriteChainConfig writes the chain config settings to the database.
-func WriteChainConfig(db ethdb.KeyValueWriter, hash common.Hash, cfg *params.ChainConfig) {
+func WriteChainConfig(db ethdb.KeyValueStore, hash common.Hash, cfg *params.ChainConfig) {
 	if cfg == nil {
 		return
 	}
 	data, err := json.Marshal(cfg)
 	if err != nil {
 		log.Crit("Failed to JSON encode chain config", "err", err)
+	}
+	// We can compare against any existing value. This makes "WriteChainConfig"
+	// safe to call even if the database is in readonly mode.
+	if old, _ := db.Get(configKey(hash)); bytes.Equal(old, data) {
+		// No need to write
+		return
 	}
 	if err := db.Put(configKey(hash), data); err != nil {
 		log.Crit("Failed to store chain config", "err", err)

--- a/core/rawdb/accessors_metadata.go
+++ b/core/rawdb/accessors_metadata.go
@@ -17,10 +17,10 @@
 package rawdb
 
 import (
+	"bytes"
 	"encoding/json"
 	"time"
 
-	"bytes"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/ethdb"
 	"github.com/ethereum/go-ethereum/log"


### PR DESCRIPTION
A hive-test started failing:

![Screenshot_20221015-090347_1](https://user-images.githubusercontent.com/142290/195985621-1177065e-1934-42ef-9748-c07c0b247312.jpg)

Git bisect showed that it started failing at this [PR](https://github.com/ethereum/go-ethereum/pull/22396). 

This PR fixes the problem. 
These are the hive-logs on the geth-instance during the test run
- An instance where it does [not work](https://github.com/ethereum/go-ethereum/files/9791984/non-working.log)
- An instance with this PR, where the test [works again](https://github.com/ethereum/go-ethereum/files/9791983/working_again.log).

When it works, the logs emit these messages as the blockchain is shutting down: 
```
DEBUG[10-15|11:53:54.838] Inserted new block                       number=999 hash=0e70e0..67a424 uncles=0 txs=0   gas=0       elapsed="275.541µs>
DEBUG[10-15|11:53:54.839] Journalled generator progress            progress=done
DEBUG[10-15|11:53:54.839] Journalled disk layer                    root=a28e77..fccc87
DEBUG[10-15|11:53:54.839] Journalled diff layer                    root=82f9fb..a6202b parent=a28e77..fccc87
DEBUG[10-15|11:53:54.839] Journalled diff layer                    root=1e5e7e..830f3c parent=82f9fb..a6202b
DEBUG[10-15|11:53:54.839] Journalled diff layer                    root=67977e..20dee4 parent=1e5e7e..830f3c
```
