### PR TITLE
core/vm: add call context (for access in precompiles)

### DIFF
--- a/core/vm/evm.go
+++ b/core/vm/evm.go
@@ -93,7 +93,7 @@ type TxContext struct {
 type EvmCallContext struct {
 	From      common.Address
 	To        common.Address
-	Operation string
+	Operation OpCode
 	Calldata  []byte
 	Value     *big.Int
 	GasLimit  uint64
@@ -185,7 +185,7 @@ func (evm *EVM) Call(caller ContractRef, addr common.Address, input []byte, gas 
 	evm.CurrentCallContext = EvmCallContext{
 		From:      caller.Address(),
 		To:        addr,
-		Operation: opCodeToString[CALL],
+		Operation: CALL,
 		Calldata:  input,
 		GasLimit:  gas,
 		Value:     value,
@@ -281,7 +281,7 @@ func (evm *EVM) CallCode(caller ContractRef, addr common.Address, input []byte, 
 	evm.CurrentCallContext = EvmCallContext{
 		From:      caller.Address(),
 		To:        addr,
-		Operation: opCodeToString[CALLCODE],
+		Operation: CALLCODE,
 		Calldata:  input,
 		GasLimit:  gas,
 		Value:     value,
@@ -340,7 +340,7 @@ func (evm *EVM) DelegateCall(caller ContractRef, addr common.Address, input []by
 	evm.CurrentCallContext = EvmCallContext{
 		From:      caller.Address(),
 		To:        addr,
-		Operation: opCodeToString[DELEGATECALL],
+		Operation: DELEGATECALL,
 		Calldata:  input,
 		GasLimit:  gas,
 		Value:     big.NewInt(0),
@@ -390,7 +390,7 @@ func (evm *EVM) StaticCall(caller ContractRef, addr common.Address, input []byte
 	evm.CurrentCallContext = EvmCallContext{
 		From:      caller.Address(),
 		To:        addr,
-		Operation: opCodeToString[STATICCALL],
+		Operation: STATICCALL,
 		Calldata:  input,
 		GasLimit:  gas,
 		Value:     big.NewInt(0),


### PR DESCRIPTION
CurrentCallContext provides `vm.EVM` with information about the current call or subcall context. 
Fields must be updated at the start of each *CALL operation.

-----

This is a feature request for precompiles to incrementally achieve parity of features with a normal smart contract. (The other additions would be storage functionality and dynamic gas management. Eventually treated by future PRs if this PR gets merged.)
I have been working to prototype & build non-pure precompiles for both Ethereum and Ethermint (EVM integrated in the Cosmos SDK): https://www.youtube.com/playlist?list=PL323JufuD9JDuDH9pWD7e-cVA623vRkXl. With details in the Etheremint repo discussions: https://github.com/evmos/ethermint/pull/1131#issuecomment-1247748825.

But I reduced my initial changes to go-ethereum to this PR, which should not affect how geth works now. But, it can also pave the way for geth to introduce non-pure precompiles.

Because `vm.EVM` & `vm.EVMInterpreter` reference each other, Ethermint can only partially use its own `vm.EVM` wrapper (https://github.com/evmos/ethermint/blob/main/x/evm/vm/geth/geth.go), as added in https://github.com/evmos/ethermint/pull/1272, because `vm.EVMInterpreter` uses `evm.` methods and not interface functions. Otherwise, maybe the `vm.EVM` wrapper could have passed its own `*CALL` functions.

Right now, for the custom precompiles to have access to the current call state, either this PR is merged or Ethermint would need to copy much more code from go-ethereum's `vm` package. Or fork go-ethereum (which is not desirable).

If these changes are approved by the go-ethereum team, I can write some tests to make sure the call contexts remain in sync after each *CALL.