### PR TITLE
rpc-client: Enable passing single argument to `Call` & improve `Subscribe`

### DIFF
--- a/rpc/client_test.go
+++ b/rpc/client_test.go
@@ -52,6 +52,21 @@ func TestClientRequest(t *testing.T) {
 	}
 }
 
+func TestClientRequestSingle(t *testing.T) {
+	server := newTestServer()
+	defer server.Stop()
+	client := DialInProc(server)
+	defer client.Close()
+
+	var resp echoResult
+	if err := client.CallContextSingle(context.Background(), &resp, "test_echo", []interface{}{"hello", 10, &echoArgs{"world"}}); err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(resp, echoResult{"hello", 10, &echoArgs{"world"}}) {
+		t.Errorf("incorrect result %#v", resp)
+	}
+}
+
 func TestClientResponseType(t *testing.T) {
 	server := newTestServer()
 	defer server.Stop()


### PR DESCRIPTION
This PR does 2 things (which could be separated in 2 PRs if needed, currently in 2 commits):
1. Add a `CallContractSingle` method to the `rpc.Client`, which enables calling an RPC server with a single argument instead of an array
2. Add `SubscribeWith` method to the `rpc.Client`, in order to be able to create subscription without the `_subscribe` suffix

For (1), this is useful because [according to specs](https://www.jsonrpc.org/specification) a method on a JSON-RPC server can be called with `params` being an `array` or an `object`. I didn't add this feature to the server part of the library, since it might be a breaking change.

For (2), this is useful for servers not respecting the `_subscribe` suffix for subscriptions.