### PR TITLE
eth/tracers: small refactor for native tracers

### DIFF
--- a/eth/tracers/native/4byte.go
+++ b/eth/tracers/native/4byte.go
@@ -21,7 +21,6 @@ import (
 	"math/big"
 	"strconv"
 	"sync/atomic"
-	"time"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/vm"
@@ -47,6 +46,7 @@ func init() {
 //	  0xc281d19e-0: 1
 //	}
 type fourByteTracer struct {
+	noopTracer
 	ids               map[string]int   // ids aggregates the 4byte ids found
 	interrupt         uint32           // Atomic flag to signal execution interruption
 	reason            error            // Textual reason for the interruption
@@ -90,10 +90,6 @@ func (t *fourByteTracer) CaptureStart(env *vm.EVM, from common.Address, to commo
 	}
 }
 
-// CaptureState implements the EVMLogger interface to trace a single step of VM execution.
-func (t *fourByteTracer) CaptureState(pc uint64, op vm.OpCode, gas, cost uint64, scope *vm.ScopeContext, rData []byte, depth int, err error) {
-}
-
 // CaptureEnter is called when EVM enters a new scope (via call, create or selfdestruct).
 func (t *fourByteTracer) CaptureEnter(op vm.OpCode, from common.Address, to common.Address, input []byte, gas uint64, value *big.Int) {
 	// Skip if tracing was interrupted
@@ -114,23 +110,6 @@ func (t *fourByteTracer) CaptureEnter(op vm.OpCode, from common.Address, to comm
 	}
 	t.store(input[0:4], len(input)-4)
 }
-
-// CaptureExit is called when EVM exits a scope, even if the scope didn't
-// execute any code.
-func (t *fourByteTracer) CaptureExit(output []byte, gasUsed uint64, err error) {
-}
-
-// CaptureFault implements the EVMLogger interface to trace an execution fault.
-func (t *fourByteTracer) CaptureFault(pc uint64, op vm.OpCode, gas, cost uint64, scope *vm.ScopeContext, depth int, err error) {
-}
-
-// CaptureEnd is called after the call finishes to finalize the tracing.
-func (t *fourByteTracer) CaptureEnd(output []byte, gasUsed uint64, _ time.Duration, err error) {
-}
-
-func (*fourByteTracer) CaptureTxStart(gasLimit uint64) {}
-
-func (*fourByteTracer) CaptureTxEnd(restGas uint64) {}
 
 // GetResult returns the json-encoded nested list of call traces, and any
 // error arising from the encoding or forceful termination (via `Stop`).

--- a/eth/tracers/native/call.go
+++ b/eth/tracers/native/call.go
@@ -99,6 +99,7 @@ type callFrameMarshaling struct {
 }
 
 type callTracer struct {
+	noopTracer
 	callstack []callFrame
 	config    callTracerConfig
 	gasLimit  uint64
@@ -179,10 +180,6 @@ func (t *callTracer) CaptureState(pc uint64, op vm.OpCode, gas, cost uint64, sco
 		log := callLog{Address: scope.Contract.Address(), Topics: topics, Data: hexutil.Bytes(data)}
 		t.callstack[len(t.callstack)-1].Logs = append(t.callstack[len(t.callstack)-1].Logs, log)
 	}
-}
-
-// CaptureFault implements the EVMLogger interface to trace an execution fault.
-func (t *callTracer) CaptureFault(pc uint64, op vm.OpCode, gas, cost uint64, scope *vm.ScopeContext, depth int, err error) {
 }
 
 // CaptureEnter is called when EVM enters a new scope (via call, create or selfdestruct).

--- a/eth/tracers/native/prestate.go
+++ b/eth/tracers/native/prestate.go
@@ -55,6 +55,7 @@ type accountMarshaling struct {
 }
 
 type prestateTracer struct {
+	noopTracer
 	env       *vm.EVM
 	pre       state
 	post      state
@@ -165,19 +166,6 @@ func (t *prestateTracer) CaptureState(pc uint64, op vm.OpCode, gas, cost uint64,
 		t.lookupAccount(addr)
 		t.created[addr] = true
 	}
-}
-
-// CaptureFault implements the EVMLogger interface to trace an execution fault.
-func (t *prestateTracer) CaptureFault(pc uint64, op vm.OpCode, gas, cost uint64, _ *vm.ScopeContext, depth int, err error) {
-}
-
-// CaptureEnter is called when EVM enters a new scope (via call, create or selfdestruct).
-func (t *prestateTracer) CaptureEnter(typ vm.OpCode, from common.Address, to common.Address, input []byte, gas uint64, value *big.Int) {
-}
-
-// CaptureExit is called when EVM exits a scope, even if the scope didn't
-// execute any code.
-func (t *prestateTracer) CaptureExit(output []byte, gasUsed uint64, err error) {
 }
 
 func (t *prestateTracer) CaptureTxStart(gasLimit uint64) {


### PR DESCRIPTION
Use `noopTracer` as a base for other native tracers to avoid extra boilerplate for unimplemented hooks.