### PR TITLE
eth/catalyst: implement exchangeCapabilities

### DIFF
--- a/eth/catalyst/api.go
+++ b/eth/catalyst/api.go
@@ -731,6 +731,6 @@ func (api *ConsensusAPI) heartbeat() {
 	}
 }
 
-func GetCapabilities([]string) []string {
+func (api *ConsensusAPI) ExchangeCapabilities([]string) []string {
 	return caps
 }

--- a/eth/catalyst/api.go
+++ b/eth/catalyst/api.go
@@ -79,6 +79,16 @@ const (
 	beaconUpdateWarnFrequency = 5 * time.Minute
 )
 
+var caps = []string{
+	"engine_forkchoiceUpdatedV1",
+	"engine_forkchoiceUpdatedV2",
+	"engine_exchangeTransitionConfigurationV1",
+	"engine_getPayloadV1",
+	"engine_getPayloadV2",
+	"engine_newPayloadV1",
+	"engine_newPayloadV2",
+}
+
 type ConsensusAPI struct {
 	eth *eth.Ethereum
 
@@ -719,4 +729,8 @@ func (api *ConsensusAPI) heartbeat() {
 			offlineLogged = time.Now()
 		}
 	}
+}
+
+func GetCapabilities([]string) []string {
+	return caps
 }

--- a/eth/catalyst/api.go
+++ b/eth/catalyst/api.go
@@ -79,6 +79,7 @@ const (
 	beaconUpdateWarnFrequency = 5 * time.Minute
 )
 
+// All methods provided over the engine endpoint.
 var caps = []string{
 	"engine_forkchoiceUpdatedV1",
 	"engine_forkchoiceUpdatedV2",
@@ -731,6 +732,7 @@ func (api *ConsensusAPI) heartbeat() {
 	}
 }
 
+// ExchangeCapabilities returns the current methods provided by this node.
 func (api *ConsensusAPI) ExchangeCapabilities([]string) []string {
 	return caps
 }


### PR DESCRIPTION
Implements the new `engine_exchangeCapabilities` method which returns all available method names.
Spec: https://github.com/ethereum/execution-apis/pull/364