### PR TITLE
common/prque, eth/downloader: fix timeout resurrection panic

### DIFF
--- a/common/prque/sstack.go
+++ b/common/prque/sstack.go
@@ -79,6 +79,9 @@ func (s *sstack[P, V]) Pop() (res any) {
 		s.active = s.blocks[s.size/blockSize]
 	}
 	res, s.active[s.offset] = s.active[s.offset], nil
+	if s.setIndex != nil {
+		s.setIndex(res.(*item[P, V]).value, -1)
+	}
 	return
 }
 

--- a/common/prque/sstack.go
+++ b/common/prque/sstack.go
@@ -79,9 +79,6 @@ func (s *sstack[P, V]) Pop() (res any) {
 		s.active = s.blocks[s.size/blockSize]
 	}
 	res, s.active[s.offset] = s.active[s.offset], nil
-	if s.setIndex != nil {
-		s.setIndex(res.(*item[P, V]).value, -1)
-	}
 	return
 }
 

--- a/eth/downloader/fetchers_concurrent.go
+++ b/eth/downloader/fetchers_concurrent.go
@@ -280,13 +280,14 @@ func (d *Downloader) concurrentFetch(queue typedQueue, beaconMode bool) error {
 			// overloading it further.
 			delete(pending, req.Peer)
 			stales[req.Peer] = req
-			delete(ordering, req)
 
-			timeouts.Pop()
+			timeouts.Pop() // Popping an item will reorder indices in `ordering`, delete after, otherwise will resurrect!
 			if timeouts.Size() > 0 {
 				_, exp := timeouts.Peek()
 				timeout.Reset(time.Until(time.Unix(0, -exp)))
 			}
+			delete(ordering, req)
+
 			// New timeout potentially set if there are more requests pending,
 			// reschedule the failed one to a free peer
 			fails := queue.unreserve(req.Peer)


### PR DESCRIPTION
There was a funky event ordering issue in the downloader, which was papered over with some `-1` indexing hack in the prque (emit -1 for a deleted item and ignore removing -1 index from the queue).

The issue was that the index updater set a new value for `ordering` when timeouts were shuffled in the priority queue, but in the code this PR fixes, the `ordering` was first deleted and only then the matching timeout popped. However, popping an item entails internal reorgs, so it actually resurrected the `ordering` item.

The original `-1` hack fixed this by resurrecting a value of `-1` in the end, which eventually got silently ignored by the `prque.Remove`. By changing the removal order to first pop the timeout (causing index changes) and only afterwards delete the `ordering`, there are no more weird resurrection and no more need for the `-1` hack.