### PR TITLE
signer/core: handle gnosis safe problem with missing chain id

### DIFF
--- a/signer/core/signed_data_test.go
+++ b/signer/core/signed_data_test.go
@@ -826,3 +826,18 @@ func TestComplexTypedData(t *testing.T) {
 		t.Fatalf("Error, got %x, wanted %x", sighash, expSigHash)
 	}
 }
+
+func TestGnosisSafe(t *testing.T) {
+	js := "{\n  \"safe\": \"0x899FcB1437DE65DC6315f5a69C017dd3F2837557\",\n  \"to\": \"0x899FcB1437DE65DC6315f5a69C017dd3F2837557\",\n  \"value\": \"0\",\n  \"data\": \"0x0d582f13000000000000000000000000d3ed2b8756b942c98c851722f3bd507a17b4745f0000000000000000000000000000000000000000000000000000000000000005\",\n  \"operation\": 0,\n  \"gasToken\": \"0x0000000000000000000000000000000000000000\",\n  \"safeTxGas\": 0,\n  \"baseGas\": 0,\n  \"gasPrice\": \"0\",\n  \"refundReceiver\": \"0x0000000000000000000000000000000000000000\",\n  \"nonce\": 0,\n  \"executionDate\": null,\n  \"submissionDate\": \"2022-02-23T14:09:00.018475Z\",\n  \"modified\": \"2022-12-01T15:52:21.214357Z\",\n  \"blockNumber\": null,\n  \"transactionHash\": null,\n  \"safeTxHash\": \"0x6f0f5cffee69087c9d2471e477a63cab2ae171cf433e754315d558d8836274f4\",\n  \"executor\": null,\n  \"isExecuted\": false,\n  \"isSuccessful\": null,\n  \"ethGasPrice\": null,\n  \"maxFeePerGas\": null,\n  \"maxPriorityFeePerGas\": null,\n  \"gasUsed\": null,\n  \"fee\": null,\n  \"origin\": \"https://gnosis-safe.io\",\n  \"dataDecoded\": {\n    \"method\": \"addOwnerWithThreshold\",\n    \"parameters\": [\n      {\n        \"name\": \"owner\",\n        \"type\": \"address\",\n        \"value\": \"0xD3Ed2b8756b942c98c851722F3bd507a17B4745F\"\n      },\n      {\n        \"name\": \"_threshold\",\n        \"type\": \"uint256\",\n        \"value\": \"5\"\n      }\n    ]\n  },\n  \"confirmationsRequired\": 4,\n  \"confirmations\": [\n    {\n      \"owner\": \"0x30B714E065B879F5c042A75Bb40a220A0BE27966\",\n      \"submissionDate\": \"2022-03-01T14:56:22Z\",\n      \"transactionHash\": \"0x6d0a9c83ac7578ef3be1f2afce089fb83b619583dfa779b82f4422fd64ff3ee9\",\n      \"signature\": \"0x00000000000000000000000030b714e065b879f5c042a75bb40a220a0be27966000000000000000000000000000000000000000000000000000000000000000001\",\n      \"signatureType\": \"APPROVED_HASH\"\n    },\n    {\n      \"owner\": \"0x8300dFEa25Da0eb744fC0D98c23283F86AB8c10C\",\n      \"submissionDate\": \"2022-12-01T15:52:21.214357Z\",\n      \"transactionHash\": null,\n      \"signature\": \"0xbce73de4cc6ee208e933a93c794dcb8ba1810f9848d1eec416b7be4dae9854c07dbf1720e60bbd310d2159197a380c941cfdb55b3ce58f9dd69efd395d7bef881b\",\n      \"signatureType\": \"EOA\"\n    }\n  ],\n  \"trusted\": true,\n  \"signatures\": null\n}\n"
+	var gnosisTx core.GnosisSafeTx
+	if err := json.Unmarshal([]byte(js), &gnosisTx); err != nil {
+		t.Fatal(err)
+	}
+	typedData := gnosisTx.ToTypedData()
+	if sighash, rawdata, err := apitypes.TypedDataAndHash(typedData); err != nil {
+		t.Fatal(err)
+	} else if !bytes.Equal(sighash, gnosisTx.InputExpHash.Bytes()) {
+		t.Logf("rawdata: %#x\n", rawdata)
+		t.Fatal(fmt.Errorf("mismatched safeTxHash; have %#x want %#x", sighash, gnosisTx.InputExpHash[:]))
+	}
+}

