### PR TITLE
core/vm: improve EVM reusability

### DIFF
--- a/core/vm/evm.go
+++ b/core/vm/evm.go
@@ -163,7 +163,9 @@ func (evm *EVM) Interpreter() *EVMInterpreter {
 // SetBlockContext updates the block context of the EVM.
 func (evm *EVM) SetBlockContext(blockCtx BlockContext) {
 	evm.Context = blockCtx
-	evm.chainRules = evm.chainConfig.Rules(blockCtx.BlockNumber, blockCtx.Random != nil)
+	num := blockCtx.BlockNumber
+	timestamp := blockCtx.Time
+	evm.chainRules = evm.chainConfig.Rules(num, blockCtx.Random != nil, timestamp)
 }
 
 // Call executes the contract associated with the addr with the given input as

--- a/core/vm/evm.go
+++ b/core/vm/evm.go
@@ -160,6 +160,28 @@ func (evm *EVM) Interpreter() *EVMInterpreter {
 	return evm.interpreter
 }
 
+// SetBlockContext updates the block context of the EVM.
+func (evm *EVM) SetBlockContext(blockCtx BlockContext) {
+	evm.Context = blockCtx
+	evm.chainRules = evm.chainConfig.Rules(blockCtx.BlockNumber, blockCtx.Random != nil)
+}
+
+// SetTracer updates the EVM tracer and enables debugging. If the tracer is nil
+// any set tracer is removed and debugging is disabled.
+func (evm *EVM) SetTracer(tracer EVMLogger) {
+	if tracer == nil {
+		evm.Config.Debug = false
+		evm.Config.Tracer = nil
+		evm.interpreter.cfg.Debug = false
+		evm.interpreter.cfg.Tracer = nil
+	} else {
+		evm.Config.Debug = true
+		evm.Config.Tracer = tracer
+		evm.interpreter.cfg.Debug = true
+		evm.interpreter.cfg.Tracer = tracer
+	}
+}
+
 // Call executes the contract associated with the addr with the given input as
 // parameters. It also handles any necessary value transfer required and takes
 // the necessary steps to create accounts and reverses the state in case of an

--- a/core/vm/evm.go
+++ b/core/vm/evm.go
@@ -133,7 +133,7 @@ func NewEVM(blockCtx BlockContext, txCtx TxContext, statedb StateDB, chainConfig
 		chainConfig: chainConfig,
 		chainRules:  chainConfig.Rules(blockCtx.BlockNumber, blockCtx.Random != nil, blockCtx.Time),
 	}
-	evm.interpreter = NewEVMInterpreter(evm, config)
+	evm.interpreter = NewEVMInterpreter(evm)
 	return evm
 }
 
