### PR TITLE
internal/ethapi: always add block withdrawal objects if present

### DIFF
--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -1246,8 +1246,6 @@ func RPCMarshalBlock(block *types.Block, inclTx bool, fullTx bool, config *param
 			}
 		}
 		fields["transactions"] = transactions
-		// inclTx also expands withdrawals
-		fields["withdrawals"] = block.Withdrawals()
 	}
 	uncles := block.Uncles()
 	uncleHashes := make([]common.Hash, len(uncles))
@@ -1255,7 +1253,9 @@ func RPCMarshalBlock(block *types.Block, inclTx bool, fullTx bool, config *param
 		uncleHashes[i] = uncle.Hash()
 	}
 	fields["uncles"] = uncleHashes
-
+	if block.Header().WithdrawalsHash != nil {
+		fields["withdrawals"] = block.Withdrawals()
+	}
 	return fields, nil
 }
 


### PR DESCRIPTION
The `execution-apis` specification says that the full list of withdrawals should _always_ be returned when requesting a block over RPC:

https://github.com/ethereum/execution-apis/blob/378c4304f75b5af2c9b5263c9c76b511e33e8984/src/schemas/block.yaml#L90-L94

This PR adopts the expected behavior.