### PR TITLE
internal/web3ext: fix eth.call regression in console

### DIFF
--- a/internal/web3ext/web3ext.go
+++ b/internal/web3ext/web3ext.go
@@ -604,6 +604,7 @@ web3._extend({
 			name: 'call',
 			call: 'eth_call',
 			params: 3,
+			inputFormatter: [formatters.inputCallFormatter, formatters.inputDefaultBlockNumberFormatter, null],
 		}),
 	],
 	properties: [


### PR DESCRIPTION
Fixes a regression in https://github.com/ethereum/go-ethereum/pull/26265.
Basically it only worked if all 3 parameters were provided.