### PR TITLE
trie: reduce unit test time

### DIFF
--- a/trie/proof_test.go
+++ b/trie/proof_test.go
@@ -20,6 +20,7 @@ import (
 	"bytes"
 	crand "crypto/rand"
 	"encoding/binary"
+	"fmt"
 	mrand "math/rand"
 	"sort"
 	"testing"
@@ -29,6 +30,24 @@ import (
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/ethdb/memorydb"
 )
+
+// Prng is a pseudo random number generator seeded by strong randomness.
+// The randomness is printed on startup in order to make failures reproducible.
+var prng = initRnd()
+
+func initRnd() *mrand.Rand {
+	var seed [8]byte
+	crand.Read(seed[:])
+	rnd := mrand.New(mrand.NewSource(int64(binary.LittleEndian.Uint64(seed[:]))))
+	fmt.Printf("Seed: %x\n", seed)
+	return rnd
+}
+
+func randBytes(n int) []byte {
+	r := make([]byte, n)
+	prng.Read(r)
+	return r
+}
 
 // makeProvers creates Merkle trie provers based on different implementations to
 // test all variations.
@@ -1039,12 +1058,6 @@ func randomTrie(n int) (*Trie, map[string]*kv) {
 		vals[string(value.k)] = value
 	}
 	return trie, vals
-}
-
-func randBytes(n int) []byte {
-	r := make([]byte, n)
-	crand.Read(r)
-	return r
 }
 
 func nonRandomTrie(n int) (*Trie, map[string]*kv) {

--- a/trie/sync_test.go
+++ b/trie/sync_test.go
@@ -434,6 +434,7 @@ func TestDuplicateAvoidanceSync(t *testing.T) {
 // Tests that at any point in time during a sync, only complete sub-tries are in
 // the database.
 func TestIncompleteSync(t *testing.T) {
+	t.Parallel()
 	// Create a random trie to copy
 	srcDb, srcTrie, _ := makeTestTrie()
 

--- a/trie/trie_test.go
+++ b/trie/trie_test.go
@@ -1146,13 +1146,18 @@ func deleteString(trie *Trie, k string) {
 
 func TestDecodeNode(t *testing.T) {
 	t.Parallel()
+
+	var seed [8]byte
+	crand.Read(seed[:])
+	rnd := rand.New(rand.NewSource(int64(binary.LittleEndian.Uint64(seed[:]))))
+	fmt.Printf("Seed: %v\n", seed)
 	var (
 		hash  = make([]byte, 20)
 		elems = make([]byte, 20)
 	)
 	for i := 0; i < 5000000; i++ {
-		crand.Read(hash)
-		crand.Read(elems)
+		rnd.Read(hash)
+		rnd.Read(elems)
 		decodeNode(hash, elems)
 	}
 }

--- a/trie/trie_test.go
+++ b/trie/trie_test.go
@@ -18,7 +18,6 @@ package trie
 
 import (
 	"bytes"
-	crand "crypto/rand"
 	"encoding/binary"
 	"errors"
 	"fmt"
@@ -1147,17 +1146,13 @@ func deleteString(trie *Trie, k string) {
 func TestDecodeNode(t *testing.T) {
 	t.Parallel()
 
-	var seed [8]byte
-	crand.Read(seed[:])
-	rnd := rand.New(rand.NewSource(int64(binary.LittleEndian.Uint64(seed[:]))))
-	fmt.Printf("Seed: %v\n", seed)
 	var (
 		hash  = make([]byte, 20)
 		elems = make([]byte, 20)
 	)
 	for i := 0; i < 5000000; i++ {
-		rnd.Read(hash)
-		rnd.Read(elems)
+		prng.Read(hash)
+		prng.Read(elems)
 		decodeNode(hash, elems)
 	}
 }


### PR DESCRIPTION
Using a secure RNG to seed a PRNG, improves test time.
Decreases test time from 12s to 1.4 seconds on my machine.
Decreases overall time needed for testing the trie package from 29.687s to 20.901s