### PR TITLE
eth: remove admin.peers[i].eth.head and difficulty

### DIFF
--- a/eth/peer.go
+++ b/eth/peer.go
@@ -17,8 +17,6 @@
 package eth
 
 import (
-	"math/big"
-
 	"github.com/ethereum/go-ethereum/eth/protocols/eth"
 	"github.com/ethereum/go-ethereum/eth/protocols/snap"
 )
@@ -26,9 +24,7 @@ import (
 // ethPeerInfo represents a short summary of the `eth` sub-protocol metadata known
 // about a connected peer.
 type ethPeerInfo struct {
-	Version    uint     `json:"version"`    // Ethereum protocol version negotiated
-	Difficulty *big.Int `json:"difficulty"` // Total difficulty of the peer's blockchain
-	Head       string   `json:"head"`       // Hex hash of the peer's best owned block
+	Version uint `json:"version"` // Ethereum protocol version negotiated
 }
 
 // ethPeer is a wrapper around eth.Peer to maintain a few extra metadata.
@@ -39,12 +35,8 @@ type ethPeer struct {
 
 // info gathers and returns some `eth` protocol metadata known about a peer.
 func (p *ethPeer) info() *ethPeerInfo {
-	hash, td := p.Head()
-
 	return &ethPeerInfo{
-		Version:    p.Version(),
-		Difficulty: td,
-		Head:       hash.Hex(),
+		Version: p.Version(),
 	}
 }
 


### PR DESCRIPTION
Post-merge there is no more block broadcasts and announcements. As such, we cannot maintain the head infos for our peers. This PR unexposes those infos on the `admin.peers` API to avoid confusion thinking all our peers are unsynced.

Fixes https://github.com/ethereum/go-ethereum/issues/26733