### PR TITLE
core: improve ambiguous block validation message

### DIFF
--- a/core/block_validator.go
+++ b/core/block_validator.go
@@ -60,14 +60,14 @@ func (v *BlockValidator) ValidateBody(block *types.Block) error {
 		return err
 	}
 	if hash := types.CalcUncleHash(block.Uncles()); hash != header.UncleHash {
-		return fmt.Errorf("uncle root hash mismatch: have %x, want %x", hash, header.UncleHash)
+		return fmt.Errorf("uncle root hash mismatch (header value %x, calculated %x)", header.UncleHash, hash)
 	}
 	if hash := types.DeriveSha(block.Transactions(), trie.NewStackTrie(nil)); hash != header.TxHash {
-		return fmt.Errorf("transaction root hash mismatch: have %x, want %x", hash, header.TxHash)
+		return fmt.Errorf("transaction root hash mismatch (header value %x, calculated %x)", header.TxHash, hash)
 	}
 	if header.WithdrawalsHash != nil {
 		if hash := types.DeriveSha(block.Withdrawals(), trie.NewStackTrie(nil)); hash != *header.WithdrawalsHash {
-			return fmt.Errorf("withdrawals root hash mismatch: have %x, want %x", hash, *header.WithdrawalsHash)
+			return fmt.Errorf("withdrawals root hash mismatch (header value %x, calculated %x)", *header.WithdrawalsHash, hash)
 		}
 	}
 	if !v.bc.HasBlockAndState(block.ParentHash(), block.NumberU64()-1) {


### PR DESCRIPTION
Makes it a bit clearer what is what. 
Also now uses the similar syntax with parenthesis as other errors in this file, e.g. 
```
		return fmt.Errorf("invalid gas used (remote: %d local: %d)", block.GasUsed(), usedGas)
```