### PR TITLE
cmd/geth: enable log rotation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,4 @@ profile.cov
 /dashboard/assets/package-lock.json
 
 **/yarn-error.log
+logs/

--- a/go.mod
+++ b/go.mod
@@ -65,6 +65,7 @@ require (
 	golang.org/x/text v0.8.0
 	golang.org/x/time v0.0.0-20220922220347-f3bd1da661af
 	golang.org/x/tools v0.7.0
+	gopkg.in/natefinch/lumberjack.v2 v2.0.0
 	gopkg.in/natefinch/npipe.v2 v2.0.0-20160621034901-c1b8fa8bdcce
 )
 

--- a/go.sum
+++ b/go.sum
@@ -7,6 +7,7 @@ github.com/Azure/azure-sdk-for-go/sdk/internal v0.8.3/go.mod h1:KLF4gFr6DcKFZwSu
 github.com/Azure/azure-sdk-for-go/sdk/storage/azblob v0.3.0 h1:Px2UA+2RvSSvv+RvJNuUB6n7rs5Wsel4dXLe90Um2n4=
 github.com/Azure/azure-sdk-for-go/sdk/storage/azblob v0.3.0/go.mod h1:tPaiy8S5bQ+S5sOiDlINkp7+Ef339+Nz5L5XO+cnOHo=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
+github.com/BurntSushi/toml v1.2.0 h1:Rt8g24XnyGTyglgET/PRUNlrUeu9F5L+7FilkXfZgs0=
 github.com/CloudyKit/fastprinter v0.0.0-20200109182630-33d98a066a53/go.mod h1:+3IMCy2vIlbG1XG/0ggNQv0SvxCAIpPM5b1nCz56Xno=
 github.com/CloudyKit/jet/v3 v3.0.0/go.mod h1:HKQPgSJmdK8hdoAbKUUWajkHyHo4RaU5rMdUywE7VMo=
 github.com/DataDog/zstd v1.5.2 h1:vUG4lAyuPCXO0TLbXvPv7EB7cNK1QV/luu55UHLrrn8=
@@ -616,6 +617,8 @@ gopkg.in/go-playground/assert.v1 v1.2.1/go.mod h1:9RXL0bg/zibRAgZUYszZSwO/z8Y/a8
 gopkg.in/go-playground/validator.v8 v8.18.2/go.mod h1:RX2a/7Ha8BgOhfk7j780h4/u/RRjR0eouCJSH80/M2Y=
 gopkg.in/ini.v1 v1.51.1/go.mod h1:pNLf8WUiyNEtQjuu5G5vTm06TEv9tsIgeAvK8hOrP4k=
 gopkg.in/mgo.v2 v2.0.0-20180705113604-9856a29383ce/go.mod h1:yeKp02qBN3iKW1OzL3MGk2IdtZzaj7SFntXj72NppTA=
+gopkg.in/natefinch/lumberjack.v2 v2.0.0 h1:1Lc07Kr7qY4U2YPouBjpCLxpiyxIVoxqXgkXLknAOE8=
+gopkg.in/natefinch/lumberjack.v2 v2.0.0/go.mod h1:l0ndWWf7gzL7RNwBG7wST/UCcT4T24xpD6X8LsfU/+k=
 gopkg.in/natefinch/npipe.v2 v2.0.0-20160621034901-c1b8fa8bdcce h1:+JknDZhAj8YMt7GC73Ei8pv4MzjDUNPHgQWJdtMAaDU=
 gopkg.in/natefinch/npipe.v2 v2.0.0-20160621034901-c1b8fa8bdcce/go.mod h1:5AcXVHNjg+BDxry382+8OKon8SEWiKktQR07RKPsv1c=
 gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 h1:uRGJdciOHaEIrze2W8Q3AKkepLTh2hOroT7a+7czfdQ=


### PR DESCRIPTION
executing geth:

