### PR TITLE
cmd/evm: output stateroot in statetest result

### DIFF
--- a/cmd/evm/staterunner.go
+++ b/cmd/evm/staterunner.go
@@ -22,12 +22,12 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/state"
 	"github.com/ethereum/go-ethereum/core/vm"
 	"github.com/ethereum/go-ethereum/eth/tracers/logger"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/tests"
-
 	"github.com/urfave/cli/v2"
 )
 
@@ -41,11 +41,12 @@ var stateTestCommand = &cli.Command{
 // StatetestResult contains the execution status after running a state test, any
 // error that might have occurred and a dump of the final state if requested.
 type StatetestResult struct {
-	Name  string      `json:"name"`
-	Pass  bool        `json:"pass"`
-	Fork  string      `json:"fork"`
-	Error string      `json:"error,omitempty"`
-	State *state.Dump `json:"state,omitempty"`
+	Name  string       `json:"name"`
+	Pass  bool         `json:"pass"`
+	Root  *common.Hash `json:"stateRoot,omitempty"`
+	Fork  string       `json:"fork"`
+	Error string       `json:"error,omitempty"`
+	State *state.Dump  `json:"state,omitempty"`
 }
 
 func stateTestCmd(ctx *cli.Context) error {
@@ -100,8 +101,12 @@ func stateTestCmd(ctx *cli.Context) error {
 			result := &StatetestResult{Name: key, Fork: st.Fork, Pass: true}
 			_, s, err := test.Run(st, cfg, false)
 			// print state root for evmlab tracing
-			if ctx.Bool(MachineFlag.Name) && s != nil {
-				fmt.Fprintf(os.Stderr, "{\"stateRoot\": \"%x\"}\n", s.IntermediateRoot(false))
+			if s != nil {
+				root := s.IntermediateRoot(false)
+				result.Root = &root
+				if ctx.Bool(MachineFlag.Name) {
+					fmt.Fprintf(os.Stderr, "{\"stateRoot\": \"%x\"}\n", root)
+				}
 			}
 			if err != nil {
 				// Test failed, mark as so and dump any state to aid debugging

--- a/cmd/evm/staterunner.go
+++ b/cmd/evm/staterunner.go
@@ -105,7 +105,7 @@ func stateTestCmd(ctx *cli.Context) error {
 				root := s.IntermediateRoot(false)
 				result.Root = &root
 				if ctx.Bool(MachineFlag.Name) {
-					fmt.Fprintf(os.Stderr, "{\"stateRoot\": \"%x\"}\n", root)
+					fmt.Fprintf(os.Stderr, "{\"stateRoot\": \"%#x\"}\n", root)
 				}
 			}
 			if err != nil {


### PR DESCRIPTION
When doing differential fuzzing, it's convenient to use the `evm statetest` command to and parse the stateroot. Currently, this is done by parsing one of the output fields:. 

```
$ go run . statetest ./foo2.json 
[
  {
    "name": "foo-test-2",
    "pass": false,
    "fork": "London",
    "error": "post state root mismatch: got bce00dc1f67e91e7f2b7461f3ecaf29d913704291639b89fcc6a9682b02c5671, want 0000000000000000000000000000000000000000000000000000000000000000"
  }
]
```
This "works" -- https://github.com/holiman/goevmlab/blob/master/evms/geth.go#L61:L67 -- I can parse the text between `got ` and `, want`. 
However, it fails in certain scenarios, like when the test errors: 
```
$ go run . statetest ./foo.json 
[
  {
    "name": "foo-test",
    "pass": false,
    "fork": "London",
    "error": "unexpected error: intrinsic gas too low: have 94, want 21688"
  }
]
```
This PR adds the post-execution state root as a full member of the `result` json, thus removing the need for parsing a field and adding it also in the fail-case (where the post-state is same as pre-state, since no tx was applied) 

```
$ go run . statetest ./foo2.json 
[
  {
    "name": "foo-test-2",
    "pass": false,
    "stateRoot": "0xbce00dc1f67e91e7f2b7461f3ecaf29d913704291639b89fcc6a9682b02c5671",
    "fork": "London",
    "error": "post state root mismatch: got bce00dc1f67e91e7f2b7461f3ecaf29d913704291639b89fcc6a9682b02c5671, want 0000000000000000000000000000000000000000000000000000000000000000"
  }
]
$ go run . statetest ./foo.json 
[
  {
    "name": "foo-test",
    "pass": false,
    "stateRoot": "0x73e0b529ce725876abdd401d882716f2e423f75681491062cd6a58eb4f3139ff",
    "fork": "London",
    "error": "unexpected error: intrinsic gas too low: have 94, want 21688"
  }
]
```


<details><summary>json files</summary>
<p>

foo.json
```json
{
  "foo-test": {
    "env": {
      "currentCoinbase": "b94f5374fce5edbc8e2a8697c15331677e6ebf0b",
      "currentDifficulty": "0x20000",
      "currentGasLimit": "0x26e1f476fe1e22",
      "currentNumber": "0x1",
      "currentTimestamp": "0x3e8",
      "previousHash": "0x0000000000000000000000000000000000000000000000000000000000000000",
      "currentBaseFee": "0x10"
    },
    "pre": {
      "0x00000000000000000000000000000000000000f1": {
        "code": "0x6000",
        "storage": {},
        "balance": "0x0",
        "nonce": "0x0"
      },
      "0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b": {
        "code": "0x",
        "storage": {},
        "balance": "0xffffffffff",
        "nonce": "0x0"
      }
    },
    "transaction": {
      "gasPrice": "0x10",
      "nonce": "0x0",
      "to": "0x00000000000000000000000000000000000000f1",
      "data": [
        "0x2521c907dea8c1e4c291af3b35362cd7fbc4ea50e0b237f5387d2bb456c4ca60d219ddd9afaf442609f659"
      ],
      "gasLimit": [
        "0x5e"
      ],
      "value": [
        "0x"
      ],
      "secretKey": "0x45a915e4d060149eb4365960e6a7a45f334393093061116b197e3240065ff2d8"
    },
    "out": "0x",
    "post": {
      "London": [
        {
          "hash": "0x0000000000000000000000000000000000000000000000000000000000000000",
          "logs": "0x0000000000000000000000000000000000000000000000000000000000000000",
          "indexes": {
            "data": 0,
            "gas": 0,
            "value": 0
          }
        }
      ]
    }
  }
}
```
foo2.json
```json
{
  "foo-test-2": {
    "env": {
      "currentCoinbase": "b94f5374fce5edbc8e2a8697c15331677e6ebf0b",
      "currentDifficulty": "0x20000",
      "currentGasLimit": "0x26e1f476fe1e22",
      "currentNumber": "0x1",
      "currentTimestamp": "0x3e8",
      "previousHash": "0x0000000000000000000000000000000000000000000000000000000000000000",
      "currentBaseFee": "0x10"
    },
    "pre": {
      "0x00000000000000000000000000000000000000f1": {
        "code": "0x6000",
        "storage": {},
        "balance": "0x0",
        "nonce": "0x0"
      },
      "0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b": {
        "code": "0x",
        "storage": {},
        "balance": "0xffffffffff",
        "nonce": "0x0"
      }
    },
    "transaction": {
      "gasPrice": "0x10",
      "nonce": "0x0",
      "to": "0x00000000000000000000000000000000000000f1",
      "data": [
        "0x2521c907dea8c1e4c291af3b35362cd7fbc4ea50e0b237f5387d2bb456c4ca60d219ddd9afaf442609f659"
      ],
      "gasLimit": [
        "0x5e000"
      ],
      "value": [
        "0x"
      ],
      "secretKey": "0x45a915e4d060149eb4365960e6a7a45f334393093061116b197e3240065ff2d8"
    },
    "out": "0x",
    "post": {
      "London": [
        {
          "hash": "0x0000000000000000000000000000000000000000000000000000000000000000",
          "logs": "0x0000000000000000000000000000000000000000000000000000000000000000",
          "indexes": {
            "data": 0,
            "gas": 0,
            "value": 0
          }
        }
      ]
    }
  }
}
```

</p>
</details>
