### PR TITLE
rpc: fix unmarshaling of null result in CallContext

### DIFF
--- a/rpc/client.go
+++ b/rpc/client.go
@@ -345,7 +345,10 @@ func (c *Client) CallContext(ctx context.Context, result interface{}, method str
 	case len(resp.Result) == 0:
 		return ErrNoResult
 	default:
-		return json.Unmarshal(resp.Result, &result)
+		if result == nil {
+			return nil
+		}
+		return json.Unmarshal(resp.Result, result)
 	}
 }
 

--- a/rpc/client_test.go
+++ b/rpc/client_test.go
@@ -37,6 +37,34 @@ import (
 	"github.com/ethereum/go-ethereum/log"
 )
 
+type nullTest struct{}
+
+func (s *nullTest) ReturnNull() json.RawMessage {
+	// An example where null results are returned is calling eth_getTransactionReceipt on a non-existent
+	// transaction. The result is null, but the call is not an error.
+	return json.RawMessage("null")
+}
+
+func TestNullResponse(t *testing.T) {
+	server := NewServer()
+	err := server.RegisterName("test", new(nullTest))
+	if err != nil {
+		panic(err)
+	}
+
+	client := DialInProc(server)
+	result := &jsonrpcMessage{}
+
+	err = client.Call(&result.Result, "test_returnNull")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if result.Result == nil {
+		t.Errorf("Expected null, got nil")
+	}
+}
+
 func TestClientRequest(t *testing.T) {
 	server := newTestServer()
 	defer server.Stop()

--- a/rpc/client_test.go
+++ b/rpc/client_test.go
@@ -47,12 +47,14 @@ func (s *nullTest) ReturnNull() json.RawMessage {
 
 func TestNullResponse(t *testing.T) {
 	server := NewServer()
+	defer server.Stop()
 	err := server.RegisterName("test", new(nullTest))
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	client := DialInProc(server)
+	defer client.Close()
 	result := &jsonrpcMessage{}
 
 	err = client.Call(&result.Result, "test_returnNull")

--- a/rpc/client_test.go
+++ b/rpc/client_test.go
@@ -37,18 +37,18 @@ import (
 	"github.com/ethereum/go-ethereum/log"
 )
 
-type nullTest struct{}
+type nullTestService struct{}
 
-func (s *nullTest) ReturnNull() json.RawMessage {
+func (s *nullTestService) ReturnNull() json.RawMessage {
 	// An example where null results are returned is calling eth_getTransactionReceipt on a non-existent
 	// transaction. The result is null, but the call is not an error.
 	return json.RawMessage("null")
 }
 
 func TestNullResponse(t *testing.T) {
-	server := NewServer()
+	server := newTestServer()
 	defer server.Stop()
-	err := server.RegisterName("test", new(nullTest))
+	err := server.RegisterName("test", new(nullTestService))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/rpc/client_test.go
+++ b/rpc/client_test.go
@@ -49,7 +49,7 @@ func TestNullResponse(t *testing.T) {
 	server := NewServer()
 	err := server.RegisterName("test", new(nullTest))
 	if err != nil {
-		panic(err)
+		t.Fatal(err)
 	}
 
 	client := DialInProc(server)
@@ -61,7 +61,11 @@ func TestNullResponse(t *testing.T) {
 	}
 
 	if result.Result == nil {
-		t.Errorf("Expected null, got nil")
+		t.Fatal("Expected non-nil result")
+	}
+
+	if !reflect.DeepEqual(result.Result, json.RawMessage("null")) {
+		t.Errorf("Expected null, got %s", result.Result)
 	}
 }
 

--- a/rpc/server_test.go
+++ b/rpc/server_test.go
@@ -45,7 +45,7 @@ func TestServerRegisterName(t *testing.T) {
 		t.Fatalf("Expected service calc to be registered")
 	}
 
-	wantCallbacks := 12
+	wantCallbacks := 13
 	if len(svc.callbacks) != wantCallbacks {
 		t.Errorf("Expected %d callbacks for service 'service', got %d", wantCallbacks, len(svc.callbacks))
 	}

--- a/rpc/testservice_test.go
+++ b/rpc/testservice_test.go
@@ -78,6 +78,10 @@ func (o *MarshalErrObj) MarshalText() ([]byte, error) {
 
 func (s *testService) NoArgsRets() {}
 
+func (s *testService) Null() any {
+	return nil
+}
+
 func (s *testService) Echo(str string, i int, args *echoArgs) echoResult {
 	return echoResult{str, i, args}
 }


### PR DESCRIPTION
This is a re-submit of PR #26701, which I cannot push to. 

The change fixes unmarshaling of JSON `null` results into `json.RawMessage`.