### PR TITLE
cmd/clef add `listAccounts` to CLI

### DIFF
--- a/cmd/clef/main.go
+++ b/cmd/clef/main.go
@@ -522,7 +522,7 @@ func listWallets(c *cli.Context) error{
 		fmt.Printf("Wallet %d at %v (%v %v)\n", i, wallet.URL, wallet.Status, wallet.Failure)
 		fmt.Printf("Accounts in Wallet %d:\n", i)
 		for j, acc := range wallet.Accounts {
-			fmt.Printf("Account %d: %v (%v)\n", j, acc.Address, acc.URL)
+			fmt.Printf("  -Account %d: %v (%v)\n", j, acc.Address, acc.URL)
 		}
 		fmt.Println()
 	}

--- a/cmd/clef/main.go
+++ b/cmd/clef/main.go
@@ -402,7 +402,7 @@ func listAccounts(c *cli.Context) error {
 	}
 	fmt.Println()
 	for _, account := range accs {
-		fmt.Println(account.Address)
+		fmt.Printf("%v (%v)\n", account.Address, account.URL)
 	}
 	return err
 }

--- a/cmd/clef/main.go
+++ b/cmd/clef/main.go
@@ -427,8 +427,11 @@ func listWallets(c *cli.Context) error{
 		fmt.Println("\nThere are no wallets.")
 	}
 	fmt.Println()
-	for _, wallet := range wallets {
-		fmt.Println(wallet)
+	for i, wallet := range wallets {
+		fmt.Printf("%d. Keystore at %v (%v %v)\n", i, wallet.URL, wallet.Status, wallet.Failure)
+		for _, acc := range wallet.Accounts {
+			fmt.Printf("\t%v (%v)\n", acc.Address, acc.URL)
+		}
 	}
 	return nil
 }

--- a/cmd/clef/main.go
+++ b/cmd/clef/main.go
@@ -216,6 +216,12 @@ The gendoc generates example structures of the json-rpc communication types.
 		Action: listAccounts,
 		Name:   "listaccounts",
 		Usage:  "List accounts in the keystore",
+		Flags: []cli.Flag{
+			logLevelFlag,
+			keystoreFlag,
+			utils.LightKDFFlag,
+			acceptFlag,
+		},
 		Description: `
 	Lists the accounts in the keystore.
 	`}

--- a/cmd/clef/main.go
+++ b/cmd/clef/main.go
@@ -378,15 +378,17 @@ func listAccounts(c *cli.Context) error {
 	am := core.StartClefAccountManager(ksLoc, true, lightKdf, "")
 	// Access external API and call List()
 	api := core.NewSignerAPI(am, 0, true, ui, nil, false, pwStorage)
-	accs, err := api.List(context.Background())
+	internalApi := core.NewUIServerAPI(api)
+	accs, err := internalApi.ListAccounts(context.Background())
 	if err != nil {
 		return err
 	}
 	if len(accs) == 0 {
 		fmt.Println("\nThe keystore is empty.")
 	}
+	fmt.Println()
 	for _, account := range accs {
-		fmt.Println(account)
+		fmt.Println(account.Address)
 	}
 	return err
 }

