### PR TITLE
[website]: rm duplicated note, fix typo

### DIFF
--- a/docs/fundamentals/les.md
+++ b/docs/fundamentals/les.md
@@ -3,8 +3,6 @@ title: Light client
 description: Introduction to Geth's light sync mode
 ---
 
-<Note>Light nodes do not currently work on proof-of-stake Ethereum, but new proof-of-stake light clients are expected to ship soon!</Note>
-
 Running a full node is the most trustless, private, decentralized and censorship resistant way to interact with Ethereum. It is also the best choice for the health of the network, because a decentralized network relies on having many individual nodes that independently verify the head of the chain. In a full node a copy of the blockchain is stored locally enabling users to verify incoming data against a local source of truth. However, running a full node requires a lot of disk space and non-negligible CPU allocation and takes hours (for snap sync) or days (for full sync) to sync the blockchain from genesis. Geth also offers a light mode that overcomes these issues and provides some of the benefits of running a node but requires only a fraction of the resources.
 
 Read more about the reasons to run nodes on [ethereum.org](https://ethereum.org/en/run-a-node/).

--- a/docs/interacting-with-geth/rpc/index.md
+++ b/docs/interacting-with-geth/rpc/index.md
@@ -50,7 +50,7 @@ Since the HTTP server is reachable from any local application, additional protec
 geth --http --http.corsdomain https://remix.ethereum.org
 ```
 
-The `--http.corsdomain` command also acceptsd wildcards that enable access to the RPC from any origin:
+The `--http.corsdomain` command also accepts wildcards that enable access to the RPC from any origin:
 
 ```sh
 --http.corsdomain '*'
@@ -111,8 +111,7 @@ The following table summarizes the relative strengths and weaknesses of each tra
 |       Remote connection       | **Y** | **Y** |   N   |
 | Per-message metadata overhead | high  |  low  |  low  |
 
-As a general rule IPC is most secure because it is limited to interactions on the local machine and cannot be exposed to external traffic. It can also be used
-to subscribe to events. HTTP is a familiar and idempotent transport that closes connections between requests and can therefore have lower overall overheads if the number of requests is fairly low. Websockets provides a continuous open channel that can enable event subscriptions and streaming and handle large volumes of requests with smaller per-message overheads.
+As a general rule IPC is most secure because it is limited to interactions on the local machine and cannot be exposed to external traffic. It can also be used to subscribe to events. HTTP is a familiar and idempotent transport that closes connections between requests and can therefore have lower overall overheads if the number of requests is fairly low. Websockets provides a continuous open channel that can enable event subscriptions and streaming and handle large volumes of requests with smaller per-message overheads.
 
 ## Engine-API {#engine-api}
 


### PR DESCRIPTION
Note about non-functional light client appeared twice on `les` page - this PR removes one of the notes.
Also fixed typo "acceptds" --> "accepts"