### PR TITLE
accounts/abi: add support for fixed bytes with size > 32

### DIFF
--- a/accounts/abi/argument.go
+++ b/accounts/abi/argument.go
@@ -206,6 +206,9 @@ func (arguments Arguments) UnpackValues(data []byte) ([]interface{}, error) {
 			// If we have a static tuple, like (uint256, bool, uint256), these are
 			// coded as just like uint256,bool,uint256
 			virtualArgs += getTypeSize(arg.Type)/32 - 1
+		} else if arg.Type.T == FixedBytesTy {
+			// support for fixed bytes with size longer than 32
+			virtualArgs += getTypeSize(arg.Type)/32 - 1
 		}
 		retval = append(retval, marshalledValue)
 	}

--- a/accounts/abi/pack.go
+++ b/accounts/abi/pack.go
@@ -64,7 +64,7 @@ func packElement(t Type, reflectValue reflect.Value) ([]byte, error) {
 		if reflectValue.Kind() == reflect.Array {
 			reflectValue = mustArrayToByteSlice(reflectValue)
 		}
-		return common.RightPadBytes(reflectValue.Bytes(), 32), nil
+		return common.RightPadBytes(reflectValue.Bytes(), (len(reflectValue.Bytes())+31)/32*32), nil
 	default:
 		return []byte{}, fmt.Errorf("Could not pack element, unknown type: %v", t.T)
 	}

--- a/accounts/abi/type.go
+++ b/accounts/abi/type.go
@@ -391,6 +391,8 @@ func getTypeSize(t Type) int {
 			total += getTypeSize(*elem)
 		}
 		return total
+	} else if t.T == FixedBytesTy {
+		return (t.Size + 31) / 32 * 32
 	}
 	return 32
 }


### PR DESCRIPTION
This PR fixes this testcase :

```
type fixedBytes struct {
	Chunk [4 * 1024]byte
	A     *big.Int
}

func TestMinimal(t *testing.T) {
	IntTy, _ := abi.NewType("uint256", "", nil)
	Bytes4096Ty, _ := abi.NewType("bytes4096", "", nil)
	Abi := abi.Arguments{
		{Type: Bytes4096Ty, Name: "Chunk"},
		{Type: IntTy, Name: "A"},
	}
	a := big.NewInt(10)
	chunk := [4 * 1024]byte{0x03, 0x4}
	packed, err := Abi.Pack(chunk, a)
	if err != nil {
		t.Fatal(err)
	}

	values, err := Abi.Unpack(packed)
	if err != nil {
		t.Fatal(err)
	}

	var decoded fixedBytes
	err = Abi.Copy(&decoded, values)
	if err != nil {
		t.Fatal(err)
	}
	if decoded.Chunk != chunk {
		t.Fatal("Chunk mismatch")
	}
	if decoded.A.Cmp(a) != 0 {
		t.Fatal("A mismatch")
	}
}
```