### PR TITLE
ethclient/gethclient: fix typo

### DIFF
--- a/ethclient/gethclient/gethclient_test.go
+++ b/ethclient/gethclient/gethclient_test.go
@@ -299,7 +299,7 @@ func testSubscribePendingTransactions(t *testing.T, client *rpc.Client) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	// Check that the transaction was send over the channel
+	// Check that the transaction was sent over the channel
 	hash := <-ch
 	if hash != signedTx.Hash() {
 		t.Fatalf("Invalid tx hash received, got %v, want %v", hash, signedTx.Hash())
@@ -333,7 +333,7 @@ func testSubscribeFullPendingTransactions(t *testing.T, client *rpc.Client) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	// Check that the transaction was send over the channel
+	// Check that the transaction was sent over the channel
 	tx = <-ch
 	if tx.Hash() != signedTx.Hash() {
 		t.Fatalf("Invalid tx hash received, got %v, want %v", tx.Hash(), signedTx.Hash())


### PR DESCRIPTION
fix grammar typo in `ethclient/gethclient/gethclient_test.go`