--- a/signer/core/signed_data_test.go
+++ b/signer/core/signed_data_test.go
@@ -21,6 +21,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"math/big"
 	"os"
 	"path"
 	"strings"
@@ -828,16 +829,22 @@ func TestComplexTypedData(t *testing.T) {
 }
 
 func TestGnosisSafe(t *testing.T) {
+	// json missing chain id
 	js := "{\n  \"safe\": \"0x899FcB1437DE65DC6315f5a69C017dd3F2837557\",\n  \"to\": \"0x899FcB1437DE65DC6315f5a69C017dd3F2837557\",\n  \"value\": \"0\",\n  \"data\": \"0x0d582f13000000000000000000000000d3ed2b8756b942c98c851722f3bd507a17b4745f0000000000000000000000000000000000000000000000000000000000000005\",\n  \"operation\": 0,\n  \"gasToken\": \"0x0000000000000000000000000000000000000000\",\n  \"safeTxGas\": 0,\n  \"baseGas\": 0,\n  \"gasPrice\": \"0\",\n  \"refundReceiver\": \"0x0000000000000000000000000000000000000000\",\n  \"nonce\": 0,\n  \"executionDate\": null,\n  \"submissionDate\": \"2022-02-23T14:09:00.018475Z\",\n  \"modified\": \"2022-12-01T15:52:21.214357Z\",\n  \"blockNumber\": null,\n  \"transactionHash\": null,\n  \"safeTxHash\": \"0x6f0f5cffee69087c9d2471e477a63cab2ae171cf433e754315d558d8836274f4\",\n  \"executor\": null,\n  \"isExecuted\": false,\n  \"isSuccessful\": null,\n  \"ethGasPrice\": null,\n  \"maxFeePerGas\": null,\n  \"maxPriorityFeePerGas\": null,\n  \"gasUsed\": null,\n  \"fee\": null,\n  \"origin\": \"https://gnosis-safe.io\",\n  \"dataDecoded\": {\n    \"method\": \"addOwnerWithThreshold\",\n    \"parameters\": [\n      {\n        \"name\": \"owner\",\n        \"type\": \"address\",\n        \"value\": \"0xD3Ed2b8756b942c98c851722F3bd507a17B4745F\"\n      },\n      {\n        \"name\": \"_threshold\",\n        \"type\": \"uint256\",\n        \"value\": \"5\"\n      }\n    ]\n  },\n  \"confirmationsRequired\": 4,\n  \"confirmations\": [\n    {\n      \"owner\": \"0x30B714E065B879F5c042A75Bb40a220A0BE27966\",\n      \"submissionDate\": \"2022-03-01T14:56:22Z\",\n      \"transactionHash\": \"0x6d0a9c83ac7578ef3be1f2afce089fb83b619583dfa779b82f4422fd64ff3ee9\",\n      \"signature\": \"0x00000000000000000000000030b714e065b879f5c042a75bb40a220a0be27966000000000000000000000000000000000000000000000000000000000000000001\",\n      \"signatureType\": \"APPROVED_HASH\"\n    },\n    {\n      \"owner\": \"0x8300dFEa25Da0eb744fC0D98c23283F86AB8c10C\",\n      \"submissionDate\": \"2022-12-01T15:52:21.214357Z\",\n      \"transactionHash\": null,\n      \"signature\": \"0xbce73de4cc6ee208e933a93c794dcb8ba1810f9848d1eec416b7be4dae9854c07dbf1720e60bbd310d2159197a380c941cfdb55b3ce58f9dd69efd395d7bef881b\",\n      \"signatureType\": \"EOA\"\n    }\n  ],\n  \"trusted\": true,\n  \"signatures\": null\n}\n"
 	var gnosisTx core.GnosisSafeTx
 	if err := json.Unmarshal([]byte(js), &gnosisTx); err != nil {
 		t.Fatal(err)
 	}
-	typedData := gnosisTx.ToTypedData()
-	if sighash, rawdata, err := apitypes.TypedDataAndHash(typedData); err != nil {
+	sighash, _, err := apitypes.TypedDataAndHash(gnosisTx.ToTypedData())
+	if err != nil {
 		t.Fatal(err)
-	} else if !bytes.Equal(sighash, gnosisTx.InputExpHash.Bytes()) {
-		t.Logf("rawdata: %#x\n", rawdata)
-		t.Fatal(fmt.Errorf("mismatched safeTxHash; have %#x want %#x", sighash, gnosisTx.InputExpHash[:]))
+	}
+	if bytes.Equal(sighash, gnosisTx.InputExpHash.Bytes()) {
+		t.Fatal("expected inequality")
+	}
+	gnosisTx.ChainId = (*math.HexOrDecimal256)(big.NewInt(1))
+	sighash, _, _ = apitypes.TypedDataAndHash(gnosisTx.ToTypedData())
+	if !bytes.Equal(sighash, gnosisTx.InputExpHash.Bytes()) {
+		t.Fatal("expected equality")
 	}
 }


### PR DESCRIPTION
This PR adds a check that the safetxhash that we sign corresponds to the one that is expected by the input. This PR also adds a case which is currently failing.

The current code calculates the `safeTxHash` for a certain json message differently than what is expected by the online safe tx machinery. 

cc @rmeissner could you please help me figure out the difference here? 

json: 
```json
{
  "safe": "0x899FcB1437DE65DC6315f5a69C017dd3F2837557",
  "to": "0x899FcB1437DE65DC6315f5a69C017dd3F2837557",
  "value": "0",
  "data": "0x0d582f13000000000000000000000000d3ed2b8756b942c98c851722f3bd507a17b4745f0000000000000000000000000000000000000000000000000000000000000005",
  "operation": 0,
  "gasToken": "0x0000000000000000000000000000000000000000",
  "safeTxGas": 0,
  "baseGas": 0,
  "gasPrice": "0",
  "refundReceiver": "0x0000000000000000000000000000000000000000",
  "nonce": 0,
  "executionDate": null,
  "submissionDate": "2022-02-23T14:09:00.018475Z",
  "modified": "2022-12-01T15:52:21.214357Z",
  "blockNumber": null,
  "transactionHash": null,
  "safeTxHash": "0x6f0f5cffee69087c9d2471e477a63cab2ae171cf433e754315d558d8836274f4",
  "executor": null,
  "isExecuted": false,
  "isSuccessful": null,
  "ethGasPrice": null,
  "maxFeePerGas": null,
  "maxPriorityFeePerGas": null,
  "gasUsed": null,
  "fee": null,
  "origin": "https://gnosis-safe.io",
  "dataDecoded": {
    "method": "addOwnerWithThreshold",
    "parameters": [
      {
        "name": "owner",
        "type": "address",
        "value": "0xD3Ed2b8756b942c98c851722F3bd507a17B4745F"
      },
      {
        "name": "_threshold",
        "type": "uint256",
        "value": "5"
      }
    ]
  },
  "confirmationsRequired": 4,
  "confirmations": [
    {
      "owner": "0x30B714E065B879F5c042A75Bb40a220A0BE27966",
      "submissionDate": "2022-03-01T14:56:22Z",
      "transactionHash": "0x6d0a9c83ac7578ef3be1f2afce089fb83b619583dfa779b82f4422fd64ff3ee9",
      "signature": "0x00000000000000000000000030b714e065b879f5c042a75bb40a220a0be27966000000000000000000000000000000000000000000000000000000000000000001",
      "signatureType": "APPROVED_HASH"
    },
    {
      "owner": "0x8300dFEa25Da0eb744fC0D98c23283F86AB8c10C",
      "submissionDate": "2022-12-01T15:52:21.214357Z",
      "transactionHash": null,
      "signature": "0xbce73de4cc6ee208e933a93c794dcb8ba1810f9848d1eec416b7be4dae9854c07dbf1720e60bbd310d2159197a380c941cfdb55b3ce58f9dd69efd395d7bef881b",
      "signatureType": "EOA"
    }
  ],
  "trusted": true,
  "signatures": null
}
```
Resulting preimage before keccak: 
```
0x190119994026f194e6a8a9be0983c8c7fc49d8f1aa03b638577e35c4be0d082145c681d1e7162ad6fcb59199bcacdd11e8228484abcd2f5fde35a4b9be40e668bf24
```
Resulting hash: 
```
0x6e6a5ede66d5838ec141746b6544a0140416bff184faff17cf62cab97f11f5ae
```
But the expectation is 
```
  "safeTxHash": "0x6f0f5cffee69087c9d2471e477a63cab2ae171cf433e754315d558d8836274f4",
```

