### PR TITLE
ethdb/pebble: Fix `MemTableStopWritesThreshold`

### DIFF
--- a/ethdb/pebble/pebble.go
+++ b/ethdb/pebble/pebble.go
@@ -449,11 +449,7 @@ func (d *Database) meter(refresh time.Duration) {
 			d.diskWriteMeter.Mark(nWrites[i%2] - nWrites[(i-1)%2])
 		}
 		// See https://github.com/cockroachdb/pebble/pull/1628#pullrequestreview-1026664054
-		manuallyAllocated := metrics.BlockCache.Size + int64(
-			metrics.MemTable.Size,
-		) + int64(
-			metrics.MemTable.ZombieSize,
-		)
+		manuallyAllocated := metrics.BlockCache.Size + int64(metrics.MemTable.Size) + int64(metrics.MemTable.ZombieSize)
 		d.manualMemAllocGauge.Update(manuallyAllocated)
 		d.memCompGauge.Update(metrics.Flush.Count)
 		d.nonlevel0CompGauge.Update(nonLevel0CompCount)

--- a/ethdb/pebble/pebble.go
+++ b/ethdb/pebble/pebble.go
@@ -125,13 +125,7 @@ func New(file string, cache int, handles int, namespace string, readonly bool) (
 		handles = minHandles
 	}
 	logger := log.New("database", file)
-	logger.Info(
-		"Allocated cache and file handles",
-		"cache",
-		common.StorageSize(cache*1024*1024),
-		"handles",
-		handles,
-	)
+	logger.Info("Allocated cache and file handles", "cache", common.StorageSize(cache*1024*1024), "handles", handles)
 
 	// The max memtable size is limited by the uint32 offsets stored in
 	// internal/arenaskl.node, DeferredBatchOp, and flushableBatchEntry.


### PR DESCRIPTION
`MemTableStopWritesThreshold` was set to the max size of all memtables before blocking writing but should be set to the max number of memtables. This is documented [here](https://github.com/cockroachdb/pebble/blob/master/options.go#L738-L742) and used in the code [here](https://github.com/cockroachdb/pebble/blob/master/db.go#L1892-L1903).

Nice work adding Pebble support! ❤️ 