### PR TITLE
les, common/prque: do not call setIndex(item, -1) when removing item

### DIFF
--- a/common/prque/lazyqueue.go
+++ b/common/prque/lazyqueue.go
@@ -182,14 +182,14 @@ func (q *LazyQueue[P, V]) Size() int {
 
 // setIndex0 translates internal queue item index to the virtual index space of LazyQueue
 func (q *LazyQueue[P, V]) setIndex0(data V, index int) {
-	if index == -1 {
-		q.setIndex(data, -1)
-	} else {
+	if index != -1 {
 		q.setIndex(data, index+index)
 	}
 }
 
 // setIndex1 translates internal queue item index to the virtual index space of LazyQueue
 func (q *LazyQueue[P, V]) setIndex1(data V, index int) {
-	q.setIndex(data, index+index+1)
+	if index != -1 {
+		q.setIndex(data, index+index+1)
+	}
 }

--- a/common/prque/sstack.go
+++ b/common/prque/sstack.go
@@ -79,9 +79,6 @@ func (s *sstack[P, V]) Pop() (res any) {
 		s.active = s.blocks[s.size/blockSize]
 	}
 	res, s.active[s.offset] = s.active[s.offset], nil
-	if s.setIndex != nil {
-		s.setIndex(res.(*item[P, V]).value, -1)
-	}
 	return
 }
 

--- a/les/flowcontrol/manager.go
+++ b/les/flowcontrol/manager.go
@@ -290,6 +290,7 @@ func (cm *ClientManager) updateRecharge(now mclock.AbsTime) {
 		dt := now - lastUpdate
 		// fetch the client that finishes first
 		rcqNode := cm.rcQueue.PopItem() // if sumRecharge > 0 then the queue cannot be empty
+		rcqNode.queueIndex = -1
 		// check whether it has already finished
 		dtNext := mclock.AbsTime(float64(rcqNode.rcFullIntValue-cm.rcLastIntValue) / bonusRatio)
 		if dt < dtNext {
@@ -356,6 +357,7 @@ func (cm *ClientManager) updateNodeRc(node *ClientNode, bvc int64, params *Serve
 		cm.sumRecharge += node.params.MinRecharge
 		if node.queueIndex != -1 {
 			cm.rcQueue.Remove(node.queueIndex)
+			node.queueIndex = -1
 		}
 		node.rcLastIntValue = cm.rcLastIntValue
 		node.rcFullIntValue = cm.rcLastIntValue + (int64(node.params.BufLimit)-node.corrBufValue)*FixedPointMultiplier/int64(node.params.MinRecharge)

--- a/les/vflux/server/prioritypool.go
+++ b/les/vflux/server/prioritypool.go
@@ -294,9 +294,11 @@ func (pp *priorityPool) inactivePriority(p *ppNodeInfo) int64 {
 func (pp *priorityPool) removeFromQueues(c *ppNodeInfo) {
 	if c.activeIndex >= 0 {
 		pp.activeQueue.Remove(c.activeIndex)
+		c.activeIndex = -1
 	}
 	if c.inactiveIndex >= 0 {
 		pp.inactiveQueue.Remove(c.inactiveIndex)
+		c.inactiveIndex = -1
 	}
 }
 
@@ -421,6 +423,7 @@ func (pp *priorityPool) enforceLimits() (*ppNodeInfo, int64) {
 		maxActivePriority int64
 	)
 	pp.activeQueue.MultiPop(func(c *ppNodeInfo, priority int64) bool {
+		c.activeIndex = -1
 		lastNode = c
 		pp.setTempState(c)
 		maxActivePriority = priority
@@ -502,6 +505,7 @@ func (pp *priorityPool) updateFlags(updates []capUpdate) {
 func (pp *priorityPool) tryActivate(commit bool) []capUpdate {
 	for pp.inactiveQueue.Size() > 0 {
 		c := pp.inactiveQueue.PopItem()
+		c.inactiveIndex = -1
 		pp.setTempState(c)
 		pp.setTempBias(c, pp.activeBias)
 		pp.setTempCapacity(c, pp.minCap)


### PR DESCRIPTION
This PR changes `Prque` behavior so that it does not call the `setIndex` callback with -1 parameter when removing an item.
Note: I am not sure whether this PR is an overall improvement, I leave that to be judged by @karalabe :) While silently ignoring a -1 index in `Remove` was indeed a paper-over hack and I agree with removing it, calling `setIndex` with -1 was kind of convenient since in multiple use cases I needed to keep track of whether an item is in the queue or not and it was nice that `Prque` automatically set the queue index field of the removed item to -1. Of course it is possible to keep track of removals on the caller side but the best way to do so in my use cases was to manually set the index to -1 after popping/removing an item. So I'm not sure if the code is overall cleaner now but on the other hand it does remove a special case from `Prque`. I'm fine with either version or alternative suggestions are also welcome but I currently don't have a more elegant idea.