### PR TITLE
console, internal/jsre: fix autocomplete issues

### DIFF
--- a/console/console.go
+++ b/console/console.go
@@ -338,8 +338,9 @@ func (c *Console) AutoCompleteInput(line string, pos int) (string, []string, str
 			continue
 		}
 		// Handle web3 in a special way (i.e. other numbers aren't auto completed)
-		if start >= 3 && line[start-3:start] == "web3" {
-			start -= 3
+		if start >= 3 && line[start-3:start+1] == "web3" {
+			// Start will be decremented one more by loop
+			start -= 2
 			continue
 		}
 		// We've hit an unexpected character, autocomplete form here

--- a/internal/jsre/completion.go
+++ b/internal/jsre/completion.go
@@ -17,11 +17,15 @@
 package jsre
 
 import (
+	"regexp"
 	"sort"
 	"strings"
 
 	"github.com/dop251/goja"
 )
+
+// JS numerical token
+var numerical = regexp.MustCompile(`^(NaN|-?((\d*\.\d+|\d+)([Ee][+-]?\d+)?|Infinity))$`)
 
 // CompleteKeywords returns potential continuations for the given line. Since line is
 // evaluated, callers need to make sure that evaluating line does not have side effects.
@@ -43,6 +47,9 @@ func getCompletions(vm *goja.Runtime, line string) (results []string) {
 	// and "x.y" is an object, obj will reference "x.y".
 	obj := vm.GlobalObject()
 	for i := 0; i < len(parts)-1; i++ {
+		if numerical.MatchString(parts[i]) {
+			return nil
+		}
 		v := obj.Get(parts[i])
 		if v == nil || goja.IsNull(v) || goja.IsUndefined(v) {
 			return nil // No object was found
@@ -67,7 +74,7 @@ func getCompletions(vm *goja.Runtime, line string) (results []string) {
 	// Append opening parenthesis (for functions) or dot (for objects)
 	// if the line itself is the only completion.
 	if len(results) == 1 && results[0] == line {
-		obj := obj.Get(parts[len(parts)-1])
+		obj := SafeGet(obj, parts[len(parts)-1])
 		if obj != nil {
 			if _, isfunc := goja.AssertFunction(obj); isfunc {
 				results[0] += "("

--- a/internal/jsre/completion.go
+++ b/internal/jsre/completion.go
@@ -74,6 +74,10 @@ func getCompletions(vm *goja.Runtime, line string) (results []string) {
 	// Append opening parenthesis (for functions) or dot (for objects)
 	// if the line itself is the only completion.
 	if len(results) == 1 && results[0] == line {
+		// Accessing the property will cause it to be evaluated.
+		// This can cause an error, e.g. in case of web3.eth.protocolVersion
+		// which has been dropped from geth. Ignore the error for autocompletion
+		// purposes.
 		obj := SafeGet(obj, parts[len(parts)-1])
 		if obj != nil {
 			if _, isfunc := goja.AssertFunction(obj); isfunc {


### PR DESCRIPTION
Fixes #26505. I also noticed while fixing this issue that autocomplete wasn't working for objects/fields with numbers in them (most importantly `web3.<tab><tab>`) which is also now fixed.

The issue is we dropped support for `protocolVersion` but the method still exists in the web3.js library. So console assumes it exists and crashes on the error it gets from server. For the fix we recover and ignore the error.

