### PR TITLE
feat: add keystore with specified filename

### DIFF
--- a/accounts/keystore/key.go
+++ b/accounts/keystore/key.go
@@ -171,14 +171,17 @@ func newKey(rand io.Reader) (*Key, error) {
 	return newKeyFromECDSA(privateKeyECDSA), nil
 }
 
-func storeNewKey(ks keyStore, rand io.Reader, auth string) (*Key, accounts.Account, error) {
+func storeNewKey(ks keyStore, rand io.Reader, auth, filename string) (*Key, accounts.Account, error) {
 	key, err := newKey(rand)
 	if err != nil {
 		return nil, accounts.Account{}, err
 	}
+	if filename == "" {
+		filename = keyFileName(key.Address)
+	}
 	a := accounts.Account{
 		Address: key.Address,
-		URL:     accounts.URL{Scheme: KeyStoreScheme, Path: ks.JoinPath(keyFileName(key.Address))},
+		URL:     accounts.URL{Scheme: KeyStoreScheme, Path: ks.JoinPath(filename)},
 	}
 	if err := ks.StoreKey(a.URL.Path, key, auth); err != nil {
 		zeroKey(key.PrivateKey)

--- a/accounts/keystore/keystore.go
+++ b/accounts/keystore/keystore.go
@@ -407,12 +407,16 @@ func (ks *KeyStore) expire(addr common.Address, u *unlocked, timeout time.Durati
 // NewAccount generates a new key and stores it into the key directory,
 // encrypting it with the passphrase.
 func (ks *KeyStore) NewAccount(passphrase string) (accounts.Account, error) {
-	return ks.NewAccountWitFile(passphrase, "")
+	return ks.NewAccountFromFilepath(passphrase, "")
 }
 
-// NewAccountWitFile generates a new key and stores it into the spec filename,
+// NewAccountFromFilepath generates a new key and stores it into the spec filename,
 // encrypting it with the passphrase.
-func (ks *KeyStore) NewAccountWitFile(passphrase, filename string) (accounts.Account, error) {
+func (ks *KeyStore) NewAccountFromFilepath(passphrase, fpath string) (accounts.Account, error) {
+	var filename string
+	if fpath != "" {
+		filename = filepath.Base(fpath)
+	}
 	_, account, err := storeNewKey(ks.storage, crand.Reader, passphrase, filename)
 	if err != nil {
 		return accounts.Account{}, err

--- a/accounts/keystore/keystore.go
+++ b/accounts/keystore/keystore.go
@@ -407,7 +407,13 @@ func (ks *KeyStore) expire(addr common.Address, u *unlocked, timeout time.Durati
 // NewAccount generates a new key and stores it into the key directory,
 // encrypting it with the passphrase.
 func (ks *KeyStore) NewAccount(passphrase string) (accounts.Account, error) {
-	_, account, err := storeNewKey(ks.storage, crand.Reader, passphrase)
+	return ks.NewAccountWitFile(passphrase, "")
+}
+
+// NewAccountWitFile generates a new key and stores it into the spec filename,
+// encrypting it with the passphrase.
+func (ks *KeyStore) NewAccountWitFile(passphrase, filename string) (accounts.Account, error) {
+	_, account, err := storeNewKey(ks.storage, crand.Reader, passphrase, filename)
 	if err != nil {
 		return accounts.Account{}, err
 	}

--- a/accounts/keystore/passphrase.go
+++ b/accounts/keystore/passphrase.go
@@ -98,7 +98,12 @@ func (ks keyStorePassphrase) GetKey(addr common.Address, filename, auth string) 
 
 // StoreKey generates a key, encrypts with 'auth' and stores in the given directory
 func StoreKey(dir, auth string, scryptN, scryptP int) (accounts.Account, error) {
-	_, a, err := storeNewKey(&keyStorePassphrase{dir, scryptN, scryptP, false}, rand.Reader, auth)
+	return StoreKeyToFile(dir, "", auth, scryptN, scryptP)
+}
+
+// StoreKeyToFile generates a key, encrypts with 'auth' and stores in the given directory and file.
+func StoreKeyToFile(dir, filename, auth string, scryptN, scryptP int) (accounts.Account, error) {
+	_, a, err := storeNewKey(&keyStorePassphrase{dir, scryptN, scryptP, false}, rand.Reader, auth, filename)
 	return a, err
 }
 

--- a/accounts/keystore/plain_test.go
+++ b/accounts/keystore/plain_test.go
@@ -43,7 +43,7 @@ func TestKeyStorePlain(t *testing.T) {
 	_, ks := tmpKeyStoreIface(t, false)
 
 	pass := "" // not used but required by API
-	k1, account, err := storeNewKey(ks, rand.Reader, pass)
+	k1, account, err := storeNewKey(ks, rand.Reader, pass, "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -63,7 +63,7 @@ func TestKeyStorePassphrase(t *testing.T) {
 	_, ks := tmpKeyStoreIface(t, true)
 
 	pass := "foo"
-	k1, account, err := storeNewKey(ks, rand.Reader, pass)
+	k1, account, err := storeNewKey(ks, rand.Reader, pass, "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -83,7 +83,7 @@ func TestKeyStorePassphraseDecryptionFail(t *testing.T) {
 	_, ks := tmpKeyStoreIface(t, true)
 
 	pass := "foo"
-	k1, account, err := storeNewKey(ks, rand.Reader, pass)
+	k1, account, err := storeNewKey(ks, rand.Reader, pass, "")
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
Sometimes, we need to generate the key and store it in our specified file. So I add this.