### PR TITLE
internal/ethapi: add `eth_getAccount`

### DIFF
--- a/core/state/state_object.go
+++ b/core/state/state_object.go
@@ -523,6 +523,10 @@ func (s *stateObject) Balance() *big.Int {
 	return s.data.Balance
 }
 
+func (s *stateObject) Root() common.Hash {
+	return s.data.Root
+}
+
 func (s *stateObject) Nonce() uint64 {
 	return s.data.Nonce
 }

--- a/core/state/statedb.go
+++ b/core/state/statedb.go
@@ -354,6 +354,14 @@ func (s *StateDB) GetCommittedState(addr common.Address, hash common.Hash) commo
 	return common.Hash{}
 }
 
+func (s *StateDB) GetRoot(addr common.Address) common.Hash {
+	stateObject := s.getStateObject(addr)
+	if stateObject == nil {
+		return common.Hash{}
+	}
+	return stateObject.Root()
+}
+
 // Database retrieves the low level database supporting the lower level trie ops.
 func (s *StateDB) Database() Database {
 	return s.db

--- a/core/vm/interface.go
+++ b/core/vm/interface.go
@@ -54,6 +54,8 @@ type StateDB interface {
 	Suicide(common.Address) bool
 	HasSuicided(common.Address) bool
 
+	GetRoot(common.Address) common.Hash
+
 	// Exist reports whether the given account exists in state.
 	// Notably this should also return true for suicided accounts.
 	Exist(common.Address) bool

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -858,6 +858,16 @@ func (s *BlockChainAPI) GetStorageAt(ctx context.Context, address common.Address
 	return res[:], state.Error()
 }
 
+// Exist returns whether an account for a given address exists in the database.
+func (s *BlockChainAPI) Exist(ctx context.Context, address common.Address, blockNrOrHash rpc.BlockNumberOrHash) (bool, error) {
+	state, _, err := s.b.StateAndHeaderByNumberOrHash(ctx, blockNrOrHash)
+	if state == nil || err != nil {
+		return false, err
+	}
+	exist := state.Exist(address)
+	return exist, state.Error()
+}
+
 // OverrideAccount indicates the overriding fields of account during the execution
 // of a message call.
 // Note, state and stateDiff can't be specified at the same time. If state is

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -858,14 +858,19 @@ func (s *BlockChainAPI) GetStorageAt(ctx context.Context, address common.Address
 	return res[:], state.Error()
 }
 
-// Exist returns whether an account for a given address exists in the database.
-func (s *BlockChainAPI) Exist(ctx context.Context, address common.Address, blockNrOrHash rpc.BlockNumberOrHash) (bool, error) {
+// GetAccount returns whether an account object from the state for the given block number.
+func (s *BlockChainAPI) GetAccount(ctx context.Context, address common.Address, blockNrOrHash rpc.BlockNumberOrHash) (*types.StateAccount, error) {
 	state, _, err := s.b.StateAndHeaderByNumberOrHash(ctx, blockNrOrHash)
 	if state == nil || err != nil {
-		return false, err
+		return nil, err
 	}
-	exist := state.Exist(address)
-	return exist, state.Error()
+
+	return &types.StateAccount{
+		Nonce:    state.GetNonce(address),
+		Balance:  state.GetBalance(address),
+		Root:     state.GetRoot(address),
+		CodeHash: state.GetCodeHash(address).Bytes(),
+	}, state.Error()
 }
 
 // OverrideAccount indicates the overriding fields of account during the execution


### PR DESCRIPTION
Feat: add eth_exists endpoint.

By introducing this endpoint, Geth will fully enable remote execution for pre-EIP158 blocks.