### PR TITLE
cmd/evm, tests: record preimages if dump is expected

### DIFF
--- a/cmd/evm/runner.go
+++ b/cmd/evm/runner.go
@@ -40,6 +40,7 @@ import (
 	"github.com/ethereum/go-ethereum/internal/flags"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/params"
+	"github.com/ethereum/go-ethereum/trie"
 	"github.com/urfave/cli/v2"
 )
 
@@ -125,6 +126,7 @@ func runCmd(ctx *cli.Context) error {
 		sender        = common.BytesToAddress([]byte("sender"))
 		receiver      = common.BytesToAddress([]byte("receiver"))
 		genesisConfig *core.Genesis
+		preimages     = ctx.Bool(DumpFlag.Name)
 	)
 	if ctx.Bool(MachineFlag.Name) {
 		tracer = logger.NewJSONLogger(logconfig, os.Stdout)
@@ -139,10 +141,12 @@ func runCmd(ctx *cli.Context) error {
 		genesisConfig = gen
 		db := rawdb.NewMemoryDatabase()
 		genesis := gen.MustCommit(db)
-		statedb, _ = state.New(genesis.Root(), state.NewDatabase(db), nil)
+		sdb := state.NewDatabaseWithConfig(db, &trie.Config{Preimages: preimages})
+		statedb, _ = state.New(genesis.Root(), sdb, nil)
 		chainConfig = gen.Config
 	} else {
-		statedb, _ = state.New(common.Hash{}, state.NewDatabase(rawdb.NewMemoryDatabase()), nil)
+		sdb := state.NewDatabaseWithConfig(rawdb.NewMemoryDatabase(), &trie.Config{Preimages: preimages})
+		statedb, _ = state.New(common.Hash{}, sdb, nil)
 		genesisConfig = new(core.Genesis)
 	}
 	if ctx.String(SenderFlag.Name) != "" {

--- a/tests/state_test_util.go
+++ b/tests/state_test_util.go
@@ -37,6 +37,7 @@ import (
 	"github.com/ethereum/go-ethereum/ethdb"
 	"github.com/ethereum/go-ethereum/params"
 	"github.com/ethereum/go-ethereum/rlp"
+	"github.com/ethereum/go-ethereum/trie"
 	"golang.org/x/crypto/sha3"
 )
 
@@ -284,7 +285,7 @@ func (t *StateTest) gasLimit(subtest StateSubtest) uint64 {
 }
 
 func MakePreState(db ethdb.Database, accounts core.GenesisAlloc, snapshotter bool) (*snapshot.Tree, *state.StateDB) {
-	sdb := state.NewDatabase(db)
+	sdb := state.NewDatabaseWithConfig(db, &trie.Config{Preimages: true})
 	statedb, _ := state.New(common.Hash{}, sdb, nil)
 	for addr, a := range accounts {
 		statedb.SetCode(addr, a.Code)


### PR DESCRIPTION
fixes #26945 

now:
```
$ go run ./cmd/evm --dump --code 600060006000f0600060006009f06c63ffffffff6000526004601cf3600052600d60006000f0 --sender 0x71660c4005ba85c37ccec55d0c4493e66fe775d3 --receiver 0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48 --value 0 run
{
    "root": "a7330b1fbb702ae9b10d3e6d37a39255c9351a19841bd54be4f04bc549330b93",
    "accounts": {
        "0x14d8508446f0786f5154b75b746fe3fe04962bb4": {
            "balance": "0",
            "nonce": 1,
            "root": "0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421",
            "codeHash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
            "key": "0xc36daef8aefc43de60e819ebec2f14dcd549ec19b53c98e594d7b909e80eac84"
        },
        "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48": {
            "balance": "0",
            "nonce": 2,
            "root": "0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421",
            "codeHash": "0x3f9fba186ea61f95eb98cd0e709dd82d8f6971137d2bf56c016cc2853b76c92a",
            "code": "0x600060006000f0600060006009f06c63ffffffff6000526004601cf3600052600d60006000f0",
            "key": "0x7b5855bb92cd7f3f78137497df02f6ccb9badda93d9782e0f230c807ba728be0"
        },
        "0xc0fa401b022e4512921457f114d917cd08a1ea9b": {
            "balance": "0",
            "nonce": 1,
            "root": "0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421",
            "codeHash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
            "key": "0x775619ae9c207dfa4e82230a7d4ef0b0a97d738f18cb02dc22726b390f0d4ecf"
        }
    }
}
```

--

With #25287 we made it so that preimages are not recorded by default. This had the side effect that the `evm` command is no longer able to dump state since it does a preimage lookup to determine the address represented by a key.

The flag `--dump` is global so I checked the other subcommands:
* compile: n/a
* disasm: n/a
* run: uses the `--dump` flag to determine whether it should record preimages.
* blocktest: doesn't support dumping
* statetest: updated db initialization in `tests/state_test_util.go`
* t8n: already supports preimages
* t9n: n/a
* b11r: n/a