### PR TITLE
core/state: replace fastcache code cache with gc-friendly structure

### DIFF
--- a/common/lru/blob_lru.go
+++ b/common/lru/blob_lru.go
@@ -1,0 +1,69 @@
+// Copyright 2022 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+package lru
+
+import (
+	"math"
+
+	"github.com/hashicorp/golang-lru/simplelru"
+)
+
+// SizeConstrainedLRU is a wrapper around simplelru.LRU, which
+// adds a byte-size constraint.
+type SizeConstrainedLRU struct {
+	size    uint64
+	maxSize uint64
+	lru     *simplelru.LRU
+}
+
+// NewSizeConstraiedLRU creates a new SizeConstrainedLRU.
+func NewSizeConstraiedLRU(max uint64) *SizeConstrainedLRU {
+	lru, err := simplelru.NewLRU(math.MaxInt, nil)
+	if err != nil {
+		panic(err)
+	}
+	return &SizeConstrainedLRU{
+		size:    0,
+		maxSize: max,
+		lru:     lru,
+	}
+}
+
+// Add adds a value to the cache.  Returns true if an eviction occurred.
+func (c *SizeConstrainedLRU) Add(key string, value string) (evicted bool) {
+	targetSize := c.size + uint64(len(value))
+	for targetSize > c.maxSize {
+		evicted = true
+		_, v, ok := c.lru.RemoveOldest()
+		if !ok {
+			// list is now empty. Break
+			break
+		}
+		targetSize -= uint64(len(v.(string)))
+	}
+	c.size = targetSize
+	c.lru.Add(key, value)
+	return evicted
+}
+
+// Get looks up a key's value from the cache.
+func (c *SizeConstrainedLRU) Get(key string) (value string, ok bool) {
+	if v, ok := c.lru.Get(key); ok {
+		return v.(string), ok
+	}
+	return "", false
+}

--- a/common/lru/blob_lru.go
+++ b/common/lru/blob_lru.go
@@ -43,6 +43,11 @@ func NewSizeConstraiedLRU(max uint64) *SizeConstrainedLRU {
 	}
 }
 
