### PR TITLE
core/state, trie: remove unused error-return from trie Commit operation

### DIFF
--- a/core/state/database.go
+++ b/core/state/database.go
@@ -109,7 +109,7 @@ type Trie interface {
 	// The returned nodeset can be nil if the trie is clean(nothing to commit).
 	// Once the trie is committed, it's not usable anymore. A new trie must
 	// be created with new root and updated trie database for following usage
-	Commit(collectLeaf bool) (common.Hash, *trie.NodeSet, error)
+	Commit(collectLeaf bool) (common.Hash, *trie.NodeSet)
 
 	// NodeIterator returns an iterator that returns nodes of the trie. Iteration
 	// starts at the key after the given start key.

--- a/core/state/snapshot/generate.go
+++ b/core/state/snapshot/generate.go
@@ -367,8 +367,8 @@ func (dl *diskLayer) generateRange(ctx *generatorContext, trieId *trie.ID, prefi
 		for i, key := range result.keys {
 			snapTrie.Update(key, result.vals[i])
 		}
-		root, nodes, err := snapTrie.Commit(false)
-		if err == nil && nodes != nil {
+		root, nodes := snapTrie.Commit(false)
+		if nodes != nil {
 			tdb.Update(trie.NewWithNodeSet(nodes))
 			tdb.Commit(root, false)
 		}

--- a/core/state/snapshot/generate_test.go
+++ b/core/state/snapshot/generate_test.go
@@ -190,7 +190,7 @@ func (t *testHelper) makeStorageTrie(stateRoot, owner common.Hash, keys []string
 	if !commit {
 		return stTrie.Hash().Bytes()
 	}
-	root, nodes, _ := stTrie.Commit(false)
+	root, nodes := stTrie.Commit(false)
 	if nodes != nil {
 		t.nodes.Merge(nodes)
 	}
@@ -198,7 +198,7 @@ func (t *testHelper) makeStorageTrie(stateRoot, owner common.Hash, keys []string
 }
 
 func (t *testHelper) Commit() common.Hash {
-	root, nodes, _ := t.accTrie.Commit(true)
+	root, nodes := t.accTrie.Commit(true)
 	if nodes != nil {
 		t.nodes.Merge(nodes)
 	}

--- a/core/state/state_object.go
+++ b/core/state/state_object.go
@@ -385,10 +385,8 @@ func (s *stateObject) commitTrie(db Database) (*trie.NodeSet, error) {
 	if metrics.EnabledExpensive {
 		defer func(start time.Time) { s.db.StorageCommits += time.Since(start) }(time.Now())
 	}
-	root, nodes, err := tr.Commit(false)
-	if err == nil {
-		s.data.Root = root
-	}
+	root, nodes := tr.Commit(false)
+	s.data.Root = root
 	return nodes, err
 }
 

--- a/core/state/statedb.go
+++ b/core/state/statedb.go
@@ -1019,10 +1019,7 @@ func (s *StateDB) Commit(deleteEmptyObjects bool) (common.Hash, error) {
 	if metrics.EnabledExpensive {
 		start = time.Now()
 	}
-	root, set, err := s.trie.Commit(true)
-	if err != nil {
-		return common.Hash{}, err
-	}
+	root, set := s.trie.Commit(true)
 	// Merge the dirty nodes of account trie into global set
 	if set != nil {
 		if err := nodes.Merge(set); err != nil {

--- a/eth/protocols/snap/sync_test.go
+++ b/eth/protocols/snap/sync_test.go
@@ -1388,7 +1388,7 @@ func makeAccountTrieNoStorage(n int) (string, *trie.Trie, entrySlice) {
 
 	// Commit the state changes into db and re-create the trie
 	// for accessing later.
-	root, nodes, _ := accTrie.Commit(false)
+	root, nodes := accTrie.Commit(false)
 	db.Update(trie.NewWithNodeSet(nodes))
 
 	accTrie, _ = trie.New(trie.StateTrieID(root), db)
@@ -1450,7 +1450,7 @@ func makeBoundaryAccountTrie(n int) (string, *trie.Trie, entrySlice) {
 
 	// Commit the state changes into db and re-create the trie
 	// for accessing later.
-	root, nodes, _ := accTrie.Commit(false)
+	root, nodes := accTrie.Commit(false)
 	db.Update(trie.NewWithNodeSet(nodes))
 
 	accTrie, _ = trie.New(trie.StateTrieID(root), db)
@@ -1496,7 +1496,7 @@ func makeAccountTrieWithStorageWithUniqueStorage(accounts, slots int, code bool)
 	sort.Sort(entries)
 
 	// Commit account trie
-	root, set, _ := accTrie.Commit(true)
+	root, set := accTrie.Commit(true)
 	nodes.Merge(set)
 
 	// Commit gathered dirty nodes into database
@@ -1561,7 +1561,7 @@ func makeAccountTrieWithStorage(accounts, slots int, code, boundary bool) (strin
 	sort.Sort(entries)
 
 	// Commit account trie
-	root, set, _ := accTrie.Commit(true)
+	root, set := accTrie.Commit(true)
 	nodes.Merge(set)
 
 	// Commit gathered dirty nodes into database
@@ -1603,7 +1603,7 @@ func makeStorageTrieWithSeed(owner common.Hash, n, seed uint64, db *trie.Databas
 		entries = append(entries, elem)
 	}
 	sort.Sort(entries)
-	root, nodes, _ := trie.Commit(false)
+	root, nodes := trie.Commit(false)
 	return root, nodes, entries
 }
 
@@ -1654,7 +1654,7 @@ func makeBoundaryStorageTrie(owner common.Hash, n int, db *trie.Database) (commo
 		entries = append(entries, elem)
 	}
 	sort.Sort(entries)
-	root, nodes, _ := trie.Commit(false)
+	root, nodes := trie.Commit(false)
 	return root, nodes, entries
 }
 

--- a/light/postprocess.go
+++ b/light/postprocess.go
@@ -212,10 +212,7 @@ func (c *ChtIndexerBackend) Process(ctx context.Context, header *types.Header) e
 
 // Commit implements core.ChainIndexerBackend
 func (c *ChtIndexerBackend) Commit() error {
-	root, nodes, err := c.trie.Commit(false)
-	if err != nil {
-		return err
-	}
+	root, nodes := c.trie.Commit(false)
 	// Commit trie changes into trie database in case it's not nil.
 	if nodes != nil {
 		if err := c.triedb.Update(trie.NewWithNodeSet(nodes)); err != nil {
@@ -226,6 +223,7 @@ func (c *ChtIndexerBackend) Commit() error {
 		}
 	}
 	// Re-create trie with newly generated root and updated database.
+	var err error
 	c.trie, err = trie.New(trie.TrieID(root), c.triedb)
 	if err != nil {
 		return err
@@ -458,10 +456,7 @@ func (b *BloomTrieIndexerBackend) Commit() error {
 			b.trie.Delete(encKey[:])
 		}
 	}
-	root, nodes, err := b.trie.Commit(false)
-	if err != nil {
-		return err
-	}
+	root, nodes := b.trie.Commit(false)
 	// Commit trie changes into trie database in case it's not nil.
 	if nodes != nil {
 		if err := b.triedb.Update(trie.NewWithNodeSet(nodes)); err != nil {
@@ -472,6 +467,7 @@ func (b *BloomTrieIndexerBackend) Commit() error {
 		}
 	}
 	// Re-create trie with newly generated root and updated database.
+	var err error
 	b.trie, err = trie.New(trie.TrieID(root), b.triedb)
 	if err != nil {
 		return err

--- a/light/trie.go
+++ b/light/trie.go
@@ -164,9 +164,9 @@ func (t *odrTrie) TryDeleteAccount(address common.Address) error {
 	})
 }
 
-func (t *odrTrie) Commit(collectLeaf bool) (common.Hash, *trie.NodeSet, error) {
+func (t *odrTrie) Commit(collectLeaf bool) (common.Hash, *trie.NodeSet) {
 	if t.trie == nil {
-		return t.id.Root, nil, nil
+		return t.id.Root, nil
 	}
 	return t.trie.Commit(collectLeaf)
 }

--- a/tests/fuzzers/stacktrie/trie_fuzzer.go
+++ b/tests/fuzzers/stacktrie/trie_fuzzer.go
@@ -182,10 +182,7 @@ func (f *fuzzer) fuzz() int {
 		return 0
 	}
 	// Flush trie -> database
-	rootA, nodes, err := trieA.Commit(false)
-	if err != nil {
-		panic(err)
-	}
+	rootA, nodes := trieA.Commit(false)
 	if nodes != nil {
 		dbA.Update(trie.NewWithNodeSet(nodes))
 	}
@@ -201,9 +198,7 @@ func (f *fuzzer) fuzz() int {
 		trieB.Update(kv.k, kv.v)
 	}
 	rootB := trieB.Hash()
-	if _, err := trieB.Commit(); err != nil {
-		panic(err)
-	}
+	trieB.Commit()
 	if rootA != rootB {
 		panic(fmt.Sprintf("roots differ: (trie) %x != %x (stacktrie)", rootA, rootB))
 	}

--- a/tests/fuzzers/trie/trie-fuzzer.go
+++ b/tests/fuzzers/trie/trie-fuzzer.go
@@ -161,10 +161,7 @@ func runRandTest(rt randTest) error {
 		case opHash:
 			tr.Hash()
 		case opCommit:
-			hash, nodes, err := tr.Commit(false)
-			if err != nil {
-				return err
-			}
+			hash, nodes := tr.Commit(false)
 			if nodes != nil {
 				if err := triedb.Update(trie.NewWithNodeSet(nodes)); err != nil {
 					return err

--- a/trie/iterator_test.go
+++ b/trie/iterator_test.go
@@ -60,10 +60,7 @@ func TestIterator(t *testing.T) {
 		all[val.k] = val.v
 		trie.Update([]byte(val.k), []byte(val.v))
 	}
-	root, nodes, err := trie.Commit(false)
-	if err != nil {
-		t.Fatalf("Failed to commit trie %v", err)
-	}
+	root, nodes := trie.Commit(false)
 	db.Update(NewWithNodeSet(nodes))
 
 	trie, _ = New(TrieID(root), db)
@@ -225,7 +222,7 @@ func TestDifferenceIterator(t *testing.T) {
 	for _, val := range testdata1 {
 		triea.Update([]byte(val.k), []byte(val.v))
 	}
-	rootA, nodesA, _ := triea.Commit(false)
+	rootA, nodesA := triea.Commit(false)
 	dba.Update(NewWithNodeSet(nodesA))
 	triea, _ = New(TrieID(rootA), dba)
 
@@ -234,7 +231,7 @@ func TestDifferenceIterator(t *testing.T) {
 	for _, val := range testdata2 {
 		trieb.Update([]byte(val.k), []byte(val.v))
 	}
-	rootB, nodesB, _ := trieb.Commit(false)
+	rootB, nodesB := trieb.Commit(false)
 	dbb.Update(NewWithNodeSet(nodesB))
 	trieb, _ = New(TrieID(rootB), dbb)
 
@@ -267,7 +264,7 @@ func TestUnionIterator(t *testing.T) {
 	for _, val := range testdata1 {
 		triea.Update([]byte(val.k), []byte(val.v))
 	}
-	rootA, nodesA, _ := triea.Commit(false)
+	rootA, nodesA := triea.Commit(false)
 	dba.Update(NewWithNodeSet(nodesA))
 	triea, _ = New(TrieID(rootA), dba)
 
@@ -276,7 +273,7 @@ func TestUnionIterator(t *testing.T) {
 	for _, val := range testdata2 {
 		trieb.Update([]byte(val.k), []byte(val.v))
 	}
-	rootB, nodesB, _ := trieb.Commit(false)
+	rootB, nodesB := trieb.Commit(false)
 	dbb.Update(NewWithNodeSet(nodesB))
 	trieb, _ = New(TrieID(rootB), dbb)
 
@@ -334,7 +331,7 @@ func testIteratorContinueAfterError(t *testing.T, memonly bool) {
 	for _, val := range testdata1 {
 		tr.Update([]byte(val.k), []byte(val.v))
 	}
-	_, nodes, _ := tr.Commit(false)
+	_, nodes := tr.Commit(false)
 	triedb.Update(NewWithNodeSet(nodes))
 	if !memonly {
 		triedb.Commit(tr.Hash(), false)
@@ -426,7 +423,7 @@ func testIteratorContinueAfterSeekError(t *testing.T, memonly bool) {
 	for _, val := range testdata1 {
 		ctr.Update([]byte(val.k), []byte(val.v))
 	}
-	root, nodes, _ := ctr.Commit(false)
+	root, nodes := ctr.Commit(false)
 	triedb.Update(NewWithNodeSet(nodes))
 	if !memonly {
 		triedb.Commit(root, false)
@@ -545,7 +542,7 @@ func makeLargeTestTrie() (*Database, *StateTrie, *loggingDb) {
 		val = crypto.Keccak256(val)
 		trie.Update(key, val)
 	}
-	_, nodes, _ := trie.Commit(false)
+	_, nodes := trie.Commit(false)
 	triedb.Update(NewWithNodeSet(nodes))
 	// Return the generated trie
 	return triedb, trie, logDb
@@ -585,7 +582,7 @@ func TestIteratorNodeBlob(t *testing.T) {
 		all[val.k] = val.v
 		trie.Update([]byte(val.k), []byte(val.v))
 	}
-	_, nodes, _ := trie.Commit(false)
+	_, nodes := trie.Commit(false)
 	triedb.Update(NewWithNodeSet(nodes))
 	triedb.Cap(0)
 

--- a/trie/secure_trie.go
+++ b/trie/secure_trie.go
@@ -211,7 +211,7 @@ func (t *StateTrie) GetKey(shaKey []byte) []byte {
 // All cached preimages will be also flushed if preimages recording is enabled.
 // Once the trie is committed, it's not usable anymore. A new trie must
 // be created with new root and updated trie database for following usage
-func (t *StateTrie) Commit(collectLeaf bool) (common.Hash, *NodeSet, error) {
+func (t *StateTrie) Commit(collectLeaf bool) (common.Hash, *NodeSet) {
 	// Write all the pre-images to the actual disk database
 	if len(t.getSecKeyCache()) > 0 {
 		if t.preimages != nil {

--- a/trie/secure_trie_test.go
+++ b/trie/secure_trie_test.go
@@ -58,10 +58,7 @@ func makeTestStateTrie() (*Database, *StateTrie, map[string][]byte) {
 			trie.Update(key, val)
 		}
 	}
-	root, nodes, err := trie.Commit(false)
-	if err != nil {
-		panic(fmt.Errorf("failed to commit trie %v", err))
-	}
+	root, nodes := trie.Commit(false)
 	if err := triedb.Update(NewWithNodeSet(nodes)); err != nil {
 		panic(fmt.Errorf("failed to commit db %v", err))
 	}

--- a/trie/sync_test.go
+++ b/trie/sync_test.go
@@ -52,10 +52,7 @@ func makeTestTrie() (*Database, *StateTrie, map[string][]byte) {
 			trie.Update(key, val)
 		}
 	}
-	root, nodes, err := trie.Commit(false)
-	if err != nil {
-		panic(fmt.Errorf("failed to commit trie %v", err))
-	}
+	root, nodes := trie.Commit(false)
 	if err := triedb.Update(NewWithNodeSet(nodes)); err != nil {
 		panic(fmt.Errorf("failed to commit db %v", err))
 	}

--- a/trie/trie.go
+++ b/trie/trie.go
@@ -566,7 +566,7 @@ func (t *Trie) Hash() common.Hash {
 // The returned nodeset can be nil if the trie is clean (nothing to commit).
 // Once the trie is committed, it's not usable anymore. A new trie must
 // be created with new root and updated trie database for following usage
-func (t *Trie) Commit(collectLeaf bool) (common.Hash, *NodeSet, error) {
+func (t *Trie) Commit(collectLeaf bool) (common.Hash, *NodeSet) {
 	defer t.tracer.reset()
 
 	// Trie is empty and can be classified into two types of situations:
@@ -576,7 +576,7 @@ func (t *Trie) Commit(collectLeaf bool) (common.Hash, *NodeSet, error) {
 		// Wrap tracked deletions as the return
 		set := NewNodeSet(t.owner)
 		t.tracer.markDeletions(set)
-		return emptyRoot, set, nil
+		return emptyRoot, set
 	}
 	// Derive the hash for all dirty nodes first. We hold the assumption
 	// in the following procedure that all nodes are hashed.
@@ -588,15 +588,12 @@ func (t *Trie) Commit(collectLeaf bool) (common.Hash, *NodeSet, error) {
 		// Replace the root node with the origin hash in order to
 		// ensure all resolved nodes are dropped after the commit.
 		t.root = hashedNode
-		return rootHash, nil, nil
+		return rootHash, nil
 	}
 	h := newCommitter(t.owner, t.tracer, collectLeaf)
-	newRoot, nodes, err := h.Commit(t.root)
-	if err != nil {
-		return common.Hash{}, nil, err
-	}
+	newRoot, nodes := h.Commit(t.root)
 	t.root = newRoot
-	return rootHash, nodes, nil
+	return rootHash, nodes
 }
 
 // hashRoot calculates the root hash of the given trie

--- a/trie/trie_test.go
+++ b/trie/trie_test.go
@@ -83,7 +83,7 @@ func testMissingNode(t *testing.T, memonly bool) {
 	trie := NewEmpty(triedb)
 	updateString(trie, "120000", "qwerqwerqwerqwerqwerqwerqwerqwer")
 	updateString(trie, "123456", "asdfasdfasdfasdfasdfasdfasdfasdf")
-	root, nodes, _ := trie.Commit(false)
+	root, nodes := trie.Commit(false)
 	triedb.Update(NewWithNodeSet(nodes))
 	if !memonly {
 		triedb.Commit(root, false)
@@ -166,10 +166,7 @@ func TestInsert(t *testing.T) {
 	updateString(trie, "A", "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
 
 	exp = common.HexToHash("d23786fb4a010da3ce639d66d5e904a11dbc02746d1ce25029e53290cabf28ab")
-	root, _, err := trie.Commit(false)
-	if err != nil {
-		t.Fatalf("commit error: %v", err)
-	}
+	root, _ = trie.Commit(false)
 	if root != exp {
 		t.Errorf("case 2: exp %x got %x", exp, root)
 	}
@@ -194,7 +191,7 @@ func TestGet(t *testing.T) {
 		if i == 1 {
 			return
 		}
-		root, nodes, _ := trie.Commit(false)
+		root, nodes := trie.Commit(false)
 		db.Update(NewWithNodeSet(nodes))
 		trie, _ = New(TrieID(root), db)
 	}
@@ -266,10 +263,7 @@ func TestReplication(t *testing.T) {
 	for _, val := range vals {
 		updateString(trie, val.k, val.v)
 	}
-	exp, nodes, err := trie.Commit(false)
-	if err != nil {
-		t.Fatalf("commit error: %v", err)
-	}
+	exp, nodes := trie.Commit(false)
 	triedb.Update(NewWithNodeSet(nodes))
 
 	// create a new trie on top of the database and check that lookups work.
@@ -282,10 +276,7 @@ func TestReplication(t *testing.T) {
 			t.Errorf("trie2 doesn't have %q => %q", kv.k, kv.v)
 		}
 	}
-	hash, nodes, err := trie2.Commit(false)
-	if err != nil {
-		t.Fatalf("commit error: %v", err)
-	}
+	hash, nodes := trie2.Commit(false)
 	if hash != exp {
 		t.Errorf("root failure. expected %x got %x", exp, hash)
 	}
@@ -454,11 +445,7 @@ func runRandTest(rt randTest) bool {
 		case opHash:
 			tr.Hash()
 		case opCommit:
-			root, nodes, err := tr.Commit(true)
-			if err != nil {
-				rt[i].err = err
-				return false
-			}
+			root, nodes := tr.Commit(true)
 			// Validity the returned nodeset
 			if nodes != nil {
 				for path, node := range nodes.updates.nodes {
@@ -710,7 +697,7 @@ func TestCommitAfterHash(t *testing.T) {
 	if exp != root {
 		t.Errorf("got %x, exp %x", root, exp)
 	}
-	root, _, _ = trie.Commit(false)
+	root, _ = trie.Commit(false)
 	if exp != root {
 		t.Errorf("got %x, exp %x", root, exp)
 	}
@@ -813,7 +800,7 @@ func TestCommitSequence(t *testing.T) {
 			trie.Update(crypto.Keccak256(addresses[i][:]), accounts[i])
 		}
 		// Flush trie -> database
-		root, nodes, _ := trie.Commit(false)
+		root, nodes := trie.Commit(false)
 		db.Update(NewWithNodeSet(nodes))
 		// Flush memdb -> disk (sponge)
 		db.Commit(root, false)
@@ -854,7 +841,7 @@ func TestCommitSequenceRandomBlobs(t *testing.T) {
 			trie.Update(key, val)
 		}
 		// Flush trie -> database
-		root, nodes, _ := trie.Commit(false)
+		root, nodes := trie.Commit(false)
 		db.Update(NewWithNodeSet(nodes))
 		// Flush memdb -> disk (sponge)
 		db.Commit(root, false)
@@ -893,7 +880,7 @@ func TestCommitSequenceStackTrie(t *testing.T) {
 			stTrie.TryUpdate(key, val)
 		}
 		// Flush trie -> database
-		root, nodes, _ := trie.Commit(false)
+		root, nodes := trie.Commit(false)
 		// Flush memdb -> disk (sponge)
 		db.Update(NewWithNodeSet(nodes))
 		db.Commit(root, false)
@@ -941,7 +928,7 @@ func TestCommitSequenceSmallRoot(t *testing.T) {
 	trie.TryUpdate(key, []byte{0x1})
 	stTrie.TryUpdate(key, []byte{0x1})
 	// Flush trie -> database
-	root, nodes, _ := trie.Commit(false)
+	root, nodes := trie.Commit(false)
 	// Flush memdb -> disk (sponge)
 	db.Update(NewWithNodeSet(nodes))
 	db.Commit(root, false)
@@ -1114,7 +1101,7 @@ func benchmarkDerefRootFixedSize(b *testing.B, addresses [][20]byte, accounts []
 		trie.Update(crypto.Keccak256(addresses[i][:]), accounts[i])
 	}
 	h := trie.Hash()
-	_, nodes, _ := trie.Commit(false)
+	_, nodes := trie.Commit(false)
 	triedb.Update(NewWithNodeSet(nodes))
 	b.StartTimer()
 	triedb.Dereference(h)

--- a/trie/util_test.go
+++ b/trie/util_test.go
@@ -69,7 +69,7 @@ func TestTrieTracer(t *testing.T) {
 	}
 
 	// Commit the changes and re-create with new root
-	root, nodes, _ := trie.Commit(false)
+	root, nodes := trie.Commit(false)
 	if err := db.Update(NewWithNodeSet(nodes)); err != nil {
 		t.Fatal(err)
 	}
@@ -154,7 +154,7 @@ func TestTrieTracePrevValue(t *testing.T) {
 	}
 
 	// Commit the changes and re-create with new root
-	root, nodes, _ := trie.Commit(false)
+	root, nodes := trie.Commit(false)
 	if err := db.Update(NewWithNodeSet(nodes)); err != nil {
 		t.Fatal(err)
 	}
@@ -261,10 +261,7 @@ func TestDeleteAll(t *testing.T) {
 	for _, val := range vals {
 		trie.Update([]byte(val.k), []byte(val.v))
 	}
-	root, set, err := trie.Commit(false)
-	if err != nil {
-		t.Fatal(err)
-	}
+	root, set := trie.Commit(false)
 	if err := db.Update(NewWithNodeSet(set)); err != nil {
 		t.Fatal(err)
 	}
@@ -288,10 +285,7 @@ func TestDeleteAll(t *testing.T) {
 	for _, val := range vals {
 		trie.Delete([]byte(val.k))
 	}
-	root, set, err = trie.Commit(false)
-	if err != nil {
-		t.Fatalf("Failed to delete trie %v", err)
-	}
+	root, set = trie.Commit(false)
 	if root != emptyRoot {
 		t.Fatalf("Invalid trie root %v", root)
 	}


### PR DESCRIPTION
I started investigating, due to https://github.com/ethereum/go-ethereum/pull/26637#discussion_r1099761367 ,  how/why a `Commit` operation could return an error, and found the answer to be: "Apparently it can't". 

This PR removes the error-return. Testing it out