### PR TITLE
metrics: improve accuracy of CPU gauges

### DIFF
--- a/metrics/cpu.go
+++ b/metrics/cpu.go
@@ -17,8 +17,9 @@
 package metrics
 
 // CPUStats is the system and process CPU stats.
+// All values are in seconds.
 type CPUStats struct {
-	GlobalTime int64 // Time spent by the CPU working on all processes
-	GlobalWait int64 // Time spent by waiting on disk for all processes
-	LocalTime  int64 // Time spent by the CPU working on this process
+	GlobalTime float64 // Time spent by the CPU working on all processes
+	GlobalWait float64 // Time spent by waiting on disk for all processes
+	LocalTime  float64 // Time spent by the CPU working on this process
 }

--- a/metrics/cpu_enabled.go
+++ b/metrics/cpu_enabled.go
@@ -38,7 +38,7 @@ func ReadCPUStats(stats *CPUStats) {
 	}
 	// requesting all cpu times will always return an array with only one time stats entry
 	timeStat := timeStats[0]
-	stats.GlobalTime = int64((timeStat.User + timeStat.Nice + timeStat.System) * cpu.ClocksPerSec)
-	stats.GlobalWait = int64((timeStat.Iowait) * cpu.ClocksPerSec)
+	stats.GlobalTime = timeStat.User + timeStat.Nice + timeStat.System
+	stats.GlobalWait = timeStat.Iowait
 	stats.LocalTime = getProcessCPUTime()
 }

--- a/metrics/cputime_nop.go
+++ b/metrics/cputime_nop.go
@@ -21,6 +21,6 @@ package metrics
 
 // getProcessCPUTime returns 0 on Windows as there is no system call to resolve
 // the actual process' CPU time.
