### PR TITLE
cmd/devp2p: add more nodekey commands

### DIFF
--- a/cmd/devp2p/keycmd.go
+++ b/cmd/devp2p/keycmd.go
@@ -31,6 +31,7 @@ var (
 		Usage: "Operations on node keys",
 		Subcommands: []*cli.Command{
 			keyGenerateCommand,
+			keyToIDCommand,
 			keyToNodeCommand,
 		},
 	}
@@ -39,6 +40,13 @@ var (
 		Usage:     "Generates node key files",
 		ArgsUsage: "keyfile",
 		Action:    genkey,
+	}
+	keyToIDCommand = &cli.Command{
+		Name:      "to-id",
+		Usage:     "Creates a node ID from a node key file",
+		ArgsUsage: "keyfile",
+		Action:    keyToID,
+		Flags:     []cli.Flag{},
 	}
 	keyToNodeCommand = &cli.Command{
 		Name:      "to-enode",
@@ -78,6 +86,15 @@ func genkey(ctx *cli.Context) error {
 		return fmt.Errorf("could not generate key: %v", err)
 	}
 	return crypto.SaveECDSA(file, key)
+}
+
+func keyToID(ctx *cli.Context) error {
+	n, err := makeRecord(ctx)
+	if err != nil {
+		return err
+	}
+	fmt.Println(n.ID())
+	return nil
 }
 
 func keyToURL(ctx *cli.Context) error {


### PR DESCRIPTION
This adds two new commands which turn a node key file into a signed ENR or simply print the node ID.

Example: 

```
$ ./devp2p key to-id node1.key
b6eb0af089fc125d0f48746c938231c15e4737a72327194a7e351e42f60a54fc

$ ./devp2p key to-enr -ip 1.2.3.4 -udp 30304 node1.key 
enr:-Iu4QAUG3OoCOHQQ3Qe5XA8tuEPgyRg7xTTsLtG5SIThHgeXPa0ktpnrTE-gFXNYgOOUuUkWVpTqW-oqvzduUwGAwyCAgmlkgnY0gmlwhAECAwSJc2VjcDI1NmsxoQOWEd6Hlr9gtrdtEGeiSm5jXhFUyief-z5eG1FYgp4yAYN0Y3CCdl-DdWRwgnZg

$ ./devp2p enrdump enr:-Iu4QAUG3OoCOHQQ3Qe5XA8tuEPgyRg7xTTsLtG5SIThHgeXPa0ktpnrTE-gFXNYgOOUuUkWVpTqW-oqvzduUwGAwyCAgmlkgnY0gmlwhAECAwSJc2VjcDI1NmsxoQOWEd6Hlr9gtrdtEGeiSm5jXhFUyief-z5eG1FYgp4yAYN0Y3CCdl-DdWRwgnZg
Node ID: b6eb0af089fc125d0f48746c938231c15e4737a72327194a7e351e42f60a54fc
URLv4:   enode://9611de8796bf60b6b76d1067a24a6e635e1154ca279ffb3e5e1b5158829e320179377f420a9817f322a623b29f750c1a52586209de3da6aea668f0c4bf4a8569@1.2.3.4:30303?discport=30304
Record has sequence number 0 and 5 key/value pairs.
  "id"        "v4"
  "ip"        1.2.3.4
  "secp256k1" a1039611de8796bf60b6b76d1067a24a6e635e1154ca279ffb3e5e1b5158829e3201
  "tcp"       30303
  "udp"       30304
```

