### PR TITLE
cmd/devp2p/internal/v4test: ignore FINDNODE in BondThenPingWithWrongFrom

### DIFF
--- a/cmd/devp2p/internal/v4test/discv4tests.go
+++ b/cmd/devp2p/internal/v4test/discv4tests.go
@@ -278,7 +278,6 @@ func BondThenPingWithWrongFrom(t *utesting.T) {
 			// PONG response, all good
 			break
 		case v4wire.FindnodePacket:
-			t.Log("Received FindNode, ignored, still waiting for PONG")
 			continue // A FindNode is ok, just ignore it
 		default:
 			t.Fatalf("Expected PONG, got %v %v", reply.Name(), reply)

--- a/cmd/devp2p/internal/v4test/discv4tests.go
+++ b/cmd/devp2p/internal/v4test/discv4tests.go
@@ -278,6 +278,7 @@ func BondThenPingWithWrongFrom(t *utesting.T) {
 			// PONG response, all good
 			break
 		case v4wire.FindnodePacket:
+			t.Log("Received FindNode, ignored, still waiting for PONG")
 			continue // A FindNode is ok, just ignore it
 		default:
 			t.Fatalf("Expected PONG, got %v %v", reply.Name(), reply)

--- a/cmd/devp2p/internal/v4test/discv4tests.go
+++ b/cmd/devp2p/internal/v4test/discv4tests.go
@@ -283,6 +283,7 @@ func BondThenPingWithWrongFrom(t *utesting.T) {
 		default:
 			t.Fatalf("Expected PONG, got %v %v", reply.Name(), reply)
 		}
+		break
 	}
 }
 


### PR DESCRIPTION
Nethermind is sometimes failing hive test `BondThenPingWithWrongFrom` because of sending `FindNode` instead of expected `Pong`. Sometimes `Pong` is our first response and then we are passing this test. As we were bonded before receiving `Ping`, we consider sending `FindNode` as acceptable. This PR is changing test `BondThenPingWithWrongFrom` to ignore received `FindNode` while waiting for `Pong` response.
I tested it and after changes from this PR we are always passing `BondThenPingWithWrongFrom`.