### PR TITLE
ci: disable coverage reporting in appveyor and travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -141,7 +141,7 @@ jobs:
       env:
         - GO111MODULE=on
       script:
-        - go run build/ci.go test -coverage $TEST_PACKAGES
+        - go run build/ci.go test $TEST_PACKAGES
 
     - stage: build
       if: type = pull_request
@@ -152,7 +152,7 @@ jobs:
       env:
         - GO111MODULE=on
       script:
-        - go run build/ci.go test -coverage $TEST_PACKAGES
+        - go run build/ci.go test $TEST_PACKAGES
 
     - stage: build
       os: linux
@@ -161,7 +161,7 @@ jobs:
       env:
         - GO111MODULE=on
       script:
-        - go run build/ci.go test -coverage $TEST_PACKAGES
+        - go run build/ci.go test $TEST_PACKAGES
 
     # This builder does the Azure archive purges to avoid accumulating junk
     - stage: build
@@ -186,5 +186,5 @@ jobs:
       env:
         - GO111MODULE=on
       script:
-        - go run build/ci.go test  -race -coverage $TEST_PACKAGES
+        - go run build/ci.go test  -race $TEST_PACKAGES
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -26,7 +26,7 @@ for:
       - go run build/ci.go lint
       - go run build/ci.go install -dlgo
     test_script:
-      - go run build/ci.go test -dlgo -coverage
+      - go run build/ci.go test -dlgo
 
   # linux/386 is disabled.
   - matrix:
@@ -54,4 +54,4 @@ for:
       - go run build/ci.go archive -arch %GETH_ARCH% -type zip -signer WINDOWS_SIGNING_KEY -upload gethstore/builds
       - go run build/ci.go nsis -arch %GETH_ARCH% -signer WINDOWS_SIGNING_KEY -upload gethstore/builds
     test_script:
-      - go run build/ci.go test -dlgo -arch %GETH_ARCH% -cc %GETH_CC% -coverage
+      - go run build/ci.go test -dlgo -arch %GETH_ARCH% -cc %GETH_CC%


### PR DESCRIPTION
This PR is the XOR of https://github.com/ethereum/go-ethereum/pull/26672 

I want to see if this makes the tests run any faster. 

Also, got this error on a windows-build on appveyor: https://ci.appveyor.com/project/ethereum/go-ethereum/builds/46263355/job/0pm78r8hddm84kv5?fullLog=true#L807 

> consolecmd_test.go:60: have "password requirements not met: password too short (<10 characters)\nerror: coverage meta-data emit failed: writing C:\\Users\\appveyor\\AppData\\Local\\Temp\\1\\go-build826161592\\b564\\gocoverdir\\covmeta.c6c1f95b00265a2816b75dfdd6bd5f2e: rename from C:\\Users\\appveyor\\AppData\\Local\\Temp\\1\\go-build826161592\\b564\\gocoverdir\\tmp.covmeta.c6c1f95b00265a2816b75dfdd6bd5f2e1676638211275736200 failed: rename C:\\Users\\appveyor\\AppData\\Local\\Temp\\1\\go-build826161592\\b564\\gocoverdir\\tmp.covmeta.c6c1f95b00265a2816b75dfdd6bd5f2e1676638211275736200 C:\\Users\\appveyor\\AppData\\Local\\Temp\\1\\go-build826161592\\b564\\gocoverdir\\covmeta.c6c1f95b00265a2816b75dfdd6bd5f2e: Access is denied.\n\n", want "password requirements not met: password too short (<10 characters)\n"

Seems like the "reflected run of self" failed to emit coverage data, and caused a failure cascade.