### PR TITLE
ethstats: set readlimit on ethstats server connection

### DIFF
--- a/ethstats/ethstats.go
+++ b/ethstats/ethstats.go
@@ -57,6 +57,8 @@ const (
 	txChanSize = 4096
 	// chainHeadChanSize is the size of channel listening to ChainHeadEvent.
 	chainHeadChanSize = 10
+
+	messageSizeLimit = 15 * 1024 * 1024
 )
 
 // backend encompasses the bare-minimum functionality needed for ethstats reporting
@@ -121,6 +123,7 @@ type connWrapper struct {
 }
 
 func newConnectionWrapper(conn *websocket.Conn) *connWrapper {
+	conn.SetReadLimit(messageSizeLimit)
 	return &connWrapper{conn: conn}
 }
 


### PR DESCRIPTION
This PR sets a read limit on the ethstats connection to the ethstats-server, which is  a DoS prevention in case the user connects to a malicious ethstats server. 

This PR changes it to use the same limit as websocket rpc: https://github.com/ethereum/go-ethereum/blob/master/rpc/websocket.go#L285

Issue reported by Jorropo via bounty email. 