### PR TITLE
core: add Timestamp method in BlockGen

### DIFF
--- a/core/chain_makers.go
+++ b/core/chain_makers.go
@@ -156,6 +156,11 @@ func (b *BlockGen) Number() *big.Int {
 	return new(big.Int).Set(b.header.Number)
 }
 
+// Timestamp returns the timestamp of the block being generated.
+func (b *BlockGen) Timestamp() uint64 {
+	return b.header.Time
+}
+
 // BaseFee returns the EIP-1559 base fee of the block being generated.
 func (b *BlockGen) BaseFee() *big.Int {
 	return new(big.Int).Set(b.header.BaseFee)


### PR DESCRIPTION
Since forks are now scheduled by block time, it can be necessary to check the timestamp of a block while generating transactions.