### PR TITLE
internal/debug: Add log.logfmt flag to set logging to use logfmt

### DIFF
--- a/internal/debug/flags.go
+++ b/internal/debug/flags.go
@@ -54,6 +54,11 @@ var (
 		Usage:    "Format logs with JSON",
 		Category: flags.LoggingCategory,
 	}
+	logfmtFlag = &cli.BoolFlag{
+		Name:     "log.logfmt",
+		Usage:    "Format logs with logfmt",
+		Category: flags.LoggingCategory,
+	}
 	logFileFlag = &cli.StringFlag{
 		Name:     "log.file",
 		Usage:    "Write logs to a file",
@@ -115,6 +120,7 @@ var Flags = []cli.Flag{
 	verbosityFlag,
 	vmoduleFlag,
 	logjsonFlag,
+	logfmtFlag,
 	logFileFlag,
 	backtraceAtFlag,
 	debugFlag,
@@ -147,6 +153,8 @@ func Setup(ctx *cli.Context) error {
 	var logfmt log.Format
 	if ctx.Bool(logjsonFlag.Name) {
 		logfmt = log.JSONFormat()
+	} else if ctx.Bool(logfmtFlag.Name) {
+		logfmt = log.LogfmtFormat()
 	} else {
 		logfmt = log.TerminalFormat(useColor)
 	}


### PR DESCRIPTION
Adds a `--log.logfmt` CLI option to configure logging to use the `logfmt` style. `logfmt` support is already built into the logging framework, but previously the setup code would only allow selecting between JSON format or terminal format.

The `--log.json` flag takes priority if both `--log.json` and `log.logfmt` is specified and the default log format is unchanged (terminal).