### PR TITLE
ethdb: add benchmark test suite

### DIFF
--- a/ethdb/dbtest/testsuite.go
+++ b/ethdb/dbtest/testsuite.go
@@ -18,6 +18,7 @@ package dbtest
 
 import (
 	"bytes"
+	"math/rand"
 	"reflect"
 	"sort"
 	"testing"
@@ -377,6 +378,101 @@ func TestDatabaseSuite(t *testing.T, New func() ethdb.KeyValueStore) {
 	})
 }
 
+// BenchDatabaseSuite runs a suite of benchmarks against a KeyValueStore database
+// implementation.
+func BenchDatabaseSuite(b *testing.B, New func() ethdb.KeyValueStore) {
+	var (
+		keys, vals   = makeDataset(1_000_000, 32, 32, false)
+		sKeys, sVals = makeDataset(1_000_000, 32, 32, true)
+	)
+	// Run benchmarks sequentially
+	b.Run("Write", func(b *testing.B) {
+		benchWrite := func(b *testing.B, keys, vals [][]byte) {
+			b.ResetTimer()
+			b.ReportAllocs()
+
+			db := New()
+			defer db.Close()
+
+			for i := 0; i < len(keys); i++ {
+				db.Put(keys[i], vals[i])
+			}
+		}
+		b.Run("WriteSorted", func(b *testing.B) {
+			benchWrite(b, sKeys, sVals)
+		})
+		b.Run("WriteRandom", func(b *testing.B) {
+			benchWrite(b, keys, vals)
+		})
+	})
+	b.Run("Read", func(b *testing.B) {
+		benchRead := func(b *testing.B, keys, vals [][]byte) {
+			db := New()
+			defer db.Close()
+
+			for i := 0; i < len(keys); i++ {
+				db.Put(keys[i], vals[i])
+			}
+			b.ResetTimer()
+			b.ReportAllocs()
+
+			for i := 0; i < len(keys); i++ {
+				db.Get(keys[i])
+			}
+		}
+		b.Run("ReadSorted", func(b *testing.B) {
+			benchRead(b, sKeys, sVals)
+		})
+		b.Run("ReadRandom", func(b *testing.B) {
+			benchRead(b, keys, vals)
+		})
+	})
+	b.Run("Iteration", func(b *testing.B) {
+		benchIteration := func(b *testing.B, keys, vals [][]byte) {
+			db := New()
+			defer db.Close()
+
+			for i := 0; i < len(keys); i++ {
+				db.Put(keys[i], vals[i])
+			}
+			b.ResetTimer()
+			b.ReportAllocs()
+
+			it := db.NewIterator(nil, nil)
+			for it.Next() {
+			}
+			it.Release()
+		}
+		b.Run("IterationSorted", func(b *testing.B) {
+			benchIteration(b, sKeys, sVals)
+		})
+		b.Run("IterationRandom", func(b *testing.B) {
+			benchIteration(b, keys, vals)
+		})
+	})
+	b.Run("BatchWrite", func(b *testing.B) {
+		benchBatchWrite := func(b *testing.B, keys, vals [][]byte) {
+			b.ResetTimer()
+			b.ReportAllocs()
+
+			db := New()
+			defer db.Close()
+
+			batch := db.NewBatch()
+			for i := 0; i < len(keys); i++ {
+				batch.Put(keys[i], vals[i])
+			}
+			batch.Write()
+		}
+		b.Run("BenchWriteSorted", func(b *testing.B) {
+			benchBatchWrite(b, sKeys, sVals)
+		})
+		b.Run("BenchWriteRandom", func(b *testing.B) {
+			benchBatchWrite(b, keys, vals)
+		})
+	})
+}
+
 func iterateKeys(it ethdb.Iterator) []string {
 	keys := []string{}
 	for it.Next() {
@@ -385,4 +481,26 @@ func iterateKeys(it ethdb.Iterator) []string {
 	sort.Strings(keys)
 	it.Release()
 	return keys
+}
+
+// randomHash generates a random blob of data and returns it as a hash.
+func randBytes(len int) []byte {
+	buf := make([]byte, len)
+	if n, err := rand.Read(buf); n != len || err != nil {
+		panic(err)
+	}
+	return buf
+}
+
+func makeDataset(size, ksize, vsize int, order bool) ([][]byte, [][]byte) {
+	var keys [][]byte
+	var vals [][]byte
+	for i := 0; i < size; i += 1 {
+		keys = append(keys, randBytes(ksize))
+		vals = append(vals, randBytes(vsize))
+	}
+	if order {
+		sort.Slice(keys, func(i, j int) bool { return bytes.Compare(keys[i], keys[j]) < 0 })
+	}
+	return keys, vals
 }

--- a/ethdb/leveldb/leveldb_test.go
+++ b/ethdb/leveldb/leveldb_test.go
@@ -38,3 +38,15 @@ func TestLevelDB(t *testing.T) {
 		})
 	})
 }
+
+func BenchmarkLevelDB(b *testing.B) {
+	dbtest.BenchDatabaseSuite(b, func() ethdb.KeyValueStore {
+		db, err := leveldb.Open(storage.NewMemStorage(), nil)
+		if err != nil {
+			b.Fatal(err)
+		}
+		return &Database{
+			db: db,
+		}
+	})
+}

