### PR TITLE
p2p/nat: set refreshInterval

### DIFF
--- a/p2p/nat/nat.go
+++ b/p2p/nat/nat.go
@@ -91,14 +91,15 @@ func Parse(spec string) (Interface, error) {
 }
 
 const (
-	mapTimeout = 10 * time.Minute
+	mapTimeout      = 10 * time.Minute
+	refreshInterval = mapTimeout - (mapTimeout / 10)
 )
 
 // Map adds a port mapping on m and keeps it alive until c is closed.
 // This function is typically invoked in its own goroutine.
 func Map(m Interface, c <-chan struct{}, protocol string, extport, intport int, name string) {
 	log := log.New("proto", protocol, "extport", extport, "intport", intport, "interface", m)
-	refresh := time.NewTimer(mapTimeout)
+	refresh := time.NewTimer(refreshInterval)
 	defer func() {
 		refresh.Stop()
 		log.Debug("Deleting port mapping")


### PR DESCRIPTION
The process of refreshing the portmap is executed as a timer every lifetime, but it is not a refresh operation because the NAT mapping is deleted in the process of generating and transmitting the request packet. It's seems remapping.  During this operation, there is a possibility that a node that was operating may not be able to communicate normally because another client preempts the port that was in use. PR is meant to prevent this.
