### PR TITLE
p2p/enode: add UDPAddr, TCPAddr methods

### DIFF
--- a/p2p/dial.go
+++ b/p2p/dial.go
@@ -64,11 +64,7 @@ type tcpDialer struct {
 }
 
 func (t tcpDialer) Dial(ctx context.Context, dest *enode.Node) (net.Conn, error) {
-	return t.d.DialContext(ctx, "tcp", nodeAddr(dest).String())
-}
-
-func nodeAddr(n *enode.Node) net.Addr {
-	return &net.TCPAddr{IP: n.IP(), Port: n.TCP()}
+	return t.d.DialContext(ctx, "tcp", dest.TCPAddr().String())
 }
 
 // checkDial errors:
@@ -536,7 +532,7 @@ func (t *dialTask) resolve(d *dialScheduler) bool {
 func (t *dialTask) dial(d *dialScheduler, dest *enode.Node) error {
 	fd, err := d.dialer.Dial(d.ctx, t.dest)
 	if err != nil {
-		d.log.Trace("Dial error", "id", t.dest.ID(), "addr", nodeAddr(t.dest), "conn", t.flags, "err", cleanupDialErr(err))
+		d.log.Trace("Dial error", "id", t.dest.ID(), "addr", t.dest.TCPAddr(), "conn", t.flags, "err", cleanupDialErr(err))
 		return &dialError{err}
 	}
 	mfd := newMeteredConn(fd, false, &net.TCPAddr{IP: dest.IP(), Port: dest.TCP()})

--- a/p2p/dial.go
+++ b/p2p/dial.go
@@ -492,7 +492,7 @@ func (t *dialTask) run(d *dialScheduler) {
 }
 
 func (t *dialTask) needResolve() bool {
-	return t.flags&staticDialedConn != 0 && t.dest.IP() == nil
+	return t.flags&staticDialedConn != 0 && t.dest.TCPAddr() == nil
 }
 
 // resolve attempts to find the current endpoint for the destination
@@ -524,7 +524,7 @@ func (t *dialTask) resolve(d *dialScheduler) bool {
 	// The node was found.
 	t.resolveDelay = initialResolveDelay
 	t.dest = resolved
-	d.log.Debug("Resolved node", "id", t.dest.ID(), "addr", &net.TCPAddr{IP: t.dest.IP(), Port: t.dest.TCP()})
+	d.log.Debug("Resolved node", "id", t.dest.ID(), "addr", t.dest.TCPAddr())
 	return true
 }
 
@@ -535,13 +535,13 @@ func (t *dialTask) dial(d *dialScheduler, dest *enode.Node) error {
 		d.log.Trace("Dial error", "id", t.dest.ID(), "addr", t.dest.TCPAddr(), "conn", t.flags, "err", cleanupDialErr(err))
 		return &dialError{err}
 	}
-	mfd := newMeteredConn(fd, false, &net.TCPAddr{IP: dest.IP(), Port: dest.TCP()})
+	mfd := newMeteredConn(fd, false, dest.TCPAddr())
 	return d.setupFunc(mfd, t.flags, dest)
 }
 
 func (t *dialTask) String() string {
 	id := t.dest.ID()
-	return fmt.Sprintf("%v %x %v:%d", t.flags, id[:8], t.dest.IP(), t.dest.TCP())
+	return fmt.Sprintf("%v %x %v", t.flags, id[:8], t.dest.TCPAddr())
 }
 
 func cleanupDialErr(err error) error {

--- a/p2p/dial_test.go
+++ b/p2p/dial_test.go
@@ -22,7 +22,6 @@ import (
 	"fmt"
 	"math/rand"
 	"net"
-	"reflect"
 	"sync"
 	"testing"
 	"time"
@@ -598,7 +597,7 @@ func (d *dialTestDialer) waitForDials(nodes []*enode.Node) error {
 			if !ok {
 				return fmt.Errorf("attempt to dial unexpected node %v", req.n.ID())
 			}
-			if !reflect.DeepEqual(req.n, want) {
+			if req.n.String() != want.String() {
 				return fmt.Errorf("ENR of dialed node %v does not match test", req.n.ID())
 			}
 			delete(waitset, req.n.ID())

--- a/p2p/dial_test.go
+++ b/p2p/dial_test.go
@@ -597,7 +597,7 @@ func (d *dialTestDialer) waitForDials(nodes []*enode.Node) error {
 			if !ok {
 				return fmt.Errorf("attempt to dial unexpected node %v", req.n.ID())
 			}
-			if req.n.String() != want.String() {
+			if !req.n.Equal(want) {
 				return fmt.Errorf("ENR of dialed node %v does not match test", req.n.ID())
 			}
 			delete(waitset, req.n.ID())

--- a/p2p/discover/node.go
+++ b/p2p/discover/node.go
@@ -21,7 +21,6 @@ import (
 	"crypto/elliptic"
 	"errors"
 	"math/big"
-	"net"
 	"time"
 
 	"github.com/ethereum/go-ethereum/common/math"
@@ -86,10 +85,6 @@ func unwrapNodes(ns []*node) []*enode.Node {
 		result[i] = unwrapNode(n)
 	}
 	return result
-}
-
-func (n *node) addr() *net.UDPAddr {
-	return &net.UDPAddr{IP: n.IP(), Port: n.UDP()}
 }
 
 func (n *node) String() string {

--- a/p2p/discover/table.go
+++ b/p2p/discover/table.go
@@ -306,7 +306,7 @@ func (tab *Table) loadSeedNodes() {
 	for i := range seeds {
 		seed := seeds[i]
 		age := log.Lazy{Fn: func() interface{} { return time.Since(tab.db.LastPongReceived(seed.ID(), seed.IP())) }}
-		tab.log.Trace("Found seed node in database", "id", seed.ID(), "addr", seed.addr(), "age", age)
+		tab.log.Trace("Found seed node in database", "id", seed.ID(), "addr", seed.Node.UDPAddr(), "age", age)
 		tab.addSeenNode(seed)
 	}
 }
@@ -329,7 +329,7 @@ func (tab *Table) doRevalidate(done chan<- struct{}) {
 	if last.Seq() < remoteSeq {
 		n, err := tab.net.RequestENR(unwrapNode(last))
 		if err != nil {
-			tab.log.Debug("ENR request failed", "id", last.ID(), "addr", last.addr(), "err", err)
+			tab.log.Debug("ENR request failed", "id", last.ID(), "addr", last.UDPAddr(), "err", err)
 		} else {
 			last = &node{Node: *n, addedAt: last.addedAt, livenessChecks: last.livenessChecks}
 		}

--- a/p2p/discover/table_test.go
+++ b/p2p/discover/table_test.go
@@ -319,7 +319,7 @@ func TestTable_addVerifiedNode(t *testing.T) {
 
 	// Verify bucket content:
 	bcontent := []*node{n1, n2}
-	if !reflect.DeepEqual(tab.bucket(n1.ID()).entries, bcontent) {
+	if !nodesEqual(tab.bucket(n1.ID()).entries, bcontent) {
 		t.Fatalf("wrong bucket content: %v", tab.bucket(n1.ID()).entries)
 	}
 
@@ -331,7 +331,7 @@ func TestTable_addVerifiedNode(t *testing.T) {
 
 	// Check that bucket is updated correctly.
 	newBcontent := []*node{newn2, n1}
-	if !reflect.DeepEqual(tab.bucket(n1.ID()).entries, newBcontent) {
+	if !nodesEqual(tab.bucket(n1.ID()).entries, newBcontent) {
 		t.Fatalf("wrong bucket content after update: %v", tab.bucket(n1.ID()).entries)
 	}
 	checkIPLimitInvariant(t, tab)
@@ -351,7 +351,7 @@ func TestTable_addSeenNode(t *testing.T) {
 
 	// Verify bucket content:
 	bcontent := []*node{n1, n2}
-	if !reflect.DeepEqual(tab.bucket(n1.ID()).entries, bcontent) {
+	if !nodesEqual(tab.bucket(n1.ID()).entries, bcontent) {
 		t.Fatalf("wrong bucket content: %v", tab.bucket(n1.ID()).entries)
 	}
 
@@ -362,7 +362,7 @@ func TestTable_addSeenNode(t *testing.T) {
 	tab.addSeenNode(newn2)
 
 	// Check that bucket content is unchanged.
-	if !reflect.DeepEqual(tab.bucket(n1.ID()).entries, bcontent) {
+	if !nodesEqual(tab.bucket(n1.ID()).entries, bcontent) {
 		t.Fatalf("wrong bucket content after update: %v", tab.bucket(n1.ID()).entries)
 	}
 	checkIPLimitInvariant(t, tab)
@@ -391,7 +391,7 @@ func TestTable_revalidateSyncRecord(t *testing.T) {
 
 	tab.doRevalidate(make(chan struct{}, 1))
 	intable := tab.getNode(id)
-	if !reflect.DeepEqual(intable, n2) {
+	if !intable.Equal(n2) {
 		t.Fatalf("table contains old record with seq %d, want seq %d", intable.Seq(), n2.Seq())
 	}
 }

--- a/p2p/discover/table_util_test.go
+++ b/p2p/discover/table_util_test.go
@@ -52,6 +52,7 @@ func newTestTable(t transport) (*Table, *enode.DB) {
 func nodeAtDistance(base enode.ID, ld int, ip net.IP) *node {
 	var r enr.Record
 	r.Set(enr.IP(ip))
+	r.Set(enr.UDP(30303))
 	return wrapNode(enode.SignNull(&r, idAtDistance(base, ld)))
 }
 

--- a/p2p/discover/table_util_test.go
+++ b/p2p/discover/table_util_test.go
@@ -114,6 +114,26 @@ func fillTable(tab *Table, nodes []*node) {
 	}
 }
 
+// nodesEqual reports whether two slices of nodes have the same content.
+func nodesEqual(ns1, ns2 []*node) bool {
+	if len(ns1) != len(ns2) {
+		return false
+	}
+	for i, node1 := range ns1 {
+		node2 := ns2[i]
+		if !node1.Node.Equal(&node2.Node) {
+			return false
+		}
+		if !node2.addedAt.Equal(node2.addedAt) {
+			return false
+		}
+		if node1.livenessChecks != node2.livenessChecks {
+			return false
+		}
+	}
+	return true
+}
+
 type pingRecorder struct {
 	mu           sync.Mutex
 	dead, pinged map[enode.ID]bool

--- a/p2p/discover/table_util_test.go
+++ b/p2p/discover/table_util_test.go
@@ -125,7 +125,7 @@ func nodesEqual(ns1, ns2 []*node) bool {
 		if !node1.Node.Equal(&node2.Node) {
 			return false
 		}
-		if !node2.addedAt.Equal(node2.addedAt) {
+		if !node1.addedAt.Equal(node2.addedAt) {
 			return false
 		}
 		if node1.livenessChecks != node2.livenessChecks {

--- a/p2p/discover/v4_udp.go
+++ b/p2p/discover/v4_udp.go
@@ -291,7 +291,7 @@ func (t *UDPv4) newLookup(ctx context.Context, targetKey encPubkey) *lookup {
 	target := enode.ID(crypto.Keccak256Hash(targetKey[:]))
 	ekey := v4wire.Pubkey(targetKey)
 	it := newLookup(ctx, t.tab, target, func(n *node) ([]*node, error) {
-		return t.findnode(n.ID(), n.addr(), ekey)
+		return t.findnode(n.ID(), n.Node.UDPAddr(), ekey)
 	})
 	return it
 }

--- a/p2p/discover/v4_udp_test.go
+++ b/p2p/discover/v4_udp_test.go
@@ -350,7 +350,7 @@ func TestUDPv4_findnodeMultiReply(t *testing.T) {
 	select {
 	case result := <-resultc:
 		want := append(list[:2], list[3:]...)
-		if !reflect.DeepEqual(result, want) {
+		if !nodesEqual(result, want) {
 			t.Errorf("neighbors mismatch:\n  got:  %v\n  want: %v", result, want)
 		}
 	case err := <-errc:
@@ -489,7 +489,7 @@ func TestUDPv4_EIP868(t *testing.T) {
 		if err != nil {
 			t.Fatalf("invalid record: %v", err)
 		}
-		if !reflect.DeepEqual(n, wantNode) {
+		if !n.Equal(wantNode) {
 			t.Fatalf("wrong node in ENRResponse: %v", n)
 		}
 	})

--- a/p2p/discover/v5_udp.go
+++ b/p2p/discover/v5_udp.go
@@ -405,7 +405,7 @@ func (t *UDPv5) verifyResponseNode(c *callV5, r *enr.Record, distances []uint, s
 		return nil, err
 	}
 
-	addr := c.node.UDPAddr()
+	addr := node.UDPAddr()
 	if addr == nil {
 		return nil, errors.New("no UDP address information")
 	}

--- a/p2p/discover/v5_udp.go
+++ b/p2p/discover/v5_udp.go
@@ -586,8 +586,7 @@ func (t *UDPv5) sendCall(c *callV5) {
 		delete(t.activeCallByAuth, c.nonce)
 	}
 
-	addr := &net.UDPAddr{IP: c.node.IP(), Port: c.node.UDP()}
-	newNonce, _ := t.send(c.node.ID(), addr, c.packet, c.challenge)
+	newNonce, _ := t.send(c.node.ID(), c.node.UDPAddr(), c.packet, c.challenge)
 	c.nonce = newNonce
 	t.activeCallByAuth[newNonce] = c
 	t.startResponseTimeout(c)

--- a/p2p/discover/v5_udp_test.go
+++ b/p2p/discover/v5_udp_test.go
@@ -219,7 +219,7 @@ func (test *udpV5Test) expectNodes(wantReqID []byte, wantTotal uint8, wantNodes 
 				if want == nil {
 					test.t.Fatalf("unexpected node in response: %v", n)
 				}
-				if !reflect.DeepEqual(record, want) {
+				if !record.Equal(want) {
 					test.t.Fatalf("wrong record in response: %v", n)
 				}
 				delete(nodeSet, n.ID())
@@ -318,7 +318,7 @@ func TestUDPv5_findnodeCall(t *testing.T) {
 	if err := <-done; err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if !reflect.DeepEqual(response, nodes) {
+	if !nodesEqual(wrapNodes(response), wrapNodes(nodes)) {
 		t.Fatalf("wrong nodes in response")
 	}
 

--- a/p2p/enode/node.go
+++ b/p2p/enode/node.go
@@ -105,6 +105,14 @@ func (n *Node) Incomplete() bool {
 	return n.IP() == nil
 }
 
+// Equal checks for equality with the given node.
+func (n *Node) Equal(other *Node) bool {
+	if n == nil || other == nil {
+		return n == other
+	}
+	return n.r.Equal(&other.r)
+}
+
 // Load retrieves an entry from the underlying record.
 func (n *Node) Load(k enr.Entry) error {
 	return n.r.Load(k)

--- a/p2p/enode/node.go
+++ b/p2p/enode/node.go
@@ -107,8 +107,8 @@ func (n *Node) Incomplete() bool {
 
 // Equal checks for equality with the given node.
 func (n *Node) Equal(other *Node) bool {
-	if n == nil || other == nil {
-		return n == other
+	if n == other {
+		return true
 	}
 	return n.r.Equal(&other.r)
 }

--- a/p2p/enode/nodedb_test.go
+++ b/p2p/enode/nodedb_test.go
@@ -21,7 +21,6 @@ import (
 	"fmt"
 	"net"
 	"path/filepath"
-	"reflect"
 	"testing"
 	"time"
 )
@@ -159,10 +158,12 @@ func TestDBFetchStore(t *testing.T) {
 	if err := db.UpdateNode(node); err != nil {
 		t.Errorf("node: failed to update: %v", err)
 	}
-	if stored := db.Node(node.ID()); stored == nil {
-		t.Errorf("node: not found")
-	} else if !reflect.DeepEqual(stored, node) {
-		t.Errorf("node: data mismatch: have %v, want %v", stored, node)
+	stored := db.Node(node.ID())
+	if stored == nil {
+		t.Fatal("node: not found")
+	}
+	if stored.String() != node.String() {
+		t.Fatalf("node: data mismatch: have %v, want %v", stored, node)
 	}
 }
 

--- a/p2p/enode/nodedb_test.go
+++ b/p2p/enode/nodedb_test.go
@@ -161,8 +161,7 @@ func TestDBFetchStore(t *testing.T) {
 	stored := db.Node(node.ID())
 	if stored == nil {
 		t.Fatal("node: not found")
-	}
-	if stored.String() != node.String() {
+	} else if !stored.Equal(node) {
 		t.Fatalf("node: data mismatch: have %v, want %v", stored, node)
 	}
 }

--- a/p2p/enr/enr.go
+++ b/p2p/enr/enr.go
@@ -96,6 +96,26 @@ type pair struct {
 	v rlp.RawValue
 }
 
+// Equal reports whether a record is equal to the given record.
+func (r *Record) Equal(other *Record) bool {
+	if r == nil || other == nil {
+		return r == other
+	}
+	if r.raw != nil && other.raw != nil {
+		return bytes.Equal(r.raw, other.raw)
+	}
+	if r.seq != other.seq || !bytes.Equal(r.signature, other.signature) || len(r.pairs) != len(other.pairs) {
+		return false
+	}
+	for i, p := range r.pairs {
+		otherp := other.pairs[i]
+		if p.k != otherp.k || !bytes.Equal(p.v, otherp.v) {
+			return false
+		}
+	}
+	return true
+}
+
 // Seq returns the sequence number.
 func (r *Record) Seq() uint64 {
 	return r.seq

--- a/p2p/enr/enr.go
+++ b/p2p/enr/enr.go
@@ -96,10 +96,10 @@ type pair struct {
 	v rlp.RawValue
 }
 
-// Equal reports whether a record is equal to the given record.
+// Equal checks for equality with the given record.
 func (r *Record) Equal(other *Record) bool {
-	if r == nil || other == nil {
-		return r == other
+	if r == other {
+		return true
 	}
 	if r.raw != nil && other.raw != nil {
 		return bytes.Equal(r.raw, other.raw)


### PR DESCRIPTION
This adds new methods to compute suitable network endpoints from ENR fields. The logic for these is not entirely trivial in the case of IPv6.

While here, add a cache to avoid reloading these fields from the record every time. Since the cache is kept in node, `reflect.DeepEqual` cannot be used with `enode.Node` anymore, and so I have also added an `Equal` method to compare nodes in tests.