### PR TITLE
core/types: make transaction.Size accurate + tests

### DIFF
--- a/core/types/transaction.go
+++ b/core/types/transaction.go
@@ -381,7 +381,10 @@ func (tx *Transaction) Size() common.StorageSize {
 	c := writeCounter(0)
 	rlp.Encode(&c, &tx.inner)
 	tx.size.Store(common.StorageSize(c))
-	return common.StorageSize(c)
+	if tx.Type() == LegacyTxType {
+		return common.StorageSize(c)
+	}
+	return common.StorageSize(1 + c)
 }
 
 // WithSignature returns a new transaction with the given signature.

--- a/core/types/transaction.go
+++ b/core/types/transaction.go
@@ -380,11 +380,12 @@ func (tx *Transaction) Size() common.StorageSize {
 	}
 	c := writeCounter(0)
 	rlp.Encode(&c, &tx.inner)
-	tx.size.Store(common.StorageSize(c))
+	size := common.StorageSize(1 + c)
 	if tx.Type() == LegacyTxType {
-		return common.StorageSize(c)
+		size = common.StorageSize(c)
 	}
-	return common.StorageSize(1 + c)
+	tx.size.Store(size)
+	return size
 }
 
 // WithSignature returns a new transaction with the given signature.

--- a/core/types/transaction_test.go
+++ b/core/types/transaction_test.go
@@ -581,8 +581,13 @@ func TestSize(t *testing.T) {
 			t.Fatalf("test %d: %v", i, err)
 		}
 		bin, _ := tx.MarshalBinary()
+		// Check initial calc.
 		if have, want := int(tx.Size()), len(bin); have != want {
 			t.Errorf("test %d: size wrong, have %d want %d", i, have, want)
+		}
+		// Check cached version too
+		if have, want := int(tx.Size()), len(bin); have != want {
+			t.Errorf("test %d: (cached) size wrong, have %d want %d", i, have, want)
 		}
 	}
 }


### PR DESCRIPTION
This PR fixes the comment made here: https://github.com/ethereum/go-ethereum/pull/25980#issuecomment-1291825932 

IMO `Size()` should  equal the output of what `MarshalBinary` produces