### PR TITLE
Test update merge

### DIFF
--- a/tests/block_test_util.go
+++ b/tests/block_test_util.go
@@ -29,6 +29,7 @@ import (
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/common/math"
 	"github.com/ethereum/go-ethereum/consensus"
+	"github.com/ethereum/go-ethereum/consensus/beacon"
 	"github.com/ethereum/go-ethereum/consensus/ethash"
 	"github.com/ethereum/go-ethereum/core"
 	"github.com/ethereum/go-ethereum/core/rawdb"
@@ -120,6 +121,9 @@ func (t *BlockTest) Run(snapshotter bool) error {
 	} else {
 		engine = ethash.NewShared()
 	}
+	// Wrap the original engine within the beacon-engine
+	engine = beacon.New(engine)
+
 	cache := &core.CacheConfig{TrieCleanLimit: 0}
 	if snapshotter {
 		cache.SnapshotLimit = 1

--- a/tests/init.go
+++ b/tests/init.go
@@ -197,6 +197,24 @@ var Forks = map[string]*params.ChainConfig{
 		LondonBlock:         big.NewInt(0),
 		ArrowGlacierBlock:   big.NewInt(0),
 	},
+	"ArrowGlacierToMergeAtDiffC0000": {
+		ChainID:                 big.NewInt(1),
+		HomesteadBlock:          big.NewInt(0),
+		EIP150Block:             big.NewInt(0),
+		EIP155Block:             big.NewInt(0),
+		EIP158Block:             big.NewInt(0),
+		ByzantiumBlock:          big.NewInt(0),
+		ConstantinopleBlock:     big.NewInt(0),
+		PetersburgBlock:         big.NewInt(0),
+		IstanbulBlock:           big.NewInt(0),
+		MuirGlacierBlock:        big.NewInt(0),
+		BerlinBlock:             big.NewInt(0),
+		LondonBlock:             big.NewInt(0),
+		ArrowGlacierBlock:       big.NewInt(0),
+		GrayGlacierBlock:        big.NewInt(0),
+		MergeNetsplitBlock:      big.NewInt(0),
+		TerminalTotalDifficulty: big.NewInt(0xC0000),
+	},
 	"GrayGlacier": {
 		ChainID:             big.NewInt(1),
 		HomesteadBlock:      big.NewInt(0),
@@ -213,7 +231,7 @@ var Forks = map[string]*params.ChainConfig{
 		ArrowGlacierBlock:   big.NewInt(0),
 		GrayGlacierBlock:    big.NewInt(0),
 	},
-	"Merged": {
+	"Merge": {
 		ChainID:                 big.NewInt(1),
 		HomesteadBlock:          big.NewInt(0),
 		EIP150Block:             big.NewInt(0),

--- a/tests/state_test.go
+++ b/tests/state_test.go
@@ -56,14 +56,12 @@ func TestState(t *testing.T) {
 	// Uses 1GB RAM per tested fork
 	st.skipLoad(`^stStaticCall/static_Call1MB`)
 
+	// Not yet supported TODO
+	st.skipLoad(`^stEIP3540/`)
+	st.skipLoad(`^stEIP3860/`)
+
 	// Broken tests:
 	// Expected failures:
-	// st.fails(`^stRevertTest/RevertPrecompiledTouch(_storage)?\.json/Byzantium/0`, "bug in test")
-	// st.fails(`^stRevertTest/RevertPrecompiledTouch(_storage)?\.json/Byzantium/3`, "bug in test")
-	// st.fails(`^stRevertTest/RevertPrecompiledTouch(_storage)?\.json/Constantinople/0`, "bug in test")
-	// st.fails(`^stRevertTest/RevertPrecompiledTouch(_storage)?\.json/Constantinople/3`, "bug in test")
-	// st.fails(`^stRevertTest/RevertPrecompiledTouch(_storage)?\.json/ConstantinopleFix/0`, "bug in test")
-	// st.fails(`^stRevertTest/RevertPrecompiledTouch(_storage)?\.json/ConstantinopleFix/3`, "bug in test")
 
 	// For Istanbul, older tests were moved into LegacyTests
 	for _, dir := range []string{

--- a/tests/state_test_util.go
+++ b/tests/state_test_util.go
@@ -249,10 +249,16 @@ func (t *StateTest) RunNoVerify(subtest StateSubtest, vmconfig vm.Config, snapsh
 	context.GetHash = vmTestBlockHash
 	context.BaseFee = baseFee
 	context.Random = nil
-	if config.IsLondon(new(big.Int)) && t.json.Env.Random != nil {
-		rnd := common.BigToHash(t.json.Env.Random)
-		context.Random = &rnd
+	if config.IsLondon(new(big.Int)) {
+		if t.json.Env.Random != nil {
+			rnd := common.BigToHash(t.json.Env.Random)
+			context.Random = &rnd
+		}
 		context.Difficulty = big.NewInt(0)
+	} else {
+		if t.json.Env.Difficulty != nil {
+			context.Difficulty = new(big.Int).Set(t.json.Env.Difficulty)
+		}
 	}
 	evm := vm.NewEVM(context, txContext, statedb, config, vmconfig)
 	// Execute the message.


### PR DESCRIPTION
This PR builds on #26299, but also updates the tests to the most recent version, which includes tests regarding TheMerge. 

This update contains an interesting error:
```
--- FAIL: TestBlockchain (0.01s)
    --- FAIL: TestBlockchain/TransitionTests/bcArrowGlacierToMerge/powToPosBlockRejection.json (0.01s)
        block_test.go:51: test without snapshotter failed: block (index 11) insertion should have failed due to: 3675PoWBlockRejected
        block_test.go:54: test with snapshotter failed: block (index 11) insertion should have failed due to: 3675PoWBlockRejected
```
Here, we try to import some blocks, and one of the blocks goes over the TTD. The test
expects us to reject the last one, however, we have this little thing in the
`beacon/consensus.go`:

```golang
func (beacon *Beacon) VerifyHeaders(chain consensus.ChainHeaderReader, headers []*types.Header, seals []bool) (chan<- struct{}, <-chan error) {
	if !beacon.IsPoSHeader(headers[len(headers)-1]) {
		return beacon.ethone.VerifyHeaders(chain, headers, seals)
	}
	var (
		preHeaders  []*types.Header
		postHeaders []*types.Header
```

That is, we check the very last header -- if it looks like a PoW-header, we ship all
headers to the `ethone` engine for verification, and done.

In the other path, where we go through the work of separating them up in pre- and post- headers,
we're much more careful about ensuring that the PoW headers do not exceed the TTD:
```
		// Verify that pre-merge headers don't overflow the TTD
		if index, err := verifyTerminalPoWBlock(chain, preHeaders); err != nil {
```

This is something we need to investigate, I'm not sure exactly what is The Correct Fix. 