### PR TITLE
eth/catalyst: increase update consensus timeout

### DIFF
--- a/eth/catalyst/api.go
+++ b/eth/catalyst/api.go
@@ -72,7 +72,7 @@ const (
 	// beaconUpdateConsensusTimeout is the max time allowed for a beacon client
 	// to send a consensus update before it's considered offline and the user is
 	// warned.
-	beaconUpdateConsensusTimeout = 30 * time.Second
+	beaconUpdateConsensusTimeout = 2 * time.Minute
 
 	// beaconUpdateWarnFrequency is the frequency at which to warn the user that
 	// the beacon client is offline.


### PR DESCRIPTION
This PR increases the time between consensus updates that we give the CL before we start warning the user. During sync it can happen that the CL will only give us updates every now and then and users are getting scared

> basically, recent nimbus versions give the EL one update every 8k blocks while syncing the finalized portion of the chain (ie during initial full sync or when catching up after being offline) - this doesn't seem to be enough to satisfy geth however in terms of the warning - per our earlier discussions, there's no point giving the EL too many FCU's or blocks that are not close to the head anyway