### PR TITLE
miner: fail early if core.NewBlockChain fails

### DIFF
--- a/miner/worker_test.go
+++ b/miner/worker_test.go
@@ -134,7 +134,10 @@ func newTestWorkerBackend(t *testing.T, chainConfig *params.ChainConfig, engine 
 	default:
 		t.Fatalf("unexpected consensus engine type: %T", engine)
 	}
-	chain, _ := core.NewBlockChain(db, &core.CacheConfig{TrieDirtyDisabled: true}, gspec, nil, engine, vm.Config{}, nil, nil)
+	chain, err := core.NewBlockChain(db, &core.CacheConfig{TrieDirtyDisabled: true}, gspec, nil, engine, vm.Config{}, nil, nil)
+	if err != nil {
+		t.Fatalf("core.NewBlockChain failed: %v", err)
+	}
 	txpool := txpool.NewTxPool(testTxPoolConfig, chainConfig, chain)
 
 	// Generate a small n-block chain and an uncle block for it


### PR DESCRIPTION
If NewBlockChain fails here, you would previously get a confusing panic later on in worker_test whose origin is non-trivial to diagnose. For example I encountered the output below when working on an eip-4844 related change:

> --- FAIL: TestGenerateBlockWithBlobsAndImportEthash (0.00s)
> panic: runtime error: invalid memory address or nil pointer dereference [recovered]
> 	panic: runtime error: invalid memory address or nil pointer dereference
> [signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x809cb4]
>
> goroutine 75 [running]:
> testing.tRunner.func1.2({0x8e19e0, 0xebe080})
> 	/usr/local/go/src/testing/testing.go:1389 +0x24e
> testing.tRunner.func1()
> 	/usr/local/go/src/testing/testing.go:1392 +0x39f
> panic({0x8e19e0, 0xebe080})
> 	/usr/local/go/src/runtime/panic.go:838 +0x207
> github.com/ethereum/go-ethereum/core.(*BlockChain).CurrentBlock(0x0?)
> 	/nvme/src/github.com/Inphi/eip4844-interop/geth/go-ethereum/core/blockchain_reader.go:43 +0x14
> github.com/ethereum/go-ethereum/core.NewTxPool({{0x0, 0x0, 0x0}, 0x0, {0x0, 0x0}, 0x34630b8a000, 0x1, 0xa, 0x10, ...}, ...)
> 	/nvme/src/github.com/Inphi/eip4844-interop/geth/go-ethereum/core/tx_pool.go:321 +0x692
> github.com/ethereum/go-ethereum/miner.newTestWorkerBackend(0xc000602340, 0xf12f00, {0xc2c588?, 0xc0000ec2a0?}, {0xc2d2d8?, 0xc00025a070}, 0x0)
> 	/nvme/src/github.com/Inphi/eip4844-interop/geth/go-ethereum/miner/worker_test.go:142 +0x42a
> github.com/ethereum/go-ethereum/miner.newTestWorker(0xc0001cd400?, 0x0?, {0xc2c588, 0xc0000ec2a0}, {0xc2d2d8?, 0xc00025a070?}, 0x6263323863666561?)
> 	/nvme/src/github.com/Inphi/eip4844-interop/geth/go-ethereum/miner/worker_test.go:243 +0x45
> github.com/ethereum/go-ethereum/miner.testGenerateBlockWithBlobsAndImport(0xc000602340, 0x0)
> 	/nvme/src/github.com/Inphi/eip4844-interop/geth/go-ethereum/miner/worker_test.go:732 +0x2a9
> github.com/ethereum/go-ethereum/miner.TestGenerateBlockWithBlobsAndImportEthash(0x6534386263376661?)
> 	/nvme/src/github.com/Inphi/eip4844-interop/geth/go-ethereum/miner/worker_test.go:790 +0x1b
> testing.tRunner(0xc000602340, 0xb7d7f0)
> 	/usr/local/go/src/testing/testing.go:1439 +0x102
> created by testing.(*T).Run
> 	/usr/local/go/src/testing/testing.go:1486 +0x35f
> exit status 2
> FAIL	github.com/ethereum/go-ethereum/miner	2.272s