### PR TITLE
accounts/abi: fixed bytes with size larger than 32 bytes is not allowed

### DIFF
--- a/accounts/abi/type.go
+++ b/accounts/abi/type.go
@@ -154,6 +154,9 @@ func NewType(t string, internalType string, components []ArgumentMarshaling) (ty
 		if varSize == 0 {
 			typ.T = BytesTy
 		} else {
+			if varSize > 32 {
+				return Type{}, fmt.Errorf("unsupported arg type: %s", t)
+			}
 			typ.T = FixedBytesTy
 			typ.Size = varSize
 		}

--- a/accounts/abi/type_test.go
+++ b/accounts/abi/type_test.go
@@ -366,3 +366,10 @@ func TestGetTypeSize(t *testing.T) {
 		}
 	}
 }
+
+func TestNewFixedBytesOver32(t *testing.T) {
+	_, err := NewType("bytes4096", "", nil)
+	if err == nil {
+		t.Errorf("fixed bytes with size over 32 is not spec'd")
+	}
+}


### PR DESCRIPTION
This is a follow-up PR for this one:https://github.com/ethereum/go-ethereum/pull/26043