### PR TITLE
common/math: allow HexOrDecimal to accept unquoted decimals too

### DIFF
--- a/common/math/big.go
+++ b/common/math/big.go
@@ -49,6 +49,17 @@ func NewHexOrDecimal256(x int64) *HexOrDecimal256 {
 	return &h
 }
 
+// UnmarshalJSON implements json.Unmarshaler.
+//
+// It is similar to UnmarshalText, but allows parsing real decimals too, not just
+// quoted decimal strings.
+func (i *HexOrDecimal256) UnmarshalJSON(input []byte) error {
+	if len(input) > 0 && input[0] == '"' {
+		input = input[1 : len(input)-1]
+	}
+	return i.UnmarshalText(input)
+}
+
 // UnmarshalText implements encoding.TextUnmarshaler.
 func (i *HexOrDecimal256) UnmarshalText(input []byte) error {
 	bigint, ok := ParseBig256(string(input))

--- a/common/math/integer.go
+++ b/common/math/integer.go
@@ -41,6 +41,17 @@ const (
 // HexOrDecimal64 marshals uint64 as hex or decimal.
 type HexOrDecimal64 uint64
 
+// UnmarshalJSON implements json.Unmarshaler.
+//
+// It is similar to UnmarshalText, but allows parsing real decimals too, not just
+// quoted decimal strings.
+func (i *HexOrDecimal64) UnmarshalJSON(input []byte) error {
+	if len(input) > 0 && input[0] == '"' {
+		input = input[1 : len(input)-1]
+	}
+	return i.UnmarshalText(input)
+}
+
 // UnmarshalText implements encoding.TextUnmarshaler.
 func (i *HexOrDecimal64) UnmarshalText(input []byte) error {
 	int, ok := ParseUint64(string(input))


### PR DESCRIPTION
Fixes https://github.com/ethereum/go-ethereum/issues/26751

Before PR:

```
> eth.feeHistory(12, "latest")
Error: invalid argument 0: json: cannot unmarshal number into Go value of type *math.HexOrDecimal64
	at web3.js:6365:9(39)
	at send (web3.js:5099:62(29))
	at <eval>:1:15(4)
```

After PR:

```
> eth.feeHistory(12, "latest")
{
  baseFeePerGas: ["0x0", "0x0"],
  gasUsedRatio: [0],
  oldestBlock: "0x0"
}
> eth.feeHistory("12", "latest")
{
  baseFeePerGas: ["0x0", "0x0"],
  gasUsedRatio: [0],
  oldestBlock: "0x0"
}
> eth.feeHistory("0xc", "latest")
{
  baseFeePerGas: ["0x0", "0x0"],
  gasUsedRatio: [0],
  oldestBlock: "0x0"
}
```