### PR TITLE
EIP-3529 Tests

### DIFF
--- a/core/blockchain_eip3529_test.go
+++ b/core/blockchain_eip3529_test.go
@@ -1,0 +1,130 @@
+package core
+
+import (
+	"math/big"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/consensus"
+	"github.com/ethereum/go-ethereum/consensus/ethash"
+	"github.com/ethereum/go-ethereum/core/rawdb"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/core/vm"
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/params"
+)
+
+func TestSelfDestructGasPostEIP3529(t *testing.T) {
+	bytecode := []byte{
+		byte(vm.PC),
+		byte(vm.SELFDESTRUCT),
+	}
+	// Expected gas is intrinsic +  pc + cold load (due to legacy tx) + SelfDestructGas
+	expectedGasUsed := params.TxGas + vm.GasQuickStep + params.ColdAccountAccessCostEIP2929 + params.SelfdestructGasEIP150
+	testGasUsage(t, params.TestChainConfig, ethash.NewFaker(), bytecode, nil, 60_000, expectedGasUsed)
+
+}
+
+func TestSstoreGasPostEIP3529(t *testing.T) {
+	bytecode := []byte{
+		byte(vm.PUSH1), 0x3, // value
+		byte(vm.PUSH1), 0x3, // location
+		byte(vm.SSTORE), // Set slot[3] = 3
+	}
+	// Expected gas is intrinsic +  2*pushGas + cold load (due to legacy tx) +  SstoreGas
+	expectedGasUsed := params.TxGas + 2*vm.GasFastestStep + params.ColdSloadCostEIP2929 + params.SstoreSetGasEIP2200
+	testGasUsage(t, params.TestChainConfig, ethash.NewFaker(), bytecode, nil, 60_000, expectedGasUsed)
+}
+
+func TestSstoreModifyGasPostEIP3529(t *testing.T) {
+	bytecode := []byte{
+		byte(vm.PUSH1), 0x3, // value
+		byte(vm.PUSH1), 0x1, // location
+		byte(vm.SSTORE), // Set slot[1] = 3
+	}
+	// initalize contract storage
+	initialStorage := make(map[common.Hash]common.Hash)
+	// Populate two slots
+	initialStorage[common.HexToHash("01")] = common.HexToHash("01")
+	initialStorage[common.HexToHash("02")] = common.HexToHash("02")
+	// Expected gas is intrinsic +  2*pushGas + cold load (due to legacy tx) + SstoreReset (a->b such that a,b!=0)
+	expectedGasUsed := params.TxGas + 2*vm.GasFastestStep + params.ColdSloadCostEIP2929 + (params.SstoreResetGasEIP2200 - params.ColdSloadCostEIP2929)
+	testGasUsage(t, params.TestChainConfig, ethash.NewFaker(), bytecode, initialStorage, 60_000, expectedGasUsed)
+}
+
+func TestSstoreClearGasPostEIP3529(t *testing.T) {
+	bytecode := []byte{
+		byte(vm.PUSH1), 0x0, // value
+		byte(vm.PUSH1), 0x1, // location
+		byte(vm.SSTORE), // Set slot[1] = 0
+	}
+	// initalize contract storage
+	initialStorage := make(map[common.Hash]common.Hash)
+	// Populate two slots
+	initialStorage[common.HexToHash("01")] = common.HexToHash("01")
+	initialStorage[common.HexToHash("02")] = common.HexToHash("02")
+
+	// Expected gas is intrinsic +  2*pushGas + cold load (due to legacy tx) + SstoreReset (a->b such that a,b!=0) - sstoreClearGasRefund
+	expectedGasUsage := params.TxGas + 2*vm.GasFastestStep + params.ColdSloadCostEIP2929 + (params.SstoreResetGasEIP2200 - params.ColdSloadCostEIP2929) - params.SstoreClearsScheduleRefundEIP3529
+	testGasUsage(t, params.TestChainConfig, ethash.NewFaker(), bytecode, initialStorage, 60_000, expectedGasUsage)
+}
+
+// Test the gas used by running a transaction sent to a smart contract with given bytecode and storage.
+func testGasUsage(t *testing.T, config *params.ChainConfig, engine consensus.Engine, bytecode []byte, initialStorage map[common.Hash]common.Hash, initialGas, expectedGasUsed uint64) {
+	var (
+		aa = common.HexToAddress("0x000000000000000000000000000000000000aaaa")
+
+		// Generate a canonical chain to act as the main dataset
+		db = rawdb.NewMemoryDatabase()
+
+		// A sender who makes transactions, has some funds
+		key, _        = crypto.HexToECDSA("b71c71a67e1177ad4e901695e1b4b9ee17ae16c6668d313eac2f96dbcda3f291")
+		address       = crypto.PubkeyToAddress(key.PublicKey)
+		balanceBefore = big.NewInt(1000000000000000)
+		gspec         = &Genesis{
+			Config: params.TestChainConfig,
+			Alloc: GenesisAlloc{
+				address: {Balance: balanceBefore},
+				aa: {
+					Code:    bytecode,
+					Storage: initialStorage,
+					Nonce:   0,
+					Balance: big.NewInt(0),
+				},
+			},
+		}
+		genesis = gspec.MustCommit(db)
+	)
+
+	blocks, _ := GenerateChain(gspec.Config, genesis, engine, db, 1, func(i int, b *BlockGen) {
+		b.SetCoinbase(common.Address{1})
+
+		// One transaction to 0xAAAA
+		signer := types.LatestSigner(gspec.Config)
+		tx, _ := types.SignNewTx(key, signer, &types.LegacyTx{
+			Nonce:    0,
+			To:       &aa,
+			Gas:      initialGas,
+			GasPrice: newGwei(5),
+		})
+		b.AddTx(tx)
+	})
+
+	// Import the canonical chain
+	diskdb := rawdb.NewMemoryDatabase()
+	gspec.MustCommit(diskdb)
+
+	chain, err := NewBlockChain(diskdb, nil, gspec, nil, engine, vm.Config{}, nil, nil)
+	if err != nil {
+		t.Fatalf("failed to create tester chain: %v", err)
+	}
+	if n, err := chain.InsertChain(blocks); err != nil {
+		t.Fatalf("block %d: failed to insert into chain: %v", n, err)
+	}
+
+	block := chain.GetBlockByNumber(1)
+
+	if block.GasUsed() != expectedGasUsed {
+		t.Fatalf("incorrect amount of gas spent: expected %d, got %d", expectedGasUsed, block.GasUsed())
+	}
+}