```
>> go-ethereum git:(lumberjack)
➜ ./build/bin/geth --mainnet --log.debug --syncmode snap --datadir data/ --log.folder "/var/folders/w0/bf3y1c7d6ys15tq97ffk5qhw0000gn/T/tmp.QRUj0o0w/"
INFO [03-09|17:57:12.531|geth/main.go:305] Starting Geth on Ethereum mainnet...
INFO [03-09|17:57:12.532|geth/main.go:315] Bumping default cache on mainnet         provided=1024 updated=4096
INFO [03-09|17:57:12.533|cmd/utils/flags.go:1421] Maximum peer count                       ETH=50 LES=0 total=50
INFO [03-09|17:57:12.537|cmd/utils/flags.go:1840] Set global gas cap                       cap=50,000,000
INFO [03-09|17:57:12.543|eth/backend.go:127]      Allocated trie memory caches             clean=614.00MiB dirty=1024.00MiB
INFO [03-09|17:57:12.543|core/rawdb/database.go:380] Using leveldb as the backing database
INFO [03-09|17:57:12.543|ethdb/leveldb/leveldb.go:118] Allocated cache and file handles         database=/Users/sudeep/repos/experiment/go-ethereum/data/geth/chaindata cache=2.00GiB handles=5120
INFO [03-09|17:57:12.628|core/rawdb/database.go:321]   Using LevelDB as the backing database
INFO [03-09|17:57:12.901|core/rawdb/freezer.go:158]    Opened ancient database                  database=/Users/sudeep/repos/experiment/go-ethereum/data/geth/chaindata/ancient/chain readonly=false
INFO [03-09|17:57:12.903|consensus/ethash/ethash.go:483] Disk storage enabled for ethash caches   dir=/Users/sudeep/repos/experiment/go-ethereum/data/geth/ethash count=3
INFO [03-09|17:57:12.903|consensus/ethash/ethash.go:486] Disk storage enabled for ethash DAGs     dir=/Users/sudeep/Library/Ethash count=2
INFO [03-09|17:57:12.903|eth/backend.go:168]             Initialising Ethereum protocol           network=1 dbversion=<nil>
INFO [03-09|17:57:12.904|core/genesis.go:308]            Writing custom genesis block
INFO [03-09|17:57:13.047|trie/database.go:679]           Persisted trie from memory database      nodes=12356 size=1.78MiB time=17.056ms gcnodes=0 gcsize=0.00B gctime=0s livenodes=1 livesize=0.00B
INFO [03-09|17:57:13.057|core/blockchain.go:250]
INFO [03-09|17:57:13.057|core/blockchain.go:251]         ---------------------------------------------------------------------------------------------------------------------------------------------------------
```


tailing logs:

```
>> bsp-geth git:(lumberj) ✗
➜ tail -f /var/folders/w0/bf3y1c7d6ys15tq97ffk5qhw0000gn/T/tmp.QRUj0o0w/log.log
WARN [03-09|17:57:13.060|core/rawdb/accessors_metadata.go:115] Error reading unclean shutdown markers   error="leveldb: not found"
WARN [03-09|17:57:13.060|eth/catalyst/api.go:42]               Engine API enabled                       protocol=eth
INFO [03-09|17:57:13.061|node/node.go:267]                     Starting peer-to-peer node               instance=Geth/v1.11.4-unstable-4be7fdb4-20230309/darwin-arm64/go1.19.7
INFO [03-09|17:57:13.177|core/state/snapshot/generate.go:709]  Generated state snapshot                 accounts=8893 slots=0 storage=409.64KiB dangling=0 elapsed=117.537ms
INFO [03-09|17:57:13.178|p2p/enode/localnode.go:317]           New local node record                    seq=1,678,364,833,178 id=8b85318761bb5024 ip=127.0.0.1 udp=30303 tcp=30303
INFO [03-09|17:57:13.179|p2p/server.go:707]                    Started P2P networking                   self=enode://6289aaec6b7ddd05c8b3d221274d3e72baa9c2849562bd1012e721d870832ead45ee4765c40b25a57e571199dc309c2d311ad6f9d8e21644c8ac81dd1fd59c55@127.0.0.1:30303
INFO [03-09|17:57:13.179|node/rpcstack.go:597]                 IPC endpoint opened                      url=/Users/sudeep/repos/experiment/go-ethereum/data/geth.ipc
INFO [03-09|17:57:13.179|node/node.go:371]                     Generated JWT secret                     path=/Users/sudeep/repos/experiment/go-ethereum/data/geth/jwtsecret
INFO [03-09|17:57:13.181|node/rpcstack.go:160]                 WebSocket enabled                        url=ws://127.0.0.1:8551
INFO [03-09|17:57:13.181|node/rpcstack.go:167]                 HTTP server started                      endpoint=127.0.0.1:8551 auth=true prefix= cors=localhost vhosts=localhost
INFO [03-09|17:57:23.937|p2p/dial.go:338]                      Looking for peers                        peercount=0 tried=24 static=0
```