### PR TITLE
eth/filters: return error if toBlock > latest block

### DIFF
--- a/eth/filters/api.go
+++ b/eth/filters/api.go
@@ -336,6 +336,11 @@ func (api *FilterAPI) GetLogs(ctx context.Context, crit FilterCriteria) ([]*type
 		end := rpc.LatestBlockNumber.Int64()
 		if crit.ToBlock != nil {
 			end = crit.ToBlock.Int64()
+			// Return an error if the user requested a toBlock that we don't have yet.
+			// Users can filter to latest by not specifying a `toBlock`.
+			if end > rpc.LatestBlockNumber.Int64() {
+				return nil, errors.New("toBlock not found")
+			}
 		}
 		// Construct the range filter
 		filter = api.sys.NewRangeFilter(begin, end, crit.Addresses, crit.Topics)


### PR DESCRIPTION
Return an error if the requested block range is not available instead of just ignoring an tracing to latest

closes: https://github.com/ethereum/go-ethereum/issues/26101