### PR TITLE
[website]: Update background color of active doc link

### DIFF
--- a/src/components/UI/docs/DocsLinks.tsx
+++ b/src/components/UI/docs/DocsLinks.tsx
@@ -74,7 +74,7 @@ export const DocsLinks: FC<Props> = ({ navLinks, toggleMobileAccordion }) => {
                       borderColor='primary'
                       w='100%'
                       bg={isSectionActive ? 'secondary' : 'bg'}
-                      color={isSectionActive ? 'body' : 'primary'}
+                      color={isSectionActive ? 'bg' : 'primary'}
                       _groupHover={{ background: 'primary', color: 'bg', textDecoration: 'none' }}
                     >
                       {to ? (


### PR DESCRIPTION
The active doc link is a bit hard to read currently

### Before this commit
<img width="346" alt="Screen Shot 2023-02-14 at 10 28 29" src="https://user-images.githubusercontent.com/5512552/218623384-6251c808-6596-4308-b2ce-115a879d99aa.png">

### After
<img width="376" alt="Screen Shot 2023-02-14 at 10 28 50" src="https://user-images.githubusercontent.com/5512552/218623411-b1d8ef61-8df5-4ab5-b6a7-69a18a76abc3.png">
