### PR TITLE
core/state, trie: fix memleak from fastcache

### DIFF
--- a/trie/database.go
+++ b/trie/database.go
@@ -301,7 +301,15 @@ func NewDatabaseWithConfig(diskdb ethdb.KeyValueStore, config *Config) *Database
 		}},
 		preimages: preimage,
 	}
+	runtime.SetFinalizer(db, (*Database).finalizer)
 	return db
+}
+
+// must call Reset() to reclaim memory used by fastcache
+func (db *Database) finalizer() {
+	if db.cleans != nil {
+		db.cleans.Reset()
+	}
 }
 
 // insert inserts a simplified trie node into the memory database.


### PR DESCRIPTION
Fastcache uses memory allocated by mmap, which is not garbage collected.
Data filled in the codeCache is therefore leaked when the stateDatabase is discarded (e.g. in StateAtBlock).
Same goes for cleans fastcache when used in the TrieDB.

Reset() doesn't unmap memory from the OS, but it does move all chunks to fastcache's global free chunk list, allowing it to be reused by later instances.

Fastcache is also used by the snapshot. I did not add Reset to those instances to minimize diff and because the snapshot is not regularly discarded. I can add cleaning that up as well if you wish.
