### PR TITLE
cmd/evm: add blocktest subcommand to evm

### DIFF
--- a/cmd/evm/blockrunner.go
+++ b/cmd/evm/blockrunner.go
@@ -1,0 +1,73 @@
+// Copyright 2023 The go-ethereum Authors
+// This file is part of go-ethereum.
+//
+// go-ethereum is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// go-ethereum is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with go-ethereum. If not, see <http://www.gnu.org/licenses/>.
+
+package main
+
+import (
+	"encoding/json"
+	"errors"
+	"os"
+
+	"github.com/ethereum/go-ethereum/core/state"
+	"github.com/ethereum/go-ethereum/log"
+	"github.com/ethereum/go-ethereum/tests"
+
+	"github.com/urfave/cli/v2"
+)
+
+var blockTestCommand = &cli.Command{
+	Action:    blockTestCmd,
+	Name:      "blocktest",
+	Usage:     "executes the given blockchain tests",
+	ArgsUsage: "<file>",
+}
+
+// BlocktestResult contains the execution status after running a blockchain test, any
+// error that might have occurred and a dump of the final blockchain if requested.
+type BlocktestResult struct {
+	Name  string      `json:"name"`
+	Pass  bool        `json:"pass"`
+	Fork  string      `json:"fork"`
+	Error string      `json:"error,omitempty"`
+	State *state.Dump `json:"state,omitempty"`
+}
+
+func blockTestCmd(ctx *cli.Context) error {
+	if len(ctx.Args().First()) == 0 {
+		return errors.New("path-to-test argument required")
+	}
+	// Configure the go-ethereum logger
+	glogger := log.NewGlogHandler(log.StreamHandler(os.Stderr, log.TerminalFormat(false)))
+	glogger.Verbosity(log.Lvl(ctx.Int(VerbosityFlag.Name)))
+	log.Root().SetHandler(glogger)
+
+	// Load the test content from the input file
+	src, err := os.ReadFile(ctx.Args().First())
+	if err != nil {
+		return err
+	}
+	var tests map[string]tests.BlockTest
+	if err = json.Unmarshal(src, &tests); err != nil {
+		return err
+	}
+	for _, test := range tests {
+		if err := test.Run(false); err != nil {
+			return err
+		}
+
+	}
+	return nil
+}

--- a/cmd/evm/blockrunner.go
+++ b/cmd/evm/blockrunner.go
@@ -67,7 +67,6 @@ func blockTestCmd(ctx *cli.Context) error {
 		if err := test.Run(false); err != nil {
 			return err
 		}
-
 	}
 	return nil
 }

--- a/cmd/evm/blockrunner.go
+++ b/cmd/evm/blockrunner.go
@@ -19,12 +19,11 @@ package main
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
 	"os"
 
-	"github.com/ethereum/go-ethereum/core/state"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/tests"
-
 	"github.com/urfave/cli/v2"
 )
 
@@ -33,16 +32,6 @@ var blockTestCommand = &cli.Command{
 	Name:      "blocktest",
 	Usage:     "executes the given blockchain tests",
 	ArgsUsage: "<file>",
-}
-
-// BlocktestResult contains the execution status after running a blockchain test, any
-// error that might have occurred and a dump of the final blockchain if requested.
-type BlocktestResult struct {
-	Name  string      `json:"name"`
-	Pass  bool        `json:"pass"`
-	Fork  string      `json:"fork"`
-	Error string      `json:"error,omitempty"`
-	State *state.Dump `json:"state,omitempty"`
 }
 
 func blockTestCmd(ctx *cli.Context) error {
@@ -63,9 +52,9 @@ func blockTestCmd(ctx *cli.Context) error {
 	if err = json.Unmarshal(src, &tests); err != nil {
 		return err
 	}
-	for _, test := range tests {
+	for i, test := range tests {
 		if err := test.Run(false); err != nil {
-			return err
+			return fmt.Errorf("test %v: %w", i, err)
 		}
 	}
 	return nil

--- a/cmd/evm/main.go
+++ b/cmd/evm/main.go
@@ -217,6 +217,7 @@ func init() {
 		compileCommand,
 		disasmCommand,
 		runCommand,
+		blockTestCommand,
 		stateTestCommand,
 		stateTransitionCommand,
 		transactionCommand,


### PR DESCRIPTION
Adds `blocktest` subcommand to the `evm` command, which is very similar to `statetest`, but instead of loading a StateTest static test it loads a BlockchainTest from a json file and runs it.

I use this a lot to double check tests are filled correctly on https://github.com/ethereum/execution-spec-tests/, and normally when testing a change I cherry-pick this commit on top of whatever I'm testing, but it might be useful to have it in master.