### PR TITLE
p2p/discover: add optional fn to validate enodes

### DIFF
--- a/p2p/discover/common.go
+++ b/p2p/discover/common.go
@@ -53,6 +53,9 @@ type Config struct {
 	// V5ProtocolID configures the discv5 protocol identifier.
 	V5ProtocolID *[6]byte
 
+	// function to validate a node before it's added to routing tables
+	ValidationFn func(enode.Node) bool
+
 	ValidSchemes enr.IdentityScheme // allowed identity schemes
 	Clock        mclock.Clock
 }

--- a/p2p/discover/table_util_test.go
+++ b/p2p/discover/table_util_test.go
@@ -43,7 +43,7 @@ func init() {
 
 func newTestTable(t transport) (*Table, *enode.DB) {
 	db, _ := enode.OpenDB("")
-	tab, _ := newTable(t, db, nil, log.Root())
+	tab, _ := newTable(t, db, nil, nil, log.Root())
 	go tab.loop()
 	return tab, db
 }

--- a/p2p/discover/v4_udp.go
+++ b/p2p/discover/v4_udp.go
@@ -142,7 +142,7 @@ func ListenV4(c UDPConn, ln *enode.LocalNode, cfg Config) (*UDPv4, error) {
 		log:             cfg.Log,
 	}
 
-	tab, err := newTable(t, ln.Database(), cfg.Bootnodes, t.log)
+	tab, err := newTable(t, ln.Database(), cfg.Bootnodes, cfg.ValidationFn, t.log)
 	if err != nil {
 		return nil, err
 	}

--- a/p2p/discover/v5_udp.go
+++ b/p2p/discover/v5_udp.go
@@ -162,7 +162,7 @@ func newUDPv5(conn UDPConn, ln *enode.LocalNode, cfg Config) (*UDPv5, error) {
 		closeCtx:       closeCtx,
 		cancelCloseCtx: cancelCloseCtx,
 	}
-	tab, err := newTable(t, t.db, cfg.Bootnodes, cfg.Log)
+	tab, err := newTable(t, t.db, cfg.Bootnodes, cfg.ValidationFn, cfg.Log)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
In this PR an optional `ValidationFn` attribute is added to discv5 `Config` so a function could be set to evaluate whether a node can be added before it's added to the routing tables. This option is occasionally useful for advanced uses of the discv5 protocol.