### PR TITLE
core: fix state flushing for catalyst mode

### DIFF
--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -1764,6 +1764,10 @@ func (bc *BlockChain) insertChain(chain types.Blocks, verifySeals, setHead bool)
 		stats.report(chain, it.index, dirty, setHead)
 
 		if !setHead {
+			// After merge we expect few side chains. Simply count
+			// all blocks the CL gives us for GC processing time
+			bc.gcproc += proctime
+
 			return it.index, nil // Direct block insertion of a single block
 		}
 		switch status {


### PR DESCRIPTION
This is the simplest solution to increase block processing time for all blocks the CL gives us regardless of whether they end up on the canonical chain or not. Alternatively we can track the execution time of each processed block.