### PR TITLE
eth/tracer: rename to revertReason

### DIFF
--- a/eth/tracers/internal/tracetest/calltrace_test.go
+++ b/eth/tracers/internal/tracetest/calltrace_test.go
@@ -55,17 +55,17 @@ type callLog struct {
 
 // callTrace is the result of a callTracer run.
 type callTrace struct {
-	From     common.Address  `json:"from"`
-	Gas      *hexutil.Uint64 `json:"gas"`
-	GasUsed  *hexutil.Uint64 `json:"gasUsed"`
-	To       common.Address  `json:"to,omitempty"`
-	Input    hexutil.Bytes   `json:"input"`
-	Output   hexutil.Bytes   `json:"output,omitempty"`
-	Error    string          `json:"error,omitempty"`
-	Revertal string          `json:"revertReason,omitempty"`
-	Calls    []callTrace     `json:"calls,omitempty"`
-	Logs     []callLog       `json:"logs,omitempty"`
-	Value    *hexutil.Big    `json:"value,omitempty"`
+	From         common.Address  `json:"from"`
+	Gas          *hexutil.Uint64 `json:"gas"`
+	GasUsed      *hexutil.Uint64 `json:"gasUsed"`
+	To           common.Address  `json:"to,omitempty"`
+	Input        hexutil.Bytes   `json:"input"`
+	Output       hexutil.Bytes   `json:"output,omitempty"`
+	Error        string          `json:"error,omitempty"`
+	RevertReason string          `json:"revertReason,omitempty"`
+	Calls        []callTrace     `json:"calls,omitempty"`
+	Logs         []callLog       `json:"logs,omitempty"`
+	Value        *hexutil.Big    `json:"value,omitempty"`
 	// Gencodec adds overridden fields at the end
 	Type string `json:"type"`
 }

--- a/eth/tracers/native/call.go
+++ b/eth/tracers/native/call.go
@@ -42,17 +42,17 @@ type callLog struct {
 }
 
 type callFrame struct {
-	Type     vm.OpCode      `json:"-"`
-	From     common.Address `json:"from"`
-	Gas      uint64         `json:"gas"`
-	GasUsed  uint64         `json:"gasUsed"`
-	To       common.Address `json:"to,omitempty" rlp:"optional"`
-	Input    []byte         `json:"input" rlp:"optional"`
-	Output   []byte         `json:"output,omitempty" rlp:"optional"`
-	Error    string         `json:"error,omitempty" rlp:"optional"`
-	Revertal string         `json:"revertReason,omitempty"`
-	Calls    []callFrame    `json:"calls,omitempty" rlp:"optional"`
-	Logs     []callLog      `json:"logs,omitempty" rlp:"optional"`
+	Type         vm.OpCode      `json:"-"`
+	From         common.Address `json:"from"`
+	Gas          uint64         `json:"gas"`
+	GasUsed      uint64         `json:"gasUsed"`
+	To           common.Address `json:"to,omitempty" rlp:"optional"`
+	Input        []byte         `json:"input" rlp:"optional"`
+	Output       []byte         `json:"output,omitempty" rlp:"optional"`
+	Error        string         `json:"error,omitempty" rlp:"optional"`
+	RevertReason string         `json:"revertReason,omitempty"`
+	Calls        []callFrame    `json:"calls,omitempty" rlp:"optional"`
+	Logs         []callLog      `json:"logs,omitempty" rlp:"optional"`
 	// Placed at end on purpose. The RLP will be decoded to 0 instead of
 	// nil if there are non-empty elements after in the struct.
 	Value *big.Int `json:"value,omitempty" rlp:"optional"`
@@ -84,7 +84,7 @@ func (f *callFrame) processOutput(output []byte, err error) {
 		return
 	}
 	if unpacked, err := abi.UnpackRevert(output); err == nil {
-		f.Revertal = unpacked
+		f.RevertReason = unpacked
 	}
 }
 

--- a/eth/tracers/native/gen_callframe_json.go
+++ b/eth/tracers/native/gen_callframe_json.go
@@ -16,19 +16,19 @@ var _ = (*callFrameMarshaling)(nil)
 // MarshalJSON marshals as JSON.
 func (c callFrame) MarshalJSON() ([]byte, error) {
 	type callFrame0 struct {
-		Type       vm.OpCode      `json:"-"`
-		From       common.Address `json:"from"`
-		Gas        hexutil.Uint64 `json:"gas"`
-		GasUsed    hexutil.Uint64 `json:"gasUsed"`
-		To         common.Address `json:"to,omitempty" rlp:"optional"`
-		Input      hexutil.Bytes  `json:"input" rlp:"optional"`
-		Output     hexutil.Bytes  `json:"output,omitempty" rlp:"optional"`
-		Error      string         `json:"error,omitempty" rlp:"optional"`
-		Revertal   string         `json:"revertReason,omitempty"`
-		Calls      []callFrame    `json:"calls,omitempty" rlp:"optional"`
-		Logs       []callLog      `json:"logs,omitempty" rlp:"optional"`
-		Value      *hexutil.Big   `json:"value,omitempty" rlp:"optional"`
-		TypeString string         `json:"type"`
+		Type         vm.OpCode      `json:"-"`
+		From         common.Address `json:"from"`
+		Gas          hexutil.Uint64 `json:"gas"`
+		GasUsed      hexutil.Uint64 `json:"gasUsed"`
+		To           common.Address `json:"to,omitempty" rlp:"optional"`
+		Input        hexutil.Bytes  `json:"input" rlp:"optional"`
+		Output       hexutil.Bytes  `json:"output,omitempty" rlp:"optional"`
+		Error        string         `json:"error,omitempty" rlp:"optional"`
+		RevertReason string         `json:"revertReason,omitempty"`
+		Calls        []callFrame    `json:"calls,omitempty" rlp:"optional"`
+		Logs         []callLog      `json:"logs,omitempty" rlp:"optional"`
+		Value        *hexutil.Big   `json:"value,omitempty" rlp:"optional"`
+		TypeString   string         `json:"type"`
 	}
 	var enc callFrame0
 	enc.Type = c.Type
@@ -39,7 +39,7 @@ func (c callFrame) MarshalJSON() ([]byte, error) {
 	enc.Input = c.Input
 	enc.Output = c.Output
 	enc.Error = c.Error
-	enc.Revertal = c.Revertal
+	enc.RevertReason = c.RevertReason
 	enc.Calls = c.Calls
 	enc.Logs = c.Logs
 	enc.Value = (*hexutil.Big)(c.Value)
@@ -50,18 +50,18 @@ func (c callFrame) MarshalJSON() ([]byte, error) {
 // UnmarshalJSON unmarshals from JSON.
 func (c *callFrame) UnmarshalJSON(input []byte) error {
 	type callFrame0 struct {
-		Type     *vm.OpCode      `json:"-"`
-		From     *common.Address `json:"from"`
-		Gas      *hexutil.Uint64 `json:"gas"`
-		GasUsed  *hexutil.Uint64 `json:"gasUsed"`
-		To       *common.Address `json:"to,omitempty" rlp:"optional"`
-		Input    *hexutil.Bytes  `json:"input" rlp:"optional"`
-		Output   *hexutil.Bytes  `json:"output,omitempty" rlp:"optional"`
-		Error    *string         `json:"error,omitempty" rlp:"optional"`
-		Revertal *string         `json:"revertReason,omitempty"`
-		Calls    []callFrame     `json:"calls,omitempty" rlp:"optional"`
-		Logs     []callLog       `json:"logs,omitempty" rlp:"optional"`
-		Value    *hexutil.Big    `json:"value,omitempty" rlp:"optional"`
+		Type         *vm.OpCode      `json:"-"`
+		From         *common.Address `json:"from"`
+		Gas          *hexutil.Uint64 `json:"gas"`
+		GasUsed      *hexutil.Uint64 `json:"gasUsed"`
+		To           *common.Address `json:"to,omitempty" rlp:"optional"`
+		Input        *hexutil.Bytes  `json:"input" rlp:"optional"`
+		Output       *hexutil.Bytes  `json:"output,omitempty" rlp:"optional"`
+		Error        *string         `json:"error,omitempty" rlp:"optional"`
+		RevertReason *string         `json:"revertReason,omitempty"`
+		Calls        []callFrame     `json:"calls,omitempty" rlp:"optional"`
+		Logs         []callLog       `json:"logs,omitempty" rlp:"optional"`
+		Value        *hexutil.Big    `json:"value,omitempty" rlp:"optional"`
 	}
 	var dec callFrame0
 	if err := json.Unmarshal(input, &dec); err != nil {
@@ -91,8 +91,8 @@ func (c *callFrame) UnmarshalJSON(input []byte) error {
 	if dec.Error != nil {
 		c.Error = *dec.Error
 	}
-	if dec.Revertal != nil {
-		c.Revertal = *dec.Revertal
+	if dec.RevertReason != nil {
+		c.RevertReason = *dec.RevertReason
 	}
 	if dec.Calls != nil {
 		c.Calls = dec.Calls


### PR DESCRIPTION
This PR renames `Revertal ` to `RevertReason` which I believe is a typo.