### PR TITLE
eth/downloader: fix empty-body case in queue fetchresult

### DIFF
--- a/eth/downloader/queue.go
+++ b/eth/downloader/queue.go
@@ -76,6 +76,8 @@ func newFetchResult(header *types.Header, fastSync bool) *fetchResult {
 	}
 	if !header.EmptyBody() {
 		item.pending |= (1 << bodyType)
+	} else if header.WithdrawalsHash != nil {
+		item.Withdrawals = make(types.Withdrawals, 0)
 	}
 	if fastSync && !header.EmptyReceipts() {
 		item.pending |= (1 << receiptType)


### PR DESCRIPTION
Follow-up to #26704, one remaining fix