### PR TITLE
eth/api_backend: return error if pos tag used pre-merge

### DIFF
--- a/eth/api_backend.go
+++ b/eth/api_backend.go
@@ -75,7 +75,7 @@ func (b *EthAPIBackend) HeaderByNumber(ctx context.Context, number rpc.BlockNumb
 		return b.eth.blockchain.CurrentBlock(), nil
 	}
 	if !b.eth.Merger().TDDReached() && (number == rpc.FinalizedBlockNumber || number == rpc.SafeBlockNumber) {
-		return nil, errors.New("tag not supported on pre-merge network")
+		return nil, errors.New("finalized/safe is not supported on pre-merge network")
 	}
 	if number == rpc.FinalizedBlockNumber {
 		block := b.eth.blockchain.CurrentFinalBlock()
@@ -127,7 +127,7 @@ func (b *EthAPIBackend) BlockByNumber(ctx context.Context, number rpc.BlockNumbe
 		return b.eth.blockchain.GetBlock(header.Hash(), header.Number.Uint64()), nil
 	}
 	if !b.eth.Merger().TDDReached() && (number == rpc.FinalizedBlockNumber || number == rpc.SafeBlockNumber) {
-		return nil, errors.New("tag not supported on pre-merge network")
+		return nil, errors.New("finalized/safe is not supported on pre-merge network")
 	}
 	if number == rpc.FinalizedBlockNumber {
 		header := b.eth.blockchain.CurrentFinalBlock()

--- a/eth/api_backend.go
+++ b/eth/api_backend.go
@@ -75,7 +75,7 @@ func (b *EthAPIBackend) HeaderByNumber(ctx context.Context, number rpc.BlockNumb
 		return b.eth.blockchain.CurrentBlock(), nil
 	}
 	if !b.eth.Merger().TDDReached() && (number == rpc.FinalizedBlockNumber || number == rpc.SafeBlockNumber) {
-		return nil, fmt.Errorf("tag not supported on pre-merge network")
+		return nil, errors.New("tag not supported on pre-merge network")
 	}
 	if number == rpc.FinalizedBlockNumber {
 		block := b.eth.blockchain.CurrentFinalBlock()

--- a/eth/api_backend.go
+++ b/eth/api_backend.go
@@ -74,10 +74,10 @@ func (b *EthAPIBackend) HeaderByNumber(ctx context.Context, number rpc.BlockNumb
 	if number == rpc.LatestBlockNumber {
 		return b.eth.blockchain.CurrentBlock(), nil
 	}
-	if !b.eth.Merger().TDDReached() && (number == rpc.FinalizedBlockNumber || number == rpc.SafeBlockNumber) {
-		return nil, errors.New("finalized/safe is not supported on pre-merge network")
-	}
 	if number == rpc.FinalizedBlockNumber {
+		if !b.eth.Merger().TDDReached() {
+			return nil, errors.New("'finalized' tag not supported on pre-merge network")
+		}
 		block := b.eth.blockchain.CurrentFinalBlock()
 		if block != nil {
 			return block, nil
@@ -85,6 +85,9 @@ func (b *EthAPIBackend) HeaderByNumber(ctx context.Context, number rpc.BlockNumb
 		return nil, errors.New("finalized block not found")
 	}
 	if number == rpc.SafeBlockNumber {
+		if !b.eth.Merger().TDDReached() {
+			return nil, errors.New("'safe' tag not supported on pre-merge network")
+		}
 		block := b.eth.blockchain.CurrentSafeBlock()
 		if block != nil {
 			return block, nil
@@ -126,14 +129,17 @@ func (b *EthAPIBackend) BlockByNumber(ctx context.Context, number rpc.BlockNumbe
 		header := b.eth.blockchain.CurrentBlock()
 		return b.eth.blockchain.GetBlock(header.Hash(), header.Number.Uint64()), nil
 	}
-	if !b.eth.Merger().TDDReached() && (number == rpc.FinalizedBlockNumber || number == rpc.SafeBlockNumber) {
-		return nil, errors.New("finalized/safe is not supported on pre-merge network")
-	}
 	if number == rpc.FinalizedBlockNumber {
+		if !b.eth.Merger().TDDReached() {
+			return nil, errors.New("'finalized' tag not supported on pre-merge network")
+		}
 		header := b.eth.blockchain.CurrentFinalBlock()
 		return b.eth.blockchain.GetBlock(header.Hash(), header.Number.Uint64()), nil
 	}
 	if number == rpc.SafeBlockNumber {
+		if !b.eth.Merger().TDDReached() {
+			return nil, errors.New("'safe' tag not supported on pre-merge network")
+		}
 		header := b.eth.blockchain.CurrentSafeBlock()
 		return b.eth.blockchain.GetBlock(header.Hash(), header.Number.Uint64()), nil
 	}

--- a/eth/api_backend.go
+++ b/eth/api_backend.go
@@ -19,7 +19,6 @@ package eth
 import (
 	"context"
 	"errors"
-	"fmt"
 	"math/big"
 	"time"
 

--- a/eth/api_backend.go
+++ b/eth/api_backend.go
@@ -127,7 +127,7 @@ func (b *EthAPIBackend) BlockByNumber(ctx context.Context, number rpc.BlockNumbe
 		return b.eth.blockchain.GetBlock(header.Hash(), header.Number.Uint64()), nil
 	}
 	if !b.eth.Merger().TDDReached() && (number == rpc.FinalizedBlockNumber || number == rpc.SafeBlockNumber) {
-		return nil, fmt.Errorf("tag not supported on pre-merge network")
+		return nil, errors.New("tag not supported on pre-merge network")
 	}
 	if number == rpc.FinalizedBlockNumber {
 		header := b.eth.blockchain.CurrentFinalBlock()

--- a/eth/api_backend.go
+++ b/eth/api_backend.go
@@ -19,6 +19,7 @@ package eth
 import (
 	"context"
 	"errors"
+	"fmt"
 	"math/big"
 	"time"
 
@@ -74,6 +75,9 @@ func (b *EthAPIBackend) HeaderByNumber(ctx context.Context, number rpc.BlockNumb
 	if number == rpc.LatestBlockNumber {
 		return b.eth.blockchain.CurrentBlock(), nil
 	}
+	if !b.eth.Merger().TDDReached() && (number == rpc.FinalizedBlockNumber || number == rpc.SafeBlockNumber) {
+		return nil, fmt.Errorf("tag not supported on pre-merge network")
+	}
 	if number == rpc.FinalizedBlockNumber {
 		block := b.eth.blockchain.CurrentFinalBlock()
 		if block != nil {
@@ -122,6 +126,9 @@ func (b *EthAPIBackend) BlockByNumber(ctx context.Context, number rpc.BlockNumbe
 	if number == rpc.LatestBlockNumber {
 		header := b.eth.blockchain.CurrentBlock()
 		return b.eth.blockchain.GetBlock(header.Hash(), header.Number.Uint64()), nil
+	}
+	if !b.eth.Merger().TDDReached() && (number == rpc.FinalizedBlockNumber || number == rpc.SafeBlockNumber) {
+		return nil, fmt.Errorf("tag not supported on pre-merge network")
 	}
 	if number == rpc.FinalizedBlockNumber {
 		header := b.eth.blockchain.CurrentFinalBlock()


### PR DESCRIPTION
fixes #26830

--

It feels like the right thing to do for pre-merge / non-PoS networks is to simply return error when `safe` or `finalized` is used. These tags have pretty specific meanings for PoS and it isn't clear what they should mean for PoW or PoS networks. `safe` *could* be repurposed for PoW to mean k-deep, but given the fact we're hoping to completely remove `ethash` at some point, it seems moot.