### PR TITLE
core: ensure increasing BlockGen withdrawal index

### DIFF
--- a/core/chain_makers.go
+++ b/core/chain_makers.go
@@ -207,9 +207,12 @@ func (b *BlockGen) AddUncle(h *types.Header) {
 }
 
 // AddWithdrawal adds a withdrawal to the generated block.
-func (b *BlockGen) AddWithdrawal(w *types.Withdrawal) {
-	w.Index = b.nextWithdrawalIndex()
-	b.withdrawals = append(b.withdrawals, w)
+// It returns the withdrawal index.
+func (b *BlockGen) AddWithdrawal(w *types.Withdrawal) uint64 {
+	cpy := *w
+	cpy.Index = b.nextWithdrawalIndex()
+	b.withdrawals = append(b.withdrawals, &cpy)
+	return cpy.Index
 }
 
 // nextWithdrawalIndex computes the index of the next withdrawal.

--- a/core/chain_makers.go
+++ b/core/chain_makers.go
@@ -210,6 +210,16 @@ func (b *BlockGen) AddUncle(h *types.Header) {
 func (b *BlockGen) AddWithdrawal(w *types.Withdrawal) {
 	// The withdrawal will be assigned the next valid index.
 	var idx uint64
+
+	// set the initial index to the last withdrawal index in the block + 1, if
+	// it exists. otherwise, determine the proper index from parent blocks
+	if len(b.withdrawals) != 0 {
+		idx = b.withdrawals[len(b.withdrawals)-1].Index + 1
+		w.Index = idx
+		b.withdrawals = append(b.withdrawals, w)
+		return
+	}
+
 	for i := b.i - 1; i >= 0; i-- {
 		if wd := b.chain[i].Withdrawals(); len(wd) != 0 {
 			idx = wd[len(wd)-1].Index + 1

--- a/core/chain_makers.go
+++ b/core/chain_makers.go
@@ -211,7 +211,7 @@ func (b *BlockGen) AddWithdrawal(w *types.Withdrawal) {
 	// The withdrawal will be assigned the next valid index.
 	var idx uint64
 
-	// set the initial index to the last withdrawal index in the block + 1, if
+	// Set the initial index to the last withdrawal index in the block + 1, if
 	// it exists. otherwise, determine the proper index from parent blocks
 	if len(b.withdrawals) != 0 {
 		idx = b.withdrawals[len(b.withdrawals)-1].Index + 1
@@ -219,7 +219,6 @@ func (b *BlockGen) AddWithdrawal(w *types.Withdrawal) {
 		b.withdrawals = append(b.withdrawals, w)
 		return
 	}
-
 	for i := b.i - 1; i >= 0; i-- {
 		if wd := b.chain[i].Withdrawals(); len(wd) != 0 {
 			idx = wd[len(wd)-1].Index + 1

--- a/core/chain_makers.go
+++ b/core/chain_makers.go
@@ -208,31 +208,27 @@ func (b *BlockGen) AddUncle(h *types.Header) {
 
 // AddWithdrawal adds a withdrawal to the generated block.
 func (b *BlockGen) AddWithdrawal(w *types.Withdrawal) {
-	// The withdrawal will be assigned the next valid index.
-	var idx uint64
+	w.Index = b.nextWithdrawalIndex()
+	b.withdrawals = append(b.withdrawals, w)
+}
 
-	// Set the initial index to the last withdrawal index in the block + 1, if
-	// it exists. otherwise, determine the proper index from parent blocks
+// nextWithdrawalIndex computes the index of the next withdrawal.
+func (b *BlockGen) nextWithdrawalIndex() uint64 {
 	if len(b.withdrawals) != 0 {
-		idx = b.withdrawals[len(b.withdrawals)-1].Index + 1
-		w.Index = idx
-		b.withdrawals = append(b.withdrawals, w)
-		return
+		return b.withdrawals[len(b.withdrawals)-1].Index + 1
 	}
 	for i := b.i - 1; i >= 0; i-- {
 		if wd := b.chain[i].Withdrawals(); len(wd) != 0 {
-			idx = wd[len(wd)-1].Index + 1
-			break
+			return wd[len(wd)-1].Index + 1
 		}
 		if i == 0 {
-			// Correctly set the index if no parent had withdrawals
+			// Correctly set the index if no parent had withdrawals.
 			if wd := b.parent.Withdrawals(); len(wd) != 0 {
-				idx = wd[len(wd)-1].Index + 1
+				return wd[len(wd)-1].Index + 1
 			}
 		}
 	}
-	w.Index = idx
-	b.withdrawals = append(b.withdrawals, w)
+	return 0
 }
 
 // PrevBlock returns a previously generated block by number. It panics if

--- a/core/chain_makers_test.go
+++ b/core/chain_makers_test.go
@@ -39,8 +39,9 @@ func TestGenerateWithdrawalChain(t *testing.T) {
 		aa      = common.Address{0xaa}
 		bb      = common.Address{0xbb}
 		funds   = big.NewInt(0).Mul(big.NewInt(1337), big.NewInt(params.Ether))
+		config  = *params.AllEthashProtocolChanges
 		gspec   = &Genesis{
-			Config:     params.AllEthashProtocolChanges,
+			Config:     &config,
 			Alloc:      GenesisAlloc{address: {Balance: funds}},
 			BaseFee:    big.NewInt(params.InitialBaseFee),
 			Difficulty: common.Big1,
@@ -50,9 +51,10 @@ func TestGenerateWithdrawalChain(t *testing.T) {
 		signer = types.LatestSigner(gspec.Config)
 		db     = rawdb.NewMemoryDatabase()
 	)
-	gspec.Config.TerminalTotalDifficultyPassed = true
-	gspec.Config.TerminalTotalDifficulty = common.Big0
-	gspec.Config.ShanghaiTime = u64(0)
+
+	config.TerminalTotalDifficultyPassed = true
+	config.TerminalTotalDifficulty = common.Big0
+	config.ShanghaiTime = u64(0)
 
 	// init 0xaa with some storage elements
 	storage := make(map[common.Hash]common.Hash)

--- a/core/chain_makers_test.go
+++ b/core/chain_makers_test.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"math/big"
 
+	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/consensus/ethash"
 	"github.com/ethereum/go-ethereum/core/rawdb"
 	"github.com/ethereum/go-ethereum/core/types"
@@ -27,6 +28,83 @@ import (
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/params"
 )
+
+func TestGenerateWithdrawalChain() {
+	var (
+		keyHex  = "9c647b8b7c4e7c3490668fb6c11473619db80c93704c70893d3813af4090c39c"
+		key, _  = crypto.HexToECDSA(keyHex)
+		address = crypto.PubkeyToAddress(key.PublicKey) // 658bdf435d810c91414ec09147daa6db62406379
+		aa      = common.Address{0xaa}
+		bb      = common.Address{0xbb}
+		funds   = big.NewInt(0).Mul(big.NewInt(1337), big.NewInt(params.Ether))
+		gspec   = &Genesis{
+			Config:     params.AllEthashProtocolChanges,
+			Alloc:      GenesisAlloc{address: {Balance: funds}},
+			BaseFee:    big.NewInt(params.InitialBaseFee),
+			Difficulty: common.Big1,
+			GasLimit:   5_000_000,
+		}
+		gendb  = rawdb.NewMemoryDatabase()
+		signer = types.LatestSigner(gspec.Config)
+		db     = rawdb.NewMemoryDatabase()
+	)
+	gspec.Config.TerminalTotalDifficultyPassed = true
+	gspec.Config.TerminalTotalDifficulty = common.Big0
+	gspec.Config.ShanghaiTime = u64(0)
+
+	// init 0xaa with some storage elements
+	storage := make(map[common.Hash]common.Hash)
+	storage[common.Hash{0x00}] = common.Hash{0x00}
+	storage[common.Hash{0x01}] = common.Hash{0x01}
+	storage[common.Hash{0x02}] = common.Hash{0x02}
+	storage[common.Hash{0x03}] = common.HexToHash("0303")
+	gspec.Alloc[aa] = GenesisAccount{
+		Balance: common.Big1,
+		Nonce:   1,
+		Storage: storage,
+		Code:    common.Hex2Bytes("6042"),
+	}
+	gspec.Alloc[bb] = GenesisAccount{
+		Balance: common.Big2,
+		Nonce:   1,
+		Storage: storage,
+		Code:    common.Hex2Bytes("600154600354"),
+	}
+
+	genesis := gspec.MustCommit(gendb)
+
+	// sealingEngine := sealingEngine{engine}
+	chain, _ := GenerateChain(gspec.Config, genesis, ethash.NewFaker(), gendb, 4, func(i int, gen *BlockGen) {
+		tx, _ := types.SignTx(types.NewTransaction(gen.TxNonce(address), address, big.NewInt(1000), params.TxGas, new(big.Int).Add(gen.BaseFee(), common.Big1), nil), signer, key)
+		gen.AddTx(tx)
+		if i == 1 {
+			// first index for the withdrawal block
+			idxOne := uint64(123)
+
+			gen.AddWithdrawal(&types.Withdrawal{
+				Index:     idxOne,
+				Validator: 42,
+				Address:   common.Address{0xee},
+				Amount:    1337,
+			})
+			gen.AddWithdrawal(&types.Withdrawal{
+				Index:     idxOne + 1,
+				Validator: 13,
+				Address:   common.Address{0xee},
+				Amount:    1,
+			})
+		}
+	})
+
+	// Import the chain. This runs all block validation rules.
+	blockchain, _ := NewBlockChain(db, nil, gspec, nil, ethash.NewFaker(), vm.Config{}, nil, nil)
+	defer blockchain.Stop()
+
+	if i, err := blockchain.InsertChain(chain); err != nil {
+		fmt.Printf("insert error (block %d): %v\n", chain[i].NumberU64(), err)
+		return
+	}
+}
 
 func ExampleGenerateChain() {
 	var (

--- a/core/chain_makers_test.go
+++ b/core/chain_makers_test.go
@@ -80,17 +80,12 @@ func TestGenerateWithdrawalChain(t *testing.T) {
 		tx, _ := types.SignTx(types.NewTransaction(gen.TxNonce(address), address, big.NewInt(1000), params.TxGas, new(big.Int).Add(gen.BaseFee(), common.Big1), nil), signer, key)
 		gen.AddTx(tx)
 		if i == 1 {
-			// first index for the withdrawal block
-			idxOne := uint64(0)
-
 			gen.AddWithdrawal(&types.Withdrawal{
-				Index:     idxOne,
 				Validator: 42,
 				Address:   common.Address{0xee},
 				Amount:    1337,
 			})
 			gen.AddWithdrawal(&types.Withdrawal{
-				Index:     idxOne + 1,
 				Validator: 13,
 				Address:   common.Address{0xee},
 				Amount:    1,


### PR DESCRIPTION
Previously, during chain generation, `AddWithdrawal` would look at parent blocks to determine what the proper withdrawal index is when adding a withdrawal. This was flawed because if there were no withdrawals in parent blocks, and one block added multiple withdrawals, those withdrawals would be given the same index.

The `AddWithdrawal` method is changed, setting the index based on the withdrawal with the highest index in the current block, if there are any other withdrawals.

A test is added, derived from the [withdrawals branch of rpctestgen](https://github.com/lightclient/rpctestgen/tree/withdrawals), making sure same-block withdrawals have increasing indexes.