### PR TITLE
eth/catalyst: shouldOverrideBuilder flag

### DIFF
--- a/beacon/engine/gen_epe.go
+++ b/beacon/engine/gen_epe.go
@@ -18,11 +18,13 @@ func (e ExecutionPayloadEnvelope) MarshalJSON() ([]byte, error) {
 		ExecutionPayload *ExecutableData `json:"executionPayload"  gencodec:"required"`
 		BlockValue       *hexutil.Big    `json:"blockValue"  gencodec:"required"`
 		BlobsBundle      *BlobsBundleV1  `json:"blobsBundle"`
+		OverrideBuilder  bool            `json:"shouldOverrideBuilder"  gencodec:"required"`
 	}
 	var enc ExecutionPayloadEnvelope
 	enc.ExecutionPayload = e.ExecutionPayload
 	enc.BlockValue = (*hexutil.Big)(e.BlockValue)
 	enc.BlobsBundle = e.BlobsBundle
+	enc.OverrideBuilder = e.OverrideBuilder
 	return json.Marshal(&enc)
 }
 
@@ -32,6 +34,7 @@ func (e *ExecutionPayloadEnvelope) UnmarshalJSON(input []byte) error {
 		ExecutionPayload *ExecutableData `json:"executionPayload"  gencodec:"required"`
 		BlockValue       *hexutil.Big    `json:"blockValue"  gencodec:"required"`
 		BlobsBundle      *BlobsBundleV1  `json:"blobsBundle"`
+		OverrideBuilder  *bool           `json:"shouldOverrideBuilder"  gencodec:"required"`
 	}
 	var dec ExecutionPayloadEnvelope
 	if err := json.Unmarshal(input, &dec); err != nil {
@@ -48,5 +51,9 @@ func (e *ExecutionPayloadEnvelope) UnmarshalJSON(input []byte) error {
 	if dec.BlobsBundle != nil {
 		e.BlobsBundle = dec.BlobsBundle
 	}
+	if dec.OverrideBuilder == nil {
+		return errors.New("missing required field 'shouldOverrideBuilder' for ExecutionPayloadEnvelope")
+	}
+	e.OverrideBuilder = *dec.OverrideBuilder
 	return nil
 }

--- a/beacon/engine/types.go
+++ b/beacon/engine/types.go
@@ -86,6 +86,7 @@ type ExecutionPayloadEnvelope struct {
 	ExecutionPayload *ExecutableData `json:"executionPayload"  gencodec:"required"`
 	BlockValue       *big.Int        `json:"blockValue"  gencodec:"required"`
 	BlobsBundle      *BlobsBundleV1  `json:"blobsBundle"`
+	OverrideBuilder  bool            `json:"shouldOverrideBuilder"  gencodec:"required"`
 }
 
 type BlobsBundleV1 struct {

--- a/core/blockchain_reader.go
+++ b/core/blockchain_reader.go
@@ -411,3 +411,8 @@ func (bc *BlockChain) SubscribeLogsEvent(ch chan<- []*types.Log) event.Subscript
 func (bc *BlockChain) SubscribeBlockProcessingEvent(ch chan<- bool) event.Subscription {
 	return bc.scope.Track(bc.blockProcFeed.Subscribe(ch))
 }
+
+// ShouldForceLocalBuilding returns true if the node suspects transactions being censored.
+func (bc *BlockChain) ShouldForceLocalBuilding() bool {
+	return bc.forceLocalBuilding
+}

--- a/eth/catalyst/api.go
+++ b/eth/catalyst/api.go
@@ -418,6 +418,7 @@ func (api *ConsensusAPI) getPayload(payloadID engine.PayloadID) (*engine.Executi
 	if data == nil {
 		return nil, engine.UnknownPayload
 	}
+	data.OverrideBuilder = api.eth.BlockChain().ShouldForceLocalBuilding()
 	return data, nil
 }
 


### PR DESCRIPTION
~~An idea to track dropped transactions and warn the user if transactions have been reorged out twice~~
This PR implements the `shouldOverrideBuilder` flag which is specified here: https://github.com/ethereum/execution-apis/pull/425
The heuristic that is currently implemented sets the flag to true if a transaction is reorged out multiple times
This change is part of the cancun spec