### PR TITLE
eth/tracers/native: fix possible crash in prestate tracer

### DIFF
--- a/eth/tracers/native/prestate.go
+++ b/eth/tracers/native/prestate.go
@@ -45,7 +45,7 @@ type account struct {
 }
 
 func (a *account) exists() bool {
-	return a.Balance.Sign() != 0 || a.Nonce > 0 || len(a.Code) > 0 || len(a.Storage) > 0
+	return a.Nonce > 0 || len(a.Code) > 0 || len(a.Storage) > 0 || (a.Balance != nil && a.Balance.Sign() != 0)
 }
 
 type accountMarshaling struct {


### PR DESCRIPTION
Someone reported a crash, https://github.com/ethereum/go-ethereum/issues/26347 , in prestate tracer. The prestate tracer has `account`s, and they have a (possibly nil) balance. The existing code does not properly nil-check before dereferencing it, which this PR fixes. 