### PR TITLE
core/rawdb: update freezertable read meter

### DIFF
--- a/core/rawdb/freezer_table.go
+++ b/core/rawdb/freezer_table.go
@@ -823,6 +823,10 @@ func (t *freezerTable) retrieveItems(start, count, maxBytes uint64) ([]byte, []i
 			break
 		}
 	}
+
+	// Update metrics.
+	t.sizeGauge.Inc(int64(totalSize))
+	t.readMeter.Mark(int64(totalSize))
 	return output[:outputSize], sizes, nil
 }
 

--- a/core/rawdb/freezer_table.go
+++ b/core/rawdb/freezer_table.go
@@ -825,7 +825,6 @@ func (t *freezerTable) retrieveItems(start, count, maxBytes uint64) ([]byte, []i
 	}
 
 	// Update metrics.
-	t.sizeGauge.Inc(int64(totalSize))
 	t.readMeter.Mark(int64(totalSize))
 	return output[:outputSize], sizes, nil
 }

--- a/core/rawdb/freezer_table.go
+++ b/core/rawdb/freezer_table.go
@@ -825,6 +825,7 @@ func (t *freezerTable) retrieveItems(start, count, maxBytes uint64) ([]byte, []i
 	}
 
 	// Update metrics.
+	t.sizeGauge.Inc(int64(totalSize))
 	t.readMeter.Mark(int64(totalSize))
 	return output[:outputSize], sizes, nil
 }


### PR DESCRIPTION
Seems the ancient reading meter is always 0, not updated