### PR TITLE
core/rawdb: expose chain freezer constructor without internals

### DIFF
--- a/core/rawdb/chain_freezer.go
+++ b/core/rawdb/chain_freezer.go
@@ -55,8 +55,8 @@ type chainFreezer struct {
 }
 
 // newChainFreezer initializes the freezer for ancient chain data.
-func newChainFreezer(datadir string, namespace string, readonly bool, maxTableSize uint32, tables map[string]bool) (*chainFreezer, error) {
-	freezer, err := NewFreezer(datadir, namespace, readonly, maxTableSize, tables)
+func newChainFreezer(datadir string, namespace string, readonly bool) (*chainFreezer, error) {
+	freezer, err := NewChainFreezer(datadir, namespace, readonly)
 	if err != nil {
 		return nil, err
 	}

--- a/core/rawdb/database.go
+++ b/core/rawdb/database.go
@@ -200,7 +200,7 @@ func resolveChainFreezerDir(ancient string) string {
 // where the chain freezer can be opened.
 func NewDatabaseWithFreezer(db ethdb.KeyValueStore, ancient string, namespace string, readonly bool) (ethdb.Database, error) {
 	// Create the idle freezer instance
-	frdb, err := newChainFreezer(resolveChainFreezerDir(ancient), namespace, readonly, freezerTableSize, chainFreezerNoSnappy)
+	frdb, err := newChainFreezer(resolveChainFreezerDir(ancient), namespace, readonly)
 	if err != nil {
 		return nil, err
 	}

--- a/core/rawdb/freezer.go
+++ b/core/rawdb/freezer.go
@@ -79,6 +79,12 @@ type Freezer struct {
 	closeOnce    sync.Once
 }
 
+// NewChainFreezer is a small utility method around NewFreezer that sets the
+// default parameters for the chain storage.
+func NewChainFreezer(datadir string, namespace string, readonly bool) (*Freezer, error) {
+	return NewFreezer(datadir, namespace, readonly, freezerTableSize, chainFreezerNoSnappy)
+}
+
 // NewFreezer creates a freezer instance for maintaining immutable ordered
 // data according to the given parameters.
 //


### PR DESCRIPTION
Although the `NewFreezer` method was public until now, it was really impossible to initiate a chain freezer out of it because two parameters: the table size limit and the configuration which tables to snappy encode and which to leave in cleartext were private. Although we could have made the configs public, it's a bit of too much internal detail. Instead, this PR makes a public helped method `NewChainFreezer` that just sets these internal configs automatically.

CC @lightclient 