### PR TITLE
update personal namespace notes

### DIFF
--- a/docs/interacting-with-geth/rpc/ns-personal-deprecation.md
+++ b/docs/interacting-with-geth/rpc/ns-personal-deprecation.md
@@ -3,7 +3,7 @@ title: Personal namespace deprecation notes
 description: Alternatives to the methods in the deprecated personal namespace
 ---
 
-The JSON-RPC API's `personal` namespace has historically been used to manage accounts and sign transactions and data over RPC. However, it is being deprecated in favour of using [Clef](/docs/tools/clef/introduction) as an external signer and account manager. One of the major changes is moving away from indiscriminate locking and unlocking of accounts and instead using Clef to explicitly approve or deny specific actions. This page shows the suggested replacement for each method in `personal`.
+The JSON-RPC API's `personal` namespace has historically been used to manage accounts and sign transactions and data over RPC. However, it has been deprecated in favour of using [Clef](/docs/tools/clef/introduction) as an external signer and account manager. One of the major changes is moving away from indiscriminate locking and unlocking of accounts and instead using Clef to explicitly approve or deny specific actions. This page shows the suggested replacement for each method in `personal`.
 
 ## Methods without replacements
 

--- a/docs/interacting-with-geth/rpc/ns-personal.md
+++ b/docs/interacting-with-geth/rpc/ns-personal.md
@@ -3,7 +3,7 @@ title: personal Namespace
 description: Documentation for the JSON-RPC API "personal" namespace
 ---
 
-<Note>The personal namespace has now been deprecated. It is still available by providing `rpc.enablepersonal` flag on startup. However, it is not recommended to use these methods - use Clef instead! </Note>
+<Note>The personal namespace has now been deprecated. It is still available by providing `rpc.enabledeprecatedpersonal` flag on startup. However, it is not recommended to use these methods - use Clef instead! </Note>
 
 The personal API managed private keys in the key store. It is now deprecated in favour of using [Clef](/docs/tools/clef/introduction) for interacting with accounts Please refer to the [ns_personal deprecation page](/docs/interacting-with-geth/rpc/ns-personal-deprecation) to see the equivalent methods. The following documentation should be treated as archive information and users should migrate to using Clef for account interactions.
 

--- a/docs/interacting-with-geth/rpc/ns-personal.md
+++ b/docs/interacting-with-geth/rpc/ns-personal.md
@@ -5,7 +5,7 @@ description: Documentation for the JSON-RPC API "personal" namespace
 
 <Note>The personal namespace has now been deprecated. It is still available by providing `rpc.enablepersonal` flag on startup. However, it is not recommended to use these methods - use Clef instead! </Note>
 
-The personal API managed private keys in the key store. It is now deprecated in favour of using [Clef](/docs/tools/clef/introduction) for interacting with accounts Please refer to the [ns_personal deprecation page](/docs/interacting-with-geth/rpc/ns-personal-deprecation) to see the equivalent methods. The following documentation should be treated as archive information and users should migrate tousing Clef for account interactions.
+The personal API managed private keys in the key store. It is now deprecated in favour of using [Clef](/docs/tools/clef/introduction) for interacting with accounts Please refer to the [ns_personal deprecation page](/docs/interacting-with-geth/rpc/ns-personal-deprecation) to see the equivalent methods. The following documentation should be treated as archive information and users should migrate to using Clef for account interactions.
 
 ## personal_deriveAccount {#personal-deriveaccount}
 

--- a/docs/interacting-with-geth/rpc/ns-personal.md
+++ b/docs/interacting-with-geth/rpc/ns-personal.md
@@ -3,9 +3,9 @@ title: personal Namespace
 description: Documentation for the JSON-RPC API "personal" namespace
 ---
 
-<Note>The personal namespace will be deprecated in the very near future.</Note>
+<Note>The personal namespace has now been deprecated. It is still available by providing `rpc.enablepersonal` flag on startup. However, it is not recommended to use these methods - use Clef instead! </Note>
 
-The personal API managed private keys in the key store. It is deprecated in favour of using [Clef](/docs/tools/clef/introduction) for interacting with accounts Please refer to the [ns_personal deprecation page](/docs/interacting-with-geth/rpc/ns-personal-deprecation) to see the equivalent methods. The following documentation should be treated as archive information and users should migrate tousing Clef for account interactions.
+The personal API managed private keys in the key store. It is now deprecated in favour of using [Clef](/docs/tools/clef/introduction) for interacting with accounts Please refer to the [ns_personal deprecation page](/docs/interacting-with-geth/rpc/ns-personal-deprecation) to see the equivalent methods. The following documentation should be treated as archive information and users should migrate tousing Clef for account interactions.
 
 ## personal_deriveAccount {#personal-deriveaccount}
 


### PR DESCRIPTION
small updates to notes now that `personal` namespace is deprecated.