### PR TITLE
eth/catalyst: return invalid params instead of invalid payload params

### DIFF
--- a/core/beacon/errors.go
+++ b/core/beacon/errors.go
@@ -80,6 +80,7 @@ var (
 	UnknownPayload           = &EngineAPIError{code: -38001, msg: "Unknown payload"}
 	InvalidForkChoiceState   = &EngineAPIError{code: -38002, msg: "Invalid forkchoice state"}
 	InvalidPayloadAttributes = &EngineAPIError{code: -38003, msg: "Invalid payload attributes"}
+	InvalidParams            = &EngineAPIError{code: -32602, msg: "Invalid parameters"}
 
 	STATUS_INVALID         = ForkChoiceResponse{PayloadStatus: PayloadStatusV1{Status: INVALID}, PayloadID: nil}
 	STATUS_SYNCING         = ForkChoiceResponse{PayloadStatus: PayloadStatusV1{Status: SYNCING}, PayloadID: nil}

--- a/eth/catalyst/api.go
+++ b/eth/catalyst/api.go
@@ -168,7 +168,7 @@ func NewConsensusAPI(eth *eth.Ethereum) *ConsensusAPI {
 // and return its payloadID.
 func (api *ConsensusAPI) ForkchoiceUpdatedV1(update beacon.ForkchoiceStateV1, payloadAttributes *beacon.PayloadAttributes) (beacon.ForkChoiceResponse, error) {
 	if payloadAttributes != nil && payloadAttributes.Withdrawals != nil {
-		return beacon.STATUS_INVALID, fmt.Errorf("withdrawals not supported in V1")
+		return beacon.STATUS_INVALID, beacon.InvalidParams.With(fmt.Errorf("withdrawals not supported in V1"))
 	}
 	return api.forkchoiceUpdated(update, payloadAttributes)
 }
@@ -177,7 +177,7 @@ func (api *ConsensusAPI) ForkchoiceUpdatedV1(update beacon.ForkchoiceStateV1, pa
 func (api *ConsensusAPI) ForkchoiceUpdatedV2(update beacon.ForkchoiceStateV1, payloadAttributes *beacon.PayloadAttributes) (beacon.ForkChoiceResponse, error) {
 	if payloadAttributes != nil {
 		if err := api.verifyPayloadAttributes(payloadAttributes); err != nil {
-			return beacon.STATUS_INVALID, beacon.InvalidPayloadAttributes.With(err)
+			return beacon.STATUS_INVALID, beacon.InvalidParams.With(err)
 		}
 	}
 	return api.forkchoiceUpdated(update, payloadAttributes)


### PR DESCRIPTION
We must return `-32602` when withdrawals are specified before shanghai, or not defined afterwards

closes https://github.com/ethereum/go-ethereum/issues/26584