### PR TITLE
build: make ios work again

### DIFF
--- a/build/ci.go
+++ b/build/ci.go
@@ -1150,7 +1150,7 @@ func doXCodeFramework(cmdline []string) {
 	tc := new(build.GoToolchain)
 
 	// Build gomobile.
-	build.MustRun(tc.Install(GOBIN, "golang.org/x/mobile/cmd/gomobile", "golang.org/x/mobile/cmd/gobind"))
+	build.MustRun(tc.Install(GOBIN, "golang.org/x/mobile/cmd/gomobile@latest", "golang.org/x/mobile/cmd/gobind@latest"))
 
 	// Build the iOS XCode framework
 	bind := gomobileTool("bind", "-ldflags", "-s -w", "--target", "ios", "-v", "github.com/ethereum/go-ethereum/mobile")


### PR DESCRIPTION
Before:
```
$ make ios
env GO111MODULE=on go run build/ci.go xcode --local
\>>> /opt/local/lib/go/bin/go install -mod=readonly golang.org/x/mobile/cmd/gomobile golang.org/x/mobile/cmd/gobind
\>>> /Users/Jakub/Projects/DEVELOPMENT/MAC/TheChain/go-ethereum_official/build/bin/gomobile bind -ldflags "-s -w" --target ios -v github.com/ethereum/go-ethereum/mobile
go: unsupported GOOS/GOARCH pair darwin/arm
/Users/Jakub/Projects/DEVELOPMENT/MAC/TheChain/go-ethereum_official/build/bin/gomobile: darwin-arm: go build -tags ios -v -ldflags -s -w -buildmode=c-archive -o /var/folders/2l/srt5z_nx559gqfgwf_0c__8r0000gp/T/gomobile-work-3436797179/geth-arm.a gobind failed: exit status 2

util.go:48: exit status 1
exit status 1
make: *** [ios] Error 1
$
```

After:
```
$ make ios
env GO111MODULE=on go run build/ci.go xcode --local
\>>> /opt/local/lib/go/bin/go install -mod=readonly golang.org/x/mobile/cmd/gomobile@latest golang.org/x/mobile/cmd/gobind@latest
\>>> /Users/Jakub/Projects/DEVELOPMENT/MAC/TheChain/go-ethereum_official/build/bin/gomobile bind -ldflags "-s -w" --target ios -v github.com/ethereum/go-ethereum/mobile

(...)

xcframework successfully written out to: /Users/Jakub/Projects/DEVELOPMENT/MAC/TheChain/go-ethereum_official/build/bin/Geth.xcframework
Done building.
Import "./build/bin/Geth.framework" to use the library.
$
```