### PR TITLE
core/vm: expose jumptable constructors

### DIFF
--- a/core/vm/jump_table_export.go
+++ b/core/vm/jump_table_export.go
@@ -1,0 +1,69 @@
+// Copyright 2023 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+package vm
+
+import "strings"
+
+// LookupInstructionSet returns the constructor for an instructionset for the
+// given fork.
+// If the fork is unknown, this method returns nil
+func LookupInstructionSet(fork string) func() JumpTable {
+	switch strings.ToLower(fork) {
+	case "frontier":
+		return newFrontierInstructionSet
+	case "homestead":
+		return newHomesteadInstructionSet
+	case "tangerinewhistle":
+		return newTangerineWhistleInstructionSet
+	case "spuriousdragon":
+		return newSpuriousDragonInstructionSet
+	case "byzantium":
+		return newByzantiumInstructionSet
+	case "constantinople":
+		return newConstantinopleInstructionSet
+	case "istanbul":
+		return newIstanbulInstructionSet
+	case "berlin":
+		return newBerlinInstructionSet
+	case "london":
+		return newLondonInstructionSet
+	case "merged":
+		return newMergeInstructionSet
+	case "shanghai":
+		return newShanghaiInstructionSet
+	}
+	return nil
+}
+
+// Stack returns the mininum and maximum stack requirements.
+func (op *operation) Stack() (int, int) {
+	return op.minStack, op.maxStack
+}
+
+// HasCost returns true if the opcode has a cost. Opcodes which do _not_ have
+// a cost assigned are one of two things:
+// - undefined, a.k.a invalid opcodes,
+// - the STOP opcode.
+// This method can thus be used to check if an opcode is "Invalid (or STOP)".
+func (op *operation) HasCost() bool {
+	// Ideally, we'd check this:
+	//	return op.execute == opUndefined
+	// However, go-lang does now allow that. So we'll just check some other
+	// 'indicators' that this is an invalid op. Alas, STOP is impossible to
+	// filter out
+	return op.dynamicGas != nil || op.constantGas != 0
+}

--- a/core/vm/jump_table_export.go
+++ b/core/vm/jump_table_export.go
@@ -16,37 +16,42 @@
 
 package vm
 
-import "strings"
+import (
+	"errors"
+	
+	"github.com/ethereum/go-ethereum/params"
+)
 
-// LookupInstructionSet returns the constructor for an instructionset for the
-// given fork.
-// If the fork is unknown, this method returns nil
-func LookupInstructionSet(fork string) func() JumpTable {
-	switch strings.ToLower(fork) {
-	case "frontier":
-		return newFrontierInstructionSet
-	case "homestead":
-		return newHomesteadInstructionSet
-	case "tangerinewhistle":
-		return newTangerineWhistleInstructionSet
-	case "spuriousdragon":
-		return newSpuriousDragonInstructionSet
-	case "byzantium":
-		return newByzantiumInstructionSet
-	case "constantinople":
-		return newConstantinopleInstructionSet
-	case "istanbul":
-		return newIstanbulInstructionSet
-	case "berlin":
-		return newBerlinInstructionSet
-	case "london":
-		return newLondonInstructionSet
-	case "merge":
-		return newMergeInstructionSet
-	case "shanghai":
-		return newShanghaiInstructionSet
+// LookupInstructionSet returns the instructionset for the fork configured by
+// the rules.
+func LookupInstructionSet(rules params.Rules) (JumpTable, error) {
+	switch {
+	case rules.IsPrague:
+		return newShanghaiInstructionSet(), errors.New("prague-fork not defined yet")
+	case rules.IsCancun:
+		return newShanghaiInstructionSet(), errors.New("cancun-fork not defined yet")
+	case rules.IsShanghai:
+		return newShanghaiInstructionSet(), nil
+	case rules.IsMerge:
+		return newMergeInstructionSet(), nil
+	case rules.IsLondon:
+		return newLondonInstructionSet(), nil
+	case rules.IsBerlin:
+		return newBerlinInstructionSet(), nil
+	case rules.IsIstanbul:
+		return newIstanbulInstructionSet(), nil
+	case rules.IsConstantinople:
+		return newConstantinopleInstructionSet(), nil
+	case rules.IsByzantium:
+		return newByzantiumInstructionSet(), nil
+	case rules.IsEIP158:
+		return newSpuriousDragonInstructionSet(), nil
+	case rules.IsEIP150:
+		return newTangerineWhistleInstructionSet(), nil
+	case rules.IsHomestead:
+		return newHomesteadInstructionSet(), nil
 	}
-	return nil
+	return newFrontierInstructionSet(), nil
 }
 
 // Stack returns the mininum and maximum stack requirements.

--- a/core/vm/jump_table_export.go
+++ b/core/vm/jump_table_export.go
@@ -18,7 +18,7 @@ package vm
 
 import (
 	"errors"
-	
+
 	"github.com/ethereum/go-ethereum/params"
 )
 

--- a/core/vm/jump_table_export.go
+++ b/core/vm/jump_table_export.go
@@ -41,7 +41,7 @@ func LookupInstructionSet(fork string) func() JumpTable {
 		return newBerlinInstructionSet
 	case "london":
 		return newLondonInstructionSet
-	case "merged":
+	case "merge":
 		return newMergeInstructionSet
 	case "shanghai":
 		return newShanghaiInstructionSet

--- a/params/config.go
+++ b/params/config.go
@@ -955,7 +955,7 @@ type Rules struct {
 	IsHomestead, IsEIP150, IsEIP155, IsEIP158               bool
 	IsByzantium, IsConstantinople, IsPetersburg, IsIstanbul bool
 	IsBerlin, IsLondon                                      bool
-	IsMerge, IsShanghai, isCancun, isPrague                 bool
+	IsMerge, IsShanghai, IsCancun, IsPrague                 bool
 }
 
 // Rules ensures c's ChainID is not nil.
@@ -978,7 +978,7 @@ func (c *ChainConfig) Rules(num *big.Int, isMerge bool, timestamp uint64) Rules 
 		IsLondon:         c.IsLondon(num),
 		IsMerge:          isMerge,
 		IsShanghai:       c.IsShanghai(timestamp),
-		isCancun:         c.IsCancun(timestamp),
-		isPrague:         c.IsPrague(timestamp),
+		IsCancun:         c.IsCancun(timestamp),
+		IsPrague:         c.IsPrague(timestamp),
 	}
 }


### PR DESCRIPTION
This PR adds three methods to the public interface

```golang
func LookupInstructionSet(fork string) func() JumpTable
func (op *operation) Stack() (int, int)
func (op *operation) HasCost() bool
```
Often, when interacting with geth as a library to e.g. produce state tests, it is desirable to obtain the consensus-correct jumptable definition for a given fork. This is useful in e.g. goevmlab or fuzzyvm. 

