### PR TITLE
feat: expand prometheus meter metric

### DIFF
--- a/metrics/prometheus/collector.go
+++ b/metrics/prometheus/collector.go
@@ -29,6 +29,7 @@ var (
 	typeGaugeTpl           = "# TYPE %s gauge\n"
 	typeCounterTpl         = "# TYPE %s counter\n"
 	typeSummaryTpl         = "# TYPE %s summary\n"
+	typeMeterTpl           = "# TYPE %s meter\n"
 	keyValueTpl            = "%s %v\n\n"
 	keyQuantileTagValueTpl = "%s {quantile=\"%s\"} %v\n"
 )
@@ -70,7 +71,13 @@ func (c *collector) addHistogram(name string, m metrics.Histogram) {
 }
 
 func (c *collector) addMeter(name string, m metrics.Meter) {
-	c.writeGaugeCounter(name, m.Count())
+	name = mutateKey(name)
+	c.buff.WriteString(fmt.Sprintf(typeMeterTpl, name))
+	c.buff.WriteString(fmt.Sprintf("%s %v\n", name+"_count", m.Count()))
+	c.buff.WriteString(fmt.Sprintf("%s %v\n", name+"_m1", m.Rate1()))
+	c.buff.WriteString(fmt.Sprintf("%s %v\n", name+"_m5", m.Rate5()))
+	c.buff.WriteString(fmt.Sprintf("%s %v\n", name+"_m15", m.Rate15()))
+	c.buff.WriteString(fmt.Sprintf("%s %v\n\n", name+"_mean", m.RateMean()))
 }
 
 func (c *collector) addTimer(name string, m metrics.Timer) {

--- a/metrics/prometheus/collector_test.go
+++ b/metrics/prometheus/collector_test.go
@@ -78,8 +78,12 @@ test_histogram {quantile="0.99"} 0
 test_histogram {quantile="0.999"} 0
 test_histogram {quantile="0.9999"} 0
 
-# TYPE test_meter gauge
-test_meter 9999999
+# TYPE test_meter meter
+test_meter_count 9999999
+test_meter_m1 0
+test_meter_m5 0
+test_meter_m15 0
+test_meter_mean 0
 
 # TYPE test_timer_count counter
 test_timer_count 6


### PR DESCRIPTION
Currently, the `meter` metric in Prometheus is only used as a `counter`.
This PR adds others statistics of `meter` metric.