### PR TITLE
eth/tracers: add multiplexing tracer

### DIFF
--- a/eth/tracers/logger/logger.go
+++ b/eth/tracers/logger/logger.go
@@ -151,7 +151,6 @@ func (l *StructLogger) CaptureStart(env *vm.EVM, from common.Address, to common.
 func (l *StructLogger) CaptureState(pc uint64, op vm.OpCode, gas, cost uint64, scope *vm.ScopeContext, rData []byte, depth int, err error) {
 	// If tracing was interrupted, set the error and stop
 	if atomic.LoadUint32(&l.interrupt) > 0 {
-		l.env.Cancel()
 		return
 	}
 	// check if already accumulated the specified number of logs

--- a/eth/tracers/native/4byte.go
+++ b/eth/tracers/native/4byte.go
@@ -47,7 +47,6 @@ func init() {
 //	  0xc281d19e-0: 1
 //	}
 type fourByteTracer struct {
-	env               *vm.EVM
 	ids               map[string]int   // ids aggregates the 4byte ids found
 	interrupt         uint32           // Atomic flag to signal execution interruption
 	reason            error            // Textual reason for the interruption
@@ -81,8 +80,6 @@ func (t *fourByteTracer) store(id []byte, size int) {
 
 // CaptureStart implements the EVMLogger interface to initialize the tracing operation.
 func (t *fourByteTracer) CaptureStart(env *vm.EVM, from common.Address, to common.Address, create bool, input []byte, gas uint64, value *big.Int) {
-	t.env = env
-
 	// Update list of precompiles based on current block
 	rules := env.ChainConfig().Rules(env.Context.BlockNumber, env.Context.Random != nil)
 	t.activePrecompiles = vm.ActivePrecompiles(rules)
@@ -101,7 +98,6 @@ func (t *fourByteTracer) CaptureState(pc uint64, op vm.OpCode, gas, cost uint64,
 func (t *fourByteTracer) CaptureEnter(op vm.OpCode, from common.Address, to common.Address, input []byte, gas uint64, value *big.Int) {
 	// Skip if tracing was interrupted
 	if atomic.LoadUint32(&t.interrupt) > 0 {
-		t.env.Cancel()
 		return
 	}
 	if len(input) < 4 {

--- a/eth/tracers/native/call.go
+++ b/eth/tracers/native/call.go
@@ -99,7 +99,6 @@ type callFrameMarshaling struct {
 }
 
 type callTracer struct {
-	env       *vm.EVM
 	callstack []callFrame
 	config    callTracerConfig
 	gasLimit  uint64
@@ -128,7 +127,6 @@ func newCallTracer(ctx *tracers.Context, cfg json.RawMessage) (tracers.Tracer, e
 
 // CaptureStart implements the EVMLogger interface to initialize the tracing operation.
 func (t *callTracer) CaptureStart(env *vm.EVM, from common.Address, to common.Address, create bool, input []byte, gas uint64, value *big.Int) {
-	t.env = env
 	t.callstack[0] = callFrame{
 		Type:  vm.CALL,
 		From:  from,
@@ -159,7 +157,6 @@ func (t *callTracer) CaptureState(pc uint64, op vm.OpCode, gas, cost uint64, sco
 	}
 	// Skip if tracing was interrupted
 	if atomic.LoadUint32(&t.interrupt) > 0 {
-		t.env.Cancel()
 		return
 	}
 	switch op {
@@ -195,7 +192,6 @@ func (t *callTracer) CaptureEnter(typ vm.OpCode, from common.Address, to common.
 	}
 	// Skip if tracing was interrupted
 	if atomic.LoadUint32(&t.interrupt) > 0 {
-		t.env.Cancel()
 		return
 	}
 

--- a/eth/tracers/native/mux.go
+++ b/eth/tracers/native/mux.go
@@ -1,0 +1,139 @@
+// Copyright 2022 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+package native
+
+import (
+	"encoding/json"
+	"math/big"
+	"time"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/vm"
+	"github.com/ethereum/go-ethereum/eth/tracers"
+)
+
+func init() {
+	register("muxTracer", newMuxTracer)
+}
+
+// muxTracer is a go implementation of the Tracer interface which
+// runs multiple tracers in one go.
+type muxTracer struct {
+	names   []string
+	tracers []tracers.Tracer
+}
+
+// newMuxTracer returns a new mux tracer.
+func newMuxTracer(ctx *tracers.Context, cfg json.RawMessage) (tracers.Tracer, error) {
+	var config map[string]json.RawMessage
+	if cfg != nil {
+		if err := json.Unmarshal(cfg, &config); err != nil {
+			return nil, err
+		}
+	}
+	objects := make([]tracers.Tracer, 0, len(config))
+	names := make([]string, 0, len(config))
+	for k, v := range config {
+		t, err := tracers.New(k, ctx, v)
+		if err != nil {
+			return nil, err
+		}
+		objects = append(objects, t)
+		names = append(names, k)
+	}
+
+	return &muxTracer{names: names, tracers: objects}, nil
+}
+
+// CaptureStart implements the EVMLogger interface to initialize the tracing operation.
+func (t *muxTracer) CaptureStart(env *vm.EVM, from common.Address, to common.Address, create bool, input []byte, gas uint64, value *big.Int) {
+	for _, t := range t.tracers {
+		t.CaptureStart(env, from, to, create, input, gas, value)
+	}
+}
+
+// CaptureEnd is called after the call finishes to finalize the tracing.
+func (t *muxTracer) CaptureEnd(output []byte, gasUsed uint64, elapsed time.Duration, err error) {
+	for _, t := range t.tracers {
+		t.CaptureEnd(output, gasUsed, elapsed, err)
+	}
+}
+
+// CaptureState implements the EVMLogger interface to trace a single step of VM execution.
+func (t *muxTracer) CaptureState(pc uint64, op vm.OpCode, gas, cost uint64, scope *vm.ScopeContext, rData []byte, depth int, err error) {
+	for _, t := range t.tracers {
+		t.CaptureState(pc, op, gas, cost, scope, rData, depth, err)
+	}
+}
+
+// CaptureFault implements the EVMLogger interface to trace an execution fault.
+func (t *muxTracer) CaptureFault(pc uint64, op vm.OpCode, gas, cost uint64, scope *vm.ScopeContext, depth int, err error) {
+	for _, t := range t.tracers {
+		t.CaptureFault(pc, op, gas, cost, scope, depth, err)
+	}
+}
+
+// CaptureEnter is called when EVM enters a new scope (via call, create or selfdestruct).
+func (t *muxTracer) CaptureEnter(typ vm.OpCode, from common.Address, to common.Address, input []byte, gas uint64, value *big.Int) {
+	for _, t := range t.tracers {
+		t.CaptureEnter(typ, from, to, input, gas, value)
+	}
+}
+
+// CaptureExit is called when EVM exits a scope, even if the scope didn't
+// execute any code.
+func (t *muxTracer) CaptureExit(output []byte, gasUsed uint64, err error) {
+	for _, t := range t.tracers {
+		t.CaptureExit(output, gasUsed, err)
+	}
+}
+
+func (t *muxTracer) CaptureTxStart(gasLimit uint64) {
+	for _, t := range t.tracers {
+		t.CaptureTxStart(gasLimit)
+	}
+}
+
+func (t *muxTracer) CaptureTxEnd(restGas uint64) {
+	for _, t := range t.tracers {
+		t.CaptureTxEnd(restGas)
+	}
+}
+
+// GetResult returns an empty json object.
+func (t *muxTracer) GetResult() (json.RawMessage, error) {
+	resObject := make(map[string]json.RawMessage)
+	for i, tt := range t.tracers {
+		r, err := tt.GetResult()
+		if err != nil {
+			return nil, err
+		}
+		resObject[t.names[i]] = r
+	}
+	res, err := json.Marshal(resObject)
+	if err != nil {
+		return nil, err
+	}
+	return res, nil
+}
+
+// Stop terminates execution of the tracer at the first opportune moment.
+func (t *muxTracer) Stop(err error) {
+	for _, t := range t.tracers {
+		t.Stop(err)
+	}
+}


### PR DESCRIPTION
Sometimes users might need the result of multiple tracers for a given tx. This PR introduces the `muxTracer` which allows you to do this. It takes in a list of tracers and their configs and returns each one's corresponding result with one run through the tx:

```console
> debug.traceTransaction('0xf8fd7bea3dc42ee81922584884d3f741e8e475ecccb75b0e4f2dad042061c723', { tracer: 'muxTracer', tracerConfig: { prestateTracer: { diffMode: true}, callTracer: null }})
{
  callTracer: {
    from: "0x2806a6d83218acc8b223063bd058957d38966a09",
    gas: "0x0",
    gasUsed: "0x5208",
    input: "0x",
    to: "0x2806a6d83218acc8b223063bd058957d38966a09",
    type: "CALL",
    value: "0x1"
  },
  prestateTracer: {
    post: {
      0x2806a6d83218acc8b223063bd058957d38966a09: {
        balance: "0xffffffffffffffffffffffffffffffffffffffffffffffffffffef49bca6f9f7",
        nonce: 1
      }
    },
    pre: {
      0x2806a6d83218acc8b223063bd058957d38966a09: {
        balance: "0xfffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff7"
      }
    }
  }
}
```

There's a trick that allows you to use the same tracer with different configs by using a nested `muxTracer` (e.g. to get both prestate and statediff):

```console
> debug.traceTransaction('0xf8fd7bea3dc42ee81922584884d3f741e8e475ecccb75b0e4f2dad042061c723', { tracer: 'muxTracer', tracerConfig: { prestateTracer: { diffMode: true}, muxTracer: { prestateTracer: null } }})
{
  muxTracer: {
    prestateTracer: {
      0x2806a6d83218acc8b223063bd058957d38966a09: {
        balance: "0xfffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff7"
      }
    }
  },
  prestateTracer: {
    post: {
      0x2806a6d83218acc8b223063bd058957d38966a09: {
        balance: "0xffffffffffffffffffffffffffffffffffffffffffffffffffffef49bca6f9f7",
        nonce: 1
      }
    },
    pre: {
      0x2806a6d83218acc8b223063bd058957d38966a09: {
        balance: "0xfffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff7"
      }
    }
  }
}
```

It's possible to directly add support for this to the API, e.g. `debug.traceTransaction('<txhash>', { tracerList: {...} })` but I feel like being able to add this feature without having to modify the API is a big plus.

Unrelated commit in the PR: I also moved EVM cancellation to be the API's responsibility instead of the tracer. I feel like it's more fitting.