### PR TITLE
eth/filters: fix failing benchmark-test

### DIFF
--- a/eth/filters/filter_test.go
+++ b/eth/filters/filter_test.go
@@ -53,10 +53,10 @@ func BenchmarkFilters(b *testing.B) {
 		gspec = &core.Genesis{
 			Alloc:   core.GenesisAlloc{addr1: {Balance: big.NewInt(1000000)}},
 			BaseFee: big.NewInt(params.InitialBaseFee),
+			Config:  params.TestChainConfig,
 		}
 	)
 	defer db.Close()
-
 	_, chain, receipts := core.GenerateChainWithGenesis(gspec, ethash.NewFaker(), 100010, func(i int, gen *core.BlockGen) {
 		switch i {
 		case 2403:
@@ -77,6 +77,11 @@ func BenchmarkFilters(b *testing.B) {
 			gen.AddUncheckedTx(types.NewTransaction(999, common.HexToAddress("0x999"), big.NewInt(999), 999, gen.BaseFee(), nil))
 		}
 	})
+	// The test txs are not properly signed, can't simply create a chain
+	// and then import blocks. TODO(rjl493456442) try to get rid of the
+	// manual database writes.
+	gspec.MustCommit(db)
+
 	for i, block := range chain {
 		rawdb.WriteBlock(db, block)
 		rawdb.WriteCanonicalHash(db, block.Hash(), block.NumberU64())


### PR DESCRIPTION
This PR fixes a benchmark-test which was made br0kken by  this commit: https://github.com/ethereum/go-ethereum/pull/25641/files#diff-dcfcc1778e0f2ab8820d4b00af81d5ce5209067a3a9b40af012d9d07b641a8e1R59  . 

Without this PR: 
```
[user@work go-ethereum]$ go test -run - -bench BenchmarkFilters  ./eth/filters
INFO [11-09|08:44:00.421] Allocated cache and file handles         database=/tmp/BenchmarkFilters672625565/001 cache=16.00MiB handles=16
INFO [11-09|08:44:00.423] Persisted trie from memory database      nodes=1 size=142.00B time="5.708µs" gcnodes=0 gcsize=0.00B gctime=0s livenodes=1 livesize=0.00B
--- FAIL: BenchmarkFilters
    filter_test.go:94: expected 4 logs, got 0
FAIL
exit status 1
FAIL    github.com/ethereum/go-ethereum/eth/filters     5.455s
FAIL

```

With this PR: 
```
[user@work go-ethereum]$ go test -run - -bench BenchmarkFilters  ./eth/filters
INFO [11-09|08:46:50.012] Allocated cache and file handles         database=/tmp/BenchmarkFilters2692416678/001 cache=16.00MiB handles=16
INFO [11-09|08:46:50.013] Persisted trie from memory database      nodes=1 size=142.00B time="5.393µs" gcnodes=0 gcsize=0.00B gctime=0s livenodes=1 livesize=0.00B
INFO [11-09|08:46:53.099] Persisted trie from memory database      nodes=1 size=142.00B time="116.421µs" gcnodes=0 gcsize=0.00B gctime=0s livenodes=1 livesize=0.00B
goos: linux
goarch: amd64
pkg: github.com/ethereum/go-ethereum/eth/filters
cpu: Intel(R) Core(TM) i9-10885H CPU @ 2.40GHz
BenchmarkFilters-8             1        1398357927 ns/op
PASS
ok      github.com/ethereum/go-ethereum/eth/filters     6.783s

```
