### PR TITLE
eth/filters: annotate last log in block

### DIFF
--- a/core/types/gen_log_json.go
+++ b/core/types/gen_log_json.go
@@ -24,7 +24,7 @@ func (l Log) MarshalJSON() ([]byte, error) {
 		BlockHash   common.Hash    `json:"blockHash"`
 		Index       hexutil.Uint   `json:"logIndex"`
 		Removed     bool           `json:"removed"`
-		Last        bool           `json:"last, omitempty"`
+		Last        bool           `json:"last,omitempty"`
 	}
 	var enc Log
 	enc.Address = l.Address
@@ -52,7 +52,7 @@ func (l *Log) UnmarshalJSON(input []byte) error {
 		BlockHash   *common.Hash    `json:"blockHash"`
 		Index       *hexutil.Uint   `json:"logIndex"`
 		Removed     *bool           `json:"removed"`
-		Last        *bool           `json:"last, omitempty"`
+		Last        *bool           `json:"last,omitempty"`
 	}
 	var dec Log
 	if err := json.Unmarshal(input, &dec); err != nil {

--- a/core/types/gen_log_json.go
+++ b/core/types/gen_log_json.go
@@ -24,6 +24,7 @@ func (l Log) MarshalJSON() ([]byte, error) {
 		BlockHash   common.Hash    `json:"blockHash"`
 		Index       hexutil.Uint   `json:"logIndex"`
 		Removed     bool           `json:"removed"`
+		Last        bool           `json:"last, omitempty"`
 	}
 	var enc Log
 	enc.Address = l.Address
@@ -35,6 +36,7 @@ func (l Log) MarshalJSON() ([]byte, error) {
 	enc.BlockHash = l.BlockHash
 	enc.Index = hexutil.Uint(l.Index)
 	enc.Removed = l.Removed
+	enc.Last = l.Last
 	return json.Marshal(&enc)
 }
 
@@ -50,6 +52,7 @@ func (l *Log) UnmarshalJSON(input []byte) error {
 		BlockHash   *common.Hash    `json:"blockHash"`
 		Index       *hexutil.Uint   `json:"logIndex"`
 		Removed     *bool           `json:"removed"`
+		Last        *bool           `json:"last, omitempty"`
 	}
 	var dec Log
 	if err := json.Unmarshal(input, &dec); err != nil {
@@ -85,6 +88,9 @@ func (l *Log) UnmarshalJSON(input []byte) error {
 	}
 	if dec.Removed != nil {
 		l.Removed = *dec.Removed
+	}
+	if dec.Last != nil {
+		l.Last = *dec.Last
 	}
 	return nil
 }

--- a/core/types/log.go
+++ b/core/types/log.go
@@ -53,7 +53,7 @@ type Log struct {
 	// The Removed field is true if this log was reverted due to a chain reorganisation.
 	// You must pay attention to this field if you receive logs through a filter query.
 	Removed bool `json:"removed"`
-	Last    bool `json:"last, omitempty"`
+	Last    bool `json:"last,omitempty"`
 }
 
 type logMarshaling struct {

--- a/core/types/log.go
+++ b/core/types/log.go
@@ -53,6 +53,7 @@ type Log struct {
 	// The Removed field is true if this log was reverted due to a chain reorganisation.
 	// You must pay attention to this field if you receive logs through a filter query.
 	Removed bool `json:"removed"`
+	Last    bool `json:"last, omitempty"`
 }
 
 type logMarshaling struct {


### PR DESCRIPTION
Alternative to https://github.com/ethereum/go-ethereum/pull/24823 

This is a reimplementation of the PR above, but this PR makes the modification to `types.Log` . Using a custom testclient, which does `	sub, err := client.SubscribeFilterLogs(context.Background(), query, logs)` at least that part seems to work as expected. 

One thing I have not tested end-to-end is using more complex criterias, e.g. making it so that the actual last log in the block becomes removed, thus making some other log the 'last' in the batch (subfiltering). 

I had to rewrite the tests a bit to accommodate for the new behaviour, the tests were a bit simplistic and contained logs in wrong order (e.g block `1, 2 ,1, 2` ). 