### PR TITLE
core, eth/catalyst: fix race conditions in tests

### DIFF
--- a/core/types/block.go
+++ b/core/types/block.go
@@ -279,6 +279,7 @@ func CopyHeader(h *Header) *Header {
 		copy(cpy.Extra, h.Extra)
 	}
 	if h.WithdrawalsHash != nil {
+		cpy.WithdrawalsHash = new(common.Hash)
 		*cpy.WithdrawalsHash = *h.WithdrawalsHash
 	}
 	return &cpy

--- a/eth/catalyst/api_test.go
+++ b/eth/catalyst/api_test.go
@@ -443,12 +443,13 @@ func startEthService(t *testing.T, genesis *core.Genesis, blocks []*types.Block)
 	if err != nil {
 		t.Fatal("can't create eth service:", err)
 	}
-	if err := n.Start(); err != nil {
-		t.Fatal("can't start node:", err)
-	}
 	if _, err := ethservice.BlockChain().InsertChain(blocks); err != nil {
 		n.Close()
 		t.Fatal("can't import test blocks:", err)
+	}
+
+	if err := n.Start(); err != nil {
+		t.Fatal("can't start node:", err)
 	}
 
 	ethservice.SetEtherbase(testAddr)
@@ -874,7 +875,7 @@ func TestNewPayloadOnInvalidTerminalBlock(t *testing.T) {
 	n, ethservice := startEthService(t, genesis, preMergeBlocks)
 	defer n.Close()
 
-	genesis.Config.TerminalTotalDifficulty = preMergeBlocks[0].Difficulty() //.Sub(genesis.Config.TerminalTotalDifficulty, preMergeBlocks[len(preMergeBlocks)-1].Difficulty())
+	ethservice.BlockChain().Config().TerminalTotalDifficulty = preMergeBlocks[len(preMergeBlocks)-1].Difficulty() //.Sub(genesis.Config.TerminalTotalDifficulty, preMergeBlocks[len(preMergeBlocks)-1].Difficulty())
 
 	var (
 		api    = NewConsensusAPI(ethservice)

--- a/eth/catalyst/api_test.go
+++ b/eth/catalyst/api_test.go
@@ -443,13 +443,12 @@ func startEthService(t *testing.T, genesis *core.Genesis, blocks []*types.Block)
 	if err != nil {
 		t.Fatal("can't create eth service:", err)
 	}
+	if err := n.Start(); err != nil {
+		t.Fatal("can't start node:", err)
+	}
 	if _, err := ethservice.BlockChain().InsertChain(blocks); err != nil {
 		n.Close()
 		t.Fatal("can't import test blocks:", err)
-	}
-
-	if err := n.Start(); err != nil {
-		t.Fatal("can't start node:", err)
 	}
 
 	ethservice.SetEtherbase(testAddr)
@@ -875,7 +874,7 @@ func TestNewPayloadOnInvalidTerminalBlock(t *testing.T) {
 	n, ethservice := startEthService(t, genesis, preMergeBlocks)
 	defer n.Close()
 
-	ethservice.BlockChain().Config().TerminalTotalDifficulty = preMergeBlocks[len(preMergeBlocks)-1].Difficulty() //.Sub(genesis.Config.TerminalTotalDifficulty, preMergeBlocks[len(preMergeBlocks)-1].Difficulty())
+	ethservice.BlockChain().Config().TerminalTotalDifficulty = preMergeBlocks[0].Difficulty() //.Sub(genesis.Config.TerminalTotalDifficulty, preMergeBlocks[len(preMergeBlocks)-1].Difficulty())
 
 	var (
 		api    = NewConsensusAPI(ethservice)

--- a/graphql/graphql.go
+++ b/graphql/graphql.go
@@ -202,6 +202,7 @@ func (t *Transaction) resolve(ctx context.Context) (*types.Transaction, error) {
 			t.block = &Block{
 				r:            t.r,
 				numberOrHash: &blockNrOrHash,
+				hash:         blockHash,
 			}
 			t.index = index
 			return t.tx, nil

--- a/graphql/graphql.go
+++ b/graphql/graphql.go
@@ -458,9 +458,9 @@ func (t *Transaction) Logs(ctx context.Context) (*[]*Log, error) {
 	if t.block == nil {
 		return nil, nil
 	}
-	hash, err := t.block.Hash(ctx)
-	if err != nil {
-		return nil, err
+	hash := t.block.readHash()
+	if hash == (common.Hash{}) {
+		return nil, errors.New("block hash not available")
 	}
 	return t.getLogs(ctx, hash)
 }
@@ -649,6 +649,19 @@ func (b *Block) Hash(ctx context.Context) (common.Hash, error) {
 		b.hash = header.Hash()
 	}
 	return b.hash, nil
+}
+
+func (b *Block) readHash() common.Hash {
+	if b.hash != (common.Hash{}) {
+		return b.hash
+	}
+	if h, ok := b.numberOrHash.Hash(); ok {
+		return h
+	}
+	if b.header != nil {
+		return b.header.Hash()
+	}
+	return common.Hash{}
 }
 
 func (b *Block) GasLimit(ctx context.Context) (Long, error) {

--- a/graphql/graphql.go
+++ b/graphql/graphql.go
@@ -462,20 +462,6 @@ func (t *Transaction) Logs(ctx context.Context) (*[]*Log, error) {
 	if err != nil {
 		return nil, err
 	}
-	// This is a sanity check. Practically block hash
-	// should be filled already.
-	if (hash == common.Hash{}) {
-		header, err := t.r.backend.HeaderByNumberOrHash(ctx, *t.block.numberOrHash)
-		if err != nil {
-			return nil, err
-		}
-		hash = header.Hash()
-		// TODO: (Marius) not setting the blockhash here
-		// prevents a race condition (since multiple calls of Logs can set the blockhash)
-		// It however also means that every subsequent call for logs of the same block hash to
-		// query the node again. Solution would be to mutex numberOrHash
-		// t.block.numberOrHash.BlockHash = &hash
-	}
 	return t.getLogs(ctx, hash)
 }
 


### PR DESCRIPTION
This PR fixes multiple race conditions and tests:

- Fixes  `TestGenerateWithdrawalChain` a test recently broken
- Fixes a race in `TestNewPayloadOnInvalidTerminalBlock` where setting the TTD raced with the miner. Solution: set the TTD on the blockchain config not the genesis config
- Fixes a race in `CopyHeader` which resulted in races all over the place
- Fixes a race in `graphql.Logs` where querying multiple transactions of one block would race on setting the blockhash. This one is not really fixed imo, fixing it would introduce a mutex on t.block.numberOrHash which I can do, wanted to know some more opinions on it though.