### PR TITLE
trie, accounts/abi: nits: adds err checks

### DIFF
--- a/accounts/abi/abi.go
+++ b/accounts/abi/abi.go
@@ -246,7 +246,10 @@ func UnpackRevert(data []byte) (string, error) {
 	if !bytes.Equal(data[:4], revertSelector) {
 		return "", errors.New("invalid data for unpacking")
 	}
-	typ, _ := NewType("string", "", nil)
+	typ, err := NewType("string", "", nil)
+	if err != nil {
+		return "", err
+	}
 	unpacked, err := (Arguments{{Type: typ}}).Unpack(data[4:])
 	if err != nil {
 		return "", err

--- a/trie/stacktrie.go
+++ b/trie/stacktrie.go
@@ -144,7 +144,9 @@ func (st *StackTrie) unmarshalBinary(r io.Reader) error {
 		Val      []byte
 		Key      []byte
 	}
-	gob.NewDecoder(r).Decode(&dec)
+	if err := gob.NewDecoder(r).Decode(&dec); err != nil {
+		return err
+	}
 	st.owner = dec.Owner
 	st.nodeType = dec.NodeType
 	st.val = dec.Val
@@ -158,7 +160,9 @@ func (st *StackTrie) unmarshalBinary(r io.Reader) error {
 			continue
 		}
 		var child StackTrie
-		child.unmarshalBinary(r)
+		if err := child.unmarshalBinary(r); err != nil {
+			return err
+		}
 		st.children[i] = &child
 	}
 	return nil


### PR DESCRIPTION
This PR adds err != nil checks for the return values of some calls in stacktrie.go and abi.go
These calls cannot actually return error, however it seems better form to check errors when they are specified in the return value.