### PR TITLE
core: fix comment about recipient for contract creation

### DIFF
--- a/core/state_transition.go
+++ b/core/state_transition.go
@@ -41,7 +41,7 @@ var emptyCodeHash = crypto.Keccak256Hash(nil)
 //
 //  1. Nonce handling
 //  2. Pre pay gas
-//  3. Create a new state object if the recipient is \0*32
+//  3. Create a new state object if the recipient is nil
 //  4. Value transfer
 //
 // == If contract creation ==


### PR DESCRIPTION
the comment suggests that contract creation happens if the recipient of a call is `0x00..00` ("zero address") but in fact the sender must be `nil`. the zero address is a regular valid address that is commonly used as a "burn" address

the comment should be updated in the event someone reads this text and gets confused