### PR TITLE
rpc, internal/guide: speed up tests a bit

### DIFF
--- a/internal/guide/guide_test.go
+++ b/internal/guide/guide_test.go
@@ -38,8 +38,8 @@ func TestAccountManagement(t *testing.T) {
 	// Create a temporary folder to work with
 	workdir := t.TempDir()
 
-	// Create an encrypted keystore with standard crypto parameters
-	ks := keystore.NewKeyStore(filepath.Join(workdir, "keystore"), keystore.StandardScryptN, keystore.StandardScryptP)
+	// Create an encrypted keystore (using light scrypt parameters)
+	ks := keystore.NewKeyStore(filepath.Join(workdir, "keystore"), keystore.LightScryptN, keystore.LightScryptP)
 
 	// Create a new account with the specified encryption passphrase
 	newAcc, err := ks.NewAccount("Creation password")

--- a/rpc/websocket_test.go
+++ b/rpc/websocket_test.go
@@ -228,6 +228,7 @@ func TestClientWebsocketLargeMessage(t *testing.T) {
 }
 
 func TestClientWebsocketSevered(t *testing.T) {
+	t.Skip("This test takes >90s to execute, and does not need to be tested on a day-to-day basis.")
 	t.Parallel()
 
 	var (

--- a/rpc/websocket_test.go
+++ b/rpc/websocket_test.go
@@ -19,14 +19,10 @@ package rpc
 import (
 	"context"
 	"errors"
-	"io"
 	"net"
 	"net/http"
 	"net/http/httptest"
-	"net/http/httputil"
-	"net/url"
 	"strings"
-	"sync/atomic"
 	"testing"
 	"time"
 
@@ -227,64 +223,6 @@ func TestClientWebsocketLargeMessage(t *testing.T) {
 	}
 }
 
-func TestClientWebsocketSevered(t *testing.T) {
-	t.Skip("This test takes >90s to execute, and does not need to be tested on a day-to-day basis.")
-	t.Parallel()
-
-	var (
-		server = wsPingTestServer(t, nil)
-		ctx    = context.Background()
-	)
-	defer server.Shutdown(ctx)
-
-	u, err := url.Parse("http://" + server.Addr)
-	if err != nil {
-		t.Fatal(err)
-	}
-	rproxy := httputil.NewSingleHostReverseProxy(u)
-	var severable *severableReadWriteCloser
-	rproxy.ModifyResponse = func(response *http.Response) error {
-		severable = &severableReadWriteCloser{ReadWriteCloser: response.Body.(io.ReadWriteCloser)}
-		response.Body = severable
-		return nil
-	}
-	frontendProxy := httptest.NewServer(rproxy)
-	defer frontendProxy.Close()
-
-	wsURL := "ws:" + strings.TrimPrefix(frontendProxy.URL, "http:")
-	client, err := DialWebsocket(ctx, wsURL, "")
-	if err != nil {
-		t.Fatalf("client dial error: %v", err)
-	}
-	defer client.Close()
-
-	resultChan := make(chan int)
-	sub, err := client.EthSubscribe(ctx, resultChan, "foo")
-	if err != nil {
-		t.Fatalf("client subscribe error: %v", err)
-	}
-
-	// sever the connection
-	severable.Sever()
-
-	// Wait for subscription error.
-	timeout := time.NewTimer(3 * wsPingInterval)
-	defer timeout.Stop()
-	for {
-		select {
-		case err := <-sub.Err():
-			t.Log("client subscription error:", err)
-			return
-		case result := <-resultChan:
-			t.Error("unexpected result:", result)
-			return
-		case <-timeout.C:
-			t.Error("didn't get any error within the test timeout")
-			return
-		}
-	}
-}
-
 // wsPingTestServer runs a WebSocket server which accepts a single subscription request.
 // When a value arrives on sendPing, the server sends a ping frame, waits for a matching
 // pong and finally delivers a single subscription result.
@@ -386,32 +324,4 @@ func wsPingTestHandler(t *testing.T, conn *websocket.Conn, shutdown, sendPing <-
 			return
 		}
 	}
-}
-
-// severableReadWriteCloser wraps an io.ReadWriteCloser and provides a Sever() method to drop writes and read empty.
-type severableReadWriteCloser struct {
-	io.ReadWriteCloser
-	severed int32 // atomic
-}
-
-func (s *severableReadWriteCloser) Sever() {
-	atomic.StoreInt32(&s.severed, 1)
-}
-
-func (s *severableReadWriteCloser) Read(p []byte) (n int, err error) {
-	if atomic.LoadInt32(&s.severed) > 0 {
-		return 0, nil
-	}
-	return s.ReadWriteCloser.Read(p)
-}
-
-func (s *severableReadWriteCloser) Write(p []byte) (n int, err error) {
-	if atomic.LoadInt32(&s.severed) > 0 {
-		return len(p), nil
-	}
-	return s.ReadWriteCloser.Write(p)
-}
-
-func (s *severableReadWriteCloser) Close() error {
-	return s.ReadWriteCloser.Close()
 }


### PR DESCRIPTION
This should remove about ~~two minutes~~ `75s` on CI. 

The `internal/guide` test was news to me, but apparently it executes the commands on the page here: https://geth.ethereum.org/docs/dapp/native-accounts . Well, doing full scrypt on CI is very slow, so maybe we don't have to do it all the time.  


On ` Image: Visual Studio 2019; Environment: GETH_ARCH=386, GETH_MINGW=C:\msys64\mingw32 `, without this PR 

```
ok  	github.com/ethereum/go-ethereum/internal/guide	18.755s	coverage: [no statements]
...
ok  	github.com/ethereum/go-ethereum/rpc	107.314s	coverage: 84.1% of statements
```
With this PR

```
ok  	github.com/ethereum/go-ethereum/internal/guide	1.751s	coverage: [no statements]
...
ok  	github.com/ethereum/go-ethereum/rpc	49.667s	coverage: 83.7% of statements
```

