### PR TITLE
p2p/nat: use `IP.IsPrivate`

### DIFF
--- a/p2p/nat/natpmp.go
+++ b/p2p/nat/natpmp.go
@@ -95,13 +95,6 @@ func discoverPMP() Interface {
 	return nil
 }
 
-var (
-	// LAN IP ranges
-	_, lan10, _  = net.ParseCIDR("10.0.0.0/8")
-	_, lan176, _ = net.ParseCIDR("172.16.0.0/12")
-	_, lan192, _ = net.ParseCIDR("192.168.0.0/16")
-)
-
 // TODO: improve this. We currently assume that (on most networks)
 // the router is X.X.X.1 in a local LAN range.
 func potentialGateways() (gws []net.IP) {
@@ -116,7 +109,7 @@ func potentialGateways() (gws []net.IP) {
 		}
 		for _, addr := range ifaddrs {
 			if x, ok := addr.(*net.IPNet); ok {
-				if lan10.Contains(x.IP) || lan176.Contains(x.IP) || lan192.Contains(x.IP) {
+				if x.IP.IsPrivate() {
 					ip := x.IP.Mask(x.Mask).To4()
 					if ip != nil {
 						ip[3] = ip[3] | 0x01


### PR DESCRIPTION
```go
// IsPrivate reports whether ip is a private address, according to
// RFC 1918 (IPv4 addresses) and RFC 4193 (IPv6 addresses).
func (ip IP) IsPrivate() bool {
	if ip4 := ip.To4(); ip4 != nil {
		// Following RFC 1918, Section 3. Private Address Space which says:
		//   The Internet Assigned Numbers Authority (IANA) has reserved the
		//   following three blocks of the IP address space for private internets:
		//     10.0.0.0        -   10.255.255.255  (10/8 prefix)
		//     172.16.0.0      -   172.31.255.255  (172.16/12 prefix)
		//     192.168.0.0     -   192.168.255.255 (192.168/16 prefix)
		return ip4[0] == 10 ||
			(ip4[0] == 172 && ip4[1]&0xf0 == 16) ||
			(ip4[0] == 192 && ip4[1] == 168)
	}
	// Following RFC 4193, Section 8. IANA Considerations which says:
	//   The IANA has assigned the FC00::/7 prefix to "Unique Local Unicast".
	return len(ip) == IPv6len && ip[0]&0xfe == 0xfc
}
```
It added in Go 1.17.

