### PR TITLE
accounts/abi/bind: handle UnpackLog with zero topics

### DIFF
--- a/accounts/abi/bind/base.go
+++ b/accounts/abi/bind/base.go
@@ -34,6 +34,11 @@ import (
 
 const basefeeWiggleMultiplier = 2
 
+var (
+	errNoEventSignature       = errors.New("no event signature")
+	errEventSignatureMismatch = errors.New("event signature mismatch")
+)
+
 // SignerFn is a signer function callback when a contract requires a method to
 // sign the transaction before submission.
 type SignerFn func(common.Address, *types.Transaction) (*types.Transaction, error)
@@ -488,8 +493,11 @@ func (c *BoundContract) WatchLogs(opts *WatchOpts, name string, query ...[]inter
 
 // UnpackLog unpacks a retrieved log into the provided output structure.
 func (c *BoundContract) UnpackLog(out interface{}, event string, log types.Log) error {
+	if len(log.Topics) == 0 {
+		return errNoEventSignature
+	}
 	if log.Topics[0] != c.abi.Events[event].ID {
-		return fmt.Errorf("event signature mismatch")
+		return errEventSignatureMismatch
 	}
 	if len(log.Data) > 0 {
 		if err := c.abi.UnpackIntoInterface(out, event, log.Data); err != nil {
@@ -507,8 +515,11 @@ func (c *BoundContract) UnpackLog(out interface{}, event string, log types.Log) 
 
 // UnpackLogIntoMap unpacks a retrieved log into the provided map.
 func (c *BoundContract) UnpackLogIntoMap(out map[string]interface{}, event string, log types.Log) error {
+	if len(log.Topics) == 0 {
+		return errNoEventSignature
+	}
 	if log.Topics[0] != c.abi.Events[event].ID {
-		return fmt.Errorf("event signature mismatch")
+		return errEventSignatureMismatch
 	}
 	if len(log.Data) > 0 {
 		if err := c.abi.UnpackIntoMap(out, event, log.Data); err != nil {

--- a/accounts/abi/bind/base.go
+++ b/accounts/abi/bind/base.go
@@ -493,16 +493,6 @@ func (c *BoundContract) WatchLogs(opts *WatchOpts, name string, query ...[]inter
 
 // UnpackLog unpacks a retrieved log into the provided output structure.
 func (c *BoundContract) UnpackLog(out interface{}, event string, log types.Log) error {
-	// Happens in case of LOG0 or an anonymous event with
-	// no indexed arg. Only parse the data.
-	if len(log.Topics) == 0 {
-		if len(log.Data) > 0 {
-			if err := c.abi.UnpackIntoInterface(out, event, log.Data); err != nil {
-				return err
-			}
-		}
-		return nil
-	}
 	// All the topics for an anonymous event are indexed inputs.
 	topics := log.Topics
 	if !c.abi.Events[event].Anonymous {
@@ -527,16 +517,6 @@ func (c *BoundContract) UnpackLog(out interface{}, event string, log types.Log) 
 
 // UnpackLogIntoMap unpacks a retrieved log into the provided map.
 func (c *BoundContract) UnpackLogIntoMap(out map[string]interface{}, event string, log types.Log) error {
-	// Happens in case of LOG0 or an anonymous event with
-	// no indexed arg. Only parse the data.
-	if len(log.Topics) == 0 {
-		if len(log.Data) > 0 {
-			if err := c.abi.UnpackIntoMap(out, event, log.Data); err != nil {
-				return err
-			}
-		}
-		return nil
-	}
 	// All the topics for an anonymous event are indexed inputs.
 	topics := log.Topics
 	if !c.abi.Events[event].Anonymous {

--- a/accounts/abi/bind/base.go
+++ b/accounts/abi/bind/base.go
@@ -493,6 +493,7 @@ func (c *BoundContract) WatchLogs(opts *WatchOpts, name string, query ...[]inter
 
 // UnpackLog unpacks a retrieved log into the provided output structure.
 func (c *BoundContract) UnpackLog(out interface{}, event string, log types.Log) error {
+	// Anonymous events are not supported.
 	if len(log.Topics) == 0 {
 		return errNoEventSignature
 	}
@@ -515,6 +516,7 @@ func (c *BoundContract) UnpackLog(out interface{}, event string, log types.Log) 
 
 // UnpackLogIntoMap unpacks a retrieved log into the provided map.
 func (c *BoundContract) UnpackLogIntoMap(out map[string]interface{}, event string, log types.Log) error {
+	// Anonymous events are not supported.
 	if len(log.Topics) == 0 {
 		return errNoEventSignature
 	}

--- a/accounts/abi/bind/base.go
+++ b/accounts/abi/bind/base.go
@@ -493,13 +493,11 @@ func (c *BoundContract) WatchLogs(opts *WatchOpts, name string, query ...[]inter
 
 // UnpackLog unpacks a retrieved log into the provided output structure.
 func (c *BoundContract) UnpackLog(out interface{}, event string, log types.Log) error {
-	// All the topics for an anonymous event are indexed inputs.
-	topics := log.Topics
-	if !c.abi.Events[event].Anonymous {
-		if log.Topics[0] != c.abi.Events[event].ID {
-			return errEventSignatureMismatch
-		}
-		topics = log.Topics[1:]
+	if len(log.Topics) == 0 {
+		return errNoEventSignature
+	}
+	if log.Topics[0] != c.abi.Events[event].ID {
+		return errEventSignatureMismatch
 	}
 	if len(log.Data) > 0 {
 		if err := c.abi.UnpackIntoInterface(out, event, log.Data); err != nil {
@@ -512,18 +510,16 @@ func (c *BoundContract) UnpackLog(out interface{}, event string, log types.Log) 
 			indexed = append(indexed, arg)
 		}
 	}
-	return abi.ParseTopics(out, indexed, topics)
+	return abi.ParseTopics(out, indexed, log.Topics[1:])
 }
 
 // UnpackLogIntoMap unpacks a retrieved log into the provided map.
 func (c *BoundContract) UnpackLogIntoMap(out map[string]interface{}, event string, log types.Log) error {
-	// All the topics for an anonymous event are indexed inputs.
-	topics := log.Topics
-	if !c.abi.Events[event].Anonymous {
-		if log.Topics[0] != c.abi.Events[event].ID {
-			return errEventSignatureMismatch
-		}
-		topics = log.Topics[1:]
+	if len(log.Topics) == 0 {
+		return errNoEventSignature
+	}
+	if log.Topics[0] != c.abi.Events[event].ID {
+		return errEventSignatureMismatch
 	}
 	if len(log.Data) > 0 {
 		if err := c.abi.UnpackIntoMap(out, event, log.Data); err != nil {
@@ -536,7 +532,7 @@ func (c *BoundContract) UnpackLogIntoMap(out map[string]interface{}, event strin
 			indexed = append(indexed, arg)
 		}
 	}
-	return abi.ParseTopicsIntoMap(out, indexed, topics)
+	return abi.ParseTopicsIntoMap(out, indexed, log.Topics[1:])
 }
 
 // ensureContext is a helper method to ensure a context is not nil, even if the

--- a/accounts/abi/bind/base_test.go
+++ b/accounts/abi/bind/base_test.go
@@ -186,7 +186,7 @@ func TestUnpackIndexedStringTyLogIntoMap(t *testing.T) {
 	unpackAndCheck(t, bc, expectedReceivedMap, mockLog)
 }
 
-func TestUnpackAnonomousLogIntoMap(t *testing.T) {
+func TestUnpackAnonymousLogIntoMap(t *testing.T) {
 	mockLog := newMockLog(nil, common.HexToHash("0x0"))
 
 	abiString := `[{"anonymous":false,"inputs":[{"indexed":false,"name":"amount","type":"uint256"}],"name":"received","type":"event"}]`

--- a/accounts/abi/bind/base_test.go
+++ b/accounts/abi/bind/base_test.go
@@ -196,7 +196,7 @@ func TestUnpackAnonymousLogIntoMap(t *testing.T) {
 	var received map[string]interface{}
 	err := bc.UnpackLogIntoMap(received, "received", mockLog)
 	if err == nil {
-		t.Error("unpacking LOG0 is not supported")
+		t.Error("unpacking anonymous event is not supported")
 	}
 	if err.Error() != "no event signature" {
 		t.Errorf("expected error 'no event signature', got '%s'", err)

--- a/accounts/abi/bind/base_test.go
+++ b/accounts/abi/bind/base_test.go
@@ -19,6 +19,7 @@ package bind_test
 import (
 	"context"
 	"errors"
+	"fmt"
 	"math/big"
 	"reflect"
 	"strings"
@@ -183,75 +184,38 @@ func TestUnpackIndexedStringTyLogIntoMap(t *testing.T) {
 		"amount": big.NewInt(1),
 		"memo":   []byte{88},
 	}
-	unpackAndCheck(t, bc, expectedReceivedMap, mockLog)
+	unpackAndCheck(t, bc, expectedReceivedMap, mockLog, "")
 }
 
-func TestLog0AndAnonymousLogIntoMap(t *testing.T) {
+func TestAnonymousLogIntoMap(t *testing.T) {
 	for i, tc := range []struct {
 		abiString string
 		topics    []common.Hash
 		expected  map[string]interface{}
 	}{
+		// Anonymous event with no indexed parameters
 		{
-			`[{"anonymous":false,"inputs":[{"indexed":false,"name":"amount","type":"uint256"}],"name":"received","type":"event"}]`,
+			`[{"anonymous":true,"inputs":[{"indexed":false,"name":"amount","type":"uint256"}],"name":"received","type":"event"}]`,
 			nil,
 			map[string]interface{}{
 				"amount": big.NewInt(1),
+			},
+		},
+		// Anonymous event with indexed parameters
+		{
+			`[{"anonymous":true,"inputs":[{"indexed":true,"name":"content","type":"bytes"},{"indexed":false,"name":"amount","type":"uint256"}],"name":"received","type":"event"}]`,
+			[]common.Hash{crypto.Keccak256Hash([]byte{1, 2, 3, 4, 5})},
+			map[string]interface{}{
+				"content": crypto.Keccak256Hash([]byte{1, 2, 3, 4, 5}),
+				"amount":  big.NewInt(1),
 			},
 		},
 	} {
 		mockLog := newMockLog(tc.topics, common.HexToHash("0x0"), "0x0000000000000000000000000000000000000000000000000000000000000001")
 		parsedAbi, _ := abi.JSON(strings.NewReader(tc.abiString))
 		bc := bind.NewBoundContract(common.HexToAddress("0x0"), parsedAbi, nil, nil, nil)
-		unpackAndCheck(t, bc, tc.expected, mockLog)
+		unpackAndCheck(t, bc, tc.expected, mockLog, fmt.Sprintf("test case %d: ", i))
 	}
-}
-
-func TestUnpackLog0IntoMap(t *testing.T) {
-	mockLog := newMockLog(nil, common.HexToHash("0x0"), "0x0000000000000000000000000000000000000000000000000000000000000001")
-
-	abiString := `[{"anonymous":false,"inputs":[{"indexed":false,"name":"amount","type":"uint256"}],"name":"received","type":"event"}]`
-	parsedAbi, _ := abi.JSON(strings.NewReader(abiString))
-	bc := bind.NewBoundContract(common.HexToAddress("0x0"), parsedAbi, nil, nil, nil)
-
-	expectedReceivedMap := map[string]interface{}{
-		"amount": big.NewInt(1),
-	}
-
-	unpackAndCheck(t, bc, expectedReceivedMap, mockLog)
-}
-
-func TestUnpackAnonymousLogIntoMap(t *testing.T) {
-	mockLog := newMockLog(nil, common.HexToHash("0x0"), "0x0000000000000000000000000000000000000000000000000000000000000001")
-
-	abiString := `[{"anonymous":true,"inputs":[{"indexed":false,"name":"amount","type":"uint256"}],"name":"received","type":"event"}]`
-	parsedAbi, _ := abi.JSON(strings.NewReader(abiString))
-	bc := bind.NewBoundContract(common.HexToAddress("0x0"), parsedAbi, nil, nil, nil)
-
-	expectedReceivedMap := map[string]interface{}{
-		"amount": big.NewInt(1),
-	}
-
-	unpackAndCheck(t, bc, expectedReceivedMap, mockLog)
-}
-
-func TestUnpackIndexedAnonymousLogIntoMap(t *testing.T) {
-	hash := crypto.Keccak256Hash([]byte{1, 2, 3, 4, 5})
-	topics := []common.Hash{
-		hash,
-	}
-
-	mockLog := newMockLog(topics, common.HexToHash("0x0"), "0x0000000000000000000000000000000000000000000000000000000000000001")
-	abiString := `[{"anonymous":true,"inputs":[{"indexed":true,"name":"content","type":"bytes"},{"indexed":false,"name":"amount","type":"uint256"}],"name":"received","type":"event"}]`
-	parsedAbi, _ := abi.JSON(strings.NewReader(abiString))
-	bc := bind.NewBoundContract(common.HexToAddress("0x0"), parsedAbi, nil, nil, nil)
-
-	expectedReceivedMap := map[string]interface{}{
-		"content": hash,
-		"amount":  big.NewInt(1),
-	}
-
-	unpackAndCheck(t, bc, expectedReceivedMap, mockLog)
 }
 
 func TestUnpackIndexedSliceTyLogIntoMap(t *testing.T) {
@@ -276,7 +240,7 @@ func TestUnpackIndexedSliceTyLogIntoMap(t *testing.T) {
 		"amount": big.NewInt(1),
 		"memo":   []byte{88},
 	}
-	unpackAndCheck(t, bc, expectedReceivedMap, mockLog)
+	unpackAndCheck(t, bc, expectedReceivedMap, mockLog, "")
 }
 
 func TestUnpackIndexedArrayTyLogIntoMap(t *testing.T) {
@@ -301,7 +265,7 @@ func TestUnpackIndexedArrayTyLogIntoMap(t *testing.T) {
 		"amount":    big.NewInt(1),
 		"memo":      []byte{88},
 	}
-	unpackAndCheck(t, bc, expectedReceivedMap, mockLog)
+	unpackAndCheck(t, bc, expectedReceivedMap, mockLog, "")
 }
 
 func TestUnpackIndexedFuncTyLogIntoMap(t *testing.T) {
@@ -327,7 +291,7 @@ func TestUnpackIndexedFuncTyLogIntoMap(t *testing.T) {
 		"amount":   big.NewInt(1),
 		"memo":     []byte{88},
 	}
-	unpackAndCheck(t, bc, expectedReceivedMap, mockLog)
+	unpackAndCheck(t, bc, expectedReceivedMap, mockLog, "")
 }
 
 func TestUnpackIndexedBytesTyLogIntoMap(t *testing.T) {
@@ -348,7 +312,7 @@ func TestUnpackIndexedBytesTyLogIntoMap(t *testing.T) {
 		"amount":  big.NewInt(1),
 		"memo":    []byte{88},
 	}
-	unpackAndCheck(t, bc, expectedReceivedMap, mockLog)
+	unpackAndCheck(t, bc, expectedReceivedMap, mockLog, "")
 }
 
 func TestTransactGasFee(t *testing.T) {
@@ -396,18 +360,18 @@ func TestTransactGasFee(t *testing.T) {
 	assert.True(mt.suggestGasPriceCalled)
 }
 
-func unpackAndCheck(t *testing.T, bc *bind.BoundContract, expected map[string]interface{}, mockLog types.Log) {
+func unpackAndCheck(t *testing.T, bc *bind.BoundContract, expected map[string]interface{}, mockLog types.Log, errPrefix string) {
 	received := make(map[string]interface{})
 	if err := bc.UnpackLogIntoMap(received, "received", mockLog); err != nil {
 		t.Error(err)
 	}
 
 	if len(received) != len(expected) {
-		t.Fatalf("unpacked map length %v not equal expected length of %v", len(received), len(expected))
+		t.Fatalf("%sunpacked map length %v not equal expected length of %v", errPrefix, len(received), len(expected))
 	}
 	for name, elem := range expected {
 		if !reflect.DeepEqual(elem, received[name]) {
-			t.Errorf("field %v does not match expected, want %v, got %v", name, elem, received[name])
+			t.Errorf("%sfield %v does not match expected, want %v, got %v", errPrefix, name, elem, received[name])
 		}
 	}
 }

--- a/accounts/abi/bind/base_test.go
+++ b/accounts/abi/bind/base_test.go
@@ -186,6 +186,23 @@ func TestUnpackIndexedStringTyLogIntoMap(t *testing.T) {
 	unpackAndCheck(t, bc, expectedReceivedMap, mockLog)
 }
 
+func TestUnpackAnonomousLogIntoMap(t *testing.T) {
+	mockLog := newMockLog(nil, common.HexToHash("0x0"))
+
+	abiString := `[{"anonymous":false,"inputs":[{"indexed":false,"name":"amount","type":"uint256"}],"name":"received","type":"event"}]`
+	parsedAbi, _ := abi.JSON(strings.NewReader(abiString))
+	bc := bind.NewBoundContract(common.HexToAddress("0x0"), parsedAbi, nil, nil, nil)
+
+	var received map[string]interface{}
+	err := bc.UnpackLogIntoMap(received, "received", mockLog)
+	if err == nil {
+		t.Error("unpacking LOG0 is not supported")
+	}
+	if err.Error() != "no event signature" {
+		t.Errorf("expected error 'no event signature', got '%s'", err)
+	}
+}
+
 func TestUnpackIndexedSliceTyLogIntoMap(t *testing.T) {
 	sliceBytes, err := rlp.EncodeToBytes([]string{"name1", "name2", "name3", "name4"})
 	if err != nil {


### PR DESCRIPTION
This PR adds error handling for the case that `UnpackLog` or `UnpackLogIntoMap` is called with a log that has zero topics.

Also moves errors from `fmt.Errorf(...)` with no formatted arguments to use `errors.New` and declare the errors at the top of the file.