### PR TITLE
log: allow tabs in log messages

### DIFF
--- a/log/format.go
+++ b/log/format.go
@@ -492,7 +492,7 @@ func escapeString(s string) string {
 func escapeMessage(s string) string {
 	needsQuoting := false
 	for _, r := range s {
-		// Carriage return and Line feed are ok
+		// Allow CR/LF/TAB. This is to make multi-line messages work.
 		if r == '\r' || r == '\n' || r == '\t' {
 			continue
 		}

--- a/log/format.go
+++ b/log/format.go
@@ -493,7 +493,7 @@ func escapeMessage(s string) string {
 	needsQuoting := false
 	for _, r := range s {
 		// Carriage return and Line feed are ok
-		if r == 0xa || r == 0xd {
+		if r == '\r' || r == '\n' || r == '\t' {
 			continue
 		}
 		// We quote everything below <space> (0x20) and above~ (0x7E),


### PR DESCRIPTION
This fixes a regression where panic reports from package rpc were quoted because they contain tab characters.