### PR TITLE
[website] Highlight active docs section

### DIFF
--- a/src/components/UI/docs/DocsLinks.tsx
+++ b/src/components/UI/docs/DocsLinks.tsx
@@ -52,7 +52,7 @@ export const DocsLinks: FC<Props> = ({ navLinks, toggleMobileAccordion }) => {
         const split = to?.split('/');
         const isActive = slug && split && split[split.length - 1] === slug[slug.length - 1];
         const index = openSections[id] ? 0 : -1;
-
+        const isSectionActive = !!openSections[id];
         return (
           <Accordion key={id} index={index} allowToggle mt='0 !important'>
             <AccordionItem border='none'>
@@ -73,7 +73,8 @@ export const DocsLinks: FC<Props> = ({ navLinks, toggleMobileAccordion }) => {
                       borderRight={items ? '2px' : 'none'}
                       borderColor='primary'
                       w='100%'
-                      bg='bg'
+                      bg={isSectionActive ? 'secondary' : 'bg'}
+                      color={isSectionActive ? 'body' : 'primary'}
                       _groupHover={{ background: 'primary', color: 'bg', textDecoration: 'none' }}
                     >
                       {to ? (


### PR DESCRIPTION
[PR migrated from now deprecated `geth-website` repo](https://github.com/ethereum/geth-website/pull/192)

Add highlighting to active doc section
![Screen Shot 2022-12-19 at 11 26 53 AM](https://user-images.githubusercontent.com/15589226/208494531-a7620248-48db-4ed8-b9a7-8d14955a4e10.png)
![Screen Shot 2022-12-19 at 11 26 58 AM](https://user-images.githubusercontent.com/15589226/208494535-12d7c0df-1fb3-4ced-aeda-420f7b480735.png)
![Screen Shot 2022-12-19 at 11 27 01 AM](https://user-images.githubusercontent.com/15589226/208494537-09917a30-60d5-48ac-8c64-19c363e04b1f.png)

