### PR TITLE
feat: add scroll to DocumentNav when content has overflow

### DIFF
--- a/src/components/UI/docs/DocumentNav.tsx
+++ b/src/components/UI/docs/DocumentNav.tsx
@@ -20,7 +20,7 @@ export const DocumentNav: FC<Props> = ({ content }) => {
   const activeHash = useActiveHash(parsedHeadings.map(heading => heading!.headingId));
 
   return parsedHeadings.length ? (
-    <Box as='aside' position='sticky' top='4'>
+    <Box as='aside' position='sticky' h='95vh' overflowY='auto' top='4'>
       <Text textStyle='document-nav-title'>on this page</Text>
       <Divider borderColor='primary' my={`4 !important`} />
       {parsedHeadings.map((heading, idx) => {


### PR DESCRIPTION
This PR adds a height to the parent container (`DocumentNav`) so it becomes scrollable

## Related issue

Fixes #26426