### PR TITLE
core/types: manually set withdrawals if withdrawalHash is emptyRootHash

### DIFF
--- a/core/genesis.go
+++ b/core/genesis.go
@@ -465,10 +465,12 @@ func (g *Genesis) ToBlock() *types.Block {
 			head.BaseFee = new(big.Int).SetUint64(params.InitialBaseFee)
 		}
 	}
+	var withdrawals []*types.Withdrawal
 	if g.Config != nil && g.Config.IsShanghai(g.Timestamp) {
 		head.WithdrawalsHash = &types.EmptyRootHash
+		withdrawals = make([]*types.Withdrawal, 0)
 	}
-	return types.NewBlock(head, nil, nil, nil, trie.NewStackTrie(nil))
+	return types.NewBlock(head, nil, nil, nil, trie.NewStackTrie(nil)).WithWithdrawals(withdrawals)
 }
 
 // Commit writes the block and state of a genesis specification to the database.

--- a/core/types/block.go
+++ b/core/types/block.go
@@ -424,6 +424,15 @@ func (b *Block) WithWithdrawals(withdrawals []*Withdrawal) *Block {
 		b.withdrawals = make([]*Withdrawal, len(withdrawals))
 		copy(b.withdrawals, withdrawals)
 	}
+	// This is a weird workaround.
+	// Both [] and nil hash to the same emptyRootHash on DeriveSHA.
+	// Thus a node could set withdrawals to nil and withdrawalHash to emptyRootHash and
+	// the block would pass the verification. We require an empty withdrawals list
+	// during block processing though, so the block will be marked as bad even though
+	// the only bad thing is nil instead of [] withdrawals.
+	if b.header.WithdrawalsHash != nil && *b.header.WithdrawalsHash == EmptyRootHash {
+		b.withdrawals = make(Withdrawals, 0)
+	}
 	return b
 }
 

--- a/core/types/block.go
+++ b/core/types/block.go
@@ -430,7 +430,7 @@ func (b *Block) WithWithdrawals(withdrawals []*Withdrawal) *Block {
 	// the block would pass the verification. We require an empty withdrawals list
 	// during block processing though, so the block will be marked as bad even though
 	// the only bad thing is nil instead of [] withdrawals.
-	if b.header.WithdrawalsHash != nil && *b.header.WithdrawalsHash == EmptyRootHash {
+	if withdrawals == nil && b.header.WithdrawalsHash != nil && *b.header.WithdrawalsHash == EmptyRootHash {
 		b.withdrawals = make(Withdrawals, 0)
 	}
 	return b

--- a/core/types/block.go
+++ b/core/types/block.go
@@ -424,15 +424,6 @@ func (b *Block) WithWithdrawals(withdrawals []*Withdrawal) *Block {
 		b.withdrawals = make([]*Withdrawal, len(withdrawals))
 		copy(b.withdrawals, withdrawals)
 	}
-	// This is a weird workaround.
-	// Both [] and nil hash to the same emptyRootHash on DeriveSHA.
-	// Thus a node could set withdrawals to nil and withdrawalHash to emptyRootHash and
-	// the block would pass the verification. We require an empty withdrawals list
-	// during block processing though, so the block will be marked as bad even though
-	// the only bad thing is nil instead of [] withdrawals.
-	if withdrawals == nil && b.header.WithdrawalsHash != nil && *b.header.WithdrawalsHash == EmptyRootHash {
-		b.withdrawals = make(Withdrawals, 0)
-	}
 	return b
 }
 

--- a/eth/downloader/queue.go
+++ b/eth/downloader/queue.go
@@ -783,6 +783,10 @@ func (q *queue) DeliverBodies(id string, txLists [][]*types.Transaction, txListH
 		if header.WithdrawalsHash == nil {
 			// discard any withdrawals if we don't have a withdrawal hash set
 			withdrawalLists[index] = nil
+		} else if *header.WithdrawalsHash == types.EmptyRootHash {
+			// if the withdrawal hash is the emptyRootHash,
+			// we expect withdrawals to be [] instead of nil
+			withdrawalLists[index] = make([]*types.Withdrawal, 0)
 		} else if withdrawalListHashes[index] != *header.WithdrawalsHash {
 			return errInvalidBody
 		}

--- a/eth/downloader/queue.go
+++ b/eth/downloader/queue.go
@@ -783,7 +783,7 @@ func (q *queue) DeliverBodies(id string, txLists [][]*types.Transaction, txListH
 		if header.WithdrawalsHash == nil {
 			// discard any withdrawals if we don't have a withdrawal hash set
 			withdrawalLists[index] = nil
-		} else if *header.WithdrawalsHash == types.EmptyRootHash {
+		} else if *header.WithdrawalsHash == types.EmptyRootHash && withdrawalLists[index] == nil {
 			// if the withdrawal hash is the emptyRootHash,
 			// we expect withdrawals to be [] instead of nil
 			withdrawalLists[index] = make([]*types.Withdrawal, 0)

--- a/eth/protocols/eth/handler_test.go
+++ b/eth/protocols/eth/handler_test.go
@@ -424,7 +424,7 @@ func testGetBlockBodies(t *testing.T, protocol uint) {
 			RequestId:         123,
 			BlockBodiesPacket: bodies,
 		}); err != nil {
-			t.Errorf("test %d: bodies mismatch: %v", i, err)
+			t.Fatalf("test %d: bodies mismatch: %v", i, err)
 		}
 	}
 }


### PR DESCRIPTION
This PR relaxes the encoding rules a bit which allows nodes to encode empty withdrawals as [] or nil. 