--- a/cmd/clef/main.go
+++ b/cmd/clef/main.go
@@ -492,7 +492,7 @@ func newAccount(c *cli.Context) error {
 func listAccounts(c *cli.Context) error {
 	internalApi, err := initInternalApi(c)
 	if err != nil {
-	    return err
+		return err
 	}
 	accs, err := internalApi.ListAccounts(context.Background())
 	if err != nil {
@@ -508,7 +508,7 @@ func listAccounts(c *cli.Context) error {
 	return err
 }
 
-func listWallets(c *cli.Context) error{
+func listWallets(c *cli.Context) error {
 	internalApi, err := initInternalApi(c)
 	if err != nil {
 		return err

--- a/cmd/clef/main.go
+++ b/cmd/clef/main.go
@@ -378,7 +378,7 @@ func attestFile(ctx *cli.Context) error {
 	return nil
 }
 
-func initInternalApi(c *cli.Context) (*core.UIServerAPI, error){
+func initInternalApi(c *cli.Context) (*core.UIServerAPI, error) {
 	if err := initialize(c); err != nil {
 		return nil, err
 	}

--- a/cmd/clef/main.go
+++ b/cmd/clef/main.go
@@ -452,18 +452,6 @@ func removeCredential(ctx *cli.Context) error {
 	return nil
 }
 
-func newAccount(c *cli.Context) error {
-	internalApi, err := initInternalApi(c)
-	if err != nil {
-		return err
-	}
-	addr, err := internalApi.New(context.Background())
-	if err == nil {
-		fmt.Printf("Generated account %v\n", addr.String())
-	}
-	return err
-}
-
 func initialize(c *cli.Context) error {
 	// Set up the logger to print everything
 	logOutput := os.Stdout
@@ -487,6 +475,18 @@ func initialize(c *cli.Context) error {
 	log.Root().SetHandler(log.LvlFilterHandler(log.Lvl(c.Int(logLevelFlag.Name)), log.StreamHandler(output, log.TerminalFormat(usecolor))))
 
 	return nil
+}
+
+func newAccount(c *cli.Context) error {
+	internalApi, err := initInternalApi(c)
+	if err != nil {
+		return err
+	}
+	addr, err := internalApi.New(context.Background())
+	if err == nil {
+		fmt.Printf("Generated account %v\n", addr.String())
+	}
+	return err
 }
 
 func listAccounts(c *cli.Context) error {
@@ -519,8 +519,7 @@ func listWallets(c *cli.Context) error{
 	}
 	fmt.Println()
 	for i, wallet := range wallets {
-		fmt.Printf("Wallet %d at %v (%v %v)\n", i, wallet.URL, wallet.Status, wallet.Failure)
-		fmt.Printf("Accounts in Wallet %d:\n", i)
+		fmt.Printf("- Wallet %d at %v (%v %v)\n", i, wallet.URL, wallet.Status, wallet.Failure)
 		for j, acc := range wallet.Accounts {
 			fmt.Printf("  -Account %d: %v (%v)\n", j, acc.Address, acc.URL)
 		}

--- a/cmd/clef/main.go
+++ b/cmd/clef/main.go
@@ -491,6 +491,9 @@ func initialize(c *cli.Context) error {
 
 func listAccounts(c *cli.Context) error {
 	internalApi, err := initInternalApi(c)
+	if err != nil {
+	    return err
+	}
 	accs, err := internalApi.ListAccounts(context.Background())
 	if err != nil {
 		return err

--- a/cmd/clef/main.go
+++ b/cmd/clef/main.go
@@ -503,7 +503,7 @@ func listAccounts(c *cli.Context) error {
 	}
 	fmt.Println()
 	for _, account := range accs {
-		fmt.Println(account.Address)
+		fmt.Printf("%v (%v)\n", account.Address, account.URL)
 	}
 	return err
 }

--- a/cmd/clef/main.go
+++ b/cmd/clef/main.go
@@ -394,43 +394,6 @@ func initInternalApi(c *cli.Context) (*core.UIServerAPI, error){
 	return internalApi, nil
 }
 
-func listAccounts(c *cli.Context) error {
-	internalApi, err := initInternalApi(c)
-	accs, err := internalApi.ListAccounts(context.Background())
-	if err != nil {
-		return err
-	}
-	if len(accs) == 0 {
-		fmt.Println("\nThe keystore is empty.")
-	}
-	fmt.Println()
-	for _, account := range accs {
-		fmt.Println(account.Address)
-	}
-	return err
-}
-
-func listWallets(c *cli.Context) error{
-	internalApi, err := initInternalApi(c)
-	if err != nil {
-		return err
-	}
-	wallets := internalApi.ListWallets()
-	if len(wallets) == 0 {
-		fmt.Println("\nThere are no wallets.")
-	}
-	fmt.Println()
-	for i, wallet := range wallets {
-		fmt.Printf("Wallet %d at %v (%v %v)\n", i, wallet.URL, wallet.Status, wallet.Failure)
-		fmt.Printf("Accounts in Wallet %d:\n", i)
-		for j, acc := range wallet.Accounts {
-			fmt.Printf("Account %d: %v (%v)\n", j, acc.Address, acc.URL)
-		}
-		fmt.Println()
-	}
-	return nil
-}
-
 func setCredential(ctx *cli.Context) error {
 	if ctx.NArg() < 1 {
 		utils.Fatalf("This command requires an address to be passed as an argument")
@@ -523,6 +486,43 @@ func initialize(c *cli.Context) error {
 	}
 	log.Root().SetHandler(log.LvlFilterHandler(log.Lvl(c.Int(logLevelFlag.Name)), log.StreamHandler(output, log.TerminalFormat(usecolor))))
 
+	return nil
+}
+
+func listAccounts(c *cli.Context) error {
+	internalApi, err := initInternalApi(c)
+	accs, err := internalApi.ListAccounts(context.Background())
+	if err != nil {
+		return err
+	}
+	if len(accs) == 0 {
+		fmt.Println("\nThe keystore is empty.")
+	}
+	fmt.Println()
+	for _, account := range accs {
+		fmt.Println(account.Address)
+	}
+	return err
+}
+
+func listWallets(c *cli.Context) error{
+	internalApi, err := initInternalApi(c)
+	if err != nil {
+		return err
+	}
+	wallets := internalApi.ListWallets()
+	if len(wallets) == 0 {
+		fmt.Println("\nThere are no wallets.")
+	}
+	fmt.Println()
+	for i, wallet := range wallets {
+		fmt.Printf("Wallet %d at %v (%v %v)\n", i, wallet.URL, wallet.Status, wallet.Failure)
+		fmt.Printf("Accounts in Wallet %d:\n", i)
+		for j, acc := range wallet.Accounts {
+			fmt.Printf("Account %d: %v (%v)\n", j, acc.Address, acc.URL)
+		}
+		fmt.Println()
+	}
 	return nil
 }
 


### PR DESCRIPTION
Account listing is not currently available in Clef's CLI - it is only available using a Clef UI or by calling `eth.accounts` or `personal.listAccounts` which is being deprecated. 

This PR adds `clef listaccounts` as a Clef subcommand. 

The benefits of this are:

a) UX is better than having to implement a UI that can access the internal API, 
b) it is secure because the request requires explicit approval in Clef; 
c) it does not rely on a running Geth instance to handle calls to `eth.accoutns` - enables listing when Clef is used as standalone signer. 

Example:

```
>> ./clef listaccounts

...

INFO [10-31|15:47:12.847] Starting clef                            keystore=/home/user/.ethereum/keystore light-kdf=false
DEBUG[10-31|15:47:12.848] FS scan times                            list="159.958µs" set="59.927µs" diff="8.627µs"
-------- List Account request--------------
A request has been made to list all accounts. 
You can select which accounts the caller can see
  [x] 0xE70CAD05D0D54Ae3C9Fe5442f901E0433f9bd14B
    URL: keystore:///home/user/.ethereum/keystore/UTC--2022-10-31T15-45-59.185124924Z--e70cad05d0d54ae3c9fe5442f901e0433f9bd14b
  [x] 0xdD309879A192eB29512591b94B30E73463055376
    URL: keystore:///home/user/.ethereum/keystore/UTC--2022-10-31T15-46-55.508862995Z--dd309879a192eb29512591b94b30e73463055376
  [x] 0x4337A0186Fd86538C4d0E55fB38962bA736e546D
    URL: keystore:///home/user/.ethereum/keystore/UTC--2022-10-31T15-47-04.828100209Z--4337a0186fd86538c4d0e55fb38962ba736e546d
-------------------------------------------
Request context:
        NA -> NA -> NA

Additional HTTP header data, provided by the external caller:
        User-Agent: ""
        Origin: ""
Approve? [y/N]:
> y
0xE70CAD05D0D54Ae3C9Fe5442f901E0433f9bd14B
0xdD309879A192eB29512591b94B30E73463055376
0x4337A0186Fd86538C4d0E55fB38962bA736e546D
```

Alternatively a warning `The keystore is empty` is returned if there are no files in the keystore.

contributes to issue #25948 