### PR TITLE
core/txpool: check if initcode size is exceeded

### DIFF
--- a/core/txpool/txpool.go
+++ b/core/txpool/txpool.go
@@ -18,6 +18,7 @@ package txpool
 
 import (
 	"errors"
+	"fmt"
 	"math"
 	"math/big"
 	"sort"
@@ -636,6 +637,10 @@ func (pool *TxPool) validateTx(tx *types.Transaction, local bool) error {
 	// cost == V + GP * GL
 	if pool.currentState.GetBalance(from).Cmp(tx.Cost()) < 0 {
 		return core.ErrInsufficientFunds
+	}
+	// Check whether the init code size has been exceeded.
+	if pool.shanghai && tx.To() == nil && len(tx.Data()) > params.MaxInitCodeSize {
+		return fmt.Errorf("%w: code size %v limit %v", core.ErrMaxInitCodeSizeExceeded, len(tx.Data()), params.MaxInitCodeSize)
 	}
 	// Ensure the transaction has more gas than the basic tx fee.
 	intrGas, err := core.IntrinsicGas(tx.Data(), tx.AccessList(), tx.To() == nil, true, pool.istanbul, pool.shanghai)


### PR DESCRIPTION
This PR makes sure that only transactions that do not exceed the initcode size make it into the txpool 

## Background

> I just found a pretty nasty edge case wrt. 3860 (Max init code size).
I send a bunch of handcrafted interesting transactions to my node, and the 
transactions got stuck all the time. After the 20th time (I know) I decided to investigate.
The issue was that transactions with initdata > MaxInitCodeSize were not rejected by 
the transaction pool. They would be rejected by nodes executing them, but not by the txpool.
This could've been used to flood a txpool with unexecutable transactions.
Since they are valid looking, they would be propagated to peers and stay in the mempool.
So it would be great if all EL teams could check that their txpool rejects transactions
where the transaction is a contract creation and the tx.data exceeds maxInitCodeSize.
I've pushed my fuzzer here: https://github.com/MariusVanDerWijden/tx-fuzz/tree/mutator,
cmd/shanghai/shanghai can be used to send a bunch of transactions. Just make sure that 
the cycle runs a few times and no transactions are stuck.

