### PR TITLE
eth/catalyst: return error if withdrawals are nil post-shanghai

### DIFF
--- a/eth/catalyst/api.go
+++ b/eth/catalyst/api.go
@@ -417,6 +417,11 @@ func (api *ConsensusAPI) NewPayloadV1(params engine.ExecutableData) (engine.Payl
 
 // NewPayloadV2 creates an Eth1 block, inserts it in the chain, and returns the status of the chain.
 func (api *ConsensusAPI) NewPayloadV2(params engine.ExecutableData) (engine.PayloadStatusV1, error) {
+	if api.eth.BlockChain().Config().IsShanghai(params.Timestamp) {
+		if params.Withdrawals == nil {
+			return engine.PayloadStatusV1{Status: engine.INVALID}, fmt.Errorf("nil withdrawals post-shanghai")
+		}
+	}
 	return api.newPayload(params)
 }
 


### PR DESCRIPTION
Spec: https://github.com/ethereum/execution-apis/blob/main/src/engine/shanghai.md#request
```
- ExecutionPayloadV1 MUST be used if the timestamp value is lower than the Shanghai timestamp,
- ExecutionPayloadV2 MUST be used if the timestamp value is greater or equal to the Shanghai timestamp,
- Client software MUST return -32602: Invalid params error if the wrong version of the structure is used in the method call.
```