### PR TITLE
fix bug:accept int and string according to different apis

### DIFF
--- a/ethclient/ethclient.go
+++ b/ethclient/ethclient.go
@@ -323,11 +323,11 @@ func (ec *Client) SubscribeNewHead(ctx context.Context, ch chan<- *types.Header)
 // NetworkID returns the network ID (also known as the chain ID) for this chain.
 func (ec *Client) NetworkID(ctx context.Context) (*big.Int, error) {
 	version := new(big.Int)
-	var ver string
+	var ver interface{}
 	if err := ec.c.CallContext(ctx, &ver, "net_version"); err != nil {
 		return nil, err
 	}
-	if _, ok := version.SetString(ver, 10); !ok {
+	if _, ok := version.SetString(fmt.Sprintf("%v", ver), 10); !ok {
 		return nil, fmt.Errorf("invalid net_version result %q", ver)
 	}
 	return version, nil


### PR DESCRIPTION
First I try on https://cloudflare-eth.com.
when I try to get chainID from that api, it response with int.
Second, on https://mainnet.infura.io/v3/{api-key}
when I call chainID function, that api responds with string.

to support those different apis,  I just use inteface.

``Also this is my first contribution on open source``