### PR TITLE
rpc: fix off-by-one in ipc endpoint length check

### DIFF
--- a/rpc/ipc_unix.go
+++ b/rpc/ipc_unix.go
@@ -31,8 +31,9 @@ import (
 
 // ipcListen will create a Unix socket on the given endpoint.
 func ipcListen(endpoint string) (net.Listener, error) {
-	if len(endpoint) > int(max_path_size) {
-		log.Warn(fmt.Sprintf("The ipc endpoint is longer than %d characters. ", max_path_size),
+	// account for null-terminator too
+	if len(endpoint)+1 > int(max_path_size) {
+		log.Warn(fmt.Sprintf("The ipc endpoint is longer than %d characters. ", max_path_size-1),
 			"endpoint", endpoint)
 	}
 


### PR DESCRIPTION
This PR fixes a minor flaw in the check for ipc endpoint length. The `max_path_size` is the max path that an ipc endpoint can have, which is `208`. However, that size concerns the __null-terminated pathname__, so we need to account for an extra null-character too. 

This bug was found by a user using a path of the exact wrong length, who got an error but did not get a warning. 

docs: https://man7.org/linux/man-pages/man7/unix.7.html