### PR TITLE
ci: add codecov integration to appveyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -26,7 +26,9 @@ for:
       - go run build/ci.go lint
       - go run build/ci.go install -dlgo
     test_script:
-      - go run build/ci.go test -dlgo -coverage
+      - go run build/ci.go test -dlgo -coverage -coverprofile=coverage.txt -covermode=count
+    codecov_uplaod:
+      - bash <(curl -s https://codecov.io/bash)
 
   # linux/386 is disabled.
   - matrix:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -26,7 +26,7 @@ for:
       - go run build/ci.go lint
       - go run build/ci.go install -dlgo
     test_script:
-      - go run build/ci.go test -dlgo -coverage -coverprofile=coverage.txt -covermode=count
+      - go run build/ci.go test -dlgo -coverage
       - bash <(curl -s https://codecov.io/bash)
 
   # linux/386 is disabled.
@@ -55,4 +55,4 @@ for:
       - go run build/ci.go archive -arch %GETH_ARCH% -type zip -signer WINDOWS_SIGNING_KEY -upload gethstore/builds
       - go run build/ci.go nsis -arch %GETH_ARCH% -signer WINDOWS_SIGNING_KEY -upload gethstore/builds
     test_script:
-      - go run build/ci.go test -dlgo -arch %GETH_ARCH% -cc %GETH_CC% -coverage
+      - go run build/ci.go test -dlgo -arch %GETH_ARCH% -cc %GETH_CC%

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -27,7 +27,6 @@ for:
       - go run build/ci.go install -dlgo
     test_script:
       - go run build/ci.go test -dlgo -coverage -coverprofile=coverage.txt -covermode=count
-    codecov_uplaod:
       - bash <(curl -s https://codecov.io/bash)
 
   # linux/386 is disabled.

--- a/build/ci.go
+++ b/build/ci.go
@@ -297,7 +297,7 @@ func doTest(cmdline []string) {
 	// and some tests run into timeouts under load.
 	gotest.Args = append(gotest.Args, "-p", "1")
 	if *coverage {
-		gotest.Args = append(gotest.Args, "-covermode=atomic", "-cover")
+		gotest.Args = append(gotest.Args, "-covermode=count", "-coverprofile=coverage.out")
 	}
 	if *verbose {
 		gotest.Args = append(gotest.Args, "-v")


### PR DESCRIPTION
This PR would upload coverage data to codecov.io. 
This PR executes 'bash scripts from the internet' on appveyor infra, which I think we should _avoid_ if we have any secrets in the appveyor ENV. As far as I know, we do not, and thus this should be fine. Otherwise, we should do it differently (e.g. pin the script) 