### PR TITLE
internal/ethapi: nit: int->uint64 in GetTxReceipt

### DIFF
--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -1626,7 +1626,7 @@ func (s *TransactionAPI) GetTransactionReceipt(ctx context.Context, hash common.
 	if err != nil {
 		return nil, err
 	}
-	if len(receipts) <= int(index) {
+	if uint64(len(receipts)) <= index {
 		return nil, nil
 	}
 	receipt := receipts[index]
@@ -1923,19 +1923,12 @@ func NewDebugAPI(b Backend) *DebugAPI {
 
 // GetRawHeader retrieves the RLP encoding for a single header.
 func (api *DebugAPI) GetRawHeader(ctx context.Context, blockNrOrHash rpc.BlockNumberOrHash) (hexutil.Bytes, error) {
-	var hash common.Hash
-	if h, ok := blockNrOrHash.Hash(); ok {
-		hash = h
-	} else {
-		block, err := api.b.BlockByNumberOrHash(ctx, blockNrOrHash)
-		if err != nil {
-			return nil, err
-		}
-		hash = block.Hash()
+	header, err := api.b.HeaderByNumberOrHash(ctx, blockNrOrHash)
+	if err != nil {
+		return nil, err
 	}
-	header, _ := api.b.HeaderByHash(ctx, hash)
 	if header == nil {
-		return nil, fmt.Errorf("header #%d not found", hash)
+		return nil, fmt.Errorf("header #%v not found", blockNrOrHash)
 	}
 	return rlp.EncodeToBytes(header)
 }

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -1923,12 +1923,19 @@ func NewDebugAPI(b Backend) *DebugAPI {
 
 // GetRawHeader retrieves the RLP encoding for a single header.
 func (api *DebugAPI) GetRawHeader(ctx context.Context, blockNrOrHash rpc.BlockNumberOrHash) (hexutil.Bytes, error) {
-	header, err := api.b.HeaderByNumberOrHash(ctx, blockNrOrHash)
-	if err != nil {
-		return nil, err
+	var hash common.Hash
+	if h, ok := blockNrOrHash.Hash(); ok {
+		hash = h
+	} else {
+		block, err := api.b.BlockByNumberOrHash(ctx, blockNrOrHash)
+		if err != nil {
+			return nil, err
+		}
+		hash = block.Hash()
 	}
+	header, _ := api.b.HeaderByHash(ctx, hash)
 	if header == nil {
-		return nil, fmt.Errorf("header #%v not found", blockNrOrHash)
+		return nil, fmt.Errorf("header #%d not found", hash)
 	}
 	return rlp.EncodeToBytes(header)
 }


### PR DESCRIPTION
This PR marginally improves readability since the cast from int -> uint64 is lossless whereas the cast of uint64(index) -> int(index) is lossy and may overflow for very large values of index.

This is not a problem in practice since the number of txs in a block is much lower than an overflow to be possible here.