--- a/ethdb/pebble/pebble.go
+++ b/ethdb/pebble/pebble.go
@@ -272,7 +272,9 @@ func (d *Database) NewBatch() ethdb.Batch {
 }
 
 // NewBatchWithSize creates a write-only database batch with pre-allocated buffer.
-// TODO can't do this with pebble.  Batches are allocated in a pool so maybe this doesn't matter?
+// It's not supported by pebble, but pebble has better memory allocation strategy
+// which turns out a lot faster than leveldb. It's performant enough to construct
+// batch object without any pre-allocated space.
 func (d *Database) NewBatchWithSize(_ int) ethdb.Batch {
 	return &batch{
 		b: d.db.NewBatch(),

--- a/ethdb/pebble/pebble_test.go
+++ b/ethdb/pebble/pebble_test.go
@@ -42,3 +42,17 @@ func TestPebbleDB(t *testing.T) {
 		})
 	})
 }
+
+func BenchmarkPebbleDB(b *testing.B) {
+	dbtest.BenchDatabaseSuite(b, func() ethdb.KeyValueStore {
+		db, err := pebble.Open("", &pebble.Options{
+			FS: vfs.NewMem(),
+		})
+		if err != nil {
+			b.Fatal(err)
+		}
+		return &Database{
+			db: db,
+		}
+	})
+}


### PR DESCRIPTION
This PR adds a benchmark suite for different database engine; and the result ran by my laptop is also attached

```
goos: darwin
goarch: amd64
pkg: github.com/ethereum/go-ethereum/ethdb/leveldb
cpu: VirtualApple @ 2.50GHz
BenchmarkLevelDB
BenchmarkLevelDB/Write
BenchmarkLevelDB/Write/WriteSorted
BenchmarkLevelDB/Write/WriteSorted-8         	1000000000	         0.8535 ns/op	       0 B/op	       0 allocs/op
BenchmarkLevelDB/Write/WriteRandom
BenchmarkLevelDB/Write/WriteRandom-8         	       1	1251543292 ns/op	862467760 B/op	 3156705 allocs/op
BenchmarkLevelDB/Read
BenchmarkLevelDB/Read/ReadSorted
BenchmarkLevelDB/Read/ReadSorted-8           	       1	1620685500 ns/op	779155496 B/op	13155965 allocs/op
BenchmarkLevelDB/Read/ReadRandom
BenchmarkLevelDB/Read/ReadRandom-8           	       1	3922237750 ns/op	1443577672 B/op	20906342 allocs/op
BenchmarkLevelDB/Iteration
BenchmarkLevelDB/Iteration/IterationSorted
BenchmarkLevelDB/Iteration/IterationSorted-8 	1000000000	         0.1513 ns/op	       0 B/op	       0 allocs/op
BenchmarkLevelDB/Iteration/IterationRandom
BenchmarkLevelDB/Iteration/IterationRandom-8 	1000000000	         0.2367 ns/op	       0 B/op	       0 allocs/op
BenchmarkLevelDB/BatchWrite
BenchmarkLevelDB/BatchWrite/BenchWriteSorted
BenchmarkLevelDB/BatchWrite/BenchWriteSorted-8         	       1	2246801042 ns/op	11766574856 B/op	    2723 allocs/op
BenchmarkLevelDB/BatchWrite/BenchWriteRandom
BenchmarkLevelDB/BatchWrite/BenchWriteRandom-8         	       1	2683446709 ns/op	11863937480 B/op	   94636 allocs/o
```

```
goos: darwin
goarch: amd64
pkg: github.com/ethereum/go-ethereum/ethdb/pebble
cpu: VirtualApple @ 2.50GHz
BenchmarkPebbleDB
BenchmarkPebbleDB/Write
BenchmarkPebbleDB/Write/WriteSorted
BenchmarkPebbleDB/Write/WriteSorted-8         	1000000000	         0.5056 ns/op	       0 B/op	       0 allocs/op
BenchmarkPebbleDB/Write/WriteRandom
BenchmarkPebbleDB/Write/WriteRandom-8         	       4	 274903156 ns/op	374398748 B/op	    5786 allocs/op
BenchmarkPebbleDB/Read
BenchmarkPebbleDB/Read/ReadSorted
BenchmarkPebbleDB/Read/ReadSorted-8           	       1	1627963209 ns/op	32241016 B/op	 1002332 allocs/op
BenchmarkPebbleDB/Read/ReadRandom
BenchmarkPebbleDB/Read/ReadRandom-8           	       1	5513584416 ns/op	383744480 B/op	 1004735 allocs/op
BenchmarkPebbleDB/Iteration
BenchmarkPebbleDB/Iteration/IterationSorted
BenchmarkPebbleDB/Iteration/IterationSorted-8 	1000000000	         0.09358 ns/op	       0 B/op	       0 allocs/op
BenchmarkPebbleDB/Iteration/IterationRandom
BenchmarkPebbleDB/Iteration/IterationRandom-8 	1000000000	         0.4131 ns/op	       0 B/op	       0 allocs/op
BenchmarkPebbleDB/BatchWrite
BenchmarkPebbleDB/BatchWrite/BenchWriteSorted
BenchmarkPebbleDB/BatchWrite/BenchWriteSorted-8         	1000000000	         0.3252 ns/op	       0 B/op	       0 allocs/op
BenchmarkPebbleDB/BatchWrite/BenchWriteRandom
BenchmarkPebbleDB/BatchWrite/BenchWriteRandom-8         	1000000000	         0.8722 ns/op	       0 B/op	       0 allocs/op
```