-func getProcessCPUTime() int64 {
+func getProcessCPUTime() float64 {
 	return 0
 }

--- a/metrics/cputime_unix.go
+++ b/metrics/cputime_unix.go
@@ -26,11 +26,11 @@ import (
 )
 
 // getProcessCPUTime retrieves the process' CPU time since program startup.
-func getProcessCPUTime() int64 {
+func getProcessCPUTime() float64 {
 	var usage syscall.Rusage
 	if err := syscall.Getrusage(syscall.RUSAGE_SELF, &usage); err != nil {
 		log.Warn("Failed to retrieve CPU time", "err", err)
 		return 0
 	}
-	return int64(usage.Utime.Sec+usage.Stime.Sec)*100 + int64(usage.Utime.Usec+usage.Stime.Usec)/10000 //nolint:unconvert
+	return float64(usage.Utime.Sec+usage.Stime.Sec) + float64(usage.Utime.Usec+usage.Stime.Usec)/1000000 //nolint:unconvert
 }

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -170,6 +170,7 @@ func CollectProcessMetrics(refresh time.Duration) {
 		// Gather CPU times.
 		ReadCPUStats(&cpustats[now])
 		refreshFreq := time.Since(lastCollectionTime).Seconds()
+		lastCollectionTime = time.Now()
 		sysLoad := (cpustats[now].GlobalTime - cpustats[prev].GlobalTime) / refreshFreq
 		sysWait := (cpustats[now].GlobalWait - cpustats[prev].GlobalWait) / refreshFreq
 		procLoad := (cpustats[now].LocalTime - cpustats[prev].LocalTime) / refreshFreq
@@ -205,7 +206,6 @@ func CollectProcessMetrics(refresh time.Duration) {
 			diskWriteBytesCounter.Inc(diskstats[now].WriteBytes - diskstats[prev].WriteBytes)
 		}
 
-		lastCollectionTime = time.Now()
 		time.Sleep(refresh)
 	}
 }

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -170,9 +170,9 @@ func CollectProcessMetrics(refresh time.Duration) {
 		// CPU
 		ReadCPUStats(&cpustats[now])
 		refreshFreq := time.Since(lastCollectionTime).Seconds()
-		cpuSysLoad.Update(int64(float64(cpustats[now].GlobalTime - cpustats[prev].GlobalTime) / refreshFreq))
-		cpuSysWait.Update(int64(float64(cpustats[now].GlobalWait - cpustats[prev].GlobalWait) / refreshFreq))
-		cpuProcLoad.Update(int64(float64(cpustats[now].LocalTime - cpustats[prev].LocalTime) / refreshFreq))
+		cpuSysLoad.Update(int64(float64(cpustats[now].GlobalTime-cpustats[prev].GlobalTime) / refreshFreq))
+		cpuSysWait.Update(int64(float64(cpustats[now].GlobalWait-cpustats[prev].GlobalWait) / refreshFreq))
+		cpuProcLoad.Update(int64(float64(cpustats[now].LocalTime-cpustats[prev].LocalTime) / refreshFreq))
 
 		// Threads
 		cpuThreads.Update(int64(threadCreateProfile.Count()))

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -141,9 +141,9 @@ func CollectProcessMetrics(refresh time.Duration) {
 
 	// Define the various metrics to collect
 	var (
-		cpuSysLoad            = GetOrRegisterGauge("system/cpu/sysload", DefaultRegistry)
-		cpuSysWait            = GetOrRegisterGauge("system/cpu/syswait", DefaultRegistry)
-		cpuProcLoad           = GetOrRegisterGauge("system/cpu/procload", DefaultRegistry)
+		cpuSysLoad            = GetOrRegisterGaugeFloat64("system/cpu/sysload", DefaultRegistry)
+		cpuSysWait            = GetOrRegisterGaugeFloat64("system/cpu/syswait", DefaultRegistry)
+		cpuProcLoad           = GetOrRegisterGaugeFloat64("system/cpu/procload", DefaultRegistry)
 		cpuThreads            = GetOrRegisterGauge("system/cpu/threads", DefaultRegistry)
 		cpuGoroutines         = GetOrRegisterGauge("system/cpu/goroutines", DefaultRegistry)
 		cpuSchedLatency       = getOrRegisterRuntimeHistogram("system/cpu/schedlatency", secondsToNs, nil)
@@ -170,9 +170,9 @@ func CollectProcessMetrics(refresh time.Duration) {
 		// CPU
 		ReadCPUStats(&cpustats[now])
 		refreshFreq := time.Since(lastCollectionTime).Seconds()
-		cpuSysLoad.Update(int64(float64(cpustats[now].GlobalTime-cpustats[prev].GlobalTime) / refreshFreq))
-		cpuSysWait.Update(int64(float64(cpustats[now].GlobalWait-cpustats[prev].GlobalWait) / refreshFreq))
-		cpuProcLoad.Update(int64(float64(cpustats[now].LocalTime-cpustats[prev].LocalTime) / refreshFreq))
+		cpuSysLoad.Update(float64(cpustats[now].GlobalTime-cpustats[prev].GlobalTime) / refreshFreq)
+		cpuSysWait.Update(float64(cpustats[now].GlobalWait-cpustats[prev].GlobalWait) / refreshFreq)
+		cpuProcLoad.Update(float64(cpustats[now].LocalTime-cpustats[prev].LocalTime) / refreshFreq)
 
 		// Threads
 		cpuThreads.Update(int64(threadCreateProfile.Count()))

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -167,11 +167,9 @@ func CollectProcessMetrics(refresh time.Duration) {
 	// Iterate loading the different stats and updating the meters.
 	now, prev := 0, 1
 	for ; ; now, prev = prev, now {
-
-		refreshFreq := int64(time.Since(lastCollectionTime) / time.Second)
-
 		// CPU
 		ReadCPUStats(&cpustats[now])
+		refreshFreq := int64(time.Since(lastCollectionTime) / time.Second)
 		cpuSysLoad.Update((cpustats[now].GlobalTime - cpustats[prev].GlobalTime) / refreshFreq)
 		cpuSysWait.Update((cpustats[now].GlobalWait - cpustats[prev].GlobalWait) / refreshFreq)
 		cpuProcLoad.Update((cpustats[now].LocalTime - cpustats[prev].LocalTime) / refreshFreq)

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -169,10 +169,10 @@ func CollectProcessMetrics(refresh time.Duration) {
 	for ; ; now, prev = prev, now {
 		// CPU
 		ReadCPUStats(&cpustats[now])
-		refreshFreq := int64(time.Since(lastCollectionTime) / time.Second)
-		cpuSysLoad.Update((cpustats[now].GlobalTime - cpustats[prev].GlobalTime) / refreshFreq)
-		cpuSysWait.Update((cpustats[now].GlobalWait - cpustats[prev].GlobalWait) / refreshFreq)
-		cpuProcLoad.Update((cpustats[now].LocalTime - cpustats[prev].LocalTime) / refreshFreq)
+		refreshFreq := time.Since(lastCollectionTime).Seconds()
+		cpuSysLoad.Update(int64(float64(cpustats[now].GlobalTime - cpustats[prev].GlobalTime) / refreshFreq))
+		cpuSysWait.Update(int64(float64(cpustats[now].GlobalWait - cpustats[prev].GlobalWait) / refreshFreq))
+		cpuProcLoad.Update(int64(float64(cpustats[now].LocalTime - cpustats[prev].LocalTime) / refreshFreq))
 
 		// Threads
 		cpuThreads.Update(int64(threadCreateProfile.Count()))


### PR DESCRIPTION
This PR changes metrics collection to actually measure the time interval between collections, rather than assume 3 seconds.  I did some ad hoc profiling, and on slower hardware (eg, my Raspberry Pi 4) I routinely saw intervals between 3.3 - 3.5 seconds, with some being as high as 4.5 seconds.  This will generally cause the CPU gauge readings to be too high, and in some cases can cause impossibly large values for the CPU load metrics (eg. greater than 400 for a 4 core CPU)