### PR TITLE
common/types: add `Address.Big`

### DIFF
--- a/common/types.go
+++ b/common/types.go
@@ -231,6 +231,9 @@ func (a Address) Bytes() []byte { return a[:] }
 // Hash converts an address to a hash by left-padding it with zeros.
 func (a Address) Hash() Hash { return BytesToHash(a[:]) }
 
+// Big converts an address to a big integer.
+func (a Address) Big() *big.Int { return new(big.Int).SetBytes(a[:]) }
+
 // Hex returns an EIP55-compliant hex string representation of the address.
 func (a Address) Hex() string {
 	return string(a.checksumHex())


### PR DESCRIPTION
Many of the other types have a function to convert the type to a `big.Int` but the `Address` is missing this function. It is useful to be able to turn an `Address` into a `big.Int` when doing EVM-like computations natively in Go. Sometimes a Solidity `address` type is casted to a `uint256` and having a `Big` method on the `Address` type makes this easy.

Can follow up with tests if desired