### PR TITLE
rpc: proper logging

### DIFF
--- a/rpc/handler.go
+++ b/rpc/handler.go
@@ -414,20 +414,22 @@ func (h *handler) handleCallMsg(ctx *callProc, msg *jsonrpcMessage) *jsonrpcMess
 	switch {
 	case msg.isNotification():
 		h.handleCall(ctx, msg)
-		h.log.Debug("Served "+msg.Method, "duration", time.Since(start))
+		h.log.Debug("Served rpc", "method", msg.Method, "duration", time.Since(start))
 		return nil
 	case msg.isCall():
 		resp := h.handleCall(ctx, msg)
 		var ctx []interface{}
-		ctx = append(ctx, "reqid", idForLog{msg.ID}, "duration", time.Since(start))
+		ctx = append(ctx, "method", msg.Method,
+			"reqid", idForLog{msg.ID},
+			"duration", time.Since(start))
 		if resp.Error != nil {
 			ctx = append(ctx, "err", resp.Error.Message)
 			if resp.Error.Data != nil {
 				ctx = append(ctx, "errdata", resp.Error.Data)
 			}
-			h.log.Warn("Served "+msg.Method, ctx...)
+			h.log.Warn("Served rpc", ctx...)
 		} else {
-			h.log.Debug("Served "+msg.Method, ctx...)
+			h.log.Debug("Served rpc", ctx...)
 		}
 		return resp
 	case msg.hasValidID():


### PR DESCRIPTION
The dynamic part of a message should be a value in a key-value pair, not part of the message