### PR TITLE
core/vm: enable EIP-3855 (PUSH0) in Shanghai

### DIFF
--- a/core/vm/jump_table.go
+++ b/core/vm/jump_table.go
@@ -81,7 +81,8 @@ func validate(jt JumpTable) JumpTable {
 
 func newShanghaiInstructionSet() JumpTable {
 	instructionSet := newMergeInstructionSet()
-	enable3860(&instructionSet)
+	enable3855(&instructionSet) // PUSH0 instruction
+	enable3860(&instructionSet) // Limit and meter initcode
 	return validate(instructionSet)
 }
 


### PR DESCRIPTION
[EIP-3855](https://eips.ethereum.org/EIPS/eip-3855): PUSH0 instruction is part of [Shanghai](https://github.com/ethereum/execution-specs/blob/master/network-upgrades/mainnet-upgrades/shanghai.md).