### PR TITLE
eth/catalyst: request too large error

### DIFF
--- a/beacon/engine/errors.go
+++ b/beacon/engine/errors.go
@@ -78,6 +78,7 @@ var (
 	UnknownPayload           = &EngineAPIError{code: -38001, msg: "Unknown payload"}
 	InvalidForkChoiceState   = &EngineAPIError{code: -38002, msg: "Invalid forkchoice state"}
 	InvalidPayloadAttributes = &EngineAPIError{code: -38003, msg: "Invalid payload attributes"}
+	TooLargeRequest          = &EngineAPIError{code: -38004, msg: "Too large request"}
 	InvalidParams            = &EngineAPIError{code: -32602, msg: "Invalid parameters"}
 
 	STATUS_INVALID         = ForkChoiceResponse{PayloadStatus: PayloadStatusV1{Status: INVALID}, PayloadID: nil}

--- a/eth/catalyst/api.go
+++ b/eth/catalyst/api.go
@@ -785,8 +785,11 @@ func (api *ConsensusAPI) GetPayloadBodiesByHashV1(hashes []common.Hash) []*engin
 // GetPayloadBodiesByRangeV1 implements engine_getPayloadBodiesByRangeV1 which allows for retrieval of a range
 // of block bodies by the engine api.
 func (api *ConsensusAPI) GetPayloadBodiesByRangeV1(start, count hexutil.Uint64) ([]*engine.ExecutionPayloadBodyV1, error) {
-	if start == 0 || count == 0 || count > 1024 {
+	if start == 0 || count == 0 {
 		return nil, engine.InvalidParams.With(fmt.Errorf("invalid start or count, start: %v count: %v", start, count))
+	}
+	if count > 1024 {
+		return nil, engine.TooLargeRequest.With(fmt.Errorf("requested count too large: %v", count))
 	}
 	// limit count up until current
 	current := api.eth.BlockChain().CurrentBlock().NumberU64()

--- a/eth/catalyst/api_test.go
+++ b/eth/catalyst/api_test.go
@@ -1403,18 +1403,37 @@ func TestGetBlockBodiesByRangeInvalidParams(t *testing.T) {
 			start: 0,
 			count: 0,
 		},
-		// More than 1024 blocks
-		{
-			start: 1,
-			count: 1025,
-		},
 	}
 
 	for _, test := range tests {
 		result, err := api.GetPayloadBodiesByRangeV1(test.start, test.count)
 		if err == nil {
 			t.Fatalf("expected error, got %v", result)
+		} else if err.Error() != engine.InvalidParams.Error() {
+			t.Fatalf("expected invalid params error, got %v", err.Error())
 		}
+	}
+}
+
+func TestGetBlockBodiesByRangeRequestTooLarge(t *testing.T) {
+	node, eth, _ := setupBodies(t)
+	api := NewConsensusAPI(eth)
+	defer node.Close()
+
+	// More than 1024 blocks
+	test := struct {
+		start hexutil.Uint64
+		count hexutil.Uint64
+	}{
+		start: 1,
+		count: 1025,
+	}
+
+	result, err := api.GetPayloadBodiesByRangeV1(test.start, test.count)
+	if err == nil {
+		t.Fatalf("expected error, got %v", result)
+	} else if err.Error() != engine.TooLargeRequest.Error() {
+		t.Fatalf("expected request too large error, got %v", err.Error())
 	}
 }
 


### PR DESCRIPTION
https://github.com/ethereum/execution-apis/blob/main/src/engine/shanghai.md#specification-4
```
The call MUST return -38004: Too large request error if the requested range is too large.
```