### PR TITLE
GraphQL: Fix the long literal passed into the nested variable

### DIFF
--- a/common/hexutil/json.go
+++ b/common/hexutil/json.go
@@ -283,6 +283,8 @@ func (b *Uint64) UnmarshalGraphQL(input interface{}) error {
 		return b.UnmarshalText([]byte(input))
 	case int32:
 		*b = Uint64(input)
+	case float64:
+		*b = Uint64(input)
 	default:
 		err = fmt.Errorf("unexpected type %T for Long", input)
 	}


### PR DESCRIPTION
This commit fixes a bug in graphql when querying with variables and having nested types in variables.

#### Expected behaviour

```shell
curl 'http://localhost:8545/graphql' --data-raw $'{"query":"query ($filter: FilterCriteria\u0021) { logs(filter: $filter) { transaction { hash } }}","variables":{"filter":{"addresses":["0x1f9840a85d5aF5bf1D1762F925BDADdC4201F984"],"fromBlock":16666666,"toBlock":16666666}}}' 

# {"data":{"logs":[{"transaction":{"hash":"0x6007bf4d384fdcf8c953d3c072bab427cb39dd849c8c59fc4555ee9d259c423f"}},{"transaction":{"hash":"0x94f2ebc630936fe30ebe8861bfa5ca424b8e236aa1f885b8282be40cac760987"}}]}}
```
#### Actual behaviour

```shell
# {"errors":[{"message":"unexpected type float64 for Long"}],"data":{}}
```
