### PR TITLE
tests/fuzzers: supply gnark multiexp config, fixes #26669

### DIFF
--- a/tests/fuzzers/bls12381/bls12381_fuzz.go
+++ b/tests/fuzzers/bls12381/bls12381_fuzz.go
@@ -218,7 +218,7 @@ func FuzzCrossG1MultiExp(data []byte) int {
 
 	// gnark multi exp
 	cp := new(gnark.G1Affine)
-	cp.MultiExp(gnarkPoints, gnarkScalars, ecc.MultiExpConfig{NbTasks: 1})
+	cp.MultiExp(gnarkPoints, gnarkScalars, ecc.MultiExpConfig{})
 
 	// compare result
 	if !(bytes.Equal(cp.Marshal(), g1.ToBytes(&kp))) {

--- a/tests/fuzzers/bls12381/bls12381_fuzz.go
+++ b/tests/fuzzers/bls12381/bls12381_fuzz.go
@@ -26,6 +26,7 @@ import (
 	"io"
 	"math/big"
 
+	"github.com/consensys/gnark-crypto/ecc"
 	gnark "github.com/consensys/gnark-crypto/ecc/bls12-381"
 	"github.com/consensys/gnark-crypto/ecc/bls12-381/fp"
 	"github.com/consensys/gnark-crypto/ecc/bls12-381/fr"
@@ -198,7 +199,7 @@ func FuzzCrossG1MultiExp(data []byte) int {
 		}
 		gethScalars = append(gethScalars, s)
 		var gnarkScalar = &fr.Element{}
-		gnarkScalar = gnarkScalar.SetBigInt(s).FromMont()
+		gnarkScalar = gnarkScalar.SetBigInt(s)
 		gnarkScalars = append(gnarkScalars, *gnarkScalar)
 
 		gethPoints = append(gethPoints, new(bls12381.PointG1).Set(kp1))
@@ -217,7 +218,7 @@ func FuzzCrossG1MultiExp(data []byte) int {
 
 	// gnark multi exp
 	cp := new(gnark.G1Affine)
-	cp.MultiExp(gnarkPoints, gnarkScalars)
+	cp.MultiExp(gnarkPoints, gnarkScalars, ecc.MultiExpConfig{NbTasks: 1})
 
 	// compare result
 	if !(bytes.Equal(cp.Marshal(), g1.ToBytes(&kp))) {


### PR DESCRIPTION
I _think_ this fixes https://github.com/ethereum/go-ethereum/issues/26669 . There may be other issues too, related to `blst`, but we can tackle that later in that case. 