@@ -164,22 +164,6 @@ func (evm *EVM) Interpreter() *EVMInterpreter {
 func (evm *EVM) SetBlockContext(blockCtx BlockContext) {
 	evm.Context = blockCtx
 	evm.chainRules = evm.chainConfig.Rules(blockCtx.BlockNumber, blockCtx.Random != nil)
-}
-
-// SetTracer updates the EVM tracer and enables debugging. If the tracer is nil
-// any set tracer is removed and debugging is disabled.
-func (evm *EVM) SetTracer(tracer EVMLogger) {
-	if tracer == nil {
-		evm.Config.Debug = false
-		evm.Config.Tracer = nil
-		evm.interpreter.cfg.Debug = false
-		evm.interpreter.cfg.Tracer = nil
-	} else {
-		evm.Config.Debug = true
-		evm.Config.Tracer = tracer
-		evm.interpreter.cfg.Debug = true
-		evm.interpreter.cfg.Tracer = tracer
-	}
 }
 
 // Call executes the contract associated with the addr with the given input as

--- a/core/vm/instructions.go
+++ b/core/vm/instructions.go
@@ -824,9 +824,9 @@ func opSelfdestruct(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext
 	balance := interpreter.evm.StateDB.GetBalance(scope.Contract.Address())
 	interpreter.evm.StateDB.AddBalance(beneficiary.Bytes20(), balance)
 	interpreter.evm.StateDB.Suicide(scope.Contract.Address())
-	if interpreter.cfg.Debug {
-		interpreter.cfg.Tracer.CaptureEnter(SELFDESTRUCT, scope.Contract.Address(), beneficiary.Bytes20(), []byte{}, 0, balance)
-		interpreter.cfg.Tracer.CaptureExit([]byte{}, 0, nil)
+	if interpreter.evm.Config.Debug {
+		interpreter.evm.Config.Tracer.CaptureEnter(SELFDESTRUCT, scope.Contract.Address(), beneficiary.Bytes20(), []byte{}, 0, balance)
+		interpreter.evm.Config.Tracer.CaptureExit([]byte{}, 0, nil)
 	}
 	return nil, errStopToken
 }

--- a/core/vm/instructions_test.go
+++ b/core/vm/instructions_test.go
@@ -203,7 +203,7 @@ func TestAddMod(t *testing.T) {
 	var (
 		env            = NewEVM(BlockContext{}, TxContext{}, nil, params.TestChainConfig, Config{})
 		stack          = newstack()
-		evmInterpreter = NewEVMInterpreter(env, env.Config)
+		evmInterpreter = NewEVMInterpreter(env)
 		pc             = uint64(0)
 	)
 	tests := []struct {
@@ -293,7 +293,7 @@ func opBenchmark(bench *testing.B, op executionFunc, args ...string) {
 		env            = NewEVM(BlockContext{}, TxContext{}, nil, params.TestChainConfig, Config{})
 		stack          = newstack()
 		scope          = &ScopeContext{nil, stack, nil}
-		evmInterpreter = NewEVMInterpreter(env, env.Config)
+		evmInterpreter = NewEVMInterpreter(env)
 	)
 
 	env.interpreter = evmInterpreter
@@ -534,7 +534,7 @@ func TestOpMstore(t *testing.T) {
 		env            = NewEVM(BlockContext{}, TxContext{}, nil, params.TestChainConfig, Config{})
 		stack          = newstack()
 		mem            = NewMemory()
-		evmInterpreter = NewEVMInterpreter(env, env.Config)
+		evmInterpreter = NewEVMInterpreter(env)
 	)
 
 	env.interpreter = evmInterpreter
@@ -560,7 +560,7 @@ func BenchmarkOpMstore(bench *testing.B) {
 		env            = NewEVM(BlockContext{}, TxContext{}, nil, params.TestChainConfig, Config{})
 		stack          = newstack()
 		mem            = NewMemory()
-		evmInterpreter = NewEVMInterpreter(env, env.Config)
+		evmInterpreter = NewEVMInterpreter(env)
 	)
 
 	env.interpreter = evmInterpreter
@@ -583,7 +583,7 @@ func TestOpTstore(t *testing.T) {
 		env            = NewEVM(BlockContext{}, TxContext{}, statedb, params.TestChainConfig, Config{})
 		stack          = newstack()
 		mem            = NewMemory()
-		evmInterpreter = NewEVMInterpreter(env, env.Config)
+		evmInterpreter = NewEVMInterpreter(env)
 		caller         = common.Address{}
 		to             = common.Address{1}
 		contractRef    = contractRef{caller}
@@ -625,7 +625,7 @@ func BenchmarkOpKeccak256(bench *testing.B) {
 		env            = NewEVM(BlockContext{}, TxContext{}, nil, params.TestChainConfig, Config{})
 		stack          = newstack()
 		mem            = NewMemory()
-		evmInterpreter = NewEVMInterpreter(env, env.Config)
+		evmInterpreter = NewEVMInterpreter(env)
 	)
 	env.interpreter = evmInterpreter
 	mem.Resize(32)

--- a/core/vm/interpreter.go
+++ b/core/vm/interpreter.go
@@ -29,8 +29,7 @@ type Config struct {
 	Tracer                  EVMLogger // Opcode logger
 	NoBaseFee               bool      // Forces the EIP-1559 baseFee to 0 (needed for 0 price calls)
 	EnablePreimageRecording bool      // Enables recording of SHA3/keccak preimages
-
-	ExtraEips []int // Additional EIPS that are to be enabled
+	ExtraEips               []int     // Additional EIPS that are to be enabled
 }
 
 // ScopeContext contains the things that are per-call, such as stack and memory,


### PR DESCRIPTION
This PR improves the reusability of the EVM struct. Two methods are added:

* `SetBlockContext(...)` 
* `SetTracer(...)`

Other attributes like the TransactionContext and the StateDB can already be updated. BlockContext and Tracer are partially not updateable right now. This PR fixes that and opens the potential to reuse an EVM struct in more ways.