### PR TITLE
crypto: Adding method for manipulating the Signature Recovery ID

### DIFF
--- a/crypto/signature_cgo.go
+++ b/crypto/signature_cgo.go
@@ -45,10 +45,19 @@ func AlterRecoveryOffsetID(sig []byte, v int) (altered []byte, err error) {
 	}
 	altered = make([]byte, SignatureLength)
 	copy(altered, sig)
+	var delta byte
 	if v > 0 {
-		altered[RecoveryIDOffset] += byte(v)
+		delta = byte(v)
+		if v+int(sig[RecoveryIDOffset]) > 255 {
+			return nil, fmt.Errorf("invalid sum, byte overflow. %d + %d is > 255", delta, sig[RecoveryIDOffset])
+		}
+		altered[RecoveryIDOffset] += delta
 	} else {
-		altered[RecoveryIDOffset] -= byte(v * -1)
+		delta = byte(v * -1)
+		if delta > sig[RecoveryIDOffset] {
+			return nil, fmt.Errorf("invalid sum, byte underflow. change %d > current id %d", delta, sig[RecoveryIDOffset])
+		}
+		altered[RecoveryIDOffset] -= delta
 	}
 	return altered, nil
 }

--- a/crypto/signature_cgo.go
+++ b/crypto/signature_cgo.go
@@ -25,7 +25,7 @@ import (
 	"fmt"
 
 	"github.com/ethereum/go-ethereum/common/math"
-  "github.com/ethereum/go-ethereum/crypto/secp256k1"
+	"github.com/ethereum/go-ethereum/crypto/secp256k1"
 )
 
 // Ecrecover returns the uncompressed public key that created the given signature.
@@ -33,24 +33,24 @@ func Ecrecover(hash, sig []byte) ([]byte, error) {
 	return secp256k1.RecoverPubkey(hash, sig)
 }
 
-// AlterRecoveryOffset adds a value v to the signature's recovery offset then 
+// AlterRecoveryOffset adds a value v to the signature's recovery offset then
 // returns the signature or error on invalid signature length.
 // For example: Ethereum's signature format uses 27/28 instead of 0/1
 func AlterRecoveryOffsetID(sig []byte, v int) (altered []byte, err error) {
-  if v > 255 || v < -255 {
-    return nil, fmt.Errorf("invalid offset ID value, byte overflow, max value is 255 min value is -255")
-  }
-  if len(sig) != SignatureLength {
-    return nil, fmt.Errorf("invalid signature length, signature is of length: %d when it should be %d", len(sig), SignatureLength)
-  }
-  altered = make([]byte, SignatureLength)
-  copy(altered, sig)
-  if v > 0 {
-   altered[RecoveryIDOffset] += byte(v) 
-  } else {
-    altered[RecoveryIDOffset] -= byte(v * -1) 
-  }
-  return altered, nil
+	if v > 255 || v < -255 {
+		return nil, fmt.Errorf("invalid offset ID value, byte overflow, max value is 255 min value is -255")
+	}
+	if len(sig) != SignatureLength {
+		return nil, fmt.Errorf("invalid signature length, signature is of length: %d when it should be %d", len(sig), SignatureLength)
+	}
+	altered = make([]byte, SignatureLength)
+	copy(altered, sig)
+	if v > 0 {
+		altered[RecoveryIDOffset] += byte(v)
+	} else {
+		altered[RecoveryIDOffset] -= byte(v * -1)
+	}
+	return altered, nil
 }
 
 // SigToPub returns the public key that created the given signature.

--- a/crypto/signature_cgo.go
+++ b/crypto/signature_cgo.go
@@ -37,9 +37,6 @@ func Ecrecover(hash, sig []byte) ([]byte, error) {
 // returns the signature or error on invalid signature length.
 // For example: Ethereum's signature format uses 27/28 instead of 0/1
 func AlterRecoveryOffsetID(sig []byte, v int) (altered []byte, err error) {
-	if v > 255 || v < -255 {
-		return nil, fmt.Errorf("invalid offset ID value, byte overflow, max value is 255 min value is -255")
-	}
 	if len(sig) != SignatureLength {
 		return nil, fmt.Errorf("invalid signature length, signature is of length: %d when it should be %d", len(sig), SignatureLength)
 	}

--- a/crypto/signature_test.go
+++ b/crypto/signature_test.go
@@ -61,6 +61,22 @@ func TestAlterSignatureOffsetID(t *testing.T) {
 			t.Errorf("AlterRecoverOffset is not associative")
 		}
 	}
+	overflowNil, overflowErr := AlterRecoveryOffsetID(testsig, 255)
+	if overflowNil != nil || overflowErr.Error() != "invalid sum, byte overflow. 255 + 1 is > 255" {
+		t.Errorf("AlterSignatureOffsetID overflow protection error")
+	}
+	underflowNil, underflowErr := AlterRecoveryOffsetID(testsig, -255)
+	if underflowNil != nil || underflowErr.Error() != "invalid sum, byte underflow. change 255 > current id 1" {
+		t.Errorf("AlterSignatureOffsetID underflow protection error")
+	}
+	vTooBigNil, vTooBigErr := AlterRecoveryOffsetID(testsig, 256)
+	if vTooBigNil != nil || vTooBigErr.Error() != "invalid offset ID value, byte overflow, max value is 255 min value is -255" {
+		t.Errorf("AlterSignatureOffsetID v too big protection error")
+	}
+	vTooSmallNil, vTooSmallErr := AlterRecoveryOffsetID(testsig, -256)
+	if vTooSmallNil != nil || vTooSmallErr.Error() != "invalid offset ID value, byte overflow, max value is 255 min value is -255" {
+		t.Errorf("AlterSignatureOffsetID v too small protection error")
+	}
 }
 
 func TestVerifySignature(t *testing.T) {

--- a/crypto/signature_test.go
+++ b/crypto/signature_test.go
@@ -44,6 +44,25 @@ func TestEcrecover(t *testing.T) {
 	}
 }
 
