### PR TITLE
crypto/bls12381: use worst case scalar for input to G1/G2 mul benchmarks

### DIFF
--- a/crypto/bls12381/g1_test.go
+++ b/crypto/bls12381/g1_test.go
@@ -262,8 +262,9 @@ func BenchmarkG1Add(t *testing.B) {
 }
 
 func BenchmarkG1Mul(t *testing.B) {
+    worstCaseScalar, _ := new(big.Int).SetString("57896044618658097711785492504343953926634992332820282019728792003956564819967", 10)
 	g1 := NewG1()
-	a, e, c := g1.rand(), q, PointG1{}
+	a, e, c := g1.rand(), worstCaseScalar, PointG1{}
 	t.ResetTimer()
 	for i := 0; i < t.N; i++ {
 		g1.MulScalar(&c, a, e)

--- a/crypto/bls12381/g1_test.go
+++ b/crypto/bls12381/g1_test.go
@@ -262,7 +262,7 @@ func BenchmarkG1Add(t *testing.B) {
 }
 
 func BenchmarkG1Mul(t *testing.B) {
-    worstCaseScalar, _ := new(big.Int).SetString("57896044618658097711785492504343953926634992332820282019728792003956564819967", 10)
+	worstCaseScalar, _ := new(big.Int).SetString("ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff", 16)
 	g1 := NewG1()
 	a, e, c := g1.rand(), worstCaseScalar, PointG1{}
 	t.ResetTimer()

--- a/crypto/bls12381/g2_test.go
+++ b/crypto/bls12381/g2_test.go
@@ -265,8 +265,9 @@ func BenchmarkG2Add(t *testing.B) {
 }
 
 func BenchmarkG2Mul(t *testing.B) {
+	worstCaseScalar, _ := new(big.Int).SetString("ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff", 16)
 	g2 := NewG2()
-	a, e, c := g2.rand(), q, PointG2{}
+	a, e, c := g2.rand(), worstCaseScalar, PointG2{}
 	t.ResetTimer()
 	for i := 0; i < t.N; i++ {
 		g2.MulScalar(&c, a, e)


### PR DESCRIPTION
Afaict, the only potential use-case for this code is to serve as a reference implementation for EIP-2537 `G1Mul` and `G2Mul` precompiles.  It makes sense to keep consistency with the  benchmarks in `core/vm/contracts_test.go` which benchmark worst-case inputs.