### PR TITLE
core: fix accessor mismatch for genesis state

### DIFF
--- a/core/genesis.go
+++ b/core/genesis.go
@@ -138,7 +138,7 @@ func (ga *GenesisAlloc) deriveHash() (common.Hash, error) {
 // flush is very similar with deriveHash, but the main difference is
 // all the generated states will be persisted into the given database.
 // Also, the genesis state specification will be flushed as well.
-func (ga *GenesisAlloc) flush(db ethdb.Database, triedb *trie.Database) error {
+func (ga *GenesisAlloc) flush(db ethdb.Database, triedb *trie.Database, blockhash common.Hash) error {
 	statedb, err := state.New(common.Hash{}, state.NewDatabaseWithNodeDB(db, triedb), nil)
 	if err != nil {
 		return err
@@ -166,15 +166,15 @@ func (ga *GenesisAlloc) flush(db ethdb.Database, triedb *trie.Database) error {
 	if err != nil {
 		return err
 	}
-	rawdb.WriteGenesisStateSpec(db, root, blob)
+	rawdb.WriteGenesisStateSpec(db, blockhash, blob)
 	return nil
 }
 
 // CommitGenesisState loads the stored genesis state with the given block
 // hash and commits it into the provided trie database.
-func CommitGenesisState(db ethdb.Database, triedb *trie.Database, hash common.Hash) error {
+func CommitGenesisState(db ethdb.Database, triedb *trie.Database, blockhash common.Hash) error {
 	var alloc GenesisAlloc
-	blob := rawdb.ReadGenesisStateSpec(db, hash)
+	blob := rawdb.ReadGenesisStateSpec(db, blockhash)
 	if len(blob) != 0 {
 		if err := alloc.UnmarshalJSON(blob); err != nil {
 			return err
@@ -186,7 +186,7 @@ func CommitGenesisState(db ethdb.Database, triedb *trie.Database, hash common.Ha
 		// - supported networks(mainnet, testnets), recover with defined allocations
 		// - private network, can't recover
 		var genesis *Genesis
-		switch hash {
+		switch blockhash {
 		case params.MainnetGenesisHash:
 			genesis = DefaultGenesisBlock()
 		case params.RinkebyGenesisHash:
@@ -202,7 +202,7 @@ func CommitGenesisState(db ethdb.Database, triedb *trie.Database, hash common.Ha
 			return errors.New("not found")
 		}
 	}
-	return alloc.flush(db, triedb)
+	return alloc.flush(db, triedb, blockhash)
 }
 
 // GenesisAccount is an account in the state of the genesis block.
@@ -493,7 +493,7 @@ func (g *Genesis) Commit(db ethdb.Database, triedb *trie.Database) (*types.Block
 	// All the checks has passed, flush the states derived from the genesis
 	// specification as well as the specification itself into the provided
 	// database.
-	if err := g.Alloc.flush(db, triedb); err != nil {
+	if err := g.Alloc.flush(db, triedb, block.Hash()); err != nil {
 		return nil, err
 	}
 	rawdb.WriteTd(db, block.Hash(), block.NumberU64(), block.Difficulty())

--- a/core/rawdb/accessors_metadata.go
+++ b/core/rawdb/accessors_metadata.go
@@ -82,15 +82,15 @@ func WriteChainConfig(db ethdb.KeyValueWriter, hash common.Hash, cfg *params.Cha
 }
 
 // ReadGenesisStateSpec retrieves the genesis state specification based on the
-// given genesis hash.
-func ReadGenesisStateSpec(db ethdb.KeyValueReader, hash common.Hash) []byte {
-	data, _ := db.Get(genesisStateSpecKey(hash))
+// given genesis (block-)hash.
+func ReadGenesisStateSpec(db ethdb.KeyValueReader, blockhash common.Hash) []byte {
+	data, _ := db.Get(genesisStateSpecKey(blockhash))
 	return data
 }
 
 // WriteGenesisStateSpec writes the genesis state specification into the disk.
-func WriteGenesisStateSpec(db ethdb.KeyValueWriter, hash common.Hash, data []byte) {
-	if err := db.Put(genesisStateSpecKey(hash), data); err != nil {
+func WriteGenesisStateSpec(db ethdb.KeyValueWriter, blockhash common.Hash, data []byte) {
+	if err := db.Put(genesisStateSpecKey(blockhash), data); err != nil {
 		log.Crit("Failed to store genesis state", "err", err)
 	}
 }


### PR DESCRIPTION
Closes https://github.com/ethereum/go-ethereum/issues/26746  
Closes #21881

```
$ geth --datadir=/tmp/foobar4  init ~/gen.json 
INFO [02-21|11:07:19.353] Maximum peer count                       ETH=50 LES=0 total=50
INFO [02-21|11:07:19.380] Set global gas cap                       cap=50,000,000
INFO [02-21|11:07:19.382] Using leveldb as the backing database 
INFO [02-21|11:07:19.382] Allocated cache and file handles         database=/tmp/foobar4/geth/chaindata cache=16.00MiB handles=16
INFO [02-21|11:07:19.383] Using LevelDB as the backing database 
INFO [02-21|11:07:19.384] Opened ancient database                  database=/tmp/foobar4/geth/chaindata/ancient/chain readonly=false
INFO [02-21|11:07:19.384] Writing custom genesis block 
INFO [02-21|11:07:19.385] Persisted trie from memory database      nodes=4 size=639.00B time="260.196µs" gcnodes=0 gcsize=0.00B gctime=0s livenodes=1 livesize=0.00B
INFO [02-21|11:07:19.385] Successfully wrote genesis state         database=chaindata                   hash=170f6a..b53b17
INFO [02-21|11:07:19.385] Using leveldb as the backing database 
INFO [02-21|11:07:19.385] Allocated cache and file handles         database=/tmp/foobar4/geth/lightchaindata cache=16.00MiB handles=16
INFO [02-21|11:07:19.386] Using LevelDB as the backing database 
INFO [02-21|11:07:19.386] Opened ancient database                  database=/tmp/foobar4/geth/lightchaindata/ancient/chain readonly=false
INFO [02-21|11:07:19.386] Writing custom genesis block 
INFO [02-21|11:07:19.386] Persisted trie from memory database      nodes=4 size=639.00B time="219.818µs" gcnodes=0 gcsize=0.00B gctime=0s livenodes=1 livesize=0.00B
INFO [02-21|11:07:19.387] Freezer shutting down 
INFO [02-21|11:07:19.387] Successfully wrote genesis state         database=lightchaindata                   hash=170f6a..b53b17
[user@work go-ethereum]$ geth --datadir=/tmp/foobar4  dumpgenesis
INFO [02-21|11:07:23.257] Maximum peer count                       ETH=50 LES=0 total=50
INFO [02-21|11:07:23.270] Set global gas cap                       cap=50,000,000
INFO [02-21|11:07:23.272] Using leveldb as the backing database 
INFO [02-21|11:07:23.272] Allocated cache and file handles         database=/tmp/foobar4/geth/chaindata cache=16.00MiB handles=16 readonly=true
INFO [02-21|11:07:23.274] Using LevelDB as the backing database 
{"config":{"chainId":12345,"homesteadBlock":0,"eip150Block":0,"eip150Hash":"0x0000000000000000000000000000000000000000000000000000000000000000","eip155Block":0,"eip158Block":0,"byzantiumBlock":0,"constantinopleBlock":0,"petersburgBlock":0,"istanbulBlock":0,"berlinBlock":0,"clique":{"period":5,"epoch":30000}},"nonce":"0x0","timestamp":"0x0","extraData":"0x00000000000000000000000000000000000000000000000000000000000000009ccf0fc294d629719ecef4570632cd1fdee02c770000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000","gasLimit":"0x7530","difficulty":"0x1","mixHash":"0x0000000000000000000000000000000000000000000000000000000000000000","coinbase":"0x0000000000000000000000000000000000000000","alloc":{"6f095002ad09006dda6c5fecdc4e58550caab34e":{"balance":"0x100000000000000000000000000000000000000000000000000"},"9ccf0fc294d629719ecef4570632cd1fdee02c77":{"balance":"0x100000000000000000000000000000000000000000000000000"},"de9ad14212772d071c65be3e84c390ea462735b6":{"balance":"0x100000000000000000000000000000000000000000000000000"}},"number":"0x0","gasUsed":"0x0","parentHash":"0x0000000000000000000000000000000000000000000000000000000000000000","baseFeePerGas":null}
```
