### PR TITLE
docs: purge references to rinkeby and ropsten

### DIFF
--- a/docs/_developers/dns-discovery-setup.md
+++ b/docs/_developers/dns-discovery-setup.md
@@ -65,7 +65,7 @@ devp2p nodeset filter all-nodes.json -eth-network mainnet > mainnet.nodes.exampl
 
 The following filter flags are available:
 
-* `-eth-network ( mainnet | ropsten | rinkeby | goerli )` selects an Ethereum network.
+* `-eth-network ( mainnet | sepolia | goerli )` selects an Ethereum network.
 * `-les-server` selects LES server nodes.
 * `-ip <mask>` restricts nodes to the given IP range.
 * `-min-age <duration>` restricts the result to nodes which have been live for the

--- a/docs/_interface/Command-Line-Options.md
+++ b/docs/_interface/Command-Line-Options.md
@@ -61,6 +61,7 @@ ETHEREUM OPTIONS:
   --rinkeby                           Rinkeby network: pre-configured proof-of-authority test network
   --goerli                            Görli network: pre-configured proof-of-authority test network
   --sepolia                           Sepolia network: pre-configured proof-of-work test network
+  --kiln                              Kiln network: pre-configured proof-of-work to proof-of-stake test network
   --datadir value                     Data directory for the databases and keystore (default: "~/.ethereum")
   --datadir.ancient value             Data directory for ancient chain segments (default = inside chaindata)
   --remotedb value                    URL for remote database

--- a/docs/_interface/Command-Line-Options.md
+++ b/docs/_interface/Command-Line-Options.md
@@ -57,6 +57,8 @@ ETHEREUM OPTIONS:
   --lightkdf                          Reduce key-derivation RAM & CPU usage at some expense of KDF strength
   --eth.requiredblocks value          Comma separated block number-to-hash mappings to require for peering (<number>=<hash>)
   --mainnet                           Ethereum mainnet
+  --ropsten                           Ropsten network: pre-configured proof-of-stake test network
+  --rinkeby                           Rinkeby network: pre-configured proof-of-authority test network
   --goerli                            Görli network: pre-configured proof-of-authority test network
   --sepolia                           Sepolia network: pre-configured proof-of-work test network
   --datadir value                     Data directory for the databases and keystore (default: "~/.ethereum")

--- a/docs/_interface/Command-Line-Options.md
+++ b/docs/_interface/Command-Line-Options.md
@@ -47,7 +47,7 @@ ETHEREUM OPTIONS:
   --keystore value                    Directory for the keystore (default = inside the datadir)
   --usb                               Enable monitoring and management of USB hardware wallets
   --pcscdpath value                   Path to the smartcard daemon (pcscd) socket file
-  --networkid value                   Explicitly set network id (integer)(For testnets: use --ropsten, --rinkeby, --goerli instead) (default: 1)
+  --networkid value                   Explicitly set network id (integer)(For testnets: --sepolia, --goerli instead) (default: 1)
   --syncmode value                    Blockchain sync mode ("snap", "full" or "light") (default: snap)
   --exitwhensynced                    Exits after block synchronisation completes
   --gcmode value                      Blockchain garbage collection mode ("full", "archive") (default: "full")
@@ -57,11 +57,8 @@ ETHEREUM OPTIONS:
   --lightkdf                          Reduce key-derivation RAM & CPU usage at some expense of KDF strength
   --eth.requiredblocks value          Comma separated block number-to-hash mappings to require for peering (<number>=<hash>)
   --mainnet                           Ethereum mainnet
-  --ropsten                           Ropsten network: pre-configured proof-of-stake test network
-  --rinkeby                           Rinkeby network: pre-configured proof-of-authority test network
   --goerli                            Görli network: pre-configured proof-of-authority test network
   --sepolia                           Sepolia network: pre-configured proof-of-work test network
-  --kiln                              Kiln network: pre-configured proof-of-work to proof-of-stake test network
   --datadir value                     Data directory for the databases and keystore (default: "~/.ethereum")
   --datadir.ancient value             Data directory for ancient chain segments (default = inside chaindata)
   --remotedb value                    URL for remote database

