### PR TITLE
geth/dumpconfig: fix undocumented helptext

### DIFF
--- a/cmd/geth/config.go
+++ b/cmd/geth/config.go
@@ -47,10 +47,10 @@ var (
 	dumpConfigCommand = &cli.Command{
 		Action:      dumpConfig,
 		Name:        "dumpconfig",
-		Usage:       "Show configuration values",
-		ArgsUsage:   "",
+		Usage:       "Export configuration values in a TOML format",
+		ArgsUsage:   "<dumpfile (optional)>",
 		Flags:       flags.Merge(nodeFlags, rpcFlags),
-		Description: `The dumpconfig command shows configuration values.`,
+		Description: `Export configuration values in TOML format (to stdout by default).`,
 	}
 
 	configFileFlag = &cli.StringFlag{


### PR DESCRIPTION
This patch documentizes the 'saving into a file' option. 

As suggested in #16383, piping dumpconfig's stdout is imcompatible to the Windows powershell due to the UTF16LE encoding.
To fix this, #18327 (428eabe) added an option to save dumpconfig in a file. However, users cannot be informed of this feature (saving into a file) without searching the relevant github issue or seeing source code.
Thus, this patch fixes the aforementioned inconvenience by improving the description of the dumpconfig's help text.

fixes: 428eabe, #26658 