### PR TITLE
 core/vm: fix to return internal error of `dynamicGas` function

### DIFF
--- a/core/vm/interpreter.go
+++ b/core/vm/interpreter.go
@@ -209,6 +209,9 @@ func (in *EVMInterpreter) Run(contract *Contract, input []byte, readOnly bool) (
 			var dynamicCost uint64
 			dynamicCost, err = operation.dynamicGas(in.evm, contract, stack, mem, memorySize)
 			cost += dynamicCost // for tracing
+			if err == ErrGasUintOverflow {
+				return nil, ErrGasUintOverflow
+			}
 			if err != nil || !contract.UseGas(dynamicCost) {
 				return nil, ErrOutOfGas
 			}

--- a/core/vm/interpreter.go
+++ b/core/vm/interpreter.go
@@ -209,10 +209,10 @@ func (in *EVMInterpreter) Run(contract *Contract, input []byte, readOnly bool) (
 			var dynamicCost uint64
 			dynamicCost, err = operation.dynamicGas(in.evm, contract, stack, mem, memorySize)
 			cost += dynamicCost // for tracing
-			if err == ErrGasUintOverflow {
-				return nil, ErrGasUintOverflow
+			if err != nil {
+				return nil, err
 			}
-			if err != nil || !contract.UseGas(dynamicCost) {
+			if !contract.UseGas(dynamicCost) {
 				return nil, ErrOutOfGas
 			}
 			// Do tracing before memory expansion


### PR DESCRIPTION
 Suppose if could return the internal error of `dynamicGas`.
