### PR TITLE
metrics: add cpu counters

### DIFF
--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -144,6 +144,9 @@ func CollectProcessMetrics(refresh time.Duration) {
 		cpuSysLoad            = GetOrRegisterGauge("system/cpu/sysload", DefaultRegistry)
 		cpuSysWait            = GetOrRegisterGauge("system/cpu/syswait", DefaultRegistry)
 		cpuProcLoad           = GetOrRegisterGauge("system/cpu/procload", DefaultRegistry)
+		cpuSysLoadTotal       = GetOrRegisterCounter("system/cpu/sysload/total", DefaultRegistry)
+		cpuSysWaitTotal       = GetOrRegisterCounter("system/cpu/syswait/total", DefaultRegistry)
+		cpuProcLoadTotal      = GetOrRegisterCounter("system/cpu/procload/total", DefaultRegistry)
 		cpuThreads            = GetOrRegisterGauge("system/cpu/threads", DefaultRegistry)
 		cpuGoroutines         = GetOrRegisterGauge("system/cpu/goroutines", DefaultRegistry)
 		cpuSchedLatency       = getOrRegisterRuntimeHistogram("system/cpu/schedlatency", secondsToNs, nil)
@@ -172,13 +175,16 @@ func CollectProcessMetrics(refresh time.Duration) {
 		secondsSinceLastCollect := collectTime.Sub(lastCollectTime).Seconds()
 		lastCollectTime = collectTime
 		if secondsSinceLastCollect > 0 {
-			sysLoad := (cpustats[now].GlobalTime - cpustats[prev].GlobalTime) / secondsSinceLastCollect
-			sysWait := (cpustats[now].GlobalWait - cpustats[prev].GlobalWait) / secondsSinceLastCollect
-			procLoad := (cpustats[now].LocalTime - cpustats[prev].LocalTime) / secondsSinceLastCollect
+			sysLoad := cpustats[now].GlobalTime - cpustats[prev].GlobalTime
+			sysWait := cpustats[now].GlobalWait - cpustats[prev].GlobalWait
+			procLoad := cpustats[now].LocalTime - cpustats[prev].LocalTime
 			// Convert to integer percentage.
-			cpuSysLoad.Update(int64(sysLoad * 100))
-			cpuSysWait.Update(int64(sysWait * 100))
-			cpuProcLoad.Update(int64(procLoad * 100))
+			cpuSysLoad.Update(int64(sysLoad / secondsSinceLastCollect * 100))
+			cpuSysWait.Update(int64(sysWait / secondsSinceLastCollect * 100))
+			cpuProcLoad.Update(int64(procLoad / secondsSinceLastCollect * 100))
+			cpuSysLoadTotal.Inc(int64(sysLoad * 100))
+			cpuSysWaitTotal.Inc(int64(sysWait * 100))
+			cpuProcLoadTotal.Inc(int64(procLoad * 100))
 		}
 
 		// Threads


### PR DESCRIPTION
This PR adds counter metrics for the CPU system and the Geth process.  Currently the only metrics available for these items are gauges.  Geth CPU usage tends to be very spikey, and my experience using Grafana is that the gauge data graphs rather poorly, in the sense that when zoomed out to larger time intervals, it doesn't really coalesce to an average, like it does with a counter.  See below.

![image](https://user-images.githubusercontent.com/7891737/222570459-2630ec36-b023-4ae3-80fa-4fd9aa7e92a1.png)

![image](https://user-images.githubusercontent.com/7891737/222570538-9581f6cc-0cad-4ff0-87af-4f1d192732c5.png)

