### PR TITLE
internal/ethapi: make NewAccount return EIP-55 format

### DIFF
--- a/common/types.go
+++ b/common/types.go
@@ -429,3 +429,16 @@ func (ma *MixedcaseAddress) ValidChecksum() bool {
 func (ma *MixedcaseAddress) Original() string {
 	return ma.original
 }
+
+// AddressEIP55 is an alias of Address with a customized json marshaller
+type AddressEIP55 Address
+
+// String returns the hex representation of the address in the manner of EIP55.
+func (addr AddressEIP55) String() string {
+	return Address(addr).Hex()
+}
+
+// MarshalJSON marshals the address in the manner of EIP55.
+func (addr AddressEIP55) MarshalJSON() ([]byte, error) {
+	return json.Marshal(addr.String())
+}

--- a/common/types_test.go
+++ b/common/types_test.go
@@ -534,3 +534,27 @@ func TestHash_Format(t *testing.T) {
 		})
 	}
 }
+
+func TestAddressEIP55(t *testing.T) {
+	addr := HexToAddress("0x5aaeb6053f3e94c9b9a09f33669435e7ef1beaed")
+	addrEIP55 := AddressEIP55(addr)
+
+	if addr.Hex() != addrEIP55.String() {
+		t.Fatal("AddressEIP55 should match original address hex")
+	}
+
+	blob, err := addrEIP55.MarshalJSON()
+	if err != nil {
+		t.Fatal("Failed to marshal AddressEIP55", err)
+	}
+	if strings.Trim(string(blob), "\"") != addr.Hex() {
+		t.Fatal("Address with checksum is expected")
+	}
+	var dec Address
+	if err := json.Unmarshal(blob, &dec); err != nil {
+		t.Fatal("Failed to unmarshal AddressEIP55", err)
+	}
+	if addr != dec {
+		t.Fatal("Unexpected address after unmarshal")
+	}
+}

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -354,19 +354,19 @@ func (s *PersonalAccountAPI) DeriveAccount(url string, path string, pin *bool) (
 }
 
 // NewAccount will create a new account and returns the address for the new account.
