### PR TITLE
all: assign zero after resize in implementations of heap.Interface

### DIFF
--- a/core/txpool/list.go
+++ b/core/txpool/list.go
@@ -45,6 +45,7 @@ func (h *nonceHeap) Pop() interface{} {
 	old := *h
 	n := len(old)
 	x := old[n-1]
+	old[n-1] = 0
 	*h = old[0 : n-1]
 	return x
 }

--- a/core/types/transaction.go
+++ b/core/types/transaction.go
@@ -508,6 +508,7 @@ func (s *TxByPriceAndTime) Pop() interface{} {
 	old := *s
 	n := len(old)
 	x := old[n-1]
+	old[n-1] = nil
 	*s = old[0 : n-1]
 	return x
 }

--- a/p2p/util.go
+++ b/p2p/util.go
@@ -70,6 +70,7 @@ func (h *expHeap) Pop() interface{} {
 	old := *h
 	n := len(old)
 	x := old[n-1]
+	old[n-1] = expItem{}
 	*h = old[0 : n-1]
 	return x
 }


### PR DESCRIPTION
Set the deleted item to its zero val so it can be garbage collected.