### PR TITLE
trie: reduce fullNode to valueNode with only index[16] after delete

### DIFF
--- a/trie/trie.go
+++ b/trie/trie.go
@@ -472,7 +472,9 @@ func (t *Trie) delete(n node, prefix, key []byte) (bool, node, error) {
 			}
 		}
 		if pos >= 0 {
-			if pos != 16 {
+			if pos == 16 {
+				return true, n.Children[16].(valueNode), nil
+			} else {
 				// If the remaining entry is a short node, it replaces
 				// n and its key gets the missing nibble tacked to the
 				// front. This avoids creating an invalid


### PR DESCRIPTION
currently:

- key: `abc[16]` would search out the same result with `abc` as value responding to key `abc` when exists
- in `delete` when a fullNode which has `[16]valueNode` has only `[16]valueNode` left after deleted, it would be reduced to a `shortNode` with key `[16]`. However it should be reduced to a `valueNode`.
- `shortNode{[16]:val}` is equal to `valueNode{val}`
  - Could work properly(since when  `tryGet` a key(leaf node), a terminator `[16]` would be added to the end(which should just meant to serve the `fullNode`),and the `tryget` would just return when it reached the leaf node without checking whether the `query key` had anything left. But not necessary.
- And in current `geth` this also not a problem, since the `key` had been set to a `hash` result, which means `fullNode` would never have `[16]fullNode`, otherwise `len(key)` would not be the same(as 32byte hash->Hex)