### PR TITLE
core/rawdb: open meta file in read only mode

### DIFF
--- a/core/rawdb/freezer_table.go
+++ b/core/rawdb/freezer_table.go
@@ -148,20 +148,12 @@ func newTable(path string, name string, readMeter metrics.Meter, writeMeter metr
 		meta  *os.File
 	)
 	if readonly {
-		// Will fail if table doesn't exist
+		// Will fail if table index file or meta file is not existent
 		index, err = openFreezerFileForReadOnly(filepath.Join(path, idxName))
 		if err != nil {
 			return nil, err
 		}
-		// TODO(rjl493456442) change it to read-only mode. Open the metadata file
-		// in rw mode. It's a temporary solution for now and should be changed
-		// whenever the tail deletion is actually used. The reason for this hack is
-		// the additional meta file for each freezer table is added in order to support
-		// tail deletion, but for most legacy nodes this file is missing. This check
-		// will suddenly break lots of database relevant commands. So the metadata file
-		// is always opened for mutation and nothing else will be written except
-		// the initialization.
-		meta, err = openFreezerFileForAppend(filepath.Join(path, fmt.Sprintf("%s.meta", name)))
+		meta, err = openFreezerFileForReadOnly(filepath.Join(path, fmt.Sprintf("%s.meta", name)))
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
Previously if a freezer table is opened in read-only mode, the corresponding meta file of this table will still be opened in read-write mode. It's mostly for backward-compatibility for legacy node.

However the meta file has been shipped for a few months and all nodes must have initialized the meta files because of the merge. Now we can ensure that if the table is existent, the corresponding meta file must be existent as well and we can drop this ugly hack.