### PR TITLE
core: print db failure in case of mismatched hash root

### DIFF
--- a/core/block_validator.go
+++ b/core/block_validator.go
@@ -113,7 +113,7 @@ func (v *BlockValidator) ValidateState(block *types.Block, statedb *state.StateD
 	// Validate the state root against the received state root and throw
 	// an error if they don't match.
 	if root := statedb.IntermediateRoot(v.config.IsEIP158(header.Number)); header.Root != root {
-		return fmt.Errorf("invalid merkle root (remote: %x local: %x)", header.Root, root)
+		return fmt.Errorf("invalid merkle root (remote: %x local: %x) dberr: %w", header.Root, root, statedb.Error())
 	}
 	return nil
 }

--- a/core/state/state_object.go
+++ b/core/state/state_object.go
@@ -355,9 +355,6 @@ func (s *stateObject) commitTrie(db Database) (*trie.NodeSet, error) {
 	if err != nil {
 		return nil, err
 	}
-	if s.db.dbErr != nil {
-		return nil, s.db.dbErr
-	}
 	// If nothing changed, don't bother with committing anything
 	if tr == nil {
 		return nil, nil

--- a/core/state/state_object.go
+++ b/core/state/state_object.go
@@ -66,13 +66,6 @@ type stateObject struct {
 	data     types.StateAccount
 	db       *StateDB
 
-	// DB error.
-	// State objects are used by the consensus core and VM which are
-	// unable to deal with database-level errors. Any error that occurs
-	// during a database read is memoized here and will eventually be returned
-	// by StateDB.Commit.
-	dbErr error
-
 	// Write caches.
 	trie Trie // storage trie, which becomes non-nil on first access
 	code Code // contract bytecode, which gets set when code is loaded
@@ -119,13 +112,6 @@ func newObject(db *StateDB, address common.Address, data types.StateAccount) *st
 // EncodeRLP implements rlp.Encoder.
 func (s *stateObject) EncodeRLP(w io.Writer) error {
 	return rlp.Encode(w, &s.data)
-}
-
-// setError remembers the first non-nil error it is called with.
-func (s *stateObject) setError(err error) {
-	if s.dbErr == nil {
-		s.dbErr = err
-	}
 }
 
 func (s *stateObject) markSuicided() {
@@ -212,7 +198,7 @@ func (s *stateObject) GetCommittedState(db Database, key common.Hash) common.Has
 		start := time.Now()
 		tr, err := s.getTrie(db)
 		if err != nil {
-			s.setError(err)
+			s.db.setError(err)
 			return common.Hash{}
 		}
 		enc, err = tr.TryGet(key.Bytes())
@@ -220,7 +206,7 @@ func (s *stateObject) GetCommittedState(db Database, key common.Hash) common.Has
 			s.db.StorageReads += time.Since(start)
 		}
 		if err != nil {
-			s.setError(err)
+			s.db.setError(err)
 			return common.Hash{}
 		}
 	}
@@ -228,7 +214,7 @@ func (s *stateObject) GetCommittedState(db Database, key common.Hash) common.Has
 	if len(enc) > 0 {
 		_, content, _, err := rlp.Split(enc)
 		if err != nil {
-			s.setError(err)
+			s.db.setError(err)
 		}
 		value.SetBytes(content)
 	}
@@ -294,7 +280,7 @@ func (s *stateObject) updateTrie(db Database) (Trie, error) {
 	)
 	tr, err := s.getTrie(db)
 	if err != nil {
-		s.setError(err)
+		s.db.setError(err)
 		return nil, err
 	}
 	// Insert all the pending updates into the trie
@@ -309,7 +295,7 @@ func (s *stateObject) updateTrie(db Database) (Trie, error) {
 		var v []byte
 		if (value == common.Hash{}) {
 			if err := tr.TryDelete(key[:]); err != nil {
-				s.setError(err)
+				s.db.setError(err)
 				return nil, err
 			}
 			s.db.StorageDeleted += 1
@@ -317,7 +303,7 @@ func (s *stateObject) updateTrie(db Database) (Trie, error) {
 			// Encoding []byte cannot fail, ok to ignore the error.
 			v, _ = rlp.EncodeToBytes(common.TrimLeftZeroes(value[:]))
 			if err := tr.TryUpdate(key[:], v); err != nil {
-				s.setError(err)
+				s.db.setError(err)
 				return nil, err
 			}
 			s.db.StorageUpdated += 1
@@ -349,7 +335,6 @@ func (s *stateObject) updateTrie(db Database) (Trie, error) {
 func (s *stateObject) updateRoot(db Database) {
 	tr, err := s.updateTrie(db)
 	if err != nil {
-		s.setError(fmt.Errorf("updateRoot (%x) error: %w", s.address, err))
 		return
 	}
 	// If nothing changed, don't bother with hashing anything
@@ -370,8 +355,8 @@ func (s *stateObject) commitTrie(db Database) (*trie.NodeSet, error) {
 	if err != nil {
 		return nil, err
 	}
-	if s.dbErr != nil {
-		return nil, s.dbErr
+	if s.db.dbErr != nil {
+		return nil, s.db.dbErr
 	}
 	// If nothing changed, don't bother with committing anything
 	if tr == nil {
@@ -383,7 +368,7 @@ func (s *stateObject) commitTrie(db Database) (*trie.NodeSet, error) {
 	}
 	root, nodes := tr.Commit(false)
 	s.data.Root = root
-	return nodes, err
+	return nodes, nil
 }
 
 // AddBalance adds amount to s's balance.
@@ -455,7 +440,7 @@ func (s *stateObject) Code(db Database) []byte {
 	}
 	code, err := db.ContractCode(s.addrHash, common.BytesToHash(s.CodeHash()))
 	if err != nil {
-		s.setError(fmt.Errorf("can't load code hash %x: %v", s.CodeHash(), err))
+		s.db.setError(fmt.Errorf("can't load code hash %x: %v", s.CodeHash(), err))
 	}
 	s.code = code
 	return code
@@ -473,7 +458,7 @@ func (s *stateObject) CodeSize(db Database) int {
 	}
 	size, err := db.ContractCodeSize(s.addrHash, common.BytesToHash(s.CodeHash()))
 	if err != nil {
-		s.setError(fmt.Errorf("can't load code size %x: %v", s.CodeHash(), err))
+		s.db.setError(fmt.Errorf("can't load code size %x: %v", s.CodeHash(), err))
 	}
 	return size
 }

--- a/core/state/state_object.go
+++ b/core/state/state_object.go
@@ -43,7 +43,6 @@ func (s Storage) String() (str string) {
 	for key, value := range s {
 		str += fmt.Sprintf("%X : %X\n", key, value)
 	}
-
 	return
 }
 
@@ -52,7 +51,6 @@ func (s Storage) Copy() Storage {
 	for key, value := range s {
 		cpy[key] = value
 	}
-
 	return cpy
 }
 
@@ -84,7 +82,7 @@ type stateObject struct {
 	dirtyStorage   Storage // Storage entries that have been modified in the current transaction execution
 
 	// Cache flags.
-	// When an object is marked suicided it will be delete from the trie
+	// When an object is marked suicided it will be deleted from the trie
 	// during the "update" phase of the state transition.
 	dirtyCode bool // true if the code was updated
 	suicided  bool
@@ -518,11 +516,4 @@ func (s *stateObject) Balance() *big.Int {
 
 func (s *stateObject) Nonce() uint64 {
 	return s.data.Nonce
-}
-
-// Value is never called, but must be present to allow stateObject to be used
-// as a vm.Account interface that also satisfies the vm.ContractRef
-// interface. Interfaces are awesome.
-func (s *stateObject) Value() *big.Int {
-	panic("Value on stateObject should never be called")
 }

--- a/core/state/statedb.go
+++ b/core/state/statedb.go
@@ -189,7 +189,7 @@ func (s *StateDB) setError(err error) {
 	}
 }
 
-// Error returns the memorized database failure occurs earlier.
+// Error returns the memorized database failure occurred earlier.
 func (s *StateDB) Error() error {
 	return s.dbErr
 }
@@ -958,7 +958,7 @@ func (s *StateDB) clearJournalAndRefund() {
 
 // Commit writes the state to the underlying in-memory trie database.
 func (s *StateDB) Commit(deleteEmptyObjects bool) (common.Hash, error) {
-	// Short circuit in case any database failure occurs earlier.
+	// Short circuit in case any database failure occurred earlier.
 	if s.dbErr != nil {
 		return common.Hash{}, fmt.Errorf("commit aborted due to earlier error: %v", s.dbErr)
 	}

--- a/core/state/statedb.go
+++ b/core/state/statedb.go
@@ -187,8 +187,14 @@ func (s *StateDB) setError(err error) {
 	}
 }
 
+// Error returns all memorized database failure wrapped in a single
+// error object.
 func (s *StateDB) Error() error {
-	return s.dbErr
+	errs := []error{s.dbErr}
+	for _, obj := range s.stateObjects {
+		errs = append(errs, obj.dbErr)
+	}
+	return errors.Join(errs...) // nil error will be ignored
 }
 
 func (s *StateDB) AddLog(log *types.Log) {

--- a/core/vm/interface.go
+++ b/core/vm/interface.go
@@ -76,8 +76,6 @@ type StateDB interface {
 
 	AddLog(*types.Log)
 	AddPreimage(common.Hash, []byte)
-
-	ForEachStorage(common.Address, func(common.Hash, common.Hash) bool) error
 }
 
 // CallContext provides a basic interface for the EVM calling conventions. The EVM


### PR DESCRIPTION
It's an alternative approach to bubble up database failure when block processor gets a state mismatch error.

Supersedes #26671
