### PR TITLE
cmd, consensus, core, eth, tests: return memorized state error

### DIFF
--- a/cmd/evm/internal/t8ntool/execution.go
+++ b/cmd/evm/internal/t8ntool/execution.go
@@ -200,7 +200,9 @@ func (pre *Prestate) Apply(vmConfig vm.Config, chainConfig *params.ChainConfig,
 			if chainConfig.IsByzantium(vmContext.BlockNumber) {
 				statedb.Finalise(true)
 			} else {
-				root = statedb.IntermediateRoot(chainConfig.IsEIP158(vmContext.BlockNumber)).Bytes()
+				// the ignored error will eventually be captured by commit.
+				hash, _ := statedb.IntermediateRoot(chainConfig.IsEIP158(vmContext.BlockNumber))
+				root = hash.Bytes()
 			}
 
 			// Create a new receipt for the transaction, storing the intermediate root and
@@ -231,7 +233,6 @@ func (pre *Prestate) Apply(vmConfig vm.Config, chainConfig *params.ChainConfig,
 
 		txIndex++
 	}
-	statedb.IntermediateRoot(chainConfig.IsEIP158(vmContext.BlockNumber))
 	// Add mining reward? (-1 means rewards are disabled)
 	if miningReward >= 0 {
 		// Add mining reward. The mining reward may be `0`, which only makes a difference in the cases

--- a/cmd/evm/runner.go
+++ b/cmd/evm/runner.go
@@ -274,8 +274,11 @@ func runCmd(ctx *cli.Context) error {
 	output, leftOverGas, stats, err := timedExec(bench, execFunc)
 
 	if ctx.Bool(DumpFlag.Name) {
-		statedb.Commit(true)
-		statedb.IntermediateRoot(true)
+		_, err := statedb.Commit(true)
+		if err != nil {
+			fmt.Println("failed to commit state changes: ", err)
+			os.Exit(1)
+		}
 		fmt.Println(string(statedb.Dump(nil)))
 	}
 

--- a/consensus/beacon/consensus.go
+++ b/consensus/beacon/consensus.go
@@ -341,9 +341,6 @@ func (beacon *Beacon) Finalize(chain consensus.ChainHeaderReader, header *types.
 		amount = amount.Mul(amount, big.NewInt(params.GWei))
 		state.AddBalance(w.Address, amount)
 	}
-	// The block reward is no longer handled here. It's done by the
-	// external consensus engine.
-	header.Root = state.IntermediateRoot(true)
 }
 
 // FinalizeAndAssemble implements consensus.Engine, setting the final state and
@@ -367,6 +364,15 @@ func (beacon *Beacon) FinalizeAndAssemble(chain consensus.ChainHeaderReader, hea
 	}
 	// Finalize and assemble the block.
 	beacon.Finalize(chain, header, state, txs, uncles, withdrawals)
+
+	// Assign the final state root to header.
+	root, err := state.IntermediateRoot(true)
+	if err != nil {
+		return nil, err
+	}
+	header.Root = root
+
+	// Assemble and return the final block.
 	return types.NewBlockWithWithdrawals(header, txs, uncles, receipts, withdrawals, trie.NewStackTrie(nil)), nil
 }
 

--- a/consensus/consensus.go
+++ b/consensus/consensus.go
@@ -84,16 +84,16 @@ type Engine interface {
 	// rules of a particular engine. The changes are executed inline.
 	Prepare(chain ChainHeaderReader, header *types.Header) error
 
-	// Finalize runs any post-transaction state modifications (e.g. block rewards)
-	// but does not assemble the block.
+	// Finalize runs any post-transaction state modifications (e.g. block rewards
+	// or process withdrawals) but does not assemble the block.
 	//
-	// Note: The block header and state database might be updated to reflect any
-	// consensus rules that happen at finalization (e.g. block rewards).
+	// Note: The state database might be updated to reflect any consensus rules
+	// that happen at finalization.
 	Finalize(chain ChainHeaderReader, header *types.Header, state *state.StateDB, txs []*types.Transaction,
 		uncles []*types.Header, withdrawals []*types.Withdrawal)
 
 	// FinalizeAndAssemble runs any post-transaction state modifications (e.g. block
-	// rewards) and assembles the final block.
+	// rewards or process withdrawals) and assembles the final block.
 	//
 	// Note: The block header and state database might be updated to reflect any
 	// consensus rules that happen at finalization (e.g. block rewards).

--- a/core/block_validator.go
+++ b/core/block_validator.go
@@ -109,7 +109,11 @@ func (v *BlockValidator) ValidateState(block *types.Block, statedb *state.StateD
 	}
 	// Validate the state root against the received state root and throw
 	// an error if they don't match.
-	if root := statedb.IntermediateRoot(v.config.IsEIP158(header.Number)); header.Root != root {
+	root, err := statedb.IntermediateRoot(v.config.IsEIP158(header.Number))
+	if err != nil {
+		return fmt.Errorf("failed to derive state root %v", err)
+	}
+	if header.Root != root {
 		return fmt.Errorf("invalid merkle root (remote: %x local: %x)", header.Root, root)
 	}
 	return nil

--- a/core/chain_makers.go
+++ b/core/chain_makers.go
@@ -352,8 +352,12 @@ func makeHeader(chain consensus.ChainReader, parent *types.Block, state *state.S
 	} else {
 		time = parent.Time() + 10 // block time is fixed at 10 seconds
 	}
+	root, err := state.IntermediateRoot(chain.Config().IsEIP158(parent.Number()))
+	if err != nil {
+		panic(err) // error shouldn't occur in tests.
+	}
 	header := &types.Header{
-		Root:       state.IntermediateRoot(chain.Config().IsEIP158(parent.Number())),
+		Root:       root,
 		ParentHash: parent.Hash(),
 		Coinbase:   parent.Coinbase(),
 		Difficulty: engine.CalcDifficulty(chain, time, &types.Header{

--- a/core/state/statedb_test.go
+++ b/core/state/statedb_test.go
@@ -54,7 +54,7 @@ func TestUpdateLeaks(t *testing.T) {
 		}
 	}
 
-	root := state.IntermediateRoot(false)
+	root, _ := state.IntermediateRoot(false)
 	if err := state.Database().TrieDB().Commit(root, false); err != nil {
 		t.Errorf("can not commit trie %v to persistent database", root.Hex())
 	}

--- a/core/state_processor.go
+++ b/core/state_processor.go
@@ -113,7 +113,11 @@ func applyTransaction(msg types.Message, config *params.ChainConfig, gp *GasPool
 	if config.IsByzantium(blockNumber) {
 		statedb.Finalise(true)
 	} else {
-		root = statedb.IntermediateRoot(config.IsEIP158(blockNumber)).Bytes()
+		hash, err := statedb.IntermediateRoot(config.IsEIP158(blockNumber))
+		if err != nil {
+			return nil, err
+		}
+		root = hash.Bytes()
 	}
 	*usedGas += result.UsedGas
 

--- a/core/vm/interface.go
+++ b/core/vm/interface.go
@@ -76,8 +76,6 @@ type StateDB interface {
 
 	AddLog(*types.Log)
 	AddPreimage(common.Hash, []byte)
-
-	ForEachStorage(common.Address, func(common.Hash, common.Hash) bool) error
 }
 
 // CallContext provides a basic interface for the EVM calling conventions. The EVM

--- a/eth/api_test.go
+++ b/eth/api_test.go
@@ -85,7 +85,7 @@ func TestAccountRange(t *testing.T) {
 		}
 	}
 	state.Commit(true)
-	root := state.IntermediateRoot(true)
+	root, _ := state.IntermediateRoot(true)
 
 	trie, err := statedb.OpenTrie(root)
 	if err != nil {

--- a/eth/tracers/api.go
+++ b/eth/tracers/api.go
@@ -570,7 +570,11 @@ func (api *API) IntermediateRoots(ctx context.Context, hash common.Hash, config 
 		}
 		// calling IntermediateRoot will internally call Finalize on the state
 		// so any modifications are written to the trie
-		roots = append(roots, statedb.IntermediateRoot(deleteEmptyObjects))
+		root, err := statedb.IntermediateRoot(deleteEmptyObjects)
+		if err == nil {
+			return nil, err // abort execution because of corrupted database
+		}
+		roots = append(roots, root)
 	}
 	return roots, nil
 }

--- a/tests/state_test.go
+++ b/tests/state_test.go
@@ -84,7 +84,11 @@ func TestState(t *testing.T) {
 					withTrace(t, test.gasLimit(subtest), func(vmconfig vm.Config) error {
 						snaps, statedb, err := test.Run(subtest, vmconfig, true)
 						if snaps != nil && statedb != nil {
-							if _, err := snaps.Journal(statedb.IntermediateRoot(false)); err != nil {
+							root, err := statedb.IntermediateRoot(false)
+							if err != nil {
+								return err
+							}
+							if _, err := snaps.Journal(root); err != nil {
 								return err
 							}
 						}

--- a/tests/state_test_util.go
+++ b/tests/state_test_util.go
@@ -273,9 +273,10 @@ func (t *StateTest) RunNoVerify(subtest StateSubtest, vmconfig vm.Config, snapsh
 	//   the coinbase gets no txfee, so isn't created, and thus needs to be touched
 	statedb.AddBalance(block.Coinbase(), new(big.Int))
 	// Commit block
-	statedb.Commit(config.IsEIP158(block.Number()))
-	// And _now_ get the state root
-	root := statedb.IntermediateRoot(config.IsEIP158(block.Number()))
+	root, err := statedb.Commit(config.IsEIP158(block.Number()))
+	if err != nil {
+		return nil, nil, common.Hash{}, err
+	}
 	return snaps, statedb, root, err
 }
 


### PR DESCRIPTION
This PR bubble up the memorized database failure in stateDB and report it in critical places(e.g. block validation).