### PR TITLE
eth/catalyst: check for error when sending NewPayloadV1 in tester

### DIFF
--- a/eth/catalyst/tester.go
+++ b/eth/catalyst/tester.go
@@ -77,7 +77,9 @@ func (tester *FullSyncTester) Start() error {
 				}
 				// Shoot out consensus events in order to trigger syncing.
 				data := beacon.BlockToExecutableData(tester.block)
-				tester.api.NewPayloadV1(*data)
+				if _, err := tester.api.NewPayloadV1(*data); err != nil {
+					log.Error("Error sending engine_newPayloadV1", "err", err)
+				}
 				tester.api.ForkchoiceUpdatedV1(beacon.ForkchoiceStateV1{
 					HeadBlockHash:      tester.block.Hash(),
 					SafeBlockHash:      tester.block.Hash(),

--- a/eth/catalyst/tester.go
+++ b/eth/catalyst/tester.go
@@ -77,8 +77,9 @@ func (tester *FullSyncTester) Start() error {
 				}
 				// Shoot out consensus events in order to trigger syncing.
 				data := beacon.BlockToExecutableData(tester.block)
-				if _, err := tester.api.NewPayloadV1(*data); err != nil {
-					log.Error("Error sending engine_newPayloadV1", "err", err)
+				if status, err := tester.api.NewPayloadV1(*data); err != nil || status.Status != beacon.VALID {
+					log.Error("Error sending engine_newPayloadV1", "err", err, "status", status.Status)
+					return
 				}
 				tester.api.ForkchoiceUpdatedV1(beacon.ForkchoiceStateV1{
 					HeadBlockHash:      tester.block.Hash(),


### PR DESCRIPTION
The `--synctarget` switch can only work with a post-merge block. This is because the difficulty is set to 0 in `ExecutableDataToBlock`, resulting in an invalid hash.

It might not be worth going through the hoops of making that possible, since this is a corner case that is probably limited to myself. Still, the returned error should be caught and displayed, so that whoever runs into the same sort of problems is at least aware that block sync will not start.