-func (s *PersonalAccountAPI) NewAccount(password string) (common.Address, error) {
+func (s *PersonalAccountAPI) NewAccount(password string) (string, error) {
 	ks, err := fetchKeystore(s.am)
 	if err != nil {
-		return common.Address{}, err
+		return "", err
 	}
 	acc, err := ks.NewAccount(password)
 	if err == nil {
-		log.Info("Your new key was generated", "address", acc.Address)
+		log.Info("Your new key was generated", "address", acc.Address.Hex())
 		log.Warn("Please backup your key file!", "path", acc.URL.Path)
 		log.Warn("Please remember your password!")
-		return acc.Address, nil
+		return acc.Address.Hex(), nil
 	}
-	return common.Address{}, err
+	return "", err
 }
 
 // fetchKeystore retrieves the encrypted keystore from the account manager.

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -354,19 +354,20 @@ func (s *PersonalAccountAPI) DeriveAccount(url string, path string, pin *bool) (
 }
 
 // NewAccount will create a new account and returns the address for the new account.
-func (s *PersonalAccountAPI) NewAccount(password string) (string, error) {
+func (s *PersonalAccountAPI) NewAccount(password string) (common.AddressEIP55, error) {
 	ks, err := fetchKeystore(s.am)
 	if err != nil {
-		return "", err
+		return common.AddressEIP55{}, err
 	}
 	acc, err := ks.NewAccount(password)
 	if err == nil {
-		log.Info("Your new key was generated", "address", acc.Address.Hex())
+		addrEIP55 := common.AddressEIP55(acc.Address)
+		log.Info("Your new key was generated", "address", addrEIP55.String())
 		log.Warn("Please backup your key file!", "path", acc.URL.Path)
 		log.Warn("Please remember your password!")
-		return acc.Address.Hex(), nil
+		return addrEIP55, nil
 	}
-	return "", err
+	return common.AddressEIP55{}, err
 }
 
 // fetchKeystore retrieves the encrypted keystore from the account manager.

--- a/internal/ethapi/api_test.go
+++ b/internal/ethapi/api_test.go
@@ -183,7 +183,7 @@ func TestNewPersonalAccount(t *testing.T) {
 		t.Fatalf("failed to create account: %v", err)
 	}
 
-	if !common.IsHexAddress(addr) {
+	if !common.IsHexAddress(addr.String()) {
 		t.Fatalf("address isn't hex encoded: %s", addr)
 	}
 }

--- a/internal/ethapi/api_test.go
+++ b/internal/ethapi/api_test.go
@@ -21,23 +21,11 @@ import (
 	"math/big"
 	"testing"
 
-	"github.com/ethereum/go-ethereum/accounts"
-	"github.com/ethereum/go-ethereum/accounts/keystore"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/params"
 )
-
-type backendTest struct {
-	backendMock
-	backends []accounts.Backend
-}
-
-func (b *backendTest) AccountManager() *accounts.Manager {
-	ac := accounts.Config{InsecureUnlockAllowed: false}
-	return accounts.NewManager(&ac, b.backends...)
-}
 
 func TestTransaction_RoundTripRpcJSON(t *testing.T) {
 	var (
@@ -167,23 +155,5 @@ func allTransactionTypes(addr common.Address, config *params.ChainConfig) []type
 			R:          big.NewInt(10),
 			S:          big.NewInt(11),
 		},
-	}
-}
-
-func TestNewPersonalAccount(t *testing.T) {
-	d := t.TempDir()
-	ks := keystore.NewKeyStore(d, keystore.StandardScryptN, keystore.StandardScryptP)
-	b := &backendTest{
-		backends: []accounts.Backend{ks},
-	}
-	nonceLock := new(AddrLocker)
-	pa := NewPersonalAccountAPI(b, nonceLock)
-	addr, err := pa.NewAccount("password")
-	if err != nil {
-		t.Fatalf("failed to create account: %v", err)
-	}
-
-	if !common.IsHexAddress(addr.String()) {
-		t.Fatalf("address isn't hex encoded: %s", addr)
 	}
 }

--- a/internal/ethapi/api_test.go
+++ b/internal/ethapi/api_test.go
@@ -21,11 +21,23 @@ import (
 	"math/big"
 	"testing"
 
+	"github.com/ethereum/go-ethereum/accounts"
+	"github.com/ethereum/go-ethereum/accounts/keystore"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/params"
 )
+
+type backendTest struct {
+	backendMock
+	backends []accounts.Backend
+}
+
+func (b *backendTest) AccountManager() *accounts.Manager {
+	ac := accounts.Config{InsecureUnlockAllowed: false}
+	return accounts.NewManager(&ac, b.backends...)
+}
 
 func TestTransaction_RoundTripRpcJSON(t *testing.T) {
 	var (
@@ -155,5 +167,23 @@ func allTransactionTypes(addr common.Address, config *params.ChainConfig) []type
 			R:          big.NewInt(10),
 			S:          big.NewInt(11),
 		},
+	}
+}
+
+func TestNewPersonalAccount(t *testing.T) {
+	d := t.TempDir()
+	ks := keystore.NewKeyStore(d, keystore.StandardScryptN, keystore.StandardScryptP)
+	b := &backendTest{
+		backends: []accounts.Backend{ks},
+	}
+	nonceLock := new(AddrLocker)
+	pa := NewPersonalAccountAPI(b, nonceLock)
+	addr, err := pa.NewAccount("password")
+	if err != nil {
+		t.Fatalf("failed to create account: %v", err)
+	}
+
+	if !common.IsHexAddress(addr) {
+		t.Fatalf("address isn't hex encoded: %s", addr)
 	}
 }


### PR DESCRIPTION
This PR implements the suggestion of #24406 to return the address as EIP-55 encoded when creating a new account.

