### PR TITLE
Added a resource in EVM tracing page.

### DIFF
--- a/docs/_evm-tracing/index.md
+++ b/docs/_evm-tracing/index.md
@@ -19,7 +19,7 @@ transactions by re-running them locally and collecting data about precisely what
 executed by the EVM.
 
 Also see this [Devcon 2022 talk](https://www.youtube.com/watch?v=b8RdmGsilfU) on 
-tracing in Geth.
+tracing in Geth or read this [article on EVM Traces](https://docs.alchemy.com/reference/what-are-evm-traces) by Alchemy.
 
 ## State availability
 


### PR DESCRIPTION
Alchemy has a great guide on "EVM Traces" that I linked in the "Introduction to tracing" page. I think it would be great to link it here for people who want to learn more about EVM traces.