--- a/docs/_interface/Command-Line-Options.md
+++ b/docs/_interface/Command-Line-Options.md
@@ -47,7 +47,7 @@ ETHEREUM OPTIONS:
   --keystore value                    Directory for the keystore (default = inside the datadir)
   --usb                               Enable monitoring and management of USB hardware wallets
   --pcscdpath value                   Path to the smartcard daemon (pcscd) socket file
-  --networkid value                   Explicitly set network id (integer)(For testnets: --sepolia, --goerli instead) (default: 1)
+  --networkid value                   Explicitly set network id (integer)(For testnets: use --ropsten, --rinkeby, --goerli instead) (default: 1)
   --syncmode value                    Blockchain sync mode ("snap", "full" or "light") (default: snap)
   --exitwhensynced                    Exits after block synchronisation completes
   --gcmode value                      Blockchain garbage collection mode ("full", "archive") (default: "full")

--- a/docs/_interface/Private-Network.md
+++ b/docs/_interface/Private-Network.md
@@ -26,7 +26,7 @@ geth --networkid 12345
 
 ### Choosing A Consensus Algorithm
 
-While the main network uses proof-of-work (PoW) to secure the blockchain, Geth also supports the the 'Clique' proof-of-authority (PoA) consensus algorithm as an alternative for private networks. Clique is strongly recommended for private testnets because PoA is far less resource-intensive than PoW. Clique is currently used as the consensus algorithm in public testnets such as [Rinkeby](https://www.rinkeby.io) and [Görli](https://goerli.net). The key differences between the consensus algorithms available in Geth are:
+While the main network uses proof-of-work (PoW) to secure the blockchain, Geth also supports the the 'Clique' proof-of-authority (PoA) consensus algorithm as an alternative for private networks. Clique is strongly recommended for private testnets because PoA is far less resource-intensive than PoW. The key differences between the consensus algorithms available in Geth are:
 
 #### Ethash
 
@@ -36,9 +36,7 @@ Geth's PoW algorithm, [Ethhash](https://ethereum.org/en/developers/docs/consensu
 
 Clique consensus is a PoA system where new blocks can be created by authorized 'signers' only. The clique consenus protocol is specified in [EIP-225][clique-eip]. The initial set of authorized signers is configured in the genesis block. Signers can be authorized and de-authorized using a voting mechanism, thus allowing the set of signers to change while the blockchain operates. Clique can be configured to target any block time (within reasonable limits) since it isn't tied to the difficulty adjustment.
 
-
 [clique-eip]: https://eips.ethereum.org/EIPS/eip-225
-
 
 ### Creating The Genesis Block
 

--- a/docs/_interface/consensus-clients.md
+++ b/docs/_interface/consensus-clients.md
@@ -93,7 +93,5 @@ information can be found on the clients' respective documentation sites or in nu
 [execution-clients-link]: https://ethereum.org/en/developers/docs/nodes-and-clients/client-diversity/#execution-clients
 [launchpad-link]:https://launchpad.ethereum.org/
 [prater-launchpad-link]:https://prater.launchpad.ethereum.org/
-[kiln-launchpad-link]:https://kiln.launchpad.ethereum.org/
-[ropsten-launchpad-link]:https://ropsten.launchpad.ethereum.org/
 [e-org-link]: https://ethereum.org/en/developers/docs/nodes-and-clients/run-a-node/
 [checklist-link]:https://launchpad.ethereum.org/en/merge-readiness

--- a/docs/_rpc/ns-eth.md
+++ b/docs/_rpc/ns-eth.md
@@ -85,6 +85,8 @@ call.
 
 #### Simple example
 
+**note that this example uses the Rinkeby testnet, which is now deprecated**
+
 With a synced Rinkeby node with RPC exposed on localhost (`geth --rinkeby --http`) we can
 make a call against the [Checkpoint
 Oracle](https://rinkeby.etherscan.io/address/0xebe8efa441b9302a0d7eaecc277c09d20d684540)


### PR DESCRIPTION
Removes references to deprecated testnets across site, persists goerli/sepolia.