### PR TITLE
[website] Fix document commit date fetch

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -177,8 +177,7 @@ export const LATEST_GETH_RELEASE_URL =
   'https://api.github.com/repos/ethereum/go-ethereum/releases/latest';
 export const ALL_GETH_COMMITS_URL = 'https://api.github.com/repos/ethereum/go-ethereum/commits/';
 export const RELEASE_COMMIT_BASE_URL = 'https://github.com/ethereum/go-ethereum/tree/';
-export const LAST_COMMIT_BASE_URL =
-  'https://api.github.com/repos/ethereum/go-ethereum/commits/website?path=';
+export const LAST_COMMIT_BASE_URL = 'https://api.github.com/repos/ethereum/go-ethereum/commits';
 
 // Binaries urls
 export const BINARIES_BASE_URL = 'https://gethstore.blob.core.windows.net/builds/';

--- a/src/utils/getLastModifiedDate.ts
+++ b/src/utils/getLastModifiedDate.ts
@@ -5,12 +5,19 @@ export const getLastModifiedDate = async (filePath: string) => {
     // About personal access tokens https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token#about-personal-access-tokens
     Authorization: 'Token ' + process.env.GITHUB_TOKEN_READ_ONLY
   });
+  const urlWithIndex = new URL(LAST_COMMIT_BASE_URL);
+  urlWithIndex.searchParams.set('path', `${filePath}/index.md`);
+  urlWithIndex.searchParams.set('page', '1');
+  urlWithIndex.searchParams.set('per_page', '1');
+  urlWithIndex.searchParams.set('sha', 'website');
+  const urlWithoutIndex = new URL(urlWithIndex);
+  urlWithoutIndex.searchParams.set('path', `${filePath}.md`);
 
-  return fetch(`${LAST_COMMIT_BASE_URL}${filePath}/index.md&page=1&per_page=1`, { headers })
+  return fetch(urlWithIndex, { headers })
     .then(res => res.json())
     .then(commits => commits[0].commit.committer.date)
     .catch(_ =>
-      fetch(`${LAST_COMMIT_BASE_URL}${filePath}.md&page=1&per_page=1`, { headers })
+      fetch(urlWithoutIndex, { headers })
         .then(res => res.json())
         .then(commits => commits[0].commit.committer.date)
         .catch(console.error)


### PR DESCRIPTION
## Description
Previously we were accidentally still pulling GitHub commit info from their REST API by pointing to the old dev form of the site on `ethereum/geth-website`.

#26619 Updated this, but the link did not properly reference the `website` branch of this repo, which required setting a new search param in the URL for `?sha=website`

This PR fixes the format for the call to the GitHub REST API to target the proper branch. I refactored the call to use the `new URL()` js object format which helps to construct these URLS with improved readability