### PR TITLE
metrics: fix metric vars

### DIFF
--- a/metrics/gauge.go
+++ b/metrics/gauge.go
@@ -28,9 +28,28 @@ func NewGauge() Gauge {
 	return &StandardGauge{0}
 }
 
+// NewMeterForced constructs a new StandardGauge no matter
+// the global switch is enabled or not.
+func NewGaugeForced() Gauge {
+	return &StandardGauge{0}
+}
+
 // NewRegisteredGauge constructs and registers a new StandardGauge.
 func NewRegisteredGauge(name string, r Registry) Gauge {
 	c := NewGauge()
+	if nil == r {
+		r = DefaultRegistry
+	}
+	r.Register(name, c)
+	return c
+}
+
+// NewRegisteredGaugeForced constructs and registers a new StandardGauge
+// and launches a goroutine no matter the global switch is enabled or not.
+// Be sure to unregister the meter from the registry once it is of no use to
+// allow for garbage collection.
+func NewRegisteredGaugeForced(name string, r Registry) Gauge {
+	c := NewGaugeForced()
 	if nil == r {
 		r = DefaultRegistry
 	}

--- a/p2p/metrics.go
+++ b/p2p/metrics.go
@@ -36,11 +36,11 @@ const (
 )
 
 var (
-	ingressConnectMeter = metrics.NewRegisteredMeter("p2p/serves", nil)
-	ingressTrafficMeter = metrics.NewRegisteredMeter(ingressMeterName, nil)
-	egressConnectMeter  = metrics.NewRegisteredMeter("p2p/dials", nil)
-	egressTrafficMeter  = metrics.NewRegisteredMeter(egressMeterName, nil)
-	activePeerGauge     = metrics.NewRegisteredGauge("p2p/peers", nil)
+	ingressConnectMeter = metrics.NewRegisteredMeterForced("p2p/serves", nil)
+	ingressTrafficMeter = metrics.NewRegisteredMeterForced(ingressMeterName, nil)
+	egressConnectMeter  = metrics.NewRegisteredMeterForced("p2p/dials", nil)
+	egressTrafficMeter  = metrics.NewRegisteredMeterForced(egressMeterName, nil)
+	activePeerGauge     = metrics.NewRegisteredGaugeForced("p2p/peers", nil)
 )
 
 // meteredConn is a wrapper around a net.Conn that meters both the


### PR DESCRIPTION
These 5 metrics were always `NilMeter/NilGauge`: 

```
        ingressConnectMeter = metrics.NewRegisteredMeter("p2p/serves", nil)
	ingressTrafficMeter = metrics.NewRegisteredMeter(ingressMeterName, nil)
	egressConnectMeter  = metrics.NewRegisteredMeter("p2p/dials", nil)
	egressTrafficMeter  = metrics.NewRegisteredMeter(egressMeterName, nil)
	activePeerGauge     = metrics.NewRegisteredGauge("p2p/peers", nil)
```

As they're created at a too early stage where `Enabled` is `false`.
