### PR TITLE
fix: keep footer element at the bottom of the page

### DIFF
--- a/docs/interacting-with-geth/rpc/ns-debug.md
+++ b/docs/interacting-with-geth/rpc/ns-debug.md
@@ -193,10 +193,10 @@ Returns a list of the last 'bad blocks' that the client has seen on the network 
 
 Retrieves and returns the RLP encoded block by number.
 
-| Client  | Method invocation                                     |
-| :------ | ----------------------------------------------------- |
-| Go      | `debug.getRawBlock(blockNrOrHash) (string, error)`    |
-| Console | `debug.getBlockRlp(blockNrOrHash)`                |
+| Client  | Method invocation                                            |
+| :------ | ------------------------------------------------------------ |
+| Go      | `debug.getRawBlock(blockNrOrHash) (string, error)`           |
+| Console | `debug.getBlockRlp(blockNrOrHash)`                           |
 | RPC     | `{"method": "debug_getRawBlock", "params": [blockNrOrHash]}` |
 
 References: [RLP](https://ethereum.org/en/developers/docs/data-structures-and-encoding/rlp/)
@@ -205,18 +205,18 @@ References: [RLP](https://ethereum.org/en/developers/docs/data-structures-and-en
 
 Returns an RLP-encoded header.
 
-| Client  | Method invocation                                   |
-| :------ | --------------------------------------------------- |
-| Console | `debug.getRawHeader(blockNrOrHash)`                      |
+| Client  | Method invocation                                             |
+| :------ | ------------------------------------------------------------- |
+| Console | `debug.getRawHeader(blockNrOrHash)`                           |
 | RPC     | `{"method": "debug_getRawHeader", "params": [blockNrOrHash]}` |
 
 ### debug_getRawTransaction
 
 Returns the bytes of the transaction.
 
-| Client  | Method invocation                                   |
-| :------ | --------------------------------------------------- |
-| Console | `debug.getRawTransaction(blockNrOrHash)`                      |
+| Client  | Method invocation                                                    |
+| :------ | -------------------------------------------------------------------- |
+| Console | `debug.getRawTransaction(blockNrOrHash)`                             |
 | RPC     | `{"method": "debug_getRawTransaction", "params": [transactionHash]}` |
 
 ### debug_getModifiedAccountsByHash

--- a/src/components/layouts/Layout.tsx
+++ b/src/components/layouts/Layout.tsx
@@ -1,5 +1,5 @@
 // Libraries
-import { Container } from '@chakra-ui/react';
+import { Container, Flex, Stack } from '@chakra-ui/react';
 import { FC } from 'react';
 
 // Components
@@ -13,11 +13,16 @@ interface Props {
 export const Layout: FC<Props> = ({ children }) => {
   return (
     <Container maxW={{ base: 'full', md: 'container.2xl' }} my={{ base: 4, md: 7 }}>
-      <Header />
+      {/* adding min-height & top margin to keep footer at the bottom of the page */}
+      <Flex direction='column' minH='100vh'>
+        <Header />
 
-      {children}
+        {children}
 
-      <Footer />
+        <Stack mt='auto'>
+          <Footer />
+        </Stack>
+      </Flex>
     </Container>
   );
 };

--- a/src/components/layouts/Layout.tsx
+++ b/src/components/layouts/Layout.tsx
@@ -14,7 +14,7 @@ export const Layout: FC<Props> = ({ children }) => {
   return (
     <Container maxW={{ base: 'full', md: 'container.2xl' }} my={{ base: 4, md: 7 }}>
       {/* adding min-height & top margin to keep footer at the bottom of the page */}
-      <Flex direction='column' minH='100vh'>
+      <Flex direction='column' minH='calc(100vh - 3.5rem)'>
         <Header />
 
         {children}

--- a/src/data/documentation-links.yaml
+++ b/src/data/documentation-links.yaml
@@ -52,24 +52,24 @@
           to: /docs/interacting-with-geth/rpc/pubsub
     - id: JSON-RPC Namespaces
       items:
-      - id: admin
-        to: /docs/interacting-with-geth/rpc/ns-admin
-      - id: clique
-        to: /docs/interacting-with-geth/rpc/ns-clique
-      - id: debug
-        to: /docs/interacting-with-geth/rpc/ns-debug
-      - id: eth
-        to: /docs/interacting-with-geth/rpc/ns-eth
-      - id: les
-        to: /docs/interacting-with-geth/rpc/ns-les
-      - id: miner (deprecated)
-        to: /docs/interacting-with-geth/rpc/ns-miner
-      - id: net
-        to: /docs/interacting-with-geth/rpc/ns-net
-      - id: personal (deprecated)
-        to: /docs/interacting-with-geth/rpc/ns-personal
-      - id: txpool
-        to: /docs/interacting-with-geth/rpc/ns-txpool
+        - id: admin
+          to: /docs/interacting-with-geth/rpc/ns-admin
+        - id: clique
+          to: /docs/interacting-with-geth/rpc/ns-clique
+        - id: debug
+          to: /docs/interacting-with-geth/rpc/ns-debug
+        - id: eth
+          to: /docs/interacting-with-geth/rpc/ns-eth
+        - id: les
+          to: /docs/interacting-with-geth/rpc/ns-les
+        - id: miner (deprecated)
+          to: /docs/interacting-with-geth/rpc/ns-miner
+        - id: net
+          to: /docs/interacting-with-geth/rpc/ns-net
+        - id: personal (deprecated)
+          to: /docs/interacting-with-geth/rpc/ns-personal
+        - id: txpool
+          to: /docs/interacting-with-geth/rpc/ns-txpool
     - id: JS Console
       to: /docs/interacting-with-geth/javascript-console
     - id: 'JS Console 2: Contracts'

--- a/src/theme/search.css
+++ b/src/theme/search.css
@@ -27,7 +27,8 @@
   justify-content: space-between;
 }
 
-.DocSearch-Button-Placeholder, .DocSearch-Button-Keys {
+.DocSearch-Button-Placeholder,
+.DocSearch-Button-Keys {
   display: flex;
 }
 
@@ -174,7 +175,8 @@ svg[aria-label='Algolia'] * {
     color: var(--chakra-colors-bg);
   }
 
-  .DocSearch-Button-Placeholder, .DocSearch-Button-Keys {
+  .DocSearch-Button-Placeholder,
+  .DocSearch-Button-Keys {
     display: none;
   }
 


### PR DESCRIPTION
This PR adds a `flex` container to layout elements, with a `min-height` and top margin to keep footer at the bottom.

## Related issues

Fixes #26425