### PR TITLE
eth, cmd: remove syncTarget from eth config

### DIFF
--- a/eth/ethconfig/config.go
+++ b/eth/ethconfig/config.go
@@ -32,7 +32,6 @@ import (
 	"github.com/ethereum/go-ethereum/consensus/ethash"
 	"github.com/ethereum/go-ethereum/core"
 	"github.com/ethereum/go-ethereum/core/txpool"
-	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/eth/downloader"
 	"github.com/ethereum/go-ethereum/eth/gasprice"
 	"github.com/ethereum/go-ethereum/ethdb"
@@ -212,10 +211,6 @@ type Config struct {
 
 	// OverrideTerminalTotalDifficultyPassed (TODO: remove after the fork)
 	OverrideTerminalTotalDifficultyPassed *bool `toml:",omitempty"`
-
-	// SyncTarget defines the target block of sync. It's only used for
-	// development purposes.
-	SyncTarget *types.Block
 }
 
 // CreateConsensusEngine creates a consensus engine for the given chain configuration.

--- a/eth/ethconfig/gen_config.go
+++ b/eth/ethconfig/gen_config.go
@@ -10,7 +10,6 @@ import (
 	"github.com/ethereum/go-ethereum/consensus/ethash"
 	"github.com/ethereum/go-ethereum/core"
 	"github.com/ethereum/go-ethereum/core/txpool"
-	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/eth/downloader"
 	"github.com/ethereum/go-ethereum/eth/gasprice"
 	"github.com/ethereum/go-ethereum/miner"
@@ -64,7 +63,6 @@ func (c Config) MarshalTOML() (interface{}, error) {
 		CheckpointOracle                      *params.CheckpointOracleConfig `toml:",omitempty"`
 		OverrideTerminalTotalDifficulty       *big.Int                       `toml:",omitempty"`
 		OverrideTerminalTotalDifficultyPassed *bool                          `toml:",omitempty"`
-		FullSyncTarget                        *types.Block
 	}
 	var enc Config
 	enc.Genesis = c.Genesis
@@ -111,7 +109,6 @@ func (c Config) MarshalTOML() (interface{}, error) {
 	enc.CheckpointOracle = c.CheckpointOracle
 	enc.OverrideTerminalTotalDifficulty = c.OverrideTerminalTotalDifficulty
 	enc.OverrideTerminalTotalDifficultyPassed = c.OverrideTerminalTotalDifficultyPassed
-	enc.FullSyncTarget = c.SyncTarget
 	return &enc, nil
 }
 
@@ -162,7 +159,6 @@ func (c *Config) UnmarshalTOML(unmarshal func(interface{}) error) error {
 		CheckpointOracle                      *params.CheckpointOracleConfig `toml:",omitempty"`
 		OverrideTerminalTotalDifficulty       *big.Int                       `toml:",omitempty"`
 		OverrideTerminalTotalDifficultyPassed *bool                          `toml:",omitempty"`
-		FullSyncTarget                        *types.Block
 	}
 	var dec Config
 	if err := unmarshal(&dec); err != nil {
@@ -299,9 +295,6 @@ func (c *Config) UnmarshalTOML(unmarshal func(interface{}) error) error {
 	}
 	if dec.OverrideTerminalTotalDifficultyPassed != nil {
 		c.OverrideTerminalTotalDifficultyPassed = dec.OverrideTerminalTotalDifficultyPassed
-	}
-	if dec.FullSyncTarget != nil {
-		c.SyncTarget = dec.FullSyncTarget
 	}
 	return nil
 }


### PR DESCRIPTION
`--syncTarget` is a feature for development purpose in post-merge world. Previously 
it's added into eth.Config. But it turns out it's a stupid idea.

- syncTarget is a block object, which is hard to be put in config file(large)
- syncTarget is just a dev feature, doesn't make too much sense to add it in config file

So I remove it from the eth config object. And it also fixes the #26328 