### PR TITLE
eth/downloader: fix cornercase when clean stale beacon headers

### DIFF
--- a/eth/downloader/skeleton.go
+++ b/eth/downloader/skeleton.go
@@ -1096,6 +1096,7 @@ func (s *skeleton) cleanStales(filled *types.Header) error {
 	var (
 		start = s.progress.Subchains[0].Tail // start deleting from the first known header
 		end   = number                       // delete until the requested threshold
+		batch = s.db.NewBatch()
 	)
 	s.progress.Subchains[0].Tail = number
 	s.progress.Subchains[0].Next = filled.ParentHash
@@ -1105,16 +1106,13 @@ func (s *skeleton) cleanStales(filled *types.Header) error {
 		// subchain forward to keep tracking the node's block imports
 		end = s.progress.Subchains[0].Head + 1 // delete the entire original range, including the head
 		s.progress.Subchains[0].Head = number  // assign a new head (tail is already assigned to this)
-	}
-	// Execute the trimming and the potential rewiring of the progress
-	batch := s.db.NewBatch()
 
-	if end != number {
 		// The entire original skeleton chain was deleted and a new one
 		// defined. Make sure the new single-header chain gets pushed to
 		// disk to keep internal state consistent.
 		rawdb.WriteSkeletonHeader(batch, filled)
 	}
+	// Execute the trimming and the potential rewiring of the progress
 	s.saveSyncStatus(batch)
 	for n := start; n < end; n++ {
 		// If the batch grew too big, flush it and continue with a new batch.
@@ -1170,8 +1168,13 @@ func (s *skeleton) Bounds() (head *types.Header, tail *types.Header, err error) 
 		return nil, nil, err
 	}
 	head = rawdb.ReadSkeletonHeader(s.db, progress.Subchains[0].Head)
+	if head == nil {
+		return nil, nil, fmt.Errorf("head skeleton header %d is missing", progress.Subchains[0].Head)
+	}
 	tail = rawdb.ReadSkeletonHeader(s.db, progress.Subchains[0].Tail)
-
+	if tail == nil {
+		return nil, nil, fmt.Errorf("tail skeleton header %d is missing", progress.Subchains[0].Tail)
+	}
 	return head, tail, nil
 }
 


### PR DESCRIPTION
This PR fixes a special corner case in stale beacon header clean. Though I think it's really hard to happen.

For example, the scenario is:

- The last filled header is 6
- The beacon skeleton head is 5

In this case, a new skeleton subchain will be created {tail=6, head=6} and all other
subchains will be dropped. The beacon header 6 is expected to be persisted.

But originally, in this case, beacon header 6 is not persisted for some reasons. This
PR fixes this issue.