### PR TITLE
eth/downloader: fix unexpected skeleton header deletion

### DIFF
--- a/eth/downloader/skeleton.go
+++ b/eth/downloader/skeleton.go
@@ -977,8 +977,14 @@ func (s *skeleton) processResponse(res *headerResponse) (linked bool, merged boo
 				// the expected new sync cycle after some propagated blocks. Log
 				// it for debugging purposes, explicitly clean and don't escalate.
 				case subchains == 2 && s.progress.Subchains[1].Head == s.progress.Subchains[1].Tail:
-					log.Debug("Cleaning previous beacon sync state", "head", s.progress.Subchains[1].Head)
-					rawdb.DeleteSkeletonHeader(batch, s.progress.Subchains[1].Head)
+					// Remove the leftover skeleton header associated with old
+					// skeleton chain only if it's not covered by the current
+					// skeleton range.
+					if s.progress.Subchains[1].Head < s.progress.Subchains[0].Tail {
+						log.Debug("Cleaning previous beacon sync state", "head", s.progress.Subchains[1].Head)
+						rawdb.DeleteSkeletonHeader(batch, s.progress.Subchains[1].Head)
+					}
+					// Drop the leftover skeleton chain since it's stale.
 					s.progress.Subchains = s.progress.Subchains[:1]
 
 				// If we have more than one header or more than one leftover chain,

--- a/eth/downloader/skeleton.go
+++ b/eth/downloader/skeleton.go
@@ -520,7 +520,7 @@ func (s *skeleton) initSync(head *types.Header) {
 				}
 				break
 			}
-			// If the last subchain can be extended, we're lucky. Otherwise create
+			// If the last subchain can be extended, we're lucky. Otherwise, create
 			// a new subchain sync task.
 			var extended bool
 			if n := len(s.progress.Subchains); n > 0 {


### PR DESCRIPTION
Fixes #26300

This PR fixes a scenario in which Geth will delete referenced skeleton header by mistake.

In the example listed in #26300 

- Local skeleton header `325@0946fa`
- New beacon header `327@e97873 `

These two headers are in different chain, reorg happens. Geth syncs up the missing skeleton
headers which links up with local chain. The link point is lower than `325`.

Then there is a special logic in beacon sync that 

```
// If there are only 2 subchains - the current one and an older
// one - and the old one consists of a single block, then it's
// the expected new sync cycle after some propagated blocks.
```

And if the associated header of leftover subchain is in range of 
new subchain(just like the example), we delete the skeleton header
referenced by new subchain by mistake because we don't check
the hash at all. 

Please check https://github.com/ethereum/go-ethereum/issues/26300 for more information.
Thanks @holiman for detailed analysis!