### PR TITLE
eth/catalyst: send INVALID instead of INVALID_BLOCK_HASH

### DIFF
--- a/beacon/engine/errors.go
+++ b/beacon/engine/errors.go
@@ -74,8 +74,6 @@ var (
 	//   - newPayloadV1: if the payload was accepted, but not processed (side chain)
 	ACCEPTED = "ACCEPTED"
 
-	INVALIDBLOCKHASH = "INVALID_BLOCK_HASH"
-
 	GenericServerError       = &EngineAPIError{code: -32000, msg: "Server error"}
 	UnknownPayload           = &EngineAPIError{code: -38001, msg: "Unknown payload"}
 	InvalidForkChoiceState   = &EngineAPIError{code: -38002, msg: "Invalid forkchoice state"}

--- a/eth/catalyst/api.go
+++ b/eth/catalyst/api.go
@@ -448,7 +448,7 @@ func (api *ConsensusAPI) newPayload(params engine.ExecutableData) (engine.Payloa
 	block, err := engine.ExecutableDataToBlock(params)
 	if err != nil {
 		log.Debug("Invalid NewPayload params", "params", params, "error", err)
-		return engine.PayloadStatusV1{Status: engine.INVALIDBLOCKHASH}, nil
+		return engine.PayloadStatusV1{Status: engine.INVALID}, nil
 	}
 	// Stash away the last update to warn the user if the beacon client goes offline
 	api.lastNewPayloadLock.Lock()

--- a/eth/catalyst/api_test.go
+++ b/eth/catalyst/api_test.go
@@ -865,7 +865,7 @@ func TestInvalidBloom(t *testing.T) {
 		t.Fatal(err)
 	}
 	if status.Status != engine.INVALID {
-		t.Errorf("invalid status: expected VALID got: %v", status.Status)
+		t.Errorf("invalid status: expected INVALID got: %v", status.Status)
 	}
 }
 

--- a/eth/catalyst/api_test.go
+++ b/eth/catalyst/api_test.go
@@ -864,7 +864,7 @@ func TestInvalidBloom(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if status.Status != engine.INVALIDBLOCKHASH {
+	if status.Status != engine.INVALID {
 		t.Errorf("invalid status: expected VALID got: %v", status.Status)
 	}
 }


### PR DESCRIPTION
From @mkalinin on discord:

> I would not change V1 in the spec but implementations can remove it from V1, as even in the context of V1 INVALID and INVALID_BLOCK_HASH are semantically equal (there were not initially but then there was a change to INVALID which made them equal). One potential issue are hive tests that expect INVALID_BLOCK_HASH to be returned to newPayloadV1 call with payload having invalid blockHash.

This change will break one hive test, but pass another and it will be the better way going forward