--- a/core/vm/operations_acl.go
+++ b/core/vm/operations_acl.go
@@ -197,7 +197,7 @@ var (
 	gasStaticCallEIP2929   = makeCallVariantGasCallEIP2929(gasStaticCall)
 	gasCallCodeEIP2929     = makeCallVariantGasCallEIP2929(gasCallCode)
 	gasSelfdestructEIP2929 = makeSelfdestructGasFn(true)
-	// gasSelfdestructEIP3529 implements the changes in EIP-2539 (no refunds)
+	// gasSelfdestructEIP3529 implements the changes in EIP-3529 (no refunds)
 	gasSelfdestructEIP3529 = makeSelfdestructGasFn(false)
 
 	// gasSStoreEIP2929 implements gas cost for SSTORE according to EIP-2929
@@ -214,12 +214,12 @@ var (
 	// see gasSStoreEIP2200(...) in core/vm/gas_table.go for more info about how EIP 2200 is specified
 	gasSStoreEIP2929 = makeGasSStoreFunc(params.SstoreClearsScheduleRefundEIP2200)
 
-	// gasSStoreEIP2539 implements gas cost for SSTORE according to EIP-2539
+	// gasSStoreEIP3529 implements gas cost for SSTORE according to EIP-3529
 	// Replace `SSTORE_CLEARS_SCHEDULE` with `SSTORE_RESET_GAS + ACCESS_LIST_STORAGE_KEY_COST` (4,800)
 	gasSStoreEIP3529 = makeGasSStoreFunc(params.SstoreClearsScheduleRefundEIP3529)
 )
 
-// makeSelfdestructGasFn can create the selfdestruct dynamic gas function for EIP-2929 and EIP-2539
+// makeSelfdestructGasFn can create the selfdestruct dynamic gas function for EIP-2929 and EIP-3529
 func makeSelfdestructGasFn(refundsEnabled bool) gasFunc {
 	gasFunc := func(evm *EVM, contract *Contract, stack *Stack, mem *Memory, memorySize uint64) (uint64, error) {
 		var (


### PR DESCRIPTION
This PR adds tests for EIP-3529 https://github.com/ethereum/go-ethereum/pull/22733 . 

The tests check for correct gas usage after calling`SELFDESTRUCT` and for different scenarios of `SSTORE`calls.