### PR TITLE
eth/downloader: move the pivot in beacon sync mode too

### DIFF
--- a/eth/downloader/beaconsync.go
+++ b/eth/downloader/beaconsync.go
@@ -308,10 +308,9 @@ func (d *Downloader) fetchBeaconHeaders(from uint64) error {
 				log.Warn("Pivot seemingly stale, moving", "old", d.pivotHeader.Number, "new", number)
 				if d.pivotHeader = d.skeleton.Header(number); d.pivotHeader == nil {
 					if number < tail.Number.Uint64() {
-						count := int(tail.Number.Uint64() - number) // it's capped by fsMinFullBlocks
-						headers := d.readHeaderRange(tail, count)
-						if len(headers) == count {
-							d.pivotHeader = headers[len(headers)-1]
+						dist := tail.Number.Uint64() - number
+						if len(localHeaders) >= int(dist) {
+							d.pivotHeader = localHeaders[dist-1]
 							log.Warn("Retrieved pivot header from local", "number", d.pivotHeader.Number, "hash", d.pivotHeader.Hash(), "latest", head.Number, "oldest", tail.Number)
 						}
 					}

--- a/eth/downloader/beaconsync.go
+++ b/eth/downloader/beaconsync.go
@@ -271,7 +271,8 @@ func (d *Downloader) findBeaconAncestor() (uint64, error) {
 // fetchBeaconHeaders feeds skeleton headers to the downloader queue for scheduling
 // until sync errors or is finished.
 func (d *Downloader) fetchBeaconHeaders(from uint64) error {
-	head, tail, err := d.skeleton.Bounds()
+	var head *types.Header
+	_, tail, err := d.skeleton.Bounds()
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Fixes https://github.com/ethereum/go-ethereum/issues/26429.

In legacy (pre-merge) sync mode, headers were contiguously downloaded from the network and when no more headers were available, we checked every few seconds whether there are 64 new blocks to move the pivot.

In beacon (post-merge) sync mode, we don't need to check for new skeleton headers non stop, since those re delivered one by one by the engine API. The missing code snippet from the header fetcher was to actually look at the latest head and move the pivot if it was more than 2*64-8 away. This PR adds the missing movement logic.

The convoluted logic of pulling headers from disk if they don't exist in the skeleton chain shouldn't really be needed, but I've added it as a sanity check in case I'm missing some reasoning now. It should result in a warning anyway so we can investigate if that clause is actually triggered.