### PR TITLE
eth/tracers: return proper error from debug_TraceTransaction when tx not found

### DIFF
--- a/eth/tracers/api.go
+++ b/eth/tracers/api.go
@@ -801,9 +801,12 @@ func containsTx(block *types.Block, hash common.Hash) bool {
 // TraceTransaction returns the structured logs created during the execution of EVM
 // and returns them as a JSON object.
 func (api *API) TraceTransaction(ctx context.Context, hash common.Hash, config *TraceConfig) (interface{}, error) {
-	_, blockHash, blockNumber, index, err := api.backend.GetTransaction(ctx, hash)
+	tx, blockHash, blockNumber, index, err := api.backend.GetTransaction(ctx, hash)
 	if err != nil {
 		return nil, err
+	}
+	if tx == nil {
+		return nil, nil
 	}
 	// It shouldn't happen in practice.
 	if blockNumber == 0 {

--- a/eth/tracers/api.go
+++ b/eth/tracers/api.go
@@ -66,9 +66,9 @@ const (
 	// for tracing. The creation of trace state will be paused if the unused
 	// trace states exceed this limit.
 	maximumPendingTraceStates = 128
-
-	errTxNotFound = "transaction not found"
 )
+
+var errTxNotFound = errors.New("transaction not found")
 
 // StateReleaseFunc is used to deallocate resources held by constructing a
 // historical state for tracing purposes.
@@ -809,7 +809,7 @@ func (api *API) TraceTransaction(ctx context.Context, hash common.Hash, config *
 	}
 	// Only mined txes are supported
 	if tx == nil {
-		return nil, errors.New(errTxNotFound)
+		return nil, errTxNotFound
 	}
 	// It shouldn't happen in practice.
 	if blockNumber == 0 {

--- a/eth/tracers/api.go
+++ b/eth/tracers/api.go
@@ -807,6 +807,7 @@ func (api *API) TraceTransaction(ctx context.Context, hash common.Hash, config *
 	if err != nil {
 		return nil, err
 	}
+	// Only mined txes are supported
 	if tx == nil {
 		return nil, errors.New(errTxNotFound)
 	}

--- a/eth/tracers/api.go
+++ b/eth/tracers/api.go
@@ -66,6 +66,8 @@ const (
 	// for tracing. The creation of trace state will be paused if the unused
 	// trace states exceed this limit.
 	maximumPendingTraceStates = 128
+
+	errTxNotFound = "transaction not found"
 )
 
 // StateReleaseFunc is used to deallocate resources held by constructing a
@@ -806,7 +808,7 @@ func (api *API) TraceTransaction(ctx context.Context, hash common.Hash, config *
 		return nil, err
 	}
 	if tx == nil {
-		return nil, errors.New("transaction not found")
+		return nil, errors.New(errTxNotFound)
 	}
 	// It shouldn't happen in practice.
 	if blockNumber == 0 {

--- a/eth/tracers/api.go
+++ b/eth/tracers/api.go
@@ -806,7 +806,7 @@ func (api *API) TraceTransaction(ctx context.Context, hash common.Hash, config *
 		return nil, err
 	}
 	if tx == nil {
-		return nil, nil
+		return nil, errors.New("transaction not found")
 	}
 	// It shouldn't happen in practice.
 	if blockNumber == 0 {

--- a/eth/tracers/api_test.go
+++ b/eth/tracers/api_test.go
@@ -364,11 +364,8 @@ func TestTraceTransaction(t *testing.T) {
 
 	// Test non-existent transaction
 	result, err = api.TraceTransaction(context.Background(), common.Hash{42}, nil)
-	if err == nil {
-		t.Fatal("Tracing a non-existent transaction should return an error")
-	}
-	if err.Error() != errTxNotFound {
-		t.Fatalf("exptected error %s, got %s", errTxNotFound, err.Error())
+	if !errors.Is(err, errTxNotFound) {
+		t.Fatalf("want %v, have %v", errTxNotFound, err)
 	}
 }
 

--- a/eth/tracers/api_test.go
+++ b/eth/tracers/api_test.go
@@ -363,8 +363,8 @@ func TestTraceTransaction(t *testing.T) {
 	}
 
 	result, err = api.TraceTransaction(context.Background(), common.Hash{42}, nil)
-	if err != nil || result != nil {
-		t.Errorf("Tracing a non-existent transaction should return nil")
+	if err == nil || result != nil {
+		t.Fatal("Tracing a non-existent transaction should return nil+error")
 	}
 }
 

--- a/eth/tracers/api_test.go
+++ b/eth/tracers/api_test.go
@@ -363,7 +363,7 @@ func TestTraceTransaction(t *testing.T) {
 	}
 
 	// Test non-existent transaction
-	result, err = api.TraceTransaction(context.Background(), common.Hash{42}, nil)
+	_, err = api.TraceTransaction(context.Background(), common.Hash{42}, nil)
 	if !errors.Is(err, errTxNotFound) {
 		t.Fatalf("want %v, have %v", errTxNotFound, err)
 	}

--- a/eth/tracers/api_test.go
+++ b/eth/tracers/api_test.go
@@ -48,9 +48,8 @@ import (
 )
 
 var (
-	errStateNotFound       = errors.New("state not found")
-	errBlockNotFound       = errors.New("block not found")
-	errTransactionNotFound = errors.New("transaction not found")
+	errStateNotFound = errors.New("state not found")
+	errBlockNotFound = errors.New("block not found")
 )
 
 type testBackend struct {
@@ -117,9 +116,6 @@ func (b *testBackend) BlockByNumber(ctx context.Context, number rpc.BlockNumber)
 
 func (b *testBackend) GetTransaction(ctx context.Context, txHash common.Hash) (*types.Transaction, common.Hash, uint64, uint64, error) {
 	tx, hash, blockNumber, index := rawdb.ReadTransaction(b.chaindb, txHash)
-	if tx == nil {
-		return nil, common.Hash{}, 0, 0, errTransactionNotFound
-	}
 	return tx, hash, blockNumber, index, nil
 }
 
@@ -364,6 +360,11 @@ func TestTraceTransaction(t *testing.T) {
 		StructLogs:  []logger.StructLogRes{},
 	}) {
 		t.Error("Transaction tracing result is different")
+	}
+
+	result, err = api.TraceTransaction(context.Background(), common.Hash{42}, nil)
+	if err != nil || result != nil {
+		t.Errorf("Tracing a non-existent transaction should return nil")
 	}
 }
 

--- a/eth/tracers/api_test.go
+++ b/eth/tracers/api_test.go
@@ -362,9 +362,13 @@ func TestTraceTransaction(t *testing.T) {
 		t.Error("Transaction tracing result is different")
 	}
 
+	// Test non-existent transaction
 	result, err = api.TraceTransaction(context.Background(), common.Hash{42}, nil)
-	if err == nil || result != nil {
-		t.Fatal("Tracing a non-existent transaction should return nil+error")
+	if err == nil {
+		t.Fatal("Tracing a non-existent transaction should return an error")
+	}
+	if err.Error() != errTxNotFound {
+		t.Fatalf("exptected error %s, got %s", errTxNotFound, err.Error())
 	}
 }
 


### PR DESCRIPTION
Currently calling `debug_TraceTransaction` with a transacation hash that doesn't exist returns a confusing error: `{code=-32000, message=genesis is not traceable}`. This is because the `GetTransaction` returns `blockNumber=0` when the transaction doesn't exist.

This PR checks if the tx is `nil` and returns `nil` if so. This will match the behavior of `eth_getTransactionByHash` and `eth_getTransactionReceipt` for transactions that don't exist or aren't yet included in a block.

Fixes #22846.

Example RPC response:
```
> curl -d '{"id":0,"jsonrpc":"2.0","method":"debug_traceTransaction","params":["0x0000000000000000000000000000000000000000000000000000000000000000"]}' -H "Content-Type: application/json" http://localhost:8545
{"jsonrpc":"2.0","id":0,"result":null}
```