### PR TITLE
accounts/abi: properly quote untrusted data in error message

### DIFF
--- a/accounts/abi/abi.go
+++ b/accounts/abi/abi.go
@@ -87,7 +87,7 @@ func (abi ABI) getArguments(name string, data []byte) (Arguments, error) {
 	var args Arguments
 	if method, ok := abi.Methods[name]; ok {
 		if len(data)%32 != 0 {
-			return nil, fmt.Errorf("abi: improperly formatted output: %x", data)
+			return nil, fmt.Errorf("abi: improperly formatted output: %q - Bytes: %+v", data, data)
 		}
 		args = method.Outputs
 	}

--- a/accounts/abi/abi.go
+++ b/accounts/abi/abi.go
@@ -87,7 +87,7 @@ func (abi ABI) getArguments(name string, data []byte) (Arguments, error) {
 	var args Arguments
 	if method, ok := abi.Methods[name]; ok {
 		if len(data)%32 != 0 {
-			return nil, fmt.Errorf("abi: improperly formatted output: %s - Bytes: [%+v]", string(data), data)
+			return nil, fmt.Errorf("abi: improperly formatted output: %x", data)
 		}
 		args = method.Outputs
 	}


### PR DESCRIPTION
Printing some bytes as `string(...)` can create some non UTF-8 characters, which can mess up some log parsers (eg. Loki/Promtail/Grafana combo). I think a hex-string should be sufficient, which can easily be converted to `string` by the end user if needed.