### PR TITLE
ethclient: fix crash in getBlock when returned block is 'null'

### DIFF
--- a/ethclient/ethclient.go
+++ b/ethclient/ethclient.go
@@ -118,7 +118,10 @@ func (ec *Client) getBlock(ctx context.Context, method string, args ...interface
 	// Decode header and transactions.
 	var head *types.Header
 	var body rpcBlock
-	if err := json.Unmarshal(raw, &head); err != nil {
+	if err := json.Unmarshal(raw, &head); err != nil || head ==nil {
+		if err==nil {
+			return nil ,fmt.Errorf("this head ptr is null,maybe raw is [0x6e,0x75,0x6c,0x6c] string")
+		}
 		return nil, err
 	}
 	if err := json.Unmarshal(raw, &body); err != nil {

--- a/ethclient/ethclient.go
+++ b/ethclient/ethclient.go
@@ -112,16 +112,13 @@ func (ec *Client) getBlock(ctx context.Context, method string, args ...interface
 	err := ec.c.CallContext(ctx, &raw, method, args...)
 	if err != nil {
 		return nil, err
-	} else if len(raw) == 0 {
+	} else if len(raw) == 0 || bytes.Equal(raw, []byte("null")) {
 		return nil, ethereum.NotFound
 	}
 	// Decode header and transactions.
 	var head *types.Header
 	var body rpcBlock
-	if err := json.Unmarshal(raw, &head); err != nil || head ==nil {
-		if err==nil {
-			return nil ,fmt.Errorf("this head ptr is null,maybe raw is [0x6e,0x75,0x6c,0x6c] string")
-		}
+	if err := json.Unmarshal(raw, &head); err != nil {
 		return nil, err
 	}
 	if err := json.Unmarshal(raw, &body); err != nil {


### PR DESCRIPTION
func (ec *Client) getBlock(ctx context.Context, method string, args ...interface{}) (*types.Block, error)
in this function , if raw  value is null , 
it will pass   this line : if len(raw) == 0  and json.Unmarshal(raw, &head);
but the head ptr is null ,
so will painc in : head.UncleHash == types.EmptyUncleHash.
