### PR TITLE
beacon/engine: don't omit empty withdrawals in ExecutionPayloadBodies

### DIFF
--- a/beacon/engine/types.go
+++ b/beacon/engine/types.go
@@ -233,5 +233,5 @@ func BlockToExecutableData(block *types.Block, fees *big.Int) *ExecutionPayloadE
 // ExecutionPayloadBodyV1 is used in the response to GetPayloadBodiesByHashV1 and GetPayloadBodiesByRangeV1
 type ExecutionPayloadBodyV1 struct {
 	TransactionData []hexutil.Bytes     `json:"transactions"`
-	Withdrawals     []*types.Withdrawal `json:"withdrawals,omitempty"`
+	Withdrawals     []*types.Withdrawal `json:"withdrawals"`
 }

--- a/eth/catalyst/api.go
+++ b/eth/catalyst/api.go
@@ -825,7 +825,7 @@ func getBody(block *types.Block) *engine.ExecutionPayloadBodyV1 {
 	var (
 		body        = block.Body()
 		txs         = make([]hexutil.Bytes, len(body.Transactions))
-		withdrawals = body.Withdrawals
+		withdrawals = make([]*types.Withdrawal, 0)
 	)
 
 	for j, tx := range body.Transactions {
@@ -834,8 +834,8 @@ func getBody(block *types.Block) *engine.ExecutionPayloadBodyV1 {
 	}
 
 	// Post-shanghai withdrawals MUST be set to empty slice instead of nil
-	if withdrawals == nil {
-		withdrawals = make([]*types.Withdrawal, 0)
+	if body.Withdrawals != nil {
+		withdrawals = body.Withdrawals
 	}
 
 	return &engine.ExecutionPayloadBodyV1{

--- a/eth/catalyst/api.go
+++ b/eth/catalyst/api.go
@@ -825,7 +825,7 @@ func getBody(block *types.Block) *engine.ExecutionPayloadBodyV1 {
 	var (
 		body        = block.Body()
 		txs         = make([]hexutil.Bytes, len(body.Transactions))
-		withdrawals = make([]*types.Withdrawal, 0)
+		withdrawals = body.Withdrawals
 	)
 
 	for j, tx := range body.Transactions {
@@ -834,8 +834,8 @@ func getBody(block *types.Block) *engine.ExecutionPayloadBodyV1 {
 	}
 
 	// Post-shanghai withdrawals MUST be set to empty slice instead of nil
-	if body.Withdrawals != nil {
-		withdrawals = body.Withdrawals
+	if withdrawals == nil && block.Header().WithdrawalsHash != nil {
+		withdrawals = make([]*types.Withdrawal, 0)
 	}
 
 	return &engine.ExecutionPayloadBodyV1{

--- a/eth/catalyst/api.go
+++ b/eth/catalyst/api.go
@@ -835,6 +835,7 @@ func getBody(block *types.Block) *engine.ExecutionPayloadBodyV1 {
 
 	// Post-shanghai withdrawals MUST be set to empty slice instead of nil
 	if withdrawals == nil && block.Header().WithdrawalsHash != nil {
+		panic("asdf")
 		withdrawals = make([]*types.Withdrawal, 0)
 	}
 

--- a/eth/catalyst/api.go
+++ b/eth/catalyst/api.go
@@ -834,8 +834,7 @@ func getBody(block *types.Block) *engine.ExecutionPayloadBodyV1 {
 	}
 
 	// Post-shanghai withdrawals MUST be set to empty slice instead of nil
-	if withdrawals == nil && block.Header().WithdrawalsHash != nil {
-		panic("asdf")
+	if withdrawals == nil {
 		withdrawals = make([]*types.Withdrawal, 0)
 	}
 

--- a/eth/catalyst/api_test.go
+++ b/eth/catalyst/api_test.go
@@ -19,6 +19,7 @@ package catalyst
 import (
 	"bytes"
 	"context"
+	crand "crypto/rand"
 	"fmt"
 	"math/big"
 	"math/rand"
@@ -1261,7 +1262,7 @@ func setupBodies(t *testing.T) (*node.Node, *eth.Ethereum, []*types.Block) {
 	withdrawals[1] = make([]*types.Withdrawal, 0)
 	for i := 2; i < len(withdrawals); i++ {
 		addr := make([]byte, 20)
-		rand.Read(addr)
+		crand.Read(addr)
 		withdrawals[i] = []*types.Withdrawal{
 			{Index: rand.Uint64(), Validator: rand.Uint64(), Amount: rand.Uint64(), Address: common.BytesToAddress(addr)},
 		}

--- a/eth/catalyst/api_test.go
+++ b/eth/catalyst/api_test.go
@@ -1483,7 +1483,7 @@ func equalBody(a *types.Body, b *engine.ExecutionPayloadBodyV1) bool {
 	}
 	for i, tx := range a.Transactions {
 		data, _ := tx.MarshalBinary()
-		if !reflect.DeepEqual(hexutil.Bytes(data), b.TransactionData[i]) {
+		if !bytes.Equal(data, b.TransactionData[i]) {
 			return false
 		}
 	}


### PR DESCRIPTION
Fixes an issue where we would omit [] withdrawals.
Adds withdrawals to the ExecutionPayloadBodies tests.