### PR TITLE
rpc: increase websocket frame size (again)

### DIFF
--- a/rpc/websocket.go
+++ b/rpc/websocket.go
@@ -38,7 +38,7 @@ const (
 	wsPingInterval     = 30 * time.Second
 	wsPingWriteTimeout = 5 * time.Second
 	wsPongTimeout      = 30 * time.Second
-	wsMessageSizeLimit = 32 * 1024 * 1024
+	wsMessageSizeLimit = 128 * 1024 * 1024
 )
 
 var wsBufferPool = new(sync.Pool)


### PR DESCRIPTION
Fixes capturing large block receipts and traces. in this case, the traces for block 3804216. see all the create internal txs (traces) here https://etherscan.io/txsInternal?block=3804216

Previous PR: https://github.com/ethereum/go-ethereum/pull/26883 increased from 15 to 32 (to match Erigon).

This change to 128 is sufficient to fetch traces for all 16.8 million blocks of Ethereum.