### PR TITLE
T8N to process withdrawals for Shanghai only

### DIFF
--- a/cmd/evm/internal/t8ntool/transition.go
+++ b/cmd/evm/internal/t8ntool/transition.go
@@ -262,8 +262,12 @@ func Transition(ctx *cli.Context) error {
 			return NewError(ErrorConfig, errors.New("EIP-1559 config but missing 'currentBaseFee' in env section"))
 		}
 	}
-	if chainConfig.IsShanghai(prestate.Env.Number) && prestate.Env.Withdrawals == nil {
-		return NewError(ErrorConfig, errors.New("Shanghai config but missing 'withdrawals' in env section"))
+	if chainConfig.IsShanghai(prestate.Env.Number) {
+		if prestate.Env.Withdrawals == nil {
+			return NewError(ErrorConfig, errors.New("Shanghai config but missing 'withdrawals' in env section"))
+		}
+	} else {
+		prestate.Env.Withdrawals = nil
 	}
 	isMerged := chainConfig.TerminalTotalDifficulty != nil && chainConfig.TerminalTotalDifficulty.BitLen() == 0
 	env := prestate.Env


### PR DESCRIPTION
The t8n tool currently processes withdrawals for the Merge fork as well as Shanghai, if the withdrawals are provided in the env.

```
dir=cmd/evm/testdata/26 && ./build/bin/evm t8n --input.alloc $dir/alloc.json --input.env $dir/env.json --input.txs $dir/txs.json --state.fork Merge
``` 

Either this withdrawal in env has to be ignored or an exception has to be thrown stating that the withdrawals for merge are invalid. This commit implements the former.