### PR TITLE
core: pass block into collectLogs

### DIFF
--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -2142,8 +2142,8 @@ func (bc *BlockChain) reorg(oldBlock, newBlock *types.Block) error {
 		bc.chainSideFeed.Send(ChainSideEvent{Block: oldChain[i]})
 
 		// Collect deleted logs for notification
-		h := oldChain[i]
-		if logs := bc.collectLogs(h.Hash(), h.NumberU64(), true); len(logs) > 0 {
+		b := oldChain[i]
+		if logs := bc.collectLogs(b.Hash(), b.NumberU64(), true); len(logs) > 0 {
 			deletedLogs = append(deletedLogs, logs...)
 		}
 		if len(deletedLogs) > 512 {
@@ -2158,8 +2158,8 @@ func (bc *BlockChain) reorg(oldBlock, newBlock *types.Block) error {
 	// New logs:
 	var rebirthLogs []*types.Log
 	for i := len(newChain) - 1; i >= 1; i-- {
-		h := newChain[i]
-		if logs := bc.collectLogs(h.Hash(), h.NumberU64(), false); len(logs) > 0 {
+		b := newChain[i]
+		if logs := bc.collectLogs(b.Hash(), b.NumberU64(), false); len(logs) > 0 {
 			rebirthLogs = append(rebirthLogs, logs...)
 		}
 		if len(rebirthLogs) > 512 {

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -1993,8 +1993,7 @@ func (bc *BlockChain) recoverAncestors(block *types.Block) (common.Hash, error) 
 }
 
 // collectLogs collects the logs that were generated or removed during
-// the processing of the block that corresponds with the given hash.
-// These logs are later announced as deleted or reborn.
+// the processing of a block. These logs are later announced as deleted or reborn.
 func (bc *BlockChain) collectLogs(b *types.Block, removed bool) []*types.Log {
 	receipts := rawdb.ReadRawReceipts(bc.db, b.Hash(), b.NumberU64())
 	receipts.DeriveFields(bc.chainConfig, b.Hash(), b.NumberU64(), b.Transactions())


### PR DESCRIPTION
While investigating another issue, I found that all callers of `collectLogs` have the complete block available. 
There is no need to read it back from the database.