### PR TITLE
cmd/devp2p, cmd/geth: add version in --help output

### DIFF
--- a/cmd/devp2p/main.go
+++ b/cmd/devp2p/main.go
@@ -29,7 +29,6 @@ import (
 var app = flags.NewApp("go-ethereum devp2p tool")
 
 func init() {
-	app.HideVersion = true
 	app.Flags = append(app.Flags, debug.Flags...)
 	app.Before = func(ctx *cli.Context) error {
 		flags.MigrateGlobalFlags(ctx)

--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -205,7 +205,6 @@ var app = flags.NewApp("the go-ethereum command line interface")
 func init() {
 	// Initialize the CLI app and start Geth
 	app.Action = geth
-	app.HideVersion = true // we have a command to print the version
 	app.Copyright = "Copyright 2013-2023 The go-ethereum Authors"
 	app.Commands = []*cli.Command{
 		// See chaincmd.go:


### PR DESCRIPTION
Not sure why this was removed, it's pretty useful to see the version also in --help.