### PR TITLE
internal/web3ext: fix eth_call stateOverrides in console

### DIFF
--- a/internal/web3ext/web3ext.go
+++ b/internal/web3ext/web3ext.go
@@ -600,6 +600,11 @@ web3._extend({
 			call: 'eth_getLogs',
 			params: 1,
 		}),
+		new web3._extend.Method({
+			name: 'call',
+			call: 'eth_call',
+			params: 3,
+		}),
 	],
 	properties: [
 		new web3._extend.Property({


### PR DESCRIPTION
web3.js's eth_call which we were defaulting to doesn't have the `stateOverrides` parameter, so this param wasn't working in the console.

This came up when looking into https://github.com/ethereum/go-ethereum/issues/26088.