### PR TITLE
rpc: remove DecimalOrHex type

### DIFF
--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -88,7 +88,7 @@ type feeHistoryResult struct {
 }
 
 // FeeHistory returns the fee market history.
-func (s *EthereumAPI) FeeHistory(ctx context.Context, blockCount rpc.DecimalOrHex, lastBlock rpc.BlockNumber, rewardPercentiles []float64) (*feeHistoryResult, error) {
+func (s *EthereumAPI) FeeHistory(ctx context.Context, blockCount math.HexOrDecimal64, lastBlock rpc.BlockNumber, rewardPercentiles []float64) (*feeHistoryResult, error) {
 	oldest, reward, baseFee, gasUsed, err := s.b.FeeHistory(ctx, int(blockCount), lastBlock, rewardPercentiles)
 	if err != nil {
 		return nil, err

--- a/rpc/types.go
+++ b/rpc/types.go
@@ -243,24 +243,3 @@ func BlockNumberOrHashWithHash(hash common.Hash, canonical bool) BlockNumberOrHa
 		RequireCanonical: canonical,
 	}
 }
-
-// DecimalOrHex unmarshals a non-negative decimal or hex parameter into a uint64.
-type DecimalOrHex uint64
-
-// UnmarshalJSON implements json.Unmarshaler.
-func (dh *DecimalOrHex) UnmarshalJSON(data []byte) error {
-	input := strings.TrimSpace(string(data))
-	if len(input) >= 2 && input[0] == '"' && input[len(input)-1] == '"' {
-		input = input[1 : len(input)-1]
-	}
-
-	value, err := strconv.ParseUint(input, 10, 64)
-	if err != nil {
-		value, err = hexutil.DecodeUint64(input)
-	}
-	if err != nil {
-		return err
-	}
-	*dh = DecimalOrHex(value)
-	return nil
-}


### PR DESCRIPTION
It's the same as math.HexOrDecimal64, which has more uses across the codebase.