### PR TITLE
cmd/evm: add more docs for t8n, t9n, and b11r

### DIFF
--- a/cmd/evm/README.md
+++ b/cmd/evm/README.md
@@ -627,6 +627,14 @@ type BlockInfo struct {
 }
 ```
 
+## A Note on Encoding
+
+The encoding of values for `evm` utility attempts to be relatively flexible. It
+generally supports hex-encoded or decimal-encoded numeric values, and
+hex-encoded byte values (like `common.Address`, `common.Hash`, etc). When in
+doubt, the [`execution-apis`](https://github.com/ethereum/execution-apis) way
+of encoding should always be accepted.
+
 ## Testing
 
 There are many test cases in the [`cmd/evm/testdata`](./testdata) directory.


### PR DESCRIPTION
The EELS team is getting ready to implement `t8n` and `b11r` so they can join in on the test-filling-fun. I tried to include some more information about that actual structure of the different objects used as input and returned as output from the various tools. I also wanted to make a note of where to look for conformance tests as other clients look to implement the `evm` utility.