### PR TITLE
core: check genesis state presence by disk read

### DIFF
--- a/core/genesis.go
+++ b/core/genesis.go
@@ -317,7 +317,7 @@ func SetupGenesisBlockWithOverride(db ethdb.Database, triedb *trie.Database, gen
 	// We have the genesis block in database(perhaps in ancient database)
 	// but the corresponding state is missing.
 	header := rawdb.ReadHeader(db, stored, 0)
-	if _, err := state.New(header.Root, state.NewDatabaseWithNodeDB(db, triedb), nil); err != nil {
+	if header.Root != types.EmptyRootHash && !rawdb.HasLegacyTrieNode(db, header.Root) {
 		if genesis == nil {
 			genesis = DefaultGenesisBlock()
 		}


### PR DESCRIPTION
This PR fixes a regression.

Previously it's a special trick to fast-bootstrap geth that people can nuke out leveldb but retain the ancient store. Once the node is restarted, it will sync up the missing state data from network but avoid re-downloading the chain segment.

Unfortunately it's broken in 1.11, we determine whether chain needs to be initialized with genesis block by the presence of genesis state, which is expected to be "NO" in the scenario described. However, in 1.11, we determine the state presence by opening it with trie database, which will also read the state from cache file. The chain initialization will be skipped if there is a leftover cache file and genesis root node is contained.

This PR fixes it by a quick hack: load the genesis root node directly from disk. 