### PR TITLE
cmd/devp2p: faster crawling + less verbose dns updates

### DIFF
--- a/cmd/devp2p/crawl.go
+++ b/cmd/devp2p/crawl.go
@@ -17,7 +17,6 @@
 package main
 
 import (
-	"fmt"
 	"sync"
 	"sync/atomic"
 	"time"

--- a/cmd/devp2p/discv4cmd.go
+++ b/cmd/devp2p/discv4cmd.go
@@ -78,7 +78,7 @@ var (
 		Name:   "crawl",
 		Usage:  "Updates a nodes.json file with random nodes found in the DHT",
 		Action: discv4Crawl,
-		Flags:  flags.Merge(discoveryNodeFlags, []cli.Flag{crawlTimeoutFlag}),
+		Flags:  flags.Merge(discoveryNodeFlags, []cli.Flag{crawlTimeoutFlag, crawlParallelismFlag}),
 	}
 	discv4TestCommand = &cli.Command{
 		Name:   "test",
@@ -119,6 +119,11 @@ var (
 		Name:  "timeout",
 		Usage: "Time limit for the crawl.",
 		Value: 30 * time.Minute,
+	}
+	crawlParallelismFlag = &cli.IntFlag{
+		Name:  "parallel",
+		Usage: "How many parallel discoveries to attempt.",
+		Value: 16,
 	}
 	remoteEnodeFlag = &cli.StringFlag{
 		Name:    "remote",
@@ -195,7 +200,7 @@ func discv4ResolveJSON(ctx *cli.Context) error {
 	defer disc.Close()
 	c := newCrawler(inputSet, disc, enode.IterNodes(nodeargs))
 	c.revalidateInterval = 0
-	output := c.run(0)
+	output := c.run(0, 1)
 	writeNodesJSON(nodesFile, output)
 	return nil
 }
@@ -214,7 +219,7 @@ func discv4Crawl(ctx *cli.Context) error {
 	defer disc.Close()
 	c := newCrawler(inputSet, disc, disc.RandomNodes())
 	c.revalidateInterval = 10 * time.Minute
-	output := c.run(ctx.Duration(crawlTimeoutFlag.Name))
+	output := c.run(ctx.Duration(crawlTimeoutFlag.Name), ctx.Int(crawlParallelismFlag.Name))
 	writeNodesJSON(nodesFile, output)
 	return nil
 }

--- a/cmd/devp2p/discv5cmd.go
+++ b/cmd/devp2p/discv5cmd.go
@@ -110,7 +110,7 @@ func discv5Crawl(ctx *cli.Context) error {
 	defer disc.Close()
 	c := newCrawler(inputSet, disc, disc.RandomNodes())
 	c.revalidateInterval = 10 * time.Minute
-	output := c.run(ctx.Duration(crawlTimeoutFlag.Name))
+	output := c.run(ctx.Duration(crawlTimeoutFlag.Name), ctx.Int(crawlParallelismFlag.Name))
 	writeNodesJSON(nodesFile, output)
 	return nil
 }

--- a/cmd/devp2p/dns_route53.go
+++ b/cmd/devp2p/dns_route53.go
@@ -329,8 +329,9 @@ func (c *route53Client) collectRecords(name string) (map[string]recordSet, error
 	var req route53.ListResourceRecordSetsInput
 	req.HostedZoneId = &c.zoneID
 	existing := make(map[string]recordSet)
+	log.Info("Loading existing TXT records", "name", name, "zone", c.zoneID)
 	for page := 0; ; page++ {
-		log.Info("Loading existing TXT records", "name", name, "zone", c.zoneID, "page", page)
+		log.Debug("Loading existing TXT records", "name", name, "zone", c.zoneID, "page", page)
 		resp, err := c.api.ListResourceRecordSets(context.TODO(), &req)
 		if err != nil {
 			return existing, err
@@ -360,7 +361,7 @@ func (c *route53Client) collectRecords(name string) (map[string]recordSet, error
 		req.StartRecordName = resp.NextRecordName
 		req.StartRecordType = resp.NextRecordType
 	}
-
+	log.Info("Loaded existing TXT records", "name", name, "zone", c.zoneID, "records", len(existing))
 	return existing, nil
 }
 


### PR DESCRIPTION
This PR does a couple of things to the `devp2p` tool. First of all, it makes the crawler faster. The op can now set the parallelism arbitrary, here's an example where I set it to `200`: 
```
$ go run . discv4 crawl -timeout 2s -parallel 200 ../../all.json 
INFO [02-14|21:27:53.135] New local node record                    seq=1,676,406,473,135 id=4607be3ac694a60a ip=127.0.0.1 udp=60182 tcp=0
INFO [02-14|21:27:53.215] New local node record                    seq=1,676,406,473,136 id=4607be3ac694a60a ip=212.85.71.121 udp=60182 tcp=0
INFO [02-14|21:28:01.184] Crawling in progress                     added=8 updated=1711 removed=44 ignored(recent)=44 ignored(incompatible)=30
INFO [02-14|21:28:09.185] Crawling in progress                     added=9 updated=3140 removed=86 ignored(recent)=86 ignored(incompatible)=40
INFO [02-14|21:28:17.185] Crawling in progress                     added=9 updated=4140 removed=131 ignored(recent)=131 ignored(incompatible)=49
```
In 24 seconds, it revalidated ~4.5K nodes. With only one, as current master, the corresponding number was `35`. 
```
INFO [02-14|16:27:31.563] Crawling in progress                     added=1 updated=35 removed=0 ignored(recent)=1 ignored(incompatible)=1
```
 
Our prod crawler takes ~12 hours to run: it revalidates 35K nodes in the `all.json`. However, it uses a mixed iterator, where half comes from all.json, and the other half from random-walking the DHT. This means that it will visit ~70K nodes before the all.json iterator is depleted, and it is "allowed" to exit. And yeah, that takes a while. 

The output from the crawler, particularly when updating the DNS entries, is a bit over-the top for level `Info`. I moved a lot to `Debug`, and instead added summarical outputs on level `Info`. 
