### PR TITLE
ci: add exclude-rules for linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -62,3 +62,6 @@ issues:
     - 'SA1019: strings.Title is deprecated'
     - 'SA1019: strings.Title has been deprecated since Go 1.18 and an alternative has been available since Go 1.0: The rule Title uses for word boundaries does not handle Unicode punctuation properly. Use golang.org/x/text/cases instead.'
     - 'SA1029: should not use built-in type string as key for value'
+    - 'SA1019: rand.Read has been deprecated'
+    - 'SA1019: rand.Seed has been deprecated'
+    - 'SA1019: mrand.Read has been deprecated'


### PR DESCRIPTION
Travis is failing: https://app.travis-ci.com/github/ethereum/go-ethereum/jobs/596122688 
This PR adds exclusions, should fix it. 
For some reason, the appveyor linter runs on `1.19.5` (https://ci.appveyor.com/project/ethereum/go-ethereum/build/job/q193h504uchyuyqc#L24) , even though it builds with `1.20.1`, we should fix that too in this PR, so it lints with the same version it builds with. 