### PR TITLE
[website]: Layout patch [Fixes 26420]

### DIFF
--- a/src/theme/search.css
+++ b/src/theme/search.css
@@ -27,6 +27,10 @@
   justify-content: space-between;
 }
 
+.DocSearch-Button-Placeholder, .DocSearch-Button-Keys {
+  display: flex;
+}
+
 .DocSearch-Button-Keys kbd {
   background: none;
   border: 1px solid var(--chakra-colors-secondary);
@@ -144,7 +148,7 @@ svg[aria-label='Algolia'] * {
   color: var(--chakra-colors-bg);
 }
 
-@media (max-width: 768px) {
+@media (max-width: 767px) {
   /* Search field in mobile menu */
   .DocSearch-Button-Container {
     flex-direction: row-reverse;
@@ -168,6 +172,10 @@ svg[aria-label='Algolia'] * {
 
   .DocSearch-Search-Icon * {
     color: var(--chakra-colors-bg);
+  }
+
+  .DocSearch-Button-Placeholder, .DocSearch-Button-Keys {
+    display: none;
   }
 
   /* Mobile modal styling */


### PR DESCRIPTION
## Description
Adjusts the `max-width` down by one pixel on the `search.css` search box styling. The remainder of the Chakra-UI breakpoint tokens function as `min-width`, so at this viewport width (`768px`) the layout is trying to be tablet/desktop, but the search was switching to mobile styling.

This also forces the contents of this search box (placeholder and keys) to properly display at this viewport width.

## Related issue
- Fixes #26420