### PR TITLE
tests: fix flaw in state test runner

### DIFF
--- a/tests/state_test_util.go
+++ b/tests/state_test_util.go
@@ -249,10 +249,16 @@ func (t *StateTest) RunNoVerify(subtest StateSubtest, vmconfig vm.Config, snapsh
 	context.GetHash = vmTestBlockHash
 	context.BaseFee = baseFee
 	context.Random = nil
-	if config.IsLondon(new(big.Int)) && t.json.Env.Random != nil {
-		rnd := common.BigToHash(t.json.Env.Random)
-		context.Random = &rnd
+	if config.IsLondon(new(big.Int)) {
+		if t.json.Env.Random != nil {
+			rnd := common.BigToHash(t.json.Env.Random)
+			context.Random = &rnd
+		}
 		context.Difficulty = big.NewInt(0)
+	} else {
+		if t.json.Env.Difficulty != nil {
+			context.Difficulty = new(big.Int).Set(t.json.Env.Difficulty)
+		}
 	}
 	evm := vm.NewEVM(context, txContext, statedb, config, vmconfig)
 	// Execute the message.


### PR DESCRIPTION
This PR fixes a flaw uncovered by @guidovranken in a bounty-report. Essentially, even on berlin rules, geth reacts to the `RANDOM` being set, and clears the DIFFICULTY, resulting in the `DIFFICULTY` op returning zero later on. 

Geth trace, where geth spits out `0x0` for difficulty: 
```
{"pc":0,"op":68,"gas":"0xb6c8f8","gasCost":"0x0","memSize":0,"stack":[],"depth":1,"refund":0,"opName":"DIFFICULTY"}
{"pc":1,"op":105,"gas":"0xb6c8f6","gasCost":"0x0","memSize":0,"stack":["0x0"],"depth":1,"refund":0,"opName":"PUSH10"}
```
I modified the statetest from the report a bit, so that it has ` currentDifficulty` at `0x020001` and `currentRandom` set to `..2002`, to disambiguate the two: 
```json
{
  "TEST": {
    "env": {
      "currentBaseFee": "0x0a",
      "currentCoinbase": "0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
      "currentDifficulty": "0x020001",
      "currentGasLimit": "0xb71b00",
      "currentNumber": "0xc5d488",
      "currentRandom": "0x0000000000000000000000000000000000000000000000000000000000020002",
      "currentTimestamp": "0x03e8",
      "previousHash": "0x5e20a0453cecd065ea59c37ac63e079ee08998b6045136a8ce6635c7912ec0b6"
    },
    "post": {
      "Berlin": [
        {
          "hash": "0x2063f93162ceacaf61a2cb7b6875eb701e788e03070af77c25d33b4d68cf81ee",
          "indexes": {
            "data": 0,
            "gas": 0,
            "value": 0
          },
          "logs": "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
          "txbytes": "0x"
        }
      ]
    },
    "pre": {
      "0x6105f4d50D5A1B669E0C87e67Ba663A6Bf1957D7": {
        "balance": "0x00",
        "code": "0x4469614de8ee56f00cbc4139fdc02589cc81d36b",
        "nonce": "0x00",
        "storage": {}
      },
      "0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b": {
        "balance": "0x0fffffffffffffffffffffffffffffffffffffffffffffffff",
        "code": "0x",
        "nonce": "0x00",
        "storage": {}
      }
    },
    "transaction": {
      "data": [
        "0x"
      ],
      "gasLimit": [
        "0xb71b00",
        "0x0ee6b280"
      ],
      "gasPrice": "0x0a",
      "nonce": "0x00",
      "secretKey": "0x45a915e4d060149eb4365960e6a7a45f334393093061116b197e3240065ff2d8",
      "sender": "0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b",
      "to": "0x6105f4d50D5A1B669E0C87e67Ba663A6Bf1957D7",
      "value": [
        "0x00"
      ]
    }
  }
}

```
With this PR, geth now correctly spits out `0x20001`
```
{"pc":0,"op":68,"gas":"0xb6c8f8","gasCost":"0x2","memSize":0,"stack":[],"depth":1,"refund":0,"opName":"DIFFICULTY"}
{"pc":1,"op":105,"gas":"0xb6c8f6","gasCost":"0x3","memSize":0,"stack":["0x20001"],"depth":1,"refund":0,"opName":"PUSH10"}
```
As for besu and nethermind, nethermind erroneously spits out `0x20002` 
```
{"pc":0,"op":68,"gas":"0xb6c8f8","gasCost":"0x0","memSize":0,"stack":[],"depth":1,"refund":0,"opName":"DIFFICULTY"}
{"pc":1,"op":105,"gas":"0xb6c8f6","gasCost":"0x0","memSize":0,"stack":["0x20002"],"depth":1,"refund":0,"opName":"PUSH10"}
```
But besu correctly spits out `0x20001`: 
```
{"pc":0,"op":68,"gas":"0xb6c8f8","gasCost":"0x0","memSize":0,"stack":[],"depth":1,"refund":0,"opName":"DIFFICULTY"}
{"pc":1,"op":105,"gas":"0xb6c8f6","gasCost":"0x0","memSize":0,"stack":["0x20001"],"depth":1,"refund":0,"opName":"PUSH10"}
```

cc @MarekM25 @LukaszRozmej 


This test does only
```
DIFFICULTY
PUSH10 0x614de8ee56f00cbc4139
REVERT
```
It caused a differing state root because `REVERT(0x614de8ee56f00cbc4139, 0)` succeeds (size zero) whereas a non-zero size fails. However, the stateroot does not change if `0x20002` is used instead of `0x20001`. So it's not a "great" test to include as is in the reference tests, but it should be fairly simple to tweak it and include it. cc @winsvega 
