### PR TITLE
core: reset txpool on sethead

### DIFF
--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -532,8 +532,12 @@ func (bc *BlockChain) loadLastState() error {
 // was fast synced or full synced and in which state, the method will try to
 // delete minimal data from disk whilst retaining chain consistency.
 func (bc *BlockChain) SetHead(head uint64) error {
-	_, err := bc.setHeadBeyondRoot(head, common.Hash{}, false)
-	return err
+	if _, err := bc.setHeadBeyondRoot(head, common.Hash{}, false); err != nil {
+		return err
+	}
+	// Send chain head event to update the transaction pool
+	bc.chainHeadFeed.Send(ChainHeadEvent{Block: bc.CurrentBlock()})
+	return nil
 }
 
 // SetFinalized sets the finalized block.

--- a/ethclient/gethclient/gethclient_test.go
+++ b/ethclient/gethclient/gethclient_test.go
@@ -119,9 +119,6 @@ func TestGethClient(t *testing.T) {
 			"TestGetNodeInfo",
 			func(t *testing.T) { testGetNodeInfo(t, client) },
 		}, {
-			"TestSetHead",
-			func(t *testing.T) { testSetHead(t, client) },
-		}, {
 			"TestSubscribePendingTxHashes",
 			func(t *testing.T) { testSubscribePendingTransactions(t, client) },
 		}, {
@@ -138,6 +135,9 @@ func TestGethClient(t *testing.T) {
 		{
 			"TestAccessList",
 			func(t *testing.T) { testAccessList(t, client) },
+		}, {
+			"TestSetHead",
+			func(t *testing.T) { testSetHead(t, client) },
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
This PR sends a HeadChainEvent on SetHead. The txpool will reset the txnoncer on receiving this head chain event.

probably closes https://github.com/ethereum/go-ethereum/issues/26154 & https://github.com/ethereum/go-ethereum/issues/20078

(The change to the test is because the setHeadTest now modifies the txpool, so the gas cost for creating the accesslist is too low)