### PR TITLE
eth, catalyst: fix flaky tests

### DIFF
--- a/eth/catalyst/api_test.go
+++ b/eth/catalyst/api_test.go
@@ -567,41 +567,55 @@ func TestNewPayloadOnInvalidChain(t *testing.T) {
 	var (
 		api    = NewConsensusAPI(ethservice)
 		parent = ethservice.BlockChain().CurrentBlock()
+		signer = types.LatestSigner(ethservice.BlockChain().Config())
 		// This EVM code generates a log when the contract is created.
 		logCode = common.Hex2Bytes("60606040525b7f24ec1d3ff24c2f6ff210738839dbc339cd45a5294d85c79361016243157aae7b60405180905060405180910390a15b600a8060416000396000f360606040526008565b00")
 	)
 	for i := 0; i < 10; i++ {
 		statedb, _ := ethservice.BlockChain().StateAt(parent.Root())
-		nonce := statedb.GetNonce(testAddr)
-		tx, _ := types.SignTx(types.NewContractCreation(nonce, new(big.Int), 1000000, big.NewInt(2*params.InitialBaseFee), logCode), types.LatestSigner(ethservice.BlockChain().Config()), testKey)
-		ethservice.TxPool().AddLocal(tx)
-
-		params := beacon.PayloadAttributesV1{
-			Timestamp:             parent.Time() + 1,
-			Random:                crypto.Keccak256Hash([]byte{byte(i)}),
-			SuggestedFeeRecipient: parent.Coinbase(),
-		}
-
-		fcState := beacon.ForkchoiceStateV1{
-			HeadBlockHash:      parent.Hash(),
-			SafeBlockHash:      common.Hash{},
-			FinalizedBlockHash: common.Hash{},
-		}
-		resp, err := api.ForkchoiceUpdatedV1(fcState, &params)
-		if err != nil {
-			t.Fatalf("error preparing payload, err=%v", err)
-		}
-		if resp.PayloadStatus.Status != beacon.VALID {
-			t.Fatalf("error preparing payload, invalid status: %v", resp.PayloadStatus.Status)
-		}
-		// give the payload some time to be built
-		time.Sleep(100 * time.Millisecond)
-		payload, err := api.GetPayloadV1(*resp.PayloadID)
-		if err != nil {
-			t.Fatalf("can't get payload: %v", err)
-		}
-		if len(payload.Transactions) == 0 {
-			t.Fatalf("payload should not be empty")
+		tx := types.MustSignNewTx(testKey, signer, &types.LegacyTx{
+			Nonce:    statedb.GetNonce(testAddr),
+			Value:    new(big.Int),
+			Gas:      1000000,
+			GasPrice: big.NewInt(2 * params.InitialBaseFee),
+			Data:     logCode,
+		})
+		ethservice.TxPool().AddRemotesSync([]*types.Transaction{tx})
+		var (
+			params = beacon.PayloadAttributesV1{
+				Timestamp:             parent.Time() + 1,
+				Random:                crypto.Keccak256Hash([]byte{byte(i)}),
+				SuggestedFeeRecipient: parent.Coinbase(),
+			}
+			fcState = beacon.ForkchoiceStateV1{
+				HeadBlockHash:      parent.Hash(),
+				SafeBlockHash:      common.Hash{},
+				FinalizedBlockHash: common.Hash{},
+			}
+			payload *beacon.ExecutableDataV1
+			resp    beacon.ForkChoiceResponse
+			err     error
+		)
+		for i := 0; ; i++ {
+			if resp, err = api.ForkchoiceUpdatedV1(fcState, &params); err != nil {
+				t.Fatalf("error preparing payload, err=%v", err)
+			}
+			if resp.PayloadStatus.Status != beacon.VALID {
+				t.Fatalf("error preparing payload, invalid status: %v", resp.PayloadStatus.Status)
+			}
+			// give the payload some time to be built
+			time.Sleep(50 * time.Millisecond)
+			if payload, err = api.GetPayloadV1(*resp.PayloadID); err != nil {
+				t.Fatalf("can't get payload: %v", err)
+			}
+			if len(payload.Transactions) > 0 {
+				break
+			}
+			// No luck this time we need to update the params and try again.
+			params.Timestamp = params.Timestamp + 1
+			if i > 10 {
+				t.Fatalf("payload should not be empty")
+			}
 		}
 		execResp, err := api.NewPayloadV1(*payload)
 		if err != nil {

--- a/eth/handler_eth_test.go
+++ b/eth/handler_eth_test.go
@@ -451,7 +451,7 @@ func testTransactionPropagation(t *testing.T, protocol uint) {
 			select {
 			case event := <-txChs[i]:
 				arrived += len(event.Txs)
-			case <-time.After(time.Second):
+			case <-time.After(2 * time.Second):
 				t.Errorf("sink %d: transaction propagation timed out: have %d, want %d", i, arrived, len(txs))
 				timeout = true
 			}


### PR DESCRIPTION
This is another PR to fix flaky tests, mostly due to built-in synchronicity requirements which do not work very well on the low-resource appveyor machines. 

Fix 1: 
```
--- FAIL: TestNewPayloadOnInvalidChain (0.14s)
    api_test.go:604: payload should not be empty

```

Fix 2: 
```
--- FAIL: TestTransactionPropagation67 (1.76s)
    handler_eth_test.go:455: sink 0: transaction propagation timed out: have 0, want 1024
INFO [11-10|03:48:40.490] Writing custom genesis block 

```
