### PR TITLE
p2p/nat: handle responses with alternative port in NAT-PMP

### DIFF
--- a/p2p/nat/natpmp.go
+++ b/p2p/nat/natpmp.go
@@ -63,7 +63,7 @@ func (n *pmp) AddMapping(protocol string, extport, intport int, name string, lif
 	if uint16(extport) != res.MappedExternalPort {
 		// Destroying meaningless mapped port map in NAT device.
 		n.c.AddPortMapping(strings.ToLower(protocol), intport, 0, 0)
-		return fmt.Errorf("preempted port")
+		return fmt.Errorf("preempted port %d(%s)", extport, protocol)
 	}
 
 	return nil

--- a/p2p/nat/natpmp.go
+++ b/p2p/nat/natpmp.go
@@ -62,7 +62,7 @@ func (n *pmp) AddMapping(protocol string, extport, intport int, name string, lif
 	if uint16(extport) != res.MappedExternalPort {
 		// Destroy the mapping in NAT device.
 		n.c.AddPortMapping(strings.ToLower(protocol), intport, 0, 0)
-		return fmt.Errorf("port %d already mapped to another address (%s)", intport, protocol)
+		return fmt.Errorf("port %d already mapped to another address (%s)", extport, protocol)
 	}
 
 	return nil

--- a/p2p/nat/natpmp.go
+++ b/p2p/nat/natpmp.go
@@ -57,9 +57,9 @@ func (n *pmp) AddMapping(protocol string, extport, intport int, name string, lif
 
 	// NAT-PMP maps an available port number if the requested port is
 	// already preempted and returns success. In this case, It returns
-	// an error because no actual communication occurs by telling the
-	// other node a different port number than the actual mapped port
-	// number.
+	// an error because no actual communication occurs by advertised
+	// the other node a different port number than the actual mapped
+	// port number.
 	if uint16(extport) != res.MappedExternalPort {
 		// Destroying meaningless mapped port map in NAT device.
 		n.c.AddPortMapping(strings.ToLower(protocol), intport, 0, 0)

--- a/p2p/nat/natpmp.go
+++ b/p2p/nat/natpmp.go
@@ -55,15 +55,14 @@ func (n *pmp) AddMapping(protocol string, extport, intport int, name string, lif
 		return err
 	}
 
-	// NAT-PMP maps an available port number if the requested port is
-	// already preempted and returns success. In this case, It returns
-	// an error because no actual communication occurs by advertised
-	// the other node a different port number than the actual mapped
-	// port number.
+	// NAT-PMP maps an alternative available port number if the requested
+	// port is already mapped to another address and returns success. In this
+	// case, we return an error because there is no way to return the new port
+	// to the caller.
 	if uint16(extport) != res.MappedExternalPort {
-		// Destroying meaningless mapped port map in NAT device.
+		// Destroy the mapping in NAT device.
 		n.c.AddPortMapping(strings.ToLower(protocol), intport, 0, 0)
-		return fmt.Errorf("preempted port %d(%s)", extport, protocol)
+		return fmt.Errorf("port %d already mapped to another address (%s)", intport, protocol)
 	}
 
 	return nil


### PR DESCRIPTION
For NAT-PMP, returns success with an available port if the requested port is already preempted. If this situation occurs, the current implementation considers it a success and performs the remaining tasks, but in practice, communication with external network nodes is impossible, and it is difficult to track down this issue.
This PR adds check logic for preempted ports and define this situation as an error.

ref: rfc6886 [p.12](https://www.rfc-editor.org/rfc/rfc6886.html#page-12), [p.29](https://www.rfc-editor.org/rfc/rfc6886.html#page-29)
