### PR TITLE
miner: fix potential goroutine leak in TestStreamUncleBlock

### DIFF
--- a/miner/worker_test.go
+++ b/miner/worker_test.go
@@ -328,7 +328,7 @@ func TestStreamUncleBlock(t *testing.T) {
 	w, b := newTestWorker(t, ethashChainConfig, ethash, rawdb.NewMemoryDatabase(), 1)
 	defer w.close()
 
-	var taskCh = make(chan struct{})
+	var taskCh = make(chan struct{}, 3)
 
 	taskIndex := 0
 	w.newTaskHook = func(task *task) {


### PR DESCRIPTION
There is a potential goroutine leak in the `TestStreamUncleBlock` test.
If the receives on `taskCh` time out before the worker starts sending, the worker will be blocked indefinitely.
This in turn blocks the main goroutine when it waits for the worker to close.

This is reproducible by inserting an appropriate `time.Sleep` before the send on `taskCh`.

The proposed fix allows the worker to proceed from sending on `taskCh` even when the reads have timed out.