### PR TITLE
Add special case to allow EIP-1820 over SubmitTransaction

### DIFF
--- a/core/types/transaction.go
+++ b/core/types/transaction.go
@@ -40,6 +40,9 @@ var (
 	errShortTypedTx         = errors.New("typed transaction too short")
 )
 
+// constant r and s value used in universal deployer pattern according to EIP-1820 spec
+var signatureValue1820Big = common.HexToHash("0x1820182018201820182018201820182018201820182018201820182018201820").Big()
+
 // Transaction types.
 const (
 	LegacyTxType = iota
@@ -241,6 +244,20 @@ func (tx *Transaction) Protected() bool {
 	default:
 		return true
 	}
+}
+
+// IsEIP1820 returns true iff the v, r, and s values match the expected signature values of an EIP-1820 signed transaction.
+// https://eips.ethereum.org/EIPS/eip-1820
+func (tx *Transaction) IsEIP1820() bool {
+	v, r, s := tx.RawSignatureValues()
+	if v.BitLen() > 8 {
+		return false
+	}
+	if v.Uint64() != 27 {
+		return false
+	}
+
+	return r.Cmp(signatureValue1820Big) == 0 && s.Cmp(signatureValue1820Big) == 0
 }
 
 // Type returns the transaction type.

--- a/core/types/transaction.go
+++ b/core/types/transaction.go
@@ -250,6 +250,9 @@ func (tx *Transaction) Protected() bool {
 // https://eips.ethereum.org/EIPS/eip-1820
 func (tx *Transaction) IsEIP1820() bool {
 	v, r, s := tx.RawSignatureValues()
+	if v == nil || r == nil || s == nil {
+		return false
+	}
 	if v.BitLen() > 8 {
 		return false
 	}

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -1684,7 +1684,7 @@ func SubmitTransaction(ctx context.Context, b Backend, tx *types.Transaction) (c
 	if err := checkTxFee(tx.GasPrice(), tx.Gas(), b.RPCTxFeeCap()); err != nil {
 		return common.Hash{}, err
 	}
-	if !b.UnprotectedAllowed() && !tx.Protected() {
+	if !b.UnprotectedAllowed() && !tx.Protected() && !tx.IsEIP1820() {
 		// Ensure only eip155 signed transactions are submitted if EIP155Required is set.
 		return common.Hash{}, errors.New("only replay-protected (EIP-155) transactions allowed over RPC")
 	}


### PR DESCRIPTION
This PR adds a helper function `IsEIP1820()` to determine if the signature for a transaction conforms to EIP-1820.

This helper is used to allow EIP-1820 universal deployer transactions. Universal deployer transactions conforming to EIP-1820 are not considered protected since they do not include a chainID. This is by design and uses constant signature values, so it can be treated as a special case to make user experience with replay protection easier.

