### PR TITLE
cmd/clef: only print first N accounts on startup

### DIFF
--- a/signer/core/cliui.go
+++ b/signer/core/cliui.go
@@ -261,7 +261,7 @@ func (ui *CommandlineUI) showAccounts() {
 		msg = ""
 	}
 	fmt.Fprint(out, "\n------- Available accounts -------\n")
-	for i, account := range accounts[0:limit] {
+	for i, account := range accounts[:limit] {
 		fmt.Fprintf(out, "%d. %s at %s\n", i, account.Address, account.URL)
 	}
 	fmt.Print(out.String(), msg)

--- a/signer/core/cliui.go
+++ b/signer/core/cliui.go
@@ -245,8 +245,6 @@ func (ui *CommandlineUI) OnApprovedTx(tx ethapi.SignTransactionResult) {
 
 func (ui *CommandlineUI) showAccounts() {
 	accounts, err := ui.api.ListAccounts(context.Background())
-	var msg string = ""
-	var out = new(strings.Builder)
 	if err != nil {
 		log.Error("Error listing accounts", "err", err)
 		return
@@ -255,6 +253,8 @@ func (ui *CommandlineUI) showAccounts() {
 		fmt.Print("No accounts found\n")
 		return
 	}
+	var msg string
+	var out = new(strings.Builder)
 	if limit := 20; len(accounts) > limit {
 		msg = fmt.Sprintf("\nFirst %d accounts listed (%d more available).\n", limit, len(accounts)-limit)
 		accounts = accounts[:limit]

--- a/signer/core/cliui.go
+++ b/signer/core/cliui.go
@@ -260,10 +260,10 @@ func (ui *CommandlineUI) showAccounts() {
 		limit = len(accounts)
 		msg = ""
 	}
+	fmt.Fprint(out, "\n------- Available accounts -------\n")
 	for i, account := range accounts[0:limit] {
 		fmt.Fprintf(out, "%d. %s at %s\n", i, account.Address, account.URL)
 	}
-	fmt.Fprint(out, "\n------- Available accounts -------\n")
 	fmt.Print(out.String(), msg)
 }
 

--- a/signer/core/cliui.go
+++ b/signer/core/cliui.go
@@ -245,8 +245,7 @@ func (ui *CommandlineUI) OnApprovedTx(tx ethapi.SignTransactionResult) {
 
 func (ui *CommandlineUI) showAccounts() {
 	accounts, err := ui.api.ListAccounts(context.Background())
-	var limit int = 20 //max N accounts to print
-	var msg string = fmt.Sprintf("\nFirst %d accounts listed (%d more available).\n", limit, len(accounts)-limit)
+	var msg string = ""
 	var out = new(strings.Builder)
 	if err != nil {
 		log.Error("Error listing accounts", "err", err)
@@ -256,12 +255,12 @@ func (ui *CommandlineUI) showAccounts() {
 		fmt.Print("No accounts found\n")
 		return
 	}
-	if len(accounts) < limit {
-		limit = len(accounts)
-		msg = ""
+	if limit := 20; len(accounts) > limit {
+		msg = fmt.Sprintf("\nFirst %d accounts listed (%d more available).\n", limit, len(accounts)-limit)
+		accounts = accounts[:limit]
 	}
 	fmt.Fprint(out, "\n------- Available accounts -------\n")
-	for i, account := range accounts[:limit] {
+	for i, account := range accounts {
 		fmt.Fprintf(out, "%d. %s at %s\n", i, account.Address, account.URL)
 	}
 	fmt.Print(out.String(), msg)

--- a/signer/core/cliui.go
+++ b/signer/core/cliui.go
@@ -245,6 +245,9 @@ func (ui *CommandlineUI) OnApprovedTx(tx ethapi.SignTransactionResult) {
 
 func (ui *CommandlineUI) showAccounts() {
 	accounts, err := ui.api.ListAccounts(context.Background())
+	var limit int = 20 //max N accounts to print
+	var msg string = fmt.Sprintf("\nFirst %d accounts listed (%d more available).\n", limit, len(accounts)-limit)
+	var out = new(strings.Builder)
 	if err != nil {
 		log.Error("Error listing accounts", "err", err)
 		return
@@ -253,12 +256,15 @@ func (ui *CommandlineUI) showAccounts() {
 		fmt.Print("No accounts found\n")
 		return
 	}
-	var out = new(strings.Builder)
-	fmt.Fprint(out, "\n------- Available accounts -------\n")
-	for i, account := range accounts {
+	if len(accounts) < limit {
+		limit = len(accounts)
+		msg = ""
+	}
+	for i, account := range accounts[0:limit] {
 		fmt.Fprintf(out, "%d. %s at %s\n", i, account.Address, account.URL)
 	}
-	fmt.Print(out.String())
+	fmt.Fprint(out, "\n------- Available accounts -------\n")
+	fmt.Print(out.String(), msg)
 }
 
 func (ui *CommandlineUI) OnSignerStartup(info StartupInfo) {


### PR DESCRIPTION
PR #26082 added account listing to `OnSignerStartup` but did not consider the case where a user has a large number of accounts which would be annoying to display.

This PR updates `showAccounts()` so that if there are more than 20 accounts available the user sees the first 20 displayed in the console followed by: `First 20 accounts listed (N more available).` 

For example for a keystore with > 20 accounts the startup info looks as follows:

```
------- Signer info -------
* extapi_ipc : /home/user/.clef/clef.ipc
* intapi_version : 7.0.1
* extapi_version : 6.1.0
* extapi_http : n/a

------- Available accounts -------
0. 0xE70CAD05D0D54Ae3C9Fe5442f901E0433f9bd14B at keystore:///home/user/Code/go-ethereum/testdata/keystore/UTC--2022-10-31T15-45-59.185124924Z--e70cad05d0d54ae3c9fe5442f901e0433f9bd14b
1. 0xdD309879A192eB29512591b94B30E73463055376 at keystore:///home/user/Code/go-ethereum/testdata/keystore/UTC--2022-10-31T15-46-55.508862995Z--dd309879a192eb29512591b94b30e73463055376
2. 0x4337A0186Fd86538C4d0E55fB38962bA736e546D at keystore:///home/user/Code/go-ethereum/testdata/keystore/UTC--2022-10-31T15-47-04.828100209Z--4337a0186fd86538c4d0e55fb38962ba736e546d
3. 0x4FDc03d09Ffca5Bba3138149E29D85C8A9E2Ac42 at keystore:///home/user/Code/go-ethereum/testdata/keystore/UTC--2022-10-31T16-47-20.001032092Z--4fdc03d09ffca5bba3138149e29d85c8a9e2ac42
4. 0xC495A887e033cC8cDEc400Be0b608aC4548B1736 at keystore:///home/user/Code/go-ethereum/testdata/keystore/UTC--2022-10-31T16-49-22.471126961Z--c495a887e033cc8cdec400be0b608ac4548b1736
5. 0x4f4094BaBd1A8c433e0f52A6ee3B6ff32dEe6a9c at keystore:///home/user/Code/go-ethereum/testdata/keystore/UTC--2022-11-01T17-05-01.517877299Z--4f4094babd1a8c433e0f52a6ee3b6ff32dee6a9c
6. 0x8Ef15919F852A8034688a71d8b57Ab0187364009 at keystore:///home/user/Code/go-ethereum/testdata/keystore/UTC--2022-11-01T17-05-11.100536003Z--8ef15919f852a8034688a71d8b57ab0187364009
7. 0x99A94ac1168B301449970310904fc38c7Bf55037 at keystore:///home/user/Code/go-ethereum/testdata/keystore/UTC--2022-11-02T11-40-55.527987625Z--99a94ac1168b301449970310904fc38c7bf55037
8. 0xe579e31e9534FbC460FC800792D652ADD713311d at keystore:///home/user/Code/go-ethereum/testdata/keystore/UTC--2022-11-07T16-09-34.770602174Z--e579e31e9534fbc460fc800792d652add713311d
9. 0x61781D92102da515B5A9E2803B0ABB8aa957DEBe at keystore:///home/user/Code/go-ethereum/testdata/keystore/UTC--2022-11-07T16-09-44.105219587Z--61781d92102da515b5a9e2803b0abb8aa957debe
10. 0x61CfA06a4fb9E7f02248E8C011943ab8b0137a2B at keystore:///home/user/Code/go-ethereum/testdata/keystore/UTC--2022-11-07T16-09-52.182740665Z--61cfa06a4fb9e7f02248e8c011943ab8b0137a2b
11. 0x3812c7E26E8258B8147E316D5A3c7e34500C97C8 at keystore:///home/user/Code/go-ethereum/testdata/keystore/UTC--2022-11-07T16-34-24.622766599Z--3812c7e26e8258b8147e316d5a3c7e34500c97c8
12. 0xa31A688070Bcc2EDf764a3b71C94B70d96D2f7d3 at keystore:///home/user/Code/go-ethereum/testdata/keystore/UTC--2022-11-07T16-34-31.246305028Z--a31a688070bcc2edf764a3b71c94b70d96d2f7d3
13. 0x3D53EcA12588Dcf6306B343806066565dbF88875 at keystore:///home/user/Code/go-ethereum/testdata/keystore/UTC--2022-11-07T16-39-04.766639979Z--3d53eca12588dcf6306b343806066565dbf88875
14. 0x3B28Aa3C5899b2A186bb00C2Ecf885844e99d501 at keystore:///home/user/Code/go-ethereum/testdata/keystore/UTC--2022-11-07T16-39-11.687678719Z--3b28aa3c5899b2a186bb00c2ecf885844e99d501
15. 0xB49b605d24675e16D180D083EdAD42E431D821b3 at keystore:///home/user/Code/go-ethereum/testdata/keystore/UTC--2022-11-07T16-39-17.534185855Z--b49b605d24675e16d180d083edad42e431d821b3
16. 0x732b46426C9a6dF481bF12e7A5611575C2065669 at keystore:///home/user/Code/go-ethereum/testdata/keystore/UTC--2022-11-07T16-39-25.696535023Z--732b46426c9a6df481bf12e7a5611575c2065669
17. 0xfcEEb159E3a4C9dDF87AC22DcbEC38F87cAFCD1a at keystore:///home/user/Code/go-ethereum/testdata/keystore/UTC--2022-11-07T16-39-32.362612101Z--fceeb159e3a4c9ddf87ac22dcbec38f87cafcd1a
18. 0x5713D0ff17F61fb5B618590EE868Ca2927873Ce2 at keystore:///home/user/Code/go-ethereum/testdata/keystore/UTC--2022-11-07T16-39-38.846217484Z--5713d0ff17f61fb5b618590ee868ca2927873ce2
19. 0x98a46D8503BE76aD3aeC2B902975BFC600d6BBC8 at keystore:///home/user/Code/go-ethereum/testdata/keystore/UTC--2022-11-07T16-39-51.198489840Z--98a46d8503be76ad3aec2b902975bfc600d6bbc8

First 20 accounts listed (1 more available).
```

For <20 accounts the console info is the same as before.
(NB 20 was a pretty arbitrary choice, I just thought it was a manageable number).