### PR TITLE
docs: add info on checkpoint sync

### DIFF
--- a/docs/_interface/consensus-clients.md
+++ b/docs/_interface/consensus-clients.md
@@ -68,16 +68,26 @@ More information on this can be found in the documentation for each consensus cl
 
 ## Validators
 
-
 Validators are responsible for securing the Ethereum blockchain. Validators are node operators that have staked at least 
 32 ETH into a deposit contract and run validator software. Each of the consensus clients have their own validator software 
 that is described in detail in their respective documentation. The easiest way to handle staking and validator key generation 
 is to use the Ethereum Foundation [Staking Launchpad][launchpad-link].
 
+## Syncing
+
+Geth cannot sync until the connected consensus client is synced. The fastest way to sync a consensus client is 
+using checkpoint sync. To do this, a checkpoint or a url to a checkpoint provider can be provided to the consensus 
+client on startup. There are several sources for these checkpoints. The ideal scenario is to get one from a 
+trusted node operator, organized out-of-band, and verified against a third node or a block explorer or checkpoint 
+provider. Some clients also allow checkpoint syncing by HTTP API access to an existing Beacon node. 
+There are also several [public checkpoint sync endpoints](https://eth-clients.github.io/checkpoint-sync-endpoints/).
+
+Please see the pages on [syncing](/docs/interface/sync-modes.md) for more detail. For troubleshooting, 
+please see the `Syncing` section on the [console log messages](/docs/interface/logs.md) page.
 
 ## Summary
 
-Geth requires a connection to a consensus client in order to follow the Etheruem blockchain. There are five consensus clients 
+Geth requires a connection to a consensus client in order to follow the Ethereum blockchain. There are five consensus clients 
 to choose from. This page provided an overview of how to choose a consensus client and configure Geth to connect to it. More
 information can be found on the clients' respective documentation sites or in numerous 
 [online guides](https://github.com/SomerEsat/ethereum-staking-guides).

--- a/docs/_interface/sync-modes.md
+++ b/docs/_interface/sync-modes.md
@@ -116,7 +116,10 @@ Read more in the [optimistic sync specs](https://github.com/ethereum/consensus-s
 Alternatively, the consensus client can grab a checkpoint from a trusted source which provides a target state to sync 
 up to, before switching to full sync and verifying each block in turn. In this mode, the node trusts that the checkpoint 
 is correct. There are many possible sources for this checkpoint - the gold standard would be to get it out-of-band 
-from another trusted friend, but it could also come from block explorers or public APIs/web apps.
+from another trusted friend, but it could also come from block explorers or [public APIs/web apps](https://eth-clients.github.io/checkpoint-sync-endpoints/).
+
+Please see the pages on [syncing](/docs/interface/sync-modes.md) for more detail. For troubleshooting, 
+please see the `Syncing` section on the [console log messages](/docs/interface/logs.md) page.
 
 **Note** it is not currently possible to use a Geth light node as an execution client on proof-of-stake Ethereum.
 


### PR DESCRIPTION
adds some information about checkpoint sync to the consensus client and sync-modes pages