+func TestAlterSignatureOffsetID(t *testing.T) {
+  alteredSig, alterErr := AlterRecoveryOffsetID(testsig, 27)
+  if alterErr != nil {
+    t.Fatal(alterErr)
+  }
+  if testsig[RecoveryIDOffset] + 27 != alteredSig[RecoveryIDOffset] {
+    t.Errorf("byte not assigned correctly to signature")
+  }
+  alterReverse, alterRevErr := AlterRecoveryOffsetID(alteredSig, -27)
+  if alterRevErr != nil {
+    t.Fatal(alterRevErr)
+  }
+  for i, _ := range testsig {
+    if testsig[i] != alterReverse[i] {
+      t.Errorf("AlterRecoverOffset is not associative")
+    }
+  }
+}
+
 func TestVerifySignature(t *testing.T) {
 	sig := testsig[:len(testsig)-1] // remove recovery id
 	if !VerifySignature(testpubkey, testmsg, sig) {

--- a/crypto/signature_test.go
+++ b/crypto/signature_test.go
@@ -69,14 +69,6 @@ func TestAlterSignatureOffsetID(t *testing.T) {
 	if underflowNil != nil || underflowErr.Error() != "invalid sum, byte underflow. change 255 > current id 1" {
 		t.Errorf("AlterSignatureOffsetID underflow protection error")
 	}
-	vTooBigNil, vTooBigErr := AlterRecoveryOffsetID(testsig, 256)
-	if vTooBigNil != nil || vTooBigErr.Error() != "invalid offset ID value, byte overflow, max value is 255 min value is -255" {
-		t.Errorf("AlterSignatureOffsetID v too big protection error")
-	}
-	vTooSmallNil, vTooSmallErr := AlterRecoveryOffsetID(testsig, -256)
-	if vTooSmallNil != nil || vTooSmallErr.Error() != "invalid offset ID value, byte overflow, max value is 255 min value is -255" {
-		t.Errorf("AlterSignatureOffsetID v too small protection error")
-	}
 }
 
 func TestVerifySignature(t *testing.T) {

--- a/crypto/signature_test.go
+++ b/crypto/signature_test.go
@@ -45,22 +45,22 @@ func TestEcrecover(t *testing.T) {
 }
 
 func TestAlterSignatureOffsetID(t *testing.T) {
-  alteredSig, alterErr := AlterRecoveryOffsetID(testsig, 27)
-  if alterErr != nil {
-    t.Fatal(alterErr)
-  }
-  if testsig[RecoveryIDOffset] + 27 != alteredSig[RecoveryIDOffset] {
-    t.Errorf("byte not assigned correctly to signature")
-  }
-  alterReverse, alterRevErr := AlterRecoveryOffsetID(alteredSig, -27)
-  if alterRevErr != nil {
-    t.Fatal(alterRevErr)
-  }
-  for i, _ := range testsig {
-    if testsig[i] != alterReverse[i] {
-      t.Errorf("AlterRecoverOffset is not associative")
-    }
-  }
+	alteredSig, alterErr := AlterRecoveryOffsetID(testsig, 27)
+	if alterErr != nil {
+		t.Fatal(alterErr)
+	}
+	if testsig[RecoveryIDOffset]+27 != alteredSig[RecoveryIDOffset] {
+		t.Errorf("byte not assigned correctly to signature")
+	}
+	alterReverse, alterRevErr := AlterRecoveryOffsetID(alteredSig, -27)
+	if alterRevErr != nil {
+		t.Fatal(alterRevErr)
+	}
+	for i := range testsig {
+		if testsig[i] != alterReverse[i] {
+			t.Errorf("AlterRecoverOffset is not associative")
+		}
+	}
 }
 
 func TestVerifySignature(t *testing.T) {


### PR DESCRIPTION
I couldn't stand having this code being in my codebase: 

```
if signature[crypto.RecoveryIDOffset] == 0 || signature[crypto.RecoveryIDOffset] == 1 {
    signature[crypto.RecoveryIDOffset] += 27 // Transform yellow paper V from 0/1 to 27/28
}
```

So I figured an official and safe way to do this would be better. This will make it much easier for golang backends using geth to interact with signatures generated by wallet plugins like metamask. 