### PR TITLE
ethclient: harden against returned interface misuse

### DIFF
--- a/ethclient/ethclient.go
+++ b/ethclient/ethclient.go
@@ -320,7 +320,14 @@ func (ec *Client) SyncProgress(ctx context.Context) (*ethereum.SyncProgress, err
 // SubscribeNewHead subscribes to notifications about the current blockchain head
 // on the given channel.
 func (ec *Client) SubscribeNewHead(ctx context.Context, ch chan<- *types.Header) (ethereum.Subscription, error) {
-	return ec.c.EthSubscribe(ctx, ch, "newHeads")
+	sub, err := ec.c.EthSubscribe(ctx, ch, "newHeads")
+	if err != nil {
+		// Defensively prefer returning nil interface explicitly on error-path, instead
+		// of letting default golang behavior wrap it with non-nil interface that stores
+		// nil concrete type value.
+		return nil, err
+	}
+	return sub, nil
 }
 
 // State Access
@@ -389,7 +396,14 @@ func (ec *Client) SubscribeFilterLogs(ctx context.Context, q ethereum.FilterQuer
 	if err != nil {
 		return nil, err
 	}
-	return ec.c.EthSubscribe(ctx, ch, "logs", arg)
+	sub, err := ec.c.EthSubscribe(ctx, ch, "logs", arg)
+	if err != nil {
+		// Defensively prefer returning nil interface explicitly on error-path, instead
+		// of letting default golang behavior wrap it with non-nil interface that stores
+		// nil concrete type value.
+		return nil, err
+	}
+	return sub, nil
 }
 
 func toFilterArg(q ethereum.FilterQuery) (interface{}, error) {


### PR DESCRIPTION
`Client.SubscribeNewHead` returns **interface** wrapping concrete type `*ClientSubscription` returned from `Client.EthSubscribe`. On error-path `*ClientSubscription` is `nil` but interface-wrapping results in non-nil **interface** returned from `Client.SubscribeNewHead` (so it can't be relied upon to have `nil` value when `error` returned is not `nil`).

In practice, this leads to unpleasant bugs for people who don't strictly follow popular golang convention: _when func returns non-`nil` `error` - other arguments in return list should be treated as "undefined" (can't be relied upon to have specific values)_, for example https://github.com/decred/dcrdex/pull/2252.

This PR tries to address that.