### PR TITLE
core/types: add EffectiveGasPrice in Receipt

### DIFF
--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -2031,7 +2031,7 @@ func (bc *BlockChain) recoverAncestors(block *types.Block) (common.Hash, error) 
 // the processing of a block. These logs are later announced as deleted or reborn.
 func (bc *BlockChain) collectLogs(b *types.Block, removed bool) []*types.Log {
 	receipts := rawdb.ReadRawReceipts(bc.db, b.Hash(), b.NumberU64())
-	receipts.DeriveFields(bc.chainConfig, b.Hash(), b.NumberU64(), b.Transactions())
+	receipts.DeriveFields(bc.chainConfig, b.Hash(), b.NumberU64(), b.BaseFee(), b.Transactions())
 
 	var logs []*types.Log
 	for _, receipt := range receipts {

--- a/core/rawdb/accessors_chain.go
+++ b/core/rawdb/accessors_chain.go
@@ -636,7 +636,12 @@ func ReadReceipts(db ethdb.Reader, hash common.Hash, number uint64, config *para
 		log.Error("Missing body but have receipt", "hash", hash, "number", number)
 		return nil
 	}
-	if err := receipts.DeriveFields(config, hash, number, body.Transactions); err != nil {
+	header := ReadHeader(db, hash, number)
+	if header == nil {
+		log.Error("Missing header", "hash", hash, "number", number)
+		return nil
+	}
+	if err := receipts.DeriveFields(config, hash, number, header.BaseFee, body.Transactions); err != nil {
 		log.Error("Failed to derive block receipts fields", "hash", hash, "number", number, "err", err)
 		return nil
 	}

--- a/core/rawdb/accessors_chain.go
+++ b/core/rawdb/accessors_chain.go
@@ -637,11 +637,13 @@ func ReadReceipts(db ethdb.Reader, hash common.Hash, number uint64, config *para
 		return nil
 	}
 	header := ReadHeader(db, hash, number)
+	var baseFee *big.Int
 	if header == nil {
-		log.Error("Missing header", "hash", hash, "number", number)
-		return nil
+		baseFee = big.NewInt(0)
+	} else {
+		baseFee = header.BaseFee
 	}
-	if err := receipts.DeriveFields(config, hash, number, header.BaseFee, body.Transactions); err != nil {
+	if err := receipts.DeriveFields(config, hash, number, baseFee, body.Transactions); err != nil {
 		log.Error("Failed to derive block receipts fields", "hash", hash, "number", number, "err", err)
 		return nil
 	}

--- a/core/types/gen_receipt_json.go
+++ b/core/types/gen_receipt_json.go
@@ -25,6 +25,7 @@ func (r Receipt) MarshalJSON() ([]byte, error) {
 		TxHash            common.Hash    `json:"transactionHash" gencodec:"required"`
 		ContractAddress   common.Address `json:"contractAddress"`
 		GasUsed           hexutil.Uint64 `json:"gasUsed" gencodec:"required"`
+		EffectiveGasPrice *hexutil.Big   `json:"effectiveGasPrice,omitempty"`
 		BlockHash         common.Hash    `json:"blockHash,omitempty"`
 		BlockNumber       *hexutil.Big   `json:"blockNumber,omitempty"`
 		TransactionIndex  hexutil.Uint   `json:"transactionIndex"`
@@ -39,6 +40,7 @@ func (r Receipt) MarshalJSON() ([]byte, error) {
 	enc.TxHash = r.TxHash
 	enc.ContractAddress = r.ContractAddress
 	enc.GasUsed = hexutil.Uint64(r.GasUsed)
+	enc.EffectiveGasPrice = (*hexutil.Big)(r.EffectiveGasPrice)
 	enc.BlockHash = r.BlockHash
 	enc.BlockNumber = (*hexutil.Big)(r.BlockNumber)
 	enc.TransactionIndex = hexutil.Uint(r.TransactionIndex)
@@ -57,6 +59,7 @@ func (r *Receipt) UnmarshalJSON(input []byte) error {
 		TxHash            *common.Hash    `json:"transactionHash" gencodec:"required"`
 		ContractAddress   *common.Address `json:"contractAddress"`
 		GasUsed           *hexutil.Uint64 `json:"gasUsed" gencodec:"required"`
+		EffectiveGasPrice *hexutil.Big    `json:"effectiveGasPrice,omitempty"`
 		BlockHash         *common.Hash    `json:"blockHash,omitempty"`
 		BlockNumber       *hexutil.Big    `json:"blockNumber,omitempty"`
 		TransactionIndex  *hexutil.Uint   `json:"transactionIndex"`
@@ -97,6 +100,9 @@ func (r *Receipt) UnmarshalJSON(input []byte) error {
 		return errors.New("missing required field 'gasUsed' for Receipt")
 	}
 	r.GasUsed = uint64(*dec.GasUsed)
+	if dec.EffectiveGasPrice != nil {
+		r.EffectiveGasPrice = (*big.Int)(dec.EffectiveGasPrice)
+	}
 	if dec.BlockHash != nil {
 		r.BlockHash = *dec.BlockHash
 	}

--- a/core/types/receipt.go
+++ b/core/types/receipt.go
@@ -60,9 +60,10 @@ type Receipt struct {
 
 	// Implementation fields: These fields are added by geth when processing a transaction.
 	// They are stored in the chain database.
-	TxHash          common.Hash    `json:"transactionHash" gencodec:"required"`
-	ContractAddress common.Address `json:"contractAddress"`
-	GasUsed         uint64         `json:"gasUsed" gencodec:"required"`
+	TxHash            common.Hash    `json:"transactionHash" gencodec:"required"`
+	ContractAddress   common.Address `json:"contractAddress"`
+	GasUsed           uint64         `json:"gasUsed" gencodec:"required"`
+	EffectiveGasPrice *big.Int       `json:"effectiveGasPrice,omitempty"`
 
 	// Inclusion information: These fields provide information about the inclusion of the
 	// transaction corresponding to this receipt.

--- a/core/types/receipt.go
+++ b/core/types/receipt.go
@@ -59,11 +59,10 @@ type Receipt struct {
 	Logs              []*Log `json:"logs"              gencodec:"required"`
 
 	// Implementation fields: These fields are added by geth when processing a transaction.
-	// They are stored in the chain database.
 	TxHash            common.Hash    `json:"transactionHash" gencodec:"required"`
 	ContractAddress   common.Address `json:"contractAddress"`
 	GasUsed           uint64         `json:"gasUsed" gencodec:"required"`
-	EffectiveGasPrice *big.Int       `json:"effectiveGasPrice,omitempty"`
+	EffectiveGasPrice *big.Int       `json:"effectiveGasPrice"`
 
 	// Inclusion information: These fields provide information about the inclusion of the
 	// transaction corresponding to this receipt.

--- a/core/types/receipt.go
+++ b/core/types/receipt.go
@@ -314,7 +314,7 @@ func (rs Receipts) EncodeIndex(i int, w *bytes.Buffer) {
 
 // DeriveFields fills the receipts with their computed fields based on consensus
 // data and contextual infos like containing block and transactions.
-func (rs Receipts) DeriveFields(config *params.ChainConfig, hash common.Hash, number uint64, txs Transactions) error {
+func (rs Receipts) DeriveFields(config *params.ChainConfig, hash common.Hash, number uint64, baseFee *big.Int, txs Transactions) error {
 	signer := MakeSigner(config, new(big.Int).SetUint64(number))
 
 	logIndex := uint(0)
@@ -342,6 +342,12 @@ func (rs Receipts) DeriveFields(config *params.ChainConfig, hash common.Hash, nu
 			rs[i].GasUsed = rs[i].CumulativeGasUsed
 		} else {
 			rs[i].GasUsed = rs[i].CumulativeGasUsed - rs[i-1].CumulativeGasUsed
+		}
+		// The effective gas price can be calculated based on baseFee for EIP1559 transactions
+		if txs[i].Type() == 2 {
+			rs[i].EffectiveGasPrice = new(big.Int).Add(baseFee, txs[i].EffectiveGasTipValue(baseFee))
+		} else {
+			rs[i].EffectiveGasPrice = new(big.Int).Set(txs[i].GasPrice())
 		}
 		// The derived log fields can simply be set from the block and transaction
 		for j := 0; j < len(rs[i].Logs); j++ {

--- a/core/types/receipt.go
+++ b/core/types/receipt.go
@@ -314,7 +314,7 @@ func (rs Receipts) EncodeIndex(i int, w *bytes.Buffer) {
 
 // DeriveFields fills the receipts with their computed fields based on consensus
 // data and contextual infos like containing block and transactions.
-func (rs Receipts) DeriveFields(config *params.ChainConfig, hash common.Hash, number uint64, baseFee *big.Int, txs Transactions) error {
+func (rs Receipts) DeriveFields(config *params.ChainConfig, hash common.Hash, number uint64, baseFee *big.Int, txs []*Transaction) error {
 	signer := MakeSigner(config, new(big.Int).SetUint64(number))
 
 	logIndex := uint(0)
@@ -325,6 +325,8 @@ func (rs Receipts) DeriveFields(config *params.ChainConfig, hash common.Hash, nu
 		// The transaction type and hash can be retrieved from the transaction itself
 		rs[i].Type = txs[i].Type()
 		rs[i].TxHash = txs[i].Hash()
+
+		rs[i].EffectiveGasPrice = txs[i].inner.effectiveGasPrice(new(big.Int), baseFee)
 
 		// block location fields
 		rs[i].BlockHash = hash
@@ -337,18 +339,14 @@ func (rs Receipts) DeriveFields(config *params.ChainConfig, hash common.Hash, nu
 			from, _ := Sender(signer, txs[i])
 			rs[i].ContractAddress = crypto.CreateAddress(from, txs[i].Nonce())
 		}
+
 		// The used gas can be calculated based on previous r
 		if i == 0 {
 			rs[i].GasUsed = rs[i].CumulativeGasUsed
 		} else {
 			rs[i].GasUsed = rs[i].CumulativeGasUsed - rs[i-1].CumulativeGasUsed
 		}
-		// The effective gas price can be calculated based on baseFee for EIP1559 transactions
-		if txs[i].Type() == 2 {
-			rs[i].EffectiveGasPrice = new(big.Int).Add(baseFee, txs[i].EffectiveGasTipValue(baseFee))
-		} else {
-			rs[i].EffectiveGasPrice = new(big.Int).Set(txs[i].GasPrice())
-		}
+
 		// The derived log fields can simply be set from the block and transaction
 		for j := 0; j < len(rs[i].Logs); j++ {
 			rs[i].Logs[j].BlockNumber = number

--- a/core/types/receipt.go
+++ b/core/types/receipt.go
@@ -337,6 +337,8 @@ func (rs Receipts) DeriveFields(config *params.ChainConfig, hash common.Hash, nu
 			// Deriving the signer is expensive, only do if it's actually needed
 			from, _ := Sender(signer, txs[i])
 			rs[i].ContractAddress = crypto.CreateAddress(from, txs[i].Nonce())
+		} else {
+			rs[i].ContractAddress = common.Address{}
 		}
 
 		// The used gas can be calculated based on previous r

--- a/core/types/receipt_test.go
+++ b/core/types/receipt_test.go
@@ -18,15 +18,16 @@ package types
 
 import (
 	"bytes"
+	"encoding/json"
 	"math"
 	"math/big"
 	"reflect"
 	"testing"
 
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/params"
 	"github.com/ethereum/go-ethereum/rlp"
+	"github.com/kylelemons/godebug/diff"
 )
 
 var (
@@ -96,122 +97,177 @@ func TestDeriveFields(t *testing.T) {
 	// Create a few transactions to have receipts for
 	to2 := common.HexToAddress("0x2")
 	to3 := common.HexToAddress("0x3")
+	to4 := common.HexToAddress("0x4")
+	to5 := common.HexToAddress("0x5")
 	txs := Transactions{
 		NewTx(&LegacyTx{
 			Nonce:    1,
 			Value:    big.NewInt(1),
 			Gas:      1,
-			GasPrice: big.NewInt(1),
+			GasPrice: big.NewInt(11),
 		}),
 		NewTx(&LegacyTx{
 			To:       &to2,
 			Nonce:    2,
 			Value:    big.NewInt(2),
 			Gas:      2,
-			GasPrice: big.NewInt(2),
+			GasPrice: big.NewInt(22),
 		}),
 		NewTx(&AccessListTx{
 			To:       &to3,
 			Nonce:    3,
 			Value:    big.NewInt(3),
 			Gas:      3,
-			GasPrice: big.NewInt(3),
+			GasPrice: big.NewInt(33),
+		}),
+		// EIP-1559 transactions.
+		NewTx(&DynamicFeeTx{
+			To:        &to4,
+			Nonce:     4,
+			Value:     big.NewInt(4),
+			Gas:       4,
+			GasTipCap: big.NewInt(44),
+			GasFeeCap: big.NewInt(1045),
+		}),
+		NewTx(&DynamicFeeTx{
+			To:        &to5,
+			Nonce:     5,
+			Value:     big.NewInt(5),
+			Gas:       5,
+			GasTipCap: big.NewInt(56),
+			GasFeeCap: big.NewInt(1055),
 		}),
 	}
+
+	blockNumber := big.NewInt(1)
+	blockHash := common.BytesToHash([]byte{0x03, 0x14})
+
 	// Create the corresponding receipts
 	receipts := Receipts{
 		&Receipt{
 			Status:            ReceiptStatusFailed,
 			CumulativeGasUsed: 1,
 			Logs: []*Log{
-				{Address: common.BytesToAddress([]byte{0x11})},
-				{Address: common.BytesToAddress([]byte{0x01, 0x11})},
+				{
+					Address: common.BytesToAddress([]byte{0x11}),
+					// derived fields:
+					BlockNumber: blockNumber.Uint64(),
+					TxHash:      txs[0].Hash(),
+					TxIndex:     0,
+					BlockHash:   blockHash,
+					Index:       0,
+				},
+				{
+					Address: common.BytesToAddress([]byte{0x01, 0x11}),
+					// derived fields:
+					BlockNumber: blockNumber.Uint64(),
+					TxHash:      txs[0].Hash(),
+					TxIndex:     0,
+					BlockHash:   blockHash,
+					Index:       1,
+				},
 			},
-			TxHash:          txs[0].Hash(),
-			ContractAddress: common.BytesToAddress([]byte{0x01, 0x11, 0x11}),
-			GasUsed:         1,
+			// derived fields:
+			TxHash:            txs[0].Hash(),
+			ContractAddress:   common.HexToAddress("0x5a443704dd4b594b382c22a083e2bd3090a6fef3"),
+			GasUsed:           1,
+			EffectiveGasPrice: big.NewInt(11),
+			BlockHash:         blockHash,
+			BlockNumber:       blockNumber,
+			TransactionIndex:  0,
 		},
 		&Receipt{
 			PostState:         common.Hash{2}.Bytes(),
 			CumulativeGasUsed: 3,
 			Logs: []*Log{
-				{Address: common.BytesToAddress([]byte{0x22})},
-				{Address: common.BytesToAddress([]byte{0x02, 0x22})},
+				{
+					Address: common.BytesToAddress([]byte{0x22}),
+					// derived fields:
+					BlockNumber: blockNumber.Uint64(),
+					TxHash:      txs[1].Hash(),
+					TxIndex:     1,
+					BlockHash:   blockHash,
+					Index:       2,
+				},
+				{
+					Address: common.BytesToAddress([]byte{0x02, 0x22}),
+					// derived fields:
+					BlockNumber: blockNumber.Uint64(),
+					TxHash:      txs[1].Hash(),
+					TxIndex:     1,
+					BlockHash:   blockHash,
+					Index:       3,
+				},
 			},
-			TxHash:          txs[1].Hash(),
-			ContractAddress: common.BytesToAddress([]byte{0x02, 0x22, 0x22}),
-			GasUsed:         2,
+			// derived fields:
+			TxHash:            txs[1].Hash(),
+			GasUsed:           2,
+			EffectiveGasPrice: big.NewInt(22),
+			BlockHash:         blockHash,
+			BlockNumber:       blockNumber,
+			TransactionIndex:  1,
 		},
 		&Receipt{
 			Type:              AccessListTxType,
 			PostState:         common.Hash{3}.Bytes(),
 			CumulativeGasUsed: 6,
-			Logs: []*Log{
-				{Address: common.BytesToAddress([]byte{0x33})},
-				{Address: common.BytesToAddress([]byte{0x03, 0x33})},
-			},
-			TxHash:          txs[2].Hash(),
-			ContractAddress: common.BytesToAddress([]byte{0x03, 0x33, 0x33}),
-			GasUsed:         3,
+			Logs:              []*Log{},
+			// derived fields:
+			TxHash:            txs[2].Hash(),
+			GasUsed:           3,
+			EffectiveGasPrice: big.NewInt(33),
+			BlockHash:         blockHash,
+			BlockNumber:       blockNumber,
+			TransactionIndex:  2,
+		},
+		&Receipt{
+			Type:              DynamicFeeTxType,
+			PostState:         common.Hash{4}.Bytes(),
+			CumulativeGasUsed: 10,
+			Logs:              []*Log{},
+			// derived fields:
+			TxHash:            txs[3].Hash(),
+			GasUsed:           4,
+			EffectiveGasPrice: big.NewInt(1044),
+			BlockHash:         blockHash,
+			BlockNumber:       blockNumber,
+			TransactionIndex:  3,
+		},
+		&Receipt{
+			Type:              DynamicFeeTxType,
+			PostState:         common.Hash{5}.Bytes(),
+			CumulativeGasUsed: 15,
+			Logs:              []*Log{},
+			// derived fields:
+			TxHash:            txs[4].Hash(),
+			GasUsed:           5,
+			EffectiveGasPrice: big.NewInt(1055),
+			BlockHash:         blockHash,
+			BlockNumber:       blockNumber,
+			TransactionIndex:  4,
 		},
 	}
-	// Clear all the computed fields and re-derive them
-	number := big.NewInt(1)
-	hash := common.BytesToHash([]byte{0x03, 0x14})
 
-	clearComputedFieldsOnReceipts(t, receipts)
-	if err := receipts.DeriveFields(params.TestChainConfig, hash, number.Uint64(), big.NewInt(0), txs); err != nil {
+	// Re-derive receipts.
+	basefee := big.NewInt(1000)
+	derivedReceipts := clearComputedFieldsOnReceipts(receipts)
+	err := Receipts(derivedReceipts).DeriveFields(params.TestChainConfig, blockHash, blockNumber.Uint64(), basefee, txs)
+	if err != nil {
 		t.Fatalf("DeriveFields(...) = %v, want <nil>", err)
 	}
-	// Iterate over all the computed fields and check that they're correct
-	signer := MakeSigner(params.TestChainConfig, number)
 
-	logIndex := uint(0)
-	for i := range receipts {
-		if receipts[i].Type != txs[i].Type() {
-			t.Errorf("receipts[%d].Type = %d, want %d", i, receipts[i].Type, txs[i].Type())
-		}
-		if receipts[i].TxHash != txs[i].Hash() {
-			t.Errorf("receipts[%d].TxHash = %s, want %s", i, receipts[i].TxHash.String(), txs[i].Hash().String())
-		}
-		if receipts[i].BlockHash != hash {
-			t.Errorf("receipts[%d].BlockHash = %s, want %s", i, receipts[i].BlockHash.String(), hash.String())
-		}
-		if receipts[i].BlockNumber.Cmp(number) != 0 {
-			t.Errorf("receipts[%c].BlockNumber = %s, want %s", i, receipts[i].BlockNumber.String(), number.String())
-		}
-		if receipts[i].TransactionIndex != uint(i) {
-			t.Errorf("receipts[%d].TransactionIndex = %d, want %d", i, receipts[i].TransactionIndex, i)
-		}
-		if receipts[i].GasUsed != txs[i].Gas() {
-			t.Errorf("receipts[%d].GasUsed = %d, want %d", i, receipts[i].GasUsed, txs[i].Gas())
-		}
-		if txs[i].To() != nil && receipts[i].ContractAddress != (common.Address{}) {
-			t.Errorf("receipts[%d].ContractAddress = %s, want %s", i, receipts[i].ContractAddress.String(), (common.Address{}).String())
-		}
-		from, _ := Sender(signer, txs[i])
-		contractAddress := crypto.CreateAddress(from, txs[i].Nonce())
-		if txs[i].To() == nil && receipts[i].ContractAddress != contractAddress {
-			t.Errorf("receipts[%d].ContractAddress = %s, want %s", i, receipts[i].ContractAddress.String(), contractAddress.String())
-		}
-		for j := range receipts[i].Logs {
-			if receipts[i].Logs[j].BlockNumber != number.Uint64() {
-				t.Errorf("receipts[%d].Logs[%d].BlockNumber = %d, want %d", i, j, receipts[i].Logs[j].BlockNumber, number.Uint64())
-			}
-			if receipts[i].Logs[j].BlockHash != hash {
-				t.Errorf("receipts[%d].Logs[%d].BlockHash = %s, want %s", i, j, receipts[i].Logs[j].BlockHash.String(), hash.String())
-			}
-			if receipts[i].Logs[j].TxHash != txs[i].Hash() {
-				t.Errorf("receipts[%d].Logs[%d].TxHash = %s, want %s", i, j, receipts[i].Logs[j].TxHash.String(), txs[i].Hash().String())
-			}
-			if receipts[i].Logs[j].TxIndex != uint(i) {
-				t.Errorf("receipts[%d].Logs[%d].TransactionIndex = %d, want %d", i, j, receipts[i].Logs[j].TxIndex, i)
-			}
-			if receipts[i].Logs[j].Index != logIndex {
-				t.Errorf("receipts[%d].Logs[%d].Index = %d, want %d", i, j, receipts[i].Logs[j].Index, logIndex)
-			}
-			logIndex++
-		}
+	// Check diff of receipts against derivedReceipts.
+	r1, err := json.MarshalIndent(receipts, "", "  ")
+	if err != nil {
+		t.Fatal("error marshaling input receipts:", err)
+	}
+	r2, err := json.MarshalIndent(derivedReceipts, "", "  ")
+	if err != nil {
+		t.Fatal("error marshaling derived receipts:", err)
+	}
+	d := diff.Diff(string(r1), string(r2))
+	if d != "" {
+		t.Fatal("receipts differ:", d)
 	}
 }
 
@@ -342,41 +398,36 @@ func TestReceiptUnmarshalBinary(t *testing.T) {
 	}
 }
 
-func clearComputedFieldsOnReceipts(t *testing.T, receipts Receipts) {
-	t.Helper()
-
-	for _, receipt := range receipts {
-		clearComputedFieldsOnReceipt(t, receipt)
+func clearComputedFieldsOnReceipts(receipts []*Receipt) []*Receipt {
+	r := make([]*Receipt, len(receipts))
+	for i, receipt := range receipts {
+		r[i] = clearComputedFieldsOnReceipt(receipt)
 	}
+	return r
 }
 
-func clearComputedFieldsOnReceipt(t *testing.T, receipt *Receipt) {
-	t.Helper()
-
-	receipt.TxHash = common.Hash{}
-	receipt.BlockHash = common.Hash{}
-	receipt.BlockNumber = big.NewInt(math.MaxUint32)
-	receipt.TransactionIndex = math.MaxUint32
-	receipt.ContractAddress = common.Address{}
-	receipt.GasUsed = 0
-
-	clearComputedFieldsOnLogs(t, receipt.Logs)
+func clearComputedFieldsOnReceipt(receipt *Receipt) *Receipt {
+	cpy := *receipt
+	cpy.TxHash = common.Hash{0xff, 0xff, 0x11}
+	cpy.BlockHash = common.Hash{0xff, 0xff, 0x22}
+	cpy.BlockNumber = big.NewInt(math.MaxUint32)
+	cpy.TransactionIndex = math.MaxUint32
+	cpy.ContractAddress = common.Address{0xff, 0xff, 0x33}
+	cpy.GasUsed = 0xffffffff
+	cpy.Logs = clearComputedFieldsOnLogs(receipt.Logs)
+	return &cpy
 }
 
-func clearComputedFieldsOnLogs(t *testing.T, logs []*Log) {
-	t.Helper()
-
-	for _, log := range logs {
-		clearComputedFieldsOnLog(t, log)
+func clearComputedFieldsOnLogs(logs []*Log) []*Log {
+	l := make([]*Log, len(logs))
+	for i, log := range logs {
+		cpy := *log
+		cpy.BlockNumber = math.MaxUint32
+		cpy.BlockHash = common.Hash{}
+		cpy.TxHash = common.Hash{}
+		cpy.TxIndex = math.MaxUint32
+		cpy.Index = math.MaxUint32
+		l[i] = &cpy
 	}
-}
-
-func clearComputedFieldsOnLog(t *testing.T, log *Log) {
-	t.Helper()
-
-	log.BlockNumber = math.MaxUint32
-	log.BlockHash = common.Hash{}
-	log.TxHash = common.Hash{}
-	log.TxIndex = math.MaxUint32
-	log.Index = math.MaxUint32
+	return l
 }

--- a/core/types/receipt_test.go
+++ b/core/types/receipt_test.go
@@ -160,7 +160,7 @@ func TestDeriveFields(t *testing.T) {
 	hash := common.BytesToHash([]byte{0x03, 0x14})
 
 	clearComputedFieldsOnReceipts(t, receipts)
-	if err := receipts.DeriveFields(params.TestChainConfig, hash, number.Uint64(), txs); err != nil {
+	if err := receipts.DeriveFields(params.TestChainConfig, hash, number.Uint64(), big.NewInt(0), txs); err != nil {
 		t.Fatalf("DeriveFields(...) = %v, want <nil>", err)
 	}
 	// Iterate over all the computed fields and check that they're correct

--- a/core/types/transaction.go
+++ b/core/types/transaction.go
@@ -85,6 +85,14 @@ type TxData interface {
 
 	rawSignatureValues() (v, r, s *big.Int)
 	setSignatureValues(chainID, v, r, s *big.Int)
+
+	// effectiveGasPrice computes the gas price paid by the transaction, given
+	// the inclusion block baseFee.
+	//
+	// Unlike other TxData methods, the returned *big.Int should be an independent
+	// copy of the computed value, i.e. callers are allowed to mutate the result.
+	// Method implementations can use 'dst' to store the result.
+	effectiveGasPrice(dst *big.Int, baseFee *big.Int) *big.Int
 }
 
 // EncodeRLP implements rlp.Encoder

--- a/core/types/tx_access_list.go
+++ b/core/types/tx_access_list.go
@@ -106,6 +106,10 @@ func (tx *AccessListTx) value() *big.Int        { return tx.Value }
 func (tx *AccessListTx) nonce() uint64          { return tx.Nonce }
 func (tx *AccessListTx) to() *common.Address    { return tx.To }
 
+func (tx *AccessListTx) effectiveGasPrice(dst *big.Int, baseFee *big.Int) *big.Int {
+	return dst.Set(tx.GasPrice)
+}
+
 func (tx *AccessListTx) rawSignatureValues() (v, r, s *big.Int) {
 	return tx.V, tx.R, tx.S
 }

--- a/core/types/tx_dynamic_fee.go
+++ b/core/types/tx_dynamic_fee.go
@@ -94,6 +94,17 @@ func (tx *DynamicFeeTx) value() *big.Int        { return tx.Value }
 func (tx *DynamicFeeTx) nonce() uint64          { return tx.Nonce }
 func (tx *DynamicFeeTx) to() *common.Address    { return tx.To }
 
+func (tx *DynamicFeeTx) effectiveGasPrice(dst *big.Int, baseFee *big.Int) *big.Int {
+	if baseFee == nil {
+		return tx.GasFeeCap
+	}
+	tip := dst.Sub(tx.GasFeeCap, baseFee)
+	if tip.Cmp(tx.GasTipCap) > 0 {
+		tip.Set(tx.GasTipCap)
+	}
+	return tip.Add(tip, baseFee)
+}
+
 func (tx *DynamicFeeTx) rawSignatureValues() (v, r, s *big.Int) {
 	return tx.V, tx.R, tx.S
 }

--- a/core/types/tx_dynamic_fee.go
+++ b/core/types/tx_dynamic_fee.go
@@ -96,7 +96,7 @@ func (tx *DynamicFeeTx) to() *common.Address    { return tx.To }
 
 func (tx *DynamicFeeTx) effectiveGasPrice(dst *big.Int, baseFee *big.Int) *big.Int {
 	if baseFee == nil {
-		return tx.GasFeeCap
+		return dst.Set(tx.GasFeeCap)
 	}
 	tip := dst.Sub(tx.GasFeeCap, baseFee)
 	if tip.Cmp(tx.GasTipCap) > 0 {

--- a/core/types/tx_legacy.go
+++ b/core/types/tx_legacy.go
@@ -103,6 +103,10 @@ func (tx *LegacyTx) value() *big.Int        { return tx.Value }
 func (tx *LegacyTx) nonce() uint64          { return tx.Nonce }
 func (tx *LegacyTx) to() *common.Address    { return tx.To }
 
+func (tx *LegacyTx) effectiveGasPrice(dst *big.Int, baseFee *big.Int) *big.Int {
+	return dst.Set(tx.GasPrice)
+}
+
 func (tx *LegacyTx) rawSignatureValues() (v, r, s *big.Int) {
 	return tx.V, tx.R, tx.S
 }

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -1649,7 +1649,7 @@ func (s *TransactionAPI) GetTransactionReceipt(ctx context.Context, hash common.
 		"logs":              receipt.Logs,
 		"logsBloom":         receipt.Bloom,
 		"type":              hexutil.Uint(tx.Type()),
-		"effectiveGasPrice": receipt.EffectiveGasPrice,
+		"effectiveGasPrice": (*hexutil.Big)(receipt.EffectiveGasPrice),
 	}
 
 	// Assign receipt status or post state.

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -1621,6 +1621,7 @@ func (s *TransactionAPI) GetTransactionReceipt(ctx context.Context, hash common.
 		// as per specification.
 		return nil, nil
 	}
+
 	receipts, err := s.b.GetReceipts(ctx, blockHash)
 	if err != nil {
 		return nil, err
@@ -1648,18 +1649,9 @@ func (s *TransactionAPI) GetTransactionReceipt(ctx context.Context, hash common.
 		"logs":              receipt.Logs,
 		"logsBloom":         receipt.Bloom,
 		"type":              hexutil.Uint(tx.Type()),
+		"effectiveGasPrice": receipt.EffectiveGasPrice,
 	}
-	// Assign the effective gas price paid
-	if !s.b.ChainConfig().IsLondon(bigblock) {
-		fields["effectiveGasPrice"] = hexutil.Uint64(tx.GasPrice().Uint64())
-	} else {
-		header, err := s.b.HeaderByHash(ctx, blockHash)
-		if err != nil {
-			return nil, err
-		}
-		gasPrice := new(big.Int).Add(header.BaseFee, tx.EffectiveGasTipValue(header.BaseFee))
-		fields["effectiveGasPrice"] = hexutil.Uint64(gasPrice.Uint64())
-	}
+
 	// Assign receipt status or post state.
 	if len(receipt.PostState) > 0 {
 		fields["root"] = hexutil.Bytes(receipt.PostState)
@@ -1669,6 +1661,7 @@ func (s *TransactionAPI) GetTransactionReceipt(ctx context.Context, hash common.
 	if receipt.Logs == nil {
 		fields["logs"] = []*types.Log{}
 	}
+
 	// If the ContractAddress is 20 0x0 bytes, assume it is not a contract creation
 	if receipt.ContractAddress != (common.Address{}) {
 		fields["contractAddress"] = receipt.ContractAddress

--- a/light/odr_util.go
+++ b/light/odr_util.go
@@ -175,7 +175,7 @@ func GetBlockReceipts(ctx context.Context, odr OdrBackend, hash common.Hash, num
 		genesis := rawdb.ReadCanonicalHash(odr.Database(), 0)
 		config := rawdb.ReadChainConfig(odr.Database(), genesis)
 
-		if err := receipts.DeriveFields(config, block.Hash(), block.NumberU64(), block.Transactions()); err != nil {
+		if err := receipts.DeriveFields(config, block.Hash(), block.NumberU64(), block.BaseFee(), block.Transactions()); err != nil {
 			return nil, err
 		}
 		rawdb.WriteReceipts(odr.Database(), hash, number, receipts)


### PR DESCRIPTION
Submitting this to take over PR #26250, which I cannot push to for some reason.

This change adds a struct field `EffectiveGasPrice` in `types.Receipt`. The field is present
in RPC responses, but not in the Go struct, and thus can't easily be accessed via ethclient.