### PR TITLE
Fix testHeaderVerificationForMerging under Ethash

### DIFF
--- a/core/block_validator_test.go
+++ b/core/block_validator_test.go
@@ -138,7 +138,7 @@ func testHeaderVerificationForMerging(t *testing.T, isClique bool) {
 
 		td := 0
 		genDb, blocks, _ := GenerateChainWithGenesis(gspec, engine, 8, nil)
-		for _, block := range preBlocks {
+		for _, block := range blocks {
 			// calculate td
 			td += int(block.Difficulty().Uint64())
 		}


### PR DESCRIPTION
I modified the ethash version of the test to iterate over `block` rather than `preBlocks` when it was computing the total difficulty of the merge point. This is in line with the isClique version of test & avoids an issue where the td was 0 (i.e. a genesis transition) rather than occurring after the preBlocks and before the postBlocks.