+// Set adds a value to the cache.  Returns true if an eviction occurred.
+func (c *SizeConstrainedLRU) Set(key []byte, value []byte) (evicted bool) {
+	return c.Add(string(key), string(value))
+}
+
 // Add adds a value to the cache.  Returns true if an eviction occurred.
 func (c *SizeConstrainedLRU) Add(key string, value string) (evicted bool) {
 	targetSize := c.size + uint64(len(value))
@@ -61,9 +66,9 @@ func (c *SizeConstrainedLRU) Add(key string, value string) (evicted bool) {
 }
 
 // Get looks up a key's value from the cache.
-func (c *SizeConstrainedLRU) Get(key string) (value string, ok bool) {
-	if v, ok := c.lru.Get(key); ok {
-		return v.(string), ok
+func (c *SizeConstrainedLRU) Get(key []byte) []byte {
+	if v, ok := c.lru.Get(string(key)); ok {
+		return []byte(v.(string))
 	}
-	return "", false
+	return nil
 }

--- a/common/lru/blob_lru_test.go
+++ b/common/lru/blob_lru_test.go
@@ -96,3 +96,18 @@ func TestBlobLruOverflow(t *testing.T) {
 		}
 	}
 }
+
+// TestBlobLruSameItem tests what happens when inserting the same k/v multiple times.
+func TestBlobLruSameItem(t *testing.T) {
+	lru := NewSizeConstraiedLRU(100)
+	// Add one 10 byte-item 10 times
+	k := fmt.Sprintf("key-%d", 0)
+	v := fmt.Sprintf("value-%04d", 0)
+	for i := 0; i < 10; i++ {
+		lru.Add(k, v)
+	}
+	// The size should be accurate
+	if have, want := lru.size, uint64(10); have != want {
+		t.Fatalf("size wrong, have %d want %d", have, want)
+	}
+}

--- a/common/lru/blob_lru_test.go
+++ b/common/lru/blob_lru_test.go
@@ -1,0 +1,98 @@
+// Copyright 2022 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+package lru
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestBlobLru(t *testing.T) {
+	lru := NewSizeConstraiedLRU(100)
+	var want uint64
+	// Add 11 items of 10 byte each. First item should be swapped out
+	for i := 0; i < 11; i++ {
+		k := fmt.Sprintf("key-%d", i)
+		v := fmt.Sprintf("value-%04d", i)
+		lru.Add(k, v)
+		want += uint64(len(v))
+		if want > 100 {
+			want = 100
+		}
+		if have := lru.size; have != want {
+			t.Fatalf("size wrong, have %d want %d", have, want)
+		}
+	}
+	// Zero:th should be evicted
+	{
+		k := fmt.Sprintf("key-%d", 0)
+		if _, ok := lru.Get(k); ok {
+			t.Fatalf("should be evicted: %v", k)
+		}
+	}
+	// Elems 1-11 should be present
+	for i := 1; i < 11; i++ {
+		k := fmt.Sprintf("key-%d", i)
+		want := fmt.Sprintf("value-%04d", i)
+		have, ok := lru.Get(k)
+		if !ok {
+			t.Fatalf("missing key %v", k)
+		}
+		if have != want {
+			t.Fatalf("wrong value, have %v want %v", have, want)
+		}
+	}
+}
+
+// TestBlobLruOverflow tests what happens when inserting an element exceeding
+// the max size
+func TestBlobLruOverflow(t *testing.T) {
+	lru := NewSizeConstraiedLRU(100)
+	// Add 10 items of 10 byte each, filling the cache
+	for i := 0; i < 10; i++ {
+		k := fmt.Sprintf("key-%d", i)
+		v := fmt.Sprintf("value-%04d", i)
+		lru.Add(k, v)
+	}
+	// Add one single large elem. We expect it to swap out all entries.
+	{
+		k := fmt.Sprintf("large-%d", 0)
+		v := make([]byte, 200)
+		lru.Add(k, string(v))
+	}
+	// Elems 0-9 should be missing
+	for i := 1; i < 10; i++ {
+		k := fmt.Sprintf("key-%d", i)
+		if _, ok := lru.Get(k); ok {
+			t.Fatalf("should be evicted: %v", k)
+		}
+	}
+	// The size should be accurate
+	if have, want := lru.size, uint64(200); have != want {
+		t.Fatalf("size wrong, have %d want %d", have, want)
+	}
+	// Adding one small item should swap out the large one
+	{
+		i := 0
+		k := fmt.Sprintf("key-%d", i)
+		v := fmt.Sprintf("value-%04d", i)
+		lru.Add(k, v)
+		if have, want := lru.size, uint64(10); have != want {
+			t.Fatalf("size wrong, have %d want %d", have, want)
+		}
+	}
+}

--- a/common/lru/blob_lru_test.go
+++ b/common/lru/blob_lru_test.go
@@ -37,7 +37,7 @@ func TestBlobLru(t *testing.T) {
 	for i := 0; i < 11; i++ {
 		k := mkHash(i)
 		v := fmt.Sprintf("value-%04d", i)
-		lru.Add(k, v)
+		lru.Add(k, []byte(v))
 		want += uint64(len(v))
 		if want > 100 {
 			want = 100
@@ -75,13 +75,13 @@ func TestBlobLruOverflow(t *testing.T) {
 	for i := 0; i < 10; i++ {
 		k := mkHash(i)
 		v := fmt.Sprintf("value-%04d", i)
-		lru.Add(k, v)
+		lru.Add(k, []byte(v))
 	}
 	// Add one single large elem. We expect it to swap out all entries.
 	{
 		k := mkHash(1337)
 		v := make([]byte, 200)
-		lru.Add(k, string(v))
+		lru.Add(k, v)
 	}
 	// Elems 0-9 should be missing
 	for i := 1; i < 10; i++ {
@@ -99,7 +99,7 @@ func TestBlobLruOverflow(t *testing.T) {
 		i := 0
 		k := mkHash(i)
 		v := fmt.Sprintf("value-%04d", i)
-		lru.Add(k, v)
+		lru.Add(k, []byte(v))
 		if have, want := lru.size, uint64(10); have != want {
 			t.Fatalf("size wrong, have %d want %d", have, want)
 		}
@@ -113,7 +113,7 @@ func TestBlobLruSameItem(t *testing.T) {
 	k := mkHash(0)
 	v := fmt.Sprintf("value-%04d", 0)
 	for i := 0; i < 10; i++ {
-		lru.Add(k, v)
+		lru.Add(k, []byte(v))
 	}
 	// The size should be accurate
 	if have, want := lru.size, uint64(10); have != want {

--- a/common/lru/blob_lru_test.go
+++ b/common/lru/blob_lru_test.go
@@ -40,7 +40,7 @@ func TestBlobLru(t *testing.T) {
 	// Zero:th should be evicted
 	{
 		k := fmt.Sprintf("key-%d", 0)
-		if _, ok := lru.Get(k); ok {
+		if val := lru.Get([]byte(k)); val != nil {
 			t.Fatalf("should be evicted: %v", k)
 		}
 	}
@@ -48,11 +48,11 @@ func TestBlobLru(t *testing.T) {
 	for i := 1; i < 11; i++ {
 		k := fmt.Sprintf("key-%d", i)
 		want := fmt.Sprintf("value-%04d", i)
-		have, ok := lru.Get(k)
-		if !ok {
+		have := lru.Get([]byte(k))
+		if have == nil {
 			t.Fatalf("missing key %v", k)
 		}
-		if have != want {
+		if string(have) != want {
 			t.Fatalf("wrong value, have %v want %v", have, want)
 		}
 	}
@@ -77,7 +77,7 @@ func TestBlobLruOverflow(t *testing.T) {
 	// Elems 0-9 should be missing
 	for i := 1; i < 10; i++ {
 		k := fmt.Sprintf("key-%d", i)
-		if _, ok := lru.Get(k); ok {
+		if val := lru.Get([]byte(k)); val != nil {
 			t.Fatalf("should be evicted: %v", k)
 		}
 	}

--- a/core/state/database.go
+++ b/core/state/database.go
@@ -181,7 +181,7 @@ func (db *cachingDB) ContractCode(addrHash, codeHash common.Hash) ([]byte, error
 	}
 	code := rawdb.ReadCode(db.disk, codeHash)
 	if len(code) > 0 {
-		db.codeCache.Add(codeHash, string(code))
+		db.codeCache.Add(codeHash, code)
 		db.codeSizeCache.Add(codeHash, len(code))
 		return code, nil
 	}
@@ -197,7 +197,7 @@ func (db *cachingDB) ContractCodeWithPrefix(addrHash, codeHash common.Hash) ([]b
 	}
 	code := rawdb.ReadCodeWithPrefix(db.disk, codeHash)
 	if len(code) > 0 {
-		db.codeCache.Add(codeHash, string(code))
+		db.codeCache.Add(codeHash, code)
 		db.codeSizeCache.Add(codeHash, len(code))
 		return code, nil
 	}

--- a/core/state/database.go
+++ b/core/state/database.go
@@ -20,8 +20,8 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/VictoriaMetrics/fastcache"
 	"github.com/ethereum/go-ethereum/common"
+	lru2 "github.com/ethereum/go-ethereum/common/lru"
 	"github.com/ethereum/go-ethereum/core/rawdb"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/ethdb"
@@ -135,7 +135,8 @@ func NewDatabaseWithConfig(db ethdb.Database, config *trie.Config) Database {
 		db:            trie.NewDatabaseWithConfig(db, config),
 		disk:          db,
 		codeSizeCache: csc,
-		codeCache:     fastcache.New(codeCacheSize),
+		//codeCache:     fastcache.New(codeCacheSize),
+		codeCache: lru2.NewSizeConstraiedLRU(codeCacheSize),
 	}
 }
 
@@ -143,7 +144,7 @@ type cachingDB struct {
 	db            *trie.Database
 	disk          ethdb.KeyValueStore
 	codeSizeCache *lru.Cache
-	codeCache     *fastcache.Cache
+	codeCache     *lru2.SizeConstrainedLRU
 }
 
 // OpenTrie opens the main account trie at a specific root hash.
@@ -176,7 +177,7 @@ func (db *cachingDB) CopyTrie(t Trie) Trie {
 
 // ContractCode retrieves a particular contract's code.
 func (db *cachingDB) ContractCode(addrHash, codeHash common.Hash) ([]byte, error) {
-	if code := db.codeCache.Get(nil, codeHash.Bytes()); len(code) > 0 {
+	if code := db.codeCache.Get(codeHash.Bytes()); len(code) > 0 {
 		return code, nil
 	}
 	code := rawdb.ReadCode(db.disk, codeHash)
@@ -192,7 +193,7 @@ func (db *cachingDB) ContractCode(addrHash, codeHash common.Hash) ([]byte, error
 // code can't be found in the cache, then check the existence with **new**
 // db scheme.
 func (db *cachingDB) ContractCodeWithPrefix(addrHash, codeHash common.Hash) ([]byte, error) {
-	if code := db.codeCache.Get(nil, codeHash.Bytes()); len(code) > 0 {
+	if code := db.codeCache.Get(codeHash.Bytes()); len(code) > 0 {
 		return code, nil
 	}
 	code := rawdb.ReadCodeWithPrefix(db.disk, codeHash)


### PR DESCRIPTION
Initial poc, one way to replace `fastcache` with a pretty simple LRU which does not require explicit closing. 

This is an alternative to https://github.com/ethereum/go-ethereum/pull/26071