### PR TITLE
[website] geth-website migration

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -6,3 +6,7 @@ NEXT_PUBLIC_ALGOLIA_BASE_SEARCH_INDEX_NAME=
 # GitHub API
 # check fine-grained tokens https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token#about-personal-access-tokens
 GITHUB_TOKEN_READ_ONLY=
+
+# Matomo
+NEXT_PUBLIC_MATOMO_URL=
+NEXT_PUBLIC_MATOMO_SITE_ID=

--- a/docs/getting-started/consensus-clients.md
+++ b/docs/getting-started/consensus-clients.md
@@ -55,7 +55,7 @@ Please see the pages on [syncing](/docs/fundamentals/sync-modes) for more detail
 
 ## Using Geth {#using-geth}
 
-Geth is the portal for users to send transactions to Ethereum. The Geth Javascript console is available for this purpose, and the majority of the [JSON-RPC API](/docs/rpc) will remain available via web3js or HTTP requests with commands as json payloads. These options are explained in more detail on the [Javascript Console page](/docs/interacting-with-geth/javascript-console). The Javascript console can be started
+Geth is the portal for users to send transactions to Ethereum. The Geth Javascript console is available for this purpose, and the majority of the [JSON-RPC API](/docs/interacting-with-geth/rpc) will remain available via web3js or HTTP requests with commands as json payloads. These options are explained in more detail on the [Javascript Console page](/docs/interacting-with-geth/javascript-console). The Javascript console can be started
 using the following command in a separate terminal (assuming Geth's IPC file is saved in `datadir`):
 
 ```sh

--- a/netlify.toml
+++ b/netlify.toml
@@ -2,3 +2,8 @@
 
 [functions]
   included_files = ["src/**"]
+
+[[headers]]
+  for = "/*"
+  [headers.values]
+    Access-Control-Allow-Origin = "https://matomo.ethereum.org"

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "@docsearch/react": "3",
     "@emotion/react": "^11.10.4",
     "@emotion/styled": "^11.10.4",
+    "@socialgouv/matomo-next": "^1.4.0",
     "algoliasearch": "^4.14.2",
     "chakra-ui-markdown-renderer": "^4.1.0",
     "fast-xml-parser": "^4.0.12",

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -19,6 +19,10 @@ export const GETH_TWITTER_URL = 'https://twitter.com/go_ethereum';
 export const GETH_DISCORD_URL = 'https://discord.com/invite/nthXNEv';
 export const GO_URL = 'https://go.dev/';
 
+// analytics
+export const DO_NOT_TRACK_URL =
+  'http://matomo.ethereum.org/piwik/index.php?module=CoreAdminHome&action=optOut';
+
 // Downloads
 export const DEFAULT_BUILD_AMOUNT_TO_SHOW = 12;
 export const DOWNLOAD_HEADER_BUTTONS: {

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -1,5 +1,7 @@
 import { ChakraProvider } from '@chakra-ui/react';
 import { AppProps } from 'next/app';
+import { useEffect } from 'react';
+import { init } from '@socialgouv/matomo-next';
 
 import { Layout } from '../components/layouts';
 
@@ -10,6 +12,13 @@ import theme from '../theme';
 import '../theme/search.css';
 
 export default function App({ Component, pageProps }: AppProps) {
+  useEffect(() => {
+    init({
+      url: process.env.NEXT_PUBLIC_MATOMO_URL!,
+      siteId: process.env.NEXT_PUBLIC_MATOMO_SITE_ID!
+    });
+  }, []);
+
   return (
     <ChakraProvider theme={theme}>
       <Layout>

--- a/yarn.lock
+++ b/yarn.lock
@@ -1274,6 +1274,11 @@
   resolved "https://registry.npmjs.org/@rushstack/eslint-patch/-/eslint-patch-1.1.4.tgz"
   integrity sha512-LwzQKA4vzIct1zNZzBmRKI9QuNpLgTQMEjsQLf3BXuGYb3QPTP4Yjf6mkdX+X1mYttZ808QpOwAzZjv28kq7DA==
 
+"@socialgouv/matomo-next@^1.4.0":
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/@socialgouv/matomo-next/-/matomo-next-1.4.0.tgz#9c428b542671542686b56f4ebdca1aa0896af628"
+  integrity sha512-S+kNX7dwo/cL0VE7GWY8Gnf3t7aeXD4CzallRz9IEttjHJDJI2S8xOrcyaGimYpInr3nDNo+WqeYrafKUdsn1g==
+
 "@swc/helpers@0.4.11":
   version "0.4.11"
   resolved "https://registry.npmjs.org/@swc/helpers/-/helpers-0.4.11.tgz"


### PR DESCRIPTION
## Description
A follow-up migration PR from the existing `ethereum/geth-website` repo. Includes a few changes that were added after the initial code freeze and site migration to the `ethereum/go-ethereum:website` branch. 

- [feat: Add Matomo analytics geth-website#199](https://github.com/ethereum/geth-website/pull/199)
- [Fix broken rpc link geth-website#203](https://github.com/ethereum/geth-website/pull/203)
