### PR TITLE
rpc: fix setting client in DialHTTPWithClient

### DIFF
--- a/rpc/http.go
+++ b/rpc/http.go
@@ -137,6 +137,7 @@ func DialHTTPWithClient(endpoint string, client *http.Client) (*Client, error) {
 	}
 
 	var cfg clientConfig
+	cfg.httpClient = client
 	fn := newClientTransportHTTP(endpoint, &cfg)
 	return newClient(context.Background(), fn)
 }


### PR DESCRIPTION
It looks like in #24911 the `httpClient` value in the config should have been set to the provided client, but it was accidentally omitted.