### PR TITLE
signer/core: accept all solidity primitive types for EIP-712 signing 

### DIFF
--- a/signer/core/apitypes/types.go
+++ b/signer/core/apitypes/types.go
@@ -819,14 +819,64 @@ func isPrimitiveTypeValid(primitiveType string) bool {
 		primitiveType == "int8[]" ||
 		primitiveType == "int16" ||
 		primitiveType == "int16[]" ||
+		primitiveType == "int24" ||
+		primitiveType == "int24[]" ||
 		primitiveType == "int32" ||
 		primitiveType == "int32[]" ||
+		primitiveType == "int40" ||
+		primitiveType == "int40[]" ||
+		primitiveType == "int48" ||
+		primitiveType == "int48[]" ||
+		primitiveType == "int56" ||
+		primitiveType == "int56[]" ||
 		primitiveType == "int64" ||
 		primitiveType == "int64[]" ||
+		primitiveType == "int72" ||
+		primitiveType == "int72[]" ||
+		primitiveType == "int80" ||
+		primitiveType == "int80[]" ||
+		primitiveType == "int88" ||
+		primitiveType == "int88[]" ||
 		primitiveType == "int96" ||
 		primitiveType == "int96[]" ||
+		primitiveType == "int104" ||
+		primitiveType == "int104[]" ||
+		primitiveType == "int112" ||
+		primitiveType == "int112[]" ||
+		primitiveType == "int120" ||
+		primitiveType == "int120[]" ||
 		primitiveType == "int128" ||
 		primitiveType == "int128[]" ||
+		primitiveType == "int136" ||
+		primitiveType == "int136[]" ||
+		primitiveType == "int144" ||
+		primitiveType == "int144[]" ||
+		primitiveType == "int152" ||
+		primitiveType == "int152[]" ||
+		primitiveType == "int160" ||
+		primitiveType == "int160[]" ||
+		primitiveType == "int168" ||
+		primitiveType == "int168[]" ||
+		primitiveType == "int176" ||
+		primitiveType == "int176[]" ||
+		primitiveType == "int184" ||
+		primitiveType == "int184[]" ||
+		primitiveType == "int192" ||
+		primitiveType == "int192[]" ||
+		primitiveType == "int200" ||
+		primitiveType == "int200[]" ||
+		primitiveType == "int208" ||
+		primitiveType == "int208[]" ||
+		primitiveType == "int216" ||
+		primitiveType == "int216[]" ||
+		primitiveType == "int224" ||
+		primitiveType == "int224[]" ||
+		primitiveType == "int232" ||
+		primitiveType == "int232[]" ||
+		primitiveType == "int240" ||
+		primitiveType == "int240[]" ||
+		primitiveType == "int248" ||
+		primitiveType == "int248[]" ||
 		primitiveType == "int256" ||
 		primitiveType == "int256[]" {
 		return true
@@ -834,19 +884,69 @@ func isPrimitiveTypeValid(primitiveType string) bool {
 	if primitiveType == "uint" ||
 		primitiveType == "uint[]" ||
 		primitiveType == "uint8" ||
-		primitiveType == "uint8[]" ||
-		primitiveType == "uint16" ||
-		primitiveType == "uint16[]" ||
-		primitiveType == "uint32" ||
-		primitiveType == "uint32[]" ||
-		primitiveType == "uint64" ||
-		primitiveType == "uint64[]" ||
-		primitiveType == "uint96" ||
-		primitiveType == "uint96[]" ||
-		primitiveType == "uint128" ||
-		primitiveType == "uint128[]" ||
-		primitiveType == "uint256" ||
-		primitiveType == "uint256[]" {
+        primitiveType == "uint8[]" ||
+        primitiveType == "uint16" ||
+        primitiveType == "uint16[]" ||
+        primitiveType == "uint24" ||
+        primitiveType == "uint24[]" ||
+        primitiveType == "uint32" ||
+        primitiveType == "uint32[]" ||
+        primitiveType == "uint40" ||
+        primitiveType == "uint40[]" ||
+        primitiveType == "uint48" ||
+        primitiveType == "uint48[]" ||
+        primitiveType == "uint56" ||
+        primitiveType == "uint56[]" ||
+        primitiveType == "uint64" ||
+        primitiveType == "uint64[]" ||
+        primitiveType == "uint72" ||
+        primitiveType == "uint72[]" ||
+        primitiveType == "uint80" ||
+        primitiveType == "uint80[]" ||
+        primitiveType == "uint88" ||
+        primitiveType == "uint88[]" ||
+        primitiveType == "uint96" ||
+        primitiveType == "uint96[]" ||
+        primitiveType == "uint104" ||
+        primitiveType == "uint104[]" ||
+        primitiveType == "uint112" ||
+        primitiveType == "uint112[]" ||
+        primitiveType == "uint120" ||
+        primitiveType == "uint120[]" ||
+        primitiveType == "uint128" ||
+        primitiveType == "uint128[]" ||
+        primitiveType == "uint136" ||
+        primitiveType == "uint136[]" ||
+        primitiveType == "uint144" ||
+        primitiveType == "uint144[]" ||
+        primitiveType == "uint152" ||
+        primitiveType == "uint152[]" ||
+        primitiveType == "uint160" ||
+        primitiveType == "uint160[]" ||
+        primitiveType == "uint168" ||
+        primitiveType == "uint168[]" ||
+        primitiveType == "uint176" ||
+        primitiveType == "uint176[]" ||
+        primitiveType == "uint184" ||
+        primitiveType == "uint184[]" ||
+        primitiveType == "uint192" ||
+        primitiveType == "uint192[]" ||
+        primitiveType == "uint200" ||
+        primitiveType == "uint200[]" ||
+        primitiveType == "uint208" ||
+        primitiveType == "uint208[]" ||
+        primitiveType == "uint216" ||
+        primitiveType == "uint216[]" ||
+        primitiveType == "uint224" ||
+        primitiveType == "uint224[]" ||
+        primitiveType == "uint232" ||
+        primitiveType == "uint232[]" ||
+        primitiveType == "uint240" ||
+        primitiveType == "uint240[]" ||
+        primitiveType == "uint248" ||
+        primitiveType == "uint248[]" ||
+        primitiveType == "uint256" ||
+        primitiveType == "uint256[]" {
 		return true
 	}
 	return false

--- a/signer/core/apitypes/types.go
+++ b/signer/core/apitypes/types.go
@@ -742,212 +742,30 @@ func isPrimitiveTypeValid(primitiveType string) bool {
 		primitiveType == "bool" ||
 		primitiveType == "bool[]" ||
 		primitiveType == "string" ||
-		primitiveType == "string[]" {
-		return true
-	}
-	if primitiveType == "bytes" ||
+		primitiveType == "string[]" ||
+		primitiveType == "bytes" ||
 		primitiveType == "bytes[]" ||
-		primitiveType == "bytes1" ||
-		primitiveType == "bytes1[]" ||
-		primitiveType == "bytes2" ||
-		primitiveType == "bytes2[]" ||
-		primitiveType == "bytes3" ||
-		primitiveType == "bytes3[]" ||
-		primitiveType == "bytes4" ||
-		primitiveType == "bytes4[]" ||
-		primitiveType == "bytes5" ||
-		primitiveType == "bytes5[]" ||
-		primitiveType == "bytes6" ||
-		primitiveType == "bytes6[]" ||
-		primitiveType == "bytes7" ||
-		primitiveType == "bytes7[]" ||
-		primitiveType == "bytes8" ||
-		primitiveType == "bytes8[]" ||
-		primitiveType == "bytes9" ||
-		primitiveType == "bytes9[]" ||
-		primitiveType == "bytes10" ||
-		primitiveType == "bytes10[]" ||
-		primitiveType == "bytes11" ||
-		primitiveType == "bytes11[]" ||
-		primitiveType == "bytes12" ||
-		primitiveType == "bytes12[]" ||
-		primitiveType == "bytes13" ||
-		primitiveType == "bytes13[]" ||
-		primitiveType == "bytes14" ||
-		primitiveType == "bytes14[]" ||
-		primitiveType == "bytes15" ||
-		primitiveType == "bytes15[]" ||
-		primitiveType == "bytes16" ||
-		primitiveType == "bytes16[]" ||
-		primitiveType == "bytes17" ||
-		primitiveType == "bytes17[]" ||
-		primitiveType == "bytes18" ||
-		primitiveType == "bytes18[]" ||
-		primitiveType == "bytes19" ||
-		primitiveType == "bytes19[]" ||
-		primitiveType == "bytes20" ||
-		primitiveType == "bytes20[]" ||
-		primitiveType == "bytes21" ||
-		primitiveType == "bytes21[]" ||
-		primitiveType == "bytes22" ||
-		primitiveType == "bytes22[]" ||
-		primitiveType == "bytes23" ||
-		primitiveType == "bytes23[]" ||
-		primitiveType == "bytes24" ||
-		primitiveType == "bytes24[]" ||
-		primitiveType == "bytes25" ||
-		primitiveType == "bytes25[]" ||
-		primitiveType == "bytes26" ||
-		primitiveType == "bytes26[]" ||
-		primitiveType == "bytes27" ||
-		primitiveType == "bytes27[]" ||
-		primitiveType == "bytes28" ||
-		primitiveType == "bytes28[]" ||
-		primitiveType == "bytes29" ||
-		primitiveType == "bytes29[]" ||
-		primitiveType == "bytes30" ||
-		primitiveType == "bytes30[]" ||
-		primitiveType == "bytes31" ||
-		primitiveType == "bytes31[]" ||
-		primitiveType == "bytes32" ||
-		primitiveType == "bytes32[]" {
-		return true
-	}
-	if primitiveType == "int" ||
+		primitiveType == "int" ||
 		primitiveType == "int[]" ||
-		primitiveType == "int8" ||
-		primitiveType == "int8[]" ||
-		primitiveType == "int16" ||
-		primitiveType == "int16[]" ||
-		primitiveType == "int24" ||
-		primitiveType == "int24[]" ||
-		primitiveType == "int32" ||
-		primitiveType == "int32[]" ||
-		primitiveType == "int40" ||
-		primitiveType == "int40[]" ||
-		primitiveType == "int48" ||
-		primitiveType == "int48[]" ||
-		primitiveType == "int56" ||
-		primitiveType == "int56[]" ||
-		primitiveType == "int64" ||
-		primitiveType == "int64[]" ||
-		primitiveType == "int72" ||
-		primitiveType == "int72[]" ||
-		primitiveType == "int80" ||
-		primitiveType == "int80[]" ||
-		primitiveType == "int88" ||
-		primitiveType == "int88[]" ||
-		primitiveType == "int96" ||
-		primitiveType == "int96[]" ||
-		primitiveType == "int104" ||
-		primitiveType == "int104[]" ||
-		primitiveType == "int112" ||
-		primitiveType == "int112[]" ||
-		primitiveType == "int120" ||
-		primitiveType == "int120[]" ||
-		primitiveType == "int128" ||
-		primitiveType == "int128[]" ||
-		primitiveType == "int136" ||
-		primitiveType == "int136[]" ||
-		primitiveType == "int144" ||
-		primitiveType == "int144[]" ||
-		primitiveType == "int152" ||
-		primitiveType == "int152[]" ||
-		primitiveType == "int160" ||
-		primitiveType == "int160[]" ||
-		primitiveType == "int168" ||
-		primitiveType == "int168[]" ||
-		primitiveType == "int176" ||
-		primitiveType == "int176[]" ||
-		primitiveType == "int184" ||
-		primitiveType == "int184[]" ||
-		primitiveType == "int192" ||
-		primitiveType == "int192[]" ||
-		primitiveType == "int200" ||
-		primitiveType == "int200[]" ||
-		primitiveType == "int208" ||
-		primitiveType == "int208[]" ||
-		primitiveType == "int216" ||
-		primitiveType == "int216[]" ||
-		primitiveType == "int224" ||
-		primitiveType == "int224[]" ||
-		primitiveType == "int232" ||
-		primitiveType == "int232[]" ||
-		primitiveType == "int240" ||
-		primitiveType == "int240[]" ||
-		primitiveType == "int248" ||
-		primitiveType == "int248[]" ||
-		primitiveType == "int256" ||
-		primitiveType == "int256[]" {
+		primitiveType == "uint" ||
+		primitiveType == "uint[]" {
 		return true
 	}
-	if primitiveType == "uint" ||
-		primitiveType == "uint[]" ||
-		primitiveType == "uint8" ||
-        primitiveType == "uint8[]" ||
-        primitiveType == "uint16" ||
-        primitiveType == "uint16[]" ||
-        primitiveType == "uint24" ||
-        primitiveType == "uint24[]" ||
-        primitiveType == "uint32" ||
-        primitiveType == "uint32[]" ||
-        primitiveType == "uint40" ||
-        primitiveType == "uint40[]" ||
-        primitiveType == "uint48" ||
-        primitiveType == "uint48[]" ||
-        primitiveType == "uint56" ||
-        primitiveType == "uint56[]" ||
-        primitiveType == "uint64" ||
-        primitiveType == "uint64[]" ||
-        primitiveType == "uint72" ||
-        primitiveType == "uint72[]" ||
-        primitiveType == "uint80" ||
-        primitiveType == "uint80[]" ||
-        primitiveType == "uint88" ||
-        primitiveType == "uint88[]" ||
-        primitiveType == "uint96" ||
-        primitiveType == "uint96[]" ||
-        primitiveType == "uint104" ||
-        primitiveType == "uint104[]" ||
-        primitiveType == "uint112" ||
-        primitiveType == "uint112[]" ||
-        primitiveType == "uint120" ||
-        primitiveType == "uint120[]" ||
-        primitiveType == "uint128" ||
-        primitiveType == "uint128[]" ||
-        primitiveType == "uint136" ||
-        primitiveType == "uint136[]" ||
-        primitiveType == "uint144" ||
-        primitiveType == "uint144[]" ||
-        primitiveType == "uint152" ||
-        primitiveType == "uint152[]" ||
-        primitiveType == "uint160" ||
-        primitiveType == "uint160[]" ||
-        primitiveType == "uint168" ||
-        primitiveType == "uint168[]" ||
-        primitiveType == "uint176" ||
-        primitiveType == "uint176[]" ||
-        primitiveType == "uint184" ||
-        primitiveType == "uint184[]" ||
-        primitiveType == "uint192" ||
-        primitiveType == "uint192[]" ||
-        primitiveType == "uint200" ||
-        primitiveType == "uint200[]" ||
-        primitiveType == "uint208" ||
-        primitiveType == "uint208[]" ||
-        primitiveType == "uint216" ||
-        primitiveType == "uint216[]" ||
-        primitiveType == "uint224" ||
-        primitiveType == "uint224[]" ||
-        primitiveType == "uint232" ||
-        primitiveType == "uint232[]" ||
-        primitiveType == "uint240" ||
-        primitiveType == "uint240[]" ||
-        primitiveType == "uint248" ||
-        primitiveType == "uint248[]" ||
-        primitiveType == "uint256" ||
-        primitiveType == "uint256[]" {
-		return true
+	// For 'bytesN', 'bytesN[]', we allow N from 1 to 32
+	for n := 1; n <= 32; n++ {
+		// e.g. 'bytes28' or 'bytes28[]'
+		if primitiveType == fmt.Sprintf("bytes%d", n) || primitiveType == fmt.Sprintf("bytes%d[]", n) {
+			return true
+		}
+	}
+	// For 'intN','intN[]' and 'uintN','uintN[]' we allow N in increments of 8, from 8 up to 256
+	for n := 8; n <= 256; n += 8 {
+		if primitiveType == fmt.Sprintf("int%d", n) || primitiveType == fmt.Sprintf("int%d[]", n) {
+			return true
+		}
+		if primitiveType == fmt.Sprintf("uint%d", n) || primitiveType == fmt.Sprintf("uint%d[]", n) {
+			return true
+		}
 	}
 	return false
 }

--- a/signer/core/apitypes/types_test.go
+++ b/signer/core/apitypes/types_test.go
@@ -1,0 +1,40 @@
+// Copyright 2023 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+package apitypes
+
+import "testing"
+
+func TestIsPrimitive(t *testing.T) {
+	// Expected positives
+	for i, tc := range []string{
+		"int24", "int24[]", "uint88", "uint88[]", "uint", "uint[]", "int256", "int256[]",
+		"uint96", "uint96[]", "int96", "int96[]", "bytes17[]", "bytes17",
+	} {
+		if !isPrimitiveTypeValid(tc) {
+			t.Errorf("test %d: expected '%v' to be a valid primitive", i, tc)
+		}
+	}
+	// Expected negatives
+	for i, tc := range []string{
+		"int257", "int257[]", "uint88 ", "uint88 []", "uint257", "uint-1[]",
+		"uint0", "uint0[]", "int95", "int95[]", "uint1", "uint1[]", "bytes33[]", "bytess",
+	} {
+		if isPrimitiveTypeValid(tc) {
+			t.Errorf("test %d: expected '%v' to not be a valid primitive", i, tc)
+		}
+	}
+}


### PR DESCRIPTION
Include all primitive types in Solidity for EIP-712 from 0 to 256 in multiples of 8

Currently, Uniswap Permit2 generates EIP-712 signatures with uint160 which will throw "unknown reference type" in validate(). Rather than just add uint160, I figured adding all multiples of 8 should be done since they are all valid primitive types. Primitive types cannot be capitalized/camel-cased, so this should cover all cases.