### PR TITLE
signer/core/apitypes: deep convert types in slice

### DIFF
--- a/signer/core/apitypes/signed_data_internal_test.go
+++ b/signer/core/apitypes/signed_data_internal_test.go
@@ -197,3 +197,12 @@ func TestParseInteger(t *testing.T) {
 		}
 	}
 }
+
+func TestConvertDataToSlice(t *testing.T) {
+	strSlice := []string{"a", "b", "c"}
+	var it interface{} = strSlice
+	_, err := convertDataToSlice(it)
+	if err != nil {
+		t.Fatal(err)
+	}
+}

--- a/signer/core/apitypes/signed_data_internal_test.go
+++ b/signer/core/apitypes/signed_data_internal_test.go
@@ -200,8 +200,8 @@ func TestParseInteger(t *testing.T) {
 }
 
 func TestConvertStringDataToSlice(t *testing.T) {
-	strSlice := []string{"a", "b", "c"}
-	var it interface{} = strSlice
+	slice := []string{"a", "b", "c"}
+	var it interface{} = slice
 	_, err := convertDataToSlice(it)
 	if err != nil {
 		t.Fatal(err)
@@ -209,12 +209,12 @@ func TestConvertStringDataToSlice(t *testing.T) {
 }
 
 func TestConvertUint256DataToSlice(t *testing.T) {
-	strSlice := []*math.HexOrDecimal256{
+	slice := []*math.HexOrDecimal256{
 		math.NewHexOrDecimal256(1),
 		math.NewHexOrDecimal256(2),
 		math.NewHexOrDecimal256(3),
 	}
-	var it interface{} = strSlice
+	var it interface{} = slice
 	_, err := convertDataToSlice(it)
 	if err != nil {
 		t.Fatal(err)
@@ -222,12 +222,12 @@ func TestConvertUint256DataToSlice(t *testing.T) {
 }
 
 func TestConvertAddressDataToSlice(t *testing.T) {
-	strSlice := []common.Address{
+	slice := []common.Address{
 		common.HexToAddress("0x0000000000000000000000000000000000000001"),
 		common.HexToAddress("0x0000000000000000000000000000000000000002"),
 		common.HexToAddress("0x0000000000000000000000000000000000000003"),
 	}
-	var it interface{} = strSlice
+	var it interface{} = slice
 	_, err := convertDataToSlice(it)
 	if err != nil {
 		t.Fatal(err)

--- a/signer/core/apitypes/signed_data_internal_test.go
+++ b/signer/core/apitypes/signed_data_internal_test.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/ethereum/go-ethereum/common/math"
 )
 
 func TestBytesPadding(t *testing.T) {
@@ -198,8 +199,34 @@ func TestParseInteger(t *testing.T) {
 	}
 }
 
-func TestConvertDataToSlice(t *testing.T) {
+func TestConvertStringDataToSlice(t *testing.T) {
 	strSlice := []string{"a", "b", "c"}
+	var it interface{} = strSlice
+	_, err := convertDataToSlice(it)
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestConvertUint256DataToSlice(t *testing.T) {
+	strSlice := []*math.HexOrDecimal256{
+		math.NewHexOrDecimal256(1),
+		math.NewHexOrDecimal256(2),
+		math.NewHexOrDecimal256(3),
+	}
+	var it interface{} = strSlice
+	_, err := convertDataToSlice(it)
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestConvertAddressDataToSlice(t *testing.T) {
+	strSlice := []common.Address{
+		common.HexToAddress("0x0000000000000000000000000000000000000001"),
+		common.HexToAddress("0x0000000000000000000000000000000000000002"),
+		common.HexToAddress("0x0000000000000000000000000000000000000003"),
+	}
 	var it interface{} = strSlice
 	_, err := convertDataToSlice(it)
 	if err != nil {


### PR DESCRIPTION
Hey, @holiman 

Golang version: v1.19
go-ethereum version: v1.10.25

I have a problem doing EIP712 signature with parameter type `uint256[]`

It's like this issue: 
https://github.com/ethereum/go-ethereum/issues/23335#issue-961626333

When the input type is a slice of the internal required type, for example: 
`[]string`,`[]*math.HexOrDecimal256`...

The following line of code will not pass the type when performing type assertion, unless the user encapsulates it in `[]interface{}` before calling
```go
arrayValue, ok:=encValue.([]interface{})
```

Reference documentation: https://github.com/golang/go/wiki/InterfaceSlice

So I processed this code, using reflection to assert whether the value is a slice, process and return the required slice