### PR TITLE
cmd/evm: slight change in how t8n handles coinbase pre eip-158

### DIFF
--- a/cmd/evm/internal/t8ntool/execution.go
+++ b/cmd/evm/internal/t8ntool/execution.go
@@ -230,8 +230,8 @@ func (pre *Prestate) Apply(vmConfig vm.Config, chainConfig *params.ChainConfig,
 		txIndex++
 	}
 	statedb.IntermediateRoot(chainConfig.IsEIP158(vmContext.BlockNumber))
-	// Add mining reward?
-	if miningReward > 0 {
+	// Add mining reward? (-1 means rewards are disabled)
+	if miningReward >= 0 {
 		// Add mining reward. The mining reward may be `0`, which only makes a difference in the cases
 		// where
 		// - the coinbase suicided, or


### PR DESCRIPTION
This PR fixes a subtle bug in `t8n`. After this PR, `t8n` behaves like our state-test runner in this particular scenario: 

- After an empty block, 
- And the config is that there is a zero block reward, 
- And the coinbase did not previously exist, 
- And we're before EIP-158, 
- Then the coinbase should be touched, a.k.a brought into existence. 

Our state test runner handles that here: https://github.com/ethereum/go-ethereum/blob/master/tests/state_test_util.go#L266 

The t8n was meant to handle that exactly identical, but failed to do so. That's what's being fixed by this PR. 
Also related, the `miningReward` comes from this flag:

```golang
	RewardFlag = &cli.Int64Flag{
		Name:  "state.reward",
		Usage: "Mining reward. Set to -1 to disable",
		Value: 0,
	}
```
cc @winsvega 